### PR TITLE
 Gauge: Fix gradient stops out of order for negative thresholds

### DIFF
--- a/devenv/dev-dashboards/panel-gauge/gauge_tests_new.json
+++ b/devenv/dev-dashboards/panel-gauge/gauge_tests_new.json
@@ -1286,6 +1286,98 @@
           }
         }
       },
+      "panel-42": {
+        "kind": "Panel",
+        "spec": {
+          "id": 42,
+          "title": "Negative thresholds + gradient",
+          "description": "Regression: gradient stops must stay ascending when thresholds span negative values (min < 0).",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "grafana-testdata-datasource",
+                      "version": "v0",
+                      "spec": {
+                        "alias": "1",
+                        "scenarioId": "csv_metric_values",
+                        "stringInput": "-25"
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {
+                "maxDataPoints": 20
+              }
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "gauge",
+            "version": "13.0.0-pre",
+            "spec": {
+              "options": {
+                "barShape": "flat",
+                "barWidthFactor": 0.72,
+                "effects": {
+                  "barGlow": false,
+                  "centerGlow": false,
+                  "gradient": true
+                },
+                "orientation": "auto",
+                "reduceOptions": {
+                  "calcs": ["lastNotNull"],
+                  "fields": "",
+                  "values": false
+                },
+                "segmentCount": 1,
+                "segmentSpacing": 0.3,
+                "shape": "gauge",
+                "showThresholdLabels": false,
+                "showThresholdMarkers": true,
+                "sparkline": false
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "min": -100,
+                  "max": 100,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": null,
+                        "color": "green"
+                      },
+                      {
+                        "value": -50,
+                        "color": "yellow"
+                      },
+                      {
+                        "value": 0,
+                        "color": "red"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
       "panel-26": {
         "kind": "Panel",
         "spec": {
@@ -3008,6 +3100,19 @@
                         "element": {
                           "kind": "ElementReference",
                           "name": "panel-28"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 20,
+                        "y": 0,
+                        "width": 4,
+                        "height": 6,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-42"
                         }
                       }
                     }

--- a/e2e-playwright/panels-suite/gauge.spec.ts
+++ b/e2e-playwright/panels-suite/gauge.spec.ts
@@ -10,7 +10,7 @@ const NEW_GAUGES_DASHBOARD_UID = 'panel-tests-gauge-new';
 const OLD_TO_NEW_GAUGES_DASHBOARD_UID = 'panel-tests-old-gauge-to-new';
 
 const OLD_GAUGES_DASHBOARD_GAUGE_COUNT = 16;
-const NEW_GAUGE_DASHBOARD_GAUGE_COUNT = 36;
+const NEW_GAUGE_DASHBOARD_GAUGE_COUNT = 37;
 
 test.describe(
   'Gauge Panel',

--- a/packages/grafana-ui/src/components/RadialGauge/colors.test.ts
+++ b/packages/grafana-ui/src/components/RadialGauge/colors.test.ts
@@ -110,6 +110,27 @@ describe('RadialGauge color utils', () => {
         )
       ).toMatchSnapshot();
     });
+
+    it('should produce ascending gradient stops when thresholds span negative values', () => {
+      const field = createField(FieldColorModeId.Thresholds);
+      const fieldDisplay = buildFieldDisplay(field, {
+        field: {
+          min: -100,
+          max: 100,
+          thresholds: {
+            mode: ThresholdsMode.Absolute,
+            steps: [
+              { value: -Infinity, color: 'green' },
+              { value: -50, color: 'yellow' },
+              { value: 0, color: 'red' },
+            ],
+          },
+        },
+      });
+      const stops = buildGradientColors(createTheme(), fieldDisplay);
+      const percents = stops.map((s) => s.percent);
+      expect(percents).toEqual([...percents].sort((a, b) => a - b));
+    });
   });
 
   describe('colorAtGradientPercent', () => {

--- a/packages/grafana-ui/src/components/RadialGauge/utils.ts
+++ b/packages/grafana-ui/src/components/RadialGauge/utils.ts
@@ -324,7 +324,7 @@ export function getFormattedThresholds(
     }
     const prev = steps[i - 1];
     formatted.push({
-      value: isFinite(step.value) ? step.value : 0,
+      value: isFinite(step.value) ? step.value : min,
       color: theme.visualization.getColorByName((offsetColor ? prev : step).color),
     });
     if (step === last) {


### PR DESCRIPTION
Reopen of #125031 after it was closed and deleted as stale. Fixes #123592.

To test, I've added a new gdev panel in the Gauge Tests (new) dashboard.

#### Before
<img width="325" height="307" alt="Screenshot 2026-07-15 at 2 06 57 PM" src="https://github.com/user-attachments/assets/3fcd82cf-09dc-41e3-b3c8-5d8c28c51d98" />

#### After
<img width="319" height="279" alt="Screenshot 2026-07-15 at 2 05 42 PM" src="https://github.com/user-attachments/assets/e4ed67d7-b080-4838-a749-f60041462220" />

