### PR TITLE
Transformations: Support timezone when converting to time

### DIFF
--- a/docs/sources/visualizations/panels-visualizations/query-transform-data/transform-data/index.md
+++ b/docs/sources/visualizations/panels-visualizations/query-transform-data/transform-data/index.md
@@ -319,7 +319,7 @@ This transformation has the following options:
     - It will parse the numeric input as a Unix epoch timestamp in milliseconds.
       You must multiply your input by 1000 if it's in seconds.
     - Will show an option to specify a DateFormat as input by a string like yyyy-mm-dd or DD MM YYYY hh:mm:ss
-    - The **Timezone** option determines how Grafana interprets input strings without timezone information. If unset, Grafana uses your configured default timezone, which defaults to the browser timezone.
+    - The **Timezone** option determines how Grafana interprets input strings without timezone information. If not set, Grafana uses the browser timezone or your configured default timezone.
   - **Boolean** - will make the values booleans
   - **Enum** - will make the values enums
     - Will show a table to manage the enums

--- a/docs/sources/visualizations/panels-visualizations/query-transform-data/transform-data/index.md
+++ b/docs/sources/visualizations/panels-visualizations/query-transform-data/transform-data/index.md
@@ -319,6 +319,7 @@ This transformation has the following options:
     - It will parse the numeric input as a Unix epoch timestamp in milliseconds.
       You must multiply your input by 1000 if it's in seconds.
     - Will show an option to specify a DateFormat as input by a string like yyyy-mm-dd or DD MM YYYY hh:mm:ss
+    - The **Timezone** option determines how Grafana interprets input strings without timezone information. It defaults to the browser timezone.
   - **Boolean** - will make the values booleans
   - **Enum** - will make the values enums
     - Will show a table to manage the enums

--- a/docs/sources/visualizations/panels-visualizations/query-transform-data/transform-data/index.md
+++ b/docs/sources/visualizations/panels-visualizations/query-transform-data/transform-data/index.md
@@ -319,7 +319,7 @@ This transformation has the following options:
     - It will parse the numeric input as a Unix epoch timestamp in milliseconds.
       You must multiply your input by 1000 if it's in seconds.
     - Will show an option to specify a DateFormat as input by a string like yyyy-mm-dd or DD MM YYYY hh:mm:ss
-    - The **Timezone** option determines how Grafana interprets input strings without timezone information. It defaults to the browser timezone.
+    - The **Timezone** option determines how Grafana interprets input strings without timezone information. If unset, Grafana uses your configured default timezone, which defaults to the browser timezone.
   - **Boolean** - will make the values booleans
   - **Enum** - will make the values enums
     - Will show a table to manage the enums

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -2333,6 +2333,11 @@
       "count": 1
     }
   },
+  "public/app/features/transformers/editors/ConvertFieldTypeTransformerEditor.tsx": {
+    "@typescript-eslint/consistent-type-assertions": {
+      "count": 1
+    }
+  },
   "public/app/features/transformers/editors/FilterByNameTransformerEditor.tsx": {
     "react-prefer-function-component/react-prefer-function-component": {
       "count": 1

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -2333,11 +2333,6 @@
       "count": 1
     }
   },
-  "public/app/features/transformers/editors/ConvertFieldTypeTransformerEditor.tsx": {
-    "@typescript-eslint/consistent-type-assertions": {
-      "count": 1
-    }
-  },
   "public/app/features/transformers/editors/FilterByNameTransformerEditor.tsx": {
     "react-prefer-function-component/react-prefer-function-component": {
       "count": 1

--- a/packages/grafana-data/src/transformations/transformers/convertFieldType.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/convertFieldType.test.ts
@@ -60,6 +60,26 @@ describe('field convert type', () => {
     });
   });
 
