### PR TITLE
PoC: flakey-test improvement: GRAFANA_TEST_DB_TEMPLATE=true

### DIFF
--- a/pkg/services/sqlstore/dbtemplate_test.go
+++ b/pkg/services/sqlstore/dbtemplate_test.go
@@ -1,0 +1,48 @@
+package sqlstore
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/sqlstore/migrations"
+	"github.com/grafana/grafana/pkg/util/testutil"
+	"github.com/grafana/grafana/pkg/util/xorm"
+)
+
+func TestIntegrationBuildSQLiteOSSTemplate(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	// Test-scoped key: always exercises build+publish, never the real OSS canonical.
+	path, err := buildSQLiteTemplate(migrations.ProvideOSSMigrations(featuremgmt.WithFeatures()), "sqlite3:builder-invariant-test")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Remove(path) })
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Greater(t, info.Size(), int64(0), "template must not be an empty file")
+
+	// The WAL must be folded in: only then is a single-file copy a complete database.
+	assert.NoFileExists(t, path+"-wal")
+	assert.NoFileExists(t, path+"-shm")
+
+	engine, err := xorm.NewEngine("sqlite3", "file:"+path+"?mode=ro")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = engine.Close() })
+
+	// migration_log is what makes copies skip already-applied migrations.
+	var applied int64
+	found, err := engine.SQL("SELECT count(1) FROM migration_log").Get(&applied)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Greater(t, applied, int64(400), "template must carry the full OSS migration log (currently ~421 entries)")
+
+	for _, table := range []string{"user", "org", "dashboard"} {
+		exists, err := engine.IsTableExist(table)
+		require.NoError(t, err)
+		assert.True(t, exists, "core table %q missing from template schema", table)
+	}
+}

--- a/pkg/services/sqlstore/migrator/migrator.go
+++ b/pkg/services/sqlstore/migrator/migrator.go
@@ -166,6 +166,13 @@ func (mg *Migrator) GetMigrationIDs(excludeNotLogged bool) []string {
 	return result
 }
 
