### PR TITLE
Datasources: panel-scoped resource limits for on-demand diagnostics

### DIFF
--- a/pkg/api/ds_query_diagnostics.go
+++ b/pkg/api/ds_query_diagnostics.go
@@ -51,11 +51,8 @@ func (hs *HTTPServer) QueryDiagnostics(c *contextmodel.ReqContext) response.Resp
 	if err := web.Bind(c.Req, &reqDTO); err != nil {
 		return response.Error(http.StatusBadRequest, "bad request data", err)
 	}
-	if len(reqDTO.Queries) == 0 {
-		return response.Error(http.StatusBadRequest, "at least one query is required", nil)
-	}
-	if len(reqDTO.Queries) > maxDiagnosticsQueries {
-		return response.Error(http.StatusBadRequest, fmt.Sprintf("too many queries (%d); the maximum is %d", len(reqDTO.Queries), maxDiagnosticsQueries), nil)
+	if r := validateDiagnosticsQueryCount(len(reqDTO.Queries)); r != nil {
+		return r
 	}
 
 	captureCtx, harBuffer := harcapture.WithCapture(ctx)
@@ -111,6 +108,18 @@ func (hs *HTTPServer) QueryDiagnostics(c *contextmodel.ReqContext) response.Resp
 	header.Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, filename))
 	header.Set("Content-Type", "application/tar+gzip")
 	return response.CreateNormalResponse(header, bundle, http.StatusOK)
+}
+
+// validateDiagnosticsQueryCount returns the 400 response to send when n (the number of queries in
+// the request) is zero or exceeds maxDiagnosticsQueries, else nil so the caller proceeds.
+func validateDiagnosticsQueryCount(n int) response.Response {
+	if n == 0 {
+		return response.Error(http.StatusBadRequest, "at least one query is required", nil)
+	}
+	if n > maxDiagnosticsQueries {
+		return response.Error(http.StatusBadRequest, fmt.Sprintf("too many queries (%d); the maximum is %d", n, maxDiagnosticsQueries), nil)
+	}
+	return nil
 }
 
 // diagnosticsNoCaptureError returns the response to send when a query failed and nothing was

--- a/pkg/api/ds_query_diagnostics.go
+++ b/pkg/api/ds_query_diagnostics.go
@@ -17,6 +17,10 @@ import (
 	"github.com/grafana/grafana/pkg/web"
 )
 
+// maxDiagnosticsQueries bounds how many queries a single-panel diagnostics request will run, so a
+// request can't trigger an unbounded number of datasource calls and captures.
+const maxDiagnosticsQueries = 100
+
 // diagnosticsRequest is the body posted by the "Download diagnostics" panel action. It carries
 // the datasource queries to run with HAR capture active, plus the optional panel and dashboard
 // definitions the client already holds (so we avoid a dashboard-service lookup).
@@ -49,6 +53,9 @@ func (hs *HTTPServer) QueryDiagnostics(c *contextmodel.ReqContext) response.Resp
 	}
 	if len(reqDTO.Queries) == 0 {
 		return response.Error(http.StatusBadRequest, "at least one query is required", nil)
+	}
+	if len(reqDTO.Queries) > maxDiagnosticsQueries {
+		return response.Error(http.StatusBadRequest, fmt.Sprintf("too many queries (%d); the maximum is %d", len(reqDTO.Queries), maxDiagnosticsQueries), nil)
 	}
 
 	captureCtx, harBuffer := harcapture.WithCapture(ctx)

--- a/pkg/api/ds_query_diagnostics_test.go
+++ b/pkg/api/ds_query_diagnostics_test.go
@@ -43,3 +43,24 @@ func TestDiagnosticsNoCaptureError(t *testing.T) {
 		require.Nil(t, hs.diagnosticsNoCaptureError(nil, nil))
 	})
 }
+
+// TestValidateDiagnosticsQueryCount guards the bounds on the number of queries a single-panel
+// diagnostics request may run: zero is rejected as a bad request, as is more than
+// maxDiagnosticsQueries; everything in between proceeds (nil).
+func TestValidateDiagnosticsQueryCount(t *testing.T) {
+	t.Run("zero queries is a client error", func(t *testing.T) {
+		r := validateDiagnosticsQueryCount(0)
+		require.NotNil(t, r)
+		require.Equal(t, http.StatusBadRequest, r.Status())
+	})
+
+	t.Run("query count at the max is allowed", func(t *testing.T) {
+		require.Nil(t, validateDiagnosticsQueryCount(maxDiagnosticsQueries))
+	})
+
+	t.Run("query count over the max is a client error", func(t *testing.T) {
+		r := validateDiagnosticsQueryCount(maxDiagnosticsQueries + 1)
+		require.NotNil(t, r)
+		require.Equal(t, http.StatusBadRequest, r.Status())
+	})
+}

