### PR TITLE
Search: add manifest merge for combining search-field sources

### DIFF
--- a/pkg/storage/unified/resource/search_field_manifest.go
+++ b/pkg/storage/unified/resource/search_field_manifest.go
@@ -1,11 +1,16 @@
 package resource
 
 import (
+	"slices"
 	"strings"
 
 	"github.com/grafana/grafana-app-sdk/app"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/grafana/grafana/pkg/infra/log"
 )
+
+var manifestMergeLogger = log.New("search-manifest-merge")
 
 // NewManifestBackedProvider builds a SearchFieldsProvider from the search
 // fields declared in the given app manifests. It walks every version's kinds,
@@ -150,4 +155,151 @@ func SearchFieldsHashesForProviders(providers map[LowerGroupResource]SearchField
 		}
 	}
 	return out
+}
+
+// MergeManifestsByKind combines manifest sources for the search wiring, given
+// in increasing order of priority. Only kinds that declare search fields take
+// part: when more than one source declares search fields for the same kind
+// (group and resource), the later source's declaration wins outright, including
+// versions the winner omits, so a kind's search fields always come from a single
+// source and stay internally consistent. A source that declares no search fields
+// for a kind never overrides another source. Dropping versions the loser
+// declared is logged as a warning, since those versions lose their search
+// fields.
+//
+// Manifests within one source share a priority. A well-formed source declares
+// each kind in a single manifest; if two manifests in the same source declare
+// the same kind, the first is used and a warning is logged.
+func MergeManifestsByKind(sources ...[]app.Manifest) []app.Manifest {
+	// Highest-priority source first, so lower-priority sources drop a kind a
+	// higher one already claimed.
+	claimedBy := map[LowerGroupResource]kindClaim{}
+	var merged []app.Manifest
+	for i := len(sources) - 1; i >= 0; i-- {
+		warnDuplicateKindsWithinSource(sources[i])
+		for _, m := range sources[i] {
+			if m.ManifestData == nil {
+				merged = append(merged, m)
+				continue
+			}
+			if kept, ok := pruneClaimedKinds(m, claimedBy); ok {
+				merged = append(merged, kept)
+			}
+		}
+	}
+	// Output order does not matter: after pruning, each kind survives in exactly
+	// one source.
+	return merged
+}
+
+// warnDuplicateKindsWithinSource logs when two manifests in one source declare
+// search fields for the same kind. That should not happen (a manifest is one
+// app with a unique group, carrying all its kinds), so this only surfaces a
+// malformed source; the merge keeps the first manifest's declaration.
+func warnDuplicateKindsWithinSource(src []app.Manifest) {
+	seen := map[LowerGroupResource]string{}
+	for _, m := range src {
+		if m.ManifestData == nil {
+			continue
+		}
+		group := m.ManifestData.Group
+		declared := map[LowerGroupResource]bool{}
+		for _, v := range m.ManifestData.Versions {
+			for _, k := range v.Kinds {
+				if declaresSearchFields(k) {
+					declared[NewLowerGroupResource(group, manifestResourceName(k))] = true
+				}
+			}
+		}
+		for key := range declared {
+			if first, ok := seen[key]; ok {
+				manifestMergeLogger.Warn("multiple manifests in one source declare search fields for the same kind, using the first",
+					"group", key.Group, "resource", key.Resource, "first", first, "duplicate", m.ManifestData.AppName)
+				continue
+			}
+			seen[key] = m.ManifestData.AppName
+		}
+	}
+}
+
+// declaresSearchFields reports whether a kind declares search fields. Only such
+// kinds claim ownership in the merge; a kind without search fields (even one
+// with selectable fields) never overrides another source's search fields.
+func declaresSearchFields(k app.ManifestVersionKind) bool {
+	return len(k.SearchFields) > 0
+}
+
+// kindClaim records the source that owns a kind and the versions it declared,
+// so a lower-priority source can tell whether it is losing a version's fields.
+type kindClaim struct {
+	app      string
+	versions map[string]bool
+}
+
+// pruneClaimedKinds drops kinds already claimed by a higher-priority source and
+// records the ones it keeps. ok is false when nothing is left to contribute.
+func pruneClaimedKinds(m app.Manifest, claimedBy map[LowerGroupResource]kindClaim) (app.Manifest, bool) {
+	group := m.ManifestData.Group
+	appName := m.ManifestData.AppName
+
+	md := *m.ManifestData
+	versions := make([]app.ManifestVersion, 0, len(md.Versions))
+	kept := map[LowerGroupResource]bool{}
+	declaredVersions := map[LowerGroupResource]map[string]bool{}
+
+	for _, v := range md.Versions {
+		kinds := make([]app.ManifestVersionKind, 0, len(v.Kinds))
+		for _, k := range v.Kinds {
+			if !declaresSearchFields(k) {
+				kinds = append(kinds, k) // nothing to claim or override
+				continue
+			}
+			key := NewLowerGroupResource(group, manifestResourceName(k))
+			if declaredVersions[key] == nil {
+				declaredVersions[key] = map[string]bool{}
+			}
+			declaredVersions[key][v.Name] = true
+			if _, taken := claimedBy[key]; taken {
+				continue
+			}
+			kept[key] = true
+			kinds = append(kinds, k)
+		}
+		v.Kinds = kinds
+		versions = append(versions, v)
+	}
+
+	for key, declared := range declaredVersions {
+		if kept[key] {
+			claimedBy[key] = kindClaim{app: appName, versions: declared}
+			continue
+		}
+		logOverriddenKind(key, appName, claimedBy[key], declared)
+	}
+
+	if len(kept) == 0 {
+		return app.Manifest{}, false
+	}
+	md.Versions = versions
+	return app.Manifest{ManifestData: &md, Location: m.Location}, true
+}
+
+// logOverriddenKind logs a kind dropped in favor of a higher-priority source. It
+// warns when the dropped source declared versions the winner did not, since
+// those versions lose their search fields; otherwise the override is expected.
+func logOverriddenKind(key LowerGroupResource, droppedApp string, winner kindClaim, droppedVersions map[string]bool) {
+	var lost []string
+	for name := range droppedVersions {
+		if !winner.versions[name] {
+			lost = append(lost, name)
+		}
+	}
+	if len(lost) > 0 {
+		slices.Sort(lost)
+		manifestMergeLogger.Warn("higher-priority manifest source overrides a kind but omits versions it declared; those versions lose their search fields",
+			"group", key.Group, "resource", key.Resource, "winner", winner.app, "dropped", droppedApp, "lostVersions", strings.Join(lost, ","))
+		return
+	}
+	manifestMergeLogger.Debug("kind overridden by higher-priority manifest source",
+		"group", key.Group, "resource", key.Resource, "winner", winner.app, "dropped", droppedApp)
 }

