### PR TITLE
Search: build search-field registry inputs from one manifest list

### DIFF
--- a/pkg/storage/unified/resource/search_field_manifest.go
+++ b/pkg/storage/unified/resource/search_field_manifest.go
@@ -157,6 +157,23 @@ func SearchFieldsHashesForProviders(providers map[LowerGroupResource]SearchField
 	return out
 }
 
+// SearchFieldsForManifests builds a SearchFieldsRegistry's three inputs from one
+// manifest list, so a reload can rebuild them together and keep them consistent.
+func SearchFieldsForManifests(manifests []app.Manifest) (
+	selectable map[LowerGroupResource][]string,
+	hashes map[LowerGroupResource]string,
+	providers map[LowerGroupResource]SearchFieldsProvider,
+	err error,
+) {
+	providers, err = SearchFieldProviders(manifests)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	hashes = SearchFieldsHashesForProviders(providers)
+	selectable = SelectableFieldsForManifests(manifests)
+	return selectable, hashes, providers, nil
+}
+
 // MergeManifestsByKind combines manifest sources for the search wiring, given
 // in increasing order of priority. Only kinds that declare search fields take
 // part: when more than one source declares search fields for the same kind
@@ -237,7 +254,9 @@ type kindClaim struct {
 }
 
 // pruneClaimedKinds drops kinds already claimed by a higher-priority source and