--- a/pkg/infra/httpclient/harcapture/harcapture.go
+++ b/pkg/infra/httpclient/harcapture/harcapture.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"sort"
@@ -27,6 +28,20 @@ import (
 	"github.com/chromedp/cdproto/har"
 )
 
+// Resource caps bound in-memory growth per capturing request. HAR stores full request/response
+// bodies, so without these a large or hostile datasource response could exhaust memory.
+const (
+	// maxHARBodyBytes caps a single captured request/response body; larger bodies are truncated in
+	// the HAR (a comment records the original size). The full body still flows to the caller intact.
+	maxHARBodyBytes = 8 << 20 // 8 MiB
+	// maxHARTotalBytes is a hard per-request cap on captured bytes; once reached, further entries are
+	// dropped and the buffer is marked truncated.
+	maxHARTotalBytes = 64 << 20 // 64 MiB
+	// harEntryOverhead is a rough fixed allowance per entry (headers, URL, timings) counted towards
+	// maxHARTotalBytes in addition to body bytes.
+	harEntryOverhead = 4 << 10 // 4 KiB
+)
+
 // encodeBody returns the HAR text representation of a body plus its encoding. Valid UTF-8 is stored
 // as-is; binary payloads are base64-encoded (with encoding "base64") so they survive JSON marshaling
 // intact instead of being corrupted by string() replacing invalid bytes with U+FFFD.
@@ -37,12 +52,26 @@ func encodeBody(body []byte) (text, encoding string) {
 	return base64.StdEncoding.EncodeToString(body), "base64"
 }
 
+// capBody truncates a captured body to maxHARBodyBytes before encoding, returning the HAR text, its
+// encoding, and a comment noting truncation (empty when the body fit). The raw bytes are truncated
+// (not the encoded text) so a base64 payload stays validly decodable.
+func capBody(full []byte) (text, encoding, comment string) {
+	if len(full) > maxHARBodyBytes {
+		text, encoding = encodeBody(full[:maxHARBodyBytes])
+		return text, encoding, fmt.Sprintf("body truncated: stored %d of %d bytes", maxHARBodyBytes, len(full))
+	}
+	text, encoding = encodeBody(full)
+	return text, encoding, ""
+}
+
 type contextKey struct{}
 
 // Buffer collects HTTP request/response pairs as HAR 1.2 entries in memory.
 type Buffer struct {
-	mu      sync.Mutex
-	entries []*har.Entry
+	mu        sync.Mutex
+	entries   []*har.Entry
+	total     int64 // approx captured bytes, bounded by maxHARTotalBytes
+	truncated bool  // set once the per-request cap is hit; further entries are dropped
 }
 
 // WithCapture returns a child context carrying a new Buffer and the buffer itself.
@@ -62,9 +91,19 @@ func FromContext(ctx context.Context) *Buffer {
 // recorded in the entry's comment. Thread-safe.
 func (b *Buffer) AddEntry(req *http.Request, resp *http.Response, rtErr error, started time.Time, elapsed time.Duration) {
 	e := buildEntry(req, resp, rtErr, started, elapsed)
+	sz := entryStoredSize(e)
+
 	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.truncated {
+		return
+	}
+	if b.total+sz > maxHARTotalBytes {
+		b.truncated = true // keep what we have; stop capturing further entries
+		return
+	}
 	b.entries = append(b.entries, e)
-	b.mu.Unlock()
+	b.total += sz
 }
 
 // Len returns the number of captured entries. Thread-safe.
@@ -74,6 +113,26 @@ func (b *Buffer) Len() int {
 	return len(b.entries)
 }
 
+// Truncated reports whether capture stopped early because the per-request byte cap was reached.
+func (b *Buffer) Truncated() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.truncated
+}
+
+// entryStoredSize approximates the memory an entry occupies: the stored (possibly truncated) body
+// text plus a fixed overhead for headers/URL/timings.
+func entryStoredSize(e *har.Entry) int64 {
+	sz := int64(harEntryOverhead)
+	if e.Response != nil && e.Response.Content != nil {
+		sz += int64(len(e.Response.Content.Text))
+	}
+	if e.Request != nil && e.Request.PostData != nil {
+		sz += int64(len(e.Request.PostData.Text))
+	}
+	return sz
+}
+
 // ToHAR serializes the captured entries to HAR 1.2 JSON. The entry types come from
 // github.com/chromedp/cdproto/har -- the same library the plugin SDK's e2e HAR storage uses -- so
 // the output stays replay-compatible with that fixture format.
