### PR TITLE
Docs: Saved queries GA docs

### DIFF
--- a/docs/sources/as-code/infrastructure-as-code/terraform/_index.md
+++ b/docs/sources/as-code/infrastructure-as-code/terraform/_index.md
@@ -24,3 +24,4 @@ The following guides help you get started using Terraform to manage your Grafana
 - [Manage Cloud Provider Observability in Grafana Cloud using Terraform](terraform-cloud-provider-o11y/): Learn how to manage Amazon CloudWatch and Microsoft Azure resources in Cloud Provider Observability using Terraform.
 - [Manage Knowledge Graph in Grafana Cloud using Terraform](terraform-knowledge-graph/): Learn how to create and manage notification alerts, suppressed assertions, custom model rules, log, trace, and profile configurations, threshold configurations, and Prometheus rules in Grafana Cloud Knowledge Graph using Terraform.
 - [Install plugins in Grafana Cloud using Terraform](terraform-plugins): Learn how to install plugins in Grafana Cloud using Terraform.
+- [Manage saved queries using Terraform](manage-saved-queries/): Learn how to create and import saved queries, also known as the query library, using Terraform.

--- a/docs/sources/as-code/infrastructure-as-code/terraform/manage-saved-queries.md
+++ b/docs/sources/as-code/infrastructure-as-code/terraform/manage-saved-queries.md
@@ -1,0 +1,119 @@
+---
+description: Learn how to manage saved queries using the Grafana Terraform provider
+keywords:
+  - Infrastructure as Code
+  - Quickstart
+  - Grafana Cloud
+  - Terraform
+  - Saved queries
+  - Query library
+labels:
+  products:
+    - cloud
+    - enterprise
+title: Manage saved queries using Terraform
+menuTitle: Manage saved queries
+weight: 400
+canonical: https://grafana.com/docs/grafana/latest/as-code/infrastructure-as-code/terraform/manage-saved-queries/
+---
+
+# Manage saved queries using Terraform
+
+This guide shows you how to manage [saved queries](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/panels-visualizations/query-transform-data/#saved-queries), also known as the query library, using the [Grafana Terraform provider](https://registry.terraform.io/providers/grafana/grafana/latest/docs). Managing saved queries as code lets you version-control your query library and keep it consistent across Grafana instances.
+
+{{< admonition type="note" >}}
+Saved queries are only available on Grafana Enterprise and Grafana Cloud.
+{{< /admonition >}}
+
+## Before you begin
+
+Before you begin, ensure you have the following:
+
+- A Grafana Enterprise or Grafana Cloud instance. For more information on setting up a Grafana Cloud account, refer to [Get started](https://grafana.com/docs/grafana-cloud/get-started/).
+- Terraform installed on your machine. For more information on how to install Terraform, refer to the [Terraform install documentation](https://developer.hashicorp.com/terraform/install).
+- A service account token with the **Writer** role for saved queries. For more information, refer to [Roles, permissions, and RBAC](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/panels-visualizations/query-transform-data/#roles-permissions-and-rbac) and [Service account tokens](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/service-accounts/#service-account-tokens).
+
+## Configure the Grafana provider
+
+Create a file named `main.tf` and add the following to set up the [Grafana provider](https://registry.terraform.io/providers/grafana/grafana/latest/docs) with the authentication required to manage saved queries:
+
+```terraform
+terraform {
+  required_providers {
+    grafana = {
+      source  = "grafana/grafana"
+      version = ">= 4.6.0"
+    }
+  }
+}
+
+provider "grafana" {
+  url  = "<Grafana-URL>"
+  auth = "<Service-account-token>"
+}
+```
+
+Replace the following field values:
+
+- `Grafana-URL` with the URL of your Grafana instance, for example `https://my-stack.grafana.net/`
+- `Service-account-token` with the service account token that you created
+
+## Create a saved query resource
+
+Create a file named `saved-queries.tf` and add the following:
+
+```terraform
+resource "grafana_apps_queries_query_v1" "example" {
+  metadata {
+    uid = "example-saved-query"
+  }
+
+  spec {
+    title       = "Requests per second"
+    description = "Prometheus rate of HTTP requests"
+    is_visible  = true
+    tags        = ["http", "prometheus"]
+
+    targets {
+      properties_json = jsonencode({
+        refId = "A"
+        expr  = "rate(http_requests_total[$__rate_interval])"
+        datasource = {
+          type = "prometheus"
+          uid  = "my-prometheus-uid"
+        }
+      })
+    }
+  }
+}
+```
+
+Because the shape of a data source query depends on the data source, the query stored in each target (`properties_json`), a target's variable replacements (`variables_json`), and a variable's value list (`value_list_definition_json`) are passed as raw JSON strings. Use `jsonencode()` to construct them.
+
+The `spec` block supports the following fields:
+
+| Field         | Description                                                                                                     |
+| ------------- | --------------------------------------------------------------------------------------------------------------- |
+| `title`       | The display name of the saved query. Required.                                                                  |
+| `description` | A longer description of the saved query.                                                                        |
+| `is_visible`  | Whether the saved query is visible in the query library.                                                        |
+| `is_locked`   | Whether the saved query is locked and can't be edited in the UI. This is for UI display only, not for security. |
+| `tags`        | The tags used to filter the saved query.                                                                        |
+| `targets`     | The query targets that make up the saved query. At least one target is required.                                |
+| `vars`        | The template variables that can be interpolated into the query targets.                                         |
+
+For the complete schema, refer to the [`grafana_apps_queries_query_v1` resource documentation](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/apps_queries_query_v1).
+
+## Import an existing saved query
+
+To bring an existing saved query under Terraform management, import it using its UID:
+
+```shell
+terraform import grafana_apps_queries_query_v1.example example-saved-query
+```
+
+## Summary
+
+In this guide, you learned how to create and import saved queries using Terraform.
+
+To learn more about saved queries, refer to [Saved queries](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/panels-visualizations/query-transform-data/#saved-queries).

--- a/docs/sources/visualizations/dashboards/build-dashboards/annotate-visualizations/index.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/annotate-visualizations/index.md
@@ -171,6 +171,7 @@ Learn more about saved queries:
 - [Saved queries dialog box](#saved-queries-dialog-box)
 - [Roles, permission, and RBAC](#roles-permissions-and-rbac)
 - [Variables in saved queries](#variables-in-saved-queries)
+- [Manage saved queries as code](#manage-saved-queries-as-code)
 - [Known limitations](#known-limitations)
 
 #### Saved queries dialog box
@@ -233,6 +234,11 @@ You can map the original variables to either:
 
 Grafana applies your selections to the query before inserting it into the dashboard.
 However, the substitutions only apply to the query when it's reused, and the original saved query remains unchanged.
+
+#### Manage saved queries as code
+
+You can manage saved queries as code with the Grafana Terraform provider, which lets you version-control your query library and keep it consistent across instances.
+For more information, refer to [Manage saved queries using Terraform](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/infrastructure-as-code/terraform/manage-saved-queries/).
 
 #### Known limitations
 

--- a/docs/sources/visualizations/dashboards/build-dashboards/annotate-visualizations/index.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/annotate-visualizations/index.md
@@ -5,10 +5,15 @@ aliases:
   - ../../../panels/visualizations/annotations/ # /docs/grafana/next/panels/visualizations/annotations/
   - ../../../reference/annotations/ # /docs/grafana/latest/reference/annotations/
 keywords:
-  - grafana
+keywords:
   - annotations
-  - documentation
-  - guide
+  - annotation query
+  - built-in query
+  - region annotation
+  - time regions
+  - tags
+  - dashboard
+  - saved queries
 labels:
   products:
     - cloud

--- a/docs/sources/visualizations/dashboards/build-dashboards/annotate-visualizations/index.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/annotate-visualizations/index.md
@@ -131,7 +131,7 @@ To add an annotation query to a dashboard, follow these steps:
    - Click **Use saved query** to open the **Saved queries** drawer. Choose a [saved query](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/panels-visualizations/query-transform-data/#saved-queries) to reuse, click **Select query**, and proceed to step 13.
 
    {{< admonition type="note" >}}
-   [Saved queries](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/panels-visualizations/query-transform-data/#saved-queries) is currently in [public preview](https://grafana.com/docs/release-life-cycle/) in Grafana Enterprise and Grafana Cloud only.
+   [Saved queries](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/panels-visualizations/query-transform-data/#saved-queries) is only available on Grafana Enterprise and Grafana Cloud.
    {{< /admonition >}}
 
 1. (Optional) Click **Test annotation query** to ensure that the query is working properly.

--- a/docs/sources/visualizations/dashboards/build-dashboards/annotate-visualizations/index.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/annotate-visualizations/index.md
@@ -183,6 +183,11 @@ To access saved queries, click **Use saved query** in the annotations configurat
 
 {{< figure src="/media/docs/grafana/dashboards/screenshot-annotation-saved-query-v13.2.png" max-width="450px" alt="Access saved queries" >}}
 
+{{< admonition type="note" >}}
+To review your saved queries, press `Ctrl + K` or `Cmd + K` to open the command palette and search "Saved queries".
+From this view, you can also select a query to open in Explore.
+{{< /admonition >}}
+
 From the **Saved queries** dialog box, you can:
 
 - Search for queries by data source name, query content, title, or description.

--- a/docs/sources/visualizations/dashboards/build-dashboards/annotate-visualizations/index.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/annotate-visualizations/index.md
@@ -5,7 +5,6 @@ aliases:
   - ../../../panels/visualizations/annotations/ # /docs/grafana/next/panels/visualizations/annotations/
   - ../../../reference/annotations/ # /docs/grafana/latest/reference/annotations/
 keywords:
-keywords:
   - annotations
   - annotation query
   - built-in query

--- a/docs/sources/visualizations/dashboards/build-dashboards/annotate-visualizations/index.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/annotate-visualizations/index.md
@@ -150,6 +150,90 @@ To add an annotation query to a dashboard, follow these steps:
 
 {{< /docs/list >}}
 
+### Saved queries
+
+{{< admonition type="note" >}}
+Saved queries is only available on Grafana Enterprise and Grafana Cloud.
+{{< /admonition >}}
+
+You can reuse queries you and others in your organization have saved in annotations.
+This helps users across your organization create annotations without having to create their own queries or know a query language.
+It also helps you avoid having several users build the same queries for the same data sources multiple times.
+
+Saved queries are supported in:
+
+- [Dashboards](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/build-dashboards/create-dashboard/#create-a-dashboard)
+- [Explore](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/explore/query-editor/)
+- [Annotations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/build-dashboards/annotate-visualizations/#add-new-annotation-queries)
+
+Learn more about saved queries:
+
+- [Saved queries dialog box](#saved-queries-dialog-box)
+- [Roles, permission, and RBAC](#roles-permissions-and-rbac)
+- [Variables in saved queries](#variables-in-saved-queries)
+- [Known limitations](#known-limitations)
+
+#### Saved queries dialog box
+
+The **Saved queries** dialog box gives you access to all the saved queries in your organization:
+
+{{< figure src="/media/docs/grafana/dashboards/screenshot-saved-queries-v13.0.png" max-width="750px" alt="List of saved queries" >}}
+
+To access saved queries, click **Use saved query** in the annotations configuration.
+
+{{< figure src="/media/docs/grafana/dashboards/screenshot-annotation-saved-query-v13.2.png" max-width="450px" alt="Access saved queries" >}}
+
+From the **Saved queries** dialog box, you can:
+
+- Search for queries by data source name, query content, title, or description.
+- Sort queries alphabetically or by creation date.
+- Filter by data source name, author name, and tags. The tag filter uses the `OR` operator, while the others use the `AND` operator. Use the **Remember filters** switch to persist your filter selections across sessions in your local storage.
+- Star queries so that they appear in the **Starred queries** filter view.
+- Duplicate or delete a saved query.
+- Edit a query title, description, or tags.
+
+You can apply all the same search, filter, and sort options in the **Starred queries** filter view.
+
+{{< admonition type="tip">}}
+When you select a query with a Loki, Mimir, Tempo, or Pyroscope data source, the **Saved queries** dialog box displays a **Drilldown** button.
+Click the button to open the associated Drilldown app, while maintaining the context of the query.
+Learn more about these apps in the [Drilldown documentation](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/simplified-exploration/).
+{{< /admonition >}}
+
+#### Roles, permissions, and RBAC
+
+Saved queries support role-based access controls.
+By default, saved queries have two RBAC roles:
+
+- **Writer**: Create, update, and delete all saved queries.
+- **Reader**: Reuse saved queries.
+
+If you used saved queries prior to the addition of RBAC support in Grafana v12.4, Grafana user roles are mapped as follows:
+
+- Admin > Writer
+- Editor > Writer
+- Viewer > Reader
+
+#### Variables in saved queries
+
+If a saved query includes variables, you can substitute the variables in the query without modifying it.
+This is useful in environments where variable names or available values differ between dashboards.
+
+You can map the original variables to either:
+
+- A variable in your dashboard
+- A custom value that you enter
+
+{{< figure src="/media/docs/grafana/panels-visualizations/screenshot-saved-query-variable-v13.0.png" max-width="450px" alt="A saved query with substituted variables" >}}
+
+Grafana applies your selections to the query before inserting it into the dashboard.
+However, the substitutions only apply to the query when it's reused, and the original saved query remains unchanged.
+
+#### Known limitations
+
+- No validation is performed when you save a query, so it's possible to save an invalid query. You should confirm the query is working properly before you save it.
+- You can save a maximum of 1000 queries.
+
 ## Built-in query
 
 After you add an annotation, they are still visible. This is due to the built-in annotation query that exists on all dashboards. This annotation query fetches all annotation events that originate from the current dashboard, which are stored in Grafana, and show them on the panel where they were created. This includes alert state history annotations.

--- a/docs/sources/visualizations/dashboards/build-dashboards/annotate-visualizations/index.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/annotate-visualizations/index.md
@@ -168,7 +168,7 @@ Saved queries are supported in:
 Learn more about saved queries:
 
 - [Saved queries dialog box](#saved-queries-dialog-box)
-- [Roles, permission, and RBAC](#roles-permissions-and-rbac)
+- [Roles, permissions, and RBAC](#roles-permissions-and-rbac)
 - [Variables in saved queries](#variables-in-saved-queries)
 - [Manage saved queries as code](#manage-saved-queries-as-code)
 - [Known limitations](#known-limitations)

--- a/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/_index.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/_index.md
@@ -5,10 +5,14 @@ aliases:
   - ../../../dashboards/build-dashboards/create-dynamic-dashboard/ # /docs/grafana/latest/dashboards/build-dashboards/create-dynamic-dashboard/
   - ./create-dynamic-dashboard/ # /docs/grafana/latest/visualizations/dashboards/build-dashboards/create-dynamic-dashboard/
 keywords:
-  - panel
   - dashboard
-  - create
-  - dynamic dashboard
+  - panel
+  - edit mode
+  - sidebar
+  - content outline
+  - layout
+  - repeat
+  - show/hide rules
 labels:
   products:
     - cloud

--- a/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/_index.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/_index.md
@@ -101,7 +101,7 @@ To create a dashboard, follow these steps:
      Then, go to step 12.
 
    {{< admonition type="note" >}}
-   [Saved queries](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/panels-visualizations/query-transform-data/#saved-queries) is currently in [public preview](https://grafana.com/docs/release-life-cycle/) in Grafana Enterprise and Grafana Cloud only.
+   [Saved queries](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/panels-visualizations/query-transform-data/#saved-queries) is only available on Grafana Enterprise and Grafana Cloud.
    {{< /admonition >}}
 
 1. If you want to change the panel data source, in the **Queries** tab, click the **Data source** drop-down list and do one of the following:

--- a/docs/sources/visualizations/explore/get-started-with-explore.md
+++ b/docs/sources/visualizations/explore/get-started-with-explore.md
@@ -3,8 +3,12 @@ aliases:
   - ../../explore/get-started-with-explore/ # /docs/grafana/next/explore/get-started-with-explore/
 keywords:
   - explore
-  - loki
-  - logs
+  - query editor
+  - split view
+  - time picker
+  - mixed data source
+  - saved queries
+  - share
 labels:
   products:
     - cloud

--- a/docs/sources/visualizations/explore/get-started-with-explore.md
+++ b/docs/sources/visualizations/explore/get-started-with-explore.md
@@ -26,7 +26,7 @@ refs:
       destination: /docs/grafana/<GRAFANA_VERSION>/visualizations/panels-visualizations/query-transform-data/#save-a-query
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/visualizations/panels-visualizations/query-transform-data/#save-a-query
-weight: 5
+weight: 1
 ---
 
 # Get started with Explore

--- a/docs/sources/visualizations/explore/get-started-with-explore.md
+++ b/docs/sources/visualizations/explore/get-started-with-explore.md
@@ -65,28 +65,84 @@ Refer to [Role-based access control (RBAC)](https://grafana.com/docs/grafana/<GR
 
 Explore consists of a toolbar, outline, query editor, the ability to add multiple queries, a query history and a query inspector.
 
-- **Outline** - Keeps track of the queries and visualization panels created in Explore. Refer to [Content outline](#content-outline) for more detail.
+### Content outline
 
-- **Toolbar** - Provides quick access to frequently used tools and settings.
-  - **Data source picker** - Select a data source from the dropdown menu, or use absolute time.
-  - **Split** - Click to compare visualizations side by side. Refer to [Split and compare](#split-and-compare) for additional detail.
-  - **Add** - Click to add your exploration to a dashboard. You can also use this to declare an incident,create a forecast, detect outliers and to run an investigation.
-  - **Time picker** - Select a time range form the time picker. You can also enter an absolute time range. Refer to [Time picker](#time-picker) for more information.
-  - **Run query** - Click to run your query.
+The content outline is a side navigation bar that keeps track of the queries and visualizations you create in Explore.
+The outline helps you quickly navigate between queries and visualizations.
+It works in a split view, with a separate outline generated for each pane.
 
-- **Query editor** - Interface where you construct the query for a specific data source. Query editor elements differ based on data source. In order to run queries across multiple data sources you need to select **Mixed** from the data source picker.
+To open the content outline, click the Outline button in the top left corner of the Explore screen.
+
+You can then click on any panel icon in the content outline to navigate to that panel.
+
+### Toolbar
+
+The toolbar provides quick access to frequently used tools and settings.
+  
+- **Data source picker** - Select a data source from the dropdown menu, or use absolute time.
+- **Split** - Click to compare visualizations side by side. Refer to [Split and compare](#split-and-compare) for additional detail.
+- **Add** - Click to add your exploration to a dashboard. You can also use this to declare an incident,create a forecast, detect outliers and to run an investigation.
+- **Time picker** - Select a time range form the time picker. You can also enter an absolute time range. Refer to [Time picker](#time-picker) for more information.
+- **Run query** - Click to run your query.
+
+#### Time picker
+
+Use the time picker to select a time range for your query. The default is **last hour**. You can select a different option from the dropdown or use an absolute time range. You can also change the timezone associated with the query, or use a fiscal year.
+
+1. Click **Change time settings** to change the timezone or apply a fiscal year.
+
+Refer to [Set dashboard time range](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/use-dashboards/#set-dashboard-time-range) for more information on absolute and relative time ranges. You can also [control the time range using a URL](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/use-dashboards/#control-the-time-range-using-a-url).
+
+#### Split and compare
+
+The split view enables easy side-by-side comparison of visualizations or simultaneous viewing of related data on a single page.
+
+To open the split view:
+
+1. Click the split button to duplicate the current query and split the page into two side-by-side queries.
+1. Run and re-run queries as often as needed.
+
+You can select a different data source, or different metrics and label filters for the new query, allowing you to compare the same query across two different servers or compare the staging environment with the production environment.
+
+{{< figure src="/media/docs/grafana/panels-visualizations/screenshot-explore-split-10.1.png" max-width= "950px" caption="Screenshot of Explore screen split" >}}
+
+You can also link the time pickers for both panels by clicking on one of the time-sync buttons attached to the time pickers. When linked, changing the time in one panel automatically updates the other, keeping the start and end times synchronized. This ensures that both split panels display data for the same time interval.
+
+Click **Close** to quit split view.
+
+### Query editor
+
+The query editor is the interface where you construct the query for a specific data source.
+Query editor elements differ based on data source.
+To run queries across multiple data sources you need to select **Mixed** from the data source picker.
+When you select Mixed, you can select a different data source for each new query that you add.
+
+You can also reuse previously created queries with the saved queries feature.
+
+#### Saved queries
+
+{{< admonition type="note" >}}
+[Saved queries](ref:saved-queries) is only available on Grafana Enterprise and Grafana Cloud.
+{{< /admonition >}}
+
   - **Saved queries**:
     - **Save query** - To [save the query](ref:save-query) for reuse, click the **Save query** button (or icon).
     - **Replace query** - Reuse a saved query.
   - **+ Add query** - Add an additional query.
   - **+ Add from saved queries** - Add an additional query by reusing a saved query.
 
-  {{< admonition type="note" >}}
-  [Saved queries](ref:saved-queries) is only available on Grafana Enterprise and Grafana Cloud.
-  {{< /admonition >}}
+### Query history
 
-- **Query history** - Query history contains the list of queries that you created in Explore. You can also add queries from the history to your saved queries. Refer to [Query history](/docs/grafana/<GRAFANA_VERSION>/explore/query-management/#query-history) for detailed information on working with your query history.
-- **Query inspector** - Provides detailed statistics regarding your query. Inspector functions as a kind of debugging tool that "inspects" your query. It provides query statistics under **Stats**, request response time under **Query**, data frame details under **{} JSON**, and the shape of your data under **Data**. Refer to [Query inspector in Explore](/docs/grafana/latest/explore/explore-inspector/) for additional information.
+The query history contains the list of queries that you created in Explore.
+You can also add queries from the history to your saved queries.
+Refer to [Query history](/docs/grafana/<GRAFANA_VERSION>/explore/query-management/#query-history) for detailed information on working with your query history.
+
+### Query inspector
+
+The query inspector provides detailed statistics regarding your query.
+Inspector functions as a kind of debugging tool that "inspects" your query.
+It provides query statistics under **Stats**, request response time under **Query**, data frame details under **{} JSON**, and the shape of your data under **Data**.
+Refer to [Query inspector in Explore](/docs/grafana/latest/explore/explore-inspector/) for additional information.
 
 ## Access Explore
 
@@ -107,47 +163,6 @@ Some query editors provide a **Kick start your query** option, which gives you a
 Based on specific data source, certain query editors allow you to select the label or labels to add to your query. Labels are fields that consist of key/value pairs representing information in the data. Some data sources allow for selecting fields.
 
 1. Click **Run query** in the upper right to run your query.
-
-## Content outline
-
-The content outline is a side navigation bar that keeps track of the queries and visualizations you created in Explore. It allows you to navigate between them quickly.
-
-The content outline works in a split view, with a separate outline generated for each pane.
-
-To open the content outline:
-
-1. Click the Outline button in the top left corner of the Explore screen.
-
-You can then click on any panel icon in the content outline to navigate to that panel.
-
-## Split and compare
-
-The split view enables easy side-by-side comparison of visualizations or simultaneous viewing of related data on a single page.
-
-To open the split view:
-
-1. Click the split button to duplicate the current query and split the page into two side-by-side queries.
-1. Run and re-run queries as often as needed.
-
-You can select a different data source, or different metrics and label filters for the new query, allowing you to compare the same query across two different servers or compare the staging environment with the production environment.
-
-{{< figure src="/media/docs/grafana/panels-visualizations/screenshot-explore-split-10.1.png" max-width= "950px" caption="Screenshot of Explore screen split" >}}
-
-You can also link the time pickers for both panels by clicking on one of the time-sync buttons attached to the time pickers. When linked, changing the time in one panel automatically updates the other, keeping the start and end times synchronized. This ensures that both split panels display data for the same time interval.
-
-Click **Close** to quit split view.
-
-## Time picker
-
-Use the time picker to select a time range for your query. The default is **last hour**. You can select a different option from the dropdown or use an absolute time range. You can also change the timezone associated with the query, or use a fiscal year.
-
-1. Click **Change time settings** to change the timezone or apply a fiscal year.
-
-Refer to [Set dashboard time range](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/use-dashboards/#set-dashboard-time-range) for more information on absolute and relative time ranges. You can also [control the time range using a URL](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/use-dashboards/#control-the-time-range-using-a-url).
-
-## Mixed data source
-
-Select **Mixed** from the data source dropdown to run queries across multiple data sources in the same panel. When you select Mixed, you can select a different data source for each new query that you add.
 
 ## Share Explore URLs
 

--- a/docs/sources/visualizations/explore/get-started-with-explore.md
+++ b/docs/sources/visualizations/explore/get-started-with-explore.md
@@ -119,7 +119,7 @@ Refer to [Query history](/docs/grafana/<GRAFANA_VERSION>/explore/query-managemen
 The query inspector provides detailed statistics regarding your query.
 Inspector functions as a kind of debugging tool that "inspects" your query.
 It provides query statistics under **Stats**, request response time under **Query**, data frame details under **{} JSON**, and the shape of your data under **Data**.
-Refer to [Query inspector in Explore](/docs/grafana/latest/explore/explore-inspector/) for additional information.
+Refer to [Query inspector in Explore](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/explore/explore-inspector/) for additional information.
 
 ## Access Explore
 

--- a/docs/sources/visualizations/explore/get-started-with-explore.md
+++ b/docs/sources/visualizations/explore/get-started-with-explore.md
@@ -65,7 +65,7 @@ You can then click on any panel icon in the content outline to navigate to that 
 ### Toolbar
 
 The toolbar provides quick access to frequently used tools and settings.
-  
+
 - **Data source picker** - Select a data source from the dropdown menu, or use absolute time.
 - **Split** - Click to compare visualizations side by side. Refer to [Split and compare](#split-and-compare) for additional detail.
 - **Add** - Click to add your exploration to a dashboard. You can also use this to declare an incident,create a forecast, detect outliers and to run an investigation.

--- a/docs/sources/visualizations/explore/get-started-with-explore.md
+++ b/docs/sources/visualizations/explore/get-started-with-explore.md
@@ -78,7 +78,7 @@ Explore consists of a toolbar, outline, query editor, the ability to add multipl
   - **+ Add from saved queries** - Add an additional query by reusing a saved query.
 
   {{< admonition type="note" >}}
-  [Saved queries](ref:saved-queries) is currently in [public preview](https://grafana.com/docs/release-life-cycle/) in Grafana Enterprise and Grafana Cloud only.
+  [Saved queries](ref:saved-queries) is only available on Grafana Enterprise and Grafana Cloud.
   {{< /admonition >}}
 
 - **Query history** - Query history contains the list of queries that you created in Explore. You can also add queries from the history to your saved queries. Refer to [Query history](/docs/grafana/<GRAFANA_VERSION>/explore/query-management/#query-history) for detailed information on working with your query history.

--- a/docs/sources/visualizations/explore/get-started-with-explore.md
+++ b/docs/sources/visualizations/explore/get-started-with-explore.md
@@ -3,11 +3,9 @@ aliases:
   - ../../explore/get-started-with-explore/ # /docs/grafana/next/explore/get-started-with-explore/
 keywords:
   - explore
-  - query editor
   - split view
   - time picker
   - mixed data source
-  - saved queries
   - share
 labels:
   products:
@@ -15,17 +13,6 @@ labels:
     - enterprise
     - oss
 title: Get started with Explore
-refs:
-  saved-queries:
-    - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA_VERSION>/visualizations/panels-visualizations/query-transform-data/#saved-queries
-    - pattern: /docs/grafana-cloud/
-      destination: /docs/grafana-cloud/visualizations/panels-visualizations/query-transform-data/#saved-queries
-  save-query:
-    - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA_VERSION>/visualizations/panels-visualizations/query-transform-data/#save-a-query
-    - pattern: /docs/grafana-cloud/
-      destination: /docs/grafana-cloud/visualizations/panels-visualizations/query-transform-data/#save-a-query
 weight: 1
 ---
 
@@ -112,24 +99,14 @@ Click **Close** to quit split view.
 
 ### Query editor
 
-The query editor is the interface where you construct the query for a specific data source.
-Query editor elements differ based on data source.
+The query editor is the interface where you construct the query for a data source.
+Each data source's query editor provides a customized user interface that helps you write queries that take advantage of its unique capabilities.
 To run queries across multiple data sources you need to select **Mixed** from the data source picker.
-When you select Mixed, you can select a different data source for each new query that you add.
+When you select **Mixed**, you can select a different data source for each new query that you add.
 
 You can also reuse previously created queries with the saved queries feature.
 
-#### Saved queries
-
-{{< admonition type="note" >}}
-[Saved queries](ref:saved-queries) is only available on Grafana Enterprise and Grafana Cloud.
-{{< /admonition >}}
-
-  - **Saved queries**:
-    - **Save query** - To [save the query](ref:save-query) for reuse, click the **Save query** button (or icon).
-    - **Replace query** - Reuse a saved query.
-  - **+ Add query** - Add an additional query.
-  - **+ Add from saved queries** - Add an additional query by reusing a saved query.
+Refer to [Query editor in Explore](http://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/explore/query-editor/) for detailed information on the query editor.
 
 ### Query history
 

--- a/docs/sources/visualizations/explore/query-editor.md
+++ b/docs/sources/visualizations/explore/query-editor.md
@@ -75,6 +75,7 @@ Learn more about saved queries:
 - [Roles, permission, and RBAC](#roles-permissions-and-rbac)
 - [How to save a query](#save-a-query)
 - [Variables in saved queries](#variables-in-saved-queries)
+- [Manage saved queries as code](#manage-saved-queries-as-code)
 - [Known limitations](#known-limitations)
 
 ### Saved queries dialog box
@@ -146,6 +147,11 @@ This is useful in environments where variable names or available values differ b
 
 Grafana applies your selections to the query before inserting it into the dashboard.
 However, the substitutions only apply to the query when it's reused, and the original saved query remains unchanged.
+
+### Manage saved queries as code
+
+You can manage saved queries as code with the Grafana Terraform provider, which lets you version-control your query library and keep it consistent across instances.
+For more information, refer to [Manage saved queries using Terraform](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/infrastructure-as-code/terraform/manage-saved-queries/).
 
 ### Known limitations
 

--- a/docs/sources/visualizations/explore/query-editor.md
+++ b/docs/sources/visualizations/explore/query-editor.md
@@ -85,7 +85,7 @@ The **Saved queries** dialog box gives you access to all the saved queries in yo
 
 You can access saved queries three ways:
 
-- Press `Ctrl + K` or `Cmd + K` to open the command palette and search "Saved queries".
+- Press `Ctrl + K` or `Cmd + K` to open the command palette and search "Saved queries". The **Shared queries** dialog box opens, where you can select a query and then click **Open in Explore**.
 - Click **Saved queries > Replace query** in the query editor.
 - At the bottom of the query editor, click **Add from saved queries**.
 

--- a/docs/sources/visualizations/explore/query-editor.md
+++ b/docs/sources/visualizations/explore/query-editor.md
@@ -2,8 +2,8 @@
 keywords:
   - explore
   - query editor
-  - mixed data source
   - saved queries
+  - mixed data source
 labels:
   products:
     - cloud
@@ -11,92 +11,17 @@ labels:
     - oss
 title: Query editor in Explore
 weight: 5
-image_maps:
-  - key: query-editor
-    src: /media/docs/grafana/panels-visualizations/screenshot-query-editor-imagemap-v13.1.png
-    alt: An annotated image of the Grafana panel query editor
-    points:
-      - x_coord: 1
-        y_coord: 50
-        content: |
-          **Sidebar**
-
-          The sidebar displays queries, expressions, and transformations as color-coded cards with visual indicators for state, like error, hidden, and disabled, while a footer tracks your total item count.
-      - x_coord: 13
-        y_coord: 8
-        content: |
-          **Data/Alerts buttons**
-
-          Click the buttons to move between data pipeline and related alerts. In **Alerts**, you have the option to start creating a alert rule.
-      - x_coord: 24
-        y_coord: 8
-        content: |
-          **Stacked view icon**
-
-          The [stacked view](#navigate-the-query-editor) displays all of your queries, expressions, and transformations in a single list in the editor pane.
-      - x_coord: 18
-        y_coord: 94
-        content: |
-          **Multi-select**
-
-          Click **Select...** in the sidebar footer to enter multi-select mode, then check the items you want to work with so you can take bulk actions. You can also press the `Shift` key while you click to select a range. If all items in your selection are queries, you can change the data source for all of them at once.
-      - x_coord: 3.5
-        y_coord: 27
-        content: |
-          **Queries & expressions**
-
-          The list of queries and expressions you've written. Click a card in the sidebar to display that query or expression in the editor pane on the right. Click the blue plus sign to add a new query, add a saved query, or an expression. For more information about expressions, refer to [Use expressions to manipulate data](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/panels-visualizations/query-transform-data/expression-queries/).
-      - x_coord: 3.5
-        y_coord: 69
-        content: |
-          **Transformations**
-
-          The list of all the transformations you've added. Click the blue plus sign to add a new transformation.
-      - x_coord: 99
-        y_coord: 50
-        content: |
-          **Editor pane**
-      - x_coord: 46
-        y_coord: 8
-        content: |
-          **Data source selector**
-
-          Select the data source to query. For more information about data sources, refer to [Data sources](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/).
-      - x_coord: 51
-        y_coord: 8
-        content: |
-          **Query name editor**
-
-          The workspace for creating and configuring queries, expressions, and transformations. It displays the selected item from the sidebar and provides controls to edit configuration, switch between available editing modes, configuring options, and running queries to inspect results.
-      - x_coord: 96
-        y_coord: 27
-        content: |
-          **Builder/Code modes**
-
-          Click the button to switch between builder and code editor modes when creating queries for some data sources.
-      - x_coord: 33
-        y_coord: 87
-        content: |
-          **Query options**
-
-          Click **Query options** in the footer of the editor pane to access options set maximum data retrieval parameters and query execution time intervals.
-      - x_coord: 90.5
-        y_coord: 87
-        content: |
-          **Query inspector button**
-
-          Click **Query inspector** in the footer of the editor pane to open the query inspector panel, where you can view and optimize your query.
 ---
 
 # Query editor in Explore
 
+The query editor is the interface where you construct the query for a data source.
 Each data source's query editor provides a customized user interface that helps you write queries that take advantage of its unique capabilities.
 
 Because of the differences between query languages, each data source query editor looks and functions differently.
 Depending on your data source, the query editor might provide auto-completion features, metric names, variable suggestions, or a visual query-building interface.
 
-{{< figure src="/media/docs/grafana/panels-visualizations/screenshot-query-editor-v13.1.png" max-width="750px" alt="The Prometheus query editor" >}}
-<!-- TODO: replace -->
+{{< figure src="/media/docs/grafana/dashboards/screenshot-explore-query-editor-v13.2.png" max-width="750px" alt="The Prometheus query editor in Explore" >}}
 
 For details on a specific data source's unique query editor features, refer to its documentation:
 
@@ -164,8 +89,7 @@ You can access saved queries three ways:
 - Click **Saved queries > Replace query** in the query editor.
 - At the bottom of the query editor, click **Add from saved queries**.
 
-{{< figure src="/media/docs/grafana/panels-visualizations/screenshot-add-save-reuse-query-v13.1.png" max-width="750px" alt="Access saved queries" >}}
-<!-- TODO: replace -->
+{{< figure src="/media/docs/grafana/dashboards/screenshot-add-saved-reuse-query-v13.2.png" max-width="750px" alt="Access saved queries" >}}
 
 Clicking **Add from saved queries** adds an additional query, while clicking **Replace query** updates your configured query.
 
@@ -207,8 +131,7 @@ To save a query you've created:
 
 1. From the query editor, open the **Saved queries** drop-down menu and click the **Save query** option:
 
-   {{< figure src="/media/docs/grafana/panels-visualizations/screenshot-save-query-v13.1.png" max-width="750px" alt="Save a query" >}}
-   <!-- TODO: replace -->
+   {{< figure src="/media/docs/grafana/dashboards/screenshot-save-query-v13.2.png" max-width="750px" alt="Save a query" >}}
 
 1. In the **Saved queries** dialog box, enter a title for the query that makes it easier to find later.
 1. (Optional) Enter a description and relevant tags.

--- a/docs/sources/visualizations/explore/query-editor.md
+++ b/docs/sources/visualizations/explore/query-editor.md
@@ -86,7 +86,7 @@ The **Saved queries** dialog box gives you access to all the saved queries in yo
 
 You can access saved queries three ways:
 
-- Press `Ctrl + K` or `Cmd + K` to open the command palette and search "Saved queries". The **Shared queries** dialog box opens, where you can select a query and then click **Open in Explore**.
+- Press `Ctrl + K` or `Cmd + K` to open the command palette and search "Saved queries", and select the **Open saved queries** action. The **Shared queries** dialog box opens, where you can select a query and then click **Open in Explore**.
 - Click **Saved queries > Replace query** in the query editor.
 - At the bottom of the query editor, click **Add from saved queries**.
 

--- a/docs/sources/visualizations/explore/query-editor.md
+++ b/docs/sources/visualizations/explore/query-editor.md
@@ -1,0 +1,16 @@
+---
+aliases:
+
+keywords:
+  - explore
+  - query editor
+  - mixed data source
+  - saved queries
+labels:
+  products:
+    - cloud
+    - enterprise
+    - oss
+title: Query editor in Explore
+weight: 50
+---

--- a/docs/sources/visualizations/explore/query-editor.md
+++ b/docs/sources/visualizations/explore/query-editor.md
@@ -72,7 +72,7 @@ Saved queries are supported in:
 Learn more about saved queries:
 
 - [Saved queries dialog box](#saved-queries-dialog-box)
-- [Roles, permission, and RBAC](#roles-permissions-and-rbac)
+- [Roles, permissions, and RBAC](#roles-permissions-and-rbac)
 - [How to save a query](#save-a-query)
 - [Variables in saved queries](#variables-in-saved-queries)
 - [Manage saved queries as code](#manage-saved-queries-as-code)

--- a/docs/sources/visualizations/explore/query-editor.md
+++ b/docs/sources/visualizations/explore/query-editor.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-
 keywords:
   - explore
   - query editor
@@ -12,5 +10,271 @@ labels:
     - enterprise
     - oss
 title: Query editor in Explore
-weight: 50
+weight: 5
+image_maps:
+  - key: query-editor
+    src: /media/docs/grafana/panels-visualizations/screenshot-query-editor-imagemap-v13.1.png
+    alt: An annotated image of the Grafana panel query editor
+    points:
+      - x_coord: 1
+        y_coord: 50
+        content: |
+          **Sidebar**
+
+          The sidebar displays queries, expressions, and transformations as color-coded cards with visual indicators for state, like error, hidden, and disabled, while a footer tracks your total item count.
+      - x_coord: 13
+        y_coord: 8
+        content: |
+          **Data/Alerts buttons**
+
+          Click the buttons to move between data pipeline and related alerts. In **Alerts**, you have the option to start creating a alert rule.
+      - x_coord: 24
+        y_coord: 8
+        content: |
+          **Stacked view icon**
+
+          The [stacked view](#navigate-the-query-editor) displays all of your queries, expressions, and transformations in a single list in the editor pane.
+      - x_coord: 18
+        y_coord: 94
+        content: |
+          **Multi-select**
+
+          Click **Select...** in the sidebar footer to enter multi-select mode, then check the items you want to work with so you can take bulk actions. You can also press the `Shift` key while you click to select a range. If all items in your selection are queries, you can change the data source for all of them at once.
+      - x_coord: 3.5
+        y_coord: 27
+        content: |
+          **Queries & expressions**
+
+          The list of queries and expressions you've written. Click a card in the sidebar to display that query or expression in the editor pane on the right. Click the blue plus sign to add a new query, add a saved query, or an expression. For more information about expressions, refer to [Use expressions to manipulate data](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/panels-visualizations/query-transform-data/expression-queries/).
+      - x_coord: 3.5
+        y_coord: 69
+        content: |
+          **Transformations**
+
+          The list of all the transformations you've added. Click the blue plus sign to add a new transformation.
+      - x_coord: 99
+        y_coord: 50
+        content: |
+          **Editor pane**
+      - x_coord: 46
+        y_coord: 8
+        content: |
+          **Data source selector**
+
+          Select the data source to query. For more information about data sources, refer to [Data sources](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/).
+      - x_coord: 51
+        y_coord: 8
+        content: |
+          **Query name editor**
+
+          The workspace for creating and configuring queries, expressions, and transformations. It displays the selected item from the sidebar and provides controls to edit configuration, switch between available editing modes, configuring options, and running queries to inspect results.
+      - x_coord: 96
+        y_coord: 27
+        content: |
+          **Builder/Code modes**
+
+          Click the button to switch between builder and code editor modes when creating queries for some data sources.
+      - x_coord: 33
+        y_coord: 87
+        content: |
+          **Query options**
+
+          Click **Query options** in the footer of the editor pane to access options set maximum data retrieval parameters and query execution time intervals.
+      - x_coord: 90.5
+        y_coord: 87
+        content: |
+          **Query inspector button**
+
+          Click **Query inspector** in the footer of the editor pane to open the query inspector panel, where you can view and optimize your query.
 ---
+
+# Query editor in Explore
+
+Each data source's query editor provides a customized user interface that helps you write queries that take advantage of its unique capabilities.
+
+Because of the differences between query languages, each data source query editor looks and functions differently.
+Depending on your data source, the query editor might provide auto-completion features, metric names, variable suggestions, or a visual query-building interface.
+
+{{< figure src="/media/docs/grafana/panels-visualizations/screenshot-query-editor-v13.1.png" max-width="750px" alt="The Prometheus query editor" >}}
+<!-- TODO: replace -->
+
+For details on a specific data source's unique query editor features, refer to its documentation:
+
+- For data sources included with Grafana, refer to [Built-in core data sources](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/#built-in-core-data-sources), which links to each core data source's documentation.
+- For data sources installed as plugins, refer to the documentation for the plugin.
+  - Data source plugins in the Grafana [plugin catalog](/grafana/plugins/) link to or include their documentation in their catalog listings.
+    For details about the plugin catalog, refer to [Plugin management](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/plugin-management/).
+  - For links to Grafana Enterprise data source plugin documentation, refer to the [Enterprise plugins index](/docs/plugins/).
+
+## Query syntax
+
+Each data source uses a different query languages to request data.
+For details on a specific data source's unique query language, refer to its documentation.
+
+**PostgreSQL example:**
+
+```
+SELECT hostname FROM host WHERE region IN($region)
+```
+
+**PromQL example:**
+
+```
+query_result(max_over_time(<metric>[${__range_s}s]) != <state>)
+```
+
+## Special data sources
+
+Grafana also includes three special data sources: **Grafana**, **Mixed**, and **Dashboard**.
+For details, refer to [Data sources](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/)
+
+## Saved queries
+
+{{< admonition type="note" >}}
+Saved queries is only available on Grafana Enterprise and Grafana Cloud.
+{{< /admonition >}}
+
+You can save queries that you've created so they can be reused by you and others in your organization.
+This helps users across your organization find insights in Explore without having to create their own queries or know a query language.
+It also helps you avoid having several users build the same queries for the same data sources multiple times.
+
+Saved queries are supported in:
+
+- [Dashboards](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/build-dashboards/create-dashboard/#create-a-dashboard)
+- [Explore](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/explore/get-started-with-explore/#explore-elements)
+- [Annotations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/build-dashboards/annotate-visualizations/#add-new-annotation-queries)
+
+Learn more about saved queries:
+
+- [Saved queries dialog box](#saved-queries-dialog-box)
+- [Roles, permission, and RBAC](#roles-permissions-and-rbac)
+- [How to save a query](#save-a-query)
+- [Variables in saved queries](#variables-in-saved-queries)
+- [Known limitations](#known-limitations)
+
+### Saved queries dialog box
+
+The **Saved queries** dialog box gives you access to all the saved queries in your organization:
+
+{{< figure src="/media/docs/grafana/dashboards/screenshot-saved-queries-v13.0.png" max-width="750px" alt="List of saved queries" >}}
+
+You can access saved queries three ways:
+
+- Press `Ctrl + K` or `Cmd + K` to open the command palette and search "Saved queries".
+- Click **Saved queries > Replace query** in the query editor.
+- At the bottom of the query editor, click **Add from saved queries**.
+
+{{< figure src="/media/docs/grafana/panels-visualizations/screenshot-add-save-reuse-query-v13.1.png" max-width="750px" alt="Access saved queries" >}}
+<!-- TODO: replace -->
+
+Clicking **Add from saved queries** adds an additional query, while clicking **Replace query** updates your configured query.
+
+From the **Saved queries** dialog box, you can:
+
+- Search for queries by data source name, query content, title, or description.
+- Sort queries alphabetically or by creation date.
+- Filter by data source name, author name, and tags. The tag filter uses the `OR` operator, while the others use the `AND` operator. Use the **Remember filters** switch to persist your filter selections across sessions in your local storage.
+- Star queries so that they appear in the **Starred queries** filter view.
+- Duplicate or delete a saved query.
+- Edit a query title, description, or tags.
+- Click **Edit** at the bottom of the dialog box to update the body of a query.
+
+You can apply all the same search, filter, and sort options in the **Starred queries** filter view.
+
+{{< admonition type="tip">}}
+When you select a query with a Loki, Mimir, Tempo, or Pyroscope data source, the **Saved queries** dialog box displays a **Drilldown** button.
+Click the button to open the associated Drilldown app, while maintaining the context of the query.
+Learn more about these apps in the [Drilldown documentation](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/simplified-exploration/).
+{{< /admonition >}}
+
+### Roles, permissions, and RBAC
+
+Saved queries support role-based access controls.
+By default, saved queries have two RBAC roles:
+
+- **Writer**: Create, update, and delete all saved queries.
+- **Reader**: Reuse saved queries.
+
+If you used saved queries prior to the addition of RBAC support in Grafana v12.4, Grafana user roles are mapped as follows:
+
+- Admin > Writer
+- Editor > Writer
+- Viewer > Reader
+
+### Save a query
+
+To save a query you've created:
+
+1. From the query editor, open the **Saved queries** drop-down menu and click the **Save query** option:
+
+   {{< figure src="/media/docs/grafana/panels-visualizations/screenshot-save-query-v13.1.png" max-width="750px" alt="Save a query" >}}
+   <!-- TODO: replace -->
+
+1. In the **Saved queries** dialog box, enter a title for the query that makes it easier to find later.
+1. (Optional) Enter a description and relevant tags.
+1. Click **Save**.
+
+### Variables in saved queries
+
+<!-- is this section applicable to Explore? -->
+
+If a saved query includes variables, you can substitute the variables in the query without modifying it.
+This is useful in environments where variable names or available values differ between dashboards.
+
+You can map the original variables to either:
+
+- A variable in your dashboard
+- A custom value that you enter
+
+{{< figure src="/media/docs/grafana/panels-visualizations/screenshot-saved-query-variable-v13.0.png" max-width="450px" alt="A saved query with substituted variables" >}}
+
+Grafana applies your selections to the query before inserting it into the dashboard.
+However, the substitutions only apply to the query when it's reused, and the original saved query remains unchanged.
+
+{{< admonition type="note">}}
+In Explore, you can map variables to custom values.
+{{< /admonition >}}
+
+### Known limitations
+
+- No validation is performed when you save a query, so it's possible to save an invalid query. You should confirm the query is working properly before you save it.
+- You can save a maximum of 1000 queries.
+- If you have multiple queries open in Explore and you edit one of them by way of the **Edit in Explore** function in the **Saved queries** dialog box, the edited query replaces your open queries in Explore.
+
+## Add a query
+
+To add a query, follow these steps:
+
+1. If you want use a data source that's not the default one, click the data source drop-down menu in the toolbar and make a selection.
+
+    If you want to use multiple data sources, select the **Mixed** data source at this step. The query editor displays a secondary data source picker.
+
+1. To create a query, do one of the following:
+   - Write or construct a query in the query language of your data source.
+   - Click **Replace** to reuse a saved query.
+
+   {{< admonition type="note" >}}
+   [Saved queries](#saved-queries) is only available on Grafana Enterprise and Grafana Cloud.
+   {{< /admonition >}}
+
+1. (Optional) To [save the query](#save-a-query) for reuse, click the **Save** in the editor pane.
+1. (Optional) At the bottom of the query editor, click **Add query** or **Add from saved queries** to add more queries as needed.
+1. Click the **Run query** icon in the toolbar.
+
+Grafana queries the data source.
+If the data source supports graph and table data, Explore displays the results in the **Graph**.
+
+## Manage queries
+
+The following table describes actions you can take for each query:
+
+<!-- prettier-ignore-start -->
+| Icon    | Description                                  |
+| ------- | -------------------------------------------- |
+| {{< figure src="/media/docs/grafana/panels-visualizations/replace-query-icon-v13.1.png" max-width="30px" max-height="30px" alt="Replace query icon" >}} | [Saved query](#saved-queries) options. Open the drop-down list and choose from **Save query** or **Replace query**.(Enterprise and Cloud only). |
+| {{< figure src="/static/img/docs/queries/query-editor-help-7-4.png" max-width="30px" max-height="30px" alt="Help icon" >}} | Toggles query editor help. If supported by the data source, click this icon to display information on how to use the query editor or provide quick access to common queries. Click the **More query actions** menu to access this option. |
+| {{< figure src="/media/docs/grafana/panels-visualizations/create-recorded-query-icon.png" max-width="30px" max-height="30px" alt="Create recorded query icon" >}} | Create [recorded queries](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/recorded-queries/) so you can see trends over time by taking a snapshot of a data point on a set interval (Enterprise and Cloud only). |
+| {{< figure src="/static/img/docs/queries/duplicate-query-icon-7-0.png" max-width="30px" max-height="30px" alt="Duplicate icon" >}} | Copies a query. Duplicating queries is useful when working with multiple complex queries that are similar and you want to either experiment with different variants or do minor alterations. Click the **More query actions** menu to access this option. |
+| {{< figure src="/static/img/docs/queries/hide-query-icon-7-0.png" max-width="30px" max-height="30px" alt="Hide icon" >}} | Hides a query. Grafana does not send hidden queries to the data source. |
+| {{< figure src="/static/img/docs/queries/remove-query-icon-7-0.png" max-width="30px" max-height="30px" alt="Remove icon">}} | Removes a query. Removing a query permanently deletes it, but sometimes you can recover deleted queries by reverting to previously saved versions of the panel. |
+<!-- prettier-ignore-end -->

--- a/docs/sources/visualizations/explore/query-editor.md
+++ b/docs/sources/visualizations/explore/query-editor.md
@@ -29,7 +29,7 @@ For details on a specific data source's unique query editor features, refer to i
 - For data sources installed as plugins, refer to the documentation for the plugin.
   - Data source plugins in the Grafana [plugin catalog](/grafana/plugins/) link to or include their documentation in their catalog listings.
     For details about the plugin catalog, refer to [Plugin management](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/plugin-management/).
-  - For links to Grafana Enterprise data source plugin documentation, refer to the [Enterprise plugins index](/docs/plugins/).
+  - For links to Grafana Enterprise data source plugin documentation, refer to the [Enterprise plugins index](https://grafana.com/docs/plugins/).
 
 ## Query syntax
 

--- a/docs/sources/visualizations/explore/query-editor.md
+++ b/docs/sources/visualizations/explore/query-editor.md
@@ -159,7 +159,7 @@ To add a query, follow these steps:
 
 1. If you want use a data source that's not the default one, click the data source drop-down menu in the toolbar and make a selection.
 
-    If you want to use multiple data sources, select the **Mixed** data source at this step. The query editor displays a secondary data source picker.
+   If you want to use multiple data sources, select the **Mixed** data source at this step. The query editor displays a secondary data source picker.
 
 1. To create a query, do one of the following:
    - Write or construct a query in the query language of your data source.

--- a/docs/sources/visualizations/explore/query-editor.md
+++ b/docs/sources/visualizations/explore/query-editor.md
@@ -139,24 +139,13 @@ To save a query you've created:
 
 ### Variables in saved queries
 
-<!-- is this section applicable to Explore? -->
-
-If a saved query includes variables, you can substitute the variables in the query without modifying it.
+If a saved query includes variables, you can substitute the variables in the query without modifying it by mapping them to a custom value.
 This is useful in environments where variable names or available values differ between dashboards.
 
-You can map the original variables to either:
-
-- A variable in your dashboard
-- A custom value that you enter
-
-{{< figure src="/media/docs/grafana/panels-visualizations/screenshot-saved-query-variable-v13.0.png" max-width="450px" alt="A saved query with substituted variables" >}}
+{{< figure src="/media/docs/grafana/dashboards/screenshot-saved-query-variable-v13.2.png" max-width="450px" alt="A saved query with substituted variables" >}}
 
 Grafana applies your selections to the query before inserting it into the dashboard.
 However, the substitutions only apply to the query when it's reused, and the original saved query remains unchanged.
-
-{{< admonition type="note">}}
-In Explore, you can map variables to custom values.
-{{< /admonition >}}
 
 ### Known limitations
 

--- a/docs/sources/visualizations/explore/query-management.md
+++ b/docs/sources/visualizations/explore/query-management.md
@@ -1,8 +1,10 @@
 ---
 keywords:
   - explore
-  - loki
-  - logs
+  - query history
+  - starred queries
+  - saved queries
+  - shortened link
 labels:
   products:
     - cloud

--- a/docs/sources/visualizations/panels-visualizations/panel-editor-overview/index.md
+++ b/docs/sources/visualizations/panels-visualizations/panel-editor-overview/index.md
@@ -64,7 +64,7 @@ The data section contains tabs where you enter queries, transform your data, and
   - **+ Add from saved queries** - Add an additional query by reusing a saved query.
 
   {{< admonition type="note" >}}
-  [Saved queries](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/panels-visualizations/query-transform-data/#saved-queries) is currently in [public preview](https://grafana.com/docs/release-life-cycle/) in Grafana Enterprise and Grafana Cloud only.
+  [Saved queries](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/panels-visualizations/query-transform-data/#saved-queries) is only available on Grafana Enterprise and Grafana Cloud.
   {{< /admonition >}}
 
 - **Transformations** - Apply data transformations. For more information, refer to [Transform data](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/panels-visualizations/query-transform-data/transform-data/).

--- a/docs/sources/visualizations/panels-visualizations/query-transform-data/_index.md
+++ b/docs/sources/visualizations/panels-visualizations/query-transform-data/_index.md
@@ -196,6 +196,7 @@ Learn more about saved queries:
 - [Roles, permission, and RBAC](#roles-permissions-and-rbac)
 - [How to save a query](#save-a-query)
 - [Variables in saved queries](#variables-in-saved-queries)
+- [Manage saved queries as code](#manage-saved-queries-as-code)
 - [Known limitations](#known-limitations)
 
 ### Saved queries dialog box
@@ -275,6 +276,11 @@ You can map the original variables to either:
 
 Grafana applies your selections to the query before inserting it into the dashboard.
 However, the substitutions only apply to the query when it's reused, and the original saved query remains unchanged.
+
+### Manage saved queries as code
+
+You can manage saved queries as code with the Grafana Terraform provider, which lets you version-control your query library and keep it consistent across instances.
+For more information, refer to [Manage saved queries using Terraform](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/infrastructure-as-code/terraform/manage-saved-queries/).
 
 ### Known limitations
 

--- a/docs/sources/visualizations/panels-visualizations/query-transform-data/_index.md
+++ b/docs/sources/visualizations/panels-visualizations/query-transform-data/_index.md
@@ -173,9 +173,7 @@ For details, refer to [Data sources](https://grafana.com/docs/grafana/<GRAFANA_V
 ## Saved queries
 
 {{< admonition type="note" >}}
-Saved queries is currently in [public preview](https://grafana.com/docs/release-life-cycle/). Grafana Labs offers limited support, and breaking changes might occur prior to the feature being made generally available.
-
-This feature is only available on Grafana Enterprise and Grafana Cloud. It will gradually roll out to all Grafana Cloud users with no action required. To try out this feature on Grafana Enterprise, enable the `queryLibrary` feature toggle.
+Saved queries is only available on Grafana Enterprise and Grafana Cloud.
 {{< /admonition >}}
 
 You can save queries that you've created so they can be reused by you and others in your organization.
@@ -342,9 +340,7 @@ To add a query to a panel, follow these steps:
    - Click **Replace** to reuse a saved query.
 
    {{< admonition type="note" >}}
-   [Saved queries](#saved-queries) is currently in [public preview](https://grafana.com/docs/release-life-cycle/). Grafana Labs offers limited support, and breaking changes might occur prior to the feature being made generally available.
-
-   This feature is only available on Grafana Enterprise and Grafana Cloud.
+   [Saved queries](#saved-queries) is only available on Grafana Enterprise and Grafana Cloud.
    {{< /admonition >}}
 
 1. (Optional) To [save the query](#save-a-query) for reuse, click the **Save** in the editor pane.

--- a/docs/sources/visualizations/panels-visualizations/query-transform-data/_index.md
+++ b/docs/sources/visualizations/panels-visualizations/query-transform-data/_index.md
@@ -184,7 +184,7 @@ You can save queries that you've created so they can be reused by you and others
 This helps users across your organization create dashboards without having to create their own queries or know a query language.
 It also helps you avoid having several users build the same queries for the same data sources multiple times.
 
-Saved queries are available in:
+Saved queries are supported in:
 
 - [Dashboards](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/build-dashboards/create-dashboard/#create-a-dashboard)
 - [Explore](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/explore/query-editor/)

--- a/docs/sources/visualizations/panels-visualizations/query-transform-data/_index.md
+++ b/docs/sources/visualizations/panels-visualizations/query-transform-data/_index.md
@@ -204,15 +204,19 @@ The **Saved queries** dialog box gives you access to all the saved queries in yo
 
 {{< figure src="/media/docs/grafana/dashboards/screenshot-saved-queries-v13.0.png" max-width="750px" alt="List of saved queries" >}}
 
-You can access saved queries three ways:
+To access saved queries:
 
-- Press `Ctrl + K` or `Cmd + K` to open the command palette and search "Saved queries".
 - Click **Replace** in the query editor pane.
 - Click the blue plus sign in the query editor sidebar and select **Add saved query**.
 
 {{< figure src="/media/docs/grafana/panels-visualizations/screenshot-add-save-reuse-query-v13.1.png" max-width="750px" alt="Access saved queries" >}}
 
 Clicking **Add saved query** adds an additional query, while clicking **Replace** updates your configured query.
+
+{{< admonition type="note" >}}
+To review your saved queries, press `Ctrl + K` or `Cmd + K` to open the command palette and search "Saved queries".
+From this view, you can also select a query to open in Explore.
+{{< /admonition >}}
 
 From the **Saved queries** dialog box, you can:
 

--- a/docs/sources/visualizations/panels-visualizations/query-transform-data/_index.md
+++ b/docs/sources/visualizations/panels-visualizations/query-transform-data/_index.md
@@ -200,28 +200,27 @@ The **Saved queries** dialog box gives you access to all the saved queries in yo
 
 {{< figure src="/media/docs/grafana/dashboards/screenshot-saved-queries-v13.0.png" max-width="750px" alt="List of saved queries" caption="The **Saved queries** dialog box accessed from Dashboards" >}}
 
-From here, you can:
+You can access saved queries three ways:
 
-- Search for queries by data source name, query content, title, or description.
-- Sort queries alphabetically or by creation date.
-- Filter by data source name, author name, and tags. The tag filter uses the `OR` operator, while the others use the `AND` operator.
-
-  {{< admonition type="tip">}}
-  Use the **Remember filters** switch to persist your filter selections across sessions in your local storage.
-  {{< /admonition >}}
-
-- Star queries so that they appear in the **Starred queries** filter view.
-- Duplicate, or delete a saved query.
-- Edit a query title, description, or tags.
-- When you access the **Saved queries** dialog box from Explore, you can use the **Edit in Explore** option to edit the body of a query.
-
-You can apply all the same search, filter, and sort options in the **Starred queries** filter view.
-
-To access your saved queries, click the blue plus sign in the sidebar and select **Add saved query** or click **Replace** in the editor pane:
+- Press `Ctrl + K` or `Cmd + K` to open the command palette and search "Saved queries".
+- Click **Replace** in the query editor pane.
+- Click the blue plus sign in the query editor sidebar and select **Add saved query**.
 
 {{< figure src="/media/docs/grafana/panels-visualizations/screenshot-add-save-reuse-query-v13.1.png" max-width="750px" alt="Access saved queries" >}}
 
 Clicking **Add saved query** adds an additional query, while clicking **Replace** updates your configured query.
+
+From the **Saved queries** dialog box, you can:
+
+- Search for queries by data source name, query content, title, or description.
+- Sort queries alphabetically or by creation date.
+- Filter by data source name, author name, and tags. The tag filter uses the `OR` operator, while the others use the `AND` operator. Use the **Remember filters** switch to persist your filter selections across sessions in your local storage.
+- Star queries so that they appear in the **Starred queries** filter view.
+- Duplicate or delete a saved query.
+- Edit a query title, description, or tags.
+- When you access the **Saved queries** dialog box from Explore, you can use the **Edit in Explore** option to edit the body of a query.
+
+You can apply all the same search, filter, and sort options in the **Starred queries** filter view.
 
 {{< admonition type="tip">}}
 When you select a query with a Loki, Mimir, Tempo, or Pyroscope data source, the **Saved queries** dialog box displays a **Drilldown** button.

--- a/docs/sources/visualizations/panels-visualizations/query-transform-data/_index.md
+++ b/docs/sources/visualizations/panels-visualizations/query-transform-data/_index.md
@@ -181,13 +181,13 @@ Saved queries is only available on Grafana Enterprise and Grafana Cloud.
 {{< /admonition >}}
 
 You can save queries that you've created so they can be reused by you and others in your organization.
-This helps users across your organization create dashboards or find insights in Explore without having to create their own queries or know a query language.
+This helps users across your organization create dashboards without having to create their own queries or know a query language.
 It also helps you avoid having several users build the same queries for the same data sources multiple times.
 
 Saved queries are available in:
 
 - [Dashboards](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/build-dashboards/create-dashboard/#create-a-dashboard)
-- [Explore](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/explore/get-started-with-explore/#explore-elements)
+- [Explore](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/explore/query-editor/)
 - [Annotations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/build-dashboards/annotate-visualizations/#add-new-annotation-queries)
 
 Learn more about saved queries:
@@ -272,15 +272,10 @@ You can map the original variables to either:
 Grafana applies your selections to the query before inserting it into the dashboard.
 However, the substitutions only apply to the query when it's reused, and the original saved query remains unchanged.
 
-{{< admonition type="note">}}
-In Explore, you can map variables to custom values.
-{{< /admonition >}}
-
 ### Known limitations
 
 - No validation is performed when you save a query, so it's possible to save an invalid query. You should confirm the query is working properly before you save it.
 - You can save a maximum of 1000 queries.
-- If you have multiple queries open in Explore and you edit one of them by way of the **Edit in Explore** function in the **Saved queries** dialog box, the edited query replaces your open queries in Explore.
 
 ## Navigate the query editor
 

--- a/docs/sources/visualizations/panels-visualizations/query-transform-data/_index.md
+++ b/docs/sources/visualizations/panels-visualizations/query-transform-data/_index.md
@@ -23,10 +23,14 @@ title: Query and transform data
 description: Query and transform your data
 weight: 40
 keywords:
+  - query
+  - query editor
+  - query options
   - saved queries
   - reuse queries
-  - saved query
-  - reuse query
+  - data source
+  - transformations
+  - expressions
 image_maps:
   - key: query-editor
     src: /media/docs/grafana/panels-visualizations/screenshot-query-editor-imagemap-v13.1.png

--- a/docs/sources/visualizations/panels-visualizations/query-transform-data/_index.md
+++ b/docs/sources/visualizations/panels-visualizations/query-transform-data/_index.md
@@ -202,7 +202,7 @@ Learn more about saved queries:
 
 The **Saved queries** dialog box gives you access to all the saved queries in your organization:
 
-{{< figure src="/media/docs/grafana/dashboards/screenshot-saved-queries-v13.0.png" max-width="750px" alt="List of saved queries" caption="The **Saved queries** dialog box accessed from Dashboards" >}}
+{{< figure src="/media/docs/grafana/dashboards/screenshot-saved-queries-v13.0.png" max-width="750px" alt="List of saved queries" >}}
 
 You can access saved queries three ways:
 
@@ -222,7 +222,6 @@ From the **Saved queries** dialog box, you can:
 - Star queries so that they appear in the **Starred queries** filter view.
 - Duplicate or delete a saved query.
 - Edit a query title, description, or tags.
-- When you access the **Saved queries** dialog box from Explore, you can use the **Edit in Explore** option to edit the body of a query.
 
 You can apply all the same search, filter, and sort options in the **Starred queries** filter view.
 
@@ -250,7 +249,7 @@ If you used saved queries prior to the addition of RBAC support in Grafana v12.4
 
 To save a query you've created:
 
-1. From the query editor, open the **Saved queries** drop-down menu and click the **Save query** option:
+1. From the query editor, click the **Save**:
 
    {{< figure src="/media/docs/grafana/panels-visualizations/screenshot-save-query-v13.1.png" max-width="750px" alt="Save a query" >}}
 
@@ -280,7 +279,6 @@ In Explore, you can map variables to custom values.
 ### Known limitations
 
 - No validation is performed when you save a query, so it's possible to save an invalid query. You should confirm the query is working properly before you save it.
-- Saved queries are currently accessible from the query editors in Dashboards and Explore.
 - You can save a maximum of 1000 queries.
 - If you have multiple queries open in Explore and you edit one of them by way of the **Edit in Explore** function in the **Saved queries** dialog box, the edited query replaces your open queries in Explore.
 


### PR DESCRIPTION
This PR:

1. Makes the saved queries content more robust, specifically in Explore and Annotations, and makes several updates to accommodate these changes. The detailed list of changes are:
    - Adds a **Query editor** page to the **Explore** docs to accommodate the addition of a saved queries section
    - Restructures the **Get started with Explore** page to improve scannability
    - Adds a **Saved queries** section to the **Annotation** docs
    - Makes several minor changes to the saved queries content to account for it being in three different contexts
    - Updates keywords for several pages

2. Adds information about managing saved queries as code using Terraform with a new **Manage saved queries using Terraform** page and links to that page from the saved queries content in Panels and visualizations, Explore, and Annotations.

3. Adds information about accessing saved queries from the command palette.

4. Removes public preview notes from all saved queries content.

TO DO

- [ ] Confirm provider version. `>= 4.6.0` is a placeholder in the guide.
- [ ] Confirm registry link resolves when dev PR is merged

Closes https://github.com/grafana/grafana-enterprise/issues/11706