### PR TITLE
Search: move IAM table column definitions to the legacy search backends

### DIFF
--- a/pkg/registry/apis/iam/team/legacy_search.go
+++ b/pkg/registry/apis/iam/team/legacy_search.go
@@ -136,6 +136,8 @@ func getResourceKey(t *team.TeamDTO, namespace string) *resourcepb.ResourceKey {
 	}
 }
 
+var teamColumns = resource.TableColumnsByName(builders.TeamSearchFields)
+
 func getColumns(fields []string) []*resourcepb.ResourceTableColumnDefinition {
 	columns := getDefaultColumns()
 
@@ -148,7 +150,7 @@ func getColumns(fields []string) []*resourcepb.ResourceTableColumnDefinition {
 			continue
 		}
 		fieldName := strings.TrimPrefix(field, resource.SEARCH_FIELD_PREFIX)
-		if col, ok := builders.TeamSearchTableColumnDefinitions[fieldName]; ok {
+		if col, ok := teamColumns[fieldName]; ok {
 			columns = append(columns, col)
 		}
 	}

--- a/pkg/registry/apis/iam/teambinding/legacy_search.go
+++ b/pkg/registry/apis/iam/teambinding/legacy_search.go
@@ -183,11 +183,13 @@ func getFieldValueFromRequirements(reqs []*resourcepb.Requirement, key string) s
 	return ""
 }
 
+var teamBindingColumnDefs = resource.TableColumnsByName(builders.TeamBindingSearchFields)
+
 func teamBindingColumns(fields []string) []*resourcepb.ResourceTableColumnDefinition {
 	cols := make([]*resourcepb.ResourceTableColumnDefinition, 0, len(fields))
 	for _, f := range fields {
 		name := strings.TrimPrefix(f, resource.SEARCH_FIELD_PREFIX)
-		if col, ok := builders.TeamBindingTableColumnDefinitions[name]; ok {
+		if col, ok := teamBindingColumnDefs[name]; ok {
 			cols = append(cols, col)
 		}
 	}

--- a/pkg/registry/apis/iam/user/legacy_search.go
+++ b/pkg/registry/apis/iam/user/legacy_search.go
@@ -198,6 +198,8 @@ func getResourceKey(item *org.OrgUserDTO, namespace string) *resourcepb.Resource
 	}
 }
 
