### PR TITLE
Provisioning: Preserve the acting user on Jobs and archived HistoricJobs

### DIFF
--- a/pkg/clientauth/roundtripper.go
+++ b/pkg/clientauth/roundtripper.go
@@ -6,7 +6,10 @@ import (
 
 	authnlib "github.com/grafana/authlib/authn"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/transport"
+
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 )
 
 // tokenExchangeRoundTripper wraps an http.RoundTripper and injects an exchanged
@@ -88,3 +91,43 @@ func NewTokenExchangeTransportWrapper(
 
 // WildcardNamespace is a convenience constant for the wildcard namespace.
 const WildcardNamespace = "*"
+
+// callerTokenForwardingRoundTripper wraps an http.RoundTripper and forwards the
+// caller's raw access and ID tokens from the request context via the
+// X-Access-Token and X-Grafana-Id headers.
+type callerTokenForwardingRoundTripper struct {
+	transport http.RoundTripper
+}
+
+var _ http.RoundTripper = (*callerTokenForwardingRoundTripper)(nil)
+
+// RoundTrip implements http.RoundTripper by copying the caller's tokens from the
+// request context into headers before forwarding the request. Requests without a
+// requester or without a raw access token are forwarded unchanged.
+func (t *callerTokenForwardingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	requester, err := identity.GetRequester(req.Context())
+	if err != nil || requester.GetAccessToken() == "" {
+		return t.transport.RoundTrip(req)
+	}
+
+	// Clone the request as RoundTrippers are not expected to mutate the passed request
+	req = utilnet.CloneRequest(req)
+
+	req.Header.Set("X-Access-Token", requester.GetAccessToken())
+	if idToken := requester.GetIDToken(); idToken != "" {
+		req.Header.Set("X-Grafana-Id", idToken)
+	}
+
+	return t.transport.RoundTrip(req)
+}
+
+// WithCallerTokenForwarding returns a copy of the given rest.Config whose transport
+// forwards the caller's tokens. The input config is not modified, so it is safe to
+// pass a shared config such as the loopback config.
+func WithCallerTokenForwarding(config *rest.Config) *rest.Config {
+	configCopy := rest.CopyConfig(config)
+	configCopy.Wrap(func(rt http.RoundTripper) http.RoundTripper {
+		return &callerTokenForwardingRoundTripper{transport: rt}
+	})
+	return configCopy
+}

--- a/pkg/clientauth/roundtripper_test.go
+++ b/pkg/clientauth/roundtripper_test.go
@@ -8,7 +8,11 @@ import (
 	"testing"
 
 	"github.com/grafana/authlib/authn"
+	authlib "github.com/grafana/authlib/types"
 	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
+
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 )
 
 type fakeExchanger struct {
@@ -195,6 +199,72 @@ func TestNewTokenExchangeTransportWrapper(t *testing.T) {
 	require.NotNil(t, exchanger.gotReq)
 	require.Equal(t, []string{"test-audience"}, exchanger.gotReq.Audiences)
 	require.Equal(t, "test-namespace", exchanger.gotReq.Namespace)
+}
+
+func TestWithCallerTokenForwarding(t *testing.T) {
+	tests := []struct {
+		name            string
+		requester       identity.Requester
+		wantAccessToken string
+		wantIDToken     string
+	}{
+		{
+			name: "user with access and id tokens forwards both",
+			requester: &identity.StaticRequester{
+				Type:        authlib.TypeUser,
+				AccessToken: "at-token",
+				IDToken:     "id-token",
+			},
+			wantAccessToken: "at-token",
+			wantIDToken:     "id-token",
+		},
+		{
+			name: "requester with access token only forwards access token",
+			requester: &identity.StaticRequester{
+				Type:        authlib.TypeAccessPolicy,
+				AccessToken: "at-token",
+			},
+			wantAccessToken: "at-token",
+		},
+		{
+			name: "requester without raw tokens leaves request untouched",
+			requester: &identity.StaticRequester{
+				Type: authlib.TypeAccessPolicy,
+			},
+		},
+		{
+			name: "no requester in context leaves request untouched",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got *http.Request
+			config := WithCallerTokenForwarding(&rest.Config{})
+			rt := config.WrapTransport(roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+				got = req
+				rr := httptest.NewRecorder()
+				rr.WriteHeader(http.StatusOK)
+				return rr.Result(), nil
+			}))
+
+			ctx := t.Context()
+			if tt.requester != nil {
+				ctx = identity.WithRequester(ctx, tt.requester)
+			}
+			req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://localhost/apis", nil)
+			require.NoError(t, err)
+
+			resp, err := rt.RoundTrip(req)
+			require.NoError(t, err)
+			_ = resp.Body.Close()
+
+			require.Equal(t, tt.wantAccessToken, got.Header.Get("X-Access-Token"))
+			require.Equal(t, tt.wantIDToken, got.Header.Get("X-Grafana-Id"))
+			require.Empty(t, req.Header.Get("X-Access-Token"))
+			require.Empty(t, req.Header.Get("X-Grafana-Id"))
+		})
+	}
 }
 
 func TestTokenExchangeRoundTripperWithStrategies(t *testing.T) {

--- a/pkg/registry/apis/provisioning/historic_job_storage.go
+++ b/pkg/registry/apis/provisioning/historic_job_storage.go
@@ -1,0 +1,28 @@
+package provisioning
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
+	"k8s.io/apiserver/pkg/registry/rest"
+
+	authlib "github.com/grafana/authlib/types"
+
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	apiutils "github.com/grafana/grafana/pkg/apimachinery/utils"
+)
+
+type historicJobStorage struct {
+	*genericregistry.Store
+}
+
+func (s *historicJobStorage) Create(ctx context.Context, obj runtime.Object, createValidation rest.ValidateObjectFunc, options *metav1.CreateOptions) (runtime.Object, error) {
+	if auth, ok := authlib.AuthInfoFrom(ctx); ok && identity.IsProvisioningServiceIdentity(auth) {
+		if meta, err := apiutils.MetaAccessor(obj); err == nil && meta.GetCreatedBy() != "" {
+			ctx = identity.WithOriginalIdentityUID(ctx, meta.GetCreatedBy())
+		}
+	}
+	return s.Store.Create(ctx, obj, createValidation, options)
+}

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -44,6 +44,7 @@ import (
 	"github.com/grafana/grafana/pkg/apiserver/auditing"
 	grafanaregistry "github.com/grafana/grafana/pkg/apiserver/registry/generic"
 	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
+	"github.com/grafana/grafana/pkg/clientauth"
 	"github.com/grafana/grafana/pkg/infra/nats"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/infra/usagestats"
@@ -948,7 +949,7 @@ func (b *APIBuilder) GetPostStartHooks() (map[string]genericapiserver.PostStartH
 			var config *clientrest.Config
 			var err error
 			if b.restConfigGetter == nil {
-				config = postStartHookCtx.LoopbackClientConfig
+				config = clientauth.WithCallerTokenForwarding(postStartHookCtx.LoopbackClientConfig)
 			} else {
 				config, err = b.restConfigGetter(postStartHookCtx.Context)
 				if err != nil {

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -855,7 +855,7 @@ func (b *APIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver.APIGroupI
 		if err != nil {
 			return fmt.Errorf("create historic job wrapper: %w", err)
 		}
-		storage[provisioning.HistoricJobResourceInfo.StoragePath()] = historicJobStore
+		storage[provisioning.HistoricJobResourceInfo.StoragePath()] = &historicJobStorage{Store: historicJobStore}
 	}
 
 	connectionsStore, err := grafanaregistry.NewRegistryStore(opts.Scheme, provisioning.ConnectionResourceInfo, opts.OptsGetter)


### PR DESCRIPTION
**What is this feature?**

In multi-tenant deployments, jobs created via the repository `jobs` subresource lost the acting user on the API server's internal loopback create — the admission mutator saw a service identity and skipped attribution, so user-triggered sync jobs committed as the default Grafana author. The loopback client now replays the caller's access/ID tokens so admission sees the real requester. Single-tenant is unaffected (in-process loopback already preserves the requester).

Also, archiving a finished job no longer overwrites the HistoricJob's `createdBy` with the provisioning identity — it keeps the original job creator.

**Why do we need this feature?**

`provisioning.userAttribution` attributed direct file-write commits correctly but not job-driven commits in multi-tenant deployments.

**Who is this feature for?**

Git Sync users who need commits and job history attributed to whoever triggered them.

**Special notes for your reviewer:**

Token forwarding only applies when the request context carries raw tokens; background callers (controllers, informers) are unchanged. The tokens are replayed to the same server that already verified them. Verified end-to-end in a multi-tenant environment; unit test covers the forwarding.

---
*Description generated with Claude Code.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)