### PR TITLE
SSE SQL: disable file reads at engine level

### DIFF
--- a/pkg/expr/sql/db.go
+++ b/pkg/expr/sql/db.go
@@ -77,7 +77,7 @@ func (db *DB) QueryFrames(ctx context.Context, tracer tracing.Tracer, name strin
 	session := mysql.NewBaseSession()
 
 	// Create a new context with the session and tracer
-	mCtx := mysql.NewContext(ctx, mysql.WithSession(session), mysql.WithTracer(tracer), mysql.WithDisableFileWrites(true), mysql.WithTraceRedaction(true))
+	mCtx := mysql.NewContext(ctx, mysql.WithSession(session), mysql.WithTracer(tracer), mysql.WithDisableFileWrites(true), mysql.WithDisableFileReads(true), mysql.WithTraceRedaction(true))
 
 	// Select the database in the context
 	mCtx.SetCurrentDatabase(dbName)

--- a/pkg/expr/sql/db_test.go
+++ b/pkg/expr/sql/db_test.go
@@ -399,6 +399,21 @@ func TestQueryFrames_Limits(t *testing.T) {
 	}
 }
 
+// TestQueryFrames_FileReadsDisabled verifies the engine-level defense-in-depth:
+// even if a file-reading query bypasses the query guard, the go-mysql-server
+// context disables LOAD_FILE via WithDisableFileReads.
+func TestQueryFrames_FileReadsDisabled(t *testing.T) {
+	// Use a permissive guard so the query reaches the engine instead of being
+	// rejected by the default AllowQuery parser guard.
+	db := DB{queryGuard: func(refID, rawSQL string) (bool, error) { return true, nil }}
+
+	_, err := db.QueryFrames(context.Background(), &testTracer{}, "a",
+		`SELECT LOAD_FILE('/etc/hostname') AS v`, nil)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "file read operations")
+}
+
 type testTracer struct {
 	trace.Tracer
 }
@@ -425,4 +440,7 @@ func (ts *testSpan) IsRecording() bool {
 }
 
 func (ts *testSpan) AddEvent(name string, options ...trace.EventOption) {
+}
+
+func (ts *testSpan) RecordError(err error, options ...trace.EventOption) {
 }


### PR DESCRIPTION
## What

Adds `mysql.WithDisableFileReads(true)` to the go-mysql-server context in `pkg/expr/sql/db.go`, alongside the existing `WithDisableFileWrites(true)`.

## Why

Defense-in-depth for SQL expressions. The parser guard (`AllowQuery`) already blocks `LOAD_FILE()` / `LOAD DATA INFILE` at parse time, but enabling the engine-level option ensures file reads are refused by go-mysql-server itself even if a query were to bypass the guard. This mirrors the file-writes protection already in place.

The option is provided by our go-mysql-server fork (`v0.20.2-grafana-4`) and returns `ErrFileReadsDisabled` for file-read attempts.

## Tests

- Added `TestQueryFrames_FileReadsDisabled`, which injects a permissive query guard so a `LOAD_FILE` query reaches the engine, then asserts the engine-level protection fires.
- `go test ./pkg/expr/sql/` and `go vet ./pkg/expr/sql/` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)