### PR TITLE
unified-storage: throw an error with declarations that exceed KV max batch ops

### DIFF
--- a/pkg/storage/unified/resource/usagestats/declaration.go
+++ b/pkg/storage/unified/resource/usagestats/declaration.go
@@ -7,7 +7,11 @@
 // stats/daily and stats/aggregates KV sections.
 package usagestats
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/grafana/grafana/pkg/storage/unified/resource/kv"
+)
 
 const (
 	dashboardsGroup    = "dashboard.grafana.app"
@@ -64,6 +68,16 @@ func (d *Declarations) add(decl StatsDeclaration) {
 func (d *Declarations) Lookup(group, resource string) (StatsDeclaration, bool) {
 	decl, ok := d.byGR[group+"/"+resource]
 	return decl, ok
+}
+
+func (d *Declarations) Validate() error {
+	for _, decl := range d.byGR {
+		if len(decl.Metrics) > kv.MaxBatchOps {
+			return fmt.Errorf("resource %s declares %d metrics, exceeding the max batch size of %d",
+				decl.GroupResource(), len(decl.Metrics), kv.MaxBatchOps)
+		}
+	}
+	return nil
 }
 
 // MaxWindow returns the largest window (in days) across all declarations.

--- a/pkg/storage/unified/resource/usagestats/ingester.go
+++ b/pkg/storage/unified/resource/usagestats/ingester.go
@@ -80,6 +80,9 @@ func NewIngester(opts IngesterOptions) (*Ingester, error) {
 	if decls == nil {
 		decls = DefaultDeclarations()
 	}
+	if err := decls.Validate(); err != nil {
+		return nil, err
+	}
 	now := opts.Now
 	if now == nil {
 		now = time.Now

--- a/pkg/storage/unified/resource/usagestats/usagestats_test.go
+++ b/pkg/storage/unified/resource/usagestats/usagestats_test.go
@@ -82,6 +82,20 @@ func TestDeclarations(t *testing.T) {
 	require.False(t, ok)
 }
 
+func TestDeclarationsValidate(t *testing.T) {
+	require.NoError(t, DefaultDeclarations().Validate())
+
+	// A resource declaring more metrics than fit in one daily batch cannot
+	// flush and must be rejected at startup.
+	tooMany := make([]string, kv.MaxBatchOps+1)
+	for i := range tooMany {
+		tooMany[i] = fmt.Sprintf("metric-%d", i)
+	}
+	decls := &Declarations{byGR: map[string]StatsDeclaration{}}
+	decls.add(StatsDeclaration{Group: "g.grafana.app", Resource: "things", Metrics: tooMany, Windows: []int{1}})
+	require.ErrorContains(t, decls.Validate(), "exceeding the max batch size")
+}
+
 func TestDeclarationFieldNames(t *testing.T) {
 	require.Equal(t, "views_last_1_days", aggregateField("views", 1))
 	require.Equal(t, "views_last_7_days", aggregateField("views", 7))


### PR DESCRIPTION
closes https://github.com/grafana/search-and-storage-team/issues/861

We don't want to chunk IncrementDaily because this is the source of truth. Instead we fail at startup if we declare stats with more than the amount of metrics we can reliably commit with `Batch` (currently 20)