### PR TITLE
Provisioning: Fix blank Action for deleted resources in PR comment

### DIFF
--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/comment.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/comment.go
@@ -165,7 +165,11 @@ const commentTemplateFooter = `
 _{{if .RepositoryTitle}}🔄 Synced from {{if .RepositoryAdminURL}}[**{{.SafeRepositoryTitle}}**]({{.RepositoryAdminURL}}){{else}}**{{.SafeRepositoryTitle}}**{{end}} · {{end}}Posted by [{{.GrafanaHost}}]({{.GrafanaBaseURL}})_`
 
 func (f *fileChangeInfo) Action() string {
-	if f.Parsed != nil {
+	// Prefer the parsed ResourceAction, but fall back to the raw FileAction when
+	// it is empty. Deleted files are parsed from the previous ref without a
+	// DryRun, so Parsed.Action is never set and only Change.Action ("deleted")
+	// carries the action.
+	if f.Parsed != nil && f.Parsed.Action != "" {
 		return string(f.Parsed.Action)
 	}
 	return string(f.Change.Action)

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/comment_test.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/comment_test.go
@@ -356,6 +356,58 @@ func TestGenerateComment_NilParsedDeletedInTableTemplate(t *testing.T) {
 	require.Contains(t, capturedComment, "File")
 }
 
+// TestGenerateComment_ParsedDeletedWithoutResourceAction reproduces how deleted
+// files are evaluated: evaluateDeletedFile parses the file at the previous ref
+// (so Parsed is non-nil) but never runs a DryRun, so Parsed.Action stays empty.
+// The action label must fall back to the FileAction ("deleted") instead of
+// rendering a blank Action column.
+func TestGenerateComment_ParsedDeletedWithoutResourceAction(t *testing.T) {
+	repo := repository.NewMockPullRequestRepo(t)
+
+	var capturedComment string
+	repo.On("CommentPullRequest", context.Background(), 1, mock.MatchedBy(func(comment string) bool {
+		capturedComment = comment
+		return true
+	})).Return(nil)
+
+	info := changeInfo{
+		GrafanaBaseURL: "http://host/",
+		Changes: []fileChangeInfo{
+			{
+				Parsed: &resources.ParsedResource{
+					Info: &repository.FileInfo{
+						Path: "valid.json",
+					},
+					Action: v0alpha1.ResourceActionCreate,
+					GVK:    schema.GroupVersionKind{Kind: "Dashboard"},
+				},
+				Title:      "Valid Dashboard",
+				PreviewURL: "http://grafana/admin/preview",
+			},
+			{
+				// Parsed is populated from the previous ref but Action is unset,
+				// exactly as evaluateDeletedFile leaves it.
+				Parsed: &resources.ParsedResource{
+					Info: &repository.FileInfo{
+						Path: "deleted-file.json",
+					},
+					GVK: schema.GroupVersionKind{Kind: "Dashboard"},
+				},
+				Change: repository.VersionedFileChange{
+					Action: repository.FileActionDeleted,
+					Path:   "deleted-file.json",
+				},
+				Title: "Deleted Dashboard",
+			},
+		},
+	}
+
+	commenter := NewCommenter(false)
+	err := commenter.Comment(context.Background(), repo, 1, info)
+	require.NoError(t, err)
+	require.Contains(t, capturedComment, "🗑️ Deleted")
+}
+
 func TestGenerateComment_SingleChangeNilParsed(t *testing.T) {
 	repo := repository.NewMockPullRequestRepo(t)
 


### PR DESCRIPTION
## What

Deleted resources now show "🗑️ Deleted" in the **Action** column of the Git Sync pull-request comment, instead of a blank cell.

## Why

When a pull request deletes provisioned resources, the summary comment rendered an empty Action column for those rows, while Added/Updated rendered correctly. Reviewers couldn't distinguish deletions from unlabeled changes.

## How

`evaluateDeletedFile` parses the file from the previous ref to recover title/kind but — unlike the create/update path — never runs `DryRun`, which is the only place that sets `Parsed.Action`. `Action()` returned `Parsed.Action` whenever `Parsed` was non-nil, so it returned the empty string and never fell back to the raw `FileAction` (`"deleted"`), leaving the Action column blank.

The fix falls back to `Change.Action` when the parsed `ResourceAction` is empty; the existing `ActionLabel` switch already maps `"deleted"` → "🗑️ Deleted".

## Testing

- Added `TestGenerateComment_ParsedDeletedWithoutResourceAction`, reproducing the exact `evaluateDeletedFile` shape (non-nil `Parsed`, empty `Action`, `Change.Action = deleted`). It fails without the fix (blank cell) and passes with it.
- `go vet`, `gofmt`, and the full `pullrequest` package test suite pass.

## Checklist

- [x] Tests added/updated
- [ ] Documentation updated (n/a)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)