### PR TITLE
Alerting: Sync alert rules from an external Mimir ruler (ini-driven)

### DIFF
--- a/pkg/server/bootstrap/wire/wire_gen.go
+++ b/pkg/server/bootstrap/wire/wire_gen.go
@@ -706,7 +706,7 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts server.Options, apiO
 	ngAlert := metrics2.ProvideService(registerer)
 	tagimplService := tagimpl.ProvideService(sqlStore)
 	repositoryImpl := annotationsimpl.ProvideService(sqlStore, cfg, featureToggles, tagimplService, tracingService, dBstore, dashboardService, registerer)
-	alertNG, err := ngalert.ProvideService(cfg, featureToggles, cacheServiceImpl, service13, routeRegisterImpl, sqlStore, kvStore, exprService, dataSourceProxyService, ruleMutationValidator, quotaService, secretsService, notificationService, ngAlert, folderimplService, accessControl, dashboardService, renderingService, inProcBus, acimplService, repositoryImpl, pluginstoreService, tracingService, dBstore, httpclientProvider, plugincontextProvider, receiverPermissionsService, routePermissionsService, userimplService, orgService, clientGenerator)
+	alertNG, err := ngalert.ProvideService(cfg, featureToggles, cacheServiceImpl, service13, routeRegisterImpl, sqlStore, kvStore, exprService, dataSourceProxyService, ruleMutationValidator, quotaService, secretsService, notificationService, ngAlert, folderimplService, accessControl, dashboardService, renderingService, inProcBus, acimplService, repositoryImpl, pluginstoreService, tracingService, dBstore, httpclientProvider, plugincontextProvider, receiverPermissionsService, routePermissionsService, folderPermissionsService, userimplService, orgService, clientGenerator)
 	if err != nil {
 		return nil, err
 	}
@@ -1466,7 +1466,7 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 	ngAlert := metrics2.ProvideService(registerer)
 	tagimplService := tagimpl.ProvideService(sqlStore)
 	repositoryImpl := annotationsimpl.ProvideService(sqlStore, cfg, featureToggles, tagimplService, tracingService, dBstore, dashboardService, registerer)
-	alertNG, err := ngalert.ProvideService(cfg, featureToggles, cacheServiceImpl, service13, routeRegisterImpl, sqlStore, kvStore, exprService, dataSourceProxyService, ruleMutationValidator, quotaService, secretsService, notificationServiceMock, ngAlert, folderimplService, accessControl, dashboardService, renderingService, inProcBus, acimplService, repositoryImpl, pluginstoreService, tracingService, dBstore, httpclientProvider, plugincontextProvider, receiverPermissionsService, routePermissionsService, userimplService, orgService, clientGenerator)
+	alertNG, err := ngalert.ProvideService(cfg, featureToggles, cacheServiceImpl, service13, routeRegisterImpl, sqlStore, kvStore, exprService, dataSourceProxyService, ruleMutationValidator, quotaService, secretsService, notificationServiceMock, ngAlert, folderimplService, accessControl, dashboardService, renderingService, inProcBus, acimplService, repositoryImpl, pluginstoreService, tracingService, dBstore, httpclientProvider, plugincontextProvider, receiverPermissionsService, routePermissionsService, folderPermissionsService, userimplService, orgService, clientGenerator)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
@@ -953,7 +953,7 @@ func setUpServiceTest(t *testing.T, cfgOverrides ...configOverrides) cloudmigrat
 		cfg, featureToggles, nil, nil, rr, sqlStore, kvStore, nil, nil, ngalertprovisioning.NoopRuleMutationValidator{}, quotatest.New(false, nil),
 		secretsService, nil, alertMetrics, mockFolder, accessControl, dashboardService, nil, bus, fakeAccessControlService,
 		annotationstest.NewFakeAnnotationsRepo(), &pluginstore.FakePluginStore{}, tracer, ruleStore,
-		httpclient.NewProvider(), nil, ngalertfakes.NewFakeReceiverPermissionsService(), ngalertfakes.NewFakeRoutePermissionsService(), usertest.NewUserServiceFake(), orgtest.NewOrgServiceFake(),
+		httpclient.NewProvider(), nil, ngalertfakes.NewFakeReceiverPermissionsService(), ngalertfakes.NewFakeRoutePermissionsService(), ngalertfakes.NewFakeFolderPermissionsService(), usertest.NewUserServiceFake(), orgtest.NewOrgServiceFake(),
 		nil, // clientGenerator
 	)
 	require.NoError(t, err)

