### PR TITLE
Datasources: On-demand diagnostics for core plugins (behind feature toggle)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -409,6 +409,7 @@
 /pkg/plugins/ @grafana/grafana-catalog
 /pkg/services/datasourceproxy/ @grafana/grafana-catalog
 /pkg/services/datasources/ @grafana/grafana-catalog
+/pkg/services/diagnostics/ @grafana/data-sources
 /pkg/services/pluginsintegration/ @grafana/grafana-catalog
 /pkg/plugins/codegen/pfs/ @grafana/grafana-catalog @grafana/grafana-as-code
 /pkg/tsdb/grafana-testdata-datasource/ @grafana/grafana-catalog

--- a/go.mod
+++ b/go.mod
@@ -58,6 +58,7 @@ require (
 	github.com/charmbracelet/bubbles v1.0.0 // @grafana/grafana-app-platform-squad
 	github.com/charmbracelet/bubbletea v1.3.10 // @grafana/grafana-app-platform-squad
 	github.com/charmbracelet/lipgloss v1.1.0 // @grafana/grafana-app-platform-squad
+	github.com/chromedp/cdproto v0.0.0-20250803210736-d308e07a266d // @grafana/data-sources
 	github.com/crewjam/saml v0.4.14 // @grafana/identity-access-team
 	github.com/dgraph-io/badger/v4 v4.9.2 // @grafana/grafana-search-and-storage
 	github.com/dlmiddlecote/sqlstats v1.0.2 // @grafana/grafana-backend-group
@@ -404,7 +405,6 @@ require (
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/cheekybits/genny v1.0.0 // indirect
-	github.com/chromedp/cdproto v0.0.0-20250803210736-d308e07a266d // indirect
 	github.com/clipperhouse/displaywidth v0.11.0 // indirect
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
 	github.com/cloudflare/circl v1.6.3 // indirect

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -502,12 +502,12 @@ func (hs *HTTPServer) registerRoutes() {
 		// DataSource w/ expressions
 		apiRoute.Post("/ds/query", requestmeta.SetSLOGroup(requestmeta.SLOGroupHighSlow), authorize(ac.EvalPermission(datasources.ActionQuery)), hs.getDSQueryEndpoint())
 
-		// On-demand datasource diagnostics. Admin-only, experimental.
-		// Two deliberate, independent gates: this registration is
-		// on-prem only (empty StackID => never on Grafana Cloud), and the handler additionally gates
-		// on the grafana.onDemandDiagnostics feature flag at request time. Admin-only, experimental.
+		// On-demand datasource diagnostics. Admin-only, on-prem-only, experimental.
+		// Two deliberate, independent gates:
+		// 1. on-prem only (empty StackID => never on Grafana Cloud)
+		// 2. grafana.onDemandDiagnostics flag at request time
 		if hs.Cfg.StackID == "" {
-			apiRoute.Post("/ds/diagnostics", reqGrafanaAdmin, routing.Wrap(hs.QueryDiagnostics))
+			apiRoute.Post("/ds/diagnostics", requestmeta.SetSLOGroup(requestmeta.SLOGroupHighSlow), reqGrafanaAdmin, routing.Wrap(hs.QueryDiagnostics))
 		}
 
 		// Unified Alerting

--- a/pkg/api/ds_query_diagnostics.go
+++ b/pkg/api/ds_query_diagnostics.go
@@ -1,38 +1,129 @@
 package api
 
 import (
+	"encoding/json"
+	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/open-feature/go-sdk/openfeature"
 
+	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/api/response"
+	"github.com/grafana/grafana/pkg/infra/httpclient/harcapture"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/services/diagnostics"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/web"
 )
 
-// diagnosticsFeatureClient is a shared OpenFeature client reused across requests (its evaluations
-// resolve against the current global provider), so we don't allocate one per request.
+// diagnosticsRequest is the body posted by the "Download diagnostics" panel action. It carries
+// the datasource queries to run with HAR capture active, plus the optional panel and dashboard
+// definitions the client already holds (so we avoid a dashboard-service lookup).
+type diagnosticsRequest struct {
+	dtos.MetricRequest
+	Dashboard json.RawMessage `json:"dashboard"`
+	Panel     json.RawMessage `json:"panel"`
+}
+
+// diagnosticsFeatureClient is a shared OpenFeature client reused across requests. Flags are
+// evaluated via OpenFeature rather than featuremgmt.FeatureToggles.IsEnabled, which is deprecated
+// (staticcheck SA1019) and slated for removal.
 var diagnosticsFeatureClient = openfeature.NewDefaultClient()
 
-// QueryDiagnostics is the entry point for on-demand datasource diagnostics: it will run the
-// supplied datasource queries with HTTP capture active and return a diagnostic bundle (captured
-// traffic, scoped logs, and the panel/dashboard JSON). Bundle generation is added in a follow-up;
-// for now the endpoint only establishes the route.
+// QueryDiagnostics executes the supplied datasource queries with HAR capture active and returns a
+// .tar.gz diagnostic bundle (captured traffic and the panel/dashboard JSON). Bundle assembly lives
+// in the diagnostics service; this handler owns the HTTP concerns: gating, request binding, running
+// the queries, and writing the response.
 //
-// Two independent gates apply by design (see registerRoutes):
-//   - Deployment: the route is registered only on on-prem/self-managed instances (empty StackID),
-//     so it is never exposed on Grafana Cloud (where the async/HA and multi-tenant story is not
-//     ready). This handler therefore never runs on Cloud.
-//   - Feature availability: within on-prem, it is gated at request time on the
-//     grafana.onDemandDiagnostics feature flag, so it can be toggled without re-registering routes.
-//
-// Access is further restricted to Grafana server admins via reqGrafanaAdmin.
+// Two independent gates apply by design (see registerRoutes): the route is registered only on
+// on-prem/self-managed instances (empty StackID) so it never runs on Grafana Cloud, and within
+// on-prem it is gated at request time on the grafana.onDemandDiagnostics feature flag. Access is
+// further restricted to Grafana server admins via reqGrafanaAdmin.
 func (hs *HTTPServer) QueryDiagnostics(c *contextmodel.ReqContext) response.Response {
 	ctx := c.Req.Context()
 	if !diagnosticsFeatureClient.Boolean(ctx, featuremgmt.FlagGrafanaOnDemandDiagnostics, false, openfeature.TransactionContext(ctx)) {
 		return response.Error(http.StatusNotFound, "on-demand diagnostics is not enabled", nil)
 	}
 
-	// Bundle generation is not implemented in this scaffold; a follow-up backend PR adds it.
-	return response.Error(http.StatusNotImplemented, "on-demand diagnostics is not implemented yet", nil)
+	reqDTO := diagnosticsRequest{}
+	if err := web.Bind(c.Req, &reqDTO); err != nil {
+		return response.Error(http.StatusBadRequest, "bad request data", err)
+	}
+	if len(reqDTO.Queries) == 0 {
+		return response.Error(http.StatusBadRequest, "at least one query is required", nil)
+	}
+
+	captureCtx, harBuffer := harcapture.WithCapture(ctx)
+
+	// Force a live query: a query-result cache hit returns without a datasource round trip, so HTTP
+	// capture would run on nothing and traffic.har would be silently empty. Diagnostics must capture
+	// what actually happens on the wire, so bypass the query cache. This is the same signal the
+	// X-Cache-Skip request header feeds (see middleware.go); the Enterprise caching service reads it
+	// back off the ReqContext via contexthandler.FromContext in the plugin caching middleware
+	// (clientmiddleware.CachingMiddleware), and c is the same ReqContext pointer stored in the query
+	// context, so mutating it here takes effect for this request.
+	c.SkipQueryCache = true
+
+	// Mirror QueryMetricsV2's dispatch (see ds_query.go) so diagnostics run the queries exactly as
+	// the panel did: with per-query time ranges when the client asks for Query V2 semantics, else
+	// the top-level from/to. Otherwise captured traffic wouldn't match a panel that uses per-query
+	// ranges, defeating the "reproduce offline" goal.
+	queryData := hs.queryDataService.QueryData
+	if c.Req.Header.Get("X-Query-V2") == "true" {
+		queryData = hs.queryDataService.QueryDataNew
+	}
+	resp, queryErr := queryData(captureCtx, c.SignedInUser, c.SkipDSCache, reqDTO.MetricRequest)
+
+	// A datasource query usually fails per-refId (DataResponse.Error) with no top-level error, the
+	// same way QueryMetricsV2 surfaces failures. Capture that too so it's recorded in the bundle.
+	respErr := diagnostics.ResponseError(resp)
+
+	// If the query failed before any traffic was captured (e.g. pre-flight access-denied or
+	// datasource-not-found, which never reach the datasource), there's nothing to diagnose, so
+	// surface the failure with the same status QueryMetricsV2 would return instead of a 200 bundle:
+	// a top-level error keeps its typed status (403/404, else 500), while a per-refId (bad-query)
+	// failure is a client error (400). A failure that did hit the wire leaves captured traffic and
+	// falls through — that captured failure is exactly what the bundle is for, recorded alongside
+	// query-error.txt.
+	if !diagnostics.HasCapturedHAR(harBuffer) {
+		if r := hs.diagnosticsNoCaptureError(queryErr, respErr); r != nil {
+			return r
+		}
+	}
+
+	// Record whatever failure occurred in the bundle, preferring the top-level error.
+	bundleErr := queryErr
+	if bundleErr == nil {
+		bundleErr = respErr
+	}
+	bundle, err := diagnostics.NewBundler().Build(harBuffer, reqDTO.Panel, reqDTO.Dashboard, bundleErr)
+	if err != nil {
+		return response.Error(http.StatusInternalServerError, "failed to build diagnostics bundle", err)
+	}
+
+	filename := fmt.Sprintf("diagnostics-%s.tar.gz", time.Now().UTC().Format("20060102-150405"))
+	header := http.Header{}
+	header.Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, filename))
+	header.Set("Content-Type", "application/tar+gzip")
+	return response.CreateNormalResponse(header, bundle, http.StatusOK)
+}
+
+// diagnosticsNoCaptureError returns the response to send when a query failed and nothing was
+// captured — there is no traffic to diagnose, so surface the failure with the same status
+// QueryMetricsV2 would return instead of a 200 bundle. A top-level error keeps its typed status
+// (403/404, else 500) via handleQueryMetricsError; a per-refId failure is a bad query, so a client
+// error (400), matching QueryMetricsV2's per-refId handling. Returns nil when nothing failed, so
+// the caller proceeds to assemble the bundle.
+func (hs *HTTPServer) diagnosticsNoCaptureError(queryErr, respErr error) response.Response {
+	// Errors are surfaced verbatim -- redaction is intentionally deferred for this experimental
+	// feature (see the harcapture package doc). A top-level error keeps its typed status via
+	// handleQueryMetricsError; a per-refId failure is a client error (400).
+	if queryErr != nil {
+		return hs.handleQueryMetricsError(queryErr)
+	}
+	if respErr != nil {
+		return response.Error(http.StatusBadRequest, "query failed", respErr)
+	}
+	return nil
 }

--- a/pkg/api/ds_query_diagnostics.go
+++ b/pkg/api/ds_query_diagnostics.go
@@ -36,10 +36,7 @@ var diagnosticsFeatureClient = openfeature.NewDefaultClient()
 // in the diagnostics service; this handler owns the HTTP concerns: gating, request binding, running
 // the queries, and writing the response.
 //
-// Two independent gates apply by design (see registerRoutes): the route is registered only on
-// on-prem/self-managed instances (empty StackID) so it never runs on Grafana Cloud, and within
-// on-prem it is gated at request time on the grafana.onDemandDiagnostics feature flag. Access is
-// further restricted to Grafana server admins via reqGrafanaAdmin.
+// Two independent gates apply by design; see registerRoutes for details.
 func (hs *HTTPServer) QueryDiagnostics(c *contextmodel.ReqContext) response.Response {
 	ctx := c.Req.Context()
 	if !diagnosticsFeatureClient.Boolean(ctx, featuremgmt.FlagGrafanaOnDemandDiagnostics, false, openfeature.TransactionContext(ctx)) {

--- a/pkg/api/ds_query_diagnostics_test.go
+++ b/pkg/api/ds_query_diagnostics_test.go
@@ -1,0 +1,45 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/services/datasources"
+)
+
+// TestDiagnosticsNoCaptureError guards the status mapping used when a query fails and no HAR was
+// captured: a per-refId (bad-query) failure must surface as 400 like QueryMetricsV2, NOT 500, while
+// top-level errors keep their typed status.
+func TestDiagnosticsNoCaptureError(t *testing.T) {
+	hs := &HTTPServer{}
+
+	t.Run("per-refId failure is a client error (400), not 500", func(t *testing.T) {
+		r := hs.diagnosticsNoCaptureError(nil, errors.New("bad promql"))
+		require.NotNil(t, r)
+		require.Equal(t, http.StatusBadRequest, r.Status())
+	})
+
+	t.Run("generic top-level error is 500", func(t *testing.T) {
+		r := hs.diagnosticsNoCaptureError(errors.New("boom"), nil)
+		require.Equal(t, http.StatusInternalServerError, r.Status())
+	})
+
+	t.Run("typed top-level errors keep their status", func(t *testing.T) {
+		require.Equal(t, http.StatusForbidden,
+			hs.diagnosticsNoCaptureError(datasources.ErrDataSourceAccessDenied, nil).Status())
+		require.Equal(t, http.StatusNotFound,
+			hs.diagnosticsNoCaptureError(datasources.ErrDataSourceNotFound, nil).Status())
+	})
+
+	t.Run("top-level error takes precedence over per-refId", func(t *testing.T) {
+		r := hs.diagnosticsNoCaptureError(errors.New("boom"), errors.New("bad promql"))
+		require.Equal(t, http.StatusInternalServerError, r.Status())
+	})
+
+	t.Run("no failure proceeds to bundle assembly (nil)", func(t *testing.T) {
+		require.Nil(t, hs.diagnosticsNoCaptureError(nil, nil))
+	})
+}

--- a/pkg/infra/httpclient/harcapture/harcapture.go
+++ b/pkg/infra/httpclient/harcapture/harcapture.go
@@ -1,0 +1,235 @@
+// Package harcapture records datasource HTTP request/response pairs in memory and serializes them
+// to HAR 1.2 for the on-demand diagnostics bundle.
+//
+// REDACTION IS INTENTIONALLY NOT PERFORMED (yet). Captured entries — request/response headers
+// (Authorization, cookies, API keys, …), query parameters, URLs, and bodies — are recorded
+// VERBATIM. This is a deliberate, temporary scope decision for the experimental, admin-only,
+// on-prem, feature-flagged diagnostics endpoint: the download drawer warns the operator that the
+// bundle may contain sensitive data and to review it before sharing, so responsible use is on the
+// operator. Automatic redaction is a planned follow-up (tracked in data-sources#1281); until it
+// lands, treat every generated bundle as containing live credentials.
+package harcapture
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+	"unicode/utf8"
+
+	"github.com/chromedp/cdproto/har"
+)
+
+// encodeBody returns the HAR text representation of a body plus its encoding. Valid UTF-8 is stored
+// as-is; binary payloads are base64-encoded (with encoding "base64") so they survive JSON marshaling
+// intact instead of being corrupted by string() replacing invalid bytes with U+FFFD.
+func encodeBody(body []byte) (text, encoding string) {
+	if utf8.Valid(body) {
+		return string(body), ""
+	}
+	return base64.StdEncoding.EncodeToString(body), "base64"
+}
+
+type contextKey struct{}
+
+// Buffer collects HTTP request/response pairs as HAR 1.2 entries in memory.
+type Buffer struct {
+	mu      sync.Mutex
+	entries []*har.Entry
+}
+
+// WithCapture returns a child context carrying a new Buffer and the buffer itself.
+func WithCapture(ctx context.Context) (context.Context, *Buffer) {
+	buf := &Buffer{}
+	return context.WithValue(ctx, contextKey{}, buf), buf
+}
+
+// FromContext returns the Buffer stored in ctx, or nil if absent.
+func FromContext(ctx context.Context) *Buffer {
+	v, _ := ctx.Value(contextKey{}).(*Buffer)
+	return v
+}
+
+// AddEntry appends a captured request/response pair. rtErr is the RoundTrip error (nil on success);
+// a transport-level failure (connection refused, DNS/TLS error, timeout) leaves resp nil and is
+// recorded in the entry's comment. Thread-safe.
+func (b *Buffer) AddEntry(req *http.Request, resp *http.Response, rtErr error, started time.Time, elapsed time.Duration) {
+	e := buildEntry(req, resp, rtErr, started, elapsed)
+	b.mu.Lock()
+	b.entries = append(b.entries, e)
+	b.mu.Unlock()
+}
+
+// Len returns the number of captured entries. Thread-safe.
+func (b *Buffer) Len() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return len(b.entries)
+}
+
+// ToHAR serializes the captured entries to HAR 1.2 JSON. The entry types come from
+// github.com/chromedp/cdproto/har -- the same library the plugin SDK's e2e HAR storage uses -- so
+// the output stays replay-compatible with that fixture format.
+func (b *Buffer) ToHAR() ([]byte, error) {
+	b.mu.Lock()
+	entries := make([]*har.Entry, len(b.entries))
+	copy(entries, b.entries)
+	b.mu.Unlock()
+
+	doc := har.HAR{
+		Log: &har.Log{
+			Version: "1.2",
+			Creator: &har.Creator{Name: "Grafana", Version: "1.0"},
+			Entries: entries,
+		},
+	}
+	return json.Marshal(doc)
+}
+
+// buildEntry builds a HAR entry from a request/response pair. Values are captured verbatim -- see the
+// package doc: redaction is intentionally deferred.
+func buildEntry(req *http.Request, resp *http.Response, rtErr error, started time.Time, elapsed time.Duration) *har.Entry {
+	reqHeaders := toNameValues(req.Header)
+	queryString := queryPairs(req.URL.Query())
+
+	var pd *har.PostData
+	var reqBodySize int64
+	if req.Body != nil {
+		body, readErr := io.ReadAll(req.Body)
+		_ = req.Body.Close() // release the original body, as the RoundTripper contract requires
+		if readErr != nil {
+			// Restore the captured (partial) bytes followed by the error rather than leaving req.Body
+			// consumed, so a caller of this shared helper can still read the body and observe the failure.
+			req.Body = io.NopCloser(io.MultiReader(bytes.NewReader(body), &errorReader{err: readErr}))
+		} else {
+			req.Body = io.NopCloser(bytes.NewReader(body))
+			reqBodySize = int64(len(body))
+			if len(body) > 0 {
+				text, _ := encodeBody(body)
+				pd = &har.PostData{
+					MimeType: req.Header.Get("Content-Type"),
+					Text:     text,
+				}
+			}
+		}
+	}
+
+	// Content is required by the HAR spec and dereferenced unconditionally by the SDK's replay, so
+	// always attach a (possibly empty) Content, even for transport failures with no response body.
+	harResp := &har.Response{HeadersSize: -1, Content: &har.Content{}}
+	if resp != nil {
+		harResp.Status = int64(resp.StatusCode)
+		// HAR statusText is the reason phrase only ("OK"), but resp.Status is the full status line
+		// ("200 OK"); strip the leading code (keeping the server's actual phrase).
+		harResp.StatusText = strings.TrimSpace(strings.TrimPrefix(resp.Status, strconv.Itoa(resp.StatusCode)))
+		harResp.HTTPVersion = resp.Proto
+		harResp.Headers = toNameValues(resp.Header)
+		harResp.Cookies = toCookies(resp.Cookies())
+		harResp.RedirectURL = resp.Header.Get("Location")
+		if resp.Body != nil {
+			// Drain then Close the original transport body so its connection is returned to the idle
+			// pool (per the net/http contract), then hand the caller a fresh reader over the bytes.
+			body, readErr := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			if readErr != nil {
+				// Preserve the original read failure for the caller: replay the captured bytes, then
+				// surface the same error rather than silently substituting a truncated body.
+				resp.Body = io.NopCloser(io.MultiReader(bytes.NewReader(body), &errorReader{err: readErr}))
+			} else {
+				resp.Body = io.NopCloser(bytes.NewReader(body))
+			}
+			harResp.BodySize = int64(len(body))
+			text, encoding := encodeBody(body)
+			harResp.Content = &har.Content{
+				Size:     int64(len(body)),
+				MimeType: resp.Header.Get("Content-Type"),
+				Text:     text,
+				Encoding: encoding,
+			}
+		}
+	}
+
+	var comment string
+	if rtErr != nil {
+		comment = "transport error: " + rtErr.Error()
+	}
+
+	waitMs := float64(elapsed.Milliseconds())
+	return &har.Entry{
+		StartedDateTime: started.UTC().Format(time.RFC3339Nano),
+		Time:            waitMs,
+		Request: &har.Request{
+			Method:      req.Method,
+			URL:         req.URL.String(),
+			HTTPVersion: req.Proto,
+			Headers:     reqHeaders,
+			QueryString: queryString,
+			Cookies:     toCookies(req.Cookies()),
+			PostData:    pd,
+			BodySize:    reqBodySize,
+			HeadersSize: -1,
+		},
+		Response: harResp,
+		Cache:    &har.Cache{},
+		Timings:  &har.Timings{Send: 0, Wait: waitMs, Receive: 0},
+		Comment:  comment,
+	}
+}
+
+// toNameValues flattens an http.Header into HAR name/value pairs, emitting one pair per value so
+// repeated headers (e.g. multiple Set-Cookie) are preserved, in sorted order for deterministic output.
+func toNameValues(h http.Header) []*har.NameValuePair {
+	names := make([]string, 0, len(h))
+	for name := range h {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	result := make([]*har.NameValuePair, 0, len(h))
+	for _, name := range names {
+		for _, v := range h[name] {
+			result = append(result, &har.NameValuePair{Name: name, Value: v})
+		}
+	}
+	return result
+}
+
+// queryPairs flattens URL query values into HAR name/value pairs, sorted for deterministic output.
+func queryPairs(query map[string][]string) []*har.NameValuePair {
+	names := make([]string, 0, len(query))
+	for name := range query {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	result := make([]*har.NameValuePair, 0, len(query))
+	for _, name := range names {
+		for _, v := range query[name] {
+			result = append(result, &har.NameValuePair{Name: name, Value: v})
+		}
+	}
+	return result
+}
+
+// toCookies converts parsed HTTP cookies into HAR cookie entries (name/value), matching the SDK
+// e2e HAR storage output so captured traffic stays replayable by the E2E fixture proxy.
+func toCookies(cookies []*http.Cookie) []*har.Cookie {
+	result := make([]*har.Cookie, 0, len(cookies))
+	for _, c := range cookies {
+		result = append(result, &har.Cookie{Name: c.Name, Value: c.Value})
+	}
+	return result
+}
+
+// errorReader yields the wrapped error on Read. Used to re-surface a request/response body read
+// failure to the caller after the captured (partial) bytes have been replayed.
+type errorReader struct{ err error }
+
+func (r *errorReader) Read([]byte) (int, error) { return 0, r.err }

--- a/pkg/infra/httpclient/harcapture/harcapture.go
+++ b/pkg/infra/httpclient/harcapture/harcapture.go
@@ -112,6 +112,11 @@ func buildEntry(req *http.Request, resp *http.Response, rtErr error, started tim
 			req.Body = io.NopCloser(bytes.NewReader(body))
 			reqBodySize = int64(len(body))
 			if len(body) > 0 {
+				// HAR 1.2 PostData has no "encoding" field (only response Content does), so a
+				// non-UTF-8 request body is base64-encoded into Text without a machine-readable
+				// marker. base64 preserves the bytes (vs string() corrupting invalid UTF-8 to U+FFFD),
+				// but a replay tool can't tell it's base64. Accepted: datasource request bodies are
+				// text in practice, and body handling overall is a redaction/limits follow-up (#1281).
 				text, _ := encodeBody(body)
 				pd = &har.PostData{
 					MimeType: req.Header.Get("Content-Type"),

--- a/pkg/infra/httpclient/harcapture/harcapture.go
+++ b/pkg/infra/httpclient/harcapture/harcapture.go
@@ -6,8 +6,8 @@
 // VERBATIM. This is a deliberate, temporary scope decision for the experimental, admin-only,
 // on-prem, feature-flagged diagnostics endpoint: the download drawer warns the operator that the
 // bundle may contain sensitive data and to review it before sharing, so responsible use is on the
-// operator. Automatic redaction is a planned follow-up (tracked in data-sources#1281); until it
-// lands, treat every generated bundle as containing live credentials.
+// operator. Automatic redaction is a planned follow-up; until it lands, treat every generated
+// bundle as containing live credentials.
 package harcapture
 
 import (

--- a/pkg/infra/httpclient/harcapture/harcapture_test.go
+++ b/pkg/infra/httpclient/harcapture/harcapture_test.go
@@ -1,0 +1,278 @@
+package harcapture
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/chromedp/cdproto/har"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithCapture(t *testing.T) {
+	ctx := context.Background()
+	child, buf := WithCapture(ctx)
+
+	require.NotNil(t, buf)
+	assert.Same(t, buf, FromContext(child))
+	assert.Nil(t, FromContext(ctx), "parent context must not carry the buffer")
+}
+
+func TestFromContext_absent(t *testing.T) {
+	assert.Nil(t, FromContext(context.Background()))
+}
+
+func TestBuffer_Len(t *testing.T) {
+	_, buf := WithCapture(context.Background())
+	assert.Equal(t, 0, buf.Len())
+
+	buf.AddEntry(newGetReq(t, "http://example.com"), okResp(200), nil, time.Now(), time.Millisecond) //nolint:bodyclose
+	assert.Equal(t, 1, buf.Len())
+}
+
+func TestBuffer_ToHAR_structure(t *testing.T) {
+	_, buf := WithCapture(context.Background())
+
+	req := newPostReq(t, "http://ds.example.com/query", `{"q":"test"}`)
+	resp := okResp(200) //nolint:bodyclose
+	resp.Body = io.NopCloser(bytes.NewBufferString(`{"data":"result"}`))
+	resp.Header.Set("Content-Type", "application/json")
+
+	buf.AddEntry(req, resp, nil, time.Now(), 42*time.Millisecond)
+
+	raw, err := buf.ToHAR()
+	require.NoError(t, err)
+
+	var doc har.HAR
+	require.NoError(t, json.Unmarshal(raw, &doc))
+
+	assert.Equal(t, "1.2", doc.Log.Version)
+	require.Len(t, doc.Log.Entries, 1)
+
+	e := doc.Log.Entries[0]
+	assert.Equal(t, "POST", e.Request.Method)
+	assert.Equal(t, "http://ds.example.com/query", e.Request.URL)
+	assert.Equal(t, `{"q":"test"}`, e.Request.PostData.Text)
+	assert.Equal(t, int64(200), e.Response.Status)
+	assert.Equal(t, `{"data":"result"}`, e.Response.Content.Text)
+	assert.InDelta(t, 42.0, e.Time, 1.0)
+}
+
+func TestBuffer_ToHAR_requestBodyRestored(t *testing.T) {
+	_, buf := WithCapture(context.Background())
+
+	req := newPostReq(t, "http://example.com", `body`)
+	buf.AddEntry(req, okResp(200), nil, time.Now(), time.Millisecond) //nolint:bodyclose
+
+	// body must still be readable after AddEntry
+	body, err := io.ReadAll(req.Body)
+	require.NoError(t, err)
+	assert.Equal(t, "body", string(body))
+}
+
+func TestBuffer_ToHAR_responseBodyRestored(t *testing.T) {
+	_, buf := WithCapture(context.Background())
+
+	resp := okResp(200) //nolint:bodyclose
+	resp.Body = io.NopCloser(bytes.NewBufferString("response"))
+	buf.AddEntry(newGetReq(t, "http://example.com"), resp, nil, time.Now(), time.Millisecond)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, "response", string(body))
+}
+
+func TestBuffer_ToHAR_responseBodyReadError_surfacedToCaller(t *testing.T) {
+	_, buf := WithCapture(context.Background())
+
+	wantErr := errors.New("read boom")
+	resp := okResp(200) //nolint:bodyclose
+	resp.Body = io.NopCloser(&partialThenErrorReader{data: []byte("partial"), err: wantErr})
+
+	buf.AddEntry(newGetReq(t, "http://example.com"), resp, nil, time.Now(), time.Millisecond)
+
+	// The caller reads the captured bytes, then the original read error is re-surfaced rather
+	// than being silently swallowed and replaced with a truncated-but-successful body.
+	got, err := io.ReadAll(resp.Body)
+	assert.Equal(t, "partial", string(got))
+	assert.ErrorIs(t, err, wantErr)
+
+	raw, e := buf.ToHAR()
+	require.NoError(t, e)
+	var doc har.HAR
+	require.NoError(t, json.Unmarshal(raw, &doc))
+	require.Len(t, doc.Log.Entries, 1)
+	assert.Equal(t, "partial", doc.Log.Entries[0].Response.Content.Text)
+}
+
+func TestBuffer_ToHAR_requestBodyReadError_restored(t *testing.T) {
+	_, buf := WithCapture(context.Background())
+
+	wantErr := errors.New("req read boom")
+	req := newGetReq(t, "http://example.com")
+	req.Body = io.NopCloser(&partialThenErrorReader{data: []byte("partial-req"), err: wantErr})
+
+	buf.AddEntry(req, okResp(200), nil, time.Now(), time.Millisecond) //nolint:bodyclose
+
+	// Symmetric with the response path: req.Body is restored (captured bytes then the error),
+	// not left consumed.
+	got, err := io.ReadAll(req.Body)
+	assert.Equal(t, "partial-req", string(got))
+	assert.ErrorIs(t, err, wantErr)
+}
+
+func TestBuffer_ToHAR_binaryResponseBody_base64(t *testing.T) {
+	_, buf := WithCapture(context.Background())
+
+	binary := []byte{0xff, 0xfe, 0x00, 0x01, 0x80, 0x02} // invalid UTF-8
+	resp := okResp(200)                                  //nolint:bodyclose
+	resp.Body = io.NopCloser(bytes.NewReader(binary))
+	resp.Header.Set("Content-Type", "application/octet-stream")
+
+	buf.AddEntry(newGetReq(t, "http://example.com"), resp, nil, time.Now(), time.Millisecond)
+
+	raw, err := buf.ToHAR()
+	require.NoError(t, err)
+	var doc har.HAR
+	require.NoError(t, json.Unmarshal(raw, &doc))
+
+	c := doc.Log.Entries[0].Response.Content
+	assert.Equal(t, "base64", c.Encoding, "binary body flagged as base64")
+	assert.Equal(t, int64(len(binary)), c.Size, "size reflects the raw byte length")
+
+	decoded, err := base64.StdEncoding.DecodeString(c.Text)
+	require.NoError(t, err)
+	assert.Equal(t, binary, decoded, "binary body round-trips losslessly")
+}
+
+func TestBuffer_ToHAR_statusTextIsReasonPhrase(t *testing.T) {
+	_, buf := WithCapture(context.Background())
+	resp := okResp(200)    //nolint:bodyclose
+	resp.Status = "200 OK" // real net/http status line (full), not just the reason phrase
+	buf.AddEntry(newGetReq(t, "http://example.com"), resp, nil, time.Now(), time.Millisecond)
+
+	raw, err := buf.ToHAR()
+	require.NoError(t, err)
+	var doc har.HAR
+	require.NoError(t, json.Unmarshal(raw, &doc))
+	// HAR 1.2 statusText is the reason phrase only, not the full "200 OK" status line.
+	assert.Equal(t, int64(200), doc.Log.Entries[0].Response.Status)
+	assert.Equal(t, "OK", doc.Log.Entries[0].Response.StatusText)
+}
+
+func TestToNameValues_sortedAndMultiValue(t *testing.T) {
+	h := http.Header{
+		"X-Zeta":  {"z"},
+		"X-Alpha": {"a1", "a2"}, // repeated header values must all be preserved
+	}
+
+	assert.Equal(t, []*har.NameValuePair{
+		{Name: "X-Alpha", Value: "a1"},
+		{Name: "X-Alpha", Value: "a2"},
+		{Name: "X-Zeta", Value: "z"},
+	}, toNameValues(h), "names sorted, one pair per value")
+}
+
+func TestBuffer_ToHAR_transportError_recordedInComment(t *testing.T) {
+	_, buf := WithCapture(context.Background())
+	// A failed dial has no HTTP response; the attempt (and why it failed) must still be captured.
+	buf.AddEntry(newGetReq(t, "http://ds.example.com/q"), nil, errors.New("dial tcp: connection refused"), time.Now(), time.Millisecond)
+
+	raw, err := buf.ToHAR()
+	require.NoError(t, err)
+	var doc har.HAR
+	require.NoError(t, json.Unmarshal(raw, &doc))
+	require.Len(t, doc.Log.Entries, 1)
+	assert.Equal(t, int64(0), doc.Log.Entries[0].Response.Status, "no-response entry has zero status")
+	assert.Contains(t, doc.Log.Entries[0].Comment, "connection refused", "transport error recorded in entry comment")
+}
+
+func TestBuffer_ToHAR_emptyHeaderValues_noPanic(t *testing.T) {
+	_, buf := WithCapture(context.Background())
+	req := newGetReq(t, "http://example.com")
+	req.Header["X-Empty"] = []string{}                                // empty value slice — must not panic
+	buf.AddEntry(req, okResp(200), nil, time.Now(), time.Millisecond) //nolint:bodyclose
+	_, err := buf.ToHAR()
+	require.NoError(t, err)
+}
+
+func TestBuffer_ToHAR_nilResponse(t *testing.T) {
+	_, buf := WithCapture(context.Background())
+	// A transport-level failure yields a nil response; the entry must still serialize.
+	buf.AddEntry(newGetReq(t, "http://example.com"), nil, nil, time.Now(), time.Millisecond)
+
+	raw, err := buf.ToHAR()
+	require.NoError(t, err)
+
+	var doc har.HAR
+	require.NoError(t, json.Unmarshal(raw, &doc))
+	require.Len(t, doc.Log.Entries, 1)
+	assert.Equal(t, int64(0), doc.Log.Entries[0].Response.Status)
+}
+
+func TestBuffer_concurrentAddEntry(t *testing.T) {
+	_, buf := WithCapture(context.Background())
+	var wg sync.WaitGroup
+	const n = 100
+	wg.Add(n)
+	for range n {
+		go func() {
+			defer wg.Done()
+			buf.AddEntry(newGetReq(t, "http://example.com"), okResp(200), nil, time.Now(), time.Millisecond) //nolint:bodyclose
+		}()
+	}
+	wg.Wait()
+	assert.Equal(t, n, buf.Len())
+}
+
+// --- helpers ---
+
+func newGetReq(t *testing.T, url string) *http.Request {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	require.NoError(t, err)
+	return req
+}
+
+func newPostReq(t *testing.T, url, body string) *http.Request {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBufferString(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+func okResp(status int) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Status:     http.StatusText(status),
+		Proto:      "HTTP/1.1",
+		Header:     http.Header{},
+		Body:       io.NopCloser(bytes.NewBufferString("")),
+	}
+}
+
+// partialThenErrorReader yields data, then fails with err -- simulating a body read that breaks
+// mid-stream (e.g. a dropped connection).
+type partialThenErrorReader struct {
+	data []byte
+	err  error
+	off  int
+}
+
+func (r *partialThenErrorReader) Read(p []byte) (int, error) {
+	if r.off < len(r.data) {
+		n := copy(p, r.data[r.off:])
+		r.off += n
+		return n, nil
+	}
+	return 0, r.err
+}

--- a/pkg/services/diagnostics/diagnostics.go
+++ b/pkg/services/diagnostics/diagnostics.go
@@ -30,12 +30,8 @@ func NewBundler() *Bundler {
 // optional panel/dashboard JSON the client supplied. traffic.har is omitted when nothing was
 // captured.
 //
-// TODO: re-add a request-scoped server log. The previous whole-file tail was dropped because it is
-// not scoped to this request and would leak unrelated activity into a bundle meant for external
-// sharing; log inclusion returns (behind a drawer option) once it can be scoped to the request.
-// queryErr is the error (if any) from running the queries. A failed query is itself diagnostic
-// signal — the captured HAR already holds the failed attempt(s) — so it is recorded in the bundle
-// rather than causing the capture to be discarded.
+// Server logs are intentionally omitted because they are not scoped to this request and would leak
+// unrelated activity into a bundle meant for external sharing; they will be tackled in a follow-up.
 func (b *Bundler) Build(harBuffer *harcapture.Buffer, panelJSON, dashboardJSON json.RawMessage, queryErr error) ([]byte, error) {
 	files := map[string][]byte{}
 

--- a/pkg/services/diagnostics/diagnostics.go
+++ b/pkg/services/diagnostics/diagnostics.go
@@ -1,0 +1,156 @@
+// Package diagnostics assembles on-demand datasource diagnostic bundles: captured HTTP traffic
+// (HAR) and the panel/dashboard JSON. The HTTP handler in pkg/api runs the queries with capture
+// active and delegates bundle assembly here.
+package diagnostics
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+
+	"github.com/grafana/grafana/pkg/infra/httpclient/harcapture"
+)
+
+// Bundler assembles diagnostic bundles.
+type Bundler struct{}
+
+// NewBundler returns a Bundler.
+func NewBundler() *Bundler {
+	return &Bundler{}
+}
+
+// Build assembles a .tar.gz bundle from the query response, the captured HAR buffer, and the
+// optional panel/dashboard JSON the client supplied. traffic.har is omitted when nothing was
+// captured.
+//
+// TODO: re-add a request-scoped server log. The previous whole-file tail was dropped because it is
+// not scoped to this request and would leak unrelated activity into a bundle meant for external
+// sharing; log inclusion returns (behind a drawer option) once it can be scoped to the request.
+// queryErr is the error (if any) from running the queries. A failed query is itself diagnostic
+// signal — the captured HAR already holds the failed attempt(s) — so it is recorded in the bundle
+// rather than causing the capture to be discarded.
+func (b *Bundler) Build(harBuffer *harcapture.Buffer, panelJSON, dashboardJSON json.RawMessage, queryErr error) ([]byte, error) {
+	files := map[string][]byte{}
+
+	har, err := collectHAR(harBuffer)
+	if err != nil {
+		return nil, err
+	}
+	if len(har) > 0 {
+		files["traffic.har"] = har
+	}
+
+	if len(panelJSON) > 0 {
+		files["panel.json"] = indentJSON(panelJSON)
+	}
+	if len(dashboardJSON) > 0 {
+		files["dashboard.json"] = indentJSON(dashboardJSON)
+	}
+
+	if queryErr != nil {
+		// Recorded verbatim -- redaction is intentionally deferred for this experimental feature
+		// (see the harcapture package doc); the error text can embed a request URL with credentials.
+		files["query-error.txt"] = []byte(queryErr.Error() + "\n")
+	}
+
+	return buildTarGz(files)
+}
+
+// ResponseError returns a combined error describing any per-refId query failures in resp
+// (backend.DataResponse.Error), or nil if there are none. Datasource queries usually fail this way
+// — QueryData returns no top-level error while individual responses carry the failure — so a caller
+// that only checks the top-level error would miss them. Errors are wrapped per refId (preserving
+// errors.Is/As for typed classification) and ordered deterministically by refId.
+func ResponseError(resp *backend.QueryDataResponse) error {
+	if resp == nil {
+		return nil
+	}
+	refIDs := make([]string, 0, len(resp.Responses))
+	for refID, r := range resp.Responses {
+		if r.Error != nil {
+			refIDs = append(refIDs, refID)
+		}
+	}
+	if len(refIDs) == 0 {
+		return nil
+	}
+	sort.Strings(refIDs)
+	errs := make([]error, 0, len(refIDs))
+	for _, refID := range refIDs {
+		errs = append(errs, fmt.Errorf("%s: %w", refID, resp.Responses[refID].Error))
+	}
+	return errors.Join(errs...)
+}
+
+// HasCapturedHAR reports whether any HAR traffic was captured for this request (the in-process
+// buffer has entries). The handler uses it to decide whether a failed query still has something
+// worth bundling.
+func HasCapturedHAR(harBuffer *harcapture.Buffer) bool {
+	return harBuffer != nil && harBuffer.Len() > 0
+}
+
+// collectHAR returns the captured HTTP traffic (from the in-process buffer) as HAR 1.2 JSON.
+// Returns (nil, nil) when nothing was captured, and a non-nil error if traffic was captured but
+// could not be serialized (so the caller can fail rather than return an empty bundle).
+func collectHAR(harBuffer *harcapture.Buffer) ([]byte, error) {
+	if harBuffer == nil || harBuffer.Len() == 0 {
+		return nil, nil
+	}
+	return harBuffer.ToHAR()
+}
+
+// buildTarGz packs the named files into a gzipped tar archive. Files are written in deterministic
+// (sorted) name order.
+func buildTarGz(files map[string][]byte) ([]byte, error) {
+	names := make([]string, 0, len(files))
+	for name := range files {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+
+	now := time.Now()
+	for _, name := range names {
+		data := files[name]
+		hdr := &tar.Header{
+			Name:    name,
+			Mode:    0o600,
+			Size:    int64(len(data)),
+			ModTime: now,
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			return nil, err
+		}
+		if _, err := tw.Write(data); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := tw.Close(); err != nil {
+		return nil, err
+	}
+	if err := gz.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// indentJSON pretty-prints raw JSON for readability in the bundle, falling back to the raw bytes
+// if it cannot be parsed.
+func indentJSON(raw []byte) []byte {
+	var out bytes.Buffer
+	if err := json.Indent(&out, raw, "", "  "); err != nil {
+		return raw
+	}
+	return out.Bytes()
+}

--- a/pkg/services/diagnostics/diagnostics_test.go
+++ b/pkg/services/diagnostics/diagnostics_test.go
@@ -1,0 +1,163 @@
+package diagnostics
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/infra/httpclient/harcapture"
+)
+
+func TestBundler_Build(t *testing.T) {
+	// No HAR captured (empty buffer, nil response) -> traffic.har omitted; only panel.json present.
+	blob, err := NewBundler().Build(&harcapture.Buffer{}, json.RawMessage(`{"id":1}`), nil, nil)
+	require.NoError(t, err)
+
+	files := readTarGz(t, blob)
+	require.Contains(t, files, "panel.json")
+	require.NotContains(t, files, "traffic.har", "no HAR was captured")
+	require.NotContains(t, files, "dashboard.json", "no dashboard JSON supplied")
+	require.NotContains(t, files, "server.log", "server log is intentionally omitted until it can be request-scoped")
+	require.NotContains(t, files, "query-error.txt", "no query error")
+	require.JSONEq(t, `{"id":1}`, string(files["panel.json"]))
+}
+
+func TestBundler_Build_recordsQueryError(t *testing.T) {
+	// A failed query must still produce a bundle, with the error recorded (capture is not discarded).
+	blob, err := NewBundler().Build(&harcapture.Buffer{}, nil, nil, errors.New("datasource timeout"))
+	require.NoError(t, err)
+
+	files := readTarGz(t, blob)
+	require.Contains(t, files, "query-error.txt")
+	require.Contains(t, string(files["query-error.txt"]), "datasource timeout")
+}
+
+func TestHasCapturedHAR(t *testing.T) {
+	require.False(t, HasCapturedHAR(nil), "nil buffer -> nothing captured")
+	require.False(t, HasCapturedHAR(&harcapture.Buffer{}), "empty buffer -> nothing captured")
+
+	buf := &harcapture.Buffer{}
+	req, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	require.NoError(t, err)
+	buf.AddEntry(req, nil, nil, time.Now(), time.Millisecond)
+	require.True(t, HasCapturedHAR(buf), "buffer with entries -> captured")
+}
+
+func TestCollectHAR_nilAndEmptyBuffer(t *testing.T) {
+	out, err := collectHAR(nil)
+	require.NoError(t, err)
+	require.Nil(t, out)
+
+	out, err = collectHAR(&harcapture.Buffer{})
+	require.NoError(t, err)
+	require.Nil(t, out)
+
+	// A nil buffer must also flow through Build without panicking.
+	bundle, err := NewBundler().Build(nil, nil, nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, bundle)
+}
+
+func TestCollectHAR_BufferOnly_returnedVerbatim(t *testing.T) {
+	buf := &harcapture.Buffer{}
+	req, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	require.NoError(t, err)
+	buf.AddEntry(req, nil, nil, time.Now(), time.Millisecond)
+
+	out, err := collectHAR(buf)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+
+	// With no external frames, the buffer's own HAR document is returned as-is (no mergeHAR
+	// re-marshal round-trip), so it must be byte-identical to Buffer.ToHAR().
+	want, err := buf.ToHAR()
+	require.NoError(t, err)
+	require.Equal(t, want, out)
+
+	var doc struct {
+		Log struct {
+			Entries []json.RawMessage `json:"entries"`
+		} `json:"log"`
+	}
+	require.NoError(t, json.Unmarshal(out, &doc))
+	require.Len(t, doc.Log.Entries, 1)
+}
+
+func TestBuildTarGz(t *testing.T) {
+	blob, err := buildTarGz(map[string][]byte{"b.txt": []byte("bbb"), "a.txt": []byte("aaa")})
+	require.NoError(t, err)
+
+	files := readTarGz(t, blob)
+	require.Equal(t, "aaa", string(files["a.txt"]))
+	require.Equal(t, "bbb", string(files["b.txt"]))
+}
+
+func TestBuildTarGz_deterministicOrder(t *testing.T) {
+	blob, err := buildTarGz(map[string][]byte{"b.txt": []byte("b"), "a.txt": []byte("a"), "c.txt": []byte("c")})
+	require.NoError(t, err)
+
+	gz, err := gzip.NewReader(bytes.NewReader(blob))
+	require.NoError(t, err)
+	tr := tar.NewReader(gz)
+	var names []string
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		require.NoError(t, err)
+		names = append(names, hdr.Name)
+	}
+	require.Equal(t, []string{"a.txt", "b.txt", "c.txt"}, names, "files written in sorted order")
+}
+
+func TestIndentJSON(t *testing.T) {
+	require.Equal(t, "{\n  \"a\": 1\n}", string(indentJSON([]byte(`{"a":1}`))))
+	require.Equal(t, "not json", string(indentJSON([]byte("not json"))), "falls back to raw bytes when unparseable")
+}
+
+func TestResponseError(t *testing.T) {
+	require.NoError(t, ResponseError(nil))
+	require.NoError(t, ResponseError(&backend.QueryDataResponse{Responses: backend.Responses{"A": {}}}))
+
+	sentinel := errors.New("boom")
+	err := ResponseError(&backend.QueryDataResponse{Responses: backend.Responses{
+		"B": {Error: sentinel},
+		"A": {Error: errors.New("bad query")},
+	}})
+	require.Error(t, err)
+	// Typed classification survives (handleQueryMetricsError relies on errors.Is).
+	require.ErrorIs(t, err, sentinel)
+	// Combined, wrapped per refId, and ordered deterministically by refId.
+	require.Equal(t, "A: bad query\nB: boom", err.Error())
+}
+
+func readTarGz(t *testing.T, data []byte) map[string][]byte {
+	t.Helper()
+
+	gz, err := gzip.NewReader(bytes.NewReader(data))
+	require.NoError(t, err)
+
+	tr := tar.NewReader(gz)
+	out := map[string][]byte{}
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		require.NoError(t, err)
+		b, err := io.ReadAll(tr)
+		require.NoError(t, err)
+		out[hdr.Name] = b
+	}
+	return out
+}

--- a/pkg/services/pluginsintegration/clientmiddleware/http_capture_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/http_capture_middleware.go
@@ -19,7 +19,7 @@ import (
 //
 // For core (in-process) plugins it injects a capturing RoundTripper as contextual middleware, so the
 // existing ContextualMiddleware in the HTTP client chain picks it up. (External out-of-process gRPC
-// plugins are captured separately once the SDK-side middleware ships — see #1270.)
+// plugins will be captured separately, in a follow-up.)
 func NewHTTPCaptureMiddleware() backend.HandlerMiddleware {
 	return backend.HandlerMiddlewareFunc(func(next backend.Handler) backend.Handler {
 		return &HTTPCaptureMiddleware{BaseHandler: backend.NewBaseHandler(next)}

--- a/pkg/services/pluginsintegration/clientmiddleware/http_capture_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/http_capture_middleware.go
@@ -1,0 +1,73 @@
+package clientmiddleware
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+
+	"github.com/grafana/grafana/pkg/infra/httpclient/harcapture"
+)
+
+// NewHTTPCaptureMiddleware creates a backend.HandlerMiddleware that captures HTTP traffic
+// for QueryData calls when a harcapture.Buffer is present in the context.
+//
+// For core (in-process) plugins it injects a capturing RoundTripper as contextual middleware, so the
+// existing ContextualMiddleware in the HTTP client chain picks it up. (External out-of-process gRPC
+// plugins are captured separately once the SDK-side middleware ships — see #1270.)
+func NewHTTPCaptureMiddleware() backend.HandlerMiddleware {
+	return backend.HandlerMiddlewareFunc(func(next backend.Handler) backend.Handler {
+		return &HTTPCaptureMiddleware{BaseHandler: backend.NewBaseHandler(next)}
+	})
+}
+
+type HTTPCaptureMiddleware struct {
+	backend.BaseHandler
+}
+
+func (m *HTTPCaptureMiddleware) QueryData(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+	buf := harcapture.FromContext(ctx)
+	if buf == nil {
+		return m.BaseHandler.QueryData(ctx, req)
+	}
+
+	// Inject capturing RoundTripper for core (in-process) plugins.
+	captureMW := sdkhttpclient.NamedMiddlewareFunc("http-capture", func(_ sdkhttpclient.Options, next http.RoundTripper) http.RoundTripper {
+		return sdkhttpclient.RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
+			// Buffer the request body before it is consumed by the transport.
+			var bodyBytes []byte
+			if r.Body != nil {
+				var readErr error
+				bodyBytes, readErr = io.ReadAll(r.Body)
+				_ = r.Body.Close()
+				if readErr != nil {
+					// Fail the request rather than silently forwarding a truncated body to the
+					// datasource; the diagnostics run surfaces the error.
+					return nil, fmt.Errorf("har capture: reading request body: %w", readErr)
+				}
+				r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+			}
+
+			started := time.Now()
+			resp, err := next.RoundTrip(r)
+			elapsed := time.Since(started)
+
+			// Capture every attempt, including transport-level failures (connection refused,
+			// timeouts, etc.) where err is non-nil and resp is nil -- those are exactly the
+			// requests worth seeing in a diagnostics bundle. Restore the request body first so
+			// buildEntry can read it.
+			r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+			buf.AddEntry(r, resp, err, started, elapsed)
+
+			return resp, err
+		})
+	})
+	ctx = sdkhttpclient.WithContextualMiddleware(ctx, captureMW)
+
+	return m.BaseHandler.QueryData(ctx, req)
+}

--- a/pkg/services/pluginsintegration/clientmiddleware/http_capture_middleware_test.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/http_capture_middleware_test.go
@@ -1,0 +1,173 @@
+package clientmiddleware
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/handlertest"
+	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/infra/httpclient/harcapture"
+)
+
+func TestHTTPCaptureMiddleware_noBuffer_passthrough(t *testing.T) {
+	var contextualMWs []sdkhttpclient.Middleware
+	var called bool
+	cdt := handlertest.NewHandlerMiddlewareTest(t, handlertest.WithMiddlewares(NewHTTPCaptureMiddleware()))
+	cdt.TestHandler.QueryDataFunc = func(ctx context.Context, _ *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+		called = true
+		contextualMWs = sdkhttpclient.ContextualMiddlewareFromContext(ctx)
+		return &backend.QueryDataResponse{}, nil
+	}
+
+	// No buffer in context -> pure pass-through, no capturing middleware injected.
+	_, err := cdt.MiddlewareHandler.QueryData(context.Background(), &backend.QueryDataRequest{})
+	require.NoError(t, err)
+	assert.True(t, called)
+	assert.Empty(t, contextualMWs)
+}
+
+func TestHTTPCaptureMiddleware_withBuffer_injectsContextualMiddleware(t *testing.T) {
+	var contextualMWs []sdkhttpclient.Middleware
+	cdt := handlertest.NewHandlerMiddlewareTest(t, handlertest.WithMiddlewares(NewHTTPCaptureMiddleware()))
+	cdt.TestHandler.QueryDataFunc = func(ctx context.Context, _ *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+		contextualMWs = sdkhttpclient.ContextualMiddlewareFromContext(ctx)
+		return &backend.QueryDataResponse{}, nil
+	}
+
+	ctx, _ := harcapture.WithCapture(context.Background())
+	_, err := cdt.MiddlewareHandler.QueryData(ctx, &backend.QueryDataRequest{})
+	require.NoError(t, err)
+	assert.NotEmpty(t, contextualMWs)
+}
+
+func TestHTTPCaptureMiddleware_withBuffer_capturesHTTPEntry(t *testing.T) {
+	cdt := handlertest.NewHandlerMiddlewareTest(t, handlertest.WithMiddlewares(NewHTTPCaptureMiddleware()))
+	cdt.TestHandler.QueryDataFunc = func(ctx context.Context, _ *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+		makeGrafanaHTTPCall(ctx, t, "http://example.com", nil)
+		return &backend.QueryDataResponse{}, nil
+	}
+
+	ctx, buf := harcapture.WithCapture(context.Background())
+	_, err := cdt.MiddlewareHandler.QueryData(ctx, &backend.QueryDataRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, buf.Len())
+}
+
+func TestHTTPCaptureMiddleware_withBuffer_capturesFailedRequest(t *testing.T) {
+	cdt := handlertest.NewHandlerMiddlewareTest(t, handlertest.WithMiddlewares(NewHTTPCaptureMiddleware()))
+	cdt.TestHandler.QueryDataFunc = func(ctx context.Context, _ *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+		// Transport-level failure: RoundTrip returns an error and a nil response.
+		makeGrafanaHTTPCall(ctx, t, "http://example.com", errors.New("connection refused"))
+		return &backend.QueryDataResponse{}, nil
+	}
+
+	ctx, buf := harcapture.WithCapture(context.Background())
+	_, err := cdt.MiddlewareHandler.QueryData(ctx, &backend.QueryDataRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, buf.Len(), "failed requests must still be captured in the HAR")
+}
+
+func TestHTTPCaptureMiddleware_capturesAndRestoresRequestBody(t *testing.T) {
+	var transportSawBody string
+	cdt := handlertest.NewHandlerMiddlewareTest(t, handlertest.WithMiddlewares(NewHTTPCaptureMiddleware()))
+	cdt.TestHandler.QueryDataFunc = func(ctx context.Context, _ *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+		rt := buildContextualRT(ctx, sdkhttpclient.RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
+			b, _ := io.ReadAll(r.Body) // the transport must still see the full body
+			transportSawBody = string(b)
+			return okHTTPResp(), nil
+		}))
+		req, _ := http.NewRequestWithContext(ctx, http.MethodPost, "http://example.com", bytes.NewBufferString("payload"))
+		_, err := rt.RoundTrip(req) //nolint:bodyclose
+		require.NoError(t, err)
+		return &backend.QueryDataResponse{}, nil
+	}
+
+	ctx, buf := harcapture.WithCapture(context.Background())
+	_, err := cdt.MiddlewareHandler.QueryData(ctx, &backend.QueryDataRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, "payload", transportSawBody, "transport receives the full (restored) request body")
+	require.Equal(t, 1, buf.Len())
+	raw, err := buf.ToHAR()
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), "payload", "captured request body appears in the HAR")
+}
+
+func TestHTTPCaptureMiddleware_requestBodyReadError_failsRequest(t *testing.T) {
+	transportCalled := false
+	var rtErr error
+	cdt := handlertest.NewHandlerMiddlewareTest(t, handlertest.WithMiddlewares(NewHTTPCaptureMiddleware()))
+	cdt.TestHandler.QueryDataFunc = func(ctx context.Context, _ *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+		rt := buildContextualRT(ctx, sdkhttpclient.RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
+			transportCalled = true
+			return okHTTPResp(), nil
+		}))
+		req, _ := http.NewRequestWithContext(ctx, http.MethodPost, "http://example.com", nil)
+		req.Body = io.NopCloser(&failingReader{err: errors.New("body boom")})
+		_, rtErr = rt.RoundTrip(req) //nolint:bodyclose
+		return &backend.QueryDataResponse{}, nil
+	}
+
+	ctx, buf := harcapture.WithCapture(context.Background())
+	_, err := cdt.MiddlewareHandler.QueryData(ctx, &backend.QueryDataRequest{})
+	require.NoError(t, err)
+	require.Error(t, rtErr)
+	assert.Contains(t, rtErr.Error(), "reading request body")
+	assert.False(t, transportCalled, "transport must not be called when the request body cannot be read")
+	assert.Equal(t, 0, buf.Len(), "no entry is recorded when the request body read fails")
+}
+
+// buildContextualRT wraps base with every contextual middleware registered in ctx (outermost last),
+// mirroring how the in-process HTTP client applies them.
+func buildContextualRT(ctx context.Context, base http.RoundTripper) http.RoundTripper {
+	rt := base
+	for _, mw := range sdkhttpclient.ContextualMiddlewareFromContext(ctx) {
+		rt = mw.CreateMiddleware(sdkhttpclient.Options{}, rt)
+	}
+	return rt
+}
+
+func okHTTPResp() *http.Response {
+	return &http.Response{
+		StatusCode: 200,
+		Status:     "200 OK",
+		Proto:      "HTTP/1.1",
+		Header:     http.Header{},
+		Body:       io.NopCloser(bytes.NewBufferString("ok")),
+	}
+}
+
+type failingReader struct{ err error }
+
+func (f *failingReader) Read([]byte) (int, error) { return 0, f.err }
+
+// makeGrafanaHTTPCall simulates an in-process plugin making an HTTP call through the contextual
+// middleware chain. When rtErr is non-nil, the simulated transport returns it with a nil response.
+func makeGrafanaHTTPCall(ctx context.Context, t *testing.T, url string, rtErr error) {
+	t.Helper()
+	mws := sdkhttpclient.ContextualMiddlewareFromContext(ctx)
+	var rt http.RoundTripper = sdkhttpclient.RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		if rtErr != nil {
+			return nil, rtErr
+		}
+		return &http.Response{
+			StatusCode: 200,
+			Status:     "200 OK",
+			Proto:      "HTTP/1.1",
+			Header:     http.Header{},
+			Body:       io.NopCloser(bytes.NewBufferString("ok")),
+		}, nil
+	})
+	for _, mw := range mws {
+		rt = mw.CreateMiddleware(sdkhttpclient.Options{}, rt)
+	}
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	_, _ = rt.RoundTrip(req) //nolint:bodyclose
+}

