### PR TITLE
Provisioning: Make Resources tab tree foldable

### DIFF
--- a/public/app/features/provisioning/Repository/ResourceTreeView.test.tsx
+++ b/public/app/features/provisioning/Repository/ResourceTreeView.test.tsx
@@ -88,5 +88,8 @@ describe('ResourceTreeView', () => {
 
     // Search bypasses the folded state, so the deeply nested match is visible without expanding.
     expect(await screen.findByText('other.json')).toBeInTheDocument();
+    // Fold toggles are disabled while searching, since search already forces everything open
+    // and toggling would silently desync the stored fold state.
+    expect(screen.getByRole('button', { name: 'dashboards' })).toBeDisabled();
   });
 });

--- a/public/app/features/provisioning/Repository/ResourceTreeView.test.tsx
+++ b/public/app/features/provisioning/Repository/ResourceTreeView.test.tsx
@@ -64,14 +64,19 @@ describe('ResourceTreeView', () => {
   it('reveals a folder’s children when its toggle is clicked and hides them again', async () => {
     render(<ResourceTreeView repo={repo} />);
 
-    await userEvent.click(screen.getByRole('button', { name: /expand dashboards/i }));
+    // The fold toggle is labelled by the folder title (via aria-labelledby); state is on aria-expanded.
+    const toggle = screen.getByRole('button', { name: 'dashboards' });
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+
+    await userEvent.click(toggle);
 
     expect(await screen.findByText('my-dashboard.json')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'dashboards' })).toHaveAttribute('aria-expanded', 'true');
     // The nested subfolder appears but stays folded, so its own file is still hidden.
     expect(screen.getByText('nested')).toBeInTheDocument();
     expect(screen.queryByText('other.json')).not.toBeInTheDocument();
 
-    await userEvent.click(screen.getByRole('button', { name: /collapse dashboards/i }));
+    await userEvent.click(screen.getByRole('button', { name: 'dashboards' }));
 
     expect(screen.queryByText('my-dashboard.json')).not.toBeInTheDocument();
   });

--- a/public/app/features/provisioning/Repository/ResourceTreeView.test.tsx
+++ b/public/app/features/provisioning/Repository/ResourceTreeView.test.tsx
@@ -1,5 +1,5 @@
 import userEvent from '@testing-library/user-event';
