### PR TITLE
Dashboard scene: Guard against undefined fieldConfig during panel mutation

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -867,7 +867,8 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
     newOptions?: Record<string, unknown>,
     newFieldConfig?: FieldConfigSource
   ) {
-    const { fieldConfig: prevFieldConfig } = panel.state;
+    // fieldConfig may be absent when a panel is created or changed via the Dashboard Mutation API.
+    const prevFieldConfig = panel.state.fieldConfig ?? { defaults: {}, overrides: [] };
 
     let cleanFieldConfig: FieldConfigSource = {
       defaults: { ...prevFieldConfig.defaults, custom: {} },

--- a/public/app/features/dashboard-scene/serialization/transformToV1TypesUtils.ts
+++ b/public/app/features/dashboard-scene/serialization/transformToV1TypesUtils.ts
@@ -115,12 +115,15 @@ export function transformMappingsToV1(fieldConfig: FieldConfigSource): FieldConf
     }
   };
 
+  // fieldConfig may be absent when a panel is created or changed via the Dashboard Mutation API.
+  const defaults: FieldConfigSource['defaults'] = fieldConfig?.defaults ?? {};
+
   const transformedDefaults: any = {
-    ...fieldConfig.defaults,
+    ...defaults,
   };
 
-  if (fieldConfig.defaults.mappings) {
-    transformedDefaults.mappings = fieldConfig.defaults.mappings.flatMap((mapping) => {
+  if (defaults.mappings) {
+    transformedDefaults.mappings = defaults.mappings.flatMap((mapping) => {
       switch (mapping.type) {
         case 'value':
           return {
@@ -159,10 +162,10 @@ export function transformMappingsToV1(fieldConfig: FieldConfigSource): FieldConf
     });
   }
 
-  if (fieldConfig.defaults.thresholds) {
+  if (defaults.thresholds) {
     transformedDefaults.thresholds = {
-      ...fieldConfig.defaults.thresholds,
-      mode: getThresholdsMode(fieldConfig.defaults.thresholds.mode),
+      ...defaults.thresholds,
+      mode: getThresholdsMode(defaults.thresholds.mode),
     };
   }
 


### PR DESCRIPTION
## What this PR does

Adds defensive guards at two sites that read `.defaults` off a `fieldConfig` that can be undefined at runtime, which can throw `Cannot read properties of undefined (reading 'defaults')` when a panel is added or changed via the Dashboard Mutation API:

- `DashboardScene.changePanelPlugin` now defaults `panel.state.fieldConfig` to `{ defaults: {}, overrides: [] }` before reading `.defaults`/`.overrides`.
- `transformMappingsToV1` now resolves `fieldConfig?.defaults ?? {}` once and reads `mappings`/`thresholds` off that local, instead of dereferencing `fieldConfig.defaults` directly.

## Why fix this in core

The Mutation API accepts partial panel payloads on purpose: omitting `fieldConfig` means "leave it unchanged", so `fieldConfig` is intentionally optional at the API boundary. Core is the layer receiving that partial input and must not crash on it. These two sites were simply the gaps: the same files already guard `fieldConfig` defensively elsewhere (`DashboardScene` and `transformSceneToSaveModelSchemaV2`), and this PR makes them consistent. Fixing it in the API client schemas instead would only patch one producer while leaving the crash reachable by any other Mutation API caller.

## Note

Defensive and behavior-preserving: for the normal case where `fieldConfig` is defined, output is unchanged. The guards only prevent the runtime crash `Cannot read properties of undefined (reading 'defaults')` when the field config is absent.