### PR TITLE
Table: Fix apply to entire row when multiple columns enable it

### DIFF
--- a/docs/sources/visualizations/panels-visualizations/visualizations/table/index.md
+++ b/docs/sources/visualizations/panels-visualizations/visualizations/table/index.md
@@ -341,7 +341,7 @@ The colored background cell type has the following options:
 | Option | Description |
 | ------ | ----------- |
 | Background display mode | Choose between **Basic** and **Gradient**. |
-| Apply to entire row | Toggle the switch on to apply the background color that's configured for the cell to the whole row. |
+| Apply to entire row | Toggle the switch on to apply the background color that's configured for the cell to the whole row. When more than one field has this option enabled (for example, when it's set through the panel-level cell type or through overrides that target multiple fields), the row uses the color from the first (leftmost) matching column. |
 | Cell value inspect | <p>Enables value inspection from table cells. When the switch is toggled on, clicking the inspect icon in a cell opens the **Inspect value** drawer which contains two tabs: **Plain text** and **Code editor**.</p><p>Grafana attempts to automatically detect the type of data in the cell and opens the drawer with the associated tab showing. However, you can switch back and forth between tabs.</p> |
 | Tooltip from field | Toggle on the **Tooltip from field** switch to use the values from another field (or column) in a tooltip. For more information, refer to the [Tooltip from field](#tooltip-from-field). |
 | Styling from field | Toggle on the **Styling from field** switch to apply the styling from another field (or column). The referenced field must contain CSS properties formatted in JSON object syntax (for example, `{"name":"John"}`). For more information, refer to the [Styling from field](#styling-from-field). |

--- a/packages/grafana-ui/src/components/Table/TableNG/legacy/LegacyTableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/legacy/LegacyTableNG.tsx
@@ -705,6 +705,8 @@ export function LegacyTableNG(props: TableNGProps) {
           !IS_SAFARI_26 && typeof rowHeight !== 'string' && (shouldTextOverflow(field) || Boolean(maxRowHeight));
         const textWrap = typeof rowHeight === 'string' || shouldTextWrap(field);
         const canBeColorized = canFieldBeColorized(cellType, applyToRowBgFn);
+        const fieldAppliesToRow =
+          cellOptions.type === TableCellDisplayMode.ColorBackground && cellOptions.applyToRow === true;
         const cellStyleOptions: TableCellStyleOptions = {
           textAlign,
           textWrap,
@@ -742,7 +744,9 @@ export function LegacyTableNG(props: TableNGProps) {
           }
 
           let style: CSSProperties = { ...rowCellStyle };
-          if (canBeColorized) {
+          // When this field itself opts into applyToRow, it defers to the shared row color
+          // (chosen from the first such field) rather than painting its own color over it.
+          if (canBeColorized && !fieldAppliesToRow) {
             const value = props.row[props.column.key];
             const displayValue = field.display!(value); // this fires here to get colors, then again to get rendered value?
             const cellColorStyles = getCellColorInlineStyles(cellOptions, displayValue, applyToRowBgFn != null);

--- a/packages/grafana-ui/src/components/Table/TableNG/refactored/RefactoredTableNG.test.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/refactored/RefactoredTableNG.test.tsx
@@ -2021,6 +2021,93 @@ describe.each(IMPLEMENTATIONS)('TableNG (%s)', (_impl, TableNG) => {
         expect(cellStyle.backgroundColor).toBe('rgb(255, 0, 0)');
       }
     });
+
+    it('colors the entire row using the first column when multiple columns enable applyToRow', () => {
+      // Reproduces the global-cell-type case: every column is ColorBackground + applyToRow
+      // with its own color. The whole row should take the first (leftmost) column's color,
+      // rather than each cell painting its own color.
+      const frame = createBasicDataFrame();
+      frame.fields[0].config.custom = {
+        ...frame.fields[0].config.custom,
+        cellOptions: {
+          type: TableCellDisplayMode.ColorBackground,
+          applyToRow: true,
+          mode: TableCellBackgroundDisplayMode.Basic,
+        },
+      };
+      frame.fields[1].config.custom = {
+        ...frame.fields[1].config.custom,
+        cellOptions: {
+          type: TableCellDisplayMode.ColorBackground,
+          applyToRow: true,
+          mode: TableCellBackgroundDisplayMode.Basic,
+        },
+      };
+
+      const origA = frame.fields[0].display;
+      frame.fields[0].display = (value: unknown) => ({
+        ...(origA ? origA(value) : { text: String(value), numeric: 0 }),
+        color: '#ff0000', // first column: red
+      });
+      const origB = frame.fields[1].display;
+      frame.fields[1].display = (value: unknown) => ({
+        ...(origB ? origB(value) : { text: String(value), numeric: 0 }),
+        color: '#0000ff', // second column: blue, should be ignored in favor of the row color
+      });
+
+      const { container } = render(<TableNG enableVirtualization={false} data={frame} width={800} height={600} />);
+
+      const rows = container.querySelectorAll('[role="row"]');
+      const cells = rows[1].querySelectorAll('[role="gridcell"]'); // Skip header row
+      expect(cells.length).toBeGreaterThan(1);
+      for (const cell of cells) {
+        expect(window.getComputedStyle(cell).backgroundColor).toBe('rgb(255, 0, 0)');
+      }
+    });
+
+    it('applies the row color from a column that is hidden via an override', () => {
+      // The color-determining column is hidden (hideFrom.viz). The visible column also uses
+      // ColorBackground + applyToRow (global cell type) with its own color, but it should
+      // defer to the hidden (first) column's color for the whole row.
+      const frame = createBasicDataFrame();
+      frame.fields[0].config.custom = {
+        ...frame.fields[0].config.custom,
+        hideFrom: { viz: true, legend: false, tooltip: false },
+        cellOptions: {
+          type: TableCellDisplayMode.ColorBackground,
+          applyToRow: true,
+          mode: TableCellBackgroundDisplayMode.Basic,
+        },
+      };
+      frame.fields[1].config.custom = {
+        ...frame.fields[1].config.custom,
+        cellOptions: {
+          type: TableCellDisplayMode.ColorBackground,
+          applyToRow: true,
+          mode: TableCellBackgroundDisplayMode.Basic,
+        },
+      };
+
+      const origA = frame.fields[0].display;
+      frame.fields[0].display = (value: unknown) => ({
+        ...(origA ? origA(value) : { text: String(value), numeric: 0 }),
+        color: '#ff0000', // hidden column drives the row color
+      });
+      const origB = frame.fields[1].display;
+      frame.fields[1].display = (value: unknown) => ({
+        ...(origB ? origB(value) : { text: String(value), numeric: 0 }),
+        color: '#0000ff', // visible column's own color, should defer to the hidden column
+      });
+
+      const { container } = render(<TableNG enableVirtualization={false} data={frame} width={800} height={600} />);
+
+      const rows = container.querySelectorAll('[role="row"]');
+      const cells = rows[1].querySelectorAll('[role="gridcell"]'); // Skip header row
+      expect(cells.length).toBeGreaterThan(0);
+      for (const cell of cells) {
+        expect(window.getComputedStyle(cell).backgroundColor).toBe('rgb(255, 0, 0)');
+      }
+    });
   });
 
   describe('Row hover functionality for shared crosshair', () => {

--- a/packages/grafana-ui/src/components/Table/TableNG/refactored/render-hooks.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/refactored/render-hooks.tsx
@@ -302,6 +302,8 @@ function buildColumnsFromFields(
       !IS_SAFARI_26 && typeof rowHeight !== 'string' && (shouldTextOverflow(field) || Boolean(maxRowHeight));
     const textWrap = typeof rowHeight === 'string' || shouldTextWrap(field);
     const canBeColorized = canFieldBeColorized(cellType, applyToRowBgFn);
+    const fieldAppliesToRow =
+      cellOptions.type === TableCellDisplayMode.ColorBackground && cellOptions.applyToRow === true;
     const cellStyleOptions: TableCellStyleOptions = {
       textAlign,
       textWrap,
@@ -342,7 +344,9 @@ function buildColumnsFromFields(
       }
 
       let style: CSSProperties = { ...rowCellStyle };
-      if (canBeColorized) {
+      // When this field itself opts into applyToRow, it defers to the shared row color
+      // (chosen from the first such field) rather than painting its own color over it.
+      if (canBeColorized && !fieldAppliesToRow) {
         const value = props.row[props.column.key];
         const displayValue = field.display!(value); // this fires here to get colors, then again to get rendered value?
         const cellColorStyles = getCellColorInlineStyles(cellOptions, displayValue, applyToRowBgFn != null);

--- a/packages/grafana-ui/src/components/Table/TableNG/utils.test.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/utils.test.ts
@@ -37,6 +37,7 @@ import {
   extractPixelValue,
   getAlignment,
   getAlignmentFactor,
+  getApplyToRowBgFn,
   getCellColorInlineStylesFactory,
   getCellLinks,
   getCellOptions,
@@ -212,6 +213,46 @@ describe('TableNG utils', () => {
           });
         }
       );
+    });
+  });
+
+  describe('getApplyToRowBgFn', () => {
+    const theme = createTheme();
+
+    const makeColorBackgroundField = (color: string, applyToRow: boolean): Field => ({
+      name: color,
+      type: FieldType.number,
+      values: [1],
+      config: {
+        custom: {
+          cellOptions: {
+            type: TableCellDisplayMode.ColorBackground,
+            mode: TableCellBackgroundDisplayMode.Basic,
+            applyToRow,
+          },
+        },
+      },
+      display: () => ({ text: '1', numeric: 1, color }),
+    });
+
+    it('returns undefined when no field has applyToRow enabled', () => {
+      const fields = [makeColorBackgroundField('#ff0000', false), makeColorBackgroundField('#0000ff', false)];
+      const getCellColorInlineStyles = getCellColorInlineStylesFactory(theme);
+      expect(getApplyToRowBgFn(fields, getCellColorInlineStyles)).toBeUndefined();
+    });
+
+    it('uses the color of the first (leftmost) field with applyToRow enabled', () => {
+      const fields = [makeColorBackgroundField('#ff0000', true), makeColorBackgroundField('#0000ff', true)];
+      const getCellColorInlineStyles = getCellColorInlineStylesFactory(theme);
+      const rowBgFn = getApplyToRowBgFn(fields, getCellColorInlineStyles);
+      expect(rowBgFn?.(0).background).toBe('#ff0000');
+    });
+
+    it('skips fields without applyToRow when picking the winning field', () => {
+      const fields = [makeColorBackgroundField('#ff0000', false), makeColorBackgroundField('#0000ff', true)];
+      const getCellColorInlineStyles = getCellColorInlineStylesFactory(theme);
+      const rowBgFn = getApplyToRowBgFn(fields, getCellColorInlineStyles);
+      expect(rowBgFn?.(0).background).toBe('#0000ff');
     });
   });
 


### PR DESCRIPTION
## What this PR does

Fixes "Apply to entire row" for colored-background table cells when more than one column enables it.

When the option is set through the **panel-level cell type** (global) or through **overrides that target multiple fields**, every colored cell was painting its own color over the shared row color. The result was that the row wasn't uniformly colored — each column showed its own value's color instead of the row taking a single color.

### Behavior after this PR

- A field that opts into `applyToRow` now **defers to the shared row color**, which is taken from the **first (leftmost)** field that enables it.
- A field using a colored background **without** `applyToRow` still paints its own cell — co-mingling of per-cell colors with a row color is preserved.
- Applies to both the legacy and refactored `TableNG` render paths (the refactored path is behind the `table.refactorNested` flag).

### Root cause

When `applyToRow` was active, the row baseline color was set from the winning field, but every colorizable cell then recomputed its own color and assigned it over the row style. A cell only inherited the row color when its own color was transparent, so any column with its own non-transparent color overrode the row.

## Related issue

Fixes #113997 (row coloring stopped working when the color-determining column is hidden via an override). A test covering the hidden-column case is included.

## Tests

- New render tests (run against both implementations via `describe.each`):
  - Multiple columns enabling `applyToRow` → the whole row uses the first column's color.
  - The color-source column hidden via an override → the row still takes that column's color.
- New unit tests for `getApplyToRowBgFn` asserting the first-column tie-break.
- Existing `applyToRow` / co-mingle tests still pass.

## Docs

Updated the table visualization docs to describe the tie-break: when multiple fields enable "Apply to entire row", the row uses the first (leftmost) matching column's color.

## Test dashboard

This test dashboard sets "apply to row" on a "global" panel option. what should happen is that every row should be colorized by the first column. Before, each column was colorized individually.

<details>
    <summary>Dashboard JSON</summary>

```json
{
  "apiVersion": "dashboard.grafana.app/v2",
  "kind": "Dashboard",
  "metadata": {
    "name": "admj7cc",
    "namespace": "default",
    "uid": "dc943f44-acc9-4fdc-b6e5-2328fb0fa7aa",
    "resourceVersion": "1784132553581017",
    "generation": 1,
    "creationTimestamp": "2026-07-15T16:22:33Z",
    "labels": {
      "grafana.app/deprecatedInternalID": "1269188078432256"
    },
    "annotations": {
      "grafana.app/createdBy": "user:ffm1lod40vls0c",
      "grafana.app/saved-from-ui": "Grafana v13.2.0-local (1312721435)"
    }
  },
  "spec": {
    "annotations": [
      {
        "kind": "AnnotationQuery",
        "spec": {
          "query": {
            "kind": "DataQuery",
            "group": "grafana",
            "version": "v0",
            "datasource": {
              "name": "-- Grafana --"
            },
            "spec": {}
          },
          "enable": true,
          "hide": true,
          "iconColor": "rgba(0, 211, 255, 1)",
          "name": "Annotations & Alerts",
          "builtIn": true
        }
      }
    ],
    "cursorSync": "Off",
    "description": "",
    "editable": true,
    "elements": {
      "panel-1": {
        "kind": "Panel",
        "spec": {
          "id": 1,
          "title": "New panel",
          "description": "",
          "links": [],
          "data": {
            "kind": "QueryGroup",
            "spec": {
              "queries": [
                {
                  "kind": "PanelQuery",
                  "spec": {
                    "query": {
                      "kind": "DataQuery",
                      "group": "",
                      "version": "v0",
                      "spec": {}
                    },
                    "refId": "A",
                    "hidden": false
                  }
                }
              ],
              "transformations": [
                {
                  "kind": "Transformation",
                  "group": "organize",
                  "spec": {
                    "options": {
                      "excludeByName": {},
                      "includeByName": {},
                      "indexByName": {
                        "A-series": 0,
                        "time": 1
                      },
                      "renameByName": {}
                    }
                  }
                }
              ],
              "queryOptions": {}
            }
          },
          "vizConfig": {
            "kind": "VizConfig",
            "group": "table",
            "version": "13.2.0-local",
            "spec": {
              "options": {
                "cellHeight": "sm",
                "showHeader": true
              },
              "fieldConfig": {
                "defaults": {
                  "thresholds": {
                    "mode": "absolute",
                    "steps": [
                      {
                        "value": 0,
                        "color": "green"
                      },
                      {
                        "value": 80,
                        "color": "red"
                      }
                    ]
                  },
                  "color": {
                    "mode": "continuous-greens"
                  },
                  "custom": {
                    "align": "auto",
                    "cellOptions": {
                      "applyToRow": true,
                      "mode": "gradient",
                      "type": "color-background"
                    },
                    "footer": {
                      "reducers": []
                    },
                    "inspect": false
                  }
                },
                "overrides": []
              }
            }
          }
        }
      }
    },
    "layout": {
      "kind": "GridLayout",
      "spec": {
        "items": [
          {
            "kind": "GridLayoutItem",
            "spec": {
              "x": 0,
              "y": 0,
              "width": 12,
              "height": 8,
              "element": {
                "kind": "ElementReference",
                "name": "panel-1"
              }
            }
          }
        ]
      }
    },
    "links": [],
    "liveNow": false,
    "preload": false,
    "tags": [],
    "timeSettings": {
      "timezone": "browser",
      "from": "now-6h",
      "to": "now",
      "autoRefresh": "",
      "autoRefreshIntervals": [
        "5s",
        "10s",
        "30s",
        "1m",
        "5m",
        "15m",
        "30m",
        "1h",
        "2h",
        "1d"
      ],
      "hideTimepicker": false,
      "fiscalYearStartMonth": 0
    },
    "title": "testing apply to whole row",
    "variables": [],
    "preferences": {
      "layout": {
        "kind": "GridLayout",
        "spec": {
          "items": []
        }
      }
    }
  }
}
```
</details>

#### Before

<img width="877" height="332" alt="Screenshot 2026-07-15 at 1 59 50 PM" src="https://github.com/user-attachments/assets/573831d7-660c-4bdf-97f0-1d3e7c3ff307" />

#### After

<img width="1387" height="629" alt="Screenshot 2026-07-15 at 2 13 02 PM" src="https://github.com/user-attachments/assets/7d1a6ac8-cb2d-4cc8-a0b8-b4a1a84ca026" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)
