### PR TITLE
Alerting: Stop using notify.BuildReceiverConfiguration

### DIFF
--- a/pkg/services/ngalert/api/compat_contact_points_test.go
+++ b/pkg/services/ngalert/api/compat_contact_points_test.go
@@ -67,9 +67,8 @@ func TestContactPointFromContactPointExports(t *testing.T) {
 			back, err := ContactPointToContactPointExport(expected)
 			require.NoError(t, err)
 
-			// Run the export/import conversion a second time on the round-tripped config. If the first
-			// conversion lost or altered any data, re-importing it will no longer match `expected`.
-			actual, err := ContactPointFromContactPointExport(getContactPointExport(t, &back))
+			// Re-run export/import on the round-tripped receiver config and assert the typed ContactPoint is unchanged
+			// (i.e., the conversion is idempotent in the ContactPoint representation).
 			require.NoError(t, err)
 
 			diff := cmp.Diff(expected, actual)

--- a/pkg/services/ngalert/api/compat_contact_points_test.go
+++ b/pkg/services/ngalert/api/compat_contact_points_test.go
@@ -21,6 +21,19 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/provisioning"
 )
 
+// knownSchemaTypos lists (integration type, PropertyName) pairs where alerting's v1 schema declares a field name
+// that doesn't match the actual JSON key its Config struct reads, so the check below would otherwise flag a false
+// gap in definitions.go. These are upstream bugs in github.com/grafana/alerting, not fixable from this repo.
+var knownSchemaTypos = map[schema.IntegrationType]map[string]bool{
+	schema.TelegramType: {
+		// grafana/alerting's telegram v1 schema declares PropertyName "disable_notification" but
+		// Config.DisableNotifications actually reads "disable_notifications" (typo introduced in
+		// alerting@3da3b9a5, "Improve schemas"). The UI checkbox for this field is currently a no-op.
+		// Fix upstream, then remove this entry.
+		"disable_notification": true,
+	},
+}
+
 // TestContactPointDefinitionsMatchSchema asserts that every field declared in the v1 schema of an integration
 // (github.com/grafana/alerting) has a matching field in the corresponding definitions.XXXIntegration struct below.
 // Without this check, a new or renamed field in alerting's schema could silently fail to round-trip through
