### PR TITLE
fix: nats notifier subject pattern

### DIFF
--- a/pkg/storage/unified/resource/notifier_nats.go
+++ b/pkg/storage/unified/resource/notifier_nats.go
@@ -42,10 +42,10 @@ func watchNotificationTypeToAction(t resourcepb.WatchNotification_Type) (kv.Data
 }
 
 // natsNotifier emits an Event per WatchNotification received from NATS rather
-// than by polling the store. Watch subscribes to the entire stream (SubjectAll)
-// and ignores the resource selectors in WatchOptions, so it is not a drop-in
-// per-watch notifier. PreviousRV is carried on the wire, matching the
-// store-sourced notifiers.
+// than by polling the store. Watch subscribes to the whole resource change
+// stream (SubjectAllResources) and ignores the resource selectors in
+// WatchOptions, so it is not a drop-in per-watch notifier. PreviousRV is carried
+// on the wire, matching the store-sourced notifiers.
 //
 // Delivery is at-most-once (core NATS, no JetStream): a missed message is never
 // redelivered, and there is no server-side polling backstop when this is the
@@ -143,7 +143,7 @@ func (n *natsNotifier) Watch(ctx context.Context, opts WatchOptions) <-chan Even
 // unsubscribes on ctx cancel and returns true; on failure it logs and returns
 // false so the caller can retry.
 func (n *natsNotifier) trySubscribe(ctx context.Context, handler func(subject string, data []byte)) bool {
-	sub, err := n.subscriber.Subscribe(ctx, resourcewatch.SubjectAll, handler)
+	sub, err := n.subscriber.Subscribe(ctx, resourcewatch.SubjectAllResources, handler)
 	if err != nil {
 		n.log.Error("failed to subscribe to nats, will retry", "error", err)
 		return false

--- a/pkg/storage/unified/resource/notifier_nats_test.go
+++ b/pkg/storage/unified/resource/notifier_nats_test.go
@@ -124,7 +124,7 @@ func TestNatsNotifierWatch_ConvertsNotifications(t *testing.T) {
 			defer cancel()
 			out := n.Watch(ctx, WatchOptions{})
 			require.NotNil(t, sub.handler)
-			assert.Equal(t, resourcewatch.SubjectAll, sub.subject)
+			assert.Equal(t, resourcewatch.SubjectAllResources, sub.subject)
 
 			sub.handler("some.subject", mustMarshalNotification(t, &resourcepb.WatchNotification{
 				Type:                    tc.typ,

--- a/pkg/storage/unified/resourcewatch/subject.go
+++ b/pkg/storage/unified/resourcewatch/subject.go
@@ -10,11 +10,11 @@ import (
 // position to watch every namespace's notifications for a resource.
 const allNamespaces = "*"
 
-// SubjectAllResources matches every Subject(...) for a single-prefix grafana.app
-// group ({prefix}.grafana.app.{namespace}.{resource}). Single-token "*" wildcards
-// keep out non-resource bus traffic (e.g. $SYS.*) that a ">" firehose would
-// deliver and fail to unmarshal. Groups with >1 token before .grafana.app are not
-// matched.
+// SubjectAllResources matches every Subject(...) whose group is a single-token
+// grafana.app group ({group}.grafana.app.{namespace}.{resource}). Single-token
+// "*" wildcards keep out non-resource bus traffic (e.g. $SYS.*) that a ">"
+// firehose would deliver and fail to unmarshal. Groups with >1 token before
+// .grafana.app are not matched.
 const SubjectAllResources = "*.grafana.app.*.*"
 
 // Subject returns the NATS subject that carries change notifications for a

--- a/pkg/storage/unified/resourcewatch/subject.go
+++ b/pkg/storage/unified/resourcewatch/subject.go
@@ -10,10 +10,12 @@ import (
 // position to watch every namespace's notifications for a resource.
 const allNamespaces = "*"
 
-// SubjectAll is the NATS multi-token wildcard (">"), matching every Subject(...)
-// value regardless of group, namespace, or resource. A consumer that needs the
-// full change stream (not one resource type) subscribes to this.
-const SubjectAll = ">"
+// SubjectAllResources matches every Subject(...) for a single-prefix grafana.app
+// group ({prefix}.grafana.app.{namespace}.{resource}). Single-token "*" wildcards
+// keep out non-resource bus traffic (e.g. $SYS.*) that a ">" firehose would
+// deliver and fail to unmarshal. Groups with >1 token before .grafana.app are not
+// matched.
+const SubjectAllResources = "*.grafana.app.*.*"
 
 // Subject returns the NATS subject that carries change notifications for a
 // resource type within a namespace, as the dotted tokens


### PR DESCRIPTION
Respect subject pattern: `*.grafana.app.*.*`. Noticed `unmarshal_error` cases on pod recycles: https://ops.grafana-ops.net/goto/slbx8m?orgId=stacks-27821 due to system events.