### PR TITLE
Navigation: Add agento11y app nav entry alongside sigil

### DIFF
--- a/pkg/services/navtree/navtreeimpl/applinks.go
+++ b/pkg/services/navtree/navtreeimpl/applinks.go
@@ -447,7 +447,8 @@ func (s *ServiceImpl) hasAccessToInclude(c *contextmodel.ReqContext, pluginID st
 
 func (s *ServiceImpl) readNavigationSettings() {
 	s.navigationAppConfig = map[string]NavigationAppConfig{
-		"grafana-sigil-app":                {SectionID: navtree.NavIDObservability, SortWeight: 1, Text: "AI", IsNew: true},
+		"grafana-sigil-app":                {SectionID: navtree.NavIDObservability, SortWeight: 1, Text: "AI", IsNew: true}, // TODO: remove this after sigil is renamed to grafana-agento11y-app, but we need to keep it for now to avoid breaking changes
+		"grafana-agento11y-app":            {SectionID: navtree.NavIDObservability, SortWeight: 1, Text: "Agent", IsNew: true},
 		"grafana-asserts-app":              {SectionID: navtree.NavIDObservability, SortWeight: 2, Icon: "asserts"},
 		"grafana-kowalski-app":             {SectionID: navtree.NavIDObservability, SortWeight: 3, Text: "Frontend"},
 		appObservabilityAppID:              {SectionID: navtree.NavIDObservability, SortWeight: 4, Text: "Application"},


### PR DESCRIPTION
## Summary
- Add `grafana-agento11y-app` to the Observability navigation section with label "Agent"
- Keep the legacy `grafana-sigil-app` entry temporarily to avoid breaking changes during the app rename

## Test plan
- [ ] Verify `grafana-agento11y-app` appears under Observability with label "Agent"
- [ ] Verify existing `grafana-sigil-app` installations still show the "AI" nav entry
- [ ] Confirm nav ordering remains correct when only one of the two apps is installed


Made with [Cursor](https://cursor.com)