### PR TITLE
Azure Monitor: Reject multiple 'starts with' dimension filter values with a clear error

### DIFF
--- a/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource.go
+++ b/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource.go
@@ -198,40 +198,18 @@ func (e *AzureMonitorDatasource) buildQuery(query backend.DataQuery, dsInfo type
 		}
 	}
 
-	// old model
-	dimension := ""
-	if azJSONModel.Dimension != nil {
-		dimension = strings.TrimSpace(*azJSONModel.Dimension)
-	}
-	dimensionFilter := ""
-	if azJSONModel.DimensionFilter != nil {
-		dimensionFilter = strings.TrimSpace(*azJSONModel.DimensionFilter)
-	}
-
-	dimSB := strings.Builder{}
-
-	if dimension != "" && dimensionFilter != "" && dimension != "None" && len(azJSONModel.DimensionFilters) == 0 {
-		dimSB.WriteString(fmt.Sprintf("%s eq '%s'", dimension, dimensionFilter))
-	} else {
-		for i, filter := range azJSONModel.DimensionFilters {
-			if len(filter.Filters) == 0 {
-				dimSB.WriteString(fmt.Sprintf("%s eq '*'", *filter.Dimension))
-			} else {
-				dimSB.WriteString(types.ConstructFiltersString(filter))
-			}
-			if i != len(azJSONModel.DimensionFilters)-1 {
-				dimSB.WriteString(" and ")
-			}
-		}
+	dimensionFilterString, err := buildDimensionFilterString(azJSONModel)
+	if err != nil {
+		return nil, err
 	}
 
 	filterString := strings.Join(resourceIDs, " or ")
 
-	if dimSB.String() != "" {
+	if dimensionFilterString != "" {
 		if filterString != "" {
-			filterString = fmt.Sprintf("(%s) and (%s)", filterString, dimSB.String())
+			filterString = fmt.Sprintf("(%s) and (%s)", filterString, dimensionFilterString)
 		} else {
-			filterString = dimSB.String()
+			filterString = dimensionFilterString
 		}
 	}
 
@@ -267,6 +245,49 @@ func (e *AzureMonitorDatasource) buildQuery(query backend.DataQuery, dsInfo type
 	}
 
 	return azureQuery, nil
+}
+
+// buildDimensionFilterString constructs the dimension portion of the metrics
+// API $filter from either the legacy single dimension/dimensionFilter fields
+// or the DimensionFilters list.
+func buildDimensionFilterString(azJSONModel *dataquery.AzureMetricQuery) (string, error) {
+	// old model
+	dimension := ""
+	if azJSONModel.Dimension != nil {
+		dimension = strings.TrimSpace(*azJSONModel.Dimension)
+	}
+	dimensionFilter := ""
+	if azJSONModel.DimensionFilter != nil {
+		dimensionFilter = strings.TrimSpace(*azJSONModel.DimensionFilter)
+	}
+
+	if dimension != "" && dimensionFilter != "" && dimension != "None" && len(azJSONModel.DimensionFilters) == 0 {
+		return fmt.Sprintf("%s eq '%s'", dimension, dimensionFilter), nil
+	}
+
+	dimSB := strings.Builder{}
+	for i, filter := range azJSONModel.DimensionFilters {
+		// The metrics API accepts at most one 'sw' clause per dimension: it
+		// rejects both "sw ... or sw ..." (or is only valid between eq
+		// clauses) and "sw ... and sw ..." (multiple sw values for one
+		// dimension), so fail here with a clearer message than the API's.
+		if filter.Operator != nil && *filter.Operator == "sw" && len(filter.Filters) > 1 {
+			filterDimension := ""
+			if filter.Dimension != nil {
+				filterDimension = *filter.Dimension
+			}
+			return "", backend.DownstreamError(fmt.Errorf("the Azure Monitor API supports only one 'starts with' filter value per dimension, but dimension %q has %d", filterDimension, len(filter.Filters)))
+		}
+		if len(filter.Filters) == 0 {
+			dimSB.WriteString(fmt.Sprintf("%s eq '*'", *filter.Dimension))
+		} else {
+			dimSB.WriteString(types.ConstructFiltersString(filter))
+		}
+		if i != len(azJSONModel.DimensionFilters)-1 {
+			dimSB.WriteString(" and ")
+		}
+	}
+	return dimSB.String(), nil
 }
 
 func getParams(azJSONModel *dataquery.AzureMetricQuery, query backend.DataQuery) (url.Values, error) {

--- a/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource_test.go
@@ -175,19 +175,6 @@ func TestAzureMonitorBuildQueries(t *testing.T) {
 			expectedPortalURL:       new("http://ds/#blade/Microsoft_Azure_MonitoringMetrics/Metrics.ReactView/Referer/MetricsExplorer/TimeContext/%7B%22absolute%22%3A%7B%22startTime%22%3A%222018-03-15T13%3A00%3A00Z%22%2C%22endTime%22%3A%222018-03-15T13%3A34%3A00Z%22%7D%7D/ChartDefinition/%7B%22v2charts%22%3A%5B%7B%22filterCollection%22%3A%7B%22filters%22%3A%5B%7B%22key%22%3A%22blob%22%2C%22operator%22%3A3%2C%22values%22%3A%5B%22test%22%5D%7D%5D%7D%2C%22grouping%22%3A%7B%22dimension%22%3A%22blob%22%2C%22sort%22%3A2%2C%22top%22%3A10%7D%2C%22metrics%22%3A%5B%7B%22resourceMetadata%22%3A%7B%22id%22%3A%22%2Fsubscriptions%2F12345678-aaaa-bbbb-cccc-123456789abc%2FresourceGroups%2Fgrafanastaging%2Fproviders%2FMicrosoft.Compute%2FvirtualMachines%2Fgrafana%22%7D%2C%22name%22%3A%22Percentage%20CPU%22%2C%22aggregationType%22%3A4%2C%22namespace%22%3A%22Microsoft.Compute%2FvirtualMachines%22%2C%22metricVisualization%22%3A%7B%22displayName%22%3A%22Percentage%20CPU%22%2C%22resourceDisplayName%22%3A%22grafana%22%7D%7D%5D%7D%5D%7D"),
 		},
 		{
-			name: "correctly constructs target when multiple filter values are provided for the 'sw' operator",
-			azureMonitorVariedProperties: map[string]any{
-				"timeGrain":        "PT1M",
-				"dimensionFilters": []dataquery.AzureMetricDimension{{Dimension: new("blob"), Operator: new("sw"), Filter: &wildcardFilter, Filters: []string{"test", "test2"}}},
-				"top":              "30",
-			},
-			queryInterval:           duration,
-			expectedInterval:        "PT1M",
-			azureMonitorQueryTarget: "aggregation=Average&api-version=2021-05-01&interval=PT1M&metricnames=Percentage+CPU&metricnamespace=Microsoft.Compute%2FvirtualMachines&timespan=2018-03-15T13%3A00%3A00Z%2F2018-03-15T13%3A34%3A00Z&top=30",
-			expectedParamFilter:     "blob sw 'test' or blob sw 'test2'",
-			expectedPortalURL:       new("http://ds/#blade/Microsoft_Azure_MonitoringMetrics/Metrics.ReactView/Referer/MetricsExplorer/TimeContext/%7B%22absolute%22%3A%7B%22startTime%22%3A%222018-03-15T13%3A00%3A00Z%22%2C%22endTime%22%3A%222018-03-15T13%3A34%3A00Z%22%7D%7D/ChartDefinition/%7B%22v2charts%22%3A%5B%7B%22filterCollection%22%3A%7B%22filters%22%3A%5B%7B%22key%22%3A%22blob%22%2C%22operator%22%3A3%2C%22values%22%3A%5B%22test%22%2C%22test2%22%5D%7D%5D%7D%2C%22grouping%22%3A%7B%22dimension%22%3A%22blob%22%2C%22sort%22%3A2%2C%22top%22%3A10%7D%2C%22metrics%22%3A%5B%7B%22resourceMetadata%22%3A%7B%22id%22%3A%22%2Fsubscriptions%2F12345678-aaaa-bbbb-cccc-123456789abc%2FresourceGroups%2Fgrafanastaging%2Fproviders%2FMicrosoft.Compute%2FvirtualMachines%2Fgrafana%22%7D%2C%22name%22%3A%22Percentage%20CPU%22%2C%22aggregationType%22%3A4%2C%22namespace%22%3A%22Microsoft.Compute%2FvirtualMachines%22%2C%22metricVisualization%22%3A%7B%22displayName%22%3A%22Percentage%20CPU%22%2C%22resourceDisplayName%22%3A%22grafana%22%7D%7D%5D%7D%5D%7D"),
-		},
-		{
 			name: "correctly sets dimension operator to eq (irrespective of operator) when filter value is '*'",
 			azureMonitorVariedProperties: map[string]any{
 				"timeGrain":        "PT1M",
@@ -359,6 +346,33 @@ func TestAzureMonitorBuildQueries(t *testing.T) {
 			require.Equal(t, expectedPortalURL, actual)
 		})
 	}
+}
+
+func TestAzureMonitorBuildQueriesRejectsMultiValueStartsWithFilter(t *testing.T) {
+	datasource := &AzureMonitorDatasource{}
+	query := backend.DataQuery{
+		RefID: "A",
+		JSON: []byte(`{
+			"subscription": "12345678-aaaa-bbbb-cccc-123456789abc",
+			"azureMonitor": {
+				"aggregation": "Total",
+				"timeGrain": "PT1M",
+				"metricName": "Transactions",
+				"metricNamespace": "Microsoft.Storage/storageAccounts",
+				"resources": [{"resourceGroup": "rg", "resourceName": "sa"}],
+				"dimensionFilters": [{"dimension": "ApiName", "operator": "sw", "filters": ["Get", "Put"]}]
+			}
+		}`),
+		TimeRange: backend.TimeRange{
+			From: time.Date(2018, 3, 15, 13, 0, 0, 0, time.UTC),
+			To:   time.Date(2018, 3, 15, 13, 34, 0, 0, time.UTC),
+		},
+	}
+
+	_, err := datasource.buildQuery(query, types.DatasourceInfo{})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "one 'starts with' filter value")
+	require.True(t, backend.IsDownstreamError(err), "a multi-value sw filter is a query configuration error, not a plugin error")
 }
 
 func TestCustomNamespace(t *testing.T) {

--- a/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource_test.go
@@ -175,6 +175,19 @@ func TestAzureMonitorBuildQueries(t *testing.T) {
 			expectedPortalURL:       new("http://ds/#blade/Microsoft_Azure_MonitoringMetrics/Metrics.ReactView/Referer/MetricsExplorer/TimeContext/%7B%22absolute%22%3A%7B%22startTime%22%3A%222018-03-15T13%3A00%3A00Z%22%2C%22endTime%22%3A%222018-03-15T13%3A34%3A00Z%22%7D%7D/ChartDefinition/%7B%22v2charts%22%3A%5B%7B%22filterCollection%22%3A%7B%22filters%22%3A%5B%7B%22key%22%3A%22blob%22%2C%22operator%22%3A3%2C%22values%22%3A%5B%22test%22%5D%7D%5D%7D%2C%22grouping%22%3A%7B%22dimension%22%3A%22blob%22%2C%22sort%22%3A2%2C%22top%22%3A10%7D%2C%22metrics%22%3A%5B%7B%22resourceMetadata%22%3A%7B%22id%22%3A%22%2Fsubscriptions%2F12345678-aaaa-bbbb-cccc-123456789abc%2FresourceGroups%2Fgrafanastaging%2Fproviders%2FMicrosoft.Compute%2FvirtualMachines%2Fgrafana%22%7D%2C%22name%22%3A%22Percentage%20CPU%22%2C%22aggregationType%22%3A4%2C%22namespace%22%3A%22Microsoft.Compute%2FvirtualMachines%22%2C%22metricVisualization%22%3A%7B%22displayName%22%3A%22Percentage%20CPU%22%2C%22resourceDisplayName%22%3A%22grafana%22%7D%7D%5D%7D%5D%7D"),
 		},
 		{
+			name: "correctly constructs target when multiple filter values are provided for the 'sw' operator",
+			azureMonitorVariedProperties: map[string]any{
+				"timeGrain":        "PT1M",
+				"dimensionFilters": []dataquery.AzureMetricDimension{{Dimension: new("blob"), Operator: new("sw"), Filter: &wildcardFilter, Filters: []string{"test", "test2"}}},
+				"top":              "30",
+			},
+			queryInterval:           duration,
+			expectedInterval:        "PT1M",
+			azureMonitorQueryTarget: "aggregation=Average&api-version=2021-05-01&interval=PT1M&metricnames=Percentage+CPU&metricnamespace=Microsoft.Compute%2FvirtualMachines&timespan=2018-03-15T13%3A00%3A00Z%2F2018-03-15T13%3A34%3A00Z&top=30",
+			expectedParamFilter:     "blob sw 'test' or blob sw 'test2'",
+			expectedPortalURL:       new("http://ds/#blade/Microsoft_Azure_MonitoringMetrics/Metrics.ReactView/Referer/MetricsExplorer/TimeContext/%7B%22absolute%22%3A%7B%22startTime%22%3A%222018-03-15T13%3A00%3A00Z%22%2C%22endTime%22%3A%222018-03-15T13%3A34%3A00Z%22%7D%7D/ChartDefinition/%7B%22v2charts%22%3A%5B%7B%22filterCollection%22%3A%7B%22filters%22%3A%5B%7B%22key%22%3A%22blob%22%2C%22operator%22%3A3%2C%22values%22%3A%5B%22test%22%2C%22test2%22%5D%7D%5D%7D%2C%22grouping%22%3A%7B%22dimension%22%3A%22blob%22%2C%22sort%22%3A2%2C%22top%22%3A10%7D%2C%22metrics%22%3A%5B%7B%22resourceMetadata%22%3A%7B%22id%22%3A%22%2Fsubscriptions%2F12345678-aaaa-bbbb-cccc-123456789abc%2FresourceGroups%2Fgrafanastaging%2Fproviders%2FMicrosoft.Compute%2FvirtualMachines%2Fgrafana%22%7D%2C%22name%22%3A%22Percentage%20CPU%22%2C%22aggregationType%22%3A4%2C%22namespace%22%3A%22Microsoft.Compute%2FvirtualMachines%22%2C%22metricVisualization%22%3A%7B%22displayName%22%3A%22Percentage%20CPU%22%2C%22resourceDisplayName%22%3A%22grafana%22%7D%7D%5D%7D%5D%7D"),
+		},
+		{
 			name: "correctly sets dimension operator to eq (irrespective of operator) when filter value is '*'",
 			azureMonitorVariedProperties: map[string]any{
 				"timeGrain":        "PT1M",

--- a/pkg/tsdb/azuremonitor/types/types.go
+++ b/pkg/tsdb/azuremonitor/types/types.go
@@ -146,16 +146,11 @@ func ConstructFiltersString(a dataquery.AzureMetricDimension) string {
 		filterStrings[i] = fmt.Sprintf("%v %v '%v'", dimension, operator, filter)
 	}
 
-	// "ne" filters exclude every value, so they are intersected. "eq" and
-	// "sw" filters each select a set of values, so they are unioned: a
-	// dimension value can never equal (or start with) two different filter
-	// values at once, and joining them with "and" produces a filter that
-	// matches nothing.
-	if a.Operator != nil && *a.Operator == "ne" {
-		return strings.Join(filterStrings, " and ")
+	if a.Operator != nil && *a.Operator == "eq" {
+		return strings.Join(filterStrings, " or ")
 	}
 
-	return strings.Join(filterStrings, " or ")
+	return strings.Join(filterStrings, " and ")
 }
 
 // LogJSONQuery is the frontend JSON query model for an Azure Log Analytics query.

--- a/pkg/tsdb/azuremonitor/types/types.go
+++ b/pkg/tsdb/azuremonitor/types/types.go
@@ -146,11 +146,16 @@ func ConstructFiltersString(a dataquery.AzureMetricDimension) string {
 		filterStrings[i] = fmt.Sprintf("%v %v '%v'", dimension, operator, filter)
 	}
 
-	if a.Operator != nil && *a.Operator == "eq" {
-		return strings.Join(filterStrings, " or ")
+	// "ne" filters exclude every value, so they are intersected. "eq" and
+	// "sw" filters each select a set of values, so they are unioned: a
+	// dimension value can never equal (or start with) two different filter
+	// values at once, and joining them with "and" produces a filter that
+	// matches nothing.
+	if a.Operator != nil && *a.Operator == "ne" {
+		return strings.Join(filterStrings, " and ")
 	}
 
-	return strings.Join(filterStrings, " and ")
+	return strings.Join(filterStrings, " or ")
 }
 
 // LogJSONQuery is the frontend JSON query model for an Azure Log Analytics query.


### PR DESCRIPTION
**What is this feature?**

A metrics query with more than one `sw` (starts with) value on a single dimension filter is now rejected before it reaches the Azure Monitor API, with a clear downstream error: `the Azure Monitor API supports only one 'starts with' filter value per dimension`.

**Why do we need this feature?**

Verified against a live Azure subscription: the metrics API accepts at most one `sw` clause per dimension. It rejects `Dim sw 'a' or Dim sw 'b'` with `Only 'eq' operator are supported for 'or' clause`, and rejects the AND-joined form Grafana currently produces with `Dimension name detected in multiple 'sw' values`. Neither message tells the user what to change in their query. Failing client-side with an actionable message covers dashboard, alert, and API-created queries alike.

This surfaced while investigating https://github.com/grafana/support-escalations/issues/23211. Multiple `sw` values cannot be produced through the query editor (it restricts `sw` to a single value) but can arrive via multi-value template variables, especially once the companion PR below expands them into separate filter values.

**Who is this feature for?**

Users filtering Azure Monitor metrics by dimension with the "starts with" operator, particularly with multi-value template variables.

**Which issue(s) does this PR fix?**:

Related to https://github.com/grafana/support-escalations/issues/23211

**Special notes for your reviewer:**

- The first commit tried OR-joining multiple `sw` clauses instead. Live testing showed the API rejects that too, so the second commit reverts it in favour of client-side validation. The `eq`/`ne` join semantics are untouched.
- The dimension filter construction moved from `buildQuery` into a `buildDimensionFilterString` helper, since the validation branch pushed `buildQuery` past the gocyclo limit.
- Companion PR: https://github.com/grafana/grafana/pull/128317 (expands multi-value template variables into separate dimension filter values). Either merge order is safe: without this PR a multi-value `sw` filter fails with Azure's 400, with it the error is clearer.

Closes #128418