### PR TITLE
feat(plugins): render Assistant onboarding fallback

### DIFF
--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebarProvider.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebarProvider.tsx
@@ -17,6 +17,7 @@ export const EXTENSION_SIDEBAR_DOCKED_LOCAL_STORAGE_KEY = 'grafana.navigation.ex
 const EXTENSION_SIDEBAR_WIDTH_LOCAL_STORAGE_KEY = 'grafana.navigation.extensionSidebarWidth';
 const PERMITTED_EXTENSION_SIDEBAR_PLUGINS = [
   'grafana-assistant-app',
+  'grafana-assistant-onboarding-app',
   'grafana-dash-app',
   // The docs plugin ID is transitioning from grafana-grafanadocsplugin-app to grafana-pathfinder-app.
   // Support both until that migration is complete.

--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionToolbarItem.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionToolbarItem.tsx
@@ -16,7 +16,7 @@ type Props = {
   compact?: boolean;
 };
 
-const compactAllowedComponents = ['grafana-assistant-app'];
+const compactAllowedComponents = ['grafana-assistant-app', 'grafana-assistant-onboarding-app'];
 const interactiveLearningPluginIds = ['grafana-pathfinder-app', 'grafana-grafanadocsplugin-app'];
 
 export function ExtensionToolbarItem({ compact }: Props) {

--- a/public/app/features/plugins/components/AppRootPage.test.tsx
+++ b/public/app/features/plugins/components/AppRootPage.test.tsx
@@ -248,7 +248,7 @@ describe('AppRootPage', () => {
   });
 
   it('should mark the plugin boundary on the page when the plugin provides its own nav', async () => {
-    getPluginSettingsMock.mockResolvedValue(pluginMeta);
+    refetchPluginSettingsMock.mockResolvedValue(pluginMeta);
 
     const NavChangingRootComponent = ({ onNavChanged }: AppRootProps) => {
       useEffect(() => {

--- a/public/app/features/plugins/components/AppRootPage.test.tsx
+++ b/public/app/features/plugins/components/AppRootPage.test.tsx
@@ -7,6 +7,7 @@ import { AppPlugin, PluginType, type AppRootProps, type NavModelItem, PluginIncl
 import { getMockPlugin } from '@grafana/data/test';
 import { selectors } from '@grafana/e2e-selectors';
 import { setEchoSrv } from '@grafana/runtime';
+import { refetchPluginSettings } from '@grafana/runtime/internal';
 import { getPluginSettings } from '@grafana/runtime/unstable';
 import { GrafanaRouteWrapper } from 'app/core/navigation/GrafanaRoute';
 import { contextSrv } from 'app/core/services/context_srv';
@@ -25,8 +26,17 @@ jest.mock('@grafana/runtime/unstable', () => ({
   ...jest.requireActual('@grafana/runtime/unstable'),
   getPluginSettings: jest.fn(),
 }));
+jest.mock('@grafana/runtime/internal', () => ({
+  ...jest.requireActual('@grafana/runtime/internal'),
+  refetchPluginSettings: jest.fn(),
+}));
 jest.mock('../importer/pluginImporter', () => ({
   pluginImporter: { importApp: jest.fn() },
+}));
+jest.mock('./pluginNavFallbacks', () => ({
+  pluginNavFallbacks: {
+    'my-awesome-plugin': () => <div>Assistant onboarding fallback</div>,
+  },
 }));
 
 jest.mock('@grafana/runtime', () => ({
@@ -59,6 +69,10 @@ const getPluginSettingsMock = getPluginSettings as jest.Mock<
   ReturnType<typeof getPluginSettings>,
   Parameters<typeof getPluginSettings>
 >;
+const refetchPluginSettingsMock = refetchPluginSettings as jest.Mock<
+  ReturnType<typeof refetchPluginSettings>,
+  Parameters<typeof refetchPluginSettings>
+>;
 
 // don't care about this component - it's just for a test
 // eslint-disable-next-line react-prefer-function-component/react-prefer-function-component
@@ -70,7 +84,7 @@ class RootComponent extends Component<AppRootProps> {
   }
 }
 
-function renderUnderRouter(page = '') {
+function renderUnderRouter(page = '', pluginId = 'my-awesome-plugin') {
   const appPluginNavItem: NavModelItem = {
     text: 'App',
     id: 'plugin-page-app',
@@ -104,11 +118,11 @@ function renderUnderRouter(page = '') {
   const pagePath = page ? `/${page}` : '';
   const route = {
     path: `/a/:pluginId/*`,
-    component: () => <AppRootPage pluginId="my-awesome-plugin" pluginNavSection={appsSection} />,
+    component: () => <AppRootPage pluginId={pluginId} pluginNavSection={appsSection} />,
   };
 
   const Foo = () => {
-    return <Link to={`/a/my-awesome-plugin${pagePath}`}>Navigate</Link>;
+    return <Link to={`/a/${pluginId}${pagePath}`}>Navigate</Link>;
   };
 
   return render(
@@ -129,7 +143,7 @@ function renderUnderRouter(page = '') {
     </ExtensionRegistriesProvider>,
     {
       historyOptions: {
-        initialEntries: [`/a/my-awesome-plugin${pagePath}`],
+        initialEntries: [`/a/${pluginId}${pagePath}`],
       },
     }
   );
@@ -149,14 +163,65 @@ describe('AppRootPage', () => {
 
   it("should show a not found page if the plugin settings can't load", async () => {
     jest.spyOn(console, 'error').mockImplementation();
-    getPluginSettingsMock.mockRejectedValue(new Error('Unknown Plugin'));
+    refetchPluginSettingsMock.mockRejectedValue(new Error('Unknown Plugin'));
     // Renders once for the first time
     renderUnderRouter();
     expect(await screen.findByText('App not found')).toBeVisible();
   });
 
+  it('renders a registered nav fallback when plugin settings return 404', async () => {
+    jest.spyOn(console, 'error').mockImplementation();
+    refetchPluginSettingsMock.mockRejectedValue(
+      new Error('Unknown Plugin', { cause: { status: 404, data: { message: 'Plugin not found' } } })
+    );
+
+    renderUnderRouter();
+
+    expect(await screen.findByText('Assistant onboarding fallback')).toBeVisible();
+    expect(screen.queryByText('App not found')).not.toBeInTheDocument();
+  });
+
+  it.each([
+    ['a 500 response', new Error('Unknown Plugin', { cause: { status: 500, data: {} } })],
+    ['a 403 response', { status: 403, data: {} }],
+    ['a non-fetch error', new Error('Import failed')],
+  ])('does not render a registered nav fallback for %s', async (_name, error) => {
+    jest.spyOn(console, 'error').mockImplementation();
+    refetchPluginSettingsMock.mockRejectedValue(error);
+
+    renderUnderRouter();
+
+    expect(await screen.findByText('App not found')).toBeVisible();
+    expect(screen.queryByText('Assistant onboarding fallback')).not.toBeInTheDocument();
+  });
+
+  it('renders a registered nav fallback without plugin install permission', async () => {
+    jest.spyOn(console, 'error').mockImplementation();
+    contextSrv.user.permissions = {};
+    refetchPluginSettingsMock.mockRejectedValue(
+      new Error('Unknown Plugin', { cause: { status: 404, data: { message: 'Plugin not found' } } })
+    );
+
+    renderUnderRouter();
+
+    expect(await screen.findByText('Assistant onboarding fallback')).toBeVisible();
+    expect(screen.queryByText('App not found')).not.toBeInTheDocument();
+  });
+
+  it('does not render a fallback for an unregistered plugin', async () => {
+    jest.spyOn(console, 'error').mockImplementation();
+    getPluginSettingsMock.mockRejectedValue(
+      new Error('Unknown Plugin', { cause: { status: 404, data: { message: 'Plugin not found' } } })
+    );
+
+    renderUnderRouter('', 'unregistered-plugin');
+
+    expect(await screen.findByText('App not found')).toBeVisible();
+    expect(screen.queryByText('Assistant onboarding fallback')).not.toBeInTheDocument();
+  });
+
   it('should not render the component if we are not under a plugin path', async () => {
-    getPluginSettingsMock.mockResolvedValue(pluginMeta);
+    refetchPluginSettingsMock.mockResolvedValue(pluginMeta);
 
     const plugin = new AppPlugin();
     plugin.meta = pluginMeta;
@@ -208,6 +273,33 @@ describe('AppRootPage', () => {
       'data-plugin-id',
       'my-awesome-plugin'
     );
+  });
+
+  it('refetches registered plugin settings when re-entering the route after uninstall', async () => {
+    jest.spyOn(console, 'error').mockImplementation();
+    refetchPluginSettingsMock
+      .mockResolvedValueOnce(pluginMeta)
+      .mockRejectedValueOnce(
+        new Error('Unknown Plugin', { cause: { status: 404, data: { message: 'Plugin not found' } } })
+      );
+
+    const plugin = new AppPlugin();
+    plugin.meta = pluginMeta;
+    plugin.root = RootComponent;
+    importAppPluginMock.mockResolvedValue(plugin);
+
+    renderUnderRouter();
+    expect(await screen.findByText('my great component')).toBeVisible();
+
+    await act(async () => {
+      screen.getByRole('link', { name: 'Navigate' }).click();
+    });
+    await act(async () => {
+      screen.getByRole('link', { name: 'Navigate' }).click();
+    });
+
+    expect(await screen.findByText('Assistant onboarding fallback')).toBeVisible();
+    expect(refetchPluginSettingsMock).toHaveBeenCalledTimes(2);
   });
 
   describe('When accessing using different roles', () => {
@@ -262,7 +354,7 @@ describe('AppRootPage', () => {
         ],
       });
 
-      getPluginSettingsMock.mockResolvedValue(pluginMetaWithIncludes);
+      refetchPluginSettingsMock.mockResolvedValue(pluginMetaWithIncludes);
 
       const plugin = new AppPlugin();
       plugin.meta = pluginMetaWithIncludes;

--- a/public/app/features/plugins/components/AppRootPage.tsx
+++ b/public/app/features/plugins/components/AppRootPage.tsx
@@ -16,7 +16,8 @@ import {
 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
-import { config, locationSearchToObject } from '@grafana/runtime';
+import { config, isFetchError, locationSearchToObject } from '@grafana/runtime';
+import { refetchPluginSettings } from '@grafana/runtime/internal';
 import { getLogger, getPluginSettings } from '@grafana/runtime/unstable';
 import { Alert, ErrorWithStack } from '@grafana/ui';
 import { appEvents } from 'app/core/app_events';
@@ -40,6 +41,7 @@ import { buildPluginSectionNav } from '../utils';
 
 import { PluginErrorBoundary } from './PluginErrorBoundary';
 import { buildPluginPageContext, PluginPageContext } from './PluginPageContext';
+import { pluginNavFallbacks } from './pluginNavFallbacks';
 import { RestrictedGrafanaApisProvider } from './restrictedGrafanaApis/RestrictedGrafanaApisProvider';
 
 interface Props {
@@ -53,6 +55,7 @@ interface Props {
 interface State {
   loading: boolean;
   loadingError: boolean;
+  errorStatus?: number;
   plugin?: AppPlugin | null;
   // Used to display a tab navigation (used before the new Top Nav)
   pluginNav: NavModel | null;
@@ -70,7 +73,7 @@ function AppRootPage({ pluginId, pluginNavSection }: Props) {
   const location = useLocation();
   const [state, dispatch] = useReducer(stateSlice.reducer, initialState);
   const currentUrl = config.appSubUrl + location.pathname + location.search;
-  const { plugin, loading, loadingError, pluginNav } = state;
+  const { plugin, loading, loadingError, errorStatus, pluginNav } = state;
   const navModel = buildPluginSectionNav(currentUrl, pluginNavSection);
   const queryParams = useMemo(() => locationSearchToObject(location.search), [location.search]);
   const context = useMemo(() => buildPluginPageContext(navModel, pluginId), [navModel, pluginId]);
@@ -88,10 +91,13 @@ function AppRootPage({ pluginId, pluginNavSection }: Props) {
   if (!plugin || pluginId !== plugin.meta.id) {
     // Use current layout while loading to reduce flickering
     const currentLayout = grafanaContext.chrome.state.getValue().layout;
+    const PluginNavFallback = pluginNavFallbacks[pluginId];
+    const shouldRenderFallback = !loading && loadingError && errorStatus === 404 && PluginNavFallback;
+
     return (
       <Page navModel={navModel} pageNav={{ text: '' }} layout={currentLayout}>
         {loading && <PageLoader />}
-        {!loading && loadingError && <EntityNotFound entity="App" />}
+        {shouldRenderFallback ? <PluginNavFallback /> : !loading && loadingError && <EntityNotFound entity="App" />}
       </Page>
     );
   }
@@ -236,7 +242,8 @@ const stateSlice = createSlice({
 
 async function loadAppPlugin(pluginId: string, dispatch: React.Dispatch<AnyAction>) {
   try {
-    const app = await getPluginSettings(pluginId).then((info) => {
+    const loadPluginSettings = pluginNavFallbacks[pluginId] ? refetchPluginSettings : getPluginSettings;
+    const app = await loadPluginSettings(pluginId).then((info) => {
       const error = getAppPluginPageError(info);
       if (error) {
         appEvents.emit(AppEvents.alertError, [error]);
@@ -245,13 +252,23 @@ async function loadAppPlugin(pluginId: string, dispatch: React.Dispatch<AnyActio
       }
       return pluginImporter.importApp(info);
     });
-    dispatch(stateSlice.actions.setState({ plugin: app, loading: false, loadingError: false, pluginNav: null }));
+    dispatch(
+      stateSlice.actions.setState({
+        plugin: app,
+        loading: false,
+        loadingError: false,
+        errorStatus: undefined,
+        pluginNav: null,
+      })
+    );
   } catch (err) {
+    const cause = err instanceof Error && err.cause ? err.cause : err;
     dispatch(
       stateSlice.actions.setState({
         plugin: null,
         loading: false,
         loadingError: true,
+        errorStatus: isFetchError(cause) ? cause.status : undefined,
         pluginNav: process.env.NODE_ENV === 'development' ? getExceptionNav(err) : getNotFoundNav(),
       })
     );

--- a/public/app/features/plugins/components/AssistantNavOnboarding.tsx
+++ b/public/app/features/plugins/components/AssistantNavOnboarding.tsx
@@ -1,0 +1,52 @@
+import { usePluginComponent } from '@grafana/runtime';
+import PageLoader from 'app/core/components/PageLoader/PageLoader';
+import { EntityNotFound } from 'app/core/components/PageNotFound/EntityNotFound';
+import { contextSrv } from 'app/core/services/context_srv';
+import { AccessControlAction } from 'app/types/accessControl';
+
+import { useInstall, useInstallStatus } from '../admin/state/hooks';
+
+const ASSISTANT_PLUGIN_ID = 'grafana-assistant-app';
+const ASSISTANT_ONBOARDING_NAV_COMPONENT_ID = 'grafana-assistant-onboarding-app/nav-onboarding/v1';
+const RELOAD_DELAY_MS = 1500;
+
+interface AssistantNavOnboardingProps {
+  isInstalled: boolean;
+  isConnected: boolean;
+  isLoading: boolean;
+  isInstalling: boolean;
+  canInstall: boolean;
+  onInstall: () => void;
+}
+
+export function AssistantNavOnboarding() {
+  const installPlugin = useInstall();
+  const { isInstalling } = useInstallStatus();
+  const { component: OnboardingPage, isLoading } = usePluginComponent<AssistantNavOnboardingProps>(
+    ASSISTANT_ONBOARDING_NAV_COMPONENT_ID
+  );
+
+  if (isLoading) {
+    return <PageLoader />;
+  }
+
+  if (!OnboardingPage) {
+    return <EntityNotFound entity="App" />;
+  }
+
+  return (
+    <OnboardingPage
+      isInstalled={false}
+      isConnected={false}
+      isLoading={false}
+      isInstalling={isInstalling}
+      canInstall={contextSrv.hasPermission(AccessControlAction.PluginsInstall)}
+      onInstall={async () => {
+        const result = await installPlugin(ASSISTANT_PLUGIN_ID);
+        if (!('error' in result)) {
+          window.setTimeout(() => window.location.reload(), RELOAD_DELAY_MS);
+        }
+      }}
+    />
+  );
+}

--- a/public/app/features/plugins/components/pluginNavFallbacks.ts
+++ b/public/app/features/plugins/components/pluginNavFallbacks.ts
@@ -1,0 +1,7 @@
+import type { ComponentType } from 'react';
+
+import { AssistantNavOnboarding } from './AssistantNavOnboarding';
+
+export const pluginNavFallbacks: Record<string, ComponentType> = {
+  'grafana-assistant-app': AssistantNavOnboarding,
+};


### PR DESCRIPTION
## What

Renders the Assistant onboarding fallback when the Assistant route resolves to a missing plugin, and allows the onboarding plugin to register the Assistant extension sidebar entry.

This PR is stacked on #128391. Merge the backend PR first, then review and merge this frontend PR. The onboarding component itself is supplied by grafana/grafana-assistant-app#7993.

## Why

The Assistant route and sidebar need a usable onboarding experience before the full Assistant plugin is installed, while keeping frontend and backend deployment changes separate.