-import { render, screen, waitFor } from 'test/test-utils';
+import { render, screen } from 'test/test-utils';
 
 import {
   type Repository,
@@ -76,22 +76,6 @@ describe('ResourceTreeView', () => {
     expect(screen.queryByText('my-dashboard.json')).not.toBeInTheDocument();
   });
 
-  it('expands and collapses the whole tree with the toolbar buttons', async () => {
-    render(<ResourceTreeView repo={repo} />);
-
-    await userEvent.click(screen.getByRole('button', { name: /expand all/i }));
-
-    expect(await screen.findByText('my-dashboard.json')).toBeInTheDocument();
-    expect(screen.getByText('other.json')).toBeInTheDocument();
-
-    await userEvent.click(screen.getByRole('button', { name: /collapse all/i }));
-
-    await waitFor(() => {
-      expect(screen.queryByText('my-dashboard.json')).not.toBeInTheDocument();
-    });
-    expect(screen.queryByText('other.json')).not.toBeInTheDocument();
-  });
-
   it('shows matching nested items regardless of fold state while searching', async () => {
     render(<ResourceTreeView repo={repo} />);
 
@@ -99,8 +83,5 @@ describe('ResourceTreeView', () => {
 
     // Search bypasses the folded state, so the deeply nested match is visible without expanding.
     expect(await screen.findByText('other.json')).toBeInTheDocument();
-    // Expand/collapse controls are disabled while a search is active.
-    expect(screen.getByRole('button', { name: /expand all/i })).toBeDisabled();
-    expect(screen.getByRole('button', { name: /collapse all/i })).toBeDisabled();
   });
 });

--- a/public/app/features/provisioning/Repository/ResourceTreeView.test.tsx
+++ b/public/app/features/provisioning/Repository/ResourceTreeView.test.tsx
@@ -1,0 +1,106 @@
+import userEvent from '@testing-library/user-event';
+import { render, screen, waitFor } from 'test/test-utils';
+
+import {
+  type Repository,
+  useGetRepositoryFilesQuery,
+  useGetRepositoryResourcesQuery,
+} from 'app/api/clients/provisioning/v0alpha1';
+
+import { ResourceTreeView } from './ResourceTreeView';
+
+jest.mock('@openfeature/react-sdk', () => ({
+  ...jest.requireActual('@openfeature/react-sdk'),
+  useBooleanFlagValue: jest.fn().mockReturnValue(false),
+}));
+
+jest.mock('app/api/clients/provisioning/v0alpha1', () => ({
+  ...jest.requireActual('app/api/clients/provisioning/v0alpha1'),
+  useGetRepositoryFilesQuery: jest.fn(),
+  useGetRepositoryResourcesQuery: jest.fn(),
+}));
+
+const mockUseGetRepositoryFilesQuery = useGetRepositoryFilesQuery as jest.MockedFunction<
+  typeof useGetRepositoryFilesQuery
+>;
+const mockUseGetRepositoryResourcesQuery = useGetRepositoryResourcesQuery as jest.MockedFunction<
+  typeof useGetRepositoryResourcesQuery
+>;
+
+const repo = {
+  metadata: { name: 'test-repo' },
+  spec: { type: 'github', github: { url: 'https://github.com/grafana/test', branch: 'main' } },
+} as unknown as Repository;
+
+// A folder "dashboards" (inferred from the file path) containing one file and a nested subfolder
+// with its own file. Enough depth to exercise folding at more than one level.
+const files = [
+  { path: 'dashboards/my-dashboard.json', hash: 'abc123', size: '100' },
+  { path: 'dashboards/nested/other.json', hash: 'def456', size: '200' },
+];
+
+function setupQueries() {
+  // Only the shape ResourceTreeView reads is relevant here.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  mockUseGetRepositoryFilesQuery.mockReturnValue({ data: { items: files }, isLoading: false } as any);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  mockUseGetRepositoryResourcesQuery.mockReturnValue({ data: { items: [] }, isLoading: false } as any);
+}
+
+describe('ResourceTreeView', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setupQueries();
+  });
+
+  it('renders folders folded by default, hiding their contents', () => {
+    render(<ResourceTreeView repo={repo} />);
+
+    expect(screen.getByText('dashboards')).toBeInTheDocument();
+    expect(screen.queryByText('my-dashboard.json')).not.toBeInTheDocument();
+    expect(screen.queryByText('nested')).not.toBeInTheDocument();
+  });
+
+  it('reveals a folder’s children when its toggle is clicked and hides them again', async () => {
+    render(<ResourceTreeView repo={repo} />);
+
+    await userEvent.click(screen.getByRole('button', { name: /expand dashboards/i }));
+
+    expect(await screen.findByText('my-dashboard.json')).toBeInTheDocument();
+    // The nested subfolder appears but stays folded, so its own file is still hidden.
+    expect(screen.getByText('nested')).toBeInTheDocument();
+    expect(screen.queryByText('other.json')).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: /collapse dashboards/i }));
+
+    expect(screen.queryByText('my-dashboard.json')).not.toBeInTheDocument();
+  });
+
+  it('expands and collapses the whole tree with the toolbar buttons', async () => {
+    render(<ResourceTreeView repo={repo} />);
+
+    await userEvent.click(screen.getByRole('button', { name: /expand all/i }));
+
+    expect(await screen.findByText('my-dashboard.json')).toBeInTheDocument();
+    expect(screen.getByText('other.json')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: /collapse all/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByText('my-dashboard.json')).not.toBeInTheDocument();
+    });
+    expect(screen.queryByText('other.json')).not.toBeInTheDocument();
+  });
+
+  it('shows matching nested items regardless of fold state while searching', async () => {
+    render(<ResourceTreeView repo={repo} />);
+
+    await userEvent.type(screen.getByPlaceholderText('Search by path or title'), 'other');
+
+    // Search bypasses the folded state, so the deeply nested match is visible without expanding.
+    expect(await screen.findByText('other.json')).toBeInTheDocument();
+    // Expand/collapse controls are disabled while a search is active.
+    expect(screen.getByRole('button', { name: /expand all/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /collapse all/i })).toBeDisabled();
+  });
+});

