### PR TITLE
Provisioning: Restore GitHub App setup order

### DIFF
--- a/public/app/features/provisioning/Wizard/AuthTypeStep.test.tsx
+++ b/public/app/features/provisioning/Wizard/AuthTypeStep.test.tsx
@@ -23,13 +23,21 @@ jest.mock('./components/RepositoryField', () => {
   };
 });
 
-function FormWrapper({ children }: { children: ReactNode }) {
+jest.mock('./components/RepositoryTokenInput', () => {
+  const React = jest.requireActual('react');
+  return {
+    RepositoryTokenInput: () => React.createElement('div', null, 'Token input'),
+  };
+});
+
+function FormWrapper({ children, defaultValues }: { children: ReactNode; defaultValues?: Partial<WizardFormData> }) {
   const methods = useForm<WizardFormData>({
     defaultValues: {
       repository: { type: 'github' },
       githubAuthType: 'github-app',
       githubAppMode: 'existing',
       githubApp: { connectionName: 'github-app' },
+      ...defaultValues,
     },
   });
 
@@ -50,5 +58,18 @@ describe('AuthTypeStep', () => {
     expect(
       githubAppConfiguration.compareDocumentPosition(repositoryUrl) & Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy();
+  });
+
+  it('shows the repository URL before the token input for PAT auth', () => {
+    render(
+      <FormWrapper defaultValues={{ githubAuthType: 'pat' }}>
+        <AuthTypeStep onGitHubAppSubmit={jest.fn()} />
+      </FormWrapper>
+    );
+
+    const repositoryUrl = screen.getByText('Repository URL');
+    const tokenInput = screen.getByText('Token input');
+
+    expect(repositoryUrl.compareDocumentPosition(tokenInput) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 });

--- a/public/app/features/provisioning/Wizard/AuthTypeStep.test.tsx
+++ b/public/app/features/provisioning/Wizard/AuthTypeStep.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react';
+import { type ReactNode } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+
+import { AuthTypeStep } from './AuthTypeStep';
+import { type WizardFormData } from './types';
+
+jest.mock('../hooks/useConnectionStatus', () => ({
+  useConnectionStatus: jest.fn(() => ({ isConnected: true })),
+}));
+
+jest.mock('./GitHubAppFields', () => {
+  const React = jest.requireActual('react');
+  return {
+    GitHubAppFields: () => React.createElement('div', null, 'GitHub App configuration'),
+  };
+});
+
+jest.mock('./components/RepositoryField', () => {
+  const React = jest.requireActual('react');
+  return {
+    RepositoryField: () => React.createElement('div', null, 'Repository URL'),
+  };
+});
+
+function FormWrapper({ children }: { children: ReactNode }) {
+  const methods = useForm<WizardFormData>({
+    defaultValues: {
+      repository: { type: 'github' },
+      githubAuthType: 'github-app',
+      githubAppMode: 'existing',
+      githubApp: { connectionName: 'github-app' },
+    },
+  });
+
+  return <FormProvider {...methods}>{children}</FormProvider>;
+}
+
+describe('AuthTypeStep', () => {
+  it('shows GitHub App configuration before the repository URL', () => {
+    render(
+      <FormWrapper>
+        <AuthTypeStep onGitHubAppSubmit={jest.fn()} />
+      </FormWrapper>
+    );
+
+    const githubAppConfiguration = screen.getByText('GitHub App configuration');
+    const repositoryUrl = screen.getByText('Repository URL');
+
+    expect(
+      githubAppConfiguration.compareDocumentPosition(repositoryUrl) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+  });
+});

--- a/public/app/features/provisioning/Wizard/AuthTypeStep.tsx
+++ b/public/app/features/provisioning/Wizard/AuthTypeStep.tsx
@@ -120,12 +120,16 @@ export function AuthTypeStep({ onGitHubAppSubmit }: AuthTypeStepProps) {
       )}
 
       {isGitHubBased(repoType) && githubAuthType === 'github-app' ? (
-        <GitHubAppFields connectionType={repoType} onGitHubAppSubmit={onGitHubAppSubmit} />
+        <>
+          <GitHubAppFields connectionType={repoType} onGitHubAppSubmit={onGitHubAppSubmit} />
+          {shouldShowRepositories && <RepositoryField isSelectedConnectionReady={isSelectedConnectionReady} />}
+        </>
       ) : (
-        <RepositoryTokenInput />
+        <>
+          <RepositoryField isSelectedConnectionReady={isSelectedConnectionReady} />
+          <RepositoryTokenInput />
+        </>
       )}
-
-      {shouldShowRepositories && <RepositoryField isSelectedConnectionReady={isSelectedConnectionReady} />}
     </Stack>
   );
 }

--- a/public/app/features/provisioning/Wizard/AuthTypeStep.tsx
+++ b/public/app/features/provisioning/Wizard/AuthTypeStep.tsx
@@ -119,13 +119,13 @@ export function AuthTypeStep({ onGitHubAppSubmit }: AuthTypeStepProps) {
         </Field>
       )}
 
-      {shouldShowRepositories && <RepositoryField isSelectedConnectionReady={isSelectedConnectionReady} />}
-
       {isGitHubBased(repoType) && githubAuthType === 'github-app' ? (
         <GitHubAppFields connectionType={repoType} onGitHubAppSubmit={onGitHubAppSubmit} />
       ) : (
         <RepositoryTokenInput />
       )}
+
+      {shouldShowRepositories && <RepositoryField isSelectedConnectionReady={isSelectedConnectionReady} />}
     </Stack>
   );
 }


### PR DESCRIPTION
**What is this feature?**

Orders the Connect step by auth method: with GitHub App auth, the app configuration renders before the repository URL (the repo list comes from the selected connection); with PAT auth, the repository URL renders before the token input so the GitHub Enterprise token-settings link can be derived from the URL origin.

**Why do we need this feature?**

The GitHub Enterprise frontend change reversed these fields, disrupting the intended first-flow setup sequence.

**Special notes for your reviewer:**

The focused regression test asserts that GitHub App configuration renders before the repository URL.

Addresses the GHES PAT link concern — the PAT flow keeps URL-first ordering.