### PR TITLE
Dashboards: process section variables during export/import

### DIFF
--- a/public/app/features/dashboard-scene/scene/export/exporters.test.ts
+++ b/public/app/features/dashboard-scene/scene/export/exporters.test.ts
@@ -922,6 +922,205 @@ describe('dashboard exporter v2', () => {
     // Restore console.error
     consoleSpy.mockRestore();
   });
+
+  describe('section variables', () => {
+    const makeSectionQueryVariable = (name: string, datasourceUid: string): QueryVariableKind => ({
+      kind: 'QueryVariable',
+      spec: {
+        name,
+        query: {
+          kind: 'DataQuery',
+          version: 'v0',
+          group: 'prometheus',
+          datasource: { name: datasourceUid },
+          spec: { expr: 'up' },
+        },
+        current: { text: 'a', value: 'a' },
+        options: [{ text: 'a', value: 'a' }],
+        hide: 'dontHide',
+        skipUrlSync: false,
+        multi: false,
+        includeAll: false,
+        allowCustomValue: false,
+        regex: '',
+        refresh: 'never',
+        sort: 'disabled',
+      },
+    });
+
+    const makeSectionDatasourceVariable = (name: string): DatasourceVariableKind => ({
+      kind: 'DatasourceVariable',
+      spec: {
+        name,
+        pluginId: 'prometheus',
+        current: { text: 'Production Prometheus', value: 'datasource1' },
+        options: [],
+        hide: 'dontHide',
+        skipUrlSync: false,
+        multi: false,
+        includeAll: false,
+        allowCustomValue: false,
+        refresh: 'never',
+        regex: '',
+      },
+    });
+
+    it('processes row QueryVariable and DatasourceVariable', async () => {
+      const schemaCopy = JSON.parse(JSON.stringify(handyTestingSchema));
+      schemaCopy.layout = {
+        kind: 'RowsLayout',
+        spec: {
+          rows: [
+            {
+              kind: 'RowsLayoutRow',
+              spec: {
+                title: 'Row 1',
+                layout: { kind: 'GridLayout', spec: { items: [] } },
+                variables: [
+                  makeSectionQueryVariable('rowQuery', 'datasource1'),
+                  makeSectionDatasourceVariable('rowDsVar'),
+                ],
+              },
+            },
+          ],
+        },
+      };
+
+      const dashboard = await makeExportableV2(schemaCopy);
+      if (typeof dashboard === 'object' && 'error' in dashboard) {
+        throw dashboard.error;
+      }
+
+      expect(dashboard.layout.kind).toBe('RowsLayout');
+      if (dashboard.layout.kind !== 'RowsLayout') {
+        return;
+      }
+      const sectionVars = dashboard.layout.spec.rows[0].spec.variables ?? [];
+      const queryVar = sectionVars.find((v) => v.kind === 'QueryVariable') as QueryVariableKind;
+      const dsVar = sectionVars.find((v) => v.kind === 'DatasourceVariable') as DatasourceVariableKind;
+
+      expect(queryVar.spec.query.datasource?.name).toBeUndefined();
+      expect(queryVar.spec.query.labels?.[ExportLabel]).toBeDefined();
+      expect(queryVar.spec.current).toEqual({ text: '', value: '' });
+      expect(queryVar.spec.options).toEqual([]);
+      expect(dsVar.spec.current).toEqual({ text: '', value: '' });
+    });
+
+    it('processes nested tab QueryVariable', async () => {
+      const schemaCopy = JSON.parse(JSON.stringify(handyTestingSchema));
+      schemaCopy.layout = {
+        kind: 'TabsLayout',
+        spec: {
+          tabs: [
+            {
+              kind: 'TabsLayoutTab',
+              spec: {
+                title: 'Tab 1',
+                layout: {
+                  kind: 'RowsLayout',
+                  spec: {
+                    rows: [
+                      {
+                        kind: 'RowsLayoutRow',
+                        spec: {
+                          title: 'Nested row',
+                          layout: { kind: 'GridLayout', spec: { items: [] } },
+                          variables: [makeSectionQueryVariable('nestedQuery', 'datasource2')],
+                        },
+                      },
+                    ],
+                  },
+                },
+                variables: [makeSectionQueryVariable('tabQuery', 'datasource1')],
+              },
+            },
+          ],
+        },
+      };
+
+      const dashboard = await makeExportableV2(schemaCopy);
+      if (typeof dashboard === 'object' && 'error' in dashboard) {
+        throw dashboard.error;
+      }
+
+      expect(dashboard.layout.kind).toBe('TabsLayout');
+      if (dashboard.layout.kind !== 'TabsLayout') {
+        return;
+      }
+      const tabVars = dashboard.layout.spec.tabs[0].spec.variables ?? [];
+      const tabQuery = tabVars[0] as QueryVariableKind;
+      expect(tabQuery.spec.query.datasource?.name).toBeUndefined();
+      expect(tabQuery.spec.query.labels?.[ExportLabel]).toBeDefined();
+
+      const nestedRows = dashboard.layout.spec.tabs[0].spec.layout;
+      expect(nestedRows.kind).toBe('RowsLayout');
+      if (nestedRows.kind !== 'RowsLayout') {
+        return;
+      }
+      const nestedQuery = nestedRows.spec.rows[0].spec.variables?.[0] as QueryVariableKind;
+      expect(nestedQuery.spec.query.datasource?.name).toBeUndefined();
+      expect(nestedQuery.spec.query.labels?.[ExportLabel]).toBeDefined();
+    });
+
+    it('keeps panel datasource ref when it uses a section DatasourceVariable', async () => {
+      const schemaCopy = JSON.parse(JSON.stringify(handyTestingSchema));
+      // Remove top-level datasourceVar so the panel only matches the section-scoped one
+      schemaCopy.variables = schemaCopy.variables.filter(
+        (v: { kind: string; spec: { name: string } }) =>
+          !(v.kind === 'DatasourceVariable' && v.spec.name === 'datasourceVar')
+      );
+      schemaCopy.layout = {
+        kind: 'RowsLayout',
+        spec: {
+          rows: [
+            {
+              kind: 'RowsLayoutRow',
+              spec: {
+                title: 'Row 1',
+                layout: { kind: 'GridLayout', spec: { items: [] } },
+                variables: [makeSectionDatasourceVariable('sectionDs')],
+              },
+            },
+          ],
+        },
+      };
+      schemaCopy.elements['panel-using-section-ds'] = {
+        kind: 'Panel',
+        spec: {
+          data: {
+            kind: 'QueryGroup',
+            spec: {
+              queries: [
+                {
+                  kind: 'PanelQuery',
+                  spec: {
+                    hidden: false,
+                    query: {
+                      datasource: { name: '${sectionDs}' },
+                      group: 'prometheus',
+                      spec: { expr: 'up' },
+                    },
+                    refId: 'A',
+                  },
+                },
+              ],
+            },
+          },
+        },
+      };
+
+      const dashboard = await makeExportableV2(schemaCopy);
+      if (typeof dashboard === 'object' && 'error' in dashboard) {
+        throw dashboard.error;
+      }
+
+      const panel = dashboard.elements['panel-using-section-ds'];
+      if (panel.kind !== 'Panel') {
+        throw new Error('Panel should be a Panel');
+      }
+      expect(panel.spec.data.spec.queries[0].spec.query.datasource?.name).toBe('${sectionDs}');
+    });
+  });
 });
 
 function getStubInstanceSettings(v: string | DataSourceRef): DataSourceInstanceSettings {

--- a/public/app/features/dashboard-scene/scene/export/exporters.test.ts
+++ b/public/app/features/dashboard-scene/scene/export/exporters.test.ts
@@ -753,18 +753,26 @@ describe('dashboard exporter v2', () => {
     ) as QueryVariableKind;
     expect(queryVariable.spec.query.labels?.[ExportLabel]).toBe('prometheus-1');
 
+    // panel-using-datasource-var keeps $datasourceVar but is also labeled (prometheus-2)
+    // when the variable's current UID differs from other prometheus datasources.
+    const dsVarPanel = dashboard.elements['panel-using-datasource-var'];
+    if (dsVarPanel.kind !== 'Panel') {
+      throw new Error('Panel should be a Panel');
+    }
+    expect(dsVarPanel.spec.data.spec.queries[0].spec.query.labels?.[ExportLabel]).toBe('prometheus-2');
+
     const groupByVariable = dashboard.variables.find(
       (variable) => variable.kind === 'GroupByVariable'
     ) as GroupByVariableKind;
-    expect(groupByVariable.labels?.[ExportLabel]).toBe('prometheus-2');
+    expect(groupByVariable.labels?.[ExportLabel]).toBe('prometheus-3');
 
     const adhocVariable = dashboard.variables.find(
       (variable) => variable.kind === 'AdhocVariable'
     ) as AdhocVariableKind;
-    expect(adhocVariable.labels?.[ExportLabel]).toBe('prometheus-3');
+    expect(adhocVariable.labels?.[ExportLabel]).toBe('prometheus-4');
 
     const annotationQuery = dashboard.annotations[0];
-    expect(annotationQuery.spec.query.labels?.[ExportLabel]).toBe('prometheus-4');
+    expect(annotationQuery.spec.query.labels?.[ExportLabel]).toBe('prometheus-5');
   });
 
   it('should assign the original datasource name as an export label during export', async () => {
@@ -805,6 +813,7 @@ describe('dashboard exporter v2', () => {
     }
     expect(panel.spec.data.spec.queries[0].spec.query.datasource?.name).toBe('${datasourceVar}');
     expect(panel.spec.data.spec.queries[0].spec.query.group).toBe('prometheus');
+    expect(panel.spec.data.spec.queries[0].spec.query.labels?.[ExportLabel]).toBeDefined();
   });
 
   it('should convert library panels to inline panels when sharing externally', async () => {
@@ -1118,7 +1127,10 @@ describe('dashboard exporter v2', () => {
       if (panel.kind !== 'Panel') {
         throw new Error('Panel should be a Panel');
       }
-      expect(panel.spec.data.spec.queries[0].spec.query.datasource?.name).toBe('${sectionDs}');
+      const query = panel.spec.data.spec.queries[0].spec.query;
+      // Keep $var ref, but attach export labels so external import can show a picker.
+      expect(query.datasource?.name).toBe('${sectionDs}');
+      expect(query.labels?.[ExportLabel]).toBeDefined();
     });
   });
 });

--- a/public/app/features/dashboard-scene/scene/export/exporters.ts
+++ b/public/app/features/dashboard-scene/scene/export/exporters.ts
@@ -19,6 +19,7 @@ import { notifyApp } from 'app/core/reducers/appNotification';
 import { buildPanelKind } from 'app/features/dashboard/api/ResponseTransformers';
 import { type DashboardModel } from 'app/features/dashboard/state/DashboardModel';
 import { type PanelModel, type GridPos } from 'app/features/dashboard/state/PanelModel';
+import { visitDashboardLayoutSections } from 'app/features/dashboard/utils/visitDashboardLayoutSections';
 import { getLibraryPanel } from 'app/features/library-panels/state/api';
 import { variableRegexExec } from 'app/features/variables/utils';
 import { dispatch } from 'app/store/store';
