### PR TITLE
Dashboard Migration: Fix v19 panel link URLs when base URL already has a query string

### DIFF
--- a/apps/dashboard/pkg/migration/schemaversion/v19.go
+++ b/apps/dashboard/pkg/migration/schemaversion/v19.go
@@ -114,36 +114,41 @@ func buildPanelLinkURL(link map[string]interface{}) string {
 		url = "/"
 	}
 
-	// Add query parameters
-	params := []string{}
-
+	// Append query parameters one at a time, mirroring the frontend's
+	// urlUtil.appendQueryToUrl: the separator depends on whether the URL already
+	// carries a query string, so a base URL like "d/abc?orgId=1" gets "&", not "?".
 	if GetBoolValue(link, "keepTime") {
-		params = append(params, "$__url_time_range")
+		url = appendQueryToURL(url, "$__url_time_range")
 	}
 
 	if GetBoolValue(link, "includeVars") {
-		params = append(params, "$__all_variables")
+		url = appendQueryToURL(url, "$__all_variables")
 	}
 
 	if customParams := GetStringValue(link, "params"); customParams != "" {
-		params = append(params, customParams)
-	}
-
-	// Append parameters to URL
-	paramUsed := false
-	for _, param := range params {
-		if param != "" {
-			if paramUsed {
-				url += "&"
-			} else {
-				url += "?"
-				paramUsed = true
-			}
-			url += param
-		}
+		url = appendQueryToURL(url, customParams)
 	}
 
 	return url
+}
+
+// appendQueryToURL appends a query fragment to url, choosing the separator the
+// same way the frontend's urlUtil.appendQueryToUrl does: "&" if url already has
+// a query string, "?" if it does not, and nothing if it ends in a bare "?".
+func appendQueryToURL(url, stringToAppend string) string {
+	if stringToAppend == "" {
+		return url
+	}
+
+	if pos := strings.Index(url, "?"); pos != -1 {
+		if len(url)-pos > 1 {
+			url += "&"
+		}
+	} else {
+		url += "?"
+	}
+
+	return url + stringToAppend
 }
 
 var reNonWordOrSpace = regexp.MustCompile(`[^a-z0-9_ ]+`)

--- a/apps/dashboard/pkg/migration/schemaversion/v19_test.go
+++ b/apps/dashboard/pkg/migration/schemaversion/v19_test.go
@@ -248,6 +248,40 @@ func TestV19(t *testing.T) {
 			},
 		},
 		{
+			name: "panel link URL that already has a query string appends with & not ?",
+			input: map[string]interface{}{
+				"title":         "V19 Existing Query String Links Migration Test Dashboard",
+				"schemaVersion": 18,
+				"panels": []interface{}{
+					map[string]interface{}{
+						"id": 1,
+						"links": []interface{}{
+							map[string]interface{}{
+								"url":      "http://example.com/d/abc?orgId=1",
+								"keepTime": true,
+								"title":    "Existing Query Link",
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"title":         "V19 Existing Query String Links Migration Test Dashboard",
+				"schemaVersion": 19,
+				"panels": []interface{}{
+					map[string]interface{}{
+						"id": 1,
+						"links": []interface{}{
+							map[string]interface{}{
+								"url":   "http://example.com/d/abc?orgId=1&$__url_time_range",
+								"title": "Existing Query Link",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "panel with no links remains unchanged",
 			input: map[string]interface{}{
 				"title":         "V19 No Links Migration Test Dashboard",


### PR DESCRIPTION
## What this PR does

Fixes malformed panel link URLs produced by the v19 dashboard schema migration when a legacy link's `url` already contains a query string.

### Root cause

`buildPanelLinkURL` collected the query params (`keepTime`, `includeVars`, `params`) and appended the **first** one with `?` unconditionally, ignoring any `?` already present in the base URL.

- Input: `{ "url": "http://example.com/d/abc?orgId=1", "keepTime": true }`
- Before: `http://example.com/d/abc?orgId=1?$__url_time_range` (malformed — two `?`)
- After: `http://example.com/d/abc?orgId=1&$__url_time_range`

### Fix

Append params one at a time through `appendQueryToURL`, a faithful port of the frontend's `urlUtil.appendQueryToUrl` (`packages/grafana-data/src/utils/url.ts`): it uses `&` when the URL already has a query string, `?` when it does not, and nothing after a bare trailing `?`.

### Testing

- Added a regression test covering a base URL that already has a query string.
- All existing `TestV19` cases and the full `apps/dashboard/pkg/migration/...` suite pass; `go vet` is clean.
