### PR TITLE
Alerting: Fix admin_config partial write when no configuration exists

### DIFF
--- a/pkg/services/ngalert/store/admin_configuration.go
+++ b/pkg/services/ngalert/store/admin_configuration.go
@@ -84,7 +84,14 @@ func (st DBstore) UpdateAdminConfiguration(cmd UpdateAdminConfigurationCmd) erro
 		}
 
 		if !has {
-			_, err := sess.Table("ngalert_configuration").Insert(cmd.AdminConfiguration)
+			// Partial writes (e.g. UID-only) can arrive before any row exists; send_alerts_to is
+			// NOT NULL and "no row" behaves as internal-only, so default a copy to internal.
+			cfg := *cmd.AdminConfiguration
+			if cfg.SendAlertsTo == nil {
+				internal := ngmodels.InternalAlertmanager
+				cfg.SendAlertsTo = &internal
+			}
+			_, err := sess.Table("ngalert_configuration").Insert(&cfg)
 			return err
 		}
 

--- a/pkg/services/ngalert/store/admin_configuration_test.go
+++ b/pkg/services/ngalert/store/admin_configuration_test.go
@@ -72,4 +72,86 @@ func TestIntegrationUpdateAdminConfiguration(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, ngmodels.ExternalAlertmanagers, *cfg3.SendAlertsTo)
 	})
+
+	uid := "some-mimir-ds-uid"
+
+	t.Run("insert with only ExternalAlertmanagerUID defaults SendAlertsTo to internal", func(t *testing.T) {
+		err := store.UpdateAdminConfiguration(UpdateAdminConfigurationCmd{
+			AdminConfiguration: &ngmodels.AdminConfiguration{
+				OrgID:                   10,
+				ExternalAlertmanagerUID: &uid,
+			},
+		})
+		require.NoError(t, err)
+
+		cfg, err := store.GetAdminConfiguration(10)
+		require.NoError(t, err)
+		require.NotNil(t, cfg.ExternalAlertmanagerUID)
+		require.Equal(t, uid, *cfg.ExternalAlertmanagerUID)
+		require.NotNil(t, cfg.SendAlertsTo)
+		require.Equal(t, ngmodels.InternalAlertmanager, *cfg.SendAlertsTo)
+	})
+
+	t.Run("UID-only update preserves existing SendAlertsTo", func(t *testing.T) {
+		external := ngmodels.ExternalAlertmanagers
+		err := store.UpdateAdminConfiguration(UpdateAdminConfigurationCmd{
+			AdminConfiguration: &ngmodels.AdminConfiguration{
+				OrgID:        11,
+				SendAlertsTo: &external,
+			},
+		})
+		require.NoError(t, err)
+
+		err = store.UpdateAdminConfiguration(UpdateAdminConfigurationCmd{
+			AdminConfiguration: &ngmodels.AdminConfiguration{
+				OrgID:                   11,
+				ExternalAlertmanagerUID: &uid,
+			},
+		})
+		require.NoError(t, err)
+
+		cfg, err := store.GetAdminConfiguration(11)
+		require.NoError(t, err)
+		require.NotNil(t, cfg.SendAlertsTo)
+		require.Equal(t, ngmodels.ExternalAlertmanagers, *cfg.SendAlertsTo)
+		require.NotNil(t, cfg.ExternalAlertmanagerUID)
+		require.Equal(t, uid, *cfg.ExternalAlertmanagerUID)
+	})
+
+	t.Run("choice-only update preserves existing UID", func(t *testing.T) {
+		err := store.UpdateAdminConfiguration(UpdateAdminConfigurationCmd{
+			AdminConfiguration: &ngmodels.AdminConfiguration{
+				OrgID:                   12,
+				ExternalAlertmanagerUID: &uid,
+			},
+		})
+		require.NoError(t, err)
+
+		external := ngmodels.ExternalAlertmanagers
+		err = store.UpdateAdminConfiguration(UpdateAdminConfigurationCmd{
+			AdminConfiguration: &ngmodels.AdminConfiguration{
+				OrgID:        12,
+				SendAlertsTo: &external,
+			},
+		})
+		require.NoError(t, err)
+
+		cfg, err := store.GetAdminConfiguration(12)
+		require.NoError(t, err)
+		require.NotNil(t, cfg.ExternalAlertmanagerUID)
+		require.Equal(t, uid, *cfg.ExternalAlertmanagerUID)
+		require.NotNil(t, cfg.SendAlertsTo)
+		require.Equal(t, ngmodels.ExternalAlertmanagers, *cfg.SendAlertsTo)
+	})
+
+	t.Run("insert without SendAlertsTo does not mutate the command", func(t *testing.T) {
+		cmd := UpdateAdminConfigurationCmd{
+			AdminConfiguration: &ngmodels.AdminConfiguration{
+				OrgID:                   13,
+				ExternalAlertmanagerUID: &uid,
+			},
+		}
+		require.NoError(t, store.UpdateAdminConfiguration(cmd))
+		require.Nil(t, cmd.AdminConfiguration.SendAlertsTo)
+	})
 }

