### PR TITLE
Dashboard Migration: Fix stack overflow in v16 when panel span exceeds grid width

### DIFF
--- a/apps/dashboard/pkg/migration/schemaversion/v16.go
+++ b/apps/dashboard/pkg/migration/schemaversion/v16.go
@@ -149,7 +149,7 @@ func upgradeToGridLayout(dashboard map[string]interface{}) {
 
 			panelWidth, panelHeight := calculatePanelDimensionsFromSpan(span, panel, widthFactor, rowGridHeight)
 
-			panelPos := rowArea.getPanelPosition(panelHeight, panelWidth)
+			panelPos := rowArea.getPanelPosition(panelHeight, panelWidth, false)
 			yPos = rowArea.yPos
 
 			// Set gridPos (lines 1072-1077 in TS)
@@ -228,7 +228,7 @@ func (r *rowArea) addPanel(gridPos map[string]interface{}) {
 	}
 }
 
-func (r *rowArea) getPanelPosition(panelHeight int, panelWidth int) map[string]interface{} {
+func (r *rowArea) getPanelPosition(panelHeight int, panelWidth int, callOnce bool) map[string]interface{} {
 	var startPlace, endPlace int
 	found := false
 
@@ -264,10 +264,18 @@ func (r *rowArea) getPanelPosition(panelHeight int, panelWidth int) map[string]i
 		}
 	}
 
-	// Wrap to next row
-	r.yPos += r.height
-	r.reset()
-	return r.getPanelPosition(panelHeight, panelWidth)
+	// Wrap to next row, but only once. Matches the frontend's callOnce guard
+	// (DashboardMigrator.ts). Without it, a panel too wide to ever fit the grid
+	// (e.g. span > 12, yielding panelWidth > gridColumnCount) recurses forever.
+	if !callOnce {
+		r.yPos += r.height
+		r.reset()
+		return r.getPanelPosition(panelHeight, panelWidth, true)
+	}
+
+	// Panel cannot be placed; return nil like the frontend returns null. The
+	// caller reads x/y via GetIntValue, which falls back to 0 for a nil map.
+	return nil
 }
 
 func getMaxPanelID(dashboard map[string]interface{}, rows []interface{}) int {

--- a/apps/dashboard/pkg/migration/schemaversion/v16_test.go
+++ b/apps/dashboard/pkg/migration/schemaversion/v16_test.go
@@ -1851,6 +1851,54 @@ func TestV16(t *testing.T) {
 				},
 			},
 		},
+		{
+			// span > 12 yields panelWidth > gridColumnCount, so the panel can never
+			// fit the row area. Previously this recursed forever in getPanelPosition
+			// and overflowed the stack; now placement gives up after one wrap.
+			name: "should not overflow the stack when a panel span exceeds the grid width",
+			input: map[string]interface{}{
+				"schemaVersion": 15,
+				"rows": []interface{}{
+					map[string]interface{}{
+						"collapse":  false,
+						"showTitle": true,
+						"title":     "Hosted Exporters API",
+						"panels": []interface{}{
+							map[string]interface{}{
+								"id":    2,
+								"type":  "table",
+								"span":  24,
+								"title": "Clusters",
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"schemaVersion": 16,
+				"panels": []interface{}{
+					map[string]interface{}{
+						"id":    2,
+						"type":  "table",
+						"title": "Clusters",
+						"gridPos": map[string]interface{}{
+							"x": 0, "y": 8, "w": 48, "h": 7,
+						},
+					},
+					map[string]interface{}{
+						"id":        3,
+						"type":      "row",
+						"title":     "Hosted Exporters API",
+						"collapsed": false,
+						"repeat":    "",
+						"panels":    []interface{}{},
+						"gridPos": map[string]interface{}{
+							"x": 0, "y": 0, "w": 24, "h": 7,
+						},
+					},
+				},
+			},
+		},
 	}
 
 	runMigrationTests(t, tests, schemaversion.V16)


### PR DESCRIPTION
## What this PR does

Fixes a stack overflow in the v14→v16 dashboard schema migration when a legacy row panel has a `span` greater than 12.

### Root cause

For a `span` of, e.g., 24, the migration computes `panelWidth = floor(span) × widthFactor = 24 × 2 = 48`, which is wider than the 24-column grid. Such a panel can never satisfy the fit check in `getPanelPosition`, so the wrap-to-next-row branch recursed **unconditionally** and overflowed the stack (`fatal error: stack overflow`).

### Fix

Restores the `callOnce` guard from the frontend reference (`DashboardMigrator.ts`): `getPanelPosition` now wraps at most once, then returns `nil` (mirroring the frontend's `null`). The caller reads `x`/`y` via `GetIntValue`, which safely falls back to `0` for a nil map, so the migration completes instead of crashing.

### Testing

- Added a regression test reproducing the crash (panel with `span: 24`).
- All existing `TestV16` cases and the full `apps/dashboard/pkg/migration/...` suite pass; `go vet` is clean.
