### PR TITLE
fix: settle watch events for nats notifier

### DIFF
--- a/pkg/storage/unified/resource/notifier.go
+++ b/pkg/storage/unified/resource/notifier.go
@@ -123,48 +123,55 @@ func (cn *channelNotifier) Watch(ctx context.Context, opts WatchOptions) <-chan 
 		cn.mu.Unlock()
 	})
 
-	go func() {
-		defer close(out)
-		var buffer []Event
+	go settleEvents(ctx, raw, out, opts)
 
-		ticker := time.NewTicker(time.Second)
-		defer ticker.Stop()
+	return out
+}
 
-		for {
-			// Wait for an event or a tick
+// settleEvents pumps raw to out, buffering events for opts.SettleDelay so late
+// or out-of-order arrivals are reordered: on each tick the buffer is sorted and
+// events settled past now-SettleDelay are emitted in ascending RV order. This
+// keeps downstream RVs monotonic, avoiding stale caches and 410 relist storms.
+// Closes out and returns when ctx is canceled or raw is closed.
+func settleEvents(ctx context.Context, raw <-chan Event, out chan<- Event, opts WatchOptions) {
+	defer close(out)
+	var buffer []Event
+
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	for {
+		// Wait for an event or a tick
+		select {
+		case evt, ok := <-raw:
+			if !ok {
+				return // channel closed, context canceled
+			}
+			buffer = append(buffer, evt)
+			continue
+		case <-ticker.C:
+		case <-ctx.Done():
+			return
+		}
+
+		// Sort buffer by RV
+		slices.SortFunc(buffer, func(a, b Event) int {
+			return cmp.Compare(a.ResourceVersion, b.ResourceVersion)
+		})
+
+		// Emit events that have "settled" (old enough that concurrent writes should have appeared).
+		threshold := snowflakeFromTime(time.Now().Add(-opts.SettleDelay))
+		emitted := 0
+		for emitted < len(buffer) && buffer[emitted].ResourceVersion <= threshold {
 			select {
-			case evt, ok := <-raw:
-				if !ok {
-					return // channel closed, context canceled
-				}
-				buffer = append(buffer, evt)
-				continue
-			case <-ticker.C:
+			case out <- buffer[emitted]:
 			case <-ctx.Done():
 				return
 			}
-
-			// Sort buffer by RV
-			slices.SortFunc(buffer, func(a, b Event) int {
-				return cmp.Compare(a.ResourceVersion, b.ResourceVersion)
-			})
-
-			// Emit events that have "settled" (old enough that concurrent writes should have appeared).
-			threshold := snowflakeFromTime(time.Now().Add(-opts.SettleDelay))
-			emitted := 0
-			for emitted < len(buffer) && buffer[emitted].ResourceVersion <= threshold {
-				select {
-				case out <- buffer[emitted]:
-				case <-ctx.Done():
-					return
-				}
-				emitted++
-			}
-			buffer = buffer[emitted:]
+			emitted++
 		}
-	}()
-
-	return out
+		buffer = buffer[emitted:]
+	}
 }
 
 func (cn *channelNotifier) Publish(event Event) {

--- a/pkg/storage/unified/resource/notifier_nats.go
+++ b/pkg/storage/unified/resource/notifier_nats.go
@@ -40,17 +40,19 @@ func watchNotificationTypeToAction(t resourcepb.WatchNotification_Type) (kv.Data
 	}
 }
 
-// natsNotifier emits an Event per WatchNotification received from NATS, learning
-// of writes the instant they are announced rather than by polling the store.
-// Watch subscribes to the entire stream (SubjectAll) and ignores the resource
-// selectors in WatchOptions, so it is not a drop-in per-watch notifier.
+// natsNotifier emits an Event per WatchNotification received from NATS rather
+// than by polling the store. Watch subscribes to the entire stream (SubjectAll)
+// and ignores the resource selectors in WatchOptions, so it is not a drop-in
+// per-watch notifier. PreviousRV is carried on the wire, matching the
+// store-sourced notifiers.
 //