--- a/pkg/tests/api/alerting/api_admin_configuration_test.go
+++ b/pkg/tests/api/alerting/api_admin_configuration_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/expr"
 	"github.com/grafana/grafana/pkg/services/datasources"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/sender"
@@ -355,5 +356,89 @@ func TestIntegrationAdminConfiguration_SendingToExternalAlertmanagers(t *testing
 
 			return len(alertmanagers.Data.Active) == 0
 		}, 16*time.Second, 8*time.Second) // the sync interval is 2s so after 8s all alertmanagers (if any) most probably are started
+	}
+}
+
+func TestIntegrationAdminConfiguration_ExternalAlertmanagerUIDOnlyInsert(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	testinfra.SQLiteIntegrationTest(t)
+
+	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
+		DisableLegacyAlerting: true,
+		EnableUnifiedAlerting: true,
+		DisableAnonymous:      true,
+		AppModeProduction:     true,
+		EnableFeatureToggles:  []string{featuremgmt.FlagAlertingSyncExternalAlertmanager},
+	})
+
+	grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
+
+	// Create a user to make authenticated requests
+	createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
+		DefaultOrgRole: string(org.RoleAdmin),
+		Login:          "grafana",
+		Password:       "password",
+	})
+
+	// Add a Mimir Alertmanager datasource to reference from the admin configuration.
+	var dsUID string
+	{
+		cmd := datasources.AddDataSourceCommand{
+			OrgID:  1,
+			Name:   "Mimir AM",
+			Type:   datasources.DS_ALERTMANAGER,
+			Access: "proxy",
+			URL:    "http://localhost:9009",
+			JsonData: simplejson.NewFromAny(map[string]any{
+				"implementation": "mimir",
+			}),
+		}
+		buf := bytes.Buffer{}
+		enc := json.NewEncoder(&buf)
+		err := enc.Encode(&cmd)
+		require.NoError(t, err)
+		dataSourcesUrl := fmt.Sprintf("http://grafana:password@%s/api/datasources", grafanaListedAddr)
+		resp := postRequest(t, dataSourcesUrl, buf.String(), http.StatusOK) // nolint
+		b, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		var res struct {
+			Datasource struct {
+				UID string `json:"uid"`
+			} `json:"datasource"`
+		}
+		err = json.Unmarshal(b, &res)
+		require.NoError(t, err)
+		dsUID = res.Datasource.UID
+		require.NotEmpty(t, dsUID)
+	}
+
+	// A UID-only write with no pre-existing admin configuration must insert a new row.
+	{
+		ac := apimodels.PostableNGalertConfig{
+			ExternalAlertmanagerUID: new(dsUID),
+		}
+		buf := bytes.Buffer{}
+		enc := json.NewEncoder(&buf)
+		err := enc.Encode(&ac)
+		require.NoError(t, err)
+
+		alertsURL := fmt.Sprintf("http://grafana:password@%s/api/v1/ngalert/admin_config", grafanaListedAddr)
+		resp := postRequest(t, alertsURL, buf.String(), http.StatusCreated) // nolint
+		b, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		var res map[string]any
+		err = json.Unmarshal(b, &res)
+		require.NoError(t, err)
+		require.Equal(t, "admin configuration updated", res["message"])
+	}
+
+	// The alertmanagers choice not sent in the request should default to internal.
+	{
+		alertsURL := fmt.Sprintf("http://grafana:password@%s/api/v1/ngalert/admin_config", grafanaListedAddr)
+		resp := getRequest(t, alertsURL, http.StatusOK) // nolint
+		b, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.JSONEq(t, fmt.Sprintf("{\"alertmanagersChoice\": %q, \"external_alertmanager_uid\": %q}\n", ngmodels.InternalAlertmanager, dsUID), string(b))
 	}
 }


### PR DESCRIPTION
## What

A POST to `/api/v1/ngalert/admin_config` carrying only `external_alertmanager_uid` failed with a 500 for orgs that had no existing configuration row: the insert wrote `NULL` into the `NOT NULL` `send_alerts_to` column. Partial-update semantics were only applied to the update path, not the insert path.

## Fix

Default `send_alerts_to` to `internal` on insert when the field is not part of the write, matching the effective behavior when no configuration exists.

## Testing

- Store-level subtests covering UID-only insert, UID-only update, and choice-only update
- API integration test for the UID-only insert path