@@ -425,8 +426,21 @@ async function convertLibraryPanelToInlinePanel(libraryPanelElement: LibraryPane
 export async function makeExportableV2(dashboard: DashboardV2Spec, isSharingExternally = false) {
   const dataQueryLabels: { [key: string]: Map<string, number> } = {};
 
-  // get all datasource variables
-  const datasourceVariables = dashboard.variables.filter((v) => v.kind === 'DatasourceVariable');
+  // Collect datasource variable names from dashboard-level and section (row/tab) scopes
+  // so panel/query refs to section DS vars are not incorrectly templateized.
+  const datasourceVariableNames = new Set<string>();
+  for (const variable of dashboard.variables) {
+    if (variable.kind === 'DatasourceVariable') {
+      datasourceVariableNames.add(variable.spec.name);
+    }
+  }
+  visitDashboardLayoutSections(dashboard.layout, (variables) => {
+    for (const variable of variables) {
+      if (variable.kind === 'DatasourceVariable') {
+        datasourceVariableNames.add(variable.spec.name);
+      }
+    }
+  });
 
   const processDataQueryKind = (dataQueryKind: DataQueryKind) => {
     if (!dataQueryKind.datasource?.name) {
@@ -478,7 +492,7 @@ export async function makeExportableV2(dashboard: DashboardV2Spec, isSharingExte
           ? datasourceUid.slice(2, -1)
           : datasourceUid.slice(1);
 
-      return !!datasourceVariables.find((v) => v.spec.name === varName);
+      return datasourceVariableNames.has(varName);
     }
 
     return false;
@@ -516,6 +530,24 @@ export async function makeExportableV2(dashboard: DashboardV2Spec, isSharingExte
     }
   };
 
+  const processVariable = (variable: DashboardV2Spec['variables'][number]) => {
+    if (variable.kind === 'QueryVariable') {
+      processDataQueryKind(variable.spec.query);
+      variable.spec.options = [];
+      variable.spec.current = {
+        text: '',
+        value: '',
+      };
+    } else if (variable.kind === 'DatasourceVariable') {
+      variable.spec.current = {
+        text: '',
+        value: '',
+      };
+    } else if (variable.kind === 'AdhocVariable' || variable.kind === 'GroupByVariable') {
+      processAdHocAndGroupByVariables(variable);
+    }
+  };
+
   try {
     const elements = dashboard.elements;
 
@@ -536,24 +568,15 @@ export async function makeExportableV2(dashboard: DashboardV2Spec, isSharingExte
       }
     }
 
-    // process template variables
+    // process dashboard-level and section (row/tab) template variables
     for (const variable of dashboard.variables) {
-      if (variable.kind === 'QueryVariable') {
-        processDataQueryKind(variable.spec.query);
-        variable.spec.options = [];
-        variable.spec.current = {
-          text: '',
-          value: '',
-        };
-      } else if (variable.kind === 'DatasourceVariable') {
-        variable.spec.current = {
-          text: '',
-          value: '',
-        };
-      } else if (variable.kind === 'AdhocVariable' || variable.kind === 'GroupByVariable') {
-        processAdHocAndGroupByVariables(variable);
-      }
+      processVariable(variable);
     }
+    visitDashboardLayoutSections(dashboard.layout, (variables) => {
+      for (const variable of variables) {
+        processVariable(variable);
+      }
+    });
 
     // process annotations vars
     for (const annotation of dashboard.annotations) {

--- a/public/app/features/dashboard-scene/scene/export/exporters.ts
+++ b/public/app/features/dashboard-scene/scene/export/exporters.ts
@@ -426,21 +426,59 @@ async function convertLibraryPanelToInlinePanel(libraryPanelElement: LibraryPane
 export async function makeExportableV2(dashboard: DashboardV2Spec, isSharingExternally = false) {
   const dataQueryLabels: { [key: string]: Map<string, number> } = {};
 
-  // Collect datasource variable names from dashboard-level and section (row/tab) scopes
-  // so panel/query refs to section DS vars are not incorrectly templateized.
-  const datasourceVariableNames = new Set<string>();
-  for (const variable of dashboard.variables) {
-    if (variable.kind === 'DatasourceVariable') {
-      datasourceVariableNames.add(variable.spec.name);
+  // Collect datasource variables from dashboard-level and section (row/tab) scopes
+  // so panel/query refs to section DS vars are not incorrectly templateized, and so
+  // we can still attach export labels for import pickers (mirrors V1).
+  const datasourceVariablesByName = new Map<string, { currentUid?: string }>();
+  const rememberDatasourceVariable = (variable: DashboardV2Spec['variables'][number]) => {
+    if (variable.kind !== 'DatasourceVariable') {
+      return;
     }
+    const currentValue = variable.spec.current?.value;
+    const currentUid =
+      typeof currentValue === 'string' && currentValue && !currentValue.startsWith('$') ? currentValue : undefined;
+    datasourceVariablesByName.set(variable.spec.name, { currentUid });
+  };
+  for (const variable of dashboard.variables) {
+    rememberDatasourceVariable(variable);
   }
   visitDashboardLayoutSections(dashboard.layout, (variables) => {
     for (const variable of variables) {
-      if (variable.kind === 'DatasourceVariable') {
-        datasourceVariableNames.add(variable.spec.name);
-      }
+      rememberDatasourceVariable(variable);
     }
   });
+
+  const getDatasourceVariableName = (datasourceUid: string): string | undefined => {
+    if (!datasourceUid.startsWith('$')) {
+      return undefined;
+    }
+    return datasourceUid.startsWith('${') && datasourceUid.endsWith('}')
+      ? datasourceUid.slice(2, -1)
+      : datasourceUid.slice(1);
+  };
+
+  const isReferencingDsTemplateVariable = (datasourceUid: string) => {
+    const varName = getDatasourceVariableName(datasourceUid);
+    return varName !== undefined && datasourceVariablesByName.has(varName);
+  };
+
+  const attachExportLabels = (
+    group: string,
+    datasourceUid: string,
+    existingLabels: DataQueryKind['labels'] | AdhocVariableKind['labels']
+  ) => {
+    // For $dsVar refs, prefer the variable's current UID so the import picker can
+    // show the original datasource name — same idea as V1's datasourceVariableRefNameMap.
+    const varName = getDatasourceVariableName(datasourceUid);
+    const resolvedUid = (varName ? datasourceVariablesByName.get(varName)?.currentUid : undefined) ?? datasourceUid;
+    const datasourceName = getDatasourceDisplayName(resolvedUid);
+
+    return {
+      ...(existingLabels ?? {}),
+      [ExportLabel]: getLabel(group, resolvedUid),
+      ...(datasourceName ? { [ExportDatasourceName]: datasourceName } : {}),
+    };
+  };
 
   const processDataQueryKind = (dataQueryKind: DataQueryKind) => {
     if (!dataQueryKind.datasource?.name) {
@@ -450,17 +488,12 @@ export async function makeExportableV2(dashboard: DashboardV2Spec, isSharingExte
     const datasourceUid = dataQueryKind.datasource.name;
 
     if (isReferencingDsTemplateVariable(datasourceUid)) {
+      // Keep $var on the query, but label it so external import can prompt for this DS type.
+      dataQueryKind.labels = attachExportLabels(dataQueryKind.group, datasourceUid, dataQueryKind.labels);
       return;
     }
 
-    const datasourceName = getDatasourceDisplayName(datasourceUid);
-
-    dataQueryKind.labels = {
-      ...(dataQueryKind.labels ?? {}),
-      [ExportLabel]: getLabel(dataQueryKind.group, datasourceUid),
-      ...(datasourceName ? { [ExportDatasourceName]: datasourceName } : {}),
-    };
-
+    dataQueryKind.labels = attachExportLabels(dataQueryKind.group, datasourceUid, dataQueryKind.labels);
     dataQueryKind.datasource = undefined;
   };
 
@@ -472,30 +505,12 @@ export async function makeExportableV2(dashboard: DashboardV2Spec, isSharingExte
     }
 
     if (isReferencingDsTemplateVariable(datasourceUid)) {
+      variable.labels = attachExportLabels(variable.group, datasourceUid, variable.labels);
       return;
     }
 
-    const datasourceName = getDatasourceDisplayName(datasourceUid);
-
-    variable.labels = {
-      ...(variable.labels ?? {}),
-      [ExportLabel]: getLabel(variable.group, datasourceUid),
-      ...(datasourceName ? { [ExportDatasourceName]: datasourceName } : {}),
-    };
+    variable.labels = attachExportLabels(variable.group, datasourceUid, variable.labels);
     variable.datasource = undefined;
-  };
-
-  const isReferencingDsTemplateVariable = (datasourceUid: string) => {
-    if (datasourceUid.startsWith('$')) {
-      const varName =
-        datasourceUid.startsWith('${') && datasourceUid.endsWith('}')
-          ? datasourceUid.slice(2, -1)
-          : datasourceUid.slice(1);
-
-      return datasourceVariableNames.has(varName);
-    }
-
-    return false;
   };
 
   const getDatasourceDisplayName = (datasourceUid: string): string | undefined => {

--- a/public/app/features/dashboard/utils/visitDashboardLayoutSections.test.ts
+++ b/public/app/features/dashboard/utils/visitDashboardLayoutSections.test.ts
@@ -1,0 +1,222 @@
+import {
+  type VariableKind,
+  defaultGridLayoutKind,
+  defaultRowsLayoutKind,
+  defaultTabsLayoutKind,
+  defaultAutoGridLayoutKind,
+} from '@grafana/schema/apis/dashboard.grafana.app/v2';
+
+import { mapDashboardLayoutSections, visitDashboardLayoutSections } from './visitDashboardLayoutSections';
+
+const makeConstant = (name: string): VariableKind => ({
+  kind: 'ConstantVariable',
+  spec: {
+    name,
+    query: name,
+    current: { text: name, value: name },
+    hide: 'dontHide',
+    skipUrlSync: false,
+  },
+});
+
+describe('visitDashboardLayoutSections', () => {
+  it('does nothing for GridLayout', () => {
+    const visitor = jest.fn();
+    visitDashboardLayoutSections(defaultGridLayoutKind(), visitor);
+    expect(visitor).not.toHaveBeenCalled();
+  });
+
+  it('does nothing for AutoGridLayout', () => {
+    const visitor = jest.fn();
+    visitDashboardLayoutSections(defaultAutoGridLayoutKind(), visitor);
+    expect(visitor).not.toHaveBeenCalled();
+  });
+
+  it('visits row section variables with path', () => {
+    const variables = [makeConstant('env')];
+    const layout = defaultRowsLayoutKind();
+    layout.spec.rows = [
+      {
+        kind: 'RowsLayoutRow',
+        spec: { title: 'Row 1', layout: defaultGridLayoutKind(), variables },
+      },
+    ];
+
+    const visitor = jest.fn();
+    visitDashboardLayoutSections(layout, visitor);
+
+    expect(visitor).toHaveBeenCalledTimes(1);
+    expect(visitor).toHaveBeenCalledWith(variables, '/rows/0');
+  });
+
+  it('visits tab section variables with path', () => {
+    const variables = [makeConstant('region')];
+    const layout = defaultTabsLayoutKind();
+    layout.spec.tabs = [
+      {
+        kind: 'TabsLayoutTab',
+        spec: { title: 'Tab 1', layout: defaultGridLayoutKind(), variables },
+      },
+    ];
+
+    const visitor = jest.fn();
+    visitDashboardLayoutSections(layout, visitor);
+
+    expect(visitor).toHaveBeenCalledTimes(1);
+    expect(visitor).toHaveBeenCalledWith(variables, '/tabs/0');
+  });
+
+  it('visits nested TabsLayout > RowsLayout sections', () => {
+    const tabVariables = [makeConstant('tabConst')];
+    const rowVariables = [makeConstant('rowConst')];
+    const rowsLayout = defaultRowsLayoutKind();
+    rowsLayout.spec.rows = [
+      {
+        kind: 'RowsLayoutRow',
+        spec: { title: 'Row 1', layout: defaultGridLayoutKind(), variables: rowVariables },
+      },
+    ];
+    const tabsLayout = defaultTabsLayoutKind();
+    tabsLayout.spec.tabs = [
+      {
+        kind: 'TabsLayoutTab',
+        spec: { title: 'Tab 1', layout: rowsLayout, variables: tabVariables },
+      },
+    ];
+
+    const visited: Array<{ path: string; names: string[] }> = [];
+    visitDashboardLayoutSections(tabsLayout, (variables, path) => {
+      visited.push({ path, names: variables.map((v) => v.spec.name) });
+    });
+
+    expect(visited).toEqual([
+      { path: '/tabs/0', names: ['tabConst'] },
+      { path: '/tabs/0/rows/0', names: ['rowConst'] },
+    ]);
+  });
+
+  it('skips sections without variables', () => {
+    const layout = defaultRowsLayoutKind();
+    layout.spec.rows = [
+      { kind: 'RowsLayoutRow', spec: { title: 'Empty', layout: defaultGridLayoutKind() } },
+      {
+        kind: 'RowsLayoutRow',
+        spec: { title: 'With vars', layout: defaultGridLayoutKind(), variables: [makeConstant('x')] },
+      },
+    ];
+
+    const visitor = jest.fn();
+    visitDashboardLayoutSections(layout, visitor);
+
+    expect(visitor).toHaveBeenCalledTimes(1);
+    expect(visitor.mock.calls[0][1]).toBe('/rows/1');
+  });
+});
+
+describe('mapDashboardLayoutSections', () => {
+  it('returns the same layout reference when mapper is a no-op', () => {
+    const variables = [makeConstant('env')];
+    const layout = defaultRowsLayoutKind();
+    layout.spec.rows = [
+      {
+        kind: 'RowsLayoutRow',
+        spec: { title: 'Row 1', layout: defaultGridLayoutKind(), variables },
+      },
+    ];
+
+    const result = mapDashboardLayoutSections(layout, (vars) => vars);
+    expect(result).toBe(layout);
+  });
+
+  it('replaces section variables immutably', () => {
+    const layout = defaultRowsLayoutKind();
+    layout.spec.rows = [
+      {
+        kind: 'RowsLayoutRow',
+        spec: {
+          title: 'Row 1',
+          layout: defaultGridLayoutKind(),
+          variables: [makeConstant('env')],
+        },
+      },
+    ];
+
+    const result = mapDashboardLayoutSections(layout, (variables): VariableKind[] | undefined => {
+      if (!variables) {
+        return variables;
+      }
+      return variables.map(
+        (v): VariableKind =>
+          v.kind === 'ConstantVariable'
+            ? { ...v, spec: { ...v.spec, query: 'staging', current: { text: 'staging', value: 'staging' } } }
+            : v
+      );
+    });
+
+    expect(result).toBeDefined();
+    expect(result).not.toBe(layout);
+    if (!result || result.kind !== 'RowsLayout') {
+      return;
+    }
+    const mappedVar = result.spec.rows[0].spec.variables?.[0];
+    expect(mappedVar?.kind).toBe('ConstantVariable');
+    if (mappedVar?.kind !== 'ConstantVariable') {
+      return;
+    }
+    expect(mappedVar.spec.query).toBe('staging');
+    // original unchanged
+    const originalVar = layout.spec.rows[0].spec.variables?.[0];
+    expect(originalVar?.kind).toBe('ConstantVariable');
+    if (originalVar?.kind !== 'ConstantVariable') {
+      return;
+    }
+    expect(originalVar.spec.query).toBe('env');
+  });
+
+  it('maps nested TabsLayout > RowsLayout variables', () => {
+    const rowsLayout = defaultRowsLayoutKind();
+    rowsLayout.spec.rows = [
+      {
+        kind: 'RowsLayoutRow',
+        spec: {
+          title: 'Row 1',
+          layout: defaultGridLayoutKind(),
+          variables: [makeConstant('rowConst')],
+        },
+      },
+    ];
+    const tabsLayout = defaultTabsLayoutKind();
+    tabsLayout.spec.tabs = [
+      {
+        kind: 'TabsLayoutTab',
+        spec: {
+          title: 'Tab 1',
+          layout: rowsLayout,
+          variables: [makeConstant('tabConst')],
+        },
+      },
+    ];
+
+    const result = mapDashboardLayoutSections(tabsLayout, (variables): VariableKind[] | undefined => {
+      if (!variables) {
+        return variables;
+      }
+      return variables.map(
+        (v): VariableKind =>
+          v.kind === 'ConstantVariable' ? { ...v, spec: { ...v.spec, name: `${v.spec.name}-mapped` } } : v
+      );
+    });
+
+    expect(result).toBeDefined();
+    if (!result || result.kind !== 'TabsLayout') {
+      return;
+    }
+    expect(result.spec.tabs[0].spec.variables?.[0].spec.name).toBe('tabConst-mapped');
+    const nestedRows = result.spec.tabs[0].spec.layout;
+    expect(nestedRows.kind).toBe('RowsLayout');
+    if (nestedRows.kind !== 'RowsLayout') {
+      return;
+    }
+    expect(nestedRows.spec.rows[0].spec.variables?.[0].spec.name).toBe('rowConst-mapped');
+  });
+});

--- a/public/app/features/dashboard/utils/visitDashboardLayoutSections.test.ts
+++ b/public/app/features/dashboard/utils/visitDashboardLayoutSections.test.ts
@@ -32,13 +32,13 @@ describe('visitDashboardLayoutSections', () => {
     expect(visitor).not.toHaveBeenCalled();
   });
 
-  it('visits row section variables with path', () => {
+  it('visits row section variables with path and scopeLabel', () => {
     const variables = [makeConstant('env')];
     const layout = defaultRowsLayoutKind();
     layout.spec.rows = [
       {
         kind: 'RowsLayoutRow',
-        spec: { title: 'Row 1', layout: defaultGridLayoutKind(), variables },
+        spec: { title: 'Servers', layout: defaultGridLayoutKind(), variables },
       },
     ];
 
@@ -46,16 +46,32 @@ describe('visitDashboardLayoutSections', () => {
     visitDashboardLayoutSections(layout, visitor);
 
     expect(visitor).toHaveBeenCalledTimes(1);
-    expect(visitor).toHaveBeenCalledWith(variables, '/rows/0');
+    expect(visitor).toHaveBeenCalledWith(variables, { path: '/rows/0', scopeLabel: 'Row: Servers' });
   });
 
-  it('visits tab section variables with path', () => {
+  it('uses indexed fallback scopeLabel when row has no title', () => {
+    const variables = [makeConstant('env')];
+    const layout = defaultRowsLayoutKind();
+    layout.spec.rows = [
+      {
+        kind: 'RowsLayoutRow',
+        spec: { layout: defaultGridLayoutKind(), variables },
+      },
+    ];
+
+    const visitor = jest.fn();
+    visitDashboardLayoutSections(layout, visitor);
+
+    expect(visitor).toHaveBeenCalledWith(variables, { path: '/rows/0', scopeLabel: 'Row 1' });
+  });
+
+  it('visits tab section variables with path and scopeLabel', () => {
     const variables = [makeConstant('region')];
     const layout = defaultTabsLayoutKind();
     layout.spec.tabs = [
       {
         kind: 'TabsLayoutTab',
-        spec: { title: 'Tab 1', layout: defaultGridLayoutKind(), variables },
+        spec: { title: 'Overview', layout: defaultGridLayoutKind(), variables },
       },
     ];
 
@@ -63,35 +79,35 @@ describe('visitDashboardLayoutSections', () => {
     visitDashboardLayoutSections(layout, visitor);
 
     expect(visitor).toHaveBeenCalledTimes(1);
-    expect(visitor).toHaveBeenCalledWith(variables, '/tabs/0');
+    expect(visitor).toHaveBeenCalledWith(variables, { path: '/tabs/0', scopeLabel: 'Tab: Overview' });
   });
 
-  it('visits nested TabsLayout > RowsLayout sections', () => {
+  it('visits nested TabsLayout > RowsLayout sections with breadcrumb scopeLabel', () => {
     const tabVariables = [makeConstant('tabConst')];
     const rowVariables = [makeConstant('rowConst')];
     const rowsLayout = defaultRowsLayoutKind();
     rowsLayout.spec.rows = [
       {
         kind: 'RowsLayoutRow',
-        spec: { title: 'Row 1', layout: defaultGridLayoutKind(), variables: rowVariables },
+        spec: { title: 'Metrics', layout: defaultGridLayoutKind(), variables: rowVariables },
       },
     ];
     const tabsLayout = defaultTabsLayoutKind();
     tabsLayout.spec.tabs = [
       {
         kind: 'TabsLayoutTab',
-        spec: { title: 'Tab 1', layout: rowsLayout, variables: tabVariables },
+        spec: { title: 'Overview', layout: rowsLayout, variables: tabVariables },
       },
     ];
 
-    const visited: Array<{ path: string; names: string[] }> = [];
-    visitDashboardLayoutSections(tabsLayout, (variables, path) => {
-      visited.push({ path, names: variables.map((v) => v.spec.name) });
+    const visited: Array<{ path: string; scopeLabel: string; names: string[] }> = [];
+    visitDashboardLayoutSections(tabsLayout, (variables, { path, scopeLabel }) => {
+      visited.push({ path, scopeLabel, names: variables.map((v) => v.spec.name) });
     });
 
     expect(visited).toEqual([
-      { path: '/tabs/0', names: ['tabConst'] },
-      { path: '/tabs/0/rows/0', names: ['rowConst'] },
+      { path: '/tabs/0', scopeLabel: 'Tab: Overview', names: ['tabConst'] },
+      { path: '/tabs/0/rows/0', scopeLabel: 'Tab: Overview › Row: Metrics', names: ['rowConst'] },
     ]);
   });
 
@@ -109,7 +125,7 @@ describe('visitDashboardLayoutSections', () => {
     visitDashboardLayoutSections(layout, visitor);
 
     expect(visitor).toHaveBeenCalledTimes(1);
-    expect(visitor.mock.calls[0][1]).toBe('/rows/1');
+    expect(visitor.mock.calls[0][1]).toEqual({ path: '/rows/1', scopeLabel: 'Row: With vars' });
   });
 });
 
@@ -218,5 +234,27 @@ describe('mapDashboardLayoutSections', () => {
       return;
     }
     expect(nestedRows.spec.rows[0].spec.variables?.[0].spec.name).toBe('rowConst-mapped');
+  });
+
+  it('passes path and scopeLabel to the mapper', () => {
+    const layout = defaultRowsLayoutKind();
+    layout.spec.rows = [
+      {
+        kind: 'RowsLayoutRow',
+        spec: {
+          title: 'Servers',
+          layout: defaultGridLayoutKind(),
+          variables: [makeConstant('env')],
+        },
+      },
+    ];
+
+    const contexts: Array<{ path: string; scopeLabel: string }> = [];
+    mapDashboardLayoutSections(layout, (variables, context) => {
+      contexts.push(context);
+      return variables;
+    });
+
+    expect(contexts).toEqual([{ path: '/rows/0', scopeLabel: 'Row: Servers' }]);
   });
 });

--- a/public/app/features/dashboard/utils/visitDashboardLayoutSections.ts
+++ b/public/app/features/dashboard/utils/visitDashboardLayoutSections.ts
@@ -1,0 +1,129 @@
+import { type Spec as DashboardV2Spec, type VariableKind } from '@grafana/schema/apis/dashboard.grafana.app/v2';
+
+export type DashboardLayout = DashboardV2Spec['layout'];
+
+export type SectionVariablesVisitor = (variables: VariableKind[], path: string) => void;
+
+export type SectionVariablesMapper = (
+  variables: VariableKind[] | undefined,
+  path: string
+) => VariableKind[] | undefined;
+
+/**
+ * Recursively visit RowsLayout / TabsLayout sections and invoke the visitor
+ * for each section that has a variables list.
+ *
+ * Paths look like `/rows/0`, `/tabs/1/rows/0`. GridLayout and AutoGridLayout are leaves.
+ */
+export function visitDashboardLayoutSections(
+  layout: DashboardLayout | undefined,
+  visitor: SectionVariablesVisitor,
+  pathPrefix = ''
+): void {
+  if (!layout) {
+    return;
+  }
+
+  if (layout.kind === 'RowsLayout') {
+    layout.spec.rows.forEach((row, index) => {
+      if (row.kind !== 'RowsLayoutRow') {
+        return;
+      }
+      const path = `${pathPrefix}/rows/${index}`;
+      if (row.spec.variables) {
+        visitor(row.spec.variables, path);
+      }
+      visitDashboardLayoutSections(row.spec.layout, visitor, path);
+    });
+    return;
+  }
+
+  if (layout.kind === 'TabsLayout') {
+    layout.spec.tabs.forEach((tab, index) => {
+      if (tab.kind !== 'TabsLayoutTab') {
+        return;
+      }
+      const path = `${pathPrefix}/tabs/${index}`;
+      if (tab.spec.variables) {
+        visitor(tab.spec.variables, path);
+      }
+      visitDashboardLayoutSections(tab.spec.layout, visitor, path);
+    });
+  }
+}
+
+/**
+ * Immutably map section variable lists under RowsLayout / TabsLayout.
+ * Returns the original layout reference when nothing changes.
+ */
+export function mapDashboardLayoutSections(
+  layout: DashboardLayout | undefined,
+  mapper: SectionVariablesMapper,
+  pathPrefix = ''
+): DashboardLayout | undefined {
+  if (!layout) {
+    return layout;
+  }
+
+  if (layout.kind === 'RowsLayout') {
+    let modified = false;
+    const rows = layout.spec.rows.map((row, index) => {
+      if (row.kind !== 'RowsLayoutRow') {
+        return row;
+      }
+      const path = `${pathPrefix}/rows/${index}`;
+      const mappedVariables = mapper(row.spec.variables, path);
+      const nestedLayout = mapDashboardLayoutSections(row.spec.layout, mapper, path) ?? row.spec.layout;
+      const variablesChanged = mappedVariables !== row.spec.variables;
+      const layoutChanged = nestedLayout !== row.spec.layout;
+
+      if (!variablesChanged && !layoutChanged) {
+        return row;
+      }
+
+      modified = true;
+      return {
+        ...row,
+        spec: {
+          ...row.spec,
+          ...(variablesChanged ? { variables: mappedVariables } : {}),
+          ...(layoutChanged ? { layout: nestedLayout } : {}),
+        },
+      };
+    });
+
+    return modified ? { ...layout, spec: { ...layout.spec, rows } } : layout;
+  }
+
+  if (layout.kind === 'TabsLayout') {
+    let modified = false;
+    const tabs = layout.spec.tabs.map((tab, index) => {
+      if (tab.kind !== 'TabsLayoutTab') {
+        return tab;
+      }
+      const path = `${pathPrefix}/tabs/${index}`;
+      const mappedVariables = mapper(tab.spec.variables, path);
+      const nestedLayout = mapDashboardLayoutSections(tab.spec.layout, mapper, path) ?? tab.spec.layout;
+      const variablesChanged = mappedVariables !== tab.spec.variables;
+      const layoutChanged = nestedLayout !== tab.spec.layout;
+
+      if (!variablesChanged && !layoutChanged) {
+        return tab;
+      }
+
+      modified = true;
+      return {
+        ...tab,
+        spec: {
+          ...tab.spec,
+          ...(variablesChanged ? { variables: mappedVariables } : {}),
+          ...(layoutChanged ? { layout: nestedLayout } : {}),
+        },
+      };
+    });
+
+    return modified ? { ...layout, spec: { ...layout.spec, tabs } } : layout;
+  }
+
+  return layout;
+}

--- a/public/app/features/dashboard/utils/visitDashboardLayoutSections.ts
+++ b/public/app/features/dashboard/utils/visitDashboardLayoutSections.ts
@@ -2,12 +2,29 @@ import { type Spec as DashboardV2Spec, type VariableKind } from '@grafana/schema
 
 export type DashboardLayout = DashboardV2Spec['layout'];
 
-export type SectionVariablesVisitor = (variables: VariableKind[], path: string) => void;
+export interface SectionVariablesContext {
+  path: string;
+  /** Human-readable breadcrumb, e.g. `Row: Servers` or `Tab: Overview › Row: Metrics`. */
+  scopeLabel: string;
+}
+
+export type SectionVariablesVisitor = (variables: VariableKind[], context: SectionVariablesContext) => void;
 
 export type SectionVariablesMapper = (
   variables: VariableKind[] | undefined,
-  path: string
+  context: SectionVariablesContext
 ) => VariableKind[] | undefined;
+
+function sectionSegment(kind: 'row' | 'tab', index: number, title?: string): string {
+  if (title?.trim()) {
+    return kind === 'row' ? `Row: ${title.trim()}` : `Tab: ${title.trim()}`;
+  }
+  return kind === 'row' ? `Row ${index + 1}` : `Tab ${index + 1}`;
+}
+
+function appendScopeLabel(prefix: string, segment: string): string {
+  return prefix ? `${prefix} › ${segment}` : segment;
+}
 
 /**
  * Recursively visit RowsLayout / TabsLayout sections and invoke the visitor
@@ -18,7 +35,8 @@ export type SectionVariablesMapper = (
 export function visitDashboardLayoutSections(
   layout: DashboardLayout | undefined,
   visitor: SectionVariablesVisitor,
-  pathPrefix = ''
+  pathPrefix = '',
+  scopeLabelPrefix = ''
 ): void {
   if (!layout) {
     return;
@@ -30,10 +48,11 @@ export function visitDashboardLayoutSections(
         return;
       }
       const path = `${pathPrefix}/rows/${index}`;
+      const scopeLabel = appendScopeLabel(scopeLabelPrefix, sectionSegment('row', index, row.spec.title));
       if (row.spec.variables) {
-        visitor(row.spec.variables, path);
+        visitor(row.spec.variables, { path, scopeLabel });
       }
-      visitDashboardLayoutSections(row.spec.layout, visitor, path);
+      visitDashboardLayoutSections(row.spec.layout, visitor, path, scopeLabel);
     });
     return;
   }
@@ -44,10 +63,11 @@ export function visitDashboardLayoutSections(
         return;
       }
       const path = `${pathPrefix}/tabs/${index}`;
+      const scopeLabel = appendScopeLabel(scopeLabelPrefix, sectionSegment('tab', index, tab.spec.title));
       if (tab.spec.variables) {
-        visitor(tab.spec.variables, path);
+        visitor(tab.spec.variables, { path, scopeLabel });
       }
-      visitDashboardLayoutSections(tab.spec.layout, visitor, path);
+      visitDashboardLayoutSections(tab.spec.layout, visitor, path, scopeLabel);
     });
   }
 }
@@ -59,7 +79,8 @@ export function visitDashboardLayoutSections(
 export function mapDashboardLayoutSections(
   layout: DashboardLayout | undefined,
   mapper: SectionVariablesMapper,
-  pathPrefix = ''
+  pathPrefix = '',
+  scopeLabelPrefix = ''
 ): DashboardLayout | undefined {
   if (!layout) {
     return layout;
@@ -72,8 +93,10 @@ export function mapDashboardLayoutSections(
         return row;
       }
       const path = `${pathPrefix}/rows/${index}`;
-      const mappedVariables = mapper(row.spec.variables, path);
-      const nestedLayout = mapDashboardLayoutSections(row.spec.layout, mapper, path) ?? row.spec.layout;
+      const scopeLabel = appendScopeLabel(scopeLabelPrefix, sectionSegment('row', index, row.spec.title));
+      const context: SectionVariablesContext = { path, scopeLabel };
+      const mappedVariables = mapper(row.spec.variables, context);
+      const nestedLayout = mapDashboardLayoutSections(row.spec.layout, mapper, path, scopeLabel) ?? row.spec.layout;
       const variablesChanged = mappedVariables !== row.spec.variables;
       const layoutChanged = nestedLayout !== row.spec.layout;
 
@@ -102,8 +125,10 @@ export function mapDashboardLayoutSections(
         return tab;
       }
       const path = `${pathPrefix}/tabs/${index}`;
-      const mappedVariables = mapper(tab.spec.variables, path);
-      const nestedLayout = mapDashboardLayoutSections(tab.spec.layout, mapper, path) ?? tab.spec.layout;
+      const scopeLabel = appendScopeLabel(scopeLabelPrefix, sectionSegment('tab', index, tab.spec.title));
+      const context: SectionVariablesContext = { path, scopeLabel };
+      const mappedVariables = mapper(tab.spec.variables, context);
+      const nestedLayout = mapDashboardLayoutSections(tab.spec.layout, mapper, path, scopeLabel) ?? tab.spec.layout;
       const variablesChanged = mappedVariables !== tab.spec.variables;
       const layoutChanged = nestedLayout !== tab.spec.layout;
 

--- a/public/app/features/dashboard/utils/visitDashboardLayoutSections.ts
+++ b/public/app/features/dashboard/utils/visitDashboardLayoutSections.ts
@@ -2,7 +2,7 @@ import { type Spec as DashboardV2Spec, type VariableKind } from '@grafana/schema
 
 export type DashboardLayout = DashboardV2Spec['layout'];
 
-export interface SectionVariablesContext {
+interface SectionVariablesContext {
   path: string;
   /** Human-readable breadcrumb, e.g. `Row: Servers` or `Tab: Overview › Row: Metrics`. */
   scopeLabel: string;

--- a/public/app/features/manage-dashboards/import/components/ImportDashboardFormV2.test.tsx
+++ b/public/app/features/manage-dashboards/import/components/ImportDashboardFormV2.test.tsx
@@ -236,4 +236,36 @@ describe('ImportDashboardFormV2', () => {
 
     expect(folderPicker).toHaveValue('some-folder');
   });
+
+  it('renders section constant with scope description and scoped form key', () => {
+    const inputs: DashboardInputs = {
+      ...mockInputs,
+      dataSources: [],
+      constants: [
+        {
+          name: 'environment',
+          label: 'Environment',
+          info: 'Specify a string constant',
+          value: 'production',
+          type: InputType.Constant,
+        },
+        {
+          name: 'environment',
+          label: 'Environment',
+          info: 'Specify a string constant',
+          value: 'staging',
+          type: InputType.Constant,
+          path: '/rows/0',
+          scopeLabel: 'Row: Servers',
+        },
+      ],
+    };
+
+    renderForm(false, inputs);
+
+    expect(screen.getAllByText('Environment')).toHaveLength(2);
+    expect(screen.getByText('Row: Servers')).toBeInTheDocument();
+    expect(document.querySelector('input[name="constant-dashboard-environment"]')).toBeInTheDocument();
+    expect(document.querySelector('input[name="constant-_rows_0-environment"]')).toBeInTheDocument();
+  });
 });

--- a/public/app/features/manage-dashboards/import/components/ImportDashboardFormV2.tsx
+++ b/public/app/features/manage-dashboards/import/components/ImportDashboardFormV2.tsx
@@ -15,6 +15,7 @@ import {
   type DataSourceInput,
   type ImportFormDataV2,
 } from '../../types';
+import { constantFormKey } from '../utils/inputs';
 import { getUidFieldDescription, getUidFieldLabel } from '../utils/uidFieldText';
 import { validateTitle, validateUid } from '../utils/validation';
 
@@ -193,10 +194,11 @@ export const ImportDashboardFormV2 = ({
 
       {inputs.constants &&
         inputs.constants.map((input: DashboardInput) => {
-          const constantKey = `constant-${input.name}`;
+          const constantKey = constantFormKey(input.path, input.name);
           return (
             <Field
               label={input.label}
+              description={input.scopeLabel}
               key={constantKey}
               invalid={!!errors[constantKey]}
               error={errors[constantKey] ? `${input.label} needs a value` : undefined}

--- a/public/app/features/manage-dashboards/import/utils/inputs.test.ts
+++ b/public/app/features/manage-dashboards/import/utils/inputs.test.ts
@@ -657,6 +657,139 @@ describe('extractV2Inputs', () => {
     expect(result.constants).toHaveLength(1);
     expect(result.constants[0].name).toBe('namespace');
   });
+
+  it('extracts datasource inputs from row QueryVariable and tab AdhocVariable', async () => {
+    const dashboard = {
+      elements: {},
+      variables: [],
+      layout: {
+        kind: 'TabsLayout',
+        spec: {
+          tabs: [
+            {
+              kind: 'TabsLayoutTab',
+              spec: {
+                title: 'Tab 1',
+                layout: {
+                  kind: 'RowsLayout',
+                  spec: {
+                    rows: [
+                      {
+                        kind: 'RowsLayoutRow',
+                        spec: {
+                          title: 'Row 1',
+                          layout: { kind: 'GridLayout', spec: { items: [] } },
+                          variables: [
+                            {
+                              kind: 'QueryVariable',
+                              spec: {
+                                name: 'rowQuery',
+                                query: {
+                                  group: 'prometheus',
+                                  labels: { [ExportLabel]: 'prom-1', [ExportDatasourceName]: 'Prod Prom' },
+                                },
+                              },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+                variables: [
+                  {
+                    kind: 'AdhocVariable',
+                    group: 'loki',
+                    labels: { [ExportLabel]: 'loki-1', [ExportDatasourceName]: 'Prod Loki' },
+                    spec: { name: 'tabAdhoc' },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    };
+
+    mockGetDataSourceSrv.getList.mockImplementation(({ pluginId }: { pluginId: string }) => {
+      if (pluginId === 'prometheus') {
+        return [{ uid: 'p1', name: 'Prod Prom', type: 'prometheus' }];
+      }
+      if (pluginId === 'loki') {
+        return [{ uid: 'l1', name: 'Prod Loki', type: 'loki' }];
+      }
+      return [];
+    });
+
+    const result = await extractV2Inputs(dashboard);
+
+    expect(result.dataSources).toHaveLength(2);
+    expect(result.dataSources.map((ds) => ds.pluginId).sort()).toEqual(['loki', 'prometheus']);
+  });
+
+  it('extracts section constants and dedupes by name against dashboard-level', async () => {
+    const dashboard = {
+      elements: {},
+      variables: [
+        {
+          kind: 'ConstantVariable',
+          spec: {
+            name: 'environment',
+            label: 'Environment',
+            query: 'production',
+            description: 'Dashboard env',
+            current: { text: 'production', value: 'production' },
+            hide: 'dontHide',
+            skipUrlSync: false,
+          },
+        },
+      ],
+      layout: {
+        kind: 'RowsLayout',
+        spec: {
+          rows: [
+            {
+              kind: 'RowsLayoutRow',
+              spec: {
+                title: 'Row 1',
+                layout: { kind: 'GridLayout', spec: { items: [] } },
+                variables: [
+                  {
+                    kind: 'ConstantVariable',
+                    spec: {
+                      name: 'environment',
+                      query: 'should-not-appear',
+                      current: { text: 'should-not-appear', value: 'should-not-appear' },
+                      hide: 'dontHide',
+                      skipUrlSync: false,
+                    },
+                  },
+                  {
+                    kind: 'ConstantVariable',
+                    spec: {
+                      name: 'region',
+                      label: 'Region',
+                      query: 'us-east-1',
+                      current: { text: 'us-east-1', value: 'us-east-1' },
+                      hide: 'dontHide',
+                      skipUrlSync: false,
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    };
+
+    const result = await extractV2Inputs(dashboard);
+
+    expect(result.constants).toHaveLength(2);
+    expect(result.constants.map((c) => c.name)).toEqual(['environment', 'region']);
+    expect(result.constants[0].value).toBe('production');
+    expect(result.constants[0].info).toBe('Dashboard env');
+  });
 });
 
 describe('applyV1Inputs', () => {
@@ -1317,6 +1450,157 @@ describe('applyV2Inputs', () => {
 
     const envVar = result.variables?.find((v) => v.kind === 'ConstantVariable' && v.spec.name === 'environment');
     expect(envVar?.kind === 'ConstantVariable' && envVar.spec.query).toBe('production');
+  });
+
+  it('applies constant form values to section ConstantVariables', () => {
+    const dashboard = {
+      title: 'old',
+      elements: {},
+      annotations: [],
+      variables: [],
+      layout: {
+        kind: 'RowsLayout',
+        spec: {
+          rows: [
+            {
+              kind: 'RowsLayoutRow',
+              spec: {
+                title: 'Row 1',
+                layout: { kind: 'GridLayout', spec: { items: [] } },
+                variables: [
+                  {
+                    kind: 'ConstantVariable',
+                    spec: {
+                      name: 'environment',
+                      query: 'production',
+                      current: { text: 'production', value: 'production' },
+                      hide: 'dontHide',
+                      skipUrlSync: false,
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    } as unknown as DashboardV2Spec;
+
+    const form: ImportFormDataV2 = {
+      dashboard,
+      folderUid: 'folder',
+      message: '',
+      'constant-environment': 'staging',
+    };
+
+    const result = applyV2Inputs(dashboard, form);
+
+    expect(result.layout.kind).toBe('RowsLayout');
+    if (result.layout.kind !== 'RowsLayout') {
+      return;
+    }
+    const sectionConst = result.layout.spec.rows[0].spec.variables?.[0];
+    expect(sectionConst?.kind).toBe('ConstantVariable');
+    if (sectionConst?.kind !== 'ConstantVariable') {
+      return;
+    }
+    expect(sectionConst.spec.query).toBe('staging');
+    expect(sectionConst.spec.current).toEqual({ text: 'staging', value: 'staging' });
+  });
+
+  it('remaps datasources on section QueryVariables and clears export labels', () => {
+    const dashboard = {
+      title: 'old',
+      elements: {},
+      annotations: [],
+      variables: [],
+      layout: {
+        kind: 'TabsLayout',
+        spec: {
+          tabs: [
+            {
+              kind: 'TabsLayoutTab',
+              spec: {
+                title: 'Tab 1',
+                layout: {
+                  kind: 'RowsLayout',
+                  spec: {
+                    rows: [
+                      {
+                        kind: 'RowsLayoutRow',
+                        spec: {
+                          title: 'Row 1',
+                          layout: { kind: 'GridLayout', spec: { items: [] } },
+                          variables: [
+                            {
+                              kind: 'QueryVariable',
+                              spec: {
+                                name: 'nestedQuery',
+                                query: {
+                                  group: 'prometheus',
+                                  labels: {
+                                    [ExportLabel]: 'prometheus-1',
+                                    [ExportDatasourceName]: 'Original Prometheus',
+                                  },
+                                  datasource: { name: 'old-ds' },
+                                },
+                              },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+                variables: [
+                  {
+                    kind: 'QueryVariable',
+                    spec: {
+                      name: 'tabQuery',
+                      query: {
+                        group: 'prometheus',
+                        labels: {
+                          [ExportLabel]: 'prometheus-1',
+                          [ExportDatasourceName]: 'Original Prometheus',
+                        },
+                        datasource: { name: 'old-ds' },
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    } as unknown as DashboardV2Spec;
+
+    const form: ImportFormDataV2 = {
+      dashboard,
+      folderUid: 'folder',
+      message: '',
+      'datasource-prometheus-1': { uid: 'ds-uid', type: 'prometheus', name: 'My DS' },
+    };
+
+    const result = applyV2Inputs(dashboard, form);
+
+    expect(result.layout.kind).toBe('TabsLayout');
+    if (result.layout.kind !== 'TabsLayout') {
+      return;
+    }
+    const tabQuery = result.layout.spec.tabs[0].spec.variables?.[0] as QueryVariableKind;
+    expect(tabQuery.spec.query?.datasource?.name).toBe('ds-uid');
+    expect(tabQuery.spec.query?.labels?.[ExportLabel]).toBeUndefined();
+    expect(tabQuery.spec.query?.labels?.[ExportDatasourceName]).toBeUndefined();
+
+    const nestedRows = result.layout.spec.tabs[0].spec.layout;
+    expect(nestedRows.kind).toBe('RowsLayout');
+    if (nestedRows.kind !== 'RowsLayout') {
+      return;
+    }
+    const nestedQuery = nestedRows.spec.rows[0].spec.variables?.[0] as QueryVariableKind;
+    expect(nestedQuery.spec.query?.datasource?.name).toBe('ds-uid');
+    expect(nestedQuery.spec.query?.labels?.[ExportLabel]).toBeUndefined();
   });
 
   it('preserves variable references and does not replace them', () => {

--- a/public/app/features/manage-dashboards/import/utils/inputs.test.ts
+++ b/public/app/features/manage-dashboards/import/utils/inputs.test.ts
@@ -1829,7 +1829,7 @@ describe('replaceDatasourcesInDashboard', () => {
     prometheus: { uid: 'new-prom-uid', type: 'prometheus', name: 'New Prometheus' },
   };
 
-  const createPanelWithQuery = (group: string, datasourceName: string) => ({
+  const createPanelWithQuery = (group: string, datasourceName: string, labels?: Record<string, string>) => ({
     kind: 'Panel' as const,
     spec: {
       id: 1,
@@ -1856,6 +1856,7 @@ describe('replaceDatasourcesInDashboard', () => {
                   group,
                   version: 'v0',
                   datasource: { name: datasourceName },
+                  ...(labels && { labels }),
                   spec: {},
                 },
               },
@@ -1955,7 +1956,7 @@ describe('replaceDatasourcesInDashboard', () => {
   });
 
   describe('query variable', () => {
-    const createQueryVariable = (group: string, datasourceName: string) => ({
+    const createQueryVariable = (group: string, datasourceName: string, labels?: Record<string, string>) => ({
       kind: 'QueryVariable' as const,
       spec: {
         name: 'test_var',
@@ -1974,6 +1975,7 @@ describe('replaceDatasourcesInDashboard', () => {
           group,
           version: 'v0',
           datasource: { name: datasourceName },
+          ...(labels && { labels }),
           spec: {},
         },
       },
@@ -2008,6 +2010,28 @@ describe('replaceDatasourcesInDashboard', () => {
 
       expect(variable?.spec.query?.datasource?.name).toBe('${ds}');
       expect(variable?.spec.options).toEqual([{ text: 'All', value: '$__all' }]);
+    });
+
+    it('strips export-only labels while preserving a $dsVar reference', () => {
+      // @ts-ignore - using minimal test schema
+      const dashboard: DashboardV2Spec = {
+        ...baseDashboard,
+        variables: [
+          createQueryVariable('prometheus', '${ds}', {
+            [ExportLabel]: 'prometheus-1',
+            [ExportDatasourceName]: 'Original Prometheus',
+          }),
+        ],
+      };
+
+      const result = replaceDatasourcesInDashboard(dashboard, {
+        'prometheus-1': { uid: 'new-prom-uid', type: 'prometheus', name: 'New Prometheus' },
+      });
+      const updated = getQueryVariable(result);
+
+      expect(updated?.spec.query?.datasource?.name).toBe('${ds}');
+      expect(updated?.spec.query?.labels).toBeUndefined();
+      expect(updated?.spec.options).toEqual([{ text: 'All', value: '$__all' }]);
     });
   });
 
@@ -2044,7 +2068,7 @@ describe('replaceDatasourcesInDashboard', () => {
       expect(variable?.spec.current?.text).toBe('New Prometheus');
     });
 
-    it('uses export-label mapping of the same type when pluginId key is absent', () => {
+    it('uses the sole export-label mapping of the same type when pluginId key is absent', () => {
       // @ts-ignore - using minimal test schema
       const dashboard: DashboardV2Spec = {
         ...baseDashboard,
@@ -2058,6 +2082,68 @@ describe('replaceDatasourcesInDashboard', () => {
 
       expect(variable?.spec.current?.value).toBe('mapped-prom-uid');
       expect(variable?.spec.current?.text).toBe('Mapped Prometheus');
+    });
+
+    it('does not assign an arbitrary same-type mapping when multiple pickers exist', () => {
+      const dsA = createDatasourceVariable('prometheus', 'old-a', 'Old A');
+      dsA.spec.name = 'dsA';
+      const dsB = createDatasourceVariable('prometheus', 'old-b', 'Old B');
+      dsB.spec.name = 'dsB';
+      // @ts-ignore - using minimal test schema
+      const dashboard: DashboardV2Spec = {
+        ...baseDashboard,
+        variables: [dsA, dsB],
+      };
+
+      const result = replaceDatasourcesInDashboard(dashboard, {
+        'prometheus-1': { uid: 'prom-uid-1', type: 'prometheus', name: 'Prometheus 1' },
+        'prometheus-2': { uid: 'prom-uid-2', type: 'prometheus', name: 'Prometheus 2' },
+      });
+
+      expect(getDatasourceVariable(result, 0)?.spec.current).toEqual({ text: 'Old A', value: 'old-a' });
+      expect(getDatasourceVariable(result, 1)?.spec.current).toEqual({ text: 'Old B', value: 'old-b' });
+    });
+
+    it('maps DatasourceVariable via export label on a labeled $dsVar query ref', () => {
+      const dsA = createDatasourceVariable('prometheus', '', '');
+      dsA.spec.name = 'dsA';
+      const dsB = createDatasourceVariable('prometheus', '', '');
+      dsB.spec.name = 'dsB';
+      // @ts-ignore - using minimal test schema
+      const dashboard: DashboardV2Spec = {
+        ...baseDashboard,
+        variables: [dsA, dsB],
+        elements: {
+          'panel-a': createPanelWithQuery('prometheus', '${dsA}', {
+            [ExportLabel]: 'prometheus-1',
+            [ExportDatasourceName]: 'Prod A',
+          }),
+          'panel-b': createPanelWithQuery('prometheus', '$dsB', {
+            [ExportLabel]: 'prometheus-2',
+            [ExportDatasourceName]: 'Prod B',
+          }),
+        },
+      };
+
+      const result = replaceDatasourcesInDashboard(dashboard, {
+        'prometheus-1': { uid: 'prom-uid-1', type: 'prometheus', name: 'Prometheus 1' },
+        'prometheus-2': { uid: 'prom-uid-2', type: 'prometheus', name: 'Prometheus 2' },
+      });
+
+      expect(getDatasourceVariable(result, 0)?.spec.current).toEqual({ text: 'Prometheus 1', value: 'prom-uid-1' });
+      expect(getDatasourceVariable(result, 1)?.spec.current).toEqual({ text: 'Prometheus 2', value: 'prom-uid-2' });
+      // $dsVar refs keep their datasource; export labels are stripped
+      expect(getPanelQueryDatasourceName(result, 'panel-a')).toBe('${dsA}');
+      expect(getPanelQueryDatasourceName(result, 'panel-b')).toBe('$dsB');
+      const panelA = result.elements['panel-a'];
+      const panelB = result.elements['panel-b'];
+      if (panelA.kind === 'Panel' && panelA.spec.data?.kind === 'QueryGroup') {
+        expect(panelA.spec.data.spec.queries[0].spec.query?.labels?.[ExportLabel]).toBeUndefined();
+        expect(panelA.spec.data.spec.queries[0].spec.query?.labels?.[ExportDatasourceName]).toBeUndefined();
+      }
+      if (panelB.kind === 'Panel' && panelB.spec.data?.kind === 'QueryGroup') {
+        expect(panelB.spec.data.spec.queries[0].spec.query?.labels?.[ExportLabel]).toBeUndefined();
+      }
     });
   });
 
@@ -2118,7 +2204,7 @@ describe('replaceDatasourcesInDashboard', () => {
         variables: [
           {
             ...variable,
-            labels: { [ExportLabel]: 'loki', [ExportDatasourceName]: 'Original Loki', team: 'observability' },
+            labels: { [ExportLabel]: 'loki', [ExportDatasourceName]: 'Original Loki', custom: 'keep-me' },
           },
         ],
       };
@@ -2126,7 +2212,29 @@ describe('replaceDatasourcesInDashboard', () => {
       const result = replaceDatasourcesInDashboard(dashboard, mappings);
       const updated = getAdhocVariable(result);
 
-      expect(updated?.labels).toEqual({ team: 'observability' });
+      expect(updated?.labels).toEqual({ custom: 'keep-me' });
+    });
+
+    it('strips export-only labels while preserving a $dsVar reference', () => {
+      const variable = createAdhocVariable('loki', '${ds}');
+      // @ts-ignore - using minimal test schema
+      const dashboard: DashboardV2Spec = {
+        ...baseDashboard,
+        variables: [
+          {
+            ...variable,
+            labels: { [ExportLabel]: 'loki-1', [ExportDatasourceName]: 'Original Loki' },
+          },
+        ],
+      };
+
+      const result = replaceDatasourcesInDashboard(dashboard, {
+        'loki-1': { uid: 'new-loki-uid', type: 'loki', name: 'New Loki' },
+      });
+      const updated = getAdhocVariable(result);
+
+      expect(updated?.datasource?.name).toBe('${ds}');
+      expect(updated?.labels).toBeUndefined();
     });
   });
 

--- a/public/app/features/manage-dashboards/import/utils/inputs.test.ts
+++ b/public/app/features/manage-dashboards/import/utils/inputs.test.ts
@@ -727,7 +727,77 @@ describe('extractV2Inputs', () => {
     expect(result.dataSources.map((ds) => ds.pluginId).sort()).toEqual(['loki', 'prometheus']);
   });
 
-  it('extracts section constants and dedupes by name against dashboard-level', async () => {
+  it('extracts datasources from $dsVar panel queries only when export-labeled (external share)', async () => {
+    const dashboard = {
+      elements: {
+        labeledVarPanel: {
+          kind: 'Panel',
+          spec: {
+            data: {
+              kind: 'QueryGroup',
+              spec: {
+                queries: [
+                  {
+                    kind: 'PanelQuery',
+                    spec: {
+                      query: {
+                        group: 'loki',
+                        datasource: { name: '${rowLoki}' },
+                        labels: { [ExportLabel]: 'loki-1', [ExportDatasourceName]: 'Prod Loki' },
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        },
+        unlabeledSameInstancePanel: {
+          kind: 'Panel',
+          spec: {
+            data: {
+              kind: 'QueryGroup',
+              spec: {
+                queries: [
+                  {
+                    kind: 'PanelQuery',
+                    spec: {
+                      query: {
+                        group: 'grafana-sqlite-datasource',
+                        // Same-instance export keeps $var without labels — no picker
+                        datasource: { name: '$rowSqlite' },
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+      variables: [],
+    };
+
+    mockGetDataSourceSrv.getList.mockImplementation(({ pluginId }: { pluginId: string }) => {
+      if (pluginId === 'loki') {
+        return [{ uid: 'l1', name: 'Prod Loki', type: 'loki' }];
+      }
+      if (pluginId === 'grafana-sqlite-datasource') {
+        return [{ uid: 's1', name: 'SQLite', type: 'grafana-sqlite-datasource' }];
+      }
+      return [];
+    });
+
+    const result = await extractV2Inputs(dashboard);
+
+    expect(result.dataSources).toHaveLength(1);
+    expect(result.dataSources[0]).toMatchObject({
+      name: 'loki-1',
+      pluginId: 'loki',
+    });
+  });
+
+  it('extracts section constants separately when names collide with dashboard-level', async () => {
     const dashboard = {
       elements: {},
       variables: [
@@ -751,15 +821,15 @@ describe('extractV2Inputs', () => {
             {
               kind: 'RowsLayoutRow',
               spec: {
-                title: 'Row 1',
+                title: 'Servers',
                 layout: { kind: 'GridLayout', spec: { items: [] } },
                 variables: [
                   {
                     kind: 'ConstantVariable',
                     spec: {
                       name: 'environment',
-                      query: 'should-not-appear',
-                      current: { text: 'should-not-appear', value: 'should-not-appear' },
+                      query: 'staging',
+                      current: { text: 'staging', value: 'staging' },
                       hide: 'dontHide',
                       skipUrlSync: false,
                     },
@@ -785,10 +855,25 @@ describe('extractV2Inputs', () => {
 
     const result = await extractV2Inputs(dashboard);
 
-    expect(result.constants).toHaveLength(2);
-    expect(result.constants.map((c) => c.name)).toEqual(['environment', 'region']);
-    expect(result.constants[0].value).toBe('production');
-    expect(result.constants[0].info).toBe('Dashboard env');
+    expect(result.constants).toHaveLength(3);
+    expect(result.constants[0]).toMatchObject({
+      name: 'environment',
+      value: 'production',
+      info: 'Dashboard env',
+    });
+    expect(result.constants[0].path).toBeUndefined();
+    expect(result.constants[1]).toMatchObject({
+      name: 'environment',
+      value: 'staging',
+      path: '/rows/0',
+      scopeLabel: 'Row: Servers',
+    });
+    expect(result.constants[2]).toMatchObject({
+      name: 'region',
+      value: 'us-east-1',
+      path: '/rows/0',
+      scopeLabel: 'Row: Servers',
+    });
   });
 });
 
@@ -1404,8 +1489,8 @@ describe('applyV2Inputs', () => {
       dashboard,
       folderUid: 'folder',
       message: '',
-      'constant-environment': 'staging',
-      'constant-region': 'eu-west-1',
+      'constant-dashboard-environment': 'staging',
+      'constant-dashboard-region': 'eu-west-1',
     };
 
     const result = applyV2Inputs(dashboard, form);
@@ -1490,7 +1575,7 @@ describe('applyV2Inputs', () => {
       dashboard,
       folderUid: 'folder',
       message: '',
-      'constant-environment': 'staging',
+      'constant-_rows_0-environment': 'staging',
     };
 
     const result = applyV2Inputs(dashboard, form);
@@ -1506,6 +1591,72 @@ describe('applyV2Inputs', () => {
     }
     expect(sectionConst.spec.query).toBe('staging');
     expect(sectionConst.spec.current).toEqual({ text: 'staging', value: 'staging' });
+  });
+
+  it('applies distinct values to same-named dashboard and section constants', () => {
+    const dashboard = {
+      title: 'old',
+      elements: {},
+      annotations: [],
+      variables: [
+        {
+          kind: 'ConstantVariable',
+          spec: {
+            name: 'environment',
+            query: 'production',
+            current: { text: 'production', value: 'production' },
+            hide: 'dontHide',
+            skipUrlSync: false,
+          },
+        },
+      ],
+      layout: {
+        kind: 'RowsLayout',
+        spec: {
+          rows: [
+            {
+              kind: 'RowsLayoutRow',
+              spec: {
+                title: 'Servers',
+                layout: { kind: 'GridLayout', spec: { items: [] } },
+                variables: [
+                  {
+                    kind: 'ConstantVariable',
+                    spec: {
+                      name: 'environment',
+                      query: 'row-default',
+                      current: { text: 'row-default', value: 'row-default' },
+                      hide: 'dontHide',
+                      skipUrlSync: false,
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    } as unknown as DashboardV2Spec;
+
+    const form: ImportFormDataV2 = {
+      dashboard,
+      folderUid: 'folder',
+      message: '',
+      'constant-dashboard-environment': 'dash-staging',
+      'constant-_rows_0-environment': 'row-staging',
+    };
+
+    const result = applyV2Inputs(dashboard, form);
+
+    const dashConst = result.variables?.find((v) => v.kind === 'ConstantVariable' && v.spec.name === 'environment');
+    expect(dashConst?.kind === 'ConstantVariable' && dashConst.spec.query).toBe('dash-staging');
+
+    expect(result.layout.kind).toBe('RowsLayout');
+    if (result.layout.kind !== 'RowsLayout') {
+      return;
+    }
+    const sectionConst = result.layout.spec.rows[0].spec.variables?.[0];
+    expect(sectionConst?.kind === 'ConstantVariable' && sectionConst.spec.query).toBe('row-staging');
   });
 
   it('remaps datasources on section QueryVariables and clears export labels', () => {
@@ -1891,6 +2042,22 @@ describe('replaceDatasourcesInDashboard', () => {
       expect(variable).toBeDefined();
       expect(variable?.spec.current?.value).toBe('new-prom-uid');
       expect(variable?.spec.current?.text).toBe('New Prometheus');
+    });
+
+    it('uses export-label mapping of the same type when pluginId key is absent', () => {
+      // @ts-ignore - using minimal test schema
+      const dashboard: DashboardV2Spec = {
+        ...baseDashboard,
+        variables: [createDatasourceVariable('prometheus', 'old-prom-uid', 'Old Prometheus')],
+      };
+
+      const result = replaceDatasourcesInDashboard(dashboard, {
+        'prometheus-1': { uid: 'mapped-prom-uid', type: 'prometheus', name: 'Mapped Prometheus' },
+      });
+      const variable = getDatasourceVariable(result);
+
+      expect(variable?.spec.current?.value).toBe('mapped-prom-uid');
+      expect(variable?.spec.current?.text).toBe('Mapped Prometheus');
     });
   });
 

--- a/public/app/features/manage-dashboards/import/utils/inputs.ts
+++ b/public/app/features/manage-dashboards/import/utils/inputs.ts
@@ -6,6 +6,10 @@ import { type AnnotationQueryKind, type Spec as DashboardV2Spec } from '@grafana
 import { isRecord } from 'app/core/utils/isRecord';
 import { ExportFormat } from 'app/features/dashboard/api/types';
 import { isDashboardV1Resource, isDashboardV2Resource, isDashboardV2Spec } from 'app/features/dashboard/api/utils';
+import {
+  mapDashboardLayoutSections,
+  visitDashboardLayoutSections,
+} from 'app/features/dashboard/utils/visitDashboardLayoutSections';
 import { ExportDatasourceName, ExportLabel } from 'app/features/dashboard-scene/scene/export/exporters';
 
 import { type LibraryElementExport } from '../../../dashboard/components/DashExportModal/DashboardExporter';
@@ -200,19 +204,32 @@ export async function extractV2Inputs(dashboard: unknown): Promise<DashboardInpu
     return inputs;
   }
 
+  const seenConstantNames = new Set<string>();
+
+  const recordConstant = (variable: DashboardV2Spec['variables'][number]) => {
+    if (variable.kind !== 'ConstantVariable' || seenConstantNames.has(variable.spec.name)) {
+      return;
+    }
+    seenConstantNames.add(variable.spec.name);
+    inputs.constants.push({
+      name: variable.spec.name,
+      label: variable.spec.label || variable.spec.name,
+      info: variable.spec.description || 'Specify a string constant',
+      value: variable.spec.query,
+      type: InputType.Constant,
+    });
+  };
+
   if (dashboard.variables) {
     for (const variable of dashboard.variables) {
-      if (variable.kind === 'ConstantVariable') {
-        inputs.constants.push({
-          name: variable.spec.name,
-          label: variable.spec.label || variable.spec.name,
-          info: variable.spec.description || 'Specify a string constant',
-          value: variable.spec.query,
-          type: InputType.Constant,
-        });
-      }
+      recordConstant(variable);
     }
   }
+  visitDashboardLayoutSections(dashboard.layout, (variables) => {
+    for (const variable of variables) {
+      recordConstant(variable);
+    }
+  });
 
   const dsTypes: { [label: string]: string } = {};
   const dsNames: { [label: string]: string } = {};
@@ -231,8 +248,8 @@ export async function extractV2Inputs(dashboard: unknown): Promise<DashboardInpu
     }
   };
 
-  if (dashboard.variables) {
-    for (const variable of dashboard.variables) {
+  const recordVariableDatasources = (variables: DashboardV2Spec['variables']) => {
+    for (const variable of variables) {
       if (variable.kind === 'QueryVariable') {
         recordDatasource(
           getExportLabel(variable.spec.query.labels),
@@ -243,7 +260,14 @@ export async function extractV2Inputs(dashboard: unknown): Promise<DashboardInpu
         recordDatasource(getExportLabel(variable.labels), variable.group, getExportDatasourceName(variable.labels));
       }
     }
+  };
+
+  if (dashboard.variables) {
+    recordVariableDatasources(dashboard.variables);
   }
+  visitDashboardLayoutSections(dashboard.layout, (variables) => {
+    recordVariableDatasources(variables);
+  });
 
   if (dashboard.annotations) {
     for (const annotation of dashboard.annotations) {
@@ -484,6 +508,30 @@ export function applyV1Inputs(
  * Apply user's datasource selections to a v2 dashboard.
  * Builds mappings from the form and delegates to replaceDatasourcesInDashboard.
  */
+function applyConstantFormValue(
+  variable: DashboardV2Spec['variables'][number],
+  form: ImportFormDataV2
+): DashboardV2Spec['variables'][number] {
+  if (variable.kind !== 'ConstantVariable') {
+    return variable;
+  }
+
+  const formKey = `constant-${variable.spec.name}`;
+  const userValue = form[formKey];
+  if (typeof userValue !== 'string') {
+    return variable;
+  }
+
+  return {
+    ...variable,
+    spec: {
+      ...variable.spec,
+      query: userValue,
+      current: { text: userValue, value: userValue },
+    },
+  };
+}
+
 export function applyV2Inputs(dashboard: DashboardV2Spec, form: ImportFormDataV2): DashboardV2Spec {
   const mappings: DatasourceMappings = {};
   for (const key of Object.keys(form)) {
@@ -497,28 +545,16 @@ export function applyV2Inputs(dashboard: DashboardV2Spec, form: ImportFormDataV2
     }
   }
 
-  const variables = dashboard.variables?.map((variable) => {
-    if (variable.kind !== 'ConstantVariable') {
-      return variable;
-    }
+  const variables = dashboard.variables?.map((variable) => applyConstantFormValue(variable, form));
+  const layout =
+    mapDashboardLayoutSections(dashboard.layout, (sectionVariables) => {
+      if (!sectionVariables) {
+        return sectionVariables;
+      }
+      return sectionVariables.map((variable) => applyConstantFormValue(variable, form));
+    }) ?? dashboard.layout;
 
-    const formKey = `constant-${variable.spec.name}`;
-    const userValue = form[formKey];
-    if (typeof userValue !== 'string') {
-      return variable;
-    }
-
-    return {
-      ...variable,
-      spec: {
-        ...variable.spec,
-        query: userValue,
-        current: { text: userValue, value: userValue },
-      },
-    };
-  });
-
-  return replaceDatasourcesInDashboard({ ...dashboard, variables }, mappings);
+  return replaceDatasourcesInDashboard({ ...dashboard, variables, layout }, mappings);
 }
 
 export function isVariableRef(dsName: string | undefined): boolean {
@@ -534,6 +570,10 @@ export function replaceDatasourcesInDashboard(
     annotations: replaceAnnotationDatasources(dashboard.annotations, mappings),
     variables: replaceVariableDatasources(dashboard.variables, mappings),
     elements: replaceElementDatasources(dashboard.elements, mappings),
+    layout:
+      mapDashboardLayoutSections(dashboard.layout, (sectionVariables) =>
+        sectionVariables ? replaceVariableDatasources(sectionVariables, mappings) : sectionVariables
+      ) ?? dashboard.layout,
   };
 }
 

--- a/public/app/features/manage-dashboards/import/utils/inputs.ts
+++ b/public/app/features/manage-dashboards/import/utils/inputs.ts
@@ -190,6 +190,12 @@ export async function extractV1Inputs(dashboard: unknown): Promise<DashboardInpu
   return inputs;
 }
 
+/** Form field key for a V2 constant, scoped by layout path so same-named section vars stay distinct. */
+export function constantFormKey(path: string | undefined, name: string): string {
+  const pathKey = !path || path === 'dashboard' ? 'dashboard' : path.replaceAll('/', '_');
+  return `constant-${pathKey}-${name}`;
+}
+
 /**
  * Extract inputs from a v2 dashboard spec
  */
@@ -204,19 +210,17 @@ export async function extractV2Inputs(dashboard: unknown): Promise<DashboardInpu
     return inputs;
   }
 
-  const seenConstantNames = new Set<string>();
-
-  const recordConstant = (variable: DashboardV2Spec['variables'][number]) => {
-    if (variable.kind !== 'ConstantVariable' || seenConstantNames.has(variable.spec.name)) {
+  const recordConstant = (variable: DashboardV2Spec['variables'][number], path?: string, scopeLabel?: string) => {
+    if (variable.kind !== 'ConstantVariable') {
       return;
     }
-    seenConstantNames.add(variable.spec.name);
     inputs.constants.push({
       name: variable.spec.name,
       label: variable.spec.label || variable.spec.name,
       info: variable.spec.description || 'Specify a string constant',
       value: variable.spec.query,
       type: InputType.Constant,
+      ...(path ? { path, scopeLabel } : {}),
     });
   };
 
@@ -225,9 +229,9 @@ export async function extractV2Inputs(dashboard: unknown): Promise<DashboardInpu
       recordConstant(variable);
     }
   }
-  visitDashboardLayoutSections(dashboard.layout, (variables) => {
+  visitDashboardLayoutSections(dashboard.layout, (variables, { path, scopeLabel }) => {
     for (const variable of variables) {
-      recordConstant(variable);
+      recordConstant(variable, path, scopeLabel);
     }
   });
 
@@ -510,13 +514,14 @@ export function applyV1Inputs(
  */
 function applyConstantFormValue(
   variable: DashboardV2Spec['variables'][number],
-  form: ImportFormDataV2
+  form: ImportFormDataV2,
+  path?: string
 ): DashboardV2Spec['variables'][number] {
   if (variable.kind !== 'ConstantVariable') {
     return variable;
   }
 
-  const formKey = `constant-${variable.spec.name}`;
+  const formKey = constantFormKey(path, variable.spec.name);
   const userValue = form[formKey];
   if (typeof userValue !== 'string') {
     return variable;
@@ -545,13 +550,13 @@ export function applyV2Inputs(dashboard: DashboardV2Spec, form: ImportFormDataV2
     }
   }
 
-  const variables = dashboard.variables?.map((variable) => applyConstantFormValue(variable, form));
+  const variables = dashboard.variables?.map((variable) => applyConstantFormValue(variable, form, 'dashboard'));
   const layout =
-    mapDashboardLayoutSections(dashboard.layout, (sectionVariables) => {
+    mapDashboardLayoutSections(dashboard.layout, (sectionVariables, { path }) => {
       if (!sectionVariables) {
         return sectionVariables;
       }
-      return sectionVariables.map((variable) => applyConstantFormValue(variable, form));
+      return sectionVariables.map((variable) => applyConstantFormValue(variable, form, path));
     }) ?? dashboard.layout;
 
   return replaceDatasourcesInDashboard({ ...dashboard, variables, layout }, mappings);
@@ -650,7 +655,10 @@ function replaceVariableDatasources(
 
     if (variable.kind === 'DatasourceVariable') {
       const dsType = variable.spec.pluginId;
-      const ds = dsType ? mappings[dsType] : undefined;
+      // Exact pluginId key (from $dsVar query extract) or any export-label of that type.
+      const ds = dsType
+        ? (mappings[dsType] ?? Object.values(mappings).find((mapping) => mapping.type === dsType))
+        : undefined;
 
       if (!dsType || !ds) {
         return variable;

--- a/public/app/features/manage-dashboards/import/utils/inputs.ts
+++ b/public/app/features/manage-dashboards/import/utils/inputs.ts
@@ -566,18 +566,120 @@ export function isVariableRef(dsName: string | undefined): boolean {
   return dsName?.startsWith('$') ?? false;
 }
 
+/** Extract variable name from `$ds` / `${ds}` datasource refs. */
+function getVariableRefName(dsName: string | undefined): string | undefined {
+  if (!isVariableRef(dsName) || !dsName) {
+    return undefined;
+  }
+  return dsName.startsWith('${') && dsName.endsWith('}') ? dsName.slice(2, -1) : dsName.slice(1);
+}
+
+type ExportLabels = { [key: string]: string } | undefined;
+
+/** Drop grafana.app/export-* keys used only for import pickers. */
+function stripExportOnlyLabels(labels: ExportLabels): ExportLabels {
+  if (!labels) {
+    return undefined;
+  }
+  const remaining = { ...labels };
+  delete remaining[ExportLabel];
+  delete remaining[ExportDatasourceName];
+  return Object.keys(remaining).length > 0 ? remaining : undefined;
+}
+
+/**
+ * Map DatasourceVariable name → export label from labeled $dsVar refs.
+ * DatasourceVariable has no labels field, so import uses these refs to pick the right mapping.
+ */
+function collectDatasourceVariableExportLabels(dashboard: DashboardV2Spec): Map<string, string> {
+  const byVarName = new Map<string, string>();
+
+  const record = (dsName: string | undefined, labels: ExportLabels) => {
+    const varName = getVariableRefName(dsName);
+    const exportLabel = getExportLabel(labels);
+    if (varName && exportLabel && !byVarName.has(varName)) {
+      byVarName.set(varName, exportLabel);
+    }
+  };
+
+  for (const annotation of dashboard.annotations ?? []) {
+    record(annotation.spec.query?.datasource?.name, annotation.spec.query?.labels);
+  }
+
+  const recordVariables = (variables: DashboardV2Spec['variables'] | undefined) => {
+    for (const variable of variables ?? []) {
+      if (variable.kind === 'QueryVariable') {
+        record(variable.spec.query?.datasource?.name, variable.spec.query?.labels);
+      } else if (variable.kind === 'AdhocVariable' || variable.kind === 'GroupByVariable') {
+        record(variable.datasource?.name, variable.labels);
+      }
+    }
+  };
+
+  recordVariables(dashboard.variables);
+  visitDashboardLayoutSections(dashboard.layout, (variables) => {
+    recordVariables(variables);
+  });
+
+  for (const element of Object.values(dashboard.elements ?? {})) {
+    if (element.kind === 'Panel' && element.spec.data?.kind === 'QueryGroup') {
+      for (const query of element.spec.data.spec.queries) {
+        if (query.kind === 'PanelQuery') {
+          record(query.spec.query?.datasource?.name, query.spec.query?.labels);
+        }
+      }
+    }
+  }
+
+  return byVarName;
+}
+
+/**
+ * Resolve a DatasourceVariable mapping without silently picking an arbitrary same-type DS.
+ * Prefer the export label from a labeled $var ref; then exact pluginId key; then only when
+ * there is exactly one mapping of that type.
+ */
+function resolveDatasourceVariableMapping(
+  pluginId: string | undefined,
+  variableName: string,
+  mappings: DatasourceMappings,
+  dsVarExportLabels: Map<string, string>
+): DatasourceMappings[string] | undefined {
+  if (!pluginId) {
+    return undefined;
+  }
+
+  const exportLabel = dsVarExportLabels.get(variableName);
+  if (exportLabel && mappings[exportLabel]) {
+    return mappings[exportLabel];
+  }
+
+  if (mappings[pluginId]) {
+    return mappings[pluginId];
+  }
+
+  const ofType = Object.values(mappings).filter((mapping) => mapping.type === pluginId);
+  if (ofType.length === 1) {
+    return ofType[0];
+  }
+
+  return undefined;
+}
+
 export function replaceDatasourcesInDashboard(
   dashboard: DashboardV2Spec,
   mappings: DatasourceMappings
 ): DashboardV2Spec {
+  const dsVarExportLabels = collectDatasourceVariableExportLabels(dashboard);
+
   return {
     ...dashboard,
     annotations: replaceAnnotationDatasources(dashboard.annotations, mappings),
-    variables: replaceVariableDatasources(dashboard.variables, mappings),
+    variables: replaceVariableDatasources(dashboard.variables, mappings, dsVarExportLabels),
     elements: replaceElementDatasources(dashboard.elements, mappings),
     layout:
       mapDashboardLayoutSections(dashboard.layout, (sectionVariables) =>
-        sectionVariables ? replaceVariableDatasources(sectionVariables, mappings) : sectionVariables
+        sectionVariables ? replaceVariableDatasources(sectionVariables, mappings, dsVarExportLabels) : sectionVariables
       ) ?? dashboard.layout,
   };
 }
@@ -591,15 +693,25 @@ function replaceAnnotationDatasources(
     const dsLabel = getExportLabel(annotation.spec.query.labels);
     const currentDsName = annotation.spec.query?.datasource?.name;
     const ds = dsLabel ? mappings[dsLabel] : dsType ? mappings[dsType] : undefined;
+    const remainingLabels = stripExportOnlyLabels(annotation.spec.query?.labels);
+    const shouldRemap = !isVariableRef(currentDsName) && !!dsType && !!ds;
 
-    if (isVariableRef(currentDsName) || !dsType || !ds) {
-      return annotation;
-    }
+    const { labels: _droppedLabels, ...queryWithoutLabels } = annotation.spec.query ?? {};
 
-    // remove export labels
-    if (annotation.spec.query?.labels) {
-      delete annotation.spec.query.labels[ExportLabel];
-      delete annotation.spec.query.labels[ExportDatasourceName];
+    if (!shouldRemap) {
+      if (!annotation.spec.query?.labels || remainingLabels === annotation.spec.query.labels) {
+        return annotation;
+      }
+      return {
+        ...annotation,
+        spec: {
+          ...annotation.spec,
+          query: {
+            ...queryWithoutLabels,
+            ...(remainingLabels && { labels: remainingLabels }),
+          },
+        },
+      };
     }
 
     return {
@@ -607,9 +719,9 @@ function replaceAnnotationDatasources(
       spec: {
         ...annotation.spec,
         query: {
-          ...annotation.spec.query,
+          ...queryWithoutLabels,
           datasource: { name: ds.uid },
-          ...(Object.keys(annotation.spec.query?.labels ?? {}).length > 0 && { labels: annotation.spec.query.labels }),
+          ...(remainingLabels && { labels: remainingLabels }),
         },
       },
     };
@@ -618,7 +730,8 @@ function replaceAnnotationDatasources(
 
 function replaceVariableDatasources(
   variables: DashboardV2Spec['variables'],
-  mappings: DatasourceMappings
+  mappings: DatasourceMappings,
+  dsVarExportLabels: Map<string, string>
 ): DashboardV2Spec['variables'] {
   return variables?.map((variable) => {
     if (variable.kind === 'QueryVariable') {
@@ -626,15 +739,25 @@ function replaceVariableDatasources(
       const dsLabel = getExportLabel(variable.spec.query.labels);
       const currentDsName = variable.spec.query?.datasource?.name;
       const ds = dsLabel ? mappings[dsLabel] : dsType ? mappings[dsType] : undefined;
+      const remainingLabels = stripExportOnlyLabels(variable.spec.query?.labels);
+      const shouldRemap = !isVariableRef(currentDsName) && !!dsType && !!ds;
 
-      if (isVariableRef(currentDsName) || !dsType || !ds) {
-        return variable;
-      }
+      const { labels: _droppedLabels, ...queryWithoutLabels } = variable.spec.query ?? {};
 
-      // remove export labels
-      if (variable.spec.query?.labels) {
-        delete variable.spec.query.labels[ExportLabel];
-        delete variable.spec.query.labels[ExportDatasourceName];
+      if (!shouldRemap) {
+        if (!variable.spec.query?.labels || remainingLabels === variable.spec.query.labels) {
+          return variable;
+        }
+        return {
+          ...variable,
+          spec: {
+            ...variable.spec,
+            query: {
+              ...queryWithoutLabels,
+              ...(remainingLabels && { labels: remainingLabels }),
+            },
+          },
+        };
       }
 
       return {
@@ -642,9 +765,9 @@ function replaceVariableDatasources(
         spec: {
           ...variable.spec,
           query: {
-            ...variable.spec.query,
+            ...queryWithoutLabels,
             datasource: { name: ds.uid },
-            ...(Object.keys(variable.spec.query?.labels ?? {}).length > 0 && { labels: variable.spec.query.labels }),
+            ...(remainingLabels && { labels: remainingLabels }),
           },
           options: [],
           current: { text: '', value: '' },
@@ -654,13 +777,14 @@ function replaceVariableDatasources(
     }
 
     if (variable.kind === 'DatasourceVariable') {
-      const dsType = variable.spec.pluginId;
-      // Exact pluginId key (from $dsVar query extract) or any export-label of that type.
-      const ds = dsType
-        ? (mappings[dsType] ?? Object.values(mappings).find((mapping) => mapping.type === dsType))
-        : undefined;
+      const ds = resolveDatasourceVariableMapping(
+        variable.spec.pluginId,
+        variable.spec.name,
+        mappings,
+        dsVarExportLabels
+      );
 
-      if (!dsType || !ds) {
+      if (!ds) {
         return variable;
       }
 
@@ -681,21 +805,24 @@ function replaceVariableDatasources(
       const dsLabel = getExportLabel(variable.labels);
       const currentDsName = variable.datasource?.name;
       const ds = dsLabel ? mappings[dsLabel] : dsType ? mappings[dsType] : undefined;
-
-      if (isVariableRef(currentDsName) || !dsType || !ds) {
-        return variable;
-      }
-
-      // Drop export-only labels.
       const { labels, ...variableWithoutLabels } = variable;
-      const remainingLabels = { ...labels };
-      delete remainingLabels[ExportLabel];
-      delete remainingLabels[ExportDatasourceName];
+      const remainingLabels = stripExportOnlyLabels(labels);
+      const shouldRemap = !isVariableRef(currentDsName) && !!dsType && !!ds;
+
+      if (!shouldRemap) {
+        if (remainingLabels === labels) {
+          return variable;
+        }
+        return {
+          ...variableWithoutLabels,
+          ...(remainingLabels ? { labels: remainingLabels } : {}),
+        };
+      }
 
       return {
         ...variableWithoutLabels,
         datasource: { name: ds.uid },
-        ...(Object.keys(remainingLabels).length > 0 && { labels: remainingLabels }),
+        ...(remainingLabels ? { labels: remainingLabels } : {}),
       };
     }
 
@@ -721,15 +848,25 @@ function replaceElementDatasources(
             const queryLabel = getExportLabel(query.spec.query.labels);
             const currentDsName = query.spec.query?.datasource?.name;
             const ds = queryLabel ? mappings[queryLabel] : queryType ? mappings[queryType] : undefined;
+            const remainingLabels = stripExportOnlyLabels(query.spec.query?.labels);
+            const shouldRemap = !isVariableRef(currentDsName) && !!queryType && !!ds;
 
-            if (isVariableRef(currentDsName) || !queryType || !ds) {
-              return query;
-            }
+            const { labels: _droppedLabels, ...queryWithoutLabels } = query.spec.query ?? {};
 
-            // remove export labels
-            if (query.spec.query?.labels) {
-              delete query.spec.query.labels[ExportLabel];
-              delete query.spec.query.labels[ExportDatasourceName];
+            if (!shouldRemap) {
+              if (!query.spec.query?.labels || remainingLabels === query.spec.query.labels) {
+                return query;
+              }
+              return {
+                ...query,
+                spec: {
+                  ...query.spec,
+                  query: {
+                    ...queryWithoutLabels,
+                    ...(remainingLabels && { labels: remainingLabels }),
+                  },
+                },
+              };
             }
 
             return {
@@ -737,9 +874,9 @@ function replaceElementDatasources(
               spec: {
                 ...query.spec,
                 query: {
-                  ...query.spec.query,
+                  ...queryWithoutLabels,
                   datasource: { name: ds.uid },
-                  ...(Object.keys(query.spec.query?.labels ?? {}).length > 0 && { labels: query.spec.query.labels }),
+                  ...(remainingLabels && { labels: remainingLabels }),
                 },
               },
             };

--- a/public/app/features/manage-dashboards/types.ts
+++ b/public/app/features/manage-dashboards/types.ts
@@ -70,6 +70,10 @@ export interface DashboardInput {
   info: string;
   value: string;
   type: InputType;
+  /** Layout path for V2 section-scoped constants (`/rows/0`). Undefined for dashboard-level. */
+  path?: string;
+  /** Human-readable section breadcrumb for import UI (e.g. `Row: Servers`). */
+  scopeLabel?: string;
 }
 
 export interface DataSourceInput extends DashboardInput {


### PR DESCRIPTION
- Process row/tab (section) variables during V2 dashboard export and import the same way as dashboard-level variables (DS templating/remapping, constant inputs).
- Add a shared layout walker (visitDashboardLayoutSections / mapDashboardLayoutSections) so export and import can reach row.spec.variables / tab.spec.variables without duplicating Rows/Tabs recursion.
- On export, collect section DatasourceVariable names so panel queries that reference $sectionDsVar are not incorrectly templateized.

For manual testing:

- [x] Export a v2 dashboard with a row QueryVariable + ConstantVariable, re-import, confirm DS picker + constant field appear, and values land on the row after import
- [x] Panel query using a section DatasourceVariable keeps its $var ref after export

Fixes: https://github.com/grafana/grafana/issues/127960

Please check that:
- [x] It works as expected from a user's perspective.

