### PR TITLE
Provisioning: Skip version history for provisioned dashboards

### DIFF
--- a/public/app/features/dashboard-scene/settings/VersionsEditView.test.tsx
+++ b/public/app/features/dashboard-scene/settings/VersionsEditView.test.tsx
@@ -2,7 +2,9 @@ import { render as RTLRender, screen } from '@testing-library/react';
 import * as React from 'react';
 import { TestProvider } from 'test/helpers/TestProvider';
 
+import { config } from '@grafana/runtime';
 import { SceneTimeRange } from '@grafana/scenes';
+import { AnnoKeyManagerKind, ManagerKind } from 'app/features/apiserver/types';
 import { VERSIONS_FETCH_LIMIT } from 'app/features/dashboard/types/revisionModels';
 import { type DashboardMeta } from 'app/types/dashboard';
 
@@ -250,6 +252,30 @@ describe('VersionsEditView', () => {
       render(<versionsView.Component model={versionsView} />);
 
       expect(await screen.findByText('user:uid-unknown')).toBeInTheDocument();
+    });
+  });
+
+  describe('Provisioned dashboards', () => {
+    beforeEach(() => {
+      config.featureToggles.provisioning = true;
+    });
+
+    afterEach(() => {
+      config.featureToggles.provisioning = false;
+      jest.clearAllMocks();
+    });
+
+    it('does not fetch version history and shows the not-available alert', async () => {
+      mockUseGetDisplayMappingQuery.mockReturnValue({ data: undefined });
+
+      const { versionsView } = await buildTestScene({
+        k8s: { annotations: { [AnnoKeyManagerKind]: ManagerKind.Repo } },
+      });
+      render(<versionsView.Component model={versionsView} />);
+
+      expect(await screen.findByText(/Version history is not available/)).toBeInTheDocument();
+      expect(mockListDashboardHistory).not.toHaveBeenCalled();
+      expect(versionsView.versions).toHaveLength(0);
     });
   });
 

--- a/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
@@ -62,6 +62,11 @@ export class VersionsEditView extends SceneObjectBase<VersionsEditViewState> imp
     });
 
     this.addActivationHandler(() => {
+      if (this._dashboard.isManagedRepository()) {
+        // The view only renders an unavailable alert for repo-managed dashboards.
+        this.setState({ isLoading: false, isAppending: false });
+        return;
+      }
       this.fetchVersions();
     });
   }


### PR DESCRIPTION
**What is this feature?**

For Git Sync-managed dashboards, Settings > Versions now shows the existing unavailable notice without requesting version history or author display mappings.

**Why do we need this feature?**

The view discards that data for repository-managed dashboards. Avoiding the unnecessary requests also removes the request path involved in #128232.

**Who is this feature for?**

Grafana users viewing version settings for Git Sync-managed dashboards.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/128232