+  it.each([
+    ['utc', Date.UTC(2024, 0, 1)],
+    ['Asia/Kolkata', Date.UTC(2023, 11, 31, 18, 30)],
+  ])('will parse string time in the specified timezone', (timezone, expected) => {
+    const field: Field = {
+      name: 'date',
+      type: FieldType.string,
+      values: ['2024-01-01 00:00:00'],
+      config: {},
+    };
+
+    const result = convertFieldType(field, {
+      destinationType: FieldType.time,
+      dateFormat: 'YYYY-MM-DD HH:mm:ss',
+      timezone,
+    });
+
+    expect(result.values).toEqual([expected]);
+  });
+
   it('will not parse improperly formatted date strings', () => {
     const options = { targetField: 'misformatted dates', destinationType: FieldType.time };
 

--- a/packages/grafana-data/src/transformations/transformers/convertFieldType.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/convertFieldType.test.ts
@@ -61,9 +61,10 @@ describe('field convert type', () => {
   });
 
   it.each([
-    ['utc', Date.UTC(2024, 0, 1)],
-    ['Asia/Kolkata', Date.UTC(2023, 11, 31, 18, 30)],
-  ])('will parse string time in the specified timezone', (timezone, expected) => {
+    ['utc', 'YYYY-MM-DD HH:mm:ss', Date.UTC(2024, 0, 1)],
+    ['Asia/Kolkata', 'YYYY-MM-DD HH:mm:ss', Date.UTC(2023, 11, 31, 18, 30)],
+    ['utc', '', Date.UTC(2024, 0, 1)],
+  ])('will parse string time in the specified timezone', (timezone, dateFormat, expected) => {
     const field: Field = {
       name: 'date',
       type: FieldType.string,
@@ -73,7 +74,7 @@ describe('field convert type', () => {
 
     const result = convertFieldType(field, {
       destinationType: FieldType.time,
-      dateFormat: 'YYYY-MM-DD HH:mm:ss',
+      dateFormat,
       timezone,
     });
 

--- a/packages/grafana-data/src/transformations/transformers/convertFieldType.ts
+++ b/packages/grafana-data/src/transformations/transformers/convertFieldType.ts
@@ -103,7 +103,7 @@ export function convertFieldTypes(options: ConvertFieldTypeTransformerOptions, f
 export function convertFieldType(field: Field, opts: ConvertFieldTypeOptions): Field {
   switch (opts.destinationType) {
     case FieldType.time:
-      return ensureTimeField(field, opts.dateFormat, opts.timezone);
+      return ensureTimeFieldWithTimeZone(field, opts.dateFormat, opts.timezone);
     case FieldType.number:
       return fieldToNumberField(field);
     case FieldType.string:
@@ -260,12 +260,15 @@ function fieldToComplexField(field: Field): Field {
  * Checks the first value. Assumes any number should be time fieldtype. Otherwise attempts to make the fieldtype time.
  * @param field - field to ensure is a time fieldtype
  * @param dateFormat - date format used to parse a string datetime
- * @param timeZone - timezone used to parse a string datetime
  * @returns field as time
  *
  * @public
  */
-export function ensureTimeField(field: Field, dateFormat?: string, timeZone?: TimeZone): Field {
+export function ensureTimeField(field: Field, dateFormat?: string): Field {
+  return ensureTimeFieldWithTimeZone(field, dateFormat);
+}
+
+function ensureTimeFieldWithTimeZone(field: Field, dateFormat?: string, timeZone?: TimeZone): Field {
   const firstValueTypeIsNumber = typeof field.values[0] === 'number';
   // if the format is unix seconds, we don't want to skip formatting
   const isUnixSecondsFormat = dateFormat === 'X';

--- a/packages/grafana-data/src/transformations/transformers/convertFieldType.ts
+++ b/packages/grafana-data/src/transformations/transformers/convertFieldType.ts
@@ -125,8 +125,12 @@ const iso8601Regex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3,})?(?:Z|[-+]
 /**
  * @internal
  */
-export function fieldToTimeField(field: Field, dateFormat?: string, timeZone?: TimeZone): Field {
-  const opts = dateFormat || timeZone ? { format: dateFormat, timeZone } : undefined;
+export function fieldToTimeField(field: Field, dateFormat?: string): Field {
+  return fieldToTimeFieldWithTimeZone(field, dateFormat);
+}
+
+function fieldToTimeFieldWithTimeZone(field: Field, dateFormat?: string, timeZone?: TimeZone): Field {
+  const opts = dateFormat || timeZone ? { format: dateFormat || undefined, timeZone } : undefined;
 
   const timeValues = field.values.slice();
 
@@ -282,7 +286,7 @@ function ensureTimeFieldWithTimeZone(field: Field, dateFormat?: string, timeZone
       type: FieldType.time, //assumes it should be time
     };
   }
-  return fieldToTimeField(field, dateFormat, timeZone);
+  return fieldToTimeFieldWithTimeZone(field, dateFormat, timeZone);
 }
 
 function fieldToEnumField(field: Field, config?: EnumFieldConfig): Field {

--- a/packages/grafana-data/src/transformations/transformers/convertFieldType.ts
+++ b/packages/grafana-data/src/transformations/transformers/convertFieldType.ts
@@ -32,7 +32,7 @@ export interface ConvertFieldTypeOptions {
    */
   joinWith?: string;
   /**
-   * When converting a date to a string an option timezone.
+   * The timezone used when parsing or formatting a date.
    */
   timezone?: TimeZone;
   /**
@@ -103,7 +103,7 @@ export function convertFieldTypes(options: ConvertFieldTypeTransformerOptions, f
 export function convertFieldType(field: Field, opts: ConvertFieldTypeOptions): Field {
   switch (opts.destinationType) {
     case FieldType.time:
-      return ensureTimeField(field, opts.dateFormat);
+      return ensureTimeField(field, opts.dateFormat, opts.timezone);
     case FieldType.number:
       return fieldToNumberField(field);
     case FieldType.string:
@@ -125,8 +125,8 @@ const iso8601Regex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3,})?(?:Z|[-+]
 /**
  * @internal
  */
-export function fieldToTimeField(field: Field, dateFormat?: string): Field {
-  let opts = dateFormat ? { format: dateFormat } : undefined;
+export function fieldToTimeField(field: Field, dateFormat?: string, timeZone?: TimeZone): Field {
+  const opts = dateFormat || timeZone ? { format: dateFormat, timeZone } : undefined;
 
   const timeValues = field.values.slice();
 
@@ -260,11 +260,12 @@ function fieldToComplexField(field: Field): Field {
  * Checks the first value. Assumes any number should be time fieldtype. Otherwise attempts to make the fieldtype time.
  * @param field - field to ensure is a time fieldtype
  * @param dateFormat - date format used to parse a string datetime
+ * @param timeZone - timezone used to parse a string datetime
  * @returns field as time
  *
  * @public
  */
-export function ensureTimeField(field: Field, dateFormat?: string): Field {
+export function ensureTimeField(field: Field, dateFormat?: string, timeZone?: TimeZone): Field {
   const firstValueTypeIsNumber = typeof field.values[0] === 'number';
   // if the format is unix seconds, we don't want to skip formatting
   const isUnixSecondsFormat = dateFormat === 'X';
@@ -278,7 +279,7 @@ export function ensureTimeField(field: Field, dateFormat?: string): Field {
       type: FieldType.time, //assumes it should be time
     };
   }
-  return fieldToTimeField(field, dateFormat);
+  return fieldToTimeField(field, dateFormat, timeZone);
 }
 
 function fieldToEnumField(field: Field, config?: EnumFieldConfig): Field {

--- a/public/app/features/transformers/docs/content.ts
+++ b/public/app/features/transformers/docs/content.ts
@@ -203,6 +203,7 @@ This transformation has the following options:
     - It will parse the numeric input as a Unix epoch timestamp in milliseconds.
       You must multiply your input by 1000 if it's in seconds.
     - Will show an option to specify a DateFormat as input by a string like yyyy-mm-dd or DD MM YYYY hh:mm:ss
+    - The **Timezone** option determines how Grafana interprets input strings without timezone information. If not set, Grafana uses the browser timezone or your configured default timezone.
   - **Boolean** - will make the values booleans
   - **Enum** - will make the values enums
     - Will show a table to manage the enums

--- a/public/app/features/transformers/editors/ConvertFieldTypeTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/ConvertFieldTypeTransformerEditor.tsx
@@ -1,13 +1,6 @@
 import { type ChangeEvent, useCallback } from 'react';
 
-import {
-  type FieldNamePickerConfigSettings,
-  FieldType,
-  type SelectableValue,
-  type StandardEditorsRegistryItem,
-  type TransformerUIProps,
-  getTimeZones,
-} from '@grafana/data';
+import { FieldType, type SelectableValue, type TransformerUIProps, getTimeZones } from '@grafana/data';
 import { type ConvertFieldTypeOptions, type ConvertFieldTypeTransformerOptions } from '@grafana/data/internal';
 import { t, Trans } from '@grafana/i18n';
 import { Button, InlineField, InlineFieldRow, Input, Select } from '@grafana/ui';
@@ -19,8 +12,11 @@ import { getTimezoneOptions } from '../utils';
 import { EnumMappingEditor } from './EnumMappingEditor';
 
 const fieldNamePickerSettings = {
+  editor: FieldNamePicker,
+  id: '',
+  name: '',
   settings: { width: 24, isClearable: false },
-} as StandardEditorsRegistryItem<string, FieldNamePickerConfigSettings>;
+} as const;
 
 export const ConvertFieldTypeTransformerEditor = ({
   input,
@@ -137,6 +133,9 @@ export const ConvertFieldTypeTransformerEditor = ({
         // This ensures consistent UI across versions where arrays may be classified differently.
         const shouldRenderJoinWith =
           c.joinWith?.length || (targetField?.type && [FieldType.other, FieldType.string].includes(targetField.type));
+        const shouldRenderTimezone =
+          c.destinationType === FieldType.time ||
+          (c.destinationType === FieldType.string && targetField?.type === FieldType.time);
 
         return (
           <div key={`${c.targetField}-${idx}`}>
@@ -211,21 +210,20 @@ export const ConvertFieldTypeTransformerEditor = ({
                           width={24}
                         />
                       </InlineField>
-                      <InlineField
-                        label={t(
-                          'transformers.convert-field-type-transformer-editor.label-set-timezone',
-                          'Set timezone'
-                        )}
-                        tooltip={t(
-                          'transformers.convert-field-type-transformer-editor.tooltip-timezone-manually',
-                          'Set the timezone of the date manually'
-                        )}
-                      >
-                        <Select options={timeZoneOptions} value={c.timezone} onChange={onTzChange(idx)} isClearable />
-                      </InlineField>
                     </>
                   )}
                 </>
+              )}
+              {shouldRenderTimezone && (
+                <InlineField
+                  label={t('transformers.convert-field-type-transformer-editor.label-set-timezone', 'Set timezone')}
+                  tooltip={t(
+                    'transformers.convert-field-type-transformer-editor.tooltip-timezone-manually',
+                    'Set the timezone of the date manually'
+                  )}
+                >
+                  <Select options={timeZoneOptions} value={c.timezone} onChange={onTzChange(idx)} isClearable />
+                </InlineField>
               )}
               <Button
                 size="md"

--- a/public/app/features/transformers/editors/ConvertFieldTypeTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/ConvertFieldTypeTransformerEditor.tsx
@@ -1,6 +1,12 @@
 import { type ChangeEvent, useCallback } from 'react';
 
-import { FieldType, type SelectableValue, type TransformerUIProps, getTimeZones } from '@grafana/data';
+import {
+  type FieldNamePickerConfigSettings,
+  FieldType,
+  type SelectableValue,
+  type StandardEditorsRegistryItem,
+  type TransformerUIProps,
+} from '@grafana/data';
 import { type ConvertFieldTypeOptions, type ConvertFieldTypeTransformerOptions } from '@grafana/data/internal';
 import { t, Trans } from '@grafana/i18n';
 import { Button, InlineField, InlineFieldRow, Input, Select } from '@grafana/ui';
@@ -12,11 +18,8 @@ import { getTimezoneOptions } from '../utils';
 import { EnumMappingEditor } from './EnumMappingEditor';
 
 const fieldNamePickerSettings = {
-  editor: FieldNamePicker,
-  id: '',
-  name: '',
   settings: { width: 24, isClearable: false },
-} as const;
+} as StandardEditorsRegistryItem<string, FieldNamePickerConfigSettings>;
 
 export const ConvertFieldTypeTransformerEditor = ({
   input,
@@ -25,20 +28,6 @@ export const ConvertFieldTypeTransformerEditor = ({
 }: TransformerUIProps<ConvertFieldTypeTransformerOptions>) => {
   const allTypes = getAllFieldTypeIconOptions().filter((v) => v.value !== FieldType.trace);
   const timeZoneOptions: Array<SelectableValue<string>> = getTimezoneOptions(true);
-
-  // Format timezone options
-  const tzs = getTimeZones();
-  timeZoneOptions.push({
-    label: t('transformers.convert-field-type-transformer-editor.label.browser', 'Browser'),
-    value: 'browser',
-  });
-  timeZoneOptions.push({
-    label: t('transformers.convert-field-type-transformer-editor.label.utc', 'UTC'),
-    value: 'utc',
-  });
-  for (const tz of tzs) {
-    timeZoneOptions.push({ label: tz, value: tz });
-  }
 
   const onSelectField = useCallback(
     (idx: number) => (value: string | undefined) => {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -15942,10 +15942,6 @@
       "description": {
         "convert-to-specified-field-type": "Convert a field to a specified field type."
       },
-      "label": {
-        "browser": "Browser",
-        "utc": "UTC"
-      },
       "label-as": "as",
       "label-date-format": "Date format",
       "label-field": "Field",


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This adds a timezone selector when using the Convert field type transformation to convert a field to Time. The selected timezone is used when parsing timezone-less date strings. If no timezone is selected, the existing browser-timezone behavior is preserved.

**Why do we need this feature?**

Convert field type currently parses timezone-less date strings using the browser timezone, even when the dates represent another timezone.

For example, in an IST browser, `2024-01-01 00:00:00` is converted to `2023-12-31 18:30:00 UTC`. A later UTC formatting transformation therefore displays `Dec` instead of `Jan`.

**Who is this feature for?**

Users who convert timezone-less date strings to Time, particularly when their browser, dashboard, and source-data timezones differ.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #90727 

**Special notes for your reviewer:**

The existing timezone option is reused, so this does not introduce a new transformation configuration field. Leaving the timezone unset preserves the previous behavior. The regression test covers parsing the same timezone-less value as UTC and Asia/Kolkata.

Manual verification using an IST browser and UTC output:
- Before: `Dec, Jan, Feb, Mar`
- With the input timezone set to UTC: `Jan, Feb, Mar, Apr`

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
