### PR TITLE
IAM: remove custom user createdAt search field

### DIFF
--- a/pkg/storage/unified/search/builders/document_test.go
+++ b/pkg/storage/unified/search/builders/document_test.go
@@ -230,5 +230,6 @@ func TestUserDocumentBuilder_Created(t *testing.T) {
 		1, value)
 	require.NoError(t, err)
 
-	assert.Equal(t, time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC).UnixMilli(), doc.Fields[USER_CREATED])
+	// The creation timestamp is carried on the standard created field.
+	assert.Equal(t, time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC).UnixMilli(), doc.Created)
 }

--- a/pkg/storage/unified/search/builders/testdata/doc/user-with-last-seen-at-and-role-out.json
+++ b/pkg/storage/unified/search/builders/testdata/doc/user-with-last-seen-at-and-role-out.json
@@ -11,7 +11,6 @@
   "title_ngram": "with-last-seen-at-and-role",
   "title_phrase": "with-last-seen-at-and-role",
   "fields": {
-    "createdAt": 0,
     "disabled": false,
     "email": "user.three@test.com",
     "lastSeenAt": 1698321600,

--- a/pkg/storage/unified/search/builders/testdata/doc/user-with-login-and-email-out.json
+++ b/pkg/storage/unified/search/builders/testdata/doc/user-with-login-and-email-out.json
@@ -11,7 +11,6 @@
   "title_ngram": "with-login-and-email",
   "title_phrase": "with-login-and-email",
   "fields": {
-    "createdAt": 0,
     "disabled": false,
     "email": "user.one@test.com",
     "lastSeenAt": 0,

--- a/pkg/storage/unified/search/builders/testdata/doc/user-with-login-only-out.json
+++ b/pkg/storage/unified/search/builders/testdata/doc/user-with-login-only-out.json
@@ -11,7 +11,6 @@
   "title_ngram": "with-login-only",
   "title_phrase": "with-login-only",
   "fields": {
-    "createdAt": 0,
     "disabled": false,
     "lastSeenAt": 0,
     "login": "user.two",

--- a/pkg/storage/unified/search/builders/user.go
+++ b/pkg/storage/unified/search/builders/user.go
@@ -1,8 +1,6 @@
 package builders
 
 import (
-	"slices"
-
 	"github.com/grafana/grafana-app-sdk/app"
 
 	iam "github.com/grafana/grafana/apps/iam/pkg/apis"
@@ -21,7 +19,6 @@ const (
 	USER_LAST_SEEN_AT = "lastSeenAt"
 	USER_ROLE         = "role"
 	USER_DISABLED     = "disabled"
-	USER_CREATED      = "createdAt"
 )
 
 // UserSortableExtraFields are the additional fields that can be used for sorting user search results.
@@ -33,7 +30,7 @@ var UserSortableExtraFields = []string{
 }
 
 // userSearchFields are read from the generated IAM manifest (declared in
-// apps/iam/kinds/user.cue), plus the createdAt field appended below.
+// apps/iam/kinds/user.cue).
 //
 // lastSeenAt (int64) and disabled (boolean) declare the filter capability to
 // record that they are meant to be filterable and to drive the bleve mapping
@@ -43,16 +40,7 @@ var UserSortableExtraFields = []string{
 // would not match a numeric-indexed term yet. No in-tree client filters by
 // lastSeenAt or disabled today, so this is a known gap rather than a rollout
 // concern.
-var userSearchFields = slices.Concat(
-	resource.NewManifestBackedProvider(iamManifests).Fields(iamv0.UserResourceInfo.GroupVersionResource()),
-	[]resource.SearchFieldDefinition{
-		// createdAt reads from the standard document's Created value rather than a
-		// resource path, so it cannot be declared in the manifest and stays here.
-		// It mirrors that value into the per-kind fields.* sub-document because
-		// the top-level created field has no bleve mapping today.
-		{Name: USER_CREATED, CopyFromStandard: resource.StandardFieldCreated, Type: resource.SearchFieldTypeInt64, Capabilities: []resource.SearchCapability{resource.SearchCapabilityRetrieve}, Description: "The creation timestamp of the user, in epoch milliseconds"},
-	},
-)
+var userSearchFields = resource.NewManifestBackedProvider(iamManifests).Fields(iamv0.UserResourceInfo.GroupVersionResource())
 
 // UserTableColumnDefinitions exposes column-defs by name for wire-API
 // consumers (the IAM legacy SQL backend in user/legacy_search.go).

--- a/pkg/storage/unified/search/testdata/bleve_mapping_user.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_user.json
@@ -47,16 +47,6 @@
         "enabled": true,
         "dynamic": false,
         "properties": {
-          "createdAt": {
-            "enabled": true,
-            "dynamic": true,
-            "fields": [
-              {
-                "type": "number",
-                "store": true
-              }
-            ]
-          },
           "disabled": {
             "enabled": true,
             "dynamic": true,


### PR DESCRIPTION
User search declared a custom `createdAt` search field that mirrored the standard `created` value into the per-kind `fields` sub-document. The consumer now reads the standard `created` field directly — the client-side switch merged in #128379 — so the custom field is redundant. This removes it, leaving `userSearchFields` sourced entirely from the IAM manifest, and triggers a one-time user index rebuild because the user search-fields hash no longer includes `createdAt`.

This depends on the client-side read-switch in #128379 having merged. What can break: during a rollout where a search backend carrying this change (no `createdAt`) is queried by an older API-layer consumer that predates #128379 and still reads `createdAt`, that consumer sees a missing column. The impact is limited and non-fatal — `createdAt` is retrieve-only (nothing sorts or filters on it), a missing column decodes to `0` rather than erroring, and the legacy SQL search path builds the created value from the database itself. So the only observable effect is a temporary `created = 0` (epoch) on the index-backed user list, which self-heals as soon as the consumer picks up #128379. No crash, no error, no data loss.

If that transient blip needs to be avoided, mitigate by backporting #128379 to the slow/steady release branches so every channel is reading the standard `created` field before this change reaches it. We are not doing that pre-emptively; it is only needed if the skew is actually observed.

Part of grafana/search-and-storage-team#827.
