### PR TITLE
Provisioning: Change commit message template to multi-line textarea

### DIFF
--- a/public/app/features/provisioning/Config/CommitOptionsSection.test.tsx
+++ b/public/app/features/provisioning/Config/CommitOptionsSection.test.tsx
@@ -92,7 +92,10 @@ describe('CommitOptionsSection', () => {
 
     await user.click(screen.getByText('Commit options'));
 
-    expect(screen.getByRole('textbox')).toHaveAttribute('name', 'commit.singleResourceMessageTemplate');
+    expect(screen.getByRole('textbox', { name: /Commit message template/i })).toHaveAttribute(
+      'name',
+      'commit.singleResourceMessageTemplate'
+    );
     expect(screen.getByRole('checkbox')).toHaveAttribute('name', 'commit.enforceTemplate');
   });
 

--- a/public/app/features/provisioning/Config/CommitOptionsSection.tsx
+++ b/public/app/features/provisioning/Config/CommitOptionsSection.tsx
@@ -109,7 +109,7 @@ export function CommitOptionsSection<T extends FieldValues>({
             }
           )}
         >
-          <Input
+          <TextArea
             id="commit-message-template"
             {...register(messageTemplateName)}
             placeholder={t(
@@ -117,6 +117,7 @@ export function CommitOptionsSection<T extends FieldValues>({
               'feat(dashboards): {{actionVar}} {{titleVar}}',
               { actionVar: '{{action}}', titleVar: '{{title}}' }
             )}
+            rows={3}
           />
         </Field>
 


### PR DESCRIPTION
<img width="1561" height="260" alt="Screenshot 2026-07-16 at 10 02 34" src="https://github.com/user-attachments/assets/3cadf8ea-21aa-4093-80f1-4b7a1977e4df" />
<img width="1009" height="744" alt="Screenshot 2026-07-16 at 10 02 08" src="https://github.com/user-attachments/assets/f04d2628-0ff2-4e88-8af5-3b4c663cc824" />
<img width="1038" height="400" alt="Screenshot 2026-07-16 at 09 58 38" src="https://github.com/user-attachments/assets/792a2ed6-8b99-4bcb-98dd-77b9b2ff4873" />


<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What is this feature?**

Changes the commit message template field in the Git Sync provisioning configuration from a single-line input to a multi-line textarea, allowing users to enter longer, multi-line commit message templates.

**Why do we need this feature?**

Users configuring Git Sync provisioning need the ability to write multi-line commit message templates. A single-line input field is limiting for users who want to create more detailed or structured commit messages (e.g., with a title and body, or following conventional commit formats with multiple lines).

**Who is this feature for?**

Grafana administrators and teams using Git Sync provisioning who want to customize their commit message templates with multi-line formats.

**Which issue(s) does this PR fix?**:

Fixes # (issue requested via Slack - #grafana-git-sync-dev)

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle. (N/A - this is a UI improvement)
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc. (No docs update needed - UI change is self-explanatory)

**Changes:**
- Changed `Input` component to `TextArea` component with `rows={3}` in `CommitOptionsSection.tsx`
- Updated test to use more specific textbox query in `CommitOptionsSection.test.tsx`
- All existing tests pass (12/12 tests)
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://raintank-corp.slack.com/archives/C08T7NVBCUA/p1784133480045579?thread_ts=1784133480.045579&cid=C08T7NVBCUA)

<div><a href="https://cursor.com/agents/bc-579f2693-9859-5e1b-9bda-8c4cb5ec6697"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-579f2693-9859-5e1b-9bda-8c4cb5ec6697"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

