### PR TITLE
infra/nats: bind to RANDOM_PORT in tests

### DIFF
--- a/pkg/infra/nats/helpers_test.go
+++ b/pkg/infra/nats/helpers_test.go
@@ -2,7 +2,6 @@ package nats
 
 import (
 	"context"
-	"net"
 	"testing"
 	"time"
 
@@ -100,13 +99,4 @@ func startService(t *testing.T, ctx context.Context, svc services.Service) {
 		svc.StopAsync()
 		_ = svc.AwaitTerminated(context.Background())
 	})
-}
-
-func freePort(t *testing.T) int {
-	t.Helper()
-	l, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	port := l.Addr().(*net.TCPAddr).Port
-	require.NoError(t, l.Close())
-	return port
 }

--- a/pkg/infra/nats/integration_test.go
+++ b/pkg/infra/nats/integration_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	natsserver "github.com/nats-io/nats-server/v2/server"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
@@ -279,12 +280,10 @@ func startEmbeddedStack(t *testing.T) (context.Context, *Server, *PublisherServi
 		Enabled:       true,
 		Mode:          setting.NATSModeEmbedded,
 		ListenAddress: "127.0.0.1",
-		// Bind free ports rather than the conventional 4222/6222 so parallel or
-		// repeated runs — and a dev Grafana already holding 4222 — don't collide;
-		// clients connect via the server's actual ClientURL. A zero ClusterPort
-		// leaves ClusterAddr() nil, which routeURLForServer dereferences.
-		ClientPort:  freePort(t),
-		ClusterPort: freePort(t),
+		// Let NATS bind ephemeral ports atomically so parallel or repeated runs —
+		// and a dev Grafana already holding 4222 — don't collide.
+		ClientPort:  natsserver.RANDOM_PORT,
+		ClusterPort: natsserver.RANDOM_PORT,
 	}
 
 	server, err := ProvideServer(cfg, nil, prometheus.NewRegistry())


### PR DESCRIPTION
Delegates the responsibility of binding to a random port to a buil-in option in NATS[^1] instead of the previous, racy approach.

CI flake: https://github.com/grafana/grafana-enterprise/actions/runs/29409401642/job/87332666562

[^1]: https://beta-docs.nats.io/reference/config/port