+var userColumns = resource.TableColumnsByName(builders.UserSearchFields)
+
 func getColumns(fields []string) []*resourcepb.ResourceTableColumnDefinition {
 	cols := make([]*resourcepb.ResourceTableColumnDefinition, 0, len(fields))
 	standardSearchFields := resource.StandardSearchFields()
@@ -206,15 +208,15 @@ func getColumns(fields []string) []*resourcepb.ResourceTableColumnDefinition {
 		case resource.SEARCH_FIELD_TITLE:
 			cols = append(cols, standardSearchFields.Field(resource.SEARCH_FIELD_TITLE))
 		case fieldLastSeenAt:
-			cols = append(cols, builders.UserTableColumnDefinitions[builders.USER_LAST_SEEN_AT])
+			cols = append(cols, userColumns[builders.USER_LAST_SEEN_AT])
 		case fieldRole:
-			cols = append(cols, builders.UserTableColumnDefinitions[builders.USER_ROLE])
+			cols = append(cols, userColumns[builders.USER_ROLE])
 		case fieldEmail:
-			cols = append(cols, builders.UserTableColumnDefinitions[builders.USER_EMAIL])
+			cols = append(cols, userColumns[builders.USER_EMAIL])
 		case fieldLogin:
-			cols = append(cols, builders.UserTableColumnDefinitions[builders.USER_LOGIN])
+			cols = append(cols, userColumns[builders.USER_LOGIN])
 		case fieldDisabled:
-			cols = append(cols, builders.UserTableColumnDefinitions[builders.USER_DISABLED])
+			cols = append(cols, userColumns[builders.USER_DISABLED])
 		case resource.SEARCH_FIELD_CREATED:
 			cols = append(cols, &resourcepb.ResourceTableColumnDefinition{
 				Name: resource.SEARCH_FIELD_CREATED,

--- a/pkg/storage/unified/resource/search_field.go
+++ b/pkg/storage/unified/resource/search_field.go
@@ -147,6 +147,17 @@ func SearchFieldDefinitionsToTableColumns(sfds []SearchFieldDefinition) []*resou
 	return out
 }
 
+// TableColumnsByName keys the table columns by field name, so the IAM legacy
+// SQL search backends can look one up by a requested field name.
+func TableColumnsByName(sfds []SearchFieldDefinition) map[string]*resourcepb.ResourceTableColumnDefinition {
+	cols := SearchFieldDefinitionsToTableColumns(sfds)
+	out := make(map[string]*resourcepb.ResourceTableColumnDefinition, len(cols))
+	for _, c := range cols {
+		out[c.Name] = c
+	}
+	return out
+}
+
 // protoTypeFromSearchFieldType maps a SearchFieldType back to its proto
 // counterpart. SearchFieldType does not preserve INT32 / FLOAT / DATE_TIME
 // distinctions, so this returns the wider variant (INT64, DOUBLE, DATE)

--- a/pkg/storage/unified/search/builders/document.go
+++ b/pkg/storage/unified/search/builders/document.go
@@ -97,19 +97,6 @@ func All(sql db.DB, sprinkles DashboardStats) ([]resource.DocumentBuilderInfo, e
 	return []resource.DocumentBuilderInfo{dashboards, users, extGroupMappings, teams, teamBindings, alertRules, recordingRules}, nil
 }
 
-// tableColumnsByName builds a map[fieldName]*ResourceTableColumnDefinition
-// from the given SearchFieldDefinitions. Used by IAM builders that expose
-// the historical XxxTableColumnDefinitions shape for wire-API consumers
-// (legacy SQL search backends) that look fields up by name.
-func tableColumnsByName(sfds []resource.SearchFieldDefinition) map[string]*resourcepb.ResourceTableColumnDefinition {
-	cols := resource.SearchFieldDefinitionsToTableColumns(sfds)
-	out := make(map[string]*resourcepb.ResourceTableColumnDefinition, len(cols))
-	for _, c := range cols {
-		out[c.Name] = c
-	}
-	return out
-}
-
 // iamBuilder assembles the DocumentBuilderInfo for an IAM kind. Every IAM kind
 // is wired the same way: its search fields come from the generated IAM manifest
 // and its documents are extracted by the standard builder, so only the resource

--- a/pkg/storage/unified/search/builders/external_group_mapping.go
+++ b/pkg/storage/unified/search/builders/external_group_mapping.go
@@ -7,7 +7,7 @@ import (
 
 // externalGroupMappingSearchFields are read from the generated IAM manifest,
 // where they are declared in apps/iam/kinds/externalgroupmapping.cue.
-var externalGroupMappingSearchFields = resource.NewManifestBackedProvider(iamManifests).Fields(
+var externalGroupMappingSearchFields = iamProvider.Fields(
 	iamv0.ExternalGroupMappingResourceInfo.GroupVersionResource(),
 )
 

--- a/pkg/storage/unified/search/builders/team.go
+++ b/pkg/storage/unified/search/builders/team.go
@@ -21,16 +21,14 @@ var TeamSortableExtraFields = []string{
 	TEAM_SEARCH_EMAIL,
 }
 
-// teamSearchFields are read from the generated IAM manifest, where they are
+// TeamSearchFields are read from the generated IAM manifest, where they are
 // declared in apps/iam/kinds/team.cue.
-var teamSearchFields = resource.NewManifestBackedProvider(iamManifests).Fields(
+//
+// Exported for the IAM legacy SQL search backend; do not mutate.
+var TeamSearchFields = iamProvider.Fields(
 	v0alpha1.TeamResourceInfo.GroupVersionResource(),
 )
 
-// TeamSearchTableColumnDefinitions exposes column-defs by name for the
-// IAM legacy SQL backend in team/legacy_search.go.
-var TeamSearchTableColumnDefinitions = tableColumnsByName(teamSearchFields)
-
 func GetTeamSearchBuilder() (resource.DocumentBuilderInfo, error) {
-	return iamBuilder(v0alpha1.TeamResourceInfo, teamSearchFields)
+	return iamBuilder(v0alpha1.TeamResourceInfo, TeamSearchFields)
 }

--- a/pkg/storage/unified/search/builders/teambinding.go
+++ b/pkg/storage/unified/search/builders/teambinding.go
@@ -12,16 +12,14 @@ const (
 	TEAM_BINDING_EXTERNAL   = "external"
 )
 
-// teamBindingSearchFields are read from the generated IAM manifest, where they
+// TeamBindingSearchFields are read from the generated IAM manifest, where they
 // are declared in apps/iam/kinds/teambinding.cue.
-var teamBindingSearchFields = resource.NewManifestBackedProvider(iamManifests).Fields(
+//
+// Exported for the IAM legacy SQL search backend; do not mutate.
+var TeamBindingSearchFields = iamProvider.Fields(
 	iamv0.TeamBindingResourceInfo.GroupVersionResource(),
 )
 
-// TeamBindingTableColumnDefinitions exposes column-defs by name for the
-// IAM legacy SQL backend in teambinding/legacy_search.go.
-var TeamBindingTableColumnDefinitions = tableColumnsByName(teamBindingSearchFields)
-
 func GetTeamBindingBuilder() (resource.DocumentBuilderInfo, error) {
-	return iamBuilder(iamv0.TeamBindingResourceInfo, teamBindingSearchFields)
+	return iamBuilder(iamv0.TeamBindingResourceInfo, TeamBindingSearchFields)
 }

--- a/pkg/storage/unified/search/builders/user.go
+++ b/pkg/storage/unified/search/builders/user.go
@@ -13,6 +13,10 @@ import (
 // populate IndexableDocument.SelectableFields for IAM kinds.
 var iamManifests = []app.Manifest{iam.LocalManifest()}
 
+// iamProvider is shared by all IAM builders and their exported field sets, so
+// the manifest is parsed once.
+var iamProvider = resource.NewManifestBackedProvider(iamManifests)
+
 const (
 	USER_EMAIL        = "email"
 	USER_LOGIN        = "login"
@@ -29,7 +33,7 @@ var UserSortableExtraFields = []string{
 	USER_LAST_SEEN_AT,
 }
 
-// userSearchFields are read from the generated IAM manifest (declared in
+// UserSearchFields are read from the generated IAM manifest (declared in
 // apps/iam/kinds/user.cue).
 //
 // lastSeenAt (int64) and disabled (boolean) declare the filter capability to
@@ -40,15 +44,10 @@ var UserSortableExtraFields = []string{
 // would not match a numeric-indexed term yet. No in-tree client filters by
 // lastSeenAt or disabled today, so this is a known gap rather than a rollout
 // concern.
-var userSearchFields = resource.NewManifestBackedProvider(iamManifests).Fields(iamv0.UserResourceInfo.GroupVersionResource())
-
-// UserTableColumnDefinitions exposes column-defs by name for wire-API
-// consumers (the IAM legacy SQL backend in user/legacy_search.go).
-// Derived from userSearchFields via tableColumnsByName. UniqueValues was
-// set on the historical hand-written email/login entries but has no
-// production consumer and is not preserved.
-var UserTableColumnDefinitions = tableColumnsByName(userSearchFields)
+//
+// Exported for the IAM legacy SQL search backend; do not mutate.
+var UserSearchFields = iamProvider.Fields(iamv0.UserResourceInfo.GroupVersionResource())
 
 func GetUserBuilder() (resource.DocumentBuilderInfo, error) {
-	return iamBuilder(iamv0.UserResourceInfo, userSearchFields)
+	return iamBuilder(iamv0.UserResourceInfo, UserSearchFields)
 }


### PR DESCRIPTION
The `XxxTableColumnDefinitions` maps were used only by the IAM legacy SQL search backends, but they lived in the search document-builder package. This moves them next to their consumers: each backend now builds its own column map from the manifest-declared field set, via a new `resource.TableColumnsByName` helper that sits alongside the existing `SearchFieldDefinitionsToTableColumns`.

The four IAM builders also each constructed their own manifest-backed provider; they now share a single one. The per-kind field sets are exported so the legacy backends can derive their columns from them. The IAM field-name constants stay in the builder package, since they are referenced across the IAM API layer and by enterprise. No behavior change.

Part of grafana/search-and-storage-team#827.
