### PR TITLE
Storage: type the search-fields map keys with LowerGroupResource

### DIFF
--- a/pkg/storage/unified/resource/document.go
+++ b/pkg/storage/unified/resource/document.go
@@ -76,18 +76,17 @@ func SearchableFieldsFromProvider(p SearchFieldsProvider, group, resource string
 	return NewSearchableDocumentFields(SearchFieldDefinitionsToTableColumns(sfds))
 }
 
-// SearchFieldsHashesForBuilders returns a lower-cased "group/resource" map
-// of SearchFieldsHash values collected from the given DocumentBuilderInfo
+// SearchFieldsHashesForBuilders returns a (group, resource) map of
+// SearchFieldsHash values collected from the given DocumentBuilderInfo
 // entries. Empty hashes are skipped so consumers can use len(...) == 0 as a
 // shorthand for "no expected hash".
-func SearchFieldsHashesForBuilders(builders []DocumentBuilderInfo) map[string]string {
-	out := map[string]string{}
+func SearchFieldsHashesForBuilders(builders []DocumentBuilderInfo) map[LowerGroupResource]string {
+	out := map[LowerGroupResource]string{}
 	for _, b := range builders {
 		if b.SearchFieldsHash == "" {
 			continue
 		}
-		key := strings.ToLower(b.GroupResource.Group + "/" + b.GroupResource.Resource)
-		out[key] = b.SearchFieldsHash
+		out[NewLowerGroupResource(b.GroupResource.Group, b.GroupResource.Resource)] = b.SearchFieldsHash
 	}
 	return out
 }
@@ -305,8 +304,7 @@ func StandardDocumentBuilderWithFields(manifests []app.Manifest, provider Search
 }
 
 type standardDocumentBuilder struct {
-	// Maps "group/resource" (in lowercase) to list of selectable fields.
-	selectableFields map[string][]string
+	selectableFields map[LowerGroupResource][]string
 	// provider supplies declarative search fields; may be nil.
 	provider SearchFieldsProvider
 	log      log.Logger
@@ -326,7 +324,7 @@ func (s *standardDocumentBuilder) BuildDocument(ctx context.Context, key *resour
 
 	doc := NewIndexableDocument(key, rv, obj, "")
 
-	sfKey := strings.ToLower(key.GetGroup() + "/" + key.GetResource())
+	sfKey := NewLowerGroupResource(key.GetGroup(), key.GetResource())
 	doc.SelectableFields = getSelectableFieldsFromObject(tmp, s.selectableFields[sfKey])
 
 	if s.provider != nil {

--- a/pkg/storage/unified/resource/keys.go
+++ b/pkg/storage/unified/resource/keys.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	"github.com/grafana/grafana/pkg/apimachinery/validation"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 )
@@ -63,6 +65,17 @@ func matchesQueryKey(query *resourcepb.ResourceKey, key *resourcepb.ResourceKey)
 		return false
 	}
 	return true
+}
+
+// LowerGroupResource is a schema.GroupResource with lower-cased Group and
+// Resource. A distinct type so keys can only be built via NewLowerGroupResource;
+// it keys the search-fields wiring maps.
+type LowerGroupResource schema.GroupResource
+
+// NewLowerGroupResource returns a LowerGroupResource, lower-casing group and
+// resource so lookups are case-insensitive.
+func NewLowerGroupResource(group, resource string) LowerGroupResource {
+	return LowerGroupResource{Group: strings.ToLower(group), Resource: strings.ToLower(resource)}
 }
 
 const clusterNamespace = "**cluster**"

--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -205,8 +205,8 @@ type searchServer struct {
 	maxIndexAge          time.Duration
 	minBuildVersion      *semver.Version
 	buildVersion         *semver.Version
-	selectableFields     map[string][]string
-	searchFieldsHashes   map[string]string
+	selectableFields     map[LowerGroupResource][]string
+	searchFieldsHashes   map[LowerGroupResource]string
 
 	bgTaskWg     sync.WaitGroup
 	bgTaskCancel func()
@@ -1339,7 +1339,7 @@ func (s *searchServer) findIndexesToRebuild(lastImportTimes map[NamespacedResour
 			continue
 		}
 
-		sfKey := fmt.Sprintf("%s/%s", strings.ToLower(key.Group), strings.ToLower(key.Resource))
+		sfKey := NewLowerGroupResource(key.Group, key.Resource)
 		sfields := s.selectableFields[sfKey]
 		expectedSearchFieldsHash := s.searchFieldsHashes[sfKey]
 

--- a/pkg/storage/unified/resource/search_field_manifest.go
+++ b/pkg/storage/unified/resource/search_field_manifest.go
@@ -85,12 +85,10 @@ func manifestSearchFieldsToDefinitions(in []app.ManifestVersionKindSearchField) 
 	return out
 }
 
-// manifestDeclaredKindKeys returns the lower-cased "group/resource" keys of
-// every kind that declares at least one search field in any version. The key
-// format matches the lower-cased "group/resource" used throughout the
-// search-fields boot wiring.
-func manifestDeclaredKindKeys(manifests []app.Manifest) map[string]bool {
-	keys := map[string]bool{}
+// manifestDeclaredKindKeys returns the (group, resource) key of every kind that
+// declares at least one search field in any version.
+func manifestDeclaredKindKeys(manifests []app.Manifest) map[LowerGroupResource]bool {
+	keys := map[LowerGroupResource]bool{}
 	for _, m := range manifests {
 		if m.ManifestData == nil {
 			continue
@@ -100,20 +98,20 @@ func manifestDeclaredKindKeys(manifests []app.Manifest) map[string]bool {
 				if len(kind.SearchFields) == 0 {
 					continue
 				}
-				keys[strings.ToLower(m.ManifestData.Group+"/"+manifestResourceName(kind))] = true
+				keys[NewLowerGroupResource(m.ManifestData.Group, manifestResourceName(kind))] = true
 			}
 		}
 	}
 	return keys
 }
 
-// SearchFieldProviders returns the per-("group/resource") provider map that
+// SearchFieldProviders returns the per-(group, resource) provider map that
 // drives bleve mappings. Every kind that declares search fields in its manifest
 // is mapped to a single manifest-backed provider; each entry queries it for its
-// own (group, resource). Keys are lower-cased "group/resource".
-func SearchFieldProviders(manifests []app.Manifest) map[string]SearchFieldsProvider {
+// own (group, resource).
+func SearchFieldProviders(manifests []app.Manifest) map[LowerGroupResource]SearchFieldsProvider {
 	declared := manifestDeclaredKindKeys(manifests)
-	out := make(map[string]SearchFieldsProvider, len(declared))
+	out := make(map[LowerGroupResource]SearchFieldsProvider, len(declared))
 	if len(declared) == 0 {
 		return out
 	}

--- a/pkg/storage/unified/resource/search_field_manifest_test.go
+++ b/pkg/storage/unified/resource/search_field_manifest_test.go
@@ -98,7 +98,7 @@ func TestSearchFieldProviders_MapsDeclaredKinds(t *testing.T) {
 
 	// The one kind that declares search fields is present and provider-backed.
 	require.Len(t, got, 1)
-	provider := got["widgets.example.test/widgets"]
+	provider := got[NewLowerGroupResource("widgets.example.test", "widgets")]
 	require.NotNil(t, provider)
 
 	// The mapped provider answers for that kind's own (group, resource).

--- a/pkg/storage/unified/resource/selectable_fields.go
+++ b/pkg/storage/unified/resource/selectable_fields.go
@@ -2,13 +2,13 @@ package resource
 
 import (
 	"slices"
-	"strings"
 
 	"github.com/grafana/grafana-app-sdk/app"
 )
 
-// SelectableFields returns map of <group>/<Kind> to list of selectable fields for known manifests.
-func SelectableFields() map[string][]string {
+// SelectableFields returns a map keyed by (group, kind) to the list of
+// selectable fields for known manifests.
+func SelectableFields() map[LowerGroupResource][]string {
 	return SelectableFieldsForManifests(AppManifests())
 }
 
@@ -33,11 +33,11 @@ func AppManifestsWithKinds(manifiests []app.Manifest) []app.Manifest {
 	return filtered
 }
 
-// SelectableFieldsForManifests returns map of <group/kind> to list of selectable fields (across all versions).
-// Also <group/plural> is included as a key, pointing to the same fields.
-// Keys are lower-case.
-func SelectableFieldsForManifests(manifests []app.Manifest) map[string][]string {
-	fields := map[string][]string{}
+// SelectableFieldsForManifests returns a map keyed by (group, kind) to the list
+// of selectable fields (across all versions). Each kind is also keyed by
+// (group, plural), pointing to the same fields.
+func SelectableFieldsForManifests(manifests []app.Manifest) map[LowerGroupResource][]string {
+	fields := map[LowerGroupResource][]string{}
 	for _, m := range manifests {
 		for k, v := range selectableFieldsForManifest(m) {
 			fields[k] = v
@@ -46,7 +46,7 @@ func SelectableFieldsForManifests(manifests []app.Manifest) map[string][]string 
 	return fields
 }
 
-func selectableFieldsForManifest(m app.Manifest) map[string][]string {
+func selectableFieldsForManifest(m app.Manifest) map[LowerGroupResource][]string {
 	kindFields := map[string]map[string]bool{}
 	kinds := map[string]app.ManifestVersionKind{}
 
@@ -65,7 +65,7 @@ func selectableFieldsForManifest(m app.Manifest) map[string][]string {
 		}
 	}
 
-	fields := map[string][]string{}
+	fields := map[LowerGroupResource][]string{}
 	for k, v := range kinds {
 		fs := make([]string, 0, len(kindFields[k]))
 		for f := range kindFields[k] {
@@ -73,8 +73,8 @@ func selectableFieldsForManifest(m app.Manifest) map[string][]string {
 		}
 		slices.Sort(fs)
 
-		fields[strings.ToLower(m.ManifestData.Group+"/"+v.Kind)] = fs
-		fields[strings.ToLower(m.ManifestData.Group+"/"+v.Plural)] = fs
+		fields[NewLowerGroupResource(m.ManifestData.Group, v.Kind)] = fs
+		fields[NewLowerGroupResource(m.ManifestData.Group, v.Plural)] = fs
 	}
 
 	return fields

--- a/pkg/storage/unified/resource/selectable_fields_test.go
+++ b/pkg/storage/unified/resource/selectable_fields_test.go
@@ -136,16 +136,16 @@ func TestSelectableFieldsForManifests(t *testing.T) {
 	})
 
 	fields := SelectableFieldsForManifests([]app.Manifest{m1, m2, m3, m4})
-	expected := map[string][]string{
+	expected := map[LowerGroupResource][]string{
 		// Nothing for test1.grafana.app, as there were no selectable fields.
-		"test2.grafana.app/testkind":  {"spec.field1", "spec.field2"},
-		"test2.grafana.app/testkinds": {"spec.field1", "spec.field2"},
-		"test3.grafana.app/testkind":  {"spec.field1", "spec.field2", "spec.field3", "spec.field4"},
-		"test3.grafana.app/testkinds": {"spec.field1", "spec.field2", "spec.field3", "spec.field4"},
-		"test4.grafana.app/kinda":     {"spec.fieldA"},
-		"test4.grafana.app/kindas":    {"spec.fieldA"},
-		"test4.grafana.app/kindb":     {"spec.fieldB"},
-		"test4.grafana.app/kindbs":    {"spec.fieldB"},
+		NewLowerGroupResource("test2.grafana.app", "testkind"):  {"spec.field1", "spec.field2"},
+		NewLowerGroupResource("test2.grafana.app", "testkinds"): {"spec.field1", "spec.field2"},
+		NewLowerGroupResource("test3.grafana.app", "testkind"):  {"spec.field1", "spec.field2", "spec.field3", "spec.field4"},
+		NewLowerGroupResource("test3.grafana.app", "testkinds"): {"spec.field1", "spec.field2", "spec.field3", "spec.field4"},
+		NewLowerGroupResource("test4.grafana.app", "kinda"):     {"spec.fieldA"},
+		NewLowerGroupResource("test4.grafana.app", "kindas"):    {"spec.fieldA"},
+		NewLowerGroupResource("test4.grafana.app", "kindb"):     {"spec.fieldB"},
+		NewLowerGroupResource("test4.grafana.app", "kindbs"):    {"spec.fieldB"},
 	}
 	require.Equal(t, expected, fields)
 }
@@ -155,12 +155,12 @@ func TestSelectableFields(t *testing.T) {
 	result := SelectableFields()
 
 	// We know IAM manifest should have TeamBinding with selectable fields
-	assert.Contains(t, result, "iam.grafana.app/teambinding")
-	assert.Contains(t, result["iam.grafana.app/teambinding"], "spec.subject.name")
-	assert.Contains(t, result["iam.grafana.app/teambinding"], "spec.teamRef.name")
+	assert.Contains(t, result, NewLowerGroupResource("iam.grafana.app", "teambinding"))
+	assert.Contains(t, result[NewLowerGroupResource("iam.grafana.app", "teambinding")], "spec.subject.name")
+	assert.Contains(t, result[NewLowerGroupResource("iam.grafana.app", "teambinding")], "spec.teamRef.name")
 
 	// Check the plural version too.
-	assert.Contains(t, result, "iam.grafana.app/teambinding")
-	assert.Contains(t, result["iam.grafana.app/teambindings"], "spec.subject.name")
-	assert.Contains(t, result["iam.grafana.app/teambindings"], "spec.teamRef.name")
+	assert.Contains(t, result, NewLowerGroupResource("iam.grafana.app", "teambindings"))
+	assert.Contains(t, result[NewLowerGroupResource("iam.grafana.app", "teambindings")], "spec.subject.name")
+	assert.Contains(t, result[NewLowerGroupResource("iam.grafana.app", "teambindings")], "spec.teamRef.name")
 }

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -280,15 +280,15 @@ type SearchOptions struct {
 	// Percentage of search requests that should fail immediately (0-100). 0 = disabled, 100 = all requests fail.
 	InjectFailuresPercent int
 
-	// Map "group/kind" -> list of selectable fields. Keys must be lower-case.
-	SelectableFieldsForKinds map[string][]string
+	// Selectable fields per kind, keyed by (group, kind) and (group, plural).
+	SelectableFieldsForKinds map[LowerGroupResource][]string
 
-	// Map "group/resource" -> hash of the SearchFieldDefinition slices
-	// registered for that (group, resource), across every version. The
-	// search server compares this against the value stored in each index's
-	// IndexBuildInfo and triggers a rebuild on mismatch. Keys must be
-	// lower-case. Entries with empty hash strings are ignored.
-	SearchFieldsHashesForKinds map[string]string
+	// Hash of the SearchFieldDefinition slices registered for a (group,
+	// resource) across every version, keyed by (group, resource). The search
+	// server compares this against the value stored in each index's
+	// IndexBuildInfo and triggers a rebuild on mismatch. Entries with empty
+	// hash strings are ignored.
+	SearchFieldsHashesForKinds map[LowerGroupResource]string
 
 	// Index snapshot settings — enable downloading pre-built search indexes from object storage on startup.
 	// IndexSnapshotEnabled gates the entire snapshot feature.

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -80,22 +80,21 @@ type BleveOptions struct {
 	// If nil, all indexes are owned by the current instance.
 	OwnsIndex func(key resource.NamespacedResource) (bool, error)
 
-	// Map "group/kind" -> list of selectable fields. Keys must be lower-case.
+	// Selectable fields per kind, keyed by (group, kind) and (group, plural).
 	// Only given fields are indexed (have mapping).
-	SelectableFieldsForKinds map[string][]string
+	SelectableFieldsForKinds map[resource.LowerGroupResource][]string
 
-	// Map "group/resource" -> hash of the SearchFieldDefinition slices
-	// registered for that (group, resource), across every version. The
-	// value is recorded in each new index's IndexBuildInfo so a future run
-	// can detect drift and rebuild. Keys must be lower-case.
-	SearchFieldsHashesForKinds map[string]string
+	// Hash of the SearchFieldDefinition slices registered for a (group,
+	// resource) across every version, keyed by (group, resource). The value
+	// is recorded in each new index's IndexBuildInfo so a future run can
+	// detect drift and rebuild.
+	SearchFieldsHashesForKinds map[resource.LowerGroupResource]string
 
-	// Map "group/resource" -> SearchFieldsProvider that drives the bleve
-	// mapping for that (group, resource). When a provider is registered
-	// for a kind, the bleve mapping is built from the provider's
-	// SearchFieldDefinitions rather than from the legacy column-definition
-	// list carried by SearchableDocumentFields. Keys must be lower-case.
-	SearchFieldsProvidersForKinds map[string]resource.SearchFieldsProvider
+	// SearchFieldsProvider per (group, resource) that drives the bleve
+	// mapping. When a provider is registered for a kind, the bleve mapping is
+	// built from the provider's SearchFieldDefinitions rather than from the
+	// legacy column-definition list carried by SearchableDocumentFields.
+	SearchFieldsProvidersForKinds map[resource.LowerGroupResource]resource.SearchFieldsProvider
 
 	// Snapshot configures remote index snapshot download at build time.
 	// If Snapshot.Store is nil, the feature is disabled and BuildIndex behaves exactly as before.
@@ -190,9 +189,9 @@ type bleveBackend struct {
 
 	indexMetrics *resource.BleveIndexMetrics
 
-	selectableFields     map[string][]string
-	searchFieldsHashes   map[string]string
-	searchFieldsProvider map[string]resource.SearchFieldsProvider
+	selectableFields     map[resource.LowerGroupResource][]string
+	searchFieldsHashes   map[resource.LowerGroupResource]string
+	searchFieldsProvider map[resource.LowerGroupResource]resource.SearchFieldsProvider
 
 	// Parsed opts.BuildVersion for snapshot tier comparisons. Nil if BuildVersion
 	// is empty. Guaranteed non-nil when opts.Snapshot.Store is set.
@@ -752,7 +751,7 @@ func (b *bleveBackend) BuildIndex(
 		attribute.String("reason", indexBuildReason),
 	)
 
-	sfKey := strings.ToLower(fmt.Sprintf("%s/%s", key.Group, key.Resource))
+	sfKey := resource.NewLowerGroupResource(key.Group, key.Resource)
 	selectableFields := b.selectableFields[sfKey]
 	searchFieldsHash := b.searchFieldsHashes[sfKey]
 	searchFieldsProvider := b.searchFieldsProvider[sfKey]

--- a/pkg/storage/unified/search/bleve_lifecycle_test.go
+++ b/pkg/storage/unified/search/bleve_lifecycle_test.go
@@ -276,8 +276,8 @@ func newFileBackedDashboardIndex(t *testing.T, key resource.NamespacedResource, 
 	})
 	require.NoError(t, err)
 
-	backend, _ := setupBleveBackend(t, withFileThreshold(0), withSearchFieldsProvidersForKinds(map[string]resource.SearchFieldsProvider{
-		"dashboard.grafana.app/dashboards": info.SearchFieldsProvider,
+	backend, _ := setupBleveBackend(t, withFileThreshold(0), withSearchFieldsProvidersForKinds(map[resource.LowerGroupResource]resource.SearchFieldsProvider{
+		resource.NewLowerGroupResource("dashboard.grafana.app", "dashboards"): info.SearchFieldsProvider,
 	}))
 	ctx := identity.WithRequester(t.Context(), &user.SignedInUser{Namespace: key.Namespace})
 

--- a/pkg/storage/unified/search/bleve_performance_test.go
+++ b/pkg/storage/unified/search/bleve_performance_test.go
@@ -73,8 +73,8 @@ func benchmarkBuildIndex(b *testing.B, docs int, fileThreshold int64) {
 		Root:          b.TempDir(),
 		FileThreshold: fileThreshold,
 		BuildVersion:  "12.3.45-789",
-		SearchFieldsProvidersForKinds: map[string]resource.SearchFieldsProvider{
-			"dashboard.grafana.app/dashboards": info.SearchFieldsProvider,
+		SearchFieldsProvidersForKinds: map[resource.LowerGroupResource]resource.SearchFieldsProvider{
+			resource.NewLowerGroupResource("dashboard.grafana.app", "dashboards"): info.SearchFieldsProvider,
 		},
 	}, nil)
 	require.NoError(b, err)

--- a/pkg/storage/unified/search/bleve_search_test.go
+++ b/pkg/storage/unified/search/bleve_search_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"strings"
 	"testing"
 	"time"
 
@@ -675,8 +674,8 @@ func newTestDashboardsIndex(t testing.TB, threshold int64, size int64, writer re
 	backend, err := search.NewBleveBackend(search.BleveOptions{
 		Root:          t.TempDir(),
 		FileThreshold: threshold, // use in-memory for tests
-		SearchFieldsProvidersForKinds: map[string]resource.SearchFieldsProvider{
-			"dashboard.grafana.app/dashboards": info.SearchFieldsProvider,
+		SearchFieldsProvidersForKinds: map[resource.LowerGroupResource]resource.SearchFieldsProvider{
+			resource.NewLowerGroupResource("dashboard.grafana.app", "dashboards"): info.SearchFieldsProvider,
 		},
 	}, nil)
 	require.NoError(t, err)
@@ -714,12 +713,12 @@ func newTestIndexWithFields(t testing.TB, key resource.NamespacedResource, colum
 		map[apischema.GroupVersionResource][]resource.SearchFieldDefinition{gvr: sfds},
 		map[apischema.GroupResource]string{gvr.GroupResource(): gvr.Version},
 	)
-	sfKey := strings.ToLower(key.Group + "/" + key.Resource)
+	sfKey := resource.NewLowerGroupResource(key.Group, key.Resource)
 
 	backend, err := search.NewBleveBackend(search.BleveOptions{
 		Root:                          t.TempDir(),
 		FileThreshold:                 threshold,
-		SearchFieldsProvidersForKinds: map[string]resource.SearchFieldsProvider{sfKey: provider},
+		SearchFieldsProvidersForKinds: map[resource.LowerGroupResource]resource.SearchFieldsProvider{sfKey: provider},
 	}, nil)
 	require.NoError(t, err)
 	t.Cleanup(backend.Stop)
@@ -783,8 +782,8 @@ func TestIndexAndSearchSelectableFields(t *testing.T) {
 	backend, err := search.NewBleveBackend(search.BleveOptions{
 		Root:          t.TempDir(),
 		FileThreshold: threshold, // use in-memory for tests
-		SelectableFieldsForKinds: map[string][]string{
-			strings.ToLower(key.Group + "/" + key.Resource): {"spec.some.field", "spec.some.other.field"},
+		SelectableFieldsForKinds: map[resource.LowerGroupResource][]string{
+			resource.NewLowerGroupResource(key.Group, key.Resource): {"spec.some.field", "spec.some.other.field"},
 		},
 	}, nil)
 	require.NoError(t, err)
@@ -1025,8 +1024,8 @@ func newTestDashboardsIndexPostRankWithConfig(t testing.TB, size int64, cfg sear
 		FileThreshold:        threshold, // use in-memory for tests
 		PostRankAuthzEnabled: true,
 		PostRankAuthz:        cfg,
-		SearchFieldsProvidersForKinds: map[string]resource.SearchFieldsProvider{
-			"dashboard.grafana.app/dashboards": info.SearchFieldsProvider,
+		SearchFieldsProvidersForKinds: map[resource.LowerGroupResource]resource.SearchFieldsProvider{
+			resource.NewLowerGroupResource("dashboard.grafana.app", "dashboards"): info.SearchFieldsProvider,
 		},
 	}, nil)
 	require.NoError(t, err)

--- a/pkg/storage/unified/search/bleve_test.go
+++ b/pkg/storage/unified/search/bleve_test.go
@@ -9,7 +9,6 @@ import (
 	"math"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -59,8 +58,8 @@ func TestBleveBackend(t *testing.T) {
 	backend, err := NewBleveBackend(BleveOptions{
 		Root:          tmpdir,
 		FileThreshold: 5, // with more than 5 items we create a file on disk
-		SearchFieldsProvidersForKinds: map[string]resource.SearchFieldsProvider{
-			"dashboard.grafana.app/dashboards": dashInfo.SearchFieldsProvider,
+		SearchFieldsProvidersForKinds: map[resource.LowerGroupResource]resource.SearchFieldsProvider{
+			resource.NewLowerGroupResource("dashboard.grafana.app", "dashboards"): dashInfo.SearchFieldsProvider,
 		},
 	}, nil)
 	require.NoError(t, err)
@@ -81,8 +80,8 @@ func TestBleveSearchRootFolderExpansion(t *testing.T) {
 	backend, err := NewBleveBackend(BleveOptions{
 		Root:          tmpdir,
 		FileThreshold: 5,
-		SearchFieldsProvidersForKinds: map[string]resource.SearchFieldsProvider{
-			"dashboard.grafana.app/dashboards": dashInfo.SearchFieldsProvider,
+		SearchFieldsProvidersForKinds: map[resource.LowerGroupResource]resource.SearchFieldsProvider{
+			resource.NewLowerGroupResource("dashboard.grafana.app", "dashboards"): dashInfo.SearchFieldsProvider,
 		},
 	}, nil)
 	require.NoError(t, err)
@@ -1114,13 +1113,13 @@ func withIndexMinUpdateInterval(d time.Duration) setupOption {
 	}
 }
 
-func withSearchFieldsHashesForKinds(m map[string]string) setupOption {
+func withSearchFieldsHashesForKinds(m map[resource.LowerGroupResource]string) setupOption {
 	return func(options *BleveOptions) {
 		options.SearchFieldsHashesForKinds = m
 	}
 }
 
-func withSearchFieldsProvidersForKinds(m map[string]resource.SearchFieldsProvider) setupOption {
+func withSearchFieldsProvidersForKinds(m map[resource.LowerGroupResource]resource.SearchFieldsProvider) setupOption {
 	return func(options *BleveOptions) {
 		options.SearchFieldsProvidersForKinds = m
 	}
@@ -2212,8 +2211,8 @@ func TestIndexBuildInfoSearchFieldsHashRoundTrip(t *testing.T) {
 		Resource:  "resource",
 	}
 	hash := "deadbeefcafef00d"
-	hashes := map[string]string{
-		strings.ToLower(ns.Group + "/" + ns.Resource): hash,
+	hashes := map[resource.LowerGroupResource]string{
+		resource.NewLowerGroupResource(ns.Group, ns.Resource): hash,
 	}
 
 	be, _ := setupBleveBackend(t, withFileThreshold(100), withSearchFieldsHashesForKinds(hashes))

--- a/pkg/storage/unified/search/options.go
+++ b/pkg/storage/unified/search/options.go
@@ -89,8 +89,8 @@ func NewSearchOptions(
 		// docs is optional in some tests; only consult it when present so the
 		// hash check is a no-op rather than a nil deref. Real callers always
 		// pass a non-nil supplier.
-		var searchFieldsHashes map[string]string
-		var searchFieldsProviders map[string]resource.SearchFieldsProvider
+		var searchFieldsHashes map[resource.LowerGroupResource]string
+		var searchFieldsProviders map[resource.LowerGroupResource]resource.SearchFieldsProvider
 		if docs != nil {
 			builders, err := docs.GetDocumentBuilders()
 			if err != nil {


### PR DESCRIPTION
The three maps that drive search indexing — the search-fields provider, the selectable fields, and the expected per-kind hashes — were keyed by a lower-cased "group/resource" string built inline at every call site. This replaces that with a small `LowerGroupResource` key type (a distinct `schema.GroupResource`) built through a single `NewLowerGroupResource` constructor that applies the lower-casing in one place.

Group and resource names are lower-case by convention but not actually enforced by our request validation, so the constructor keeps lookups case-insensitive. Making it a distinct type rather than an alias means a raw `schema.GroupResource` can't be used as a key by accident. No behaviour change.

Part of grafana/search-and-storage-team#827.
