### PR TITLE
unified-storage: reuse DB connection when creating database from snapshot

### DIFF
--- a/pkg/services/sqlstore/migrator/mysql_dialect.go
+++ b/pkg/services/sqlstore/migrator/mysql_dialect.go
@@ -405,7 +405,7 @@ func (s *MySQLDialect) executeStatements(ctx context.Context, engine *xorm.Engin
 	if err != nil {
 		return fmt.Errorf("failed to acquire connection for snapshot restore: %w", err)
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	for _, statement := range statements {
 		if _, err := conn.ExecContext(ctx, statement); err != nil {

--- a/pkg/services/sqlstore/migrator/mysql_dialect.go
+++ b/pkg/services/sqlstore/migrator/mysql_dialect.go
@@ -352,7 +352,7 @@ func (db *MySQLDialect) CreateDatabaseFromSnapshot(ctx context.Context, engine *
 		}
 
 		statements := extractStatements(string(data))
-		if err := db.executeStatements(engine, statements); err != nil {
+		if err := db.executeStatements(ctx, engine, statements); err != nil {
 			return err
 		}
 	}
@@ -399,12 +399,17 @@ func extractStatements(schema string) []string {
 	return statements
 }
 
-func (s *MySQLDialect) executeStatements(engine *xorm.Engine, statements []string) error {
-	sess := engine.NewSession()
-	for _, s := range statements {
-		_, err := sess.Exec(s)
-		if err != nil {
-			return fmt.Errorf("statement %s failed with error: %v", s, err)
+func (s *MySQLDialect) executeStatements(ctx context.Context, engine *xorm.Engine, statements []string) error {
+	// mysqldump statements rely on connection-scoped session state, so they must all use the same connection.
+	conn, err := engine.DB().Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to acquire connection for snapshot restore: %w", err)
+	}
+	defer conn.Close()
+
+	for _, statement := range statements {
+		if _, err := conn.ExecContext(ctx, statement); err != nil {
+			return fmt.Errorf("statement %s failed with error: %w", statement, err)
 		}
 	}
 	return nil

--- a/pkg/services/sqlstore/migrator/mysql_dialect_test.go
+++ b/pkg/services/sqlstore/migrator/mysql_dialect_test.go
@@ -1,0 +1,26 @@
+package migrator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractStatementsPreservesMySQLConditionalComments(t *testing.T) {
+	schema := `
+-- Table structure for table alert
+/*!40101 SET @saved_cs_client = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE alert (
+  id bigint NOT NULL
+);
+/*!40101 SET character_set_client = @saved_cs_client */;
+`
+
+	require.Equal(t, []string{
+		"/*!40101 SET @saved_cs_client = @@character_set_client */",
+		"/*!50503 SET character_set_client = utf8mb4 */",
+		"CREATE TABLE alert (\nid bigint NOT NULL\n)",
+		"/*!40101 SET character_set_client = @saved_cs_client */",
+	}, extractStatements(schema))
+}

--- a/pkg/services/sqlstore/sqlstore_testinfra_test.go
+++ b/pkg/services/sqlstore/sqlstore_testinfra_test.go
@@ -35,7 +35,20 @@ func TestIntegrationTempDatabaseConnect(t *testing.T) {
 func TestIntegrationTempDatabaseOSSMigrate(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 
-	_ = sqlstore.NewTestStore(t, sqlstore.WithOSSMigrations())
+	store := sqlstore.NewTestStore(t, sqlstore.WithOSSMigrations())
+	countMigrationLogs := func() int64 {
+		t.Helper()
+
+		count, err := store.GetEngine().Table("migration_log").Count()
+		require.NoError(t, err)
+		return count
+	}
+
+	initialCount := countMigrationLogs()
+	require.Positive(t, initialCount)
+
+	require.NoError(t, store.Migrate(false))
+	require.Equal(t, initialCount, countMigrationLogs())
 }
 
 func TestIntegrationUniqueConstraintViolation(t *testing.T) {


### PR DESCRIPTION
The snapshot files use session-variables, which assume they are being executed in the same connection. When executing each statement independently directly through a connection pool, as was the case before this commit, it was possible that two statements would run in different connections, leading to errors like the one below:

```
failed to create database from snapshot: statement /*!40101 SET
character_set_client = @saved_cs_client */ failed with error: Error 1231
(42000): Variable 'character_set_client' can't be set to the value of 'NULL'
```