### PR TITLE
Home: Add the invite-team recommendation with org-user count

### DIFF
--- a/public/app/features/home/Recommendations/RecommendationCard.tsx
+++ b/public/app/features/home/Recommendations/RecommendationCard.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/css';
+import Skeleton from 'react-loading-skeleton';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { Icon, LinkButton, Stack, Text, useStyles2 } from '@grafana/ui';
@@ -23,9 +24,13 @@ export function RecommendationCard({ recommendation }: RecommendationCardProps) 
 
         <Stack direction="row" alignItems="center" gap={1}>
           <Icon name={recommendation.icon} className={styles.icon} />
-          <Text variant="body" color="secondary">
-            {recommendation.context}
-          </Text>
+          {recommendation.contextLoading ? (
+            <Skeleton width={180} containerTestId="recommendation-context-skeleton" />
+          ) : (
+            <Text variant="body" color="secondary">
+              {recommendation.context}
+            </Text>
+          )}
         </Stack>
 
         <Text variant="body">{recommendation.description}</Text>

--- a/public/app/features/home/Recommendations/Recommendations.test.tsx
+++ b/public/app/features/home/Recommendations/Recommendations.test.tsx
@@ -460,6 +460,34 @@ describe('Recommendations', () => {
       jest.useRealTimers();
     }
   });
