### PR TITLE
Search: hold per-kind search fields in a shared registry

### DIFF
--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -205,8 +205,7 @@ type searchServer struct {
 	maxIndexAge          time.Duration
 	minBuildVersion      *semver.Version
 	buildVersion         *semver.Version
-	selectableFields     map[LowerGroupResource][]string
-	searchFieldsHashes   map[LowerGroupResource]string
+	searchFields         *SearchFieldsRegistry
 
 	bgTaskWg     sync.WaitGroup
 	bgTaskCancel func()
@@ -275,6 +274,11 @@ func newSearchServer(opts SearchOptions, storage StorageBackend, vectorBackend v
 		}
 	}
 
+	searchFields := opts.SearchFields
+	if searchFields == nil {
+		searchFields = NewSearchFieldsRegistry(nil, nil, nil)
+	}
+
 	s := &searchServer{
 		access:         access,
 		storage:        storage,
@@ -293,8 +297,7 @@ func newSearchServer(opts SearchOptions, storage StorageBackend, vectorBackend v
 		maxIndexAge:               opts.MaxIndexAge,
 		minBuildVersion:           opts.MinBuildVersion,
 		buildVersion:              opts.BuildVersion,
-		selectableFields:          opts.SelectableFieldsForKinds,
-		searchFieldsHashes:        opts.SearchFieldsHashesForKinds,
+		searchFields:              searchFields,
 		injectFailuresPercent:     opts.InjectFailuresPercent,
 		indexModificationCacheTTL: opts.IndexModificationCacheTTL,
 
@@ -1343,8 +1346,7 @@ func (s *searchServer) findIndexesToRebuild(lastImportTimes map[NamespacedResour
 		}
 
 		sfKey := NewLowerGroupResource(key.Group, key.Resource)
-		sfields := s.selectableFields[sfKey]
-		expectedSearchFieldsHash := s.searchFieldsHashes[sfKey]
+		sfields, expectedSearchFieldsHash, _ := s.searchFields.For(sfKey)
 
 		if shouldRebuildIndex(bi, s.minBuildVersion, s.buildVersion, minBuildTime, lastImportTime, sfields, expectedSearchFieldsHash, nil) {
 			completeCh := make(chan struct{})

--- a/pkg/storage/unified/resource/search_field.go
+++ b/pkg/storage/unified/resource/search_field.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"sync"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -563,4 +564,52 @@ func (p *mapProvider) IndexAffectingHash(group, resource string) string {
 	}
 	sum := sha256.Sum256(blob)
 	return hex.EncodeToString(sum[:])
+}
+
+// SearchFieldsRegistry holds the per-kind search-field wiring shared by the
+// index backend (which builds the bleve mapping) and the search server (which
+// decides when an index must be rebuilt). A mutex guards all three maps so a
+// future live-manifest source can replace them together, keeping the mapping
+// the backend builds and the hash the server compares consistent.
+type SearchFieldsRegistry struct {
+	mu                   sync.RWMutex
+	selectableFields     map[LowerGroupResource][]string
+	searchFieldsHashes   map[LowerGroupResource]string
+	searchFieldsProvider map[LowerGroupResource]SearchFieldsProvider
+}
+
+// NewSearchFieldsRegistry returns a registry seeded with the given per-kind
+// maps. Nil maps are allowed; lookups then return zero values.
+func NewSearchFieldsRegistry(
+	selectableFields map[LowerGroupResource][]string,
+	searchFieldsHashes map[LowerGroupResource]string,
+	searchFieldsProvider map[LowerGroupResource]SearchFieldsProvider,
+) *SearchFieldsRegistry {
+	return &SearchFieldsRegistry{
+		selectableFields:     selectableFields,
+		searchFieldsHashes:   searchFieldsHashes,
+		searchFieldsProvider: searchFieldsProvider,
+	}
+}
+
+// For returns the mapping inputs for a kind: its selectable fields, the hash of
+// its search-field definitions, and the provider that drives its bleve mapping.
+func (r *SearchFieldsRegistry) For(key LowerGroupResource) (selectableFields []string, hash string, provider SearchFieldsProvider) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.selectableFields[key], r.searchFieldsHashes[key], r.searchFieldsProvider[key]
+}
+
+// Replace atomically swaps all three maps. Callers must not mutate the maps
+// afterwards. A live-manifest source uses this to reload search fields.
+func (r *SearchFieldsRegistry) Replace(
+	selectableFields map[LowerGroupResource][]string,
+	searchFieldsHashes map[LowerGroupResource]string,
+	searchFieldsProvider map[LowerGroupResource]SearchFieldsProvider,
+) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.selectableFields = selectableFields
+	r.searchFieldsHashes = searchFieldsHashes
+	r.searchFieldsProvider = searchFieldsProvider
 }

--- a/pkg/storage/unified/resource/search_field_test.go
+++ b/pkg/storage/unified/resource/search_field_test.go
@@ -466,3 +466,48 @@ func TestValidateCrossVersionConsistency(t *testing.T) {
 			})
 	})
 }
