### PR TITLE
LogsTable: use TableNG instead of TablePanel as integration point

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -986,6 +986,7 @@ playwright.storybook.config.ts @grafana/grafana-frontend-platform
 /public/app/features/canvas/ @grafana/dataviz-squad
 /public/app/features/geo/ @grafana/dataviz-squad
 /public/app/features/visualization/data-hover/ @grafana/dataviz-squad
+/public/app/features/table/ @grafana/dataviz-squad
 /public/app/features/commandPalette/ @grafana/grafana-frontend-navigation
 /public/app/features/commandPalette/scopes/ @grafana/grafana-operator-experience-squad
 /public/app/features/connections/ @grafana/grafana-catalog

--- a/public/app/features/table/utils.test.ts
+++ b/public/app/features/table/utils.test.ts
@@ -1,19 +1,46 @@
-import { type FieldConfigSource, FieldMatcherID } from '@grafana/data';
+import { type ActionModel, type Field, type FieldConfigSource, FieldMatcherID, FieldType } from '@grafana/data';
+import { getActions } from 'app/features/actions/utils';
 
-import { onColumnResize } from './TablePanel';
+import { getCellActions, getCurrentFrameIndex, onColumnResize, onSortByChange } from './utils';
 
-const setup = (overrides: FieldConfigSource['overrides']) => {
-  const fieldConfig: FieldConfigSource = { defaults: {}, overrides };
-  const onFieldConfigChange = jest.fn();
-  return {
-    fieldConfig,
-    onFieldConfigChange,
-    props: { fieldConfig, onFieldConfigChange },
-    nextConfig: () => onFieldConfigChange.mock.calls[0][0] as FieldConfigSource,
-  };
-};
+jest.mock('app/features/actions/utils', () => ({
+  getActions: jest.fn(),
+}));
+
+const getActionsMock = jest.mocked(getActions);
+
+describe('getCurrentFrameIndex', () => {
+  const frames = [{}, {}, {}] as never[];
+
+  it('returns 0 when frameIndex is 0', () => {
+    expect(getCurrentFrameIndex(frames, { frameIndex: 0 })).toBe(0);
+  });
+
+  it('returns the frameIndex when it is within range', () => {
+    expect(getCurrentFrameIndex(frames, { frameIndex: 2 })).toBe(2);
+  });
+
+  it('returns 0 when frameIndex is negative', () => {
+    expect(getCurrentFrameIndex(frames, { frameIndex: -1 })).toBe(0);
+  });
+
+  it('returns 0 when frameIndex is out of range', () => {
+    expect(getCurrentFrameIndex(frames, { frameIndex: 5 })).toBe(0);
+  });
+});
 
 describe('onColumnResize', () => {
+  const setup = (overrides: FieldConfigSource['overrides']) => {
+    const fieldConfig: FieldConfigSource = { defaults: {}, overrides };
+    const onFieldConfigChange = jest.fn();
+    return {
+      fieldConfig,
+      onFieldConfigChange,
+      props: { fieldConfig, onFieldConfigChange },
+      nextConfig: () => onFieldConfigChange.mock.calls[0][0] as FieldConfigSource,
+    };
+  };
+
   it('appends a new override when no overrides exist', () => {
     const { props, onFieldConfigChange, nextConfig } = setup([]);
 
@@ -194,5 +221,63 @@ describe('onColumnResize', () => {
       ],
     });
     expect(next.overrides[1].properties).toEqual([{ id: 'custom.width', value: 250 }]);
+  });
+});
+
+describe('onSortByChange', () => {
+  it('merges the new sortBy onto the existing options and forwards them', () => {
+    const onOptionsChange = jest.fn();
+    const options = { showHeader: true, sortBy: [{ displayName: 'old' }] };
+
+    onSortByChange([{ displayName: 'time', desc: true }], { options, onOptionsChange });
+
+    expect(onOptionsChange).toHaveBeenCalledTimes(1);
+    expect(onOptionsChange).toHaveBeenCalledWith({
+      showHeader: true,
+      sortBy: [{ displayName: 'time', desc: true }],
+    });
+  });
+});
+
+describe('getCellActions', () => {
+  const frame = { fields: [], length: 0 } as never;
+
+  const makeField = (actions?: unknown[]): Field =>
+    ({
+      name: 'value',
+      type: FieldType.string,
+      values: [],
+      config: { actions },
+      state: { scopedVars: {} },
+    }) as unknown as Field;
+
+  const action = (title: string): ActionModel<Field> => ({ title }) as unknown as ActionModel<Field>;
+
+  beforeEach(() => {
+    getActionsMock.mockReset();
+  });
+
+  it('returns an empty array and skips resolution when the field has no configured actions', () => {
+    const result = getCellActions(frame, makeField(), 0, undefined);
+
+    expect(result).toEqual([]);
+    expect(getActionsMock).not.toHaveBeenCalled();
+  });
+
+  it('returns the single resolved action as-is', () => {
+    getActionsMock.mockReturnValue([action('open')]);
+
+    const result = getCellActions(frame, makeField([{}]), 0, undefined);
+
+    expect(result).toEqual([action('open')]);
+    expect(getActionsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('de-duplicates resolved actions by title', () => {
+    getActionsMock.mockReturnValue([action('open'), action('open'), action('close')]);
+
+    const result = getCellActions(frame, makeField([{}, {}]), 0, undefined);
+
+    expect(result).toEqual([action('open'), action('close')]);
   });
 });

--- a/public/app/features/table/utils.ts
+++ b/public/app/features/table/utils.ts
@@ -1,0 +1,124 @@
+import {
+  type ActionModel,
+  type DataFrame,
+  type Field,
+  type FieldConfigSource,
+  FieldMatcherID,
+  type InterpolateFunction,
+} from '@grafana/data';
+import { type MatcherScope } from '@grafana/schema';
+import { type TableSortByFieldState } from '@grafana/ui/internal';
+import { getActions } from 'app/features/actions/utils';
+
+/**
+ * Returns the index of the frame to display, clamped to the range of available frames.
+ */
+export function getCurrentFrameIndex(frames: DataFrame[], options: { frameIndex: number }) {
+  return options.frameIndex > 0 && options.frameIndex < frames.length ? options.frameIndex : 0;
+}
+
+/**
+ * Persists a column width change as a `custom.width` field override, matched by field display name
+ * and matcher scope. An unscoped override is treated as implicitly 'series'.
+ */
+export function onColumnResize(
+  fieldDisplayName: string,
+  width: number,
+  fieldScope: MatcherScope = 'series',
+  props: { fieldConfig: FieldConfigSource; onFieldConfigChange: (fieldConfig: FieldConfigSource) => void }
+) {
+  const { fieldConfig } = props;
+  const { overrides } = fieldConfig;
+
+  const matcherId = FieldMatcherID.byName;
+  const propId = 'custom.width';
+
+  // look for existing override. an unscoped override is treated as implicitly 'series'.
+  const override = overrides.find(
+    (o) =>
+      o.matcher.id === matcherId &&
+      o.matcher.options === fieldDisplayName &&
+      (o.matcher.scope ?? 'series') === fieldScope
+  );
+
+  if (override) {
+    // look for existing property
+    const property = override.properties.find((prop) => prop.id === propId);
+    if (property) {
+      property.value = width;
+    } else {
+      override.properties.push({ id: propId, value: width });
+    }
+  } else {
+    overrides.push({
+      matcher: { id: matcherId, options: fieldDisplayName, scope: fieldScope },
+      properties: [{ id: propId, value: width }],
+    });
+  }
+
+  props.onFieldConfigChange({
+    ...fieldConfig,
+    overrides,
+  });
+}
+
+/**
+ * Persists a sort change onto the panel options. Generic over the options shape so it can be reused
+ * by any panel whose options include a `sortBy` array.
+ */
+export function onSortByChange<TOptions extends { sortBy?: TableSortByFieldState[] }>(
+  sortBy: TableSortByFieldState[],
+  props: { options: TOptions; onOptionsChange: (options: TOptions) => void }
+) {
+  props.onOptionsChange({
+    ...props.options,
+    sortBy,
+  });
+}
+
+// placeholder function; assuming the values are already interpolated
+const replaceVars: InterpolateFunction = (value: string) => value;
+
+/**
+ * Resolves the actions configured on a field for a given row, de-duplicating by title.
+ */
+export const getCellActions = (
+  dataFrame: DataFrame,
+  field: Field,
+  rowIndex: number,
+  replaceVariables: InterpolateFunction | undefined
+): Array<ActionModel<Field>> => {
+  const numActions = field.config.actions?.length ?? 0;
+
+  if (numActions > 0) {
+    const actions = getActions(
+      dataFrame,
+      field,
+      field.state!.scopedVars!,
+      replaceVariables ?? replaceVars,
+      field.config.actions ?? [],
+      { valueRowIndex: rowIndex },
+      'table'
+    );
+
+    if (actions.length === 1) {
+      return actions;
+    } else {
+      const actionsOut: Array<ActionModel<Field>> = [];
+      const actionLookup = new Set<string>();
+
+      actions.forEach((action) => {
+        const key = action.title;
+
+        if (!actionLookup.has(key)) {
+          actionsOut.push(action);
+          actionLookup.add(key);
+        }
+      });
+
+      return actionsOut;
+    }
+  }
+
+  return [];
+};

--- a/public/app/plugins/panel/logstable/TableNGWrap.tsx
+++ b/public/app/plugins/panel/logstable/TableNGWrap.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/css';
 import { useCallback, useMemo, useState } from 'react';
 
 import {
+  cacheFieldDisplayNames,
   DashboardCursorSync,
   type DataFrame,
   type Field,
@@ -50,6 +51,10 @@ export function TableNGWrap({
   containerElement,
   onWrapTextClick,
 }: Props) {
+  useMemo(() => {
+    cacheFieldDisplayNames(data.series);
+  }, [data.series]);
+
   const panelContext = usePanelContext();
   const protoParserEnabled = useFlagTableProtoRowParser();
   const nestedRefactorEnabled = useFlagTableRefactorNested();

--- a/public/app/plugins/panel/logstable/TableNGWrap.tsx
+++ b/public/app/plugins/panel/logstable/TableNGWrap.tsx
@@ -23,8 +23,7 @@ import { LogTableControls } from 'app/features/logs/components/panel/LogTableCon
 import { LOG_LIST_CONTROLS_WIDTH } from 'app/features/logs/components/panel/virtualization';
 import { dataFrameToLogsModel } from 'app/features/logs/logsModel';
 import { type DownloadFormat, downloadLogs as download } from 'app/features/logs/utils';
-
-import { getCellActions, getCurrentFrameIndex, onColumnResize, onSortByChange } from '../table/TablePanel';
+import { getCellActions, getCurrentFrameIndex, onColumnResize, onSortByChange } from 'app/features/table/utils';
 
 import { type Options } from './options/types';
 import { defaultOptions } from './panelcfg.gen';

--- a/public/app/plugins/panel/logstable/TableNGWrap.tsx
+++ b/public/app/plugins/panel/logstable/TableNGWrap.tsx
@@ -1,16 +1,21 @@
 import { css } from '@emotion/css';
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 import {
-  type FieldConfigSource,
+  DashboardCursorSync,
+  type DataFrame,
+  type Field,
   type GrafanaTheme2,
   LogSortOrderChangeEvent,
   LogsSortOrder,
   type PanelProps,
   store,
 } from '@grafana/data';
-import { getAppEvents } from '@grafana/runtime';
-import { useStyles2 } from '@grafana/ui';
+import { config, getAppEvents } from '@grafana/runtime';
+import { useFlagTableProtoRowParser, useFlagTableRefactorNested } from '@grafana/runtime/internal';
+import { usePanelContext, useStyles2 } from '@grafana/ui';
+import { TableNG } from '@grafana/ui/unstable';
+import { getConfig } from 'app/core/config';
 import { getDefaultFieldSelectorWidth } from 'app/features/logs/components/fieldSelector/FieldSelector';
 import { getDefaultControlsExpandedMode } from 'app/features/logs/components/panel/LogListContext';
 import { CONTROLS_WIDTH_EXPANDED } from 'app/features/logs/components/panel/LogListControls';
@@ -19,7 +24,7 @@ import { LOG_LIST_CONTROLS_WIDTH } from 'app/features/logs/components/panel/virt
 import { dataFrameToLogsModel } from 'app/features/logs/logsModel';
 import { type DownloadFormat, downloadLogs as download } from 'app/features/logs/utils';
 
-import { TablePanel } from '../table/TablePanel';
+import { getCellActions, getCurrentFrameIndex, onColumnResize, onSortByChange } from '../table/TablePanel';
 
 import { type Options } from './options/types';
 import { defaultOptions } from './panelcfg.gen';
@@ -32,8 +37,6 @@ interface Props extends Omit<PanelProps<Options>, 'timeRange'> {
 }
 
 export function TableNGWrap({
-  timeZone,
-  id,
   data,
   options,
   onOptionsChange,
@@ -41,17 +44,22 @@ export function TableNGWrap({
   width: tableWidth,
   transparent,
   fieldConfig,
-  renderCounter,
-  title,
-  eventBus,
   onFieldConfigChange,
   replaceVariables,
-  onChangeTimeRange,
   initialRowIndex,
   logOptionsStorageKey,
   containerElement,
   onWrapTextClick,
 }: Props) {
+  const panelContext = usePanelContext();
+  const protoParserEnabled = useFlagTableProtoRowParser();
+  const nestedRefactorEnabled = useFlagTableRefactorNested();
+  const userCanExecuteActions = useMemo(() => panelContext.canExecuteActions?.() ?? false, [panelContext]);
+  const getActions = useCallback(
+    (frame: DataFrame, field: Field, rowIndex: number) =>
+      userCanExecuteActions ? getCellActions(frame, field, rowIndex, replaceVariables) : [],
+    [replaceVariables, userCanExecuteActions]
+  );
   const fieldSelectorWidth = options.fieldSelectorWidth ?? getDefaultFieldSelectorWidth();
   const showControls = options.showControls ?? defaultOptions.showControls ?? true;
   const controlsExpandedFromStore = store.getBool(
@@ -73,13 +81,6 @@ export function TableNGWrap({
       onOptionsChange({ ...options, sortOrder });
     },
     [onOptionsChange, options]
-  );
-
-  const handleTableOnFieldConfigChange = useCallback(
-    (fieldConfig: FieldConfigSource) => {
-      onFieldConfigChange(fieldConfig);
-    },
-    [onFieldConfigChange]
   );
 
   const downloadLogs = useCallback(
@@ -109,25 +110,40 @@ export function TableNGWrap({
         </div>
       )}
 
-      <TablePanel
-        sortByBehavior={'managed'}
+      <TableNG
+        sortByBehavior="managed"
         initialRowIndex={initialRowIndex}
-        data={data}
+        data={data.series[getCurrentFrameIndex(data.series, options)]}
         timeRange={data.timeRange}
         width={Math.max(tableWidth - fieldSelectorWidth - controlsWidth, 0)}
         height={height}
-        id={id}
-        timeZone={timeZone}
-        options={options}
-        transparent={transparent}
+        noHeader={!options.showHeader}
+        noValue={fieldConfig.defaults.noValue}
+        showTypeIcons={options.showTypeIcons}
+        resizable={true}
+        sortBy={options.sortBy}
+        onSortByChange={(sortBy) => onSortByChange(sortBy, { onOptionsChange, options })}
+        onColumnResize={(displayName, resizedWidth, fieldScope) =>
+          onColumnResize(displayName, resizedWidth, fieldScope, { fieldConfig, onFieldConfigChange })
+        }
+        onCellFilterAdded={panelContext.onAddAdHocFilter}
+        frozenColumns={options.frozenColumns?.left}
+        enablePagination={options.enablePagination}
+        cellHeight={options.cellHeight}
+        maxRowHeight={options.maxRowHeight}
+        enableSharedCrosshair={
+          Boolean(config.featureToggles.tableSharedCrosshair) &&
+          Boolean(panelContext.sync) &&
+          panelContext.sync!() !== DashboardCursorSync.Off
+        }
         fieldConfig={fieldConfig}
-        renderCounter={renderCounter}
-        title={title}
-        eventBus={eventBus}
-        onOptionsChange={onOptionsChange}
-        onFieldConfigChange={handleTableOnFieldConfigChange}
-        replaceVariables={replaceVariables}
-        onChangeTimeRange={onChangeTimeRange}
+        getActions={getActions}
+        structureRev={data.structureRev}
+        transparent={transparent}
+        disableSanitizeHtml={getConfig().disableSanitizeHtml}
+        disableKeyboardEvents={options.disableKeyboardEvents}
+        protoParserEnabled={protoParserEnabled}
+        nestedRefactorEnabled={nestedRefactorEnabled}
       />
     </div>
   );

--- a/public/app/plugins/panel/table/TablePanel.tsx
+++ b/public/app/plugins/panel/table/TablePanel.tsx
@@ -139,7 +139,7 @@ export function TablePanel(props: Props) {
   );
 }
 
-function getCurrentFrameIndex(frames: DataFrame[], options: Options) {
+export function getCurrentFrameIndex(frames: DataFrame[], options: Pick<Options, 'frameIndex'>) {
   return options.frameIndex > 0 && options.frameIndex < frames.length ? options.frameIndex : 0;
 }
 
@@ -184,7 +184,7 @@ export function onColumnResize(
   });
 }
 
-function onSortByChange(sortBy: TableSortByFieldState[], props: Props) {
+export function onSortByChange(sortBy: TableSortByFieldState[], props: Pick<Props, 'onOptionsChange' | 'options'>) {
   props.onOptionsChange({
     ...props.options,
     sortBy,
@@ -201,7 +201,7 @@ function onChangeTableSelection(val: SelectableValue<number>, props: Props) {
 // placeholder function; assuming the values are already interpolated
 const replaceVars: InterpolateFunction = (value: string) => value;
 
-const getCellActions = (
+export const getCellActions = (
   dataFrame: DataFrame,
   field: Field,
   rowIndex: number,

--- a/public/app/plugins/panel/table/TablePanel.tsx
+++ b/public/app/plugins/panel/table/TablePanel.tsx
@@ -2,12 +2,9 @@ import { css } from '@emotion/css';
 import { useCallback, useMemo } from 'react';
 
 import {
-  type ActionModel,
   DashboardCursorSync,
   type DataFrame,
-  FieldMatcherID,
   getFrameDisplayName,
-  type InterpolateFunction,
   type PanelProps,
   type SelectableValue,
   type Field,
@@ -15,12 +12,10 @@ import {
 } from '@grafana/data';
 import { config, PanelDataErrorView } from '@grafana/runtime';
 import { useFlagTableProtoRowParser, useFlagTableRefactorNested } from '@grafana/runtime/internal';
-import { type MatcherScope } from '@grafana/schema';
 import { Combobox, usePanelContext, useTheme2 } from '@grafana/ui';
-import { type TableSortByFieldState } from '@grafana/ui/internal';
 import { TableNG } from '@grafana/ui/unstable';
 import { getConfig } from 'app/core/config';
-import { getActions } from 'app/features/actions/utils';
+import { getCellActions, getCurrentFrameIndex, onColumnResize, onSortByChange } from 'app/features/table/utils';
 
 import { hasDeprecatedParentRowIndex, migrateFromParentRowIndexToNestedFrames } from './migrations';
 import { type Options } from './panelcfg.gen';
@@ -139,108 +134,12 @@ export function TablePanel(props: Props) {
   );
 }
 
-export function getCurrentFrameIndex(frames: DataFrame[], options: Pick<Options, 'frameIndex'>) {
-  return options.frameIndex > 0 && options.frameIndex < frames.length ? options.frameIndex : 0;
-}
-
-export function onColumnResize(
-  fieldDisplayName: string,
-  width: number,
-  fieldScope: MatcherScope = 'series',
-  props: Pick<Props, 'fieldConfig' | 'onFieldConfigChange'>
-) {
-  const { fieldConfig } = props;
-  const { overrides } = fieldConfig;
-
-  const matcherId = FieldMatcherID.byName;
-  const propId = 'custom.width';
-
-  // look for existing override. an unscoped override is treated as implicitly 'series'.
-  const override = overrides.find(
-    (o) =>
-      o.matcher.id === matcherId &&
-      o.matcher.options === fieldDisplayName &&
-      (o.matcher.scope ?? 'series') === fieldScope
-  );
-
-  if (override) {
-    // look for existing property
-    const property = override.properties.find((prop) => prop.id === propId);
-    if (property) {
-      property.value = width;
-    } else {
-      override.properties.push({ id: propId, value: width });
-    }
-  } else {
-    overrides.push({
-      matcher: { id: matcherId, options: fieldDisplayName, scope: fieldScope },
-      properties: [{ id: propId, value: width }],
-    });
-  }
-
-  props.onFieldConfigChange({
-    ...fieldConfig,
-    overrides,
-  });
-}
-
-export function onSortByChange(sortBy: TableSortByFieldState[], props: Pick<Props, 'onOptionsChange' | 'options'>) {
-  props.onOptionsChange({
-    ...props.options,
-    sortBy,
-  });
-}
-
 function onChangeTableSelection(val: SelectableValue<number>, props: Props) {
   props.onOptionsChange({
     ...props.options,
     frameIndex: val.value || 0,
   });
 }
-
-// placeholder function; assuming the values are already interpolated
-const replaceVars: InterpolateFunction = (value: string) => value;
-
-export const getCellActions = (
-  dataFrame: DataFrame,
-  field: Field,
-  rowIndex: number,
-  replaceVariables: InterpolateFunction | undefined
-): Array<ActionModel<Field>> => {
-  const numActions = field.config.actions?.length ?? 0;
-
-  if (numActions > 0) {
-    const actions = getActions(
-      dataFrame,
-      field,
-      field.state!.scopedVars!,
-      replaceVariables ?? replaceVars,
-      field.config.actions ?? [],
-      { valueRowIndex: rowIndex },
-      'table'
-    );
-
-    if (actions.length === 1) {
-      return actions;
-    } else {
-      const actionsOut: Array<ActionModel<Field>> = [];
-      const actionLookup = new Set<string>();
-
-      actions.forEach((action) => {
-        const key = action.title;
-
-        if (!actionLookup.has(key)) {
-          actionsOut.push(action);
-          actionLookup.add(key);
-        }
-      });
-
-      return actionsOut;
-    }
-  }
-
-  return [];
-};
 
 const tableStyles = {
   wrapper: css({


### PR DESCRIPTION
Currently, the LogsTable panel component mounts the TablePanel root component. This is ok, but it does prevent us from doing proper panel decoupling between these two panels long-term. To me, it's worth having a bit of duplication between these two panels but directly integrating with TableNG.