--- a/pkg/services/ngalert/api/api.go
+++ b/pkg/services/ngalert/api/api.go
@@ -87,6 +87,9 @@ type API struct {
 	AppUrl                *url.URL
 	UserService           user.Service
 	SilenceLimitsProvider notifier.LimitsProvider
+	// ExternalRulerSync gates manual convert-API rule imports when external
+	// ruler sync owns the org's rules. Always set in RegisterAPIEndpoints.
+	ExternalRulerSync ExternalRulerSyncChecker
 
 	// Hooks can be used to replace API handlers for specific paths.
 	Hooks *Hooks
@@ -110,6 +113,7 @@ func (api *API) RegisterAPIEndpoints(m *metrics.API) {
 		api.FeatureManager,
 		api.MultiOrgAlertmanager,
 		accesscontrol.NewAlertmanagerImportsAccess(api.AccessControl),
+		api.ExternalRulerSync,
 	)
 
 	// Register endpoints for proxying to Alertmanager-compatible backends.

--- a/pkg/services/ngalert/api/api_convert_prometheus.go
+++ b/pkg/services/ngalert/api/api_convert_prometheus.go
@@ -141,6 +141,17 @@ type ConvertPrometheusSrv struct {
 	featureToggles   featuremgmt.FeatureToggles
 	am               Alertmanager
 	importsAuthz     notifier.ExtraConfigAuthz
+	rulerSync        ExternalRulerSyncChecker
+}
+
+// ExternalRulerSyncChecker reports whether external Mimir ruler sync is
+// configured for an org and whether a folder is part of the sync's managed
+// subtree. The convert API uses it to reject manual imports that target the
+// sync-managed folder (the sync worker owns those rules), while allowing imports
+// into unrelated folders. Satisfied by *rulesync.ExternalRulerSyncer.
+type ExternalRulerSyncChecker interface {
+	IsConfiguredForOrg(ctx context.Context, orgID int64) (bool, error)
+	IsManagedFolder(ctx context.Context, orgID int64, folderUID string) (bool, error)
 }
 
 type Alertmanager interface {
@@ -160,6 +171,7 @@ func NewConvertPrometheusSrv(
 	featureToggles featuremgmt.FeatureToggles,
 	am Alertmanager,
 	importsAuthz notifier.ExtraConfigAuthz,
+	rulerSync ExternalRulerSyncChecker,
 ) *ConvertPrometheusSrv {
 	return &ConvertPrometheusSrv{
 		cfg:              cfg,
@@ -170,6 +182,7 @@ func NewConvertPrometheusSrv(
 		featureToggles:   featureToggles,
 		am:               am,
 		importsAuthz:     importsAuthz,
+		rulerSync:        rulerSync,
 	}
 }
 
@@ -224,6 +237,10 @@ func (srv *ConvertPrometheusSrv) RouteConvertPrometheusDeleteNamespace(c *contex
 	workingFolderUID := getWorkingFolderUID(c)
 	logger = logger.New("working_folder_uid", workingFolderUID)
 
+	if resp := srv.rejectManagedFolderChange(c, logger, workingFolderUID); resp != nil {
+		return resp
+	}
+
 	logger.Debug("Looking up folder by title", "folder_title", namespaceTitle)
 	namespace, err := srv.ruleStore.GetNamespaceByTitle(c.Req.Context(), namespaceTitle, c.GetOrgID(), c.SignedInUser, workingFolderUID)
 	if err != nil {
@@ -254,6 +271,10 @@ func (srv *ConvertPrometheusSrv) RouteConvertPrometheusDeleteRuleGroup(c *contex
 
 	workingFolderUID := getWorkingFolderUID(c)
 	logger = logger.New("working_folder_uid", workingFolderUID)
+
+	if resp := srv.rejectManagedFolderChange(c, logger, workingFolderUID); resp != nil {
+		return resp
+	}
 
 	logger.Debug("Looking up folder by title", "folder_title", namespaceTitle)
 	folder, err := srv.ruleStore.GetNamespaceByTitle(c.Req.Context(), namespaceTitle, c.GetOrgID(), c.SignedInUser, workingFolderUID)
@@ -360,6 +381,31 @@ func (srv *ConvertPrometheusSrv) RouteConvertPrometheusGetRuleGroup(c *contextmo
 	return convertPrometheusResponse(c, http.StatusOK, promGroup)
 }
 
+// rejectManagedFolderChange returns a 409 response when external ruler sync is
+// configured for the org and folderUID is inside the sync-managed folder
+// subtree, so manual convert-API mutations (imports and deletes) can't collide
+// with the rules the sync worker owns. Returns nil when the operation may
+// proceed (sync disabled, or folder not managed by the sync worker).
+func (srv *ConvertPrometheusSrv) rejectManagedFolderChange(c *contextmodel.ReqContext, logger log.Logger, folderUID string) response.Response {
+	syncConfigured, err := srv.rulerSync.IsConfiguredForOrg(c.Req.Context(), c.GetOrgID())
+	if err != nil {
+		logger.Error("Failed to check external ruler sync configuration", "error", err)
+		return response.Error(http.StatusInternalServerError, "failed to check external ruler sync configuration", err)
+	}
+	if !syncConfigured {
+		return nil
+	}
+	managed, err := srv.rulerSync.IsManagedFolder(c.Req.Context(), c.GetOrgID(), folderUID)
+	if err != nil {
+		logger.Error("Failed to check external ruler sync managed folder", "error", err)
+		return response.Error(http.StatusInternalServerError, "failed to check external ruler sync configuration", err)
+	}
+	if managed {
+		return response.Error(http.StatusConflict, "rule changes are disabled while external ruler sync is configured for this organization", nil)
+	}
+	return nil
+}
+
 // RouteConvertPrometheusPostRuleGroup converts a Prometheus rule group into a Grafana rule group
 // and creates or updates it within the specified namespace (folder).
 //
@@ -375,6 +421,13 @@ func (srv *ConvertPrometheusSrv) RouteConvertPrometheusPostRuleGroups(c *context
 	// 1. Parse the appropriate headers
 	workingFolderUID := getWorkingFolderUID(c)
 	logger = logger.New("working_folder_uid", workingFolderUID)
+
+	// Refuse manual changes that target the sync-managed folder subtree when
+	// external ruler sync is configured: the sync worker owns those rules.
+	// Changes to unrelated folders are still allowed.
+	if resp := srv.rejectManagedFolderChange(c, logger, workingFolderUID); resp != nil {
+		return resp
+	}
 
 	pauseRecordingRules, err := parseBooleanHeader(c.Req.Header.Get(recordingRulesPausedHeader), recordingRulesPausedHeader)
 	if err != nil {
@@ -446,29 +499,29 @@ func (srv *ConvertPrometheusSrv) RouteConvertPrometheusPostRuleGroups(c *context
 		}
 
 		for _, rg := range rgs {
-			// If we're importing recording rules, we can only import them if the feature is enabled,
-			// and the feature flag that enables configuring target datasources per-rule is also enabled.
-			if promGroupHasRecordingRules(rg) {
-				if !srv.cfg.RecordingRules.Enabled {
+			logger.Info("Converting Prometheus rules to Grafana rules", "rules", len(rg.Rules), "folder_uid", namespace.UID, "datasource_uid", ds.UID, "datasource_type", ds.Type)
+			grafanaGroup, err := prom.ConvertRuleGroup(
+				srv.cfg,
+				ds,
+				tds,
+				c.GetOrgID(),
+				namespace.UID,
+				rg,
+				prom.Options{
+					PauseRecordingRules:        pauseRecordingRules,
+					PauseAlertRules:            pauseAlertRules,
+					KeepOriginalRuleDefinition: keepOriginalRuleDefinition,
+					NotificationSettings:       notificationSettings,
+					ExtraLabels:                extraLabels,
+				},
+			)
+			if err != nil {
+				// The group has recording rules but the recording rules feature is
+				// disabled: surface the existing public HTTP error/message.
+				if errors.Is(err, prom.ErrRecordingRulesNotEnabled) {
 					logger.Error("Cannot import recording rules", "error", errRecordingRulesNotEnabled)
 					return errorToResponse(errRecordingRulesNotEnabled)
 				}
-			}
-
-			grafanaGroup, err := srv.convertToGrafanaRuleGroup(
-				c,
-				ds,
-				tds,
-				namespace.UID,
-				rg,
-				pauseRecordingRules,
-				pauseAlertRules,
-				keepOriginalRuleDefinition,
-				notificationSettings,
-				extraLabels,
-				logger,
-			)
-			if err != nil {
 				logger.Error("Failed to convert Prometheus rules to Grafana rules", "error", err)
 				return errorToResponse(err)
 			}
@@ -525,75 +578,6 @@ func (srv *ConvertPrometheusSrv) getOrCreateNamespace(c *contextmodel.ReqContext
 	logger.Debug("Using folder for the converted rules", "folder_uid", ns.UID)
 
 	return ns, nil
-}
-
-func (srv *ConvertPrometheusSrv) convertToGrafanaRuleGroup(
-	c *contextmodel.ReqContext,
-	ds *datasources.DataSource,
-	tds *datasources.DataSource,
-	namespaceUID string,
-	promGroup apimodels.PrometheusRuleGroup,
-	pauseRecordingRules bool,
-	pauseAlertRules bool,
-	keepOriginalRuleDefinition bool,
-	notificationSettings *models.NotificationSettings,
-	extraLabels map[string]string,
-	logger log.Logger,
-) (*models.AlertRuleGroup, error) {
-	logger.Info("Converting Prometheus rules to Grafana rules", "rules", len(promGroup.Rules), "folder_uid", namespaceUID, "datasource_uid", ds.UID, "datasource_type", ds.Type)
-
-	rules := make([]prom.PrometheusRule, len(promGroup.Rules))
-	for i, r := range promGroup.Rules {
-		rules[i] = prom.PrometheusRule{
-			Alert:         r.Alert,
-			Expr:          r.Expr,
-			For:           r.For,
-			KeepFiringFor: r.KeepFiringFor,
-			Labels:        r.Labels,
-			Annotations:   r.Annotations,
-			Record:        r.Record,
-		}
-	}
-	group := prom.PrometheusRuleGroup{
-		Name:        promGroup.Name,
-		Interval:    promGroup.Interval,
-		Rules:       rules,
-		QueryOffset: promGroup.QueryOffset,
-		Limit:       promGroup.Limit,
-		Labels:      promGroup.Labels,
-	}
-
-	converter, err := prom.NewConverter(
-		prom.Config{
-			DatasourceUID:        ds.UID,
-			DatasourceType:       ds.Type,
-			TargetDatasourceUID:  tds.UID,
-			TargetDatasourceType: tds.Type,
-			DefaultInterval:      srv.cfg.DefaultRuleEvaluationInterval,
-			RecordingRules: prom.RulesConfig{
-				IsPaused: pauseRecordingRules,
-			},
-			AlertRules: prom.RulesConfig{
-				IsPaused: pauseAlertRules,
-			},
-			KeepOriginalRuleDefinition: new(keepOriginalRuleDefinition),
-			EvaluationOffset:           &srv.cfg.PrometheusConversion.RuleQueryOffset,
-			NotificationSettings:       notificationSettings,
-			ExtraLabels:                extraLabels,
-		},
-	)
-	if err != nil {
-		logger.Error("Failed to create Prometheus converter", "datasource_uid", ds.UID, "datasource_type", ds.Type, "error", err)
-		return nil, err
-	}
-
-	grafanaGroup, err := converter.PrometheusRulesToGrafana(c.GetOrgID(), namespaceUID, group)
-	if err != nil {
-		logger.Error("Failed to convert Prometheus rules to Grafana rules", "error", err)
-		return nil, err
-	}
-
-	return grafanaGroup, nil
 }
 
 func (srv *ConvertPrometheusSrv) RouteConvertPrometheusPostAlertmanagerConfig(c *contextmodel.ReqContext, amCfg apimodels.AlertmanagerUserConfig) response.Response {
@@ -868,15 +852,6 @@ func namespaceErrorResponse(err error) response.Response {
 	}
 
 	return toNamespaceErrorResponse(err)
-}
-
-func promGroupHasRecordingRules(promGroup apimodels.PrometheusRuleGroup) bool {
-	for _, rule := range promGroup.Rules {
-		if rule.Record != "" {
-			return true
-		}
-	}
-	return false
 }
 
 // getManagerProperties determines the ManagerProperties to use for rules created via the Prometheus conversion API.

--- a/pkg/services/ngalert/api/api_convert_prometheus.go
+++ b/pkg/services/ngalert/api/api_convert_prometheus.go
@@ -246,6 +246,9 @@ func (srv *ConvertPrometheusSrv) RouteConvertPrometheusDeleteNamespace(c *contex
 	if err != nil {
 		return namespaceErrorResponse(err)
 	}
+	if resp := srv.rejectManagedFolderChange(c, logger, namespace.UID); resp != nil {
+		return resp
+	}
 	logger.Info("Deleting all Prometheus-imported rule groups", "folder_uid", namespace.UID, "folder_title", namespaceTitle)
 
 	manager := getManagerProperties(c)
@@ -280,6 +283,9 @@ func (srv *ConvertPrometheusSrv) RouteConvertPrometheusDeleteRuleGroup(c *contex
 	folder, err := srv.ruleStore.GetNamespaceByTitle(c.Req.Context(), namespaceTitle, c.GetOrgID(), c.SignedInUser, workingFolderUID)
 	if err != nil {
 		return namespaceErrorResponse(err)
+	}
+	if resp := srv.rejectManagedFolderChange(c, logger, folder.UID); resp != nil {
+		return resp
 	}
 	logger.Info("Deleting Prometheus-imported rule group", "folder_uid", folder.UID, "folder_title", namespaceTitle, "group", group)
 
@@ -496,6 +502,13 @@ func (srv *ConvertPrometheusSrv) RouteConvertPrometheusPostRuleGroups(c *context
 		if errResp != nil {
 			logger.Error("Failed to create a new namespace", "folder_uid", workingFolderUID)
 			return errResp
+		}
+
+		// The namespace title can resolve into the sync-managed subtree even when the
+		// working folder isn't managed (e.g. the sync root's own title at the root
+		// level), so re-check the resolved folder.
+		if resp := srv.rejectManagedFolderChange(c, logger, namespace.UID); resp != nil {
+			return resp
 		}
 
 		for _, rg := range rgs {

--- a/pkg/services/ngalert/api/api_convert_prometheus_test.go
+++ b/pkg/services/ngalert/api/api_convert_prometheus_test.go
@@ -115,6 +115,45 @@ func TestRouteConvertPrometheusDelete_ExternalRulerSyncGate(t *testing.T) {
 	})
 }
 
+func TestRouteConvertPrometheus_ExternalRulerSyncGate_ResolvedFolder(t *testing.T) {
+	group := apimodels.PrometheusRuleGroup{
+		Name:  "g",
+		Rules: []apimodels.PrometheusRule{{Alert: "A", Expr: "up == 0"}},
+	}
+	// A namespace set to the sync root's own title, imported/deleted with no folder
+	// header, resolves straight to the top-level managed folder — the gate must catch
+	// that even though the working (root) folder isn't itself managed.
+	const syncRootTitle = "[Alerting] External Ruler Sync (test-ds)"
+	const managedUID = "sync-root-uid"
+
+	setup := func(t *testing.T) *ConvertPrometheusSrv {
+		srv, _, ruleStore := createConvertPrometheusSrv(t, withRulerSync(fakeRulerSyncChecker{
+			configured:     true,
+			managedFolders: map[string]bool{managedUID: true},
+		}))
+		ruleStore.Folders[1] = append(ruleStore.Folders[1], &folder.Folder{
+			UID:       managedUID,
+			Title:     syncRootTitle,
+			ParentUID: folder.LegacyRootFolderUID, //nolint:staticcheck
+		})
+		return srv
+	}
+
+	t.Run("POST resolving to the managed folder by namespace title is rejected", func(t *testing.T) {
+		srv := setup(t)
+		resp := srv.RouteConvertPrometheusPostRuleGroup(createRequestCtx(), syncRootTitle, group)
+		require.Equal(t, http.StatusConflict, resp.Status())
+		require.Contains(t, string(resp.Body()), "external ruler sync")
+	})
+
+	t.Run("DELETE resolving to the managed folder by namespace title is rejected", func(t *testing.T) {
+		srv := setup(t)
+		resp := srv.RouteConvertPrometheusDeleteNamespace(createRequestCtx(), syncRootTitle)
+		require.Equal(t, http.StatusConflict, resp.Status())
+		require.Contains(t, string(resp.Body()), "external ruler sync")
+	})
+}
+
 func TestRouteConvertPrometheusPostRuleGroup(t *testing.T) {
 	simpleGroup := apimodels.PrometheusRuleGroup{
 		Name:     "Test Group",

--- a/pkg/services/ngalert/api/api_convert_prometheus_test.go
+++ b/pkg/services/ngalert/api/api_convert_prometheus_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.yaml.in/yaml/v3"
 
+	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -42,6 +43,77 @@ import (
 const (
 	existingDSUID = "test-ds"
 )
+
+func TestRouteConvertPrometheusPostRuleGroups_ExternalRulerSyncGate(t *testing.T) {
+	group := apimodels.PrometheusRuleGroup{
+		Name:  "g",
+		Rules: []apimodels.PrometheusRule{{Alert: "A", Expr: "up == 0"}},
+	}
+
+	const managedFolderUID = "managed-folder"
+
+	// postToFolder issues an import whose working folder is folderUID (via the
+	// folder header), so the folder-scoped gate can be exercised per case.
+	postToFolder := func(srv *ConvertPrometheusSrv, folderUID string) response.Response {
+		rc := createRequestCtx()
+		rc.Req.Header.Set(folderUIDHeader, folderUID)
+		return srv.RouteConvertPrometheusPostRuleGroup(rc, "test", group)
+	}
+
+	t.Run("allows when ruler sync is not configured", func(t *testing.T) {
+		srv, _, _ := createConvertPrometheusSrv(t, withRulerSync(fakeRulerSyncChecker{
+			configured:     false,
+			managedFolders: map[string]bool{managedFolderUID: true},
+		}))
+		resp := postToFolder(srv, managedFolderUID)
+		require.Equal(t, http.StatusAccepted, resp.Status())
+	})
+
+	t.Run("allows when configured but import targets a non-managed folder", func(t *testing.T) {
+		srv, _, _ := createConvertPrometheusSrv(t, withRulerSync(fakeRulerSyncChecker{
+			configured:     true,
+			managedFolders: map[string]bool{managedFolderUID: true},
+		}))
+		resp := postToFolder(srv, "some-other-folder")
+		require.Equal(t, http.StatusAccepted, resp.Status())
+	})
+
+	t.Run("rejects with 409 when configured and import targets the managed folder", func(t *testing.T) {
+		srv, _, _ := createConvertPrometheusSrv(t, withRulerSync(fakeRulerSyncChecker{
+			configured:     true,
+			managedFolders: map[string]bool{managedFolderUID: true},
+		}))
+		resp := postToFolder(srv, managedFolderUID)
+		require.Equal(t, http.StatusConflict, resp.Status())
+		require.Contains(t, string(resp.Body()), "external ruler sync")
+	})
+}
+
+func TestRouteConvertPrometheusDelete_ExternalRulerSyncGate(t *testing.T) {
+	const managedFolderUID = "managed-folder"
+	sync := withRulerSync(fakeRulerSyncChecker{
+		configured:     true,
+		managedFolders: map[string]bool{managedFolderUID: true},
+	})
+
+	t.Run("DeleteNamespace rejects with 409 in the managed folder", func(t *testing.T) {
+		srv, _, _ := createConvertPrometheusSrv(t, sync)
+		rc := createRequestCtx()
+		rc.Req.Header.Set(folderUIDHeader, managedFolderUID)
+		resp := srv.RouteConvertPrometheusDeleteNamespace(rc, "test-ns")
+		require.Equal(t, http.StatusConflict, resp.Status())
+		require.Contains(t, string(resp.Body()), "external ruler sync")
+	})
+
+	t.Run("DeleteRuleGroup rejects with 409 in the managed folder", func(t *testing.T) {
+		srv, _, _ := createConvertPrometheusSrv(t, sync)
+		rc := createRequestCtx()
+		rc.Req.Header.Set(folderUIDHeader, managedFolderUID)
+		resp := srv.RouteConvertPrometheusDeleteRuleGroup(rc, "test-ns", "test-group")
+		require.Equal(t, http.StatusConflict, resp.Status())
+		require.Contains(t, string(resp.Body()), "external ruler sync")
+	})
+}
 
 func TestRouteConvertPrometheusPostRuleGroup(t *testing.T) {
 	simpleGroup := apimodels.PrometheusRuleGroup{
@@ -1728,6 +1800,7 @@ type convertPrometheusSrvOptions struct {
 	featureToggles               featuremgmt.FeatureToggles
 	alertmanager                 Alertmanager
 	folderService                folder.Service
+	rulerSync                    ExternalRulerSyncChecker
 }
 
 type convertPrometheusSrvOptionsFunc func(*convertPrometheusSrvOptions)
@@ -1762,6 +1835,29 @@ func withAlertmanager(am Alertmanager) convertPrometheusSrvOptionsFunc {
 	}
 }
 
+func withRulerSync(checker ExternalRulerSyncChecker) convertPrometheusSrvOptionsFunc {
+	return func(opts *convertPrometheusSrvOptions) {
+		opts.rulerSync = checker
+	}
+}
+
+type fakeRulerSyncChecker struct {
+	configured     bool
+	err            error
+	managedFolders map[string]bool
+}
+
+func (f fakeRulerSyncChecker) IsConfiguredForOrg(context.Context, int64) (bool, error) {
+	return f.configured, f.err
+}
+
+func (f fakeRulerSyncChecker) IsManagedFolder(_ context.Context, _ int64, folderUID string) (bool, error) {
+	if f.err != nil {
+		return false, f.err
+	}
+	return f.managedFolders[folderUID], nil
+}
+
 func withFolderService(f folder.Service) convertPrometheusSrvOptionsFunc {
 	return func(opts *convertPrometheusSrvOptions) {
 		opts.folderService = f
@@ -1780,6 +1876,7 @@ func createConvertPrometheusSrv(t *testing.T, opts ...convertPrometheusSrvOption
 		fakeAccessControlRuleService: &acfakes.FakeRuleService{},
 		quotaChecker:                 quotas,
 		folderService:                foldertest.NewFakeService(),
+		rulerSync:                    fakeRulerSyncChecker{},
 	}
 
 	for _, opt := range opts {
@@ -1819,7 +1916,7 @@ func createConvertPrometheusSrv(t *testing.T, opts ...convertPrometheusSrvOption
 		},
 	}
 
-	srv := NewConvertPrometheusSrv(cfg, log.NewNopLogger(), ruleStore, dsCache, alertRuleService, options.featureToggles, options.alertmanager, nil)
+	srv := NewConvertPrometheusSrv(cfg, log.NewNopLogger(), ruleStore, dsCache, alertRuleService, options.featureToggles, options.alertmanager, nil, options.rulerSync)
 
 	return srv, dsCache, ruleStore
 }

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -98,43 +98,45 @@ func ProvideService(
 	pluginContextProvider *plugincontext.Provider,
 	resourcePermissions accesscontrol.ReceiverPermissionsService,
 	routeResourcePermissions accesscontrol.RoutePermissionsService,
+	folderResourcePermissions accesscontrol.FolderPermissionsService,
 	userService user.Service,
 	orgService org.Service,
 	clientGenerator resource.ClientGenerator,
 ) (*AlertNG, error) {
 	ng := &AlertNG{
-		Cfg:                      cfg,
-		FeatureToggles:           featureToggles,
-		DataSourceCache:          dataSourceCache,
-		DataSourceService:        dataSourceService,
-		RouteRegister:            routeRegister,
-		SQLStore:                 sqlStore,
-		KVStore:                  kvStore,
-		ExpressionService:        expressionService,
-		DataProxy:                dataProxy,
-		ruleMutationValidator:    ruleMutationValidator,
-		QuotaService:             quotaService,
-		SecretsService:           secretsService,
-		Metrics:                  m,
-		Log:                      log.New("ngalert"),
-		NotificationService:      notificationService,
-		folderService:            folderService,
-		accesscontrol:            ac,
-		dashboardService:         dashboardService,
-		renderService:            renderService,
-		bus:                      bus,
-		AccesscontrolService:     accesscontrolService,
-		annotationsRepo:          annotationsRepo,
-		pluginsStore:             pluginsStore,
-		tracer:                   tracer,
-		store:                    ruleStore,
-		httpClientProvider:       httpClientProvider,
-		pluginContextProvider:    pluginContextProvider,
-		clientGenerator:          clientGenerator,
-		ResourcePermissions:      resourcePermissions,
-		RouteResourcePermissions: routeResourcePermissions,
-		userService:              userService,
-		orgService:               orgService,
+		Cfg:                       cfg,
+		FeatureToggles:            featureToggles,
+		DataSourceCache:           dataSourceCache,
+		DataSourceService:         dataSourceService,
+		RouteRegister:             routeRegister,
+		SQLStore:                  sqlStore,
+		KVStore:                   kvStore,
+		ExpressionService:         expressionService,
+		DataProxy:                 dataProxy,
+		ruleMutationValidator:     ruleMutationValidator,
+		QuotaService:              quotaService,
+		SecretsService:            secretsService,
+		Metrics:                   m,
+		Log:                       log.New("ngalert"),
+		NotificationService:       notificationService,
+		folderService:             folderService,
+		accesscontrol:             ac,
+		dashboardService:          dashboardService,
+		renderService:             renderService,
+		bus:                       bus,
+		AccesscontrolService:      accesscontrolService,
+		annotationsRepo:           annotationsRepo,
+		pluginsStore:              pluginsStore,
+		tracer:                    tracer,
+		store:                     ruleStore,
+		httpClientProvider:        httpClientProvider,
+		pluginContextProvider:     pluginContextProvider,
+		clientGenerator:           clientGenerator,
+		ResourcePermissions:       resourcePermissions,
+		RouteResourcePermissions:  routeResourcePermissions,
+		FolderResourcePermissions: folderResourcePermissions,
+		userService:               userService,
+		orgService:                orgService,
 	}
 
 	if ng.IsDisabled() {
@@ -180,17 +182,18 @@ type AlertNG struct {
 	StartupInstanceReader state.InstanceReader
 
 	// Alerting notification services
-	MultiOrgAlertmanager     *notifier.MultiOrgAlertmanager
-	AlertsRouter             *sender.AlertsRouter
-	externalRulerSyncer      *rulesync.ExternalRulerSyncer
-	accesscontrol            accesscontrol.AccessControl
-	AccesscontrolService     accesscontrol.Service
-	ResourcePermissions      accesscontrol.ReceiverPermissionsService
-	RouteResourcePermissions accesscontrol.RoutePermissionsService
-	annotationsRepo          annotations.Repository
-	store                    *store.DBstore
-	userService              user.Service
-	orgService               org.Service
+	MultiOrgAlertmanager      *notifier.MultiOrgAlertmanager
+	AlertsRouter              *sender.AlertsRouter
+	externalRulerSyncer       *rulesync.ExternalRulerSyncer
+	accesscontrol             accesscontrol.AccessControl
+	AccesscontrolService      accesscontrol.Service
+	ResourcePermissions       accesscontrol.ReceiverPermissionsService
+	RouteResourcePermissions  accesscontrol.RoutePermissionsService
+	FolderResourcePermissions accesscontrol.FolderPermissionsService
+	annotationsRepo           annotations.Repository
+	store                     *store.DBstore
+	userService               user.Service
+	orgService                org.Service
 
 	bus             bus.Bus
 	pluginsStore    pluginstore.Store
@@ -608,6 +611,7 @@ func (ng *AlertNG) init() error {
 		alertRuleService,
 		ng.store,
 		ng.store,
+		ng.FolderResourcePermissions,
 	)
 
 	ng.Api = &api.API{

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -50,6 +50,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/provisioning"
 	"github.com/grafana/grafana/pkg/services/ngalert/remote"
 	remoteClient "github.com/grafana/grafana/pkg/services/ngalert/remote/client"
+	"github.com/grafana/grafana/pkg/services/ngalert/rulesync"
 	"github.com/grafana/grafana/pkg/services/ngalert/schedule"
 	"github.com/grafana/grafana/pkg/services/ngalert/sender"
 	"github.com/grafana/grafana/pkg/services/ngalert/state"
@@ -181,6 +182,7 @@ type AlertNG struct {
 	// Alerting notification services
 	MultiOrgAlertmanager     *notifier.MultiOrgAlertmanager
 	AlertsRouter             *sender.AlertsRouter
+	externalRulerSyncer      *rulesync.ExternalRulerSyncer
 	accesscontrol            accesscontrol.AccessControl
 	AccesscontrolService     accesscontrol.Service
 	ResourcePermissions      accesscontrol.ReceiverPermissionsService
@@ -593,6 +595,21 @@ func (ng *AlertNG) init() error {
 		ng.Cfg.UnifiedAlerting.RulesPerRuleGroupLimit, ng.Log, notifier.NewNotificationSettingsValidationService(ng.store),
 		ac.NewRuleService(ng.accesscontrol), ng.ruleMutationValidator)
 
+	// External Mimir ruler sync worker. Routes the ruler config GET through
+	// the datasource proxy service (same transport, auth and egress validation as
+	// the user-driven proxy). It only runs when the operator has set the
+	// external_ruler_uid setting (the enable signal; no separate feature flag).
+	ng.externalRulerSyncer = rulesync.NewExternalRulerSyncer(
+		&ng.Cfg.UnifiedAlerting,
+		log.New("ngalert.rulesync"),
+		rulesync.NewMetrics(ng.Metrics.Registerer),
+		ng.DataSourceService,
+		ng.DataProxy,
+		alertRuleService,
+		ng.store,
+		ng.store,
+	)
+
 	ng.Api = &api.API{
 		Cfg:                   ng.Cfg,
 		DatasourceCache:       ng.DataSourceCache,
@@ -619,6 +636,7 @@ func (ng *AlertNG) init() error {
 		InhibitionRules:       inhibitionRuleService,
 		AlertRules:            alertRuleService,
 		AlertsRouter:          alertsRouter,
+		ExternalRulerSync:     ng.externalRulerSyncer,
 		EvaluatorFactory:      evalFactory,
 		ConditionValidator:    conditionValidator,
 		FeatureManager:        ng.FeatureToggles,
@@ -744,6 +762,11 @@ func (ng *AlertNG) Run(ctx context.Context) error {
 	children.Go(func() error {
 		return ng.AlertsRouter.Run(subCtx)
 	})
+	if ng.externalRulerSyncer != nil {
+		children.Go(func() error {
+			return ng.externalRulerSyncer.Run(subCtx)
+		})
+	}
 
 	if ng.Cfg.UnifiedAlerting.ExecuteAlerts {
 		children.Go(func() error {

--- a/pkg/services/ngalert/prom/convert_group.go
+++ b/pkg/services/ngalert/prom/convert_group.go
@@ -1,0 +1,98 @@
+package prom
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/grafana/grafana/pkg/services/datasources"
+	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+// ErrRecordingRulesNotEnabled is returned by ConvertRuleGroup when a group has
+// recording rules but the recording rules feature is disabled.
+var ErrRecordingRulesNotEnabled = errors.New("recording rules not enabled")
+
+// Options carries per-import conversion knobs not derived from the datasource or config.
+type Options struct {
+	PauseRecordingRules bool
+	PauseAlertRules     bool
+	// KeepOriginalRuleDefinition preserves the source Prometheus YAML in metadata.
+	KeepOriginalRuleDefinition bool
+	NotificationSettings       *models.NotificationSettings
+	ExtraLabels                map[string]string
+}
+
+// GroupHasRecordingRules reports whether the group contains any recording rules.
+func GroupHasRecordingRules(promGroup apimodels.PrometheusRuleGroup) bool {
+	for _, rule := range promGroup.Rules {
+		if rule.Record != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// ConvertRuleGroup converts one Prometheus rule group into a Grafana rule group,
+// using ds as the query datasource and tds as the recording-rules target. Returns
+// ErrRecordingRulesNotEnabled if the group has recording rules but the feature is off.
+func ConvertRuleGroup(
+	cfg *setting.UnifiedAlertingSettings,
+	ds *datasources.DataSource,
+	tds *datasources.DataSource,
+	orgID int64,
+	namespaceUID string,
+	promGroup apimodels.PrometheusRuleGroup,
+	opts Options,
+) (*models.AlertRuleGroup, error) {
+	if GroupHasRecordingRules(promGroup) && !cfg.RecordingRules.Enabled {
+		return nil, ErrRecordingRulesNotEnabled
+	}
+
+	rules := make([]PrometheusRule, len(promGroup.Rules))
+	for i, r := range promGroup.Rules {
+		rules[i] = PrometheusRule{
+			Alert:         r.Alert,
+			Expr:          r.Expr,
+			For:           r.For,
+			KeepFiringFor: r.KeepFiringFor,
+			Labels:        r.Labels,
+			Annotations:   r.Annotations,
+			Record:        r.Record,
+		}
+	}
+	group := PrometheusRuleGroup{
+		Name:        promGroup.Name,
+		Interval:    promGroup.Interval,
+		Rules:       rules,
+		QueryOffset: promGroup.QueryOffset,
+		Limit:       promGroup.Limit,
+		Labels:      promGroup.Labels,
+	}
+
+	keepOriginal := opts.KeepOriginalRuleDefinition
+	converter, err := NewConverter(Config{
+		DatasourceUID:              ds.UID,
+		DatasourceType:             ds.Type,
+		TargetDatasourceUID:        tds.UID,
+		TargetDatasourceType:       tds.Type,
+		DefaultInterval:            cfg.DefaultRuleEvaluationInterval,
+		RecordingRules:             RulesConfig{IsPaused: opts.PauseRecordingRules},
+		AlertRules:                 RulesConfig{IsPaused: opts.PauseAlertRules},
+		KeepOriginalRuleDefinition: &keepOriginal,
+		EvaluationOffset:           &cfg.PrometheusConversion.RuleQueryOffset,
+		NotificationSettings:       opts.NotificationSettings,
+		ExtraLabels:                opts.ExtraLabels,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Prometheus converter: %w", err)
+	}
+
+	grafanaGroup, err := converter.PrometheusRulesToGrafana(orgID, namespaceUID, group)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert Prometheus rules to Grafana rules: %w", err)
+	}
+
+	return grafanaGroup, nil
+}

--- a/pkg/services/ngalert/prom/convert_group_test.go
+++ b/pkg/services/ngalert/prom/convert_group_test.go
@@ -1,0 +1,67 @@
+package prom
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/services/datasources"
+	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+func testCfg(recordingEnabled bool) *setting.UnifiedAlertingSettings {
+	return &setting.UnifiedAlertingSettings{
+		DefaultRuleEvaluationInterval: time.Minute,
+		RecordingRules:                setting.RecordingRuleSettings{Enabled: recordingEnabled},
+	}
+}
+
+func promDS() *datasources.DataSource {
+	return &datasources.DataSource{UID: "ds-uid", Type: datasources.DS_PROMETHEUS}
+}
+
+func alertGroup() apimodels.PrometheusRuleGroup {
+	return apimodels.PrometheusRuleGroup{
+		Name:  "g1",
+		Rules: []apimodels.PrometheusRule{{Alert: "HighLatency", Expr: "latency > 1"}},
+	}
+}
+
+func TestConvertRuleGroup(t *testing.T) {
+	ds := promDS()
+	recordingGroup := apimodels.PrometheusRuleGroup{
+		Name:  "rec",
+		Rules: []apimodels.PrometheusRule{{Record: "job:latency:avg", Expr: "avg(latency)"}},
+	}
+
+	t.Run("keeps the original rule definition when requested", func(t *testing.T) {
+		group, err := ConvertRuleGroup(testCfg(false), ds, ds, 1, "folder-uid", alertGroup(), Options{
+			KeepOriginalRuleDefinition: true,
+		})
+		require.NoError(t, err)
+		require.Len(t, group.Rules, 1)
+		require.NotNil(t, group.Rules[0].Metadata.PrometheusStyleRule)
+		require.NotEmpty(t, group.Rules[0].Metadata.PrometheusStyleRule.OriginalRuleDefinition)
+	})
+
+	t.Run("rejects recording rules when the feature is disabled", func(t *testing.T) {
+		_, err := ConvertRuleGroup(testCfg(false), ds, ds, 1, "folder-uid", recordingGroup, Options{})
+		require.ErrorIs(t, err, ErrRecordingRulesNotEnabled)
+	})
+
+	t.Run("converts recording rules when the feature is enabled", func(t *testing.T) {
+		group, err := ConvertRuleGroup(testCfg(true), ds, ds, 1, "folder-uid", recordingGroup, Options{})
+		require.NoError(t, err)
+		require.Len(t, group.Rules, 1)
+		require.NotNil(t, group.Rules[0].Record)
+	})
+}
+
+func TestGroupHasRecordingRules(t *testing.T) {
+	require.False(t, GroupHasRecordingRules(alertGroup()))
+	require.True(t, GroupHasRecordingRules(apimodels.PrometheusRuleGroup{
+		Rules: []apimodels.PrometheusRule{{Alert: "A", Expr: "x"}, {Record: "r", Expr: "y"}},
+	}))
+}

--- a/pkg/services/ngalert/rulesync/fetch.go
+++ b/pkg/services/ngalert/rulesync/fetch.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/infra/log"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
@@ -45,12 +46,13 @@ type datasourceProxy interface {
 // datasource by routing the ruler config GET through Grafana's datasource proxy
 // service (transport, auth and egress validation are all handled there).
 type RulerFetcher struct {
-	proxy datasourceProxy
+	proxy  datasourceProxy
+	logger log.Logger
 }
 
 // NewRulerFetcher constructs a RulerFetcher around the datasource proxy service.
-func NewRulerFetcher(proxy datasourceProxy) *RulerFetcher {
-	return &RulerFetcher{proxy: proxy}
+func NewRulerFetcher(proxy datasourceProxy, logger log.Logger) *RulerFetcher {
+	return &RulerFetcher{proxy: proxy, logger: logger}
 }
 
 // Fetch retrieves the ruler configuration from ds, returning the parsed configs
@@ -86,6 +88,10 @@ func (f *RulerFetcher) Fetch(ctx context.Context, ds *datasources.DataSource) (R
 			Resp: web.NewResponseWriter(req.Method, &closeNotifierResponseWriter{resp}),
 		},
 		SignedInUser: serviceIdentityUser(ds.OrgID),
+		// The proxy calls ReqContext.JsonApiErr on failures (datasource lookup,
+		// access, plugin load), which logs via Logger when err != nil — it must be
+		// non-nil or that call panics (and this runs in a background goroutine).
+		Logger: f.logger,
 	}
 
 	f.proxy.ProxyDatasourceRequestWithUID(c, ds.UID)

--- a/pkg/services/ngalert/rulesync/fetch.go
+++ b/pkg/services/ngalert/rulesync/fetch.go
@@ -1,0 +1,152 @@
+package rulesync
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"hash/fnv"
+	"io"
+	"net/http"
+
+	"go.yaml.in/yaml/v3"
+
+	"github.com/grafana/grafana/pkg/api/response"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/services/datasources"
+	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/grafana/grafana/pkg/web"
+)
+
+// RulerConfig is the namespace-grouped rule configuration returned by a
+// Mimir ruler config API — the exact shape the convert API already
+// accepts (map[namespace][]PrometheusRuleGroup).
+type RulerConfig = map[string][]apimodels.PrometheusRuleGroup
+
+// ErrNotARuler indicates the datasource returned a 2xx response that does not
+// parse as namespace-grouped rule configs — i.e. it is not a Mimir ruler config
+// API — letting callers distinguish a misconfigured datasource from a fetch
+// failure (any non-2xx is classified as a transient fetch error). An empty ruler
+// (no rule groups) is NOT an error; see Fetch.
+var ErrNotARuler = errors.New("datasource does not expose a Mimir ruler config API")
+
+// datasourceProxy routes an outbound request through Grafana's datasource proxy
+// service, so the datasource's configured auth/TLS/headers are honoured and the
+// same egress allow/deny-list validation the user-driven proxy runs is applied.
+// *datasourceproxy.DataSourceProxyService satisfies it; a fake stands in for it
+// in tests.
+type datasourceProxy interface {
+	ProxyDatasourceRequestWithUID(c *contextmodel.ReqContext, dsUID string)
+}
+
+// RulerFetcher fetches namespace-grouped rule configs from a Mimir ruler
+// datasource by routing the ruler config GET through Grafana's datasource proxy
+// service (transport, auth and egress validation are all handled there).
+type RulerFetcher struct {
+	proxy datasourceProxy
+}
+
+// NewRulerFetcher constructs a RulerFetcher around the datasource proxy service.
+func NewRulerFetcher(proxy datasourceProxy) *RulerFetcher {
+	return &RulerFetcher{proxy: proxy}
+}
+
+// Fetch retrieves the ruler configuration from ds, returning the parsed configs
+// and the FNV-1a hash of the raw body (for cross-tick dedup). A 404 is "no rules
+// configured" (empty RulerConfig, nil error); any other non-2xx is a fetch
+// failure; an unparseable 2xx yields ErrNotARuler. The GET is routed through the datasource
+// proxy service, which loads the datasource by UID, access-checks SignedInUser,
+// validates egress, and derives the upstream path from the request URL
+// (/api/datasources/proxy/uid/<uid>/config/v1/rules -> config/v1/rules).
+func (f *RulerFetcher) Fetch(ctx context.Context, ds *datasources.DataSource) (RulerConfig, uint64, error) {
+	// Service-identity context so the proxy's requester lookup succeeds; Fetch
+	// runs from a background job with no user request context.
+	svcCtx, _ := identity.WithServiceIdentity(ctx, ds.OrgID)
+
+	// The proxy strips the /api/datasources/proxy/uid/<uid>/ prefix to derive the
+	// upstream path.
+	proxyURL := fmt.Sprintf("/api/datasources/proxy/uid/%s/config/v1/rules", ds.UID)
+	req, err := http.NewRequestWithContext(svcCtx, http.MethodGet, proxyURL, nil)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to create HTTP request: %w", err)
+	}
+	// Mimir serves the ruler config API as YAML.
+	req.Header.Set("Accept", "application/yaml")
+
+	// Capture the proxied reply in-memory (mirrors AlertingProxy.withReq in
+	// api/util.go): response.NormalResponse records status/body and the wrapper
+	// adds the CloseNotify method web.NewResponseWriter requires. SignedInUser is
+	// the org-scoped service identity the proxy access-checks.
+	resp := response.CreateNormalResponse(make(http.Header), nil, 0)
+	c := &contextmodel.ReqContext{
+		Context: &web.Context{
+			Req:  req,
+			Resp: web.NewResponseWriter(req.Method, &closeNotifierResponseWriter{resp}),
+		},
+		SignedInUser: serviceIdentityUser(ds.OrgID),
+	}
+
+	f.proxy.ProxyDatasourceRequestWithUID(c, ds.UID)
+
+	// 404 → no rule groups (mirrors Grafana's frontend ruler client).
+	if resp.Status() == http.StatusNotFound {
+		return RulerConfig{}, emptyHash, nil
+	}
+
+	if resp.Status()/100 != 2 {
+		// Any other non-2xx is a failed fetch (transient 5xx, auth, wrong URL, ...),
+		// not a definitive "not a ruler" signal — SyncOrg classifies it as a fetch
+		// failure. Cap the body echoed into the error.
+		body, _ := io.ReadAll(io.LimitReader(bytes.NewReader(resp.Body()), 1024))
+		return nil, 0, fmt.Errorf("ruler config API returned HTTP %d: %s", resp.Status(), string(body))
+	}
+
+	body := resp.Body()
+	var cfg RulerConfig
+	if err := yaml.Unmarshal(body, &cfg); err != nil {
+		return nil, 0, fmt.Errorf("%w: failed to parse response as ruler config: %v", ErrNotARuler, err)
+	}
+
+	h := fnv.New64a()
+	_, _ = h.Write(body)
+	return cfg, h.Sum64(), nil
+}
+
+// closeNotifierResponseWriter adapts the in-memory response.NormalResponse to
+// what web.NewResponseWriter expects, adding CloseNotify. Mirrors the
+// safeMacaronWrapper used by AlertingProxy (api/util.go).
+type closeNotifierResponseWriter struct {
+	http.ResponseWriter
+}
+
+func (w *closeNotifierResponseWriter) CloseNotify() <-chan bool {
+	return make(chan bool)
+}
+
+// serviceIdentityUser builds the *user.SignedInUser the datasource proxy
+// access-checks. The ReqContext requires a *user.SignedInUser, which
+// identity.WithServiceIdentity does not provide, so mirror it here carrying the
+// datasource query/read permissions the proxy's access check requires.
+func serviceIdentityUser(orgID int64) *user.SignedInUser {
+	return &user.SignedInUser{
+		OrgID:          orgID,
+		OrgRole:        identity.RoleAdmin,
+		Login:          "grafana_external_ruler_sync",
+		IsGrafanaAdmin: true,
+		Permissions: map[int64]map[string][]string{
+			orgID: {
+				datasources.ActionQuery: {datasources.ScopeAll},
+				datasources.ActionRead:  {datasources.ScopeAll},
+			},
+		},
+	}
+}
+
+// emptyHash is the FNV-1a hash of an empty body, used for the no-rules (404)
+// case so dedup treats "still empty" as unchanged across ticks.
+var emptyHash = func() uint64 {
+	h := fnv.New64a()
+	return h.Sum64()
+}()

--- a/pkg/services/ngalert/rulesync/fetch.go
+++ b/pkg/services/ngalert/rulesync/fetch.go
@@ -59,7 +59,7 @@ func NewRulerFetcher(proxy datasourceProxy, logger log.Logger) *RulerFetcher {
 // and the FNV-1a hash of the raw body (for cross-tick dedup). Any non-2xx
 // (including a 404) is a fetch failure — the ruler config list API returns 200
 // with an empty object when there are no rule groups, so a 404 is never "no
-// rules"; an unparseable or empty 2xx body yields ErrNotARuler. The GET is routed through the datasource
+// rules"; a 2xx body that is not a rule-config object (unparseable, empty or null) yields ErrNotARuler. The GET is routed through the datasource
 // proxy service, which loads the datasource by UID, access-checks SignedInUser,
 // validates egress, and derives the upstream path from the request URL
 // (/api/datasources/proxy/uid/<uid>/config/v1/rules -> config/v1/rules).
@@ -108,17 +108,16 @@ func (f *RulerFetcher) Fetch(ctx context.Context, ds *datasources.DataSource) (R
 	}
 
 	body := resp.Body()
-	// A ruler config API always returns at least an empty object ("{}") when it
-	// has no rule groups, so a 2xx with an empty body is a broken or non-ruler
-	// response, not "no rules" — treating it as empty would prune every synced
-	// rule. An empty YAML body also unmarshals to a nil map without error, so it
-	// must be rejected explicitly.
-	if len(bytes.TrimSpace(body)) == 0 {
-		return nil, 0, fmt.Errorf("%w: empty response body", ErrNotARuler)
-	}
 	var cfg RulerConfig
 	if err := yaml.Unmarshal(body, &cfg); err != nil {
 		return nil, 0, fmt.Errorf("%w: failed to parse response as ruler config: %v", ErrNotARuler, err)
+	}
+	// A real ruler returns "{}" (a non-nil empty map) when it has no rule groups. A
+	// nil map means the body was empty, null ("null"/"~"), or otherwise not a
+	// rule-config object — treating that as "no rules" would prune every synced
+	// rule, so reject it as not-a-ruler.
+	if cfg == nil {
+		return nil, 0, fmt.Errorf("%w: response is empty or null, not a rule-config object", ErrNotARuler)
 	}
 
 	h := fnv.New64a()

--- a/pkg/services/ngalert/rulesync/fetch.go
+++ b/pkg/services/ngalert/rulesync/fetch.go
@@ -56,9 +56,10 @@ func NewRulerFetcher(proxy datasourceProxy, logger log.Logger) *RulerFetcher {
 }
 
 // Fetch retrieves the ruler configuration from ds, returning the parsed configs
-// and the FNV-1a hash of the raw body (for cross-tick dedup). A 404 is "no rules
-// configured" (empty RulerConfig, nil error); any other non-2xx is a fetch
-// failure; an unparseable 2xx yields ErrNotARuler. The GET is routed through the datasource
+// and the FNV-1a hash of the raw body (for cross-tick dedup). Any non-2xx
+// (including a 404) is a fetch failure — the ruler config list API returns 200
+// with an empty object when there are no rule groups, so a 404 is never "no
+// rules"; an unparseable or empty 2xx body yields ErrNotARuler. The GET is routed through the datasource
 // proxy service, which loads the datasource by UID, access-checks SignedInUser,
 // validates egress, and derives the upstream path from the request URL
 // (/api/datasources/proxy/uid/<uid>/config/v1/rules -> config/v1/rules).
@@ -107,6 +108,14 @@ func (f *RulerFetcher) Fetch(ctx context.Context, ds *datasources.DataSource) (R
 	}
 
 	body := resp.Body()
+	// A ruler config API always returns at least an empty object ("{}") when it
+	// has no rule groups, so a 2xx with an empty body is a broken or non-ruler
+	// response, not "no rules" — treating it as empty would prune every synced
+	// rule. An empty YAML body also unmarshals to a nil map without error, so it
+	// must be rejected explicitly.
+	if len(bytes.TrimSpace(body)) == 0 {
+		return nil, 0, fmt.Errorf("%w: empty response body", ErrNotARuler)
+	}
 	var cfg RulerConfig
 	if err := yaml.Unmarshal(body, &cfg); err != nil {
 		return nil, 0, fmt.Errorf("%w: failed to parse response as ruler config: %v", ErrNotARuler, err)

--- a/pkg/services/ngalert/rulesync/fetch.go
+++ b/pkg/services/ngalert/rulesync/fetch.go
@@ -96,15 +96,12 @@ func (f *RulerFetcher) Fetch(ctx context.Context, ds *datasources.DataSource) (R
 
 	f.proxy.ProxyDatasourceRequestWithUID(c, ds.UID)
 
-	// 404 → no rule groups (mirrors Grafana's frontend ruler client).
-	if resp.Status() == http.StatusNotFound {
-		return RulerConfig{}, emptyHash, nil
-	}
-
+	// The ruler config list API returns HTTP 200 with an empty object when there
+	// are no rule groups (see Mimir's ListRules), so a non-2xx is never "no rules":
+	// a 404 here is a proxy-local error (datasource/plugin not found) or an upstream
+	// failure, not an empty ruler. Treat every non-2xx as a fetch failure so
+	// apply/prune never runs and synced rules aren't wiped.
 	if resp.Status()/100 != 2 {
-		// Any other non-2xx is a failed fetch (transient 5xx, auth, wrong URL, ...),
-		// not a definitive "not a ruler" signal — SyncOrg classifies it as a fetch
-		// failure. Cap the body echoed into the error.
 		body, _ := io.ReadAll(io.LimitReader(bytes.NewReader(resp.Body()), 1024))
 		return nil, 0, fmt.Errorf("ruler config API returned HTTP %d: %s", resp.Status(), string(body))
 	}
@@ -149,10 +146,3 @@ func serviceIdentityUser(orgID int64) *user.SignedInUser {
 		},
 	}
 }
-
-// emptyHash is the FNV-1a hash of an empty body, used for the no-rules (404)
-// case so dedup treats "still empty" as unchanged across ticks.
-var emptyHash = func() uint64 {
-	h := fnv.New64a()
-	return h.Sum64()
-}()

--- a/pkg/services/ngalert/rulesync/fetch_test.go
+++ b/pkg/services/ngalert/rulesync/fetch_test.go
@@ -94,13 +94,24 @@ func TestRulerFetcher_Fetch(t *testing.T) {
 		assert.Equal(t, "/api/datasources/proxy/uid/ds1/config/v1/rules", proxy.gotPath)
 	})
 
-	t.Run("404 yields an empty config and no error (empty ruler)", func(t *testing.T) {
-		proxy := &fakeDatasourceProxy{status: http.StatusNotFound, body: []byte("no rule groups found")}
+	t.Run("200 with an empty object yields an empty config (empty ruler)", func(t *testing.T) {
+		// Mimir's ListRules returns 200 with {} when there are no rule groups.
+		proxy := &fakeDatasourceProxy{status: http.StatusOK, body: []byte("{}")}
 
-		got, hash, err := NewRulerFetcher(proxy, log.NewNopLogger()).Fetch(ctx, testDS())
+		got, _, err := NewRulerFetcher(proxy, log.NewNopLogger()).Fetch(ctx, testDS())
 		require.NoError(t, err)
 		assert.Empty(t, got)
-		assert.Equal(t, emptyHash, hash)
+	})
+
+	t.Run("a 404 is a fetch error, never empty (list API returns 200 when empty)", func(t *testing.T) {
+		// A 404 is always an error here (e.g. the proxy can't find the
+		// datasource/plugin). Treating it as an empty ruler would prune every synced
+		// rule, so it must be a fetch error instead.
+		proxy := &fakeDatasourceProxy{status: http.StatusNotFound, body: []byte(`{"message":"Unable to find datasource plugin"}`)}
+
+		_, _, err := NewRulerFetcher(proxy, log.NewNopLogger()).Fetch(ctx, testDS())
+		require.Error(t, err)
+		assert.NotErrorIs(t, err, ErrNotARuler)
 	})
 
 	t.Run("non-2xx (not 404) is a fetch error, not ErrNotARuler", func(t *testing.T) {
@@ -140,6 +151,6 @@ func TestRulerFetcher_Fetch(t *testing.T) {
 		_, h2, err := f.Fetch(ctx, testDS())
 		require.NoError(t, err)
 		assert.Equal(t, h1, h2)
-		assert.NotEqual(t, emptyHash, h1)
+		assert.NotZero(t, h1)
 	})
 }

--- a/pkg/services/ngalert/rulesync/fetch_test.go
+++ b/pkg/services/ngalert/rulesync/fetch_test.go
@@ -1,0 +1,122 @@
+package rulesync
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v3"
+
+	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/services/datasources"
+	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+)
+
+// fakeDatasourceProxy stands in for *datasourceproxy.DataSourceProxyService. It
+// records the request it received and writes a canned status + body into the
+// ReqContext's ResponseWriter, simulating the proxied datasource response —
+// letting the fetcher be unit-tested without a live datasource or the full proxy
+// stack.
+type fakeDatasourceProxy struct {
+	status int
+	body   []byte
+
+	// captured from the most recent call
+	gotUID  string
+	gotPath string
+	calls   int
+}
+
+func (f *fakeDatasourceProxy) ProxyDatasourceRequestWithUID(c *contextmodel.ReqContext, dsUID string) {
+	f.calls++
+	f.gotUID = dsUID
+	f.gotPath = c.Req.URL.Path
+
+	status := f.status
+	if status == 0 {
+		status = http.StatusOK
+	}
+	c.Resp.WriteHeader(status)
+	_, _ = c.Resp.Write(f.body)
+}
+
+func testDS() *datasources.DataSource {
+	return &datasources.DataSource{UID: "ds1", OrgID: 1, Type: datasources.DS_PROMETHEUS, URL: "http://mimir:9009/prometheus"}
+}
+
+func TestRulerFetcher_Fetch(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("parses namespace-grouped rule configs", func(t *testing.T) {
+		want := RulerConfig{
+			"ns1": {{Name: "group1", Rules: []apimodels.PrometheusRule{{Alert: "A", Expr: "up == 0"}}}},
+			"ns2": {{Name: "group2", Rules: []apimodels.PrometheusRule{{Record: "r", Expr: "vector(1)"}}}},
+		}
+		body, err := yaml.Marshal(want)
+		require.NoError(t, err)
+		proxy := &fakeDatasourceProxy{status: http.StatusOK, body: body}
+
+		got, hash, err := NewRulerFetcher(proxy).Fetch(ctx, testDS())
+		require.NoError(t, err)
+		assert.NotZero(t, hash)
+		require.Len(t, got, 2)
+		require.Len(t, got["ns1"], 1)
+		assert.Equal(t, "group1", got["ns1"][0].Name)
+		require.Len(t, got["ns1"][0].Rules, 1)
+		assert.Equal(t, "A", got["ns1"][0].Rules[0].Alert)
+		assert.Equal(t, "group2", got["ns2"][0].Name)
+	})
+
+	t.Run("routes through the proxy with the expected uid and path", func(t *testing.T) {
+		proxy := &fakeDatasourceProxy{status: http.StatusOK, body: []byte("{}")}
+
+		_, _, err := NewRulerFetcher(proxy).Fetch(ctx, testDS())
+		require.NoError(t, err)
+		assert.Equal(t, 1, proxy.calls)
+		assert.Equal(t, "ds1", proxy.gotUID)
+		// The proxy strips /api/datasources/proxy/uid/<uid>/ to derive the upstream
+		// path, so the config path must sit after that prefix.
+		assert.Equal(t, "/api/datasources/proxy/uid/ds1/config/v1/rules", proxy.gotPath)
+	})
+
+	t.Run("404 yields an empty config and no error (empty ruler)", func(t *testing.T) {
+		proxy := &fakeDatasourceProxy{status: http.StatusNotFound, body: []byte("no rule groups found")}
+
+		got, hash, err := NewRulerFetcher(proxy).Fetch(ctx, testDS())
+		require.NoError(t, err)
+		assert.Empty(t, got)
+		assert.Equal(t, emptyHash, hash)
+	})
+
+	t.Run("non-2xx (not 404) is a fetch error, not ErrNotARuler", func(t *testing.T) {
+		proxy := &fakeDatasourceProxy{status: http.StatusInternalServerError, body: []byte("boom")}
+
+		_, _, err := NewRulerFetcher(proxy).Fetch(ctx, testDS())
+		require.Error(t, err)
+		assert.NotErrorIs(t, err, ErrNotARuler)
+	})
+
+	t.Run("200 with unparseable body is ErrNotARuler", func(t *testing.T) {
+		// A YAML scalar cannot unmarshal into map[string][]PrometheusRuleGroup.
+		proxy := &fakeDatasourceProxy{status: http.StatusOK, body: []byte("just a string, not a ruler config")}
+
+		_, _, err := NewRulerFetcher(proxy).Fetch(ctx, testDS())
+		assert.ErrorIs(t, err, ErrNotARuler)
+	})
+
+	t.Run("hash is stable for identical responses (dedup)", func(t *testing.T) {
+		body, err := yaml.Marshal(RulerConfig{"ns": {{Name: "g", Rules: []apimodels.PrometheusRule{{Alert: "A", Expr: "up"}}}}})
+		require.NoError(t, err)
+		proxy := &fakeDatasourceProxy{status: http.StatusOK, body: body}
+		f := NewRulerFetcher(proxy)
+
+		_, h1, err := f.Fetch(ctx, testDS())
+		require.NoError(t, err)
+		_, h2, err := f.Fetch(ctx, testDS())
+		require.NoError(t, err)
+		assert.Equal(t, h1, h2)
+		assert.NotEqual(t, emptyHash, h1)
+	})
+}

--- a/pkg/services/ngalert/rulesync/fetch_test.go
+++ b/pkg/services/ngalert/rulesync/fetch_test.go
@@ -103,14 +103,15 @@ func TestRulerFetcher_Fetch(t *testing.T) {
 		assert.Empty(t, got)
 	})
 
-	t.Run("200 with an empty body is ErrNotARuler (a ruler returns at least {})", func(t *testing.T) {
-		// A truly empty body (unlike {}) would unmarshal to a nil map and prune
-		// everything; a real ruler never returns that, so reject it.
-		for _, body := range [][]byte{[]byte(""), []byte("  \n")} {
+	t.Run("200 with an empty or null body is ErrNotARuler (a ruler returns at least {})", func(t *testing.T) {
+		// Empty, whitespace and YAML null bodies all unmarshal to a nil map, which
+		// must not be treated as "no rules" (that would prune everything); a real
+		// ruler returns at least "{}".
+		for _, body := range [][]byte{[]byte(""), []byte("  \n"), []byte("null"), []byte("~"), []byte("null\n")} {
 			proxy := &fakeDatasourceProxy{status: http.StatusOK, body: body}
 
 			_, _, err := NewRulerFetcher(proxy, log.NewNopLogger()).Fetch(ctx, testDS())
-			require.Error(t, err)
+			require.Errorf(t, err, "body %q should be rejected", string(body))
 			assert.ErrorIs(t, err, ErrNotARuler)
 		}
 	})

--- a/pkg/services/ngalert/rulesync/fetch_test.go
+++ b/pkg/services/ngalert/rulesync/fetch_test.go
@@ -2,6 +2,7 @@ package rulesync
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"testing"
 
@@ -9,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.yaml.in/yaml/v3"
 
+	"github.com/grafana/grafana/pkg/infra/log"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
@@ -23,6 +25,12 @@ type fakeDatasourceProxy struct {
 	status int
 	body   []byte
 
+	// if apiErr is set, respond via ReqContext.JsonApiErr (which logs via
+	// c.Logger), mimicking the real proxy's error paths (datasource not found,
+	// access denied, plugin load).
+	apiErrStatus int
+	apiErr       error
+
 	// captured from the most recent call
 	gotUID  string
 	gotPath string
@@ -33,6 +41,11 @@ func (f *fakeDatasourceProxy) ProxyDatasourceRequestWithUID(c *contextmodel.ReqC
 	f.calls++
 	f.gotUID = dsUID
 	f.gotPath = c.Req.URL.Path
+
+	if f.apiErr != nil {
+		c.JsonApiErr(f.apiErrStatus, "proxy error", f.apiErr)
+		return
+	}
 
 	status := f.status
 	if status == 0 {
@@ -58,7 +71,7 @@ func TestRulerFetcher_Fetch(t *testing.T) {
 		require.NoError(t, err)
 		proxy := &fakeDatasourceProxy{status: http.StatusOK, body: body}
 
-		got, hash, err := NewRulerFetcher(proxy).Fetch(ctx, testDS())
+		got, hash, err := NewRulerFetcher(proxy, log.NewNopLogger()).Fetch(ctx, testDS())
 		require.NoError(t, err)
 		assert.NotZero(t, hash)
 		require.Len(t, got, 2)
@@ -72,7 +85,7 @@ func TestRulerFetcher_Fetch(t *testing.T) {
 	t.Run("routes through the proxy with the expected uid and path", func(t *testing.T) {
 		proxy := &fakeDatasourceProxy{status: http.StatusOK, body: []byte("{}")}
 
-		_, _, err := NewRulerFetcher(proxy).Fetch(ctx, testDS())
+		_, _, err := NewRulerFetcher(proxy, log.NewNopLogger()).Fetch(ctx, testDS())
 		require.NoError(t, err)
 		assert.Equal(t, 1, proxy.calls)
 		assert.Equal(t, "ds1", proxy.gotUID)
@@ -84,7 +97,7 @@ func TestRulerFetcher_Fetch(t *testing.T) {
 	t.Run("404 yields an empty config and no error (empty ruler)", func(t *testing.T) {
 		proxy := &fakeDatasourceProxy{status: http.StatusNotFound, body: []byte("no rule groups found")}
 
-		got, hash, err := NewRulerFetcher(proxy).Fetch(ctx, testDS())
+		got, hash, err := NewRulerFetcher(proxy, log.NewNopLogger()).Fetch(ctx, testDS())
 		require.NoError(t, err)
 		assert.Empty(t, got)
 		assert.Equal(t, emptyHash, hash)
@@ -93,7 +106,17 @@ func TestRulerFetcher_Fetch(t *testing.T) {
 	t.Run("non-2xx (not 404) is a fetch error, not ErrNotARuler", func(t *testing.T) {
 		proxy := &fakeDatasourceProxy{status: http.StatusInternalServerError, body: []byte("boom")}
 
-		_, _, err := NewRulerFetcher(proxy).Fetch(ctx, testDS())
+		_, _, err := NewRulerFetcher(proxy, log.NewNopLogger()).Fetch(ctx, testDS())
+		require.Error(t, err)
+		assert.NotErrorIs(t, err, ErrNotARuler)
+	})
+
+	t.Run("proxy error path does not panic (nil-logger regression)", func(t *testing.T) {
+		// The real proxy calls ReqContext.JsonApiErr on failures, which logs via
+		// c.Logger; Fetch must supply a non-nil logger or this panics.
+		proxy := &fakeDatasourceProxy{apiErrStatus: http.StatusForbidden, apiErr: errors.New("access denied")}
+
+		_, _, err := NewRulerFetcher(proxy, log.NewNopLogger()).Fetch(ctx, testDS())
 		require.Error(t, err)
 		assert.NotErrorIs(t, err, ErrNotARuler)
 	})
@@ -102,7 +125,7 @@ func TestRulerFetcher_Fetch(t *testing.T) {
 		// A YAML scalar cannot unmarshal into map[string][]PrometheusRuleGroup.
 		proxy := &fakeDatasourceProxy{status: http.StatusOK, body: []byte("just a string, not a ruler config")}
 
-		_, _, err := NewRulerFetcher(proxy).Fetch(ctx, testDS())
+		_, _, err := NewRulerFetcher(proxy, log.NewNopLogger()).Fetch(ctx, testDS())
 		assert.ErrorIs(t, err, ErrNotARuler)
 	})
 
@@ -110,7 +133,7 @@ func TestRulerFetcher_Fetch(t *testing.T) {
 		body, err := yaml.Marshal(RulerConfig{"ns": {{Name: "g", Rules: []apimodels.PrometheusRule{{Alert: "A", Expr: "up"}}}}})
 		require.NoError(t, err)
 		proxy := &fakeDatasourceProxy{status: http.StatusOK, body: body}
-		f := NewRulerFetcher(proxy)
+		f := NewRulerFetcher(proxy, log.NewNopLogger())
 
 		_, h1, err := f.Fetch(ctx, testDS())
 		require.NoError(t, err)

--- a/pkg/services/ngalert/rulesync/fetch_test.go
+++ b/pkg/services/ngalert/rulesync/fetch_test.go
@@ -103,6 +103,18 @@ func TestRulerFetcher_Fetch(t *testing.T) {
 		assert.Empty(t, got)
 	})
 
+	t.Run("200 with an empty body is ErrNotARuler (a ruler returns at least {})", func(t *testing.T) {
+		// A truly empty body (unlike {}) would unmarshal to a nil map and prune
+		// everything; a real ruler never returns that, so reject it.
+		for _, body := range [][]byte{[]byte(""), []byte("  \n")} {
+			proxy := &fakeDatasourceProxy{status: http.StatusOK, body: body}
+
+			_, _, err := NewRulerFetcher(proxy, log.NewNopLogger()).Fetch(ctx, testDS())
+			require.Error(t, err)
+			assert.ErrorIs(t, err, ErrNotARuler)
+		}
+	})
+
 	t.Run("a 404 is a fetch error, never empty (list API returns 200 when empty)", func(t *testing.T) {
 		// A 404 is always an error here (e.g. the proxy can't find the
 		// datasource/plugin). Treating it as an empty ruler would prune every synced

--- a/pkg/services/ngalert/rulesync/metrics.go
+++ b/pkg/services/ngalert/rulesync/metrics.go
@@ -1,0 +1,62 @@
+package rulesync
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
+)
+
+// mask53 masks a 64-bit hash to 53 bits so it fits Prometheus's float64 gauge
+// storage without loss, matching the alertmanager_config_hash / external AM
+// sync hash gauges.
+const mask53 = (1 << 53) - 1
+
+// Metrics holds the external ruler sync metrics. They mirror the external
+// Alertmanager config sync metrics (partitioned by org, and by reason for
+// failures) so operators get a consistent view across both syncs.
+type Metrics struct {
+	// SyncTotal counts sync attempts that successfully fetched and parsed the
+	// upstream ruler config, by org (includes ticks deduped to the same hash).
+	SyncTotal *prometheus.CounterVec
+	// SyncFailures counts failed sync attempts by org and reason.
+	SyncFailures *prometheus.CounterVec
+	// SyncDuration measures per-org sync duration in seconds.
+	SyncDuration *prometheus.HistogramVec
+	// SyncHash exposes the FNV-1a hash of the most recently synced ruler config
+	// per org (masked to 53 bits), so operators can correlate sync state with
+	// what's applied.
+	SyncHash *prometheus.GaugeVec
+}
+
+// NewMetrics constructs the external ruler sync metrics against r. Pass nil to
+// disable registration (e.g. in tests).
+func NewMetrics(r prometheus.Registerer) *Metrics {
+	return &Metrics{
+		SyncTotal: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: metrics.Subsystem,
+			Name:      "external_ruler_sync_total",
+			Help:      "Total number of successful external ruler sync attempts, partitioned by org.",
+		}, []string{"org_id"}),
+		SyncFailures: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: metrics.Subsystem,
+			Name:      "external_ruler_sync_failures_total",
+			Help:      "Total number of failed external ruler sync attempts, partitioned by org and failure reason.",
+		}, []string{"org_id", "reason"}),
+		SyncDuration: promauto.With(r).NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: metrics.Subsystem,
+			Name:      "external_ruler_sync_duration_seconds",
+			Help:      "Duration of external ruler sync operations in seconds, partitioned by org.",
+			Buckets:   prometheus.DefBuckets,
+		}, []string{"org_id"}),
+		SyncHash: promauto.With(r).NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: metrics.Subsystem,
+			Name:      "external_ruler_sync_hash",
+			Help:      "FNV-1a hash of the most recently synced external ruler configuration per org, masked to 53 bits to fit Prometheus float64 storage.",
+		}, []string{"org_id"}),
+	}
+}

--- a/pkg/services/ngalert/rulesync/metrics.go
+++ b/pkg/services/ngalert/rulesync/metrics.go
@@ -27,6 +27,12 @@ type Metrics struct {
 	// per org (masked to 53 bits), so operators can correlate sync state with
 	// what's applied.
 	SyncHash *prometheus.GaugeVec
+	// SyncGroups exposes the number of rule groups applied in the most recent
+	// successful sync, per org.
+	SyncGroups *prometheus.GaugeVec
+	// SyncRules exposes the number of rules applied in the most recent successful
+	// sync, per org.
+	SyncRules *prometheus.GaugeVec
 }
 
 // NewMetrics constructs the external ruler sync metrics against r. Pass nil to
@@ -57,6 +63,18 @@ func NewMetrics(r prometheus.Registerer) *Metrics {
 			Subsystem: metrics.Subsystem,
 			Name:      "external_ruler_sync_hash",
 			Help:      "FNV-1a hash of the most recently synced external ruler configuration per org, masked to 53 bits to fit Prometheus float64 storage.",
+		}, []string{"org_id"}),
+		SyncGroups: promauto.With(r).NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: metrics.Subsystem,
+			Name:      "external_ruler_sync_groups",
+			Help:      "Number of rule groups applied in the most recent successful external ruler sync, partitioned by org.",
+		}, []string{"org_id"}),
+		SyncRules: promauto.With(r).NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: metrics.Subsystem,
+			Name:      "external_ruler_sync_rules",
+			Help:      "Number of rules applied in the most recent successful external ruler sync, partitioned by org.",
 		}, []string{"org_id"}),
 	}
 }

--- a/pkg/services/ngalert/rulesync/status.go
+++ b/pkg/services/ngalert/rulesync/status.go
@@ -16,6 +16,9 @@ const (
 	ReasonConvert   SyncReason = "convert"
 	ReasonSave      SyncReason = "save"
 	ReasonPrune     SyncReason = "prune"
+	// ReasonPanic is recorded when a per-org sync tick panics and is recovered so
+	// the background goroutine (and the process) survives.
+	ReasonPanic SyncReason = "panic"
 	// ReasonUnclassified is the safety net for errors not tagged with
 	// *SyncError. Keeps Prometheus label cardinality bounded.
 	ReasonUnclassified SyncReason = "unclassified"

--- a/pkg/services/ngalert/rulesync/status.go
+++ b/pkg/services/ngalert/rulesync/status.go
@@ -1,0 +1,50 @@
+package rulesync
+
+import "errors"
+
+// SyncReason categorises a sync failure. The snake_case value is the Prometheus
+// `reason` metric label. Single source of truth: wrap errors in *SyncError,
+// extract via reasonOf.
+type SyncReason string
+
+const (
+	ReasonDatasourceLookup SyncReason = "datasource_lookup"
+	ReasonRulerFetch       SyncReason = "ruler_fetch"
+	// ReasonNotARuler: the datasource responded but not as a ruler config API
+	// (see ErrNotARuler). Distinct from ReasonRulerFetch (fetch failure).
+	ReasonNotARuler SyncReason = "not_a_ruler"
+	ReasonConvert   SyncReason = "convert"
+	ReasonSave      SyncReason = "save"
+	ReasonPrune     SyncReason = "prune"
+	// ReasonUnclassified is the safety net for errors not tagged with
+	// *SyncError. Keeps Prometheus label cardinality bounded.
+	ReasonUnclassified SyncReason = "unclassified"
+)
+
+func (r SyncReason) Label() string { return string(r) }
+
+// SyncError tags an error with a SyncReason so callers can classify via
+// errors.As without parsing messages.
+type SyncError struct {
+	Reason SyncReason
+	Cause  error
+}
+
+func (e *SyncError) Error() string {
+	if e.Cause == nil {
+		return string(e.Reason)
+	}
+	return e.Cause.Error()
+}
+
+func (e *SyncError) Unwrap() error { return e.Cause }
+
+// reasonOf extracts the SyncReason via errors.As. Returns ReasonUnclassified
+// for un-tagged errors — keeps metric label cardinality bounded.
+func reasonOf(err error) SyncReason {
+	var se *SyncError
+	if errors.As(err, &se) {
+		return se.Reason
+	}
+	return ReasonUnclassified
+}

--- a/pkg/services/ngalert/rulesync/status.go
+++ b/pkg/services/ngalert/rulesync/status.go
@@ -13,7 +13,6 @@ const (
 	// ReasonNotARuler: the datasource responded but not as a ruler config API
 	// (see ErrNotARuler). Distinct from ReasonRulerFetch (fetch failure).
 	ReasonNotARuler SyncReason = "not_a_ruler"
-	ReasonConvert   SyncReason = "convert"
 	ReasonSave      SyncReason = "save"
 	ReasonPrune     SyncReason = "prune"
 	// ReasonPanic is recorded when a per-org sync tick panics and is recovered so

--- a/pkg/services/ngalert/rulesync/status_test.go
+++ b/pkg/services/ngalert/rulesync/status_test.go
@@ -1,0 +1,24 @@
+package rulesync
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReasonOf(t *testing.T) {
+	assert.Equal(t, ReasonUnclassified, reasonOf(errors.New("bare")))
+	assert.Equal(t, ReasonNotARuler, reasonOf(&SyncError{Reason: ReasonNotARuler, Cause: ErrNotARuler}))
+	// Wrapped SyncError is still classified.
+	assert.Equal(t, ReasonSave, reasonOf(&SyncError{Reason: ReasonSave, Cause: errors.New("db down")}))
+}
+
+func TestSyncError_UnwrapAndMessage(t *testing.T) {
+	cause := errors.New("db down")
+	e := &SyncError{Reason: ReasonSave, Cause: cause}
+	assert.Equal(t, "db down", e.Error())
+	assert.ErrorIs(t, e, cause)
+	// Nil cause falls back to the reason label.
+	assert.Equal(t, "save", (&SyncError{Reason: ReasonSave}).Error())
+}

--- a/pkg/services/ngalert/rulesync/syncer.go
+++ b/pkg/services/ngalert/rulesync/syncer.go
@@ -101,7 +101,7 @@ func NewExternalRulerSyncer(
 		logger:         logger,
 		metrics:        m,
 		datasources:    datasourceService,
-		fetcher:        NewRulerFetcher(proxy),
+		fetcher:        NewRulerFetcher(proxy, logger),
 		ruleService:    ruleSvc,
 		namespaceStore: namespaceStore,
 		orgStore:       orgStore,

--- a/pkg/services/ngalert/rulesync/syncer.go
+++ b/pkg/services/ngalert/rulesync/syncer.go
@@ -206,6 +206,11 @@ func (s *ExternalRulerSyncer) SyncOrg(ctx context.Context, orgID int64) {
 		s.recordFailure(orgID, orgIDStr, &SyncError{Reason: ReasonDatasourceLookup, Cause: err})
 		return
 	}
+	// TODO: validate the datasource (prometheus-compatible + Mimir flavor) at the
+	// rules-app Config-resource admission when it lands, mirroring the external
+	// Alertmanager sync's input-time check. The operator-set ini datasource is
+	// trusted here (as the AM ini path is).
+	//
 	// Recording rules write to the same datasource they are queried from.
 	targetDS := ds
 

--- a/pkg/services/ngalert/rulesync/syncer.go
+++ b/pkg/services/ngalert/rulesync/syncer.go
@@ -1,0 +1,338 @@
+package rulesync
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/services/datasourceproxy"
+	"github.com/grafana/grafana/pkg/services/datasources"
+	"github.com/grafana/grafana/pkg/services/folder"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/services/ngalert/prom"
+	"github.com/grafana/grafana/pkg/services/ngalert/provisioning"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+// rootFolderTitle is the title of the dedicated folder the syncer lands imported
+// namespaces under, isolating them from user-managed folders. One folder per
+// ruler datasource UID so distinct rulers never collide. prune and
+// IsManagedFolder key on the folder UID, not this title, so a pre-existing user
+// folder with the same title is harmless.
+func rootFolderTitle(dsUID string) string {
+	return fmt.Sprintf("[Alerting] External Ruler Sync (%s)", dsUID)
+}
+
+const versionMessage = "external ruler sync"
+
+// convertedPrometheusManager marks the rules the syncer owns. Mirrors the manager
+// the convert API assigns to converted-Prometheus imports.
+var convertedPrometheusManager = utils.ManagerProperties{Kind: utils.ManagerKindClassicConvertedPrometheus} //nolint:staticcheck
+
+// ruleService is the subset of provisioning.AlertRuleService the syncer needs.
+type ruleService interface {
+	ReplaceRuleGroups(ctx context.Context, user identity.Requester, groups []*models.AlertRuleGroup, manager utils.ManagerProperties, versionMessage string) error
+	DeleteRuleGroups(ctx context.Context, user identity.Requester, manager utils.ManagerProperties, filterOpts *provisioning.FilterOptions) error
+	GetAlertGroupsWithFolderFullpath(ctx context.Context, user identity.Requester, filterOpts *provisioning.FilterOptions) ([]models.AlertRuleGroupWithFolderFullpath, error)
+}
+
+// namespaceStore creates/looks up the folders the imported rules live in.
+type namespaceStore interface {
+	GetOrCreateNamespaceByTitle(ctx context.Context, title string, orgID int64, user identity.Requester, parentUID string) (*folder.FolderReference, bool, error)
+	GetNamespaceByTitle(ctx context.Context, title string, orgID int64, user identity.Requester, parentUID string) (*folder.FolderReference, error)
+	GetNamespaceChildren(ctx context.Context, uid string, orgID int64, user identity.Requester) ([]*folder.FolderReference, error)
+}
+
+// rulerFetcher fetches the upstream ruler config. Satisfied by *RulerFetcher.
+type rulerFetcher interface {
+	Fetch(ctx context.Context, ds *datasources.DataSource) (RulerConfig, uint64, error)
+}
+
+type datasourceGetter interface {
+	GetDataSource(ctx context.Context, query *datasources.GetDataSourceQuery) (*datasources.DataSource, error)
+}
+
+type orgStore interface {
+	FetchOrgIds(ctx context.Context) ([]int64, error)
+}
+
+// ExternalRulerSyncer mirrors alert rules from a configured external Mimir
+// ruler datasource into Grafana as converted-Prometheus rules. It is the rule
+// analogue of ExternalAMSyncer. The loop driver (Run) is intentionally thin so
+// the same SyncOrg core could later be hosted by an app runner instead.
+type ExternalRulerSyncer struct {
+	settings *setting.UnifiedAlertingSettings
+	logger   log.Logger
+	metrics  *Metrics
+
+	datasources    datasourceGetter
+	fetcher        rulerFetcher
+	ruleService    ruleService
+	namespaceStore namespaceStore
+	orgStore       orgStore
+
+	lastSyncHashMu sync.RWMutex
+	lastSyncHash   map[int64]uint64
+}
+
+// NewExternalRulerSyncer constructs an ExternalRulerSyncer. The ruler config GET
+// is routed through the datasource proxy service (transport, auth and egress
+// validation are handled there). The syncer runs from the external_ruler_uid
+// ini setting alone.
+func NewExternalRulerSyncer(
+	settings *setting.UnifiedAlertingSettings,
+	logger log.Logger,
+	m *Metrics,
+	datasourceService datasources.DataSourceService,
+	proxy *datasourceproxy.DataSourceProxyService,
+	ruleSvc ruleService,
+	namespaceStore namespaceStore,
+	orgStore orgStore,
+) *ExternalRulerSyncer {
+	return &ExternalRulerSyncer{
+		settings:       settings,
+		logger:         logger,
+		metrics:        m,
+		datasources:    datasourceService,
+		fetcher:        NewRulerFetcher(proxy),
+		ruleService:    ruleSvc,
+		namespaceStore: namespaceStore,
+		orgStore:       orgStore,
+		lastSyncHash:   make(map[int64]uint64),
+	}
+}
+
+// Run polls all orgs at AdminConfigPollInterval until ctx is cancelled. It is a
+// no-op unless the operator configured a ruler datasource via the
+// external_ruler_uid setting — that setting is the enable signal (there is no
+// separate feature flag).
+func (s *ExternalRulerSyncer) Run(ctx context.Context) error {
+	if s.settings.ExternalRulerUID == "" {
+		s.logger.Debug("External ruler sync not configured (external_ruler_uid unset); not starting")
+		return nil
+	}
+	s.logger.Info("Starting external ruler syncer", "poll_interval", s.settings.AdminConfigPollInterval)
+	ticker := time.NewTicker(s.settings.AdminConfigPollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			s.syncAllOrgs(ctx)
+		}
+	}
+}
+
+func (s *ExternalRulerSyncer) syncAllOrgs(ctx context.Context) {
+	orgIDs, err := s.orgStore.FetchOrgIds(ctx)
+	if err != nil {
+		s.logger.Error("Failed to fetch org IDs for external ruler sync", "error", err)
+		return
+	}
+	for _, orgID := range orgIDs {
+		if _, disabled := s.settings.DisabledOrgs[orgID]; disabled {
+			continue
+		}
+		s.SyncOrg(ctx, orgID)
+	}
+}
+
+// IsConfiguredForOrg reports whether external ruler sync is configured — i.e.
+// the external_ruler_uid ini setting is set. Used by the convert API to reject
+// manual rule imports while sync owns the org's rules.
+func (s *ExternalRulerSyncer) IsConfiguredForOrg(_ context.Context, _ int64) (bool, error) {
+	return s.settings.ExternalRulerUID != "", nil
+}
+
+// IsManagedFolder reports whether folderUID is inside the org's sync-managed
+// folder subtree — the dedicated root folder (resolved by its deterministic
+// title) or one of its namespace subfolders. The convert API uses it to fold the
+// 409 gate down to just the folders the sync worker owns, so manual imports into
+// unrelated folders are still allowed. If the root folder doesn't exist yet
+// nothing is managed, so this returns false (allow).
+func (s *ExternalRulerSyncer) IsManagedFolder(ctx context.Context, orgID int64, folderUID string) (bool, error) {
+	uid := s.settings.ExternalRulerUID
+	if uid == "" {
+		return false, nil
+	}
+	svcCtx, user := identity.WithServiceIdentity(ctx, orgID)
+	root, err := s.namespaceStore.GetNamespaceByTitle(svcCtx, rootFolderTitle(uid), orgID, user, "")
+	if err != nil {
+		if errors.Is(err, dashboards.ErrFolderNotFound) {
+			return false, nil
+		}
+		return false, fmt.Errorf("look up sync root folder: %w", err)
+	}
+	if folderUID == root.UID {
+		return true, nil
+	}
+	// Namespaces are the only subfolders and never nest, so direct children suffice.
+	children, err := s.namespaceStore.GetNamespaceChildren(svcCtx, root.UID, orgID, user)
+	if err != nil {
+		return false, fmt.Errorf("list sync folder children: %w", err)
+	}
+	for _, child := range children {
+		if child.UID == folderUID {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// SyncOrg runs one sync tick for a single org. It never returns an error;
+// failures are logged and counted so a bad org can't break the others.
+func (s *ExternalRulerSyncer) SyncOrg(ctx context.Context, orgID int64) {
+	uid := s.settings.ExternalRulerUID
+	if uid == "" {
+		return
+	}
+	orgIDStr := strconv.FormatInt(orgID, 10)
+
+	svcCtx, svcUser := identity.WithServiceIdentity(ctx, orgID)
+
+	start := time.Now()
+	defer func() { s.metrics.SyncDuration.WithLabelValues(orgIDStr).Observe(time.Since(start).Seconds()) }()
+
+	ds, err := s.datasources.GetDataSource(svcCtx, &datasources.GetDataSourceQuery{UID: uid, OrgID: orgID})
+	if err != nil {
+		s.recordFailure(orgID, orgIDStr, &SyncError{Reason: ReasonDatasourceLookup, Cause: err})
+		return
+	}
+	// Recording rules write to the same datasource they are queried from.
+	targetDS := ds
+
+	cfg, hash, err := s.fetcher.Fetch(svcCtx, ds)
+	if err != nil {
+		reason := ReasonRulerFetch
+		if errors.Is(err, ErrNotARuler) {
+			reason = ReasonNotARuler
+		}
+		s.recordFailure(orgID, orgIDStr, &SyncError{Reason: reason, Cause: err})
+		return
+	}
+	s.metrics.SyncTotal.WithLabelValues(orgIDStr).Inc()
+
+	// Skip if the upstream is unchanged since the last successful apply.
+	s.lastSyncHashMu.RLock()
+	prev, has := s.lastSyncHash[orgID]
+	s.lastSyncHashMu.RUnlock()
+	if has && prev == hash {
+		s.logger.Debug("External ruler config unchanged since last sync", "org_id", orgID)
+		return
+	}
+
+	if applyErr := s.apply(svcCtx, svcUser, orgID, ds, targetDS, cfg); applyErr != nil {
+		s.recordFailure(orgID, orgIDStr, applyErr)
+		return
+	}
+
+	s.lastSyncHashMu.Lock()
+	s.lastSyncHash[orgID] = hash
+	s.lastSyncHashMu.Unlock()
+	s.metrics.SyncHash.WithLabelValues(orgIDStr).Set(float64(hash & mask53))
+	s.logger.Debug("External ruler sync applied", "org_id", orgID, "namespaces", len(cfg))
+}
+
+type groupKey struct {
+	folderUID string
+	group     string
+}
+
+// apply converts the fetched ruler config into Grafana rule groups, persists
+// them, and prunes previously-synced groups that vanished upstream. Returns a
+// classified *SyncError on failure.
+func (s *ExternalRulerSyncer) apply(ctx context.Context, user identity.Requester, orgID int64, ds *datasources.DataSource, targetDS *datasources.DataSource, cfg RulerConfig) *SyncError {
+	root, _, err := s.namespaceStore.GetOrCreateNamespaceByTitle(ctx, rootFolderTitle(ds.UID), orgID, user, "")
+	if err != nil {
+		return &SyncError{Reason: ReasonSave, Cause: fmt.Errorf("get-or-create root folder: %w", err)}
+	}
+
+	groups := make([]*models.AlertRuleGroup, 0)
+	desired := make(map[groupKey]struct{})
+	for namespace, promGroups := range cfg {
+		nsFolder, _, err := s.namespaceStore.GetOrCreateNamespaceByTitle(ctx, namespace, orgID, user, root.UID)
+		if err != nil {
+			return &SyncError{Reason: ReasonSave, Cause: fmt.Errorf("get-or-create namespace folder %q: %w", namespace, err)}
+		}
+		for _, promGroup := range promGroups {
+			group, err := prom.ConvertRuleGroup(s.settings, ds, targetDS, orgID, nsFolder.UID, promGroup, prom.Options{
+				KeepOriginalRuleDefinition: true,
+			})
+			if err != nil {
+				return &SyncError{Reason: ReasonConvert, Cause: fmt.Errorf("convert group %q in namespace %q: %w", promGroup.Name, namespace, err)}
+			}
+			groups = append(groups, group)
+			desired[groupKey{folderUID: nsFolder.UID, group: group.Title}] = struct{}{}
+		}
+	}
+
+	if err := s.ruleService.ReplaceRuleGroups(ctx, user, groups, convertedPrometheusManager, versionMessage); err != nil {
+		return &SyncError{Reason: ReasonSave, Cause: err}
+	}
+
+	if err := s.prune(ctx, user, orgID, root.UID, desired); err != nil {
+		return &SyncError{Reason: ReasonPrune, Cause: err}
+	}
+	return nil
+}
+
+// prune deletes converted-Prometheus rule groups that live under the sync's
+// dedicated folder subtree (the root folder and its namespace subfolders) but
+// that are no longer present upstream. Scoping the store queries to those
+// folders ensures we never enumerate or delete converted rules that live in
+// user-managed folders.
+func (s *ExternalRulerSyncer) prune(ctx context.Context, user identity.Requester, orgID int64, rootUID string, desired map[groupKey]struct{}) error {
+	children, err := s.namespaceStore.GetNamespaceChildren(ctx, rootUID, orgID, user)
+	if err != nil {
+		return fmt.Errorf("list sync folder children: %w", err)
+	}
+	nsUIDs := make([]string, 0, len(children)+1)
+	nsUIDs = append(nsUIDs, rootUID)
+	for _, child := range children {
+		nsUIDs = append(nsUIDs, child.UID)
+	}
+
+	existing, err := s.ruleService.GetAlertGroupsWithFolderFullpath(ctx, user, &provisioning.FilterOptions{
+		NamespaceUIDs:               nsUIDs,
+		HasPrometheusRuleDefinition: new(true),
+	})
+	if err != nil {
+		return fmt.Errorf("list converted rule groups: %w", err)
+	}
+
+	for _, g := range existing {
+		if g.AlertRuleGroup == nil || len(g.Rules) == 0 {
+			continue
+		}
+		if _, ok := desired[groupKey{folderUID: g.FolderUID, group: g.Title}]; ok {
+			continue // still present upstream
+		}
+		if err := s.ruleService.DeleteRuleGroups(ctx, user, convertedPrometheusManager, &provisioning.FilterOptions{
+			NamespaceUIDs:               []string{g.FolderUID},
+			RuleGroups:                  []string{g.Title},
+			HasPrometheusRuleDefinition: new(true),
+		}); err != nil {
+			return fmt.Errorf("delete stale rule group %q in folder %q: %w", g.Title, g.FolderUID, err)
+		}
+		s.logger.Info("Pruned external ruler rule group no longer present upstream", "folder_uid", g.FolderUID, "group", g.Title)
+	}
+	// TODO: delete a namespace subfolder (and the root) once it has no rules
+	// left, instead of leaving it empty. Deferred until we track a durable owner
+	// marker on the folder, so we can be sure it is ours and truly empty (no
+	// user-created dashboards or rules) before deleting.
+	return nil
+}
+
+// recordFailure logs a classified failure and increments the failures metric.
+func (s *ExternalRulerSyncer) recordFailure(orgID int64, orgIDStr string, syncErr *SyncError) {
+	s.logger.Warn("External ruler sync failed", "org_id", orgID, "reason", syncErr.Reason.Label(), "error", syncErr)
+	s.metrics.SyncFailures.WithLabelValues(orgIDStr, syncErr.Reason.Label()).Inc()
+}

--- a/pkg/services/ngalert/rulesync/syncer.go
+++ b/pkg/services/ngalert/rulesync/syncer.go
@@ -307,6 +307,14 @@ func (s *ExternalRulerSyncer) apply(ctx context.Context, user identity.Requester
 		return &SyncError{Reason: ReasonSave, Cause: err}
 	}
 
+	orgIDStr := strconv.FormatInt(orgID, 10)
+	ruleCount := 0
+	for _, g := range groups {
+		ruleCount += len(g.Rules)
+	}
+	s.metrics.SyncGroups.WithLabelValues(orgIDStr).Set(float64(len(groups)))
+	s.metrics.SyncRules.WithLabelValues(orgIDStr).Set(float64(ruleCount))
+
 	if err := s.prune(ctx, user, orgID, root.UID, desired); err != nil {
 		return &SyncError{Reason: ReasonPrune, Cause: err}
 	}

--- a/pkg/services/ngalert/rulesync/syncer.go
+++ b/pkg/services/ngalert/rulesync/syncer.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/datasourceproxy"
 	"github.com/grafana/grafana/pkg/services/datasources"
@@ -19,6 +20,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/prom"
 	"github.com/grafana/grafana/pkg/services/ngalert/provisioning"
+	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
@@ -78,6 +80,8 @@ type ExternalRulerSyncer struct {
 	ruleService    ruleService
 	namespaceStore namespaceStore
 	orgStore       orgStore
+	// folderPermissions restricts the sync folder to admin-only modification.
+	folderPermissions accesscontrol.FolderPermissionsService
 
 	lastSyncHashMu sync.RWMutex
 	lastSyncHash   map[int64]uint64
@@ -96,17 +100,19 @@ func NewExternalRulerSyncer(
 	ruleSvc ruleService,
 	namespaceStore namespaceStore,
 	orgStore orgStore,
+	folderPermissions accesscontrol.FolderPermissionsService,
 ) *ExternalRulerSyncer {
 	return &ExternalRulerSyncer{
-		settings:       settings,
-		logger:         logger,
-		metrics:        m,
-		datasources:    datasourceService,
-		fetcher:        NewRulerFetcher(proxy, logger),
-		ruleService:    ruleSvc,
-		namespaceStore: namespaceStore,
-		orgStore:       orgStore,
-		lastSyncHash:   make(map[int64]uint64),
+		settings:          settings,
+		logger:            logger,
+		metrics:           m,
+		datasources:       datasourceService,
+		fetcher:           NewRulerFetcher(proxy, logger),
+		ruleService:       ruleSvc,
+		namespaceStore:    namespaceStore,
+		orgStore:          orgStore,
+		folderPermissions: folderPermissions,
+		lastSyncHash:      make(map[int64]uint64),
 	}
 }
 
@@ -266,9 +272,12 @@ type groupKey struct {
 // them, and prunes previously-synced groups that vanished upstream. Returns a
 // classified *SyncError on failure.
 func (s *ExternalRulerSyncer) apply(ctx context.Context, user identity.Requester, orgID int64, ds *datasources.DataSource, targetDS *datasources.DataSource, cfg RulerConfig) *SyncError {
-	root, _, err := s.namespaceStore.GetOrCreateNamespaceByTitle(ctx, rootFolderTitle(ds.UID), orgID, user, "")
+	root, created, err := s.namespaceStore.GetOrCreateNamespaceByTitle(ctx, rootFolderTitle(ds.UID), orgID, user, "")
 	if err != nil {
 		return &SyncError{Reason: ReasonSave, Cause: fmt.Errorf("get-or-create root folder: %w", err)}
+	}
+	if created {
+		s.restrictFolderToAdmins(ctx, orgID, root.UID)
 	}
 
 	groups := make([]*models.AlertRuleGroup, 0)
@@ -302,6 +311,21 @@ func (s *ExternalRulerSyncer) apply(ctx context.Context, user identity.Requester
 		return &SyncError{Reason: ReasonPrune, Cause: err}
 	}
 	return nil
+}
+
+// restrictFolderToAdmins locks a freshly-created sync folder to admin-only
+// modification: editors and viewers get view-only, so operators can see the
+// synced rules but not change what the sync owns. Admins keep full access, the
+// sync itself runs as a service identity so it is unaffected, and namespace
+// subfolders inherit these permissions. Best-effort: a permissions failure is
+// logged, not fatal, so it never blocks the rule sync.
+func (s *ExternalRulerSyncer) restrictFolderToAdmins(ctx context.Context, orgID int64, folderUID string) {
+	if _, err := s.folderPermissions.SetPermissions(ctx, orgID, folderUID,
+		accesscontrol.SetResourcePermissionCommand{BuiltinRole: string(org.RoleEditor), Permission: "View"},
+		accesscontrol.SetResourcePermissionCommand{BuiltinRole: string(org.RoleViewer), Permission: "View"},
+	); err != nil {
+		s.logger.Warn("Failed to restrict external ruler sync folder to admin-only access", "org_id", orgID, "folder_uid", folderUID, "error", err)
+	}
 }
 
 // prune deletes converted-Prometheus rule groups that live under the sync's

--- a/pkg/services/ngalert/rulesync/syncer.go
+++ b/pkg/services/ngalert/rulesync/syncer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime/debug"
 	"strconv"
 	"sync"
 	"time"
@@ -190,11 +191,21 @@ func (s *ExternalRulerSyncer) IsManagedFolder(ctx context.Context, orgID int64, 
 // SyncOrg runs one sync tick for a single org. It never returns an error;
 // failures are logged and counted so a bad org can't break the others.
 func (s *ExternalRulerSyncer) SyncOrg(ctx context.Context, orgID int64) {
+	orgIDStr := strconv.FormatInt(orgID, 10)
+	// A panic in a per-org tick (conversion, datasource proxy, upstream response)
+	// must not crash the background syncer goroutine and the process; recover and
+	// record it like any other per-org failure.
+	defer func() {
+		if r := recover(); r != nil {
+			s.logger.Error("External ruler sync panicked", "org_id", orgID, "panic", r, "stack", string(debug.Stack()))
+			s.metrics.SyncFailures.WithLabelValues(orgIDStr, ReasonPanic.Label()).Inc()
+		}
+	}()
+
 	uid := s.settings.ExternalRulerUID
 	if uid == "" {
 		return
 	}
-	orgIDStr := strconv.FormatInt(orgID, 10)
 
 	svcCtx, svcUser := identity.WithServiceIdentity(ctx, orgID)
 

--- a/pkg/services/ngalert/rulesync/syncer.go
+++ b/pkg/services/ngalert/rulesync/syncer.go
@@ -283,7 +283,11 @@ func (s *ExternalRulerSyncer) apply(ctx context.Context, user identity.Requester
 				KeepOriginalRuleDefinition: true,
 			})
 			if err != nil {
-				return &SyncError{Reason: ReasonConvert, Cause: fmt.Errorf("convert group %q in namespace %q: %w", promGroup.Name, namespace, err)}
+				// Best-effort: skip a group we can't convert (e.g. it has recording
+				// rules but recording rules are disabled) rather than aborting the whole
+				// org — one bad group must not block the rest.
+				s.logger.Warn("Skipping external ruler group that failed to convert", "org_id", orgID, "namespace", namespace, "group", promGroup.Name, "error", err)
+				continue
 			}
 			groups = append(groups, group)
 			desired[groupKey{folderUID: nsFolder.UID, group: group.Title}] = struct{}{}

--- a/pkg/services/ngalert/rulesync/syncer_pipeline_test.go
+++ b/pkg/services/ngalert/rulesync/syncer_pipeline_test.go
@@ -1,0 +1,128 @@
+package rulesync
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v3"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/datasources"
+	"github.com/grafana/grafana/pkg/services/folder"
+	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+// These tests exercise the whole sync tick — fetch -> parse -> convert -> apply
+// -> prune — with only the datasource HTTP API stubbed (via fakeDatasourceProxy,
+// the same seam the real proxy service occupies). The real RulerFetcher and
+// prom.ConvertRuleGroup run, so a raw ruler response is turned into stored
+// Grafana rule groups the same way as in production, without a database. (The
+// database-backed, full-server test lives in pkg/tests/api/alerting.)
+
+// newPipelineSyncer wires a syncer to the real RulerFetcher backed by proxy,
+// stubbing only the datasource HTTP API. The rule service and folder store are
+// in-memory fakes so assertions can inspect what was applied and pruned.
+func newPipelineSyncer(proxy *fakeDatasourceProxy, rs *fakeRuleService, ns fakeNamespaceStore) *ExternalRulerSyncer {
+	return &ExternalRulerSyncer{
+		settings:          &setting.UnifiedAlertingSettings{DefaultRuleEvaluationInterval: time.Minute, ExternalRulerUID: "ds1"},
+		logger:            log.NewNopLogger(),
+		metrics:           NewMetrics(nil),
+		datasources:       fakeDatasourceGetter{ds: &datasources.DataSource{UID: "ds1", OrgID: 1, Type: datasources.DS_PROMETHEUS, URL: "http://mimir/prometheus"}},
+		fetcher:           NewRulerFetcher(proxy, log.NewNopLogger()),
+		ruleService:       rs,
+		namespaceStore:    ns,
+		folderPermissions: &recordingFolderPermissions{},
+		lastSyncHash:      make(map[int64]uint64),
+	}
+}
+
+// rulerAPIResponse serializes cfg the way a Mimir ruler config API would, for
+// the stubbed datasource proxy to return.
+func rulerAPIResponse(t *testing.T, cfg RulerConfig) []byte {
+	t.Helper()
+	b, err := yaml.Marshal(cfg)
+	require.NoError(t, err)
+	return b
+}
+
+func TestSyncOrg_FromRulerAPI(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("rules served by the datasource API are fetched, converted and applied", func(t *testing.T) {
+		cfg := RulerConfig{
+			"cpu": {{
+				Name: "cpu-alerts",
+				Rules: []apimodels.PrometheusRule{
+					{Alert: "HighCPU", Expr: "instance:cpu:ratio > 0.9", Labels: map[string]string{"severity": "warning"}, Annotations: map[string]string{"summary": "CPU high"}},
+					{Alert: "HostDown", Expr: "up == 0"},
+				},
+			}},
+			"mem": {{
+				Name:  "mem-alerts",
+				Rules: []apimodels.PrometheusRule{{Alert: "HighMem", Expr: "instance:mem:ratio > 0.9"}},
+			}},
+		}
+		proxy := &fakeDatasourceProxy{status: http.StatusOK, body: rulerAPIResponse(t, cfg)}
+		rs := &fakeRuleService{}
+		s := newPipelineSyncer(proxy, rs, fakeNamespaceStore{})
+
+		s.SyncOrg(ctx, 1)
+
+		require.Equal(t, 1, proxy.calls, "fetched through the datasource proxy")
+		require.Len(t, rs.replaced, 2, "one converted group per namespace")
+
+		rules := map[string]int{}
+		folders := map[string]string{}
+		for _, g := range rs.replaced {
+			rules[g.Title] = len(g.Rules)
+			folders[g.Title] = g.FolderUID
+		}
+		assert.Equal(t, 2, rules["cpu-alerts"])
+		assert.Equal(t, 1, rules["mem-alerts"])
+		// Each namespace lands in its own subfolder under the sync root.
+		assert.Equal(t, "folder-cpu", folders["cpu-alerts"])
+		assert.Equal(t, "folder-mem", folders["mem-alerts"])
+	})
+
+	t.Run("a group dropped upstream is pruned on the next fetch", func(t *testing.T) {
+		// Upstream now serves only cpu-alerts; stale-alerts was synced before but
+		// is gone, so it must be pruned while cpu-alerts is kept.
+		cfg := RulerConfig{
+			"cpu": {{Name: "cpu-alerts", Rules: []apimodels.PrometheusRule{{Alert: "HighCPU", Expr: "up == 0"}}}},
+		}
+		proxy := &fakeDatasourceProxy{status: http.StatusOK, body: rulerAPIResponse(t, cfg)}
+		rs := &fakeRuleService{existing: []models.AlertRuleGroupWithFolderFullpath{
+			ownedGroup("folder-cpu", "cpu-alerts"),
+			ownedGroup("folder-cpu", "stale-alerts"),
+		}}
+		s := newPipelineSyncer(proxy, rs, fakeNamespaceStore{children: []*folder.FolderReference{{UID: "folder-cpu", Title: "cpu"}}})
+
+		s.SyncOrg(ctx, 1)
+
+		require.Len(t, rs.deleted, 1, "only the dropped group is pruned")
+		assert.Equal(t, []string{"folder-cpu"}, rs.deleted[0].NamespaceUIDs)
+		assert.Equal(t, []string{"stale-alerts"}, rs.deleted[0].RuleGroups)
+	})
+
+	t.Run("an empty ruler prunes everything it previously synced", func(t *testing.T) {
+		// Mimir returns 200 {} when it has no rule groups; sync mirrors that by
+		// removing the rules it had synced (sync converges to the source).
+		proxy := &fakeDatasourceProxy{status: http.StatusOK, body: []byte("{}")}
+		rs := &fakeRuleService{existing: []models.AlertRuleGroupWithFolderFullpath{
+			ownedGroup("folder-cpu", "cpu-alerts"),
+		}}
+		s := newPipelineSyncer(proxy, rs, fakeNamespaceStore{children: []*folder.FolderReference{{UID: "folder-cpu", Title: "cpu"}}})
+
+		s.SyncOrg(ctx, 1)
+
+		assert.Empty(t, rs.replaced, "nothing to apply from an empty ruler")
+		require.Len(t, rs.deleted, 1, "the previously-synced group is pruned")
+		assert.Equal(t, []string{"cpu-alerts"}, rs.deleted[0].RuleGroups)
+	})
+}

--- a/pkg/services/ngalert/rulesync/syncer_test.go
+++ b/pkg/services/ngalert/rulesync/syncer_test.go
@@ -1,0 +1,275 @@
+package rulesync
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/services/datasources"
+	"github.com/grafana/grafana/pkg/services/folder"
+	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/services/ngalert/provisioning"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+// --- fakes ---
+
+type fakeFetcher struct {
+	cfg   RulerConfig
+	hash  uint64
+	err   error
+	calls int
+}
+
+func (f *fakeFetcher) Fetch(context.Context, *datasources.DataSource) (RulerConfig, uint64, error) {
+	f.calls++
+	return f.cfg, f.hash, f.err
+}
+
+type fakeRuleService struct {
+	replaced []*models.AlertRuleGroup
+	existing []models.AlertRuleGroupWithFolderFullpath
+	deleted  []provisioning.FilterOptions
+}
+
+func (f *fakeRuleService) ReplaceRuleGroups(_ context.Context, _ identity.Requester, groups []*models.AlertRuleGroup, _ utils.ManagerProperties, _ string) error {
+	f.replaced = groups
+	return nil
+}
+func (f *fakeRuleService) DeleteRuleGroups(_ context.Context, _ identity.Requester, _ utils.ManagerProperties, filterOpts *provisioning.FilterOptions) error {
+	f.deleted = append(f.deleted, *filterOpts)
+	return nil
+}
+func (f *fakeRuleService) GetAlertGroupsWithFolderFullpath(_ context.Context, _ identity.Requester, filterOpts *provisioning.FilterOptions) ([]models.AlertRuleGroupWithFolderFullpath, error) {
+	// Emulate the store's NamespaceUIDs filter so the fake is faithful to the
+	// real query the syncer relies on for folder-scoped prune.
+	if filterOpts == nil || len(filterOpts.NamespaceUIDs) == 0 {
+		return f.existing, nil
+	}
+	allowed := make(map[string]struct{}, len(filterOpts.NamespaceUIDs))
+	for _, uid := range filterOpts.NamespaceUIDs {
+		allowed[uid] = struct{}{}
+	}
+	var out []models.AlertRuleGroupWithFolderFullpath
+	for _, g := range f.existing {
+		if g.AlertRuleGroup == nil {
+			continue
+		}
+		if _, ok := allowed[g.FolderUID]; ok {
+			out = append(out, g)
+		}
+	}
+	return out, nil
+}
+
+// fakeNamespaceStore returns a folder whose UID is the title prefixed, so root
+// and namespace folders get distinct, deterministic UIDs. children configures
+// the folders returned by GetNamespaceChildren (the sync's namespace subfolders).
+type fakeNamespaceStore struct {
+	children []*folder.FolderReference
+	// byTitle resolves GetNamespaceByTitle; a missing title yields ErrFolderNotFound.
+	byTitle map[string]*folder.FolderReference
+}
+
+func (fakeNamespaceStore) GetOrCreateNamespaceByTitle(_ context.Context, title string, _ int64, _ identity.Requester, _ string) (*folder.FolderReference, bool, error) {
+	return &folder.FolderReference{UID: "folder-" + title, Title: title}, false, nil
+}
+
+func (f fakeNamespaceStore) GetNamespaceByTitle(_ context.Context, title string, _ int64, _ identity.Requester, _ string) (*folder.FolderReference, error) {
+	if fr, ok := f.byTitle[title]; ok {
+		return fr, nil
+	}
+	return nil, dashboards.ErrFolderNotFound
+}
+
+func (f fakeNamespaceStore) GetNamespaceChildren(_ context.Context, _ string, _ int64, _ identity.Requester) ([]*folder.FolderReference, error) {
+	return f.children, nil
+}
+
+type fakeDatasourceGetter struct {
+	ds *datasources.DataSource
+}
+
+func (f fakeDatasourceGetter) GetDataSource(_ context.Context, q *datasources.GetDataSourceQuery) (*datasources.DataSource, error) {
+	// Return a datasource carrying the requested UID.
+	return &datasources.DataSource{UID: q.UID, OrgID: q.OrgID, Type: f.ds.Type, URL: f.ds.URL}, nil
+}
+
+func newTestSyncer(t *testing.T, fetch *fakeFetcher, rs *fakeRuleService) *ExternalRulerSyncer {
+	t.Helper()
+	return &ExternalRulerSyncer{
+		settings:       &setting.UnifiedAlertingSettings{DefaultRuleEvaluationInterval: time.Minute},
+		logger:         log.NewNopLogger(),
+		metrics:        NewMetrics(nil),
+		datasources:    fakeDatasourceGetter{ds: &datasources.DataSource{UID: "ds1", OrgID: 1, Type: datasources.DS_PROMETHEUS, URL: "http://mimir/prometheus"}},
+		fetcher:        fetch,
+		ruleService:    rs,
+		namespaceStore: fakeNamespaceStore{},
+		lastSyncHash:   make(map[int64]uint64),
+	}
+}
+
+func upstreamGroup(name, alert string) RulerConfig {
+	return RulerConfig{
+		"ns1": {{Name: name, Rules: []apimodels.PrometheusRule{{Alert: alert, Expr: "up == 0"}}}},
+	}
+}
+
+// ownedGroup builds an existing converted rule group in folderUID. The rule
+// carries a PrometheusStyleRule with a non-empty OriginalRuleDefinition so
+// HasPrometheusRuleDefinition() reports true, matching the store's filter.
+func ownedGroup(folderUID, group string) models.AlertRuleGroupWithFolderFullpath {
+	return models.AlertRuleGroupWithFolderFullpath{
+		AlertRuleGroup: &models.AlertRuleGroup{
+			Title:     group,
+			FolderUID: folderUID,
+			Rules: []models.AlertRule{{
+				Title:    "r",
+				Metadata: models.AlertRuleMetadata{PrometheusStyleRule: &models.PrometheusStyleRule{OriginalRuleDefinition: "def"}},
+			}},
+		},
+	}
+}
+
+func TestSyncOrg_HappyPath(t *testing.T) {
+	rs := &fakeRuleService{}
+	s := newTestSyncer(t, &fakeFetcher{cfg: upstreamGroup("g1", "A"), hash: 111}, rs)
+	s.settings.ExternalRulerUID = "ds1"
+
+	s.SyncOrg(context.Background(), 1)
+
+	require.Len(t, rs.replaced, 1, "one group replaced")
+	require.Len(t, rs.replaced[0].Rules, 1)
+}
+
+func TestSyncOrg_NotConfigured(t *testing.T) {
+	rs := &fakeRuleService{}
+	s := newTestSyncer(t, &fakeFetcher{}, rs)
+	// ExternalRulerUID unset → nothing synced.
+
+	s.SyncOrg(context.Background(), 1)
+
+	assert.Nil(t, rs.replaced, "nothing synced when not configured")
+}
+
+func TestSyncOrg_Dedup(t *testing.T) {
+	rs := &fakeRuleService{}
+	s := newTestSyncer(t, &fakeFetcher{cfg: upstreamGroup("g1", "A"), hash: 42}, rs)
+	s.settings.ExternalRulerUID = "ds1"
+
+	s.SyncOrg(context.Background(), 1)
+	require.Len(t, rs.replaced, 1)
+
+	// Second tick, same hash → skipped (replaced reset to confirm not called again).
+	rs.replaced = nil
+	s.SyncOrg(context.Background(), 1)
+	assert.Nil(t, rs.replaced, "unchanged hash is deduped")
+}
+
+func TestSyncOrg_NotARuler(t *testing.T) {
+	rs := &fakeRuleService{}
+	s := newTestSyncer(t, &fakeFetcher{err: ErrNotARuler}, rs)
+	s.settings.ExternalRulerUID = "ds1"
+
+	s.SyncOrg(context.Background(), 1)
+
+	assert.Nil(t, rs.replaced, "nothing synced when the datasource is not a ruler")
+}
+
+func TestSyncOrg_PruneScopedByFolder(t *testing.T) {
+	rs := &fakeRuleService{
+		existing: []models.AlertRuleGroupWithFolderFullpath{
+			// Under a sync folder but NOT in upstream (ns1/g1 is upstream) → pruned.
+			ownedGroup("folder-ns1", "stale-group"),
+			// Under a folder outside the sync subtree → filtered out, NOT pruned.
+			ownedGroup("folder-other", "other-group"),
+			// Still present upstream (ns1/g1) → must NOT be pruned.
+			ownedGroup("folder-ns1", "g1"),
+		},
+	}
+	s := newTestSyncer(t, &fakeFetcher{cfg: upstreamGroup("g1", "A"), hash: 7}, rs)
+	s.settings.ExternalRulerUID = "ds1"
+	// The sync's namespace subfolders (children of the root sync folder).
+	s.namespaceStore = fakeNamespaceStore{children: []*folder.FolderReference{{UID: "folder-ns1", Title: "ns1"}}}
+
+	s.SyncOrg(context.Background(), 1)
+
+	require.Len(t, rs.deleted, 1, "exactly one stale, in-folder group pruned")
+	assert.Equal(t, []string{"folder-ns1"}, rs.deleted[0].NamespaceUIDs)
+	assert.Equal(t, []string{"stale-group"}, rs.deleted[0].RuleGroups)
+	// Delete is scoped to converted-Prometheus rules only.
+	require.NotNil(t, rs.deleted[0].HasPrometheusRuleDefinition)
+	assert.True(t, *rs.deleted[0].HasPrometheusRuleDefinition)
+}
+
+func TestIsManagedFolder(t *testing.T) {
+	ctx := context.Background()
+	root := &folder.FolderReference{UID: "root-uid", Title: rootFolderTitle("ds1")}
+	child := &folder.FolderReference{UID: "child-uid", Title: "ns1", ParentUID: "root-uid"}
+
+	newSyncer := func(ns fakeNamespaceStore, uid string) *ExternalRulerSyncer {
+		return &ExternalRulerSyncer{
+			settings:       &setting.UnifiedAlertingSettings{ExternalRulerUID: uid},
+			logger:         log.NewNopLogger(),
+			namespaceStore: ns,
+		}
+	}
+	rootResolvable := fakeNamespaceStore{
+		byTitle:  map[string]*folder.FolderReference{rootFolderTitle("ds1"): root},
+		children: []*folder.FolderReference{child},
+	}
+
+	t.Run("unconfigured -> not managed", func(t *testing.T) {
+		managed, err := newSyncer(rootResolvable, "").IsManagedFolder(ctx, 1, "root-uid")
+		require.NoError(t, err)
+		assert.False(t, managed)
+	})
+
+	t.Run("root folder does not exist yet -> not managed", func(t *testing.T) {
+		managed, err := newSyncer(fakeNamespaceStore{}, "ds1").IsManagedFolder(ctx, 1, "root-uid")
+		require.NoError(t, err)
+		assert.False(t, managed)
+	})
+
+	t.Run("the root folder itself is managed", func(t *testing.T) {
+		managed, err := newSyncer(rootResolvable, "ds1").IsManagedFolder(ctx, 1, "root-uid")
+		require.NoError(t, err)
+		assert.True(t, managed)
+	})
+
+	t.Run("a namespace subfolder is managed", func(t *testing.T) {
+		managed, err := newSyncer(rootResolvable, "ds1").IsManagedFolder(ctx, 1, "child-uid")
+		require.NoError(t, err)
+		assert.True(t, managed)
+	})
+
+	t.Run("an unrelated folder is not managed", func(t *testing.T) {
+		managed, err := newSyncer(rootResolvable, "ds1").IsManagedFolder(ctx, 1, "user-folder")
+		require.NoError(t, err)
+		assert.False(t, managed)
+	})
+}
+
+func TestRun_NoOpWhenUnconfigured(t *testing.T) {
+	// external_ruler_uid unset is the disable signal: Run must not start the poll
+	// loop (there is no separate feature flag).
+	s := newTestSyncer(t, &fakeFetcher{cfg: upstreamGroup("g1", "A"), hash: 1}, &fakeRuleService{})
+	s.settings.AdminConfigPollInterval = time.Minute // avoid a ticker panic if the gate regresses
+
+	done := make(chan error, 1)
+	go func() { done <- s.Run(context.Background()) }()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return; missing gate on external_ruler_uid")
+	}
+}

--- a/pkg/services/ngalert/rulesync/syncer_test.go
+++ b/pkg/services/ngalert/rulesync/syncer_test.go
@@ -214,6 +214,26 @@ func TestSyncOrg_PruneScopedByFolder(t *testing.T) {
 	assert.True(t, *rs.deleted[0].HasPrometheusRuleDefinition)
 }
 
+func TestSyncOrg_SkipsUnconvertibleGroup(t *testing.T) {
+	// Recording rules are disabled in the test settings, so the recording group
+	// can't convert. It must be skipped (best-effort), not abort the whole org.
+	cfg := RulerConfig{
+		"ns1": {
+			{Name: "alerts", Rules: []apimodels.PrometheusRule{{Alert: "A", Expr: "up == 0"}}},
+			{Name: "recording", Rules: []apimodels.PrometheusRule{{Record: "r", Expr: "vector(1)"}}},
+		},
+	}
+	rs := &fakeRuleService{}
+	s := newTestSyncer(t, &fakeFetcher{cfg: cfg, hash: 1}, rs)
+	s.settings.ExternalRulerUID = "ds1"
+
+	s.SyncOrg(context.Background(), 1)
+
+	// The alert group is applied; the recording group is skipped.
+	require.Len(t, rs.replaced, 1)
+	assert.Equal(t, "alerts", rs.replaced[0].Title)
+}
+
 func TestSyncOrg_RecoversPanic(t *testing.T) {
 	s := newTestSyncer(t, &fakeFetcher{panicMsg: "boom"}, &fakeRuleService{})
 	s.settings.ExternalRulerUID = "ds1"

--- a/pkg/services/ngalert/rulesync/syncer_test.go
+++ b/pkg/services/ngalert/rulesync/syncer_test.go
@@ -23,14 +23,18 @@ import (
 // --- fakes ---
 
 type fakeFetcher struct {
-	cfg   RulerConfig
-	hash  uint64
-	err   error
-	calls int
+	cfg      RulerConfig
+	hash     uint64
+	err      error
+	calls    int
+	panicMsg string
 }
 
 func (f *fakeFetcher) Fetch(context.Context, *datasources.DataSource) (RulerConfig, uint64, error) {
 	f.calls++
+	if f.panicMsg != "" {
+		panic(f.panicMsg)
+	}
 	return f.cfg, f.hash, f.err
 }
 
@@ -208,6 +212,14 @@ func TestSyncOrg_PruneScopedByFolder(t *testing.T) {
 	// Delete is scoped to converted-Prometheus rules only.
 	require.NotNil(t, rs.deleted[0].HasPrometheusRuleDefinition)
 	assert.True(t, *rs.deleted[0].HasPrometheusRuleDefinition)
+}
+
+func TestSyncOrg_RecoversPanic(t *testing.T) {
+	s := newTestSyncer(t, &fakeFetcher{panicMsg: "boom"}, &fakeRuleService{})
+	s.settings.ExternalRulerUID = "ds1"
+
+	// A panic in a tick must be recovered so the background goroutine survives.
+	require.NotPanics(t, func() { s.SyncOrg(context.Background(), 1) })
 }
 
 func TestIsManagedFolder(t *testing.T) {

--- a/pkg/services/ngalert/rulesync/syncer_test.go
+++ b/pkg/services/ngalert/rulesync/syncer_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/folder"
@@ -81,10 +82,13 @@ type fakeNamespaceStore struct {
 	children []*folder.FolderReference
 	// byTitle resolves GetNamespaceByTitle; a missing title yields ErrFolderNotFound.
 	byTitle map[string]*folder.FolderReference
+	// created is the "newly created" flag GetOrCreateNamespaceByTitle returns,
+	// which drives the admin-only permission set on the sync root folder.
+	created bool
 }
 
-func (fakeNamespaceStore) GetOrCreateNamespaceByTitle(_ context.Context, title string, _ int64, _ identity.Requester, _ string) (*folder.FolderReference, bool, error) {
-	return &folder.FolderReference{UID: "folder-" + title, Title: title}, false, nil
+func (f fakeNamespaceStore) GetOrCreateNamespaceByTitle(_ context.Context, title string, _ int64, _ identity.Requester, _ string) (*folder.FolderReference, bool, error) {
+	return &folder.FolderReference{UID: "folder-" + title, Title: title}, f.created, nil
 }
 
 func (f fakeNamespaceStore) GetNamespaceByTitle(_ context.Context, title string, _ int64, _ identity.Requester, _ string) (*folder.FolderReference, error) {
@@ -107,17 +111,34 @@ func (f fakeDatasourceGetter) GetDataSource(_ context.Context, q *datasources.Ge
 	return &datasources.DataSource{UID: q.UID, OrgID: q.OrgID, Type: f.ds.Type, URL: f.ds.URL}, nil
 }
 
+// recordingFolderPermissions captures the SetPermissions calls the syncer makes
+// to lock its folder to admin-only access. It embeds the interface so only the
+// one method the syncer actually uses needs implementing.
+type recordingFolderPermissions struct {
+	accesscontrol.FolderPermissionsService
+	got map[string][]accesscontrol.SetResourcePermissionCommand
+}
+
+func (f *recordingFolderPermissions) SetPermissions(_ context.Context, _ int64, resourceID string, cmds ...accesscontrol.SetResourcePermissionCommand) ([]accesscontrol.ResourcePermission, error) {
+	if f.got == nil {
+		f.got = map[string][]accesscontrol.SetResourcePermissionCommand{}
+	}
+	f.got[resourceID] = cmds
+	return nil, nil
+}
+
 func newTestSyncer(t *testing.T, fetch *fakeFetcher, rs *fakeRuleService) *ExternalRulerSyncer {
 	t.Helper()
 	return &ExternalRulerSyncer{
-		settings:       &setting.UnifiedAlertingSettings{DefaultRuleEvaluationInterval: time.Minute},
-		logger:         log.NewNopLogger(),
-		metrics:        NewMetrics(nil),
-		datasources:    fakeDatasourceGetter{ds: &datasources.DataSource{UID: "ds1", OrgID: 1, Type: datasources.DS_PROMETHEUS, URL: "http://mimir/prometheus"}},
-		fetcher:        fetch,
-		ruleService:    rs,
-		namespaceStore: fakeNamespaceStore{},
-		lastSyncHash:   make(map[int64]uint64),
+		settings:          &setting.UnifiedAlertingSettings{DefaultRuleEvaluationInterval: time.Minute},
+		logger:            log.NewNopLogger(),
+		metrics:           NewMetrics(nil),
+		datasources:       fakeDatasourceGetter{ds: &datasources.DataSource{UID: "ds1", OrgID: 1, Type: datasources.DS_PROMETHEUS, URL: "http://mimir/prometheus"}},
+		fetcher:           fetch,
+		ruleService:       rs,
+		namespaceStore:    fakeNamespaceStore{},
+		folderPermissions: &recordingFolderPermissions{},
+		lastSyncHash:      make(map[int64]uint64),
 	}
 }
 
@@ -304,4 +325,36 @@ func TestRun_NoOpWhenUnconfigured(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("Run did not return; missing gate on external_ruler_uid")
 	}
+}
+
+func TestSyncOrg_RestrictsNewFolderToAdmins(t *testing.T) {
+	perms := &recordingFolderPermissions{}
+	s := newTestSyncer(t, &fakeFetcher{cfg: upstreamGroup("g1", "A"), hash: 1}, &fakeRuleService{})
+	s.settings.ExternalRulerUID = "ds1"
+	s.namespaceStore = fakeNamespaceStore{created: true}
+	s.folderPermissions = perms
+
+	s.SyncOrg(context.Background(), 1)
+
+	root := "folder-" + rootFolderTitle("ds1")
+	require.Contains(t, perms.got, root, "permissions set on the newly-created sync root folder")
+	byRole := map[string]string{}
+	for _, c := range perms.got[root] {
+		byRole[c.BuiltinRole] = c.Permission
+	}
+	// Editors and viewers are view-only; admins keep full access implicitly.
+	assert.Equal(t, "View", byRole["Editor"])
+	assert.Equal(t, "View", byRole["Viewer"])
+}
+
+func TestSyncOrg_DoesNotResetPermissionsOnExistingFolder(t *testing.T) {
+	perms := &recordingFolderPermissions{}
+	s := newTestSyncer(t, &fakeFetcher{cfg: upstreamGroup("g1", "A"), hash: 1}, &fakeRuleService{})
+	s.settings.ExternalRulerUID = "ds1"
+	s.namespaceStore = fakeNamespaceStore{} // created == false
+	s.folderPermissions = perms
+
+	s.SyncOrg(context.Background(), 1)
+
+	assert.Empty(t, perms.got, "permissions are only set when the folder is first created")
 }

--- a/pkg/services/ngalert/tests/fakes/permissions.go
+++ b/pkg/services/ngalert/tests/fakes/permissions.go
@@ -42,3 +42,10 @@ func (f FakeRoutePermissionsService) SetDefaultPermissions(ctx context.Context, 
 }
 
 var _ accesscontrol.RoutePermissionsService = new(FakeRoutePermissionsService)
+
+// NewFakeFolderPermissionsService returns a no-op FolderPermissionsService for
+// tests. FolderPermissionsService is just PermissionsService, which
+// actest.FakePermissionsService already implements.
+func NewFakeFolderPermissionsService() accesscontrol.FolderPermissionsService {
+	return &actest.FakePermissionsService{}
+}

--- a/pkg/services/ngalert/tests/util.go
+++ b/pkg/services/ngalert/tests/util.go
@@ -91,7 +91,7 @@ func SetupTestEnv(tb testing.TB, baseInterval time.Duration, opts ...TestEnvOpti
 	ng, err := ngalert.ProvideService(
 		cfg, options.featureToggles, nil, nil, routing.NewRouteRegister(), sqlStore, kvstore.NewFakeKVStore(), nil, nil, provisioning.NoopRuleMutationValidator{}, quotatest.New(false, nil),
 		secretsService, nil, m, folderService, ac, &dashboards.FakeDashboardService{}, nil, bus, ac,
-		annotationstest.NewFakeAnnotationsRepo(), &pluginstore.FakePluginStore{}, tracer, ruleStore, httpclient.NewProvider(), nil, ngalertfakes.NewFakeReceiverPermissionsService(), ngalertfakes.NewFakeRoutePermissionsService(), usertest.NewUserServiceFake(), orgtest.NewOrgServiceFake(),
+		annotationstest.NewFakeAnnotationsRepo(), &pluginstore.FakePluginStore{}, tracer, ruleStore, httpclient.NewProvider(), nil, ngalertfakes.NewFakeReceiverPermissionsService(), ngalertfakes.NewFakeRoutePermissionsService(), ngalertfakes.NewFakeFolderPermissionsService(), usertest.NewUserServiceFake(), orgtest.NewOrgServiceFake(),
 		nil, // clientGenerator
 	)
 	require.NoError(tb, err)

--- a/pkg/services/quota/quotaimpl/quota_test.go
+++ b/pkg/services/quota/quotaimpl/quota_test.go
@@ -561,7 +561,7 @@ func setupEnv(t *testing.T, sqlStore db.DB, cfg *setting.Cfg, b bus.Bus, quotaSe
 	_, err = ngalert.ProvideService(
 		cfg, featuremgmt.WithFeatures(), nil, nil, routing.NewRouteRegister(), sqlStore, ngalertfakes.NewFakeKVStore(t), nil, nil, ngalertprovisioning.NoopRuleMutationValidator{}, quotaService,
 		secretsService, nil, m, &foldertest.FakeService{}, &acmock.Mock{}, &dashboards.FakeDashboardService{}, nil, b, &acmock.Mock{},
-		annotationstest.NewFakeAnnotationsRepo(), &pluginstore.FakePluginStore{}, tracer, ruleStore, httpclient.NewProvider(), nil, ngalertfakes.NewFakeReceiverPermissionsService(), ngalertfakes.NewFakeRoutePermissionsService(), usertest.NewUserServiceFake(), orgtest.NewOrgServiceFake(),
+		annotationstest.NewFakeAnnotationsRepo(), &pluginstore.FakePluginStore{}, tracer, ruleStore, httpclient.NewProvider(), nil, ngalertfakes.NewFakeReceiverPermissionsService(), ngalertfakes.NewFakeRoutePermissionsService(), ngalertfakes.NewFakeFolderPermissionsService(), usertest.NewUserServiceFake(), orgtest.NewOrgServiceFake(),
 		nil, // clientGenerator
 	)
 	require.NoError(t, err)

--- a/pkg/setting/setting_unified_alerting.go
+++ b/pkg/setting/setting_unified_alerting.go
@@ -172,6 +172,14 @@ type UnifiedAlertingSettings struct {
 	// Configured via the [unified_alerting] ini key "external_alertmanager_uid" or the
 	// GF_UNIFIED_ALERTING_EXTERNAL_ALERTMANAGER_UID environment variable.
 	ExternalAlertmanagerUID string
+
+	// ExternalRulerUID is the operator-level override for the Mimir Prometheus
+	// (ruler) datasource UID to sync alert rules from into Grafana. When non-empty, it
+	// applies to all orgs and overrides any per-org value stored on the AlertingConfig
+	// resource.
+	// Configured via the [unified_alerting] ini key "external_ruler_uid" or the
+	// GF_UNIFIED_ALERTING_EXTERNAL_RULER_UID environment variable.
+	ExternalRulerUID string
 }
 
 type RecordingRuleSettings struct {
@@ -650,6 +658,7 @@ func (cfg *Cfg) ReadUnifiedAlertingSettings(iniFile *ini.File) error {
 
 	uaCfg.LimitEmailToOrgMembers = ua.Key("limit_email_to_org_members").MustBool(false)
 	uaCfg.ExternalAlertmanagerUID = ua.Key("external_alertmanager_uid").MustString("")
+	uaCfg.ExternalRulerUID = ua.Key("external_ruler_uid").MustString("")
 
 	cfg.UnifiedAlerting = uaCfg
 	return nil


### PR DESCRIPTION
Adds a background worker that mirrors alert rules from a configured Mimir ruler datasource into Grafana as converted-Prometheus rules — the rule-side analogue of the external Alertmanager config sync. Driven by the `external_ruler_uid` setting (that setting is the enable signal; there is no separate feature flag).

### What's here
- Extracts the Prometheus rule-group conversion used by the convert API into a shared helper in the `prom` package (`prom.ConvertRuleGroup`), so the convert API and the worker share one conversion path.
- The worker fetches the ruler config API through the datasource proxy (transport, auth and egress validation handled there), dedups on a body hash, converts via `prom.ConvertRuleGroup`, and writes the rules into a dedicated per-datasource folder (`[Alerting] External Ruler Sync (<uid>)`). Rules that vanish upstream are pruned from that folder subtree.
- Ownership is folder-based: the worker only writes/prunes within its dedicated folder subtree, so it never touches user-managed rules.
- The convert API returns 409 for manual imports *and* deletes that target the sync-managed folder subtree, so manual changes can't collide with the worker's rules (other folders are unaffected).

Per-org configuration and sync status (a `Config` resource in the rules app) land in a follow-up; this PR is driven by the operator `external_ruler_uid` setting. Only Mimir rulers are supported for now (the ruler config path is Mimir's `/config/v1/rules`); other Prometheus flavors (e.g. Cortex) use a different path and are a follow-up.

### Testing
Unit tests for the syncer (dedup, folder-scoped prune, managed-folder detection), the fetcher (proxy routing, 404 / parse / fetch-error handling), the shared conversion path, and the folder-scoped 409 gate (imports + deletes). Verified end-to-end against a live ruler: empty→404 handled cleanly, populated→mirrored, prune, and the 409 gate. `go vet` + `gofmt` clean.



Part of grafana/alerting-squad#1747 (Auto-sync alert rules from an external ruler).
