### PR TITLE
Generate immutable per-datasource grafanaExternalId for Grafana Assume Role

### DIFF
--- a/docs/sources/datasources/aws-cloudwatch/aws-authentication/index.md
+++ b/docs/sources/datasources/aws-cloudwatch/aws-authentication/index.md
@@ -126,7 +126,7 @@ Grafana Assume Role is only available in Grafana Cloud for Amazon CloudWatch and
 
 The Grafana Assume Role authentication provider lets you access AWS without creating or managing long-term AWS IAM users or rotating access keys. Instead, you can create an IAM role that has permissions to access CloudWatch and trusts a Grafana AWS account.
 
-The Grafana AWS account then makes a Security Token Service (STS) request to generate temporary credentials for your AWS data. This request includes an `externalID` shown in the data source settings (stack-level for legacy data sources, or unique to the data source when that feature is enabled), which ensures that only trusted callers can assume the role.
+The Grafana AWS account then makes a Security Token Service (STS) request to generate temporary credentials for your AWS data. This request includes an `externalID` unique to your Grafana Cloud account, which ensures users can access only their own AWS resources.
 
 For more information, refer to the [AWS documentation on external ID](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html).
 
@@ -135,7 +135,7 @@ To use the Grafana Assume Role:
 1. Create a new CloudWatch data source (or update an existing one) and select **Grafana Assume Role** as an authentication provider.
 2. In the AWS Console, create a new IAM role, and under **Trusted entity type**, select **Another AWS account** as the trusted Entity.
 3. Enter the Grafana account id (displayed in the instructions box on the **Settings** tab of the CloudWatch data source configuration) and check the **Require external ID** box.
-4. Enter the external ID specified in the instructions box on the **Settings** tab of the CloudWatch data source configuration in Grafana. Use the value shown for this data source (stack-level for legacy data sources; a per-data-source ID when that feature is enabled).
+4. Enter the external ID specified in the instructions box on the **Settings** tab of the CloudWatch data source configuration in Grafana. This external ID will be unique to your Grafana instance.
 5. Attach any required permissions you would like Grafana to be able to access on your behalf (for example, CloudWatch Logs and CloudWatch Metrics policies).
 6. Give the role a name and description, and click **Create role**.
 7. Copy the ARN of the role you just created and paste it into the **Assume Role ARN** field on the **Settings** tab of CloudWatch data source configuration in Grafana.
@@ -154,7 +154,7 @@ To use the Grafana Assume Role:
             "Action": "sts:AssumeRole",
             "Condition": {
                 "StringEquals": {
-                    "sts:ExternalId": {External ID shown for this data source}
+                    "sts:ExternalId": {External ID unique to your account}
                 }
             }
         }

--- a/docs/sources/datasources/aws-cloudwatch/aws-authentication/index.md
+++ b/docs/sources/datasources/aws-cloudwatch/aws-authentication/index.md
@@ -126,7 +126,7 @@ Grafana Assume Role is only available in Grafana Cloud for Amazon CloudWatch and
 
 The Grafana Assume Role authentication provider lets you access AWS without creating or managing long-term AWS IAM users or rotating access keys. Instead, you can create an IAM role that has permissions to access CloudWatch and trusts a Grafana AWS account.
 
-The Grafana AWS account then makes a Security Token Service (STS) request to generate temporary credentials for your AWS data. This request includes an `externalID` unique to the data source, which ensures that only that data source can assume the trusted role.
+The Grafana AWS account then makes a Security Token Service (STS) request to generate temporary credentials for your AWS data. This request includes an `externalID` shown in the data source settings (stack-level for legacy data sources, or unique to the data source when that feature is enabled), which ensures that only trusted callers can assume the role.
 
 For more information, refer to the [AWS documentation on external ID](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html).
 
@@ -135,7 +135,7 @@ To use the Grafana Assume Role:
 1. Create a new CloudWatch data source (or update an existing one) and select **Grafana Assume Role** as an authentication provider.
 2. In the AWS Console, create a new IAM role, and under **Trusted entity type**, select **Another AWS account** as the trusted Entity.
 3. Enter the Grafana account id (displayed in the instructions box on the **Settings** tab of the CloudWatch data source configuration) and check the **Require external ID** box.
-4. Enter the external ID specified in the instructions box on the **Settings** tab of the CloudWatch data source configuration in Grafana. This external ID is unique to the data source.
+4. Enter the external ID specified in the instructions box on the **Settings** tab of the CloudWatch data source configuration in Grafana. Use the value shown for this data source (stack-level for legacy data sources; a per-data-source ID when that feature is enabled).
 5. Attach any required permissions you would like Grafana to be able to access on your behalf (for example, CloudWatch Logs and CloudWatch Metrics policies).
 6. Give the role a name and description, and click **Create role**.
 7. Copy the ARN of the role you just created and paste it into the **Assume Role ARN** field on the **Settings** tab of CloudWatch data source configuration in Grafana.
@@ -154,7 +154,7 @@ To use the Grafana Assume Role:
             "Action": "sts:AssumeRole",
             "Condition": {
                 "StringEquals": {
-                    "sts:ExternalId": {External ID unique to your data source}
+                    "sts:ExternalId": {External ID shown for this data source}
                 }
             }
         }

--- a/docs/sources/datasources/aws-cloudwatch/aws-authentication/index.md
+++ b/docs/sources/datasources/aws-cloudwatch/aws-authentication/index.md
@@ -126,7 +126,7 @@ Grafana Assume Role is only available in Grafana Cloud for Amazon CloudWatch and
 
 The Grafana Assume Role authentication provider lets you access AWS without creating or managing long-term AWS IAM users or rotating access keys. Instead, you can create an IAM role that has permissions to access CloudWatch and trusts a Grafana AWS account.
 
