### PR TITLE
fix: nats notifier retry reconnect on failure

### DIFF
--- a/pkg/storage/unified/resource/notifier_nats.go
+++ b/pkg/storage/unified/resource/notifier_nats.go
@@ -2,11 +2,11 @@ package resource
 
 import (
 	"context"
-	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/grafana/dskit/backoff"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/storage/unified/resource/kv"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
@@ -54,23 +54,21 @@ func watchNotificationTypeToAction(t resourcepb.WatchNotification_Type) (kv.Data
 // relist). Core NATS also delivers in arrival order, not RV order, so Watch runs
 // arrivals through the same settle buffer as the channel notifier (held for
 // SettleDelay, emitted sorted by RV) to keep downstream RVs monotonic.
-// natsNotifierRetryInterval is how long Watch waits before retrying a failed
-// subscription (e.g. the bus is not reachable yet at startup).
-const natsNotifierRetryInterval = 5 * time.Second
-
+//
+// A failed subscription (e.g. the bus is not reachable yet at startup) is
+// retried in the background with exponential backoff bounded by the watch's
+// MinBackoff/MaxBackoff.
 type natsNotifier struct {
-	subscriber    EventSubscriber
-	dropped       *prometheus.CounterVec // by reason; nil is allowed (no accounting)
-	retryInterval time.Duration
-	log           log.Logger
+	subscriber EventSubscriber
+	dropped    *prometheus.CounterVec // by reason; nil is allowed (no accounting)
+	log        log.Logger
 }
 
 func newNatsNotifier(subscriber EventSubscriber, dropped *prometheus.CounterVec, logger log.Logger) *natsNotifier {
 	return &natsNotifier{
-		subscriber:    subscriber,
-		dropped:       dropped,
-		retryInterval: natsNotifierRetryInterval,
-		log:           logger,
+		subscriber: subscriber,
+		dropped:    dropped,
+		log:        logger,
 	}
 }
 
@@ -111,12 +109,13 @@ func (n *natsNotifier) Watch(ctx context.Context, opts WatchOptions) <-chan Even
 	// Once subscribed, the nats client auto-resumes across reconnects.
 	if !n.trySubscribe(ctx, handler) {
 		go func() {
-			for ctx.Err() == nil {
-				select {
-				case <-ctx.Done():
-					return
-				case <-time.After(n.retryInterval):
-				}
+			bo := backoff.New(ctx, backoff.Config{
+				MinBackoff: opts.MinBackoff,
+				MaxBackoff: opts.MaxBackoff,
+				MaxRetries: 0, // infinite retries; ctx cancel stops the loop
+			})
+			for bo.Ongoing() {
+				bo.Wait()
 				if n.trySubscribe(ctx, handler) {
 					return
 				}
@@ -133,7 +132,7 @@ func (n *natsNotifier) Watch(ctx context.Context, opts WatchOptions) <-chan Even
 func (n *natsNotifier) trySubscribe(ctx context.Context, handler func(subject string, data []byte)) bool {
 	sub, err := n.subscriber.Subscribe(ctx, resourcewatch.SubjectAll, handler)
 	if err != nil {
-		n.log.Error("failed to subscribe to nats, will retry", "error", err, "retry_interval", n.retryInterval)
+		n.log.Error("failed to subscribe to nats, will retry", "error", err)
 		return false
 	}
 	n.log.Info("subscribed to nats watch stream")

--- a/pkg/storage/unified/resource/notifier_nats.go
+++ b/pkg/storage/unified/resource/notifier_nats.go
@@ -2,6 +2,7 @@ package resource
 
 import (
 	"context"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/protobuf/proto"
@@ -53,14 +54,24 @@ func watchNotificationTypeToAction(t resourcepb.WatchNotification_Type) (kv.Data
 // relist). Core NATS also delivers in arrival order, not RV order, so Watch runs
 // arrivals through the same settle buffer as the channel notifier (held for
 // SettleDelay, emitted sorted by RV) to keep downstream RVs monotonic.
+// natsNotifierRetryInterval is how long Watch waits before retrying a failed
+// subscription (e.g. the bus is not reachable yet at startup).
+const natsNotifierRetryInterval = 5 * time.Second
+
 type natsNotifier struct {
-	subscriber EventSubscriber
-	dropped    *prometheus.CounterVec // by reason; nil is allowed (no accounting)
-	log        log.Logger
+	subscriber    EventSubscriber
+	dropped       *prometheus.CounterVec // by reason; nil is allowed (no accounting)
+	retryInterval time.Duration
+	log           log.Logger
 }
 
 func newNatsNotifier(subscriber EventSubscriber, dropped *prometheus.CounterVec, logger log.Logger) *natsNotifier {
-	return &natsNotifier{subscriber: subscriber, dropped: dropped, log: logger}
+	return &natsNotifier{
+		subscriber:    subscriber,
+		dropped:       dropped,
+		retryInterval: natsNotifierRetryInterval,
+		log:           logger,
+	}
 }
 
 func (n *natsNotifier) drop(reason string) {
@@ -73,34 +84,18 @@ func (n *natsNotifier) Watch(ctx context.Context, opts WatchOptions) <-chan Even
 	opts = opts.normalize()
 	n.log.Info("creating new nats notifier", "buffer_size", opts.BufferSize)
 
-	// The NATS callback writes raw; the pump owns and closes out. raw is never
-	// closed, so a callback firing after ctx cancellation can't send on a closed
-	// channel.
+	// The callback writes raw; settleEvents owns and closes out on ctx cancel.
+	// It runs for the whole watch, so retrying a failed subscription does not
+	// tear down the consumer's channel. raw is never closed, so a late callback
+	// can't send on a closed channel.
 	raw := make(chan Event, opts.BufferSize)
 	out := make(chan Event, opts.BufferSize)
+	go settleEvents(ctx, raw, out, opts)
 
 	handler := func(subject string, data []byte) {
-		var notification resourcepb.WatchNotification
-		if err := proto.Unmarshal(data, &notification); err != nil {
-			n.drop("unmarshal_error")
-			n.log.Warn("failed to unmarshal watch notification", "subject", subject, "error", err)
-			return
-		}
-		action, ok := watchNotificationTypeToAction(notification.Type)
+		evt, ok := n.decode(subject, data)
 		if !ok {
-			n.drop("unknown_type")
-			n.log.Warn("dropped watch notification with unknown type", "subject", subject)
 			return
-		}
-		evt := Event{
-			Namespace:       notification.Namespace,
-			Group:           notification.Group,
-			Resource:        notification.Resource,
-			Name:            notification.Name,
-			ResourceVersion: notification.ResourceVersion,
-			Action:          action,
-			Folder:          notification.Folder,
-			PreviousRV:      notification.PreviousResourceVersion,
 		}
 		select {
 		case raw <- evt:
@@ -110,23 +105,71 @@ func (n *natsNotifier) Watch(ctx context.Context, opts WatchOptions) <-chan Even
 		}
 	}
 
-	sub, err := n.subscriber.Subscribe(ctx, resourcewatch.SubjectAll, handler)
-	if err != nil {
-		n.log.Error("failed to subscribe to nats", "error", err)
-		close(out)
-		return out
+	// Subscribe synchronously so a healthy bus wires delivery before returning;
+	// if the bus is unreachable (e.g. embedded server not started yet), retry in
+	// the background instead of closing out and losing the watch until restart.
+	// Once subscribed, the nats client auto-resumes across reconnects.
+	if !n.trySubscribe(ctx, handler) {
+		go func() {
+			for ctx.Err() == nil {
+				select {
+				case <-ctx.Done():
+					return
+				case <-time.After(n.retryInterval):
+				}
+				if n.trySubscribe(ctx, handler) {
+					return
+				}
+			}
+		}()
 	}
 
+	return out
+}
+
+// trySubscribe subscribes to the whole change stream once. On success it
+// unsubscribes on ctx cancel and returns true; on failure it logs and returns
+// false so the caller can retry.
+func (n *natsNotifier) trySubscribe(ctx context.Context, handler func(subject string, data []byte)) bool {
+	sub, err := n.subscriber.Subscribe(ctx, resourcewatch.SubjectAll, handler)
+	if err != nil {
+		n.log.Error("failed to subscribe to nats, will retry", "error", err, "retry_interval", n.retryInterval)
+		return false
+	}
+	n.log.Info("subscribed to nats watch stream")
 	context.AfterFunc(ctx, func() {
 		if err := sub.Unsubscribe(); err != nil {
 			n.log.Warn("failed to unsubscribe from nats", "error", err)
 		}
 	})
+	return true
+}
 
-	// raw is never closed here; settleEvents exits on ctx.Done().
-	go settleEvents(ctx, raw, out, opts)
-
-	return out
+// decode turns a raw notification into an Event, returning ok=false (and
+// accounting the drop) for undecodable payloads or unknown types.
+func (n *natsNotifier) decode(subject string, data []byte) (Event, bool) {
+	var notification resourcepb.WatchNotification
+	if err := proto.Unmarshal(data, &notification); err != nil {
+		n.drop("unmarshal_error")
+		n.log.Warn("failed to unmarshal watch notification", "subject", subject, "error", err)
+		return Event{}, false
+	}
+	action, ok := watchNotificationTypeToAction(notification.Type)
+	if !ok {
+		n.drop("unknown_type")
+		n.log.Warn("dropped watch notification with unknown type", "subject", subject)
+		return Event{}, false
+	}
+	return Event{
+		Namespace:       notification.Namespace,
+		Group:           notification.Group,
+		Resource:        notification.Resource,
+		Name:            notification.Name,
+		ResourceVersion: notification.ResourceVersion,
+		Action:          action,
+		Folder:          notification.Folder,
+		PreviousRV:      notification.PreviousResourceVersion,
+	}, true
 }
 
 // TODO: currently the events are published to NATS in watch_publisher.go,

--- a/pkg/storage/unified/resource/notifier_nats_test.go
+++ b/pkg/storage/unified/resource/notifier_nats_test.go
@@ -241,11 +241,11 @@ func TestNatsNotifierWatch_RetriesUntilSubscribeSucceeds(t *testing.T) {
 	// and re-subscribe rather than closing it and losing the watch.
 	sub := &fakeEventSubscriber{enabled: true, subErr: errors.New("boom")}
 	n := newNatsNotifier(sub, nil, log.NewNopLogger())
-	n.retryInterval = 10 * time.Millisecond
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	out := n.Watch(ctx, WatchOptions{})
+	// Small backoff bounds keep the subscription retry loop fast for the test.
+	out := n.Watch(ctx, WatchOptions{MinBackoff: 10 * time.Millisecond, MaxBackoff: 20 * time.Millisecond})
 
 	// The channel must stay open across the failed subscribe.
 	select {

--- a/pkg/storage/unified/resource/notifier_nats_test.go
+++ b/pkg/storage/unified/resource/notifier_nats_test.go
@@ -3,6 +3,7 @@ package resource
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -18,17 +19,31 @@ import (
 	"github.com/grafana/grafana/pkg/storage/unified/resourcewatch"
 )
 
-type fakeSubscription struct{ unsubscribed bool }
+type fakeSubscription struct {
+	mu           sync.Mutex
+	unsubscribed bool
+}
 
 func (f *fakeSubscription) Unsubscribe() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.unsubscribed = true
 	return nil
 }
 
+func (f *fakeSubscription) wasUnsubscribed() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.unsubscribed
+}
+
 type fakeEventSubscriber struct {
 	enabled bool
-	subErr  error
 
+	// mu guards the fields below: the notifier's retry loop may call Subscribe
+	// concurrently with a test inspecting the wiring.
+	mu      sync.Mutex
+	subErr  error
 	subject string
 	handler func(subject string, data []byte)
 	sub     *fakeSubscription
@@ -37,6 +52,8 @@ type fakeEventSubscriber struct {
 func (f *fakeEventSubscriber) Enabled() bool { return f.enabled }
 
 func (f *fakeEventSubscriber) Subscribe(_ context.Context, subject string, handler func(subject string, data []byte)) (Subscription, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	if f.subErr != nil {
 		return nil, f.subErr
 	}
@@ -44,6 +61,18 @@ func (f *fakeEventSubscriber) Subscribe(_ context.Context, subject string, handl
 	f.handler = handler
 	f.sub = &fakeSubscription{}
 	return f.sub, nil
+}
+
+func (f *fakeEventSubscriber) setSubErr(err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.subErr = err
+}
+
+func (f *fakeEventSubscriber) currentHandler() func(subject string, data []byte) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.handler
 }
 
 func mustMarshalNotification(t *testing.T, n *resourcepb.WatchNotification) []byte {
@@ -203,22 +232,43 @@ func TestNatsNotifierWatch_ClosesAndUnsubscribesOnContextCancel(t *testing.T) {
 
 	// AfterFunc runs asynchronously; give it a moment.
 	require.Eventually(t, func() bool {
-		return sub.sub != nil && sub.sub.unsubscribed
+		return sub.sub != nil && sub.sub.wasUnsubscribed()
 	}, 2*time.Second, 10*time.Millisecond, "expected Unsubscribe to be called")
 }
 
-func TestNatsNotifierWatch_SubscribeErrorClosesChannel(t *testing.T) {
+func TestNatsNotifierWatch_RetriesUntilSubscribeSucceeds(t *testing.T) {
+	// Bus unreachable at first, then available: Watch must keep the channel open
+	// and re-subscribe rather than closing it and losing the watch.
 	sub := &fakeEventSubscriber{enabled: true, subErr: errors.New("boom")}
 	n := newNatsNotifier(sub, nil, log.NewNopLogger())
+	n.retryInterval = 10 * time.Millisecond
 
-	out := n.Watch(context.Background(), WatchOptions{})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	out := n.Watch(ctx, WatchOptions{})
 
+	// The channel must stay open across the failed subscribe.
 	select {
 	case _, ok := <-out:
-		assert.False(t, ok, "channel should be closed when subscribe fails")
-	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for channel to close")
+		require.True(t, ok, "channel closed on subscribe error; expected retry to keep it open")
+	case <-time.After(50 * time.Millisecond):
 	}
+
+	// Bus recovers; the retry loop should subscribe and start delivering.
+	sub.setSubErr(nil)
+	require.Eventually(t, func() bool {
+		return sub.currentHandler() != nil
+	}, 2*time.Second, 10*time.Millisecond, "expected retry to subscribe once the bus is reachable")
+
+	sub.currentHandler()("some.subject", mustMarshalNotification(t, &resourcepb.WatchNotification{
+		Type:            resourcepb.WatchNotification_ADDED,
+		Group:           "playlist.grafana.app",
+		Resource:        "playlists",
+		Namespace:       "default",
+		Name:            "abc",
+		ResourceVersion: 1,
+	}))
+	assert.Equal(t, "abc", recvEvent(t, out).Name)
 }
 
 func TestNatsNotifierPublishIsNoOp(t *testing.T) {

--- a/pkg/storage/unified/resource/notifier_shadow.go
+++ b/pkg/storage/unified/resource/notifier_shadow.go
@@ -48,43 +48,29 @@ func newNatsShadowMetrics(reg prometheus.Registerer) *natsShadowMetrics {
 // watch pipeline, so enabling it cannot change what watch clients observe. It
 // validates NATS delivery (coverage + latency) on a live backend before NATS is
 // wired into the watch path for real.
-// natsShadowRetryInterval is how long start waits before re-subscribing after
-// the notifier channel closes (e.g. NATS was unavailable at startup).
-const natsShadowRetryInterval = 5 * time.Second
-
 type natsShadow struct {
-	notifier      *natsNotifier
-	watchOpts     WatchOptions
-	metrics       *natsShadowMetrics
-	retryInterval time.Duration
-	log           log.Logger
+	notifier  *natsNotifier
+	watchOpts WatchOptions
+	metrics   *natsShadowMetrics
+	log       log.Logger
 }
 
 func newNatsShadow(subscriber EventSubscriber, watchOpts WatchOptions, reg prometheus.Registerer, logger log.Logger) *natsShadow {
 	metrics := newNatsShadowMetrics(reg)
 	return &natsShadow{
-		notifier:      newNatsNotifier(subscriber, metrics.dropped, logger),
-		watchOpts:     watchOpts,
-		metrics:       metrics,
-		retryInterval: natsShadowRetryInterval,
-		log:           logger,
+		notifier:  newNatsNotifier(subscriber, metrics.dropped, logger),
+		watchOpts: watchOpts,
+		metrics:   metrics,
+		log:       logger,
 	}
 }
 
-// start consumes the NATS notifier in a goroutine until ctx is cancelled. The
-// channel closes on ctx cancellation (exit) or subscribe failure; in the latter
-// case it re-subscribes after retryInterval so a NATS outage at startup doesn't
-// leave the shadow inert until the next process restart.
+// start consumes the notifier until ctx is cancelled. The notifier owns its own
+// subscription retry, so a startup outage no longer leaves the shadow inert.
 func (s *natsShadow) start(ctx context.Context) {
 	go func() {
-		for ctx.Err() == nil {
-			for evt := range s.notifier.Watch(ctx, s.watchOpts) {
-				s.observe(evt)
-			}
-			select {
-			case <-ctx.Done():
-			case <-time.After(s.retryInterval):
-			}
+		for evt := range s.notifier.Watch(ctx, s.watchOpts) {
+			s.observe(evt)
 		}
 	}()
 }

--- a/pkg/storage/unified/resource/notifier_shadow_test.go
+++ b/pkg/storage/unified/resource/notifier_shadow_test.go
@@ -43,9 +43,8 @@ func (c *countingSubscriber) callCount() int {
 
 func TestNatsShadow_ReSubscribesAfterInitialFailure(t *testing.T) {
 	sub := &countingSubscriber{failFirst: 2}
-	s := newNatsShadow(sub, WatchOptions{}, prometheus.NewRegistry(), log.NewNopLogger())
-	// The notifier owns the retry loop; keep it fast for the test.
-	s.notifier.retryInterval = 10 * time.Millisecond
+	// Small backoff bounds keep the notifier's subscription retry loop fast.
+	s := newNatsShadow(sub, WatchOptions{MinBackoff: 10 * time.Millisecond, MaxBackoff: 20 * time.Millisecond}, prometheus.NewRegistry(), log.NewNopLogger())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/pkg/storage/unified/resource/notifier_shadow_test.go
+++ b/pkg/storage/unified/resource/notifier_shadow_test.go
@@ -44,7 +44,8 @@ func (c *countingSubscriber) callCount() int {
 func TestNatsShadow_ReSubscribesAfterInitialFailure(t *testing.T) {
 	sub := &countingSubscriber{failFirst: 2}
 	s := newNatsShadow(sub, WatchOptions{}, prometheus.NewRegistry(), log.NewNopLogger())
-	s.retryInterval = 10 * time.Millisecond
+	// The notifier owns the retry loop; keep it fast for the test.
+	s.notifier.retryInterval = 10 * time.Millisecond
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
Retry loop (using backoff package) on subscribe failure for the nats notifier. I noticed that sometimes the embedded server is not up and running when the notifier is being run.


Test to run (optional):
```ini
# custom.ini
[nats]
enabled = true
mode = embedded
notifier = true
```

```bash
# Terminal A
➜  ~ curl -sN -u admin:admin \
  "http://localhost:3000/apis/playlist.grafana.app/v0alpha1/namespaces/default/playlists?watch=true"

# Terminal B
➜  ~ curl -s -u admin:admin -X POST \
  http://localhost:3000/apis/playlist.grafana.app/v0alpha1/namespaces/default/playlists \
  -H 'Content-Type: application/json' \
  -d '{"apiVersion":"playlist.grafana.app/v0alpha1","kind":"Playlist","metadata":{"generateName":"p"},"spec":{"title":"demo","interval":"5m","items":[]}}'
  
# You should be seeing `ADDED` events in terminal A:
 {"type":"ADDED","object":{"kind":"Playlist","apiVersion":"playlist.grafana.app/v0alpha1","metadata":{"name":"pxldp8","namespace":"default","uid":"4851c36d-7fd3-43a0-ae2a-8d9b7c27dc23","resourceVersion":"2076980784891166731","generation":1,"creationTimestamp":"2026-07-14T10:43:02Z","annotations":{"grafana.app/createdBy":"user:effok04b15728a"},"managedFields":[{"manager":"curl","operation":"Update","apiVersion":"playlist.grafana.app/v0alpha1","time":"2026-07-14T10:43:02Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:generateName":{}},"f:spec":{"f:interval":{},"f:items":{},"f:title":{}}}}]},"spec":{"title":"demo","interval":"5m","items":[]},"status":{}}}
```