### PR TITLE
chore: bump TRIAGE_REF to pick up the DataPro review overlay

### DIFF
--- a/.github/workflows/external-fr-notify.yml
+++ b/.github/workflows/external-fr-notify.yml
@@ -18,7 +18,7 @@ concurrency:
 env:
   # community-triage logic version this repo is pinned to. Bump deliberately;
   # re-resolve with: git ls-remote https://github.com/grafana/community-triage main
-  TRIAGE_REF: 34b9d3b337897c6a45232d6f4601aec6593b7c1d
+  TRIAGE_REF: 34b9d3b337897c6a45232d6f4601aec6593b7c1d # trufflehog:ignore
 
 jobs:
   notify:

--- a/.github/workflows/external-fr-notify.yml
+++ b/.github/workflows/external-fr-notify.yml
@@ -18,7 +18,7 @@ concurrency:
 env:
   # community-triage logic version this repo is pinned to. Bump deliberately;
   # re-resolve with: git ls-remote https://github.com/grafana/community-triage main
-  TRIAGE_REF: 72c2a930d8219e4684db86663cfac8f3f9ad163c
+  TRIAGE_REF: 34b9d3b337897c6a45232d6f4601aec6593b7c1d
 
 jobs:
   notify:

--- a/.github/workflows/external-fr-weekly-digest.yml
+++ b/.github/workflows/external-fr-weekly-digest.yml
@@ -31,7 +31,7 @@ concurrency:
 env:
   # community-triage logic version this repo is pinned to. Bump deliberately;
   # re-resolve with: git ls-remote https://github.com/grafana/community-triage main
-  TRIAGE_REF: 72c2a930d8219e4684db86663cfac8f3f9ad163c
+  TRIAGE_REF: 34b9d3b337897c6a45232d6f4601aec6593b7c1d
 
 jobs:
   digest:

--- a/.github/workflows/external-fr-weekly-digest.yml
+++ b/.github/workflows/external-fr-weekly-digest.yml
@@ -31,7 +31,7 @@ concurrency:
 env:
   # community-triage logic version this repo is pinned to. Bump deliberately;
   # re-resolve with: git ls-remote https://github.com/grafana/community-triage main
-  TRIAGE_REF: 34b9d3b337897c6a45232d6f4601aec6593b7c1d
+  TRIAGE_REF: 34b9d3b337897c6a45232d6f4601aec6593b7c1d # trufflehog:ignore
 
 jobs:
   digest:

--- a/.github/workflows/external-issue-notify.yml
+++ b/.github/workflows/external-issue-notify.yml
@@ -18,7 +18,7 @@ concurrency:
 env:
   # community-triage logic version this repo is pinned to. Bump deliberately;
   # re-resolve with: git ls-remote https://github.com/grafana/community-triage main
-  TRIAGE_REF: 34b9d3b337897c6a45232d6f4601aec6593b7c1d
+  TRIAGE_REF: 34b9d3b337897c6a45232d6f4601aec6593b7c1d # trufflehog:ignore
 
 jobs:
   notify:

--- a/.github/workflows/external-issue-notify.yml
+++ b/.github/workflows/external-issue-notify.yml
@@ -18,7 +18,7 @@ concurrency:
 env:
   # community-triage logic version this repo is pinned to. Bump deliberately;
   # re-resolve with: git ls-remote https://github.com/grafana/community-triage main
-  TRIAGE_REF: 72c2a930d8219e4684db86663cfac8f3f9ad163c
+  TRIAGE_REF: 34b9d3b337897c6a45232d6f4601aec6593b7c1d
 
 jobs:
   notify:

--- a/.github/workflows/external-issue-weekly-digest.yml
+++ b/.github/workflows/external-issue-weekly-digest.yml
@@ -31,7 +31,7 @@ concurrency:
 env:
   # community-triage logic version this repo is pinned to. Bump deliberately;
   # re-resolve with: git ls-remote https://github.com/grafana/community-triage main
-  TRIAGE_REF: 72c2a930d8219e4684db86663cfac8f3f9ad163c
+  TRIAGE_REF: 34b9d3b337897c6a45232d6f4601aec6593b7c1d
 
 jobs:
   digest:

--- a/.github/workflows/external-issue-weekly-digest.yml
+++ b/.github/workflows/external-issue-weekly-digest.yml
@@ -31,7 +31,7 @@ concurrency:
 env:
   # community-triage logic version this repo is pinned to. Bump deliberately;
   # re-resolve with: git ls-remote https://github.com/grafana/community-triage main
-  TRIAGE_REF: 34b9d3b337897c6a45232d6f4601aec6593b7c1d
+  TRIAGE_REF: 34b9d3b337897c6a45232d6f4601aec6593b7c1d # trufflehog:ignore
 
 jobs:
   digest:

--- a/.github/workflows/external-pr-notify-handler.yml
+++ b/.github/workflows/external-pr-notify-handler.yml
@@ -25,7 +25,7 @@ env:
   # community-triage logic version this repo is pinned to (main as of PR #6).
   # Bump deliberately; re-resolve with:
   #   git ls-remote https://github.com/grafana/community-triage main
-  TRIAGE_REF: 72c2a930d8219e4684db86663cfac8f3f9ad163c
+  TRIAGE_REF: 34b9d3b337897c6a45232d6f4601aec6593b7c1d
 
 jobs:
   triage:

--- a/.github/workflows/external-pr-notify-handler.yml
+++ b/.github/workflows/external-pr-notify-handler.yml
@@ -25,7 +25,7 @@ env:
   # community-triage logic version this repo is pinned to (main as of PR #6).
   # Bump deliberately; re-resolve with:
   #   git ls-remote https://github.com/grafana/community-triage main
-  TRIAGE_REF: 34b9d3b337897c6a45232d6f4601aec6593b7c1d
+  TRIAGE_REF: 34b9d3b337897c6a45232d6f4601aec6593b7c1d # trufflehog:ignore
 
 jobs:
   triage:

--- a/.github/workflows/external-pr-weekly-digest.yml
+++ b/.github/workflows/external-pr-weekly-digest.yml
@@ -31,7 +31,7 @@ permissions: {}
 env:
   # community-triage logic version this repo is pinned to. Bump deliberately;
   # re-resolve with: git ls-remote https://github.com/grafana/community-triage main
-  TRIAGE_REF: 72c2a930d8219e4684db86663cfac8f3f9ad163c
+  TRIAGE_REF: 34b9d3b337897c6a45232d6f4601aec6593b7c1d
   STALE_THRESHOLD_DAYS: ${{ inputs.stale_days || 30 }}
 
 concurrency:

--- a/.github/workflows/external-pr-weekly-digest.yml
+++ b/.github/workflows/external-pr-weekly-digest.yml
@@ -31,7 +31,7 @@ permissions: {}
 env:
   # community-triage logic version this repo is pinned to. Bump deliberately;
   # re-resolve with: git ls-remote https://github.com/grafana/community-triage main
-  TRIAGE_REF: 34b9d3b337897c6a45232d6f4601aec6593b7c1d
+  TRIAGE_REF: 34b9d3b337897c6a45232d6f4601aec6593b7c1d # trufflehog:ignore
   STALE_THRESHOLD_DAYS: ${{ inputs.stale_days || 30 }}
 
 concurrency:


### PR DESCRIPTION
Bumps `TRIAGE_REF` to community-triage `34b9d3b`, which adds the `team-datapro` review overlay (community-triage#13). DataPro agent reviews now apply the domain-specific rules instead of the base skill only.

Skill-file addition only — no logic change between the old and new pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)