### PR TITLE
Azure Monitor: Expand multi-value template variables in dimension filter values

### DIFF
--- a/public/app/plugins/datasource/azuremonitor/azure_monitor/azure_monitor_datasource.test.ts
+++ b/public/app/plugins/datasource/azuremonitor/azure_monitor/azure_monitor_datasource.test.ts
@@ -144,6 +144,64 @@ describe('AzureMonitorDatasource', () => {
       });
     });
 
+    it('should expand a multi-value template variable in dimension filter values', () => {
+      replace = (
+        target?: string,
+        _scopedVars?: ScopedVars,
+        _format?: string | Function,
+        interpolated?: VariableInterpolation[]
+      ) => {
+        if (target?.includes('$entities')) {
+          if (interpolated) {
+            interpolated.push({ value: 'topic-a,topic-b', match: '$entities', variableName: 'entities' });
+          }
+          return 'topic-a,topic-b';
+        }
+        return target || '';
+      };
+      ctx.ds = new AzureMonitorDatasource(ctx.instanceSettings);
+      const query = createMockQuery({
+        azureMonitor: {
+          dimensionFilters: [{ dimension: 'EntityName', operator: 'eq', filters: ['$entities'] }],
+        },
+      });
+      const templatedQuery = ctx.ds.azureMonitorDatasource.applyTemplateVariables(query, {});
+      expect(templatedQuery).toMatchObject({
+        azureMonitor: {
+          dimensionFilters: [{ dimension: 'EntityName', operator: 'eq', filters: ['topic-a', 'topic-b'] }],
+        },
+      });
+    });
+
+    it('should leave single-value dimension filter values unchanged', () => {
+      replace = (
+        target?: string,
+        _scopedVars?: ScopedVars,
+        _format?: string | Function,
+        interpolated?: VariableInterpolation[]
+      ) => {
+        if (target?.includes('$entity')) {
+          if (interpolated) {
+            interpolated.push({ value: 'topic-a', match: '$entity', variableName: 'entity' });
+          }
+          return 'topic-a';
+        }
+        return target || '';
+      };
+      ctx.ds = new AzureMonitorDatasource(ctx.instanceSettings);
+      const query = createMockQuery({
+        azureMonitor: {
+          dimensionFilters: [{ dimension: 'EntityName', operator: 'sw', filters: ['$entity', 'literal-value'] }],
+        },
+      });
+      const templatedQuery = ctx.ds.azureMonitorDatasource.applyTemplateVariables(query, {});
+      expect(templatedQuery).toMatchObject({
+        azureMonitor: {
+          dimensionFilters: [{ dimension: 'EntityName', operator: 'sw', filters: ['topic-a', 'literal-value'] }],
+        },
+      });
+    });
+
     it('expand template variables in resource groups and names', () => {
       const resourceGroup = '$rg';
       const resourceName = '$rn';

--- a/public/app/plugins/datasource/azuremonitor/azure_monitor/azure_monitor_datasource.test.ts
+++ b/public/app/plugins/datasource/azuremonitor/azure_monitor/azure_monitor_datasource.test.ts
@@ -204,6 +204,36 @@ describe('AzureMonitorDatasource', () => {
       });
     });
 
