### PR TITLE
Table Panel : Fix nested row background color inheritance

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableNG/legacy/LegacyTableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/legacy/LegacyTableNG.tsx
@@ -726,7 +726,7 @@ export function LegacyTableNG(props: TableNGProps) {
 
         // this fires first
         const renderCellRoot = (key: Key, props: CellRendererProps<TableRow, TableSummaryRow>): ReactNode => {
-          const rowIdx = props.row.__index;
+          const rowIdx = props.row.__parentIndex ?? props.row.__index;
 
           // meh, this should be cached by the renderRow() call?
           if (rowIdx !== lastRowIdx) {

--- a/packages/grafana-ui/src/components/Table/TableNG/refactored/RefactoredTableNG.test.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/refactored/RefactoredTableNG.test.tsx
@@ -145,6 +145,67 @@ const createNestedDataFrame = (meta?: DataFrame['meta']): DataFrame => {
   );
 };
 
+const createNestedDataFrameWithApplyToRow = (): DataFrame => {
+  const nestedFrame0 = withFieldOverrides(
+    toDataFrame({
+      name: 'NestedData0',
+      fields: [{ name: 'Detail', type: FieldType.string, values: ['detail-A'], config: { custom: {} } }],
+    })
+  );
+  const nestedFrame1 = withFieldOverrides(
+    toDataFrame({
+      name: 'NestedData1',
+      fields: [{ name: 'Detail', type: FieldType.string, values: ['detail-B'], config: { custom: {} } }],
+    })
+  );
+
+  const frame = withFieldOverrides(
+    toDataFrame({
+      name: 'TestData',
+      length: 2,
+      fields: [
+        { name: 'Parent', type: FieldType.string, values: ['Parent-A', 'Parent-B'], config: { custom: {} } },
+        {
+          name: 'MatchTotal',
+          type: FieldType.number,
+          values: [16, 4],
+          config: { custom: {} },
+          display: displayNumber,
+          ...stdField,
+        },
+        { name: '__depth', type: FieldType.number, values: [0, 0], config: { custom: { hideFrom: { viz: true } } } },
+        { name: '__index', type: FieldType.number, values: [0, 1], config: { custom: { hideFrom: { viz: true } } } },
+        {
+          name: '__nestedFrames',
+          type: FieldType.nestedFrames,
+          values: [[nestedFrame0], [nestedFrame1]],
+          config: { custom: {} },
+        },
+      ],
+    })
+  );
+
+  const matchTotalField = frame.fields.find((f) => f.name === 'MatchTotal')!;
+  matchTotalField.config.custom = {
+    ...matchTotalField.config.custom,
+    cellOptions: {
+      type: TableCellDisplayMode.ColorBackground,
+      applyToRow: true,
+      mode: TableCellBackgroundDisplayMode.Basic,
+    },
+  };
+  const originalDisplay = matchTotalField.display!;
+  matchTotalField.display = (value: unknown) => {
+    const displayValue = originalDisplay(value);
+    return {
+      ...displayValue,
+      color: Number(value) === 16 ? '#ff0000' : '#0000ff',
+    };
+  };
+
+  return frame;
+};
+
 /**
  * A frame carrying a __nestedFrames field but with zero rows — the shape produced when a panel
  * returns no data yet still runs a Group to nested tables transform. There is no first nested
@@ -562,6 +623,25 @@ describe.each(IMPLEMENTATIONS)('TableNG (%s)', (_impl, TableNG) => {
         const expandedRow = container.querySelector('[aria-expanded="true"]');
         expect(expandedRow).toBeInTheDocument();
       }
+    });
+
+    it('applies parent apply-to-row background color to nested rows using __parentIndex', async () => {
+      window.HTMLElement.prototype.scrollIntoView = jest.fn();
+
+      const { container } = render(
+        <TableNG enableVirtualization={false} data={createNestedDataFrameWithApplyToRow()} width={800} height={600} />
+      );
+
+      const expandButtons = container.querySelectorAll('[aria-label="Expand row"]');
+      expect(expandButtons.length).toBe(2);
+
+      await user.click(expandButtons[1]);
+
+      expect(screen.getByText('detail-B')).toBeInTheDocument();
+
+      const detailCell = screen.getByText('detail-B').closest('[role="gridcell"]');
+      expect(detailCell).toBeInTheDocument();
+      expect(window.getComputedStyle(detailCell!).backgroundColor).toBe('rgb(0, 0, 255)');
     });
 
     it('auto-expands all rows when expandAllRows is set in frame meta', () => {

--- a/packages/grafana-ui/src/components/Table/TableNG/refactored/render-hooks.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/refactored/render-hooks.tsx
@@ -326,7 +326,9 @@ function buildColumnsFromFields(
       key: Key,
       props: CellRendererProps<TableRow, TableSummaryRow>
     ): ReactNode => {
-      const rowIdx = props.row.__index;
+      // Nested rows carry __parentIndex (set when compiling nested frame records). Use it
+      // for apply-to-row background so nested rows inherit the expanded parent's color.
+      const rowIdx = props.row.__parentIndex ?? props.row.__index;
 
       // meh, this should be cached by the renderRow() call?
       if (rowIdx !== lastRowIdx) {


### PR DESCRIPTION
**What is this feature?**

This PR fixes a bug in the Table panel where nested rows show incorrect row background colors when a field override uses **Colored background** with **Apply to entire row** enabled.

Nested rows now use the expanded parent row's background color instead of resolving colors from unrelated parent row indices in the top-level frame.

**Why do we need this feature?**

When a table uses the **Group to nested tables** transformation and a field override with apply-to-row coloring, expanding different parent rows renders nested child rows with the wrong background color.

For example, expanding parent row 2 may still show nested row colors that match parent rows 0 or 1. This makes conditional row coloring misleading in nested tables.

The issue happens because `applyToRowBgFn` is called with the nested row's local `__index` (0, 1, 2, … within the sub-table) instead of the parent row's `__parentIndex`. Nested frame records already carry `__parentIndex` when compiled in `utils.ts`; this PR fixes the consumer side in both TableNG rendering paths.

**Who is this feature for?**

Dashboard authors who use nested tables with field overrides and **Apply to entire row** coloring — for example, status or threshold coloring on parent rows that should visually extend to nested detail rows when a parent is expanded.

**Which issue(s) does this PR fix?**:

Fixes [#128467](https://github.com/grafana/grafana/issues/128467)

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective — expanding different parent rows shows nested rows with that parent's apply-to-row background color.
- [x] If this is a pre-GA feature, it is behind a feature toggle — N/A; this is a bug fix. Both **legacy** (`LegacyTableNG.tsx`) and **refactored** (`render-hooks.tsx`) TableNG paths are updated because routing depends on the `table.refactorNested` feature toggle.
- [x] The docs are updated — N/A; no user-facing configuration change.

## Changes

| File | Change |
|------|--------|
| `packages/grafana-ui/src/components/Table/TableNG/legacy/LegacyTableNG.tsx` | Use `props.row.__parentIndex ?? props.row.__index` when resolving row index for `applyToRowBgFn` in `renderCellRoot` |
| `packages/grafana-ui/src/components/Table/TableNG/refactored/render-hooks.tsx` | Same fix for the refactored nested-table rendering path |
| `packages/grafana-ui/src/components/Table/TableNG/refactored/RefactoredTableNG.test.tsx` | Regression test: expand the second parent row and assert nested cells get the correct parent color |

## Root cause

`getApplyToRowBgFn()` builds a closure over the parent frame's field `values[]` and returns a function that looks up background color by parent row index:

```ts
return (rowIndex: number) =>
  getCellColorInlineStyles(cellOptions, fieldDisplay(field.values[rowIndex]), true);
```

Nested rows are compiled with:

- `__index` — index within the nested sub-frame (0, 1, 2, …)
- `__parentIndex` — index of the expanded parent row in the top-level table

When rendering nested cells, `renderCellRoot` was calling `applyToRowBgFn(props.row.__index)`. For nested rows, `__index` is the nested local index, not the parent table index. That caused nested rows to read `field.values[0]`, `field.values[1]`, etc. from the parent frame instead of the color for the actually expanded parent (`__parentIndex`).

## Fix

```ts
const rowIdx = props.row.__parentIndex ?? props.row.__index;
```

- Top-level rows: `__parentIndex` is undefined → falls back to `__index` (unchanged)
- Nested rows: `__parentIndex` is set during nested frame record compilation → correct parent color is used

## Test plan

### Automated

```bash
cd packages/grafana-ui
yarn jest RefactoredTableNG.test.tsx --testNamePattern="applies parent apply-to-row background color"
```

The new test:

1. Creates a nested table with two parent rows and different apply-to-row colors (red for value 16, blue for value 4)
2. Expands the **second** parent row
3. Asserts the nested `detail-B` cell has `background-color: rgb(0, 0, 255)` (blue), not red from parent index 0

### Manual

1. Import a dashboard with a table using **Group to nested tables**
2. Add a field override with **Colored background** + **Apply to entire row**
3. Expand different parent rows one at a time
4. Confirm nested rows match the expanded parent's row color in every case

## Screenshots

**Before**

<img width="605" height="340" alt="grafana oss screenshot" src="https://github.com/user-attachments/assets/7787ddca-f0a7-4cc9-8ffd-6079defcf715" />

**After**

<img width="572" height="338" alt="image" src="https://github.com/user-attachments/assets/0e60361c-a32d-4e94-a45a-b2a3da38c770" />
