### PR TITLE
OpenAPI: Add KeepLast option to noDataState/execErrState

### DIFF
--- a/packages/grafana-openapi/src/api/openapi3.json
+++ b/packages/grafana-openapi/src/api/openapi3.json
@@ -2539,7 +2539,7 @@
             "type": "array"
           },
           "execErrState": {
-            "enum": ["OK", "Alerting", "Error"],
+            "enum": ["OK", "Alerting", "Error", "KeepLast"],
             "type": "string"
           },
           "for": {
@@ -2562,7 +2562,7 @@
             "type": "integer"
           },
           "noDataState": {
-            "enum": ["Alerting", "NoData", "OK"],
+            "enum": ["Alerting", "NoData", "OK", "KeepLast"],
             "type": "string"
           },
           "notification_settings": {
@@ -3230,7 +3230,7 @@
             "type": "array"
           },
           "exec_err_state": {
-            "enum": ["OK", "Alerting", "Error"],
+            "enum": ["OK", "Alerting", "Error", "KeepLast"],
             "type": "string"
           },
           "for": {
@@ -3260,7 +3260,7 @@
             "type": "string"
           },
           "no_data_state": {
-            "enum": ["Alerting", "NoData", "OK"],
+            "enum": ["Alerting", "NoData", "OK", "KeepLast"],
             "type": "string"
           },
           "rule_group": {
@@ -6074,7 +6074,7 @@
             "type": "array"
           },
           "exec_err_state": {
-            "enum": ["OK", "Alerting", "Error"],
+            "enum": ["OK", "Alerting", "Error", "KeepLast"],
             "type": "string"
           },
           "guid": {
@@ -6102,7 +6102,7 @@
             "type": "string"
           },
           "no_data_state": {
-            "enum": ["Alerting", "NoData", "OK"],
+            "enum": ["Alerting", "NoData", "OK", "KeepLast"],
             "type": "string"
           },
           "notification_settings": {
@@ -8549,7 +8549,7 @@
             "type": "array"
           },
           "exec_err_state": {
-            "enum": ["OK", "Alerting", "Error"],
+            "enum": ["OK", "Alerting", "Error", "KeepLast"],
             "type": "string"
           },
           "is_paused": {
@@ -8565,7 +8565,7 @@
             "type": "integer"
           },
           "no_data_state": {
-            "enum": ["Alerting", "NoData", "OK"],
+            "enum": ["Alerting", "NoData", "OK", "KeepLast"],
             "type": "string"
           },
           "notification_settings": {
@@ -8876,7 +8876,7 @@
             "type": "array"
           },
           "execErrState": {
-            "enum": ["OK", "Alerting", "Error"],
+            "enum": ["OK", "Alerting", "Error", "KeepLast"],
             "type": "string"
           },
           "folderUID": {
@@ -8914,7 +8914,7 @@
             "type": "integer"
           },
           "noDataState": {
-            "enum": ["Alerting", "NoData", "OK"],
+            "enum": ["Alerting", "NoData", "OK", "KeepLast"],
             "type": "string"
           },
           "notification_settings": {

--- a/pkg/services/ngalert/api/tooling/api.json
+++ b/pkg/services/ngalert/api/tooling/api.json
@@ -198,7 +198,8 @@
      "enum": [
       "OK",
       "Alerting",
-      "Error"
+      "Error",
+      "KeepLast"
      ],
      "type": "string"
     },
@@ -225,7 +226,8 @@
      "enum": [
       "Alerting",
       "NoData",
-      "OK"
+      "OK",
+      "KeepLast"
      ],
      "type": "string"
     },
@@ -660,7 +662,8 @@
      "enum": [
       "OK",
       "Alerting",
-      "Error"
+      "Error",
+      "KeepLast"
      ],
      "type": "string"
     },
@@ -694,7 +697,8 @@
      "enum": [
       "Alerting",
       "NoData",
-      "OK"
+      "OK",
+      "KeepLast"
      ],
      "type": "string"
     },
@@ -1750,7 +1754,8 @@
      "enum": [
       "OK",
       "Alerting",
-      "Error"
+      "Error",
+      "KeepLast"
      ],
      "type": "string"
     },
@@ -1782,7 +1787,8 @@
      "enum": [
       "Alerting",
       "NoData",
-      "OK"
+      "OK",
+      "KeepLast"
      ],
      "type": "string"
     },
@@ -3137,7 +3143,8 @@
      "enum": [
       "OK",
       "Alerting",
-      "Error"
+      "Error",
+      "KeepLast"
      ],
      "type": "string"
     },
@@ -3157,7 +3164,8 @@
      "enum": [
       "Alerting",
       "NoData",
-      "OK"
+      "OK",
+      "KeepLast"
      ],
      "type": "string"
     },
