### PR TITLE
CI: Add Workflow to Generate and Attach SBOM on Release

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -63,6 +63,7 @@
 /.policy.yml @grafana/grafana-backend-group
 /.policy.yml.tmpl @grafana/grafana-backend-group
 /.github/workflows/policybot.yml @grafana/grafana-backend-group
+/.github/workflows/sbom-on-release.yml @grafana/security
 
 # Backend code
 /go.mod @grafana/grafana-backend-group

--- a/.github/workflows/sbom-on-release.yml
+++ b/.github/workflows/sbom-on-release.yml
@@ -28,12 +28,12 @@ jobs:
         with:
           socket_api_token: ${{ fromJSON(steps.vault-secrets.outputs.secrets).SOCKET_API_TOKEN }}
           socket_org: grafana
-          output_file: ${{ github.event.repository.name }}-${{ github.event.release.tag_name || inputs.tag }}.spdx.json
+          output_file: ${{ github.event.repository.name }}-${{ github.event.release.tag_name }}.spdx.json
 
       - name: "Upload SBOM to release"
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-          TAG: ${{ github.event.release.tag_name || inputs.tag }}
+          TAG: ${{ github.event.release.tag_name }}
           SBOM_PATH: ${{ steps.export-sbom.outputs.path }}
         run: gh release upload "$TAG" "$SBOM_PATH" --clobber

--- a/.github/workflows/sbom-on-release.yml
+++ b/.github/workflows/sbom-on-release.yml
@@ -1,0 +1,39 @@
+name: "SBOM on Release"
+
+on:
+  release:
+    types:
+      - published
+
+permissions: {}
+
+jobs:
+  export-sbom:
+    name: "Export SBOM and attach to release"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # to upload the SBOM as a release asset
+      id-token: write # to authenticate to Vault
+    steps:
+      - name: "Get Socket API token from Vault"
+        id: vault-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@e46fe1e9a2bf9e618bcf8d8d32f3a7381b45c06d # get-vault-secrets/v2.0.0
+        with:
+          common_secrets: |
+            SOCKET_API_TOKEN=socket:SOCKET_API_KEY
+
+      - name: "Export SPDX SBOM from Socket"
+        id: export-sbom
+        uses: grafana/shared-workflows/actions/socket-export-sbom@ff9aaa53f25716fcd6dde39f6d4e41c4e16fb5e1 # socket-export-sbom/v0.1.2
+        with:
+          socket_api_token: ${{ fromJSON(steps.vault-secrets.outputs.secrets).SOCKET_API_TOKEN }}
+          socket_org: grafana
+          output_file: ${{ github.event.repository.name }}-${{ github.event.release.tag_name || inputs.tag }}.spdx.json
+
+      - name: "Upload SBOM to release"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ github.event.release.tag_name || inputs.tag }}
+          SBOM_PATH: ${{ steps.export-sbom.outputs.path }}
+        run: gh release upload "$TAG" "$SBOM_PATH" --clobber


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

CI workflow for generating an SBOM on release, which is added to the release assets. SBOMs are generated using the socket.dev API 

**Why do we need this feature?**

The GRC team semi-frequently gets requests for Software Bill of Material (SBOMs) from contracted customers and prospects. Grafana's Open Source repos are enrolled in and scanned for dependencies by socket.dev, which also generates SBOMs. Currently, the GRC generates SBOMs ad-hoc using Socket's API. Adding a standardized workflow for SBOM generating reduces the burden for the GRC team and also makes them available for consumption by members of our OSS community.

**Who is this feature for?**

A Grafana internal user or a member of the public who requires an SBOM for a specific release of the product.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