+// MigrationIDs returns the ordered migration IDs that register would add
+func MigrationIDs(driverName string, register func(*Migrator)) []string {
+	mg := newMigrator(nil, nil, "", NewDialect(driverName))
+	register(mg)
+	return mg.GetMigrationIDs(false)
+}
+
 func (mg *Migrator) GetMigrationLog() (map[string]MigrationLog, error) {
 	logMap := make(map[string]MigrationLog)
 	logItems := make([]MigrationLog, 0)

--- a/pkg/services/sqlstore/sqlstore_testinfra.go
+++ b/pkg/services/sqlstore/sqlstore_testinfra.go
@@ -6,9 +6,14 @@ package sqlstore
 import (
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"os"
+	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -17,6 +22,7 @@ import (
 	"github.com/grafana/grafana/pkg/registry"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrations"
+	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util/xorm"
 )
@@ -128,6 +134,47 @@ func WithTruncation() TestOption {
 	}
 }
 
+// dbTemplate is one pre-migrated template; ref meaning is engine-specific (sqlite: file path; postgres/mysql: template database name).
+type dbTemplate struct {
+	once sync.Once
+	ref  string
+	err  error
+}
+
+// dbTemplates caches templates per fingerprint key, built at most once per process each; clones carry migration_log so Migrate near-no-ops.
+var dbTemplates sync.Map
+
+// dbTemplateRequest asks createTemporaryDatabase for a database pre-migrated with the given migration set.
+type dbTemplateRequest struct {
+	key        string // fingerprint: driver + hash of the set's ordered migration IDs
+	dbMigrator registry.DatabaseMigrator
+}
+
+// getDBTemplate returns the template ref for key, building it once per process via build.
+func getDBTemplate(key string, build func() (string, error)) (string, error) {
+	v, _ := dbTemplates.LoadOrStore(key, &dbTemplate{})
+	t := v.(*dbTemplate)
+	t.once.Do(func() {
+		t.ref, t.err = build()
+	})
+	return t.ref, t.err
+}
+
+// dbTemplateFingerprint identifies a migration set by its ordered migration IDs — the same identity migration_log uses, so cache validity and skip-logic agree by construction.
+func dbTemplateFingerprint(dbm registry.DatabaseMigrator) (key string, err error) {
+	defer func() {
+		// AddMigration panics on ID conflicts; a set we cannot enumerate is a set we do not cache.
+		if r := recover(); r != nil {
+			err = fmt.Errorf("fingerprint registration panicked: %v", r)
+		}
+	}()
+
+	dbType := getTestDBType()
+	ids := migrator.MigrationIDs(dbType, dbm.AddMigration)
+	sum := sha256.Sum256([]byte(strings.Join(ids, "\n")))
+	return dbType + ":" + hex.EncodeToString(sum[:8]), nil
+}
+
 // NewTestStore creates a new SQLStore with a test database. It is useful in parallel tests.
 // All cleanup is scheduled via the passed TestingTB; the caller does not need to do anything about it.
 // Temporary, clean databases are created for each test, and are destroyed when the test finishes.
@@ -151,7 +198,20 @@ func NewTestStore(tb TestingTB, opts ...TestOption) *SQLStore {
 	}
 
 	features := newFeatureToggles(options.FeatureFlags)
-	testDB, err := createTemporaryDatabase(tb)
+	dbMigrator := options.MigratorFactory(features)
+
+	// Opt-in: GRAFANA_TEST_DB_TEMPLATE=true (read per call, for t.Setenv) serves stores from
+	// pre-migrated templates. Fresh factory instances per use: AddMigration may mutate its receiver.
+	var tmpl *dbTemplateRequest
+	if dbMigrator != nil && strings.EqualFold(os.Getenv("GRAFANA_TEST_DB_TEMPLATE"), "true") {
+		if key, ferr := dbTemplateFingerprint(options.MigratorFactory(features)); ferr == nil {
+			tmpl = &dbTemplateRequest{key: key, dbMigrator: options.MigratorFactory(features)}
+		} else {
+			tb.Logf("DB template fingerprint unavailable, falling back to running migrations: %v", ferr)
+		}
+	}
+
+	testDB, err := createTemporaryDatabase(tb, tmpl)
 	if err != nil {
 		tb.Fatalf("failed to create a temporary database: %v", err)
 		panic("unreachable")
@@ -178,7 +238,7 @@ func NewTestStore(tb TestingTB, opts ...TestOption) *SQLStore {
 	shouldEnsure := fmt.Sprintf("%t", !options.NoDefaultUserOrg && !options.Truncate)
 	cfgDBSec.Key("ensure_default_org_and_user").SetValue(shouldEnsure)
 
-	store, err := newStore(cfg, engine, features, options.MigratorFactory(features),
+	store, err := newStore(cfg, engine, features, dbMigrator,
 		options.Bus, options.Tracer)
 	if err != nil {
 		tb.Fatalf("failed to create a new SQLStore: %v", err)
@@ -255,15 +315,23 @@ type testDB struct {
 
 // createTemporaryDatabase returns a connection string to a temporary database.
 // The database is created by us, and destroyed by the TestingTB cleanup function.
-// This means every database is entirely empty and isolated. Migrations are not run here.
+// Every database is isolated. When tmpl is non-nil, supporting engines return a database
+// pre-migrated from a template; otherwise (and on any template failure) it is empty and migrations run normally.
 // If cleanup fails, the database and its data may be partially or entirely left behind.
 //
 // We assume the database credentials we are given in environment variables are those of a super user who can create databases.
-func createTemporaryDatabase(tb TestingTB) (*testDB, error) {
+func createTemporaryDatabase(tb TestingTB, tmpl *dbTemplateRequest) (*testDB, error) {
 	dbType := getTestDBType()
 	if dbType == "sqlite3" {
 		// SQLite doesn't have a concept of a database server, so we always create a new file with no connections required.
-		return newSQLite3DB(tb)
+		db, err := newSQLite3DB(tb)
+		if err == nil && tmpl != nil && db.Path != "" { // Path=="" is SQLITE_INMEMORY
+			if terr := cloneSQLiteTemplate(tb, tmpl, db.Path); terr != nil {
+				// Destination is still an empty file; the normal migration path stays correct.
+				tb.Logf("sqlite DB template unavailable, falling back to running migrations: %v", terr)
+			}
+		}
+		return db, err
 	}
 
 	// On the remaining databases, we first connect to the configured credentials, create a new database, then return this new database's info as a connection string.
@@ -291,9 +359,47 @@ func createTemporaryDatabase(tb TestingTB) (*testDB, error) {
 	}()
 
 	id := generateDatabaseName()
-	_, err = engine.Exec("CREATE DATABASE " + id)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create a new database %s: %w", id, err)
+	created := false
+	if tmpl != nil && dbType == "postgres" {
+		// Postgres clones at CREATE time; the template must have zero connections (the builder closes its engine).
+		ref, terr := getDBTemplate(tmpl.key, func() (string, error) {
+			return buildPostgresTemplate(tmpl.dbMigrator)
+		})
+		if terr == nil {
+			if _, cerr := engine.Exec("CREATE DATABASE " + id + " TEMPLATE " + ref); cerr == nil {
+				created = true
+			} else {
+				tb.Logf("postgres DB template clone failed, falling back to plain create: %v", cerr)
+			}
+		} else {
+			tb.Logf("postgres DB template unavailable, falling back to running migrations: %v", terr)
+		}
+	}
+	if !created {
+		if _, err := engine.Exec("CREATE DATABASE " + id); err != nil {
+			return nil, fmt.Errorf("failed to create a new database %s: %w", id, err)
+		}
+	}
+
+	if tmpl != nil && dbType == "mysql" {
+		// MySQL has no native clone; copy the template's tables into the fresh database.
+		ref, terr := getDBTemplate(tmpl.key, func() (string, error) {
+			return buildMySQLTemplate(tmpl.dbMigrator)
+		})
+		if terr == nil {
+			if cerr := copyMySQLDatabase(engine, ref, id); cerr != nil {
+				tb.Logf("mysql DB template clone failed, falling back to running migrations: %v", cerr)
+				// A partial copy must never reach the migrator: reset to a clean empty database.
+				if _, derr := engine.Exec("DROP DATABASE " + id); derr != nil {
+					return nil, fmt.Errorf("failed to reset database %s after failed template clone: %w", id, derr)
+				}
+				if _, rerr := engine.Exec("CREATE DATABASE " + id); rerr != nil {
+					return nil, fmt.Errorf("failed to recreate database %s after failed template clone: %w", id, rerr)
+				}
+			}
+		} else {
+			tb.Logf("mysql DB template unavailable, falling back to running migrations: %v", terr)
+		}
 	}
 	tb.Cleanup(func() {
 		engine, err := xorm.NewEngine(driver, connString)
@@ -374,6 +480,292 @@ func newSQLite3DB(tb TestingTB) (*testDB, error) {
 		Path:   tmp.Name(),
 		Conn:   fmt.Sprintf("file:%s?cache=private&mode=rwc&_journal_mode=WAL&_synchronous=OFF", tmp.Name()),
 	}, nil
+}
+
+// cloneSQLiteTemplate copies the template's file (built once per fingerprint) into dst; on failure dst is reset to empty for safe fallback (only a failed reset is fatal).
+func cloneSQLiteTemplate(tb TestingTB, tmpl *dbTemplateRequest, dst string) error {
+	tb.Helper()
+
+	ref, err := getDBTemplate(tmpl.key, func() (string, error) {
+		return buildSQLiteTemplate(tmpl.dbMigrator, tmpl.key)
+	})
+	if err != nil {
+		return fmt.Errorf("template build failed: %w", err)
+	}
+
+	if err := copyFile(ref, dst); err != nil {
+		if truncErr := os.Truncate(dst, 0); truncErr != nil {
+			tb.Fatalf("failed to reset test database %s after failed template copy: %v (copy error: %v)", dst, truncErr, err)
+			panic("unreachable")
+		}
+		return fmt.Errorf("template copy failed: %w", err)
+	}
+	return nil
+}
+
+// buildPostgresTemplate migrates a fresh template database and closes every connection to
+// it (Postgres refuses to clone a template with live connections). The template DB is left behind (PoC: one per package run).
+func buildPostgresTemplate(dbm registry.DatabaseMigrator) (name string, err error) {
+	defer func() {
+		// A panicking build must not poison the sync.Once cache.
+		if r := recover(); r != nil {
+			err = fmt.Errorf("template build panicked: %v", r)
+		}
+	}()
+
+	driver, adminConn := newPostgresConnString(env("POSTGRES_DB", "grafanatest"))
+	admin, err := xorm.NewEngine(driver, adminConn)
+	if err != nil {
+		return "", fmt.Errorf("template admin engine: %w", err)
+	}
+	defer func() {
+		_ = admin.Close()
+	}()
+
+	name = "grafana_tmpl_" + randomLowerHex(10)
+	if _, err := admin.Exec("CREATE DATABASE " + name); err != nil {
+		return "", fmt.Errorf("template create database: %w", err)
+	}
+	dropTemplate := func() { _, _ = admin.Exec("DROP DATABASE " + name) }
+
+	tmplDriver, tmplConn := newPostgresConnString(name)
+	templateDB := &testDB{Driver: tmplDriver, Conn: tmplConn}
+
+	features := featuremgmt.WithFeatures()
+	cfg, err := newTestCfg(nil, features, templateDB)
+	if err != nil {
+		dropTemplate()
+		return "", fmt.Errorf("template cfg: %w", err)
+	}
+	// Deterministic template: never seed default org/user; callers apply their own setting per call, after the clone.
+	cfg.Raw.Section("database").Key("ensure_default_org_and_user").SetValue("false")
+
+	engine, err := xorm.NewEngine(templateDB.Driver, templateDB.Conn)
+	if err != nil {
+		dropTemplate()
+		return "", fmt.Errorf("template engine: %w", err)
+	}
+	engine.DatabaseTZ = time.UTC
+	engine.TZLocation = time.UTC
+
+	tracer := tracing.InitializeTracerForTest()
+	store, err := newStore(cfg, engine, features, dbm, bus.ProvideBus(tracer), tracer)
+	if err != nil {
+		_ = engine.Close()
+		dropTemplate()
+		return "", fmt.Errorf("template store: %w", err)
+	}
+	if err := store.Migrate(false); err != nil {
+		_ = engine.Close()
+		dropTemplate()
+		return "", fmt.Errorf("template migrate: %w", err)
+	}
+
+	if err := engine.Close(); err != nil {
+		dropTemplate()
+		return "", fmt.Errorf("template engine close: %w", err)
+	}
+	return name, nil
+}
+
+// buildMySQLTemplate migrates a fresh template database; it is left behind (PoC: one per package run).
+func buildMySQLTemplate(dbm registry.DatabaseMigrator) (name string, err error) {
+	defer func() {
+		// A panicking build must not poison the sync.Once cache.
+		if r := recover(); r != nil {
+			err = fmt.Errorf("template build panicked: %v", r)
+		}
+	}()
+
+	driver, adminConn := newMySQLConnString(env("MYSQL_DB", "grafana_tests"))
+	admin, err := xorm.NewEngine(driver, adminConn)
+	if err != nil {
+		return "", fmt.Errorf("template admin engine: %w", err)
+	}
+	defer func() {
+		_ = admin.Close()
+	}()
+
+	name = "grafana_tmpl_" + randomLowerHex(10)
+	if _, err := admin.Exec("CREATE DATABASE " + name); err != nil {
+		return "", fmt.Errorf("template create database: %w", err)
+	}
+	dropTemplate := func() { _, _ = admin.Exec("DROP DATABASE " + name) }
+
+	tmplDriver, tmplConn := newMySQLConnString(name)
+	templateDB := &testDB{Driver: tmplDriver, Conn: tmplConn}
+
+	features := featuremgmt.WithFeatures()
+	cfg, err := newTestCfg(nil, features, templateDB)
+	if err != nil {
+		dropTemplate()
+		return "", fmt.Errorf("template cfg: %w", err)
+	}
+	// Deterministic template: never seed default org/user; callers apply their own setting per call, after the clone.
+	cfg.Raw.Section("database").Key("ensure_default_org_and_user").SetValue("false")
+
+	engine, err := xorm.NewEngine(templateDB.Driver, templateDB.Conn)
+	if err != nil {
+		dropTemplate()
+		return "", fmt.Errorf("template engine: %w", err)
+	}
+	engine.DatabaseTZ = time.UTC
+	engine.TZLocation = time.UTC
+
+	tracer := tracing.InitializeTracerForTest()
+	store, err := newStore(cfg, engine, features, dbm, bus.ProvideBus(tracer), tracer)
+	if err != nil {
+		_ = engine.Close()
+		dropTemplate()
+		return "", fmt.Errorf("template store: %w", err)
+	}
+	if err := store.Migrate(false); err != nil {
+		_ = engine.Close()
+		dropTemplate()
+		return "", fmt.Errorf("template migrate: %w", err)
+	}
+	if err := engine.Close(); err != nil {
+		dropTemplate()
+		return "", fmt.Errorf("template engine close: %w", err)
+	}
+	return name, nil
+}
+
+// copyMySQLDatabase copies every base table from src into dst (CREATE TABLE LIKE +
+// INSERT ... SELECT; foreign keys are not copied — Grafana's schema has none).
+func copyMySQLDatabase(admin *xorm.Engine, src, dst string) error {
+	sess := admin.NewSession()
+	defer sess.Close()
+	rows, err := sess.Query("SHOW FULL TABLES FROM `" + src + "` WHERE Table_type = 'BASE TABLE'")
+	if err != nil {
+		return fmt.Errorf("list template tables: %w", err)
+	}
+
+	// Measured: cost is per-table server-side DDL, not round trips; clone ≈ migrate on MySQL.
+	for _, row := range rows {
+		var table string
+		for col, val := range row {
+			if strings.HasPrefix(col, "Tables_in_") {
+				table = string(val)
+				break
+			}
+		}
+		if table == "" {
+			return fmt.Errorf("unexpected SHOW FULL TABLES row shape: %v", row)
+		}
+		if _, err := admin.Exec(fmt.Sprintf("CREATE TABLE `%s`.`%s` LIKE `%s`.`%s`", dst, table, src, table)); err != nil {
+			return fmt.Errorf("copy table %s schema: %w", table, err)
+		}
+		if _, err := admin.Exec(fmt.Sprintf("INSERT INTO `%s`.`%s` SELECT * FROM `%s`.`%s`", dst, table, src, table)); err != nil {
+			return fmt.Errorf("copy table %s rows: %w", table, err)
+		}
+	}
+	return nil
+}
+
+// buildSQLiteTemplate returns the content-addressed template file, building it if absent
+// (migrate → WAL checkpoint → close → atomic rename); partials never exist under the canonical name, so reuse needs no locking.
+func buildSQLiteTemplate(dbm registry.DatabaseMigrator, key string) (path string, err error) {
+	defer func() {
+		// A panicking build must not poison the sync.Once cache.
+		if r := recover(); r != nil {
+			err = fmt.Errorf("template build panicked: %v", r)
+		}
+	}()
+
+	canonical := filepath.Join(os.TempDir(), "grafana-test-sqlite-template-"+strings.ReplaceAll(key, ":", "-")+".db")
+	if info, serr := os.Stat(canonical); serr == nil && info.Size() > 0 {
+		// Cross-process warm start: published templates are complete by construction.
+		return canonical, nil
+	}
+
+	tmp, err := os.CreateTemp(os.TempDir(), "grafana-test-sqlite-tmplbuild-*.db")
+	if err != nil {
+		return "", fmt.Errorf("create template file: %w", err)
+	}
+	removeTemplate := func() { _ = os.Remove(tmp.Name()) }
+	if err := tmp.Close(); err != nil {
+		removeTemplate()
+		return "", fmt.Errorf("close template file handle: %w", err)
+	}
+
+	templateDB := &testDB{
+		Driver: "sqlite3",
+		Path:   tmp.Name(),
+		Conn:   fmt.Sprintf("file:%s?cache=private&mode=rwc&_journal_mode=WAL&_synchronous=OFF", tmp.Name()),
+	}
+
+	features := featuremgmt.WithFeatures()
+	cfg, err := newTestCfg(nil, features, templateDB)
+	if err != nil {
+		removeTemplate()
+		return "", fmt.Errorf("template cfg: %w", err)
+	}
+	// Deterministic template: never seed default org/user; callers apply their own setting per call, after the copy.
+	cfg.Raw.Section("database").Key("ensure_default_org_and_user").SetValue("false")
+
+	engine, err := xorm.NewEngine(templateDB.Driver, templateDB.Conn)
+	if err != nil {
+		removeTemplate()
+		return "", fmt.Errorf("template engine: %w", err)
+	}
+	defer func() {
+		_ = engine.Close()
+	}()
+	engine.DatabaseTZ = time.UTC
+	engine.TZLocation = time.UTC
+
+	tracer := tracing.InitializeTracerForTest()
+	store, err := newStore(cfg, engine, features, dbm, bus.ProvideBus(tracer), tracer)
+	if err != nil {
+		removeTemplate()
+		return "", fmt.Errorf("template store: %w", err)
+	}
+	if err := store.Migrate(false); err != nil {
+		removeTemplate()
+		return "", fmt.Errorf("template migrate: %w", err)
+	}
+
+	// Fold the WAL into the main file so a single-file copy is a complete database.
+	if _, err := engine.Exec("PRAGMA wal_checkpoint(TRUNCATE)"); err != nil {
+		removeTemplate()
+		return "", fmt.Errorf("template WAL checkpoint: %w", err)
+	}
+	if err := engine.Close(); err != nil {
+		removeTemplate()
+		return "", fmt.Errorf("template engine close: %w", err)
+	}
+
+	if rerr := os.Rename(tmp.Name(), canonical); rerr != nil {
+		removeTemplate()
+		// A concurrent publisher (or Windows file lock) may have won; a complete canonical is fine either way.
+		if info, serr := os.Stat(canonical); serr == nil && info.Size() > 0 {
+			return canonical, nil
+		}
+		return "", fmt.Errorf("template publish: %w", rerr)
+	}
+	return canonical, nil
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src) //nolint:gosec // both paths are test-infra-generated temp files, not user input
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = in.Close()
+	}()
+
+	// Truncate rather than recreate: os.CreateTemp's handle on dst stays open until test cleanup.
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_TRUNC, 0) //nolint:gosec // see above
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		return err
+	}
+	return out.Close()
 }
 
 func randomLowerHex(length int) string {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

**integration tests**: Introduces `GRAFANA_TEST_DB_TEMPLATE=true` which opts-in `NewTestStore` to creating databases from a pre-migrated template database. This should improve performance for tests that adopt `NewTestStore` to get their own isolated database.

* opt-in (GRAFANA_TEST_DB_TEMPLATE=true; default off → zero behavior change): NewTestStore clones each test database from a pre-migrated template instead of replaying all ~421 migrations per call.
* temporary db template files are keyed by a fingerprint of the set of ordered migration  IDs - the same identity migration_log uses - so OSS/custom/enterprise sets each get their own template automatically; any failure falls back to full migrations (the optimization can never fail a test).
* production surface area: one additive helper, migrator.MigrationIDs (7 lines); everything else is test infrastructure.
* db templating approach:
  * `sqlite3`: copy a pre-migrated .db file per test: ~0ms per clone
  * `postgres`: `CREATE DATABASE ... TEMPLATE <tmpl>`: ~40ms per clone.
  * `mysql`: no native clone; re-create each table via `CREATE TABLE ... LIKE + INSERT ... SELECT`: clone ≈ migrate, no win here 😞 

**Why do we need this feature?**

* to help isolate flakey tests, new tests can opt-in to using `NewTestStore` which creates an isolated database for the test run. Setting `GRAFANA_TEST_DB_TEMPLATE=true` attempts to speed up the database creation by running db migrations *once* on a "template" database and quickly using that database to create pre-migrated database instances.

**Who is this feature for?**

* developers who encounter slow + flakey integration tests on their PRs

**Special notes for your reviewer:**

🧪 Sample demo/benchmark:

```
time go test -run '^$' -count=1 ./pkg/services/sqlstore/ > /dev/null   # warm the build cache

TESTS='^TestIntegrationTempDatabase|^TestIntegrationUniqueConstraint|^TestIntegrationTruncateDatabase|^TestIntegrationBuildSQLite'
for db in sqlite3 postgres mysql; do
  case $db in
    postgres) extra=(PGPASSWORD=grafanatest POSTGRES_HOST=127.0.0.1);;
    mysql)    extra=(MYSQL_HOST=devenv-mysqltests-1.orb.local);;
    *)        extra=();;
  esac
  for tmpl in false true; do
    printf '%-9s TEMPLATE=%-5s : ' "$db" "$tmpl"
    env GRAFANA_TEST_DB=$db "${extra[@]}" GRAFANA_TEST_DB_TEMPLATE=$tmpl \
      go test -count=5 -run "$TESTS" ./pkg/services/sqlstore/ 2>&1 | tail -1
  done
done
```

These preliminary numbers highlight an issue with the "template database" approach with `mysql`:

```
go test -run '^$' -count=1 ./pkg/services/sqlstore/ > /dev/null  3.37s user 3.64s system 70% cpu 9.891 total

sqlite3   TEMPLATE=false : ok   github.com/grafana/grafana/pkg/services/sqlstore        8.897s
sqlite3   TEMPLATE=true  : ok   github.com/grafana/grafana/pkg/services/sqlstore        3.197s
postgres  TEMPLATE=false : ok   github.com/grafana/grafana/pkg/services/sqlstore        14.993s
postgres  TEMPLATE=true  : ok   github.com/grafana/grafana/pkg/services/sqlstore        4.572s
mysql     TEMPLATE=false : ok   github.com/grafana/grafana/pkg/services/sqlstore        15.244s
mysql     TEMPLATE=true  : ok   github.com/grafana/grafana/pkg/services/sqlstore        16.878s
```

`mysql` does not provide a quick way to create/clone a database from an existing database so this template approach ends up being roughly the same as if we just ran the migrations against a fresh database.

^^^ 🤔 this suggests for `mysql` it may be worthwhile to identify which sets of tests *really* benefit from testing/running MySQL and perhaps not re-run tests on `mysql` (and even `postgres`) that may get most of their testing coverage from running on the faster `sqlite`.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
