### PR TITLE
Jaeger: Add to default bundled and preinstalled plugins

### DIFF
--- a/pkg/setting/setting_plugins.go
+++ b/pkg/setting/setting_plugins.go
@@ -44,6 +44,7 @@ var (
 		"opentsdb":                     {ID: "opentsdb"},
 		"stackdriver":                  {ID: "stackdriver"},
 		"mssql":                        {ID: "mssql"},
+		"jaeger":                       {ID: "jaeger"},
 		"grafana-advisor-app":          {ID: "grafana-advisor-app"},
 		"grafana-pyroscope-datasource": {ID: "grafana-pyroscope-datasource"},
 	}

--- a/scripts/catalog-plugins-defaults
+++ b/scripts/catalog-plugins-defaults
@@ -6,4 +6,5 @@ zipkin
 opentsdb
 stackdriver
 mssql
+jaeger
 grafana-pyroscope-datasource


### PR DESCRIPTION
**What is this feature?**

Add Jaeger datasource to the default plugin lists so on-prem and OSS users continue to have access to it after it is removed from core.
This is the on-prem preparation step before removing Jaeger datasource from core. With both core and bundled versions present, nightly builds can validate that the external plugin works correctly as a drop-in replacement.

**Why do we need this feature?**

To be able to remove Jaeger datasource from grafana/grafana 

**Who is this feature for?**

grafana developers

Reference PRs:
- https://github.com/grafana/grafana/pull/128405

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
