### PR TITLE
Home: Remove extra wrapper when redesign enabled

### DIFF
--- a/public/app/features/home/HomePage.tsx
+++ b/public/app/features/home/HomePage.tsx
@@ -57,11 +57,14 @@ export default function HomePage() {
     props: {},
     components: extraComponents,
     pluginId: SETUPGUIDE_PLUGIN_ID,
-    wrapper: ({ children }) => (
-      <div className={styles.extra}>
-        <HomeSection>{children}</HomeSection>
-      </div>
-    ),
+    wrapper: ({ children }) =>
+      redesignEnabled ? (
+        children
+      ) : (
+        <div className={styles.extra}>
+          <HomeSection>{children}</HomeSection>
+        </div>
+      ),
   });
   const showExtra = extraContent !== null;
   const showAlertsCard = canViewFiringAlerts();


### PR DESCRIPTION
**What is this feature?**

Removes the extra HomeSection wrapper around the extra content injected by SetupGuide on the homepage, when the new redesign flag is enabled.

**Why do we need this feature?**

Per the design, there is no outer card wrapper around these sections in the redesign.

**Who is this feature for?**

All users.

**Which issue(s) does this PR fix?**:

cc https://github.com/grafana/grafana/issues/128199

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
