### PR TITLE
Plugins: Fix alias ID resolution for plugin settings lookup

### DIFF
--- a/pkg/api/dtos/plugins.go
+++ b/pkg/api/dtos/plugins.go
@@ -10,6 +10,7 @@ type PluginSetting struct {
 	Name             string               `json:"name"`
 	Type             string               `json:"type"`
 	Id               string               `json:"id"`
+	AliasIDs         []string             `json:"aliasIDs,omitempty"`
 	Enabled          bool                 `json:"enabled"`
 	Pinned           bool                 `json:"pinned"`
 	AutoEnabled      bool                 `json:"autoEnabled"`

--- a/pkg/api/plugins.go
+++ b/pkg/api/plugins.go
@@ -203,6 +203,7 @@ func (hs *HTTPServer) GetPluginSettingByID(c *contextmodel.ReqContext) response.
 	dto := &dtos.PluginSetting{
 		Type:             string(plugin.Type),
 		Id:               plugin.ID,
+		AliasIDs:         plugin.AliasIDs,
 		Name:             plugin.Name,
 		Info:             plugin.Info,
 		Dependencies:     plugin.Dependencies,
@@ -229,7 +230,7 @@ func (hs *HTTPServer) GetPluginSettingByID(c *contextmodel.ReqContext) response.
 	}
 
 	ps, err := hs.PluginSettings.GetPluginSettingByPluginID(c.Req.Context(), &pluginsettings.GetByPluginIDArgs{
-		PluginID: pluginID,
+		PluginID: plugin.ID,
 		OrgID:    c.GetOrgID(),
 	})
 	if err != nil {


### PR DESCRIPTION
## Summary

- When a plugin is accessed via an alias ID (e.g. `grafana-sigil-app` → `grafana-agento11y-app`), the plugin settings lookup now uses the canonical plugin ID instead of the raw URL parameter. Previously, querying settings by alias returned `enabled: false` because no DB record existed under the alias name.
- Exposes `aliasIDs` in the plugin settings API response so consumers can detect alias navigation.

## Test plan

- [ ] `GET /api/plugins/grafana-sigil-app/settings` returns `enabled: true` (matching the canonical plugin's state)
- [ ] `GET /api/plugins/grafana-agento11y-app/settings` still works as before
- [ ] Response includes `aliasIDs` field


Made with [Cursor](https://cursor.com)