-The Grafana AWS account then makes a Security Token Service (STS) request to generate temporary credentials for your AWS data. This request includes an `externalID` unique to your Grafana Cloud account, which ensures users can access only their own AWS resources.
+The Grafana AWS account then makes a Security Token Service (STS) request to generate temporary credentials for your AWS data. This request includes an `externalID` unique to the data source, which ensures that only that data source can assume the trusted role.
 
 For more information, refer to the [AWS documentation on external ID](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html).
 
@@ -135,7 +135,7 @@ To use the Grafana Assume Role:
 1. Create a new CloudWatch data source (or update an existing one) and select **Grafana Assume Role** as an authentication provider.
 2. In the AWS Console, create a new IAM role, and under **Trusted entity type**, select **Another AWS account** as the trusted Entity.
 3. Enter the Grafana account id (displayed in the instructions box on the **Settings** tab of the CloudWatch data source configuration) and check the **Require external ID** box.
-4. Enter the external ID specified in the instructions box on the **Settings** tab of the CloudWatch data source configuration in Grafana. This external ID will be unique to your Grafana instance.
+4. Enter the external ID specified in the instructions box on the **Settings** tab of the CloudWatch data source configuration in Grafana. This external ID is unique to the data source.
 5. Attach any required permissions you would like Grafana to be able to access on your behalf (for example, CloudWatch Logs and CloudWatch Metrics policies).
 6. Give the role a name and description, and click **Create role**.
 7. Copy the ARN of the role you just created and paste it into the **Assume Role ARN** field on the **Settings** tab of CloudWatch data source configuration in Grafana.