-// Delivery is at-most-once (core NATS, no JetStream); a missed message is never
-// redelivered, so it is a low-latency signal, not a source of truth. When it is
-// the selected notifier there is no server-side polling backstop (newNotifier
-// returns this OR the polling notifier, never both) — recovery relies on
-// consumers relisting (k8s reflector resync, provisioning informer relist).
-// PreviousRV is carried on the wire, matching the store-sourced notifiers.
+// Delivery is at-most-once (core NATS, no JetStream): a missed message is never
+// redelivered, and there is no server-side polling backstop when this is the
+// selected notifier (newNotifier returns this OR polling, never both), so
+// recovery relies on consumers relisting (reflector resync, provisioning
+// relist). Core NATS also delivers in arrival order, not RV order, so Watch runs
+// arrivals through the same settle buffer as the channel notifier (held for
+// SettleDelay, emitted sorted by RV) to keep downstream RVs monotonic.
 type natsNotifier struct {
 	subscriber EventSubscriber
 	dropped    *prometheus.CounterVec // by reason; nil is allowed (no accounting)
@@ -121,21 +123,8 @@ func (n *natsNotifier) Watch(ctx context.Context, opts WatchOptions) <-chan Even
 		}
 	})
 
-	go func() {
-		defer close(out)
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case evt := <-raw:
-				select {
-				case out <- evt:
-				case <-ctx.Done():
-					return
-				}
-			}
-		}
-	}()
+	// raw is never closed here; settleEvents exits on ctx.Done().
+	go settleEvents(ctx, raw, out, opts)
 
 	return out
 }

--- a/pkg/storage/unified/resource/notifier_nats_test.go
+++ b/pkg/storage/unified/resource/notifier_nats_test.go
@@ -122,6 +122,35 @@ func TestNatsNotifierWatch_ConvertsNotifications(t *testing.T) {
 	}
 }
 
+func TestNatsNotifierWatch_EmitsInResourceVersionOrder(t *testing.T) {
+	sub := &fakeEventSubscriber{enabled: true}
+	n := newNatsNotifier(sub, nil, log.NewNopLogger())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	out := n.Watch(ctx, WatchOptions{})
+	require.NotNil(t, sub.handler)
+
+	// Deliver notifications for the same object out of RV order, all within one
+	// settle window. The settle buffer must reorder them so the watcher sees
+	// ascending resource versions regardless of bus arrival order.
+	for _, rv := range []int64{30, 10, 20} {
+		sub.handler("some.subject", mustMarshalNotification(t, &resourcepb.WatchNotification{
+			Type:                    resourcepb.WatchNotification_MODIFIED,
+			Group:                   "playlist.grafana.app",
+			Resource:                "playlists",
+			Namespace:               "default",
+			Name:                    "abc",
+			ResourceVersion:         rv,
+			PreviousResourceVersion: rv - 1,
+		}))
+	}
+
+	require.Equal(t, int64(10), recvEvent(t, out).ResourceVersion)
+	require.Equal(t, int64(20), recvEvent(t, out).ResourceVersion)
+	require.Equal(t, int64(30), recvEvent(t, out).ResourceVersion)
+}
+
 func TestNatsNotifierWatch_DropsUnknownType(t *testing.T) {
 	sub := &fakeEventSubscriber{enabled: true}
 	dropped := prometheus.NewCounterVec(prometheus.CounterOpts{Name: "dropped_total"}, []string{"reason"})


### PR DESCRIPTION
Reorder NATS notifier events by ResourceVersion. The NATS notifier piped watch events straight from the bus to watchers in arrival order. Core NATS gives no RV ordering, so same-object reorder produced stale informer caches, non-monotonic `lastSyncResourceVersion`, and 410 relist storms downstream.

This applies the same settle buffer the channel notifier already uses:

- Extracts the channel notifier's buffer→sort→settle-by-RV loop into a shared `settleEvents` helper (logic unchanged).
- Wires `natsNotifier.Watch` to it: arrivals are held for `SettleDelay`, sorted by RV, and emitted once settled → downstream RVs stay monotonic.

Does **not** recover dropped messages. Core NATS is still at-most-once; that gap stays covered by reflector resync. 

**Tradeoff:** NATS emission is now delayed ~`SettleDelay` (default 3s), matching the channel/polling notifiers.
