### PR TITLE
Unified Storage: order resource watch subject as group.resource.namespace

### DIFF
--- a/pkg/storage/unified/resource/notifier_nats_integration_test.go
+++ b/pkg/storage/unified/resource/notifier_nats_integration_test.go
@@ -122,7 +122,7 @@ func TestIntegrationNatsWatchNotificationRoundTrip(t *testing.T) {
 			select {
 			case subj := <-got:
 				require.Equal(t, subject, subj)
-				require.Equal(t, "provisioning.grafana.app.default.repositories", subj)
+				require.Equal(t, "provisioning.grafana.app.repositories.default", subj)
 				return true
 			case <-time.After(20 * time.Millisecond):
 				return false

--- a/pkg/storage/unified/resource/notifier_nats_integration_test.go
+++ b/pkg/storage/unified/resource/notifier_nats_integration_test.go
@@ -76,19 +76,41 @@ func TestIntegrationNatsWatchNotificationRoundTrip(t *testing.T) {
 
 		establishInterest(t, ctx, out, backend)
 
-		// Guards the publish and consume switches (in separate files) staying in sync.
-		for _, action := range []kv.DataAction{DataActionCreated, DataActionUpdated, DataActionDeleted} {
+		// Guards the publish and consume switches (in separate files) staying in
+		// sync. Each action gets a distinct resource version so deliveries can be
+		// matched to their action regardless of arrival order. The publisher
+		// dual-publishes on the new and legacy subjects during the transition and
+		// this consumer watches the whole stream (SubjectAll), so a notification
+		// arrives more than once; collecting into a map keyed by RV absorbs the
+		// duplicates, and filtering by name drops any warm-up straggler.
+		want := map[int64]kv.DataAction{
+			1: DataActionCreated,
+			2: DataActionUpdated,
+			3: DataActionDeleted,
+		}
+		for rv, action := range want {
 			backend.publishWatchNotification(ctx, Event{
 				Namespace:       "default",
 				Group:           "playlist.grafana.app",
 				Resource:        "playlists",
 				Name:            "p-1",
-				ResourceVersion: 1,
+				ResourceVersion: rv,
 				Action:          action,
 			})
-			got := recvEvent(t, out)
-			assert.Equal(t, action, got.Action, "action %q must survive the round trip", action)
 		}
+
+		got := make(map[int64]kv.DataAction, len(want))
+		require.Eventually(t, func() bool {
+			select {
+			case evt := <-out:
+				if evt.Name == "p-1" {
+					got[evt.ResourceVersion] = evt.Action
+				}
+			case <-time.After(50 * time.Millisecond):
+			}
+			return len(got) == len(want)
+		}, 5*time.Second, time.Millisecond)
+		assert.Equal(t, want, got)
 	})
 
 	t.Run("publisher targets the resource-specific subject a per-resource consumer subscribes to", func(t *testing.T) {

--- a/pkg/storage/unified/resource/watch_publisher.go
+++ b/pkg/storage/unified/resource/watch_publisher.go
@@ -50,10 +50,10 @@ func (k *kvStorageBackend) publishWatchNotification(ctx context.Context, event E
 		return
 	}
 
-	subject := resourcewatch.Subject(schema.GroupVersionResource{
+	gvr := schema.GroupVersionResource{
 		Group:    event.Group,
 		Resource: event.Resource,
-	}, event.Namespace)
+	}
 
 	payload, err := proto.Marshal(&resourcepb.WatchNotification{
 		Type:                    actionToWatchNotificationType(event.Action),
@@ -66,11 +66,21 @@ func (k *kvStorageBackend) publishWatchNotification(ctx context.Context, event E
 		PreviousResourceVersion: event.PreviousRV,
 	})
 	if err != nil {
-		k.log.Warn("failed to marshal watch notification", "subject", subject, "error", err)
+		k.log.Warn("failed to marshal watch notification", "group", event.Group, "resource", event.Resource, "namespace", event.Namespace, "error", err)
 		return
 	}
 
-	if err := k.eventPublisher.Publish(ctx, subject, payload); err != nil {
-		k.log.Warn("failed to publish watch notification", "subject", subject, "error", err)
+	// Dual-publish during the deployment transition: the storage-api (publisher)
+	// ships ahead of the provisioning operators (subscribers), so we publish on
+	// both the new subject order and the legacy one until every subscriber has
+	// moved over. Once they have, drop LegacySubject and this loop.
+	subjects := []string{
+		resourcewatch.Subject(gvr, event.Namespace),
+		resourcewatch.LegacySubject(gvr, event.Namespace),
+	}
+	for _, subject := range subjects {
+		if err := k.eventPublisher.Publish(ctx, subject, payload); err != nil {
+			k.log.Warn("failed to publish watch notification", "subject", subject, "error", err)
+		}
 	}
 }

--- a/pkg/storage/unified/resource/watch_publisher_test.go
+++ b/pkg/storage/unified/resource/watch_publisher_test.go
@@ -48,14 +48,20 @@ func TestPublishWatchNotification(t *testing.T) {
 		PreviousRV:      41,
 	}
 
-	t.Run("publishes a metadata-only notification on the resource subject", func(t *testing.T) {
+	t.Run("dual-publishes a metadata-only notification on the new and legacy subjects", func(t *testing.T) {
 		pub := &fakeEventPublisher{enabled: true}
 		backend := &kvStorageBackend{log: log.NewNopLogger(), eventPublisher: pub}
 
 		backend.publishWatchNotification(context.Background(), event)
 
-		require.Len(t, pub.subjects, 1)
-		assert.Equal(t, "provisioning.grafana.app.repositories.default", pub.subjects[0])
+		// The storage-api (publisher) deploys ahead of the provisioning operators
+		// (subscribers), so during the transition it publishes on both the new
+		// subject order and the legacy one.
+		require.Equal(t, []string{
+			"provisioning.grafana.app.repositories.default",
+			"provisioning.grafana.app.default.repositories",
+		}, pub.subjects)
+		require.Equal(t, pub.payloads[0], pub.payloads[1])
 
 		var got resourcepb.WatchNotification
 		require.NoError(t, proto.Unmarshal(pub.payloads[0], &got))

--- a/pkg/storage/unified/resource/watch_publisher_test.go
+++ b/pkg/storage/unified/resource/watch_publisher_test.go
@@ -55,7 +55,7 @@ func TestPublishWatchNotification(t *testing.T) {
 		backend.publishWatchNotification(context.Background(), event)
 
 		require.Len(t, pub.subjects, 1)
-		assert.Equal(t, "provisioning.grafana.app.default.repositories", pub.subjects[0])
+		assert.Equal(t, "provisioning.grafana.app.repositories.default", pub.subjects[0])
 
 		var got resourcepb.WatchNotification
 		require.NoError(t, proto.Unmarshal(pub.payloads[0], &got))

--- a/pkg/storage/unified/resourcewatch/subject.go
+++ b/pkg/storage/unified/resourcewatch/subject.go
@@ -45,3 +45,24 @@ func Subject(gvr schema.GroupVersionResource, namespace string) string {
 		ns,
 	}, ".")
 }
+
+// LegacySubject returns the pre-reorder subject with the namespace and resource
+// tokens swapped:
+//
+//	{group}.{namespace}.{resource}
+//
+// It is retained only for the deployment transition. The storage-api (publisher)
+// ships ahead of the provisioning operators (subscribers), so the publisher
+// dual-publishes on both Subject and LegacySubject until every subscriber has
+// moved to the new order; then this and the dual-publish can be removed.
+func LegacySubject(gvr schema.GroupVersionResource, namespace string) string {
+	ns := namespace
+	if ns == "" {
+		ns = allNamespaces
+	}
+	return strings.Join([]string{
+		gvr.Group,
+		ns,
+		gvr.Resource,
+	}, ".")
+}

--- a/pkg/storage/unified/resourcewatch/subject.go
+++ b/pkg/storage/unified/resourcewatch/subject.go
@@ -6,8 +6,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-// allNamespaces is the NATS single-token wildcard ("*") used in the namespace
-// position to watch every namespace's notifications for a resource.
+// allNamespaces is the NATS single-token wildcard ("*") used in the trailing
+// namespace position to watch every namespace's notifications for a resource.
 const allNamespaces = "*"
 
 // SubjectAll is the NATS multi-token wildcard (">"), matching every Subject(...)
@@ -18,14 +18,18 @@ const SubjectAll = ">"
 // Subject returns the NATS subject that carries change notifications for a
 // resource type within a namespace, as the dotted tokens
 //
-//	{group}.{namespace}.{resource}
+//	{group}.{resource}.{namespace}
 //
-// The version is intentionally absent: notifications are version-agnostic and a
-// consumer resolves the object at its own version via GET, so a single subject
-// serves every version. An empty namespace yields the "*" single-token wildcard
-// in the namespace position, so a consumer can watch every namespace's
-// notifications for the resource (Grafana namespaces have no dots, so a concrete
-// namespace is always exactly one token and never bleeds into the wildcard).
+// The namespace is the trailing token so that "{group}.{resource}" is a prefix of
+// every namespace's subject: a consumer can watch or be granted a whole resource
+// across all namespaces with a subtree wildcard (e.g. NATS
+// "provisioning.grafana.app.repositories.>"). The version is intentionally absent:
+// notifications are version-agnostic and a consumer resolves the object at its own
+// version via GET, so a single subject serves every version. An empty namespace
+// yields the "*" single-token wildcard in the trailing position, so a consumer can
+// watch every namespace's notifications for the resource (Grafana namespaces have
+// no dots, so a concrete namespace is always exactly one token and never bleeds
+// into the wildcard).
 //
 // The group keeps its dots and therefore spans several tokens
 // (provisioning.grafana.app -> three tokens); publisher and consumer build the
@@ -37,7 +41,7 @@ func Subject(gvr schema.GroupVersionResource, namespace string) string {
 	}
 	return strings.Join([]string{
 		gvr.Group,
-		ns,
 		gvr.Resource,
+		ns,
 	}, ".")
 }

--- a/pkg/storage/unified/resourcewatch/subject_test.go
+++ b/pkg/storage/unified/resourcewatch/subject_test.go
@@ -24,25 +24,25 @@ func TestSubject(t *testing.T) {
 			name:      "namespaced, version-agnostic",
 			gvr:       gvr,
 			namespace: "default",
-			want:      "provisioning.grafana.app.default.repositories",
+			want:      "provisioning.grafana.app.repositories.default",
 		},
 		{
-			name:      "empty namespace becomes the single-token wildcard",
+			name:      "empty namespace becomes the trailing single-token wildcard",
 			gvr:       gvr,
 			namespace: "",
-			want:      "provisioning.grafana.app.*.repositories",
+			want:      "provisioning.grafana.app.repositories.*",
 		},
 		{
 			name:      "version is ignored",
 			gvr:       schema.GroupVersionResource{Group: "provisioning.grafana.app", Version: "v9", Resource: "repositories"},
 			namespace: "stacks-1",
-			want:      "provisioning.grafana.app.stacks-1.repositories",
+			want:      "provisioning.grafana.app.repositories.stacks-1",
 		},
 		{
 			name:      "groupless resource",
 			gvr:       schema.GroupVersionResource{Resource: "configmaps"},
 			namespace: "default",
-			want:      ".default.configmaps",
+			want:      ".configmaps.default",
 		},
 	}
 

--- a/pkg/storage/unified/resourcewatch/subject_test.go
+++ b/pkg/storage/unified/resourcewatch/subject_test.go
@@ -52,3 +52,37 @@ func TestSubject(t *testing.T) {
 		})
 	}
 }
+
+func TestLegacySubject(t *testing.T) {
+	gvr := schema.GroupVersionResource{
+		Group:    "provisioning.grafana.app",
+		Version:  "v0alpha1",
+		Resource: "repositories",
+	}
+
+	tests := []struct {
+		name      string
+		gvr       schema.GroupVersionResource
+		namespace string
+		want      string
+	}{
+		{
+			name:      "namespace and resource tokens are swapped",
+			gvr:       gvr,
+			namespace: "default",
+			want:      "provisioning.grafana.app.default.repositories",
+		},
+		{
+			name:      "empty namespace becomes the single-token wildcard",
+			gvr:       gvr,
+			namespace: "",
+			want:      "provisioning.grafana.app.*.repositories",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, LegacySubject(tt.gvr, tt.namespace))
+		})
+	}
+}


### PR DESCRIPTION
Move the namespace to the trailing token in the resource watch NATS subject, from `{group}.{namespace}.{resource}` to `{group}.{resource}.{namespace}`.

This makes `{group}.{resource}` a prefix of every namespace's subject, so a consumer can watch or be granted a whole resource across all namespaces with a subtree wildcard (e.g. `provisioning.grafana.app.repositories.>`). Publisher and subscriber build the subject from the same GVR via `Subject()`, so the ordering stays consistent on both sides.

## Deployment transition: dual-publish

The storage-api (publisher) deploys ahead of the provisioning operators (subscribers), so switching the subject in a single step would drop notifications to operators still listening on the old order. To bridge the gap the publisher **dual-publishes**:

- `resourcewatch.LegacySubject()` builds the old `{group}.{namespace}.{resource}` ordering.
- `publishWatchNotification` marshals the payload once and publishes it to both the new `Subject()` and `LegacySubject()`. Each publish failure is logged and swallowed, as before — the event store remains the durable source of truth.

The in-repo consumer (`informer.go`) rides the same storage-api deployment and already uses the new `Subject()`, so only the external operators rely on the legacy subject.

**Follow-up:** once every subscriber has migrated to the new order, remove `LegacySubject` and the dual-publish loop (both flagged in code comments).
