### PR TITLE
Provisioning: Strip deprecatedInternalId label for dashboards

### DIFF
--- a/pkg/registry/apis/provisioning/resources/parser.go
+++ b/pkg/registry/apis/provisioning/resources/parser.go
@@ -201,11 +201,19 @@ func (r *parser) Parse(ctx context.Context, info *repository.FileInfo) (parsed *
 		}
 	}
 
-	// Remove the internal dashboard UID,version and id if they exist
+	// Remove the internal dashboard UID, version and id if they exist. The
+	// deprecated internal ID is likewise owned by the storage layer, not the
+	// repository file, so strip its label too. Otherwise a repo-authored ID
+	// would ride a create straight past the uniqueness guard, which relies on
+	// an eventually-consistent search index and so lets duplicate IDs through
+	// when several dashboards are created within a single sync operation. With
+	// the label cleared, storage mints a fresh unique ID on create and restores
+	// the previous value on update.
 	if parsed.GVK.Group == dashboard.GROUP && parsed.GVK.Kind == "Dashboard" {
 		unstructured.RemoveNestedField(parsed.Obj.Object, "spec", "uid")
 		unstructured.RemoveNestedField(parsed.Obj.Object, "spec", "version")
 		unstructured.RemoveNestedField(parsed.Obj.Object, "spec", "id") // now managed as a label
+		unstructured.RemoveNestedField(parsed.Obj.Object, "metadata", "labels", utils.LabelKeyDeprecatedInternalID)
 	}
 
 	parsed.Meta, err = utils.MetaAccessor(parsed.Obj)

--- a/pkg/registry/apis/provisioning/resources/parser_test.go
+++ b/pkg/registry/apis/provisioning/resources/parser_test.go
@@ -116,6 +116,40 @@ spec:
 		require.Equal(t, "v0alpha1", dash.GVR.Version)
 	})
 
+	t.Run("strips storage-owned dashboard fields including the deprecated internal ID", func(t *testing.T) {
+		// spec uid/version/id and the deprecatedInternalID label are owned by the
+		// storage layer, not the repository. Leaving the ID label on a create would
+		// bypass the eventually-consistent uniqueness guard and can reintroduce
+		// duplicate IDs when several dashboards sync together.
+		dash, err := parser.Parse(context.Background(), &repository.FileInfo{
+			Data: []byte(`apiVersion: dashboard.grafana.app/v0alpha1
+kind: Dashboard
+metadata:
+  name: test-strip
+  labels:
+    grafana.app/deprecatedInternalID: "42"
+    keep-me: "yes"
+spec:
+  uid: should-be-removed
+  version: 7
+  id: 42
+  title: Test dashboard
+`),
+		})
+		require.NoError(t, err)
+
+		_, hasUID, _ := unstructured.NestedFieldNoCopy(dash.Obj.Object, "spec", "uid")
+		require.False(t, hasUID, "spec.uid should be stripped")
+		_, hasVersion, _ := unstructured.NestedFieldNoCopy(dash.Obj.Object, "spec", "version")
+		require.False(t, hasVersion, "spec.version should be stripped")
+		_, hasID, _ := unstructured.NestedFieldNoCopy(dash.Obj.Object, "spec", "id")
+		require.False(t, hasID, "spec.id should be stripped")
+
+		require.Zero(t, dash.Meta.GetDeprecatedInternalID(), "deprecatedInternalID label should be cleared") // nolint:staticcheck
+		require.NotContains(t, dash.Obj.GetLabels(), utils.LabelKeyDeprecatedInternalID, "internal ID label should be removed")
+		require.Equal(t, "yes", dash.Obj.GetLabels()["keep-me"], "other labels should be preserved")
+	})
+
 	t.Run("validate proper folder metadata is set", func(t *testing.T) {
 		testCases := []struct {
 			name           string


### PR DESCRIPTION
Fixes grafana/git-ui-sync-project#1297

## What

Strip the `grafana.app/deprecatedInternalID` label from dashboards during git-sync parsing, so the internal ID is always assigned by the storage layer instead of carried in from the repository file.

## Why

The MT dashboard API server guards against duplicate `deprecatedInternalID`s using a search-index lookup. That index is eventually consistent, so when several dashboards sharing the same `deprecatedInternalID` are created within a single sync operation, the first create isn't indexed yet when the second is processed — the lookup returns nothing and both creates are allowed, reintroducing the duplicate ID.

Relying on the search guard alone is insufficient. Stripping the ID on git-sync create forces storage to mint a fresh, unique ID for each dashboard, closing the race.

## Change

- `resources/parser.go`: in the existing dashboard strip block (which already removes `spec.uid/version/id`), also remove the `deprecatedInternalID` label. In `Parse()` this covers both paths:
  - **create** → no ID label → storage generates a fresh unique ID
  - **update** → label already absent → storage restores the previous value (matches prior behavior)
- Added a parser unit test asserting the ID label is stripped, other labels are preserved, and spec fields are removed.

## Scope / notes

- Does not change `ensureSingleDeprecatedInternalID` — the search guard remains for non-git-sync writes. This only prevents git-sync from carrying a duplicate ID in.
- Behavior change: dashboards synced from a repo now always get a storage-assigned internal ID rather than any value hand-authored in the file (the field is deprecated and storage-owned).

## Testing

- `go test ./pkg/registry/apis/provisioning/resources/` passes.
- Reproduced in `dev-us-central-0` by syncing a repo containing dashboards-as-code with a shared `deprecatedInternalID`.