@@ -81,16 +140,18 @@ func (b *Buffer) ToHAR() ([]byte, error) {
 	b.mu.Lock()
 	entries := make([]*har.Entry, len(b.entries))
 	copy(entries, b.entries)
+	truncated := b.truncated
 	b.mu.Unlock()
 
-	doc := har.HAR{
-		Log: &har.Log{
-			Version: "1.2",
-			Creator: &har.Creator{Name: "Grafana", Version: "1.0"},
-			Entries: entries,
-		},
+	logEntry := &har.Log{
+		Version: "1.2",
+		Creator: &har.Creator{Name: "Grafana", Version: "1.0"},
+		Entries: entries,
 	}
-	return json.Marshal(doc)
+	if truncated {
+		logEntry.Comment = fmt.Sprintf("capture truncated: per-request limit of %d bytes reached; some entries were dropped", maxHARTotalBytes)
+	}
+	return json.Marshal(har.HAR{Log: logEntry})
 }
 
 // buildEntry builds a HAR entry from a request/response pair. Values are captured verbatim -- see the
@@ -117,10 +178,11 @@ func buildEntry(req *http.Request, resp *http.Response, rtErr error, started tim
 				// marker. base64 preserves the bytes (vs string() corrupting invalid UTF-8 to U+FFFD),
 				// but a replay tool can't tell it's base64. Accepted: datasource request bodies are
 				// text in practice, and body handling overall is a redaction/limits follow-up (#1281).
-				text, _ := encodeBody(body)
+				text, _, comment := capBody(body)
 				pd = &har.PostData{
 					MimeType: req.Header.Get("Content-Type"),
 					Text:     text,
+					Comment:  comment,
 				}
 			}
 		}
@@ -151,12 +213,13 @@ func buildEntry(req *http.Request, resp *http.Response, rtErr error, started tim
 				resp.Body = io.NopCloser(bytes.NewReader(body))
 			}
 			harResp.BodySize = int64(len(body))
-			text, encoding := encodeBody(body)
+			text, encoding, comment := capBody(body)
 			harResp.Content = &har.Content{
 				Size:     int64(len(body)),
 				MimeType: resp.Header.Get("Content-Type"),
 				Text:     text,
 				Encoding: encoding,
+				Comment:  comment,
 			}
 		}
 	}

--- a/pkg/infra/httpclient/harcapture/harcapture.go
+++ b/pkg/infra/httpclient/harcapture/harcapture.go
@@ -127,7 +127,9 @@ func (b *Buffer) Truncated() bool {
 }
 
 // entryStoredSize approximates the memory an entry occupies: the stored (possibly truncated) body
