### PR TITLE
Plugins: Fix managed plugin major aligned regression

### DIFF
--- a/public/app/features/plugins/admin/components/VersionList.test.tsx
+++ b/public/app/features/plugins/admin/components/VersionList.test.tsx
@@ -227,6 +227,81 @@ describe('VersionList', () => {
     config.pluginAdminExternalManageEnabled = pluginAdminExternalManageEnabledOriginal;
   });
 
+  it('should allow installing the latest of the current and newer majors for a managed major aligned plugin', () => {
+    // Regression test: hiding the (untrustworthy) installed version for managed plugins must not
+    // change which versions are installable. With 2.0.0 installed, the latest of major 2 and the
+    // latest of major 3 must both stay enabled.
+    const versions = [
+      ...generateVersionsForMajor('1', 3),
+      ...generateVersionsForMajor('2', 3),
+      ...generateVersionsForMajor('3', 3),
+    ];
+
+    const installedVersion = '2.0.0';
+
+    const managedPluginsV2Original = config.featureToggles.managedPluginsV2;
+    config.featureToggles.managedPluginsV2 = true;
+
+    const pluginAdminExternalManageEnabledOriginal = config.pluginAdminExternalManageEnabled;
+    config.pluginAdminExternalManageEnabled = true;
+
+    const plugin = getCatalogPluginMock({
+      details: {
+        grafanaDependency: '>=8.0.0',
+        pluginDependencies: [],
+        links: [{ name: 'GitHub', url: 'https://example.com' }],
+        versions,
+      },
+      managed: { enabled: true, strategy: PluginUpdateStrategy.MajorAligned },
+      installedVersion,
+    });
+
+    renderWithStore(<VersionList plugin={plugin} />, { managedPluginsV2: true });
+    const buttons = screen.getAllByRole('button');
+    const enabledButtons = buttons.filter((btn) => !(btn as HTMLButtonElement).disabled);
+    expect(enabledButtons).toHaveLength(2);
+    const enabledRows = enabledButtons.map((btn) => btn.closest('tr')?.textContent);
+    expect(enabledRows.join(' ')).toContain('2.2.0');
+    expect(enabledRows.join(' ')).toContain('3.2.0');
+
+    config.featureToggles.managedPluginsV2 = managedPluginsV2Original;
+    config.pluginAdminExternalManageEnabled = pluginAdminExternalManageEnabledOriginal;
+  });
+
+  it('should fall back to only the latest compatible version when a managed major aligned plugin has an invalid installed version', () => {
+    // An invalid semver installedVersion (e.g. a dev build) must not crash the version list.
+    const versions = [
+      ...generateVersionsForMajor('1', 3),
+      ...generateVersionsForMajor('2', 3),
+      ...generateVersionsForMajor('3', 3),
+    ];
+
+    const managedPluginsV2Original = config.featureToggles.managedPluginsV2;
+    config.featureToggles.managedPluginsV2 = true;
+
+    const pluginAdminExternalManageEnabledOriginal = config.pluginAdminExternalManageEnabled;
+    config.pluginAdminExternalManageEnabled = true;
+
+    const plugin = getCatalogPluginMock({
+      details: {
+        grafanaDependency: '>=8.0.0',
+        pluginDependencies: [],
+        links: [{ name: 'GitHub', url: 'https://example.com' }],
+        versions,
+      },
+      managed: { enabled: true, strategy: PluginUpdateStrategy.MajorAligned },
+      installedVersion: 'dev',
+    });
+
+    renderWithStore(<VersionList plugin={plugin} />, { managedPluginsV2: true });
+    const buttons = screen.getAllByRole('button');
+    const enabledButtons = buttons.filter((btn) => !(btn as HTMLButtonElement).disabled);
+    expect(enabledButtons).toHaveLength(1);
+
+    config.featureToggles.managedPluginsV2 = managedPluginsV2Original;
+    config.pluginAdminExternalManageEnabled = pluginAdminExternalManageEnabledOriginal;
+  });
+
   it('should enable only the install button for the major aligned compatible version, when it is major aligned managed plugin and there is no version installed', () => {
     const versions = [
       ...generateVersionsForMajor('1', 3),
@@ -298,6 +373,16 @@ describe('VersionList', () => {
     expect(screen.queryByText('Downgrade')).not.toBeInTheDocument();
     expect(screen.getByText('4.17.0')).toBeInTheDocument();
     expect(screen.getByText(/^4\.19\.0/)).toBeInTheDocument();
+
+    // Even though the row is not labeled as installed, the stored installed version still
+    // cannot be redundantly reinstalled.
+    expect(screen.getByText('4.17.0').closest('tr')?.querySelector('button')).toBeDisabled();
+    expect(
+      screen
+        .getByText(/^4\.19\.0/)
+        .closest('tr')
+        ?.querySelector('button')
+    ).toBeEnabled();
   });
 
   it('should disable all versions when plugin is managed and update strategy is "assigned"', () => {

--- a/public/app/features/plugins/admin/components/VersionList.tsx
+++ b/public/app/features/plugins/admin/components/VersionList.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import { useEffect, useState, useMemo } from 'react';
-import { major, compare, lte } from 'semver';
+import { major, compare, lte, valid } from 'semver';
 
 import { dateTimeFormatTimeAgo, type GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
@@ -23,7 +23,11 @@ export const VersionList = ({ plugin }: Props) => {
   const disableInstallation = useMemo(() => shouldDisablePluginInstall(plugin), [plugin]);
 
   const isManagedPlugin = plugin.managed.enabled;
-  const installedVersion = isManagedPlugin ? undefined : plugin.installedVersion;
+  // For managed plugins the stored installedVersion may be stale, so it is never displayed as
+  // ground truth ("installed version" labels). The raw plugin.installedVersion must still feed
+  // the install gating below, otherwise every version except the latest compatible one gets
+  // disabled.
+  const displayedInstalledVersion = isManagedPlugin ? undefined : plugin.installedVersion;
 
   const latestCompatibleVersion = getLatestCompatibleVersion(versions);
   const latestMajorVersions = getLatestMajorVersions(versions);
@@ -36,11 +40,11 @@ export const VersionList = ({ plugin }: Props) => {
 
   // Check if installed version is in the versions list
   const isInstalledVersionMissing = useMemo(() => {
-    if (!installedVersion) {
+    if (!displayedInstalledVersion) {
       return false;
     }
-    return !versions.some((v) => v.version === installedVersion);
-  }, [versions, installedVersion]);
+    return !versions.some((v) => v.version === displayedInstalledVersion);
+  }, [versions, displayedInstalledVersion]);
 
   if (versions.length === 0 && !isInstalledVersionMissing) {
     return (
@@ -73,7 +77,7 @@ export const VersionList = ({ plugin }: Props) => {
       <tbody>
         {versions.map((version) => {
           let tooltip: string | undefined = undefined;
-          const isInstalledVersion = installedVersion === version.version;
+          const isInstalledVersion = displayedInstalledVersion === version.version;
 
           if (version.angularDetected) {
             tooltip = 'This plugin version is AngularJS type which is not supported';
@@ -122,7 +126,7 @@ export const VersionList = ({ plugin }: Props) => {
                     hideInstallState={isManagedPlugin}
                     onConfirmInstallation={onInstallClick}
                     disabled={
-                      isInstalledVersion ||
+                      version.version === plugin.installedVersion ||
                       isInstalling ||
                       version.angularDetected ||
                       !version.isCompatible ||
@@ -131,7 +135,7 @@ export const VersionList = ({ plugin }: Props) => {
                         version,
                         latestMajorVersions,
                         latestCompatibleVersion: latestCompatibleVersion?.version,
-                        installedVersion,
+                        installedVersion: plugin.installedVersion,
                         updateStrategy: plugin.managed.strategy,
                       })
                     }
@@ -227,8 +231,8 @@ function shouldDisableVersionInstallation({
   }
 
   if (updateStrategy === PluginUpdateStrategy.MajorAligned) {
-    if (!installedVersion) {
-      // When no version is installed, only the latest compatible version can be installed
+    if (!installedVersion || !valid(installedVersion)) {
+      // When no valid version is installed, only the latest compatible version can be installed
       return version.version !== latestCompatibleVersion;
     }
 


### PR DESCRIPTION
**What is this feature?**

Fixes a regression introduced by https://github.com/grafana/grafana/pull/128312 in the Plugin Catalog Version history tab (`VersionList.tsx`). That PR hid the stored `installedVersion` for managed plugins, but the nulled display value was also fed into the update strategy check. For major aligned managed plugins this meant every version except the latest compatible one was disabled, so updates within the current major or to a newer major (e.g. 2.0.0 to 3.0.0) could no longer be installed. The update strategy checks now use the `plugin.installedVersion` again while the display behavior from #128312 is unchanged.

**Why do we need this feature?**

Major aligned managed plugins are not automatically bumped across major versions, so users rely on the Version History tab to move to a newer major manually. After #128312 those install buttons were disabled.

**Who is this feature for?**

**Which issue(s) does this PR fix?**:

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle. *(N/A, bug fix, no new toggle)*
- [ ] The docs are updated... *(N/A, restores existing behavior)*
