### PR TITLE
Loki: Use PartialResult for split queries with Streaming fallback

### DIFF
--- a/public/app/plugins/datasource/loki/incrementalQueryLoadingState.test.ts
+++ b/public/app/plugins/datasource/loki/incrementalQueryLoadingState.test.ts
@@ -1,0 +1,31 @@
+import { LoadingState } from '@grafana/data';
+
+import { getIncrementalSplitQueryLoadingState } from './incrementalQueryLoadingState';
+
+describe('getIncrementalSplitQueryLoadingState', () => {
+  it('returns PartialResult when LoadingState supports it', () => {
+    expect('PartialResult' in LoadingState).toBe(true);
+    expect(getIncrementalSplitQueryLoadingState()).toBe(LoadingState.PartialResult);
+  });
+
+  it('falls back to Streaming when PartialResult is not on LoadingState', () => {
+    jest.isolateModules(() => {
+      jest.doMock('@grafana/data', () => {
+        const actual = jest.requireActual('@grafana/data');
+        return {
+          ...actual,
+          LoadingState: {
+            NotStarted: actual.LoadingState.NotStarted,
+            Loading: actual.LoadingState.Loading,
+            Streaming: actual.LoadingState.Streaming,
+            Done: actual.LoadingState.Done,
+            Error: actual.LoadingState.Error,
+          },
+        };
+      });
+
+      const { getIncrementalSplitQueryLoadingState: getState } = require('./incrementalQueryLoadingState');
+      expect(getState()).toBe(LoadingState.Streaming);
+    });
+  });
+});

--- a/public/app/plugins/datasource/loki/incrementalQueryLoadingState.ts
+++ b/public/app/plugins/datasource/loki/incrementalQueryLoadingState.ts
@@ -1,0 +1,14 @@
+import { LoadingState } from '@grafana/data';
+
+/**
+ * Loading state for incremental split-query responses.
+ * Uses PartialResult when supported by the connected Grafana version; otherwise Streaming
+ * so the plugin remains compatible with older Grafana instances.
+ */
+export function getIncrementalSplitQueryLoadingState(): LoadingState {
+  if ('PartialResult' in LoadingState) {
+    return LoadingState.PartialResult;
+  }
+
+  return LoadingState.Streaming;
+}

--- a/public/app/plugins/datasource/loki/querySplitting.test.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.test.ts
@@ -1,4 +1,5 @@
 import { of } from 'rxjs';
+import { tap } from 'rxjs/operators';
 
 import {
   type DataQueryError,
@@ -11,6 +12,7 @@ import { config } from '@grafana/runtime';
 
 import { LokiQueryType, LokiQueryDirection } from './dataquery.gen';
 import { type LokiDatasource } from './datasource';
+import { getIncrementalSplitQueryLoadingState } from './incrementalQueryLoadingState';
 import { createLokiDatasource } from './mocks/datasource';
 import { getMockFrames } from './mocks/frames';
 import { runSplitQuery } from './querySplitting';
@@ -78,6 +80,22 @@ describe.each([false, true])('runSplitQuery(aligned = %s)', (lokiAlignedQuerySpl
       expect(datasource.runQuery).toHaveBeenCalledTimes(3);
       // 3 sub-requests + complete
       expect(emitted).toHaveLength(4);
+    });
+  });
+
+  test('Emits incremental loading state for intermediate responses and Done for the final response', async () => {
+    const incrementalState = getIncrementalSplitQueryLoadingState();
+    const capturedStates: Array<LoadingState | undefined> = [];
+    await expect(
+      runSplitQuery(datasource, globalRequest).pipe(tap((r) => capturedStates.push(r.state)))
+    ).toEmitValuesWith(() => {
+      expect(capturedStates).toHaveLength(4);
+      const intermediateStates = capturedStates.slice(0, -1);
+      const finalState = capturedStates[capturedStates.length - 1];
+      for (const state of intermediateStates) {
+        expect(state).toBe(incrementalState);
+      }
+      expect(finalState).toBe(LoadingState.Done);
     });
   });
 

--- a/public/app/plugins/datasource/loki/querySplitting.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.ts
@@ -17,6 +17,7 @@ import { config } from '@grafana/runtime';
 
 import { LokiQueryType, LokiQueryDirection } from './dataquery.gen';
 import { type LokiDatasource } from './datasource';
