### PR TITLE
Scopes: disable scope redirect when rendering for image capture

### DIFF
--- a/e2e-playwright/dashboard-cujs/scope-redirect.spec.ts
+++ b/e2e-playwright/dashboard-cujs/scope-redirect.spec.ts
@@ -275,6 +275,39 @@ test.describe('Scope Redirect Functionality', () => {
     });
   });
 
+  test('should not redirect when the image renderer binding is present', async ({ page, gotoDashboardPage }) => {
+    const scopes = testScopesWithRedirect();
+
+    await test.step('Inject the image-renderer binding before any page script runs', async () => {
+      // Mimics what grafana-image-renderer's chromedp does on real /render calls.
+      await page.addInitScript(() => {
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        (
+          window as unknown as { __grafanaImageRendererMessageChannel: (m: string) => void }
+        ).__grafanaImageRendererMessageChannel = () => {};
+      });
+    });
+
+    await test.step('Set up routes and navigate to dashboard', async () => {
+      await setupScopeRoutes(page, scopes);
+      await gotoDashboardPage({ uid: 'cuj-dashboard-3' });
+    });
+
+    await test.step('Apply a scope whose redirect fallback would normally navigate away', async () => {
+      await openScopesSelector(page, scopes);
+      await selectScope(page, 'sn-redirect-fallback', scopes[1]);
+      await applyScopes(page, [scopes[1]]);
+
+      // Scope must still be applied…
+      await expect(page).toHaveURL(/scopes=scope-sn-redirect-fallback/);
+      // …but the redirect must not fire, so we stay on cuj-dashboard-3
+      // (which is NOT in the scope's dashboard bindings — the same dashboard
+      // that causes a redirect in the non-render-target sibling test above).
+      await expect(page).toHaveURL(/\/d\/cuj-dashboard-3/);
+      await expect(page).not.toHaveURL(/\/d\/cuj-dashboard-2/);
+    });
+  });
+
   test('should redirect again after exiting edit mode', async ({ page, gotoDashboardPage, selectors }) => {
     const scopes = testScopesWithRedirect();
     let dashboardPage: Awaited<ReturnType<typeof gotoDashboardPage>>;

--- a/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
@@ -39,6 +39,7 @@ import { getDashboardSceneProfiler } from 'app/features/dashboard/services/Dashb
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
 import { initializeReportRenderReadinessObserver } from 'app/features/dashboard/services/ReportRenderReadinessObserver';
 import { initializeScenePerformanceLogger } from 'app/features/dashboard/services/ScenePerformanceLogger';
+import { isRenderTarget } from 'app/features/dashboard/services/isRenderTarget';
 import { emitDashboardViewEvent } from 'app/features/dashboard/state/analyticsProcessor';
 import { CustomDashboardTemplateInteractions } from 'app/features/dashboard-scene/analytics/dashboard-templates/main';
 import { transformTemplateToSaveModelSchemaV2 } from 'app/features/dashboard-scene/utils/dashboardTemplateEnvelope';
@@ -443,13 +444,10 @@ abstract class DashboardScenePageStateManagerBase<T>
 
       trackDashboardSceneLoaded(dashboard, measure?.duration);
 
-      const isRenderTarget =
-        options.route === DashboardRoutes.Report ||
-        options.route === DashboardRoutes.Embedded ||
-        (options.route === DashboardRoutes.Normal && contextSrv.user?.authenticatedBy === 'render');
+      const renderTarget = isRenderTarget(options.route);
       const enableProfiling =
         config.dashboardPerformanceMetrics.findIndex((uid) => uid === '*' || uid === options.uid) !== -1 ||
-        isRenderTarget;
+        renderTarget;
 
       if (enableProfiling) {
         // Initialize both performance services before starting profiling to ensure observers are registered
@@ -462,7 +460,7 @@ abstract class DashboardScenePageStateManagerBase<T>
         }
       }
 
-      if (isRenderTarget) {
+      if (renderTarget) {
         // Register the report render readiness observer so the image renderer can detect
         // when the dashboard has fully rendered (queries + transforms + fieldConfig + render)
         initializeReportRenderReadinessObserver();

--- a/public/app/features/dashboard-scene/scene/DashboardSceneRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneRenderer.tsx
@@ -32,6 +32,7 @@ export function DashboardSceneRenderer({ model }: SceneComponentProps<DashboardS
 
   // Disable scope redirects while in edit mode so users aren't navigated away mid-edit.
   // Also close the scopes dashboards drawer while editing and restore it on exit.
+  // (Render-target suppression is handled synchronously inside redirectAfterApply.)
   useEffect(() => {
     scopesServices?.scopesSelectorService.setRedirectEnabled(!isEditing);
 

--- a/public/app/features/dashboard-scene/scene/DashboardSceneRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneRenderer.tsx
@@ -32,7 +32,6 @@ export function DashboardSceneRenderer({ model }: SceneComponentProps<DashboardS
 
   // Disable scope redirects while in edit mode so users aren't navigated away mid-edit.
   // Also close the scopes dashboards drawer while editing and restore it on exit.
-  // (Render-target suppression is handled synchronously inside redirectAfterApply.)
   useEffect(() => {
     scopesServices?.scopesSelectorService.setRedirectEnabled(!isEditing);
 

--- a/public/app/features/dashboard/services/isRenderTarget.test.ts
+++ b/public/app/features/dashboard/services/isRenderTarget.test.ts
@@ -1,0 +1,97 @@
+import { contextSrv } from 'app/core/services/context_srv';
+import { DashboardRoutes } from 'app/types/dashboard';
+
+import { isRenderTarget } from './isRenderTarget';
+
+describe('isRenderTarget', () => {
+  const originalAuthenticatedBy = contextSrv.user?.authenticatedBy;
+
+  afterEach(() => {
+    delete (window as { __grafanaImageRendererMessageChannel?: unknown }).__grafanaImageRendererMessageChannel;
+    if (contextSrv.user) {
+      contextSrv.user.authenticatedBy = originalAuthenticatedBy ?? '';
+    }
+  });
+
+  describe('by route', () => {
+    it('returns true for Report route', () => {
+      expect(isRenderTarget(DashboardRoutes.Report)).toBe(true);
+    });
+
+    it('returns true for Embedded route', () => {
+      expect(isRenderTarget(DashboardRoutes.Embedded)).toBe(true);
+    });
+
+    it('returns false for Normal route without other signals', () => {
+      expect(isRenderTarget(DashboardRoutes.Normal)).toBe(false);
+    });
+
+    it('returns false for Home route without other signals', () => {
+      expect(isRenderTarget(DashboardRoutes.Home)).toBe(false);
+    });
+  });
+
+  describe('by image renderer binding', () => {
+    it('returns true when the chromedp binding is present', () => {
+      (window as { __grafanaImageRendererMessageChannel?: unknown }).__grafanaImageRendererMessageChannel = jest.fn();
+      expect(isRenderTarget()).toBe(true);
+    });
+
+    it('returns true when the binding is present and route is Normal', () => {
+      (window as { __grafanaImageRendererMessageChannel?: unknown }).__grafanaImageRendererMessageChannel = jest.fn();
+      expect(isRenderTarget(DashboardRoutes.Normal)).toBe(true);
+    });
+
+    it('returns false when the binding is not a function', () => {
+      (window as { __grafanaImageRendererMessageChannel?: unknown }).__grafanaImageRendererMessageChannel = 'not-a-fn';
+      expect(isRenderTarget()).toBe(false);
+    });
+  });
+
+  describe('by authenticatedBy fallback', () => {
+    it('returns true when authenticatedBy is "render"', () => {
+      if (contextSrv.user) {
+        contextSrv.user.authenticatedBy = 'render';
+      }
+      expect(isRenderTarget()).toBe(true);
+    });
+
+    it('returns false when authenticatedBy is another value', () => {
+      if (contextSrv.user) {
+        contextSrv.user.authenticatedBy = 'password';
+      }
+      expect(isRenderTarget()).toBe(false);
+    });
+
+    it('returns false when authenticatedBy is empty', () => {
+      if (contextSrv.user) {
+        contextSrv.user.authenticatedBy = '';
+      }
+      expect(isRenderTarget()).toBe(false);
+    });
+  });
+
+  describe('combined signals', () => {
+    it('returns true when route is Report even if no other signals', () => {
+      if (contextSrv.user) {
+        contextSrv.user.authenticatedBy = '';
+      }
+      expect(isRenderTarget(DashboardRoutes.Report)).toBe(true);
+    });
+
+    it('returns true when route is Normal but binding is present', () => {
+      (window as { __grafanaImageRendererMessageChannel?: unknown }).__grafanaImageRendererMessageChannel = jest.fn();
+      if (contextSrv.user) {
+        contextSrv.user.authenticatedBy = '';
+      }
+      expect(isRenderTarget(DashboardRoutes.Normal)).toBe(true);
+    });
+
+    it('returns false with no route, no binding, and no matching auth', () => {
+      if (contextSrv.user) {
+        contextSrv.user.authenticatedBy = 'password';
+      }
+      expect(isRenderTarget()).toBe(false);
+    });
+  });
+});

--- a/public/app/features/dashboard/services/isRenderTarget.ts
+++ b/public/app/features/dashboard/services/isRenderTarget.ts
@@ -1,0 +1,22 @@
+import { contextSrv } from 'app/core/services/context_srv';
+import { DashboardRoutes } from 'app/types/dashboard';
+
+/**
+ * True when the current page is being loaded specifically for image/PDF capture by the
+ * grafana-image-renderer, or is otherwise a render-only surface (Report, Embedded).
+ *
+ * The chromedp binding check is the ground-truth signal for image-renderer captures.
+ * `authenticatedBy === 'render'` is kept as a legacy fallback but is not currently
+ * propagated to `contextSrv.user` in all render flows.
+ */
+export function isRenderTarget(route?: DashboardRoutes): boolean {
+  if (route === DashboardRoutes.Report || route === DashboardRoutes.Embedded) {
+    return true;
+  }
+
+  if (typeof window !== 'undefined' && typeof window.__grafanaImageRendererMessageChannel === 'function') {
+    return true;
+  }
+
+  return contextSrv.user?.authenticatedBy === 'render';
+}

--- a/public/app/features/scopes/selector/ScopesSelectorService.test.ts
+++ b/public/app/features/scopes/selector/ScopesSelectorService.test.ts
@@ -999,6 +999,34 @@ describe('ScopesSelectorService', () => {
       expect(locationService.push).not.toHaveBeenCalled();
     });
 
+    it('should NOT redirect when the image renderer binding is present', async () => {
+      (window as { __grafanaImageRendererMessageChannel?: unknown }).__grafanaImageRendererMessageChannel = jest.fn();
+
+      dashboardsService.state.scopeNavigations = [
+        {
+          spec: {
+            scope: 'test-scope',
+            url: '/d/dashboard1',
+          },
+          status: {
+            title: 'Dashboard 1',
+            groups: [],
+          },
+          metadata: {
+            name: 'dashboard1',
+          },
+        },
+      ];
+      (locationService.getLocation as jest.Mock).mockReturnValue({ pathname: '/d/some-other-dashboard' });
+
+      try {
+        await service.changeScopes(['test-scope']);
+        expect(locationService.push).not.toHaveBeenCalled();
+      } finally {
+        delete (window as { __grafanaImageRendererMessageChannel?: unknown }).__grafanaImageRendererMessageChannel;
+      }
+    });
+
     it('should redirect again after re-enabling redirects', async () => {
       dashboardsService.state.scopeNavigations = [
         {

--- a/public/app/features/scopes/selector/ScopesSelectorService.ts
+++ b/public/app/features/scopes/selector/ScopesSelectorService.ts
@@ -2,6 +2,7 @@ import { type ScopeNode, store as storeImpl } from '@grafana/data';
 import { config, locationService } from '@grafana/runtime';
 import { type performanceUtils } from '@grafana/scenes';
 import { getDashboardSceneProfiler } from 'app/features/dashboard/services/DashboardProfiler';
+import { isRenderTarget } from 'app/features/dashboard/services/isRenderTarget';
 
 import { type ScopesApiClient } from '../ScopesApiClient';
 import { ScopesServiceBase } from '../ScopesServiceBase';
@@ -485,6 +486,13 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
   // Redirect to the scope node's redirect URL if it exists, otherwise redirect to the first scope navigation.
   private redirectAfterApply = (scopeNode: ScopeNode | undefined) => {
     if (!this.redirectEnabled) {
+      return;
+    }
+
+    // Never redirect during image/PDF capture — the renderer must stay on the requested dashboard
+    // so its panels can render. Checked synchronously here (not via setRedirectEnabled) because
+    // applyScopes runs during ScopesService boot, before any React effect can toggle the flag.
+    if (isRenderTarget()) {
       return;
     }
 


### PR DESCRIPTION
## Summary
- When a dashboard is rendered via grafana-image-renderer (PDF export / \`/render\` / reports), \`ScopesSelectorService.redirectAfterApply\` was pushing the renderer off the requested dashboard toward the scope's "most relevant" dashboard. The renderer then captured the destination page before its panels had loaded — the resulting image showed chrome + timepicker but no panel frames.
- The redirect is now short-circuited synchronously inside \`redirectAfterApply\` when the grafana-image-renderer chromedp binding (\`window.__grafanaImageRendererMessageChannel\`) is present.
- Doing the check inside \`redirectAfterApply\` — rather than only via \`setRedirectEnabled\` from \`DashboardSceneRenderer\` — avoids a React-lifecycle race where \`applyScopes\` runs during \`ScopesService\` boot from the URL, before any component effect could toggle the flag.
- Extracts the "is this a render target?" logic into a shared \`isRenderTarget()\` helper reused by \`DashboardScenePageStateManager\` (the previous inline predicate). \`contextSrv.user.authenticatedBy === 'render'\` turned out not to be reliably populated on render tokens, so the chromedp binding is the ground-truth signal; the auth check is kept as a legacy fallback.

## Test plan
- [x] Unit — new helper: \`public/app/features/dashboard/services/isRenderTarget.test.ts\` (13 tests covering route / binding / \`authenticatedBy\` / combined signals)
- [x] Unit — redirect suppression: \`ScopesSelectorService.test.ts\` — new "should NOT redirect when the image renderer binding is present" case
- [x] E2e — \`scope-redirect.spec.ts\` new case that injects the binding via \`page.addInitScript\` before navigation and asserts no redirect fires (mirrors the existing edit-mode suppression test)
- [x] \`yarn lint:ts\` clean
- [ ] Reproduce manually via \`/api/reports/render/pdfs\` with a dashboard whose default scope's \`redirectPath\` targets a different dashboard, and confirm panels render on the requested dashboard rather than the redirect target

🤖 Generated with [Claude Code](https://claude.com/claude-code)