### PR TITLE
SSOSettings: Propagate context to new feature toggle

### DIFF
--- a/pkg/services/ssosettings/ssosettings.go
+++ b/pkg/services/ssosettings/ssosettings.go
@@ -50,7 +50,7 @@ type Reloadable interface {
 // than the database. This is useful for providers that are not configured in the database, but instead are configured
 // using the config file and/or environment variables. Used mostly for backwards compatibility.
 type FallbackStrategy interface {
-	IsMatch(provider string) bool
+	IsMatch(ctx context.Context, provider string) bool
 	// TODO: check if GetProviderConfig can return an error
 	GetProviderConfig(ctx context.Context, provider string) (map[string]any, error)
 }

--- a/pkg/services/ssosettings/ssosettingsimpl/service.go
+++ b/pkg/services/ssosettings/ssosettingsimpl/service.go
@@ -384,7 +384,7 @@ func (s *Service) RegisterFallbackStrategy(providerRegex string, strategy ssoset
 }
 
 func (s *Service) loadSettingsUsingFallbackStrategy(ctx context.Context, provider string) (*models.SSOSettings, error) {
-	loadStrategy, ok := s.getFallbackStrategyFor(provider)
+	loadStrategy, ok := s.getFallbackStrategyFor(ctx, provider)
 	if !ok {
 		return nil, errors.New("no fallback strategy found for provider: " + provider)
 	}
@@ -410,9 +410,9 @@ func getSettingByProvider(provider string, settings []*models.SSOSettings) *mode
 	return nil
 }
 
-func (s *Service) getFallbackStrategyFor(provider string) (ssosettings.FallbackStrategy, bool) {
+func (s *Service) getFallbackStrategyFor(ctx context.Context, provider string) (ssosettings.FallbackStrategy, bool) {
 	for _, strategy := range s.fbStrategies {
-		if strategy.IsMatch(provider) {
+		if strategy.IsMatch(ctx, provider) {
 			return strategy, true
 		}
 	}

--- a/pkg/services/ssosettings/ssosettingstests/fallback_strategy_fake.go
+++ b/pkg/services/ssosettings/ssosettingstests/fallback_strategy_fake.go
@@ -13,7 +13,7 @@ func NewFakeFallbackStrategy() *FakeFallbackStrategy {
 	return &FakeFallbackStrategy{}
 }
 
-func (f *FakeFallbackStrategy) IsMatch(provider string) bool {
+func (f *FakeFallbackStrategy) IsMatch(_ context.Context, provider string) bool {
 	return f.ExpectedIsMatch
 }
 

--- a/pkg/services/ssosettings/strategies/ldap_strategy.go
+++ b/pkg/services/ssosettings/strategies/ldap_strategy.go
@@ -23,7 +23,7 @@ func NewLDAPStrategy(cfg *setting.Cfg) *LDAPStrategy {
 	}
 }
 
-func (s *LDAPStrategy) IsMatch(provider string) bool {
+func (s *LDAPStrategy) IsMatch(_ context.Context, provider string) bool {
 	return provider == social.LDAPProviderName
 }
 

--- a/pkg/services/ssosettings/strategies/mtsettings_strategy.go
+++ b/pkg/services/ssosettings/strategies/mtsettings_strategy.go
@@ -20,10 +20,7 @@ type mtSettingsStrategy struct {
 	matches func(provider string) bool
 }
 
-func (s *mtSettingsStrategy) IsMatch(provider string) bool {
-	// IsMatch carries no context and the toggle is an instance-global gate,
-	// so evaluation uses a background context.
-	ctx := context.Background()
+func (s *mtSettingsStrategy) IsMatch(ctx context.Context, provider string) bool {
 	enabled := openfeature.NewDefaultClient().Boolean(ctx,
 		featuremgmt.FlagGrafanaSsoSettingsToMTSettings, false, openfeature.TransactionContext(ctx))
 	return enabled && s.matches(provider)

--- a/pkg/services/ssosettings/strategies/mtsettings_strategy_test.go
+++ b/pkg/services/ssosettings/strategies/mtsettings_strategy_test.go
@@ -45,7 +45,7 @@ func TestMTSettingsStrategies_IsMatch(t *testing.T) {
 
 		for _, adapter := range adapters {
 			for _, p := range providers {
-				require.False(t, adapter.IsMatch(p))
+				require.False(t, adapter.IsMatch(t.Context(), p))
 			}
 		}
 	})
@@ -58,18 +58,18 @@ func TestMTSettingsStrategies_IsMatch(t *testing.T) {
 		saml := NewMTSettingsSAMLStrategy()
 
 		for _, p := range ssosettings.AllOAuthProviders {
-			require.True(t, oauth.IsMatch(p))
-			require.False(t, ldap.IsMatch(p))
-			require.False(t, saml.IsMatch(p))
+			require.True(t, oauth.IsMatch(t.Context(), p))
+			require.False(t, ldap.IsMatch(t.Context(), p))
+			require.False(t, saml.IsMatch(t.Context(), p))
 		}
 
-		require.True(t, ldap.IsMatch(social.LDAPProviderName))
-		require.False(t, oauth.IsMatch(social.LDAPProviderName))
-		require.False(t, saml.IsMatch(social.LDAPProviderName))
+		require.True(t, ldap.IsMatch(t.Context(), social.LDAPProviderName))
+		require.False(t, oauth.IsMatch(t.Context(), social.LDAPProviderName))
+		require.False(t, saml.IsMatch(t.Context(), social.LDAPProviderName))
 
-		require.True(t, saml.IsMatch(social.SAMLProviderName))
-		require.False(t, oauth.IsMatch(social.SAMLProviderName))
-		require.False(t, ldap.IsMatch(social.SAMLProviderName))
+		require.True(t, saml.IsMatch(t.Context(), social.SAMLProviderName))
+		require.False(t, oauth.IsMatch(t.Context(), social.SAMLProviderName))
+		require.False(t, ldap.IsMatch(t.Context(), social.SAMLProviderName))
 	})
 }
 

--- a/pkg/services/ssosettings/strategies/oauth_strategy.go
+++ b/pkg/services/ssosettings/strategies/oauth_strategy.go
@@ -36,7 +36,7 @@ func NewOAuthStrategy(cfg *setting.Cfg) *OAuthStrategy {
 	return oauthStrategy
 }
 
-func (s *OAuthStrategy) IsMatch(provider string) bool {
+func (s *OAuthStrategy) IsMatch(_ context.Context, provider string) bool {
 	_, ok := s.settingsByProvider[provider]
 	return ok
 }

--- a/pkg/services/ssosettings/strategies/saml_strategy.go
+++ b/pkg/services/ssosettings/strategies/saml_strategy.go
@@ -21,7 +21,7 @@ func NewSAMLStrategy(settingsProvider setting.Provider) *SAMLStrategy {
 	}
 }
 
-func (s *SAMLStrategy) IsMatch(provider string) bool {
+func (s *SAMLStrategy) IsMatch(_ context.Context, provider string) bool {
 	return provider == social.SAMLProviderName
 }
 

--- a/pkg/services/ssosettings/strategies/saml_strategy_test.go
+++ b/pkg/services/ssosettings/strategies/saml_strategy_test.go
@@ -98,8 +98,8 @@ var (
 func TestSAMLIsMatch(t *testing.T) {
 	cfg := setting.NewCfg()
 	strategy := NewSAMLStrategy(&setting.OSSImpl{Cfg: cfg})
-	require.True(t, strategy.IsMatch("saml"))
-	require.False(t, strategy.IsMatch("oauth"))
+	require.True(t, strategy.IsMatch(t.Context(), "saml"))
+	require.False(t, strategy.IsMatch(t.Context(), "oauth"))
 }
 
 func TestSAMLGetProviderConfig(t *testing.T) {


### PR DESCRIPTION
Related to https://github.com/grafana/grafana/pull/127998#discussion_r3570255837

Propagates the `ctx` from `loadSettingsUsingFallbackStrategy()` down to all the calls to `IsMatch()`.