### PR TITLE
Azure Monitor: Reject 'starts with' dimension filters split across filter entries

### DIFF
--- a/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource.go
+++ b/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource.go
@@ -265,19 +265,31 @@ func buildDimensionFilterString(azJSONModel *dataquery.AzureMetricQuery) (string
 		return fmt.Sprintf("%s eq '%s'", dimension, dimensionFilter), nil
 	}
 
+	// The metrics API accepts at most one 'sw' clause per dimension: it
+	// rejects both "sw ... or sw ..." (or is only valid between eq clauses)
+	// and "sw ... and sw ..." (multiple sw values for one dimension), so fail
+	// here with a clearer message than the API's. Values are counted across
+	// all filter entries because the same dimension may appear more than once
+	// in the list, and dimension names are compared case-insensitively
+	// because the API treats them that way.
+	swValueCounts := map[string]int{}
+	for _, filter := range azJSONModel.DimensionFilters {
+		if filter.Operator == nil || *filter.Operator != "sw" {
+			continue
+		}
+		filterDimension := ""
+		if filter.Dimension != nil {
+			filterDimension = *filter.Dimension
+		}
+		key := strings.ToLower(filterDimension)
+		swValueCounts[key] += len(filter.Filters)
+		if swValueCounts[key] > 1 {
+			return "", backend.DownstreamError(fmt.Errorf("the Azure Monitor API supports only one 'starts with' filter value per dimension, but dimension %q has %d", filterDimension, swValueCounts[key]))
+		}
+	}
+
 	dimSB := strings.Builder{}
 	for i, filter := range azJSONModel.DimensionFilters {
-		// The metrics API accepts at most one 'sw' clause per dimension: it
-		// rejects both "sw ... or sw ..." (or is only valid between eq
-		// clauses) and "sw ... and sw ..." (multiple sw values for one
-		// dimension), so fail here with a clearer message than the API's.
-		if filter.Operator != nil && *filter.Operator == "sw" && len(filter.Filters) > 1 {
-			filterDimension := ""
-			if filter.Dimension != nil {
-				filterDimension = *filter.Dimension
-			}
-			return "", backend.DownstreamError(fmt.Errorf("the Azure Monitor API supports only one 'starts with' filter value per dimension, but dimension %q has %d", filterDimension, len(filter.Filters)))
-		}
 		if len(filter.Filters) == 0 {
 			dimSB.WriteString(fmt.Sprintf("%s eq '*'", *filter.Dimension))
 		} else {

--- a/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource_test.go
@@ -350,29 +350,69 @@ func TestAzureMonitorBuildQueries(t *testing.T) {
 
 func TestAzureMonitorBuildQueriesRejectsMultiValueStartsWithFilter(t *testing.T) {
 	datasource := &AzureMonitorDatasource{}
-	query := backend.DataQuery{
-		RefID: "A",
-		JSON: []byte(`{
-			"subscription": "12345678-aaaa-bbbb-cccc-123456789abc",
-			"azureMonitor": {
-				"aggregation": "Total",
-				"timeGrain": "PT1M",
-				"metricName": "Transactions",
-				"metricNamespace": "Microsoft.Storage/storageAccounts",
-				"resources": [{"resourceGroup": "rg", "resourceName": "sa"}],
-				"dimensionFilters": [{"dimension": "ApiName", "operator": "sw", "filters": ["Get", "Put"]}]
-			}
-		}`),
-		TimeRange: backend.TimeRange{
-			From: time.Date(2018, 3, 15, 13, 0, 0, 0, time.UTC),
-			To:   time.Date(2018, 3, 15, 13, 34, 0, 0, time.UTC),
+	tests := []struct {
+		name             string
+		dimensionFilters string
+		wantErr          bool
+	}{
+		{
+			name:             "multiple values in one sw filter",
+			dimensionFilters: `[{"dimension": "ApiName", "operator": "sw", "filters": ["Get", "Put"]}]`,
+			wantErr:          true,
+		},
+		{
+			name:             "single-value sw filters split across entries for the same dimension",
+			dimensionFilters: `[{"dimension": "ApiName", "operator": "sw", "filters": ["Get"]}, {"dimension": "ApiName", "operator": "sw", "filters": ["Put"]}]`,
+			wantErr:          true,
+		},
+		{
+			name:             "same dimension in different casing across entries",
+			dimensionFilters: `[{"dimension": "ApiName", "operator": "sw", "filters": ["Get"]}, {"dimension": "apiname", "operator": "sw", "filters": ["Put"]}]`,
+			wantErr:          true,
+		},
+		{
+			name:             "one sw filter per dimension is allowed",
+			dimensionFilters: `[{"dimension": "ApiName", "operator": "sw", "filters": ["Get"]}, {"dimension": "Tier", "operator": "sw", "filters": ["Hot"]}]`,
+			wantErr:          false,
+		},
+		{
+			name:             "sw and eq entries on the same dimension are allowed",
+			dimensionFilters: `[{"dimension": "ApiName", "operator": "sw", "filters": ["Get"]}, {"dimension": "ApiName", "operator": "eq", "filters": ["GetBlob"]}]`,
+			wantErr:          false,
 		},
 	}
 
-	_, err := datasource.buildQuery(query, types.DatasourceInfo{})
-	require.Error(t, err)
-	require.ErrorContains(t, err, "one 'starts with' filter value")
-	require.True(t, backend.IsDownstreamError(err), "a multi-value sw filter is a query configuration error, not a plugin error")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			query := backend.DataQuery{
+				RefID: "A",
+				JSON: fmt.Appendf(nil, `{
+					"subscription": "12345678-aaaa-bbbb-cccc-123456789abc",
+					"azureMonitor": {
+						"aggregation": "Total",
+						"timeGrain": "PT1M",
+						"metricName": "Transactions",
+						"metricNamespace": "Microsoft.Storage/storageAccounts",
+						"resources": [{"resourceGroup": "rg", "resourceName": "sa"}],
+						"dimensionFilters": %s
+					}
+				}`, tt.dimensionFilters),
+				TimeRange: backend.TimeRange{
+					From: time.Date(2018, 3, 15, 13, 0, 0, 0, time.UTC),
+					To:   time.Date(2018, 3, 15, 13, 34, 0, 0, time.UTC),
+				},
+			}
+
+			_, err := datasource.buildQuery(query, types.DatasourceInfo{})
+			if !tt.wantErr {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			require.ErrorContains(t, err, "one 'starts with' filter value")
+			require.True(t, backend.IsDownstreamError(err), "a multi-value sw filter is a query configuration error, not a plugin error")
+		})
+	}
 }
 
 func TestCustomNamespace(t *testing.T) {


### PR DESCRIPTION
**What is this feature?**

Follow-up to https://github.com/grafana/grafana/pull/128316, addressing https://github.com/grafana/grafana/pull/128316#pullrequestreview-4708627242. The one-`sw`-value-per-dimension validation now counts values across the complete dimension filter list, so the equivalent shape with single-value `sw` entries repeated for the same dimension is caught too:

```json
"dimensionFilters": [
  { "dimension": "ApiName", "operator": "sw", "filters": ["Get"] },
  { "dimension": "ApiName", "operator": "sw", "filters": ["Put"] }
]
```

Previously this bypassed the validation (each entry has only one value), reached Azure, and failed with the API's opaque `Dimension name detected in multiple 'sw' values` 400.

**Why do we need this feature?**

The query editor prevents duplicate dimension entries, but API-created and provisioned queries can carry this shape, and it fails against Azure identically to the multi-value case the original validation covers. Counting per dimension closes the gap and subsumes the previous per-entry check.

**Who is this feature for?**

Users creating Azure Monitor metric queries via the API or provisioning with "starts with" dimension filters.

**Which issue(s) does this PR fix?**:

Related to https://github.com/grafana/support-escalations/issues/23211

**Special notes for your reviewer:**

- Dimension names are compared case-insensitively, matching how the metrics API treats them (its own error message lowercases the dimension name).
- Only the `sw`+`sw` combination is rejected, since that is the case verified against the live API. An `sw` entry combined with an `eq` entry on the same dimension remains allowed and is covered by a test.
