### PR TITLE
Timeseries: Fix flaky tooltip e2e test

### DIFF
--- a/devenv/dev-dashboards/panel-timeseries/timeseries.json
+++ b/devenv/dev-dashboards/panel-timeseries/timeseries.json
@@ -51,7 +51,8 @@
                         "name": "PD8C576611E62080A"
                       },
                       "spec": {
-                        "scenarioId": "random_walk"
+                        "scenarioId": "random_walk",
+                        "startValue": 10
                       }
                     },
                     "refId": "A",
@@ -69,7 +70,8 @@
                         "name": "PD8C576611E62080A"
                       },
                       "spec": {
-                        "scenarioId": "random_walk"
+                        "scenarioId": "random_walk",
+                        "startValue": 10
                       }
                     },
                     "refId": "B",
@@ -4402,8 +4404,8 @@
     "preload": false,
     "tags": ["gdev", "panel-tests", "graph-ng"],
     "timeSettings": {
-      "from": "now-30m",
-      "to": "now",
+      "from": "2024-01-01T00:00:00.000Z",
+      "to": "2024-01-01T00:30:00.000Z",
       "autoRefresh": "",
       "autoRefreshIntervals": ["5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"],
       "hideTimepicker": false,

--- a/e2e-playwright/panels-suite/timeseries.spec.ts
+++ b/e2e-playwright/panels-suite/timeseries.spec.ts
@@ -16,14 +16,15 @@ test.describe('Panels test: TimeSeries', { tag: ['@panels', '@timeseries'] }, ()
     await expect(errorInfo, 'no errors in the panels').toBeHidden();
   });
 
-  // TODO: https://github.com/grafana/grafana/issues/124170
-  test.skip('tooltip interactions', async ({ gotoDashboardPage, page, selectors }) => {
+  test('tooltip interactions', async ({ gotoDashboardPage, page, selectors }) => {
     const dashboardPage = await gotoDashboardPage({
       uid: DASHBOARD_UID,
       queryParams: new URLSearchParams({ editPanel: '19' }),
     });
 
-    const timeseriesUplot = page.locator('.uplot');
+    const timeseriesUplot = dashboardPage
+      .getByGrafanaSelector(selectors.components.Panels.Panel.content)
+      .locator('.uplot');
     await expect(timeseriesUplot, 'uplot is rendered').toBeVisible();
 
     const tooltip = dashboardPage.getByGrafanaSelector(selectors.components.Panels.Visualization.Tooltip.Wrapper);


### PR DESCRIPTION
**What is this feature?**

Fixes the flaky, previously-skipped `tooltip interactions` e2e test for the TimeSeries panel by making its underlying test data deterministic and its panel locator unambiguous.

**Why do we need this feature?**

The test hovers/clicks at hardcoded pixel coordinates on a "Random Walk" testdata panel that used a relative time range. The random walk's seed is derived from the query's absolute from/to timestamps, so a relative range produced different data — and a different line position — on every run, making the fixed coordinates unreliable. Re-enabling the test also surfaced a second, unrelated flake: the `.uplot` locator wasn't scoped to the panel, so it also matched `.uplot` elements from the panel-style preview thumbnails in the options pane, causing a strict-mode violation.

**Who is this feature for?**

Contributors and maintainers who rely on a stable e2e signal for the TimeSeries panel.

**Which issue(s) does this PR fix?**:

Fixes #124170

**Special notes for your reviewer:**

- `devenv/dev-dashboards/panel-timeseries/timeseries.json`: switched the dashboard's time range from relative (`now-30m`/`now`) to a fixed absolute range, and set `startValue: 10` on the "Single mode" panel's (id 19) Random Walk queries — matching the deterministic-data change in #124264.
- `e2e-playwright/panels-suite/timeseries.spec.ts`: un-skipped `tooltip interactions` and scoped the uplot locator to `Panels.Panel.content`.
- Verified locally: `timeseries.spec.ts` full suite passing repeatedly (including 3x repeats of `tooltip interactions` alone), no regressions in the other specs using the same dashboard (`panelEdit_base`, `timeseries-mouse-zoom-interaction`, `solo-route`), and the Go `TestIntegrationSearchDevDashboards` integration test still passes against the edited dashboard file.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.
