### PR TITLE
[release-12.4.6] Azure Monitor Pagination: Log groups/Subscriptions

### DIFF
--- a/public/app/plugins/datasource/azuremonitor/azure_log_analytics/azure_log_analytics_datasource.test.ts
+++ b/public/app/plugins/datasource/azuremonitor/azure_log_analytics/azure_log_analytics_datasource.test.ts
@@ -127,6 +127,29 @@ describe('AzureLogAnalyticsDatasource', () => {
       const workspaces = await ctx.datasource.azureLogAnalyticsDatasource.getWorkspaces('sub');
       expect(workspaces).toEqual([{ text: 'foobar', value: 'foo' }]);
     });
+
+    it('follows nextLink and aggregates workspaces across pages', async () => {
+      const getResource = jest
+        .fn()
+        .mockResolvedValueOnce({
+          value: [{ name: 'ws-1', id: 'id-1', properties: { customerId: 'c1' } }],
+          nextLink:
+            'https://management.azure.com/subscriptions/sub/providers/Microsoft.OperationalInsights/workspaces?api-version=2017-04-26-preview&$skiptoken=TOKEN',
+        })
+        .mockResolvedValueOnce({ value: [{ name: 'ws-2', id: 'id-2', properties: { customerId: 'c2' } }] });
+      ctx.datasource.azureLogAnalyticsDatasource.getResource = getResource;
+
+      const workspaces = await ctx.datasource.azureLogAnalyticsDatasource.getWorkspaces('sub');
+
+      expect(getResource).toHaveBeenCalledTimes(2);
+      expect(getResource.mock.calls[1][0]).toBe(
+        'azuremonitor/subscriptions/sub/providers/Microsoft.OperationalInsights/workspaces?api-version=2017-04-26-preview&$skiptoken=TOKEN'
+      );
+      expect(workspaces).toEqual([
+        { text: 'ws-1', value: 'id-1' },
+        { text: 'ws-2', value: 'id-2' },
+      ]);
+    });
   });
 
   describe('When performing getFirstWorkspace', () => {

--- a/public/app/plugins/datasource/azuremonitor/azure_log_analytics/azure_log_analytics_datasource.ts
+++ b/public/app/plugins/datasource/azuremonitor/azure_log_analytics/azure_log_analytics_datasource.ts
@@ -17,7 +17,7 @@ import {
   DatasourceValidationResult,
   Subscription,
 } from '../types/types';
-import { interpolateVariable, routeNames } from '../utils/common';
+import { fetchAllArmPages, interpolateVariable, routeNames } from '../utils/common';
 
 import { transformMetadataToKustoSchema } from './utils';
 
@@ -66,32 +66,33 @@ export default class AzureLogAnalyticsDatasource extends DataSourceWithBackend<
       return [];
     }
 
-    const path = `${this.azureMonitorPath}?api-version=2019-03-01`;
-    return await this.getResource<AzureAPIResponse<Subscription>>(path).then((result) => {
-      return ResponseParser.parseSubscriptions(result);
-    });
+    const value = await fetchAllArmPages<Subscription>(
+      routeNames.azureMonitor,
+      `${this.azureMonitorPath}?api-version=2019-03-01`,
+      (path) => this.getResource<AzureAPIResponse<Subscription>>(path)
+    );
+    return ResponseParser.parseSubscriptions({ value });
   }
 
   async getWorkspaces(subscription: string): Promise<AzureLogsVariable[]> {
-    const response = await this.getWorkspaceList(subscription);
+    const subscriptionId = this.templateSrv.replace(subscription || this.defaultSubscriptionId);
+
+    const workspaceListUrl =
+      this.azureMonitorPath +
+      `/${subscriptionId}/providers/Microsoft.OperationalInsights/workspaces?api-version=2017-04-26-preview`;
+
+    const value = await fetchAllArmPages<Workspace>(routeNames.azureMonitor, workspaceListUrl, (path) =>
+      this.getResource<AzureAPIResponse<Workspace>>(path)
+    );
 
     return (
-      map(response.value, (val: Workspace) => {
+      map(value, (val: Workspace) => {
         return {
           text: val.name,
           value: val.id,
         };
       }) || []
     );
-  }
-
-  private getWorkspaceList(subscription: string): Promise<AzureAPIResponse<Workspace>> {
-    const subscriptionId = this.templateSrv.replace(subscription || this.defaultSubscriptionId);
-
-    const workspaceListUrl =
-      this.azureMonitorPath +
-      `/${subscriptionId}/providers/Microsoft.OperationalInsights/workspaces?api-version=2017-04-26-preview`;
-    return this.getResource<AzureAPIResponse<Workspace>>(workspaceListUrl);
   }
 
   async getMetadata(resourceUri: string) {

--- a/public/app/plugins/datasource/azuremonitor/azure_monitor/azure_monitor_datasource.test.ts
+++ b/public/app/plugins/datasource/azuremonitor/azure_monitor/azure_monitor_datasource.test.ts
@@ -756,6 +756,30 @@ describe('AzureMonitorDatasource', () => {
           expect(results[0].value).toEqual('99999999-cccc-bbbb-aaaa-9106972f9572');
         });
       });
+
+      it('should follow nextLink and aggregate all pages of subscriptions', async () => {
+        const firstPage = {
+          value: [
+            { subscriptionId: 'sub-1', displayName: 'Subscription 1' },
+            { subscriptionId: 'sub-2', displayName: 'Subscription 2' },
+          ],
+          nextLink: 'https://management.azure.com/subscriptions?api-version=2019-03-01&$skiptoken=TOKEN123',
+        };
+        const secondPage = {
+          value: [{ subscriptionId: 'sub-3', displayName: 'Subscription 3' }],
+        };
+        const getResource = jest.fn().mockResolvedValueOnce(firstPage).mockResolvedValueOnce(secondPage);
+        ctx.ds.azureMonitorDatasource.getResource = getResource;
+
+        const results = await ctx.ds.getSubscriptions();
+
+        expect(results.map((r: { value: string }) => r.value)).toEqual(['sub-1', 'sub-2', 'sub-3']);
+        expect(getResource).toHaveBeenCalledTimes(2);
+        expect(getResource).toHaveBeenNthCalledWith(
+          2,
+          'azuremonitor/subscriptions?api-version=2019-03-01&$skiptoken=TOKEN123'
+        );
+      });
     });
 
     describe('When performing getResourceGroups', () => {

--- a/public/app/plugins/datasource/azuremonitor/azure_monitor/azure_monitor_datasource.ts
+++ b/public/app/plugins/datasource/azuremonitor/azure_monitor/azure_monitor_datasource.ts
@@ -27,7 +27,7 @@ import {
   Subscription,
   TablePlan,
 } from '../types/types';
-import { replaceTemplateVariables, routeNames } from '../utils/common';
+import { fetchAllArmPages, replaceTemplateVariables, routeNames } from '../utils/common';
 import migrateQuery from '../utils/migrateQuery';
 
 import ResponseParser from './response_parser';
@@ -171,11 +171,12 @@ export default class AzureMonitorDatasource extends DataSourceWithBackend<
       return [];
     }
 
-    return this.getResource<AzureAPIResponse<Subscription>>(
-      `${this.resourcePath}/subscriptions?api-version=2019-03-01`
-    ).then((result) => {
-      return ResponseParser.parseSubscriptions(result);
-    });
+    const value = await fetchAllArmPages<Subscription>(
+      this.resourcePath,
+      `${this.resourcePath}/subscriptions?api-version=2019-03-01`,
+      (path) => this.getResource<AzureAPIResponse<Subscription>>(path)
+    );
+    return ResponseParser.parseSubscriptions({ value });
   }
 
   // Note globalRegion should be false when querying custom metric namespaces

