### PR TITLE
unified-storage: dont check quota for cluster scoped resources

### DIFF
--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -2314,6 +2314,10 @@ func (s *server) RebuildIndexes(ctx context.Context, req *resourcepb.RebuildInde
 }
 
 func (s *server) checkQuota(ctx context.Context, nsr NamespacedResource) error {
+	if nsr.Namespace == "" {
+		return nil
+	}
+
 	span := trace.SpanFromContext(ctx)
 	span.AddEvent("checkQuota", trace.WithAttributes(
 		attribute.String("namespace", nsr.Namespace),


### PR DESCRIPTION
we don't enforce quotas on cluster scoped resources so this is just logging an error for no reason. skipping it