-// records the ones it keeps. ok is false when nothing is left to contribute.
+// records the ones it keeps. ok is false only when no kind survives, so a
+// manifest whose kinds carry only selectable fields is kept: the merge output
+// also drives selectable-field wiring, not just search fields.
 func pruneClaimedKinds(m app.Manifest, claimedBy map[LowerGroupResource]kindClaim) (app.Manifest, bool) {
 	group := m.ManifestData.Group
 	appName := m.ManifestData.AppName
@@ -246,12 +265,14 @@ func pruneClaimedKinds(m app.Manifest, claimedBy map[LowerGroupResource]kindClai
 	versions := make([]app.ManifestVersion, 0, len(md.Versions))
 	kept := map[LowerGroupResource]bool{}
 	declaredVersions := map[LowerGroupResource]map[string]bool{}
+	anyKind := false
 
 	for _, v := range md.Versions {
 		kinds := make([]app.ManifestVersionKind, 0, len(v.Kinds))
 		for _, k := range v.Kinds {
 			if !declaresSearchFields(k) {
-				kinds = append(kinds, k) // nothing to claim or override
+				kinds = append(kinds, k) // kept for its selectable fields, if any
+				anyKind = true
 				continue
 			}
 			key := NewLowerGroupResource(group, manifestResourceName(k))
@@ -264,6 +285,7 @@ func pruneClaimedKinds(m app.Manifest, claimedBy map[LowerGroupResource]kindClai
 			}
 			kept[key] = true
 			kinds = append(kinds, k)
+			anyKind = true
 		}
 		v.Kinds = kinds
 		versions = append(versions, v)
@@ -277,7 +299,7 @@ func pruneClaimedKinds(m app.Manifest, claimedBy map[LowerGroupResource]kindClai
 		logOverriddenKind(key, appName, claimedBy[key], declared)
 	}
 
-	if len(kept) == 0 {
+	if !anyKind {
 		return app.Manifest{}, false
 	}
 	md.Versions = versions

--- a/pkg/storage/unified/resource/search_field_manifest_test.go
+++ b/pkg/storage/unified/resource/search_field_manifest_test.go
@@ -232,9 +232,42 @@ func TestMergeManifestsByKind(t *testing.T) {
 		require.Equal(t, []string{"first"}, fieldNames(t, merged, "g.test", "v1", "foos"))
 	})
 
+	t.Run("a selectable-only manifest survives the merge", func(t *testing.T) {
+		// Its kinds declare only selectable fields (no search fields), and the merge
+		// output drives selectable-field wiring too, so it must not be dropped.
+		kind := app.ManifestVersionKind{Kind: "Foo", Plural: "foos", SelectableFields: []string{"spec.x"}}
+		in := []app.Manifest{mergeTestManifest("app", "g.test", app.ManifestVersion{Name: "v1", Kinds: []app.ManifestVersionKind{kind}})}
+
+		merged := MergeManifestsByKind(in)
+
+		require.NotEmpty(t, SelectableFieldsForManifests(merged))
+		require.Equal(t, SelectableFieldsForManifests(in), SelectableFieldsForManifests(merged))
+	})
+
 	t.Run("manifests without data pass through", func(t *testing.T) {
 		merged := MergeManifestsByKind([]app.Manifest{{ManifestData: nil}})
 		require.Len(t, merged, 1)
 		require.Nil(t, merged[0].ManifestData)
 	})
+}
+
+func TestSearchFieldsForManifests(t *testing.T) {
+	kind := mergeTestKind("Foo", "one")
+	kind.SelectableFields = []string{"spec.two"}
+	manifests := []app.Manifest{mergeTestManifest("app", "g.test", app.ManifestVersion{Name: "v1", Kinds: []app.ManifestVersionKind{kind}})}
+
+	selectable, hashes, providers, err := SearchFieldsForManifests(manifests)
+	require.NoError(t, err)
+
+	// The three inputs all come from the same manifests.
+	wantProviders, err := SearchFieldProviders(manifests)
+	require.NoError(t, err)
+	require.Equal(t, wantProviders, providers)
+	require.Equal(t, SearchFieldsHashesForProviders(wantProviders), hashes)
+	require.Equal(t, SelectableFieldsForManifests(manifests), selectable)
+
+	// The kind declares both search and selectable fields, so none is empty.
+	require.NotEmpty(t, providers)
+	require.NotEmpty(t, hashes)
+	require.NotEmpty(t, selectable)
 }

--- a/pkg/storage/unified/search/options.go
+++ b/pkg/storage/unified/search/options.go
@@ -86,26 +86,24 @@ func NewSearchOptions(
 			return resource.SearchOptions{}, err
 		}
 
-		// docs is optional in some tests; only install the search-field mappings
-		// and their hashes when a real supplier is present. Both come from the app
-		// manifests, and the hashes are derived from the same providers that drive
-		// the mappings so the two always agree.
-		var searchFieldsHashes map[resource.LowerGroupResource]string
-		var searchFieldsProviders map[resource.LowerGroupResource]resource.SearchFieldsProvider
-		if docs != nil {
-			// Search fields come from the app manifests: every in-tree kind that
-			// has custom search fields declares them in its CUE manifest.
-			searchFieldsProviders, err = resource.SearchFieldProviders(resource.AppManifests())
-			if err != nil {
-				return resource.SearchOptions{}, err
-			}
-			searchFieldsHashes = resource.SearchFieldsHashesForProviders(searchFieldsProviders)
+		// MergeManifestsByKind is the single point a future live-manifest source will
+		// be added to; the built-in manifests are the only source today.
+		manifests := resource.MergeManifestsByKind(resource.AppManifests())
+		selectableFields, searchFieldsHashes, searchFieldsProviders, err := resource.SearchFieldsForManifests(manifests)
+		if err != nil {
+			return resource.SearchOptions{}, err
+		}
+
+		// Without a document supplier (some tests) the index has nothing to map, so
+		// leave out the mappings and their hashes; the selectable fields stay.
+		if docs == nil {
+			searchFieldsHashes, searchFieldsProviders = nil, nil
 		}
 
 		// One registry holds selectable fields, hashes, and providers, shared by the
 		// index backend and the search server so a future live-manifest source can
 		// swap them consistently.
-		searchFields := resource.NewSearchFieldsRegistry(resource.SelectableFields(), searchFieldsHashes, searchFieldsProviders)
+		searchFields := resource.NewSearchFieldsRegistry(selectableFields, searchFieldsHashes, searchFieldsProviders)
 
 		bleve, err := NewBleveBackend(BleveOptions{
 			Root:                           root,


### PR DESCRIPTION
This adds a single function that builds the three search-field registry inputs (selectable fields, providers, and provider hashes) from one manifest list, so they always come from the same source and a future reload can rebuild them together. The search options wiring now uses it instead of assembling the pieces inline.

It also routes the built-in manifests through the manifest merge added earlier, which is the single point a live-manifest source will later be added to. That is the only source today, so there is no behavior change — but both the merge and the new function now have a production caller.

Part of grafana/search-and-storage-team#827.