--- a/pkg/services/pluginsintegration/pluginsintegration.go
+++ b/pkg/services/pluginsintegration/pluginsintegration.go
@@ -213,6 +213,7 @@ func CreateMiddlewares(cfg *setting.Cfg, oAuthTokenService oauthtoken.OAuthToken
 		middlewares = append(middlewares, clientmiddleware.NewHostedGrafanaACHeaderMiddleware(cfg))
 	}
 
+	middlewares = append(middlewares, clientmiddleware.NewHTTPCaptureMiddleware())
 	middlewares = append(middlewares, clientmiddleware.NewHTTPClientMiddleware())
 
 	// ErrorSourceMiddleware should be at the very bottom, or any middlewares below it won't see the


### PR DESCRIPTION
### What this PR does

Adds on-demand **datasource diagnostics** for **core (in-process) plugins**, behind the experimental `grafana.onDemandDiagnostics` feature toggle.

The frontend panel action with drawer that calls this endpoint is already merged (#128212).

### ⚠️ Redaction is intentionally deferred

Captured traffic is recorded **verbatim** — request/response headers (Authorization, cookies, API keys), query parameters, URLs, and bodies are **not** redacted in this PR. This is a deliberate scope decision:

- the feature is **experimental, admin-only, on-prem-only, and off by default**;
- the **download drawer already warns** the operator that the bundle may contain sensitive data and to review it before sharing (#128212), so responsible handling is on the operator;
- automatic redaction is a **planned follow-up** (tracked in data-sources#1281). Deferring it keeps this PR focused on the capture/bundle mechanics and avoids shipping a large, security-sensitive redaction layer before it can be reviewed on its own.

The `harcapture` package doc states this prominently so callers aren't misled into assuming the bundle is safe to share unreviewed.

### Scope / follow-ups

- **Core (in-process) plugins only.** External out-of-process (gRPC) plugin capture is a separate follow-up (needs the SDK-side capture middleware + a `go.mod` bump — data-sources#1270).
- **Redaction** (data-sources#1281) and **body/size caps** (data-sources#1283) are tracked follow-ups.