-// text plus a fixed overhead for headers/URL/timings.
+// text, request/response headers, plus a fixed overhead for URL/timings/other fields. Headers are
+// counted explicitly (rather than folded into the fixed overhead) so a response with unusually
+// large or numerous headers still counts toward the per-request byte cap.
 func entryStoredSize(e *har.Entry) int64 {
 	sz := int64(harEntryOverhead)
 	if e.Response != nil && e.Response.Content != nil {
@@ -135,6 +137,23 @@ func entryStoredSize(e *har.Entry) int64 {
 	}
 	if e.Request != nil && e.Request.PostData != nil {
 		sz += int64(len(e.Request.PostData.Text))
+	}
+	if e.Request != nil {
+		sz += headerPairsSize(e.Request.Headers)
+	}
+	if e.Response != nil {
+		sz += headerPairsSize(e.Response.Headers)
+	}
+	return sz
+}
+
+// headerPairsSize sums the name+value byte length of HAR name/value pairs (headers).
+func headerPairsSize(pairs []*har.NameValuePair) int64 {
+	var sz int64
+	for _, p := range pairs {
+		if p != nil {
+			sz += int64(len(p.Name) + len(p.Value))
+		}
 	}
 	return sz
 }

--- a/pkg/infra/httpclient/harcapture/harcapture.go
+++ b/pkg/infra/httpclient/harcapture/harcapture.go
@@ -57,11 +57,28 @@ func encodeBody(body []byte) (text, encoding string) {
 // (not the encoded text) so a base64 payload stays validly decodable.
 func capBody(full []byte) (text, encoding, comment string) {
 	if len(full) > maxHARBodyBytes {
-		text, encoding = encodeBody(full[:maxHARBodyBytes])
-		return text, encoding, fmt.Sprintf("body truncated: stored %d of %d bytes", maxHARBodyBytes, len(full))
+		truncated := trimIncompleteRune(full[:maxHARBodyBytes])
+		text, encoding = encodeBody(truncated)
+		return text, encoding, fmt.Sprintf("body truncated: stored %d of %d bytes", len(truncated), len(full))
 	}
 	text, encoding = encodeBody(full)
 	return text, encoding, ""
+}
+
+// trimIncompleteRune drops up to utf8.UTFMax-1 trailing bytes that form an incomplete UTF-8 rune, so
+// truncating a valid UTF-8 body at an arbitrary byte offset doesn't spuriously force it into base64
+// just because the cut landed mid-rune. Bytes that aren't UTF-8 to begin with are left as found
+// (aside from at most a few extra trimmed bytes) -- encodeBody's own utf8.Valid check still decides
+// text vs. base64 for the result.
+func trimIncompleteRune(b []byte) []byte {
+	end := len(b)
+	for i := 0; i < utf8.UTFMax && end > 0; i++ {
+		if r, size := utf8.DecodeLastRune(b[:end]); r != utf8.RuneError || size > 1 {
+			break
+		}
+		end--
+	}
+	return b[:end]
 }
 
 type contextKey struct{}

--- a/pkg/infra/httpclient/harcapture/harcapture.go
+++ b/pkg/infra/httpclient/harcapture/harcapture.go
@@ -90,6 +90,12 @@ func FromContext(ctx context.Context) *Buffer {
 // a transport-level failure (connection refused, DNS/TLS error, timeout) leaves resp nil and is
 // recorded in the entry's comment. Thread-safe.
 func (b *Buffer) AddEntry(req *http.Request, resp *http.Response, rtErr error, started time.Time, elapsed time.Duration) {
+	if b.Truncated() {
+		// Already over the per-request cap: skip the read/encode work below entirely, rather than
+		// doing it only to discard the result once locked.
+		return
+	}
+
 	e := buildEntry(req, resp, rtErr, started, elapsed)
 	sz := entryStoredSize(e)
 

--- a/pkg/infra/httpclient/harcapture/harcapture_test.go
+++ b/pkg/infra/httpclient/harcapture/harcapture_test.go
@@ -235,6 +235,48 @@ func TestBuffer_concurrentAddEntry(t *testing.T) {
 
 // --- helpers ---
 
+func TestBuffer_bodyTruncation(t *testing.T) {
+	buf := &Buffer{}
+	body := bytes.Repeat([]byte("a"), maxHARBodyBytes+10)
+	buf.AddEntry(newGetReq(t, "http://example.com"), respWithBody(200, body), nil, time.Now(), time.Millisecond) //nolint:bodyclose
+
+	out, err := buf.ToHAR()
+	require.NoError(t, err)
+	var doc har.HAR
+	require.NoError(t, json.Unmarshal(out, &doc))
+	c := doc.Log.Entries[0].Response.Content
+	require.Equal(t, int64(len(body)), c.Size, "Content.Size reports the original (untruncated) size")
+	require.Len(t, c.Text, maxHARBodyBytes, "stored body text is capped at maxHARBodyBytes")
+	require.Contains(t, c.Comment, "body truncated")
+}
+
+func TestBuffer_perRequestTotalCap(t *testing.T) {
+	buf := &Buffer{}
+	body := bytes.Repeat([]byte("a"), maxHARBodyBytes) // 8 MiB, at the per-body cap (not itself truncated)
+	for i := 0; i < 12 && !buf.Truncated(); i++ {
+		buf.AddEntry(newGetReq(t, "http://example.com"), respWithBody(200, body), nil, time.Now(), time.Millisecond) //nolint:bodyclose
+	}
+	require.True(t, buf.Truncated(), "per-request byte cap should trip after enough large entries")
+
+	n := buf.Len()
+	buf.AddEntry(newGetReq(t, "http://example.com"), respWithBody(200, body), nil, time.Now(), time.Millisecond) //nolint:bodyclose
+	require.Equal(t, n, buf.Len(), "entries are dropped once the buffer is truncated")
+
+	out, err := buf.ToHAR()
+	require.NoError(t, err)
+	require.Contains(t, string(out), "capture truncated", "the HAR log records that capture was truncated")
+}
+
+func respWithBody(status int, body []byte) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Status:     http.StatusText(status),
+		Proto:      "HTTP/1.1",
+		Header:     http.Header{},
+		Body:       io.NopCloser(bytes.NewReader(body)),
+	}
+}
+
 func newGetReq(t *testing.T, url string) *http.Request {
 	t.Helper()
 	req, err := http.NewRequest(http.MethodGet, url, nil)

--- a/pkg/infra/httpclient/harcapture/harcapture_test.go
+++ b/pkg/infra/httpclient/harcapture/harcapture_test.go
@@ -267,6 +267,14 @@ func TestBuffer_perRequestTotalCap(t *testing.T) {
 	require.Contains(t, string(out), "capture truncated", "the HAR log records that capture was truncated")
 }
 
+func TestBuffer_headerBytesCountTowardTotalCap(t *testing.T) {
+	buf := &Buffer{}
+	resp := respWithBody(200, nil)
+	resp.Header.Set("X-Huge", string(bytes.Repeat([]byte("a"), maxHARTotalBytes)))
+	buf.AddEntry(newGetReq(t, "http://example.com"), resp, nil, time.Now(), time.Millisecond) //nolint:bodyclose
+	require.True(t, buf.Truncated(), "an oversized header value alone should trip the per-request byte cap")
+}
+
 func respWithBody(status int, body []byte) *http.Response {
 	return &http.Response{
 		StatusCode: status,

--- a/pkg/infra/httpclient/harcapture/harcapture_test.go
+++ b/pkg/infra/httpclient/harcapture/harcapture_test.go
@@ -269,7 +269,7 @@ func TestBuffer_perRequestTotalCap(t *testing.T) {
 
 func TestBuffer_headerBytesCountTowardTotalCap(t *testing.T) {
 	buf := &Buffer{}
-	resp := respWithBody(200, nil)
+	resp := respWithBody(200, nil) //nolint:bodyclose
 	resp.Header.Set("X-Huge", string(bytes.Repeat([]byte("a"), maxHARTotalBytes)))
 	buf.AddEntry(newGetReq(t, "http://example.com"), resp, nil, time.Now(), time.Millisecond) //nolint:bodyclose
 	require.True(t, buf.Truncated(), "an oversized header value alone should trip the per-request byte cap")

--- a/pkg/infra/httpclient/harcapture/harcapture_test.go
+++ b/pkg/infra/httpclient/harcapture/harcapture_test.go
@@ -8,9 +8,11 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"strings"
 	"sync"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/chromedp/cdproto/har"
 	"github.com/stretchr/testify/assert"
@@ -248,6 +250,21 @@ func TestBuffer_bodyTruncation(t *testing.T) {
 	require.Equal(t, int64(len(body)), c.Size, "Content.Size reports the original (untruncated) size")
 	require.Len(t, c.Text, maxHARBodyBytes, "stored body text is capped at maxHARBodyBytes")
 	require.Contains(t, c.Comment, "body truncated")
+}
+
+func TestCapBody_truncationAtRuneBoundary(t *testing.T) {
+	const euro = "€" // 3-byte UTF-8 rune; maxHARBodyBytes isn't a multiple of 3, so a naive
+	// byte-offset cut lands mid-rune here.
+	repeats := maxHARBodyBytes/len(euro) + 10
+	body := []byte(strings.Repeat(euro, repeats))
+
+	text, encoding, comment := capBody(body)
+
+	require.Empty(t, encoding, "a body cut mid-rune should still round-trip as plain text, not fall back to base64")
+	require.True(t, utf8.ValidString(text), "trimmed text must itself be valid UTF-8")
+	require.Contains(t, comment, "body truncated")
+	require.LessOrEqual(t, len(text), maxHARBodyBytes, "trimmed text never exceeds the cap")
+	require.Greater(t, len(text), maxHARBodyBytes-utf8.UTFMax, "trims only the incomplete trailing rune, nothing more")
 }
 
 func TestBuffer_perRequestTotalCap(t *testing.T) {


### PR DESCRIPTION
## What this PR does

Bounds per-request resource use for the single-panel diagnostics endpoint (#128378) so a request can't exhaust memory or trigger unbounded work.

**harcapture:**
- **Per-body cap (8 MiB)** — larger request/response bodies are truncated in the HAR with a comment recording the original size; the full body still flows to the caller untouched.
- **Hard per-request cap (64 MiB)** — once reached, further entries are dropped and the HAR log is flagged truncated (`Buffer.Truncated()`).

**Endpoint:**
- Single-panel request capped at **100 queries** (`400` when exceeded).

## Scope

This PR is intentionally **panel-focused**. Deferred to follow-ups (tracked): the aggregate whole-**dashboard** bundle cap, dashboard job concurrency/retention caps, a response-body on/off toggle, and streaming/bounded (`TeeReader`) capture to bound *peak* memory on very large responses.

