### PR TITLE
Log elapsed time needed to get resource stats from storage.

### DIFF
--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -1127,7 +1127,10 @@ func (s *searchServer) startupIndexStats(ctx context.Context) ([]ResourceStats, 
 		s.log.FromContext(ctx).Debug("open index stats unavailable, falling back to resource stats")
 	}
 
-	return s.storage.GetResourceStats(ctx, NamespacedResource{}, s.initMinSize)
+	start := time.Now()
+	stats, err = s.storage.GetResourceStats(ctx, NamespacedResource{}, s.initMinSize)
+	s.log.Debug("startupIndexStats: got resource stats from storage", "elapsed", time.Since(start).String(), "stats", len(stats), "err", err)
+	return stats, err
 }
 
 func (s *searchServer) buildIndexes(ctx context.Context) (int, error) {


### PR DESCRIPTION
Log how long it takes to get resource stats from storage on startup (when we can't reuse cache).