@@ -62,6 +75,9 @@ func definitionsStructFor(t *testing.T, integrationType schema.IntegrationType) 
 func assertFieldsMatchSchema(t *testing.T, integrationType schema.IntegrationType, fields []schema.Field, goType reflect.Type) {
 	t.Helper()
 	for _, field := range fields {
+		if knownSchemaTypos[integrationType][field.PropertyName] {
+			continue
+		}
 		structField, ok := jsonField(goType, field.PropertyName)
 		if !assert.Truef(t, ok, "%s: schema field %q has no matching field in definitions.%s", integrationType, field.PropertyName, goType.Name()) {
 			continue

--- a/pkg/services/ngalert/api/compat_contact_points_test.go
+++ b/pkg/services/ngalert/api/compat_contact_points_test.go
@@ -2,13 +2,18 @@ package api
 
 import (
 	"encoding/base64"
+	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	alertingmodels "github.com/grafana/alerting/models"
+	alertingNotify "github.com/grafana/alerting/notify"
 	"github.com/grafana/alerting/notify/notifytest"
+	"github.com/grafana/alerting/receivers/schema"
 
 	apicompat "github.com/grafana/grafana/pkg/services/ngalert/api/compat"
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
@@ -16,8 +21,95 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/provisioning"
 )
 
-// Test that conversion alertingmodels.ReceiverConfig -> definitions.ContactPoint -> alertingmodels.ReceiverConfig does not lose data
-func TestContactPointFromContactPointExports(t *testing.T) {
+// TestContactPointDefinitionsMatchSchema asserts that every field declared in the v1 schema of an integration
+// (github.com/grafana/alerting) has a matching field in the corresponding definitions.XXXIntegration struct below.
+// Without this check, a new or renamed field in alerting's schema could silently fail to round-trip through
+// Grafana's contact point API (provisioning, export, Terraform) without any test noticing.
+func TestContactPointDefinitionsMatchSchema(t *testing.T) {
+	for _, integrationSchema := range alertingNotify.GetSchemaForAllIntegrations() {
+		v1, ok := integrationSchema.GetVersion(schema.V1)
+		if !ok {
+			continue
+		}
+		t.Run(string(integrationSchema.Type), func(t *testing.T) {
+			goType := definitionsStructFor(t, integrationSchema.Type)
+			assertFieldsMatchSchema(t, integrationSchema.Type, v1.Options, goType)
+		})
+	}
+}
+
+// definitionsStructFor returns the definitions.XXXIntegration struct type that
+// ContactPointFromContactPointExport populates for the given integration type.
+func definitionsStructFor(t *testing.T, integrationType schema.IntegrationType) reflect.Type {
+	t.Helper()
+	export := definitions.ContactPointExport{
+		Receivers: []definitions.ReceiverExport{{Type: string(integrationType), Settings: definitions.RawMessage(`{}`)}},
+	}
+	cp, err := ContactPointFromContactPointExport(export)
+	require.NoError(t, err)
+
+	for _, f := range reflect.ValueOf(cp).Fields() {
+		if f.Kind() == reflect.Slice && f.Len() == 1 {
+			return f.Index(0).Type()
+		}
+	}
+	t.Fatalf("no definitions.ContactPoint field is populated for integration type %q; add it to ContactPointFromContactPointExport", integrationType)
+	return nil
+}
+
+// assertFieldsMatchSchema asserts that every field declared in fields has a matching JSON field in goType,
+// recursing into the nested struct for subform fields.
+func assertFieldsMatchSchema(t *testing.T, integrationType schema.IntegrationType, fields []schema.Field, goType reflect.Type) {
+	t.Helper()
+	for _, field := range fields {
+		structField, ok := jsonField(goType, field.PropertyName)
+		if !assert.Truef(t, ok, "%s: schema field %q has no matching field in definitions.%s", integrationType, field.PropertyName, goType.Name()) {
+			continue
+		}
+		if field.Element != schema.ElementTypeSubform {
+			continue
+		}
+		nested := structType(structField.Type)
+		if !assert.NotNilf(t, nested, "%s: schema field %q is a subform but definitions.%s.%s is not a struct", integrationType, field.PropertyName, goType.Name(), structField.Name) {
+			continue
+		}
+		assertFieldsMatchSchema(t, integrationType, field.SubformOptions, nested)
+	}
+}
+
+// jsonField returns the field of struct type t whose JSON tag matches name.
+func jsonField(t reflect.Type, name string) (reflect.StructField, bool) {
+	for f := range t.Fields() {
+		tag, ok := f.Tag.Lookup("json")
+		if !ok {
+			continue
+		}
+		tagName, _, _ := strings.Cut(tag, ",")
+		if tagName == name {
+			return f, true
+		}
+	}
+	return reflect.StructField{}, false
+}
+
+// structType returns the underlying struct type of t (dereferencing a pointer), or nil if t is not a struct.
+func structType(t reflect.Type) reflect.Type {
+	if t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	if t.Kind() == reflect.Struct {
+		return t
+	}
+	return nil
+}
+
+// TestContactPointRoundTrip complements TestContactPointDefinitionsMatchSchema: that test checks the definitions
+// structs declare every field the schema knows about, but says nothing about whether values actually survive the
+// conversion (ContactPointToContactPointExport, the custom jsoniter codecs, secret-setting handling). This test
+// covers that: it converts a fully-populated config to a typed ContactPoint and back to raw settings, then
+// re-imports those raw settings and asserts the result is unchanged. A field that is declared but dropped or
+// mis-serialized during the round trip will show up as a diff here.
+func TestContactPointRoundTrip(t *testing.T) {
 	getContactPointExport := func(t *testing.T, receiver *alertingmodels.ReceiverConfig) definitions.ContactPointExport {
 		export := make([]definitions.ReceiverExport, 0, len(receiver.Integrations))
 		for _, integrationConfig := range receiver.Integrations {
@@ -67,8 +159,9 @@ func TestContactPointFromContactPointExports(t *testing.T) {
 			back, err := ContactPointToContactPointExport(expected)
 			require.NoError(t, err)
 
-			// Re-run export/import on the round-tripped receiver config and assert the typed ContactPoint is unchanged
-			// (i.e., the conversion is idempotent in the ContactPoint representation).
+			// Run the export/import conversion a second time on the round-tripped config. If the conversion
+			// lost or altered any data, re-importing it will no longer match `expected`.
+			actual, err := ContactPointFromContactPointExport(getContactPointExport(t, &back))
 			require.NoError(t, err)
 
 			diff := cmp.Diff(expected, actual)
@@ -77,7 +170,9 @@ func TestContactPointFromContactPointExports(t *testing.T) {
 			}
 		})
 	}
+}
 
+func TestContactPointFromContactPointExport(t *testing.T) {
 	t.Run("pushover optional numbers as string", func(t *testing.T) {
 		export := definitions.ContactPointExport{
 			Name: "test",

--- a/pkg/services/ngalert/api/compat_contact_points_test.go
+++ b/pkg/services/ngalert/api/compat_contact_points_test.go
@@ -1,19 +1,14 @@
 package api
 
 import (
-	"context"
 	"encoding/base64"
-	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 
 	alertingmodels "github.com/grafana/alerting/models"
-	"github.com/grafana/alerting/notify"
 	"github.com/grafana/alerting/notify/notifytest"
-	"github.com/grafana/alerting/receivers/line"
-	receiversTesting "github.com/grafana/alerting/receivers/testing"
 
 	apicompat "github.com/grafana/grafana/pkg/services/ngalert/api/compat"
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
@@ -66,49 +61,18 @@ func TestContactPointFromContactPointExports(t *testing.T) {
 				},
 			}
 
-			expected, err := notify.BuildReceiverConfiguration(context.Background(), *recCfg, notify.DecodeSecretsFromBase64, func(ctx context.Context, sjd map[string][]byte, key string, fallback string) string {
-				value, _ := receiversTesting.DecryptForTesting(sjd)(key, fallback)
-				return value
-			})
+			expected, err := ContactPointFromContactPointExport(getContactPointExport(t, recCfg))
 			require.NoError(t, err)
 
-			result, err := ContactPointFromContactPointExport(getContactPointExport(t, recCfg))
+			back, err := ContactPointToContactPointExport(expected)
 			require.NoError(t, err)
 
-			back, err := ContactPointToContactPointExport(result)
+			// Run the export/import conversion a second time on the round-tripped config. If the first
+			// conversion lost or altered any data, re-importing it will no longer match `expected`.
+			actual, err := ContactPointFromContactPointExport(getContactPointExport(t, &back))
 			require.NoError(t, err)
 
-			actual, err := notify.BuildReceiverConfiguration(context.Background(), back, notify.DecodeSecretsFromBase64, func(ctx context.Context, sjd map[string][]byte, key string, fallback string) string {
-				value, _ := receiversTesting.DecryptForTesting(sjd)(key, fallback)
-				return value
-			})
-			require.NoError(t, err)
-
-			pathFilters := []string{
-				"Metadata.UID",
-				"Metadata.Name",
-				"WecomConfigs.Settings.EndpointURL", // This field is not exposed to user
-			}
-			if integrationType != "webhook" {
-				// Many notifiers now support HTTPClientConfig but only Webhook currently has it enabled in schema.
-				// TODO: Remove this once HTTPClientConfig is added to other schemas.
-				pathFilters = append(pathFilters, "HTTPClientConfig")
-			}
-			if integrationType == line.Type {
-				for _, l := range actual.LineConfigs {
-					l.Type = line.Type
-				}
-			}
-			pathFilter := cmp.FilterPath(func(path cmp.Path) bool {
-				for _, filter := range pathFilters {
-					if strings.Contains(path.String(), filter) {
-						return true
-					}
-				}
-				return false
-			}, cmp.Ignore())
-
-			diff := cmp.Diff(expected, actual, pathFilter)
+			diff := cmp.Diff(expected, actual)
 			if len(diff) != 0 {
 				require.Failf(t, "The re-marshalled configuration does not match the expected one", diff)
 			}

--- a/pkg/services/ngalert/api/tooling/definitions/contact_points.go
+++ b/pkg/services/ngalert/api/tooling/definitions/contact_points.go
@@ -36,11 +36,12 @@ type DingdingIntegration struct {
 type DiscordIntegration struct {
 	DisableResolveMessage *bool `json:"-" yaml:"-" hcl:"disable_resolve_message"`
 
-	WebhookURL         Secret  `json:"url" yaml:"url" hcl:"url"`
-	Title              *string `json:"title,omitempty" yaml:"title,omitempty" hcl:"title"`
-	Message            *string `json:"message,omitempty" yaml:"message,omitempty" hcl:"message"`
-	AvatarURL          *string `json:"avatar_url,omitempty" yaml:"avatar_url,omitempty" hcl:"avatar_url"`
-	UseDiscordUsername *bool   `json:"use_discord_username,omitempty" yaml:"use_discord_username,omitempty" hcl:"use_discord_username"`
+	WebhookURL          Secret  `json:"url" yaml:"url" hcl:"url"`
+	Title               *string `json:"title,omitempty" yaml:"title,omitempty" hcl:"title"`
+	Message             *string `json:"message,omitempty" yaml:"message,omitempty" hcl:"message"`
+	AvatarURL           *string `json:"avatar_url,omitempty" yaml:"avatar_url,omitempty" hcl:"avatar_url"`
+	UseDiscordUsername  *bool   `json:"use_discord_username,omitempty" yaml:"use_discord_username,omitempty" hcl:"use_discord_username"`
+	UseEmbedDescription *bool   `json:"use_embed_description,omitempty" yaml:"use_embed_description,omitempty" hcl:"use_embed_description"`
 }
 
 type EmailIntegration struct {
@@ -256,6 +257,7 @@ type SlackIntegration struct {
 	MentionUsers   *string `json:"mentionUsers,omitempty" yaml:"mentionUsers,omitempty" hcl:"mention_users"`
 	MentionGroups  *string `json:"mentionGroups,omitempty" yaml:"mentionGroups,omitempty" hcl:"mention_groups"`
 	Color          *string `json:"color,omitempty" yaml:"color,omitempty" hcl:"color"`
+	Footer         *string `json:"footer,omitempty" yaml:"footer,omitempty" hcl:"footer"`
 }
 
 type TelegramIntegration struct {

--- a/pkg/services/ngalert/models/receivers.go
+++ b/pkg/services/ngalert/models/receivers.go
@@ -425,14 +425,7 @@ func ValidateIntegration(ctx context.Context, integration models.IntegrationConf
 	if integration.Settings == nil {
 		return fmt.Errorf("settings should not be empty")
 	}
-
-	_, err := alertingNotify.BuildReceiverConfiguration(ctx, models.ReceiverConfig{
-		Integrations: []*models.IntegrationConfig{&integration},
-	}, alertingNotify.DecodeSecretsFromBase64, decryptFunc)
-	if err != nil {
-		return err
-	}
-	return nil
+	return alertingNotify.ValidateIntegrationConfig(ctx, &integration, alertingNotify.DecodeSecretsFromBase64, decryptFunc)
 }
 
 type EncryptFn = func(string) (string, error)

--- a/pkg/services/ngalert/provisioning/compat_test.go
+++ b/pkg/services/ngalert/provisioning/compat_test.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"testing"
 
+	"github.com/grafana/alerting/receivers/schema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -13,6 +14,22 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 )
+
+func TestEmbeddedContactPointToGrafanaIntegrationConfig_UsesV1(t *testing.T) {
+	settings := simplejson.NewFromAny(map[string]any{
+		"url": "https://example.com",
+	})
+	cp := &definitions.EmbeddedContactPoint{
+		UID:      "test-uid",
+		Name:     "test-name",
+		Type:     "webhook",
+		Settings: settings,
+	}
+
+	integration, err := EmbeddedContactPointToGrafanaIntegrationConfig(cp)
+	require.NoError(t, err)
+	assert.Equal(t, schema.V1, integration.Version)
+}
 
 func TestPostableGrafanaReceiverToEmbeddedContactPoint(t *testing.T) {
 	expectedProvenance := models.KnownProvenances[rand.Intn(len(models.KnownProvenances))]


### PR DESCRIPTION
## Summary
- `ValidateIntegration` now calls `alertingNotify.ValidateIntegrationConfig` directly instead of building a full `GrafanaReceiverConfig` just to discard it.
- `notify.BuildReceiverConfiguration` is being removed from `grafana/alerting` (related to https://github.com/grafana/alerting/pull/623). The contact point round-trip test that depended on it is replaced by two complementary checks:
  - `TestContactPointRoundTrip`: converts a fully-populated config to a typed `ContactPoint` and back to raw settings, then re-imports and asserts the result is unchanged. Catches data loss or mis-serialization in the conversion itself (the custom jsoniter codecs, secret-setting handling).
  - `TestContactPointDefinitionsMatchSchema`: a reflection-based check that every field declared in an integration's v1 schema (`github.com/grafana/alerting`) has a matching field in the corresponding `definitions.XXXIntegration` struct. Catches drift where alerting adds or renames a schema field that Grafana's own struct doesn't expose yet — something the round-trip test alone can't catch, since a field missing from the Go struct is dropped consistently on both sides of that comparison.
- `TestContactPointDefinitionsMatchSchema` found two real, pre-existing gaps, now fixed:
  - `DiscordIntegration` was missing `use_embed_description`.
  - `SlackIntegration` was missing `footer`.
- Telegram's `disable_notification` is left as a documented, narrow exception in the test: `definitions.TelegramIntegration` already has the correct, working field (`DisableNotifications` / `disable_notifications`). The actual bug is a typo in alerting's own v1 schema (`PropertyName: "disable_notification"` vs the Config struct's real JSON tag `disable_notifications`) — not fixable from this repo, needs an upstream fix in `grafana/alerting`. Fixed in https://github.com/grafana/alerting/pull/626
- Added `TestEmbeddedContactPointToGrafanaIntegrationConfig_UsesV1`, asserting `EmbeddedContactPointToGrafanaIntegrationConfig` always sets schema version V1.
- After this change, `notify.BuildReceiverConfiguration` has no remaining callers in this repo.

## Test plan
- [x] `go build ./pkg/services/ngalert/...`
- [x] `go test ./pkg/services/ngalert/models/...`, `.../provisioning/...`, `.../notifier/...`, `.../api/...` all pass
- [x] `golangci-lint run` clean on affected packages