### PR TITLE
fix(explore): seed Starred query history filters from last-used filte…

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1909,11 +1909,6 @@
       "count": 1
     }
   },
-  "public/app/features/explore/RichHistory/RichHistoryStarredTab.tsx": {
-    "react-hooks/exhaustive-deps": {
-      "count": 1
-    }
-  },
   "public/app/features/explore/TraceView/components/TracePageHeader/SpanGraph/ViewingLayer.tsx": {
     "react-prefer-function-component/react-prefer-function-component": {
       "count": 1

--- a/public/app/features/explore/RichHistory/RichHistory.test.tsx
+++ b/public/app/features/explore/RichHistory/RichHistory.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { TestProvider } from 'test/helpers/TestProvider';
 
 import { SortOrder } from 'app/core/utils/richHistoryTypes';
@@ -7,7 +8,9 @@ import { Tabs } from '../QueriesDrawer/QueriesDrawerContext';
 
 import { RichHistory, type RichHistoryProps } from './RichHistory';
 
-jest.mock('../state/selectors', () => ({ selectExploreDSMaps: jest.fn().mockReturnValue({ dsToExplore: [] }) }));
+jest.mock('../state/selectors', () => ({
+  selectExploreDSMaps: jest.fn().mockReturnValue({ dsToExplore: [{ datasource: { uid: 'active-ds-uid' } }] }),
+}));
 
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
@@ -20,9 +23,16 @@ jest.mock('@grafana/runtime', () => ({
   },
 }));
 
+// Stable identity: a fresh array per render would re-trigger effects that
+// depend on the datasource list on every render.
+const mockDataSourceItems = [{ name: 'active-ds', uid: 'active-ds-uid' }];
+
 jest.mock('@grafana/runtime/unstable', () => ({
   ...jest.requireActual('@grafana/runtime/unstable'),
-  useDataSourceInstanceList: () => ({ isLoading: false, items: [] }),
+  useDataSourceInstanceList: () => ({
+    isLoading: false,
+    items: mockDataSourceItems,
+  }),
 }));
 
 jest.mock('react-use', () => ({
@@ -83,5 +93,32 @@ describe('RichHistory', () => {
     const tabs = screen.getAllByRole('tab');
     expect(tabs[0].className).toMatch(/-*activeTabStyle/);
     expect(tabs[1].className).not.toMatch(/-*activeTabStyle/);
+  });
+
+  it('should seed Starred filters from last-used filters, not the active datasource', async () => {
+    const user = userEvent.setup();
+    const updateHistorySearchFilters = jest.fn();
+    setup({
+      updateHistorySearchFilters,
+      richHistorySettings: {
+        retentionPeriod: 7,
+        starredTabAsFirstTab: false,
+        activeDatasourcesOnly: false,
+        lastUsedDatasourceFilters: [],
+      },
+    });
+    await screen.findByPlaceholderText(/search queries/i);
+    updateHistorySearchFilters.mockClear();
+
+    await user.click(screen.getByRole('tab', { name: 'Starred' }));
+    expect(updateHistorySearchFilters).toHaveBeenLastCalledWith(
+      expect.objectContaining({ datasourceFilters: [], starred: true })
+    );
+
+    await user.click(screen.getByRole('tab', { name: 'Query history' }));
+    await user.click(screen.getByRole('tab', { name: 'Starred' }));
+    expect(updateHistorySearchFilters).toHaveBeenLastCalledWith(
+      expect.objectContaining({ datasourceFilters: [], starred: true })
+    );
   });
 });

--- a/public/app/features/explore/RichHistory/RichHistoryStarredTab.test.tsx
+++ b/public/app/features/explore/RichHistory/RichHistoryStarredTab.test.tsx
@@ -5,7 +5,12 @@ import { SortOrder } from 'app/core/utils/richHistoryTypes';
 
 import { RichHistoryStarredTab, type RichHistoryStarredTabProps } from './RichHistoryStarredTab';
 
-jest.mock('../state/selectors', () => ({ selectExploreDSMaps: jest.fn().mockReturnValue({ dsToExplore: [] }) }));
+jest.mock('../state/selectors', () => ({
+  ...jest.requireActual('../state/selectors'),
+  selectExploreDSMaps: jest
+    .fn()
+    .mockReturnValue({ dsToExplore: [{ datasource: { uid: 'active-ds-uid' } }], exploreToDS: [] }),
+}));
 
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
@@ -16,9 +21,16 @@ jest.mock('@grafana/runtime', () => ({
   },
 }));
 
+// Stable identity: a fresh array per render would re-trigger the component's
+// useAsync (which depends on the datasource list) on every render.
+const mockDataSourceItems = [{ name: 'active-ds', uid: 'active-ds-uid' }];
+
 jest.mock('@grafana/runtime/unstable', () => ({
   ...jest.requireActual('@grafana/runtime/unstable'),
-  useDataSourceInstanceList: () => ({ isLoading: false, items: [] }),
+  useDataSourceInstanceList: () => ({
+    isLoading: false,
+    items: mockDataSourceItems,
+  }),
 }));
 
 const setup = (propOverrides?: Partial<RichHistoryStarredTabProps>) => {
@@ -90,5 +102,73 @@ describe('RichHistoryStarredTab', () => {
     fireEvent.change(input, { target: { value: '|=' } });
 
     expect(updateFiltersSpy).toHaveBeenCalledWith(expect.objectContaining({ search: '|=' }));
+  });
+
+  it('should show the loading message instead of cards while datasource instances are loading', async () => {
+    setup({
+      queries: [
+        {
+          id: '1',
+          createdAt: 1,
+          datasourceUid: 'active-ds-uid',
+          datasourceName: 'active-ds',
+          starred: true,
+          comment: 'starred query comment',
+          queries: [],
+        },
+      ],
+    });
+
+    // the datasource-instance fetch starts in a loading state, so the message
+    // must show before any cards
+    expect(screen.getByText('Loading results...')).toBeInTheDocument();
+    expect(screen.queryByText('starred query comment')).not.toBeInTheDocument();
+
+    // once instances resolve, cards render
+    expect(await screen.findByText('starred query comment')).toBeInTheDocument();
+  });
+
+  it('should initialize with the last used datasource filters when active datasources only is disabled', async () => {
+    const updateFiltersSpy = jest.fn();
+    setup({
+      updateFilters: updateFiltersSpy,
+      richHistorySettings: {
+        retentionPeriod: 7,
+        starredTabAsFirstTab: false,
+        activeDatasourcesOnly: false,
+        lastUsedDatasourceFilters: ['saved-ds'],
+      },
+    });
+    await screen.findByPlaceholderText(/search queries/i);
+
+    expect(updateFiltersSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ datasourceFilters: ['saved-ds'], starred: true })
+    );
+  });
+
+  it('should preserve cleared datasource filters when active datasources only is disabled', async () => {
+    const updateFiltersSpy = jest.fn();
+    setup({ updateFilters: updateFiltersSpy });
+    await screen.findByPlaceholderText(/search queries/i);
+
+    expect(updateFiltersSpy).toHaveBeenCalledWith(expect.objectContaining({ datasourceFilters: [], starred: true }));
+  });
+
+  it('should initialize with the active Explore datasource when active datasources only is enabled', async () => {
+    const updateFiltersSpy = jest.fn();
+    setup({
+      updateFilters: updateFiltersSpy,
+      richHistorySettings: {
+        retentionPeriod: 7,
+        starredTabAsFirstTab: false,
+        activeDatasourcesOnly: true,
+        lastUsedDatasourceFilters: ['saved-ds'],
+      },
+    });
+    await screen.findByPlaceholderText(/search queries/i);
+
+    expect(updateFiltersSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ datasourceFilters: ['active-ds'], starred: true })
+    );
   });
 });

