### PR TITLE
Chore: update enterprise imports

### DIFF
--- a/pkg/extensions/enterprise_imports_test.go
+++ b/pkg/extensions/enterprise_imports_test.go
@@ -6,6 +6,7 @@
 package extensions
 
 import (
+	_ "github.com/DATA-DOG/go-sqlmock"
 	_ "github.com/alicebob/miniredis/v2"
 	_ "github.com/google/go-github/v82/github"
 	_ "github.com/grafana/authlib/authz/proto/v1"
@@ -51,6 +52,7 @@ import (
 	_ "github.com/grafana/grafana/pkg/tests/testsuite"
 	_ "github.com/grafana/grafana/pkg/util/testutil"
 	_ "github.com/grafana/grafana/pkg/util/testutil/pgtest"
+	_ "github.com/grafana/grafana/pkg/util/xorm/core"
 	_ "github.com/grafana/grafana/pkg/web/webtest"
 	_ "github.com/jackc/pgx/v5"
 	_ "github.com/migueleliasweb/go-github-mock/src/mock"


### PR DESCRIPTION
## Summary

Updates the generated enterprise imports list after adding enterprise-only test dependencies.

Enterprise companion PR: https://github.com/grafana/grafana-enterprise/pull/12654

## Testing

- `make update-workspace`
