### PR TITLE
Search: remove dead Priority filter in getAllFields

### DIFF
--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -3114,11 +3114,7 @@ func getAllFields(standard resource.SearchableDocumentFields, custom resource.Se
 
 	if custom != nil {
 		for _, name := range custom.Fields() {
-			f := custom.Field(name)
-			if f.Priority > 10 {
-				continue
-			}
-			fields = append(fields, f)
+			fields = append(fields, custom.Field(name))
 		}
 	}
 	for _, field := range fields {


### PR DESCRIPTION
`getAllFields` skipped any custom search field whose column `Priority` exceeded 10. But `Priority` is never set anywhere in unified storage — no builder or provider assigns it, so it is always its zero value. The check was therefore always false and the branch dead.

This removes it, leaving the loop to simply collect the custom fields. No behaviour change; the `Priority` field on the proto column type is untouched.

Part of grafana/search-and-storage-team#827.
