### PR TITLE
Provisioning: Show folder path in Migrate resources list

### DIFF
--- a/public/app/features/provisioning/Migrate/FolderEntry.tsx
+++ b/public/app/features/provisioning/Migrate/FolderEntry.tsx
@@ -57,6 +57,11 @@ export function FolderEntry({
         />
         <Icon name="folder" />
         <Stack direction="column" gap={0} flex={1}>
+          {folder.path.length > 0 && (
+            <Text variant="bodySmall" color="secondary" truncate>
+              {folder.path.join(' / ')}
+            </Text>
+          )}
           <Text>{folder.title}</Text>
           <Text variant="bodySmall" color="secondary">
             {t('provisioning.migrate.resources-folder-summary', '', {

--- a/public/app/features/provisioning/Migrate/ResourcesToMigrate.test.tsx
+++ b/public/app/features/provisioning/Migrate/ResourcesToMigrate.test.tsx
@@ -59,8 +59,10 @@ describe('ResourcesToMigrate', () => {
   it('omits the breadcrumb for a root-level folder', () => {
     setup();
 
-    // Team A has an empty path, so no breadcrumb separator is rendered.
-    expect(screen.queryByText(/\//)).not.toBeInTheDocument();
+    // Team A has an empty path, so the breadcrumb line (folder titles joined by
+    // " / ") is never rendered. Match the separator with its surrounding spaces
+    // so unrelated slashes elsewhere in the UI can't trip this assertion.
+    expect(screen.queryByText(/ \/ /)).not.toBeInTheDocument();
   });
 
   it('expands a folder to reveal its resources', async () => {

--- a/public/app/features/provisioning/Migrate/ResourcesToMigrate.test.tsx
+++ b/public/app/features/provisioning/Migrate/ResourcesToMigrate.test.tsx
@@ -9,6 +9,7 @@ const folders: FolderRow[] = [
   {
     uid: 'team-a',
     title: 'Team A',
+    path: [],
     resourceCount: 2,
     directResources: [
       { uid: 'd1', title: 'Dashboard One', kind: resourceKindInfos.dashboard },
@@ -43,6 +44,23 @@ describe('ResourcesToMigrate', () => {
     expect(screen.getByText('Resources to migrate')).toBeInTheDocument();
     expect(screen.getByText('Team A')).toBeInTheDocument();
     expect(screen.getByText('Showing 1–1 of 1 folder')).toBeInTheDocument();
+  });
+
+  it('shows the ancestor path breadcrumb for a nested folder', () => {
+    setup({
+      folders: [{ ...folders[0], path: ['Parent', 'Child'] }],
+    });
+
+    expect(screen.getByText('Parent / Child')).toBeInTheDocument();
+    // The folder's own title still renders separately below the breadcrumb.
+    expect(screen.getByText('Team A')).toBeInTheDocument();
+  });
+
+  it('omits the breadcrumb for a root-level folder', () => {
+    setup();
+
+    // Team A has an empty path, so no breadcrumb separator is rendered.
+    expect(screen.queryByText(/\//)).not.toBeInTheDocument();
   });
 
   it('expands a folder to reveal its resources', async () => {
@@ -130,6 +148,7 @@ describe('ResourcesToMigrate', () => {
       {
         uid: '__playlists__',
         title: 'Playlists',
+        path: [],
         resourceCount: 2,
         directResources: [
           { uid: 'p1', title: 'Morning rotation', kind: resourceKindInfos.playlist },
@@ -175,6 +194,7 @@ describe('ResourcesToMigrate', () => {
     const manyFolders: FolderRow[] = Array.from({ length: 25 }, (_, i) => ({
       uid: `folder-${i}`,
       title: `Folder ${i}`,
+      path: [],
       resourceCount: 25 - i,
       directResources: [{ uid: `r-${i}`, title: `Resource ${i}`, kind: resourceKindInfos.dashboard }],
     }));
@@ -261,6 +281,7 @@ describe('ResourcesToMigrate', () => {
       {
         uid: 'alpha',
         title: 'Alpha',
+        path: [],
         resourceCount: 2,
         directResources: [
           { uid: 'a1', title: 'Alpha One', kind: resourceKindInfos.dashboard },
@@ -270,6 +291,7 @@ describe('ResourcesToMigrate', () => {
       {
         uid: 'beta',
         title: 'Beta',
+        path: [],
         resourceCount: 5,
         directResources: [{ uid: 'b1', title: 'Beta One', kind: resourceKindInfos.dashboard }],
       },

--- a/public/app/features/provisioning/Migrate/hooks/useMigrationData.test.ts
+++ b/public/app/features/provisioning/Migrate/hooks/useMigrationData.test.ts
@@ -78,6 +78,24 @@ describe('useMigrationData (folder-scoped kinds)', () => {
     expect(result.current.data.find((f) => f.uid === 'child')?.directResources.map((d) => d.uid)).toEqual(['d2']);
   });
 
+  it('records the ancestor path for nested folders and leaves root/general rows pathless', async () => {
+    mockSearch([
+      folder('grandparent'),
+      folder('parent', 'grandparent'),
+      folder('child', 'parent'),
+      dashboard('d1', 'child'),
+      dashboard('r1', ''),
+    ]);
+
+    const { result } = renderHook(() => useMigrationData(dashboardKinds), { wrapper });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    // The deeply-nested folder carries its ancestors, outermost first, excluding itself.
+    expect(result.current.data.find((f) => f.uid === 'child')?.path).toEqual(['grandparent', 'parent']);
+    // Root resources roll into the pathless General row.
+    expect(result.current.data.find((f) => f.uid === 'general')?.path).toEqual([]);
+  });
+
   it('rolls root-level dashboards into a synthetic General row and excludes managed ones', async () => {
     mockSearch([
       folder('a'),

--- a/public/app/features/provisioning/Migrate/hooks/useMigrationData.test.ts
+++ b/public/app/features/provisioning/Migrate/hooks/useMigrationData.test.ts
@@ -96,6 +96,45 @@ describe('useMigrationData (folder-scoped kinds)', () => {
     expect(result.current.data.find((f) => f.uid === 'general')?.path).toEqual([]);
   });
 
+  it('stops the ancestor walk when a parent folder is not in the listed folders', async () => {
+    // `orphan` points at a parent (`ghost`) that the search never returned, so
+    // the walk can't resolve it. The path ends up empty rather than throwing.
+    mockSearch([folder('orphan', 'ghost'), dashboard('d1', 'orphan')]);
+
+    const { result } = renderHook(() => useMigrationData(dashboardKinds), { wrapper });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.data.find((f) => f.uid === 'orphan')?.path).toEqual([]);
+  });
+
+  it('falls back to the folder uid and an empty path when the containing folder is not listed', async () => {
+    // The dashboard names a parent folder that search never returned as a folder
+    // row. The row still renders, keyed by the parent uid it references, with the
+    // uid used as the title (no folder title to resolve) and no ancestor path.
+    mockSearch([dashboard('d1', 'unlisted')]);
+
+    const { result } = renderHook(() => useMigrationData(dashboardKinds), { wrapper });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.data).toHaveLength(1);
+    const [row] = result.current.data;
+    // Unresolved folder: the title falls back to the uid and the path is empty.
+    expect(row.title).toBe(row.uid);
+    expect(row.path).toEqual([]);
+    expect(row.directResources.map((d) => d.uid)).toEqual(['d1']);
+  });
+
+  it('does not loop forever on a cyclic parent reference', async () => {
+    // A malformed hierarchy where `a` and `b` are each other's parent. The seen
+    // guard stops the walk after one hop instead of spinning indefinitely.
+    mockSearch([folder('a', 'b'), folder('b', 'a'), dashboard('d1', 'a')]);
+
+    const { result } = renderHook(() => useMigrationData(dashboardKinds), { wrapper });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.data.find((f) => f.uid === 'a')?.path).toEqual(['b']);
+  });
+
   it('rolls root-level dashboards into a synthetic General row and excludes managed ones', async () => {
     mockSearch([
       folder('a'),
@@ -182,6 +221,21 @@ describe('useMigrationData (non-folder kinds)', () => {
     // p3 is already managed, so only p1 and p2 are migration candidates.
     expect(row.directResources.map((r) => r.uid)).toEqual(['p1', 'p2']);
     expect(row.directResources.every((r) => r.kind.kind === 'Playlist')).toBe(true);
+  });
+
+  it('skips the folder listing entirely when no kind is folder-scoped', async () => {
+    // Playlists are the only kind here and aren't folder-scoped, so the hook
+    // never lists folders. A search failure must not matter — nothing depends
+    // on it — and the synthetic playlist row still renders.
+    server.use(http.get(searchRoute, () => HttpResponse.json({ message: 'boom' }, { status: 500 })));
+    mockPlaylists([playlist('p1', 'Morning rotation')]);
+
+    const { result } = renderHook(() => useMigrationData([resourceKindInfos.playlist]), { wrapper });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.isError).toBe(false);
+    expect(result.current.data.map((f) => f.title)).toEqual(['Playlists']);
+    expect(result.current.data[0].directResources.map((r) => r.uid)).toEqual(['p1']);
   });
 
   it('falls back to the name when a playlist has no title, and drops entries without a name', async () => {

--- a/public/app/features/provisioning/Migrate/hooks/useMigrationData.ts
+++ b/public/app/features/provisioning/Migrate/hooks/useMigrationData.ts
@@ -32,6 +32,13 @@ export function resourceKey(resource: MigratableResource): string {
 export interface FolderRow {
   uid: string;
   title: string;
+  /**
+   * Titles of the ancestor folders above this one, outermost first and excluding
+   * the folder itself. Shown as a breadcrumb so folders that share a name (e.g.
+   * two "Team" subfolders in different parents) can be told apart. Empty for
+   * root-level folders, the synthetic General row, and non-folder synthetic rows.
+   */
+  path: string[];
   /** Number of unmanaged resources directly in this folder. */
   resourceCount: number;
   /**
@@ -66,6 +73,28 @@ function syntheticFolderUid(kind: ResourceKindInfo): string {
 }
 
 /**
+ * Walks the parent chain of a folder and returns its ancestor titles, outermost
+ * first and excluding the folder itself. Missing ancestors (a parent not present
+ * in the listed folders) end the walk; a `seen` guard keeps a malformed cyclic
+ * parent reference from looping forever.
+ */
+function ancestorTitles(uid: string, folderByUid: Map<string, ListedResource>): string[] {
+  const titles: string[] = [];
+  const seen = new Set<string>([uid]);
+  let parentUid = folderByUid.get(uid)?.parentUid;
+  while (parentUid && !seen.has(parentUid)) {
+    seen.add(parentUid);
+    const parent = folderByUid.get(parentUid);
+    if (!parent) {
+      break;
+    }
+    titles.unshift(parent.title);
+    parentUid = parent.parentUid;
+  }
+  return titles;
+}
+
+/**
  * Joins the enumerated resources into the per-folder table the UI renders.
  * Folder-scoped kinds nest under the folder that directly contains them (and
  * roll up at the root into a synthetic "General" row); non-folder kinds get one
@@ -74,7 +103,7 @@ function syntheticFolderUid(kind: ResourceKindInfo): string {
  * left out entirely.
  */
 function aggregate(folders: ListedResource[], results: KindResult[]): FolderRow[] {
-  const folderTitle = new Map(folders.map((folder) => [folder.uid, folder.title]));
+  const folderByUid = new Map(folders.map((folder) => [folder.uid, folder]));
   const directByFolder = new Map<string, MigratableResource[]>();
   const rootResources: MigratableResource[] = [];
   const syntheticRows: FolderRow[] = [];
@@ -87,6 +116,7 @@ function aggregate(folders: ListedResource[], results: KindResult[]): FolderRow[
         syntheticRows.push({
           uid: syntheticFolderUid(kind),
           title: kind.pluralLabel(),
+          path: [],
           resourceCount: unmanaged.length,
           directResources: unmanaged.map((r) => ({ uid: r.uid, title: r.title, kind })),
         });
@@ -113,7 +143,8 @@ function aggregate(folders: ListedResource[], results: KindResult[]): FolderRow[
   for (const [uid, directResources] of directByFolder) {
     rows.push({
       uid,
-      title: folderTitle.get(uid) ?? uid,
+      title: folderByUid.get(uid)?.title ?? uid,
+      path: ancestorTitles(uid, folderByUid),
       resourceCount: directResources.length,
       directResources,
     });
@@ -122,6 +153,7 @@ function aggregate(folders: ListedResource[], results: KindResult[]): FolderRow[
     rows.push({
       uid: GENERAL_FOLDER_UID,
       title: t('provisioning.migrate.general-folder-title', 'General (root resources)'),
+      path: [],
       resourceCount: rootResources.length,
       directResources: rootResources,
     });

--- a/public/app/features/provisioning/Migrate/hooks/useMigrationData.ts
+++ b/public/app/features/provisioning/Migrate/hooks/useMigrationData.ts
@@ -79,6 +79,8 @@ function syntheticFolderUid(kind: ResourceKindInfo): string {
  * parent reference from looping forever.
  */
 function ancestorTitles(uid: string, folderByUid: Map<string, ListedResource>): string[] {
+  // Collected innermost-first while walking up, then reversed once so the walk
+  // stays linear (unshift-per-step would be O(depth²)).
   const titles: string[] = [];
   const seen = new Set<string>([uid]);
   let parentUid = folderByUid.get(uid)?.parentUid;
@@ -88,10 +90,10 @@ function ancestorTitles(uid: string, folderByUid: Map<string, ListedResource>): 
     if (!parent) {
       break;
     }
-    titles.unshift(parent.title);
+    titles.push(parent.title);
     parentUid = parent.parentUid;
   }
-  return titles;
+  return titles.reverse();
 }
 
 /**

--- a/public/app/features/provisioning/Migrate/selection.test.ts
+++ b/public/app/features/provisioning/Migrate/selection.test.ts
@@ -13,6 +13,7 @@ function folder(uid: string, dashboardUids: string[]): FolderRow {
   return {
     uid,
     title: uid,
+    path: [],
     resourceCount: directResources.length,
     directResources,
   };
@@ -25,6 +26,7 @@ function playlistFolder(uid: string, playlistUids: string[]): FolderRow {
   return {
     uid,
     title: 'Playlists',
+    path: [],
     resourceCount: directResources.length,
     directResources,
   };

--- a/public/app/features/provisioning/Migrate/sorting.test.ts
+++ b/public/app/features/provisioning/Migrate/sorting.test.ts
@@ -2,7 +2,7 @@ import { type FolderRow } from './hooks/useMigrationData';
 import { compareFolders } from './sorting';
 
 function folder(uid: string, title: string, resourceCount: number): FolderRow {
-  return { uid, title, resourceCount, directResources: [] };
+  return { uid, title, path: [], resourceCount, directResources: [] };
 }
 
 describe('compareFolders', () => {


### PR DESCRIPTION

<img width="1776" height="918" alt="Screenshot 2026-07-15 at 20 15 44" src="https://github.com/user-attachments/assets/7b93399b-3a3d-4dab-9345-b590a079675f" />
<img width="1830" height="632" alt="Screenshot 2026-07-15 at 20 15 28" src="https://github.com/user-attachments/assets/bce4ecbd-6180-4ec7-b477-c4472c7c50fb" />


## What

Adds an ancestor-path breadcrumb (e.g. `Parent / Child`) above each folder title in the **Resources to migrate** table of the Migrate-to-GitOps flow.

Closes grafana/git-ui-sync-project#1286

## Why

The table only showed each folder's own title. Nested folders that share a name — e.g. two `Team` subfolders under different parents — were indistinguishable, so users couldn't tell which folder they were actually selecting to migrate. Showing the path disambiguates them.

## How

- **`hooks/useMigrationData.ts`**: Added a `path: string[]` field to `FolderRow` (ancestor titles, outermost first, excluding the folder itself). A new `ancestorTitles()` helper walks the parent chain via a `folderByUid` map, with a `seen` guard against malformed cyclic parent references and graceful termination when an ancestor is missing. Root-level folders, the synthetic "General" row, and non-folder synthetic rows (playlists / library panels) get an empty path.
- **`FolderEntry.tsx`**: Renders the joined path as a small, truncated secondary line above the folder title, only when the path is non-empty. No new i18n key — it's plain joined data.
- Updated `FolderRow` test fixtures for the new required field.

Frontend-only change.

## Testing

- `yarn jest public/app/features/provisioning/Migrate/` — 110 passed. New tests: nested folder records its ancestor path; General row stays pathless; breadcrumb renders for nested folders and is omitted for root folders.
- `yarn typecheck` — clean.
- `yarn eslint` on changed files — clean.

## Checklist

- [x] Tests added/updated
- [x] No breaking changes
- [ ] Documentation updated (n/a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)