### PR TITLE
Plugins: Fix alias ID resolution for plugin settings and app routing

### DIFF
--- a/pkg/api/dtos/plugins.go
+++ b/pkg/api/dtos/plugins.go
@@ -10,6 +10,7 @@ type PluginSetting struct {
 	Name             string               `json:"name"`
 	Type             string               `json:"type"`
 	Id               string               `json:"id"`
+	AliasIDs         []string             `json:"aliasIDs,omitempty"`
 	Enabled          bool                 `json:"enabled"`
 	Pinned           bool                 `json:"pinned"`
 	AutoEnabled      bool                 `json:"autoEnabled"`

--- a/pkg/api/plugins.go
+++ b/pkg/api/plugins.go
@@ -203,6 +203,7 @@ func (hs *HTTPServer) GetPluginSettingByID(c *contextmodel.ReqContext) response.
 	dto := &dtos.PluginSetting{
 		Type:             string(plugin.Type),
 		Id:               plugin.ID,
+		AliasIDs:         plugin.AliasIDs,
 		Name:             plugin.Name,
 		Info:             plugin.Info,
 		Dependencies:     plugin.Dependencies,
@@ -229,7 +230,7 @@ func (hs *HTTPServer) GetPluginSettingByID(c *contextmodel.ReqContext) response.
 	}
 
 	ps, err := hs.PluginSettings.GetPluginSettingByPluginID(c.Req.Context(), &pluginsettings.GetByPluginIDArgs{
-		PluginID: pluginID,
+		PluginID: plugin.ID,
 		OrgID:    c.GetOrgID(),
 	})
 	if err != nil {

--- a/pkg/services/navtree/navtreeimpl/applinks.go
+++ b/pkg/services/navtree/navtreeimpl/applinks.go
@@ -448,6 +448,7 @@ func (s *ServiceImpl) hasAccessToInclude(c *contextmodel.ReqContext, pluginID st
 func (s *ServiceImpl) readNavigationSettings() {
 	s.navigationAppConfig = map[string]NavigationAppConfig{
 		"grafana-sigil-app":                {SectionID: navtree.NavIDObservability, SortWeight: 1, Text: "AI", IsNew: true},
+		"grafana-agento11y-app":            {SectionID: navtree.NavIDObservability, SortWeight: 1, Text: "Agent", IsNew: true},
 		"grafana-asserts-app":              {SectionID: navtree.NavIDObservability, SortWeight: 2, Icon: "asserts"},
 		"grafana-kowalski-app":             {SectionID: navtree.NavIDObservability, SortWeight: 3, Text: "Frontend"},
 		appObservabilityAppID:              {SectionID: navtree.NavIDObservability, SortWeight: 4, Text: "Application"},

--- a/pkg/services/navtree/navtreeimpl/applinks.go
+++ b/pkg/services/navtree/navtreeimpl/applinks.go
@@ -448,7 +448,6 @@ func (s *ServiceImpl) hasAccessToInclude(c *contextmodel.ReqContext, pluginID st
 func (s *ServiceImpl) readNavigationSettings() {
 	s.navigationAppConfig = map[string]NavigationAppConfig{
 		"grafana-sigil-app":                {SectionID: navtree.NavIDObservability, SortWeight: 1, Text: "AI", IsNew: true},
-		"grafana-agento11y-app":            {SectionID: navtree.NavIDObservability, SortWeight: 1, Text: "Agent", IsNew: true},
 		"grafana-asserts-app":              {SectionID: navtree.NavIDObservability, SortWeight: 2, Icon: "asserts"},
 		"grafana-kowalski-app":             {SectionID: navtree.NavIDObservability, SortWeight: 3, Text: "Frontend"},
 		appObservabilityAppID:              {SectionID: navtree.NavIDObservability, SortWeight: 4, Text: "Application"},

--- a/public/app/features/plugins/components/AppRootPage.tsx
+++ b/public/app/features/plugins/components/AppRootPage.tsx
@@ -2,7 +2,7 @@
 import { type AnyAction, createSlice, type PayloadAction } from '@reduxjs/toolkit';
 import { useCallback, useEffect, useMemo, useReducer } from 'react';
 import * as React from 'react';
-import { useLocation, useParams } from 'react-router-dom-v5-compat';
+import { Navigate, useLocation, useParams } from 'react-router-dom-v5-compat';
 
 import {
   AppEvents,
@@ -84,6 +84,13 @@ function AppRootPage({ pluginId, pluginNavSection }: Props) {
     (newPluginNav: NavModel) => dispatch(stateSlice.actions.changeNav(newPluginNav)),
     []
   );
+
+  // Redirect alias URLs to the canonical plugin URL so old deep-links keep working.
+  // The aliasIDs check avoids misfiring during navigation between two different apps.
+  if (plugin && pluginId !== plugin.meta.id && plugin.meta.aliasIDs?.includes(pluginId)) {
+    const canonicalPath = location.pathname.replace(`/a/${pluginId}`, `/a/${plugin.meta.id}`);
+    return <Navigate replace to={{ pathname: canonicalPath, search: location.search, hash: location.hash }} />;
+  }
 
   if (!plugin || pluginId !== plugin.meta.id) {
     // Use current layout while loading to reduce flickering


### PR DESCRIPTION
## Summary

- **Backend**: When a plugin is accessed via an alias ID (e.g. `grafana-sigil-app` → `grafana-agento11y-app`), the plugin settings lookup now uses the canonical plugin ID instead of the raw URL parameter. Previously, querying settings by alias returned `enabled: false` because no DB record existed under the alias.
- **Backend**: Expose `aliasIDs` in the plugin settings API response so the frontend can detect alias navigation.
- **Frontend**: Add alias-to-canonical URL redirect in `AppRootPage` so old deep-links (using a renamed plugin's former ID) redirect to the canonical plugin URL.

## Test plan

- [ ] Navigate to `/a/grafana-sigil-app` and verify it redirects to `/a/grafana-agento11y-app`
- [ ] Verify `/api/plugins/grafana-sigil-app/settings` returns `enabled: true` (matching the canonical plugin's state)
- [ ] Verify `/api/plugins/grafana-agento11y-app/settings` still works as before


Made with [Cursor](https://cursor.com)