### PR TITLE
Panel: fix onFieldConfigChange type

### DIFF
--- a/packages/grafana-data/src/types/panel.ts
+++ b/packages/grafana-data/src/types/panel.ts
@@ -111,8 +111,12 @@ export interface PanelProps<T = any> {
   /** Handler for options change. Invoke it to update the panel custom options. */
   onOptionsChange: (options: T) => void;
 
-  /** Field config change handler. Invoke it to update the panel field config. */
-  onFieldConfigChange: (config: FieldConfigSource) => void;
+  /**
+   * Field config change handler. Invoke it to update the panel field config.
+   * By default, the given config is deep-merged into the current field config;
+   * Pass `replace: true` to replace the field config entirely.
+   */
+  onFieldConfigChange: (config: FieldConfigSource, replace?: boolean) => void;
 
   /** Template variables interpolation function. Given a string containing template variables, it returns the string with interpolated values. */
   replaceVariables: InterpolateFunction;


### PR DESCRIPTION
**What is this fix?**
Currently panelPlugins calling `onFieldConfigChange` without replace set cannot remove field overrides, so users calling `onFieldConfigChange({...fieldConfig, overrides: []})` start to doubt their sanity.

**Why do we need this feature?**
So published types match runtime contract.

**Who is this feature for?**
Panel plugin developers

**Special notes for your reviewer:**
Replace added in https://github.com/grafana/scenes/pull/363
Current main definition: https://github.com/grafana/scenes/blob/main/packages/scenes/src/components/VizPanel/VizPanel.tsx#L468

**How do we prevent drift from happening again in the future?** 
Good question, I dug into this a bit here: https://github.com/grafana/scenes/pull/1577, but I don't think there _is_ a worthwhile solution to that particular problem at this time.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
