### PR TITLE
Dashboard-scene: Address flaky tests

### DIFF
--- a/public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor/VariableOptionsSpreadsheet/clipboard.test.ts
+++ b/public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor/VariableOptionsSpreadsheet/clipboard.test.ts
@@ -269,7 +269,10 @@ describe('useClipboardPaste', () => {
       mockPermissionState('granted');
 
       const { result } = renderHook(() => useClipboardPaste());
-      await waitFor(() => expect(result.current.canPaste).toBe(true));
+      await waitFor(() => {
+        expect(result.current.access).toBe('granted');
+        expect(result.current.canPaste).toBe(true);
+      });
 
       expect(result.current.access).toBe('granted');
       expect(result.current.clipboardFormat).toBe('csv');
@@ -291,7 +294,10 @@ describe('useClipboardPaste', () => {
       mockPermissionState('granted');
 
       const { result } = renderHook(() => useClipboardPaste());
-      await waitFor(() => expect(result.current.canPaste).toBe(true));
+      await waitFor(() => {
+        expect(result.current.access).toBe('granted');
+        expect(result.current.canPaste).toBe(true);
+      });
       act(() => {
         result.current.markImported('a,b,c');
       });
@@ -319,7 +325,10 @@ describe('useClipboardPaste', () => {
       mockPermissionState('granted');
 
       const { result } = renderHook(() => useClipboardPaste());
-      await waitFor(() => expect(result.current.canPaste).toBe(true));
+      await waitFor(() => {
+        expect(result.current.access).toBe('granted');
+        expect(result.current.canPaste).toBe(true);
+      });
       act(() => {
         result.current.markImported('a,b,c');
       });

--- a/public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor/VariableOptionsSpreadsheet/clipboard.test.ts
+++ b/public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor/VariableOptionsSpreadsheet/clipboard.test.ts
@@ -339,7 +339,10 @@ describe('useClipboardPaste', () => {
       mockPermissionState('granted');
 
       const { result } = renderHook(() => useClipboardPaste());
-      await waitFor(() => expect(result.current.canPaste).toBe(true));
+      await waitFor(() => {
+        expect(result.current.access).toBe('granted');
+        expect(result.current.canPaste).toBe(true);
+      });
       act(() => {
         result.current.markImported('a,b,c');
       });


### PR DESCRIPTION
**What is this feature?**

Fixes a flaky test that occurred during a CI [run](https://github.com/grafana/grafana/actions/runs/29322621532/job/87052303643) in one of the PRs that I had opened. 
This PR then applies a similar fix to the tests that can potentially become flaky as well. 

**Why do we need this feature?**

The flakiness comes from the fact that the feature's initial state is `gesture-only` and the `canPaste` variable is already true there, which messed with the test flow and could end up in the error that `act` was throwing inside the test body.