### PR TITLE
Provisioning: link Git Sync PR footer to repo admin page

### DIFF
--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/changes.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/changes.go
@@ -29,8 +29,11 @@ type changeInfo struct {
 	// Attribution: identifies which provisioning repository posted this comment
 	RepositoryName  string
 	RepositoryTitle string
-	// RepositoryURL links to the git repository (empty for local repositories)
-	RepositoryURL string
+	// RepositoryAdminURL links to the repository's management page in the
+	// Grafana UI (…/admin/provisioning/<name>), so readers land where they
+	// manage the sync rather than on the raw git remote. Empty only when the
+	// Grafana base URL cannot be parsed.
+	RepositoryAdminURL string
 
 	// Files we tried to read
 	Changes []fileChangeInfo
@@ -121,15 +124,16 @@ func (e *evaluator) Evaluate(ctx context.Context, repo repository.Reader, opts p
 
 	rendererAvailable := e.render.IsAvailable(ctx)
 	shouldRender := rendererAvailable && len(changes) == 1 && cfg.ShouldGenerateDashboardPreviews()
+	baseURL := e.urls.Internal(ctx, cfg.Namespace)
+	orgID := orgIDForLinks(cfg.Namespace)
 	info := changeInfo{
-		GrafanaBaseURL:       e.urls.Internal(ctx, cfg.Namespace),
+		GrafanaBaseURL:       baseURL,
 		RepositoryName:       cfg.Name,
 		RepositoryTitle:      cfg.Spec.Title,
-		RepositoryURL:        stripUserinfo(cfg.URL()),
+		RepositoryAdminURL:   repositoryAdminURL(baseURL, cfg.Name, orgID),
 		MissingImageRenderer: !rendererAvailable,
 	}
 	screenshotBaseURL := e.urls.Public(ctx, cfg.Namespace)
-	orgID := orgIDForLinks(cfg.Namespace)
 
 	logger := logging.FromContext(ctx)
 
@@ -164,6 +168,25 @@ func stripUserinfo(raw string) string {
 		return ""
 	}
 	u.User = nil
+	return u.String()
+}
+
+// repositoryAdminURL builds a link to the repository's management page in the
+// Grafana UI (…/admin/provisioning/<name>), mirroring how GrafanaURL/PreviewURL
+// are constructed. orgID pins the org for non-primary on-prem orgs the same way.
+// Returns "" when the base URL cannot be parsed, so the footer falls back to
+// plain text rather than rendering a broken link.
+func repositoryAdminURL(baseURL, name string, orgID int64) string {
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return ""
+	}
+	u = u.JoinPath("admin/provisioning", name)
+	if orgID > 0 {
+		query := url.Values{}
+		query.Set("orgId", strconv.FormatInt(orgID, 10))
+		u.RawQuery = query.Encode()
+	}
 	return u.String()
 }
 

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/changes_test.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/changes_test.go
@@ -1514,7 +1514,7 @@ func TestEvaluate_PopulatesSourceAndRepositoryURLs(t *testing.T) {
 	}}, progress)
 
 	require.NoError(t, err)
-	require.Equal(t, "https://github.com/example/repo", info.RepositoryURL)
+	require.Equal(t, "http://host/admin/provisioning/test-repo", info.RepositoryAdminURL)
 	require.Len(t, info.Changes, 1)
 	require.Equal(t, "https://github.com/example/repo/blob/ref/path/to/file.json", info.Changes[0].SourceURL)
 }
@@ -1577,10 +1577,11 @@ func TestEvaluate_StripsCredentialsFromURLs(t *testing.T) {
 	}}, progress)
 
 	require.NoError(t, err)
-	require.Equal(t, "https://github.com/example/repo", info.RepositoryURL)
+	// The repository admin link is derived from the Grafana base URL, so it never
+	// carries git credentials regardless of what the repo is configured with.
+	require.Equal(t, "http://host/admin/provisioning/creds-repo", info.RepositoryAdminURL)
 	require.Len(t, info.Changes, 1)
 	require.Equal(t, "https://github.com/example/repo/blob/ref/path/to/file.json", info.Changes[0].SourceURL)
-	require.NotContains(t, info.RepositoryURL, "token")
 	require.NotContains(t, info.Changes[0].SourceURL, "token")
 }
 

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/comment.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/comment.go
@@ -162,7 +162,7 @@ const commentTemplateMissingImageRenderer = `
 const commentTemplateFooter = `
 
 ---
