### PR TITLE
Sqlite: Fix pragma parsing

### DIFF
--- a/pkg/util/sqlite/sqlite_nocgo.go
+++ b/pkg/util/sqlite/sqlite_nocgo.go
@@ -78,8 +78,8 @@ func convertSQLite3URL(dsn string) (string, error) {
 		value := values[0]
 		switch mapped {
 		case "_pragma":
-			value = strings.TrimPrefix(value, "_")
-			q.Add("_pragma", fmt.Sprintf("%s(%s)", key, value))
+			pragma := strings.TrimPrefix(key, "_")
+			q.Add("_pragma", fmt.Sprintf("%s(%s)", pragma, value))
 		case "_txlock":
 			q.Set("_txlock", value)
 		case "_time_format":

--- a/pkg/util/sqlite/sqlite_nocgo_test.go
+++ b/pkg/util/sqlite/sqlite_nocgo_test.go
@@ -1,0 +1,51 @@
+package sqlite
+
+import (
+	"database/sql"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestAppliesConvertedPragmas(t *testing.T) {
+	dsn := "file:" + filepath.Join(t.TempDir(), "test.db") + "?_journal_mode=WAL&_synchronous=OFF&_cache_size=2000&_temp_store=MEMORY"
+	db, err := sql.Open("sqlite3", dsn)
+	if err != nil {
+		t.Fatalf("open SQLite database: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Errorf("close SQLite database: %v", err)
+		}
+	})
+
+	conn, err := db.Conn(t.Context())
+	if err != nil {
+		t.Fatalf("open SQLite connection: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := conn.Close(); err != nil {
+			t.Errorf("close SQLite connection: %v", err)
+		}
+	})
+
+	testCases := []struct {
+		pragma string
+		want   any
+	}{
+		{pragma: "busy_timeout", want: int64(7500)},
+		{pragma: "cache_size", want: int64(2000)},
+		{pragma: "journal_mode", want: "wal"},
+		{pragma: "synchronous", want: int64(0)},
+		{pragma: "temp_store", want: int64(2)},
+	}
+	for _, tc := range testCases {
+		var got any
+		if err := conn.QueryRowContext(t.Context(), "PRAGMA "+tc.pragma).Scan(&got); err != nil {
+			t.Fatalf("query PRAGMA %s: %v", tc.pragma, err)
+		}
+		if !reflect.DeepEqual(got, tc.want) {
+			t.Errorf("unexpected PRAGMA %s: got %#v, want %#v", tc.pragma, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
Fixes SQLite DSN conversion for the modernc driver by stripping the leading underscore from pragma names rather than their values.

**Before**
`_journal_mode=WAL` => `_pragma=_journal_mode(WAL)` which is invalid and silently ignored.

**After**
`_journal_mode=WAL` => `_pragma=journal_mode(WAL)` which is correctly applied by SQLite.

The test results show that there is a general improvement in the SQLite integration tests, more than regressions in test time.

## Test Time Comparison

Used this PR as a baseline: https://github.com/grafana/grafana/actions/runs/29394321696/job/87284330874

### Summary

| Scope | Baseline | New | Time difference |
|---|---:|---:|---:|
| All 210 packages | 3526.921 s | 2703.864 s | -823.057 s |

### Package details

| Package | Baseline | New | Time Diff |
|---|---:|---:|---:|
| `pkg/api` | 7.294 s | 2.671 s | -4.623 s |
| `pkg/extensions/apiserver/registry/provisioning/githubenterprise` | 13.117 s | 5.023 s | -8.094 s |
| `pkg/extensions/caching/cache` | 8.833 s | 8.882 s | *+0.049 s* |
| `pkg/infra/remotecache` | 4.449 s | 2.320 s | -2.129 s |
| `pkg/services/accesscontrol/dualwrite` | 8.890 s | 1.555 s | -7.335 s |
| `pkg/services/libraryelements` | 78.148 s | 35.893 s | -42.255 s |
| `pkg/services/pluginsintegration/pluginsettings/service` | 2.742 s | 1.068 s | -1.674 s |
| `pkg/services/sqlstore` | 10.250 s | 2.987 s | -7.263 s |
| `pkg/storage/unified/search` | 0.098 s | 0.474 s | *+0.376 s* |
| `pkg/tests/api/influxdb` | 0.144 s | 0.170 s | *+0.026 s* |
| `pkg/tests/apis/alerting/rules/recordingrule` | 27.081 s | 19.305 s | -7.776 s |
| `pkg/tests/apis/iam/user` | 144.005 s | 123.965 s | -20.040 s |
| `pkg/tests/apis/provisioning/jobs` | 63.030 s | 56.284 s | -6.746 s |
| `pkg/tsdb/influxdb/fsql` | 0.126 s | 0.136 s | *+0.010 s* |
| `pkg/api/pluginproxy` | 2.227 s | 1.104 s | -1.123 s |
| `pkg/extensions/apiserver/registry/provisioning/gitlab` | 13.143 s | 4.652 s | -8.491 s |
| `pkg/extensions/caching/storage` | 3.919 s | 0.916 s | -3.003 s |
| `pkg/infra/serverlock` | 4.083 s | 0.746 s | -3.337 s |
| `pkg/services/accesscontrol/migrator` | 3.222 s | 0.766 s | -2.456 s |
| `pkg/services/librarypanels` | 3.803 s | 1.169 s | -2.634 s |
| `pkg/services/pluginsintegration/plugintest` | 7.317 s | 3.683 s | -3.634 s |
| `pkg/services/sqlstore/migrations` | 0.226 s | 0.225 s | -0.001 s |
| `pkg/storage/unified/search/embed/embedder` | 0.219 s | 0.323 s | *+0.104 s* |
| `pkg/tests/api/loki` | 11.983 s | 3.452 s | -8.531 s |
| `pkg/tests/apis/alerting/rules/rulesequence` | 7.093 s | 3.793 s | -3.300 s |
| `pkg/tests/apis/playlist` | 6.279 s | 3.710 s | -2.569 s |
| `pkg/tests/apis/provisioning/jobs/conflict` | 5.731 s | 3.587 s | -2.144 s |
| `pkg/tsdb/mysql` | 0.084 s | 0.011 s | -0.073 s |
| `pkg/cmd/grafana-cli/commands` | 3.617 s | 1.268 s | -2.349 s |
| `pkg/extensions/apiserver/registry/secret/encryption` | 0.175 s | 0.141 s | -0.034 s |
| `pkg/extensions/cachingmt/cache/wrappers` | 8.532 s | 8.507 s | -0.025 s |
| `pkg/infra/usagestats/service` | 3.491 s | 0.823 s | -2.668 s |
| `pkg/services/accesscontrol/resourcepermissions` | 10.317 s | 1.295 s | -9.022 s |
| `pkg/services/live` | 0.108 s | 0.125 s | *+0.017 s* |
| `pkg/services/preference/prefimpl` | 1.728 s | 0.874 s | -0.854 s |
| `pkg/services/sqlstore/migrations/usermig/test` | 3.898 s | 1.780 s | -2.118 s |
| `pkg/storage/unified/search/embed/embedder/vertex` | 0.059 s | 0.049 s | -0.010 s |
| `pkg/tests/api/plugins` | 9.614 s | 6.159 s | -3.455 s |
| `pkg/tests/apis/annotations` | 19.797 s | 15.032 s | -4.765 s |
| `pkg/tests/apis/plugins` | 25.753 s | 20.216 s | -5.537 s |
| `pkg/tests/apis/provisioning/jobs/instanceauth` | 7.031 s | 4.013 s | -3.018 s |
| `pkg/cmd/grafana-cli/commands/datamigrations` | 1.730 s | 1.848 s | *+0.118 s* |
| `pkg/extensions/apiserver/registry/secret/inline` | 0.689 s | 0.656 s | -0.033 s |
| `pkg/extensions/enterprisepublicdashboards/api` | 4.639 s | 3.273 s | -1.366 s |
| `pkg/infra/usagestats/statscollector` | 2.730 s | 0.946 s | -1.784 s |
| `pkg/services/annotations/annotationsimpl` | 14.969 s | 29.069 s | *+14.100 s* |
| `pkg/services/live/managedstream` | 0.054 s | 0.054 s | 0.000 s |
| `pkg/services/provisioning/dashboards` | 2.659 s | 0.932 s | -1.727 s |
| `pkg/services/ssosettings/database` | 3.702 s | 0.724 s | -2.978 s |
| `pkg/storage/unified/search/vector` | 0.109 s | 0.078 s | -0.031 s |
| `pkg/tests/api/plugins/backendplugin` | 4.820 s | 2.964 s | -1.856 s |
| `pkg/tests/apis/appplugin` | 12.867 s | 10.645 s | -2.222 s |
| `pkg/tests/apis/preferences` | 10.512 s | 7.620 s | -2.892 s |
| `pkg/tests/apis/provisioning/maxfilesize` | 6.457 s | 4.211 s | -2.246 s |
| `pkg/extensions/accesscontrol/acimpl` | 2.646 s | 1.528 s | -1.118 s |
| `pkg/extensions/apiserver/registry/secret/reststorage` | 0.758 s | 0.837 s | *+0.079 s* |
| `pkg/extensions/enterprisepublicdashboards/database` | 3.732 s | 1.361 s | -2.371 s |
| `pkg/login/social/socialimpl` | 3.195 s | 1.314 s | -1.881 s |
| `pkg/services/annotations/annotationsimpl/loki` | 2.251 s | 1.266 s | -0.985 s |
| `pkg/services/login/authinfoimpl` | 2.182 s | 1.011 s | -1.171 s |
| `pkg/services/publicdashboards/internal/database` | 4.529 s | 1.057 s | -3.472 s |
| `pkg/services/star/starimpl` | 2.082 s | 0.891 s | -1.191 s |
| `pkg/storage/unified/sql` | 10.526 s | 10.724 s | *+0.198 s* |
| `pkg/tests/api/prometheus` | 5.990 s | 2.630 s | -3.360 s |
| `pkg/tests/apis/collections` | 10.413 s | 6.443 s | -3.970 s |
| `pkg/tests/apis/provisioning` | 55.400 s | 46.882 s | -8.518 s |
| `pkg/tests/apis/provisioning/nats` | 14.922 s | 13.189 s | -1.733 s |
| `pkg/extensions/accesscontrol/database` | 4.674 s | 1.697 s | -2.977 s |
| `pkg/extensions/apiserver/tests` | 12.423 s | 4.926 s | -7.497 s |
| `pkg/extensions/ldapsync` | 0.065 s | 0.109 s | *+0.044 s* |
| `pkg/registry/apis/dashboard/snapshot/migrator` | 6.146 s | 1.018 s | -5.128 s |
| `pkg/services/anonymous/anonimpl` | 6.114 s | 1.114 s | -5.000 s |
| `pkg/services/loginattempt/loginattemptimpl` | 7.470 s | 1.071 s | -6.399 s |
| `pkg/services/publicdashboards/internal/service` | 10.660 s | 1.179 s | -9.481 s |
| `pkg/services/stats/statsimpl` | 4.546 s | 1.111 s | -3.435 s |
| `pkg/storage/unified/sql/test` | 48.895 s | 26.516 s | -22.379 s |
| `pkg/tests/api/stats` | 10.427 s | 4.637 s | -5.790 s |
| `pkg/tests/apis/correlations` | 6.796 s | 3.270 s | -3.526 s |
| `pkg/tests/apis/provisioning/apiversion` | 7.903 s | 5.385 s | -2.518 s |
| `pkg/tests/apis/provisioning/nats/historicjob` | 19.532 s | 16.986 s | -2.546 s |
| `pkg/extensions/accesscontrol/globalrolesync` | 0.211 s | 0.322 s | *+0.111 s* |
| `pkg/extensions/apiserver/tests/datasource` | 9.620 s | 5.518 s | -4.102 s |
| `pkg/extensions/licensing/service` | 3.810 s | 1.638 s | -2.172 s |
| `pkg/registry/apis/iam/resourcepermission` | 4.845 s | 1.731 s | -3.114 s |
| `pkg/services/anonymous/anonimpl/anonstore` | 3.399 s | 1.444 s | -1.955 s |
| `pkg/services/ngalert/api` | 13.957 s | 2.528 s | -11.429 s |
| `pkg/services/query` | 5.153 s | 1.623 s | -3.530 s |
| `pkg/services/store` | 5.259 s | 0.980 s | -4.279 s |
| `pkg/storage/unified/testing` | 135.394 s | 68.492 s | -66.902 s |
| `pkg/tests/apis` | 8.511 s | 4.368 s | -4.143 s |
| `pkg/tests/apis/dashboard` | 36.629 s | 34.540 s | -2.089 s |
| `pkg/tests/apis/provisioning/connection` | 36.649 s | 32.783 s | -3.866 s |
| `pkg/tests/apis/provisioning/nats/relist` | 19.694 s | 20.958 s | *+1.264 s* |
| `pkg/extensions/analytics/datasources` | 8.375 s | 8.243 s | -0.132 s |
| `pkg/extensions/apiserver/tests/iam` | 134.553 s | 121.362 s | -13.191 s |
| `pkg/extensions/recordedqueries/repo` | 4.928 s | 1.064 s | -3.864 s |
| `pkg/registry/apis/provisioning/controller` | 0.395 s | 0.315 s | -0.080 s |
| `pkg/services/apikey/apikeyimpl` | 3.418 s | 1.046 s | -2.372 s |
| `pkg/services/ngalert/models` | 0.263 s | 0.260 s | -0.003 s |
| `pkg/services/queryhistory` | 10.382 s | 1.385 s | -8.997 s |
| `pkg/services/tag/tagimpl` | 2.937 s | 0.928 s | -2.009 s |
| `pkg/tests/api/admin/encryption` | 11.028 s | 51.399 s | *+40.371 s* |
| `pkg/tests/apis/alerting/notifications/config` | 18.439 s | 12.451 s | -5.988 s |
| `pkg/tests/apis/dashboard/integration` | 126.918 s | 119.261 s | -7.657 s |
| `pkg/tests/apis/provisioning/folderapiversion` | 8.324 s | 4.018 s | -4.306 s |
| `pkg/tests/apis/provisioning/orgs` | 9.807 s | 5.452 s | -4.355 s |
| `pkg/extensions/analytics/datasources/database` | 18.672 s | 10.486 s | -8.186 s |
| `pkg/extensions/apiserver/tests/mt/annotations` | 0.176 s | 0.325 s | *+0.149 s* |
| `pkg/extensions/saml` | 0.171 s | 0.621 s | *+0.450 s* |
| `pkg/registry/apis/secret` | 0.647 s | 0.516 s | -0.131 s |
| `pkg/services/auth/authimpl` | 4.598 s | 1.426 s | -3.172 s |
| `pkg/services/ngalert/notifier` | 2.924 s | 1.946 s | -0.978 s |
| `pkg/services/quota/quotaimpl` | 4.374 s | 3.537 s | -0.837 s |
| `pkg/services/team/teamimpl` | 3.021 s | 1.364 s | -1.657 s |
| `pkg/tests/api/alerting` | 193.654 s | 175.499 s | -18.155 s |
| `pkg/tests/apis/alerting/notifications/inhibitionrule` | 13.076 s | 9.111 s | -3.965 s |
| `pkg/tests/apis/datasource` | 22.771 s | 15.883 s | -6.888 s |
| `pkg/tests/apis/provisioning/foldermetadata` | 131.703 s | 124.530 s | -7.173 s |
| `pkg/tests/apis/provisioning/quota` | 50.107 s | 40.223 s | -9.884 s |
| `pkg/extensions/analytics/summaries/database` | 8.655 s | 6.645 s | -2.010 s |
| `pkg/extensions/apiserver/tests/mt/datasource` | 0.562 s | 1.166 s | *+0.604 s* |
| `pkg/extensions/settings/settingsprovider` | 2.514 s | 0.815 s | -1.699 s |
| `pkg/registry/apis/secret/encryption/manager` | 0.987 s | 0.559 s | -0.428 s |
| `pkg/services/auth/jwt` | 4.761 s | 0.898 s | -3.863 s |
| `pkg/services/ngalert/provisioning` | 3.762 s | 1.429 s | -2.333 s |
| `pkg/services/secrets/kvstore` | 2.834 s | 0.916 s | -1.918 s |
| `pkg/services/temp_user/tempuserimpl` | 3.251 s | 0.725 s | -2.526 s |
| `pkg/tests/api/annotations` | 6.250 s | 3.635 s | -2.615 s |
| `pkg/tests/apis/alerting/notifications/integrationtypeschema` | 7.892 s | 5.036 s | -2.856 s |
| `pkg/tests/apis/features` | 5.850 s | 3.434 s | -2.416 s |
| `pkg/tests/apis/provisioning/foldermetadata/full` | 27.506 s | 26.859 s | -0.647 s |
| `pkg/tests/apis/provisioning/quota/foldermetadata` | 29.546 s | 28.960 s | -0.586 s |
| `pkg/extensions/apiserver/plugins` | 0.086 s | 0.112 s | *+0.026 s* |
| `pkg/extensions/apiserver/tests/querycaching` | 31.132 s | 22.812 s | -8.320 s |
| `pkg/extensions/storage/unified/kv` | 13.294 s | 8.280 s | -5.014 s |
| `pkg/registry/apis/secret/inline` | 2.262 s | 0.502 s | -1.760 s |
| `pkg/services/authz/zanzana/server` | 35.667 s | 19.072 s | -16.595 s |
| `pkg/services/ngalert/remote` | 4.257 s | 1.889 s | -2.368 s |
| `pkg/services/secrets/kvstore/migrations` | 3.985 s | 1.327 s | -2.658 s |
| `pkg/services/user/userimpl` | 6.346 s | 1.606 s | -4.740 s |
| `pkg/tests/api/azuremonitor` | 0.143 s | 0.184 s | *+0.041 s* |
| `pkg/tests/apis/alerting/notifications/receivers` | 50.320 s | 46.493 s | -3.827 s |
| `pkg/tests/apis/folder` | 60.377 s | 48.418 s | -11.959 s |
| `pkg/tests/apis/provisioning/foldermetadata/incremental` | 220.948 s | 219.180 s | -1.768 s |
| `pkg/tests/apis/provisioning/repository` | 61.539 s | 56.380 s | -5.159 s |
| `pkg/extensions/apiserver/registry/iam/externalgroupmapping` | 12.718 s | 8.638 s | -4.080 s |
| `pkg/extensions/apiserver/tests/reporting` | 45.182 s | 34.008 s | -11.174 s |
| `pkg/extensions/teamgroupsync/database` | 9.041 s | 3.074 s | -5.967 s |
| `pkg/registry/apps/annotation` | 0.376 s | 0.535 s | *+0.159 s* |
| `pkg/services/dashboards/service` | 4.683 s | 1.315 s | -3.368 s |
| `pkg/services/ngalert/sender` | 1.536 s | 1.739 s | *+0.203 s* |
| `pkg/services/secrets/manager` | 8.392 s | 2.535 s | -5.857 s |
| `pkg/storage/secret/metadata` | 1.984 s | 0.906 s | -1.078 s |
| `pkg/tests/api/correlations` | 14.695 s | 10.535 s | -4.160 s |
| `pkg/tests/apis/alerting/notifications/routingtree` | 43.281 s | 33.025 s | -10.256 s |
| `pkg/tests/apis/iam` | 12.019 s | 4.031 s | -7.988 s |
| `pkg/tests/apis/provisioning/folderscope` | 6.901 s | 4.236 s | -2.665 s |
| `pkg/tests/apis/provisioning/resourcekinds` | 17.189 s | 15.623 s | -1.566 s |
| `pkg/extensions/apiserver/registry/iam/globalrole/legacy` | 3.065 s | 1.241 s | -1.824 s |
| `pkg/extensions/apiserver/tests/scim` | 20.863 s | 18.410 s | -2.453 s |
| `pkg/extensions/teamgroupsync/synchronizer` | 4.110 s | 1.665 s | -2.445 s |
| `pkg/server` | 0.332 s | 0.206 s | -0.126 s |
| `pkg/services/dashboardsnapshots/database` | 2.963 s | 1.505 s | -1.458 s |
| `pkg/services/ngalert/state` | 3.438 s | 1.922 s | -1.516 s |
| `pkg/services/serviceaccounts/database` | 5.713 s | 1.973 s | -3.740 s |
| `pkg/storage/unified/apistore` | 5.467 s | 3.870 s | -1.597 s |
| `pkg/tests/api/dashboards` | 21.153 s | 15.505 s | -5.648 s |
| `pkg/tests/apis/alerting/notifications/templategroup` | 25.734 s | 19.534 s | -6.200 s |
| `pkg/tests/apis/iam/resourcepermission` | 13.481 s | 9.318 s | -4.163 s |
| `pkg/tests/apis/provisioning/git` | 120.890 s | 107.237 s | -13.653 s |
| `pkg/tests/apis/provisioning/v1beta1` | 18.304 s | 12.839 s | -5.465 s |
| `pkg/extensions/apiserver/registry/iam/role/legacy` | 3.009 s | 1.447 s | -1.562 s |
| `pkg/extensions/apiserver/tests/scopes` | 16.426 s | 12.097 s | -4.329 s |
| `pkg/infra/filestorage` | 0.252 s | 0.145 s | -0.107 s |
| `pkg/services/accesscontrol` | 5.944 s | 1.205 s | -4.739 s |
| `pkg/services/dashboardsnapshots/service` | 3.065 s | 1.066 s | -1.999 s |
| `pkg/services/ngalert/store` | 12.757 s | 2.098 s | -10.659 s |
| `pkg/services/serviceaccounts/manager` | 2.908 s | 1.056 s | -1.852 s |
| `pkg/storage/unified/federated` | 2.890 s | 0.936 s | -1.954 s |
| `pkg/tests/api/datasources` | 15.490 s | 10.003 s | -5.487 s |
| `pkg/tests/apis/alerting/notifications/timeinterval` | 28.384 s | 18.147 s | -10.237 s |
| `pkg/tests/apis/iam/serviceaccount` | 16.072 s | 10.337 s | -5.735 s |
| `pkg/tests/apis/provisioning/git/incrementaldiffthreshold` | 41.607 s | 39.309 s | -2.298 s |
| `pkg/tests/apis/shorturl` | 14.979 s | 9.859 s | -5.120 s |
| `pkg/extensions/apiserver/registry/iam/rolebinding/legacy` | 17.651 s | 7.932 s | -9.719 s |
| `pkg/extensions/apiserver/tests/secret` | 15.198 s | 10.806 s | -4.392 s |
| `pkg/infra/kvstore` | 4.147 s | 1.226 s | -2.921 s |
| `pkg/services/accesscontrol/acimpl` | 7.061 s | 1.555 s | -5.506 s |
| `pkg/services/datasources/service` | 10.596 s | 2.962 s | -7.634 s |
| `pkg/services/oauthtoken` | 9.865 s | 3.470 s | -6.395 s |
| `pkg/services/shorturls/shorturlimpl` | 3.794 s | 1.220 s | -2.574 s |
| `pkg/storage/unified/migrations` | 56.670 s | 42.726 s | -13.944 s |
| `pkg/tests/api/folders` | 21.364 s | 17.522 s | -3.842 s |
| `pkg/tests/apis/alerting/rules/alertrule` | 34.215 s | 30.902 s | -3.313 s |
| `pkg/tests/apis/iam/team` | 71.644 s | 63.615 s | -8.029 s |
| `pkg/tests/apis/provisioning/git/sourcepath_guard` | 30.507 s | 29.863 s | -0.644 s |
| `pkg/tests/web` | 14.455 s | 12.388 s | -2.067 s |
| `pkg/extensions/apiserver/registry/provisioning/bitbucket` | 7.659 s | 4.299 s | -3.360 s |
| `pkg/extensions/auth` | 3.200 s | 0.918 s | -2.282 s |
| `pkg/infra/nats` | 2.103 s | 2.055 s | -0.048 s |
| `pkg/services/accesscontrol/database` | 6.999 s | 1.156 s | -5.843 s |
| `pkg/services/folder/folderimpl` | 2.405 s | 0.896 s | -1.509 s |
| `pkg/services/org/orgimpl` | 3.892 s | 0.867 s | -3.025 s |
| `pkg/services/signingkeys/signingkeystore` | 2.491 s | 0.737 s | -1.754 s |
| `pkg/storage/unified/resource` | 35.886 s | 27.899 s | -7.987 s |
| `pkg/tests/api/graphite` | 5.534 s | 2.685 s | -2.849 s |
| `pkg/tests/apis/alerting/rules/compat` | 21.672 s | 20.241 s | -1.431 s |
| `pkg/tests/apis/iam/teambinding` | 0.130 s | 0.201 s | *+0.071 s* |
| `pkg/tests/apis/provisioning/git/webhook` | 25.093 s | 25.350 s | *+0.257 s* |
| `pkg/tsdb/grafana-postgresql-datasource` | 0.009 s | 0.011 s | *+0.002 s* |
