### PR TITLE
Unified storage: stop test backends to avoid SQLite contention

### DIFF
--- a/pkg/storage/unified/testing/storage_backend.go
+++ b/pkg/storage/unified/testing/storage_backend.go
@@ -107,7 +107,14 @@ func RunStorageBackendTest(t *testing.T, newBackend NewBackendFunc, opts *TestOp
 				t.Skip()
 			}
 
-			tc.fn(t, newBackend(context.Background()), opts.NSPrefix)
+			backend := newBackend(context.Background())
+			// Stop background goroutines when the case ends so they don't keep
+			// writing to the (SQLite) DB and contend with later cases.
+			if s, ok := backend.(resource.ResourceServerStopper); ok {
+				t.Cleanup(func() { _ = s.Stop(context.Background()) })
+			}
+
+			tc.fn(t, backend, opts.NSPrefix)
 		})
 	}
 }


### PR DESCRIPTION
**What is this feature?**

Test-only fix. `RunStorageBackendTest` created a `StorageBackend` per case but never stopped it, so each backend's background goroutines (pruner, GC, tenant deleter, lease renewal) kept writing to its SQLite DB while later cases ran. Now each backend is stopped on its subtest cleanup.

**Why do we need this feature?**

The leaked writers contended on SQLite and surfaced a flaky `SQLITE_BUSY` in `TestIntegrationSQLKVStorageBackend` ([failed job](https://github.com/grafana/grafana/actions/runs/29283625737/job/86930649950)).

