### PR TITLE
Zanzana: split BatchCheck folder benchmarks

### DIFF
--- a/pkg/services/authz/zanzana/server/server_bench_test.go
+++ b/pkg/services/authz/zanzana/server/server_bench_test.go
@@ -340,6 +340,9 @@ func setupBenchmarkServer(b *testing.B) (*Server, *benchmarkData) {
 	}
 
 	cfg := setting.NewCfg()
+	// The benchmark's large synthetic folder hierarchy needs a larger budget than production
+	// so ListObjects cases measure completion time instead of the production timeout.
+	cfg.ZanzanaServer.ListObjectsDeadline = listTimeout
 
 	// Enable all caching options for optimal performance
 	cfg.ZanzanaServer.CacheSettings.CheckCacheLimit = 100000             // Cache check results
@@ -1007,6 +1010,8 @@ func BenchmarkBatchCheck(b *testing.B) {
 	}
 
 	usersPerPattern := len(data.users) / numPermissionPatterns
+	listObjectsFolderCheckThreshold := srv.getFolderCheckBatchThreshold()
+	nativeBatchFolderCheckThreshold := batchCheckSize * len(expandedSubresourcePermissionRelations(common.RelationSubresourceGet))
 
 	b.Run("GroupResourceDirect", func(b *testing.B) {
 		// User with group_resource permission - should have access to everything
@@ -1024,37 +1029,46 @@ func BenchmarkBatchCheck(b *testing.B) {
 		}
 	})
 
-	b.Run("FolderInheritance/Depth1", func(b *testing.B) {
-		// User with folder permission on shallow folder
-		user := data.users[usersPerPattern]
-		items := createFolderBatchItems(data.folders, 1, data.folderDepths)
-		b.Logf("Testing BatchCheck with %d items at depth 1", len(items))
+	folderCases := []struct {
+		name  string
+		user  string
+		depth int
+	}{
+		{name: "Depth1", user: data.users[usersPerPattern], depth: 1},
+		{name: "Depth4", user: data.users[2*usersPerPattern], depth: 4},
+	}
 
-		b.ResetTimer()
-		for range b.N {
-			res, err := srv.BatchCheck(ctx, newBatchCheckReq(user, items))
-			if err != nil {
-				b.Fatal(err)
+	for _, strategy := range []struct {
+		name      string
+		threshold int
+	}{
+		{name: "NativeBatchCheck", threshold: nativeBatchFolderCheckThreshold},
+		{name: "ListObjects", threshold: listObjectsFolderCheckThreshold},
+	} {
+		b.Run("FolderInheritance/"+strategy.name, func(b *testing.B) {
+			previousThreshold := srv.cfg.FolderCheckBatchThreshold
+			srv.cfg.FolderCheckBatchThreshold = strategy.threshold
+			defer func() {
+				srv.cfg.FolderCheckBatchThreshold = previousThreshold
+			}()
+
+			for _, folderCase := range folderCases {
+				b.Run(folderCase.name, func(b *testing.B) {
+					items := createFolderBatchItems(data.folders, folderCase.depth, data.folderDepths)
+					b.Logf("Testing BatchCheck with %d items at depth %d using %s", len(items), folderCase.depth, strategy.name)
+
+					b.ResetTimer()
+					for range b.N {
+						res, err := srv.BatchCheck(ctx, newBatchCheckReq(folderCase.user, items))
+						if err != nil {
+							b.Fatal(err)
+						}
+						_ = res.Results
+					}
+				})
 			}
-			_ = res.Results
-		}
-	})
-
-	b.Run("FolderInheritance/Depth4", func(b *testing.B) {
-		// User with folder permission on mid-depth folder
-		user := data.users[2*usersPerPattern]
-		items := createFolderBatchItems(data.folders, 4, data.folderDepths)
-		b.Logf("Testing BatchCheck with %d items at depth 4", len(items))
-
-		b.ResetTimer()
-		for range b.N {
-			res, err := srv.BatchCheck(ctx, newBatchCheckReq(user, items))
-			if err != nil {
-				b.Fatal(err)
-			}
-			_ = res.Results
-		}
-	})
+		})
+	}
 
 	b.Run("DirectResource", func(b *testing.B) {
 		// User with direct resource permission


### PR DESCRIPTION
## What changed

- split folder inheritance benchmarks into explicit native BatchCheck and ListObjects strategies
- retain shallow and mid-depth scenarios for both strategies
- give the synthetic ListObjects benchmark a 30-second deadline so it measures completion rather than the production timeout

## Why

The benchmark's 9,840-folder hierarchy caused broad ListObjects scenarios to hit the production deadline, hiding the performance crossover between object-specific checks and accessible-set enumeration. Separate strategy cases make that tradeoff visible.

This is benchmark-only follow-up work to the native BatchCheck implementation in #117600 and the folder ListObjects optimization in #122465.

## Validation

```bash
go test ./pkg/services/authz/zanzana/server -run '^$' -bench '^BenchmarkBatchCheck$' -benchtime=1x
```

The full benchmark passes. In the verification run, native BatchCheck was faster at depth 1, while ListObjects was faster at depth 4.