+
+func TestSearchFieldsRegistry(t *testing.T) {
+	dash := NewLowerGroupResource("dashboard.grafana.app", "dashboards")
+	provider := NewMapProvider(
+		map[schema.GroupVersionResource][]SearchFieldDefinition{
+			{Group: "dashboard.grafana.app", Version: "v1", Resource: "dashboards"}: {
+				{Name: "title", Path: "spec.title", Type: SearchFieldTypeString, Capabilities: []SearchCapability{SearchCapabilityFilter}},
+			},
+		},
+		nil,
+	)
+
+	r := NewSearchFieldsRegistry(
+		map[LowerGroupResource][]string{dash: {"spec.a", "spec.b"}},
+		map[LowerGroupResource]string{dash: "hash-1"},
+		map[LowerGroupResource]SearchFieldsProvider{dash: provider},
+	)
+
+	t.Run("reads the seeded values", func(t *testing.T) {
+		selectable, hash, p := r.For(dash)
+		require.Equal(t, []string{"spec.a", "spec.b"}, selectable)
+		require.Equal(t, "hash-1", hash)
+		require.Same(t, provider, p)
+	})
+
+	t.Run("returns zero values for an unknown kind", func(t *testing.T) {
+		other := NewLowerGroupResource("iam.grafana.app", "users")
+		selectable, hash, p := r.For(other)
+		require.Nil(t, selectable)
+		require.Empty(t, hash)
+		require.Nil(t, p)
+	})
+
+	t.Run("Replace swaps all three maps", func(t *testing.T) {
+		r.Replace(
+			map[LowerGroupResource][]string{dash: {"spec.c"}},
+			map[LowerGroupResource]string{dash: "hash-2"},
+			nil,
+		)
+		selectable, hash, p := r.For(dash)
+		require.Equal(t, []string{"spec.c"}, selectable)
+		require.Equal(t, "hash-2", hash)
+		require.Nil(t, p)
+	})
+}

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -280,15 +280,11 @@ type SearchOptions struct {
 	// Percentage of search requests that should fail immediately (0-100). 0 = disabled, 100 = all requests fail.
 	InjectFailuresPercent int
 
-	// Selectable fields per kind, keyed by (group, kind) and (group, plural).
-	SelectableFieldsForKinds map[LowerGroupResource][]string
-
-	// Hash of the SearchFieldDefinition slices registered for a (group,
-	// resource) across every version, keyed by (group, resource). The search
-	// server compares this against the value stored in each index's
-	// IndexBuildInfo and triggers a rebuild on mismatch. Entries with empty
-	// hash strings are ignored.
-	SearchFieldsHashesForKinds map[LowerGroupResource]string
+	// SearchFields holds the per-kind search-field wiring shared with the index
+	// backend. The search server reads the selectable fields and the definition
+	// hash from it and triggers a rebuild when either differs from the values
+	// stored in an index's IndexBuildInfo. May be nil.
+	SearchFields *SearchFieldsRegistry
 
 	// Index snapshot settings — enable downloading pre-built search indexes from object storage on startup.
 	// IndexSnapshotEnabled gates the entire snapshot feature.

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -80,21 +80,12 @@ type BleveOptions struct {
 	// If nil, all indexes are owned by the current instance.
 	OwnsIndex func(key resource.NamespacedResource) (bool, error)
 
-	// Selectable fields per kind, keyed by (group, kind) and (group, plural).
-	// Only given fields are indexed (have mapping).
-	SelectableFieldsForKinds map[resource.LowerGroupResource][]string
-
-	// Hash of the SearchFieldDefinition slices registered for a (group,
-	// resource) across every version, keyed by (group, resource). The value
-	// is recorded in each new index's IndexBuildInfo so a future run can
-	// detect drift and rebuild.
-	SearchFieldsHashesForKinds map[resource.LowerGroupResource]string
-
-	// SearchFieldsProvider per (group, resource) that drives the bleve
-	// mapping. When a provider is registered for a kind, the bleve mapping is
-	// built from the provider's SearchFieldDefinitions rather than from the
-	// legacy column-definition list carried by SearchableDocumentFields.
-	SearchFieldsProvidersForKinds map[resource.LowerGroupResource]resource.SearchFieldsProvider
+	// SearchFields holds the per-kind search-field wiring: selectable fields,
+	// the hash of the SearchFieldDefinitions (recorded in each new index's
+	// IndexBuildInfo for drift detection), and the provider that drives the
+	// bleve mapping. Shared with the search server so both see the same set.
+	// May be nil in tests.
+	SearchFields *resource.SearchFieldsRegistry
 
 	// Snapshot configures remote index snapshot download at build time.
 	// If Snapshot.Store is nil, the feature is disabled and BuildIndex behaves exactly as before.
@@ -189,9 +180,7 @@ type bleveBackend struct {
 
 	indexMetrics *resource.BleveIndexMetrics
 
-	selectableFields     map[resource.LowerGroupResource][]string
-	searchFieldsHashes   map[resource.LowerGroupResource]string
-	searchFieldsProvider map[resource.LowerGroupResource]resource.SearchFieldsProvider
+	fields *resource.SearchFieldsRegistry
 
 	// Parsed opts.BuildVersion for snapshot tier comparisons. Nil if BuildVersion
 	// is empty. Guaranteed non-nil when opts.Snapshot.Store is set.
@@ -265,15 +254,18 @@ func NewBleveBackend(opts BleveOptions, indexMetrics *resource.BleveIndexMetrics
 		ownFn = func(key resource.NamespacedResource) (bool, error) { return true, nil }
 	}
 
+	fields := opts.SearchFields
+	if fields == nil {
+		fields = resource.NewSearchFieldsRegistry(nil, nil, nil)
+	}
+
 	be := &bleveBackend{
 		log:                     l,
 		cache:                   map[resource.NamespacedResource]*bleveIndex{},
 		opts:                    opts,
 		ownsIndexFn:             ownFn,
 		indexMetrics:            indexMetrics,
-		selectableFields:        opts.SelectableFieldsForKinds,
-		searchFieldsHashes:      opts.SearchFieldsHashesForKinds,
-		searchFieldsProvider:    opts.SearchFieldsProvidersForKinds,
+		fields:                  fields,
 		runningBuildVersion:     runningBuildVersion,
 		maxSupportedIndexFormat: maxSupportedFormat,
 		lastUploadTime:          map[resource.NamespacedResource]time.Time{},
@@ -752,9 +744,7 @@ func (b *bleveBackend) BuildIndex(
 	)
 
 	sfKey := resource.NewLowerGroupResource(key.Group, key.Resource)
-	selectableFields := b.selectableFields[sfKey]
-	searchFieldsHash := b.searchFieldsHashes[sfKey]
-	searchFieldsProvider := b.searchFieldsProvider[sfKey]
+	selectableFields, searchFieldsHash, searchFieldsProvider := b.fields.For(sfKey)
 
 	mapper, err := GetBleveMappings(searchFieldsProvider, key.Group, key.Resource, selectableFields)
 	if err != nil {

--- a/pkg/storage/unified/search/bleve_lifecycle_test.go
+++ b/pkg/storage/unified/search/bleve_lifecycle_test.go
@@ -276,9 +276,9 @@ func newFileBackedDashboardIndex(t *testing.T, key resource.NamespacedResource, 
 	})
 	require.NoError(t, err)
 
-	backend, _ := setupBleveBackend(t, withFileThreshold(0), withSearchFieldsProvidersForKinds(map[resource.LowerGroupResource]resource.SearchFieldsProvider{
+	backend, _ := setupBleveBackend(t, withFileThreshold(0), withSearchFields(resource.NewSearchFieldsRegistry(nil, nil, map[resource.LowerGroupResource]resource.SearchFieldsProvider{
 		resource.NewLowerGroupResource("dashboard.grafana.app", "dashboards"): info.SearchFieldsProvider,
-	}))
+	})))
 	ctx := identity.WithRequester(t.Context(), &user.SignedInUser{Namespace: key.Namespace})
 
 	resourceIndex, err := backend.BuildIndex(ctx, key, docCount, "test", func(index resource.ResourceIndex) (int64, error) {

--- a/pkg/storage/unified/search/bleve_performance_test.go
+++ b/pkg/storage/unified/search/bleve_performance_test.go
@@ -73,9 +73,9 @@ func benchmarkBuildIndex(b *testing.B, docs int, fileThreshold int64) {
 		Root:          b.TempDir(),
 		FileThreshold: fileThreshold,
 		BuildVersion:  "12.3.45-789",
-		SearchFieldsProvidersForKinds: map[resource.LowerGroupResource]resource.SearchFieldsProvider{
+		SearchFields: resource.NewSearchFieldsRegistry(nil, nil, map[resource.LowerGroupResource]resource.SearchFieldsProvider{
 			resource.NewLowerGroupResource("dashboard.grafana.app", "dashboards"): info.SearchFieldsProvider,
-		},
+		}),
 	}, nil)
 	require.NoError(b, err)
 	defer backend.Stop()

--- a/pkg/storage/unified/search/bleve_search_test.go
+++ b/pkg/storage/unified/search/bleve_search_test.go
@@ -674,9 +674,9 @@ func newTestDashboardsIndex(t testing.TB, threshold int64, size int64, writer re
 	backend, err := search.NewBleveBackend(search.BleveOptions{
 		Root:          t.TempDir(),
 		FileThreshold: threshold, // use in-memory for tests
-		SearchFieldsProvidersForKinds: map[resource.LowerGroupResource]resource.SearchFieldsProvider{
+		SearchFields: resource.NewSearchFieldsRegistry(nil, nil, map[resource.LowerGroupResource]resource.SearchFieldsProvider{
 			resource.NewLowerGroupResource("dashboard.grafana.app", "dashboards"): info.SearchFieldsProvider,
-		},
+		}),
 	}, nil)
 	require.NoError(t, err)
 
@@ -716,9 +716,9 @@ func newTestIndexWithFields(t testing.TB, key resource.NamespacedResource, colum
 	sfKey := resource.NewLowerGroupResource(key.Group, key.Resource)
 
 	backend, err := search.NewBleveBackend(search.BleveOptions{
-		Root:                          t.TempDir(),
-		FileThreshold:                 threshold,
-		SearchFieldsProvidersForKinds: map[resource.LowerGroupResource]resource.SearchFieldsProvider{sfKey: provider},
+		Root:          t.TempDir(),
+		FileThreshold: threshold,
+		SearchFields:  resource.NewSearchFieldsRegistry(nil, nil, map[resource.LowerGroupResource]resource.SearchFieldsProvider{sfKey: provider}),
 	}, nil)
 	require.NoError(t, err)
 	t.Cleanup(backend.Stop)
@@ -782,9 +782,9 @@ func TestIndexAndSearchSelectableFields(t *testing.T) {
 	backend, err := search.NewBleveBackend(search.BleveOptions{
 		Root:          t.TempDir(),
 		FileThreshold: threshold, // use in-memory for tests
-		SelectableFieldsForKinds: map[resource.LowerGroupResource][]string{
+		SearchFields: resource.NewSearchFieldsRegistry(map[resource.LowerGroupResource][]string{
 			resource.NewLowerGroupResource(key.Group, key.Resource): {"spec.some.field", "spec.some.other.field"},
-		},
+		}, nil, nil),
 	}, nil)
 	require.NoError(t, err)
 	t.Cleanup(backend.Stop)
@@ -1024,9 +1024,9 @@ func newTestDashboardsIndexPostRankWithConfig(t testing.TB, size int64, cfg sear
 		FileThreshold:        threshold, // use in-memory for tests
 		PostRankAuthzEnabled: true,
 		PostRankAuthz:        cfg,
-		SearchFieldsProvidersForKinds: map[resource.LowerGroupResource]resource.SearchFieldsProvider{
+		SearchFields: resource.NewSearchFieldsRegistry(nil, nil, map[resource.LowerGroupResource]resource.SearchFieldsProvider{
 			resource.NewLowerGroupResource("dashboard.grafana.app", "dashboards"): info.SearchFieldsProvider,
-		},
+		}),
 	}, nil)
 	require.NoError(t, err)
 	t.Cleanup(backend.Stop)

--- a/pkg/storage/unified/search/bleve_test.go
+++ b/pkg/storage/unified/search/bleve_test.go
@@ -58,9 +58,9 @@ func TestBleveBackend(t *testing.T) {
 	backend, err := NewBleveBackend(BleveOptions{
 		Root:          tmpdir,
 		FileThreshold: 5, // with more than 5 items we create a file on disk
-		SearchFieldsProvidersForKinds: map[resource.LowerGroupResource]resource.SearchFieldsProvider{
+		SearchFields: resource.NewSearchFieldsRegistry(nil, nil, map[resource.LowerGroupResource]resource.SearchFieldsProvider{
 			resource.NewLowerGroupResource("dashboard.grafana.app", "dashboards"): dashInfo.SearchFieldsProvider,
-		},
+		}),
 	}, nil)
 	require.NoError(t, err)
 	t.Cleanup(backend.Stop)
@@ -80,9 +80,9 @@ func TestBleveSearchRootFolderExpansion(t *testing.T) {
 	backend, err := NewBleveBackend(BleveOptions{
 		Root:          tmpdir,
 		FileThreshold: 5,
-		SearchFieldsProvidersForKinds: map[resource.LowerGroupResource]resource.SearchFieldsProvider{
+		SearchFields: resource.NewSearchFieldsRegistry(nil, nil, map[resource.LowerGroupResource]resource.SearchFieldsProvider{
 			resource.NewLowerGroupResource("dashboard.grafana.app", "dashboards"): dashInfo.SearchFieldsProvider,
-		},
+		}),
 	}, nil)
 	require.NoError(t, err)
 	t.Cleanup(backend.Stop)
@@ -1113,15 +1113,9 @@ func withIndexMinUpdateInterval(d time.Duration) setupOption {
 	}
 }
 
-func withSearchFieldsHashesForKinds(m map[resource.LowerGroupResource]string) setupOption {
+func withSearchFields(reg *resource.SearchFieldsRegistry) setupOption {
 	return func(options *BleveOptions) {
-		options.SearchFieldsHashesForKinds = m
-	}
-}
-
-func withSearchFieldsProvidersForKinds(m map[resource.LowerGroupResource]resource.SearchFieldsProvider) setupOption {
-	return func(options *BleveOptions) {
-		options.SearchFieldsProvidersForKinds = m
+		options.SearchFields = reg
 	}
 }
 func TestMemoryBleveIndexCanBeCopiedToFilesystem(t *testing.T) {
@@ -2215,7 +2209,7 @@ func TestIndexBuildInfoSearchFieldsHashRoundTrip(t *testing.T) {
 		resource.NewLowerGroupResource(ns.Group, ns.Resource): hash,
 	}
 
-	be, _ := setupBleveBackend(t, withFileThreshold(100), withSearchFieldsHashesForKinds(hashes))
+	be, _ := setupBleveBackend(t, withFileThreshold(100), withSearchFields(resource.NewSearchFieldsRegistry(nil, hashes, nil)))
 	index, err := be.BuildIndex(t.Context(), ns, 10, "test", indexTestDocs(ns, 10, 100), nil, false, time.Time{}, 0)
 	require.NoError(t, err)
 

--- a/pkg/storage/unified/search/options.go
+++ b/pkg/storage/unified/search/options.go
@@ -102,6 +102,11 @@ func NewSearchOptions(
 			searchFieldsHashes = resource.SearchFieldsHashesForProviders(searchFieldsProviders)
 		}
 
+		// One registry holds selectable fields, hashes, and providers, shared by the
+		// index backend and the search server so a future live-manifest source can
+		// swap them consistently.
+		searchFields := resource.NewSearchFieldsRegistry(resource.SelectableFields(), searchFieldsHashes, searchFieldsProviders)
+
 		bleve, err := NewBleveBackend(BleveOptions{
 			Root:                           root,
 			FileThreshold:                  int64(cfg.IndexFileThreshold), // fewer than X items will use a memory index
@@ -109,9 +114,7 @@ func NewSearchOptions(
 			BuildVersion:                   cfg.BuildVersion,
 			OwnsIndex:                      ownsIndexFn,
 			IndexMinUpdateInterval:         cfg.IndexMinUpdateInterval,
-			SelectableFieldsForKinds:       resource.SelectableFields(),
-			SearchFieldsHashesForKinds:     searchFieldsHashes,
-			SearchFieldsProvidersForKinds:  searchFieldsProviders,
+			SearchFields:                   searchFields,
 			Snapshot:                       snapshot,
 			DiskCleanupInterval:            cfg.DiskIndexCleanupInterval,
 			DiskCleanupGracePeriod:         cfg.DiskIndexCleanupGracePeriod,
@@ -151,7 +154,7 @@ func NewSearchOptions(
 			IndexSnapshotLockTTL:            DefaultSnapshotLockTTL,
 			IndexSnapshotCleanupInterval:    DefaultSnapshotCleanupInterval,
 			IndexSnapshotCleanupGracePeriod: cleanupGracePeriodOrDefault(cfg.IndexSnapshotCleanupGracePeriod),
-			SearchFieldsHashesForKinds:      searchFieldsHashes,
+			SearchFields:                    searchFields,
 		}, nil
 	}
 	return resource.SearchOptions{


### PR DESCRIPTION
The index backend and the search server each kept their own copies of the per-kind selectable fields, definition hashes, and providers. This moves them into a single mutex-guarded `SearchFieldsRegistry` that both reference, so the mapping the backend builds and the hash the server compares always come from one place. It also lets a future runtime manifest source swap all three together atomically.

There is no behavior change: the registry is seeded from the same data as before and both consumers read the same values. Along the way this drops the now-redundant per-kind option and struct fields (`SelectableFieldsForKinds`, `SearchFieldsHashesForKinds`, `SearchFieldsProvidersForKinds` and the server's separate maps), which collapse into the one registry. The registry's `Replace` method has no caller yet; it is the hook the runtime source will use.

Part of grafana/search-and-storage-team#827.
