### PR TITLE
chore: bump TRIAGE_REF to community-triage main (digest fixes)

### DIFF
--- a/.github/workflows/external-fr-notify.yml
+++ b/.github/workflows/external-fr-notify.yml
@@ -18,7 +18,7 @@ concurrency:
 env:
   # community-triage logic version this repo is pinned to. Bump deliberately;
   # re-resolve with: git ls-remote https://github.com/grafana/community-triage main
-  TRIAGE_REF: 34b9d3b337897c6a45232d6f4601aec6593b7c1d # trufflehog:ignore
+  TRIAGE_REF: 0d8ce6ae83a207e29a62affbe8204d3071b7383f # trufflehog:ignore
 
 jobs:
   notify:

--- a/.github/workflows/external-fr-weekly-digest.yml
+++ b/.github/workflows/external-fr-weekly-digest.yml
@@ -31,7 +31,7 @@ concurrency:
 env:
   # community-triage logic version this repo is pinned to. Bump deliberately;
   # re-resolve with: git ls-remote https://github.com/grafana/community-triage main
-  TRIAGE_REF: 34b9d3b337897c6a45232d6f4601aec6593b7c1d # trufflehog:ignore
+  TRIAGE_REF: 0d8ce6ae83a207e29a62affbe8204d3071b7383f # trufflehog:ignore
 
 jobs:
   digest:

--- a/.github/workflows/external-issue-notify.yml
+++ b/.github/workflows/external-issue-notify.yml
@@ -18,7 +18,7 @@ concurrency:
 env:
   # community-triage logic version this repo is pinned to. Bump deliberately;
   # re-resolve with: git ls-remote https://github.com/grafana/community-triage main
-  TRIAGE_REF: 34b9d3b337897c6a45232d6f4601aec6593b7c1d # trufflehog:ignore
+  TRIAGE_REF: 0d8ce6ae83a207e29a62affbe8204d3071b7383f # trufflehog:ignore
 
 jobs:
   notify:

--- a/.github/workflows/external-issue-weekly-digest.yml
+++ b/.github/workflows/external-issue-weekly-digest.yml
@@ -31,7 +31,7 @@ concurrency:
 env:
   # community-triage logic version this repo is pinned to. Bump deliberately;
   # re-resolve with: git ls-remote https://github.com/grafana/community-triage main
-  TRIAGE_REF: 34b9d3b337897c6a45232d6f4601aec6593b7c1d # trufflehog:ignore
+  TRIAGE_REF: 0d8ce6ae83a207e29a62affbe8204d3071b7383f # trufflehog:ignore
 
 jobs:
   digest:

--- a/.github/workflows/external-pr-notify-handler.yml
+++ b/.github/workflows/external-pr-notify-handler.yml
@@ -25,7 +25,7 @@ env:
   # community-triage logic version this repo is pinned to (main as of PR #6).
   # Bump deliberately; re-resolve with:
   #   git ls-remote https://github.com/grafana/community-triage main
-  TRIAGE_REF: 34b9d3b337897c6a45232d6f4601aec6593b7c1d # trufflehog:ignore
+  TRIAGE_REF: 0d8ce6ae83a207e29a62affbe8204d3071b7383f # trufflehog:ignore
 
 jobs:
   triage:

--- a/.github/workflows/external-pr-weekly-digest.yml
+++ b/.github/workflows/external-pr-weekly-digest.yml
@@ -31,7 +31,7 @@ permissions: {}
 env:
   # community-triage logic version this repo is pinned to. Bump deliberately;
   # re-resolve with: git ls-remote https://github.com/grafana/community-triage main
-  TRIAGE_REF: 34b9d3b337897c6a45232d6f4601aec6593b7c1d # trufflehog:ignore
+  TRIAGE_REF: 0d8ce6ae83a207e29a62affbe8204d3071b7383f # trufflehog:ignore
   STALE_THRESHOLD_DAYS: ${{ inputs.stale_days || 30 }}
 
 concurrency:


### PR DESCRIPTION
Bumps `TRIAGE_REF` to community-triage `0d8ce6a`: adds the digest **Other open** section and fixes the multi-label **View all** links (repeated `label:` qualifiers were ANDed, so multi-label teams' links returned no results). Carries the DataPro overlay already in the prior pin. Config-only, no logic here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)