### PR TITLE
Alerting: Made sending parameters configurable & Added parallel sending

### DIFF
--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -364,7 +364,7 @@ func (ng *AlertNG) init() error {
 
 	alertsRouter := sender.NewAlertsRouter(ng.MultiOrgAlertmanager, ng.store, clk, appUrl, ng.Cfg.UnifiedAlerting.DisabledOrgs,
 		ng.Cfg.UnifiedAlerting.AdminConfigPollInterval, ng.DataSourceService, ng.SecretsService, ng.FeatureToggles,
-		ng.Cfg.UnifiedAlerting.HASingleNodeEvaluation, ng.Metrics.GetSenderMetrics())
+		ng.Cfg.UnifiedAlerting.HASingleNodeEvaluation, ng.Metrics.GetSenderMetrics(), ng.Cfg.UnifiedAlerting)
 
 	// Make sure we sync at least once as Grafana starts to get the router up and running before we start sending any alerts.
 	if err := alertsRouter.SyncAndApplyConfigFromDatabase(initCtx); err != nil {

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -249,14 +249,17 @@ func (ng *AlertNG) init() error {
 		}
 
 		cfg := remote.AlertmanagerConfig{
-			BasicAuthPassword: ng.Cfg.UnifiedAlerting.RemoteAlertmanager.Password,
-			DefaultConfig:     ng.Cfg.UnifiedAlerting.DefaultConfiguration,
-			TenantID:          ng.Cfg.UnifiedAlerting.RemoteAlertmanager.TenantID,
-			URL:               ng.Cfg.UnifiedAlerting.RemoteAlertmanager.URL,
-			ExternalURL:       ng.Cfg.AppURL,
-			SmtpConfig:        smtpCfg,
-			Timeout:           ng.Cfg.UnifiedAlerting.RemoteAlertmanager.Timeout,
-			RuntimeConfig:     runtimeConfig,
+			BasicAuthPassword:       ng.Cfg.UnifiedAlerting.RemoteAlertmanager.Password,
+			DefaultConfig:           ng.Cfg.UnifiedAlerting.DefaultConfiguration,
+			TenantID:                ng.Cfg.UnifiedAlerting.RemoteAlertmanager.TenantID,
+			URL:                     ng.Cfg.UnifiedAlerting.RemoteAlertmanager.URL,
+			ExternalURL:             ng.Cfg.AppURL,
+			SmtpConfig:              smtpCfg,
+			Timeout:                 ng.Cfg.UnifiedAlerting.RemoteAlertmanager.Timeout,
+			RuntimeConfig:           runtimeConfig,
+			SenderQueueCapacity:     ng.Cfg.UnifiedAlerting.SenderQueueCapacity,
+			SenderBatchSize:         ng.Cfg.UnifiedAlerting.SenderBatchSize,
+			SenderDispatcherWorkers: ng.Cfg.UnifiedAlerting.SenderDispatcherWorkers,
 		}
 
 		// This function will be used by the MOA to create new Alertmanagers.

--- a/pkg/services/ngalert/remote/alertmanager.go
+++ b/pkg/services/ngalert/remote/alertmanager.go
@@ -118,6 +118,11 @@ type AlertmanagerConfig struct {
 	// label/annotation name or value. 0 keeps the sender default
 	// (sender.DefaultMaxLabelStringSize)
 	MaxLabelStringSize int
+
+	// Sender configurations
+	SenderQueueCapacity     int
+	SenderBatchSize         int
+	SenderDispatcherWorkers int
 }
 
 func (cfg *AlertmanagerConfig) Validate() error {
@@ -187,6 +192,9 @@ func NewAlertmanager(
 	senderOpts := []sender.Option{
 		sender.WithDoFunc(doFunc),
 		sender.WithUTF8Labels(),
+		sender.WithMaxQueueCapacity(cfg.SenderQueueCapacity),
+		sender.WithMaxBatchSize(cfg.SenderBatchSize),
+		sender.WithDispatcherWorkers(cfg.SenderDispatcherWorkers),
 	}
 	if cfg.MaxLabelStringSize > 0 {
 		senderOpts = append(senderOpts, sender.WithMaxLabelStringSize(cfg.MaxLabelStringSize))

--- a/pkg/services/ngalert/sender/notifier.go
+++ b/pkg/services/ngalert/sender/notifier.go
@@ -48,7 +48,7 @@ import (
 
 const (
 	// DefaultMaxBatchSize is the default maximum number of alerts to send in a single request to the alertmanager.
-	DefaultMaxBatchSize = 256
+	DefaultMaxBatchSize = 1024
 
 	contentTypeJSON = "application/json"
 )
@@ -128,6 +128,9 @@ type Options struct {
 
 	// MaxBatchSize determines the maximum number of alerts to send in a single request to the alertmanager.
 	MaxBatchSize int
+
+	// DispatcherWorkers determines the number of concurrent goroutines dispatching alerts.
+	DispatcherWorkers int
 }
 
 type alertMetrics struct {
@@ -150,6 +153,9 @@ func NewManager(o *Options, logger *slog.Logger) *Manager {
 	// Set default MaxBatchSize if not provided.
 	if o.MaxBatchSize <= 0 {
 		o.MaxBatchSize = DefaultMaxBatchSize
+	}
+	if o.DispatcherWorkers <= 0 {
+		o.DispatcherWorkers = 1
 	}
 	if logger == nil {
 		logger = promslog.NewNopLogger()
@@ -217,7 +223,17 @@ func (n *Manager) Run(tsets <-chan map[string][]*targetgroup.Group) {
 
 	go func() {
 		defer wg.Done()
-		n.sendLoop()
+
+		sendWg := sync.WaitGroup{}
+		sendWg.Add(n.opts.DispatcherWorkers)
+		for i := 0; i < n.opts.DispatcherWorkers; i++ {
+			go func() {
+				defer sendWg.Done()
+				n.sendLoop()
+			}()
+		}
+		sendWg.Wait()
+
 		n.drainQueue()
 	}()
 
@@ -240,11 +256,6 @@ func (n *Manager) sendLoop() {
 
 			case <-n.more:
 				n.sendOneBatch()
-
-				// If the queue still has items left, kick off the next iteration.
-				if n.queueLen() > 0 {
-					n.setMore()
-				}
 			}
 		}
 	}
@@ -271,8 +282,16 @@ func (n *Manager) targetUpdateLoop(tsets <-chan map[string][]*targetgroup.Group)
 func (n *Manager) sendOneBatch() {
 	alerts := n.nextBatch()
 
-	if !n.sendAll(alerts...) {
-		n.metrics.dropped.Add(float64(len(alerts)))
+	// If the queue still has items left, wake up another worker immediately
+	// before we block on sending this batch.
+	if n.queueLen() > 0 {
+		n.setMore()
+	}
+
+	if len(alerts) > 0 {
+		if !n.sendAll(alerts...) {
+			n.metrics.dropped.Add(float64(len(alerts)))
+		}
 	}
 }
 

--- a/pkg/services/ngalert/sender/notifier_test.go
+++ b/pkg/services/ngalert/sender/notifier_test.go
@@ -49,7 +49,7 @@ import (
 	"github.com/prometheus/prometheus/model/relabel"
 )
 
-const maxBatchSize = 256
+const maxBatchSize = 1024
 
 func TestPostPath(t *testing.T) {
 	cases := []struct {

--- a/pkg/services/ngalert/sender/router.go
+++ b/pkg/services/ngalert/sender/router.go
@@ -23,6 +23,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier"
 	"github.com/grafana/grafana/pkg/services/ngalert/store"
 	"github.com/grafana/grafana/pkg/services/secrets"
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 // AlertsRouter handles alerts generated during alert rule evaluation.
@@ -53,6 +54,7 @@ type AlertsRouter struct {
 	featureManager    featuremgmt.FeatureToggles
 	broadcastAlerts   bool
 	senderMetrics     *metrics.Sender
+	uaSettings        setting.UnifiedAlertingSettings
 }
 
 func NewAlertsRouter(multiOrgNotifier *notifier.MultiOrgAlertmanager, store store.AdminConfigurationStore,
@@ -61,6 +63,7 @@ func NewAlertsRouter(multiOrgNotifier *notifier.MultiOrgAlertmanager, store stor
 	secretService secrets.Service, //nolint:staticcheck // SA1019: Legacy envelope encryption for single-tenant feature
 	featureManager featuremgmt.FeatureToggles,
 	broadcastAlerts bool, senderMetrics *metrics.Sender,
+	uaSettings setting.UnifiedAlertingSettings,
 ) *AlertsRouter {
 	d := &AlertsRouter{
 		logger:           log.New("ngalert.sender.router"),
@@ -83,6 +86,7 @@ func NewAlertsRouter(multiOrgNotifier *notifier.MultiOrgAlertmanager, store stor
 		featureManager:    featureManager,
 		broadcastAlerts:   broadcastAlerts,
 		senderMetrics:     senderMetrics,
+		uaSettings:        uaSettings,
 	}
 	return d
 }
@@ -181,7 +185,14 @@ func (d *AlertsRouter) SyncAndApplyConfigFromDatabase(ctx context.Context) error
 		// No sender and have Alertmanager(s) to send to - start a new one.
 		d.logger.Info("Creating new sender for the external alertmanagers", "org", cfg.OrgID, "alertmanagers", redactedAMs)
 		senderLogger := log.New("ngalert.sender.external-alertmanager")
-		s, err := NewExternalAlertmanagerSender(senderLogger, d.senderMetrics.GetOrCreateOrgRegistry(cfg.OrgID))
+		s, err := NewExternalAlertmanagerSender(
+			senderLogger, 
+			d.senderMetrics.GetOrCreateOrgRegistry(cfg.OrgID),
+			WithMaxQueueCapacity(d.uaSettings.SenderQueueCapacity),
+			WithMaxBatchSize(d.uaSettings.SenderBatchSize),
+			WithTimeout(d.uaSettings.SenderTimeout),
+			WithDispatcherWorkers(d.uaSettings.SenderDispatcherWorkers),
+		)
 		if err != nil {
 			d.adminConfigMtx.Unlock()
 			return err

--- a/pkg/services/ngalert/sender/router_test.go
+++ b/pkg/services/ngalert/sender/router_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier"
 	"github.com/grafana/grafana/pkg/services/ngalert/store"
 	fake_secrets "github.com/grafana/grafana/pkg/services/secrets/fakes"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
 	"github.com/grafana/grafana/pkg/util/testutil"
 )
@@ -62,7 +63,7 @@ func TestIntegrationSendingToExternalAlertmanager(t *testing.T) {
 		}),
 	}
 	alertsRouter := NewAlertsRouter(moa, fakeAdminConfigStore, mockedClock, appUrl, map[int64]struct{}{}, 10*time.Minute,
-		&fake_ds.FakeDataSourceService{DataSources: []*datasources.DataSource{&ds1}}, fake_secrets.NewFakeSecretsService(), featuremgmt.WithFeatures(), false, metrics.NewSenderMetrics(prometheus.NewPedanticRegistry()))
+		&fake_ds.FakeDataSourceService{DataSources: []*datasources.DataSource{&ds1}}, fake_secrets.NewFakeSecretsService(), featuremgmt.WithFeatures(), false, metrics.NewSenderMetrics(prometheus.NewPedanticRegistry()), setting.UnifiedAlertingSettings{})
 
 	mockedGetAdminConfigurations.Return([]*models.AdminConfiguration{
 		{OrgID: ruleKey.OrgID, SendAlertsTo: new(models.AllAlertmanagers)},
@@ -132,7 +133,7 @@ func TestIntegrationSendingToExternalAlertmanager_WithMultipleOrgs(t *testing.T)
 	}
 	fakeDs := &fake_ds.FakeDataSourceService{DataSources: []*datasources.DataSource{&ds1}}
 	alertsRouter := NewAlertsRouter(moa, fakeAdminConfigStore, mockedClock, appUrl, map[int64]struct{}{}, 10*time.Minute,
-		fakeDs, fake_secrets.NewFakeSecretsService(), featuremgmt.WithFeatures(), false, metrics.NewSenderMetrics(prometheus.NewPedanticRegistry()))
+		fakeDs, fake_secrets.NewFakeSecretsService(), featuremgmt.WithFeatures(), false, metrics.NewSenderMetrics(prometheus.NewPedanticRegistry()), setting.UnifiedAlertingSettings{})
 
 	mockedGetAdminConfigurations.Return([]*models.AdminConfiguration{
 		{OrgID: ruleKey1.OrgID, SendAlertsTo: new(models.AllAlertmanagers)},
@@ -291,7 +292,7 @@ func TestChangingAlertmanagersChoice(t *testing.T) {
 		}),
 	}
 	alertsRouter := NewAlertsRouter(moa, fakeAdminConfigStore, mockedClock, appUrl, map[int64]struct{}{},
-		10*time.Minute, &fake_ds.FakeDataSourceService{DataSources: []*datasources.DataSource{&ds}}, fake_secrets.NewFakeSecretsService(), featuremgmt.WithFeatures(), false, metrics.NewSenderMetrics(prometheus.NewPedanticRegistry()))
+		10*time.Minute, &fake_ds.FakeDataSourceService{DataSources: []*datasources.DataSource{&ds}}, fake_secrets.NewFakeSecretsService(), featuremgmt.WithFeatures(), false, metrics.NewSenderMetrics(prometheus.NewPedanticRegistry()), setting.UnifiedAlertingSettings{})
 
 	mockedGetAdminConfigurations.Return([]*models.AdminConfiguration{
 		{OrgID: ruleKey.OrgID, SendAlertsTo: new(models.AllAlertmanagers)},
@@ -393,7 +394,7 @@ func TestAlertmanagersChoiceWithDisableExternalFeatureToggle(t *testing.T) {
 
 	alertsRouter := NewAlertsRouter(moa, fakeAdminConfigStore, mockedClock, appUrl, map[int64]struct{}{},
 		10*time.Minute, &fake_ds.FakeDataSourceService{DataSources: []*datasources.DataSource{&ds}},
-		fake_secrets.NewFakeSecretsService(), featuremgmt.WithFeatures(featuremgmt.FlagAlertingDisableSendAlertsExternal), false, metrics.NewSenderMetrics(prometheus.NewPedanticRegistry()))
+		fake_secrets.NewFakeSecretsService(), featuremgmt.WithFeatures(featuremgmt.FlagAlertingDisableSendAlertsExternal), false, metrics.NewSenderMetrics(prometheus.NewPedanticRegistry()), setting.UnifiedAlertingSettings{})
 
 	// Test that we only send to the internal Alertmanager even though the configuration specifies AllAlertmanagers.
 

--- a/pkg/services/ngalert/sender/sender.go
+++ b/pkg/services/ngalert/sender/sender.go
@@ -28,9 +28,10 @@ import (
 )
 
 const (
-	defaultMaxQueueCapacity = 10000
-	defaultTimeout          = 10 * time.Second
+	defaultMaxQueueCapacity = 50000
+	defaultTimeout          = 30 * time.Second
 	defaultDrainOnShutdown  = true
+	defaultDispatcherWorkers = 4
 
 	// DefaultMaxLabelStringSize is the default byte cap applied to any single
 	// label/annotation name or value forwarded to an Alertmanager. The
@@ -71,6 +72,7 @@ type ExternalAMOptions struct {
 	// MaxLabelStringSize caps the byte length of any single label/annotation
 	// name or value. A non-positive value disables the clamp.
 	MaxLabelStringSize int
+	Timeout            time.Duration
 }
 
 type Option func(*ExternalAMOptions)
@@ -114,10 +116,24 @@ func WithMaxQueueCapacity(capacity int) Option {
 	}
 }
 
+// WithTimeout sets the fallback timeout used when sending to external Alertmanagers.
+func WithTimeout(timeout time.Duration) Option {
+	return func(opts *ExternalAMOptions) {
+		opts.Timeout = timeout
+	}
+}
+
 // WithMaxBatchSize sets the maximum batch size for sending alerts to the external Alertmanager(s).
 func WithMaxBatchSize(size int) Option {
 	return func(opts *ExternalAMOptions) {
 		opts.MaxBatchSize = size
+	}
+}
+
+// WithDispatcherWorkers sets the number of concurrent goroutines dispatching alerts.
+func WithDispatcherWorkers(workers int) Option {
+	return func(opts *ExternalAMOptions) {
+		opts.DispatcherWorkers = workers
 	}
 }
 
@@ -159,12 +175,14 @@ func NewExternalAlertmanagerSender(l log.Logger, reg prometheus.Registerer, opts
 
 	options := &ExternalAMOptions{
 		Options: Options{
-			QueueCapacity:   defaultMaxQueueCapacity,
-			MaxBatchSize:    DefaultMaxBatchSize,
-			Registerer:      reg,
-			DrainOnShutdown: defaultDrainOnShutdown,
+			QueueCapacity:     defaultMaxQueueCapacity,
+			MaxBatchSize:      DefaultMaxBatchSize,
+			DispatcherWorkers: defaultDispatcherWorkers,
+			Registerer:        reg,
+			DrainOnShutdown:   defaultDrainOnShutdown,
 		},
 		MaxLabelStringSize: DefaultMaxLabelStringSize,
+		Timeout:            defaultTimeout,
 	}
 
 	for _, opt := range opts {
@@ -205,7 +223,7 @@ func NewExternalAlertmanagerSender(l log.Logger, reg prometheus.Registerer, opts
 
 // ApplyConfig syncs a configuration with the sender.
 func (s *ExternalAlertmanager) ApplyConfig(orgId, id int64, alertmanagers []ExternalAMcfg) error {
-	notifierCfg, headers, dataSourceUIDs, err := buildNotifierConfig(alertmanagers)
+	notifierCfg, headers, dataSourceUIDs, err := buildNotifierConfig(alertmanagers, s.options.Timeout)
 	if err != nil {
 		return err
 	}
@@ -285,12 +303,12 @@ func (s *ExternalAlertmanager) DroppedAlertmanagers() []*url.URL {
 	return s.manager.DroppedAlertmanagers()
 }
 
-func buildNotifierConfig(alertmanagers []ExternalAMcfg) (*config.Config, map[string]http.Header, map[string]string, error) {
+func buildNotifierConfig(alertmanagers []ExternalAMcfg, fallbackTimeout time.Duration) (*config.Config, map[string]http.Header, map[string]string, error) {
 	amConfigs := make([]*config.AlertmanagerConfig, 0, len(alertmanagers))
 	headers := map[string]http.Header{}
 	dataSourceUIDs := map[string]string{}
 	for i, am := range alertmanagers {
-		amConfig, err := externalAMcfgToAlertmanagerConfig(am)
+		amConfig, err := externalAMcfgToAlertmanagerConfig(am, fallbackTimeout)
 		if err != nil {
 			return nil, nil, nil, err
 		}
@@ -320,7 +338,7 @@ func buildNotifierConfig(alertmanagers []ExternalAMcfg) (*config.Config, map[str
 }
 
 // externalAMcfgToAlertmanagerConfig converts an ExternalAMcfg to a Prometheus AlertmanagerConfig.
-func externalAMcfgToAlertmanagerConfig(am ExternalAMcfg) (*config.AlertmanagerConfig, error) {
+func externalAMcfgToAlertmanagerConfig(am ExternalAMcfg, fallbackTimeout time.Duration) (*config.AlertmanagerConfig, error) {
 	u, err := url.Parse(am.URL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse alertmanager URL: %w", err)
@@ -336,7 +354,7 @@ func externalAMcfgToAlertmanagerConfig(am ExternalAMcfg) (*config.AlertmanagerCo
 
 	timeout := am.Timeout
 	if timeout == 0 {
-		timeout = defaultTimeout
+		timeout = fallbackTimeout
 	}
 
 	amConfig := &config.AlertmanagerConfig{

--- a/pkg/services/ngalert/sender/sender.go
+++ b/pkg/services/ngalert/sender/sender.go
@@ -112,28 +112,36 @@ func WithMaxLabelStringSize(size int) Option {
 // WithMaxQueueCapacity sets the maximum capacity of the queue used by the sender.
 func WithMaxQueueCapacity(capacity int) Option {
 	return func(opts *ExternalAMOptions) {
-		opts.QueueCapacity = capacity
+		if capacity > 0 {
+			opts.QueueCapacity = capacity
+		}
 	}
 }
 
 // WithTimeout sets the fallback timeout used when sending to external Alertmanagers.
 func WithTimeout(timeout time.Duration) Option {
 	return func(opts *ExternalAMOptions) {
-		opts.Timeout = timeout
+		if timeout > 0 {
+			opts.Timeout = timeout
+		}
 	}
 }
 
 // WithMaxBatchSize sets the maximum batch size for sending alerts to the external Alertmanager(s).
 func WithMaxBatchSize(size int) Option {
 	return func(opts *ExternalAMOptions) {
-		opts.MaxBatchSize = size
+		if size > 0 {
+			opts.MaxBatchSize = size
+		}
 	}
 }
 
 // WithDispatcherWorkers sets the number of concurrent goroutines dispatching alerts.
 func WithDispatcherWorkers(workers int) Option {
 	return func(opts *ExternalAMOptions) {
-		opts.DispatcherWorkers = workers
+		if workers > 0 {
+			opts.DispatcherWorkers = workers
+		}
 	}
 }
 

--- a/pkg/services/ngalert/sender/sender_test.go
+++ b/pkg/services/ngalert/sender/sender_test.go
@@ -203,6 +203,42 @@ func TestWithMaxBatchSize(t *testing.T) {
 	})
 }
 
+func TestWithTimeout(t *testing.T) {
+	logger := log.NewNopLogger()
+
+	t.Run("WithTimeout sets custom timeout", func(t *testing.T) {
+		customTimeout := 42 * time.Second
+		am, err := NewExternalAlertmanagerSender(logger, prometheus.NewRegistry(), WithTimeout(customTimeout))
+		require.NoError(t, err)
+		require.Equal(t, customTimeout, am.options.Timeout)
+	})
+
+	t.Run("default timeout when option is not used", func(t *testing.T) {
+		am, err := NewExternalAlertmanagerSender(logger, prometheus.NewRegistry())
+		require.NoError(t, err)
+		require.Equal(t, defaultTimeout, am.options.Timeout)
+	})
+}
+
+func TestWithDispatcherWorkers(t *testing.T) {
+	logger := log.NewNopLogger()
+
+	t.Run("WithDispatcherWorkers sets custom workers count", func(t *testing.T) {
+		customWorkers := 8
+		am, err := NewExternalAlertmanagerSender(logger, prometheus.NewRegistry(), WithDispatcherWorkers(customWorkers))
+		require.NoError(t, err)
+		require.Equal(t, customWorkers, am.options.DispatcherWorkers)
+		require.Equal(t, customWorkers, am.manager.opts.DispatcherWorkers)
+	})
+
+	t.Run("default workers when option is not used", func(t *testing.T) {
+		am, err := NewExternalAlertmanagerSender(logger, prometheus.NewRegistry())
+		require.NoError(t, err)
+		require.Equal(t, defaultDispatcherWorkers, am.options.DispatcherWorkers)
+		require.Equal(t, defaultDispatcherWorkers, am.manager.opts.DispatcherWorkers)
+	})
+}
+
 func TestWithUTF8Labels(t *testing.T) {
 	logger := log.NewNopLogger()
 

--- a/pkg/setting/setting_unified_alerting.go
+++ b/pkg/setting/setting_unified_alerting.go
@@ -170,6 +170,11 @@ type UnifiedAlertingSettings struct {
 	// Configured via the [unified_alerting] ini key "external_alertmanager_uid" or the
 	// GF_UNIFIED_ALERTING_EXTERNAL_ALERTMANAGER_UID environment variable.
 	ExternalAlertmanagerUID string
+	
+	SenderQueueCapacity     int
+	SenderBatchSize         int
+	SenderTimeout           time.Duration
+	SenderDispatcherWorkers int
 }
 
 type RecordingRuleSettings struct {
@@ -629,6 +634,11 @@ func (cfg *Cfg) ReadUnifiedAlertingSettings(iniFile *ini.File) error {
 
 	uaCfg.LimitEmailToOrgMembers = ua.Key("limit_email_to_org_members").MustBool(false)
 	uaCfg.ExternalAlertmanagerUID = ua.Key("external_alertmanager_uid").MustString("")
+
+	uaCfg.SenderQueueCapacity = ua.Key("sender_queue_capacity").MustInt(50000)
+	uaCfg.SenderBatchSize = ua.Key("sender_batch_size").MustInt(1024)
+	uaCfg.SenderTimeout = ua.Key("sender_timeout").MustDuration(30 * time.Second)
+	uaCfg.SenderDispatcherWorkers = ua.Key("sender_dispatcher_workers").MustInt(4)
 
 	cfg.UnifiedAlerting = uaCfg
 	return nil

--- a/pkg/setting/setting_unified_alerting.go
+++ b/pkg/setting/setting_unified_alerting.go
@@ -636,9 +636,21 @@ func (cfg *Cfg) ReadUnifiedAlertingSettings(iniFile *ini.File) error {
 	uaCfg.ExternalAlertmanagerUID = ua.Key("external_alertmanager_uid").MustString("")
 
 	uaCfg.SenderQueueCapacity = ua.Key("sender_queue_capacity").MustInt(50000)
+	if uaCfg.SenderQueueCapacity <= 0 {
+		uaCfg.SenderQueueCapacity = 50000
+	}
 	uaCfg.SenderBatchSize = ua.Key("sender_batch_size").MustInt(1024)
+	if uaCfg.SenderBatchSize <= 0 {
+		uaCfg.SenderBatchSize = 1024
+	}
 	uaCfg.SenderTimeout = ua.Key("sender_timeout").MustDuration(30 * time.Second)
+	if uaCfg.SenderTimeout <= 0 {
+		uaCfg.SenderTimeout = 30 * time.Second
+	}
 	uaCfg.SenderDispatcherWorkers = ua.Key("sender_dispatcher_workers").MustInt(4)
+	if uaCfg.SenderDispatcherWorkers <= 0 {
+		uaCfg.SenderDispatcherWorkers = 4
+	}
 
 	cfg.UnifiedAlerting = uaCfg
 	return nil

--- a/pkg/setting/setting_unified_alerting_test.go
+++ b/pkg/setting/setting_unified_alerting_test.go
@@ -110,6 +110,9 @@ func TestUnifiedAlertingSettings(t *testing.T) {
 				require.Equal(t, 90*time.Second, cfg.UnifiedAlerting.EvaluationTimeout)
 				require.Equal(t, SchedulerBaseInterval, cfg.UnifiedAlerting.BaseInterval)
 				require.Equal(t, DefaultRuleEvaluationInterval, cfg.UnifiedAlerting.DefaultRuleEvaluationInterval)
+				require.Equal(t, 50000, cfg.UnifiedAlerting.SenderQueueCapacity)
+				require.Equal(t, 1024, cfg.UnifiedAlerting.SenderBatchSize)
+				require.Equal(t, 30*time.Second, cfg.UnifiedAlerting.SenderTimeout)
 			},
 		},
 		{
@@ -134,6 +137,10 @@ func TestUnifiedAlertingSettings(t *testing.T) {
 				require.Equal(t, 160*time.Second, cfg.UnifiedAlerting.EvaluationTimeout)
 				require.Equal(t, SchedulerBaseInterval, cfg.UnifiedAlerting.BaseInterval)
 				require.Equal(t, 120*time.Second, cfg.UnifiedAlerting.DefaultRuleEvaluationInterval)
+				require.Equal(t, 50000, cfg.UnifiedAlerting.SenderQueueCapacity)
+				require.Equal(t, 1024, cfg.UnifiedAlerting.SenderBatchSize)
+				require.Equal(t, 30*time.Second, cfg.UnifiedAlerting.SenderTimeout)
+				require.Equal(t, 4, cfg.UnifiedAlerting.SenderDispatcherWorkers)
 			},
 		},
 		{


### PR DESCRIPTION
…) & Added parallel alert notification

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

I want to make the sending alerts part inside grafana to be more robust.
I have a grafana instance with high amount of alert (in the hundred thousands), and i see that sending alerts is becoming harder.
I want to make the inside queues and timeout to be more robust and configurable.

**Why do we need this feature?**

Better throughput.

**Who is this feature for?**

For users with a high amount of configured alerts.



**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
