### PR TITLE
SSOSettings: read provider config from the MT-Settings service

### DIFF
--- a/pkg/services/ssosettings/errors.go
+++ b/pkg/services/ssosettings/errors.go
@@ -25,4 +25,8 @@ var (
 	ErrMTSettingsNotImplemented = errutil.NotImplemented("sso.mtSettingsNotImplemented",
 		errutil.WithPublicMessage("Resolving SSO settings from the MT-Settings service is not implemented yet")).
 		Errorf("MT-Settings SSO settings resolution not implemented")
+
+	ErrMTSettingsClientNotConfigured = errutil.Internal("sso.mtSettingsClientNotConfigured",
+		errutil.WithPublicMessage("The MT-Settings service client is not configured")).
+		Errorf("MT-Settings client not configured or failed to initialize; see server startup logs")
 )

--- a/pkg/services/ssosettings/ssosettingsimpl/mtsettings_client.go
+++ b/pkg/services/ssosettings/ssosettingsimpl/mtsettings_client.go
@@ -1,0 +1,88 @@
+package ssosettingsimpl
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/grafana/authlib/authn"
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/client-go/rest"
+
+	settingsvc "github.com/grafana/grafana/pkg/services/setting"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+// newMTSettingsClient initializes the MT-Settings client for the MT-Settings
+// fallback strategies. Expected configuration:
+//
+// [tls_client_config]
+// root_ca_file =
+// insecure =
+//
+// [grpc_client_authentication]
+// token =
+// token_exchange_url =
+//
+// [settings_service]
+// url =
+// qps =
+// burst =
+// cache_ttl =
+//
+// Returns nil without error when [settings_service] url is not configured:
+// the MT-Settings strategies are gated off by the ssoSettingsToMTSettings
+// feature toggle and fail loudly on read, so an absent client is only
+// reachable through an explicit misconfiguration.
+func newMTSettingsClient(cfg *setting.Cfg, promRegister prometheus.Registerer) (settingsvc.Service, error) {
+	settingsSec := cfg.SectionWithEnvOverrides("settings_service")
+	settingsServiceURL := settingsSec.Key("url").String()
+	if settingsServiceURL == "" {
+		return nil, nil
+	}
+
+	tlsConfigSection := cfg.SectionWithEnvOverrides("tls_client_config")
+	tlsConfig := rest.TLSClientConfig{
+		Insecure: tlsConfigSection.Key("insecure").MustBool(false),
+		CAFile:   tlsConfigSection.Key("root_ca_file").String(),
+	}
+
+	gRPCAuth := cfg.SectionWithEnvOverrides("grpc_client_authentication")
+	token := gRPCAuth.Key("token").String()
+	tokenExchangeURL := gRPCAuth.Key("token_exchange_url").String()
+	if token == "" {
+		return nil, fmt.Errorf("grpc_client_authentication.token is required for the settings service")
+	}
+	if tokenExchangeURL == "" {
+		return nil, fmt.Errorf("grpc_client_authentication.token_exchange_url is required for the settings service")
+	}
+
+	tokenClient, err := authn.NewTokenExchangeClient(authn.TokenExchangeConfig{
+		Token:            token,
+		TokenExchangeURL: tokenExchangeURL,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create token exchange client: %w", err)
+	}
+
+	settingsService, err := settingsvc.New(settingsvc.Config{
+		URL:                 settingsServiceURL,
+		TokenExchangeClient: tokenClient,
+		TLSClientConfig:     tlsConfig,
+		QPS:                 float32(settingsSec.Key("qps").MustFloat64(0)),
+		Burst:               settingsSec.Key("burst").MustInt(0),
+		CacheTTL:            settingsSec.Key("cache_ttl").MustDuration(0),
+		ServiceName:         "grafana-sso-settings",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create settings service client: %w", err)
+	}
+
+	if err := promRegister.Register(settingsService); err != nil {
+		var alreadyRegisteredErr prometheus.AlreadyRegisteredError
+		if !errors.As(err, &alreadyRegisteredErr) {
+			return nil, fmt.Errorf("failed to register settings service metrics: %w", err)
+		}
+	}
+
+	return settingsService, nil
+}

--- a/pkg/services/ssosettings/ssosettingsimpl/mtsettings_client.go
+++ b/pkg/services/ssosettings/ssosettingsimpl/mtsettings_client.go
@@ -1,16 +1,37 @@
 package ssosettingsimpl
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"strconv"
 
 	"github.com/grafana/authlib/authn"
 	"github.com/prometheus/client_golang/prometheus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/client-go/rest"
 
+	grafanarequest "github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
 	settingsvc "github.com/grafana/grafana/pkg/services/setting"
+	"github.com/grafana/grafana/pkg/services/ssosettings/strategies"
 	"github.com/grafana/grafana/pkg/setting"
 )
+
+// namespacedSettingsClient scopes every List to the instance's namespace.
+// Provider settings are instance-global, so the namespace comes from the
+// instance configuration rather than the caller's context: reload paths run
+// on background contexts that carry no namespace.
+type namespacedSettingsClient struct {
+	svc       settingsvc.Service
+	namespace string
+}
+
+var _ strategies.SettingsLister = (*namespacedSettingsClient)(nil)
+
+func (c *namespacedSettingsClient) List(ctx context.Context, selector metav1.LabelSelector) ([]*settingsvc.Setting, error) {
+	return c.svc.List(request.WithNamespace(ctx, c.namespace), selector)
+}
 
 // newMTSettingsClient initializes the MT-Settings client for the MT-Settings
 // fallback strategies. Expected configuration:
@@ -33,11 +54,23 @@ import (
 // the MT-Settings strategies are gated off by the ssoSettingsToMTSettings
 // feature toggle and fail loudly on read, so an absent client is only
 // reachable through an explicit misconfiguration.
-func newMTSettingsClient(cfg *setting.Cfg, promRegister prometheus.Registerer) (settingsvc.Service, error) {
+//
+// Mirrors setupSettingsService in pkg/services/frontend/settings_service.go —
+// keep the config keys in sync when either changes.
+func newMTSettingsClient(cfg *setting.Cfg, promRegister prometheus.Registerer) (strategies.SettingsLister, error) {
 	settingsSec := cfg.SectionWithEnvOverrides("settings_service")
 	settingsServiceURL := settingsSec.Key("url").String()
 	if settingsServiceURL == "" {
 		return nil, nil
+	}
+
+	// A malformed stack ID would otherwise be silently mapped to stacks-0 by
+	// the namespace mapper, pointing a credentialed cross-service client at
+	// the wrong tenant's settings — fail closed instead.
+	if cfg.StackID != "" {
+		if _, err := strconv.ParseInt(cfg.StackID, 10, 64); err != nil {
+			return nil, fmt.Errorf("stack_id %q is not numeric; refusing to derive a settings-service namespace from it", cfg.StackID)
+		}
 	}
 
 	tlsConfigSection := cfg.SectionWithEnvOverrides("tls_client_config")
@@ -84,5 +117,10 @@ func newMTSettingsClient(cfg *setting.Cfg, promRegister prometheus.Registerer) (
 		}
 	}
 
-	return settingsService, nil
+	// SSO settings are instance-global, so the org-1 namespace stands in for
+	// the whole instance; with a stack ID configured the mapper is constant.
+	return &namespacedSettingsClient{
+		svc:       settingsService,
+		namespace: grafanarequest.GetNamespaceMapper(cfg)(1),
+	}, nil
 }

--- a/pkg/services/ssosettings/ssosettingsimpl/mtsettings_client_test.go
+++ b/pkg/services/ssosettings/ssosettingsimpl/mtsettings_client_test.go
@@ -1,0 +1,159 @@
+package ssosettingsimpl
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/endpoints/request"
+
+	settingsvc "github.com/grafana/grafana/pkg/services/setting"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+type fakeSettingService struct {
+	settingsvc.Service
+	settings     []*settingsvc.Setting
+	err          error
+	gotNamespace string
+	gotSelector  metav1.LabelSelector
+}
+
+func (f *fakeSettingService) List(ctx context.Context, selector metav1.LabelSelector) ([]*settingsvc.Setting, error) {
+	f.gotNamespace = request.NamespaceValue(ctx)
+	f.gotSelector = selector
+	return f.settings, f.err
+}
+
+func TestNamespacedSettingsClient_List(t *testing.T) {
+	t.Run("stamps the configured namespace on the context", func(t *testing.T) {
+		svc := &fakeSettingService{}
+		client := &namespacedSettingsClient{svc: svc, namespace: "stacks-42"}
+
+		_, err := client.List(context.Background(), metav1.LabelSelector{})
+
+		require.NoError(t, err)
+		require.Equal(t, "stacks-42", svc.gotNamespace)
+	})
+
+	t.Run("passes the selector through and returns the results verbatim", func(t *testing.T) {
+		want := []*settingsvc.Setting{{Section: "auth.saml", Key: "enabled", Value: "true"}}
+		svc := &fakeSettingService{settings: want}
+		client := &namespacedSettingsClient{svc: svc, namespace: "stacks-42"}
+		selector := metav1.LabelSelector{MatchLabels: map[string]string{"section": "auth.saml"}}
+
+		got, err := client.List(context.Background(), selector)
+
+		require.NoError(t, err)
+		require.Equal(t, want, got)
+		require.Equal(t, selector, svc.gotSelector)
+	})
+
+	t.Run("propagates errors from the underlying service", func(t *testing.T) {
+		listErr := errors.New("settings service unavailable")
+		svc := &fakeSettingService{err: listErr}
+		client := &namespacedSettingsClient{svc: svc, namespace: "stacks-42"}
+
+		_, err := client.List(context.Background(), metav1.LabelSelector{})
+
+		require.ErrorIs(t, err, listErr)
+	})
+}
+
+func TestNewMTSettingsClient(t *testing.T) {
+	configuredCfg := func(t *testing.T) *setting.Cfg {
+		t.Helper()
+		cfg := setting.NewCfg()
+		_, err := cfg.Raw.Section("settings_service").NewKey("url", "http://localhost:6446")
+		require.NoError(t, err)
+		_, err = cfg.Raw.Section("grpc_client_authentication").NewKey("token", "test-token")
+		require.NoError(t, err)
+		_, err = cfg.Raw.Section("grpc_client_authentication").NewKey("token_exchange_url", "http://localhost:6481/sign/access-token")
+		require.NoError(t, err)
+		return cfg
+	}
+
+	t.Run("returns nil without error when not configured", func(t *testing.T) {
+		cfg := setting.NewCfg()
+
+		client, err := newMTSettingsClient(cfg, prometheus.NewRegistry())
+
+		require.NoError(t, err)
+		require.Nil(t, client)
+	})
+
+	t.Run("errors when the authentication token is missing", func(t *testing.T) {
+		cfg := setting.NewCfg()
+		_, err := cfg.Raw.Section("settings_service").NewKey("url", "http://localhost:6446")
+		require.NoError(t, err)
+
+		client, err := newMTSettingsClient(cfg, prometheus.NewRegistry())
+
+		require.ErrorContains(t, err, "grpc_client_authentication.token is required")
+		require.Nil(t, client)
+	})
+
+	t.Run("errors when the token exchange URL is missing", func(t *testing.T) {
+		cfg := setting.NewCfg()
+		_, err := cfg.Raw.Section("settings_service").NewKey("url", "http://localhost:6446")
+		require.NoError(t, err)
+		_, err = cfg.Raw.Section("grpc_client_authentication").NewKey("token", "test-token")
+		require.NoError(t, err)
+
+		client, err := newMTSettingsClient(cfg, prometheus.NewRegistry())
+
+		require.ErrorContains(t, err, "grpc_client_authentication.token_exchange_url is required")
+		require.Nil(t, client)
+	})
+
+	t.Run("errors on a non-numeric stack ID instead of deriving a wrong namespace", func(t *testing.T) {
+		cfg := configuredCfg(t)
+		cfg.StackID = "stacks-42"
+
+		client, err := newMTSettingsClient(cfg, prometheus.NewRegistry())
+
+		require.ErrorContains(t, err, "is not numeric")
+		require.Nil(t, client)
+	})
+
+	t.Run("builds a client scoped to the stack namespace", func(t *testing.T) {
+		cfg := configuredCfg(t)
+		cfg.StackID = "42"
+
+		client, err := newMTSettingsClient(cfg, prometheus.NewRegistry())
+
+		require.NoError(t, err)
+		require.NotNil(t, client)
+
+		namespaced, ok := client.(*namespacedSettingsClient)
+		require.True(t, ok)
+		require.Equal(t, "stacks-42", namespaced.namespace)
+	})
+
+	t.Run("falls back to the org-1 namespace without a stack ID", func(t *testing.T) {
+		cfg := configuredCfg(t)
+
+		client, err := newMTSettingsClient(cfg, prometheus.NewRegistry())
+
+		require.NoError(t, err)
+		require.NotNil(t, client)
+
+		namespaced, ok := client.(*namespacedSettingsClient)
+		require.True(t, ok)
+		require.Equal(t, "default", namespaced.namespace)
+	})
+
+	t.Run("tolerates re-registration of the client metrics", func(t *testing.T) {
+		registry := prometheus.NewRegistry()
+
+		_, err := newMTSettingsClient(configuredCfg(t), registry)
+		require.NoError(t, err)
+
+		client, err := newMTSettingsClient(configuredCfg(t), registry)
+		require.NoError(t, err)
+		require.NotNil(t, client)
+	})
+}

--- a/pkg/services/ssosettings/ssosettingsimpl/service.go
+++ b/pkg/services/ssosettings/ssosettingsimpl/service.go
@@ -59,7 +59,8 @@ func ProvideService(cfg *setting.Cfg, sqlStore db.DB, ac ac.AccessControl,
 
 	// ProvideService cannot return an error: a broken MT-Settings client
 	// configuration leaves the strategies without a client, and they fail
-	// loudly on read while the legacy path keeps serving at mode 0.
+	// loudly on read while the legacy strategies keep serving when the
+	// ssoSettingsToMTSettings toggle is off.
 	mtSettingsClient, err := newMTSettingsClient(cfg, registerer)
 	if err != nil {
 		logger.Error("Failed to initialize the MT-Settings client", "error", err)
@@ -94,7 +95,7 @@ func ProvideService(cfg *setting.Cfg, sqlStore db.DB, ac ac.AccessControl,
 	store := database.ProvideStore(sqlStore)
 
 	svc := &Service{
-		logger:                log.New("ssosettings.service"),
+		logger:                logger,
 		cfg:                   cfg,
 		store:                 store,
 		ac:                    ac,

--- a/pkg/services/ssosettings/ssosettingsimpl/service.go
+++ b/pkg/services/ssosettings/ssosettingsimpl/service.go
@@ -55,14 +55,24 @@ func ProvideService(cfg *setting.Cfg, sqlStore db.DB, ac ac.AccessControl,
 	usageStats usagestats.Service, registerer prometheus.Registerer,
 	settingsProvider setting.Provider, licensing licensing.Licensing,
 ) *Service {
+	logger := log.New("ssosettings.service")
+
+	// ProvideService cannot return an error: a broken MT-Settings client
+	// configuration leaves the strategies without a client, and they fail
+	// loudly on read while the legacy path keeps serving at mode 0.
+	mtSettingsClient, err := newMTSettingsClient(cfg, registerer)
+	if err != nil {
+		logger.Error("Failed to initialize the MT-Settings client", "error", err)
+	}
+
 	// Each provider family pairs an MT-Settings adapter with its legacy
 	// strategy. The adapter sits first: while the ssoSettingsToMTSettings
 	// feature toggle is enabled it wins the match for its family, otherwise
 	// it matches nothing and the legacy strategy behaves as before.
 	fbStrategies := []ssosettings.FallbackStrategy{
-		strategies.NewMTSettingsOAuthStrategy(),
+		strategies.NewMTSettingsOAuthStrategy(mtSettingsClient),
 		strategies.NewOAuthStrategy(cfg),
-		strategies.NewMTSettingsLDAPStrategy(),
+		strategies.NewMTSettingsLDAPStrategy(mtSettingsClient),
 		strategies.NewLDAPStrategy(cfg),
 	}
 
@@ -76,7 +86,7 @@ func ProvideService(cfg *setting.Cfg, sqlStore db.DB, ac ac.AccessControl,
 	configurableProviders[social.LDAPProviderName] = true
 
 	if licensing.FeatureEnabled(social.SAMLProviderName) {
-		fbStrategies = append(fbStrategies, strategies.NewMTSettingsSAMLStrategy(), strategies.NewSAMLStrategy(settingsProvider))
+		fbStrategies = append(fbStrategies, strategies.NewMTSettingsSAMLStrategy(mtSettingsClient), strategies.NewSAMLStrategy(settingsProvider))
 		providersList = append(providersList, social.SAMLProviderName)
 		configurableProviders[social.SAMLProviderName] = true
 	}

--- a/pkg/services/ssosettings/ssosettingsimpl/service.go
+++ b/pkg/services/ssosettings/ssosettingsimpl/service.go
@@ -11,11 +11,15 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/infra/usagestats"
 	"github.com/grafana/grafana/pkg/login/social"
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
@@ -31,6 +35,8 @@ import (
 )
 
 var _ ssosettings.Service = (*Service)(nil)
+
+var tracer = otel.Tracer("github.com/grafana/grafana/pkg/services/ssosettings/ssosettingsimpl")
 
 type Service struct {
 	logger           log.Logger
@@ -395,14 +401,19 @@ func (s *Service) RegisterFallbackStrategy(providerRegex string, strategy ssoset
 }
 
 func (s *Service) loadSettingsUsingFallbackStrategy(ctx context.Context, provider string) (*models.SSOSettings, error) {
+	ctx, span := tracer.Start(ctx, "ssosettings.Service.loadSettingsUsingFallbackStrategy",
+		trace.WithAttributes(attribute.String("provider", provider)))
+	defer span.End()
+
 	loadStrategy, ok := s.getFallbackStrategyFor(ctx, provider)
 	if !ok {
-		return nil, errors.New("no fallback strategy found for provider: " + provider)
+		return nil, tracing.Errorf(span, "no fallback strategy found for provider: %s", provider)
 	}
+	span.SetAttributes(attribute.String("strategy", fmt.Sprintf("%T", loadStrategy)))
 
 	settingsFromSystem, err := loadStrategy.GetProviderConfig(ctx, provider)
 	if err != nil {
-		return nil, err
+		return nil, tracing.Error(span, err)
 	}
 
 	return &models.SSOSettings{

--- a/pkg/services/ssosettings/strategies/mtsettings_strategy.go
+++ b/pkg/services/ssosettings/strategies/mtsettings_strategy.go
@@ -5,11 +5,19 @@ import (
 	"slices"
 
 	"github.com/open-feature/go-sdk/openfeature"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/grafana/grafana/pkg/login/social"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	settingsvc "github.com/grafana/grafana/pkg/services/setting"
 	"github.com/grafana/grafana/pkg/services/ssosettings"
 )
+
+// SettingsLister is the subset of the MT-Settings client the MT-Settings
+// strategies need to load provider settings.
+type SettingsLister interface {
+	List(ctx context.Context, selector metav1.LabelSelector) ([]*settingsvc.Setting, error)
+}
 
 // The MT-Settings strategies resolve provider settings from the MT-Settings
 // service. Each provider family has its own adapter, registered directly in
@@ -17,7 +25,8 @@ import (
 // feature toggle is enabled the adapter wins the match and fails loudly
 // instead of silently falling back to the legacy mechanism.
 type mtSettingsStrategy struct {
-	matches func(provider string) bool
+	settings SettingsLister
+	matches  func(provider string) bool
 }
 
 func (s *mtSettingsStrategy) IsMatch(ctx context.Context, provider string) bool {
@@ -36,8 +45,9 @@ type MTSettingsOAuthStrategy struct {
 
 var _ ssosettings.FallbackStrategy = (*MTSettingsOAuthStrategy)(nil)
 
-func NewMTSettingsOAuthStrategy() *MTSettingsOAuthStrategy {
+func NewMTSettingsOAuthStrategy(settings SettingsLister) *MTSettingsOAuthStrategy {
 	return &MTSettingsOAuthStrategy{mtSettingsStrategy{
+		settings: settings,
 		matches: func(provider string) bool {
 			return slices.Contains(ssosettings.AllOAuthProviders, provider)
 		},
@@ -50,8 +60,9 @@ type MTSettingsLDAPStrategy struct {
 
 var _ ssosettings.FallbackStrategy = (*MTSettingsLDAPStrategy)(nil)
 
-func NewMTSettingsLDAPStrategy() *MTSettingsLDAPStrategy {
+func NewMTSettingsLDAPStrategy(settings SettingsLister) *MTSettingsLDAPStrategy {
 	return &MTSettingsLDAPStrategy{mtSettingsStrategy{
+		settings: settings,
 		matches: func(provider string) bool {
 			return provider == social.LDAPProviderName
 		},
@@ -64,8 +75,9 @@ type MTSettingsSAMLStrategy struct {
 
 var _ ssosettings.FallbackStrategy = (*MTSettingsSAMLStrategy)(nil)
 
-func NewMTSettingsSAMLStrategy() *MTSettingsSAMLStrategy {
+func NewMTSettingsSAMLStrategy(settings SettingsLister) *MTSettingsSAMLStrategy {
 	return &MTSettingsSAMLStrategy{mtSettingsStrategy{
+		settings: settings,
 		matches: func(provider string) bool {
 			return provider == social.SAMLProviderName
 		},

--- a/pkg/services/ssosettings/strategies/mtsettings_strategy.go
+++ b/pkg/services/ssosettings/strategies/mtsettings_strategy.go
@@ -5,13 +5,19 @@ import (
 	"slices"
 
 	"github.com/open-feature/go-sdk/openfeature"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/login/social"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	settingsvc "github.com/grafana/grafana/pkg/services/setting"
 	"github.com/grafana/grafana/pkg/services/ssosettings"
 )
+
+var tracer = otel.Tracer("github.com/grafana/grafana/pkg/services/ssosettings/strategies")
 
 // SettingsLister is the subset of the MT-Settings client the MT-Settings
 // strategies need to load provider settings.
@@ -44,8 +50,12 @@ func (s *mtSettingsStrategy) IsMatch(ctx context.Context, provider string) bool 
 // rather than a fully-defaulted key set — the MT-Settings source layering is
 // expected to materialize defaults server-side.
 func (s *mtSettingsStrategy) GetProviderConfig(ctx context.Context, provider string) (map[string]any, error) {
+	ctx, span := tracer.Start(ctx, "mtSettingsStrategy.GetProviderConfig",
+		trace.WithAttributes(attribute.String("provider", provider)))
+	defer span.End()
+
 	if s.settings == nil {
-		return nil, ssosettings.ErrMTSettingsClientNotConfigured
+		return nil, tracing.Error(span, ssosettings.ErrMTSettingsClientNotConfigured)
 	}
 
 	selector := metav1.LabelSelector{MatchLabels: map[string]string{
@@ -53,13 +63,14 @@ func (s *mtSettingsStrategy) GetProviderConfig(ctx context.Context, provider str
 	}}
 	settings, err := s.settings.List(ctx, selector)
 	if err != nil {
-		return nil, err
+		return nil, tracing.Error(span, err)
 	}
 
 	result := make(map[string]any, len(settings))
 	for _, st := range settings {
 		result[st.Key] = st.Value
 	}
+	span.SetAttributes(attribute.Int("settings_count", len(result)))
 	return result, nil
 }
 

--- a/pkg/services/ssosettings/strategies/mtsettings_strategy.go
+++ b/pkg/services/ssosettings/strategies/mtsettings_strategy.go
@@ -35,8 +35,32 @@ func (s *mtSettingsStrategy) IsMatch(ctx context.Context, provider string) bool 
 	return enabled && s.matches(provider)
 }
 
-func (s *mtSettingsStrategy) GetProviderConfig(_ context.Context, _ string) (map[string]any, error) {
-	return nil, ssosettings.ErrMTSettingsNotImplemented
+// GetProviderConfig loads the provider's settings from the MT-Settings
+// service: the rows of the auth.<provider> section, keyed like the ini keys
+// the legacy strategies return. Source-layer precedence and decrypt-on-read
+// are handled by the MT-Settings server. Two deliberate divergences from the
+// legacy strategies: values are raw strings (consumers decode with weak
+// typing) rather than typed, and an absent section yields an empty map
+// rather than a fully-defaulted key set — the MT-Settings source layering is
+// expected to materialize defaults server-side.
+func (s *mtSettingsStrategy) GetProviderConfig(ctx context.Context, provider string) (map[string]any, error) {
+	if s.settings == nil {
+		return nil, ssosettings.ErrMTSettingsClientNotConfigured
+	}
+
+	selector := metav1.LabelSelector{MatchLabels: map[string]string{
+		"section": "auth." + provider,
+	}}
+	settings, err := s.settings.List(ctx, selector)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(map[string]any, len(settings))
+	for _, st := range settings {
+		result[st.Key] = st.Value
+	}
+	return result, nil
 }
 
 type MTSettingsOAuthStrategy struct {
@@ -60,13 +84,26 @@ type MTSettingsLDAPStrategy struct {
 
 var _ ssosettings.FallbackStrategy = (*MTSettingsLDAPStrategy)(nil)
 
+// NewMTSettingsLDAPStrategy never matches for now: LDAP's nested servers
+// configuration has no decided MT-Settings representation yet, so LDAP stays
+// on the legacy strategy even while the toggle is enabled. Matching with a
+// failing read would poison every provider — Service.List aborts on the
+// first fallback error and doReload stops reloading all providers.
 func NewMTSettingsLDAPStrategy(settings SettingsLister) *MTSettingsLDAPStrategy {
 	return &MTSettingsLDAPStrategy{mtSettingsStrategy{
 		settings: settings,
-		matches: func(provider string) bool {
-			return provider == social.LDAPProviderName
+		matches: func(_ string) bool {
+			return false
 		},
 	}}
+}
+
+// GetProviderConfig stays not-implemented for LDAP (unreachable while the
+// strategy never matches): its servers configuration is nested (servers[],
+// group mappings) and how it maps onto MT-Settings' flat section/key/value
+// model is not decided yet. The injected client is unused until then.
+func (s *MTSettingsLDAPStrategy) GetProviderConfig(_ context.Context, _ string) (map[string]any, error) {
+	return nil, ssosettings.ErrMTSettingsNotImplemented
 }
 
 type MTSettingsSAMLStrategy struct {

--- a/pkg/services/ssosettings/strategies/mtsettings_strategy_test.go
+++ b/pkg/services/ssosettings/strategies/mtsettings_strategy_test.go
@@ -2,18 +2,35 @@ package strategies
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/open-feature/go-sdk/openfeature"
 	"github.com/open-feature/go-sdk/openfeature/memprovider"
 	oftesting "github.com/open-feature/go-sdk/openfeature/testing"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/grafana/grafana/pkg/login/social"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	settingsvc "github.com/grafana/grafana/pkg/services/setting"
 	"github.com/grafana/grafana/pkg/services/ssosettings"
 	"github.com/grafana/grafana/pkg/setting"
 )
+
+type fakeSettingsLister struct {
+	settings    []*settingsvc.Setting
+	err         error
+	gotSelector metav1.LabelSelector
+}
+
+func (f *fakeSettingsLister) List(_ context.Context, selector metav1.LabelSelector) ([]*settingsvc.Setting, error) {
+	f.gotSelector = selector
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.settings, nil
+}
 
 var provider = oftesting.NewTestProvider()
 
@@ -63,32 +80,87 @@ func TestMTSettingsStrategies_IsMatch(t *testing.T) {
 			require.False(t, saml.IsMatch(t.Context(), p))
 		}
 
-		require.True(t, ldap.IsMatch(t.Context(), social.LDAPProviderName))
-		require.False(t, oauth.IsMatch(t.Context(), social.LDAPProviderName))
-		require.False(t, saml.IsMatch(t.Context(), social.LDAPProviderName))
-
 		require.True(t, saml.IsMatch(t.Context(), social.SAMLProviderName))
 		require.False(t, oauth.IsMatch(t.Context(), social.SAMLProviderName))
 		require.False(t, ldap.IsMatch(t.Context(), social.SAMLProviderName))
 	})
+
+	t.Run("the LDAP adapter matches nothing until its representation is decided", func(t *testing.T) {
+		provider.UsingFlags(t, toggleFlags(true))
+
+		ldap := NewMTSettingsLDAPStrategy(nil)
+
+		require.False(t, ldap.IsMatch(t.Context(), social.LDAPProviderName))
+	})
 }
 
 func TestMTSettingsStrategies_GetProviderConfig(t *testing.T) {
-	provider.UsingFlags(t, toggleFlags(true))
+	t.Run("returns the auth.<provider> section rows keyed like ini keys", func(t *testing.T) {
+		lister := &fakeSettingsLister{settings: []*settingsvc.Setting{
+			{Section: "auth.generic_oauth", Key: "enabled", Value: "true"},
+			{Section: "auth.generic_oauth", Key: "client_id", Value: "grafana-oauth"},
+			{Section: "auth.generic_oauth", Key: "auth_url", Value: "http://localhost:8087/auth"},
+		}}
 
-	testCases := []struct {
-		adapter  ssosettings.FallbackStrategy
-		provider string
-	}{
-		{NewMTSettingsOAuthStrategy(nil), social.GenericOAuthProviderName},
-		{NewMTSettingsLDAPStrategy(nil), social.LDAPProviderName},
-		{NewMTSettingsSAMLStrategy(nil), social.SAMLProviderName},
-	}
+		config, err := NewMTSettingsOAuthStrategy(lister).GetProviderConfig(context.Background(), social.GenericOAuthProviderName)
 
-	for _, tc := range testCases {
-		config, err := tc.adapter.GetProviderConfig(context.Background(), tc.provider)
+		require.NoError(t, err)
+		require.Equal(t, map[string]any{
+			"enabled":   "true",
+			"client_id": "grafana-oauth",
+			"auth_url":  "http://localhost:8087/auth",
+		}, config)
+		require.Equal(t, map[string]string{"section": "auth.generic_oauth"}, lister.gotSelector.MatchLabels)
+	})
+
+	t.Run("an absent section yields an empty map", func(t *testing.T) {
+		lister := &fakeSettingsLister{}
+
+		config, err := NewMTSettingsSAMLStrategy(lister).GetProviderConfig(context.Background(), social.SAMLProviderName)
+
+		require.NoError(t, err)
+		require.Empty(t, config)
+		require.NotNil(t, config)
+		require.Equal(t, map[string]string{"section": "auth.saml"}, lister.gotSelector.MatchLabels)
+	})
+
+	t.Run("the last row wins on duplicate keys", func(t *testing.T) {
+		lister := &fakeSettingsLister{settings: []*settingsvc.Setting{
+			{Section: "auth.generic_oauth", Key: "enabled", Value: "false"},
+			{Section: "auth.generic_oauth", Key: "enabled", Value: "true"},
+		}}
+
+		config, err := NewMTSettingsOAuthStrategy(lister).GetProviderConfig(context.Background(), social.GenericOAuthProviderName)
+
+		require.NoError(t, err)
+		require.Equal(t, map[string]any{"enabled": "true"}, config)
+	})
+
+	t.Run("a list error propagates to the caller", func(t *testing.T) {
+		listErr := errors.New("settings service unavailable")
+		lister := &fakeSettingsLister{err: listErr}
+
+		config, err := NewMTSettingsOAuthStrategy(lister).GetProviderConfig(context.Background(), social.GitHubProviderName)
+
+		require.Nil(t, config)
+		require.ErrorIs(t, err, listErr)
+	})
+
+	t.Run("a missing client fails loudly", func(t *testing.T) {
+		config, err := NewMTSettingsOAuthStrategy(nil).GetProviderConfig(context.Background(), social.GenericOAuthProviderName)
+
+		require.Nil(t, config)
+		require.ErrorIs(t, err, ssosettings.ErrMTSettingsClientNotConfigured)
+	})
+
+	t.Run("LDAP stays not-implemented until its representation is decided", func(t *testing.T) {
+		lister := &fakeSettingsLister{settings: []*settingsvc.Setting{
+			{Section: "auth.ldap", Key: "enabled", Value: "true"},
+		}}
+
+		config, err := NewMTSettingsLDAPStrategy(lister).GetProviderConfig(context.Background(), social.LDAPProviderName)
 
 		require.Nil(t, config)
 		require.ErrorIs(t, err, ssosettings.ErrMTSettingsNotImplemented)
-	}
+	})
 }

--- a/pkg/services/ssosettings/strategies/mtsettings_strategy_test.go
+++ b/pkg/services/ssosettings/strategies/mtsettings_strategy_test.go
@@ -36,9 +36,9 @@ func TestMTSettingsStrategies_IsMatch(t *testing.T) {
 		provider.UsingFlags(t, toggleFlags(false))
 
 		adapters := []ssosettings.FallbackStrategy{
-			NewMTSettingsOAuthStrategy(),
-			NewMTSettingsLDAPStrategy(),
-			NewMTSettingsSAMLStrategy(),
+			NewMTSettingsOAuthStrategy(nil),
+			NewMTSettingsLDAPStrategy(nil),
+			NewMTSettingsSAMLStrategy(nil),
 		}
 		providers := append([]string{}, ssosettings.AllOAuthProviders...)
 		providers = append(providers, social.LDAPProviderName, social.SAMLProviderName)
@@ -53,9 +53,9 @@ func TestMTSettingsStrategies_IsMatch(t *testing.T) {
 	t.Run("each adapter matches exactly its own family when the toggle is enabled", func(t *testing.T) {
 		provider.UsingFlags(t, toggleFlags(true))
 
-		oauth := NewMTSettingsOAuthStrategy()
-		ldap := NewMTSettingsLDAPStrategy()
-		saml := NewMTSettingsSAMLStrategy()
+		oauth := NewMTSettingsOAuthStrategy(nil)
+		ldap := NewMTSettingsLDAPStrategy(nil)
+		saml := NewMTSettingsSAMLStrategy(nil)
 
 		for _, p := range ssosettings.AllOAuthProviders {
 			require.True(t, oauth.IsMatch(t.Context(), p))
@@ -80,9 +80,9 @@ func TestMTSettingsStrategies_GetProviderConfig(t *testing.T) {
 		adapter  ssosettings.FallbackStrategy
 		provider string
 	}{
-		{NewMTSettingsOAuthStrategy(), social.GenericOAuthProviderName},
-		{NewMTSettingsLDAPStrategy(), social.LDAPProviderName},
-		{NewMTSettingsSAMLStrategy(), social.SAMLProviderName},
+		{NewMTSettingsOAuthStrategy(nil), social.GenericOAuthProviderName},
+		{NewMTSettingsLDAPStrategy(nil), social.LDAPProviderName},
+		{NewMTSettingsSAMLStrategy(nil), social.SAMLProviderName},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Adds the read pipe of the SSO settings migration ([Stage 2](https://github.com/grafana/identity-access-team/issues/2203)): behind the `grafana.ssoSettingsToMTSettings` toggle, the MT-Settings fallback strategies resolve provider config from the settings service (`setting.grafana.app`) instead of failing loudly. With the toggle off, nothing changes.

Fixes grafana/identity-access-team#2229

## What

Three commits, reviewable in order:

1. **Wire the MT-Settings client** — a `SettingsLister` seam on the strategies, and the client built inside `ProvideService` from `[settings_service]`/`[grpc_client_authentication]` config (nil when unconfigured). Deliberately no `ProvideService` signature change, so no enterprise wire regeneration is needed.
2. **Read provider config** — `GetProviderConfig` lists `section=auth.<provider>` rows through a namespace-stamping wrapper. The namespace derives from `stack_id` once at startup and a non-numeric value fails client construction (it would otherwise be silently mapped to `stacks-0` — the wrong tenant). Two documented divergences from the legacy strategies: values are raw strings (downstream decodes weakly), and absent sections yield an empty map — the server materializes the defaults.ini layer, verified live.
   - **LDAP**: its adapter matches nothing until the nested servers-config representation is decided; a matching-but-failing read would poison `Service.List` and `doReload` for every provider.
3. **Tracing** — `ssosettings.Service.loadSettingsUsingFallbackStrategy` records the provider and which strategy won the match (covers the legacy strategies too); `mtSettingsStrategy.GetProviderConfig` parents the settings-client spans. Background reload ticks emit root spans deliberately — reload visibility is the point.

## How to test

Validated end-to-end with a Keycloak login served entirely from MT-Settings (`[auth.generic_oauth]` absent from ini):

1. mt-tilt env (enterprise `devenv/mt-tilt`) with **Setting + Secrets** selected; `tilt up`.
2. Seed `auth.generic_oauth` rows (values from `devenv/docker/blocks/auth/oauth/readme.md`) via the settings API on `:6458`. `client_secret` is auto-classified by the mutator and stored as a SecureValue — the plaintext never reaches unified storage.
3. `custom.ini`: `[settings_service] url = https://localhost:6458`; `[tls_client_config] root_ca_file = <repo>/data/grafana-aggregator/ca.crt`; `[grpc_client_authentication]` token + exchange URL (tilt signer, `:6481`); `[environment] stack_id = 11`; `[feature_toggles] grafana.ssoSettingsToMTSettings = true` (full name — the `grafana.` prefix is part of the registered flag).
4. `make devenv sources=auth/oauth`, then `make run` → the Keycloak-OAuth button appears on the login page; login as `oauth-admin`/`grafana` succeeds, which exercises decrypt-on-read of `client_secret` through the whole pipe.
5. Toggle off → legacy ini behavior, unchanged (also covered by unit tests).

## Risks / notes

- **Tenant isolation (verified)**: namespace scoping is enforced at token-exchange time — wildcard (`*`) access tokens are only issued to system-level access policies, and per-stack policies can only obtain tokens for their own `stacks-{id}` namespace. The settings service can therefore trust the token's namespace claim; no cross-tenant exposure from this read path. This PR additionally keeps the client-side fail-closed StackID validation.
- **Cloud enablement dependency (outside this PR)**: the shared settings client (`pkg/services/setting`, not modified here) exchanges its token with `namespace: "*"`. Per-stack instance policies cannot obtain wildcard tokens, so in Cloud that exchange is rejected and reads fail closed until the client exchanges for the request's own namespace. Flagged to the owning squad as a prerequisite for enabling the toggle in Cloud. Local dev (system-scoped signer tokens) and on-prem are unaffected.
- String-typed values change the SSO settings admin API response shape when the toggle flips (e.g. `"enabled": "true"`); connectors decode weakly and this is validated by the live login.
- On-prem is unaffected: toggle off / no settings service configured keeps the legacy mechanism; if the toggle is forced without a client, reads fail loudly rather than silently falling back.