@@ -3407,7 +3415,8 @@
      "enum": [
       "OK",
       "Alerting",
-      "Error"
+      "Error",
+      "KeepLast"
      ],
      "type": "string"
     },
@@ -3449,7 +3458,8 @@
      "enum": [
       "Alerting",
       "NoData",
-      "OK"
+      "OK",
+      "KeepLast"
      ],
      "type": "string"
     },

--- a/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
+++ b/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
@@ -502,6 +502,7 @@ const (
 	Alerting NoDataState = "Alerting"
 	NoData   NoDataState = "NoData"
 	OK       NoDataState = "OK"
+	KeepLast NoDataState = "KeepLast"
 )
 
 // swagger:enum ExecutionErrorState
@@ -511,6 +512,7 @@ const (
 	OkErrState       ExecutionErrorState = "OK"
 	AlertingErrState ExecutionErrorState = "Alerting"
 	ErrorErrState    ExecutionErrorState = "Error"
+	KeepLastErrState ExecutionErrorState = "KeepLast"
 )
 
 // swagger:model

--- a/pkg/services/ngalert/api/tooling/post.json
+++ b/pkg/services/ngalert/api/tooling/post.json
@@ -198,7 +198,8 @@
      "enum": [
       "OK",
       "Alerting",
-      "Error"
+      "Error",
+      "KeepLast"
      ],
      "type": "string"
     },
@@ -225,7 +226,8 @@
      "enum": [
       "Alerting",
       "NoData",
-      "OK"
+      "OK",
+      "KeepLast"
      ],
      "type": "string"
     },
@@ -660,7 +662,8 @@
      "enum": [
       "OK",
       "Alerting",
-      "Error"
+      "Error",
+      "KeepLast"
      ],
      "type": "string"
     },
@@ -694,7 +697,8 @@
      "enum": [
       "Alerting",
       "NoData",
-      "OK"
+      "OK",
+      "KeepLast"
      ],
      "type": "string"
     },
@@ -1750,7 +1754,8 @@
      "enum": [
       "OK",
       "Alerting",
-      "Error"
+      "Error",
+      "KeepLast"
      ],
      "type": "string"
     },
@@ -1782,7 +1787,8 @@
      "enum": [
       "Alerting",
       "NoData",
-      "OK"
+      "OK",
+      "KeepLast"
      ],
      "type": "string"
     },
@@ -3140,7 +3146,8 @@
      "enum": [
       "OK",
       "Alerting",
-      "Error"
+      "Error",
+      "KeepLast"
      ],
      "type": "string"
     },
@@ -3160,7 +3167,8 @@
      "enum": [
       "Alerting",
       "NoData",
-      "OK"
+      "OK",
+      "KeepLast"
      ],
      "type": "string"
     },
@@ -3410,7 +3418,8 @@
      "enum": [
       "OK",
       "Alerting",
-      "Error"
+      "Error",
+      "KeepLast"
      ],
      "type": "string"
     },
@@ -3452,7 +3461,8 @@
      "enum": [
       "Alerting",
       "NoData",
-      "OK"
+      "OK",
+      "KeepLast"
      ],
      "type": "string"
     },