+import { getIncrementalSplitQueryLoadingState } from './incrementalQueryLoadingState';
 import {
   splitTimeRange as splitLogsTimeRange,
   splitTimeRangeAligned as splitLogsTimeRangeAligned,
@@ -131,7 +132,11 @@ function runSplitGroupedQueries(
   options: QuerySplittingOptions = {}
 ) {
   const responseKey = requests.length ? requests[0].request.queryGroupId : generateUUID();
-  let mergedResponse: DataQueryResponse = { data: [], state: LoadingState.Streaming, key: responseKey };
+  let mergedResponse: DataQueryResponse = {
+    data: [],
+    state: getIncrementalSplitQueryLoadingState(),
+    key: responseKey,
+  };
   const totalRequests = Math.max(...requests.map(({ partition }) => partition.length));
   const longestPartition = requests.filter(({ partition }) => partition.length === totalRequests)[0].partition;
 

--- a/public/app/plugins/datasource/loki/shardQuerySplitting.test.ts
+++ b/public/app/plugins/datasource/loki/shardQuerySplitting.test.ts
@@ -1,10 +1,12 @@
 import { of } from 'rxjs';
+import { tap } from 'rxjs/operators';
 
 import { type DataQueryRequest, type DataQueryResponse, dateTime, LoadingState } from '@grafana/data';
 import { config } from '@grafana/runtime';
 
 import { LokiQueryDirection, LokiQueryType } from './dataquery.gen';
 import { type LokiDatasource } from './datasource';
+import { getIncrementalSplitQueryLoadingState } from './incrementalQueryLoadingState';
 import { createLokiDatasource } from './mocks/datasource';
 import { getMockFrames } from './mocks/frames';
 import { LOKI_MAX_QUERY_BYTES_READ_ERROR_MSG_PREFIX, LOKI_TIMEOUT_ERROR_MSG } from './responseUtils';
@@ -85,6 +87,22 @@ describe('runShardSplitQuery()', () => {
     await expect(runShardSplitQuery(datasource, request)).toEmitValuesWith(() => {
       // 5 shards, 3 groups + empty shard group, 4 requests * 3 days, 3 chunks, 3 requests = 12 requests
       expect(datasource.runQuery).toHaveBeenCalledTimes(12);
+    });
+  });
+
+  test('Emits incremental loading state for intermediate responses and Done for the final response', async () => {
+    const incrementalState = getIncrementalSplitQueryLoadingState();
+    const capturedStates: Array<LoadingState | undefined> = [];
+    await expect(
+      runShardSplitQuery(datasource, request).pipe(tap((r) => capturedStates.push(r.state)))
+    ).toEmitValuesWith(() => {
+      expect(capturedStates.length).toBeGreaterThan(1);
+      const intermediateStates = capturedStates.slice(0, -1);
+      const finalState = capturedStates[capturedStates.length - 1];
+      for (const state of intermediateStates) {
+        expect(state).toBe(incrementalState);
+      }
+      expect(finalState).toBe(LoadingState.Done);
     });
   });
 

--- a/public/app/plugins/datasource/loki/shardQuerySplitting.ts
+++ b/public/app/plugins/datasource/loki/shardQuerySplitting.ts
@@ -11,6 +11,7 @@ import {
 import { config } from '@grafana/runtime';
 
 import { type LokiDatasource } from './datasource';
+import { getIncrementalSplitQueryLoadingState } from './incrementalQueryLoadingState';
 import { combineResponses, replaceResponses } from './mergeResponses';
 import { adjustTargetsFromResponseState, runSplitQuery } from './querySplitting';
 import {
@@ -83,7 +84,11 @@ function splitQueriesByStreamShard(
   splittingTargets: LokiQuery[]
 ) {
   let shouldStop = false;
-  let mergedResponse: DataQueryResponse = { data: [], state: LoadingState.Streaming, key: generateUUID() };
+  let mergedResponse: DataQueryResponse = {
+    data: [],
+    state: getIncrementalSplitQueryLoadingState(),
+    key: generateUUID(),
+  };
   let subquerySubscription: Subscription | null = null;
   let retriesMap = new Map<string, number>();
   let retryTimer: ReturnType<typeof setTimeout> | null = null;


### PR DESCRIPTION
## Summary

- Emit `PartialResult` (when available) instead of `Streaming` for intermediate responses in `querySplitting` and `shardQuerySplitting`
- Add `getIncrementalSplitQueryLoadingState()` which explicitly checks `'PartialResult' in LoadingState` and returns `LoadingState.PartialResult`; falls back to `Streaming` on older Grafana instances without the enum value

## Context

Part of the `LoadingState.PartialResult` work for reporting / query-splitting correctness (Fixes #118659).

**Targets:** [grafana/grafana#128466](https://github.com/grafana/grafana/pull/128466) (`fix/loading-state-partial-result`) — not `main`.

Merge order:
1. [grafana/grafana#128466](https://github.com/grafana/grafana/pull/128466) — add `PartialResult` to `@grafana/data`
2. [grafana/scenes#1383](https://github.com/grafana/scenes/pull/1383) — don't call `queryCompleted()` on `PartialResult`
3. **This PR** — Loki emits `PartialResult` for split queries

Until #128466 is released, the helper transparently falls back to `Streaming`, preserving behaviour on older Grafana versions.

## See also

Optional hardening (dev warnings, stale requestId filtering, dedup alignment, Scenes UX) is tracked under **Future follow-ups** in [grafana/grafana#128466](https://github.com/grafana/grafana/pull/128466).

## Test plan

- [x] `yarn jest --watchAll=false incrementalQueryLoadingState.test.ts querySplitting.test.ts shardQuerySplitting.test.ts -t "incremental loading state|getIncrementalSplitQueryLoadingState"`
- [ ] Manual: Loki dashboard with query splitting on Grafana with #128466 + Scenes #1383 — reporting waits for final `Done`