--- a/public/app/plugins/datasource/azuremonitor/azure_monitor/response_parser.ts
+++ b/public/app/plugins/datasource/azuremonitor/azure_monitor/response_parser.ts
@@ -1,7 +1,5 @@
 import { find, get } from 'lodash';
 
-import { FetchResponse } from '@grafana/runtime';
-
 import TimeGrainConverter from '../time_grain_converter';
 import {
   AzureAPIResponse,
@@ -114,9 +112,7 @@ export default class ResponseParser {
     return list;
   }
 
-  static parseSubscriptionsForSelect(
-    result?: FetchResponse<AzureAPIResponse<Subscription>>
-  ): Array<{ label: string; value: string }> {
+  static parseSubscriptionsForSelect(result?: AzureAPIResponse<Subscription>): Array<{ label: string; value: string }> {
     const list: Array<{ label: string; value: string }> = [];
 
     if (!result) {
@@ -125,11 +121,11 @@ export default class ResponseParser {
 
     const valueFieldName = 'subscriptionId';
     const textFieldName = 'displayName';
-    for (let i = 0; i < result.data.value.length; i++) {
-      if (!find(list, ['value', get(result.data.value[i], valueFieldName)])) {
+    for (let i = 0; i < result.value.length; i++) {
+      if (!find(list, ['value', get(result.value[i], valueFieldName)])) {
         list.push({
-          label: `${get(result.data.value[i], textFieldName)} - ${get(result.data.value[i], valueFieldName)}`,
-          value: get(result.data.value[i], valueFieldName),
+          label: `${get(result.value[i], textFieldName)} - ${get(result.value[i], valueFieldName)}`,
+          value: get(result.value[i], valueFieldName),
         });
       }
     }

--- a/public/app/plugins/datasource/azuremonitor/components/ConfigEditor/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/ConfigEditor/ConfigEditor.tsx
@@ -72,7 +72,7 @@ export class ConfigEditor extends PureComponent<Props, State> {
     await this.saveOptions();
 
     const query = `?api-version=2019-03-01`;
-    const resourcesPrefix = `/api/datasources/${this.props.options.id}/resources/${routeNames.azureMonitor}`;
+    const resourcesPrefix = `/api/datasources/uid/${this.props.options.uid}/resources/${routeNames.azureMonitor}`;
     try {
       const value = await fetchAllArmPages<Subscription>(resourcesPrefix, this.baseURL + query, async (url) => {
         const response = await getBackendSrv()

--- a/public/app/plugins/datasource/azuremonitor/components/ConfigEditor/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/ConfigEditor/ConfigEditor.tsx
@@ -14,7 +14,7 @@ import {
   AzureMonitorDataSourceSettings,
   Subscription,
 } from '../../types/types';
-import { routeNames } from '../../utils/common';
+import { fetchAllArmPages, routeNames } from '../../utils/common';
 
 import { MonitorConfig } from './MonitorConfig';
 
@@ -72,16 +72,17 @@ export class ConfigEditor extends PureComponent<Props, State> {
     await this.saveOptions();
 
     const query = `?api-version=2019-03-01`;
+    const resourcesPrefix = `/api/datasources/${this.props.options.id}/resources/${routeNames.azureMonitor}`;
     try {
-      const result = await getBackendSrv()
-        .fetch<AzureAPIResponse<Subscription>>({
-          url: this.baseURL + query,
-          method: 'GET',
-        })
-        .toPromise();
+      const value = await fetchAllArmPages<Subscription>(resourcesPrefix, this.baseURL + query, async (url) => {
+        const response = await getBackendSrv()
+          .fetch<AzureAPIResponse<Subscription>>({ url, method: 'GET' })
+          .toPromise();
+        return response?.data;
+      });
 
       this.setState({ error: undefined });
-      return ResponseParser.parseSubscriptionsForSelect(result);
+      return ResponseParser.parseSubscriptionsForSelect({ value });
     } catch (err) {
       if (isFetchError(err)) {
         this.setState({

--- a/public/app/plugins/datasource/azuremonitor/locales/en-US/grafana-azure-monitor-datasource.json
+++ b/public/app/plugins/datasource/azuremonitor/locales/en-US/grafana-azure-monitor-datasource.json
@@ -198,6 +198,10 @@
       "label-order-by": "Order By",
       "tooltip-order-by": "Sort results based on one or more columns in ascending or descending order."
     },
+    "pagination": {
+      "results-truncated-message": "Stopped loading after {{maxPages}} pages; some results may be omitted.",
+      "results-truncated-title": "Azure Monitor"
+    },
     "query-editor": {
       "alert-error-occurred": "An error occurred while requesting metadata from Azure Monitor"
     },

--- a/public/app/plugins/datasource/azuremonitor/types/types.ts
+++ b/public/app/plugins/datasource/azuremonitor/types/types.ts
@@ -265,6 +265,7 @@ export interface AzureAPIResponse<T> {
   };
   status?: number;
   statusText?: string;
+  nextLink?: string;
 }
 
 export interface AzureLogAnalyticsTable {

--- a/public/app/plugins/datasource/azuremonitor/utils/common.test.ts
+++ b/public/app/plugins/datasource/azuremonitor/utils/common.test.ts
@@ -1,6 +1,13 @@
+import { logWarning } from '@grafana/runtime';
+
 import { initialCustomVariableModelState } from '../mocks/variables';
 
 import { fetchAllArmPages, hasOption, interpolateVariable, MAX_ARM_PAGES, nextLinkToPath } from './common';
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  logWarning: jest.fn(),
+}));
 
 describe('AzureMonitor: hasOption', () => {
   it('can find an option in flat array', () => {
@@ -60,6 +67,10 @@ describe('AzureMonitor: nextLinkToPath', () => {
 });
 
 describe('AzureMonitor: fetchAllArmPages', () => {
+  beforeEach(() => {
+    jest.mocked(logWarning).mockClear();
+  });
+
   it('returns the single page when there is no nextLink', async () => {
     const fetchPage = jest.fn().mockResolvedValue({ value: [{ id: 1 }, { id: 2 }] });
 
@@ -87,15 +98,13 @@ describe('AzureMonitor: fetchAllArmPages', () => {
 
   it('stops early and warns when a page returns no result', async () => {
     const fetchPage = jest.fn().mockResolvedValue(undefined);
-    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
 
     const results = await fetchAllArmPages('azuremonitor', 'azuremonitor/subscriptions?api-version=x', fetchPage);
 
     expect(results).toEqual([]);
     expect(fetchPage).toHaveBeenCalledTimes(1);
-    expect(warn).toHaveBeenCalledTimes(1);
-    expect(warn).toHaveBeenCalledWith('[azuremonitor] ARM page request returned no result; stopping pagination.');
-    warn.mockRestore();
+    expect(logWarning).toHaveBeenCalledTimes(1);
+    expect(logWarning).toHaveBeenCalledWith('[azuremonitor] ARM page request returned no result; stopping pagination.');
   });
 
   it('does not emit the page-cap warning when a later page returns no result', async () => {
@@ -106,15 +115,13 @@ describe('AzureMonitor: fetchAllArmPages', () => {
         nextLink: 'https://management.azure.com/subscriptions?api-version=x&$skiptoken=abc',
       })
       .mockResolvedValueOnce(undefined);
-    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
 
     const results = await fetchAllArmPages('azuremonitor', 'azuremonitor/subscriptions?api-version=x', fetchPage);
 
     expect(results).toEqual([{ id: 1 }]);
-    expect(warn).toHaveBeenCalledTimes(1);
-    expect(warn).toHaveBeenCalledWith('[azuremonitor] ARM page request returned no result; stopping pagination.');
-    expect(warn).not.toHaveBeenCalledWith(expect.stringContaining('ARM listing stopped after'));
-    warn.mockRestore();
+    expect(logWarning).toHaveBeenCalledTimes(1);
+    expect(logWarning).toHaveBeenCalledWith('[azuremonitor] ARM page request returned no result; stopping pagination.');
+    expect(logWarning).not.toHaveBeenCalledWith(expect.stringContaining('ARM listing stopped after'));
   });
 
   it('stops after MAX_ARM_PAGES even if nextLink never clears, and warns', async () => {
@@ -122,17 +129,15 @@ describe('AzureMonitor: fetchAllArmPages', () => {
       value: [{ id: 1 }],
       nextLink: 'https://management.azure.com/subscriptions?api-version=x&$skiptoken=loop',
     });
-    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
 
     const results = await fetchAllArmPages('azuremonitor', 'azuremonitor/subscriptions?api-version=x', fetchPage);
 
     expect(fetchPage).toHaveBeenCalledTimes(MAX_ARM_PAGES);
     expect(results).toHaveLength(MAX_ARM_PAGES);
-    expect(warn).toHaveBeenCalledTimes(1);
-    expect(warn).toHaveBeenCalledWith(
+    expect(logWarning).toHaveBeenCalledTimes(1);
+    expect(logWarning).toHaveBeenCalledWith(
       `[azuremonitor] ARM listing stopped after ${MAX_ARM_PAGES} pages; some results may be omitted.`
     );
-    warn.mockRestore();
   });
 });
 

--- a/public/app/plugins/datasource/azuremonitor/utils/common.test.ts
+++ b/public/app/plugins/datasource/azuremonitor/utils/common.test.ts
@@ -1,12 +1,16 @@
-import { logWarning } from '@grafana/runtime';
+import { AppEvents } from '@grafana/data';
+import { getAppEvents, logWarning } from '@grafana/runtime';
 
 import { initialCustomVariableModelState } from '../mocks/variables';
 
 import { fetchAllArmPages, hasOption, interpolateVariable, MAX_ARM_PAGES, nextLinkToPath } from './common';
 
+const publish = jest.fn();
+
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
   logWarning: jest.fn(),
+  getAppEvents: jest.fn(() => ({ publish })),
 }));
 
 describe('AzureMonitor: hasOption', () => {
@@ -69,6 +73,8 @@ describe('AzureMonitor: nextLinkToPath', () => {
 describe('AzureMonitor: fetchAllArmPages', () => {
   beforeEach(() => {
     jest.mocked(logWarning).mockClear();
+    jest.mocked(getAppEvents).mockClear();
+    publish.mockClear();
   });
 
   it('returns the single page when there is no nextLink', async () => {
@@ -138,6 +144,30 @@ describe('AzureMonitor: fetchAllArmPages', () => {
     expect(logWarning).toHaveBeenCalledWith(
       `[azuremonitor] ARM listing stopped after ${MAX_ARM_PAGES} pages; some results may be omitted.`
     );
+    expect(publish).toHaveBeenCalledTimes(1);
+    expect(publish).toHaveBeenCalledWith(expect.objectContaining({ type: AppEvents.alertWarning.name }));
+  });
+
+  it('does not emit a warning toast when all pages load within the cap', async () => {
+    const fetchPage = jest
+      .fn()
+      .mockResolvedValueOnce({
+        value: [{ id: 1 }],
+        nextLink: 'https://management.azure.com/subscriptions?api-version=x&$skiptoken=abc',
+      })
+      .mockResolvedValueOnce({ value: [{ id: 2 }] });
+
+    await fetchAllArmPages('azuremonitor', 'azuremonitor/subscriptions?api-version=x', fetchPage);
+
+    expect(publish).not.toHaveBeenCalled();
+  });
+
+  it('does not emit a warning toast when a page returns no result', async () => {
+    const fetchPage = jest.fn().mockResolvedValue(undefined);
+
+    await fetchAllArmPages('azuremonitor', 'azuremonitor/subscriptions?api-version=x', fetchPage);
+
+    expect(publish).not.toHaveBeenCalled();
   });
 });
 

--- a/public/app/plugins/datasource/azuremonitor/utils/common.test.ts
+++ b/public/app/plugins/datasource/azuremonitor/utils/common.test.ts
@@ -93,7 +93,27 @@ describe('AzureMonitor: fetchAllArmPages', () => {
 
     expect(results).toEqual([]);
     expect(fetchPage).toHaveBeenCalledTimes(1);
-    expect(warn).toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith('[azuremonitor] ARM page request returned no result; stopping pagination.');
+    warn.mockRestore();
+  });
+
+  it('does not emit the page-cap warning when a later page returns no result', async () => {
+    const fetchPage = jest
+      .fn()
+      .mockResolvedValueOnce({
+        value: [{ id: 1 }],
+        nextLink: 'https://management.azure.com/subscriptions?api-version=x&$skiptoken=abc',
+      })
+      .mockResolvedValueOnce(undefined);
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const results = await fetchAllArmPages('azuremonitor', 'azuremonitor/subscriptions?api-version=x', fetchPage);
+
+    expect(results).toEqual([{ id: 1 }]);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith('[azuremonitor] ARM page request returned no result; stopping pagination.');
+    expect(warn).not.toHaveBeenCalledWith(expect.stringContaining('ARM listing stopped after'));
     warn.mockRestore();
   });
 
@@ -108,7 +128,10 @@ describe('AzureMonitor: fetchAllArmPages', () => {
 
     expect(fetchPage).toHaveBeenCalledTimes(MAX_ARM_PAGES);
     expect(results).toHaveLength(MAX_ARM_PAGES);
-    expect(warn).toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(
+      `[azuremonitor] ARM listing stopped after ${MAX_ARM_PAGES} pages; some results may be omitted.`
+    );
     warn.mockRestore();
   });
 });

--- a/public/app/plugins/datasource/azuremonitor/utils/common.test.ts
+++ b/public/app/plugins/datasource/azuremonitor/utils/common.test.ts
@@ -1,6 +1,6 @@
 import { initialCustomVariableModelState } from '../mocks/variables';
 
-import { hasOption, interpolateVariable } from './common';
+import { fetchAllArmPages, hasOption, interpolateVariable, MAX_ARM_PAGES, nextLinkToPath } from './common';
 
 describe('AzureMonitor: hasOption', () => {
   it('can find an option in flat array', () => {
@@ -40,6 +40,76 @@ describe('AzureMonitor: hasOption', () => {
     ];
 
     expect(hasOption(options, 'c-b')).toBeTruthy();
+  });
+});
+
+describe('AzureMonitor: nextLinkToPath', () => {
+  it('drops the ARM host and joins pathname + query onto the prefix', () => {
+    const nextLink = 'https://management.azure.com/subscriptions?api-version=2019-03-01&$skiptoken=TOKEN';
+    expect(nextLinkToPath('azuremonitor', nextLink)).toBe(
+      'azuremonitor/subscriptions?api-version=2019-03-01&$skiptoken=TOKEN'
+    );
+  });
+
+  it('works for a full resources base URL prefix and sovereign clouds', () => {
+    const nextLink = 'https://management.usgovcloudapi.net/subscriptions?api-version=2019-03-01&$skiptoken=TOKEN';
+    expect(nextLinkToPath('/api/datasources/1/resources/azuremonitor', nextLink)).toBe(
+      '/api/datasources/1/resources/azuremonitor/subscriptions?api-version=2019-03-01&$skiptoken=TOKEN'
+    );
+  });
+});
+
+describe('AzureMonitor: fetchAllArmPages', () => {
+  it('returns the single page when there is no nextLink', async () => {
+    const fetchPage = jest.fn().mockResolvedValue({ value: [{ id: 1 }, { id: 2 }] });
+
+    const results = await fetchAllArmPages('azuremonitor', 'azuremonitor/subscriptions?api-version=x', fetchPage);
+
+    expect(results).toEqual([{ id: 1 }, { id: 2 }]);
+    expect(fetchPage).toHaveBeenCalledTimes(1);
+    expect(fetchPage).toHaveBeenCalledWith('azuremonitor/subscriptions?api-version=x');
+  });
+
+  it('follows nextLink across pages and rebuilds the path via the resource prefix', async () => {
+    const fetchPage = jest
+      .fn()
+      .mockResolvedValueOnce({
+        value: [{ id: 1 }],
+        nextLink: 'https://management.azure.com/subscriptions?api-version=x&$skiptoken=abc',
+      })
+      .mockResolvedValueOnce({ value: [{ id: 2 }] });
+
+    const results = await fetchAllArmPages('azuremonitor', 'azuremonitor/subscriptions?api-version=x', fetchPage);
+
+    expect(results).toEqual([{ id: 1 }, { id: 2 }]);
+    expect(fetchPage).toHaveBeenNthCalledWith(2, 'azuremonitor/subscriptions?api-version=x&$skiptoken=abc');
+  });
+
+  it('stops early and warns when a page returns no result', async () => {
+    const fetchPage = jest.fn().mockResolvedValue(undefined);
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const results = await fetchAllArmPages('azuremonitor', 'azuremonitor/subscriptions?api-version=x', fetchPage);
+
+    expect(results).toEqual([]);
+    expect(fetchPage).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('stops after MAX_ARM_PAGES even if nextLink never clears, and warns', async () => {
+    const fetchPage = jest.fn().mockResolvedValue({
+      value: [{ id: 1 }],
+      nextLink: 'https://management.azure.com/subscriptions?api-version=x&$skiptoken=loop',
+    });
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const results = await fetchAllArmPages('azuremonitor', 'azuremonitor/subscriptions?api-version=x', fetchPage);
+
+    expect(fetchPage).toHaveBeenCalledTimes(MAX_ARM_PAGES);
+    expect(results).toHaveLength(MAX_ARM_PAGES);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
   });
 });
 

--- a/public/app/plugins/datasource/azuremonitor/utils/common.ts
+++ b/public/app/plugins/datasource/azuremonitor/utils/common.ts
@@ -66,6 +66,7 @@ export async function fetchAllArmPages<T>(
     if (!page) {
       // eslint-disable-next-line no-console
       console.warn('[azuremonitor] ARM page request returned no result; stopping pagination.');
+      path = undefined;
       break;
     }
     results.push(...(page.value ?? []));

--- a/public/app/plugins/datasource/azuremonitor/utils/common.ts
+++ b/public/app/plugins/datasource/azuremonitor/utils/common.ts
@@ -3,7 +3,7 @@ import { map } from 'lodash';
 import { ScopedVars, SelectableValue, VariableWithMultiSupport } from '@grafana/data';
 import { TemplateSrv, VariableInterpolation } from '@grafana/runtime';
 
-import { AzureMonitorOption, VariableOptionGroup } from '../types/types';
+import { AzureAPIResponse, AzureMonitorOption, VariableOptionGroup } from '../types/types';
 
 export const hasOption = (options: AzureMonitorOption[], value: string): boolean =>
   options.some((v) => (v.options ? hasOption(v.options, value) : v.value === value));
@@ -44,6 +44,39 @@ export const routeNames = {
   appInsights: 'appinsights',
   resourceGraph: 'resourcegraph',
 };
+
+export const MAX_ARM_PAGES = 50;
+
+export function nextLinkToPath(prefix: string, nextLink: string): string {
+  const { pathname, search } = new URL(nextLink);
+  return `${prefix}${pathname}${search}`;
+}
+
+export async function fetchAllArmPages<T>(
+  prefix: string,
+  initialPath: string,
+  fetchPage: (path: string) => Promise<AzureAPIResponse<T> | undefined>,
+  maxPages: number = MAX_ARM_PAGES
+): Promise<T[]> {
+  const results: T[] = [];
+  let path: string | undefined = initialPath;
+  let pages = 0;
+  for (; path && pages < maxPages; pages++) {
+    const page = await fetchPage(path);
+    if (!page) {
+      // eslint-disable-next-line no-console
+      console.warn('[azuremonitor] ARM page request returned no result; stopping pagination.');
+      break;
+    }
+    results.push(...(page.value ?? []));
+    path = page.nextLink ? nextLinkToPath(prefix, page.nextLink) : undefined;
+  }
+  if (path) {
+    // eslint-disable-next-line no-console
+    console.warn(`[azuremonitor] ARM listing stopped after ${maxPages} pages; some results may be omitted.`);
+  }
+  return results;
+}
 
 export function interpolateVariable(
   value: string | number | Array<string | number>,

--- a/public/app/plugins/datasource/azuremonitor/utils/common.ts
+++ b/public/app/plugins/datasource/azuremonitor/utils/common.ts
@@ -1,7 +1,7 @@
 import { map } from 'lodash';
 
 import { ScopedVars, SelectableValue, VariableWithMultiSupport } from '@grafana/data';
-import { TemplateSrv, VariableInterpolation } from '@grafana/runtime';
+import { logWarning, TemplateSrv, VariableInterpolation } from '@grafana/runtime';
 
 import { AzureAPIResponse, AzureMonitorOption, VariableOptionGroup } from '../types/types';
 
@@ -64,8 +64,7 @@ export async function fetchAllArmPages<T>(
   for (; path && pages < maxPages; pages++) {
     const page = await fetchPage(path);
     if (!page) {
-      // eslint-disable-next-line no-console
-      console.warn('[azuremonitor] ARM page request returned no result; stopping pagination.');
+      logWarning('[azuremonitor] ARM page request returned no result; stopping pagination.');
       path = undefined;
       break;
     }
@@ -73,8 +72,7 @@ export async function fetchAllArmPages<T>(
     path = page.nextLink ? nextLinkToPath(prefix, page.nextLink) : undefined;
   }
   if (path) {
-    // eslint-disable-next-line no-console
-    console.warn(`[azuremonitor] ARM listing stopped after ${maxPages} pages; some results may be omitted.`);
+    logWarning(`[azuremonitor] ARM listing stopped after ${maxPages} pages; some results may be omitted.`);
   }
   return results;
 }

--- a/public/app/plugins/datasource/azuremonitor/utils/common.ts
+++ b/public/app/plugins/datasource/azuremonitor/utils/common.ts
@@ -1,7 +1,8 @@
 import { map } from 'lodash';
 
-import { ScopedVars, SelectableValue, VariableWithMultiSupport } from '@grafana/data';
-import { logWarning, TemplateSrv, VariableInterpolation } from '@grafana/runtime';
+import { AppEvents, ScopedVars, SelectableValue, VariableWithMultiSupport } from '@grafana/data';
+import { t } from '@grafana/i18n';
+import { getAppEvents, logWarning, TemplateSrv, VariableInterpolation } from '@grafana/runtime';
 
 import { AzureAPIResponse, AzureMonitorOption, VariableOptionGroup } from '../types/types';
 
@@ -73,6 +74,17 @@ export async function fetchAllArmPages<T>(
   }
   if (path) {
     logWarning(`[azuremonitor] ARM listing stopped after ${maxPages} pages; some results may be omitted.`);
+    getAppEvents().publish({
+      type: AppEvents.alertWarning.name,
+      payload: [
+        t('components.pagination.results-truncated-title', 'Azure Monitor'),
+        t(
+          'components.pagination.results-truncated-message',
+          'Stopped loading after {{maxPages}} pages; some results may be omitted.',
+          { maxPages }
+        ),
+      ],
+    });
   }
   return results;
 }


### PR DESCRIPTION
**What is this feature?**

- Adds a shared `fetchAllArmPages` helper that follows ARM's `nextLink` cursor and merges every page.
- Applies it everywhere only the first ARM page was read:
  - **Subscriptions** — config editor dropdown + Azure Monitor & Log Analytics datasources
  - **Log Analytics workspaces** list
- Adds `nextLink` to `AzureAPIResponse<T>`; caps traversal at `MAX_ARM_PAGES = 50` (warns + stops beyond).

**Why do we need this feature?**

ARM returns subscriptions/workspaces in pages. We only fetched page 1, so large tenants got a **truncated** list — entries silently missing from pickers and template variables.

    Before:  page 1 ─▶ list                       (rest dropped ✂)
    After:   page 1 ─▶ nextLink ─▶ page 2 ─▶ … ─▶ merged list   (≤ 50 pages)

**Who is this feature for?**

Azure Monitor users whose tenants have more subscriptions or Log Analytics workspaces than fit in one ARM page.

**Which issue(s) does this PR fix?**

Fixes #111637

**Special notes for your reviewer:**

- Backport of #128241 to `release-12.4.6`, adapted for this branch (class-based `ConfigEditor`, non-type imports).
- Frontend-only; no backend/API change.
- Tests: `common.test.ts` (pagination, page cap, empty result) + subscription/workspace pagination tests in both datasource specs.
- `parseSubscriptions*` now take the unwrapped `{ value }` shape (was `FetchResponse.data`).
- [x] Works as expected from a user's perspective
- [x] Not pre-GA — bug/behaviour fix, no feature toggle
- [x] Docs: n/a (no user-facing config change)