### PR TITLE
IAM: read standard created field in user search

### DIFF
--- a/pkg/registry/apis/iam/user/legacy_search.go
+++ b/pkg/registry/apis/iam/user/legacy_search.go
@@ -36,7 +36,6 @@ var (
 	fieldLastSeenAt                                 = fmt.Sprintf("%s%s", resource.SEARCH_FIELD_PREFIX, builders.USER_LAST_SEEN_AT)
 	fieldRole                                       = fmt.Sprintf("%s%s", resource.SEARCH_FIELD_PREFIX, builders.USER_ROLE)
 	fieldDisabled                                   = fmt.Sprintf("%s%s", resource.SEARCH_FIELD_PREFIX, builders.USER_DISABLED)
-	fieldCreated                                    = fmt.Sprintf("%s%s", resource.SEARCH_FIELD_PREFIX, builders.USER_CREATED)
 	legacyIDField                                   = resource.SEARCH_FIELD_LABELS + "." + resource.SEARCH_FIELD_LEGACY_ID
 	wildcardsMatcher                                = regexp.MustCompile(`[\*\?\\]`)
 
@@ -216,8 +215,11 @@ func getColumns(fields []string) []*resourcepb.ResourceTableColumnDefinition {
 			cols = append(cols, builders.UserTableColumnDefinitions[builders.USER_LOGIN])
 		case fieldDisabled:
 			cols = append(cols, builders.UserTableColumnDefinitions[builders.USER_DISABLED])
-		case fieldCreated:
-			cols = append(cols, builders.UserTableColumnDefinitions[builders.USER_CREATED])
+		case resource.SEARCH_FIELD_CREATED:
+			cols = append(cols, &resourcepb.ResourceTableColumnDefinition{
+				Name: resource.SEARCH_FIELD_CREATED,
+				Type: resourcepb.ResourceTableColumnDefinition_INT64,
+			})
 		case legacyIDField:
 			cols = append(cols, &resourcepb.ResourceTableColumnDefinition{
 				Name: legacyIDField,
@@ -250,7 +252,7 @@ func createCells(u *org.OrgUserDTO, fields []string) [][]byte {
 			} else {
 				cells = append(cells, []byte{0})
 			}
-		case fieldCreated:
+		case resource.SEARCH_FIELD_CREATED:
 			b := make([]byte, 8)
 			binary.BigEndian.PutUint64(b, uint64(u.Created.UnixMilli()))
 			cells = append(cells, b)

--- a/pkg/registry/apis/iam/user/legacy_search_test.go
+++ b/pkg/registry/apis/iam/user/legacy_search_test.go
@@ -165,7 +165,7 @@ func TestUserLegacySearchClient_Search(t *testing.T) {
 			Limit:   10,
 			Page:    1,
 			Options: &resourcepb.ListOptions{Key: &resourcepb.ResourceKey{Namespace: "default"}},
-			Fields:  []string{legacyIDField, fieldCreated, fieldDisabled},
+			Fields:  []string{legacyIDField, res.SEARCH_FIELD_CREATED, fieldDisabled},
 		}
 
 		mockOrgService.On("SearchOrgUsers", mock.Anything, mock.Anything).Return(&org.SearchOrgUsersQueryResult{
@@ -178,7 +178,7 @@ func TestUserLegacySearchClient_Search(t *testing.T) {
 		require.Len(t, resp.Results.Rows, 1)
 
 		require.Equal(t,
-			[]string{legacyIDField, builders.USER_CREATED, builders.USER_DISABLED},
+			[]string{legacyIDField, res.SEARCH_FIELD_CREATED, builders.USER_DISABLED},
 			[]string{resp.Results.Columns[0].Name, resp.Results.Columns[1].Name, resp.Results.Columns[2].Name})
 
 		cells := resp.Results.Rows[0].Cells

--- a/pkg/registry/apis/iam/user/search.go
+++ b/pkg/registry/apis/iam/user/search.go
@@ -299,7 +299,7 @@ func (s *SearchHandler) DoSearch(w http.ResponseWriter, r *http.Request) {
 			},
 		},
 		Query:  searchQuery,
-		Fields: []string{resource.SEARCH_FIELD_TITLE, fieldEmail, fieldLogin, fieldLastSeenAt, fieldRole, fieldDisabled, fieldCreated, legacyIDField},
+		Fields: []string{resource.SEARCH_FIELD_TITLE, fieldEmail, fieldLogin, fieldLastSeenAt, fieldRole, fieldDisabled, resource.SEARCH_FIELD_CREATED, legacyIDField},
 		// The query is a wildcard (*...*), so only Name is used from each
 		// QueryField to specify which fields to search in (Type and Boost
 		// are ignored for wildcard queries).
@@ -487,7 +487,7 @@ func parseUserHit(row *resourcepb.ResourceTableRow, colIdx map[string]int) iamv0
 		Email:   string(cell(builders.USER_EMAIL)),
 		Login:   string(cell(builders.USER_LOGIN)),
 		Role:    string(cell(builders.USER_ROLE)),
-		Created: asInt64(builders.USER_CREATED),
+		Created: asInt64(resource.SEARCH_FIELD_CREATED),
 	}
 
 	if id, err := strconv.ParseInt(string(cell(legacyIDField)), 10, 64); err == nil {

--- a/pkg/registry/apis/iam/user/search_test.go
+++ b/pkg/registry/apis/iam/user/search_test.go
@@ -484,7 +484,7 @@ func TestParseResults(t *testing.T) {
 		{Name: builders.USER_LAST_SEEN_AT},
 		{Name: builders.USER_ROLE},
 		{Name: builders.USER_DISABLED},
-		{Name: builders.USER_CREATED},
+		{Name: resource.SEARCH_FIELD_CREATED},
 		{Name: legacyIDField},
 	}
 	created := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC).UnixMilli()


### PR DESCRIPTION
User search fills the created timestamp of each user from a custom `createdAt` search field. That field only mirrors the standard `created` value, which the search backend now stores and returns everywhere, so this reads the standard `created` field directly instead.

Both consumer paths switch over: the index-backed result parser and the legacy SQL backend. The custom `createdAt` field stays indexed for now so any caller that hasn't picked up this change keeps working; removing it is a small follow-up once this has rolled out.

Part of grafana/search-and-storage-team#827.
