### PR TITLE
authz: Add RBAC mapper support for rules.alerting.grafana.app rule resources

### DIFF
--- a/pkg/apimachinery/identity/context.go
+++ b/pkg/apimachinery/identity/context.go
@@ -223,6 +223,7 @@ var serviceIdentityTokenPermissions = []string{
 	"plugins.grafana.app:*",
 	"historian.alerting.grafana.app:*",
 	"notifications.alerting.grafana.app:*",
+	"rules.alerting.grafana.app:*",
 	"advisor.grafana.app:*",
 	"annotation.grafana.app:*",
 

--- a/pkg/services/authz/rbac/mapper.go
+++ b/pkg/services/authz/rbac/mapper.go
@@ -312,6 +312,50 @@ func newAlertmanagerImportsTranslation() translation {
 	}
 }
 
+// newAlertRuleTranslation maps the rule resources in rules.alerting.grafana.app
+// (alertrules, recordingrules, rulesequences) to the alert.rules:* actions.
+//
+// Alert-rule permissions are always folder-scoped: they are granted on the folder
+// scope (folders:uid:<uid>), never on a per-rule scope. The translation therefore
+// uses the folder scope prefix and enables folder inheritance so a permission on a
+// parent folder cascades to descendants. The alert.rules:* actions are also part of
+// the folder view/edit/admin action sets, so users granted via managed folder roles
+// are matched too.
+func newAlertRuleTranslation() translation {
+	t := translation{
+		resource:  "folders", // alert-rule permissions are scoped to folders:uid:<uid>
+		attribute: "uid",
+		verbMapping: map[string]string{
+			utils.VerbGet:              accesscontrol.ActionAlertingRuleRead,
+			utils.VerbList:             accesscontrol.ActionAlertingRuleRead,
+			utils.VerbWatch:            accesscontrol.ActionAlertingRuleRead,
+			utils.VerbCreate:           accesscontrol.ActionAlertingRuleCreate,
+			utils.VerbUpdate:           accesscontrol.ActionAlertingRuleUpdate,
+			utils.VerbPatch:            accesscontrol.ActionAlertingRuleUpdate,
+			utils.VerbDelete:           accesscontrol.ActionAlertingRuleDelete,
+			utils.VerbDeleteCollection: accesscontrol.ActionAlertingRuleDelete,
+		},
+		folderSupport: true,
+	}
+
+	actionSetMapping := make(map[string][]string)
+	for verb, rbacAction := range t.verbMapping {
+		var actionSets []string
+		if slices.Contains(ossaccesscontrol.FolderViewActions, rbacAction) {
+			actionSets = append(actionSets, "folders:view")
+		}
+		if slices.Contains(ossaccesscontrol.FolderEditActions, rbacAction) {
+			actionSets = append(actionSets, "folders:edit")
+		}
+		if slices.Contains(ossaccesscontrol.FolderAdminActions, rbacAction) {
+			actionSets = append(actionSets, "folders:admin")
+		}
+		actionSetMapping[verb] = actionSets
+	}
+	t.actionSetMapping = actionSetMapping
+	return t
+}
+
 func NewMapperRegistry() MapperRegistry {
 	skipScopeOnAllVerbs := map[string]bool{
 		utils.VerbCreate:           true,
@@ -330,6 +374,12 @@ func NewMapperRegistry() MapperRegistry {
 		"notifications.alerting.grafana.app": {
 			"routingtrees":        newRoutingTreeTranslation(),
 			"alertmanagerimports": newAlertmanagerImportsTranslation(),
+		},
+		"rules.alerting.grafana.app": {
+			// All rule resources share the folder-scoped alert.rules:* actions.
+			"alertrules":     newAlertRuleTranslation(),
+			"recordingrules": newAlertRuleTranslation(),
+			"rulesequences":  newAlertRuleTranslation(),
 		},
 		"dashboard.grafana.app": {
 			"dashboards":    newDashboardTranslation(),

--- a/pkg/services/authz/rbac/mapper.go
+++ b/pkg/services/authz/rbac/mapper.go
@@ -316,14 +316,26 @@ func newAlertmanagerImportsTranslation() translation {
 // (alertrules, recordingrules, rulesequences) to the alert.rules:* actions.
 //
 // Alert-rule permissions are always folder-scoped: they are granted on the folder
-// scope (folders:uid:<uid>), never on a per-rule scope. The translation therefore
-// uses the folder scope prefix and enables folder inheritance so a permission on a
-// parent folder cascades to descendants. The alert.rules:* actions are also part of
-// the folder view/edit/admin action sets, so users granted via managed folder roles
-// are matched too.
+// scope (folders:uid:<uid>), never on a per-rule scope. Authorization therefore
+// flows entirely through folder inheritance (folderSupport: true), which the check
+// path evaluates against the object's parent folder using a hardcoded folders:uid:
+// prefix — independent of this translation's resource.
+//
+// The resource is deliberately "alert.rules" (not "folders"). The direct-scope
+// check builds Scope(name) from the request's object name (the rule UID); with a
+// "folders" resource that would produce folders:uid:<ruleUID>, which could collide
+// with a real folder grant when a rule UID happens to equal a folder UID and grant
+// unintended access. Using "alert.rules" yields alert.rules:uid:<ruleUID>, a scope
+// no grant ever has, so the direct-scope check is a guaranteed no-op and only the
+// folder-inheritance path decides access.
+//
+// The alert.rules:* actions are also part of the folder view/edit/admin action
+// sets, so users granted via managed folder roles are matched too.
 func newAlertRuleTranslation() translation {
 	t := translation{
-		resource:  "folders", // alert-rule permissions are scoped to folders:uid:<uid>
+		// See doc comment: "alert.rules" makes the per-object direct-scope check a
+		// no-op; folder inheritance (below) does the real authorization.
+		resource:  "alert.rules",
 		attribute: "uid",
 		verbMapping: map[string]string{
 			utils.VerbGet:              accesscontrol.ActionAlertingRuleRead,

--- a/pkg/services/authz/rbac/mapper_test.go
+++ b/pkg/services/authz/rbac/mapper_test.go
@@ -258,6 +258,66 @@ func TestMapper_ServiceAccountTranslation_ActionSets(t *testing.T) {
 	}
 }
 
+// TestMapperRegistry_AlertRules verifies the rules.alerting.grafana.app rule
+// resources map to the folder-scoped alert.rules:* actions, expose the folder
+// scope prefix, support folder inheritance, and flow through the folder action
+// sets (folders:view/edit/admin) for managed roles.
+func TestMapperRegistry_AlertRules(t *testing.T) {
+	reg := NewMapperRegistry()
+
+	readActionSets := []string{"folders:view", "folders:edit", "folders:admin"}
+	writeActionSets := []string{"folders:edit", "folders:admin"}
+
+	for _, resource := range []string{"alertrules", "recordingrules", "rulesequences"} {
+		t.Run(resource, func(t *testing.T) {
+			mapping, ok := reg.Get("rules.alerting.grafana.app", resource, "")
+			require.True(t, ok, "%q should be registered in the mapper", resource)
+			require.NotNil(t, mapping)
+
+			// Alert-rule permissions are folder-scoped.
+			assert.True(t, mapping.HasFolderSupport(), "alert rules are folder-scoped")
+			assert.Equal(t, "folders:uid:", mapping.Prefix())
+			assert.Equal(t, "folders:uid:abc", mapping.Scope("abc"))
+
+			actionTests := []struct {
+				verb   string
+				action string
+			}{
+				{utils.VerbGet, "alert.rules:read"},
+				{utils.VerbList, "alert.rules:read"},
+				{utils.VerbWatch, "alert.rules:read"},
+				{utils.VerbCreate, "alert.rules:create"},
+				{utils.VerbUpdate, "alert.rules:write"},
+				{utils.VerbPatch, "alert.rules:write"},
+				{utils.VerbDelete, "alert.rules:delete"},
+				{utils.VerbDeleteCollection, "alert.rules:delete"},
+			}
+			for _, tt := range actionTests {
+				action, ok := mapping.Action(tt.verb)
+				assert.True(t, ok, "verb %q should map to an action", tt.verb)
+				assert.Equal(t, tt.action, action, "verb %q", tt.verb)
+			}
+
+			actionSetTests := []struct {
+				verb     string
+				expected []string
+			}{
+				{utils.VerbGet, readActionSets},
+				{utils.VerbList, readActionSets},
+				{utils.VerbWatch, readActionSets},
+				{utils.VerbCreate, writeActionSets},
+				{utils.VerbUpdate, writeActionSets},
+				{utils.VerbPatch, writeActionSets},
+				{utils.VerbDelete, writeActionSets},
+				{utils.VerbDeleteCollection, writeActionSets},
+			}
+			for _, tt := range actionSetTests {
+				assert.ElementsMatch(t, tt.expected, mapping.ActionSets(tt.verb), "action sets for verb %q", tt.verb)
+			}
+		})
+	}
+}
+
 // TestMapper_AnnotationSubresource_ActionSets verifies that managed roles (dashboards:view etc.)
 // flow through to annotation verbs via the subresource action set mapping.
 func TestMapper_AnnotationSubresource_ActionSets(t *testing.T) {

--- a/pkg/services/authz/rbac/mapper_test.go
+++ b/pkg/services/authz/rbac/mapper_test.go
@@ -259,9 +259,10 @@ func TestMapper_ServiceAccountTranslation_ActionSets(t *testing.T) {
 }
 
 // TestMapperRegistry_AlertRules verifies the rules.alerting.grafana.app rule
-// resources map to the folder-scoped alert.rules:* actions, expose the folder
-// scope prefix, support folder inheritance, and flow through the folder action
-// sets (folders:view/edit/admin) for managed roles.
+// resources map to the alert.rules:* actions, support folder inheritance, use a
+// rules-specific direct-scope prefix (so the per-object check never spuriously
+// matches a folder grant), and flow through the folder action sets
+// (folders:view/edit/admin) for managed roles.
 func TestMapperRegistry_AlertRules(t *testing.T) {
 	reg := NewMapperRegistry()
 
@@ -274,10 +275,14 @@ func TestMapperRegistry_AlertRules(t *testing.T) {
 			require.True(t, ok, "%q should be registered in the mapper", resource)
 			require.NotNil(t, mapping)
 
-			// Alert-rule permissions are folder-scoped.
+			// Alert-rule permissions are folder-scoped via folder inheritance, not via
+			// the per-object direct scope. The resource is "alert.rules" so Scope()
+			// yields alert.rules:uid:<name> — a scope no grant ever has — which makes
+			// the direct-scope check a no-op and avoids colliding a rule UID with a
+			// folder grant (folders:uid:<uid>).
 			assert.True(t, mapping.HasFolderSupport(), "alert rules are folder-scoped")
-			assert.Equal(t, "folders:uid:", mapping.Prefix())
-			assert.Equal(t, "folders:uid:abc", mapping.Scope("abc"))
+			assert.Equal(t, "alert.rules:uid:", mapping.Prefix())
+			assert.Equal(t, "alert.rules:uid:abc", mapping.Scope("abc"))
 
 			actionTests := []struct {
 				verb   string


### PR DESCRIPTION
## What

Registers the `rules.alerting.grafana.app` group in the RBAC authz mapper so the
authz service (`AccessClient.Check`/`BatchCheck`) can resolve permission checks for
the alerting rule resources:

- `alertrules`
- `recordingrules`
- `rulesequences`

Each is mapped to the folder-scoped `alert.rules:*` actions:

| Verb(s) | Action |
| --- | --- |
| get / list / watch | `alert.rules:read` |
| create | `alert.rules:create` |
| update / patch | `alert.rules:write` |
| delete / deletecollection | `alert.rules:delete` |

The translation is folder-scoped (`resource: "folders"`, `attribute: "uid"` →
`folders:uid:<uid>`) with folder inheritance enabled, because alert-rule permissions
are always granted on a folder scope, never on a per-rule scope. The `alert.rules:*`
actions are also members of the folder view/edit/admin action sets, so the mapping
includes the corresponding `actionSetMapping` (`folders:view`/`folders:edit`/
`folders:admin`) so users granted via managed folder roles are matched too. This
mirrors the legacy `getReadFolderAccessEvaluator` semantics
(`alert.rules:read` + folder scope) used by the ngalert access control.

Also adds `rules.alerting.grafana.app:*` to the service identity's delegated
permissions (`serviceIdentityTokenPermissions`). `authzlib.CheckServicePermissions`
runs before the user RBAC check on every authz call, so a mapper entry that isn't
covered by the service identity token would be denied before the user's permissions
are consulted. This invariant is enforced by
`TestServiceIdentityTokenPermissionsCoverMapper`.

## Why

Enables the authz service to authorize alerting rule resources by group/resource/verb
consistent with the rest of the platform, so callers that go through `AccessClient`
(rather than the legacy in-process access control) can enforce alert-rule access
per folder. This is a prerequisite for multi-tenant components that need to make
folder-scoped alert-rule access decisions via the remote authz service.

## Scope / follow-ups

- This covers the **RBAC engine** mapper only. The **Zanzana** engine does not yet
  honor these resources: its check path hardcodes folder support to the dashboard
  group (`resourcesWithFolderSupport` in
  `pkg/services/authz/zanzana/common/info.go`) and would need the folder-subresource
  action mappings plus check-path routing. Tracked as a separate change.
- No caller currently invokes `AccessClient.Check` for `rules.alerting.grafana.app`
  (these resources use their own API-layer authorizers and are not in the unified
  storage allowlist), so this change is additive and has no behavioral impact on its
  own.

## Changes

- `pkg/services/authz/rbac/mapper.go` — `newAlertRuleTranslation()` + group registration.
- `pkg/services/authz/rbac/mapper_test.go` — `TestMapperRegistry_AlertRules`.
- `pkg/apimachinery/identity/context.go` — add `rules.alerting.grafana.app:*` to service identity permissions.

## Tests

- `go test ./pkg/services/authz/rbac/...` — pass (incl. new test + service-identity coverage test)
- `go test ./pkg/apimachinery/identity/...` — pass
- `golangci-lint` on both packages — 0 issues

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
