### PR TITLE
Datasources: whole-dashboard on-demand diagnostics (async backend)

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -508,6 +508,10 @@ func (hs *HTTPServer) registerRoutes() {
 		// 2. grafana.onDemandDiagnostics flag at request time
 		if hs.Cfg.StackID == "" {
 			apiRoute.Post("/ds/diagnostics", requestmeta.SetSLOGroup(requestmeta.SLOGroupHighSlow), reqGrafanaAdmin, routing.Wrap(hs.QueryDiagnostics))
+			// Dashboard-level diagnostics: async create/poll/download (support-bundle style).
+			apiRoute.Post("/ds/dashboard-diagnostics", requestmeta.SetSLOGroup(requestmeta.SLOGroupHighSlow), reqGrafanaAdmin, routing.Wrap(hs.QueryDashboardDiagnostics))
+			apiRoute.Get("/ds/dashboard-diagnostics/:uid", reqGrafanaAdmin, routing.Wrap(hs.GetDashboardDiagnosticsStatus))
+			apiRoute.Get("/ds/dashboard-diagnostics/:uid/download", reqGrafanaAdmin, routing.Wrap(hs.DownloadDashboardDiagnostics))
 		}
 
 		// Unified Alerting

--- a/pkg/api/ds_query_dashboard_diagnostics.go
+++ b/pkg/api/ds_query_dashboard_diagnostics.go
@@ -221,11 +221,15 @@ func (hs *HTTPServer) QueryDashboardDiagnostics(c *contextmodel.ReqContext) resp
 	skipDSCache := c.SkipDSCache
 
 	// detachedCtx carries its own cloned *http.Request (see contexthandler.CopyWithReqContext), so
-	// it stays safe to use after this handler returns. Force SkipQueryCache on it so a cache-hit
-	// query still goes to the wire under capture -- otherwise HAR capture runs on nothing and
-	// traffic.har is silently empty (same requirement as QueryDiagnostics in ds_query_diagnostics.go
-	// for the single-panel path, where c.SkipQueryCache is set directly on the request's ReqContext).
-	detachedCtx := contexthandler.CopyWithReqContext(c.Req.Context())
+	// it stays safe to use after this handler returns. CopyWithReqContext only clones the request;
+	// it does not detach from cancellation, and the parent request's context is canceled by net/http
+	// as soon as this handler returns -- so context.WithoutCancel first, or the background goroutine
+	// below would be canceled within microseconds of starting, before any panel query completes.
+	// Force SkipQueryCache on it so a cache-hit query still goes to the wire under capture --
+	// otherwise HAR capture runs on nothing and traffic.har is silently empty (same requirement as
+	// QueryDiagnostics in ds_query_diagnostics.go for the single-panel path, where c.SkipQueryCache
+	// is set directly on the request's ReqContext).
+	detachedCtx := contexthandler.CopyWithReqContext(context.WithoutCancel(c.Req.Context()))
 	if reqCtx := contexthandler.FromContext(detachedCtx); reqCtx != nil {
 		reqCtx.SkipQueryCache = true
 	}

--- a/pkg/api/ds_query_dashboard_diagnostics.go
+++ b/pkg/api/ds_query_dashboard_diagnostics.go
@@ -1,0 +1,313 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/open-feature/go-sdk/openfeature"
+
+	"github.com/grafana/grafana/pkg/api/dtos"
+	"github.com/grafana/grafana/pkg/api/response"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/infra/httpclient/harcapture"
+	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/services/diagnostics"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/util"
+	"github.com/grafana/grafana/pkg/web"
+)
+
+// maxDashboardDiagnosticsPanels bounds how many panels a single request will execute, so a huge
+// dashboard can't spawn an unbounded amount of query work.
+const maxDashboardDiagnosticsPanels = 50
+
+// dashboardDiagnosticsTTL is how long a generated bundle is retained for download.
+const dashboardDiagnosticsTTL = 30 * time.Minute
+
+// dashboardDiagnosticsTimeout caps a background generation run so a slow/large dashboard can't keep
+// a goroutine (and its captured data) alive indefinitely.
+const dashboardDiagnosticsTimeout = 5 * time.Minute
+
+// diagnosticsEnabled reports whether the grafana.onDemandDiagnostics feature flag is on for the
+// current request. It reuses the shared OpenFeature client (see ds_query_diagnostics.go).
+func diagnosticsEnabled(ctx context.Context) bool {
+	return diagnosticsFeatureClient.Boolean(ctx, featuremgmt.FlagGrafanaOnDemandDiagnostics, false, openfeature.TransactionContext(ctx))
+}
+
+// dashboardDiagnosticsRequest is posted by the dashboard-level "Download diagnostics" action. The
+// client resolves each data panel's queries (template variables applied) and sends them with the
+// panel definition, so the backend can run them without a dashboard-service lookup.
+type dashboardDiagnosticsRequest struct {
+	Dashboard json.RawMessage        `json:"dashboard"`
+	Panels    []panelDiagnosticsSpec `json:"panels"`
+}
+
+type panelDiagnosticsSpec struct {
+	dtos.MetricRequest                 // from/to/queries for this panel
+	ID                 int64           `json:"id"`
+	Title              string          `json:"title"`
+	Panel              json.RawMessage `json:"panel"`
+}
+
+// ---- async job store (in-memory; mirrors the support-bundle create/pending/complete model) -------
+//
+// NOTE: in-memory means jobs don't survive a restart and aren't shared across HA replicas. A
+// production version would persist to a store (as the support bundle does via kvstore).
+
+type diagnosticsJobState string
+
+const (
+	jobPending  diagnosticsJobState = "pending"
+	jobComplete diagnosticsJobState = "complete"
+	jobError    diagnosticsJobState = "error"
+)
+
+type diagnosticsJob struct {
+	UID         string
+	State       diagnosticsJobState
+	CreatedAt   time.Time
+	ExpiresAt   time.Time
+	PanelsTotal int
+	PanelsDone  int
+	Err         string
+	archive     []byte
+}
+
+type diagnosticsJobSnapshot struct {
+	UID         string
+	State       diagnosticsJobState
+	PanelsTotal int
+	PanelsDone  int
+	Err         string
+	CreatedAt   time.Time
+	ExpiresAt   time.Time
+}
+
+type diagnosticsJobStore struct {
+	mu   sync.RWMutex
+	jobs map[string]*diagnosticsJob
+}
+
+// dashboardDiagnosticsJobs is the process-wide job store. Package-level so the endpoint methods on
+// *HTTPServer can share it without new wire/DI wiring for this experimental feature.
+var dashboardDiagnosticsJobs = &diagnosticsJobStore{jobs: map[string]*diagnosticsJob{}}
+
+func (s *diagnosticsJobStore) create(total int) *diagnosticsJob {
+	now := time.Now()
+	j := &diagnosticsJob{
+		UID:         util.GenerateShortUID(),
+		State:       jobPending,
+		CreatedAt:   now,
+		ExpiresAt:   now.Add(dashboardDiagnosticsTTL),
+		PanelsTotal: total,
+	}
+	s.mu.Lock()
+	for uid, existing := range s.jobs { // prune expired
+		if now.After(existing.ExpiresAt) {
+			delete(s.jobs, uid)
+		}
+	}
+	s.jobs[j.UID] = j
+	s.mu.Unlock()
+	return j
+}
+
+func (s *diagnosticsJobStore) setProgress(uid string, done int) {
+	s.mu.Lock()
+	if j := s.jobs[uid]; j != nil {
+		j.PanelsDone = done
+	}
+	s.mu.Unlock()
+}
+
+func (s *diagnosticsJobStore) complete(uid string, archive []byte) {
+	s.mu.Lock()
+	if j := s.jobs[uid]; j != nil {
+		j.State = jobComplete
+		j.archive = archive
+	}
+	s.mu.Unlock()
+}
+
+func (s *diagnosticsJobStore) fail(uid string, err error) {
+	s.mu.Lock()
+	if j := s.jobs[uid]; j != nil {
+		j.State = jobError
+		j.Err = err.Error()
+	}
+	s.mu.Unlock()
+}
+
+func (s *diagnosticsJobStore) snapshot(uid string) (diagnosticsJobSnapshot, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	j := s.jobs[uid]
+	if j == nil {
+		return diagnosticsJobSnapshot{}, false
+	}
+	return diagnosticsJobSnapshot{j.UID, j.State, j.PanelsTotal, j.PanelsDone, j.Err, j.CreatedAt, j.ExpiresAt}, true
+}
+
+func (s *diagnosticsJobStore) archiveOf(uid string) (archive []byte, state diagnosticsJobState, found bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	j := s.jobs[uid]
+	if j == nil {
+		return nil, "", false
+	}
+	return j.archive, j.State, true
+}
+
+// ---- handlers -----------------------------------------------------------------------------------
+
+// QueryDashboardDiagnostics starts an asynchronous dashboard-diagnostics generation and returns a
+// job UID immediately (202). Generation runs in a background goroutine with its own timeout so a
+// large/slow dashboard can't block or time out the HTTP request. Poll the status endpoint, then
+// download when complete. Gated on the grafana.onDemandDiagnostics flag; server-admin only (route).
+func (hs *HTTPServer) QueryDashboardDiagnostics(c *contextmodel.ReqContext) response.Response {
+	if !diagnosticsEnabled(c.Req.Context()) {
+		return response.Error(http.StatusNotFound, "on-demand diagnostics is not enabled", nil)
+	}
+
+	reqDTO := dashboardDiagnosticsRequest{}
+	if err := web.Bind(c.Req, &reqDTO); err != nil {
+		return response.Error(http.StatusBadRequest, "bad request data", err)
+	}
+	if len(reqDTO.Panels) == 0 {
+		return response.Error(http.StatusBadRequest, "at least one panel is required", nil)
+	}
+
+	job := dashboardDiagnosticsJobs.create(len(reqDTO.Panels))
+
+	// Snapshot the identity + cache flag; the goroutine must not touch the request or its context
+	// (both are tied to the HTTP request's lifetime, which ends when we return 202).
+	user := c.SignedInUser
+	skipDSCache := c.SkipDSCache
+
+	go func(uid string, user identity.Requester, skipDSCache bool, req dashboardDiagnosticsRequest) {
+		ctx, cancel := context.WithTimeout(context.Background(), dashboardDiagnosticsTimeout)
+		defer cancel()
+		defer func() {
+			if r := recover(); r != nil {
+				dashboardDiagnosticsJobs.fail(uid, fmt.Errorf("dashboard diagnostics panic: %v", r))
+			}
+		}()
+
+		archive, err := hs.buildDashboardDiagnosticsArchive(ctx, user, skipDSCache, req, uid)
+		if err != nil {
+			dashboardDiagnosticsJobs.fail(uid, err)
+			return
+		}
+		dashboardDiagnosticsJobs.complete(uid, archive)
+	}(job.UID, user, skipDSCache, reqDTO)
+
+	return response.JSON(http.StatusAccepted, map[string]any{"uid": job.UID, "state": jobPending})
+}
+
+// GetDashboardDiagnosticsStatus reports a generation job's progress/state.
+func (hs *HTTPServer) GetDashboardDiagnosticsStatus(c *contextmodel.ReqContext) response.Response {
+	if !diagnosticsEnabled(c.Req.Context()) {
+		return response.Error(http.StatusNotFound, "on-demand diagnostics is not enabled", nil)
+	}
+	uid := web.Params(c.Req)[":uid"]
+	snap, ok := dashboardDiagnosticsJobs.snapshot(uid)
+	if !ok {
+		return response.Error(http.StatusNotFound, "diagnostics job not found (it may have expired)", nil)
+	}
+	return response.JSON(http.StatusOK, map[string]any{
+		"uid":         snap.UID,
+		"state":       snap.State,
+		"panelsTotal": snap.PanelsTotal,
+		"panelsDone":  snap.PanelsDone,
+		"error":       snap.Err,
+		"createdAt":   snap.CreatedAt.UTC().Format(time.RFC3339),
+		"expiresAt":   snap.ExpiresAt.UTC().Format(time.RFC3339),
+	})
+}
+
+// DownloadDashboardDiagnostics serves the generated .tar.gz once the job is complete.
+func (hs *HTTPServer) DownloadDashboardDiagnostics(c *contextmodel.ReqContext) response.Response {
+	if !diagnosticsEnabled(c.Req.Context()) {
+		return response.Error(http.StatusNotFound, "on-demand diagnostics is not enabled", nil)
+	}
+	uid := web.Params(c.Req)[":uid"]
+	archive, state, ok := dashboardDiagnosticsJobs.archiveOf(uid)
+	if !ok {
+		return response.Error(http.StatusNotFound, "diagnostics job not found (it may have expired)", nil)
+	}
+	if state != jobComplete {
+		return response.Error(http.StatusConflict, fmt.Sprintf("diagnostics not ready (state: %s)", state), nil)
+	}
+
+	filename := fmt.Sprintf("dashboard-diagnostics-%s.tar.gz", time.Now().UTC().Format("20060102-150405"))
+	header := http.Header{}
+	header.Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, filename))
+	header.Set("Content-Type", "application/tar+gzip")
+	return response.CreateNormalResponse(header, archive, http.StatusOK)
+}
+
+// ---- generation ---------------------------------------------------------------------------------
+
+// buildDashboardDiagnosticsArchive runs each panel's queries with independent HAR capture, updating
+// job progress as panels complete, then delegates archive assembly to the diagnostics service. A
+// non-data panel (no queries) is recorded as skipped rather than run.
+func (hs *HTTPServer) buildDashboardDiagnosticsArchive(ctx context.Context, user identity.Requester, skipDSCache bool, reqDTO dashboardDiagnosticsRequest, jobUID string) ([]byte, error) {
+	specs := reqDTO.Panels
+	truncated := false
+	if len(specs) > maxDashboardDiagnosticsPanels {
+		specs = specs[:maxDashboardDiagnosticsPanels]
+		truncated = true
+	}
+
+	panels := make([]diagnostics.DashboardPanel, 0, len(specs))
+	for i, p := range specs {
+		if err := ctx.Err(); err != nil { // respect the generation timeout/cancel
+			return nil, err
+		}
+
+		panel := diagnostics.DashboardPanel{
+			ID:          p.ID,
+			Title:       p.Title,
+			PanelJSON:   p.Panel,
+			Datasources: panelDatasourceUIDs(p.MetricRequest),
+		}
+
+		if len(p.Queries) == 0 {
+			panel.Skipped = "no queries (non-data panel)"
+			panels = append(panels, panel)
+			dashboardDiagnosticsJobs.setProgress(jobUID, i+1)
+			continue
+		}
+
+		pctx, harBuffer := harcapture.WithCapture(ctx) // capture each panel independently
+		_, err := hs.queryDataService.QueryData(pctx, user, skipDSCache, p.MetricRequest)
+		panel.HARBuffer = harBuffer
+		panel.QueryErr = err
+
+		panels = append(panels, panel)
+		dashboardDiagnosticsJobs.setProgress(jobUID, i+1)
+	}
+
+	return diagnostics.NewBundler().BuildDashboard(reqDTO.Dashboard, panels, len(reqDTO.Panels), truncated)
+}
+
+// panelDatasourceUIDs returns the unique datasource UIDs referenced by a panel's queries.
+func panelDatasourceUIDs(req dtos.MetricRequest) []string {
+	seen := map[string]bool{}
+	uids := make([]string, 0, len(req.Queries))
+	for _, q := range req.Queries {
+		if q == nil {
+			continue
+		}
+		uid := q.Get("datasource").Get("uid").MustString()
+		if uid != "" && !seen[uid] {
+			seen[uid] = true
+			uids = append(uids, uid)
+		}
+	}
+	return uids
+}

