### PR TITLE
Search: derive search-field hashes from the manifest providers

### DIFF
--- a/pkg/storage/unified/resource/document.go
+++ b/pkg/storage/unified/resource/document.go
@@ -42,15 +42,6 @@ type DocumentBuilderInfo struct {
 	// Complicated builders (eg dashboards!) will be declared dynamically and managed by the ResourceServer
 	Namespaced NamespacedDocumentSupplier
 
-	// SearchFieldsHash is a stable hex hash over the SearchFieldDefinition
-	// slices registered for GroupResource across every version. The hash is
-	// stored in IndexBuildInfo when an index is built and re-checked
-	// whenever a rebuild is considered, so the index is rebuilt
-	// automatically when index-affecting search-field metadata changes.
-	//
-	// Empty when the builder does not use a SearchFieldsProvider.
-	SearchFieldsHash string
-
 	// SearchFieldsProvider is the manifest-driven source of truth for this
 	// builder's search fields. When non-nil, the bleve mapping for
 	// GroupResource is built from the provider's SearchFieldDefinition
@@ -74,21 +65,6 @@ func SearchableFieldsFromProvider(p SearchFieldsProvider, group, resource string
 		Resource: resource,
 	})
 	return NewSearchableDocumentFields(SearchFieldDefinitionsToTableColumns(sfds))
-}
-
-// SearchFieldsHashesForBuilders returns a (group, resource) map of
-// SearchFieldsHash values collected from the given DocumentBuilderInfo
-// entries. Empty hashes are skipped so consumers can use len(...) == 0 as a
-// shorthand for "no expected hash".
-func SearchFieldsHashesForBuilders(builders []DocumentBuilderInfo) map[LowerGroupResource]string {
-	out := map[LowerGroupResource]string{}
-	for _, b := range builders {
-		if b.SearchFieldsHash == "" {
-			continue
-		}
-		out[NewLowerGroupResource(b.GroupResource.Group, b.GroupResource.Resource)] = b.SearchFieldsHash
-	}
-	return out
 }
 
 type DocumentBuilderSupplier interface {

--- a/pkg/storage/unified/resource/search_field_manifest.go
+++ b/pkg/storage/unified/resource/search_field_manifest.go
@@ -140,3 +140,17 @@ func SearchFieldProviders(manifests []app.Manifest) (map[LowerGroupResource]Sear
 	}
 	return out, nil
 }
+
+// SearchFieldsHashesForProviders returns the per-kind index-affecting hash for
+// each provider in the map. Deriving the change-detection hashes from the same
+// providers that drive the mappings keeps the two in step, so an index rebuild
+// is triggered exactly when the fields that shape the mapping change.
+func SearchFieldsHashesForProviders(providers map[LowerGroupResource]SearchFieldsProvider) map[LowerGroupResource]string {
+	out := make(map[LowerGroupResource]string, len(providers))
+	for key, p := range providers {
+		if h := p.IndexAffectingHash(key.Group, key.Resource); h != "" {
+			out[key] = h
+		}
+	}
+	return out
+}

--- a/pkg/storage/unified/search/builders/dashboard.go
+++ b/pkg/storage/unified/search/builders/dashboard.go
@@ -79,7 +79,6 @@ func DashboardBuilder(namespaced resource.NamespacedDocumentSupplier) (resource.
 	return resource.DocumentBuilderInfo{
 		GroupResource:        gr,
 		Namespaced:           namespaced,
-		SearchFieldsHash:     provider.IndexAffectingHash(gr.Group, gr.Resource),
 		SearchFieldsProvider: provider,
 	}, nil
 }

--- a/pkg/storage/unified/search/builders/document.go
+++ b/pkg/storage/unified/search/builders/document.go
@@ -119,7 +119,6 @@ func iamBuilder(ri utils.ResourceInfo, searchFields []resource.SearchFieldDefini
 	return resource.DocumentBuilderInfo{
 		GroupResource:        gr,
 		Builder:              resource.StandardDocumentBuilderWithFields(iamManifests, provider),
-		SearchFieldsHash:     provider.IndexAffectingHash(gr.Group, gr.Resource),
 		SearchFieldsProvider: provider,
 	}, nil
 }

--- a/pkg/storage/unified/search/options.go
+++ b/pkg/storage/unified/search/options.go
@@ -86,23 +86,20 @@ func NewSearchOptions(
 			return resource.SearchOptions{}, err
 		}
 
-		// docs is optional in some tests; only consult it when present so the
-		// hash check is a no-op rather than a nil deref. Real callers always
-		// pass a non-nil supplier.
+		// docs is optional in some tests; only install the search-field mappings
+		// and their hashes when a real supplier is present. Both come from the app
+		// manifests, and the hashes are derived from the same providers that drive
+		// the mappings so the two always agree.
 		var searchFieldsHashes map[resource.LowerGroupResource]string
 		var searchFieldsProviders map[resource.LowerGroupResource]resource.SearchFieldsProvider
 		if docs != nil {
-			builders, err := docs.GetDocumentBuilders()
-			if err != nil {
-				return resource.SearchOptions{}, err
-			}
-			searchFieldsHashes = resource.SearchFieldsHashesForBuilders(builders)
 			// Search fields come from the app manifests: every in-tree kind that
 			// has custom search fields declares them in its CUE manifest.
 			searchFieldsProviders, err = resource.SearchFieldProviders(resource.AppManifests())
 			if err != nil {
 				return resource.SearchOptions{}, err
 			}
+			searchFieldsHashes = resource.SearchFieldsHashesForProviders(searchFieldsProviders)
 		}
 
 		bleve, err := NewBleveBackend(BleveOptions{


### PR DESCRIPTION
The per-kind hashes that trigger an index rebuild when search-field metadata changes were collected from the document builders, each of which computed the hash from its own provider. Compute them instead from the same manifest-backed providers that already drive the bleve mappings, via a new `SearchFieldsHashesForProviders`, so the rebuild hash and the mapping always come from one source.

This was not a no-op until recently: the user builder declared a custom `createdAt` search field that the manifest did not, so the builder-derived hash for users differed from the provider-derived one, and switching would have forced an unnecessary user-index reindex. That field was removed in #128481, so the two sources now produce identical hashes for every in-tree kind and there is no reindex.

This also removes the now-unused builder-side hash path: `SearchFieldsHashesForBuilders`, the `DocumentBuilderInfo.SearchFieldsHash` field, and the two builders that computed it.

Part of grafana/search-and-storage-team#827.
