### PR TITLE
Azure Monitor: Backend driven pagination [frontend]

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -2581,7 +2581,7 @@
   },
   "public/app/plugins/datasource/azuremonitor/utils/common.ts": {
     "@typescript-eslint/consistent-type-assertions": {
-      "count": 1
+      "count": 2
     }
   },
   "public/app/plugins/datasource/azuremonitor/utils/messageFromError.ts": {

--- a/public/app/plugins/datasource/azuremonitor/azure_log_analytics/azure_log_analytics_datasource.test.ts
+++ b/public/app/plugins/datasource/azuremonitor/azure_log_analytics/azure_log_analytics_datasource.test.ts
@@ -1,4 +1,6 @@
-import { type CustomVariableModel } from '@grafana/data';
+import { of } from 'rxjs';
+
+import { AppEvents, type CustomVariableModel } from '@grafana/data';
 
 import { type AzureLogsQuery, AzureQueryType, type AzureTracesQuery } from '../dataquery.gen';
 import { type Context, createContext } from '../mocks/datasource';
@@ -11,6 +13,8 @@ import FakeSchemaData from './mocks/schema';
 
 let getTempVars = () => [] as CustomVariableModel[];
 let replace = () => '';
+const backendFetch = jest.fn();
+const publishAppEvent = jest.fn();
 
 jest.mock('@grafana/runtime', () => {
   return {
@@ -22,15 +26,25 @@ jest.mock('@grafana/runtime', () => {
       updateTimeRange: jest.fn(),
       containsTemplate: jest.fn(),
     }),
+    getBackendSrv: () => ({ fetch: backendFetch }),
+    getAppEvents: () => ({ publish: publishAppEvent }),
+    logWarning: jest.fn(),
   };
 });
+
+function mockArmPage<T>(value: T[], headers: Record<string, string> = {}) {
+  return of({
+    data: { value },
+    headers: { get: (key: string) => headers[key] ?? null },
+  });
+}
 
 describe('AzureLogAnalyticsDatasource', () => {
   let ctx: Context;
 
   beforeEach(() => {
     ctx = createContext({
-      instanceSettings: { jsonData: { subscriptionId: 'xxx' }, url: 'http://azureloganalyticsapi' },
+      instanceSettings: { uid: 'la-uid', jsonData: { subscriptionId: 'xxx' }, url: 'http://azureloganalyticsapi' },
     });
   });
 
@@ -118,9 +132,9 @@ describe('AzureLogAnalyticsDatasource', () => {
 
   describe('When performing getWorkspaces', () => {
     beforeEach(() => {
-      ctx.datasource.azureLogAnalyticsDatasource.getResource = jest
-        .fn()
-        .mockResolvedValue({ value: [{ name: 'foobar', id: 'foo', properties: { customerId: 'bar' } }] });
+      backendFetch.mockClear();
+      publishAppEvent.mockClear();
+      backendFetch.mockReturnValue(mockArmPage([{ name: 'foobar', id: 'foo', properties: { customerId: 'bar' } }]));
     });
 
     it('should return the workspace id', async () => {
@@ -128,27 +142,40 @@ describe('AzureLogAnalyticsDatasource', () => {
       expect(workspaces).toEqual([{ text: 'foobar', value: 'foo' }]);
     });
 
-    it('follows nextLink and aggregates workspaces across pages', async () => {
-      const getResource = jest
-        .fn()
-        .mockResolvedValueOnce({
-          value: [{ name: 'ws-1', id: 'id-1', properties: { customerId: 'c1' } }],
-          nextLink:
-            'https://management.azure.com/subscriptions/sub/providers/Microsoft.OperationalInsights/workspaces?api-version=2017-04-26-preview&$skiptoken=TOKEN',
-        })
-        .mockResolvedValueOnce({ value: [{ name: 'ws-2', id: 'id-2', properties: { customerId: 'c2' } }] });
-      ctx.datasource.azureLogAnalyticsDatasource.getResource = getResource;
+    it('requests the backend workspaces endpoint once in eager mode', async () => {
+      backendFetch.mockReturnValue(
+        mockArmPage([
+          { name: 'ws-1', id: 'id-1', properties: { customerId: 'c1' } },
+          { name: 'ws-2', id: 'id-2', properties: { customerId: 'c2' } },
+        ])
+      );
 
       const workspaces = await ctx.datasource.azureLogAnalyticsDatasource.getWorkspaces('sub');
 
-      expect(getResource).toHaveBeenCalledTimes(2);
-      expect(getResource.mock.calls[1][0]).toBe(
-        'azuremonitor/subscriptions/sub/providers/Microsoft.OperationalInsights/workspaces?api-version=2017-04-26-preview&$skiptoken=TOKEN'
+      expect(backendFetch).toHaveBeenCalledTimes(1);
+      expect(backendFetch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: '/api/datasources/uid/la-uid/resources/workspaces',
+          method: 'GET',
+          params: expect.objectContaining({ listAll: 'true' }),
+        })
       );
       expect(workspaces).toEqual([
         { text: 'ws-1', value: 'id-1' },
         { text: 'ws-2', value: 'id-2' },
       ]);
+    });
+
+    it('warns when the backend reports the listing was truncated', async () => {
+      backendFetch.mockReturnValue(
+        mockArmPage([{ name: 'ws-1', id: 'id-1', properties: { customerId: 'c1' } }], {
+          'X-Results-Truncated': 'true',
+        })
+      );
+
+      await ctx.datasource.azureLogAnalyticsDatasource.getWorkspaces('sub');
+
+      expect(publishAppEvent).toHaveBeenCalledWith(expect.objectContaining({ type: AppEvents.alertWarning.name }));
     });
   });
 

--- a/public/app/plugins/datasource/azuremonitor/azure_log_analytics/azure_log_analytics_datasource.test.ts
+++ b/public/app/plugins/datasource/azuremonitor/azure_log_analytics/azure_log_analytics_datasource.test.ts
@@ -1,6 +1,7 @@
 import { of } from 'rxjs';
 
 import { AppEvents, type CustomVariableModel } from '@grafana/data';
+import { config } from '@grafana/runtime';
 
 import { type AzureLogsQuery, AzureQueryType, type AzureTracesQuery } from '../dataquery.gen';
 import { type Context, createContext } from '../mocks/datasource';
@@ -32,12 +33,19 @@ jest.mock('@grafana/runtime', () => {
   };
 });
 
-function mockArmPage<T>(value: T[], headers: Record<string, string> = {}) {
-  return of({
-    data: { value },
-    headers: { get: (key: string) => headers[key] ?? null },
-  });
+// Flag ON: normalized body + Link/X-Results-Truncated headers.
+function onArmPage<T>(value: T[], headers: Record<string, string> = {}) {
+  return of({ data: { value }, headers: new Headers(headers) });
 }
+
+// Flag OFF: raw ARM body carrying nextLink, no Link header.
+function offArmPage<T>(value: T[], nextLink?: string) {
+  return of({ data: { value, nextLink } });
+}
+
+const setServerSidePagination = (enabled: boolean) => {
+  (config.featureToggles as Record<string, boolean | undefined>).azureMonitorServerSidePagination = enabled;
+};
 
 describe('AzureLogAnalyticsDatasource', () => {
   let ctx: Context;
@@ -131,51 +139,145 @@ describe('AzureLogAnalyticsDatasource', () => {
   });
 
   describe('When performing getWorkspaces', () => {
+    const workspacesPathOff =
+      '/api/datasources/uid/la-uid/resources/azuremonitor/subscriptions/sub/providers/Microsoft.OperationalInsights/workspaces?api-version=2017-04-26-preview';
+    const workspacesPathOn = `${workspacesPathOff}&listAll=true`;
+
     beforeEach(() => {
       backendFetch.mockClear();
       publishAppEvent.mockClear();
-      backendFetch.mockReturnValue(mockArmPage([{ name: 'foobar', id: 'foo', properties: { customerId: 'bar' } }]));
+      replace = (target?: string) => target || '';
     });
 
-    it('should return the workspace id', async () => {
-      const workspaces = await ctx.datasource.azureLogAnalyticsDatasource.getWorkspaces('sub');
-      expect(workspaces).toEqual([{ text: 'foobar', value: 'foo' }]);
+    afterEach(() => {
+      setServerSidePagination(false);
     });
 
-    it('requests the backend workspaces endpoint once in eager mode', async () => {
-      backendFetch.mockReturnValue(
-        mockArmPage([
-          { name: 'ws-1', id: 'id-1', properties: { customerId: 'c1' } },
-          { name: 'ws-2', id: 'id-2', properties: { customerId: 'c2' } },
-        ])
-      );
+    describe('with server-side pagination OFF (raw ARM nextLink)', () => {
+      beforeEach(() => {
+        setServerSidePagination(false);
+      });
 
-      const workspaces = await ctx.datasource.azureLogAnalyticsDatasource.getWorkspaces('sub');
+      it('should return the workspace id', async () => {
+        backendFetch.mockReturnValue(offArmPage([{ name: 'foobar', id: 'foo', properties: { customerId: 'bar' } }]));
+        const workspaces = await ctx.datasource.azureLogAnalyticsDatasource.getWorkspaces('sub');
+        expect(workspaces).toEqual([{ text: 'foobar', value: 'foo' }]);
+      });
 
-      expect(backendFetch).toHaveBeenCalledTimes(1);
-      expect(backendFetch).toHaveBeenCalledWith(
-        expect.objectContaining({
-          url: '/api/datasources/uid/la-uid/resources/workspaces',
-          method: 'GET',
-          params: expect.objectContaining({ listAll: 'true' }),
-        })
-      );
-      expect(workspaces).toEqual([
-        { text: 'ws-1', value: 'id-1' },
-        { text: 'ws-2', value: 'id-2' },
-      ]);
+      it('requests the passthrough workspaces path with the subscriptionId interpolated and no params', async () => {
+        backendFetch.mockReturnValue(
+          offArmPage([
+            { name: 'ws-1', id: 'id-1', properties: { customerId: 'c1' } },
+            { name: 'ws-2', id: 'id-2', properties: { customerId: 'c2' } },
+          ])
+        );
+
+        const workspaces = await ctx.datasource.azureLogAnalyticsDatasource.getWorkspaces('sub');
+
+        expect(backendFetch).toHaveBeenCalledTimes(1);
+        expect(backendFetch).toHaveBeenCalledWith({ url: workspacesPathOff, method: 'GET' });
+        expect(workspaces).toEqual([
+          { text: 'ws-1', value: 'id-1' },
+          { text: 'ws-2', value: 'id-2' },
+        ]);
+      });
+
+      it('follows the raw ARM nextLink across pages', async () => {
+        backendFetch
+          .mockReturnValueOnce(
+            offArmPage(
+              [{ name: 'ws-1', id: 'id-1', properties: { customerId: 'c1' } }],
+              'https://management.azure.com/subscriptions/sub/providers/Microsoft.OperationalInsights/workspaces?api-version=2017-04-26-preview&$skiptoken=tok2'
+            )
+          )
+          .mockReturnValueOnce(offArmPage([{ name: 'ws-2', id: 'id-2', properties: { customerId: 'c2' } }]));
+
+        const workspaces = await ctx.datasource.azureLogAnalyticsDatasource.getWorkspaces('sub');
+
+        expect(workspaces).toEqual([
+          { text: 'ws-1', value: 'id-1' },
+          { text: 'ws-2', value: 'id-2' },
+        ]);
+        expect(backendFetch).toHaveBeenCalledTimes(2);
+        expect(backendFetch.mock.calls[1][0].url).toContain('$skiptoken=tok2');
+      });
     });
 
-    it('warns when the backend reports the listing was truncated', async () => {
-      backendFetch.mockReturnValue(
-        mockArmPage([{ name: 'ws-1', id: 'id-1', properties: { customerId: 'c1' } }], {
-          'X-Results-Truncated': 'true',
-        })
-      );
+    describe('with server-side pagination ON (Link header cursor)', () => {
+      beforeEach(() => {
+        setServerSidePagination(true);
+      });
 
-      await ctx.datasource.azureLogAnalyticsDatasource.getWorkspaces('sub');
+      it('requests the passthrough workspaces endpoint once in eager mode', async () => {
+        backendFetch.mockReturnValue(
+          onArmPage([
+            { name: 'ws-1', id: 'id-1', properties: { customerId: 'c1' } },
+            { name: 'ws-2', id: 'id-2', properties: { customerId: 'c2' } },
+          ])
+        );
 
-      expect(publishAppEvent).toHaveBeenCalledWith(expect.objectContaining({ type: AppEvents.alertWarning.name }));
+        const workspaces = await ctx.datasource.azureLogAnalyticsDatasource.getWorkspaces('sub');
+
+        expect(backendFetch).toHaveBeenCalledTimes(1);
+        expect(backendFetch).toHaveBeenCalledWith({ url: workspacesPathOn, method: 'GET' });
+        expect(workspaces).toEqual([
+          { text: 'ws-1', value: 'id-1' },
+          { text: 'ws-2', value: 'id-2' },
+        ]);
+      });
+
+      it('warns when the backend reports the listing was truncated', async () => {
+        backendFetch.mockReturnValue(
+          onArmPage([{ name: 'ws-1', id: 'id-1', properties: { customerId: 'c1' } }], {
+            'X-Results-Truncated': 'true',
+          })
+        );
+
+        await ctx.datasource.azureLogAnalyticsDatasource.getWorkspaces('sub');
+
+        expect(publishAppEvent).toHaveBeenCalledWith(expect.objectContaining({ type: AppEvents.alertWarning.name }));
+      });
+    });
+
+    describe('getWorkspacesPage (incremental)', () => {
+      it('under ON, sends listAll=false + nextToken and reads the Link header cursor', async () => {
+        setServerSidePagination(true);
+        backendFetch.mockReturnValue(
+          onArmPage([{ name: 'ws-1', id: 'id-1', properties: { customerId: 'c1' } }], {
+            Link: '<?nextToken=page2>; rel="next"',
+          })
+        );
+
+        const { workspaces, nextToken } = await ctx.datasource.azureLogAnalyticsDatasource.getWorkspacesPage(
+          'sub',
+          'page1'
+        );
+
+        expect(workspaces).toEqual([{ text: 'ws-1', value: 'id-1' }]);
+        expect(nextToken).toBe('page2');
+        expect(backendFetch.mock.calls[0][0].url).toContain('&listAll=false');
+        expect(backendFetch.mock.calls[0][0].url).toContain('&nextToken=page1');
+      });
+
+      it('under OFF, forwards nextToken as $skiptoken and derives the next token from the body nextLink', async () => {
+        setServerSidePagination(false);
+        backendFetch.mockReturnValue(
+          offArmPage(
+            [{ name: 'ws-1', id: 'id-1', properties: { customerId: 'c1' } }],
+            'https://management.azure.com/subscriptions/sub/providers/Microsoft.OperationalInsights/workspaces?api-version=2017-04-26-preview&$skiptoken=tok2'
+          )
+        );
+
+        const { workspaces, nextToken } = await ctx.datasource.azureLogAnalyticsDatasource.getWorkspacesPage(
+          'sub',
+          'tok1'
+        );
+
+        expect(workspaces).toEqual([{ text: 'ws-1', value: 'id-1' }]);
+        expect(nextToken).toBe('tok2');
+        expect(backendFetch.mock.calls[0][0].url).toContain('&$skiptoken=tok1');
+        expect(backendFetch.mock.calls[0][0].url).not.toContain('listAll');
+      });
     });
   });
 

--- a/public/app/plugins/datasource/azuremonitor/azure_log_analytics/azure_log_analytics_datasource.ts
+++ b/public/app/plugins/datasource/azuremonitor/azure_log_analytics/azure_log_analytics_datasource.ts
@@ -11,15 +11,24 @@ import { type AzureMonitorQuery } from '../types/query';
 import {
   type AzureMonitorDataSourceJsonData,
   type AzureMonitorDataSourceInstanceSettings,
-  type AzureAPIResponse,
   type AzureLogsVariable,
   type Workspace,
   type DatasourceValidationResult,
   type Subscription,
 } from '../types/types';
-import { fetchAllArmPages, interpolateVariable, routeNames } from '../utils/common';
+import {
+  fetchAllArmResources,
+  fetchArmResourcePage,
+  interpolateVariable,
+  paginatedRoutes,
+  routeNames,
+} from '../utils/common';
 
 import { transformMetadataToKustoSchema } from './utils';
+
+function workspacesToVariables(value: Workspace[]): AzureLogsVariable[] {
+  return map(value, (val: Workspace) => ({ text: val.name, value: val.id })) || [];
+}
 
 export default class AzureLogAnalyticsDatasource extends DataSourceWithBackend<
   AzureMonitorQuery,
@@ -31,7 +40,6 @@ export default class AzureLogAnalyticsDatasource extends DataSourceWithBackend<
 
   defaultSubscriptionId?: string;
 
-  azureMonitorPath: string;
   firstWorkspace?: string;
 
   constructor(
@@ -42,7 +50,6 @@ export default class AzureLogAnalyticsDatasource extends DataSourceWithBackend<
     this.credentials = getCredentials(instanceSettings);
 
     this.resourcePath = `${routeNames.logAnalytics}`;
-    this.azureMonitorPath = `${routeNames.azureMonitor}/subscriptions`;
 
     this.defaultSubscriptionId = this.instanceSettings.jsonData.subscriptionId || '';
   }
@@ -66,33 +73,33 @@ export default class AzureLogAnalyticsDatasource extends DataSourceWithBackend<
       return [];
     }
 
-    const value = await fetchAllArmPages<Subscription>(
-      routeNames.azureMonitor,
-      `${this.azureMonitorPath}?api-version=2019-03-01`,
-      (path) => this.getResource<AzureAPIResponse<Subscription>>(path)
-    );
+    const value = await fetchAllArmResources<Subscription>(this.uid, paginatedRoutes.subscriptions);
     return ResponseParser.parseSubscriptions({ value });
   }
 
   async getWorkspaces(subscription: string): Promise<AzureLogsVariable[]> {
     const subscriptionId = this.templateSrv.replace(subscription || this.defaultSubscriptionId);
 
-    const workspaceListUrl =
-      this.azureMonitorPath +
-      `/${subscriptionId}/providers/Microsoft.OperationalInsights/workspaces?api-version=2017-04-26-preview`;
+    const value = await fetchAllArmResources<Workspace>(this.uid, paginatedRoutes.workspaces, { subscriptionId });
+    return workspacesToVariables(value);
+  }
 
-    const value = await fetchAllArmPages<Workspace>(routeNames.azureMonitor, workspaceListUrl, (path) =>
-      this.getResource<AzureAPIResponse<Workspace>>(path)
-    );
+  async getWorkspacesPage(
+    subscription: string,
+    nextToken?: string
+  ): Promise<{ workspaces: AzureLogsVariable[]; nextToken?: string }> {
+    const subscriptionId = this.templateSrv.replace(subscription || this.defaultSubscriptionId);
 
-    return (
-      map(value, (val: Workspace) => {
-        return {
-          text: val.name,
-          value: val.id,
-        };
-      }) || []
+    const params: Record<string, string> = { subscriptionId, listAll: 'false' };
+    if (nextToken) {
+      params.nextToken = nextToken;
+    }
+    const { value, nextToken: next } = await fetchArmResourcePage<Workspace>(
+      this.uid,
+      paginatedRoutes.workspaces,
+      params
     );
+    return { workspaces: workspacesToVariables(value), nextToken: next };
   }
 
   async getMetadata(resourceUri: string) {

--- a/public/app/plugins/datasource/azuremonitor/azure_monitor/azure_monitor_datasource.test.ts
+++ b/public/app/plugins/datasource/azuremonitor/azure_monitor/azure_monitor_datasource.test.ts
@@ -1,6 +1,7 @@
 import { get, set } from 'lodash';
+import { of } from 'rxjs';
 
-import { type ScopedVars } from '@grafana/data';
+import { AppEvents, type ScopedVars } from '@grafana/data';
 import { type VariableInterpolation } from '@grafana/runtime';
 
 import AzureMonitorDatasource from '../datasource';
@@ -19,6 +20,8 @@ import {
 // We declare this as a function so that we can overwrite it in each test
 // without affecting the rest of the @grafana/runtime module.
 let replace = (val: string) => val;
+const backendFetch = jest.fn();
+const publishAppEvent = jest.fn();
 
 jest.mock('@grafana/runtime', () => {
   return {
@@ -30,8 +33,18 @@ jest.mock('@grafana/runtime', () => {
       updateTimeRange: jest.fn(),
       containsTemplate: jest.fn(),
     }),
+    getBackendSrv: () => ({ fetch: backendFetch }),
+    getAppEvents: () => ({ publish: publishAppEvent }),
+    logWarning: jest.fn(),
   };
 });
+
+function mockArmPage<T>(value: T[], headers: Record<string, string> = {}) {
+  return of({
+    data: { value },
+    headers: { get: (key: string) => headers[key] ?? null },
+  });
+}
 
 interface TestContext {
   instanceSettings: AzureMonitorDataSourceInstanceSettings;
@@ -902,8 +915,9 @@ describe('AzureMonitorDatasource', () => {
 
       beforeEach(() => {
         ctx.instanceSettings.jsonData.azureAuthType = 'msi';
+        ctx.instanceSettings.uid = 'azuremonitor-uid';
         ctx.ds = new AzureMonitorDatasource(ctx.instanceSettings);
-        ctx.ds.azureMonitorDatasource.getResource = jest.fn().mockResolvedValue(response);
+        backendFetch.mockReturnValue(mockArmPage(response.value));
       });
 
       it('should return list of subscriptions', () => {
@@ -914,38 +928,33 @@ describe('AzureMonitorDatasource', () => {
         });
       });
 
-      it('should follow nextLink and aggregate all pages of subscriptions', async () => {
-        const firstPage = {
-          value: [
+      it('requests the backend subscriptions endpoint once in eager mode', async () => {
+        backendFetch.mockReturnValue(
+          mockArmPage([
             { subscriptionId: 'sub-1', displayName: 'Subscription 1' },
             { subscriptionId: 'sub-2', displayName: 'Subscription 2' },
-          ],
-          nextLink: 'https://management.azure.com/subscriptions?api-version=2019-03-01&$skiptoken=TOKEN123',
-        };
-        const secondPage = {
-          value: [{ subscriptionId: 'sub-3', displayName: 'Subscription 3' }],
-        };
-        const getResource = jest.fn().mockResolvedValueOnce(firstPage).mockResolvedValueOnce(secondPage);
-        ctx.ds.azureMonitorDatasource.getResource = getResource;
+          ])
+        );
 
         const results = await ctx.ds.getSubscriptions();
 
-        expect(results.map((r: { value: string }) => r.value)).toEqual(['sub-1', 'sub-2', 'sub-3']);
-        expect(getResource).toHaveBeenCalledTimes(2);
-        expect(getResource).toHaveBeenNthCalledWith(
-          2,
-          'azuremonitor/subscriptions?api-version=2019-03-01&$skiptoken=TOKEN123'
-        );
+        expect(results.map((r: { value: string }) => r.value)).toEqual(['sub-1', 'sub-2']);
+        expect(backendFetch).toHaveBeenCalledTimes(1);
+        expect(backendFetch).toHaveBeenCalledWith({
+          url: '/api/datasources/uid/azuremonitor-uid/resources/subscriptions',
+          params: { listAll: 'true' },
+          method: 'GET',
+        });
       });
 
-      it('should stop paginating once nextLink is absent', async () => {
-        const getResource = jest.fn().mockResolvedValue({ value: [{ subscriptionId: 'only', displayName: 'Only' }] });
-        ctx.ds.azureMonitorDatasource.getResource = getResource;
+      it('warns when the backend reports the listing was truncated', async () => {
+        backendFetch.mockReturnValue(
+          mockArmPage([{ subscriptionId: 'sub-1', displayName: 'Subscription 1' }], { 'X-Results-Truncated': 'true' })
+        );
 
-        const results = await ctx.ds.getSubscriptions();
+        await ctx.ds.getSubscriptions();
 
-        expect(results.length).toEqual(1);
-        expect(getResource).toHaveBeenCalledTimes(1);
+        expect(publishAppEvent).toHaveBeenCalledWith(expect.objectContaining({ type: AppEvents.alertWarning.name }));
       });
     });
 

--- a/public/app/plugins/datasource/azuremonitor/azure_monitor/azure_monitor_datasource.test.ts
+++ b/public/app/plugins/datasource/azuremonitor/azure_monitor/azure_monitor_datasource.test.ts
@@ -2,7 +2,7 @@ import { get, set } from 'lodash';
 import { of } from 'rxjs';
 
 import { AppEvents, type ScopedVars } from '@grafana/data';
-import { type VariableInterpolation } from '@grafana/runtime';
+import { config, type VariableInterpolation } from '@grafana/runtime';
 
 import AzureMonitorDatasource from '../datasource';
 import createMockQuery from '../mocks/query';
@@ -39,12 +39,19 @@ jest.mock('@grafana/runtime', () => {
   };
 });
 
-function mockArmPage<T>(value: T[], headers: Record<string, string> = {}) {
-  return of({
-    data: { value },
-    headers: { get: (key: string) => headers[key] ?? null },
-  });
+// Flag ON: normalized body + Link/X-Results-Truncated headers.
+function onArmPage<T>(value: T[], headers: Record<string, string> = {}) {
+  return of({ data: { value }, headers: new Headers(headers) });
 }
+
+// Flag OFF: raw ARM body carrying nextLink, no Link header.
+function offArmPage<T>(value: T[], nextLink?: string) {
+  return of({ data: { value, nextLink } });
+}
+
+const setServerSidePagination = (enabled: boolean) => {
+  (config.featureToggles as Record<string, boolean | undefined>).azureMonitorServerSidePagination = enabled;
+};
 
 interface TestContext {
   instanceSettings: AzureMonitorDataSourceInstanceSettings;
@@ -917,44 +924,130 @@ describe('AzureMonitorDatasource', () => {
         ctx.instanceSettings.jsonData.azureAuthType = 'msi';
         ctx.instanceSettings.uid = 'azuremonitor-uid';
         ctx.ds = new AzureMonitorDatasource(ctx.instanceSettings);
-        backendFetch.mockReturnValue(mockArmPage(response.value));
       });
 
-      it('should return list of subscriptions', () => {
-        return ctx.ds.getSubscriptions().then((results: Array<{ text: string; value: string }>) => {
-          expect(results.length).toEqual(1);
-          expect(results[0].text).toEqual('Primary Subscription');
-          expect(results[0].value).toEqual('99999999-cccc-bbbb-aaaa-9106972f9572');
+      describe('with server-side pagination OFF (raw ARM nextLink)', () => {
+        beforeEach(() => {
+          setServerSidePagination(false);
+          backendFetch.mockReturnValue(offArmPage(response.value));
+        });
+
+        it('should return list of subscriptions', () => {
+          return ctx.ds.getSubscriptions().then((results: Array<{ text: string; value: string }>) => {
+            expect(results.length).toEqual(1);
+            expect(results[0].text).toEqual('Primary Subscription');
+            expect(results[0].value).toEqual('99999999-cccc-bbbb-aaaa-9106972f9572');
+          });
+        });
+
+        it('requests the passthrough subscriptions path with no listAll/nextToken params', async () => {
+          backendFetch.mockReturnValue(
+            offArmPage([
+              { subscriptionId: 'sub-1', displayName: 'Subscription 1' },
+              { subscriptionId: 'sub-2', displayName: 'Subscription 2' },
+            ])
+          );
+
+          const results = await ctx.ds.getSubscriptions();
+
+          expect(results.map((r: { value: string }) => r.value)).toEqual(['sub-1', 'sub-2']);
+          expect(backendFetch).toHaveBeenCalledTimes(1);
+          expect(backendFetch).toHaveBeenCalledWith({
+            url: '/api/datasources/uid/azuremonitor-uid/resources/azuremonitor/subscriptions?api-version=2019-03-01',
+            method: 'GET',
+          });
+        });
+
+        it('follows the raw ARM nextLink across pages', async () => {
+          backendFetch
+            .mockReturnValueOnce(
+              offArmPage(
+                [{ subscriptionId: 'sub-1', displayName: 'Subscription 1' }],
+                'https://management.azure.com/subscriptions?api-version=2019-03-01&$skiptoken=tok2'
+              )
+            )
+            .mockReturnValueOnce(offArmPage([{ subscriptionId: 'sub-2', displayName: 'Subscription 2' }]));
+
+          const results = await ctx.ds.getSubscriptions();
+
+          expect(results.map((r: { value: string }) => r.value)).toEqual(['sub-1', 'sub-2']);
+          expect(backendFetch).toHaveBeenCalledTimes(2);
+          expect(backendFetch.mock.calls[1][0].url).toContain('$skiptoken=tok2');
         });
       });
 
-      it('requests the backend subscriptions endpoint once in eager mode', async () => {
-        backendFetch.mockReturnValue(
-          mockArmPage([
-            { subscriptionId: 'sub-1', displayName: 'Subscription 1' },
-            { subscriptionId: 'sub-2', displayName: 'Subscription 2' },
-          ])
-        );
+      describe('with server-side pagination ON (Link header cursor)', () => {
+        beforeEach(() => {
+          setServerSidePagination(true);
+        });
 
-        const results = await ctx.ds.getSubscriptions();
+        afterEach(() => {
+          setServerSidePagination(false);
+        });
 
-        expect(results.map((r: { value: string }) => r.value)).toEqual(['sub-1', 'sub-2']);
-        expect(backendFetch).toHaveBeenCalledTimes(1);
-        expect(backendFetch).toHaveBeenCalledWith({
-          url: '/api/datasources/uid/azuremonitor-uid/resources/subscriptions',
-          params: { listAll: 'true' },
-          method: 'GET',
+        it('requests the passthrough subscriptions endpoint once in eager mode', async () => {
+          backendFetch.mockReturnValue(
+            onArmPage([
+              { subscriptionId: 'sub-1', displayName: 'Subscription 1' },
+              { subscriptionId: 'sub-2', displayName: 'Subscription 2' },
+            ])
+          );
+
+          const results = await ctx.ds.getSubscriptions();
+
+          expect(results.map((r: { value: string }) => r.value)).toEqual(['sub-1', 'sub-2']);
+          expect(backendFetch).toHaveBeenCalledTimes(1);
+          expect(backendFetch).toHaveBeenCalledWith({
+            url: '/api/datasources/uid/azuremonitor-uid/resources/azuremonitor/subscriptions?api-version=2019-03-01&listAll=true',
+            method: 'GET',
+          });
+        });
+
+        it('warns when the backend reports the listing was truncated', async () => {
+          backendFetch.mockReturnValue(
+            onArmPage([{ subscriptionId: 'sub-1', displayName: 'Subscription 1' }], { 'X-Results-Truncated': 'true' })
+          );
+
+          await ctx.ds.getSubscriptions();
+
+          expect(publishAppEvent).toHaveBeenCalledWith(expect.objectContaining({ type: AppEvents.alertWarning.name }));
         });
       });
 
-      it('warns when the backend reports the listing was truncated', async () => {
-        backendFetch.mockReturnValue(
-          mockArmPage([{ subscriptionId: 'sub-1', displayName: 'Subscription 1' }], { 'X-Results-Truncated': 'true' })
-        );
+      describe('getSubscriptionsPage (incremental)', () => {
+        it('under ON, sends listAll=false + nextToken and reads the Link header cursor', async () => {
+          setServerSidePagination(true);
+          backendFetch.mockReturnValue(
+            onArmPage([{ subscriptionId: 'sub-1', displayName: 'Subscription 1' }], {
+              Link: '<?nextToken=page2>; rel="next"',
+            })
+          );
 
-        await ctx.ds.getSubscriptions();
+          const { subscriptions, nextToken } = await ctx.ds.azureMonitorDatasource.getSubscriptionsPage('page1');
 
-        expect(publishAppEvent).toHaveBeenCalledWith(expect.objectContaining({ type: AppEvents.alertWarning.name }));
+          expect(subscriptions.map((s) => s.value)).toEqual(['sub-1']);
+          expect(nextToken).toBe('page2');
+          expect(backendFetch.mock.calls[0][0].url).toContain('&listAll=false');
+          expect(backendFetch.mock.calls[0][0].url).toContain('&nextToken=page1');
+          setServerSidePagination(false);
+        });
+
+        it('under OFF, forwards nextToken as $skiptoken and derives the next token from the body nextLink', async () => {
+          setServerSidePagination(false);
+          backendFetch.mockReturnValue(
+            offArmPage(
+              [{ subscriptionId: 'sub-1', displayName: 'Subscription 1' }],
+              'https://management.azure.com/subscriptions?api-version=2019-03-01&$skiptoken=tok2'
+            )
+          );
+
+          const { subscriptions, nextToken } = await ctx.ds.azureMonitorDatasource.getSubscriptionsPage('tok1');
+
+          expect(subscriptions.map((s) => s.value)).toEqual(['sub-1']);
+          expect(nextToken).toBe('tok2');
+          expect(backendFetch.mock.calls[0][0].url).toContain('&$skiptoken=tok1');
+          expect(backendFetch.mock.calls[0][0].url).not.toContain('listAll');
+        });
       });
     });
 

--- a/public/app/plugins/datasource/azuremonitor/azure_monitor/azure_monitor_datasource.ts
+++ b/public/app/plugins/datasource/azuremonitor/azure_monitor/azure_monitor_datasource.ts
@@ -27,7 +27,13 @@ import {
   type Subscription,
   TablePlan,
 } from '../types/types';
-import { fetchAllArmPages, replaceTemplateVariables, routeNames } from '../utils/common';
+import {
+  fetchAllArmResources,
+  fetchArmResourcePage,
+  paginatedRoutes,
+  replaceTemplateVariables,
+  routeNames,
+} from '../utils/common';
 import migrateQuery from '../utils/migrateQuery';
 
 import ResponseParser from './response_parser';
@@ -198,12 +204,23 @@ export default class AzureMonitorDatasource extends DataSourceWithBackend<
       return [];
     }
 
-    const value = await fetchAllArmPages<Subscription>(
-      this.resourcePath,
-      `${this.resourcePath}/subscriptions?api-version=2019-03-01`,
-      (path) => this.getResource<AzureAPIResponse<Subscription>>(path)
-    );
+    const value = await fetchAllArmResources<Subscription>(this.uid, paginatedRoutes.subscriptions);
     return ResponseParser.parseSubscriptions({ value });
+  }
+
+  async getSubscriptionsPage(
+    nextToken?: string
+  ): Promise<{ subscriptions: Array<{ text: string; value: string }>; nextToken?: string }> {
+    const params: Record<string, string> = { listAll: 'false' };
+    if (nextToken) {
+      params.nextToken = nextToken;
+    }
+    const { value, nextToken: next } = await fetchArmResourcePage<Subscription>(
+      this.uid,
+      paginatedRoutes.subscriptions,
+      params
+    );
+    return { subscriptions: ResponseParser.parseSubscriptions({ value }), nextToken: next };
   }
 
   // Note globalRegion should be false when querying custom metric namespaces

--- a/public/app/plugins/datasource/azuremonitor/components/ConfigEditor/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/ConfigEditor/ConfigEditor.tsx
@@ -12,13 +12,12 @@ import { Alert, Divider, SecureSocksProxySettings } from '@grafana/ui';
 
 import ResponseParser from '../../azure_monitor/response_parser';
 import {
-  type AzureAPIResponse,
   type AzureMonitorDataSourceJsonData,
   type AzureMonitorDataSourceSecureJsonData,
   type AzureMonitorDataSourceSettings,
   type Subscription,
 } from '../../types/types';
-import { fetchAllArmPages, routeNames } from '../../utils/common';
+import { fetchAllArmResources, paginatedRoutes } from '../../utils/common';
 
 import { MonitorConfig } from './MonitorConfig';
 
@@ -37,8 +36,6 @@ export const ConfigEditor = memo(function ConfigEditor(props: Props) {
   const { options, onOptionsChange } = props;
   const [unsaved, setUnsaved] = useState(false);
   const [error, setError] = useState<ErrorMessage | undefined>(undefined);
-
-  const baseURL = `/api/datasources/uid/${options.uid}/resources/${routeNames.azureMonitor}/subscriptions`;
 
   function updateOptions(
     optionsFunc: (options: AzureMonitorDataSourceSettings) => AzureMonitorDataSourceSettings
@@ -63,16 +60,8 @@ export const ConfigEditor = memo(function ConfigEditor(props: Props) {
   async function getSubscriptions(): Promise<Array<SelectableValue<string>>> {
     await saveOptions();
 
-    const query = `?api-version=2019-03-01`;
-    const resourcePath = `/api/datasources/uid/${options.uid}/resources/${routeNames.azureMonitor}`;
     try {
-      const value = await fetchAllArmPages<Subscription>(resourcePath, baseURL + query, async (path) => {
-        const response = await getBackendSrv()
-          .fetch<AzureAPIResponse<Subscription>>({ url: path, method: 'GET' })
-          .toPromise();
-        return response?.data;
-      });
-
+      const value = await fetchAllArmResources<Subscription>(options.uid, paginatedRoutes.subscriptions);
       setError(undefined);
       return ResponseParser.parseSubscriptionsForSelect({ value });
     } catch (err) {

--- a/public/app/plugins/datasource/azuremonitor/locales/en-US/grafana-azure-monitor-datasource.json
+++ b/public/app/plugins/datasource/azuremonitor/locales/en-US/grafana-azure-monitor-datasource.json
@@ -206,7 +206,7 @@
       "tooltip-order-by": "Sort results based on one or more columns in ascending or descending order."
     },
     "pagination": {
-      "results-truncated-message": "Stopped loading after {{maxPages}} pages; some results may be omitted.",
+      "results-truncated-message": "Some results may be omitted because there were too many to load.",
       "results-truncated-title": "Azure Monitor"
     },
     "query-editor": {

--- a/public/app/plugins/datasource/azuremonitor/utils/common.test.ts
+++ b/public/app/plugins/datasource/azuremonitor/utils/common.test.ts
@@ -1,17 +1,35 @@
+import { of } from 'rxjs';
+
 import { AppEvents } from '@grafana/data';
-import { getAppEvents, logWarning } from '@grafana/runtime';
+import { logWarning } from '@grafana/runtime';
 
 import { initialCustomVariableModelState } from '../mocks/variables';
 
-import { fetchAllArmPages, hasOption, interpolateVariable, MAX_ARM_PAGES, nextLinkToPath } from './common';
+import {
+  fetchAllArmResources,
+  fetchArmResourcePage,
+  hasOption,
+  interpolateVariable,
+  parseNextLinkToken,
+  warnResultsTruncated,
+} from './common';
 
 const publish = jest.fn();
+const fetchMock = jest.fn();
 
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
   logWarning: jest.fn(),
   getAppEvents: jest.fn(() => ({ publish })),
+  getBackendSrv: jest.fn(() => ({ fetch: fetchMock })),
 }));
+
+function mockFetchResponse<T>(value: T[], headers: Record<string, string> = {}) {
+  return of({
+    data: { value },
+    headers: { get: (key: string) => headers[key] ?? null },
+  });
+}
 
 describe('AzureMonitor: hasOption', () => {
   it('can find an option in flat array', () => {
@@ -54,120 +72,103 @@ describe('AzureMonitor: hasOption', () => {
   });
 });
 
-describe('AzureMonitor: nextLinkToPath', () => {
-  it('drops the ARM host and joins pathname + query onto the prefix', () => {
-    const nextLink = 'https://management.azure.com/subscriptions?api-version=2019-03-01&$skiptoken=TOKEN';
-    expect(nextLinkToPath('azuremonitor', nextLink)).toBe(
-      'azuremonitor/subscriptions?api-version=2019-03-01&$skiptoken=TOKEN'
-    );
+describe('AzureMonitor: parseNextLinkToken', () => {
+  it('extracts the nextToken from a Link: rel="next" header', () => {
+    expect(parseNextLinkToken('<?nextToken=page2>; rel="next"')).toBe('page2');
   });
 
-  it('works for a full resources base URL prefix and sovereign clouds', () => {
-    const nextLink = 'https://management.usgovcloudapi.net/subscriptions?api-version=2019-03-01&$skiptoken=TOKEN';
-    expect(nextLinkToPath('/api/datasources/uid/abc/resources/azuremonitor', nextLink)).toBe(
-      '/api/datasources/uid/abc/resources/azuremonitor/subscriptions?api-version=2019-03-01&$skiptoken=TOKEN'
-    );
+  it('extracts the nextToken alongside other params', () => {
+    expect(parseNextLinkToken('<?nextToken=page2&subscriptionId=sub-1>; rel="next"')).toBe('page2');
+  });
+
+  it('returns undefined when the header does not match', () => {
+    expect(parseNextLinkToken('garbage')).toBeUndefined();
+  });
+
+  it('returns undefined when there is no nextToken param', () => {
+    expect(parseNextLinkToken('<?subscriptionId=sub-1>; rel="next"')).toBeUndefined();
   });
 });
 
-describe('AzureMonitor: fetchAllArmPages', () => {
+describe('AzureMonitor: fetchArmResourcePage', () => {
   beforeEach(() => {
-    jest.mocked(logWarning).mockClear();
-    jest.mocked(getAppEvents).mockClear();
+    fetchMock.mockClear();
+  });
+
+  it('requests the backend resource endpoint with the given params', async () => {
+    fetchMock.mockReturnValue(mockFetchResponse([{ id: 1 }, { id: 2 }]));
+
+    const page = await fetchArmResourcePage<{ id: number }>('abc', 'subscriptions', { listAll: 'true' });
+
+    expect(fetchMock).toHaveBeenCalledWith({
+      url: '/api/datasources/uid/abc/resources/subscriptions',
+      params: { listAll: 'true' },
+      method: 'GET',
+    });
+    expect(page.value).toEqual([{ id: 1 }, { id: 2 }]);
+    expect(page.nextToken).toBeUndefined();
+    expect(page.truncated).toBe(false);
+  });
+
+  it('surfaces the continuation token from the Link header', async () => {
+    fetchMock.mockReturnValue(mockFetchResponse([{ id: 1 }], { Link: '<?nextToken=page2>; rel="next"' }));
+
+    const page = await fetchArmResourcePage<{ id: number }>('abc', 'subscriptions', { listAll: 'false' });
+
+    expect(page.value).toEqual([{ id: 1 }]);
+    expect(page.nextToken).toBe('page2');
+  });
+
+  it('flags truncation from the X-Results-Truncated header', async () => {
+    fetchMock.mockReturnValue(mockFetchResponse([{ id: 1 }], { 'X-Results-Truncated': 'true' }));
+
+    const page = await fetchArmResourcePage<{ id: number }>('abc', 'subscriptions', { listAll: 'true' });
+
+    expect(page.truncated).toBe(true);
+  });
+});
+
+describe('AzureMonitor: fetchAllArmResources', () => {
+  beforeEach(() => {
+    fetchMock.mockClear();
     publish.mockClear();
   });
 
-  it('returns the single page when there is no nextLink', async () => {
-    const fetchPage = jest.fn().mockResolvedValue({ value: [{ id: 1 }, { id: 2 }] });
+  it('requests eager listing and returns the value array', async () => {
+    fetchMock.mockReturnValue(mockFetchResponse([{ id: 1 }, { id: 2 }]));
 
-    const results = await fetchAllArmPages('azuremonitor', 'azuremonitor/subscriptions?api-version=x', fetchPage);
+    const value = await fetchAllArmResources<{ id: number }>('abc', 'workspaces', { subscriptionId: 'sub-1' });
 
-    expect(results).toEqual([{ id: 1 }, { id: 2 }]);
-    expect(fetchPage).toHaveBeenCalledTimes(1);
-    expect(fetchPage).toHaveBeenCalledWith('azuremonitor/subscriptions?api-version=x');
-  });
-
-  it('follows nextLink across pages and rebuilds the path via the resource prefix', async () => {
-    const fetchPage = jest
-      .fn()
-      .mockResolvedValueOnce({
-        value: [{ id: 1 }],
-        nextLink: 'https://management.azure.com/subscriptions?api-version=x&$skiptoken=abc',
-      })
-      .mockResolvedValueOnce({ value: [{ id: 2 }] });
-
-    const results = await fetchAllArmPages('azuremonitor', 'azuremonitor/subscriptions?api-version=x', fetchPage);
-
-    expect(results).toEqual([{ id: 1 }, { id: 2 }]);
-    expect(fetchPage).toHaveBeenNthCalledWith(2, 'azuremonitor/subscriptions?api-version=x&$skiptoken=abc');
-  });
-
-  it('stops early and warns when a page returns no result', async () => {
-    const fetchPage = jest.fn().mockResolvedValue(undefined);
-
-    const results = await fetchAllArmPages('azuremonitor', 'azuremonitor/subscriptions?api-version=x', fetchPage);
-
-    expect(results).toEqual([]);
-    expect(fetchPage).toHaveBeenCalledTimes(1);
-    expect(logWarning).toHaveBeenCalledTimes(1);
-    expect(logWarning).toHaveBeenCalledWith('[azuremonitor] ARM page request returned no result; stopping pagination.');
-  });
-
-  it('does not emit the page-cap warning when a later page returns no result', async () => {
-    const fetchPage = jest
-      .fn()
-      .mockResolvedValueOnce({
-        value: [{ id: 1 }],
-        nextLink: 'https://management.azure.com/subscriptions?api-version=x&$skiptoken=abc',
-      })
-      .mockResolvedValueOnce(undefined);
-
-    const results = await fetchAllArmPages('azuremonitor', 'azuremonitor/subscriptions?api-version=x', fetchPage);
-
-    expect(results).toEqual([{ id: 1 }]);
-    expect(logWarning).toHaveBeenCalledTimes(1);
-    expect(logWarning).toHaveBeenCalledWith('[azuremonitor] ARM page request returned no result; stopping pagination.');
-    expect(logWarning).not.toHaveBeenCalledWith(expect.stringContaining('ARM listing stopped after'));
-  });
-
-  it('stops after MAX_ARM_PAGES even if nextLink never clears, and warns', async () => {
-    const fetchPage = jest.fn().mockResolvedValue({
-      value: [{ id: 1 }],
-      nextLink: 'https://management.azure.com/subscriptions?api-version=x&$skiptoken=loop',
+    expect(fetchMock).toHaveBeenCalledWith({
+      url: '/api/datasources/uid/abc/resources/workspaces',
+      params: { subscriptionId: 'sub-1', listAll: 'true' },
+      method: 'GET',
     });
+    expect(value).toEqual([{ id: 1 }, { id: 2 }]);
+    expect(publish).not.toHaveBeenCalled();
+  });
 
-    const results = await fetchAllArmPages('azuremonitor', 'azuremonitor/subscriptions?api-version=x', fetchPage);
+  it('warns when the backend truncated the listing', async () => {
+    fetchMock.mockReturnValue(mockFetchResponse([{ id: 1 }], { 'X-Results-Truncated': 'true' }));
 
-    expect(fetchPage).toHaveBeenCalledTimes(MAX_ARM_PAGES);
-    expect(results).toHaveLength(MAX_ARM_PAGES);
-    expect(logWarning).toHaveBeenCalledTimes(1);
-    expect(logWarning).toHaveBeenCalledWith(
-      `[azuremonitor] ARM listing stopped after ${MAX_ARM_PAGES} pages; some results may be omitted.`
-    );
-    expect(publish).toHaveBeenCalledTimes(1);
+    await fetchAllArmResources<{ id: number }>('abc', 'subscriptions');
+
     expect(publish).toHaveBeenCalledWith(expect.objectContaining({ type: AppEvents.alertWarning.name }));
   });
+});
 
-  it('does not emit a warning toast when all pages load within the cap', async () => {
-    const fetchPage = jest
-      .fn()
-      .mockResolvedValueOnce({
-        value: [{ id: 1 }],
-        nextLink: 'https://management.azure.com/subscriptions?api-version=x&$skiptoken=abc',
-      })
-      .mockResolvedValueOnce({ value: [{ id: 2 }] });
-
-    await fetchAllArmPages('azuremonitor', 'azuremonitor/subscriptions?api-version=x', fetchPage);
-
-    expect(publish).not.toHaveBeenCalled();
+describe('AzureMonitor: warnResultsTruncated', () => {
+  beforeEach(() => {
+    jest.mocked(logWarning).mockClear();
+    publish.mockClear();
   });
 
-  it('does not emit a warning toast when a page returns no result', async () => {
-    const fetchPage = jest.fn().mockResolvedValue(undefined);
+  it('logs and publishes an alert-warning app event', () => {
+    warnResultsTruncated();
 
-    await fetchAllArmPages('azuremonitor', 'azuremonitor/subscriptions?api-version=x', fetchPage);
-
-    expect(publish).not.toHaveBeenCalled();
+    expect(logWarning).toHaveBeenCalledTimes(1);
+    expect(publish).toHaveBeenCalledTimes(1);
+    expect(publish).toHaveBeenCalledWith(expect.objectContaining({ type: AppEvents.alertWarning.name }));
   });
 });
 

--- a/public/app/plugins/datasource/azuremonitor/utils/common.test.ts
+++ b/public/app/plugins/datasource/azuremonitor/utils/common.test.ts
@@ -1,7 +1,7 @@
 import { of } from 'rxjs';
 
 import { AppEvents } from '@grafana/data';
-import { logWarning } from '@grafana/runtime';
+import { config, logWarning } from '@grafana/runtime';
 
 import { initialCustomVariableModelState } from '../mocks/variables';
 
@@ -10,7 +10,9 @@ import {
   fetchArmResourcePage,
   hasOption,
   interpolateVariable,
+  nextLinkToPath,
   parseNextLinkToken,
+  skipTokenFromNextLink,
   warnResultsTruncated,
 } from './common';
 
@@ -24,11 +26,18 @@ jest.mock('@grafana/runtime', () => ({
   getBackendSrv: jest.fn(() => ({ fetch: fetchMock })),
 }));
 
-function mockFetchResponse<T>(value: T[], headers: Record<string, string> = {}) {
-  return of({
-    data: { value },
-    headers: { get: (key: string) => headers[key] ?? null },
-  });
+const setServerSidePagination = (enabled: boolean) => {
+  (config.featureToggles as Record<string, boolean | undefined>).azureMonitorServerSidePagination = enabled;
+};
+
+// Flag ON: normalized body + Link/X-Results-Truncated headers.
+function onPageResponse<T>(value: T[], headers: Record<string, string> = {}) {
+  return of({ data: { value }, headers: new Headers(headers) });
+}
+
+// Flag OFF: raw ARM body carrying nextLink, no Link header.
+function offPageResponse<T>(value: T[], nextLink?: string) {
+  return of({ data: { value, nextLink } });
 }
 
 describe('AzureMonitor: hasOption', () => {
@@ -90,19 +99,48 @@ describe('AzureMonitor: parseNextLinkToken', () => {
   });
 });
 
-describe('AzureMonitor: fetchArmResourcePage', () => {
-  beforeEach(() => {
-    fetchMock.mockClear();
+describe('AzureMonitor: skipTokenFromNextLink', () => {
+  it('extracts the $skiptoken from a raw ARM nextLink', () => {
+    expect(
+      skipTokenFromNextLink('https://management.azure.com/subscriptions?api-version=2019-03-01&$skiptoken=tok2')
+    ).toBe('tok2');
   });
 
-  it('requests the backend resource endpoint with the given params', async () => {
-    fetchMock.mockReturnValue(mockFetchResponse([{ id: 1 }, { id: 2 }]));
+  it('returns undefined when there is no nextLink or no $skiptoken', () => {
+    expect(skipTokenFromNextLink(undefined)).toBeUndefined();
+    expect(skipTokenFromNextLink('https://management.azure.com/subscriptions?api-version=2019-03-01')).toBeUndefined();
+    expect(skipTokenFromNextLink('not-a-url')).toBeUndefined();
+  });
+});
+
+describe('AzureMonitor: nextLinkToPath', () => {
+  it('rewrites a raw ARM nextLink onto the passthrough prefix, keeping path + query', () => {
+    expect(
+      nextLinkToPath(
+        '/api/datasources/uid/abc/resources/azuremonitor',
+        'https://management.azure.com/subscriptions?api-version=2019-03-01&$skiptoken=tok2'
+      )
+    ).toBe('/api/datasources/uid/abc/resources/azuremonitor/subscriptions?api-version=2019-03-01&$skiptoken=tok2');
+  });
+});
+
+describe('AzureMonitor: fetchArmResourcePage (server-side pagination ON)', () => {
+  beforeEach(() => {
+    fetchMock.mockClear();
+    setServerSidePagination(true);
+  });
+
+  afterEach(() => {
+    setServerSidePagination(false);
+  });
+
+  it('requests the passthrough resource path forwarding listAll', async () => {
+    fetchMock.mockReturnValue(onPageResponse([{ id: 1 }, { id: 2 }]));
 
     const page = await fetchArmResourcePage<{ id: number }>('abc', 'subscriptions', { listAll: 'true' });
 
     expect(fetchMock).toHaveBeenCalledWith({
-      url: '/api/datasources/uid/abc/resources/subscriptions',
-      params: { listAll: 'true' },
+      url: '/api/datasources/uid/abc/resources/azuremonitor/subscriptions?api-version=2019-03-01&listAll=true',
       method: 'GET',
     });
     expect(page.value).toEqual([{ id: 1 }, { id: 2 }]);
@@ -110,17 +148,33 @@ describe('AzureMonitor: fetchArmResourcePage', () => {
     expect(page.truncated).toBe(false);
   });
 
-  it('surfaces the continuation token from the Link header', async () => {
-    fetchMock.mockReturnValue(mockFetchResponse([{ id: 1 }], { Link: '<?nextToken=page2>; rel="next"' }));
+  it('interpolates the subscriptionId into the workspaces path (not as a query param)', async () => {
+    fetchMock.mockReturnValue(onPageResponse([{ id: 1 }]));
 
-    const page = await fetchArmResourcePage<{ id: number }>('abc', 'subscriptions', { listAll: 'false' });
+    await fetchArmResourcePage<{ id: number }>('abc', 'workspaces', { subscriptionId: 'sub-1', listAll: 'false' });
 
+    expect(fetchMock).toHaveBeenCalledWith({
+      url: '/api/datasources/uid/abc/resources/azuremonitor/subscriptions/sub-1/providers/Microsoft.OperationalInsights/workspaces?api-version=2017-04-26-preview&listAll=false',
+      method: 'GET',
+    });
+  });
+
+  it('surfaces the continuation token from the Link header and forwards nextToken', async () => {
+    fetchMock.mockReturnValue(onPageResponse([{ id: 1 }], { Link: '<?nextToken=page2>; rel="next"' }));
+
+    const page = await fetchArmResourcePage<{ id: number }>('abc', 'subscriptions', {
+      listAll: 'false',
+      nextToken: 'page1',
+    });
+
+    expect(fetchMock.mock.calls[0][0].url).toContain('&listAll=false');
+    expect(fetchMock.mock.calls[0][0].url).toContain('&nextToken=page1');
     expect(page.value).toEqual([{ id: 1 }]);
     expect(page.nextToken).toBe('page2');
   });
 
   it('flags truncation from the X-Results-Truncated header', async () => {
-    fetchMock.mockReturnValue(mockFetchResponse([{ id: 1 }], { 'X-Results-Truncated': 'true' }));
+    fetchMock.mockReturnValue(onPageResponse([{ id: 1 }], { 'X-Results-Truncated': 'true' }));
 
     const page = await fetchArmResourcePage<{ id: number }>('abc', 'subscriptions', { listAll: 'true' });
 
@@ -128,20 +182,65 @@ describe('AzureMonitor: fetchArmResourcePage', () => {
   });
 });
 
-describe('AzureMonitor: fetchAllArmResources', () => {
+describe('AzureMonitor: fetchArmResourcePage (server-side pagination OFF)', () => {
+  beforeEach(() => {
+    fetchMock.mockClear();
+    setServerSidePagination(false);
+  });
+
+  it('requests the passthrough path without listAll/nextToken and reads the body', async () => {
+    fetchMock.mockReturnValue(offPageResponse([{ id: 1 }, { id: 2 }]));
+
+    const page = await fetchArmResourcePage<{ id: number }>('abc', 'subscriptions', { listAll: 'true' });
+
+    expect(fetchMock).toHaveBeenCalledWith({
+      url: '/api/datasources/uid/abc/resources/azuremonitor/subscriptions?api-version=2019-03-01',
+      method: 'GET',
+    });
+    expect(page.value).toEqual([{ id: 1 }, { id: 2 }]);
+    expect(page.nextToken).toBeUndefined();
+    expect(page.truncated).toBe(false);
+  });
+
+  it('derives the continuation token from the body nextLink $skiptoken', async () => {
+    fetchMock.mockReturnValue(
+      offPageResponse([{ id: 1 }], 'https://management.azure.com/subscriptions?api-version=2019-03-01&$skiptoken=tok2')
+    );
+
+    const page = await fetchArmResourcePage<{ id: number }>('abc', 'subscriptions', { listAll: 'false' });
+
+    expect(page.nextToken).toBe('tok2');
+  });
+
+  it('forwards a prior nextToken to ARM as $skiptoken', async () => {
+    fetchMock.mockReturnValue(offPageResponse([{ id: 1 }]));
+
+    await fetchArmResourcePage<{ id: number }>('abc', 'subscriptions', { listAll: 'false', nextToken: 'tok2' });
+
+    expect(fetchMock.mock.calls[0][0].url).toContain('&$skiptoken=tok2');
+    expect(fetchMock.mock.calls[0][0].url).not.toContain('listAll');
+    expect(fetchMock.mock.calls[0][0].url).not.toContain('nextToken=');
+  });
+});
+
+describe('AzureMonitor: fetchAllArmResources (server-side pagination ON)', () => {
   beforeEach(() => {
     fetchMock.mockClear();
     publish.mockClear();
+    setServerSidePagination(true);
   });
 
-  it('requests eager listing and returns the value array', async () => {
-    fetchMock.mockReturnValue(mockFetchResponse([{ id: 1 }, { id: 2 }]));
+  afterEach(() => {
+    setServerSidePagination(false);
+  });
+
+  it('requests eager listing on the passthrough path and returns the value array', async () => {
+    fetchMock.mockReturnValue(onPageResponse([{ id: 1 }, { id: 2 }]));
 
     const value = await fetchAllArmResources<{ id: number }>('abc', 'workspaces', { subscriptionId: 'sub-1' });
 
     expect(fetchMock).toHaveBeenCalledWith({
-      url: '/api/datasources/uid/abc/resources/workspaces',
-      params: { subscriptionId: 'sub-1', listAll: 'true' },
+      url: '/api/datasources/uid/abc/resources/azuremonitor/subscriptions/sub-1/providers/Microsoft.OperationalInsights/workspaces?api-version=2017-04-26-preview&listAll=true',
       method: 'GET',
     });
     expect(value).toEqual([{ id: 1 }, { id: 2 }]);
@@ -149,11 +248,42 @@ describe('AzureMonitor: fetchAllArmResources', () => {
   });
 
   it('warns when the backend truncated the listing', async () => {
-    fetchMock.mockReturnValue(mockFetchResponse([{ id: 1 }], { 'X-Results-Truncated': 'true' }));
+    fetchMock.mockReturnValue(onPageResponse([{ id: 1 }], { 'X-Results-Truncated': 'true' }));
 
     await fetchAllArmResources<{ id: number }>('abc', 'subscriptions');
 
     expect(publish).toHaveBeenCalledWith(expect.objectContaining({ type: AppEvents.alertWarning.name }));
+  });
+});
+
+describe('AzureMonitor: fetchAllArmResources (server-side pagination OFF)', () => {
+  beforeEach(() => {
+    fetchMock.mockClear();
+    publish.mockClear();
+    setServerSidePagination(false);
+  });
+
+  it('follows the raw ARM nextLink across pages, rewriting it onto the passthrough path', async () => {
+    fetchMock
+      .mockReturnValueOnce(
+        offPageResponse(
+          [{ id: 1 }],
+          'https://management.azure.com/subscriptions?api-version=2019-03-01&$skiptoken=tok2'
+        )
+      )
+      .mockReturnValueOnce(offPageResponse([{ id: 2 }]));
+
+    const value = await fetchAllArmResources<{ id: number }>('abc', 'subscriptions');
+
+    expect(value).toEqual([{ id: 1 }, { id: 2 }]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0][0].url).toBe(
+      '/api/datasources/uid/abc/resources/azuremonitor/subscriptions?api-version=2019-03-01'
+    );
+    expect(fetchMock.mock.calls[1][0].url).toBe(
+      '/api/datasources/uid/abc/resources/azuremonitor/subscriptions?api-version=2019-03-01&$skiptoken=tok2'
+    );
+    expect(publish).not.toHaveBeenCalled();
   });
 });
 

--- a/public/app/plugins/datasource/azuremonitor/utils/common.ts
+++ b/public/app/plugins/datasource/azuremonitor/utils/common.ts
@@ -1,8 +1,15 @@
 import { map } from 'lodash';
+import { lastValueFrom } from 'rxjs';
 
 import { AppEvents, type ScopedVars, type SelectableValue, type VariableWithMultiSupport } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { getAppEvents, logWarning, type TemplateSrv, type VariableInterpolation } from '@grafana/runtime';
+import {
+  getAppEvents,
+  getBackendSrv,
+  logWarning,
+  type TemplateSrv,
+  type VariableInterpolation,
+} from '@grafana/runtime';
 
 import { type AzureAPIResponse, type AzureMonitorOption, type VariableOptionGroup } from '../types/types';
 
@@ -46,47 +53,68 @@ export const routeNames = {
   resourceGraph: 'resourcegraph',
 };
 
-export const MAX_ARM_PAGES = 50;
+export const paginatedRoutes = {
+  subscriptions: 'subscriptions',
+  workspaces: 'workspaces',
+} as const;
 
-export function nextLinkToPath(prefix: string, nextLink: string): string {
-  const { pathname, search } = new URL(nextLink);
-  return `${prefix}${pathname}${search}`;
+export interface ArmResourcePage<T> {
+  value: T[];
+  nextToken?: string;
+  truncated: boolean;
 }
 
-export async function fetchAllArmPages<T>(
-  prefix: string,
-  initialPath: string,
-  fetchPage: (path: string) => Promise<AzureAPIResponse<T> | undefined>,
-  maxPages: number = MAX_ARM_PAGES
+export function parseNextLinkToken(linkHeader: string): string | undefined {
+  const match = /<\?([^>]*)>;\s*rel="next"/.exec(linkHeader);
+  if (!match) {
+    return undefined;
+  }
+  return new URLSearchParams(match[1]).get('nextToken') ?? undefined;
+}
+
+export async function fetchArmResourcePage<T>(
+  datasourceUid: string,
+  subtype: string,
+  params: Record<string, string> = {}
+): Promise<ArmResourcePage<T>> {
+  const response = await lastValueFrom(
+    getBackendSrv().fetch<AzureAPIResponse<T>>({
+      url: `/api/datasources/uid/${datasourceUid}/resources/${subtype}`,
+      params,
+      method: 'GET',
+    })
+  );
+  const value = response.data?.value ?? [];
+  const linkHeader = response.headers.get('Link');
+  const nextToken = linkHeader ? parseNextLinkToken(linkHeader) : undefined;
+  const truncated = response.headers.get('X-Results-Truncated') === 'true';
+  return { value, nextToken, truncated };
+}
+
+export async function fetchAllArmResources<T>(
+  datasourceUid: string,
+  subtype: string,
+  params: Record<string, string> = {}
 ): Promise<T[]> {
-  const results: T[] = [];
-  let path: string | undefined = initialPath;
-  let pages = 0;
-  for (; path && pages < maxPages; pages++) {
-    const page = await fetchPage(path);
-    if (!page) {
-      logWarning('[azuremonitor] ARM page request returned no result; stopping pagination.');
-      path = undefined;
-      break;
-    }
-    results.push(...(page.value ?? []));
-    path = page.nextLink ? nextLinkToPath(prefix, page.nextLink) : undefined;
+  const { value, truncated } = await fetchArmResourcePage<T>(datasourceUid, subtype, { ...params, listAll: 'true' });
+  if (truncated) {
+    warnResultsTruncated();
   }
-  if (path) {
-    logWarning(`[azuremonitor] ARM listing stopped after ${maxPages} pages; some results may be omitted.`);
-    getAppEvents().publish({
-      type: AppEvents.alertWarning.name,
-      payload: [
-        t('components.pagination.results-truncated-title', 'Azure Monitor'),
-        t(
-          'components.pagination.results-truncated-message',
-          'Stopped loading after {{maxPages}} pages; some results may be omitted.',
-          { maxPages }
-        ),
-      ],
-    });
-  }
-  return results;
+  return value;
+}
+
+export function warnResultsTruncated(): void {
+  logWarning('[azuremonitor] ARM listing truncated by the backend; some results may be omitted.');
+  getAppEvents().publish({
+    type: AppEvents.alertWarning.name,
+    payload: [
+      t('components.pagination.results-truncated-title', 'Azure Monitor'),
+      t(
+        'components.pagination.results-truncated-message',
+        'Some results may be omitted because there were too many to load.'
+      ),
+    ],
+  });
 }
 
 export function interpolateVariable(

--- a/public/app/plugins/datasource/azuremonitor/utils/common.ts
+++ b/public/app/plugins/datasource/azuremonitor/utils/common.ts
@@ -4,6 +4,7 @@ import { lastValueFrom } from 'rxjs';
 import { AppEvents, type ScopedVars, type SelectableValue, type VariableWithMultiSupport } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import {
+  config,
   getAppEvents,
   getBackendSrv,
   logWarning,
@@ -58,10 +59,50 @@ export const paginatedRoutes = {
   workspaces: 'workspaces',
 } as const;
 
+// Cap the number of raw ARM pages we follow client-side (flag OFF) to avoid runaway loops.
+export const MAX_ARM_PAGES = 50;
+
+const armApiVersions = {
+  subscriptions: '2019-03-01',
+  workspaces: '2017-04-26-preview',
+};
+
 export interface ArmResourcePage<T> {
   value: T[];
   nextToken?: string;
   truncated: boolean;
+}
+
+function serverSidePaginationEnabled(): boolean {
+  return (config.featureToggles as Record<string, boolean | undefined>).azureMonitorServerSidePagination === true;
+}
+
+// Maps a paginated subtype onto the passthrough ARM resource path (with api-version). The
+// subscriptionId (workspaces only) lives in the path, not as a forwarded query param.
+function armResourcePath(subtype: string, params: Record<string, string>): string {
+  if (subtype === paginatedRoutes.subscriptions) {
+    return `${routeNames.azureMonitor}/subscriptions?api-version=${armApiVersions.subscriptions}`;
+  }
+  if (subtype === paginatedRoutes.workspaces) {
+    return `${routeNames.azureMonitor}/subscriptions/${params.subscriptionId}/providers/Microsoft.OperationalInsights/workspaces?api-version=${armApiVersions.workspaces}`;
+  }
+  return subtype;
+}
+
+const resourcesUrl = (datasourceUid: string, path: string): string =>
+  `/api/datasources/uid/${datasourceUid}/resources/${path}`;
+
+function appendParams(url: string, params: Record<string, string | undefined>): string {
+  // Keys are controlled literals (listAll/nextToken/$skiptoken) so are left verbatim; only
+  // values are encoded (ARM $skiptoken values can contain reserved characters).
+  const query = Object.entries(params)
+    .filter((entry): entry is [string, string] => entry[1] !== undefined && entry[1] !== '')
+    .map(([key, value]) => `${key}=${encodeURIComponent(value)}`)
+    .join('&');
+  if (!query) {
+    return url;
+  }
+  return `${url}${url.includes('?') ? '&' : '?'}${query}`;
 }
 
 export function parseNextLinkToken(linkHeader: string): string | undefined {
@@ -72,23 +113,51 @@ export function parseNextLinkToken(linkHeader: string): string | undefined {
   return new URLSearchParams(match[1]).get('nextToken') ?? undefined;
 }
 
+export function skipTokenFromNextLink(nextLink?: string): string | undefined {
+  if (!nextLink) {
+    return undefined;
+  }
+  try {
+    return new URL(nextLink).searchParams.get('$skiptoken') ?? undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+// Rewrites a raw ARM nextLink (absolute management.azure.com URL) onto a passthrough path by
+// stripping the scheme+host, keeping path+query, and re-prefixing with the resources route.
+export function nextLinkToPath(prefix: string, nextLink: string): string {
+  const { pathname, search } = new URL(nextLink);
+  return `${prefix}${pathname}${search}`;
+}
+
 export async function fetchArmResourcePage<T>(
   datasourceUid: string,
   subtype: string,
   params: Record<string, string> = {}
 ): Promise<ArmResourcePage<T>> {
-  const response = await lastValueFrom(
-    getBackendSrv().fetch<AzureAPIResponse<T>>({
-      url: `/api/datasources/uid/${datasourceUid}/resources/${subtype}`,
-      params,
-      method: 'GET',
-    })
-  );
+  const path = armResourcePath(subtype, params);
+
+  if (serverSidePaginationEnabled()) {
+    // Flag ON: the passthrough understands listAll/nextToken and returns the cursor in the Link header.
+    const url = appendParams(resourcesUrl(datasourceUid, path), {
+      listAll: params.listAll,
+      nextToken: params.nextToken,
+    });
+    const response = await lastValueFrom(getBackendSrv().fetch<AzureAPIResponse<T>>({ url, method: 'GET' }));
+    const value = response.data?.value ?? [];
+    const linkHeader = response.headers.get('Link');
+    const nextToken = linkHeader ? parseNextLinkToken(linkHeader) : undefined;
+    const truncated = response.headers.get('X-Results-Truncated') === 'true';
+    return { value, nextToken, truncated };
+  }
+
+  // Flag OFF: raw ARM body. Do not forward listAll/nextToken; continuation rides ARM's own $skiptoken.
+  const url = appendParams(resourcesUrl(datasourceUid, path), { $skiptoken: params.nextToken });
+  const response = await lastValueFrom(getBackendSrv().fetch<AzureAPIResponse<T>>({ url, method: 'GET' }));
   const value = response.data?.value ?? [];
-  const linkHeader = response.headers.get('Link');
-  const nextToken = linkHeader ? parseNextLinkToken(linkHeader) : undefined;
-  const truncated = response.headers.get('X-Results-Truncated') === 'true';
-  return { value, nextToken, truncated };
+  const nextToken = skipTokenFromNextLink(response.data?.nextLink);
+  return { value, nextToken, truncated: false };
 }
 
 export async function fetchAllArmResources<T>(
@@ -96,11 +165,30 @@ export async function fetchAllArmResources<T>(
   subtype: string,
   params: Record<string, string> = {}
 ): Promise<T[]> {
-  const { value, truncated } = await fetchArmResourcePage<T>(datasourceUid, subtype, { ...params, listAll: 'true' });
-  if (truncated) {
+  if (serverSidePaginationEnabled()) {
+    // Flag ON: the backend eagerly pages server-side; request everything and honour the truncation header.
+    const { value, truncated } = await fetchArmResourcePage<T>(datasourceUid, subtype, { ...params, listAll: 'true' });
+    if (truncated) {
+      warnResultsTruncated();
+    }
+    return value;
+  }
+
+  // Flag OFF: follow the raw ARM nextLink client-side, rewriting each onto the passthrough path.
+  const prefix = resourcesUrl(datasourceUid, routeNames.azureMonitor);
+  const results: T[] = [];
+  let url: string | undefined = resourcesUrl(datasourceUid, armResourcePath(subtype, params));
+  let pages = 0;
+  for (; url && pages < MAX_ARM_PAGES; pages++) {
+    const response = await lastValueFrom(getBackendSrv().fetch<AzureAPIResponse<T>>({ url, method: 'GET' }));
+    results.push(...(response.data?.value ?? []));
+    const nextLink = response.data?.nextLink;
+    url = nextLink ? nextLinkToPath(prefix, nextLink) : undefined;
+  }
+  if (url) {
     warnResultsTruncated();
   }
-  return value;
+  return results;
 }
 
 export function warnResultsTruncated(): void {


### PR DESCRIPTION
**What is this feature?**

Routes subscription and workspace listing through the backend's paginated `/subscriptions` and `/workspaces` endpoints instead of the frontend `nextLink` loop.

- `getSubscriptions`/`getWorkspaces`/`ConfigEditor` now request `listAll=true` (identical eager UX) via `getBackendSrv().fetch` so the `X-Results-Truncated` header can reproduce the previous truncation warning.
- Adds `getSubscriptionsPage` and `getWorkspacesPage` for on-demand cursor pagination.
- Retires `fetchAllArmPages`, `nextLinkToPath`, and `MAX_ARM_PAGES`.

**Why do we need this feature?**

Pagination of ARM listings previously happened in the frontend via a `nextLink` loop. Moving it to the backend's paginated endpoints centralizes the logic, preserves the existing eager listing behavior and truncation warning (via the `X-Results-Truncated` header), and enables true on-demand cursor pagination.

**Who is this feature for?**

Users of the Azure datasource who list subscriptions and workspaces, including in the config editor.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.