### PR TITLE
Search: Drop removed SearchFieldsHash field from rule builders

### DIFF
--- a/pkg/storage/unified/search/builders/alertingrules.go
+++ b/pkg/storage/unified/search/builders/alertingrules.go
@@ -40,7 +40,6 @@ func GetAlertRuleSearchBuilder() (resource.DocumentBuilderInfo, error) {
 	return resource.DocumentBuilderInfo{
 		GroupResource:        gr,
 		Builder:              &alertRuleSearchBuilder{declared: resource.StandardDocumentBuilderWithFields(rulesManifests, rulesSearchFieldsProvider)},
-		SearchFieldsHash:     rulesSearchFieldsProvider.IndexAffectingHash(gr.Group, gr.Resource),
 		SearchFieldsProvider: rulesSearchFieldsProvider,
 	}, nil
 }
@@ -50,7 +49,6 @@ func GetRecordingRuleSearchBuilder() (resource.DocumentBuilderInfo, error) {
 	return resource.DocumentBuilderInfo{
 		GroupResource:        gr,
 		Builder:              &recordingRuleSearchBuilder{declared: resource.StandardDocumentBuilderWithFields(rulesManifests, rulesSearchFieldsProvider)},
-		SearchFieldsHash:     rulesSearchFieldsProvider.IndexAffectingHash(gr.Group, gr.Resource),
 		SearchFieldsProvider: rulesSearchFieldsProvider,
 	}, nil
 }

--- a/pkg/storage/unified/search/builders/alertingrules_test.go
+++ b/pkg/storage/unified/search/builders/alertingrules_test.go
@@ -261,12 +261,17 @@ func TestRuleSearchFields_derivedFromManifest(t *testing.T) {
 func TestRuleSearchBuilders_expose_search_fields_hash(t *testing.T) {
 	alertInfo, err := GetAlertRuleSearchBuilder()
 	require.NoError(t, err)
-	assert.NotEmpty(t, alertInfo.SearchFieldsHash)
+	require.NotNil(t, alertInfo.SearchFieldsProvider)
 
 	recordingInfo, err := GetRecordingRuleSearchBuilder()
 	require.NoError(t, err)
-	assert.NotEmpty(t, recordingInfo.SearchFieldsHash)
+	require.NotNil(t, recordingInfo.SearchFieldsProvider)
+
+	alertHash := alertInfo.SearchFieldsProvider.IndexAffectingHash(alertInfo.GroupResource.Group, alertInfo.GroupResource.Resource)
+	recordingHash := recordingInfo.SearchFieldsProvider.IndexAffectingHash(recordingInfo.GroupResource.Group, recordingInfo.GroupResource.Resource)
+	assert.NotEmpty(t, alertHash)
+	assert.NotEmpty(t, recordingHash)
 
 	// The two kinds declare different fields, so their hashes must differ.
-	assert.NotEqual(t, alertInfo.SearchFieldsHash, recordingInfo.SearchFieldsHash)
+	assert.NotEqual(t, alertHash, recordingHash)
 }


### PR DESCRIPTION
**What is this feature?**

Fixes a build break on `main`. `alertingrules.go` still populated a `SearchFieldsHash` field on `resource.DocumentBuilderInfo`, but that field no longer exists on the struct, so the package failed to compile:

```
pkg/storage/unified/search/builders/alertingrules.go:43:3: unknown field SearchFieldsHash in struct literal of type ...DocumentBuilderInfo
```

This drops the two stale assignments and updates the corresponding test to obtain the hash from the `SearchFieldsProvider` instead.

**Why do we need this feature?**

This is a merge-order collision between two independent PRs that each passed CI against a base that did not include the other:

- #127479 added the rule search builders, which set `SearchFieldsHash: rulesSearchFieldsProvider.IndexAffectingHash(...)`.
- #128499 removed the `SearchFieldsHash` field from `DocumentBuilderInfo`, moving hash derivation to the centralized provider path (`SearchFieldsHashesForProviders`).

The builders already pass `SearchFieldsProvider`, from which the hash is now derived centrally, so the per-builder assignment was redundant and can simply be removed. The test's intent (each rule kind exposes a distinct, non-empty index-affecting hash) is preserved by asserting on `SearchFieldsProvider.IndexAffectingHash(...)`.

**Who is this feature for?**

Grafana developers; unblocks the build for unified storage/search.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
