### PR TITLE
FeatureMgmt: Add `frontendUsed` attribute to generated toggles   

### DIFF
--- a/pkg/services/featuremgmt/feature_toggle_api/types.go
+++ b/pkg/services/featuremgmt/feature_toggle_api/types.go
@@ -41,6 +41,9 @@ type FeatureSpec struct {
 	// The flab behavior only effects frontend -- it is not used in the backend
 	FrontendOnly bool `json:"frontend,omitempty"`
 
+	// Unlike FrontendOnly, this is true for flags used by both frontend and backend.
+	FrontendUsed bool `json:"frontendUsed,omitempty"`
+
 	// The flag is used at startup, so any change requires a restart
 	RequiresRestart bool `json:"requiresRestart,omitempty"`
 

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -1,4 +1,4 @@
-Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
+Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly,FrontendUsed
 2022-02-15,panelTitleSearch,preview,@grafana/search-and-storage,false,false,false
 2023-01-03,publicDashboardsEmailSharing,preview,@grafana/grafana-operator-experience-squad,false,false,false
 2023-06-19,lokiExperimentalStreaming,experimental,@grafana/data-sources-plugins,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -22,13 +22,17 @@
     {
       "metadata": {
         "name": "advisorDatasourceIntegration",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables the advisor report integration with datasource pages",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-catalog",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
@@ -50,13 +54,17 @@
     {
       "metadata": {
         "name": "alertEnrichment",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-06-06T12:16:07Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-06-06T12:16:07Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enable configuration of alert enrichments in Grafana Cloud.",
         "stage": "experimental",
         "codeowner": "@grafana/alerting-squad",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -64,14 +72,18 @@
     {
       "metadata": {
         "name": "alertEnrichmentConditional",
-        "resourceVersion": "1779440584464",
+        "resourceVersion": "1783954958299",
         "creationTimestamp": "2025-07-31T22:56:50Z",
-        "deletionTimestamp": "2025-08-01T11:30:17Z"
+        "deletionTimestamp": "2025-08-01T11:30:17Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enable conditional alert enrichment steps.",
         "stage": "experimental",
         "codeowner": "@grafana/alerting-squad",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -79,14 +91,18 @@
     {
       "metadata": {
         "name": "alertEnrichmentMultiStep",
-        "resourceVersion": "1779440584464",
+        "resourceVersion": "1783954958299",
         "creationTimestamp": "2025-07-31T22:56:50Z",
-        "deletionTimestamp": "2025-08-01T11:30:17Z"
+        "deletionTimestamp": "2025-08-01T11:30:17Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Allow multiple steps per enrichment.",
         "stage": "experimental",
         "codeowner": "@grafana/alerting-squad",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -94,13 +110,17 @@
     {
       "metadata": {
         "name": "alertEnrichmentPreview",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enable alert enrichment preview (notification-history-based) in view and edit drawers.",
         "stage": "experimental",
         "codeowner": "@grafana/alerting-squad",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -108,40 +128,52 @@
     {
       "metadata": {
         "name": "alertRuleRestore",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-03-05T14:15:26Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-03-05T14:15:26Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables the alert rule restore feature",
         "stage": "preview",
         "codeowner": "@grafana/alerting-squad",
+        "frontendUsed": true,
         "expression": "true"
       }
     },
     {
       "metadata": {
         "name": "alerting.notificationsAPIV1Beta1",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Switch the Grafana Alerting UI from notifications.alerting.grafana.app/v0alpha1 to v1beta1",
         "stage": "experimental",
         "codeowner": "@grafana/alerting-squad",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "alerting.rulesAPIV2",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables the new Rules API v2 UI with evaluation chains and groupless rule creation",
         "stage": "experimental",
         "codeowner": "@grafana/alerting-squad",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -149,13 +181,17 @@
     {
       "metadata": {
         "name": "alerting.syncExternalAlertmanager",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Automatically syncs external Alertmanager datasource configuration as ExtraConfiguration in Grafana",
         "stage": "experimental",
         "codeowner": "@grafana/alerting-squad",
+        "frontendUsed": true,
         "requiresRestart": true,
         "hideFromDocs": true,
         "expression": "false"
@@ -164,13 +200,17 @@
     {
       "metadata": {
         "name": "alertingAIAnalyzeCentralStateHistory",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-07-16T16:42:42Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-07-16T16:42:42Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enable AI-analyze central state history.",
         "stage": "experimental",
         "codeowner": "@grafana/alerting-squad",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -178,13 +218,17 @@
     {
       "metadata": {
         "name": "alertingAIFeedback",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-07-23T12:38:09Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-07-23T12:38:09Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enable AI-generated feedback from the Grafana UI.",
         "stage": "experimental",
         "codeowner": "@grafana/alerting-squad",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -192,13 +236,17 @@
     {
       "metadata": {
         "name": "alertingAIGenAlertRules",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-07-16T16:42:42Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-07-16T16:42:42Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enable AI-generated alert rules.",
         "stage": "experimental",
         "codeowner": "@grafana/alerting-squad",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -206,13 +254,17 @@
     {
       "metadata": {
         "name": "alertingAIGenTemplates",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-07-16T16:42:42Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-07-16T16:42:42Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enable AI-generated alerting templates.",
         "stage": "experimental",
         "codeowner": "@grafana/alerting-squad",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -220,13 +272,17 @@
     {
       "metadata": {
         "name": "alertingAIImproveAlertRules",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-07-16T16:42:42Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-07-16T16:42:42Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enable AI-improve alert rules labels and annotations.",
         "stage": "experimental",
         "codeowner": "@grafana/alerting-squad",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -234,28 +290,36 @@
     {
       "metadata": {
         "name": "alertingAlertListPanelEnhancements",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables enhanced stat mode for the Alert List panel with thresholds, value mappings, and linking",
         "stage": "experimental",
         "codeowner": "@grafana/alerting-squad",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "alertingAlertsActivityBanner",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Shows a promotional banner for the Alerts Activity feature on the Rule List page",
         "stage": "experimental",
         "codeowner": "@grafana/alerting-squad",
         "frontend": true,
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -263,27 +327,35 @@
     {
       "metadata": {
         "name": "alertingBacktesting",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2022-12-14T14:44:14Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2022-12-14T14:44:14Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Rule backtesting API for alerting",
         "stage": "experimental",
         "codeowner": "@grafana/alerting-squad",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "alertingBulkActionsInUI",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-04-24T14:49:59Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-04-24T14:49:59Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables the alerting bulk actions in the UI",
         "stage": "GA",
         "codeowner": "@grafana/alerting-squad",
         "frontend": true,
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "true"
       }
@@ -291,26 +363,34 @@
     {
       "metadata": {
         "name": "alertingCentralAlertHistory",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2024-05-29T15:01:38Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2024-05-29T15:01:38Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables the new central alert history.",
         "stage": "experimental",
         "codeowner": "@grafana/alerting-squad",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "alertingDisableDMAinUI",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Disables the DMA feature in the UI",
         "stage": "experimental",
         "codeowner": "@grafana/alerting-squad",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -318,13 +398,17 @@
     {
       "metadata": {
         "name": "alertingDisableSendAlertsExternal",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2024-05-23T12:29:19Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2024-05-23T12:29:19Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Disables the ability to send alerts to an external Alertmanager datasource.",
         "stage": "experimental",
         "codeowner": "@grafana/alerting-squad",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -332,14 +416,18 @@
     {
       "metadata": {
         "name": "alertingEnrichmentAssistantInvestigations",
-        "resourceVersion": "1779440584464",
+        "resourceVersion": "1783954958299",
         "creationTimestamp": "2025-08-29T14:46:39Z",
-        "deletionTimestamp": "2025-09-01T09:33:33Z"
+        "deletionTimestamp": "2025-09-01T09:33:33Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enable Assistant Investigations enrichment type.",
         "stage": "experimental",
         "codeowner": "@grafana/alerting-squad",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -347,14 +435,18 @@
     {
       "metadata": {
         "name": "alertingEnrichmentPerRule",
-        "resourceVersion": "1779440584464",
+        "resourceVersion": "1783954958299",
         "creationTimestamp": "2025-07-31T22:56:50Z",
-        "deletionTimestamp": "2025-08-01T11:30:17Z"
+        "deletionTimestamp": "2025-08-01T11:30:17Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enable enrichment per rule in the alerting UI.",
         "stage": "experimental",
         "codeowner": "@grafana/alerting-squad",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -362,13 +454,17 @@
     {
       "metadata": {
         "name": "alertingIgnorePendingForNoDataAndError",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Makes NoData and Error alerts fire immediately, without 'pending' stage",
         "stage": "experimental",
         "codeowner": "@grafana/alerting-squad",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -376,13 +472,17 @@
     {
       "metadata": {
         "name": "alertingImportAlertmanagerAPI",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-06-10T08:32:50Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-06-10T08:32:50Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables the API to import Alertmanager configuration",
         "stage": "experimental",
         "codeowner": "@grafana/alerting-squad",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -390,28 +490,36 @@
     {
       "metadata": {
         "name": "alertingImportYAMLUI",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-05-21T15:59:41Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-05-21T15:59:41Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables a UI feature for importing rules from a Prometheus file to Grafana-managed rules",
         "stage": "GA",
         "codeowner": "@grafana/alerting-squad",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "true"
       }
     },
     {
       "metadata": {
         "name": "alertingJiraIntegration",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-02-14T12:22:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-02-14T12:22:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables the new Jira integration for contact points in cloud alert managers.",
         "stage": "experimental",
         "codeowner": "@grafana/alerting-squad",
         "frontend": true,
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -419,98 +527,123 @@
     {
       "metadata": {
         "name": "alertingListViewV2",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2024-05-24T14:40:49Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2024-05-24T14:40:49Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables the new alert list view design",
         "stage": "GA",
         "codeowner": "@grafana/alerting-squad",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "true"
       }
     },
     {
       "metadata": {
         "name": "alertingListViewV2PreviewToggle",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-04-22T08:50:34Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-04-22T08:50:34Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables the alerting list view v2 preview toggle",
         "stage": "preview",
         "codeowner": "@grafana/alerting-squad",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "alertingMigrationUI",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-03-14T16:40:05Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-03-14T16:40:05Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables the alerting migration UI, to migrate data source-managed rules to Grafana-managed rules",
         "stage": "GA",
         "codeowner": "@grafana/alerting-squad",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "true"
       }
     },
     {
       "metadata": {
         "name": "alertingMigrationWizardUI",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables the migration wizard UI to migrate alert rules and notification resources from external sources to Grafana Alerting",
         "stage": "experimental",
         "codeowner": "@grafana/alerting-squad",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "alertingMultiplePolicies",
-        "resourceVersion": "1781102456776",
+        "resourceVersion": "1783954958299",
         "creationTimestamp": "2026-05-22T09:03:04Z",
         "annotations": {
-          "grafana.app/updatedTimestamp": "2026-06-10 14:40:56.776063699 +0000 UTC"
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
         }
       },
       "spec": {
         "description": "Enables the ability to create multiple notification policies in alerting",
         "stage": "GA",
         "codeowner": "@grafana/alerting-squad",
+        "frontendUsed": true,
         "expression": "true"
       }
     },
     {
       "metadata": {
         "name": "alertingNavigationV2",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-01-14T10:58:11Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-01-14T10:58:11Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables the new Alerting navigation structure with improved menu grouping",
         "stage": "GA",
         "codeowner": "@grafana/alerting-squad",
+        "frontendUsed": true,
         "expression": "true"
       }
     },
     {
       "metadata": {
         "name": "alertingNotificationHistory",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-07-17T13:26:26Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-07-17T13:26:26Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables the notification history feature",
         "stage": "experimental",
         "codeowner": "@grafana/alerting-squad",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -518,13 +651,17 @@
     {
       "metadata": {
         "name": "alertingNotificationHistoryDetail",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables the notification history detail page",
         "stage": "experimental",
         "codeowner": "@grafana/alerting-squad",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -532,13 +669,17 @@
     {
       "metadata": {
         "name": "alertingNotificationHistoryGlobal",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables the notification history global menu item viewer",
         "stage": "experimental",
         "codeowner": "@grafana/alerting-squad",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -546,13 +687,17 @@
     {
       "metadata": {
         "name": "alertingNotificationHistoryRuleViewer",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables the notification history tab in the rule viewer",
         "stage": "experimental",
         "codeowner": "@grafana/alerting-squad",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -560,13 +705,17 @@
     {
       "metadata": {
         "name": "alertingNotificationHistoryTriage",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables the notification history timeline in the triage instance details drawer",
         "stage": "experimental",
         "codeowner": "@grafana/alerting-squad",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -574,28 +723,36 @@
     {
       "metadata": {
         "name": "alertingNotificationsStepMode",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2024-11-22T11:07:45Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2024-11-22T11:07:45Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables simplified step mode in the notifications section",
         "stage": "GA",
         "codeowner": "@grafana/alerting-squad",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "true"
       }
     },
     {
       "metadata": {
         "name": "alertingPolicyRoutingSettings",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Use notification settings policy field instead of labels for named policy routing in alert rules",
         "stage": "experimental",
         "codeowner": "@grafana/alerting-squad",
         "frontend": true,
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -603,27 +760,35 @@
     {
       "metadata": {
         "name": "alertingPrometheusRulesPrimary",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2024-09-27T12:27:16Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2024-09-27T12:27:16Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Uses Prometheus rules as the primary source of truth for ruler-enabled data sources",
         "stage": "experimental",
         "codeowner": "@grafana/alerting-squad",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "alertingProvenanceLockWrites",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-07-23T18:16:06Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-07-23T18:16:06Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables a feature to avoid issues with concurrent writes to the alerting provenance table in MySQL",
         "stage": "experimental",
         "codeowner": "@grafana/alerting-squad",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -631,54 +796,70 @@
     {
       "metadata": {
         "name": "alertingQueryAndExpressionsStepMode",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2024-09-26T06:33:14Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2024-09-26T06:33:14Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables step mode for alerting queries and expressions",
         "stage": "GA",
         "codeowner": "@grafana/alerting-squad",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "true"
       }
     },
     {
       "metadata": {
         "name": "alertingQueryOptimization",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2024-01-10T20:52:58Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2024-01-10T20:52:58Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Optimizes eligible queries in order to reduce load on datasources",
         "stage": "GA",
         "codeowner": "@grafana/alerting-squad",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "alertingRuleGroupSortByFolderFullpath",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Sort alert rule groups by folder full path in the Prometheus rules API",
         "stage": "experimental",
         "codeowner": "@grafana/alerting-squad",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "alertingRulePermanentlyDelete",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-04-03T11:18:25Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-04-03T11:18:25Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables UI functionality to permanently delete alert rules",
         "stage": "GA",
         "codeowner": "@grafana/alerting-squad",
         "frontend": true,
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "true"
       }
@@ -686,13 +867,17 @@
     {
       "metadata": {
         "name": "alertingRuleRecoverDeleted",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-03-27T14:39:26Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-03-27T14:39:26Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables the UI functionality to recover and view deleted alert rules",
         "stage": "GA",
         "codeowner": "@grafana/alerting-squad",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "true"
       }
@@ -700,14 +885,18 @@
     {
       "metadata": {
         "name": "alertingRuleVersionHistoryRestore",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-02-17T12:25:32Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-02-17T12:25:32Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables the alert rule version history restore feature",
         "stage": "GA",
         "codeowner": "@grafana/alerting-squad",
         "frontend": true,
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "true"
       }
@@ -715,39 +904,51 @@
     {
       "metadata": {
         "name": "alertingSaveStateCompressed",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-01-27T17:47:33Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-01-27T17:47:33Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables the compressed protobuf-based alert state storage. Default is enabled.",
         "stage": "preview",
         "codeowner": "@grafana/alerting-squad",
+        "frontendUsed": true,
         "expression": "true"
       }
     },
     {
       "metadata": {
         "name": "alertingSaveStatePeriodic",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2024-01-23T16:03:30Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2024-01-23T16:03:30Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Writes the state periodically to the database, asynchronous to rule evaluation",
         "stage": "privatePreview",
         "codeowner": "@grafana/alerting-squad",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "alertingSyncDispatchTimer",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-01-14T09:04:29Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-01-14T09:04:29Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Use synchronized dispatch timer to minimize duplicate notifications across alertmanager HA pods",
         "stage": "experimental",
         "codeowner": "@grafana/alerting-squad",
+        "frontendUsed": true,
         "requiresRestart": true,
         "hideFromDocs": true,
         "expression": "false"
@@ -756,28 +957,36 @@
     {
       "metadata": {
         "name": "alertingSyncNotifiersApiMigration",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Use the new k8s API for fetching integration type schemas",
         "stage": "experimental",
         "codeowner": "@grafana/alerting-squad",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "alertingTriage",
-        "resourceVersion": "1779440584464",
+        "resourceVersion": "1783954958299",
         "creationTimestamp": "2025-07-31T22:56:50Z",
-        "deletionTimestamp": "2025-08-01T11:30:17Z"
+        "deletionTimestamp": "2025-08-01T11:30:17Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables the alerting triage feature",
         "stage": "experimental",
         "codeowner": "@grafana/alerting-squad",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -785,27 +994,35 @@
     {
       "metadata": {
         "name": "alertingUIOptimizeReducer",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2024-11-18T10:59:00Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2024-11-18T10:59:00Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables removing the reducer from the alerting UI when creating a new alert rule and using instant query",
         "stage": "GA",
         "codeowner": "@grafana/alerting-squad",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "true"
       }
     },
     {
       "metadata": {
         "name": "alertingUIUseBackendFilters",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-11-13T14:52:14Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-11-13T14:52:14Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables the UI to use certain backend-side filters",
         "stage": "preview",
         "codeowner": "@grafana/alerting-squad",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "true"
       }
@@ -813,13 +1030,17 @@
     {
       "metadata": {
         "name": "alertingUIUseFullyCompatBackendFilters",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-11-24T11:42:09Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-11-24T11:42:09Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables the UI to use rules backend-side filters 100% compatible with the frontend filters",
         "stage": "preview",
         "codeowner": "@grafana/alerting-squad",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "true"
       }
@@ -827,14 +1048,18 @@
     {
       "metadata": {
         "name": "alertingUseNewSimplifiedRoutingHashAlgorithm",
-        "resourceVersion": "1779440584464",
+        "resourceVersion": "1783954958299",
         "creationTimestamp": "2025-08-29T14:46:39Z",
-        "deletionTimestamp": "2025-09-01T09:33:33Z"
+        "deletionTimestamp": "2025-09-01T09:33:33Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "",
         "stage": "preview",
         "codeowner": "@grafana/alerting-squad",
+        "frontendUsed": true,
         "requiresRestart": true,
         "hideFromDocs": true,
         "expression": "true"
@@ -843,39 +1068,51 @@
     {
       "metadata": {
         "name": "alertmanagerRemotePrimary",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2023-10-30T16:27:08Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2023-10-30T16:27:08Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enable Grafana to have a remote Alertmanager instance as the primary Alertmanager.",
         "stage": "experimental",
         "codeowner": "@grafana/alerting-squad",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "alertmanagerRemoteSecondary",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2023-10-30T16:27:08Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2023-10-30T16:27:08Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enable Grafana to sync configuration and state with a remote Alertmanager.",
         "stage": "experimental",
         "codeowner": "@grafana/alerting-squad",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "alertmanagerRemoteSecondaryWithRemoteState",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-07-25T15:06:59Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-07-25T15:06:59Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Starts Grafana in remote secondary mode pulling the latest state from the remote Alertmanager to avoid duplicate notifications.",
         "stage": "experimental",
         "codeowner": "@grafana/alerting-squad",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -883,14 +1120,18 @@
     {
       "metadata": {
         "name": "analyticsFramework",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables new analytics framework",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-frontend-platform",
         "frontend": true,
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -898,13 +1139,17 @@
     {
       "metadata": {
         "name": "annotationPermissionUpdate",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2023-10-31T13:30:13Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2023-10-31T13:30:13Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Change the way annotation permissions work by scoping them to folders and dashboards.",
         "stage": "GA",
         "codeowner": "@grafana/identity-access-team",
+        "frontendUsed": true,
         "expression": "true"
       }
     },
@@ -926,13 +1171,17 @@
     {
       "metadata": {
         "name": "appPlatformGrpcClientAuth",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2024-10-14T10:47:18Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2024-10-14T10:47:18Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables the gRPC client to authenticate with the App Platform by using ID \u0026 access tokens",
         "stage": "experimental",
         "codeowner": "@grafana/identity-access-team",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -968,27 +1217,35 @@
     {
       "metadata": {
         "name": "assistant.frontend.tools.dashboardTemplates",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables the template dashboard assistant",
         "stage": "experimental",
         "codeowner": "@grafana/sharing-squad",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "auditLoggingAppPlatform",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-12-29T15:28:29Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-12-29T15:28:29Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enable audit logging with Kubernetes under app platform",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-operator-experience-squad",
+        "frontendUsed": true,
         "requiresRestart": true,
         "hideFromDocs": true,
         "expression": "false"
@@ -1014,13 +1271,17 @@
     {
       "metadata": {
         "name": "authZGRPCServer",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2024-06-13T09:41:35Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2024-06-13T09:41:35Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables the gRPC server for authorization",
         "stage": "experimental",
         "codeowner": "@grafana/identity-access-team",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -1028,119 +1289,155 @@
     {
       "metadata": {
         "name": "awsAsyncQueryCaching",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2023-07-21T15:34:07Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2023-07-21T15:34:07Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enable caching for async queries for Redshift and Athena. Requires that the data source has caching and async query support enabled",
         "stage": "GA",
         "codeowner": "@grafana/data-sources-plugins",
+        "frontendUsed": true,
         "expression": "true"
       }
     },
     {
       "metadata": {
         "name": "awsDatasourcesHttpProxy",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-11-12T18:51:23Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-11-12T18:51:23Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables http proxy settings for aws datasources",
         "stage": "experimental",
         "codeowner": "@grafana/data-sources-plugins",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "awsDatasourcesTempCredentials",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2023-07-06T15:06:11Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2023-07-06T15:06:11Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Support temporary security credentials in AWS plugins for Grafana Cloud customers",
         "stage": "GA",
         "codeowner": "@grafana/data-sources-plugins",
+        "frontendUsed": true,
         "expression": "true"
       }
     },
     {
       "metadata": {
         "name": "azureMonitorDisableLogLimit",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2024-10-24T13:32:09Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2024-10-24T13:32:09Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Disables the log limit restriction for Azure Monitor when true. The limit is enabled by default.",
         "stage": "GA",
         "codeowner": "@grafana/data-sources-plugins",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "azureMonitorEnableUserAuth",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2024-11-27T14:01:54Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2024-11-27T14:01:54Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables user auth for Azure Monitor datasource only",
         "stage": "GA",
         "codeowner": "@grafana/data-sources-plugins",
+        "frontendUsed": true,
         "expression": "true"
       }
     },
     {
       "metadata": {
         "name": "azureMonitorLogsBuilderEditor",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-04-02T14:15:25Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-04-02T14:15:25Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables the logs builder mode for the Azure Monitor data source",
         "stage": "preview",
         "codeowner": "@grafana/data-sources-plugins",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "azureMonitorPrometheusExemplars",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2024-06-06T16:53:17Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2024-06-06T16:53:17Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Allows configuration of Azure Monitor as a data source that can provide Prometheus exemplars",
         "stage": "GA",
         "codeowner": "@grafana/data-sources-plugins",
+        "frontendUsed": true,
         "expression": "true"
       }
     },
     {
       "metadata": {
         "name": "azureResourcePickerUpdates",
-        "resourceVersion": "1779440584464",
+        "resourceVersion": "1783954958299",
         "creationTimestamp": "2025-07-31T22:56:50Z",
-        "deletionTimestamp": "2025-08-01T11:30:17Z"
+        "deletionTimestamp": "2025-08-01T11:30:17Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables the updated Azure Monitor resource picker",
         "stage": "GA",
         "codeowner": "@grafana/data-sources-plugins",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "true"
       }
     },
     {
       "metadata": {
         "name": "cacheConfigUnifiedStorageMigration",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables cache configs data migration to unified storage",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-operator-experience-squad",
+        "frontendUsed": true,
         "requiresRestart": true,
         "expression": "false"
       }
@@ -1162,69 +1459,89 @@
     {
       "metadata": {
         "name": "canvasExternalPlugin",
-        "resourceVersion": "1780948766147",
-        "creationTimestamp": "2026-06-08T19:59:26Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-06-08T19:59:26Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Load Canvas panel from an external plugin instead of the bundled core plugin",
         "stage": "experimental",
         "codeowner": "@grafana/dataviz-squad",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "canvasPanelNesting",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2022-05-31T19:03:34Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2022-05-31T19:03:34Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Allow elements nesting",
         "stage": "experimental",
         "codeowner": "@grafana/dataviz-squad",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "canvasPanelPanZoom",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2024-01-02T19:52:21Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2024-01-02T19:52:21Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Allow pan and zoom in canvas panel",
         "stage": "preview",
         "codeowner": "@grafana/dataviz-squad",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "cdnPluginsLoadFirst",
-        "resourceVersion": "1779440584464",
+        "resourceVersion": "1783954958299",
         "creationTimestamp": "2025-08-29T14:46:39Z",
-        "deletionTimestamp": "2025-09-01T09:33:33Z"
+        "deletionTimestamp": "2025-09-01T09:33:33Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Prioritize loading plugins from the CDN before other sources",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-catalog",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "cdnPluginsUrls",
-        "resourceVersion": "1779440584464",
+        "resourceVersion": "1783954958299",
         "creationTimestamp": "2025-08-29T14:46:39Z",
-        "deletionTimestamp": "2025-09-01T09:33:33Z"
+        "deletionTimestamp": "2025-09-01T09:33:33Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enable loading plugins via declarative URLs",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-catalog",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
@@ -1250,13 +1567,17 @@
     {
       "metadata": {
         "name": "clickHouseConfigValidation",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables validation on the ClickHouse data source configuration page",
         "stage": "experimental",
         "codeowner": "@grafana/data-sources-plugins",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -1264,13 +1585,17 @@
     {
       "metadata": {
         "name": "cloudRBACRoles",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2024-01-10T13:19:01Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2024-01-10T13:19:01Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enabled grafana cloud specific RBAC roles",
         "stage": "preview",
         "codeowner": "@grafana/identity-access-team",
+        "frontendUsed": true,
         "requiresRestart": true,
         "hideFromDocs": true,
         "expression": "false"
@@ -1279,52 +1604,68 @@
     {
       "metadata": {
         "name": "cloudWatchBatchQueries",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2023-10-20T19:09:41Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2023-10-20T19:09:41Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Runs CloudWatch metrics queries as separate batches",
         "stage": "GA",
         "codeowner": "@grafana/data-sources-plugins",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "cloudWatchCrossAccountQuerying",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2022-11-28T11:39:12Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2022-11-28T11:39:12Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables cross-account querying in CloudWatch datasources",
         "stage": "GA",
         "codeowner": "@grafana/data-sources-plugins",
+        "frontendUsed": true,
         "expression": "true"
       }
     },
     {
       "metadata": {
         "name": "cloudWatchNewLabelParsing",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2024-04-05T15:57:56Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2024-04-05T15:57:56Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Updates CloudWatch label parsing to be more accurate",
         "stage": "GA",
         "codeowner": "@grafana/data-sources-plugins",
+        "frontendUsed": true,
         "expression": "true"
       }
     },
     {
       "metadata": {
         "name": "cloudWatchRoundUpEndTime",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2024-06-27T15:10:28Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2024-06-27T15:10:28Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Round up end time for metric queries to the next minute to avoid missing data",
         "stage": "GA",
         "codeowner": "@grafana/data-sources-plugins",
+        "frontendUsed": true,
         "expression": "true"
       }
     },
@@ -1362,13 +1703,17 @@
     {
       "metadata": {
         "name": "configurableSchedulerTick",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2023-07-26T16:44:12Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2023-07-26T16:44:12Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enable changing the scheduler base interval via configuration option unified_alerting.scheduler_tick_interval",
         "stage": "experimental",
         "codeowner": "@grafana/alerting-squad",
+        "frontendUsed": true,
         "requiresRestart": true,
         "hideFromDocs": true,
         "expression": "false"
@@ -1377,28 +1722,36 @@
     {
       "metadata": {
         "name": "crashDetection",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2024-11-12T15:07:27Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2024-11-12T15:07:27Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables browser crash detection reporting to Faro.",
         "stage": "experimental",
         "codeowner": "@grafana/observability-traces-and-profiling",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "createAlertRuleFromPanel",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables creating alert rules from a panel using a drawer UI",
         "stage": "experimental",
         "codeowner": "@grafana/alerting-squad",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
@@ -1420,10 +1773,10 @@
     {
       "metadata": {
         "name": "cujTracking",
-        "resourceVersion": "1782510975281",
+        "resourceVersion": "1783954958299",
         "creationTimestamp": "2026-04-20T08:50:40Z",
         "annotations": {
-          "grafana.app/updatedTimestamp": "2026-06-26 21:56:15.281108 +0000 UTC"
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
         }
       },
       "spec": {
@@ -1431,61 +1784,78 @@
         "stage": "experimental",
         "codeowner": "@grafana/dashboards-squad",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "dashboard.notebooks",
-        "resourceVersion": "1783509818865",
-        "creationTimestamp": "2026-07-08T11:23:38Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-07-08T11:23:38Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enable notebooks, a resource in the dashboard API group for mixing text cells, code cells, and visualization panels",
         "stage": "experimental",
         "codeowner": "@grafana/sharing-squad",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "dashboard.vectorSearch",
-        "resourceVersion": "1781031364322",
+        "resourceVersion": "1783954958299",
         "creationTimestamp": "2026-06-09T18:56:04Z",
-        "deletionTimestamp": "2026-06-09T20:44:47Z"
+        "deletionTimestamp": "2026-06-09T20:44:47Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Exposes the semantic (vector) search endpoint for dashboards under the dashboard API",
         "stage": "experimental",
         "codeowner": "@grafana/search-and-storage",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "dashboardAssistantPopover",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables the assistant prompt popover on panel click in dashboard view mode",
         "stage": "experimental",
         "codeowner": "@grafana/dashboards-squad",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "dashboardDefaultLayoutSelector",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables default layout selector in dashboard settings",
         "stage": "GA",
         "codeowner": "@grafana/dashboards-squad",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "true"
       }
     },
@@ -1524,42 +1894,54 @@
     {
       "metadata": {
         "name": "dashboardLevelTimeMacros",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-07-31T09:49:07Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-07-31T09:49:07Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Supports __from and __to macros that always use the dashboard level time range",
         "stage": "experimental",
         "codeowner": "@grafana/dashboards-squad",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "dashboardLibrary",
-        "resourceVersion": "1779440584464",
+        "resourceVersion": "1783954958299",
         "creationTimestamp": "2025-08-29T14:46:39Z",
-        "deletionTimestamp": "2025-09-01T09:33:33Z"
+        "deletionTimestamp": "2025-09-01T09:33:33Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Displays datasource provisioned dashboards in dashboard empty page, only when coming from datasource configuration page",
         "stage": "experimental",
         "codeowner": "@grafana/sharing-squad",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "dashboardNewLayouts",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2024-10-23T08:55:45Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2024-10-23T08:55:45Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables new dashboard layouts",
         "stage": "GA",
         "codeowner": "@grafana/dashboards-squad",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "true"
       }
     },
@@ -1584,66 +1966,82 @@
     {
       "metadata": {
         "name": "dashboardSectionVariables",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables support for section level variables (rows and tabs)",
         "stage": "GA",
         "codeowner": "@grafana/dashboards-squad",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "true"
       }
     },
     {
       "metadata": {
         "name": "dashboardTemplates",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-10-28T20:05:32Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-10-28T20:05:32Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables a flow to get started with a new dashboard from a template",
         "stage": "preview",
         "codeowner": "@grafana/sharing-squad",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "dashboardTemplatesAssistantButton",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables the Assistant button in the dashboard templates card",
         "stage": "experimental",
         "codeowner": "@grafana/sharing-squad",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "dashboardUndoRedo",
-        "resourceVersion": "1779440584464",
+        "resourceVersion": "1783954958299",
         "creationTimestamp": "2025-08-29T14:46:39Z",
-        "deletionTimestamp": "2025-09-01T09:33:33Z"
+        "deletionTimestamp": "2025-09-01T09:33:33Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables undo/redo in dynamic dashboards",
         "stage": "experimental",
         "codeowner": "@grafana/dashboards-squad",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "dashboardUnifiedDrilldownControls",
-        "resourceVersion": "1779444036082",
+        "resourceVersion": "1783954958299",
         "creationTimestamp": "2026-03-09T18:40:15Z",
         "annotations": {
-          "grafana.app/updatedTimestamp": "2026-05-22 10:00:36.082015 +0000 UTC"
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
         }
       },
       "spec": {
@@ -1651,6 +2049,7 @@
         "stage": "GA",
         "codeowner": "@grafana/dashboards-squad",
         "frontend": true,
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "true"
       }
@@ -1658,13 +2057,17 @@
     {
       "metadata": {
         "name": "dashboardValidatorApp",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables dashboard validator app to run compatibility checks between a dashboard and data source",
         "stage": "experimental",
         "codeowner": "@grafana/sharing-squad",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
@@ -1713,13 +2116,17 @@
     {
       "metadata": {
         "name": "datasourceAPIServers",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2024-09-19T08:28:27Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2024-09-19T08:28:27Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Expose some datasources as apiservers.",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-app-platform-squad",
+        "frontendUsed": true,
         "requiresRestart": true,
         "expression": "false"
       }
@@ -1727,27 +2134,35 @@
     {
       "metadata": {
         "name": "datasourceConnectionsTab",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-01-21T17:39:48Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-01-21T17:39:48Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Shows defined connections for a data source in the plugins detail page",
         "stage": "privatePreview",
         "codeowner": "@grafana/grafana-catalog",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "datasourceLegacyIdApi",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Register legacy datasource apis that use the numeric id",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-datasources-core-services",
+        "frontendUsed": true,
         "requiresRestart": true,
         "expression": "false"
       }
@@ -1755,14 +2170,18 @@
     {
       "metadata": {
         "name": "datasources.apiserver.useNewAPIsForDatasourceResources",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Use the new datasource API groups for datasource resource requests, frontend flag",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-datasources-core-services",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
@@ -1782,14 +2201,18 @@
     {
       "metadata": {
         "name": "datasources.config.ui.useNewDatasourceCRUDAPIs",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Use the new datasource API groups for datasource CRUD requests, frontend flag",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-datasources-core-services",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
@@ -1837,93 +2260,121 @@
     {
       "metadata": {
         "name": "datasourcesApiServerEnableHealthEndpoint",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Handle datasource health requests to the legacy API routes by querying the new datasource api group endpoints behind the scenes.",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-datasources-core-services",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "datasourcesApiServerEnableHealthEndpointFrontend",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Send Datsource health requests to /apis/ API routes instead of the legacy /api/datasources/uid/{uid}/health route.",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-datasources-core-services",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "datasourcesApiServerEnableHealthEndpointRedirect",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Redirect datasource health requests from the legacy API routes to the new datasource api group endpoints.",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-datasources-core-services",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "datasourcesApiServerEnableResourceEndpoint",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Handle datasource resource requests to the legacy API routes by querying the new datasource api group endpoints behind the scenes.",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-datasources-core-services",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "datasourcesApiserverEnableResourceEndpointRedirect",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "redirect datasource resource requests from the legacy API routes to the new datasource api group endpoints.",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-datasources-core-services",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "datasourcesRerouteLegacyCRUDAPIs",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Handle datasource CRUD requests to the legacy API routes by querying the new datasource api group endpoints behind the scenes.",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-datasources-core-services",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "dataviz.experimentalColorSchemes",
-        "resourceVersion": "1782241743120",
-        "creationTimestamp": "2026-06-23T19:09:03Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-06-23T19:09:03Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables additional experimental color schemes for visualizations.",
         "stage": "experimental",
         "codeowner": "@grafana/dataviz-squad",
         "frontend": true,
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -1931,13 +2382,17 @@
     {
       "metadata": {
         "name": "disableNumericMetricsSortingInExpressions",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2024-04-16T14:52:47Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2024-04-16T14:52:47Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "In server-side expressions, disable the sorting of numeric-kind metrics by their metric name or labels.",
         "stage": "experimental",
         "codeowner": "@grafana/data-sources-plugins",
+        "frontendUsed": true,
         "requiresRestart": true,
         "expression": "false"
       }
@@ -1945,13 +2400,17 @@
     {
       "metadata": {
         "name": "disableSSEDataplane",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2023-04-12T16:24:34Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2023-04-12T16:24:34Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Disables dataplane specific processing in server side expressions.",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-datasources-core-services",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
@@ -1973,13 +2432,17 @@
     {
       "metadata": {
         "name": "dsAbstractionApp",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Registers the dsabstraction app for querying datasources via unified SQL",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-datasources-core-services",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -1987,13 +2450,17 @@
     {
       "metadata": {
         "name": "elasticsearchCrossClusterSearch",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2024-12-12T22:20:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2024-12-12T22:20:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables cross cluster search in the Elasticsearch data source",
         "stage": "GA",
         "codeowner": "@grafana/data-sources-plugins",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
@@ -2014,13 +2481,17 @@
     {
       "metadata": {
         "name": "elasticsearchImprovedParsing",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-01-15T17:05:54Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-01-15T17:05:54Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables less memory intensive Elasticsearch result parsing",
         "stage": "experimental",
         "codeowner": "@grafana/data-sources-plugins",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
@@ -2041,14 +2512,18 @@
     {
       "metadata": {
         "name": "enableAppChromeExtensions",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-06-30T04:32:08Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-06-30T04:32:08Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Set this to true to enable all app chrome extensions registered by plugins.",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-catalog",
         "frontend": true,
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -2056,28 +2531,36 @@
     {
       "metadata": {
         "name": "enableColorblindSafePanelOptions",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables new colorblind safe palette and line fill patterns for panels",
         "stage": "experimental",
         "codeowner": "@grafana/dataviz-squad",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "enableDashboardEmptyExtensions",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-10-13T07:03:13Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-10-13T07:03:13Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Set this to true to enable all dashboard empty state extensions registered by plugins.",
         "stage": "experimental",
         "codeowner": "@grafana/dashboards-squad",
         "frontend": true,
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -2085,13 +2568,17 @@
     {
       "metadata": {
         "name": "enableExtensionsAdminPage",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2024-11-05T15:55:10Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2024-11-05T15:55:10Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables the extension admin page regardless of development mode",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-catalog",
+        "frontendUsed": true,
         "requiresRestart": true,
         "expression": "false"
       }
@@ -2099,29 +2586,34 @@
     {
       "metadata": {
         "name": "enableSCIM",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2024-11-07T14:38:46Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2024-11-07T14:38:46Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables SCIM support for user and group management",
         "stage": "GA",
         "codeowner": "@grafana/identity-access-team",
+        "frontendUsed": true,
         "expression": "true"
       }
     },
     {
       "metadata": {
         "name": "enableScopesInMetricsExplore",
-        "resourceVersion": "1782915825637",
+        "resourceVersion": "1783954958299",
         "creationTimestamp": "2024-11-06T13:11:33Z",
         "annotations": {
-          "grafana.app/updatedTimestamp": "2026-07-01 14:23:45.637495 +0000 UTC"
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
         }
       },
       "spec": {
         "description": "Enables the scopes usage in Metrics Explore",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-operator-experience-squad",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -2129,13 +2621,17 @@
     {
       "metadata": {
         "name": "excludeRedundantManagedPermissions",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Exclude redundant individual dashboard/folder permissions from managed roles at query time",
         "stage": "experimental",
         "codeowner": "@grafana/identity-access-team",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -2143,14 +2639,18 @@
     {
       "metadata": {
         "name": "experimentRecentlyViewedDashboards",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-01-13T15:22:20Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-01-13T15:22:20Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "A/A test for recently viewed dashboards feature",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-frontend-navigation",
         "frontend": true,
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -2158,41 +2658,53 @@
     {
       "metadata": {
         "name": "exploreLogsAggregatedMetrics",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2024-08-29T13:55:59Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2024-08-29T13:55:59Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Used in Logs Drilldown to query by aggregated metrics",
         "stage": "experimental",
         "codeowner": "@grafana/observability-logs",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "exploreLogsShardSplitting",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2024-08-29T13:55:59Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2024-08-29T13:55:59Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Deprecated. Replace with lokiShardSplitting. Used in Logs Drilldown to split queries into multiple queries based on the number of shards",
         "stage": "experimental",
         "codeowner": "@grafana/observability-logs",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "externalServiceAccounts",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2023-09-28T07:26:37Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2023-09-28T07:26:37Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Automatic service account and token setup for plugins",
         "stage": "preview",
         "codeowner": "@grafana/identity-access-team",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
@@ -2214,16 +2726,17 @@
     {
       "metadata": {
         "name": "externalSnapshotsK8SAPIPush",
-        "resourceVersion": "1779386639364",
+        "resourceVersion": "1783954958299",
         "creationTimestamp": "2026-05-19T14:20:50Z",
         "annotations": {
-          "grafana.app/updatedTimestamp": "2026-05-21 18:03:59.364818 +0000 UTC"
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
         }
       },
       "spec": {
         "description": "When kubernetesSnapshots is enabled, push/delete external snapshots via the K8s API. When off, the K8s snapshots handler falls back to the legacy /api/snapshots endpoint on the external instance.",
         "stage": "experimental",
         "codeowner": "@grafana/sharing-squad",
+        "frontendUsed": true,
         "requiresRestart": true,
         "expression": "false"
       }
@@ -2245,16 +2758,17 @@
     {
       "metadata": {
         "name": "externalSnapshotsSupportLegacyAPI",
-        "resourceVersion": "1779389019012",
+        "resourceVersion": "1783954958299",
         "creationTimestamp": "2026-05-21T18:03:59Z",
         "annotations": {
-          "grafana.app/updatedTimestamp": "2026-05-21 18:43:39.012069 +0000 UTC"
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
         }
       },
       "spec": {
         "description": "On a SnapshotPublicMode instance with kubernetesSnapshots enabled, keep accepting anonymous /api/snapshots pushes by routing them through CreateDashboardSnapshotPublic instead of the authenticated k8s create endpoint. Default off: the migrated end state rejects anonymous legacy pushes. Turn on as a temporary backward-compat lever while senders migrate to the authenticated k8s API push, then turn off once migration completes. Not compatible with snapshot dual-write Mode5 (k8s-only storage), where the k8s create API is mandatory.",
         "stage": "experimental",
         "codeowner": "@grafana/sharing-squad",
+        "frontendUsed": true,
         "requiresRestart": true,
         "expression": "false"
       }
@@ -2280,84 +2794,108 @@
     {
       "metadata": {
         "name": "faroDatasourceSelector",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2023-05-05T00:35:10Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2023-05-05T00:35:10Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enable the data source selector within the Frontend Apps section of the Frontend Observability",
         "stage": "preview",
         "codeowner": "@grafana/app-o11y",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "faroSessionReplay",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enable Faro session replay for Grafana",
         "stage": "experimental",
         "codeowner": "@grafana/session-replay",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "favoriteDatasources",
-        "resourceVersion": "1779440584464",
+        "resourceVersion": "1783954958299",
         "creationTimestamp": "2025-07-31T22:56:50Z",
-        "deletionTimestamp": "2025-08-01T11:30:17Z"
+        "deletionTimestamp": "2025-08-01T11:30:17Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enable favorite datasources",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-catalog",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "featureHighlights",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2022-02-03T11:53:23Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2022-02-03T11:53:23Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Highlight Grafana Enterprise features",
         "stage": "GA",
         "codeowner": "@grafana/grafana-operator-experience-squad",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "feedbackButton",
-        "resourceVersion": "1779440584464",
+        "resourceVersion": "1783954958299",
         "creationTimestamp": "2024-12-02T17:08:15Z",
-        "deletionTimestamp": "2025-11-20T10:18:50Z"
+        "deletionTimestamp": "2025-11-20T10:18:50Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables the feedback button in the dashboard edit sidebar",
         "stage": "preview",
         "codeowner": "@grafana/dashboards-squad",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "true"
       }
     },
     {
       "metadata": {
         "name": "fetchRulesInCompactMode",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-12-18T09:06:39Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-12-18T09:06:39Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Add compact=true when fetching rules",
         "stage": "experimental",
         "codeowner": "@grafana/alerting-squad",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -2365,13 +2903,17 @@
     {
       "metadata": {
         "name": "fetchRulesUsingPost",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-01-29T12:17:44Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-01-29T12:17:44Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Use a POST request to list rules by passing down the namespaces user has access to",
         "stage": "experimental",
         "codeowner": "@grafana/alerting-squad",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -2379,28 +2921,36 @@
     {
       "metadata": {
         "name": "flameGraphWithCallTree",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables the new Flame Graph UI containing the Call Tree view",
         "stage": "preview",
         "codeowner": "@grafana/observability-traces-and-profiling",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "foldersAppPlatformAPI",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-07-03T14:15:23Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-07-03T14:15:23Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables use of app platform API for folders",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-frontend-navigation",
         "frontend": true,
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -2466,13 +3016,17 @@
     {
       "metadata": {
         "name": "globalDashboardVariables",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables global and folder-scoped dashboard variables via dashboard.grafana.app",
         "stage": "experimental",
         "codeowner": "@grafana/dashboards-squad",
+        "frontendUsed": true,
         "requiresRestart": true,
         "expression": "false"
       }
@@ -2506,41 +3060,53 @@
     {
       "metadata": {
         "name": "grafana.customDashboardTemplates",
-        "resourceVersion": "1781723429145",
-        "creationTimestamp": "2026-06-17T19:10:29Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-06-17T19:10:29Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables custom dashboard templates for enterprise",
         "stage": "experimental",
         "codeowner": "@grafana/sharing-squad",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "grafana.customizableMegaMenu",
-        "resourceVersion": "1782389631454",
-        "creationTimestamp": "2026-06-25T12:13:51Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-06-25T12:13:51Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Allows users to customise the mega menu by hiding top-level navigation items they are not interested in",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-frontend-navigation",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "grafana.dashboardSettingsRedesign",
-        "resourceVersion": "1782823244633",
-        "creationTimestamp": "2026-06-30T12:40:44Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-06-30T12:40:44Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Redesigns dashboard settings page into Advanced Settings in a modal window",
         "stage": "GA",
         "codeowner": "@grafana/dashboards-squad",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "true"
       }
     },
@@ -2560,14 +3126,18 @@
     {
       "metadata": {
         "name": "grafana.enableScopesFirstMode",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables UI changes for integrations that require a scope to always be selected (for example, hides the scope selector's Remove all button)",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-operator-experience-squad",
         "frontend": true,
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -2589,42 +3159,54 @@
     {
       "metadata": {
         "name": "grafana.growthHomepage",
-        "resourceVersion": "1782913620784",
-        "creationTimestamp": "2026-07-01T13:47:00Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-07-01T13:47:00Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables PLG-focused growth redesign of the unified homepage",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-frontend-navigation",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "grafana.kubernetesAnnotationsClient",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables usage of the new annotations API client",
         "stage": "experimental",
         "codeowner": "@grafana/dashboards-squad",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "grafana.logLevelInference",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables log level inference from log line contents when level is not defined as a field or a label",
         "stage": "deprecated",
         "codeowner": "@grafana/observability-logs",
         "frontend": true,
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -2676,46 +3258,52 @@
     {
       "metadata": {
         "name": "grafana.newPanelQueryErrorsUI",
-        "resourceVersion": "1781775898347",
-        "creationTimestamp": "2026-06-18T09:44:58Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-06-18T09:44:58Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables a new UI for query errors and notices",
         "stage": "experimental",
         "codeowner": "@grafana/dashboards-squad",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "grafana.newPreferencesPage",
-        "resourceVersion": "1781704114797",
+        "resourceVersion": "1783954958299",
         "creationTimestamp": "2026-05-22T09:03:04Z",
         "annotations": {
-          "grafana.app/updatedTimestamp": "2026-06-17 13:48:34.797786 +0000 UTC"
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
         }
       },
       "spec": {
         "description": "Whether to use the new SharedPreferences functional component",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-frontend-platform",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "grafana.onDemandDiagnostics",
-        "resourceVersion": "1782469062023",
+        "resourceVersion": "1783954958299",
         "creationTimestamp": "2026-06-26T10:14:02Z",
         "annotations": {
-          "grafana.app/updatedTimestamp": "2026-06-26 10:17:42.023006 +0000 UTC"
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
         }
       },
       "spec": {
         "description": "Adds a 'Download diagnostics' action that bundles diagnostic artifacts such as HTTP traffic (HAR), server log, dashboard and panel JSONs, and more",
         "stage": "experimental",
         "codeowner": "@grafana/data-sources",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
@@ -2736,10 +3324,10 @@
     {
       "metadata": {
         "name": "grafana.panelEditNextFeedbackEvent",
-        "resourceVersion": "1780592255785",
+        "resourceVersion": "1783954958299",
         "creationTimestamp": "2026-05-27T17:36:12Z",
         "annotations": {
-          "grafana.app/updatedTimestamp": "2026-06-04 16:57:35.785848 +0000 UTC"
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
         }
       },
       "spec": {
@@ -2747,6 +3335,7 @@
         "stage": "experimental",
         "codeowner": "@grafana/datapro",
         "frontend": true,
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -2754,24 +3343,28 @@
     {
       "metadata": {
         "name": "grafana.queryVarEditorRedesign",
-        "resourceVersion": "1781718345897",
-        "creationTimestamp": "2026-06-17T17:45:45Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-06-17T17:45:45Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables a redesigned query variable editor with split-pane preview and a spreadsheet for managing static options",
         "stage": "GA",
         "codeowner": "@grafana/dashboards-squad",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "true"
       }
     },
     {
       "metadata": {
         "name": "grafana.scenesFlickeringFix",
-        "resourceVersion": "1778737357419",
+        "resourceVersion": "1783954958299",
         "creationTimestamp": "2026-05-06T09:26:24Z",
         "annotations": {
-          "grafana.app/updatedTimestamp": "2026-05-14 05:42:37.419249 +0000 UTC"
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
         }
       },
       "spec": {
@@ -2779,6 +3372,7 @@
         "stage": "GA",
         "codeowner": "@grafana/dashboards-squad",
         "frontend": true,
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "true"
       }
@@ -2786,14 +3380,18 @@
     {
       "metadata": {
         "name": "grafana.secretsReferenceValueUI",
-        "resourceVersion": "1782512869856",
-        "creationTimestamp": "2026-06-26T22:27:49Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-06-26T22:27:49Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enable referencing an existing secret in an active keeper when creating a secure value",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-operator-experience-squad",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
@@ -2814,42 +3412,54 @@
     {
       "metadata": {
         "name": "grafana.starredFolders",
-        "resourceVersion": "1781683112920",
-        "creationTimestamp": "2026-06-17T07:58:32Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-06-17T07:58:32Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables starring folders and a virtual Starred folders folder in the dashboards list and folder picker",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-frontend-navigation",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "grafana.unifiedHomepage",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Replaces the bundled home dashboard with the unified homepage React page",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-frontend-navigation",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "grafana.useDefaultScopesEndpoint",
-        "resourceVersion": "1783088074749",
-        "creationTimestamp": "2026-07-03T14:14:34Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-07-03T14:14:34Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Use the find default scope endpoint to seed the initial scope selection when none is set and grafana.enableScopesFirstMode is enabled.",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-operator-experience-squad",
         "frontend": true,
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -2857,28 +3467,36 @@
     {
       "metadata": {
         "name": "grafana.vectorSearchCmdk",
-        "resourceVersion": "1782378994121",
-        "creationTimestamp": "2026-06-25T09:16:34Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-06-25T09:16:34Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables semantic (vector) dashboard search in the command palette",
         "stage": "experimental",
         "codeowner": "@grafana/search-and-storage",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "grafana.viewPanelPane",
-        "resourceVersion": "1778761195995",
-        "creationTimestamp": "2026-05-14T12:19:55Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-14T12:19:55Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables the sidebar pane with new toggles and options in panel view mode",
         "stage": "experimental",
         "codeowner": "@grafana/dashboards-squad",
         "frontend": true,
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -2886,14 +3504,18 @@
     {
       "metadata": {
         "name": "grafana.visualDesignRefresh",
-        "resourceVersion": "1781257253520",
-        "creationTimestamp": "2026-06-12T09:40:53Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-06-12T09:40:53Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables the new visual design refresh for the Grafana UI",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-frontend-platform",
         "frontend": true,
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -2901,14 +3523,18 @@
     {
       "metadata": {
         "name": "grafanaAPIServerEnsureKubectlAccess",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2023-12-06T20:21:21Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2023-12-06T20:21:21Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Start an additional https handler and write kubectl options",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-app-platform-squad",
         "requiresDevMode": true,
+        "frontendUsed": true,
         "requiresRestart": true,
         "expression": "false"
       }
@@ -2916,14 +3542,18 @@
     {
       "metadata": {
         "name": "grafanaAPIServerWithExperimentalAPIs",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2023-10-06T18:55:22Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2023-10-06T18:55:22Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Register experimental APIs with the k8s API server, including all datasources",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-app-platform-squad",
         "requiresDevMode": true,
+        "frontendUsed": true,
         "requiresRestart": true,
         "expression": "false"
       }
@@ -2931,42 +3561,54 @@
     {
       "metadata": {
         "name": "grafanaAdvisor",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-01-20T10:08:00Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-01-20T10:08:00Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables Advisor app",
         "stage": "GA",
         "codeowner": "@grafana/grafana-catalog",
+        "frontendUsed": true,
         "expression": "true"
       }
     },
     {
       "metadata": {
         "name": "grafanaAssistantInProfilesDrilldown",
-        "resourceVersion": "1779440584464",
+        "resourceVersion": "1783954958299",
         "creationTimestamp": "2025-07-31T22:56:50Z",
-        "deletionTimestamp": "2025-08-01T11:30:17Z"
+        "deletionTimestamp": "2025-08-01T11:30:17Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables integration with Grafana Assistant in Profiles Drilldown",
         "stage": "GA",
         "codeowner": "@grafana/observability-traces-and-profiling",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "true"
       }
     },
     {
       "metadata": {
         "name": "grafanaManagedRecordingRules",
-        "resourceVersion": "1779440584464",
+        "resourceVersion": "1783954958299",
         "creationTimestamp": "2024-04-22T17:53:16Z",
-        "deletionTimestamp": "2025-05-19T10:15:49Z"
+        "deletionTimestamp": "2025-05-19T10:15:49Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables Grafana-managed recording rules.",
         "stage": "experimental",
         "codeowner": "@grafana/alerting-squad",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -2990,27 +3632,35 @@
     {
       "metadata": {
         "name": "graphiteBackendMode",
-        "resourceVersion": "1779440584464",
+        "resourceVersion": "1783954958299",
         "creationTimestamp": "2025-07-31T22:56:50Z",
-        "deletionTimestamp": "2025-08-01T11:30:17Z"
+        "deletionTimestamp": "2025-08-01T11:30:17Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables the Graphite data source full backend mode",
         "stage": "privatePreview",
         "codeowner": "@grafana/data-sources-plugins",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "groupAttributeSync",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2024-09-09T15:29:43Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2024-09-09T15:29:43Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enable the groupsync extension for managing Group Attribute Sync feature",
         "stage": "privatePreview",
         "codeowner": "@grafana/identity-access-team",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -3018,13 +3668,17 @@
     {
       "metadata": {
         "name": "groupByVariable",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2024-02-14T17:18:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2024-02-14T17:18:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enable groupBy variable support in scenes dashboards",
         "stage": "experimental",
         "codeowner": "@grafana/dashboards-squad",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -3049,14 +3703,18 @@
     {
       "metadata": {
         "name": "heatmapNegativeLogBuckets",
-        "resourceVersion": "1780479590437",
-        "creationTimestamp": "2026-06-03T09:39:50Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-06-03T09:39:50Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Render native histogram (exponential and NHCB) zero and negative heatmap buckets on a symlog y-axis",
         "stage": "experimental",
         "codeowner": "@grafana/dataviz-squad",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
@@ -3098,52 +3756,68 @@
     {
       "metadata": {
         "name": "improvedExternalSessionHandling",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2024-09-17T10:54:39Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2024-09-17T10:54:39Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables improved support for OAuth external sessions. After enabling this feature, users might need to re-authenticate themselves.",
         "stage": "GA",
         "codeowner": "@grafana/identity-access-team",
+        "frontendUsed": true,
         "expression": "true"
       }
     },
     {
       "metadata": {
         "name": "improvedExternalSessionHandlingSAML",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-01-09T17:02:49Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-01-09T17:02:49Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables improved support for SAML external sessions. Ensure the NameID format is correctly configured in Grafana for SAML Single Logout to function properly.",
         "stage": "GA",
         "codeowner": "@grafana/identity-access-team",
+        "frontendUsed": true,
         "expression": "true"
       }
     },
     {
       "metadata": {
         "name": "infinityRunQueriesInParallel",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-03-14T12:54:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-03-14T12:54:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables running Infinity queries in parallel",
         "stage": "privatePreview",
         "codeowner": "@grafana/data-sources-plugins",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "influxDBConfigValidation",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables validation on the InfluxDB data source configuration page",
         "stage": "experimental",
         "codeowner": "@grafana/data-sources-plugins",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -3166,79 +3840,103 @@
     {
       "metadata": {
         "name": "influxdbRunQueriesInParallel",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2024-02-01T10:58:24Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2024-02-01T10:58:24Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables running InfluxDB Influxql queries in parallel",
         "stage": "privatePreview",
         "codeowner": "@grafana/data-sources-plugins",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "influxqlStreamingParser",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2023-11-29T17:29:35Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2023-11-29T17:29:35Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enable streaming JSON parser for InfluxDB datasource InfluxQL query language",
         "stage": "experimental",
         "codeowner": "@grafana/data-sources-plugins",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "inlineLogDetailsNoScrolls",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables an inline version of Log Details that creates no new scrolls",
         "stage": "experimental",
         "codeowner": "@grafana/observability-logs",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "interactiveLearning",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-10-22T08:06:21Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-10-22T08:06:21Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables the interactive learning app",
         "stage": "preview",
         "codeowner": "@grafana/pathfinder",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "jaegerEnableGrpcEndpoint",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-10-31T18:19:16Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-10-31T18:19:16Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enable querying trace data through Jaeger's gRPC endpoint (HTTP)",
         "stage": "experimental",
         "codeowner": "@grafana/data-sources-plugins",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "jitterAlertRulesWithinGroups",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2024-01-18T18:48:11Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2024-01-18T18:48:11Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Distributes alert rule evaluations more evenly over time, including spreading out rules within the same group. Disables sequential evaluation if enabled.",
         "stage": "preview",
         "codeowner": "@grafana/alerting-squad",
+        "frontendUsed": true,
         "requiresRestart": true,
         "hideFromDocs": true,
         "expression": "false"
@@ -3247,13 +3945,17 @@
     {
       "metadata": {
         "name": "kubernetesAggregator",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2024-02-12T20:59:35Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2024-02-12T20:59:35Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enable grafana's embedded kube-aggregator",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-app-platform-squad",
+        "frontendUsed": true,
         "requiresRestart": true,
         "expression": "false"
       }
@@ -3261,13 +3963,17 @@
     {
       "metadata": {
         "name": "kubernetesAggregatorCapTokenAuth",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-05-15T18:14:23Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-05-15T18:14:23Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enable CAP token based authentication in grafana's embedded kube-aggregator",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-app-platform-squad",
+        "frontendUsed": true,
         "requiresRestart": true,
         "expression": "false"
       }
@@ -3275,13 +3981,17 @@
     {
       "metadata": {
         "name": "kubernetesAlertingHistorian",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-11-27T16:14:16Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-11-27T16:14:16Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Adds support for Kubernetes alerting historian APIs",
         "stage": "experimental",
         "codeowner": "@grafana/alerting-squad",
+        "frontendUsed": true,
         "requiresRestart": true,
         "expression": "false"
       }
@@ -3289,13 +3999,17 @@
     {
       "metadata": {
         "name": "kubernetesAuthZResourcePermissionsRedirect",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Redirects the traffic from the legacy resource permissions endpoints to the new K8s AuthZ endpoints",
         "stage": "experimental",
         "codeowner": "@grafana/identity-access-team",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -3303,13 +4017,17 @@
     {
       "metadata": {
         "name": "kubernetesAuthzDatasourceResourcePermissions",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables datasource resource permissions via the K8s IAM resource permission APIs",
         "stage": "experimental",
         "codeowner": "@grafana/identity-access-team",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -3317,13 +4035,17 @@
     {
       "metadata": {
         "name": "kubernetesAuthzGlobalRolesApi",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-01-15T08:13:46Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-01-15T08:13:46Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Registers AuthZ Global Roles /apis endpoint",
         "stage": "experimental",
         "codeowner": "@grafana/identity-access-team",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -3331,14 +4053,18 @@
     {
       "metadata": {
         "name": "kubernetesAuthzResourcePermissionApis",
-        "resourceVersion": "1779440584464",
+        "resourceVersion": "1783954958299",
         "creationTimestamp": "2025-07-31T22:56:50Z",
-        "deletionTimestamp": "2025-08-01T11:30:17Z"
+        "deletionTimestamp": "2025-08-01T11:30:17Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Registers AuthZ resource permission /apis endpoints",
         "stage": "experimental",
         "codeowner": "@grafana/identity-access-team",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -3346,13 +4072,17 @@
     {
       "metadata": {
         "name": "kubernetesAuthzRoleBindingsApi",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-01-12T08:00:51Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-01-12T08:00:51Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Registers AuthZ Role Bindings /apis endpoint",
         "stage": "experimental",
         "codeowner": "@grafana/identity-access-team",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -3360,13 +4090,17 @@
     {
       "metadata": {
         "name": "kubernetesAuthzRolesAndRoleBindingsRedirect",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Redirects the traffic from the legacy roles and role bindings endpoints to the new K8s AuthZ endpoints",
         "stage": "experimental",
         "codeowner": "@grafana/identity-access-team",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -3374,13 +4108,17 @@
     {
       "metadata": {
         "name": "kubernetesAuthzRolesApi",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-01-12T08:00:51Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-01-12T08:00:51Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Registers AuthZ Roles /apis endpoint",
         "stage": "experimental",
         "codeowner": "@grafana/identity-access-team",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -3388,13 +4126,17 @@
     {
       "metadata": {
         "name": "kubernetesAuthzServiceAccountResourcePermissions",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables service account resource permissions via the K8s IAM resource permission APIs",
         "stage": "experimental",
         "codeowner": "@grafana/identity-access-team",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -3402,13 +4144,17 @@
     {
       "metadata": {
         "name": "kubernetesAuthzTeamLBACRuleApi",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Registers AuthZ TeamLBACRule /apis endpoint",
         "stage": "experimental",
         "codeowner": "@grafana/identity-access-team",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -3416,13 +4162,17 @@
     {
       "metadata": {
         "name": "kubernetesAuthzZanzanaSync",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-10-13T19:37:13Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-10-13T19:37:13Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enable sync of Zanzana authorization store on AuthZ CRD mutations",
         "stage": "experimental",
         "codeowner": "@grafana/identity-access-team",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -3430,14 +4180,18 @@
     {
       "metadata": {
         "name": "kubernetesCorrelations",
-        "resourceVersion": "1779440584464",
+        "resourceVersion": "1783954958299",
         "creationTimestamp": "2025-08-29T14:46:39Z",
-        "deletionTimestamp": "2025-09-01T09:33:33Z"
+        "deletionTimestamp": "2025-09-01T09:33:33Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Adds support for Kubernetes correlations",
         "stage": "experimental",
         "codeowner": "@grafana/datapro",
+        "frontendUsed": true,
         "requiresRestart": true,
         "expression": "false"
       }
@@ -3445,13 +4199,17 @@
     {
       "metadata": {
         "name": "kubernetesExternalGroupMappingsApi",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables external group mapping APIs in the app platform",
         "stage": "experimental",
         "codeowner": "@grafana/identity-access-team",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -3459,13 +4217,17 @@
     {
       "metadata": {
         "name": "kubernetesExternalGroupMappingsRedirect",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Redirects the request of the external group mapping endpoints to the app platform APIs",
         "stage": "experimental",
         "codeowner": "@grafana/identity-access-team",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -3487,13 +4249,17 @@
     {
       "metadata": {
         "name": "kubernetesLibraryPanels",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-06-25T22:21:56Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-06-25T22:21:56Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Routes library panel requests from /api to the /apis endpoint",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-app-platform-squad",
+        "frontendUsed": true,
         "requiresRestart": true,
         "expression": "false"
       }
@@ -3501,13 +4267,17 @@
     {
       "metadata": {
         "name": "kubernetesLogsDrilldown",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-10-16T21:31:42Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-10-16T21:31:42Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Adds support for Kubernetes logs drilldown",
         "stage": "experimental",
         "codeowner": "@grafana/observability-logs",
+        "frontendUsed": true,
         "requiresRestart": true,
         "expression": "false"
       }
@@ -3515,13 +4285,17 @@
     {
       "metadata": {
         "name": "kubernetesQueryCaching",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-10-20T16:11:25Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-10-20T16:11:25Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Adds support for Kubernetes querycaching",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-operator-experience-squad",
+        "frontendUsed": true,
         "requiresRestart": true,
         "expression": "false"
       }
@@ -3546,13 +4320,17 @@
     {
       "metadata": {
         "name": "kubernetesServiceAccountTokensApi",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables service account token APIs in the app platform",
         "stage": "experimental",
         "codeowner": "@grafana/identity-access-team",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -3560,13 +4338,17 @@
     {
       "metadata": {
         "name": "kubernetesServiceAccountsApi",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables service account APIs in the app platform",
         "stage": "experimental",
         "codeowner": "@grafana/identity-access-team",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -3589,13 +4371,17 @@
     {
       "metadata": {
         "name": "kubernetesSnapshots",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2023-12-05T22:31:49Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2023-12-05T22:31:49Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Routes snapshot requests from /api to the /apis endpoint",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-app-platform-squad",
+        "frontendUsed": true,
         "requiresRestart": true,
         "expression": "false"
       }
@@ -3603,13 +4389,17 @@
     {
       "metadata": {
         "name": "kubernetesSsoSettingsApi",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables SSO settings APIs in the app platform",
         "stage": "experimental",
         "codeowner": "@grafana/identity-access-team",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -3617,13 +4407,17 @@
     {
       "metadata": {
         "name": "kubernetesTeamSync",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Use the new APIs for syncing users to teams",
         "stage": "experimental",
         "codeowner": "@grafana/identity-access-team",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -3631,13 +4425,17 @@
     {
       "metadata": {
         "name": "kubernetesTeamsApi",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables team APIs in the app platform",
         "stage": "experimental",
         "codeowner": "@grafana/identity-access-team",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -3645,13 +4443,17 @@
     {
       "metadata": {
         "name": "kubernetesTeamsRedirect",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Redirects the request of the team endpoints to the app platform APIs",
         "stage": "experimental",
         "codeowner": "@grafana/identity-access-team",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -3659,13 +4461,17 @@
     {
       "metadata": {
         "name": "kubernetesUsersApi",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables user APIs in the app platform",
         "stage": "experimental",
         "codeowner": "@grafana/identity-access-team",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -3673,13 +4479,17 @@
     {
       "metadata": {
         "name": "kubernetesUsersRedirect",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Redirects the requests of the user service to the app platform APIs",
         "stage": "experimental",
         "codeowner": "@grafana/identity-access-team",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -3718,13 +4528,17 @@
     {
       "metadata": {
         "name": "logQLScope",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2024-11-11T11:53:24Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2024-11-11T11:53:24Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "In-development feature that will allow injection of labels into loki queries.",
         "stage": "privatePreview",
         "codeowner": "@grafana/data-sources-plugins",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -3732,10 +4546,10 @@
     {
       "metadata": {
         "name": "logsTablePanelNG",
-        "resourceVersion": "1782158134143",
+        "resourceVersion": "1783954958299",
         "creationTimestamp": "2026-05-22T09:03:04Z",
         "annotations": {
-          "grafana.app/updatedTimestamp": "2026-06-22 19:55:34.143374 +0000 UTC"
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
         }
       },
       "spec": {
@@ -3743,6 +4557,7 @@
         "stage": "experimental",
         "codeowner": "@grafana/observability-logs",
         "frontend": true,
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -3750,120 +4565,156 @@
     {
       "metadata": {
         "name": "lokiAlignedQuerySplitting",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Aligns query splitting chunks with UTC midnight",
         "stage": "experimental",
         "codeowner": "@grafana/observability-logs",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "lokiExperimentalStreaming",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2023-06-19T10:03:51Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2023-06-19T10:03:51Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Support new streaming approach for loki (prototype, needs special loki build)",
         "stage": "experimental",
         "codeowner": "@grafana/data-sources-plugins",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "lokiLabelNamesQueryApi",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2024-12-13T14:31:41Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2024-12-13T14:31:41Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Defaults to using the Loki `/labels` API instead of `/series`",
         "stage": "GA",
         "codeowner": "@grafana/data-sources-plugins",
+        "frontendUsed": true,
         "expression": "true"
       }
     },
     {
       "metadata": {
         "name": "lokiLogsDataplane",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2023-07-13T07:58:00Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2023-07-13T07:58:00Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Changes logs responses from Loki to be compliant with the dataplane specification.",
         "stage": "experimental",
         "codeowner": "@grafana/data-sources-plugins",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "lokiQueryLimitsContext",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-11-21T13:19:55Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-11-21T13:19:55Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Send X-Loki-Query-Limits-Context header to Loki on first split request",
         "stage": "experimental",
         "codeowner": "@grafana/observability-logs",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "lokiQuerySplitting",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2023-02-09T17:27:02Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2023-02-09T17:27:02Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Split large interval queries into subqueries with smaller time intervals",
         "stage": "GA",
         "codeowner": "@grafana/observability-logs",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "true"
       }
     },
     {
       "metadata": {
         "name": "lokiRunQueriesInParallel",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2023-09-19T09:34:01Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2023-09-19T09:34:01Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables running Loki queries in parallel",
         "stage": "privatePreview",
         "codeowner": "@grafana/data-sources-plugins",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "lokiShardSplitting",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2024-10-23T11:21:03Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2024-10-23T11:21:03Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Use stream shards to split queries into smaller subqueries",
         "stage": "experimental",
         "codeowner": "@grafana/observability-logs",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "managedPluginsV2",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables managed plugins v2 (expanded rollout, community plugin coverage)",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-catalog",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -3871,27 +4722,35 @@
     {
       "metadata": {
         "name": "metricsFromProfiles",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-04-09T10:55:28Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-04-09T10:55:28Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables creating metrics from profiles and storing them as recording rules",
         "stage": "privatePreview",
         "codeowner": "@grafana/observability-traces-and-profiling",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "mlExpressions",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2023-07-13T17:37:50Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2023-07-13T17:37:50Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enable support for Machine Learning in server-side expressions",
         "stage": "experimental",
         "codeowner": "@grafana/alerting-squad",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
@@ -3916,13 +4775,17 @@
     {
       "metadata": {
         "name": "multiTenantTempCredentials",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-04-02T20:25:50Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-04-02T20:25:50Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "use multi-tenant path for awsTempCredentials",
         "stage": "experimental",
         "codeowner": "@grafana/data-sources-plugins",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -3945,27 +4808,35 @@
     {
       "metadata": {
         "name": "newClickhouseConfigPageDesign",
-        "resourceVersion": "1779440584464",
+        "resourceVersion": "1783954958299",
         "creationTimestamp": "2025-07-31T22:56:50Z",
-        "deletionTimestamp": "2025-08-01T11:30:17Z"
+        "deletionTimestamp": "2025-08-01T11:30:17Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables new design for the Clickhouse data source configuration page",
         "stage": "GA",
         "codeowner": "@grafana/data-sources-plugins",
+        "frontendUsed": true,
         "expression": "true"
       }
     },
     {
       "metadata": {
         "name": "newDashboardWithFiltersAndGroupBy",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2024-04-04T11:25:21Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2024-04-04T11:25:21Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables filters and group by variables on all new dashboards. Variables are added only if default data source supports filtering.",
         "stage": "experimental",
         "codeowner": "@grafana/dashboards-squad",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -3973,13 +4844,17 @@
     {
       "metadata": {
         "name": "newInfluxDSConfigPageDesign",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-06-25T16:39:54Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-06-25T16:39:54Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables new design for the InfluxDB data source configuration page",
         "stage": "privatePreview",
         "codeowner": "@grafana/data-sources-plugins",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
@@ -4019,27 +4894,35 @@
     {
       "metadata": {
         "name": "newSavedQueriesExperience",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables the new Saved queries (query library) modal experience",
         "stage": "preview",
         "codeowner": "@grafana/sharing-squad",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "newShareReportDrawer",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-02-17T19:05:46Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-02-17T19:05:46Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables the report creation drawer in a dashboard",
         "stage": "preview",
         "codeowner": "@grafana/grafana-operator-experience-squad",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -4062,13 +4945,17 @@
     {
       "metadata": {
         "name": "oauthRequireSubClaim",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2024-03-25T13:22:24Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2024-03-25T13:22:24Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Require that sub claims is present in oauth tokens.",
         "stage": "experimental",
         "codeowner": "@grafana/identity-access-team",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -4076,13 +4963,17 @@
     {
       "metadata": {
         "name": "onlyStoreActionSets",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-10-20T15:02:56Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-10-20T15:02:56Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "When storing dashboard and folder resource permissions, only store action sets and not the full list of underlying permission",
         "stage": "GA",
         "codeowner": "@grafana/identity-access-team",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "true"
       }
@@ -4119,14 +5010,18 @@
     {
       "metadata": {
         "name": "otelLogsFormatting",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-07-16T15:42:14Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-07-16T15:42:14Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Applies OTel formatting templates to displayed logs",
         "stage": "experimental",
         "codeowner": "@grafana/observability-logs",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
@@ -4182,39 +5077,51 @@
     {
       "metadata": {
         "name": "panelTimeSettings",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-10-29T08:06:23Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-10-29T08:06:23Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables a new panel time settings drawer",
         "stage": "preview",
         "codeowner": "@grafana/dashboards-squad",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "panelTitleSearch",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2022-02-15T18:26:03Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2022-02-15T18:26:03Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Search for dashboards using panel title",
         "stage": "preview",
         "codeowner": "@grafana/search-and-storage",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "pdfTables",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2023-11-06T13:39:22Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2023-11-06T13:39:22Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables generating table data as PDF in reporting",
         "stage": "preview",
         "codeowner": "@grafana/grafana-operator-experience-squad",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
@@ -4236,54 +5143,70 @@
     {
       "metadata": {
         "name": "perPanelNonApplicableDrilldowns",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-11-21T16:03:27Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-11-21T16:03:27Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables viewing non-applicable drilldowns on a panel level",
         "stage": "experimental",
         "codeowner": "@grafana/dashboards-squad",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "pieChartGradientColorScheme",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enable gradient color scheme option for the pie chart panel",
         "stage": "experimental",
         "codeowner": "@grafana/dataviz-squad",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "playlistsRBAC",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables RBAC for playlists",
         "stage": "GA",
         "codeowner": "@grafana/sharing-squad",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "playlistsReconciler",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2024-12-20T03:09:31Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2024-12-20T03:09:31Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables experimental reconciler for playlists",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-app-platform-squad",
+        "frontendUsed": true,
         "requiresRestart": true,
         "expression": "false"
       }
@@ -4291,14 +5214,18 @@
     {
       "metadata": {
         "name": "pluginContainers",
-        "resourceVersion": "1779440584464",
+        "resourceVersion": "1783954958299",
         "creationTimestamp": "2025-07-31T22:56:50Z",
-        "deletionTimestamp": "2025-08-01T11:30:17Z"
+        "deletionTimestamp": "2025-08-01T11:30:17Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables running plugins in containers",
         "stage": "privatePreview",
         "codeowner": "@grafana/grafana-catalog",
+        "frontendUsed": true,
         "requiresRestart": true,
         "expression": "false"
       }
@@ -4306,68 +5233,88 @@
     {
       "metadata": {
         "name": "pluginInsights",
-        "resourceVersion": "1779440584464",
+        "resourceVersion": "1783954958299",
         "creationTimestamp": "2025-12-16T10:20:18Z",
-        "deletionTimestamp": "2025-12-18T17:11:33Z"
+        "deletionTimestamp": "2025-12-18T17:11:33Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Show insights for plugins in the plugin details page",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-catalog",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "pluginInstallAPISync",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-10-24T12:09:26Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-10-24T12:09:26Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enable syncing plugin installations to the installs API",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-catalog",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "pluginProxyPreserveTrailingSlash",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2024-06-05T11:36:14Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2024-06-05T11:36:14Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Preserve plugin proxy trailing slash.",
         "stage": "GA",
         "codeowner": "@grafana/grafana-catalog",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "pluginStoreServiceLoading",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-10-17T20:01:43Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-10-17T20:01:43Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Load plugins on store service startup instead of wire provider, and call RegisterFixedRoles after all plugins are loaded",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-catalog",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "plugins.initDataSourcesAsync",
-        "resourceVersion": "1779789947610",
-        "creationTimestamp": "2026-05-26T10:05:47Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-26T10:05:47Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Initializes data source instance settings asynchronously from the API instead of synchronously from boot data",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-catalog",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
@@ -4388,14 +5335,18 @@
     {
       "metadata": {
         "name": "plugins.useMTPluginSettings",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables plugins setting from new apis",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-frontend-platform",
         "frontend": true,
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -4403,14 +5354,18 @@
     {
       "metadata": {
         "name": "plugins.useMTPlugins",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables plugins decoupling from bootdata",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-catalog",
         "frontend": true,
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -4418,39 +5373,51 @@
     {
       "metadata": {
         "name": "pluginsAutoUpdate",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-04-16T11:44:39Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-04-16T11:44:39Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables auto-updating of users installed plugins",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-catalog",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "pluginsSriChecks",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2024-10-04T12:55:09Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2024-10-04T12:55:09Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables SRI checks for plugin assets",
         "stage": "GA",
         "codeowner": "@grafana/grafana-catalog",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "preferLibraryPanelTitle",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-06-17T11:21:21Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-06-17T11:21:21Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Prefer library panel title over viz panel title.",
         "stage": "privatePreview",
         "codeowner": "@grafana/dashboards-squad",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
@@ -4470,13 +5437,17 @@
     {
       "metadata": {
         "name": "preserveDashboardStateWhenNavigating",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2024-05-27T12:28:06Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2024-05-27T12:28:06Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables possibility to preserve dashboard variables and time range when navigating between dashboards",
         "stage": "experimental",
         "codeowner": "@grafana/dashboards-squad",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -4499,71 +5470,88 @@
     {
       "metadata": {
         "name": "profilesExemplars",
-        "resourceVersion": "1780997707204",
+        "resourceVersion": "1783954958299",
         "creationTimestamp": "2026-01-07T12:25:42Z",
         "annotations": {
-          "grafana.app/updatedTimestamp": "2026-06-09 09:35:07.204275 +0000 UTC"
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
         }
       },
       "spec": {
         "description": "Enables profiles exemplars support in profiles drilldown",
         "stage": "GA",
         "codeowner": "@grafana/observability-traces-and-profiling",
+        "frontendUsed": true,
         "expression": "true"
       }
     },
     {
       "metadata": {
         "name": "profilesHeatmap",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables heatmap visualization support for Pyroscope profiles",
         "stage": "experimental",
         "codeowner": "@grafana/observability-traces-and-profiling",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "prometheusAzureOverrideAudience",
-        "resourceVersion": "1779440584464",
+        "resourceVersion": "1783954958299",
         "creationTimestamp": "2022-05-30T15:43:32Z",
-        "deletionTimestamp": "2023-07-16T21:30:14Z"
+        "deletionTimestamp": "2023-07-16T21:30:14Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Deprecated. Allow override default AAD audience for Azure Prometheus endpoint. Enabled by default. This feature should no longer be used and will be removed in the future.",
         "stage": "deprecated",
         "codeowner": "@grafana/data-sources-plugins",
+        "frontendUsed": true,
         "expression": "true"
       }
     },
     {
       "metadata": {
         "name": "prometheusSpecialCharsInLabelValues",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2024-12-18T21:31:08Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2024-12-18T21:31:08Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Adds support for quotes and special characters in label values for Prometheus queries",
         "stage": "experimental",
         "codeowner": "@grafana/data-sources-plugins",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "prometheusTypeMigration",
-        "resourceVersion": "1779440584464",
+        "resourceVersion": "1783954958299",
         "creationTimestamp": "2025-07-31T22:56:50Z",
-        "deletionTimestamp": "2025-08-01T11:30:17Z"
+        "deletionTimestamp": "2025-08-01T11:30:17Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Checks for deprecated Prometheus authentication methods (SigV4 and Azure), installs the relevant data source, and migrates the Prometheus data sources",
         "stage": "deprecated",
         "codeowner": "@grafana/data-sources-plugins",
+        "frontendUsed": true,
         "requiresRestart": true,
         "expression": "true"
       }
@@ -4571,13 +5559,17 @@
     {
       "metadata": {
         "name": "provisioning",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2024-11-22T09:03:50Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2024-11-22T09:03:50Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables Git Sync and as-code provisioning for Grafana resources",
         "stage": "GA",
         "codeowner": "@grafana/grafana-app-platform-squad",
+        "frontendUsed": true,
         "requiresRestart": true,
         "expression": "true"
       }
@@ -4585,13 +5577,17 @@
     {
       "metadata": {
         "name": "provisioning.gitConventions",
-        "resourceVersion": "1780985056992",
-        "creationTimestamp": "2026-06-09T06:04:16Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-06-09T06:04:16Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enable configurable commit message, branch name, and pull request title conventions for Git Sync",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-app-platform-squad",
+        "frontendUsed": true,
         "requiresRestart": true,
         "expression": "false"
       }
@@ -4599,10 +5595,10 @@
     {
       "metadata": {
         "name": "provisioning.readmes",
-        "resourceVersion": "1781078230859",
+        "resourceVersion": "1783954958299",
         "creationTimestamp": "2026-05-22T09:03:04Z",
         "annotations": {
-          "grafana.app/updatedTimestamp": "2026-06-10 07:57:10.859008 +0000 UTC"
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
         }
       },
       "spec": {
@@ -4610,35 +5606,41 @@
         "stage": "preview",
         "codeowner": "@grafana/grafana-app-platform-squad",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "true"
       }
     },
     {
       "metadata": {
         "name": "provisioning.userAttribution",
-        "resourceVersion": "1783717809512",
+        "resourceVersion": "1783954958299",
         "creationTimestamp": "2026-07-08T13:32:58Z",
         "annotations": {
-          "grafana.app/updatedTimestamp": "2026-07-10 21:10:09.512157 +0000 UTC"
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
         }
       },
       "spec": {
         "description": "Author Git Sync commits as the acting Grafana user",
         "stage": "preview",
         "codeowner": "@grafana/grafana-app-platform-squad",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "provisioningExport",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enable export functionality for provisioned resources",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-app-platform-squad",
+        "frontendUsed": true,
         "requiresRestart": true,
         "expression": "false"
       }
@@ -4646,13 +5648,17 @@
     {
       "metadata": {
         "name": "provisioningFolderMetadata",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Allow setting folder metadata for provisioned folders",
         "stage": "GA",
         "codeowner": "@grafana/grafana-app-platform-squad",
+        "frontendUsed": true,
         "requiresRestart": true,
         "expression": "true"
       }
@@ -4675,13 +5681,17 @@
     {
       "metadata": {
         "name": "publicDashboardsEmailSharing",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2023-01-03T19:45:15Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2023-01-03T19:45:15Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables public dashboard sharing to be restricted to only allowed emails",
         "stage": "preview",
         "codeowner": "@grafana/grafana-operator-experience-squad",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -4702,10 +5712,10 @@
     {
       "metadata": {
         "name": "queryEditorNext",
-        "resourceVersion": "1781715640825",
+        "resourceVersion": "1783954958299",
         "creationTimestamp": "2026-05-22T09:03:04Z",
         "annotations": {
-          "grafana.app/updatedTimestamp": "2026-06-17 17:00:40.825547 +0000 UTC"
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
         }
       },
       "spec": {
@@ -4713,6 +5723,7 @@
         "stage": "preview",
         "codeowner": "@grafana/datapro",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
@@ -4734,23 +5745,27 @@
     {
       "metadata": {
         "name": "queryFetchConfigFromSettingsService",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables the query service to fetch the configuration from the settings service",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-datasources-core-services",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "queryHistory.localOnly",
-        "resourceVersion": "1779463558878",
+        "resourceVersion": "1783954958299",
         "creationTimestamp": "2026-05-21T19:21:07Z",
         "annotations": {
-          "grafana.app/updatedTimestamp": "2026-05-22 15:25:58.878199 +0000 UTC"
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
         }
       },
       "spec": {
@@ -4758,16 +5773,17 @@
         "stage": "experimental",
         "codeowner": "@grafana/datapro",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "queryHistory.recentQueriesUI",
-        "resourceVersion": "1779463558878",
+        "resourceVersion": "1783954958299",
         "creationTimestamp": "2026-05-21T19:21:07Z",
         "annotations": {
-          "grafana.app/updatedTimestamp": "2026-05-22 15:25:58.878199 +0000 UTC"
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
         }
       },
       "spec": {
@@ -4775,33 +5791,42 @@
         "stage": "experimental",
         "codeowner": "@grafana/datapro",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "queryLibrary",
-        "resourceVersion": "1779440584464",
+        "resourceVersion": "1783954958299",
         "creationTimestamp": "2022-10-07T18:31:45Z",
-        "deletionTimestamp": "2023-03-20T16:00:14Z"
+        "deletionTimestamp": "2023-03-20T16:00:14Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables Saved queries (query library) feature",
         "stage": "preview",
         "codeowner": "@grafana/sharing-squad",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "queryService",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2024-04-19T09:26:21Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2024-04-19T09:26:21Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Register /apis/query.grafana.app/ -- will eventually replace /api/ds/query",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-datasources-core-services",
+        "frontendUsed": true,
         "requiresRestart": true,
         "expression": "false"
       }
@@ -4809,27 +5834,35 @@
     {
       "metadata": {
         "name": "queryServiceFromUI",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2024-04-19T09:26:21Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2024-04-19T09:26:21Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Routes requests to the new query service",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-datasources-core-services",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "queryServiceRewrite",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2024-04-19T09:26:21Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2024-04-19T09:26:21Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Rewrite requests targeting /ds/query to the query service",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-datasources-core-services",
+        "frontendUsed": true,
         "requiresRestart": true,
         "expression": "false"
       }
@@ -4837,14 +5870,18 @@
     {
       "metadata": {
         "name": "queryServiceWithConnections",
-        "resourceVersion": "1779440584464",
+        "resourceVersion": "1783954958299",
         "creationTimestamp": "2025-08-28T19:28:26Z",
-        "deletionTimestamp": "2025-08-29T12:49:57Z"
+        "deletionTimestamp": "2025-08-29T12:49:57Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Adds datasource connections to the query service",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-datasources-core-services",
+        "frontendUsed": true,
         "requiresRestart": true,
         "expression": "false"
       }
@@ -4852,14 +5889,18 @@
     {
       "metadata": {
         "name": "queryWithAssistant",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables the Query with Assistant button in the query editor",
         "stage": "experimental",
         "codeowner": "@grafana/data-sources-plugins",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
@@ -4905,30 +5946,35 @@
     {
       "metadata": {
         "name": "react19",
-        "resourceVersion": "1781168092989",
+        "resourceVersion": "1783954958299",
         "creationTimestamp": "2026-05-22T09:03:04Z",
         "annotations": {
-          "grafana.app/updatedTimestamp": "2026-06-11 08:54:52.989837 +0000 UTC"
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
         }
       },
       "spec": {
         "description": "Whether to use the new React 19 runtime",
         "stage": "GA",
         "codeowner": "@grafana/grafana-frontend-platform",
+        "frontendUsed": true,
         "expression": "true"
       }
     },
     {
       "metadata": {
         "name": "recentlyViewedDashboards",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-12-10T16:28:19Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-12-10T16:28:19Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables recently viewed dashboards section in the browsing dashboard page",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-frontend-navigation",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
@@ -4949,13 +5995,17 @@
     {
       "metadata": {
         "name": "refreshTokenRequired",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-11-19T18:21:40Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-11-19T18:21:40Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Require that refresh tokens are present in oauth tokens.",
         "stage": "experimental",
         "codeowner": "@grafana/identity-access-team",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -4963,13 +6013,17 @@
     {
       "metadata": {
         "name": "reloadDashboardsOnParamsChange",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2024-10-25T12:56:54Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2024-10-25T12:56:54Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables reload of dashboards on scopes, time range and variables changes",
         "stage": "experimental",
         "codeowner": "@grafana/dashboards-squad",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -4977,13 +6031,17 @@
     {
       "metadata": {
         "name": "rememberUserOrgForSso",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Remember the last viewed organization for users using SSO",
         "stage": "GA",
         "codeowner": "@grafana/identity-access-team",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "true"
       }
@@ -5004,26 +6062,34 @@
     {
       "metadata": {
         "name": "reportRenderBinding",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables render binding support for report rendering",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-operator-experience-squad",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "reporting.anyPageReporting",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables reporting for any page in Grafana",
         "stage": "experimental",
         "codeowner": "@grafana/sharing-squad",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
@@ -5043,57 +6109,73 @@
     {
       "metadata": {
         "name": "reportingFooterSettings",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables the configurable footer settings for PDF reports",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-operator-experience-squad",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "reportingHeaderSettings",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables configuration of PDF report settings",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-operator-experience-squad",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "reportingV2Layouts",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enable v2 dashboard layout support in reports (auto-grid, tabs, rows)",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-operator-experience-squad",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "restrictedPluginApis",
-        "resourceVersion": "1779440584464",
+        "resourceVersion": "1783954958299",
         "creationTimestamp": "2025-07-31T22:56:50Z",
-        "deletionTimestamp": "2025-08-01T11:30:17Z"
+        "deletionTimestamp": "2025-08-01T11:30:17Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables sharing a list of APIs with a list of plugins",
         "stage": "GA",
         "codeowner": "@grafana/grafana-catalog",
         "frontend": true,
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "true"
       }
@@ -5101,13 +6183,17 @@
     {
       "metadata": {
         "name": "rolePickerDrawer",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2024-09-26T12:51:38Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2024-09-26T12:51:38Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables the new role picker drawer design",
         "stage": "experimental",
         "codeowner": "@grafana/identity-access-team",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
@@ -5129,42 +6215,51 @@
     {
       "metadata": {
         "name": "savedQueriesRBAC",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables Saved queries (query library) RBAC permissions",
         "stage": "preview",
         "codeowner": "@grafana/sharing-squad",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "scopeApi",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2024-11-27T07:58:25Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2024-11-27T07:58:25Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "In-development feature flag for the scope api using the app platform.",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-app-platform-squad",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "scopeFilters",
-        "resourceVersion": "1782915825637",
+        "resourceVersion": "1783954958299",
         "creationTimestamp": "2024-03-05T15:41:19Z",
         "annotations": {
-          "grafana.app/updatedTimestamp": "2026-07-01 14:23:45.637495 +0000 UTC"
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
         }
       },
       "spec": {
         "description": "Enables the use of scope filters in Grafana",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-operator-experience-squad",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -5172,13 +6267,17 @@
     {
       "metadata": {
         "name": "scopeSearchAllLevels",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-04-14T07:42:16Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-04-14T07:42:16Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enable scope search to include all levels of the scope node tree",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-operator-experience-squad",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -5186,27 +6285,35 @@
     {
       "metadata": {
         "name": "secretsKeeperUI",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enable the Secrets Keeper management UI for configuring external secret storage",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-operator-experience-squad",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "secretsManagementAppPlatformAwsKeeper",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-01-06T14:30:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-01-06T14:30:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables the creation of keepers that manage secrets stored on AWS secrets manager",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-operator-experience-squad",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -5214,14 +6321,18 @@
     {
       "metadata": {
         "name": "secretsManagementAppPlatformUI",
-        "resourceVersion": "1779440584464",
+        "resourceVersion": "1783954958299",
         "creationTimestamp": "2025-07-31T22:56:50Z",
-        "deletionTimestamp": "2025-08-01T11:30:17Z"
+        "deletionTimestamp": "2025-08-01T11:30:17Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enable the secrets management app platform UI",
         "stage": "preview",
         "codeowner": "@grafana/grafana-operator-experience-squad",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
@@ -5258,28 +6369,36 @@
     {
       "metadata": {
         "name": "smoothingTransformation",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-01-05T16:53:45Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-01-05T16:53:45Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables the ASAP smoothing transformation for time series data",
         "stage": "experimental",
         "codeowner": "@grafana/datapro",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "splashScreen",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables the splash screen modal for introducing new Grafana features on first session",
         "stage": "preview",
         "codeowner": "@grafana/grafana-frontend-platform",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
@@ -5300,67 +6419,87 @@
     {
       "metadata": {
         "name": "sqlExpressions",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2024-02-27T21:16:00Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2024-02-27T21:16:00Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables SQL Expressions, which can execute SQL queries against data source results.",
         "stage": "GA",
         "codeowner": "@grafana/grafana-datasources-core-services",
+        "frontendUsed": true,
         "expression": "true"
       }
     },
     {
       "metadata": {
         "name": "sqlExpressionsCodeMirror",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables CodeMirror editor for SQL Expressions",
         "stage": "experimental",
         "codeowner": "@grafana/datapro",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "sqlExpressionsColumnAutoComplete",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-07-23T21:49:58Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-07-23T21:49:58Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables column autocomplete for SQL Expressions",
         "stage": "experimental",
         "codeowner": "@grafana/datapro",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "sseExpressionErrorIsolation",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Isolate expression build errors to the broken expression's refID instead of failing the entire pipeline",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-datasources-core-services",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "sseGroupByDatasource",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2023-09-07T20:02:07Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2023-09-07T20:02:07Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Send query to the same datasource in a single request when using server side expressions. The `cloudWatchBatchQueries` feature toggle should be enabled if this used with CloudWatch.",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-datasources-core-services",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
@@ -5397,15 +6536,19 @@
     {
       "metadata": {
         "name": "starsFromAPIServer",
-        "resourceVersion": "1779440584464",
+        "resourceVersion": "1783954958299",
         "creationTimestamp": "2025-08-29T14:46:39Z",
-        "deletionTimestamp": "2025-09-01T09:33:33Z"
+        "deletionTimestamp": "2025-09-01T09:33:33Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "populate star status from apiserver",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-frontend-navigation",
         "frontend": true,
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -5413,27 +6556,35 @@
     {
       "metadata": {
         "name": "stateTimeline.nameAboveBars",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables option to position series names above bars in the state timeline panel",
         "stage": "experimental",
         "codeowner": "@grafana/dataviz-squad",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "streamingForwardTeamHeadersTempo",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables forwarding team headers from tempo for streaming requests with LBAC rules",
         "stage": "privatePreview",
         "codeowner": "@grafana/data-sources-plugins",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -5441,41 +6592,53 @@
     {
       "metadata": {
         "name": "suggestedDashboards",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-11-07T13:38:59Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-11-07T13:38:59Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Displays datasource provisioned and community dashboards in dashboard empty page, only when coming from datasource configuration page",
         "stage": "experimental",
         "codeowner": "@grafana/sharing-squad",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "suggestedDashboardsAssistantButton",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables the 'Customize with Assistant' button on suggested dashboard cards",
         "stage": "experimental",
         "codeowner": "@grafana/sharing-squad",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "table.protoRowParser",
-        "resourceVersion": "1782139478281",
-        "creationTimestamp": "2026-06-22T14:44:38Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-06-22T14:44:38Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables a new internal parser for table panel which doesn't rely on constructing a dynamic function and works in more browser environments.",
         "stage": "experimental",
         "codeowner": "@grafana/dataviz-squad",
         "frontend": true,
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -5483,14 +6646,18 @@
     {
       "metadata": {
         "name": "table.refactorNested",
-        "resourceVersion": "1782413661913",
-        "creationTimestamp": "2026-06-25T18:54:21Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-06-25T18:54:21Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables the refactored TableNG nested-table implementation",
         "stage": "experimental",
         "codeowner": "@grafana/dataviz-squad",
         "frontend": true,
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -5498,14 +6665,18 @@
     {
       "metadata": {
         "name": "tableSharedCrosshair",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2023-12-13T09:33:14Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2023-12-13T09:33:14Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables shared crosshair in table panel",
         "stage": "experimental",
         "codeowner": "@grafana/dataviz-squad",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
@@ -5529,148 +6700,192 @@
     {
       "metadata": {
         "name": "teamHttpHeadersFromAppPlatform",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Use the Kubernetes TeamLBACRule API for team HTTP headers on datasource query requests",
         "stage": "experimental",
         "codeowner": "@grafana/identity-access-team",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "teamHttpHeadersTempo",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-05-22T19:13:31Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-05-22T19:13:31Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables LBAC for datasources for Tempo to apply LBAC filtering of traces to the client requests for users in teams",
         "stage": "experimental",
         "codeowner": "@grafana/identity-access-team",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "teamLBACApiReadFromAppPlatform",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Use the Kubernetes TeamLBACRule API for reading team LBAC rules in the legacy API server",
         "stage": "experimental",
         "codeowner": "@grafana/identity-access-team",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "teamLBACApiWriteFromAppPlatform",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Use the Kubernetes TeamLBACRule API for writing team LBAC rules in the legacy API server",
         "stage": "experimental",
         "codeowner": "@grafana/identity-access-team",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "tempoAlerting",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-07-15T13:36:36Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-07-15T13:36:36Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables creating alerts from Tempo data source",
         "stage": "experimental",
         "codeowner": "@grafana/data-sources-plugins",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "timeComparison",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-07-24T20:07:28Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-07-24T20:07:28Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables time comparison option in supported panels",
         "stage": "preview",
         "codeowner": "@grafana/dataviz-squad",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "timeRangeProvider",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2024-10-22T10:52:33Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2024-10-22T10:52:33Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables time pickers sync",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-frontend-platform",
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "tracesDrilldownTimeSeeker",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables the time seeker in traces drilldown",
         "stage": "experimental",
         "codeowner": "@grafana/observability-traces-and-profiling",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "transformationsEmptyPlaceholder",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-11-17T13:57:05Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-11-17T13:57:05Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Show transformation quick-start cards in empty transformations state",
         "stage": "preview",
         "codeowner": "@grafana/datapro",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "ttlPluginInstanceManager",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-11-18T11:17:23Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-11-18T11:17:23Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enable TTL plugin instance manager",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-catalog",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "unifiedNavbars",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-04-09T12:51:22Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-04-09T12:51:22Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables unified navbars",
         "stage": "GA",
         "codeowner": "@grafana/grafana-catalog",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
@@ -5692,15 +6907,19 @@
     {
       "metadata": {
         "name": "useKubernetesShortURLsAPI",
-        "resourceVersion": "1779440584464",
+        "resourceVersion": "1783954958299",
         "creationTimestamp": "2025-08-29T14:46:39Z",
-        "deletionTimestamp": "2025-09-01T09:33:33Z"
+        "deletionTimestamp": "2025-09-01T09:33:33Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Routes short URL requests from /api to the /apis endpoint in the frontend. Depends on kubernetesShortURLs",
         "stage": "GA",
         "codeowner": "@grafana/sharing-squad",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "true"
       }
     },
@@ -5723,14 +6942,18 @@
     {
       "metadata": {
         "name": "useNewAPIsForDatasourceCRUD",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Use the new datasource API groups for datasource CRUD requests",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-datasources-core-services",
         "frontend": true,
+        "frontendUsed": true,
         "requiresRestart": true,
         "expression": "false"
       }
@@ -5754,14 +6977,18 @@
     {
       "metadata": {
         "name": "useScopesNavigationEndpoint",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-03-31T15:20:00Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-03-31T15:20:00Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Use the scopes navigation endpoint instead of the dashboardbindings endpoint",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-operator-experience-squad",
         "frontend": true,
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -5769,28 +6996,36 @@
     {
       "metadata": {
         "name": "useSessionStorageForRedirection",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2024-09-23T09:31:23Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2024-09-23T09:31:23Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Use session storage for handling the redirection after login",
         "stage": "GA",
         "codeowner": "@grafana/identity-access-team",
+        "frontendUsed": true,
         "expression": "true"
       }
     },
     {
       "metadata": {
         "name": "vizActionsAuth",
-        "resourceVersion": "1779440584464",
+        "resourceVersion": "1783954958299",
         "creationTimestamp": "2025-07-31T22:56:50Z",
-        "deletionTimestamp": "2025-08-01T11:30:17Z"
+        "deletionTimestamp": "2025-08-01T11:30:17Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Allows authenticated API calls in actions",
         "stage": "preview",
         "codeowner": "@grafana/dataviz-squad",
         "frontend": true,
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -5834,27 +7069,35 @@
     {
       "metadata": {
         "name": "yAxisTickControl",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables fine-grained Y-axis tick options beyond the auto-ticks",
         "stage": "experimental",
         "codeowner": "@grafana/dataviz-squad",
         "frontend": true,
+        "frontendUsed": true,
         "expression": "false"
       }
     },
     {
       "metadata": {
         "name": "zanzana",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2024-06-19T13:59:47Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2024-06-19T13:59:47Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Use openFGA as authorization engine.",
         "stage": "experimental",
         "codeowner": "@grafana/identity-access-team",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -5862,13 +7105,17 @@
     {
       "metadata": {
         "name": "zanzanaMergeUserPermissions",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Merge Zanzana permissions into legacy RBAC for access-control API endpoints.",
         "stage": "experimental",
         "codeowner": "@grafana/identity-access-team",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }
@@ -5876,13 +7123,17 @@
     {
       "metadata": {
         "name": "zanzanaNoLegacyClient",
-        "resourceVersion": "1779440584464",
-        "creationTimestamp": "2025-10-21T14:03:17Z"
+        "resourceVersion": "1783954958299",
+        "creationTimestamp": "2025-10-21T14:03:17Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-13 15:02:38.299818 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Use openFGA as main authorization engine and disable legacy RBAC clietn.",
         "stage": "experimental",
         "codeowner": "@grafana/identity-access-team",
+        "frontendUsed": true,
         "hideFromDocs": true,
         "expression": "false"
       }

--- a/pkg/services/featuremgmt/toggles_gen_test.go
+++ b/pkg/services/featuremgmt/toggles_gen_test.go
@@ -78,6 +78,24 @@ func TestFeatureToggleFiles(t *testing.T) {
 	})
 }
 
+func TestFrontendUsedField(t *testing.T) {
+	dual := 0
+	for _, flag := range standardFeatureFlags {
+		frontendUsed := flag.Generate.React || flag.Generate.LegacyFrontend
+		frontendOnly := !flag.Generate.Go && !flag.Generate.LegacyGo
+		if frontendOnly {
+			require.True(t, frontendUsed,
+				"flag %q is FrontendOnly but not frontendUsed", flag.Name)
+		}
+		if frontendUsed && !frontendOnly {
+			dual++
+		}
+	}
+	require.Positive(t, dual,
+		"expected frontend+backend flags where frontendUsed differs from FrontendOnly; "+
+			"if this is 0 the field adds nothing over FrontendOnly")
+}
+
 func readFeatureList(t *testing.T) map[string]featuretoggleapi.Feature {
 	created := v1.NewTime(time.Now().UTC())
 	resourceVersion := fmt.Sprintf("%d", created.UnixMilli())
@@ -104,6 +122,7 @@ func readFeatureList(t *testing.T) map[string]featuretoggleapi.Feature {
 			Owner:           string(flag.Owner),
 			RequiresDevMode: flag.RequiresDevMode,
 			FrontendOnly:    !flag.Generate.Go && !flag.Generate.LegacyGo,
+			FrontendUsed:    flag.Generate.React || flag.Generate.LegacyFrontend,
 			RequiresRestart: flag.RequiresRestart,
 			HideFromDocs:    flag.HideFromDocs,
 			Expression:      flag.Expression,
@@ -408,6 +427,7 @@ func generateCSV(lookup map[string]featuretoggleapi.Feature) string {
 		"requiresDevMode", //strconv.FormatBool(flag.RequiresDevMode),
 		"RequiresRestart", //strconv.FormatBool(flag.RequiresRestart),
 		"FrontendOnly",    //strconv.FormatBool(flag.FrontendOnly),
+		"FrontendUsed",    //strconv.FormatBool(flag.Generate.React || flag.Generate.LegacyFrontend),
 	})
 
 	for _, flag := range standardFeatureFlags {


### PR DESCRIPTION
 We need a way to tell which feature flags are used by the frontend, so we can annotate the the matching GOFF flags with that metadata https://github.com/grafana/grafana-org/issues/931. 
It's needed for OFREP bulk-eval filtering - flags not  marked as frontend-used will eventually stop reaching the browser.                                    
                                                                                                      
We can't rely on the current `FrontendOnly` field (`!Go && !LegacyGo`) as it misses flags used by both frontend and backend. So this PR adds a new `frontendUsed` attribute, derived as `React || LegacyFrontend`.
                                                                                                      
_The large `toggles_gen.json` diff is just regeneration (new field and `resourceVersion` bump)._             