### PR TITLE
Advisor: Remove grafanaAdvisor feature toggle usage in the frontend

### DIFF
--- a/public/app/features/connections/components/AdvisorRedirectNotice/AdvisorRedirectNotice.test.tsx
+++ b/public/app/features/connections/components/AdvisorRedirectNotice/AdvisorRedirectNotice.test.tsx
@@ -1,12 +1,11 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import { config, useAppPluginInstalled } from '@grafana/runtime';
+import { useAppPluginInstalled } from '@grafana/runtime';
 import { contextSrv } from 'app/core/services/context_srv';
 
 import { AdvisorRedirectNotice } from './AdvisorRedirectNotice';
 
-const originalFeatureToggleValue = config.featureToggles.grafanaAdvisor;
 jest.mock('@grafana/runtime/internal', () => ({
   UserStorage: jest.fn().mockImplementation(() => ({
     getItem: jest.fn().mockResolvedValue('true'),
@@ -23,24 +22,16 @@ const useAppPluginInstalledMock = jest.mocked(useAppPluginInstalled);
 
 describe('AdvisorRedirectNotice', () => {
   beforeEach(() => {
-    config.featureToggles.grafanaAdvisor = true;
     contextSrv.isGrafanaAdmin = true;
     useAppPluginInstalledMock.mockReturnValue({ loading: false, value: true, error: undefined });
   });
 
   afterEach(() => {
     jest.clearAllMocks();
-    config.featureToggles.grafanaAdvisor = originalFeatureToggleValue;
   });
 
   it('should not render when user is not admin', async () => {
     contextSrv.isGrafanaAdmin = false;
-    render(<AdvisorRedirectNotice />);
-    expect(screen.queryByRole('status')).not.toBeInTheDocument();
-  });
-
-  it('should not render when feature flag is disabled', async () => {
-    config.featureToggles.grafanaAdvisor = false;
     render(<AdvisorRedirectNotice />);
     expect(screen.queryByRole('status')).not.toBeInTheDocument();
   });

--- a/public/app/features/connections/components/AdvisorRedirectNotice/AdvisorRedirectNotice.tsx
+++ b/public/app/features/connections/components/AdvisorRedirectNotice/AdvisorRedirectNotice.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { config, useAppPluginInstalled } from '@grafana/runtime';
+import { useAppPluginInstalled } from '@grafana/runtime';
 import { UserStorage } from '@grafana/runtime/internal';
 import { Alert, LinkButton, useStyles2 } from '@grafana/ui';
 import { contextSrv } from 'app/core/services/context_srv';
@@ -29,7 +29,7 @@ export function AdvisorRedirectNotice() {
   const [showNotice, setShowNotice] = useState(false);
   const { value: isAdvisorInstalled } = useAppPluginInstalled('grafana-advisor-app');
 
-  const canUseAdvisor = hasAdminRights && config.featureToggles.grafanaAdvisor && Boolean(isAdvisorInstalled);
+  const canUseAdvisor = hasAdminRights && Boolean(isAdvisorInstalled);
 
   useEffect(() => {
     if (!canUseAdvisor) {

--- a/public/app/features/connections/hooks/useDatasourceAdvisorChecks.test.tsx
+++ b/public/app/features/connections/hooks/useDatasourceAdvisorChecks.test.tsx
@@ -164,7 +164,6 @@ describe('useLatestDatasourceCheck', () => {
     jest.clearAllMocks();
     config.featureToggles = {
       ...originalFeatureToggles,
-      grafanaAdvisor: true,
       advisorDatasourceIntegration: true,
     };
     useGetCheckTypeMock.mockReturnValue({ data: undefined, isLoading: false });
@@ -174,8 +173,8 @@ describe('useLatestDatasourceCheck', () => {
     config.featureToggles = originalFeatureToggles;
   });
 
-  it('returns isLoading false when grafanaAdvisor feature toggle is off', () => {
-    config.featureToggles = { ...originalFeatureToggles, grafanaAdvisor: false };
+  it('returns isLoading false when advisor is disabled', () => {
+    config.featureToggles = { ...originalFeatureToggles, advisorDatasourceIntegration: false };
     mockPluginFunctions({});
 
     const { result } = renderHook(() => useLatestDatasourceCheck(), { wrapper });
@@ -241,7 +240,6 @@ describe('useDatasourceFailureByUID', () => {
     jest.clearAllMocks();
     config.featureToggles = {
       ...originalFeatureToggles,
-      grafanaAdvisor: true,
       advisorDatasourceIntegration: true,
     };
     useGetCheckTypeMock.mockReturnValue({ data: undefined, isLoading: false });
@@ -324,7 +322,7 @@ describe('useDatasourceFailureByUID', () => {
   });
 
   it('returns empty map when advisor is disabled', () => {
-    config.featureToggles = { ...originalFeatureToggles, grafanaAdvisor: false };
+    config.featureToggles = { ...originalFeatureToggles, advisorDatasourceIntegration: false };
     mockPluginFunctions({});
 
     const { result } = renderHook(() => useDatasourceFailureByUID(), { wrapper });
@@ -387,7 +385,6 @@ describe('useRetryDatasourceAdvisorCheck', () => {
     jest.clearAllMocks();
     config.featureToggles = {
       ...originalFeatureToggles,
-      grafanaAdvisor: true,
       advisorDatasourceIntegration: true,
     };
     useGetCheckTypeMock.mockReturnValue({ data: undefined, isLoading: false });
@@ -412,7 +409,7 @@ describe('useRetryDatasourceAdvisorCheck', () => {
   });
 
   it('does not call retryCheck when advisor is disabled', async () => {
-    config.featureToggles = { ...originalFeatureToggles, grafanaAdvisor: false };
+    config.featureToggles = { ...originalFeatureToggles, advisorDatasourceIntegration: false };
 
     const retryCheckFn = jest.fn();
     const check = makeCheck({ name: 'check-sk5fn', failures: emptyReport });
@@ -448,7 +445,6 @@ describe('useCreateDatasourceAdvisorChecks', () => {
     jest.clearAllMocks();
     config.featureToggles = {
       ...originalFeatureToggles,
-      grafanaAdvisor: true,
       advisorDatasourceIntegration: true,
     };
     useGetCheckTypeMock.mockReturnValue({ data: undefined, isLoading: false });
@@ -471,7 +467,7 @@ describe('useCreateDatasourceAdvisorChecks', () => {
   });
 
   it('does not call createChecks when advisor is disabled', () => {
-    config.featureToggles = { ...originalFeatureToggles, grafanaAdvisor: false };
+    config.featureToggles = { ...originalFeatureToggles, advisorDatasourceIntegration: false };
     const createChecksFn = jest.fn();
     mockPluginFunctions({ createChecksFn });
 

--- a/public/app/features/connections/hooks/useDatasourceAdvisorChecks.tsx
+++ b/public/app/features/connections/hooks/useDatasourceAdvisorChecks.tsx
@@ -37,7 +37,7 @@ type CreateChecksFn = () => {
 };
 
 export function isAdvisorEnabled(): boolean {
-  return Boolean(config.featureToggles.grafanaAdvisor && config.featureToggles.advisorDatasourceIntegration);
+  return Boolean(config.featureToggles.advisorDatasourceIntegration);
 }
 
 interface AdvisorCheckContextValue {


### PR DESCRIPTION
## What this does

This PR removes the **frontend usage** of the `grafanaAdvisor` toggle. 

Ref: https://github.com/grafana/grafana-catalog-team/issues/1060