### PR TITLE
Provisioning: Export v0 dashboards as v1 so synced files load

### DIFF
--- a/pkg/registry/apis/provisioning/jobs/export/resources.go
+++ b/pkg/registry/apis/provisioning/jobs/export/resources.go
@@ -276,39 +276,41 @@ func exportItem(ctx context.Context,
 	return progress.TooManyErrors()
 }
 
-// newDashboardConversionShim returns a conversionShim that preserves each
-// dashboard's original apiVersion when the default v1 response has
-// lossy-converted fields. For v0 the stored model is simply restored via
-// apiVersion rewrite; for other stored versions we re-Get through a cached
-// dynamic client keyed on the version string.
+// newDashboardConversionShim returns a conversionShim that keeps each exported
+// dashboard's body and apiVersion consistent. The export lists dashboards at the
+// preferred version, which lossily converts any dashboard stored at a different
+// version, so we re-Get the un-converted object through a dynamic client pinned
+// to the stored version. v0 is the exception: a file labeled v0alpha1 cannot be
+// loaded by the frontend dashboard loader (nor the provisioning preview path)
+// once it is synced back, so v0 dashboards are fetched (losslessly) as v1.
 func newDashboardConversionShim(gvr schema.GroupVersionResource, clients resources.ResourceClients) conversionShim {
 	versionClients := make(map[string]dynamic.ResourceInterface)
 	return func(ctx context.Context, item *unstructured.Unstructured) (*unstructured.Unstructured, error) {
 		// Check if there's a stored version in the conversion status.
-		// This indicates the original API version the dashboard was created with,
-		// which should be preserved during export regardless of whether conversion succeeded or failed.
+		// This indicates the original API version the dashboard was created with.
 		storedVersion, _, _ := unstructured.NestedString(item.Object, "status", "conversion", "storedVersion")
 		if storedVersion != "" {
-			// For v0 we can simply fallback -- the full model is saved
+			// Fetch the un-converted object at its stored version. v0 is exported as
+			// v1 instead: a v0alpha1-labeled file cannot be loaded once synced back,
+			// and v0 maps to v1 losslessly.
+			fetchVersion := storedVersion
 			if strings.HasPrefix(storedVersion, "v0") {
-				item.SetAPIVersion(fmt.Sprintf("%s/%s", gvr.Group, storedVersion))
-				return item, nil
+				fetchVersion = resources.DashboardResource.Version
 			}
 
-			// For any other version (v1, v2, v3, etc.), fetch the original version via client
-			versionClient, ok := versionClients[storedVersion]
+			versionClient, ok := versionClients[fetchVersion]
 			if !ok {
 				versionGVR := schema.GroupVersionResource{
 					Group:    gvr.Group,
-					Version:  storedVersion,
+					Version:  fetchVersion,
 					Resource: gvr.Resource,
 				}
 				var err error
 				versionClient, _, err = clients.ForResource(ctx, versionGVR)
 				if err != nil {
-					return nil, fmt.Errorf("get client for version %s: %w", storedVersion, err)
+					return nil, fmt.Errorf("get client for version %s: %w", fetchVersion, err)
 				}
-				versionClients[storedVersion] = versionClient
+				versionClients[fetchVersion] = versionClient
 			}
 			return versionClient.Get(ctx, item.GetName(), metav1.GetOptions{})
 		}

--- a/pkg/registry/apis/provisioning/jobs/export/resources_test.go
+++ b/pkg/registry/apis/provisioning/jobs/export/resources_test.go
@@ -231,24 +231,43 @@ func TestExportResources_Dashboards_IgnoresExisting(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestExportResources_Dashboards_SavedVersion(t *testing.T) {
+// TestExportResources_Dashboards_V0StoredVersionExportsAsV1 asserts that a
+// dashboard whose stored version is v0 is re-fetched at v1 and exported with the
+// v1 apiVersion, rather than being relabeled back to v0alpha1. The export lists
+// dashboards at the preferred version (here v2), which lossily converts a classic
+// dashboard, so the shim must re-Get the un-converted form. A file labeled
+// v0alpha1 is rejected by the frontend dashboard loader (and the provisioning
+// preview path) and fails to load once synced back in, so v0 is exported as v1.
+func TestExportResources_Dashboards_V0StoredVersionExportsAsV1(t *testing.T) {
+	// Listed at the preferred version with a v0 stored version + failed conversion.
 	mockItems := []unstructured.Unstructured{
 		{
 			Object: map[string]interface{}{
-				"apiVersion": resources.DashboardResource.GroupVersion().String(),
+				"apiVersion": resources.DashboardResourceV2.GroupVersion().String(),
 				"kind":       "Dashboard",
 				"metadata": map[string]interface{}{
 					"name": "existing-dashboard",
 				},
-				"spec": map[string]interface{}{
-					"hello": "world",
-				},
 				"status": map[string]interface{}{
 					"conversion": map[string]interface{}{
 						"failed":        true,
-						"storedVersion": "v0xyz",
+						"storedVersion": "v0alpha1",
 					},
 				},
+			},
+		},
+	}
+
+	// The un-converted object the v1 client returns for the re-fetch.
+	v1Dashboard := unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": resources.DashboardResource.GroupVersion().String(),
+			"kind":       "Dashboard",
+			"metadata": map[string]interface{}{
+				"name": "existing-dashboard",
+			},
+			"spec": map[string]interface{}{
+				"title": "classic dashboard",
 			},
 		},
 	}
@@ -264,34 +283,25 @@ func TestExportResources_Dashboards_SavedVersion(t *testing.T) {
 
 	setupResources := func(repoResources *resources.MockRepositoryResources, resourceClients *resources.MockResourceClients, mockClient *mockDynamicInterface, gvk schema.GroupVersionKind) {
 		resourceClients.On("ForKind", mock.Anything, mock.Anything).Return(mockClient, resources.DashboardResource, nil)
+
+		// v0 must be re-fetched through the v1 client, not v0alpha1.
+		v1GVR := schema.GroupVersionResource{
+			Group:    resources.DashboardResource.Group,
+			Version:  resources.DashboardResource.Version,
+			Resource: resources.DashboardResource.Resource,
+		}
+		versionClient := &mockDynamicInterface{items: []unstructured.Unstructured{v1Dashboard}}
+		resourceClients.On("ForResource", mock.Anything, v1GVR).Return(versionClient, gvk, nil)
+
 		options := resources.WriteOptions{
 			Path: "grafana",
 			Ref:  "feature/branch",
 		}
-
 		repoResources.On("WriteResourceFileFromObject", mock.Anything, mock.MatchedBy(func(obj *unstructured.Unstructured) bool {
-			// Verify that the object has the expected status.conversion.storedVersion field
-			status, exists, err := unstructured.NestedMap(obj.Object, "status")
-			if !exists || err != nil {
-				return false
-			}
-
-			conversion, exists, err := unstructured.NestedMap(status, "conversion")
-			if !exists || err != nil {
-				return false
-			}
-
-			storedVersion, exists, err := unstructured.NestedString(conversion, "storedVersion")
-			if !exists || err != nil {
-				return false
-			}
-
-			if storedVersion != "v0xyz" {
-				return false
-			}
-
-			return obj.GetName() == "existing-dashboard"
-		}), options).Return("", fmt.Errorf("XXX"))
+			// The exported object must carry the v1 apiVersion, not v0alpha1.
+			return obj.GetName() == "existing-dashboard" &&
+				obj.GetAPIVersion() == resources.DashboardResource.GroupVersion().String()
+		}), options).Return("existing-dashboard.json", nil)
 	}
 
 	err := runExportTest(t, mockItems, setupProgress, setupResources)

--- a/pkg/tests/apis/provisioning/jobs/exportjob_specific_test.go
+++ b/pkg/tests/apis/provisioning/jobs/exportjob_specific_test.go
@@ -82,6 +82,8 @@ func TestIntegrationProvisioning_ExportSpecificResources(t *testing.T) {
 
 	// Named dashboards should be written, each with its stored apiVersion
 	// and a regenerated metadata.name (standalone export uses new UIDs).
+	// v0 is the exception: it is relabeled to v1 on export so the synced file
+	// remains loadable (see the conversion shim in jobs/export/resources.go).
 	type expected struct {
 		title      string
 		origName   string
@@ -89,7 +91,7 @@ func TestIntegrationProvisioning_ExportSpecificResources(t *testing.T) {
 		fileName   string
 	}
 	for _, tt := range []expected{
-		{title: "Test dashboard. Created at v0", origName: "test-v0", apiVersion: "dashboard.grafana.app/v0alpha1", fileName: "test-dashboard-created-at-v0.json"},
+		{title: "Test dashboard. Created at v0", origName: "test-v0", apiVersion: "dashboard.grafana.app/v1", fileName: "test-dashboard-created-at-v0.json"},
 		{title: "Test dashboard. Created at v1", origName: "test-v1", apiVersion: "dashboard.grafana.app/v1", fileName: "test-dashboard-created-at-v1.json"},
 		{title: "Test dashboard. Created at v2", origName: "test-v2", apiVersion: "dashboard.grafana.app/v2", fileName: "test-dashboard-created-at-v2.json"},
 		{title: "Test dashboard. Created at v2beta1", origName: "test-v2beta1", apiVersion: "dashboard.grafana.app/v2beta1", fileName: "test-dashboard-created-at-v2beta1.json"},

--- a/pkg/tests/apis/provisioning/jobs/exportjob_test.go
+++ b/pkg/tests/apis/provisioning/jobs/exportjob_test.go
@@ -72,9 +72,12 @@ func TestIntegrationProvisioning_ExportUnifiedToRepository(t *testing.T) {
 
 	common.PrintFileTree(t, helper.ProvisioningPath)
 
-	// Check that each file was exported with its stored version and new UIDs
+	// Check that each file was exported with its stored version and new UIDs.
+	// A dashboard created at v0 is relabeled to v1 on export: its body is already
+	// the lossless v1 representation, and a file labeled v0alpha1 cannot be loaded
+	// by the frontend dashboard loader once it is synced back in.
 	for _, test := range []props{
-		{title: "Test dashboard. Created at v0", apiVersion: "dashboard.grafana.app/v0alpha1", name: "test-v0", fileName: "test-dashboard-created-at-v0.json"},
+		{title: "Test dashboard. Created at v0", apiVersion: "dashboard.grafana.app/v1", name: "test-v0", fileName: "test-dashboard-created-at-v0.json"},
 		{title: "Test dashboard. Created at v1", apiVersion: "dashboard.grafana.app/v1", name: "test-v1", fileName: "test-dashboard-created-at-v1.json"},
 		{title: "Test dashboard. Created at v2alpha1", apiVersion: "dashboard.grafana.app/v2alpha1", name: "test-v2alpha1", fileName: "test-dashboard-created-at-v2alpha1.json"},
 		{title: "Test dashboard. Created at v2beta1", apiVersion: "dashboard.grafana.app/v2beta1", name: "test-v2beta1", fileName: "test-dashboard-created-at-v2beta1.json"},
@@ -128,8 +131,10 @@ func TestIntegrationProvisioning_ExportDashboardsWithStoredVersions(t *testing.T
 			},
 			expectedTitle: "Test dashboard. Created at v0",
 			expectedName:  "test-v0",
-			expectedVer:   "dashboard.grafana.app/v0alpha1",
-			fileName:      "test-dashboard-created-at-v0.json",
+			// v0 is relabeled to v1 on export so the synced file remains loadable;
+			// see the conversion shim in jobs/export/resources.go.
+			expectedVer: "dashboard.grafana.app/v1",
+			fileName:    "test-dashboard-created-at-v0.json",
 		},
 		{
 			name: "v1",
@@ -207,10 +212,11 @@ func TestIntegrationProvisioning_ExportDashboardsWithStoredVersions(t *testing.T
 			err = json.Unmarshal(body, &obj)
 			require.NoError(t, err, "exported file not json %s", fpath)
 
-			// Verify API version matches the stored version
+			// Verify the exported apiVersion. Non-v0 versions are preserved as stored;
+			// v0 is relabeled to v1 so the synced file stays loadable.
 			val, _, err := unstructured.NestedString(obj, "apiVersion")
 			require.NoError(t, err)
-			require.Equal(t, tt.expectedVer, val, "exported dashboard should have original stored version")
+			require.Equal(t, tt.expectedVer, val, "exported dashboard should have expected apiVersion")
 
 			// Verify title
 			val, _, err = unstructured.NestedString(obj, "spec", "title")
@@ -258,10 +264,10 @@ func TestIntegrationProvisioning_ExportDashboardsWithStoredVersions(t *testing.T
 
 							exportedVersion, _, err := unstructured.NestedString(obj, "apiVersion")
 							require.NoError(t, err)
-							// Extract version from apiVersion (e.g., "dashboard.grafana.app/v2alpha1" -> "v2alpha1")
-							expectedVersion := "dashboard.grafana.app/" + storedVersion
-							require.Equal(t, expectedVersion, exportedVersion,
-								"exported version should match storedVersion %s for dashboard %s", storedVersion, dashboardName)
+							// The exported apiVersion tracks the stored version, except v0
+							// which is relabeled to v1 (see the export conversion shim).
+							require.Equal(t, tt.expectedVer, exportedVersion,
+								"exported version for dashboard %s should be %s (storedVersion=%s)", dashboardName, tt.expectedVer, storedVersion)
 						}
 					}
 				}


### PR DESCRIPTION
Fixes https://github.com/grafana/git-ui-sync-project/issues/1279

## Summary

Dashboards exported by provisioning/git-sync with `apiVersion: dashboard.grafana.app/v0alpha1` fail to load in the frontend once synced back in.

**Root cause.** The dashboard export conversion shim (`pkg/registry/apis/provisioning/jobs/export/resources.go`) relabeled `v0`-stored dashboards back to `v0alpha1`. The export lists dashboards at the *preferred* version (currently `v2`), which lossily converts a classic dashboard, and the shim then rewrote only the `apiVersion` label to `v0alpha1` **without re-fetching the un-converted body**. Because `ToSaveBytes` strips `status`, the committed file's entire version identity is that mislabeled `apiVersion`.

The frontend can't load such a file: the request-side resolver (`DashboardAPIVersionResolver`) doesn't know the string `v0alpha1`, and the provisioning preview path (`DashboardScenePageStateManager.processDashboardFromProvisioning`) only branches `v2`-vs-classic — so the dashboard fails to render.

**Fix.** Fetch `v0`-stored dashboards at **v1** instead — lossless for classic dashboards and loadable by the frontend's v1/classic path — unifying the `v0` case with the re-fetch already used for other stored versions. All other stored versions (`v1`, `v2*`) are unchanged.

Backend-only, per the repo's separate FE/BE PR rule.

## Changes

- `jobs/export/resources.go`: `newDashboardConversionShim` now re-Gets `v0`-stored dashboards through the v1 client rather than relabeling the (lossily converted) listed body to `v0alpha1`.
- `jobs/export/resources_test.go`: replaced the old `SavedVersion` unit test with `TestExportResources_Dashboards_V0StoredVersionExportsAsV1`, asserting the v0→v1 re-fetch and exported apiVersion.
- `pkg/tests/apis/provisioning/jobs/exportjob_test.go`: updated the export integration tests' v0 expectations from `v0alpha1` → `v1` (v1/v2* cases unchanged).

## Testing

- `go test ./pkg/registry/apis/provisioning/jobs/export/ -run TestExportResources_Dashboards` — pass
- `go test ./pkg/tests/apis/provisioning/jobs/ -run 'TestIntegrationProvisioning_ExportDashboardsWithStoredVersions|TestIntegrationProvisioning_ExportUnifiedToRepository'` — pass (confirms a v0-created dashboard now exports as `dashboard.grafana.app/v1`)
- `gofmt` / `go vet` clean

## Notes / follow-ups

- This fixes **new** exports. Dashboards already committed to a repo as `v0alpha1` still need re-exporting to become loadable.
- The frontend provisioning-preview path still lacks version negotiation (trusts the globally-active manager instead of the file's `apiVersion`); a separate FE hardening PR could add defence-in-depth.

## Checklist

- [x] Tests added/updated (unit + integration)
- [ ] Documentation updated (n/a — internal export behavior)
- [x] No breaking changes for v1/v2 exports; v0 exports intentionally relabel to v1

🤖 Generated with [Claude Code](https://claude.com/claude-code)