### PR TITLE
Dashboards: Handle unknown field override matcher ids without crashing

### DIFF
--- a/public/app/features/dashboard-scene/mutation-api/commands/schemas.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/schemas.test.ts
@@ -1,0 +1,62 @@
+import { FieldMatcherID } from '@grafana/data';
+
+import { payloads } from './schemas';
+
+function updatePanelPayloadWithMatcherId(matcherId: string) {
+  return {
+    element: { name: 'panel-1' },
+    panel: {
+      spec: {
+        vizConfig: {
+          spec: {
+            fieldConfig: {
+              defaults: {},
+              overrides: [{ matcher: { id: matcherId, options: 'foo' }, properties: [] }],
+            },
+          },
+        },
+      },
+    },
+  };
+}
+
+describe('fieldConfigSchema matcher validation', () => {
+  it.each(Object.values(FieldMatcherID))('accepts registered field matcher id "%s"', (matcherId) => {
+    const result = payloads.updatePanel.safeParse(updatePanelPayloadWithMatcherId(matcherId));
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects an unknown matcher id with an error listing the valid options', () => {
+    const result = payloads.updatePanel.safeParse(updatePanelPayloadWithMatcherId('byNamePattern'));
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      throw new Error('expected parse failure');
+    }
+
+    const issue = result.error.issues.find((i) => i.path.at(-1) === 'id');
+    expect(issue?.path).toEqual(['panel', 'spec', 'vizConfig', 'spec', 'fieldConfig', 'overrides', 0, 'matcher', 'id']);
+    expect(issue?.message).toContain('byName');
+  });
+
+  it('rejects an unknown matcher id on ADD_PANEL payloads', () => {
+    const result = payloads.addPanel.safeParse({
+      panel: {
+        spec: {
+          title: 'Test panel',
+          data: { spec: { queries: [] } },
+          vizConfig: {
+            group: 'timeseries',
+            spec: {
+              fieldConfig: {
+                overrides: [{ matcher: { id: 'byNamePattern' }, properties: [] }],
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/public/app/features/dashboard-scene/mutation-api/commands/schemas.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/schemas.ts
@@ -9,8 +9,9 @@
  * 2. PAYLOAD SCHEMAS & `payloads` RECORD -- one Zod schema per mutation
  *    command, accessible via DashboardMutationAPI.getPayloadSchema().
  *
- * This file only depends on Zod, keeping it safe for import from any
- * internal module without pulling in the DashboardScene dependency tree.
+ * This file only depends on Zod and enum constants from @grafana/data,
+ * keeping it safe for import from any internal module without pulling in
+ * the DashboardScene dependency tree.
  *
  * DEFAULTS: Literal `kind` and `version` fields use .optional().default()
  * so consumers (e.g. LLM tools) can omit boilerplate. After parsing, these
@@ -22,6 +23,7 @@
 
 import { z } from 'zod';
 
+import { FieldMatcherID } from '@grafana/data';
 import type { GridLayoutItemKind } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 
 const dataQueryKindSchema = z.object({
@@ -873,7 +875,9 @@ const fieldConfigSchema = z
       .array(
         z.object({
           matcher: z.object({
-            id: z.string().describe('Matcher ID'),
+            id: z
+              .enum(FieldMatcherID)
+              .describe('Field matcher ID (e.g., "byName", "byRegexp", "byType", "byFrameRefID", "byValue")'),
             options: z.unknown().optional().describe('Matcher options'),
           }),
           properties: z.array(

--- a/public/app/features/dashboard/components/PanelEditor/OverrideCategoryTitle.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/OverrideCategoryTitle.tsx
@@ -8,7 +8,7 @@ import { type FieldMatcherUIRegistryItem } from '@grafana/ui/internal';
 interface Props {
   isExpanded: boolean;
   registry: FieldConfigOptionsRegistry;
-  matcherUi: FieldMatcherUIRegistryItem<ConfigOverrideRule>;
+  matcherUi?: FieldMatcherUIRegistryItem<ConfigOverrideRule>;
   override: ConfigOverrideRule;
   overrideName: string;
   onOverrideRemove: () => void;
@@ -25,7 +25,8 @@ export const OverrideCategoryTitle = ({
 
   const properties = override.properties.map((p) => registry.getIfExists(p.id)).filter((prop) => !!prop);
   const propertyNames = properties.map((p) => p?.name).join(', ');
-  const matcherOptions = matcherUi.optionsToLabel(override.matcher.options);
+  // Fall back to the raw matcher id when the matcher type is unknown
+  const matcherOptions = matcherUi ? matcherUi.optionsToLabel(override.matcher.options) : override.matcher.id;
 
   return (
     <div>

--- a/public/app/features/dashboard/components/PanelEditor/getFieldOverrideElements.test.ts
+++ b/public/app/features/dashboard/components/PanelEditor/getFieldOverrideElements.test.ts
@@ -13,17 +13,22 @@ jest.mock('app/features/panel/panellinks/link_srv', () => ({
   getDataLinksVariableSuggestions: () => [],
 }));
 
-jest.mock('@grafana/ui', () => ({
-  ...jest.requireActual('@grafana/ui'),
-  fieldMatchersUI: {
-    get: jest.fn().mockReturnValue({
-      name: 'By Name',
-      matcher: {},
-      component: () => null,
-    }),
-    selectOptions: jest.fn().mockReturnValue({ options: [] }),
-  },
-}));
+jest.mock('@grafana/ui', () => {
+  const byNameMatcherUi = {
+    name: 'By Name',
+    matcher: {},
+    component: () => null,
+  };
+
+  return {
+    ...jest.requireActual('@grafana/ui'),
+    fieldMatchersUI: {
+      get: jest.fn().mockReturnValue(byNameMatcherUi),
+      getIfExists: jest.fn().mockImplementation((id?: string) => (id === 'byName' ? byNameMatcherUi : undefined)),
+      selectOptions: jest.fn().mockReturnValue({ options: [] }),
+    },
+  };
+});
 
 function makeRegistry(items: FieldConfigPropertyItem[]): FieldConfigOptionsRegistry {
   return new Registry<FieldConfigPropertyItem>(() => items);
@@ -132,6 +137,45 @@ describe('getFieldOverrideCategories', () => {
       }>;
 
       expect(element.props.options).toHaveLength(3);
+    });
+  });
+
+  describe('unknown matcher id', () => {
+    const fieldConfig: FieldConfigSource = {
+      defaults: {},
+      overrides: [{ matcher: { id: 'byNamePattern', options: 'foo.*' }, properties: [{ id: 'links', value: [] }] }],
+    };
+
+    it('renders an error state for the override instead of throwing', () => {
+      const registry = makeRegistry([makeItem('links')]);
+      const categories = getFieldOverrideCategories(fieldConfig, registry, [], '', jest.fn());
+
+      // the broken override category + the "add button" category
+      expect(categories).toHaveLength(2);
+
+      const overrideCategory = categories[0];
+      expect(overrideCategory.items).toHaveLength(1);
+      expect(overrideCategory.items[0].props.id).toBe('panel-options-override-0-unknown-matcher');
+
+      const element = overrideCategory.items[0].props.render(overrideCategory.items[0]) as React.ReactElement<{
+        severity: string;
+        title: string;
+      }>;
+      expect(element.props.severity).toBe('error');
+      expect(element.props.title).toContain('byNamePattern');
+    });
+
+    it('keeps the remove override action working', () => {
+      const registry = makeRegistry([makeItem('links')]);
+      const onFieldConfigsChange = jest.fn();
+      const categories = getFieldOverrideCategories(fieldConfig, registry, [], '', onFieldConfigsChange);
+
+      const titleElement = categories[0].props.renderTitle?.(true) as React.ReactElement<{
+        onOverrideRemove: () => void;
+      }>;
+      titleElement.props.onOverrideRemove();
+
+      expect(onFieldConfigsChange).toHaveBeenCalledWith({ defaults: {}, overrides: [] });
     });
   });
 });

--- a/public/app/features/dashboard/components/PanelEditor/getFieldOverrideElements.test.ts
+++ b/public/app/features/dashboard/components/PanelEditor/getFieldOverrideElements.test.ts
@@ -178,4 +178,40 @@ describe('getFieldOverrideCategories', () => {
       expect(onFieldConfigsChange).toHaveBeenCalledWith({ defaults: {}, overrides: [] });
     });
   });
+
+  describe('matcher without visual editor', () => {
+    // 'numeric' exists in the runtime fieldMatchers registry but has no options-pane UI
+    const fieldConfig: FieldConfigSource = {
+      defaults: {},
+      overrides: [{ matcher: { id: 'numeric', options: {} }, properties: [{ id: 'links', value: [] }] }],
+    };
+
+    it('renders an info state saying the override is active, not an error', () => {
+      const registry = makeRegistry([makeItem('links')]);
+      const categories = getFieldOverrideCategories(fieldConfig, registry, [], '', jest.fn());
+
+      const overrideCategory = categories[0];
+      expect(overrideCategory.items).toHaveLength(1);
+
+      const element = overrideCategory.items[0].props.render(overrideCategory.items[0]) as React.ReactElement<{
+        severity: string;
+        title: string;
+      }>;
+      expect(element.props.severity).toBe('info');
+      expect(element.props.title).toContain('no visual editor');
+    });
+
+    it('keeps the remove override action working', () => {
+      const registry = makeRegistry([makeItem('links')]);
+      const onFieldConfigsChange = jest.fn();
+      const categories = getFieldOverrideCategories(fieldConfig, registry, [], '', onFieldConfigsChange);
+
+      const titleElement = categories[0].props.renderTitle?.(true) as React.ReactElement<{
+        onOverrideRemove: () => void;
+      }>;
+      titleElement.props.onOverrideRemove();
+
+      expect(onFieldConfigsChange).toHaveBeenCalledWith({ defaults: {}, overrides: [] });
+    });
+  });
 });

--- a/public/app/features/dashboard/components/PanelEditor/getFieldOverrideElements.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/getFieldOverrideElements.tsx
@@ -16,6 +16,7 @@ import {
 import { t } from '@grafana/i18n';
 import { type MatcherScope } from '@grafana/schema';
 import {
+  Alert,
   fieldMatchersUI,
   getUniqueMatcherScopes,
   MatcherScopeSelector,
@@ -74,7 +75,7 @@ export function getFieldOverrideCategories(
   };
 
   const onOverrideAdd = (value: SelectableValue<string>) => {
-    const info = fieldMatchers.get(value.value!);
+    const info = fieldMatchers.getIfExists(value.value!);
     if (!info) {
       return;
     }
@@ -105,7 +106,56 @@ export function getFieldOverrideCategories(
       overrideNum: idx + 1,
     });
     const overrideId = `panel-options-override-${idx}`;
-    const matcherUi = fieldMatchersUI.get(override.matcher.id);
+    const matcherUi = fieldMatchersUI.getIfExists(override.matcher.id);
+
+    // Unknown matcher id (e.g. hand-edited or generated dashboard JSON). Render the override
+    // in an error state so it can still be removed instead of crashing the options pane.
+    if (!matcherUi) {
+      const category = new OptionsPaneCategoryDescriptor({
+        title: overrideName,
+        id: overrideId,
+        forceOpen: true,
+        renderTitle: function renderOverrideTitle(isExpanded: boolean) {
+          return (
+            <OverrideCategoryTitle
+              override={override}
+              isExpanded={isExpanded}
+              registry={registry}
+              overrideName={overrideName}
+              onOverrideRemove={() => onOverrideRemove(idx)}
+            />
+          );
+        },
+      });
+
+      category.addItem(
+        new OptionsPaneItemDescriptor({
+          skipField: true,
+          id: `${overrideId}-unknown-matcher`,
+          render: function renderUnknownMatcher() {
+            return (
+              <Alert
+                severity="error"
+                title={t(
+                  'dashboard.get-field-override-categories.title-unknown-matcher',
+                  'Unknown matcher type "{{matcherId}}"',
+                  { matcherId: override.matcher.id }
+                )}
+              >
+                {t(
+                  'dashboard.get-field-override-categories.body-unknown-matcher',
+                  'This override has no effect. Remove it, or correct the matcher id in the dashboard JSON.'
+                )}
+              </Alert>
+            );
+          },
+        })
+      );
+
+      categories.push(category);
+      continue;
+    }
+
     const configPropertiesOptions = registry.selectOptions(
       undefined,
       (item) => !item.hideFromOverrides,

--- a/public/app/features/dashboard/components/PanelEditor/getFieldOverrideElements.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/getFieldOverrideElements.tsx
@@ -108,9 +108,12 @@ export function getFieldOverrideCategories(
     const overrideId = `panel-options-override-${idx}`;
     const matcherUi = fieldMatchersUI.getIfExists(override.matcher.id);
 
-    // Unknown matcher id (e.g. hand-edited or generated dashboard JSON). Render the override
-    // in an error state so it can still be removed instead of crashing the options pane.
+    // No options-pane editor for this matcher id. Either the matcher exists in the runtime
+    // registry but has no UI (e.g. numeric, byTypes - the override still applies), or the id is
+    // truly unknown (hand-edited or generated dashboard JSON - the override has no effect).
+    // Render a non-crashing state for both so the override can still be removed.
     if (!matcherUi) {
+      const runtimeMatcher = fieldMatchers.getIfExists(override.matcher.id);
       const category = new OptionsPaneCategoryDescriptor({
         title: overrideName,
         id: overrideId,
@@ -133,6 +136,23 @@ export function getFieldOverrideCategories(
           skipField: true,
           id: `${overrideId}-unknown-matcher`,
           render: function renderUnknownMatcher() {
+            if (runtimeMatcher) {
+              return (
+                <Alert
+                  severity="info"
+                  title={t(
+                    'dashboard.get-field-override-categories.title-matcher-no-editor',
+                    'Matcher "{{matcherName}}" has no visual editor',
+                    { matcherName: runtimeMatcher.name }
+                  )}
+                >
+                  {t(
+                    'dashboard.get-field-override-categories.body-matcher-no-editor',
+                    'This override is active, but this matcher type can only be edited in the dashboard JSON.'
+                  )}
+                </Alert>
+              );
+            }
             return (
               <Alert
                 severity="error"

--- a/public/app/features/dashboard/dashgrid/SeriesVisibilityConfigFactory.ts
+++ b/public/app/features/dashboard/dashgrid/SeriesVisibilityConfigFactory.ts
@@ -184,7 +184,11 @@ const getNamesOfHiddenFields = (overrides: ConfigOverrideRule[], data: DataFrame
     const property = override.properties.find((p) => p.id === 'custom.hideFrom');
 
     if (property !== undefined && property.value?.legend === true) {
-      const info = fieldMatchers.get(override.matcher.id);
+      // Unknown matcher ids never apply at runtime (see fieldOverrides), so they hide nothing
+      const info = fieldMatchers.getIfExists(override.matcher.id);
+      if (!info) {
+        continue;
+      }
       const matcher = info.get(override.matcher.options);
 
       for (const frame of data) {

--- a/public/app/features/transformers/configFromQuery/ConfigFromQueryTransformerEditor.tsx
+++ b/public/app/features/transformers/configFromQuery/ConfigFromQueryTransformerEditor.tsx
@@ -20,7 +20,7 @@ export function ConfigFromQueryTransformerEditor({ input, onChange, options }: P
 
   const currentRefId = options.configRefId || 'config';
   const currentMatcher = options.applyTo ?? { id: FieldMatcherID.byType, options: 'number' };
-  const matcherUI = fieldMatchersUI.get(currentMatcher.id);
+  const matcherUI = fieldMatchersUI.getIfExists(currentMatcher.id) ?? fieldMatchersUI.get(FieldMatcherID.byType);
   const configFrame = input.find((x) => x.refId === currentRefId);
 
   const onRefIdChange = (value: SelectableValue<string>) => {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -5813,12 +5813,14 @@
       }
     },
     "get-field-override-categories": {
+      "body-unknown-matcher": "This override has no effect. Remove it, or correct the matcher id in the dashboard JSON.",
       "label-add-field-override": "Add field override",
       "label-add-override-property": "Add override property",
       "override-name": "Override {{overrideNum}}",
       "title": {
         "add-button": "add button"
-      }
+      },
+      "title-unknown-matcher": "Unknown matcher type \"{{matcherId}}\""
     },
     "get-library-panel-options-category": {
       "descriptor": {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -5813,6 +5813,7 @@
       }
     },
     "get-field-override-categories": {
+      "body-matcher-no-editor": "This override is active, but this matcher type can only be edited in the dashboard JSON.",
       "body-unknown-matcher": "This override has no effect. Remove it, or correct the matcher id in the dashboard JSON.",
       "label-add-field-override": "Add field override",
       "label-add-override-property": "Add override property",
@@ -5820,6 +5821,7 @@
       "title": {
         "add-button": "add button"
       },
+      "title-matcher-no-editor": "Matcher \"{{matcherName}}\" has no visual editor",
       "title-unknown-matcher": "Unknown matcher type \"{{matcherId}}\""
     },
     "get-library-panel-options-category": {


### PR DESCRIPTION
A field override with an unknown matcher id (hand-edited or generated dashboard JSON) crashed the panel editor: the options pane resolved the matcher UI with a throwing registry lookup. The same class of crash existed in the legend visibility toggle and the config-from-query transformer editor.

Render such overrides in an error state instead - the override is clearly marked as having no effect and can still be removed. No silent coercion to a different matcher. The legend flow skips unknown matchers, matching runtime fieldOverrides semantics.

Also constrain matcher.id in the MutationAPI payload schemas to the FieldMatcherID enum so programmatic clients (including LLM tools, which receive this schema as JSON schema) get invalid ids rejected at the API boundary instead of persisting them.
