### PR TITLE
authz: Require uid in k8s formatted datasource scopes

### DIFF
--- a/pkg/registry/apis/iam/datasourcek8s/k8s.go
+++ b/pkg/registry/apis/iam/datasourcek8s/k8s.go
@@ -23,9 +23,13 @@ func DSTypeFromDatasourceAPIGroup(group string) string {
 }
 
 // LegacyUIDScopeToK8s builds a k8s-style datasource resource scope from the suffix of
-// legacy scope "datasources:uid:<uid>"
+// legacy scope "datasources:uid:<uid>". Wildcard ("*") stays as "datasources:*";
+// concrete UIDs use the "datasources:uid:<uid>" form.
 func LegacyUIDScopeToK8s(dsType, uid string) string {
-	return K8sDatasourceAPIGroup(dsType) + "/datasources:" + uid
+	if uid == "*" {
+		return K8sDatasourceAPIGroup(dsType) + "/datasources:*"
+	}
+	return K8sDatasourceAPIGroup(dsType) + "/datasources:uid:" + uid
 }
 
 // LegacyVerbToK8sAction maps the substring after legacy prefix "datasources:" to a Kubernetes API action.

--- a/pkg/registry/apis/iam/datasourcek8s/k8s_test.go
+++ b/pkg/registry/apis/iam/datasourcek8s/k8s_test.go
@@ -12,7 +12,7 @@ func TestK8sDatasourceAPIGroup(t *testing.T) {
 }
 
 func TestLegacyUIDScopeToK8s(t *testing.T) {
-	assert.Equal(t, "loki.datasource.grafana.app/datasources:abc", LegacyUIDScopeToK8s("loki", "abc"))
+	assert.Equal(t, "loki.datasource.grafana.app/datasources:uid:abc", LegacyUIDScopeToK8s("loki", "abc"))
 	assert.Equal(t, "*.datasource.grafana.app/datasources:*", LegacyUIDScopeToK8s("*", "*"))
 }
 
@@ -36,7 +36,7 @@ func TestLegacyDatasourceScopeAndActionToK8s(t *testing.T) {
 	assert.Equal(t, "datasources:read", action)
 
 	scope, action = LegacyDatasourceScopeAndActionToK8s("loki", "datasources:uid:abc", "datasources:read")
-	assert.Equal(t, "loki.datasource.grafana.app/datasources:abc", scope)
+	assert.Equal(t, "loki.datasource.grafana.app/datasources:uid:abc", scope)
 	assert.Equal(t, "loki.datasource.grafana.app/datasources:get", action)
 
 	scope, action = LegacyDatasourceScopeAndActionToK8s("*", "datasources:*", "datasources.permissions:write")

--- a/pkg/registry/apis/iam/datasourcek8s/legacy.go
+++ b/pkg/registry/apis/iam/datasourcek8s/legacy.go
@@ -39,19 +39,29 @@ func K8sDSActionToLegacy(action string) (string, bool) {
 	}
 }
 
-// DSUIDScopeToLegacy converts a k8s datasource instance scope to legacy datasources:uid:
+// K8sDSUIDScopeToLegacy converts a k8s datasource instance scope to legacy datasources:uid:
 // and returns the datasource type (e.g. "loki", or "*" for wildcard groups).
+// e.g. "loki.datasource.grafana.app/datasources:uid:abc" → "datasources:uid:abc", "loki"
+// e.g. "loki.datasource.grafana.app/datasources:*" → "datasources:*", "loki"
+// e.g. "loki.datasource.grafana.app/datasources:uid:*" → "datasources:uid:*", "loki"
 func K8sDSUIDScopeToLegacy(scope string) (legacyScope, dsType string, ok bool) {
 	group, resourceUID, ok := strings.Cut(scope, "/")
 	if !ok {
 		return "", "", false
 	}
-	resource, uid, ok := strings.Cut(resourceUID, ":")
-	if !ok || resource != "datasources" || uid == "" {
+	resource, rest, ok := strings.Cut(resourceUID, ":")
+	if !ok || resource != "datasources" || rest == "" {
 		return "", "", false
 	}
 	dsType, ok = strings.CutSuffix(group, K8sDatasourceAPIGroupSuffix)
 	if !ok || dsType == "" {
+		return "", "", false
+	}
+	if rest == "*" {
+		return "datasources:*", dsType, true
+	}
+	uid, ok := strings.CutPrefix(rest, "uid:")
+	if !ok || uid == "" {
 		return "", "", false
 	}
 	return "datasources:uid:" + uid, dsType, true

--- a/pkg/registry/apis/iam/datasourcek8s/legacy_test.go
+++ b/pkg/registry/apis/iam/datasourcek8s/legacy_test.go
@@ -102,13 +102,23 @@ func TestK8sDSActionToLegacy(t *testing.T) {
 }
 
 func TestK8sDSUIDScopeToLegacy(t *testing.T) {
-	scope, dsType, ok := K8sDSUIDScopeToLegacy("loki.datasource.grafana.app/datasources:abc")
+	scope, dsType, ok := K8sDSUIDScopeToLegacy("loki.datasource.grafana.app/datasources:uid:abc")
 	require.True(t, ok)
 	require.Equal(t, "datasources:uid:abc", scope)
 	require.Equal(t, "loki", dsType)
 
 	scope, dsType, ok = K8sDSUIDScopeToLegacy("*.datasource.grafana.app/datasources:*")
 	require.True(t, ok)
-	require.Equal(t, "datasources:uid:*", scope)
+	require.Equal(t, "datasources:*", scope)
 	require.Equal(t, "*", dsType)
+
+	scope, dsType, ok = K8sDSUIDScopeToLegacy("loki.datasource.grafana.app/datasources:uid:*")
+	require.True(t, ok)
+	require.Equal(t, "datasources:uid:*", scope)
+	require.Equal(t, "loki", dsType)
+
+	// old short form (no uid: attribute) is no longer accepted — rejected by admission
+	// validation (validatePermissionScopes), so this must not parse.
+	_, _, ok = K8sDSUIDScopeToLegacy("loki.datasource.grafana.app/datasources:abc")
+	require.False(t, ok)
 }


### PR DESCRIPTION
This PR adds `:uid:` to k8s-style datasource instance scopes

**Format rule**

- Instance scope (UID specified): `{group}/datasources:uid:{uid}` — e.g. `loki.datasource.grafana.app/datasources:uid:abc`
- Wildcard scope: `{group}/datasources:*` — unchanged, no attribute segment

**Why**

This matches the `kind:attribute:identifier` grammar used by every other k8s-style scope: `k8sNativeMapping.Scope()` produces `{group}/{resource}:uid:{name}` ([pkg/services/authz/rbac/k8s_native_mapping.go](pkg/services/authz/rbac/k8s_native_mapping.go)), the resource-permissions service in `K8sActionFormat` mode produces, and `accesscontrol.SplitScope` parses 3-segment scopes as `kind:attribute:identifier`.
