### PR TITLE
TimeRangePicker: Better error message when field is empty

### DIFF
--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
@@ -45,7 +45,6 @@ interface FormState {
 }
 
 const ERROR_MESSAGES = {
-  required: () => t('time-picker.range-content.required-error', 'This field is required'),
   default: () =>
     t(
       'time-picker.range-content.default-error',
@@ -180,7 +179,7 @@ export const TimeRangeContent = (props: Props) => {
         >
           <Input
             {...register('from', {
-              required: ERROR_MESSAGES.required(),
+              required: ERROR_MESSAGES.default(),
 
               validate: (value, formValues) => {
                 if (!isValid(value, false, timeZone)) {
@@ -209,7 +208,7 @@ export const TimeRangeContent = (props: Props) => {
         <Field label={t('time-picker.range-content.to-input', 'To')} invalid={!!errors.to} error={errors.to?.message}>
           <Input
             {...register('to', {
-              required: ERROR_MESSAGES.required(),
+              required: ERROR_MESSAGES.default(),
               validate: (value, formValues) => {
                 if (!isValid(value, true, timeZone)) {
                   return ERROR_MESSAGES.default();

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -15695,7 +15695,6 @@
       "from-input": "From",
       "open-input-calendar": "Open calendar",
       "range-error": "\"From\" date must be before \"To\" date",
-      "required-error": "This field is required",
       "to-input": "To"
     },
     "range-picker": {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- replaces the previous generic required error message (`This field is required`) with a more instructive (`Enter a date (YYYY-MM-DD HH:mm:ss) or relative time (now, now-1h)`)

**Why do we need this feature?**

- better error message

**Who is this feature for?**

- everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
