### PR TITLE
Azure Monitor: Backend driven pagination [backend]

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -690,6 +690,11 @@ export interface FeatureToggles {
   */
   azureMonitorDisableLogLimit?: boolean;
   /**
+  * Enables server-side ARM pagination for Azure Monitor subscription and workspace listing on the passthrough resource endpoints.
+  * @default false
+  */
+  azureMonitorServerSidePagination?: boolean;
+  /**
   * Enables experimental reconciler for playlists
   * @default false
   */

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1351,6 +1351,14 @@ var (
 			Generate:    Generate{LegacyGo: true, LegacyFrontend: true},
 		},
 		{
+			Name:        "azureMonitorServerSidePagination",
+			Description: "Enables server-side ARM pagination for Azure Monitor subscription and workspace listing on the passthrough resource endpoints.",
+			Stage:       FeatureStageExperimental,
+			Owner:       grafanaDataSourcesPlugins,
+			Expression:  "false",
+			Generate:    Generate{LegacyGo: true, LegacyFrontend: true},
+		},
+		{
 			Name:            "playlistsReconciler",
 			Description:     "Enables experimental reconciler for playlists",
 			Stage:           FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -156,6 +156,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2024-10-04,pluginsSriChecks,GA,@grafana/grafana-catalog,false,false,false
 2024-10-22,timeRangeProvider,experimental,@grafana/grafana-frontend-platform,false,false,false
 2024-10-24,azureMonitorDisableLogLimit,GA,@grafana/data-sources-plugins,false,false,false
+2026-07-20,azureMonitorServerSidePagination,experimental,@grafana/data-sources-plugins,false,false,false
 2024-12-20,playlistsReconciler,experimental,@grafana/grafana-app-platform-squad,false,true,false
 2024-12-18,prometheusSpecialCharsInLabelValues,experimental,@grafana/data-sources-plugins,false,false,true
 2024-11-05,enableExtensionsAdminPage,experimental,@grafana/grafana-catalog,false,true,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -455,6 +455,10 @@ const (
 	// Disables the log limit restriction for Azure Monitor when true. The limit is enabled by default.
 	FlagAzureMonitorDisableLogLimit = "azureMonitorDisableLogLimit"
 
+	// FlagAzureMonitorServerSidePagination
+	// Enables server-side ARM pagination for Azure Monitor subscription and workspace listing on the passthrough resource endpoints.
+	FlagAzureMonitorServerSidePagination = "azureMonitorServerSidePagination"
+
 	// FlagPlaylistsReconciler
 	// Enables experimental reconciler for playlists
 	FlagPlaylistsReconciler = "playlistsReconciler"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1194,6 +1194,19 @@
     },
     {
       "metadata": {
+        "name": "azureMonitorServerSidePagination",
+        "resourceVersion": "1784586223726",
+        "creationTimestamp": "2026-07-20T22:23:43Z"
+      },
+      "spec": {
+        "description": "Enables server-side ARM pagination for Azure Monitor subscription and workspace listing on the passthrough resource endpoints.",
+        "stage": "experimental",
+        "codeowner": "@grafana/data-sources-plugins",
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "azureResourcePickerUpdates",
         "resourceVersion": "1779440584464",
         "creationTimestamp": "2025-07-31T22:56:50Z",

--- a/pkg/tsdb/azuremonitor/azuremonitor-resource-handler.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor-resource-handler.go
@@ -35,8 +35,10 @@ func (s *httpServiceProxy) writeErrorResponse(rw http.ResponseWriter, statusCode
 	rw.Header().Set("Content-Type", "application/json")
 	rw.WriteHeader(statusCode)
 
+	// Set error response to initial error message
 	errorBody := map[string]string{"error": message}
 
+	// Attempt to locate JSON portion in error message
 	re := regexp.MustCompile(`\{.*?\}`)
 	jsonPart := re.FindString(message)
 	if jsonPart != "" {
@@ -45,10 +47,12 @@ func (s *httpServiceProxy) writeErrorResponse(rw http.ResponseWriter, statusCode
 			errorBody["error"] = fmt.Sprintf("Invalid JSON format in error message. Raw error: %s", message)
 			s.logger.Error("failed to unmarshal JSON error message", "error", unmarshalErr)
 		} else {
+			// Extract relevant fields for a formatted error message
 			errorType, _ := jsonData["error"].(string)
 			errorDescription, ok := jsonData["error_description"].(string)
 			if !ok {
 				s.logger.Error("unable to convert error_description to string", "rawError", jsonData["error_description"])
+				// Attempt to just format the error as a string
 				errorDescription = fmt.Sprintf("%v", jsonData["error_description"])
 			}
 			if errorType == "" {
@@ -102,6 +106,7 @@ func (s *httpServiceProxy) Do(rw http.ResponseWriter, req *http.Request, cli *ht
 		}
 	}
 
+	// Return the ResponseWriter for testing purposes
 	return rw, nil
 }
 
@@ -166,6 +171,8 @@ func (s *Service) handleResourceReq(subDataSource string) func(rw http.ResponseW
 
 		_, err = s.executors[subDataSource].ResourceRequest(rw, req, service.HTTPClient)
 		if err != nil {
+			// The ResourceRequest function should handle writing the error response
+			// We log the error here to ensure it's captured
 			s.logger.Error("error in resource request", "error", err)
 			return
 		}

--- a/pkg/tsdb/azuremonitor/azuremonitor-resource-handler.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor-resource-handler.go
@@ -241,7 +241,7 @@ func (s *Service) listArmResource(rw http.ResponseWriter, req *http.Request, ser
 		s.logger.Warn("Azure Monitor ARM listing stopped at page cap; some results may be omitted", "maxPages", MaxArmPages, "path", armPath)
 	}
 
-	if err := writePaginatedResponse(rw, value, nextToken, truncated, linkParams); err != nil {
+	if err := writePaginatedResponse(rw, value, nextToken, truncated, listAll, linkParams); err != nil {
 		s.logger.Error("failed to write paginated response", "error", err)
 	}
 }

--- a/pkg/tsdb/azuremonitor/azuremonitor-resource-handler.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor-resource-handler.go
@@ -2,6 +2,7 @@ package azuremonitor
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -170,6 +171,85 @@ func (s *Service) handleResourceReq(subDataSource string) func(rw http.ResponseW
 	}
 }
 
+type armListEndpoint struct {
+	service   string
+	buildPath func(query url.Values) (path string, linkParams url.Values, err error)
+}
+
+var armListEndpoints = map[string]armListEndpoint{
+	"/subscriptions": {
+		service: azureMonitor,
+		buildPath: func(url.Values) (string, url.Values, error) {
+			return "/subscriptions?api-version=2019-03-01", nil, nil
+		},
+	},
+	"/workspaces": {
+		service: azureMonitor,
+		buildPath: func(query url.Values) (string, url.Values, error) {
+			subscriptionID := query.Get("subscriptionId")
+			if subscriptionID == "" {
+				return "", nil, errors.New("subscriptionId is required")
+			}
+			path := fmt.Sprintf(
+				"/subscriptions/%s/providers/Microsoft.OperationalInsights/workspaces?api-version=2017-04-26-preview",
+				url.PathEscape(subscriptionID),
+			)
+			return path, url.Values{"subscriptionId": {subscriptionID}}, nil
+		},
+	},
+}
+
+func (s *Service) armListHandler(ep armListEndpoint) func(rw http.ResponseWriter, req *http.Request) {
+	return func(rw http.ResponseWriter, req *http.Request) {
+		path, linkParams, err := ep.buildPath(req.URL.Query())
+		if err != nil {
+			writeErrorResponse(rw, http.StatusBadRequest, err.Error())
+			return
+		}
+		s.listArmResource(rw, req, ep.service, path, linkParams)
+	}
+}
+
+func (s *Service) listArmResource(rw http.ResponseWriter, req *http.Request, serviceName, armPath string, linkParams url.Values) {
+	dsInfo, err := s.getDataSourceFromHTTPReq(req)
+	if err != nil {
+		writeErrorResponse(rw, http.StatusInternalServerError, fmt.Sprintf("unexpected error %v", err))
+		return
+	}
+
+	service, ok := dsInfo.Services[serviceName]
+	if !ok {
+		writeErrorResponse(rw, http.StatusInternalServerError, fmt.Sprintf("%s service not configured", serviceName))
+		return
+	}
+
+	query := req.URL.Query()
+	listAll := query.Get("listAll") != "false"
+
+	requestURL := service.URL + armPath
+	if token := query.Get("nextToken"); token != "" {
+		requestURL = appendSkipToken(requestURL, token)
+	}
+
+	value, nextToken, truncated, err := fetchArmPages(req.Context(), service.HTTPClient, requestURL, listAll, MaxArmPages)
+	if err != nil {
+		status := http.StatusInternalServerError
+		var armErr *armHTTPError
+		if errors.As(err, &armErr) {
+			status = armErr.status
+		}
+		writeErrorResponse(rw, status, err.Error())
+		return
+	}
+	if truncated {
+		s.logger.Warn("Azure Monitor ARM listing stopped at page cap; some results may be omitted", "maxPages", MaxArmPages, "path", armPath)
+	}
+
+	if err := writePaginatedResponse(rw, value, nextToken, truncated, linkParams); err != nil {
+		s.logger.Error("failed to write paginated response", "error", err)
+	}
+}
+
 // newResourceMux provides route definitions shared with the frontend.
 // Check: /public/app/plugins/datasource/azuremonitor/utils/common.ts <routeNames>
 func (s *Service) newResourceMux() *http.ServeMux {
@@ -177,5 +257,8 @@ func (s *Service) newResourceMux() *http.ServeMux {
 	mux.HandleFunc("/azuremonitor/", s.handleResourceReq(azureMonitor))
 	mux.HandleFunc("/loganalytics/", s.handleResourceReq(azureLogAnalytics))
 	mux.HandleFunc("/resourcegraph/", s.handleResourceReq(azureResourceGraph))
+	for route, ep := range armListEndpoints {
+		mux.HandleFunc(route, s.armListHandler(ep))
+	}
 	return mux
 }

--- a/pkg/tsdb/azuremonitor/azuremonitor-resource-handler.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor-resource-handler.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+	"github.com/grafana/grafana-plugin-sdk-go/config"
 
 	"github.com/grafana/grafana/pkg/tsdb/azuremonitor/types"
 )
@@ -141,6 +142,12 @@ func (s *Service) handleResourceReq(subDataSource string) func(rw http.ResponseW
 			return
 		}
 
+		if subDataSource == azureMonitor && req.Method == http.MethodGet && isArmListPath(newPath) &&
+			config.GrafanaConfigFromContext(req.Context()).FeatureToggles().IsEnabled("azureMonitorServerSidePagination") {
+			s.listArmResourceProxy(rw, req, azureMonitor, newPath)
+			return
+		}
+
 		dsInfo, err := s.getDataSourceFromHTTPReq(req)
 		if err != nil {
 			writeErrorResponse(rw, http.StatusInternalServerError, fmt.Sprintf("unexpected error %v", err))
@@ -165,45 +172,21 @@ func (s *Service) handleResourceReq(subDataSource string) func(rw http.ResponseW
 	}
 }
 
-type armListEndpoint struct {
-	service   string
-	buildPath func(query url.Values) (path string, linkParams url.Values, err error)
+var workspacesListRe = regexp.MustCompile(`^/subscriptions/[^/]+/providers/Microsoft\.OperationalInsights/workspaces$`)
+
+func isArmListPath(p string) bool {
+	return p == "/subscriptions" || workspacesListRe.MatchString(p)
 }
 
-func armListEndpoints() map[string]armListEndpoint {
-	return map[string]armListEndpoint{
-		"/subscriptions": {
-			service: azureMonitor,
-			buildPath: func(url.Values) (string, url.Values, error) {
-				return "/subscriptions?api-version=2019-03-01", nil, nil
-			},
-		},
-		"/workspaces": {
-			service: azureMonitor,
-			buildPath: func(query url.Values) (string, url.Values, error) {
-				subscriptionID := query.Get("subscriptionId")
-				if subscriptionID == "" {
-					return "", nil, errors.New("subscriptionId is required")
-				}
-				path := fmt.Sprintf(
-					"/subscriptions/%s/providers/Microsoft.OperationalInsights/workspaces?api-version=2017-04-26-preview",
-					url.PathEscape(subscriptionID),
-				)
-				return path, url.Values{"subscriptionId": {subscriptionID}}, nil
-			},
-		},
+func (s *Service) listArmResourceProxy(rw http.ResponseWriter, req *http.Request, serviceName, strippedPath string) {
+	q := req.URL.Query()
+	q.Del("listAll")
+	q.Del("nextToken")
+	armPath := strippedPath
+	if enc := q.Encode(); enc != "" {
+		armPath += "?" + enc
 	}
-}
-
-func (s *Service) armListHandler(ep armListEndpoint) func(rw http.ResponseWriter, req *http.Request) {
-	return func(rw http.ResponseWriter, req *http.Request) {
-		path, linkParams, err := ep.buildPath(req.URL.Query())
-		if err != nil {
-			writeErrorResponse(rw, http.StatusBadRequest, err.Error())
-			return
-		}
-		s.listArmResource(rw, req, ep.service, path, linkParams)
-	}
+	s.listArmResource(rw, req, serviceName, armPath, nil)
 }
 
 func (s *Service) listArmResource(rw http.ResponseWriter, req *http.Request, serviceName, armPath string, linkParams url.Values) {
@@ -253,10 +236,5 @@ func (s *Service) newResourceMux() *http.ServeMux {
 	mux.HandleFunc("/azuremonitor/", s.handleResourceReq(azureMonitor))
 	mux.HandleFunc("/loganalytics/", s.handleResourceReq(azureLogAnalytics))
 	mux.HandleFunc("/resourcegraph/", s.handleResourceReq(azureResourceGraph))
-	for route, ep := range armListEndpoints() {
-		handler := s.armListHandler(ep)
-		mux.HandleFunc(route, handler)
-		mux.HandleFunc(route+"/{$}", handler)
-	}
 	return mux
 }

--- a/pkg/tsdb/azuremonitor/azuremonitor-resource-handler.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor-resource-handler.go
@@ -224,7 +224,7 @@ func (s *Service) listArmResource(rw http.ResponseWriter, req *http.Request, ser
 	}
 
 	query := req.URL.Query()
-	listAll := query.Get("listAll") != "false"
+	listAll := query.Get("listAll") == "true"
 
 	requestURL := service.URL + armPath
 	if token := query.Get("nextToken"); token != "" {

--- a/pkg/tsdb/azuremonitor/azuremonitor-resource-handler.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor-resource-handler.go
@@ -193,7 +193,7 @@ func (s *Service) listArmResourceProxy(rw http.ResponseWriter, req *http.Request
 	if enc := q.Encode(); enc != "" {
 		armPath += "?" + enc
 	}
-	s.listArmResource(rw, req, serviceName, armPath, nil)
+	s.listArmResource(rw, req, serviceName, armPath, q)
 }
 
 func (s *Service) listArmResource(rw http.ResponseWriter, req *http.Request, serviceName, armPath string, linkParams url.Values) {

--- a/pkg/tsdb/azuremonitor/azuremonitor-resource-handler.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor-resource-handler.go
@@ -34,10 +34,8 @@ func (s *httpServiceProxy) writeErrorResponse(rw http.ResponseWriter, statusCode
 	rw.Header().Set("Content-Type", "application/json")
 	rw.WriteHeader(statusCode)
 
-	// Set error response to initial error message
 	errorBody := map[string]string{"error": message}
 
-	// Attempt to locate JSON portion in error message
 	re := regexp.MustCompile(`\{.*?\}`)
 	jsonPart := re.FindString(message)
 	if jsonPart != "" {
@@ -46,12 +44,10 @@ func (s *httpServiceProxy) writeErrorResponse(rw http.ResponseWriter, statusCode
 			errorBody["error"] = fmt.Sprintf("Invalid JSON format in error message. Raw error: %s", message)
 			s.logger.Error("failed to unmarshal JSON error message", "error", unmarshalErr)
 		} else {
-			// Extract relevant fields for a formatted error message
 			errorType, _ := jsonData["error"].(string)
 			errorDescription, ok := jsonData["error_description"].(string)
 			if !ok {
 				s.logger.Error("unable to convert error_description to string", "rawError", jsonData["error_description"])
-				// Attempt to just format the error as a string
 				errorDescription = fmt.Sprintf("%v", jsonData["error_description"])
 			}
 			if errorType == "" {
@@ -105,7 +101,6 @@ func (s *httpServiceProxy) Do(rw http.ResponseWriter, req *http.Request, cli *ht
 		}
 	}
 
-	// Return the ResponseWriter for testing purposes
 	return rw, nil
 }
 
@@ -124,6 +119,7 @@ func (s *Service) getDataSourceFromHTTPReq(req *http.Request) (types.DatasourceI
 }
 
 func writeErrorResponse(rw http.ResponseWriter, code int, msg string) {
+	rw.Header().Set("Content-Type", "application/json")
 	rw.WriteHeader(code)
 	errorBody := map[string]string{
 		"error": msg,
@@ -163,8 +159,6 @@ func (s *Service) handleResourceReq(subDataSource string) func(rw http.ResponseW
 
 		_, err = s.executors[subDataSource].ResourceRequest(rw, req, service.HTTPClient)
 		if err != nil {
-			// The ResourceRequest function should handle writing the error response
-			// We log the error here to ensure it's captured
 			s.logger.Error("error in resource request", "error", err)
 			return
 		}
@@ -176,27 +170,29 @@ type armListEndpoint struct {
 	buildPath func(query url.Values) (path string, linkParams url.Values, err error)
 }
 
-var armListEndpoints = map[string]armListEndpoint{
-	"/subscriptions": {
-		service: azureMonitor,
-		buildPath: func(url.Values) (string, url.Values, error) {
-			return "/subscriptions?api-version=2019-03-01", nil, nil
+func armListEndpoints() map[string]armListEndpoint {
+	return map[string]armListEndpoint{
+		"/subscriptions": {
+			service: azureMonitor,
+			buildPath: func(url.Values) (string, url.Values, error) {
+				return "/subscriptions?api-version=2019-03-01", nil, nil
+			},
 		},
-	},
-	"/workspaces": {
-		service: azureMonitor,
-		buildPath: func(query url.Values) (string, url.Values, error) {
-			subscriptionID := query.Get("subscriptionId")
-			if subscriptionID == "" {
-				return "", nil, errors.New("subscriptionId is required")
-			}
-			path := fmt.Sprintf(
-				"/subscriptions/%s/providers/Microsoft.OperationalInsights/workspaces?api-version=2017-04-26-preview",
-				url.PathEscape(subscriptionID),
-			)
-			return path, url.Values{"subscriptionId": {subscriptionID}}, nil
+		"/workspaces": {
+			service: azureMonitor,
+			buildPath: func(query url.Values) (string, url.Values, error) {
+				subscriptionID := query.Get("subscriptionId")
+				if subscriptionID == "" {
+					return "", nil, errors.New("subscriptionId is required")
+				}
+				path := fmt.Sprintf(
+					"/subscriptions/%s/providers/Microsoft.OperationalInsights/workspaces?api-version=2017-04-26-preview",
+					url.PathEscape(subscriptionID),
+				)
+				return path, url.Values{"subscriptionId": {subscriptionID}}, nil
+			},
 		},
-	},
+	}
 }
 
 func (s *Service) armListHandler(ep armListEndpoint) func(rw http.ResponseWriter, req *http.Request) {
@@ -257,8 +253,10 @@ func (s *Service) newResourceMux() *http.ServeMux {
 	mux.HandleFunc("/azuremonitor/", s.handleResourceReq(azureMonitor))
 	mux.HandleFunc("/loganalytics/", s.handleResourceReq(azureLogAnalytics))
 	mux.HandleFunc("/resourcegraph/", s.handleResourceReq(azureResourceGraph))
-	for route, ep := range armListEndpoints {
-		mux.HandleFunc(route, s.armListHandler(ep))
+	for route, ep := range armListEndpoints() {
+		handler := s.armListHandler(ep)
+		mux.HandleFunc(route, handler)
+		mux.HandleFunc(route+"/{$}", handler)
 	}
 	return mux
 }

--- a/pkg/tsdb/azuremonitor/azuremonitor-resource-handler_test.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor-resource-handler_test.go
@@ -128,3 +128,28 @@ func Test_handleResourceReq(t *testing.T) {
 		t.Errorf("Unexpected result URL. Got %s, expecting %s", proxy.requestedURL, expectedURL)
 	}
 }
+
+func Test_newResourceMux_armListRouting(t *testing.T) {
+	srv, _, _ := newArmPagingServer(t, 1, 1)
+	s := newPaginationTestService(srv.URL, srv.Client())
+	mux := s.newResourceMux()
+
+	tests := []struct {
+		name       string
+		path       string
+		wantStatus int
+	}{
+		{"exact match returns results", "/subscriptions", http.StatusOK},
+		{"bare trailing slash is tolerated", "/subscriptions/", http.StatusOK},
+		{"arbitrary suffix is not swallowed", "/subscriptions/foo", http.StatusNotFound},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rw := httptest.NewRecorder()
+			req, err := http.NewRequest(http.MethodGet, "http://foo"+tt.path, nil)
+			require.NoError(t, err)
+			mux.ServeHTTP(rw, req)
+			require.Equal(t, tt.wantStatus, rw.Result().StatusCode)
+		})
+	}
+}

--- a/pkg/tsdb/azuremonitor/azuremonitor-resource-handler_test.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor-resource-handler_test.go
@@ -128,28 +128,3 @@ func Test_handleResourceReq(t *testing.T) {
 		t.Errorf("Unexpected result URL. Got %s, expecting %s", proxy.requestedURL, expectedURL)
 	}
 }
-
-func Test_newResourceMux_armListRouting(t *testing.T) {
-	srv, _, _ := newArmPagingServer(t, 1, 1)
-	s := newPaginationTestService(srv.URL, srv.Client())
-	mux := s.newResourceMux()
-
-	tests := []struct {
-		name       string
-		path       string
-		wantStatus int
-	}{
-		{"exact match returns results", "/subscriptions", http.StatusOK},
-		{"bare trailing slash is tolerated", "/subscriptions/", http.StatusOK},
-		{"arbitrary suffix is not swallowed", "/subscriptions/foo", http.StatusNotFound},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			rw := httptest.NewRecorder()
-			req, err := http.NewRequest(http.MethodGet, "http://foo"+tt.path, nil)
-			require.NoError(t, err)
-			mux.ServeHTTP(rw, req)
-			require.Equal(t, tt.wantStatus, rw.Result().StatusCode)
-		})
-	}
-}

--- a/pkg/tsdb/azuremonitor/resource_pagination.go
+++ b/pkg/tsdb/azuremonitor/resource_pagination.go
@@ -1,0 +1,148 @@
+package azuremonitor
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+)
+
+const MaxArmPages = 50
+
+type armListResponse struct {
+	Value    []json.RawMessage `json:"value"`
+	NextLink string            `json:"nextLink"`
+}
+
+type armHTTPError struct {
+	status int
+	body   string
+}
+
+func (e *armHTTPError) Error() string {
+	return fmt.Sprintf("ARM request failed with status %d: %s", e.status, e.body)
+}
+
+func fetchArmPages(ctx context.Context, cli *http.Client, initialURL string, listAll bool, maxPages int) (value []json.RawMessage, nextToken string, truncated bool, err error) {
+	value = []json.RawMessage{}
+	nextURL := initialURL
+	pages := 0
+	for nextURL != "" {
+		page, err := fetchArmPage(ctx, cli, nextURL)
+		if err != nil {
+			return nil, "", false, err
+		}
+		value = append(value, page.Value...)
+		pages++
+
+		if !listAll {
+			return value, skipTokenFromNextLink(page.NextLink), false, nil
+		}
+
+		nextURL = rebaseNextLink(initialURL, page.NextLink)
+		if nextURL != "" && pages >= maxPages {
+			return value, "", true, nil
+		}
+	}
+	return value, "", false, nil
+}
+
+func rebaseNextLink(baseURL, nextLink string) string {
+	if nextLink == "" {
+		return ""
+	}
+	next, err := url.Parse(nextLink)
+	if err != nil {
+		return nextLink
+	}
+	base, err := url.Parse(baseURL)
+	if err != nil {
+		return nextLink
+	}
+	next.Scheme = base.Scheme
+	next.Host = base.Host
+	return next.String()
+}
+
+func fetchArmPage(ctx context.Context, cli *http.Client, rawURL string) (*armListResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := cli.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("unexpected error: %v", err)
+	}
+	defer func() { _ = res.Body.Close() }()
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+	if res.StatusCode/100 != 2 {
+		return nil, &armHTTPError{status: res.StatusCode, body: string(body)}
+	}
+
+	var parsed armListResponse
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return nil, fmt.Errorf("failed to parse ARM response: %w", err)
+	}
+	return &parsed, nil
+}
+
+func skipTokenFromNextLink(nextLink string) string {
+	if nextLink == "" {
+		return ""
+	}
+	u, err := url.Parse(nextLink)
+	if err != nil {
+		return ""
+	}
+	q := u.Query()
+	if token := q.Get("$skiptoken"); token != "" {
+		return token
+	}
+	return q.Get("$skipToken")
+}
+
+func appendSkipToken(rawURL, token string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	q := u.Query()
+	q.Set("$skiptoken", token)
+	u.RawQuery = q.Encode()
+	return u.String()
+}
+
+func writePaginatedResponse(rw http.ResponseWriter, value []json.RawMessage, nextToken string, truncated bool, linkParams url.Values) error {
+	body, err := json.Marshal(struct {
+		Value []json.RawMessage `json:"value"`
+	}{Value: value})
+	if err != nil {
+		return fmt.Errorf("failed to marshal response: %w", err)
+	}
+
+	rw.Header().Set("Content-Type", "application/json")
+	if nextToken != "" {
+		nextParams := url.Values{}
+		for k, v := range linkParams {
+			nextParams[k] = v
+		}
+		nextParams.Set("nextToken", nextToken)
+		rw.Header().Set("Link", fmt.Sprintf(`<?%s>; rel="next"`, nextParams.Encode()))
+	}
+	if truncated {
+		rw.Header().Set("X-Results-Truncated", "true")
+	}
+
+	rw.WriteHeader(http.StatusOK)
+	if _, err := rw.Write(body); err != nil {
+		return fmt.Errorf("unable to write HTTP response: %v", err)
+	}
+	return nil
+}

--- a/pkg/tsdb/azuremonitor/resource_pagination.go
+++ b/pkg/tsdb/azuremonitor/resource_pagination.go
@@ -56,11 +56,11 @@ func rebaseNextLink(baseURL, nextLink string) string {
 	}
 	next, err := url.Parse(nextLink)
 	if err != nil {
-		return nextLink
+		return ""
 	}
 	base, err := url.Parse(baseURL)
 	if err != nil {
-		return nextLink
+		return ""
 	}
 	rebased := *base
 	rebased.RawQuery = next.RawQuery

--- a/pkg/tsdb/azuremonitor/resource_pagination.go
+++ b/pkg/tsdb/azuremonitor/resource_pagination.go
@@ -43,7 +43,7 @@ func fetchArmPages(ctx context.Context, cli *http.Client, initialURL string, lis
 
 		nextURL = rebaseNextLink(initialURL, page.NextLink)
 		if nextURL != "" && pages >= maxPages {
-			return value, "", true, nil
+			return value, skipTokenFromNextLink(page.NextLink), true, nil
 		}
 	}
 	return value, "", false, nil
@@ -74,7 +74,7 @@ func fetchArmPage(ctx context.Context, cli *http.Client, rawURL string) (*armLis
 
 	res, err := cli.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("unexpected error: %v", err)
+		return nil, fmt.Errorf("unexpected error: %w", err)
 	}
 	defer func() { _ = res.Body.Close() }()
 

--- a/pkg/tsdb/azuremonitor/resource_pagination.go
+++ b/pkg/tsdb/azuremonitor/resource_pagination.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 )
 
-const MaxArmPages = 50
+const MaxArmPages = 5
 
 type armListResponse struct {
 	Value    []json.RawMessage `json:"value"`

--- a/pkg/tsdb/azuremonitor/resource_pagination.go
+++ b/pkg/tsdb/azuremonitor/resource_pagination.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 )
 
 const MaxArmPages = 50
@@ -61,9 +62,9 @@ func rebaseNextLink(baseURL, nextLink string) string {
 	if err != nil {
 		return nextLink
 	}
-	next.Scheme = base.Scheme
-	next.Host = base.Host
-	return next.String()
+	rebased := *base
+	rebased.RawQuery = next.RawQuery
+	return rebased.String()
 }
 
 func fetchArmPage(ctx context.Context, cli *http.Client, rawURL string) (*armListResponse, error) {
@@ -113,13 +114,16 @@ func appendSkipToken(rawURL, token string) string {
 	if err != nil {
 		return rawURL
 	}
-	q := u.Query()
-	q.Set("$skiptoken", token)
-	u.RawQuery = q.Encode()
+	param := "$skiptoken=" + url.QueryEscape(token)
+	if u.RawQuery == "" {
+		u.RawQuery = param
+	} else {
+		u.RawQuery += "&" + param
+	}
 	return u.String()
 }
 
-func writePaginatedResponse(rw http.ResponseWriter, value []json.RawMessage, nextToken string, truncated bool, linkParams url.Values) error {
+func writePaginatedResponse(rw http.ResponseWriter, value []json.RawMessage, nextToken string, truncated bool, listAll bool, linkParams url.Values) error {
 	body, err := json.Marshal(struct {
 		Value []json.RawMessage `json:"value"`
 	}{Value: value})
@@ -134,6 +138,7 @@ func writePaginatedResponse(rw http.ResponseWriter, value []json.RawMessage, nex
 			nextParams[k] = v
 		}
 		nextParams.Set("nextToken", nextToken)
+		nextParams.Set("listAll", strconv.FormatBool(listAll))
 		rw.Header().Set("Link", fmt.Sprintf(`<?%s>; rel="next"`, nextParams.Encode()))
 	}
 	if truncated {

--- a/pkg/tsdb/azuremonitor/resource_pagination.go
+++ b/pkg/tsdb/azuremonitor/resource_pagination.go
@@ -68,12 +68,12 @@ func rebaseNextLink(baseURL, nextLink string) string {
 }
 
 func fetchArmPage(ctx context.Context, cli *http.Client, rawURL string) (*armListResponse, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil) // #nosec G704 -- datasource client targets operator-configured URL
 	if err != nil {
 		return nil, err
 	}
 
-	res, err := cli.Do(req)
+	res, err := cli.Do(req) // #nosec G704 -- datasource client targets operator-configured URL
 	if err != nil {
 		return nil, fmt.Errorf("unexpected error: %w", err)
 	}

--- a/pkg/tsdb/azuremonitor/resource_pagination_test.go
+++ b/pkg/tsdb/azuremonitor/resource_pagination_test.go
@@ -167,12 +167,34 @@ func TestHandleSubscriptions(t *testing.T) {
 		require.Equal(t, []string{"sub-3", "sub-4"}, decodeSubscriptionIDs(t, body))
 	})
 
+	t.Run("default (no listAll) returns a single page plus a Link cursor", func(t *testing.T) {
+		srv, count, _ := newArmPagingServer(t, 3, 2)
+		s := newPaginationTestService(srv.URL, srv.Client())
+
+		rw := httptest.NewRecorder()
+		req, err := http.NewRequest(http.MethodGet, "http://foo/subscriptions", nil)
+		require.NoError(t, err)
+		s.armListHandler(armListEndpoints["/subscriptions"])(rw, req)
+
+		res := rw.Result()
+		require.Equal(t, http.StatusOK, res.StatusCode)
+		require.Equal(t, 1, *count)
+
+		link := res.Header.Get("Link")
+		require.Contains(t, link, `rel="next"`)
+		require.Contains(t, link, "nextToken=page2")
+
+		body, err := readAllClose(res)
+		require.NoError(t, err)
+		require.Equal(t, []string{"sub-1", "sub-2"}, decodeSubscriptionIDs(t, body))
+	})
+
 	t.Run("eager mode stops at the page cap and flags truncation", func(t *testing.T) {
 		srv, count, _ := newArmPagingServer(t, MaxArmPages+10, 1)
 		s := newPaginationTestService(srv.URL, srv.Client())
 
 		rw := httptest.NewRecorder()
-		req, err := http.NewRequest(http.MethodGet, "http://foo/subscriptions", nil)
+		req, err := http.NewRequest(http.MethodGet, "http://foo/subscriptions?listAll=true", nil)
 		require.NoError(t, err)
 		s.armListHandler(armListEndpoints["/subscriptions"])(rw, req)
 

--- a/pkg/tsdb/azuremonitor/resource_pagination_test.go
+++ b/pkg/tsdb/azuremonitor/resource_pagination_test.go
@@ -7,15 +7,23 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+	"github.com/grafana/grafana-plugin-sdk-go/config"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/grafana/pkg/tsdb/azuremonitor/metrics"
 	"github.com/grafana/grafana/pkg/tsdb/azuremonitor/types"
 )
+
+func withPaginationFlag(req *http.Request) *http.Request {
+	cfg := config.NewGrafanaCfg(map[string]string{"GF_INSTANCE_FEATURE_TOGGLES_ENABLE": "azureMonitorServerSidePagination"})
+	return req.WithContext(config.WithGrafanaConfig(req.Context(), cfg))
+}
 
 func newArmPagingServer(t *testing.T, totalPages, perPage int) (srv *httptest.Server, requestCount *int, seenTokens *[]string) {
 	t.Helper()
@@ -84,14 +92,16 @@ func decodeSubscriptionIDs(t *testing.T, body []byte) []string {
 }
 
 func TestHandleSubscriptions(t *testing.T) {
+	const path = "http://foo/azuremonitor/subscriptions?api-version=2019-03-01"
+
 	t.Run("single page returns all items with no cursor", func(t *testing.T) {
 		srv, count, _ := newArmPagingServer(t, 1, 3)
 		s := newPaginationTestService(srv.URL, srv.Client())
 
 		rw := httptest.NewRecorder()
-		req, err := http.NewRequest(http.MethodGet, "http://foo/subscriptions", nil)
+		req, err := http.NewRequest(http.MethodGet, path, nil)
 		require.NoError(t, err)
-		s.armListHandler(armListEndpoints()["/subscriptions"])(rw, req)
+		s.handleResourceReq(azureMonitor)(rw, withPaginationFlag(req))
 
 		res := rw.Result()
 		require.Equal(t, http.StatusOK, res.StatusCode)
@@ -109,9 +119,9 @@ func TestHandleSubscriptions(t *testing.T) {
 		s := newPaginationTestService(srv.URL, srv.Client())
 
 		rw := httptest.NewRecorder()
-		req, err := http.NewRequest(http.MethodGet, "http://foo/subscriptions?listAll=true", nil)
+		req, err := http.NewRequest(http.MethodGet, path+"&listAll=true", nil)
 		require.NoError(t, err)
-		s.armListHandler(armListEndpoints()["/subscriptions"])(rw, req)
+		s.handleResourceReq(azureMonitor)(rw, withPaginationFlag(req))
 
 		res := rw.Result()
 		require.Equal(t, http.StatusOK, res.StatusCode)
@@ -131,9 +141,9 @@ func TestHandleSubscriptions(t *testing.T) {
 		s := newPaginationTestService(srv.URL, srv.Client())
 
 		rw := httptest.NewRecorder()
-		req, err := http.NewRequest(http.MethodGet, "http://foo/subscriptions?listAll=false", nil)
+		req, err := http.NewRequest(http.MethodGet, path+"&listAll=false", nil)
 		require.NoError(t, err)
-		s.armListHandler(armListEndpoints()["/subscriptions"])(rw, req)
+		s.handleResourceReq(azureMonitor)(rw, withPaginationFlag(req))
 
 		res := rw.Result()
 		require.Equal(t, http.StatusOK, res.StatusCode)
@@ -149,45 +159,31 @@ func TestHandleSubscriptions(t *testing.T) {
 		require.Equal(t, []string{"sub-1", "sub-2"}, decodeSubscriptionIDs(t, body))
 	})
 
-	t.Run("on-demand mode re-injects the continuation token", func(t *testing.T) {
-		srv, count, tokens := newArmPagingServer(t, 3, 2)
+	t.Run("on-demand mode re-injects the continuation token without leaking control params", func(t *testing.T) {
+		var seenQuery url.Values
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			seenQuery = r.URL.Query()
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"value":[{"subscriptionId":"sub-3"},{"subscriptionId":"sub-4"}]}`))
+		}))
+		t.Cleanup(srv.Close)
 		s := newPaginationTestService(srv.URL, srv.Client())
 
 		rw := httptest.NewRecorder()
-		req, err := http.NewRequest(http.MethodGet, "http://foo/subscriptions?listAll=false&nextToken=page2", nil)
+		req, err := http.NewRequest(http.MethodGet, path+"&listAll=false&nextToken=page2", nil)
 		require.NoError(t, err)
-		s.armListHandler(armListEndpoints()["/subscriptions"])(rw, req)
+		s.handleResourceReq(azureMonitor)(rw, withPaginationFlag(req))
 
 		res := rw.Result()
 		require.Equal(t, http.StatusOK, res.StatusCode)
-		require.Equal(t, 1, *count)
-		require.Equal(t, []string{"page2"}, *tokens)
+		require.Equal(t, "page2", seenQuery.Get("$skiptoken"))
+		require.Empty(t, seenQuery.Get("listAll"))
+		require.Empty(t, seenQuery.Get("nextToken"))
+		require.Equal(t, "2019-03-01", seenQuery.Get("api-version"))
 
 		body, err := readAllClose(res)
 		require.NoError(t, err)
 		require.Equal(t, []string{"sub-3", "sub-4"}, decodeSubscriptionIDs(t, body))
-	})
-
-	t.Run("default (no listAll) returns a single page plus a Link cursor", func(t *testing.T) {
-		srv, count, _ := newArmPagingServer(t, 3, 2)
-		s := newPaginationTestService(srv.URL, srv.Client())
-
-		rw := httptest.NewRecorder()
-		req, err := http.NewRequest(http.MethodGet, "http://foo/subscriptions", nil)
-		require.NoError(t, err)
-		s.armListHandler(armListEndpoints()["/subscriptions"])(rw, req)
-
-		res := rw.Result()
-		require.Equal(t, http.StatusOK, res.StatusCode)
-		require.Equal(t, 1, *count)
-
-		link := res.Header.Get("Link")
-		require.Contains(t, link, `rel="next"`)
-		require.Contains(t, link, "nextToken=page2")
-
-		body, err := readAllClose(res)
-		require.NoError(t, err)
-		require.Equal(t, []string{"sub-1", "sub-2"}, decodeSubscriptionIDs(t, body))
 	})
 
 	t.Run("eager mode stops at the page cap and flags truncation", func(t *testing.T) {
@@ -195,9 +191,9 @@ func TestHandleSubscriptions(t *testing.T) {
 		s := newPaginationTestService(srv.URL, srv.Client())
 
 		rw := httptest.NewRecorder()
-		req, err := http.NewRequest(http.MethodGet, "http://foo/subscriptions?listAll=true", nil)
+		req, err := http.NewRequest(http.MethodGet, path+"&listAll=true", nil)
 		require.NoError(t, err)
-		s.armListHandler(armListEndpoints()["/subscriptions"])(rw, req)
+		s.handleResourceReq(azureMonitor)(rw, withPaginationFlag(req))
 
 		res := rw.Result()
 		require.Equal(t, http.StatusOK, res.StatusCode)
@@ -221,24 +217,53 @@ func TestHandleSubscriptions(t *testing.T) {
 		s := newPaginationTestService(srv.URL, srv.Client())
 
 		rw := httptest.NewRecorder()
-		req, err := http.NewRequest(http.MethodGet, "http://foo/subscriptions", nil)
+		req, err := http.NewRequest(http.MethodGet, path, nil)
 		require.NoError(t, err)
-		s.armListHandler(armListEndpoints()["/subscriptions"])(rw, req)
+		s.handleResourceReq(azureMonitor)(rw, withPaginationFlag(req))
 
 		require.Equal(t, http.StatusBadGateway, rw.Result().StatusCode)
+	})
+
+	t.Run("flag off proxies the request verbatim without pagination", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"value":[{"subscriptionId":"sub-1"}],"nextLink":"https://management.azure.com/subscriptions?api-version=2019-03-01&$skiptoken=page2"}`))
+		}))
+		t.Cleanup(srv.Close)
+		s := &Service{
+			im: &fakeInstance{
+				services: map[string]types.DatasourceService{
+					azureMonitor: {
+						URL:        srv.URL,
+						HTTPClient: srv.Client(),
+						Logger:     log.DefaultLogger,
+					},
+				},
+			},
+			executors: map[string]azDatasourceExecutor{
+				azureMonitor: &metrics.AzureMonitorDatasource{
+					Proxy: &httpServiceProxy{logger: log.DefaultLogger},
+				},
+			},
+			logger: log.DefaultLogger,
+		}
+
+		rw := httptest.NewRecorder()
+		req, err := http.NewRequest(http.MethodGet, path, nil)
+		require.NoError(t, err)
+		s.handleResourceReq(azureMonitor)(rw, req)
+
+		res := rw.Result()
+		require.Equal(t, http.StatusOK, res.StatusCode)
+		require.Empty(t, res.Header.Get("Link"))
+
+		body, err := readAllClose(res)
+		require.NoError(t, err)
+		require.Contains(t, string(body), "nextLink")
 	})
 }
 
 func TestHandleWorkspaces(t *testing.T) {
-	t.Run("requires subscriptionId", func(t *testing.T) {
-		s := newPaginationTestService("https://management.azure.com", &http.Client{})
-		rw := httptest.NewRecorder()
-		req, err := http.NewRequest(http.MethodGet, "http://foo/workspaces", nil)
-		require.NoError(t, err)
-		s.armListHandler(armListEndpoints()["/workspaces"])(rw, req)
-		require.Equal(t, http.StatusBadRequest, rw.Result().StatusCode)
-	})
-
 	t.Run("targets the workspaces path for the subscription", func(t *testing.T) {
 		var requestedPath string
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -250,9 +275,9 @@ func TestHandleWorkspaces(t *testing.T) {
 		s := newPaginationTestService(srv.URL, srv.Client())
 
 		rw := httptest.NewRecorder()
-		req, err := http.NewRequest(http.MethodGet, "http://foo/workspaces?subscriptionId=sub-42", nil)
+		req, err := http.NewRequest(http.MethodGet, "http://foo/azuremonitor/subscriptions/sub-42/providers/Microsoft.OperationalInsights/workspaces?api-version=2017-04-26-preview", nil)
 		require.NoError(t, err)
-		s.armListHandler(armListEndpoints()["/workspaces"])(rw, req)
+		s.handleResourceReq(azureMonitor)(rw, withPaginationFlag(req))
 
 		require.Equal(t, http.StatusOK, rw.Result().StatusCode)
 		require.Equal(t, "/subscriptions/sub-42/providers/Microsoft.OperationalInsights/workspaces", requestedPath)

--- a/pkg/tsdb/azuremonitor/resource_pagination_test.go
+++ b/pkg/tsdb/azuremonitor/resource_pagination_test.go
@@ -153,6 +153,7 @@ func TestHandleSubscriptions(t *testing.T) {
 		require.Contains(t, link, `rel="next"`)
 		require.Contains(t, link, "nextToken=page2")
 		require.Contains(t, link, "listAll=false")
+		require.Contains(t, link, "api-version=2019-03-01")
 
 		body, err := readAllClose(res)
 		require.NoError(t, err)

--- a/pkg/tsdb/azuremonitor/resource_pagination_test.go
+++ b/pkg/tsdb/azuremonitor/resource_pagination_test.go
@@ -91,7 +91,7 @@ func TestHandleSubscriptions(t *testing.T) {
 		rw := httptest.NewRecorder()
 		req, err := http.NewRequest(http.MethodGet, "http://foo/subscriptions", nil)
 		require.NoError(t, err)
-		s.armListHandler(armListEndpoints["/subscriptions"])(rw, req)
+		s.armListHandler(armListEndpoints()["/subscriptions"])(rw, req)
 
 		res := rw.Result()
 		require.Equal(t, http.StatusOK, res.StatusCode)
@@ -111,7 +111,7 @@ func TestHandleSubscriptions(t *testing.T) {
 		rw := httptest.NewRecorder()
 		req, err := http.NewRequest(http.MethodGet, "http://foo/subscriptions?listAll=true", nil)
 		require.NoError(t, err)
-		s.armListHandler(armListEndpoints["/subscriptions"])(rw, req)
+		s.armListHandler(armListEndpoints()["/subscriptions"])(rw, req)
 
 		res := rw.Result()
 		require.Equal(t, http.StatusOK, res.StatusCode)
@@ -133,7 +133,7 @@ func TestHandleSubscriptions(t *testing.T) {
 		rw := httptest.NewRecorder()
 		req, err := http.NewRequest(http.MethodGet, "http://foo/subscriptions?listAll=false", nil)
 		require.NoError(t, err)
-		s.armListHandler(armListEndpoints["/subscriptions"])(rw, req)
+		s.armListHandler(armListEndpoints()["/subscriptions"])(rw, req)
 
 		res := rw.Result()
 		require.Equal(t, http.StatusOK, res.StatusCode)
@@ -155,7 +155,7 @@ func TestHandleSubscriptions(t *testing.T) {
 		rw := httptest.NewRecorder()
 		req, err := http.NewRequest(http.MethodGet, "http://foo/subscriptions?listAll=false&nextToken=page2", nil)
 		require.NoError(t, err)
-		s.armListHandler(armListEndpoints["/subscriptions"])(rw, req)
+		s.armListHandler(armListEndpoints()["/subscriptions"])(rw, req)
 
 		res := rw.Result()
 		require.Equal(t, http.StatusOK, res.StatusCode)
@@ -174,7 +174,7 @@ func TestHandleSubscriptions(t *testing.T) {
 		rw := httptest.NewRecorder()
 		req, err := http.NewRequest(http.MethodGet, "http://foo/subscriptions", nil)
 		require.NoError(t, err)
-		s.armListHandler(armListEndpoints["/subscriptions"])(rw, req)
+		s.armListHandler(armListEndpoints()["/subscriptions"])(rw, req)
 
 		res := rw.Result()
 		require.Equal(t, http.StatusOK, res.StatusCode)
@@ -196,7 +196,7 @@ func TestHandleSubscriptions(t *testing.T) {
 		rw := httptest.NewRecorder()
 		req, err := http.NewRequest(http.MethodGet, "http://foo/subscriptions?listAll=true", nil)
 		require.NoError(t, err)
-		s.armListHandler(armListEndpoints["/subscriptions"])(rw, req)
+		s.armListHandler(armListEndpoints()["/subscriptions"])(rw, req)
 
 		res := rw.Result()
 		require.Equal(t, http.StatusOK, res.StatusCode)
@@ -218,7 +218,7 @@ func TestHandleSubscriptions(t *testing.T) {
 		rw := httptest.NewRecorder()
 		req, err := http.NewRequest(http.MethodGet, "http://foo/subscriptions", nil)
 		require.NoError(t, err)
-		s.armListHandler(armListEndpoints["/subscriptions"])(rw, req)
+		s.armListHandler(armListEndpoints()["/subscriptions"])(rw, req)
 
 		require.Equal(t, http.StatusBadGateway, rw.Result().StatusCode)
 	})
@@ -230,7 +230,7 @@ func TestHandleWorkspaces(t *testing.T) {
 		rw := httptest.NewRecorder()
 		req, err := http.NewRequest(http.MethodGet, "http://foo/workspaces", nil)
 		require.NoError(t, err)
-		s.armListHandler(armListEndpoints["/workspaces"])(rw, req)
+		s.armListHandler(armListEndpoints()["/workspaces"])(rw, req)
 		require.Equal(t, http.StatusBadRequest, rw.Result().StatusCode)
 	})
 
@@ -247,7 +247,7 @@ func TestHandleWorkspaces(t *testing.T) {
 		rw := httptest.NewRecorder()
 		req, err := http.NewRequest(http.MethodGet, "http://foo/workspaces?subscriptionId=sub-42", nil)
 		require.NoError(t, err)
-		s.armListHandler(armListEndpoints["/workspaces"])(rw, req)
+		s.armListHandler(armListEndpoints()["/workspaces"])(rw, req)
 
 		require.Equal(t, http.StatusOK, rw.Result().StatusCode)
 		require.Equal(t, "/subscriptions/sub-42/providers/Microsoft.OperationalInsights/workspaces", requestedPath)
@@ -274,9 +274,8 @@ func TestSkipTokenFromNextLink(t *testing.T) {
 
 func TestAppendSkipToken(t *testing.T) {
 	out := appendSkipToken("https://management.azure.com/subscriptions?api-version=2019-03-01", "page2")
-	u := out
-	require.Contains(t, u, "api-version=2019-03-01")
-	require.Contains(t, u, "skiptoken=page2")
+	require.Contains(t, out, "api-version=2019-03-01")
+	require.Contains(t, out, "skiptoken=page2")
 	require.Equal(t, "page2", skipTokenFromNextLink(out))
 }
 
@@ -319,9 +318,10 @@ func TestFetchArmPagesTruncation(t *testing.T) {
 	value, nextToken, truncated, err := fetchArmPages(context.Background(), srv.Client(), srv.URL+"/subscriptions?api-version=2019-03-01", true, 3)
 	require.NoError(t, err)
 	require.True(t, truncated)
-	require.Empty(t, nextToken)
 	require.Len(t, value, 3)
 	require.Equal(t, 3, *count)
+	require.NotEmpty(t, nextToken)
+	require.Equal(t, "page4", nextToken)
 }
 
 func readAllClose(res *http.Response) ([]byte, error) {

--- a/pkg/tsdb/azuremonitor/resource_pagination_test.go
+++ b/pkg/tsdb/azuremonitor/resource_pagination_test.go
@@ -142,6 +142,7 @@ func TestHandleSubscriptions(t *testing.T) {
 		link := res.Header.Get("Link")
 		require.Contains(t, link, `rel="next"`)
 		require.Contains(t, link, "nextToken=page2")
+		require.Contains(t, link, "listAll=false")
 
 		body, err := readAllClose(res)
 		require.NoError(t, err)
@@ -202,6 +203,10 @@ func TestHandleSubscriptions(t *testing.T) {
 		require.Equal(t, http.StatusOK, res.StatusCode)
 		require.Equal(t, MaxArmPages, *count)
 		require.Equal(t, "true", res.Header.Get("X-Results-Truncated"))
+
+		link := res.Header.Get("Link")
+		require.Contains(t, link, `rel="next"`)
+		require.Contains(t, link, "listAll=true")
 
 		body, err := readAllClose(res)
 		require.NoError(t, err)
@@ -275,7 +280,8 @@ func TestSkipTokenFromNextLink(t *testing.T) {
 func TestAppendSkipToken(t *testing.T) {
 	out := appendSkipToken("https://management.azure.com/subscriptions?api-version=2019-03-01", "page2")
 	require.Contains(t, out, "api-version=2019-03-01")
-	require.Contains(t, out, "skiptoken=page2")
+	require.Contains(t, out, "$skiptoken=page2")
+	require.NotContains(t, out, "%24skiptoken")
 	require.Equal(t, "page2", skipTokenFromNextLink(out))
 }
 
@@ -286,6 +292,12 @@ func TestRebaseNextLink(t *testing.T) {
 	)
 	require.Equal(t, "https://proxy.internal/subscriptions?api-version=2019-03-01&$skiptoken=abc", got)
 	require.Equal(t, "", rebaseNextLink("https://proxy.internal/x", ""))
+
+	withPrefix := rebaseNextLink(
+		"https://proxy.internal/api/datasources/proxy/42/subscriptions?api-version=2019-03-01",
+		"https://management.azure.com/subscriptions?api-version=2019-03-01&$skiptoken=abc",
+	)
+	require.Equal(t, "https://proxy.internal/api/datasources/proxy/42/subscriptions?api-version=2019-03-01&$skiptoken=abc", withPrefix)
 }
 
 func TestFetchArmPagesRebasesNextLinkHost(t *testing.T) {

--- a/pkg/tsdb/azuremonitor/resource_pagination_test.go
+++ b/pkg/tsdb/azuremonitor/resource_pagination_test.go
@@ -1,0 +1,308 @@
+package azuremonitor
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/tsdb/azuremonitor/types"
+)
+
+func newArmPagingServer(t *testing.T, totalPages, perPage int) (srv *httptest.Server, requestCount *int, seenTokens *[]string) {
+	t.Helper()
+	count := 0
+	tokens := []string{}
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count++
+		tok := r.URL.Query().Get("$skiptoken")
+		tokens = append(tokens, tok)
+
+		page := 1
+		if tok != "" {
+			p, err := strconv.Atoi(strings.TrimPrefix(tok, "page"))
+			require.NoError(t, err)
+			page = p
+		}
+
+		value := make([]map[string]string, 0, perPage)
+		for i := 0; i < perPage; i++ {
+			n := (page-1)*perPage + i + 1
+			value = append(value, map[string]string{
+				"subscriptionId": fmt.Sprintf("sub-%d", n),
+				"displayName":    fmt.Sprintf("Sub %d", n),
+			})
+		}
+
+		resp := map[string]any{"value": value}
+		if page < totalPages {
+			resp["nextLink"] = fmt.Sprintf("%s/subscriptions?api-version=2019-03-01&$skiptoken=page%d", srv.URL, page+1)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(resp))
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &count, &tokens
+}
+
+func newPaginationTestService(serverURL string, client *http.Client) *Service {
+	return &Service{
+		im: &fakeInstance{
+			services: map[string]types.DatasourceService{
+				azureMonitor: {
+					URL:        serverURL,
+					HTTPClient: client,
+					Logger:     log.DefaultLogger,
+				},
+			},
+		},
+		logger: log.DefaultLogger,
+	}
+}
+
+func decodeSubscriptionIDs(t *testing.T, body []byte) []string {
+	t.Helper()
+	var parsed struct {
+		Value []struct {
+			SubscriptionID string `json:"subscriptionId"`
+		} `json:"value"`
+	}
+	require.NoError(t, json.Unmarshal(body, &parsed))
+	ids := make([]string, 0, len(parsed.Value))
+	for _, v := range parsed.Value {
+		ids = append(ids, v.SubscriptionID)
+	}
+	return ids
+}
+
+func TestHandleSubscriptions(t *testing.T) {
+	t.Run("single page returns all items with no cursor", func(t *testing.T) {
+		srv, count, _ := newArmPagingServer(t, 1, 3)
+		s := newPaginationTestService(srv.URL, srv.Client())
+
+		rw := httptest.NewRecorder()
+		req, err := http.NewRequest(http.MethodGet, "http://foo/subscriptions", nil)
+		require.NoError(t, err)
+		s.armListHandler(armListEndpoints["/subscriptions"])(rw, req)
+
+		res := rw.Result()
+		require.Equal(t, http.StatusOK, res.StatusCode)
+		require.Equal(t, 1, *count)
+		require.Empty(t, res.Header.Get("Link"))
+		require.Empty(t, res.Header.Get("X-Results-Truncated"))
+
+		body, err := readAllClose(res)
+		require.NoError(t, err)
+		require.Equal(t, []string{"sub-1", "sub-2", "sub-3"}, decodeSubscriptionIDs(t, body))
+	})
+
+	t.Run("eager mode aggregates every page in order", func(t *testing.T) {
+		srv, count, _ := newArmPagingServer(t, 3, 2)
+		s := newPaginationTestService(srv.URL, srv.Client())
+
+		rw := httptest.NewRecorder()
+		req, err := http.NewRequest(http.MethodGet, "http://foo/subscriptions?listAll=true", nil)
+		require.NoError(t, err)
+		s.armListHandler(armListEndpoints["/subscriptions"])(rw, req)
+
+		res := rw.Result()
+		require.Equal(t, http.StatusOK, res.StatusCode)
+		require.Equal(t, 3, *count)
+		require.Empty(t, res.Header.Get("Link"))
+
+		body, err := readAllClose(res)
+		require.NoError(t, err)
+		require.Equal(t,
+			[]string{"sub-1", "sub-2", "sub-3", "sub-4", "sub-5", "sub-6"},
+			decodeSubscriptionIDs(t, body),
+		)
+	})
+
+	t.Run("on-demand mode returns a single page plus a Link cursor", func(t *testing.T) {
+		srv, count, _ := newArmPagingServer(t, 3, 2)
+		s := newPaginationTestService(srv.URL, srv.Client())
+
+		rw := httptest.NewRecorder()
+		req, err := http.NewRequest(http.MethodGet, "http://foo/subscriptions?listAll=false", nil)
+		require.NoError(t, err)
+		s.armListHandler(armListEndpoints["/subscriptions"])(rw, req)
+
+		res := rw.Result()
+		require.Equal(t, http.StatusOK, res.StatusCode)
+		require.Equal(t, 1, *count)
+
+		link := res.Header.Get("Link")
+		require.Contains(t, link, `rel="next"`)
+		require.Contains(t, link, "nextToken=page2")
+
+		body, err := readAllClose(res)
+		require.NoError(t, err)
+		require.Equal(t, []string{"sub-1", "sub-2"}, decodeSubscriptionIDs(t, body))
+	})
+
+	t.Run("on-demand mode re-injects the continuation token", func(t *testing.T) {
+		srv, count, tokens := newArmPagingServer(t, 3, 2)
+		s := newPaginationTestService(srv.URL, srv.Client())
+
+		rw := httptest.NewRecorder()
+		req, err := http.NewRequest(http.MethodGet, "http://foo/subscriptions?listAll=false&nextToken=page2", nil)
+		require.NoError(t, err)
+		s.armListHandler(armListEndpoints["/subscriptions"])(rw, req)
+
+		res := rw.Result()
+		require.Equal(t, http.StatusOK, res.StatusCode)
+		require.Equal(t, 1, *count)
+		require.Equal(t, []string{"page2"}, *tokens)
+
+		body, err := readAllClose(res)
+		require.NoError(t, err)
+		require.Equal(t, []string{"sub-3", "sub-4"}, decodeSubscriptionIDs(t, body))
+	})
+
+	t.Run("eager mode stops at the page cap and flags truncation", func(t *testing.T) {
+		srv, count, _ := newArmPagingServer(t, MaxArmPages+10, 1)
+		s := newPaginationTestService(srv.URL, srv.Client())
+
+		rw := httptest.NewRecorder()
+		req, err := http.NewRequest(http.MethodGet, "http://foo/subscriptions", nil)
+		require.NoError(t, err)
+		s.armListHandler(armListEndpoints["/subscriptions"])(rw, req)
+
+		res := rw.Result()
+		require.Equal(t, http.StatusOK, res.StatusCode)
+		require.Equal(t, MaxArmPages, *count)
+		require.Equal(t, "true", res.Header.Get("X-Results-Truncated"))
+
+		body, err := readAllClose(res)
+		require.NoError(t, err)
+		require.Len(t, decodeSubscriptionIDs(t, body), MaxArmPages)
+	})
+
+	t.Run("ARM error propagates the downstream status", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "boom", http.StatusBadGateway)
+		}))
+		t.Cleanup(srv.Close)
+		s := newPaginationTestService(srv.URL, srv.Client())
+
+		rw := httptest.NewRecorder()
+		req, err := http.NewRequest(http.MethodGet, "http://foo/subscriptions", nil)
+		require.NoError(t, err)
+		s.armListHandler(armListEndpoints["/subscriptions"])(rw, req)
+
+		require.Equal(t, http.StatusBadGateway, rw.Result().StatusCode)
+	})
+}
+
+func TestHandleWorkspaces(t *testing.T) {
+	t.Run("requires subscriptionId", func(t *testing.T) {
+		s := newPaginationTestService("https://management.azure.com", &http.Client{})
+		rw := httptest.NewRecorder()
+		req, err := http.NewRequest(http.MethodGet, "http://foo/workspaces", nil)
+		require.NoError(t, err)
+		s.armListHandler(armListEndpoints["/workspaces"])(rw, req)
+		require.Equal(t, http.StatusBadRequest, rw.Result().StatusCode)
+	})
+
+	t.Run("targets the workspaces path for the subscription", func(t *testing.T) {
+		var requestedPath string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestedPath = r.URL.Path
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"value":[{"id":"ws-1","name":"Workspace 1"}]}`))
+		}))
+		t.Cleanup(srv.Close)
+		s := newPaginationTestService(srv.URL, srv.Client())
+
+		rw := httptest.NewRecorder()
+		req, err := http.NewRequest(http.MethodGet, "http://foo/workspaces?subscriptionId=sub-42", nil)
+		require.NoError(t, err)
+		s.armListHandler(armListEndpoints["/workspaces"])(rw, req)
+
+		require.Equal(t, http.StatusOK, rw.Result().StatusCode)
+		require.Equal(t, "/subscriptions/sub-42/providers/Microsoft.OperationalInsights/workspaces", requestedPath)
+	})
+}
+
+func TestSkipTokenFromNextLink(t *testing.T) {
+	tests := []struct {
+		name     string
+		nextLink string
+		expected string
+	}{
+		{"empty", "", ""},
+		{"skiptoken lowercase", "https://management.azure.com/subscriptions?api-version=2019-03-01&$skiptoken=abc123", "abc123"},
+		{"skipToken camelCase", "https://management.azure.com/subscriptions?$skipToken=XYZ", "XYZ"},
+		{"no token", "https://management.azure.com/subscriptions?api-version=2019-03-01", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, skipTokenFromNextLink(tt.nextLink))
+		})
+	}
+}
+
+func TestAppendSkipToken(t *testing.T) {
+	out := appendSkipToken("https://management.azure.com/subscriptions?api-version=2019-03-01", "page2")
+	u := out
+	require.Contains(t, u, "api-version=2019-03-01")
+	require.Contains(t, u, "skiptoken=page2")
+	require.Equal(t, "page2", skipTokenFromNextLink(out))
+}
+
+func TestRebaseNextLink(t *testing.T) {
+	got := rebaseNextLink(
+		"https://proxy.internal/subscriptions?api-version=2019-03-01",
+		"https://management.azure.com/subscriptions?api-version=2019-03-01&$skiptoken=abc",
+	)
+	require.Equal(t, "https://proxy.internal/subscriptions?api-version=2019-03-01&$skiptoken=abc", got)
+	require.Equal(t, "", rebaseNextLink("https://proxy.internal/x", ""))
+}
+
+func TestFetchArmPagesRebasesNextLinkHost(t *testing.T) {
+	var srv *httptest.Server
+	count := 0
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count++
+		page := 1
+		if tok := r.URL.Query().Get("$skiptoken"); tok == "page2" {
+			page = 2
+		}
+		resp := map[string]any{"value": []map[string]string{{"subscriptionId": fmt.Sprintf("sub-%d", page)}}}
+		if page < 2 {
+			resp["nextLink"] = "https://management.azure.com/subscriptions?api-version=2019-03-01&$skiptoken=page2"
+		}
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(resp))
+	}))
+	t.Cleanup(srv.Close)
+
+	value, _, truncated, err := fetchArmPages(context.Background(), srv.Client(), srv.URL+"/subscriptions?api-version=2019-03-01", true, MaxArmPages)
+	require.NoError(t, err)
+	require.False(t, truncated)
+	require.Len(t, value, 2)
+	require.Equal(t, 2, count)
+}
+
+func TestFetchArmPagesTruncation(t *testing.T) {
+	srv, count, _ := newArmPagingServer(t, 100, 1)
+	value, nextToken, truncated, err := fetchArmPages(context.Background(), srv.Client(), srv.URL+"/subscriptions?api-version=2019-03-01", true, 3)
+	require.NoError(t, err)
+	require.True(t, truncated)
+	require.Empty(t, nextToken)
+	require.Len(t, value, 3)
+	require.Equal(t, 3, *count)
+}
+
+func readAllClose(res *http.Response) ([]byte, error) {
+	defer func() { _ = res.Body.Close() }()
+	return io.ReadAll(res.Body)
+}


### PR DESCRIPTION
**What is this feature?**

Allows resource endpoint to paginate ARM listings server-side, modeled after the CloudWatch datasource.

- `listAll=true` eagerly follows `nextLink` up to a page cap.
- `listAll=false` (default) returns a single page plus a continuation cursor delivered in a `Link: rel="next"` header for true on-demand pagination.
- Eager truncation is flagged with an `X-Results-Truncated` header.

`nextLink` is rebased onto the configured service host before being followed, so auth scoping stays intact and sovereign-cloud/proxy endpoints work.

**Why do we need this feature?**

ARM listings can span many pages, and previously there was no server-side pagination for subscriptions and workspaces. This lets callers either fetch the full list eagerly or page through results on demand, while keeping auth scoping and sovereign-cloud/proxy endpoints working correctly.

**Who is this feature for?**

Users of the Azure datasource who list subscriptions and workspaces, including those on sovereign clouds or behind proxy endpoints.

[grafana/grafana-azure-monitor-datasource PR #97](https://github.com/grafana/grafana-azure-monitor-datasource/pull/97)

**Special notes for your reviewer:**
Users should experience no functional change from the previous pagination implementation.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.