### PR TITLE
fix(annotations): enforce time window lower bound for point annotations

### DIFF
--- a/pkg/registry/apps/annotation/postgres_partitioned.go
+++ b/pkg/registry/apps/annotation/postgres_partitioned.go
@@ -365,8 +365,8 @@ func buildListQuery(namespace string, opts ListOptions, offset, limit int64) (st
 	}
 
 	if opts.From > 0 {
-		// Range overlap: annotation's time_end is NULL (point) OR time_end >= from
-		conditions = append(conditions, fmt.Sprintf("(time_end IS NULL OR time_end >= $%d)", argNum))
+		// Check against time for point annotations and time_end for range annotations
+		conditions = append(conditions, fmt.Sprintf("COALESCE(time_end, time) >= $%d", argNum))
 		args = append(args, opts.From)
 		argNum++
 	}

--- a/pkg/registry/apps/annotation/postgres_partitioned.go
+++ b/pkg/registry/apps/annotation/postgres_partitioned.go
@@ -366,7 +366,7 @@ func buildListQuery(namespace string, opts ListOptions, offset, limit int64) (st
 
 	if opts.From > 0 {
 		// Check against time for point annotations and time_end for range annotations
-		conditions = append(conditions, fmt.Sprintf("COALESCE(time_end, time) >= $%d", argNum))
+		conditions = append(conditions, fmt.Sprintf("((time_end IS NULL AND time >= $%d) OR (time_end IS NOT NULL AND time_end >= $%d))", argNum, argNum))
 		args = append(args, opts.From)
 		argNum++
 	}

--- a/pkg/registry/apps/annotation/postgres_store_test.go
+++ b/pkg/registry/apps/annotation/postgres_store_test.go
@@ -129,18 +129,22 @@ func TestIntegrationPostgresStore(t *testing.T) {
 			create(t, "tw-point-before", at(500))
 			create(t, "tw-point-inside", at(1500))
 			create(t, "tw-point-after", at(2500))
-			create(t, "tw-region-overlap", at(500), timeEnd(1500))
+			create(t, "tw-region-overlap-start", at(500), timeEnd(1500))
+			create(t, "tw-region-overlap-end", at(1500), timeEnd(2500))
 			create(t, "tw-region-before", at(100), timeEnd(500))
+			create(t, "tw-region-after", at(2500), timeEnd(3000))
 
 			list, err := store.List(ctx, ns, ListOptions{DashboardUID: twDash, From: from, To: to})
 			require.NoError(t, err)
 
 			names := annotationNames(list)
 			assert.Contains(t, names, "tw-point-inside")
-			assert.Contains(t, names, "tw-region-overlap")
+			assert.Contains(t, names, "tw-region-overlap-start")
+			assert.Contains(t, names, "tw-region-overlap-end")
 			assert.NotContains(t, names, "tw-point-before")
 			assert.NotContains(t, names, "tw-point-after")
 			assert.NotContains(t, names, "tw-region-before")
+			assert.NotContains(t, names, "tw-region-after")
 		})
 
 		t.Run("Filters by tags requiring all to match", func(t *testing.T) {

--- a/pkg/registry/apps/annotation/postgres_store_test.go
+++ b/pkg/registry/apps/annotation/postgres_store_test.go
@@ -92,12 +92,104 @@ func TestIntegrationPostgresStore(t *testing.T) {
 		require.ErrorIs(t, err, ErrNotFound)
 	})
 
-	t.Run("List filters by dashboard UID", func(t *testing.T) {
-		create(t, "list-dash", func(a *annotationV0.Annotation) { a.Spec.DashboardUID = &dashboardUID })
+	t.Run("List", func(t *testing.T) {
+		t.Run("Filters by dashboard UID", func(t *testing.T) {
+			create(t, "list-dash", func(a *annotationV0.Annotation) { a.Spec.DashboardUID = &dashboardUID })
 
-		list, err := store.List(ctx, ns, ListOptions{DashboardUID: dashboardUID})
-		require.NoError(t, err)
-		assert.Contains(t, annotationNames(list), "list-dash")
+			list, err := store.List(ctx, ns, ListOptions{DashboardUID: dashboardUID})
+			require.NoError(t, err)
+			assert.Contains(t, annotationNames(list), "list-dash")
+		})
+
+		t.Run("Filters by panel ID", func(t *testing.T) {
+			panelID := int64(42)
+			create(t, "panel-match", func(a *annotationV0.Annotation) { a.Spec.PanelID = &panelID })
+			create(t, "panel-other", func(a *annotationV0.Annotation) { other := int64(43); a.Spec.PanelID = &other })
+
+			list, err := store.List(ctx, ns, ListOptions{PanelID: panelID})
+			require.NoError(t, err)
+			names := annotationNames(list)
+			assert.Contains(t, names, "panel-match")
+			assert.NotContains(t, names, "panel-other")
+		})
+
+		t.Run("Filters by time window", func(t *testing.T) {
+			twDash := "tw-dash"
+			from, to := int64(1000), int64(2000)
+			timeEnd := func(v int64) func(*annotationV0.Annotation) {
+				return func(a *annotationV0.Annotation) { a.Spec.TimeEnd = &v }
+			}
+			at := func(v int64) func(*annotationV0.Annotation) {
+				return func(a *annotationV0.Annotation) {
+					a.Spec.Time = v
+					a.Spec.DashboardUID = &twDash
+				}
+			}
+
+			create(t, "tw-point-before", at(500))
+			create(t, "tw-point-inside", at(1500))
+			create(t, "tw-point-after", at(2500))
+			create(t, "tw-region-overlap", at(500), timeEnd(1500))
+			create(t, "tw-region-before", at(100), timeEnd(500))
+
+			list, err := store.List(ctx, ns, ListOptions{DashboardUID: twDash, From: from, To: to})
+			require.NoError(t, err)
+
+			names := annotationNames(list)
+			assert.Contains(t, names, "tw-point-inside")
+			assert.Contains(t, names, "tw-region-overlap")
+			assert.NotContains(t, names, "tw-point-before")
+			assert.NotContains(t, names, "tw-point-after")
+			assert.NotContains(t, names, "tw-region-before")
+		})
+
+		t.Run("Filters by tags requiring all to match", func(t *testing.T) {
+			tags := func(vs ...string) func(*annotationV0.Annotation) {
+				return func(a *annotationV0.Annotation) { a.Spec.Tags = vs }
+			}
+			create(t, "tags-all-both", tags("red", "blue"))
+			create(t, "tags-all-one", tags("red"))
+
+			list, err := store.List(ctx, ns, ListOptions{Tags: []string{"red", "blue"}})
+			require.NoError(t, err)
+			names := annotationNames(list)
+			assert.Contains(t, names, "tags-all-both")
+			assert.NotContains(t, names, "tags-all-one")
+		})
+
+		t.Run("Filters by tags matching any", func(t *testing.T) {
+			tags := func(vs ...string) func(*annotationV0.Annotation) {
+				return func(a *annotationV0.Annotation) { a.Spec.Tags = vs }
+			}
+			create(t, "tags-any-match", tags("green"))
+			create(t, "tags-any-miss", tags("yellow"))
+
+			list, err := store.List(ctx, ns, ListOptions{Tags: []string{"green", "orange"}, TagsMatchAny: true})
+			require.NoError(t, err)
+			names := annotationNames(list)
+			assert.Contains(t, names, "tags-any-match")
+			assert.NotContains(t, names, "tags-any-miss")
+		})
+
+		t.Run("Paginates with a continue token", func(t *testing.T) {
+			pageDash := "page-dash"
+			for _, name := range []string{"page-a", "page-b", "page-c"} {
+				create(t, name, func(a *annotationV0.Annotation) { a.Spec.DashboardUID = &pageDash })
+			}
+
+			first, err := store.List(ctx, ns, ListOptions{DashboardUID: pageDash, Limit: 2})
+			require.NoError(t, err)
+			require.Len(t, first.Items, 2)
+			require.NotEmpty(t, first.Continue, "expected a continue token when more results remain")
+
+			second, err := store.List(ctx, ns, ListOptions{DashboardUID: pageDash, Limit: 2, Continue: first.Continue})
+			require.NoError(t, err)
+			require.Len(t, second.Items, 1)
+			assert.Empty(t, second.Continue, "expected no continue token on the final page")
+
+			all := append(annotationNames(first), annotationNames(second)...)
+			assert.ElementsMatch(t, []string{"page-a", "page-b", "page-c"}, all)
+		})
 	})
 
 	t.Run("Delete of a missing annotation returns ErrNotFound", func(t *testing.T) {


### PR DESCRIPTION
This PR fixes an issue with the annotation app platform API where the time window lower bound (`from`) was not being enforced for point annotations since the WHERE clause matched any record where `time_end IS NULL`. This PR changes the query to align with how we handle point annotations in the legacy API, checking against `time_end` for range annotations and `time` for point annotations (see [here](https://github.com/grafana/grafana/blob/b40e2e8a6c0e24a7fa8e5edeba7c1dc3e3465137/pkg/services/annotations/annotationsimpl/xorm_store.go#L27-L32) where we set `EpochEnd` to `Epoch` for point annotations in the legacy API).

This issue was noticed when adding integration tests for the `List` store function for Postgres, so the PR includes additional test cases for other core `List` functionality as well.