--- a/pkg/api/ds_query_dashboard_diagnostics.go
+++ b/pkg/api/ds_query_dashboard_diagnostics.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/httpclient/harcapture"
+	"github.com/grafana/grafana/pkg/services/contexthandler"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/diagnostics"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -181,15 +182,29 @@ func (hs *HTTPServer) QueryDashboardDiagnostics(c *contextmodel.ReqContext) resp
 		return response.Error(http.StatusBadRequest, "at least one panel is required", nil)
 	}
 
-	job := dashboardDiagnosticsJobs.create(len(reqDTO.Panels))
+	jobTotal := len(reqDTO.Panels)
+	if jobTotal > maxDashboardDiagnosticsPanels {
+		jobTotal = maxDashboardDiagnosticsPanels // status polling only ever sees the capped run
+	}
+	job := dashboardDiagnosticsJobs.create(jobTotal)
 
 	// Snapshot the identity + cache flag; the goroutine must not touch the request or its context
 	// (both are tied to the HTTP request's lifetime, which ends when we return 202).
 	user := c.SignedInUser
 	skipDSCache := c.SkipDSCache
 
+	// detachedCtx carries its own cloned *http.Request (see contexthandler.CopyWithReqContext), so
+	// it stays safe to use after this handler returns. Force SkipQueryCache on it so a cache-hit
+	// query still goes to the wire under capture -- otherwise HAR capture runs on nothing and
+	// traffic.har is silently empty (same requirement as QueryDiagnostics in ds_query_diagnostics.go
+	// for the single-panel path, where c.SkipQueryCache is set directly on the request's ReqContext).
+	detachedCtx := contexthandler.CopyWithReqContext(c.Req.Context())
+	if reqCtx := contexthandler.FromContext(detachedCtx); reqCtx != nil {
+		reqCtx.SkipQueryCache = true
+	}
+
 	go func(uid string, user identity.Requester, skipDSCache bool, req dashboardDiagnosticsRequest) {
-		ctx, cancel := context.WithTimeout(context.Background(), dashboardDiagnosticsTimeout)
+		ctx, cancel := context.WithTimeout(detachedCtx, dashboardDiagnosticsTimeout)
 		defer cancel()
 		defer func() {
 			if r := recover(); r != nil {

--- a/pkg/api/ds_query_dashboard_diagnostics.go
+++ b/pkg/api/ds_query_dashboard_diagnostics.go
@@ -76,6 +76,17 @@ type diagnosticsJob struct {
 	PanelsDone  int
 	Err         string
 	archive     []byte
+
+	// createdByOrgID/createdByUID scope status/download to the identity that started the run. Jobs
+	// may hold verbatim captured HTTP traffic (see the harcapture package doc), so this is enforced
+	// even though the routes themselves are already gated admin-only.
+	createdByOrgID int64
+	createdByUID   string
+}
+
+// jobOwnedBy reports whether requester is the identity that created j.
+func jobOwnedBy(j *diagnosticsJob, requester identity.Requester) bool {
+	return j.createdByOrgID == requester.GetOrgID() && j.createdByUID == requester.GetUID()
 }
 
 type diagnosticsJobSnapshot struct {
@@ -97,24 +108,34 @@ type diagnosticsJobStore struct {
 // *HTTPServer can share it without new wire/DI wiring for this experimental feature.
 var dashboardDiagnosticsJobs = &diagnosticsJobStore{jobs: map[string]*diagnosticsJob{}}
 
-func (s *diagnosticsJobStore) create(total int) *diagnosticsJob {
+func (s *diagnosticsJobStore) create(total int, creator identity.Requester) *diagnosticsJob {
 	now := time.Now()
 	j := &diagnosticsJob{
-		UID:         util.GenerateShortUID(),
-		State:       jobPending,
-		CreatedAt:   now,
-		ExpiresAt:   now.Add(dashboardDiagnosticsTTL),
-		PanelsTotal: total,
+		UID:            util.GenerateShortUID(),
+		State:          jobPending,
+		CreatedAt:      now,
+		ExpiresAt:      now.Add(dashboardDiagnosticsTTL),
+		PanelsTotal:    total,
+		createdByOrgID: creator.GetOrgID(),
+		createdByUID:   creator.GetUID(),
 	}
 	s.mu.Lock()
-	for uid, existing := range s.jobs { // prune expired
+	s.pruneExpiredLocked(now)
+	s.jobs[j.UID] = j
+	s.mu.Unlock()
+	return j
+}
+
+// pruneExpiredLocked removes expired jobs (and their in-memory archives). Callers must hold s.mu
+// for writing. Called from every store access, not just create, so an idle feature (no new jobs,
+// but the odd status poll) still reclaims memory instead of holding onto expired archives until
+// the next generation run.
+func (s *diagnosticsJobStore) pruneExpiredLocked(now time.Time) {
+	for uid, existing := range s.jobs {
 		if now.After(existing.ExpiresAt) {
 			delete(s.jobs, uid)
 		}
 	}
-	s.jobs[j.UID] = j
-	s.mu.Unlock()
-	return j
 }
 
 func (s *diagnosticsJobStore) setProgress(uid string, done int) {
@@ -143,21 +164,27 @@ func (s *diagnosticsJobStore) fail(uid string, err error) {
 	s.mu.Unlock()
 }
 
-func (s *diagnosticsJobStore) snapshot(uid string) (diagnosticsJobSnapshot, bool) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+// snapshot returns uid's status, scoped to requester: a job that exists but belongs to a different
+// identity is reported exactly like an unknown UID, so this can't be used to probe for other users'
+// job IDs.
+func (s *diagnosticsJobStore) snapshot(uid string, requester identity.Requester) (diagnosticsJobSnapshot, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.pruneExpiredLocked(time.Now())
 	j := s.jobs[uid]
-	if j == nil {
+	if j == nil || !jobOwnedBy(j, requester) {
 		return diagnosticsJobSnapshot{}, false
 	}
 	return diagnosticsJobSnapshot{j.UID, j.State, j.PanelsTotal, j.PanelsDone, j.Err, j.CreatedAt, j.ExpiresAt}, true
 }
 
-func (s *diagnosticsJobStore) archiveOf(uid string) (archive []byte, state diagnosticsJobState, found bool) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+// archiveOf returns uid's archive, scoped to requester the same way snapshot is.
+func (s *diagnosticsJobStore) archiveOf(uid string, requester identity.Requester) (archive []byte, state diagnosticsJobState, found bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.pruneExpiredLocked(time.Now())
 	j := s.jobs[uid]
-	if j == nil {
+	if j == nil || !jobOwnedBy(j, requester) {
 		return nil, "", false
 	}
 	return j.archive, j.State, true
@@ -186,7 +213,7 @@ func (hs *HTTPServer) QueryDashboardDiagnostics(c *contextmodel.ReqContext) resp
 	if jobTotal > maxDashboardDiagnosticsPanels {
 		jobTotal = maxDashboardDiagnosticsPanels // status polling only ever sees the capped run
 	}
-	job := dashboardDiagnosticsJobs.create(jobTotal)
+	job := dashboardDiagnosticsJobs.create(jobTotal, c.SignedInUser)
 
 	// Snapshot the identity + cache flag; the goroutine must not touch the request or its context
 	// (both are tied to the HTTP request's lifetime, which ends when we return 202).
@@ -229,7 +256,7 @@ func (hs *HTTPServer) GetDashboardDiagnosticsStatus(c *contextmodel.ReqContext) 
 		return response.Error(http.StatusNotFound, "on-demand diagnostics is not enabled", nil)
 	}
 	uid := web.Params(c.Req)[":uid"]
-	snap, ok := dashboardDiagnosticsJobs.snapshot(uid)
+	snap, ok := dashboardDiagnosticsJobs.snapshot(uid, c.SignedInUser)
 	if !ok {
 		return response.Error(http.StatusNotFound, "diagnostics job not found (it may have expired)", nil)
 	}
@@ -250,7 +277,7 @@ func (hs *HTTPServer) DownloadDashboardDiagnostics(c *contextmodel.ReqContext) r
 		return response.Error(http.StatusNotFound, "on-demand diagnostics is not enabled", nil)
 	}
 	uid := web.Params(c.Req)[":uid"]
-	archive, state, ok := dashboardDiagnosticsJobs.archiveOf(uid)
+	archive, state, ok := dashboardDiagnosticsJobs.archiveOf(uid, c.SignedInUser)
 	if !ok {
 		return response.Error(http.StatusNotFound, "diagnostics job not found (it may have expired)", nil)
 	}

--- a/pkg/api/ds_query_dashboard_diagnostics_test.go
+++ b/pkg/api/ds_query_dashboard_diagnostics_test.go
@@ -6,44 +6,54 @@ import (
 
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/stretchr/testify/require"
 )
 
 func TestDiagnosticsJobStore_lifecycle(t *testing.T) {
 	s := &diagnosticsJobStore{jobs: map[string]*diagnosticsJob{}}
+	creator := &user.SignedInUser{OrgID: 1, UserUID: "creator"}
+	someoneElse := &user.SignedInUser{OrgID: 1, UserUID: "someone-else"}
 
-	job := s.create(3)
+	job := s.create(3, creator)
 	require.NotEmpty(t, job.UID)
 
-	snap, ok := s.snapshot(job.UID)
+	snap, ok := s.snapshot(job.UID, creator)
 	require.True(t, ok)
 	require.Equal(t, jobPending, snap.State)
 	require.Equal(t, 3, snap.PanelsTotal)
 
 	s.setProgress(job.UID, 2)
-	snap, _ = s.snapshot(job.UID)
+	snap, _ = s.snapshot(job.UID, creator)
 	require.Equal(t, 2, snap.PanelsDone)
 
 	// Before completion there is no downloadable archive.
-	_, state, ok := s.archiveOf(job.UID)
+	_, state, ok := s.archiveOf(job.UID, creator)
 	require.True(t, ok)
 	require.Equal(t, jobPending, state)
 
 	s.complete(job.UID, []byte("archive-bytes"))
-	archive, state, ok := s.archiveOf(job.UID)
+	archive, state, ok := s.archiveOf(job.UID, creator)
 	require.True(t, ok)
 	require.Equal(t, jobComplete, state)
 	require.Equal(t, []byte("archive-bytes"), archive)
 
+	// A different identity gets the same "not found" as an unknown UID -- it must not be able to
+	// tell the job exists at all, let alone read its status or archive.
+	_, ok = s.snapshot(job.UID, someoneElse)
+	require.False(t, ok, "a different identity must not see another creator's job")
+	_, _, ok = s.archiveOf(job.UID, someoneElse)
+	require.False(t, ok, "a different identity must not download another creator's archive")
+
 	// A failed job carries its error and stays without an archive.
-	other := s.create(1)
-	s.fail(other.UID, errors.New("boom"))
-	snap, _ = s.snapshot(other.UID)
+	otherJob := s.create(1, creator)
+	s.fail(otherJob.UID, errors.New("boom"))
+	snap, _ = s.snapshot(otherJob.UID, creator)
 	require.Equal(t, jobError, snap.State)
 	require.Equal(t, "boom", snap.Err)
 
 	// Unknown UID is reported as not found.
-	_, ok = s.snapshot("nope")
+	_, ok = s.snapshot("nope", creator)
 	require.False(t, ok)
 }
 

--- a/pkg/api/ds_query_dashboard_diagnostics_test.go
+++ b/pkg/api/ds_query_dashboard_diagnostics_test.go
@@ -1,0 +1,63 @@
+package api
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/grafana/grafana/pkg/api/dtos"
+	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiagnosticsJobStore_lifecycle(t *testing.T) {
+	s := &diagnosticsJobStore{jobs: map[string]*diagnosticsJob{}}
+
+	job := s.create(3)
+	require.NotEmpty(t, job.UID)
+
+	snap, ok := s.snapshot(job.UID)
+	require.True(t, ok)
+	require.Equal(t, jobPending, snap.State)
+	require.Equal(t, 3, snap.PanelsTotal)
+
+	s.setProgress(job.UID, 2)
+	snap, _ = s.snapshot(job.UID)
+	require.Equal(t, 2, snap.PanelsDone)
+
+	// Before completion there is no downloadable archive.
+	_, state, ok := s.archiveOf(job.UID)
+	require.True(t, ok)
+	require.Equal(t, jobPending, state)
+
+	s.complete(job.UID, []byte("archive-bytes"))
+	archive, state, ok := s.archiveOf(job.UID)
+	require.True(t, ok)
+	require.Equal(t, jobComplete, state)
+	require.Equal(t, []byte("archive-bytes"), archive)
+
+	// A failed job carries its error and stays without an archive.
+	other := s.create(1)
+	s.fail(other.UID, errors.New("boom"))
+	snap, _ = s.snapshot(other.UID)
+	require.Equal(t, jobError, snap.State)
+	require.Equal(t, "boom", snap.Err)
+
+	// Unknown UID is reported as not found.
+	_, ok = s.snapshot("nope")
+	require.False(t, ok)
+}
+
+func TestPanelDatasourceUIDs(t *testing.T) {
+	q := func(uid string) *simplejson.Json {
+		j := simplejson.New()
+		if uid != "" {
+			j.SetPath([]string{"datasource", "uid"}, uid)
+		}
+		return j
+	}
+	req := dtos.MetricRequest{Queries: []*simplejson.Json{q("prom"), q("prom"), q("loki"), q(""), nil}}
+	// Deduplicated, in first-seen order; empty/nil entries dropped.
+	require.Equal(t, []string{"prom", "loki"}, panelDatasourceUIDs(req))
+
+	require.Empty(t, panelDatasourceUIDs(dtos.MetricRequest{}))
+}

--- a/pkg/api/ds_query_dashboard_diagnostics_test.go
+++ b/pkg/api/ds_query_dashboard_diagnostics_test.go
@@ -1,14 +1,84 @@
 package api
 
 import (
+	"context"
+	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	backend "github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/infra/log"
+	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/query"
 	"github.com/grafana/grafana/pkg/services/user"
-	"github.com/stretchr/testify/require"
+	"github.com/grafana/grafana/pkg/web"
 )
+
+// TestQueryDashboardDiagnostics_survivesRequestContextCancellation guards against a regression
+// where the background generation goroutine was derived from the initiating HTTP request's own
+// context. net/http cancels that context as soon as the handler returns (see Request.Context
+// docs), which happens almost immediately after this handler kicks off the goroutine and responds
+// 202 -- so the generation must not inherit that cancellation.
+func TestQueryDashboardDiagnostics_survivesRequestContextCancellation(t *testing.T) {
+	setupOpenFeatureFlag(t, featuremgmt.FlagGrafanaOnDemandDiagnostics, true)
+
+	fakeQuery := query.NewFakeQueryService(t)
+	fakeQuery.On("QueryData", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(backend.NewQueryDataResponse(), nil)
+	hs := &HTTPServer{queryDataService: fakeQuery}
+
+	body := `{"panels":[{"id":1,"title":"Panel 1","from":"now-1h","to":"now","queries":[{"refId":"A","datasource":{"uid":"prom"}}]}]}`
+	req, err := http.NewRequest(http.MethodPost, "/api/ds/dashboard-diagnostics", strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	// A cancelable context stands in for the real *http.Request context, which net/http cancels
+	// as soon as ServeHTTP returns.
+	reqCtx, cancelReq := context.WithCancel(req.Context())
+	req = req.WithContext(reqCtx)
+
+	c := &contextmodel.ReqContext{
+		Context: &web.Context{
+			Req:  req,
+			Resp: web.NewResponseWriter(req.Method, httptest.NewRecorder()),
+		},
+		SignedInUser: &user.SignedInUser{OrgID: 1, UserUID: "u1"},
+		Logger:       log.New("test"),
+	}
+
+	resp := hs.QueryDashboardDiagnostics(c)
+	require.Equal(t, http.StatusAccepted, resp.Status())
+
+	var accepted map[string]any
+	require.NoError(t, json.Unmarshal(resp.Body(), &accepted))
+	uid, _ := accepted["uid"].(string)
+	require.NotEmpty(t, uid)
+
+	// Simulate net/http canceling the request's context immediately after the handler returns --
+	// exactly what happens in production once the 202 response is written.
+	cancelReq()
+
+	require.Eventually(t, func() bool {
+		snap, ok := dashboardDiagnosticsJobs.snapshot(uid, c.SignedInUser)
+		return ok && snap.State != jobPending
+	}, 2*time.Second, 10*time.Millisecond, "job never left pending state")
+
+	snap, ok := dashboardDiagnosticsJobs.snapshot(uid, c.SignedInUser)
+	require.True(t, ok)
+	require.Equal(t, jobComplete, snap.State,
+		"job must complete even though the initiating request's context was canceled after the handler returned")
+	require.Empty(t, snap.Err)
+}
 
 func TestDiagnosticsJobStore_lifecycle(t *testing.T) {
 	s := &diagnosticsJobStore{jobs: map[string]*diagnosticsJob{}}

--- a/pkg/services/diagnostics/diagnostics.go
+++ b/pkg/services/diagnostics/diagnostics.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
@@ -57,6 +58,140 @@ func (b *Bundler) Build(harBuffer *harcapture.Buffer, panelJSON, dashboardJSON j
 	}
 
 	return buildTarGz(files)
+}
+
+// DashboardPanel is one panel's captured input for a whole-dashboard diagnostics archive. The
+// caller runs each panel's queries with an independent HAR capture buffer and hands the results
+// here for assembly.
+type DashboardPanel struct {
+	ID          int64
+	Title       string
+	PanelJSON   json.RawMessage
+	Datasources []string           // datasource UIDs the panel references (for the manifest)
+	HARBuffer   *harcapture.Buffer // capture buffer for this panel's queries
+	QueryErr    error              // top-level error running the panel's queries, if any
+	Skipped     string             // non-empty => panel was not executed (e.g. non-data panel)
+}
+
+// dashboardManifest is manifest.json: a machine-readable summary of what the whole-dashboard bundle
+// contains, so a reader can see which panels ran, were skipped, or errored without unpacking each dir.
+type dashboardManifest struct {
+	GeneratedAt string               `json:"generatedAt"`
+	PanelsTotal int                  `json:"panelsTotal"`
+	PanelsRun   int                  `json:"panelsRun"`
+	Truncated   bool                 `json:"truncated,omitempty"`
+	Panels      []manifestPanelEntry `json:"panels"`
+}
+
+type manifestPanelEntry struct {
+	ID          int64    `json:"id"`
+	Title       string   `json:"title"`
+	Dir         string   `json:"dir,omitempty"`
+	Datasources []string `json:"datasources,omitempty"`
+	HARBytes    int      `json:"harBytes,omitempty"`
+	Skipped     string   `json:"skipped,omitempty"`
+	Error       string   `json:"error,omitempty"`
+}
+
+// BuildDashboard assembles a whole-dashboard .tar.gz: a shared dashboard.json and manifest.json plus
+// per-panel panels/<id>-<slug>/{panel.json, traffic.har, query-error.txt}. panelsTotal is the number
+// of panels the caller intended to run (before any cap) and truncated reports whether the caller
+// capped the panels slice, so the manifest reflects the full picture.
+//
+// Like Build, captured traffic and error text are recorded VERBATIM -- redaction is intentionally
+// deferred (see the harcapture package doc) -- and server logs are omitted (not request-scoped).
+func (b *Bundler) BuildDashboard(dashboardJSON json.RawMessage, panels []DashboardPanel, panelsTotal int, truncated bool) ([]byte, error) {
+	manifest := dashboardManifest{
+		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
+		PanelsTotal: panelsTotal,
+		Truncated:   truncated,
+	}
+
+	files := map[string][]byte{}
+	if len(dashboardJSON) > 0 {
+		files["dashboard.json"] = indentJSON(dashboardJSON)
+	}
+
+	usedDirs := map[string]bool{}
+	for _, p := range panels {
+		entry := manifestPanelEntry{ID: p.ID, Title: p.Title, Datasources: p.Datasources}
+
+		if p.Skipped != "" {
+			entry.Skipped = p.Skipped
+			manifest.Panels = append(manifest.Panels, entry)
+			continue
+		}
+
+		dir := uniquePanelDir(p.ID, p.Title, usedDirs)
+		entry.Dir = dir
+		if len(p.PanelJSON) > 0 {
+			files[dir+"/panel.json"] = indentJSON(p.PanelJSON)
+		}
+
+		har, err := collectHAR(p.HARBuffer)
+		if err != nil {
+			return nil, err
+		}
+		if len(har) > 0 {
+			files[dir+"/traffic.har"] = har
+			entry.HARBytes = len(har)
+		}
+
+		if p.QueryErr != nil {
+			entry.Error = p.QueryErr.Error()
+			files[dir+"/query-error.txt"] = []byte(p.QueryErr.Error() + "\n")
+		} else {
+			manifest.PanelsRun++
+		}
+
+		manifest.Panels = append(manifest.Panels, entry)
+	}
+
+	if manifestJSON, err := json.MarshalIndent(manifest, "", "  "); err == nil {
+		files["manifest.json"] = manifestJSON
+	}
+
+	return buildTarGz(files)
+}
+
+// uniquePanelDir builds a stable, filesystem-safe directory name (panels/<id>-<slug>),
+// disambiguating collisions with a numeric suffix.
+func uniquePanelDir(id int64, title string, used map[string]bool) string {
+	base := fmt.Sprintf("panels/%d", id)
+	if slug := panelTitleSlug(title); slug != "" {
+		base += "-" + slug
+	}
+	dir := base
+	for i := 2; used[dir]; i++ {
+		dir = fmt.Sprintf("%s-%d", base, i)
+	}
+	used[dir] = true
+	return dir
+}
+
+// panelTitleSlug lowercases a title and keeps only [a-z0-9], collapsing other runs to single
+// hyphens and capping length so directory names stay short and portable.
+func panelTitleSlug(s string) string {
+	s = strings.ToLower(s)
+	var b strings.Builder
+	prevDash := false
+	for _, r := range s {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'):
+			b.WriteRune(r)
+			prevDash = false
+		default:
+			if !prevDash && b.Len() > 0 {
+				b.WriteByte('-')
+				prevDash = true
+			}
+		}
+	}
+	out := strings.Trim(b.String(), "-")
+	if len(out) > 40 {
+		out = strings.Trim(out[:40], "-")
+	}
+	return out
 }
 
 // ResponseError returns a combined error describing any per-refId query failures in resp

--- a/pkg/services/diagnostics/diagnostics_test.go
+++ b/pkg/services/diagnostics/diagnostics_test.go
@@ -141,6 +141,82 @@ func TestResponseError(t *testing.T) {
 	require.Equal(t, "A: bad query\nB: boom", err.Error())
 }
 
+func bufferWithEntry(t *testing.T, url string) *harcapture.Buffer {
+	t.Helper()
+	buf := &harcapture.Buffer{}
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	require.NoError(t, err)
+	buf.AddEntry(req, nil, nil, time.Now(), time.Millisecond)
+	return buf
+}
+
+func TestBuildDashboard(t *testing.T) {
+	panels := []DashboardPanel{
+		{ID: 1, Title: "CPU Usage", PanelJSON: json.RawMessage(`{"id":1}`), Datasources: []string{"prom"}, HARBuffer: bufferWithEntry(t, "http://ds/1")},
+		{ID: 2, Title: "Text panel", Skipped: "no queries (non-data panel)"},
+	}
+	blob, err := NewBundler().BuildDashboard(json.RawMessage(`{"title":"My dash"}`), panels, 2, false)
+	require.NoError(t, err)
+
+	files := readTarGz(t, blob)
+	require.Contains(t, files, "dashboard.json")
+	require.Contains(t, files, "manifest.json")
+	require.Contains(t, files, "panels/1-cpu-usage/panel.json")
+	require.Contains(t, files, "panels/1-cpu-usage/traffic.har")
+	require.NotContains(t, files, "server.log", "server log is intentionally omitted (not request-scoped)")
+	// A skipped panel gets no dir.
+	for name := range files {
+		require.NotContains(t, name, "panels/2", "skipped panel must not have a dir")
+	}
+
+	var m dashboardManifest
+	require.NoError(t, json.Unmarshal(files["manifest.json"], &m))
+	require.Equal(t, 2, m.PanelsTotal)
+	require.Equal(t, 1, m.PanelsRun, "only the data panel ran")
+	require.False(t, m.Truncated)
+	require.Len(t, m.Panels, 2)
+	require.Equal(t, "no queries (non-data panel)", m.Panels[1].Skipped)
+	require.Equal(t, "panels/1-cpu-usage", m.Panels[0].Dir)
+	require.Positive(t, m.Panels[0].HARBytes)
+}
+
+func TestBuildDashboard_recordsPanelQueryError(t *testing.T) {
+	panels := []DashboardPanel{
+		{ID: 7, Title: "Broken", QueryErr: errors.New("datasource exploded")},
+	}
+	blob, err := NewBundler().BuildDashboard(nil, panels, 1, false)
+	require.NoError(t, err)
+
+	files := readTarGz(t, blob)
+	require.Contains(t, files, "panels/7-broken/query-error.txt")
+	require.Contains(t, string(files["panels/7-broken/query-error.txt"]), "datasource exploded")
+
+	var m dashboardManifest
+	require.NoError(t, json.Unmarshal(files["manifest.json"], &m))
+	require.Equal(t, 0, m.PanelsRun, "a panel whose query errored is not counted as run")
+	require.Equal(t, "datasource exploded", m.Panels[0].Error)
+}
+
+func TestBuildDashboard_truncationAndDirCollision(t *testing.T) {
+	// Two panels share an id+title, so their dirs must be disambiguated.
+	panels := []DashboardPanel{
+		{ID: 3, Title: "Same", HARBuffer: bufferWithEntry(t, "http://ds/a")},
+		{ID: 3, Title: "Same", HARBuffer: bufferWithEntry(t, "http://ds/b")},
+	}
+	// panelsTotal (10) > len(panels): the caller capped the list, so truncated is recorded.
+	blob, err := NewBundler().BuildDashboard(nil, panels, 10, true)
+	require.NoError(t, err)
+
+	files := readTarGz(t, blob)
+	require.Contains(t, files, "panels/3-same/traffic.har")
+	require.Contains(t, files, "panels/3-same-2/traffic.har", "collision disambiguated with a numeric suffix")
+
+	var m dashboardManifest
+	require.NoError(t, json.Unmarshal(files["manifest.json"], &m))
+	require.True(t, m.Truncated)
+	require.Equal(t, 10, m.PanelsTotal)
+}
+
 func readTarGz(t *testing.T, data []byte) map[string][]byte {
 	t.Helper()
 


### PR DESCRIPTION
## What this PR does

Adds **dashboard-level** on-demand diagnostics on top of the merged core panel capture (#128378): run every data panel's queries with independent HTTP capture and pack a single `.tar.gz`. Because a whole dashboard can be slow, generation is **asynchronous** (support-bundle style).

## Scope

**Backend only.** The dashboard-level frontend action is a separate PR (per the repo's FE/BE split).

The in-memory job store is not persisted / not HA-shared — durability (kvstore / object storage) is a tracked follow-up.