--- a/pkg/services/ngalert/api/tooling/spec.json
+++ b/pkg/services/ngalert/api/tooling/spec.json
@@ -4742,7 +4742,8 @@
           "enum": [
             "OK",
             "Alerting",
-            "Error"
+            "Error",
+            "KeepLast"
           ]
         },
         "for": {
@@ -4769,7 +4770,8 @@
           "enum": [
             "Alerting",
             "NoData",
-            "OK"
+            "OK",
+            "KeepLast"
           ]
         },
         "notification_settings": {
@@ -5203,7 +5205,8 @@
           "enum": [
             "OK",
             "Alerting",
-            "Error"
+            "Error",
+            "KeepLast"
           ]
         },
         "for": {
@@ -5237,7 +5240,8 @@
           "enum": [
             "Alerting",
             "NoData",
-            "OK"
+            "OK",
+            "KeepLast"
           ]
         },
         "rule_group": {
@@ -6294,7 +6298,8 @@
           "enum": [
             "OK",
             "Alerting",
-            "Error"
+            "Error",
+            "KeepLast"
           ]
         },
         "guid": {
@@ -6326,7 +6331,8 @@
           "enum": [
             "Alerting",
             "NoData",
-            "OK"
+            "OK",
+            "KeepLast"
           ]
         },
         "notification_settings": {
@@ -7685,7 +7691,8 @@
           "enum": [
             "OK",
             "Alerting",
-            "Error"
+            "Error",
+            "KeepLast"
           ]
         },
         "is_paused": {
@@ -7705,7 +7712,8 @@
           "enum": [
             "Alerting",
             "NoData",
-            "OK"
+            "OK",
+            "KeepLast"
           ]
         },
         "notification_settings": {
@@ -7966,7 +7974,8 @@
           "enum": [
             "OK",
             "Alerting",
-            "Error"
+            "Error",
+            "KeepLast"
           ]
         },
         "folderUID": {
@@ -8008,7 +8017,8 @@
           "enum": [
             "Alerting",
             "NoData",
-            "OK"
+            "OK",
+            "KeepLast"
           ]
         },
         "notification_settings": {

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -12661,7 +12661,8 @@
           "enum": [
             "OK",
             "Alerting",
-            "Error"
+            "Error",
+            "KeepLast"
           ]
         },
         "for": {
@@ -12688,7 +12689,8 @@
           "enum": [
             "Alerting",
             "NoData",
-            "OK"
+            "OK",
+            "KeepLast"
           ]
         },
         "notification_settings": {
@@ -13384,7 +13386,8 @@
           "enum": [
             "OK",
             "Alerting",
-            "Error"
+            "Error",
+            "KeepLast"
           ]
         },
         "for": {
@@ -13418,7 +13421,8 @@
           "enum": [
             "Alerting",
             "NoData",
-            "OK"
+            "OK",
+            "KeepLast"
           ]
         },
         "rule_group": {
@@ -16276,7 +16280,8 @@
           "enum": [
             "OK",
             "Alerting",
-            "Error"
+            "Error",
+            "KeepLast"
           ]
         },
         "guid": {
@@ -16308,7 +16313,8 @@
           "enum": [
             "Alerting",
             "NoData",
-            "OK"
+            "OK",
+            "KeepLast"
           ]
         },
         "notification_settings": {
@@ -18791,7 +18797,8 @@
           "enum": [
             "OK",
             "Alerting",
-            "Error"
+            "Error",
+            "KeepLast"
           ]
         },
         "is_paused": {
@@ -18811,7 +18818,8 @@
           "enum": [
             "Alerting",
             "NoData",
-            "OK"
+            "OK",
+            "KeepLast"
           ]
         },
         "notification_settings": {
@@ -19144,7 +19152,8 @@
           "enum": [
             "OK",
             "Alerting",
-            "Error"
+            "Error",
+            "KeepLast"
           ]
         },
         "folderUID": {
@@ -19186,7 +19195,8 @@
           "enum": [
             "Alerting",
             "NoData",
-            "OK"
+            "OK",
+            "KeepLast"
           ]
         },
         "notification_settings": {

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -2594,7 +2594,8 @@
             "enum": [
               "OK",
               "Alerting",
-              "Error"
+              "Error",
+              "KeepLast"
             ],
             "type": "string"
           },
@@ -2621,7 +2622,8 @@
             "enum": [
               "Alerting",
               "NoData",
-              "OK"
+              "OK",
+              "KeepLast"
             ],
             "type": "string"
           },
@@ -3318,7 +3320,8 @@
             "enum": [
               "OK",
               "Alerting",
-              "Error"
+              "Error",
+              "KeepLast"
             ],
             "type": "string"
           },
@@ -3352,7 +3355,8 @@
             "enum": [
               "Alerting",
               "NoData",
-              "OK"
+              "OK",
+              "KeepLast"
             ],
             "type": "string"
           },
@@ -6210,7 +6214,8 @@
             "enum": [
               "OK",
               "Alerting",
-              "Error"
+              "Error",
+              "KeepLast"
             ],
             "type": "string"
           },
@@ -6242,7 +6247,8 @@
             "enum": [
               "Alerting",
               "NoData",
-              "OK"
+              "OK",
+              "KeepLast"
             ],
             "type": "string"
           },
@@ -8725,7 +8731,8 @@
             "enum": [
               "OK",
               "Alerting",
-              "Error"
+              "Error",
+              "KeepLast"
             ],
             "type": "string"
           },
@@ -8745,7 +8752,8 @@
             "enum": [
               "Alerting",
               "NoData",
-              "OK"
+              "OK",
+              "KeepLast"
             ],
             "type": "string"
           },
@@ -9067,7 +9075,8 @@
             "enum": [
               "OK",
               "Alerting",
-              "Error"
+              "Error",
+              "KeepLast"
             ],
             "type": "string"
           },
@@ -9109,7 +9118,8 @@
             "enum": [
               "Alerting",
               "NoData",
-              "OK"
+              "OK",
+              "KeepLast"
             ],
             "type": "string"
           },


### PR DESCRIPTION
**What is this feature?**

Add a `KeepLast` option to `noDataState`/`execErrState` to match https://github.com/grafana/grafana/blob/main/pkg/services/ngalert/models/alert_rule.go

**Why do we need this feature?**

So that the `KeepLast` enum is supported in OpenAPI clients, in particular the Grafana MCP.

**Who is this feature for?**

OpenAPI users.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/107962

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