+
+  it('does not schedule autoplay when there is a single recommendation', async () => {
+    mockAllAppsEnabled(); // invite card is the only recommendation
+    jest.useFakeTimers();
+    // A hand-rolled wrapper instead of jest.spyOn: the afterEach restoreAllMocks would re-install
+    // the fake-timer setTimeout after useRealTimers and poison the following tests.
+    const fakeSetTimeout = window.setTimeout;
+    const scheduledDelays: Array<number | undefined> = [];
+    window.setTimeout = new Proxy(fakeSetTimeout, {
+      apply(target, thisArg, args) {
+        scheduledDelays.push(args[1]);
+        return Reflect.apply(target, thisArg, args);
+      },
+    });
+    try {
+      render(<Recommendations />);
+      expect(await screen.findByRole('heading', { name: 'Invite your team' })).toBeInTheDocument();
+      act(() => {
+        jest.advanceTimersByTime(20_000);
+      });
+      // The autoplay effect arms a 5s tick; with a lone slide it must never be scheduled.
+      expect(scheduledDelays.filter((delay) => delay === 5000)).toHaveLength(0);
+      expect(screen.getByRole('heading', { name: 'Invite your team' })).toBeInTheDocument();
+    } finally {
+      window.setTimeout = fakeSetTimeout;
+      jest.useRealTimers();
+    }
+  });
   it('announces the recommendation slides as a carousel region', async () => {
     render(<Recommendations />);
 

--- a/public/app/features/home/Recommendations/Recommendations.test.tsx
+++ b/public/app/features/home/Recommendations/Recommendations.test.tsx
@@ -8,6 +8,7 @@ import { type LocalPlugin } from 'app/features/plugins/admin/types';
 import { AccessControlAction } from 'app/types/accessControl';
 
 import { Recommendations } from './Recommendations';
+import { fetchOrgUserCount } from './inviteTeam';
 import {
   fetchClusterCpuSeries,
   fetchKubernetesHealth,
@@ -41,6 +42,11 @@ jest.mock('./kubernetesData', () => ({
   fetchClusterCpuSeries: jest.fn().mockResolvedValue(null),
 }));
 
+jest.mock('./inviteTeam', () => ({
+  ...jest.requireActual('./inviteTeam'),
+  fetchOrgUserCount: jest.fn(),
+}));
+
 const APP_IDS = [
   'grafana-exploretraces-app',
   'grafana-synthetic-monitoring-app',
@@ -53,8 +59,10 @@ const listItem = (id: string, overrides: Partial<LocalPlugin> = {}) => ({
   accessControl: { [AccessControlAction.PluginsWrite]: true },
   ...overrides,
 });
+const mockAllAppsEnabled = () => mockGet.mockResolvedValue(APP_IDS.map((id) => listItem(id, { enabled: true })));
 
 const mockUsePluginBridge = jest.mocked(usePluginBridge);
+const mockFetchOrgUserCount = jest.mocked(fetchOrgUserCount);
 
 beforeEach(() => {
   window.localStorage.clear();
@@ -66,6 +74,7 @@ beforeEach(() => {
   });
   mockGet.mockReset();
   mockGet.mockResolvedValue(APP_IDS.map((id) => listItem(id)));
+  mockFetchOrgUserCount.mockResolvedValue(1);
   jest.spyOn(contextSrv, 'hasPermission').mockReturnValue(true);
 });
 
@@ -192,6 +201,87 @@ describe('Recommendations', () => {
       await waitFor(() => expect(container).toBeEmptyDOMElement());
     } finally {
       config.pluginAdminEnabled = true;
+    }
+  });
+
+  it('appends the invite-team recommendation as the last carousel item', async () => {
+    const { user } = render(<Recommendations />);
+
+    await screen.findByText('Recommendations for your stack');
+    // 4 plugin cards + invite; wrapping backwards from the first slide lands on the invite card.
+    await user.click(screen.getByRole('button', { name: 'Previous' }));
+
+    expect(screen.getByRole('heading', { name: 'Invite your team' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Invite teammates/ })).toHaveAttribute('href', '/org/users/invite');
+  });
+
+  it('falls back to the invite-team recommendation when every app is already enabled', async () => {
+    mockAllAppsEnabled();
+
+    render(<Recommendations />);
+
+    expect(await screen.findByRole('heading', { name: 'Invite your team' })).toBeInTheDocument();
+    // Count resolved to 1 — the solo claim is grounded, not static copy.
+    expect(screen.getByText("You're the only user here")).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /Enable Hosted Traces/, hidden: true })).not.toBeInTheDocument();
+  });
+
+  it('grounds the invite context in the org user count', async () => {
+    mockAllAppsEnabled();
+    mockFetchOrgUserCount.mockResolvedValue(12);
+
+    render(<Recommendations />);
+
+    expect(await screen.findByText('12 users in this organization')).toBeInTheDocument();
+    expect(screen.queryByText(/only user here/)).not.toBeInTheDocument();
+  });
+
+  it('uses countless invite copy when the user count is unavailable', async () => {
+    mockAllAppsEnabled();
+    mockFetchOrgUserCount.mockResolvedValue(null);
+
+    render(<Recommendations />);
+
+    expect(await screen.findByRole('heading', { name: 'Invite your team' })).toBeInTheDocument();
+    expect(screen.getByText('Bring your teammates into Grafana')).toBeInTheDocument();
+    expect(screen.queryByText(/only user here/)).not.toBeInTheDocument();
+  });
+
+  it('renders the section with a count skeleton while the org-user lookup is pending', async () => {
+    mockAllAppsEnabled();
+    mockFetchOrgUserCount.mockImplementation(() => new Promise(() => {}));
+
+    render(<Recommendations />);
+
+    expect(await screen.findByText('Recommendations for your stack')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Invite teammates/ })).toBeInTheDocument();
+    expect(screen.getByTestId('recommendation-context-skeleton')).toBeInTheDocument();
+    expect(screen.queryByText(/users in this organization/)).not.toBeInTheDocument();
+  });
+
+  it('hides the section when nothing is recommendable and the user cannot invite', async () => {
+    mockAllAppsEnabled();
+    jest.mocked(contextSrv.hasPermission).mockImplementation((action) => action !== AccessControlAction.OrgUsersAdd);
+
+    const { container } = render(<Recommendations />);
+
+    await waitFor(() => expect(container).toBeEmptyDOMElement());
+  });
+
+  it('sends the invite CTA to the external user management portal when configured', async () => {
+    const original = config.externalUserMngLinkUrl;
+    config.externalUserMngLinkUrl = 'https://grafana.com/orgs/example/members';
+    try {
+      mockAllAppsEnabled();
+
+      render(<Recommendations />);
+
+      expect(await screen.findByRole('link', { name: /Invite teammates/ })).toHaveAttribute(
+        'href',
+        'https://grafana.com/orgs/example/members'
+      );
+    } finally {
+      config.externalUserMngLinkUrl = original;
     }
   });
 

