### PR TITLE
fix(annotations): scope proxy token exchange to stack namespace

### DIFF
--- a/pkg/services/annotations/annotationsapi/api_client.go
+++ b/pkg/services/annotations/annotationsapi/api_client.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 
 	authnlib "github.com/grafana/authlib/authn"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
 	"github.com/grafana/grafana/pkg/setting"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -48,11 +49,12 @@ func newAnnotationAPIClient(cfg *setting.Cfg, userSvc user.Service, exchanger au
 		return nil
 	}
 
-	restCfg := buildRESTConfig(url, exchanger, cfg.Env == setting.Dev)
+	nsMapper := request.GetNamespaceMapper(cfg)
+	restCfg := buildRESTConfig(url, exchanger, nsMapper, cfg.Env == setting.Dev)
 
 	return &annotationAPIClient{
 		k8sClient: client.NewK8sHandler(
-			request.GetNamespaceMapper(cfg),
+			nsMapper,
 			annotationV0.AnnotationKind().GroupVersionResource(),
 			func(_ context.Context) (*rest.Config, error) { return restCfg, nil },
 			userSvc,
@@ -237,10 +239,10 @@ func newTokenExchangeClient(token, tokenExchangeURL string, allowInsecure bool) 
 	return tc, nil
 }
 
-func buildRESTConfig(url string, exchanger authnlib.TokenExchanger, allowInsecure bool) *rest.Config {
+func buildRESTConfig(url string, exchanger authnlib.TokenExchanger, nsMapper request.NamespaceMapper, allowInsecure bool) *rest.Config {
 	return &rest.Config{
 		Host:          url,
-		WrapTransport: newBearerTokenExchangeWrapper(exchanger),
+		WrapTransport: newBearerTokenExchangeWrapper(exchanger, nsMapper),
 		TLSClientConfig: rest.TLSClientConfig{
 			Insecure: allowInsecure,
 		},
@@ -249,13 +251,20 @@ func buildRESTConfig(url string, exchanger authnlib.TokenExchanger, allowInsecur
 
 type bearerTokenExchangeRT struct {
 	exchanger authnlib.TokenExchanger
+	nsMapper  request.NamespaceMapper
 	next      http.RoundTripper
 }
 
 func (rt *bearerTokenExchangeRT) RoundTrip(req *http.Request) (*http.Response, error) {
-	resp, err := rt.exchanger.Exchange(req.Context(), authnlib.TokenExchangeRequest{
+	ctx := req.Context()
+	requester, err := identity.GetRequester(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("resolving requester for token exchange: %w", err)
+	}
+
+	resp, err := rt.exchanger.Exchange(ctx, authnlib.TokenExchangeRequest{
 		Audiences: []string{annotationServerAudience},
-		Namespace: "*",
+		Namespace: rt.nsMapper(requester.GetOrgID()),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("exchanging token: %w", err)
@@ -265,8 +274,8 @@ func (rt *bearerTokenExchangeRT) RoundTrip(req *http.Request) (*http.Response, e
 	return rt.next.RoundTrip(req)
 }
 
-func newBearerTokenExchangeWrapper(exchanger authnlib.TokenExchanger) func(http.RoundTripper) http.RoundTripper {
+func newBearerTokenExchangeWrapper(exchanger authnlib.TokenExchanger, nsMapper request.NamespaceMapper) func(http.RoundTripper) http.RoundTripper {
 	return func(rt http.RoundTripper) http.RoundTripper {
-		return &bearerTokenExchangeRT{exchanger: exchanger, next: rt}
+		return &bearerTokenExchangeRT{exchanger: exchanger, nsMapper: nsMapper, next: rt}
 	}
 }

--- a/pkg/services/annotations/annotationsapi/api_client_test.go
+++ b/pkg/services/annotations/annotationsapi/api_client_test.go
@@ -1,0 +1,102 @@
+package annotationsapi
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	authnlib "github.com/grafana/authlib/authn"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/setting"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeTokenExchanger struct {
+	gotRequest authnlib.TokenExchangeRequest
+}
+
+func (f *fakeTokenExchanger) Exchange(_ context.Context, r authnlib.TokenExchangeRequest) (*authnlib.TokenExchangeResponse, error) {
+	f.gotRequest = r
+	return &authnlib.TokenExchangeResponse{Token: "signed-token"}, nil
+}
+
+type stubRoundTripper struct {
+	gotToken string
+}
+
+func (s *stubRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	s.gotToken = req.Header.Get("X-Access-Token")
+	return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}, nil
+}
+
+func TestNewAnnotationAPIClient_TokenExchange(t *testing.T) {
+	tests := []struct {
+		name          string
+		stackID       string
+		requester     *identity.StaticRequester
+		wantNamespace string
+		wantErr       bool
+	}{
+		{
+			name:          "scopes to stack namespace when stackID is set",
+			stackID:       "123",
+			requester:     &identity.StaticRequester{OrgID: 1},
+			wantNamespace: "stacks-123",
+		},
+		{
+			name:          "scopes to the default namespace when stackID is not set and orgID is 1",
+			requester:     &identity.StaticRequester{OrgID: 1},
+			wantNamespace: "default",
+		},
+		{
+			name:          "scopes to the org namespace when stackID is not set and orgID is not 1",
+			requester:     &identity.StaticRequester{OrgID: 7},
+			wantNamespace: "org-7",
+		},
+		{
+			name:    "fails when the requester is missing",
+			stackID: "123",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &setting.Cfg{
+				StackID: tt.stackID,
+				AnnotationAppPlatform: setting.AnnotationAppPlatformSettings{
+					APIServerURL: "https://annotation.cluster.local",
+				},
+			}
+
+			exchanger := &fakeTokenExchanger{}
+			c := newAnnotationAPIClient(cfg, nil, exchanger)
+			require.NotNil(t, c)
+			require.NotNil(t, c.restCfg.WrapTransport)
+
+			next := &stubRoundTripper{}
+			rt := c.restCfg.WrapTransport(next)
+
+			req, err := http.NewRequest(http.MethodPost, cfg.AnnotationAppPlatform.APIServerURL+"/annotations", http.NoBody)
+			require.NoError(t, err)
+			if tt.requester != nil {
+				req = req.WithContext(identity.WithRequester(req.Context(), tt.requester))
+			}
+
+			resp, err := rt.RoundTrip(req)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Empty(t, next.gotToken)
+				return
+			}
+			require.NoError(t, err)
+			defer func() { require.NoError(t, resp.Body.Close()) }()
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+
+			assert.Equal(t, tt.wantNamespace, exchanger.gotRequest.Namespace)
+			assert.Equal(t, []string{annotationServerAudience}, exchanger.gotRequest.Audiences)
+			assert.Equal(t, "signed-token", next.gotToken)
+		})
+	}
+}


### PR DESCRIPTION
This PR fixes a 500 error when the legacy annotations API proxies writes to the annotation service by scoping the exchanged token to the stack's namespace (`stacks-<StackID>`) instead of the `*` wildcard. This lets ordinary stack-scoped `grpc_client_authentication` tokens work with the proxy.

This resolves the the following error seen when proxying writes to the annotation service:
```
exchanging token: invalid exchange response: failed to set valid namespace for token
```