-_{{if .RepositoryTitle}}🔄 Synced from {{if .RepositoryURL}}[**{{.SafeRepositoryTitle}}**]({{.RepositoryURL}}){{else}}**{{.SafeRepositoryTitle}}**{{end}} · {{end}}Posted by [{{.GrafanaHost}}]({{.GrafanaBaseURL}})_`
+_{{if .RepositoryTitle}}🔄 Synced from {{if .RepositoryAdminURL}}[**{{.SafeRepositoryTitle}}**]({{.RepositoryAdminURL}}){{else}}**{{.SafeRepositoryTitle}}**{{end}} · {{end}}Posted by [{{.GrafanaHost}}]({{.GrafanaBaseURL}})_`
 
 func (f *fileChangeInfo) Action() string {
 	if f.Parsed != nil {

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/comment_test.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/comment_test.go
@@ -69,10 +69,10 @@ func TestGenerateComment(t *testing.T) {
 			RepositoryTitle: "My Repo",
 		}},
 		{"new dashboard", changeInfo{
-			GrafanaBaseURL:  "http://host/",
-			RepositoryName:  "my-repo",
-			RepositoryTitle: "My Repo",
-			RepositoryURL:   "https://github.com/example/repo",
+			GrafanaBaseURL:     "http://host/",
+			RepositoryName:     "my-repo",
+			RepositoryTitle:    "My Repo",
+			RepositoryAdminURL: "http://host/admin/provisioning/my-repo",
 			Changes: []fileChangeInfo{
 				{
 					Parsed: &resources.ParsedResource{
@@ -90,10 +90,10 @@ func TestGenerateComment(t *testing.T) {
 			},
 		}},
 		{"update dashboard", changeInfo{
-			GrafanaBaseURL:  "http://host/",
-			RepositoryName:  "my-repo",
-			RepositoryTitle: "My Repo",
-			RepositoryURL:   "https://github.com/example/repo",
+			GrafanaBaseURL:     "http://host/",
+			RepositoryName:     "my-repo",
+			RepositoryTitle:    "My Repo",
+			RepositoryAdminURL: "http://host/admin/provisioning/my-repo",
 			Changes: []fileChangeInfo{
 				{
 					Parsed: &resources.ParsedResource{
@@ -114,10 +114,10 @@ func TestGenerateComment(t *testing.T) {
 			},
 		}},
 		{"update dashboard missing renderer", changeInfo{
-			GrafanaBaseURL:  "http://host/",
-			RepositoryName:  "my-repo",
-			RepositoryTitle: "My Repo",
-			RepositoryURL:   "https://github.com/example/repo",
+			GrafanaBaseURL:     "http://host/",
+			RepositoryName:     "my-repo",
+			RepositoryTitle:    "My Repo",
+			RepositoryAdminURL: "http://host/admin/provisioning/my-repo",
 			Changes: []fileChangeInfo{
 				{
 					Parsed: &resources.ParsedResource{
@@ -136,11 +136,11 @@ func TestGenerateComment(t *testing.T) {
 			MissingImageRenderer: true,
 		}},
 		{"multiple files", changeInfo{
-			GrafanaBaseURL:  "http://host/",
-			RepositoryName:  "my-repo",
-			RepositoryTitle: "My Repo",
-			RepositoryURL:   "https://github.com/example/repo",
-			SkippedFiles:    5,
+			GrafanaBaseURL:     "http://host/",
+			RepositoryName:     "my-repo",
+			RepositoryTitle:    "My Repo",
+			RepositoryAdminURL: "http://host/admin/provisioning/my-repo",
+			SkippedFiles:       5,
 			Changes: []fileChangeInfo{
 				{
 					Parsed: &resources.ParsedResource{
@@ -218,10 +218,10 @@ func TestGenerateComment(t *testing.T) {
 			},
 		}},
 		{"multiple files with stripped metadata", changeInfo{
-			GrafanaBaseURL:  "http://host/",
-			RepositoryName:  "my-repo",
-			RepositoryTitle: "My Repo",
-			RepositoryURL:   "https://github.com/example/repo",
+			GrafanaBaseURL:     "http://host/",
+			RepositoryName:     "my-repo",
+			RepositoryTitle:    "My Repo",
+			RepositoryAdminURL: "http://host/admin/provisioning/my-repo",
 			Changes: []fileChangeInfo{
 				{
 					Parsed: &resources.ParsedResource{

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/multiple-files-with-stripped-metadata.md
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/multiple-files-with-stripped-metadata.md
@@ -10,4 +10,4 @@ All resources passed validation. ✅
 > ℹ️ **Note:** Some metadata fields (such as `namespace`, `labels`, or `annotations`) were removed from the resource files. Git Sync normalizes resources to a minimal format. This is expected behavior and does not affect your dashboards in Grafana.
 
 ---
-_🔄 Synced from [**My Repo**](https://github.com/example/repo) · Posted by [host](http://host/)_
+_🔄 Synced from [**My Repo**](http://host/admin/provisioning/my-repo) · Posted by [host](http://host/)_

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/multiple-files.md
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/multiple-files.md
@@ -11,4 +11,4 @@ and 5 more files.
 All resources passed validation. ✅
 
 ---
-_🔄 Synced from [**My Repo**](https://github.com/example/repo) · Posted by [host](http://host/)_
+_🔄 Synced from [**My Repo**](http://host/admin/provisioning/my-repo) · Posted by [host](http://host/)_

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/new-dashboard.md
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/new-dashboard.md
@@ -6,4 +6,4 @@
 [**New Dashboard**](https://github.com/example/repo/blob/pr/file.json) — [preview changes](http://grafana/admin/preview)
 
 ---
-_🔄 Synced from [**My Repo**](https://github.com/example/repo) · Posted by [host](http://host/)_
+_🔄 Synced from [**My Repo**](http://host/admin/provisioning/my-repo) · Posted by [host](http://host/)_

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/update-dashboard-missing-renderer.md
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/update-dashboard-missing-renderer.md
@@ -3,4 +3,4 @@
 [**Existing Dashboard**](https://github.com/example/repo/blob/pr/file.json) — [view current](http://grafana/d/uid) · [preview changes](http://grafana/admin/preview)
 
 ---
-_🔄 Synced from [**My Repo**](https://github.com/example/repo) · Posted by [host](http://host/)_
+_🔄 Synced from [**My Repo**](http://host/admin/provisioning/my-repo) · Posted by [host](http://host/)_

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/update-dashboard.md
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/update-dashboard.md
@@ -8,4 +8,4 @@
 [**Existing Dashboard**](https://github.com/example/repo/blob/pr/file.json) — [view current](http://grafana/d/uid) · [preview changes](http://grafana/admin/preview)
 
 ---
-_🔄 Synced from [**My Repo**](https://github.com/example/repo) · Posted by [host](http://host/)_
+_🔄 Synced from [**My Repo**](http://host/admin/provisioning/my-repo) · Posted by [host](http://host/)_


### PR DESCRIPTION
## Summary

The Git Sync pull-request comment footer ("🔄 Synced from **<repo>**") linked to the raw git repository URL. This points it instead at the repository's management page in the Grafana UI (`…/admin/provisioning/<name>`), so a reader clicking through lands where they manage the sync rather than on the git remote.

## Changes

- `changes.go`: replaced the `changeInfo.RepositoryURL` field (previously the stripped git remote from `cfg.URL()`) with `RepositoryAdminURL`, and added a `repositoryAdminURL(baseURL, name, orgID)` helper that builds `…/admin/provisioning/<name>` from the Grafana base URL — mirroring how the existing `GrafanaURL`/`PreviewURL` links are constructed, including `orgId` pinning for non-primary on-prem orgs.
- `comment.go`: footer template now links the repository title to `.RepositoryAdminURL`.
- Updated unit tests (`changes_test.go`, `comment_test.go`) and the 5 `testdata/*.md` golden files.

## Behavior notes

- The admin URL is always constructible (Grafana base URL + repo name), so local / non-GitHub repositories now get a working link where they previously rendered as plain text. The plain-text fallback only remains if the Grafana base URL can't be parsed.
- Because the link is Grafana-derived, it can never leak embedded git credentials. Per-file `SourceURL` credential stripping (`stripUserinfo`) is unchanged.

## Testing

- `go test ./pkg/registry/apis/provisioning/webhooks/pullrequest/` — passes
- `gofmt` clean, `go vet` clean
- Verified the provisioning integration tests (`pkg/tests/apis/provisioning/git/webhook/webhook_test.go`) do not assert the footer link, so they are unaffected.

## Checklist

- [x] Tests added/updated
- [x] No breaking changes (internal PR-comment rendering only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)