### PR TITLE
Scopes: Fix page-container padding when scopes drawer hidden in kiosk/render

### DIFF
--- a/public/app/core/components/AppChrome/AppChrome.test.tsx
+++ b/public/app/core/components/AppChrome/AppChrome.test.tsx
@@ -4,11 +4,12 @@ import { type ReactNode } from 'react';
 import { getGrafanaContextMock } from 'test/mocks/getGrafanaContextMock';
 import { render, screen, waitFor, act, getWrapper } from 'test/test-utils';
 
-import { config, setBackendSrv } from '@grafana/runtime';
+import { config, setBackendSrv, useScopes } from '@grafana/runtime';
 import { getCustomSearchHandler } from '@grafana/test-utils/handlers';
 import server, { setupMockServer } from '@grafana/test-utils/server';
 import { useMediaQueryMinWidth } from 'app/core/hooks/useMediaQueryMinWidth';
 import { HOME_NAV_ID } from 'app/core/reducers/navModel';
+import { KioskMode } from 'app/types/dashboard';
 
 import { backendSrv } from '../../services/backend_srv';
 import { Page } from '../Page/Page';
@@ -22,6 +23,7 @@ import {
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
   usePluginLinks: jest.fn().mockReturnValue({ links: [] }),
+  useScopes: jest.fn(),
 }));
 
 jest.mock('app/core/hooks/useMediaQueryMinWidth');
@@ -38,6 +40,7 @@ jest.mock('./ExtensionSidebar/ExtensionSidebarProvider', () => ({
 
 const mockUseMediaQueryMinWidth = jest.mocked(useMediaQueryMinWidth);
 const mockUseExtensionSidebarContext = jest.mocked(useExtensionSidebarContext);
+const mockUseScopes = jest.mocked(useScopes);
 
 const closedSidebarContext: ExtensionSidebarContextType = {
   isOpen: false,
@@ -98,6 +101,7 @@ describe('AppChrome', () => {
     server.use(getCustomSearchHandler([]));
     mockUseMediaQueryMinWidth.mockReturnValue(false);
     mockUseExtensionSidebarContext.mockReturnValue(closedSidebarContext);
+    mockUseScopes.mockReturnValue(undefined);
   });
 
   afterEach(() => {
@@ -143,6 +147,40 @@ describe('AppChrome', () => {
     });
     waitFor(() => {
       expect(screen.queryByRole('link', { name: 'Skip to main content' })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('scopes dashboard drawer padding', () => {
+    beforeEach(() => {
+      mockUseScopes.mockReturnValue({
+        state: { enabled: true, drawerOpened: true, readOnly: false },
+      } as ReturnType<typeof useScopes>);
+    });
+
+    it('should apply left padding when scopes drawer is open', async () => {
+      setup(<Page navId="child1">Children</Page>);
+
+      const mainContent = document.getElementById('pageContent')!;
+      await waitFor(() => {
+        expect(parseFloat(getComputedStyle(mainContent).paddingLeft)).toBeGreaterThan(0);
+      });
+    });
+
+    it('should not apply left padding in kiosk mode when scopes drawer is open', async () => {
+      const { context } = setup(<Page navId="child1">Children</Page>);
+
+      const mainContent = document.getElementById('pageContent')!;
+      await waitFor(() => {
+        expect(parseFloat(getComputedStyle(mainContent).paddingLeft)).toBeGreaterThan(0);
+      });
+
+      act(() => {
+        context.chrome.update({ kioskMode: KioskMode.Full });
+      });
+
+      await waitFor(() => {
+        expect(parseFloat(getComputedStyle(mainContent).paddingLeft) || 0).toBe(0);
+      });
     });
   });
 

--- a/public/app/core/components/AppChrome/AppChrome.tsx
+++ b/public/app/core/components/AppChrome/AppChrome.tsx
@@ -48,7 +48,7 @@ export function AppChrome({ children }: Props) {
 
   const menuDockedAndOpen = !state.chromeless && state.megaMenuDocked && state.megaMenuOpen;
   const isScopesDashboardsOpen = Boolean(
-    scopes?.state.enabled && scopes?.state.drawerOpened && !scopes?.state.readOnly
+    !state.chromeless && scopes?.state.enabled && scopes?.state.drawerOpened && !scopes?.state.readOnly
   );
 
   const headerLevels = useChromeHeaderLevels();


### PR DESCRIPTION
When kiosk mode or other chromeless routes hide the scopes dashboard drawer, stop applying the left padding reserved for it so the dashboard uses full width.

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Remove the page padding when in chromeless mode and scope navigation drawer is visible.

**Why do we need this feature?**

We don't want empty space.

**Who is this feature for?**

Chromeless scopes users

**Which issue(s) does this PR fix?**:


Fixes https://github.com/grafana/hyperion-planning/issues/673

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
