### PR TITLE
Datasources: whole-dashboard "Download diagnostics" (frontend, MVP)

### DIFF
--- a/public/app/features/dashboard-scene/sharing/DownloadDashboardDiagnostics.test.tsx
+++ b/public/app/features/dashboard-scene/sharing/DownloadDashboardDiagnostics.test.tsx
@@ -99,6 +99,26 @@ describe('DownloadDashboardDiagnostics', () => {
     expect(onDismiss).toHaveBeenCalledTimes(1);
     expect(downloadDashboardDiagnostics).not.toHaveBeenCalled();
   });
+
+  it('sends one entry per repeat-by-variable clone, all carrying the source panel id', async () => {
+    jest.mocked(startDashboardDiagnostics).mockResolvedValue('job-1');
+    jest
+      .mocked(getDashboardDiagnosticsStatus)
+      .mockResolvedValue({ uid: 'job-1', state: 'complete', panelsDone: 2, panelsTotal: 2 });
+    const { tab } = setupCloneScenario();
+
+    render(<tab.Component model={tab} />);
+    await userEvent.click(screen.getByRole('button', { name: 'Download diagnostics' }));
+
+    await screen.findByRole('button', { name: 'Download diagnostics' });
+
+    // Repeat clones aren't serialized as separate elements in dashboard.getSaveModel(), so the id
+    // sent for each clone must match the one source panel the backend can actually resolve --
+    // fabricating a distinct id per clone would leave it unable to find panel JSON for any of them.
+    const [panels] = jest.mocked(startDashboardDiagnostics).mock.calls[0];
+    expect(panels.map((p) => p.id)).toEqual([3, 3]);
+    expect(panels.map((p) => p.title)).toEqual(['Repeated panel', 'Repeated panel']);
+  });
 });
 
 function setupScenario(opts: { onDismiss?: () => void; onlyEmptyPanels?: boolean } = {}) {
@@ -139,6 +159,42 @@ function setupScenario(opts: { onDismiss?: () => void; onlyEmptyPanels?: boolean
   // query-runner lookup need here. We deliberately skip activation so the SceneQueryRunners do not
   // try to execute (and fail) their queries against a real datasource.
   const tab = new DownloadDashboardDiagnostics({ dashboardRef: dashboard.getRef(), onDismiss });
+
+  return { tab, dashboard };
+}
+
+function setupCloneScenario() {
+  // Mirrors how repeat-by-variable actually keys clones: the source panel's own key, suffixed with
+  // `-clone-<n>` (see dashboard-scene/utils/clone.ts). Both clones below parse to base id 3.
+  const source = new VizPanel({
+    key: 'panel-3',
+    pluginId: 'table',
+    title: 'Repeated panel',
+    $data: new SceneQueryRunner({ queries: [{ refId: 'A' }] }),
+  });
+  const clone = new VizPanel({
+    key: 'panel-3-clone-1',
+    pluginId: 'table',
+    title: 'Repeated panel',
+    $data: new SceneQueryRunner({ queries: [{ refId: 'A' }] }),
+  });
+
+  const dashboard = new DashboardScene({
+    title: 'Dash',
+    uid: 'dash-1',
+    meta: { canEdit: true },
+    $timeRange: new SceneTimeRange({}),
+    body: new DefaultGridLayoutManager({
+      grid: new SceneGridLayout({
+        children: [
+          new DashboardGridItem({ key: 'grid-item-1', body: source }),
+          new DashboardGridItem({ key: 'grid-item-2', body: clone }),
+        ],
+      }),
+    }),
+  });
+
+  const tab = new DownloadDashboardDiagnostics({ dashboardRef: dashboard.getRef() });
 
   return { tab, dashboard };
 }

--- a/public/app/features/dashboard-scene/sharing/DownloadDashboardDiagnostics.test.tsx
+++ b/public/app/features/dashboard-scene/sharing/DownloadDashboardDiagnostics.test.tsx
@@ -1,0 +1,144 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from 'test/test-utils';
+
+import { getPanelPlugin } from '@grafana/data/test';
+import { setPluginImportUtils } from '@grafana/runtime';
+import { SceneGridLayout, SceneQueryRunner, SceneTimeRange, VizPanel } from '@grafana/scenes';
+import {
+  downloadDashboardDiagnostics,
+  getDashboardDiagnosticsStatus,
+  startDashboardDiagnostics,
+} from 'app/features/query/diagnostics/downloadDiagnostics';
+
+import { DashboardScene } from '../scene/DashboardScene';
+import { DashboardGridItem } from '../scene/layout-default/DashboardGridItem';
+import { DefaultGridLayoutManager } from '../scene/layout-default/DefaultGridLayoutManager';
+
+import { DownloadDashboardDiagnostics } from './DownloadDashboardDiagnostics';
+
+jest.mock('app/features/query/diagnostics/downloadDiagnostics', () => ({
+  startDashboardDiagnostics: jest.fn(),
+  getDashboardDiagnosticsStatus: jest.fn(),
+  downloadDashboardDiagnostics: jest.fn(),
+}));
+
+setPluginImportUtils({
+  importPanelPlugin: () => Promise.resolve(getPanelPlugin({})),
+  getPanelPluginFromCache: () => undefined,
+});
+
+describe('DownloadDashboardDiagnostics', () => {
+  beforeEach(() => {
+    jest.mocked(startDashboardDiagnostics).mockReset();
+    jest.mocked(getDashboardDiagnosticsStatus).mockReset();
+    jest.mocked(downloadDashboardDiagnostics).mockReset();
+  });
+
+  it('renders the sensitive-data warning and download action', () => {
+    const { tab } = setupScenario();
+
+    render(<tab.Component model={tab} />);
+
+    expect(screen.getByText('May contain sensitive data')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Download diagnostics' })).toBeInTheDocument();
+  });
+
+  it('collects every panel with active queries, starts a job, and downloads the completed bundle', async () => {
+    jest.mocked(startDashboardDiagnostics).mockResolvedValue('job-1');
+    jest
+      .mocked(getDashboardDiagnosticsStatus)
+      .mockResolvedValue({ uid: 'job-1', state: 'complete', panelsDone: 2, panelsTotal: 2 });
+    jest.mocked(downloadDashboardDiagnostics).mockResolvedValue(undefined);
+    const { tab } = setupScenario();
+
+    render(<tab.Component model={tab} />);
+    await userEvent.click(screen.getByRole('button', { name: 'Download diagnostics' }));
+
+    expect(await screen.findByRole('button', { name: 'Download diagnostics' })).toBeInTheDocument();
+    expect(downloadDashboardDiagnostics).toHaveBeenCalledWith('job-1', expect.anything());
+
+    // Only the two data panels are sent; the text panel (no active queries) is skipped.
+    const [panels] = jest.mocked(startDashboardDiagnostics).mock.calls[0];
+    expect(panels.map((p) => p.title)).toEqual(['Panel A', 'Panel B']);
+  });
+
+  it('shows the generation-failed alert when the job errors out', async () => {
+    jest.mocked(startDashboardDiagnostics).mockResolvedValue('job-1');
+    jest
+      .mocked(getDashboardDiagnosticsStatus)
+      .mockResolvedValue({ uid: 'job-1', state: 'error', panelsDone: 0, panelsTotal: 2, error: 'boom' });
+    const { tab } = setupScenario();
+
+    render(<tab.Component model={tab} />);
+    await userEvent.click(screen.getByRole('button', { name: 'Download diagnostics' }));
+
+    expect(await screen.findByText('boom')).toBeInTheDocument();
+    expect(downloadDashboardDiagnostics).not.toHaveBeenCalled();
+  });
+
+  it('shows a message and does not start a job when no panel has active queries', async () => {
+    const { tab } = setupScenario({ onlyEmptyPanels: true });
+
+    render(<tab.Component model={tab} />);
+    await userEvent.click(screen.getByRole('button', { name: 'Download diagnostics' }));
+
+    expect(await screen.findByText('This dashboard has no panels with active queries.')).toBeInTheDocument();
+    expect(startDashboardDiagnostics).not.toHaveBeenCalled();
+  });
+
+  it('calls onDismiss when cancelled', async () => {
+    const onDismiss = jest.fn();
+    jest.mocked(startDashboardDiagnostics).mockImplementation(() => new Promise(() => {})); // never resolves
+    const { tab } = setupScenario({ onDismiss });
+
+    render(<tab.Component model={tab} />);
+    await userEvent.click(screen.getByRole('button', { name: 'Download diagnostics' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    expect(downloadDashboardDiagnostics).not.toHaveBeenCalled();
+  });
+});
+
+function setupScenario(opts: { onDismiss?: () => void; onlyEmptyPanels?: boolean } = {}) {
+  const { onDismiss, onlyEmptyPanels } = opts;
+
+  const panelA = new VizPanel({
+    key: 'panel-1',
+    pluginId: 'table',
+    title: 'Panel A',
+    $data: new SceneQueryRunner({ queries: onlyEmptyPanels ? [] : [{ refId: 'A' }] }),
+  });
+  const panelB = new VizPanel({
+    key: 'panel-2',
+    pluginId: 'table',
+    title: 'Panel B',
+    $data: new SceneQueryRunner({ queries: onlyEmptyPanels ? [] : [{ refId: 'A' }] }),
+  });
+  // A panel with no query runner at all (e.g. a text panel) should be skipped, not crash.
+  const textPanel = new VizPanel({ key: 'panel-3', pluginId: 'text', title: 'Text panel' });
+
+  const dashboard = new DashboardScene({
+    title: 'Dash',
+    uid: 'dash-1',
+    meta: { canEdit: true },
+    $timeRange: new SceneTimeRange({}),
+    body: new DefaultGridLayoutManager({
+      grid: new SceneGridLayout({
+        children: [
+          new DashboardGridItem({ key: 'grid-item-1', body: panelA }),
+          new DashboardGridItem({ key: 'grid-item-2', body: panelB }),
+          new DashboardGridItem({ key: 'grid-item-3', body: textPanel }),
+        ],
+      }),
+    }),
+  });
+
+  // Constructing the scene wires up parent pointers, which is all sceneGraph.getTimeRange and the
+  // query-runner lookup need here. We deliberately skip activation so the SceneQueryRunners do not
+  // try to execute (and fail) their queries against a real datasource.
+  const tab = new DownloadDashboardDiagnostics({ dashboardRef: dashboard.getRef(), onDismiss });
+
+  return { tab, dashboard };
+}

--- a/public/app/features/dashboard-scene/sharing/DownloadDashboardDiagnostics.tsx
+++ b/public/app/features/dashboard-scene/sharing/DownloadDashboardDiagnostics.tsx
@@ -82,11 +82,6 @@ function panelIdFrom(panel: VizPanel): number {
 function collectDashboardPanels(dashboard: DashboardScene): DashboardDiagnosticsPanel[] {
   const vizPanels = sceneGraph.findAllObjects(dashboard, (o) => o instanceof VizPanel);
   const panels: DashboardDiagnosticsPanel[] = [];
-  // Repeat-by-variable clones share their source panel's key (e.g. `panel-3-clone-1` and
-  // `panel-3-clone-2` both parse to id 3 in panelIdFrom), so track how many times each id has
-  // already been seen and disambiguate repeats with a negative id -- real panel ids are never
-  // negative, so this can't collide with another panel's id.
-  const seenCounts = new Map<number, number>();
 
   for (const obj of vizPanels) {
     const panel = obj instanceof VizPanel ? obj : undefined;
@@ -102,11 +97,14 @@ function collectDashboardPanels(dashboard: DashboardScene): DashboardDiagnostics
       continue;
     }
     const timeRange = sceneGraph.getTimeRange(panel).state.value;
-    const baseId = panelIdFrom(panel);
-    const occurrence = seenCounts.get(baseId) ?? 0;
-    seenCounts.set(baseId, occurrence + 1);
+    // Repeat-by-variable clones share their source panel's key (e.g. `panel-3-clone-1` and
+    // `panel-3-clone-2` both parse to id 3 in panelIdFrom), so multiple entries below can carry the
+    // same id -- that's intentional. dashboard.getSaveModel(), sent alongside this list in
+    // startDashboardDiagnostics, only serializes the source panel once (clones aren't separate
+    // save-model elements), so the id has to match that source panel for the backend to resolve its
+    // panel JSON. Each clone still gets its own array entry, so its captured queries aren't lost.
     panels.push({
-      id: occurrence === 0 ? baseId : -(baseId * 1000 + occurrence),
+      id: panelIdFrom(panel),
       title: panel.state.title ?? '',
       from: String(timeRange.from.valueOf()),
       to: String(timeRange.to.valueOf()),

--- a/public/app/features/dashboard-scene/sharing/DownloadDashboardDiagnostics.tsx
+++ b/public/app/features/dashboard-scene/sharing/DownloadDashboardDiagnostics.tsx
@@ -72,8 +72,11 @@ function getQueryRunnerFor(sceneObject: SceneObject | undefined): SceneQueryRunn
 }
 
 // panel.state.key is "panel-<id>"; parse the numeric id without importing utils (import cycle, as above).
+// Mirrors getPanelIdForVizPanel in dashboard-scene/utils/utils.ts, including its non-null assertion:
+// every VizPanel in the scene graph is keyed this way, so an undefined key indicates a real bug
+// upstream rather than something to paper over with a fallback id.
 function panelIdFrom(panel: VizPanel): number {
-  return parseInt(panel.state.key?.replace('panel-', '') ?? '0', 10);
+  return parseInt(panel.state.key!.replace('panel-', ''), 10);
 }
 
 // Collects every data panel's queries (with the runner-level datasource filled in and hidden queries

--- a/public/app/features/dashboard-scene/sharing/DownloadDashboardDiagnostics.tsx
+++ b/public/app/features/dashboard-scene/sharing/DownloadDashboardDiagnostics.tsx
@@ -1,0 +1,255 @@
+import { css } from '@emotion/css';
+import { useEffect, useRef, useState } from 'react';
+import { useAsyncFn } from 'react-use';
+
+import { type GrafanaTheme2 } from '@grafana/data';
+import { Trans, t } from '@grafana/i18n';
+import { isFetchError } from '@grafana/runtime';
+import {
+  sceneGraph,
+  type SceneComponentProps,
+  SceneDataTransformer,
+  type SceneObject,
+  SceneObjectBase,
+  type SceneObjectRef,
+  SceneQueryRunner,
+  VizPanel,
+} from '@grafana/scenes';
+import { type DataQuery } from '@grafana/schema';
+import { Alert, Button, useStyles2 } from '@grafana/ui';
+import {
+  type DashboardDiagnosticsPanel,
+  downloadDashboardDiagnostics,
+  getDashboardDiagnosticsStatus,
+  startDashboardDiagnostics,
+} from 'app/features/query/diagnostics/downloadDiagnostics';
+
+import { type DashboardScene } from '../scene/DashboardScene';
+
+import { type SceneShareTabState, type ShareView } from './types';
+
+// How long to wait between status polls, and the cap on attempts (~5 min, matching the backend's
+// generation timeout) before giving up client-side.
+const POLL_INTERVAL_MS = 1000;
+const MAX_POLL_ATTEMPTS = 300;
+
+export interface DownloadDashboardDiagnosticsState extends SceneShareTabState {
+  dashboardRef?: SceneObjectRef<DashboardScene>;
+}
+
+export class DownloadDashboardDiagnostics
+  extends SceneObjectBase<DownloadDashboardDiagnosticsState>
+  implements ShareView
+{
+  static Component = DownloadDashboardDiagnosticsRenderer;
+
+  public getTabLabel() {
+    return t('dashboard.diagnostics.title', 'Download diagnostics');
+  }
+
+  public getSubtitle() {
+    return t(
+      'dashboard.diagnostics.subtitle-dashboard',
+      'Bundle HTTP traffic (HAR) and panel JSON for every panel in this dashboard to help troubleshoot.'
+    );
+  }
+}
+
+// Inlined rather than imported from dashboard-scene/utils/utils: that module transitively reaches
+// DashboardScene, which imports ShareDrawer (which imports this view), creating an import cycle.
+function getQueryRunnerFor(sceneObject: SceneObject | undefined): SceneQueryRunner | undefined {
+  if (!sceneObject) {
+    return undefined;
+  }
+  const dataProvider = sceneObject.state.$data ?? sceneObject.parent?.state.$data;
+  if (dataProvider instanceof SceneQueryRunner) {
+    return dataProvider;
+  }
+  if (dataProvider instanceof SceneDataTransformer) {
+    return getQueryRunnerFor(dataProvider);
+  }
+  return undefined;
+}
+
+// panel.state.key is "panel-<id>"; parse the numeric id without importing utils (import cycle, as above).
+function panelIdFrom(panel: VizPanel): number {
+  return parseInt(panel.state.key?.replace('panel-', '') ?? '0', 10);
+}
+
+// Collects every data panel's queries (with the runner-level datasource filled in and hidden queries
+// dropped, mirroring the single-panel view) into the whole-dashboard request payload. Panels with no
+// active queries (e.g. text panels) are omitted.
+function collectDashboardPanels(dashboard: DashboardScene): DashboardDiagnosticsPanel[] {
+  const vizPanels = sceneGraph.findAllObjects(dashboard, (o) => o instanceof VizPanel);
+  const panels: DashboardDiagnosticsPanel[] = [];
+  // Repeat-by-variable clones share their source panel's key (e.g. `panel-3-clone-1` and
+  // `panel-3-clone-2` both parse to id 3 in panelIdFrom), so track how many times each id has
+  // already been seen and disambiguate repeats with a negative id -- real panel ids are never
+  // negative, so this can't collide with another panel's id.
+  const seenCounts = new Map<number, number>();
+
+  for (const obj of vizPanels) {
+    const panel = obj instanceof VizPanel ? obj : undefined;
+    if (!panel) {
+      continue;
+    }
+    const runner = getQueryRunnerFor(panel);
+    const runnerDatasource = runner?.state.datasource;
+    const queries: DataQuery[] = (runner?.state.queries ?? [])
+      .map((query) => (query.datasource ? query : { ...query, datasource: runnerDatasource }))
+      .filter((query) => !query.hide);
+    if (queries.length === 0) {
+      continue;
+    }
+    const timeRange = sceneGraph.getTimeRange(panel).state.value;
+    const baseId = panelIdFrom(panel);
+    const occurrence = seenCounts.get(baseId) ?? 0;
+    seenCounts.set(baseId, occurrence + 1);
+    panels.push({
+      id: occurrence === 0 ? baseId : -(baseId * 1000 + occurrence),
+      title: panel.state.title ?? '',
+      from: String(timeRange.from.valueOf()),
+      to: String(timeRange.to.valueOf()),
+      queries,
+    });
+  }
+
+  return panels;
+}
+
+// The download uses blob/json fetches whose FetchError carries the detail in status/statusText, so
+// build the message from those rather than error.message (which would leave the alert body empty).
+function diagnosticsErrorMessage(error: Error): string {
+  if (isFetchError(error)) {
+    const parts = [error.status, error.statusText].filter(Boolean);
+    return parts.length ? parts.join(' ') : t('dashboard.diagnostics.request-failed', 'Request failed');
+  }
+  return error.message || t('dashboard.diagnostics.error-title', 'Failed to generate diagnostics');
+}
+
+const delay = (ms: number, signal: AbortSignal) =>
+  new Promise<void>((resolve, reject) => {
+    const id = setTimeout(resolve, ms);
+    signal.addEventListener(
+      'abort',
+      () => {
+        clearTimeout(id);
+        reject(new DOMException('aborted', 'AbortError'));
+      },
+      { once: true }
+    );
+  });
+
+function DownloadDashboardDiagnosticsRenderer({ model }: SceneComponentProps<DownloadDashboardDiagnostics>) {
+  const { onDismiss, dashboardRef } = model.useState();
+  const styles = useStyles2(getStyles);
+  const abortRef = useRef<AbortController | null>(null);
+  const [progress, setProgress] = useState<{ done: number; total: number } | null>(null);
+
+  // Abort any in-flight request if the drawer unmounts.
+  useEffect(() => () => abortRef.current?.abort(), []);
+
+  const [{ loading: isGenerating, error }, onDownload] = useAsyncFn(async () => {
+    const dashboard = dashboardRef?.resolve();
+    if (!dashboard) {
+      return;
+    }
+    const panels = collectDashboardPanels(dashboard);
+    // Known limitation (follow-up): template variables are sent un-interpolated, so captured traffic
+    // won't match panels that use $vars until per-datasource interpolation is applied.
+    if (panels.length === 0) {
+      throw new Error(t('dashboard.diagnostics.no-panels', 'This dashboard has no panels with active queries.'));
+    }
+
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setProgress({ done: 0, total: panels.length });
+
+    const uid = await startDashboardDiagnostics(panels, dashboard.getSaveModel(), controller.signal);
+
+    for (let attempt = 0; ; attempt++) {
+      const status = await getDashboardDiagnosticsStatus(uid, controller.signal);
+      setProgress({ done: status.panelsDone, total: status.panelsTotal });
+      if (status.state === 'complete') {
+        break;
+      }
+      if (status.state === 'error') {
+        throw new Error(status.error || t('dashboard.diagnostics.generation-failed', 'Diagnostics generation failed'));
+      }
+      if (attempt >= MAX_POLL_ATTEMPTS) {
+        throw new Error(t('dashboard.diagnostics.timed-out', 'Timed out waiting for diagnostics generation'));
+      }
+      await delay(POLL_INTERVAL_MS, controller.signal);
+    }
+
+    await downloadDashboardDiagnostics(uid, controller.signal);
+  }, [dashboardRef]);
+
+  const handleDismiss = () => {
+    abortRef.current?.abort();
+    onDismiss?.();
+  };
+
+  return (
+    <div>
+      <p className={styles.info}>
+        <Trans i18nKey="dashboard.diagnostics.info-text-dashboard">
+          Generates a diagnostic bundle for the whole dashboard by re-running every panel&apos;s queries with HTTP
+          capture active. This runs in the background and may take a while for large dashboards.
+        </Trans>
+      </p>
+
+      <Alert
+        severity="warning"
+        title={t('dashboard.diagnostics.sensitive-warning-title', 'May contain sensitive data')}
+      >
+        <Trans i18nKey="dashboard.diagnostics.sensitive-warning-body">
+          The bundle can include request headers, query parameters, and server log lines. Review it before sharing
+          outside your organization.
+        </Trans>
+      </Alert>
+
+      {isGenerating && progress && (
+        <p className={styles.info}>
+          <Trans i18nKey="dashboard.diagnostics.progress" values={{ done: progress.done, total: progress.total }}>
+            Capturing panel {'{{done}}'} of {'{{total}}'}…
+          </Trans>
+        </p>
+      )}
+
+      {error && (
+        <Alert severity="error" title={t('dashboard.diagnostics.error-title', 'Failed to generate diagnostics')}>
+          {diagnosticsErrorMessage(error)}
+        </Alert>
+      )}
+
+      <div
+        className={styles.buttonRow}
+        role="group"
+        aria-label={t('dashboard.diagnostics.actions', 'Diagnostics actions')}
+      >
+        <Button variant="primary" onClick={onDownload} disabled={isGenerating} icon="download-alt">
+          {isGenerating ? (
+            <Trans i18nKey="dashboard.diagnostics.generating-button">Generating…</Trans>
+          ) : (
+            <Trans i18nKey="dashboard.diagnostics.download-button">Download diagnostics</Trans>
+          )}
+        </Button>
+        <Button variant="secondary" onClick={handleDismiss} fill="outline">
+          <Trans i18nKey="dashboard.diagnostics.cancel-button">Cancel</Trans>
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  info: css({
+    marginBottom: theme.spacing(2),
+  }),
+  buttonRow: css({
+    display: 'flex',
+    gap: theme.spacing(2),
+    marginTop: theme.spacing(2),
+  }),
+});

--- a/public/app/features/dashboard-scene/sharing/ExportButton/ExportMenu.tsx
+++ b/public/app/features/dashboard-scene/sharing/ExportButton/ExportMenu.tsx
@@ -3,7 +3,10 @@ import { useCallback, useContext, useMemo } from 'react';
 import { selectors as e2eSelectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 import { locationService, reportInteraction } from '@grafana/runtime';
+import { FlagKeys, getFeatureFlagClient } from '@grafana/runtime/internal';
 import { type IconName, Menu, ModalsContext } from '@grafana/ui';
+import { contextSrv } from 'app/core/services/context_srv';
+import { isOnPrem } from 'app/core/utils/isOnPrem';
 import { getTrackingSource, shareDashboardType } from 'app/features/dashboard/components/ShareModal/utils';
 
 import { type DashboardScene } from '../../scene/DashboardScene';
@@ -56,6 +59,19 @@ export default function ExportMenu({ dashboard }: { dashboard: DashboardScene })
       label: t('share-dashboard.menu.export-image-title', 'Export as image'),
       renderCondition: true,
       onClick: () => onMenuItemClick(shareDashboardType.image),
+    });
+
+    // Whole-dashboard diagnostics: admin-only, on-prem-only, gated on the on-demand diagnostics flag
+    // (matches the per-panel entry in PanelMenuBehavior). No panelRef -> dashboard-scoped share view.
+    menuItems.push({
+      shareId: shareDashboardType.downloadDiagnostics,
+      icon: 'download-alt',
+      label: t('dashboard.toolbar.new.export.download-diagnostics', 'Download diagnostics'),
+      renderCondition:
+        isOnPrem() &&
+        contextSrv.isGrafanaAdmin &&
+        getFeatureFlagClient().getBooleanValue(FlagKeys.GrafanaOnDemandDiagnostics, false),
+      onClick: () => onMenuItemClick(shareDashboardType.downloadDiagnostics),
     });
 
     return menuItems.filter((item) => item.renderCondition);

--- a/public/app/features/dashboard-scene/sharing/ShareDrawer/ShareDrawer.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareDrawer/ShareDrawer.tsx
@@ -11,6 +11,7 @@ import { Drawer } from '@grafana/ui';
 import { shareDashboardType } from '../../../dashboard/components/ShareModal/utils';
 import { type DashboardScene } from '../../scene/DashboardScene';
 import { getDashboardSceneFor } from '../../utils/utils';
+import { DownloadDashboardDiagnostics } from '../DownloadDashboardDiagnostics';
 import { DownloadDiagnostics } from '../DownloadDiagnostics';
 import { ExportAsCode } from '../ExportButton/ExportAsCode';
 import { ExportAsImage } from '../ExportButton/ExportAsImage';
@@ -108,6 +109,8 @@ function getShareView(
       return new ExportAsCode({ onDismiss });
     case shareDashboardType.image:
       return new ExportAsImage({ onDismiss });
+    case shareDashboardType.downloadDiagnostics:
+      return new DownloadDashboardDiagnostics({ dashboardRef, onDismiss });
     default:
       return new ShareInternally({ onDismiss });
   }

--- a/public/app/features/query/diagnostics/downloadDiagnostics.test.ts
+++ b/public/app/features/query/diagnostics/downloadDiagnostics.test.ts
@@ -93,7 +93,7 @@ describe('dashboard diagnostics', () => {
   it('startDashboardDiagnostics throws when no uid is returned', async () => {
     setupBackendSrv({ data: {} });
     await expect(startDashboardDiagnostics([{ id: 1, title: 'A', from: '1', to: '2', queries: [] }])).rejects.toThrow(
-      'diagnostics job was not created'
+      'Diagnostics job was not created'
     );
   });
 

--- a/public/app/features/query/diagnostics/downloadDiagnostics.test.ts
+++ b/public/app/features/query/diagnostics/downloadDiagnostics.test.ts
@@ -4,7 +4,12 @@ import { of } from 'rxjs';
 import { getBackendSrv } from '@grafana/runtime';
 import { type DataQuery } from '@grafana/schema';
 
-import { downloadDiagnosticsForQueries } from './downloadDiagnostics';
+import {
+  downloadDashboardDiagnostics,
+  downloadDiagnosticsForQueries,
+  getDashboardDiagnosticsStatus,
+  startDashboardDiagnostics,
+} from './downloadDiagnostics';
 
 jest.mock('file-saver', () => ({ saveAs: jest.fn() }));
 jest.mock('@grafana/runtime', () => ({ getBackendSrv: jest.fn() }));
@@ -60,5 +65,64 @@ describe('downloadDiagnosticsForQueries', () => {
     expect(saveAs).toHaveBeenCalledTimes(1);
     const [, filename] = jest.mocked(saveAs).mock.calls[0];
     expect(filename).toMatch(/^diagnostics-\d{8}-\d{6}\.tar\.gz$/);
+  });
+});
+
+describe('dashboard diagnostics', () => {
+  beforeEach(() => {
+    jest.mocked(saveAs).mockClear();
+  });
+
+  it('startDashboardDiagnostics POSTs the panels and returns the job uid', async () => {
+    const fetch = setupBackendSrv({ data: { uid: 'job-123', state: 'pending' } });
+    const panels = [{ id: 1, title: 'A', from: '1', to: '2', queries: [{ refId: 'A' }] }];
+
+    const uid = await startDashboardDiagnostics(panels);
+
+    expect(uid).toBe('job-123');
+    expect(fetch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: '/api/ds/dashboard-diagnostics',
+        method: 'POST',
+        responseType: 'json',
+        data: { dashboard: undefined, panels },
+      })
+    );
+  });
+
+  it('startDashboardDiagnostics throws when no uid is returned', async () => {
+    setupBackendSrv({ data: {} });
+    await expect(startDashboardDiagnostics([{ id: 1, title: 'A', from: '1', to: '2', queries: [] }])).rejects.toThrow(
+      'diagnostics job was not created'
+    );
+  });
+
+  it('getDashboardDiagnosticsStatus GETs the job status', async () => {
+    const fetch = setupBackendSrv({ data: { uid: 'job-123', state: 'complete', panelsTotal: 2, panelsDone: 2 } });
+
+    const status = await getDashboardDiagnosticsStatus('job-123');
+
+    expect(status.state).toBe('complete');
+    expect(fetch).toHaveBeenCalledWith(
+      expect.objectContaining({ url: '/api/ds/dashboard-diagnostics/job-123', method: 'GET' })
+    );
+  });
+
+  it('downloadDashboardDiagnostics downloads the completed bundle', async () => {
+    const blob = new Blob(['bundle'], { type: 'application/gzip' });
+    const fetch = setupBackendSrv({ data: blob, headers: new Headers() });
+
+    await downloadDashboardDiagnostics('job-123');
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: '/api/ds/dashboard-diagnostics/job-123/download',
+        method: 'GET',
+        responseType: 'blob',
+      })
+    );
+    expect(saveAs).toHaveBeenCalledTimes(1);
+    const [, filename] = jest.mocked(saveAs).mock.calls[0];
+    expect(filename).toMatch(/^dashboard-diagnostics-\d{8}-\d{6}\.tar\.gz$/);
   });
 });

--- a/public/app/features/query/diagnostics/downloadDiagnostics.ts
+++ b/public/app/features/query/diagnostics/downloadDiagnostics.ts
@@ -1,6 +1,7 @@
 import { saveAs } from 'file-saver';
 import { lastValueFrom } from 'rxjs';
 
+import { t } from '@grafana/i18n';
 import { getBackendSrv } from '@grafana/runtime';
 import { type DataQuery } from '@grafana/schema';
 
@@ -104,7 +105,7 @@ export async function startDashboardDiagnostics(
   );
   const uid = response.data?.uid;
   if (!uid) {
-    throw new Error('diagnostics job was not created');
+    throw new Error(t('dashboard.diagnostics.job-not-created', 'Diagnostics job was not created'));
   }
   return uid;
 }

--- a/public/app/features/query/diagnostics/downloadDiagnostics.ts
+++ b/public/app/features/query/diagnostics/downloadDiagnostics.ts
@@ -5,14 +5,15 @@ import { getBackendSrv } from '@grafana/runtime';
 import { type DataQuery } from '@grafana/schema';
 
 const DIAGNOSTICS_ENDPOINT = '/api/ds/diagnostics';
+const DASHBOARD_DIAGNOSTICS_ENDPOINT = '/api/ds/dashboard-diagnostics';
 
 /** Fallback bundle filename, e.g. `diagnostics-20260623-172901.tar.gz` (local time), used when the
  * response carries no Content-Disposition filename. */
-function fallbackFileName(): string {
+function fallbackFileName(prefix = 'diagnostics'): string {
   const now = new Date();
   const pad = (n: number) => String(n).padStart(2, '0');
   const stamp = `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}-${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}`;
-  return `diagnostics-${stamp}.tar.gz`;
+  return `${prefix}-${stamp}.tar.gz`;
 }
 
 /** Extracts the filename from a Content-Disposition header, if present. */
@@ -55,5 +56,89 @@ export async function downloadDiagnosticsForQueries(
   );
 
   const filename = fileNameFromContentDisposition(response.headers.get('Content-Disposition')) ?? fallbackFileName();
+  saveAs(response.data, filename);
+}
+
+/** One panel's diagnostics input for a whole-dashboard request: its resolved queries and time range
+ * (template variables applied by the caller). The dashboard's own JSON, sent alongside the panel
+ * list in {@link startDashboardDiagnostics}, is what supplies the panel JSON for the bundle. */
+export interface DashboardDiagnosticsPanel {
+  id: number;
+  title: string;
+  from: string;
+  to: string;
+  queries: DataQuery[];
+}
+
+/** State of an async dashboard-diagnostics generation job, as reported by the status endpoint. */
+export interface DashboardDiagnosticsStatus {
+  uid: string;
+  state: 'pending' | 'complete' | 'error';
+  panelsTotal: number;
+  panelsDone: number;
+  error?: string;
+}
+
+/**
+ * Starts an asynchronous whole-dashboard diagnostics generation and returns the job UID.
+ *
+ * Whole-dashboard generation can be slow (it re-runs every panel's queries with capture active), so
+ * the backend runs it in the background: this POST returns a job UID immediately, the caller polls
+ * {@link getDashboardDiagnosticsStatus}, then downloads via {@link downloadDashboardDiagnostics}.
+ * The endpoint lands in a separate backend PR; until then this fails and the drawer surfaces it.
+ */
+export async function startDashboardDiagnostics(
+  panels: DashboardDiagnosticsPanel[],
+  dashboard?: unknown,
+  signal?: AbortSignal
+): Promise<string> {
+  const response = await lastValueFrom(
+    getBackendSrv().fetch<{ uid: string }>({
+      url: DASHBOARD_DIAGNOSTICS_ENDPOINT,
+      method: 'POST',
+      responseType: 'json',
+      data: { dashboard, panels },
+      showErrorAlert: false,
+      abortSignal: signal,
+    })
+  );
+  const uid = response.data?.uid;
+  if (!uid) {
+    throw new Error('diagnostics job was not created');
+  }
+  return uid;
+}
+
+/** Fetches the current state/progress of a dashboard-diagnostics job. */
+export async function getDashboardDiagnosticsStatus(
+  uid: string,
+  signal?: AbortSignal
+): Promise<DashboardDiagnosticsStatus> {
+  const response = await lastValueFrom(
+    getBackendSrv().fetch<DashboardDiagnosticsStatus>({
+      url: `${DASHBOARD_DIAGNOSTICS_ENDPOINT}/${encodeURIComponent(uid)}`,
+      method: 'GET',
+      responseType: 'json',
+      showErrorAlert: false,
+      abortSignal: signal,
+    })
+  );
+  return response.data;
+}
+
+/** Downloads the completed bundle for a dashboard-diagnostics job. */
+export async function downloadDashboardDiagnostics(uid: string, signal?: AbortSignal): Promise<void> {
+  const response = await lastValueFrom(
+    getBackendSrv().fetch<Blob>({
+      url: `${DASHBOARD_DIAGNOSTICS_ENDPOINT}/${encodeURIComponent(uid)}/download`,
+      method: 'GET',
+      responseType: 'blob',
+      showErrorAlert: false,
+      abortSignal: signal,
+    })
+  );
+  const filename =
+    fileNameFromContentDisposition(response.headers.get('Content-Disposition')) ??
+    fallbackFileName('dashboard-diagnostics');
   saveAs(response.data, filename);
 }

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -5582,6 +5582,7 @@
       "generation-failed": "Diagnostics generation failed",
       "info-text-dashboard": "Generates a diagnostic bundle for the whole dashboard by re-running every panel's queries with HTTP capture active. This runs in the background and may take a while for large dashboards.",
       "info-text-panel": "Generates a diagnostic bundle for this panel by re-running its queries with HTTP capture active. The download may take a moment while the bundle is generated.",
+      "job-not-created": "Diagnostics job was not created",
       "no-panels": "This dashboard has no panels with active queries.",
       "no-queries": "This panel has no active queries to capture.",
       "progress": "Capturing panel {{done}} of {{total}}…",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -5579,12 +5579,18 @@
       "download-button": "Download diagnostics",
       "error-title": "Failed to generate diagnostics",
       "generating-button": "Generating…",
+      "generation-failed": "Diagnostics generation failed",
+      "info-text-dashboard": "Generates a diagnostic bundle for the whole dashboard by re-running every panel's queries with HTTP capture active. This runs in the background and may take a while for large dashboards.",
       "info-text-panel": "Generates a diagnostic bundle for this panel by re-running its queries with HTTP capture active. The download may take a moment while the bundle is generated.",
+      "no-panels": "This dashboard has no panels with active queries.",
       "no-queries": "This panel has no active queries to capture.",
+      "progress": "Capturing panel {{done}} of {{total}}…",
       "request-failed": "Request failed",
       "sensitive-warning-body": "The bundle can include request headers, query parameters, and server log lines. Review it before sharing outside your organization.",
       "sensitive-warning-title": "May contain sensitive data",
+      "subtitle-dashboard": "Bundle HTTP traffic (HAR) and panel JSON for every panel in this dashboard to help troubleshoot.",
       "subtitle-panel": "Bundle HTTP traffic (HAR), logs, and panel JSON to help troubleshoot this panel.",
+      "timed-out": "Timed out waiting for diagnostics generation",
       "title": "Download diagnostics"
     },
     "dynamic-config-value-editor": {
@@ -6357,6 +6363,7 @@
           "tooltip": "This dashboard was marked as read only"
         },
         "export": {
+          "download-diagnostics": "Download diagnostics",
           "tooltip": {
             "as-code": "Export as code"
           }


### PR DESCRIPTION
## What this PR does

Adds the dashboard-level **"Download diagnostics"** frontend on top of the merged per-panel action (#128212), driving the async whole-dashboard backend endpoints.

## Dependency note

This is the frontend of the whole-dashboard flow; it calls `POST /api/ds/dashboard-diagnostics`, which is provided by the dashboard-level **backend** PR (#1522). Like the merged panel FE (#128212), which shipped ahead of its backend, this is flag-gated/off-by-default and safe to merge independently — the feature is functional once the backend lands.


## Deferred to a follow-up (limits)

Pairs with the backend MVP (#128598). Backend-side **resource limits are intentionally deferred** to a separate dashboard-limits PR — panel-count capping, per-request truncation, bundle retention/TTL, per-run timeout, and aggregate bundle-size cap. This FE drives the generation flow only; it adds no capping/truncation of its own.
