### PR TITLE
Advisor: Remove advisorDatasourceIntegration feature toggle

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1376,11 +1376,6 @@ export interface FeatureToggles {
   */
   flameGraphWithCallTree?: boolean;
   /**
-  * Enables the advisor report integration with datasource pages
-  * @default false
-  */
-  advisorDatasourceIntegration?: boolean;
-  /**
   * Enables an inline version of Log Details that creates no new scrolls
   * @default false
   */

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -2630,14 +2630,6 @@ var (
 			Expression:  "false",
 		},
 		{
-			Name:        "advisorDatasourceIntegration",
-			Description: "Enables the advisor report integration with datasource pages",
-			Stage:       FeatureStageExperimental,
-			Owner:       grafanaCatalogSquad,
-			Expression:  "false",
-			Generate:    Generate{LegacyGo: true, LegacyFrontend: true},
-		},
-		{
 			Name:        "inlineLogDetailsNoScrolls",
 			Description: "Enables an inline version of Log Details that creates no new scrolls",
 			Stage:       FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -304,7 +304,6 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-05-22,datasourcesApiServerEnableHealthEndpointFrontend,experimental,@grafana/grafana-datasources-core-services,false,false,true
 2026-05-22,datasourcesApiServerEnableHealthEndpointRedirect,experimental,@grafana/grafana-datasources-core-services,false,false,false
 2026-05-22,flameGraphWithCallTree,preview,@grafana/observability-traces-and-profiling,false,false,true
-2026-05-22,advisorDatasourceIntegration,experimental,@grafana/grafana-catalog,false,false,false
 2026-05-22,inlineLogDetailsNoScrolls,experimental,@grafana/observability-logs,false,false,true
 2026-05-22,logsTablePanelNG,experimental,@grafana/observability-logs,false,false,true
 2026-05-22,plugins.useMTPluginSettings,experimental,@grafana/grafana-frontend-platform,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -862,10 +862,6 @@ const (
 	// Redirect datasource health requests from the legacy API routes to the new datasource api group endpoints.
 	FlagDatasourcesApiServerEnableHealthEndpointRedirect = "datasourcesApiServerEnableHealthEndpointRedirect"
 
-	// FlagAdvisorDatasourceIntegration
-	// Enables the advisor report integration with datasource pages
-	FlagAdvisorDatasourceIntegration = "advisorDatasourceIntegration"
-
 	// FlagStreamingForwardTeamHeadersTempo
 	// Enables forwarding team headers from tempo for streaming requests with LBAC rules
 	FlagStreamingForwardTeamHeadersTempo = "streamingForwardTeamHeadersTempo"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -23,7 +23,8 @@
       "metadata": {
         "name": "advisorDatasourceIntegration",
         "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "deletionTimestamp": "2026-07-15T11:02:00Z"
       },
       "spec": {
         "description": "Enables the advisor report integration with datasource pages",

--- a/public/app/features/connections/components/RunAdvisorChecksButton/RunAdvisorChecksButton.test.tsx
+++ b/public/app/features/connections/components/RunAdvisorChecksButton/RunAdvisorChecksButton.test.tsx
@@ -4,7 +4,6 @@ import { reportInteraction } from '@grafana/runtime';
 import { useAppNotification } from 'app/core/copy/appNotification';
 import { contextSrv } from 'app/core/services/context_srv';
 import {
-  isAdvisorEnabled,
   useCreateDatasourceAdvisorChecks,
   useLatestDatasourceCheck,
 } from 'app/features/connections/hooks/useDatasourceAdvisorChecks';
@@ -12,7 +11,6 @@ import {
 import { RunAdvisorChecksButton } from './RunAdvisorChecksButton';
 
 jest.mock('app/features/connections/hooks/useDatasourceAdvisorChecks', () => ({
-  isAdvisorEnabled: jest.fn(),
   useCreateDatasourceAdvisorChecks: jest.fn(),
   useLatestDatasourceCheck: jest.fn(),
 }));
@@ -24,7 +22,6 @@ jest.mock('app/core/copy/appNotification', () => ({
   useAppNotification: jest.fn(),
 }));
 
-const mockIsAdvisorEnabled = isAdvisorEnabled as jest.Mock;
 const mockUseCreateDatasourceAdvisorChecks = useCreateDatasourceAdvisorChecks as jest.Mock;
 const mockUseLatestDatasourceCheck = useLatestDatasourceCheck as jest.Mock;
 const mockReportInteraction = reportInteraction as jest.Mock;
@@ -40,7 +37,6 @@ describe('RunAdvisorChecksButton', () => {
       error: jest.fn(),
       info: jest.fn(),
     });
-    mockIsAdvisorEnabled.mockReturnValue(true);
     jest.spyOn(contextSrv, 'hasRole').mockReturnValue(true);
     contextSrv.isGrafanaAdmin = false;
     mockUseCreateDatasourceAdvisorChecks.mockReturnValue({
@@ -49,14 +45,6 @@ describe('RunAdvisorChecksButton', () => {
       isAvailable: true,
     });
     mockUseLatestDatasourceCheck.mockReturnValue({ check: undefined, isLoading: false });
-  });
-
-  it('does not render when advisor is disabled', () => {
-    mockIsAdvisorEnabled.mockReturnValue(false);
-
-    const { container } = render(<RunAdvisorChecksButton />);
-
-    expect(container).toBeEmptyDOMElement();
   });
 
   it('does not render when user is not an admin', () => {

--- a/public/app/features/connections/components/RunAdvisorChecksButton/RunAdvisorChecksButton.tsx
+++ b/public/app/features/connections/components/RunAdvisorChecksButton/RunAdvisorChecksButton.tsx
@@ -7,17 +7,12 @@ import { Button } from '@grafana/ui';
 import { useAppNotification } from 'app/core/copy/appNotification';
 import { contextSrv } from 'app/core/services/context_srv';
 
-import {
-  isAdvisorEnabled,
-  useCreateDatasourceAdvisorChecks,
-  useLatestDatasourceCheck,
-} from '../../hooks/useDatasourceAdvisorChecks';
+import { useCreateDatasourceAdvisorChecks, useLatestDatasourceCheck } from '../../hooks/useDatasourceAdvisorChecks';
 
 export function RunAdvisorChecksButton(): JSX.Element | null {
   const notifyApp = useAppNotification();
   const { createChecks, isCreatingChecks, isAvailable } = useCreateDatasourceAdvisorChecks();
   const { check, isLoading: isLatestCheckLoading } = useLatestDatasourceCheck();
-  const advisorEnabled = isAdvisorEnabled();
   const hasAdminRights = contextSrv.hasRole('Admin') || contextSrv.isGrafanaAdmin;
   const [isWaitingForCheckCompletion, setIsWaitingForCheckCompletion] = useState(false);
 
@@ -46,7 +41,7 @@ export function RunAdvisorChecksButton(): JSX.Element | null {
 
   // Keep the button visible while checks are running, but hide it once
   // onboarding is complete (a check exists and checks are no longer running).
-  if (!advisorEnabled || !isAvailable || !hasAdminRights) {
+  if (!isAvailable || !hasAdminRights) {
     return null;
   }
 

--- a/public/app/features/connections/hooks/useDatasourceAdvisorChecks.test.tsx
+++ b/public/app/features/connections/hooks/useDatasourceAdvisorChecks.test.tsx
@@ -257,6 +257,17 @@ describe('useDatasourceFailureByUID', () => {
     expect(result.current.datasourceFailureByUID.size).toBe(0);
   });
 
+  it('does not report hasCheck when a check exists but has not produced a report yet', () => {
+    // Check object created but not yet completed: no status/report.
+    const check = makeCheck({});
+    mockPluginFunctions({ completedCheck: check });
+
+    const { result } = renderHook(() => useDatasourceFailureByUID(), { wrapper });
+
+    expect(result.current.hasCheck).toBe(false);
+    expect(result.current.datasourceFailureByUID.size).toBe(0);
+  });
+
   it('returns all datasources with any failure and their highest severity', () => {
     const check = makeCheck({
       failures: {

--- a/public/app/features/connections/hooks/useDatasourceAdvisorChecks.test.tsx
+++ b/public/app/features/connections/hooks/useDatasourceAdvisorChecks.test.tsx
@@ -233,6 +233,17 @@ describe('useDatasourceFailureByUID', () => {
     expect(result.current.datasourceFailureByUID.size).toBe(0);
   });
 
+  it('reports advisor unavailable without hanging when the plugin is not installed', () => {
+    // Plugin extensions never register (advisor app not installed) and loading has settled.
+    usePluginFunctionsMock.mockReturnValue({ isLoading: false, functions: [] });
+
+    const { result } = renderHook(() => useDatasourceFailureByUID(), { wrapper });
+
+    expect(result.current.isAvailable).toBe(false);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.datasourceFailureByUID.size).toBe(0);
+  });
+
   it('returns all datasources with any failure and their highest severity', () => {
     const check = makeCheck({
       failures: {

--- a/public/app/features/connections/hooks/useDatasourceAdvisorChecks.test.tsx
+++ b/public/app/features/connections/hooks/useDatasourceAdvisorChecks.test.tsx
@@ -225,12 +225,14 @@ describe('useDatasourceFailureByUID', () => {
     config.featureToggles = originalFeatureToggles;
   });
 
-  it('returns empty map when there is no check', () => {
+  it('returns empty map and reports no check when advisor is available but has not run yet', () => {
     mockPluginFunctions({});
 
     const { result } = renderHook(() => useDatasourceFailureByUID(), { wrapper });
 
     expect(result.current.datasourceFailureByUID.size).toBe(0);
+    expect(result.current.isAvailable).toBe(true);
+    expect(result.current.hasCheck).toBe(false);
   });
 
   it('reports advisor unavailable without hanging when the plugin is not installed', () => {
@@ -240,7 +242,18 @@ describe('useDatasourceFailureByUID', () => {
     const { result } = renderHook(() => useDatasourceFailureByUID(), { wrapper });
 
     expect(result.current.isAvailable).toBe(false);
+    expect(result.current.hasCheck).toBe(false);
     expect(result.current.isLoading).toBe(false);
+    expect(result.current.datasourceFailureByUID.size).toBe(0);
+  });
+
+  it('reports hasCheck when a completed check exists', () => {
+    const check = makeCheck({ failures: emptyReport });
+    mockPluginFunctions({ completedCheck: check });
+
+    const { result } = renderHook(() => useDatasourceFailureByUID(), { wrapper });
+
+    expect(result.current.hasCheck).toBe(true);
     expect(result.current.datasourceFailureByUID.size).toBe(0);
   });
 

--- a/public/app/features/connections/hooks/useDatasourceAdvisorChecks.test.tsx
+++ b/public/app/features/connections/hooks/useDatasourceAdvisorChecks.test.tsx
@@ -165,7 +165,6 @@ describe('useLatestDatasourceCheck', () => {
     config.featureToggles = {
       ...originalFeatureToggles,
       grafanaAdvisor: true,
-      advisorDatasourceIntegration: true,
     };
     useGetCheckTypeMock.mockReturnValue({ data: undefined, isLoading: false });
   });
@@ -242,7 +241,6 @@ describe('useDatasourceFailureByUID', () => {
     config.featureToggles = {
       ...originalFeatureToggles,
       grafanaAdvisor: true,
-      advisorDatasourceIntegration: true,
     };
     useGetCheckTypeMock.mockReturnValue({ data: undefined, isLoading: false });
   });
@@ -388,7 +386,6 @@ describe('useRetryDatasourceAdvisorCheck', () => {
     config.featureToggles = {
       ...originalFeatureToggles,
       grafanaAdvisor: true,
-      advisorDatasourceIntegration: true,
     };
     useGetCheckTypeMock.mockReturnValue({ data: undefined, isLoading: false });
   });
@@ -449,7 +446,6 @@ describe('useCreateDatasourceAdvisorChecks', () => {
     config.featureToggles = {
       ...originalFeatureToggles,
       grafanaAdvisor: true,
-      advisorDatasourceIntegration: true,
     };
     useGetCheckTypeMock.mockReturnValue({ data: undefined, isLoading: false });
   });

--- a/public/app/features/connections/hooks/useDatasourceAdvisorChecks.tsx
+++ b/public/app/features/connections/hooks/useDatasourceAdvisorChecks.tsx
@@ -39,12 +39,19 @@ type CreateChecksFn = () => {
 interface AdvisorCheckContextValue {
   check?: Check;
   isLoading: boolean;
+  // Whether the advisor plugin is installed and has registered its extensions.
+  // Consumers use this to decide whether to surface advisor UI or query its APIs.
+  isAvailable: boolean;
   retryCheck?: (checkName: string, itemID: string) => void;
   createChecks?: () => void;
   isCreatingChecks?: boolean;
 }
 
-const AdvisorCheckContext = createContext<AdvisorCheckContextValue>({ isLoading: false });
+// Data produced by the bridge from the plugin's hook functions; availability is
+// derived by the provider, not the bridge, so it's excluded here.
+type AdvisorCheckData = Omit<AdvisorCheckContextValue, 'isAvailable'>;
+
+const AdvisorCheckContext = createContext<AdvisorCheckContextValue>({ isLoading: false, isAvailable: false });
 
 /**
  * Provides advisor check data to descendant hooks via context.
@@ -52,7 +59,7 @@ const AdvisorCheckContext = createContext<AdvisorCheckContextValue>({ isLoading:
  * only after they are loaded, avoiding React hook ordering violations.
  */
 export function AdvisorCheckProvider({ children }: { children: ReactNode }) {
-  const [advisorData, setAdvisorData] = useState<AdvisorCheckContextValue | null>(null);
+  const [advisorData, setAdvisorData] = useState<AdvisorCheckData | null>(null);
 
   const { functions: completedChecksFns, isLoading: isLoadingCompletedChecks } = usePluginFunctions<CompletedChecksFn>({
     extensionPointId: PluginExtensionPoints.AdvisorCompletedChecks,
@@ -67,19 +74,21 @@ export function AdvisorCheckProvider({ children }: { children: ReactNode }) {
   const completedChecksFn = completedChecksFns.find((f) => f.pluginId === ADVISOR_PLUGIN_ID)?.fn;
   const retryCheckFn = retryCheckFns.find((f) => f.pluginId === ADVISOR_PLUGIN_ID)?.fn;
   const createChecksFn = createChecksFns.find((f) => f.pluginId === ADVISOR_PLUGIN_ID)?.fn;
-  const isPluginReady =
-    !isLoadingCompletedChecks &&
-    !isLoadingRetryChecks &&
-    !isLoadingCreateChecks &&
-    !!completedChecksFn &&
-    !!retryCheckFn;
+  const isLoadingPlugins = isLoadingCompletedChecks || isLoadingRetryChecks || isLoadingCreateChecks;
+  const isPluginReady = !isLoadingPlugins && !!completedChecksFn && !!retryCheckFn;
 
   const contextValue = useMemo<AdvisorCheckContextValue>(() => {
-    if (!isPluginReady || !advisorData) {
-      return { isLoading: true };
+    if (!isPluginReady) {
+      // The advisor plugin's functions are either still loading or the plugin
+      // isn't installed. Only report loading while the lookup is in flight so
+      // consumers don't hang forever when advisor is unavailable.
+      return { isLoading: isLoadingPlugins, isAvailable: false };
     }
-    return advisorData;
-  }, [isPluginReady, advisorData]);
+    if (!advisorData) {
+      return { isLoading: true, isAvailable: true };
+    }
+    return { ...advisorData, isAvailable: true };
+  }, [isPluginReady, isLoadingPlugins, advisorData]);
 
   return (
     <AdvisorCheckContext.Provider value={contextValue}>
@@ -110,7 +119,7 @@ function AdvisorCheckBridge({
   completedChecksFn: CompletedChecksFn;
   retryCheckFn: RetryCheckFn;
   createChecksFn?: CreateChecksFn;
-  onChange: (value: AdvisorCheckContextValue) => void;
+  onChange: (value: AdvisorCheckData) => void;
 }) {
   const completedChecks = completedChecksFn({ checkType: 'datasource' });
   const retryCheckResult = retryCheckFn();
@@ -147,6 +156,8 @@ export type DatasourceFailuresResult = {
   /** Map of datasource UID to the highest severity among its failures. Only datasources with at least one failure are included. */
   datasourceFailureByUID: Map<string, DatasourceFailureDetails>;
   isLoading: boolean;
+  /** Whether the advisor plugin is available to evaluate datasources. */
+  isAvailable: boolean;
 };
 
 /**
@@ -154,8 +165,11 @@ export type DatasourceFailuresResult = {
  * advisor check, to the highest severity among their failures.
  */
 export function useDatasourceFailureByUID(): DatasourceFailuresResult {
-  const { check, isLoading } = useLatestDatasourceCheck();
-  const { data: checkType, isLoading: isCheckTypeLoading } = useGetCheckTypeQuery({ name: 'datasource' });
+  const { check, isLoading, isAvailable } = useContext(AdvisorCheckContext);
+  const { data: checkType, isLoading: isCheckTypeLoading } = useGetCheckTypeQuery(
+    { name: 'datasource' },
+    { skip: !isAvailable }
+  );
 
   const datasourceFailureByUID = useMemo(() => {
     const failures = check?.status?.report?.failures;
@@ -178,7 +192,7 @@ export function useDatasourceFailureByUID(): DatasourceFailuresResult {
     return byUID;
   }, [check, checkType]);
 
-  return { datasourceFailureByUID, isLoading: isLoading || isCheckTypeLoading };
+  return { datasourceFailureByUID, isLoading: isLoading || isCheckTypeLoading, isAvailable };
 }
 
 /**

--- a/public/app/features/connections/hooks/useDatasourceAdvisorChecks.tsx
+++ b/public/app/features/connections/hooks/useDatasourceAdvisorChecks.tsx
@@ -39,8 +39,6 @@ type CreateChecksFn = () => {
 interface AdvisorCheckContextValue {
   check?: Check;
   isLoading: boolean;
-  // Whether the advisor plugin is installed and has registered its extensions.
-  // Consumers use this to decide whether to surface advisor UI or query its APIs.
   isAvailable: boolean;
   retryCheck?: (checkName: string, itemID: string) => void;
   createChecks?: () => void;
@@ -79,9 +77,6 @@ export function AdvisorCheckProvider({ children }: { children: ReactNode }) {
 
   const contextValue = useMemo<AdvisorCheckContextValue>(() => {
     if (!isPluginReady) {
-      // The advisor plugin's functions are either still loading or the plugin
-      // isn't installed. Only report loading while the lookup is in flight so
-      // consumers don't hang forever when advisor is unavailable.
       return { isLoading: isLoadingPlugins, isAvailable: false };
     }
     if (!advisorData) {
@@ -158,6 +153,8 @@ export type DatasourceFailuresResult = {
   isLoading: boolean;
   /** Whether the advisor plugin is available to evaluate datasources. */
   isAvailable: boolean;
+  /** Whether advisor has produced a completed datasource check. When false, no datasource has been evaluated yet. */
+  hasCheck: boolean;
 };
 
 /**
@@ -192,7 +189,7 @@ export function useDatasourceFailureByUID(): DatasourceFailuresResult {
     return byUID;
   }, [check, checkType]);
 
-  return { datasourceFailureByUID, isLoading: isLoading || isCheckTypeLoading, isAvailable };
+  return { datasourceFailureByUID, isLoading: isLoading || isCheckTypeLoading, isAvailable, hasCheck: Boolean(check) };
 }
 
 /**

--- a/public/app/features/connections/hooks/useDatasourceAdvisorChecks.tsx
+++ b/public/app/features/connections/hooks/useDatasourceAdvisorChecks.tsx
@@ -37,7 +37,7 @@ type CreateChecksFn = () => {
 };
 
 export function isAdvisorEnabled(): boolean {
-  return Boolean(config.featureToggles.grafanaAdvisor && config.featureToggles.advisorDatasourceIntegration);
+  return Boolean(config.featureToggles.grafanaAdvisor);
 }
 
 interface AdvisorCheckContextValue {

--- a/public/app/features/connections/hooks/useDatasourceAdvisorChecks.tsx
+++ b/public/app/features/connections/hooks/useDatasourceAdvisorChecks.tsx
@@ -189,7 +189,11 @@ export function useDatasourceFailureByUID(): DatasourceFailuresResult {
     return byUID;
   }, [check, checkType]);
 
-  return { datasourceFailureByUID, isLoading: isLoading || isCheckTypeLoading, isAvailable, hasCheck: Boolean(check) };
+  // A check object can exist before it has produced a report (created but not
+  // yet completed); only treat it as evaluated once the report is present.
+  const hasCheck = Boolean(check?.status?.report);
+
+  return { datasourceFailureByUID, isLoading: isLoading || isCheckTypeLoading, isAvailable, hasCheck };
 }
 
 /**

--- a/public/app/features/datasources/components/DataSourceTabPage.tsx
+++ b/public/app/features/datasources/components/DataSourceTabPage.tsx
@@ -17,13 +17,14 @@ interface Props {
 
 function DataSourceTabPage({ uid, pageId }: Props) {
   const { navId, pageNav, dataSourceHeader } = useDataSourceSettingsNav(pageId ?? undefined);
-  const { datasourceFailureByUID } = useDatasourceFailureByUID();
+  const { datasourceFailureByUID, isAvailable: advisorAvailable } = useDatasourceFailureByUID();
 
   const info = useDataSourceInfo({
     dataSourcePluginName: pageNav.dataSourcePluginName,
     alertingSupported: dataSourceHeader.alertingSupported,
     alertingLoading: dataSourceHeader.alertingLoading,
     failure: datasourceFailureByUID.get(uid),
+    advisorAvailable,
   });
 
   const dataSource = useDataSource(uid);

--- a/public/app/features/datasources/components/DataSourceTabPage.tsx
+++ b/public/app/features/datasources/components/DataSourceTabPage.tsx
@@ -17,14 +17,14 @@ interface Props {
 
 function DataSourceTabPage({ uid, pageId }: Props) {
   const { navId, pageNav, dataSourceHeader } = useDataSourceSettingsNav(pageId ?? undefined);
-  const { datasourceFailureByUID, isAvailable: advisorAvailable } = useDatasourceFailureByUID();
+  const { datasourceFailureByUID, hasCheck: advisorChecked } = useDatasourceFailureByUID();
 
   const info = useDataSourceInfo({
     dataSourcePluginName: pageNav.dataSourcePluginName,
     alertingSupported: dataSourceHeader.alertingSupported,
     alertingLoading: dataSourceHeader.alertingLoading,
     failure: datasourceFailureByUID.get(uid),
-    advisorAvailable,
+    advisorChecked,
   });
 
   const dataSource = useDataSource(uid);

--- a/public/app/features/datasources/components/useDataSourceInfo.test.tsx
+++ b/public/app/features/datasources/components/useDataSourceInfo.test.tsx
@@ -55,7 +55,7 @@ describe('useDataSourceInfo', () => {
     expect(screen.getByText('Not supported')).toBeInTheDocument();
   });
 
-  it('should omit the Advisor badge when advisor is not available', () => {
+  it('should omit the Advisor badge when advisor has not checked the datasource', () => {
     const { result } = renderHook(() =>
       useDataSourceInfo({
         dataSourcePluginName: 'Prometheus',
@@ -66,12 +66,12 @@ describe('useDataSourceInfo', () => {
     expect(result.current.map((item) => item.label)).not.toContain('Advisor');
   });
 
-  it('should show a "Success" Advisor badge when advisor is available and there is no failure', () => {
+  it('should show a "Success" Advisor badge when advisor has checked the datasource and there is no failure', () => {
     const { result } = renderHook(() =>
       useDataSourceInfo({
         dataSourcePluginName: 'Prometheus',
         alertingSupported: true,
-        advisorAvailable: true,
+        advisorChecked: true,
       })
     );
 

--- a/public/app/features/datasources/components/useDataSourceInfo.test.tsx
+++ b/public/app/features/datasources/components/useDataSourceInfo.test.tsx
@@ -54,4 +54,30 @@ describe('useDataSourceInfo', () => {
 
     expect(screen.getByText('Not supported')).toBeInTheDocument();
   });
+
+  it('should omit the Advisor badge when advisor is not available', () => {
+    const { result } = renderHook(() =>
+      useDataSourceInfo({
+        dataSourcePluginName: 'Prometheus',
+        alertingSupported: true,
+      })
+    );
+
+    expect(result.current.map((item) => item.label)).not.toContain('Advisor');
+  });
+
+  it('should show a "Success" Advisor badge when advisor is available and there is no failure', () => {
+    const { result } = renderHook(() =>
+      useDataSourceInfo({
+        dataSourcePluginName: 'Prometheus',
+        alertingSupported: true,
+        advisorAvailable: true,
+      })
+    );
+
+    const advisorItem = result.current.find((item) => item.label === 'Advisor');
+    render(<>{advisorItem?.value}</>);
+
+    expect(screen.getByText('Success')).toBeInTheDocument();
+  });
 });

--- a/public/app/features/datasources/components/useDataSourceInfo.tsx
+++ b/public/app/features/datasources/components/useDataSourceInfo.tsx
@@ -12,10 +12,8 @@ type DataSourceInfo = {
   // while true, alertingSupported is not known yet and the badge is not rendered
   alertingLoading?: boolean;
   failure?: DatasourceFailureDetails;
-  // whether the advisor plugin is available to evaluate this datasource; the
-  // Advisor badge is only rendered when true, so pages that don't wire advisor
-  // data (e.g. feature-highlight pages) don't show a misleading "Success".
-  advisorAvailable?: boolean;
+  // whether advisor has produced a completed check for this datasource
+  advisorChecked?: boolean;
 };
 
 export const useDataSourceInfo = (dataSourceInfo: DataSourceInfo): PageInfoItem[] => {
@@ -48,7 +46,7 @@ export const useDataSourceInfo = (dataSourceInfo: DataSourceInfo): PageInfoItem[
     });
   }
 
-  if (dataSourceInfo.advisorAvailable) {
+  if (dataSourceInfo.advisorChecked) {
     info.push({
       label: t('datasources.use-data-source-info.label.advisor', 'Advisor'),
       value: failureSeverity ? (

--- a/public/app/features/datasources/components/useDataSourceInfo.tsx
+++ b/public/app/features/datasources/components/useDataSourceInfo.tsx
@@ -2,7 +2,7 @@ import { t } from '@grafana/i18n';
 import { Badge } from '@grafana/ui';
 import { type PageInfoItem } from 'app/core/components/Page/types';
 
-import { isAdvisorEnabled, type DatasourceFailureDetails } from '../../connections/hooks/useDatasourceAdvisorChecks';
+import { type DatasourceFailureDetails } from '../../connections/hooks/useDatasourceAdvisorChecks';
 
 import { DataSourceFailureBadge } from './DataSourceFailureBadge';
 
@@ -44,16 +44,14 @@ export const useDataSourceInfo = (dataSourceInfo: DataSourceInfo): PageInfoItem[
     });
   }
 
-  if (isAdvisorEnabled()) {
-    info.push({
-      label: t('datasources.use-data-source-info.label.advisor', 'Advisor'),
-      value: failureSeverity ? (
-        <DataSourceFailureBadge severity={failureSeverity} message={dataSourceInfo.failure?.message} />
-      ) : (
-        <Badge color="green" text={t('datasources.use-data-source-info.badge-text-success', 'Success')} />
-      ),
-    });
-  }
+  info.push({
+    label: t('datasources.use-data-source-info.label.advisor', 'Advisor'),
+    value: failureSeverity ? (
+      <DataSourceFailureBadge severity={failureSeverity} message={dataSourceInfo.failure?.message} />
+    ) : (
+      <Badge color="green" text={t('datasources.use-data-source-info.badge-text-success', 'Success')} />
+    ),
+  });
 
   return info;
 };

--- a/public/app/features/datasources/components/useDataSourceInfo.tsx
+++ b/public/app/features/datasources/components/useDataSourceInfo.tsx
@@ -12,6 +12,10 @@ type DataSourceInfo = {
   // while true, alertingSupported is not known yet and the badge is not rendered
   alertingLoading?: boolean;
   failure?: DatasourceFailureDetails;
+  // whether the advisor plugin is available to evaluate this datasource; the
+  // Advisor badge is only rendered when true, so pages that don't wire advisor
+  // data (e.g. feature-highlight pages) don't show a misleading "Success".
+  advisorAvailable?: boolean;
 };
 
 export const useDataSourceInfo = (dataSourceInfo: DataSourceInfo): PageInfoItem[] => {
@@ -44,14 +48,16 @@ export const useDataSourceInfo = (dataSourceInfo: DataSourceInfo): PageInfoItem[
     });
   }
 
-  info.push({
-    label: t('datasources.use-data-source-info.label.advisor', 'Advisor'),
-    value: failureSeverity ? (
-      <DataSourceFailureBadge severity={failureSeverity} message={dataSourceInfo.failure?.message} />
-    ) : (
-      <Badge color="green" text={t('datasources.use-data-source-info.badge-text-success', 'Success')} />
-    ),
-  });
+  if (dataSourceInfo.advisorAvailable) {
+    info.push({
+      label: t('datasources.use-data-source-info.label.advisor', 'Advisor'),
+      value: failureSeverity ? (
+        <DataSourceFailureBadge severity={failureSeverity} message={dataSourceInfo.failure?.message} />
+      ) : (
+        <Badge color="green" text={t('datasources.use-data-source-info.badge-text-success', 'Success')} />
+      ),
+    });
+  }
 
   return info;
 };


### PR DESCRIPTION
## What this does

Remove the `advisorDatasourceIntegration` feature flag to enable it by default.

This is a small feature that has been running in Cloud with no issues.

https://github.com/grafana/grafana-catalog-team/issues/1062