+    it('should not duplicate filter values when the same variable appears twice in one expression', () => {
+      replace = (
+        target?: string,
+        _scopedVars?: ScopedVars,
+        _format?: string | Function,
+        interpolated?: VariableInterpolation[]
+      ) => {
+        const result = target ?? '';
+        // The real templateSrv records one interpolation entry per match,
+        // so a repeated variable produces duplicate entries.
+        const occurrences = (result.match(/\$env/g) ?? []).length;
+        for (let i = 0; i < occurrences; i++) {
+          interpolated?.push({ value: 'dev,prod', match: '$env', variableName: 'env' });
+        }
+        return result.replaceAll('$env', 'dev,prod');
+      };
+      ctx.ds = new AzureMonitorDatasource(ctx.instanceSettings);
+      const query = createMockQuery({
+        azureMonitor: {
+          dimensionFilters: [{ dimension: 'EntityName', operator: 'eq', filters: ['$env-$env'] }],
+        },
+      });
+      const templatedQuery = ctx.ds.azureMonitorDatasource.applyTemplateVariables(query, {});
+      expect(templatedQuery).toMatchObject({
+        azureMonitor: {
+          dimensionFilters: [{ dimension: 'EntityName', operator: 'eq', filters: ['dev-dev', 'prod-prod'] }],
+        },
+      });
+    });
+
     it('should expand multiple multi-value variables in one dimension filter value', () => {
       replace = (
         target?: string,

--- a/public/app/plugins/datasource/azuremonitor/azure_monitor/azure_monitor_datasource.test.ts
+++ b/public/app/plugins/datasource/azuremonitor/azure_monitor/azure_monitor_datasource.test.ts
@@ -173,6 +173,75 @@ describe('AzureMonitorDatasource', () => {
       });
     });
 
+    it('should preserve literal text around a multi-value variable in dimension filter values', () => {
+      replace = (
+        target?: string,
+        _scopedVars?: ScopedVars,
+        _format?: string | Function,
+        interpolated?: VariableInterpolation[]
+      ) => {
+        if (target?.includes('$entities')) {
+          if (interpolated) {
+            interpolated.push({ value: 'topic-a,topic-b', match: '$entities', variableName: 'entities' });
+          }
+          return (target ?? '').replace('$entities', 'topic-a,topic-b');
+        }
+        return target || '';
+      };
+      ctx.ds = new AzureMonitorDatasource(ctx.instanceSettings);
+      const query = createMockQuery({
+        azureMonitor: {
+          dimensionFilters: [{ dimension: 'EntityName', operator: 'eq', filters: ['prefix-$entities'] }],
+        },
+      });
+      const templatedQuery = ctx.ds.azureMonitorDatasource.applyTemplateVariables(query, {});
+      expect(templatedQuery).toMatchObject({
+        azureMonitor: {
+          dimensionFilters: [
+            { dimension: 'EntityName', operator: 'eq', filters: ['prefix-topic-a', 'prefix-topic-b'] },
+          ],
+        },
+      });
+    });
+
+    it('should expand multiple multi-value variables in one dimension filter value', () => {
+      replace = (
+        target?: string,
+        _scopedVars?: ScopedVars,
+        _format?: string | Function,
+        interpolated?: VariableInterpolation[]
+      ) => {
+        let result = target ?? '';
+        if (result.includes('$regions')) {
+          if (interpolated) {
+            interpolated.push({ value: 'eu,us', match: '$regions', variableName: 'regions' });
+          }
+          result = result.replace('$regions', 'eu,us');
+        }
+        if (result.includes('$envs')) {
+          if (interpolated) {
+            interpolated.push({ value: 'dev,prod', match: '$envs', variableName: 'envs' });
+          }
+          result = result.replace('$envs', 'dev,prod');
+        }
+        return result;
+      };
+      ctx.ds = new AzureMonitorDatasource(ctx.instanceSettings);
+      const query = createMockQuery({
+        azureMonitor: {
+          dimensionFilters: [{ dimension: 'EntityName', operator: 'eq', filters: ['$regions-$envs'] }],
+        },
+      });
+      const templatedQuery = ctx.ds.azureMonitorDatasource.applyTemplateVariables(query, {});
+      expect(templatedQuery).toMatchObject({
+        azureMonitor: {
+          dimensionFilters: [
+            { dimension: 'EntityName', operator: 'eq', filters: ['eu-dev', 'eu-prod', 'us-dev', 'us-prod'] },
+          ],
+        },
+      });
+    });
+
     it('should leave single-value dimension filter values unchanged', () => {
       replace = (
         target?: string,

--- a/public/app/plugins/datasource/azuremonitor/azure_monitor/azure_monitor_datasource.ts
+++ b/public/app/plugins/datasource/azuremonitor/azure_monitor/azure_monitor_datasource.ts
@@ -2,7 +2,12 @@ import { find } from 'lodash';
 
 import { type AzureCredentials } from '@grafana/azure-sdk';
 import { type ScopedVars } from '@grafana/data';
-import { DataSourceWithBackend, getTemplateSrv, type TemplateSrv } from '@grafana/runtime';
+import {
+  DataSourceWithBackend,
+  getTemplateSrv,
+  type TemplateSrv,
+  type VariableInterpolation,
+} from '@grafana/runtime';
 
 import { getCredentials } from '../credentials';
 import { type AzureMetricQuery, AzureQueryType } from '../dataquery.gen';
@@ -135,11 +140,22 @@ export default class AzureMonitorDatasource extends DataSourceWithBackend<
     const dimensionFilters = (migratedQuery.dimensionFilters ?? [])
       .filter((f) => f.dimension && f.dimension !== 'None')
       .map((f) => {
-        const filters = f.filters?.map((filter) => this.templateSrv.replace(filter ?? '', scopedVars));
+        const filters = (f.filters ?? []).flatMap((filter) => {
+          const interpolated: VariableInterpolation[] = [];
+          const replaced = this.templateSrv.replace(filter ?? '', scopedVars, 'raw', interpolated);
+          // A multi-value template variable interpolates to a
+          // comma-separated list. Spread it into separate filter values so
+          // each becomes its own clause in the metrics API $filter, rather
+          // than a single literal that matches no dimension value.
+          if (interpolated.some((v) => v.found !== false && v.value?.includes(','))) {
+            return replaced.split(',');
+          }
+          return [replaced];
+        });
         return {
           dimension: this.templateSrv.replace(f.dimension, scopedVars),
           operator: f.operator || 'eq',
-          filters: filters || [],
+          filters,
         };
       });
 

--- a/public/app/plugins/datasource/azuremonitor/azure_monitor/azure_monitor_datasource.ts
+++ b/public/app/plugins/datasource/azuremonitor/azure_monitor/azure_monitor_datasource.ts
@@ -148,9 +148,14 @@ export default class AzureMonitorDatasource extends DataSourceWithBackend<
           // the original expression so every combination becomes its own
           // filter value (preserving any literal text around the variable),
           // rather than a single glob literal that matches no dimension
-          // value.
+          // value. templateSrv records one interpolation entry per match, so
+          // a variable repeated in the expression must be expanded only once
+          // (replaceAll already substitutes every occurrence of the match).
+          const uniqueVariables = foundVariables.filter(
+            (variable, index) => foundVariables.findIndex((other) => other.match === variable.match) === index
+          );
           let expanded = [rawValue];
-          for (const variable of foundVariables) {
+          for (const variable of uniqueVariables) {
             const values = variable.value.split(',');
             expanded = expanded.flatMap((expression) =>
               values.map((value) => expression.replaceAll(variable.match, value))

--- a/public/app/plugins/datasource/azuremonitor/azure_monitor/azure_monitor_datasource.ts
+++ b/public/app/plugins/datasource/azuremonitor/azure_monitor/azure_monitor_datasource.ts
@@ -2,12 +2,7 @@ import { find } from 'lodash';
 
 import { type AzureCredentials } from '@grafana/azure-sdk';
 import { type ScopedVars } from '@grafana/data';
-import {
-  DataSourceWithBackend,
-  getTemplateSrv,
-  type TemplateSrv,
-  type VariableInterpolation,
-} from '@grafana/runtime';
+import { DataSourceWithBackend, getTemplateSrv, type TemplateSrv, type VariableInterpolation } from '@grafana/runtime';
 
 import { getCredentials } from '../credentials';
 import { type AzureMetricQuery, AzureQueryType } from '../dataquery.gen';

--- a/public/app/plugins/datasource/azuremonitor/azure_monitor/azure_monitor_datasource.ts
+++ b/public/app/plugins/datasource/azuremonitor/azure_monitor/azure_monitor_datasource.ts
@@ -141,16 +141,27 @@ export default class AzureMonitorDatasource extends DataSourceWithBackend<
       .filter((f) => f.dimension && f.dimension !== 'None')
       .map((f) => {
         const filters = (f.filters ?? []).flatMap((filter) => {
+          const rawValue = filter ?? '';
           const interpolated: VariableInterpolation[] = [];
-          const replaced = this.templateSrv.replace(filter ?? '', scopedVars, 'raw', interpolated);
-          // A multi-value template variable interpolates to a
-          // comma-separated list. Spread it into separate filter values so
-          // each becomes its own clause in the metrics API $filter, rather
-          // than a single literal that matches no dimension value.
-          if (interpolated.some((v) => v.found !== false && v.value?.includes(','))) {
-            return replaced.split(',');
+          const replaced = this.templateSrv.replace(rawValue, scopedVars, 'raw', interpolated);
+          const foundVariables = interpolated.filter((v) => v.found !== false);
+          if (!foundVariables.some((v) => v.value?.includes(','))) {
+            return [replaced];
           }
-          return [replaced];
+          // A multi-value template variable interpolates to a
+          // comma-separated list. Substitute each selected value back into
+          // the original expression so every combination becomes its own
+          // filter value (preserving any literal text around the variable),
+          // rather than a single glob literal that matches no dimension
+          // value.
+          let expanded = [rawValue];
+          for (const variable of foundVariables) {
+            const values = variable.value.split(',');
+            expanded = expanded.flatMap((expression) =>
+              values.map((value) => expression.replaceAll(variable.match, value))
+            );
+          }
+          return expanded;
         });
         return {
           dimension: this.templateSrv.replace(f.dimension, scopedVars),


### PR DESCRIPTION
**What is this feature?**

Multi-value template variables used as Azure Monitor dimension filter values are now expanded into separate filter values during interpolation. Previously each filter value was interpolated with the default format, so a multi-value variable became the glob literal `{a,b}`, which was then sent to the Azure Monitor API as a single dimension value.

**Why do we need this feature?**

The metrics API `$filter` has no glob syntax, so the current behaviour silently returns zero series whenever a multi-value (or include-all) variable is used in a dimension filter (verified against a live Azure subscription: the request is accepted and returns an empty timeseries list). Spreading the values lets the backend construct one clause per value, matching how multi-value variables already behave for resource groups and resource names (`replaceTemplateVariables` in `utils/common.ts`, which this change mirrors). This surfaced while investigating https://github.com/grafana/support-escalations/issues/23211, where metric values in Grafana did not match the Azure portal for dimension-filtered queries driven by template variables.

**Who is this feature for?**

Users driving Azure Monitor dimension filters from multi-value template variables.

**Which issue(s) does this PR fix?**:

Related to https://github.com/grafana/support-escalations/issues/23211

**Special notes for your reviewer:**

- Single-value interpolation is unchanged (the `raw` format only differs from the default for multi-value variables).
- Same known limitation as the existing resources helper: a single selected value containing a literal comma would be split. Multi-value variable values are comma-joined by the `raw` format, so the two cases cannot be distinguished at this layer.
- With the `sw` operator, a spread multi-value variable produces multiple `sw` values for one dimension, which the Azure API cannot express (verified live: it rejects both `and` and `or` joins). Companion PR https://github.com/grafana/grafana/pull/128316 rejects that combination with a clear client-side error. Either merge order is safe: without it the query fails with Azure's own 400, which is loud but less actionable.

Closes #128417