### PR TITLE
IAM: Fix teams list UI search when team contains special characters

### DIFF
--- a/public/app/features/teams/TeamList.test.tsx
+++ b/public/app/features/teams/TeamList.test.tsx
@@ -84,11 +84,11 @@ describe('TeamList', () => {
         })
       );
 
-      render(<TeamList />);
+      const { user } = render(<TeamList />);
       const input = await screen.findByPlaceholderText('Search teams');
       // Regex-special characters like the hyphen must reach the backend unescaped (not "k8s\-test").
-      await userEvent.click(input);
-      await userEvent.paste('k8s-test alpha');
+      await user.click(input);
+      await user.paste('k8s-test alpha');
 
       await waitFor(() => expect(capturedQuery).toBe('k8s-test alpha'));
     });
@@ -108,10 +108,10 @@ describe('TeamList', () => {
         })
       );
 
-      render(<TeamList />);
+      const { user } = render(<TeamList />);
       const input = await screen.findByPlaceholderText('Search teams');
-      await userEvent.click(input);
-      await userEvent.paste('k8s-test');
+      await user.click(input);
+      await user.paste('k8s-test');
 
       // The initial (empty query) response lists all teams, so wait until the
       // non-matching team is filtered out before asserting on the results.

--- a/public/app/features/teams/TeamList.test.tsx
+++ b/public/app/features/teams/TeamList.test.tsx
@@ -1,3 +1,4 @@
+import { HttpResponse, http } from 'msw';
 import { render, screen, userEvent, waitFor, within } from 'test/test-utils';
 
 import { setBackendSrv } from '@grafana/runtime';
@@ -14,7 +15,7 @@ import { TeamDeleteModal } from './TeamDeleteModal';
 import TeamList from './TeamList';
 
 setBackendSrv(backendSrv);
-setupMockServer();
+const server = setupMockServer();
 
 describe('TeamList', () => {
   beforeEach(() => {
@@ -61,6 +62,61 @@ describe('TeamList', () => {
       render(<TeamList />);
 
       expect(await screen.findByRole('link', { name: /new team/i })).toHaveStyle('pointer-events: none');
+    });
+  });
+
+  describe('when searching teams', () => {
+    it('sends the raw query to the backend without regex-escaping special characters', async () => {
+      let capturedQuery: string | null = null;
+      server.use(
+        http.get('/api/teams/search', ({ request }) => {
+          capturedQuery = new URL(request.url).searchParams.get('query');
+          const teams = MOCK_TEAMS.map((team) => ({
+            name: team.spec.title,
+            uid: team.metadata.name,
+            id: Number(team.metadata.labels['grafana.app/deprecatedInternalID']),
+            orgId: 1,
+            memberCount: 0,
+            permission: 0,
+            accessControl: null,
+          }));
+          return HttpResponse.json({ totalCount: teams.length, teams, page: 1, perPage: 20 });
+        })
+      );
+
+      render(<TeamList />);
+      const input = await screen.findByPlaceholderText('Search teams');
+      // Regex-special characters like the hyphen must reach the backend unescaped (not "k8s\-test").
+      await userEvent.click(input);
+      await userEvent.paste('k8s-test alpha');
+
+      await waitFor(() => expect(capturedQuery).toBe('k8s-test alpha'));
+    });
+
+    it('finds a team whose name contains a hyphen', async () => {
+      // Mimic the backend substring match. With regex-escaping the query becomes
+      // "k8s\-test", which matches nothing; only the raw query "k8s-test" matches.
+      const searchableTeams = [
+        { name: 'k8s-test', uid: 'team-1', id: 1, orgId: 1, memberCount: 0, permission: 0, accessControl: null },
+        { name: 'production', uid: 'team-2', id: 2, orgId: 1, memberCount: 0, permission: 0, accessControl: null },
+      ];
+      server.use(
+        http.get('/api/teams/search', ({ request }) => {
+          const query = (new URL(request.url).searchParams.get('query') ?? '').toLowerCase();
+          const matches = searchableTeams.filter((team) => team.name.toLowerCase().includes(query));
+          return HttpResponse.json({ totalCount: matches.length, teams: matches, page: 1, perPage: 20 });
+        })
+      );
+
+      render(<TeamList />);
+      const input = await screen.findByPlaceholderText('Search teams');
+      await userEvent.click(input);
+      await userEvent.paste('k8s-test');
+
+      // The initial (empty query) response lists all teams, so wait until the
+      // non-matching team is filtered out before asserting on the results.
+      await waitFor(() => expect(screen.queryByText('production')).not.toBeInTheDocument(), { timeout: 5000 });
+      expect(screen.getByText('k8s-test')).toBeInTheDocument();
     });
   });
 

--- a/public/app/features/teams/TeamList.tsx
+++ b/public/app/features/teams/TeamList.tsx
@@ -335,6 +335,7 @@ const TeamList = () => {
                 <FilterInput
                   placeholder={t('teams.team-list.placeholder-search-teams', 'Search teams')}
                   value={query}
+                  escapeRegex={false}
                   onChange={setQuery}
                 />
               </InlineField>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
The Teams admin list search box returns "No teams found" for any query containing a regex-special character (hyphen, ., etc.), so searching for most real team names fails ("Alpha.Team" or "k8s-test" match nothing).
This change sets `escapeRegex={false}` on the `FilterInput`, like `UserListAdminPage` does. This change is secure because the search query is sent to the backend as a bound `SQL LIKE` parameter (not a regex or concatenated SQL).

**Why do we need this feature?**
Before this change, `FilterInput` regex-escapes the query (default `escapeRegex=true`), but `TeamList` passes it straight through as the server query param, so the backend searches for the literal escaped string (`Alpha\ Team`, `k8s\-test`).

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/identity-access-team/issues/2214

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
