### PR TITLE
Docs: Updated SQL expressions - move to GA, added Grafana Assistant and other updates

### DIFF
--- a/docs/sources/visualizations/panels-visualizations/query-transform-data/sql-expressions/index.md
+++ b/docs/sources/visualizations/panels-visualizations/query-transform-data/sql-expressions/index.md
@@ -291,6 +291,7 @@ Following are some best practices for alerting and recording rules:
 
 - Grafana supports certain data sources. Refer to [compatible data sources](#compatible-data-sources) for a current list.
 - A SQL expression can only reference data source queries. It can't reference other expressions, and you can't use the output of a SQL expression as the input to another expression.
+- You can use only one SQL expression per panel or alert.
 - Each SQL expression query must include a time range.
 - SQL expressions aren't supported on 32-bit ARM builds of Grafana.
 - Autocomplete is available, but column and field autocomplete requires the experimental `sqlExpressionsColumnAutoComplete` feature toggle.
@@ -313,7 +314,7 @@ SQL expressions run on an embedded SQL engine that evaluates regular expressions
 SQL expressions that use regular expression functions have limitations such as:
 
 - Lack of back-references.
-- No before or after text matching.
+- No lookahead or lookbehind assertions.
 - Differences in handling carriage return (`\r`) characters.
 
 There may be other minor differences as well.
@@ -398,7 +399,7 @@ This approach ensures that a schema exists even when one query returns no data.
 You can also ask Assistant to build a panel using natural language. When you ask it to combine or correlate data across multiple queries, it prefers SQL expressions over join transformations and writes the SQL expression directly into your panel.
 
 {{< admonition type="note" >}}
-Grafana Assistant is generally available on Grafana Cloud and in public preview for Grafana OSS and Grafana Enterprise. To use it with Grafana OSS or Grafana Enterprise, you must install the Assistant app and connect it to a Grafana Cloud stack. For more information, refer to the [Grafana Assistant documentation](ref:assistant).
+Grafana Assistant is generally available on Grafana Cloud and in public preview for Grafana OSS and Grafana Enterprise. On Grafana Enterprise (version 13.1 and later), Assistant comes pre-installed, so you only need to connect your Grafana Cloud account to start using it. On Grafana OSS, install the Assistant app from the plugin catalog and connect it to a Grafana Cloud stack. For more information, refer to the [Grafana Assistant documentation](ref:assistant).
 {{< /admonition >}}
 
 When Grafana Assistant is available on your instance, the SQL expression editor shows Assistant buttons to the right of the **Run query** button. When you use a button, Assistant opens in the sidebar with your SQL query, any query errors, and your schema column metadata already included as context, so it can reference the actual field names and types in your data. From there you get the full Assistant experience, including follow-up questions, conversation history, and access to the Assistant's built-in tools.

--- a/docs/sources/visualizations/panels-visualizations/query-transform-data/sql-expressions/index.md
+++ b/docs/sources/visualizations/panels-visualizations/query-transform-data/sql-expressions/index.md
@@ -224,16 +224,16 @@ The following non-tabular formats are automatically converted to a tabular forma
 
 - **Time Series Wide**: Label keys become column names.
 - **Time Series Multi**: Label values become the values in each row (or null if a label is missing).
-- **Numeric Wide**: The `value` column contains the numeric metric value.
-- **Numeric Multi**: If a display name exists, it will appear in the `display_name` column.
+- **Numeric Wide**: The `__value__` column contains the numeric metric value.
+- **Numeric Multi**: If a display name exists, it will appear in the `__display_name__` column.
 
 During conversion:
 
 - Label keys become column names.
 - Label values populate the corresponding rows (null if a label is missing).
-- The `value` column contains the numeric metric.
-- If available, the `display_name` column contains a human-readable name.
-- The `metric_name` column stores the raw metric identifier.
+- The `__value__` column contains the numeric metric.
+- If available, the `__display_name__` column contains a human-readable name.
+- The `__metric_name__` column stores the raw metric identifier.
 - For time series data, Grafana includes a `time` column with timestamps
 
 ## Supported functions

--- a/docs/sources/visualizations/panels-visualizations/query-transform-data/sql-expressions/index.md
+++ b/docs/sources/visualizations/panels-visualizations/query-transform-data/sql-expressions/index.md
@@ -30,9 +30,9 @@ refs:
 
 # SQL expressions
 
-SQL Expressions are server-side expressions that manipulate and transform the results of data source queries using MySQL-like syntax. They allow you to easily query and transform your data after it has been queried, using SQL, which provides a familiar and powerful syntax that can handle everything from simple filters to highly complex, multi-step transformations.
+SQL Expressions are server-side expressions that manipulate and transform the results of data source queries using MySQL-like syntax. They allow you to easily query and transform your data after the data source returns it, using SQL, which provides a familiar and powerful syntax that can handle everything from simple filters to highly complex, multi-step transformations.
 
-In Grafana, a server-side expression is a way to transform or calculate data after it has been retrieved from the data source, but before it is sent to the frontend for visualization. Grafana evaluates these expressions on the server, not in the browser or at the data source.
+In Grafana, a server-side expression is a way to transform or calculate data after Grafana retrieves it from the data source, but before Grafana sends it to the frontend for visualization. Grafana evaluates these expressions on the server, not in the browser or at the data source.
 
 For general information on Grafana expressions, refer to [Write expression queries](ref:expressions).
 
@@ -138,7 +138,7 @@ Use the following workflow to create a SQL expression:
 
 When selecting a visualization type, **ensure your SQL expression returns data in the required shape**. For example, time series panels require a column with a time field (such as a timestamp) and a numeric value column (such as `__value__`). If the output is not shaped correctly, your visualization may appear empty or fail to render.
 
-The SQL expression workflow in Grafana is designed with the following behaviors:
+The SQL expression workflow in Grafana has the following behaviors:
 
 - **Unhidden queries are visualized automatically.** If an input query is not hidden, Grafana will attempt to render it alongside your SQL expression. This can clutter the output, especially in table visualizations.
 
@@ -150,7 +150,7 @@ The SQL expression workflow in Grafana is designed with the following behaviors:
 
 The SQL expression editor provides several tools to help you write and run queries.
 
-- **Run query**: Runs your SQL expression and refreshes the result. You can also press Ctrl+Enter, or Cmd+Enter on macOS, while the editor is focused.
+- **Run query**: Runs your SQL expression and refreshes the result. You can also press Ctrl+Enter, or Cmd+Enter on macOS, while your cursor is in the editor.
 - **Format query**: Formats your SQL for readability while preserving template variables.
 - **Copy query**: Copies the current SQL to your clipboard.
 
@@ -162,7 +162,7 @@ An enhanced editor built on CodeMirror is available on an experimental basis beh
 
 ### Schema inspector
 
-When the query service API is enabled on your instance, the editor includes a **Schema inspector** side panel. Click the eye icon next to the editor to show or hide it.
+When you enable the query service API on your instance, the editor includes a **Schema inspector** side panel. Click the eye icon next to the editor to show or hide it.
 
 The Schema inspector has a tab for each source query and lists the following details for every column, so you can reference the correct field names and types as you write your SQL:
 
@@ -177,7 +177,7 @@ When you reference a RefID within a SQL statement (for example, `SELECT * FROM A
 
 The SQL conversion path:
 
-- The query result appears as a single data frame, without labels, and is mapped directly to a tabular format.
+- The query result appears as a single data frame, without labels, and maps directly to a tabular format.
 - If the frame type is present and is either numeric, wide time series, or multi-frame time series (for example: labeled formats), Grafana automatically converts the data into a table structure.
 
 ## Supported functions
@@ -236,7 +236,7 @@ Following are some best practices for alerting and recording rules:
 Grafana supports three types of data source response formats:
 
 1. **Single Table-like Frame**:  
-   This refers to data returned in a standard tabular structure, where all values are organized into rows and columns, similar to what you'd get from a SQL query.
+   This refers to data returned in a standard tabular structure that organizes all values into rows and columns, similar to what you'd get from a SQL query.
    - **Example**: Any query against a SQL data source (for example, PostgreSQL, MySQL) with the format set to Table.
 
 2. **Dataplane: Time Series Format**:  
@@ -244,7 +244,7 @@ Grafana supports three types of data source response formats:
    - **Example**: Prometheus or Loki Range Queries (queries that return a set of values over time).
 
 3. **Dataplane: Numeric Long Format**:  
-   This format is used for point-in-time (instant) metric queries that return a single value (or a set of values) at a specific moment.
+   This format represents point-in-time (instant) metric queries that return a single value (or a set of values) at a specific moment.
    - **Example**: Prometheus or Loki Instant Queries (queries that return the current value of a metric).
 
 <!-- vale Grafana.Spelling = NO -->
@@ -275,7 +275,7 @@ During conversion:
 - A SQL expression can only reference data source queries. It can't reference other expressions, and you can't use the output of a SQL expression as the input to another expression.
 - Each SQL expression query must include a time range.
 - SQL expressions aren't supported on 32-bit ARM builds of Grafana.
-- Autocomplete is available, but column/field autocomplete is only available after enabling the `sqlExpressionsColumnAutoComplete` feature toggle, which is provided on an experimental basis.
+- Autocomplete is available, but column and field autocomplete requires the experimental `sqlExpressionsColumnAutoComplete` feature toggle.
 
 ### Query limits
 
@@ -290,7 +290,7 @@ For each limit, a value of `0` means no limit.
 
 ### Regular expression limitations in SQL expressions
 
-SQL expressions depend on a third-party SQL engine that uses `cgo` by default for full regular expression compatibility with MySQL. However, Grafana is built without `cgo`, which limits regular expression support.
+SQL expressions depend on a third-party SQL engine that uses `cgo` by default for full regular expression compatibility with MySQL. However, Grafana builds don't include `cgo`, which limits regular expression support.
 
 SQL expressions that use regular expression functions have limitations such as:
 
@@ -304,9 +304,9 @@ For implementation context, refer to the [`go-mysql-server` regular expression c
 
 ### Schema changes and missing data
 
-SQL expressions have known limitations that may cause queries to fail or return unexpected results. These constraints are inherent to how the feature is implemented and should be understood when building queries.
+SQL expressions have known limitations that may cause queries to fail or return unexpected results. These constraints are inherent to how the feature works, so keep them in mind when you build queries.
 
-The following situations are affected:
+These limitations affect the following situations:
 
 - **Error responses**: When a data source query returns an error, SQL expressions cannot interpret the result.
 
@@ -314,7 +314,7 @@ The following situations are affected:
 
 - **Dynamic schema responses**: If the set of columns or labels changes between query executions, SQL expressions may fail because it treats column changes as schema changes.
 
-SQL expressions are powered by an embedded SQL engine where each query result is treated as a table. The schema of that table is derived from the columns returned by the underlying data source.
+An embedded SQL engine powers SQL expressions, treating each query result as a table. Grafana derives the schema of that table from the columns that the underlying data source returns.
 
 Unlike traditional SQL databases, where schemas are usually fixed, many Grafana data sources (for example, Prometheus) can return results with varying label sets or no data at all.
 

--- a/docs/sources/visualizations/panels-visualizations/query-transform-data/sql-expressions/index.md
+++ b/docs/sources/visualizations/panels-visualizations/query-transform-data/sql-expressions/index.md
@@ -171,6 +171,24 @@ The Schema inspector has a tab for each source query and lists the following det
 - **Nullable**: Whether the column can contain null values.
 - **Sample values**: Example values from the query result.
 
+## SQL expressions examples
+
+1. Create the following Prometheus query:
+
+   ```promql
+   sum(
+     rate(go_cpu_classes_gc_total_cpu_seconds_total{namespace=~".*(namespace).*5."}[$__rate_interval])
+   ) by (namespace)
+   ```
+
+   The panel displays the CPU usage by Go garbage collection (GC) over time, broken down by namespace.
+
+   ![Example using a Prometheus query](/media/docs/sql-expressions/sql-expressions-prom-query-example.png)
+
+2. Add the SQL expression `SELECT * from A`. After you add a SQL expression that selects from RefID A, Grafana converts it to a table response:
+
+   ![Add the SQL expression](/media/docs/sql-expressions/add-the-sql-expression.png)
+
 ## SQL conversion rules
 
 When you reference a RefID within a SQL statement (for example, `SELECT * FROM A`), the system invokes a distinct SQL conversion process.
@@ -179,6 +197,44 @@ The SQL conversion path:
 
 - The query result appears as a single data frame, without labels, and maps directly to a tabular format.
 - If the frame type is present and is either numeric, wide time series, or multi-frame time series (for example: labeled formats), Grafana automatically converts the data into a table structure.
+
+## Data source response formats
+
+Grafana supports three types of data source response formats:
+
+1. **Single Table-like Frame**:  
+   This refers to data returned in a standard tabular structure that organizes all values into rows and columns, similar to what you'd get from a SQL query.
+   - **Example**: Any query against a SQL data source (for example, PostgreSQL, MySQL) with the format set to Table.
+
+2. **Dataplane: Time Series Format**:  
+   This format represents time series data with timestamps and associated values. It is typically returned from monitoring data sources.
+   - **Example**: Prometheus or Loki Range Queries (queries that return a set of values over time).
+
+3. **Dataplane: Numeric Long Format**:  
+   This format represents point-in-time (instant) metric queries that return a single value (or a set of values) at a specific moment.
+   - **Example**: Prometheus or Loki Instant Queries (queries that return the current value of a metric).
+
+<!-- vale Grafana.Spelling = NO -->
+
+For more information on these formats, refer to the [Grafana Dataplane documentation](https://grafana.com/developers/dataplane).
+
+<!-- vale Grafana.Spelling = YES -->
+
+The following non-tabular formats are automatically converted to a tabular format (`FullLong`) when used in SQL expressions:
+
+- **Time Series Wide**: Label keys become column names.
+- **Time Series Multi**: Label values become the values in each row (or null if a label is missing).
+- **Numeric Wide**: The `value` column contains the numeric metric value.
+- **Numeric Multi**: If a display name exists, it will appear in the `display_name` column.
+
+During conversion:
+
+- Label keys become column names.
+- Label values populate the corresponding rows (null if a label is missing).
+- The `value` column contains the numeric metric.
+- If available, the `display_name` column contains a human-readable name.
+- The `metric_name` column stores the raw metric identifier.
+- For time series data, Grafana includes a `time` column with timestamps
 
 ## Supported functions
 
@@ -230,44 +286,6 @@ Following are some best practices for alerting and recording rules:
 - Avoid too many unique label combinations, as this can result in high cardinality.
 - Always use `GROUP BY` to avoid duplicate label errors.
 - Aggregate numeric values logically (for example: `SUM(error_count)`).
-
-## Supported data source formats
-
-Grafana supports three types of data source response formats:
-
-1. **Single Table-like Frame**:  
-   This refers to data returned in a standard tabular structure that organizes all values into rows and columns, similar to what you'd get from a SQL query.
-   - **Example**: Any query against a SQL data source (for example, PostgreSQL, MySQL) with the format set to Table.
-
-2. **Dataplane: Time Series Format**:  
-   This format represents time series data with timestamps and associated values. It is typically returned from monitoring data sources.
-   - **Example**: Prometheus or Loki Range Queries (queries that return a set of values over time).
-
-3. **Dataplane: Numeric Long Format**:  
-   This format represents point-in-time (instant) metric queries that return a single value (or a set of values) at a specific moment.
-   - **Example**: Prometheus or Loki Instant Queries (queries that return the current value of a metric).
-
-<!-- vale Grafana.Spelling = NO -->
-
-For more information on these formats, refer to the [Grafana Dataplane documentation](https://grafana.com/developers/dataplane).
-
-<!-- vale Grafana.Spelling = YES -->
-
-The following non-tabular formats are automatically converted to a tabular format (`FullLong`) when used in SQL expressions:
-
-- **Time Series Wide**: Label keys become column names.
-- **Time Series Multi**: Label values become the values in each row (or null if a label is missing).
-- **Numeric Wide**: The `value` column contains the numeric metric value.
-- **Numeric Multi**: If a display name exists, it will appear in the `display_name` column.
-
-During conversion:
-
-- Label keys become column names.
-- Label values populate the corresponding rows (null if a label is missing).
-- The `value` column contains the numeric metric.
-- If available, the `display_name` column contains a human-readable name.
-- The `metric_name` column stores the raw metric identifier.
-- For time series data, Grafana includes a `time` column with timestamps
 
 ## Known limitations
 
@@ -372,24 +390,6 @@ FULL OUTER JOIN (
 <!-- vale Grafana.Spelling = YES -->
 
 This approach ensures that a schema exists even when one query returns no data.
-
-## SQL expressions examples
-
-1. Create the following Prometheus query:
-
-   ```promql
-   sum(
-     rate(go_cpu_classes_gc_total_cpu_seconds_total{namespace=~".*(namespace).*5."}[$__rate_interval])
-   ) by (namespace)
-   ```
-
-   The panel displays the CPU usage by Go garbage collection (GC) over time, broken down by namespace.
-
-   ![Example using a Prometheus query](/media/docs/sql-expressions/sql-expressions-prom-query-example.png)
-
-2. Add the SQL expression `SELECT * from A`. After you add a SQL expression that selects from RefID A, Grafana converts it to a table response:
-
-   ![Add the SQL expression](/media/docs/sql-expressions/add-the-sql-expression.png)
 
 ## Grafana Assistant integration
 

--- a/docs/sources/visualizations/panels-visualizations/query-transform-data/sql-expressions/index.md
+++ b/docs/sources/visualizations/panels-visualizations/query-transform-data/sql-expressions/index.md
@@ -346,6 +346,8 @@ This approach ensures that a schema exists even when one query returns no data.
 
 [Grafana Assistant](ref:assistant) brings AI-powered assistance to your SQL expressions workflow. Assistant knows SQL expressions, so it can explain a query, fix syntax errors, and suggest improvements using the correct MySQL-dialect syntax, table references, and column conventions.
 
+You can also ask Assistant to build a panel using natural language. When you ask it to combine or correlate data across multiple queries, it prefers SQL expressions over join transformations and writes the SQL expression directly into your panel.
+
 {{< admonition type="note" >}}
 Grafana Assistant is generally available on Grafana Cloud and in public preview for Grafana OSS and Grafana Enterprise. To use it with Grafana OSS or Grafana Enterprise, you must install the Assistant app and connect it to a Grafana Cloud stack. For more information, refer to the [Grafana Assistant documentation](ref:assistant).
 {{< /admonition >}}

--- a/docs/sources/visualizations/panels-visualizations/query-transform-data/sql-expressions/index.md
+++ b/docs/sources/visualizations/panels-visualizations/query-transform-data/sql-expressions/index.md
@@ -20,8 +20,6 @@ refs:
 
 # SQL expressions
 
-{{< docs/public-preview product="SQL expressions" >}}
-
 SQL Expressions are server-side expressions that manipulate and transform the results of data source queries using MySQL-like syntax. They allow you to easily query and transform your data after it has been queried, using SQL, which provides a familiar and powerful syntax that can handle everything from simple filters to highly complex, multi-step transformations.
 
 In Grafana, a server-side expression is a way to transform or calculate data after it has been retrieved from the data source, but before it is sent to the frontend for visualization. Grafana evaluates these expressions on the server, not in the browser or at the data source.
@@ -37,15 +35,8 @@ For information about the new panel query editor experience, currently in public
 
 ## Before you begin
 
-- Enable SQL expressions under the feature toggle `sqlExpressions`.
-  - If you self-host Grafana, you can find feature toggles in the configuration file `grafana.ini`.
-
-```
-[feature_toggles]
-enable = sqlExpressions
-```
-
-- If you are using Grafana Cloud, contact [Support](https://grafana.com/help/) to enable this feature.
+- SQL expressions are enabled by default. You don't need to set a feature toggle or change your configuration to use them.
+- You must query a backend data source. SQL expressions don't work with frontend-only data sources.
 
 ## Transform data with SQL expressions
 

--- a/docs/sources/visualizations/panels-visualizations/query-transform-data/sql-expressions/index.md
+++ b/docs/sources/visualizations/panels-visualizations/query-transform-data/sql-expressions/index.md
@@ -314,7 +314,9 @@ SQL expressions run on an embedded SQL engine that evaluates regular expressions
 SQL expressions that use regular expression functions have limitations such as:
 
 - Lack of back-references.
+<!-- vale Grafana.Spelling = NO -->
 - No lookahead or lookbehind assertions.
+<!-- vale Grafana.Spelling = YES -->
 - Differences in handling carriage return (`\r`) characters.
 
 There may be other minor differences as well.

--- a/docs/sources/visualizations/panels-visualizations/query-transform-data/sql-expressions/index.md
+++ b/docs/sources/visualizations/panels-visualizations/query-transform-data/sql-expressions/index.md
@@ -133,7 +133,7 @@ Use the following workflow to create a SQL expression:
    SELECT * FROM <B, C, D, etc> LIMIT 10
    ```
 
-1. **Construct the SQL expression.** Once you understand your data, you can write your SQL expression to join, filter, or otherwise transform the data.
+1. **Construct the SQL expression.** After you understand your data, you can write your SQL expression to join, filter, or otherwise transform the data.
 1. **Validate and iterate**. Click **Refresh** every time you update your SQL query to re-evaluate and see the updated result.
 
 When selecting a visualization type, **ensure your SQL expression returns data in the required shape**. For example, time series panels require a column with a time field (such as a timestamp) and a numeric value column (such as `__value__`). If the output is not shaped correctly, your visualization may appear empty or fail to render.

--- a/docs/sources/visualizations/panels-visualizations/query-transform-data/sql-expressions/index.md
+++ b/docs/sources/visualizations/panels-visualizations/query-transform-data/sql-expressions/index.md
@@ -290,17 +290,15 @@ For each limit, a value of `0` means no limit.
 
 ### Regular expression limitations in SQL expressions
 
-SQL expressions depend on a third-party SQL engine that uses `cgo` by default for full regular expression compatibility with MySQL. However, Grafana builds don't include `cgo`, which limits regular expression support.
+SQL expressions run on an embedded SQL engine that evaluates regular expressions with Go's standard `regexp` package, which uses RE2 syntax instead of the SQL engine's full MySQL-compatible regular expressions. As a result, some regular expression features aren't available.
 
 SQL expressions that use regular expression functions have limitations such as:
 
 - Lack of back-references.
-- No before/after text matching.
+- No before or after text matching.
 - Differences in handling carriage return (`\r`) characters.
 
 There may be other minor differences as well.
-
-For implementation context, refer to the [`go-mysql-server` regular expression compatibility notes](https://github.com/grafana/go-mysql-server/blob/main/README.md).
 
 ### Schema changes and missing data
 

--- a/docs/sources/visualizations/panels-visualizations/query-transform-data/sql-expressions/index.md
+++ b/docs/sources/visualizations/panels-visualizations/query-transform-data/sql-expressions/index.md
@@ -59,7 +59,7 @@ SQL expressions allow you to:
   - Show, hide, or rename columns.
   - Filter rows based on conditions.
   - Aggregate data (for example: sum, average, count).
-- Write subqueries and Common Table Expressions (CTEs) to support more complex logic:
+- Write subqueries and Common Table Expressions (**CTEs**) to support more complex logic:
   - **Subqueries** are nested queries used for filtering, calculations, or transformations.
   - **CTEs** are temporary named result sets that help make complex queries more readable and reusable.
 
@@ -89,7 +89,7 @@ The following are compatible data sources:
 - TestData
 - Tempo
 - Prometheus
-- Cloudwatch
+- CloudWatch
 - GitHub
 - BigQuery
 
@@ -125,7 +125,7 @@ Use the following workflow to create a SQL expression:
    SELECT * FROM A LIMIT 10
    ```
 
-   This lets you see the available columns and sample rows from `query A`. Repeat this for each input query you want to use (e.g., `SELECT * FROM B LIMIT 10`).
+   This lets you see the available columns and sample rows from `query A`. Repeat this for each input query you want to use (for example, `SELECT * FROM B LIMIT 10`).
 
 1. **Inspect your data**. Repeat this for each input query to understand the column structure and data types you're working with.
 
@@ -136,7 +136,7 @@ Use the following workflow to create a SQL expression:
 1. **Construct the SQL expression.** Once you understand your data, you can write your SQL expression to join, filter, or otherwise transform the data.
 1. **Validate and iterate**. Click **Refresh** every time you update your SQL query to re-evaluate and see the updated result.
 
-When selecting a visualization type, **ensure your SQL expression returns data in the required shape**. For example, time series panels require a column with a time field (e.g., timestamp) and a numeric value column (e.g., \_\_value\_\_). If the output is not shaped correctly, your visualization may appear empty or fail to render.
+When selecting a visualization type, **ensure your SQL expression returns data in the required shape**. For example, time series panels require a column with a time field (such as a timestamp) and a numeric value column (such as `__value__`). If the output is not shaped correctly, your visualization may appear empty or fail to render.
 
 The SQL expression workflow in Grafana is designed with the following behaviors:
 
@@ -173,7 +173,7 @@ The Schema inspector has a tab for each source query and lists the following det
 
 ## SQL conversion rules
 
-When you reference a RefID within a SQL statement (e.g., `SELECT * FROM A`), the system invokes a distinct SQL conversion process.
+When you reference a RefID within a SQL statement (for example, `SELECT * FROM A`), the system invokes a distinct SQL conversion process.
 
 The SQL conversion path:
 
@@ -182,7 +182,7 @@ The SQL conversion path:
 
 ## Supported functions
 
-Grafana maintains a complete list of supported SQL keywords, operators, and functions in the SQL expressions query validator implementation.
+Grafana maintains a complete list of supported SQL keywords, operators, and functions in the SQL expressions query validation code.
 
 For the most up-to-date reference of all supported SQL functionality, refer to the `allowedNode` and `allowedFunction` definitions in the Grafana [codebase](https://github.com/grafana/grafana/blob/main/pkg/expr/sql/parser_allow.go).
 
@@ -237,7 +237,7 @@ Grafana supports three types of data source response formats:
 
 1. **Single Table-like Frame**:  
    This refers to data returned in a standard tabular structure, where all values are organized into rows and columns, similar to what you'd get from a SQL query.
-   - **Example**: Any query against a SQL data source (e.g., PostgreSQL, MySQL) with the format set to Table.
+   - **Example**: Any query against a SQL data source (for example, PostgreSQL, MySQL) with the format set to Table.
 
 2. **Dataplane: Time Series Format**:  
    This format represents time series data with timestamps and associated values. It is typically returned from monitoring data sources.
@@ -247,7 +247,11 @@ Grafana supports three types of data source response formats:
    This format is used for point-in-time (instant) metric queries that return a single value (or a set of values) at a specific moment.
    - **Example**: Prometheus or Loki Instant Queries (queries that return the current value of a metric).
 
-For more information on Dataplane formats, refer to [Grafana Dataplane Documentation](https://grafana.com/developers/dataplane).
+<!-- vale Grafana.Spelling = NO -->
+
+For more information on these formats, refer to the [Grafana Dataplane documentation](https://grafana.com/developers/dataplane).
+
+<!-- vale Grafana.Spelling = YES -->
 
 The following non-tabular formats are automatically converted to a tabular format (`FullLong`) when used in SQL expressions:
 
@@ -304,11 +308,11 @@ SQL expressions have known limitations that may cause queries to fail or return 
 
 The following situations are affected:
 
-- Error responses – When a data source query returns an error, SQL expressions cannot interpret the result.
+- **Error responses**: When a data source query returns an error, SQL expressions cannot interpret the result.
 
-- No data responses – If a query returns no rows, the SQL expression engine cannot infer a schema.
+- **No data responses**: If a query returns no rows, the SQL expression engine cannot infer a schema.
 
-- Dynamic schema responses – If the set of columns or labels changes between query executions, SQL expressions may fail because it treats column changes as schema changes.
+- **Dynamic schema responses**: If the set of columns or labels changes between query executions, SQL expressions may fail because it treats column changes as schema changes.
 
 SQL expressions are powered by an embedded SQL engine where each query result is treated as a table. The schema of that table is derived from the columns returned by the underlying data source.
 
@@ -326,13 +330,15 @@ As a result, SQL expressions can’t gracefully handle changes in schema or no-d
 
 You can mitigate these issues in the following ways:
 
-- Avoid `SELECT *` – Explicitly select only the columns you expect to exist.
+- Avoid `SELECT *`: Explicitly select only the columns you expect to exist.
 
-- Ensure a consistent schema – If possible, configure your query to always return columns, even when no data is present.
+- Ensure a consistent schema: If possible, configure your query to always return columns, even when no data is present.
 
 #### Example: Handling Prometheus no data
 
 When joining results from the same Prometheus query across different data source instances, you can use this pattern:
+
+<!-- vale Grafana.Spelling = NO -->
 
 ```sql
 -- Prometheus query
@@ -364,6 +370,8 @@ FULL OUTER JOIN (
     LIMIT 5
 ) b ON a.time = b.time;
 ```
+
+<!-- vale Grafana.Spelling = YES -->
 
 This approach ensures that a schema exists even when one query returns no data.
 

--- a/docs/sources/visualizations/panels-visualizations/query-transform-data/sql-expressions/index.md
+++ b/docs/sources/visualizations/panels-visualizations/query-transform-data/sql-expressions/index.md
@@ -16,6 +16,11 @@ refs:
       destination: /docs/grafana/<GRAFANA_VERSION>/panels-visualizations/query-transform-data/expression-queries/
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/visualizations/panels-visualizations/query-transform-data/expression-queries/
+  assistant:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/administration/assistant/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/machine-learning/assistant/
 ---
 
 # SQL expressions
@@ -35,7 +40,7 @@ For information about the new panel query editor experience, currently in public
 
 ## Before you begin
 
-- SQL expressions are enabled by default. You don't need to set a feature toggle or change your configuration to use them.
+- Grafana enables SQL expressions by default. You don't need to set a feature toggle or change your configuration to use them.
 - You must query a backend data source. SQL expressions don't work with frontend-only data sources.
 
 ## Transform data with SQL expressions
@@ -337,18 +342,15 @@ This approach ensures that a schema exists even when one query returns no data.
 
    ![Add the SQL expression](/media/docs/sql-expressions/add-the-sql-expression.png)
 
-## LLM integration
+## Grafana Assistant integration
 
-The Grafana LLM plugin seamlessly integrates AI-powered assistance into your SQL expressions workflow.
+[Grafana Assistant](ref:assistant) brings AI-powered assistance to your SQL expressions workflow. Assistant knows SQL expressions, so it can explain a query, fix syntax errors, and suggest improvements using the correct MySQL-dialect syntax, table references, and column conventions.
 
 {{< admonition type="note" >}}
-The Grafana LLM plugin is currently in public preview, meaning Grafana offers limited support, and breaking changes might occur prior to the feature being made generally available.
+Grafana Assistant is generally available on Grafana Cloud and in public preview for Grafana OSS and Grafana Enterprise. To use it with Grafana OSS or Grafana Enterprise, you must install the Assistant app and connect it to a Grafana Cloud stack. For more information, refer to the [Grafana Assistant documentation](ref:assistant).
 {{< /admonition >}}
 
-To use this integration, first [install and configure the LLM plugin](https://grafana.com/grafana/plugins/grafana-llm-app/). After installation, open your dashboard and select **Edit** to open the panel editor. Navigate to the **Queries** tab and scroll to the bottom where you'll find two new buttons positioned to the right of the **Run query** button in your SQL Expressions query.
+When Grafana Assistant is available on your instance, the SQL expression editor shows Assistant buttons to the right of the **Run query** button. When you use a button, Assistant opens in the sidebar with your SQL query, any query errors, and your schema column metadata already included as context, so it can reference the actual field names and types in your data. From there you get the full Assistant experience, including follow-up questions, conversation history, and access to the Assistant's built-in tools.
 
-{{< figure src="/media/docs/sql-expressions/sqlexpressions-LLM-integration-v12.2.png" caption="LLM integration" >}}
-
-Click **Explain query** to open a drawer that displays a detailed explanation of your query, including its interpreted business meaning and performance statistics. Once the explanation is generated, the button changes to **View explanation**.
-
-Click **Improve query** to open a suggestions drawer that contains performance and reliability enhancements, column naming best practices, and guidance on panel optimization. Click **Apply** to implement a suggestion. After you’ve interacted with the interface, you'll see a **Suggestions** button for quick access. Newer suggestions appear at the top, with older ones listed below, creating a history of improvements. If your SQL query has a parsing error, such as a syntax issue, the LLM will attempt to provide a corrected version. The LLM automatically identifies errors and helps you rewrite the query correctly.
+- **Explain query**: Describes what your query does, including its interpreted meaning.
+- **Improve query**: Suggests performance, reliability, and readability enhancements, and fixes syntax errors. If you haven't written a query yet, this appears as **Generate suggestion** and proposes a starting query, such as a join, aggregation, filter, percentile, or time-based window function, using your available queries.

--- a/docs/sources/visualizations/panels-visualizations/query-transform-data/sql-expressions/index.md
+++ b/docs/sources/visualizations/panels-visualizations/query-transform-data/sql-expressions/index.md
@@ -21,6 +21,11 @@ refs:
       destination: /docs/grafana/<GRAFANA_VERSION>/administration/assistant/
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/machine-learning/assistant/
+  configure-expressions:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#expressions
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#expressions
 ---
 
 # SQL expressions
@@ -58,7 +63,7 @@ SQL expressions allow you to:
   - **Subqueries** are nested queries used for filtering, calculations, or transformations.
   - **CTEs** are temporary named result sets that help make complex queries more readable and reusable.
 
-A key capability of SQL expressions is the ability to JOIN data from multiple tables. This allows users to combine and transform data in a predictable, user-friendly way—even for complex use cases. You can JOIN data from an unlimited number of data source queries.
+A key capability of SQL expressions is the ability to JOIN data from multiple tables. This allows users to combine and transform data in a predictable, user-friendly way—even for complex use cases. You can JOIN data from many data source queries, subject to the [input cell limit](#known-limitations).
 
 To work with SQL expressions, you must use data from a backend data source. In Grafana, a backend data source refers to a data source plugin or integration that communicates with a database, service, or API through the Grafana server, rather than directly from the browser (frontend).
 
@@ -141,6 +146,31 @@ The SQL expression workflow in Grafana is designed with the following behaviors:
 
 - **Non-tabular or incorrectly shaped data will not render in certain panels.** Visualizations such as graphs or gauges require properly structured data. Mismatched formats will result in rendering issues or missing data.
 
+## The SQL expression editor
+
+The SQL expression editor provides several tools to help you write and run queries.
+
+- **Run query**: Runs your SQL expression and refreshes the result. You can also press Ctrl+Enter, or Cmd+Enter on macOS, while the editor is focused.
+- **Format query**: Formats your SQL for readability while preserving template variables.
+- **Copy query**: Copies the current SQL to your clipboard.
+
+The editor autocompletes SQL keywords, [supported functions](#supported-functions), and the RefIDs of your other queries as table names. Column autocomplete is experimental and requires the `sqlExpressionsColumnAutoComplete` feature toggle. When enabled, the editor suggests column names by querying your data sources for their fields.
+
+{{< admonition type="note" >}}
+An enhanced editor built on CodeMirror is available on an experimental basis behind the `sqlExpressionsCodeMirror` feature toggle. It adds function signature help and context-aware column suggestions, such as resolving table aliases.
+{{< /admonition >}}
+
+### Schema inspector
+
+When the query service API is enabled on your instance, the editor includes a **Schema inspector** side panel. Click the eye icon next to the editor to show or hide it.
+
+The Schema inspector has a tab for each source query and lists the following details for every column, so you can reference the correct field names and types as you write your SQL:
+
+- **Field**: The column name.
+- **Type**: The MySQL data type.
+- **Nullable**: Whether the column can contain null values.
+- **Sample values**: Example values from the query result.
+
 ## SQL conversion rules
 
 When you reference a RefID within a SQL statement (e.g., `SELECT * FROM A`), the system invokes a distinct SQL conversion process.
@@ -162,7 +192,7 @@ SQL expressions integrates alerting and recording rules, allowing you to define 
 
 For SQL Expressions to work properly with alerting and recording rules, your query must return:
 
-- One numeric column - **_required_**. This contains the value that triggers alerts or gets recorded.
+- Exactly one numeric column - **_required_**. This contains the value that triggers alerts or gets recorded. The query fails if it returns no numeric column or more than one.
 - Unique string column combinations - **_required_**. Each row must have a unique combination of string column values.
 - One or more string columns - _optional_. These become **labels** for the alert instances or metrics. Examples: `service`, `region`.
 
@@ -237,9 +267,22 @@ During conversion:
 
 ## Known limitations
 
-- Currently, only one SQL expression is supported per panel or alert.
 - Grafana supports certain data sources. Refer to [compatible data sources](#compatible-data-sources) for a current list.
+- A SQL expression can only reference data source queries. It can't reference other expressions, and you can't use the output of a SQL expression as the input to another expression.
+- Each SQL expression query must include a time range.
+- SQL expressions aren't supported on 32-bit ARM builds of Grafana.
 - Autocomplete is available, but column/field autocomplete is only available after enabling the `sqlExpressionsColumnAutoComplete` feature toggle, which is provided on an experimental basis.
+
+### Query limits
+
+Grafana enforces the following limits on SQL expressions. Administrators can configure them in the `[expressions]` section of the Grafana configuration. For more information, refer to [Configure Grafana](ref:configure-expressions).
+
+- **Input cells**: The total number of cells, that is rows multiplied by columns, across all referenced queries can't exceed `sql_expression_cell_limit`. The default is `100000`. If the input exceeds this limit, the query fails.
+- **Output cells**: The number of cells returned can't exceed `sql_expression_output_cell_limit`. The default is `100000`. If the output exceeds this limit, Grafana truncates the result and returns a warning.
+- **Query length**: The SQL text can't exceed `sql_expression_query_length_limit` characters. The default is `10000`.
+- **Timeout**: Grafana cancels a SQL expression that runs longer than `sql_expression_timeout`. The default is `10s`.
+
+For each limit, a value of `0` means no limit.
 
 ### Regular expression limitations in SQL expressions
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Updates to the SQL expressions documentation to reflect its general availability, document the new Grafana Assistant integration, and align the page with the current backend and frontend implementations. 

**Changes:**

GA status

- Removed the public preview banner and updated Before you begin to reflect that SQL expressions are enabled by default (no feature toggle required), based on the sqlExpressions toggle being GA.

Grafana Assistant integration

- Replaced the old Grafana LLM plugin section with a Grafana Assistant integration section, covering the in-editor Explain/Improve buttons, natural-language panel building, and the preference for SQL expressions over join transformations.
- Reflects grafana/grafana#122085, grafana/grafana-assistant-app#5053, and grafana/grafana-assistant-app#5133.

Accuracy updates from a codebase review

- Added a SQL expression editor section (Run/Format/Copy, autocomplete, experimental CodeMirror editor) and a Schema inspector section.
- Added Query limits (input/output cell limits, query length, timeout, with defaults) linked to Configure Grafana.
- Documented expression constraints (data-source-query inputs only, no chaining, time range required, no 32-bit ARM).
- Corrected the regular expression limitations section (the previous cgo-based explanation was outdated).
- Removed the inaccurate "one SQL expression per panel" limitation (no enforcement exists in code).
- Editorial

Reordered sections for better flow (grouped the two conversion sections, moved the examples up, renamed "Supported data source formats" → "Data source response formats").

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
