### PR TITLE
Datasource migration: use ListStoredResources to discover stale groups

### DIFF
--- a/pkg/registry/apis/datasource/migrator/migrator.go
+++ b/pkg/registry/apis/datasource/migrator/migrator.go
@@ -28,7 +28,7 @@ type DataSourceMigrator interface {
 	// PluginGroups resolves the distinct per-plugin GroupResources for the given
 	// namespace, including stale groups from unified storage, for bulk stream
 	// pre-authorization.
-	PluginGroups(ctx context.Context, namespace string, client resource.SearchClient) ([]schema.GroupResource, error)
+	PluginGroups(ctx context.Context, namespace string, client resource.ResourceClient) ([]schema.GroupResource, error)
 }
 
 var logger = log.New("storage.unified.datasource.migrator")
@@ -196,7 +196,7 @@ func (m *dataSourceMigrator) MigrateDataSources(ctx context.Context, orgId int64
 	return nil
 }
 
-func (m *dataSourceMigrator) PluginGroups(ctx context.Context, namespace string, client resource.SearchClient) ([]schema.GroupResource, error) {
+func (m *dataSourceMigrator) PluginGroups(ctx context.Context, namespace string, client resource.ResourceClient) ([]schema.GroupResource, error) {
 	dsList, err := m.getter(ctx, namespace)
 	if err != nil {
 		return nil, err
@@ -226,19 +226,21 @@ func (m *dataSourceMigrator) PluginGroups(ctx context.Context, namespace string,
 // that currently hold datasource data in the given namespace. This ensures
 // stale groups (migrated previously but since deleted from legacy) are included
 // in the bulk collection so their data is cleaned up on re-migration.
-func storageGroupsForDatasources(ctx context.Context, namespace string, client resource.SearchClient) ([]schema.GroupResource, error) {
-	resp, err := client.GetStats(ctx, &resourcepb.ResourceStatsRequest{Namespace: namespace})
+//
+// It uses discovery (ListStoredResources) rather than GetStats: only the
+// group/resource identities are needed, not counts, and discovery avoids
+// building search indexes during migration.
+func storageGroupsForDatasources(ctx context.Context, namespace string, client resource.ResourceClient) ([]schema.GroupResource, error) {
+	resp, err := client.ListStoredResources(ctx, &resourcepb.ListStoredResourcesRequest{
+		Namespace: namespace,
+		Resource:  "datasources",
+	})
 	if err != nil {
-		return nil, fmt.Errorf("getting storage stats: %w", err)
+		return nil, fmt.Errorf("listing stored datasource resources: %w", err)
 	}
-	if resp.Error != nil {
-		return nil, fmt.Errorf("getting storage stats: %s", resp.Error.Message)
-	}
-	var result []schema.GroupResource
-	for _, s := range resp.Stats {
-		if s.Resource == "datasources" {
-			result = append(result, schema.GroupResource{Group: s.Group, Resource: s.Resource})
-		}
+	result := make([]schema.GroupResource, 0, len(resp.Items))
+	for _, item := range resp.Items {
+		result = append(result, schema.GroupResource{Group: item.Group, Resource: item.Resource})
 	}
 	return result, nil
 }

--- a/pkg/registry/apis/datasource/migrator/migrator_test.go
+++ b/pkg/registry/apis/datasource/migrator/migrator_test.go
@@ -1,0 +1,60 @@
+package migrator
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/grafana/grafana/pkg/storage/unified/resource"
+	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
+)
+
+func TestStorageGroupsForDatasources(t *testing.T) {
+	const ns = "org-1"
+
+	t.Run("maps discovered datasource identities to group resources", func(t *testing.T) {
+		client := resource.NewMockResourceClient(t)
+		client.EXPECT().
+			ListStoredResources(mock.Anything, mock.MatchedBy(func(req *resourcepb.ListStoredResourcesRequest) bool {
+				// Discovery must be scoped to the namespace and datasources resource.
+				return req.Namespace == ns && req.Resource == "datasources"
+			})).
+			Return(&resourcepb.ListStoredResourcesResponse{
+				Items: []*resourcepb.ListStoredResourcesResponse_StoredResource{
+					{Namespace: ns, Group: "prometheus.datasource.grafana.app", Resource: "datasources"},
+					{Namespace: ns, Group: "loki.datasource.grafana.app", Resource: "datasources"},
+				},
+			}, nil)
+
+		got, err := storageGroupsForDatasources(t.Context(), ns, client)
+		require.NoError(t, err)
+		require.Equal(t, []schema.GroupResource{
+			{Group: "prometheus.datasource.grafana.app", Resource: "datasources"},
+			{Group: "loki.datasource.grafana.app", Resource: "datasources"},
+		}, got)
+	})
+
+	t.Run("empty discovery yields no groups", func(t *testing.T) {
+		client := resource.NewMockResourceClient(t)
+		client.EXPECT().
+			ListStoredResources(mock.Anything, mock.Anything).
+			Return(&resourcepb.ListStoredResourcesResponse{}, nil)
+
+		got, err := storageGroupsForDatasources(t.Context(), ns, client)
+		require.NoError(t, err)
+		require.Empty(t, got)
+	})
+
+	t.Run("propagates discovery error", func(t *testing.T) {
+		client := resource.NewMockResourceClient(t)
+		client.EXPECT().
+			ListStoredResources(mock.Anything, mock.Anything).
+			Return(nil, errors.New("boom"))
+
+		_, err := storageGroupsForDatasources(t.Context(), ns, client)
+		require.Error(t, err)
+	})
+}

--- a/pkg/storage/unified/migrations/migrator.go
+++ b/pkg/storage/unified/migrations/migrator.go
@@ -33,7 +33,7 @@ type UnifiedMigrator interface {
 // unifiedMigration handles the migration of legacy resources to unified storage
 type unifiedMigration struct {
 	streamProvider streamProvider
-	client         resource.SearchClient
+	client         resource.ResourceClient
 	log            log.Logger
 	registry       *MigrationRegistry
 }
@@ -79,7 +79,7 @@ func ProvideUnifiedMigrator(
 
 func newUnifiedMigrator(
 	streamProvider streamProvider,
-	client resource.SearchClient,
+	client resource.ResourceClient,
 	log log.Logger,
 	registry *MigrationRegistry,
 ) UnifiedMigrator {
@@ -113,7 +113,7 @@ func (m *unifiedMigration) Migrate(ctx context.Context, opts MigrateOptions) (*r
 
 	// If a definition provides a dynamic group resolver, call it to discover
 	// which groups actually exist in this namespace. The resolver receives the
-	// SearchClient so it can also query unified storage for stale groups and
+	// ResourceClient so it can also query unified storage for stale groups and
 	// merge them in — keeping all resource-specific logic in the resolver.
 	//
 	// If the result is empty (namespace has no data at all), keep

--- a/pkg/storage/unified/migrations/registry.go
+++ b/pkg/storage/unified/migrations/registry.go
@@ -46,9 +46,9 @@ type MigrationDefinition struct {
 	SkipWhenMissing bool                                  // For fully migrated resources, the table may not exist at all
 	// ResourceGroupsFunc, when set, is called before opening the bulk stream to
 	// resolve the actual groups present in the namespace, replacing the static
-	// Resources list for stream pre-authorization. The SearchClient is provided
+	// Resources list for stream pre-authorization. The ResourceClient is provided
 	// so implementations can also account for stale groups in unified storage.
-	ResourceGroupsFunc func(ctx context.Context, namespace string, client resource.SearchClient) ([]schema.GroupResource, error)
+	ResourceGroupsFunc func(ctx context.Context, namespace string, client resource.ResourceClient) ([]schema.GroupResource, error)
 }
 
 // CreateValidators creates validators from the stored factory functions.
@@ -175,7 +175,7 @@ func (r *MigrationRegistry) HasResource(gr schema.GroupResource) bool {
 // GetResourceGroupsFunc returns the ResourceGroupsFunc for the definition that
 // covers the given resource, or nil if none is registered or the definition has
 // no dynamic resolver.
-func (r *MigrationRegistry) GetResourceGroupsFunc(gr schema.GroupResource) func(ctx context.Context, namespace string, client resource.SearchClient) ([]schema.GroupResource, error) {
+func (r *MigrationRegistry) GetResourceGroupsFunc(gr schema.GroupResource) func(ctx context.Context, namespace string, client resource.ResourceClient) ([]schema.GroupResource, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	for _, def := range r.definitions {


### PR DESCRIPTION
Follow-up to #127717 and #127876. The datasource migrator discovers which API groups already hold datasource data in unified storage, so stale groups — migrated by a previous run but since deleted from legacy — are included in the bulk collection and cleaned up on re-migration.

That discovery only needs the group/resource identities, not counts, so this switches `storageGroupsForDatasources` from `GetStats` to the cheaper `ListStoredResources` (scoped to the namespace and the `datasources` resource). It also avoids building search indexes during migration, which the empty-`Kinds` `GetStats` path would trigger.

Because `ListStoredResources` lives on `ResourceStore` rather than the search API, the resolver's client type widens from `resource.SearchClient` to `resource.ResourceClient` (which is what the migrator is already constructed with). This touches `ResourceGroupsFunc`, the `DataSourceMigrator.PluginGroups` signature, and the `unifiedMigration` client field.

The count validator (`validator.go`) keeps using `GetStats` — it needs actual counts and already passes explicit `Kinds`.

---

This change necessarily spans `pkg/storage/unified/migrations/` (the `ResourceGroupsFunc` resolver type) and `pkg/registry/apis/datasource/` (its only implementation), so it carries the `no-check-unified-storage-compatibility` label. There is no runtime deployment-compatibility concern: the migrator and the storage discovery API ship together, and `ListStoredResources` was already added in #127717.
