### PR TITLE
BrowseDashboards: Report restore outcomes to Faro

### DIFF
--- a/public/app/features/browse-dashboards/components/RecentlyDeletedActions.test.tsx
+++ b/public/app/features/browse-dashboards/components/RecentlyDeletedActions.test.tsx
@@ -2,7 +2,7 @@ import { act, type ComponentProps } from 'react';
 import { render, screen } from 'test/test-utils';
 
 import { DataFrameView, FieldType, toDataFrame } from '@grafana/data';
-import { setBackendSrv } from '@grafana/runtime';
+import { logMeasurement, setBackendSrv } from '@grafana/runtime';
 import { setupMockServer } from '@grafana/test-utils/server';
 import { backendSrv } from 'app/core/services/backend_srv';
 import { getDashboardAPI } from 'app/features/dashboard/api/dashboard_api';
@@ -16,15 +16,20 @@ import { useActionSelectionState } from '../state/hooks';
 import { RecentlyDeletedActions } from './RecentlyDeletedActions';
 import { RestoreModal } from './RestoreModal';
 
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  logMeasurement: jest.fn(),
+}));
 jest.mock('../api/useRecentlyDeletedStateManager');
 jest.mock('../state/hooks');
 jest.mock('../../search/service/deletedDashboardsCache');
 jest.mock('app/features/dashboard/api/dashboard_api', () => ({
   getDashboardAPI: jest.fn(),
 }));
