### PR TITLE
Provisioning: Enable Github Enterprise provider by default

### DIFF
--- a/pkg/tests/apis/provisioning/repository/repository_test.go
+++ b/pkg/tests/apis/provisioning/repository/repository_test.go
@@ -206,6 +206,7 @@ func TestIntegrationProvisioning_CreatingAndGetting(t *testing.T) {
 					provisioning.GitHubRepositoryType,
 					provisioning.BitbucketRepositoryType,
 					provisioning.GitLabRepositoryType,
+					provisioning.GitHubEnterpriseRepositoryType,
 				}, settings.AvailableRepositoryTypes)
 			} else {
 				assert.ElementsMatch(collect, []provisioning.RepositoryType{


### PR DESCRIPTION
**What is this feature?**
Enable Github Enterprise by default. 

Enterprise PR: https://github.com/grafana/grafana-enterprise/pull/12639

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/1137

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