--- a/public/app/features/provisioning/Repository/ResourceTreeView.tsx
+++ b/public/app/features/provisioning/Repository/ResourceTreeView.tsx
@@ -7,7 +7,6 @@ import { Trans, t } from '@grafana/i18n';
 import {
   type CellProps,
   type Column,
-  Button,
   FilterInput,
   Icon,
   IconButton,
@@ -28,14 +27,7 @@ import {
 import { type FlatTreeItem, type TreeItem } from '../types';
 import { getRepoFileUrl } from '../utils/git';
 import { getKindInfoByItemType } from '../utils/resourceKinds';
-import {
-  buildTree,
-  filterTree,
-  flattenTree,
-  getAllFolderPaths,
-  getIconName,
-  mergeFilesAndResources,
-} from '../utils/treeUtils';
+import { buildTree, filterTree, flattenTree, getIconName, mergeFilesAndResources } from '../utils/treeUtils';
 
 interface ResourceTreeViewProps {
   repo: Repository;
@@ -90,14 +82,6 @@ export function ResourceTreeView({ repo }: ResourceTreeViewProps) {
       }
       return next;
     });
-  }, []);
-
-  const handleExpandAll = useCallback(() => {
-    setExpandedPaths(new Set(getAllFolderPaths(tree)));
-  }, [tree]);
-
-  const handleCollapseAll = useCallback(() => {
-    setExpandedPaths(new Set());
   }, []);
 
   const columns: Array<Column<FlatTreeItem>> = useMemo(
@@ -249,34 +233,12 @@ export function ResourceTreeView({ repo }: ResourceTreeViewProps) {
 
   return (
     <Stack direction="column" gap={2}>
-      <Stack direction="row" gap={2} alignItems="center">
-        <div className={styles.filter}>
-          <FilterInput
-            placeholder={t('provisioning.resource-tree.search-placeholder', 'Search by path or title')}
-            autoFocus={true}
-            value={searchQuery}
-            onChange={setSearchQuery}
-          />
-        </div>
-        <Button
-          variant="secondary"
-          fill="text"
-          icon="angle-double-down"
-          onClick={handleExpandAll}
-          disabled={!!searchQuery}
-        >
-          <Trans i18nKey="provisioning.resource-tree.expand-all">Expand all</Trans>
-        </Button>
-        <Button
-          variant="secondary"
-          fill="text"
-          icon="angle-double-up"
-          onClick={handleCollapseAll}
-          disabled={!!searchQuery}
-        >
-          <Trans i18nKey="provisioning.resource-tree.collapse-all">Collapse all</Trans>
-        </Button>
-      </Stack>
+      <FilterInput
+        placeholder={t('provisioning.resource-tree.search-placeholder', 'Search by path or title')}
+        autoFocus={true}
+        value={searchQuery}
+        onChange={setSearchQuery}
+      />
       <InteractiveTable
         columns={columns}
         data={flatItems}
@@ -288,9 +250,6 @@ export function ResourceTreeView({ repo }: ResourceTreeViewProps) {
 }
 
 const getStyles = (theme: GrafanaTheme2) => ({
-  filter: css({
-    flexGrow: 1,
-  }),
   titleCell: css({
     display: 'flex',
     alignItems: 'center',

--- a/public/app/features/provisioning/Repository/ResourceTreeView.tsx
+++ b/public/app/features/provisioning/Repository/ResourceTreeView.tsx
@@ -1,14 +1,16 @@
 import { css } from '@emotion/css';
 import { useBooleanFlagValue } from '@openfeature/react-sdk';
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 import { textUtil, type GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import {
   type CellProps,
   type Column,
+  Button,
   FilterInput,
   Icon,
+  IconButton,
   InteractiveTable,
   Link,
   LinkButton,
@@ -26,7 +28,14 @@ import {
 import { type FlatTreeItem, type TreeItem } from '../types';
 import { getRepoFileUrl } from '../utils/git';
 import { getKindInfoByItemType } from '../utils/resourceKinds';
-import { buildTree, filterTree, flattenTree, getIconName, mergeFilesAndResources } from '../utils/treeUtils';
+import {
+  buildTree,
+  filterTree,
+  flattenTree,
+  getAllFolderPaths,
+  getIconName,
+  mergeFilesAndResources,
+} from '../utils/treeUtils';
 
 interface ResourceTreeViewProps {
   repo: Repository;
@@ -49,23 +58,47 @@ export function ResourceTreeView({ repo }: ResourceTreeViewProps) {
   const resourcesQuery = useGetRepositoryResourcesQuery({ name });
 
   const [searchQuery, setSearchQuery] = useState('');
+  // Folder paths that are currently unfolded. Empty by default so the tree starts fully folded.
+  const [expandedPaths, setExpandedPaths] = useState<Set<string>>(new Set());
   const provisioningFolderMetadataEnabled = useBooleanFlagValue('provisioningFolderMetadata', false);
 
   const isLoading = filesQuery.isLoading || resourcesQuery.isLoading;
 
-  const flatItems = useMemo(() => {
+  const tree = useMemo(() => {
     const files = filesQuery.data?.items ?? [];
     const resources = resourcesQuery.data?.items ?? [];
 
     const merged = mergeFilesAndResources(files, resources);
-    let tree = buildTree(merged);
+    const built = buildTree(merged);
 
-    if (searchQuery) {
-      tree = filterTree(tree, searchQuery);
-    }
-
-    return flattenTree(tree);
+    return searchQuery ? filterTree(built, searchQuery) : built;
   }, [filesQuery.data?.items, resourcesQuery.data?.items, searchQuery]);
+
+  // While searching, ignore the folded state so every matching item stays visible.
+  const flatItems = useMemo(
+    () => flattenTree(tree, searchQuery ? undefined : expandedPaths),
+    [tree, expandedPaths, searchQuery]
+  );
+
+  const handleToggleExpand = useCallback((path: string) => {
+    setExpandedPaths((prev) => {
+      const next = new Set(prev);
+      if (next.has(path)) {
+        next.delete(path);
+      } else {
+        next.add(path);
+      }
+      return next;
+    });
+  }, []);
+
+  const handleExpandAll = useCallback(() => {
+    setExpandedPaths(new Set(getAllFolderPaths(tree)));
+  }, [tree]);
+
+  const handleCollapseAll = useCallback(() => {
+    setExpandedPaths(new Set());
+  }, []);
 
   const columns: Array<Column<FlatTreeItem>> = useMemo(
     () => [
@@ -73,12 +106,26 @@ export function ResourceTreeView({ repo }: ResourceTreeViewProps) {
         id: 'title',
         header: t('provisioning.resource-tree.header-title', 'Title'),
         cell: ({ row: { original } }: TreeCell) => {
-          const { item, level } = original;
+          const { item, level, isExpandable, isExpanded } = original;
           const iconName = getIconName(item.type);
           const link = getGrafanaLink(item);
 
           return (
             <div className={styles.titleCell} style={{ paddingLeft: level * 24 }}>
+              {isExpandable ? (
+                <IconButton
+                  name={isExpanded ? 'angle-down' : 'angle-right'}
+                  size="sm"
+                  onClick={() => handleToggleExpand(item.path)}
+                  aria-label={
+                    isExpanded
+                      ? t('provisioning.resource-tree.collapse-folder', 'Collapse {{title}}', { title: item.title })
+                      : t('provisioning.resource-tree.expand-folder', 'Expand {{title}}', { title: item.title })
+                  }
+                />
+              ) : (
+                <span className={styles.expandSpacer} />
+              )}
               <Icon name={iconName} className={styles.icon} />
               {link ? <Link href={link}>{item.title}</Link> : <span>{item.title}</span>}
             </div>
@@ -189,7 +236,7 @@ export function ResourceTreeView({ repo }: ResourceTreeViewProps) {
         },
       },
     ],
-    [provisioningFolderMetadataEnabled, repo.spec, styles]
+    [handleToggleExpand, provisioningFolderMetadataEnabled, repo.spec, styles]
   );
 
   if (isLoading) {
@@ -202,12 +249,34 @@ export function ResourceTreeView({ repo }: ResourceTreeViewProps) {
 
   return (
     <Stack direction="column" gap={2}>
-      <FilterInput
-        placeholder={t('provisioning.resource-tree.search-placeholder', 'Search by path or title')}
-        autoFocus={true}
-        value={searchQuery}
-        onChange={setSearchQuery}
-      />
+      <Stack direction="row" gap={2} alignItems="center">
+        <div className={styles.filter}>
+          <FilterInput
+            placeholder={t('provisioning.resource-tree.search-placeholder', 'Search by path or title')}
+            autoFocus={true}
+            value={searchQuery}
+            onChange={setSearchQuery}
+          />
+        </div>
+        <Button
+          variant="secondary"
+          fill="text"
+          icon="angle-double-down"
+          onClick={handleExpandAll}
+          disabled={!!searchQuery}
+        >
+          <Trans i18nKey="provisioning.resource-tree.expand-all">Expand all</Trans>
+        </Button>
+        <Button
+          variant="secondary"
+          fill="text"
+          icon="angle-double-up"
+          onClick={handleCollapseAll}
+          disabled={!!searchQuery}
+        >
+          <Trans i18nKey="provisioning.resource-tree.collapse-all">Collapse all</Trans>
+        </Button>
+      </Stack>
       <InteractiveTable
         columns={columns}
         data={flatItems}
@@ -219,10 +288,19 @@ export function ResourceTreeView({ repo }: ResourceTreeViewProps) {
 }
 
 const getStyles = (theme: GrafanaTheme2) => ({
+  filter: css({
+    flexGrow: 1,
+  }),
   titleCell: css({
     display: 'flex',
     alignItems: 'center',
     gap: theme.spacing(1),
+  }),
+  // Keeps rows without a fold control aligned with the chevron on foldable rows.
+  expandSpacer: css({
+    display: 'inline-block',
+    width: theme.spacing(2),
+    flexShrink: 0,
   }),
   icon: css({
     color: theme.colors.text.secondary,

--- a/public/app/features/provisioning/Repository/ResourceTreeView.tsx
+++ b/public/app/features/provisioning/Repository/ResourceTreeView.tsx
@@ -93,6 +93,9 @@ export function ResourceTreeView({ repo }: ResourceTreeViewProps) {
           const { item, level, isExpandable, isExpanded } = original;
           const iconName = getIconName(item.type);
           const link = getGrafanaLink(item);
+          // Label the fold toggle by the item's own title so screen readers announce which
+          // folder is being expanded/collapsed without needing a separate translated string.
+          const titleId = `resource-tree-item-${item.path}`;
 
           return (
             <div className={styles.titleCell} style={{ paddingLeft: level * 24 }}>
@@ -101,17 +104,20 @@ export function ResourceTreeView({ repo }: ResourceTreeViewProps) {
                   name={isExpanded ? 'angle-down' : 'angle-right'}
                   size="sm"
                   onClick={() => handleToggleExpand(item.path)}
-                  aria-label={
-                    isExpanded
-                      ? t('provisioning.resource-tree.collapse-folder', 'Collapse {{title}}', { title: item.title })
-                      : t('provisioning.resource-tree.expand-folder', 'Expand {{title}}', { title: item.title })
-                  }
+                  aria-expanded={isExpanded}
+                  aria-labelledby={titleId}
                 />
               ) : (
                 <span className={styles.expandSpacer} />
               )}
               <Icon name={iconName} className={styles.icon} />
-              {link ? <Link href={link}>{item.title}</Link> : <span>{item.title}</span>}
+              {link ? (
+                <Link id={titleId} href={link}>
+                  {item.title}
+                </Link>
+              ) : (
+                <span id={titleId}>{item.title}</span>
+              )}
             </div>
           );
         },

--- a/public/app/features/provisioning/Repository/ResourceTreeView.tsx
+++ b/public/app/features/provisioning/Repository/ResourceTreeView.tsx
@@ -84,6 +84,8 @@ export function ResourceTreeView({ repo }: ResourceTreeViewProps) {
     });
   }, []);
 
+  const isSearching = !!searchQuery;
+
   const columns: Array<Column<FlatTreeItem>> = useMemo(
     () => [
       {
@@ -95,7 +97,9 @@ export function ResourceTreeView({ repo }: ResourceTreeViewProps) {
           const link = getGrafanaLink(item);
           // Label the fold toggle by the item's own title so screen readers announce which
           // folder is being expanded/collapsed without needing a separate translated string.
-          const titleId = `resource-tree-item-${item.path}`;
+          // Encode the path so ids stay whitespace-free — aria-labelledby is a space-separated
+          // list, and folder paths may contain spaces.
+          const titleId = `resource-tree-item-${encodeURIComponent(item.path)}`;
 
           return (
             <div className={styles.titleCell} style={{ paddingLeft: level * 24 }}>
@@ -104,6 +108,8 @@ export function ResourceTreeView({ repo }: ResourceTreeViewProps) {
                   name={isExpanded ? 'angle-down' : 'angle-right'}
                   size="sm"
                   onClick={() => handleToggleExpand(item.path)}
+                  // Search forces every folder open, so the toggle can't change what's shown.
+                  disabled={isSearching}
                   aria-expanded={isExpanded}
                   aria-labelledby={titleId}
                 />
@@ -226,7 +232,7 @@ export function ResourceTreeView({ repo }: ResourceTreeViewProps) {
         },
       },
     ],
-    [handleToggleExpand, provisioningFolderMetadataEnabled, repo.spec, styles]
+    [handleToggleExpand, isSearching, provisioningFolderMetadataEnabled, repo.spec, styles]
   );
 
   if (isLoading) {

--- a/public/app/features/provisioning/Repository/ResourceTreeView.tsx
+++ b/public/app/features/provisioning/Repository/ResourceTreeView.tsx
@@ -255,6 +255,9 @@ export function ResourceTreeView({ repo }: ResourceTreeViewProps) {
         columns={columns}
         data={flatItems}
         pageSize={25}
+        // Folding rows or clearing a search can shrink the list below the current page; reset to
+        // the first page so users aren't stranded on a now-empty page.
+        autoResetPage={true}
         getRowId={(item: FlatTreeItem) => item.item.path}
       />
     </Stack>

--- a/public/app/features/provisioning/types.ts
+++ b/public/app/features/provisioning/types.ts
@@ -121,6 +121,10 @@ export interface TreeItem {
 export interface FlatTreeItem {
   item: TreeItem;
   level: number;
+  // Whether this row is a folder with children that can be folded/unfolded.
+  isExpandable: boolean;
+  // Whether an expandable row is currently showing its children.
+  isExpanded: boolean;
 }
 
 // External repository from the provider (e.g., GitHub)

--- a/public/app/features/provisioning/utils/treeUtils.test.ts
+++ b/public/app/features/provisioning/utils/treeUtils.test.ts
@@ -1120,7 +1120,9 @@ describe('flattenTree', () => {
             title: 'Subfolder',
             type: 'Folder',
             level: 0,
-            children: [{ path: 'folder/subfolder/file.json', title: 'file.json', type: 'File', level: 0, children: [] }],
+            children: [
+              { path: 'folder/subfolder/file.json', title: 'file.json', type: 'File', level: 0, children: [] },
+            ],
           },
         ],
       },
@@ -1151,7 +1153,9 @@ describe('getAllFolderPaths', () => {
             title: 'Subfolder',
             type: 'Folder',
             level: 0,
-            children: [{ path: 'folder/subfolder/file.json', title: 'file.json', type: 'File', level: 0, children: [] }],
+            children: [
+              { path: 'folder/subfolder/file.json', title: 'file.json', type: 'File', level: 0, children: [] },
+            ],
           },
         ],
       },

--- a/public/app/features/provisioning/utils/treeUtils.test.ts
+++ b/public/app/features/provisioning/utils/treeUtils.test.ts
@@ -6,7 +6,6 @@ import {
   buildTree,
   filterTree,
   flattenTree,
-  getAllFolderPaths,
   getIconName,
   getItemType,
   getStatus,
@@ -1136,39 +1135,6 @@ describe('flattenTree', () => {
     expect(result[0].isExpanded).toBe(true);
     expect(result[1].item.path).toBe('folder/subfolder');
     expect(result[1].isExpanded).toBe(false);
-  });
-});
-
-describe('getAllFolderPaths', () => {
-  it('should collect paths of every folder with children', () => {
-    const tree: TreeItem[] = [
-      {
-        path: 'folder',
-        title: 'Folder',
-        type: 'Folder',
-        level: 0,
-        children: [
-          {
-            path: 'folder/subfolder',
-            title: 'Subfolder',
-            type: 'Folder',
-            level: 0,
-            children: [
-              { path: 'folder/subfolder/file.json', title: 'file.json', type: 'File', level: 0, children: [] },
-            ],
-          },
-        ],
-      },
-      { path: 'root-file.json', title: 'root-file.json', type: 'File', level: 0, children: [] },
-    ];
-
-    expect(getAllFolderPaths(tree)).toEqual(['folder', 'folder/subfolder']);
-  });
-
-  it('should return an empty array when there are no folders with children', () => {
-    const tree: TreeItem[] = [{ path: 'file.json', title: 'file.json', type: 'File', level: 0, children: [] }];
-
-    expect(getAllFolderPaths(tree)).toEqual([]);
   });
 });
 

--- a/public/app/features/provisioning/utils/treeUtils.test.ts
+++ b/public/app/features/provisioning/utils/treeUtils.test.ts
@@ -6,6 +6,7 @@ import {
   buildTree,
   filterTree,
   flattenTree,
+  getAllFolderPaths,
   getIconName,
   getItemType,
   getStatus,
@@ -1065,6 +1066,105 @@ describe('flattenTree', () => {
     const result = flattenTree([]);
 
     expect(result).toHaveLength(0);
+  });
+
+  it('should mark folders expandable and expand everything when no expanded set is given', () => {
+    const tree: TreeItem[] = [
+      {
+        path: 'folder',
+        title: 'Folder',
+        type: 'Folder',
+        level: 0,
+        children: [{ path: 'folder/file.json', title: 'file.json', type: 'File', level: 0, children: [] }],
+      },
+    ];
+
+    const result = flattenTree(tree);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].isExpandable).toBe(true);
+    expect(result[0].isExpanded).toBe(true);
+    expect(result[1].isExpandable).toBe(false);
+    expect(result[1].isExpanded).toBe(false);
+  });
+
+  it('should hide children of folders that are not in the expanded set', () => {
+    const tree: TreeItem[] = [
+      {
+        path: 'folder',
+        title: 'Folder',
+        type: 'Folder',
+        level: 0,
+        children: [{ path: 'folder/file.json', title: 'file.json', type: 'File', level: 0, children: [] }],
+      },
+    ];
+
+    const result = flattenTree(tree, new Set());
+
+    expect(result).toHaveLength(1);
+    expect(result[0].item.path).toBe('folder');
+    expect(result[0].isExpandable).toBe(true);
+    expect(result[0].isExpanded).toBe(false);
+  });
+
+  it('should show children only for expanded folders', () => {
+    const tree: TreeItem[] = [
+      {
+        path: 'folder',
+        title: 'Folder',
+        type: 'Folder',
+        level: 0,
+        children: [
+          {
+            path: 'folder/subfolder',
+            title: 'Subfolder',
+            type: 'Folder',
+            level: 0,
+            children: [{ path: 'folder/subfolder/file.json', title: 'file.json', type: 'File', level: 0, children: [] }],
+          },
+        ],
+      },
+    ];
+
+    // Only the top folder is expanded, so its child folder shows but the grandchild file stays hidden.
+    const result = flattenTree(tree, new Set(['folder']));
+
+    expect(result).toHaveLength(2);
+    expect(result[0].item.path).toBe('folder');
+    expect(result[0].isExpanded).toBe(true);
+    expect(result[1].item.path).toBe('folder/subfolder');
+    expect(result[1].isExpanded).toBe(false);
+  });
+});
+
+describe('getAllFolderPaths', () => {
+  it('should collect paths of every folder with children', () => {
+    const tree: TreeItem[] = [
+      {
+        path: 'folder',
+        title: 'Folder',
+        type: 'Folder',
+        level: 0,
+        children: [
+          {
+            path: 'folder/subfolder',
+            title: 'Subfolder',
+            type: 'Folder',
+            level: 0,
+            children: [{ path: 'folder/subfolder/file.json', title: 'file.json', type: 'File', level: 0, children: [] }],
+          },
+        ],
+      },
+      { path: 'root-file.json', title: 'root-file.json', type: 'File', level: 0, children: [] },
+    ];
+
+    expect(getAllFolderPaths(tree)).toEqual(['folder', 'folder/subfolder']);
+  });
+
+  it('should return an empty array when there are no folders with children', () => {
+    const tree: TreeItem[] = [{ path: 'file.json', title: 'file.json', type: 'File', level: 0, children: [] }];
+
+    expect(getAllFolderPaths(tree)).toEqual([]);
   });
 });
 

--- a/public/app/features/provisioning/utils/treeUtils.ts
+++ b/public/app/features/provisioning/utils/treeUtils.ts
@@ -198,21 +198,48 @@ export function buildTree(mergedItems: MergedItem[]): TreeItem[] {
   return roots;
 }
 
-export function flattenTree(items: TreeItem[], level = 0): FlatTreeItem[] {
+/**
+ * Flatten a tree into the ordered list the table renders. A folder's descendants are only
+ * included when it is expanded. `expandedPaths` holds the set of folder paths currently expanded;
+ * pass `undefined` to expand everything (e.g. while searching, so all matches stay visible).
+ */
+export function flattenTree(items: TreeItem[], expandedPaths?: Set<string>, level = 0): FlatTreeItem[] {
   const result: FlatTreeItem[] = [];
 
   for (const item of items) {
+    const isExpandable = item.children.length > 0;
+    const isExpanded = isExpandable && (!expandedPaths || expandedPaths.has(item.path));
+
     result.push({
       item: { ...item, level },
       level,
+      isExpandable,
+      isExpanded,
     });
 
-    if (item.children.length > 0) {
-      result.push(...flattenTree(item.children, level + 1));
+    if (isExpanded) {
+      result.push(...flattenTree(item.children, expandedPaths, level + 1));
     }
   }
 
   return result;
+}
+
+/** Collect the paths of every folder that has children, so the UI can expand them all at once. */
+export function getAllFolderPaths(items: TreeItem[]): string[] {
+  const paths: string[] = [];
+
+  const walk = (nodes: TreeItem[]) => {
+    for (const node of nodes) {
+      if (node.children.length > 0) {
+        paths.push(node.path);
+        walk(node.children);
+      }
+    }
+  };
+
+  walk(items);
+  return paths;
 }
 
 /**

--- a/public/app/features/provisioning/utils/treeUtils.ts
+++ b/public/app/features/provisioning/utils/treeUtils.ts
@@ -225,23 +225,6 @@ export function flattenTree(items: TreeItem[], expandedPaths?: Set<string>, leve
   return result;
 }
 
-/** Collect the paths of every folder that has children, so the UI can expand them all at once. */
-export function getAllFolderPaths(items: TreeItem[]): string[] {
-  const paths: string[] = [];
-
-  const walk = (nodes: TreeItem[]) => {
-    for (const node of nodes) {
-      if (node.children.length > 0) {
-        paths.push(node.path);
-        walk(node.children);
-      }
-    }
-  };
-
-  walk(items);
-  return paths;
-}
-
 /**
  * Filter tree by search query (searches path and title).
  * Returns filtered tree including ancestor folders for matching items.

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -13869,6 +13869,10 @@
       "playlists": "Playlists"
     },
     "resource-tree": {
+      "collapse-all": "Collapse all",
+      "collapse-folder": "Collapse {{title}}",
+      "expand-all": "Expand all",
+      "expand-folder": "Expand {{title}}",
       "header-hash": "Hash",
       "header-status": "Status",
       "header-title": "Title",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -13869,8 +13869,6 @@
       "playlists": "Playlists"
     },
     "resource-tree": {
-      "collapse-folder": "Collapse {{title}}",
-      "expand-folder": "Expand {{title}}",
       "header-hash": "Hash",
       "header-status": "Status",
       "header-title": "Title",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -13869,9 +13869,7 @@
       "playlists": "Playlists"
     },
     "resource-tree": {
-      "collapse-all": "Collapse all",
       "collapse-folder": "Collapse {{title}}",
-      "expand-all": "Expand all",
       "expand-folder": "Expand {{title}}",
       "header-hash": "Hash",
       "header-status": "Status",


### PR DESCRIPTION

<img width="1387" height="642" alt="Screenshot 2026-07-15 at 14 39 45" src="https://github.com/user-attachments/assets/e01ae7cc-a43a-45dd-b50b-abc15d2031e6" />

## What

Makes the Resources tab tree (`ResourceTreeView`) foldable. Folders now start **folded by default** and each folder row has an expand/collapse toggle. Searching bypasses the folded state so all matches stay visible.

Closes grafana/git-ui-sync-project#1288.

## Why

The Resources tab rendered the entire file/resource tree fully expanded at all times. For repositories with many folders and files this produces a long, hard-to-scan list and makes it difficult to get an overview of the repository structure. Folding lets users collapse what they don't care about and drill into what they do.

## How

- **`utils/treeUtils.ts`**
  - `flattenTree(items, expandedPaths?, level?)` now takes an optional `Set<string>` of expanded folder paths and only recurses into folders in that set. Each `FlatTreeItem` carries `isExpandable` / `isExpanded`. Passing `undefined` expands everything — backwards compatible, and used while searching so all matches stay visible.
- **`types.ts`** — `FlatTreeItem` gains `isExpandable` and `isExpanded`.
- **`Repository/ResourceTreeView.tsx`**
  - New `expandedPaths` state, empty by default (folded by default).
  - Folder rows render an `angle-right` / `angle-down` toggle; non-folder rows get an alignment spacer so titles line up.
  - The toggle is labelled via `aria-labelledby` pointing at the folder title already on screen, with `aria-expanded` conveying state — no extra translated strings needed.

## Testing

- `treeUtils.test.ts` — added `flattenTree` cases for the expandable flags and per-folder visibility with an expanded set.
- `ResourceTreeView.test.tsx` (new) — covers folded-by-default, per-folder toggle (with `aria-expanded`), and search bypassing the fold state. Restores the frontend coverage for `@grafana/grafana-frontend-navigation`.
- `yarn typecheck`, `yarn eslint`, and `yarn prettier:check` pass on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)