### PR TITLE
Datasources: capture external (gRPC) plugin traffic for on-demand diagnostics

### DIFF
--- a/pkg/api/ds_query_diagnostics.go
+++ b/pkg/api/ds_query_diagnostics.go
@@ -73,8 +73,13 @@ func (hs *HTTPServer) QueryDiagnostics(c *contextmodel.ReqContext) response.Resp
 	resp, queryErr := queryData(captureCtx, c.SignedInUser, c.SkipDSCache, reqDTO.MetricRequest)
 
 	// A datasource query usually fails per-refId (DataResponse.Error) with no top-level error, the
-	// same way QueryMetricsV2 surfaces failures. Capture that too so it's recorded in the bundle.
+	// same way QueryMetricsV2 surfaces failures. Capture that too so it's recorded in the bundle. An
+	// externalized plugin whose top-level QueryData error was swallowed to survive the gRPC boundary
+	// carries it in the __har__ frame instead; fold that in as well.
 	respErr := diagnostics.ResponseError(resp)
+	if respErr == nil {
+		respErr = diagnostics.PluginCaptureError(resp)
+	}
 
 	// If the query failed before any traffic was captured (e.g. pre-flight access-denied or
 	// datasource-not-found, which never reach the datasource), there's nothing to diagnose, so
@@ -83,7 +88,7 @@ func (hs *HTTPServer) QueryDiagnostics(c *contextmodel.ReqContext) response.Resp
 	// failure is a client error (400). A failure that did hit the wire leaves captured traffic and
 	// falls through — that captured failure is exactly what the bundle is for, recorded alongside
 	// query-error.txt.
