### PR TITLE
httpclient/harcapture: HAR capture buffer with redaction (for on-demand diagnostics)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -58,6 +58,7 @@ require (
 	github.com/charmbracelet/bubbles v1.0.0 // @grafana/grafana-app-platform-squad
 	github.com/charmbracelet/bubbletea v1.3.10 // @grafana/grafana-app-platform-squad
 	github.com/charmbracelet/lipgloss v1.1.0 // @grafana/grafana-app-platform-squad
+	github.com/chromedp/cdproto v0.0.0-20250803210736-d308e07a266d // @grafana/data-sources
 	github.com/crewjam/saml v0.4.14 // @grafana/identity-access-team
 	github.com/dgraph-io/badger/v4 v4.9.2 // @grafana/grafana-search-and-storage
 	github.com/dlmiddlecote/sqlstats v1.0.2 // @grafana/grafana-backend-group
@@ -404,7 +405,6 @@ require (
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/cheekybits/genny v1.0.0 // indirect
-	github.com/chromedp/cdproto v0.0.0-20250803210736-d308e07a266d // indirect
 	github.com/clipperhouse/displaywidth v0.11.0 // indirect
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
 	github.com/cloudflare/circl v1.6.3 // indirect

--- a/pkg/infra/httpclient/harcapture/harcapture.go
+++ b/pkg/infra/httpclient/harcapture/harcapture.go
@@ -121,6 +121,45 @@ func redactQueryParam(name, value string) string {
 	return value
 }
 
+// redactedQueryPairs parses a raw query string into HAR name/value pairs with sensitive values
+// redacted. Unlike url.Query() (which splits only on "&"), it splits on both "&" and ";" and fails
+// closed on an undecodable key -- matching redactedURLString -- so a secret after a ";" (e.g.
+// foo=bar;token=SECRET, which url.Query() would leave inside foo's value) is redacted here too.
+func redactedQueryPairs(rawQuery string) []*har.NameValuePair {
+	if rawQuery == "" {
+		return nil
+	}
+	var pairs []*har.NameValuePair
+	for _, seg := range strings.Split(rawQuery, "&") {
+		for _, sub := range strings.Split(seg, ";") {
+			if sub == "" {
+				continue
+			}
+			rawKey, rawVal, hasValue := strings.Cut(sub, "=")
+			name, keyErr := url.QueryUnescape(rawKey)
+			if keyErr != nil {
+				name = rawKey
+			}
+			var value string
+			if hasValue {
+				if v, err := url.QueryUnescape(rawVal); err == nil {
+					value = v
+				} else {
+					value = rawVal
+				}
+				if keyErr != nil {
+					// Fail closed: the key can't be decoded to check against the denylist.
+					value = redactedValue
+				} else {
+					value = redactQueryParam(name, value)
+				}
+			}
+			pairs = append(pairs, &har.NameValuePair{Name: name, Value: value})
+		}
+	}
+	return pairs
+}
+
 // redactedURLString renders u with inline credentials stripped and sensitive query params redacted.
 // The query is only rewritten when a param was actually redacted, so an otherwise-untouched URL is
 // preserved verbatim (parameter order and encoding unchanged).
@@ -288,22 +327,7 @@ func (b *Buffer) ToHAR() ([]byte, error) {
 func buildEntry(req *http.Request, resp *http.Response, rtErr error, started time.Time, elapsed time.Duration, extra map[string]struct{}) *har.Entry {
 	reqHeaders := toNameValues(req.Header, extra)
 
-	// The queryString HAR array uses url.Query(): unlike the URL string (redactedURLString, which
-	// parses RawQuery manually and fails closed), url.Query() silently drops any malformed pair, so
-	// such a pair is simply absent here rather than leaked -- and every pair that does parse is run
-	// through redactQueryParam. The redacted URL string above is the authoritative fail-closed copy.
-	query := req.URL.Query()
-	queryKeys := make([]string, 0, len(query))
-	for k := range query {
-		queryKeys = append(queryKeys, k)
-	}
-	sort.Strings(queryKeys)
-	queryString := make([]*har.NameValuePair, 0, len(query))
-	for _, k := range queryKeys {
-		for _, v := range query[k] {
-			queryString = append(queryString, &har.NameValuePair{Name: k, Value: redactQueryParam(k, v)})
-		}
-	}
+	queryString := redactedQueryPairs(req.URL.RawQuery)
 
 	var pd *har.PostData
 	var reqBodySize int64

--- a/pkg/infra/httpclient/harcapture/harcapture.go
+++ b/pkg/infra/httpclient/harcapture/harcapture.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -67,6 +68,8 @@ var sensitiveQueryParams = map[string]struct{}{
 	"api_key":       {},
 	"apikey":        {},
 	"access_token":  {},
+	"refresh_token": {},
+	"id_token":      {},
 	"auth_token":    {},
 	"token":         {},
 	"private_token": {},
@@ -331,7 +334,10 @@ func buildEntry(req *http.Request, resp *http.Response, rtErr error, started tim
 	harResp := &har.Response{HeadersSize: -1, Content: &har.Content{}}
 	if resp != nil {
 		harResp.Status = int64(resp.StatusCode)
-		harResp.StatusText = resp.Status
+		// HAR statusText is the reason phrase only ("OK"), but resp.Status is the full status line
+		// ("200 OK"); strip the leading code (keeping the server's actual phrase) so entries match
+		// the HAR 1.2 replay format.
+		harResp.StatusText = strings.TrimSpace(strings.TrimPrefix(resp.Status, strconv.Itoa(resp.StatusCode)))
 		harResp.HTTPVersion = resp.Proto
 		harResp.Headers = toNameValues(resp.Header, extra)
 		harResp.Cookies = toCookies(resp.Cookies())

--- a/pkg/infra/httpclient/harcapture/harcapture.go
+++ b/pkg/infra/httpclient/harcapture/harcapture.go
@@ -148,11 +148,18 @@ func redactedURLString(u *url.URL) string {
 			subs := strings.Split(seg, ";")
 			for j, sub := range subs {
 				key, _, hasValue := strings.Cut(sub, "=")
-				name := key
-				if unescaped, err := url.QueryUnescape(key); err == nil {
-					name = unescaped
+				if !hasValue {
+					continue // no value to redact
 				}
-				if _, sensitive := sensitiveQueryParams[strings.ToLower(name)]; sensitive && hasValue {
+				name, err := url.QueryUnescape(key)
+				if err != nil {
+					// Fail closed: the key can't be decoded to compare against the denylist, so we
+					// can't prove it isn't sensitive -- redact the value rather than risk leaking it.
+					subs[j] = key + "=" + redactedValue
+					changed = true
+					continue
+				}
+				if _, sensitive := sensitiveQueryParams[strings.ToLower(name)]; sensitive {
 					subs[j] = key + "=" + redactedValue
 					changed = true
 				}
@@ -278,6 +285,10 @@ func (b *Buffer) ToHAR() ([]byte, error) {
 func buildEntry(req *http.Request, resp *http.Response, rtErr error, started time.Time, elapsed time.Duration, extra map[string]struct{}) *har.Entry {
 	reqHeaders := toNameValues(req.Header, extra)
 
+	// The queryString HAR array uses url.Query(): unlike the URL string (redactedURLString, which
+	// parses RawQuery manually and fails closed), url.Query() silently drops any malformed pair, so
+	// such a pair is simply absent here rather than leaked -- and every pair that does parse is run
+	// through redactQueryParam. The redacted URL string above is the authoritative fail-closed copy.
 	query := req.URL.Query()
 	queryKeys := make([]string, 0, len(query))
 	for k := range query {

--- a/pkg/infra/httpclient/harcapture/harcapture.go
+++ b/pkg/infra/httpclient/harcapture/harcapture.go
@@ -1,0 +1,416 @@
+package harcapture
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+	"unicode/utf8"
+
+	"github.com/chromedp/cdproto/har"
+)
+
+// urlInText matches URL substrings in freeform text, e.g. a Go net/url.Error message, which renders
+// the full request URL including its query string. Case-insensitive (URL schemes are case-insensitive
+// per RFC 3986 and net/url preserves the original case) and scheme-agnostic (so credentials in a
+// non-HTTP DSN such as redis://user:pass@host or postgres://... are redacted too, not just http(s)).
+var urlInText = regexp.MustCompile(`(?i)[a-z][a-z0-9+.-]*://[^\s"'<>]+`)
+
+// RedactErrorText redacts inline credentials, fragments, and sensitive query params from any URL
+// substrings in a freeform error message. Transport errors (net/url.Error) embed the full request
+// URL -- query string included -- and Go only masks userinfo passwords, not query params, so an
+// unredacted error would leak a datasource credential carried in a query param (e.g. ?api_key=,
+// Azure ?sig=) into a bundle meant for external sharing. Non-URL text is returned unchanged.
+func RedactErrorText(msg string) string {
+	return urlInText.ReplaceAllStringFunc(msg, func(u string) string {
+		// Strip trailing punctuation the error format appends after the URL (": ", ".", ")", ...)
+		// so it is not fed to url.Parse and then re-appended verbatim.
+		trailing := ""
+		for len(u) > 0 && strings.IndexByte(":.,;)]}", u[len(u)-1]) >= 0 {
+			trailing = string(u[len(u)-1]) + trailing
+			u = u[:len(u)-1]
+		}
+		return redactURLValue(u) + trailing
+	})
+}
+
+// redactedValue replaces sensitive header/cookie/query values in captured traffic. Diagnostic
+// bundles are meant to be shared (often externally), and the capture sits after the middlewares
+// that inject auth headers, so credentials must never reach the archive.
+const redactedValue = "[REDACTED]"
+
+// sensitiveHeaders (canonical form) have their value redacted in captured HAR entries.
+var sensitiveHeaders = map[string]struct{}{
+	"Authorization":        {},
+	"Proxy-Authorization":  {},
+	"Www-Authenticate":     {},
+	"Cookie":               {},
+	"Set-Cookie":           {},
+	"X-Api-Key":            {},
+	"Api-Key":              {},
+	"X-Auth-Token":         {},
+	"X-Grafana-Id":         {},
+	"X-Id-Token":           {},
+	"X-Amz-Security-Token": {}, // AWS SigV4 header-based auth (IRSA / temporary credentials)
+}
+
+// sensitiveQueryParams (lower-case) have their value redacted in captured request URLs.
+var sensitiveQueryParams = map[string]struct{}{
+	"api_key":       {},
+	"apikey":        {},
+	"access_token":  {},
+	"auth_token":    {},
+	"token":         {},
+	"private_token": {},
+	"password":      {},
+	"passwd":        {},
+	"pwd":           {},
+	"secret":        {},
+	"client_secret": {},
+	"signature":     {},
+	"sig":           {}, // Azure SAS
+	// AWS SigV4 presigned URLs
+	"x-amz-signature":      {},
+	"x-amz-credential":     {},
+	"x-amz-security-token": {},
+	// GCS signed URLs
+	"x-goog-signature":  {},
+	"x-goog-credential": {},
+}
+
+// urlValuedHeaders (canonical form) carry a URL whose query string may hold secrets; their value is
+// query-redacted (rather than dropped) so the redirect/referrer target stays visible.
+var urlValuedHeaders = map[string]struct{}{
+	"Location":         {},
+	"Content-Location": {},
+	"Referer":          {},
+}
+
+// redactHeader redacts a header value if its name is in the static denylist or in extra -- the
+// per-request set of datasource "Custom HTTP Headers" names, which carry secrets under arbitrary
+// names the static denylist can't enumerate. extra may be nil.
+func redactHeader(name, value string, extra map[string]struct{}) string {
+	canonical := http.CanonicalHeaderKey(name)
+	if _, ok := sensitiveHeaders[canonical]; ok {
+		return redactedValue
+	}
+	if _, ok := extra[canonical]; ok {
+		return redactedValue
+	}
+	if _, ok := urlValuedHeaders[canonical]; ok {
+		return redactURLValue(value)
+	}
+	return value
+}
+
+func redactQueryParam(name, value string) string {
+	if _, ok := sensitiveQueryParams[strings.ToLower(name)]; ok {
+		return redactedValue
+	}
+	return value
+}
+
+// redactedURLString renders u with inline credentials stripped and sensitive query params redacted.
+// The query is only rewritten when a param was actually redacted, so an otherwise-untouched URL is
+// preserved verbatim (parameter order and encoding unchanged).
+func redactedURLString(u *url.URL) string {
+	if u == nil {
+		return ""
+	}
+	redacted := *u
+	redacted.User = nil // drop any inline user:password@ credentials
+	// Drop any #fragment: it can carry secrets (e.g. an OAuth implicit-flow #access_token=...) and
+	// is query-shaped but not covered by the query-param redaction below, so fail closed.
+	redacted.Fragment = ""
+	redacted.RawFragment = ""
+	if redacted.RawQuery != "" {
+		// Parse RawQuery manually rather than via url.Query(): url.Query() silently drops any pair
+		// whose value has a malformed percent-escape (e.g. sig=abc%ZZ), which would leave that
+		// sensitive value in RawQuery unredacted -- a fail-open. Splitting the raw string never drops
+		// a pair, and preserves parameter order/encoding for the untouched ones.
+		changed := false
+		// Split on both "&" and ";": ";" is a historically-valid query separator, so a secret after
+		// one (?foo=bar;token=SECRET) would otherwise ride along inside a non-sensitive segment
+		// unredacted. Both separators round-trip through Split/Join, so untouched params keep their
+		// exact bytes (and the changed gate leaves the query verbatim when nothing was redacted). We
+		// deliberately do NOT split on "," or "|" — those are ordinary characters in real query
+		// values (e.g. region=us,eu), not separators.
+		amp := strings.Split(redacted.RawQuery, "&")
+		for i, seg := range amp {
+			subs := strings.Split(seg, ";")
+			for j, sub := range subs {
+				key, _, hasValue := strings.Cut(sub, "=")
+				name := key
+				if unescaped, err := url.QueryUnescape(key); err == nil {
+					name = unescaped
+				}
+				if _, sensitive := sensitiveQueryParams[strings.ToLower(name)]; sensitive && hasValue {
+					subs[j] = key + "=" + redactedValue
+					changed = true
+				}
+			}
+			amp[i] = strings.Join(subs, ";")
+		}
+		if changed {
+			redacted.RawQuery = strings.Join(amp, "&")
+		}
+	}
+	return redacted.String()
+}
+
+// redactURLValue query-redacts a URL-valued string, failing closed: a value that can't be parsed
+// can't be safely query-redacted, so it is dropped (redactedValue) rather than passed through. This
+// matters because net/url.Parse rejects some inputs (e.g. a raw control character a misbehaving
+// datasource might emit), and this bundle is meant for external sharing.
+func redactURLValue(value string) string {
+	u, err := url.Parse(value)
+	if err != nil {
+		return redactedValue
+	}
+	return redactedURLString(u)
+}
+
+// encodeBody returns the HAR text representation of a body plus its encoding. Valid UTF-8 is stored
+// as-is; binary payloads are base64-encoded (with encoding "base64") so they survive JSON marshaling
+// intact instead of being corrupted by string() replacing invalid bytes with U+FFFD.
+func encodeBody(body []byte) (text, encoding string) {
+	if utf8.Valid(body) {
+		return string(body), ""
+	}
+	return base64.StdEncoding.EncodeToString(body), "base64"
+}
+
+type contextKey struct{}
+
+// Buffer collects HTTP request/response pairs as HAR 1.2 entries in memory.
+type Buffer struct {
+	mu      sync.Mutex
+	entries []*har.Entry
+	// extraSensitive holds per-request header names (canonical form) to redact in addition to the
+	// static denylist -- e.g. a datasource's "Custom HTTP Headers", which carry secrets under
+	// arbitrary names. Populated via MarkSensitiveHeaders as the client middleware chain is built.
+	extraSensitive map[string]struct{}
+}
+
+// MarkSensitiveHeaders registers header names whose values must be redacted from captured entries,
+// in addition to the static denylist. Names are canonicalized. Thread-safe.
+func (b *Buffer) MarkSensitiveHeaders(names ...string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.extraSensitive == nil {
+		b.extraSensitive = make(map[string]struct{}, len(names))
+	}
+	for _, n := range names {
+		b.extraSensitive[http.CanonicalHeaderKey(n)] = struct{}{}
+	}
+}
+
+// snapshotSensitive returns a copy of the extra sensitive-header set, safe to read without the lock.
+func (b *Buffer) snapshotSensitive() map[string]struct{} {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if len(b.extraSensitive) == 0 {
+		return nil
+	}
+	cp := make(map[string]struct{}, len(b.extraSensitive))
+	for k := range b.extraSensitive {
+		cp[k] = struct{}{}
+	}
+	return cp
+}
+
+// WithCapture returns a child context carrying a new Buffer and the buffer itself.
+func WithCapture(ctx context.Context) (context.Context, *Buffer) {
+	buf := &Buffer{}
+	return context.WithValue(ctx, contextKey{}, buf), buf
+}
+
+// FromContext returns the Buffer stored in ctx, or nil if absent.
+func FromContext(ctx context.Context) *Buffer {
+	v, _ := ctx.Value(contextKey{}).(*Buffer)
+	return v
+}
+
+// AddEntry appends a captured request/response pair. rtErr is the RoundTrip error (nil on success);
+// a transport-level failure (connection refused, DNS/TLS error, timeout) leaves resp nil and is
+// recorded in the entry's comment. Thread-safe.
+func (b *Buffer) AddEntry(req *http.Request, resp *http.Response, rtErr error, started time.Time, elapsed time.Duration) {
+	e := buildEntry(req, resp, rtErr, started, elapsed, b.snapshotSensitive())
+	b.mu.Lock()
+	b.entries = append(b.entries, e)
+	b.mu.Unlock()
+}
+
+// Len returns the number of captured entries. Thread-safe.
+func (b *Buffer) Len() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return len(b.entries)
+}
+
+// ToHAR serializes the captured entries to HAR 1.2 JSON. The entry types come from
+// github.com/chromedp/cdproto/har -- the same library the plugin SDK's e2e HAR storage uses -- so
+// the output stays replay-compatible with that fixture format.
+func (b *Buffer) ToHAR() ([]byte, error) {
+	b.mu.Lock()
+	entries := make([]*har.Entry, len(b.entries))
+	copy(entries, b.entries)
+	b.mu.Unlock()
+
+	doc := har.HAR{
+		Log: &har.Log{
+			Version: "1.2",
+			Creator: &har.Creator{Name: "Grafana", Version: "1.0"},
+			Entries: entries,
+		},
+	}
+	return json.Marshal(doc)
+}
+
+func buildEntry(req *http.Request, resp *http.Response, rtErr error, started time.Time, elapsed time.Duration, extra map[string]struct{}) *har.Entry {
+	reqHeaders := toNameValues(req.Header, extra)
+
+	query := req.URL.Query()
+	queryKeys := make([]string, 0, len(query))
+	for k := range query {
+		queryKeys = append(queryKeys, k)
+	}
+	sort.Strings(queryKeys)
+	queryString := make([]*har.NameValuePair, 0, len(query))
+	for _, k := range queryKeys {
+		for _, v := range query[k] {
+			queryString = append(queryString, &har.NameValuePair{Name: k, Value: redactQueryParam(k, v)})
+		}
+	}
+
+	var pd *har.PostData
+	var reqBodySize int64
+	if req.Body != nil {
+		body, readErr := io.ReadAll(req.Body)
+		if readErr != nil {
+			// Mirror the response-body path: restore the captured (partial) bytes followed by the
+			// error rather than leaving req.Body consumed, so a caller of this shared helper can
+			// still read the body and observe the failure.
+			req.Body = io.NopCloser(io.MultiReader(bytes.NewReader(body), &errorReader{err: readErr}))
+		} else {
+			req.Body = io.NopCloser(bytes.NewReader(body))
+			reqBodySize = int64(len(body))
+			if len(body) > 0 {
+				// HAR PostData has no encoding field, so a binary request body is base64-encoded to
+				// avoid corruption on marshal (datasource request bodies are text in practice).
+				text, _ := encodeBody(body)
+				pd = &har.PostData{
+					MimeType: req.Header.Get("Content-Type"),
+					Text:     text,
+				}
+			}
+		}
+	}
+
+	// Content is required by the HAR spec and dereferenced unconditionally by the SDK's replay, so
+	// always attach a (possibly empty) Content, even for transport failures with no response body.
+	harResp := &har.Response{HeadersSize: -1, Content: &har.Content{}}
+	if resp != nil {
+		harResp.Status = int64(resp.StatusCode)
+		harResp.StatusText = resp.Status
+		harResp.HTTPVersion = resp.Proto
+		harResp.Headers = toNameValues(resp.Header, extra)
+		harResp.Cookies = toCookies(resp.Cookies())
+		if loc := resp.Header.Get("Location"); loc != "" {
+			harResp.RedirectURL = redactURLValue(loc)
+		}
+		if resp.Body != nil {
+			// Drain then Close the original transport body so its connection is returned to the
+			// idle pool (per the net/http contract), then hand the caller a fresh reader over the
+			// captured bytes.
+			body, readErr := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			if readErr != nil {
+				// Preserve the original read failure for the caller: replay the captured bytes,
+				// then surface the same error rather than silently substituting a truncated body.
+				resp.Body = io.NopCloser(io.MultiReader(bytes.NewReader(body), &errorReader{err: readErr}))
+			} else {
+				resp.Body = io.NopCloser(bytes.NewReader(body))
+			}
+			harResp.BodySize = int64(len(body))
+			text, encoding := encodeBody(body)
+			harResp.Content = &har.Content{
+				Size:     int64(len(body)),
+				MimeType: resp.Header.Get("Content-Type"),
+				Text:     text,
+				Encoding: encoding,
+			}
+		}
+	}
+
+	var comment string
+	if rtErr != nil {
+		// Redact URLs in the transport error: it can embed the full request URL (with secret query
+		// params), and this comment is written verbatim into the externally-shared bundle.
+		comment = "transport error: " + RedactErrorText(rtErr.Error())
+	}
+
+	waitMs := float64(elapsed.Milliseconds())
+	return &har.Entry{
+		StartedDateTime: started.UTC().Format(time.RFC3339Nano),
+		Time:            waitMs,
+		Request: &har.Request{
+			Method:      req.Method,
+			URL:         redactedURLString(req.URL),
+			HTTPVersion: req.Proto,
+			Headers:     reqHeaders,
+			QueryString: queryString,
+			Cookies:     toCookies(req.Cookies()),
+			PostData:    pd,
+			BodySize:    reqBodySize,
+			HeadersSize: -1,
+		},
+		Response: harResp,
+		Cache:    &har.Cache{},
+		Timings:  &har.Timings{Send: 0, Wait: waitMs, Receive: 0},
+		Comment:  comment,
+	}
+}
+
+// toNameValues flattens an http.Header into HAR name/value pairs, emitting one pair per value so
+// repeated headers (e.g. multiple Set-Cookie) are preserved, in sorted order for deterministic output.
+func toNameValues(h http.Header, extra map[string]struct{}) []*har.NameValuePair {
+	names := make([]string, 0, len(h))
+	for name := range h {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	result := make([]*har.NameValuePair, 0, len(h))
+	for _, name := range names {
+		for _, v := range h[name] {
+			result = append(result, &har.NameValuePair{Name: name, Value: redactHeader(name, v, extra)})
+		}
+	}
+	return result
+}
+
+// toCookies converts parsed HTTP cookies into HAR cookie entries (name/value), matching the SDK
+// e2e HAR storage output so captured traffic stays replayable by the E2E fixture proxy.
+func toCookies(cookies []*http.Cookie) []*har.Cookie {
+	// Cookie values are session/auth tokens; keep the name for context but always redact the value.
+	result := make([]*har.Cookie, 0, len(cookies))
+	for _, c := range cookies {
+		result = append(result, &har.Cookie{Name: c.Name, Value: redactedValue})
+	}
+	return result
+}
+
+// errorReader yields the wrapped error on Read. Used to re-surface a response-body read failure to
+// the caller after the captured (partial) bytes have been replayed.
+type errorReader struct{ err error }
+
+func (r *errorReader) Read([]byte) (int, error) { return 0, r.err }

--- a/pkg/infra/httpclient/harcapture/harcapture_test.go
+++ b/pkg/infra/httpclient/harcapture/harcapture_test.go
@@ -261,6 +261,29 @@ func TestRedactedURLString_failsClosedOnMalformedKey(t *testing.T) {
 	assert.Contains(t, out, "region=eu", "well-formed non-sensitive param preserved")
 }
 
+func TestRedactsOAuthTokenQueryParams(t *testing.T) {
+	for _, p := range []string{"access_token", "refresh_token", "id_token"} {
+		out := redactURLValue("https://idp.example.com/cb?" + p + "=SECRET&state=ok")
+		assert.NotContains(t, out, "SECRET", p+" must be redacted")
+		assert.Contains(t, out, "state=ok", "non-sensitive param preserved alongside "+p)
+	}
+}
+
+func TestBuffer_ToHAR_statusTextIsReasonPhrase(t *testing.T) {
+	_, buf := WithCapture(context.Background())
+	resp := okResp(200)    //nolint:bodyclose
+	resp.Status = "200 OK" // real net/http status line (full), not just the reason phrase
+	buf.AddEntry(newGetReq(t, "http://example.com"), resp, nil, time.Now(), time.Millisecond)
+
+	raw, err := buf.ToHAR()
+	require.NoError(t, err)
+	var doc har.HAR
+	require.NoError(t, json.Unmarshal(raw, &doc))
+	// HAR 1.2 statusText is the reason phrase only, not the full "200 OK" status line.
+	assert.Equal(t, int64(200), doc.Log.Entries[0].Response.Status)
+	assert.Equal(t, "OK", doc.Log.Entries[0].Response.StatusText)
+}
+
 func TestRedactURLValue_failsClosedOnUnparseable(t *testing.T) {
 	// net/url.Parse rejects raw control characters; such a value can't be query-redacted, so it
 	// must be dropped rather than passed through into a bundle meant for external sharing.

--- a/pkg/infra/httpclient/harcapture/harcapture_test.go
+++ b/pkg/infra/httpclient/harcapture/harcapture_test.go
@@ -1,0 +1,411 @@
+package harcapture
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/chromedp/cdproto/har"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithCapture(t *testing.T) {
+	ctx := context.Background()
+	child, buf := WithCapture(ctx)
+
+	require.NotNil(t, buf)
+	assert.Same(t, buf, FromContext(child))
+	assert.Nil(t, FromContext(ctx), "parent context must not carry the buffer")
+}
+
+func TestFromContext_absent(t *testing.T) {
+	assert.Nil(t, FromContext(context.Background()))
+}
+
+func TestBuffer_Len(t *testing.T) {
+	_, buf := WithCapture(context.Background())
+	assert.Equal(t, 0, buf.Len())
+
+	buf.AddEntry(newGetReq(t, "http://example.com"), okResp(200), nil, time.Now(), time.Millisecond) //nolint:bodyclose
+	assert.Equal(t, 1, buf.Len())
+}
+
+func TestBuffer_ToHAR_structure(t *testing.T) {
+	_, buf := WithCapture(context.Background())
+
+	req := newPostReq(t, "http://ds.example.com/query", `{"q":"test"}`)
+	resp := okResp(200) //nolint:bodyclose
+	resp.Body = io.NopCloser(bytes.NewBufferString(`{"data":"result"}`))
+	resp.Header.Set("Content-Type", "application/json")
+
+	buf.AddEntry(req, resp, nil, time.Now(), 42*time.Millisecond)
+
+	raw, err := buf.ToHAR()
+	require.NoError(t, err)
+
+	var doc har.HAR
+	require.NoError(t, json.Unmarshal(raw, &doc))
+
+	assert.Equal(t, "1.2", doc.Log.Version)
+	require.Len(t, doc.Log.Entries, 1)
+
+	e := doc.Log.Entries[0]
+	assert.Equal(t, "POST", e.Request.Method)
+	assert.Equal(t, "http://ds.example.com/query", e.Request.URL)
+	assert.Equal(t, `{"q":"test"}`, e.Request.PostData.Text)
+	assert.Equal(t, int64(200), e.Response.Status)
+	assert.Equal(t, `{"data":"result"}`, e.Response.Content.Text)
+	assert.InDelta(t, 42.0, e.Time, 1.0)
+}
+
+func TestBuffer_ToHAR_requestBodyRestored(t *testing.T) {
+	_, buf := WithCapture(context.Background())
+
+	req := newPostReq(t, "http://example.com", `body`)
+	buf.AddEntry(req, okResp(200), nil, time.Now(), time.Millisecond) //nolint:bodyclose
+
+	// body must still be readable after AddEntry
+	body, err := io.ReadAll(req.Body)
+	require.NoError(t, err)
+	assert.Equal(t, "body", string(body))
+}
+
+func TestBuffer_ToHAR_responseBodyRestored(t *testing.T) {
+	_, buf := WithCapture(context.Background())
+
+	resp := okResp(200) //nolint:bodyclose
+	resp.Body = io.NopCloser(bytes.NewBufferString("response"))
+	buf.AddEntry(newGetReq(t, "http://example.com"), resp, nil, time.Now(), time.Millisecond)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, "response", string(body))
+}
+
+func TestBuffer_ToHAR_responseBodyReadError_surfacedToCaller(t *testing.T) {
+	_, buf := WithCapture(context.Background())
+
+	wantErr := errors.New("read boom")
+	resp := okResp(200) //nolint:bodyclose
+	resp.Body = io.NopCloser(&partialThenErrorReader{data: []byte("partial"), err: wantErr})
+
+	buf.AddEntry(newGetReq(t, "http://example.com"), resp, nil, time.Now(), time.Millisecond)
+
+	// The caller reads the captured bytes, then the original read error is re-surfaced rather
+	// than being silently swallowed and replaced with a truncated-but-successful body.
+	got, err := io.ReadAll(resp.Body)
+	assert.Equal(t, "partial", string(got))
+	assert.ErrorIs(t, err, wantErr)
+
+	raw, e := buf.ToHAR()
+	require.NoError(t, e)
+	var doc har.HAR
+	require.NoError(t, json.Unmarshal(raw, &doc))
+	require.Len(t, doc.Log.Entries, 1)
+	assert.Equal(t, "partial", doc.Log.Entries[0].Response.Content.Text)
+}
+
+func TestBuffer_ToHAR_requestBodyReadError_restored(t *testing.T) {
+	_, buf := WithCapture(context.Background())
+
+	wantErr := errors.New("req read boom")
+	req := newGetReq(t, "http://example.com")
+	req.Body = io.NopCloser(&partialThenErrorReader{data: []byte("partial-req"), err: wantErr})
+
+	buf.AddEntry(req, okResp(200), nil, time.Now(), time.Millisecond) //nolint:bodyclose
+
+	// Symmetric with the response path: req.Body is restored (captured bytes then the error),
+	// not left consumed.
+	got, err := io.ReadAll(req.Body)
+	assert.Equal(t, "partial-req", string(got))
+	assert.ErrorIs(t, err, wantErr)
+}
+
+func TestBuffer_ToHAR_redactsSensitiveData(t *testing.T) {
+	_, buf := WithCapture(context.Background())
+
+	req := newGetReq(t, "http://ds.example.com/query?api_key=QUERYSECRET&X-Amz-Signature=AWSSIG&region=us-east-1")
+	req.Header.Set("Authorization", "Bearer super-secret-token")
+	req.Header.Set("X-Grafana-Id", "id-token-value")
+	req.Header.Set("X-Amz-Security-Token", "AWSSESSION")
+	req.Header.Set("Accept", "application/json")
+	req.AddCookie(&http.Cookie{Name: "grafana_session", Value: "req-cookie-secret"})
+
+	resp := okResp(200) //nolint:bodyclose
+	resp.Header.Set("Set-Cookie", "grafana_session=resp-cookie-secret; Path=/")
+
+	buf.AddEntry(req, resp, nil, time.Now(), time.Millisecond)
+
+	raw, err := buf.ToHAR()
+	require.NoError(t, err)
+	s := string(raw)
+
+	// Secrets must not appear anywhere in the serialized HAR (headers, cookies, query, or URL).
+	for _, secret := range []string{"super-secret-token", "id-token-value", "AWSSESSION", "QUERYSECRET", "AWSSIG", "req-cookie-secret", "resp-cookie-secret"} {
+		assert.NotContains(t, s, secret, "secret leaked into HAR")
+	}
+	assert.Contains(t, s, redactedValue)
+	// Non-sensitive values are preserved.
+	assert.Contains(t, s, "us-east-1")
+	assert.Contains(t, s, "application/json")
+}
+
+func TestBuffer_ToHAR_binaryResponseBody_base64(t *testing.T) {
+	_, buf := WithCapture(context.Background())
+
+	binary := []byte{0xff, 0xfe, 0x00, 0x01, 0x80, 0x02} // invalid UTF-8
+	resp := okResp(200)                                  //nolint:bodyclose
+	resp.Body = io.NopCloser(bytes.NewReader(binary))
+	resp.Header.Set("Content-Type", "application/octet-stream")
+
+	buf.AddEntry(newGetReq(t, "http://example.com"), resp, nil, time.Now(), time.Millisecond)
+
+	raw, err := buf.ToHAR()
+	require.NoError(t, err)
+	var doc har.HAR
+	require.NoError(t, json.Unmarshal(raw, &doc))
+
+	c := doc.Log.Entries[0].Response.Content
+	assert.Equal(t, "base64", c.Encoding, "binary body flagged as base64")
+	assert.Equal(t, int64(len(binary)), c.Size, "size reflects the raw byte length")
+
+	decoded, err := base64.StdEncoding.DecodeString(c.Text)
+	require.NoError(t, err)
+	assert.Equal(t, binary, decoded, "binary body round-trips losslessly")
+}
+
+func TestBuffer_ToHAR_redactsURLsAndCredentials(t *testing.T) {
+	_, buf := WithCapture(context.Background())
+
+	// Inline credentials + a non-sensitive query on the request URL.
+	req := newGetReq(t, "https://user:pass@ds.example.com/api?b=2&a=1")
+	resp := okResp(302) //nolint:bodyclose
+	// A redirect whose Location carries a secret in its query string.
+	resp.Header.Set("Location", "https://idp.example.com/cb?access_token=SECRET&state=ok")
+
+	buf.AddEntry(req, resp, nil, time.Now(), time.Millisecond)
+
+	raw, err := buf.ToHAR()
+	require.NoError(t, err)
+	s := string(raw)
+
+	assert.NotContains(t, s, "user:pass", "inline URL credentials are dropped")
+	assert.NotContains(t, s, "SECRET", "sensitive param in the redirect Location is redacted")
+	assert.Contains(t, s, "state=ok", "non-sensitive redirect param is kept")
+
+	var doc har.HAR
+	require.NoError(t, json.Unmarshal(raw, &doc))
+	// No sensitive request params -> the query is preserved verbatim (order not rewritten).
+	assert.Equal(t, "https://ds.example.com/api?b=2&a=1", doc.Log.Entries[0].Request.URL)
+	assert.NotContains(t, doc.Log.Entries[0].Response.RedirectURL, "SECRET")
+}
+
+func TestRedactErrorText(t *testing.T) {
+	// A Go *url.Error renders the full request URL (query string included); the secret query param
+	// must be redacted while the surrounding message and non-sensitive params survive.
+	in := `Get "https://ds.example.com/api?api_key=SECRET&region=eu": dial tcp: connection refused`
+	out := RedactErrorText(in)
+	assert.NotContains(t, out, "SECRET", "secret query param must be redacted from error text")
+	assert.Contains(t, out, "region=eu", "non-sensitive param preserved")
+	assert.Contains(t, out, "connection refused", "surrounding error message preserved")
+
+	// Unquoted URL form followed by ": " — trailing colon must not defeat parsing/redaction.
+	in2 := `Get https://ds.example.com/q?token=SECRET: EOF`
+	assert.NotContains(t, RedactErrorText(in2), "SECRET")
+
+	// Uppercase/mixed-case scheme must still be redacted (URL schemes are case-insensitive).
+	assert.NotContains(t, RedactErrorText(`Get "HTTPS://host/db?api_key=SUPERSECRET": refused`), "SUPERSECRET")
+
+	// Non-HTTP scheme DSNs carrying inline credentials must have the userinfo dropped.
+	assert.NotContains(t, RedactErrorText(`dial redis://default:hunter2@host:6379: timeout`), "hunter2")
+
+	// A malformed percent-escape in a sensitive param must not fail open (url.Query drops it).
+	assert.NotContains(t, RedactErrorText(`Get "https://host/p?sig=abc%ZZ": bad`), "abc%ZZ")
+
+	// A secret after a ";" separator must be redacted (";" is a valid query separator)...
+	assert.NotContains(t, RedactErrorText(`Get "https://host/p?foo=bar;token=SECRET": bad`), "SECRET")
+	// ...but "," is an ordinary value char and must NOT be treated as a separator.
+	out2 := RedactErrorText(`Get "https://host/p?region=us,eu&token=SECRET": bad`)
+	assert.NotContains(t, out2, "SECRET")
+	assert.Contains(t, out2, "region=us,eu", "comma-containing values are preserved, not split")
+
+	// Non-URL text is returned unchanged.
+	assert.Equal(t, "context deadline exceeded", RedactErrorText("context deadline exceeded"))
+}
+
+func TestRedactedURLString_dropsFragment(t *testing.T) {
+	// A #fragment can carry a token (OAuth implicit flow); it must be dropped, not passed through.
+	u, err := url.Parse("https://idp.example.com/cb?state=ok#access_token=SECRET")
+	require.NoError(t, err)
+	out := redactedURLString(u)
+	assert.NotContains(t, out, "SECRET")
+	assert.NotContains(t, out, "access_token")
+	assert.Equal(t, "https://idp.example.com/cb?state=ok", out)
+}
+
+func TestRedactURLValue_failsClosedOnUnparseable(t *testing.T) {
+	// net/url.Parse rejects raw control characters; such a value can't be query-redacted, so it
+	// must be dropped rather than passed through into a bundle meant for external sharing.
+	bad := "https://idp.example.com/cb?access_token=SECRET\x7f"
+	require.Error(t, func() error { _, err := url.Parse(bad); return err }(), "guard: value must be unparseable")
+
+	assert.Equal(t, redactedValue, redactURLValue(bad))
+	// The same must hold when the value arrives via a URL-valued header (Location/Referer/...).
+	assert.Equal(t, redactedValue, redactHeader("Location", bad, nil))
+	assert.NotContains(t, redactHeader("Referer", bad, nil), "SECRET")
+
+	// A parseable URL is still query-redacted in place (not dropped wholesale).
+	ok := redactHeader("Location", "https://idp.example.com/cb?access_token=SECRET&state=ok", nil)
+	assert.NotContains(t, ok, "SECRET")
+	assert.Contains(t, ok, "state=ok")
+}
+
+func TestToNameValues_sortedAndMultiValue(t *testing.T) {
+	h := http.Header{
+		"X-Zeta":  {"z"},
+		"X-Alpha": {"a1", "a2"}, // repeated header values must all be preserved
+	}
+
+	assert.Equal(t, []*har.NameValuePair{
+		{Name: "X-Alpha", Value: "a1"},
+		{Name: "X-Alpha", Value: "a2"},
+		{Name: "X-Zeta", Value: "z"},
+	}, toNameValues(h, nil), "names sorted, one pair per value")
+}
+
+func TestBuffer_ToHAR_transportError_recordedInComment(t *testing.T) {
+	_, buf := WithCapture(context.Background())
+	// A failed dial has no HTTP response; the attempt (and why it failed) must still be captured.
+	buf.AddEntry(newGetReq(t, "http://ds.example.com/q"), nil, errors.New("dial tcp: connection refused"), time.Now(), time.Millisecond)
+
+	raw, err := buf.ToHAR()
+	require.NoError(t, err)
+	var doc har.HAR
+	require.NoError(t, json.Unmarshal(raw, &doc))
+	require.Len(t, doc.Log.Entries, 1)
+	assert.Equal(t, int64(0), doc.Log.Entries[0].Response.Status, "no-response entry has zero status")
+	assert.Contains(t, doc.Log.Entries[0].Comment, "connection refused", "transport error recorded in entry comment")
+}
+
+func TestBuffer_ToHAR_transportErrorComment_redactsURL(t *testing.T) {
+	_, buf := WithCapture(context.Background())
+	// A transport error can embed the full request URL (secret query params included); the entry
+	// comment is written into the shared bundle, so it must be redacted too.
+	rtErr := errors.New(`Get "https://ds.example.com/q?api_key=SECRET": dial tcp: connection refused`)
+	buf.AddEntry(newGetReq(t, "https://ds.example.com/q"), nil, rtErr, time.Now(), time.Millisecond)
+
+	raw, err := buf.ToHAR()
+	require.NoError(t, err)
+	assert.NotContains(t, string(raw), "SECRET", "secret in the transport-error comment must be redacted")
+}
+
+func TestBuffer_ToHAR_redactsCustomHeaders(t *testing.T) {
+	_, buf := WithCapture(context.Background())
+	// A datasource's custom HTTP headers carry secrets under arbitrary names not in the denylist.
+	buf.MarkSensitiveHeaders("PRIVATE-TOKEN", "x-vault-token")
+
+	req := newGetReq(t, "http://ds.example.com")
+	req.Header.Set("PRIVATE-TOKEN", "glpat-SECRET")
+	req.Header.Set("X-Vault-Token", "vault-SECRET") // canonicalization must still match
+	req.Header.Set("Accept", "application/json")    // untouched header stays for fidelity
+
+	buf.AddEntry(req, okResp(200), nil, time.Now(), time.Millisecond) //nolint:bodyclose
+	raw, err := buf.ToHAR()
+	require.NoError(t, err)
+	s := string(raw)
+
+	assert.NotContains(t, s, "glpat-SECRET", "custom header value must be redacted")
+	assert.NotContains(t, s, "vault-SECRET", "custom header value must be redacted (case-insensitive name)")
+	assert.Contains(t, s, "application/json", "non-custom headers stay for diagnostic fidelity")
+}
+
+func TestBuffer_ToHAR_emptyHeaderValues_noPanic(t *testing.T) {
+	_, buf := WithCapture(context.Background())
+	req := newGetReq(t, "http://example.com")
+	req.Header["X-Empty"] = []string{}                                // empty value slice — must not panic
+	buf.AddEntry(req, okResp(200), nil, time.Now(), time.Millisecond) //nolint:bodyclose
+	_, err := buf.ToHAR()
+	require.NoError(t, err)
+}
+
+func TestBuffer_ToHAR_nilResponse(t *testing.T) {
+	_, buf := WithCapture(context.Background())
+	// A transport-level failure yields a nil response; the entry must still serialize.
+	buf.AddEntry(newGetReq(t, "http://example.com"), nil, nil, time.Now(), time.Millisecond)
+
+	raw, err := buf.ToHAR()
+	require.NoError(t, err)
+
+	var doc har.HAR
+	require.NoError(t, json.Unmarshal(raw, &doc))
+	require.Len(t, doc.Log.Entries, 1)
+	assert.Equal(t, int64(0), doc.Log.Entries[0].Response.Status)
+}
+
+func TestBuffer_concurrentAddEntry(t *testing.T) {
+	_, buf := WithCapture(context.Background())
+	var wg sync.WaitGroup
+	const n = 100
+	wg.Add(n)
+	for range n {
+		go func() {
+			defer wg.Done()
+			buf.AddEntry(newGetReq(t, "http://example.com"), okResp(200), nil, time.Now(), time.Millisecond) //nolint:bodyclose
+		}()
+	}
+	wg.Wait()
+	assert.Equal(t, n, buf.Len())
+}
+
+// --- helpers ---
+
+func newGetReq(t *testing.T, url string) *http.Request {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	require.NoError(t, err)
+	return req
+}
+
+func newPostReq(t *testing.T, url, body string) *http.Request {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBufferString(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+func okResp(status int) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Status:     http.StatusText(status),
+		Proto:      "HTTP/1.1",
+		Header:     http.Header{},
+		Body:       io.NopCloser(bytes.NewBufferString("")),
+	}
+}
+
+// partialThenErrorReader yields data, then fails with err -- simulating a body read that breaks
+// mid-stream (e.g. a dropped connection).
+type partialThenErrorReader struct {
+	data []byte
+	err  error
+	off  int
+}
+
+func (r *partialThenErrorReader) Read(p []byte) (int, error) {
+	if r.off < len(r.data) {
+		n := copy(p, r.data[r.off:])
+		r.off += n
+		return n, nil
+	}
+	return 0, r.err
+}

--- a/pkg/infra/httpclient/harcapture/harcapture_test.go
+++ b/pkg/infra/httpclient/harcapture/harcapture_test.go
@@ -252,6 +252,15 @@ func TestRedactedURLString_dropsFragment(t *testing.T) {
 	assert.Equal(t, "https://idp.example.com/cb?state=ok", out)
 }
 
+func TestRedactedURLString_failsClosedOnMalformedKey(t *testing.T) {
+	// A query key with a malformed percent-escape can't be decoded to compare against the denylist,
+	// so its value must be redacted (fail closed) rather than passed through; well-formed params are
+	// unaffected.
+	out := redactURLValue("https://h/p?bad%zzkey=SECRET&region=eu")
+	assert.NotContains(t, out, "SECRET", "value under an undecodable key must be redacted")
+	assert.Contains(t, out, "region=eu", "well-formed non-sensitive param preserved")
+}
+
 func TestRedactURLValue_failsClosedOnUnparseable(t *testing.T) {
 	// net/url.Parse rejects raw control characters; such a value can't be query-redacted, so it
 	// must be dropped rather than passed through into a bundle meant for external sharing.

--- a/pkg/infra/httpclient/harcapture/harcapture_test.go
+++ b/pkg/infra/httpclient/harcapture/harcapture_test.go
@@ -261,6 +261,25 @@ func TestRedactedURLString_failsClosedOnMalformedKey(t *testing.T) {
 	assert.Contains(t, out, "region=eu", "well-formed non-sensitive param preserved")
 }
 
+func TestBuffer_ToHAR_semicolonSecretRedactedInQueryStringArray(t *testing.T) {
+	// url.Query() only splits on "&", so a secret after a ";" would ride inside a non-sensitive
+	// value and land in the queryString array unredacted. Both the URL string and the array must
+	// redact it.
+	_, buf := WithCapture(context.Background())
+	req := newGetReq(t, "http://ds.example.com/q?foo=bar;token=SEMISECRET&region=eu")
+	buf.AddEntry(req, okResp(200), nil, time.Now(), time.Millisecond) //nolint:bodyclose
+
+	raw, err := buf.ToHAR()
+	require.NoError(t, err)
+	assert.NotContains(t, string(raw), "SEMISECRET", "secret after ';' must not appear anywhere in the HAR")
+
+	var doc har.HAR
+	require.NoError(t, json.Unmarshal(raw, &doc))
+	for _, p := range doc.Log.Entries[0].Request.QueryString {
+		assert.NotContains(t, p.Value, "SEMISECRET", "queryString array value must be redacted")
+	}
+}
+
 func TestRedactsOAuthTokenQueryParams(t *testing.T) {
 	for _, p := range []string{"access_token", "refresh_token", "id_token"} {
 		out := redactURLValue("https://idp.example.com/cb?" + p + "=SECRET&state=ok")


### PR DESCRIPTION
### What this PR does

Adds `pkg/infra/httpclient/harcapture` — an in-memory **HAR capture buffer with capture-time redaction**. It records HTTP request/response pairs and serializes them to a HAR 1.2 document (using `github.com/chromedp/cdproto/har`, the same types the plugin SDK's e2e HAR storage uses, so the output is replay-compatible).

This is the capture/redaction **primitive**. It's consumed by the on-demand datasource **diagnostics endpoint**, which is a **stacked follow-up PR** (`feat/on-demand-diagnostics-ds-endpoint`). This PR intentionally lands the security-sensitive redaction logic on its own so it can be reviewed in isolation; it has no runtime effect until that consumer merges.

### Redaction design notes

- **Out of scope (tracked separately):** request/response **body payload** redaction — only headers/cookies/query/URLs are redacted (data-sources#1281); no byte-size cap yet (data-sources#1283).
