### PR TITLE
Plugins: Hide version in history for managed plugins

### DIFF
--- a/public/app/features/plugins/admin/components/VersionInstallButton.test.tsx
+++ b/public/app/features/plugins/admin/components/VersionInstallButton.test.tsx
@@ -281,6 +281,34 @@ describe('VersionInstallButton', () => {
     expect(mockInstall).toHaveBeenCalledWith('test', '2.0.0', PluginStatus.UPDATE);
   });
 
+  it('should not show the downgrade confirmation modal for a managed plugin, even for a lower version', () => {
+    // Regression test: because the button is presented as a neutral "Install" for managed plugins,
+    // clicking it must not pop the "Downgrade plugin version" confirmation — that would contradict
+    // the label. The dispatched operation is still correctly typed as a downgrade.
+    const version: Version = {
+      version: '1.0.0',
+      createdAt: '',
+      isCompatible: true,
+      grafanaDependency: null,
+    };
+    renderWithStore(
+      <VersionInstallButton
+        installedVersion="2.0.0"
+        hideInstallState
+        pluginId={'test'}
+        version={version}
+        disabled={false}
+        onConfirmInstallation={() => {}}
+      />
+    );
+
+    expect(screen.queryByText('Downgrade')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByText('Install'));
+
+    expect(screen.queryByText('Downgrade plugin version')).not.toBeInTheDocument();
+    expect(mockInstall).toHaveBeenCalledWith('test', '1.0.0', PluginStatus.DOWNGRADE);
+  });
+
   it('should show the installation button if invalid semver installed version is provided', () => {
     const version: Version = {
       version: '1.0.0',

--- a/public/app/features/plugins/admin/components/VersionInstallButton.test.tsx
+++ b/public/app/features/plugins/admin/components/VersionInstallButton.test.tsx
@@ -281,33 +281,6 @@ describe('VersionInstallButton', () => {
     expect(mockInstall).toHaveBeenCalledWith('test', '2.0.0', PluginStatus.UPDATE);
   });
 
-  it('should not show the downgrade confirmation modal for a managed plugin, even for a lower version', () => {
-    // Regression test: because the button is presented as a neutral "Install" for managed plugins,
-    // clicking it must not pop the "Downgrade plugin version" confirmation — that would contradict
-    // the label. The dispatched operation is still correctly typed as a downgrade.
-    const version: Version = {
-      version: '1.0.0',
-      createdAt: '',
-      isCompatible: true,
-      grafanaDependency: null,
-    };
-    renderWithStore(
-      <VersionInstallButton
-        installedVersion="2.0.0"
-        hideInstallState
-        pluginId={'test'}
-        version={version}
-        disabled={false}
-        onConfirmInstallation={() => {}}
-      />
-    );
-
-    expect(screen.queryByText('Downgrade')).not.toBeInTheDocument();
-    fireEvent.click(screen.getByText('Install'));
-
-    expect(screen.queryByText('Downgrade plugin version')).not.toBeInTheDocument();
-    expect(mockInstall).toHaveBeenCalledWith('test', '1.0.0', PluginStatus.DOWNGRADE);
-  });
 
   it('should show the installation button if invalid semver installed version is provided', () => {
     const version: Version = {

--- a/public/app/features/plugins/admin/components/VersionInstallButton.test.tsx
+++ b/public/app/features/plugins/admin/components/VersionInstallButton.test.tsx
@@ -5,18 +5,20 @@ import { Provider } from 'react-redux';
 import { config } from '@grafana/runtime';
 import { configureStore } from 'app/store/configureStore';
 
-import { type Version } from '../types';
+import { PluginStatus, type Version } from '../types';
 
 import { VersionInstallButton } from './VersionInstallButton';
 
+const mockInstall = jest.fn();
 jest.mock('../state/hooks', () => ({
   ...jest.requireActual('../state/hooks'),
-  useInstall: () => jest.fn(),
+  useInstall: () => mockInstall,
 }));
 
 describe('VersionInstallButton', () => {
   const originalConfig = { ...config };
   afterEach(() => {
+    mockInstall.mockClear();
     config.featureToggles = {
       ...originalConfig.featureToggles,
     };
@@ -248,6 +250,35 @@ describe('VersionInstallButton', () => {
 
     expect(screen.getByRole('button')).not.toBeDisabled();
     expect(screen.getByText('Install')).toBeInTheDocument();
+  });
+
+  it('should dispatch an update (not a fresh install) for a managed plugin upgrade', () => {
+    // Regression test: hideInstallState only neutralizes the displayed label to "Install" — the
+    // dispatched operation must still be an UPDATE so hasUpdate is cleared and the plugin info
+    // cache is invalidated, exactly as it would be for a non-managed upgrade.
+    const version: Version = {
+      version: '2.0.0',
+      createdAt: '',
+      isCompatible: true,
+      grafanaDependency: null,
+    };
+    renderWithStore(
+      <VersionInstallButton
+        installedVersion="1.0.0"
+        hideInstallState
+        pluginId={'test'}
+        version={version}
+        disabled={false}
+        onConfirmInstallation={() => {}}
+      />
+    );
+
+    // Display is a neutral "Install" (no Upgrade label) for managed plugins...
+    const button = screen.getByText('Install');
+    fireEvent.click(button);
+
+    // ...but the underlying operation is still an update.
+    expect(mockInstall).toHaveBeenCalledWith('test', '2.0.0', PluginStatus.UPDATE);
   });
 
   it('should show the installation button if invalid semver installed version is provided', () => {

--- a/public/app/features/plugins/admin/components/VersionInstallButton.test.tsx
+++ b/public/app/features/plugins/admin/components/VersionInstallButton.test.tsx
@@ -281,7 +281,6 @@ describe('VersionInstallButton', () => {
     expect(mockInstall).toHaveBeenCalledWith('test', '2.0.0', PluginStatus.UPDATE);
   });
 
-
   it('should show the installation button if invalid semver installed version is provided', () => {
     const version: Version = {
       version: '1.0.0',

--- a/public/app/features/plugins/admin/components/VersionInstallButton.test.tsx
+++ b/public/app/features/plugins/admin/components/VersionInstallButton.test.tsx
@@ -9,6 +9,11 @@ import { type Version } from '../types';
 
 import { VersionInstallButton } from './VersionInstallButton';
 
+jest.mock('../state/hooks', () => ({
+  ...jest.requireActual('../state/hooks'),
+  useInstall: () => jest.fn(),
+}));
+
 describe('VersionInstallButton', () => {
   const originalConfig = { ...config };
   afterEach(() => {
@@ -197,6 +202,51 @@ describe('VersionInstallButton', () => {
         onConfirmInstallation={() => {}}
       />
     );
+    expect(screen.getByText('Install')).toBeInTheDocument();
+  });
+
+  it('should clear the spinner once installedVersion catches up, even with hideInstallState set', () => {
+    // Regression test: hideInstallState (used for managed plugins) must only suppress the
+    // Installed/Upgrade/Downgrade labeling — it must not prevent this component from noticing
+    // that a triggered install has actually completed and clearing its own local spinner state.
+    const version: Version = {
+      version: '1.0.1',
+      createdAt: '',
+      isCompatible: false,
+      grafanaDependency: null,
+    };
+    const store = configureStore();
+
+    const { rerender } = render(
+      <Provider store={store}>
+        <VersionInstallButton
+          installedVersion={undefined}
+          hideInstallState
+          pluginId={'test'}
+          version={version}
+          disabled={false}
+          onConfirmInstallation={() => {}}
+        />
+      </Provider>
+    );
+
+    fireEvent.click(screen.getByText('Install'));
+    expect(screen.getByRole('button')).toBeDisabled();
+
+    rerender(
+      <Provider store={store}>
+        <VersionInstallButton
+          installedVersion={version.version}
+          hideInstallState
+          pluginId={'test'}
+          version={version}
+          disabled={false}
+          onConfirmInstallation={() => {}}
+        />
+      </Provider>
+    );
+
+    expect(screen.getByRole('button')).not.toBeDisabled();
     expect(screen.getByText('Install')).toBeInTheDocument();
   });
 

--- a/public/app/features/plugins/admin/components/VersionInstallButton.tsx
+++ b/public/app/features/plugins/admin/components/VersionInstallButton.tsx
@@ -21,6 +21,10 @@ interface Props {
   disabled: boolean;
   tooltip?: string;
   onConfirmInstallation: () => void;
+  // Suppresses the "Installed"/Upgrade/Downgrade labeling (used for managed plugins, where
+  // installedVersion may not be trustworthy) without affecting installedVersion itself, which
+  // this component still needs to detect when an install it triggered has actually completed.
+  hideInstallState?: boolean;
 }
 
 export const VersionInstallButton = ({
@@ -31,13 +35,14 @@ export const VersionInstallButton = ({
   disabled,
   tooltip,
   onConfirmInstallation,
+  hideInstallState,
 }: Props) => {
   const install = useInstall();
   const [isInstalling, setIsInstalling] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const styles = useStyles2(getStyles);
 
-  const installState = getInstallState(installedVersion, version.version);
+  const installState = hideInstallState ? PluginStatus.INSTALL : getInstallState(installedVersion, version.version);
 
   useEffect(() => {
     if (installedVersion === version.version) {
@@ -46,7 +51,7 @@ export const VersionInstallButton = ({
     }
   }, [installedVersion, version.version]);
 
-  if (version.version === installedVersion) {
+  if (!hideInstallState && version.version === installedVersion) {
     return (
       <Badge
         className={styles.badge}

--- a/public/app/features/plugins/admin/components/VersionInstallButton.tsx
+++ b/public/app/features/plugins/admin/components/VersionInstallButton.tsx
@@ -42,7 +42,12 @@ export const VersionInstallButton = ({
   const [isModalOpen, setIsModalOpen] = useState(false);
   const styles = useStyles2(getStyles);
 
-  const installState = hideInstallState ? PluginStatus.INSTALL : getInstallState(installedVersion, version.version);
+  // The actual operation (install vs update vs downgrade), its tracking event, cache invalidation
+  // and downgrade confirmation must reflect the real installed version — even for managed plugins.
+  const installState = getInstallState(installedVersion, version.version);
+  // Managed plugins present a neutral "Install" action instead of Upgrade/Downgrade, since their
+  // installedVersion isn't a trustworthy baseline. This only affects the label/icon, not behavior.
+  const displayInstallState = hideInstallState ? PluginStatus.INSTALL : installState;
 
   useEffect(() => {
     if (installedVersion === version.version) {
@@ -120,8 +125,8 @@ export const VersionInstallButton = ({
         tooltip={tooltip}
         tooltipPlacement="bottom-start"
       >
-        {getLabel(installState)}{' '}
-        {isInstalling ? <Spinner className={styles.spinner} inline size="sm" /> : getIcon(installState)}
+        {getLabel(displayInstallState)}{' '}
+        {isInstalling ? <Spinner className={styles.spinner} inline size="sm" /> : getIcon(displayInstallState)}
       </Button>
       <ConfirmModal
         isOpen={isModalOpen}

--- a/public/app/features/plugins/admin/components/VersionInstallButton.tsx
+++ b/public/app/features/plugins/admin/components/VersionInstallButton.tsx
@@ -42,11 +42,12 @@ export const VersionInstallButton = ({
   const [isModalOpen, setIsModalOpen] = useState(false);
   const styles = useStyles2(getStyles);
 
-  // The actual operation (install vs update vs downgrade), its tracking event, cache invalidation
-  // and downgrade confirmation must reflect the real installed version — even for managed plugins.
+  // The dispatched operation (install vs update vs downgrade), its tracking event and cache
+  // invalidation must reflect the real installed version — even for managed plugins.
   const installState = getInstallState(installedVersion, version.version);
   // Managed plugins present a neutral "Install" action instead of Upgrade/Downgrade, since their
-  // installedVersion isn't a trustworthy baseline. This only affects the label/icon, not behavior.
+  // installedVersion isn't a trustworthy baseline. This governs the presented action — the label,
+  // the icon, and whether the downgrade confirmation is shown — but never the dispatched operation.
   const displayInstallState = hideInstallState ? PluginStatus.INSTALL : installState;
 
   useEffect(() => {
@@ -92,7 +93,10 @@ export const VersionInstallButton = ({
   };
 
   const onInstallClick = () => {
-    if (installState === PluginStatus.DOWNGRADE) {
+    // Gate on displayInstallState so the confirmation matches what's shown: a button labeled
+    // "Install" (managed plugins) must not pop the downgrade confirmation modal. The dispatched
+    // operation in performInstallation still uses the real installState.
+    if (displayInstallState === PluginStatus.DOWNGRADE) {
       setIsModalOpen(true);
     } else {
       performInstallation();

--- a/public/app/features/plugins/admin/components/VersionInstallButton.tsx
+++ b/public/app/features/plugins/admin/components/VersionInstallButton.tsx
@@ -21,9 +21,7 @@ interface Props {
   disabled: boolean;
   tooltip?: string;
   onConfirmInstallation: () => void;
-  // Suppresses the "Installed"/Upgrade/Downgrade labeling (used for managed plugins, where
-  // installedVersion may not be trustworthy) without affecting installedVersion itself, which
-  // this component still needs to detect when an install it triggered has actually completed.
+  // Present a neutral "Install" action instead of Upgrade/Downgrade (used for managed plugins).
   hideInstallState?: boolean;
 }
 
@@ -42,12 +40,9 @@ export const VersionInstallButton = ({
   const [isModalOpen, setIsModalOpen] = useState(false);
   const styles = useStyles2(getStyles);
 
-  // The dispatched operation (install vs update vs downgrade), its tracking event and cache
-  // invalidation must reflect the real installed version — even for managed plugins.
+  // installState drives the dispatched operation and tracking; displayInstallState drives the
+  // button label/icon, which managed plugins neutralize to a plain "Install".
   const installState = getInstallState(installedVersion, version.version);
-  // Managed plugins present a neutral "Install" action instead of Upgrade/Downgrade, since their
-  // installedVersion isn't a trustworthy baseline. This governs the presented action — the label,
-  // the icon, and whether the downgrade confirmation is shown — but never the dispatched operation.
   const displayInstallState = hideInstallState ? PluginStatus.INSTALL : installState;
 
   useEffect(() => {
@@ -93,10 +88,7 @@ export const VersionInstallButton = ({
   };
 
   const onInstallClick = () => {
-    // Gate on displayInstallState so the confirmation matches what's shown: a button labeled
-    // "Install" (managed plugins) must not pop the downgrade confirmation modal. The dispatched
-    // operation in performInstallation still uses the real installState.
-    if (displayInstallState === PluginStatus.DOWNGRADE) {
+    if (installState === PluginStatus.DOWNGRADE) {
       setIsModalOpen(true);
     } else {
       performInstallation();

--- a/public/app/features/plugins/admin/components/VersionInstallButton.tsx
+++ b/public/app/features/plugins/admin/components/VersionInstallButton.tsx
@@ -21,7 +21,6 @@ interface Props {
   disabled: boolean;
   tooltip?: string;
   onConfirmInstallation: () => void;
-  // Present a neutral "Install" action instead of Upgrade/Downgrade (used for managed plugins).
   hideInstallState?: boolean;
 }
 
@@ -40,8 +39,6 @@ export const VersionInstallButton = ({
   const [isModalOpen, setIsModalOpen] = useState(false);
   const styles = useStyles2(getStyles);
 
-  // installState drives the dispatched operation and tracking; displayInstallState drives the
-  // button label/icon, which managed plugins neutralize to a plain "Install".
   const installState = getInstallState(installedVersion, version.version);
   const displayInstallState = hideInstallState ? PluginStatus.INSTALL : installState;
 

--- a/public/app/features/plugins/admin/components/VersionList.test.tsx
+++ b/public/app/features/plugins/admin/components/VersionList.test.tsx
@@ -259,6 +259,47 @@ describe('VersionList', () => {
     config.pluginAdminExternalManageEnabled = pluginAdminExternalManageEnabledOriginal;
   });
 
+  it('should not mark any row as installed or show upgrade/downgrade for a managed plugin', () => {
+    const versions = [
+      {
+        version: '4.19.0',
+        createdAt: '2024-01-01',
+        isCompatible: true,
+        grafanaDependency: '>=10.0.0',
+      },
+      {
+        version: '4.17.0',
+        createdAt: '2023-08-01',
+        isCompatible: true,
+        grafanaDependency: '>=9.0.0',
+      },
+    ];
+
+    // The stored installedVersion is stale/unreliable for managed plugins (e.g. remote
+    // CDN-provisioned datasources) — it should never be trusted as ground truth.
+    const installedVersion = '4.17.0';
+
+    const plugin = getCatalogPluginMock({
+      details: {
+        grafanaDependency: '>=8.0.0',
+        pluginDependencies: [],
+        links: [{ name: 'GitHub', url: 'https://example.com' }],
+        versions,
+      },
+      managed: { enabled: true, strategy: PluginUpdateStrategy.MajorAligned },
+      installedVersion,
+    });
+
+    renderWithStore(<VersionList plugin={plugin} />);
+
+    expect(screen.queryByText(/\(installed version\)/)).not.toBeInTheDocument();
+    expect(screen.queryByText('Installed')).not.toBeInTheDocument();
+    expect(screen.queryByText('Upgrade')).not.toBeInTheDocument();
+    expect(screen.queryByText('Downgrade')).not.toBeInTheDocument();
+    expect(screen.getByText('4.17.0')).toBeInTheDocument();
+    expect(screen.getByText(/^4\.19\.0/)).toBeInTheDocument();
+  });
+
   it('should disable all versions when plugin is managed and update strategy is "assigned"', () => {
     const versions = [
       ...generateVersionsForMajor('1', 3),

--- a/public/app/features/plugins/admin/components/VersionList.test.tsx
+++ b/public/app/features/plugins/admin/components/VersionList.test.tsx
@@ -1,5 +1,5 @@
 import { OpenFeatureTestProvider } from '@openfeature/react-sdk';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import type { JSX } from 'react';
 import { Provider } from 'react-redux';
 
@@ -10,6 +10,12 @@ import { getCatalogPluginMock } from '../mocks/mockHelpers';
 import { PluginUpdateStrategy } from '../types';
 
 import { VersionList } from './VersionList';
+
+const mockInstall = jest.fn();
+jest.mock('../state/hooks', () => ({
+  ...jest.requireActual('../state/hooks'),
+  useInstall: () => mockInstall,
+}));
 
 describe('VersionList', () => {
   it('should only show installs when no version is installed', () => {
@@ -298,6 +304,40 @@ describe('VersionList', () => {
     expect(screen.queryByText('Downgrade')).not.toBeInTheDocument();
     expect(screen.getByText('4.17.0')).toBeInTheDocument();
     expect(screen.getByText(/^4\.19\.0/)).toBeInTheDocument();
+  });
+
+  it('should not open the downgrade modal from a managed plugin row that is labeled "Install"', () => {
+    // Reachability check for the label/modal mismatch: with external manage disabled (the default),
+    // an older still-listed version of a managed plugin renders an *enabled* button. Since managed
+    // rows are labeled "Install" (not "Downgrade"), clicking must not pop the downgrade modal.
+    const versions = [
+      { version: '2.0.0', createdAt: '', isCompatible: true, grafanaDependency: '>=9.0.0' },
+      { version: '1.0.0', createdAt: '', isCompatible: true, grafanaDependency: '>=8.0.0' },
+    ];
+
+    const plugin = getCatalogPluginMock({
+      details: {
+        grafanaDependency: '>=8.0.0',
+        pluginDependencies: [],
+        links: [{ name: 'GitHub', url: 'https://example.com' }],
+        versions,
+      },
+      managed: { enabled: true, strategy: PluginUpdateStrategy.MajorAligned },
+      installedVersion: '2.0.0',
+    });
+
+    renderWithStore(<VersionList plugin={plugin} />);
+
+    // No row advertises a downgrade, and the older row's button is a plain enabled "Install".
+    expect(screen.queryByText('Downgrade')).not.toBeInTheDocument();
+    const installButtons = screen.getAllByText('Install');
+    const olderVersionButton = installButtons[installButtons.length - 1];
+    expect(olderVersionButton.closest('button')).toBeEnabled();
+
+    fireEvent.click(olderVersionButton);
+
+    // Clicking it must not surface the downgrade confirmation modal.
+    expect(screen.queryByText('Downgrade plugin version')).not.toBeInTheDocument();
   });
 
   it('should disable all versions when plugin is managed and update strategy is "assigned"', () => {

--- a/public/app/features/plugins/admin/components/VersionList.test.tsx
+++ b/public/app/features/plugins/admin/components/VersionList.test.tsx
@@ -1,5 +1,5 @@
 import { OpenFeatureTestProvider } from '@openfeature/react-sdk';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import type { JSX } from 'react';
 import { Provider } from 'react-redux';
 
@@ -10,12 +10,6 @@ import { getCatalogPluginMock } from '../mocks/mockHelpers';
 import { PluginUpdateStrategy } from '../types';
 
 import { VersionList } from './VersionList';
-
-const mockInstall = jest.fn();
-jest.mock('../state/hooks', () => ({
-  ...jest.requireActual('../state/hooks'),
-  useInstall: () => mockInstall,
-}));
 
 describe('VersionList', () => {
   it('should only show installs when no version is installed', () => {
@@ -304,40 +298,6 @@ describe('VersionList', () => {
     expect(screen.queryByText('Downgrade')).not.toBeInTheDocument();
     expect(screen.getByText('4.17.0')).toBeInTheDocument();
     expect(screen.getByText(/^4\.19\.0/)).toBeInTheDocument();
-  });
-
-  it('should not open the downgrade modal from a managed plugin row that is labeled "Install"', () => {
-    // Reachability check for the label/modal mismatch: with external manage disabled (the default),
-    // an older still-listed version of a managed plugin renders an *enabled* button. Since managed
-    // rows are labeled "Install" (not "Downgrade"), clicking must not pop the downgrade modal.
-    const versions = [
-      { version: '2.0.0', createdAt: '', isCompatible: true, grafanaDependency: '>=9.0.0' },
-      { version: '1.0.0', createdAt: '', isCompatible: true, grafanaDependency: '>=8.0.0' },
-    ];
-
-    const plugin = getCatalogPluginMock({
-      details: {
-        grafanaDependency: '>=8.0.0',
-        pluginDependencies: [],
-        links: [{ name: 'GitHub', url: 'https://example.com' }],
-        versions,
-      },
-      managed: { enabled: true, strategy: PluginUpdateStrategy.MajorAligned },
-      installedVersion: '2.0.0',
-    });
-
-    renderWithStore(<VersionList plugin={plugin} />);
-
-    // No row advertises a downgrade, and the older row's button is a plain enabled "Install".
-    expect(screen.queryByText('Downgrade')).not.toBeInTheDocument();
-    const installButtons = screen.getAllByText('Install');
-    const olderVersionButton = installButtons[installButtons.length - 1];
-    expect(olderVersionButton.closest('button')).toBeEnabled();
-
-    fireEvent.click(olderVersionButton);
-
-    // Clicking it must not surface the downgrade confirmation modal.
-    expect(screen.queryByText('Downgrade plugin version')).not.toBeInTheDocument();
   });
 
   it('should disable all versions when plugin is managed and update strategy is "assigned"', () => {

--- a/public/app/features/plugins/admin/components/VersionList.tsx
+++ b/public/app/features/plugins/admin/components/VersionList.tsx
@@ -20,14 +20,13 @@ export const VersionList = ({ plugin }: Props) => {
   const styles = useStyles2(getStyles);
   const pluginId = plugin.id;
   const versions = useMemo(() => plugin.details?.versions ?? [], [plugin.details?.versions]);
-  const installedVersion = plugin.installedVersion;
   const disableInstallation = useMemo(() => shouldDisablePluginInstall(plugin), [plugin]);
 
-  // Managed plugins don't have a meaningful per-instance installed version (see usePluginInfo,
-  // which substitutes "Managed by Grafana" for the same reason) — treat as if nothing is installed
-  // rather than presenting a potentially stale version number as ground truth.
+  // Managed plugins have no trustworthy per-instance installed version, so treat them as if
+  // nothing is installed for display and install-gating (see usePluginInfo, which shows
+  // "Managed by Grafana" for the same reason).
   const isManagedPlugin = plugin.managed.enabled;
-  const effectiveInstalledVersion = isManagedPlugin ? undefined : installedVersion;
+  const installedVersion = isManagedPlugin ? undefined : plugin.installedVersion;
 
   const latestCompatibleVersion = getLatestCompatibleVersion(versions);
   const latestMajorVersions = getLatestMajorVersions(versions);
@@ -36,15 +35,15 @@ export const VersionList = ({ plugin }: Props) => {
 
   useEffect(() => {
     setIsInstalling(false);
-  }, [installedVersion]);
+  }, [plugin.installedVersion]);
 
   // Check if installed version is in the versions list
   const isInstalledVersionMissing = useMemo(() => {
-    if (!effectiveInstalledVersion) {
+    if (!installedVersion) {
       return false;
     }
-    return !versions.some((v) => v.version === effectiveInstalledVersion);
-  }, [versions, effectiveInstalledVersion]);
+    return !versions.some((v) => v.version === installedVersion);
+  }, [versions, installedVersion]);
 
   if (versions.length === 0 && !isInstalledVersionMissing) {
     return (
@@ -77,7 +76,7 @@ export const VersionList = ({ plugin }: Props) => {
       <tbody>
         {versions.map((version) => {
           let tooltip: string | undefined = undefined;
-          const isInstalledVersion = effectiveInstalledVersion === version.version;
+          const isInstalledVersion = installedVersion === version.version;
 
           if (version.angularDetected) {
             tooltip = 'This plugin version is AngularJS type which is not supported';
@@ -122,7 +121,8 @@ export const VersionList = ({ plugin }: Props) => {
                     pluginId={pluginId}
                     version={version}
                     latestCompatibleVersion={latestCompatibleVersion?.version}
-                    installedVersion={installedVersion}
+                    // Real version (not the managed-suppressed one) so the button can detect its own install completing.
+                    installedVersion={plugin.installedVersion}
                     hideInstallState={isManagedPlugin}
                     onConfirmInstallation={onInstallClick}
                     disabled={
@@ -135,7 +135,7 @@ export const VersionList = ({ plugin }: Props) => {
                         version,
                         latestMajorVersions,
                         latestCompatibleVersion: latestCompatibleVersion?.version,
-                        installedVersion: effectiveInstalledVersion,
+                        installedVersion,
                         updateStrategy: plugin.managed.strategy,
                       })
                     }

--- a/public/app/features/plugins/admin/components/VersionList.tsx
+++ b/public/app/features/plugins/admin/components/VersionList.tsx
@@ -23,6 +23,12 @@ export const VersionList = ({ plugin }: Props) => {
   const installedVersion = plugin.installedVersion;
   const disableInstallation = useMemo(() => shouldDisablePluginInstall(plugin), [plugin]);
 
+  // Managed plugins don't have a meaningful per-instance installed version (see usePluginInfo,
+  // which substitutes "Managed by Grafana" for the same reason) — treat as if nothing is installed
+  // rather than presenting a potentially stale version number as ground truth.
+  const isManagedPlugin = plugin.managed.enabled;
+  const effectiveInstalledVersion = isManagedPlugin ? undefined : installedVersion;
+
   const latestCompatibleVersion = getLatestCompatibleVersion(versions);
   const latestMajorVersions = getLatestMajorVersions(versions);
 
@@ -34,11 +40,11 @@ export const VersionList = ({ plugin }: Props) => {
 
   // Check if installed version is in the versions list
   const isInstalledVersionMissing = useMemo(() => {
-    if (!installedVersion) {
+    if (!effectiveInstalledVersion) {
       return false;
     }
-    return !versions.some((v) => v.version === installedVersion);
-  }, [versions, installedVersion]);
+    return !versions.some((v) => v.version === effectiveInstalledVersion);
+  }, [versions, effectiveInstalledVersion]);
 
   if (versions.length === 0 && !isInstalledVersionMissing) {
     return (
@@ -71,7 +77,7 @@ export const VersionList = ({ plugin }: Props) => {
       <tbody>
         {versions.map((version) => {
           let tooltip: string | undefined = undefined;
-          const isInstalledVersion = installedVersion === version.version;
+          const isInstalledVersion = effectiveInstalledVersion === version.version;
 
           if (version.angularDetected) {
             tooltip = 'This plugin version is AngularJS type which is not supported';
@@ -116,7 +122,7 @@ export const VersionList = ({ plugin }: Props) => {
                     pluginId={pluginId}
                     version={version}
                     latestCompatibleVersion={latestCompatibleVersion?.version}
-                    installedVersion={installedVersion}
+                    installedVersion={effectiveInstalledVersion}
                     onConfirmInstallation={onInstallClick}
                     disabled={
                       isInstalledVersion ||
@@ -128,7 +134,7 @@ export const VersionList = ({ plugin }: Props) => {
                         version,
                         latestMajorVersions,
                         latestCompatibleVersion: latestCompatibleVersion?.version,
-                        installedVersion,
+                        installedVersion: effectiveInstalledVersion,
                         updateStrategy: plugin.managed.strategy,
                       })
                     }

--- a/public/app/features/plugins/admin/components/VersionList.tsx
+++ b/public/app/features/plugins/admin/components/VersionList.tsx
@@ -122,7 +122,8 @@ export const VersionList = ({ plugin }: Props) => {
                     pluginId={pluginId}
                     version={version}
                     latestCompatibleVersion={latestCompatibleVersion?.version}
-                    installedVersion={effectiveInstalledVersion}
+                    installedVersion={installedVersion}
+                    hideInstallState={isManagedPlugin}
                     onConfirmInstallation={onInstallClick}
                     disabled={
                       isInstalledVersion ||

--- a/public/app/features/plugins/admin/components/VersionList.tsx
+++ b/public/app/features/plugins/admin/components/VersionList.tsx
@@ -22,9 +22,6 @@ export const VersionList = ({ plugin }: Props) => {
   const versions = useMemo(() => plugin.details?.versions ?? [], [plugin.details?.versions]);
   const disableInstallation = useMemo(() => shouldDisablePluginInstall(plugin), [plugin]);
 
-  // Managed plugins have no trustworthy per-instance installed version, so treat them as if
-  // nothing is installed for display and install-gating (see usePluginInfo, which shows
-  // "Managed by Grafana" for the same reason).
   const isManagedPlugin = plugin.managed.enabled;
   const installedVersion = isManagedPlugin ? undefined : plugin.installedVersion;
 
@@ -121,7 +118,6 @@ export const VersionList = ({ plugin }: Props) => {
                     pluginId={pluginId}
                     version={version}
                     latestCompatibleVersion={latestCompatibleVersion?.version}
-                    // Real version (not the managed-suppressed one) so the button can detect its own install completing.
                     installedVersion={plugin.installedVersion}
                     hideInstallState={isManagedPlugin}
                     onConfirmInstallation={onInstallClick}


### PR DESCRIPTION
**What is this feature?**

Fixes the "Version history" tab in the Plugin Catalog (`VersionList.tsx`) so it no longer treats a managed plugin's stored `installedVersion` as ground truth. For managed plugins, that value can be stale or otherwise untrustworthy, so the UI now suppresses the "(installed version)" label and Upgrade/Downgrade actions instead of presenting a version number that may not reflect what's actually running.

![image](https://github.com/user-attachments/assets/0bc3ebc0-224a-4baa-86c6-f3dbc1c07cb3)


**Why do we need this feature?**

For managed plugins (e.g. remote/CDN-provisioned datasources), the per-instance `installedVersion` record isn't guaranteed to be kept in sync with the actual deployed version. The Version History tab rendered it unconditionally anyway — marking a row "✓ Installed" and computing Upgrade/Downgrade eligibility from it, which can show incorrect, misleading version info.

**Who is this feature for?**

**Which issue(s) does this PR fix?**:

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle. *(N/A — bug fix, no new toggle)*
- [ ] The docs are updated... *(N/A — no user-facing behavior change worth documenting; this only removes misleading info)*