@@ -154,7 +154,7 @@ To use the Grafana Assume Role:
             "Action": "sts:AssumeRole",
             "Condition": {
                 "StringEquals": {
-                    "sts:ExternalId": {External ID unique to your account}
+                    "sts:ExternalId": {External ID unique to your data source}
                 }
             }
         }

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -109,6 +109,11 @@ export interface FeatureToggles {
   */
   awsDatasourcesTempCredentials?: boolean;
   /**
+  * Generate a per-datasource external ID for Grafana Assume Role (jsonData.grafanaExternalId). When disabled, new datasources keep using the stack-level external ID.
+  * @default false
+  */
+  awsAssumeRolePerDatasourceExternalId?: boolean;
+  /**
   * Enable support for Machine Learning in server-side expressions
   * @default false
   */

--- a/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
@@ -14,6 +14,7 @@ declare module "@openfeature/core" {
     | "faroSessionReplay"
     | "queryHistory.localOnly"
     | "queryHistory.recentQueriesUI"
+    | "awsAssumeRolePerDatasourceExternalId"
     | "provisioningFolderMetadata"
     | "provisioning.readmes"
     | "provisioning.gitConventions"

--- a/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
@@ -19,6 +19,8 @@ export const FlagKeys = {
   AnalyticsFramework: "analyticsFramework",
   /** Enables the template dashboard assistant */
   AssistantFrontendToolsDashboardTemplates: "assistant.frontend.tools.dashboardTemplates",
+  /** Generate a per-datasource external ID for Grafana Assume Role (jsonData.grafanaExternalId). When disabled, new datasources keep using the stack-level external ID. */
+  AwsAssumeRolePerDatasourceExternalId: "awsAssumeRolePerDatasourceExternalId",
   /** Exposes the semantic (vector) search endpoint for dashboards under the dashboard API */
   DashboardVectorSearch: "dashboard.vectorSearch",
   /** Enables support for section level variables (rows and tabs) */
@@ -160,6 +162,17 @@ export const useFlagAnalyticsFramework = (options?: ReactFlagEvaluationOptions):
  */
 export const useFlagAssistantFrontendToolsDashboardTemplates = (options?: ReactFlagEvaluationOptions): boolean => {
   return useFlag("assistant.frontend.tools.dashboardTemplates", false, options).value;
+};
+
+/**
+ * Generate a per-datasource external ID for Grafana Assume Role (jsonData.grafanaExternalId). When disabled, new datasources keep using the stack-level external ID.
+ *
+ * **Details:**
+ * - flag key: `awsAssumeRolePerDatasourceExternalId`
+ * - default value: `false`
+ */
+export const useFlagAwsAssumeRolePerDatasourceExternalId = (options?: ReactFlagEvaluationOptions): boolean => {
+  return useFlag("awsAssumeRolePerDatasourceExternalId", false, options).value;
 };
 
 /**

--- a/pkg/services/datasources/service/aws_external_id.go
+++ b/pkg/services/datasources/service/aws_external_id.go
@@ -25,12 +25,33 @@ func isValidGrafanaExternalID(id, stackExternalID, datasourceUID string) bool {
 	return id == buildGrafanaExternalID(stackExternalID, datasourceUID)
 }
 
-// ensureGrafanaExternalID sets a per-datasource external ID on create.
-// If the client already supplied a valid ID for this stack+UID (pre-save UX), it is kept.
-// Otherwise a new ID is generated. Invalid client values are replaced.
-// Gated on authType only — plugin allowlists live in enterprise dsauth / aws-sdk-react UI.
-func ensureGrafanaExternalID(uid, stackExternalID string, jsonData *simplejson.Json) {
+// clearInvalidGrafanaExternalID removes a client- or store-supplied grafanaExternalId that is
+// not bound to this datasource. Dual-read always prefers a set grafanaExternalId for STS, so
+// invalid values must never be persisted regardless of the minting feature toggle.
+func clearInvalidGrafanaExternalID(uid, stackExternalID string, jsonData *simplejson.Json) {
 	if jsonData == nil {
+		return
+	}
+	id := jsonData.Get(grafanaExternalIDJSONKey).MustString()
+	if id == "" {
+		return
+	}
+	if !isValidGrafanaExternalID(id, stackExternalID, uid) {
+		jsonData.Del(grafanaExternalIDJSONKey)
+	}
+}
+
+// ensureGrafanaExternalID validates (and clears) any client-supplied grafanaExternalId on create.
+// When allowGenerate is true and auth is grafana_assume_role, it mints {stack}-{uid} if the field
+// is empty after validation. If the client already supplied a valid ID (pre-save UX), it is kept.
+func ensureGrafanaExternalID(uid, stackExternalID string, jsonData *simplejson.Json, allowGenerate bool) {
+	if jsonData == nil {
+		return
+	}
+
+	clearInvalidGrafanaExternalID(uid, stackExternalID, jsonData)
+
+	if !allowGenerate {
 		return
 	}
 	if jsonData.Get("authType").MustString() != grafanaAssumeRoleAuthType {
@@ -39,23 +60,26 @@ func ensureGrafanaExternalID(uid, stackExternalID string, jsonData *simplejson.J
 	if stackExternalID == "" || uid == "" {
 		return
 	}
-
-	existing := jsonData.Get(grafanaExternalIDJSONKey).MustString()
-	if isValidGrafanaExternalID(existing, stackExternalID, uid) {
+	if jsonData.Get(grafanaExternalIDJSONKey).MustString() != "" {
 		return
 	}
 
 	jsonData.Set(grafanaExternalIDJSONKey, buildGrafanaExternalID(stackExternalID, uid))
 }
 
-// preserveGrafanaExternalID keeps an existing per-datasource external ID
-// immutable across updates, and generates one when switching to grafana_assume_role.
-// Legacy grafana_assume_role datasources without an ID keep using the stack-level
-// fallback until explicitly migrated — we do not generate on ordinary updates.
-func preserveGrafanaExternalID(uid, stackExternalID string, existing, updated *simplejson.Json) {
+// preserveGrafanaExternalID keeps a valid existing per-datasource external ID immutable across updates,
+// scrubs invalid stored or client-supplied values, and optionally mints when switching into
+// grafana_assume_role (when allowGenerate is true).
+//
+// Legacy grafana_assume_role datasources without an ID keep using the stack-level fallback until
+// explicitly migrated — we do not generate on ordinary updates.
+func preserveGrafanaExternalID(uid, stackExternalID string, existing, updated *simplejson.Json, allowGenerate bool) {
 	if updated == nil {
 		return
 	}
+
+	// Never persist a stolen / mismatched ID from the update payload.
+	clearInvalidGrafanaExternalID(uid, stackExternalID, updated)
 
 	existingID := ""
 	existingAuthType := ""
@@ -63,14 +87,23 @@ func preserveGrafanaExternalID(uid, stackExternalID string, existing, updated *s
 		existingID = existing.Get(grafanaExternalIDJSONKey).MustString()
 		existingAuthType = existing.Get("authType").MustString()
 	}
-	updatedAuthType := updated.Get("authType").MustString()
 
 	if existingID != "" {
-		// Immutable once set.
-		updated.Set(grafanaExternalIDJSONKey, existingID)
+		if isValidGrafanaExternalID(existingID, stackExternalID, uid) {
+			// Immutable once set (even when generation is feature-flagged off).
+			updated.Set(grafanaExternalIDJSONKey, existingID)
+			return
+		}
+		// Scrub planted values already in the store so STS falls back to the stack ID.
+		updated.Del(grafanaExternalIDJSONKey)
+		existingID = ""
+	}
+
+	if !allowGenerate {
 		return
 	}
 
+	updatedAuthType := updated.Get("authType").MustString()
 	if updatedAuthType != grafanaAssumeRoleAuthType {
 		return
 	}
@@ -83,8 +116,7 @@ func preserveGrafanaExternalID(uid, stackExternalID string, existing, updated *s
 		return
 	}
 
-	clientID := updated.Get(grafanaExternalIDJSONKey).MustString()
-	if isValidGrafanaExternalID(clientID, stackExternalID, uid) {
+	if updated.Get(grafanaExternalIDJSONKey).MustString() != "" {
 		return
 	}
 

--- a/pkg/services/datasources/service/aws_external_id.go
+++ b/pkg/services/datasources/service/aws_external_id.go
@@ -1,0 +1,92 @@
+package service
+
+import (
+	"github.com/grafana/grafana/pkg/components/simplejson"
+)
+
+const (
+	grafanaAssumeRoleAuthType = "grafana_assume_role"
+	grafanaExternalIDJSONKey  = "grafanaExternalId"
+)
+
+// buildGrafanaExternalID returns "{stackExternalId}-{dsUID}".
+// The stack prefix keeps IDs unique across Cloud stacks (UIDs alone are only unique per org).
+// The datasource UID binds the ID to this datasource so a copied ID from another DS fails validation.
+func buildGrafanaExternalID(stackExternalID, datasourceUID string) string {
+	return stackExternalID + "-" + datasourceUID
+}
+
+// isValidGrafanaExternalID reports whether id is bound to this stack + datasource UID.
+// Equality is used instead of splitting on "-" because stack IDs and UIDs may contain dashes.
+func isValidGrafanaExternalID(id, stackExternalID, datasourceUID string) bool {
+	if id == "" || stackExternalID == "" || datasourceUID == "" {
+		return false
+	}
+	return id == buildGrafanaExternalID(stackExternalID, datasourceUID)
+}
+
+// ensureGrafanaExternalID sets a per-datasource external ID on create.
+// If the client already supplied a valid ID for this stack+UID (pre-save UX), it is kept.
+// Otherwise a new ID is generated. Invalid client values are replaced.
+// Gated on authType only — plugin allowlists live in enterprise dsauth / aws-sdk-react UI.
+func ensureGrafanaExternalID(uid, stackExternalID string, jsonData *simplejson.Json) {
+	if jsonData == nil {
+		return
+	}
+	if jsonData.Get("authType").MustString() != grafanaAssumeRoleAuthType {
+		return
+	}
+	if stackExternalID == "" || uid == "" {
+		return
+	}
+
+	existing := jsonData.Get(grafanaExternalIDJSONKey).MustString()
+	if isValidGrafanaExternalID(existing, stackExternalID, uid) {
+		return
+	}
+
+	jsonData.Set(grafanaExternalIDJSONKey, buildGrafanaExternalID(stackExternalID, uid))
+}
+
+// preserveGrafanaExternalID keeps an existing per-datasource external ID
+// immutable across updates, and generates one when switching to grafana_assume_role.
+// Legacy grafana_assume_role datasources without an ID keep using the stack-level
+// fallback until explicitly migrated — we do not generate on ordinary updates.
+func preserveGrafanaExternalID(uid, stackExternalID string, existing, updated *simplejson.Json) {
+	if updated == nil {
+		return
+	}
+
+	existingID := ""
+	existingAuthType := ""
+	if existing != nil {
+		existingID = existing.Get(grafanaExternalIDJSONKey).MustString()
+		existingAuthType = existing.Get("authType").MustString()
+	}
+	updatedAuthType := updated.Get("authType").MustString()
+
+	if existingID != "" {
+		// Immutable once set.
+		updated.Set(grafanaExternalIDJSONKey, existingID)
+		return
+	}
+
+	if updatedAuthType != grafanaAssumeRoleAuthType {
+		return
+	}
+
+	// Generate only when switching into grafana_assume_role from another auth type.
+	if existingAuthType == grafanaAssumeRoleAuthType {
+		return
+	}
+	if stackExternalID == "" || uid == "" {
+		return
+	}
+
+	clientID := updated.Get(grafanaExternalIDJSONKey).MustString()
+	if isValidGrafanaExternalID(clientID, stackExternalID, uid) {
+		return
+	}
+
+	updated.Set(grafanaExternalIDJSONKey, buildGrafanaExternalID(stackExternalID, uid))
+}

--- a/pkg/services/datasources/service/aws_external_id_test.go
+++ b/pkg/services/datasources/service/aws_external_id_test.go
@@ -18,8 +18,25 @@ func TestBuildGrafanaExternalID(t *testing.T) {
 func TestEnsureGrafanaExternalID(t *testing.T) {
 	t.Run("generates stack-uid for grafana_assume_role", func(t *testing.T) {
 		jd := simplejson.NewFromAny(map[string]any{"authType": grafanaAssumeRoleAuthType})
-		ensureGrafanaExternalID("dsUid1", "stackABC", jd)
+		ensureGrafanaExternalID("dsUid1", "stackABC", jd, true)
 		assert.Equal(t, "stackABC-dsUid1", jd.Get(grafanaExternalIDJSONKey).MustString())
+	})
+
+	t.Run("no mint when generation disabled", func(t *testing.T) {
+		jd := simplejson.NewFromAny(map[string]any{"authType": grafanaAssumeRoleAuthType})
+		ensureGrafanaExternalID("dsUid1", "stackABC", jd, false)
+		assert.Empty(t, jd.Get(grafanaExternalIDJSONKey).MustString())
+	})
+
+	t.Run("clears stolen ID even when generation disabled", func(t *testing.T) {
+		// Hole 1: FT off must not be a full no-op — dual-read would otherwise use a planted ID.
+		stolen := "stackABC-otherUid"
+		jd := simplejson.NewFromAny(map[string]any{
+			"authType":               grafanaAssumeRoleAuthType,
+			grafanaExternalIDJSONKey: stolen,
+		})
+		ensureGrafanaExternalID("dsUid1", "stackABC", jd, false)
+		assert.Empty(t, jd.Get(grafanaExternalIDJSONKey).MustString())
 	})
 
 	t.Run("keeps valid client-supplied ID for pre-save UX", func(t *testing.T) {
@@ -28,7 +45,7 @@ func TestEnsureGrafanaExternalID(t *testing.T) {
 			"authType":               grafanaAssumeRoleAuthType,
 			grafanaExternalIDJSONKey: clientID,
 		})
-		ensureGrafanaExternalID("dsUid1", "stackABC", jd)
+		ensureGrafanaExternalID("dsUid1", "stackABC", jd, true)
 		assert.Equal(t, clientID, jd.Get(grafanaExternalIDJSONKey).MustString())
 	})
 
@@ -38,20 +55,32 @@ func TestEnsureGrafanaExternalID(t *testing.T) {
 			"authType":               grafanaAssumeRoleAuthType,
 			grafanaExternalIDJSONKey: stolen,
 		})
-		ensureGrafanaExternalID("dsUid1", "stackABC", jd)
+		ensureGrafanaExternalID("dsUid1", "stackABC", jd, true)
 		assert.Equal(t, "stackABC-dsUid1", jd.Get(grafanaExternalIDJSONKey).MustString())
 	})
 
-	t.Run("no-op for keys auth", func(t *testing.T) {
+	t.Run("clears stolen ID under non-GAR auth without minting", func(t *testing.T) {
+		stolen := "stackABC-otherUid"
+		jd := simplejson.NewFromAny(map[string]any{
+			"authType":               "keys",
+			"externalId":             "cross-account",
+			grafanaExternalIDJSONKey: stolen,
+		})
+		ensureGrafanaExternalID("dsUid1", "stackABC", jd, true)
+		assert.Empty(t, jd.Get(grafanaExternalIDJSONKey).MustString())
+		assert.Equal(t, "cross-account", jd.Get("externalId").MustString())
+	})
+
+	t.Run("no-op for keys auth without grafanaExternalId", func(t *testing.T) {
 		jd := simplejson.NewFromAny(map[string]any{"authType": "keys", "externalId": "cross-account"})
-		ensureGrafanaExternalID("dsUid1", "stackABC", jd)
+		ensureGrafanaExternalID("dsUid1", "stackABC", jd, true)
 		assert.Empty(t, jd.Get(grafanaExternalIDJSONKey).MustString())
 		assert.Equal(t, "cross-account", jd.Get("externalId").MustString())
 	})
 
 	t.Run("no-op when stack external ID missing", func(t *testing.T) {
 		jd := simplejson.NewFromAny(map[string]any{"authType": grafanaAssumeRoleAuthType})
-		ensureGrafanaExternalID("dsUid1", "", jd)
+		ensureGrafanaExternalID("dsUid1", "", jd, true)
 		assert.Empty(t, jd.Get(grafanaExternalIDJSONKey).MustString())
 	})
 }
@@ -66,8 +95,71 @@ func TestPreserveGrafanaExternalID(t *testing.T) {
 			"authType":               grafanaAssumeRoleAuthType,
 			grafanaExternalIDJSONKey: "stackABC-stolen",
 		})
-		preserveGrafanaExternalID("dsUid1", "stackABC", existing, updated)
+		preserveGrafanaExternalID("dsUid1", "stackABC", existing, updated, true)
 		assert.Equal(t, "stackABC-dsUid1", updated.Get(grafanaExternalIDJSONKey).MustString())
+	})
+
+	t.Run("preserves existing ID when generation disabled", func(t *testing.T) {
+		existing := simplejson.NewFromAny(map[string]any{
+			"authType":               grafanaAssumeRoleAuthType,
+			grafanaExternalIDJSONKey: "stackABC-dsUid1",
+		})
+		updated := simplejson.NewFromAny(map[string]any{
+			"authType":               grafanaAssumeRoleAuthType,
+			grafanaExternalIDJSONKey: "stackABC-stolen",
+		})
+		preserveGrafanaExternalID("dsUid1", "stackABC", existing, updated, false)
+		assert.Equal(t, "stackABC-dsUid1", updated.Get(grafanaExternalIDJSONKey).MustString())
+	})
+
+	t.Run("clears planted ID on legacy GAR update without minting", func(t *testing.T) {
+		// Hole 2: legacy GAR has no stored ID; client must not plant another DS's ID.
+		existing := simplejson.NewFromAny(map[string]any{"authType": grafanaAssumeRoleAuthType})
+		updated := simplejson.NewFromAny(map[string]any{
+			"authType":               grafanaAssumeRoleAuthType,
+			grafanaExternalIDJSONKey: "stackABC-otherUid",
+		})
+		preserveGrafanaExternalID("dsUid1", "stackABC", existing, updated, true)
+		assert.Empty(t, updated.Get(grafanaExternalIDJSONKey).MustString())
+	})
+
+	t.Run("scrubs invalid ID already stored and does not re-preserve it", func(t *testing.T) {
+		existing := simplejson.NewFromAny(map[string]any{
+			"authType":               grafanaAssumeRoleAuthType,
+			grafanaExternalIDJSONKey: "stackABC-otherUid",
+		})
+		updated := simplejson.NewFromAny(map[string]any{
+			"authType": grafanaAssumeRoleAuthType,
+		})
+		preserveGrafanaExternalID("dsUid1", "stackABC", existing, updated, true)
+		assert.Empty(t, updated.Get(grafanaExternalIDJSONKey).MustString())
+	})
+
+	t.Run("clears smuggled ID under keys then mints on switch to GAR", func(t *testing.T) {
+		// Hole 3: plant under non-GAR, then switch — must not preserve the stolen value.
+		existing := simplejson.NewFromAny(map[string]any{
+			"authType":               "keys",
+			grafanaExternalIDJSONKey: "stackABC-otherUid",
+		})
+		updated := simplejson.NewFromAny(map[string]any{
+			"authType":               grafanaAssumeRoleAuthType,
+			grafanaExternalIDJSONKey: "stackABC-otherUid",
+		})
+		preserveGrafanaExternalID("dsUid1", "stackABC", existing, updated, true)
+		assert.Equal(t, "stackABC-dsUid1", updated.Get(grafanaExternalIDJSONKey).MustString())
+	})
+
+	t.Run("clears smuggled ID on switch when generation disabled", func(t *testing.T) {
+		existing := simplejson.NewFromAny(map[string]any{
+			"authType":               "keys",
+			grafanaExternalIDJSONKey: "stackABC-otherUid",
+		})
+		updated := simplejson.NewFromAny(map[string]any{
+			"authType":               grafanaAssumeRoleAuthType,
+			grafanaExternalIDJSONKey: "stackABC-otherUid",
+		})
+		preserveGrafanaExternalID("dsUid1", "stackABC", existing, updated, false)
+		assert.Empty(t, updated.Get(grafanaExternalIDJSONKey).MustString())
 	})
 
 	t.Run("generates when switching to grafana_assume_role without touching externalId", func(t *testing.T) {
@@ -79,9 +171,22 @@ func TestPreserveGrafanaExternalID(t *testing.T) {
 			"authType":   grafanaAssumeRoleAuthType,
 			"externalId": "cross-account-id",
 		})
-		preserveGrafanaExternalID("dsUid1", "stackABC", existing, updated)
+		preserveGrafanaExternalID("dsUid1", "stackABC", existing, updated, true)
 		assert.Equal(t, "stackABC-dsUid1", updated.Get(grafanaExternalIDJSONKey).MustString())
 		assert.Equal(t, "cross-account-id", updated.Get("externalId").MustString())
+	})
+
+	t.Run("does not generate on auth switch when generation disabled", func(t *testing.T) {
+		existing := simplejson.NewFromAny(map[string]any{
+			"authType":   "keys",
+			"externalId": "cross-account-id",
+		})
+		updated := simplejson.NewFromAny(map[string]any{
+			"authType":   grafanaAssumeRoleAuthType,
+			"externalId": "cross-account-id",
+		})
+		preserveGrafanaExternalID("dsUid1", "stackABC", existing, updated, false)
+		assert.Empty(t, updated.Get(grafanaExternalIDJSONKey).MustString())
 	})
 
 	t.Run("leaves field when switching away from grafana_assume_role", func(t *testing.T) {
@@ -92,14 +197,14 @@ func TestPreserveGrafanaExternalID(t *testing.T) {
 		updated := simplejson.NewFromAny(map[string]any{
 			"authType": "keys",
 		})
-		preserveGrafanaExternalID("dsUid1", "stackABC", existing, updated)
+		preserveGrafanaExternalID("dsUid1", "stackABC", existing, updated, true)
 		assert.Equal(t, "stackABC-dsUid1", updated.Get(grafanaExternalIDJSONKey).MustString())
 	})
 
 	t.Run("does not auto-migrate legacy grafana_assume_role on update", func(t *testing.T) {
 		existing := simplejson.NewFromAny(map[string]any{"authType": grafanaAssumeRoleAuthType})
 		updated := simplejson.NewFromAny(map[string]any{"authType": grafanaAssumeRoleAuthType, "assumeRoleArn": "arn:aws:iam::123:role/x"})
-		preserveGrafanaExternalID("dsUid1", "stackABC", existing, updated)
+		preserveGrafanaExternalID("dsUid1", "stackABC", existing, updated, true)
 		assert.Empty(t, updated.Get(grafanaExternalIDJSONKey).MustString())
 	})
 }

--- a/pkg/services/datasources/service/aws_external_id_test.go
+++ b/pkg/services/datasources/service/aws_external_id_test.go
@@ -1,0 +1,105 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildGrafanaExternalID(t *testing.T) {
+	id := buildGrafanaExternalID("stack123", "P7DC3E4760")
+	assert.Equal(t, "stack123-P7DC3E4760", id)
+	assert.True(t, isValidGrafanaExternalID(id, "stack123", "P7DC3E4760"))
+	assert.False(t, isValidGrafanaExternalID(id, "otherstack", "P7DC3E4760"))
+	assert.False(t, isValidGrafanaExternalID(id, "stack123", "OTHERUID"))
+}
+
+func TestEnsureGrafanaExternalID(t *testing.T) {
+	t.Run("generates stack-uid for grafana_assume_role", func(t *testing.T) {
+		jd := simplejson.NewFromAny(map[string]any{"authType": grafanaAssumeRoleAuthType})
+		ensureGrafanaExternalID("dsUid1", "stackABC", jd)
+		assert.Equal(t, "stackABC-dsUid1", jd.Get(grafanaExternalIDJSONKey).MustString())
+	})
+
+	t.Run("keeps valid client-supplied ID for pre-save UX", func(t *testing.T) {
+		clientID := "stackABC-dsUid1"
+		jd := simplejson.NewFromAny(map[string]any{
+			"authType":               grafanaAssumeRoleAuthType,
+			grafanaExternalIDJSONKey: clientID,
+		})
+		ensureGrafanaExternalID("dsUid1", "stackABC", jd)
+		assert.Equal(t, clientID, jd.Get(grafanaExternalIDJSONKey).MustString())
+	})
+
+	t.Run("replaces ID that belongs to another datasource", func(t *testing.T) {
+		stolen := "stackABC-otherUid"
+		jd := simplejson.NewFromAny(map[string]any{
+			"authType":               grafanaAssumeRoleAuthType,
+			grafanaExternalIDJSONKey: stolen,
+		})
+		ensureGrafanaExternalID("dsUid1", "stackABC", jd)
+		assert.Equal(t, "stackABC-dsUid1", jd.Get(grafanaExternalIDJSONKey).MustString())
+	})
+
+	t.Run("no-op for keys auth", func(t *testing.T) {
+		jd := simplejson.NewFromAny(map[string]any{"authType": "keys", "externalId": "cross-account"})
+		ensureGrafanaExternalID("dsUid1", "stackABC", jd)
+		assert.Empty(t, jd.Get(grafanaExternalIDJSONKey).MustString())
+		assert.Equal(t, "cross-account", jd.Get("externalId").MustString())
+	})
+
+	t.Run("no-op when stack external ID missing", func(t *testing.T) {
+		jd := simplejson.NewFromAny(map[string]any{"authType": grafanaAssumeRoleAuthType})
+		ensureGrafanaExternalID("dsUid1", "", jd)
+		assert.Empty(t, jd.Get(grafanaExternalIDJSONKey).MustString())
+	})
+}
+
+func TestPreserveGrafanaExternalID(t *testing.T) {
+	t.Run("preserves existing ID on update", func(t *testing.T) {
+		existing := simplejson.NewFromAny(map[string]any{
+			"authType":               grafanaAssumeRoleAuthType,
+			grafanaExternalIDJSONKey: "stackABC-dsUid1",
+		})
+		updated := simplejson.NewFromAny(map[string]any{
+			"authType":               grafanaAssumeRoleAuthType,
+			grafanaExternalIDJSONKey: "stackABC-stolen",
+		})
+		preserveGrafanaExternalID("dsUid1", "stackABC", existing, updated)
+		assert.Equal(t, "stackABC-dsUid1", updated.Get(grafanaExternalIDJSONKey).MustString())
+	})
+
+	t.Run("generates when switching to grafana_assume_role without touching externalId", func(t *testing.T) {
+		existing := simplejson.NewFromAny(map[string]any{
+			"authType":   "keys",
+			"externalId": "cross-account-id",
+		})
+		updated := simplejson.NewFromAny(map[string]any{
+			"authType":   grafanaAssumeRoleAuthType,
+			"externalId": "cross-account-id",
+		})
+		preserveGrafanaExternalID("dsUid1", "stackABC", existing, updated)
+		assert.Equal(t, "stackABC-dsUid1", updated.Get(grafanaExternalIDJSONKey).MustString())
+		assert.Equal(t, "cross-account-id", updated.Get("externalId").MustString())
+	})
+
+	t.Run("leaves field when switching away from grafana_assume_role", func(t *testing.T) {
+		existing := simplejson.NewFromAny(map[string]any{
+			"authType":               grafanaAssumeRoleAuthType,
+			grafanaExternalIDJSONKey: "stackABC-dsUid1",
+		})
+		updated := simplejson.NewFromAny(map[string]any{
+			"authType": "keys",
+		})
+		preserveGrafanaExternalID("dsUid1", "stackABC", existing, updated)
+		assert.Equal(t, "stackABC-dsUid1", updated.Get(grafanaExternalIDJSONKey).MustString())
+	})
+
+	t.Run("does not auto-migrate legacy grafana_assume_role on update", func(t *testing.T) {
+		existing := simplejson.NewFromAny(map[string]any{"authType": grafanaAssumeRoleAuthType})
+		updated := simplejson.NewFromAny(map[string]any{"authType": grafanaAssumeRoleAuthType, "assumeRoleArn": "arn:aws:iam::123:role/x"})
+		preserveGrafanaExternalID("dsUid1", "stackABC", existing, updated)
+		assert.Empty(t, updated.Get(grafanaExternalIDJSONKey).MustString())
+	})
+}

--- a/pkg/services/datasources/service/datasource.go
+++ b/pkg/services/datasources/service/datasource.go
@@ -36,7 +36,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/secrets"
 	"github.com/grafana/grafana/pkg/services/secrets/kvstore"
 	"github.com/grafana/grafana/pkg/setting"
-	"github.com/grafana/grafana/pkg/util"
 )
 
 const (
@@ -391,10 +390,15 @@ func (s *Service) AddDataSource(ctx context.Context, cmd *datasources.AddDataSou
 	if cmd.JsonData == nil {
 		cmd.JsonData = simplejson.New()
 	}
-	if cmd.UID == "" {
-		cmd.UID = util.GenerateShortUID()
+	allowPerDsExternalID := s.features.IsEnabled(ctx, featuremgmt.FlagAwsAssumeRolePerDatasourceExternalId)
+	if allowPerDsExternalID && cmd.UID == "" {
+		uid, genErr := s.SQLStore.GenerateNewUID(ctx, cmd.OrgID)
+		if genErr != nil {
+			return nil, genErr
+		}
+		cmd.UID = uid
 	}
-	ensureGrafanaExternalID(cmd.UID, s.cfg.AWSExternalId, cmd.JsonData)
+	ensureGrafanaExternalID(cmd.UID, s.cfg.AWSExternalId, cmd.JsonData, allowPerDsExternalID)
 
 	var dataSource *datasources.DataSource
 	err = s.db.InTransaction(ctx, func(ctx context.Context) error {
@@ -679,7 +683,8 @@ func (s *Service) UpdateDataSource(ctx context.Context, cmd *datasources.UpdateD
 		if cmd.JsonData == nil {
 			cmd.JsonData = simplejson.New()
 		}
-		preserveGrafanaExternalID(cmd.UID, s.cfg.AWSExternalId, dataSource.JsonData, cmd.JsonData)
+		allowPerDsExternalID := s.features.IsEnabled(ctx, featuremgmt.FlagAwsAssumeRolePerDatasourceExternalId)
+		preserveGrafanaExternalID(cmd.UID, s.cfg.AWSExternalId, dataSource.JsonData, cmd.JsonData, allowPerDsExternalID)
 
 		// preserve existing lbac rules when updating datasource if we're not updating lbac rules
 		// TODO: Refactor to store lbac rules separate from a datasource

--- a/pkg/services/datasources/service/datasource.go
+++ b/pkg/services/datasources/service/datasource.go
@@ -36,6 +36,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/secrets"
 	"github.com/grafana/grafana/pkg/services/secrets/kvstore"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/util"
 )
 
 const (
@@ -387,6 +388,13 @@ func (s *Service) AddDataSource(ctx context.Context, cmd *datasources.AddDataSou
 			return nil, err
 		}
 	}
+	if cmd.JsonData == nil {
+		cmd.JsonData = simplejson.New()
+	}
+	if cmd.UID == "" {
+		cmd.UID = util.GenerateShortUID()
+	}
+	ensureGrafanaExternalID(cmd.UID, s.cfg.AWSExternalId, cmd.JsonData)
 
 	var dataSource *datasources.DataSource
 	err = s.db.InTransaction(ctx, func(ctx context.Context) error {
@@ -668,6 +676,10 @@ func (s *Service) UpdateDataSource(ctx context.Context, cmd *datasources.UpdateD
 				return err
 			}
 		}
+		if cmd.JsonData == nil {
+			cmd.JsonData = simplejson.New()
+		}
+		preserveGrafanaExternalID(cmd.UID, s.cfg.AWSExternalId, dataSource.JsonData, cmd.JsonData)
 
 		// preserve existing lbac rules when updating datasource if we're not updating lbac rules
 		// TODO: Refactor to store lbac rules separate from a datasource

--- a/pkg/services/datasources/service/store.go
+++ b/pkg/services/datasources/service/store.go
@@ -33,6 +33,9 @@ type Store interface {
 	UpdateDataSource(context.Context, *datasources.UpdateDataSourceCommand) (*datasources.DataSource, error)
 	GetAllDataSources(ctx context.Context, query *datasources.GetAllDataSourcesQuery) (res []*datasources.DataSource, err error)
 	GetPrunableProvisionedDataSources(ctx context.Context) (res []*datasources.DataSource, err error)
+	// GenerateNewUID returns an org-unique datasource UID (with the same retry
+	// behavior used when AddDataSource assigns a UID).
+	GenerateNewUID(ctx context.Context, orgID int64) (string, error)
 
 	Count(context.Context, *quota.ScopeParameters) (*quota.Map, error)
 }
@@ -441,6 +444,17 @@ func (ss *SqlStore) UpdateDataSource(ctx context.Context, cmd *datasources.Updat
 
 		return err
 	})
+}
+
+// GenerateNewUID returns an org-unique datasource UID.
+func (ss *SqlStore) GenerateNewUID(ctx context.Context, orgID int64) (string, error) {
+	var uid string
+	err := ss.db.WithDbSession(ctx, func(sess *db.Session) error {
+		var genErr error
+		uid, genErr = generateNewDatasourceUid(sess, orgID)
+		return genErr
+	})
+	return uid, err
 }
 
 func generateNewDatasourceUid(sess *db.Session, orgId int64) (string, error) {

--- a/pkg/services/datasources/service/store_test.go
+++ b/pkg/services/datasources/service/store_test.go
@@ -111,6 +111,46 @@ func TestIntegrationDataAccess(t *testing.T) {
 		})
 	})
 
+	t.Run("GenerateNewUID", func(t *testing.T) {
+		t.Run("returns an unused uid for the org", func(t *testing.T) {
+			db := db.InitTestDB(t)
+			ss := SqlStore{db: db}
+			uid, err := ss.GenerateNewUID(context.Background(), 10)
+			require.NoError(t, err)
+			require.NotEmpty(t, uid)
+
+			cmd := defaultAddDatasourceCommand
+			cmd.UID = uid
+			_, err = ss.AddDataSource(context.Background(), &cmd)
+			require.NoError(t, err)
+		})
+
+		t.Run("retries when a generated uid already exists", func(t *testing.T) {
+			db := db.InitTestDB(t)
+			ss := SqlStore{db: db}
+			cmd := defaultAddDatasourceCommand
+			cmd.UID = "taken-uid"
+			_, err := ss.AddDataSource(context.Background(), &cmd)
+			require.NoError(t, err)
+
+			orig := generateNewUid
+			t.Cleanup(func() { generateNewUid = orig })
+			calls := 0
+			generateNewUid = func() string {
+				calls++
+				if calls == 1 {
+					return "taken-uid"
+				}
+				return "free-uid"
+			}
+
+			uid, err := ss.GenerateNewUID(context.Background(), 10)
+			require.NoError(t, err)
+			require.Equal(t, "free-uid", uid)
+			require.GreaterOrEqual(t, calls, 2)
+		})
+	})
+
 	t.Run("UpdateDataSource", func(t *testing.T) {
 		t.Run("updates datasource with version", func(t *testing.T) {
 			db := db.InitTestDB(t)

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -209,6 +209,15 @@ var (
 			Generate:    Generate{LegacyGo: true, LegacyFrontend: true},
 		},
 		{
+			Name: "awsAssumeRolePerDatasourceExternalId",
+			Description: "Generate a per-datasource external ID for Grafana Assume Role " +
+				"(jsonData.grafanaExternalId). When disabled, new datasources keep using the stack-level external ID.",
+			Stage:      FeatureStageExperimental,
+			Expression: "false",
+			Owner:      grafanaDataSourcesPlugins,
+			Generate:   Generate{LegacyGo: true, LegacyFrontend: true, React: true},
+		},
+		{
 			Name:        "mlExpressions",
 			Description: "Enable support for Machine Learning in server-side expressions",
 			Stage:       FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -22,6 +22,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-05-21,queryHistory.localOnly,experimental,@grafana/datapro,false,false,true
 2026-05-21,queryHistory.recentQueriesUI,experimental,@grafana/datapro,false,false,true
 2023-07-06,awsDatasourcesTempCredentials,GA,@grafana/data-sources-plugins,false,false,false
+2026-07-14,awsAssumeRolePerDatasourceExternalId,experimental,@grafana/data-sources-plugins,false,false,false
 2023-07-13,mlExpressions,experimental,@grafana/alerting-squad,false,false,false
 2024-09-19,datasourceAPIServers,experimental,@grafana/grafana-app-platform-squad,false,true,false
 2023-10-06,grafanaAPIServerWithExperimentalAPIs,experimental,@grafana/grafana-app-platform-squad,true,true,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -67,6 +67,10 @@ const (
 	// Support temporary security credentials in AWS plugins for Grafana Cloud customers
 	FlagAwsDatasourcesTempCredentials = "awsDatasourcesTempCredentials"
 
+	// FlagAwsAssumeRolePerDatasourceExternalId
+	// Generate a per-datasource external ID for Grafana Assume Role (jsonData.grafanaExternalId). When disabled, new datasources keep using the stack-level external ID.
+	FlagAwsAssumeRolePerDatasourceExternalId = "awsAssumeRolePerDatasourceExternalId"
+
 	// FlagMlExpressions
 	// Enable support for Machine Learning in server-side expressions
 	FlagMlExpressions = "mlExpressions"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1026,6 +1026,19 @@
     },
     {
       "metadata": {
+        "name": "awsAssumeRolePerDatasourceExternalId",
+        "resourceVersion": "1784038809429",
+        "creationTimestamp": "2026-07-14T14:20:09Z"
+      },
+      "spec": {
+        "description": "Generate a per-datasource external ID for Grafana Assume Role (jsonData.grafanaExternalId). When disabled, new datasources keep using the stack-level external ID.",
+        "stage": "experimental",
+        "codeowner": "@grafana/data-sources-plugins",
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "awsAsyncQueryCaching",
         "resourceVersion": "1779440584464",
         "creationTimestamp": "2023-07-21T15:34:07Z"


### PR DESCRIPTION
## Summary
- Mint immutable `jsonData.grafanaExternalId` as `{stackExternalId}-{dsUid}` for `authType=grafana_assume_role`
- Gate **minting only** on experimental FT `awsAssumeRolePerDatasourceExternalId` (default off)
- Always scrub invalid/stolen client or stored IDs; preserve valid existing IDs even when the FT is off
- Assign early UIDs via store uniqueness retry before minting; do not auto-migrate legacy GAR datasources
- Docs intentionally **not** updated here — follow-up when FT is enabled / near GA

Related: grafana/oss-plugin-partnerships#1473

## Test plan
- [ ] `go test ./pkg/services/datasources/service/ -run 'GrafanaExternal|EnsureGrafana|PreserveGrafana|GenerateNewUID'`
- [ ] With FT on: create CloudWatch GAR DS → expect `{stack}-{uid}`
- [ ] With FT off: no new mint; existing per-DS ID still preserved and used
- [ ] Stolen/mismatched `grafanaExternalId` on create/update is cleared
- [ ] Legacy GAR without field stays on stack ID (no auto-migrate)

## Merge order
Depends on: `grafana-aws-sdk` dual-read (can merge in parallel; FT stays off until UI + plugins catch up).