### PR TITLE
Provisioning: add ability to force full pull instead of incremental sync

### DIFF
--- a/public/app/features/provisioning/Repository/SyncRepository.test.tsx
+++ b/public/app/features/provisioning/Repository/SyncRepository.test.tsx
@@ -1,0 +1,158 @@
+import { render, screen } from 'test/test-utils';
+
+import { reportInteraction } from '@grafana/runtime';
+import {
+  type Repository,
+  useCreateRepositoryJobsMutation,
+  useListJobQuery,
+} from 'app/api/clients/provisioning/v0alpha1';
+import { appEvents } from 'app/core/app_events';
+import { ShowConfirmModalEvent } from 'app/types/events';
+
+import { SyncRepository } from './SyncRepository';
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  reportInteraction: jest.fn(),
+}));
+
+jest.mock('app/api/clients/provisioning/v0alpha1', () => ({
+  ...jest.requireActual('app/api/clients/provisioning/v0alpha1'),
+  useCreateRepositoryJobsMutation: jest.fn(),
+  useListJobQuery: jest.fn(),
+}));
+
+const mockCreateJob = jest.fn();
+
+const createMockRepository = (overrides: Partial<Repository> = {}): Repository => ({
+  metadata: { name: 'test-repo' },
+  spec: {
+    title: 'Test Repository',
+    type: 'github',
+    sync: { target: 'folder', enabled: true },
+    workflows: [],
+    github: {
+      url: 'https://github.com/owner/repo',
+      branch: 'main',
+    },
+  },
+  status: {
+    health: { healthy: true, checked: 0 },
+    sync: { state: 'success', message: [] },
+    observedGeneration: 1,
+    webhook: {},
+  },
+  ...overrides,
+});
+
+const setActiveJobs = (items: unknown[] = []) => {
+  jest.mocked(useListJobQuery).mockReturnValue({ data: { items } } as unknown as ReturnType<typeof useListJobQuery>);
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.mocked(useCreateRepositoryJobsMutation).mockReturnValue([mockCreateJob, { isLoading: false, reset: jest.fn() }]);
+  setActiveJobs([]);
+});
+
+describe('SyncRepository', () => {
+  it('renders the pull button', () => {
+    render(<SyncRepository repository={createMockRepository()} />);
+
+    expect(screen.getByRole('button', { name: /pull/i })).toBeInTheDocument();
+  });
+
+  it('disables the button and shows a tooltip when the repository is unhealthy', () => {
+    const repo = createMockRepository({
+      status: {
+        health: { healthy: false, checked: 0 },
+        sync: { state: 'success', message: [] },
+        observedGeneration: 1,
+        webhook: {},
+      },
+    });
+    render(<SyncRepository repository={repo} />);
+
+    // With a tooltip present, grafana-ui uses aria-disabled (not the native
+    // disabled attribute) so the tooltip still fires on hover.
+    expect(screen.getByRole('button', { name: /pull/i })).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('disables the button when a job is already working', () => {
+    setActiveJobs([{ status: { state: 'working' } }]);
+    render(<SyncRepository repository={createMockRepository()} />);
+
+    expect(screen.getByRole('button', { name: /pull/i })).toBeDisabled();
+  });
+
+  it('disables the button when a job is pending', () => {
+    setActiveJobs([{ status: { state: 'pending' } }]);
+    render(<SyncRepository repository={createMockRepository()} />);
+
+    expect(screen.getByRole('button', { name: /pull/i })).toBeDisabled();
+  });
+
+  it('disables the button while the create job mutation is loading', () => {
+    jest
+      .mocked(useCreateRepositoryJobsMutation)
+      .mockReturnValue([mockCreateJob, { isLoading: true, reset: jest.fn() }]);
+    render(<SyncRepository repository={createMockRepository()} />);
+
+    expect(screen.getByRole('button', { name: /pull/i })).toBeDisabled();
+  });
+
+  it('triggers an incremental pull and reports the interaction', async () => {
+    const { user } = render(<SyncRepository repository={createMockRepository()} />);
+
+    await user.click(screen.getByRole('button', { name: /pull/i }));
+    await user.click(screen.getByRole('menuitem', { name: /pull based on diff/i }));
+
+    expect(mockCreateJob).toHaveBeenCalledWith({
+      name: 'test-repo',
+      jobSpec: { action: 'pull', pull: { incremental: true } },
+    });
+    expect(reportInteraction).toHaveBeenCalledWith('grafana_provisioning_repository_pull_triggered', {
+      repositoryName: 'test-repo',
+      repositoryType: 'github',
+      target: 'folder',
+      incremental: true,
+    });
+  });
+
+  it('asks for confirmation before a full pull and triggers it on confirm', async () => {
+    const publishSpy = jest.spyOn(appEvents, 'publish');
+    const { user } = render(<SyncRepository repository={createMockRepository()} />);
+
+    await user.click(screen.getByRole('button', { name: /pull/i }));
+    await user.click(screen.getByRole('menuitem', { name: /force full pull/i }));
+
+    // The confirm modal is shown via an app event; the job is not created yet.
+    expect(publishSpy).toHaveBeenCalledWith(expect.any(ShowConfirmModalEvent));
+    expect(mockCreateJob).not.toHaveBeenCalled();
+
+    const event = publishSpy.mock.calls[0][0] as ShowConfirmModalEvent;
+    event.payload.onConfirm?.();
+
+    expect(mockCreateJob).toHaveBeenCalledWith({
+      name: 'test-repo',
+      jobSpec: { action: 'pull', pull: { incremental: false } },
+    });
+    expect(reportInteraction).toHaveBeenCalledWith('grafana_provisioning_repository_pull_triggered', {
+      repositoryName: 'test-repo',
+      repositoryType: 'github',
+      target: 'folder',
+      incremental: false,
+    });
+  });
+
+  it('does not trigger a pull when the repository has no name', async () => {
+    const repo = createMockRepository({ metadata: {} });
+    const { user } = render(<SyncRepository repository={repo} />);
+
+    // No name means the button is disabled, so the menu cannot be opened.
+    expect(screen.getByRole('button', { name: /pull/i })).toBeDisabled();
+    await user.click(screen.getByRole('button', { name: /pull/i }));
+    expect(screen.queryByRole('menuitem')).not.toBeInTheDocument();
+    expect(mockCreateJob).not.toHaveBeenCalled();
+  });
+});

--- a/public/app/features/provisioning/Repository/SyncRepository.tsx
+++ b/public/app/features/provisioning/Repository/SyncRepository.tsx
@@ -1,7 +1,9 @@
 import { Trans, t } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
-import { Button } from '@grafana/ui';
+import { Button, Dropdown, Icon, Menu, Stack } from '@grafana/ui';
 import { type Repository, useCreateRepositoryJobsMutation } from 'app/api/clients/provisioning/v0alpha1';
+import { appEvents } from 'app/core/app_events';
+import { ShowConfirmModalEvent } from 'app/types/events';
 
 import { useGetActiveJob } from '../useGetActiveJob';
 
@@ -14,7 +16,7 @@ export function SyncRepository({ repository }: Props) {
   const name = repository.metadata?.name;
   const activeJob = useGetActiveJob(name);
 
-  const onClick = () => {
+  const triggerPull = (incremental: boolean) => {
     if (!name) {
       return;
     }
@@ -22,41 +24,78 @@ export function SyncRepository({ repository }: Props) {
       repositoryName: name,
       repositoryType: repository.spec?.type ?? 'unknown',
       target: repository.spec?.sync.target ?? 'unknown',
+      incremental,
     });
     createJob({
       name,
       jobSpec: {
         action: 'pull',
         pull: {
-          incremental: false, // will queue a full resync job
+          incremental,
         },
       },
     });
   };
 
+  const confirmFullPull = () => {
+    appEvents.publish(
+      new ShowConfirmModalEvent({
+        title: t('provisioning.sync-repository.title-force-full-pull', 'Force full pull?'),
+        text: t(
+          'provisioning.sync-repository.confirm-force-full-pull',
+          'Are you sure you want to do a full pull? This may take a while, so only continue if you have resources that are unexpectedly not syncing.'
+        ),
+        yesText: t('provisioning.sync-repository.button-force-full-pull', 'Force full pull'),
+        noText: t('provisioning.sync-repository.button-cancel', 'Cancel'),
+        onConfirm: () => triggerPull(false),
+      })
+    );
+  };
+
   const isHealthy = Boolean(repository.status?.health.healthy);
+  const isBusy = jobQuery.isLoading || activeJob?.status?.state === 'working' || activeJob?.status?.state === 'pending';
+  const disabled = isBusy || !name || !isHealthy;
+
+  const menu = (
+    <Menu>
+      <Menu.Item
+        label={t('provisioning.sync-repository.pull-diff', 'Pull based on diff')}
+        icon="cloud-download"
+        description={t(
+          'provisioning.sync-repository.pull-diff-description',
+          'Syncs only the changes since the last synced commit. Use for routine updates.'
+        )}
+        onClick={() => triggerPull(true)}
+      />
+      <Menu.Item
+        label={t('provisioning.sync-repository.pull-full', 'Force full pull')}
+        icon="sync"
+        description={t(
+          'provisioning.sync-repository.pull-full-description',
+          'Re-reads every file in the repository and reconciles all resources, including removing orphaned ones. This may be a long running job that will prevent other syncs while it completes. Use only when there are unexpected issues. '
+        )}
+        onClick={confirmFullPull}
+      />
+    </Menu>
+  );
 
   return (
-    <>
+    <Dropdown overlay={menu} placement="bottom-start">
       <Button
         icon="cloud-download"
-        variant={'secondary'}
+        variant="secondary"
         tooltip={
           isHealthy
             ? undefined
             : t('provisioning.sync-repository.tooltip-unhealthy-repository', 'Unable to pull an unhealthy repository')
         }
-        disabled={
-          jobQuery.isLoading ||
-          activeJob?.status?.state === 'working' ||
-          activeJob?.status?.state === 'pending' ||
-          !name ||
-          !isHealthy
-        }
-        onClick={onClick}
+        disabled={disabled}
       >
-        <Trans i18nKey="provisioning.sync-repository.pull">Pull</Trans>
+        <Stack alignItems="center" gap={0.5}>
+          <Trans i18nKey="provisioning.sync-repository.pull">Pull</Trans>
+          <Icon name="angle-down" />
+        </Stack>
       </Button>
-    </>
+    </Dropdown>
   );
 }

--- a/public/app/features/provisioning/Repository/SyncRepository.tsx
+++ b/public/app/features/provisioning/Repository/SyncRepository.tsx
@@ -59,23 +59,10 @@ export function SyncRepository({ repository }: Props) {
   const menu = (
     <Menu>
       <Menu.Item
-        label={t('provisioning.sync-repository.pull-diff', 'Pull based on diff')}
-        icon="cloud-download"
-        description={t(
-          'provisioning.sync-repository.pull-diff-description',
-          'Syncs only the changes since the last synced commit. Use for routine updates.'
-        )}
+        label={t('provisioning.sync-repository.pull-diff', 'Pull based on diff (default)')}
         onClick={() => triggerPull(true)}
       />
-      <Menu.Item
-        label={t('provisioning.sync-repository.pull-full', 'Force full pull')}
-        icon="sync"
-        description={t(
-          'provisioning.sync-repository.pull-full-description',
-          'Re-reads every file in the repository and reconciles all resources, including removing orphaned ones. This may be a long running job that will prevent other syncs while it completes. Use only when there are unexpected issues. '
-        )}
-        onClick={confirmFullPull}
-      />
+      <Menu.Item label={t('provisioning.sync-repository.pull-full', 'Force full pull')} onClick={confirmFullPull} />
     </Menu>
   );
 

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -13919,10 +13919,8 @@
       "confirm-force-full-pull": "Are you sure you want to do a full pull? This may take a while, so only continue if you have resources that are unexpectedly not syncing.",
       "error-pulling-resources": "Error pulling resources",
       "pull": "Pull",
-      "pull-diff": "Pull based on diff",
-      "pull-diff-description": "Syncs only the changes since the last synced commit. Use for routine updates.",
+      "pull-diff": "Pull based on diff (default)",
       "pull-full": "Force full pull",
-      "pull-full-description": "Re-reads every file in the repository and reconciles all resources, including removing orphaned ones. This may be a long running job that will prevent other syncs while it completes. Use only when there are unexpected issues. ",
       "success-pull-started": "Pull started",
       "title-force-full-pull": "Force full pull?",
       "tooltip-unhealthy-repository": "Unable to pull an unhealthy repository"

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -13914,9 +13914,17 @@
       "migrate-default-message": "Migrate Grafana resources into repository"
     },
     "sync-repository": {
+      "button-cancel": "Cancel",
+      "button-force-full-pull": "Force full pull",
+      "confirm-force-full-pull": "Are you sure you want to do a full pull? This may take a while, so only continue if you have resources that are unexpectedly not syncing.",
       "error-pulling-resources": "Error pulling resources",
       "pull": "Pull",
+      "pull-diff": "Pull based on diff",
+      "pull-diff-description": "Syncs only the changes since the last synced commit. Use for routine updates.",
+      "pull-full": "Force full pull",
+      "pull-full-description": "Re-reads every file in the repository and reconciles all resources, including removing orphaned ones. This may be a long running job that will prevent other syncs while it completes. Use only when there are unexpected issues. ",
       "success-pull-started": "Pull started",
+      "title-force-full-pull": "Force full pull?",
       "tooltip-unhealthy-repository": "Unable to pull an unhealthy repository"
     },
     "synchronize-step": {


### PR DESCRIPTION
**What is this feature?**
Add option in UI to run full sync. 

https://github.com/user-attachments/assets/4b4e44b7-1cc5-4ec5-96ba-a6903cca457c



**Why do we need this feature?**
Previously the backend would determine [what kind of sync](https://github.com/grafana/grafana/blob/439720e90268090959923fde2e02ffd6e2e15abf/pkg/registry/apis/provisioning/controller/repository.go#L408) we would run. Allow users from UI to trigger a full sync. 

**Who is this feature for?**
users migrating 

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/1277

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
