### PR TITLE
Dashboard Migration: Run v8/v10 panel migrations on panels nested in legacy rows

### DIFF
--- a/apps/dashboard/pkg/migration/schemaversion/migration_utils.go
+++ b/apps/dashboard/pkg/migration/schemaversion/migration_utils.go
@@ -103,6 +103,38 @@ func IsArray(value interface{}) bool {
 	return ok
 }
 
+// collectPanelsIncludingRows returns every panel in the dashboard, looking both
+// at the top-level "panels" array and inside each legacy "rows" entry's "panels"
+// array. Migrations that run before V16 (which hoists row panels to the top
+// level) must use this so they also process panels still nested in rows.
+func collectPanelsIncludingRows(dashboard map[string]interface{}) []map[string]interface{} {
+	var result []map[string]interface{}
+
+	appendPanels := func(value interface{}) {
+		panels, ok := value.([]interface{})
+		if !ok {
+			return
+		}
+		for _, p := range panels {
+			if panel, ok := p.(map[string]interface{}); ok {
+				result = append(result, panel)
+			}
+		}
+	}
+
+	appendPanels(dashboard["panels"])
+
+	if rows, ok := dashboard["rows"].([]interface{}); ok {
+		for _, r := range rows {
+			if row, ok := r.(map[string]interface{}); ok {
+				appendPanels(row["panels"])
+			}
+		}
+	}
+
+	return result
+}
+
 // AngularPanelMigrations maps deprecated Angular panel types to their modern equivalents.
 // Used by both v0→v1 and v1→v2 conversions to ensure consistent migration behavior.
 var AngularPanelMigrations = map[string]string{

--- a/apps/dashboard/pkg/migration/schemaversion/v10.go
+++ b/apps/dashboard/pkg/migration/schemaversion/v10.go
@@ -50,48 +50,46 @@ import "context"
 func V10(_ context.Context, dashboard map[string]interface{}) error {
 	dashboard["schemaVersion"] = 10
 
-	panels, ok := dashboard["panels"].([]interface{})
-	if !ok {
-		return nil
-	}
-
-	for _, p := range panels {
-		panel, ok := p.(map[string]interface{})
-		if !ok {
-			continue
-		}
-
-		// Only process table panels
-		panelType := GetStringValue(panel, "type")
-		if panelType != "table" {
-			continue
-		}
-
-		styles, ok := panel["styles"].([]interface{})
-		if !ok {
-			continue
-		}
-
-		// Process each style in the table panel
-		for _, s := range styles {
-			style, ok := s.(map[string]interface{})
-			if !ok {
-				continue
-			}
-
-			thresholds, ok := style["thresholds"].([]interface{})
-			if !ok {
-				continue
-			}
-
-			// Only modify thresholds if they have 3 or more values
-			if len(thresholds) >= 3 {
-				// Remove the first threshold value
-				newThresholds := thresholds[1:]
-				style["thresholds"] = newThresholds
-			}
-		}
+	// This migration runs before V16 hoists row panels to the top level, so in
+	// pre-v16 dashboards the panels still live inside rows. Visit both locations
+	// to match the frontend, which applies this upgrade after the row->grid
+	// conversion.
+	for _, panel := range collectPanelsIncludingRows(dashboard) {
+		migrateTableThresholdsInPanel(panel)
 	}
 
 	return nil
+}
+
+func migrateTableThresholdsInPanel(panel map[string]interface{}) {
+	// Only process table panels
+	panelType := GetStringValue(panel, "type")
+	if panelType != "table" {
+		return
+	}
+
+	styles, ok := panel["styles"].([]interface{})
+	if !ok {
+		return
+	}
+
+	// Process each style in the table panel
+	for _, s := range styles {
+		style, ok := s.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		thresholds, ok := style["thresholds"].([]interface{})
+		if !ok {
+			continue
+		}
+
+		// Only modify thresholds if they have 3 or more values
+		if len(thresholds) >= 3 {
+			// Remove the first threshold value
+			newThresholds := thresholds[1:]
+			style["thresholds"] = newThresholds
+		}
+	}
 }

--- a/apps/dashboard/pkg/migration/schemaversion/v10_test.go
+++ b/apps/dashboard/pkg/migration/schemaversion/v10_test.go
@@ -9,6 +9,43 @@ import (
 func TestV10(t *testing.T) {
 	tests := []migrationTestCase{
 		{
+			name: "table thresholds in a panel nested inside a row are migrated",
+			input: map[string]interface{}{
+				"schemaVersion": 9,
+				"rows": []interface{}{
+					map[string]interface{}{
+						"panels": []interface{}{
+							map[string]interface{}{
+								"type": "table",
+								"styles": []interface{}{
+									map[string]interface{}{
+										"thresholds": []interface{}{"10", "20", "30"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"schemaVersion": 10,
+				"rows": []interface{}{
+					map[string]interface{}{
+						"panels": []interface{}{
+							map[string]interface{}{
+								"type": "table",
+								"styles": []interface{}{
+									map[string]interface{}{
+										"thresholds": []interface{}{"20", "30"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "table panel with thresholds having 3 or more values should have first threshold removed",
 			input: map[string]interface{}{
 				"title":         "V10 Table Thresholds Migration Test Dashboard",

--- a/apps/dashboard/pkg/migration/schemaversion/v8.go
+++ b/apps/dashboard/pkg/migration/schemaversion/v8.go
@@ -67,140 +67,138 @@ import "context"
 func V8(_ context.Context, dashboard map[string]interface{}) error {
 	dashboard["schemaVersion"] = 8
 
-	panels, ok := dashboard["panels"].([]interface{})
-	if !ok {
-		return nil
-	}
-
-	for _, p := range panels {
-		panel, ok := p.(map[string]interface{})
-		if !ok {
-			continue
-		}
-
-		targets, ok := panel["targets"].([]interface{})
-		if !ok {
-			continue
-		}
-
-		for _, t := range targets {
-			target, ok := t.(map[string]interface{})
-			if !ok {
-				continue
-			}
-
-			// Check if this target has the old InfluxDB schema
-			fields, hasFields := target["fields"]
-			_, hasTags := target["tags"]
-			groupBy, hasGroupBy := target["groupBy"]
-
-			if !hasFields || !hasTags || !hasGroupBy {
-				continue
-			}
-
-			// Check if this is a raw query
-			rawQuery, isRawQuery := target["rawQuery"].(bool)
-			if isRawQuery && rawQuery {
-				// For raw queries, just delete fields and fill
-				delete(target, "fields")
-				delete(target, "fill")
-			} else {
-				// For structured queries, convert fields to select format
-				fieldsArray, ok := fields.([]interface{})
-				if ok {
-					selectArray := make([]interface{}, 0, len(fieldsArray))
-
-					for _, f := range fieldsArray {
-						field, ok := f.(map[string]interface{})
-						if !ok {
-							continue
-						}
-
-						parts := make([]interface{}, 0)
-
-						// Add field part
-						if name, ok := field["name"].(string); ok {
-							parts = append(parts, map[string]interface{}{
-								"type":   "field",
-								"params": []interface{}{name},
-							})
-						}
-
-						// Add function part
-						if funcName, ok := field["func"].(string); ok {
-							parts = append(parts, map[string]interface{}{
-								"type":   funcName,
-								"params": []interface{}{},
-							})
-						}
-
-						// Add math expression if present
-						if mathExpr, ok := field["mathExpr"].(string); ok {
-							parts = append(parts, map[string]interface{}{
-								"type":   "math",
-								"params": []interface{}{mathExpr},
-							})
-						}
-
-						// Add alias if present
-						if asExpr, ok := field["asExpr"].(string); ok {
-							parts = append(parts, map[string]interface{}{
-								"type":   "alias",
-								"params": []interface{}{asExpr},
-							})
-						}
-
-						if len(parts) > 0 {
-							selectArray = append(selectArray, parts)
-						}
-					}
-
-					target["select"] = selectArray
-				}
-
-				// Remove the old fields property
-				delete(target, "fields")
-
-				// Update groupBy format
-				if groupByArray, ok := groupBy.([]interface{}); ok {
-					for _, gb := range groupByArray {
-						groupByPart, ok := gb.(map[string]interface{})
-						if !ok {
-							continue
-						}
-
-						// Convert time groupBy
-						if partType, ok := groupByPart["type"].(string); ok && partType == "time" {
-							if interval, ok := groupByPart["interval"].(string); ok {
-								groupByPart["params"] = []interface{}{interval}
-								delete(groupByPart, "interval")
-							}
-						}
-
-						// Convert tag groupBy
-						if partType, ok := groupByPart["type"].(string); ok && partType == "tag" {
-							if key, ok := groupByPart["key"].(string); ok {
-								groupByPart["params"] = []interface{}{key}
-								delete(groupByPart, "key")
-							}
-						}
-					}
-
-					// Add fill to groupBy if present
-					if fill, hasFill := target["fill"]; hasFill {
-						newGroupByArray := make([]interface{}, len(groupByArray)) //nolint:prealloc
-						copy(newGroupByArray, groupByArray)
-						newGroupByArray = append(newGroupByArray, map[string]interface{}{
-							"type":   "fill",
-							"params": []interface{}{fill},
-						})
-						target["groupBy"] = newGroupByArray
-						delete(target, "fill")
-					}
-				}
-			}
-		}
+	// This migration runs before V16 hoists row panels to the top level, so in
+	// pre-v16 dashboards the panels still live inside rows. Visit both locations
+	// to match the frontend, which applies this upgrade after the row->grid
+	// conversion.
+	for _, panel := range collectPanelsIncludingRows(dashboard) {
+		migrateInfluxdbQueriesInPanel(panel)
 	}
 
 	return nil
+}
+
+func migrateInfluxdbQueriesInPanel(panel map[string]interface{}) {
+	targets, ok := panel["targets"].([]interface{})
+	if !ok {
+		return
+	}
+
+	for _, t := range targets {
+		target, ok := t.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		// Check if this target has the old InfluxDB schema
+		fields, hasFields := target["fields"]
+		_, hasTags := target["tags"]
+		groupBy, hasGroupBy := target["groupBy"]
+
+		if !hasFields || !hasTags || !hasGroupBy {
+			continue
+		}
+
+		// Check if this is a raw query
+		rawQuery, isRawQuery := target["rawQuery"].(bool)
+		if isRawQuery && rawQuery {
+			// For raw queries, just delete fields and fill
+			delete(target, "fields")
+			delete(target, "fill")
+		} else {
+			// For structured queries, convert fields to select format
+			fieldsArray, ok := fields.([]interface{})
+			if ok {
+				selectArray := make([]interface{}, 0, len(fieldsArray))
+
+				for _, f := range fieldsArray {
+					field, ok := f.(map[string]interface{})
+					if !ok {
+						continue
+					}
+
+					parts := make([]interface{}, 0)
+
+					// Add field part
+					if name, ok := field["name"].(string); ok {
+						parts = append(parts, map[string]interface{}{
+							"type":   "field",
+							"params": []interface{}{name},
+						})
+					}
+
+					// Add function part
+					if funcName, ok := field["func"].(string); ok {
+						parts = append(parts, map[string]interface{}{
+							"type":   funcName,
+							"params": []interface{}{},
+						})
+					}
+
+					// Add math expression if present
+					if mathExpr, ok := field["mathExpr"].(string); ok {
+						parts = append(parts, map[string]interface{}{
+							"type":   "math",
+							"params": []interface{}{mathExpr},
+						})
+					}
+
+					// Add alias if present
+					if asExpr, ok := field["asExpr"].(string); ok {
+						parts = append(parts, map[string]interface{}{
+							"type":   "alias",
+							"params": []interface{}{asExpr},
+						})
+					}
+
+					if len(parts) > 0 {
+						selectArray = append(selectArray, parts)
+					}
+				}
+
+				target["select"] = selectArray
+			}
+
+			// Remove the old fields property
+			delete(target, "fields")
+
+			// Update groupBy format
+			if groupByArray, ok := groupBy.([]interface{}); ok {
+				for _, gb := range groupByArray {
+					groupByPart, ok := gb.(map[string]interface{})
+					if !ok {
+						continue
+					}
+
+					// Convert time groupBy
+					if partType, ok := groupByPart["type"].(string); ok && partType == "time" {
+						if interval, ok := groupByPart["interval"].(string); ok {
+							groupByPart["params"] = []interface{}{interval}
+							delete(groupByPart, "interval")
+						}
+					}
+
+					// Convert tag groupBy
+					if partType, ok := groupByPart["type"].(string); ok && partType == "tag" {
+						if key, ok := groupByPart["key"].(string); ok {
+							groupByPart["params"] = []interface{}{key}
+							delete(groupByPart, "key")
+						}
+					}
+				}
+
+				// Add fill to groupBy if present
+				if fill, hasFill := target["fill"]; hasFill {
+					newGroupByArray := make([]interface{}, len(groupByArray)) //nolint:prealloc
+					copy(newGroupByArray, groupByArray)
+					newGroupByArray = append(newGroupByArray, map[string]interface{}{
+						"type":   "fill",
+						"params": []interface{}{fill},
+					})
+					target["groupBy"] = newGroupByArray
+					delete(target, "fill")
+				}
+			}
+		}
+	}
 }

--- a/apps/dashboard/pkg/migration/schemaversion/v8_test.go
+++ b/apps/dashboard/pkg/migration/schemaversion/v8_test.go
@@ -9,6 +9,55 @@ import (
 func TestV8(t *testing.T) {
 	tests := []migrationTestCase{
 		{
+			name: "InfluxDB query in a panel nested inside a row is migrated",
+			input: map[string]interface{}{
+				"title":         "V8 Nested Row InfluxDB Test Dashboard",
+				"schemaVersion": 7,
+				"rows": []interface{}{
+					map[string]interface{}{
+						"panels": []interface{}{
+							map[string]interface{}{
+								"id": 1,
+								"targets": []interface{}{
+									map[string]interface{}{
+										"rawQuery": true,
+										"query":    "select value from cpu",
+										"fields": []interface{}{
+											map[string]interface{}{"name": "value"},
+										},
+										"tags":    []interface{}{},
+										"groupBy": []interface{}{},
+										"fill":    "null",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"title":         "V8 Nested Row InfluxDB Test Dashboard",
+				"schemaVersion": 8,
+				"rows": []interface{}{
+					map[string]interface{}{
+						"panels": []interface{}{
+							map[string]interface{}{
+								"id": 1,
+								"targets": []interface{}{
+									map[string]interface{}{
+										"rawQuery": true,
+										"query":    "select value from cpu",
+										"tags":     []interface{}{},
+										"groupBy":  []interface{}{},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "InfluxDB structured query should be converted to new select format",
 			input: map[string]interface{}{
 				"title":         "V8 InfluxDB Query Migration Test Dashboard",


### PR DESCRIPTION
## What this PR does

Fixes schema migrations **V8** (legacy InfluxDB query → `select` format) and **V10** (table threshold cleanup) so they actually run on the panels of genuinely old dashboards.

### Root cause

The Go migration pipeline runs migrations sequentially by version, so V8 and V10 run **before** V16 — the migration that hoists row panels to the top-level `panels` array. In a real pre-v16 dashboard, panels live inside `rows[].panels`, and top-level `panels` doesn't exist yet. Because V8/V10 only iterated `dashboard["panels"]`, they found nothing and silently did nothing on exactly the dashboards they were meant to fix.

The canonical frontend `DashboardMigrator` avoids this by collecting these as `panelUpgrades` and applying them **after** the row→grid conversion, so they run against the final panel set.

### Fix

Added a shared `collectPanelsIncludingRows` helper that returns panels from both the top-level `panels` array and each legacy `rows[].panels` array. V8 and V10 now iterate that, so they process panels wherever they live at that schema version. V16 later hoists the same (already-migrated) panel objects to the top level, so the transforms persist.

Each migration's per-panel transform was extracted into a helper (`migrateInfluxdbQueriesInPanel`, `migrateTableThresholdsInPanel`); top-level behavior is unchanged.

### Testing

- Added a regression test to each of V8 and V10 for a panel nested inside a row; verified both **fail** before the fix and **pass** after.
- Verified end-to-end that a `schemaVersion: 7` rows-based dashboard migrated through the full pipeline to the latest version has its InfluxDB target correctly converted.
- Full `apps/dashboard/pkg/migration/...` suite passes; `gofmt` and `go vet` clean.
