### PR TITLE
Dashboards: Track "Use library panel" clicks on the unconfigured panel

### DIFF
--- a/public/app/features/dashboard-scene/scene/UnconfiguredPanel.test.tsx
+++ b/public/app/features/dashboard-scene/scene/UnconfiguredPanel.test.tsx
@@ -292,6 +292,17 @@ describe('UnconfiguredPanelComp', () => {
 
         expect(dashboard.onShowAddLibraryPanelDrawer).toHaveBeenCalled();
       });
+
+      it('tracks the use library panel interaction', async () => {
+        const dashboard = buildDashboard({ isEditing: true });
+        jest.spyOn(dashboard, 'onShowAddLibraryPanelDrawer').mockImplementation(() => {});
+        const { user, root } = renderPanel();
+
+        await user.hover(root);
+        await user.click(screen.getByRole('button', { name: /use library panel/i }));
+
+        expect(DashboardInteractions.panelActionClicked).toHaveBeenCalledWith('use_library_panel', 1, 'panel');
+      });
     });
 
     describe('queryLibraryEnabled = false', () => {

--- a/public/app/features/dashboard-scene/scene/UnconfiguredPanel.tsx
+++ b/public/app/features/dashboard-scene/scene/UnconfiguredPanel.tsx
@@ -147,6 +147,7 @@ export function UnconfiguredPanelComp(props: PanelProps) {
     }
 
     dashboard.onShowAddLibraryPanelDrawer(panel.getRef());
+    DashboardInteractions.panelActionClicked('use_library_panel', props.id, 'panel');
   };
 
   if (panelContext.app === CoreApp.PanelEditor) {

--- a/public/app/features/dashboard-scene/utils/interactions.ts
+++ b/public/app/features/dashboard-scene/utils/interactions.ts
@@ -158,7 +158,7 @@ export const DashboardInteractions = {
   },
 
   panelActionClicked(
-    item: 'configure' | 'configure_dropdown' | 'edit' | 'copy' | 'duplicate' | 'delete' | 'view',
+    item: 'configure' | 'configure_dropdown' | 'edit' | 'copy' | 'duplicate' | 'delete' | 'view' | 'use_library_panel',
     id: number,
     source: 'panel' | 'edit_pane' | 'keyboard'
   ) {


### PR DESCRIPTION
## What is this feature?

Adds instrumentation for the "Use library panel" button on the unconfigured panel (introduced in #121089). Clicking it now fires the existing `dashboards_panel_action_clicked` event with `item: 'use_library_panel'`, `id`, and `source: 'panel'` — the same event and shape the "Configure visualization" button on this panel already uses, so the two choices can be compared directly.

## Why do we need this feature?

With `dashboardNewLayouts` enabled, the unconfigured panel button is the primary way to add a library panel to a dashboard (the old toolbar "Import from library" and empty-dashboard entry points don't exist in the new edit experience), and it was untracked.

## Who is this feature for?

Grafana PMs/engineers analyzing dashboard creation flows.

## Which issue(s) does this PR fix?

n/a — analytics-only change, no user-facing behavior.

## Special notes for your reviewer:

- The tracking call sits after the existing guards in `onUseLibraryPanel`, so it only fires when the drawer actually opens (mirrors `onConfigure`).
- "Use saved query" on the same panel is already tracked by the query library plugin (`query_library-add_query_from_library_clicked` with `context: 'unconfigured-panel'`), so no change needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)