### PR TITLE
Provisioning: Size the folder README row to its content so Safari can scroll it

### DIFF
--- a/public/app/features/browse-dashboards/components/DashboardsTree.test.tsx
+++ b/public/app/features/browse-dashboards/components/DashboardsTree.test.tsx
@@ -1,5 +1,5 @@
 import { assertIsDefined } from 'test/helpers/asserts';
-import { render, screen } from 'test/test-utils';
+import { render, screen, waitFor } from 'test/test-utils';
 
 import { selectors } from '@grafana/e2e-selectors';
 import { config } from '@grafana/runtime';
@@ -60,6 +60,38 @@ describe('browse-dashboards DashboardsTree', () => {
     expect(screen.getByText(dashboard.item.title)).toBeInTheDocument();
     expect(screen.getByText(assertIsDefined(dashboard.item.tags)[0])).toBeInTheDocument();
     expect(screen.getByTestId(selectors.pages.BrowseDashboards.table.checkbox(dashboard.item.uid))).toBeInTheDocument();
+  });
+
+  it('grows the README row to its measured content height', async () => {
+    const offsetHeightSpy = jest.spyOn(HTMLElement.prototype, 'offsetHeight', 'get').mockReturnValue(500);
+
+    render(
+      <DashboardsTree
+        permissions={mockPermissions}
+        items={[
+          dashboard,
+          { item: { kind: 'ui', uiKind: 'readme', uid: 'folder-readme-folder1' }, level: 0, isOpen: false },
+        ]}
+        folderUID="folder1"
+        isSelected={isSelected}
+        width={WIDTH}
+        height={HEIGHT}
+        onFolderClick={noop}
+        onTagClick={noop}
+        onItemSelectionChange={noop}
+        onAllSelectionChange={noop}
+        isItemLoaded={allItemsAreLoaded}
+        requestLoadMore={requestLoadMore}
+      />
+    );
+
+    // 500px measured content + 16px row padding, replacing the 320px estimate.
+    await waitFor(() => {
+      const rows = screen.getAllByRole('row');
+      expect(rows[rows.length - 1]).toHaveStyle({ height: '516px' });
+    });
+
+    offsetHeightSpy.mockRestore();
   });
 
   it('does not render checkbox when disabled', () => {

--- a/public/app/features/browse-dashboards/components/DashboardsTree.test.tsx
+++ b/public/app/features/browse-dashboards/components/DashboardsTree.test.tsx
@@ -94,6 +94,48 @@ describe('browse-dashboards DashboardsTree', () => {
     offsetHeightSpy.mockRestore();
   });
 
+  it('resets the README row height when navigating to another folder', async () => {
+    const offsetHeightSpy = jest.spyOn(HTMLElement.prototype, 'offsetHeight', 'get').mockReturnValue(500);
+
+    const treeFor = (folderUID: string) => (
+      <DashboardsTree
+        permissions={mockPermissions}
+        items={[
+          dashboard,
+          { item: { kind: 'ui', uiKind: 'readme', uid: `folder-readme-${folderUID}` }, level: 0, isOpen: false },
+        ]}
+        folderUID={folderUID}
+        isSelected={isSelected}
+        width={WIDTH}
+        height={HEIGHT}
+        onFolderClick={noop}
+        onTagClick={noop}
+        onItemSelectionChange={noop}
+        onAllSelectionChange={noop}
+        isItemLoaded={allItemsAreLoaded}
+        requestLoadMore={requestLoadMore}
+      />
+    );
+
+    const { rerender } = render(treeFor('folder1'));
+
+    await waitFor(() => {
+      const rows = screen.getAllByRole('row');
+      expect(rows[rows.length - 1]).toHaveStyle({ height: '516px' });
+    });
+
+    // The next panel's 0 measurement is ignored, so the reset restores the estimate.
+    offsetHeightSpy.mockReturnValue(0);
+    rerender(treeFor('folder2'));
+
+    await waitFor(() => {
+      const rows = screen.getAllByRole('row');
+      expect(rows[rows.length - 1]).toHaveStyle({ height: '336px' });
+    });
+
+    offsetHeightSpy.mockRestore();
+  });
+
   it('does not render checkbox when disabled', () => {
     mockPermissions.canEditFolders = false;
     mockPermissions.canEditDashboards = false;

--- a/public/app/features/browse-dashboards/components/DashboardsTree.tsx
+++ b/public/app/features/browse-dashboards/components/DashboardsTree.tsx
@@ -83,6 +83,11 @@ export function DashboardsTree({
       setReadmeHeight(Math.ceil(height));
     }
   }, []);
+  useEffect(() => {
+    // The tree stays mounted across folder navigation; a stale measurement would
+    // otherwise persist when the next folder's README panel renders nothing.
+    setReadmeHeight(README_ROW_HEIGHT);
+  }, [folderUID]);
 
   useEffect(() => {
     // If the tree changed identity, then some indexes that were previously loaded may now be unloaded,

--- a/public/app/features/browse-dashboards/components/DashboardsTree.tsx
+++ b/public/app/features/browse-dashboards/components/DashboardsTree.tsx
@@ -1,6 +1,6 @@
 import { css, cx } from '@emotion/css';
 import * as React from 'react';
-import { useCallback, useEffect, useId, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 import { type TableInstance, useTable } from 'react-table';
 import { VariableSizeList as List } from 'react-window';
 import InfiniteLoader from 'react-window-infinite-loader';
@@ -47,7 +47,11 @@ interface DashboardsTreeProps {
 const HEADER_HEIGHT = 36;
 const ROW_HEIGHT = 36;
 const DIVIDER_HEIGHT = 0; // Yes - make it appear as a border on the row rather than a row itself
-// README is always the last item, so an approximate height is fine.
+// Initial estimate for the README row; replaced by the ResizeObserver-measured
+// height once the row mounts. The row must cover the real content height:
+// WebKit does not extend the scroller's scrollable area for content that
+// overflows the absolutely-positioned row, so an undersized row makes Safari
+// snap the scroll position back (content past the row is unreachable).
 const README_ROW_HEIGHT = 320;
 const README_ROW_PADDING_TOP = 16; // matches theme.spacing(2)
 
@@ -71,6 +75,15 @@ export function DashboardsTree({
   const listRef = useRef<List | null>(null);
   const styles = useStyles2(getStyles);
 
+  const [readmeHeight, setReadmeHeight] = useState(README_ROW_HEIGHT);
+
+  const handleReadmeHeightChange = useCallback((height: number) => {
+    // Ignore 0 (display:none / mid-unmount); React bails out on same-value sets.
+    if (height > 0) {
+      setReadmeHeight(Math.ceil(height));
+    }
+  }, []);
+
   useEffect(() => {
     // If the tree changed identity, then some indexes that were previously loaded may now be unloaded,
     // especially after a refetch after a move/delete.
@@ -83,6 +96,11 @@ export function DashboardsTree({
       listRef.current.resetAfterIndex(0);
     }
   }, [items]);
+
+  useEffect(() => {
+    // VariableSizeList caches row offsets; re-measure when the README grows/shrinks.
+    listRef.current?.resetAfterIndex(0);
+  }, [readmeHeight]);
 
   const tableColumns = useMemo(() => {
     const checkboxColumn: DashboardsTreeColumn = {
@@ -127,10 +145,21 @@ export function DashboardsTree({
       treeID,
       permissions,
       folderUID,
+      onReadmeHeightChange: handleReadmeHeightChange,
     }),
     // we need this to rerender if items changes
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [table, isSelected, onAllSelectionChange, onItemSelectionChange, items, treeID, permissions, folderUID]
+    [
+      table,
+      isSelected,
+      onAllSelectionChange,
+      onItemSelectionChange,
+      items,
+      treeID,
+      permissions,
+      folderUID,
+      handleReadmeHeightChange,
+    ]
   );
 
   const handleIsItemLoaded = useCallback(
@@ -155,12 +184,12 @@ export function DashboardsTree({
         return DIVIDER_HEIGHT;
       }
       if (row.item.kind === 'ui' && row.item.uiKind === 'readme') {
-        return README_ROW_HEIGHT + README_ROW_PADDING_TOP;
+        return readmeHeight + README_ROW_PADDING_TOP;
       }
 
       return ROW_HEIGHT;
     },
-    [items]
+    [items, readmeHeight]
   );
 
   const itemKey = useCallback(
@@ -242,6 +271,7 @@ interface VirtualListRowProps {
     treeID: string;
     permissions: BrowseDashboardsPermissions;
     folderUID?: string;
+    onReadmeHeightChange: (height: number) => void;
   };
 }
 
@@ -266,9 +296,7 @@ function VirtualListRow({ index, style, data }: VirtualListRowProps) {
 
   if (dashboardItem.kind === 'ui' && dashboardItem.uiKind === 'readme' && data.folderUID) {
     return (
-      <div key={key} {...rowProps} className={styles.readmeRow}>
-        <FolderReadmePanel folderUID={data.folderUID} />
-      </div>
+      <ReadmeRow key={key} rowProps={rowProps} folderUID={data.folderUID} onHeightChange={data.onReadmeHeightChange} />
     );
   }
 
@@ -291,6 +319,37 @@ function VirtualListRow({ index, style, data }: VirtualListRowProps) {
           </div>
         );
       })}
+    </div>
+  );
+}
+
+interface ReadmeRowProps {
+  rowProps: React.HTMLAttributes<HTMLDivElement>;
+  folderUID: string;
+  onHeightChange: (height: number) => void;
+}
+
+function ReadmeRow({ rowProps, folderUID, onHeightChange }: ReadmeRowProps) {
+  const styles = useStyles2(getStyles);
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const element = contentRef.current;
+    if (!element) {
+      return;
+    }
+    const observer = new ResizeObserver(() => {
+      onHeightChange(element.offsetHeight);
+    });
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [onHeightChange]);
+
+  return (
+    <div {...rowProps} className={styles.readmeRow}>
+      <div ref={contentRef}>
+        <FolderReadmePanel folderUID={folderUID} />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
**What is this feature?**

Measures the rendered height of a provisioned folder README and resizes its virtualized dashboard-list row, so the entire README is reachable by scrolling. Adds a regression test for the measured row size.

**Why do we need this feature?**

Safari/WebKit can clamp scrolling to the fixed virtual-row height when README content extends past that row, causing the scrollbar to snap back before users can read it. Sizing the row to its content makes the list's scrollable area include the README.

**Who is this feature for?**

Grafana users reading provisioned folder READMEs in Safari.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/128368

**Special notes for your reviewer:**

The observer measures an inner wrapper because the outer virtualized row always has the height assigned by react-window. Targeted DashboardsTree/BrowseView Jest suites and `yarn typecheck:tsgo` pass.