-	if !diagnostics.HasCapturedHAR(harBuffer) {
+	if !diagnostics.HasCapturedHAR(resp, harBuffer) {
 		if r := hs.diagnosticsNoCaptureError(queryErr, respErr); r != nil {
 			return r
 		}
@@ -94,7 +99,7 @@ func (hs *HTTPServer) QueryDiagnostics(c *contextmodel.ReqContext) response.Resp
 	if bundleErr == nil {
 		bundleErr = respErr
 	}
-	bundle, err := diagnostics.NewBundler().Build(harBuffer, reqDTO.Panel, reqDTO.Dashboard, bundleErr)
+	bundle, err := diagnostics.NewBundler().Build(resp, harBuffer, reqDTO.Panel, reqDTO.Dashboard, bundleErr)
 	if err != nil {
 		return response.Error(http.StatusInternalServerError, "failed to build diagnostics bundle", err)
 	}

--- a/pkg/api/ds_query_diagnostics.go
+++ b/pkg/api/ds_query_diagnostics.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -76,10 +77,11 @@ func (hs *HTTPServer) QueryDiagnostics(c *contextmodel.ReqContext) response.Resp
 	// same way QueryMetricsV2 surfaces failures. Capture that too so it's recorded in the bundle. An
 	// externalized plugin whose top-level QueryData error was swallowed to survive the gRPC boundary
 	// carries it in the __har__ frame instead; fold that in as well.
-	respErr := diagnostics.ResponseError(resp)
-	if respErr == nil {
-		respErr = diagnostics.PluginCaptureError(resp)
-	}
+	// Combine both: a mixed multi-datasource panel can carry a per-refId failure (ResponseError) AND
+	// an external plugin's swallowed error (PluginCaptureError, from the __har__ frame) at the same
+	// time, so folding in only one would drop the other from query-error.txt. errors.Join is nil-safe
+	// (returns nil when both are nil).
+	respErr := errors.Join(diagnostics.ResponseError(resp), diagnostics.PluginCaptureError(resp))
 
 	// If the query failed before any traffic was captured (e.g. pre-flight access-denied or
 	// datasource-not-found, which never reach the datasource), there's nothing to diagnose, so

--- a/pkg/services/diagnostics/diagnostics.go
+++ b/pkg/services/diagnostics/diagnostics.go
@@ -154,12 +154,15 @@ func HasCapturedHAR(resp *backend.QueryDataResponse, harBuffer *harcapture.Buffe
 	if harBuffer != nil && harBuffer.Len() > 0 {
 		return true
 	}
-	// Only count a frame that actually carries a non-empty "har" payload -- the same thing collectHAR
-	// extracts. A frame present but without a har payload contributes nothing, so treating it as
-	// "captured" would wrongly suppress the no-capture error path.
+	// A frame only counts if its "har" payload actually parses as HAR JSON -- entries may
+	// legitimately be empty (the plugin's capture middleware ran but made zero HTTP calls), but a
+	// malformed payload is indistinguishable from no payload at all: collectHAR/mergeHAR would skip
+	// it and contribute nothing to the bundle, so treating it as "captured" here would wrongly
+	// suppress the no-capture error path and leave the handler returning a 200 bundle with no
+	// traffic.har.
 	captured := false
 	forEachHARFrameCustom(resp, func(custom map[string]interface{}) {
-		if harStr, ok := custom["har"].(string); ok && harStr != "" {
+		if harStr, ok := custom["har"].(string); ok && isParseableHAR(harStr) {
 			captured = true
 		}
 	})
@@ -239,18 +242,29 @@ func collectHAR(resp *backend.QueryDataResponse, harBuffer *harcapture.Buffer) (
 	return mergeHAR(docs)
 }
 
+// harEnvelope is the minimal HAR 1.2 shape used to inspect and merge captured documents.
+type harEnvelope struct {
+	Log struct {
+		Creator json.RawMessage   `json:"creator"`
+		Entries []json.RawMessage `json:"entries"`
+	} `json:"log"`
+}
+
+// isParseableHAR reports whether harStr parses as HAR JSON. Shared by HasCapturedHAR and mergeHAR
+// (via harEnvelope) so both agree on what a malformed payload is: HasCapturedHAR must not count a
+// payload as captured if mergeHAR would just skip it and contribute nothing to the bundle. Entries
+// may legitimately be empty -- that's a real, distinct "the plugin ran but made no calls" case, not
+// a malformed one -- so this only checks parseability, not entry count.
+func isParseableHAR(harStr string) bool {
+	var env harEnvelope
+	return json.Unmarshal([]byte(harStr), &env) == nil
+}
+
 // mergeHAR combines multiple HAR 1.2 documents into a single one by concatenating their
 // log.entries. Documents that fail to parse are skipped. Returns (nil, nil) when there are no
 // entries (a benign "no captured traffic" -- e.g. a valid but empty external frame), and a non-nil
 // error only when the merged result can't be marshaled.
 func mergeHAR(docs [][]byte) ([]byte, error) {
-	type harEnvelope struct {
-		Log struct {
-			Creator json.RawMessage   `json:"creator"`
-			Entries []json.RawMessage `json:"entries"`
-		} `json:"log"`
-	}
-
 	entries := make([]json.RawMessage, 0)
 	var creator json.RawMessage
 	for _, d := range docs {

--- a/pkg/services/diagnostics/diagnostics.go
+++ b/pkg/services/diagnostics/diagnostics.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
@@ -32,10 +33,10 @@ func NewBundler() *Bundler {
 //
 // Server logs are intentionally omitted because they are not scoped to this request and would leak
 // unrelated activity into a bundle meant for external sharing; they will be tackled in a follow-up.
-func (b *Bundler) Build(harBuffer *harcapture.Buffer, panelJSON, dashboardJSON json.RawMessage, queryErr error) ([]byte, error) {
+func (b *Bundler) Build(resp *backend.QueryDataResponse, harBuffer *harcapture.Buffer, panelJSON, dashboardJSON json.RawMessage, queryErr error) ([]byte, error) {
 	files := map[string][]byte{}
 
-	har, err := collectHAR(harBuffer)
+	har, err := collectHAR(resp, harBuffer)
 	if err != nil {
 		return nil, err
 	}
@@ -59,6 +60,40 @@ func (b *Bundler) Build(harBuffer *harcapture.Buffer, panelJSON, dashboardJSON j
 	return buildTarGz(files)
 }
 
+// harResponseRefIDPrefix is the reserved refId prefix for the synthetic capture responses that
+// externalized (gRPC) plugins return. The SDK namespaces the refId per datasource UID (e.g.
+// "__har__P123") so frames from multiple datasources don't collide when Grafana merges a
+// multi-datasource query into one flat response map (pkg/services/query); older/no-UID plugins use
+// the bare prefix. We therefore match these responses by PREFIX, not an exact key.
+const harResponseRefIDPrefix = "__har__"
+
+// isHARResponse reports whether a refId is a synthetic capture response (matched by prefix).
+func isHARResponse(refID string) bool {
+	return strings.HasPrefix(refID, harResponseRefIDPrefix)
+}
+
+// forEachHARFrameCustom calls fn with the Custom map of every frame across all synthetic capture
+// responses (__har__-prefixed) in resp. No-op when resp is nil. Centralizes the nil-checks and type
+// assertion so collectHAR / HasCapturedHAR / PluginCaptureError don't each re-implement them.
+func forEachHARFrameCustom(resp *backend.QueryDataResponse, fn func(custom map[string]interface{})) {
+	if resp == nil {
+		return
+	}
+	for refID, r := range resp.Responses {
+		if !isHARResponse(refID) {
+			continue
+		}
+		for _, frame := range r.Frames {
+			if frame == nil || frame.Meta == nil {
+				continue
+			}
+			if custom, ok := frame.Meta.Custom.(map[string]interface{}); ok {
+				fn(custom)
+			}
+		}
+	}
+}
+
 // ResponseError returns a combined error describing any per-refId query failures in resp
 // (backend.DataResponse.Error), or nil if there are none. Datasource queries usually fail this way
 // — QueryData returns no top-level error while individual responses carry the failure — so a caller
@@ -70,6 +105,12 @@ func ResponseError(resp *backend.QueryDataResponse) error {
 	}
 	refIDs := make([]string, 0, len(resp.Responses))
 	for refID, r := range resp.Responses {
+		// Skip the synthetic capture frames: an externalized plugin sets an error on them (so the
+		// SDK's own middlewares see the failure), but their clean error text is read via
+		// PluginCaptureError, not surfaced here under the reserved refIDs.
+		if isHARResponse(refID) {
+			continue
+		}
 		if r.Error != nil {
 			refIDs = append(refIDs, refID)
 		}
@@ -85,21 +126,160 @@ func ResponseError(resp *backend.QueryDataResponse) error {
 	return errors.Join(errs...)
 }
 
-// HasCapturedHAR reports whether any HAR traffic was captured for this request (the in-process
-// buffer has entries). The handler uses it to decide whether a failed query still has something
-// worth bundling.
-func HasCapturedHAR(harBuffer *harcapture.Buffer) bool {
-	return harBuffer != nil && harBuffer.Len() > 0
+// PluginCaptureError returns the error an externalized (gRPC) plugin stashed alongside its captured
+// __har__ frame (Custom["queryError"]), or nil if absent. The SDK capture middleware records a
+// top-level QueryData error there rather than returning it, because a gRPC error would discard the
+// whole response — and the captured traffic with it — before it crossed the wire. Reading it back
+// here lets the failure still be recorded in the bundle.
+func PluginCaptureError(resp *backend.QueryDataResponse) error {
+	var msgs []string
+	forEachHARFrameCustom(resp, func(custom map[string]interface{}) {
+		if msg, ok := custom["queryError"].(string); ok && msg != "" {
+			msgs = append(msgs, msg)
+		}
+	})
+	if len(msgs) == 0 {
+		return nil
+	}
+	// A multi-datasource run can have more than one external plugin stash an error; report them all,
+	// ordered for determinism.
+	sort.Strings(msgs)
+	return errors.New(strings.Join(msgs, "\n"))
 }
 
-// collectHAR returns the captured HTTP traffic (from the in-process buffer) as HAR 1.2 JSON.
-// Returns (nil, nil) when nothing was captured, and a non-nil error if traffic was captured but
-// could not be serialized (so the caller can fail rather than return an empty bundle).
-func collectHAR(harBuffer *harcapture.Buffer) ([]byte, error) {
-	if harBuffer == nil || harBuffer.Len() == 0 {
+// HasCapturedHAR reports whether any HAR traffic was captured for this request — either the
+// in-process buffer has entries (core plugins) or an external plugin returned a __har__ frame. The
+// handler uses it to decide whether a failed query still has something worth bundling.
+func HasCapturedHAR(resp *backend.QueryDataResponse, harBuffer *harcapture.Buffer) bool {
+	if harBuffer != nil && harBuffer.Len() > 0 {
+		return true
+	}
+	// Only count a frame that actually carries a non-empty "har" payload -- the same thing collectHAR
+	// extracts. A frame present but without a har payload contributes nothing, so treating it as
+	// "captured" would wrongly suppress the no-capture error path.
+	captured := false
+	forEachHARFrameCustom(resp, func(custom map[string]interface{}) {
+		if harStr, ok := custom["har"].(string); ok && harStr != "" {
+			captured = true
+		}
+	})
+	return captured
+}
+
+// collectHAR returns the captured HTTP traffic as HAR 1.2 JSON. It merges two sources: the
+// in-process buffer (core plugins) and the __har__ response frame(s) returned by externalized gRPC
+// plugins. Returns (nil, nil) when nothing was captured, and a non-nil error if traffic was
+// captured but could not be serialized (so the caller can fail rather than return an empty bundle).
+//
+// NOTE: the __har__ frame path is inert until the SDK-side HTTP capture middleware that emits those
+// frames ships and Grafana is bumped to that SDK version — until then external (out-of-process)
+// plugin traffic is NOT captured. Externally-sourced frames are merged VERBATIM: redaction is
+// intentionally deferred (see the harcapture package doc), so — exactly like in-process capture —
+// the recorded headers/cookies/query/URLs/bodies are not sanitized.
+func collectHAR(resp *backend.QueryDataResponse, harBuffer *harcapture.Buffer) ([]byte, error) {
+	var bufferDoc []byte
+	if harBuffer != nil && harBuffer.Len() > 0 {
+		b, err := harBuffer.ToHAR()
+		if err != nil {
+			// The in-process buffer captured traffic but couldn't be serialized. Surface the error
+			// instead of silently dropping traffic.har and returning a success bundle with no
+			// captured traffic.
+			return nil, err
+		}
+		bufferDoc = b
+	}
+
+	// Synthetic __har__-prefixed responses carry capture from externalized gRPC plugins
+	// (out-of-process). The SDK namespaces the refId per datasource (e.g. "__har__P123") so a
+	// multi-datasource query yields one such response per external datasource; collect them all.
+	// These are reserved synthetic refIds; consuming them here is harmless as query results are not
+	// part of the bundle (only captured traffic + panel/dashboard JSON).
+	var frameDocs [][]byte
+	if resp != nil {
+		// Collect the reserved refIds first, then delete + drain them (can't delete while ranging the
+		// map). Sorted so the merged HAR entry order is deterministic across datasources.
+		var harRefIDs []string
+		for refID := range resp.Responses {
+			if isHARResponse(refID) {
+				harRefIDs = append(harRefIDs, refID)
+			}
+		}
+		sort.Strings(harRefIDs)
+		for _, refID := range harRefIDs {
+			harResp := resp.Responses[refID]
+			delete(resp.Responses, refID)
+			// A plugin may split its capture across multiple frames; collect every frame's HAR
+			// payload rather than only the first, so no entries are lost.
+			for _, frame := range harResp.Frames {
+				if frame == nil || frame.Meta == nil {
+					continue
+				}
+				custom, ok := frame.Meta.Custom.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				if harStr, ok := custom["har"].(string); ok && harStr != "" {
+					frameDocs = append(frameDocs, []byte(harStr))
+				}
+			}
+		}
+	}
+
+	// Common case: only the in-process buffer captured traffic (core plugins). Its ToHAR output is
+	// already a complete HAR 1.2 document, so return it directly rather than re-parsing and
+	// re-marshaling every captured request/response through mergeHAR.
+	if len(frameDocs) == 0 {
+		return bufferDoc, nil
+	}
+
+	docs := frameDocs
+	if bufferDoc != nil {
+		docs = append([][]byte{bufferDoc}, frameDocs...)
+	}
+	return mergeHAR(docs)
+}
+
+// mergeHAR combines multiple HAR 1.2 documents into a single one by concatenating their
+// log.entries. Documents that fail to parse are skipped. Returns (nil, nil) when there are no
+// entries (a benign "no captured traffic" -- e.g. a valid but empty external frame), and a non-nil
+// error only when the merged result can't be marshaled.
+func mergeHAR(docs [][]byte) ([]byte, error) {
+	type harEnvelope struct {
+		Log struct {
+			Creator json.RawMessage   `json:"creator"`
+			Entries []json.RawMessage `json:"entries"`
+		} `json:"log"`
+	}
+
+	entries := make([]json.RawMessage, 0)
+	var creator json.RawMessage
+	for _, d := range docs {
+		var env harEnvelope
+		if err := json.Unmarshal(d, &env); err != nil {
+			continue
+		}
+		entries = append(entries, env.Log.Entries...)
+		if creator == nil && len(env.Log.Creator) > 0 {
+			creator = env.Log.Creator
+		}
+	}
+	if len(entries) == 0 {
+		// No usable entries: treat as "nothing captured", same as an empty in-process buffer, rather
+		// than an error. (An untrusted plugin emitting an empty capture frame must not 500 the run.)
 		return nil, nil
 	}
-	return harBuffer.ToHAR()
+	if creator == nil {
+		creator = json.RawMessage(`{"name":"Grafana","version":"1.0"}`)
+	}
+
+	out := map[string]any{
+		"log": map[string]any{
+			"version": "1.2",
+			"creator": creator,
+			"entries": entries,
+		},
+	}
+	return json.Marshal(out)
 }
 
 // buildTarGz packs the named files into a gzipped tar archive. Files are written in deterministic

--- a/pkg/services/diagnostics/diagnostics_test.go
+++ b/pkg/services/diagnostics/diagnostics_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/infra/httpclient/harcapture"
@@ -19,7 +20,7 @@ import (
 
 func TestBundler_Build(t *testing.T) {
 	// No HAR captured (empty buffer, nil response) -> traffic.har omitted; only panel.json present.
-	blob, err := NewBundler().Build(&harcapture.Buffer{}, json.RawMessage(`{"id":1}`), nil, nil)
+	blob, err := NewBundler().Build(nil, &harcapture.Buffer{}, json.RawMessage(`{"id":1}`), nil, nil)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -33,7 +34,7 @@ func TestBundler_Build(t *testing.T) {
 
 func TestBundler_Build_recordsQueryError(t *testing.T) {
 	// A failed query must still produce a bundle, with the error recorded (capture is not discarded).
-	blob, err := NewBundler().Build(&harcapture.Buffer{}, nil, nil, errors.New("datasource timeout"))
+	blob, err := NewBundler().Build(nil, &harcapture.Buffer{}, nil, nil, errors.New("datasource timeout"))
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -41,30 +42,138 @@ func TestBundler_Build_recordsQueryError(t *testing.T) {
 	require.Contains(t, string(files["query-error.txt"]), "datasource timeout")
 }
 
-func TestHasCapturedHAR(t *testing.T) {
-	require.False(t, HasCapturedHAR(nil), "nil buffer -> nothing captured")
-	require.False(t, HasCapturedHAR(&harcapture.Buffer{}), "empty buffer -> nothing captured")
+func TestMergeHAR(t *testing.T) {
+	d1 := []byte(`{"log":{"creator":{"name":"A","version":"1"},"entries":[{"n":1}]}}`)
+	d2 := []byte(`{"log":{"entries":[{"n":2},{"n":3}]}}`)
+	malformed := []byte(`not json`)
 
+	out, err := mergeHAR([][]byte{d1, malformed, d2})
+	require.NoError(t, err)
+	require.NotNil(t, out)
+
+	var env struct {
+		Log struct {
+			Version string            `json:"version"`
+			Creator json.RawMessage   `json:"creator"`
+			Entries []json.RawMessage `json:"entries"`
+		} `json:"log"`
+	}
+	require.NoError(t, json.Unmarshal(out, &env))
+	require.Equal(t, "1.2", env.Log.Version)
+	require.Len(t, env.Log.Entries, 3, "entries from all valid docs are concatenated; malformed skipped")
+	require.JSONEq(t, `{"name":"A","version":"1"}`, string(env.Log.Creator), "first creator is kept")
+
+	// No parseable entries -> (nil, nil): benign "nothing captured", not an error.
+	out, err = mergeHAR([][]byte{malformed})
+	require.NoError(t, err)
+	require.Nil(t, out)
+	out, err = mergeHAR(nil)
+	require.NoError(t, err)
+	require.Nil(t, out)
+}
+
+func TestCollectHAR_emptyExternalFrame_benign(t *testing.T) {
+	// A valid-but-empty external frame ({"log":{"entries":[]}}) is "no traffic", not a failure:
+	// collectHAR must return (nil, nil) so the handler produces a 200 bundle without traffic.har,
+	// not a 500. (Regression guard: an untrusted plugin's empty capture must not fail the run.)
+	f := data.NewFrame("")
+	f.Meta = &data.FrameMeta{Custom: map[string]interface{}{"har": `{"log":{"entries":[]}}`}}
+	resp := &backend.QueryDataResponse{Responses: backend.Responses{"__har__": backend.DataResponse{Frames: data.Frames{f}}}}
+
+	out, err := collectHAR(resp, &harcapture.Buffer{})
+	require.NoError(t, err)
+	require.Nil(t, out)
+}
+
+func TestHasCapturedHAR(t *testing.T) {
+	require.False(t, HasCapturedHAR(nil, &harcapture.Buffer{}), "no buffer entries, no response")
+	require.False(t, HasCapturedHAR(&backend.QueryDataResponse{Responses: backend.Responses{}}, &harcapture.Buffer{}))
+
+	// In-process buffer with entries counts as captured.
 	buf := &harcapture.Buffer{}
 	req, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
 	require.NoError(t, err)
 	buf.AddEntry(req, nil, nil, time.Now(), time.Millisecond)
-	require.True(t, HasCapturedHAR(buf), "buffer with entries -> captured")
+	require.True(t, HasCapturedHAR(nil, buf), "buffer with entries -> captured")
+
+	// An external __har__ frame counts as captured even when the in-process buffer is empty — the
+	// handler must not short-circuit a failed query away in that case.
+	f := data.NewFrame("")
+	f.Meta = &data.FrameMeta{Custom: map[string]interface{}{"har": `{"log":{"entries":[]}}`}}
+	resp := &backend.QueryDataResponse{Responses: backend.Responses{"__har__": backend.DataResponse{Frames: data.Frames{f}}}}
+	require.True(t, HasCapturedHAR(resp, &harcapture.Buffer{}))
+
+	// A __har__ frame WITHOUT a har payload must NOT count as captured (else the no-capture error
+	// path is wrongly suppressed and the bundle is empty).
+	empty := data.NewFrame("")
+	empty.Meta = &data.FrameMeta{Custom: map[string]interface{}{"other": "x"}}
+	noPayload := &backend.QueryDataResponse{Responses: backend.Responses{"__har__": backend.DataResponse{Frames: data.Frames{empty}}}}
+	require.False(t, HasCapturedHAR(noPayload, &harcapture.Buffer{}), "frame without a har payload is not captured traffic")
 }
 
-func TestCollectHAR_nilAndEmptyBuffer(t *testing.T) {
-	out, err := collectHAR(nil)
+func TestCollectHAR_malformedExternalFrame_benign(t *testing.T) {
+	// A frame carries a non-empty but unparseable "har" payload and there's no in-process buffer.
+	// Redaction is deferred, so the frame is merged verbatim: mergeHAR skips the unparseable document
+	// and, with no other entries, returns (nil, nil) — a benign empty bundle, not an error.
+	f := data.NewFrame("")
+	f.Meta = &data.FrameMeta{Custom: map[string]interface{}{"har": "not valid har"}}
+	resp := &backend.QueryDataResponse{Responses: backend.Responses{"__har__": backend.DataResponse{Frames: data.Frames{f}}}}
+
+	out, err := collectHAR(resp, &harcapture.Buffer{})
 	require.NoError(t, err)
 	require.Nil(t, out)
+}
 
-	out, err = collectHAR(&harcapture.Buffer{})
+func TestCollectHAR_ExternalFramesVerbatim_andNilFrame(t *testing.T) {
+	// A frame with a secret in a request header. Redaction is intentionally deferred, so it must be
+	// merged VERBATIM (the secret is preserved, not stripped) — same policy as in-process capture.
+	frameHAR := `{"log":{"entries":[{"request":{"headers":[{"name":"Authorization","value":"Bearer FRAMESECRET"}],"queryString":[],"cookies":[],"url":"http://x/y"},"response":{"headers":[],"cookies":[]}}]}}`
+	withHAR := data.NewFrame("")
+	withHAR.Meta = &data.FrameMeta{Custom: map[string]interface{}{"har": frameHAR}}
+
+	resp := &backend.QueryDataResponse{
+		Responses: backend.Responses{
+			// A nil frame must not panic (regression guard), and the HAR frame must be collected.
+			"__har__": backend.DataResponse{Frames: data.Frames{nil, withHAR}},
+		},
+	}
+
+	out, err := collectHAR(resp, &harcapture.Buffer{})
+	require.NoError(t, err)
+	require.NotNil(t, out)
+
+	var env struct {
+		Log struct {
+			Entries []json.RawMessage `json:"entries"`
+		} `json:"log"`
+	}
+	require.NoError(t, json.Unmarshal(out, &env))
+	require.Len(t, env.Log.Entries, 1)
+	require.Contains(t, string(out), "FRAMESECRET", "external-plugin frame is merged verbatim (redaction deferred)")
+
+	_, ok := resp.Responses["__har__"]
+	require.False(t, ok, "__har__ synthetic response is consumed, not returned to the client")
+}
+
+func TestCollectHAR_nilBuffer_noPanic(t *testing.T) {
+	out, err := collectHAR(nil, nil)
 	require.NoError(t, err)
 	require.Nil(t, out)
 
 	// A nil buffer must also flow through Build without panicking.
-	bundle, err := NewBundler().Build(nil, nil, nil, nil)
+	bundle, err := NewBundler().Build(nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 	require.NotNil(t, bundle)
+}
+
+func TestCollectHAR_Empty(t *testing.T) {
+	out, err := collectHAR(nil, &harcapture.Buffer{})
+	require.NoError(t, err)
+	require.Nil(t, out)
+
+	out, err = collectHAR(&backend.QueryDataResponse{Responses: backend.Responses{}}, &harcapture.Buffer{})
+	require.NoError(t, err)
+	require.Nil(t, out)
 }
 
 func TestCollectHAR_BufferOnly_returnedVerbatim(t *testing.T) {
@@ -73,7 +182,7 @@ func TestCollectHAR_BufferOnly_returnedVerbatim(t *testing.T) {
 	require.NoError(t, err)
 	buf.AddEntry(req, nil, nil, time.Now(), time.Millisecond)
 
-	out, err := collectHAR(buf)
+	out, err := collectHAR(nil, buf)
 	require.NoError(t, err)
 	require.NotNil(t, out)
 
@@ -90,6 +199,94 @@ func TestCollectHAR_BufferOnly_returnedVerbatim(t *testing.T) {
 	}
 	require.NoError(t, json.Unmarshal(out, &doc))
 	require.Len(t, doc.Log.Entries, 1)
+}
+
+func TestCollectHAR_mergesBufferAndExternalFrame(t *testing.T) {
+	// Both sources captured traffic: the in-process buffer (core) and an external __har__ frame.
+	// collectHAR must merge them into one HAR document carrying both entries.
+	buf := &harcapture.Buffer{}
+	req, err := http.NewRequest(http.MethodGet, "http://core.example.com", nil)
+	require.NoError(t, err)
+	buf.AddEntry(req, nil, nil, time.Now(), time.Millisecond)
+
+	frameHAR := `{"log":{"entries":[{"request":{"url":"http://external/y"}}]}}`
+	f := data.NewFrame("")
+	f.Meta = &data.FrameMeta{Custom: map[string]interface{}{"har": frameHAR}}
+	resp := &backend.QueryDataResponse{Responses: backend.Responses{"__har__": backend.DataResponse{Frames: data.Frames{f}}}}
+
+	out, err := collectHAR(resp, buf)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+
+	var env struct {
+		Log struct {
+			Entries []json.RawMessage `json:"entries"`
+		} `json:"log"`
+	}
+	require.NoError(t, json.Unmarshal(out, &env))
+	require.Len(t, env.Log.Entries, 2, "buffer entry + external frame entry are both present")
+}
+
+func TestCollectHAR_multipleDatasources_namespacedRefIDs(t *testing.T) {
+	// Regression guard for the multi-datasource collision: the SDK namespaces the capture refId per
+	// datasource ("__har__<uid>"), so a query spanning two external datasources yields two distinct
+	// __har__-prefixed responses. collectHAR must collect BOTH (not just one) and consume both.
+	frameA := data.NewFrame("__har__A")
+	frameA.Meta = &data.FrameMeta{Custom: map[string]interface{}{"har": `{"log":{"entries":[{"request":{"url":"http://a/1"}}]}}`}}
+	frameB := data.NewFrame("__har__B")
+	frameB.Meta = &data.FrameMeta{Custom: map[string]interface{}{"har": `{"log":{"entries":[{"request":{"url":"http://b/1"}},{"request":{"url":"http://b/2"}}]}}`}}
+	resp := &backend.QueryDataResponse{Responses: backend.Responses{
+		"__har__A": backend.DataResponse{Frames: data.Frames{frameA}},
+		"__har__B": backend.DataResponse{Frames: data.Frames{frameB}},
+	}}
+
+	out, err := collectHAR(resp, &harcapture.Buffer{})
+	require.NoError(t, err)
+	require.NotNil(t, out)
+
+	var env struct {
+		Log struct {
+			Entries []json.RawMessage `json:"entries"`
+		} `json:"log"`
+	}
+	require.NoError(t, json.Unmarshal(out, &env))
+	require.Len(t, env.Log.Entries, 3, "entries from BOTH datasources' capture frames are merged (1 + 2)")
+
+	_, aKept := resp.Responses["__har__A"]
+	_, bKept := resp.Responses["__har__B"]
+	require.False(t, aKept || bKept, "all __har__-prefixed synthetic responses are consumed")
+}
+
+func TestHasCapturedHAR_namespacedRefID(t *testing.T) {
+	f := data.NewFrame("__har__P123")
+	f.Meta = &data.FrameMeta{Custom: map[string]interface{}{"har": `{"log":{"entries":[]}}`}}
+	resp := &backend.QueryDataResponse{Responses: backend.Responses{"__har__P123": backend.DataResponse{Frames: data.Frames{f}}}}
+	require.True(t, HasCapturedHAR(resp, &harcapture.Buffer{}), "a datasource-namespaced capture frame counts as captured")
+}
+
+func TestResponseError_skipsNamespacedHARFrames(t *testing.T) {
+	// Namespaced synthetic responses must be skipped by ResponseError (their error is read via
+	// PluginCaptureError); a real per-refId error alongside them is still reported.
+	resp := &backend.QueryDataResponse{Responses: backend.Responses{
+		"__har__A": {Error: errors.New("swallowed A")},
+		"__har__B": {Error: errors.New("swallowed B")},
+		"C":        {Error: errors.New("real boom")},
+	}}
+	require.EqualError(t, ResponseError(resp), "C: real boom")
+}
+
+func TestPluginCaptureError_multipleDatasources(t *testing.T) {
+	// Each external datasource can stash its own queryError under its namespaced frame; report all,
+	// ordered deterministically.
+	fa := data.NewFrame("__har__A")
+	fa.Meta = &data.FrameMeta{Custom: map[string]interface{}{"queryError": "boom A"}}
+	fb := data.NewFrame("__har__B")
+	fb.Meta = &data.FrameMeta{Custom: map[string]interface{}{"queryError": "boom B"}}
+	resp := &backend.QueryDataResponse{Responses: backend.Responses{
+		"__har__A": {Frames: data.Frames{fa}},
+		"__har__B": {Frames: data.Frames{fb}},
+	}}
+	require.EqualError(t, PluginCaptureError(resp), "boom A\nboom B")
 }
 
 func TestBuildTarGz(t *testing.T) {
@@ -123,6 +320,38 @@ func TestBuildTarGz_deterministicOrder(t *testing.T) {
 func TestIndentJSON(t *testing.T) {
 	require.Equal(t, "{\n  \"a\": 1\n}", string(indentJSON([]byte(`{"a":1}`))))
 	require.Equal(t, "not json", string(indentJSON([]byte("not json"))), "falls back to raw bytes when unparseable")
+}
+
+func TestPluginCaptureError(t *testing.T) {
+	require.NoError(t, PluginCaptureError(nil))
+	require.NoError(t, PluginCaptureError(&backend.QueryDataResponse{Responses: backend.Responses{"A": {}}}))
+
+	// No queryError in the frame -> nil.
+	noErr := data.NewFrame("__har__")
+	noErr.Meta = &data.FrameMeta{Custom: map[string]interface{}{"har": "{}"}}
+	require.NoError(t, PluginCaptureError(&backend.QueryDataResponse{Responses: backend.Responses{
+		"__har__": {Frames: data.Frames{noErr}},
+	}}))
+
+	// queryError present -> surfaced.
+	withErr := data.NewFrame("__har__")
+	withErr.Meta = &data.FrameMeta{Custom: map[string]interface{}{"har": "{}", "queryError": "datasource boom"}}
+	err := PluginCaptureError(&backend.QueryDataResponse{Responses: backend.Responses{
+		"__har__": {Frames: data.Frames{withErr}},
+	}})
+	require.EqualError(t, err, "datasource boom")
+}
+
+func TestResponseError_skipsSyntheticHARFrame(t *testing.T) {
+	// The SDK sets an error on the synthetic __har__ response so its own middlewares see the failure;
+	// ResponseError must not surface it under the reserved refID (PluginCaptureError handles it).
+	resp := &backend.QueryDataResponse{Responses: backend.Responses{
+		"__har__": {Error: errors.New("swallowed boom")},
+	}}
+	require.NoError(t, ResponseError(resp), "__har__ synthetic error must be skipped")
+	// A real per-refId error alongside it is still reported.
+	resp.Responses["A"] = backend.DataResponse{Error: errors.New("real boom")}
+	require.EqualError(t, ResponseError(resp), "A: real boom")
 }
 
 func TestResponseError(t *testing.T) {

--- a/pkg/services/diagnostics/diagnostics_test.go
+++ b/pkg/services/diagnostics/diagnostics_test.go
@@ -109,6 +109,15 @@ func TestHasCapturedHAR(t *testing.T) {
 	empty.Meta = &data.FrameMeta{Custom: map[string]interface{}{"other": "x"}}
 	noPayload := &backend.QueryDataResponse{Responses: backend.Responses{"__har__": backend.DataResponse{Frames: data.Frames{empty}}}}
 	require.False(t, HasCapturedHAR(noPayload, &harcapture.Buffer{}), "frame without a har payload is not captured traffic")
+
+	// A __har__ frame with a non-empty but unparseable har payload must NOT count as captured
+	// either: collectHAR/mergeHAR would skip it and contribute nothing, so counting it here would
+	// let a failed query fall through to a 200 bundle with no traffic.har -- the exact outcome the
+	// no-capture error path exists to prevent.
+	malformed := data.NewFrame("")
+	malformed.Meta = &data.FrameMeta{Custom: map[string]interface{}{"har": "not valid har"}}
+	malformedResp := &backend.QueryDataResponse{Responses: backend.Responses{"__har__": backend.DataResponse{Frames: data.Frames{malformed}}}}
+	require.False(t, HasCapturedHAR(malformedResp, &harcapture.Buffer{}), "a malformed har payload is not captured traffic")
 }
 
 func TestCollectHAR_malformedExternalFrame_benign(t *testing.T) {

--- a/pkg/services/pluginsintegration/clientmiddleware/http_capture_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/http_capture_middleware.go
@@ -14,12 +14,18 @@ import (
 	"github.com/grafana/grafana/pkg/infra/httpclient/harcapture"
 )
 
+const harCaptureHeader = "X-Grafana-HAR-Capture"
+
 // NewHTTPCaptureMiddleware creates a backend.HandlerMiddleware that captures HTTP traffic
 // for QueryData calls when a harcapture.Buffer is present in the context.
 //
-// For core (in-process) plugins it injects a capturing RoundTripper as contextual middleware, so the
-// existing ContextualMiddleware in the HTTP client chain picks it up. (External out-of-process gRPC
-// plugins will be captured separately, in a follow-up.)
+// For core (in-process) plugins: injects a capturing RoundTripper as contextual middleware
+// so the existing ContextualMiddleware in the HTTP client chain picks it up.
+//
+// For external gRPC plugins: sets X-Grafana-HAR-Capture on the request headers. NOTE: this is
+// currently inert — the SDK-side middleware that reads this header and emits __har__ response frames
+// is not released yet, so out-of-process plugin traffic is NOT captured until Grafana is bumped to
+// an SDK version that includes it. The header is set now only for forward compatibility.
 func NewHTTPCaptureMiddleware() backend.HandlerMiddleware {
 	return backend.HandlerMiddlewareFunc(func(next backend.Handler) backend.Handler {
 		return &HTTPCaptureMiddleware{BaseHandler: backend.NewBaseHandler(next)}
@@ -35,6 +41,12 @@ func (m *HTTPCaptureMiddleware) QueryData(ctx context.Context, req *backend.Quer
 	if buf == nil {
 		return m.BaseHandler.QueryData(ctx, req)
 	}
+
+	// Signal external gRPC plugins via request header.
+	if req.Headers == nil {
+		req.Headers = map[string]string{}
+	}
+	req.Headers[harCaptureHeader] = "true"
 
 	// Inject capturing RoundTripper for core (in-process) plugins.
 	captureMW := sdkhttpclient.NamedMiddlewareFunc("http-capture", func(_ sdkhttpclient.Options, next http.RoundTripper) http.RoundTripper {

--- a/pkg/services/pluginsintegration/clientmiddleware/http_capture_middleware_test.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/http_capture_middleware_test.go
@@ -20,32 +20,39 @@ import (
 func TestHTTPCaptureMiddleware_noBuffer_passthrough(t *testing.T) {
 	var contextualMWs []sdkhttpclient.Middleware
 	var called bool
+	var gotHeader string
 	cdt := handlertest.NewHandlerMiddlewareTest(t, handlertest.WithMiddlewares(NewHTTPCaptureMiddleware()))
-	cdt.TestHandler.QueryDataFunc = func(ctx context.Context, _ *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+	cdt.TestHandler.QueryDataFunc = func(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
 		called = true
 		contextualMWs = sdkhttpclient.ContextualMiddlewareFromContext(ctx)
+		gotHeader = req.Headers[harCaptureHeader]
 		return &backend.QueryDataResponse{}, nil
 	}
 
-	// No buffer in context -> pure pass-through, no capturing middleware injected.
+	// No buffer in context -> pure pass-through: no capturing middleware injected and no external
+	// capture header set.
 	_, err := cdt.MiddlewareHandler.QueryData(context.Background(), &backend.QueryDataRequest{})
 	require.NoError(t, err)
 	assert.True(t, called)
 	assert.Empty(t, contextualMWs)
+	assert.Empty(t, gotHeader)
 }
 
-func TestHTTPCaptureMiddleware_withBuffer_injectsContextualMiddleware(t *testing.T) {
+func TestHTTPCaptureMiddleware_withBuffer_injectsContextualMiddlewareAndSetsHeader(t *testing.T) {
 	var contextualMWs []sdkhttpclient.Middleware
+	var gotHeader string
 	cdt := handlertest.NewHandlerMiddlewareTest(t, handlertest.WithMiddlewares(NewHTTPCaptureMiddleware()))
-	cdt.TestHandler.QueryDataFunc = func(ctx context.Context, _ *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+	cdt.TestHandler.QueryDataFunc = func(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
 		contextualMWs = sdkhttpclient.ContextualMiddlewareFromContext(ctx)
+		gotHeader = req.Headers[harCaptureHeader]
 		return &backend.QueryDataResponse{}, nil
 	}
 
 	ctx, _ := harcapture.WithCapture(context.Background())
 	_, err := cdt.MiddlewareHandler.QueryData(ctx, &backend.QueryDataRequest{})
 	require.NoError(t, err)
-	assert.NotEmpty(t, contextualMWs)
+	assert.NotEmpty(t, contextualMWs, "core (in-process) capturing RoundTripper is injected")
+	assert.Equal(t, "true", gotHeader, "external gRPC plugins are signalled via the capture header")
 }
 
 func TestHTTPCaptureMiddleware_withBuffer_capturesHTTPEntry(t *testing.T) {


### PR DESCRIPTION
## What this PR does

Extends on-demand datasource diagnostics to **external (out-of-process, gRPC) plugins**, on top of the merged core in-process capture (#128378).

When a diagnostics run is active, the middleware sets `X-Grafana-HAR-Capture: true` on the `QueryData` request. A plugin built against a recent SDK (which ships the capture middleware in its default chain) reads that header and returns its captured HTTP traffic as a synthetic `__har__` response frame. As for core plugins, the feature is behing a feature flag (off by default), and is admin- and on-prem-only.
