### PR TITLE
Search: remove CopyFromStandard search-field support

### DIFF
--- a/pkg/storage/unified/resource/document.go
+++ b/pkg/storage/unified/resource/document.go
@@ -327,19 +327,6 @@ func (s *standardDocumentBuilder) extractDeclaredFields(_ context.Context, tmp *
 		return
 	}
 	for _, def := range defs {
-		if def.CopyFromStandard != StandardFieldUnknown {
-			if v, ok := standardFieldValue(doc, def.CopyFromStandard); ok {
-				if doc.Fields == nil {
-					doc.Fields = make(map[string]any)
-				}
-				doc.Fields[def.Name] = v
-			} else {
-				s.log.Warn("unknown CopyFromStandard target",
-					"group", gvr.Group, "version", gvr.Version, "resource", gvr.Resource,
-					"field", def.Name, "target", def.CopyFromStandard)
-			}
-			continue
-		}
 		if def.Path == "" {
 			continue
 		}
@@ -373,25 +360,6 @@ func (s *standardDocumentBuilder) extractDeclaredFields(_ context.Context, tmp *
 		}
 		doc.Fields[def.Name] = coerced
 	}
-}
-
-// standardFieldValue returns the value of a top-level IndexableDocument field
-// referenced by CopyFromStandard. The set of supported targets is closed and
-// matches the StandardField* constants in search_field.go.
-func standardFieldValue(doc *IndexableDocument, target StandardField) (any, bool) {
-	switch target {
-	case StandardFieldCreated:
-		return doc.Created, true
-	case StandardFieldUpdated:
-		return doc.Updated, true
-	case StandardFieldCreatedBy:
-		return doc.CreatedBy, true
-	case StandardFieldUpdatedBy:
-		return doc.UpdatedBy, true
-	case StandardFieldUnknown:
-		return nil, false
-	}
-	return nil, false
 }
 
 // zeroValueForFieldDefinition returns the type-appropriate zero value for a

--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -1538,9 +1538,8 @@ func shouldRebuildIndex(buildInfo IndexBuildInfo, minBuildVersion, maxBuildVersi
 	}
 
 	// Search-field metadata that affects what gets indexed (paths, types,
-	// capabilities, EmitZeroIfAbsent, CopyFromStandard) has changed since the
-	// index was built. Rebuild so documents are re-extracted with the new
-	// declarations.
+	// capabilities, EmitZeroIfAbsent) has changed since the index was built.
+	// Rebuild so documents are re-extracted with the new declarations.
 	//
 	// An empty expected hash means "no opinion" for this kind: either no
 	// SearchFieldsProvider is registered today, or the running binary doesn't

--- a/pkg/storage/unified/resource/search_field.go
+++ b/pkg/storage/unified/resource/search_field.go
@@ -106,37 +106,7 @@ type SearchFieldDefinition struct {
 	// indexed document. Set this when sort or range queries depend on every
 	// document having the field present.
 	EmitZeroIfAbsent bool
-
-	// CopyFromStandard copies a value from one of the IndexableDocument's
-	// standard top-level fields into doc.Fields[Name]. Used to expose a
-	// standard field (e.g. Created) under a resource-specific name in the
-	// per-kind fields.* sub-document, because some top-level fields lack a
-	// bleve FieldMapping and are otherwise unindexed / unretrievable.
-	//
-	// Mutually exclusive with Path: when CopyFromStandard is set, the
-	// extractor reads from the already-built IndexableDocument instead of
-	// from the raw JSON.
-	//
-	// This is a workaround for the current top-level mapping asymmetry.
-	// A planned follow-up promotes Created, Updated and similar fields to
-	// StandardSearchFieldDefinitions with their own top-level
-	// FieldMappings; once that lands, kinds can read those fields directly
-	// and the CopyFromStandard mirror becomes redundant.
-	CopyFromStandard StandardField
 }