--- a/pkg/storage/unified/resource/search_field_manifest_test.go
+++ b/pkg/storage/unified/resource/search_field_manifest_test.go
@@ -143,3 +143,98 @@ func TestSearchFieldProviders_InvalidManifestReturnsError(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, got)
 }
+
+func mergeTestManifest(appName, group string, versions ...app.ManifestVersion) app.Manifest {
+	return app.Manifest{ManifestData: &app.ManifestData{AppName: appName, Group: group, Versions: versions}}
+}
+
+func mergeTestKind(kind, field string) app.ManifestVersionKind {
+	return app.ManifestVersionKind{
+		Kind:   kind,
+		Plural: kind + "s",
+		SearchFields: []app.ManifestVersionKindSearchField{
+			{Name: field, Path: "spec." + field, Type: "string", Capabilities: []string{"filter"}},
+		},
+	}
+}
+
+// fieldNames lets a test assert whose declaration of a kind survived a merge.
+func fieldNames(t *testing.T, manifests []app.Manifest, group, version, resource string) []string {
+	t.Helper()
+	p, err := newManifestBackedProvider(manifests)
+	require.NoError(t, err)
+	fields := p.Fields(schema.GroupVersionResource{Group: group, Version: version, Resource: resource})
+	names := make([]string, 0, len(fields))
+	for _, f := range fields {
+		names = append(names, f.Name)
+	}
+	return names
+}
+
+func TestMergeManifestsByKind(t *testing.T) {
+	t.Run("disjoint kinds from different sources are all kept", func(t *testing.T) {
+		builtin := mergeTestManifest("builtin", "a.test", app.ManifestVersion{Name: "v1", Kinds: []app.ManifestVersionKind{mergeTestKind("Foo", "one")}})
+		live := mergeTestManifest("live", "b.test", app.ManifestVersion{Name: "v1", Kinds: []app.ManifestVersionKind{mergeTestKind("Bar", "two")}})
+
+		merged := MergeManifestsByKind([]app.Manifest{builtin}, []app.Manifest{live})
+
+		require.Equal(t, []string{"one"}, fieldNames(t, merged, "a.test", "v1", "foos"))
+		require.Equal(t, []string{"two"}, fieldNames(t, merged, "b.test", "v1", "bars"))
+	})
+
+	t.Run("later source wins the whole kind across all versions", func(t *testing.T) {
+		builtin := mergeTestManifest("builtin", "g.test",
+			app.ManifestVersion{Name: "v1", Kinds: []app.ManifestVersionKind{mergeTestKind("Foo", "builtin_v1")}},
+			app.ManifestVersion{Name: "v2", Kinds: []app.ManifestVersionKind{mergeTestKind("Foo", "builtin_v2")}},
+		)
+		// The higher-priority source declares Foo only in v1.
+		live := mergeTestManifest("live", "g.test",
+			app.ManifestVersion{Name: "v1", Kinds: []app.ManifestVersionKind{mergeTestKind("Foo", "live_v1")}},
+		)
+
+		merged := MergeManifestsByKind([]app.Manifest{builtin}, []app.Manifest{live})
+
+		// Whole kind comes from the winner: v2 is gone, not kept from built-in.
+		require.Equal(t, []string{"live_v1"}, fieldNames(t, merged, "g.test", "v1", "foos"))
+		require.Empty(t, fieldNames(t, merged, "g.test", "v2", "foos"))
+	})
+
+	t.Run("a fully overridden manifest is dropped from the output", func(t *testing.T) {
+		builtin := mergeTestManifest("builtin", "g.test", app.ManifestVersion{Name: "v1", Kinds: []app.ManifestVersionKind{mergeTestKind("Foo", "builtin")}})
+		live := mergeTestManifest("live", "g.test", app.ManifestVersion{Name: "v1", Kinds: []app.ManifestVersionKind{mergeTestKind("Foo", "live")}})
+
+		merged := MergeManifestsByKind([]app.Manifest{builtin}, []app.Manifest{live})
+
+		require.Len(t, merged, 1)
+		require.Equal(t, "live", merged[0].ManifestData.AppName)
+	})
+
+	t.Run("a source without search fields for a kind does not override another source", func(t *testing.T) {
+		builtin := mergeTestManifest("builtin", "g.test", app.ManifestVersion{Name: "v1", Kinds: []app.ManifestVersionKind{mergeTestKind("Foo", "builtin")}})
+		// The higher-priority source declares Foo with selectable fields but no
+		// search fields, so it must not claim the kind and strip the built-in's
+		// search fields.
+		live := mergeTestManifest("live", "g.test", app.ManifestVersion{Name: "v1", Kinds: []app.ManifestVersionKind{{Kind: "Foo", Plural: "foos", SelectableFields: []string{"spec.x"}}}})
+
+		merged := MergeManifestsByKind([]app.Manifest{builtin}, []app.Manifest{live})
+
+		require.Equal(t, []string{"builtin"}, fieldNames(t, merged, "g.test", "v1", "foos"))
+	})
+
+	t.Run("within one source the first manifest wins a duplicated kind", func(t *testing.T) {
+		// A well-formed source never does this (one manifest per app); the guard
+		// logs a warning and the merge keeps the first manifest's declaration.
+		a := mergeTestManifest("a", "g.test", app.ManifestVersion{Name: "v1", Kinds: []app.ManifestVersionKind{mergeTestKind("Foo", "first")}})
+		b := mergeTestManifest("b", "g.test", app.ManifestVersion{Name: "v1", Kinds: []app.ManifestVersionKind{mergeTestKind("Foo", "second")}})
+
+		merged := MergeManifestsByKind([]app.Manifest{a, b})
+
+		require.Equal(t, []string{"first"}, fieldNames(t, merged, "g.test", "v1", "foos"))
+	})
+
+	t.Run("manifests without data pass through", func(t *testing.T) {
+		merged := MergeManifestsByKind([]app.Manifest{{ManifestData: nil}})
+		require.Len(t, merged, 1)
+		require.Nil(t, merged[0].ManifestData)
+	})
+}


### PR DESCRIPTION
This adds `MergeManifestsByKind`, which combines several manifest lists into one for the search wiring. Sources are passed in increasing priority order; when more than one declares the same kind (its group and resource), the higher-priority source's declaration wins the kind outright, so a kind's search fields always come from a single source and stay internally consistent. If that drops versions the losing source declared, it is logged as a warning so a stale or incomplete source is visible.

This is groundwork for reading search-field manifests from a live source alongside the built-in list; it has no caller yet.

Part of grafana/search-and-storage-team#827.