--- a/public/app/features/explore/RichHistory/RichHistoryStarredTab.tsx
+++ b/public/app/features/explore/RichHistory/RichHistoryStarredTab.tsx
@@ -94,7 +94,7 @@ export function RichHistoryStarredTab(props: RichHistoryStarredTabProps) {
       return;
     }
     const datasourceFilters =
-      richHistorySettings.activeDatasourcesOnly && richHistorySettings.lastUsedDatasourceFilters
+      !richHistorySettings.activeDatasourcesOnly && richHistorySettings.lastUsedDatasourceFilters
         ? richHistorySettings.lastUsedDatasourceFilters
         : exploreActiveDS.dsToExplore
             .map((eDs) => listOfDatasources.find((ds) => ds.uid === eDs.datasource?.uid)?.name)
@@ -126,7 +126,7 @@ export function RichHistoryStarredTab(props: RichHistoryStarredTabProps) {
       richHistorySearchFilters?.datasourceFilters && richHistorySearchFilters?.datasourceFilters.length > 0
         ? richHistorySearchFilters?.datasourceFilters
         : listOfDatasources.map((ds) => ds.uid);
-    const dsGetProm = await datasourcesToGet.map(async (dsf) => {
+    const dsGetProm = datasourcesToGet.map(async (dsf) => {
       try {
         return await getDataSourceInstance(dsf);
       } catch (e) {
@@ -141,12 +141,12 @@ export function RichHistoryStarredTab(props: RichHistoryStarredTabProps) {
     } else {
       return [];
     }
-  }, [richHistorySearchFilters?.datasourceFilters]);
+  }, [richHistorySearchFilters?.datasourceFilters, listOfDatasources]);
 
   if (!richHistorySearchFilters) {
     return (
       <span>
-        <Trans i18nKey="explore.rich-history-starred-tab.loading">Loading...</Trans>;
+        <Trans i18nKey="explore.rich-history-starred-tab.loading">Loading...</Trans>
       </span>
     );
   }
@@ -197,12 +197,12 @@ export function RichHistoryStarredTab(props: RichHistoryStarredTabProps) {
             />
           </div>
         </div>
-        {loading && loadingDs && (
+        {(loading || loadingDs) && (
           <span>
             <Trans i18nKey="explore.rich-history-starred-tab.loading-results">Loading results...</Trans>
           </span>
         )}
-        {!(loading && loadingDs) &&
+        {!(loading || loadingDs) &&
           queries.map((q) => {
             return <RichHistoryCard queryHistoryItem={q} key={q.id} datasourceInstances={datasourceFilterApis} />;
           })}


### PR DESCRIPTION
## Description
  <!--- A high level description of what this PR is doing -->

  Fixes [DPRO-205](https://linear.app/grafana/issue/DPRO-205/fix-inverted-datasource-filter-initialization-in-starred-query-history).

  Corrects datasource filter initialization in the Starred Query History tab. Previously, the tab used the active Explore datasource when “Only show
  queries for data source currently active in Explore” was disabled, overwriting saved or cleared filters.

  ## Changes
  <!--- Describe your changes in detail -->
  * Correct datasource filter initialization to restore last-used filters when active-datasource-only filtering is disabled.
  * Use the active Explore datasource when active-datasource-only filtering is enabled.
  * Refresh datasource instances when the available datasource list changes.
  * Show the loading state while either queries or datasource instances are loading.
  * Add regression coverage for saved filters, cleared filters, active-datasource-only behavior, loading behavior, and switching between Query History
  tabs.
  * Remove the obsolete ESLint suppression.

  ## Risks
  <!--- Describe what risks you've considered i.e. what features are most likely to break -->

  The changes are limited to the Starred Query History tab. The primary risk is changing which datasource filters are applied when opening or switching
  back to the tab. Tests cover both values of the active-datasource-only setting, including an explicitly cleared filter.

  The loading-state change may delay rendering query cards until datasource instances have resolved, preventing cards from rendering with incomplete
  datasource information.

  ## Demo
  <!--- Attach a demo gif/video or screenshots of the changes if applicable -->

  Original bug reproduction: https://github.com/grafana/grafana/pull/127579#pullrequestreview-4703858727

  ## Testing Instructions
  <!--- Provide step by step instructions and the dashboard if applicable -->
  * Open Explore with a datasource selected.
  * Open Query History and switch to the Starred tab.
  * With “Only show queries for data source currently active in Explore” disabled, select or clear the datasource filter.
  * Switch to Query History and then back to Starred.
  * Confirm the previous datasource filter remains selected or cleared.
  * Enable “Only show queries for data source currently active in Explore.”
  * Reopen the Starred tab and confirm it filters by the active Explore datasource.
  * Run:
    `yarn jest --no-watch public/app/features/explore/RichHistory/RichHistoryStarredTab.test.tsx public/app/features/explore/RichHistory/
    RichHistory.test.tsx`
  * Run:
    `yarn jest --no-watch public/app/features/explore/spec/queryHistory.test.tsx`

  ## Reviewer Checklist
  <!--- The reviewer should make sure the following has been done -->
  - [ ] Tests are added where applicable
  - [ ] Issue is linked to PR
  - [ ] Code pulled and tested
  - [ ] Code is meaningfully improved if applicabl