+const mockRestoreDashboard = jest.fn();
 jest.mock('../api/browseDashboardsAPI', () => ({
   ...jest.requireActual('../api/browseDashboardsAPI'),
-  useRestoreDashboardMutation: () => [jest.fn().mockResolvedValue({ data: { name: 'dashboard-1' } })],
+  useRestoreDashboardMutation: () => [mockRestoreDashboard],
 }));
 jest.mock('./RestoreModal', () => ({
   RestoreModal: jest.fn(() => null),
@@ -38,7 +43,11 @@ const mockUseRecentlyDeletedStateManager = useRecentlyDeletedStateManager as jes
 >;
 const mockUseActionSelectionState = useActionSelectionState as jest.MockedFunction<typeof useActionSelectionState>;
 const mockRestoreModal = RestoreModal as jest.MockedFunction<typeof RestoreModal>;
-const mockGetDashboardAPI = getDashboardAPI as jest.MockedFunction<typeof getDashboardAPI>;
+// onRestore only calls getDashboard, so the mock stubs just that method.
+const mockGetDashboardAPI = getDashboardAPI as unknown as jest.MockedFunction<
+  () => Promise<{ getDashboard: jest.Mock }>
+>;
+const mockGetDashboard = jest.fn();
 
 describe('RecentlyDeletedActions', () => {
   beforeEach(() => {
@@ -65,6 +74,10 @@ describe('RecentlyDeletedActions', () => {
       columnDefinitions: [],
       metadata: { resourceVersion: '1' },
     });
+
+    mockRestoreDashboard.mockResolvedValue({ data: { name: 'dashboard-1' } });
+    mockGetDashboard.mockResolvedValue({ metadata: { name: 'dashboard-1', annotations: {} }, spec: {} });
+    mockGetDashboardAPI.mockResolvedValue({ getDashboard: mockGetDashboard });
   });
 
   it('renders restore button', () => {
@@ -144,8 +157,7 @@ describe('RecentlyDeletedActions', () => {
       metadata: { name: 'dashboard-1', annotations: {} },
       spec: {},
     });
-    // Only `getDashboard` is exercised by onRestore; the rest of the API is unused here.
-    mockGetDashboardAPI.mockResolvedValue({ getDashboard } as unknown as Awaited<ReturnType<typeof getDashboardAPI>>);
+    mockGetDashboardAPI.mockResolvedValue({ getDashboard });
 
     const { user } = render(<RecentlyDeletedActions />);
     await user.click(screen.getByRole('button', { name: 'Restore' }));
@@ -173,6 +185,104 @@ describe('RecentlyDeletedActions', () => {
     await user.click(screen.getByRole('button', { name: 'Restore' }));
 
     expect(getRestoreModalProps().originCandidate).toBeUndefined();
+  });
+
+  describe('restore outcome measurement', () => {
+    const fetchError404 = { status: 404, data: { message: 'not found' }, config: { url: '' } };
+
+    async function driveRestore() {
+      const { user } = render(<RecentlyDeletedActions />);
+      await user.click(screen.getByRole('button', { name: 'Restore' }));
+      const onConfirm = getRestoreModalProps().onConfirm;
+      expect(onConfirm).toBeDefined();
+      await act(async () => {
+        await onConfirm!('folder-target');
+      });
+    }
+
+    beforeEach(() => {
+      mockUseActionSelectionState.mockReturnValue({
+        dashboard: { 'dashboard-1': true },
+        folder: {},
+      });
+    });
+
+    it('reports success when all restores succeed', async () => {
+      await driveRestore();
+
+      expect(jest.mocked(logMeasurement)).toHaveBeenCalledWith(
+        'browse_dashboards.restore_result',
+        { total_count: 1, success_count: 1, failure_count: 0 },
+        { status: 'success', error_status_codes: '', failed_steps: '' }
+      );
+    });
+
+    it('reports a fetch failure when the read at the pre-delete resource version fails', async () => {
+      // The June 2026 incident shape: the GET at the trash RV 404s before any
+      // restore call is made.
+      mockGetDashboard.mockRejectedValueOnce(fetchError404);
+
+      await driveRestore();
+
+      expect(jest.mocked(logMeasurement)).toHaveBeenCalledWith(
+        'browse_dashboards.restore_result',
+        { total_count: 1, success_count: 0, failure_count: 1 },
+        { status: 'failure', error_status_codes: '404', failed_steps: 'fetch' }
+      );
+    });
+
+    it('reports a create failure when the restore mutation returns an error', async () => {
+      mockRestoreDashboard.mockResolvedValueOnce({ error: { status: 500, data: { message: 'boom' } } });
+
+      await driveRestore();
+
+      expect(jest.mocked(logMeasurement)).toHaveBeenCalledWith(
+        'browse_dashboards.restore_result',
+        { total_count: 1, success_count: 0, failure_count: 1 },
+        { status: 'failure', error_status_codes: '500', failed_steps: 'create' }
+      );
+    });
+
+    it('reports partial failure when only some dashboards restore', async () => {
+      setRecentlyDeletedState({
+        uids: ['dashboard-1', 'dashboard-2'],
+        locations: ['folder-1', 'folder-1'],
+      });
+      mockUseActionSelectionState.mockReturnValue({
+        dashboard: { 'dashboard-1': true, 'dashboard-2': true },
+        folder: {},
+      });
+      (deletedDashboardsCache.getAsTable as jest.Mock).mockResolvedValue({
+        rows: ['dashboard-1', 'dashboard-2'].map((name) => ({
+          cells: [],
+          object: { metadata: { name, resourceVersion: '1', creationTimestamp: '2024-01-01T00:00:00Z' } },
+        })),
+        columnDefinitions: [],
+        metadata: { resourceVersion: '1' },
+      });
+      mockGetDashboard.mockRejectedValueOnce(fetchError404);
+
+      await driveRestore();
+
+      expect(jest.mocked(logMeasurement)).toHaveBeenCalledWith(
+        'browse_dashboards.restore_result',
+        { total_count: 2, success_count: 1, failure_count: 1 },
+        { status: 'partial_failure', error_status_codes: '404', failed_steps: 'fetch' }
+      );
+    });
+
+    it('counts a restored dashboard with an empty title as a success', async () => {
+      mockRestoreDashboard.mockResolvedValueOnce({ data: { name: '' } });
+
+      await driveRestore();
+
+      expect(jest.mocked(logMeasurement)).toHaveBeenCalledWith(
+        'browse_dashboards.restore_result',
+        { total_count: 1, success_count: 1, failure_count: 0 },
+        { status: 'success', error_status_codes: '', failed_steps: '' }
+      );
+      expect(deletedDashboardsCache.removeItems).toHaveBeenCalledWith(['dashboard-1']);
+    });
   });
 });
 

--- a/public/app/features/browse-dashboards/components/RecentlyDeletedActions.tsx
+++ b/public/app/features/browse-dashboards/components/RecentlyDeletedActions.tsx
@@ -1,12 +1,13 @@
 import { useMemo, useState } from 'react';
 
 import { Trans } from '@grafana/i18n';
-import { reportInteraction } from '@grafana/runtime';
+import { logMeasurement, reportInteraction } from '@grafana/runtime';
 import { Button, Stack } from '@grafana/ui';
 import { appEvents } from 'app/core/app_events';
 import { buildNotificationButton } from 'app/core/components/AppNotifications/NotificationButton';
 import { createSuccessNotification } from 'app/core/copy/appNotification';
 import { notifyApp } from 'app/core/reducers/appNotification';
+import { getStatusFromError } from 'app/core/utils/errors';
 import { AnnoKeyFolder } from 'app/features/apiserver/types';
 import { getDashboardAPI } from 'app/features/dashboard/api/dashboard_api';
 import { isRootFolderUID } from 'app/features/search/constants';
@@ -95,13 +96,13 @@ export function RecentlyDeletedActions() {
       const row = table.rows.find((r) => r.object.metadata.name === uid);
       if (!row) {
         console.warn(`Dashboard ${uid} not found in deleted items`);
-        return { uid, error: 'not_found' };
+        return { uid, error: 'not_found', step: 'lookup' as const };
       }
 
       const deleteRV = row.object.metadata.resourceVersion;
       if (!deleteRV) {
         console.warn(`Dashboard ${uid} is missing a resourceVersion in the trash listing`);
-        return { uid, error: 'not_found' };
+        return { uid, error: 'not_found', step: 'lookup' as const };
       }
       // The RV on a trash row is the delete event's RV, which points at the
       // tombstone (and on some storage backends returns 404). Step back by one
@@ -124,25 +125,52 @@ export function RecentlyDeletedActions() {
 
     // Separate successful and failed restores
     const successful: string[] = [];
-    const failed: Array<{ uid: string; error: string }> = [];
+    const failed: Array<{ uid: string; error: string; status?: number; step: 'lookup' | 'fetch' | 'create' }> = [];
 
     results.forEach((result, index) => {
       const dashboardUid = selectedDashboards[index];
       if (result.status === 'rejected') {
-        const errorMessage = getErrorMessage(result.reason);
-        if (errorMessage) {
-          failed.push({ uid: dashboardUid, error: errorMessage });
-        }
+        // Rejections come from the trash-cache lookup or the GET at the
+        // pre-delete resourceVersion — the read path of the restore pipeline.
+        failed.push({
+          uid: dashboardUid,
+          error: getErrorMessage(result.reason),
+          status: getStatusFromError(result.reason),
+          step: 'fetch',
+        });
       } else if (result.value.error) {
-        const errorMessage = getErrorMessage(result.value.error);
-        if (errorMessage) {
-          failed.push({ uid: dashboardUid, error: errorMessage });
-        }
-      } else if ('data' in result.value && result.value.data?.name) {
-        // Track the UID of successfully restored dashboards
+        failed.push({
+          uid: dashboardUid,
+          error: getErrorMessage(result.value.error),
+          status: getStatusFromError(result.value.error),
+          step: 'step' in result.value ? result.value.step : 'create',
+        });
+      } else {
+        // Every settled promise lands in exactly one bucket: an empty error
+        // message or an untitled dashboard must not fall through, or the
+        // measurement below and the trash-cache cleanup drift out of sync.
         successful.push(dashboardUid);
       }
     });
+
+    // Outcome telemetry for the restore flow: failures are caught and surfaced
+    // only as a toast, so this measurement is the only regression signal
+    // (PIR follow-up for #127601, removable once FEP ships wider coverage).
+    const errorStatusCodes = [...new Set(failed.map((f) => f.status?.toString() ?? 'unknown'))].join(',');
+    const failedSteps = [...new Set(failed.map((f) => f.step))].join(',');
+    logMeasurement(
+      'browse_dashboards.restore_result',
+      {
+        total_count: selectedDashboards.length,
+        success_count: successful.length,
+        failure_count: failed.length,
+      },
+      {
+        status: failed.length === 0 ? 'success' : successful.length === 0 ? 'failure' : 'partial_failure',
+        error_status_codes: errorStatusCodes, // e.g. '404' | '404,500' | 'unknown' | ''
+        failed_steps: failedSteps, // e.g. 'fetch' | 'lookup,create' | ''
+      }
+    );
 
     const parentUIDs = new Set<string | undefined>();
     for (const uid of selectedDashboards) {


### PR DESCRIPTION
**What is this feature?**

Emits a Faro measurement `browse_dashboards.restore_result` when a restore operation on the Recently deleted page settles, with success/failure counts and failure attribution (`failed_steps`: `lookup` | `fetch` | `create`; `error_status_codes`, e.g. `404`). One aggregate measurement per restore operation, sent only when `grafanaJavascriptAgent` is enabled. It also tightens the outcome classification so every settled restore lands in exactly one of success/failure — previously a failure with an empty error message, or a restored dashboard with an empty title, fell into neither bucket (the notification under-counted and the trash cache kept an already-restored dashboard).

**Why do we need this feature?**

PIR action item: when deleted-dashboard restore silently broke in June 2026 (fixed in #126873), no telemetry caught it — the failure is caught in `onRestore` and surfaced only as a toast, so exceptions, logs and click events all stayed flat. This measurement makes restore outcomes observable and alertable; a regression of the same shape shows up as `failed_steps=fetch` with `error_status_codes=404`. Deliberately the smallest instrumentation that catches this class of regression, removable once a wider frontend-observability solution covers it.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana/issues/127601