-
-// StandardField identifies a top-level field of IndexableDocument that
-// CopyFromStandard can mirror into doc.Fields. The set is intentionally
-// closed; adding a new value requires extending the switch in document.go.
-type StandardField string
-
-const (
-	StandardFieldUnknown   StandardField = ""
-	StandardFieldCreated   StandardField = "Created"
-	StandardFieldUpdated   StandardField = "Updated"
-	StandardFieldCreatedBy StandardField = "CreatedBy"
-	StandardFieldUpdatedBy StandardField = "UpdatedBy"
-)
 
 // HasCapability reports whether the field declares the given capability.
 func (f SearchFieldDefinition) HasCapability(c SearchCapability) bool {
@@ -217,8 +187,8 @@ type SearchFieldsProvider interface {
 	// (group, resource), all declarations must agree on Type, Array, and
 	// Capabilities — the attributes that feed into the kind's bleve
 	// mapping. NewMapProvider rejects diverging declarations at
-	// construction time. Path, EmitZeroIfAbsent, CopyFromStandard, and
-	// Description may differ across versions: they are extractor- or
+	// construction time. Path, EmitZeroIfAbsent, and Description may
+	// differ across versions: they are extractor- or
 	// presentation-side and the extractor applies them per-document with
 	// the document's own version's declaration. The returned slice is
 	// owned by the provider; do not mutate it.
@@ -233,7 +203,7 @@ type SearchFieldsProvider interface {
 	// shared StandardSearchFieldDefinitions and every per-(group, resource)
 	// SearchFieldDefinition across all registered versions. Only fields
 	// that change what gets indexed contribute: Name, Path, Type, Array,
-	// Capabilities (sorted), EmitZeroIfAbsent, CopyFromStandard.
+	// Capabilities (sorted), and EmitZeroIfAbsent.
 	// Description is intentionally excluded so presentation-only edits do
 	// not trigger a rebuild.
 	//
@@ -296,8 +266,8 @@ func newMapProvider(fields map[schema.GroupVersionResource][]SearchFieldDefiniti
 // SearchFieldDefinition used for cross-version equality. Only Type, Array,
 // and Capabilities count: those are what GetBleveMappings reads to produce
 // the kind's mapping, which is built once per (group, resource) from the
-// union across versions. Path, EmitZeroIfAbsent, and CopyFromStandard are
-// extractor-side concerns applied per-document with the document's own
+// union across versions. Path and EmitZeroIfAbsent are extractor-side
+// concerns applied per-document with the document's own
 // version's declaration, so they may legitimately differ between versions.
 // Description is presentation-only.
 //
@@ -351,7 +321,7 @@ func diffMappingAttributes(a, b mappingAttributes) []string {
 // first.
 //
 // A field declared by only one version is fine: union without conflict.
-// Path, EmitZeroIfAbsent, CopyFromStandard, and Description may differ
+// Path, EmitZeroIfAbsent, and Description may differ
 // across versions: they do not feed into the mapping and the extractor
 // applies them per-document with the document's own version's declaration.
 func validateCrossVersionConsistency(fields map[schema.GroupVersionResource][]SearchFieldDefinition) error {
@@ -503,7 +473,6 @@ type hashableField struct {
 	Array            bool               `json:"a,omitempty"`
 	Capabilities     []SearchCapability `json:"c,omitempty"`
 	EmitZeroIfAbsent bool               `json:"z,omitempty"`
-	CopyFromStandard StandardField      `json:"s,omitempty"`
 }
 
 type hashableVersion struct {
@@ -535,7 +504,6 @@ func canonicalHashableFields(sfds []SearchFieldDefinition) []hashableField {
 			Array:            sfd.Array,
 			Capabilities:     caps,
 			EmitZeroIfAbsent: sfd.EmitZeroIfAbsent,
-			CopyFromStandard: sfd.CopyFromStandard,
 		})
 	}
 	slices.SortFunc(fields, func(a, b hashableField) int {

--- a/pkg/storage/unified/resource/search_field_manifest.go
+++ b/pkg/storage/unified/resource/search_field_manifest.go
@@ -13,9 +13,6 @@ import (
 // same map-backed provider NewMapProvider produces, so the per-field and
 // cross-version consistency checks apply here too.
 //
-// CopyFromStandard has no manifest counterpart and is never set from a
-// manifest. A kind that needs it keeps a builder-side provider instead.
-//
 // Panics on an invalid declaration, like NewMapProvider. Runtime callers use
 // newManifestBackedProvider instead.
 func NewManifestBackedProvider(manifests []app.Manifest) SearchFieldsProvider {

--- a/pkg/storage/unified/resource/search_field_test.go
+++ b/pkg/storage/unified/resource/search_field_test.go
@@ -155,7 +155,6 @@ func TestMapProvider_IndexAffectingHash(t *testing.T) {
 			"Array":            func(s *SearchFieldDefinition) { s.Array = true },
 			"Capabilities":     func(s *SearchFieldDefinition) { s.Capabilities = []SearchCapability{SearchCapabilityRetrieve} },
 			"EmitZeroIfAbsent": func(s *SearchFieldDefinition) { s.EmitZeroIfAbsent = true },
-			"CopyFromStandard": func(s *SearchFieldDefinition) { s.CopyFromStandard = StandardFieldCreated },
 		}
 		for name, mutate := range cases {
 			t.Run(name, func(t *testing.T) {
@@ -225,7 +224,7 @@ func TestMapProvider_IndexAffectingHash_GoldenHash(t *testing.T) {
 		v0: {
 			{Name: "email", Path: "spec.email", Type: SearchFieldTypeString, Capabilities: []SearchCapability{SearchCapabilityFilter, SearchCapabilityRetrieve}},
 			{Name: "disabled", Path: "spec.disabled", Type: SearchFieldTypeBoolean, Capabilities: []SearchCapability{SearchCapabilityRetrieve}, EmitZeroIfAbsent: true},
-			{Name: "createdAt", Type: SearchFieldTypeInt64, Capabilities: []SearchCapability{SearchCapabilityFilter, SearchCapabilityRetrieve}, CopyFromStandard: StandardFieldCreated},
+			{Name: "createdAt", Path: "spec.createdAt", Type: SearchFieldTypeInt64, Capabilities: []SearchCapability{SearchCapabilityFilter, SearchCapabilityRetrieve}},
 			{Name: "members", Path: "spec.members[*].name", Type: SearchFieldTypeString, Array: true, Capabilities: []SearchCapability{SearchCapabilityFilter, SearchCapabilityRetrieve}},
 		},
 		v1: {
@@ -234,7 +233,7 @@ func TestMapProvider_IndexAffectingHash_GoldenHash(t *testing.T) {
 	}, nil)
 
 	// The standard name field has sort capability so Bleve can use it as a stable pagination tie-breaker.
-	const expected = "c4587931c884566e46c37eb573565b9b0d7246aeef6d7b7e3bf95d5aac24ca01"
+	const expected = "3484142f1ce8094a4659bb0275fe91e4d68f0ce6fa1ed24a17dd81615a8a76d1"
 	assert.Equal(t, expected, p.IndexAffectingHash(group, resource),
 		"canonical hash drifted. If json.Marshal output changed (Go release), update the literal; otherwise a code change shifted the canonical form.")
 }
@@ -396,14 +395,6 @@ func TestValidateCrossVersionConsistency(t *testing.T) {
 		err := validateCrossVersionConsistency(map[schema.GroupVersionResource][]SearchFieldDefinition{
 			v1: {{Name: "count", Type: SearchFieldTypeInt64, Capabilities: []SearchCapability{SearchCapabilityFilter}, EmitZeroIfAbsent: true}},
 			v2: {{Name: "count", Type: SearchFieldTypeInt64, Capabilities: []SearchCapability{SearchCapabilityFilter}}},
-		})
-		require.NoError(t, err)
-	})
-
-	t.Run("copyFromStandard differing across versions is allowed", func(t *testing.T) {
-		err := validateCrossVersionConsistency(map[schema.GroupVersionResource][]SearchFieldDefinition{
-			v1: {{Name: "created", Type: SearchFieldTypeInt64, Capabilities: []SearchCapability{SearchCapabilityRetrieve}, CopyFromStandard: StandardFieldCreated}},
-			v2: {{Name: "created", Type: SearchFieldTypeInt64, Capabilities: []SearchCapability{SearchCapabilityRetrieve}}},
 		})
 		require.NoError(t, err)
 	})


### PR DESCRIPTION
`CopyFromStandard` let a declared search field mirror a standard document field (e.g. `Created`) into the per-kind `fields` sub-document, as a workaround for standard fields that had no bleve mapping of their own. Its only user was the user `createdAt` field, which was removed in #128481, so the mechanism is now dead. This removes it entirely: the `SearchFieldDefinition.CopyFromStandard` field, the `StandardField` type and constants, the document-extraction branch and its `standardFieldValue` helper, and the hashable-form entry.

Removing it changes no production hash and triggers no reindex: nothing sets `CopyFromStandard` anymore, and it was serialised with `omitempty`, so it was already absent from every computed hash. The only hash that moves is a synthetic fixture in a unit test, updated here.

Part of grafana/search-and-storage-team#827.
