### PR TITLE
[Patch steady] Auth: Assign base Grafana Cloud roles to Grafana.com users on Cloud instances (#128331)

### DIFF
--- a/pkg/services/authn/authnimpl/registration.go
+++ b/pkg/services/authn/authnimpl/registration.go
@@ -133,10 +133,10 @@ func ProvideRegistration(
 		authnSvc.RegisterPostAuthHook(userSync.ValidateUserProvisioningHook, 30)
 	}
 
-	rbacSync := sync.ProvideRBACSync(accessControlService, tracer, permRegistry)
+	rbacSync := sync.ProvideRBACSync(cfg, accessControlService, tracer, permRegistry, features)
+	authnSvc.RegisterPostAuthHook(rbacSync.SyncCloudRoles, 110)
 	//nolint:staticcheck // not yet migrated to OpenFeature
 	if features.IsEnabledGlobally(featuremgmt.FlagCloudRBACRoles) {
-		authnSvc.RegisterPostAuthHook(rbacSync.SyncCloudRoles, 110)
 		authnSvc.RegisterPreLogoutHook(gcomsso.ProvideGComSSOService(cfg).LogoutHook, 50)
 	}
 

--- a/pkg/services/authn/authnimpl/sync/rbac_sync.go
+++ b/pkg/services/authn/authnimpl/sync/rbac_sync.go
@@ -18,8 +18,10 @@ import (
 	"github.com/grafana/grafana/pkg/services/accesscontrol/permreg"
 	"github.com/grafana/grafana/pkg/services/authn"
 	rbac "github.com/grafana/grafana/pkg/services/authz/rbac"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/login"
 	"github.com/grafana/grafana/pkg/services/org"
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 var (
@@ -27,22 +29,26 @@ var (
 	errSyncPermissionsForbidden = errutil.Forbidden("permissions.sync.forbidden")
 )
 
-func ProvideRBACSync(acService accesscontrol.Service, tracer tracing.Tracer, permRegistry permreg.PermissionRegistry) *RBACSync {
+func ProvideRBACSync(cfg *setting.Cfg, acService accesscontrol.Service, tracer tracing.Tracer, permRegistry permreg.PermissionRegistry, features featuremgmt.FeatureToggles) *RBACSync {
 	return &RBACSync{
+		cfg:          cfg,
 		ac:           acService,
 		log:          log.New("permissions.sync"),
 		permRegistry: permRegistry,
 		tracer:       tracer,
 		mapper:       rbac.NewMapperRegistry(),
+		features:     features,
 	}
 }
 
 type RBACSync struct {
+	cfg          *setting.Cfg
 	ac           accesscontrol.Service
 	permRegistry permreg.PermissionRegistry
 	log          log.Logger
 	tracer       tracing.Tracer
 	mapper       rbac.MapperRegistry
+	features     featuremgmt.FeatureToggles
 }
 
 func (s *RBACSync) SyncPermissionsHook(ctx context.Context, ident *authn.Identity, _ *authn.Request) error {
@@ -222,13 +228,23 @@ func (s *RBACSync) translateK8sPermissions(_ context.Context, k8sPerms []string)
 	return permissions
 }
 
-func cloudRolesToAddAndRemove(ident *authn.Identity) ([]string, []string, error) {
+func (s *RBACSync) cloudRolesToAddAndRemove(ident *authn.Identity) ([]string, []string, error) {
 	// Since Cloud Admin/Editor/Viewer roles are not yet implemented one-to-one in the Grafana, it becomes a confusing experience for users,
 	// therefore we are doing granular mapping of all available functionality in the Grafana temporary.
 	var fixedCloudRoles = map[org.RoleType][]string{
-		org.RoleViewer: {accesscontrol.FixedCloudViewerRole, accesscontrol.FixedCloudSupportTicketReader},
-		org.RoleEditor: {accesscontrol.FixedCloudEditorRole, accesscontrol.FixedCloudSupportTicketAdmin},
-		org.RoleAdmin:  {accesscontrol.FixedCloudAdminRole, accesscontrol.FixedCloudSupportTicketAdmin},
+		org.RoleViewer: {accesscontrol.FixedCloudViewerRole},
+		org.RoleEditor: {accesscontrol.FixedCloudEditorRole},
+		org.RoleAdmin:  {accesscontrol.FixedCloudAdminRole},
+	}
+
+	// The support-ticket roles remain gated behind the cloudRBACRoles feature
+	// toggle. When disabled, they are left out of both the add and remove sets
+	// so any pre-existing assignments are not touched.
+	//nolint:staticcheck // not yet migrated to OpenFeature
+	if s.features.IsEnabledGlobally(featuremgmt.FlagCloudRBACRoles) {
+		fixedCloudRoles[org.RoleViewer] = append(fixedCloudRoles[org.RoleViewer], accesscontrol.FixedCloudSupportTicketReader)
+		fixedCloudRoles[org.RoleEditor] = append(fixedCloudRoles[org.RoleEditor], accesscontrol.FixedCloudSupportTicketAdmin)
+		fixedCloudRoles[org.RoleAdmin] = append(fixedCloudRoles[org.RoleAdmin], accesscontrol.FixedCloudSupportTicketAdmin)
 	}
 
 	rolesToAdd := make(map[string]bool)
@@ -265,6 +281,11 @@ func (s *RBACSync) SyncCloudRoles(ctx context.Context, ident *authn.Identity, r 
 	ctx, span := s.tracer.Start(ctx, "rbac.sync.SyncCloudRoles")
 	defer span.End()
 
+	// The cloud roles only make sense when running in Grafana Cloud (StackID set).
+	if s.cfg.StackID == "" {
+		return nil
+	}
+
 	// we only want to run this hook during login and if the module used is grafana com
 	if r.GetMeta(authn.MetaKeyAuthModule) != login.GrafanaComAuthModule {
 		return nil
@@ -280,16 +301,25 @@ func (s *RBACSync) SyncCloudRoles(ctx context.Context, ident *authn.Identity, r 
 		return err
 	}
 
-	rolesToAdd, rolesToRemove, err := cloudRolesToAddAndRemove(ident)
+	rolesToAdd, rolesToRemove, err := s.cloudRolesToAddAndRemove(ident)
 	if err != nil {
 		return err
 	}
 
-	return s.ac.SyncUserRoles(ctx, ident.GetOrgID(), accesscontrol.SyncUserRolesCommand{
+	err = s.ac.SyncUserRoles(ctx, ident.GetOrgID(), accesscontrol.SyncUserRolesCommand{
 		UserID:        userID,
 		RolesToAdd:    rolesToAdd,
 		RolesToRemove: rolesToRemove,
 	})
+	if errors.Is(err, accesscontrol.ErrRoleNotFound) {
+		// A cloud role may not be registered yet when the enterprise build has
+		// not caught up with the role definitions. Skip this login's sync rather
+		// than blocking login; the roles apply once the definitions land.
+		s.log.FromContext(ctx).Warn("Skipping cloud role sync; role not registered", "error", err)
+		return nil
+	}
+
+	return err
 }
 
 // ClearUserPermissionCacheHook clears a user's permission cache if user Login succeeded. Necessary so that if a user logs in

--- a/pkg/services/authn/authnimpl/sync/rbac_sync_test.go
+++ b/pkg/services/authn/authnimpl/sync/rbac_sync_test.go
@@ -17,8 +17,10 @@ import (
 	permreg "github.com/grafana/grafana/pkg/services/accesscontrol/permreg/test"
 	"github.com/grafana/grafana/pkg/services/authn"
 	rbac "github.com/grafana/grafana/pkg/services/authz/rbac"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/login"
 	"github.com/grafana/grafana/pkg/services/org"
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 func TestRBACSync_SyncPermission(t *testing.T) {
@@ -249,15 +251,18 @@ func TestRBACSync_SyncCloudRoles(t *testing.T) {
 	type testCase struct {
 		desc           string
 		module         string
+		stackID        string
 		identity       *authn.Identity
+		syncErr        error
 		expectedErr    error
 		expectedCalled bool
 	}
 
 	tests := []testCase{
 		{
-			desc:   "should call sync when authenticated with grafana com and has viewer role",
-			module: login.GrafanaComAuthModule,
+			desc:    "should call sync when authenticated with grafana com and has viewer role",
+			module:  login.GrafanaComAuthModule,
+			stackID: "1",
 			identity: &authn.Identity{
 				ID:       "1",
 				Type:     claims.TypeUser,
@@ -268,8 +273,22 @@ func TestRBACSync_SyncCloudRoles(t *testing.T) {
 			expectedCalled: true,
 		},
 		{
-			desc:   "should call sync when authenticated with grafana com and has editor role",
-			module: login.GrafanaComAuthModule,
+			desc:    "should not call sync when not running in Grafana Cloud",
+			module:  login.GrafanaComAuthModule,
+			stackID: "",
+			identity: &authn.Identity{
+				ID:       "1",
+				Type:     claims.TypeUser,
+				OrgID:    1,
+				OrgRoles: map[int64]org.RoleType{1: org.RoleAdmin},
+			},
+			expectedErr:    nil,
+			expectedCalled: false,
+		},
+		{
+			desc:    "should call sync when authenticated with grafana com and has editor role",
+			module:  login.GrafanaComAuthModule,
+			stackID: "1",
 			identity: &authn.Identity{
 				ID:       "1",
 				Type:     claims.TypeUser,
@@ -280,8 +299,9 @@ func TestRBACSync_SyncCloudRoles(t *testing.T) {
 			expectedCalled: true,
 		},
 		{
-			desc:   "should call sync when authenticated with grafana com and has admin role",
-			module: login.GrafanaComAuthModule,
+			desc:    "should call sync when authenticated with grafana com and has admin role",
+			module:  login.GrafanaComAuthModule,
+			stackID: "1",
 			identity: &authn.Identity{
 				ID:       "1",
 				Type:     claims.TypeUser,
@@ -292,8 +312,9 @@ func TestRBACSync_SyncCloudRoles(t *testing.T) {
 			expectedCalled: true,
 		},
 		{
-			desc:   "should not call sync when authenticated with grafana com and has invalid role",
-			module: login.GrafanaComAuthModule,
+			desc:    "should not call sync when authenticated with grafana com and has invalid role",
+			module:  login.GrafanaComAuthModule,
+			stackID: "1",
 			identity: &authn.Identity{
 				ID:       "1",
 				Type:     claims.TypeUser,
@@ -304,8 +325,9 @@ func TestRBACSync_SyncCloudRoles(t *testing.T) {
 			expectedCalled: false,
 		},
 		{
-			desc:   "should not call sync when not authenticated with grafana com",
-			module: login.LDAPAuthModule,
+			desc:    "should not call sync when not authenticated with grafana com",
+			module:  login.LDAPAuthModule,
+			stackID: "1",
 			identity: &authn.Identity{
 				ID:       "1",
 				Type:     claims.TypeUser,
@@ -314,6 +336,20 @@ func TestRBACSync_SyncCloudRoles(t *testing.T) {
 			},
 			expectedErr:    nil,
 			expectedCalled: false,
+		},
+		{
+			desc:    "should not fail login when a cloud role is not registered",
+			module:  login.GrafanaComAuthModule,
+			stackID: "1",
+			identity: &authn.Identity{
+				ID:       "1",
+				Type:     claims.TypeUser,
+				OrgID:    1,
+				OrgRoles: map[int64]org.RoleType{1: org.RoleViewer},
+			},
+			syncErr:        accesscontrol.ErrRoleNotFound,
+			expectedErr:    nil,
+			expectedCalled: true,
 		},
 	}
 
@@ -324,11 +360,13 @@ func TestRBACSync_SyncCloudRoles(t *testing.T) {
 				ac: &acmock.Mock{
 					SyncUserRolesFunc: func(_ context.Context, _ int64, _ accesscontrol.SyncUserRolesCommand) error {
 						called = true
-						return nil
+						return tt.syncErr
 					},
 				},
-				log:    log.NewNopLogger(),
-				tracer: tracing.InitializeTracerForTest(),
+				log:      log.NewNopLogger(),
+				tracer:   tracing.InitializeTracerForTest(),
+				features: featuremgmt.WithFeatures(featuremgmt.FlagCloudRBACRoles),
+				cfg:      &setting.Cfg{StackID: tt.stackID},
 			}
 
 			req := &authn.Request{}
@@ -343,23 +381,25 @@ func TestRBACSync_SyncCloudRoles(t *testing.T) {
 
 func TestRBACSync_cloudRolesToAddAndRemove(t *testing.T) {
 	type testCase struct {
-		desc                  string
-		identity              *authn.Identity
-		expectedErr           error
-		expectedRolesToAdd    []string
-		expectedRolesToRemove []string
+		desc                      string
+		identity                  *authn.Identity
+		includeSupportTicketRoles bool
+		expectedErr               error
+		expectedRolesToAdd        []string
+		expectedRolesToRemove     []string
 	}
 
 	tests := []testCase{
 		{
-			desc: "should map Cloud Viewer to Grafana Cloud Viewer and Support ticket reader",
+			desc: "should map Cloud Viewer to Grafana Cloud Viewer and Support ticket reader when support ticket roles are included",
 			identity: &authn.Identity{
 				ID:       "1",
 				Type:     claims.TypeUser,
 				OrgID:    1,
 				OrgRoles: map[int64]org.RoleType{1: org.RoleViewer},
 			},
-			expectedErr: nil,
+			includeSupportTicketRoles: true,
+			expectedErr:               nil,
 			expectedRolesToAdd: []string{
 				accesscontrol.FixedCloudViewerRole,
 				accesscontrol.FixedCloudSupportTicketReader,
@@ -372,14 +412,15 @@ func TestRBACSync_cloudRolesToAddAndRemove(t *testing.T) {
 			},
 		},
 		{
-			desc: "should map Cloud Editor to Grafana Cloud Editor and Support ticket admin",
+			desc: "should map Cloud Editor to Grafana Cloud Editor and Support ticket admin when support ticket roles are included",
 			identity: &authn.Identity{
 				ID:       "1",
 				Type:     claims.TypeUser,
 				OrgID:    1,
 				OrgRoles: map[int64]org.RoleType{1: org.RoleEditor},
 			},
-			expectedErr: nil,
+			includeSupportTicketRoles: true,
+			expectedErr:               nil,
 			expectedRolesToAdd: []string{
 				accesscontrol.FixedCloudEditorRole,
 				accesscontrol.FixedCloudSupportTicketAdmin,
@@ -391,14 +432,15 @@ func TestRBACSync_cloudRolesToAddAndRemove(t *testing.T) {
 			},
 		},
 		{
-			desc: "should map Cloud Admin to Grafana Cloud Admin and Support ticket admin",
+			desc: "should map Cloud Admin to Grafana Cloud Admin and Support ticket admin when support ticket roles are included",
 			identity: &authn.Identity{
 				ID:       "1",
 				Type:     claims.TypeUser,
 				OrgID:    1,
 				OrgRoles: map[int64]org.RoleType{1: org.RoleAdmin},
 			},
-			expectedErr: nil,
+			includeSupportTicketRoles: true,
+			expectedErr:               nil,
 			expectedRolesToAdd: []string{
 				accesscontrol.FixedCloudAdminRole,
 				accesscontrol.FixedCloudSupportTicketAdmin,
@@ -406,6 +448,42 @@ func TestRBACSync_cloudRolesToAddAndRemove(t *testing.T) {
 			expectedRolesToRemove: []string{
 				accesscontrol.FixedCloudViewerRole,
 				accesscontrol.FixedCloudSupportTicketReader,
+				accesscontrol.FixedCloudEditorRole,
+			},
+		},
+		{
+			desc: "should map Cloud Viewer to only the base Grafana Cloud Viewer role when support ticket roles are excluded",
+			identity: &authn.Identity{
+				ID:       "1",
+				Type:     claims.TypeUser,
+				OrgID:    1,
+				OrgRoles: map[int64]org.RoleType{1: org.RoleViewer},
+			},
+			includeSupportTicketRoles: false,
+			expectedErr:               nil,
+			expectedRolesToAdd: []string{
+				accesscontrol.FixedCloudViewerRole,
+			},
+			expectedRolesToRemove: []string{
+				accesscontrol.FixedCloudEditorRole,
+				accesscontrol.FixedCloudAdminRole,
+			},
+		},
+		{
+			desc: "should map Cloud Admin to only the base Grafana Cloud Admin role when support ticket roles are excluded",
+			identity: &authn.Identity{
+				ID:       "1",
+				Type:     claims.TypeUser,
+				OrgID:    1,
+				OrgRoles: map[int64]org.RoleType{1: org.RoleAdmin},
+			},
+			includeSupportTicketRoles: false,
+			expectedErr:               nil,
+			expectedRolesToAdd: []string{
+				accesscontrol.FixedCloudAdminRole,
+			},
+			expectedRolesToRemove: []string{
+				accesscontrol.FixedCloudViewerRole,
 				accesscontrol.FixedCloudEditorRole,
 			},
 		},
@@ -417,15 +495,24 @@ func TestRBACSync_cloudRolesToAddAndRemove(t *testing.T) {
 				OrgID:    1,
 				OrgRoles: map[int64]org.RoleType{1: org.RoleNone},
 			},
-			expectedErr:           errInvalidCloudRole,
-			expectedRolesToAdd:    []string{},
-			expectedRolesToRemove: []string{},
+			includeSupportTicketRoles: true,
+			expectedErr:               errInvalidCloudRole,
+			expectedRolesToAdd:        []string{},
+			expectedRolesToRemove:     []string{},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			rolesToAdd, rolesToRemove, err := cloudRolesToAddAndRemove(tt.identity)
+			var features featuremgmt.FeatureToggles
+			if tt.includeSupportTicketRoles {
+				features = featuremgmt.WithFeatures(featuremgmt.FlagCloudRBACRoles)
+			} else {
+				features = featuremgmt.WithFeatures()
+			}
+			s := &RBACSync{features: features}
+
+			rolesToAdd, rolesToRemove, err := s.cloudRolesToAddAndRemove(tt.identity)
 			assert.ErrorIs(t, tt.expectedErr, err)
 			assert.ElementsMatch(t, tt.expectedRolesToAdd, rolesToAdd)
 			assert.ElementsMatch(t, tt.expectedRolesToRemove, rolesToRemove)


### PR DESCRIPTION
Slack ctx: https://raintank-corp.slack.com/archives/C07NCBRSABU/p1784211787881639 (🔐)