### PR TITLE
Logs Table: Fix sticky filter after closing details

### DIFF
--- a/public/app/plugins/panel/logstable/LogsTableDetails.test.tsx
+++ b/public/app/plugins/panel/logstable/LogsTableDetails.test.tsx
@@ -374,6 +374,61 @@ describe('LogsTableDetails', () => {
     });
   });
 
+  test('does not re-apply the previous search filter after reopening details', async () => {
+    const log = createLogLine({
+      logLevel: LogLevel.error,
+      timeEpochMs: 1546297200000,
+      datasourceUid: lokiDS.uid,
+      labels: { svc: 'api' },
+    });
+
+    const renderDetails = (currentLog: LogListModel | undefined) => (
+      <PanelContextProvider value={{ eventsScope: 'test', eventBus: new EventBusSrv(), app: CoreApp.Dashboard }}>
+        <LogDetailsContext.Provider
+          value={{
+            ...emptyContextData,
+            enableLogDetails: true,
+            logs: [log],
+            showDetails: currentLog ? [log] : [],
+            currentLog,
+            closeDetails: jest.fn(),
+            setCurrentLog: jest.fn(),
+            toggleDetails: jest.fn(),
+          }}
+        >
+          <LogsTableDetails
+            containerElement={null}
+            options={baseOptions}
+            onOptionsChange={jest.fn()}
+            timeRange={timeRange}
+            timeZone="UTC"
+          />
+        </LogDetailsContext.Provider>
+      </PanelContextProvider>
+    );
+
+    const { rerender } = render(renderDetails(log));
+
+    await waitFor(() => {
+      expect(screen.getByText('Log line')).toBeInTheDocument();
+    });
+
+    await userEvent.type(screen.getByPlaceholderText('Search field names and values'), 'api');
+    expect(screen.getByLabelText('Clear')).toBeInTheDocument();
+
+    // Close (which resets the search), then reopen the same log.
+    await userEvent.click(screen.getByLabelText('Close log details sidebar'));
+    rerender(renderDetails(undefined));
+    rerender(renderDetails(log));
+
+    await waitFor(() => {
+      expect(screen.getByText('Log line')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByLabelText('Clear')).not.toBeInTheDocument();
+    expect(screen.getByPlaceholderText<HTMLInputElement>('Search field names and values')).toHaveValue('');
+  });
+
   test('applies logDetailsWidth from panel options on the resizable container', async () => {
     setup(undefined, { logDetailsWidth: 428 });
 

--- a/public/app/plugins/panel/logstable/LogsTableDetails.tsx
+++ b/public/app/plugins/panel/logstable/LogsTableDetails.tsx
@@ -229,6 +229,9 @@ const getStyles = (theme: GrafanaTheme2) => ({
     backgroundColor: theme.colors.background.elevated,
     border: `1px solid ${theme.colors.border.weak}`,
     boxShadow: theme.shadows.z3,
+    // position is required for zIndex to take effect and establish a stacking
+    // context, otherwise the tabs render behind elements in the table below.
+    position: 'relative',
     zIndex: theme.zIndex.navbarFixed,
     height: '100%',
     display: 'flex',

--- a/public/app/plugins/panel/logstable/LogsTableDetails.tsx
+++ b/public/app/plugins/panel/logstable/LogsTableDetails.tsx
@@ -47,17 +47,23 @@ export const LogsTableDetails = ({ containerElement, options, onOptionsChange, t
   const styles = useStyles2(getStyles);
   const dragStyles = useStyles2(getDragStyles);
 
+  const handleCloseDetails = useCallback(() => {
+    inputRef.current = '';
+    setSearch('');
+    closeDetails();
+  }, [closeDetails]);
+
   useEffect(() => {
     function handleClose(event: KeyboardEvent) {
       if (event.key === 'Escape' && showDetails.length > 0) {
-        closeDetails();
+        handleCloseDetails();
       }
     }
     document.addEventListener('keyup', handleClose);
     return () => {
       document.removeEventListener('keyup', handleClose);
     };
-  }, [closeDetails, showDetails.length]);
+  }, [handleCloseDetails, showDetails.length]);
 
   useEffect(() => {
     function handleKeydown(e: KeyboardEvent) {
@@ -192,7 +198,7 @@ export const LogsTableDetails = ({ containerElement, options, onOptionsChange, t
             wrapLogMessage
           >
             <LogLineDetailsHeader
-              closeDetails={closeDetails}
+              closeDetails={handleCloseDetails}
               detailsMode="sidebar"
               log={currentLog}
               search={search}


### PR DESCRIPTION
This PR fixes a bug where a fields filter sticks after closing details in the Table.

https://github.com/user-attachments/assets/7f8ec533-b0f3-44bc-a812-fe16978dab74

Additionally, it fixes an overlap between the view selector and the details tabs in Logs Drilldown.

<img width="253" height="56" alt="Overlap" src="https://github.com/user-attachments/assets/f4c1f9e3-df16-432d-ac8a-82129b50d92d" />
