### PR TITLE
feat(navigation): add Assistant onboarding nav entry

### DIFF
--- a/pkg/services/navtree/navtreeimpl/applinks.go
+++ b/pkg/services/navtree/navtreeimpl/applinks.go
@@ -19,6 +19,8 @@ import (
 // The Knowledge Graph's version of the "Application" page.
 const assertsServicesPath = "/a/grafana-asserts-app/services"
 const appObservabilityAppID = "grafana-app-observability-app"
+const assistantAppID = "grafana-assistant-app"
+const assistantOnboardingAppID = "grafana-assistant-onboarding-app"
 
 func (s *ServiceImpl) addAppLinks(treeRoot *navtree.NavTreeRoot, c *contextmodel.ReqContext) error {
 	hasAccess := ac.HasAccess(s.accessControl, c)
@@ -42,10 +44,19 @@ func (s *ServiceImpl) addAppLinks(treeRoot *navtree.NavTreeRoot, c *contextmodel
 	}
 
 	enabledAccessibleAppPluginMap := make(map[string]*pluginstore.Plugin)
+	assistantAppEnabled := false
+	assistantOnboardingAppEnabled := false
 
 	for _, plugin := range s.pluginStore.Plugins(c.Req.Context(), plugins.TypeApp) {
 		if !isPluginEnabled(plugin) {
 			continue
+		}
+
+		switch plugin.ID {
+		case assistantAppID:
+			assistantAppEnabled = true
+		case assistantOnboardingAppID:
+			assistantOnboardingAppEnabled = true
 		}
 
 		if !hasAccess(ac.EvalPermission(pluginaccesscontrol.ActionAppAccess, pluginaccesscontrol.ScopeProvider.GetResourceScope(plugin.ID))) {
@@ -56,6 +67,19 @@ func (s *ServiceImpl) addAppLinks(treeRoot *navtree.NavTreeRoot, c *contextmodel
 		if appNode := s.processAppPlugin(plugin, c, treeRoot); appNode != nil {
 			appLinks = append(appLinks, appNode)
 		}
+	}
+
+	if assistantOnboardingAppEnabled && !assistantAppEnabled {
+		treeRoot.AddSection(&navtree.NavLink{
+			Text:       "Assistant",
+			Id:         "plugin-page-" + assistantAppID,
+			SubTitle:   "AI-powered assistant for Grafana",
+			Icon:       "ai-sparkle",
+			SortWeight: navtree.WeightAssistant,
+			IsSection:  true,
+			PluginID:   assistantAppID,
+			Url:        s.cfg.AppSubURL + "/a/" + assistantAppID,
+		})
 	}
 
 	if adaptiveTelemetryPlugin := enabledAccessibleAppPluginMap["grafana-adaptivetelemetry-app"]; adaptiveTelemetryPlugin != nil {

--- a/pkg/services/navtree/navtreeimpl/applinks_test.go
+++ b/pkg/services/navtree/navtreeimpl/applinks_test.go
@@ -376,6 +376,88 @@ func TestAddAppLinks(t *testing.T) {
 	})
 }
 
+func TestAssistantStubNav(t *testing.T) {
+	httpReq, _ := http.NewRequest(http.MethodGet, "", nil)
+	reqCtx := &contextmodel.ReqContext{SignedInUser: &user.SignedInUser{}, Context: &web.Context{Req: httpReq}}
+	onboardingPlugin := pluginstore.Plugin{
+		JSONData: plugins.JSONData{
+			ID:          assistantOnboardingAppID,
+			Name:        "Grafana Assistant Onboarding",
+			Type:        plugins.TypeApp,
+			AutoEnabled: true,
+		},
+	}
+	assistantPlugin := pluginstore.Plugin{
+		JSONData: plugins.JSONData{
+			ID:          assistantAppID,
+			Name:        "Grafana Assistant",
+			Type:        plugins.TypeApp,
+			AutoEnabled: true,
+		},
+	}
+	appAccess := ac.Permission{Action: pluginaccesscontrol.ActionAppAccess, Scope: "*"}
+	installAccess := ac.Permission{Action: pluginaccesscontrol.ActionInstall, Scope: "*"}
+
+	tests := []struct {
+		name        string
+		plugins     []pluginstore.Plugin
+		permissions []ac.Permission
+		wantStub    bool
+	}{
+		{
+			name:        "adds stub when onboarding plugin is enabled and Assistant is absent",
+			plugins:     []pluginstore.Plugin{onboardingPlugin},
+			permissions: []ac.Permission{appAccess, installAccess},
+			wantStub:    true,
+		},
+		{
+			name:        "suppresses stub when Assistant is enabled",
+			plugins:     []pluginstore.Plugin{onboardingPlugin, assistantPlugin},
+			permissions: []ac.Permission{appAccess, installAccess},
+		},
+		{
+			name:        "suppresses stub when onboarding plugin is absent",
+			permissions: []ac.Permission{appAccess, installAccess},
+		},
+		{
+			name:        "adds stub when user cannot install plugins",
+			plugins:     []pluginstore.Plugin{onboardingPlugin},
+			permissions: []ac.Permission{appAccess},
+			wantStub:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := ServiceImpl{
+				log:            log.New("navtree"),
+				cfg:            setting.NewCfg(),
+				accessControl:  accesscontrolmock.New().WithPermissions(tt.permissions),
+				pluginSettings: &pluginsettings.FakePluginSettings{Plugins: map[string]*pluginsettings.DTO{}},
+				features:       featuremgmt.WithFeatures(),
+				pluginStore:    &pluginstore.FakePluginStore{PluginList: tt.plugins},
+			}
+
+			treeRoot := navtree.NavTreeRoot{}
+			err := service.addAppLinks(&treeRoot, reqCtx)
+			require.NoError(t, err)
+
+			node := treeRoot.FindById("plugin-page-" + assistantAppID)
+			if !tt.wantStub {
+				require.Nil(t, node)
+				return
+			}
+
+			require.NotNil(t, node)
+			require.Equal(t, "Assistant", node.Text)
+			require.Equal(t, "/a/"+assistantAppID, node.Url)
+			require.Equal(t, "ai-sparkle", node.Icon)
+			require.Equal(t, assistantAppID, node.PluginID)
+			require.Equal(t, int64(navtree.WeightAssistant), node.SortWeight)
+		})
+	}
+}
+
 func TestAddAppLinksObservabilityAssertsOrdering(t *testing.T) {
 	httpReq, _ := http.NewRequest(http.MethodGet, "", nil)
 	reqCtx := &contextmodel.ReqContext{SignedInUser: &user.SignedInUser{}, Context: &web.Context{Req: httpReq}}


### PR DESCRIPTION
## What

Adds a backend navigation entry for Assistant when the onboarding plugin is enabled and the full Assistant plugin is absent.

This backend-only PR lands first. The frontend fallback in #128387 is stacked on this branch and will follow separately.

## Why

Users need a stable Assistant navigation entry during onboarding, including users without plugin-install permission. Keeping backend and frontend changes separate preserves independent deployment compatibility.