--- a/public/app/features/home/Recommendations/Recommendations.tsx
+++ b/public/app/features/home/Recommendations/Recommendations.tsx
@@ -5,6 +5,7 @@ import { contextSrv } from 'app/core/services/context_srv';
 import { AccessControlAction } from 'app/types/accessControl';
 
 import { RecommendationsView } from './RecommendationsView';
+import { buildInviteTeamItem, fetchOrgUserCount } from './inviteTeam';
 import { fetchInstalledPlugins, getRecommendations } from './pluginRecommendations';
 
 export function Recommendations() {
@@ -23,6 +24,7 @@ interface GatedRecommendationsProps {
 
 function GatedRecommendations({ canInstall }: GatedRecommendationsProps) {
   const { value: installedPlugins, loading: pluginsLoading } = useAsync(fetchInstalledPlugins, []);
+  const { value: orgUserCount, loading: countLoading } = useAsync(fetchOrgUserCount, []);
 
   // An unavailable plugin list fails closed. /api/plugins always lists at least the core plugins,
   // so an empty response means the list is unreliable and also fails closed.
@@ -44,7 +46,8 @@ function GatedRecommendations({ canInstall }: GatedRecommendationsProps) {
     return contextSrv.hasPermissionInMetadata(AccessControlAction.PluginsWrite, plugin);
   });
 
-  const recommendations = pluginRecommendations;
+  const inviteItem = buildInviteTeamItem(orgUserCount ?? null, countLoading);
+  const recommendations = inviteItem ? [...pluginRecommendations, inviteItem] : pluginRecommendations;
   if (recommendations.length === 0) {
     return null;
   }

--- a/public/app/features/home/Recommendations/RecommendationsView.tsx
+++ b/public/app/features/home/Recommendations/RecommendationsView.tsx
@@ -37,7 +37,7 @@ export function RecommendationsView({ recommendations }: RecommendationsViewProp
   const safeIndex = Math.min(index, recommendations.length - 1);
 
   useEffect(() => {
-    if (collapsed || paused) {
+    if (collapsed || paused || recommendations.length <= 1) {
       return;
     }
 
@@ -116,10 +116,10 @@ export function RecommendationsView({ recommendations }: RecommendationsViewProp
                     aria-label={t('home.recommendations.previous', 'Previous')}
                   />
 
-                  {recommendations.map((_, i) =>
+                  {recommendations.map((recommendation, i) =>
                     i === safeIndex ? (
                       <Button
-                        key={i}
+                        key={recommendation.id}
                         variant="secondary"
                         size="sm"
                         fill="solid"
@@ -133,7 +133,7 @@ export function RecommendationsView({ recommendations }: RecommendationsViewProp
                       />
                     ) : (
                       <Button
-                        key={i}
+                        key={recommendation.id}
                         variant="secondary"
                         size="sm"
                         fill="solid"

--- a/public/app/features/home/Recommendations/inviteTeam.ts
+++ b/public/app/features/home/Recommendations/inviteTeam.ts
@@ -1,0 +1,79 @@
+import { locationUtil } from '@grafana/data';
+import { t } from '@grafana/i18n';
+import { config, getBackendSrv } from '@grafana/runtime';
+import { contextSrv } from 'app/core/services/context_srv';
+import { getCanInviteUsersToOrg, getExternalUserMngLinkUrl } from 'app/features/users/utils';
+import { AccessControlAction } from 'app/types/accessControl';
+
+import type { RecommendationItem } from './types';
+
+// Minimal slice of the /api/org/users/search payload; the full result also carries orgUsers/paging.
+interface OrgUsersSearchResult {
+  totalCount?: number;
+}
+
+/**
+ * Number of (non-hidden) users in the current org, or null when the requester lacks
+ * org.users:read or the lookup fails — callers fall back to copy without numbers. Never rejects.
+ */
+export async function fetchOrgUserCount(): Promise<number | null> {
+  if (!contextSrv.hasPermission(AccessControlAction.OrgUsersRead)) {
+    return null;
+  }
+  try {
+    const result = await getBackendSrv().get<OrgUsersSearchResult>('/api/org/users/search', { perpage: 1, page: 1 });
+    return typeof result.totalCount === 'number' ? result.totalCount : null;
+  } catch {
+    return null;
+  }
+}
+
+// Where "Invite teammates" sends the user: the external user-management portal when one is
+// configured (hosted Grafana), otherwise the built-in invite page. Null when the user cannot
+// add org users or no invite path exists.
+function getInviteTeamHref(): string | null {
+  if (config.externalUserMngLinkUrl) {
+    if (!contextSrv.hasPermission(AccessControlAction.OrgUsersAdd)) {
+      return null;
+    }
+    try {
+      return getExternalUserMngLinkUrl('home-recommendations');
+    } catch {
+      return null; // malformed config.externalUserMngLinkUrl must not take down the homepage
+    }
+  }
+  return getCanInviteUsersToOrg() ? locationUtil.assureBaseUrl('/org/users/invite') : null;
+}
+
+/**
+ * The always-appended last recommendation: bring teammates in. It doubles as the fallback that
+ * keeps the section rendered when every curated app is enabled. Null when the user cannot invite.
+ * The context line only states a user count that was actually resolved — never a static claim.
+ */
+export function buildInviteTeamItem(userCount: number | null, countLoading = false): RecommendationItem | null {
+  const href = getInviteTeamHref();
+  if (!href) {
+    return null;
+  }
+  return {
+    id: 'invite-team',
+    icon: 'users-alt',
+    color: (theme) => theme.visualization.getColorByName('yellow'),
+    title: t('home.recommendations.invite-team.title', 'Invite your team'),
+    contextLoading: countLoading,
+    context:
+      userCount !== null && userCount >= 1
+        ? t('home.recommendations.invite-team.user-count', '', {
+            count: userCount,
+            defaultValue_one: "You're the only user here",
+            defaultValue_other: '{{count}} users in this organization',
+          })
+        : t('home.recommendations.invite-team.context', 'Bring your teammates into Grafana'),
+    description: t(
+      'home.recommendations.invite-team.description',
+      'Observability is a team sport — share dashboards, alerts, and on-call with your teammates.'
+    ),
+    action: t('home.recommendations.invite-team.action', 'Invite teammates'),
+    href,
+  };
+}

--- a/public/app/features/home/Recommendations/types.ts
+++ b/public/app/features/home/Recommendations/types.ts
@@ -8,6 +8,7 @@ export interface RecommendationItem {
   icon: IconName;
   color: string | ((theme: GrafanaTheme2) => string);
   context: string; // short "why you are seeing this" line under the title
+  contextLoading?: boolean; // context line renders a skeleton while true
   description: string;
   action: string; // CTA label, e.g. "Enable Hosted Traces"
   href: string;

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -10943,6 +10943,14 @@
         "description": "Add distributed tracing to see how requests flow between services and where they slow down.",
         "title": "Trace requests across services"
       },
+      "invite-team": {
+        "action": "Invite teammates",
+        "context": "Bring your teammates into Grafana",
+        "description": "Observability is a team sport — share dashboards, alerts, and on-call with your teammates.",
+        "title": "Invite your team",
+        "user-count_one": "You're the only user here",
+        "user-count_other": "{{count}} users in this organization"
+      },
       "kubernetes": {
         "action": "Open K8s app",
         "alerts-firing_one": "{{value}} alert firing",


### PR DESCRIPTION
## What

Adds the invite-team recommendation as the last carousel card on the homepage recommendations section, extracted from #127858 so that PR stays Kubernetes-only:

- `inviteTeam.ts`: org-user count lookup (`/api/org/users/search`), invite href (external user management portal when configured), and the card builder gated on `OrgUsersAdd`.
- Context line grounds the copy in the org user count, with a skeleton while the lookup is pending (`contextLoading`).
- `fix(home)`: autoplay is skipped when there is a single recommendation, and carousel dots are keyed by `recommendation.id` instead of index (review feedback from #127858).
