### PR TITLE
Provisioning: Fix test flakes from cross-repository dashboard/folder counting

### DIFF
--- a/pkg/tests/apis/provisioning/apiversion/version_test.go
+++ b/pkg/tests/apis/provisioning/apiversion/version_test.go
@@ -208,6 +208,7 @@ func TestIntegrationVersionConsistency(t *testing.T) {
 // when using the typed dynamic client (schema.GroupVersionResource with v1beta1).
 func TestIntegrationDynamicClientVersionConsistency(t *testing.T) {
 	helper := sharedHelper(t)
+
 	repoClient := common.GetRepositoryClientV1Beta1(helper.K8sTestHelper)
 
 	t.Run("create and get", func(t *testing.T) {

--- a/pkg/tests/apis/provisioning/apiversion/version_test.go
+++ b/pkg/tests/apis/provisioning/apiversion/version_test.go
@@ -1,7 +1,6 @@
 package apiversion
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -209,7 +208,6 @@ func TestIntegrationVersionConsistency(t *testing.T) {
 // when using the typed dynamic client (schema.GroupVersionResource with v1beta1).
 func TestIntegrationDynamicClientVersionConsistency(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 	repoClient := common.GetRepositoryClientV1Beta1(helper.K8sTestHelper)
 
 	t.Run("create and get", func(t *testing.T) {
@@ -217,17 +215,17 @@ func TestIntegrationDynamicClientVersionConsistency(t *testing.T) {
 			Object: repositoryBody("dyn-v1beta1-repo", v1beta1APIVersion, helper.ProvisioningPath),
 		}
 
-		created, err := repoClient.Resource.Create(ctx, repo, metav1.CreateOptions{})
+		created, err := repoClient.Resource.Create(t.Context(), repo, metav1.CreateOptions{})
 		require.NoError(t, err)
 		assert.Equal(t, v1beta1APIVersion, created.GetAPIVersion())
 
-		fetched, err := repoClient.Resource.Get(ctx, "dyn-v1beta1-repo", metav1.GetOptions{})
+		fetched, err := repoClient.Resource.Get(t.Context(), "dyn-v1beta1-repo", metav1.GetOptions{})
 		require.NoError(t, err)
 		assert.Equal(t, v1beta1APIVersion, fetched.GetAPIVersion())
 	})
 
 	t.Run("list", func(t *testing.T) {
-		list, err := repoClient.Resource.List(ctx, metav1.ListOptions{})
+		list, err := repoClient.Resource.List(t.Context(), metav1.ListOptions{})
 		require.NoError(t, err)
 		assert.Equal(t, v1beta1APIVersion, list.GetAPIVersion())
 
@@ -243,10 +241,9 @@ func TestIntegrationDynamicClientVersionConsistency(t *testing.T) {
 // endpoints exist with the expected resources.
 func TestIntegrationAPIGroupDiscoveryVersions(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	t.Run("API group lists both versions", func(t *testing.T) {
-		result := helper.AdminREST.Get().AbsPath("/apis/provisioning.grafana.app").Do(ctx)
+		result := helper.AdminREST.Get().AbsPath("/apis/provisioning.grafana.app").Do(t.Context())
 		require.NoError(t, result.Error())
 
 		raw, err := result.Raw()
@@ -266,7 +263,7 @@ func TestIntegrationAPIGroupDiscoveryVersions(t *testing.T) {
 	t.Run("v1beta1 resource list contains expected resources", func(t *testing.T) {
 		result := helper.AdminREST.Get().
 			AbsPath("/apis/provisioning.grafana.app/v1beta1").
-			Do(ctx)
+			Do(t.Context())
 		require.NoError(t, result.Error())
 
 		raw, err := result.Raw()

--- a/pkg/tests/apis/provisioning/bom_test.go
+++ b/pkg/tests/apis/provisioning/bom_test.go
@@ -1,7 +1,6 @@
 package provisioning
 
 import (
-	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -19,7 +18,6 @@ import (
 // TestIntegrationProvisioning_BOMs tests that BOMs in provisioned files are handled correctly
 func TestIntegrationProvisioning_BOMs(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	const repo = "bom-test-repo"
 
@@ -53,7 +51,7 @@ func TestIntegrationProvisioning_BOMs(t *testing.T) {
 		// Wait for dashboard to be provisioned
 		var dashboard *unstructured.Unstructured
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
-			dashboard, err = helper.DashboardsV1.Resource.Get(ctx, "bom-prefix-test", metav1.GetOptions{})
+			dashboard, err = helper.DashboardsV1.Resource.Get(t.Context(), "bom-prefix-test", metav1.GetOptions{})
 			if err != nil {
 				collect.Errorf("could not get dashboard: %s", err.Error())
 				return
@@ -76,7 +74,7 @@ func TestIntegrationProvisioning_BOMs(t *testing.T) {
 		require.NotContains(t, string(dashboardJSON), "\ufeff", "stored dashboard should not contain any BOMs")
 
 		// Cleanup - delete repository
-		err = helper.Repositories.Resource.Delete(ctx, repo, metav1.DeleteOptions{})
+		err = helper.Repositories.Resource.Delete(t.Context(), repo, metav1.DeleteOptions{})
 		require.NoError(t, err)
 	})
 
@@ -123,7 +121,7 @@ func TestIntegrationProvisioning_BOMs(t *testing.T) {
 		// Wait for dashboard to be provisioned
 		var dashboard *unstructured.Unstructured
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
-			dashboard, err = helper.DashboardsV1.Resource.Get(ctx, "bom-embedded-test", metav1.GetOptions{})
+			dashboard, err = helper.DashboardsV1.Resource.Get(t.Context(), "bom-embedded-test", metav1.GetOptions{})
 			if err != nil {
 				collect.Errorf("could not get dashboard: %s", err.Error())
 				return
@@ -159,7 +157,7 @@ func TestIntegrationProvisioning_BOMs(t *testing.T) {
 		require.NotContains(t, panel2Title, "\ufeff")
 
 		// Cleanup
-		err = helper.Repositories.Resource.Delete(ctx, repoName, metav1.DeleteOptions{})
+		err = helper.Repositories.Resource.Delete(t.Context(), repoName, metav1.DeleteOptions{})
 		require.NoError(t, err)
 	})
 
@@ -203,7 +201,7 @@ func TestIntegrationProvisioning_BOMs(t *testing.T) {
 		// Wait for dashboard to be provisioned
 		var dashboard *unstructured.Unstructured
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
-			dashboard, err = helper.DashboardsV1.Resource.Get(ctx, "bom-deletion-test", metav1.GetOptions{})
+			dashboard, err = helper.DashboardsV1.Resource.Get(t.Context(), "bom-deletion-test", metav1.GetOptions{})
 			if err != nil {
 				collect.Errorf("could not get dashboard: %s", err.Error())
 				return
@@ -227,17 +225,17 @@ func TestIntegrationProvisioning_BOMs(t *testing.T) {
 		patchData := []byte(`[
 			{"op": "replace", "path": "/metadata/finalizers", "value": ["cleanup", "release-orphan-resources"]}
 		]`)
-		_, err = helper.Repositories.Resource.Patch(ctx, repoName, types.JSONPatchType, patchData, metav1.PatchOptions{})
+		_, err = helper.Repositories.Resource.Patch(t.Context(), repoName, types.JSONPatchType, patchData, metav1.PatchOptions{})
 		require.NoError(t, err, "should successfully patch finalizers")
 
 		// Delete the repository - finalizer will patch dashboard to remove annotations
 		// The key test: PATCH should succeed even though dashboard has BOMs in spec
-		err = helper.Repositories.Resource.Delete(ctx, repoName, metav1.DeleteOptions{})
+		err = helper.Repositories.Resource.Delete(t.Context(), repoName, metav1.DeleteOptions{})
 		require.NoError(t, err)
 
 		// Wait for repository to be deleted (finalizer has completed)
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
-			_, err = helper.Repositories.Resource.Get(ctx, repoName, metav1.GetOptions{})
+			_, err = helper.Repositories.Resource.Get(t.Context(), repoName, metav1.GetOptions{})
 			if err == nil {
 				collect.Errorf("repository should be deleted")
 				return
@@ -246,7 +244,7 @@ func TestIntegrationProvisioning_BOMs(t *testing.T) {
 		}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "repository should be deleted")
 
 		// Verify dashboard STILL EXISTS (released, not deleted)
-		dashboard, err = helper.DashboardsV1.Resource.Get(ctx, "bom-deletion-test", metav1.GetOptions{})
+		dashboard, err = helper.DashboardsV1.Resource.Get(t.Context(), "bom-deletion-test", metav1.GetOptions{})
 		require.NoError(t, err, "dashboard should still exist after repository deletion")
 
 		// Verify ownership annotations were REMOVED by the finalizer
@@ -298,7 +296,7 @@ spec:
 		// Wait for dashboard to be provisioned
 		var dashboard *unstructured.Unstructured
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
-			dashboard, err = helper.DashboardsV1.Resource.Get(ctx, "bom-yaml-test", metav1.GetOptions{})
+			dashboard, err = helper.DashboardsV1.Resource.Get(t.Context(), "bom-yaml-test", metav1.GetOptions{})
 			if err != nil {
 				collect.Errorf("could not get dashboard: %s", err.Error())
 				return
@@ -313,7 +311,7 @@ spec:
 		require.NotContains(t, title, "\ufeff")
 
 		// Cleanup
-		err = helper.Repositories.Resource.Delete(ctx, repoName, metav1.DeleteOptions{})
+		err = helper.Repositories.Resource.Delete(t.Context(), repoName, metav1.DeleteOptions{})
 		require.NoError(t, err)
 	})
 }

--- a/pkg/tests/apis/provisioning/bom_test.go
+++ b/pkg/tests/apis/provisioning/bom_test.go
@@ -24,10 +24,9 @@ func TestIntegrationProvisioning_BOMs(t *testing.T) {
 	t.Run("dashboard JSON file with UTF-8 BOM prefix", func(t *testing.T) {
 		// Create repository first
 		helper.CreateLocalRepo(t, common.TestRepo{
-			Name:                   repo,
-			LocalPath:              helper.ProvisioningPath,
-			SyncTarget:             "folder",
-			SkipResourceAssertions: true,
+			Name:       repo,
+			LocalPath:  helper.ProvisioningPath,
+			SyncTarget: "folder",
 		})
 
 		// Create a dashboard JSON file with UTF-8 BOM prefix (EF BB BF)
@@ -109,10 +108,9 @@ func TestIntegrationProvisioning_BOMs(t *testing.T) {
 		// Create repository
 		repoName := "bom-embedded-repo"
 		helper.CreateLocalRepo(t, common.TestRepo{
-			Name:                   repoName,
-			LocalPath:              helper.ProvisioningPath,
-			SyncTarget:             "folder",
-			SkipResourceAssertions: true,
+			Name:       repoName,
+			LocalPath:  helper.ProvisioningPath,
+			SyncTarget: "folder",
 		})
 
 		// Trigger sync to provision the dashboard
@@ -183,10 +181,9 @@ func TestIntegrationProvisioning_BOMs(t *testing.T) {
 		// Create repository first
 		repoName := "bom-deletion-repo"
 		helper.CreateLocalRepo(t, common.TestRepo{
-			Name:                   repoName,
-			LocalPath:              helper.ProvisioningPath,
-			SyncTarget:             "folder",
-			SkipResourceAssertions: true,
+			Name:       repoName,
+			LocalPath:  helper.ProvisioningPath,
+			SyncTarget: "folder",
 		})
 
 		// Now create the dashboard file with BOMs
@@ -279,10 +276,9 @@ spec:
 		// Create repository first
 		repoName := "bom-yaml-repo"
 		helper.CreateLocalRepo(t, common.TestRepo{
-			Name:                   repoName,
-			LocalPath:              helper.ProvisioningPath,
-			SyncTarget:             "folder",
-			SkipResourceAssertions: true,
+			Name:       repoName,
+			LocalPath:  helper.ProvisioningPath,
+			SyncTarget: "folder",
 		})
 
 		testFile := filepath.Join(helper.ProvisioningPath, "bom-yaml-dashboard.yaml")

--- a/pkg/tests/apis/provisioning/classic_delete_test.go
+++ b/pkg/tests/apis/provisioning/classic_delete_test.go
@@ -33,11 +33,11 @@ func TestIntegrationProvisioning_ClassicDashboardDeletion(t *testing.T) {
 			Copies: map[string]string{
 				"testdata/all-panels.json": "dashboard1.json",
 			},
-			SkipResourceAssertions: true,
 		})
 
-		// Verify the classic dashboard was created (all-panels.json has uid "n1jR8vnnz")
 		helper.RequireRepoDashboardCount(t, repo, 1)
+
+		// Verify the classic dashboard was created (all-panels.json has uid "n1jR8vnnz")
 		_, err := helper.DashboardsV1.Resource.Get(t.Context(), "n1jR8vnnz", metav1.GetOptions{})
 		require.NoError(t, err, "classic dashboard should exist after initial sync")
 
@@ -71,14 +71,14 @@ func TestIntegrationProvisioning_ClassicDashboardDeletion(t *testing.T) {
 		require.NoError(t, err)
 
 		helper.CreateLocalRepo(t, common.TestRepo{
-			Name:                   repo,
-			LocalPath:              repoPath,
-			SyncTarget:             "folder",
-			SkipResourceAssertions: true,
+			Name:       repo,
+			LocalPath:  repoPath,
+			SyncTarget: "folder",
 		})
 
-		// Verify the dashboard was created
 		helper.RequireRepoDashboardCount(t, repo, 1)
+
+		// Verify the dashboard was created
 		_, err = helper.DashboardsV1.Resource.Get(t.Context(), "inline-classic-uid", metav1.GetOptions{})
 		require.NoError(t, err, "inline classic dashboard should exist after initial sync")
 
@@ -111,10 +111,9 @@ func TestIntegrationProvisioning_ClassicDashboardDeletion(t *testing.T) {
 		require.NoError(t, err)
 
 		helper.CreateLocalRepo(t, common.TestRepo{
-			Name:                   repo,
-			LocalPath:              repoPath,
-			SyncTarget:             "folder",
-			SkipResourceAssertions: true,
+			Name:       repo,
+			LocalPath:  repoPath,
+			SyncTarget: "folder",
 		})
 
 		helper.RequireRepoDashboardCount(t, repo, 1)
@@ -177,10 +176,9 @@ func TestIntegrationProvisioning_ClassicDashboardDeletion(t *testing.T) {
 		require.NoError(t, err)
 
 		helper.CreateLocalRepo(t, common.TestRepo{
-			Name:                   repo,
-			LocalPath:              repoPath,
-			SyncTarget:             "folder",
-			SkipResourceAssertions: true,
+			Name:       repo,
+			LocalPath:  repoPath,
+			SyncTarget: "folder",
 		})
 
 		// Verify both dashboards were created

--- a/pkg/tests/apis/provisioning/client_test.go
+++ b/pkg/tests/apis/provisioning/client_test.go
@@ -1,7 +1,6 @@
 package provisioning
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -15,13 +14,12 @@ import (
 func TestIntegrationProvisioning_Client(t *testing.T) {
 	helper := sharedHelper(t)
 
-	ctx := context.Background()
 	clientFactory := resources.NewClientFactory(&helper.Org1.Admin)
-	clients, err := clientFactory.Clients(ctx, "default")
+	clients, err := clientFactory.Clients(t.Context(), "default")
 	require.NoError(t, err)
 
 	t.Run("dashboard client support", func(t *testing.T) {
-		_, _, err := clients.ForResource(ctx, schema.GroupVersionResource{
+		_, _, err := clients.ForResource(t.Context(), schema.GroupVersionResource{
 			Group:    dashboardV2.GROUP,
 			Version:  dashboardV2.VERSION,
 			Resource: "dashboards",
@@ -29,7 +27,7 @@ func TestIntegrationProvisioning_Client(t *testing.T) {
 		require.NoError(t, err)
 
 		// With empty version, we should get the preferred version (v2)
-		_, gvk, err := clients.ForResource(ctx, schema.GroupVersionResource{
+		_, gvk, err := clients.ForResource(t.Context(), schema.GroupVersionResource{
 			Group:    dashboardV2.GROUP,
 			Resource: "dashboards",
 		})
@@ -37,7 +35,7 @@ func TestIntegrationProvisioning_Client(t *testing.T) {
 		require.Equal(t, dashboardV2.VERSION, gvk.Version)
 		require.Equal(t, "Dashboard", gvk.Kind)
 
-		_, _, err = clients.ForKind(ctx, schema.GroupVersionKind{
+		_, _, err = clients.ForKind(t.Context(), schema.GroupVersionKind{
 			Group:   dashboardV2.GROUP,
 			Version: dashboardV2.VERSION,
 			Kind:    "Dashboard",

--- a/pkg/tests/apis/provisioning/common/testing.go
+++ b/pkg/tests/apis/provisioning/common/testing.go
@@ -190,27 +190,26 @@ func (h *ProvisioningTestHelper) WithNamespace(t *testing.T, namespace string, u
 // This should be called (typically via defer) after tests that create resources in specific namespaces.
 func (h *ProvisioningTestHelper) Cleanup(t *testing.T) {
 	t.Helper()
-	ctx := context.Background()
 
 	// Delete all repositories
-	if err := h.Repositories.Resource.DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{}); err != nil && !apierrors.IsNotFound(err) {
+	if err := h.Repositories.Resource.DeleteCollection(t.Context(), metav1.DeleteOptions{}, metav1.ListOptions{}); err != nil && !apierrors.IsNotFound(err) {
 		t.Logf("warning: failed to delete repositories: %v", err)
 	}
 
 	// Delete all connections
-	if err := h.Connections.Resource.DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{}); err != nil && !apierrors.IsNotFound(err) {
+	if err := h.Connections.Resource.DeleteCollection(t.Context(), metav1.DeleteOptions{}, metav1.ListOptions{}); err != nil && !apierrors.IsNotFound(err) {
 		t.Logf("warning: failed to delete connections: %v", err)
 	}
 
 	// Delete all folders
-	if err := h.Folders.Resource.DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{}); err != nil && !apierrors.IsNotFound(err) {
+	if err := h.Folders.Resource.DeleteCollection(t.Context(), metav1.DeleteOptions{}, metav1.ListOptions{}); err != nil && !apierrors.IsNotFound(err) {
 		t.Logf("warning: failed to delete folders: %v", err)
 	}
 
 	// Delete all dashboards (V0, V1, V2, V2alpha1, V2beta1)
 	for _, client := range []*apis.K8sResourceClient{h.DashboardsV0, h.DashboardsV1, h.DashboardsV2, h.DashboardsV2alpha1, h.DashboardsV2beta1} {
 		if client != nil {
-			if err := client.Resource.DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			if err := client.Resource.DeleteCollection(t.Context(), metav1.DeleteOptions{}, metav1.ListOptions{}); err != nil && !apierrors.IsNotFound(err) {
 				t.Logf("warning: failed to delete dashboards: %v", err)
 			}
 		}
@@ -267,7 +266,7 @@ func (h *ProvisioningTestHelper) SyncAndWait(t *testing.T, repo string, options 
 	// to the historic subresource that check trivially passes (0 >= 0) and
 	// SyncAndWait returns without having waited for the sync to complete,
 	// causing flakes in callers that immediately list provisioned resources.
-	job := h.AwaitJob(t, t.Context(), unstruct)
+	job := h.AwaitJob(t, unstruct)
 	state := MustNestedString(job.Object, "status", "state")
 	if state == string(provisioning.JobStateError) {
 		h.DebugState(t, repo, fmt.Sprintf("SYNC FAILED: %s", name))
@@ -303,7 +302,7 @@ func (h *ProvisioningTestHelper) TriggerJobAndWaitForSuccess(t *testing.T, repo 
 
 	name := unstruct.GetName()
 	require.NotEmpty(t, name, "expecting name to be set")
-	h.AwaitJobSuccess(t, t.Context(), unstruct)
+	h.AwaitJobSuccess(t, unstruct)
 }
 
 func (h *ProvisioningTestHelper) TriggerJobAndWaitForComplete(t *testing.T, repo string, spec provisioning.JobSpec) *unstructured.Unstructured {
@@ -334,7 +333,7 @@ func (h *ProvisioningTestHelper) TriggerJobAndWaitForComplete(t *testing.T, repo
 	name := unstruct.GetName()
 	require.NotEmpty(t, name, "expecting name to be set")
 
-	return h.AwaitJob(t, t.Context(), unstruct)
+	return h.AwaitJob(t, unstruct)
 }
 
 // CreatePullJob creates a pull Job resource directly, bypassing the
@@ -400,9 +399,9 @@ func (h *ProvisioningTestHelper) AwaitLatestHistoricJob(t *testing.T, repo strin
 	return latest.DeepCopy()
 }
 
-func (h *ProvisioningTestHelper) AwaitJobSuccess(t *testing.T, ctx context.Context, job *unstructured.Unstructured) {
+func (h *ProvisioningTestHelper) AwaitJobSuccess(t *testing.T, job *unstructured.Unstructured) {
 	t.Helper()
-	job = h.AwaitJob(t, ctx, job)
+	job = h.AwaitJob(t, job)
 	lastErrors := MustNestedStringSlice(job.Object, "status", "errors")
 	lastState := MustNestedString(job.Object, "status", "state")
 	// A worker that returns an error records it in status.message, not
@@ -424,7 +423,7 @@ func (h *ProvisioningTestHelper) AwaitJobSuccess(t *testing.T, ctx context.Conte
 		"historic job '%s' was not successful (message: %q)", job.GetName(), lastMessage)
 }
 
-func (h *ProvisioningTestHelper) AwaitJob(t *testing.T, ctx context.Context, job *unstructured.Unstructured) *unstructured.Unstructured {
+func (h *ProvisioningTestHelper) AwaitJob(t *testing.T, job *unstructured.Unstructured) *unstructured.Unstructured {
 	t.Helper()
 
 	repo := job.GetLabels()[jobs.LabelRepository]
@@ -432,7 +431,7 @@ func (h *ProvisioningTestHelper) AwaitJob(t *testing.T, ctx context.Context, job
 
 	var lastResult *unstructured.Unstructured
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		result, err := h.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{},
+		result, err := h.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{},
 			"jobs", string(job.GetUID()))
 
 		if !assert.False(collect, apierrors.IsNotFound(err)) {
@@ -651,14 +650,12 @@ func (h *ProvisioningTestHelper) DebugState(t *testing.T, repo string, label str
 	t.Helper()
 	t.Logf("=== DEBUG STATE: %s ===", label)
 
-	ctx := context.Background()
-
 	// Log filesystem contents using existing tree function
 	PrintFileTree(t, h.ProvisioningPath)
 
 	// Log all repositories first
 	t.Logf("All repositories:")
-	repos, err := h.Repositories.Resource.List(ctx, metav1.ListOptions{})
+	repos, err := h.Repositories.Resource.List(t.Context(), metav1.ListOptions{})
 	if err != nil {
 		t.Logf("  ERROR listing repositories: %v", err)
 	} else {
@@ -670,7 +667,7 @@ func (h *ProvisioningTestHelper) DebugState(t *testing.T, repo string, label str
 
 	// Log repository files for the specific repo
 	t.Logf("Repository '%s' files:", repo)
-	h.logRepositoryFiles(t, ctx, repo, "  ")
+	h.logRepositoryFiles(t, repo, "  ")
 
 	// Log files for all other repositories too
 	if repos != nil && len(repos.Items) > 1 {
@@ -678,14 +675,14 @@ func (h *ProvisioningTestHelper) DebugState(t *testing.T, repo string, label str
 		for _, repository := range repos.Items {
 			if repository.GetName() != repo {
 				t.Logf("  Repository '%s' files:", repository.GetName())
-				h.logRepositoryFiles(t, ctx, repository.GetName(), "    ")
+				h.logRepositoryFiles(t, repository.GetName(), "    ")
 			}
 		}
 	}
 
 	// Log Grafana dashboards
 	t.Logf("Grafana dashboards:")
-	dashboards, err := h.DashboardsV1.Resource.List(ctx, metav1.ListOptions{})
+	dashboards, err := h.DashboardsV1.Resource.List(t.Context(), metav1.ListOptions{})
 	if err != nil {
 		t.Logf("  ERROR listing dashboards: %v", err)
 	} else {
@@ -697,7 +694,7 @@ func (h *ProvisioningTestHelper) DebugState(t *testing.T, repo string, label str
 
 	// Log Grafana folders
 	t.Logf("Grafana folders:")
-	folders, err := h.Folders.Resource.List(ctx, metav1.ListOptions{})
+	folders, err := h.Folders.Resource.List(t.Context(), metav1.ListOptions{})
 	if err != nil {
 		t.Logf("  ERROR listing folders: %v", err)
 	} else {
@@ -711,11 +708,11 @@ func (h *ProvisioningTestHelper) DebugState(t *testing.T, repo string, label str
 }
 
 // logRepositoryFiles logs repository file structure using the files API
-func (h *ProvisioningTestHelper) logRepositoryFiles(t *testing.T, ctx context.Context, repoName string, prefix string) {
+func (h *ProvisioningTestHelper) logRepositoryFiles(t *testing.T, repoName string, prefix string) {
 	t.Helper()
 
 	// Try to list files at root level
-	files, err := h.Repositories.Resource.Get(ctx, repoName, metav1.GetOptions{}, "files")
+	files, err := h.Repositories.Resource.Get(t.Context(), repoName, metav1.GetOptions{}, "files")
 	if err != nil {
 		t.Logf("%sERROR getting repository files: %v", prefix, err)
 		return
@@ -787,7 +784,7 @@ func (h *ProvisioningTestHelper) logRepositoryObject(t *testing.T, obj map[strin
 // If folder is nested, folder annotations should not be empty.
 // Also checks that the managerId property exists.
 func (h *ProvisioningTestHelper) ValidateManagedDashboardsFolderMetadata(t *testing.T,
-	ctx context.Context, repoName string, dashboards []unstructured.Unstructured) {
+	repoName string, dashboards []unstructured.Unstructured) {
 	t.Helper()
 
 	// Check if folder is nested or not.
@@ -1172,7 +1169,6 @@ func (h *ProvisioningTestHelper) RequireRepoFolderCount(t *testing.T, repoName s
 // concurrent controller reconciliations.
 func (h *ProvisioningTestHelper) TriggerConnectionReconciliation(t *testing.T, name string) {
 	t.Helper()
-	ctx := t.Context()
 	statusPatch, err := json.Marshal(map[string]any{
 		"status": map[string]any{
 			"health": map[string]any{
@@ -1181,7 +1177,7 @@ func (h *ProvisioningTestHelper) TriggerConnectionReconciliation(t *testing.T, n
 		},
 	})
 	require.NoError(t, err)
-	_, err = h.Connections.Resource.Patch(ctx, name,
+	_, err = h.Connections.Resource.Patch(t.Context(), name,
 		types.MergePatchType, statusPatch, metav1.PatchOptions{}, "status")
 	require.NoError(t, err, "failed to patch status for connection %s", name)
 }
@@ -1193,7 +1189,6 @@ func (h *ProvisioningTestHelper) TriggerConnectionReconciliation(t *testing.T, n
 // conflicts with concurrent controller reconciliations.
 func (h *ProvisioningTestHelper) TriggerRepositoryReconciliation(t *testing.T, name string) {
 	t.Helper()
-	ctx := t.Context()
 	statusPatch, err := json.Marshal(map[string]any{
 		"status": map[string]any{
 			"health": map[string]any{
@@ -1202,7 +1197,7 @@ func (h *ProvisioningTestHelper) TriggerRepositoryReconciliation(t *testing.T, n
 		},
 	})
 	require.NoError(t, err)
-	_, err = h.Repositories.Resource.Patch(ctx, name,
+	_, err = h.Repositories.Resource.Patch(t.Context(), name,
 		types.MergePatchType, statusPatch, metav1.PatchOptions{}, "status")
 	require.NoError(t, err, "failed to patch status for repository %s", name)
 }
@@ -1269,9 +1264,8 @@ func (h *ProvisioningTestHelper) WaitForHealthyConnection(t *testing.T, name str
 // that first brings the repository to healthy.
 func (h *ProvisioningTestHelper) RequireRepositoryReReconciles(t *testing.T, name string) {
 	t.Helper()
-	ctx := t.Context()
 
-	obj, err := h.Repositories.Resource.Get(ctx, name, metav1.GetOptions{})
+	obj, err := h.Repositories.Resource.Get(t.Context(), name, metav1.GetOptions{})
 	require.NoError(t, err, "failed to get repository %s", name)
 	before, found := mustNestedInt64(obj.Object, "status", "health", "checked")
 	require.True(t, found, "repository %s should already have a health checked timestamp", name)
@@ -1279,7 +1273,7 @@ func (h *ProvisioningTestHelper) RequireRepositoryReReconciles(t *testing.T, nam
 	h.TriggerRepositoryReconciliation(t, name)
 
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		cur, err := h.Repositories.Resource.Get(ctx, name, metav1.GetOptions{})
+		cur, err := h.Repositories.Resource.Get(t.Context(), name, metav1.GetOptions{})
 		if !assert.NoError(collect, err, "failed to get repository %s", name) {
 			return
 		}
@@ -1292,10 +1286,10 @@ func (h *ProvisioningTestHelper) RequireRepositoryReReconciles(t *testing.T, nam
 // WaitForRepositoryDeleted polls until the named repository reports NotFound.
 // Repository deletion is finalizer-driven (cleanup → release/remove orphan
 // resources); on loaded CI runners the chain routinely exceeds short bounds.
-func (h *ProvisioningTestHelper) WaitForRepositoryDeleted(t *testing.T, ctx context.Context, name string) {
+func (h *ProvisioningTestHelper) WaitForRepositoryDeleted(t *testing.T, name string) {
 	t.Helper()
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		_, err := h.Repositories.Resource.Get(ctx, name, metav1.GetOptions{})
+		_, err := h.Repositories.Resource.Get(t.Context(), name, metav1.GetOptions{})
 		assert.True(collect, apierrors.IsNotFound(err), "repository %s should be deleted", name)
 	}, WaitTimeoutDefault, WaitIntervalDefault, "repository %s should be deleted", name)
 }
@@ -1303,10 +1297,10 @@ func (h *ProvisioningTestHelper) WaitForRepositoryDeleted(t *testing.T, ctx cont
 // WaitForResourcesReleased polls until every item returned by client no longer
 // carries provisioning-manager annotations — i.e. the release-orphan-resources
 // finalizer has finished handing the objects back to the user.
-func WaitForResourcesReleased(t *testing.T, ctx context.Context, client dynamic.ResourceInterface, resourceKind string) {
+func WaitForResourcesReleased(t *testing.T, client dynamic.ResourceInterface, resourceKind string) {
 	t.Helper()
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		items, err := client.List(ctx, metav1.ListOptions{})
+		items, err := client.List(t.Context(), metav1.ListOptions{})
 		if !assert.NoError(collect, err, "can list %s", resourceKind) {
 			return
 		}
@@ -1323,10 +1317,10 @@ func WaitForResourcesReleased(t *testing.T, ctx context.Context, client dynamic.
 // WaitForResourcesDeleted polls until the given client lists zero items.
 // Use this after a repository delete when the remove-orphan-resources
 // finalizer should have swept the managed resources away.
-func WaitForResourcesDeleted(t *testing.T, ctx context.Context, client dynamic.ResourceInterface, resourceKind string) {
+func WaitForResourcesDeleted(t *testing.T, client dynamic.ResourceInterface, resourceKind string) {
 	t.Helper()
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		items, err := client.List(ctx, metav1.ListOptions{})
+		items, err := client.List(t.Context(), metav1.ListOptions{})
 		if !assert.NoError(collect, err, "can list %s", resourceKind) {
 			return
 		}
@@ -1336,11 +1330,11 @@ func WaitForResourcesDeleted(t *testing.T, ctx context.Context, client dynamic.R
 
 // RequireResource polls until the named resource is gettable via client and returns it.
 // Use after a write/sync to assert a resource has been provisioned into Grafana.
-func RequireResource(t *testing.T, ctx context.Context, client dynamic.ResourceInterface, name string) *unstructured.Unstructured {
+func RequireResource(t *testing.T, client dynamic.ResourceInterface, name string) *unstructured.Unstructured {
 	t.Helper()
 	var got *unstructured.Unstructured
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		obj, err := client.Get(ctx, name, metav1.GetOptions{})
+		obj, err := client.Get(t.Context(), name, metav1.GetOptions{})
 		if !assert.NoError(collect, err, "get %q", name) {
 			return
 		}
@@ -1635,7 +1629,7 @@ func buildProvisioningHelper(t *testing.T, k8sHelper *apis.K8sTestHelper, provis
 		DashboardsV2beta1:  dashboardsV2beta1Client,
 	}
 
-	h.CleanupAllResources(t, context.Background())
+	h.CleanupAllResources(t)
 
 	return h
 }
@@ -1742,7 +1736,7 @@ func deleteAndWait(ctx context.Context, client dynamic.ResourceInterface, timeou
 // (see git history) only masks it. Cleanup deletes every folder anyway, so the
 // empty-folder check serves no purpose here; bypassing it makes folder cleanup
 // deterministic instead of racing the index.
-func (h *ProvisioningTestHelper) CleanupAllResources(t *testing.T, ctx context.Context) {
+func (h *ProvisioningTestHelper) CleanupAllResources(t *testing.T) {
 	t.Helper()
 	forceDelete := metav1.DeleteOptions{GracePeriodSeconds: new(int64)} // gracePeriodSeconds=0
 	for _, c := range []struct {
@@ -1756,7 +1750,7 @@ func (h *ProvisioningTestHelper) CleanupAllResources(t *testing.T, ctx context.C
 		{"dashboards", h.DashboardsV1.Resource, waitTimeoutCleanup, metav1.DeleteOptions{}},
 		{"folders", h.Folders.Resource, waitTimeoutFolderCleanup, forceDelete},
 	} {
-		if err := deleteAndWait(ctx, c.client, c.timeout, c.deleteOpts); err != nil {
+		if err := deleteAndWait(t.Context(), c.client, c.timeout, c.deleteOpts); err != nil {
 			t.Fatalf("CleanupAllResources(%s): %v", c.name, err)
 		}
 	}
@@ -1814,7 +1808,7 @@ func (e *SharedEnv) GetHelper(t *testing.T) *ProvisioningTestHelper {
 func (e *SharedEnv) GetCleanHelper(t *testing.T) *ProvisioningTestHelper {
 	t.Helper()
 	h := e.GetHelper(t)
-	h.CleanupAllResources(t, context.Background())
+	h.CleanupAllResources(t)
 	return h
 }
 
@@ -1965,14 +1959,14 @@ func (h *ProvisioningTestHelper) PostFilesRequest(t *testing.T, repo string, opt
 // (GET .../files/). It is a directory listing only — it does not parse resources or run
 // a dry-run, so it is safe to call regardless of whether the files are already
 // provisioned in Grafana.
-func (h *ProvisioningTestHelper) ListRepositoryFiles(t *testing.T, ctx context.Context, repo string) []provisioning.FileItem {
+func (h *ProvisioningTestHelper) ListRepositoryFiles(t *testing.T, repo string) []provisioning.FileItem {
 	t.Helper()
 	rsp := h.AdminREST.Get().
 		Namespace("default").
 		Resource("repositories").
 		Name(repo).
 		Suffix("files/").
-		Do(ctx)
+		Do(t.Context())
 	require.NoError(t, rsp.Error(), "listing repository files should succeed")
 	list := &provisioning.FileList{}
 	require.NoError(t, rsp.Into(list))
@@ -2076,20 +2070,20 @@ func FolderBody(t *testing.T, uid, title string) []byte {
 }
 
 // ReadFolderUID reads the folder UID (metadata.name) from the _folder.json at the given path.
-func (c *FilesClient) ReadFolderUID(t *testing.T, ctx context.Context, metadataPath string) string {
+func (c *FilesClient) ReadFolderUID(t *testing.T, metadataPath string) string {
 	t.Helper()
-	return c.readFolderField(t, ctx, metadataPath, "metadata", "name")
+	return c.readFolderField(t, metadataPath, "metadata", "name")
 }
 
 // ReadFolderTitle reads the folder title (spec.title) from the _folder.json at the given path.
-func (c *FilesClient) ReadFolderTitle(t *testing.T, ctx context.Context, metadataPath string) string {
+func (c *FilesClient) ReadFolderTitle(t *testing.T, metadataPath string) string {
 	t.Helper()
-	return c.readFolderField(t, ctx, metadataPath, "spec", "title")
+	return c.readFolderField(t, metadataPath, "spec", "title")
 }
 
-func (c *FilesClient) readFolderField(t *testing.T, ctx context.Context, metadataPath string, fields ...string) string {
+func (c *FilesClient) readFolderField(t *testing.T, metadataPath string, fields ...string) string {
 	t.Helper()
-	wrapObj, err := c.helper.Repositories.Resource.Get(ctx, c.repo, metav1.GetOptions{}, "files", metadataPath)
+	wrapObj, err := c.helper.Repositories.Resource.Get(t.Context(), c.repo, metav1.GetOptions{}, "files", metadataPath)
 	require.NoError(t, err, "%s: should be readable via the files endpoint", metadataPath)
 	keyPath := append([]string{"resource", "file"}, fields...)
 	val, _, _ := unstructured.NestedString(wrapObj.Object, keyPath...)
@@ -2098,9 +2092,9 @@ func (c *FilesClient) readFolderField(t *testing.T, ctx context.Context, metadat
 
 // RequireValidFolderMetadata reads the _folder.json at folderPath/_folder.json,
 // asserts it has a valid apiVersion, kind, non-empty UID and title, and returns (uid, title).
-func (c *FilesClient) RequireValidFolderMetadata(t *testing.T, ctx context.Context, folderMetadataPath string) (uid, title string) {
+func (c *FilesClient) RequireValidFolderMetadata(t *testing.T, folderMetadataPath string) (uid, title string) {
 	t.Helper()
-	wrapObj, err := c.helper.Repositories.Resource.Get(ctx, c.repo, metav1.GetOptions{}, "files", folderMetadataPath)
+	wrapObj, err := c.helper.Repositories.Resource.Get(t.Context(), c.repo, metav1.GetOptions{}, "files", folderMetadataPath)
 	require.NoError(t, err, "%s: _folder.json should be readable via the files endpoint", folderMetadataPath)
 
 	apiVersion, _, _ := unstructured.NestedString(wrapObj.Object, "resource", "file", "apiVersion")
@@ -2174,17 +2168,16 @@ func CountFilesInDir(rootPath string) (int, error) {
 // CleanupAllRepos deletes all repositories and waits for them to be fully removed
 func (h *ProvisioningTestHelper) CleanupAllRepos(t *testing.T) {
 	t.Helper()
-	ctx := context.Background()
 
 	// First, get all repositories that exist
-	list, err := h.Repositories.Resource.List(ctx, metav1.ListOptions{})
+	list, err := h.Repositories.Resource.List(t.Context(), metav1.ListOptions{})
 	if err != nil || len(list.Items) == 0 {
 		return // Nothing to clean up
 	}
 
 	// Wait for any active jobs to complete before deleting repositories
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		activeJobs, err := h.Jobs.Resource.List(ctx, metav1.ListOptions{})
+		activeJobs, err := h.Jobs.Resource.List(t.Context(), metav1.ListOptions{})
 		if !assert.NoError(collect, err, "failed to list active jobs") {
 			return
 		}
@@ -2193,13 +2186,13 @@ func (h *ProvisioningTestHelper) CleanupAllRepos(t *testing.T) {
 
 	// Now delete all repositories with retries
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		list, err := h.Repositories.Resource.List(ctx, metav1.ListOptions{})
+		list, err := h.Repositories.Resource.List(t.Context(), metav1.ListOptions{})
 		if !assert.NoError(collect, err) {
 			return
 		}
 
 		for _, repo := range list.Items {
-			err := h.Repositories.Resource.Delete(ctx, repo.GetName(), metav1.DeleteOptions{})
+			err := h.Repositories.Resource.Delete(t.Context(), repo.GetName(), metav1.DeleteOptions{})
 			// Don't fail if already deleted (404 is OK)
 			if err != nil {
 				assert.True(collect, apierrors.IsNotFound(err), "Should be able to delete repository %s (or it should already be deleted)", repo.GetName())
@@ -2209,7 +2202,7 @@ func (h *ProvisioningTestHelper) CleanupAllRepos(t *testing.T) {
 
 	// Then wait for repositories to be fully deleted to ensure clean state
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		list, err := h.Repositories.Resource.List(ctx, metav1.ListOptions{})
+		list, err := h.Repositories.Resource.List(t.Context(), metav1.ListOptions{})
 		if !assert.NoError(collect, err) {
 			return
 		}
@@ -2219,7 +2212,7 @@ func (h *ProvisioningTestHelper) CleanupAllRepos(t *testing.T) {
 
 func (h *ProvisioningTestHelper) CreateGithubConnection(
 	t *testing.T,
-	ctx context.Context,
+
 	connection *unstructured.Unstructured,
 ) (*unstructured.Unstructured, error) {
 	t.Helper()
@@ -2231,7 +2224,7 @@ func (h *ProvisioningTestHelper) CreateGithubConnection(
 
 	var res *unstructured.Unstructured
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		res, err = h.Connections.Resource.Create(ctx, connection, metav1.CreateOptions{FieldValidation: "Strict"})
+		res, err = h.Connections.Resource.Create(t.Context(), connection, metav1.CreateOptions{FieldValidation: "Strict"})
 		require.NoError(collect, err)
 	}, WaitTimeoutDefault, WaitIntervalDefault, "connection should be created")
 
@@ -2240,7 +2233,7 @@ func (h *ProvisioningTestHelper) CreateGithubConnection(
 
 func (h *ProvisioningTestHelper) UpdateGithubConnection(
 	t *testing.T,
-	ctx context.Context,
+
 	connection *unstructured.Unstructured,
 ) (*unstructured.Unstructured, error) {
 	t.Helper()
@@ -2252,7 +2245,7 @@ func (h *ProvisioningTestHelper) UpdateGithubConnection(
 
 	var res *unstructured.Unstructured
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		res, err = h.Connections.Resource.Update(ctx, connection, metav1.UpdateOptions{FieldValidation: "Strict"})
+		res, err = h.Connections.Resource.Update(t.Context(), connection, metav1.UpdateOptions{FieldValidation: "Strict"})
 		require.NoError(collect, err)
 	}, WaitTimeoutDefault, WaitIntervalDefault, "connection should be updated")
 
@@ -2425,10 +2418,10 @@ type ExpectedDashboard struct {
 }
 
 // RequireDashboardCount asserts the total number of dashboards in the instance.
-func RequireDashboardCount(t *testing.T, dashboardClient *apis.K8sResourceClient, ctx context.Context, expected int) {
+func RequireDashboardCount(t *testing.T, dashboardClient *apis.K8sResourceClient, expected int) {
 	t.Helper()
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		list, err := dashboardClient.Resource.List(ctx, metav1.ListOptions{})
+		list, err := dashboardClient.Resource.List(t.Context(), metav1.ListOptions{})
 		if !assert.NoError(c, err, "failed to list dashboards") {
 			return
 		}
@@ -2440,10 +2433,10 @@ func RequireDashboardCount(t *testing.T, dashboardClient *apis.K8sResourceClient
 // available in unified storage and is annotated as managed by the named repo
 // at the given source path. Polls until the assertions hold or the default
 // wait timeout elapses.
-func RequireRepoManagedDashboard(t *testing.T, dashboardClient *apis.K8sResourceClient, ctx context.Context, uid, repoName, sourcePath string) {
+func RequireRepoManagedDashboard(t *testing.T, dashboardClient *apis.K8sResourceClient, uid, repoName, sourcePath string) {
 	t.Helper()
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		dash, err := dashboardClient.Resource.Get(ctx, uid, metav1.GetOptions{})
+		dash, err := dashboardClient.Resource.Get(t.Context(), uid, metav1.GetOptions{})
 		if !assert.NoError(c, err) {
 			return
 		}
@@ -2456,10 +2449,10 @@ func RequireRepoManagedDashboard(t *testing.T, dashboardClient *apis.K8sResource
 
 // RequireDashboardTitle asserts that the dashboard with the given uid (K8s name)
 // has the expected title.
-func RequireDashboardTitle(t *testing.T, dashboardClient *apis.K8sResourceClient, ctx context.Context, uid, expectedTitle string) {
+func RequireDashboardTitle(t *testing.T, dashboardClient *apis.K8sResourceClient, uid, expectedTitle string) {
 	t.Helper()
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		list, err := dashboardClient.Resource.List(ctx, metav1.ListOptions{})
+		list, err := dashboardClient.Resource.List(t.Context(), metav1.ListOptions{})
 		if !assert.NoError(c, err, "failed to list dashboards") {
 			return
 		}
@@ -2477,10 +2470,10 @@ func RequireDashboardTitle(t *testing.T, dashboardClient *apis.K8sResourceClient
 
 // RequireDashboards lists dashboards once and asserts that exactly the expected
 // set exists with matching count, title, and grafana.app/sourcePath for each UID.
-func RequireDashboards(t *testing.T, dashboardClient *apis.K8sResourceClient, ctx context.Context, expected map[string]ExpectedDashboard) {
+func RequireDashboards(t *testing.T, dashboardClient *apis.K8sResourceClient, expected map[string]ExpectedDashboard) {
 	t.Helper()
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		list, err := dashboardClient.Resource.List(ctx, metav1.ListOptions{})
+		list, err := dashboardClient.Resource.List(t.Context(), metav1.ListOptions{})
 		if !assert.NoError(c, err, "failed to list dashboards") {
 			return
 		}
@@ -2507,10 +2500,10 @@ func RequireDashboards(t *testing.T, dashboardClient *apis.K8sResourceClient, ct
 
 // RequireRepoDashboardParent asserts that the dashboard managed by repoName at
 // the given sourcePath is parented to the expected folder UID.
-func RequireRepoDashboardParent(t *testing.T, dashboardClient *apis.K8sResourceClient, ctx context.Context, repoName, sourcePath, expectedFolderUID string) {
+func RequireRepoDashboardParent(t *testing.T, dashboardClient *apis.K8sResourceClient, repoName, sourcePath, expectedFolderUID string) {
 	t.Helper()
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		list, err := dashboardClient.Resource.List(ctx, metav1.ListOptions{})
+		list, err := dashboardClient.Resource.List(t.Context(), metav1.ListOptions{})
 		if !assert.NoError(c, err, "failed to list dashboards") {
 			return
 		}
@@ -2532,11 +2525,11 @@ func RequireRepoDashboardParent(t *testing.T, dashboardClient *apis.K8sResourceC
 
 // RequireRepoFolderTitle asserts that a folder managed by repoName exists with
 // the given title and returns its UID.
-func RequireRepoFolderTitle(t *testing.T, folderClient *apis.K8sResourceClient, ctx context.Context, repoName, expectedTitle string) string {
+func RequireRepoFolderTitle(t *testing.T, folderClient *apis.K8sResourceClient, repoName, expectedTitle string) string {
 	t.Helper()
 	var folderUID string
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		list, err := folderClient.Resource.List(ctx, metav1.ListOptions{})
+		list, err := folderClient.Resource.List(t.Context(), metav1.ListOptions{})
 		if !assert.NoError(c, err, "failed to list folders") {
 			return
 		}
@@ -2559,10 +2552,10 @@ func RequireRepoFolderTitle(t *testing.T, folderClient *apis.K8sResourceClient, 
 
 // RequireRepoFolderTitle asserts that a folder managed by repoName exists with
 // the given title and returns its UID.
-func RequireRepoFolderUID(t *testing.T, folderClient *apis.K8sResourceClient, ctx context.Context, repoName, expectedUID string) {
+func RequireRepoFolderUID(t *testing.T, folderClient *apis.K8sResourceClient, repoName, expectedUID string) {
 	t.Helper()
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		folder, err := folderClient.Resource.Get(ctx, expectedUID, metav1.GetOptions{})
+		folder, err := folderClient.Resource.Get(t.Context(), expectedUID, metav1.GetOptions{})
 		require.NoError(c, err, "failed to get folder")
 		mgr, _, _ := unstructured.NestedString(folder.Object, "metadata", "annotations", "grafana.app/managerId")
 		require.Equal(c, repoName, mgr, "folder %q is not managed by %q", expectedUID, repoName)
@@ -2571,10 +2564,10 @@ func RequireRepoFolderUID(t *testing.T, folderClient *apis.K8sResourceClient, ct
 
 // RequireRepoFolders lists folders once and asserts that the set of
 // grafana.app/sourcePath values for folders managed by repoName matches exactly.
-func RequireRepoFolders(t *testing.T, folderClient *apis.K8sResourceClient, ctx context.Context, repoName string, expectedSourcePaths []string) {
+func RequireRepoFolders(t *testing.T, folderClient *apis.K8sResourceClient, repoName string, expectedSourcePaths []string) {
 	t.Helper()
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		list, err := folderClient.Resource.List(ctx, metav1.ListOptions{})
+		list, err := folderClient.Resource.List(t.Context(), metav1.ListOptions{})
 		if !assert.NoError(c, err, "failed to list folders") {
 			return
 		}
@@ -2987,9 +2980,9 @@ func NewUnmanagedDashboard(apiVersion, title, folderUID string) *unstructured.Un
 // CreateUnmanagedFolder creates a folder with no manager annotations under the
 // given parent (pass "" for a root folder) and returns its generated UID. It
 // asserts the folder starts unmanaged so callers can rely on that precondition.
-func (h *ProvisioningTestHelper) CreateUnmanagedFolder(t *testing.T, ctx context.Context, title, parentUID string) string {
+func (h *ProvisioningTestHelper) CreateUnmanagedFolder(t *testing.T, title, parentUID string) string {
 	t.Helper()
-	created, err := h.Folders.Resource.Create(ctx, NewUnmanagedFolder(title, parentUID), metav1.CreateOptions{})
+	created, err := h.Folders.Resource.Create(t.Context(), NewUnmanagedFolder(title, parentUID), metav1.CreateOptions{})
 	require.NoError(t, err, "should create unmanaged folder %q", title)
 	require.Empty(t, created.GetAnnotations()[utils.AnnoKeyManagerIdentity], "folder %q should start unmanaged", title)
 	return created.GetName()
@@ -2998,9 +2991,9 @@ func (h *ProvisioningTestHelper) CreateUnmanagedFolder(t *testing.T, ctx context
 // CreateUnmanagedDashboard creates a v1 dashboard with no manager annotations in
 // the given folder (pass "" for a root dashboard) and returns its generated
 // name. It asserts the dashboard starts unmanaged.
-func (h *ProvisioningTestHelper) CreateUnmanagedDashboard(t *testing.T, ctx context.Context, title, folderUID string) string {
+func (h *ProvisioningTestHelper) CreateUnmanagedDashboard(t *testing.T, title, folderUID string) string {
 	t.Helper()
-	created, err := h.DashboardsV1.Resource.Create(ctx, NewUnmanagedDashboard("dashboard.grafana.app/v1", title, folderUID), metav1.CreateOptions{})
+	created, err := h.DashboardsV1.Resource.Create(t.Context(), NewUnmanagedDashboard("dashboard.grafana.app/v1", title, folderUID), metav1.CreateOptions{})
 	require.NoError(t, err, "should create unmanaged dashboard %q", title)
 	require.Empty(t, created.GetAnnotations()[utils.AnnoKeyManagerIdentity], "dashboard %q should start unmanaged", title)
 	return created.GetName()
@@ -3075,8 +3068,7 @@ func RunGrafanaWithGitServer(t *testing.T, options ...GrafanaOption) *GitTestHel
 func runGrafanaWithGitServerShared(t *testing.T, options ...GrafanaOption) (*GitTestHelper, func()) {
 	t.Helper()
 
-	ctx := context.Background()
-	gitServer, err := gittest.NewServer(ctx, gittest.WithLogger(gittest.NewWriterLogger(os.Stderr)))
+	gitServer, err := gittest.NewServer(t.Context(), gittest.WithLogger(gittest.NewWriterLogger(os.Stderr)))
 	require.NoError(t, err, "failed to start git server")
 
 	allOpts := append([]GrafanaOption{WithRepositoryTypes([]string{"git"})}, options...)
@@ -3098,8 +3090,7 @@ func runGrafanaWithGitServerShared(t *testing.T, options ...GrafanaOption) (*Git
 
 func startGitServer(t *testing.T) *gittest.Server {
 	t.Helper()
-	ctx := context.Background()
-	gitServer, err := gittest.NewServer(ctx, gittest.WithLogger(gittest.NewTestLogger(t)))
+	gitServer, err := gittest.NewServer(t.Context(), gittest.WithLogger(gittest.NewTestLogger(t)))
 	require.NoError(t, err, "failed to start git server")
 	t.Cleanup(func() {
 		if err := gitServer.Cleanup(); err != nil {
@@ -3137,7 +3128,7 @@ func (e *SharedGitEnv) GetHelper(t *testing.T) *GitTestHelper {
 func (e *SharedGitEnv) GetCleanHelper(t *testing.T) *GitTestHelper {
 	t.Helper()
 	h := e.GetHelper(t)
-	h.CleanupAllResources(t, context.Background())
+	h.CleanupAllResources(t)
 	return h
 }
 
@@ -3162,10 +3153,10 @@ func (e *SharedGitEnv) RunTestMain(m *testing.M) {
 // CleanupAllResources removes Grafana-managed resources left by a previous
 // test. It first waits for active jobs to finish, then delegates to
 // ProvisioningTestHelper.CleanupAllResources.
-func (h *GitTestHelper) CleanupAllResources(t *testing.T, ctx context.Context) {
+func (h *GitTestHelper) CleanupAllResources(t *testing.T) {
 	t.Helper()
 	h.waitForNoActiveJobs(t)
-	h.ProvisioningTestHelper.CleanupAllResources(t, ctx)
+	h.ProvisioningTestHelper.CleanupAllResources(t)
 }
 
 // CreateGitRepo creates a git repository with sync target "instance" and registers
@@ -3261,23 +3252,21 @@ func (h *GitTestHelper) createRepo(
 ) (*gittest.RemoteRepository, *gittest.LocalRepo) {
 	t.Helper()
 
-	ctx := context.Background()
-
 	user := opts.user
 	if user == nil {
 		var err error
-		user, err = h.gitServer.CreateUser(ctx)
+		user, err = h.gitServer.CreateUser(t.Context())
 		require.NoError(t, err, "failed to create user")
 	}
 
-	remote, err := h.gitServer.CreateRepo(ctx, repoName, user)
+	remote, err := h.gitServer.CreateRepo(t.Context(), repoName, user)
 	require.NoError(t, err, "failed to create remote repository")
 
 	if opts.exportRepo {
 		h.exportRepoInfos[repoName] = &exportRepoInfo{user: user, remote: remote}
 	}
 
-	local, err := gittest.NewLocalRepo(ctx)
+	local, err := gittest.NewLocalRepo(t.Context())
 	require.NoError(t, err, "failed to create local repository")
 	t.Cleanup(func() {
 		if err := local.Cleanup(); err != nil {
@@ -3326,7 +3315,7 @@ func (h *GitTestHelper) createRepo(
 	tmpl := TestdataPath(repoType + ".json.tmpl")
 	repoObj := h.RenderObject(t, tmpl, templateValues)
 
-	_, err = h.Repositories.Resource.Create(ctx, repoObj, metav1.CreateOptions{})
+	_, err = h.Repositories.Resource.Create(t.Context(), repoObj, metav1.CreateOptions{})
 	require.NoError(t, err, "failed to create repository")
 
 	if opts.waitForReady {
@@ -3453,10 +3442,10 @@ func (h *GitTestHelper) waitForNoActiveJobs(t *testing.T) {
 
 // RequireRepoDashboardCount asserts the number of dashboards whose
 // grafana.app/managerId annotation matches repoName.
-func RequireRepoDashboardCount(t *testing.T, h *GitTestHelper, ctx context.Context, repoName string, expected int) {
+func RequireRepoDashboardCount(t *testing.T, h *GitTestHelper, repoName string, expected int) {
 	t.Helper()
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		list, err := h.DashboardsV1.Resource.List(ctx, metav1.ListOptions{})
+		list, err := h.DashboardsV1.Resource.List(t.Context(), metav1.ListOptions{})
 		if !assert.NoError(c, err, "failed to list dashboards") {
 			return
 		}
@@ -3473,10 +3462,10 @@ func RequireRepoDashboardCount(t *testing.T, h *GitTestHelper, ctx context.Conte
 
 // RequireRepoFolderCount asserts the number of folders whose
 // grafana.app/managerId annotation matches repoName.
-func RequireRepoFolderCount(t *testing.T, h *GitTestHelper, ctx context.Context, repoName string, expected int) {
+func RequireRepoFolderCount(t *testing.T, h *GitTestHelper, repoName string, expected int) {
 	t.Helper()
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		list, err := h.Folders.Resource.List(ctx, metav1.ListOptions{})
+		list, err := h.Folders.Resource.List(t.Context(), metav1.ListOptions{})
 		if !assert.NoError(c, err, "failed to list folders") {
 			return
 		}
@@ -3517,7 +3506,7 @@ func (h *GitTestHelper) CreateExportGitRepo(t *testing.T, repoName string, initF
 	})
 }
 
-func (h *GitTestHelper) cloneExportRepo(t *testing.T, ctx context.Context, repoName string) (string, func()) {
+func (h *GitTestHelper) cloneExportRepo(t *testing.T, repoName string) (string, func()) {
 	t.Helper()
 	info, ok := h.exportRepoInfos[repoName]
 	if !ok {
@@ -3528,7 +3517,7 @@ func (h *GitTestHelper) cloneExportRepo(t *testing.T, ctx context.Context, repoN
 	require.NoError(t, err, "failed to create temp dir for git clone")
 
 	cloneDir := filepath.Join(tmpDir, "repo")
-	cmd := exec.CommandContext(ctx, "git", "clone", info.remote.AuthURL, cloneDir) //nolint:gosec
+	cmd := exec.CommandContext(t.Context(), "git", "clone", info.remote.AuthURL, cloneDir) //nolint:gosec
 	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
 	if out, err := cmd.CombinedOutput(); err != nil {
 		_ = os.RemoveAll(tmpDir)
@@ -3541,9 +3530,9 @@ func (h *GitTestHelper) cloneExportRepo(t *testing.T, ctx context.Context, repoN
 // GitFileExists reports whether filePath exists on the main branch of an export
 // repository. It clones the repo via git (bypassing the provisioning files
 // endpoint, which rejects hidden files such as .keep).
-func (h *GitTestHelper) GitFileExists(t *testing.T, ctx context.Context, repoName, filePath string) bool {
+func (h *GitTestHelper) GitFileExists(t *testing.T, repoName, filePath string) bool {
 	t.Helper()
-	cloneDir, cleanup := h.cloneExportRepo(t, ctx, repoName)
+	cloneDir, cleanup := h.cloneExportRepo(t, repoName)
 	defer cleanup()
 
 	_, err := os.Stat(filepath.Join(cloneDir, filePath))
@@ -3552,9 +3541,9 @@ func (h *GitTestHelper) GitFileExists(t *testing.T, ctx context.Context, repoNam
 
 // GitReadFile returns the raw bytes of filePath on the main branch of an export
 // repository. It fails the test if the file does not exist.
-func (h *GitTestHelper) GitReadFile(t *testing.T, ctx context.Context, repoName, filePath string) []byte {
+func (h *GitTestHelper) GitReadFile(t *testing.T, repoName, filePath string) []byte {
 	t.Helper()
-	cloneDir, cleanup := h.cloneExportRepo(t, ctx, repoName)
+	cloneDir, cleanup := h.cloneExportRepo(t, repoName)
 	defer cleanup()
 
 	data, err := os.ReadFile(filepath.Join(cloneDir, filePath)) //nolint:gosec

--- a/pkg/tests/apis/provisioning/common/testing.go
+++ b/pkg/tests/apis/provisioning/common/testing.go
@@ -784,7 +784,8 @@ func (h *ProvisioningTestHelper) logRepositoryObject(t *testing.T, obj map[strin
 // If folder is nested, folder annotations should not be empty.
 // Also checks that the managerId property exists.
 func (h *ProvisioningTestHelper) ValidateManagedDashboardsFolderMetadata(t *testing.T,
-	repoName string, dashboards []unstructured.Unstructured) {
+	repoName string, dashboards []unstructured.Unstructured,
+) {
 	t.Helper()
 
 	// Check if folder is nested or not.
@@ -838,13 +839,10 @@ type TestRepo struct {
 	GenerateDashboardPreviews bool
 
 	// Test control fields (not used by templates)
-	LocalPath              string
-	Copies                 map[string]string
-	ExpectedDashboards     int
-	ExpectedFolders        int
-	SkipSync               bool
-	SkipResourceAssertions bool
-	Template               string
+	LocalPath string
+	Copies    map[string]string
+	SkipSync  bool
+	Template  string
 }
 
 type LocalRepositorySpec struct {
@@ -980,82 +978,54 @@ func (h *ProvisioningTestHelper) CreateLocalRepo(t *testing.T, repo TestRepo) {
 	} else {
 		h.DebugState(t, repo.Name, "AFTER REPO CREATION")
 	}
-
-	// Verify initial state. ExpectedDashboards/ExpectedFolders count this
-	// repo's synced resources plus any unmanaged resources a test pre-seeds
-	// (e.g. the selective export/migrate tests). It deliberately does NOT
-	// count dangling orphans — resources still annotated as managed by a
-	// repository that no longer exists. Those can leak from a prior test: the
-	// per-test cleanup deletes a repo whose RemoveOrphanResources finalizer
-	// then enumerates its managed resources through the eventually-consistent
-	// search index; if that index lags and reports none, the finalizer deletes
-	// nothing and the folder survives as a managed orphan that surfaces later
-	// and would otherwise inflate this count.
-	if !repo.SkipResourceAssertions {
-		require.EventuallyWithT(t, func(collect *assert.CollectT) {
-			existingRepos, err := h.repoNameSet(t.Context())
-			if err != nil {
-				collect.Errorf("could not list repositories: error: %s", err.Error())
-				return
-			}
-
-			dashboards, err := h.DashboardsV1.Resource.List(t.Context(), metav1.ListOptions{})
-			if err != nil {
-				collect.Errorf("could not list dashboards error: %s", err.Error())
-				return
-			}
-			dashboardCount := countNonOrphanedResources(dashboards.Items, existingRepos)
-			if dashboardCount != repo.ExpectedDashboards {
-				collect.Errorf("should have the expected dashboards after sync. got: %d. expected: %d", dashboardCount, repo.ExpectedDashboards)
-				return
-			}
-			folders, err := h.Folders.Resource.List(t.Context(), metav1.ListOptions{})
-			if err != nil {
-				collect.Errorf("could not list folders: error: %s", err.Error())
-				return
-			}
-			folderCount := countNonOrphanedResources(folders.Items, existingRepos)
-			if folderCount != repo.ExpectedFolders {
-				collect.Errorf("should have the expected folders after sync. got: %d. expected: %d", folderCount, repo.ExpectedFolders)
-				return
-			}
-		}, WaitTimeoutDefault, WaitIntervalDefault, "should have the expected dashboards and folders after sync")
-	}
 }
 
-// repoNameSet returns the set of repository names that currently exist.
-func (h *ProvisioningTestHelper) repoNameSet(ctx context.Context) (map[string]struct{}, error) {
-	repos, err := h.Repositories.Resource.List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return nil, err
-	}
-	names := make(map[string]struct{}, len(repos.Items))
-	for i := range repos.Items {
-		names[repos.Items[i].GetName()] = struct{}{}
-	}
-	return names, nil
-}
-
-// countNonOrphanedResources counts resources except dangling repo orphans:
-// resources annotated as managed by a repository (managedBy=repo) whose
-// repository no longer exists. Those leak from a prior test and would inflate
-// the count. Unmanaged resources and resources managed by other kinds
-// (kubectl, terraform, ...) are always counted, as are repo-managed resources
-// whose repository still exists.
-func countNonOrphanedResources(items []unstructured.Unstructured, existingRepos map[string]struct{}) int {
+// countManagedResources counts resources managed by repoName.
+func countManagedResources(items []unstructured.Unstructured, repoName string) int {
 	var count int
 	for i := range items {
 		annotations := items[i].GetAnnotations()
-		managerKind := annotations["grafana.app/managedBy"]
-		managerID := annotations["grafana.app/managerId"]
-		if managerKind == "repo" {
-			if _, ok := existingRepos[managerID]; !ok {
-				continue
-			}
+		if annotations["grafana.app/managedBy"] == "repo" && annotations["grafana.app/managerId"] == repoName {
+			count++
 		}
-		count++
 	}
 	return count
+}
+
+// RequireDashboards polls until every named dashboard exists, regardless of manager.
+func (h *ProvisioningTestHelper) RequireDashboards(t *testing.T, names ...string) {
+	t.Helper()
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		dashboards, err := h.DashboardsV1.Resource.List(t.Context(), metav1.ListOptions{})
+		if !assert.NoError(c, err, "failed to list dashboards") {
+			return
+		}
+		var found []string
+		for _, d := range dashboards.Items {
+			found = append(found, d.GetName())
+		}
+		for _, name := range names {
+			assert.Contains(c, found, name, "expected dashboard %q to exist", name)
+		}
+	}, WaitTimeoutDefault, WaitIntervalDefault, "expected dashboards %v to exist", names)
+}
+
+// RequireFolders polls until every named folder exists, regardless of manager.
+func (h *ProvisioningTestHelper) RequireFolders(t *testing.T, names ...string) {
+	t.Helper()
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		folders, err := h.Folders.Resource.List(t.Context(), metav1.ListOptions{})
+		if !assert.NoError(c, err, "failed to list folders") {
+			return
+		}
+		var found []string
+		for _, f := range folders.Items {
+			found = append(found, f.GetName())
+		}
+		for _, name := range names {
+			assert.Contains(c, found, name, "expected folder %q to exist", name)
+		}
+	}, WaitTimeoutDefault, WaitIntervalDefault, "expected folders %v to exist", names)
 }
 
 // WaitForResourceQuotaLimit waits until the repository's Status.Quota.MaxResourcesPerRepository
@@ -1126,13 +1096,7 @@ func (h *ProvisioningTestHelper) RequireRepoDashboardCount(t *testing.T, repoNam
 			return
 		}
 
-		var count int
-		for _, d := range dashboards.Items {
-			managerID, _, _ := unstructured.NestedString(d.Object, "metadata", "annotations", "grafana.app/managerId")
-			if managerID == repoName {
-				count++
-			}
-		}
+		count := countManagedResources(dashboards.Items, repoName)
 		assert.Equal(c, expectedCount, count, "unexpected number of dashboards managed by repo %s", repoName)
 	}, WaitTimeoutDefault, WaitIntervalDefault,
 		"expected %d dashboard(s) managed by repo %s", expectedCount, repoName)
@@ -1151,13 +1115,7 @@ func (h *ProvisioningTestHelper) RequireRepoFolderCount(t *testing.T, repoName s
 			return
 		}
 
-		var count int
-		for _, f := range folders.Items {
-			managerID, _, _ := unstructured.NestedString(f.Object, "metadata", "annotations", "grafana.app/managerId")
-			if managerID == repoName {
-				count++
-			}
-		}
+		count := countManagedResources(folders.Items, repoName)
 		assert.Equal(c, expectedCount, count, "unexpected number of folders managed by repo %s", repoName)
 	}, WaitTimeoutDefault, WaitIntervalDefault,
 		"expected %d folder(s) managed by repo %s", expectedCount, repoName)
@@ -2417,18 +2375,6 @@ type ExpectedDashboard struct {
 	Folder     string // grafana.app/folder annotation; only checked when non-empty
 }
 
-// RequireDashboardCount asserts the total number of dashboards in the instance.
-func RequireDashboardCount(t *testing.T, dashboardClient *apis.K8sResourceClient, expected int) {
-	t.Helper()
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		list, err := dashboardClient.Resource.List(t.Context(), metav1.ListOptions{})
-		if !assert.NoError(c, err, "failed to list dashboards") {
-			return
-		}
-		assert.Len(c, list.Items, expected, "unexpected dashboard count")
-	}, WaitTimeoutDefault, WaitIntervalDefault, "expected %d dashboard(s)", expected)
-}
-
 // RequireRepoManagedDashboard waits until the dashboard with the given uid is
 // available in unified storage and is annotated as managed by the named repo
 // at the given source path. Polls until the assertions hold or the default
@@ -3090,6 +3036,7 @@ func runGrafanaWithGitServerShared(t *testing.T, options ...GrafanaOption) (*Git
 
 func startGitServer(t *testing.T) *gittest.Server {
 	t.Helper()
+
 	gitServer, err := gittest.NewServer(t.Context(), gittest.WithLogger(gittest.NewTestLogger(t)))
 	require.NoError(t, err, "failed to start git server")
 	t.Cleanup(func() {
@@ -3438,46 +3385,6 @@ func (h *GitTestHelper) waitForNoActiveJobs(t *testing.T) {
 		}
 		assert.Empty(collect, jobs.Items, "jobs still active from previous test")
 	}, WaitTimeoutDefault, WaitIntervalDefault, "jobs should complete before cleanup")
-}
-
-// RequireRepoDashboardCount asserts the number of dashboards whose
-// grafana.app/managerId annotation matches repoName.
-func RequireRepoDashboardCount(t *testing.T, h *GitTestHelper, repoName string, expected int) {
-	t.Helper()
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		list, err := h.DashboardsV1.Resource.List(t.Context(), metav1.ListOptions{})
-		if !assert.NoError(c, err, "failed to list dashboards") {
-			return
-		}
-		var count int
-		for _, d := range list.Items {
-			if mgr, _, _ := unstructured.NestedString(d.Object, "metadata", "annotations", "grafana.app/managerId"); mgr == repoName {
-				count++
-			}
-		}
-		assert.Equal(c, expected, count, "unexpected dashboard count for repo %q", repoName)
-	}, WaitTimeoutDefault, WaitIntervalDefault,
-		"expected %d dashboard(s) for repo %q", expected, repoName)
-}
-
-// RequireRepoFolderCount asserts the number of folders whose
-// grafana.app/managerId annotation matches repoName.
-func RequireRepoFolderCount(t *testing.T, h *GitTestHelper, repoName string, expected int) {
-	t.Helper()
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		list, err := h.Folders.Resource.List(t.Context(), metav1.ListOptions{})
-		if !assert.NoError(c, err, "failed to list folders") {
-			return
-		}
-		var count int
-		for _, f := range list.Items {
-			if mgr, _, _ := unstructured.NestedString(f.Object, "metadata", "annotations", "grafana.app/managerId"); mgr == repoName {
-				count++
-			}
-		}
-		assert.Equal(c, expected, count, "unexpected folder count for repo %q", repoName)
-	}, WaitTimeoutDefault, WaitIntervalDefault,
-		"expected %d folder(s) for repo %q", expected, repoName)
 }
 
 // RequireJobWarningContains asserts that at least one warning in the job status

--- a/pkg/tests/apis/provisioning/connection/connection_test.go
+++ b/pkg/tests/apis/provisioning/connection/connection_test.go
@@ -29,6 +29,7 @@ import (
 
 func TestIntegrationProvisioning_ConnectionCRUDL(t *testing.T) {
 	helper := sharedHelper(t)
+
 	privateKeyBase64 := base64.StdEncoding.EncodeToString([]byte(common.TestGithubPrivateKeyPEM))
 
 	t.Run("should perform CRUDL requests on connection", func(t *testing.T) {
@@ -184,6 +185,7 @@ func TestIntegrationProvisioning_ConnectionCRUDL(t *testing.T) {
 
 func TestIntegrationProvisioning_ConnectionMutation(t *testing.T) {
 	helper := sharedHelper(t)
+
 	privateKeyBase64 := base64.StdEncoding.EncodeToString([]byte(common.TestGithubPrivateKeyPEM))
 
 	t.Run("should update connection name with type prefix", func(t *testing.T) {
@@ -304,6 +306,7 @@ func TestIntegrationProvisioning_ConnectionMutation(t *testing.T) {
 func TestIntegrationProvisioning_ConnectionValidation(t *testing.T) {
 	helper := sharedHelper(t)
 	createOptions := metav1.CreateOptions{FieldValidation: "Strict"}
+
 	privateKeyBase64 := base64.StdEncoding.EncodeToString([]byte(common.TestGithubPrivateKeyPEM))
 
 	t.Run("should fail when type is empty", func(t *testing.T) {
@@ -671,6 +674,7 @@ func TestIntegrationProvisioning_ConnectionValidation(t *testing.T) {
 
 func TestIntegrationConnectionController_TokenCreation(t *testing.T) {
 	helper := sharedHelper(t)
+
 	namespace := "default"
 
 	// Create typed client from REST config
@@ -879,6 +883,7 @@ func TestIntegrationConnectionController_TokenCreation(t *testing.T) {
 
 func TestIntegrationConnectionController_HealthCheckUpdates(t *testing.T) {
 	helper := sharedHelper(t)
+
 	namespace := "default"
 
 	// Create typed client from REST config
@@ -1049,6 +1054,7 @@ func TestIntegrationConnectionController_HealthCheckUpdates(t *testing.T) {
 
 func TestIntegrationConnectionController_UnhealthyWithValidationErrors(t *testing.T) {
 	helper := sharedHelper(t)
+
 	namespace := "default"
 
 	// Create typed client from REST config
@@ -1288,6 +1294,7 @@ func TestIntegrationConnectionController_UnhealthyWithValidationErrors(t *testin
 
 func TestIntegrationConnectionController_FieldErrorsCleared(t *testing.T) {
 	helper := sharedHelper(t)
+
 	namespace := "default"
 
 	// Create typed client from REST config
@@ -1449,6 +1456,7 @@ func TestIntegrationConnectionController_FieldErrorsCleared(t *testing.T) {
 
 func TestIntegrationProvisioning_RepositoryFieldSelectorByConnection(t *testing.T) {
 	helper := sharedHelper(t)
+
 	createOptions := metav1.CreateOptions{FieldValidation: "Strict"}
 	privateKeyBase64 := base64.StdEncoding.EncodeToString([]byte(common.TestGithubPrivateKeyPEM))
 
@@ -1623,6 +1631,7 @@ func TestIntegrationProvisioning_RepositoryFieldSelectorByConnection(t *testing.
 
 func TestIntegrationProvisioning_ConnectionDeleteBlockedByRepository(t *testing.T) {
 	helper := sharedHelper(t)
+
 	createOptions := metav1.CreateOptions{}
 	deleteOptions := metav1.DeleteOptions{}
 	privateKeyBase64 := base64.StdEncoding.EncodeToString([]byte(common.TestGithubPrivateKeyPEM))
@@ -1719,6 +1728,7 @@ func TestIntegrationProvisioning_ConnectionDeleteBlockedByRepository(t *testing.
 
 func TestIntegrationProvisioning_ConnectionDeleteWithNoReferences(t *testing.T) {
 	helper := sharedHelper(t)
+
 	createOptions := metav1.CreateOptions{}
 	deleteOptions := metav1.DeleteOptions{}
 	privateKeyBase64 := base64.StdEncoding.EncodeToString([]byte(common.TestGithubPrivateKeyPEM))
@@ -1763,6 +1773,7 @@ func TestIntegrationProvisioning_ConnectionDeleteWithNoReferences(t *testing.T) 
 
 func TestIntegrationConnectionController_GranularConditionReasons(t *testing.T) {
 	helper := sharedHelper(t)
+
 	namespace := "default"
 
 	// Create typed client from REST config

--- a/pkg/tests/apis/provisioning/connection/connection_test.go
+++ b/pkg/tests/apis/provisioning/connection/connection_test.go
@@ -29,7 +29,6 @@ import (
 
 func TestIntegrationProvisioning_ConnectionCRUDL(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 	privateKeyBase64 := base64.StdEncoding.EncodeToString([]byte(common.TestGithubPrivateKeyPEM))
 
 	t.Run("should perform CRUDL requests on connection", func(t *testing.T) {
@@ -55,13 +54,13 @@ func TestIntegrationProvisioning_ConnectionCRUDL(t *testing.T) {
 			},
 		}}
 		// CREATE
-		c, err := helper.CreateGithubConnection(t, ctx, connection)
+		c, err := helper.CreateGithubConnection(t, connection)
 		require.NoError(t, err, "failed to create resource")
 
 		connectionName := c.GetName()
 
 		// READ
-		output, err := helper.Connections.Resource.Get(ctx, connectionName, metav1.GetOptions{})
+		output, err := helper.Connections.Resource.Get(t.Context(), connectionName, metav1.GetOptions{})
 		require.NoError(t, err, "failed to read back resource")
 		assert.Equal(t, connectionName, output.GetName(), "name should be equal")
 		assert.Equal(t, "default", output.GetNamespace(), "namespace should be equal")
@@ -76,7 +75,7 @@ func TestIntegrationProvisioning_ConnectionCRUDL(t *testing.T) {
 		assert.Contains(t, output.Object["secure"], "privateKey", "secure should contain PrivateKey")
 
 		// LIST
-		list, err := helper.Connections.Resource.List(ctx, metav1.ListOptions{})
+		list, err := helper.Connections.Resource.List(t.Context(), metav1.ListOptions{})
 		require.NoError(t, err, "failed to list resource")
 		assert.Equal(t, 1, len(list.Items), "should have one connection")
 		assert.Equal(t, connectionName, list.Items[0].GetName(), "name should be equal")
@@ -103,7 +102,7 @@ func TestIntegrationProvisioning_ConnectionCRUDL(t *testing.T) {
 				},
 			},
 		}}
-		res, err := helper.UpdateGithubConnection(t, ctx, updatedConnection)
+		res, err := helper.UpdateGithubConnection(t, updatedConnection)
 		require.NoError(t, err, "failed to update resource")
 		spec = res.Object["spec"].(map[string]any)
 		require.Contains(t, spec, "github")
@@ -113,7 +112,7 @@ func TestIntegrationProvisioning_ConnectionCRUDL(t *testing.T) {
 		// DELETE - Retry delete to handle resource version conflicts
 		// The controller may have updated the resource after our update, changing the resource version
 		require.Eventually(t, func() bool {
-			err := helper.Connections.Resource.Delete(ctx, connectionName, metav1.DeleteOptions{})
+			err := helper.Connections.Resource.Delete(t.Context(), connectionName, metav1.DeleteOptions{})
 			if err != nil {
 				if k8serrors.IsConflict(err) {
 					// Resource version conflict - retry
@@ -128,7 +127,7 @@ func TestIntegrationProvisioning_ConnectionCRUDL(t *testing.T) {
 			}
 			return true
 		}, 5*time.Second, 100*time.Millisecond, "should successfully delete resource")
-		list, err = helper.Connections.Resource.List(ctx, metav1.ListOptions{})
+		list, err = helper.Connections.Resource.List(t.Context(), metav1.ListOptions{})
 		require.NoError(t, err, "failed to list resources")
 		assert.Equal(t, 0, len(list.Items), "should have no connections")
 	})
@@ -185,7 +184,6 @@ func TestIntegrationProvisioning_ConnectionCRUDL(t *testing.T) {
 
 func TestIntegrationProvisioning_ConnectionMutation(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 	privateKeyBase64 := base64.StdEncoding.EncodeToString([]byte(common.TestGithubPrivateKeyPEM))
 
 	t.Run("should update connection name with type prefix", func(t *testing.T) {
@@ -213,13 +211,14 @@ func TestIntegrationProvisioning_ConnectionMutation(t *testing.T) {
 			},
 		}}
 
-		c, err := helper.CreateGithubConnection(t, ctx, connection)
+		c, err := helper.CreateGithubConnection(t, connection)
 		require.NoError(t, err, "failed to create resource")
 		require.Contains(t, c.GetName(), namePrefix, "name should be updated")
 
 		t.Cleanup(func() {
+			cleanupCtx := context.WithoutCancel(t.Context())
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {
-				err := helper.Connections.Resource.Delete(ctx, c.GetName(), metav1.DeleteOptions{})
+				err := helper.Connections.Resource.Delete(cleanupCtx, c.GetName(), metav1.DeleteOptions{})
 				require.NoError(collect, err)
 			}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
 		})
@@ -250,13 +249,14 @@ func TestIntegrationProvisioning_ConnectionMutation(t *testing.T) {
 			},
 		}}
 
-		c, err := helper.CreateGithubConnection(t, ctx, connection)
+		c, err := helper.CreateGithubConnection(t, connection)
 		require.NoError(t, err, "failed to create resource")
 		require.Contains(t, c.GetName(), generateName, "name should be updated")
 
 		t.Cleanup(func() {
+			cleanupCtx := context.WithoutCancel(t.Context())
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {
-				err := helper.Connections.Resource.Delete(ctx, c.GetName(), metav1.DeleteOptions{})
+				err := helper.Connections.Resource.Delete(cleanupCtx, c.GetName(), metav1.DeleteOptions{})
 				require.NoError(collect, err)
 			}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
 		})
@@ -287,13 +287,14 @@ func TestIntegrationProvisioning_ConnectionMutation(t *testing.T) {
 			},
 		}}
 
-		c, err := helper.CreateGithubConnection(t, ctx, connection)
+		c, err := helper.CreateGithubConnection(t, connection)
 		require.NoError(t, err, "failed to create resource")
 		require.Equal(t, name, c.GetName(), "name should be identical")
 
 		t.Cleanup(func() {
+			cleanupCtx := context.WithoutCancel(t.Context())
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {
-				err := helper.Connections.Resource.Delete(ctx, c.GetName(), metav1.DeleteOptions{})
+				err := helper.Connections.Resource.Delete(cleanupCtx, c.GetName(), metav1.DeleteOptions{})
 				require.NoError(collect, err)
 			}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
 		})
@@ -303,7 +304,6 @@ func TestIntegrationProvisioning_ConnectionMutation(t *testing.T) {
 func TestIntegrationProvisioning_ConnectionValidation(t *testing.T) {
 	helper := sharedHelper(t)
 	createOptions := metav1.CreateOptions{FieldValidation: "Strict"}
-	ctx := context.Background()
 	privateKeyBase64 := base64.StdEncoding.EncodeToString([]byte(common.TestGithubPrivateKeyPEM))
 
 	t.Run("should fail when type is empty", func(t *testing.T) {
@@ -324,7 +324,7 @@ func TestIntegrationProvisioning_ConnectionValidation(t *testing.T) {
 				},
 			},
 		}}
-		_, err := helper.Connections.Resource.Create(ctx, connection, createOptions)
+		_, err := helper.Connections.Resource.Create(t.Context(), connection, createOptions)
 		require.Error(t, err, "failed to create resource")
 		assert.Contains(t, err.Error(), "connection type \"\" is not supported")
 	})
@@ -347,7 +347,7 @@ func TestIntegrationProvisioning_ConnectionValidation(t *testing.T) {
 				},
 			},
 		}}
-		_, err := helper.Connections.Resource.Create(ctx, connection, createOptions)
+		_, err := helper.Connections.Resource.Create(t.Context(), connection, createOptions)
 		require.Error(t, err, "failed to create resource")
 		assert.Contains(t, err.Error(), "connection type \"some-invalid-type\" is not supported")
 	})
@@ -370,7 +370,7 @@ func TestIntegrationProvisioning_ConnectionValidation(t *testing.T) {
 				},
 			},
 		}}
-		_, err := helper.Connections.Resource.Create(ctx, connection, createOptions)
+		_, err := helper.Connections.Resource.Create(t.Context(), connection, createOptions)
 		require.Error(t, err, "failed to create resource")
 		assert.Contains(t, err.Error(), "connection type \"git\" is not supported")
 	})
@@ -393,7 +393,7 @@ func TestIntegrationProvisioning_ConnectionValidation(t *testing.T) {
 				},
 			},
 		}}
-		_, err := helper.Connections.Resource.Create(ctx, connection, createOptions)
+		_, err := helper.Connections.Resource.Create(t.Context(), connection, createOptions)
 		require.Error(t, err, "failed to create resource")
 		assert.Contains(t, err.Error(), "connection type \"local\" is not supported")
 	})
@@ -416,7 +416,7 @@ func TestIntegrationProvisioning_ConnectionValidation(t *testing.T) {
 				},
 			},
 		}}
-		_, err := helper.Connections.Resource.Create(ctx, connection, createOptions)
+		_, err := helper.Connections.Resource.Create(t.Context(), connection, createOptions)
 		require.Error(t, err, "failed to create resource")
 		assert.Contains(t, err.Error(), "github info must be specified for GitHub connection")
 	})
@@ -438,7 +438,7 @@ func TestIntegrationProvisioning_ConnectionValidation(t *testing.T) {
 				},
 			},
 		}}
-		_, err := helper.Connections.Resource.Create(ctx, connection, createOptions)
+		_, err := helper.Connections.Resource.Create(t.Context(), connection, createOptions)
 		require.Error(t, err, "failed to create resource")
 		assert.Contains(t, err.Error(), "privateKey must be specified for GitHub connection")
 	})
@@ -468,7 +468,7 @@ func TestIntegrationProvisioning_ConnectionValidation(t *testing.T) {
 				},
 			},
 		}}
-		_, err := helper.Connections.Resource.Create(ctx, connection, createOptions)
+		_, err := helper.Connections.Resource.Create(t.Context(), connection, createOptions)
 		require.Error(t, err, "failed to create resource")
 		assert.Contains(t, err.Error(), "clientSecret is forbidden in GitHub connection")
 	})
@@ -513,13 +513,14 @@ func TestIntegrationProvisioning_ConnectionValidation(t *testing.T) {
 			},
 		}}
 		// CREATE should succeed - runtime validation happens in controller
-		created, err := helper.Connections.Resource.Create(ctx, connection, createOptions)
+		created, err := helper.Connections.Resource.Create(t.Context(), connection, createOptions)
 		require.NoError(t, err, "CREATE should succeed")
 		require.NotNil(t, created)
 
 		connName := created.GetName()
 		t.Cleanup(func() {
-			_ = helper.Connections.Resource.Delete(ctx, connName, metav1.DeleteOptions{})
+			cleanupCtx := context.WithoutCancel(t.Context())
+			_ = helper.Connections.Resource.Delete(cleanupCtx, connName, metav1.DeleteOptions{})
 		})
 
 		// Wait for controller to process and mark connection as unhealthy
@@ -529,7 +530,7 @@ func TestIntegrationProvisioning_ConnectionValidation(t *testing.T) {
 		connClient := provisioningClient.ProvisioningV0alpha1().Connections("default")
 
 		require.Eventually(t, func() bool {
-			conn, err := connClient.Get(ctx, connName, metav1.GetOptions{})
+			conn, err := connClient.Get(t.Context(), connName, metav1.GetOptions{})
 			if err != nil {
 				return false
 			}
@@ -540,7 +541,7 @@ func TestIntegrationProvisioning_ConnectionValidation(t *testing.T) {
 		}, 10*time.Second, 500*time.Millisecond, "connection should be marked unhealthy")
 
 		// Verify the error message contains information about API being unavailable
-		conn, err := connClient.Get(ctx, connName, metav1.GetOptions{})
+		conn, err := connClient.Get(t.Context(), connName, metav1.GetOptions{})
 		require.NoError(t, err)
 		assert.False(t, conn.Status.Health.Healthy, "connection should be unhealthy")
 		readyCondition := meta.FindStatusCondition(conn.Status.Conditions, provisioning.ConditionTypeReady)
@@ -608,13 +609,14 @@ func TestIntegrationProvisioning_ConnectionValidation(t *testing.T) {
 			},
 		}}
 		// CREATE should succeed - runtime validation happens in controller
-		created, err := helper.Connections.Resource.Create(ctx, connection, createOptions)
+		created, err := helper.Connections.Resource.Create(t.Context(), connection, createOptions)
 		require.NoError(t, err, "CREATE should succeed")
 		require.NotNil(t, created)
 
 		connName := created.GetName()
 		t.Cleanup(func() {
-			_ = helper.Connections.Resource.Delete(ctx, connName, metav1.DeleteOptions{})
+			cleanupCtx := context.WithoutCancel(t.Context())
+			_ = helper.Connections.Resource.Delete(cleanupCtx, connName, metav1.DeleteOptions{})
 		})
 
 		// Wait for controller to process and mark connection as unhealthy
@@ -624,7 +626,7 @@ func TestIntegrationProvisioning_ConnectionValidation(t *testing.T) {
 		connClient := provisioningClient.ProvisioningV0alpha1().Connections("default")
 
 		require.Eventually(t, func() bool {
-			conn, err := connClient.Get(ctx, connName, metav1.GetOptions{})
+			conn, err := connClient.Get(t.Context(), connName, metav1.GetOptions{})
 			if err != nil {
 				return false
 			}
@@ -637,7 +639,7 @@ func TestIntegrationProvisioning_ConnectionValidation(t *testing.T) {
 		}, 10*time.Second, 500*time.Millisecond, "connection should be reconciled and marked unhealthy")
 
 		// Verify the error message contains information about app ID mismatch
-		conn, err := connClient.Get(ctx, connName, metav1.GetOptions{})
+		conn, err := connClient.Get(t.Context(), connName, metav1.GetOptions{})
 		require.NoError(t, err)
 		assert.False(t, conn.Status.Health.Healthy, "connection should be unhealthy")
 		readyCondition := meta.FindStatusCondition(conn.Status.Conditions, provisioning.ConditionTypeReady)
@@ -669,7 +671,6 @@ func TestIntegrationProvisioning_ConnectionValidation(t *testing.T) {
 
 func TestIntegrationConnectionController_TokenCreation(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 	namespace := "default"
 
 	// Create typed client from REST config
@@ -706,19 +707,20 @@ func TestIntegrationConnectionController_TokenCreation(t *testing.T) {
 			},
 		}}
 
-		createdUnstructured, err := helper.CreateGithubConnection(t, ctx, connUnstructured)
+		createdUnstructured, err := helper.CreateGithubConnection(t, connUnstructured)
 		require.NoError(t, err)
 		require.NotNil(t, createdUnstructured)
 
 		connName := createdUnstructured.GetName()
 
 		t.Cleanup(func() {
-			_ = helper.Connections.Resource.Delete(ctx, connName, metav1.DeleteOptions{})
+			cleanupCtx := context.WithoutCancel(t.Context())
+			_ = helper.Connections.Resource.Delete(cleanupCtx, connName, metav1.DeleteOptions{})
 		})
 
 		// Wait for initial reconciliation - controller should update status
 		require.Eventually(t, func() bool {
-			updated, err := connClient.Get(ctx, connName, metav1.GetOptions{})
+			updated, err := connClient.Get(t.Context(), connName, metav1.GetOptions{})
 			if err != nil {
 				return false
 			}
@@ -730,13 +732,13 @@ func TestIntegrationConnectionController_TokenCreation(t *testing.T) {
 		}, 10*time.Second, 500*time.Millisecond, "connection should be reconciled")
 
 		// Verify initial health check was set
-		initial, err := connClient.Get(ctx, connName, metav1.GetOptions{})
+		initial, err := connClient.Get(t.Context(), connName, metav1.GetOptions{})
 		require.NoError(t, err)
 		require.NotNil(t, initial)
 		require.False(t, initial.Secure.Token.IsZero())
 
 		// Verifying token
-		decrypted, err := decryptService.Decrypt(ctx, "provisioning.grafana.app", initial.Namespace, initial.Secure.Token.Name)
+		decrypted, err := decryptService.Decrypt(t.Context(), "provisioning.grafana.app", initial.Namespace, initial.Secure.Token.Name)
 		require.NoError(t, err, "decryption error")
 		require.Len(t, decrypted, 1)
 
@@ -772,19 +774,20 @@ func TestIntegrationConnectionController_TokenCreation(t *testing.T) {
 			},
 		}}
 
-		createdUnstructured, err := helper.CreateGithubConnection(t, ctx, connUnstructured)
+		createdUnstructured, err := helper.CreateGithubConnection(t, connUnstructured)
 		require.NoError(t, err)
 		require.NotNil(t, createdUnstructured)
 
 		connName := createdUnstructured.GetName()
 
 		t.Cleanup(func() {
-			_ = helper.Connections.Resource.Delete(ctx, connName, metav1.DeleteOptions{})
+			cleanupCtx := context.WithoutCancel(t.Context())
+			_ = helper.Connections.Resource.Delete(cleanupCtx, connName, metav1.DeleteOptions{})
 		})
 
 		// Wait for initial reconciliation - controller should update status
 		require.Eventually(t, func() bool {
-			updated, err := connClient.Get(ctx, connName, metav1.GetOptions{})
+			updated, err := connClient.Get(t.Context(), connName, metav1.GetOptions{})
 			if err != nil {
 				return false
 			}
@@ -796,13 +799,13 @@ func TestIntegrationConnectionController_TokenCreation(t *testing.T) {
 		}, 10*time.Second, 500*time.Millisecond, "connection should be reconciled")
 
 		// Verify initial health check was set
-		initial, err := connClient.Get(ctx, connName, metav1.GetOptions{})
+		initial, err := connClient.Get(t.Context(), connName, metav1.GetOptions{})
 		require.NoError(t, err)
 		require.NotNil(t, initial)
 		require.False(t, initial.Secure.Token.IsZero())
 
 		// Verifying token
-		decrypted, err := decryptService.Decrypt(ctx, "provisioning.grafana.app", initial.Namespace, initial.Secure.Token.Name)
+		decrypted, err := decryptService.Decrypt(t.Context(), "provisioning.grafana.app", initial.Namespace, initial.Secure.Token.Name)
 		require.NoError(t, err, "decryption error")
 		require.Len(t, decrypted, 1)
 
@@ -836,13 +839,13 @@ func TestIntegrationConnectionController_TokenCreation(t *testing.T) {
 			},
 		}}
 
-		updatedUnstructured, err := helper.UpdateGithubConnection(t, ctx, updated)
+		updatedUnstructured, err := helper.UpdateGithubConnection(t, updated)
 		require.NoError(t, err)
 		require.NotNil(t, updatedUnstructured)
 
 		// Wait for initial reconciliation - controller should update status
 		require.Eventually(t, func() bool {
-			updated, err := connClient.Get(ctx, connName, metav1.GetOptions{})
+			updated, err := connClient.Get(t.Context(), connName, metav1.GetOptions{})
 			if err != nil {
 				return false
 			}
@@ -853,14 +856,14 @@ func TestIntegrationConnectionController_TokenCreation(t *testing.T) {
 				updated.Status.Health.Healthy
 		}, 10*time.Second, 500*time.Millisecond, "connection should be reconciled again")
 
-		c, err := connClient.Get(ctx, connName, metav1.GetOptions{})
+		c, err := connClient.Get(t.Context(), connName, metav1.GetOptions{})
 		require.NoError(t, err)
 		require.NotNil(t, c)
 		// Verify secret got updated
 		require.NotEqual(t, c.Secure.Token.Name, initial.Secure.Token.Name)
 
 		// Verifying token
-		newSecretDecrypted, err := decryptService.Decrypt(ctx, "provisioning.grafana.app", c.Namespace, c.Secure.Token.Name)
+		newSecretDecrypted, err := decryptService.Decrypt(t.Context(), "provisioning.grafana.app", c.Namespace, c.Secure.Token.Name)
 		require.NoError(t, err, "decryption error")
 		require.Len(t, decrypted, 1)
 
@@ -876,7 +879,6 @@ func TestIntegrationConnectionController_TokenCreation(t *testing.T) {
 
 func TestIntegrationConnectionController_HealthCheckUpdates(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 	namespace := "default"
 
 	// Create typed client from REST config
@@ -910,19 +912,20 @@ func TestIntegrationConnectionController_HealthCheckUpdates(t *testing.T) {
 			},
 		}}
 
-		createdUnstructured, err := helper.CreateGithubConnection(t, ctx, connUnstructured)
+		createdUnstructured, err := helper.CreateGithubConnection(t, connUnstructured)
 		require.NoError(t, err)
 		require.NotNil(t, createdUnstructured)
 
 		connName := createdUnstructured.GetName()
 
 		t.Cleanup(func() {
-			_ = helper.Connections.Resource.Delete(ctx, connName, metav1.DeleteOptions{})
+			cleanupCtx := context.WithoutCancel(t.Context())
+			_ = helper.Connections.Resource.Delete(cleanupCtx, connName, metav1.DeleteOptions{})
 		})
 
 		// Wait for initial reconciliation - controller should update status
 		require.Eventually(t, func() bool {
-			updated, err := connClient.Get(ctx, connName, metav1.GetOptions{})
+			updated, err := connClient.Get(t.Context(), connName, metav1.GetOptions{})
 			if err != nil {
 				return false
 			}
@@ -934,7 +937,7 @@ func TestIntegrationConnectionController_HealthCheckUpdates(t *testing.T) {
 		}, 10*time.Second, 500*time.Millisecond, "connection should be initially reconciled with health status")
 
 		// Verify initial health check was set
-		initial, err := connClient.Get(ctx, connName, metav1.GetOptions{})
+		initial, err := connClient.Get(t.Context(), connName, metav1.GetOptions{})
 		require.NoError(t, err)
 		assert.True(t, initial.Status.Health.Healthy, "connection should be healthy")
 		readyCondition := meta.FindStatusCondition(initial.Status.Conditions, provisioning.ConditionTypeReady)
@@ -975,20 +978,21 @@ func TestIntegrationConnectionController_HealthCheckUpdates(t *testing.T) {
 			},
 		}}
 
-		createdUnstructured, err := helper.CreateGithubConnection(t, ctx, connUnstructured)
+		createdUnstructured, err := helper.CreateGithubConnection(t, connUnstructured)
 		require.NoError(t, err)
 		require.NotNil(t, createdUnstructured)
 
 		connName := createdUnstructured.GetName()
 
 		t.Cleanup(func() {
-			_ = helper.Connections.Resource.Delete(ctx, connName, metav1.DeleteOptions{})
+			cleanupCtx := context.WithoutCancel(t.Context())
+			_ = helper.Connections.Resource.Delete(cleanupCtx, connName, metav1.DeleteOptions{})
 		})
 
 		// Wait for initial reconciliation
 		var initialHealthChecked int64
 		require.Eventually(t, func() bool {
-			updated, err := connClient.Get(ctx, connName, metav1.GetOptions{})
+			updated, err := connClient.Get(t.Context(), connName, metav1.GetOptions{})
 			if err != nil {
 				return false
 			}
@@ -1000,25 +1004,25 @@ func TestIntegrationConnectionController_HealthCheckUpdates(t *testing.T) {
 		}, 10*time.Second, 500*time.Millisecond, "connection should be initially reconciled")
 
 		// Get the latest version before updating to avoid conflicts with controller updates
-		latestUnstructured, err := helper.Connections.Resource.Get(ctx, connName, metav1.GetOptions{})
+		latestUnstructured, err := helper.Connections.Resource.Get(t.Context(), connName, metav1.GetOptions{})
 		require.NoError(t, err)
 
 		// Forcing the update of healthcheck - marking it as old.
 		health := latestUnstructured.Object["status"].(map[string]any)["health"].(map[string]any)
 		health["checked"] = time.UnixMilli(initialHealthChecked).Add(-5 * time.Minute).UnixMilli()
-		updated, err := helper.Connections.Resource.UpdateStatus(ctx, latestUnstructured, metav1.UpdateOptions{})
+		updated, err := helper.Connections.Resource.UpdateStatus(t.Context(), latestUnstructured, metav1.UpdateOptions{})
 		require.NoError(t, err)
 
 		// Update the connection spec using the latest version
 		updatedUnstructured := updated.DeepCopy()
 		githubSpec := updatedUnstructured.Object["spec"].(map[string]any)["github"].(map[string]any)
 		githubSpec["appID"] = "99999"
-		_, err = helper.UpdateGithubConnection(t, ctx, updatedUnstructured)
+		_, err = helper.UpdateGithubConnection(t, updatedUnstructured)
 		require.NoError(t, err)
 
 		// Wait for reconciliation after spec change
 		require.Eventually(t, func() bool {
-			reconciled, err := connClient.Get(ctx, connName, metav1.GetOptions{})
+			reconciled, err := connClient.Get(t.Context(), connName, metav1.GetOptions{})
 			if err != nil {
 				return false
 			}
@@ -1027,7 +1031,7 @@ func TestIntegrationConnectionController_HealthCheckUpdates(t *testing.T) {
 		}, 10*time.Second, 500*time.Millisecond, "connection should be reconciled after spec change")
 
 		// Verify health check was updated
-		final, err := connClient.Get(ctx, connName, metav1.GetOptions{})
+		final, err := connClient.Get(t.Context(), connName, metav1.GetOptions{})
 		require.NoError(t, err)
 		assert.Equal(t, final.Generation, final.Status.ObservedGeneration, "observed generation should match generation")
 		assert.Greater(t, final.Status.Health.Checked, initialHealthChecked, "health check should be updated after spec change")
@@ -1045,7 +1049,6 @@ func TestIntegrationConnectionController_HealthCheckUpdates(t *testing.T) {
 
 func TestIntegrationConnectionController_UnhealthyWithValidationErrors(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 	namespace := "default"
 
 	// Create typed client from REST config
@@ -1079,7 +1082,7 @@ func TestIntegrationConnectionController_UnhealthyWithValidationErrors(t *testin
 			},
 		}}
 
-		createdUnstructured, err := helper.CreateGithubConnection(t, ctx, connUnstructured)
+		createdUnstructured, err := helper.CreateGithubConnection(t, connUnstructured)
 		require.NoError(t, err)
 		require.NotNil(t, createdUnstructured)
 
@@ -1123,12 +1126,13 @@ func TestIntegrationConnectionController_UnhealthyWithValidationErrors(t *testin
 		connName := createdUnstructured.GetName()
 
 		t.Cleanup(func() {
-			_ = helper.Connections.Resource.Delete(ctx, connName, metav1.DeleteOptions{})
+			cleanupCtx := context.WithoutCancel(t.Context())
+			_ = helper.Connections.Resource.Delete(cleanupCtx, connName, metav1.DeleteOptions{})
 		})
 
 		// Wait for reconciliation - connection should become unhealthy due to invalid installation ID
 		require.Eventually(t, func() bool {
-			conn, err := connClient.Get(ctx, connName, metav1.GetOptions{})
+			conn, err := connClient.Get(t.Context(), connName, metav1.GetOptions{})
 			if err != nil {
 				return false
 			}
@@ -1139,7 +1143,7 @@ func TestIntegrationConnectionController_UnhealthyWithValidationErrors(t *testin
 		}, 15*time.Second, 500*time.Millisecond, "connection should be reconciled and marked unhealthy")
 
 		// Verify the connection is unhealthy and has fieldErrors
-		conn, err := connClient.Get(ctx, connName, metav1.GetOptions{})
+		conn, err := connClient.Get(t.Context(), connName, metav1.GetOptions{})
 		require.NoError(t, err)
 		assert.False(t, conn.Status.Health.Healthy, "connection should be unhealthy")
 		readyCondition := meta.FindStatusCondition(conn.Status.Conditions, provisioning.ConditionTypeReady)
@@ -1193,7 +1197,7 @@ func TestIntegrationConnectionController_UnhealthyWithValidationErrors(t *testin
 			},
 		}}
 
-		createdUnstructured, err := helper.CreateGithubConnection(t, ctx, connUnstructured)
+		createdUnstructured, err := helper.CreateGithubConnection(t, connUnstructured)
 		require.NoError(t, err)
 		require.NotNil(t, createdUnstructured)
 
@@ -1234,12 +1238,13 @@ func TestIntegrationConnectionController_UnhealthyWithValidationErrors(t *testin
 		connName := createdUnstructured.GetName()
 
 		t.Cleanup(func() {
-			_ = helper.Connections.Resource.Delete(ctx, connName, metav1.DeleteOptions{})
+			cleanupCtx := context.WithoutCancel(t.Context())
+			_ = helper.Connections.Resource.Delete(cleanupCtx, connName, metav1.DeleteOptions{})
 		})
 
 		// Wait for reconciliation - connection should become unhealthy due to invalid app ID
 		require.Eventually(t, func() bool {
-			conn, err := connClient.Get(ctx, connName, metav1.GetOptions{})
+			conn, err := connClient.Get(t.Context(), connName, metav1.GetOptions{})
 			if err != nil {
 				return false
 			}
@@ -1250,7 +1255,7 @@ func TestIntegrationConnectionController_UnhealthyWithValidationErrors(t *testin
 		}, 15*time.Second, 500*time.Millisecond, "connection should be reconciled and marked unhealthy")
 
 		// Verify the connection is unhealthy and has fieldErrors
-		conn, err := connClient.Get(ctx, connName, metav1.GetOptions{})
+		conn, err := connClient.Get(t.Context(), connName, metav1.GetOptions{})
 		require.NoError(t, err)
 		assert.False(t, conn.Status.Health.Healthy, "connection should be unhealthy")
 		readyCondition := meta.FindStatusCondition(conn.Status.Conditions, provisioning.ConditionTypeReady)
@@ -1283,7 +1288,6 @@ func TestIntegrationConnectionController_UnhealthyWithValidationErrors(t *testin
 
 func TestIntegrationConnectionController_FieldErrorsCleared(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 	namespace := "default"
 
 	// Create typed client from REST config
@@ -1317,7 +1321,7 @@ func TestIntegrationConnectionController_FieldErrorsCleared(t *testing.T) {
 			},
 		}}
 
-		createdUnstructured, err := helper.CreateGithubConnection(t, ctx, connUnstructured)
+		createdUnstructured, err := helper.CreateGithubConnection(t, connUnstructured)
 		require.NoError(t, err)
 		require.NotNil(t, createdUnstructured)
 
@@ -1356,12 +1360,13 @@ func TestIntegrationConnectionController_FieldErrorsCleared(t *testing.T) {
 		connName := createdUnstructured.GetName()
 
 		t.Cleanup(func() {
-			_ = helper.Connections.Resource.Delete(ctx, connName, metav1.DeleteOptions{})
+			cleanupCtx := context.WithoutCancel(t.Context())
+			_ = helper.Connections.Resource.Delete(cleanupCtx, connName, metav1.DeleteOptions{})
 		})
 
 		// Wait for reconciliation - connection should become unhealthy with fieldErrors
 		require.Eventually(t, func() bool {
-			conn, err := connClient.Get(ctx, connName, metav1.GetOptions{})
+			conn, err := connClient.Get(t.Context(), connName, metav1.GetOptions{})
 			if err != nil {
 				return false
 			}
@@ -1372,12 +1377,12 @@ func TestIntegrationConnectionController_FieldErrorsCleared(t *testing.T) {
 		}, 15*time.Second, 500*time.Millisecond, "connection should be unhealthy with fieldErrors")
 
 		// Verify fieldErrors are present
-		connWithErrors, err := connClient.Get(ctx, connName, metav1.GetOptions{})
+		connWithErrors, err := connClient.Get(t.Context(), connName, metav1.GetOptions{})
 		require.NoError(t, err)
 		require.Greater(t, len(connWithErrors.Status.FieldErrors), 0, "fieldErrors should be present when unhealthy")
 
 		// Fix the connection by updating to a valid installation ID
-		latestUnstructured, err := helper.Connections.Resource.Get(ctx, connName, metav1.GetOptions{})
+		latestUnstructured, err := helper.Connections.Resource.Get(t.Context(), connName, metav1.GetOptions{})
 		require.NoError(t, err)
 
 		updatedUnstructured := latestUnstructured.DeepCopy()
@@ -1413,12 +1418,12 @@ func TestIntegrationConnectionController_FieldErrorsCleared(t *testing.T) {
 		)
 		helper.SetGithubConnectionFactory(connectionFactory)
 
-		_, err = helper.Connections.Resource.Update(ctx, updatedUnstructured, metav1.UpdateOptions{})
+		_, err = helper.Connections.Resource.Update(t.Context(), updatedUnstructured, metav1.UpdateOptions{})
 		require.NoError(t, err)
 
 		// Wait for reconciliation - connection should become healthy and fieldErrors should be cleared
 		require.Eventually(t, func() bool {
-			conn, err := connClient.Get(ctx, connName, metav1.GetOptions{})
+			conn, err := connClient.Get(t.Context(), connName, metav1.GetOptions{})
 			if err != nil {
 				return false
 			}
@@ -1429,7 +1434,7 @@ func TestIntegrationConnectionController_FieldErrorsCleared(t *testing.T) {
 		}, 15*time.Second, 500*time.Millisecond, "connection should be healthy with fieldErrors cleared")
 
 		// Verify fieldErrors are cleared
-		connHealthy, err := connClient.Get(ctx, connName, metav1.GetOptions{})
+		connHealthy, err := connClient.Get(t.Context(), connName, metav1.GetOptions{})
 		require.NoError(t, err)
 		assert.True(t, connHealthy.Status.Health.Healthy, "connection should be healthy")
 		assert.Empty(t, connHealthy.Status.FieldErrors, "fieldErrors should be cleared when connection becomes healthy")
@@ -1444,7 +1449,6 @@ func TestIntegrationConnectionController_FieldErrorsCleared(t *testing.T) {
 
 func TestIntegrationProvisioning_RepositoryFieldSelectorByConnection(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 	createOptions := metav1.CreateOptions{FieldValidation: "Strict"}
 	privateKeyBase64 := base64.StdEncoding.EncodeToString([]byte(common.TestGithubPrivateKeyPEM))
 
@@ -1471,18 +1475,19 @@ func TestIntegrationProvisioning_RepositoryFieldSelectorByConnection(t *testing.
 		},
 	}}
 
-	c, err := helper.CreateGithubConnection(t, ctx, connection)
+	c, err := helper.CreateGithubConnection(t, connection)
 	require.NoError(t, err, "failed to create connection")
 
 	connectionName := c.GetName()
 
 	t.Cleanup(func() {
+		cleanupCtx := context.WithoutCancel(t.Context())
 		// Clean up repositories first
-		_ = helper.Repositories.Resource.Delete(ctx, "repo-with-connection", metav1.DeleteOptions{})
-		_ = helper.Repositories.Resource.Delete(ctx, "repo-without-connection", metav1.DeleteOptions{})
-		_ = helper.Repositories.Resource.Delete(ctx, "repo-with-different-connection", metav1.DeleteOptions{})
+		_ = helper.Repositories.Resource.Delete(cleanupCtx, "repo-with-connection", metav1.DeleteOptions{})
+		_ = helper.Repositories.Resource.Delete(cleanupCtx, "repo-without-connection", metav1.DeleteOptions{})
+		_ = helper.Repositories.Resource.Delete(cleanupCtx, "repo-with-different-connection", metav1.DeleteOptions{})
 		// Then clean up the connection
-		_ = helper.Connections.Resource.Delete(ctx, connectionName, metav1.DeleteOptions{})
+		_ = helper.Connections.Resource.Delete(cleanupCtx, connectionName, metav1.DeleteOptions{})
 	})
 
 	// Create a repository WITH the connection
@@ -1509,7 +1514,7 @@ func TestIntegrationProvisioning_RepositoryFieldSelectorByConnection(t *testing.
 		},
 	}}
 
-	_, err = helper.Repositories.Resource.Create(ctx, repoWithConnection, createOptions)
+	_, err = helper.Repositories.Resource.Create(t.Context(), repoWithConnection, createOptions)
 	require.NoError(t, err, "failed to create repository with connection")
 
 	// Create a repository WITHOUT the connection
@@ -1533,7 +1538,7 @@ func TestIntegrationProvisioning_RepositoryFieldSelectorByConnection(t *testing.
 		},
 	}}
 
-	_, err = helper.Repositories.Resource.Create(ctx, repoWithoutConnection, createOptions)
+	_, err = helper.Repositories.Resource.Create(t.Context(), repoWithoutConnection, createOptions)
 	require.NoError(t, err, "failed to create repository without connection")
 
 	// Create a repository with a DIFFERENT connection name (non-existent)
@@ -1560,12 +1565,12 @@ func TestIntegrationProvisioning_RepositoryFieldSelectorByConnection(t *testing.
 		},
 	}}
 
-	_, err = helper.Repositories.Resource.Create(ctx, repoWithDifferentConnection, createOptions)
+	_, err = helper.Repositories.Resource.Create(t.Context(), repoWithDifferentConnection, createOptions)
 	require.NoError(t, err, "failed to create repository with different connection")
 
 	t.Run("filter repositories by spec.connection.name", func(t *testing.T) {
 		// List repositories with field selector for the specific connection
-		list, err := helper.Repositories.Resource.List(ctx, metav1.ListOptions{
+		list, err := helper.Repositories.Resource.List(t.Context(), metav1.ListOptions{
 			FieldSelector: "spec.connection.name=" + connectionName,
 		})
 		require.NoError(t, err, "failed to list repositories with field selector")
@@ -1577,7 +1582,7 @@ func TestIntegrationProvisioning_RepositoryFieldSelectorByConnection(t *testing.
 
 	t.Run("filter repositories by non-existent connection returns empty", func(t *testing.T) {
 		// List repositories with field selector for a non-existent connection
-		list, err := helper.Repositories.Resource.List(ctx, metav1.ListOptions{
+		list, err := helper.Repositories.Resource.List(t.Context(), metav1.ListOptions{
 			FieldSelector: "spec.connection.name=non-existent-connection",
 		})
 		require.NoError(t, err, "failed to list repositories with field selector")
@@ -1588,7 +1593,7 @@ func TestIntegrationProvisioning_RepositoryFieldSelectorByConnection(t *testing.
 
 	t.Run("filter repositories by empty connection name", func(t *testing.T) {
 		// List repositories with field selector for empty connection (repos without connection)
-		list, err := helper.Repositories.Resource.List(ctx, metav1.ListOptions{
+		list, err := helper.Repositories.Resource.List(t.Context(), metav1.ListOptions{
 			FieldSelector: "spec.connection.name=",
 		})
 		require.NoError(t, err, "failed to list repositories with empty connection field selector")
@@ -1600,7 +1605,7 @@ func TestIntegrationProvisioning_RepositoryFieldSelectorByConnection(t *testing.
 
 	t.Run("list all repositories without field selector", func(t *testing.T) {
 		// List all repositories without field selector
-		list, err := helper.Repositories.Resource.List(ctx, metav1.ListOptions{})
+		list, err := helper.Repositories.Resource.List(t.Context(), metav1.ListOptions{})
 		require.NoError(t, err, "failed to list all repositories")
 
 		// Should return all three repositories
@@ -1618,7 +1623,6 @@ func TestIntegrationProvisioning_RepositoryFieldSelectorByConnection(t *testing.
 
 func TestIntegrationProvisioning_ConnectionDeleteBlockedByRepository(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 	createOptions := metav1.CreateOptions{}
 	deleteOptions := metav1.DeleteOptions{}
 	privateKeyBase64 := base64.StdEncoding.EncodeToString([]byte(common.TestGithubPrivateKeyPEM))
@@ -1646,7 +1650,7 @@ func TestIntegrationProvisioning_ConnectionDeleteBlockedByRepository(t *testing.
 		},
 	}}
 
-	c, err := helper.Connections.Resource.Create(ctx, connection, createOptions)
+	c, err := helper.Connections.Resource.Create(t.Context(), connection, createOptions)
 	require.NoError(t, err, "failed to create connection")
 
 	connectionName := c.GetName()
@@ -1675,11 +1679,11 @@ func TestIntegrationProvisioning_ConnectionDeleteBlockedByRepository(t *testing.
 		},
 	}}
 
-	_, err = helper.Repositories.Resource.Create(ctx, repo, createOptions)
+	_, err = helper.Repositories.Resource.Create(t.Context(), repo, createOptions)
 	require.NoError(t, err, "failed to create repository referencing connection")
 
 	t.Run("should block connection deletion when referenced by repository", func(t *testing.T) {
-		err := helper.Connections.Resource.Delete(ctx, connectionName, deleteOptions)
+		err := helper.Connections.Resource.Delete(t.Context(), connectionName, deleteOptions)
 		require.Error(t, err, "expected deletion to be blocked")
 
 		// Verify it's an Invalid error (containing Forbidden field error)
@@ -1690,24 +1694,24 @@ func TestIntegrationProvisioning_ConnectionDeleteBlockedByRepository(t *testing.
 
 	t.Run("should allow connection deletion after repository is deleted", func(t *testing.T) {
 		// Delete the repository first
-		err := helper.Repositories.Resource.Delete(ctx, "repo-referencing-connection", deleteOptions)
+		err := helper.Repositories.Resource.Delete(t.Context(), "repo-referencing-connection", deleteOptions)
 		require.NoError(t, err, "failed to delete repository")
 
 		// Wait for the repository to be fully deleted (might have finalizers)
 		require.Eventually(t, func() bool {
-			_, err := helper.Repositories.Resource.Get(ctx, "repo-referencing-connection", metav1.GetOptions{})
+			_, err := helper.Repositories.Resource.Get(t.Context(), "repo-referencing-connection", metav1.GetOptions{})
 			return k8serrors.IsNotFound(err)
 		}, 30*time.Second, 100*time.Millisecond, "repository should be deleted")
 
 		// Now deletion should succeed
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
-			err := helper.Connections.Resource.Delete(ctx, connectionName, deleteOptions)
+			err := helper.Connections.Resource.Delete(t.Context(), connectionName, deleteOptions)
 			require.NoError(collect, err, "failed to delete connection")
 		}, 10*time.Second, 100*time.Millisecond, "deletion should succeed")
 
 		// Verify connection is actually deleted
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
-			_, err = helper.Connections.Resource.Get(ctx, connectionName, metav1.GetOptions{})
+			_, err = helper.Connections.Resource.Get(t.Context(), connectionName, metav1.GetOptions{})
 			require.True(collect, k8serrors.IsNotFound(err), "connection should be deleted")
 		}, 10*time.Second, 100*time.Millisecond, "connection should be deleted")
 	})
@@ -1715,7 +1719,6 @@ func TestIntegrationProvisioning_ConnectionDeleteBlockedByRepository(t *testing.
 
 func TestIntegrationProvisioning_ConnectionDeleteWithNoReferences(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 	createOptions := metav1.CreateOptions{}
 	deleteOptions := metav1.DeleteOptions{}
 	privateKeyBase64 := base64.StdEncoding.EncodeToString([]byte(common.TestGithubPrivateKeyPEM))
@@ -1743,24 +1746,23 @@ func TestIntegrationProvisioning_ConnectionDeleteWithNoReferences(t *testing.T) 
 		},
 	}}
 
-	c, err := helper.Connections.Resource.Create(ctx, connection, createOptions)
+	c, err := helper.Connections.Resource.Create(t.Context(), connection, createOptions)
 	require.NoError(t, err, "failed to create connection")
 
 	connectionName := c.GetName()
 
 	t.Run("should allow deletion of connection with no repository references", func(t *testing.T) {
-		err := helper.Connections.Resource.Delete(ctx, connectionName, deleteOptions)
+		err := helper.Connections.Resource.Delete(t.Context(), connectionName, deleteOptions)
 		require.NoError(t, err, "expected deletion to succeed for unreferenced connection")
 
 		// Verify connection is deleted
-		_, err = helper.Connections.Resource.Get(ctx, connectionName, metav1.GetOptions{})
+		_, err = helper.Connections.Resource.Get(t.Context(), connectionName, metav1.GetOptions{})
 		assert.True(t, k8serrors.IsNotFound(err), "connection should be deleted")
 	})
 }
 
 func TestIntegrationConnectionController_GranularConditionReasons(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 	namespace := "default"
 
 	// Create typed client from REST config
@@ -1794,7 +1796,7 @@ func TestIntegrationConnectionController_GranularConditionReasons(t *testing.T) 
 			},
 		}}
 
-		createdUnstructured, err := helper.CreateGithubConnection(t, ctx, connUnstructured)
+		createdUnstructured, err := helper.CreateGithubConnection(t, connUnstructured)
 		require.NoError(t, err)
 		require.NotNil(t, createdUnstructured)
 
@@ -1820,12 +1822,13 @@ func TestIntegrationConnectionController_GranularConditionReasons(t *testing.T) 
 		connName := createdUnstructured.GetName()
 
 		t.Cleanup(func() {
-			_ = helper.Connections.Resource.Delete(ctx, connName, metav1.DeleteOptions{})
+			cleanupCtx := context.WithoutCancel(t.Context())
+			_ = helper.Connections.Resource.Delete(cleanupCtx, connName, metav1.DeleteOptions{})
 		})
 
 		// Wait for reconciliation - connection should become unhealthy with ServiceUnavailable reason
 		require.Eventually(t, func() bool {
-			conn, err := connClient.Get(ctx, connName, metav1.GetOptions{})
+			conn, err := connClient.Get(t.Context(), connName, metav1.GetOptions{})
 			if err != nil {
 				return false
 			}
@@ -1835,7 +1838,7 @@ func TestIntegrationConnectionController_GranularConditionReasons(t *testing.T) 
 		}, 15*time.Second, 500*time.Millisecond, "connection should be reconciled and marked unhealthy")
 
 		// Verify the connection has ServiceUnavailable reason
-		conn, err := connClient.Get(ctx, connName, metav1.GetOptions{})
+		conn, err := connClient.Get(t.Context(), connName, metav1.GetOptions{})
 		require.NoError(t, err)
 		assert.False(t, conn.Status.Health.Healthy, "connection should be unhealthy")
 		readyCondition := meta.FindStatusCondition(conn.Status.Conditions, provisioning.ConditionTypeReady)
@@ -1946,7 +1949,6 @@ func createAppInstallationWithPermissions(id int64, permissions map[string]strin
 
 func TestIntegrationProvisioning_GithubAppPermissionValidation(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	// Base64 encoded test private key
 	privateKeyBase64 := base64.StdEncoding.EncodeToString([]byte(common.TestGithubPrivateKeyPEM))
@@ -2090,12 +2092,13 @@ func TestIntegrationProvisioning_GithubAppPermissionValidation(t *testing.T) {
 				},
 			}}
 
-			c, err := helper.Connections.Resource.Create(ctx, connection, metav1.CreateOptions{})
+			c, err := helper.Connections.Resource.Create(t.Context(), connection, metav1.CreateOptions{})
 			require.NoError(t, err)
 			require.NotNil(t, c)
 			t.Cleanup(func() {
+				cleanupCtx := context.WithoutCancel(t.Context())
 				require.EventuallyWithT(t, func(collect *assert.CollectT) {
-					err := helper.Connections.Resource.Delete(ctx, c.GetName(), metav1.DeleteOptions{})
+					err := helper.Connections.Resource.Delete(cleanupCtx, c.GetName(), metav1.DeleteOptions{})
 					require.NoError(collect, err)
 				}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
 			})
@@ -2109,7 +2112,7 @@ func TestIntegrationProvisioning_GithubAppPermissionValidation(t *testing.T) {
 			var conn *provisioning.Connection
 			require.Eventually(t, func() bool {
 				var err error
-				conn, err = connClient.Get(ctx, c.GetName(), metav1.GetOptions{})
+				conn, err = connClient.Get(t.Context(), c.GetName(), metav1.GetOptions{})
 				if err != nil {
 					return false
 				}
@@ -2159,7 +2162,6 @@ func TestIntegrationProvisioning_GithubAppPermissionValidation(t *testing.T) {
 
 func TestIntegrationProvisioning_GithubAppInstallationPermissionValidation(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	// Base64 encoded test private key
 	privateKeyBase64 := base64.StdEncoding.EncodeToString([]byte(common.TestGithubPrivateKeyPEM))
@@ -2307,12 +2309,13 @@ func TestIntegrationProvisioning_GithubAppInstallationPermissionValidation(t *te
 				},
 			}}
 
-			c, err := helper.Connections.Resource.Create(ctx, connection, metav1.CreateOptions{})
+			c, err := helper.Connections.Resource.Create(t.Context(), connection, metav1.CreateOptions{})
 			require.NoError(t, err)
 			require.NotNil(t, c)
 			t.Cleanup(func() {
+				cleanupCtx := context.WithoutCancel(t.Context())
 				require.EventuallyWithT(t, func(collect *assert.CollectT) {
-					err := helper.Connections.Resource.Delete(ctx, c.GetName(), metav1.DeleteOptions{})
+					err := helper.Connections.Resource.Delete(cleanupCtx, c.GetName(), metav1.DeleteOptions{})
 					require.NoError(collect, err)
 				}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
 			})
@@ -2326,7 +2329,7 @@ func TestIntegrationProvisioning_GithubAppInstallationPermissionValidation(t *te
 			var conn *provisioning.Connection
 			require.Eventually(t, func() bool {
 				var err error
-				conn, err = connClient.Get(ctx, c.GetName(), metav1.GetOptions{})
+				conn, err = connClient.Get(t.Context(), c.GetName(), metav1.GetOptions{})
 				if err != nil {
 					return false
 				}

--- a/pkg/tests/apis/provisioning/connection/github_branch_protection_test.go
+++ b/pkg/tests/apis/provisioning/connection/github_branch_protection_test.go
@@ -1,7 +1,6 @@
 package connection
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -24,7 +23,6 @@ import (
 // when configuring a GitHub repository with the write workflow.
 func TestIntegrationGitHubBranchProtection(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	// Start test git server that responds to nanogit's smart HTTP protocol
 	gitServer := startTestGitServer(t)
@@ -91,7 +89,7 @@ func TestIntegrationGitHubBranchProtection(t *testing.T) {
 			SubResource("test").
 			Body(makeRepoConfig("test-bp-required-pr", []string{"write"})).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).
+			Do(t.Context()).
 			Raw()
 
 		var testResults provisioning.TestResults
@@ -133,7 +131,7 @@ func TestIntegrationGitHubBranchProtection(t *testing.T) {
 			SubResource("test").
 			Body(makeRepoConfig("test-bp-locked", []string{"write"})).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).
+			Do(t.Context()).
 			Raw()
 
 		var testResults provisioning.TestResults
@@ -176,7 +174,7 @@ func TestIntegrationGitHubBranchProtection(t *testing.T) {
 			SubResource("test").
 			Body(makeRepoConfig("test-bp-multiple", []string{"write"})).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).
+			Do(t.Context()).
 			Raw()
 
 		var testResults provisioning.TestResults
@@ -218,7 +216,7 @@ func TestIntegrationGitHubBranchProtection(t *testing.T) {
 			SubResource("test").
 			Body(makeRepoConfig("test-bp-unprotected", []string{"write"})).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx)
+			Do(t.Context())
 
 		require.NoError(t, result.Error())
 
@@ -255,7 +253,7 @@ func TestIntegrationGitHubBranchProtection(t *testing.T) {
 			SubResource("test").
 			Body(makeRepoConfig("test-bp-branch-wf", []string{"branch"})).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx)
+			Do(t.Context())
 
 		require.NoError(t, result.Error())
 
@@ -297,7 +295,7 @@ func TestIntegrationGitHubBranchProtection(t *testing.T) {
 			SubResource("test").
 			Body(makeRepoConfig("test-bp-forbidden", []string{"write"})).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx)
+			Do(t.Context())
 
 		require.NoError(t, result.Error())
 
@@ -350,7 +348,7 @@ func TestIntegrationGitHubBranchProtection(t *testing.T) {
 			SubResource("test").
 			Body(makeRepoConfig("test-ruleset-pr", []string{"write"})).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).
+			Do(t.Context()).
 			Raw()
 
 		var testResults provisioning.TestResults
@@ -402,7 +400,7 @@ func TestIntegrationGitHubBranchProtection(t *testing.T) {
 			SubResource("test").
 			Body(makeRepoConfig("test-ruleset-non-blocking", []string{"write"})).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).
+			Do(t.Context()).
 			Raw()
 
 		var testResults provisioning.TestResults
@@ -451,7 +449,7 @@ func TestIntegrationGitHubBranchProtection(t *testing.T) {
 			SubResource("test").
 			Body(makeRepoConfig("test-combined-protection", []string{"write"})).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).
+			Do(t.Context()).
 			Raw()
 
 		var testResults provisioning.TestResults
@@ -497,7 +495,7 @@ func TestIntegrationGitHubBranchProtection(t *testing.T) {
 			SubResource("test").
 			Body(makeRepoConfig("test-disabled-ruleset", []string{"write"})).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx)
+			Do(t.Context())
 
 		require.NoError(t, result.Error())
 
@@ -541,7 +539,7 @@ func TestIntegrationGitHubBranchProtection(t *testing.T) {
 			SubResource("test").
 			Body(makeRepoConfig("test-non-matching-ruleset", []string{"write"})).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx)
+			Do(t.Context())
 
 		require.NoError(t, result.Error())
 
@@ -585,7 +583,7 @@ func TestIntegrationGitHubBranchProtection(t *testing.T) {
 			SubResource("test").
 			Body(makeRepoConfig("test-ruleset-forbidden", []string{"write"})).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx)
+			Do(t.Context())
 
 		require.NoError(t, result.Error())
 
@@ -660,7 +658,6 @@ func startTestGitServer(t *testing.T) *httptest.Server {
 // are created successfully, but their health status reflects the branch protection issue.
 func TestIntegrationGitHubBranchProtection_HealthStatus(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	// Start test git server
 	gitServer := startTestGitServer(t)
@@ -723,7 +720,7 @@ func TestIntegrationGitHubBranchProtection_HealthStatus(t *testing.T) {
 			Resource("repositories").
 			Body(body).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx)
+			Do(t.Context())
 
 		// Repository creation should succeed
 		require.NoError(t, result.Error(), "repository creation should succeed even with protected branch")
@@ -736,7 +733,7 @@ func TestIntegrationGitHubBranchProtection_HealthStatus(t *testing.T) {
 
 		// Wait for health check to run and mark repository as unhealthy
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
-			repoStatus, err := helper.Repositories.Resource.Get(ctx, "test-health-pr-reviews", metav1.GetOptions{})
+			repoStatus, err := helper.Repositories.Resource.Get(t.Context(), "test-health-pr-reviews", metav1.GetOptions{})
 			if !assert.NoError(collect, err, "failed to get repository status") {
 				return
 			}
@@ -824,7 +821,7 @@ func TestIntegrationGitHubBranchProtection_HealthStatus(t *testing.T) {
 			Resource("repositories").
 			Body(body).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx)
+			Do(t.Context())
 
 		// Repository creation should succeed
 		require.NoError(t, result.Error(), "repository creation should succeed even with locked branch")
@@ -837,7 +834,7 @@ func TestIntegrationGitHubBranchProtection_HealthStatus(t *testing.T) {
 
 		// Wait for health check to run and mark repository as unhealthy
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
-			repoStatus, err := helper.Repositories.Resource.Get(ctx, "test-health-locked", metav1.GetOptions{})
+			repoStatus, err := helper.Repositories.Resource.Get(t.Context(), "test-health-locked", metav1.GetOptions{})
 			if !assert.NoError(collect, err, "failed to get repository status") {
 				return
 			}
@@ -924,7 +921,7 @@ func TestIntegrationGitHubBranchProtection_HealthStatus(t *testing.T) {
 			Resource("repositories").
 			Body(body).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx)
+			Do(t.Context())
 
 		// Repository creation should succeed
 		require.NoError(t, result.Error(), "repository creation should succeed with unprotected branch")
@@ -937,7 +934,7 @@ func TestIntegrationGitHubBranchProtection_HealthStatus(t *testing.T) {
 
 		// Wait for health check to run, then verify no branch protection errors
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
-			repoStatus, err := helper.Repositories.Resource.Get(ctx, "test-health-unprotected", metav1.GetOptions{})
+			repoStatus, err := helper.Repositories.Resource.Get(t.Context(), "test-health-unprotected", metav1.GetOptions{})
 			if !assert.NoError(collect, err, "failed to get repository status") {
 				return
 			}

--- a/pkg/tests/apis/provisioning/connection/pending_delete_test.go
+++ b/pkg/tests/apis/provisioning/connection/pending_delete_test.go
@@ -47,7 +47,7 @@ func TestIntegrationProvisioning_ConnectionPendingDeleteLabel_SkipsReconciliatio
 		},
 	}}
 
-	_, err := helper.CreateGithubConnection(t, t.Context(), connObj)
+	_, err := helper.CreateGithubConnection(t, connObj)
 	require.NoError(t, err)
 
 	// After the initial reconciliation the controller has observed the current spec,
@@ -167,7 +167,7 @@ func TestIntegrationProvisioning_ConnectionPendingDeleteAdmission(t *testing.T) 
 	// Sufficient for tests that exercise the admission webhook synchronously.
 	createConn := func(t *testing.T, name string) {
 		t.Helper()
-		_, err := helper.CreateGithubConnection(t, t.Context(), makeConnObj(name))
+		_, err := helper.CreateGithubConnection(t, makeConnObj(name))
 		require.NoError(t, err)
 	}
 

--- a/pkg/tests/apis/provisioning/connection/repositories_test.go
+++ b/pkg/tests/apis/provisioning/connection/repositories_test.go
@@ -1,7 +1,6 @@
 package connection
 
 import (
-	"context"
 	"encoding/base64"
 	"encoding/json"
 	"net/http"
@@ -17,7 +16,6 @@ import (
 
 func TestIntegrationProvisioning_ConnectionRepositories(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 	privateKeyBase64 := base64.StdEncoding.EncodeToString([]byte(common.TestGithubPrivateKeyPEM))
 	connectionName := "connection-repositories-test"
 
@@ -43,7 +41,7 @@ func TestIntegrationProvisioning_ConnectionRepositories(t *testing.T) {
 			},
 		},
 	}}
-	_, err := helper.CreateGithubConnection(t, ctx, connection)
+	_, err := helper.CreateGithubConnection(t, connection)
 	require.NoError(t, err)
 
 	t.Run("admin can access endpoint and get repository list", func(t *testing.T) {
@@ -54,7 +52,7 @@ func TestIntegrationProvisioning_ConnectionRepositories(t *testing.T) {
 			Resource("connections").
 			Name(connectionName).
 			SubResource("repositories").
-			Do(ctx).
+			Do(t.Context()).
 			StatusCode(&statusCode)
 
 		// Endpoint is implemented and should return 200 with repository list
@@ -89,7 +87,7 @@ func TestIntegrationProvisioning_ConnectionRepositories(t *testing.T) {
 			Resource("connections").
 			Name(connectionName).
 			SubResource("repositories").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.Error(t, result.Error(), "editor should not be able to access repositories endpoint")
 		require.Equal(t, http.StatusForbidden, statusCode, "should return 403 Forbidden")
@@ -103,7 +101,7 @@ func TestIntegrationProvisioning_ConnectionRepositories(t *testing.T) {
 			Resource("connections").
 			Name(connectionName).
 			SubResource("repositories").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.Error(t, result.Error(), "viewer should not be able to access repositories endpoint")
 		require.Equal(t, http.StatusForbidden, statusCode, "should return 403 Forbidden")
@@ -121,7 +119,7 @@ func TestIntegrationProvisioning_ConnectionRepositories(t *testing.T) {
 			SubResource("repositories").
 			Body(configBytes).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.Error(t, result.Error(), "POST should not be allowed")
 		require.True(t, apierrors.IsMethodNotSupported(result.Error()), "error should be MethodNotSupported")
@@ -130,7 +128,6 @@ func TestIntegrationProvisioning_ConnectionRepositories(t *testing.T) {
 
 func TestIntegrationProvisioning_ConnectionRepositoriesResponseType(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 	privateKeyBase64 := base64.StdEncoding.EncodeToString([]byte(common.TestGithubPrivateKeyPEM))
 
 	// Create a connection for testing
@@ -155,7 +152,7 @@ func TestIntegrationProvisioning_ConnectionRepositoriesResponseType(t *testing.T
 			},
 		},
 	}}
-	_, err := helper.CreateGithubConnection(t, ctx, connection)
+	_, err := helper.CreateGithubConnection(t, connection)
 	require.NoError(t, err)
 
 	t.Run("verify ExternalRepositoryList type exists in API", func(t *testing.T) {

--- a/pkg/tests/apis/provisioning/connection/repositories_test.go
+++ b/pkg/tests/apis/provisioning/connection/repositories_test.go
@@ -16,6 +16,7 @@ import (
 
 func TestIntegrationProvisioning_ConnectionRepositories(t *testing.T) {
 	helper := sharedHelper(t)
+
 	privateKeyBase64 := base64.StdEncoding.EncodeToString([]byte(common.TestGithubPrivateKeyPEM))
 	connectionName := "connection-repositories-test"
 
@@ -128,6 +129,7 @@ func TestIntegrationProvisioning_ConnectionRepositories(t *testing.T) {
 
 func TestIntegrationProvisioning_ConnectionRepositoriesResponseType(t *testing.T) {
 	helper := sharedHelper(t)
+
 	privateKeyBase64 := base64.StdEncoding.EncodeToString([]byte(common.TestGithubPrivateKeyPEM))
 
 	// Create a connection for testing

--- a/pkg/tests/apis/provisioning/connection/status_auth_test.go
+++ b/pkg/tests/apis/provisioning/connection/status_auth_test.go
@@ -14,6 +14,7 @@ import (
 
 func TestIntegrationProvisioning_ConnectionStatusAuthorization(t *testing.T) {
 	helper := sharedHelper(t)
+
 	privateKeyBase64 := base64.StdEncoding.EncodeToString([]byte(common.TestGithubPrivateKeyPEM))
 
 	// Create a connection for testing

--- a/pkg/tests/apis/provisioning/connection/status_auth_test.go
+++ b/pkg/tests/apis/provisioning/connection/status_auth_test.go
@@ -1,7 +1,6 @@
 package connection
 
 import (
-	"context"
 	"encoding/base64"
 	"net/http"
 	"testing"
@@ -15,7 +14,6 @@ import (
 
 func TestIntegrationProvisioning_ConnectionStatusAuthorization(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 	privateKeyBase64 := base64.StdEncoding.EncodeToString([]byte(common.TestGithubPrivateKeyPEM))
 
 	// Create a connection for testing
@@ -40,7 +38,7 @@ func TestIntegrationProvisioning_ConnectionStatusAuthorization(t *testing.T) {
 			},
 		},
 	}}
-	c, err := helper.CreateGithubConnection(t, ctx, connection)
+	c, err := helper.CreateGithubConnection(t, connection)
 	require.NoError(t, err)
 
 	connectionName := c.GetName()
@@ -52,7 +50,7 @@ func TestIntegrationProvisioning_ConnectionStatusAuthorization(t *testing.T) {
 			Resource("connections").
 			Name(connectionName).
 			SubResource("status").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.NoError(t, result.Error(), "admin should be able to GET connection status")
 		require.Equal(t, http.StatusOK, statusCode, "should return 200 OK")
@@ -65,7 +63,7 @@ func TestIntegrationProvisioning_ConnectionStatusAuthorization(t *testing.T) {
 			Resource("connections").
 			Name(connectionName).
 			SubResource("status").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.Error(t, result.Error(), "editor should not be able to GET connection status")
 		require.Equal(t, http.StatusForbidden, statusCode, "should return 403 Forbidden")
@@ -79,7 +77,7 @@ func TestIntegrationProvisioning_ConnectionStatusAuthorization(t *testing.T) {
 			Resource("connections").
 			Name(connectionName).
 			SubResource("status").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.Error(t, result.Error(), "viewer should not be able to GET connection status")
 		require.Equal(t, http.StatusForbidden, statusCode, "should return 403 Forbidden")

--- a/pkg/tests/apis/provisioning/fieldselector_test.go
+++ b/pkg/tests/apis/provisioning/fieldselector_test.go
@@ -1,7 +1,6 @@
 package provisioning
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -17,7 +16,6 @@ import (
 // fieldSelector=metadata.name=<name> was not working properly.
 func TestIntegrationProvisioning_RepositoryFieldSelector(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	// Create multiple repositories for testing
 	repo1Name := "repo-selector-test-1"
@@ -42,12 +40,12 @@ func TestIntegrationProvisioning_RepositoryFieldSelector(t *testing.T) {
 	})
 
 	// Verify all repositories were created
-	allRepos, err := helper.Repositories.Resource.List(ctx, metav1.ListOptions{})
+	allRepos, err := helper.Repositories.Resource.List(t.Context(), metav1.ListOptions{})
 	require.NoError(t, err, "should be able to list all repositories")
 	require.GreaterOrEqual(t, len(allRepos.Items), 3, "should have at least 3 repositories")
 
 	t.Run("should filter by metadata.name and return single repository", func(t *testing.T) {
-		list, err := helper.Repositories.Resource.List(ctx, metav1.ListOptions{
+		list, err := helper.Repositories.Resource.List(t.Context(), metav1.ListOptions{
 			FieldSelector: "metadata.name=" + repo2Name,
 		})
 		require.NoError(t, err, "fieldSelector query should succeed")
@@ -56,7 +54,7 @@ func TestIntegrationProvisioning_RepositoryFieldSelector(t *testing.T) {
 	})
 
 	t.Run("should filter by different metadata.name", func(t *testing.T) {
-		list, err := helper.Repositories.Resource.List(ctx, metav1.ListOptions{
+		list, err := helper.Repositories.Resource.List(t.Context(), metav1.ListOptions{
 			FieldSelector: "metadata.name=" + repo1Name,
 		})
 		require.NoError(t, err, "fieldSelector query should succeed")
@@ -65,7 +63,7 @@ func TestIntegrationProvisioning_RepositoryFieldSelector(t *testing.T) {
 	})
 
 	t.Run("should return empty when fieldSelector does not match any repository", func(t *testing.T) {
-		list, err := helper.Repositories.Resource.List(ctx, metav1.ListOptions{
+		list, err := helper.Repositories.Resource.List(t.Context(), metav1.ListOptions{
 			FieldSelector: "metadata.name=non-existent-repository",
 		})
 		require.NoError(t, err, "fieldSelector query should succeed even with no matches")
@@ -73,7 +71,7 @@ func TestIntegrationProvisioning_RepositoryFieldSelector(t *testing.T) {
 	})
 
 	t.Run("listing without fieldSelector should return all repositories", func(t *testing.T) {
-		list, err := helper.Repositories.Resource.List(ctx, metav1.ListOptions{})
+		list, err := helper.Repositories.Resource.List(t.Context(), metav1.ListOptions{})
 		require.NoError(t, err, "should be able to list without fieldSelector")
 		require.GreaterOrEqual(t, len(list.Items), 3, "should return all repositories when no filter is applied")
 
@@ -93,7 +91,6 @@ func TestIntegrationProvisioning_RepositoryFieldSelector(t *testing.T) {
 // fieldSelector=metadata.name=<name> was not working properly.
 func TestIntegrationProvisioning_JobFieldSelector(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	// Create a repository to trigger jobs
 	repoName := "job-selector-test-repo"
@@ -122,7 +119,7 @@ func TestIntegrationProvisioning_JobFieldSelector(t *testing.T) {
 		SubResource("jobs").
 		Body(body1).
 		SetHeader("Content-Type", "application/json").
-		Do(ctx)
+		Do(t.Context())
 	require.NoError(t, result1.Error(), "should be able to trigger first job")
 
 	obj1, err := result1.Get()
@@ -142,7 +139,7 @@ func TestIntegrationProvisioning_JobFieldSelector(t *testing.T) {
 		SubResource("jobs").
 		Body(body1).
 		SetHeader("Content-Type", "application/json").
-		Do(ctx)
+		Do(t.Context())
 	require.NoError(t, result2.Error(), "should be able to trigger second job")
 
 	obj2, err := result2.Get()
@@ -153,7 +150,7 @@ func TestIntegrationProvisioning_JobFieldSelector(t *testing.T) {
 
 	t.Run("should filter by metadata.name and return single job", func(t *testing.T) {
 		// Note: Jobs are ephemeral and may complete quickly, so we test while they exist
-		list, err := helper.Jobs.Resource.List(ctx, metav1.ListOptions{
+		list, err := helper.Jobs.Resource.List(t.Context(), metav1.ListOptions{
 			FieldSelector: "metadata.name=" + job2Name,
 		})
 		require.NoError(t, err, "fieldSelector query should succeed")
@@ -166,7 +163,7 @@ func TestIntegrationProvisioning_JobFieldSelector(t *testing.T) {
 	})
 
 	t.Run("should filter by different metadata.name", func(t *testing.T) {
-		list, err := helper.Jobs.Resource.List(ctx, metav1.ListOptions{
+		list, err := helper.Jobs.Resource.List(t.Context(), metav1.ListOptions{
 			FieldSelector: "metadata.name=" + job1Name,
 		})
 		require.NoError(t, err, "fieldSelector query should succeed")
@@ -179,7 +176,7 @@ func TestIntegrationProvisioning_JobFieldSelector(t *testing.T) {
 	})
 
 	t.Run("should return empty when fieldSelector does not match any job", func(t *testing.T) {
-		list, err := helper.Jobs.Resource.List(ctx, metav1.ListOptions{
+		list, err := helper.Jobs.Resource.List(t.Context(), metav1.ListOptions{
 			FieldSelector: "metadata.name=non-existent-job",
 		})
 		require.NoError(t, err, "fieldSelector query should succeed even with no matches")
@@ -187,7 +184,7 @@ func TestIntegrationProvisioning_JobFieldSelector(t *testing.T) {
 	})
 
 	t.Run("listing without fieldSelector should work", func(t *testing.T) {
-		list, err := helper.Jobs.Resource.List(ctx, metav1.ListOptions{})
+		list, err := helper.Jobs.Resource.List(t.Context(), metav1.ListOptions{})
 		require.NoError(t, err, "should be able to list without fieldSelector")
 		// Jobs may have completed, so we don't assert on count, just that the query works
 		t.Logf("Found %d active jobs without filter", len(list.Items))

--- a/pkg/tests/apis/provisioning/files_test.go
+++ b/pkg/tests/apis/provisioning/files_test.go
@@ -53,7 +53,6 @@ func TestIntegrationProvisioning_EmptyRepositoryFileList(t *testing.T) {
 
 func TestIntegrationProvisioning_DeleteResources(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	const repo = "delete-test-repo"
 	helper.CreateLocalRepo(t, common.TestRepo{
@@ -97,7 +96,7 @@ func TestIntegrationProvisioning_DeleteResources(t *testing.T) {
 		assert.Len(collect, folders.Items, 2)
 	}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "should have the expected dashboards and folders after sync")
 
-	helper.ValidateManagedDashboardsFolderMetadata(t, ctx, repo, dashboards.Items)
+	helper.ValidateManagedDashboardsFolderMetadata(t, repo, dashboards.Items)
 
 	t.Run("delete individual dashboard file on configured branch should succeed", func(t *testing.T) {
 		result := helper.AdminREST.Delete().
@@ -105,12 +104,12 @@ func TestIntegrationProvisioning_DeleteResources(t *testing.T) {
 			Resource("repositories").
 			Name(repo).
 			SubResource("files", "dashboard1.json").
-			Do(ctx)
+			Do(t.Context())
 		require.NoError(t, result.Error(), "delete file on configured branch should succeed")
 
 		// Verify the dashboard is removed from Grafana
 		const allPanelsUID = "n1jR8vnnz" // UID from all-panels.json
-		_, err := helper.DashboardsV1.Resource.Get(ctx, allPanelsUID, metav1.GetOptions{})
+		_, err := helper.DashboardsV1.Resource.Get(t.Context(), allPanelsUID, metav1.GetOptions{})
 		require.Error(t, err, "dashboard should be deleted from Grafana")
 		require.True(t, apierrors.IsNotFound(err), "should return NotFound for deleted dashboard")
 	})
@@ -127,7 +126,7 @@ func TestIntegrationProvisioning_DeleteResources(t *testing.T) {
 			Name(repo).
 			SubResource("files", "branch-test-delete.json").
 			Param("ref", branchRef).
-			Do(ctx)
+			Do(t.Context())
 		// Note: This might fail if branch doesn't exist, but the important thing is it doesn't return MethodNotAllowed
 		if result.Error() != nil {
 			var statusErr *apierrors.StatusError
@@ -151,7 +150,7 @@ func TestIntegrationProvisioning_DeleteResources(t *testing.T) {
 		require.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode, "should return MethodNotAllowed for configured branch folder delete")
 
 		// Verify a file inside the folder still exists (operation was rejected)
-		_, err = helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "folder", "dashboard2.json")
+		_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "folder", "dashboard2.json")
 		require.NoError(t, err, "file inside folder should still exist after rejected delete")
 	})
 
@@ -161,14 +160,13 @@ func TestIntegrationProvisioning_DeleteResources(t *testing.T) {
 			Resource("repositories").
 			Name(repo).
 			SubResource("files", "non-existent.json").
-			Do(ctx)
+			Do(t.Context())
 		require.Error(t, result.Error())
 	})
 }
 
 func TestIntegrationProvisioning_MoveResources(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 	repo := "move-test-repo"
 	helper.CreateLocalRepo(t, common.TestRepo{
 		Name:       repo,
@@ -183,15 +181,15 @@ func TestIntegrationProvisioning_MoveResources(t *testing.T) {
 	})
 
 	// Validate the dashboard metadata
-	dashboards, err := helper.DashboardsV1.Resource.List(ctx, metav1.ListOptions{})
+	dashboards, err := helper.DashboardsV1.Resource.List(t.Context(), metav1.ListOptions{})
 	require.NoError(t, err)
 	require.Equal(t, 1, len(dashboards.Items))
 
-	helper.ValidateManagedDashboardsFolderMetadata(t, ctx, repo, dashboards.Items)
+	helper.ValidateManagedDashboardsFolderMetadata(t, repo, dashboards.Items)
 
 	// Verify the original dashboard exists in Grafana (using the UID from all-panels.json)
 	const allPanelsUID = "n1jR8vnnz" // This is the UID from the all-panels.json file
-	obj, err := helper.DashboardsV1.Resource.Get(ctx, allPanelsUID, metav1.GetOptions{})
+	obj, err := helper.DashboardsV1.Resource.Get(t.Context(), allPanelsUID, metav1.GetOptions{})
 	require.NoError(t, err, "original dashboard should exist in Grafana")
 	require.Equal(t, repo, obj.GetAnnotations()[utils.AnnoKeyManagerIdentity])
 
@@ -209,11 +207,11 @@ func TestIntegrationProvisioning_MoveResources(t *testing.T) {
 		require.Equal(t, http.StatusOK, resp.StatusCode, "move operation on configured branch should succeed")
 
 		// Verify file was moved - read from new location
-		_, err = helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "moved", "simple-move.json")
+		_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "moved", "simple-move.json")
 		require.NoError(t, err, "file should exist at new location")
 
 		// Verify file no longer exists at old location
-		_, err = helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "all-panels.json")
+		_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "all-panels.json")
 		require.Error(t, err, "file should not exist at old location")
 	})
 
@@ -237,7 +235,7 @@ func TestIntegrationProvisioning_MoveResources(t *testing.T) {
 
 		// If move succeeded (not MethodNotAllowed), verify the file moved in the repository
 		if resp.StatusCode == http.StatusOK {
-			movedObj, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "moved", "simple-move-branch.json")
+			movedObj, err := helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "moved", "simple-move-branch.json")
 			require.NoError(t, err, "moved file should exist in repository")
 
 			// Check the content is preserved (verify it's still the all-panels dashboard)
@@ -271,11 +269,11 @@ func TestIntegrationProvisioning_MoveResources(t *testing.T) {
 		require.Equal(t, http.StatusOK, resp.StatusCode, "move operation on configured branch should succeed")
 
 		// File should exist at new location
-		_, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "deep", "nested", "timeline.json")
+		_, err := helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "deep", "nested", "timeline.json")
 		require.NoError(t, err, "file should exist at new nested location")
 
 		// File should not exist at original location
-		_, err = helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", sourceFile)
+		_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", sourceFile)
 		require.Error(t, err, "file should not exist at original location after move")
 	})
 
@@ -298,7 +296,7 @@ func TestIntegrationProvisioning_MoveResources(t *testing.T) {
 		require.Equal(t, http.StatusOK, resp.StatusCode, "move with content update on configured branch should succeed")
 
 		// File should exist at new location with updated content
-		movedObj, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "updated", "content-updated.json")
+		movedObj, err := helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "updated", "content-updated.json")
 		require.NoError(t, err, "file should exist at new location")
 
 		// Verify content was updated (should be text-options dashboard now)
@@ -311,7 +309,7 @@ func TestIntegrationProvisioning_MoveResources(t *testing.T) {
 		require.Equal(t, "Text options", title, "content should be updated")
 
 		// Source file should not exist anymore
-		_, err = helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", sourcePath)
+		_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", sourcePath)
 		require.Error(t, err, "source file should not exist after move")
 	})
 
@@ -344,7 +342,7 @@ func TestIntegrationProvisioning_MoveResources(t *testing.T) {
 		require.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode, "directory move on configured branch should return MethodNotAllowed")
 
 		// Verify files in source directory still exist (operation was rejected)
-		_, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "source-dir", "timeline-demo.json")
+		_, err := helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "source-dir", "timeline-demo.json")
 		require.NoError(t, err, "file in source directory should still exist after rejected move")
 	})
 
@@ -357,7 +355,7 @@ func TestIntegrationProvisioning_MoveResources(t *testing.T) {
 				SubResource("files", "target.json").
 				Body([]byte(`{"test": "content"}`)).
 				SetHeader("Content-Type", "application/json").
-				Do(ctx)
+				Do(t.Context())
 			require.Error(t, result.Error(), "should fail without originalPath")
 		})
 
@@ -370,7 +368,7 @@ func TestIntegrationProvisioning_MoveResources(t *testing.T) {
 				SubResource("files", "simple-test.json").
 				Body(helper.LoadFile("testdata/all-panels.json")).
 				SetHeader("Content-Type", "application/json").
-				Do(ctx)
+				Do(t.Context())
 			require.NoError(t, result.Error(), "should create test file")
 
 			// Now try to move this file to a directory path using helper function
@@ -398,7 +396,7 @@ func TestIntegrationProvisioning_MoveResources(t *testing.T) {
 				Param("originalPath", "non-existent.json").
 				Body([]byte("")).
 				SetHeader("Content-Type", "application/json").
-				Do(ctx)
+				Do(t.Context())
 			require.Error(t, result.Error(), "should fail when source file doesn't exist")
 		})
 	})
@@ -406,7 +404,6 @@ func TestIntegrationProvisioning_MoveResources(t *testing.T) {
 
 func TestIntegrationProvisioning_FilesOwnershipProtection(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	const repo1 = "ownership-repo-1"
 	helper.CreateLocalRepo(t, common.TestRepo{
@@ -456,7 +453,7 @@ func TestIntegrationProvisioning_FilesOwnershipProtection(t *testing.T) {
 		assert.Len(collect, folders.Items, 2)
 	}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "should have the expected dashboards and folders after sync")
 
-	allDashboards, err := helper.DashboardsV1.Resource.List(ctx, metav1.ListOptions{})
+	allDashboards, err := helper.DashboardsV1.Resource.List(t.Context(), metav1.ListOptions{})
 	require.NoError(t, err)
 	for _, dashboard := range allDashboards.Items {
 		annotations := dashboard.GetAnnotations()
@@ -477,7 +474,7 @@ func TestIntegrationProvisioning_FilesOwnershipProtection(t *testing.T) {
 			SubResource("files", "conflicting-dashboard.json").
 			Body(helper.LoadFile("testdata/all-panels.json")). // Same file = same UID
 			SetHeader("Content-Type", "application/json").
-			Do(ctx)
+			Do(t.Context())
 
 		// This should fail with ownership conflict
 		require.Error(t, result.Error(), "creating resource with UID already owned by different repository should fail")
@@ -512,7 +509,7 @@ func TestIntegrationProvisioning_FilesOwnershipProtection(t *testing.T) {
 			SubResource("files", "conflicting-update.json").
 			Body(helper.LoadFile("testdata/all-panels.json")). // Same UID as repo1's dashboard
 			SetHeader("Content-Type", "application/json").
-			Do(ctx)
+			Do(t.Context())
 
 		// This should fail with ownership conflict
 		require.Error(t, result.Error(), "updating resource owned by different repository should fail")
@@ -549,7 +546,7 @@ func TestIntegrationProvisioning_FilesOwnershipProtection(t *testing.T) {
 			Name(repo2).
 			SubResource("files", "conflicting-delete.json").
 			SetHeader("Content-Type", "application/json").
-			Do(ctx)
+			Do(t.Context())
 
 		// This should fail with ownership conflict
 		require.Error(t, result.Error(), "deleting resource owned by different repository should fail")
@@ -604,12 +601,12 @@ func TestIntegrationProvisioning_FilesOwnershipProtection(t *testing.T) {
 		const timelineUID = "mIJjFy8Kz"  // UID from timeline-demo.json (repo2)
 
 		// Verify repo1's dashboard is still owned by repo1
-		dashboard1, err := helper.DashboardsV1.Resource.Get(ctx, allPanelsUID, metav1.GetOptions{})
+		dashboard1, err := helper.DashboardsV1.Resource.Get(t.Context(), allPanelsUID, metav1.GetOptions{})
 		require.NoError(t, err, "repo1's dashboard should still exist")
 		require.Equal(t, repo1, dashboard1.GetAnnotations()[utils.AnnoKeyManagerIdentity], "repo1's dashboard should still be owned by repo1")
 
 		// Verify repo2's dashboard is still owned by repo2
-		dashboard2, err := helper.DashboardsV1.Resource.Get(ctx, timelineUID, metav1.GetOptions{})
+		dashboard2, err := helper.DashboardsV1.Resource.Get(t.Context(), timelineUID, metav1.GetOptions{})
 		require.NoError(t, err, "repo2's dashboard should still exist")
 		require.Equal(t, repo2, dashboard2.GetAnnotations()[utils.AnnoKeyManagerIdentity], "repo2's dashboard should still be owned by repo2")
 	})
@@ -617,7 +614,6 @@ func TestIntegrationProvisioning_FilesOwnershipProtection(t *testing.T) {
 
 func TestIntegrationProvisioning_ReadmeFiles(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	const repo = "readme-test-repo"
 	const readmeContent = "# Test Repository\n\nThis is a test README for the provisioning API."
@@ -889,7 +885,7 @@ func TestIntegrationProvisioning_ReadmeFiles(t *testing.T) {
 			"a user without any folder grants and no basic role should be denied")
 	})
 
-	_ = ctx
+	_ = t.Context()
 }
 
 // TestIntegrationProvisioning_ReadmeFiles_FolderTarget exercises the folder-scoped
@@ -941,7 +937,6 @@ func TestIntegrationProvisioning_ReadmeFiles_FolderTarget(t *testing.T) {
 
 func TestIntegrationProvisioning_FilesAuthorization(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	const repo = "auth-test-repo"
 	helper.CreateLocalRepo(t, common.TestRepo{
@@ -1017,7 +1012,7 @@ func TestIntegrationProvisioning_FilesAuthorization(t *testing.T) {
 				Resource("repositories").
 				Name(repo).
 				SubResource("files", "dashboard1.json").
-				Do(ctx).StatusCode(&statusCode)
+				Do(t.Context()).StatusCode(&statusCode)
 
 			require.NoError(t, result.Error(), "viewer should be able to GET files")
 			require.Equal(t, http.StatusOK, statusCode, "should return 200 OK")
@@ -1030,7 +1025,7 @@ func TestIntegrationProvisioning_FilesAuthorization(t *testing.T) {
 				Resource("repositories").
 				Name(repo).
 				SubResource("files", "dashboard1.json").
-				Do(ctx).StatusCode(&statusCode)
+				Do(t.Context()).StatusCode(&statusCode)
 
 			require.NoError(t, result.Error(), "editor should be able to GET files")
 			require.Equal(t, http.StatusOK, statusCode, "should return 200 OK")
@@ -1043,7 +1038,7 @@ func TestIntegrationProvisioning_FilesAuthorization(t *testing.T) {
 				Resource("repositories").
 				Name(repo).
 				SubResource("files", "dashboard1.json").
-				Do(ctx).StatusCode(&statusCode)
+				Do(t.Context()).StatusCode(&statusCode)
 
 			require.NoError(t, result.Error(), "admin should be able to GET files")
 			require.Equal(t, http.StatusOK, statusCode, "should return 200 OK")
@@ -1060,7 +1055,7 @@ func TestIntegrationProvisioning_FilesAuthorization(t *testing.T) {
 				SubResource("files", "viewer-test.json").
 				Body(helper.LoadFile("testdata/text-options.json")).
 				SetHeader("Content-Type", "application/json").
-				Do(ctx).StatusCode(&statusCode)
+				Do(t.Context()).StatusCode(&statusCode)
 
 			require.Error(t, result.Error(), "viewer should not be able to POST files")
 			require.Equal(t, http.StatusForbidden, statusCode, "should return 403 Forbidden")
@@ -1076,7 +1071,7 @@ func TestIntegrationProvisioning_FilesAuthorization(t *testing.T) {
 				SubResource("files", "editor-test.json").
 				Body(helper.LoadFile("testdata/text-options.json")).
 				SetHeader("Content-Type", "application/json").
-				Do(ctx).StatusCode(&statusCode)
+				Do(t.Context()).StatusCode(&statusCode)
 
 			require.NoError(t, result.Error(), "editor should be able to POST files")
 			require.Equal(t, http.StatusOK, statusCode, "should return 200 OK")
@@ -1087,7 +1082,7 @@ func TestIntegrationProvisioning_FilesAuthorization(t *testing.T) {
 				Resource("repositories").
 				Name(repo).
 				SubResource("files", "editor-test.json").
-				Do(ctx)
+				Do(t.Context())
 		})
 
 		t.Run("admin can POST files", func(t *testing.T) {
@@ -1099,7 +1094,7 @@ func TestIntegrationProvisioning_FilesAuthorization(t *testing.T) {
 				SubResource("files", "admin-test.json").
 				Body(helper.LoadFile("testdata/text-options.json")).
 				SetHeader("Content-Type", "application/json").
-				Do(ctx).StatusCode(&statusCode)
+				Do(t.Context()).StatusCode(&statusCode)
 
 			require.NoError(t, result.Error(), "admin should be able to POST files")
 			require.Equal(t, http.StatusOK, statusCode, "should return 200 OK")
@@ -1110,7 +1105,7 @@ func TestIntegrationProvisioning_FilesAuthorization(t *testing.T) {
 				Resource("repositories").
 				Name(repo).
 				SubResource("files", "admin-test.json").
-				Do(ctx)
+				Do(t.Context())
 		})
 	})
 
@@ -1123,7 +1118,7 @@ func TestIntegrationProvisioning_FilesAuthorization(t *testing.T) {
 			SubResource("files", "update-test.json").
 			Body(helper.LoadFile("testdata/text-options.json")).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx)
+			Do(t.Context())
 
 		t.Run("viewer cannot PUT files", func(t *testing.T) {
 			var statusCode int
@@ -1134,7 +1129,7 @@ func TestIntegrationProvisioning_FilesAuthorization(t *testing.T) {
 				SubResource("files", "update-test.json").
 				Body(helper.LoadFile("testdata/timeline-demo.json")).
 				SetHeader("Content-Type", "application/json").
-				Do(ctx).StatusCode(&statusCode)
+				Do(t.Context()).StatusCode(&statusCode)
 
 			require.Error(t, result.Error(), "viewer should not be able to PUT files")
 			require.Equal(t, http.StatusForbidden, statusCode, "should return 403 Forbidden")
@@ -1150,7 +1145,7 @@ func TestIntegrationProvisioning_FilesAuthorization(t *testing.T) {
 				SubResource("files", "update-test.json").
 				Body(helper.LoadFile("testdata/timeline-demo.json")).
 				SetHeader("Content-Type", "application/json").
-				Do(ctx).StatusCode(&statusCode)
+				Do(t.Context()).StatusCode(&statusCode)
 
 			require.NoError(t, result.Error(), "editor should be able to PUT files")
 			require.Equal(t, http.StatusOK, statusCode, "should return 200 OK")
@@ -1165,7 +1160,7 @@ func TestIntegrationProvisioning_FilesAuthorization(t *testing.T) {
 				SubResource("files", "update-test.json").
 				Body(helper.LoadFile("testdata/text-options.json")).
 				SetHeader("Content-Type", "application/json").
-				Do(ctx).StatusCode(&statusCode)
+				Do(t.Context()).StatusCode(&statusCode)
 
 			require.NoError(t, result.Error(), "admin should be able to PUT files")
 			require.Equal(t, http.StatusOK, statusCode, "should return 200 OK")
@@ -1177,7 +1172,7 @@ func TestIntegrationProvisioning_FilesAuthorization(t *testing.T) {
 			Resource("repositories").
 			Name(repo).
 			SubResource("files", "update-test.json").
-			Do(ctx)
+			Do(t.Context())
 	})
 
 	t.Run("DELETE operations", func(t *testing.T) {
@@ -1189,7 +1184,7 @@ func TestIntegrationProvisioning_FilesAuthorization(t *testing.T) {
 			SubResource("files", "delete-viewer-test.json").
 			Body(helper.LoadFile("testdata/text-options.json")).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx)
+			Do(t.Context())
 
 		helper.AdminREST.Post().
 			Namespace("default").
@@ -1198,7 +1193,7 @@ func TestIntegrationProvisioning_FilesAuthorization(t *testing.T) {
 			SubResource("files", "delete-editor-test.json").
 			Body(helper.LoadFile("testdata/text-options.json")).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx)
+			Do(t.Context())
 
 		helper.AdminREST.Post().
 			Namespace("default").
@@ -1207,7 +1202,7 @@ func TestIntegrationProvisioning_FilesAuthorization(t *testing.T) {
 			SubResource("files", "delete-admin-test.json").
 			Body(helper.LoadFile("testdata/text-options.json")).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx)
+			Do(t.Context())
 
 		t.Run("viewer cannot DELETE files", func(t *testing.T) {
 			var statusCode int
@@ -1216,14 +1211,14 @@ func TestIntegrationProvisioning_FilesAuthorization(t *testing.T) {
 				Resource("repositories").
 				Name(repo).
 				SubResource("files", "delete-viewer-test.json").
-				Do(ctx).StatusCode(&statusCode)
+				Do(t.Context()).StatusCode(&statusCode)
 
 			require.Error(t, result.Error(), "viewer should not be able to DELETE files")
 			require.Equal(t, http.StatusForbidden, statusCode, "should return 403 Forbidden")
 			require.True(t, apierrors.IsForbidden(result.Error()), "error should be forbidden")
 
 			// Verify file still exists
-			_, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "delete-viewer-test.json")
+			_, err := helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "delete-viewer-test.json")
 			require.NoError(t, err, "file should still exist after failed delete")
 		})
 
@@ -1234,13 +1229,13 @@ func TestIntegrationProvisioning_FilesAuthorization(t *testing.T) {
 				Resource("repositories").
 				Name(repo).
 				SubResource("files", "delete-editor-test.json").
-				Do(ctx).StatusCode(&statusCode)
+				Do(t.Context()).StatusCode(&statusCode)
 
 			require.NoError(t, result.Error(), "editor should be able to DELETE files")
 			require.Equal(t, http.StatusOK, statusCode, "should return 200 OK")
 
 			// Verify file was deleted
-			_, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "delete-editor-test.json")
+			_, err := helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "delete-editor-test.json")
 			require.Error(t, err, "file should be deleted")
 			require.True(t, apierrors.IsNotFound(err), "should return NotFound for deleted file")
 		})
@@ -1252,13 +1247,13 @@ func TestIntegrationProvisioning_FilesAuthorization(t *testing.T) {
 				Resource("repositories").
 				Name(repo).
 				SubResource("files", "delete-admin-test.json").
-				Do(ctx).StatusCode(&statusCode)
+				Do(t.Context()).StatusCode(&statusCode)
 
 			require.NoError(t, result.Error(), "admin should be able to DELETE files")
 			require.Equal(t, http.StatusOK, statusCode, "should return 200 OK")
 
 			// Verify file was deleted
-			_, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "delete-admin-test.json")
+			_, err := helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "delete-admin-test.json")
 			require.Error(t, err, "file should be deleted")
 			require.True(t, apierrors.IsNotFound(err), "should return NotFound for deleted file")
 		})
@@ -1351,7 +1346,7 @@ func TestIntegrationProvisioning_FilesAuthorization(t *testing.T) {
 			SubResource("files", "security-test.json").
 			Body([]byte(dashboardContent)).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.NoError(t, result.Error(), "admin should be able to create dashboard")
 		require.Equal(t, http.StatusOK, statusCode, "should return 200 OK")
@@ -1395,7 +1390,7 @@ func TestIntegrationProvisioning_FilesAuthorization(t *testing.T) {
 			SubResource("files", "security-test.json").
 			Body([]byte(maliciousDashboard)).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		// The request should succeed because editor has permissions
 		// The key validation is that authorization checks the ACTUAL path location (root folder)
@@ -1409,7 +1404,7 @@ func TestIntegrationProvisioning_FilesAuthorization(t *testing.T) {
 			Resource("repositories").
 			Name(repo).
 			SubResource("files", "security-test.json").
-			Do(ctx)
+			Do(t.Context())
 	})
 }
 
@@ -1420,7 +1415,6 @@ func TestIntegrationProvisioning_FilesAuthorization(t *testing.T) {
 // to e.g. the GitHub REST API.
 func TestIntegrationProvisioning_RefValidation(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	const repo = "ref-validation-repo"
 	helper.CreateLocalRepo(t, common.TestRepo{
@@ -1472,7 +1466,7 @@ func TestIntegrationProvisioning_RefValidation(t *testing.T) {
 					Name(repo).
 					SubResource("files", "dashboard.json").
 					Param("ref", tc.ref).
-					Do(ctx).StatusCode(&statusCode)
+					Do(t.Context()).StatusCode(&statusCode)
 
 				require.Error(t, result.Error(), "invalid ref %q should be rejected", tc.ref)
 				require.True(t, apierrors.IsBadRequest(result.Error()) || statusCode == http.StatusBadRequest,
@@ -1489,7 +1483,7 @@ func TestIntegrationProvisioning_RefValidation(t *testing.T) {
 					Name(repo).
 					SubResource("files", "dashboard.json").
 					Param("ref", tc.ref).
-					Do(ctx).StatusCode(&statusCode)
+					Do(t.Context()).StatusCode(&statusCode)
 
 				// The file/branch may not exist (NotFound) or the backend may not
 				// support the ref, but the response must not be BadRequest from
@@ -1515,7 +1509,7 @@ func TestIntegrationProvisioning_RefValidation(t *testing.T) {
 					Name(repo).
 					SubResource("files", "dashboard.json").
 					Param("ref", tc.ref).
-					Do(ctx).StatusCode(&statusCode)
+					Do(t.Context()).StatusCode(&statusCode)
 
 				require.Error(t, result.Error(), "invalid ref %q should be rejected", tc.ref)
 				require.True(t, apierrors.IsBadRequest(result.Error()) || statusCode == http.StatusBadRequest,
@@ -1536,7 +1530,7 @@ func TestIntegrationProvisioning_RefValidation(t *testing.T) {
 					Name(repo).
 					SubResource("history", "dashboard.json").
 					Param("ref", tc.ref).
-					Do(ctx).StatusCode(&statusCode)
+					Do(t.Context()).StatusCode(&statusCode)
 
 				require.Error(t, result.Error(), "invalid ref %q should be rejected", tc.ref)
 				require.True(t, apierrors.IsBadRequest(result.Error()) || statusCode == http.StatusBadRequest,

--- a/pkg/tests/apis/provisioning/files_test.go
+++ b/pkg/tests/apis/provisioning/files_test.go
@@ -30,12 +30,13 @@ func TestIntegrationProvisioning_EmptyRepositoryFileList(t *testing.T) {
 
 	const repo = "empty-files-repo"
 	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:               repo,
-		LocalPath:          helper.ProvisioningPath,
-		SyncTarget:         "instance",
-		ExpectedDashboards: 0,
-		ExpectedFolders:    0,
+		Name:       repo,
+		LocalPath:  helper.ProvisioningPath,
+		SyncTarget: "instance",
 	})
+
+	helper.RequireRepoDashboardCount(t, repo, 0)
+	helper.RequireRepoFolderCount(t, repo, 0)
 
 	rsp := helper.AdminREST.Get().
 		Namespace("default").
@@ -66,7 +67,6 @@ func TestIntegrationProvisioning_DeleteResources(t *testing.T) {
 			"testdata/timeline-demo.json": "folder/nested/dashboard3.json",
 			"testdata/.keep":              "folder/nested/.keep",
 		},
-		SkipResourceAssertions: true, // tested below
 	})
 
 	var dashboards *unstructured.UnstructuredList
@@ -167,6 +167,7 @@ func TestIntegrationProvisioning_DeleteResources(t *testing.T) {
 
 func TestIntegrationProvisioning_MoveResources(t *testing.T) {
 	helper := sharedHelper(t)
+
 	repo := "move-test-repo"
 	helper.CreateLocalRepo(t, common.TestRepo{
 		Name:       repo,
@@ -176,9 +177,10 @@ func TestIntegrationProvisioning_MoveResources(t *testing.T) {
 		Copies: map[string]string{
 			"testdata/all-panels.json": "all-panels.json",
 		},
-		ExpectedDashboards: 1,
-		ExpectedFolders:    0,
 	})
+
+	helper.RequireRepoDashboardCount(t, repo, 1)
+	helper.RequireRepoFolderCount(t, repo, 0)
 
 	// Validate the dashboard metadata
 	dashboards, err := helper.DashboardsV1.Resource.List(t.Context(), metav1.ListOptions{})
@@ -414,7 +416,6 @@ func TestIntegrationProvisioning_FilesOwnershipProtection(t *testing.T) {
 		Copies: map[string]string{
 			"testdata/all-panels.json": "dashboard1.json",
 		},
-		SkipResourceAssertions: true, // will check both at the same time below
 	})
 
 	const repo2 = "ownership-repo-2"
@@ -426,7 +427,6 @@ func TestIntegrationProvisioning_FilesOwnershipProtection(t *testing.T) {
 		Copies: map[string]string{
 			"testdata/timeline-demo.json": "dashboard2.json",
 		},
-		SkipResourceAssertions: true, // will check both at the same time below
 	})
 
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
@@ -619,13 +619,14 @@ func TestIntegrationProvisioning_ReadmeFiles(t *testing.T) {
 	const readmeContent = "# Test Repository\n\nThis is a test README for the provisioning API."
 
 	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:               repo,
-		LocalPath:          helper.ProvisioningPath,
-		SyncTarget:         "instance",
-		Workflows:          []string{"write"},
-		ExpectedDashboards: 0,
-		ExpectedFolders:    0,
+		Name:       repo,
+		LocalPath:  helper.ProvisioningPath,
+		SyncTarget: "instance",
+		Workflows:  []string{"write"},
 	})
+
+	helper.RequireRepoDashboardCount(t, repo, 0)
+	helper.RequireRepoFolderCount(t, repo, 0)
 
 	helper.WriteToProvisioningPath(t, "README.md", []byte(readmeContent))
 
@@ -885,13 +886,15 @@ func TestIntegrationProvisioning_ReadmeFiles(t *testing.T) {
 			"a user without any folder grants and no basic role should be denied")
 	})
 
-	_ = t.Context()
+	_ = t.Context(
+
+	// TestIntegrationProvisioning_ReadmeFiles_FolderTarget exercises the folder-scoped
+	// auth check on a folder-target repository, where RootFolder() resolves to the
+	// repo's name as the folder UID. This is the path that proved the new authorizer
+	// resolves the synced folder rather than always falling back to the empty root.
+	)
 }
 
-// TestIntegrationProvisioning_ReadmeFiles_FolderTarget exercises the folder-scoped
-// auth check on a folder-target repository, where RootFolder() resolves to the
-// repo's name as the folder UID. This is the path that proved the new authorizer
-// resolves the synced folder rather than always falling back to the empty root.
 func TestIntegrationProvisioning_ReadmeFiles_FolderTarget(t *testing.T) {
 	helper := sharedHelper(t)
 
@@ -899,11 +902,10 @@ func TestIntegrationProvisioning_ReadmeFiles_FolderTarget(t *testing.T) {
 	const readmeContent = "# Folder-target README"
 
 	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:                   repo,
-		LocalPath:              helper.ProvisioningPath,
-		SyncTarget:             "folder",
-		Workflows:              []string{"write"},
-		SkipResourceAssertions: true,
+		Name:       repo,
+		LocalPath:  helper.ProvisioningPath,
+		SyncTarget: "folder",
+		Workflows:  []string{"write"},
 	})
 
 	helper.WriteToProvisioningPath(t, "README.md", []byte(readmeContent))
@@ -947,9 +949,10 @@ func TestIntegrationProvisioning_FilesAuthorization(t *testing.T) {
 		Copies: map[string]string{
 			"testdata/all-panels.json": "dashboard1.json",
 		},
-		ExpectedDashboards: 1,
-		ExpectedFolders:    0,
 	})
+
+	helper.RequireRepoDashboardCount(t, repo, 1)
+	helper.RequireRepoFolderCount(t, repo, 0)
 
 	// Wait for initial sync to complete
 	var dashboardUID string
@@ -1418,13 +1421,14 @@ func TestIntegrationProvisioning_RefValidation(t *testing.T) {
 
 	const repo = "ref-validation-repo"
 	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:               repo,
-		LocalPath:          helper.ProvisioningPath,
-		SyncTarget:         "instance",
-		Workflows:          []string{"write"},
-		ExpectedDashboards: 0,
-		ExpectedFolders:    0,
+		Name:       repo,
+		LocalPath:  helper.ProvisioningPath,
+		SyncTarget: "instance",
+		Workflows:  []string{"write"},
 	})
+
+	helper.RequireRepoDashboardCount(t, repo, 0)
+	helper.RequireRepoFolderCount(t, repo, 0)
 
 	invalidRefs := []struct {
 		name string

--- a/pkg/tests/apis/provisioning/folder_authorization_test.go
+++ b/pkg/tests/apis/provisioning/folder_authorization_test.go
@@ -23,10 +23,9 @@ func TestIntegrationProvisioning_FolderAuthorizationWithoutMetadata(t *testing.T
 	)
 
 	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:                   repoName,
-		SyncTarget:             "instance",
-		Workflows:              []string{"write"},
-		SkipResourceAssertions: true,
+		Name:       repoName,
+		SyncTarget: "instance",
+		Workflows:  []string{"write"},
 	})
 
 	helper.SetPermissions(helper.Org1.Editor, []resourcepermissions.SetResourcePermissionCommand{

--- a/pkg/tests/apis/provisioning/folderapiversion/folder_api_version_test.go
+++ b/pkg/tests/apis/provisioning/folderapiversion/folder_api_version_test.go
@@ -31,7 +31,6 @@ func TestIntegrationProvisioning_FolderAPIVersionDiscovery(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 
 	helper := common.RunGrafana(t)
-	ctx := t.Context()
 
 	// Resolve the server's preferred folder version via discovery — this is the
 	// same version provisioning is expected to use for the folders it writes.
@@ -63,7 +62,7 @@ func TestIntegrationProvisioning_FolderAPIVersionDiscovery(t *testing.T) {
 	expectedAPIVersion := folderv1.APIGroup + "/" + preferredVersion
 
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		folders, err := folderClient.Resource.List(ctx, metav1.ListOptions{})
+		folders, err := folderClient.Resource.List(t.Context(), metav1.ListOptions{})
 		if !assert.NoError(collect, err) {
 			return
 		}

--- a/pkg/tests/apis/provisioning/folderapiversion/folder_api_version_test.go
+++ b/pkg/tests/apis/provisioning/folderapiversion/folder_api_version_test.go
@@ -45,8 +45,7 @@ func TestIntegrationProvisioning_FolderAPIVersionDiscovery(t *testing.T) {
 		Copies: map[string]string{
 			"../testdata/all-panels.json": "subfolder/dashboard.json",
 		},
-		SkipSync:               true,
-		SkipResourceAssertions: true,
+		SkipSync: true,
 	})
 	helper.SyncAndWait(t, repoName, nil)
 

--- a/pkg/tests/apis/provisioning/foldermetadata/create_folder_git_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/create_folder_git_test.go
@@ -1,7 +1,6 @@
 package foldermetadata
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -18,7 +17,6 @@ func TestIntegrationGitFiles_CreateFolderWithFolderMetadata(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 
 	helper := sharedGitHelper(t)
-	ctx := context.Background()
 
 	repoName := "test-folder-metadata-files"
 	_, _ = helper.CreateGitRepo(t, repoName, nil, "write", "branch")
@@ -34,7 +32,7 @@ func TestIntegrationGitFiles_CreateFolderWithFolderMetadata(t *testing.T) {
 			Resource("repositories").
 			Name(repoName).
 			SubResource("files", "meta-folder", "_folder.json").
-			Do(ctx)
+			Do(t.Context())
 		require.NoError(t, result.Error(), "_folder.json should exist in the folder")
 	})
 
@@ -52,7 +50,7 @@ func TestIntegrationGitFiles_CreateFolderWithFolderMetadata(t *testing.T) {
 			Name(repoName).
 			SubResource("files", "branch-meta-folder", "_folder.json").
 			Param("ref", branchName).
-			Do(ctx)
+			Do(t.Context())
 		require.NoError(t, result.Error(), "_folder.json should exist on the branch")
 
 		result = helper.AdminREST.Get().
@@ -60,7 +58,7 @@ func TestIntegrationGitFiles_CreateFolderWithFolderMetadata(t *testing.T) {
 			Resource("repositories").
 			Name(repoName).
 			SubResource("files", "branch-meta-folder", "_folder.json").
-			Do(ctx)
+			Do(t.Context())
 		require.True(t, apierrors.IsNotFound(result.Error()), "_folder.json should not exist on the default branch")
 	})
 
@@ -78,7 +76,7 @@ func TestIntegrationGitFiles_CreateFolderWithFolderMetadata(t *testing.T) {
 			Name(repoName).
 			SubResource("files", "outer", "_folder.json").
 			Param("ref", branchName).
-			Do(ctx)
+			Do(t.Context())
 		require.NoError(t, result.Error(), "parent _folder.json should exist on the branch")
 
 		result = helper.AdminREST.Get().
@@ -87,7 +85,7 @@ func TestIntegrationGitFiles_CreateFolderWithFolderMetadata(t *testing.T) {
 			Name(repoName).
 			SubResource("files", "outer", "inner", "_folder.json").
 			Param("ref", branchName).
-			Do(ctx)
+			Do(t.Context())
 		require.NoError(t, result.Error(), "child _folder.json should exist on the branch")
 	})
 
@@ -104,7 +102,7 @@ func TestIntegrationGitFiles_CreateFolderWithFolderMetadata(t *testing.T) {
 			Resource("repositories").
 			Name(repoName).
 			SubResource("files", "existing-parent", "_folder.json").
-			Do(ctx)
+			Do(t.Context())
 		require.NoError(t, result.Error(), "parent _folder.json should exist on default branch")
 
 		// Now create a child inside that parent on a NEW branch.
@@ -124,7 +122,7 @@ func TestIntegrationGitFiles_CreateFolderWithFolderMetadata(t *testing.T) {
 			Name(repoName).
 			SubResource("files", "existing-parent", "new-child", "_folder.json").
 			Param("ref", branchName).
-			Do(ctx)
+			Do(t.Context())
 		require.NoError(t, result.Error(), "child _folder.json should exist on the branch")
 
 		// Verify the parent _folder.json is still readable on the branch (inherited from default).
@@ -134,7 +132,7 @@ func TestIntegrationGitFiles_CreateFolderWithFolderMetadata(t *testing.T) {
 			Name(repoName).
 			SubResource("files", "existing-parent", "_folder.json").
 			Param("ref", branchName).
-			Do(ctx)
+			Do(t.Context())
 		require.NoError(t, result.Error(), "parent _folder.json should be readable on the branch (inherited)")
 	})
 }

--- a/pkg/tests/apis/provisioning/foldermetadata/export_folders_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/export_folders_test.go
@@ -465,7 +465,7 @@ func TestIntegrationProvisioning_ExportJob_SelectiveGeneratesFolderMetadata(t *t
 	createUnmanagedFolder(t, helper, unrelatedUID, unrelatedTitle)
 
 	// The dashboard lives in the child folder; only it is named in the export.
-	selectedDash := helper.CreateUnmanagedDashboard(t, t.Context(), "selective-meta-dash", childUID)
+	selectedDash := helper.CreateUnmanagedDashboard(t, "selective-meta-dash", childUID)
 
 	result := helper.TriggerJobAndWaitForComplete(t, repo, provisioning.JobSpec{
 		Action: provisioning.JobActionPush,

--- a/pkg/tests/apis/provisioning/foldermetadata/export_folders_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/export_folders_test.go
@@ -77,11 +77,10 @@ func TestIntegrationProvisioning_ExportJob_FolderMetadataFlag(t *testing.T) {
 
 		const repo = "export-meta-new-repo"
 		helper.CreateLocalRepo(t, common.TestRepo{
-			Name:                   repo,
-			SyncTarget:             "instance",
-			Workflows:              []string{"write"},
-			SkipSync:               true,
-			SkipResourceAssertions: true,
+			Name:       repo,
+			SyncTarget: "instance",
+			Workflows:  []string{"write"},
+			SkipSync:   true,
 		})
 
 		const (
@@ -112,11 +111,10 @@ func TestIntegrationProvisioning_ExportJob_FolderMetadataFlag(t *testing.T) {
 
 		const repo = "export-existing-folder-repo"
 		helper.CreateLocalRepo(t, common.TestRepo{
-			Name:                   repo,
-			SyncTarget:             "instance",
-			Workflows:              []string{"write"},
-			SkipSync:               true,
-			SkipResourceAssertions: true,
+			Name:       repo,
+			SyncTarget: "instance",
+			Workflows:  []string{"write"},
+			SkipSync:   true,
 		})
 
 		// Simulate a folder directory that already exists in the repository
@@ -155,11 +153,10 @@ func TestIntegrationProvisioning_ExportJob_NestedFolders(t *testing.T) {
 
 		const repo = "nested-middle-existing-repo"
 		helper.CreateLocalRepo(t, common.TestRepo{
-			Name:                   repo,
-			SyncTarget:             "instance",
-			Workflows:              []string{"write"},
-			SkipSync:               true,
-			SkipResourceAssertions: true,
+			Name:       repo,
+			SyncTarget: "instance",
+			Workflows:  []string{"write"},
+			SkipSync:   true,
 		})
 
 		const (
@@ -208,11 +205,10 @@ func TestIntegrationProvisioning_ExportJob_NestedFolders(t *testing.T) {
 
 		const repo = "nested-two-level-repo"
 		helper.CreateLocalRepo(t, common.TestRepo{
-			Name:                   repo,
-			SyncTarget:             "instance",
-			Workflows:              []string{"write"},
-			SkipSync:               true,
-			SkipResourceAssertions: true,
+			Name:       repo,
+			SyncTarget: "instance",
+			Workflows:  []string{"write"},
+			SkipSync:   true,
 		})
 
 		const (
@@ -246,11 +242,10 @@ func TestIntegrationProvisioning_ExportJob_NestedFolders(t *testing.T) {
 
 		const repo = "nested-three-level-repo"
 		helper.CreateLocalRepo(t, common.TestRepo{
-			Name:                   repo,
-			SyncTarget:             "instance",
-			Workflows:              []string{"write"},
-			SkipSync:               true,
-			SkipResourceAssertions: true,
+			Name:       repo,
+			SyncTarget: "instance",
+			Workflows:  []string{"write"},
+			SkipSync:   true,
 		})
 
 		const (
@@ -293,11 +288,10 @@ func TestIntegrationProvisioning_ExportJob_NestedFolders(t *testing.T) {
 
 		const repo = "nested-siblings-repo"
 		helper.CreateLocalRepo(t, common.TestRepo{
-			Name:                   repo,
-			SyncTarget:             "instance",
-			Workflows:              []string{"write"},
-			SkipSync:               true,
-			SkipResourceAssertions: true,
+			Name:       repo,
+			SyncTarget: "instance",
+			Workflows:  []string{"write"},
+			SkipSync:   true,
 		})
 
 		const (
@@ -362,11 +356,10 @@ func TestIntegrationProvisioning_ExportJob_GenerateNewFolderIDs(t *testing.T) {
 		t.Helper()
 		helper := sharedHelper(t)
 		helper.CreateLocalRepo(t, common.TestRepo{
-			Name:                   repo,
-			SyncTarget:             "folder",
-			Workflows:              []string{"write"},
-			SkipSync:               true,
-			SkipResourceAssertions: true,
+			Name:       repo,
+			SyncTarget: "folder",
+			Workflows:  []string{"write"},
+			SkipSync:   true,
 		})
 		createUnmanagedFolder(t, helper, parentUID, parentTitle)
 		createUnmanagedFolderWithParent(t, helper, childUID, childTitle, parentUID)
@@ -444,11 +437,10 @@ func TestIntegrationProvisioning_ExportJob_SelectiveGeneratesFolderMetadata(t *t
 
 	const repo = "selective-export-meta-repo"
 	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:                   repo,
-		SyncTarget:             "instance",
-		Workflows:              []string{"write"},
-		SkipSync:               true,
-		SkipResourceAssertions: true,
+		Name:       repo,
+		SyncTarget: "instance",
+		Workflows:  []string{"write"},
+		SkipSync:   true,
 	})
 
 	const (

--- a/pkg/tests/apis/provisioning/foldermetadata/export_git_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/export_git_test.go
@@ -2,7 +2,6 @@ package foldermetadata
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"testing"
 
@@ -17,7 +16,6 @@ import (
 // exported folder contains a _folder.json manifest (no .keep file).
 func TestIntegrationProvisioning_ExportJob_GitRepo_FolderMetadataEnabled(t *testing.T) {
 	helper := sharedGitHelper(t)
-	ctx := context.Background()
 
 	const (
 		repoName    = "git-export-with-meta"
@@ -34,7 +32,7 @@ func TestIntegrationProvisioning_ExportJob_GitRepo_FolderMetadataEnabled(t *test
 	// With the feature flag enabled, a _folder.json manifest must be committed instead of
 	// a bare .keep placeholder.  Read the file directly from the git server to avoid the
 	// ownership-conflict check that the provisioning files API performs on unmanaged resources.
-	data := helper.GitReadFile(t, ctx, repoName, folderTitle+"/_folder.json")
+	data := helper.GitReadFile(t, repoName, folderTitle+"/_folder.json")
 
 	// The committed _folder.json must be pretty-printed with two-space indentation,
 	// matching the formatting of other resource files written to the repository.
@@ -48,6 +46,6 @@ func TestIntegrationProvisioning_ExportJob_GitRepo_FolderMetadataEnabled(t *test
 	require.Equal(t, folderTitle, manifest.Spec.Title, "_folder.json must carry the folder's title")
 
 	// No .keep file must be present when _folder.json is written.
-	require.False(t, helper.GitFileExists(t, ctx, repoName, folderTitle+"/.keep"),
+	require.False(t, helper.GitFileExists(t, repoName, folderTitle+"/.keep"),
 		".keep must not exist when the feature flag is enabled")
 }

--- a/pkg/tests/apis/provisioning/foldermetadata/fixfoldermetadata_git_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/fixfoldermetadata_git_test.go
@@ -1,7 +1,6 @@
 package foldermetadata
 
 import (
-	"context"
 	"strings"
 	"testing"
 
@@ -18,7 +17,6 @@ import (
 // leaves the default branch untouched.
 func TestIntegrationGit_FixFolderMetadata_Branch(t *testing.T) {
 	helper := sharedGitHelper(t)
-	ctx := context.Background()
 
 	const repoName = "fix-meta-git-branch"
 	const featureBranch = "add-folder-metadata"
@@ -46,16 +44,16 @@ func TestIntegrationGit_FixFolderMetadata_Branch(t *testing.T) {
 		"fix-folder-metadata job on branch %q should succeed", featureBranch)
 
 	// Both _folder.json files must appear on the feature branch with valid content.
-	parentUID := requireFolderMetadataOnRef(t, helper, ctx, repoName, "parent/_folder.json", featureBranch)
-	childUID := requireFolderMetadataOnRef(t, helper, ctx, repoName, "parent/child/_folder.json", featureBranch)
+	parentUID := requireFolderMetadataOnRef(t, helper, repoName, "parent/_folder.json", featureBranch)
+	childUID := requireFolderMetadataOnRef(t, helper, repoName, "parent/child/_folder.json", featureBranch)
 	require.NotEqual(t, parentUID, childUID,
 		"parent and child folders should have different UIDs")
 	require.Equal(t, expectedCommitMsg, common.LatestCommitSubject(t, repo, featureBranch))
 
 	// Neither file should exist on the default branch — the job only touched the
 	// feature branch.
-	requireFileAbsentOnDefaultBranch(t, helper, ctx, repoName, "parent/_folder.json")
-	requireFileAbsentOnDefaultBranch(t, helper, ctx, repoName, "parent/child/_folder.json")
+	requireFileAbsentOnDefaultBranch(t, helper, repoName, "parent/_folder.json")
+	requireFileAbsentOnDefaultBranch(t, helper, repoName, "parent/child/_folder.json")
 }
 
 // TestIntegrationGit_FixFolderMetadata_ExistingBranch verifies that the
@@ -65,7 +63,6 @@ func TestIntegrationGit_FixFolderMetadata_Branch(t *testing.T) {
 // leave the default branch untouched.
 func TestIntegrationGit_FixFolderMetadata_ExistingBranch(t *testing.T) {
 	helper := sharedGitHelper(t)
-	ctx := context.Background()
 
 	const repoName = "fix-meta-git-existing-branch"
 	const featureBranch = "pre-existing-branch"
@@ -96,15 +93,15 @@ func TestIntegrationGit_FixFolderMetadata_ExistingBranch(t *testing.T) {
 		"fix-folder-metadata job on pre-existing branch %q should succeed", featureBranch)
 
 	// Both _folder.json files must appear on the feature branch with valid content.
-	parentUID := requireFolderMetadataOnRef(t, helper, ctx, repoName, "parent/_folder.json", featureBranch)
-	childUID := requireFolderMetadataOnRef(t, helper, ctx, repoName, "parent/child/_folder.json", featureBranch)
+	parentUID := requireFolderMetadataOnRef(t, helper, repoName, "parent/_folder.json", featureBranch)
+	childUID := requireFolderMetadataOnRef(t, helper, repoName, "parent/child/_folder.json", featureBranch)
 
 	require.NotEqual(t, parentUID, childUID,
 		"parent and child folders should have different UIDs")
 
 	// Neither file should exist on the default branch.
-	requireFileAbsentOnDefaultBranch(t, helper, ctx, repoName, "parent/_folder.json")
-	requireFileAbsentOnDefaultBranch(t, helper, ctx, repoName, "parent/child/_folder.json")
+	requireFileAbsentOnDefaultBranch(t, helper, repoName, "parent/_folder.json")
+	requireFileAbsentOnDefaultBranch(t, helper, repoName, "parent/child/_folder.json")
 }
 
 // TestIntegrationGit_FixFolderMetadata_ReadOnlyDefaultBranch verifies that the
@@ -113,7 +110,6 @@ func TestIntegrationGit_FixFolderMetadata_ExistingBranch(t *testing.T) {
 // would push directly to main, which is not allowed.
 func TestIntegrationGit_FixFolderMetadata_ReadOnlyDefaultBranch(t *testing.T) {
 	helper := sharedGitHelper(t)
-	ctx := context.Background()
 
 	const repoName = "fix-meta-readonly-main"
 
@@ -136,14 +132,14 @@ func TestIntegrationGit_FixFolderMetadata_ReadOnlyDefaultBranch(t *testing.T) {
 		SubResource("jobs").
 		Body(body).
 		SetHeader("Content-Type", "application/json").
-		Do(ctx)
+		Do(t.Context())
 
 	require.True(t, apierrors.IsForbidden(result.Error()),
 		"job targeting the default branch on a read-only repo should be forbidden; got: %v", result.Error())
 
 	// The default branch (main) must remain untouched.
-	requireFileAbsentOnDefaultBranch(t, helper, ctx, repoName, "parent/_folder.json")
-	requireFileAbsentOnDefaultBranch(t, helper, ctx, repoName, "parent/child/_folder.json")
+	requireFileAbsentOnDefaultBranch(t, helper, repoName, "parent/_folder.json")
+	requireFileAbsentOnDefaultBranch(t, helper, repoName, "parent/child/_folder.json")
 }
 
 // TestIntegrationGit_FixFolderMetadata_ReadOnlyDefaultBranch_WithRef verifies
@@ -153,7 +149,6 @@ func TestIntegrationGit_FixFolderMetadata_ReadOnlyDefaultBranch(t *testing.T) {
 // branch and the default branch stays untouched.
 func TestIntegrationGit_FixFolderMetadata_ReadOnlyDefaultBranch_WithRef(t *testing.T) {
 	helper := sharedGitHelper(t)
-	ctx := context.Background()
 
 	const repoName = "fix-meta-readonly-branch"
 	const featureBranch = "fix-folders"
@@ -173,19 +168,19 @@ func TestIntegrationGit_FixFolderMetadata_ReadOnlyDefaultBranch_WithRef(t *testi
 	require.Equal(t, string(provisioning.JobStateSuccess), state,
 		"fix-folder-metadata job on branch %q should succeed even when the default branch is read-only", featureBranch)
 
-	parentUID := requireFolderMetadataOnRef(t, helper, ctx, repoName, "parent/_folder.json", featureBranch)
-	childUID := requireFolderMetadataOnRef(t, helper, ctx, repoName, "parent/child/_folder.json", featureBranch)
+	parentUID := requireFolderMetadataOnRef(t, helper, repoName, "parent/_folder.json", featureBranch)
+	childUID := requireFolderMetadataOnRef(t, helper, repoName, "parent/child/_folder.json", featureBranch)
 
 	require.NotEqual(t, parentUID, childUID,
 		"parent and child folders should have different UIDs")
 
-	requireFileAbsentOnDefaultBranch(t, helper, ctx, repoName, "parent/_folder.json")
-	requireFileAbsentOnDefaultBranch(t, helper, ctx, repoName, "parent/child/_folder.json")
+	requireFileAbsentOnDefaultBranch(t, helper, repoName, "parent/_folder.json")
+	requireFileAbsentOnDefaultBranch(t, helper, repoName, "parent/child/_folder.json")
 }
 
 // ── helpers ────────────────────────────────────────────────────────────────
 
-func requireFolderMetadataOnRef(t *testing.T, h *common.GitTestHelper, ctx context.Context, repoName, filePath, ref string) string {
+func requireFolderMetadataOnRef(t *testing.T, h *common.GitTestHelper, repoName, filePath, ref string) string {
 	t.Helper()
 
 	subresourceParts := append([]string{"files"}, strings.Split(filePath, "/")...)
@@ -195,7 +190,7 @@ func requireFolderMetadataOnRef(t *testing.T, h *common.GitTestHelper, ctx conte
 		Name(repoName).
 		SubResource(subresourceParts...).
 		Param("ref", ref).
-		Do(ctx)
+		Do(t.Context())
 
 	require.NoError(t, result.Error(),
 		"%s: _folder.json should be readable on branch %q", filePath, ref)
@@ -219,7 +214,7 @@ func requireFolderMetadataOnRef(t *testing.T, h *common.GitTestHelper, ctx conte
 	return uid
 }
 
-func requireFileAbsentOnDefaultBranch(t *testing.T, h *common.GitTestHelper, ctx context.Context, repoName, filePath string) {
+func requireFileAbsentOnDefaultBranch(t *testing.T, h *common.GitTestHelper, repoName, filePath string) {
 	t.Helper()
 
 	subresourceParts := append([]string{"files"}, strings.Split(filePath, "/")...)
@@ -228,7 +223,7 @@ func requireFileAbsentOnDefaultBranch(t *testing.T, h *common.GitTestHelper, ctx
 		Resource("repositories").
 		Name(repoName).
 		SubResource(subresourceParts...).
-		Do(ctx)
+		Do(t.Context())
 
 	require.True(t, apierrors.IsNotFound(result.Error()),
 		"%s should not exist on the default branch; got: %v", filePath, result.Error())

--- a/pkg/tests/apis/provisioning/foldermetadata/fixfoldermetadata_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/fixfoldermetadata_test.go
@@ -1,7 +1,6 @@
 package foldermetadata
 
 import (
-	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -23,7 +22,6 @@ const folderMetadataFileName = "_folder.json"
 // have them yet.
 func TestIntegrationProvisioning_FixFolderMetadata_MissingFile(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	const repoName = "fix-meta-no-metadata"
 	repoPath := filepath.Join(helper.ProvisioningPath, repoName)
@@ -50,8 +48,8 @@ func TestIntegrationProvisioning_FixFolderMetadata_MissingFile(t *testing.T) {
 	runFixFolderMetadataJob(t, helper, repoName)
 
 	// After the job both folders must have a well-formed metadata file.
-	parentUID, _ := requireValidFolderMetadata(t, ctx, helper, repoName, "parent")
-	childUID, _ := requireValidFolderMetadata(t, ctx, helper, repoName, "parent/child")
+	parentUID, _ := requireValidFolderMetadata(t, helper, repoName, "parent")
+	childUID, _ := requireValidFolderMetadata(t, helper, repoName, "parent/child")
 
 	// The two folders should carry distinct UIDs.
 	require.NotEqual(t, parentUID, childUID,
@@ -62,7 +60,6 @@ func TestIntegrationProvisioning_FixFolderMetadata_MissingFile(t *testing.T) {
 // fix-folder-metadata job leaves already-correct _folder.json files unchanged.
 func TestIntegrationProvisioning_FixFolderMetadata_ValidFile(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	const repoName = "fix-meta-valid-metadata"
 	repoPath := filepath.Join(helper.ProvisioningPath, repoName)
@@ -82,16 +79,16 @@ func TestIntegrationProvisioning_FixFolderMetadata_ValidFile(t *testing.T) {
 	// First run: let the job create the metadata files.
 	runFixFolderMetadataJob(t, helper, repoName)
 
-	firstParentUID, firstParentTitle := requireValidFolderMetadata(t, ctx, helper, repoName, "parent")
-	firstChildUID, firstChildTitle := requireValidFolderMetadata(t, ctx, helper, repoName, "parent/child")
+	firstParentUID, firstParentTitle := requireValidFolderMetadata(t, helper, repoName, "parent")
+	firstChildUID, firstChildTitle := requireValidFolderMetadata(t, helper, repoName, "parent/child")
 
 	// Second run: the metadata files are already correct, nothing should change.
 	runFixFolderMetadataJob(t, helper, repoName)
 
-	afterParentUID, afterParentTitle := requireValidFolderMetadata(t, ctx, helper, repoName, "parent")
+	afterParentUID, afterParentTitle := requireValidFolderMetadata(t, helper, repoName, "parent")
 	require.Equal(t, firstParentUID, afterParentUID, "parent folder UID must not change when the metadata file is already valid")
 	require.Equal(t, firstParentTitle, afterParentTitle, "parent folder title must not change when the metadata file is already valid")
-	afterChildUID, afterChildTitle := requireValidFolderMetadata(t, ctx, helper, repoName, "parent/child")
+	afterChildUID, afterChildTitle := requireValidFolderMetadata(t, helper, repoName, "parent/child")
 	require.Equal(t, firstChildUID, afterChildUID, "child folder UID must not change when the metadata file is already valid")
 	require.Equal(t, firstChildTitle, afterChildTitle, "child folder title must not change when the metadata file is already valid")
 }
@@ -186,11 +183,11 @@ func requireFileAbsent(t *testing.T, path string) {
 // requireValidFolderMetadata reads a _folder.json via the repository files API
 // and asserts it is a valid Folder resource (correct apiVersion/kind, non-empty
 // UID and title).
-func requireValidFolderMetadata(t *testing.T, ctx context.Context, h *common.ProvisioningTestHelper, repoName, folderPath string) (string, string) {
+func requireValidFolderMetadata(t *testing.T, h *common.ProvisioningTestHelper, repoName, folderPath string) (string, string) {
 	t.Helper()
 
 	filePath := filepath.Join(folderPath, folderMetadataFileName)
-	wrapObj, err := h.Repositories.Resource.Get(ctx, repoName, metav1.GetOptions{}, "files", filePath)
+	wrapObj, err := h.Repositories.Resource.Get(t.Context(), repoName, metav1.GetOptions{}, "files", filePath)
 	require.NoError(t, err, "%s: _folder.json should be readable via the files endpoint", filePath)
 
 	apiVersion, _, _ := unstructured.NestedString(wrapObj.Object, "resource", "file", "apiVersion")

--- a/pkg/tests/apis/provisioning/foldermetadata/fixfoldermetadata_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/fixfoldermetadata_test.go
@@ -36,10 +36,11 @@ func TestIntegrationProvisioning_FixFolderMetadata_MissingFile(t *testing.T) {
 			// created in Grafana during sync.
 			"../testdata/all-panels.json": "parent/child/dashboard.json",
 		},
-		ExpectedDashboards: 1,
 		// root folder + parent + parent/child
-		ExpectedFolders: 3,
 	})
+
+	helper.RequireRepoDashboardCount(t, repoName, 1)
+	helper.RequireRepoFolderCount(t, repoName, 3)
 
 	// Confirm the metadata files do not exist before the job runs.
 	requireFileAbsent(t, filepath.Join(repoPath, "parent", folderMetadataFileName))
@@ -72,9 +73,10 @@ func TestIntegrationProvisioning_FixFolderMetadata_ValidFile(t *testing.T) {
 		Copies: map[string]string{
 			"../testdata/all-panels.json": "parent/child/dashboard.json",
 		},
-		ExpectedDashboards: 1,
-		ExpectedFolders:    3,
 	})
+
+	helper.RequireRepoDashboardCount(t, repoName, 1)
+	helper.RequireRepoFolderCount(t, repoName, 3)
 
 	// First run: let the job create the metadata files.
 	runFixFolderMetadataJob(t, helper, repoName)
@@ -110,9 +112,10 @@ func TestIntegrationProvisioning_FixFolderMetadata_SkipsExistingMetadata(t *test
 		Copies: map[string]string{
 			"../testdata/all-panels.json": "parent/child/dashboard.json",
 		},
-		ExpectedDashboards: 1,
-		ExpectedFolders:    3,
 	})
+
+	helper.RequireRepoDashboardCount(t, repoName, 1)
+	helper.RequireRepoFolderCount(t, repoName, 3)
 
 	// Plant _folder.json files with arbitrary UIDs so we can verify the job
 	// leaves them untouched.
@@ -146,9 +149,10 @@ func TestIntegrationProvisioning_FixFolderMetadata_SkipsMalformedMetadata(t *tes
 		Copies: map[string]string{
 			"../testdata/all-panels.json": "parent/child/dashboard.json",
 		},
-		ExpectedDashboards: 1,
-		ExpectedFolders:    3,
 	})
+
+	helper.RequireRepoDashboardCount(t, repoName, 1)
+	helper.RequireRepoFolderCount(t, repoName, 3)
 
 	// Write _folder.json files that are valid JSON but not Folder resources.
 	writeMalformedMetadata(t, filepath.Join(repoPath, "parent"))

--- a/pkg/tests/apis/provisioning/foldermetadata/fixfoldermetadatajob_auth_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/fixfoldermetadatajob_auth_test.go
@@ -16,14 +16,15 @@ func TestIntegrationProvisioning_FixFolderMetadataJobAuthorization(t *testing.T)
 
 	const repo = "fixfoldermetadata-auth-test"
 	testRepo := common.TestRepo{
-		Name:               repo,
-		SyncTarget:         "folder",
-		Workflows:          []string{"write"},
-		Copies:             map[string]string{},
-		ExpectedDashboards: 0,
-		ExpectedFolders:    1,
+		Name:       repo,
+		SyncTarget: "folder",
+		Workflows:  []string{"write"},
+		Copies:     map[string]string{},
 	}
 	helper.CreateLocalRepo(t, testRepo)
+
+	helper.RequireRepoDashboardCount(t, repo, 0)
+	helper.RequireRepoFolderCount(t, repo, 1)
 
 	body := common.AsJSON(provisioning.JobSpec{
 		Action: provisioning.JobActionFixFolderMetadata,

--- a/pkg/tests/apis/provisioning/foldermetadata/fixfoldermetadatajob_auth_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/fixfoldermetadatajob_auth_test.go
@@ -1,7 +1,6 @@
 package foldermetadata
 
 import (
-	"context"
 	"net/http"
 	"testing"
 
@@ -14,7 +13,6 @@ import (
 
 func TestIntegrationProvisioning_FixFolderMetadataJobAuthorization(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	const repo = "fixfoldermetadata-auth-test"
 	testRepo := common.TestRepo{
@@ -40,7 +38,7 @@ func TestIntegrationProvisioning_FixFolderMetadataJobAuthorization(t *testing.T)
 			SubResource("jobs").
 			Body(body).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.NoError(t, result.Error(), "admin should be able to create fixFolderMetadata job")
 		require.Equal(t, http.StatusAccepted, statusCode, "should return 202 Accepted")
@@ -57,7 +55,7 @@ func TestIntegrationProvisioning_FixFolderMetadataJobAuthorization(t *testing.T)
 			SubResource("jobs").
 			Body(body).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.NoError(t, result.Error(), "editor should be able to create fixFolderMetadata job")
 		require.Equal(t, http.StatusAccepted, statusCode, "should return 202 Accepted")
@@ -74,7 +72,7 @@ func TestIntegrationProvisioning_FixFolderMetadataJobAuthorization(t *testing.T)
 			SubResource("jobs").
 			Body(body).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.Error(t, result.Error(), "viewer should not be able to create fixFolderMetadata job")
 		require.Equal(t, http.StatusForbidden, statusCode, "should return 403 Forbidden")

--- a/pkg/tests/apis/provisioning/foldermetadata/fixfoldermetadatajob_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/fixfoldermetadatajob_test.go
@@ -24,10 +24,11 @@ func TestIntegrationProvisioning_FixFolderMetadataJob(t *testing.T) {
 		Copies: map[string]string{
 			"../testdata/all-panels.json": "dashboard1.json",
 		},
-		ExpectedDashboards: 1,
-		ExpectedFolders:    1,
 	}
 	helper.CreateLocalRepo(t, testRepo)
+
+	helper.RequireRepoDashboardCount(t, repo, 1)
+	helper.RequireRepoFolderCount(t, repo, 1)
 
 	t.Run("job completes successfully", func(t *testing.T) {
 		spec := provisioning.JobSpec{
@@ -80,10 +81,9 @@ func TestIntegrationProvisioning_FixFolderMetadataJob_RemovesKeepFiles(t *testin
 
 	const repo = "fix-folder-metadata-keep-files"
 	testRepo := common.TestRepo{
-		Name:                   repo,
-		SyncTarget:             "folder",
-		Workflows:              []string{"write"},
-		SkipResourceAssertions: true,
+		Name:       repo,
+		SyncTarget: "folder",
+		Workflows:  []string{"write"},
 	}
 	helper.CreateLocalRepo(t, testRepo)
 

--- a/pkg/tests/apis/provisioning/foldermetadata/folder_authorization_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/folder_authorization_test.go
@@ -1,7 +1,6 @@
 package foldermetadata
 
 import (
-	"context"
 	"net/http"
 	"testing"
 
@@ -18,7 +17,6 @@ import (
 // already exists in a folder the caller can write to.
 func TestIntegrationProvisioning_CrossFolderWriteDeniedWithoutDestinationAccess(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	const repoName = "cross-folder-auth-test"
 
@@ -46,9 +44,9 @@ func TestIntegrationProvisioning_CrossFolderWriteDeniedWithoutDestinationAccess(
 	helper.SyncAndWait(t, repoName, nil)
 
 	// Verify both folders exist in Grafana before setting permissions.
-	_, err := helper.Folders.Resource.Get(ctx, "inner-a-uid", metav1.GetOptions{})
+	_, err := helper.Folders.Resource.Get(t.Context(), "inner-a-uid", metav1.GetOptions{})
 	require.NoError(t, err, "innerA should exist after sync")
-	_, err = helper.Folders.Resource.Get(ctx, "inner-b-uid", metav1.GetOptions{})
+	_, err = helper.Folders.Resource.Get(t.Context(), "inner-b-uid", metav1.GetOptions{})
 	require.NoError(t, err, "innerB should exist after sync")
 
 	// Resolve the Viewer user's integer ID so we can set a user-specific folder ACL.
@@ -96,7 +94,6 @@ func TestIntegrationProvisioning_CrossFolderWriteDeniedWithoutDestinationAccess(
 // The flag-disabled counterpart lives in the core provisioning package.
 func TestIntegrationProvisioning_FolderAuthorizationWithMetadata(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	const (
 		repoName         = "folder-auth-metadata-enabled-repo"
@@ -136,7 +133,7 @@ func TestIntegrationProvisioning_FolderAuthorizationWithMetadata(t *testing.T) {
 		resp := adminFiles.Post(t, folderPathPrefix+"/", nil)
 		require.Equal(t, http.StatusOK, resp.StatusCode, "Admin should be able to create parent folder")
 
-		parentUID := adminFiles.ReadFolderUID(t, ctx, folderPathPrefix+"/_folder.json")
+		parentUID := adminFiles.ReadFolderUID(t, folderPathPrefix+"/_folder.json")
 		require.NotEmpty(t, parentUID, "parent should have stable UID")
 
 		// Editor should be able to create a child folder.
@@ -144,13 +141,13 @@ func TestIntegrationProvisioning_FolderAuthorizationWithMetadata(t *testing.T) {
 		childResp := editorFiles.Post(t, folderPathPrefix+"/child/", nil)
 		require.Equal(t, http.StatusOK, childResp.StatusCode, "Editor should be able to create child folder")
 
-		childUID := adminFiles.ReadFolderUID(t, ctx, folderPathPrefix+"/child/_folder.json")
+		childUID := adminFiles.ReadFolderUID(t, folderPathPrefix+"/child/_folder.json")
 		require.NotEmpty(t, childUID, "child should have stable UID")
 
-		parentUID2 := adminFiles.ReadFolderUID(t, ctx, folderPathPrefix+"/_folder.json")
+		parentUID2 := adminFiles.ReadFolderUID(t, folderPathPrefix+"/_folder.json")
 		require.NotEqual(t, parentUID2, childUID, "parent and child should have different UIDs")
 
-		_, err := helper.Folders.Resource.Get(ctx, childUID, metav1.GetOptions{})
+		_, err := helper.Folders.Resource.Get(t.Context(), childUID, metav1.GetOptions{})
 		require.NoError(t, err, "child Grafana folder should exist with the stable UID")
 	})
 }

--- a/pkg/tests/apis/provisioning/foldermetadata/folder_authorization_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/folder_authorization_test.go
@@ -35,10 +35,9 @@ func TestIntegrationProvisioning_CrossFolderWriteDeniedWithoutDestinationAccess(
 	writeToProvisioningPath(t, helper, "innerA/cross-folder-dash.json", dashboardBody)
 
 	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:                   repoName,
-		SyncTarget:             "folder",
-		Workflows:              []string{"write"},
-		SkipResourceAssertions: true,
+		Name:       repoName,
+		SyncTarget: "folder",
+		Workflows:  []string{"write"},
 	})
 
 	helper.SyncAndWait(t, repoName, nil)
@@ -101,10 +100,9 @@ func TestIntegrationProvisioning_FolderAuthorizationWithMetadata(t *testing.T) {
 	)
 
 	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:                   repoName,
-		SyncTarget:             "instance",
-		Workflows:              []string{"write"},
-		SkipResourceAssertions: true,
+		Name:       repoName,
+		SyncTarget: "instance",
+		Workflows:  []string{"write"},
 	})
 
 	helper.SetPermissions(helper.Org1.Editor, []resourcepermissions.SetResourcePermissionCommand{

--- a/pkg/tests/apis/provisioning/foldermetadata/folder_creation_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/folder_creation_test.go
@@ -15,7 +15,7 @@ func TestIntegrationProvisioning_CreateFolder_FolderMetadataFlag(t *testing.T) {
 
 	const repo = "folder-metadata-test-repo"
 	helper.CreateLocalRepo(t, common.TestRepo{
-		Name: repo, SyncTarget: "instance", Workflows: []string{"write"}, SkipResourceAssertions: true,
+		Name: repo, SyncTarget: "instance", Workflows: []string{"write"},
 		Copies: map[string]string{
 			"../testdata/.keep": "no-meta-existing-folder/.keep",
 		},

--- a/pkg/tests/apis/provisioning/foldermetadata/folder_creation_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/folder_creation_test.go
@@ -1,7 +1,6 @@
 package foldermetadata
 
 import (
-	"context"
 	"net/http"
 	"testing"
 
@@ -13,7 +12,6 @@ import (
 
 func TestIntegrationProvisioning_CreateFolder_FolderMetadataFlag(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	const repo = "folder-metadata-test-repo"
 	helper.CreateLocalRepo(t, common.TestRepo{
@@ -29,13 +27,13 @@ func TestIntegrationProvisioning_CreateFolder_FolderMetadataFlag(t *testing.T) {
 		resp := files.Post(t, "meta-test-folder/", nil)
 		require.Equal(t, http.StatusOK, resp.StatusCode, "creating folder should succeed")
 
-		uid, title := files.RequireValidFolderMetadata(t, ctx, "meta-test-folder/_folder.json")
+		uid, title := files.RequireValidFolderMetadata(t, "meta-test-folder/_folder.json")
 		require.Equal(t, "meta-test-folder", title)
 
-		_, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "meta-test-folder/.keep")
+		_, err := helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "meta-test-folder/.keep")
 		require.Error(t, err, ".keep should not exist when flag is enabled")
 
-		_, err = helper.Folders.Resource.Get(ctx, uid, metav1.GetOptions{})
+		_, err = helper.Folders.Resource.Get(t.Context(), uid, metav1.GetOptions{})
 		require.NoError(t, err, "Grafana folder should exist with the stable UID from _folder.json")
 	})
 
@@ -43,13 +41,13 @@ func TestIntegrationProvisioning_CreateFolder_FolderMetadataFlag(t *testing.T) {
 		resp := files.Post(t, "parent-folder/child-folder/", nil)
 		require.Equal(t, http.StatusOK, resp.StatusCode, "creating nested folder should succeed")
 
-		parentUID, _ := files.RequireValidFolderMetadata(t, ctx, "parent-folder/_folder.json")
-		childUID, childTitle := files.RequireValidFolderMetadata(t, ctx, "parent-folder/child-folder/_folder.json")
+		parentUID, _ := files.RequireValidFolderMetadata(t, "parent-folder/_folder.json")
+		childUID, childTitle := files.RequireValidFolderMetadata(t, "parent-folder/child-folder/_folder.json")
 
 		require.NotEqual(t, parentUID, childUID, "each folder gets a distinct UID")
 		require.Equal(t, "child-folder", childTitle)
 
-		_, err := helper.Folders.Resource.Get(ctx, childUID, metav1.GetOptions{})
+		_, err := helper.Folders.Resource.Get(t.Context(), childUID, metav1.GetOptions{})
 		require.NoError(t, err, "child Grafana folder should exist with the stable UID")
 	})
 
@@ -66,10 +64,10 @@ func TestIntegrationProvisioning_CreateFolder_FolderMetadataFlag(t *testing.T) {
 		resp := files.Post(t, "implicit-folder/dashboard.json", body)
 		require.Equal(t, http.StatusOK, resp.StatusCode, "creating dashboard in new folder should succeed")
 
-		uid, title := files.RequireValidFolderMetadata(t, ctx, "implicit-folder/_folder.json")
+		uid, title := files.RequireValidFolderMetadata(t, "implicit-folder/_folder.json")
 		require.Equal(t, "implicit-folder", title)
 
-		_, err := helper.Folders.Resource.Get(ctx, uid, metav1.GetOptions{})
+		_, err := helper.Folders.Resource.Get(t.Context(), uid, metav1.GetOptions{})
 		require.NoError(t, err, "Grafana folder should exist with the UID from _folder.json")
 	})
 
@@ -78,13 +76,13 @@ func TestIntegrationProvisioning_CreateFolder_FolderMetadataFlag(t *testing.T) {
 		resp := files.Post(t, "reuse-folder/dashboard.json", body)
 		require.Equal(t, http.StatusOK, resp.StatusCode, "creating dashboard should succeed")
 
-		uid := files.ReadFolderUID(t, ctx, "reuse-folder/_folder.json")
+		uid := files.ReadFolderUID(t, "reuse-folder/_folder.json")
 		require.NotEmpty(t, uid, "implicit _folder.json should have a UID")
 
 		resp2 := files.Post(t, "reuse-folder/", nil)
 		require.Equal(t, http.StatusConflict, resp2.StatusCode, "explicit folder creation should return 409 because folder already exists")
 
-		uid2 := files.ReadFolderUID(t, ctx, "reuse-folder/_folder.json")
+		uid2 := files.ReadFolderUID(t, "reuse-folder/_folder.json")
 		require.Equal(t, uid, uid2, "UID must not change after explicit folder creation attempt")
 	})
 
@@ -93,14 +91,14 @@ func TestIntegrationProvisioning_CreateFolder_FolderMetadataFlag(t *testing.T) {
 		resp := files.Post(t, "ancestor-a/ancestor-b/dashboard.json", body)
 		require.Equal(t, http.StatusOK, resp.StatusCode, "creating nested dashboard should succeed: %s", string(resp.Body))
 
-		parentUID, _ := files.RequireValidFolderMetadata(t, ctx, "ancestor-a/_folder.json")
-		childUID, _ := files.RequireValidFolderMetadata(t, ctx, "ancestor-a/ancestor-b/_folder.json")
+		parentUID, _ := files.RequireValidFolderMetadata(t, "ancestor-a/_folder.json")
+		childUID, _ := files.RequireValidFolderMetadata(t, "ancestor-a/ancestor-b/_folder.json")
 
 		require.NotEqual(t, parentUID, childUID, "each folder gets a distinct UID")
 
-		_, err := helper.Folders.Resource.Get(ctx, parentUID, metav1.GetOptions{})
+		_, err := helper.Folders.Resource.Get(t.Context(), parentUID, metav1.GetOptions{})
 		require.NoError(t, err, "parent Grafana folder should exist")
-		_, err = helper.Folders.Resource.Get(ctx, childUID, metav1.GetOptions{})
+		_, err = helper.Folders.Resource.Get(t.Context(), childUID, metav1.GetOptions{})
 		require.NoError(t, err, "child Grafana folder should exist")
 	})
 
@@ -109,11 +107,11 @@ func TestIntegrationProvisioning_CreateFolder_FolderMetadataFlag(t *testing.T) {
 		resp := files.Post(t, "no-meta-existing-folder/should-have-meta/dashboard.json", body)
 		require.Equal(t, http.StatusOK, resp.StatusCode, "creating nested dashboard should succeed: %s", string(resp.Body))
 
-		_, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "no-meta-existing-folder/_folder.json")
+		_, err := helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "no-meta-existing-folder/_folder.json")
 		require.Error(t, err, "_folder.json should not exist when flag is enabled")
 
-		childUID, _ := files.RequireValidFolderMetadata(t, ctx, "no-meta-existing-folder/should-have-meta/_folder.json")
-		_, err = helper.Folders.Resource.Get(ctx, childUID, metav1.GetOptions{})
+		childUID, _ := files.RequireValidFolderMetadata(t, "no-meta-existing-folder/should-have-meta/_folder.json")
+		_, err = helper.Folders.Resource.Get(t.Context(), childUID, metav1.GetOptions{})
 		require.NoError(t, err, "child Grafana folder should exist")
 	})
 
@@ -121,22 +119,22 @@ func TestIntegrationProvisioning_CreateFolder_FolderMetadataFlag(t *testing.T) {
 		resp := files.Post(t, "managed-parent/", nil)
 		require.Equal(t, http.StatusOK, resp.StatusCode, "creating parent folder should succeed")
 
-		parentUID := files.ReadFolderUID(t, ctx, "managed-parent/_folder.json")
+		parentUID := files.ReadFolderUID(t, "managed-parent/_folder.json")
 		require.NotEmpty(t, parentUID, "parent should have a non-empty stable UID")
 
 		resp2 := files.Post(t, "managed-parent/child-folder/", nil)
 		require.Equal(t, http.StatusOK, resp2.StatusCode, "creating child folder should succeed")
 
-		childUID := files.ReadFolderUID(t, ctx, "managed-parent/child-folder/_folder.json")
+		childUID := files.ReadFolderUID(t, "managed-parent/child-folder/_folder.json")
 		require.NotEmpty(t, childUID, "child should have a non-empty stable UID")
 		require.NotEqual(t, parentUID, childUID, "child and parent UIDs must differ")
 
-		parentUID2 := files.ReadFolderUID(t, ctx, "managed-parent/_folder.json")
+		parentUID2 := files.ReadFolderUID(t, "managed-parent/_folder.json")
 		require.Equal(t, parentUID, parentUID2, "parent UID must be unchanged after child creation")
 
-		_, err := helper.Folders.Resource.Get(ctx, parentUID, metav1.GetOptions{})
+		_, err := helper.Folders.Resource.Get(t.Context(), parentUID, metav1.GetOptions{})
 		require.NoError(t, err, "parent Grafana folder should exist")
-		_, err = helper.Folders.Resource.Get(ctx, childUID, metav1.GetOptions{})
+		_, err = helper.Folders.Resource.Get(t.Context(), childUID, metav1.GetOptions{})
 		require.NoError(t, err, "child Grafana folder should exist")
 	})
 }

--- a/pkg/tests/apis/provisioning/foldermetadata/folder_file_protection_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/folder_file_protection_test.go
@@ -1,7 +1,6 @@
 package foldermetadata
 
 import (
-	"context"
 	"net/http"
 	"testing"
 
@@ -12,7 +11,6 @@ import (
 
 func TestIntegrationProvisioning_FolderMetadataFileProtection(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	const repo = "folder-protection-test-repo"
 	helper.CreateLocalRepo(t, common.TestRepo{Name: repo, SyncTarget: "instance", Workflows: []string{"write"}, SkipResourceAssertions: true})
@@ -39,7 +37,7 @@ func TestIntegrationProvisioning_FolderMetadataFileProtection(t *testing.T) {
 	})
 
 	t.Run("GET of _folder.json is still allowed", func(t *testing.T) {
-		uid := files.ReadFolderUID(t, ctx, "protected-folder/_folder.json")
+		uid := files.ReadFolderUID(t, "protected-folder/_folder.json")
 		require.NotEmpty(t, uid)
 	})
 

--- a/pkg/tests/apis/provisioning/foldermetadata/folder_file_protection_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/folder_file_protection_test.go
@@ -13,7 +13,7 @@ func TestIntegrationProvisioning_FolderMetadataFileProtection(t *testing.T) {
 	helper := sharedHelper(t)
 
 	const repo = "folder-protection-test-repo"
-	helper.CreateLocalRepo(t, common.TestRepo{Name: repo, SyncTarget: "instance", Workflows: []string{"write"}, SkipResourceAssertions: true})
+	helper.CreateLocalRepo(t, common.TestRepo{Name: repo, SyncTarget: "instance", Workflows: []string{"write"}})
 
 	files := helper.NewFilesClient(repo)
 

--- a/pkg/tests/apis/provisioning/foldermetadata/folder_permissions_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/folder_permissions_test.go
@@ -28,7 +28,7 @@ func TestIntegrationFolderPermissions_ProvisionedFolders_WithFlag(t *testing.T) 
 	t.Run("should succeed updating permissions for provisioned nested folder when flag is enabled", func(t *testing.T) {
 		folders, err := helper.Folders.Resource.List(t.Context(), metav1.ListOptions{})
 		require.NoError(t, err)
-		require.GreaterOrEqual(t, len(folders.Items), 2, "should have 2 folders (root and nested)")
+		helper.RequireRepoFolderCount(t, repoName, 3) // root, folder, subfolder
 
 		// Find all folders managed by provisioning
 		var provisionedFolders []*unstructured.Unstructured

--- a/pkg/tests/apis/provisioning/foldermetadata/folder_permissions_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/folder_permissions_test.go
@@ -19,13 +19,11 @@ func TestIntegrationFolderPermissions_ProvisionedFolders_WithFlag(t *testing.T) 
 	repoName := "nested-folder-repo-flag"
 	helper := sharedHelper(t)
 	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:            repoName,
-		SyncTarget:      "folder",
-		ExpectedFolders: 1,
+		Name:       repoName,
+		SyncTarget: "folder",
 		Copies: map[string]string{
 			"../testdata/all-panels.json": "folder/subfolder/dashboard.json",
 		},
-		SkipResourceAssertions: true,
 	})
 	t.Run("should succeed updating permissions for provisioned nested folder when flag is enabled", func(t *testing.T) {
 		folders, err := helper.Folders.Resource.List(t.Context(), metav1.ListOptions{})

--- a/pkg/tests/apis/provisioning/foldermetadata/folder_title_normalization_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/folder_title_normalization_test.go
@@ -83,10 +83,9 @@ func TestIntegrationProvisioning_MigrateFolderTitleNormalization(t *testing.T) {
 
 	const repo = "folder-title-normalization-repo"
 	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:                   repo,
-		SyncTarget:             "folder",
-		Workflows:              []string{"write"},
-		SkipResourceAssertions: true,
+		Name:       repo,
+		SyncTarget: "folder",
+		Workflows:  []string{"write"},
 	})
 
 	// Expected normalized path segments. Titles themselves are preserved in
@@ -224,11 +223,10 @@ func TestIntegrationProvisioning_PullFoldersWithSpaces(t *testing.T) {
 	// SkipSync so the repository exists before we seed it; the pull below is the
 	// action under test.
 	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:                   repo,
-		SyncTarget:             "folder",
-		Workflows:              []string{"write"},
-		SkipSync:               true,
-		SkipResourceAssertions: true,
+		Name:       repo,
+		SyncTarget: "folder",
+		Workflows:  []string{"write"},
+		SkipSync:   true,
 	})
 
 	// Seed a repository whose directory names contain spaces, each carrying a
@@ -289,10 +287,9 @@ func TestIntegrationProvisioning_MigrateFolderTitleCollisionFails(t *testing.T) 
 
 	const repo = "folder-title-collision-repo"
 	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:                   repo,
-		SyncTarget:             "folder",
-		Workflows:              []string{"write"},
-		SkipResourceAssertions: true,
+		Name:       repo,
+		SyncTarget: "folder",
+		Workflows:  []string{"write"},
 	})
 
 	job := helper.TriggerJobAndWaitForComplete(t, repo, provisioning.JobSpec{

--- a/pkg/tests/apis/provisioning/foldermetadata/folder_title_normalization_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/folder_title_normalization_test.go
@@ -61,7 +61,6 @@ import (
 // migrate reported "no changes to sync" as a success while exporting nothing.
 func TestIntegrationProvisioning_MigrateFolderTitleNormalization(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := t.Context()
 
 	// Fixed UIDs keep every assertion deterministic — including the UID-fallback
 	// case, where the path segment is the UID itself.
@@ -80,7 +79,7 @@ func TestIntegrationProvisioning_MigrateFolderTitleNormalization(t *testing.T) {
 	createUnmanagedFolderWithParent(t, helper, betaUID, betaTitle, alphaUID)
 	createUnmanagedFolderWithParent(t, helper, gammaUID, gammaTitle, betaUID)
 	createUnmanagedFolderWithParent(t, helper, deltaUID, deltaTitle, gammaUID)
-	dashName := helper.CreateUnmanagedDashboard(t, ctx, "Sample Dashboard", deltaUID)
+	dashName := helper.CreateUnmanagedDashboard(t, "Sample Dashboard", deltaUID)
 
 	const repo = "folder-title-normalization-repo"
 	helper.CreateLocalRepo(t, common.TestRepo{
@@ -147,21 +146,21 @@ func TestIntegrationProvisioning_MigrateFolderTitleNormalization(t *testing.T) {
 	// The /files endpoint always uses forward slashes; ToSlash keeps the path
 	// correct if filepath.Join produced OS-specific separators (e.g. on Windows).
 	files := helper.NewFilesClient(repo)
-	require.Equal(t, betaTitle, files.ReadFolderTitle(t, ctx, filepath.ToSlash(betaPath)+"/_folder.json"),
+	require.Equal(t, betaTitle, files.ReadFolderTitle(t, filepath.ToSlash(betaPath)+"/_folder.json"),
 		"reading a _folder.json at a path with a space through the /files endpoint should work")
-	require.Equal(t, deltaUID, files.ReadFolderUID(t, ctx, filepath.ToSlash(deltaPath)+"/_folder.json"))
+	require.Equal(t, deltaUID, files.ReadFolderUID(t, filepath.ToSlash(deltaPath)+"/_folder.json"))
 
 	// 4) The pull half of the migrate consumed the normalized/space paths: the
 	// deepest folder and the dashboard end up managed by the repository.
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		f, err := helper.Folders.Resource.Get(ctx, deltaUID, metav1.GetOptions{})
+		f, err := helper.Folders.Resource.Get(t.Context(), deltaUID, metav1.GetOptions{})
 		if !assert.NoError(collect, err, "deepest folder should exist") {
 			return
 		}
 		assert.Equal(collect, repo, f.GetAnnotations()[utils.AnnoKeyManagerIdentity],
 			"deepest folder should be managed by the repo after migrate")
 
-		d, err := helper.DashboardsV1.Resource.Get(ctx, dashName, metav1.GetOptions{})
+		d, err := helper.DashboardsV1.Resource.Get(t.Context(), dashName, metav1.GetOptions{})
 		if !assert.NoError(collect, err, "dashboard should exist") {
 			return
 		}
@@ -185,7 +184,7 @@ func TestIntegrationProvisioning_MigrateFolderTitleNormalization(t *testing.T) {
 	// A pull must read the space path back out of the repo tree and reconcile it.
 	helper.SyncAndWait(t, repo, nil)
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		d, err := helper.DashboardsV1.Resource.Get(ctx, writtenUID, metav1.GetOptions{})
+		d, err := helper.DashboardsV1.Resource.Get(t.Context(), writtenUID, metav1.GetOptions{})
 		if !assert.NoError(collect, err, "written dashboard should exist after pull") {
 			return
 		}
@@ -211,7 +210,6 @@ func TestIntegrationProvisioning_MigrateFolderTitleNormalization(t *testing.T) {
 //	   └─ pulled-dashboard.json            └─ dashboard "pull-dash"
 func TestIntegrationProvisioning_PullFoldersWithSpaces(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := t.Context()
 
 	const (
 		repo        = "pull-space-folders-repo"
@@ -247,7 +245,7 @@ func TestIntegrationProvisioning_PullFoldersWithSpaces(t *testing.T) {
 	})
 
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		parent, err := helper.Folders.Resource.Get(ctx, parentUID, metav1.GetOptions{})
+		parent, err := helper.Folders.Resource.Get(t.Context(), parentUID, metav1.GetOptions{})
 		if !assert.NoError(collect, err, "parent folder should be created by the pull") {
 			return
 		}
@@ -256,7 +254,7 @@ func TestIntegrationProvisioning_PullFoldersWithSpaces(t *testing.T) {
 		parentGrafanaTitle, _, _ := unstructured.NestedString(parent.Object, "spec", "title")
 		assert.Equal(collect, parentTitle, parentGrafanaTitle, "parent title should survive the pull")
 
-		child, err := helper.Folders.Resource.Get(ctx, childUID, metav1.GetOptions{})
+		child, err := helper.Folders.Resource.Get(t.Context(), childUID, metav1.GetOptions{})
 		if !assert.NoError(collect, err, "nested folder should be created by the pull") {
 			return
 		}
@@ -267,7 +265,7 @@ func TestIntegrationProvisioning_PullFoldersWithSpaces(t *testing.T) {
 		childGrafanaTitle, _, _ := unstructured.NestedString(child.Object, "spec", "title")
 		assert.Equal(collect, childTitle, childGrafanaTitle, "nested folder title should survive the pull")
 
-		d, err := helper.DashboardsV1.Resource.Get(ctx, dashUID, metav1.GetOptions{})
+		d, err := helper.DashboardsV1.Resource.Get(t.Context(), dashUID, metav1.GetOptions{})
 		if !assert.NoError(collect, err, "dashboard should be created by the pull") {
 			return
 		}

--- a/pkg/tests/apis/provisioning/foldermetadata/full/export_folders_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/full/export_folders_test.go
@@ -1,7 +1,6 @@
 package full
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -50,7 +49,6 @@ func triggerExport(t *testing.T, helper *common.GitTestHelper, repo string) *pro
 // folder contains a .keep placeholder (no _folder.json).
 func TestIntegrationProvisioning_ExportJob_GitRepo_FolderMetadataDisabled(t *testing.T) {
 	helper := sharedGitHelper(t)
-	ctx := context.Background()
 
 	const repoName = "git-export-no-meta"
 	helper.CreateExportGitRepo(t, repoName, nil)
@@ -63,10 +61,10 @@ func TestIntegrationProvisioning_ExportJob_GitRepo_FolderMetadataDisabled(t *tes
 	// Without the feature flag git cannot track an empty directory, so a
 	// .keep placeholder must be committed inside every exported folder.
 	// The files API rejects hidden-file paths, so we verify via the git clone.
-	require.True(t, helper.GitFileExists(t, ctx, repoName, "git-no-meta-folder/.keep"),
+	require.True(t, helper.GitFileExists(t, repoName, "git-no-meta-folder/.keep"),
 		".keep file must be committed for an exported folder when the feature flag is disabled")
 
 	// No _folder.json must be present when the flag is off.
-	_, err := helper.Repositories.Resource.Get(ctx, repoName, metav1.GetOptions{}, "files", "git-no-meta-folder/_folder.json")
+	_, err := helper.Repositories.Resource.Get(t.Context(), repoName, metav1.GetOptions{}, "files", "git-no-meta-folder/_folder.json")
 	require.True(t, apierrors.IsNotFound(err), "_folder.json must not exist when the feature flag is disabled")
 }

--- a/pkg/tests/apis/provisioning/foldermetadata/full/metadata_name_change_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/full/metadata_name_change_test.go
@@ -29,7 +29,7 @@ func TestIntegrationProvisioning_FullSync_MetadataNameChange(t *testing.T) {
 	}, "write", "branch")
 
 	helper.SyncAndWait(t, repoName)
-	common.RequireDashboardCount(t, helper.DashboardsV1, 1)
+	helper.RequireRepoDashboardCount(t, repoName, 1)
 	common.RequireDashboardTitle(t, helper.DashboardsV1, "name-change-full-001", "Dashboard One")
 
 	// Change the metadata.name (uid) in the same file path.
@@ -58,7 +58,7 @@ func TestIntegrationProvisioning_FullSync_MetadataNameChange(t *testing.T) {
 		assert.True(c, apierrors.IsNotFound(err), "old dashboard should be NotFound, got: %v", err)
 	}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "old dashboard should be deleted after name change")
 
-	common.RequireDashboardCount(t, helper.DashboardsV1, 1)
+	helper.RequireRepoDashboardCount(t, repoName, 1)
 }
 
 // TestIntegrationProvisioning_FullSync_ChainedNameChanges verifies that
@@ -73,7 +73,7 @@ func TestIntegrationProvisioning_FullSync_ChainedNameChanges(t *testing.T) {
 	}, "write", "branch")
 
 	helper.SyncAndWait(t, repoName)
-	common.RequireDashboardCount(t, helper.DashboardsV1, 1)
+	helper.RequireRepoDashboardCount(t, repoName, 1)
 
 	// First name change: v1 -> v2
 	require.NoError(t, local.UpdateFile("dashboard.json", string(common.DashboardJSON("chained-v2", "Dashboard V2", 2))))
@@ -94,7 +94,7 @@ func TestIntegrationProvisioning_FullSync_ChainedNameChanges(t *testing.T) {
 		_, err := helper.DashboardsV1.Resource.Get(t.Context(), "chained-v1", metav1.GetOptions{})
 		assert.True(c, apierrors.IsNotFound(err), "v1 should be NotFound, got: %v", err)
 	}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
-	common.RequireDashboardCount(t, helper.DashboardsV1, 1)
+	helper.RequireRepoDashboardCount(t, repoName, 1)
 
 	// Second name change: v2 -> v3
 	require.NoError(t, local.UpdateFile("dashboard.json", string(common.DashboardJSON("chained-v3", "Dashboard V3", 3))))
@@ -115,7 +115,7 @@ func TestIntegrationProvisioning_FullSync_ChainedNameChanges(t *testing.T) {
 		_, err := helper.DashboardsV1.Resource.Get(t.Context(), "chained-v2", metav1.GetOptions{})
 		assert.True(c, apierrors.IsNotFound(err), "v2 should be NotFound, got: %v", err)
 	}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
-	common.RequireDashboardCount(t, helper.DashboardsV1, 1)
+	helper.RequireRepoDashboardCount(t, repoName, 1)
 }
 
 // TestIntegrationProvisioning_FullSync_MultipleFilesNameChange verifies that
@@ -131,7 +131,7 @@ func TestIntegrationProvisioning_FullSync_MultipleFilesNameChange(t *testing.T) 
 	}, "write", "branch")
 
 	helper.SyncAndWait(t, repoName)
-	common.RequireDashboardCount(t, helper.DashboardsV1, 2)
+	helper.RequireRepoDashboardCount(t, repoName, 2)
 
 	// Change both names simultaneously.
 	require.NoError(t, local.UpdateFile("dash1.json", string(common.DashboardJSON("multi-c", "Dashboard C", 2))))
@@ -161,7 +161,7 @@ func TestIntegrationProvisioning_FullSync_MultipleFilesNameChange(t *testing.T) 
 		assert.True(c, apierrors.IsNotFound(err), "dashboard B should be NotFound, got: %v", err)
 	}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
 
-	common.RequireDashboardCount(t, helper.DashboardsV1, 2)
+	helper.RequireRepoDashboardCount(t, repoName, 2)
 }
 
 // TestIntegrationProvisioning_FullSync_OrphanCleanupOnSubsequentSync verifies
@@ -182,7 +182,7 @@ func TestIntegrationProvisioning_FullSync_OrphanCleanupOnSubsequentSync(t *testi
 	}, "write", "branch")
 
 	helper.SyncAndWait(t, repoName)
-	common.RequireDashboardCount(t, helper.DashboardsV1, 1)
+	helper.RequireRepoDashboardCount(t, repoName, 1)
 
 	// Inject an orphan directly into unified storage, bypassing the K8s API
 	// admission hooks that prevent creating a second managed resource at the
@@ -227,12 +227,12 @@ func TestIntegrationProvisioning_FullSync_OrphanCleanupOnSubsequentSync(t *testi
 	require.Nil(t, rsp.GetError(), "resource create should not return error: %v", rsp.GetError())
 
 	// Confirm two dashboards exist before cleanup.
-	common.RequireDashboardCount(t, helper.DashboardsV1, 2)
+	helper.RequireRepoDashboardCount(t, repoName, 2)
 
 	// Full sync should detect the duplicate sourcePath and delete the orphan.
 	helper.SyncAndWait(t, repoName)
 
-	common.RequireDashboardCount(t, helper.DashboardsV1, 1)
+	helper.RequireRepoDashboardCount(t, repoName, 1)
 
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		_, err := helper.DashboardsV1.Resource.Get(t.Context(), "real-dash", metav1.GetOptions{})

--- a/pkg/tests/apis/provisioning/foldermetadata/full/metadata_name_change_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/full/metadata_name_change_test.go
@@ -1,7 +1,6 @@
 package full
 
 import (
-	"context"
 	"encoding/json"
 	"testing"
 
@@ -22,7 +21,6 @@ import (
 // creates the new resource and deletes the old one so no orphan is left behind.
 func TestIntegrationProvisioning_FullSync_MetadataNameChange(t *testing.T) {
 	helper := sharedGitHelper(t)
-	ctx := context.Background()
 
 	const repoName = "git-full-name-change"
 
@@ -31,8 +29,8 @@ func TestIntegrationProvisioning_FullSync_MetadataNameChange(t *testing.T) {
 	}, "write", "branch")
 
 	helper.SyncAndWait(t, repoName)
-	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 1)
-	common.RequireDashboardTitle(t, helper.DashboardsV1, ctx, "name-change-full-001", "Dashboard One")
+	common.RequireDashboardCount(t, helper.DashboardsV1, 1)
+	common.RequireDashboardTitle(t, helper.DashboardsV1, "name-change-full-001", "Dashboard One")
 
 	// Change the metadata.name (uid) in the same file path.
 	require.NoError(t, local.UpdateFile("dashboard1.json", string(common.DashboardJSON("name-change-full-002", "Dashboard One Renamed", 2))))
@@ -47,7 +45,7 @@ func TestIntegrationProvisioning_FullSync_MetadataNameChange(t *testing.T) {
 
 	// The new dashboard should exist with the new name.
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		d, err := helper.DashboardsV1.Resource.Get(ctx, "name-change-full-002", metav1.GetOptions{})
+		d, err := helper.DashboardsV1.Resource.Get(t.Context(), "name-change-full-002", metav1.GetOptions{})
 		assert.NoError(c, err, "new dashboard should exist")
 		if d != nil {
 			assert.Equal(c, "name-change-full-002", d.GetName())
@@ -56,18 +54,17 @@ func TestIntegrationProvisioning_FullSync_MetadataNameChange(t *testing.T) {
 
 	// The old dashboard should be deleted — no orphan left behind.
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		_, err := helper.DashboardsV1.Resource.Get(ctx, "name-change-full-001", metav1.GetOptions{})
+		_, err := helper.DashboardsV1.Resource.Get(t.Context(), "name-change-full-001", metav1.GetOptions{})
 		assert.True(c, apierrors.IsNotFound(err), "old dashboard should be NotFound, got: %v", err)
 	}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "old dashboard should be deleted after name change")
 
-	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 1)
+	common.RequireDashboardCount(t, helper.DashboardsV1, 1)
 }
 
 // TestIntegrationProvisioning_FullSync_ChainedNameChanges verifies that
 // sequential metadata.name changes never accumulate orphaned resources.
 func TestIntegrationProvisioning_FullSync_ChainedNameChanges(t *testing.T) {
 	helper := sharedGitHelper(t)
-	ctx := context.Background()
 
 	const repoName = "git-full-chained-name"
 
@@ -76,7 +73,7 @@ func TestIntegrationProvisioning_FullSync_ChainedNameChanges(t *testing.T) {
 	}, "write", "branch")
 
 	helper.SyncAndWait(t, repoName)
-	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 1)
+	common.RequireDashboardCount(t, helper.DashboardsV1, 1)
 
 	// First name change: v1 -> v2
 	require.NoError(t, local.UpdateFile("dashboard.json", string(common.DashboardJSON("chained-v2", "Dashboard V2", 2))))
@@ -90,14 +87,14 @@ func TestIntegrationProvisioning_FullSync_ChainedNameChanges(t *testing.T) {
 	helper.SyncAndWait(t, repoName)
 
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		_, err := helper.DashboardsV1.Resource.Get(ctx, "chained-v2", metav1.GetOptions{})
+		_, err := helper.DashboardsV1.Resource.Get(t.Context(), "chained-v2", metav1.GetOptions{})
 		assert.NoError(c, err, "v2 should exist")
 	}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		_, err := helper.DashboardsV1.Resource.Get(ctx, "chained-v1", metav1.GetOptions{})
+		_, err := helper.DashboardsV1.Resource.Get(t.Context(), "chained-v1", metav1.GetOptions{})
 		assert.True(c, apierrors.IsNotFound(err), "v1 should be NotFound, got: %v", err)
 	}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
-	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 1)
+	common.RequireDashboardCount(t, helper.DashboardsV1, 1)
 
 	// Second name change: v2 -> v3
 	require.NoError(t, local.UpdateFile("dashboard.json", string(common.DashboardJSON("chained-v3", "Dashboard V3", 3))))
@@ -111,21 +108,20 @@ func TestIntegrationProvisioning_FullSync_ChainedNameChanges(t *testing.T) {
 	helper.SyncAndWait(t, repoName)
 
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		_, err := helper.DashboardsV1.Resource.Get(ctx, "chained-v3", metav1.GetOptions{})
+		_, err := helper.DashboardsV1.Resource.Get(t.Context(), "chained-v3", metav1.GetOptions{})
 		assert.NoError(c, err, "v3 should exist")
 	}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		_, err := helper.DashboardsV1.Resource.Get(ctx, "chained-v2", metav1.GetOptions{})
+		_, err := helper.DashboardsV1.Resource.Get(t.Context(), "chained-v2", metav1.GetOptions{})
 		assert.True(c, apierrors.IsNotFound(err), "v2 should be NotFound, got: %v", err)
 	}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
-	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 1)
+	common.RequireDashboardCount(t, helper.DashboardsV1, 1)
 }
 
 // TestIntegrationProvisioning_FullSync_MultipleFilesNameChange verifies that
 // simultaneous metadata.name changes across multiple files all get cleaned up.
 func TestIntegrationProvisioning_FullSync_MultipleFilesNameChange(t *testing.T) {
 	helper := sharedGitHelper(t)
-	ctx := context.Background()
 
 	const repoName = "git-full-multi-name"
 
@@ -135,7 +131,7 @@ func TestIntegrationProvisioning_FullSync_MultipleFilesNameChange(t *testing.T) 
 	}, "write", "branch")
 
 	helper.SyncAndWait(t, repoName)
-	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 2)
+	common.RequireDashboardCount(t, helper.DashboardsV1, 2)
 
 	// Change both names simultaneously.
 	require.NoError(t, local.UpdateFile("dash1.json", string(common.DashboardJSON("multi-c", "Dashboard C", 2))))
@@ -151,21 +147,21 @@ func TestIntegrationProvisioning_FullSync_MultipleFilesNameChange(t *testing.T) 
 
 	// New dashboards should exist.
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		_, err := helper.DashboardsV1.Resource.Get(ctx, "multi-c", metav1.GetOptions{})
+		_, err := helper.DashboardsV1.Resource.Get(t.Context(), "multi-c", metav1.GetOptions{})
 		assert.NoError(c, err, "dashboard C should exist")
-		_, err = helper.DashboardsV1.Resource.Get(ctx, "multi-d", metav1.GetOptions{})
+		_, err = helper.DashboardsV1.Resource.Get(t.Context(), "multi-d", metav1.GetOptions{})
 		assert.NoError(c, err, "dashboard D should exist")
 	}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
 
 	// Old dashboards should be deleted.
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		_, err := helper.DashboardsV1.Resource.Get(ctx, "multi-a", metav1.GetOptions{})
+		_, err := helper.DashboardsV1.Resource.Get(t.Context(), "multi-a", metav1.GetOptions{})
 		assert.True(c, apierrors.IsNotFound(err), "dashboard A should be NotFound, got: %v", err)
-		_, err = helper.DashboardsV1.Resource.Get(ctx, "multi-b", metav1.GetOptions{})
+		_, err = helper.DashboardsV1.Resource.Get(t.Context(), "multi-b", metav1.GetOptions{})
 		assert.True(c, apierrors.IsNotFound(err), "dashboard B should be NotFound, got: %v", err)
 	}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
 
-	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 2)
+	common.RequireDashboardCount(t, helper.DashboardsV1, 2)
 }
 
 // TestIntegrationProvisioning_FullSync_OrphanCleanupOnSubsequentSync verifies
@@ -178,7 +174,6 @@ func TestIntegrationProvisioning_FullSync_MultipleFilesNameChange(t *testing.T) 
 // otherwise refuse to create a second resource at the same sourcePath.
 func TestIntegrationProvisioning_FullSync_OrphanCleanupOnSubsequentSync(t *testing.T) {
 	helper := sharedGitHelper(t)
-	ctx := context.Background()
 
 	const repoName = "git-full-orphan-cleanup"
 
@@ -187,7 +182,7 @@ func TestIntegrationProvisioning_FullSync_OrphanCleanupOnSubsequentSync(t *testi
 	}, "write", "branch")
 
 	helper.SyncAndWait(t, repoName)
-	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 1)
+	common.RequireDashboardCount(t, helper.DashboardsV1, 1)
 
 	// Inject an orphan directly into unified storage, bypassing the K8s API
 	// admission hooks that prevent creating a second managed resource at the
@@ -216,7 +211,7 @@ func TestIntegrationProvisioning_FullSync_OrphanCleanupOnSubsequentSync(t *testi
 	orphanBytes, err := json.Marshal(orphanObj.Object)
 	require.NoError(t, err)
 
-	provCtx, _, err := identity.WithProvisioningIdentity(ctx, "default")
+	provCtx, _, err := identity.WithProvisioningIdentity(t.Context(), "default")
 	require.NoError(t, err)
 
 	rsp, err := helper.GetEnv().ResourceClient.Create(provCtx, &resourcepb.CreateRequest{
@@ -232,20 +227,20 @@ func TestIntegrationProvisioning_FullSync_OrphanCleanupOnSubsequentSync(t *testi
 	require.Nil(t, rsp.GetError(), "resource create should not return error: %v", rsp.GetError())
 
 	// Confirm two dashboards exist before cleanup.
-	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 2)
+	common.RequireDashboardCount(t, helper.DashboardsV1, 2)
 
 	// Full sync should detect the duplicate sourcePath and delete the orphan.
 	helper.SyncAndWait(t, repoName)
 
-	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 1)
+	common.RequireDashboardCount(t, helper.DashboardsV1, 1)
 
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		_, err := helper.DashboardsV1.Resource.Get(ctx, "real-dash", metav1.GetOptions{})
+		_, err := helper.DashboardsV1.Resource.Get(t.Context(), "real-dash", metav1.GetOptions{})
 		assert.NoError(c, err, "real dashboard should survive cleanup")
 	}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
 
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		_, err := helper.DashboardsV1.Resource.Get(ctx, "orphan-dash", metav1.GetOptions{})
+		_, err := helper.DashboardsV1.Resource.Get(t.Context(), "orphan-dash", metav1.GetOptions{})
 		assert.True(c, apierrors.IsNotFound(err), "orphan should be deleted, got: %v", err)
 	}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
 }

--- a/pkg/tests/apis/provisioning/foldermetadata/full_permissions_move_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/full_permissions_move_test.go
@@ -22,10 +22,9 @@ func TestIntegrationProvisioning_FullSync_FolderMovePreservesPermissions(t *test
 	writeToProvisioningPath(t, helper, "teamB/_folder.json", folderMetadataJSON("team-b-uid", "Team B"))
 
 	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:                   repo,
-		SyncTarget:             "folder",
-		SkipSync:               true,
-		SkipResourceAssertions: true,
+		Name:       repo,
+		SyncTarget: "folder",
+		SkipSync:   true,
 	})
 
 	helper.SyncAndWait(t, repo, nil)
@@ -115,10 +114,9 @@ func TestIntegrationProvisioning_FullSync_FolderMoveDoesNotPreservePermissionsFo
 	writeToProvisioningPath(t, helper, "plain/.keep", []byte{})
 
 	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:                   repo,
-		SyncTarget:             "folder",
-		SkipSync:               true,
-		SkipResourceAssertions: true,
+		Name:       repo,
+		SyncTarget: "folder",
+		SkipSync:   true,
 	})
 
 	helper.SyncAndWait(t, repo, nil)
@@ -188,10 +186,9 @@ func TestIntegrationProvisioning_FullSync_NestedFolderMovePreservesPermissions(t
 	writeToProvisioningPath(t, helper, "destination/.keep", []byte{})
 
 	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:                   repo,
-		SyncTarget:             "folder",
-		SkipSync:               true,
-		SkipResourceAssertions: true,
+		Name:       repo,
+		SyncTarget: "folder",
+		SkipSync:   true,
 	})
 
 	helper.SyncAndWait(t, repo, nil)
@@ -244,10 +241,9 @@ func TestIntegrationProvisioning_FullSync_RootToLeafMovePreservesPermissions(t *
 	writeToProvisioningPath(t, helper, "container/inner/_folder.json", folderMetadataJSON("inner-uid", "Inner"))
 
 	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:                   repo,
-		SyncTarget:             "folder",
-		SkipSync:               true,
-		SkipResourceAssertions: true,
+		Name:       repo,
+		SyncTarget: "folder",
+		SkipSync:   true,
 	})
 
 	helper.SyncAndWait(t, repo, nil)
@@ -298,10 +294,9 @@ func TestIntegrationProvisioning_FullSync_LeafToRootMovePreservesPermissions(t *
 	writeToProvisioningPath(t, helper, "parent/deep/leaf/_folder.json", folderMetadataJSON("leaf-uid", "Leaf"))
 
 	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:                   repo,
-		SyncTarget:             "folder",
-		SkipSync:               true,
-		SkipResourceAssertions: true,
+		Name:       repo,
+		SyncTarget: "folder",
+		SkipSync:   true,
 	})
 
 	helper.SyncAndWait(t, repo, nil)
@@ -353,10 +348,9 @@ func TestIntegrationProvisioning_FullSync_MetadataFolderMovedUnderLegacyPreserve
 	writeToProvisioningPath(t, helper, "legacy-parent/.keep", []byte{})
 
 	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:                   repo,
-		SyncTarget:             "folder",
-		SkipSync:               true,
-		SkipResourceAssertions: true,
+		Name:       repo,
+		SyncTarget: "folder",
+		SkipSync:   true,
 	})
 
 	helper.SyncAndWait(t, repo, nil)

--- a/pkg/tests/apis/provisioning/foldermetadata/full_sync_invalid_folder_metadata_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/full_sync_invalid_folder_metadata_test.go
@@ -1,7 +1,6 @@
 package foldermetadata
 
 import (
-	"context"
 	"strings"
 	"testing"
 
@@ -15,7 +14,6 @@ import (
 func TestIntegrationProvisioning_FullSync_InvalidFolderMetadata(t *testing.T) {
 	t.Run("invalid folder metadata created on existing folder keeps unstable uid and preserves children", func(t *testing.T) {
 		helper := sharedHelper(t)
-		ctx := context.Background()
 		const repo = "full-sync-invalid-meta-existing"
 
 		helper.CreateLocalRepo(t, common.TestRepo{
@@ -31,7 +29,7 @@ func TestIntegrationProvisioning_FullSync_InvalidFolderMetadata(t *testing.T) {
 
 		parentUID := findFolderUIDBySourcePath(t, helper, repo, "myfolder")
 		childUID := findFolderUIDBySourcePath(t, helper, repo, "myfolder/child")
-		common.RequireDashboardTitle(t, helper.DashboardsV1, ctx, "existing-child-dash", "Child Dashboard")
+		common.RequireDashboardTitle(t, helper.DashboardsV1, "existing-child-dash", "Child Dashboard")
 		requireDashboardParents(t, helper, repo, map[string]string{
 			"myfolder/dashboard.json":             parentUID,
 			"myfolder/child/child-dashboard.json": childUID,
@@ -49,7 +47,7 @@ func TestIntegrationProvisioning_FullSync_InvalidFolderMetadata(t *testing.T) {
 
 		require.Equal(t, parentUID, findFolderUIDBySourcePath(t, helper, repo, "myfolder"))
 		require.Equal(t, childUID, findFolderUIDBySourcePath(t, helper, repo, "myfolder/child"))
-		common.RequireDashboardTitle(t, helper.DashboardsV1, ctx, "existing-child-dash", "Child Dashboard Updated")
+		common.RequireDashboardTitle(t, helper.DashboardsV1, "existing-child-dash", "Child Dashboard Updated")
 		requireDashboardParents(t, helper, repo, map[string]string{
 			"myfolder/dashboard.json":             parentUID,
 			"myfolder/child/child-dashboard.json": childUID,
@@ -58,7 +56,6 @@ func TestIntegrationProvisioning_FullSync_InvalidFolderMetadata(t *testing.T) {
 
 	t.Run("invalid folder metadata on new folder falls back to unstable uid and reconciles children", func(t *testing.T) {
 		helper := sharedHelper(t)
-		ctx := context.Background()
 		const repo = "full-sync-invalid-meta-new"
 
 		helper.CreateLocalRepo(t, common.TestRepo{
@@ -82,8 +79,8 @@ func TestIntegrationProvisioning_FullSync_InvalidFolderMetadata(t *testing.T) {
 		childUID := findFolderUIDBySourcePath(t, helper, repo, "myfolder/child")
 		require.NotEmpty(t, parentUID)
 		require.NotEmpty(t, childUID)
-		common.RequireDashboardTitle(t, helper.DashboardsV1, ctx, "new-parent-dash", "Parent Dashboard")
-		common.RequireDashboardTitle(t, helper.DashboardsV1, ctx, "new-child-dash", "Child Dashboard")
+		common.RequireDashboardTitle(t, helper.DashboardsV1, "new-parent-dash", "Parent Dashboard")
+		common.RequireDashboardTitle(t, helper.DashboardsV1, "new-child-dash", "Child Dashboard")
 		requireDashboardParents(t, helper, repo, map[string]string{
 			"myfolder/dashboard.json":             parentUID,
 			"myfolder/child/child-dashboard.json": childUID,

--- a/pkg/tests/apis/provisioning/foldermetadata/full_sync_invalid_folder_metadata_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/full_sync_invalid_folder_metadata_test.go
@@ -14,13 +14,13 @@ import (
 func TestIntegrationProvisioning_FullSync_InvalidFolderMetadata(t *testing.T) {
 	t.Run("invalid folder metadata created on existing folder keeps unstable uid and preserves children", func(t *testing.T) {
 		helper := sharedHelper(t)
+
 		const repo = "full-sync-invalid-meta-existing"
 
 		helper.CreateLocalRepo(t, common.TestRepo{
-			Name:                   repo,
-			SyncTarget:             "folder",
-			SkipSync:               true,
-			SkipResourceAssertions: true,
+			Name:       repo,
+			SyncTarget: "folder",
+			SkipSync:   true,
 		})
 		writeToProvisioningPath(t, helper, "myfolder/dashboard.json", common.DashboardJSON("existing-parent-dash", "Parent Dashboard", 1))
 		writeToProvisioningPath(t, helper, "myfolder/child/child-dashboard.json", common.DashboardJSON("existing-child-dash", "Child Dashboard", 1))
@@ -56,13 +56,13 @@ func TestIntegrationProvisioning_FullSync_InvalidFolderMetadata(t *testing.T) {
 
 	t.Run("invalid folder metadata on new folder falls back to unstable uid and reconciles children", func(t *testing.T) {
 		helper := sharedHelper(t)
+
 		const repo = "full-sync-invalid-meta-new"
 
 		helper.CreateLocalRepo(t, common.TestRepo{
-			Name:                   repo,
-			SyncTarget:             "folder",
-			SkipSync:               true,
-			SkipResourceAssertions: true,
+			Name:       repo,
+			SyncTarget: "folder",
+			SkipSync:   true,
 		})
 		writeToProvisioningPath(t, helper, "myfolder/_folder.json", invalidFolderMetadataMissingNameJSON("Broken Folder"))
 		writeToProvisioningPath(t, helper, "myfolder/dashboard.json", common.DashboardJSON("new-parent-dash", "Parent Dashboard", 1))
@@ -92,10 +92,9 @@ func TestIntegrationProvisioning_FullSync_InvalidFolderMetadata(t *testing.T) {
 		const repo = "fs-inv-move-existing"
 
 		helper.CreateLocalRepo(t, common.TestRepo{
-			Name:                   repo,
-			SyncTarget:             "folder",
-			SkipSync:               true,
-			SkipResourceAssertions: true,
+			Name:       repo,
+			SyncTarget: "folder",
+			SkipSync:   true,
 		})
 		writeToProvisioningPath(t, helper, "dashboard.json", common.DashboardJSON("move-into-existing-invalid", "Move Into Existing Invalid", 1))
 		writeToProvisioningPath(t, helper, "broken/existing.json", common.DashboardJSON("existing-invalid-target", "Existing Invalid Target", 1))
@@ -136,10 +135,9 @@ func TestIntegrationProvisioning_FullSync_InvalidFolderMetadata(t *testing.T) {
 		const repo = "fs-inv-move-new"
 
 		helper.CreateLocalRepo(t, common.TestRepo{
-			Name:                   repo,
-			SyncTarget:             "folder",
-			SkipSync:               true,
-			SkipResourceAssertions: true,
+			Name:       repo,
+			SyncTarget: "folder",
+			SkipSync:   true,
 		})
 		writeToProvisioningPath(t, helper, "dashboard.json", common.DashboardJSON("move-into-new-invalid", "Move Into New Invalid", 1))
 
@@ -167,10 +165,9 @@ func TestIntegrationProvisioning_FullSync_InvalidFolderMetadata(t *testing.T) {
 		const repo = "fs-inv-folder-move"
 
 		helper.CreateLocalRepo(t, common.TestRepo{
-			Name:                   repo,
-			SyncTarget:             "folder",
-			SkipSync:               true,
-			SkipResourceAssertions: true,
+			Name:       repo,
+			SyncTarget: "folder",
+			SkipSync:   true,
 		})
 		writeToProvisioningPath(t, helper, "broken/_folder.json", invalidFolderMetadataMissingNameJSON("Broken Folder"))
 		writeToProvisioningPath(t, helper, "broken/dashboard.json", common.DashboardJSON("move-invalid-folder", "Move Invalid Folder", 1))

--- a/pkg/tests/apis/provisioning/foldermetadata/full_sync_invalid_uid_chars_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/full_sync_invalid_uid_chars_test.go
@@ -33,10 +33,9 @@ func TestIntegrationProvisioning_FullSync_FolderInvalidUIDChars(t *testing.T) {
 	const illegalUID = "hello world"
 
 	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:                   repo,
-		SyncTarget:             "folder",
-		SkipSync:               true,
-		SkipResourceAssertions: true,
+		Name:       repo,
+		SyncTarget: "folder",
+		SkipSync:   true,
 	})
 
 	// Shallow folder with a valid UID — must be created normally despite

--- a/pkg/tests/apis/provisioning/foldermetadata/full_sync_move_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/full_sync_move_test.go
@@ -88,7 +88,7 @@ func TestIntegrationProvisioning_FullSync_FolderMoveWithMetadata(t *testing.T) {
 		"teamA/teamC/dashboard.json":       newTeamCUID,
 	})
 
-	common.RequireDashboards(t, helper.DashboardsV1, t.Context(), map[string]common.ExpectedDashboard{
+	common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 		"n1jR8vnnz": {Title: "Panel tests - All panels", SourcePath: "teamA/dashboard.json"},
 		"WZ7AhQiVz": {Title: "Text options", SourcePath: "teamA/teamC/teamB/dashboard.json"},
 		"mIJjFy8Kz": {Title: "Timeline Demo", SourcePath: "teamA/teamC/dashboard.json"},
@@ -111,7 +111,6 @@ func TestIntegrationProvisioning_FullSync_FolderMoveWithMetadata(t *testing.T) {
 
 func TestIntegrationProvisioning_FullSync_DuplicateFolderPathReparentsChildBeforeCleanup(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := t.Context()
 
 	const (
 		repo         = "folder-duplicate-path-cleanup"
@@ -132,7 +131,7 @@ func TestIntegrationProvisioning_FullSync_DuplicateFolderPathReparentsChildBefor
 
 	helper.SyncAndWait(t, repo, nil)
 	common.RequireFolderState(t, helper.Folders, currentUID, "My Folder", "myfolder", repo)
-	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 1)
+	common.RequireDashboardCount(t, helper.DashboardsV1, 1)
 	requireDashboardParents(t, helper, repo, map[string]string{
 		"myfolder/dashboard.json": currentUID,
 	})
@@ -157,12 +156,11 @@ func TestIntegrationProvisioning_FullSync_DuplicateFolderPathReparentsChildBefor
 	})
 	after := common.SnapshotDashboardsBySourcePath(t, helper, repo, []string{"myfolder/dashboard.json"})
 	common.RequireDashboardsUpdatedInPlace(t, before, after, []string{"myfolder/dashboard.json"})
-	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 1)
+	common.RequireDashboardCount(t, helper.DashboardsV1, 1)
 }
 
 func TestIntegrationProvisioning_FullSync_DuplicateFolderBothWithChildren(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := t.Context()
 
 	const (
 		repo       = "folder-dup-both-children"
@@ -188,7 +186,7 @@ func TestIntegrationProvisioning_FullSync_DuplicateFolderBothWithChildren(t *tes
 
 	helper.SyncAndWait(t, repo, nil)
 	common.RequireFolderState(t, helper.Folders, currentUID, "My Folder", "myfolder", repo)
-	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 3)
+	common.RequireDashboardCount(t, helper.DashboardsV1, 3)
 	requireDashboardParents(t, helper, repo, map[string]string{
 		"myfolder/dash1.json": currentUID,
 		"myfolder/dash2.json": currentUID,
@@ -228,12 +226,11 @@ func TestIntegrationProvisioning_FullSync_DuplicateFolderBothWithChildren(t *tes
 	common.RequireDashboardsUpdatedInPlace(t, before, after, []string{
 		"myfolder/dash1.json", "myfolder/dash2.json", "myfolder/dash3.json",
 	})
-	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 3)
+	common.RequireDashboardCount(t, helper.DashboardsV1, 3)
 }
 
 func TestIntegrationProvisioning_FullSync_DuplicateFolderBothWithChildren_Nested(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := t.Context()
 
 	const (
 		repo       = "folder-dup-nested-children"
@@ -261,7 +258,7 @@ func TestIntegrationProvisioning_FullSync_DuplicateFolderBothWithChildren_Nested
 	helper.SyncAndWait(t, repo, nil)
 	common.RequireFolderState(t, helper.Folders, parentUID, "Parent", "parent", repo)
 	common.RequireFolderState(t, helper.Folders, currentUID, "Child", "parent/child", parentUID)
-	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 3)
+	common.RequireDashboardCount(t, helper.DashboardsV1, 3)
 	requireDashboardParents(t, helper, repo, map[string]string{
 		"parent/child/dash1.json": currentUID,
 		"parent/child/dash2.json": currentUID,
@@ -302,12 +299,11 @@ func TestIntegrationProvisioning_FullSync_DuplicateFolderBothWithChildren_Nested
 	common.RequireDashboardsUpdatedInPlace(t, before, after, []string{
 		"parent/child/dash1.json", "parent/child/dash2.json", "parent/child/dash3.json",
 	})
-	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 3)
+	common.RequireDashboardCount(t, helper.DashboardsV1, 3)
 }
 
 func TestIntegrationProvisioning_FullSync_DuplicateFolderWithConcurrentFolderRename(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := t.Context()
 
 	const (
 		repo         = "folder-dup-plus-rename"
@@ -368,7 +364,7 @@ func TestIntegrationProvisioning_FullSync_DuplicateFolderWithConcurrentFolderRen
 		"teamB/panel-dashboard.json": teamBUID,
 	})
 
-	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 2)
+	common.RequireDashboardCount(t, helper.DashboardsV1, 2)
 }
 
 func TestIntegrationProvisioning_FullSync_FolderMoveWithMetadata_NestedSubtree(t *testing.T) {
@@ -417,7 +413,7 @@ func TestIntegrationProvisioning_FullSync_FolderMoveWithMetadata_NestedSubtree(t
 		"other/child/grand/dashboard.json": newGrandUID,
 	})
 
-	common.RequireDashboards(t, helper.DashboardsV1, t.Context(), map[string]common.ExpectedDashboard{
+	common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 		"n1jR8vnnz": {Title: "Panel tests - All panels", SourcePath: "root/dashboard.json"},
 		"WZ7AhQiVz": {Title: "Text options", SourcePath: "other/child/dashboard.json"},
 		"mIJjFy8Kz": {Title: "Timeline Demo", SourcePath: "other/child/grand/dashboard.json"},
@@ -462,7 +458,7 @@ func TestIntegrationProvisioning_FullSync_FolderMoveWithMetadata_MixedLegacy(t *
 		"metaA/plainB/dashboard.json": newPlainBUID,
 	})
 
-	common.RequireDashboards(t, helper.DashboardsV1, t.Context(), map[string]common.ExpectedDashboard{
+	common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 		"n1jR8vnnz": {Title: "Panel tests - All panels", SourcePath: "metaA/dashboard.json"},
 		"WZ7AhQiVz": {Title: "Text options", SourcePath: "metaA/plainB/dashboard.json"},
 	})
@@ -500,7 +496,7 @@ func TestIntegrationProvisioning_FullSync_FolderMoveWithMetadata_MetaToPlainPare
 		"child/dashboard.json": "child-uid",
 	})
 
-	common.RequireDashboards(t, helper.DashboardsV1, t.Context(), map[string]common.ExpectedDashboard{
+	common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 		"n1jR8vnnz": {Title: "Panel tests - All panels", SourcePath: "child/dashboard.json"},
 	})
 }
@@ -543,7 +539,7 @@ func TestIntegrationProvisioning_FullSync_FolderMoveWithMetadata_RootToNested(t 
 		"parent/myfolder/dashboard.json": "my-uid",
 	})
 
-	common.RequireDashboards(t, helper.DashboardsV1, t.Context(), map[string]common.ExpectedDashboard{
+	common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 		"n1jR8vnnz": {Title: "Panel tests - All panels", SourcePath: "parent/myfolder/dashboard.json"},
 	})
 }
@@ -586,7 +582,7 @@ func TestIntegrationProvisioning_FullSync_FolderMoveWithMetadata_NestedToRoot(t 
 		"child/dashboard.json": "child-uid",
 	})
 
-	common.RequireDashboards(t, helper.DashboardsV1, t.Context(), map[string]common.ExpectedDashboard{
+	common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 		"n1jR8vnnz": {Title: "Panel tests - All panels", SourcePath: "child/dashboard.json"},
 	})
 }

--- a/pkg/tests/apis/provisioning/foldermetadata/full_sync_move_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/full_sync_move_test.go
@@ -36,8 +36,7 @@ func TestIntegrationProvisioning_FullSync_FolderMoveWithMetadata(t *testing.T) {
 			"../testdata/text-options.json":  "teamB/dashboard.json",
 			"../testdata/timeline-demo.json": "teamC/dashboard.json",
 		},
-		SkipSync:               true,
-		SkipResourceAssertions: true,
+		SkipSync: true,
 	})
 
 	helper.SyncAndWait(t, repo, nil)
@@ -123,15 +122,14 @@ func TestIntegrationProvisioning_FullSync_DuplicateFolderPathReparentsChildBefor
 	writeToProvisioningPath(t, helper, "myfolder/dashboard.json", common.DashboardJSON(dashboardUID, "Dashboard in Duplicate Folder", 1))
 
 	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:                   repo,
-		SyncTarget:             "folder",
-		SkipSync:               true,
-		SkipResourceAssertions: true,
+		Name:       repo,
+		SyncTarget: "folder",
+		SkipSync:   true,
 	})
 
 	helper.SyncAndWait(t, repo, nil)
 	common.RequireFolderState(t, helper.Folders, currentUID, "My Folder", "myfolder", repo)
-	common.RequireDashboardCount(t, helper.DashboardsV1, 1)
+	helper.RequireRepoDashboardCount(t, repo, 1)
 	requireDashboardParents(t, helper, repo, map[string]string{
 		"myfolder/dashboard.json": currentUID,
 	})
@@ -156,12 +154,11 @@ func TestIntegrationProvisioning_FullSync_DuplicateFolderPathReparentsChildBefor
 	})
 	after := common.SnapshotDashboardsBySourcePath(t, helper, repo, []string{"myfolder/dashboard.json"})
 	common.RequireDashboardsUpdatedInPlace(t, before, after, []string{"myfolder/dashboard.json"})
-	common.RequireDashboardCount(t, helper.DashboardsV1, 1)
+	helper.RequireRepoDashboardCount(t, repo, 1)
 }
 
 func TestIntegrationProvisioning_FullSync_DuplicateFolderBothWithChildren(t *testing.T) {
 	helper := sharedHelper(t)
-
 	const (
 		repo       = "folder-dup-both-children"
 		currentUID = "dup-both-current-uid"
@@ -178,15 +175,14 @@ func TestIntegrationProvisioning_FullSync_DuplicateFolderBothWithChildren(t *tes
 	writeToProvisioningPath(t, helper, "myfolder/dash3.json", common.DashboardJSON(dash3UID, "Dashboard 3", 1))
 
 	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:                   repo,
-		SyncTarget:             "folder",
-		SkipSync:               true,
-		SkipResourceAssertions: true,
+		Name:       repo,
+		SyncTarget: "folder",
+		SkipSync:   true,
 	})
 
 	helper.SyncAndWait(t, repo, nil)
 	common.RequireFolderState(t, helper.Folders, currentUID, "My Folder", "myfolder", repo)
-	common.RequireDashboardCount(t, helper.DashboardsV1, 3)
+	helper.RequireRepoDashboardCount(t, repo, 3)
 	requireDashboardParents(t, helper, repo, map[string]string{
 		"myfolder/dash1.json": currentUID,
 		"myfolder/dash2.json": currentUID,
@@ -226,7 +222,7 @@ func TestIntegrationProvisioning_FullSync_DuplicateFolderBothWithChildren(t *tes
 	common.RequireDashboardsUpdatedInPlace(t, before, after, []string{
 		"myfolder/dash1.json", "myfolder/dash2.json", "myfolder/dash3.json",
 	})
-	common.RequireDashboardCount(t, helper.DashboardsV1, 3)
+	helper.RequireRepoDashboardCount(t, repo, 3)
 }
 
 func TestIntegrationProvisioning_FullSync_DuplicateFolderBothWithChildren_Nested(t *testing.T) {
@@ -249,16 +245,15 @@ func TestIntegrationProvisioning_FullSync_DuplicateFolderBothWithChildren_Nested
 	writeToProvisioningPath(t, helper, "parent/child/dash3.json", common.DashboardJSON(dash3UID, "Dashboard 3", 1))
 
 	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:                   repo,
-		SyncTarget:             "folder",
-		SkipSync:               true,
-		SkipResourceAssertions: true,
+		Name:       repo,
+		SyncTarget: "folder",
+		SkipSync:   true,
 	})
 
 	helper.SyncAndWait(t, repo, nil)
 	common.RequireFolderState(t, helper.Folders, parentUID, "Parent", "parent", repo)
 	common.RequireFolderState(t, helper.Folders, currentUID, "Child", "parent/child", parentUID)
-	common.RequireDashboardCount(t, helper.DashboardsV1, 3)
+	helper.RequireRepoDashboardCount(t, repo, 3)
 	requireDashboardParents(t, helper, repo, map[string]string{
 		"parent/child/dash1.json": currentUID,
 		"parent/child/dash2.json": currentUID,
@@ -299,7 +294,7 @@ func TestIntegrationProvisioning_FullSync_DuplicateFolderBothWithChildren_Nested
 	common.RequireDashboardsUpdatedInPlace(t, before, after, []string{
 		"parent/child/dash1.json", "parent/child/dash2.json", "parent/child/dash3.json",
 	})
-	common.RequireDashboardCount(t, helper.DashboardsV1, 3)
+	helper.RequireRepoDashboardCount(t, repo, 3)
 }
 
 func TestIntegrationProvisioning_FullSync_DuplicateFolderWithConcurrentFolderRename(t *testing.T) {
@@ -324,8 +319,7 @@ func TestIntegrationProvisioning_FullSync_DuplicateFolderWithConcurrentFolderRen
 		Copies: map[string]string{
 			"../testdata/all-panels.json": "teamA/panel-dashboard.json",
 		},
-		SkipSync:               true,
-		SkipResourceAssertions: true,
+		SkipSync: true,
 	})
 
 	helper.SyncAndWait(t, repo, nil)
@@ -364,7 +358,7 @@ func TestIntegrationProvisioning_FullSync_DuplicateFolderWithConcurrentFolderRen
 		"teamB/panel-dashboard.json": teamBUID,
 	})
 
-	common.RequireDashboardCount(t, helper.DashboardsV1, 2)
+	helper.RequireRepoDashboardCount(t, repo, 2)
 }
 
 func TestIntegrationProvisioning_FullSync_FolderMoveWithMetadata_NestedSubtree(t *testing.T) {
@@ -384,8 +378,7 @@ func TestIntegrationProvisioning_FullSync_FolderMoveWithMetadata_NestedSubtree(t
 			"../testdata/text-options.json":  "root/child/dashboard.json",
 			"../testdata/timeline-demo.json": "root/child/grand/dashboard.json",
 		},
-		SkipSync:               true,
-		SkipResourceAssertions: true,
+		SkipSync: true,
 	})
 
 	helper.SyncAndWait(t, repo, nil)
@@ -434,8 +427,7 @@ func TestIntegrationProvisioning_FullSync_FolderMoveWithMetadata_MixedLegacy(t *
 			"../testdata/all-panels.json":   "metaA/dashboard.json",
 			"../testdata/text-options.json": "plainB/dashboard.json",
 		},
-		SkipSync:               true,
-		SkipResourceAssertions: true,
+		SkipSync: true,
 	})
 
 	helper.SyncAndWait(t, repo, nil)
@@ -477,8 +469,7 @@ func TestIntegrationProvisioning_FullSync_FolderMoveWithMetadata_MetaToPlainPare
 		Copies: map[string]string{
 			"../testdata/all-panels.json": "parent/child/dashboard.json",
 		},
-		SkipSync:               true,
-		SkipResourceAssertions: true,
+		SkipSync: true,
 	})
 
 	helper.SyncAndWait(t, repo, nil)
@@ -515,8 +506,7 @@ func TestIntegrationProvisioning_FullSync_FolderMoveWithMetadata_RootToNested(t 
 		Copies: map[string]string{
 			"../testdata/all-panels.json": "myfolder/dashboard.json",
 		},
-		SkipSync:               true,
-		SkipResourceAssertions: true,
+		SkipSync: true,
 	})
 
 	helper.SyncAndWait(t, repo, nil)
@@ -558,8 +548,7 @@ func TestIntegrationProvisioning_FullSync_FolderMoveWithMetadata_NestedToRoot(t 
 		Copies: map[string]string{
 			"../testdata/all-panels.json": "parent/child/dashboard.json",
 		},
-		SkipSync:               true,
-		SkipResourceAssertions: true,
+		SkipSync: true,
 	})
 
 	helper.SyncAndWait(t, repo, nil)
@@ -602,8 +591,7 @@ func TestIntegrationProvisioning_FullSync_FolderMovePreservesGeneration(t *testi
 			"../testdata/all-panels.json":   "myfolder/dashboard.json",
 			"../testdata/text-options.json": "plain/dashboard.json",
 		},
-		SkipSync:               true,
-		SkipResourceAssertions: true,
+		SkipSync: true,
 	})
 
 	helper.SyncAndWait(t, repo, nil)
@@ -690,8 +678,7 @@ func TestIntegrationProvisioning_FullSync_FolderMove_NestedToNested_PreservesGen
 		Copies: map[string]string{
 			"../testdata/all-panels.json": "parentA/myfolder/dashboard.json",
 		},
-		SkipSync:               true,
-		SkipResourceAssertions: true,
+		SkipSync: true,
 	})
 
 	helper.SyncAndWait(t, repo, nil)
@@ -749,8 +736,7 @@ func TestIntegrationProvisioning_FullSync_FolderMove_RootToNested_PreservesGener
 		Copies: map[string]string{
 			"../testdata/all-panels.json": "myfolder/dashboard.json",
 		},
-		SkipSync:               true,
-		SkipResourceAssertions: true,
+		SkipSync: true,
 	})
 
 	helper.SyncAndWait(t, repo, nil)
@@ -807,8 +793,7 @@ func TestIntegrationProvisioning_FullSync_FolderMove_NestedToRoot_PreservesGener
 		Copies: map[string]string{
 			"../testdata/all-panels.json": "parent/myfolder/dashboard.json",
 		},
-		SkipSync:               true,
-		SkipResourceAssertions: true,
+		SkipSync: true,
 	})
 
 	helper.SyncAndWait(t, repo, nil)
@@ -869,10 +854,9 @@ func TestIntegrationProvisioning_FullSync_FolderMoveUpdatesChildrenFolders(t *te
 	writeToProvisioningPath(t, helper, "target/.keep", []byte{})
 
 	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:                   repo,
-		SyncTarget:             "folder",
-		SkipSync:               true,
-		SkipResourceAssertions: true,
+		Name:       repo,
+		SyncTarget: "folder",
+		SkipSync:   true,
 	})
 
 	helper.SyncAndWait(t, repo, nil)
@@ -913,10 +897,9 @@ func TestIntegrationProvisioning_FullSync_FolderMoveWithUIDChange_NoGenerationPr
 	writeToProvisioningPath(t, helper, "myfolder/.keep", []byte{})
 
 	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:                   repo,
-		SyncTarget:             "folder",
-		SkipSync:               true,
-		SkipResourceAssertions: true,
+		Name:       repo,
+		SyncTarget: "folder",
+		SkipSync:   true,
 	})
 
 	helper.SyncAndWait(t, repo, nil)
@@ -956,8 +939,7 @@ func TestIntegrationProvisioning_FullSync_FolderMoveWithMetadata_DuplicateUID(t 
 			"../testdata/all-panels.json":   "folderA/dashboard.json",
 			"../testdata/text-options.json": "folderB/dashboard.json",
 		},
-		SkipSync:               true,
-		SkipResourceAssertions: true,
+		SkipSync: true,
 	})
 
 	helper.SyncAndWait(t, repo, nil)
@@ -1238,8 +1220,7 @@ func TestIntegrationProvisioning_FullSync_DashboardMoveInPlace(t *testing.T) {
 		Copies: map[string]string{
 			"../testdata/all-panels.json": "folderA/dashboard.json",
 		},
-		SkipSync:               true,
-		SkipResourceAssertions: true,
+		SkipSync: true,
 	})
 
 	helper.SyncAndWait(t, repo, nil)

--- a/pkg/tests/apis/provisioning/foldermetadata/full_sync_uid_too_long_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/full_sync_uid_too_long_test.go
@@ -40,10 +40,9 @@ func TestIntegrationProvisioning_FullSync_FolderUIDTooLong(t *testing.T) {
 	require.Equal(t, 41, len(tooLongUID), "test fixture must be exactly one over the 40-char limit")
 
 	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:                   repo,
-		SyncTarget:             "folder",
-		SkipSync:               true,
-		SkipResourceAssertions: true,
+		Name:       repo,
+		SyncTarget: "folder",
+		SkipSync:   true,
 	})
 
 	// Shallow folder with a valid UID — must be created normally to prove

--- a/pkg/tests/apis/provisioning/foldermetadata/github_urls_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/github_urls_test.go
@@ -42,6 +42,7 @@ func githubHealthCheckMockClient() *http.Client {
 // new branch creation and a later update to the same branch.
 func TestIntegrationGitHubFiles_DashboardBranchURLs(t *testing.T) {
 	helper := sharedGitHelper(t)
+
 	helper.GetEnv().GithubRepoFactory.Client = githubHealthCheckMockClient()
 
 	const repoName = "github-dashboard-urls"
@@ -82,6 +83,7 @@ func TestIntegrationGitHubFiles_DashboardBranchURLs(t *testing.T) {
 // which is the regression surface for folder rename/update operations.
 func TestIntegrationGitHubFiles_FolderMetadataBranchURLs(t *testing.T) {
 	helper := sharedGitHelper(t)
+
 	helper.GetEnv().GithubRepoFactory.Client = githubHealthCheckMockClient()
 
 	const repoName = "github-folder-urls"

--- a/pkg/tests/apis/provisioning/foldermetadata/github_urls_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/github_urls_test.go
@@ -1,7 +1,6 @@
 package foldermetadata
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -43,7 +42,6 @@ func githubHealthCheckMockClient() *http.Client {
 // new branch creation and a later update to the same branch.
 func TestIntegrationGitHubFiles_DashboardBranchURLs(t *testing.T) {
 	helper := sharedGitHelper(t)
-	ctx := context.Background()
 	helper.GetEnv().GithubRepoFactory.Client = githubHealthCheckMockClient()
 
 	const repoName = "github-dashboard-urls"
@@ -61,7 +59,7 @@ func TestIntegrationGitHubFiles_DashboardBranchURLs(t *testing.T) {
 		Param("message", "Create dashboard on branch").
 		Body(common.DashboardJSON("github-url-dash", "GitHub URL Dashboard", 1)).
 		SetHeader("Content-Type", "application/json").
-		Do(ctx)
+		Do(t.Context())
 	require.NoError(t, result.Error(), "should create dashboard on branch")
 	assertGitHubFileURLs(t, decodeResourceWrapperResult(t, result), remote.URL, branch, dashboardPath)
 
@@ -74,7 +72,7 @@ func TestIntegrationGitHubFiles_DashboardBranchURLs(t *testing.T) {
 		Param("message", "Update dashboard on branch").
 		Body(common.DashboardJSON("github-url-dash", "GitHub URL Dashboard Updated", 2)).
 		SetHeader("Content-Type", "application/json").
-		Do(ctx)
+		Do(t.Context())
 	require.NoError(t, result.Error(), "should update dashboard on existing branch")
 	assertGitHubFileURLs(t, decodeResourceWrapperResult(t, result), remote.URL, branch, dashboardPath)
 }
@@ -84,7 +82,6 @@ func TestIntegrationGitHubFiles_DashboardBranchURLs(t *testing.T) {
 // which is the regression surface for folder rename/update operations.
 func TestIntegrationGitHubFiles_FolderMetadataBranchURLs(t *testing.T) {
 	helper := sharedGitHelper(t)
-	ctx := context.Background()
 	helper.GetEnv().GithubRepoFactory.Client = githubHealthCheckMockClient()
 
 	const repoName = "github-folder-urls"
@@ -95,7 +92,7 @@ func TestIntegrationGitHubFiles_FolderMetadataBranchURLs(t *testing.T) {
 	_ = resp.Body.Close()
 	require.Equal(t, http.StatusOK, resp.StatusCode, "creating folder on default branch should succeed: %s", string(body))
 
-	uid := readFolderFieldOnRef(t, helper, ctx, repoName, "team-a/_folder.json", "", "metadata", "name")
+	uid := readFolderFieldOnRef(t, helper, repoName, "team-a/_folder.json", "", "metadata", "name")
 	require.NotEmpty(t, uid, "setup: folder should have a UID")
 
 	const branch = "feature-folder-urls"

--- a/pkg/tests/apis/provisioning/foldermetadata/incremental/incremental_folder_metadata_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/incremental/incremental_folder_metadata_test.go
@@ -1,7 +1,6 @@
 package incremental
 
 import (
-	"context"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -120,7 +119,6 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitle(t *testing.
 
 	t.Run("folder uses spec.title from _folder.json", func(t *testing.T) {
 		helper := sharedGitHelper(t)
-		ctx := context.Background()
 
 		const repoName = "incr-meta-title"
 
@@ -144,12 +142,11 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitle(t *testing.
 		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 
 		// Verify the Grafana folder was created with the metadata title, not the directory name.
-		common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "My Team Display Name")
+		common.RequireRepoFolderTitle(t, helper.Folders, repoName, "My Team Display Name")
 	})
 
 	t.Run("folder falls back to directory name when spec.title is empty", func(t *testing.T) {
 		helper := sharedGitHelper(t)
-		ctx := context.Background()
 
 		const repoName = "incr-meta-title-empty"
 
@@ -171,12 +168,11 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitle(t *testing.
 		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 
 		// Should use directory name "reports" as the title.
-		common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "reports")
+		common.RequireRepoFolderTitle(t, helper.Folders, repoName, "reports")
 	})
 
 	t.Run("folder uses directory name when no _folder.json exists", func(t *testing.T) {
 		helper := sharedGitHelper(t)
-		ctx := context.Background()
 
 		const repoName = "incr-meta-title-absent"
 
@@ -197,12 +193,11 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitle(t *testing.
 		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Warning())
 
 		// Should use directory name "analytics" as the title.
-		common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "analytics")
+		common.RequireRepoFolderTitle(t, helper.Folders, repoName, "analytics")
 	})
 
 	t.Run("nested folders use respective spec.title from _folder.json", func(t *testing.T) {
 		helper := sharedGitHelper(t)
-		ctx := context.Background()
 
 		const repoName = "incr-meta-title-nested"
 
@@ -225,8 +220,8 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitle(t *testing.
 		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 
 		// Both folders should use their metadata titles.
-		common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "Parent Display")
-		common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "Child Display")
+		common.RequireRepoFolderTitle(t, helper.Folders, repoName, "Parent Display")
+		common.RequireRepoFolderTitle(t, helper.Folders, repoName, "Child Display")
 	})
 }
 
@@ -235,7 +230,6 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataCreation(t *testi
 
 	t.Run("adding _folder.json clears prior missing metadata warnings", func(t *testing.T) {
 		helper := sharedGitHelper(t)
-		ctx := context.Background()
 
 		const repoName = "incr-meta-create-clears-warning"
 
@@ -245,9 +239,9 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataCreation(t *testi
 
 		helper.SyncAndWait(t, repoName)
 
-		hashUID := common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "myfolder")
+		hashUID := common.RequireRepoFolderTitle(t, helper.Folders, repoName, "myfolder")
 		require.NotEqual(t, "stable-uid", hashUID, "folder should start with a hash-based UID")
-		common.RequireRepoDashboardParent(t, helper.DashboardsV1, ctx, repoName, "myfolder/dash.json", hashUID)
+		common.RequireRepoDashboardParent(t, helper.DashboardsV1, repoName, "myfolder/dash.json", hashUID)
 
 		require.NoError(t, local.CreateFile("myfolder/_folder.json", string(folderMetadataJSON("stable-uid", "My Folder"))))
 		_, err := local.Git("add", ".")
@@ -271,15 +265,14 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataCreation(t *testi
 				"expected missing-metadata warning to be cleared, got: %v", jobObj.Status.Warnings)
 		}
 
-		common.RequireRepoFolderUID(t, helper.Folders, ctx, repoName, "stable-uid")
-		common.RequireRepoFolderCount(t, helper, ctx, repoName, 1)
-		common.RequireRepoDashboardCount(t, helper, ctx, repoName, 1)
-		common.RequireRepoDashboardParent(t, helper.DashboardsV1, ctx, repoName, "myfolder/dash.json", "stable-uid")
+		common.RequireRepoFolderUID(t, helper.Folders, repoName, "stable-uid")
+		common.RequireRepoFolderCount(t, helper, repoName, 1)
+		common.RequireRepoDashboardCount(t, helper, repoName, 1)
+		common.RequireRepoDashboardParent(t, helper.DashboardsV1, repoName, "myfolder/dash.json", "stable-uid")
 	})
 
 	t.Run("new _folder.json creates a brand-new empty folder", func(t *testing.T) {
 		helper := sharedGitHelper(t)
-		ctx := context.Background()
 
 		const repoName = "incr-meta-create-empty-folder"
 
@@ -300,13 +293,12 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataCreation(t *testi
 		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 
 		common.RequireFolderState(t, helper.Folders, "empty-team-uid", "Empty Team", "empty-team", "")
-		common.RequireRepoFolderCount(t, helper, ctx, repoName, 1)
-		common.RequireRepoDashboardCount(t, helper, ctx, repoName, 1)
+		common.RequireRepoFolderCount(t, helper, repoName, 1)
+		common.RequireRepoDashboardCount(t, helper, repoName, 1)
 	})
 
 	t.Run("new _folder.json transitions existing folder to stable uid", func(t *testing.T) {
 		helper := sharedGitHelper(t)
-		ctx := context.Background()
 
 		const repoName = "incr-meta-create-existing"
 
@@ -316,9 +308,9 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataCreation(t *testi
 
 		helper.SyncAndWait(t, repoName)
 
-		oldUID := common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "myfolder")
+		oldUID := common.RequireRepoFolderTitle(t, helper.Folders, repoName, "myfolder")
 		require.NotEqual(t, "stable-uid", oldUID, "folder should start with a hash-based UID")
-		common.RequireRepoDashboardParent(t, helper.DashboardsV1, ctx, repoName, "myfolder/dash.json", oldUID)
+		common.RequireRepoDashboardParent(t, helper.DashboardsV1, repoName, "myfolder/dash.json", oldUID)
 
 		require.NoError(t, local.CreateFile("myfolder/_folder.json", string(folderMetadataJSON("stable-uid", "My Folder"))))
 		_, err := local.Git("add", ".")
@@ -330,15 +322,14 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataCreation(t *testi
 
 		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 
-		common.RequireRepoFolderUID(t, helper.Folders, ctx, repoName, "stable-uid")
-		common.RequireRepoFolderCount(t, helper, ctx, repoName, 1)
-		common.RequireRepoDashboardCount(t, helper, ctx, repoName, 1)
-		common.RequireRepoDashboardParent(t, helper.DashboardsV1, ctx, repoName, "myfolder/dash.json", "stable-uid")
+		common.RequireRepoFolderUID(t, helper.Folders, repoName, "stable-uid")
+		common.RequireRepoFolderCount(t, helper, repoName, 1)
+		common.RequireRepoDashboardCount(t, helper, repoName, 1)
+		common.RequireRepoDashboardParent(t, helper.DashboardsV1, repoName, "myfolder/dash.json", "stable-uid")
 	})
 
 	t.Run("new _folder.json transitions existing folder to stable uid and re-parents children", func(t *testing.T) {
 		helper := sharedGitHelper(t)
-		ctx := context.Background()
 
 		const repoName = "incr-meta-create-existing"
 
@@ -349,12 +340,12 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataCreation(t *testi
 
 		helper.SyncAndWait(t, repoName)
 
-		oldUID := common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "myfolder")
+		oldUID := common.RequireRepoFolderTitle(t, helper.Folders, repoName, "myfolder")
 		require.NotEqual(t, "stable-uid", oldUID, "folder should start with a hash-based UID")
-		common.RequireRepoDashboardParent(t, helper.DashboardsV1, ctx, repoName, "myfolder/dash.json", oldUID)
+		common.RequireRepoDashboardParent(t, helper.DashboardsV1, repoName, "myfolder/dash.json", oldUID)
 
-		childUID := common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "child")
-		common.RequireRepoDashboardParent(t, helper.DashboardsV1, ctx, repoName, "myfolder/child/dash.json", childUID)
+		childUID := common.RequireRepoFolderTitle(t, helper.Folders, repoName, "child")
+		common.RequireRepoDashboardParent(t, helper.DashboardsV1, repoName, "myfolder/child/dash.json", childUID)
 
 		require.NoError(t, local.CreateFile("myfolder/_folder.json", string(folderMetadataJSON("stable-uid", "My Folder"))))
 		_, err := local.Git("add", ".")
@@ -366,18 +357,17 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataCreation(t *testi
 
 		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Warning())
 
-		common.RequireRepoFolderUID(t, helper.Folders, ctx, repoName, "stable-uid")
-		childUID = common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "child")
+		common.RequireRepoFolderUID(t, helper.Folders, repoName, "stable-uid")
+		childUID = common.RequireRepoFolderTitle(t, helper.Folders, repoName, "child")
 		common.RequireFolderState(t, helper.Folders, childUID, "child", "myfolder/child", "stable-uid")
 
-		common.RequireRepoFolderCount(t, helper, ctx, repoName, 2)
-		common.RequireRepoDashboardCount(t, helper, ctx, repoName, 2)
-		common.RequireRepoDashboardParent(t, helper.DashboardsV1, ctx, repoName, "myfolder/dash.json", "stable-uid")
+		common.RequireRepoFolderCount(t, helper, repoName, 2)
+		common.RequireRepoDashboardCount(t, helper, repoName, 2)
+		common.RequireRepoDashboardParent(t, helper.DashboardsV1, repoName, "myfolder/dash.json", "stable-uid")
 	})
 
 	t.Run("new _folder.json with direct child rename does not replay the old child path", func(t *testing.T) {
 		helper := sharedGitHelper(t)
-		ctx := context.Background()
 
 		const repoName = "incr-meta-create-child-rename"
 
@@ -387,9 +377,9 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataCreation(t *testi
 
 		helper.SyncAndWait(t, repoName)
 
-		oldUID := common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "myfolder")
+		oldUID := common.RequireRepoFolderTitle(t, helper.Folders, repoName, "myfolder")
 		require.NotEqual(t, "stable-uid", oldUID, "folder should start with a hash-based UID")
-		common.RequireRepoDashboardParent(t, helper.DashboardsV1, ctx, repoName, "myfolder/dash.json", oldUID)
+		common.RequireRepoDashboardParent(t, helper.DashboardsV1, repoName, "myfolder/dash.json", oldUID)
 
 		require.NoError(t, local.CreateFile("myfolder/_folder.json", string(folderMetadataJSON("stable-uid", "My Folder"))))
 		_, err := local.Git("mv", "myfolder/dash.json", "myfolder/dash-renamed.json")
@@ -403,15 +393,14 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataCreation(t *testi
 
 		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 
-		common.RequireRepoFolderUID(t, helper.Folders, ctx, repoName, "stable-uid")
-		common.RequireRepoFolderCount(t, helper, ctx, repoName, 1)
-		common.RequireRepoDashboardCount(t, helper, ctx, repoName, 1)
-		common.RequireRepoDashboardParent(t, helper.DashboardsV1, ctx, repoName, "myfolder/dash-renamed.json", "stable-uid")
+		common.RequireRepoFolderUID(t, helper.Folders, repoName, "stable-uid")
+		common.RequireRepoFolderCount(t, helper, repoName, 1)
+		common.RequireRepoDashboardCount(t, helper, repoName, 1)
+		common.RequireRepoDashboardParent(t, helper.DashboardsV1, repoName, "myfolder/dash-renamed.json", "stable-uid")
 	})
 
 	t.Run("new nested _folder.json files transition both parent and child to stable uids", func(t *testing.T) {
 		helper := sharedGitHelper(t)
-		ctx := context.Background()
 
 		const repoName = "incr-meta-create-nested"
 
@@ -421,13 +410,13 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataCreation(t *testi
 
 		helper.SyncAndWait(t, repoName)
 
-		oldParentUID := common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "parent")
-		oldChildUID := common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "child")
+		oldParentUID := common.RequireRepoFolderTitle(t, helper.Folders, repoName, "parent")
+		oldChildUID := common.RequireRepoFolderTitle(t, helper.Folders, repoName, "child")
 		require.NotEqual(t, "p-new", oldParentUID, "parent should start with a hash-based UID")
 		require.NotEqual(t, "c-new", oldChildUID, "child should start with a hash-based UID")
 		common.RequireFolderState(t, helper.Folders, oldParentUID, "parent", "parent", "")
 		common.RequireFolderState(t, helper.Folders, oldChildUID, "child", "parent/child", oldParentUID)
-		common.RequireRepoDashboardParent(t, helper.DashboardsV1, ctx, repoName, "parent/child/dash.json", oldChildUID)
+		common.RequireRepoDashboardParent(t, helper.DashboardsV1, repoName, "parent/child/dash.json", oldChildUID)
 
 		require.NoError(t, local.CreateFile("parent/_folder.json", string(folderMetadataJSON("p-new", "Parent"))))
 		require.NoError(t, local.CreateFile("parent/child/_folder.json", string(folderMetadataJSON("c-new", "Child"))))
@@ -440,18 +429,18 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataCreation(t *testi
 
 		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 
-		_, err = helper.Folders.Resource.Get(ctx, oldParentUID, metav1.GetOptions{})
+		_, err = helper.Folders.Resource.Get(t.Context(), oldParentUID, metav1.GetOptions{})
 		require.True(t, apierrors.IsNotFound(err), "old parent folder should be deleted")
 
-		_, err = helper.Folders.Resource.Get(ctx, oldChildUID, metav1.GetOptions{})
+		_, err = helper.Folders.Resource.Get(t.Context(), oldChildUID, metav1.GetOptions{})
 		require.True(t, apierrors.IsNotFound(err), "old child folder should be deleted")
 
 		common.RequireFolderState(t, helper.Folders, "p-new", "Parent", "parent", "")
 		common.RequireFolderState(t, helper.Folders, "c-new", "Child", "parent/child", "p-new")
-		common.RequireRepoFolders(t, helper.Folders, ctx, repoName, []string{"parent", "parent/child"})
-		common.RequireRepoFolderCount(t, helper, ctx, repoName, 2)
-		common.RequireRepoDashboardCount(t, helper, ctx, repoName, 1)
-		common.RequireRepoDashboardParent(t, helper.DashboardsV1, ctx, repoName, "parent/child/dash.json", "c-new")
+		common.RequireRepoFolders(t, helper.Folders, repoName, []string{"parent", "parent/child"})
+		common.RequireRepoFolderCount(t, helper, repoName, 2)
+		common.RequireRepoDashboardCount(t, helper, repoName, 1)
+		common.RequireRepoDashboardParent(t, helper.DashboardsV1, repoName, "parent/child/dash.json", "c-new")
 	})
 }
 
@@ -462,7 +451,6 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitleUpdate(t *te
 
 	t.Run("updates folder title when _folder.json spec.title changes", func(t *testing.T) {
 		helper := sharedGitHelper(t)
-		ctx := context.Background()
 
 		const repoName = "incr-meta-title-update"
 
@@ -472,7 +460,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitleUpdate(t *te
 		})
 
 		common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
-		common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "Alpha")
+		common.RequireRepoFolderTitle(t, helper.Folders, repoName, "Alpha")
 
 		require.NoError(t, local.UpdateFile("alpha/_folder.json", string(folderMetadataJSON("alpha-uid", "Alpha Renamed"))))
 		_, err := local.Git("add", ".")
@@ -484,12 +472,11 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitleUpdate(t *te
 
 		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 
-		common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "Alpha Renamed")
+		common.RequireRepoFolderTitle(t, helper.Folders, repoName, "Alpha Renamed")
 	})
 
 	t.Run("updates nested folder title", func(t *testing.T) {
 		helper := sharedGitHelper(t)
-		ctx := context.Background()
 
 		const repoName = "incr-meta-title-nested-upd"
 
@@ -500,8 +487,8 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitleUpdate(t *te
 		})
 
 		common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
-		common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "Parent Title")
-		common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "Child Title")
+		common.RequireRepoFolderTitle(t, helper.Folders, repoName, "Parent Title")
+		common.RequireRepoFolderTitle(t, helper.Folders, repoName, "Child Title")
 
 		require.NoError(t, local.UpdateFile("parent/child/_folder.json", string(folderMetadataJSON("child-uid-upd", "Child Title Updated"))))
 		_, err := local.Git("add", ".")
@@ -513,13 +500,12 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitleUpdate(t *te
 
 		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 
-		common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "Parent Title")
-		common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "Child Title Updated")
+		common.RequireRepoFolderTitle(t, helper.Folders, repoName, "Parent Title")
+		common.RequireRepoFolderTitle(t, helper.Folders, repoName, "Child Title Updated")
 	})
 
 	t.Run("updates title alongside dashboard changes", func(t *testing.T) {
 		helper := sharedGitHelper(t)
-		ctx := context.Background()
 
 		const repoName = "incr-meta-title-with-dash"
 
@@ -529,8 +515,8 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitleUpdate(t *te
 		})
 
 		common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
-		common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "Original Team")
-		common.RequireDashboardTitle(t, helper.DashboardsV1, ctx, "combo-dash", "Original Dashboard")
+		common.RequireRepoFolderTitle(t, helper.Folders, repoName, "Original Team")
+		common.RequireDashboardTitle(t, helper.DashboardsV1, "combo-dash", "Original Dashboard")
 
 		require.NoError(t, local.UpdateFile("team/_folder.json", string(folderMetadataJSON("team-uid-combo", "Updated Team"))))
 		require.NoError(t, local.UpdateFile("team/dash.json", string(common.DashboardJSON("combo-dash", "Updated Dashboard", 2))))
@@ -543,8 +529,8 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataTitleUpdate(t *te
 
 		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 
-		common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "Updated Team")
-		common.RequireDashboardTitle(t, helper.DashboardsV1, ctx, "combo-dash", "Updated Dashboard")
+		common.RequireRepoFolderTitle(t, helper.Folders, repoName, "Updated Team")
+		common.RequireDashboardTitle(t, helper.DashboardsV1, "combo-dash", "Updated Dashboard")
 	})
 }
 
@@ -558,7 +544,6 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 
 	t.Run("root to root rename", func(t *testing.T) {
 		helper := sharedGitHelper(t)
-		ctx := context.Background()
 
 		const repoName = "incr-rename-root-root"
 		const folderUID = "rr-folder-uid"
@@ -569,13 +554,13 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 		})
 
 		common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
-		common.RequireRepoFolders(t, helper.Folders, ctx, repoName, []string{"old-team"})
+		common.RequireRepoFolders(t, helper.Folders, repoName, []string{"old-team"})
 
-		folderBefore, err := helper.Folders.Resource.Get(ctx, folderUID, metav1.GetOptions{})
+		folderBefore, err := helper.Folders.Resource.Get(t.Context(), folderUID, metav1.GetOptions{})
 		require.NoError(t, err)
 		folderSnap := common.SnapshotObject(t, folderBefore)
 
-		dashBefore, err := helper.DashboardsV1.Resource.Get(ctx, "rr-dash-001", metav1.GetOptions{})
+		dashBefore, err := helper.DashboardsV1.Resource.Get(t.Context(), "rr-dash-001", metav1.GetOptions{})
 		require.NoError(t, err)
 		dashSnap := common.SnapshotObject(t, dashBefore)
 
@@ -588,7 +573,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 
 		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 
-		folderAfter, err := helper.Folders.Resource.Get(ctx, folderUID, metav1.GetOptions{})
+		folderAfter, err := helper.Folders.Resource.Get(t.Context(), folderUID, metav1.GetOptions{})
 		require.NoError(t, err, "folder should still exist with same UID")
 		common.RequireUpdatedInPlace(t, "folder", folderSnap, common.SnapshotObject(t, folderAfter))
 
@@ -597,20 +582,19 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 		folderParent, _, _ := unstructured.NestedString(folderAfter.Object, "metadata", "annotations", "grafana.app/folder")
 		require.Empty(t, folderParent, "root-level folder should have no parent")
 
-		common.RequireRepoFolders(t, helper.Folders, ctx, repoName, []string{"new-team"})
+		common.RequireRepoFolders(t, helper.Folders, repoName, []string{"new-team"})
 
-		dashAfter, err := helper.DashboardsV1.Resource.Get(ctx, "rr-dash-001", metav1.GetOptions{})
+		dashAfter, err := helper.DashboardsV1.Resource.Get(t.Context(), "rr-dash-001", metav1.GetOptions{})
 		require.NoError(t, err)
 		common.RequireUpdatedInPlace(t, "dashboard", dashSnap, common.SnapshotObject(t, dashAfter))
 
-		common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+		common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 			"rr-dash-001": {Title: "Team Dashboard", SourcePath: "new-team/dashboard1.json", Folder: folderUID},
 		})
 	})
 
 	t.Run("nested to nested rename within same parent", func(t *testing.T) {
 		helper := sharedGitHelper(t)
-		ctx := context.Background()
 
 		const repoName = "incr-rename-nested-nested"
 		const parentUID = "nn-parent-uid"
@@ -623,13 +607,13 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 		})
 
 		common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
-		common.RequireRepoFolders(t, helper.Folders, ctx, repoName, []string{"parent", "parent/old-child"})
+		common.RequireRepoFolders(t, helper.Folders, repoName, []string{"parent", "parent/old-child"})
 
-		childBefore, err := helper.Folders.Resource.Get(ctx, childUID, metav1.GetOptions{})
+		childBefore, err := helper.Folders.Resource.Get(t.Context(), childUID, metav1.GetOptions{})
 		require.NoError(t, err)
 		childSnap := common.SnapshotObject(t, childBefore)
 
-		dashBefore, err := helper.DashboardsV1.Resource.Get(ctx, "nn-dash-001", metav1.GetOptions{})
+		dashBefore, err := helper.DashboardsV1.Resource.Get(t.Context(), "nn-dash-001", metav1.GetOptions{})
 		require.NoError(t, err)
 		dashSnap := common.SnapshotObject(t, dashBefore)
 
@@ -642,7 +626,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 
 		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 
-		childAfter, err := helper.Folders.Resource.Get(ctx, childUID, metav1.GetOptions{})
+		childAfter, err := helper.Folders.Resource.Get(t.Context(), childUID, metav1.GetOptions{})
 		require.NoError(t, err, "child folder should still exist with same UID")
 		common.RequireUpdatedInPlace(t, "child folder", childSnap, common.SnapshotObject(t, childAfter))
 
@@ -651,20 +635,19 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 		childParent, _, _ := unstructured.NestedString(childAfter.Object, "metadata", "annotations", "grafana.app/folder")
 		require.Equal(t, parentUID, childParent, "child folder should still be parented under parent")
 
-		common.RequireRepoFolders(t, helper.Folders, ctx, repoName, []string{"parent", "parent/new-child"})
+		common.RequireRepoFolders(t, helper.Folders, repoName, []string{"parent", "parent/new-child"})
 
-		dashAfter, err := helper.DashboardsV1.Resource.Get(ctx, "nn-dash-001", metav1.GetOptions{})
+		dashAfter, err := helper.DashboardsV1.Resource.Get(t.Context(), "nn-dash-001", metav1.GetOptions{})
 		require.NoError(t, err)
 		common.RequireUpdatedInPlace(t, "dashboard", dashSnap, common.SnapshotObject(t, dashAfter))
 
-		common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+		common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 			"nn-dash-001": {Title: "Child Dashboard", SourcePath: "parent/new-child/dashboard1.json", Folder: childUID},
 		})
 	})
 
 	t.Run("root to nested rename", func(t *testing.T) {
 		helper := sharedGitHelper(t)
-		ctx := context.Background()
 
 		const repoName = "incr-rename-root-nested"
 		const parentUID = "rn-parent-uid"
@@ -677,13 +660,13 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 		})
 
 		common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
-		common.RequireRepoFolders(t, helper.Folders, ctx, repoName, []string{"parent", "my-folder"})
+		common.RequireRepoFolders(t, helper.Folders, repoName, []string{"parent", "my-folder"})
 
-		folderBefore, err := helper.Folders.Resource.Get(ctx, movedUID, metav1.GetOptions{})
+		folderBefore, err := helper.Folders.Resource.Get(t.Context(), movedUID, metav1.GetOptions{})
 		require.NoError(t, err)
 		folderSnap := common.SnapshotObject(t, folderBefore)
 
-		dashBefore, err := helper.DashboardsV1.Resource.Get(ctx, "rn-dash-001", metav1.GetOptions{})
+		dashBefore, err := helper.DashboardsV1.Resource.Get(t.Context(), "rn-dash-001", metav1.GetOptions{})
 		require.NoError(t, err)
 		dashSnap := common.SnapshotObject(t, dashBefore)
 
@@ -696,7 +679,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 
 		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 
-		folderAfter, err := helper.Folders.Resource.Get(ctx, movedUID, metav1.GetOptions{})
+		folderAfter, err := helper.Folders.Resource.Get(t.Context(), movedUID, metav1.GetOptions{})
 		require.NoError(t, err, "moved folder should still exist with same UID")
 		common.RequireUpdatedInPlace(t, "folder", folderSnap, common.SnapshotObject(t, folderAfter))
 
@@ -706,20 +689,19 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 		parentAnnotation, _, _ := unstructured.NestedString(folderAfter.Object, "metadata", "annotations", "grafana.app/folder")
 		require.Equal(t, parentUID, parentAnnotation, "moved folder should now be parented under parent")
 
-		common.RequireRepoFolders(t, helper.Folders, ctx, repoName, []string{"parent", "parent/my-folder"})
+		common.RequireRepoFolders(t, helper.Folders, repoName, []string{"parent", "parent/my-folder"})
 
-		dashAfter, err := helper.DashboardsV1.Resource.Get(ctx, "rn-dash-001", metav1.GetOptions{})
+		dashAfter, err := helper.DashboardsV1.Resource.Get(t.Context(), "rn-dash-001", metav1.GetOptions{})
 		require.NoError(t, err)
 		common.RequireUpdatedInPlace(t, "dashboard", dashSnap, common.SnapshotObject(t, dashAfter))
 
-		common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+		common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 			"rn-dash-001": {Title: "Moved Dashboard", SourcePath: "parent/my-folder/dashboard1.json", Folder: movedUID},
 		})
 	})
 
 	t.Run("nested to root rename", func(t *testing.T) {
 		helper := sharedGitHelper(t)
-		ctx := context.Background()
 
 		const repoName = "incr-rename-nested-root"
 		const parentUID = "nr-parent-uid"
@@ -732,13 +714,13 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 		})
 
 		common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
-		common.RequireRepoFolders(t, helper.Folders, ctx, repoName, []string{"parent", "parent/my-folder"})
+		common.RequireRepoFolders(t, helper.Folders, repoName, []string{"parent", "parent/my-folder"})
 
-		folderBefore, err := helper.Folders.Resource.Get(ctx, movedUID, metav1.GetOptions{})
+		folderBefore, err := helper.Folders.Resource.Get(t.Context(), movedUID, metav1.GetOptions{})
 		require.NoError(t, err)
 		folderSnap := common.SnapshotObject(t, folderBefore)
 
-		dashBefore, err := helper.DashboardsV1.Resource.Get(ctx, "nr-dash-001", metav1.GetOptions{})
+		dashBefore, err := helper.DashboardsV1.Resource.Get(t.Context(), "nr-dash-001", metav1.GetOptions{})
 		require.NoError(t, err)
 		dashSnap := common.SnapshotObject(t, dashBefore)
 
@@ -751,7 +733,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 
 		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 
-		folderAfter, err := helper.Folders.Resource.Get(ctx, movedUID, metav1.GetOptions{})
+		folderAfter, err := helper.Folders.Resource.Get(t.Context(), movedUID, metav1.GetOptions{})
 		require.NoError(t, err, "moved folder should still exist with same UID")
 		common.RequireUpdatedInPlace(t, "folder", folderSnap, common.SnapshotObject(t, folderAfter))
 
@@ -760,20 +742,19 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 		folderParent, _, _ := unstructured.NestedString(folderAfter.Object, "metadata", "annotations", "grafana.app/folder")
 		require.Empty(t, folderParent, "folder moved to root should have no parent")
 
-		common.RequireRepoFolders(t, helper.Folders, ctx, repoName, []string{"parent", "my-folder"})
+		common.RequireRepoFolders(t, helper.Folders, repoName, []string{"parent", "my-folder"})
 
-		dashAfter, err := helper.DashboardsV1.Resource.Get(ctx, "nr-dash-001", metav1.GetOptions{})
+		dashAfter, err := helper.DashboardsV1.Resource.Get(t.Context(), "nr-dash-001", metav1.GetOptions{})
 		require.NoError(t, err)
 		common.RequireUpdatedInPlace(t, "dashboard", dashSnap, common.SnapshotObject(t, dashAfter))
 
-		common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+		common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 			"nr-dash-001": {Title: "Moved Dashboard", SourcePath: "my-folder/dashboard1.json", Folder: movedUID},
 		})
 	})
 
 	t.Run("rename folder with both resources and folder children", func(t *testing.T) {
 		helper := sharedGitHelper(t)
-		ctx := context.Background()
 
 		const repoName = "incr-rename-mixed"
 		const parentUID = "mx-parent-uid"
@@ -788,21 +769,21 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 		})
 
 		common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
-		common.RequireRepoFolders(t, helper.Folders, ctx, repoName, []string{"old-parent", "old-parent/child"})
+		common.RequireRepoFolders(t, helper.Folders, repoName, []string{"old-parent", "old-parent/child"})
 
-		parentBefore, err := helper.Folders.Resource.Get(ctx, parentUID, metav1.GetOptions{})
+		parentBefore, err := helper.Folders.Resource.Get(t.Context(), parentUID, metav1.GetOptions{})
 		require.NoError(t, err)
 		parentSnap := common.SnapshotObject(t, parentBefore)
 
-		childBefore, err := helper.Folders.Resource.Get(ctx, childUID, metav1.GetOptions{})
+		childBefore, err := helper.Folders.Resource.Get(t.Context(), childUID, metav1.GetOptions{})
 		require.NoError(t, err)
 		childSnap := common.SnapshotObject(t, childBefore)
 
-		parentDashBefore, err := helper.DashboardsV1.Resource.Get(ctx, "mx-parent-dash", metav1.GetOptions{})
+		parentDashBefore, err := helper.DashboardsV1.Resource.Get(t.Context(), "mx-parent-dash", metav1.GetOptions{})
 		require.NoError(t, err)
 		parentDashSnap := common.SnapshotObject(t, parentDashBefore)
 
-		childDashBefore, err := helper.DashboardsV1.Resource.Get(ctx, "mx-child-dash", metav1.GetOptions{})
+		childDashBefore, err := helper.DashboardsV1.Resource.Get(t.Context(), "mx-child-dash", metav1.GetOptions{})
 		require.NoError(t, err)
 		childDashSnap := common.SnapshotObject(t, childDashBefore)
 
@@ -817,7 +798,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 
 		// Verify parent folder updated in place.
-		parentAfter, err := helper.Folders.Resource.Get(ctx, parentUID, metav1.GetOptions{})
+		parentAfter, err := helper.Folders.Resource.Get(t.Context(), parentUID, metav1.GetOptions{})
 		require.NoError(t, err, "parent folder should still exist with same UID")
 		common.RequireUpdatedInPlace(t, "parent folder", parentSnap, common.SnapshotObject(t, parentAfter))
 
@@ -827,7 +808,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 		require.Empty(t, parentAnnotation, "root-level parent should have no parent annotation")
 
 		// Verify child folder updated in place and still parented under the renamed parent.
-		childAfter, err := helper.Folders.Resource.Get(ctx, childUID, metav1.GetOptions{})
+		childAfter, err := helper.Folders.Resource.Get(t.Context(), childUID, metav1.GetOptions{})
 		require.NoError(t, err, "child folder should still exist with same UID")
 		common.RequireUpdatedInPlace(t, "child folder", childSnap, common.SnapshotObject(t, childAfter))
 
@@ -836,17 +817,17 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 		childParent, _, _ := unstructured.NestedString(childAfter.Object, "metadata", "annotations", "grafana.app/folder")
 		require.Equal(t, parentUID, childParent, "child should still be parented under renamed parent")
 
-		common.RequireRepoFolders(t, helper.Folders, ctx, repoName, []string{"new-parent", "new-parent/child"})
+		common.RequireRepoFolders(t, helper.Folders, repoName, []string{"new-parent", "new-parent/child"})
 
-		parentDashAfter, err := helper.DashboardsV1.Resource.Get(ctx, "mx-parent-dash", metav1.GetOptions{})
+		parentDashAfter, err := helper.DashboardsV1.Resource.Get(t.Context(), "mx-parent-dash", metav1.GetOptions{})
 		require.NoError(t, err)
 		common.RequireUpdatedInPlace(t, "parent dashboard", parentDashSnap, common.SnapshotObject(t, parentDashAfter))
 
-		childDashAfter, err := helper.DashboardsV1.Resource.Get(ctx, "mx-child-dash", metav1.GetOptions{})
+		childDashAfter, err := helper.DashboardsV1.Resource.Get(t.Context(), "mx-child-dash", metav1.GetOptions{})
 		require.NoError(t, err)
 		common.RequireUpdatedInPlace(t, "child dashboard", childDashSnap, common.SnapshotObject(t, childDashAfter))
 
-		common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+		common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 			"mx-parent-dash": {Title: "Parent Dashboard", SourcePath: "new-parent/parent-dash.json", Folder: parentUID},
 			"mx-child-dash":  {Title: "Child Dashboard", SourcePath: "new-parent/child/child-dash.json", Folder: childUID},
 		})
@@ -854,7 +835,6 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 
 	t.Run("non-metadata folder rename still works via delete and create", func(t *testing.T) {
 		helper := sharedGitHelper(t)
-		ctx := context.Background()
 
 		const repoName = "incr-graceful-rename-nometa"
 
@@ -863,7 +843,7 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 		})
 
 		common.SyncAndWait(t, helper, common.Repo(repoName), common.Warning())
-		common.RequireRepoFolders(t, helper.Folders, ctx, repoName, []string{"old-team"})
+		common.RequireRepoFolders(t, helper.Folders, repoName, []string{"old-team"})
 
 		_, err := local.Git("mv", "old-team", "new-team")
 		require.NoError(t, err)
@@ -874,9 +854,9 @@ func TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename(t *testing
 
 		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Warning())
 
-		common.RequireRepoFolders(t, helper.Folders, ctx, repoName, []string{"new-team"})
+		common.RequireRepoFolders(t, helper.Folders, repoName, []string{"new-team"})
 
-		common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+		common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 			"gr-nometa-001": {Title: "No Meta Dashboard", SourcePath: "new-team/dashboard1.json"},
 		})
 	})
@@ -891,7 +871,6 @@ func TestIntegrationProvisioning_IncrementalSync_FolderUIDChange(t *testing.T) {
 
 	t.Run("simple UID change re-parents dashboard", func(t *testing.T) {
 		helper := sharedGitHelper(t)
-		ctx := context.Background()
 
 		const repoName = "incr-uid-change-simple"
 		const oldUID = "old-folder-uid"
@@ -903,9 +882,9 @@ func TestIntegrationProvisioning_IncrementalSync_FolderUIDChange(t *testing.T) {
 		})
 
 		helper.SyncAndWait(t, repoName)
-		common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "Alpha")
+		common.RequireRepoFolderTitle(t, helper.Folders, repoName, "Alpha")
 
-		common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+		common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 			"uid-dash-001": {Title: "Alpha Dashboard", SourcePath: "alpha/dash.json", Folder: oldUID},
 		})
 
@@ -922,22 +901,21 @@ func TestIntegrationProvisioning_IncrementalSync_FolderUIDChange(t *testing.T) {
 			Pull:   &provisioning.SyncJobOptions{Incremental: true},
 		})
 
-		folderAfter, err := helper.Folders.Resource.Get(ctx, newUID, metav1.GetOptions{})
+		folderAfter, err := helper.Folders.Resource.Get(t.Context(), newUID, metav1.GetOptions{})
 		require.NoError(t, err, "folder with new UID should exist")
 		title, _, _ := unstructured.NestedString(folderAfter.Object, "spec", "title")
 		require.Equal(t, "Alpha", title)
 
-		_, err = helper.Folders.Resource.Get(ctx, oldUID, metav1.GetOptions{})
+		_, err = helper.Folders.Resource.Get(t.Context(), oldUID, metav1.GetOptions{})
 		require.True(t, apierrors.IsNotFound(err), "old folder UID should be deleted after UID change")
 
-		common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+		common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 			"uid-dash-001": {Title: "Alpha Dashboard", SourcePath: "alpha/dash.json", Folder: newUID},
 		})
 	})
 
 	t.Run("UID change with nested child folder", func(t *testing.T) {
 		helper := sharedGitHelper(t)
-		ctx := context.Background()
 
 		const repoName = "incr-uid-change-nested"
 		const parentOldUID = "parent-old-uid"
@@ -952,10 +930,10 @@ func TestIntegrationProvisioning_IncrementalSync_FolderUIDChange(t *testing.T) {
 		})
 
 		helper.SyncAndWait(t, repoName)
-		common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "Parent")
-		common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "Child")
+		common.RequireRepoFolderTitle(t, helper.Folders, repoName, "Parent")
+		common.RequireRepoFolderTitle(t, helper.Folders, repoName, "Child")
 
-		common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+		common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 			"uid-parent-001": {Title: "Parent Dashboard", SourcePath: "parent/parent-dash.json", Folder: parentOldUID},
 			"uid-nested-001": {Title: "Nested Dashboard", SourcePath: "parent/child/nested-dash.json", Folder: childUID},
 		})
@@ -973,18 +951,18 @@ func TestIntegrationProvisioning_IncrementalSync_FolderUIDChange(t *testing.T) {
 			Pull:   &provisioning.SyncJobOptions{Incremental: true},
 		})
 
-		_, err = helper.Folders.Resource.Get(ctx, parentNewUID, metav1.GetOptions{})
+		_, err = helper.Folders.Resource.Get(t.Context(), parentNewUID, metav1.GetOptions{})
 		require.NoError(t, err, "parent folder with new UID should exist")
 
-		_, err = helper.Folders.Resource.Get(ctx, parentOldUID, metav1.GetOptions{})
+		_, err = helper.Folders.Resource.Get(t.Context(), parentOldUID, metav1.GetOptions{})
 		require.True(t, apierrors.IsNotFound(err), "old parent folder UID should be deleted after UID change")
 
-		childAfter, err := helper.Folders.Resource.Get(ctx, childUID, metav1.GetOptions{})
+		childAfter, err := helper.Folders.Resource.Get(t.Context(), childUID, metav1.GetOptions{})
 		require.NoError(t, err, "child folder should still exist")
 		childParent, _, _ := unstructured.NestedString(childAfter.Object, "metadata", "annotations", "grafana.app/folder")
 		require.Equal(t, parentNewUID, childParent, "child should be re-parented to new parent UID")
 
-		common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+		common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 			"uid-parent-001": {Title: "Parent Dashboard", SourcePath: "parent/parent-dash.json", Folder: parentNewUID},
 			"uid-nested-001": {Title: "Nested Dashboard", SourcePath: "parent/child/nested-dash.json", Folder: childUID},
 		})
@@ -992,7 +970,6 @@ func TestIntegrationProvisioning_IncrementalSync_FolderUIDChange(t *testing.T) {
 
 	t.Run("UID change alongside dashboard update in same commit", func(t *testing.T) {
 		helper := sharedGitHelper(t)
-		ctx := context.Background()
 
 		const repoName = "incr-uid-change-combo"
 		const oldUID = "combo-old-uid"
@@ -1019,22 +996,21 @@ func TestIntegrationProvisioning_IncrementalSync_FolderUIDChange(t *testing.T) {
 			Pull:   &provisioning.SyncJobOptions{Incremental: true},
 		})
 
-		folderAfter, err := helper.Folders.Resource.Get(ctx, newUID, metav1.GetOptions{})
+		folderAfter, err := helper.Folders.Resource.Get(t.Context(), newUID, metav1.GetOptions{})
 		require.NoError(t, err)
 		title, _, _ := unstructured.NestedString(folderAfter.Object, "spec", "title")
 		require.Equal(t, "Team Rebranded", title)
 
-		_, err = helper.Folders.Resource.Get(ctx, oldUID, metav1.GetOptions{})
+		_, err = helper.Folders.Resource.Get(t.Context(), oldUID, metav1.GetOptions{})
 		require.True(t, apierrors.IsNotFound(err), "old folder UID should be deleted after UID change")
 
-		common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+		common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 			"uid-combo-001": {Title: "Updated Dashboard", SourcePath: "team/dash.json", Folder: newUID},
 		})
 	})
 
 	t.Run("chained UID changes never accumulate orphans", func(t *testing.T) {
 		helper := sharedGitHelper(t)
-		ctx := context.Background()
 
 		const repoName = "incr-uid-chained"
 
@@ -1044,7 +1020,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderUIDChange(t *testing.T) {
 		})
 
 		common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
-		common.RequireRepoFolderCount(t, helper, ctx, repoName, 1)
+		common.RequireRepoFolderCount(t, helper, repoName, 1)
 
 		// v1 -> v2
 		require.NoError(t, local.UpdateFile("team/_folder.json", string(folderMetadataJSON("uid-v2", "Team v2"))))
@@ -1057,11 +1033,11 @@ func TestIntegrationProvisioning_IncrementalSync_FolderUIDChange(t *testing.T) {
 
 		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 
-		_, err = helper.Folders.Resource.Get(ctx, "uid-v2", metav1.GetOptions{})
+		_, err = helper.Folders.Resource.Get(t.Context(), "uid-v2", metav1.GetOptions{})
 		require.NoError(t, err, "v2 folder should exist")
-		_, err = helper.Folders.Resource.Get(ctx, "uid-v1", metav1.GetOptions{})
+		_, err = helper.Folders.Resource.Get(t.Context(), "uid-v1", metav1.GetOptions{})
 		require.True(t, apierrors.IsNotFound(err), "v1 folder should be deleted")
-		common.RequireRepoFolderCount(t, helper, ctx, repoName, 1)
+		common.RequireRepoFolderCount(t, helper, repoName, 1)
 
 		// v2 -> v3
 		require.NoError(t, local.UpdateFile("team/_folder.json", string(folderMetadataJSON("uid-v3", "Team v3"))))
@@ -1074,22 +1050,21 @@ func TestIntegrationProvisioning_IncrementalSync_FolderUIDChange(t *testing.T) {
 
 		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 
-		_, err = helper.Folders.Resource.Get(ctx, "uid-v3", metav1.GetOptions{})
+		_, err = helper.Folders.Resource.Get(t.Context(), "uid-v3", metav1.GetOptions{})
 		require.NoError(t, err, "v3 folder should exist")
-		_, err = helper.Folders.Resource.Get(ctx, "uid-v2", metav1.GetOptions{})
+		_, err = helper.Folders.Resource.Get(t.Context(), "uid-v2", metav1.GetOptions{})
 		require.True(t, apierrors.IsNotFound(err), "v2 folder should be deleted")
-		_, err = helper.Folders.Resource.Get(ctx, "uid-v1", metav1.GetOptions{})
+		_, err = helper.Folders.Resource.Get(t.Context(), "uid-v1", metav1.GetOptions{})
 		require.True(t, apierrors.IsNotFound(err), "v1 folder should still be deleted")
-		common.RequireRepoFolderCount(t, helper, ctx, repoName, 1)
+		common.RequireRepoFolderCount(t, helper, repoName, 1)
 
-		common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+		common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 			"chain-dash": {Title: "Dashboard", SourcePath: "team/dash.json", Folder: "uid-v3"},
 		})
 	})
 
 	t.Run("full sync after incremental UID changes cleans up any remaining orphans", func(t *testing.T) {
 		helper := sharedGitHelper(t)
-		ctx := context.Background()
 
 		const repoName = "incr-uid-full-cleanup"
 
@@ -1099,7 +1074,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderUIDChange(t *testing.T) {
 		})
 
 		common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
-		common.RequireRepoFolderCount(t, helper, ctx, repoName, 1)
+		common.RequireRepoFolderCount(t, helper, repoName, 1)
 
 		// Change UID via incremental sync
 		require.NoError(t, local.UpdateFile("team/_folder.json", string(folderMetadataJSON("cleanup-v2", "Team v2"))))
@@ -1111,18 +1086,18 @@ func TestIntegrationProvisioning_IncrementalSync_FolderUIDChange(t *testing.T) {
 		require.NoError(t, err)
 
 		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
-		common.RequireRepoFolderCount(t, helper, ctx, repoName, 1)
+		common.RequireRepoFolderCount(t, helper, repoName, 1)
 
 		// A subsequent full sync should be idempotent — still exactly 1 folder
 		helper.SyncAndWait(t, repoName)
-		common.RequireRepoFolderCount(t, helper, ctx, repoName, 1)
+		common.RequireRepoFolderCount(t, helper, repoName, 1)
 
-		_, err = helper.Folders.Resource.Get(ctx, "cleanup-v2", metav1.GetOptions{})
+		_, err = helper.Folders.Resource.Get(t.Context(), "cleanup-v2", metav1.GetOptions{})
 		require.NoError(t, err, "current folder should still exist")
-		_, err = helper.Folders.Resource.Get(ctx, "cleanup-v1", metav1.GetOptions{})
+		_, err = helper.Folders.Resource.Get(t.Context(), "cleanup-v1", metav1.GetOptions{})
 		require.True(t, apierrors.IsNotFound(err), "old folder should not reappear")
 
-		common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+		common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 			"cleanup-dash": {Title: "Dashboard", SourcePath: "team/dash.json", Folder: "cleanup-v2"},
 		})
 	})
@@ -1136,7 +1111,6 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataDeletion(t *testi
 
 	t.Run("simple metadata deletion re-parents dashboard", func(t *testing.T) {
 		helper := sharedGitHelper(t)
-		ctx := context.Background()
 
 		const repoName = "incr-meta-delete-simple"
 		const stableUID = "stable-folder-uid"
@@ -1149,10 +1123,10 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataDeletion(t *testi
 		helper.SyncAndWait(t, repoName)
 
 		// Verify folder exists with stable UID
-		_, err := helper.Folders.Resource.Get(ctx, stableUID, metav1.GetOptions{})
+		_, err := helper.Folders.Resource.Get(t.Context(), stableUID, metav1.GetOptions{})
 		require.NoError(t, err, "folder with stable UID should exist after full sync")
 
-		common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+		common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 			"meta-del-001": {Title: "Alpha Dashboard", SourcePath: "alpha/dash.json", Folder: stableUID},
 		})
 
@@ -1170,22 +1144,21 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataDeletion(t *testi
 		})
 
 		// Old stable UID folder should be deleted
-		_, err = helper.Folders.Resource.Get(ctx, stableUID, metav1.GetOptions{})
+		_, err = helper.Folders.Resource.Get(t.Context(), stableUID, metav1.GetOptions{})
 		require.True(t, apierrors.IsNotFound(err), "old stable UID folder should be deleted after metadata deletion")
 
 		// New folder should exist with hash-based UID and directory name as title
-		newFolderUID := common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "alpha")
+		newFolderUID := common.RequireRepoFolderTitle(t, helper.Folders, repoName, "alpha")
 		require.NotEqual(t, stableUID, newFolderUID, "new folder should have a different UID")
 
 		// Dashboard should be re-parented to the new folder
-		common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+		common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 			"meta-del-001": {Title: "Alpha Dashboard", SourcePath: "alpha/dash.json", Folder: newFolderUID},
 		})
 	})
 
 	t.Run("metadata deletion with nested child folder", func(t *testing.T) {
 		helper := sharedGitHelper(t)
-		ctx := context.Background()
 
 		const repoName = "incr-meta-delete-nested"
 		const parentStableUID = "parent-stable-uid"
@@ -1200,7 +1173,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataDeletion(t *testi
 
 		helper.SyncAndWait(t, repoName)
 
-		common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+		common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 			"nested-parent-001": {Title: "Parent Dashboard", SourcePath: "parent/parent-dash.json", Folder: parentStableUID},
 			"nested-child-001":  {Title: "Child Dashboard", SourcePath: "parent/child/child-dash.json", Folder: childStableUID},
 		})
@@ -1219,21 +1192,21 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataDeletion(t *testi
 		})
 
 		// Old parent folder should be gone
-		_, err = helper.Folders.Resource.Get(ctx, parentStableUID, metav1.GetOptions{})
+		_, err = helper.Folders.Resource.Get(t.Context(), parentStableUID, metav1.GetOptions{})
 		require.True(t, apierrors.IsNotFound(err), "old parent folder should be deleted")
 
 		// New parent folder should exist with hash-based UID
-		newParentUID := common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "parent")
+		newParentUID := common.RequireRepoFolderTitle(t, helper.Folders, repoName, "parent")
 		require.NotEqual(t, parentStableUID, newParentUID)
 
 		// Child folder should still exist with its stable UID, re-parented under new parent
-		childAfter, err := helper.Folders.Resource.Get(ctx, childStableUID, metav1.GetOptions{})
+		childAfter, err := helper.Folders.Resource.Get(t.Context(), childStableUID, metav1.GetOptions{})
 		require.NoError(t, err, "child folder should still exist")
 		childParent, _, _ := unstructured.NestedString(childAfter.Object, "metadata", "annotations", "grafana.app/folder")
 		require.Equal(t, newParentUID, childParent, "child should be re-parented to new parent UID")
 
 		// Parent dashboard re-parented; child dashboard unchanged
-		common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+		common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 			"nested-parent-001": {Title: "Parent Dashboard", SourcePath: "parent/parent-dash.json", Folder: newParentUID},
 			"nested-child-001":  {Title: "Child Dashboard", SourcePath: "parent/child/child-dash.json", Folder: childStableUID},
 		})
@@ -1241,7 +1214,6 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataDeletion(t *testi
 
 	t.Run("metadata deletion re-parents all direct children", func(t *testing.T) {
 		helper := sharedGitHelper(t)
-		ctx := context.Background()
 
 		const repoName = "incr-meta-delete-children"
 		const stableUID = "children-stable-uid"
@@ -1258,17 +1230,17 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataDeletion(t *testi
 
 		helper.SyncAndWait(t, repoName)
 
-		_, err := helper.Folders.Resource.Get(ctx, stableUID, metav1.GetOptions{})
+		_, err := helper.Folders.Resource.Get(t.Context(), stableUID, metav1.GetOptions{})
 		require.NoError(t, err, "folder with stable UID should exist")
 
-		common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+		common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 			"child-dash-a": {Title: "Dashboard A", SourcePath: "team/dash-a.json", Folder: stableUID},
 			"child-dash-b": {Title: "Dashboard B", SourcePath: "team/dash-b.json", Folder: stableUID},
 			"child-dash-c": {Title: "Dashboard C", SourcePath: "team/dash-c.json", Folder: stableUID},
 			"child-nested": {Title: "Nested Dashboard", SourcePath: "team/sub/nested-dash.json", Folder: childFolderUID},
 		})
 
-		childBefore, err := helper.Folders.Resource.Get(ctx, childFolderUID, metav1.GetOptions{})
+		childBefore, err := helper.Folders.Resource.Get(t.Context(), childFolderUID, metav1.GetOptions{})
 		require.NoError(t, err)
 		childParentBefore, _, _ := unstructured.NestedString(childBefore.Object, "metadata", "annotations", "grafana.app/folder")
 		require.Equal(t, stableUID, childParentBefore, "child folder should initially be parented under stable UID")
@@ -1287,15 +1259,15 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataDeletion(t *testi
 		})
 
 		// Old stable UID folder should be deleted
-		_, err = helper.Folders.Resource.Get(ctx, stableUID, metav1.GetOptions{})
+		_, err = helper.Folders.Resource.Get(t.Context(), stableUID, metav1.GetOptions{})
 		require.True(t, apierrors.IsNotFound(err), "old stable UID folder should be deleted")
 
 		// New folder should exist with hash-based UID
-		newFolderUID := common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "team")
+		newFolderUID := common.RequireRepoFolderTitle(t, helper.Folders, repoName, "team")
 		require.NotEqual(t, stableUID, newFolderUID)
 
 		// All three dashboards should be re-parented to the new folder
-		common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+		common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 			"child-dash-a": {Title: "Dashboard A", SourcePath: "team/dash-a.json", Folder: newFolderUID},
 			"child-dash-b": {Title: "Dashboard B", SourcePath: "team/dash-b.json", Folder: newFolderUID},
 			"child-dash-c": {Title: "Dashboard C", SourcePath: "team/dash-c.json", Folder: newFolderUID},
@@ -1303,7 +1275,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataDeletion(t *testi
 		})
 
 		// Child folder should be re-parented to the new parent UID
-		childAfter, err := helper.Folders.Resource.Get(ctx, childFolderUID, metav1.GetOptions{})
+		childAfter, err := helper.Folders.Resource.Get(t.Context(), childFolderUID, metav1.GetOptions{})
 		require.NoError(t, err, "child folder should still exist")
 		childParentAfter, _, _ := unstructured.NestedString(childAfter.Object, "metadata", "annotations", "grafana.app/folder")
 		require.Equal(t, newFolderUID, childParentAfter, "child folder should be re-parented to new hash-based UID")
@@ -1311,7 +1283,6 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataDeletion(t *testi
 
 	t.Run("metadata deletion alongside dashboard update in same commit", func(t *testing.T) {
 		helper := sharedGitHelper(t)
-		ctx := context.Background()
 
 		const repoName = "incr-meta-delete-combo"
 		const stableUID = "combo-stable-uid"
@@ -1340,15 +1311,15 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataDeletion(t *testi
 		})
 
 		// Old folder should be gone
-		_, err = helper.Folders.Resource.Get(ctx, stableUID, metav1.GetOptions{})
+		_, err = helper.Folders.Resource.Get(t.Context(), stableUID, metav1.GetOptions{})
 		require.True(t, apierrors.IsNotFound(err), "old stable UID folder should be deleted")
 
 		// New folder with hash-based UID
-		newFolderUID := common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "team")
+		newFolderUID := common.RequireRepoFolderTitle(t, helper.Folders, repoName, "team")
 		require.NotEqual(t, stableUID, newFolderUID)
 
 		// Dashboard should be updated and re-parented
-		common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+		common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 			"combo-del-001": {Title: "Updated Dashboard", SourcePath: "team/dash.json", Folder: newFolderUID},
 		})
 	})
@@ -1363,7 +1334,6 @@ func TestIntegrationProvisioning_IncrementalSync_RenamedFolderMetadataOrphanClea
 
 	t.Run("metadata-only folder rename cleans up old folder", func(t *testing.T) {
 		helper := sharedGitHelper(t)
-		ctx := context.Background()
 
 		const repoName = "incr-meta-rename-orphan"
 		const folderUID = "rename-orphan-uid"
@@ -1375,7 +1345,7 @@ func TestIntegrationProvisioning_IncrementalSync_RenamedFolderMetadataOrphanClea
 
 		common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
 		common.RequireFolderState(t, helper.Folders, folderUID, "Old Team", "old-team", "")
-		common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+		common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 			"rename-orphan-dash": {Title: "Team Dashboard", SourcePath: "old-team/dash.json", Folder: folderUID},
 		})
 
@@ -1397,16 +1367,15 @@ func TestIntegrationProvisioning_IncrementalSync_RenamedFolderMetadataOrphanClea
 		common.RequireFolderState(t, helper.Folders, folderUID, "Old Team", "new-team", "")
 
 		// Only one folder should exist for this repo — old-team should be gone.
-		common.RequireRepoFolders(t, helper.Folders, ctx, repoName, []string{"new-team"})
+		common.RequireRepoFolders(t, helper.Folders, repoName, []string{"new-team"})
 
-		common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+		common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 			"rename-orphan-dash": {Title: "Team Dashboard", SourcePath: "new-team/dash.json", Folder: folderUID},
 		})
 	})
 
 	t.Run("metadata moved to folder with dashboard but no metadata", func(t *testing.T) {
 		helper := sharedGitHelper(t)
-		ctx := context.Background()
 
 		const repoName = "incr-meta-rename-to-existing"
 		const folderUID = "src-uid-001"
@@ -1424,7 +1393,7 @@ func TestIntegrationProvisioning_IncrementalSync_RenamedFolderMetadataOrphanClea
 		common.SyncAndWait(t, helper, common.Repo(repoName), common.Warning())
 		common.RequireFolderState(t, helper.Folders, folderUID, "Source Folder", "src", "")
 		// dst/ gets a hash-derived UID since it has no metadata.
-		dstAutoUID := common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "dst")
+		dstAutoUID := common.RequireRepoFolderTitle(t, helper.Folders, repoName, "dst")
 		require.NotEqual(t, folderUID, dstAutoUID)
 
 		// Move _folder.json from src/ to dst/. The dashboard stays put.
@@ -1442,12 +1411,12 @@ func TestIntegrationProvisioning_IncrementalSync_RenamedFolderMetadataOrphanClea
 
 		// src/ should still exist (it has a dashboard) but with a
 		// hash-derived UID since its metadata is gone.
-		srcAutoUID := common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "src")
+		srcAutoUID := common.RequireRepoFolderTitle(t, helper.Folders, repoName, "src")
 		require.NotEqual(t, folderUID, srcAutoUID)
 
-		common.RequireRepoFolders(t, helper.Folders, ctx, repoName, []string{"src", "dst"})
+		common.RequireRepoFolders(t, helper.Folders, repoName, []string{"src", "dst"})
 
-		common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+		common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 			"dash-src": {Title: "Source Dashboard", SourcePath: "src/dash-src.json", Folder: srcAutoUID},
 			"dash-dst": {Title: "Dest Dashboard", SourcePath: "dst/dash-dst.json", Folder: folderUID},
 		})
@@ -1455,7 +1424,6 @@ func TestIntegrationProvisioning_IncrementalSync_RenamedFolderMetadataOrphanClea
 
 	t.Run("metadata moved to folder with dashboard and pre-existing metadata", func(t *testing.T) {
 		helper := sharedGitHelper(t)
-		ctx := context.Background()
 
 		const repoName = "incr-meta-rename-over"
 		const srcUID = "override-src-uid"
@@ -1495,12 +1463,12 @@ func TestIntegrationProvisioning_IncrementalSync_RenamedFolderMetadataOrphanClea
 		common.RequireFolderState(t, helper.Folders, srcUID, "Source", "dst", "")
 
 		// src/ still has a dashboard, so it should exist with a hash UID.
-		srcAutoUID := common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "src")
+		srcAutoUID := common.RequireRepoFolderTitle(t, helper.Folders, repoName, "src")
 		require.NotEqual(t, srcUID, srcAutoUID)
 
-		common.RequireRepoFolders(t, helper.Folders, ctx, repoName, []string{"src", "dst"})
+		common.RequireRepoFolders(t, helper.Folders, repoName, []string{"src", "dst"})
 
-		common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+		common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 			"dash-s": {Title: "Src Dash", SourcePath: "src/dash-s.json", Folder: srcAutoUID},
 			"dash-d": {Title: "Dst Dash", SourcePath: "dst/dash-d.json", Folder: srcUID},
 		})
@@ -1508,7 +1476,6 @@ func TestIntegrationProvisioning_IncrementalSync_RenamedFolderMetadataOrphanClea
 
 	t.Run("metadata-only empty folder rename cleans up old folder", func(t *testing.T) {
 		helper := sharedGitHelper(t)
-		ctx := context.Background()
 
 		const repoName = "incr-meta-rename-empty"
 		const folderUID = "empty-rename-uid"
@@ -1536,8 +1503,8 @@ func TestIntegrationProvisioning_IncrementalSync_RenamedFolderMetadataOrphanClea
 		common.RequireFolderState(t, helper.Folders, folderUID, "Empty Folder", "new-empty", "")
 
 		// Only one folder should exist for this repo.
-		common.RequireRepoFolders(t, helper.Folders, ctx, repoName, []string{"new-empty"})
-		common.RequireRepoFolderCount(t, helper, ctx, repoName, 1)
+		common.RequireRepoFolders(t, helper.Folders, repoName, []string{"new-empty"})
+		common.RequireRepoFolderCount(t, helper, repoName, 1)
 	})
 }
 
@@ -1549,7 +1516,6 @@ func TestIntegrationProvisioning_IncrementalSync_FileRenameIntoRelocatedFolder(t
 
 	t.Run("dashboard renamed into folder whose metadata was also renamed", func(t *testing.T) {
 		helper := sharedGitHelper(t)
-		ctx := context.Background()
 
 		const repoName = "incr-file-rename-into-relocated"
 		const folderUID = "relocated-folder-uid"
@@ -1566,7 +1532,7 @@ func TestIntegrationProvisioning_IncrementalSync_FileRenameIntoRelocatedFolder(t
 
 		common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
 		common.RequireFolderState(t, helper.Folders, folderUID, "Source Folder", "src", "")
-		common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+		common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 			"dash-move": {Title: "Moving Dashboard", SourcePath: "src/move.json", Folder: folderUID},
 			"dash-stay": {Title: "Staying Dashboard", SourcePath: "src/stay.json", Folder: folderUID},
 		})
@@ -1593,12 +1559,12 @@ func TestIntegrationProvisioning_IncrementalSync_FileRenameIntoRelocatedFolder(t
 		common.RequireFolderState(t, helper.Folders, folderUID, "Source Folder", "dst", "")
 
 		// src/ should still exist with a hash-derived UID (has stay.json).
-		srcAutoUID := common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "src")
+		srcAutoUID := common.RequireRepoFolderTitle(t, helper.Folders, repoName, "src")
 		require.NotEqual(t, folderUID, srcAutoUID, "src/ should have a hash-derived UID after losing _folder.json")
 
-		common.RequireRepoFolders(t, helper.Folders, ctx, repoName, []string{"src", "dst"})
+		common.RequireRepoFolders(t, helper.Folders, repoName, []string{"src", "dst"})
 
-		common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+		common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 			"dash-move": {Title: "Moving Dashboard", SourcePath: "dst/move.json", Folder: folderUID},
 			"dash-stay": {Title: "Staying Dashboard", SourcePath: "src/stay.json", Folder: srcAutoUID},
 		})
@@ -1606,7 +1572,6 @@ func TestIntegrationProvisioning_IncrementalSync_FileRenameIntoRelocatedFolder(t
 
 	t.Run("dashboard from unrelated folder renamed into relocated metadata folder", func(t *testing.T) {
 		helper := sharedGitHelper(t)
-		ctx := context.Background()
 
 		const repoName = "incr-cross-folder-rename-reloc"
 		const srcUID = "cross-src-uid"
@@ -1622,8 +1587,8 @@ func TestIntegrationProvisioning_IncrementalSync_FileRenameIntoRelocatedFolder(t
 
 		common.SyncAndWait(t, helper, common.Repo(repoName), common.Warning())
 		common.RequireFolderState(t, helper.Folders, srcUID, "Team A", "teamA", "")
-		teamBUID := common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "teamB")
-		common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+		teamBUID := common.RequireRepoFolderTitle(t, helper.Folders, repoName, "teamB")
+		common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 			"dash-own":     {Title: "Own Dashboard", SourcePath: "teamA/own.json", Folder: srcUID},
 			"dash-migrate": {Title: "Migrate Dashboard", SourcePath: "teamB/migrate.json", Folder: teamBUID},
 		})
@@ -1650,10 +1615,10 @@ func TestIntegrationProvisioning_IncrementalSync_FileRenameIntoRelocatedFolder(t
 		common.RequireFolderState(t, helper.Folders, srcUID, "Team A", "teamC", "")
 
 		// teamA/ should still exist with a hash-derived UID.
-		teamAAutoUID := common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "teamA")
+		teamAAutoUID := common.RequireRepoFolderTitle(t, helper.Folders, repoName, "teamA")
 		require.NotEqual(t, srcUID, teamAAutoUID)
 
-		common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+		common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 			"dash-own":     {Title: "Own Dashboard", SourcePath: "teamA/own.json", Folder: teamAAutoUID},
 			"dash-migrate": {Title: "Migrate Dashboard", SourcePath: "teamC/migrate.json", Folder: srcUID},
 		})
@@ -1661,7 +1626,6 @@ func TestIntegrationProvisioning_IncrementalSync_FileRenameIntoRelocatedFolder(t
 
 	t.Run("dashboard renamed into nested path under relocated metadata folder", func(t *testing.T) {
 		helper := sharedGitHelper(t)
-		ctx := context.Background()
 
 		const repoName = "incr-nested-path-rename-reloc"
 		const srcUID = "nested-reloc-src-uid"
@@ -1705,10 +1669,10 @@ func TestIntegrationProvisioning_IncrementalSync_FileRenameIntoRelocatedFolder(t
 
 		// teamA/ still has own.json, so it should exist with a
 		// hash-derived UID.
-		teamAAutoUID := common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "teamA")
+		teamAAutoUID := common.RequireRepoFolderTitle(t, helper.Folders, repoName, "teamA")
 		require.NotEqual(t, srcUID, teamAAutoUID)
 
-		common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+		common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 			"dash-own":     {Title: "Own Dashboard", SourcePath: "teamA/own.json", Folder: teamAAutoUID},
 			"dash-migrate": {Title: "Migrate Dashboard", SourcePath: "teamC/nested/migrate.json"},
 		})
@@ -1723,7 +1687,6 @@ func TestIntegrationProvisioning_IncrementalSync_FolderUIDConflict(t *testing.T)
 
 	t.Run("updating metadata to steal another folder UID produces a conflict warning", func(t *testing.T) {
 		helper := sharedGitHelper(t)
-		ctx := context.Background()
 
 		const repoName = "incr-uid-conflict"
 		const ownerUID = "owner-folder-uid"
@@ -1776,12 +1739,11 @@ func TestIntegrationProvisioning_IncrementalSync_FolderUIDConflict(t *testing.T)
 
 		// The thief folder's UID conflict was rejected, so it should still
 		// exist under its original UID.
-		common.RequireRepoFolderUID(t, helper.Folders, ctx, repoName, thiefUID)
+		common.RequireRepoFolderUID(t, helper.Folders, repoName, thiefUID)
 	})
 
 	t.Run("real relocation succeeds while simultaneous UID theft is rejected", func(t *testing.T) {
 		helper := sharedGitHelper(t)
-		ctx := context.Background()
 
 		const repoName = "incr-uid-conflict-dual"
 		const movingUID = "moving-folder-uid"
@@ -1839,11 +1801,11 @@ func TestIntegrationProvisioning_IncrementalSync_FolderUIDConflict(t *testing.T)
 		common.RequireFolderState(t, helper.Folders, movingUID, "Moving Folder", "dst", "")
 
 		// src/ should still exist (has stay.json) with a hash-derived UID.
-		srcAutoUID := common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "src")
+		srcAutoUID := common.RequireRepoFolderTitle(t, helper.Folders, repoName, "src")
 		require.NotEqual(t, movingUID, srcAutoUID, "src/ should have a hash-derived UID after losing _folder.json")
 
 		// The thief's UID conflict was rejected, so it should retain its original UID.
-		common.RequireRepoFolderUID(t, helper.Folders, ctx, repoName, thiefUID)
+		common.RequireRepoFolderUID(t, helper.Folders, repoName, thiefUID)
 	})
 }
 
@@ -1856,7 +1818,6 @@ func TestIntegrationProvisioning_IncrementalSync_NestedFolderRenameWithStableUID
 
 	t.Run("parent and nested child folder rename preserves both stable UIDs", func(t *testing.T) {
 		helper := sharedGitHelper(t)
-		ctx := context.Background()
 
 		const repoName = "incr-nested-rename-stable"
 		const parentUID = "nrs-parent-uid"
@@ -1869,17 +1830,17 @@ func TestIntegrationProvisioning_IncrementalSync_NestedFolderRenameWithStableUID
 		})
 
 		common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
-		common.RequireRepoFolders(t, helper.Folders, ctx, repoName, []string{"team", "team/project"})
+		common.RequireRepoFolders(t, helper.Folders, repoName, []string{"team", "team/project"})
 
-		parentBefore, err := helper.Folders.Resource.Get(ctx, parentUID, metav1.GetOptions{})
+		parentBefore, err := helper.Folders.Resource.Get(t.Context(), parentUID, metav1.GetOptions{})
 		require.NoError(t, err)
 		parentSnap := common.SnapshotObject(t, parentBefore)
 
-		childBefore, err := helper.Folders.Resource.Get(ctx, childUID, metav1.GetOptions{})
+		childBefore, err := helper.Folders.Resource.Get(t.Context(), childUID, metav1.GetOptions{})
 		require.NoError(t, err)
 		childSnap := common.SnapshotObject(t, childBefore)
 
-		dashBefore, err := helper.DashboardsV1.Resource.Get(ctx, "nrs-dash", metav1.GetOptions{})
+		dashBefore, err := helper.DashboardsV1.Resource.Get(t.Context(), "nrs-dash", metav1.GetOptions{})
 		require.NoError(t, err)
 		dashSnap := common.SnapshotObject(t, dashBefore)
 
@@ -1894,7 +1855,7 @@ func TestIntegrationProvisioning_IncrementalSync_NestedFolderRenameWithStableUID
 		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 
 		// Parent folder updated in place with new source path.
-		parentAfter, err := helper.Folders.Resource.Get(ctx, parentUID, metav1.GetOptions{})
+		parentAfter, err := helper.Folders.Resource.Get(t.Context(), parentUID, metav1.GetOptions{})
 		require.NoError(t, err, "parent folder should still exist with same UID")
 		common.RequireUpdatedInPlace(t, "parent folder", parentSnap, common.SnapshotObject(t, parentAfter))
 
@@ -1902,7 +1863,7 @@ func TestIntegrationProvisioning_IncrementalSync_NestedFolderRenameWithStableUID
 		require.Equal(t, "squad", parentSP)
 
 		// Child folder updated in place and still parented under the renamed parent.
-		childAfter, err := helper.Folders.Resource.Get(ctx, childUID, metav1.GetOptions{})
+		childAfter, err := helper.Folders.Resource.Get(t.Context(), childUID, metav1.GetOptions{})
 		require.NoError(t, err, "child folder should still exist with same UID")
 		common.RequireUpdatedInPlace(t, "child folder", childSnap, common.SnapshotObject(t, childAfter))
 
@@ -1911,21 +1872,20 @@ func TestIntegrationProvisioning_IncrementalSync_NestedFolderRenameWithStableUID
 		childParent, _, _ := unstructured.NestedString(childAfter.Object, "metadata", "annotations", "grafana.app/folder")
 		require.Equal(t, parentUID, childParent, "child should still be parented under renamed parent")
 
-		common.RequireRepoFolders(t, helper.Folders, ctx, repoName, []string{"squad", "squad/project"})
+		common.RequireRepoFolders(t, helper.Folders, repoName, []string{"squad", "squad/project"})
 
 		// Dashboard updated in place under the renamed hierarchy.
-		dashAfter, err := helper.DashboardsV1.Resource.Get(ctx, "nrs-dash", metav1.GetOptions{})
+		dashAfter, err := helper.DashboardsV1.Resource.Get(t.Context(), "nrs-dash", metav1.GetOptions{})
 		require.NoError(t, err)
 		common.RequireUpdatedInPlace(t, "dashboard", dashSnap, common.SnapshotObject(t, dashAfter))
 
-		common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+		common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 			"nrs-dash": {Title: "Nested Dashboard", SourcePath: "squad/project/dash.json", Folder: childUID},
 		})
 	})
 
 	t.Run("three-level folder rename preserves all stable UIDs", func(t *testing.T) {
 		helper := sharedGitHelper(t)
-		ctx := context.Background()
 
 		const repoName = "incr-3level-rename-stable"
 		const grandparentUID = "3l-gp-uid"
@@ -1940,19 +1900,19 @@ func TestIntegrationProvisioning_IncrementalSync_NestedFolderRenameWithStableUID
 		})
 
 		common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
-		common.RequireRepoFolders(t, helper.Folders, ctx, repoName, []string{
+		common.RequireRepoFolders(t, helper.Folders, repoName, []string{
 			"org", "org/team", "org/team/project",
 		})
 
-		gpBefore, err := helper.Folders.Resource.Get(ctx, grandparentUID, metav1.GetOptions{})
+		gpBefore, err := helper.Folders.Resource.Get(t.Context(), grandparentUID, metav1.GetOptions{})
 		require.NoError(t, err)
 		gpSnap := common.SnapshotObject(t, gpBefore)
 
-		parentBefore, err := helper.Folders.Resource.Get(ctx, parentUID, metav1.GetOptions{})
+		parentBefore, err := helper.Folders.Resource.Get(t.Context(), parentUID, metav1.GetOptions{})
 		require.NoError(t, err)
 		parentSnap := common.SnapshotObject(t, parentBefore)
 
-		childBefore, err := helper.Folders.Resource.Get(ctx, childUID, metav1.GetOptions{})
+		childBefore, err := helper.Folders.Resource.Get(t.Context(), childUID, metav1.GetOptions{})
 		require.NoError(t, err)
 		childSnap := common.SnapshotObject(t, childBefore)
 
@@ -1967,7 +1927,7 @@ func TestIntegrationProvisioning_IncrementalSync_NestedFolderRenameWithStableUID
 		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 
 		// Grandparent updated in place.
-		gpAfter, err := helper.Folders.Resource.Get(ctx, grandparentUID, metav1.GetOptions{})
+		gpAfter, err := helper.Folders.Resource.Get(t.Context(), grandparentUID, metav1.GetOptions{})
 		require.NoError(t, err, "grandparent folder should still exist with same UID")
 		common.RequireUpdatedInPlace(t, "grandparent folder", gpSnap, common.SnapshotObject(t, gpAfter))
 
@@ -1975,7 +1935,7 @@ func TestIntegrationProvisioning_IncrementalSync_NestedFolderRenameWithStableUID
 		require.Equal(t, "corp", gpSP)
 
 		// Parent updated in place.
-		parentAfter, err := helper.Folders.Resource.Get(ctx, parentUID, metav1.GetOptions{})
+		parentAfter, err := helper.Folders.Resource.Get(t.Context(), parentUID, metav1.GetOptions{})
 		require.NoError(t, err, "parent folder should still exist with same UID")
 		common.RequireUpdatedInPlace(t, "parent folder", parentSnap, common.SnapshotObject(t, parentAfter))
 
@@ -1985,7 +1945,7 @@ func TestIntegrationProvisioning_IncrementalSync_NestedFolderRenameWithStableUID
 		require.Equal(t, grandparentUID, parentParent)
 
 		// Child updated in place.
-		childAfter, err := helper.Folders.Resource.Get(ctx, childUID, metav1.GetOptions{})
+		childAfter, err := helper.Folders.Resource.Get(t.Context(), childUID, metav1.GetOptions{})
 		require.NoError(t, err, "child folder should still exist with same UID")
 		common.RequireUpdatedInPlace(t, "child folder", childSnap, common.SnapshotObject(t, childAfter))
 
@@ -1994,11 +1954,11 @@ func TestIntegrationProvisioning_IncrementalSync_NestedFolderRenameWithStableUID
 		childParent, _, _ := unstructured.NestedString(childAfter.Object, "metadata", "annotations", "grafana.app/folder")
 		require.Equal(t, parentUID, childParent)
 
-		common.RequireRepoFolders(t, helper.Folders, ctx, repoName, []string{
+		common.RequireRepoFolders(t, helper.Folders, repoName, []string{
 			"corp", "corp/team", "corp/team/project",
 		})
 
-		common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+		common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 			"3l-dash": {Title: "Deep Dashboard", SourcePath: "corp/team/project/dash.json", Folder: childUID},
 		})
 	})

--- a/pkg/tests/apis/provisioning/foldermetadata/incremental/incremental_folder_metadata_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/incremental/incremental_folder_metadata_test.go
@@ -266,8 +266,8 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataCreation(t *testi
 		}
 
 		common.RequireRepoFolderUID(t, helper.Folders, repoName, "stable-uid")
-		common.RequireRepoFolderCount(t, helper, repoName, 1)
-		common.RequireRepoDashboardCount(t, helper, repoName, 1)
+		helper.RequireRepoFolderCount(t, repoName, 1)
+		helper.RequireRepoDashboardCount(t, repoName, 1)
 		common.RequireRepoDashboardParent(t, helper.DashboardsV1, repoName, "myfolder/dash.json", "stable-uid")
 	})
 
@@ -293,8 +293,8 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataCreation(t *testi
 		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 
 		common.RequireFolderState(t, helper.Folders, "empty-team-uid", "Empty Team", "empty-team", "")
-		common.RequireRepoFolderCount(t, helper, repoName, 1)
-		common.RequireRepoDashboardCount(t, helper, repoName, 1)
+		helper.RequireRepoFolderCount(t, repoName, 1)
+		helper.RequireRepoDashboardCount(t, repoName, 1)
 	})
 
 	t.Run("new _folder.json transitions existing folder to stable uid", func(t *testing.T) {
@@ -323,8 +323,8 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataCreation(t *testi
 		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 
 		common.RequireRepoFolderUID(t, helper.Folders, repoName, "stable-uid")
-		common.RequireRepoFolderCount(t, helper, repoName, 1)
-		common.RequireRepoDashboardCount(t, helper, repoName, 1)
+		helper.RequireRepoFolderCount(t, repoName, 1)
+		helper.RequireRepoDashboardCount(t, repoName, 1)
 		common.RequireRepoDashboardParent(t, helper.DashboardsV1, repoName, "myfolder/dash.json", "stable-uid")
 	})
 
@@ -361,8 +361,8 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataCreation(t *testi
 		childUID = common.RequireRepoFolderTitle(t, helper.Folders, repoName, "child")
 		common.RequireFolderState(t, helper.Folders, childUID, "child", "myfolder/child", "stable-uid")
 
-		common.RequireRepoFolderCount(t, helper, repoName, 2)
-		common.RequireRepoDashboardCount(t, helper, repoName, 2)
+		helper.RequireRepoFolderCount(t, repoName, 2)
+		helper.RequireRepoDashboardCount(t, repoName, 2)
 		common.RequireRepoDashboardParent(t, helper.DashboardsV1, repoName, "myfolder/dash.json", "stable-uid")
 	})
 
@@ -394,8 +394,8 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataCreation(t *testi
 		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 
 		common.RequireRepoFolderUID(t, helper.Folders, repoName, "stable-uid")
-		common.RequireRepoFolderCount(t, helper, repoName, 1)
-		common.RequireRepoDashboardCount(t, helper, repoName, 1)
+		helper.RequireRepoFolderCount(t, repoName, 1)
+		helper.RequireRepoDashboardCount(t, repoName, 1)
 		common.RequireRepoDashboardParent(t, helper.DashboardsV1, repoName, "myfolder/dash-renamed.json", "stable-uid")
 	})
 
@@ -438,8 +438,8 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataCreation(t *testi
 		common.RequireFolderState(t, helper.Folders, "p-new", "Parent", "parent", "")
 		common.RequireFolderState(t, helper.Folders, "c-new", "Child", "parent/child", "p-new")
 		common.RequireRepoFolders(t, helper.Folders, repoName, []string{"parent", "parent/child"})
-		common.RequireRepoFolderCount(t, helper, repoName, 2)
-		common.RequireRepoDashboardCount(t, helper, repoName, 1)
+		helper.RequireRepoFolderCount(t, repoName, 2)
+		helper.RequireRepoDashboardCount(t, repoName, 1)
 		common.RequireRepoDashboardParent(t, helper.DashboardsV1, repoName, "parent/child/dash.json", "c-new")
 	})
 }
@@ -1020,7 +1020,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderUIDChange(t *testing.T) {
 		})
 
 		common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
-		common.RequireRepoFolderCount(t, helper, repoName, 1)
+		helper.RequireRepoFolderCount(t, repoName, 1)
 
 		// v1 -> v2
 		require.NoError(t, local.UpdateFile("team/_folder.json", string(folderMetadataJSON("uid-v2", "Team v2"))))
@@ -1037,7 +1037,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderUIDChange(t *testing.T) {
 		require.NoError(t, err, "v2 folder should exist")
 		_, err = helper.Folders.Resource.Get(t.Context(), "uid-v1", metav1.GetOptions{})
 		require.True(t, apierrors.IsNotFound(err), "v1 folder should be deleted")
-		common.RequireRepoFolderCount(t, helper, repoName, 1)
+		helper.RequireRepoFolderCount(t, repoName, 1)
 
 		// v2 -> v3
 		require.NoError(t, local.UpdateFile("team/_folder.json", string(folderMetadataJSON("uid-v3", "Team v3"))))
@@ -1056,7 +1056,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderUIDChange(t *testing.T) {
 		require.True(t, apierrors.IsNotFound(err), "v2 folder should be deleted")
 		_, err = helper.Folders.Resource.Get(t.Context(), "uid-v1", metav1.GetOptions{})
 		require.True(t, apierrors.IsNotFound(err), "v1 folder should still be deleted")
-		common.RequireRepoFolderCount(t, helper, repoName, 1)
+		helper.RequireRepoFolderCount(t, repoName, 1)
 
 		common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 			"chain-dash": {Title: "Dashboard", SourcePath: "team/dash.json", Folder: "uid-v3"},
@@ -1074,7 +1074,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderUIDChange(t *testing.T) {
 		})
 
 		common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
-		common.RequireRepoFolderCount(t, helper, repoName, 1)
+		helper.RequireRepoFolderCount(t, repoName, 1)
 
 		// Change UID via incremental sync
 		require.NoError(t, local.UpdateFile("team/_folder.json", string(folderMetadataJSON("cleanup-v2", "Team v2"))))
@@ -1086,11 +1086,11 @@ func TestIntegrationProvisioning_IncrementalSync_FolderUIDChange(t *testing.T) {
 		require.NoError(t, err)
 
 		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
-		common.RequireRepoFolderCount(t, helper, repoName, 1)
+		helper.RequireRepoFolderCount(t, repoName, 1)
 
 		// A subsequent full sync should be idempotent — still exactly 1 folder
 		helper.SyncAndWait(t, repoName)
-		common.RequireRepoFolderCount(t, helper, repoName, 1)
+		helper.RequireRepoFolderCount(t, repoName, 1)
 
 		_, err = helper.Folders.Resource.Get(t.Context(), "cleanup-v2", metav1.GetOptions{})
 		require.NoError(t, err, "current folder should still exist")
@@ -1504,7 +1504,7 @@ func TestIntegrationProvisioning_IncrementalSync_RenamedFolderMetadataOrphanClea
 
 		// Only one folder should exist for this repo.
 		common.RequireRepoFolders(t, helper.Folders, repoName, []string{"new-empty"})
-		common.RequireRepoFolderCount(t, helper, repoName, 1)
+		helper.RequireRepoFolderCount(t, repoName, 1)
 	})
 }
 

--- a/pkg/tests/apis/provisioning/foldermetadata/incremental/incremental_invalid_folder_metadata_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/incremental/incremental_invalid_folder_metadata_test.go
@@ -23,10 +23,10 @@ func TestIntegrationProvisioning_IncrementalSync_InvalidFolderMetadata(t *testin
 	helper := sharedGitHelper(t)
 
 	t.Run("invalid metadata creation on existing folder keeps unstable uid and reconciles changed child", func(t *testing.T) {
-		ctx := context.Background()
 		const repoName = "incr-invalid-meta-existing"
 		t.Cleanup(func() {
-			require.NoError(t, helper.Repositories.Resource.Delete(ctx, repoName, metav1.DeleteOptions{}))
+			cleanupCtx := context.WithoutCancel(t.Context())
+			require.NoError(t, helper.Repositories.Resource.Delete(cleanupCtx, repoName, metav1.DeleteOptions{}))
 		})
 
 		_, local := helper.CreateGitRepo(t, repoName, map[string][]byte{
@@ -34,7 +34,7 @@ func TestIntegrationProvisioning_IncrementalSync_InvalidFolderMetadata(t *testin
 		})
 
 		common.SyncAndWait(t, helper, common.Repo(repoName), common.Warning())
-		oldUID := common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "team")
+		oldUID := common.RequireRepoFolderTitle(t, helper.Folders, repoName, "team")
 
 		require.NoError(t, local.CreateFile("team/_folder.json", string(invalidFolderMetadataJSON("Broken Team"))))
 		require.NoError(t, local.CreateFile("team/dashboard.json", string(common.DashboardJSON("team-dash", "Team Dashboard Updated", 1))))
@@ -56,18 +56,18 @@ func TestIntegrationProvisioning_IncrementalSync_InvalidFolderMetadata(t *testin
 		require.Equal(t, provisioning.JobStateWarning, jobObj.Status.State)
 		requireInvalidFolderMetadataWarning(t, jobObj, "team/", repository.FileActionCreated)
 
-		common.RequireRepoFolderUID(t, helper.Folders, ctx, repoName, oldUID)
-		common.RequireRepoDashboardParent(t, helper.DashboardsV1, ctx, repoName, "team/dashboard.json", oldUID)
-		common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+		common.RequireRepoFolderUID(t, helper.Folders, repoName, oldUID)
+		common.RequireRepoDashboardParent(t, helper.DashboardsV1, repoName, "team/dashboard.json", oldUID)
+		common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 			"team-dash": {Title: "Team Dashboard Updated", SourcePath: "team/dashboard.json", Folder: oldUID},
 		})
 	})
 
 	t.Run("invalid metadata on new folder falls back to unstable uid and reconciles children", func(t *testing.T) {
-		ctx := context.Background()
 		const repoName = "incr-invalid-meta-new"
 		t.Cleanup(func() {
-			require.NoError(t, helper.Repositories.Resource.Delete(ctx, repoName, metav1.DeleteOptions{}))
+			cleanupCtx := context.WithoutCancel(t.Context())
+			require.NoError(t, helper.Repositories.Resource.Delete(cleanupCtx, repoName, metav1.DeleteOptions{}))
 		})
 
 		_, local := helper.CreateGitRepo(t, repoName, map[string][]byte{
@@ -96,20 +96,20 @@ func TestIntegrationProvisioning_IncrementalSync_InvalidFolderMetadata(t *testin
 		require.Equal(t, provisioning.JobStateWarning, jobObj.Status.State)
 		requireInvalidFolderMetadataWarning(t, jobObj, "team/", repository.FileActionCreated)
 
-		folderUID := common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "team")
-		common.RequireRepoDashboardParent(t, helper.DashboardsV1, ctx, repoName, "team/dashboard.json", folderUID)
-		common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+		folderUID := common.RequireRepoFolderTitle(t, helper.Folders, repoName, "team")
+		common.RequireRepoDashboardParent(t, helper.DashboardsV1, repoName, "team/dashboard.json", folderUID)
+		common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 			"root-dash": {Title: "Root Dashboard", SourcePath: "root.json"},
 			"team-dash": {Title: "Team Dashboard", SourcePath: "team/dashboard.json", Folder: folderUID},
 		})
 	})
 
 	t.Run("invalid metadata update on stable folder keeps stable uid and reconciles changed child", func(t *testing.T) {
-		ctx := context.Background()
 		const repoName = "incr-invalid-meta-update"
 		const stableUID = "team-stable-uid"
 		t.Cleanup(func() {
-			require.NoError(t, helper.Repositories.Resource.Delete(ctx, repoName, metav1.DeleteOptions{}))
+			cleanupCtx := context.WithoutCancel(t.Context())
+			require.NoError(t, helper.Repositories.Resource.Delete(cleanupCtx, repoName, metav1.DeleteOptions{}))
 		})
 
 		_, local := helper.CreateGitRepo(t, repoName, map[string][]byte{
@@ -139,19 +139,19 @@ func TestIntegrationProvisioning_IncrementalSync_InvalidFolderMetadata(t *testin
 		require.Equal(t, provisioning.JobStateWarning, jobObj.Status.State)
 		requireInvalidFolderMetadataWarning(t, jobObj, "team/", repository.FileActionUpdated)
 
-		common.RequireRepoFolderUID(t, helper.Folders, ctx, repoName, stableUID)
-		common.RequireRepoDashboardParent(t, helper.DashboardsV1, ctx, repoName, "team/dashboard.json", stableUID)
-		common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+		common.RequireRepoFolderUID(t, helper.Folders, repoName, stableUID)
+		common.RequireRepoDashboardParent(t, helper.DashboardsV1, repoName, "team/dashboard.json", stableUID)
+		common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 			"team-dash": {Title: "Team Dashboard Updated", SourcePath: "team/dashboard.json", Folder: stableUID},
 		})
 	})
 
 	t.Run("follow-up child update under already-invalid metadata keeps the existing stable uid", func(t *testing.T) {
-		ctx := context.Background()
 		const repoName = "incr-invalid-meta-follow-up-child"
 		const stableUID = "team-stable-uid"
 		t.Cleanup(func() {
-			require.NoError(t, helper.Repositories.Resource.Delete(ctx, repoName, metav1.DeleteOptions{}))
+			cleanupCtx := context.WithoutCancel(t.Context())
+			require.NoError(t, helper.Repositories.Resource.Delete(cleanupCtx, repoName, metav1.DeleteOptions{}))
 		})
 
 		_, local := helper.CreateGitRepo(t, repoName, map[string][]byte{
@@ -196,21 +196,21 @@ func TestIntegrationProvisioning_IncrementalSync_InvalidFolderMetadata(t *testin
 		require.Empty(t, jobObj.Status.Errors)
 		require.Equal(t, provisioning.JobStateSuccess, jobObj.Status.State)
 
-		common.RequireRepoFolderUID(t, helper.Folders, ctx, repoName, stableUID)
-		common.RequireRepoDashboardParent(t, helper.DashboardsV1, ctx, repoName, "team/dashboard.json", stableUID)
-		common.RequireRepoFolderCount(t, helper, ctx, repoName, 1)
-		common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+		common.RequireRepoFolderUID(t, helper.Folders, repoName, stableUID)
+		common.RequireRepoDashboardParent(t, helper.DashboardsV1, repoName, "team/dashboard.json", stableUID)
+		common.RequireRepoFolderCount(t, helper, repoName, 1)
+		common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 			"team-dash": {Title: "Team Dashboard Follow-up", SourcePath: "team/dashboard.json", Folder: stableUID},
 		})
 	})
 
 	t.Run("invalid metadata creation on existing folder does not break valid folder meta creation on another folder in the same incremental sync", func(t *testing.T) {
-		ctx := context.Background()
 		const repoName = "incr-invalid-meta-with-valid-replaced"
 		const parentStableUID = "parent-stable-uid"
 		const childUID = "child-stable-uid"
 		t.Cleanup(func() {
-			require.NoError(t, helper.Repositories.Resource.Delete(ctx, repoName, metav1.DeleteOptions{}))
+			cleanupCtx := context.WithoutCancel(t.Context())
+			require.NoError(t, helper.Repositories.Resource.Delete(cleanupCtx, repoName, metav1.DeleteOptions{}))
 		})
 
 		_, local := helper.CreateGitRepo(t, repoName, map[string][]byte{
@@ -222,8 +222,8 @@ func TestIntegrationProvisioning_IncrementalSync_InvalidFolderMetadata(t *testin
 
 		common.SyncAndWait(t, helper, common.Repo(repoName), common.Warning())
 
-		oldBrokenUID := common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "broken")
-		oldParentUID := common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "parent")
+		oldBrokenUID := common.RequireRepoFolderTitle(t, helper.Folders, repoName, "broken")
+		oldParentUID := common.RequireRepoFolderTitle(t, helper.Folders, repoName, "parent")
 		require.NotEqual(t, parentStableUID, oldParentUID, "parent should start with an unstable uid")
 		common.RequireFolderState(t, helper.Folders, childUID, "Child", "parent/child", oldParentUID)
 
@@ -247,23 +247,23 @@ func TestIntegrationProvisioning_IncrementalSync_InvalidFolderMetadata(t *testin
 		require.Equal(t, provisioning.JobStateWarning, jobObj.Status.State)
 		requireInvalidFolderMetadataWarning(t, jobObj, "broken/", repository.FileActionCreated)
 
-		common.RequireRepoFolderUID(t, helper.Folders, ctx, repoName, parentStableUID)
+		common.RequireRepoFolderUID(t, helper.Folders, repoName, parentStableUID)
 		common.RequireFolderState(t, helper.Folders, childUID, "Child", "parent/child", parentStableUID)
-		common.RequireRepoDashboardParent(t, helper.DashboardsV1, ctx, repoName, "parent/child/dashboard.json", childUID)
-		common.RequireRepoDashboardParent(t, helper.DashboardsV1, ctx, repoName, "parent/child/second-dash.json", childUID)
+		common.RequireRepoDashboardParent(t, helper.DashboardsV1, repoName, "parent/child/dashboard.json", childUID)
+		common.RequireRepoDashboardParent(t, helper.DashboardsV1, repoName, "parent/child/second-dash.json", childUID)
 
-		_, err = helper.Folders.Resource.Get(ctx, oldParentUID, metav1.GetOptions{})
+		_, err = helper.Folders.Resource.Get(t.Context(), oldParentUID, metav1.GetOptions{})
 		require.Error(t, err)
 		require.True(t, apierrors.IsNotFound(err), "old unstable parent folder should be deleted")
 
-		common.RequireRepoFolderUID(t, helper.Folders, ctx, repoName, oldBrokenUID)
+		common.RequireRepoFolderUID(t, helper.Folders, repoName, oldBrokenUID)
 	})
 
 	t.Run("moving a resource into an existing folder with invalid metadata still works", func(t *testing.T) {
-		ctx := context.Background()
 		const repoName = "incr-invalid-meta-move-into-existing"
 		t.Cleanup(func() {
-			require.NoError(t, helper.Repositories.Resource.Delete(ctx, repoName, metav1.DeleteOptions{}))
+			cleanupCtx := context.WithoutCancel(t.Context())
+			require.NoError(t, helper.Repositories.Resource.Delete(cleanupCtx, repoName, metav1.DeleteOptions{}))
 		})
 
 		_, local := helper.CreateGitRepo(t, repoName, map[string][]byte{
@@ -275,7 +275,7 @@ func TestIntegrationProvisioning_IncrementalSync_InvalidFolderMetadata(t *testin
 			Action: provisioning.JobActionPull,
 			Pull:   &provisioning.SyncJobOptions{Incremental: true},
 		})
-		folderUID := common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "team")
+		folderUID := common.RequireRepoFolderTitle(t, helper.Folders, repoName, "team")
 
 		_, err := local.Git("mv", "root.json", "team/root.json")
 		require.NoError(t, err)
@@ -293,17 +293,17 @@ func TestIntegrationProvisioning_IncrementalSync_InvalidFolderMetadata(t *testin
 
 		require.Empty(t, jobObj.Status.Errors)
 		require.Equal(t, provisioning.JobStateSuccess, jobObj.Status.State)
-		common.RequireRepoDashboardParent(t, helper.DashboardsV1, ctx, repoName, "team/root.json", folderUID)
-		common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+		common.RequireRepoDashboardParent(t, helper.DashboardsV1, repoName, "team/root.json", folderUID)
+		common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 			"root-dash": {Title: "Root Dashboard", SourcePath: "team/root.json", Folder: folderUID},
 		})
 	})
 
 	t.Run("moving a resource into a new folder with invalid metadata falls back to unstable uid", func(t *testing.T) {
-		ctx := context.Background()
 		const repoName = "incr-invalid-meta-move-into-new"
 		t.Cleanup(func() {
-			require.NoError(t, helper.Repositories.Resource.Delete(ctx, repoName, metav1.DeleteOptions{}))
+			cleanupCtx := context.WithoutCancel(t.Context())
+			require.NoError(t, helper.Repositories.Resource.Delete(cleanupCtx, repoName, metav1.DeleteOptions{}))
 		})
 
 		_, local := helper.CreateGitRepo(t, repoName, map[string][]byte{
@@ -333,19 +333,19 @@ func TestIntegrationProvisioning_IncrementalSync_InvalidFolderMetadata(t *testin
 		require.Equal(t, provisioning.JobStateWarning, jobObj.Status.State)
 		requireInvalidFolderMetadataWarning(t, jobObj, "team/", repository.FileActionCreated)
 
-		folderUID := common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "team")
-		common.RequireRepoDashboardParent(t, helper.DashboardsV1, ctx, repoName, "team/root.json", folderUID)
-		common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+		folderUID := common.RequireRepoFolderTitle(t, helper.Folders, repoName, "team")
+		common.RequireRepoDashboardParent(t, helper.DashboardsV1, repoName, "team/root.json", folderUID)
+		common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 			"root-dash": {Title: "Root Dashboard", SourcePath: "team/root.json", Folder: folderUID},
 		})
 	})
 
 	t.Run("moving a folder with invalid metadata falls back to delete and recreate", func(t *testing.T) {
-		ctx := context.Background()
 		const repoName = "incr-invalid-meta-folder-move"
 		const stableUID = "team-stable-uid"
 		t.Cleanup(func() {
-			require.NoError(t, helper.Repositories.Resource.Delete(ctx, repoName, metav1.DeleteOptions{}))
+			cleanupCtx := context.WithoutCancel(t.Context())
+			require.NoError(t, helper.Repositories.Resource.Delete(cleanupCtx, repoName, metav1.DeleteOptions{}))
 		})
 
 		_, local := helper.CreateGitRepo(t, repoName, map[string][]byte{
@@ -376,26 +376,26 @@ func TestIntegrationProvisioning_IncrementalSync_InvalidFolderMetadata(t *testin
 		require.Equal(t, provisioning.JobStateWarning, jobObj.Status.State)
 		requireInvalidFolderMetadataWarning(t, jobObj, "moved/", repository.FileActionCreated)
 
-		_, err = helper.Folders.Resource.Get(ctx, stableUID, metav1.GetOptions{})
+		_, err = helper.Folders.Resource.Get(t.Context(), stableUID, metav1.GetOptions{})
 		require.Error(t, err)
 		require.True(t, apierrors.IsNotFound(err))
 
-		newUID := common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "moved")
+		newUID := common.RequireRepoFolderTitle(t, helper.Folders, repoName, "moved")
 		require.NotEqual(t, stableUID, newUID)
 
-		common.RequireRepoDashboardParent(t, helper.DashboardsV1, ctx, repoName, "moved/dashboard.json", newUID)
-		common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+		common.RequireRepoDashboardParent(t, helper.DashboardsV1, repoName, "moved/dashboard.json", newUID)
+		common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 			"team-dash": {Title: "Team Dashboard", SourcePath: "moved/dashboard.json", Folder: newUID},
 		})
 	})
 
 	t.Run("invalid metadata creation does not break valid metadata-backed folder rename in the same incremental sync", func(t *testing.T) {
-		ctx := context.Background()
 		const repoName = "incr-invalid-meta-with-valid-rename"
 		const parentStableUID = "parent-stable-uid"
 		const childUID = "child-stable-uid"
 		t.Cleanup(func() {
-			require.NoError(t, helper.Repositories.Resource.Delete(ctx, repoName, metav1.DeleteOptions{}))
+			cleanupCtx := context.WithoutCancel(t.Context())
+			require.NoError(t, helper.Repositories.Resource.Delete(cleanupCtx, repoName, metav1.DeleteOptions{}))
 		})
 
 		_, local := helper.CreateGitRepo(t, repoName, map[string][]byte{
@@ -433,9 +433,9 @@ func TestIntegrationProvisioning_IncrementalSync_InvalidFolderMetadata(t *testin
 
 		common.RequireFolderState(t, helper.Folders, parentStableUID, "Parent", "new-parent", "")
 		common.RequireFolderState(t, helper.Folders, childUID, "Child", "new-parent/child", parentStableUID)
-		common.RequireRepoDashboardParent(t, helper.DashboardsV1, ctx, repoName, "new-parent/child/dashboard.json", childUID)
-		common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
-			"broken-dash": {Title: "Broken Dashboard", SourcePath: "broken/dashboard.json", Folder: common.RequireRepoFolderTitle(t, helper.Folders, ctx, repoName, "broken")},
+		common.RequireRepoDashboardParent(t, helper.DashboardsV1, repoName, "new-parent/child/dashboard.json", childUID)
+		common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
+			"broken-dash": {Title: "Broken Dashboard", SourcePath: "broken/dashboard.json", Folder: common.RequireRepoFolderTitle(t, helper.Folders, repoName, "broken")},
 			"child-dash":  {Title: "Child Dashboard", SourcePath: "new-parent/child/dashboard.json", Folder: childUID},
 		})
 	})

--- a/pkg/tests/apis/provisioning/foldermetadata/incremental/incremental_invalid_folder_metadata_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/incremental/incremental_invalid_folder_metadata_test.go
@@ -198,7 +198,7 @@ func TestIntegrationProvisioning_IncrementalSync_InvalidFolderMetadata(t *testin
 
 		common.RequireRepoFolderUID(t, helper.Folders, repoName, stableUID)
 		common.RequireRepoDashboardParent(t, helper.DashboardsV1, repoName, "team/dashboard.json", stableUID)
-		common.RequireRepoFolderCount(t, helper, repoName, 1)
+		helper.RequireRepoFolderCount(t, repoName, 1)
 		common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 			"team-dash": {Title: "Team Dashboard Follow-up", SourcePath: "team/dashboard.json", Folder: stableUID},
 		})

--- a/pkg/tests/apis/provisioning/foldermetadata/incremental/incremental_permissions_move_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/incremental/incremental_permissions_move_test.go
@@ -1,7 +1,6 @@
 package incremental
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -26,7 +25,6 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMovePermissions(t *testin
 	testutil.SkipIntegrationTestInShortMode(t)
 
 	helper := sharedGitHelper(t)
-	ctx := context.Background()
 	addr := helper.GetEnv().Server.HTTPServer.Listener.Addr().String()
 
 	// FolderMovePreservesPermissions verifies that custom permissions set on a
@@ -42,8 +40,8 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMovePermissions(t *testin
 
 		common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
 
-		requireGitFolderState(t, helper, ctx, "team-a-uid", "Team A", "teamA", repoName)
-		requireGitFolderState(t, helper, ctx, "team-b-uid", "Team B", "teamB", repoName)
+		requireGitFolderState(t, helper, "team-a-uid", "Team A", "teamA", repoName)
+		requireGitFolderState(t, helper, "team-b-uid", "Team B", "teamB", repoName)
 
 		// Set a known ACL on teamA (check 4) so we can assert it is not touched when
 		// a child folder is moved into it.
@@ -91,7 +89,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMovePermissions(t *testin
 		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 
 		// teamB should now live under teamA with the same stable UID.
-		requireGitFolderState(t, helper, ctx, "team-b-uid", "Team B", "teamA/teamB", "team-a-uid")
+		requireGitFolderState(t, helper, "team-b-uid", "Team B", "teamA/teamB", "team-a-uid")
 
 		teamBPermsAfter := snapshotFolderPermissions(t, addr, "team-b-uid")
 
@@ -129,8 +127,8 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMovePermissions(t *testin
 
 		common.SyncAndWait(t, helper, common.Repo(repoName), common.Warning())
 
-		requireGitFolderState(t, helper, ctx, "parent-uid", "Parent", "parent", repoName)
-		plainUID := findGitFolderUIDBySourcePath(t, helper, ctx, repoName, "plain")
+		requireGitFolderState(t, helper, "parent-uid", "Parent", "parent", repoName)
+		plainUID := findGitFolderUIDBySourcePath(t, helper, repoName, "plain")
 		require.NotEmpty(t, plainUID)
 
 		// Set a Viewer permission on the legacy (no-metadata) folder.
@@ -162,10 +160,10 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMovePermissions(t *testin
 
 		// The old folder object must be gone — without metadata the path change
 		// causes a delete-and-recreate rather than an in-place update.
-		assertGitFolderAbsent(t, helper, ctx, plainUID)
+		assertGitFolderAbsent(t, helper, plainUID)
 
 		// The new folder at the moved path must exist with a different (hash-based) UID.
-		newPlainUID := findGitFolderUIDBySourcePath(t, helper, ctx, repoName, "parent/plain")
+		newPlainUID := findGitFolderUIDBySourcePath(t, helper, repoName, "parent/plain")
 		require.NotEmpty(t, newPlainUID)
 		require.NotEqual(t, plainUID, newPlainUID,
 			"legacy folder must get a new UID when its path changes")
@@ -201,10 +199,10 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMovePermissions(t *testin
 
 		common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
 
-		requireGitFolderState(t, helper, ctx, "root-uid", "Root", "root", repoName)
-		requireGitFolderState(t, helper, ctx, "child-uid", "Child", "root/child", "root-uid")
-		requireGitFolderState(t, helper, ctx, "grandchild-uid", "Grandchild", "root/child/grandchild", "child-uid")
-		requireGitFolderState(t, helper, ctx, "destination-uid", "Destination", "destination", repoName)
+		requireGitFolderState(t, helper, "root-uid", "Root", "root", repoName)
+		requireGitFolderState(t, helper, "child-uid", "Child", "root/child", "root-uid")
+		requireGitFolderState(t, helper, "grandchild-uid", "Grandchild", "root/child/grandchild", "child-uid")
+		requireGitFolderState(t, helper, "destination-uid", "Destination", "destination", repoName)
 
 		// Grant Editor permission on the deepest (grandchild) folder.
 		_, code, err := common.PostHelper(t, *helper.K8sTestHelper,
@@ -231,9 +229,9 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMovePermissions(t *testin
 
 		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 
-		requireGitFolderState(t, helper, ctx, "destination-uid", "Destination", "destination", repoName)
-		requireGitFolderState(t, helper, ctx, "child-uid", "Child", "destination/child", "destination-uid")
-		requireGitFolderState(t, helper, ctx, "grandchild-uid", "Grandchild", "destination/child/grandchild", "child-uid")
+		requireGitFolderState(t, helper, "destination-uid", "Destination", "destination", repoName)
+		requireGitFolderState(t, helper, "child-uid", "Child", "destination/child", "destination-uid")
+		requireGitFolderState(t, helper, "grandchild-uid", "Grandchild", "destination/child/grandchild", "child-uid")
 
 		grandchildPermsAfter := snapshotFolderPermissions(t, addr, "grandchild-uid")
 		require.Equal(t, len(grandchildPermsBefore), len(grandchildPermsAfter),
@@ -255,9 +253,9 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMovePermissions(t *testin
 
 		common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
 
-		requireGitFolderState(t, helper, ctx, "top-uid", "Top", "top", repoName)
-		requireGitFolderState(t, helper, ctx, "container-uid", "Container", "container", repoName)
-		requireGitFolderState(t, helper, ctx, "inner-uid", "Inner", "container/inner", "container-uid")
+		requireGitFolderState(t, helper, "top-uid", "Top", "top", repoName)
+		requireGitFolderState(t, helper, "container-uid", "Container", "container", repoName)
+		requireGitFolderState(t, helper, "inner-uid", "Inner", "container/inner", "container-uid")
 
 		// Grant Viewer permission on the root-level "top" folder before the move.
 		_, code, err := common.PostHelper(t, *helper.K8sTestHelper,
@@ -284,7 +282,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMovePermissions(t *testin
 
 		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 
-		requireGitFolderState(t, helper, ctx, "top-uid", "Top", "container/inner/top", "inner-uid")
+		requireGitFolderState(t, helper, "top-uid", "Top", "container/inner/top", "inner-uid")
 
 		topPermsAfter := snapshotFolderPermissions(t, addr, "top-uid")
 		require.Equal(t, len(topPermsBefore), len(topPermsAfter),
@@ -311,9 +309,9 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMovePermissions(t *testin
 
 		common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
 
-		requireGitFolderState(t, helper, ctx, "ltroot-parent-uid", "Parent", "parent", repoName)
-		requireGitFolderState(t, helper, ctx, "ltroot-deep-uid", "Deep", "parent/deep", "ltroot-parent-uid")
-		requireGitFolderState(t, helper, ctx, "ltroot-leaf-uid", "Leaf", "parent/deep/leaf", "ltroot-deep-uid")
+		requireGitFolderState(t, helper, "ltroot-parent-uid", "Parent", "parent", repoName)
+		requireGitFolderState(t, helper, "ltroot-deep-uid", "Deep", "parent/deep", "ltroot-parent-uid")
+		requireGitFolderState(t, helper, "ltroot-leaf-uid", "Leaf", "parent/deep/leaf", "ltroot-deep-uid")
 
 		// Grant Editor permission on the deeply nested leaf folder.
 		_, code, err := common.PostHelper(t, *helper.K8sTestHelper,
@@ -340,7 +338,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMovePermissions(t *testin
 
 		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 
-		requireGitFolderState(t, helper, ctx, "ltroot-leaf-uid", "Leaf", "leaf", repoName)
+		requireGitFolderState(t, helper, "ltroot-leaf-uid", "Leaf", "leaf", repoName)
 
 		leafPermsAfter := snapshotFolderPermissions(t, addr, "ltroot-leaf-uid")
 		require.Equal(t, len(leafPermsBefore), len(leafPermsAfter),
@@ -363,8 +361,8 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMovePermissions(t *testin
 		// legacy-parent has no _folder.json, so the sync correctly warns about missing metadata.
 		common.SyncAndWait(t, helper, common.Repo(repoName), common.Warning())
 
-		requireGitFolderState(t, helper, ctx, "child-meta-uid", "Child With Meta", "child-with-meta", repoName)
-		legacyParentUID := findGitFolderUIDBySourcePath(t, helper, ctx, repoName, "legacy-parent")
+		requireGitFolderState(t, helper, "child-meta-uid", "Child With Meta", "child-with-meta", repoName)
+		legacyParentUID := findGitFolderUIDBySourcePath(t, helper, repoName, "legacy-parent")
 		require.NotEmpty(t, legacyParentUID)
 
 		// Set Viewer permission on the metadata-backed child folder.
@@ -395,10 +393,10 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMovePermissions(t *testin
 		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Warning())
 
 		// The legacy parent keeps its original hash-based UID (its path did not change).
-		requireGitFolderState(t, helper, ctx, legacyParentUID, "legacy-parent", "legacy-parent", repoName)
+		requireGitFolderState(t, helper, legacyParentUID, "legacy-parent", "legacy-parent", repoName)
 
 		// The metadata child retains its stable UID and is now under the legacy parent.
-		requireGitFolderState(t, helper, ctx, "child-meta-uid", "Child With Meta", "legacy-parent/child-with-meta", legacyParentUID)
+		requireGitFolderState(t, helper, "child-meta-uid", "Child With Meta", "legacy-parent/child-with-meta", legacyParentUID)
 
 		childPermsAfter := snapshotFolderPermissions(t, addr, "child-meta-uid")
 		require.Equal(t, len(childPermsBefore), len(childPermsAfter),
@@ -412,10 +410,10 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMovePermissions(t *testin
 // requireGitFolderState asserts that a folder tracked by the gitTestHelper has the expected
 // title, sourcePath annotation, and parent annotation. It polls until the state matches or the
 // timeout expires, so it is safe to call immediately after triggering an incremental sync.
-func requireGitFolderState(t *testing.T, h *common.GitTestHelper, ctx context.Context, folderUID, expectedTitle, expectedSourcePath, expectedParent string) {
+func requireGitFolderState(t *testing.T, h *common.GitTestHelper, folderUID, expectedTitle, expectedSourcePath, expectedParent string) {
 	t.Helper()
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		obj, err := h.Folders.Resource.Get(ctx, folderUID, metav1.GetOptions{})
+		obj, err := h.Folders.Resource.Get(t.Context(), folderUID, metav1.GetOptions{})
 		if !assert.NoError(c, err, "failed to get folder %s", folderUID) {
 			return
 		}
@@ -435,11 +433,11 @@ func requireGitFolderState(t *testing.T, h *common.GitTestHelper, ctx context.Co
 
 // findGitFolderUIDBySourcePath returns the UID of the folder managed by repoName at sourcePath.
 // It polls until the folder appears or the timeout expires.
-func findGitFolderUIDBySourcePath(t *testing.T, h *common.GitTestHelper, ctx context.Context, repoName, sourcePath string) string {
+func findGitFolderUIDBySourcePath(t *testing.T, h *common.GitTestHelper, repoName, sourcePath string) string {
 	t.Helper()
 	var uid string
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		list, err := h.Folders.Resource.List(ctx, metav1.ListOptions{})
+		list, err := h.Folders.Resource.List(t.Context(), metav1.ListOptions{})
 		if !assert.NoError(c, err, "failed to list folders") {
 			return
 		}
@@ -460,10 +458,10 @@ func findGitFolderUIDBySourcePath(t *testing.T, h *common.GitTestHelper, ctx con
 }
 
 // assertGitFolderAbsent asserts that the folder with the given UID no longer exists.
-func assertGitFolderAbsent(t *testing.T, h *common.GitTestHelper, ctx context.Context, folderUID string) {
+func assertGitFolderAbsent(t *testing.T, h *common.GitTestHelper, folderUID string) {
 	t.Helper()
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		_, err := h.Folders.Resource.Get(ctx, folderUID, metav1.GetOptions{})
+		_, err := h.Folders.Resource.Get(t.Context(), folderUID, metav1.GetOptions{})
 		if err == nil {
 			c.Errorf("folder %q still exists, expected NotFound", folderUID)
 			return

--- a/pkg/tests/apis/provisioning/foldermetadata/incremental/incremental_permissions_move_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/incremental/incremental_permissions_move_test.go
@@ -25,6 +25,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMovePermissions(t *testin
 	testutil.SkipIntegrationTestInShortMode(t)
 
 	helper := sharedGitHelper(t)
+
 	addr := helper.GetEnv().Server.HTTPServer.Listener.Addr().String()
 
 	// FolderMovePreservesPermissions verifies that custom permissions set on a

--- a/pkg/tests/apis/provisioning/foldermetadata/jobs_auth_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/jobs_auth_test.go
@@ -16,14 +16,15 @@ func TestIntegrationProvisioning_JobsAuthorization(t *testing.T) {
 
 	const repo = "jobs-auth-test"
 	testRepo := common.TestRepo{
-		Name:               repo,
-		SyncTarget:         "folder",
-		Workflows:          []string{"write"},
-		Copies:             map[string]string{},
-		ExpectedDashboards: 0,
-		ExpectedFolders:    1,
+		Name:       repo,
+		SyncTarget: "folder",
+		Workflows:  []string{"write"},
+		Copies:     map[string]string{},
 	}
 	helper.CreateLocalRepo(t, testRepo)
+
+	helper.RequireRepoDashboardCount(t, repo, 0)
+	helper.RequireRepoFolderCount(t, repo, 1)
 
 	t.Run("admin can LIST jobs", func(t *testing.T) {
 		var statusCode int

--- a/pkg/tests/apis/provisioning/foldermetadata/jobs_auth_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/jobs_auth_test.go
@@ -1,7 +1,6 @@
 package foldermetadata
 
 import (
-	"context"
 	"net/http"
 	"testing"
 
@@ -14,7 +13,6 @@ import (
 
 func TestIntegrationProvisioning_JobsAuthorization(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	const repo = "jobs-auth-test"
 	testRepo := common.TestRepo{
@@ -32,7 +30,7 @@ func TestIntegrationProvisioning_JobsAuthorization(t *testing.T) {
 		result := helper.AdminREST.Get().
 			Namespace("default").
 			Resource("jobs").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.NoError(t, result.Error(), "admin should be able to LIST jobs")
 		require.Equal(t, http.StatusOK, statusCode, "should return 200 OK")
@@ -43,7 +41,7 @@ func TestIntegrationProvisioning_JobsAuthorization(t *testing.T) {
 		result := helper.EditorREST.Get().
 			Namespace("default").
 			Resource("jobs").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.NoError(t, result.Error(), "editor should be able to LIST jobs")
 		require.Equal(t, http.StatusOK, statusCode, "should return 200 OK")
@@ -54,7 +52,7 @@ func TestIntegrationProvisioning_JobsAuthorization(t *testing.T) {
 		result := helper.ViewerREST.Get().
 			Namespace("default").
 			Resource("jobs").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.Error(t, result.Error(), "viewer should not be able to LIST jobs")
 		require.Equal(t, http.StatusForbidden, statusCode, "should return 403 Forbidden")
@@ -75,7 +73,7 @@ func TestIntegrationProvisioning_JobsAuthorization(t *testing.T) {
 			SubResource("jobs").
 			Body(body).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.NoError(t, result.Error(), "admin should be able to create job")
 		require.Equal(t, http.StatusAccepted, statusCode, "should return 202 Accepted")
@@ -96,7 +94,7 @@ func TestIntegrationProvisioning_JobsAuthorization(t *testing.T) {
 			SubResource("jobs").
 			Body(body).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.NoError(t, result.Error(), "editor should be able to create job")
 		require.Equal(t, http.StatusAccepted, statusCode, "should return 202 Accepted")
@@ -117,7 +115,7 @@ func TestIntegrationProvisioning_JobsAuthorization(t *testing.T) {
 			SubResource("jobs").
 			Body(body).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.Error(t, result.Error(), "viewer should not be able to create job")
 		require.Equal(t, http.StatusForbidden, statusCode, "should return 403 Forbidden")

--- a/pkg/tests/apis/provisioning/foldermetadata/migrate_folder_ids_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/migrate_folder_ids_test.go
@@ -47,10 +47,9 @@ func TestIntegrationProvisioning_MigrateJob_GenerateNewFolderIDs(t *testing.T) {
 	)
 
 	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:                   repo,
-		SyncTarget:             "folder",
-		Workflows:              []string{"write"},
-		SkipResourceAssertions: true,
+		Name:       repo,
+		SyncTarget: "folder",
+		Workflows:  []string{"write"},
 	})
 
 	createUnmanagedFolder(t, helper, parentUID, parentTitle)

--- a/pkg/tests/apis/provisioning/foldermetadata/migrate_folder_ids_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/migrate_folder_ids_test.go
@@ -37,7 +37,6 @@ func TestIntegrationProvisioning_MigrateJob_GenerateNewFolderIDs(t *testing.T) {
 	}
 
 	helper := sharedHelper(t)
-	ctx := t.Context()
 
 	const (
 		repo        = "migrate-newids-repo"
@@ -83,14 +82,14 @@ func TestIntegrationProvisioning_MigrateJob_GenerateNewFolderIDs(t *testing.T) {
 	// After the sync phase the new UIDs exist as managed folders, and the nested
 	// parent/child relationship is preserved through the new UIDs.
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		newParent, err := helper.Folders.Resource.Get(ctx, newParentUID, metav1.GetOptions{})
+		newParent, err := helper.Folders.Resource.Get(t.Context(), newParentUID, metav1.GetOptions{})
 		if !assert.NoError(collect, err, "new parent folder %q should exist after migrate", newParentUID) {
 			return
 		}
 		assert.Equal(collect, repo, newParent.GetAnnotations()[utils.AnnoKeyManagerIdentity],
 			"new parent folder should be managed by the repository")
 
-		newChild, err := helper.Folders.Resource.Get(ctx, newChildUID, metav1.GetOptions{})
+		newChild, err := helper.Folders.Resource.Get(t.Context(), newChildUID, metav1.GetOptions{})
 		if !assert.NoError(collect, err, "new child folder %q should exist after migrate", newChildUID) {
 			return
 		}

--- a/pkg/tests/apis/provisioning/foldermetadata/move_creation_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/move_creation_test.go
@@ -27,7 +27,7 @@ func TestIntegrationProvisioning_MoveFile_FolderMetadataFlag(t *testing.T) {
 
 	const repo = "folder-metadata-move-test-repo"
 	helper.CreateLocalRepo(t, common.TestRepo{
-		Name: repo, SyncTarget: "instance", Workflows: []string{"write"}, SkipResourceAssertions: true,
+		Name: repo, SyncTarget: "instance", Workflows: []string{"write"},
 	})
 
 	files := helper.NewFilesClient(repo)

--- a/pkg/tests/apis/provisioning/foldermetadata/move_creation_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/move_creation_test.go
@@ -1,7 +1,6 @@
 package foldermetadata
 
 import (
-	"context"
 	"net/http"
 	"testing"
 
@@ -25,7 +24,6 @@ func move(t *testing.T, helper *common.ProvisioningTestHelper, repo, originalPat
 
 func TestIntegrationProvisioning_MoveFile_FolderMetadataFlag(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	const repo = "folder-metadata-move-test-repo"
 	helper.CreateLocalRepo(t, common.TestRepo{
@@ -41,13 +39,13 @@ func TestIntegrationProvisioning_MoveFile_FolderMetadataFlag(t *testing.T) {
 		move(t, helper, repo, "move-src-1.json", "move-dest-1/dashboard.json",
 			common.DashboardJSON("move-dash-1", "Move Dash 1 Updated", 2))
 
-		uid, title := files.RequireValidFolderMetadata(t, ctx, "move-dest-1/_folder.json")
+		uid, title := files.RequireValidFolderMetadata(t, "move-dest-1/_folder.json")
 		require.Equal(t, "move-dest-1", title)
 
-		_, err := helper.Folders.Resource.Get(ctx, uid, metav1.GetOptions{})
+		_, err := helper.Folders.Resource.Get(t.Context(), uid, metav1.GetOptions{})
 		require.NoError(t, err, "Grafana folder should exist with the UID from _folder.json")
 
-		_, err = helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "move-src-1.json")
+		_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "move-src-1.json")
 		require.Error(t, err, "original file should no longer exist after the move")
 	})
 
@@ -58,21 +56,21 @@ func TestIntegrationProvisioning_MoveFile_FolderMetadataFlag(t *testing.T) {
 		move(t, helper, repo, "move-src-2.json", "anc-x/anc-y/dashboard.json",
 			common.DashboardJSON("move-dash-2", "Move Dash 2 Updated", 2))
 
-		parentUID, _ := files.RequireValidFolderMetadata(t, ctx, "anc-x/_folder.json")
-		childUID, childTitle := files.RequireValidFolderMetadata(t, ctx, "anc-x/anc-y/_folder.json")
+		parentUID, _ := files.RequireValidFolderMetadata(t, "anc-x/_folder.json")
+		childUID, childTitle := files.RequireValidFolderMetadata(t, "anc-x/anc-y/_folder.json")
 		require.Equal(t, "anc-y", childTitle)
 		require.NotEqual(t, parentUID, childUID, "each ancestor folder gets a distinct UID")
 
-		_, err := helper.Folders.Resource.Get(ctx, parentUID, metav1.GetOptions{})
+		_, err := helper.Folders.Resource.Get(t.Context(), parentUID, metav1.GetOptions{})
 		require.NoError(t, err, "parent Grafana folder should exist")
-		_, err = helper.Folders.Resource.Get(ctx, childUID, metav1.GetOptions{})
+		_, err = helper.Folders.Resource.Get(t.Context(), childUID, metav1.GetOptions{})
 		require.NoError(t, err, "child Grafana folder should exist")
 	})
 
 	t.Run("move into existing managed folder does not change its _folder.json UID", func(t *testing.T) {
 		resp := files.Post(t, "existing-move-folder/", nil)
 		require.Equal(t, http.StatusOK, resp.StatusCode, "creating destination folder should succeed")
-		existingUID := files.ReadFolderUID(t, ctx, "existing-move-folder/_folder.json")
+		existingUID := files.ReadFolderUID(t, "existing-move-folder/_folder.json")
 		require.NotEmpty(t, existingUID)
 
 		resp = files.Post(t, "move-src-3.json", common.DashboardJSON("move-dash-3", "Move Dash 3", 1))
@@ -81,7 +79,7 @@ func TestIntegrationProvisioning_MoveFile_FolderMetadataFlag(t *testing.T) {
 		move(t, helper, repo, "move-src-3.json", "existing-move-folder/dashboard.json",
 			common.DashboardJSON("move-dash-3", "Move Dash 3 Updated", 2))
 
-		uidAfter := files.ReadFolderUID(t, ctx, "existing-move-folder/_folder.json")
+		uidAfter := files.ReadFolderUID(t, "existing-move-folder/_folder.json")
 		require.Equal(t, existingUID, uidAfter, "moving into an existing folder must not change its UID")
 	})
 
@@ -91,13 +89,13 @@ func TestIntegrationProvisioning_MoveFile_FolderMetadataFlag(t *testing.T) {
 
 		move(t, helper, repo, "move-src-4.json", "rename-dest/move-src-4.json", nil)
 
-		uid, title := files.RequireValidFolderMetadata(t, ctx, "rename-dest/_folder.json")
+		uid, title := files.RequireValidFolderMetadata(t, "rename-dest/_folder.json")
 		require.Equal(t, "rename-dest", title)
 
-		_, err := helper.Folders.Resource.Get(ctx, uid, metav1.GetOptions{})
+		_, err := helper.Folders.Resource.Get(t.Context(), uid, metav1.GetOptions{})
 		require.NoError(t, err, "Grafana folder should exist with the UID from _folder.json")
 
-		_, err = helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "move-src-4.json")
+		_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "move-src-4.json")
 		require.Error(t, err, "original file should no longer exist after the rename move")
 	})
 }

--- a/pkg/tests/apis/provisioning/foldermetadata/sync_folder_metadata_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/sync_folder_metadata_test.go
@@ -42,8 +42,7 @@ func TestIntegrationProvisioning_FullSync_MissingFolderMetadata_FlagEnabled(t *t
 				// Dashboard inside a folder that intentionally has no _folder.json
 				"../testdata/all-panels.json": "myfolder/dashboard.json",
 			},
-			SkipSync:               true,
-			SkipResourceAssertions: true,
+			SkipSync: true,
 		})
 
 		job := helper.TriggerJobAndWaitForComplete(t, repo, provisioning.JobSpec{
@@ -83,8 +82,7 @@ func TestIntegrationProvisioning_FullSync_MissingFolderMetadata_FlagEnabled(t *t
 				"../testdata/all-panels.json":    "folderA/dashboard1.json",
 				"../testdata/timeline-demo.json": "folderB/dashboard2.json",
 			},
-			SkipSync:               true,
-			SkipResourceAssertions: true,
+			SkipSync: true,
 		})
 
 		job := helper.TriggerJobAndWaitForComplete(t, repo, provisioning.JobSpec{
@@ -130,8 +128,7 @@ func TestIntegrationProvisioning_FullSync_MissingFolderMetadata_FlagEnabled(t *t
 				// Invalid dashboard at root → ResourceInvalid
 				"../testdata/dashboard-missing-name.json": "bad-dashboard.json",
 			},
-			SkipSync:               true,
-			SkipResourceAssertions: true,
+			SkipSync: true,
 		})
 
 		job := helper.TriggerJobAndWaitForComplete(t, repo, provisioning.JobSpec{
@@ -211,8 +208,7 @@ func TestIntegrationProvisioning_FullSync_FolderMetadataTitle(t *testing.T) {
 			Copies: map[string]string{
 				"../testdata/all-panels.json": "my-team/dashboard.json",
 			},
-			SkipSync:               true,
-			SkipResourceAssertions: true,
+			SkipSync: true,
 		})
 
 		helper.SyncAndWait(t, repo, nil)
@@ -233,8 +229,7 @@ func TestIntegrationProvisioning_FullSync_FolderMetadataTitle(t *testing.T) {
 			Copies: map[string]string{
 				"../testdata/all-panels.json": "reports/dashboard.json",
 			},
-			SkipSync:               true,
-			SkipResourceAssertions: true,
+			SkipSync: true,
 		})
 
 		helper.SyncAndWait(t, repo, nil)
@@ -252,8 +247,7 @@ func TestIntegrationProvisioning_FullSync_FolderMetadataTitle(t *testing.T) {
 			Copies: map[string]string{
 				"../testdata/all-panels.json": "analytics/dashboard.json",
 			},
-			SkipSync:               true,
-			SkipResourceAssertions: true,
+			SkipSync: true,
 		})
 
 		helper.SyncAndWait(t, repo, nil)
@@ -274,8 +268,7 @@ func TestIntegrationProvisioning_FullSync_FolderMetadataTitle(t *testing.T) {
 			Copies: map[string]string{
 				"../testdata/all-panels.json": "parent/child/dashboard.json",
 			},
-			SkipSync:               true,
-			SkipResourceAssertions: true,
+			SkipSync: true,
 		})
 
 		helper.SyncAndWait(t, repo, nil)
@@ -296,8 +289,7 @@ func TestIntegrationProvisioning_FullSync_FolderMetadataTitle(t *testing.T) {
 			Copies: map[string]string{
 				"../testdata/all-panels.json": "old-dir/dashboard.json",
 			},
-			SkipSync:               true,
-			SkipResourceAssertions: true,
+			SkipSync: true,
 		})
 
 		// First sync creates the folder with "My Team" title.
@@ -325,8 +317,7 @@ func TestIntegrationProvisioning_FullSync_FolderMetadataTitle(t *testing.T) {
 				// Folder has no _folder.json — title defaults to directory name.
 				"../testdata/all-panels.json": "old-name/dashboard.json",
 			},
-			SkipSync:               true,
-			SkipResourceAssertions: true,
+			SkipSync: true,
 		})
 
 		// First sync: folder title should equal the directory name "old-name".
@@ -387,8 +378,7 @@ func TestIntegrationProvisioning_FullSync_FolderMetadataChecksum(t *testing.T) {
 			Copies: map[string]string{
 				"../testdata/all-panels.json": "my-folder/dashboard.json",
 			},
-			SkipSync:               true,
-			SkipResourceAssertions: true,
+			SkipSync: true,
 		})
 
 		helper.SyncAndWait(t, repo, nil)
@@ -407,8 +397,7 @@ func TestIntegrationProvisioning_FullSync_FolderMetadataChecksum(t *testing.T) {
 			Copies: map[string]string{
 				"../testdata/all-panels.json": "plain-folder/dashboard.json",
 			},
-			SkipSync:               true,
-			SkipResourceAssertions: true,
+			SkipSync: true,
 		})
 
 		helper.SyncAndWait(t, repo, nil)
@@ -452,8 +441,7 @@ func TestIntegrationProvisioning_FullSync_FolderMetadataChecksum(t *testing.T) {
 			Copies: map[string]string{
 				"../testdata/all-panels.json": "parent/child/dashboard.json",
 			},
-			SkipSync:               true,
-			SkipResourceAssertions: true,
+			SkipSync: true,
 		})
 
 		helper.SyncAndWait(t, repo, nil)
@@ -480,8 +468,7 @@ func TestIntegrationProvisioning_FullSync_FolderMetadataReconciliation(t *testin
 			Copies: map[string]string{
 				"../testdata/all-panels.json": "my-folder/dashboard.json",
 			},
-			SkipSync:               true,
-			SkipResourceAssertions: true,
+			SkipSync: true,
 		})
 
 		helper.SyncAndWait(t, repo, nil)
@@ -511,8 +498,7 @@ func TestIntegrationProvisioning_FullSync_FolderMetadataReconciliation(t *testin
 			Copies: map[string]string{
 				"../testdata/all-panels.json": "my-folder/dashboard.json",
 			},
-			SkipSync:               true,
-			SkipResourceAssertions: true,
+			SkipSync: true,
 		})
 
 		helper.SyncAndWait(t, repo, nil)
@@ -543,8 +529,7 @@ func TestIntegrationProvisioning_FullSync_FolderMetadataUIDChange(t *testing.T) 
 			Copies: map[string]string{
 				"../testdata/all-panels.json": "my-folder/dashboard.json",
 			},
-			SkipSync:               true,
-			SkipResourceAssertions: true,
+			SkipSync: true,
 		})
 
 		helper.SyncAndWait(t, repo, nil)
@@ -610,8 +595,7 @@ func TestIntegrationProvisioning_FullSync_FolderMetadataUIDChange(t *testing.T) 
 			Copies: map[string]string{
 				"../testdata/all-panels.json": "parent/child/dashboard.json",
 			},
-			SkipSync:               true,
-			SkipResourceAssertions: true,
+			SkipSync: true,
 		})
 
 		helper.SyncAndWait(t, repo, nil)
@@ -655,8 +639,7 @@ func TestIntegrationProvisioning_FullSync_FolderMetadataUIDChange(t *testing.T) 
 			Copies: map[string]string{
 				"../testdata/all-panels.json": "parent/child/dashboard.json",
 			},
-			SkipSync:               true,
-			SkipResourceAssertions: true,
+			SkipSync: true,
 		})
 
 		helper.SyncAndWait(t, repo, nil)
@@ -697,8 +680,7 @@ func TestIntegrationProvisioning_FullSync_FolderMetadataUIDChange(t *testing.T) 
 			Copies: map[string]string{
 				"../testdata/all-panels.json": "root-folder/dashboard.json",
 			},
-			SkipSync:               true,
-			SkipResourceAssertions: true,
+			SkipSync: true,
 		})
 
 		helper.SyncAndWait(t, repo, nil)
@@ -741,8 +723,7 @@ func TestIntegrationProvisioning_FullSync_FolderMetadataDeletedReverts(t *testin
 			Copies: map[string]string{
 				"../testdata/all-panels.json": "my-folder/dashboard.json",
 			},
-			SkipSync:               true,
-			SkipResourceAssertions: true,
+			SkipSync: true,
 		})
 		helper.SyncAndWait(t, repo, nil)
 		common.RequireFolderState(t, helper.Folders, "stable-uid", "Custom Title", "my-folder", repo)
@@ -797,8 +778,7 @@ func TestIntegrationProvisioning_FullSync_FolderMetadataDeletedReverts(t *testin
 			Copies: map[string]string{
 				"../testdata/all-panels.json": "parent/child/dashboard.json",
 			},
-			SkipSync:               true,
-			SkipResourceAssertions: true,
+			SkipSync: true,
 		})
 		helper.SyncAndWait(t, repo, nil)
 		common.RequireFolderState(t, helper.Folders, "parent-uid", "Parent", "parent", repo)
@@ -858,8 +838,7 @@ func TestIntegrationProvisioning_FullSync_FolderMetadataDeletedReverts(t *testin
 			Copies: map[string]string{
 				"../testdata/all-panels.json": "parent/child/dashboard.json",
 			},
-			SkipSync:               true,
-			SkipResourceAssertions: true,
+			SkipSync: true,
 		})
 		helper.SyncAndWait(t, repo, nil)
 		common.RequireFolderState(t, helper.Folders, "parent-uid", "Parent", "parent", repo)

--- a/pkg/tests/apis/provisioning/foldermetadata/update_folder_metadata_git_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/update_folder_metadata_git_test.go
@@ -2,7 +2,6 @@ package foldermetadata
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -24,7 +23,6 @@ import (
 // The fix falls back to reading from the configured branch.
 func TestIntegrationGitFiles_UpdateFolderMetadataOnNewBranch(t *testing.T) {
 	helper := sharedGitHelper(t)
-	ctx := context.Background()
 
 	const repoName = "update-folder-metadata-branch"
 	helper.CreateGitRepo(t, repoName, nil, "write", "branch")
@@ -35,9 +33,9 @@ func TestIntegrationGitFiles_UpdateFolderMetadataOnNewBranch(t *testing.T) {
 	_ = resp.Body.Close()
 	require.Equal(t, http.StatusOK, resp.StatusCode, "creating folder on default branch should succeed: %s", string(body))
 
-	originalUID := readFolderFieldOnRef(t, helper, ctx, repoName, "rename-target/_folder.json", "", "metadata", "name")
+	originalUID := readFolderFieldOnRef(t, helper, repoName, "rename-target/_folder.json", "", "metadata", "name")
 	require.NotEmpty(t, originalUID, "setup: folder should have a UID")
-	originalTitle := readFolderFieldOnRef(t, helper, ctx, repoName, "rename-target/_folder.json", "", "spec", "title")
+	originalTitle := readFolderFieldOnRef(t, helper, repoName, "rename-target/_folder.json", "", "spec", "title")
 	require.NotEmpty(t, originalTitle, "setup: folder should have a title")
 
 	t.Run("rename folder on new branch succeeds", func(t *testing.T) {
@@ -51,17 +49,17 @@ func TestIntegrationGitFiles_UpdateFolderMetadataOnNewBranch(t *testing.T) {
 		require.Equal(t, http.StatusOK, resp.StatusCode, "PUT to rename folder on new branch should succeed: %s", string(body))
 
 		// The _folder.json on the new branch must have the updated title.
-		newTitle := readFolderFieldOnRef(t, helper, ctx, repoName,
+		newTitle := readFolderFieldOnRef(t, helper, repoName,
 			"rename-target/_folder.json", newBranch, "spec", "title")
 		require.Equal(t, "Renamed Title", newTitle, "title should be updated on the new branch")
 
 		// The UID must be preserved.
-		newUID := readFolderFieldOnRef(t, helper, ctx, repoName,
+		newUID := readFolderFieldOnRef(t, helper, repoName,
 			"rename-target/_folder.json", newBranch, "metadata", "name")
 		require.Equal(t, originalUID, newUID, "UID must not change after rename")
 
 		// The default branch must be untouched.
-		defaultTitle := readFolderFieldOnRef(t, helper, ctx, repoName,
+		defaultTitle := readFolderFieldOnRef(t, helper, repoName,
 			"rename-target/_folder.json", "", "spec", "title")
 		require.Equal(t, originalTitle, defaultTitle, "default branch title must not change")
 	})
@@ -85,11 +83,11 @@ func TestIntegrationGitFiles_UpdateFolderMetadataOnNewBranch(t *testing.T) {
 		_ = resp.Body.Close()
 		require.Equal(t, http.StatusOK, resp.StatusCode, "second rename on existing branch should succeed: %s", string(body))
 
-		title := readFolderFieldOnRef(t, helper, ctx, repoName,
+		title := readFolderFieldOnRef(t, helper, repoName,
 			"rename-target/_folder.json", branch, "spec", "title")
 		require.Equal(t, "Second Rename", title, "title should reflect the second rename")
 
-		uid := readFolderFieldOnRef(t, helper, ctx, repoName,
+		uid := readFolderFieldOnRef(t, helper, repoName,
 			"rename-target/_folder.json", branch, "metadata", "name")
 		require.Equal(t, originalUID, uid, "UID must not change after multiple renames")
 	})
@@ -101,7 +99,7 @@ func TestIntegrationGitFiles_UpdateFolderMetadataOnNewBranch(t *testing.T) {
 		_ = resp.Body.Close()
 		require.Equal(t, http.StatusOK, resp.StatusCode, "creating nested folder should succeed: %s", string(body))
 
-		childUID := readFolderFieldOnRef(t, helper, ctx, repoName,
+		childUID := readFolderFieldOnRef(t, helper, repoName,
 			"rename-target/child/_folder.json", "", "metadata", "name")
 		require.NotEmpty(t, childUID, "child folder should have a UID")
 
@@ -114,11 +112,11 @@ func TestIntegrationGitFiles_UpdateFolderMetadataOnNewBranch(t *testing.T) {
 		_ = resp.Body.Close()
 		require.Equal(t, http.StatusOK, resp.StatusCode, "PUT to rename nested folder should succeed: %s", string(body))
 
-		title := readFolderFieldOnRef(t, helper, ctx, repoName,
+		title := readFolderFieldOnRef(t, helper, repoName,
 			"rename-target/child/_folder.json", nestedBranch, "spec", "title")
 		require.Equal(t, "Renamed Child", title, "nested folder title should be updated on the branch")
 
-		uid := readFolderFieldOnRef(t, helper, ctx, repoName,
+		uid := readFolderFieldOnRef(t, helper, repoName,
 			"rename-target/child/_folder.json", nestedBranch, "metadata", "name")
 		require.Equal(t, childUID, uid, "nested folder UID must not change")
 	})
@@ -131,7 +129,6 @@ func TestIntegrationGitFiles_UpdateFolderMetadataOnNewBranch(t *testing.T) {
 // and the RBAC ancestor walk failed because the hash-based UID wasn't in the folder tree.
 func TestIntegrationGitFiles_EditorCreatesDashboardOnNewBranchWithGranularPermissions(t *testing.T) {
 	helper := sharedGitHelper(t)
-	ctx := context.Background()
 
 	const repoName = "editor-new-branch-granular-perms"
 	helper.CreateGitRepo(t, repoName, nil, "write", "branch")
@@ -142,7 +139,7 @@ func TestIntegrationGitFiles_EditorCreatesDashboardOnNewBranchWithGranularPermis
 	_ = resp.Body.Close()
 	require.Equal(t, http.StatusOK, resp.StatusCode, "folder creation should succeed: %s", string(body))
 
-	folderUID := readFolderFieldOnRef(t, helper, ctx, repoName, "team-a/_folder.json", "", "metadata", "name")
+	folderUID := readFolderFieldOnRef(t, helper, repoName, "team-a/_folder.json", "", "metadata", "name")
 	require.NotEmpty(t, folderUID, "team-a should have a stable UID from _folder.json")
 
 	// Grant editor granular permissions scoped to the repo root folder only.
@@ -168,7 +165,7 @@ func TestIntegrationGitFiles_EditorCreatesDashboardOnNewBranchWithGranularPermis
 		Param("message", "Add dashboard on new branch").
 		Body(dashboardContent).
 		SetHeader("Content-Type", "application/json").
-		Do(ctx)
+		Do(t.Context())
 
 	require.NoError(t, result.Error(),
 		"editor with granular folder permissions should be able to create a dashboard on a new branch")
@@ -180,7 +177,7 @@ func TestIntegrationGitFiles_EditorCreatesDashboardOnNewBranchWithGranularPermis
 		Name(repoName).
 		SubResource("files", "team-a", "editor-dashboard.json").
 		Param("ref", branchName).
-		Do(ctx)
+		Do(t.Context())
 	require.NoError(t, getResult.Error(), "dashboard file should exist on the new branch")
 }
 
@@ -225,7 +222,7 @@ func putFolderViaFilesAPI(t *testing.T, helper *common.GitTestHelper, repoName, 
 // branch. fields is the JSON path under "resource" → "file", e.g.
 // ("metadata", "name") or ("spec", "title").
 func readFolderFieldOnRef(
-	t *testing.T, helper *common.GitTestHelper, ctx context.Context,
+	t *testing.T, helper *common.GitTestHelper,
 	repoName, filePath, ref string, fields ...string,
 ) string {
 	t.Helper()
@@ -241,7 +238,7 @@ func readFolderFieldOnRef(
 		req = req.Param("ref", ref)
 	}
 
-	result := req.Do(ctx)
+	result := req.Do(t.Context())
 	require.NoError(t, result.Error(), "%s (ref=%q): should be readable via the files endpoint", filePath, ref)
 
 	wrapObj := &unstructured.Unstructured{}

--- a/pkg/tests/apis/provisioning/foldermetadata/update_folder_metadata_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/update_folder_metadata_test.go
@@ -1,7 +1,6 @@
 package foldermetadata
 
 import (
-	"context"
 	"net/http"
 	"testing"
 
@@ -15,7 +14,6 @@ import (
 
 func TestIntegrationProvisioning_UpdateFolderMetadata(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	const repo = "update-folder-metadata-repo"
 	helper.CreateLocalRepo(t, common.TestRepo{Name: repo, SyncTarget: "instance", Workflows: []string{"write"}, SkipResourceAssertions: true})
@@ -26,19 +24,19 @@ func TestIntegrationProvisioning_UpdateFolderMetadata(t *testing.T) {
 	resp := files.Post(t, "update-test/", nil)
 	require.Equal(t, http.StatusOK, resp.StatusCode, "setup: creating folder should succeed")
 
-	originalUID := files.ReadFolderUID(t, ctx, "update-test/_folder.json")
+	originalUID := files.ReadFolderUID(t, "update-test/_folder.json")
 	require.NotEmpty(t, originalUID, "setup: folder should have a UID")
-	originalTitle := files.ReadFolderTitle(t, ctx, "update-test/_folder.json")
+	originalTitle := files.ReadFolderTitle(t, "update-test/_folder.json")
 	require.Equal(t, "update-test", originalTitle, "setup: folder should have initial title")
 
 	t.Run("update folder title via PUT to folder path succeeds", func(t *testing.T) {
 		resp := files.Put(t, "update-test/", common.FolderBody(t, originalUID, "Updated Title"))
 		require.Equal(t, http.StatusOK, resp.StatusCode, "PUT to folder path should update title: %s", resp.BodyString())
 
-		newTitle := files.ReadFolderTitle(t, ctx, "update-test/_folder.json")
+		newTitle := files.ReadFolderTitle(t, "update-test/_folder.json")
 		require.Equal(t, "Updated Title", newTitle, "title should be updated in _folder.json")
 
-		newUID := files.ReadFolderUID(t, ctx, "update-test/_folder.json")
+		newUID := files.ReadFolderUID(t, "update-test/_folder.json")
 		require.Equal(t, originalUID, newUID, "UID must not change after title update")
 	})
 
@@ -47,7 +45,7 @@ func TestIntegrationProvisioning_UpdateFolderMetadata(t *testing.T) {
 		require.Equal(t, http.StatusOK, resp.StatusCode, "updating folder title should succeed: %s", resp.BodyString())
 
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
-			folderObj, err := helper.Folders.Resource.Get(ctx, originalUID, metav1.GetOptions{})
+			folderObj, err := helper.Folders.Resource.Get(t.Context(), originalUID, metav1.GetOptions{})
 			if err != nil {
 				collect.Errorf("could not get folder: %v", err)
 				return
@@ -61,10 +59,10 @@ func TestIntegrationProvisioning_UpdateFolderMetadata(t *testing.T) {
 		resp := files.Put(t, "update-test/", common.FolderBody(t, "", "No ID Provided"))
 		require.Equal(t, http.StatusOK, resp.StatusCode, "update with omitted ID should succeed: %s", resp.BodyString())
 
-		newTitle := files.ReadFolderTitle(t, ctx, "update-test/_folder.json")
+		newTitle := files.ReadFolderTitle(t, "update-test/_folder.json")
 		require.Equal(t, "No ID Provided", newTitle, "title should be updated")
 
-		newUID := files.ReadFolderUID(t, ctx, "update-test/_folder.json")
+		newUID := files.ReadFolderUID(t, "update-test/_folder.json")
 		require.Equal(t, originalUID, newUID, "UID must not change")
 	})
 
@@ -73,7 +71,7 @@ func TestIntegrationProvisioning_UpdateFolderMetadata(t *testing.T) {
 		require.Equal(t, http.StatusBadRequest, resp.StatusCode, "changing folder ID must be rejected: %s", resp.BodyString())
 		require.Contains(t, resp.BodyString(), "folder ID change is not allowed")
 
-		unchangedUID := files.ReadFolderUID(t, ctx, "update-test/_folder.json")
+		unchangedUID := files.ReadFolderUID(t, "update-test/_folder.json")
 		require.Equal(t, originalUID, unchangedUID, "UID must not have changed after rejected request")
 	})
 
@@ -104,16 +102,16 @@ func TestIntegrationProvisioning_UpdateFolderMetadata(t *testing.T) {
 		resp := files.Post(t, "nested-parent/nested-child/", nil)
 		require.Equal(t, http.StatusOK, resp.StatusCode, "setup: creating nested folder should succeed")
 
-		childUID := files.ReadFolderUID(t, ctx, "nested-parent/nested-child/_folder.json")
+		childUID := files.ReadFolderUID(t, "nested-parent/nested-child/_folder.json")
 		require.NotEmpty(t, childUID)
 
 		resp = files.Put(t, "nested-parent/nested-child/", common.FolderBody(t, childUID, "Child Renamed"))
 		require.Equal(t, http.StatusOK, resp.StatusCode, "nested title update should succeed: %s", resp.BodyString())
 
-		newTitle := files.ReadFolderTitle(t, ctx, "nested-parent/nested-child/_folder.json")
+		newTitle := files.ReadFolderTitle(t, "nested-parent/nested-child/_folder.json")
 		require.Equal(t, "Child Renamed", newTitle)
 
-		newUID := files.ReadFolderUID(t, ctx, "nested-parent/nested-child/_folder.json")
+		newUID := files.ReadFolderUID(t, "nested-parent/nested-child/_folder.json")
 		require.Equal(t, childUID, newUID, "nested folder UID must not change")
 	})
 }

--- a/pkg/tests/apis/provisioning/foldermetadata/update_folder_metadata_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/update_folder_metadata_test.go
@@ -16,7 +16,7 @@ func TestIntegrationProvisioning_UpdateFolderMetadata(t *testing.T) {
 	helper := sharedHelper(t)
 
 	const repo = "update-folder-metadata-repo"
-	helper.CreateLocalRepo(t, common.TestRepo{Name: repo, SyncTarget: "instance", Workflows: []string{"write"}, SkipResourceAssertions: true})
+	helper.CreateLocalRepo(t, common.TestRepo{Name: repo, SyncTarget: "instance", Workflows: []string{"write"}})
 
 	files := helper.NewFilesClient(repo)
 

--- a/pkg/tests/apis/provisioning/folderownerrefs_test.go
+++ b/pkg/tests/apis/provisioning/folderownerrefs_test.go
@@ -94,8 +94,8 @@ func TestIntegrationFolderOwnerRefs_UnprovisionedFolders(t *testing.T) {
 		require.NoError(t, err, "should successfully patch finalizers")
 
 		require.NoError(t, helper.Repositories.Resource.Delete(t.Context(), repo, metav1.DeleteOptions{}))
-		helper.WaitForRepositoryDeleted(t, t.Context(), repo)
-		common.WaitForResourcesReleased(t, t.Context(), helper.Folders.Resource, "folders")
+		helper.WaitForRepositoryDeleted(t, repo)
+		common.WaitForResourcesReleased(t, helper.Folders.Resource, "folders")
 
 		_, err = helper.Folders.Resource.Patch(t.Context(), managedFolderName, types.JSONPatchType, ownerRefsPatch, metav1.PatchOptions{})
 		require.NoError(t, err, "should set ownerReferences on released folder")

--- a/pkg/tests/apis/provisioning/folderownerrefs_test.go
+++ b/pkg/tests/apis/provisioning/folderownerrefs_test.go
@@ -27,10 +27,12 @@ var ownerRefsPatch = []byte(`[{
 func TestIntegrationFolderOwnerRefs_ProvisionedFolders(t *testing.T) {
 	helper := sharedHelper(t)
 	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:            "test-repo",
-		SyncTarget:      "folder",
-		ExpectedFolders: 1,
+		Name:       "test-repo",
+		SyncTarget: "folder",
 	})
+
+	helper.RequireRepoDashboardCount(t, "test-repo", 0)
+	helper.RequireRepoFolderCount(t, "test-repo", 1)
 
 	t.Run("should fail to set ownerReferences on provisioned folder via patch", func(t *testing.T) {
 		folders, err := helper.Folders.Resource.List(t.Context(), metav1.ListOptions{})
@@ -71,10 +73,12 @@ func TestIntegrationFolderOwnerRefs_UnprovisionedFolders(t *testing.T) {
 	const repo = "test-repo"
 	helper := sharedHelper(t)
 	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:            repo,
-		SyncTarget:      "folder",
-		ExpectedFolders: 1,
+		Name:       repo,
+		SyncTarget: "folder",
 	})
+
+	helper.RequireRepoDashboardCount(t, repo, 0)
+	helper.RequireRepoFolderCount(t, repo, 1)
 
 	t.Run("should set ownerReferences when folder is released", func(t *testing.T) {
 		folders, err := helper.Folders.Resource.List(t.Context(), metav1.ListOptions{})

--- a/pkg/tests/apis/provisioning/folderpermissions_test.go
+++ b/pkg/tests/apis/provisioning/folderpermissions_test.go
@@ -93,8 +93,8 @@ func TestIntegrationFolderPermissions_UnprovisionedFolders(t *testing.T) {
 		require.NoError(t, err, "should successfully patch finalizers")
 
 		require.NoError(t, helper.Repositories.Resource.Delete(t.Context(), repo, metav1.DeleteOptions{}))
-		helper.WaitForRepositoryDeleted(t, t.Context(), repo)
-		common.WaitForResourcesReleased(t, t.Context(), helper.Folders.Resource, "folders")
+		helper.WaitForRepositoryDeleted(t, repo)
+		common.WaitForResourcesReleased(t, helper.Folders.Resource, "folders")
 
 		permissionsPayload := map[string]interface{}{
 			"items": []map[string]interface{}{

--- a/pkg/tests/apis/provisioning/folderpermissions_test.go
+++ b/pkg/tests/apis/provisioning/folderpermissions_test.go
@@ -19,13 +19,11 @@ func TestIntegrationFolderPermissions_ProvisionedFolders(t *testing.T) {
 	repoName := "nested-folder-repo"
 	helper := sharedHelper(t)
 	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:            repoName,
-		SyncTarget:      "folder",
-		ExpectedFolders: 1,
+		Name:       repoName,
+		SyncTarget: "folder",
 		Copies: map[string]string{
 			"testdata/all-panels.json": "folder/subfolder/dashboard.json",
 		},
-		SkipResourceAssertions: true,
 	})
 	t.Run("should fail to update permissions for provisioned nested folder", func(t *testing.T) {
 		folders, err := helper.Folders.Resource.List(t.Context(), metav1.ListOptions{})
@@ -70,10 +68,12 @@ func TestIntegrationFolderPermissions_UnprovisionedFolders(t *testing.T) {
 	const repo = "test-repo"
 	helper := sharedHelper(t)
 	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:            repo,
-		SyncTarget:      "folder",
-		ExpectedFolders: 1,
+		Name:       repo,
+		SyncTarget: "folder",
 	})
+
+	helper.RequireRepoDashboardCount(t, repo, 0)
+	helper.RequireRepoFolderCount(t, repo, 1)
 
 	t.Run("should update permissions when folder is released", func(t *testing.T) {
 		folders, err := helper.Folders.Resource.List(t.Context(), metav1.ListOptions{})

--- a/pkg/tests/apis/provisioning/folderscope/folder_annotation_guard_test.go
+++ b/pkg/tests/apis/provisioning/folderscope/folder_annotation_guard_test.go
@@ -1,7 +1,6 @@
 package folderscope
 
 import (
-	"context"
 	"testing"
 
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
@@ -17,7 +16,6 @@ import (
 // default and is covered by the foldermetadata suite and the parser unit tests.
 func TestIntegrationProvisioning_OrgScopedResourceGetsNoFolderAnnotation(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	const (
 		repo       = "folder-guard-org-scoped"
@@ -33,5 +31,5 @@ func TestIntegrationProvisioning_OrgScopedResourceGetsNoFolderAnnotation(t *test
 	})
 
 	// An empty expected folder UID asserts the dashboard carries no folder annotation.
-	common.RequireRepoDashboardParent(t, helper.DashboardsV1, ctx, repo, sourcePath, "")
+	common.RequireRepoDashboardParent(t, helper.DashboardsV1, repo, sourcePath, "")
 }

--- a/pkg/tests/apis/provisioning/folderscope/folder_annotation_guard_test.go
+++ b/pkg/tests/apis/provisioning/folderscope/folder_annotation_guard_test.go
@@ -27,7 +27,6 @@ func TestIntegrationProvisioning_OrgScopedResourceGetsNoFolderAnnotation(t *test
 		Copies: map[string]string{
 			"../testdata/all-panels.json": sourcePath,
 		},
-		SkipResourceAssertions: true,
 	})
 
 	// An empty expected folder UID asserts the dashboard carries no folder annotation.

--- a/pkg/tests/apis/provisioning/git/commit_author_test.go
+++ b/pkg/tests/apis/provisioning/git/commit_author_test.go
@@ -12,7 +12,6 @@ import (
 
 func TestIntegrationGit_Files_CommitAuthor(t *testing.T) {
 	helper := sharedGitHelper(t)
-	ctx := t.Context()
 
 	repoName := "commit-author"
 	_, local := helper.CreateGitRepo(t, repoName, nil, "write")
@@ -28,7 +27,7 @@ func TestIntegrationGit_Files_CommitAuthor(t *testing.T) {
 		Param("message", "Create dashboard.json").
 		Body(common.DashboardJSON("commit-author-dash", "Commit Author", 1)).
 		SetHeader("Content-Type", "application/json").
-		Do(ctx)
+		Do(t.Context())
 	require.NoError(t, result.Error(), "should create file")
 
 	name, email := user.Identity.GetName(), user.Identity.GetEmail()

--- a/pkg/tests/apis/provisioning/git/files_test.go
+++ b/pkg/tests/apis/provisioning/git/files_test.go
@@ -1,7 +1,6 @@
 package git
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -19,7 +18,6 @@ import (
 
 func TestIntegrationGitFiles_CreateFile(t *testing.T) {
 	helper := sharedGitHelper(t)
-	ctx := context.Background()
 
 	repoName := "test-create-file"
 	// Enable branch workflow since we test creating files on new branches
@@ -46,12 +44,12 @@ func TestIntegrationGitFiles_CreateFile(t *testing.T) {
 			Param("message", "Create dashboard1.json").
 			Body(dashboardContent).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx)
+			Do(t.Context())
 
 		require.NoError(t, result.Error(), "should create file on default branch")
 
 		// Verify file exists in repository
-		fileObj, err := helper.Repositories.Resource.Get(ctx, repoName, metav1.GetOptions{}, "files", "dashboard1.json")
+		fileObj, err := helper.Repositories.Resource.Get(t.Context(), repoName, metav1.GetOptions{}, "files", "dashboard1.json")
 		require.NoError(t, err, "file should exist in repository")
 		require.NotNil(t, fileObj)
 
@@ -59,7 +57,7 @@ func TestIntegrationGitFiles_CreateFile(t *testing.T) {
 		helper.SyncAndWait(t, repoName)
 
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
-			dashboards, err := helper.DashboardsV1.Resource.List(ctx, metav1.ListOptions{})
+			dashboards, err := helper.DashboardsV1.Resource.List(t.Context(), metav1.ListOptions{})
 			if !assert.NoError(collect, err) {
 				return
 			}
@@ -90,7 +88,7 @@ func TestIntegrationGitFiles_CreateFile(t *testing.T) {
 			Param("message", "Create dashboard2.json on feature branch").
 			Body(dashboardContent).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx)
+			Do(t.Context())
 
 		require.NoError(t, result.Error(), "should create file on new branch")
 
@@ -101,7 +99,7 @@ func TestIntegrationGitFiles_CreateFile(t *testing.T) {
 			Name(repoName).
 			SubResource("files", "dashboard2.json").
 			Param("ref", branchName).
-			Do(ctx)
+			Do(t.Context())
 
 		require.NoError(t, result.Error(), "file should exist on branch")
 	})
@@ -109,7 +107,6 @@ func TestIntegrationGitFiles_CreateFile(t *testing.T) {
 
 func TestIntegrationGitFiles_UpdateFile(t *testing.T) {
 	helper := sharedGitHelper(t)
-	ctx := context.Background()
 
 	repoName := "test-update-file"
 	initialContent := map[string][]byte{
@@ -149,7 +146,7 @@ func TestIntegrationGitFiles_UpdateFile(t *testing.T) {
 			Param("message", "Update dashboard.json title").
 			Body(updatedContent).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx)
+			Do(t.Context())
 
 		require.NoError(t, result.Error(), "should update file on default branch")
 
@@ -157,7 +154,7 @@ func TestIntegrationGitFiles_UpdateFile(t *testing.T) {
 		helper.SyncAndWait(t, repoName)
 
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
-			dashboard, err := helper.DashboardsV1.Resource.Get(ctx, "test-dash", metav1.GetOptions{})
+			dashboard, err := helper.DashboardsV1.Resource.Get(t.Context(), "test-dash", metav1.GetOptions{})
 			if !assert.NoError(collect, err) {
 				return
 			}
@@ -194,12 +191,12 @@ func TestIntegrationGitFiles_UpdateFile(t *testing.T) {
 			Param("message", "Update dashboard.json on branch").
 			Body(updatedContent).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx)
+			Do(t.Context())
 
 		require.NoError(t, result.Error(), "should update file on branch")
 
 		// Verify the file was updated on the branch
-		fileObj, err := helper.Repositories.Resource.Get(ctx, repoName, metav1.GetOptions{
+		fileObj, err := helper.Repositories.Resource.Get(t.Context(), repoName, metav1.GetOptions{
 			ResourceVersion: branchName,
 		}, "files", "dashboard.json")
 		require.NoError(t, err, "file should exist on branch")
@@ -209,7 +206,6 @@ func TestIntegrationGitFiles_UpdateFile(t *testing.T) {
 
 func TestIntegrationGitFiles_DeleteFile(t *testing.T) {
 	helper := sharedGitHelper(t)
-	ctx := context.Background()
 
 	repoName := "test-delete-file"
 	initialContent := map[string][]byte{
@@ -246,7 +242,7 @@ func TestIntegrationGitFiles_DeleteFile(t *testing.T) {
 			Name(repoName).
 			SubResource("files", "dashboard1.json").
 			Param("message", "Delete dashboard1.json").
-			Do(ctx)
+			Do(t.Context())
 
 		require.NoError(t, result.Error(), "should delete file on default branch")
 
@@ -254,7 +250,7 @@ func TestIntegrationGitFiles_DeleteFile(t *testing.T) {
 		helper.SyncAndWait(t, repoName)
 
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
-			_, err := helper.DashboardsV1.Resource.Get(ctx, "dash-1", metav1.GetOptions{})
+			_, err := helper.DashboardsV1.Resource.Get(t.Context(), "dash-1", metav1.GetOptions{})
 			assert.True(collect, apierrors.IsNotFound(err), "dashboard should be deleted from Grafana")
 		}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "dashboard should be deleted after sync")
 	})
@@ -269,7 +265,7 @@ func TestIntegrationGitFiles_DeleteFile(t *testing.T) {
 			SubResource("files", "dashboard2.json").
 			Param("ref", branchName).
 			Param("message", "Delete dashboard2.json on branch").
-			Do(ctx)
+			Do(t.Context())
 
 		require.NoError(t, result.Error(), "should delete file on branch")
 
@@ -280,7 +276,7 @@ func TestIntegrationGitFiles_DeleteFile(t *testing.T) {
 			Name(repoName).
 			SubResource("files", "dashboard2.json").
 			Param("ref", branchName).
-			Do(ctx)
+			Do(t.Context())
 		require.True(t, apierrors.IsNotFound(result.Error()), "file should not exist on delete branch")
 
 		// File should still exist on main branch
@@ -289,14 +285,13 @@ func TestIntegrationGitFiles_DeleteFile(t *testing.T) {
 			Resource("repositories").
 			Name(repoName).
 			SubResource("files", "dashboard2.json").
-			Do(ctx)
+			Do(t.Context())
 		require.NoError(t, result.Error(), "file should still exist on main branch")
 	})
 }
 
 func TestIntegrationGitFiles_MoveFile(t *testing.T) {
 	helper := sharedGitHelper(t)
-	ctx := context.Background()
 
 	repoName := "test-move-file"
 	initialContent := map[string][]byte{
@@ -335,17 +330,16 @@ func TestIntegrationGitFiles_MoveFile(t *testing.T) {
 		require.Equal(t, http.StatusOK, resp.StatusCode, "should move file on default branch")
 
 		// Verify file moved
-		_, err = helper.Repositories.Resource.Get(ctx, repoName, metav1.GetOptions{}, "files", "moved", "dashboard.json")
+		_, err = helper.Repositories.Resource.Get(t.Context(), repoName, metav1.GetOptions{}, "files", "moved", "dashboard.json")
 		require.NoError(t, err, "file should exist at new location")
 
-		_, err = helper.Repositories.Resource.Get(ctx, repoName, metav1.GetOptions{}, "files", "dashboard.json")
+		_, err = helper.Repositories.Resource.Get(t.Context(), repoName, metav1.GetOptions{}, "files", "dashboard.json")
 		require.Error(t, err, "file should not exist at old location")
 	})
 }
 
 func TestIntegrationGitFiles_MoveDirectoryOnBranch(t *testing.T) {
 	helper := sharedGitHelper(t)
-	ctx := context.Background()
 
 	repoName := "test-move-dir"
 	initialContent := map[string][]byte{
@@ -388,14 +382,13 @@ func TestIntegrationGitFiles_MoveDirectoryOnBranch(t *testing.T) {
 			Name(repoName).
 			SubResource("files", "renamed", "dashboard.json").
 			Param("ref", branchName).
-			Do(ctx)
+			Do(t.Context())
 		require.NoError(t, result.Error(), "dashboard should exist at new location on branch")
 	})
 }
 
 func TestIntegrationGitFiles_ListFiles(t *testing.T) {
 	helper := sharedGitHelper(t)
-	ctx := context.Background()
 
 	repoName := "test-list-files"
 	initialContent := map[string][]byte{
@@ -412,7 +405,7 @@ func TestIntegrationGitFiles_ListFiles(t *testing.T) {
 			Resource("repositories").
 			Name(repoName).
 			Suffix("files/").
-			Do(ctx)
+			Do(t.Context())
 
 		require.NoError(t, result.Error(), "should list files")
 
@@ -445,7 +438,7 @@ func TestIntegrationGitFiles_ListFiles(t *testing.T) {
 			Resource("repositories").
 			Name(repoName).
 			SubResource("files", "folder", "dashboard3.json").
-			Do(ctx)
+			Do(t.Context())
 
 		require.NoError(t, result.Error(), "should get file in subdirectory")
 
@@ -462,7 +455,6 @@ func TestIntegrationGitFiles_ListFiles(t *testing.T) {
 
 func TestIntegrationGitFiles_BranchOperations(t *testing.T) {
 	helper := sharedGitHelper(t)
-	ctx := context.Background()
 
 	repoName := "test-branch-ops"
 	initialContent := map[string][]byte{
@@ -486,7 +478,7 @@ func TestIntegrationGitFiles_BranchOperations(t *testing.T) {
 			Param("message", "Create branch-file1.json").
 			Body(file1Content).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx)
+			Do(t.Context())
 
 		require.NoError(t, result.Error(), "should create first file on branch")
 
@@ -501,7 +493,7 @@ func TestIntegrationGitFiles_BranchOperations(t *testing.T) {
 			Param("message", "Create branch-file2.json").
 			Body(file2Content).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx)
+			Do(t.Context())
 
 		require.NoError(t, result.Error(), "should create second file on same branch")
 
@@ -512,7 +504,7 @@ func TestIntegrationGitFiles_BranchOperations(t *testing.T) {
 			Name(repoName).
 			SubResource("files", "branch-file1.json").
 			Param("ref", branchName).
-			Do(ctx)
+			Do(t.Context())
 		require.NoError(t, result.Error(), "first file should exist on branch")
 
 		result = helper.AdminREST.Get().
@@ -521,7 +513,7 @@ func TestIntegrationGitFiles_BranchOperations(t *testing.T) {
 			Name(repoName).
 			SubResource("files", "branch-file2.json").
 			Param("ref", branchName).
-			Do(ctx)
+			Do(t.Context())
 		require.NoError(t, result.Error(), "second file should exist on branch")
 
 		// Verify files don't exist on main branch
@@ -530,7 +522,7 @@ func TestIntegrationGitFiles_BranchOperations(t *testing.T) {
 			Resource("repositories").
 			Name(repoName).
 			SubResource("files", "branch-file1.json").
-			Do(ctx)
+			Do(t.Context())
 		require.True(t, apierrors.IsNotFound(result.Error()), "first file should not exist on main branch")
 
 		result = helper.AdminREST.Get().
@@ -538,7 +530,7 @@ func TestIntegrationGitFiles_BranchOperations(t *testing.T) {
 			Resource("repositories").
 			Name(repoName).
 			SubResource("files", "branch-file2.json").
-			Do(ctx)
+			Do(t.Context())
 		require.True(t, apierrors.IsNotFound(result.Error()), "second file should not exist on main branch")
 	})
 
@@ -556,7 +548,7 @@ func TestIntegrationGitFiles_BranchOperations(t *testing.T) {
 			Param("message", "Create multi-branch.json").
 			Body(initialContent).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx)
+			Do(t.Context())
 
 		require.NoError(t, result.Error(), "should create initial file")
 
@@ -571,7 +563,7 @@ func TestIntegrationGitFiles_BranchOperations(t *testing.T) {
 			Param("message", "Update multi-branch.json on branch 1").
 			Body(branch1Content).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx)
+			Do(t.Context())
 
 		require.NoError(t, result.Error(), "should update file on branch 1")
 
@@ -586,7 +578,7 @@ func TestIntegrationGitFiles_BranchOperations(t *testing.T) {
 			Param("message", "Update multi-branch.json on branch 2").
 			Body(branch2Content).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx)
+			Do(t.Context())
 
 		require.NoError(t, result.Error(), "should update file on branch 2")
 
@@ -597,7 +589,7 @@ func TestIntegrationGitFiles_BranchOperations(t *testing.T) {
 			Name(repoName).
 			SubResource("files", "multi-branch.json").
 			Param("ref", branch1).
-			Do(ctx)
+			Do(t.Context())
 		require.NoError(t, result.Error(), "should get file from branch 1")
 
 		branch1File := &unstructured.Unstructured{}
@@ -610,7 +602,7 @@ func TestIntegrationGitFiles_BranchOperations(t *testing.T) {
 			Name(repoName).
 			SubResource("files", "multi-branch.json").
 			Param("ref", branch2).
-			Do(ctx)
+			Do(t.Context())
 		require.NoError(t, result.Error(), "should get file from branch 2")
 
 		branch2File := &unstructured.Unstructured{}

--- a/pkg/tests/apis/provisioning/git/folder_file_rejection_test.go
+++ b/pkg/tests/apis/provisioning/git/folder_file_rejection_test.go
@@ -55,7 +55,7 @@ func TestIntegrationProvisioning_FullSync_FolderFileIsWarning(t *testing.T) {
 		"full sync should produce at least one warning for the folder file")
 	common.RequireJobWarningContains(t, jobObj, "cannot declare folders through files")
 
-	common.RequireRepoDashboardCount(t, helper, repoName, 1)
+	helper.RequireRepoDashboardCount(t, repoName, 1)
 }
 
 // TestIntegrationProvisioning_IncrementalSync_FolderFileCreateIsWarning
@@ -71,7 +71,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderFileCreateIsWarning(t *te
 	})
 
 	helper.SyncAndWait(t, repoName)
-	common.RequireRepoDashboardCount(t, helper, repoName, 1)
+	helper.RequireRepoDashboardCount(t, repoName, 1)
 
 	require.NoError(t, local.CreateFile("new-folder.json", string(folderJSON("new-folder", "New Folder"))))
 	_, err := local.Git("add", ".")
@@ -96,7 +96,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderFileCreateIsWarning(t *te
 		"incremental sync should produce at least one warning for the folder file")
 	common.RequireJobWarningContains(t, jobObj, "cannot declare folders through files")
 
-	common.RequireRepoDashboardCount(t, helper, repoName, 1)
+	helper.RequireRepoDashboardCount(t, repoName, 1)
 }
 
 // TestIntegrationProvisioning_IncrementalSync_FolderFileDeletedIsWarning
@@ -119,7 +119,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderFileDeletedIsWarning(t *t
 		Action: provisioning.JobActionPull,
 		Pull:   &provisioning.SyncJobOptions{},
 	})
-	common.RequireRepoDashboardCount(t, helper, repoName, 1)
+	helper.RequireRepoDashboardCount(t, repoName, 1)
 
 	// Delete the folder file from git.
 	_, err := local.Git("rm", "my-folder.json")
@@ -145,7 +145,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderFileDeletedIsWarning(t *t
 		"incremental sync should produce at least one warning for the deleted folder file")
 	common.RequireJobWarningContains(t, incrJobObj, "cannot declare folders through files")
 
-	common.RequireRepoDashboardCount(t, helper, repoName, 1)
+	helper.RequireRepoDashboardCount(t, repoName, 1)
 }
 
 // TestIntegrationGitFiles_CreateFolderFileRejected verifies that creating a

--- a/pkg/tests/apis/provisioning/git/folder_file_rejection_test.go
+++ b/pkg/tests/apis/provisioning/git/folder_file_rejection_test.go
@@ -1,7 +1,6 @@
 package git
 
 import (
-	"context"
 	"encoding/json"
 	"testing"
 
@@ -33,7 +32,6 @@ func folderJSON(uid, title string) []byte {
 // folder-typed JSON file produces a warning (not an error) during full sync.
 func TestIntegrationProvisioning_FullSync_FolderFileIsWarning(t *testing.T) {
 	helper := sharedGitHelper(t)
-	ctx := context.Background()
 
 	const repoName = "full-folder-file-warning"
 
@@ -57,7 +55,7 @@ func TestIntegrationProvisioning_FullSync_FolderFileIsWarning(t *testing.T) {
 		"full sync should produce at least one warning for the folder file")
 	common.RequireJobWarningContains(t, jobObj, "cannot declare folders through files")
 
-	common.RequireRepoDashboardCount(t, helper, ctx, repoName, 1)
+	common.RequireRepoDashboardCount(t, helper, repoName, 1)
 }
 
 // TestIntegrationProvisioning_IncrementalSync_FolderFileCreateIsWarning
@@ -65,7 +63,6 @@ func TestIntegrationProvisioning_FullSync_FolderFileIsWarning(t *testing.T) {
 // sync produces a warning rather than an error.
 func TestIntegrationProvisioning_IncrementalSync_FolderFileCreateIsWarning(t *testing.T) {
 	helper := sharedGitHelper(t)
-	ctx := context.Background()
 
 	const repoName = "incr-folder-file-create"
 
@@ -74,7 +71,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderFileCreateIsWarning(t *te
 	})
 
 	helper.SyncAndWait(t, repoName)
-	common.RequireRepoDashboardCount(t, helper, ctx, repoName, 1)
+	common.RequireRepoDashboardCount(t, helper, repoName, 1)
 
 	require.NoError(t, local.CreateFile("new-folder.json", string(folderJSON("new-folder", "New Folder"))))
 	_, err := local.Git("add", ".")
@@ -99,7 +96,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderFileCreateIsWarning(t *te
 		"incremental sync should produce at least one warning for the folder file")
 	common.RequireJobWarningContains(t, jobObj, "cannot declare folders through files")
 
-	common.RequireRepoDashboardCount(t, helper, ctx, repoName, 1)
+	common.RequireRepoDashboardCount(t, helper, repoName, 1)
 }
 
 // TestIntegrationProvisioning_IncrementalSync_FolderFileDeletedIsWarning
@@ -108,7 +105,6 @@ func TestIntegrationProvisioning_IncrementalSync_FolderFileCreateIsWarning(t *te
 // managed by directory structure, not file content.
 func TestIntegrationProvisioning_IncrementalSync_FolderFileDeletedIsWarning(t *testing.T) {
 	helper := sharedGitHelper(t)
-	ctx := context.Background()
 
 	const repoName = "incr-folder-file-delete"
 
@@ -123,7 +119,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderFileDeletedIsWarning(t *t
 		Action: provisioning.JobActionPull,
 		Pull:   &provisioning.SyncJobOptions{},
 	})
-	common.RequireRepoDashboardCount(t, helper, ctx, repoName, 1)
+	common.RequireRepoDashboardCount(t, helper, repoName, 1)
 
 	// Delete the folder file from git.
 	_, err := local.Git("rm", "my-folder.json")
@@ -149,14 +145,13 @@ func TestIntegrationProvisioning_IncrementalSync_FolderFileDeletedIsWarning(t *t
 		"incremental sync should produce at least one warning for the deleted folder file")
 	common.RequireJobWarningContains(t, incrJobObj, "cannot declare folders through files")
 
-	common.RequireRepoDashboardCount(t, helper, ctx, repoName, 1)
+	common.RequireRepoDashboardCount(t, helper, repoName, 1)
 }
 
 // TestIntegrationGitFiles_CreateFolderFileRejected verifies that creating a
 // folder-typed resource via the POST /files/ endpoint is rejected with BadRequest.
 func TestIntegrationGitFiles_CreateFolderFileRejected(t *testing.T) {
 	helper := sharedGitHelper(t)
-	ctx := context.Background()
 
 	repoName := "test-create-folder-file"
 	_, _ = helper.CreateGitRepo(t, repoName, nil, "write")
@@ -169,7 +164,7 @@ func TestIntegrationGitFiles_CreateFolderFileRejected(t *testing.T) {
 		Param("message", "Create folder file").
 		Body(folderJSON("new-folder", "New Folder")).
 		SetHeader("Content-Type", "application/json").
-		Do(ctx)
+		Do(t.Context())
 
 	require.Error(t, result.Error(), "creating a folder file should be rejected")
 	require.True(t, apierrors.IsBadRequest(result.Error()),
@@ -180,7 +175,6 @@ func TestIntegrationGitFiles_CreateFolderFileRejected(t *testing.T) {
 // folder-typed file via the DELETE /files/ endpoint is rejected with BadRequest.
 func TestIntegrationGitFiles_DeleteFolderFileRejected(t *testing.T) {
 	helper := sharedGitHelper(t)
-	ctx := context.Background()
 
 	repoName := "test-delete-folder-file"
 	_, _ = helper.CreateGitRepo(t, repoName, map[string][]byte{
@@ -193,7 +187,7 @@ func TestIntegrationGitFiles_DeleteFolderFileRejected(t *testing.T) {
 		Name(repoName).
 		SubResource("files", "my-folder.json").
 		Param("message", "Delete folder file").
-		Do(ctx)
+		Do(t.Context())
 
 	require.Error(t, result.Error(), "deleting a folder file should be rejected")
 	require.True(t, apierrors.IsBadRequest(result.Error()),
@@ -204,7 +198,6 @@ func TestIntegrationGitFiles_DeleteFolderFileRejected(t *testing.T) {
 // folder-typed file via the PUT /files/ endpoint is rejected with BadRequest.
 func TestIntegrationGitFiles_UpdateFolderFileRejected(t *testing.T) {
 	helper := sharedGitHelper(t)
-	ctx := context.Background()
 
 	repoName := "test-update-folder-file"
 	_, _ = helper.CreateGitRepo(t, repoName, map[string][]byte{
@@ -219,7 +212,7 @@ func TestIntegrationGitFiles_UpdateFolderFileRejected(t *testing.T) {
 		Param("message", "Update folder file").
 		Body(folderJSON("upd-folder", "Updated")).
 		SetHeader("Content-Type", "application/json").
-		Do(ctx)
+		Do(t.Context())
 
 	require.Error(t, result.Error(), "updating a folder file should be rejected")
 	require.True(t, apierrors.IsBadRequest(result.Error()),

--- a/pkg/tests/apis/provisioning/git/health_test.go
+++ b/pkg/tests/apis/provisioning/git/health_test.go
@@ -2,7 +2,6 @@ package git
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -95,10 +94,9 @@ func TestIntegrationGitTestEndpoint_EmptyRepository(t *testing.T) {
 	})
 
 	t.Run("test endpoint succeeds after pushing a commit to empty repository", func(t *testing.T) {
-		ctx := context.Background()
 		remote, user := createEmptyGitRepo(t, helper, "test-empty-then-push")
 
-		local, err := gittest.NewLocalRepo(ctx)
+		local, err := gittest.NewLocalRepo(t.Context())
 		require.NoError(t, err, "failed to create local repository")
 		t.Cleanup(func() {
 			if err := local.Cleanup(); err != nil {
@@ -184,12 +182,10 @@ func callTestEndpoint(t *testing.T, h *common.GitTestHelper, repoName string, re
 func createEmptyGitRepo(t *testing.T, h *common.GitTestHelper, repoName string) (*gittest.RemoteRepository, *gittest.User) {
 	t.Helper()
 
-	ctx := context.Background()
-
-	user, err := h.GitServer().CreateUser(ctx)
+	user, err := h.GitServer().CreateUser(t.Context())
 	require.NoError(t, err, "failed to create user")
 
-	remote, err := h.GitServer().CreateRepo(ctx, repoName, user)
+	remote, err := h.GitServer().CreateRepo(t.Context(), repoName, user)
 	require.NoError(t, err, fmt.Sprintf("failed to create remote repository %s", repoName))
 
 	return remote, user

--- a/pkg/tests/apis/provisioning/git/incremental_test.go
+++ b/pkg/tests/apis/provisioning/git/incremental_test.go
@@ -1,7 +1,6 @@
 package git
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -16,7 +15,6 @@ import (
 // sync imports a newly committed file without re-processing the full tree.
 func TestIntegrationProvisioning_IncrementalGitSync_Add(t *testing.T) {
 	helper := sharedGitHelper(t)
-	ctx := context.Background()
 
 	const repoName = "git-incremental-add"
 
@@ -25,7 +23,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_Add(t *testing.T) {
 	}, "write", "branch")
 
 	common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
-	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 1)
+	common.RequireDashboardCount(t, helper.DashboardsV1, 1)
 
 	require.NoError(t, local.CreateFile("dashboard2.json", string(common.DashboardJSON("incr-dash-002", "Dashboard Two", 1))))
 	_, err := local.Git("add", ".")
@@ -36,14 +34,13 @@ func TestIntegrationProvisioning_IncrementalGitSync_Add(t *testing.T) {
 	require.NoError(t, err)
 
 	common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
-	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 2)
+	common.RequireDashboardCount(t, helper.DashboardsV1, 2)
 }
 
 // TestIntegrationProvisioning_IncrementalGitSync_Update verifies that
 // incremental sync applies an in-place file modification.
 func TestIntegrationProvisioning_IncrementalGitSync_Update(t *testing.T) {
 	helper := sharedGitHelper(t)
-	ctx := context.Background()
 
 	const repoName = "git-incremental-update"
 
@@ -52,7 +49,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_Update(t *testing.T) {
 	}, "write", "branch")
 
 	common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
-	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 1)
+	common.RequireDashboardCount(t, helper.DashboardsV1, 1)
 
 	require.NoError(t, local.UpdateFile("dashboard1.json", string(common.DashboardJSON("incr-dash-001", "Dashboard One Updated", 2))))
 	_, err := local.Git("add", ".")
@@ -63,15 +60,14 @@ func TestIntegrationProvisioning_IncrementalGitSync_Update(t *testing.T) {
 	require.NoError(t, err)
 
 	common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
-	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 1)
-	common.RequireDashboardTitle(t, helper.DashboardsV1, ctx, "incr-dash-001", "Dashboard One Updated")
+	common.RequireDashboardCount(t, helper.DashboardsV1, 1)
+	common.RequireDashboardTitle(t, helper.DashboardsV1, "incr-dash-001", "Dashboard One Updated")
 }
 
 // TestIntegrationProvisioning_IncrementalGitSync_Delete verifies that
 // incremental sync removes a dashboard whose file was deleted from the repo.
 func TestIntegrationProvisioning_IncrementalGitSync_Delete(t *testing.T) {
 	helper := sharedGitHelper(t)
-	ctx := context.Background()
 
 	const repoName = "git-incremental-delete"
 
@@ -81,7 +77,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_Delete(t *testing.T) {
 	}, "write", "branch")
 
 	common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
-	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 2)
+	common.RequireDashboardCount(t, helper.DashboardsV1, 2)
 
 	_, err := local.Git("rm", "dashboard2.json")
 	require.NoError(t, err)
@@ -91,10 +87,10 @@ func TestIntegrationProvisioning_IncrementalGitSync_Delete(t *testing.T) {
 	require.NoError(t, err)
 
 	common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
-	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 1)
+	common.RequireDashboardCount(t, helper.DashboardsV1, 1)
 
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		_, err := helper.DashboardsV1.Resource.Get(ctx, "incr-dash-002", metav1.GetOptions{})
+		_, err := helper.DashboardsV1.Resource.Get(t.Context(), "incr-dash-002", metav1.GetOptions{})
 		assert.True(c, apierrors.IsNotFound(err), "dashboard incr-dash-002 should be deleted")
 	}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "deleted dashboard should be removed from Grafana")
 }
@@ -103,7 +99,6 @@ func TestIntegrationProvisioning_IncrementalGitSync_Delete(t *testing.T) {
 // sync is a no-op when there are no new commits since the last sync.
 func TestIntegrationProvisioning_IncrementalGitSync_Noop(t *testing.T) {
 	helper := sharedGitHelper(t)
-	ctx := context.Background()
 
 	const repoName = "git-incremental-noop"
 
@@ -112,17 +107,16 @@ func TestIntegrationProvisioning_IncrementalGitSync_Noop(t *testing.T) {
 	}, "write", "branch")
 
 	common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
-	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 1)
+	common.RequireDashboardCount(t, helper.DashboardsV1, 1)
 
 	common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
-	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 1)
+	common.RequireDashboardCount(t, helper.DashboardsV1, 1)
 }
 
 // TestIntegrationProvisioning_IncrementalGitSync_Rename verifies that
 // incremental sync handles a file rename (git mv) without losing the dashboard.
 func TestIntegrationProvisioning_IncrementalGitSync_Rename(t *testing.T) {
 	helper := sharedGitHelper(t)
-	ctx := context.Background()
 
 	const repoName = "git-incremental-rename"
 
@@ -131,11 +125,11 @@ func TestIntegrationProvisioning_IncrementalGitSync_Rename(t *testing.T) {
 	}, "write", "branch")
 
 	common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
-	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+	common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 		"incr-dash-001": {Title: "Dashboard One", SourcePath: "dashboard1.json"},
 	})
 
-	dashBefore, err := helper.DashboardsV1.Resource.Get(ctx, "incr-dash-001", metav1.GetOptions{})
+	dashBefore, err := helper.DashboardsV1.Resource.Get(t.Context(), "incr-dash-001", metav1.GetOptions{})
 	require.NoError(t, err)
 	dashSnap := common.SnapshotObject(t, dashBefore)
 
@@ -147,11 +141,11 @@ func TestIntegrationProvisioning_IncrementalGitSync_Rename(t *testing.T) {
 	require.NoError(t, err)
 
 	common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
-	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+	common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 		"incr-dash-001": {Title: "Dashboard One", SourcePath: "renamed-dashboard1.json"},
 	})
 
-	dashAfter, err := helper.DashboardsV1.Resource.Get(ctx, "incr-dash-001", metav1.GetOptions{})
+	dashAfter, err := helper.DashboardsV1.Resource.Get(t.Context(), "incr-dash-001", metav1.GetOptions{})
 	require.NoError(t, err)
 	common.RequireUpdatedInPlace(t, "dashboard", dashSnap, common.SnapshotObject(t, dashAfter))
 }
@@ -160,7 +154,6 @@ func TestIntegrationProvisioning_IncrementalGitSync_Rename(t *testing.T) {
 // incremental sync handles moving a dashboard from root into a subfolder.
 func TestIntegrationProvisioning_IncrementalGitSync_MoveIntoFolder(t *testing.T) {
 	helper := sharedGitHelper(t)
-	ctx := context.Background()
 
 	const repoName = "git-incremental-move-into-folder"
 
@@ -169,12 +162,12 @@ func TestIntegrationProvisioning_IncrementalGitSync_MoveIntoFolder(t *testing.T)
 	}, "write", "branch")
 
 	common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
-	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+	common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 		"move-in-001": {Title: "Dashboard One", SourcePath: "dashboard1.json"},
 	})
-	common.RequireRepoFolders(t, helper.Folders, ctx, repoName, []string{})
+	common.RequireRepoFolders(t, helper.Folders, repoName, []string{})
 
-	dashBefore, err := helper.DashboardsV1.Resource.Get(ctx, "move-in-001", metav1.GetOptions{})
+	dashBefore, err := helper.DashboardsV1.Resource.Get(t.Context(), "move-in-001", metav1.GetOptions{})
 	require.NoError(t, err)
 	dashSnap := common.SnapshotObject(t, dashBefore)
 
@@ -187,12 +180,12 @@ func TestIntegrationProvisioning_IncrementalGitSync_MoveIntoFolder(t *testing.T)
 	require.NoError(t, err)
 
 	common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
-	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+	common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 		"move-in-001": {Title: "Dashboard One", SourcePath: "team-a/dashboard1.json"},
 	})
-	common.RequireRepoFolders(t, helper.Folders, ctx, repoName, []string{"team-a"})
+	common.RequireRepoFolders(t, helper.Folders, repoName, []string{"team-a"})
 
-	dashAfter, err := helper.DashboardsV1.Resource.Get(ctx, "move-in-001", metav1.GetOptions{})
+	dashAfter, err := helper.DashboardsV1.Resource.Get(t.Context(), "move-in-001", metav1.GetOptions{})
 	require.NoError(t, err)
 	common.RequireUpdatedInPlace(t, "dashboard", dashSnap, common.SnapshotObject(t, dashAfter))
 }
@@ -201,7 +194,6 @@ func TestIntegrationProvisioning_IncrementalGitSync_MoveIntoFolder(t *testing.T)
 // that incremental sync handles moving a dashboard from one folder to another.
 func TestIntegrationProvisioning_IncrementalGitSync_MoveBetweenFolders(t *testing.T) {
 	helper := sharedGitHelper(t)
-	ctx := context.Background()
 
 	const repoName = "git-incremental-move-between"
 
@@ -211,12 +203,12 @@ func TestIntegrationProvisioning_IncrementalGitSync_MoveBetweenFolders(t *testin
 	}, "write", "branch")
 
 	common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
-	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+	common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 		"move-btwn-001": {Title: "Dashboard Between", SourcePath: "folder-a/dashboard1.json"},
 	})
-	common.RequireRepoFolders(t, helper.Folders, ctx, repoName, []string{"folder-a", "folder-b"})
+	common.RequireRepoFolders(t, helper.Folders, repoName, []string{"folder-a", "folder-b"})
 
-	dashBefore, err := helper.DashboardsV1.Resource.Get(ctx, "move-btwn-001", metav1.GetOptions{})
+	dashBefore, err := helper.DashboardsV1.Resource.Get(t.Context(), "move-btwn-001", metav1.GetOptions{})
 	require.NoError(t, err)
 	dashSnap := common.SnapshotObject(t, dashBefore)
 
@@ -228,12 +220,12 @@ func TestIntegrationProvisioning_IncrementalGitSync_MoveBetweenFolders(t *testin
 	require.NoError(t, err)
 
 	common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
-	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+	common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 		"move-btwn-001": {Title: "Dashboard Between", SourcePath: "folder-b/dashboard1.json"},
 	})
-	common.RequireRepoFolders(t, helper.Folders, ctx, repoName, []string{"folder-b"})
+	common.RequireRepoFolders(t, helper.Folders, repoName, []string{"folder-b"})
 
-	dashAfter, err := helper.DashboardsV1.Resource.Get(ctx, "move-btwn-001", metav1.GetOptions{})
+	dashAfter, err := helper.DashboardsV1.Resource.Get(t.Context(), "move-btwn-001", metav1.GetOptions{})
 	require.NoError(t, err)
 	common.RequireUpdatedInPlace(t, "dashboard", dashSnap, common.SnapshotObject(t, dashAfter))
 }
@@ -242,7 +234,6 @@ func TestIntegrationProvisioning_IncrementalGitSync_MoveBetweenFolders(t *testin
 // incremental sync handles moving a dashboard from a subfolder back to root.
 func TestIntegrationProvisioning_IncrementalGitSync_MoveToRoot(t *testing.T) {
 	helper := sharedGitHelper(t)
-	ctx := context.Background()
 
 	const repoName = "git-incremental-move-to-root"
 
@@ -251,12 +242,12 @@ func TestIntegrationProvisioning_IncrementalGitSync_MoveToRoot(t *testing.T) {
 	}, "write", "branch")
 
 	common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
-	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+	common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 		"move-root-001": {Title: "Dashboard Root", SourcePath: "team-x/dashboard1.json"},
 	})
-	common.RequireRepoFolders(t, helper.Folders, ctx, repoName, []string{"team-x"})
+	common.RequireRepoFolders(t, helper.Folders, repoName, []string{"team-x"})
 
-	dashBefore, err := helper.DashboardsV1.Resource.Get(ctx, "move-root-001", metav1.GetOptions{})
+	dashBefore, err := helper.DashboardsV1.Resource.Get(t.Context(), "move-root-001", metav1.GetOptions{})
 	require.NoError(t, err)
 	dashSnap := common.SnapshotObject(t, dashBefore)
 
@@ -268,12 +259,12 @@ func TestIntegrationProvisioning_IncrementalGitSync_MoveToRoot(t *testing.T) {
 	require.NoError(t, err)
 
 	common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
-	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+	common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 		"move-root-001": {Title: "Dashboard Root", SourcePath: "dashboard1.json"},
 	})
-	common.RequireRepoFolders(t, helper.Folders, ctx, repoName, []string{})
+	common.RequireRepoFolders(t, helper.Folders, repoName, []string{})
 
-	dashAfter, err := helper.DashboardsV1.Resource.Get(ctx, "move-root-001", metav1.GetOptions{})
+	dashAfter, err := helper.DashboardsV1.Resource.Get(t.Context(), "move-root-001", metav1.GetOptions{})
 	require.NoError(t, err)
 	common.RequireUpdatedInPlace(t, "dashboard", dashSnap, common.SnapshotObject(t, dashAfter))
 }
@@ -283,7 +274,6 @@ func TestIntegrationProvisioning_IncrementalGitSync_MoveToRoot(t *testing.T) {
 // inside it. Git reports individual file renames for each file in the folder.
 func TestIntegrationProvisioning_IncrementalGitSync_RenameFolder(t *testing.T) {
 	helper := sharedGitHelper(t)
-	ctx := context.Background()
 
 	const repoName = "git-incremental-rename-folder"
 
@@ -293,17 +283,17 @@ func TestIntegrationProvisioning_IncrementalGitSync_RenameFolder(t *testing.T) {
 	}, "write", "branch")
 
 	common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
-	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+	common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 		"ren-fold-001": {Title: "Folder Dash One", SourcePath: "old-team/dashboard1.json"},
 		"ren-fold-002": {Title: "Folder Dash Two", SourcePath: "old-team/dashboard2.json"},
 	})
-	common.RequireRepoFolders(t, helper.Folders, ctx, repoName, []string{"old-team"})
+	common.RequireRepoFolders(t, helper.Folders, repoName, []string{"old-team"})
 
-	dash1Before, err := helper.DashboardsV1.Resource.Get(ctx, "ren-fold-001", metav1.GetOptions{})
+	dash1Before, err := helper.DashboardsV1.Resource.Get(t.Context(), "ren-fold-001", metav1.GetOptions{})
 	require.NoError(t, err)
 	dash1Snap := common.SnapshotObject(t, dash1Before)
 
-	dash2Before, err := helper.DashboardsV1.Resource.Get(ctx, "ren-fold-002", metav1.GetOptions{})
+	dash2Before, err := helper.DashboardsV1.Resource.Get(t.Context(), "ren-fold-002", metav1.GetOptions{})
 	require.NoError(t, err)
 	dash2Snap := common.SnapshotObject(t, dash2Before)
 
@@ -315,17 +305,17 @@ func TestIntegrationProvisioning_IncrementalGitSync_RenameFolder(t *testing.T) {
 	require.NoError(t, err)
 
 	common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
-	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+	common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 		"ren-fold-001": {Title: "Folder Dash One", SourcePath: "new-team/dashboard1.json"},
 		"ren-fold-002": {Title: "Folder Dash Two", SourcePath: "new-team/dashboard2.json"},
 	})
-	common.RequireRepoFolders(t, helper.Folders, ctx, repoName, []string{"new-team"})
+	common.RequireRepoFolders(t, helper.Folders, repoName, []string{"new-team"})
 
-	dash1After, err := helper.DashboardsV1.Resource.Get(ctx, "ren-fold-001", metav1.GetOptions{})
+	dash1After, err := helper.DashboardsV1.Resource.Get(t.Context(), "ren-fold-001", metav1.GetOptions{})
 	require.NoError(t, err)
 	common.RequireUpdatedInPlace(t, "dashboard 1", dash1Snap, common.SnapshotObject(t, dash1After))
 
-	dash2After, err := helper.DashboardsV1.Resource.Get(ctx, "ren-fold-002", metav1.GetOptions{})
+	dash2After, err := helper.DashboardsV1.Resource.Get(t.Context(), "ren-fold-002", metav1.GetOptions{})
 	require.NoError(t, err)
 	common.RequireUpdatedInPlace(t, "dashboard 2", dash2Snap, common.SnapshotObject(t, dash2After))
 }
@@ -334,7 +324,6 @@ func TestIntegrationProvisioning_IncrementalGitSync_RenameFolder(t *testing.T) {
 // that incremental sync handles moving a dashboard between nested folder levels.
 func TestIntegrationProvisioning_IncrementalGitSync_MoveNestedDashboard(t *testing.T) {
 	helper := sharedGitHelper(t)
-	ctx := context.Background()
 
 	const repoName = "git-incremental-move-nested"
 
@@ -344,12 +333,12 @@ func TestIntegrationProvisioning_IncrementalGitSync_MoveNestedDashboard(t *testi
 	}, "write", "branch")
 
 	common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
-	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+	common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 		"nested-001": {Title: "Nested Dashboard", SourcePath: "parent/child-a/dashboard1.json"},
 	})
-	common.RequireRepoFolders(t, helper.Folders, ctx, repoName, []string{"parent", "parent/child-a", "parent/child-b"})
+	common.RequireRepoFolders(t, helper.Folders, repoName, []string{"parent", "parent/child-a", "parent/child-b"})
 
-	dashBefore, err := helper.DashboardsV1.Resource.Get(ctx, "nested-001", metav1.GetOptions{})
+	dashBefore, err := helper.DashboardsV1.Resource.Get(t.Context(), "nested-001", metav1.GetOptions{})
 	require.NoError(t, err)
 	dashSnap := common.SnapshotObject(t, dashBefore)
 
@@ -361,12 +350,12 @@ func TestIntegrationProvisioning_IncrementalGitSync_MoveNestedDashboard(t *testi
 	require.NoError(t, err)
 
 	common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
-	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+	common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 		"nested-001": {Title: "Nested Dashboard", SourcePath: "parent/child-b/dashboard1.json"},
 	})
-	common.RequireRepoFolders(t, helper.Folders, ctx, repoName, []string{"parent", "parent/child-b"})
+	common.RequireRepoFolders(t, helper.Folders, repoName, []string{"parent", "parent/child-b"})
 
-	dashAfter, err := helper.DashboardsV1.Resource.Get(ctx, "nested-001", metav1.GetOptions{})
+	dashAfter, err := helper.DashboardsV1.Resource.Get(t.Context(), "nested-001", metav1.GetOptions{})
 	require.NoError(t, err)
 	common.RequireUpdatedInPlace(t, "dashboard", dashSnap, common.SnapshotObject(t, dashAfter))
 }
@@ -375,7 +364,6 @@ func TestIntegrationProvisioning_IncrementalGitSync_MoveNestedDashboard(t *testi
 // that renaming a nested folder preserves all dashboards inside it.
 func TestIntegrationProvisioning_IncrementalGitSync_RenameNestedFolder(t *testing.T) {
 	helper := sharedGitHelper(t)
-	ctx := context.Background()
 
 	const repoName = "git-incremental-rename-nested"
 
@@ -385,13 +373,13 @@ func TestIntegrationProvisioning_IncrementalGitSync_RenameNestedFolder(t *testin
 	}, "write", "branch")
 
 	common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
-	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+	common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 		"ren-nest-001": {Title: "Nested Rename Dash", SourcePath: "parent/old-child/dashboard1.json"},
 		"ren-nest-002": {Title: "Sibling Dash", SourcePath: "parent/sibling/dashboard2.json"},
 	})
-	common.RequireRepoFolders(t, helper.Folders, ctx, repoName, []string{"parent", "parent/old-child", "parent/sibling"})
+	common.RequireRepoFolders(t, helper.Folders, repoName, []string{"parent", "parent/old-child", "parent/sibling"})
 
-	dashBefore, err := helper.DashboardsV1.Resource.Get(ctx, "ren-nest-001", metav1.GetOptions{})
+	dashBefore, err := helper.DashboardsV1.Resource.Get(t.Context(), "ren-nest-001", metav1.GetOptions{})
 	require.NoError(t, err)
 	dashSnap := common.SnapshotObject(t, dashBefore)
 
@@ -403,13 +391,13 @@ func TestIntegrationProvisioning_IncrementalGitSync_RenameNestedFolder(t *testin
 	require.NoError(t, err)
 
 	common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
-	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+	common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 		"ren-nest-001": {Title: "Nested Rename Dash", SourcePath: "parent/new-child/dashboard1.json"},
 		"ren-nest-002": {Title: "Sibling Dash", SourcePath: "parent/sibling/dashboard2.json"},
 	})
-	common.RequireRepoFolders(t, helper.Folders, ctx, repoName, []string{"parent", "parent/new-child", "parent/sibling"})
+	common.RequireRepoFolders(t, helper.Folders, repoName, []string{"parent", "parent/new-child", "parent/sibling"})
 
-	dashAfter, err := helper.DashboardsV1.Resource.Get(ctx, "ren-nest-001", metav1.GetOptions{})
+	dashAfter, err := helper.DashboardsV1.Resource.Get(t.Context(), "ren-nest-001", metav1.GetOptions{})
 	require.NoError(t, err)
 	common.RequireUpdatedInPlace(t, "dashboard", dashSnap, common.SnapshotObject(t, dashAfter))
 }
@@ -423,7 +411,6 @@ func TestIntegrationProvisioning_IncrementalGitSync_RenameNestedFolder(t *testin
 // path completes without re-validating the unchanged spec.
 func TestIntegrationProvisioning_IncrementalGitSync_PureRename_PreservesContent(t *testing.T) {
 	helper := sharedGitHelper(t)
-	ctx := context.Background()
 
 	const repoName = "git-incremental-pure-rename"
 	const uid = "pure-rename-001"
@@ -434,11 +421,11 @@ func TestIntegrationProvisioning_IncrementalGitSync_PureRename_PreservesContent(
 	}, "write", "branch")
 
 	common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
-	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+	common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 		uid: {Title: "Pure Rename Dash", SourcePath: "old/dashboard.json"},
 	})
 
-	dashBefore, err := helper.DashboardsV1.Resource.Get(ctx, uid, metav1.GetOptions{})
+	dashBefore, err := helper.DashboardsV1.Resource.Get(t.Context(), uid, metav1.GetOptions{})
 	require.NoError(t, err)
 	dashSnap := common.SnapshotObject(t, dashBefore)
 
@@ -451,14 +438,14 @@ func TestIntegrationProvisioning_IncrementalGitSync_PureRename_PreservesContent(
 	require.NoError(t, err)
 
 	common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
-	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+	common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 		uid: {Title: "Pure Rename Dash", SourcePath: "new/dashboard.json"},
 	})
 
 	// The spec must be untouched: an in-place UPDATE was issued, but the body
 	// it carried was the same bytes the cluster already had, so RV bumps and
 	// folder annotation are the only mutations.
-	dashAfter, err := helper.DashboardsV1.Resource.Get(ctx, uid, metav1.GetOptions{})
+	dashAfter, err := helper.DashboardsV1.Resource.Get(t.Context(), uid, metav1.GetOptions{})
 	require.NoError(t, err)
 	common.RequireUpdatedInPlace(t, "dashboard", dashSnap, common.SnapshotObject(t, dashAfter))
 }
@@ -470,7 +457,6 @@ func TestIntegrationProvisioning_IncrementalGitSync_PureRename_PreservesContent(
 // along with a path change.
 func TestIntegrationProvisioning_IncrementalGitSync_RenameWithEdit_AppliesNewContent(t *testing.T) {
 	helper := sharedGitHelper(t)
-	ctx := context.Background()
 
 	const repoName = "git-incremental-rename-with-edit"
 	const uid = "rename-edit-001"
@@ -480,7 +466,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_RenameWithEdit_AppliesNewCon
 	}, "write", "branch")
 
 	common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
-	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+	common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 		uid: {Title: "Original Title", SourcePath: "old/dashboard.json"},
 	})
 
@@ -501,8 +487,8 @@ func TestIntegrationProvisioning_IncrementalGitSync_RenameWithEdit_AppliesNewCon
 	require.NoError(t, err)
 
 	common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
-	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+	common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 		uid: {Title: "Edited Title", SourcePath: "new/dashboard.json"},
 	})
-	common.RequireDashboardTitle(t, helper.DashboardsV1, ctx, uid, "Edited Title")
+	common.RequireDashboardTitle(t, helper.DashboardsV1, uid, "Edited Title")
 }

--- a/pkg/tests/apis/provisioning/git/incremental_test.go
+++ b/pkg/tests/apis/provisioning/git/incremental_test.go
@@ -23,7 +23,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_Add(t *testing.T) {
 	}, "write", "branch")
 
 	common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
-	common.RequireDashboardCount(t, helper.DashboardsV1, 1)
+	helper.RequireRepoDashboardCount(t, repoName, 1)
 
 	require.NoError(t, local.CreateFile("dashboard2.json", string(common.DashboardJSON("incr-dash-002", "Dashboard Two", 1))))
 	_, err := local.Git("add", ".")
@@ -34,7 +34,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_Add(t *testing.T) {
 	require.NoError(t, err)
 
 	common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
-	common.RequireDashboardCount(t, helper.DashboardsV1, 2)
+	helper.RequireRepoDashboardCount(t, repoName, 2)
 }
 
 // TestIntegrationProvisioning_IncrementalGitSync_Update verifies that
@@ -49,7 +49,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_Update(t *testing.T) {
 	}, "write", "branch")
 
 	common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
-	common.RequireDashboardCount(t, helper.DashboardsV1, 1)
+	helper.RequireRepoDashboardCount(t, repoName, 1)
 
 	require.NoError(t, local.UpdateFile("dashboard1.json", string(common.DashboardJSON("incr-dash-001", "Dashboard One Updated", 2))))
 	_, err := local.Git("add", ".")
@@ -60,7 +60,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_Update(t *testing.T) {
 	require.NoError(t, err)
 
 	common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
-	common.RequireDashboardCount(t, helper.DashboardsV1, 1)
+	helper.RequireRepoDashboardCount(t, repoName, 1)
 	common.RequireDashboardTitle(t, helper.DashboardsV1, "incr-dash-001", "Dashboard One Updated")
 }
 
@@ -77,7 +77,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_Delete(t *testing.T) {
 	}, "write", "branch")
 
 	common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
-	common.RequireDashboardCount(t, helper.DashboardsV1, 2)
+	helper.RequireRepoDashboardCount(t, repoName, 2)
 
 	_, err := local.Git("rm", "dashboard2.json")
 	require.NoError(t, err)
@@ -87,7 +87,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_Delete(t *testing.T) {
 	require.NoError(t, err)
 
 	common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
-	common.RequireDashboardCount(t, helper.DashboardsV1, 1)
+	helper.RequireRepoDashboardCount(t, repoName, 1)
 
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		_, err := helper.DashboardsV1.Resource.Get(t.Context(), "incr-dash-002", metav1.GetOptions{})
@@ -107,10 +107,10 @@ func TestIntegrationProvisioning_IncrementalGitSync_Noop(t *testing.T) {
 	}, "write", "branch")
 
 	common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
-	common.RequireDashboardCount(t, helper.DashboardsV1, 1)
+	helper.RequireRepoDashboardCount(t, repoName, 1)
 
 	common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
-	common.RequireDashboardCount(t, helper.DashboardsV1, 1)
+	helper.RequireRepoDashboardCount(t, repoName, 1)
 }
 
 // TestIntegrationProvisioning_IncrementalGitSync_Rename verifies that

--- a/pkg/tests/apis/provisioning/git/incrementaldiffthreshold/incremental_diff_threshold_test.go
+++ b/pkg/tests/apis/provisioning/git/incrementaldiffthreshold/incremental_diff_threshold_test.go
@@ -105,16 +105,15 @@ func createGitRepoWithSyncEnabled(
 	initialFiles map[string][]byte,
 ) (*gittest.RemoteRepository, *gittest.LocalRepo) {
 	t.Helper()
-	ctx := context.Background()
 
 	gitServer := h.GitServer()
-	user, err := gitServer.CreateUser(ctx)
+	user, err := gitServer.CreateUser(t.Context())
 	require.NoError(t, err, "failed to create git user")
 
-	remote, err := gitServer.CreateRepo(ctx, repoName, user)
+	remote, err := gitServer.CreateRepo(t.Context(), repoName, user)
 	require.NoError(t, err, "failed to create git remote repository")
 
-	local, err := gittest.NewLocalRepo(ctx)
+	local, err := gittest.NewLocalRepo(t.Context())
 	require.NoError(t, err, "failed to create git local repository")
 	t.Cleanup(func() {
 		if err := local.Cleanup(); err != nil {
@@ -151,7 +150,7 @@ func createGitRepoWithSyncEnabled(
 		"WorkflowsJSON":       `[]`,
 	})
 
-	_, err = h.Repositories.Resource.Create(ctx, repoObj, metav1.CreateOptions{})
+	_, err = h.Repositories.Resource.Create(t.Context(), repoObj, metav1.CreateOptions{})
 	require.NoError(t, err, "failed to create repository")
 
 	h.WaitForHealthyRepository(t, repoName)

--- a/pkg/tests/apis/provisioning/git/job_commit_author_test.go
+++ b/pkg/tests/apis/provisioning/git/job_commit_author_test.go
@@ -15,7 +15,6 @@ import (
 
 func TestIntegrationGit_DeleteJob_CommitAuthor(t *testing.T) {
 	helper := sharedGitHelper(t)
-	ctx := t.Context()
 
 	const (
 		repoName = "job-commit-author"
@@ -52,12 +51,12 @@ func TestIntegrationGit_DeleteJob_CommitAuthor(t *testing.T) {
 			},
 		})).
 		SetHeader("Content-Type", "application/json").
-		Do(ctx)
+		Do(t.Context())
 	obj, err := result.Get()
 	require.NoError(t, err, "should trigger delete job")
 	unstruct, ok := obj.(*unstructured.Unstructured)
 	require.True(t, ok)
-	helper.AwaitJob(t, ctx, unstruct)
+	helper.AwaitJob(t, unstruct)
 
 	name, email := user.Identity.GetName(), user.Identity.GetEmail()
 	require.NotEmpty(t, name)

--- a/pkg/tests/apis/provisioning/git/managed_dashboard_commit_message_test.go
+++ b/pkg/tests/apis/provisioning/git/managed_dashboard_commit_message_test.go
@@ -1,7 +1,6 @@
 package git
 
 import (
-	"context"
 	"testing"
 
 	dashboardV1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1"
@@ -29,7 +28,6 @@ import (
 
 func TestIntegrationGit_ManagedDashboardUpdate_CommitMessage(t *testing.T) {
 	helper := sharedGitHelper(t)
-	ctx := context.Background()
 
 	const (
 		repoName     = "managed-msg-update"
@@ -41,10 +39,10 @@ func TestIntegrationGit_ManagedDashboardUpdate_CommitMessage(t *testing.T) {
 		dashboardFn: common.DashboardJSON(dashboardUID, "Managed Dashboard", 1),
 	})
 	helper.SyncAndWait(t, repoName)
-	common.RequireRepoManagedDashboard(t, helper.DashboardsV1, ctx, dashboardUID, repoName, dashboardFn)
+	common.RequireRepoManagedDashboard(t, helper.DashboardsV1, dashboardUID, repoName, dashboardFn)
 
 	t.Run("fallback message", func(t *testing.T) {
-		fresh, err := helper.DashboardsV1.Resource.Get(ctx, dashboardUID, metav1.GetOptions{})
+		fresh, err := helper.DashboardsV1.Resource.Get(t.Context(), dashboardUID, metav1.GetOptions{})
 		require.NoError(t, err)
 
 		annotations := fresh.GetAnnotations()
@@ -52,7 +50,7 @@ func TestIntegrationGit_ManagedDashboardUpdate_CommitMessage(t *testing.T) {
 		fresh.SetAnnotations(annotations)
 		require.NoError(t, unstructured.SetNestedField(fresh.Object, "Updated (fallback)", "spec", "title"))
 
-		_, err = helper.DashboardsV1.Resource.Update(ctx, fresh, metav1.UpdateOptions{})
+		_, err = helper.DashboardsV1.Resource.Update(t.Context(), fresh, metav1.UpdateOptions{})
 		require.NoError(t, err, "PUT must not fail with empty commit message")
 
 		require.Equal(t, "Update "+dashboardUID, common.LatestCommitSubject(t, local, "main"))
@@ -60,7 +58,7 @@ func TestIntegrationGit_ManagedDashboardUpdate_CommitMessage(t *testing.T) {
 
 	t.Run("annotation message", func(t *testing.T) {
 		const msg = "Updated dashboard from integration test"
-		fresh, err := helper.DashboardsV1.Resource.Get(ctx, dashboardUID, metav1.GetOptions{})
+		fresh, err := helper.DashboardsV1.Resource.Get(t.Context(), dashboardUID, metav1.GetOptions{})
 		require.NoError(t, err)
 
 		annotations := fresh.GetAnnotations()
@@ -71,7 +69,7 @@ func TestIntegrationGit_ManagedDashboardUpdate_CommitMessage(t *testing.T) {
 		fresh.SetAnnotations(annotations)
 		require.NoError(t, unstructured.SetNestedField(fresh.Object, "Updated (annotated)", "spec", "title"))
 
-		_, err = helper.DashboardsV1.Resource.Update(ctx, fresh, metav1.UpdateOptions{})
+		_, err = helper.DashboardsV1.Resource.Update(t.Context(), fresh, metav1.UpdateOptions{})
 		require.NoError(t, err)
 
 		require.Equal(t, msg, common.LatestCommitSubject(t, local, "main"))
@@ -80,7 +78,6 @@ func TestIntegrationGit_ManagedDashboardUpdate_CommitMessage(t *testing.T) {
 
 func TestIntegrationGit_ManagedDashboardCreate_CommitMessage(t *testing.T) {
 	helper := sharedGitHelper(t)
-	ctx := context.Background()
 	dashboardAPIVersion := dashboardV1.DashboardResourceInfo.GroupVersion().String()
 
 	const repoName = "managed-msg-create"
@@ -96,7 +93,7 @@ func TestIntegrationGit_ManagedDashboardCreate_CommitMessage(t *testing.T) {
 		)
 		dash := common.NewManagedDashboard(dashboardAPIVersion, newUID, repoName, newFn, msg)
 
-		_, err := helper.DashboardsV1.Resource.Create(ctx, dash, metav1.CreateOptions{})
+		_, err := helper.DashboardsV1.Resource.Create(t.Context(), dash, metav1.CreateOptions{})
 		require.NoError(t, err, "POST must not fail with empty commit message")
 
 		require.Equal(t, msg, common.LatestCommitSubject(t, local, "main"))
@@ -109,7 +106,7 @@ func TestIntegrationGit_ManagedDashboardCreate_CommitMessage(t *testing.T) {
 		)
 		dash := common.NewManagedDashboard(dashboardAPIVersion, newUID, repoName, newFn, "")
 
-		_, err := helper.DashboardsV1.Resource.Create(ctx, dash, metav1.CreateOptions{})
+		_, err := helper.DashboardsV1.Resource.Create(t.Context(), dash, metav1.CreateOptions{})
 		require.NoError(t, err, "POST must not fail with empty commit message")
 
 		require.Equal(t, "Create "+newUID, common.LatestCommitSubject(t, local, "main"))
@@ -118,7 +115,6 @@ func TestIntegrationGit_ManagedDashboardCreate_CommitMessage(t *testing.T) {
 
 func TestIntegrationGit_ManagedDashboardDelete_CommitMessage(t *testing.T) {
 	helper := sharedGitHelper(t)
-	ctx := context.Background()
 
 	const (
 		repoName     = "managed-msg-delete"
@@ -130,9 +126,9 @@ func TestIntegrationGit_ManagedDashboardDelete_CommitMessage(t *testing.T) {
 		dashboardFn: common.DashboardJSON(dashboardUID, "Managed Dashboard", 1),
 	})
 	helper.SyncAndWait(t, repoName)
-	common.RequireRepoManagedDashboard(t, helper.DashboardsV1, ctx, dashboardUID, repoName, dashboardFn)
+	common.RequireRepoManagedDashboard(t, helper.DashboardsV1, dashboardUID, repoName, dashboardFn)
 
-	require.NoError(t, helper.DashboardsV1.Resource.Delete(ctx, dashboardUID, metav1.DeleteOptions{}),
+	require.NoError(t, helper.DashboardsV1.Resource.Delete(t.Context(), dashboardUID, metav1.DeleteOptions{}),
 		"DELETE must not fail with empty commit message")
 
 	require.Equal(t, "Delete "+dashboardUID, common.LatestCommitSubject(t, local, "main"))

--- a/pkg/tests/apis/provisioning/git/managed_dashboard_commit_message_test.go
+++ b/pkg/tests/apis/provisioning/git/managed_dashboard_commit_message_test.go
@@ -78,6 +78,7 @@ func TestIntegrationGit_ManagedDashboardUpdate_CommitMessage(t *testing.T) {
 
 func TestIntegrationGit_ManagedDashboardCreate_CommitMessage(t *testing.T) {
 	helper := sharedGitHelper(t)
+
 	dashboardAPIVersion := dashboardV1.DashboardResourceInfo.GroupVersion().String()
 
 	const repoName = "managed-msg-create"

--- a/pkg/tests/apis/provisioning/git/metadata_name_change_test.go
+++ b/pkg/tests/apis/provisioning/git/metadata_name_change_test.go
@@ -1,7 +1,6 @@
 package git
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -18,7 +17,6 @@ import (
 // no orphan is left behind.
 func TestIntegrationProvisioning_IncrementalGitSync_MetadataNameChange(t *testing.T) {
 	helper := sharedGitHelper(t)
-	ctx := context.Background()
 
 	const repoName = "git-incremental-name-change"
 
@@ -27,8 +25,8 @@ func TestIntegrationProvisioning_IncrementalGitSync_MetadataNameChange(t *testin
 	}, "write", "branch")
 
 	common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
-	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 1)
-	common.RequireDashboardTitle(t, helper.DashboardsV1, ctx, "name-change-incr-001", "Dashboard One")
+	common.RequireDashboardCount(t, helper.DashboardsV1, 1)
+	common.RequireDashboardTitle(t, helper.DashboardsV1, "name-change-incr-001", "Dashboard One")
 
 	// Change the metadata.name (uid) in the same file path.
 	require.NoError(t, local.UpdateFile("dashboard1.json", string(common.DashboardJSON("name-change-incr-002", "Dashboard One Renamed", 2))))
@@ -43,7 +41,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MetadataNameChange(t *testin
 
 	// The new dashboard should exist with the new name.
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		d, err := helper.DashboardsV1.Resource.Get(ctx, "name-change-incr-002", metav1.GetOptions{})
+		d, err := helper.DashboardsV1.Resource.Get(t.Context(), "name-change-incr-002", metav1.GetOptions{})
 		assert.NoError(c, err, "new dashboard should exist")
 		if d != nil {
 			assert.Equal(c, "name-change-incr-002", d.GetName())
@@ -52,9 +50,9 @@ func TestIntegrationProvisioning_IncrementalGitSync_MetadataNameChange(t *testin
 
 	// The old dashboard should be deleted — no orphan left behind.
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		_, err := helper.DashboardsV1.Resource.Get(ctx, "name-change-incr-001", metav1.GetOptions{})
+		_, err := helper.DashboardsV1.Resource.Get(t.Context(), "name-change-incr-001", metav1.GetOptions{})
 		assert.True(c, apierrors.IsNotFound(err), "old dashboard should be NotFound, got: %v", err)
 	}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "old dashboard should be deleted after name change")
 
-	common.RequireDashboardCount(t, helper.DashboardsV1, ctx, 1)
+	common.RequireDashboardCount(t, helper.DashboardsV1, 1)
 }

--- a/pkg/tests/apis/provisioning/git/metadata_name_change_test.go
+++ b/pkg/tests/apis/provisioning/git/metadata_name_change_test.go
@@ -25,7 +25,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MetadataNameChange(t *testin
 	}, "write", "branch")
 
 	common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
-	common.RequireDashboardCount(t, helper.DashboardsV1, 1)
+	helper.RequireRepoDashboardCount(t, repoName, 1)
 	common.RequireDashboardTitle(t, helper.DashboardsV1, "name-change-incr-001", "Dashboard One")
 
 	// Change the metadata.name (uid) in the same file path.
@@ -54,5 +54,5 @@ func TestIntegrationProvisioning_IncrementalGitSync_MetadataNameChange(t *testin
 		assert.True(c, apierrors.IsNotFound(err), "old dashboard should be NotFound, got: %v", err)
 	}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "old dashboard should be deleted after name change")
 
-	common.RequireDashboardCount(t, helper.DashboardsV1, 1)
+	helper.RequireRepoDashboardCount(t, repoName, 1)
 }

--- a/pkg/tests/apis/provisioning/git/quota_test.go
+++ b/pkg/tests/apis/provisioning/git/quota_test.go
@@ -25,7 +25,7 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 
 		// Initial full sync fills the quota (2/2).
 		common.SyncAndWait(t, helper, common.Repo(repo), common.Succeeded())
-		common.RequireRepoDashboardCount(t, helper, repo, 2)
+		helper.RequireRepoDashboardCount(t, repo, 2)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
 
 		// Create dashboard3
@@ -60,7 +60,7 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 			"quota warning should identify the skipped file")
 
 		// Quota is still at 2/2 — dashboard3 was never created.
-		common.RequireRepoDashboardCount(t, helper, repo, 2)
+		helper.RequireRepoDashboardCount(t, repo, 2)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
 	})
 
@@ -75,7 +75,7 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 		})
 
 		common.SyncAndWait(t, helper, common.Repo(repo), common.Succeeded())
-		common.RequireRepoDashboardCount(t, helper, repo, 1)
+		helper.RequireRepoDashboardCount(t, repo, 1)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
 
 		// Commit A — remove dashboard1.json from the git tree.
@@ -117,7 +117,7 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 		require.Empty(t, jobObj.Status.Warnings, "no quota warnings expected when the delete frees room for the create")
 
 		// dashboard1 deleted, dashboard2 created — net zero, still at 1/1.
-		common.RequireRepoDashboardCount(t, helper, repo, 1)
+		helper.RequireRepoDashboardCount(t, repo, 1)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
 	})
 
@@ -133,7 +133,7 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 		})
 
 		common.SyncAndWait(t, helper, common.Repo(repo), common.Succeeded())
-		common.RequireRepoDashboardCount(t, helper, repo, 2)
+		helper.RequireRepoDashboardCount(t, repo, 2)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
 
 		// Incremental sync 1 — commit a deletion of dashboard1 to the git repo,
@@ -147,7 +147,7 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 		require.NoError(t, err)
 
 		common.SyncAndWait(t, helper, common.Repo(repo), common.Incremental, common.Succeeded())
-		common.RequireRepoDashboardCount(t, helper, repo, 1)
+		helper.RequireRepoDashboardCount(t, repo, 1)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonWithinQuota)
 
 		// Incremental sync 2 — commit dashboard3 to the git repo; the freed slot
@@ -162,7 +162,7 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 		require.NoError(t, err)
 
 		common.SyncAndWait(t, helper, common.Repo(repo), common.Incremental, common.Succeeded())
-		common.RequireRepoDashboardCount(t, helper, repo, 2)
+		helper.RequireRepoDashboardCount(t, repo, 2)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
 	})
 
@@ -181,8 +181,8 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 
 		// Initial full sync: 2 dashboards + 1 implicit folder = 3/3 resources.
 		common.SyncAndWait(t, helper, common.Repo(repo), common.Succeeded())
-		common.RequireRepoDashboardCount(t, helper, repo, 2)
-		common.RequireRepoFolderCount(t, helper, repo, 1)
+		helper.RequireRepoDashboardCount(t, repo, 2)
+		helper.RequireRepoFolderCount(t, repo, 1)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
 
 		// Push a new dashboard inside a brand-new subfolder.
@@ -215,8 +215,8 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 			"quota warning should identify the skipped file")
 
 		// Still 2 dashboards and 1 folder — folder2 was never created.
-		common.RequireRepoDashboardCount(t, helper, repo, 2)
-		common.RequireRepoFolderCount(t, helper, repo, 1)
+		helper.RequireRepoDashboardCount(t, repo, 2)
+		helper.RequireRepoFolderCount(t, repo, 1)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
 	})
 
@@ -234,8 +234,8 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 
 		// Initial full sync: folder1 + dash1 + dash2 = 3/3 resources.
 		common.SyncAndWait(t, helper, common.Repo(repo), common.Succeeded())
-		common.RequireRepoDashboardCount(t, helper, repo, 2)
-		common.RequireRepoFolderCount(t, helper, repo, 1)
+		helper.RequireRepoDashboardCount(t, repo, 2)
+		helper.RequireRepoFolderCount(t, repo, 1)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
 
 		// Remove the only dashboard inside folder1 so the folder becomes orphaned.
@@ -251,8 +251,8 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 		common.SyncAndWait(t, helper, common.Repo(repo), common.Incremental, common.Succeeded())
 
 		// dashboard1 and folder1 are gone; only dashboard2 remains.
-		common.RequireRepoDashboardCount(t, helper, repo, 1)
-		common.RequireRepoFolderCount(t, helper, repo, 0)
+		helper.RequireRepoDashboardCount(t, repo, 1)
+		helper.RequireRepoFolderCount(t, repo, 0)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonWithinQuota)
 	})
 
@@ -267,7 +267,7 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 		})
 
 		common.SyncAndWait(t, helper, common.Repo(repo), common.Succeeded())
-		common.RequireRepoDashboardCount(t, helper, repo, 1)
+		helper.RequireRepoDashboardCount(t, repo, 1)
 
 		// Add three more dashboards as separate git commits pushed to the remote.
 		for i, uid := range []string{"incr-ulim-dash-002", "incr-ulim-dash-003", "incr-ulim-dash-004"} {
@@ -294,7 +294,7 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 			"unlimited quota should allow all creates")
 		require.Empty(t, jobObj.Status.Warnings, "no quota warnings expected with unlimited quota")
 
-		common.RequireRepoDashboardCount(t, helper, repo, 4)
+		helper.RequireRepoDashboardCount(t, repo, 4)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaUnlimited)
 	})
 }

--- a/pkg/tests/apis/provisioning/git/quota_test.go
+++ b/pkg/tests/apis/provisioning/git/quota_test.go
@@ -1,7 +1,6 @@
 package git
 
 import (
-	"context"
 	"testing"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
@@ -15,9 +14,8 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 
 	// ─── Skips creates when the repository is at its resource quota ──────────
 	t.Run("skips creates when at quota", func(t *testing.T) {
-		helper.CleanupAllResources(t, context.Background())
+		helper.CleanupAllResources(t)
 		helper.SetQuotaStatus(provisioning.QuotaStatus{MaxResourcesPerRepository: 2})
-		ctx := context.Background()
 
 		const repo = "incr-quota-blocks-repo"
 		_, local := helper.CreateGitRepo(t, repo, map[string][]byte{
@@ -27,7 +25,7 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 
 		// Initial full sync fills the quota (2/2).
 		common.SyncAndWait(t, helper, common.Repo(repo), common.Succeeded())
-		common.RequireRepoDashboardCount(t, helper, ctx, repo, 2)
+		common.RequireRepoDashboardCount(t, helper, repo, 2)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
 
 		// Create dashboard3
@@ -62,15 +60,14 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 			"quota warning should identify the skipped file")
 
 		// Quota is still at 2/2 — dashboard3 was never created.
-		common.RequireRepoDashboardCount(t, helper, ctx, repo, 2)
+		common.RequireRepoDashboardCount(t, helper, repo, 2)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
 	})
 
 	// ─── Delete-and-create in the same incremental window respects priority ──
 	t.Run("delete and create in same incremental window respects deletion-first priority", func(t *testing.T) {
-		helper.CleanupAllResources(t, context.Background())
+		helper.CleanupAllResources(t)
 		helper.SetQuotaStatus(provisioning.QuotaStatus{MaxResourcesPerRepository: 1})
-		ctx := context.Background()
 
 		const repo = "incr-quota-swap-repo"
 		_, local := helper.CreateGitRepo(t, repo, map[string][]byte{
@@ -78,7 +75,7 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 		})
 
 		common.SyncAndWait(t, helper, common.Repo(repo), common.Succeeded())
-		common.RequireRepoDashboardCount(t, helper, ctx, repo, 1)
+		common.RequireRepoDashboardCount(t, helper, repo, 1)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
 
 		// Commit A — remove dashboard1.json from the git tree.
@@ -120,15 +117,14 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 		require.Empty(t, jobObj.Status.Warnings, "no quota warnings expected when the delete frees room for the create")
 
 		// dashboard1 deleted, dashboard2 created — net zero, still at 1/1.
-		common.RequireRepoDashboardCount(t, helper, ctx, repo, 1)
+		common.RequireRepoDashboardCount(t, helper, repo, 1)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
 	})
 
 	// ─── Delete releases a slot for the *next* incremental sync ──────────────
 	t.Run("delete in one incremental sync releases quota for a subsequent sync", func(t *testing.T) {
-		helper.CleanupAllResources(t, context.Background())
+		helper.CleanupAllResources(t)
 		helper.SetQuotaStatus(provisioning.QuotaStatus{MaxResourcesPerRepository: 2})
-		ctx := context.Background()
 
 		const repo = "incr-quota-release-repo"
 		_, local := helper.CreateGitRepo(t, repo, map[string][]byte{
@@ -137,7 +133,7 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 		})
 
 		common.SyncAndWait(t, helper, common.Repo(repo), common.Succeeded())
-		common.RequireRepoDashboardCount(t, helper, ctx, repo, 2)
+		common.RequireRepoDashboardCount(t, helper, repo, 2)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
 
 		// Incremental sync 1 — commit a deletion of dashboard1 to the git repo,
@@ -151,7 +147,7 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 		require.NoError(t, err)
 
 		common.SyncAndWait(t, helper, common.Repo(repo), common.Incremental, common.Succeeded())
-		common.RequireRepoDashboardCount(t, helper, ctx, repo, 1)
+		common.RequireRepoDashboardCount(t, helper, repo, 1)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonWithinQuota)
 
 		// Incremental sync 2 — commit dashboard3 to the git repo; the freed slot
@@ -166,17 +162,16 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 		require.NoError(t, err)
 
 		common.SyncAndWait(t, helper, common.Repo(repo), common.Incremental, common.Succeeded())
-		common.RequireRepoDashboardCount(t, helper, ctx, repo, 2)
+		common.RequireRepoDashboardCount(t, helper, repo, 2)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
 	})
 
 	// ─── Folder+dashboard pair skipped when at quota ───────────────
 	t.Run("folder and its dashboard creation are skipped when at quota", func(t *testing.T) {
-		helper.CleanupAllResources(t, context.Background())
+		helper.CleanupAllResources(t)
 		// quota=3 accounts for exactly: 1 folder + 2 dashboards from the initial
 		// setup, so the repo starts at capacity.
 		helper.SetQuotaStatus(provisioning.QuotaStatus{MaxResourcesPerRepository: 3})
-		ctx := context.Background()
 
 		const repo = "incr-quota-folder-block-repo"
 		_, local := helper.CreateGitRepo(t, repo, map[string][]byte{
@@ -186,8 +181,8 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 
 		// Initial full sync: 2 dashboards + 1 implicit folder = 3/3 resources.
 		common.SyncAndWait(t, helper, common.Repo(repo), common.Succeeded())
-		common.RequireRepoDashboardCount(t, helper, ctx, repo, 2)
-		common.RequireRepoFolderCount(t, helper, ctx, repo, 1)
+		common.RequireRepoDashboardCount(t, helper, repo, 2)
+		common.RequireRepoFolderCount(t, helper, repo, 1)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
 
 		// Push a new dashboard inside a brand-new subfolder.
@@ -220,17 +215,16 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 			"quota warning should identify the skipped file")
 
 		// Still 2 dashboards and 1 folder — folder2 was never created.
-		common.RequireRepoDashboardCount(t, helper, ctx, repo, 2)
-		common.RequireRepoFolderCount(t, helper, ctx, repo, 1)
+		common.RequireRepoDashboardCount(t, helper, repo, 2)
+		common.RequireRepoFolderCount(t, helper, repo, 1)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
 	})
 
 	// ─── Delete folder's last dashboard: orphaned folder cleaned up ───────────
 	t.Run("deleting folder's only dashboard releases quota and cleans up orphaned folder", func(t *testing.T) {
-		helper.CleanupAllResources(t, context.Background())
+		helper.CleanupAllResources(t)
 		// quota=3: 1 folder (folder1) + 1 subfolder dashboard + 1 root dashboard = 3/3.
 		helper.SetQuotaStatus(provisioning.QuotaStatus{MaxResourcesPerRepository: 3})
-		ctx := context.Background()
 
 		const repo = "incr-quota-folder-cleanup-repo"
 		_, local := helper.CreateGitRepo(t, repo, map[string][]byte{
@@ -240,8 +234,8 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 
 		// Initial full sync: folder1 + dash1 + dash2 = 3/3 resources.
 		common.SyncAndWait(t, helper, common.Repo(repo), common.Succeeded())
-		common.RequireRepoDashboardCount(t, helper, ctx, repo, 2)
-		common.RequireRepoFolderCount(t, helper, ctx, repo, 1)
+		common.RequireRepoDashboardCount(t, helper, repo, 2)
+		common.RequireRepoFolderCount(t, helper, repo, 1)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
 
 		// Remove the only dashboard inside folder1 so the folder becomes orphaned.
@@ -257,16 +251,15 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 		common.SyncAndWait(t, helper, common.Repo(repo), common.Incremental, common.Succeeded())
 
 		// dashboard1 and folder1 are gone; only dashboard2 remains.
-		common.RequireRepoDashboardCount(t, helper, ctx, repo, 1)
-		common.RequireRepoFolderCount(t, helper, ctx, repo, 0)
+		common.RequireRepoDashboardCount(t, helper, repo, 1)
+		common.RequireRepoFolderCount(t, helper, repo, 0)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonWithinQuota)
 	})
 
 	// ─── Unlimited quota never blocks incremental creates ─────────────────────
 	t.Run("unlimited quota does not block incremental creates", func(t *testing.T) {
-		helper.CleanupAllResources(t, context.Background())
+		helper.CleanupAllResources(t)
 		helper.SetQuotaStatus(provisioning.QuotaStatus{})
-		ctx := context.Background()
 
 		const repo = "incr-quota-unlimited-repo"
 		_, local := helper.CreateGitRepo(t, repo, map[string][]byte{
@@ -274,7 +267,7 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 		})
 
 		common.SyncAndWait(t, helper, common.Repo(repo), common.Succeeded())
-		common.RequireRepoDashboardCount(t, helper, ctx, repo, 1)
+		common.RequireRepoDashboardCount(t, helper, repo, 1)
 
 		// Add three more dashboards as separate git commits pushed to the remote.
 		for i, uid := range []string{"incr-ulim-dash-002", "incr-ulim-dash-003", "incr-ulim-dash-004"} {
@@ -301,7 +294,7 @@ func TestIntegrationProvisioning_IncrementalGitQuota(t *testing.T) {
 			"unlimited quota should allow all creates")
 		require.Empty(t, jobObj.Status.Warnings, "no quota warnings expected with unlimited quota")
 
-		common.RequireRepoDashboardCount(t, helper, ctx, repo, 4)
+		common.RequireRepoDashboardCount(t, helper, repo, 4)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaUnlimited)
 	})
 }

--- a/pkg/tests/apis/provisioning/git/sourcepath_guard/sourcepath_guard_test.go
+++ b/pkg/tests/apis/provisioning/git/sourcepath_guard/sourcepath_guard_test.go
@@ -1,7 +1,6 @@
 package sourcepathguard
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -18,7 +17,6 @@ import (
 // preserving the resource that A just claimed.
 func TestIntegrationProvisioning_IncrementalGitSync_MultiFileUIDTakeover(t *testing.T) {
 	helper := sharedGitHelper(t)
-	ctx := context.Background()
 
 	const repoName = "git-incr-uid-takeover"
 
@@ -28,7 +26,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MultiFileUIDTakeover(t *test
 	}, "write", "branch")
 
 	common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
-	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+	common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 		"takeover-uid-a": {Title: "Dashboard A", SourcePath: "dashboard_a.json"},
 		"takeover-uid-b": {Title: "Dashboard B", SourcePath: "dashboard_b.json"},
 	})
@@ -50,7 +48,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MultiFileUIDTakeover(t *test
 
 	helper.SyncAndWaitIncremental(t, repoName)
 
-	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+	common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 		"takeover-uid-b":   {Title: "Dashboard A Took B", SourcePath: "dashboard_a.json"},
 		"takeover-uid-new": {Title: "Dashboard B New UID", SourcePath: "dashboard_b.json"},
 	})
@@ -72,7 +70,6 @@ func TestIntegrationProvisioning_IncrementalGitSync_MultiFileUIDTakeover(t *test
 // Both dashboards survive with their UIDs swapped.
 func TestIntegrationProvisioning_IncrementalGitSync_MultiFileUIDSwap(t *testing.T) {
 	helper := sharedGitHelper(t)
-	ctx := context.Background()
 
 	const repoName = "git-incr-uid-swap"
 
@@ -82,7 +79,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MultiFileUIDSwap(t *testing.
 	}, "write", "branch")
 
 	common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
-	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+	common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 		"swap-uid-a": {Title: "Dashboard A", SourcePath: "dashboard_a.json"},
 		"swap-uid-b": {Title: "Dashboard B", SourcePath: "dashboard_b.json"},
 	})
@@ -99,7 +96,7 @@ func TestIntegrationProvisioning_IncrementalGitSync_MultiFileUIDSwap(t *testing.
 
 	helper.SyncAndWaitIncremental(t, repoName)
 
-	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+	common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 		"swap-uid-a": {Title: "Dashboard B Swapped", SourcePath: "dashboard_b.json"},
 		"swap-uid-b": {Title: "Dashboard A Swapped", SourcePath: "dashboard_a.json"},
 	})
@@ -123,7 +120,6 @@ func TestIntegrationProvisioning_IncrementalGitSync_MultiFileUIDSwap(t *testing.
 // exists to document the bug and verify the recovery path.
 func TestIntegrationProvisioning_FullSync_MultiFileUIDTakeover_Recovery(t *testing.T) {
 	helper := sharedGitHelper(t)
-	ctx := context.Background()
 
 	const repoName = "git-full-uid-takeover-recovery"
 
@@ -133,7 +129,7 @@ func TestIntegrationProvisioning_FullSync_MultiFileUIDTakeover_Recovery(t *testi
 	}, "write", "branch")
 
 	common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
-	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+	common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 		"full-uid-a": {Title: "Dashboard A", SourcePath: "dashboard_a.json"},
 		"full-uid-b": {Title: "Dashboard B", SourcePath: "dashboard_b.json"},
 	})
@@ -159,7 +155,7 @@ func TestIntegrationProvisioning_FullSync_MultiFileUIDTakeover_Recovery(t *testi
 	// After this, the state must converge to the correct result.
 	common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
 
-	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+	common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 		"full-uid-b":   {Title: "Dashboard A Took B", SourcePath: "dashboard_a.json"},
 		"full-uid-new": {Title: "Dashboard B New UID", SourcePath: "dashboard_b.json"},
 	})
@@ -180,7 +176,6 @@ func TestIntegrationProvisioning_FullSync_MultiFileUIDTakeover_Recovery(t *testi
 // current Grafana resources and re-creates any missing dashboards.
 func TestIntegrationProvisioning_FullSync_MultiFileUIDSwap_Recovery(t *testing.T) {
 	helper := sharedGitHelper(t)
-	ctx := context.Background()
 
 	const repoName = "git-full-uid-swap-recovery"
 
@@ -190,7 +185,7 @@ func TestIntegrationProvisioning_FullSync_MultiFileUIDSwap_Recovery(t *testing.T
 	}, "write", "branch")
 
 	common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
-	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+	common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 		"fswap-uid-a": {Title: "Dashboard A", SourcePath: "dashboard_a.json"},
 		"fswap-uid-b": {Title: "Dashboard B", SourcePath: "dashboard_b.json"},
 	})
@@ -214,7 +209,7 @@ func TestIntegrationProvisioning_FullSync_MultiFileUIDSwap_Recovery(t *testing.T
 	// resources, converging to the correct state.
 	common.SyncAndWait(t, helper, common.Repo(repoName), common.Succeeded())
 
-	common.RequireDashboards(t, helper.DashboardsV1, ctx, map[string]common.ExpectedDashboard{
+	common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 		"fswap-uid-a": {Title: "Dashboard B Swapped", SourcePath: "dashboard_b.json"},
 		"fswap-uid-b": {Title: "Dashboard A Swapped", SourcePath: "dashboard_a.json"},
 	})

--- a/pkg/tests/apis/provisioning/git/url_token_test.go
+++ b/pkg/tests/apis/provisioning/git/url_token_test.go
@@ -1,7 +1,6 @@
 package git
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -20,7 +19,6 @@ import (
 
 func TestIntegrationProvisioning_GitRequiresNewTokenWhenRepositoryURLChanges(t *testing.T) {
 	helper := sharedGitHelper(t)
-	ctx := context.Background()
 
 	repoName := "git-url-change-test"
 	helper.CreateGitRepo(t, repoName, map[string][]byte{
@@ -29,13 +27,13 @@ func TestIntegrationProvisioning_GitRequiresNewTokenWhenRepositoryURLChanges(t *
 
 	t.Run("update rejects url change without a new token", func(t *testing.T) {
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
-			repo, err := helper.Repositories.Resource.Get(ctx, repoName, metav1.GetOptions{})
+			repo, err := helper.Repositories.Resource.Get(t.Context(), repoName, metav1.GetOptions{})
 			require.NoError(collect, err)
 			updated := common.MustToUnstructured(t, repo)
 			require.NoError(collect, unstructured.SetNestedField(updated.Object, "https://some-new-url/", "spec", "git", "url"))
 			unstructured.RemoveNestedField(updated.Object, "secure", "token")
 
-			_, err = helper.Repositories.Resource.Update(ctx, updated, metav1.UpdateOptions{})
+			_, err = helper.Repositories.Resource.Update(t.Context(), updated, metav1.UpdateOptions{})
 			require.Error(collect, err)
 			require.True(collect, apierrors.IsInvalid(err), "expected invalid repository update, got %v", err)
 			require.ErrorContains(collect, err, "secure.token")
@@ -47,7 +45,7 @@ func TestIntegrationProvisioning_GitRequiresNewTokenWhenRepositoryURLChanges(t *
 		changedRemote, changedUser := createEmptyGitRepo(t, helper, "git-url-change-new-token-new")
 
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
-			repo, err := helper.Repositories.Resource.Get(ctx, repoName, metav1.GetOptions{})
+			repo, err := helper.Repositories.Resource.Get(t.Context(), repoName, metav1.GetOptions{})
 			require.NoError(collect, err)
 
 			repoObj := common.MustFromUnstructured[provisioning.Repository](t, repo)
@@ -55,7 +53,7 @@ func TestIntegrationProvisioning_GitRequiresNewTokenWhenRepositoryURLChanges(t *
 			repoObj.Spec.Git.TokenUser = changedUser.Username
 			repoObj.Secure.Token = apicommon.InlineSecureValue{Create: apicommon.RawSecureValue(changedUser.Password)}
 
-			result, err := helper.Repositories.Resource.Update(ctx, common.MustToUnstructured(t, repoObj), metav1.UpdateOptions{})
+			result, err := helper.Repositories.Resource.Update(t.Context(), common.MustToUnstructured(t, repoObj), metav1.UpdateOptions{})
 			require.NoError(collect, err)
 
 			updatedRepo := common.MustFromUnstructured[provisioning.Repository](t, result)
@@ -98,7 +96,7 @@ func TestIntegrationProvisioning_GitRequiresNewTokenWhenRepositoryURLChanges(t *
 			SubResource("test").
 			Body(configBytes).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.Error(t, result.Error())
 		require.Equal(t, http.StatusBadRequest, statusCode)
@@ -109,7 +107,7 @@ func TestIntegrationProvisioning_GitRequiresNewTokenWhenRepositoryURLChanges(t *
 	t.Run("test subresource allows url change with a new token", func(t *testing.T) {
 		changedRemote, changedUser := createEmptyGitRepo(t, helper, "git-url-change-test-no-token-new")
 
-		local, err := gittest.NewLocalRepo(ctx)
+		local, err := gittest.NewLocalRepo(t.Context())
 		require.NoError(t, err, "failed to create local repository")
 		t.Cleanup(func() {
 			if err := local.Cleanup(); err != nil {
@@ -156,7 +154,7 @@ func TestIntegrationProvisioning_GitRequiresNewTokenWhenRepositoryURLChanges(t *
 			SubResource("test").
 			Body(configBytes).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.NoError(t, result.Error())
 		require.Equal(t, http.StatusOK, statusCode)

--- a/pkg/tests/apis/provisioning/git/webhook/webhook_test.go
+++ b/pkg/tests/apis/provisioning/git/webhook/webhook_test.go
@@ -106,6 +106,7 @@ func expectedWebhookURL(baseURL, namespace, repoName string) string {
 // waitForWebhook polls until Status.Webhook is populated with the expected ID.
 func waitForWebhook(t *testing.T, helper *common.GitTestHelper, repoName string, expectedID int64) {
 	t.Helper()
+
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		obj, err := helper.Repositories.Resource.Get(t.Context(), repoName, metav1.GetOptions{})
 		require.NoError(collect, err)

--- a/pkg/tests/apis/provisioning/git/webhook/webhook_test.go
+++ b/pkg/tests/apis/provisioning/git/webhook/webhook_test.go
@@ -1,7 +1,6 @@
 package webhook
 
 import (
-	"context"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
@@ -107,9 +106,8 @@ func expectedWebhookURL(baseURL, namespace, repoName string) string {
 // waitForWebhook polls until Status.Webhook is populated with the expected ID.
 func waitForWebhook(t *testing.T, helper *common.GitTestHelper, repoName string, expectedID int64) {
 	t.Helper()
-	ctx := context.Background()
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		obj, err := helper.Repositories.Resource.Get(ctx, repoName, metav1.GetOptions{})
+		obj, err := helper.Repositories.Resource.Get(t.Context(), repoName, metav1.GetOptions{})
 		require.NoError(collect, err)
 		repo := common.MustFromUnstructured[provisioning.Repository](t, obj)
 		require.NotNil(collect, repo.Status.Webhook, "webhook should be set")
@@ -120,7 +118,6 @@ func waitForWebhook(t *testing.T, helper *common.GitTestHelper, repoName string,
 
 func TestIntegrationProvisioning_GithubRepoNoWebhookWhenDisabled(t *testing.T) {
 	helper := sharedGitHelper(t)
-	ctx := context.Background()
 
 	// The package enables a public root URL so webhook delivery can be tested;
 	// this repo opts out explicitly and should not register a webhook.
@@ -132,7 +129,7 @@ func TestIntegrationProvisioning_GithubRepoNoWebhookWhenDisabled(t *testing.T) {
 	}, "write")
 
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		obj, err := helper.Repositories.Resource.Get(ctx, repoName, metav1.GetOptions{})
+		obj, err := helper.Repositories.Resource.Get(t.Context(), repoName, metav1.GetOptions{})
 		if !assert.NoError(collect, err) {
 			return
 		}
@@ -164,7 +161,6 @@ func TestIntegrationProvisioning_GithubRepoWebhookCreated(t *testing.T) {
 // mocked GitHub comments endpoint captures the PR worker's generated comment.
 func TestIntegrationProvisioning_GithubPullRequestWebhookPostsComment(t *testing.T) {
 	helper := sharedGitHelper(t)
-	ctx := context.Background()
 
 	const repoName = "github-pr-comment"
 	const dashboardPath = "dashboard.json"
@@ -209,7 +205,7 @@ func TestIntegrationProvisioning_GithubPullRequestWebhookPostsComment(t *testing
 	// produces the [original] link in the comment; SyncAndWait only waits for
 	// job success, not resource visibility, so without this barrier the Get can
 	// race the sync write and drop the [original] link.
-	common.RequireRepoManagedDashboard(t, helper.DashboardsV1, ctx, "gh-pr-comment-dash", repoName, dashboardPath)
+	common.RequireRepoManagedDashboard(t, helper.DashboardsV1, "gh-pr-comment-dash", repoName, dashboardPath)
 
 	const branchName = "feature-pr-comment"
 	_, err := local.Git("checkout", "-b", branchName)
@@ -247,13 +243,13 @@ func TestIntegrationProvisioning_GithubPullRequestWebhookPostsComment(t *testing
 
 	// Sign with the webhook secret Grafana persisted for this repository,
 	// because the webhook handler validates against that decrypted value.
-	obj, err := helper.Repositories.Resource.Get(ctx, repoName, metav1.GetOptions{})
+	obj, err := helper.Repositories.Resource.Get(t.Context(), repoName, metav1.GetOptions{})
 	require.NoError(t, err, "failed to read repository")
 	repo := common.MustFromUnstructured[provisioning.Repository](t, obj)
 	secretName := repo.Secure.WebhookSecret.Name
 	require.NotEmpty(t, secretName, "webhook secret should be stored")
 
-	decrypted, err := helper.GetEnv().DecryptService.Decrypt(ctx, provisioning.GROUP, repo.Namespace, secretName)
+	decrypted, err := helper.GetEnv().DecryptService.Decrypt(t.Context(), provisioning.GROUP, repo.Namespace, secretName)
 	require.NoError(t, err, "failed to decrypt webhook secret")
 	require.Len(t, decrypted, 1)
 	result, ok := decrypted[secretName]
@@ -279,7 +275,7 @@ func TestIntegrationProvisioning_GithubPullRequestWebhookPostsComment(t *testing
 		SetHeader(github.EventTypeHeader, "pull_request").
 		SetHeader(github.DeliveryIDHeader, fmt.Sprintf("%s-delivery", repoName)).
 		SetHeader(github.SHA256SignatureHeader, signature).
-		Do(ctx).
+		Do(t.Context()).
 		StatusCode(&code)
 
 	require.NoError(t, webhookResult.Error(), "webhook should accept pull request payload")
@@ -289,7 +285,7 @@ func TestIntegrationProvisioning_GithubPullRequestWebhookPostsComment(t *testing
 	require.NoError(t, err, "webhook response should include the queued job")
 	job, ok := jobObj.(*unstructured.Unstructured)
 	require.True(t, ok, "webhook response should be an unstructured job, got %T", jobObj)
-	helper.AwaitJobSuccess(t, ctx, job)
+	helper.AwaitJobSuccess(t, job)
 
 	commentsMu.Lock()
 	capturedComments := append([]string(nil), comments...)
@@ -328,7 +324,6 @@ func TestIntegrationProvisioning_GithubPullRequestWebhookPostsComment(t *testing
 
 func TestIntegrationProvisioning_GithubRepoWebhookRecreatedWhenMissing(t *testing.T) {
 	helper := sharedGitHelper(t)
-	ctx := context.Background()
 
 	const repoName = "github-webhook-restart"
 	webhookURL := expectedWebhookURL(webhookBaseURL, helper.Namespace, repoName)
@@ -349,19 +344,19 @@ func TestIntegrationProvisioning_GithubRepoWebhookRecreatedWhenMissing(t *testin
 	// "secure value not found" even though the patch itself doesn't touch secure.
 	patch := []byte(`{"status":{"webhook":null}}`)
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		_, err := helper.Repositories.Resource.Patch(ctx, repoName, types.MergePatchType, patch, metav1.PatchOptions{}, "status")
+		_, err := helper.Repositories.Resource.Patch(t.Context(), repoName, types.MergePatchType, patch, metav1.PatchOptions{}, "status")
 		assert.NoError(collect, err)
 	}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "clear webhook status")
 
 	// Trigger reconciliation by updating the spec.
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		latest, err := helper.Repositories.Resource.Get(ctx, repoName, metav1.GetOptions{})
+		latest, err := helper.Repositories.Resource.Get(t.Context(), repoName, metav1.GetOptions{})
 		if !assert.NoError(collect, err) {
 			return
 		}
 		updated := latest.DeepCopy()
 		updated.Object["spec"].(map[string]any)["title"] = "Restart Dashboard (updated)"
-		_, err = helper.Repositories.Resource.Update(ctx, updated, metav1.UpdateOptions{})
+		_, err = helper.Repositories.Resource.Update(t.Context(), updated, metav1.UpdateOptions{})
 		assert.NoError(collect, err)
 	}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "spec update should succeed")
 
@@ -371,7 +366,6 @@ func TestIntegrationProvisioning_GithubRepoWebhookRecreatedWhenMissing(t *testin
 
 func TestIntegrationProvisioning_WebhookLastRotatedSetOnCreation(t *testing.T) {
 	helper := sharedGitHelper(t)
-	ctx := context.Background()
 
 	const repoName = "github-last-rotated"
 	webhookURL := expectedWebhookURL(webhookBaseURL, helper.Namespace, repoName)
@@ -385,7 +379,7 @@ func TestIntegrationProvisioning_WebhookLastRotatedSetOnCreation(t *testing.T) {
 
 	// Wait for webhook, then check LastRotated.
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		obj, err := helper.Repositories.Resource.Get(ctx, repoName, metav1.GetOptions{})
+		obj, err := helper.Repositories.Resource.Get(t.Context(), repoName, metav1.GetOptions{})
 		if !assert.NoError(collect, err) {
 			return
 		}
@@ -399,7 +393,6 @@ func TestIntegrationProvisioning_WebhookLastRotatedSetOnCreation(t *testing.T) {
 
 func TestIntegrationProvisioning_WebhookSecretRotatedWhenExpired(t *testing.T) {
 	helper := sharedGitHelper(t)
-	ctx := context.Background()
 
 	const repoName = "github-rotation-test"
 	webhookURL := expectedWebhookURL(webhookBaseURL, helper.Namespace, repoName)
@@ -435,25 +428,25 @@ func TestIntegrationProvisioning_WebhookSecretRotatedWhenExpired(t *testing.T) {
 	expiredTimestamp := int64(1)
 	patch := []byte(fmt.Sprintf(`{"status":{"webhook":{"id":200,"url":"https://grafana.example.com/hook","subscribedEvents":["pull_request","push"],"lastRotated":%d}}}`, expiredTimestamp))
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		_, err := helper.Repositories.Resource.Patch(ctx, repoName, types.MergePatchType, patch, metav1.PatchOptions{}, "status")
+		_, err := helper.Repositories.Resource.Patch(t.Context(), repoName, types.MergePatchType, patch, metav1.PatchOptions{}, "status")
 		assert.NoError(collect, err)
 	}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "expire LastRotated")
 
 	// Trigger reconciliation.
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		latest, err := helper.Repositories.Resource.Get(ctx, repoName, metav1.GetOptions{})
+		latest, err := helper.Repositories.Resource.Get(t.Context(), repoName, metav1.GetOptions{})
 		if !assert.NoError(collect, err) {
 			return
 		}
 		updated := latest.DeepCopy()
 		updated.Object["spec"].(map[string]any)["title"] = "Rotation Dashboard (updated)"
-		_, err = helper.Repositories.Resource.Update(ctx, updated, metav1.UpdateOptions{})
+		_, err = helper.Repositories.Resource.Update(t.Context(), updated, metav1.UpdateOptions{})
 		assert.NoError(collect, err)
 	}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "spec update should succeed")
 
 	// Wait for rotation — LastRotated should be updated.
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		obj, err := helper.Repositories.Resource.Get(ctx, repoName, metav1.GetOptions{})
+		obj, err := helper.Repositories.Resource.Get(t.Context(), repoName, metav1.GetOptions{})
 		if !assert.NoError(collect, err) {
 			return
 		}

--- a/pkg/tests/apis/provisioning/git/worker_commit_message_test.go
+++ b/pkg/tests/apis/provisioning/git/worker_commit_message_test.go
@@ -17,7 +17,6 @@ import (
 
 func TestIntegrationGit_DeleteJob_CommitMessage(t *testing.T) {
 	helper := sharedGitHelper(t)
-	ctx := context.Background()
 
 	const (
 		repoName = "delete-commit-msg"
@@ -42,7 +41,7 @@ func TestIntegrationGit_DeleteJob_CommitMessage(t *testing.T) {
 	require.Equal(t, expectedMessage, common.LatestCommitSubject(t, local, "main"))
 
 	// TODO Fcai
-	require.False(t, helper.GitFileExists(t, ctx, repoName, dashFn),
+	require.False(t, helper.GitFileExists(t, repoName, dashFn),
 		"deleted file should be gone from the remote")
 }
 
@@ -75,16 +74,16 @@ func TestIntegrationGit_MoveJob_CommitMessage(t *testing.T) {
 
 func TestIntegrationGit_ExportJob_CommitMessage(t *testing.T) {
 	helper := sharedGitHelper(t)
-	ctx := context.Background()
 
 	const repoName = "export-commit-msg"
 
 	// Seed an unmanaged dashboard in storage so the export job has something to push.
 	dash := helper.LoadYAMLOrJSONFile("../exportunifiedtorepository/dashboard-test-v1.yaml")
-	_, err := helper.DashboardsV1.Resource.Create(ctx, dash, metav1.CreateOptions{})
+	_, err := helper.DashboardsV1.Resource.Create(t.Context(), dash, metav1.CreateOptions{})
 	require.NoError(t, err, "should be able to create v1 dashboard")
 	t.Cleanup(func() {
-		_ = helper.DashboardsV1.Resource.Delete(ctx, dash.GetName(), metav1.DeleteOptions{})
+		cleanupCtx := context.WithoutCancel(t.Context())
+		_ = helper.DashboardsV1.Resource.Delete(cleanupCtx, dash.GetName(), metav1.DeleteOptions{})
 	})
 
 	_, local := helper.CreateGitRepo(t, repoName, nil)
@@ -101,16 +100,16 @@ func TestIntegrationGit_ExportJob_CommitMessage(t *testing.T) {
 
 func TestIntegrationGit_MigrateJob_CommitMessage(t *testing.T) {
 	helper := sharedGitHelper(t)
-	ctx := context.Background()
 
 	const repoName = "migrate-commit-msg"
 
 	// Seed an unmanaged dashboard in storage so migration has something to take over.
 	dash := helper.LoadYAMLOrJSONFile("../exportunifiedtorepository/dashboard-test-v1.yaml")
-	_, err := helper.DashboardsV1.Resource.Create(ctx, dash, metav1.CreateOptions{})
+	_, err := helper.DashboardsV1.Resource.Create(t.Context(), dash, metav1.CreateOptions{})
 	require.NoError(t, err, "should be able to create v1 dashboard")
 	t.Cleanup(func() {
-		_ = helper.DashboardsV1.Resource.Delete(ctx, dash.GetName(), metav1.DeleteOptions{})
+		cleanupCtx := context.WithoutCancel(t.Context())
+		_ = helper.DashboardsV1.Resource.Delete(cleanupCtx, dash.GetName(), metav1.DeleteOptions{})
 	})
 
 	_, local := helper.CreateGitRepo(t, repoName, nil)

--- a/pkg/tests/apis/provisioning/health_test.go
+++ b/pkg/tests/apis/provisioning/health_test.go
@@ -1,7 +1,6 @@
 package provisioning
 
 import (
-	"context"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -25,7 +24,6 @@ import (
 
 func TestIntegrationHealth(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 	repo := "test-repo-health"
 	helper.CreateLocalRepo(t, common.TestRepo{
 		Name:            repo,
@@ -34,7 +32,7 @@ func TestIntegrationHealth(t *testing.T) {
 	})
 
 	// Verify the health status before calling the endpoint
-	repoObj, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{})
+	repoObj, err := helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{})
 	require.NoError(t, err)
 	originalRepo := common.MustFromUnstructured[provisioning.Repository](t, repoObj)
 	require.True(t, originalRepo.Status.Health.Healthy, "repository should be marked healthy")
@@ -85,7 +83,7 @@ func TestIntegrationHealth(t *testing.T) {
 			SubResource("test").
 			Body(configBytes).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx)
+			Do(t.Context())
 
 		require.NoError(t, result.Error(), "test endpoint should work for new repository configurations")
 
@@ -97,7 +95,7 @@ func TestIntegrationHealth(t *testing.T) {
 		require.Equal(t, 200, testResults.Code, "should return 200 for successful test")
 
 		// Verify the repository was not actually created (this was just a test)
-		_, err = helper.Repositories.Resource.Get(ctx, "test-new-config", metav1.GetOptions{})
+		_, err = helper.Repositories.Resource.Get(t.Context(), "test-new-config", metav1.GetOptions{})
 		require.True(t, err != nil, "repository should not be created during test")
 	})
 
@@ -133,7 +131,7 @@ func TestIntegrationHealth(t *testing.T) {
 			SubResource("test").
 			Body(configBytes).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx)
+			Do(t.Context())
 
 		require.NoError(t, result.Error(), "test endpoint should work for new repository configurations")
 
@@ -145,7 +143,7 @@ func TestIntegrationHealth(t *testing.T) {
 		require.Equal(t, 200, testResults.Code, "should return 200 for successful test")
 
 		// Verify the repository was not actually created (this was just a test)
-		_, err = helper.Repositories.Resource.Get(ctx, "test-new-config", metav1.GetOptions{})
+		_, err = helper.Repositories.Resource.Get(t.Context(), "test-new-config", metav1.GetOptions{})
 		require.True(t, err != nil, "repository should not be created during test")
 	})
 
@@ -156,7 +154,7 @@ func TestIntegrationHealth(t *testing.T) {
 			Name(repo).
 			SubResource("test").
 			SetHeader("Content-Type", "application/json").
-			Do(ctx)
+			Do(t.Context())
 
 		require.NoError(t, result.Error(), "test endpoint should return NOT an error for existing repository")
 		obj, err := result.Get()
@@ -168,7 +166,7 @@ func TestIntegrationHealth(t *testing.T) {
 		require.Equal(t, 200, testResults.Code, "should return 200 for successful test")
 
 		// Verify repository health status after update
-		repoObj, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{})
+		repoObj, err := helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{})
 		require.NoError(t, err)
 		afterTest := common.MustFromUnstructured[provisioning.Repository](t, repoObj)
 		require.True(t, afterTest.Status.Health.Healthy, "repository should be marked healthy")
@@ -195,7 +193,7 @@ func TestIntegrationHealth(t *testing.T) {
 		// (In a real scenario, this would be detected during the next health check cycle)
 
 		// Get the repository status before the test
-		repoObj, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{})
+		repoObj, err := helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{})
 		require.NoError(t, err)
 		beforeTest := common.MustFromUnstructured[provisioning.Repository](t, repoObj)
 		t.Logf("Before test - Healthy: %v, Checked: %d", beforeTest.Status.Health.Healthy, beforeTest.Status.Health.Checked)
@@ -207,7 +205,7 @@ func TestIntegrationHealth(t *testing.T) {
 			Name(repo).
 			SubResource("test").
 			SetHeader("Content-Type", "application/json").
-			Do(ctx)
+			Do(t.Context())
 
 		// The test endpoint may return an error for unhealthy repositories
 		obj, err := result.Get()
@@ -221,7 +219,7 @@ func TestIntegrationHealth(t *testing.T) {
 		}
 
 		// Verify repository health status after test - timestamp should change
-		repoObj, err = helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{})
+		repoObj, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{})
 		require.NoError(t, err)
 		afterTest := common.MustFromUnstructured[provisioning.Repository](t, repoObj)
 		t.Logf("After test - Healthy: %v, Checked: %d", afterTest.Status.Health.Healthy, afterTest.Status.Health.Checked)
@@ -242,7 +240,7 @@ func TestIntegrationHealth(t *testing.T) {
 			Name(repo).
 			SubResource("test").
 			SetHeader("Content-Type", "application/json").
-			Do(ctx)
+			Do(t.Context())
 
 		// Should succeed now that the directory is recreated
 		require.NoError(t, result.Error(), "test endpoint should work after recreating directory")
@@ -253,7 +251,7 @@ func TestIntegrationHealth(t *testing.T) {
 		require.Equal(t, 200, testResults.Code, "should return 200 after recreating directory")
 
 		// Verify repository health status is now healthy again
-		repoObj, err = helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{})
+		repoObj, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{})
 		require.NoError(t, err)
 		finalRepo := common.MustFromUnstructured[provisioning.Repository](t, repoObj)
 		t.Logf("After recreating directory - Healthy: %v, Checked: %d", finalRepo.Status.Health.Healthy, finalRepo.Status.Health.Checked)
@@ -292,7 +290,6 @@ func parseTestResults(t *testing.T, obj runtime.Object) *provisioning.TestResult
 
 func TestIntegrationProvisioning_ConnectionTestEndpointWithPermissions(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	privateKeyBase64 := base64.StdEncoding.EncodeToString([]byte(common.TestGithubPrivateKeyPEM))
 
@@ -353,7 +350,7 @@ func TestIntegrationProvisioning_ConnectionTestEndpointWithPermissions(t *testin
 		}
 
 		// Create with dryRun - that would test the connection
-		c, err := helper.Connections.Resource.Create(ctx, config, metav1.CreateOptions{
+		c, err := helper.Connections.Resource.Create(t.Context(), config, metav1.CreateOptions{
 			DryRun: []string{"All"},
 		})
 		require.Error(t, err)
@@ -443,7 +440,7 @@ func TestIntegrationProvisioning_ConnectionTestEndpointWithPermissions(t *testin
 		}
 
 		// Create with dryRun - that would test the connection
-		c, err := helper.Connections.Resource.Create(ctx, config, metav1.CreateOptions{
+		c, err := helper.Connections.Resource.Create(t.Context(), config, metav1.CreateOptions{
 			DryRun: []string{"All"},
 		})
 		require.Error(t, err)
@@ -534,7 +531,7 @@ func TestIntegrationProvisioning_ConnectionTestEndpointWithPermissions(t *testin
 		}
 
 		// Create with dryRun - that would test the connection
-		c, err := helper.Connections.Resource.Create(ctx, config, metav1.CreateOptions{
+		c, err := helper.Connections.Resource.Create(t.Context(), config, metav1.CreateOptions{
 			DryRun: []string{"All"},
 		})
 		require.NoError(t, err)
@@ -544,7 +541,6 @@ func TestIntegrationProvisioning_ConnectionTestEndpointWithPermissions(t *testin
 
 func TestIntegrationProvisioning_GitRepositoryWritePermissions(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	// Use public GitHub repository (grafana-git-sync-demo) via git type - no token needed for read access
 	// This tests that:
@@ -589,7 +585,7 @@ func TestIntegrationProvisioning_GitRepositoryWritePermissions(t *testing.T) {
 			SubResource("test").
 			Body(configBytes).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx)
+			Do(t.Context())
 
 		// Validation errors can be returned as HTTP errors or as TestResults
 		if result.Error() != nil {
@@ -654,7 +650,7 @@ func TestIntegrationProvisioning_GitRepositoryWritePermissions(t *testing.T) {
 			SubResource("test").
 			Body(configBytes).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx)
+			Do(t.Context())
 
 		require.NoError(t, result.Error())
 
@@ -704,7 +700,7 @@ func TestIntegrationProvisioning_GitRepositoryWritePermissions(t *testing.T) {
 		}
 
 		// Create the repository
-		repo, err := helper.Repositories.Resource.Create(ctx, repoConfig, metav1.CreateOptions{})
+		repo, err := helper.Repositories.Resource.Create(t.Context(), repoConfig, metav1.CreateOptions{})
 		require.NoError(t, err, "repository creation should succeed")
 		require.NotNil(t, repo)
 
@@ -712,7 +708,7 @@ func TestIntegrationProvisioning_GitRepositoryWritePermissions(t *testing.T) {
 		helper.WaitForUnhealthyRepository(t, "test-git-unhealthy")
 
 		// Cleanup
-		err = helper.Repositories.Resource.Delete(ctx, "test-git-unhealthy", metav1.DeleteOptions{})
+		err = helper.Repositories.Resource.Delete(t.Context(), "test-git-unhealthy", metav1.DeleteOptions{})
 		require.NoError(t, err)
 	})
 
@@ -750,7 +746,7 @@ func TestIntegrationProvisioning_GitRepositoryWritePermissions(t *testing.T) {
 		}
 
 		// Create the repository
-		repo, err := helper.Repositories.Resource.Create(ctx, repoConfig, metav1.CreateOptions{})
+		repo, err := helper.Repositories.Resource.Create(t.Context(), repoConfig, metav1.CreateOptions{})
 		require.NoError(t, err, "repository creation should succeed")
 		require.NotNil(t, repo)
 
@@ -758,7 +754,7 @@ func TestIntegrationProvisioning_GitRepositoryWritePermissions(t *testing.T) {
 		helper.WaitForHealthyRepository(t, "test-git-healthy-readonly")
 
 		// Cleanup
-		err = helper.Repositories.Resource.Delete(ctx, "test-git-healthy-readonly", metav1.DeleteOptions{})
+		err = helper.Repositories.Resource.Delete(t.Context(), "test-git-healthy-readonly", metav1.DeleteOptions{})
 		require.NoError(t, err)
 	})
 }

--- a/pkg/tests/apis/provisioning/health_test.go
+++ b/pkg/tests/apis/provisioning/health_test.go
@@ -24,12 +24,15 @@ import (
 
 func TestIntegrationHealth(t *testing.T) {
 	helper := sharedHelper(t)
+
 	repo := "test-repo-health"
 	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:            repo,
-		SyncTarget:      "folder",
-		ExpectedFolders: 1,
+		Name:       repo,
+		SyncTarget: "folder",
 	})
+
+	helper.RequireRepoDashboardCount(t, repo, 0)
+	helper.RequireRepoFolderCount(t, repo, 1)
 
 	// Verify the health status before calling the endpoint
 	repoObj, err := helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{})

--- a/pkg/tests/apis/provisioning/jobs/conflict/conflict_test.go
+++ b/pkg/tests/apis/provisioning/jobs/conflict/conflict_test.go
@@ -1,7 +1,6 @@
 package conflict
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -16,7 +15,6 @@ import (
 // job they received before the other updated it, that one will fail. This is critical for concurrent jobs.
 func TestIntegrationProvisioning_JobConflict(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	obj := &unstructured.Unstructured{
 		Object: map[string]interface{}{
@@ -35,12 +33,12 @@ func TestIntegrationProvisioning_JobConflict(t *testing.T) {
 			},
 		},
 	}
-	createdJob, err := helper.Jobs.Resource.Create(ctx, obj, metav1.CreateOptions{})
+	createdJob, err := helper.Jobs.Resource.Create(t.Context(), obj, metav1.CreateOptions{})
 	require.NoError(t, err)
 
-	job, err := helper.Jobs.Resource.Get(ctx, createdJob.GetName(), metav1.GetOptions{})
+	job, err := helper.Jobs.Resource.Get(t.Context(), createdJob.GetName(), metav1.GetOptions{})
 	require.NoError(t, err)
-	job2, err := helper.Jobs.Resource.Get(ctx, createdJob.GetName(), metav1.GetOptions{})
+	job2, err := helper.Jobs.Resource.Get(t.Context(), createdJob.GetName(), metav1.GetOptions{})
 	require.NoError(t, err)
 
 	client1Update := job.DeepCopy()
@@ -50,7 +48,7 @@ func TestIntegrationProvisioning_JobConflict(t *testing.T) {
 	labels := client1Update.GetLabels()
 	labels["provisioning.grafana.app/claim"] = "client1-claim"
 	client1Update.SetLabels(labels)
-	updatedJob, err := helper.Jobs.Resource.Update(ctx, client1Update, metav1.UpdateOptions{})
+	updatedJob, err := helper.Jobs.Resource.Update(t.Context(), client1Update, metav1.UpdateOptions{})
 	require.NoError(t, err)
 	require.NotEqual(t, job.GetResourceVersion(), updatedJob.GetResourceVersion())
 
@@ -61,10 +59,10 @@ func TestIntegrationProvisioning_JobConflict(t *testing.T) {
 	labels2 := client2Update.GetLabels()
 	labels2["provisioning.grafana.app/claim"] = "client2-claim"
 	client2Update.SetLabels(labels2)
-	_, err = helper.Jobs.Resource.Update(ctx, client2Update, metav1.UpdateOptions{})
+	_, err = helper.Jobs.Resource.Update(t.Context(), client2Update, metav1.UpdateOptions{})
 	require.Error(t, err)
 	require.True(t, apierrors.IsConflict(err), "should get conflict error when updating with stale resource version")
 
-	err = helper.Jobs.Resource.Delete(ctx, createdJob.GetName(), metav1.DeleteOptions{})
+	err = helper.Jobs.Resource.Delete(t.Context(), createdJob.GetName(), metav1.DeleteOptions{})
 	require.NoError(t, err)
 }

--- a/pkg/tests/apis/provisioning/jobs/deletejob_auth_test.go
+++ b/pkg/tests/apis/provisioning/jobs/deletejob_auth_test.go
@@ -22,10 +22,11 @@ func TestIntegrationProvisioning_DeleteJobAuthorization(t *testing.T) {
 		Copies: map[string]string{
 			"../testdata/all-panels.json": "dashboard.json",
 		},
-		ExpectedDashboards: 1,
-		ExpectedFolders:    0,
 	}
 	helper.CreateLocalRepo(t, testRepo)
+
+	helper.RequireRepoDashboardCount(t, repo, 1)
+	helper.RequireRepoFolderCount(t, repo, 0)
 
 	// Grant the editor user dashboard permissions (the default editor role
 	// does not include dashboards:delete which is required by the pre-flight check).

--- a/pkg/tests/apis/provisioning/jobs/deletejob_auth_test.go
+++ b/pkg/tests/apis/provisioning/jobs/deletejob_auth_test.go
@@ -1,7 +1,6 @@
 package jobs
 
 import (
-	"context"
 	"net/http"
 	"testing"
 
@@ -15,7 +14,6 @@ import (
 
 func TestIntegrationProvisioning_DeleteJobAuthorization(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	const repo = "delete-auth-test"
 	testRepo := common.TestRepo{
@@ -56,7 +54,7 @@ func TestIntegrationProvisioning_DeleteJobAuthorization(t *testing.T) {
 			SubResource("jobs").
 			Body(body).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.NoError(t, result.Error(), "admin should be able to create delete job")
 		require.Equal(t, http.StatusAccepted, statusCode, "should return 202 Accepted")
@@ -83,7 +81,7 @@ func TestIntegrationProvisioning_DeleteJobAuthorization(t *testing.T) {
 			SubResource("jobs").
 			Body(body).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.NoError(t, result.Error(), "editor should be able to create delete job")
 		require.Equal(t, http.StatusAccepted, statusCode, "should return 202 Accepted")
@@ -107,7 +105,7 @@ func TestIntegrationProvisioning_DeleteJobAuthorization(t *testing.T) {
 			SubResource("jobs").
 			Body(body).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.Error(t, result.Error(), "viewer should not be able to create delete job")
 		require.Equal(t, http.StatusForbidden, statusCode, "should return 403 Forbidden")
@@ -133,7 +131,7 @@ func TestIntegrationProvisioning_DeleteJobAuthorization(t *testing.T) {
 			SubResource("jobs").
 			Body(body).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.Error(t, result.Error(), "delete job should be blocked for folder resource in a file")
 		require.NotEqual(t, http.StatusAccepted, statusCode, "should not return 202 Accepted")
@@ -158,7 +156,7 @@ func TestIntegrationProvisioning_DeleteJobAuthorization(t *testing.T) {
 			SubResource("jobs").
 			Body(body).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.Error(t, result.Error(), "delete job should be blocked for unsupported resource type")
 		require.NotEqual(t, http.StatusAccepted, statusCode, "should not return 202 Accepted")

--- a/pkg/tests/apis/provisioning/jobs/deletejob_test.go
+++ b/pkg/tests/apis/provisioning/jobs/deletejob_test.go
@@ -1,7 +1,6 @@
 package jobs
 
 import (
-	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -35,7 +34,6 @@ func renameDashboard(t *testing.T, content []byte, name string) string {
 
 func TestIntegrationProvisioning_DeleteJob(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	const repo = "delete-job-test-repo"
 	testRepo := common.TestRepo{
@@ -59,7 +57,7 @@ func TestIntegrationProvisioning_DeleteJob(t *testing.T) {
 		helper.DebugState(t, repo, "BEFORE DELETE")
 
 		// Verify file exists in repository before attempting delete
-		_, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "dashboard1.json")
+		_, err := helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "dashboard1.json")
 		require.NoError(t, err, "dashboard1.json should exist in repository before delete")
 
 		spec := provisioning.JobSpec{
@@ -77,20 +75,20 @@ func TestIntegrationProvisioning_DeleteJob(t *testing.T) {
 		// FIXME: create a helper to verify repository files
 
 		// Verify file is deleted from repository
-		_, err = helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "dashboard1.json")
+		_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "dashboard1.json")
 		require.Error(t, err, "file should be deleted from repository")
 		require.True(t, apierrors.IsNotFound(err), "should be not found error")
 
 		// FIXME: create a helper to verify grafana resources
 		// Verify dashboard is removed from Grafana after sync
-		dashboards, err := helper.DashboardsV1.Resource.List(ctx, metav1.ListOptions{})
+		dashboards, err := helper.DashboardsV1.Resource.List(t.Context(), metav1.ListOptions{})
 		require.NoError(t, err)
 		require.Equal(t, 2, len(dashboards.Items), "should have 2 dashboards after delete")
 
 		// Verify other files still exist
-		_, err = helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "dashboard2.json")
+		_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "dashboard2.json")
 		require.NoError(t, err, "other files should still exist")
-		_, err = helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "folder", "dashboard3.json")
+		_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "folder", "dashboard3.json")
 		require.NoError(t, err, "nested files should still exist")
 	})
 
@@ -105,16 +103,16 @@ func TestIntegrationProvisioning_DeleteJob(t *testing.T) {
 
 		// FIXME: use helper
 		// Verify files are deleted from repository
-		_, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "dashboard2.json")
+		_, err := helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "dashboard2.json")
 		require.Error(t, err, "dashboard2.json should be deleted")
 		require.True(t, apierrors.IsNotFound(err))
 
-		_, err = helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "folder", "dashboard3.json")
+		_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "folder", "dashboard3.json")
 		require.Error(t, err, "folder/dashboard3.json should be deleted")
 		require.True(t, apierrors.IsNotFound(err))
 
 		// Verify all dashboards are removed from Grafana after sync
-		dashboards, err := helper.DashboardsV1.Resource.List(ctx, metav1.ListOptions{})
+		dashboards, err := helper.DashboardsV1.Resource.List(t.Context(), metav1.ListOptions{})
 		require.NoError(t, err)
 		require.Equal(t, 0, len(dashboards.Items), "should have 0 dashboards after deleting all")
 	})
@@ -152,7 +150,7 @@ func TestIntegrationProvisioning_DeleteJob(t *testing.T) {
 		helper.SyncAndWait(t, repo, nil)
 
 		// Verify the new resources are created
-		dashboards, err := helper.DashboardsV1.Resource.List(ctx, metav1.ListOptions{})
+		dashboards, err := helper.DashboardsV1.Resource.List(t.Context(), metav1.ListOptions{})
 		require.NoError(t, err)
 		require.GreaterOrEqual(t, len(dashboards.Items), 3, "should have at least 3 dashboards after adding test resources")
 
@@ -179,19 +177,19 @@ func TestIntegrationProvisioning_DeleteJob(t *testing.T) {
 
 			// FIXME: use helpers
 			// Verify corresponding file is deleted from repository
-			_, err = helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "resource-test-1.json")
+			_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "resource-test-1.json")
 			require.Error(t, err, "file should be deleted from repository")
 			require.True(t, apierrors.IsNotFound(err), "should be not found error")
 
 			// Verify dashboard is removed from Grafana (check count like other successful tests)
-			dashboards, err = helper.DashboardsV1.Resource.List(ctx, metav1.ListOptions{})
+			dashboards, err = helper.DashboardsV1.Resource.List(t.Context(), metav1.ListOptions{})
 			require.NoError(t, err)
 			require.Equal(t, 2, len(dashboards.Items), "should have 2 dashboards after deleting 1 from 3")
 
 			// Verify other resources still exist
-			_, err = helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "resource-test-2.json")
+			_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "resource-test-2.json")
 			require.NoError(t, err, "other files should still exist")
-			_, err = helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "nested", "resource-test-3.json")
+			_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "nested", "resource-test-3.json")
 			require.NoError(t, err, "nested files should still exist")
 		})
 
@@ -217,23 +215,23 @@ func TestIntegrationProvisioning_DeleteJob(t *testing.T) {
 
 			// FIXME: use helpers
 			// Verify both dashboards are removed from Grafana
-			_, err = helper.DashboardsV1.Resource.Get(ctx, "resourceref2", metav1.GetOptions{})
+			_, err = helper.DashboardsV1.Resource.Get(t.Context(), "resourceref2", metav1.GetOptions{})
 			require.Error(t, err, "text-options dashboard should be deleted")
 			require.True(t, apierrors.IsNotFound(err))
 
-			_, err = helper.DashboardsV1.Resource.Get(ctx, "resourceref3", metav1.GetOptions{})
+			_, err = helper.DashboardsV1.Resource.Get(t.Context(), "resourceref3", metav1.GetOptions{})
 			require.Error(t, err, "timeline-demo dashboard should be deleted")
 			require.True(t, apierrors.IsNotFound(err))
 
 			// Verify corresponding files are deleted from repository
-			_, err = helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "resource-test-2.json")
+			_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "resource-test-2.json")
 			require.Error(t, err, "resource-test-2.json should be deleted")
 
-			_, err = helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "nested", "resource-test-3.json")
+			_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "nested", "resource-test-3.json")
 			require.Error(t, err, "nested/resource-test-3.json should be deleted")
 
 			// Verify specific dashboards are removed from Grafana
-			dashboards, err = helper.DashboardsV1.Resource.List(ctx, metav1.ListOptions{})
+			dashboards, err = helper.DashboardsV1.Resource.List(t.Context(), metav1.ListOptions{})
 			require.NoError(t, err)
 			require.Equal(t, 0, len(dashboards.Items), "should have 0 dashboards after deleting 2 more (2 -> 0)")
 		})
@@ -273,24 +271,24 @@ func TestIntegrationProvisioning_DeleteJob(t *testing.T) {
 
 			// FIXME: use the helpers
 			// Verify both targeted resources are deleted from Grafana
-			_, err = helper.DashboardsV1.Resource.Get(ctx, "resourceref1", metav1.GetOptions{})
+			_, err = helper.DashboardsV1.Resource.Get(t.Context(), "resourceref1", metav1.GetOptions{})
 			require.Error(t, err, "dashboard deleted by path should be removed")
 
-			_, err = helper.DashboardsV1.Resource.Get(ctx, "resourceref2", metav1.GetOptions{})
+			_, err = helper.DashboardsV1.Resource.Get(t.Context(), "resourceref2", metav1.GetOptions{})
 			require.Error(t, err, "dashboard deleted by resource ref should be removed")
 
 			// Verify the untargeted resource still exists
-			_, err = helper.DashboardsV1.Resource.Get(ctx, "resourceref3", metav1.GetOptions{})
+			_, err = helper.DashboardsV1.Resource.Get(t.Context(), "resourceref3", metav1.GetOptions{})
 			require.NoError(t, err, "untargeted dashboard should still exist")
 
 			// Verify files are properly deleted/preserved in repository
-			_, err = helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "mixed-test-1.json")
+			_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "mixed-test-1.json")
 			require.Error(t, err, "file deleted by path should be removed")
 
-			_, err = helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "mixed-test-2.json")
+			_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "mixed-test-2.json")
 			require.Error(t, err, "file for resource deleted by ref should be removed")
 
-			_, err = helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "mixed-test-3.json")
+			_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "mixed-test-3.json")
 			require.NoError(t, err, "untargeted file should still exist")
 		})
 
@@ -311,7 +309,7 @@ func TestIntegrationProvisioning_DeleteJob(t *testing.T) {
 			helper.SyncAndWait(t, repo, nil)
 
 			// Verify folder was created in Grafana as a Folder resource
-			folders, err := helper.Folders.Resource.List(ctx, metav1.ListOptions{})
+			folders, err := helper.Folders.Resource.List(t.Context(), metav1.ListOptions{})
 			require.NoError(t, err)
 
 			var testFolder *unstructured.Unstructured
@@ -326,7 +324,7 @@ func TestIntegrationProvisioning_DeleteJob(t *testing.T) {
 			testFolderName := testFolder.GetName()
 
 			// Verify dashboard inside the folder exists
-			_, err = helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "test-folder", "dashboard-in-folder.json")
+			_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "test-folder", "dashboard-in-folder.json")
 			require.NoError(t, err, "dashboard inside folder should exist")
 
 			spec := provisioning.JobSpec{
@@ -345,12 +343,12 @@ func TestIntegrationProvisioning_DeleteJob(t *testing.T) {
 
 			// FIXME: use helpers
 			// Verify folder is deleted from Grafana
-			_, err = helper.Folders.Resource.Get(ctx, testFolderName, metav1.GetOptions{})
+			_, err = helper.Folders.Resource.Get(t.Context(), testFolderName, metav1.GetOptions{})
 			require.Error(t, err, "folder should be deleted from Grafana")
 			require.True(t, apierrors.IsNotFound(err), "should be not found error")
 
 			// Verify folder contents are also deleted from repository
-			_, err = helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "test-folder", "dashboard-in-folder.json")
+			_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "test-folder", "dashboard-in-folder.json")
 			require.Error(t, err, "dashboard inside deleted folder should also be deleted")
 			require.True(t, apierrors.IsNotFound(err), "should be not found error")
 		})
@@ -391,7 +389,7 @@ func TestIntegrationProvisioning_DeleteJob(t *testing.T) {
 			SubResource("jobs").
 			Body(body).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx)
+			Do(t.Context())
 
 		require.Error(t, result.Error(), "delete job for non-existent file should be rejected at creation")
 	})
@@ -417,7 +415,7 @@ func TestIntegrationProvisioning_DeleteJob(t *testing.T) {
 			SubResource("jobs").
 			Body(body).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx)
+			Do(t.Context())
 
 		require.Error(t, result.Error(), "delete job with any non-existent file should be rejected at creation")
 	})
@@ -441,7 +439,7 @@ func TestIntegrationProvisioning_DeleteJob(t *testing.T) {
 			SubResource("jobs").
 			Body(body).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx)
+			Do(t.Context())
 
 		require.Error(t, result.Error(), "delete job for all non-existent files should be rejected at creation")
 	})

--- a/pkg/tests/apis/provisioning/jobs/deletejob_test.go
+++ b/pkg/tests/apis/provisioning/jobs/deletejob_test.go
@@ -44,11 +44,12 @@ func TestIntegrationProvisioning_DeleteJob(t *testing.T) {
 			"../testdata/text-options.json":  "dashboard2.json",
 			"../testdata/timeline-demo.json": "folder/dashboard3.json",
 		},
-		ExpectedDashboards: 3,
-		ExpectedFolders:    1,
 	}
 
 	helper.CreateLocalRepo(t, testRepo)
+
+	helper.RequireRepoDashboardCount(t, repo, 3)
+	helper.RequireRepoFolderCount(t, repo, 1)
 
 	t.Run("delete single file", func(t *testing.T) {
 		// FIXME: make the tests in a way that we can simply have a spec and some expectations per scenario.

--- a/pkg/tests/apis/provisioning/jobs/deleteresourcesjob_auth_test.go
+++ b/pkg/tests/apis/provisioning/jobs/deleteresourcesjob_auth_test.go
@@ -1,7 +1,6 @@
 package jobs
 
 import (
-	"context"
 	"net/http"
 	"testing"
 
@@ -14,7 +13,6 @@ import (
 
 func TestIntegrationProvisioning_DeleteResourcesJobAuthorization(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	body := common.AsJSON(provisioning.JobSpec{
 		Action:     provisioning.JobActionDeleteResources,
@@ -30,7 +28,7 @@ func TestIntegrationProvisioning_DeleteResourcesJobAuthorization(t *testing.T) {
 			SubResource("jobs").
 			Body(body).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.NoError(t, result.Error(), "admin should be able to create deleteResources job for nonexistent repo")
 		require.Equal(t, http.StatusAccepted, statusCode, "should return 202 Accepted")
@@ -45,7 +43,7 @@ func TestIntegrationProvisioning_DeleteResourcesJobAuthorization(t *testing.T) {
 			SubResource("jobs").
 			Body(body).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.Error(t, result.Error(), "editor should not be able to create deleteResources job")
 		require.Equal(t, http.StatusForbidden, statusCode, "should return 403 Forbidden")
@@ -61,7 +59,7 @@ func TestIntegrationProvisioning_DeleteResourcesJobAuthorization(t *testing.T) {
 			SubResource("jobs").
 			Body(body).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.Error(t, result.Error(), "viewer should not be able to create deleteResources job")
 		require.Equal(t, http.StatusForbidden, statusCode, "should return 403 Forbidden")
@@ -92,7 +90,7 @@ func TestIntegrationProvisioning_DeleteResourcesJobAuthorization(t *testing.T) {
 			SubResource("jobs").
 			Body(existingRepoBody).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.Error(t, result.Error(), "deleteResources should be rejected for a healthy repository")
 		require.Equal(t, http.StatusConflict, statusCode, "should return 409 Conflict")

--- a/pkg/tests/apis/provisioning/jobs/deleteresourcesjob_auth_test.go
+++ b/pkg/tests/apis/provisioning/jobs/deleteresourcesjob_auth_test.go
@@ -69,13 +69,14 @@ func TestIntegrationProvisioning_DeleteResourcesJobAuthorization(t *testing.T) {
 	t.Run("deleteResources rejected when repository exists and is healthy", func(t *testing.T) {
 		const repo = "deleteresources-conflict-test"
 		testRepo := common.TestRepo{
-			Name:               repo,
-			SyncTarget:         "folder",
-			Copies:             map[string]string{},
-			ExpectedDashboards: 0,
-			ExpectedFolders:    1,
+			Name:       repo,
+			SyncTarget: "folder",
+			Copies:     map[string]string{},
 		}
 		helper.CreateLocalRepo(t, testRepo)
+
+		helper.RequireRepoDashboardCount(t, repo, 0)
+		helper.RequireRepoFolderCount(t, repo, 1)
 
 		existingRepoBody := common.AsJSON(provisioning.JobSpec{
 			Action:     provisioning.JobActionDeleteResources,

--- a/pkg/tests/apis/provisioning/jobs/export_folders_flag_disabled_test.go
+++ b/pkg/tests/apis/provisioning/jobs/export_folders_flag_disabled_test.go
@@ -75,11 +75,10 @@ func TestIntegrationProvisioning_ExportJob_FolderMetadataFlagDisabled(t *testing
 
 		const repo = "export-no-meta-repo"
 		helper.CreateLocalRepo(t, common.TestRepo{
-			Name:                   repo,
-			SyncTarget:             "instance",
-			Workflows:              []string{"write"},
-			SkipSync:               true,
-			SkipResourceAssertions: true,
+			Name:       repo,
+			SyncTarget: "instance",
+			Workflows:  []string{"write"},
+			SkipSync:   true,
 		})
 
 		createUnmanagedFolder(t, helper, "no-meta-folder-uid", "no-meta-folder")
@@ -100,11 +99,10 @@ func TestIntegrationProvisioning_ExportJob_FolderMetadataFlagDisabled(t *testing
 
 		const repo = "nested-no-meta-repo"
 		helper.CreateLocalRepo(t, common.TestRepo{
-			Name:                   repo,
-			SyncTarget:             "instance",
-			Workflows:              []string{"write"},
-			SkipSync:               true,
-			SkipResourceAssertions: true,
+			Name:       repo,
+			SyncTarget: "instance",
+			Workflows:  []string{"write"},
+			SkipSync:   true,
 		})
 
 		const (

--- a/pkg/tests/apis/provisioning/jobs/exportjob_specific_kinds_test.go
+++ b/pkg/tests/apis/provisioning/jobs/exportjob_specific_kinds_test.go
@@ -1,7 +1,6 @@
 package jobs
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -22,15 +21,14 @@ import (
 // requested dashboard and the requested folder are written.
 func TestIntegrationProvisioning_ExportSpecificResources_FolderExported(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	dash := helper.LoadYAMLOrJSONFile("../exportunifiedtorepository/dashboard-test-v1.yaml")
-	_, err := helper.DashboardsV1.Resource.Create(ctx, dash, metav1.CreateOptions{})
+	_, err := helper.DashboardsV1.Resource.Create(t.Context(), dash, metav1.CreateOptions{})
 	require.NoError(t, err, "should be able to create v1 dashboard")
 
 	// A real folder, named explicitly in the export. Unlike the old behavior, a
 	// passed folder is now exported rather than silently skipped.
-	folderUID := helper.CreateUnmanagedFolder(t, ctx, "exportedfolderref", "")
+	folderUID := helper.CreateUnmanagedFolder(t, "exportedfolderref", "")
 
 	const repo = "selective-export-folderref-repo"
 	helper.CreateLocalRepo(t, common.TestRepo{

--- a/pkg/tests/apis/provisioning/jobs/exportjob_specific_kinds_test.go
+++ b/pkg/tests/apis/provisioning/jobs/exportjob_specific_kinds_test.go
@@ -32,11 +32,10 @@ func TestIntegrationProvisioning_ExportSpecificResources_FolderExported(t *testi
 
 	const repo = "selective-export-folderref-repo"
 	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:                   repo,
-		SyncTarget:             "instance",
-		Workflows:              []string{"write"},
-		Copies:                 map[string]string{},
-		SkipResourceAssertions: true,
+		Name:       repo,
+		SyncTarget: "instance",
+		Workflows:  []string{"write"},
+		Copies:     map[string]string{},
 	})
 
 	spec := provisioning.JobSpec{

--- a/pkg/tests/apis/provisioning/jobs/exportjob_specific_test.go
+++ b/pkg/tests/apis/provisioning/jobs/exportjob_specific_test.go
@@ -29,35 +29,38 @@ func TestIntegrationProvisioning_ExportSpecificResources(t *testing.T) {
 	// named in Resources and expected to land in the repo, v2alpha1 is left
 	// out to prove non-selected dashboards stay excluded.
 	v0Dash := helper.LoadYAMLOrJSONFile("../exportunifiedtorepository/dashboard-test-v0.yaml")
-	_, err := helper.DashboardsV0.Resource.Create(t.Context(), v0Dash, metav1.CreateOptions{})
+	createdV0, err := helper.DashboardsV0.Resource.Create(t.Context(), v0Dash, metav1.CreateOptions{})
 	require.NoError(t, err, "should be able to create v0 dashboard")
 
 	v1Dash := helper.LoadYAMLOrJSONFile("../exportunifiedtorepository/dashboard-test-v1.yaml")
-	_, err = helper.DashboardsV1.Resource.Create(t.Context(), v1Dash, metav1.CreateOptions{})
+	createdV1, err := helper.DashboardsV1.Resource.Create(t.Context(), v1Dash, metav1.CreateOptions{})
 	require.NoError(t, err, "should be able to create v1 dashboard")
 
 	v2Dash := helper.LoadYAMLOrJSONFile("../exportunifiedtorepository/dashboard-test-v2.yaml")
-	_, err = helper.DashboardsV2.Resource.Create(t.Context(), v2Dash, metav1.CreateOptions{})
+	createdV2, err := helper.DashboardsV2.Resource.Create(t.Context(), v2Dash, metav1.CreateOptions{})
 	require.NoError(t, err, "should be able to create v2 dashboard")
 
 	v2alphaDash := helper.LoadYAMLOrJSONFile("../exportunifiedtorepository/dashboard-test-v2alpha1.yaml")
-	_, err = helper.DashboardsV2alpha1.Resource.Create(t.Context(), v2alphaDash, metav1.CreateOptions{})
+	createdV2alpha, err := helper.DashboardsV2alpha1.Resource.Create(t.Context(), v2alphaDash, metav1.CreateOptions{})
 	require.NoError(t, err, "should be able to create v2alpha1 dashboard")
 
 	v2betaDash := helper.LoadYAMLOrJSONFile("../exportunifiedtorepository/dashboard-test-v2beta1.yaml")
-	_, err = helper.DashboardsV2beta1.Resource.Create(t.Context(), v2betaDash, metav1.CreateOptions{})
+	createdV2beta, err := helper.DashboardsV2beta1.Resource.Create(t.Context(), v2betaDash, metav1.CreateOptions{})
 	require.NoError(t, err, "should be able to create v2beta1 dashboard")
 
 	const repo = "selective-export-repo"
 	testRepo := common.TestRepo{
-		Name:               repo,
-		SyncTarget:         "instance",
-		Workflows:          []string{"write"},
-		Copies:             map[string]string{},
-		ExpectedDashboards: 5,
-		ExpectedFolders:    0,
+		Name:       repo,
+		SyncTarget: "instance",
+		Workflows:  []string{"write"},
+		Copies:     map[string]string{},
 	}
 	helper.CreateLocalRepo(t, testRepo)
+
+	helper.RequireDashboards(t,
+		createdV0.GetName(), createdV1.GetName(), createdV2.GetName(), createdV2alpha.GetName(), createdV2beta.GetName(),
+	)
+	helper.RequireRepoFolderCount(t, repo, 0)
 
 	helper.DebugState(t, repo, "BEFORE SELECTIVE EXPORT")
 
@@ -148,13 +151,14 @@ func TestIntegrationProvisioning_SelectiveMigrateDashboardInNestedFolders(t *tes
 
 	const repo = "selective-migrate-nested-repo"
 	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:               repo,
-		SyncTarget:         "instance",
-		Workflows:          []string{"write"},
-		Copies:             map[string]string{},
-		ExpectedDashboards: 1,
-		ExpectedFolders:    3,
+		Name:       repo,
+		SyncTarget: "instance",
+		Workflows:  []string{"write"},
+		Copies:     map[string]string{},
 	})
+
+	helper.RequireDashboards(t, dashName)
+	helper.RequireFolders(t, grandparentUID, parentUID, childUID)
 
 	// Selective migrate naming only the dashboard. The folders are not named, but
 	// the export emits the folder tree so the dashboard's nested path resolves.
@@ -211,18 +215,19 @@ func TestIntegrationProvisioning_ExportSpecificResources_NotFound(t *testing.T) 
 	// partial-write behavior: present ones are still written even though the
 	// job ends in error because of the missing sibling.
 	v1Dash := helper.LoadYAMLOrJSONFile("../exportunifiedtorepository/dashboard-test-v1.yaml")
-	_, err := helper.DashboardsV1.Resource.Create(t.Context(), v1Dash, metav1.CreateOptions{})
+	createdV1, err := helper.DashboardsV1.Resource.Create(t.Context(), v1Dash, metav1.CreateOptions{})
 	require.NoError(t, err, "should be able to create v1 dashboard")
 
 	const repo = "selective-export-notfound-repo"
 	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:               repo,
-		SyncTarget:         "instance",
-		Workflows:          []string{"write"},
-		Copies:             map[string]string{},
-		ExpectedDashboards: 1,
-		ExpectedFolders:    0,
+		Name:       repo,
+		SyncTarget: "instance",
+		Workflows:  []string{"write"},
+		Copies:     map[string]string{},
 	})
+
+	helper.RequireDashboards(t, createdV1.GetName())
+	helper.RequireRepoFolderCount(t, repo, 0)
 
 	spec := provisioning.JobSpec{
 		Action: provisioning.JobActionPush,
@@ -274,17 +279,18 @@ func TestIntegrationProvisioning_ExportSpecificResources_GeneratesFolderAncestry
 	selectedDash := helper.CreateUnmanagedDashboard(t, "selecteddash", exportedChild)
 
 	unrelatedFolder := helper.CreateUnmanagedFolder(t, "unrelatedfolder", "")
-	_ = helper.CreateUnmanagedDashboard(t, "unrelateddash", unrelatedFolder)
+	unrelatedDash := helper.CreateUnmanagedDashboard(t, "unrelateddash", unrelatedFolder)
 
 	const repo = "selective-export-folders-repo"
 	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:               repo,
-		SyncTarget:         "instance",
-		Workflows:          []string{"write"},
-		Copies:             map[string]string{},
-		ExpectedDashboards: 2,
-		ExpectedFolders:    3,
+		Name:       repo,
+		SyncTarget: "instance",
+		Workflows:  []string{"write"},
+		Copies:     map[string]string{},
 	})
+
+	helper.RequireDashboards(t, selectedDash, unrelatedDash)
+	helper.RequireFolders(t, exportedParent, exportedChild, unrelatedFolder)
 
 	helper.DebugState(t, repo, "BEFORE SELECTIVE EXPORT")
 

--- a/pkg/tests/apis/provisioning/jobs/exportjob_specific_test.go
+++ b/pkg/tests/apis/provisioning/jobs/exportjob_specific_test.go
@@ -1,7 +1,6 @@
 package jobs
 
 import (
-	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -25,29 +24,28 @@ import (
 // of the exported tree.
 func TestIntegrationProvisioning_ExportSpecificResources(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	// Five dashboards across every supported version; v0, v1, v2, v2beta1 are
 	// named in Resources and expected to land in the repo, v2alpha1 is left
 	// out to prove non-selected dashboards stay excluded.
 	v0Dash := helper.LoadYAMLOrJSONFile("../exportunifiedtorepository/dashboard-test-v0.yaml")
-	_, err := helper.DashboardsV0.Resource.Create(ctx, v0Dash, metav1.CreateOptions{})
+	_, err := helper.DashboardsV0.Resource.Create(t.Context(), v0Dash, metav1.CreateOptions{})
 	require.NoError(t, err, "should be able to create v0 dashboard")
 
 	v1Dash := helper.LoadYAMLOrJSONFile("../exportunifiedtorepository/dashboard-test-v1.yaml")
-	_, err = helper.DashboardsV1.Resource.Create(ctx, v1Dash, metav1.CreateOptions{})
+	_, err = helper.DashboardsV1.Resource.Create(t.Context(), v1Dash, metav1.CreateOptions{})
 	require.NoError(t, err, "should be able to create v1 dashboard")
 
 	v2Dash := helper.LoadYAMLOrJSONFile("../exportunifiedtorepository/dashboard-test-v2.yaml")
-	_, err = helper.DashboardsV2.Resource.Create(ctx, v2Dash, metav1.CreateOptions{})
+	_, err = helper.DashboardsV2.Resource.Create(t.Context(), v2Dash, metav1.CreateOptions{})
 	require.NoError(t, err, "should be able to create v2 dashboard")
 
 	v2alphaDash := helper.LoadYAMLOrJSONFile("../exportunifiedtorepository/dashboard-test-v2alpha1.yaml")
-	_, err = helper.DashboardsV2alpha1.Resource.Create(ctx, v2alphaDash, metav1.CreateOptions{})
+	_, err = helper.DashboardsV2alpha1.Resource.Create(t.Context(), v2alphaDash, metav1.CreateOptions{})
 	require.NoError(t, err, "should be able to create v2alpha1 dashboard")
 
 	v2betaDash := helper.LoadYAMLOrJSONFile("../exportunifiedtorepository/dashboard-test-v2beta1.yaml")
-	_, err = helper.DashboardsV2beta1.Resource.Create(ctx, v2betaDash, metav1.CreateOptions{})
+	_, err = helper.DashboardsV2beta1.Resource.Create(t.Context(), v2betaDash, metav1.CreateOptions{})
 	require.NoError(t, err, "should be able to create v2beta1 dashboard")
 
 	const repo = "selective-export-repo"
@@ -140,14 +138,13 @@ func TestIntegrationProvisioning_ExportSpecificResources(t *testing.T) {
 // (TestEnsureFolderExists_TakeoverAllowlist).
 func TestIntegrationProvisioning_SelectiveMigrateDashboardInNestedFolders(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	// Pre-existing unmanaged folder hierarchy: grandparent > parent > child, with
 	// an unmanaged dashboard in the deepest (child) folder.
-	grandparentUID := helper.CreateUnmanagedFolder(t, ctx, "Selective Migrate Grandparent", "")
-	parentUID := helper.CreateUnmanagedFolder(t, ctx, "Selective Migrate Parent", grandparentUID)
-	childUID := helper.CreateUnmanagedFolder(t, ctx, "Selective Migrate Child", parentUID)
-	dashName := helper.CreateUnmanagedDashboard(t, ctx, "Dashboard in nested unmanaged folder", childUID)
+	grandparentUID := helper.CreateUnmanagedFolder(t, "Selective Migrate Grandparent", "")
+	parentUID := helper.CreateUnmanagedFolder(t, "Selective Migrate Parent", grandparentUID)
+	childUID := helper.CreateUnmanagedFolder(t, "Selective Migrate Child", parentUID)
+	dashName := helper.CreateUnmanagedDashboard(t, "Dashboard in nested unmanaged folder", childUID)
 
 	const repo = "selective-migrate-nested-repo"
 	helper.CreateLocalRepo(t, common.TestRepo{
@@ -176,7 +173,7 @@ func TestIntegrationProvisioning_SelectiveMigrateDashboardInNestedFolders(t *tes
 	// The dashboard is now managed by the repo, and every folder in its ancestry
 	// (child > parent > grandparent) is managed by the repo too.
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		d, err := helper.DashboardsV1.Resource.Get(ctx, dashName, metav1.GetOptions{})
+		d, err := helper.DashboardsV1.Resource.Get(t.Context(), dashName, metav1.GetOptions{})
 		if !assert.NoError(collect, err, "dashboard should still exist") {
 			return
 		}
@@ -189,7 +186,7 @@ func TestIntegrationProvisioning_SelectiveMigrateDashboardInNestedFolders(t *tes
 		depth := 0
 		folderUID := d.GetAnnotations()[utils.AnnoKeyFolder]
 		for folderUID != "" {
-			f, err := helper.Folders.Resource.Get(ctx, folderUID, metav1.GetOptions{})
+			f, err := helper.Folders.Resource.Get(t.Context(), folderUID, metav1.GetOptions{})
 			if !assert.NoError(collect, err, "ancestor folder %q should exist", folderUID) {
 				return
 			}
@@ -209,13 +206,12 @@ func TestIntegrationProvisioning_SelectiveMigrateDashboardInNestedFolders(t *tes
 // rather than silently dropping the reference.
 func TestIntegrationProvisioning_ExportSpecificResources_NotFound(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	// A real dashboard exists alongside the missing ref so we can assert the
 	// partial-write behavior: present ones are still written even though the
 	// job ends in error because of the missing sibling.
 	v1Dash := helper.LoadYAMLOrJSONFile("../exportunifiedtorepository/dashboard-test-v1.yaml")
-	_, err := helper.DashboardsV1.Resource.Create(ctx, v1Dash, metav1.CreateOptions{})
+	_, err := helper.DashboardsV1.Resource.Create(t.Context(), v1Dash, metav1.CreateOptions{})
 	require.NoError(t, err, "should be able to create v1 dashboard")
 
 	const repo = "selective-export-notfound-repo"
@@ -269,17 +265,16 @@ func TestIntegrationProvisioning_ExportSpecificResources_NotFound(t *testing.T) 
 // unrelated, non-exported dashboards stay out of the repository entirely.
 func TestIntegrationProvisioning_ExportSpecificResources_GeneratesFolderAncestry(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	// Two independent folder hierarchies, each holding one dashboard. Only the
 	// dashboard in the "exported" hierarchy is named in the export; the
 	// "unrelated" hierarchy must not be touched.
-	exportedParent := helper.CreateUnmanagedFolder(t, ctx, "exportedparent", "")
-	exportedChild := helper.CreateUnmanagedFolder(t, ctx, "exportedchild", exportedParent)
-	selectedDash := helper.CreateUnmanagedDashboard(t, ctx, "selecteddash", exportedChild)
+	exportedParent := helper.CreateUnmanagedFolder(t, "exportedparent", "")
+	exportedChild := helper.CreateUnmanagedFolder(t, "exportedchild", exportedParent)
+	selectedDash := helper.CreateUnmanagedDashboard(t, "selecteddash", exportedChild)
 
-	unrelatedFolder := helper.CreateUnmanagedFolder(t, ctx, "unrelatedfolder", "")
-	_ = helper.CreateUnmanagedDashboard(t, ctx, "unrelateddash", unrelatedFolder)
+	unrelatedFolder := helper.CreateUnmanagedFolder(t, "unrelatedfolder", "")
+	_ = helper.CreateUnmanagedDashboard(t, "unrelateddash", unrelatedFolder)
 
 	const repo = "selective-export-folders-repo"
 	helper.CreateLocalRepo(t, common.TestRepo{
@@ -314,7 +309,7 @@ func TestIntegrationProvisioning_ExportSpecificResources_GeneratesFolderAncestry
 
 	// The unrelated hierarchy must not have been exported: neither its folder
 	// directory nor its dashboard file may appear in the repository.
-	files := helper.ListRepositoryFiles(t, ctx, repo)
+	files := helper.ListRepositoryFiles(t, repo)
 	for _, f := range files {
 		require.NotContains(t, f.Path, "unrelated",
 			"unrelated folder/dashboard must not be exported during selective export; got file %q", f.Path)

--- a/pkg/tests/apis/provisioning/jobs/exportjob_test.go
+++ b/pkg/tests/apis/provisioning/jobs/exportjob_test.go
@@ -19,33 +19,34 @@ func TestIntegrationProvisioning_ExportUnifiedToRepository(t *testing.T) {
 
 	// Write dashboards at
 	dashboard := helper.LoadYAMLOrJSONFile("../exportunifiedtorepository/dashboard-test-v0.yaml")
-	_, err := helper.DashboardsV0.Resource.Create(t.Context(), dashboard, metav1.CreateOptions{})
+	createdV0, err := helper.DashboardsV0.Resource.Create(t.Context(), dashboard, metav1.CreateOptions{})
 	require.NoError(t, err, "should be able to create v0 dashboard")
 
 	// FIXME: add helper and template for dashboards in different versions
 	dashboard = helper.LoadYAMLOrJSONFile("../exportunifiedtorepository/dashboard-test-v1.yaml")
-	_, err = helper.DashboardsV1.Resource.Create(t.Context(), dashboard, metav1.CreateOptions{})
+	createdV1, err := helper.DashboardsV1.Resource.Create(t.Context(), dashboard, metav1.CreateOptions{})
 	require.NoError(t, err, "should be able to create v1 dashboard")
 
 	dashboard = helper.LoadYAMLOrJSONFile("../exportunifiedtorepository/dashboard-test-v2alpha1.yaml")
-	_, err = helper.DashboardsV2alpha1.Resource.Create(t.Context(), dashboard, metav1.CreateOptions{})
+	createdV2alpha, err := helper.DashboardsV2alpha1.Resource.Create(t.Context(), dashboard, metav1.CreateOptions{})
 	require.NoError(t, err, "should be able to create v2alpha1 dashboard")
 
 	dashboard = helper.LoadYAMLOrJSONFile("../exportunifiedtorepository/dashboard-test-v2beta1.yaml")
-	_, err = helper.DashboardsV2beta1.Resource.Create(t.Context(), dashboard, metav1.CreateOptions{})
+	createdV2beta, err := helper.DashboardsV2beta1.Resource.Create(t.Context(), dashboard, metav1.CreateOptions{})
 	require.NoError(t, err, "should be able to create v2beta1 dashboard")
 
 	// Now for the repository.
 	const repo = "local-repository"
 	testRepo := common.TestRepo{
-		Name:               repo,
-		SyncTarget:         "instance", // Export is only supported for instance sync
-		Workflows:          []string{"write"},
-		Copies:             map[string]string{}, // No initial files needed for export test
-		ExpectedDashboards: 4,                   // 4 dashboards created above (v0, v1, v2alpha1, v2beta1)
-		ExpectedFolders:    0,                   // No folders expected after sync
+		Name:       repo,
+		SyncTarget: "instance", // Export is only supported for instance sync
+		Workflows:  []string{"write"},
+		Copies:     map[string]string{}, // No initial files needed for export test
 	}
 	helper.CreateLocalRepo(t, testRepo)
+
+	helper.RequireDashboards(t, createdV0.GetName(), createdV1.GetName(), createdV2alpha.GetName(), createdV2beta.GetName())
+	helper.RequireRepoFolderCount(t, repo, 0)
 
 	// Now export
 	helper.DebugState(t, repo, "BEFORE EXPORT TO REPOSITORY")
@@ -169,23 +170,26 @@ func TestIntegrationProvisioning_ExportDashboardsWithStoredVersions(t *testing.T
 	}
 
 	// Create dashboards in different versions
+	names := make([]string, 0, len(tests))
 	for _, tt := range tests {
 		dashboard := helper.LoadYAMLOrJSONFile(tt.file)
-		_, err := tt.createFunc(dashboard, metav1.CreateOptions{})
+		created, err := tt.createFunc(dashboard, metav1.CreateOptions{})
 		require.NoError(t, err, "should be able to create %s dashboard", tt.name)
+		names = append(names, created.GetName())
 	}
 
 	// Create repository
 	const repo = "version-test-repository"
 	testRepo := common.TestRepo{
-		Name:               repo,
-		SyncTarget:         "instance", // Export is only supported for instance sync
-		Workflows:          []string{"write"},
-		Copies:             map[string]string{},
-		ExpectedDashboards: len(tests),
-		ExpectedFolders:    0,
+		Name:       repo,
+		SyncTarget: "instance", // Export is only supported for instance sync
+		Workflows:  []string{"write"},
+		Copies:     map[string]string{},
 	}
 	helper.CreateLocalRepo(t, testRepo)
+
+	helper.RequireDashboards(t, names...)
+	helper.RequireRepoFolderCount(t, repo, 0)
 
 	// Export dashboards
 	spec := provisioning.JobSpec{

--- a/pkg/tests/apis/provisioning/jobs/exportjob_test.go
+++ b/pkg/tests/apis/provisioning/jobs/exportjob_test.go
@@ -1,7 +1,6 @@
 package jobs
 
 import (
-	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -17,24 +16,23 @@ import (
 
 func TestIntegrationProvisioning_ExportUnifiedToRepository(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	// Write dashboards at
 	dashboard := helper.LoadYAMLOrJSONFile("../exportunifiedtorepository/dashboard-test-v0.yaml")
-	_, err := helper.DashboardsV0.Resource.Create(ctx, dashboard, metav1.CreateOptions{})
+	_, err := helper.DashboardsV0.Resource.Create(t.Context(), dashboard, metav1.CreateOptions{})
 	require.NoError(t, err, "should be able to create v0 dashboard")
 
 	// FIXME: add helper and template for dashboards in different versions
 	dashboard = helper.LoadYAMLOrJSONFile("../exportunifiedtorepository/dashboard-test-v1.yaml")
-	_, err = helper.DashboardsV1.Resource.Create(ctx, dashboard, metav1.CreateOptions{})
+	_, err = helper.DashboardsV1.Resource.Create(t.Context(), dashboard, metav1.CreateOptions{})
 	require.NoError(t, err, "should be able to create v1 dashboard")
 
 	dashboard = helper.LoadYAMLOrJSONFile("../exportunifiedtorepository/dashboard-test-v2alpha1.yaml")
-	_, err = helper.DashboardsV2alpha1.Resource.Create(ctx, dashboard, metav1.CreateOptions{})
+	_, err = helper.DashboardsV2alpha1.Resource.Create(t.Context(), dashboard, metav1.CreateOptions{})
 	require.NoError(t, err, "should be able to create v2alpha1 dashboard")
 
 	dashboard = helper.LoadYAMLOrJSONFile("../exportunifiedtorepository/dashboard-test-v2beta1.yaml")
-	_, err = helper.DashboardsV2beta1.Resource.Create(ctx, dashboard, metav1.CreateOptions{})
+	_, err = helper.DashboardsV2beta1.Resource.Create(t.Context(), dashboard, metav1.CreateOptions{})
 	require.NoError(t, err, "should be able to create v2beta1 dashboard")
 
 	// Now for the repository.
@@ -111,7 +109,6 @@ func TestIntegrationProvisioning_ExportUnifiedToRepository(t *testing.T) {
 
 func TestIntegrationProvisioning_ExportDashboardsWithStoredVersions(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	// Test table for different dashboard versions
 	tests := []struct {
@@ -127,7 +124,7 @@ func TestIntegrationProvisioning_ExportDashboardsWithStoredVersions(t *testing.T
 			name: "v0alpha1",
 			file: "../exportunifiedtorepository/dashboard-test-v0.yaml",
 			createFunc: func(dashboard *unstructured.Unstructured, opts metav1.CreateOptions) (*unstructured.Unstructured, error) {
-				return helper.DashboardsV0.Resource.Create(ctx, dashboard, opts)
+				return helper.DashboardsV0.Resource.Create(t.Context(), dashboard, opts)
 			},
 			expectedTitle: "Test dashboard. Created at v0",
 			expectedName:  "test-v0",
@@ -140,7 +137,7 @@ func TestIntegrationProvisioning_ExportDashboardsWithStoredVersions(t *testing.T
 			name: "v1",
 			file: "../exportunifiedtorepository/dashboard-test-v1.yaml",
 			createFunc: func(dashboard *unstructured.Unstructured, opts metav1.CreateOptions) (*unstructured.Unstructured, error) {
-				return helper.DashboardsV1.Resource.Create(ctx, dashboard, opts)
+				return helper.DashboardsV1.Resource.Create(t.Context(), dashboard, opts)
 			},
 			expectedTitle: "Test dashboard. Created at v1",
 			expectedName:  "test-v1",
@@ -151,7 +148,7 @@ func TestIntegrationProvisioning_ExportDashboardsWithStoredVersions(t *testing.T
 			name: "v2alpha1",
 			file: "../exportunifiedtorepository/dashboard-test-v2alpha1.yaml",
 			createFunc: func(dashboard *unstructured.Unstructured, opts metav1.CreateOptions) (*unstructured.Unstructured, error) {
-				return helper.DashboardsV2alpha1.Resource.Create(ctx, dashboard, opts)
+				return helper.DashboardsV2alpha1.Resource.Create(t.Context(), dashboard, opts)
 			},
 			expectedTitle: "Test dashboard. Created at v2alpha1",
 			expectedName:  "test-v2alpha1",
@@ -162,7 +159,7 @@ func TestIntegrationProvisioning_ExportDashboardsWithStoredVersions(t *testing.T
 			name: "v2beta1",
 			file: "../exportunifiedtorepository/dashboard-test-v2beta1.yaml",
 			createFunc: func(dashboard *unstructured.Unstructured, opts metav1.CreateOptions) (*unstructured.Unstructured, error) {
-				return helper.DashboardsV2beta1.Resource.Create(ctx, dashboard, opts)
+				return helper.DashboardsV2beta1.Resource.Create(t.Context(), dashboard, opts)
 			},
 			expectedTitle: "Test dashboard. Created at v2beta1",
 			expectedName:  "test-v2beta1",
@@ -237,7 +234,7 @@ func TestIntegrationProvisioning_ExportDashboardsWithStoredVersions(t *testing.T
 
 	// Verify that listing via v1 API shows storedVersion when conversion fails
 	// This tests the generic version handling logic
-	dashboards, err := helper.DashboardsV1.Resource.List(ctx, metav1.ListOptions{})
+	dashboards, err := helper.DashboardsV1.Resource.List(t.Context(), metav1.ListOptions{})
 	require.NoError(t, err, "should be able to list dashboards via v1 API")
 
 	for _, dashboard := range dashboards.Items {

--- a/pkg/tests/apis/provisioning/jobs/flagdisabled_test.go
+++ b/pkg/tests/apis/provisioning/jobs/flagdisabled_test.go
@@ -16,14 +16,15 @@ func TestIntegrationProvisioning_FixFolderMetadataJobFlagDisabled(t *testing.T) 
 
 	const repo = "fixfoldermeta-flag-disabled"
 	testRepo := common.TestRepo{
-		Name:               repo,
-		SyncTarget:         "folder",
-		Workflows:          []string{"write"},
-		Copies:             map[string]string{},
-		ExpectedDashboards: 0,
-		ExpectedFolders:    1,
+		Name:       repo,
+		SyncTarget: "folder",
+		Workflows:  []string{"write"},
+		Copies:     map[string]string{},
 	}
 	helper.CreateLocalRepo(t, testRepo)
+
+	helper.RequireRepoDashboardCount(t, repo, 0)
+	helper.RequireRepoFolderCount(t, repo, 1)
 
 	body := common.AsJSON(provisioning.JobSpec{
 		Action: provisioning.JobActionFixFolderMetadata,

--- a/pkg/tests/apis/provisioning/jobs/flagdisabled_test.go
+++ b/pkg/tests/apis/provisioning/jobs/flagdisabled_test.go
@@ -1,7 +1,6 @@
 package jobs
 
 import (
-	"context"
 	"net/http"
 	"testing"
 
@@ -14,7 +13,6 @@ import (
 
 func TestIntegrationProvisioning_FixFolderMetadataJobFlagDisabled(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	const repo = "fixfoldermeta-flag-disabled"
 	testRepo := common.TestRepo{
@@ -40,7 +38,7 @@ func TestIntegrationProvisioning_FixFolderMetadataJobFlagDisabled(t *testing.T) 
 			SubResource("jobs").
 			Body(body).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.Error(t, result.Error(), "should fail when flag is disabled")
 		require.Equal(t, http.StatusBadRequest, statusCode, "should return 400 Bad Request")

--- a/pkg/tests/apis/provisioning/jobs/folderless_test.go
+++ b/pkg/tests/apis/provisioning/jobs/folderless_test.go
@@ -1,7 +1,6 @@
 package jobs
 
 import (
-	"context"
 	"net/http"
 	"path"
 	"path/filepath"
@@ -28,7 +27,6 @@ const (
 // after the repository) and turns subdirectories into top-level folders.
 func TestIntegrationProvisioning_FolderlessSyncPlacement(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	const repo = "folderless-placement"
 	helper.CreateLocalRepo(t, common.TestRepo{
@@ -44,12 +42,12 @@ func TestIntegrationProvisioning_FolderlessSyncPlacement(t *testing.T) {
 	})
 
 	// No wrapper folder named after the repository must be created.
-	_, err := helper.Folders.Resource.Get(ctx, repo, metav1.GetOptions{})
+	_, err := helper.Folders.Resource.Get(t.Context(), repo, metav1.GetOptions{})
 	require.True(t, apierrors.IsNotFound(err),
 		"folderless must not create a wrapper folder named after the repository")
 
 	// The single folder is the top-level folder derived from the subdirectory.
-	folders, err := helper.Folders.Resource.List(ctx, metav1.ListOptions{})
+	folders, err := helper.Folders.Resource.List(t.Context(), metav1.ListOptions{})
 	require.NoError(t, err)
 	require.Len(t, folders.Items, 1, "only the subdirectory should become a folder")
 	subFolder := folders.Items[0]
@@ -60,14 +58,14 @@ func TestIntegrationProvisioning_FolderlessSyncPlacement(t *testing.T) {
 		"the folder must be managed by the folderless repo")
 
 	// Root-level dashboard must be top-level (no parent folder).
-	rootDash, err := helper.DashboardsV1.Resource.Get(ctx, allPanelsUID, metav1.GetOptions{})
+	rootDash, err := helper.DashboardsV1.Resource.Get(t.Context(), allPanelsUID, metav1.GetOptions{})
 	require.NoError(t, err, "root dashboard should exist")
 	require.Empty(t, rootDash.GetAnnotations()[utils.AnnoKeyFolder],
 		"root-level dashboard must have no parent folder")
 	require.Equal(t, repo, rootDash.GetAnnotations()[utils.AnnoKeyManagerIdentity])
 
 	// Nested dashboard must live inside the top-level folder.
-	nestedDash, err := helper.DashboardsV1.Resource.Get(ctx, timelineUID, metav1.GetOptions{})
+	nestedDash, err := helper.DashboardsV1.Resource.Get(t.Context(), timelineUID, metav1.GetOptions{})
 	require.NoError(t, err, "nested dashboard should exist")
 	require.Equal(t, subFolder.GetName(), nestedDash.GetAnnotations()[utils.AnnoKeyFolder],
 		"nested dashboard must be parented to the top-level folder")
@@ -80,11 +78,10 @@ func TestIntegrationProvisioning_FolderlessSyncPlacement(t *testing.T) {
 // This is the deletion-safety invariant for the per-repo ownership scope.
 func TestIntegrationProvisioning_FolderlessCoexistence(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	// An unprovisioned dashboard created directly in Grafana.
 	unmanaged := helper.LoadYAMLOrJSONFile("../exportunifiedtorepository/dashboard-test-v1.yaml")
-	createdUnmanaged, err := helper.DashboardsV1.Resource.Create(ctx, unmanaged, metav1.CreateOptions{})
+	createdUnmanaged, err := helper.DashboardsV1.Resource.Create(t.Context(), unmanaged, metav1.CreateOptions{})
 	require.NoError(t, err, "should create an unprovisioned dashboard")
 	unmanagedName := createdUnmanaged.GetName()
 
@@ -111,13 +108,13 @@ func TestIntegrationProvisioning_FolderlessCoexistence(t *testing.T) {
 
 	// Each repo owns its own dashboard; the unprovisioned one stays unmanaged.
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		d1, err := helper.DashboardsV1.Resource.Get(ctx, allPanelsUID, metav1.GetOptions{})
+		d1, err := helper.DashboardsV1.Resource.Get(t.Context(), allPanelsUID, metav1.GetOptions{})
 		if !assert.NoError(collect, err) {
 			return
 		}
 		assert.Equal(collect, repo1, d1.GetAnnotations()[utils.AnnoKeyManagerIdentity])
 
-		d2, err := helper.DashboardsV1.Resource.Get(ctx, timelineUID, metav1.GetOptions{})
+		d2, err := helper.DashboardsV1.Resource.Get(t.Context(), timelineUID, metav1.GetOptions{})
 		if !assert.NoError(collect, err) {
 			return
 		}
@@ -125,18 +122,18 @@ func TestIntegrationProvisioning_FolderlessCoexistence(t *testing.T) {
 	}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "both folderless repos should own their dashboards")
 
 	// Sync repo1; repo2's dashboard and the unprovisioned dashboard must survive.
-	repo2Before, err := helper.DashboardsV1.Resource.Get(ctx, timelineUID, metav1.GetOptions{})
+	repo2Before, err := helper.DashboardsV1.Resource.Get(t.Context(), timelineUID, metav1.GetOptions{})
 	require.NoError(t, err)
 
 	helper.SyncAndWait(t, repo1, nil)
 
-	repo2After, err := helper.DashboardsV1.Resource.Get(ctx, timelineUID, metav1.GetOptions{})
+	repo2After, err := helper.DashboardsV1.Resource.Get(t.Context(), timelineUID, metav1.GetOptions{})
 	require.NoError(t, err, "repo2's dashboard must survive a repo1 sync")
 	require.Equal(t, repo2, repo2After.GetAnnotations()[utils.AnnoKeyManagerIdentity])
 	require.Equal(t, repo2Before.GetGeneration(), repo2After.GetGeneration(),
 		"repo2's dashboard must not be modified by a repo1 sync")
 
-	survivor, err := helper.DashboardsV1.Resource.Get(ctx, unmanagedName, metav1.GetOptions{})
+	survivor, err := helper.DashboardsV1.Resource.Get(t.Context(), unmanagedName, metav1.GetOptions{})
 	require.NoError(t, err, "unprovisioned dashboard must survive a folderless sync")
 	require.Empty(t, survivor.GetAnnotations()[utils.AnnoKeyManagerIdentity],
 		"unprovisioned dashboard must remain unmanaged")
@@ -149,11 +146,10 @@ func TestIntegrationProvisioning_FolderlessCoexistence(t *testing.T) {
 // folderless repo leaves the others untouched.
 func TestIntegrationProvisioning_FolderlessCoexistsWithFolderAndUnmanaged(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	// 1. Unprovisioned dashboard created directly in Grafana.
 	unmanaged := helper.LoadYAMLOrJSONFile("../exportunifiedtorepository/dashboard-test-v1.yaml")
-	createdUnmanaged, err := helper.DashboardsV1.Resource.Create(ctx, unmanaged, metav1.CreateOptions{})
+	createdUnmanaged, err := helper.DashboardsV1.Resource.Create(t.Context(), unmanaged, metav1.CreateOptions{})
 	require.NoError(t, err, "should create an unprovisioned dashboard")
 	unmanagedName := createdUnmanaged.GetName()
 
@@ -183,7 +179,7 @@ func TestIntegrationProvisioning_FolderlessCoexistsWithFolderAndUnmanaged(t *tes
 
 	// Each repository owns only its own dashboard; the unprovisioned one stays unmanaged.
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		fd, err := helper.DashboardsV1.Resource.Get(ctx, allPanelsUID, metav1.GetOptions{})
+		fd, err := helper.DashboardsV1.Resource.Get(t.Context(), allPanelsUID, metav1.GetOptions{})
 		if !assert.NoError(collect, err) {
 			return
 		}
@@ -191,7 +187,7 @@ func TestIntegrationProvisioning_FolderlessCoexistsWithFolderAndUnmanaged(t *tes
 		// A folder-sync root file lives inside the repo's wrapper folder.
 		assert.Equal(collect, folderRepo, fd.GetAnnotations()[utils.AnnoKeyFolder])
 
-		fld, err := helper.DashboardsV1.Resource.Get(ctx, timelineUID, metav1.GetOptions{})
+		fld, err := helper.DashboardsV1.Resource.Get(t.Context(), timelineUID, metav1.GetOptions{})
 		if !assert.NoError(collect, err) {
 			return
 		}
@@ -199,7 +195,7 @@ func TestIntegrationProvisioning_FolderlessCoexistsWithFolderAndUnmanaged(t *tes
 		// A folderless root file is at the top level.
 		assert.Empty(collect, fld.GetAnnotations()[utils.AnnoKeyFolder])
 
-		um, err := helper.DashboardsV1.Resource.Get(ctx, unmanagedName, metav1.GetOptions{})
+		um, err := helper.DashboardsV1.Resource.Get(t.Context(), unmanagedName, metav1.GetOptions{})
 		if !assert.NoError(collect, err) {
 			return
 		}
@@ -207,28 +203,28 @@ func TestIntegrationProvisioning_FolderlessCoexistsWithFolderAndUnmanaged(t *tes
 	}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "all three should coexist with correct ownership")
 
 	// The folder repo has a wrapper folder; the folderless repo has none.
-	_, err = helper.Folders.Resource.Get(ctx, folderRepo, metav1.GetOptions{})
+	_, err = helper.Folders.Resource.Get(t.Context(), folderRepo, metav1.GetOptions{})
 	require.NoError(t, err, "folder-sync repo should have a wrapper folder")
-	_, err = helper.Folders.Resource.Get(ctx, folderlessRepo, metav1.GetOptions{})
+	_, err = helper.Folders.Resource.Get(t.Context(), folderlessRepo, metav1.GetOptions{})
 	require.True(t, apierrors.IsNotFound(err), "folderless repo must not create a wrapper folder")
 
 	// Capture state before syncing the folderless repo.
-	folderDashBefore, err := helper.DashboardsV1.Resource.Get(ctx, allPanelsUID, metav1.GetOptions{})
+	folderDashBefore, err := helper.DashboardsV1.Resource.Get(t.Context(), allPanelsUID, metav1.GetOptions{})
 	require.NoError(t, err)
-	unmanagedBefore, err := helper.DashboardsV1.Resource.Get(ctx, unmanagedName, metav1.GetOptions{})
+	unmanagedBefore, err := helper.DashboardsV1.Resource.Get(t.Context(), unmanagedName, metav1.GetOptions{})
 	require.NoError(t, err)
 
 	// Syncing the folderless repo must not touch the folder repo's or unprovisioned resources.
 	helper.SyncAndWait(t, folderlessRepo, nil)
 
-	folderDashAfter, err := helper.DashboardsV1.Resource.Get(ctx, allPanelsUID, metav1.GetOptions{})
+	folderDashAfter, err := helper.DashboardsV1.Resource.Get(t.Context(), allPanelsUID, metav1.GetOptions{})
 	require.NoError(t, err, "folder repo's dashboard must survive a folderless sync")
 	require.Equal(t, folderRepo, folderDashAfter.GetAnnotations()[utils.AnnoKeyManagerIdentity],
 		"folder repo's dashboard must keep its owner")
 	require.Equal(t, folderDashBefore.GetGeneration(), folderDashAfter.GetGeneration(),
 		"folder repo's dashboard must not be modified by a folderless sync")
 
-	unmanagedAfter, err := helper.DashboardsV1.Resource.Get(ctx, unmanagedName, metav1.GetOptions{})
+	unmanagedAfter, err := helper.DashboardsV1.Resource.Get(t.Context(), unmanagedName, metav1.GetOptions{})
 	require.NoError(t, err, "unprovisioned dashboard must survive a folderless sync")
 	require.Empty(t, unmanagedAfter.GetAnnotations()[utils.AnnoKeyManagerIdentity],
 		"unprovisioned dashboard must remain unmanaged")
@@ -242,16 +238,15 @@ func TestIntegrationProvisioning_FolderlessCoexistsWithFolderAndUnmanaged(t *tes
 // cleaning the namespace.
 func TestIntegrationProvisioning_FolderlessMigrate(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	// Two unprovisioned dashboards to migrate.
 	dash1 := helper.LoadYAMLOrJSONFile("../exportunifiedtorepository/dashboard-test-v1.yaml")
-	created1, err := helper.DashboardsV1.Resource.Create(ctx, dash1, metav1.CreateOptions{})
+	created1, err := helper.DashboardsV1.Resource.Create(t.Context(), dash1, metav1.CreateOptions{})
 	require.NoError(t, err)
 	name1 := created1.GetName()
 
 	dash2 := helper.LoadYAMLOrJSONFile("../exportunifiedtorepository/dashboard-test-v2beta1.yaml")
-	created2, err := helper.DashboardsV2beta1.Resource.Create(ctx, dash2, metav1.CreateOptions{})
+	created2, err := helper.DashboardsV2beta1.Resource.Create(t.Context(), dash2, metav1.CreateOptions{})
 	require.NoError(t, err)
 	name2 := created2.GetName()
 
@@ -274,7 +269,7 @@ func TestIntegrationProvisioning_FolderlessMigrate(t *testing.T) {
 	// Both dashboards are now managed by the repo and remain at the top level.
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		for _, name := range []string{name1, name2} {
-			d, err := helper.DashboardsV1.Resource.Get(ctx, name, metav1.GetOptions{})
+			d, err := helper.DashboardsV1.Resource.Get(t.Context(), name, metav1.GetOptions{})
 			if !assert.NoError(collect, err) {
 				return
 			}
@@ -286,7 +281,7 @@ func TestIntegrationProvisioning_FolderlessMigrate(t *testing.T) {
 	}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "dashboards should be managed at the top level")
 
 	// No wrapper folder must be created by the migration.
-	_, err = helper.Folders.Resource.Get(ctx, repo, metav1.GetOptions{})
+	_, err = helper.Folders.Resource.Get(t.Context(), repo, metav1.GetOptions{})
 	require.True(t, apierrors.IsNotFound(err), "folderless migrate must not create a wrapper folder")
 
 	// The export phase wrote the managed dashboards into the repository.
@@ -301,7 +296,6 @@ func TestIntegrationProvisioning_FolderlessMigrate(t *testing.T) {
 // wrapper folder for the repository.
 func TestIntegrationProvisioning_FolderlessFileCreate(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	const repo = "folderless-create"
 	helper.CreateLocalRepo(t, common.TestRepo{
@@ -337,11 +331,11 @@ func TestIntegrationProvisioning_FolderlessFileCreate(t *testing.T) {
 	require.Equal(t, http.StatusOK, resp.StatusCode, "creating a file in a subdirectory should succeed: %s", resp.BodyString())
 
 	// No wrapper folder named after the repository.
-	_, err := helper.Folders.Resource.Get(ctx, repo, metav1.GetOptions{})
+	_, err := helper.Folders.Resource.Get(t.Context(), repo, metav1.GetOptions{})
 	require.True(t, apierrors.IsNotFound(err), "folderless must not create a wrapper folder")
 
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		root, err := helper.DashboardsV1.Resource.Get(ctx, "fldless-root", metav1.GetOptions{})
+		root, err := helper.DashboardsV1.Resource.Get(t.Context(), "fldless-root", metav1.GetOptions{})
 		if !assert.NoError(collect, err, "root dashboard should exist") {
 			return
 		}
@@ -349,7 +343,7 @@ func TestIntegrationProvisioning_FolderlessFileCreate(t *testing.T) {
 		assert.Empty(collect, root.GetAnnotations()[utils.AnnoKeyFolder],
 			"root file must map to a top-level resource")
 
-		sub, err := helper.DashboardsV1.Resource.Get(ctx, "fldless-sub", metav1.GetOptions{})
+		sub, err := helper.DashboardsV1.Resource.Get(t.Context(), "fldless-sub", metav1.GetOptions{})
 		if !assert.NoError(collect, err, "subdirectory dashboard should exist") {
 			return
 		}
@@ -361,7 +355,7 @@ func TestIntegrationProvisioning_FolderlessFileCreate(t *testing.T) {
 		assert.NotEqual(collect, repo, parent, "the parent folder must not be a repo wrapper folder")
 
 		// The parent folder must itself be top-level (no grandparent).
-		parentFolder, err := helper.Folders.Resource.Get(ctx, parent, metav1.GetOptions{})
+		parentFolder, err := helper.Folders.Resource.Get(t.Context(), parent, metav1.GetOptions{})
 		if !assert.NoError(collect, err, "parent folder should exist") {
 			return
 		}
@@ -375,7 +369,6 @@ func TestIntegrationProvisioning_FolderlessFileCreate(t *testing.T) {
 // from the top level for a folderless repository.
 func TestIntegrationProvisioning_FolderlessFileMove(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	const repo = "folderless-files"
 	helper.CreateLocalRepo(t, common.TestRepo{
@@ -391,7 +384,7 @@ func TestIntegrationProvisioning_FolderlessFileMove(t *testing.T) {
 	})
 
 	// Initially top-level: no parent folder.
-	dash, err := helper.DashboardsV1.Resource.Get(ctx, allPanelsUID, metav1.GetOptions{})
+	dash, err := helper.DashboardsV1.Resource.Get(t.Context(), allPanelsUID, metav1.GetOptions{})
 	require.NoError(t, err)
 	require.Empty(t, dash.GetAnnotations()[utils.AnnoKeyFolder], "dashboard should start at the top level")
 
@@ -404,14 +397,14 @@ func TestIntegrationProvisioning_FolderlessFileMove(t *testing.T) {
 	_ = resp.Body.Close()
 	require.Equal(t, 200, resp.StatusCode, "move into subfolder should succeed")
 
-	_, err = helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "team-y", "dashboard.json")
+	_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "team-y", "dashboard.json")
 	require.NoError(t, err, "file should exist at the new subdirectory path")
-	_, err = helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "dashboard.json")
+	_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "dashboard.json")
 	require.Error(t, err, "file should no longer exist at the repo root")
 
 	// The dashboard is reparented into the (now top-level) subfolder.
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		moved, err := helper.DashboardsV1.Resource.Get(ctx, allPanelsUID, metav1.GetOptions{})
+		moved, err := helper.DashboardsV1.Resource.Get(t.Context(), allPanelsUID, metav1.GetOptions{})
 		if !assert.NoError(collect, err) {
 			return
 		}
@@ -429,11 +422,11 @@ func TestIntegrationProvisioning_FolderlessFileMove(t *testing.T) {
 	_ = resp.Body.Close()
 	require.Equal(t, 200, resp.StatusCode, "move back to root should succeed")
 
-	_, err = helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "dashboard.json")
+	_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "dashboard.json")
 	require.NoError(t, err, "file should exist back at the repo root")
 
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		back, err := helper.DashboardsV1.Resource.Get(ctx, allPanelsUID, metav1.GetOptions{})
+		back, err := helper.DashboardsV1.Resource.Get(t.Context(), allPanelsUID, metav1.GetOptions{})
 		if !assert.NoError(collect, err) {
 			return
 		}

--- a/pkg/tests/apis/provisioning/jobs/folderless_test.go
+++ b/pkg/tests/apis/provisioning/jobs/folderless_test.go
@@ -37,9 +37,10 @@ func TestIntegrationProvisioning_FolderlessSyncPlacement(t *testing.T) {
 			"../testdata/all-panels.json":    "root-dashboard.json",
 			"../testdata/timeline-demo.json": "team-x/nested-dashboard.json",
 		},
-		ExpectedDashboards: 2, // both dashboards
-		ExpectedFolders:    1, // only team-x; NO wrapper folder for the repo
 	})
+
+	helper.RequireRepoDashboardCount(t, repo, 2)
+	helper.RequireRepoFolderCount(t, repo, 1)
 
 	// No wrapper folder named after the repository must be created.
 	_, err := helper.Folders.Resource.Get(t.Context(), repo, metav1.GetOptions{})
@@ -94,7 +95,6 @@ func TestIntegrationProvisioning_FolderlessCoexistence(t *testing.T) {
 		Copies: map[string]string{
 			"../testdata/all-panels.json": "dashboard1.json",
 		},
-		SkipResourceAssertions: true,
 	})
 	helper.CreateLocalRepo(t, common.TestRepo{
 		Name:       repo2,
@@ -103,7 +103,6 @@ func TestIntegrationProvisioning_FolderlessCoexistence(t *testing.T) {
 		Copies: map[string]string{
 			"../testdata/timeline-demo.json": "dashboard2.json",
 		},
-		SkipResourceAssertions: true,
 	})
 
 	// Each repo owns its own dashboard; the unprovisioned one stays unmanaged.
@@ -162,7 +161,6 @@ func TestIntegrationProvisioning_FolderlessCoexistsWithFolderAndUnmanaged(t *tes
 		Copies: map[string]string{
 			"../testdata/all-panels.json": "folder-dashboard.json",
 		},
-		SkipResourceAssertions: true,
 	})
 
 	// 3. Folderless repository (top level, no wrapper folder).
@@ -174,7 +172,6 @@ func TestIntegrationProvisioning_FolderlessCoexistsWithFolderAndUnmanaged(t *tes
 		Copies: map[string]string{
 			"../testdata/timeline-demo.json": "folderless-dashboard.json",
 		},
-		SkipResourceAssertions: true,
 	})
 
 	// Each repository owns only its own dashboard; the unprovisioned one stays unmanaged.
@@ -253,13 +250,14 @@ func TestIntegrationProvisioning_FolderlessMigrate(t *testing.T) {
 	const repo = "folderless-migrate"
 	repoPath := filepath.Join(helper.ProvisioningPath, repo)
 	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:               repo,
-		LocalPath:          repoPath,
-		SyncTarget:         "folderless",
-		Workflows:          []string{"write"},
-		ExpectedDashboards: 2, // the two unprovisioned dashboards (not yet managed)
-		ExpectedFolders:    0, // no wrapper folder
+		Name:       repo,
+		LocalPath:  repoPath,
+		SyncTarget: "folderless",
+		Workflows:  []string{"write"},
 	})
+
+	helper.RequireDashboards(t, name1, name2)
+	helper.RequireRepoFolderCount(t, repo, 0)
 
 	helper.TriggerJobAndWaitForSuccess(t, repo, provisioning.JobSpec{
 		Action:  provisioning.JobActionMigrate,
@@ -299,11 +297,10 @@ func TestIntegrationProvisioning_FolderlessFileCreate(t *testing.T) {
 
 	const repo = "folderless-create"
 	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:                   repo,
-		LocalPath:              path.Join(helper.ProvisioningPath, repo),
-		SyncTarget:             "folderless",
-		Workflows:              []string{"write"},
-		SkipResourceAssertions: true,
+		Name:       repo,
+		LocalPath:  path.Join(helper.ProvisioningPath, repo),
+		SyncTarget: "folderless",
+		Workflows:  []string{"write"},
 	})
 
 	files := helper.NewFilesClient(repo)
@@ -379,9 +376,10 @@ func TestIntegrationProvisioning_FolderlessFileMove(t *testing.T) {
 		Copies: map[string]string{
 			"../testdata/all-panels.json": "dashboard.json",
 		},
-		ExpectedDashboards: 1,
-		ExpectedFolders:    0, // top-level resource, no folders yet
 	})
+
+	helper.RequireRepoDashboardCount(t, repo, 1)
+	helper.RequireRepoFolderCount(t, repo, 0)
 
 	// Initially top-level: no parent folder.
 	dash, err := helper.DashboardsV1.Resource.Get(t.Context(), allPanelsUID, metav1.GetOptions{})

--- a/pkg/tests/apis/provisioning/jobs/historicjobs_auth_test.go
+++ b/pkg/tests/apis/provisioning/jobs/historicjobs_auth_test.go
@@ -1,7 +1,6 @@
 package jobs
 
 import (
-	"context"
 	"net/http"
 	"testing"
 
@@ -14,7 +13,6 @@ import (
 
 func TestIntegrationProvisioning_HistoricJobsAuthorization(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	const repo = "historicjobs-auth-test"
 	testRepo := common.TestRepo{
@@ -42,7 +40,7 @@ func TestIntegrationProvisioning_HistoricJobsAuthorization(t *testing.T) {
 		SubResource("jobs").
 		Body(body).
 		SetHeader("Content-Type", "application/json").
-		Do(ctx).StatusCode(&statusCode)
+		Do(t.Context()).StatusCode(&statusCode)
 	require.NoError(t, result.Error(), "should be able to create job")
 	require.Equal(t, http.StatusAccepted, statusCode)
 
@@ -59,7 +57,7 @@ func TestIntegrationProvisioning_HistoricJobsAuthorization(t *testing.T) {
 			Namespace("default").
 			Resource("historicjobs").
 			Name(historicJobName).
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.NoError(t, result.Error(), "admin should be able to GET historic job")
 		require.Equal(t, http.StatusOK, statusCode, "should return 200 OK")
@@ -71,7 +69,7 @@ func TestIntegrationProvisioning_HistoricJobsAuthorization(t *testing.T) {
 			Namespace("default").
 			Resource("historicjobs").
 			Name(historicJobName).
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.Error(t, result.Error(), "editor should not be able to GET historic job")
 		require.Equal(t, http.StatusForbidden, statusCode, "should return 403 Forbidden")
@@ -84,7 +82,7 @@ func TestIntegrationProvisioning_HistoricJobsAuthorization(t *testing.T) {
 			Namespace("default").
 			Resource("historicjobs").
 			Name(historicJobName).
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.Error(t, result.Error(), "viewer should not be able to GET historic job")
 		require.Equal(t, http.StatusForbidden, statusCode, "should return 403 Forbidden")

--- a/pkg/tests/apis/provisioning/jobs/historicjobs_auth_test.go
+++ b/pkg/tests/apis/provisioning/jobs/historicjobs_auth_test.go
@@ -16,13 +16,14 @@ func TestIntegrationProvisioning_HistoricJobsAuthorization(t *testing.T) {
 
 	const repo = "historicjobs-auth-test"
 	testRepo := common.TestRepo{
-		Name:               repo,
-		SyncTarget:         "folder",
-		Copies:             map[string]string{}, // No files needed for this test
-		ExpectedDashboards: 0,
-		ExpectedFolders:    1, // Repository creates a folder
+		Name:       repo,
+		SyncTarget: "folder",
+		Copies:     map[string]string{}, // No files needed for this test
 	}
 	helper.CreateLocalRepo(t, testRepo)
+
+	helper.RequireRepoDashboardCount(t, repo, 0)
+	helper.RequireRepoFolderCount(t, repo, 1)
 
 	// Trigger a job to create a historic job entry
 	jobSpec := provisioning.JobSpec{

--- a/pkg/tests/apis/provisioning/jobs/instanceauth/exportjob_auth_test.go
+++ b/pkg/tests/apis/provisioning/jobs/instanceauth/exportjob_auth_test.go
@@ -16,14 +16,15 @@ func TestIntegrationProvisioning_ExportJobAuthorization(t *testing.T) {
 
 	const repo = "export-auth-test"
 	testRepo := common.TestRepo{
-		Name:               repo,
-		SyncTarget:         "instance",
-		Workflows:          []string{"write"},
-		Copies:             map[string]string{},
-		ExpectedDashboards: 0,
-		ExpectedFolders:    0,
+		Name:       repo,
+		SyncTarget: "instance",
+		Workflows:  []string{"write"},
+		Copies:     map[string]string{},
 	}
 	helper.CreateLocalRepo(t, testRepo)
+
+	helper.RequireRepoDashboardCount(t, repo, 0)
+	helper.RequireRepoFolderCount(t, repo, 0)
 
 	t.Run("admin can create export job", func(t *testing.T) {
 		body := common.AsJSON(provisioning.JobSpec{

--- a/pkg/tests/apis/provisioning/jobs/instanceauth/exportjob_auth_test.go
+++ b/pkg/tests/apis/provisioning/jobs/instanceauth/exportjob_auth_test.go
@@ -1,7 +1,6 @@
 package instanceauth
 
 import (
-	"context"
 	"net/http"
 	"testing"
 
@@ -14,7 +13,6 @@ import (
 
 func TestIntegrationProvisioning_ExportJobAuthorization(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	const repo = "export-auth-test"
 	testRepo := common.TestRepo{
@@ -41,7 +39,7 @@ func TestIntegrationProvisioning_ExportJobAuthorization(t *testing.T) {
 			SubResource("jobs").
 			Body(body).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.NoError(t, result.Error(), "admin should be able to create export job")
 		require.Equal(t, http.StatusAccepted, statusCode, "should return 202 Accepted")
@@ -63,7 +61,7 @@ func TestIntegrationProvisioning_ExportJobAuthorization(t *testing.T) {
 			SubResource("jobs").
 			Body(body).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.Error(t, result.Error(), "editor should not be able to export on instance-scoped repo")
 		require.Equal(t, http.StatusForbidden, statusCode, "should return 403 Forbidden")
@@ -84,7 +82,7 @@ func TestIntegrationProvisioning_ExportJobAuthorization(t *testing.T) {
 			SubResource("jobs").
 			Body(body).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.Error(t, result.Error(), "viewer should not be able to create export job")
 		require.Equal(t, http.StatusForbidden, statusCode, "should return 403 Forbidden")

--- a/pkg/tests/apis/provisioning/jobs/instanceauth/migratejob_auth_test.go
+++ b/pkg/tests/apis/provisioning/jobs/instanceauth/migratejob_auth_test.go
@@ -1,7 +1,6 @@
 package instanceauth
 
 import (
-	"context"
 	"net/http"
 	"testing"
 
@@ -14,7 +13,6 @@ import (
 
 func TestIntegrationProvisioning_MigrateJobAuthorization(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	const repo = "migrate-auth-test"
 	testRepo := common.TestRepo{
@@ -41,7 +39,7 @@ func TestIntegrationProvisioning_MigrateJobAuthorization(t *testing.T) {
 			SubResource("jobs").
 			Body(body).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.NoError(t, result.Error(), "admin should be able to create migrate job")
 		require.Equal(t, http.StatusAccepted, statusCode, "should return 202 Accepted")
@@ -63,7 +61,7 @@ func TestIntegrationProvisioning_MigrateJobAuthorization(t *testing.T) {
 			SubResource("jobs").
 			Body(body).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.Error(t, result.Error(), "editor should not be able to migrate on instance-scoped repo")
 		require.Equal(t, http.StatusForbidden, statusCode, "should return 403 Forbidden")
@@ -84,7 +82,7 @@ func TestIntegrationProvisioning_MigrateJobAuthorization(t *testing.T) {
 			SubResource("jobs").
 			Body(body).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.Error(t, result.Error(), "viewer should not be able to create migrate job")
 		require.Equal(t, http.StatusForbidden, statusCode, "should return 403 Forbidden")

--- a/pkg/tests/apis/provisioning/jobs/instanceauth/migratejob_auth_test.go
+++ b/pkg/tests/apis/provisioning/jobs/instanceauth/migratejob_auth_test.go
@@ -16,14 +16,15 @@ func TestIntegrationProvisioning_MigrateJobAuthorization(t *testing.T) {
 
 	const repo = "migrate-auth-test"
 	testRepo := common.TestRepo{
-		Name:               repo,
-		SyncTarget:         "instance",
-		Workflows:          []string{"write"},
-		Copies:             map[string]string{},
-		ExpectedDashboards: 0,
-		ExpectedFolders:    0,
+		Name:       repo,
+		SyncTarget: "instance",
+		Workflows:  []string{"write"},
+		Copies:     map[string]string{},
 	}
 	helper.CreateLocalRepo(t, testRepo)
+
+	helper.RequireRepoDashboardCount(t, repo, 0)
+	helper.RequireRepoFolderCount(t, repo, 0)
 
 	t.Run("admin can create migrate job", func(t *testing.T) {
 		body := common.AsJSON(provisioning.JobSpec{

--- a/pkg/tests/apis/provisioning/jobs/job_validation_configured_resources_test.go
+++ b/pkg/tests/apis/provisioning/jobs/job_validation_configured_resources_test.go
@@ -1,7 +1,6 @@
 package jobs
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -32,7 +31,6 @@ func TestIntegrationProvisioning_JobValidationConfiguredResources(t *testing.T) 
 			"playlist.grafana.app/Playlist:disabled",
 		}
 	})
-	ctx := context.Background()
 
 	// The job admission validator only requires a non-empty repository name; it does not check
 	// repository existence (that happens later, in the jobs connector / worker). Creating Job
@@ -141,12 +139,12 @@ func TestIntegrationProvisioning_JobValidationConfiguredResources(t *testing.T) 
 				},
 			}
 
-			_, err := helper.Jobs.Resource.Create(ctx, jobObj, metav1.CreateOptions{})
+			_, err := helper.Jobs.Resource.Create(t.Context(), jobObj, metav1.CreateOptions{})
 			if tt.wantAccepted {
 				require.NoError(t, err, "job referencing a configured kind should pass admission")
 				// Best-effort cleanup: the job controller reconciles the new job concurrently, so a
 				// delete can race with a status update. Admission acceptance is the assertion here.
-				_ = helper.Jobs.Resource.Delete(ctx, name, metav1.DeleteOptions{})
+				_ = helper.Jobs.Resource.Delete(t.Context(), name, metav1.DeleteOptions{})
 				return
 			}
 

--- a/pkg/tests/apis/provisioning/jobs/job_validation_test.go
+++ b/pkg/tests/apis/provisioning/jobs/job_validation_test.go
@@ -1,7 +1,6 @@
 package jobs
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -16,7 +15,6 @@ import (
 
 func TestIntegrationProvisioning_JobValidation(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	// Create a test repository first
 	const repo = "job-validation-test-repo"
@@ -309,7 +307,7 @@ func TestIntegrationProvisioning_JobValidation(t *testing.T) {
 			}
 
 			// Try to create the job - should fail with validation error
-			_, err := helper.Jobs.Resource.Create(ctx, jobObj, metav1.CreateOptions{})
+			_, err := helper.Jobs.Resource.Create(t.Context(), jobObj, metav1.CreateOptions{})
 			require.Error(t, err, "expected validation error for invalid job spec")
 
 			// Verify it's a validation error with correct status code

--- a/pkg/tests/apis/provisioning/jobs/job_validation_test.go
+++ b/pkg/tests/apis/provisioning/jobs/job_validation_test.go
@@ -19,13 +19,14 @@ func TestIntegrationProvisioning_JobValidation(t *testing.T) {
 	// Create a test repository first
 	const repo = "job-validation-test-repo"
 	testRepo := common.TestRepo{
-		Name:               repo,
-		SyncTarget:         "folder",
-		Copies:             map[string]string{},
-		ExpectedDashboards: 0,
-		ExpectedFolders:    1, // folder sync creates a folder
+		Name:       repo,
+		SyncTarget: "folder",
+		Copies:     map[string]string{},
 	}
 	helper.CreateLocalRepo(t, testRepo)
+
+	helper.RequireRepoDashboardCount(t, repo, 0)
+	helper.RequireRepoFolderCount(t, repo, 1)
 
 	// Build a resource list that exceeds the selective-export cap (100).
 	overLimitResources := make([]map[string]interface{}, 101)

--- a/pkg/tests/apis/provisioning/jobs/job_warning_result_test.go
+++ b/pkg/tests/apis/provisioning/jobs/job_warning_result_test.go
@@ -23,8 +23,7 @@ func TestIntegrationProvisioning_JobWarningResult(t *testing.T) {
 		Copies: map[string]string{
 			"../testdata/invalid.json": "dashboard1.json",
 		},
-		SkipSync:               true, // Skip initial sync so we can add the malformed file first
-		SkipResourceAssertions: true, // will check both at the same time below to reduce duration of this test
+		SkipSync: true, // Skip initial sync so we can add the malformed file first
 	}
 	helper.CreateLocalRepo(t, testRepo)
 
@@ -78,8 +77,7 @@ func TestIntegrationProvisioning_JobWarningResult_MissingName(t *testing.T) {
 		Copies: map[string]string{
 			"../testdata/dashboard-missing-name.json": "dashboard-no-name.json",
 		},
-		SkipSync:               true,
-		SkipResourceAssertions: true,
+		SkipSync: true,
 	}
 	helper.CreateLocalRepo(t, testRepo)
 
@@ -124,8 +122,7 @@ func TestIntegrationProvisioning_JobWarningResult_DashboardRefreshInterval(t *te
 		Copies: map[string]string{
 			"../testdata/dashboard-refresh-too-low.json": "dashboard-refresh-low.json",
 		},
-		SkipSync:               true,
-		SkipResourceAssertions: true,
+		SkipSync: true,
 	}
 	helper.CreateLocalRepo(t, testRepo)
 
@@ -173,8 +170,7 @@ func TestIntegrationProvisioning_JobWarningResult_DashboardSchemaInvalid(t *test
 		Copies: map[string]string{
 			"../testdata/dashboard-v2-schema-invalid.json": "dashboard-v2-invalid.json",
 		},
-		SkipSync:               true,
-		SkipResourceAssertions: true,
+		SkipSync: true,
 	}
 	helper.CreateLocalRepo(t, testRepo)
 
@@ -235,8 +231,7 @@ func TestIntegrationProvisioning_JobWarningResult_DuplicateName(t *testing.T) {
 			"../testdata/dashboard-duplicate-name.json":      "dashboard-dup1.json",
 			"../testdata/dashboard-duplicate-name-copy.json": "dashboard-dup2.json",
 		},
-		SkipSync:               true,
-		SkipResourceAssertions: true,
+		SkipSync: true,
 	}
 	helper.CreateLocalRepo(t, testRepo)
 

--- a/pkg/tests/apis/provisioning/jobs/jobs_validation_test.go
+++ b/pkg/tests/apis/provisioning/jobs/jobs_validation_test.go
@@ -1,7 +1,6 @@
 package jobs
 
 import (
-	"context"
 	"net/http"
 	"testing"
 
@@ -14,7 +13,6 @@ import (
 
 func TestIntegrationProvisioning_WritePermissionValidation(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	const repoReadOnly = "job-validation-readonly"
 	testRepo := common.TestRepo{
@@ -88,7 +86,7 @@ func TestIntegrationProvisioning_WritePermissionValidation(t *testing.T) {
 					SubResource("jobs").
 					Body(body).
 					SetHeader("Content-Type", "application/json").
-					Do(ctx).StatusCode(&statusCode)
+					Do(t.Context()).StatusCode(&statusCode)
 
 				require.Error(t, result.Error(), "write job should be rejected for read-only repository")
 				require.Equal(t, http.StatusForbidden, statusCode, "should return 403 Forbidden")
@@ -112,7 +110,7 @@ func TestIntegrationProvisioning_WritePermissionValidation(t *testing.T) {
 			SubResource("jobs").
 			Body(body).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.NoError(t, result.Error(), "pull job should be allowed for read-only repository")
 		require.Equal(t, http.StatusAccepted, statusCode, "should return 202 Accepted")

--- a/pkg/tests/apis/provisioning/jobs/jobs_validation_test.go
+++ b/pkg/tests/apis/provisioning/jobs/jobs_validation_test.go
@@ -16,14 +16,15 @@ func TestIntegrationProvisioning_WritePermissionValidation(t *testing.T) {
 
 	const repoReadOnly = "job-validation-readonly"
 	testRepo := common.TestRepo{
-		Name:               repoReadOnly,
-		SyncTarget:         "folder",
-		Workflows:          []string{},
-		Copies:             map[string]string{},
-		ExpectedDashboards: 0,
-		ExpectedFolders:    1,
+		Name:       repoReadOnly,
+		SyncTarget: "folder",
+		Workflows:  []string{},
+		Copies:     map[string]string{},
 	}
 	helper.CreateLocalRepo(t, testRepo)
+
+	helper.RequireRepoDashboardCount(t, repoReadOnly, 0)
+	helper.RequireRepoFolderCount(t, repoReadOnly, 1)
 
 	t.Run("write jobs should be rejected for read-only repositories", func(t *testing.T) {
 		writeJobs := []struct {

--- a/pkg/tests/apis/provisioning/jobs/migratejob_test.go
+++ b/pkg/tests/apis/provisioning/jobs/migratejob_test.go
@@ -56,11 +56,10 @@ func TestIntegrationProvisioning_PullJobUnmanagedConflict(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(repoPath, "conflict-dashboard.json"), []byte(dashFileContent), 0o600))
 
 	testRepo := common.TestRepo{
-		Name:                   repo,
-		SyncTarget:             "folder",
-		LocalPath:              repoPath,
-		SkipSync:               true,
-		SkipResourceAssertions: true,
+		Name:       repo,
+		SyncTarget: "folder",
+		LocalPath:  repoPath,
+		SkipSync:   true,
 	}
 	helper.CreateLocalRepo(t, testRepo)
 
@@ -123,14 +122,15 @@ func TestIntegrationProvisioning_MigrateTakeover(t *testing.T) {
 	// Step 2: Create a repository targeting the whole instance.
 	const repo = "migrate-takeover-repo"
 	testRepo := common.TestRepo{
-		Name:               repo,
-		SyncTarget:         "instance",
-		Workflows:          []string{"write"},
-		Copies:             map[string]string{},
-		ExpectedDashboards: 2,
-		ExpectedFolders:    0,
+		Name:       repo,
+		SyncTarget: "instance",
+		Workflows:  []string{"write"},
+		Copies:     map[string]string{},
 	}
 	helper.CreateLocalRepo(t, testRepo)
+
+	helper.RequireDashboards(t, dashName1, dashName2)
+	helper.RequireRepoFolderCount(t, repo, 0)
 
 	// Step 3: Trigger a migration job (export + sync).
 	spec := provisioning.JobSpec{
@@ -195,25 +195,26 @@ func TestIntegrationProvisioning_SecondMigrateOnlyExportsNewDashboards(t *testin
 
 	// Create two unmanaged dashboards.
 	dashboard1 := helper.LoadYAMLOrJSONFile("../exportunifiedtorepository/dashboard-test-v1.yaml")
-	_, err := helper.DashboardsV1.Resource.Create(t.Context(), dashboard1, metav1.CreateOptions{})
+	created1, err := helper.DashboardsV1.Resource.Create(t.Context(), dashboard1, metav1.CreateOptions{})
 	require.NoError(t, err, "should create first dashboard")
 
 	dashboard2 := helper.LoadYAMLOrJSONFile("../exportunifiedtorepository/dashboard-test-v2beta1.yaml")
-	_, err = helper.DashboardsV2beta1.Resource.Create(t.Context(), dashboard2, metav1.CreateOptions{})
+	created2, err := helper.DashboardsV2beta1.Resource.Create(t.Context(), dashboard2, metav1.CreateOptions{})
 	require.NoError(t, err, "should create second dashboard")
 
 	// Create repo1 and migrate — should export both dashboards.
 	const repo1 = "first-repository"
 	repo1Path := filepath.Join(helper.ProvisioningPath, repo1)
 	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:               repo1,
-		SyncTarget:         "folder",
-		Workflows:          []string{"write"},
-		LocalPath:          repo1Path,
-		Copies:             map[string]string{},
-		ExpectedDashboards: 2,
-		ExpectedFolders:    1,
+		Name:       repo1,
+		SyncTarget: "folder",
+		Workflows:  []string{"write"},
+		LocalPath:  repo1Path,
+		Copies:     map[string]string{},
 	})
+
+	helper.RequireDashboards(t, created1.GetName(), created2.GetName())
+	helper.RequireRepoFolderCount(t, repo1, 1)
 
 	helper.TriggerJobAndWaitForSuccess(t, repo1, provisioning.JobSpec{
 		Action:  provisioning.JobActionMigrate,
@@ -229,12 +230,11 @@ func TestIntegrationProvisioning_SecondMigrateOnlyExportsNewDashboards(t *testin
 	const repo2 = "second-repository"
 	repo2Path := filepath.Join(helper.ProvisioningPath, repo2)
 	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:                   repo2,
-		SyncTarget:             "folder",
-		Workflows:              []string{"write"},
-		LocalPath:              repo2Path,
-		Copies:                 map[string]string{},
-		SkipResourceAssertions: true,
+		Name:       repo2,
+		SyncTarget: "folder",
+		Workflows:  []string{"write"},
+		LocalPath:  repo2Path,
+		Copies:     map[string]string{},
 	})
 
 	// Create a third dashboard that is still unmanaged.

--- a/pkg/tests/apis/provisioning/jobs/migratejob_test.go
+++ b/pkg/tests/apis/provisioning/jobs/migratejob_test.go
@@ -1,7 +1,6 @@
 package jobs
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -24,17 +23,16 @@ import (
 // with the same name as a file in the repository.
 func TestIntegrationProvisioning_PullJobUnmanagedConflict(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	// Step 1: Create an unmanaged dashboard directly via the API.
 	unmanagedDash := helper.LoadYAMLOrJSONFile("../exportunifiedtorepository/dashboard-test-v1.yaml")
-	created, err := helper.DashboardsV1.Resource.Create(ctx, unmanagedDash, metav1.CreateOptions{})
+	created, err := helper.DashboardsV1.Resource.Create(t.Context(), unmanagedDash, metav1.CreateOptions{})
 	require.NoError(t, err, "should create unmanaged dashboard")
 	dashName := created.GetName()
 	t.Logf("Created unmanaged dashboard: %s", dashName)
 
 	// Verify it is truly unmanaged (no manager annotation).
-	dash, err := helper.DashboardsV1.Resource.Get(ctx, dashName, metav1.GetOptions{})
+	dash, err := helper.DashboardsV1.Resource.Get(t.Context(), dashName, metav1.GetOptions{})
 	require.NoError(t, err)
 	managerID := dash.GetAnnotations()[utils.AnnoKeyManagerIdentity]
 	require.Empty(t, managerID, "dashboard should be unmanaged before sync")
@@ -96,7 +94,7 @@ func TestIntegrationProvisioning_PullJobUnmanagedConflict(t *testing.T) {
 	require.True(t, found, "should have unmanaged conflict warning, got: %v", jobObj.Status.Warnings)
 
 	// Step 5: Verify the original dashboard is still unmanaged and unchanged.
-	dash, err = helper.DashboardsV1.Resource.Get(ctx, dashName, metav1.GetOptions{})
+	dash, err = helper.DashboardsV1.Resource.Get(t.Context(), dashName, metav1.GetOptions{})
 	require.NoError(t, err, "unmanaged dashboard should still exist")
 	managerID = dash.GetAnnotations()[utils.AnnoKeyManagerIdentity]
 	require.Empty(t, managerID, "dashboard should remain unmanaged after sync warning")
@@ -108,17 +106,16 @@ func TestIntegrationProvisioning_PullJobUnmanagedConflict(t *testing.T) {
 // 3. After migration, the dashboards are managed by the repository.
 func TestIntegrationProvisioning_MigrateTakeover(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	// Step 1: Create two unmanaged dashboards directly.
 	dash1 := helper.LoadYAMLOrJSONFile("../exportunifiedtorepository/dashboard-test-v1.yaml")
-	created1, err := helper.DashboardsV1.Resource.Create(ctx, dash1, metav1.CreateOptions{})
+	created1, err := helper.DashboardsV1.Resource.Create(t.Context(), dash1, metav1.CreateOptions{})
 	require.NoError(t, err, "should create first unmanaged dashboard")
 	dashName1 := created1.GetName()
 	t.Logf("Created unmanaged dashboard 1: %s", dashName1)
 
 	dash2 := helper.LoadYAMLOrJSONFile("../exportunifiedtorepository/dashboard-test-v2beta1.yaml")
-	created2, err := helper.DashboardsV2beta1.Resource.Create(ctx, dash2, metav1.CreateOptions{})
+	created2, err := helper.DashboardsV2beta1.Resource.Create(t.Context(), dash2, metav1.CreateOptions{})
 	require.NoError(t, err, "should create second unmanaged dashboard")
 	dashName2 := created2.GetName()
 	t.Logf("Created unmanaged dashboard 2: %s", dashName2)
@@ -146,14 +143,14 @@ func TestIntegrationProvisioning_MigrateTakeover(t *testing.T) {
 
 	// Step 4: After migration, both dashboards should be managed by the repository.
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		d1, err := helper.DashboardsV1.Resource.Get(ctx, dashName1, metav1.GetOptions{})
+		d1, err := helper.DashboardsV1.Resource.Get(t.Context(), dashName1, metav1.GetOptions{})
 		if !assert.NoError(collect, err, "dashboard 1 should still exist") {
 			return
 		}
 		assert.Equal(collect, repo, d1.GetAnnotations()[utils.AnnoKeyManagerIdentity],
 			"dashboard 1 should be managed by the repo after migration")
 
-		d2, err := helper.DashboardsV1.Resource.Get(ctx, dashName2, metav1.GetOptions{})
+		d2, err := helper.DashboardsV1.Resource.Get(t.Context(), dashName2, metav1.GetOptions{})
 		if !assert.NoError(collect, err, "dashboard 2 should still exist") {
 			return
 		}
@@ -162,7 +159,7 @@ func TestIntegrationProvisioning_MigrateTakeover(t *testing.T) {
 	}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "both dashboards should become managed after migration")
 
 	// Step 5: Verify no warnings or errors on the completed migration job.
-	result, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "jobs")
+	result, err := helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "jobs")
 	require.NoError(t, err)
 	list, err := result.ToList()
 	require.NoError(t, err)
@@ -195,15 +192,14 @@ func TestIntegrationProvisioning_MigrateTakeover(t *testing.T) {
 // This test focuses on files written to each repository directory.
 func TestIntegrationProvisioning_SecondMigrateOnlyExportsNewDashboards(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	// Create two unmanaged dashboards.
 	dashboard1 := helper.LoadYAMLOrJSONFile("../exportunifiedtorepository/dashboard-test-v1.yaml")
-	_, err := helper.DashboardsV1.Resource.Create(ctx, dashboard1, metav1.CreateOptions{})
+	_, err := helper.DashboardsV1.Resource.Create(t.Context(), dashboard1, metav1.CreateOptions{})
 	require.NoError(t, err, "should create first dashboard")
 
 	dashboard2 := helper.LoadYAMLOrJSONFile("../exportunifiedtorepository/dashboard-test-v2beta1.yaml")
-	_, err = helper.DashboardsV2beta1.Resource.Create(ctx, dashboard2, metav1.CreateOptions{})
+	_, err = helper.DashboardsV2beta1.Resource.Create(t.Context(), dashboard2, metav1.CreateOptions{})
 	require.NoError(t, err, "should create second dashboard")
 
 	// Create repo1 and migrate — should export both dashboards.
@@ -243,7 +239,7 @@ func TestIntegrationProvisioning_SecondMigrateOnlyExportsNewDashboards(t *testin
 
 	// Create a third dashboard that is still unmanaged.
 	dashboard3 := helper.LoadYAMLOrJSONFile("../exportunifiedtorepository/dashboard-test-v0.yaml")
-	_, err = helper.DashboardsV0.Resource.Create(ctx, dashboard3, metav1.CreateOptions{})
+	_, err = helper.DashboardsV0.Resource.Create(t.Context(), dashboard3, metav1.CreateOptions{})
 	require.NoError(t, err, "should create third dashboard")
 
 	// Migrate repo2 — should only export dashboard3 (the unmanaged one).

--- a/pkg/tests/apis/provisioning/jobs/movejob_auth_test.go
+++ b/pkg/tests/apis/provisioning/jobs/movejob_auth_test.go
@@ -1,7 +1,6 @@
 package jobs
 
 import (
-	"context"
 	"net/http"
 	"testing"
 
@@ -15,7 +14,6 @@ import (
 
 func TestIntegrationProvisioning_MoveJobAuthorization(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	const repo = "move-auth-test"
 	testRepo := common.TestRepo{
@@ -58,7 +56,7 @@ func TestIntegrationProvisioning_MoveJobAuthorization(t *testing.T) {
 			SubResource("jobs").
 			Body(body).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.NoError(t, result.Error(), "admin should be able to create move job")
 		require.Equal(t, http.StatusAccepted, statusCode, "should return 202 Accepted")
@@ -83,7 +81,7 @@ func TestIntegrationProvisioning_MoveJobAuthorization(t *testing.T) {
 			SubResource("jobs").
 			Body(body).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.NoError(t, result.Error(), "editor should be able to create move job")
 		require.Equal(t, http.StatusAccepted, statusCode, "should return 202 Accepted")
@@ -108,7 +106,7 @@ func TestIntegrationProvisioning_MoveJobAuthorization(t *testing.T) {
 			SubResource("jobs").
 			Body(body).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.Error(t, result.Error(), "viewer should not be able to create move job")
 		require.Equal(t, http.StatusForbidden, statusCode, "should return 403 Forbidden")
@@ -135,7 +133,7 @@ func TestIntegrationProvisioning_MoveJobAuthorization(t *testing.T) {
 			SubResource("jobs").
 			Body(body).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.Error(t, result.Error(), "move job should be blocked for folder resource in a file")
 		require.NotEqual(t, http.StatusAccepted, statusCode, "should not return 202 Accepted")
@@ -161,7 +159,7 @@ func TestIntegrationProvisioning_MoveJobAuthorization(t *testing.T) {
 			SubResource("jobs").
 			Body(body).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.Error(t, result.Error(), "move job should be blocked for unsupported resource type")
 		require.NotEqual(t, http.StatusAccepted, statusCode, "should not return 202 Accepted")

--- a/pkg/tests/apis/provisioning/jobs/movejob_auth_test.go
+++ b/pkg/tests/apis/provisioning/jobs/movejob_auth_test.go
@@ -22,10 +22,11 @@ func TestIntegrationProvisioning_MoveJobAuthorization(t *testing.T) {
 		Copies: map[string]string{
 			"../testdata/all-panels.json": "dashboard.json",
 		},
-		ExpectedDashboards: 1,
-		ExpectedFolders:    0,
 	}
 	helper.CreateLocalRepo(t, testRepo)
+
+	helper.RequireRepoDashboardCount(t, repo, 1)
+	helper.RequireRepoFolderCount(t, repo, 0)
 
 	// Grant the editor user dashboard permissions (the default editor role
 	// does not include dashboards:write/dashboards:create which are required

--- a/pkg/tests/apis/provisioning/jobs/movejob_test.go
+++ b/pkg/tests/apis/provisioning/jobs/movejob_test.go
@@ -1,7 +1,6 @@
 package jobs
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -16,7 +15,6 @@ import (
 
 func TestIntegrationProvisioning_MoveJob(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 	const repo = "move-test-repo"
 	testRepo := common.TestRepo{
 		Name:       repo,
@@ -50,22 +48,22 @@ func TestIntegrationProvisioning_MoveJob(t *testing.T) {
 
 		// FIXME: use the helpers for assertions
 		// Verify file is moved in repository
-		_, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "moved", "dashboard1.json")
+		_, err := helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "moved", "dashboard1.json")
 		require.NoError(t, err, "file should exist at new location in repository")
 
 		// Verify original file is gone from repository
-		_, err = helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "dashboard1.json")
+		_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "dashboard1.json")
 		require.Error(t, err, "original file should be gone from repository")
 		require.True(t, apierrors.IsNotFound(err), "should be not found error")
 
 		// Verify other files still exist at original locations
-		_, err = helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "dashboard2.json")
+		_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "dashboard2.json")
 		require.NoError(t, err, "other files should still exist")
-		_, err = helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "folder", "dashboard3.json")
+		_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "folder", "dashboard3.json")
 		require.NoError(t, err, "nested files should still exist")
 
 		// Verify dashboard still exists in Grafana after sync
-		dashboards, err := helper.DashboardsV1.Resource.List(ctx, metav1.ListOptions{})
+		dashboards, err := helper.DashboardsV1.Resource.List(t.Context(), metav1.ListOptions{})
 		require.NoError(t, err)
 		require.Len(t, dashboards.Items, 3, "should still have 3 dashboards after move")
 		// Verify that dashboards have the correct source paths
@@ -98,24 +96,24 @@ func TestIntegrationProvisioning_MoveJob(t *testing.T) {
 		helper.SyncAndWait(t, repo, nil)
 
 		// Verify files are moved in repository
-		_, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "archived", "dashboard2.json")
+		_, err := helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "archived", "dashboard2.json")
 		require.NoError(t, err, "dashboard2.json should exist at new location")
-		_, err = helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "archived", "folder", "dashboard3.json")
+		_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "archived", "folder", "dashboard3.json")
 		require.NoError(t, err, "folder/dashboard3.json should exist at new nested location")
 
 		// Verify original files are gone from repository
-		_, err = helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "dashboard2.json")
+		_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "dashboard2.json")
 		require.Error(t, err, "dashboard2.json should be gone from original location")
 		require.True(t, apierrors.IsNotFound(err))
 
-		_, err = helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "folder", "dashboard3.json")
+		_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "folder", "dashboard3.json")
 		require.Error(t, err, "folder should be gone from original location")
 		require.True(t, apierrors.IsNotFound(err), err.Error())
 
 		// Verify dashboards still exist in Grafana after sync
 		// Note: Since dashboard1.json was moved in the previous test, we now expect all 3 dashboards
 		// to be accessible from their moved locations (dashboard1 from moved/, dashboard2 and dashboard3 from archived/)
-		dashboards, err := helper.DashboardsV1.Resource.List(ctx, metav1.ListOptions{})
+		dashboards, err := helper.DashboardsV1.Resource.List(t.Context(), metav1.ListOptions{})
 		require.NoError(t, err)
 		require.Len(t, dashboards.Items, 3, "should still have 3 dashboards after move")
 
@@ -147,7 +145,7 @@ func TestIntegrationProvisioning_MoveJob(t *testing.T) {
 			SubResource("jobs").
 			Body(body).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx)
+			Do(t.Context())
 
 		require.Error(t, result.Error(), "move job for non-existent file should be rejected at creation")
 	})
@@ -191,7 +189,7 @@ func TestIntegrationProvisioning_MoveJob(t *testing.T) {
 			SubResource("jobs").
 			Body(body).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx)
+			Do(t.Context())
 
 		require.Error(t, result.Error(), "move job without target path should fail validation")
 		statusError := helper.RequireApiErrorStatus(result.Error(), metav1.StatusReasonInvalid, 422)
@@ -200,11 +198,11 @@ func TestIntegrationProvisioning_MoveJob(t *testing.T) {
 
 	t.Run("move by resource reference", func(t *testing.T) {
 		// Delete the existing repository to avoid conflicts with validation rules
-		err := helper.Repositories.Resource.Delete(ctx, repo, metav1.DeleteOptions{})
+		err := helper.Repositories.Resource.Delete(t.Context(), repo, metav1.DeleteOptions{})
 		require.NoError(t, err)
 
 		// Wait for repository to be fully deleted
-		helper.WaitForRepositoryDeleted(t, ctx, repo)
+		helper.WaitForRepositoryDeleted(t, repo)
 
 		// Create modified test files with unique UIDs for ResourceRef testing
 		allPanelsContent := helper.LoadFile("../testdata/all-panels.json")
@@ -257,21 +255,21 @@ func TestIntegrationProvisioning_MoveJob(t *testing.T) {
 
 			helper.TriggerJobAndWaitForSuccess(t, refRepo, spec)
 			// Verify corresponding file is moved in repository
-			_, err = helper.Repositories.Resource.Get(ctx, refRepo, metav1.GetOptions{}, "files", "moved-by-ref", "move-source-1.json")
+			_, err = helper.Repositories.Resource.Get(t.Context(), refRepo, metav1.GetOptions{}, "files", "moved-by-ref", "move-source-1.json")
 			require.NoError(t, err, "file should be moved to new location in repository")
 
 			// Verify original file is deleted from repository
-			_, err = helper.Repositories.Resource.Get(ctx, refRepo, metav1.GetOptions{}, "files", "move-source-1.json")
+			_, err = helper.Repositories.Resource.Get(t.Context(), refRepo, metav1.GetOptions{}, "files", "move-source-1.json")
 			require.Error(t, err, "original file should be deleted from repository")
 			require.True(t, apierrors.IsNotFound(err), "should be not found error")
 
 			// Verify dashboard still exists in Grafana (should be updated after sync)
 			helper.SyncAndWait(t, refRepo, nil)
-			_, err = helper.DashboardsV1.Resource.Get(ctx, "moveref1", metav1.GetOptions{})
+			_, err = helper.DashboardsV1.Resource.Get(t.Context(), "moveref1", metav1.GetOptions{})
 			require.NoError(t, err, "dashboard should still exist in Grafana after move")
 
 			// Verify other resource still exists in original location
-			_, err = helper.Repositories.Resource.Get(ctx, refRepo, metav1.GetOptions{}, "files", "move-source-2.json")
+			_, err = helper.Repositories.Resource.Get(t.Context(), refRepo, metav1.GetOptions{}, "files", "move-source-2.json")
 			require.NoError(t, err, "other files should still exist in original location")
 		})
 
@@ -292,17 +290,17 @@ func TestIntegrationProvisioning_MoveJob(t *testing.T) {
 			helper.TriggerJobAndWaitForSuccess(t, refRepo, spec)
 
 			// Verify file is moved in repository
-			_, err = helper.Repositories.Resource.Get(ctx, refRepo, metav1.GetOptions{}, "files", "archived-by-ref", "move-source-2.json")
+			_, err = helper.Repositories.Resource.Get(t.Context(), refRepo, metav1.GetOptions{}, "files", "archived-by-ref", "move-source-2.json")
 			require.NoError(t, err, "file should be moved to new location")
 
 			// Verify original file is deleted from repository
-			_, err = helper.Repositories.Resource.Get(ctx, refRepo, metav1.GetOptions{}, "files", "move-source-2.json")
+			_, err = helper.Repositories.Resource.Get(t.Context(), refRepo, metav1.GetOptions{}, "files", "move-source-2.json")
 			require.Error(t, err, "original file should be deleted from repository")
 			require.True(t, apierrors.IsNotFound(err), "should be not found error")
 
 			// Verify dashboard still exists in Grafana after sync
 			helper.SyncAndWait(t, refRepo, nil)
-			_, err = helper.DashboardsV1.Resource.Get(ctx, "moveref2", metav1.GetOptions{})
+			_, err = helper.DashboardsV1.Resource.Get(t.Context(), "moveref2", metav1.GetOptions{})
 			require.NoError(t, err, "dashboard should still exist in Grafana after move")
 		})
 
@@ -318,9 +316,9 @@ func TestIntegrationProvisioning_MoveJob(t *testing.T) {
 			helper.SyncAndWait(t, refRepo, nil)
 
 			// Verify dashboard exists before the move
-			_, err = helper.DashboardsV1.Resource.Get(ctx, "movetoroot1", metav1.GetOptions{})
+			_, err = helper.DashboardsV1.Resource.Get(t.Context(), "movetoroot1", metav1.GetOptions{})
 			require.NoError(t, err, "dashboard should exist before move")
-			_, err = helper.Repositories.Resource.Get(ctx, refRepo, metav1.GetOptions{}, "files", "inner-folder", "move-to-root.json")
+			_, err = helper.Repositories.Resource.Get(t.Context(), refRepo, metav1.GetOptions{}, "files", "inner-folder", "move-to-root.json")
 			require.NoError(t, err, "file should exist in nested folder before move")
 
 			spec := provisioning.JobSpec{
@@ -341,15 +339,15 @@ func TestIntegrationProvisioning_MoveJob(t *testing.T) {
 			helper.SyncAndWait(t, refRepo, nil)
 
 			// The dashboard must NOT be deleted — it should still exist in Grafana
-			_, err = helper.DashboardsV1.Resource.Get(ctx, "movetoroot1", metav1.GetOptions{})
+			_, err = helper.DashboardsV1.Resource.Get(t.Context(), "movetoroot1", metav1.GetOptions{})
 			require.NoError(t, err, "dashboard should NOT be deleted when moving to root path '/'")
 
 			// The file should now live at the repository root
-			_, err = helper.Repositories.Resource.Get(ctx, refRepo, metav1.GetOptions{}, "files", "move-to-root.json")
+			_, err = helper.Repositories.Resource.Get(t.Context(), refRepo, metav1.GetOptions{}, "files", "move-to-root.json")
 			require.NoError(t, err, "file should exist at root level after move to '/'")
 
 			// The file should be gone from the nested folder
-			_, err = helper.Repositories.Resource.Get(ctx, refRepo, metav1.GetOptions{}, "files", "inner-folder", "move-to-root.json")
+			_, err = helper.Repositories.Resource.Get(t.Context(), refRepo, metav1.GetOptions{}, "files", "inner-folder", "move-to-root.json")
 			require.Error(t, err, "file should be gone from nested folder after move")
 			require.True(t, apierrors.IsNotFound(err), "should be not found error")
 		})
@@ -388,25 +386,25 @@ func TestIntegrationProvisioning_MoveJob(t *testing.T) {
 			helper.TriggerJobAndWaitForSuccess(t, refRepo, spec)
 
 			// Verify both targeted resources are moved in repository
-			_, err = helper.Repositories.Resource.Get(ctx, refRepo, metav1.GetOptions{}, "files", "mixed-target", "mixed-move-1.json")
+			_, err = helper.Repositories.Resource.Get(t.Context(), refRepo, metav1.GetOptions{}, "files", "mixed-target", "mixed-move-1.json")
 			require.NoError(t, err, "file moved by path should exist at new location")
 
-			_, err = helper.Repositories.Resource.Get(ctx, refRepo, metav1.GetOptions{}, "files", "mixed-target", "mixed-move-2.json")
+			_, err = helper.Repositories.Resource.Get(t.Context(), refRepo, metav1.GetOptions{}, "files", "mixed-target", "mixed-move-2.json")
 			require.NoError(t, err, "file moved by resource ref should exist at new location")
 
 			// Verify files are deleted from original locations
-			_, err = helper.Repositories.Resource.Get(ctx, refRepo, metav1.GetOptions{}, "files", "mixed-move-1.json")
+			_, err = helper.Repositories.Resource.Get(t.Context(), refRepo, metav1.GetOptions{}, "files", "mixed-move-1.json")
 			require.Error(t, err, "file moved by path should be deleted from original location")
 
-			_, err = helper.Repositories.Resource.Get(ctx, refRepo, metav1.GetOptions{}, "files", "mixed-move-2.json")
+			_, err = helper.Repositories.Resource.Get(t.Context(), refRepo, metav1.GetOptions{}, "files", "mixed-move-2.json")
 			require.Error(t, err, "file moved by resource ref should be deleted from original location")
 
 			// Verify dashboards still exist in Grafana after sync
 			helper.SyncAndWait(t, refRepo, nil)
-			_, err = helper.DashboardsV1.Resource.Get(ctx, "mixedmove1", metav1.GetOptions{})
+			_, err = helper.DashboardsV1.Resource.Get(t.Context(), "mixedmove1", metav1.GetOptions{})
 			require.NoError(t, err, "dashboard moved by path should still exist in Grafana")
 
-			_, err = helper.DashboardsV1.Resource.Get(ctx, "mixedmove2", metav1.GetOptions{})
+			_, err = helper.DashboardsV1.Resource.Get(t.Context(), "mixedmove2", metav1.GetOptions{})
 			require.NoError(t, err, "dashboard moved by resource ref should still exist in Grafana")
 		})
 	})

--- a/pkg/tests/apis/provisioning/jobs/movejob_test.go
+++ b/pkg/tests/apis/provisioning/jobs/movejob_test.go
@@ -15,6 +15,7 @@ import (
 
 func TestIntegrationProvisioning_MoveJob(t *testing.T) {
 	helper := sharedHelper(t)
+
 	const repo = "move-test-repo"
 	testRepo := common.TestRepo{
 		Name:       repo,
@@ -25,10 +26,11 @@ func TestIntegrationProvisioning_MoveJob(t *testing.T) {
 			"../testdata/text-options.json":  "dashboard2.json",
 			"../testdata/timeline-demo.json": "folder/dashboard3.json",
 		},
-		ExpectedDashboards: 3,
-		ExpectedFolders:    2, // folder sync creates a folder for the repo + one nested folder
 	}
 	helper.CreateLocalRepo(t, testRepo)
+
+	helper.RequireRepoDashboardCount(t, repo, 3)
+	helper.RequireRepoFolderCount(t, repo, 2)
 
 	t.Run("move single file", func(t *testing.T) {
 		helper.DebugState(t, repo, "BEFORE MOVE SINGLE FILE")
@@ -232,10 +234,9 @@ func TestIntegrationProvisioning_MoveJob(t *testing.T) {
 		// Create a unique repository for resource reference testing to avoid contamination
 		const refRepo = "move-ref-test-repo"
 		helper.CreateLocalRepo(t, common.TestRepo{
-			Name:                   refRepo,
-			SyncTarget:             "folder",
-			Workflows:              []string{"write"},
-			SkipResourceAssertions: true, // HACK: I am not sure why sometimes it's 6 or 3 dashbaords.
+			Name:       refRepo,
+			SyncTarget: "folder",
+			Workflows:  []string{"write"},
 		})
 
 		t.Run("move single dashboard by resource reference", func(t *testing.T) {

--- a/pkg/tests/apis/provisioning/jobs/orphanjob_get_test.go
+++ b/pkg/tests/apis/provisioning/jobs/orphanjob_get_test.go
@@ -1,7 +1,6 @@
 package jobs
 
 import (
-	"context"
 	"net/http"
 	"testing"
 
@@ -20,7 +19,6 @@ import (
 // specifically created for missing or terminating repositories.
 func TestIntegrationProvisioning_OrphanCleanupJobGetEndpoint(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	for _, action := range []provisioning.JobAction{
 		provisioning.JobActionReleaseResources,
@@ -42,7 +40,7 @@ func TestIntegrationProvisioning_OrphanCleanupJobGetEndpoint(t *testing.T) {
 				SubResource("jobs").
 				Body(body).
 				SetHeader("Content-Type", "application/json").
-				Do(ctx).StatusCode(&statusCode)
+				Do(t.Context()).StatusCode(&statusCode)
 			require.NoError(t, result.Error(), "admin should be able to create %s job", action)
 			require.Equal(t, http.StatusAccepted, statusCode)
 
@@ -58,7 +56,7 @@ func TestIntegrationProvisioning_OrphanCleanupJobGetEndpoint(t *testing.T) {
 			// because there are no managed resources for a nonexistent repo).
 			var historicJob *unstructured.Unstructured
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {
-				got, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "jobs", jobUID)
+				got, err := helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "jobs", jobUID)
 				if !assert.NoError(collect, err, "GET by UID should succeed for nonexistent repo") {
 					return
 				}
@@ -75,7 +73,7 @@ func TestIntegrationProvisioning_OrphanCleanupJobGetEndpoint(t *testing.T) {
 			})
 
 			t.Run("GET job list returns at least one job", func(t *testing.T) {
-				listResult, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "jobs")
+				listResult, err := helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "jobs")
 				require.NoError(t, err, "GET job list should succeed for nonexistent repo")
 
 				list, err := listResult.ToList()

--- a/pkg/tests/apis/provisioning/jobs/pending_delete_test.go
+++ b/pkg/tests/apis/provisioning/jobs/pending_delete_test.go
@@ -27,21 +27,20 @@ func TestIntegrationProvisioning_JobPendingDeleteLabel_SkipsExecution(t *testing
 	// Create a local repository with one dashboard and run the initial sync so
 	// the resource is present in Grafana.
 	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:               repoName,
-		SyncTarget:         "folder",
-		ExpectedDashboards: 1,
-		ExpectedFolders:    1, // folder sync creates a root folder for the repository
+		Name:       repoName,
+		SyncTarget: "folder",
 		Copies: map[string]string{
 			"../testdata/all-panels.json": "dashboard.json",
 		},
 	})
 
-	// Remove the file from disk. A real pull job would propagate this deletion to
-	// Grafana; a skipped job must leave the dashboard intact.
-	err := os.Remove(filepath.Join(helper.ProvisioningPath, "dashboard.json"))
-	require.NoError(t, err)
+	helper.RequireRepoDashboardCount(t, repoName, 1)
+	helper.RequireRepoFolderCount(t, repoName, 1)
 
-	// Label the repository as pending-delete before submitting the job.
+	// Label the repository as pending-delete BEFORE removing the file from disk.
+	// The repository was created with sync enabled, so a controller-triggered pull
+	// could otherwise run in the window between the file removal and the label
+	// update and delete the dashboard this test expects preserved.
 	repoObj, err := helper.Repositories.Resource.Get(t.Context(), repoName, metav1.GetOptions{})
 	require.NoError(t, err)
 
@@ -53,6 +52,11 @@ func TestIntegrationProvisioning_JobPendingDeleteLabel_SkipsExecution(t *testing
 	repoObj.SetLabels(labels)
 
 	_, err = helper.Repositories.Resource.Update(t.Context(), repoObj, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	// Remove the file from disk now that the label is set. A real pull job would
+	// propagate this deletion to Grafana; a skipped job must leave the dashboard intact.
+	err = os.Remove(filepath.Join(helper.ProvisioningPath, "dashboard.json"))
 	require.NoError(t, err)
 
 	// Submit a pull job. Without the pending-delete skip this would sync the

--- a/pkg/tests/apis/provisioning/jobs/pulljob_auth_test.go
+++ b/pkg/tests/apis/provisioning/jobs/pulljob_auth_test.go
@@ -1,7 +1,6 @@
 package jobs
 
 import (
-	"context"
 	"net/http"
 	"testing"
 
@@ -14,7 +13,6 @@ import (
 
 func TestIntegrationProvisioning_PullJobAuthorization(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	const repo = "pull-auth-test"
 	testRepo := common.TestRepo{
@@ -40,7 +38,7 @@ func TestIntegrationProvisioning_PullJobAuthorization(t *testing.T) {
 			SubResource("jobs").
 			Body(body).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.NoError(t, result.Error(), "admin should be able to create pull job")
 		require.Equal(t, http.StatusAccepted, statusCode, "should return 202 Accepted")
@@ -57,7 +55,7 @@ func TestIntegrationProvisioning_PullJobAuthorization(t *testing.T) {
 			SubResource("jobs").
 			Body(body).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.Error(t, result.Error(), "editor should not be able to create pull job")
 		require.Equal(t, http.StatusForbidden, statusCode, "should return 403 Forbidden")
@@ -73,7 +71,7 @@ func TestIntegrationProvisioning_PullJobAuthorization(t *testing.T) {
 			SubResource("jobs").
 			Body(body).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.Error(t, result.Error(), "viewer should not be able to create pull job")
 		require.Equal(t, http.StatusForbidden, statusCode, "should return 403 Forbidden")

--- a/pkg/tests/apis/provisioning/jobs/pulljob_auth_test.go
+++ b/pkg/tests/apis/provisioning/jobs/pulljob_auth_test.go
@@ -16,13 +16,14 @@ func TestIntegrationProvisioning_PullJobAuthorization(t *testing.T) {
 
 	const repo = "pull-auth-test"
 	testRepo := common.TestRepo{
-		Name:               repo,
-		SyncTarget:         "folder",
-		Copies:             map[string]string{},
-		ExpectedDashboards: 0,
-		ExpectedFolders:    1,
+		Name:       repo,
+		SyncTarget: "folder",
+		Copies:     map[string]string{},
 	}
 	helper.CreateLocalRepo(t, testRepo)
+
+	helper.RequireRepoDashboardCount(t, repo, 0)
+	helper.RequireRepoFolderCount(t, repo, 1)
 
 	body := common.AsJSON(provisioning.JobSpec{
 		Action: provisioning.JobActionPull,

--- a/pkg/tests/apis/provisioning/jobs/pulljob_folder_depth_test.go
+++ b/pkg/tests/apis/provisioning/jobs/pulljob_folder_depth_test.go
@@ -40,8 +40,7 @@ func TestIntegrationProvisioning_PullJobFolderDepthExceeded(t *testing.T) {
 			"../testdata/text-options.json":  deepDir + "/dashboard2.json",
 			"../testdata/timeline-demo.json": deepDir + "/dashboard3.json",
 		},
-		SkipSync:               true,
-		SkipResourceAssertions: true,
+		SkipSync: true,
 	})
 
 	job := helper.TriggerJobAndWaitForComplete(t, repo, provisioning.JobSpec{
@@ -171,8 +170,7 @@ func TestIntegrationProvisioning_PullJobFolderDepthExceeded_RecoversAfterFix(t *
 			"../testdata/all-panels.json":   "ok/dashboard.json",
 			"../testdata/text-options.json": deepDashboardRel,
 		},
-		SkipSync:               true,
-		SkipResourceAssertions: true,
+		SkipSync: true,
 	})
 
 	job := helper.TriggerJobAndWaitForComplete(t, repo, provisioning.JobSpec{

--- a/pkg/tests/apis/provisioning/jobs/pulljob_test.go
+++ b/pkg/tests/apis/provisioning/jobs/pulljob_test.go
@@ -32,7 +32,6 @@ func TestIntegrationProvisioning_PullJobOwnershipProtection(t *testing.T) {
 		Copies: map[string]string{
 			"../testdata/all-panels.json": "dashboard1.json",
 		},
-		SkipResourceAssertions: true, // will check both at the same time below
 	})
 	helper.CreateLocalRepo(t, common.TestRepo{
 		Name:       repo2,
@@ -41,7 +40,6 @@ func TestIntegrationProvisioning_PullJobOwnershipProtection(t *testing.T) {
 		Copies: map[string]string{
 			"../testdata/timeline-demo.json": "dashboard2.json",
 		},
-		SkipResourceAssertions: true, // will check both at the same time below
 	})
 
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
@@ -172,11 +170,13 @@ func TestIntegrationProvisioning_PullJobUnmanagedRootConflict(t *testing.T) {
 	repoPath := path.Join(helper.ProvisioningPath, "unmanaged-root-repo-data")
 
 	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:            repo,
-		LocalPath:       repoPath,
-		SyncTarget:      "folder",
-		ExpectedFolders: 1,
+		Name:       repo,
+		LocalPath:  repoPath,
+		SyncTarget: "folder",
 	})
+
+	helper.RequireRepoDashboardCount(t, repo, 0)
+	helper.RequireRepoFolderCount(t, repo, 1)
 
 	rootFolder, err := helper.Folders.Resource.Get(t.Context(), repo, metav1.GetOptions{})
 	require.NoError(t, err, "root folder should exist after initial sync")
@@ -205,11 +205,10 @@ func TestIntegrationProvisioning_PullJobUnmanagedRootConflict(t *testing.T) {
 	// and inspect the pull job ourselves rather than racing the helper's
 	// initial sync.
 	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:                   repo,
-		LocalPath:              repoPath,
-		SyncTarget:             "folder",
-		SkipSync:               true,
-		SkipResourceAssertions: true,
+		Name:       repo,
+		LocalPath:  repoPath,
+		SyncTarget: "folder",
+		SkipSync:   true,
 	})
 
 	job := helper.TriggerJobAndWaitForComplete(t, repo, provisioning.JobSpec{

--- a/pkg/tests/apis/provisioning/jobs/pulljob_test.go
+++ b/pkg/tests/apis/provisioning/jobs/pulljob_test.go
@@ -1,7 +1,6 @@
 package jobs
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path"
@@ -22,7 +21,6 @@ import (
 
 func TestIntegrationProvisioning_PullJobOwnershipProtection(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	const repo1 = "pulljob-repo-1"
 	const repo2 = "pulljob-repo-2"
@@ -113,7 +111,7 @@ func TestIntegrationProvisioning_PullJobOwnershipProtection(t *testing.T) {
 		require.True(t, found, "should have ownership conflict warning")
 
 		// Step 4: Verify original resource is still owned by repo1 and unchanged
-		originalDashboard, err := helper.DashboardsV1.Resource.Get(ctx, allPanelsUID, metav1.GetOptions{})
+		originalDashboard, err := helper.DashboardsV1.Resource.Get(t.Context(), allPanelsUID, metav1.GetOptions{})
 		require.NoError(t, err, "original dashboard should still exist")
 		require.Equal(t, repo1, originalDashboard.GetAnnotations()[utils.AnnoKeyManagerIdentity], "ownership should remain with repo1")
 
@@ -131,11 +129,11 @@ func TestIntegrationProvisioning_PullJobOwnershipProtection(t *testing.T) {
 		const allPanelsUID = "n1jR8vnnz" // UID from all-panels.json (repo1)
 		const timelineUID = "mIJjFy8Kz"  // UID from timeline-demo.json (repo2)
 
-		repo1Dashboard, err := helper.DashboardsV1.Resource.Get(ctx, allPanelsUID, metav1.GetOptions{})
+		repo1Dashboard, err := helper.DashboardsV1.Resource.Get(t.Context(), allPanelsUID, metav1.GetOptions{})
 		require.NoError(t, err, "repo1's dashboard should exist")
 		require.Equal(t, repo1, repo1Dashboard.GetAnnotations()[utils.AnnoKeyManagerIdentity], "should be owned by repo1")
 
-		repo2Dashboard, err := helper.DashboardsV1.Resource.Get(ctx, timelineUID, metav1.GetOptions{})
+		repo2Dashboard, err := helper.DashboardsV1.Resource.Get(t.Context(), timelineUID, metav1.GetOptions{})
 		require.NoError(t, err, "repo2's dashboard should exist")
 		require.Equal(t, repo2, repo2Dashboard.GetAnnotations()[utils.AnnoKeyManagerIdentity], "should be owned by repo2")
 
@@ -143,7 +141,7 @@ func TestIntegrationProvisioning_PullJobOwnershipProtection(t *testing.T) {
 		helper.SyncAndWait(t, repo1, nil)
 
 		// Step 3: Verify that repo2's resource is still intact after repo1's pull
-		persistentRepo2Dashboard, err := helper.DashboardsV1.Resource.Get(ctx, timelineUID, metav1.GetOptions{})
+		persistentRepo2Dashboard, err := helper.DashboardsV1.Resource.Get(t.Context(), timelineUID, metav1.GetOptions{})
 		require.NoError(t, err, "repo2's dashboard should still exist after repo1 pull")
 		require.Equal(t, repo2, persistentRepo2Dashboard.GetAnnotations()[utils.AnnoKeyManagerIdentity], "ownership should remain with repo2")
 		require.Equal(t, repo2Dashboard.GetGeneration(), persistentRepo2Dashboard.GetGeneration(), "repo2's resource should not be modified by repo1 pull")
@@ -154,7 +152,7 @@ func TestIntegrationProvisioning_PullJobOwnershipProtection(t *testing.T) {
 			Pull:   &provisioning.SyncJobOptions{},
 		})
 
-		persistentRepo1Dashboard, err := helper.DashboardsV1.Resource.Get(ctx, allPanelsUID, metav1.GetOptions{})
+		persistentRepo1Dashboard, err := helper.DashboardsV1.Resource.Get(t.Context(), allPanelsUID, metav1.GetOptions{})
 		require.NoError(t, err, "repo1's dashboard should still exist after repo2 pull")
 		require.Equal(t, repo1, persistentRepo1Dashboard.GetAnnotations()[utils.AnnoKeyManagerIdentity], "ownership should remain with repo1")
 		require.Equal(t, repo1Dashboard.GetGeneration(), persistentRepo1Dashboard.GetGeneration(), "repo1's resource should not be modified by repo2 pull")
@@ -169,7 +167,6 @@ func TestIntegrationProvisioning_PullJobOwnershipProtection(t *testing.T) {
 // hard-failing the whole job. The orphan must not be silently adopted.
 func TestIntegrationProvisioning_PullJobUnmanagedRootConflict(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	const repo = "unmanaged-root-repo"
 	repoPath := path.Join(helper.ProvisioningPath, "unmanaged-root-repo-data")
@@ -181,23 +178,23 @@ func TestIntegrationProvisioning_PullJobUnmanagedRootConflict(t *testing.T) {
 		ExpectedFolders: 1,
 	})
 
-	rootFolder, err := helper.Folders.Resource.Get(ctx, repo, metav1.GetOptions{})
+	rootFolder, err := helper.Folders.Resource.Get(t.Context(), repo, metav1.GetOptions{})
 	require.NoError(t, err, "root folder should exist after initial sync")
 	require.Equal(t, repo, rootFolder.GetAnnotations()[utils.AnnoKeyManagerIdentity],
 		"root folder should be managed by the repo")
 
 	// Mimic "Delete and keep resources" from the UI: ensure the
 	// release-orphan-resources finalizer is set, then delete the repo.
-	_, err = helper.Repositories.Resource.Patch(ctx, repo, types.JSONPatchType, []byte(`[
+	_, err = helper.Repositories.Resource.Patch(t.Context(), repo, types.JSONPatchType, []byte(`[
 		{"op": "replace", "path": "/metadata/finalizers", "value": ["cleanup", "release-orphan-resources"]}
 	]`), metav1.PatchOptions{})
 	require.NoError(t, err, "should patch finalizers")
 
-	require.NoError(t, helper.Repositories.Resource.Delete(ctx, repo, metav1.DeleteOptions{}))
-	helper.WaitForRepositoryDeleted(t, ctx, repo)
-	common.WaitForResourcesReleased(t, ctx, helper.Folders.Resource, "folders")
+	require.NoError(t, helper.Repositories.Resource.Delete(t.Context(), repo, metav1.DeleteOptions{}))
+	helper.WaitForRepositoryDeleted(t, repo)
+	common.WaitForResourcesReleased(t, helper.Folders.Resource, "folders")
 
-	orphan, err := helper.Folders.Resource.Get(ctx, repo, metav1.GetOptions{})
+	orphan, err := helper.Folders.Resource.Get(t.Context(), repo, metav1.GetOptions{})
 	require.NoError(t, err, "orphan root folder should still exist after release")
 	require.NotContains(t, orphan.GetAnnotations(), utils.AnnoKeyManagerIdentity,
 		"orphan folder must have manager annotations stripped")
@@ -244,7 +241,7 @@ func TestIntegrationProvisioning_PullJobUnmanagedRootConflict(t *testing.T) {
 	// Defensive: the orphan folder must not have been silently adopted by
 	// the recreated repository. The whole point of the existing guard is
 	// that takeover requires explicit migration.
-	orphan, err = helper.Folders.Resource.Get(ctx, repo, metav1.GetOptions{})
+	orphan, err = helper.Folders.Resource.Get(t.Context(), repo, metav1.GetOptions{})
 	require.NoError(t, err, "orphan root folder should still exist")
 	require.NotContains(t, orphan.GetAnnotations(), utils.AnnoKeyManagerIdentity,
 		"orphan folder must not be silently adopted by the recreated repo")

--- a/pkg/tests/apis/provisioning/jobs/pullrequestjob_auth_test.go
+++ b/pkg/tests/apis/provisioning/jobs/pullrequestjob_auth_test.go
@@ -1,7 +1,6 @@
 package jobs
 
 import (
-	"context"
 	"net/http"
 	"testing"
 
@@ -14,7 +13,6 @@ import (
 
 func TestIntegrationProvisioning_PullRequestJobRejected(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	const repo = "pr-job-rejected-test"
 	testRepo := common.TestRepo{
@@ -47,7 +45,7 @@ func TestIntegrationProvisioning_PullRequestJobRejected(t *testing.T) {
 			SubResource("jobs").
 			Body(body).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.Error(t, result.Error(), "admin should not be able to create pull request job")
 		require.Equal(t, http.StatusBadRequest, statusCode, "should return 400 Bad Request")
@@ -63,7 +61,7 @@ func TestIntegrationProvisioning_PullRequestJobRejected(t *testing.T) {
 			SubResource("jobs").
 			Body(body).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.Error(t, result.Error(), "editor should not be able to create pull request job")
 		require.Equal(t, http.StatusBadRequest, statusCode, "should return 400 Bad Request")
@@ -79,7 +77,7 @@ func TestIntegrationProvisioning_PullRequestJobRejected(t *testing.T) {
 			SubResource("jobs").
 			Body(body).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.Error(t, result.Error(), "viewer should not be able to create pull request job")
 		// Viewer is blocked at the API authorization layer (403) before reaching the connector

--- a/pkg/tests/apis/provisioning/jobs/pullrequestjob_auth_test.go
+++ b/pkg/tests/apis/provisioning/jobs/pullrequestjob_auth_test.go
@@ -19,14 +19,11 @@ func TestIntegrationProvisioning_PullRequestJobRejected(t *testing.T) {
 		Name:       repo,
 		SyncTarget: "folder",
 		Copies:     map[string]string{},
-		// The namespace-wide count assertion in CreateLocalRepo flakes when a
-		// prior test leaks resources into this shared server; scope the check
-		// to this repo's own managed resources instead.
-		SkipResourceAssertions: true,
 	}
 	helper.CreateLocalRepo(t, testRepo)
-	helper.RequireRepoFolderCount(t, repo, 1)
+
 	helper.RequireRepoDashboardCount(t, repo, 0)
+	helper.RequireRepoFolderCount(t, repo, 1)
 
 	body := common.AsJSON(provisioning.JobSpec{
 		Action: provisioning.JobActionPullRequest,

--- a/pkg/tests/apis/provisioning/jobs/releaseresourcesjob_auth_test.go
+++ b/pkg/tests/apis/provisioning/jobs/releaseresourcesjob_auth_test.go
@@ -69,13 +69,14 @@ func TestIntegrationProvisioning_ReleaseResourcesJobAuthorization(t *testing.T) 
 	t.Run("releaseResources rejected when repository exists and is healthy", func(t *testing.T) {
 		const repo = "release-conflict-test"
 		testRepo := common.TestRepo{
-			Name:               repo,
-			SyncTarget:         "folder",
-			Copies:             map[string]string{},
-			ExpectedDashboards: 0,
-			ExpectedFolders:    1,
+			Name:       repo,
+			SyncTarget: "folder",
+			Copies:     map[string]string{},
 		}
 		helper.CreateLocalRepo(t, testRepo)
+
+		helper.RequireRepoDashboardCount(t, repo, 0)
+		helper.RequireRepoFolderCount(t, repo, 1)
 
 		existingRepoBody := common.AsJSON(provisioning.JobSpec{
 			Action:     provisioning.JobActionReleaseResources,

--- a/pkg/tests/apis/provisioning/jobs/releaseresourcesjob_auth_test.go
+++ b/pkg/tests/apis/provisioning/jobs/releaseresourcesjob_auth_test.go
@@ -1,7 +1,6 @@
 package jobs
 
 import (
-	"context"
 	"net/http"
 	"testing"
 
@@ -14,7 +13,6 @@ import (
 
 func TestIntegrationProvisioning_ReleaseResourcesJobAuthorization(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	body := common.AsJSON(provisioning.JobSpec{
 		Action:     provisioning.JobActionReleaseResources,
@@ -30,7 +28,7 @@ func TestIntegrationProvisioning_ReleaseResourcesJobAuthorization(t *testing.T) 
 			SubResource("jobs").
 			Body(body).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.NoError(t, result.Error(), "admin should be able to create releaseResources job for nonexistent repo")
 		require.Equal(t, http.StatusAccepted, statusCode, "should return 202 Accepted")
@@ -45,7 +43,7 @@ func TestIntegrationProvisioning_ReleaseResourcesJobAuthorization(t *testing.T) 
 			SubResource("jobs").
 			Body(body).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.Error(t, result.Error(), "editor should not be able to create releaseResources job")
 		require.Equal(t, http.StatusForbidden, statusCode, "should return 403 Forbidden")
@@ -61,7 +59,7 @@ func TestIntegrationProvisioning_ReleaseResourcesJobAuthorization(t *testing.T) 
 			SubResource("jobs").
 			Body(body).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.Error(t, result.Error(), "viewer should not be able to create releaseResources job")
 		require.Equal(t, http.StatusForbidden, statusCode, "should return 403 Forbidden")
@@ -92,7 +90,7 @@ func TestIntegrationProvisioning_ReleaseResourcesJobAuthorization(t *testing.T) 
 			SubResource("jobs").
 			Body(existingRepoBody).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.Error(t, result.Error(), "releaseResources should be rejected for a healthy repository")
 		require.Equal(t, http.StatusConflict, statusCode, "should return 409 Conflict")

--- a/pkg/tests/apis/provisioning/librarypanels_test.go
+++ b/pkg/tests/apis/provisioning/librarypanels_test.go
@@ -154,8 +154,8 @@ func TestIntegrationLibraryPanels_UnprovisionedFolders(t *testing.T) {
 		require.NoError(t, err, "should successfully patch finalizers")
 
 		require.NoError(t, helper.Repositories.Resource.Delete(t.Context(), repo, metav1.DeleteOptions{}))
-		helper.WaitForRepositoryDeleted(t, t.Context(), repo)
-		common.WaitForResourcesReleased(t, t.Context(), helper.Folders.Resource, "folders")
+		helper.WaitForRepositoryDeleted(t, repo)
+		common.WaitForResourcesReleased(t, helper.Folders.Resource, "folders")
 
 		libraryElement := map[string]interface{}{
 			"kind":      1,

--- a/pkg/tests/apis/provisioning/librarypanels_test.go
+++ b/pkg/tests/apis/provisioning/librarypanels_test.go
@@ -41,10 +41,12 @@ func waitForSingleFolder(t *testing.T, helper *common.ProvisioningTestHelper) *u
 func TestIntegrationLibraryPanels_ProvisionedFolders(t *testing.T) {
 	helper := sharedHelper(t)
 	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:            "test-repo",
-		SyncTarget:      "folder",
-		ExpectedFolders: 1,
+		Name:       "test-repo",
+		SyncTarget: "folder",
 	})
+
+	helper.RequireRepoDashboardCount(t, "test-repo", 0)
+	helper.RequireRepoFolderCount(t, "test-repo", 1)
 
 	t.Run("should fail to create library element in provisioned folder", func(t *testing.T) {
 		managedFolderName := waitForSingleFolder(t, helper).GetName()
@@ -133,10 +135,12 @@ func TestIntegrationLibraryPanels_UnprovisionedFolders(t *testing.T) {
 	const repo = "test-repo"
 	helper := sharedHelper(t)
 	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:            repo,
-		SyncTarget:      "folder",
-		ExpectedFolders: 1,
+		Name:       repo,
+		SyncTarget: "folder",
 	})
+
+	helper.RequireRepoDashboardCount(t, repo, 0)
+	helper.RequireRepoFolderCount(t, repo, 1)
 
 	t.Run("should create library element when folder is released", func(t *testing.T) {
 		managedFolder := waitForSingleFolder(t, helper)

--- a/pkg/tests/apis/provisioning/managed_test.go
+++ b/pkg/tests/apis/provisioning/managed_test.go
@@ -36,12 +36,10 @@ func TestIntegrationFolderManagerConsistency(t *testing.T) {
 	})
 	helper.RequireRepoFolderCount(t, repoName, 1)
 
-	ctx := t.Context()
-
 	// Find the managed folder created by the repo sync.
 	var managedFolderName string
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		folders, err := helper.Folders.Resource.List(ctx, metav1.ListOptions{})
+		folders, err := helper.Folders.Resource.List(t.Context(), metav1.ListOptions{})
 		if !assert.NoError(collect, err) {
 			return
 		}
@@ -76,7 +74,7 @@ func TestIntegrationFolderManagerConsistency(t *testing.T) {
 			},
 		}
 
-		_, err := helper.DashboardsV1.Resource.Create(ctx, dashboard, metav1.CreateOptions{})
+		_, err := helper.DashboardsV1.Resource.Create(t.Context(), dashboard, metav1.CreateOptions{})
 		require.Error(t, err, "should reject unmanaged dashboard in a managed folder")
 		require.True(t, apierrors.IsForbidden(err), "error should be Forbidden, got: %v", err)
 		require.Contains(t, err.Error(), "folder is managed by repo:"+repoName)
@@ -103,7 +101,7 @@ func TestIntegrationFolderManagerConsistency(t *testing.T) {
 			},
 		}
 
-		_, err := helper.DashboardsV1.Resource.Create(ctx, dashboard, metav1.CreateOptions{})
+		_, err := helper.DashboardsV1.Resource.Create(t.Context(), dashboard, metav1.CreateOptions{})
 		require.Error(t, err, "should reject dashboard managed by a different manager")
 		require.True(t, apierrors.IsForbidden(err), "error should be Forbidden, got: %v", err)
 		require.Contains(t, err.Error(), "resource manager (kubectl:some-other-manager) does not match folder manager (repo:"+repoName+")")
@@ -122,7 +120,7 @@ func TestIntegrationFolderManagerConsistency(t *testing.T) {
 				},
 			},
 		}
-		createdFolder, err := helper.Folders.Resource.Create(ctx, unmanagedFolder, metav1.CreateOptions{})
+		createdFolder, err := helper.Folders.Resource.Create(t.Context(), unmanagedFolder, metav1.CreateOptions{})
 		require.NoError(t, err, "should create unmanaged folder")
 		unmanagedFolderName := createdFolder.GetName()
 
@@ -145,7 +143,7 @@ func TestIntegrationFolderManagerConsistency(t *testing.T) {
 			},
 		}
 
-		created, err := helper.DashboardsV1.Resource.Create(ctx, dashboard, metav1.CreateOptions{})
+		created, err := helper.DashboardsV1.Resource.Create(t.Context(), dashboard, metav1.CreateOptions{})
 		require.NoError(t, err, "should allow managed dashboard in unmanaged folder")
 		require.NotNil(t, created)
 	})
@@ -163,7 +161,7 @@ func TestIntegrationFolderManagerConsistency(t *testing.T) {
 				},
 			},
 		}
-		createdFolder, err := helper.Folders.Resource.Create(ctx, unmanagedFolder, metav1.CreateOptions{})
+		createdFolder, err := helper.Folders.Resource.Create(t.Context(), unmanagedFolder, metav1.CreateOptions{})
 		require.NoError(t, err, "should create plain folder")
 
 		dashboard := &unstructured.Unstructured{
@@ -183,7 +181,7 @@ func TestIntegrationFolderManagerConsistency(t *testing.T) {
 			},
 		}
 
-		created, err := helper.DashboardsV1.Resource.Create(ctx, dashboard, metav1.CreateOptions{})
+		created, err := helper.DashboardsV1.Resource.Create(t.Context(), dashboard, metav1.CreateOptions{})
 		require.NoError(t, err, "should allow unmanaged dashboard in unmanaged folder")
 		require.NotNil(t, created)
 	})
@@ -203,7 +201,7 @@ func TestIntegrationFolderManagerConsistency(t *testing.T) {
 				},
 			},
 		}
-		createdFolder, err := helper.Folders.Resource.Create(ctx, unmanagedFolder, metav1.CreateOptions{})
+		createdFolder, err := helper.Folders.Resource.Create(t.Context(), unmanagedFolder, metav1.CreateOptions{})
 		require.NoError(t, err)
 
 		dashboard := &unstructured.Unstructured{
@@ -222,17 +220,17 @@ func TestIntegrationFolderManagerConsistency(t *testing.T) {
 				},
 			},
 		}
-		created, err := helper.DashboardsV1.Resource.Create(ctx, dashboard, metav1.CreateOptions{})
+		created, err := helper.DashboardsV1.Resource.Create(t.Context(), dashboard, metav1.CreateOptions{})
 		require.NoError(t, err)
 
-		fresh, err := helper.DashboardsV1.Resource.Get(ctx, created.GetName(), metav1.GetOptions{})
+		fresh, err := helper.DashboardsV1.Resource.Get(t.Context(), created.GetName(), metav1.GetOptions{})
 		require.NoError(t, err)
 
 		annotations := fresh.GetAnnotations()
 		annotations["grafana.app/folder"] = managedFolderName
 		fresh.SetAnnotations(annotations)
 
-		_, err = helper.DashboardsV1.Resource.Update(ctx, fresh, metav1.UpdateOptions{})
+		_, err = helper.DashboardsV1.Resource.Update(t.Context(), fresh, metav1.UpdateOptions{})
 		require.Error(t, err, "should reject moving unmanaged dashboard to managed folder")
 		require.True(t, apierrors.IsForbidden(err), "error should be Forbidden, got: %v", err)
 		require.Contains(t, err.Error(), "folder is managed by repo:"+repoName)
@@ -252,7 +250,7 @@ func TestIntegrationFolderManagerConsistency(t *testing.T) {
 				},
 			},
 		}
-		createdA, err := helper.Folders.Resource.Create(ctx, folderA, metav1.CreateOptions{})
+		createdA, err := helper.Folders.Resource.Create(t.Context(), folderA, metav1.CreateOptions{})
 		require.NoError(t, err)
 
 		folderB := &unstructured.Unstructured{
@@ -267,7 +265,7 @@ func TestIntegrationFolderManagerConsistency(t *testing.T) {
 				},
 			},
 		}
-		createdB, err := helper.Folders.Resource.Create(ctx, folderB, metav1.CreateOptions{})
+		createdB, err := helper.Folders.Resource.Create(t.Context(), folderB, metav1.CreateOptions{})
 		require.NoError(t, err)
 
 		dashboard := &unstructured.Unstructured{
@@ -286,17 +284,17 @@ func TestIntegrationFolderManagerConsistency(t *testing.T) {
 				},
 			},
 		}
-		created, err := helper.DashboardsV1.Resource.Create(ctx, dashboard, metav1.CreateOptions{})
+		created, err := helper.DashboardsV1.Resource.Create(t.Context(), dashboard, metav1.CreateOptions{})
 		require.NoError(t, err)
 
-		fresh, err := helper.DashboardsV1.Resource.Get(ctx, created.GetName(), metav1.GetOptions{})
+		fresh, err := helper.DashboardsV1.Resource.Get(t.Context(), created.GetName(), metav1.GetOptions{})
 		require.NoError(t, err)
 
 		annotations := fresh.GetAnnotations()
 		annotations["grafana.app/folder"] = createdB.GetName()
 		fresh.SetAnnotations(annotations)
 
-		updated, err := helper.DashboardsV1.Resource.Update(ctx, fresh, metav1.UpdateOptions{})
+		updated, err := helper.DashboardsV1.Resource.Update(t.Context(), fresh, metav1.UpdateOptions{})
 		require.NoError(t, err, "should allow moving dashboard to unmanaged folder")
 		require.Equal(t, createdB.GetName(), updated.GetAnnotations()["grafana.app/folder"])
 	})
@@ -318,7 +316,7 @@ func TestIntegrationFolderManagerConsistency(t *testing.T) {
 				},
 			},
 		}
-		createdFolder, err := helper.Folders.Resource.Create(ctx, unmanagedFolder, metav1.CreateOptions{})
+		createdFolder, err := helper.Folders.Resource.Create(t.Context(), unmanagedFolder, metav1.CreateOptions{})
 		require.NoError(t, err)
 
 		dashboard := &unstructured.Unstructured{
@@ -339,10 +337,10 @@ func TestIntegrationFolderManagerConsistency(t *testing.T) {
 				},
 			},
 		}
-		created, err := helper.DashboardsV1.Resource.Create(ctx, dashboard, metav1.CreateOptions{})
+		created, err := helper.DashboardsV1.Resource.Create(t.Context(), dashboard, metav1.CreateOptions{})
 		require.NoError(t, err)
 
-		fresh, err := helper.DashboardsV1.Resource.Get(ctx, created.GetName(), metav1.GetOptions{})
+		fresh, err := helper.DashboardsV1.Resource.Get(t.Context(), created.GetName(), metav1.GetOptions{})
 		require.NoError(t, err)
 
 		annotations := fresh.GetAnnotations()
@@ -350,7 +348,7 @@ func TestIntegrationFolderManagerConsistency(t *testing.T) {
 		delete(annotations, utils.AnnoKeyManagerIdentity)
 		fresh.SetAnnotations(annotations)
 
-		updated, err := helper.DashboardsV1.Resource.Update(ctx, fresh, metav1.UpdateOptions{})
+		updated, err := helper.DashboardsV1.Resource.Update(t.Context(), fresh, metav1.UpdateOptions{})
 		require.NoError(t, err, "removing manager in unmanaged folder should be allowed")
 		require.Empty(t, updated.GetAnnotations()[utils.AnnoKeyManagerKind])
 	})
@@ -368,7 +366,7 @@ func TestIntegrationFolderManagerConsistency(t *testing.T) {
 				},
 			},
 		}
-		createdFolder, err := helper.Folders.Resource.Create(ctx, unmanagedFolder, metav1.CreateOptions{})
+		createdFolder, err := helper.Folders.Resource.Create(t.Context(), unmanagedFolder, metav1.CreateOptions{})
 		require.NoError(t, err)
 
 		dashboard := &unstructured.Unstructured{
@@ -389,10 +387,10 @@ func TestIntegrationFolderManagerConsistency(t *testing.T) {
 				},
 			},
 		}
-		created, err := helper.DashboardsV1.Resource.Create(ctx, dashboard, metav1.CreateOptions{})
+		created, err := helper.DashboardsV1.Resource.Create(t.Context(), dashboard, metav1.CreateOptions{})
 		require.NoError(t, err)
 
-		fresh, err := helper.DashboardsV1.Resource.Get(ctx, created.GetName(), metav1.GetOptions{})
+		fresh, err := helper.DashboardsV1.Resource.Get(t.Context(), created.GetName(), metav1.GetOptions{})
 		require.NoError(t, err)
 
 		// Remove manager first (required — cannot change manager directly)
@@ -401,11 +399,11 @@ func TestIntegrationFolderManagerConsistency(t *testing.T) {
 		delete(annotations, utils.AnnoKeyManagerIdentity)
 		fresh.SetAnnotations(annotations)
 
-		updated, err := helper.DashboardsV1.Resource.Update(ctx, fresh, metav1.UpdateOptions{})
+		updated, err := helper.DashboardsV1.Resource.Update(t.Context(), fresh, metav1.UpdateOptions{})
 		require.NoError(t, err, "removing terraform manager in unmanaged folder should be allowed")
 
 		// Now re-add with different identity
-		fresh2, err := helper.DashboardsV1.Resource.Get(ctx, updated.GetName(), metav1.GetOptions{})
+		fresh2, err := helper.DashboardsV1.Resource.Get(t.Context(), updated.GetName(), metav1.GetOptions{})
 		require.NoError(t, err)
 
 		annotations2 := fresh2.GetAnnotations()
@@ -413,7 +411,7 @@ func TestIntegrationFolderManagerConsistency(t *testing.T) {
 		annotations2[utils.AnnoKeyManagerIdentity] = "tf-workspace-2"
 		fresh2.SetAnnotations(annotations2)
 
-		updated2, err := helper.DashboardsV1.Resource.Update(ctx, fresh2, metav1.UpdateOptions{})
+		updated2, err := helper.DashboardsV1.Resource.Update(t.Context(), fresh2, metav1.UpdateOptions{})
 		require.NoError(t, err, "adding new terraform manager in unmanaged folder should be allowed")
 		require.Equal(t, "tf-workspace-2", updated2.GetAnnotations()[utils.AnnoKeyManagerIdentity])
 	})
@@ -437,7 +435,7 @@ func TestIntegrationFolderManagerConsistency(t *testing.T) {
 			},
 		}
 
-		_, err := helper.Folders.Resource.Create(ctx, folder, metav1.CreateOptions{})
+		_, err := helper.Folders.Resource.Create(t.Context(), folder, metav1.CreateOptions{})
 		require.Error(t, err, "should reject unmanaged sub-folder in a managed folder")
 		require.True(t, apierrors.IsForbidden(err), "error should be Forbidden, got: %v", err)
 		require.Contains(t, err.Error(), "folder is managed by repo:"+repoName)
@@ -463,7 +461,7 @@ func TestIntegrationFolderManagerConsistency(t *testing.T) {
 			},
 		}
 
-		_, err := helper.Folders.Resource.Create(ctx, folder, metav1.CreateOptions{})
+		_, err := helper.Folders.Resource.Create(t.Context(), folder, metav1.CreateOptions{})
 		require.Error(t, err, "should reject sub-folder managed by a different manager")
 		require.True(t, apierrors.IsForbidden(err), "error should be Forbidden, got: %v", err)
 		require.Contains(t, err.Error(), "resource manager (kubectl:some-other-manager) does not match folder manager (repo:"+repoName+")")
@@ -482,7 +480,7 @@ func TestIntegrationFolderManagerConsistency(t *testing.T) {
 				},
 			},
 		}
-		createdParent, err := helper.Folders.Resource.Create(ctx, parent, metav1.CreateOptions{})
+		createdParent, err := helper.Folders.Resource.Create(t.Context(), parent, metav1.CreateOptions{})
 		require.NoError(t, err, "should create unmanaged parent folder")
 
 		child := &unstructured.Unstructured{
@@ -503,7 +501,7 @@ func TestIntegrationFolderManagerConsistency(t *testing.T) {
 			},
 		}
 
-		created, err := helper.Folders.Resource.Create(ctx, child, metav1.CreateOptions{})
+		created, err := helper.Folders.Resource.Create(t.Context(), child, metav1.CreateOptions{})
 		require.NoError(t, err, "should allow managed sub-folder in unmanaged folder")
 		require.NotNil(t, created)
 	})
@@ -521,7 +519,7 @@ func TestIntegrationFolderManagerConsistency(t *testing.T) {
 				},
 			},
 		}
-		createdParent, err := helper.Folders.Resource.Create(ctx, parent, metav1.CreateOptions{})
+		createdParent, err := helper.Folders.Resource.Create(t.Context(), parent, metav1.CreateOptions{})
 		require.NoError(t, err, "should create plain parent folder")
 
 		child := &unstructured.Unstructured{
@@ -540,7 +538,7 @@ func TestIntegrationFolderManagerConsistency(t *testing.T) {
 			},
 		}
 
-		created, err := helper.Folders.Resource.Create(ctx, child, metav1.CreateOptions{})
+		created, err := helper.Folders.Resource.Create(t.Context(), child, metav1.CreateOptions{})
 		require.NoError(t, err, "should allow unmanaged sub-folder in unmanaged folder")
 		require.NotNil(t, created)
 	})
@@ -548,7 +546,6 @@ func TestIntegrationFolderManagerConsistency(t *testing.T) {
 
 func TestIntegrationProvisioning_BlockManagerChange(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	const repo = "managed-change-test"
 	helper.CreateLocalRepo(t, common.TestRepo{
@@ -566,7 +563,7 @@ func TestIntegrationProvisioning_BlockManagerChange(t *testing.T) {
 	var err error
 
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		dashboard, err = helper.DashboardsV1.Resource.Get(ctx, dashboardUID, metav1.GetOptions{})
+		dashboard, err = helper.DashboardsV1.Resource.Get(t.Context(), dashboardUID, metav1.GetOptions{})
 		if err != nil {
 			collect.Errorf("dashboard not found yet: %s", err.Error())
 			return
@@ -577,7 +574,7 @@ func TestIntegrationProvisioning_BlockManagerChange(t *testing.T) {
 	}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "dashboard should be provisioned with repo manager")
 
 	t.Run("changing manager from repo to kubectl is blocked", func(t *testing.T) {
-		fresh, err := helper.DashboardsV1.Resource.Get(ctx, dashboardUID, metav1.GetOptions{})
+		fresh, err := helper.DashboardsV1.Resource.Get(t.Context(), dashboardUID, metav1.GetOptions{})
 		require.NoError(t, err)
 
 		annotations := fresh.GetAnnotations()
@@ -585,18 +582,18 @@ func TestIntegrationProvisioning_BlockManagerChange(t *testing.T) {
 		annotations[utils.AnnoKeyManagerIdentity] = "some-kubectl-manager"
 		fresh.SetAnnotations(annotations)
 
-		_, err = helper.DashboardsV1.Resource.Update(ctx, fresh, metav1.UpdateOptions{})
+		_, err = helper.DashboardsV1.Resource.Update(t.Context(), fresh, metav1.UpdateOptions{})
 		require.Error(t, err, "should not be able to change manager from repo to kubectl")
 		require.True(t, apierrors.IsForbidden(err), "expected Forbidden, got: %v", err)
 
-		unchanged, err := helper.DashboardsV1.Resource.Get(ctx, dashboardUID, metav1.GetOptions{})
+		unchanged, err := helper.DashboardsV1.Resource.Get(t.Context(), dashboardUID, metav1.GetOptions{})
 		require.NoError(t, err)
 		require.Equal(t, string(utils.ManagerKindRepo), unchanged.GetAnnotations()[utils.AnnoKeyManagerKind])
 		require.Equal(t, repo, unchanged.GetAnnotations()[utils.AnnoKeyManagerIdentity])
 	})
 
 	t.Run("changing manager from repo to terraform is blocked", func(t *testing.T) {
-		fresh, err := helper.DashboardsV1.Resource.Get(ctx, dashboardUID, metav1.GetOptions{})
+		fresh, err := helper.DashboardsV1.Resource.Get(t.Context(), dashboardUID, metav1.GetOptions{})
 		require.NoError(t, err)
 
 		annotations := fresh.GetAnnotations()
@@ -604,18 +601,18 @@ func TestIntegrationProvisioning_BlockManagerChange(t *testing.T) {
 		annotations[utils.AnnoKeyManagerIdentity] = "some-terraform-manager"
 		fresh.SetAnnotations(annotations)
 
-		_, err = helper.DashboardsV1.Resource.Update(ctx, fresh, metav1.UpdateOptions{})
+		_, err = helper.DashboardsV1.Resource.Update(t.Context(), fresh, metav1.UpdateOptions{})
 		require.Error(t, err, "should not be able to change manager from repo to terraform")
 		require.True(t, apierrors.IsForbidden(err), "expected Forbidden, got: %v", err)
 
-		unchanged, err := helper.DashboardsV1.Resource.Get(ctx, dashboardUID, metav1.GetOptions{})
+		unchanged, err := helper.DashboardsV1.Resource.Get(t.Context(), dashboardUID, metav1.GetOptions{})
 		require.NoError(t, err)
 		require.Equal(t, string(utils.ManagerKindRepo), unchanged.GetAnnotations()[utils.AnnoKeyManagerKind])
 		require.Equal(t, repo, unchanged.GetAnnotations()[utils.AnnoKeyManagerIdentity])
 	})
 
 	t.Run("removing manager from repo-managed dashboard is blocked", func(t *testing.T) {
-		fresh, err := helper.DashboardsV1.Resource.Get(ctx, dashboardUID, metav1.GetOptions{})
+		fresh, err := helper.DashboardsV1.Resource.Get(t.Context(), dashboardUID, metav1.GetOptions{})
 		require.NoError(t, err)
 
 		annotations := fresh.GetAnnotations()
@@ -623,11 +620,11 @@ func TestIntegrationProvisioning_BlockManagerChange(t *testing.T) {
 		delete(annotations, utils.AnnoKeyManagerIdentity)
 		fresh.SetAnnotations(annotations)
 
-		_, err = helper.DashboardsV1.Resource.Update(ctx, fresh, metav1.UpdateOptions{})
+		_, err = helper.DashboardsV1.Resource.Update(t.Context(), fresh, metav1.UpdateOptions{})
 		require.Error(t, err, "should not be able to remove manager from repo-managed dashboard")
 		require.True(t, apierrors.IsForbidden(err), "expected Forbidden, got: %v", err)
 
-		unchanged, err := helper.DashboardsV1.Resource.Get(ctx, dashboardUID, metav1.GetOptions{})
+		unchanged, err := helper.DashboardsV1.Resource.Get(t.Context(), dashboardUID, metav1.GetOptions{})
 		require.NoError(t, err)
 		require.Equal(t, string(utils.ManagerKindRepo), unchanged.GetAnnotations()[utils.AnnoKeyManagerKind])
 		require.Equal(t, repo, unchanged.GetAnnotations()[utils.AnnoKeyManagerIdentity])
@@ -636,7 +633,6 @@ func TestIntegrationProvisioning_BlockManagerChange(t *testing.T) {
 
 func TestIntegrationProvisioning_AdminCanReleaseManagedResource(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	const repo = "admin-release-test"
 	helper.CreateLocalRepo(t, common.TestRepo{
@@ -652,7 +648,7 @@ func TestIntegrationProvisioning_AdminCanReleaseManagedResource(t *testing.T) {
 	const dashboardUID = "n1jR8vnnz"
 
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		dashboard, err := helper.DashboardsV1.Resource.Get(ctx, dashboardUID, metav1.GetOptions{})
+		dashboard, err := helper.DashboardsV1.Resource.Get(t.Context(), dashboardUID, metav1.GetOptions{})
 		if err != nil {
 			collect.Errorf("dashboard not found yet: %s", err.Error())
 			return
@@ -669,7 +665,7 @@ func TestIntegrationProvisioning_AdminCanReleaseManagedResource(t *testing.T) {
 			GVR:       dashboardV1.DashboardResourceInfo.GroupVersionResource(),
 		})
 
-		fresh, err := editorDashboards.Resource.Get(ctx, dashboardUID, metav1.GetOptions{})
+		fresh, err := editorDashboards.Resource.Get(t.Context(), dashboardUID, metav1.GetOptions{})
 		require.NoError(t, err)
 
 		annotations := fresh.GetAnnotations()
@@ -679,7 +675,7 @@ func TestIntegrationProvisioning_AdminCanReleaseManagedResource(t *testing.T) {
 		delete(annotations, utils.AnnoKeySourceChecksum)
 		fresh.SetAnnotations(annotations)
 
-		_, err = editorDashboards.Resource.Update(ctx, fresh, metav1.UpdateOptions{})
+		_, err = editorDashboards.Resource.Update(t.Context(), fresh, metav1.UpdateOptions{})
 		require.Error(t, err, "editor should not be able to release managed dashboard")
 		require.True(t, apierrors.IsForbidden(err), "expected Forbidden, got: %v", err)
 	})
@@ -688,7 +684,7 @@ func TestIntegrationProvisioning_AdminCanReleaseManagedResource(t *testing.T) {
 		// Release top-down: the folder must be released before the dashboard,
 		// otherwise the folder-manager consistency check rejects an unmanaged
 		// resource inside a managed folder.
-		folder, err := helper.Folders.Resource.Get(ctx, repo, metav1.GetOptions{})
+		folder, err := helper.Folders.Resource.Get(t.Context(), repo, metav1.GetOptions{})
 		require.NoError(t, err)
 
 		fa := folder.GetAnnotations()
@@ -698,10 +694,10 @@ func TestIntegrationProvisioning_AdminCanReleaseManagedResource(t *testing.T) {
 		delete(fa, utils.AnnoKeySourceChecksum)
 		folder.SetAnnotations(fa)
 
-		_, err = helper.Folders.Resource.Update(ctx, folder, metav1.UpdateOptions{})
+		_, err = helper.Folders.Resource.Update(t.Context(), folder, metav1.UpdateOptions{})
 		require.NoError(t, err, "admin should be able to release the folder first")
 
-		fresh, err := helper.DashboardsV1.Resource.Get(ctx, dashboardUID, metav1.GetOptions{})
+		fresh, err := helper.DashboardsV1.Resource.Get(t.Context(), dashboardUID, metav1.GetOptions{})
 		require.NoError(t, err)
 
 		annotations := fresh.GetAnnotations()
@@ -711,7 +707,7 @@ func TestIntegrationProvisioning_AdminCanReleaseManagedResource(t *testing.T) {
 		delete(annotations, utils.AnnoKeySourceChecksum)
 		fresh.SetAnnotations(annotations)
 
-		updated, err := helper.DashboardsV1.Resource.Update(ctx, fresh, metav1.UpdateOptions{})
+		updated, err := helper.DashboardsV1.Resource.Update(t.Context(), fresh, metav1.UpdateOptions{})
 		require.NoError(t, err, "admin should be able to release managed dashboard")
 
 		releasedAnnotations := updated.GetAnnotations()
@@ -722,7 +718,6 @@ func TestIntegrationProvisioning_AdminCanReleaseManagedResource(t *testing.T) {
 
 func TestIntegrationProvisioning_TerraformManagerIDTransitions(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 	dashboardAPIVersion := dashboardV1.DashboardResourceInfo.GroupVersion().String()
 
 	// Create an unmanaged folder for testing
@@ -738,7 +733,7 @@ func TestIntegrationProvisioning_TerraformManagerIDTransitions(t *testing.T) {
 			},
 		},
 	}
-	createdFolder, err := helper.Folders.Resource.Create(ctx, unmanagedFolder, metav1.CreateOptions{})
+	createdFolder, err := helper.Folders.Resource.Create(t.Context(), unmanagedFolder, metav1.CreateOptions{})
 	require.NoError(t, err)
 	folderName := createdFolder.GetName()
 
@@ -761,17 +756,17 @@ func TestIntegrationProvisioning_TerraformManagerIDTransitions(t *testing.T) {
 				},
 			},
 		}
-		created, err := helper.DashboardsV1.Resource.Create(ctx, dashboard, metav1.CreateOptions{})
+		created, err := helper.DashboardsV1.Resource.Create(t.Context(), dashboard, metav1.CreateOptions{})
 		require.NoError(t, err)
 
-		fresh, err := helper.DashboardsV1.Resource.Get(ctx, created.GetName(), metav1.GetOptions{})
+		fresh, err := helper.DashboardsV1.Resource.Get(t.Context(), created.GetName(), metav1.GetOptions{})
 		require.NoError(t, err)
 
 		annotations := fresh.GetAnnotations()
 		annotations[utils.AnnoKeyManagerIdentity] = "Terraform/1.6.0 (+https://www.terraform.io) terraform-provider-grafana/v4.0.0"
 		fresh.SetAnnotations(annotations)
 
-		updated, err := helper.DashboardsV1.Resource.Update(ctx, fresh, metav1.UpdateOptions{})
+		updated, err := helper.DashboardsV1.Resource.Update(t.Context(), fresh, metav1.UpdateOptions{})
 		require.NoError(t, err, "should allow User-Agent to User-Agent transition")
 		require.Equal(t, "Terraform/1.6.0 (+https://www.terraform.io) terraform-provider-grafana/v4.0.0",
 			updated.GetAnnotations()[utils.AnnoKeyManagerIdentity])
@@ -796,17 +791,17 @@ func TestIntegrationProvisioning_TerraformManagerIDTransitions(t *testing.T) {
 				},
 			},
 		}
-		created, err := helper.DashboardsV1.Resource.Create(ctx, dashboard, metav1.CreateOptions{})
+		created, err := helper.DashboardsV1.Resource.Create(t.Context(), dashboard, metav1.CreateOptions{})
 		require.NoError(t, err)
 
-		fresh, err := helper.DashboardsV1.Resource.Get(ctx, created.GetName(), metav1.GetOptions{})
+		fresh, err := helper.DashboardsV1.Resource.Get(t.Context(), created.GetName(), metav1.GetOptions{})
 		require.NoError(t, err)
 
 		annotations := fresh.GetAnnotations()
 		annotations[utils.AnnoKeyManagerIdentity] = "my-terraform-provider"
 		fresh.SetAnnotations(annotations)
 
-		updated, err := helper.DashboardsV1.Resource.Update(ctx, fresh, metav1.UpdateOptions{})
+		updated, err := helper.DashboardsV1.Resource.Update(t.Context(), fresh, metav1.UpdateOptions{})
 		require.NoError(t, err, "should allow User-Agent to simple ID transition (migration)")
 		require.Equal(t, "my-terraform-provider", updated.GetAnnotations()[utils.AnnoKeyManagerIdentity])
 	})
@@ -830,17 +825,17 @@ func TestIntegrationProvisioning_TerraformManagerIDTransitions(t *testing.T) {
 				},
 			},
 		}
-		created, err := helper.DashboardsV1.Resource.Create(ctx, dashboard, metav1.CreateOptions{})
+		created, err := helper.DashboardsV1.Resource.Create(t.Context(), dashboard, metav1.CreateOptions{})
 		require.NoError(t, err)
 
-		fresh, err := helper.DashboardsV1.Resource.Get(ctx, created.GetName(), metav1.GetOptions{})
+		fresh, err := helper.DashboardsV1.Resource.Get(t.Context(), created.GetName(), metav1.GetOptions{})
 		require.NoError(t, err)
 
 		annotations := fresh.GetAnnotations()
 		annotations[utils.AnnoKeyManagerIdentity] = "my-terraform-provider-v2"
 		fresh.SetAnnotations(annotations)
 
-		_, err = helper.DashboardsV1.Resource.Update(ctx, fresh, metav1.UpdateOptions{})
+		_, err = helper.DashboardsV1.Resource.Update(t.Context(), fresh, metav1.UpdateOptions{})
 		require.Error(t, err, "should block simple ID to simple ID transition")
 		require.True(t, apierrors.IsForbidden(err), "expected Forbidden, got: %v", err)
 		require.Contains(t, err.Error(), "Cannot change Terraform manager ID")
@@ -866,17 +861,17 @@ func TestIntegrationProvisioning_TerraformManagerIDTransitions(t *testing.T) {
 				},
 			},
 		}
-		created, err := helper.DashboardsV1.Resource.Create(ctx, dashboard, metav1.CreateOptions{})
+		created, err := helper.DashboardsV1.Resource.Create(t.Context(), dashboard, metav1.CreateOptions{})
 		require.NoError(t, err)
 
-		fresh, err := helper.DashboardsV1.Resource.Get(ctx, created.GetName(), metav1.GetOptions{})
+		fresh, err := helper.DashboardsV1.Resource.Get(t.Context(), created.GetName(), metav1.GetOptions{})
 		require.NoError(t, err)
 
 		annotations := fresh.GetAnnotations()
 		annotations[utils.AnnoKeyManagerIdentity] = "Terraform/1.6.0 (+https://www.terraform.io) terraform-provider-grafana/v4.0.0"
 		fresh.SetAnnotations(annotations)
 
-		_, err = helper.DashboardsV1.Resource.Update(ctx, fresh, metav1.UpdateOptions{})
+		_, err = helper.DashboardsV1.Resource.Update(t.Context(), fresh, metav1.UpdateOptions{})
 		require.Error(t, err, "should block simple ID to User-Agent transition")
 		require.True(t, apierrors.IsForbidden(err), "expected Forbidden, got: %v", err)
 		require.Contains(t, err.Error(), "Cannot change Terraform manager ID back to User-Agent format")
@@ -885,7 +880,6 @@ func TestIntegrationProvisioning_TerraformManagerIDTransitions(t *testing.T) {
 
 func TestIntegrationProvisioning_AdminCanReleaseManagedResourceViaPatch(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	const repo = "admin-release-patch-test"
 	helper.CreateLocalRepo(t, common.TestRepo{
@@ -932,7 +926,7 @@ func TestIntegrationProvisioning_AdminCanReleaseManagedResourceViaPatch(t *testi
 	})
 
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		dashboard, err := helper.DashboardsV1.Resource.Get(ctx, dashboardUID, metav1.GetOptions{})
+		dashboard, err := helper.DashboardsV1.Resource.Get(t.Context(), dashboardUID, metav1.GetOptions{})
 		if err != nil {
 			collect.Errorf("dashboard not found yet: %s", err.Error())
 			return
@@ -974,7 +968,7 @@ func TestIntegrationProvisioning_AdminCanReleaseManagedResourceViaPatch(t *testi
 			GVR:       dashboardV1.DashboardResourceInfo.GroupVersionResource(),
 		})
 
-		_, err := editorDashboards.Resource.Patch(ctx, dashboardUID, types.MergePatchType, mergePatch, metav1.PatchOptions{})
+		_, err := editorDashboards.Resource.Patch(t.Context(), dashboardUID, types.MergePatchType, mergePatch, metav1.PatchOptions{})
 		require.Error(t, err, "editor should not be able to release via merge patch")
 		require.True(t, apierrors.IsForbidden(err), "expected Forbidden, got: %v", err)
 	})
@@ -986,7 +980,7 @@ func TestIntegrationProvisioning_AdminCanReleaseManagedResourceViaPatch(t *testi
 			GVR:       dashboardV1.DashboardResourceInfo.GroupVersionResource(),
 		})
 
-		_, err := editorDashboards.Resource.Patch(ctx, dashboardUID, types.JSONPatchType, jsonPatch, metav1.PatchOptions{})
+		_, err := editorDashboards.Resource.Patch(t.Context(), dashboardUID, types.JSONPatchType, jsonPatch, metav1.PatchOptions{})
 		require.Error(t, err, "editor should not be able to release via JSON patch")
 		require.True(t, apierrors.IsForbidden(err), "expected Forbidden, got: %v", err)
 	})
@@ -994,10 +988,10 @@ func TestIntegrationProvisioning_AdminCanReleaseManagedResourceViaPatch(t *testi
 	t.Run("admin can release via merge patch", func(t *testing.T) {
 		// Release the folder first (top-down) so the dashboard can become
 		// unmanaged without violating folder-manager consistency.
-		_, err := helper.Folders.Resource.Patch(ctx, repo, types.MergePatchType, mergePatch, metav1.PatchOptions{})
+		_, err := helper.Folders.Resource.Patch(t.Context(), repo, types.MergePatchType, mergePatch, metav1.PatchOptions{})
 		require.NoError(t, err, "admin should be able to release the folder first")
 
-		updated, err := helper.DashboardsV1.Resource.Patch(ctx, dashboardUID, types.MergePatchType, mergePatch, metav1.PatchOptions{})
+		updated, err := helper.DashboardsV1.Resource.Patch(t.Context(), dashboardUID, types.MergePatchType, mergePatch, metav1.PatchOptions{})
 		require.NoError(t, err, "admin should be able to release via merge patch")
 
 		releasedAnnotations := updated.GetAnnotations()

--- a/pkg/tests/apis/provisioning/managed_test.go
+++ b/pkg/tests/apis/provisioning/managed_test.go
@@ -29,11 +29,9 @@ func TestIntegrationFolderManagerConsistency(t *testing.T) {
 	helper.CreateLocalRepo(t, common.TestRepo{
 		Name:       repoName,
 		SyncTarget: "folder",
-		// The namespace-wide count assertion in CreateLocalRepo flakes when a
-		// prior test leaks resources into this shared server; scope the check
-		// to this repo's own managed folder instead.
-		SkipResourceAssertions: true,
 	})
+
+	helper.RequireRepoDashboardCount(t, repoName, 0)
 	helper.RequireRepoFolderCount(t, repoName, 1)
 
 	// Find the managed folder created by the repo sync.
@@ -554,9 +552,10 @@ func TestIntegrationProvisioning_BlockManagerChange(t *testing.T) {
 		Copies: map[string]string{
 			"testdata/all-panels.json": "all-panels.json",
 		},
-		ExpectedDashboards: 1,
-		ExpectedFolders:    1,
 	})
+
+	helper.RequireRepoDashboardCount(t, repo, 1)
+	helper.RequireRepoFolderCount(t, repo, 1)
 
 	const dashboardUID = "n1jR8vnnz"
 	var dashboard *unstructured.Unstructured
@@ -641,9 +640,10 @@ func TestIntegrationProvisioning_AdminCanReleaseManagedResource(t *testing.T) {
 		Copies: map[string]string{
 			"testdata/all-panels.json": "all-panels.json",
 		},
-		ExpectedDashboards: 1,
-		ExpectedFolders:    1,
 	})
+
+	helper.RequireRepoDashboardCount(t, repo, 1)
+	helper.RequireRepoFolderCount(t, repo, 1)
 
 	const dashboardUID = "n1jR8vnnz"
 
@@ -718,6 +718,7 @@ func TestIntegrationProvisioning_AdminCanReleaseManagedResource(t *testing.T) {
 
 func TestIntegrationProvisioning_TerraformManagerIDTransitions(t *testing.T) {
 	helper := sharedHelper(t)
+
 	dashboardAPIVersion := dashboardV1.DashboardResourceInfo.GroupVersion().String()
 
 	// Create an unmanaged folder for testing
@@ -888,9 +889,10 @@ func TestIntegrationProvisioning_AdminCanReleaseManagedResourceViaPatch(t *testi
 		Copies: map[string]string{
 			"testdata/all-panels.json": "all-panels.json",
 		},
-		ExpectedDashboards: 1,
-		ExpectedFolders:    1,
 	})
+
+	helper.RequireRepoDashboardCount(t, repo, 1)
+	helper.RequireRepoFolderCount(t, repo, 1)
 
 	const dashboardUID = "n1jR8vnnz"
 

--- a/pkg/tests/apis/provisioning/maxfilesize/files_max_file_size_test.go
+++ b/pkg/tests/apis/provisioning/maxfilesize/files_max_file_size_test.go
@@ -2,7 +2,6 @@ package maxfilesize
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -88,7 +87,6 @@ func TestIntegrationProvisioning_MaxFileSize_RawRead(t *testing.T) {
 // rejected before the resource is parsed or persisted.
 func TestIntegrationProvisioning_MaxFileSize_Write(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	const repo = "max-file-size-write"
 	helper.CreateLocalRepo(t, common.TestRepo{
@@ -119,7 +117,7 @@ func TestIntegrationProvisioning_MaxFileSize_Write(t *testing.T) {
 		SubResource("files", "huge.json").
 		Body(oversized).
 		SetHeader("Content-Type", "application/json").
-		Do(ctx).StatusCode(&statusCode)
+		Do(t.Context()).StatusCode(&statusCode)
 
 	require.Error(t, result.Error(), "oversized POST should be rejected")
 	require.Equal(t, http.StatusRequestEntityTooLarge, statusCode,

--- a/pkg/tests/apis/provisioning/maxfilesize/files_max_file_size_test.go
+++ b/pkg/tests/apis/provisioning/maxfilesize/files_max_file_size_test.go
@@ -25,11 +25,10 @@ func TestIntegrationProvisioning_MaxFileSize_RawRead(t *testing.T) {
 
 	const repo = "max-file-size-raw-read"
 	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:                   repo,
-		LocalPath:              helper.ProvisioningPath,
-		SyncTarget:             "instance",
-		Workflows:              []string{"write"},
-		SkipResourceAssertions: true,
+		Name:       repo,
+		LocalPath:  helper.ProvisioningPath,
+		SyncTarget: "instance",
+		Workflows:  []string{"write"},
 	})
 
 	smallReadme := []byte("# small README\n")
@@ -90,11 +89,10 @@ func TestIntegrationProvisioning_MaxFileSize_Write(t *testing.T) {
 
 	const repo = "max-file-size-write"
 	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:                   repo,
-		LocalPath:              helper.ProvisioningPath,
-		SyncTarget:             "instance",
-		Workflows:              []string{"write"},
-		SkipResourceAssertions: true,
+		Name:       repo,
+		LocalPath:  helper.ProvisioningPath,
+		SyncTarget: "instance",
+		Workflows:  []string{"write"},
 	})
 
 	// A minimal but well-formed dashboard JSON, padded to exceed the cap.
@@ -136,11 +134,10 @@ func TestIntegrationProvisioning_MaxFileSize_Pull(t *testing.T) {
 
 	const repo = "max-file-size-pull"
 	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:                   repo,
-		LocalPath:              helper.ProvisioningPath,
-		SyncTarget:             "instance",
-		Workflows:              []string{"write"},
-		SkipResourceAssertions: true,
+		Name:       repo,
+		LocalPath:  helper.ProvisioningPath,
+		SyncTarget: "instance",
+		Workflows:  []string{"write"},
 	})
 
 	smallDashboard := common.DashboardJSON("small-dash", "Small Dashboard", 1)

--- a/pkg/tests/apis/provisioning/nats/connection_test.go
+++ b/pkg/tests/apis/provisioning/nats/connection_test.go
@@ -1,6 +1,7 @@
 package nats
 
 import (
+	"context"
 	"encoding/base64"
 	"testing"
 
@@ -19,7 +20,6 @@ import (
 // notification.
 func TestIntegrationProvisioningNATS_ConnectionReconciledOverNATS(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := t.Context()
 	privateKeyBase64 := base64.StdEncoding.EncodeToString([]byte(common.TestGithubPrivateKeyPEM))
 
 	const connName = "nats-connection"
@@ -45,10 +45,11 @@ func TestIntegrationProvisioningNATS_ConnectionReconciledOverNATS(t *testing.T) 
 		},
 	}}
 
-	created, err := helper.CreateGithubConnection(t, ctx, conn)
+	created, err := helper.CreateGithubConnection(t, conn)
 	require.NoError(t, err, "failed to create connection")
 	t.Cleanup(func() {
-		_ = helper.Connections.Resource.Delete(ctx, created.GetName(), metav1.DeleteOptions{})
+		cleanupCtx := context.WithoutCancel(t.Context())
+		_ = helper.Connections.Resource.Delete(cleanupCtx, created.GetName(), metav1.DeleteOptions{})
 	})
 
 	helper.WaitForHealthyConnection(t, created.GetName())

--- a/pkg/tests/apis/provisioning/nats/historicjob/historicjob_test.go
+++ b/pkg/tests/apis/provisioning/nats/historicjob/historicjob_test.go
@@ -26,7 +26,6 @@ import (
 // HistoricJob must then be swept by the listing-driven cleanup.
 func TestIntegrationProvisioningNATSHistoricJob_CleanedViaListing(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := t.Context()
 
 	historicJobs := helper.GetResourceClient(apis.ResourceClientArgs{
 		User:      helper.Org1.Admin,
@@ -45,7 +44,7 @@ func TestIntegrationProvisioningNATSHistoricJob_CleanedViaListing(t *testing.T) 
 	// window without racing a two-phase assertion.
 	var archived bool
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		items := listHistoricJobs(ctx, collect, historicJobs)
+		items := listHistoricJobs(t.Context(), collect, historicJobs)
 		if len(items) > 0 {
 			archived = true
 		}

--- a/pkg/tests/apis/provisioning/nats/jobs_test.go
+++ b/pkg/tests/apis/provisioning/nats/jobs_test.go
@@ -21,12 +21,11 @@ import (
 // liveDeliveryWait therefore proves live delivery.
 func TestIntegrationProvisioningNATS_JobProcessedOverNATS(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := t.Context()
 
 	job := helper.CreatePullJob(t, "nats-job-direct", "ghost-repo")
 
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		got, err := helper.Jobs.Resource.Get(ctx, job.GetName(), metav1.GetOptions{})
+		got, err := helper.Jobs.Resource.Get(t.Context(), job.GetName(), metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
 			// Archived to a historic job — it was picked up and processed.
 			return

--- a/pkg/tests/apis/provisioning/nats/relist/connection_test.go
+++ b/pkg/tests/apis/provisioning/nats/relist/connection_test.go
@@ -1,6 +1,7 @@
 package relist
 
 import (
+	"context"
 	"encoding/base64"
 	"testing"
 
@@ -21,7 +22,6 @@ import (
 // same resync_interval as the repository and job informers.
 func TestIntegrationProvisioningNATSReList_ConnectionReconciledViaReList(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := t.Context()
 	privateKeyBase64 := base64.StdEncoding.EncodeToString([]byte(common.TestGithubPrivateKeyPEM))
 
 	const connName = "nats-relist-connection"
@@ -47,10 +47,11 @@ func TestIntegrationProvisioningNATSReList_ConnectionReconciledViaReList(t *test
 		},
 	}}
 
-	created, err := helper.CreateGithubConnection(t, ctx, conn)
+	created, err := helper.CreateGithubConnection(t, conn)
 	require.NoError(t, err, "failed to create connection")
 	t.Cleanup(func() {
-		_ = helper.Connections.Resource.Delete(ctx, created.GetName(), metav1.DeleteOptions{})
+		cleanupCtx := context.WithoutCancel(t.Context())
+		_ = helper.Connections.Resource.Delete(cleanupCtx, created.GetName(), metav1.DeleteOptions{})
 	})
 
 	helper.WaitForHealthyConnection(t, created.GetName())

--- a/pkg/tests/apis/provisioning/nats/relist/relist_test.go
+++ b/pkg/tests/apis/provisioning/nats/relist/relist_test.go
@@ -16,10 +16,9 @@ func TestIntegrationProvisioningNATSReList_RepositoryReconciledViaReList(t *test
 	const repo = "nats-relist-create"
 
 	helper.CreateRepositoryNoWait(t, common.TestRepo{
-		Name:                   repo,
-		SyncTarget:             "folder",
-		SkipSync:               true,
-		SkipResourceAssertions: true,
+		Name:       repo,
+		SyncTarget: "folder",
+		SkipSync:   true,
 	})
 	helper.WaitForHealthyRepository(t, repo)
 }
@@ -33,10 +32,9 @@ func TestIntegrationProvisioningNATSReList_RepositoryReCheckedViaReList(t *testi
 	const repo = "nats-relist-update"
 
 	helper.CreateRepositoryNoWait(t, common.TestRepo{
-		Name:                   repo,
-		SyncTarget:             "folder",
-		SkipSync:               true,
-		SkipResourceAssertions: true,
+		Name:       repo,
+		SyncTarget: "folder",
+		SkipSync:   true,
 	})
 	helper.WaitForHealthyRepository(t, repo)
 	helper.RequireRepositoryReReconciles(t, repo)

--- a/pkg/tests/apis/provisioning/nats/repository_test.go
+++ b/pkg/tests/apis/provisioning/nats/repository_test.go
@@ -18,10 +18,9 @@ func TestIntegrationProvisioningNATS_RepositoryCreateReconciledOverNATS(t *testi
 	const repo = "nats-repo-create"
 
 	helper.CreateRepositoryNoWait(t, common.TestRepo{
-		Name:                   repo,
-		SyncTarget:             "folder",
-		SkipSync:               true,
-		SkipResourceAssertions: true,
+		Name:       repo,
+		SyncTarget: "folder",
+		SkipSync:   true,
 	})
 	helper.WaitForHealthyRepository(t, repo)
 }
@@ -35,10 +34,9 @@ func TestIntegrationProvisioningNATS_RepositoryUpdateReconciledOverNATS(t *testi
 	const repo = "nats-repo-update"
 
 	helper.CreateRepositoryNoWait(t, common.TestRepo{
-		Name:                   repo,
-		SyncTarget:             "folder",
-		SkipSync:               true,
-		SkipResourceAssertions: true,
+		Name:       repo,
+		SyncTarget: "folder",
+		SkipSync:   true,
 	})
 	helper.WaitForHealthyRepository(t, repo)
 	helper.RequireRepositoryReReconciles(t, repo)

--- a/pkg/tests/apis/provisioning/orgs/namespace_isolation_test.go
+++ b/pkg/tests/apis/provisioning/orgs/namespace_isolation_test.go
@@ -139,7 +139,6 @@ func TestIntegration_CrossNamespaceIsolation_FolderSync(t *testing.T) {
 
 	// Step 4: Verify cross-namespace access is blocked
 	t.Run("verify no cross-namespace visibility", func(t *testing.T) {
-
 		// Try to access orgB repository from orgA viewer context - should fail
 		orgAViewOfOrgBRepos := helper.GetResourceClient(apis.ResourceClientArgs{
 			User:      helper.Org1.Viewer,

--- a/pkg/tests/apis/provisioning/orgs/namespace_isolation_test.go
+++ b/pkg/tests/apis/provisioning/orgs/namespace_isolation_test.go
@@ -139,7 +139,6 @@ func TestIntegration_CrossNamespaceIsolation_FolderSync(t *testing.T) {
 
 	// Step 4: Verify cross-namespace access is blocked
 	t.Run("verify no cross-namespace visibility", func(t *testing.T) {
-		ctx := context.Background()
 
 		// Try to access orgB repository from orgA viewer context - should fail
 		orgAViewOfOrgBRepos := helper.GetResourceClient(apis.ResourceClientArgs{
@@ -148,7 +147,7 @@ func TestIntegration_CrossNamespaceIsolation_FolderSync(t *testing.T) {
 			GVR:       schema.GroupVersionResource{Group: "provisioning.grafana.app", Resource: "repositories", Version: "v0alpha1"},
 		})
 
-		_, err := orgAViewOfOrgBRepos.Resource.Get(ctx, orgBRepoName, metav1.GetOptions{})
+		_, err := orgAViewOfOrgBRepos.Resource.Get(t.Context(), orgBRepoName, metav1.GetOptions{})
 		assert.Error(t, err, "orgA user should not be able to access orgB repository")
 		t.Logf("✓ orgA correctly denied access to orgB namespace (error: %v)", err)
 
@@ -160,7 +159,7 @@ func TestIntegration_CrossNamespaceIsolation_FolderSync(t *testing.T) {
 			GVR:       schema.GroupVersionResource{Group: "provisioning.grafana.app", Resource: "repositories", Version: "v0alpha1"},
 		})
 
-		_, err = orgBViewOfOrgARepos.Resource.Get(ctx, orgARepoName, metav1.GetOptions{})
+		_, err = orgBViewOfOrgARepos.Resource.Get(t.Context(), orgARepoName, metav1.GetOptions{})
 		assert.Error(t, err, "orgB user should not be able to access orgA repository")
 		t.Logf("✓ orgB correctly denied access to orgA namespace (error: %v)", err)
 	})

--- a/pkg/tests/apis/provisioning/orgs/usagestats_test.go
+++ b/pkg/tests/apis/provisioning/orgs/usagestats_test.go
@@ -37,16 +37,14 @@ func TestIntegrationProvisioning_MultiOrgUsageStats(t *testing.T) {
 	// One synced local repo (with a single dashboard) in each org. Distinct
 	// LocalPath dirs keep the two repositories fully isolated on disk.
 	orgAHelper.CreateLocalRepo(t, common.TestRepo{
-		Name:                   "org-a-usage-repo",
-		LocalPath:              helper.ProvisioningPath + "/org-a-usage-repo",
-		Copies:                 map[string]string{"../testdata/all-panels.json": "dashboard.json"},
-		SkipResourceAssertions: true,
+		Name:      "org-a-usage-repo",
+		LocalPath: helper.ProvisioningPath + "/org-a-usage-repo",
+		Copies:    map[string]string{"../testdata/all-panels.json": "dashboard.json"},
 	})
 	orgBHelper.CreateLocalRepo(t, common.TestRepo{
-		Name:                   "org-b-usage-repo",
-		LocalPath:              helper.ProvisioningPath + "/org-b-usage-repo",
-		Copies:                 map[string]string{"../testdata/all-panels.json": "dashboard.json"},
-		SkipResourceAssertions: true,
+		Name:      "org-b-usage-repo",
+		LocalPath: helper.ProvisioningPath + "/org-b-usage-repo",
+		Copies:    map[string]string{"../testdata/all-panels.json": "dashboard.json"},
 	})
 
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {

--- a/pkg/tests/apis/provisioning/quota/exportjob_quota_test.go
+++ b/pkg/tests/apis/provisioning/quota/exportjob_quota_test.go
@@ -21,24 +21,25 @@ func TestIntegrationProvisioning_ExportQuota(t *testing.T) {
 
 		// Create 2 unmanaged dashboards directly in Grafana
 		dashboard1 := helper.LoadYAMLOrJSONFile("../exportunifiedtorepository/dashboard-test-v1.yaml")
-		_, err := helper.DashboardsV1.Resource.Create(t.Context(), dashboard1, metav1.CreateOptions{})
+		created1, err := helper.DashboardsV1.Resource.Create(t.Context(), dashboard1, metav1.CreateOptions{})
 		require.NoError(t, err, "should be able to create first dashboard")
 
 		dashboard2 := helper.LoadYAMLOrJSONFile("../exportunifiedtorepository/dashboard-test-v0.yaml")
-		_, err = helper.DashboardsV0.Resource.Create(t.Context(), dashboard2, metav1.CreateOptions{})
+		created2, err := helper.DashboardsV0.Resource.Create(t.Context(), dashboard2, metav1.CreateOptions{})
 		require.NoError(t, err, "should be able to create second dashboard")
 
 		// Create an empty repository with instance target for export
 		const repo = "export-quota-success"
 		testRepo := common.TestRepo{
-			Name:               repo,
-			SyncTarget:         "instance",
-			Workflows:          []string{"write"},
-			Copies:             map[string]string{},
-			ExpectedDashboards: 2,
-			ExpectedFolders:    0,
+			Name:       repo,
+			SyncTarget: "instance",
+			Workflows:  []string{"write"},
+			Copies:     map[string]string{},
 		}
 		helper.CreateLocalRepo(t, testRepo)
+
+		helper.RequireDashboards(t, created1.GetName(), created2.GetName())
+		helper.RequireRepoFolderCount(t, repo, 0)
 
 		// Wait for quota reconciliation to confirm limits are set on the repository
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonWithinQuota)
@@ -65,23 +66,24 @@ func TestIntegrationProvisioning_ExportQuota(t *testing.T) {
 
 		// Create 2 unmanaged dashboards — these alone will exceed the quota of 1
 		dashboard1 := helper.LoadYAMLOrJSONFile("../exportunifiedtorepository/dashboard-test-v1.yaml")
-		_, err := helper.DashboardsV1.Resource.Create(t.Context(), dashboard1, metav1.CreateOptions{})
+		created1, err := helper.DashboardsV1.Resource.Create(t.Context(), dashboard1, metav1.CreateOptions{})
 		require.NoError(t, err, "should be able to create first dashboard")
 
 		dashboard2 := helper.LoadYAMLOrJSONFile("../exportunifiedtorepository/dashboard-test-v0.yaml")
-		_, err = helper.DashboardsV0.Resource.Create(t.Context(), dashboard2, metav1.CreateOptions{})
+		created2, err := helper.DashboardsV0.Resource.Create(t.Context(), dashboard2, metav1.CreateOptions{})
 		require.NoError(t, err, "should be able to create second dashboard")
 
 		const repo = "export-quota-resources-exceeded"
 		testRepo := common.TestRepo{
-			Name:               repo,
-			SyncTarget:         "instance",
-			Workflows:          []string{"write"},
-			Copies:             map[string]string{},
-			ExpectedDashboards: 2,
-			ExpectedFolders:    0,
+			Name:       repo,
+			SyncTarget: "instance",
+			Workflows:  []string{"write"},
+			Copies:     map[string]string{},
 		}
 		helper.CreateLocalRepo(t, testRepo)
+
+		helper.RequireDashboards(t, created1.GetName(), created2.GetName())
+		helper.RequireRepoFolderCount(t, repo, 0)
 
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonWithinQuota)
 
@@ -116,12 +118,13 @@ func TestIntegrationProvisioning_ExportQuota(t *testing.T) {
 
 		// Create 1 unmanaged dashboard (alone would fit in quota of 2)
 		dashboard := helper.LoadYAMLOrJSONFile("../exportunifiedtorepository/dashboard-test-v1.yaml")
-		_, err := helper.DashboardsV1.Resource.Create(t.Context(), dashboard, metav1.CreateOptions{})
+		createdDash, err := helper.DashboardsV1.Resource.Create(t.Context(), dashboard, metav1.CreateOptions{})
 		require.NoError(t, err, "should be able to create dashboard")
 
 		// Create 2 unmanaged folders — together with the dashboard, the total
 		// becomes 1 dashboard + 2 folders = 3 resources which exceeds the quota of 2.
-		for i, name := range []string{"export-test-folder-1", "export-test-folder-2"} {
+		folderNames := []string{"export-test-folder-1", "export-test-folder-2"}
+		for i, name := range folderNames {
 			folderObj := &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"apiVersion": foldersV1.FolderResourceInfo.GroupVersion().String(),
@@ -140,14 +143,15 @@ func TestIntegrationProvisioning_ExportQuota(t *testing.T) {
 
 		const repo = "export-quota-folders-exceeded"
 		testRepo := common.TestRepo{
-			Name:               repo,
-			SyncTarget:         "instance",
-			Workflows:          []string{"write"},
-			Copies:             map[string]string{},
-			ExpectedDashboards: 1,
-			ExpectedFolders:    2,
+			Name:       repo,
+			SyncTarget: "instance",
+			Workflows:  []string{"write"},
+			Copies:     map[string]string{},
 		}
 		helper.CreateLocalRepo(t, testRepo)
+
+		helper.RequireDashboards(t, createdDash.GetName())
+		helper.RequireFolders(t, folderNames...)
 
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonWithinQuota)
 

--- a/pkg/tests/apis/provisioning/quota/exportjob_quota_test.go
+++ b/pkg/tests/apis/provisioning/quota/exportjob_quota_test.go
@@ -1,7 +1,6 @@
 package quota
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -19,15 +18,14 @@ func TestIntegrationProvisioning_ExportQuota(t *testing.T) {
 	t.Run("export succeeds when resources are within quota", func(t *testing.T) {
 		helper := sharedHelper(t)
 		helper.SetQuotaStatus(provisioning.QuotaStatus{MaxResourcesPerRepository: 10})
-		ctx := context.Background()
 
 		// Create 2 unmanaged dashboards directly in Grafana
 		dashboard1 := helper.LoadYAMLOrJSONFile("../exportunifiedtorepository/dashboard-test-v1.yaml")
-		_, err := helper.DashboardsV1.Resource.Create(ctx, dashboard1, metav1.CreateOptions{})
+		_, err := helper.DashboardsV1.Resource.Create(t.Context(), dashboard1, metav1.CreateOptions{})
 		require.NoError(t, err, "should be able to create first dashboard")
 
 		dashboard2 := helper.LoadYAMLOrJSONFile("../exportunifiedtorepository/dashboard-test-v0.yaml")
-		_, err = helper.DashboardsV0.Resource.Create(ctx, dashboard2, metav1.CreateOptions{})
+		_, err = helper.DashboardsV0.Resource.Create(t.Context(), dashboard2, metav1.CreateOptions{})
 		require.NoError(t, err, "should be able to create second dashboard")
 
 		// Create an empty repository with instance target for export
@@ -64,15 +62,14 @@ func TestIntegrationProvisioning_ExportQuota(t *testing.T) {
 	t.Run("export fails when existing resources already exceed the quota", func(t *testing.T) {
 		helper := sharedHelper(t)
 		helper.SetQuotaStatus(provisioning.QuotaStatus{MaxResourcesPerRepository: 1})
-		ctx := context.Background()
 
 		// Create 2 unmanaged dashboards — these alone will exceed the quota of 1
 		dashboard1 := helper.LoadYAMLOrJSONFile("../exportunifiedtorepository/dashboard-test-v1.yaml")
-		_, err := helper.DashboardsV1.Resource.Create(ctx, dashboard1, metav1.CreateOptions{})
+		_, err := helper.DashboardsV1.Resource.Create(t.Context(), dashboard1, metav1.CreateOptions{})
 		require.NoError(t, err, "should be able to create first dashboard")
 
 		dashboard2 := helper.LoadYAMLOrJSONFile("../exportunifiedtorepository/dashboard-test-v0.yaml")
-		_, err = helper.DashboardsV0.Resource.Create(ctx, dashboard2, metav1.CreateOptions{})
+		_, err = helper.DashboardsV0.Resource.Create(t.Context(), dashboard2, metav1.CreateOptions{})
 		require.NoError(t, err, "should be able to create second dashboard")
 
 		const repo = "export-quota-resources-exceeded"
@@ -116,11 +113,10 @@ func TestIntegrationProvisioning_ExportQuota(t *testing.T) {
 	t.Run("export fails when exceeding folders and resources already exceed the quota", func(t *testing.T) {
 		helper := sharedHelper(t)
 		helper.SetQuotaStatus(provisioning.QuotaStatus{MaxResourcesPerRepository: 2})
-		ctx := context.Background()
 
 		// Create 1 unmanaged dashboard (alone would fit in quota of 2)
 		dashboard := helper.LoadYAMLOrJSONFile("../exportunifiedtorepository/dashboard-test-v1.yaml")
-		_, err := helper.DashboardsV1.Resource.Create(ctx, dashboard, metav1.CreateOptions{})
+		_, err := helper.DashboardsV1.Resource.Create(t.Context(), dashboard, metav1.CreateOptions{})
 		require.NoError(t, err, "should be able to create dashboard")
 
 		// Create 2 unmanaged folders — together with the dashboard, the total
@@ -138,7 +134,7 @@ func TestIntegrationProvisioning_ExportQuota(t *testing.T) {
 					},
 				},
 			}
-			_, err = helper.Folders.Resource.Create(ctx, folderObj, metav1.CreateOptions{})
+			_, err = helper.Folders.Resource.Create(t.Context(), folderObj, metav1.CreateOptions{})
 			require.NoError(t, err, "should be able to create folder %s", name)
 		}
 

--- a/pkg/tests/apis/provisioning/quota/files_quota_test.go
+++ b/pkg/tests/apis/provisioning/quota/files_quota_test.go
@@ -27,8 +27,7 @@ func TestIntegrationProvisioning_FilesQuotaEnforcement(t *testing.T) {
 			Copies: map[string]string{
 				"../testdata/all-panels.json": "dashboard1.json",
 			},
-			SkipSync:               true,
-			SkipResourceAssertions: true,
+			SkipSync: true,
 		})
 		helper.SyncAndWait(t, repo, nil)
 
@@ -86,8 +85,7 @@ func TestIntegrationProvisioning_FilesQuotaEnforcement(t *testing.T) {
 			Copies: map[string]string{
 				"../testdata/all-panels.json": "dashboard1.json",
 			},
-			SkipSync:               true,
-			SkipResourceAssertions: true,
+			SkipSync: true,
 		})
 		helper.SyncAndWait(t, repo, nil)
 		// Wait for quota condition to show within quota
@@ -144,8 +142,7 @@ func TestIntegrationProvisioning_FilesQuotaEnforcement(t *testing.T) {
 			Copies: map[string]string{
 				"../testdata/all-panels.json": "dashboard1.json",
 			},
-			SkipSync:               true,
-			SkipResourceAssertions: true,
+			SkipSync: true,
 		})
 		helper.SyncAndWait(t, repo, nil)
 		// Wait for quota condition to show reached
@@ -202,8 +199,7 @@ func TestIntegrationProvisioning_FilesQuotaEnforcement(t *testing.T) {
 				"../testdata/all-panels.json":   "dashboard1.json",
 				"../testdata/text-options.json": "dashboard2.json",
 			},
-			SkipSync:               true,
-			SkipResourceAssertions: true,
+			SkipSync: true,
 		})
 		helper.SyncAndWait(t, repo, nil)
 

--- a/pkg/tests/apis/provisioning/quota/files_quota_test.go
+++ b/pkg/tests/apis/provisioning/quota/files_quota_test.go
@@ -1,7 +1,6 @@
 package quota
 
 import (
-	"context"
 	"io"
 	"net/http"
 	"path/filepath"
@@ -17,7 +16,6 @@ import (
 func TestIntegrationProvisioning_FilesQuotaEnforcement(t *testing.T) {
 	t.Run("no quota configured allows create and update via files endpoint", func(t *testing.T) {
 		helper := sharedHelper(t)
-		ctx := context.Background()
 
 		const repo = "files-quota-unlimited-repo"
 		repoPath := filepath.Join(helper.ProvisioningPath, repo)
@@ -46,7 +44,7 @@ func TestIntegrationProvisioning_FilesQuotaEnforcement(t *testing.T) {
 			SubResource("files", "new-dashboard.json").
 			Body(helper.LoadFile("../testdata/text-options.json")).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).StatusCode(&createStatusCode)
+			Do(t.Context()).StatusCode(&createStatusCode)
 		require.NoError(t, result.Error(), "POST (create) should succeed when no quota is configured")
 		require.Equal(t, http.StatusOK, createStatusCode, "should return 200 OK for create")
 
@@ -59,7 +57,7 @@ func TestIntegrationProvisioning_FilesQuotaEnforcement(t *testing.T) {
 			SubResource("files", "dashboard1.json").
 			Body(helper.LoadFile("../testdata/text-options.json")).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).StatusCode(&updateStatusCode)
+			Do(t.Context()).StatusCode(&updateStatusCode)
 		require.NoError(t, result.Error(), "PUT (update) should succeed when no quota is configured")
 		require.Equal(t, http.StatusOK, updateStatusCode, "should return 200 OK for update")
 
@@ -77,7 +75,6 @@ func TestIntegrationProvisioning_FilesQuotaEnforcement(t *testing.T) {
 		// With folder target: 1 dashboard + 1 folder = 2 resources, limit 10 → within quota
 		helper := sharedHelper(t)
 		helper.SetQuotaStatus(provisioning.QuotaStatus{MaxResourcesPerRepository: 10})
-		ctx := context.Background()
 
 		const repo = "files-quota-within-repo"
 		repoPath := filepath.Join(helper.ProvisioningPath, repo)
@@ -105,7 +102,7 @@ func TestIntegrationProvisioning_FilesQuotaEnforcement(t *testing.T) {
 			SubResource("files", "new-dashboard.json").
 			Body(helper.LoadFile("../testdata/text-options.json")).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).StatusCode(&createStatusCode)
+			Do(t.Context()).StatusCode(&createStatusCode)
 		require.NoError(t, result.Error(), "POST (create) should succeed when within quota")
 		require.Equal(t, http.StatusOK, createStatusCode, "should return 200 OK for create")
 
@@ -118,7 +115,7 @@ func TestIntegrationProvisioning_FilesQuotaEnforcement(t *testing.T) {
 			SubResource("files", "dashboard1.json").
 			Body(helper.LoadFile("../testdata/text-options.json")).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).StatusCode(&updateStatusCode)
+			Do(t.Context()).StatusCode(&updateStatusCode)
 		require.NoError(t, result.Error(), "PUT (update) should succeed when within quota")
 		require.Equal(t, http.StatusOK, updateStatusCode, "should return 200 OK for update")
 
@@ -136,7 +133,6 @@ func TestIntegrationProvisioning_FilesQuotaEnforcement(t *testing.T) {
 		// With folder target: 1 dashboard + 1 folder = 2 resources, limit 2 → exactly at limit (reached)
 		helper := sharedHelper(t)
 		helper.SetQuotaStatus(provisioning.QuotaStatus{MaxResourcesPerRepository: 2})
-		ctx := context.Background()
 
 		const repo = "files-quota-reached-repo"
 		repoPath := filepath.Join(helper.ProvisioningPath, repo)
@@ -163,7 +159,7 @@ func TestIntegrationProvisioning_FilesQuotaEnforcement(t *testing.T) {
 			SubResource("files", "new-dashboard.json").
 			Body(helper.LoadFile("../testdata/text-options.json")).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx)
+			Do(t.Context())
 		require.Error(t, result.Error(), "POST (create) should be blocked when quota is reached")
 		require.True(t, apierrors.IsForbidden(result.Error()), "error should be Forbidden, got: %v", result.Error())
 
@@ -176,7 +172,7 @@ func TestIntegrationProvisioning_FilesQuotaEnforcement(t *testing.T) {
 			SubResource("files", "dashboard1.json").
 			Body(helper.LoadFile("../testdata/text-options.json")).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).StatusCode(&updateStatusCode)
+			Do(t.Context()).StatusCode(&updateStatusCode)
 		require.NoError(t, result.Error(), "PUT (update) should succeed when quota is reached")
 		require.Equal(t, http.StatusOK, updateStatusCode, "should return 200 OK for update")
 
@@ -193,7 +189,6 @@ func TestIntegrationProvisioning_FilesQuotaEnforcement(t *testing.T) {
 	t.Run("quota exceeded blocks both create and update via files endpoint", func(t *testing.T) {
 		// With folder target: 2 dashboards + 1 folder = 3 resources, limit 1 → exceeded
 		helper := sharedHelper(t)
-		ctx := context.Background()
 
 		const repo = "files-quota-exceeded-repo"
 		repoPath := filepath.Join(helper.ProvisioningPath, repo)
@@ -227,7 +222,7 @@ func TestIntegrationProvisioning_FilesQuotaEnforcement(t *testing.T) {
 			SubResource("files", "new-dashboard.json").
 			Body(helper.LoadFile("../testdata/timeline-demo.json")).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx)
+			Do(t.Context())
 		require.Error(t, result.Error(), "POST (create) should be blocked when quota is exceeded")
 		require.True(t, apierrors.IsForbidden(result.Error()), "error should be Forbidden, got: %v", result.Error())
 
@@ -239,7 +234,7 @@ func TestIntegrationProvisioning_FilesQuotaEnforcement(t *testing.T) {
 			SubResource("files", "dashboard1.json").
 			Body(helper.LoadFile("../testdata/text-options.json")).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx)
+			Do(t.Context())
 		require.Error(t, result.Error(), "PUT (update) should be blocked when quota is exceeded")
 		require.True(t, apierrors.IsForbidden(result.Error()), "error should be Forbidden, got: %v", result.Error())
 

--- a/pkg/tests/apis/provisioning/quota/foldermetadata/sync_quota_metadata_test.go
+++ b/pkg/tests/apis/provisioning/quota/foldermetadata/sync_quota_metadata_test.go
@@ -1,7 +1,6 @@
 package foldermetadata
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -16,7 +15,6 @@ func TestIntegrationProvisioning_QuotaWithFolderMetadata(t *testing.T) {
 		// Quota allows exactly the resources that exist after initial sync.
 		// Changing the folder UID in _folder.json is a replacement (create new +
 		// delete old) that should be net-zero and succeed even at the limit.
-		ctx := context.Background()
 		helper := sharedGitHelperWithQuota(t, 3)
 
 		const repo = "quota-meta-uid-change"
@@ -27,8 +25,8 @@ func TestIntegrationProvisioning_QuotaWithFolderMetadata(t *testing.T) {
 
 		// Full sync: root folder + subfolder (original-uid) + dashboard = 3 resources.
 		common.SyncAndWait(t, helper, common.Repo(repo), common.Succeeded())
-		common.RequireRepoDashboardCount(t, helper, ctx, repo, 1)
-		common.RequireRepoFolderCount(t, helper, ctx, repo, 2)
+		common.RequireRepoDashboardCount(t, helper, repo, 1)
+		common.RequireRepoFolderCount(t, helper, repo, 2)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
 
 		common.RequireFolderState(t, helper.Folders, "original-uid", "My Folder", "subfolder", repo)
@@ -50,8 +48,8 @@ func TestIntegrationProvisioning_QuotaWithFolderMetadata(t *testing.T) {
 		requireFolderNotExists(t, helper, "original-uid")
 
 		// Resource counts unchanged: root folder + subfolder (new-uid) + dashboard = 3.
-		common.RequireRepoDashboardCount(t, helper, ctx, repo, 1)
-		common.RequireRepoFolderCount(t, helper, ctx, repo, 2)
+		common.RequireRepoDashboardCount(t, helper, repo, 1)
+		common.RequireRepoFolderCount(t, helper, repo, 2)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
 	})
 
@@ -60,7 +58,6 @@ func TestIntegrationProvisioning_QuotaWithFolderMetadata(t *testing.T) {
 		// sync whose net change does not bring the repo back within limits.
 		// A folder UID change (FileActionUpdated, net 0) does not reduce the
 		// count, so the sync is expected to be blocked.
-		ctx := context.Background()
 		helper := sharedGitHelper(t)
 
 		const repo = "quota-meta-uid-over"
@@ -71,8 +68,8 @@ func TestIntegrationProvisioning_QuotaWithFolderMetadata(t *testing.T) {
 
 		// Full sync without quota: root + subfolder + dashboard = 3 resources.
 		common.SyncAndWait(t, helper, common.Repo(repo), common.Succeeded())
-		common.RequireRepoDashboardCount(t, helper, ctx, repo, 1)
-		common.RequireRepoFolderCount(t, helper, ctx, repo, 2)
+		common.RequireRepoDashboardCount(t, helper, repo, 1)
+		common.RequireRepoFolderCount(t, helper, repo, 2)
 
 		// Lower the quota below the current count to put the repo over limit.
 		helper.SetQuotaStatus(provisioning.QuotaStatus{MaxResourcesPerRepository: 2})
@@ -107,7 +104,7 @@ func TestIntegrationProvisioning_QuotaWithFolderMetadata(t *testing.T) {
 
 		// The original folder should remain unchanged.
 		common.RequireFolderState(t, helper.Folders, "stable-uid", "My Folder", "subfolder", repo)
-		common.RequireRepoDashboardCount(t, helper, ctx, repo, 1)
+		common.RequireRepoDashboardCount(t, helper, repo, 1)
 	})
 
 	t.Run("full sync: invalid _folder.json falls back to hash UID under quota pressure", func(t *testing.T) {
@@ -115,7 +112,6 @@ func TestIntegrationProvisioning_QuotaWithFolderMetadata(t *testing.T) {
 		// identity. If that UID differs from the stable one a replacement
 		// occurs. At the quota limit this exercises the same create-before-
 		// delete path as a normal UID change.
-		ctx := context.Background()
 		helper := sharedGitHelperWithQuota(t, 3)
 
 		const repo = "quota-meta-invalid"
@@ -126,8 +122,8 @@ func TestIntegrationProvisioning_QuotaWithFolderMetadata(t *testing.T) {
 
 		// Full sync: root + subfolder (valid-uid) + dashboard = 3 resources.
 		common.SyncAndWait(t, helper, common.Repo(repo), common.Succeeded())
-		common.RequireRepoDashboardCount(t, helper, ctx, repo, 1)
-		common.RequireRepoFolderCount(t, helper, ctx, repo, 2)
+		common.RequireRepoDashboardCount(t, helper, repo, 1)
+		common.RequireRepoFolderCount(t, helper, repo, 2)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
 
 		common.RequireFolderState(t, helper.Folders, "valid-uid", "My Folder", "subfolder", repo)
@@ -158,15 +154,14 @@ func TestIntegrationProvisioning_QuotaWithFolderMetadata(t *testing.T) {
 		require.Empty(t, jobObj.Status.Errors, "invalid metadata should not cause errors")
 
 		// The dashboard should still exist regardless of folder UID changes.
-		common.RequireRepoDashboardCount(t, helper, ctx, repo, 1)
-		common.RequireRepoFolderCount(t, helper, ctx, repo, 2)
+		common.RequireRepoDashboardCount(t, helper, repo, 1)
+		common.RequireRepoFolderCount(t, helper, repo, 2)
 	})
 
 	t.Run("incremental sync: folder UID change via _folder.json succeeds at quota limit", func(t *testing.T) {
 		// Same scenario as the full-sync test but via incremental sync.
 		// The replacement folders are processed by deleteFolders() after
 		// applyIncrementalChanges(), so quota must be released in time.
-		ctx := context.Background()
 		helper := sharedGitHelperWithQuota(t, 3)
 
 		const repo = "quota-meta-incr-uid"
@@ -177,8 +172,8 @@ func TestIntegrationProvisioning_QuotaWithFolderMetadata(t *testing.T) {
 
 		// Full sync first to establish baseline.
 		common.SyncAndWait(t, helper, common.Repo(repo), common.Succeeded())
-		common.RequireRepoDashboardCount(t, helper, ctx, repo, 1)
-		common.RequireRepoFolderCount(t, helper, ctx, repo, 2)
+		common.RequireRepoDashboardCount(t, helper, repo, 1)
+		common.RequireRepoFolderCount(t, helper, repo, 2)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
 
 		common.RequireFolderState(t, helper.Folders, "incr-original-uid", "My Folder", "subfolder", repo)
@@ -200,8 +195,8 @@ func TestIntegrationProvisioning_QuotaWithFolderMetadata(t *testing.T) {
 		requireFolderNotExists(t, helper, "incr-original-uid")
 
 		// Resource counts unchanged.
-		common.RequireRepoDashboardCount(t, helper, ctx, repo, 1)
-		common.RequireRepoFolderCount(t, helper, ctx, repo, 2)
+		common.RequireRepoDashboardCount(t, helper, repo, 1)
+		common.RequireRepoFolderCount(t, helper, repo, 2)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
 	})
 }

--- a/pkg/tests/apis/provisioning/quota/foldermetadata/sync_quota_metadata_test.go
+++ b/pkg/tests/apis/provisioning/quota/foldermetadata/sync_quota_metadata_test.go
@@ -25,8 +25,8 @@ func TestIntegrationProvisioning_QuotaWithFolderMetadata(t *testing.T) {
 
 		// Full sync: root folder + subfolder (original-uid) + dashboard = 3 resources.
 		common.SyncAndWait(t, helper, common.Repo(repo), common.Succeeded())
-		common.RequireRepoDashboardCount(t, helper, repo, 1)
-		common.RequireRepoFolderCount(t, helper, repo, 2)
+		helper.RequireRepoDashboardCount(t, repo, 1)
+		helper.RequireRepoFolderCount(t, repo, 2)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
 
 		common.RequireFolderState(t, helper.Folders, "original-uid", "My Folder", "subfolder", repo)
@@ -48,8 +48,8 @@ func TestIntegrationProvisioning_QuotaWithFolderMetadata(t *testing.T) {
 		requireFolderNotExists(t, helper, "original-uid")
 
 		// Resource counts unchanged: root folder + subfolder (new-uid) + dashboard = 3.
-		common.RequireRepoDashboardCount(t, helper, repo, 1)
-		common.RequireRepoFolderCount(t, helper, repo, 2)
+		helper.RequireRepoDashboardCount(t, repo, 1)
+		helper.RequireRepoFolderCount(t, repo, 2)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
 	})
 
@@ -68,8 +68,8 @@ func TestIntegrationProvisioning_QuotaWithFolderMetadata(t *testing.T) {
 
 		// Full sync without quota: root + subfolder + dashboard = 3 resources.
 		common.SyncAndWait(t, helper, common.Repo(repo), common.Succeeded())
-		common.RequireRepoDashboardCount(t, helper, repo, 1)
-		common.RequireRepoFolderCount(t, helper, repo, 2)
+		helper.RequireRepoDashboardCount(t, repo, 1)
+		helper.RequireRepoFolderCount(t, repo, 2)
 
 		// Lower the quota below the current count to put the repo over limit.
 		helper.SetQuotaStatus(provisioning.QuotaStatus{MaxResourcesPerRepository: 2})
@@ -104,7 +104,7 @@ func TestIntegrationProvisioning_QuotaWithFolderMetadata(t *testing.T) {
 
 		// The original folder should remain unchanged.
 		common.RequireFolderState(t, helper.Folders, "stable-uid", "My Folder", "subfolder", repo)
-		common.RequireRepoDashboardCount(t, helper, repo, 1)
+		helper.RequireRepoDashboardCount(t, repo, 1)
 	})
 
 	t.Run("full sync: invalid _folder.json falls back to hash UID under quota pressure", func(t *testing.T) {
@@ -122,8 +122,8 @@ func TestIntegrationProvisioning_QuotaWithFolderMetadata(t *testing.T) {
 
 		// Full sync: root + subfolder (valid-uid) + dashboard = 3 resources.
 		common.SyncAndWait(t, helper, common.Repo(repo), common.Succeeded())
-		common.RequireRepoDashboardCount(t, helper, repo, 1)
-		common.RequireRepoFolderCount(t, helper, repo, 2)
+		helper.RequireRepoDashboardCount(t, repo, 1)
+		helper.RequireRepoFolderCount(t, repo, 2)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
 
 		common.RequireFolderState(t, helper.Folders, "valid-uid", "My Folder", "subfolder", repo)
@@ -154,8 +154,8 @@ func TestIntegrationProvisioning_QuotaWithFolderMetadata(t *testing.T) {
 		require.Empty(t, jobObj.Status.Errors, "invalid metadata should not cause errors")
 
 		// The dashboard should still exist regardless of folder UID changes.
-		common.RequireRepoDashboardCount(t, helper, repo, 1)
-		common.RequireRepoFolderCount(t, helper, repo, 2)
+		helper.RequireRepoDashboardCount(t, repo, 1)
+		helper.RequireRepoFolderCount(t, repo, 2)
 	})
 
 	t.Run("incremental sync: folder UID change via _folder.json succeeds at quota limit", func(t *testing.T) {
@@ -172,8 +172,8 @@ func TestIntegrationProvisioning_QuotaWithFolderMetadata(t *testing.T) {
 
 		// Full sync first to establish baseline.
 		common.SyncAndWait(t, helper, common.Repo(repo), common.Succeeded())
-		common.RequireRepoDashboardCount(t, helper, repo, 1)
-		common.RequireRepoFolderCount(t, helper, repo, 2)
+		helper.RequireRepoDashboardCount(t, repo, 1)
+		helper.RequireRepoFolderCount(t, repo, 2)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
 
 		common.RequireFolderState(t, helper.Folders, "incr-original-uid", "My Folder", "subfolder", repo)
@@ -195,8 +195,8 @@ func TestIntegrationProvisioning_QuotaWithFolderMetadata(t *testing.T) {
 		requireFolderNotExists(t, helper, "incr-original-uid")
 
 		// Resource counts unchanged.
-		common.RequireRepoDashboardCount(t, helper, repo, 1)
-		common.RequireRepoFolderCount(t, helper, repo, 2)
+		helper.RequireRepoDashboardCount(t, repo, 1)
+		helper.RequireRepoFolderCount(t, repo, 2)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
 	})
 }

--- a/pkg/tests/apis/provisioning/quota/limits_test.go
+++ b/pkg/tests/apis/provisioning/quota/limits_test.go
@@ -20,13 +20,14 @@ func TestIntegrationProvisioning_RepositoryLimits(t *testing.T) {
 
 	originalName := "original-repo"
 	originalRepo := common.TestRepo{
-		Name:               originalName,
-		SyncTarget:         "instance",
-		Copies:             map[string]string{},
-		ExpectedDashboards: 0,
-		ExpectedFolders:    0,
+		Name:       originalName,
+		SyncTarget: "instance",
+		Copies:     map[string]string{},
 	}
 	helper.CreateLocalRepo(t, originalRepo)
+
+	helper.RequireRepoDashboardCount(t, originalName, 0)
+	helper.RequireRepoFolderCount(t, originalName, 0)
 
 	t.Run("folder sync is rejected when instance sync exists", func(t *testing.T) {
 		folderRepo := helper.RenderObject(t, common.TestdataPath("local.json.tmpl"), map[string]any{
@@ -110,13 +111,14 @@ func TestIntegrationProvisioning_RepositoryLimits(t *testing.T) {
 		for i := 2; i <= 10; i++ {
 			repoName := fmt.Sprintf("limit-test-repo-%d", i)
 			limitTestRepo := common.TestRepo{
-				Name:               repoName,
-				SyncTarget:         "folder",
-				Copies:             map[string]string{},
-				ExpectedDashboards: 0,
-				ExpectedFolders:    i,
+				Name:       repoName,
+				SyncTarget: "folder",
+				Copies:     map[string]string{},
 			}
 			helper.CreateLocalRepo(t, limitTestRepo)
+
+			helper.RequireRepoDashboardCount(t, repoName, 0)
+			helper.RequireRepoFolderCount(t, repoName, 1)
 		}
 
 		eleventhRepoName := "limit-test-repo-11"

--- a/pkg/tests/apis/provisioning/quota/limits_test.go
+++ b/pkg/tests/apis/provisioning/quota/limits_test.go
@@ -1,7 +1,6 @@
 package quota
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -18,7 +17,6 @@ import (
 func TestIntegrationProvisioning_RepositoryLimits(t *testing.T) {
 	helper := sharedHelper(t)
 	helper.SetQuotaStatus(provisioning.QuotaStatus{MaxRepositories: 10})
-	ctx := context.Background()
 
 	originalName := "original-repo"
 	originalRepo := common.TestRepo{
@@ -39,7 +37,7 @@ func TestIntegrationProvisioning_RepositoryLimits(t *testing.T) {
 			"WorkflowsJSON": `["write"]`,
 		})
 
-		_, err := helper.Repositories.Resource.Create(ctx, folderRepo, metav1.CreateOptions{FieldValidation: "Strict"})
+		_, err := helper.Repositories.Resource.Create(t.Context(), folderRepo, metav1.CreateOptions{FieldValidation: "Strict"})
 		require.Error(t, err, "folder sync repository should be rejected when instance sync exists")
 
 		statusError := helper.RequireApiErrorStatus(err, metav1.StatusReasonInvalid, http.StatusUnprocessableEntity)
@@ -47,15 +45,15 @@ func TestIntegrationProvisioning_RepositoryLimits(t *testing.T) {
 	})
 
 	t.Run("change between folder and instance sync for the same repository if no previous sync happened", func(t *testing.T) {
-		repo, err := helper.Repositories.Resource.Get(ctx, originalName, metav1.GetOptions{})
+		repo, err := helper.Repositories.Resource.Get(t.Context(), originalName, metav1.GetOptions{})
 		require.NoError(t, err, "failed to get repository")
 		err = unstructured.SetNestedField(repo.Object, "folder", "spec", "sync", "target")
 		require.NoError(t, err, "failed to set syncTarget to folder")
-		_, err = helper.Repositories.Resource.Update(ctx, repo, metav1.UpdateOptions{FieldValidation: "Strict"})
+		_, err = helper.Repositories.Resource.Update(t.Context(), repo, metav1.UpdateOptions{FieldValidation: "Strict"})
 		require.NoError(t, err, "failed to update repository to folder sync")
 
 		require.Eventually(t, func() bool {
-			repos, err := helper.Repositories.Resource.List(ctx, metav1.ListOptions{})
+			repos, err := helper.Repositories.Resource.List(t.Context(), metav1.ListOptions{})
 			if err != nil {
 				return false
 			}
@@ -84,7 +82,7 @@ func TestIntegrationProvisioning_RepositoryLimits(t *testing.T) {
 			"WorkflowsJSON": `["write"]`,
 		})
 
-		_, err := helper.Repositories.Resource.Create(ctx, instanceRepo, metav1.CreateOptions{FieldValidation: "Strict"})
+		_, err := helper.Repositories.Resource.Create(t.Context(), instanceRepo, metav1.CreateOptions{FieldValidation: "Strict"})
 		require.Error(t, err, "instance sync repository should be rejected when any other repository exists")
 
 		statusError := helper.RequireApiErrorStatus(err, metav1.StatusReasonInvalid, http.StatusUnprocessableEntity)
@@ -93,7 +91,7 @@ func TestIntegrationProvisioning_RepositoryLimits(t *testing.T) {
 
 	t.Run("repository limit validation of 10 for folder syncs repositories", func(t *testing.T) {
 		require.Eventually(t, func() bool {
-			repo, err := helper.Repositories.Resource.Get(ctx, originalName, metav1.GetOptions{})
+			repo, err := helper.Repositories.Resource.Get(t.Context(), originalName, metav1.GetOptions{})
 			if err != nil {
 				return false
 			}
@@ -104,7 +102,7 @@ func TestIntegrationProvisioning_RepositoryLimits(t *testing.T) {
 			return syncTarget == "folder"
 		}, time.Second*10, time.Millisecond*100, "original repo should be folder sync")
 
-		existingRepos, err := helper.Repositories.Resource.List(ctx, metav1.ListOptions{})
+		existingRepos, err := helper.Repositories.Resource.List(t.Context(), metav1.ListOptions{})
 		require.NoError(t, err, "failed to list repositories")
 		existingCount := len(existingRepos.Items)
 		require.Equal(t, 1, existingCount, "should have 1 existing repository (original-repo)")
@@ -130,7 +128,7 @@ func TestIntegrationProvisioning_RepositoryLimits(t *testing.T) {
 			"WorkflowsJSON": `["write"]`,
 		})
 
-		_, createErr := helper.Repositories.Resource.Create(ctx, eleventhRepo, metav1.CreateOptions{FieldValidation: "Strict"})
+		_, createErr := helper.Repositories.Resource.Create(t.Context(), eleventhRepo, metav1.CreateOptions{FieldValidation: "Strict"})
 		require.Error(t, createErr, "11th repository should be rejected due to limit")
 
 		statusError := helper.RequireApiErrorStatus(createErr, metav1.StatusReasonInvalid, http.StatusUnprocessableEntity)

--- a/pkg/tests/apis/provisioning/quota/namespace_quota_test.go
+++ b/pkg/tests/apis/provisioning/quota/namespace_quota_test.go
@@ -32,18 +32,16 @@ func TestIntegrationProvisioning_NamespaceRepositoryQuota(t *testing.T) {
 	// --- Step 1: create 2 repos with unlimited quota  ---------
 	helper.SetQuotaStatus(provisioning.QuotaStatus{MaxRepositories: 0})
 	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:                   repo1Name,
-		LocalPath:              repo1Path,
-		SyncTarget:             "folder",
-		SkipSync:               true,
-		SkipResourceAssertions: true,
+		Name:       repo1Name,
+		LocalPath:  repo1Path,
+		SyncTarget: "folder",
+		SkipSync:   true,
 	})
 	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:                   repo2Name,
-		LocalPath:              repo2Path,
-		SyncTarget:             "folder",
-		SkipSync:               true,
-		SkipResourceAssertions: true,
+		Name:       repo2Name,
+		LocalPath:  repo2Path,
+		SyncTarget: "folder",
+		SkipSync:   true,
 	})
 
 	waitForHealthyWithNamespaceQuota(t, helper, repo1Name, provisioning.ReasonQuotaUnlimited)
@@ -116,6 +114,7 @@ func waitForHealthyWithNamespaceQuota(t *testing.T, helper *common.ProvisioningT
 // blocked due to namespace quota being exceeded.
 func TestIntegrationProvisioning_HealthAndTokenRefreshWhileOverNamespaceQuota(t *testing.T) {
 	helper := sharedHelper(t)
+
 	privateKeyBase64 := base64.StdEncoding.EncodeToString([]byte(common.TestGithubPrivateKeyPEM))
 
 	const (

--- a/pkg/tests/apis/provisioning/quota/namespace_quota_test.go
+++ b/pkg/tests/apis/provisioning/quota/namespace_quota_test.go
@@ -1,7 +1,6 @@
 package quota
 
 import (
-	"context"
 	"encoding/base64"
 	"path/filepath"
 	"testing"
@@ -117,7 +116,6 @@ func waitForHealthyWithNamespaceQuota(t *testing.T, helper *common.ProvisioningT
 // blocked due to namespace quota being exceeded.
 func TestIntegrationProvisioning_HealthAndTokenRefreshWhileOverNamespaceQuota(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 	privateKeyBase64 := base64.StdEncoding.EncodeToString([]byte(common.TestGithubPrivateKeyPEM))
 
 	const (
@@ -149,12 +147,12 @@ func TestIntegrationProvisioning_HealthAndTokenRefreshWhileOverNamespaceQuota(t 
 		},
 	}}
 
-	_, err := helper.CreateGithubConnection(t, ctx, conn)
+	_, err := helper.CreateGithubConnection(t, conn)
 	require.NoError(t, err, "failed to create GitHub connection")
 
 	// Wait for the connection itself to be reconciled (token acquired).
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		obj, err := helper.Connections.Resource.Get(ctx, connName, metav1.GetOptions{})
+		obj, err := helper.Connections.Resource.Get(t.Context(), connName, metav1.GetOptions{})
 		if !assert.NoError(c, err) {
 			return
 		}
@@ -196,7 +194,7 @@ func TestIntegrationProvisioning_HealthAndTokenRefreshWhileOverNamespaceQuota(t 
 				},
 			},
 		}}
-		_, err = helper.Repositories.Resource.Create(ctx, repoObj, metav1.CreateOptions{})
+		_, err = helper.Repositories.Resource.Create(t.Context(), repoObj, metav1.CreateOptions{})
 		require.NoError(t, err, "failed to create repository %s", name)
 	}
 
@@ -204,7 +202,7 @@ func TestIntegrationProvisioning_HealthAndTokenRefreshWhileOverNamespaceQuota(t 
 	for _, name := range []string{repoName1, repoName2} {
 		name := name
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			obj, err := helper.Repositories.Resource.Get(ctx, name, metav1.GetOptions{})
+			obj, err := helper.Repositories.Resource.Get(t.Context(), name, metav1.GetOptions{})
 			if !assert.NoError(c, err) {
 				return
 			}
@@ -252,13 +250,13 @@ func TestIntegrationProvisioning_HealthAndTokenRefreshWhileOverNamespaceQuota(t 
 		},
 	})
 	require.NoError(t, err)
-	_, err = helper.Repositories.Resource.Patch(ctx, repoName1,
+	_, err = helper.Repositories.Resource.Patch(t.Context(), repoName1,
 		types.MergePatchType, statusPatch, metav1.PatchOptions{}, "status")
 	require.NoError(t, err, "failed to patch repo1 status with near-expiry token")
 
 	// --- Step 5: verify health check AND token refresh happened, repo still blocked
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		obj, err := helper.Repositories.Resource.Get(ctx, repoName1, metav1.GetOptions{})
+		obj, err := helper.Repositories.Resource.Get(t.Context(), repoName1, metav1.GetOptions{})
 		if !assert.NoError(c, err) {
 			return
 		}

--- a/pkg/tests/apis/provisioning/quota/quota_test.go
+++ b/pkg/tests/apis/provisioning/quota/quota_test.go
@@ -1,7 +1,6 @@
 package quota
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,7 +14,6 @@ import (
 func TestIntegrationProvisioning_QuotaCondition(t *testing.T) {
 	t.Run("quota condition is QuotaUnlimited when no limit is configured", func(t *testing.T) {
 		helper := sharedHelper(t)
-		ctx := context.Background()
 
 		const repo = "quota-unlimited-repo"
 		testRepo := common.TestRepo{
@@ -33,7 +31,7 @@ func TestIntegrationProvisioning_QuotaCondition(t *testing.T) {
 
 		// Wait for the repository to be synced and check the Quota condition
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
-			repoObj, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{})
+			repoObj, err := helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{})
 			if err != nil {
 				collect.Errorf("failed to get repository: %v", err)
 				return
@@ -73,7 +71,6 @@ func TestIntegrationProvisioning_QuotaCondition(t *testing.T) {
 	t.Run("quota condition is ResourceQuotaExceeded when limit is exceeded", func(t *testing.T) {
 		// Set a low resource limit
 		helper := sharedHelper(t)
-		ctx := context.Background()
 
 		const repo = "quota-exceeded-repo"
 		testRepo := common.TestRepo{
@@ -98,7 +95,7 @@ func TestIntegrationProvisioning_QuotaCondition(t *testing.T) {
 
 		// Wait for the repository to be synced and check the Quota condition
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
-			repoObj, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{})
+			repoObj, err := helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{})
 			if err != nil {
 				collect.Errorf("failed to get repository: %v", err)
 				return
@@ -138,7 +135,6 @@ func TestIntegrationProvisioning_QuotaCondition(t *testing.T) {
 		// Set a limit higher than resources
 		helper := sharedHelper(t)
 		helper.SetQuotaStatus(provisioning.QuotaStatus{MaxResourcesPerRepository: 10})
-		ctx := context.Background()
 
 		const repo = "quota-within-repo"
 		testRepo := common.TestRepo{
@@ -157,7 +153,7 @@ func TestIntegrationProvisioning_QuotaCondition(t *testing.T) {
 
 		// Wait for the repository to be synced and check the Quota condition
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
-			repoObj, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{})
+			repoObj, err := helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{})
 			if err != nil {
 				collect.Errorf("failed to get repository: %v", err)
 				return
@@ -230,7 +226,6 @@ func TestIntegrationProvisioning_QuotaStatus(t *testing.T) {
 			MaxResourcesPerRepository: 50,
 			MaxRepositories:           5,
 		})
-		ctx := context.Background()
 
 		const repo = "quota-status-configured-repo"
 		testRepo := common.TestRepo{
@@ -248,7 +243,7 @@ func TestIntegrationProvisioning_QuotaStatus(t *testing.T) {
 
 		// Wait for the repository to be reconciled and check the QuotaStatus
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
-			repoObj, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{})
+			repoObj, err := helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{})
 			if err != nil {
 				collect.Errorf("failed to get repository: %v", err)
 				return
@@ -287,7 +282,6 @@ func TestIntegrationProvisioning_QuotaStatus(t *testing.T) {
 	t.Run("quota status shows unlimited when no limits configured", func(t *testing.T) {
 		// Don't set any quota limits (defaults to 0 = unlimited)
 		helper := sharedHelper(t)
-		ctx := context.Background()
 
 		const repo = "quota-status-unlimited-repo"
 		testRepo := common.TestRepo{
@@ -305,7 +299,7 @@ func TestIntegrationProvisioning_QuotaStatus(t *testing.T) {
 
 		// Wait for the repository to be reconciled and check the QuotaStatus
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
-			repoObj, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{})
+			repoObj, err := helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{})
 			if err != nil {
 				collect.Errorf("failed to get repository: %v", err)
 				return

--- a/pkg/tests/apis/provisioning/quota/quota_test.go
+++ b/pkg/tests/apis/provisioning/quota/quota_test.go
@@ -22,8 +22,7 @@ func TestIntegrationProvisioning_QuotaCondition(t *testing.T) {
 			Copies: map[string]string{
 				"../testdata/all-panels.json": "dashboard1.json",
 			},
-			SkipSync:               true, // Prevent controller auto-sync racing with file copy
-			SkipResourceAssertions: true,
+			SkipSync: true, // Prevent controller auto-sync racing with file copy
 		}
 		helper.CreateLocalRepo(t, testRepo)
 		helper.SyncAndWait(t, repo, nil)
@@ -81,8 +80,7 @@ func TestIntegrationProvisioning_QuotaCondition(t *testing.T) {
 				"../testdata/all-panels.json":   "dashboard1.json",
 				"../testdata/text-options.json": "dashboard2.json",
 			},
-			SkipSync:               true, // Prevent controller auto-sync racing with file copy
-			SkipResourceAssertions: true,
+			SkipSync: true, // Prevent controller auto-sync racing with file copy
 		}
 		helper.CreateLocalRepo(t, testRepo)
 		helper.SyncAndWait(t, repo, nil)
@@ -144,8 +142,7 @@ func TestIntegrationProvisioning_QuotaCondition(t *testing.T) {
 				// Adding 1 dashboard, well under the limit of 10
 				"../testdata/all-panels.json": "dashboard1.json",
 			},
-			SkipSync:               true, // Prevent controller auto-sync racing with file copy
-			SkipResourceAssertions: true,
+			SkipSync: true, // Prevent controller auto-sync racing with file copy
 		}
 		helper.CreateLocalRepo(t, testRepo)
 		helper.SyncAndWait(t, repo, nil)
@@ -234,8 +231,7 @@ func TestIntegrationProvisioning_QuotaStatus(t *testing.T) {
 			Copies: map[string]string{
 				"../testdata/all-panels.json": "dashboard1.json",
 			},
-			SkipSync:               true, // Prevent controller auto-sync racing with file copy
-			SkipResourceAssertions: true,
+			SkipSync: true, // Prevent controller auto-sync racing with file copy
 		}
 		helper.CreateLocalRepo(t, testRepo)
 		helper.SyncAndWait(t, repo, nil)
@@ -290,8 +286,7 @@ func TestIntegrationProvisioning_QuotaStatus(t *testing.T) {
 			Copies: map[string]string{
 				"../testdata/all-panels.json": "dashboard1.json",
 			},
-			SkipSync:               true, // Prevent controller auto-sync racing with file copy
-			SkipResourceAssertions: true,
+			SkipSync: true, // Prevent controller auto-sync racing with file copy
 		}
 		helper.CreateLocalRepo(t, testRepo)
 		helper.SyncAndWait(t, repo, nil)

--- a/pkg/tests/apis/provisioning/quota/sync_quota_test.go
+++ b/pkg/tests/apis/provisioning/quota/sync_quota_test.go
@@ -31,8 +31,7 @@ func TestIntegrationProvisioning_SyncQuotaHandling(t *testing.T) {
 				"../testdata/all-panels.json":   "dashboard1.json",
 				"../testdata/text-options.json": "dashboard2.json",
 			},
-			SkipSync:               true,
-			SkipResourceAssertions: true,
+			SkipSync: true,
 		}
 		helper.CreateLocalRepo(t, testRepo)
 		helper.SyncAndWait(t, repo, nil)
@@ -75,8 +74,7 @@ func TestIntegrationProvisioning_SyncQuotaHandling(t *testing.T) {
 			Copies: map[string]string{
 				"../testdata/all-panels.json": "dashboard1.json",
 			},
-			SkipSync:               true,
-			SkipResourceAssertions: true,
+			SkipSync: true,
 		}
 		helper.CreateLocalRepo(t, testRepo)
 		helper.SyncAndWait(t, repo, nil)
@@ -121,8 +119,7 @@ func TestIntegrationProvisioning_SyncQuotaHandling(t *testing.T) {
 				"../testdata/all-panels.json":   "dashboard1.json",
 				"../testdata/text-options.json": "dashboard2.json",
 			},
-			SkipSync:               true,
-			SkipResourceAssertions: true,
+			SkipSync: true,
 		}
 		helper.CreateLocalRepo(t, testRepo)
 		helper.SyncAndWait(t, repo, nil)
@@ -185,8 +182,7 @@ func TestIntegrationProvisioning_SyncQuotaHandling(t *testing.T) {
 			Copies: map[string]string{
 				"../testdata/all-panels.json": "dashboard1.json",
 			},
-			SkipSync:               true,
-			SkipResourceAssertions: true,
+			SkipSync: true,
 		}
 		helper.CreateLocalRepo(t, testRepo)
 		helper.SyncAndWait(t, repo, nil)
@@ -271,8 +267,7 @@ func TestIntegrationProvisioning_SyncQuotaHandling(t *testing.T) {
 				"../testdata/all-panels.json":   "subfolder/dashboard1.json",
 				"../testdata/text-options.json": "subfolder/nested/dashboard2.json",
 			},
-			SkipSync:               true,
-			SkipResourceAssertions: true,
+			SkipSync: true,
 		}
 		helper.CreateLocalRepo(t, testRepo)
 		helper.SyncAndWait(t, repo, nil)
@@ -374,8 +369,7 @@ func TestIntegrationProvisioning_SyncQuotaHandling(t *testing.T) {
 				"../testdata/text-options.json":  "dashboard2.json",
 				"../testdata/timeline-demo.json": "dashboard3.json",
 			},
-			SkipSync:               true,
-			SkipResourceAssertions: true,
+			SkipSync: true,
 		}
 		helper.CreateLocalRepo(t, testRepo)
 		helper.SyncAndWait(t, repo, nil)
@@ -422,8 +416,7 @@ func TestIntegrationProvisioning_SyncQuotaHandling(t *testing.T) {
 				"../testdata/text-options.json":  "dashboard2.json",
 				"../testdata/timeline-demo.json": "dashboard3.json",
 			},
-			SkipSync:               true,
-			SkipResourceAssertions: true,
+			SkipSync: true,
 		}
 		helper.CreateLocalRepo(t, testRepo)
 		helper.SyncAndWait(t, repo, nil)

--- a/pkg/tests/apis/provisioning/repository/pending_delete_test.go
+++ b/pkg/tests/apis/provisioning/repository/pending_delete_test.go
@@ -23,10 +23,9 @@ func TestIntegrationProvisioning_PendingDeleteLabel_SkipsReconciliation(t *testi
 
 	const repoName = "pending-delete-skip-test"
 	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:                   repoName,
-		SyncTarget:             "folder",
-		SkipSync:               true,
-		SkipResourceAssertions: true,
+		Name:       repoName,
+		SyncTarget: "folder",
+		SkipSync:   true,
 	})
 	helper.SyncAndWait(t, repoName, nil)
 

--- a/pkg/tests/apis/provisioning/repository/repository_subresources_auth_test.go
+++ b/pkg/tests/apis/provisioning/repository/repository_subresources_auth_test.go
@@ -1,7 +1,6 @@
 package repository
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -14,7 +13,6 @@ import (
 
 func TestIntegrationProvisioning_RepositorySubresourcesAuthorization(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	const repo = "subresources-auth-test"
 	testRepo := common.TestRepo{
@@ -62,7 +60,7 @@ func TestIntegrationProvisioning_RepositorySubresourcesAuthorization(t *testing.
 				SubResource("test").
 				Body(configBytes).
 				SetHeader("Content-Type", "application/json").
-				Do(ctx).StatusCode(&statusCode)
+				Do(t.Context()).StatusCode(&statusCode)
 
 			require.NoError(t, result.Error(), "admin should be able to POST test")
 			require.Equal(t, http.StatusOK, statusCode, "should return 200 OK")
@@ -77,7 +75,7 @@ func TestIntegrationProvisioning_RepositorySubresourcesAuthorization(t *testing.
 				SubResource("test").
 				Body(configBytes).
 				SetHeader("Content-Type", "application/json").
-				Do(ctx).StatusCode(&statusCode)
+				Do(t.Context()).StatusCode(&statusCode)
 
 			require.Error(t, result.Error(), "editor should not be able to POST test")
 			require.Equal(t, http.StatusForbidden, statusCode, "should return 403 Forbidden")
@@ -93,7 +91,7 @@ func TestIntegrationProvisioning_RepositorySubresourcesAuthorization(t *testing.
 				SubResource("test").
 				Body(configBytes).
 				SetHeader("Content-Type", "application/json").
-				Do(ctx).StatusCode(&statusCode)
+				Do(t.Context()).StatusCode(&statusCode)
 
 			require.Error(t, result.Error(), "viewer should not be able to POST test")
 			require.Equal(t, http.StatusForbidden, statusCode, "should return 403 Forbidden")
@@ -109,7 +107,7 @@ func TestIntegrationProvisioning_RepositorySubresourcesAuthorization(t *testing.
 				Resource("repositories").
 				Name(repo).
 				SubResource("resources").
-				Do(ctx).StatusCode(&statusCode)
+				Do(t.Context()).StatusCode(&statusCode)
 
 			require.NoError(t, result.Error(), "admin should be able to GET resources")
 			require.Equal(t, http.StatusOK, statusCode, "should return 200 OK")
@@ -122,7 +120,7 @@ func TestIntegrationProvisioning_RepositorySubresourcesAuthorization(t *testing.
 				Resource("repositories").
 				Name(repo).
 				SubResource("resources").
-				Do(ctx).StatusCode(&statusCode)
+				Do(t.Context()).StatusCode(&statusCode)
 
 			require.Error(t, result.Error(), "editor should not be able to GET resources")
 			require.Equal(t, http.StatusForbidden, statusCode, "should return 403 Forbidden")
@@ -136,7 +134,7 @@ func TestIntegrationProvisioning_RepositorySubresourcesAuthorization(t *testing.
 				Resource("repositories").
 				Name(repo).
 				SubResource("resources").
-				Do(ctx).StatusCode(&statusCode)
+				Do(t.Context()).StatusCode(&statusCode)
 
 			require.Error(t, result.Error(), "viewer should not be able to GET resources")
 			require.Equal(t, http.StatusForbidden, statusCode, "should return 403 Forbidden")
@@ -152,7 +150,7 @@ func TestIntegrationProvisioning_RepositorySubresourcesAuthorization(t *testing.
 				Resource("repositories").
 				Name(repo).
 				SubResource("history").
-				Do(ctx).StatusCode(&statusCode)
+				Do(t.Context()).StatusCode(&statusCode)
 
 			// Admin should pass authorization - may get BadRequest if repo doesn't support history
 			// but should NOT get Forbidden (which would indicate authorization failure)
@@ -173,7 +171,7 @@ func TestIntegrationProvisioning_RepositorySubresourcesAuthorization(t *testing.
 				Resource("repositories").
 				Name(repo).
 				SubResource("history").
-				Do(ctx).StatusCode(&statusCode)
+				Do(t.Context()).StatusCode(&statusCode)
 
 			require.Error(t, result.Error(), "editor should not be able to GET history")
 			require.Equal(t, http.StatusForbidden, statusCode, "should return 403 Forbidden")
@@ -187,7 +185,7 @@ func TestIntegrationProvisioning_RepositorySubresourcesAuthorization(t *testing.
 				Resource("repositories").
 				Name(repo).
 				SubResource("history").
-				Do(ctx).StatusCode(&statusCode)
+				Do(t.Context()).StatusCode(&statusCode)
 
 			require.Error(t, result.Error(), "viewer should not be able to GET history")
 			require.Equal(t, http.StatusForbidden, statusCode, "should return 403 Forbidden")
@@ -203,7 +201,7 @@ func TestIntegrationProvisioning_RepositorySubresourcesAuthorization(t *testing.
 				Resource("repositories").
 				Name(repo).
 				SubResource("status").
-				Do(ctx).StatusCode(&statusCode)
+				Do(t.Context()).StatusCode(&statusCode)
 
 			require.NoError(t, result.Error(), "admin should be able to GET status")
 			require.Equal(t, http.StatusOK, statusCode, "should return 200 OK")
@@ -216,7 +214,7 @@ func TestIntegrationProvisioning_RepositorySubresourcesAuthorization(t *testing.
 				Resource("repositories").
 				Name(repo).
 				SubResource("status").
-				Do(ctx).StatusCode(&statusCode)
+				Do(t.Context()).StatusCode(&statusCode)
 
 			require.Error(t, result.Error(), "editor should not be able to GET status")
 			require.Equal(t, http.StatusForbidden, statusCode, "should return 403 Forbidden")
@@ -230,7 +228,7 @@ func TestIntegrationProvisioning_RepositorySubresourcesAuthorization(t *testing.
 				Resource("repositories").
 				Name(repo).
 				SubResource("status").
-				Do(ctx).StatusCode(&statusCode)
+				Do(t.Context()).StatusCode(&statusCode)
 
 			require.Error(t, result.Error(), "viewer should not be able to GET status")
 			require.Equal(t, http.StatusForbidden, statusCode, "should return 403 Forbidden")

--- a/pkg/tests/apis/provisioning/repository/repository_subresources_auth_test.go
+++ b/pkg/tests/apis/provisioning/repository/repository_subresources_auth_test.go
@@ -16,13 +16,14 @@ func TestIntegrationProvisioning_RepositorySubresourcesAuthorization(t *testing.
 
 	const repo = "subresources-auth-test"
 	testRepo := common.TestRepo{
-		Name:               repo,
-		SyncTarget:         "folder",
-		Copies:             map[string]string{}, // No files needed for this test
-		ExpectedDashboards: 0,
-		ExpectedFolders:    1, // Repository creates a folder
+		Name:       repo,
+		SyncTarget: "folder",
+		Copies:     map[string]string{}, // No files needed for this test
 	}
 	helper.CreateLocalRepo(t, testRepo)
+
+	helper.RequireRepoDashboardCount(t, repo, 0)
+	helper.RequireRepoFolderCount(t, repo, 1)
 
 	t.Run("test subresource", func(t *testing.T) {
 		newRepoConfig := map[string]any{

--- a/pkg/tests/apis/provisioning/repository/repository_test.go
+++ b/pkg/tests/apis/provisioning/repository/repository_test.go
@@ -1061,9 +1061,10 @@ func TestIntegrationProvisioning_DashboardStrictValidationExempted(t *testing.T)
 		Copies: map[string]string{
 			"../testdata/dashboard-unknown-field.json": "dashboard-unknown-field.json",
 		},
-		ExpectedDashboards: 1,
-		ExpectedFolders:    0,
 	})
+
+	helper.RequireRepoDashboardCount(t, repo, 1)
+	helper.RequireRepoFolderCount(t, repo, 0)
 
 	// The dry run through the files endpoint must succeed despite the unknown
 	// field, because dashboards are exempt from strict validation.
@@ -1103,16 +1104,17 @@ func TestIntegrationProvisioning_CreatingGitHubRepository(t *testing.T) {
 
 	const repo = "github-create-test"
 	testRepo := common.TestRepo{
-		Name:               repo,
-		Template:           common.TestdataPath("github.json.tmpl"),
-		SyncTarget:         "folder",
-		Path:               "grafana/",
-		Workflows:          []string{},
-		ExpectedDashboards: 3,
-		ExpectedFolders:    3, // Folder sync creates an additional folder for the repository itself
+		Name:       repo,
+		Template:   common.TestdataPath("github.json.tmpl"),
+		SyncTarget: "folder",
+		Path:       "grafana/",
+		Workflows:  []string{},
 	}
 
 	helper.CreateLocalRepo(t, testRepo)
+
+	helper.RequireRepoDashboardCount(t, repo, 3)
+	helper.RequireRepoFolderCount(t, repo, 3)
 
 	// By now, we should have synced, meaning we have data to read in the local Grafana instance!
 
@@ -1479,10 +1481,9 @@ func TestIntegrationProvisioning_WebhookRejectedForUnhealthyRepository(t *testin
 	require.NoError(t, os.MkdirAll(repoPath, 0o750))
 
 	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:                   repoName,
-		LocalPath:              repoPath,
-		SyncTarget:             "folder",
-		SkipResourceAssertions: true,
+		Name:       repoName,
+		LocalPath:  repoPath,
+		SyncTarget: "folder",
 	})
 	helper.WaitForHealthyRepository(t, repoName)
 
@@ -1536,13 +1537,13 @@ func TestIntegrationProvisioning_RunLocalRepository(t *testing.T) {
 
 	// Set up the repository.
 	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:                   repo,
-		SyncTarget:             "folder",
-		Workflows:              []string{"write"},
-		ExpectedDashboards:     0,
-		ExpectedFolders:        1, // folder sync creates a folder for the repo
-		SkipResourceAssertions: false,
+		Name:       repo,
+		SyncTarget: "folder",
+		Workflows:  []string{"write"},
 	})
+
+	helper.RequireRepoDashboardCount(t, repo, 0)
+	helper.RequireRepoFolderCount(t, repo, 1)
 
 	// Write a file -- this will create it *both* in the local file system, and in grafana
 	t.Run("write all panels", func(t *testing.T) {
@@ -1724,15 +1725,16 @@ func TestIntegrationProvisioning_ImportAllPanelsFromLocalRepository(t *testing.T
 	const repo = "local-tmp"
 	// Set up the repository and the file to import.
 	testRepo := common.TestRepo{
-		Name:               repo,
-		SyncTarget:         "folder",
-		Workflows:          []string{"write"},
-		Copies:             map[string]string{"../testdata/all-panels.json": "all-panels.json"},
-		ExpectedDashboards: 1,
-		ExpectedFolders:    1, // folder sync creates a folder
+		Name:       repo,
+		SyncTarget: "folder",
+		Workflows:  []string{"write"},
+		Copies:     map[string]string{"../testdata/all-panels.json": "all-panels.json"},
 	}
 	// We create the repository
 	helper.CreateLocalRepo(t, testRepo)
+
+	helper.RequireRepoDashboardCount(t, repo, 1)
+	helper.RequireRepoFolderCount(t, repo, 1)
 
 	// Now, we import it, such that it may exist
 	// The sync may not be necessary as the sync may have happened automatically at this point
@@ -1782,15 +1784,16 @@ func TestIntegrationProvisioning_DeleteRepositoryAndReleaseResources(t *testing.
 
 	const repo = "gh-repo"
 	testRepo := common.TestRepo{
-		Name:               repo,
-		Template:           common.TestdataPath("github.json.tmpl"),
-		SyncTarget:         "folder",
-		Path:               "grafana/",
-		Workflows:          []string{},
-		ExpectedDashboards: 3,
-		ExpectedFolders:    3,
+		Name:       repo,
+		Template:   common.TestdataPath("github.json.tmpl"),
+		SyncTarget: "folder",
+		Path:       "grafana/",
+		Workflows:  []string{},
 	}
 	helper.CreateLocalRepo(t, testRepo)
+
+	helper.RequireRepoDashboardCount(t, repo, 3)
+	helper.RequireRepoFolderCount(t, repo, 3)
 
 	// Checking resources are there and are managed
 	foundFolders, err := helper.Folders.Resource.List(t.Context(), metav1.ListOptions{})
@@ -1845,10 +1848,9 @@ func TestIntegrationProvisioning_DeleteRepositoryAndCleanupClassicDashboards(t *
 		require.NoError(t, os.WriteFile(filepath.Join(repoPath, "classic.json"), classicDashboard, 0o600))
 
 		helper.CreateLocalRepo(t, common.TestRepo{
-			Name:                   repo,
-			LocalPath:              repoPath,
-			SyncTarget:             "folder",
-			SkipResourceAssertions: true,
+			Name:       repo,
+			LocalPath:  repoPath,
+			SyncTarget: "folder",
 		})
 
 		helper.RequireRepoDashboardCount(t, repo, 1)
@@ -1884,10 +1886,9 @@ func TestIntegrationProvisioning_DeleteRepositoryAndCleanupClassicDashboards(t *
 		require.NoError(t, os.WriteFile(filepath.Join(repoPath, "classic.json"), classicDashboard, 0o600))
 
 		helper.CreateLocalRepo(t, common.TestRepo{
-			Name:                   repo,
-			LocalPath:              repoPath,
-			SyncTarget:             "folder",
-			SkipResourceAssertions: true,
+			Name:       repo,
+			LocalPath:  repoPath,
+			SyncTarget: "folder",
 		})
 
 		helper.RequireRepoDashboardCount(t, repo, 1)
@@ -1923,14 +1924,15 @@ func TestIntegrationProvisioning_JobPermissions(t *testing.T) {
 
 	const repo = "job-permissions-test"
 	testRepo := common.TestRepo{
-		Name:               repo,
-		SyncTarget:         "folder",
-		Workflows:          []string{"write"},
-		Copies:             map[string]string{}, // No files needed for this test
-		ExpectedDashboards: 0,
-		ExpectedFolders:    1, // Repository creates a folder
+		Name:       repo,
+		SyncTarget: "folder",
+		Workflows:  []string{"write"},
+		Copies:     map[string]string{}, // No files needed for this test
 	}
 	helper.CreateLocalRepo(t, testRepo)
+
+	helper.RequireRepoDashboardCount(t, repo, 0)
+	helper.RequireRepoFolderCount(t, repo, 1)
 
 	adminJobBody := common.AsJSON(provisioning.JobSpec{
 		Action: provisioning.JobActionPull,
@@ -2007,15 +2009,16 @@ func TestIntegrationProvisioning_RefsPermissions(t *testing.T) {
 
 	const repo = "refs-permissions-test"
 	testRepo := common.TestRepo{
-		Name:               repo,
-		Template:           common.TestdataPath("github.json.tmpl"),
-		SyncTarget:         "folder",
-		Path:               "grafana/",
-		Workflows:          []string{},
-		ExpectedDashboards: 3,
-		ExpectedFolders:    3, // Repository creates folders
+		Name:       repo,
+		Template:   common.TestdataPath("github.json.tmpl"),
+		SyncTarget: "folder",
+		Path:       "grafana/",
+		Workflows:  []string{},
 	}
 	helper.CreateLocalRepo(t, testRepo)
+
+	helper.RequireRepoDashboardCount(t, repo, 3)
+	helper.RequireRepoFolderCount(t, repo, 3)
 
 	t.Run("editor can GET refs", func(t *testing.T) {
 		var statusCode int
@@ -2070,14 +2073,15 @@ func TestIntegrationProvisioning_EmptyPath(t *testing.T) {
 	t.Run("repository with empty path syncs from root", func(t *testing.T) {
 		const repo = "empty-path-test"
 		testRepo := common.TestRepo{
-			Name:               repo,
-			Template:           common.TestdataPath("github.json.tmpl"),
-			SyncTarget:         "folder",
-			Workflows:          []string{},
-			ExpectedDashboards: 3, // Syncs 3 dashboards from grafana/ directory
-			ExpectedFolders:    6, // Creates 6 folders: repo root, assets, gifs, grafana, DemoFolder, DemoDeeperFolder
+			Name:       repo,
+			Template:   common.TestdataPath("github.json.tmpl"),
+			SyncTarget: "folder",
+			Workflows:  []string{},
 		}
 		helper.CreateLocalRepo(t, testRepo)
+
+		helper.RequireRepoDashboardCount(t, repo, 3)
+		helper.RequireRepoFolderCount(t, repo, 6)
 
 		// Verify the repository has empty path
 		repoObj, err := helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{})
@@ -2097,14 +2101,15 @@ func TestIntegrationProvisioning_EmptyPath(t *testing.T) {
 
 		// Step 1: Create first repository with empty path - syncs successfully
 		testRepo1 := common.TestRepo{
-			Name:               repo1,
-			Template:           common.TestdataPath("github.json.tmpl"),
-			SyncTarget:         "folder",
-			Workflows:          []string{},
-			ExpectedDashboards: 3, // Successfully syncs 3 dashboards
-			ExpectedFolders:    6, // Successfully creates 6 folders
+			Name:       repo1,
+			Template:   common.TestdataPath("github.json.tmpl"),
+			SyncTarget: "folder",
+			Workflows:  []string{},
 		}
 		helper.CreateLocalRepo(t, testRepo1)
+
+		helper.RequireRepoDashboardCount(t, repo1, 3)
+		helper.RequireRepoFolderCount(t, repo1, 6)
 
 		// Step 2: Create second repository with same URL, branch, and empty path.
 		// Empty path represents the repository root, so this is a duplicate path.
@@ -2133,6 +2138,7 @@ func TestIntegrationProvisioning_EmptyPath(t *testing.T) {
 
 func TestIntegrationProvisioning_RepositoryConnection(t *testing.T) {
 	helper := sharedHelper(t)
+
 	createOptions := metav1.CreateOptions{FieldValidation: "Strict"}
 	privateKeyBase64 := base64.StdEncoding.EncodeToString([]byte(testPrivateKeyPEM))
 
@@ -2303,6 +2309,7 @@ func TestIntegrationProvisioning_RepositoryConnection(t *testing.T) {
 
 func TestIntegrationProvisioning_RepositoryUnhealthyWithValidationErrors(t *testing.T) {
 	helper := sharedHelper(t)
+
 	namespace := "default"
 
 	// Create typed client from REST config
@@ -2489,6 +2496,7 @@ func TestIntegrationProvisioning_RepositoryUnhealthyWithValidationErrors(t *test
 
 func TestIntegrationRepositoryController_FieldErrorsCleared(t *testing.T) {
 	helper := sharedHelper(t)
+
 	namespace := "default"
 
 	// Create typed client from REST config
@@ -2625,6 +2633,7 @@ func TestIntegrationRepositoryController_FieldErrorsCleared(t *testing.T) {
 
 func TestIntegrationRepositoryController_DefaultBranch(t *testing.T) {
 	helper := sharedHelper(t)
+
 	namespace := "default"
 	defaultBranchName := "defaultBranchName"
 
@@ -2827,13 +2836,14 @@ func TestIntegrationProvisioning_FolderTitleUpdatesOnSync(t *testing.T) {
 	const updatedTitle = "Updated Folder Title"
 
 	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:               repoName,
-		SyncTarget:         "folder",
-		Copies:             map[string]string{"../testdata/all-panels.json": "all-panels.json"},
-		ExpectedDashboards: 1,
-		ExpectedFolders:    1,
-		Title:              initialTitle,
+		Name:       repoName,
+		SyncTarget: "folder",
+		Copies:     map[string]string{"../testdata/all-panels.json": "all-panels.json"},
+		Title:      initialTitle,
 	})
+
+	helper.RequireRepoDashboardCount(t, repoName, 1)
+	helper.RequireRepoFolderCount(t, repoName, 1)
 
 	// Verify the root folder has the initial title.
 	// The root folder for a folder-sync repo has the same name as the repository.

--- a/pkg/tests/apis/provisioning/repository/repository_test.go
+++ b/pkg/tests/apis/provisioning/repository/repository_test.go
@@ -69,7 +69,6 @@ u5/wOyuHp1cIBnjeN41/pluOWFBHI9xLW3ExLtmYMiecJ8VdRA==
 func TestIntegrationProvisioning_CreatingAndGetting(t *testing.T) {
 	helper := sharedHelper(t)
 	createOptions := metav1.CreateOptions{FieldValidation: "Strict"}
-	ctx := context.Background()
 
 	inputFiles := []struct {
 		path   string
@@ -84,10 +83,10 @@ func TestIntegrationProvisioning_CreatingAndGetting(t *testing.T) {
 			input := helper.RenderObject(t, inputFile.path, inputFile.values)
 			name := common.MustNestedString(input.Object, "metadata", "name")
 
-			_, err := helper.Repositories.Resource.Create(ctx, input, createOptions)
+			_, err := helper.Repositories.Resource.Create(t.Context(), input, createOptions)
 			require.NoError(t, err, "failed to create resource")
 
-			output, err := helper.Repositories.Resource.Get(ctx, name, metav1.GetOptions{})
+			output, err := helper.Repositories.Resource.Get(t.Context(), name, metav1.GetOptions{})
 			require.NoError(t, err, "failed to read back resource")
 
 			// Move encrypted token mutation
@@ -319,7 +318,6 @@ func TestIntegrationProvisioning_ViewerSettings_CustomRepositoryTypes(t *testing
 
 func TestIntegrationProvisioning_RepositoryValidation(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	for _, testCase := range []struct {
 		name        string
@@ -583,7 +581,7 @@ func TestIntegrationProvisioning_RepositoryValidation(t *testing.T) {
 		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
-			_, err := helper.Repositories.Resource.Create(ctx, testCase.repo, metav1.CreateOptions{})
+			_, err := helper.Repositories.Resource.Create(t.Context(), testCase.repo, metav1.CreateOptions{})
 			if testCase.expectedErr == "" {
 				assert.NoError(t, err)
 			} else {
@@ -641,7 +639,7 @@ func TestIntegrationProvisioning_RepositoryValidation(t *testing.T) {
 					"WorkflowsJSON": `[]`,
 				})
 
-				_, err := helper.Repositories.Resource.Create(ctx, gitRepo, metav1.CreateOptions{FieldValidation: "Strict"})
+				_, err := helper.Repositories.Resource.Create(t.Context(), gitRepo, metav1.CreateOptions{FieldValidation: "Strict"})
 
 				if test.expectError != nil {
 					require.Error(t, err, "Expected error for repository with path: %s", test.path)
@@ -673,7 +671,7 @@ func TestIntegrationProvisioning_RepositoryValidation(t *testing.T) {
 			"SyncTarget":    "folder",
 			"WorkflowsJSON": `[]`,
 		})
-		_, err := helper.Repositories.Resource.Create(ctx, firstRepo, metav1.CreateOptions{FieldValidation: "Strict"})
+		_, err := helper.Repositories.Resource.Create(t.Context(), firstRepo, metav1.CreateOptions{FieldValidation: "Strict"})
 		require.NoError(t, err, "First repository should be created successfully")
 
 		// Create a second repo pointing to same URL with a child path and sync disabled.
@@ -686,7 +684,7 @@ func TestIntegrationProvisioning_RepositoryValidation(t *testing.T) {
 			"SyncTarget":    "folder",
 			"WorkflowsJSON": `[]`,
 		})
-		_, err = helper.Repositories.Resource.Create(ctx, secondRepo, metav1.CreateOptions{FieldValidation: "Strict"})
+		_, err = helper.Repositories.Resource.Create(t.Context(), secondRepo, metav1.CreateOptions{FieldValidation: "Strict"})
 		require.NoError(t, err, "Second repository with child path should succeed when sync is disabled")
 
 		// Create a third repo with the same path (duplicate) and sync disabled
@@ -698,7 +696,7 @@ func TestIntegrationProvisioning_RepositoryValidation(t *testing.T) {
 			"SyncTarget":    "folder",
 			"WorkflowsJSON": `[]`,
 		})
-		_, err = helper.Repositories.Resource.Create(ctx, thirdRepo, metav1.CreateOptions{FieldValidation: "Strict"})
+		_, err = helper.Repositories.Resource.Create(t.Context(), thirdRepo, metav1.CreateOptions{FieldValidation: "Strict"})
 		require.NoError(t, err, "Third repository with duplicate path should succeed when sync is disabled")
 
 		// Create a fourth repo with empty path (root) and sync disabled - wizard step 1 scenario
@@ -710,7 +708,7 @@ func TestIntegrationProvisioning_RepositoryValidation(t *testing.T) {
 			"SyncTarget":    "folder",
 			"WorkflowsJSON": `[]`,
 		})
-		_, err = helper.Repositories.Resource.Create(ctx, fourthRepo, metav1.CreateOptions{FieldValidation: "Strict"})
+		_, err = helper.Repositories.Resource.Create(t.Context(), fourthRepo, metav1.CreateOptions{FieldValidation: "Strict"})
 		require.NoError(t, err, "Fourth repository with empty path should succeed when sync is disabled")
 	})
 
@@ -729,7 +727,7 @@ func TestIntegrationProvisioning_RepositoryValidation(t *testing.T) {
 			"SyncTarget":    "folder",
 			"WorkflowsJSON": `[]`,
 		})
-		_, err := helper.Repositories.Resource.Create(ctx, firstRepo, metav1.CreateOptions{FieldValidation: "Strict"})
+		_, err := helper.Repositories.Resource.Create(t.Context(), firstRepo, metav1.CreateOptions{FieldValidation: "Strict"})
 		require.NoError(t, err, "First repository should be created successfully")
 
 		// Create second repo with conflicting child path but sync disabled (should succeed)
@@ -741,12 +739,12 @@ func TestIntegrationProvisioning_RepositoryValidation(t *testing.T) {
 			"SyncTarget":    "folder",
 			"WorkflowsJSON": `[]`,
 		})
-		created, err := helper.Repositories.Resource.Create(ctx, secondRepo, metav1.CreateOptions{FieldValidation: "Strict"})
+		created, err := helper.Repositories.Resource.Create(t.Context(), secondRepo, metav1.CreateOptions{FieldValidation: "Strict"})
 		require.NoError(t, err, "Second repository with child path should succeed when sync is disabled")
 
 		// Now try to enable sync on the second repo - this should fail due to parent/child conflict
 		created.Object["spec"].(map[string]interface{})["sync"].(map[string]interface{})["enabled"] = true
-		_, err = helper.Repositories.Resource.Update(ctx, created, metav1.UpdateOptions{FieldValidation: "Strict"})
+		_, err = helper.Repositories.Resource.Update(t.Context(), created, metav1.UpdateOptions{FieldValidation: "Strict"})
 		require.Error(t, err, "Enabling sync should fail due to parent/child path conflict")
 		require.ErrorContains(t, err, provisioningAPIServer.ErrRepositoryParentFolderConflict.Error())
 	})
@@ -805,7 +803,7 @@ func TestIntegrationProvisioning_RepositoryValidation(t *testing.T) {
 					"WorkflowsJSON": `[]`,
 				})
 
-				_, err := helper.Repositories.Resource.Create(ctx, gitRepo, metav1.CreateOptions{FieldValidation: "Strict"})
+				_, err := helper.Repositories.Resource.Create(t.Context(), gitRepo, metav1.CreateOptions{FieldValidation: "Strict"})
 
 				if test.expectError != nil {
 					require.Error(t, err, "Expected error for repo branch=%s path=%s", test.branch, test.path)
@@ -834,7 +832,7 @@ func TestIntegrationProvisioning_RepositoryValidation(t *testing.T) {
 			"SyncTarget":    "folder",
 			"WorkflowsJSON": `[]`,
 		})
-		_, err := helper.Repositories.Resource.Create(ctx, firstRepo, metav1.CreateOptions{FieldValidation: "Strict"})
+		_, err := helper.Repositories.Resource.Create(t.Context(), firstRepo, metav1.CreateOptions{FieldValidation: "Strict"})
 		require.NoError(t, err, "First repository with empty path should succeed")
 
 		secondRepo := helper.RenderObject(t, common.TestdataPath("github.json.tmpl"), map[string]any{
@@ -846,7 +844,7 @@ func TestIntegrationProvisioning_RepositoryValidation(t *testing.T) {
 			"SyncTarget":    "folder",
 			"WorkflowsJSON": `[]`,
 		})
-		_, err = helper.Repositories.Resource.Create(ctx, secondRepo, metav1.CreateOptions{FieldValidation: "Strict"})
+		_, err = helper.Repositories.Resource.Create(t.Context(), secondRepo, metav1.CreateOptions{FieldValidation: "Strict"})
 		require.Error(t, err, "Second repository with same URL, branch, and empty path should fail")
 		require.ErrorContains(t, err, provisioningAPIServer.ErrRepositoryDuplicatePath.Error())
 		var statusError *apierrors.StatusError
@@ -864,7 +862,7 @@ func TestIntegrationProvisioning_RepositoryValidation(t *testing.T) {
 			"SyncTarget":    "folder",
 			"WorkflowsJSON": `[]`,
 		})
-		_, err = helper.Repositories.Resource.Create(ctx, thirdRepo, metav1.CreateOptions{FieldValidation: "Strict"})
+		_, err = helper.Repositories.Resource.Create(t.Context(), thirdRepo, metav1.CreateOptions{FieldValidation: "Strict"})
 		require.NoError(t, err, "Third repository with different branch and empty path should succeed")
 	})
 
@@ -880,7 +878,7 @@ func TestIntegrationProvisioning_RepositoryValidation(t *testing.T) {
 			"SyncTarget":    "folder",
 			"WorkflowsJSON": `[]`,
 		})
-		_, err := helper.Repositories.Resource.Create(ctx, firstRepo, metav1.CreateOptions{FieldValidation: "Strict"})
+		_, err := helper.Repositories.Resource.Create(t.Context(), firstRepo, metav1.CreateOptions{FieldValidation: "Strict"})
 		require.NoError(t, err, "First repository with sync disabled should succeed")
 
 		secondRepo := helper.RenderObject(t, common.TestdataPath("github.json.tmpl"), map[string]any{
@@ -892,7 +890,7 @@ func TestIntegrationProvisioning_RepositoryValidation(t *testing.T) {
 			"SyncTarget":    "folder",
 			"WorkflowsJSON": `[]`,
 		})
-		_, err = helper.Repositories.Resource.Create(ctx, secondRepo, metav1.CreateOptions{FieldValidation: "Strict"})
+		_, err = helper.Repositories.Resource.Create(t.Context(), secondRepo, metav1.CreateOptions{FieldValidation: "Strict"})
 		require.NoError(t, err, "Second repository with duplicate path should succeed when sync is disabled")
 
 		thirdRepo := helper.RenderObject(t, common.TestdataPath("github.json.tmpl"), map[string]any{
@@ -904,7 +902,7 @@ func TestIntegrationProvisioning_RepositoryValidation(t *testing.T) {
 			"SyncTarget":    "folder",
 			"WorkflowsJSON": `[]`,
 		})
-		_, err = helper.Repositories.Resource.Create(ctx, thirdRepo, metav1.CreateOptions{FieldValidation: "Strict"})
+		_, err = helper.Repositories.Resource.Create(t.Context(), thirdRepo, metav1.CreateOptions{FieldValidation: "Strict"})
 		require.NoError(t, err, "Third repository with different branch should succeed when sync is disabled")
 
 		fourthRepo := helper.RenderObject(t, common.TestdataPath("github.json.tmpl"), map[string]any{
@@ -916,7 +914,7 @@ func TestIntegrationProvisioning_RepositoryValidation(t *testing.T) {
 			"SyncTarget":    "folder",
 			"WorkflowsJSON": `[]`,
 		})
-		_, err = helper.Repositories.Resource.Create(ctx, fourthRepo, metav1.CreateOptions{FieldValidation: "Strict"})
+		_, err = helper.Repositories.Resource.Create(t.Context(), fourthRepo, metav1.CreateOptions{FieldValidation: "Strict"})
 		require.NoError(t, err, "Fourth repository with parent-child path should succeed when sync is disabled")
 	})
 
@@ -928,7 +926,7 @@ func TestIntegrationProvisioning_RepositoryValidation(t *testing.T) {
 			"Path":                helper.ProvisioningPath,
 			"WorkflowsJSON":       `[]`,
 		})
-		created, err := helper.Repositories.Resource.Create(ctx, r, metav1.CreateOptions{})
+		created, err := helper.Repositories.Resource.Create(t.Context(), r, metav1.CreateOptions{})
 		require.NoError(t, err)
 
 		createdRepo := common.MustFromUnstructured[provisioning.Repository](t, created)
@@ -946,7 +944,7 @@ func TestIntegrationProvisioning_RepositoryValidation(t *testing.T) {
 		// Verify the template doesn't have finalizers set (or set them explicitly to nil)
 		r.SetFinalizers(nil)
 
-		created, err := helper.Repositories.Resource.Create(ctx, r, metav1.CreateOptions{})
+		created, err := helper.Repositories.Resource.Create(t.Context(), r, metav1.CreateOptions{})
 		require.NoError(t, err, "repository creation should succeed")
 
 		// Verify finalizers were automatically added by the mutator
@@ -965,7 +963,7 @@ func TestIntegrationProvisioning_RepositoryValidation(t *testing.T) {
 			"WorkflowsJSON": `[]`,
 		})
 
-		created, err := helper.Repositories.Resource.Create(ctx, r, metav1.CreateOptions{})
+		created, err := helper.Repositories.Resource.Create(t.Context(), r, metav1.CreateOptions{})
 		require.NoError(t, err, "repository creation should succeed")
 
 		createdRepo := common.MustFromUnstructured[provisioning.Repository](t, created)
@@ -974,12 +972,12 @@ func TestIntegrationProvisioning_RepositoryValidation(t *testing.T) {
 		require.Contains(t, createdRepo.Finalizers, repository.CleanFinalizer, "should contain CleanFinalizer")
 
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
-			storedRepo, err := helper.Repositories.Resource.Get(ctx, "repo-update-finalizers", metav1.GetOptions{})
+			storedRepo, err := helper.Repositories.Resource.Get(t.Context(), "repo-update-finalizers", metav1.GetOptions{})
 			require.NoError(t, err, "repository retrieve should succeed")
 
 			// Update the repository and try to remove finalizers
 			storedRepo.SetFinalizers([]string{})
-			updated, err := helper.Repositories.Resource.Update(ctx, storedRepo, metav1.UpdateOptions{})
+			updated, err := helper.Repositories.Resource.Update(t.Context(), storedRepo, metav1.UpdateOptions{})
 			require.NoError(collect, err, "repository update should succeed")
 
 			// Verify finalizers were re-added by the mutator
@@ -995,7 +993,6 @@ func TestIntegrationProvisioning_FailInvalidSchema(t *testing.T) {
 	t.Skip("Reenable this test once we enforce schema validation for provisioning")
 
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	const repo = "invalid-schema-tmp"
 	// Set up the repository and the file to import.
@@ -1007,16 +1004,16 @@ func TestIntegrationProvisioning_FailInvalidSchema(t *testing.T) {
 		"Path":          helper.ProvisioningPath,
 		"WorkflowsJSON": `["write"]`,
 	})
-	_, err := helper.Repositories.Resource.Create(ctx, localTmp, metav1.CreateOptions{})
+	_, err := helper.Repositories.Resource.Create(t.Context(), localTmp, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	// Make sure the repo can read and validate the file
-	_, err = helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "invalid-dashboard-schema.json")
+	_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "invalid-dashboard-schema.json")
 	status := helper.RequireApiErrorStatus(err, metav1.StatusReasonBadRequest, http.StatusBadRequest)
 	require.Equal(t, status.Message, "Dry run failed: Dashboard.dashboard.grafana.app \"invalid-schema-uid\" is invalid: [spec.panels.0.repeatDirection: Invalid value: conflicting values \"h\" and \"this is not an allowed value\", spec.panels.0.repeatDirection: Invalid value: conflicting values \"v\" and \"this is not an allowed value\"]")
 
 	const invalidSchemaUid = "invalid-schema-uid"
-	_, err = helper.DashboardsV1.Resource.Get(ctx, invalidSchemaUid, metav1.GetOptions{})
+	_, err = helper.DashboardsV1.Resource.Get(t.Context(), invalidSchemaUid, metav1.GetOptions{})
 	require.Error(t, err, "invalid dashboard shouldn't exist")
 	require.True(t, apierrors.IsNotFound(err))
 
@@ -1036,11 +1033,11 @@ func TestIntegrationProvisioning_FailInvalidSchema(t *testing.T) {
 	assert.Equal(t, job.Status.Message, "completed with errors")
 	assert.Equal(t, job.Status.Errors[0], "Dashboard.dashboard.grafana.app \"invalid-schema-uid\" is invalid: [spec.panels.0.repeatDirection: Invalid value: conflicting values \"h\" and \"this is not an allowed value\", spec.panels.0.repeatDirection: Invalid value: conflicting values \"v\" and \"this is not an allowed value\"]")
 
-	_, err = helper.DashboardsV1.Resource.Get(ctx, invalidSchemaUid, metav1.GetOptions{})
+	_, err = helper.DashboardsV1.Resource.Get(t.Context(), invalidSchemaUid, metav1.GetOptions{})
 	require.Error(t, err, "invalid dashboard shouldn't have been created")
 	require.True(t, apierrors.IsNotFound(err))
 
-	err = helper.Repositories.Resource.Delete(ctx, repo, metav1.DeleteOptions{}, "files", "invalid-dashboard-schema.json")
+	err = helper.Repositories.Resource.Delete(t.Context(), repo, metav1.DeleteOptions{}, "files", "invalid-dashboard-schema.json")
 	require.NoError(t, err, "should delete the resource file")
 }
 
@@ -1055,7 +1052,6 @@ func TestIntegrationProvisioning_FailInvalidSchema(t *testing.T) {
 // guard for the exemption, not just a happy-path check.
 func TestIntegrationProvisioning_DashboardStrictValidationExempted(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	const repo = "dashboard-strict-exempt"
 	helper.CreateLocalRepo(t, common.TestRepo{
@@ -1071,20 +1067,19 @@ func TestIntegrationProvisioning_DashboardStrictValidationExempted(t *testing.T)
 
 	// The dry run through the files endpoint must succeed despite the unknown
 	// field, because dashboards are exempt from strict validation.
-	_, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "dashboard-unknown-field.json")
+	_, err := helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "dashboard-unknown-field.json")
 	require.NoError(t, err, "dry run of a dashboard with an unknown field should succeed while dashboards are exempt from strict validation")
 
 	// The dashboard must exist in Grafana after sync.
 	const dashboardUID = "dashboard-unknown-field"
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		_, err := helper.DashboardsV1.Resource.Get(ctx, dashboardUID, metav1.GetOptions{})
+		_, err := helper.DashboardsV1.Resource.Get(t.Context(), dashboardUID, metav1.GetOptions{})
 		assert.NoError(collect, err, "dashboard with an unknown field should have been created via the strict-validation exemption")
 	}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "dashboard with an unknown field should exist after sync")
 }
 
 func TestIntegrationProvisioning_CreatingGitHubRepository(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	// FIXME: instead of using an existing GitHub repository, we should create a new one for the tests and a branch
 	// This was the previous structure
@@ -1121,7 +1116,7 @@ func TestIntegrationProvisioning_CreatingGitHubRepository(t *testing.T) {
 
 	// By now, we should have synced, meaning we have data to read in the local Grafana instance!
 
-	found, err := helper.DashboardsV1.Resource.List(ctx, metav1.ListOptions{})
+	found, err := helper.DashboardsV1.Resource.List(t.Context(), metav1.ListOptions{})
 	require.NoError(t, err, "can list values")
 
 	names := make([]string, 0, len(found.Items))
@@ -1133,11 +1128,11 @@ func TestIntegrationProvisioning_CreatingGitHubRepository(t *testing.T) {
 	assert.Contains(t, names, "admfz74", "should contain dashboard2.yaml's contents")
 	assert.Contains(t, names, "adn5mxb", "should contain dashboard2.yaml's contents")
 
-	err = helper.Repositories.Resource.Delete(ctx, repo, metav1.DeleteOptions{})
+	err = helper.Repositories.Resource.Delete(t.Context(), repo, metav1.DeleteOptions{})
 	require.NoError(t, err, "should delete values")
 
-	common.WaitForResourcesDeleted(t, ctx, helper.DashboardsV1.Resource, "dashboards")
-	helper.WaitForRepositoryDeleted(t, ctx, repo)
+	common.WaitForResourcesDeleted(t, helper.DashboardsV1.Resource, "dashboards")
+	helper.WaitForRepositoryDeleted(t, repo)
 
 	t.Run("github url cleanup", func(t *testing.T) {
 		tests := []struct {
@@ -1174,10 +1169,10 @@ func TestIntegrationProvisioning_CreatingGitHubRepository(t *testing.T) {
 					"WorkflowsJSON": `[]`,
 				})
 
-				_, err := helper.Repositories.Resource.Create(ctx, input, metav1.CreateOptions{})
+				_, err := helper.Repositories.Resource.Create(t.Context(), input, metav1.CreateOptions{})
 				require.NoError(t, err, "failed to create resource")
 
-				obj, err := helper.Repositories.Resource.Get(ctx, test.name, metav1.GetOptions{})
+				obj, err := helper.Repositories.Resource.Get(t.Context(), test.name, metav1.GetOptions{})
 				require.NoError(t, err, "failed to read back resource")
 
 				url, _, err := unstructured.NestedString(obj.Object, "spec", "github", "url")
@@ -1190,7 +1185,6 @@ func TestIntegrationProvisioning_CreatingGitHubRepository(t *testing.T) {
 
 func TestIntegrationProvisioning_ReadOnlyRepositoryNoWebhook(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	t.Run("repository with no workflows should not create a webhook", func(t *testing.T) {
 		repoName := "readonly-no-webhook"
@@ -1200,12 +1194,12 @@ func TestIntegrationProvisioning_ReadOnlyRepositoryNoWebhook(t *testing.T) {
 			"WorkflowsJSON": `[]`,
 		})
 
-		_, err := helper.Repositories.Resource.Create(ctx, input, metav1.CreateOptions{})
+		_, err := helper.Repositories.Resource.Create(t.Context(), input, metav1.CreateOptions{})
 		require.NoError(t, err, "failed to create read-only repository")
 
 		helper.WaitForHealthyRepository(t, repoName)
 
-		repoObj, err := helper.Repositories.Resource.Get(ctx, repoName, metav1.GetOptions{})
+		repoObj, err := helper.Repositories.Resource.Get(t.Context(), repoName, metav1.GetOptions{})
 		require.NoError(t, err, "failed to get repository")
 
 		repo := common.MustFromUnstructured[provisioning.Repository](t, repoObj)
@@ -1216,7 +1210,6 @@ func TestIntegrationProvisioning_ReadOnlyRepositoryNoWebhook(t *testing.T) {
 
 func TestIntegrationProvisioning_WebhookFailureDoesNotRetryImmediately(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	var webhookCreateCalls atomic.Int32
 
@@ -1262,15 +1255,16 @@ func TestIntegrationProvisioning_WebhookFailureDoesNotRetryImmediately(t *testin
 		"baseUrl": "https://grafana.example.com",
 	}
 
-	_, err := helper.Repositories.Resource.Create(ctx, input, metav1.CreateOptions{})
+	_, err := helper.Repositories.Resource.Create(t.Context(), input, metav1.CreateOptions{})
 	require.NoError(t, err, "failed to create repository")
 
 	t.Cleanup(func() {
-		_ = helper.Repositories.Resource.Delete(ctx, repoName, metav1.DeleteOptions{})
+		cleanupCtx := context.WithoutCancel(t.Context())
+		_ = helper.Repositories.Resource.Delete(cleanupCtx, repoName, metav1.DeleteOptions{})
 	})
 
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		repoObj, err := helper.Repositories.Resource.Get(ctx, repoName, metav1.GetOptions{})
+		repoObj, err := helper.Repositories.Resource.Get(t.Context(), repoName, metav1.GetOptions{})
 		if !assert.NoError(collect, err, "failed to get repository") {
 			return
 		}
@@ -1289,7 +1283,6 @@ func TestIntegrationProvisioning_WebhookFailureDoesNotRetryImmediately(t *testin
 
 func TestIntegrationProvisioning_WebhookConfig(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	t.Run("create repository with HTTPS webhook base URL", func(t *testing.T) {
 		repo := &unstructured.Unstructured{Object: map[string]any{
@@ -1320,7 +1313,7 @@ func TestIntegrationProvisioning_WebhookConfig(t *testing.T) {
 			},
 		}}
 
-		created, err := helper.Repositories.Resource.Create(ctx, repo, metav1.CreateOptions{})
+		created, err := helper.Repositories.Resource.Create(t.Context(), repo, metav1.CreateOptions{})
 		require.NoError(t, err, "should create repository with webhook config")
 
 		createdRepo := common.MustFromUnstructured[provisioning.Repository](t, created)
@@ -1357,7 +1350,7 @@ func TestIntegrationProvisioning_WebhookConfig(t *testing.T) {
 			},
 		}}
 
-		created, err := helper.Repositories.Resource.Create(ctx, repo, metav1.CreateOptions{})
+		created, err := helper.Repositories.Resource.Create(t.Context(), repo, metav1.CreateOptions{})
 		require.NoError(t, err, "should accept HTTP webhook base URL")
 
 		createdRepo := common.MustFromUnstructured[provisioning.Repository](t, created)
@@ -1366,7 +1359,7 @@ func TestIntegrationProvisioning_WebhookConfig(t *testing.T) {
 	})
 
 	t.Run("read back webhook config", func(t *testing.T) {
-		obj, err := helper.Repositories.Resource.Get(ctx, "repo-with-webhook", metav1.GetOptions{})
+		obj, err := helper.Repositories.Resource.Get(t.Context(), "repo-with-webhook", metav1.GetOptions{})
 		require.NoError(t, err, "should read back repository")
 
 		repo := common.MustFromUnstructured[provisioning.Repository](t, obj)
@@ -1376,14 +1369,14 @@ func TestIntegrationProvisioning_WebhookConfig(t *testing.T) {
 
 	t.Run("update repository to change webhook base URL", func(t *testing.T) {
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
-			obj, err := helper.Repositories.Resource.Get(ctx, "repo-with-webhook", metav1.GetOptions{})
+			obj, err := helper.Repositories.Resource.Get(t.Context(), "repo-with-webhook", metav1.GetOptions{})
 			require.NoError(t, err)
 
 			repo := common.MustFromUnstructured[provisioning.Repository](t, obj)
 			repo.Spec.Webhook.BaseURL = "https://new-proxy.example.com/"
 			updated := common.MustToUnstructured(t, repo)
 
-			result, err := helper.Repositories.Resource.Update(ctx, updated, metav1.UpdateOptions{})
+			result, err := helper.Repositories.Resource.Update(t.Context(), updated, metav1.UpdateOptions{})
 			require.NoError(collect, err, "should update webhook base URL")
 
 			updatedRepo := common.MustFromUnstructured[provisioning.Repository](t, result)
@@ -1394,14 +1387,14 @@ func TestIntegrationProvisioning_WebhookConfig(t *testing.T) {
 
 	t.Run("update repository to remove webhook config", func(t *testing.T) {
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
-			obj, err := helper.Repositories.Resource.Get(ctx, "repo-with-webhook", metav1.GetOptions{})
+			obj, err := helper.Repositories.Resource.Get(t.Context(), "repo-with-webhook", metav1.GetOptions{})
 			require.NoError(t, err)
 
 			repo := common.MustFromUnstructured[provisioning.Repository](t, obj)
 			repo.Spec.Webhook = nil
 			updated := common.MustToUnstructured(t, repo)
 
-			result, err := helper.Repositories.Resource.Update(ctx, updated, metav1.UpdateOptions{})
+			result, err := helper.Repositories.Resource.Update(t.Context(), updated, metav1.UpdateOptions{})
 			require.NoError(collect, err, "should clear webhook config")
 
 			updatedRepo := common.MustFromUnstructured[provisioning.Repository](t, result)
@@ -1438,7 +1431,7 @@ func TestIntegrationProvisioning_WebhookConfig(t *testing.T) {
 			},
 		}}
 
-		_, err := helper.Repositories.Resource.Create(ctx, repo, metav1.CreateOptions{})
+		_, err := helper.Repositories.Resource.Create(t.Context(), repo, metav1.CreateOptions{})
 		require.Error(t, err, "should reject unsupported scheme")
 		assert.ErrorContains(t, err, "must use HTTP or HTTPS scheme")
 	})
@@ -1472,7 +1465,7 @@ func TestIntegrationProvisioning_WebhookConfig(t *testing.T) {
 			},
 		}}
 
-		_, err := helper.Repositories.Resource.Create(ctx, repo, metav1.CreateOptions{})
+		_, err := helper.Repositories.Resource.Create(t.Context(), repo, metav1.CreateOptions{})
 		require.Error(t, err, "should reject webhook URL without host")
 		assert.ErrorContains(t, err, "must include a host")
 	})
@@ -1480,7 +1473,6 @@ func TestIntegrationProvisioning_WebhookConfig(t *testing.T) {
 
 func TestIntegrationProvisioning_WebhookRejectedForUnhealthyRepository(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	repoName := "webhook-unhealthy-test"
 	repoPath := filepath.Join(helper.ProvisioningPath, repoName)
@@ -1498,11 +1490,11 @@ func TestIntegrationProvisioning_WebhookRejectedForUnhealthyRepository(t *testin
 	require.NoError(t, os.RemoveAll(repoPath))
 
 	// Trigger reconciliation so the controller detects the missing directory.
-	latestObj, err := helper.Repositories.Resource.Get(ctx, repoName, metav1.GetOptions{})
+	latestObj, err := helper.Repositories.Resource.Get(t.Context(), repoName, metav1.GetOptions{})
 	require.NoError(t, err)
 	updated := latestObj.DeepCopy()
 	updated.Object["spec"].(map[string]any)["title"] = "Webhook Unhealthy Test (updated)"
-	_, err = helper.Repositories.Resource.Update(ctx, updated, metav1.UpdateOptions{})
+	_, err = helper.Repositories.Resource.Update(t.Context(), updated, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
 	// Wait for the controller to mark the repository unhealthy.
@@ -1512,7 +1504,7 @@ func TestIntegrationProvisioning_WebhookRejectedForUnhealthyRepository(t *testin
 	repoClient := provisioningClient.ProvisioningV0alpha1().Repositories("default")
 
 	require.Eventually(t, func() bool {
-		repo, err := repoClient.Get(ctx, repoName, metav1.GetOptions{})
+		repo, err := repoClient.Get(t.Context(), repoName, metav1.GetOptions{})
 		if err != nil {
 			return false
 		}
@@ -1529,7 +1521,7 @@ func TestIntegrationProvisioning_WebhookRejectedForUnhealthyRepository(t *testin
 		Name(repoName).
 		SubResource("webhook").
 		SetHeader("Content-Type", "application/json").
-		Do(ctx).StatusCode(&statusCode)
+		Do(t.Context()).StatusCode(&statusCode)
 
 	require.Error(t, result.Error(), "webhook request should be rejected for unhealthy repository")
 	require.Equal(t, http.StatusFailedDependency, statusCode, "should return 424 Failed Dependency for unhealthy repository")
@@ -1537,7 +1529,6 @@ func TestIntegrationProvisioning_WebhookRejectedForUnhealthyRepository(t *testin
 
 func TestIntegrationProvisioning_RunLocalRepository(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	const allPanels = "n1jR8vnnz"
 	const repo = "local-local-examples"
@@ -1565,7 +1556,7 @@ func TestIntegrationProvisioning_RunLocalRepository(t *testing.T) {
 			SubResource("files", targetPath).
 			Body(helper.LoadFile("../testdata/all-panels-classic.json")).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).StatusCode(&code)
+			Do(t.Context()).StatusCode(&code)
 		require.Equal(t, http.StatusNotFound, code)
 		require.True(t, apierrors.IsNotFound(result.Error()))
 
@@ -1577,7 +1568,7 @@ func TestIntegrationProvisioning_RunLocalRepository(t *testing.T) {
 			SubResource("files", targetPath).
 			Body(helper.LoadFile("../testdata/all-panels-classic.json")).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).StatusCode(&code)
+			Do(t.Context()).StatusCode(&code)
 		require.NoError(t, result.Error(), "expecting to be able to create file")
 		wrapper := &provisioning.ResourceWrapper{}
 		raw, err := result.Raw()
@@ -1592,7 +1583,7 @@ func TestIntegrationProvisioning_RunLocalRepository(t *testing.T) {
 		require.Equal(t, allPanels, name, "save the name from the request")
 
 		// Get the file from the grafana database
-		obj, err := helper.DashboardsV1.Resource.Get(ctx, allPanels, metav1.GetOptions{})
+		obj, err := helper.DashboardsV1.Resource.Get(t.Context(), allPanels, metav1.GetOptions{})
 		require.NoError(t, err, "the value should be saved in grafana")
 		val, _, _ := unstructured.NestedString(obj.Object, "metadata", "annotations", utils.AnnoKeyManagerKind)
 		require.Equal(t, string(utils.ManagerKindRepo), val, "should have repo annotations")
@@ -1600,7 +1591,7 @@ func TestIntegrationProvisioning_RunLocalRepository(t *testing.T) {
 		require.Equal(t, repo, val, "should have repo annotations")
 
 		// Read the file we wrote
-		wrapObj, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", targetPath)
+		wrapObj, err := helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", targetPath)
 		require.NoError(t, err, "read value")
 
 		wrap := &unstructured.Unstructured{}
@@ -1621,7 +1612,7 @@ func TestIntegrationProvisioning_RunLocalRepository(t *testing.T) {
 			SubResource("files", targetPath).
 			Body(body).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).StatusCode(&code)
+			Do(t.Context()).StatusCode(&code)
 		require.Equal(t, 200, code)
 		require.NoError(t, result.Error(), "update as admin value")
 		raw, err = result.Raw()
@@ -1639,7 +1630,7 @@ func TestIntegrationProvisioning_RunLocalRepository(t *testing.T) {
 			SubResource("files", targetPath).
 			Body(body).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).StatusCode(&code)
+			Do(t.Context()).StatusCode(&code)
 		require.Equal(t, 403, code)
 		require.True(t, apierrors.IsForbidden(result.Error()), code)
 	})
@@ -1652,11 +1643,11 @@ func TestIntegrationProvisioning_RunLocalRepository(t *testing.T) {
 			SubResource("files", "test", "..", "..", "all-panels.json"). // UNSAFE PATH
 			Body(helper.LoadFile("../testdata/all-panels.json")).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx)
+			Do(t.Context())
 		require.Error(t, result.Error(), "invalid path should return error")
 
 		// Read a file with a bad path
-		_, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "../../all-panels.json")
+		_, err := helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "../../all-panels.json")
 		require.Error(t, err, "invalid path should error")
 	})
 
@@ -1671,7 +1662,7 @@ func TestIntegrationProvisioning_RunLocalRepository(t *testing.T) {
 kind: Dashboard
 spec:
   title: Test dashboard
-`)).Do(ctx).StatusCode(&code)
+`)).Do(t.Context()).StatusCode(&code)
 		require.Error(t, result.Error(), "missing name")
 
 		result = helper.AdminREST.Post().
@@ -1685,7 +1676,7 @@ metadata:
   generateName: prefix-
 spec:
   title: Test dashboard
-`)).Do(ctx).StatusCode(&code)
+`)).Do(t.Context()).StatusCode(&code)
 		require.NoError(t, result.Error(), "should create name")
 		require.Equal(t, 200, code, "expect OK result")
 
@@ -1714,7 +1705,7 @@ metadata:
   name: someFolder
 spec:
   title: Test Folder
-`)).Do(ctx).StatusCode(&code)
+`)).Do(t.Context()).StatusCode(&code)
 		require.Error(t, result.Error(), "should return error")
 		require.Contains(t, result.Error().Error(), "cannot declare folders through files")
 		require.Equal(t, http.StatusBadRequest, code, "expect bad request result")
@@ -1723,11 +1714,10 @@ spec:
 
 func TestIntegrationProvisioning_ImportAllPanelsFromLocalRepository(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	// The dashboard shouldn't exist yet
 	const allPanels = "n1jR8vnnz"
-	_, err := helper.DashboardsV1.Resource.Get(ctx, allPanels, metav1.GetOptions{})
+	_, err := helper.DashboardsV1.Resource.Get(t.Context(), allPanels, metav1.GetOptions{})
 	require.Error(t, err, "no all-panels dashboard should exist")
 	require.True(t, apierrors.IsNotFound(err))
 
@@ -1749,7 +1739,7 @@ func TestIntegrationProvisioning_ImportAllPanelsFromLocalRepository(t *testing.T
 	helper.SyncAndWait(t, repo, nil)
 
 	// Make sure the repo can read and validate the file
-	obj, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "all-panels.json")
+	obj, err := helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "all-panels.json")
 	require.NoError(t, err, "valid path should be fine")
 
 	resource, _, err := unstructured.NestedMap(obj.Object, "resource")
@@ -1763,33 +1753,32 @@ func TestIntegrationProvisioning_ImportAllPanelsFromLocalRepository(t *testing.T
 	// FIXME: there is no point in in returning action for a read / get request.
 	require.Equal(t, "update", action)
 
-	_, err = helper.DashboardsV1.Resource.List(ctx, metav1.ListOptions{})
+	_, err = helper.DashboardsV1.Resource.List(t.Context(), metav1.ListOptions{})
 	require.NoError(t, err, "can list values")
 
-	obj, err = helper.DashboardsV1.Resource.Get(ctx, allPanels, metav1.GetOptions{})
+	obj, err = helper.DashboardsV1.Resource.Get(t.Context(), allPanels, metav1.GetOptions{})
 	require.NoError(t, err, "all-panels dashboard should exist")
 	require.Equal(t, repo, obj.GetAnnotations()[utils.AnnoKeyManagerIdentity])
 
 	// Try writing the value directly
 	err = unstructured.SetNestedField(obj.Object, []any{"aaa", "bbb"}, "spec", "tags")
 	require.NoError(t, err, "set tags")
-	obj, err = helper.DashboardsV1.Resource.Update(ctx, obj, metav1.UpdateOptions{})
+	obj, err = helper.DashboardsV1.Resource.Update(t.Context(), obj, metav1.UpdateOptions{})
 	require.NoError(t, err)
 	v, _, _ := unstructured.NestedString(obj.Object, "metadata", "annotations", utils.AnnoKeyUpdatedBy)
 	require.Equal(t, "access-policy:provisioning", v)
 
 	// Should be able to directly delete the managed resource
-	err = helper.DashboardsV1.Resource.Delete(ctx, allPanels, metav1.DeleteOptions{})
+	err = helper.DashboardsV1.Resource.Delete(t.Context(), allPanels, metav1.DeleteOptions{})
 	require.NoError(t, err, "user can delete")
 
-	_, err = helper.DashboardsV1.Resource.Get(ctx, allPanels, metav1.GetOptions{})
+	_, err = helper.DashboardsV1.Resource.Get(t.Context(), allPanels, metav1.GetOptions{})
 	require.Error(t, err, "should delete the internal resource")
 	require.True(t, apierrors.IsNotFound(err))
 }
 
 func TestIntegrationProvisioning_DeleteRepositoryAndReleaseResources(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	const repo = "gh-repo"
 	testRepo := common.TestRepo{
@@ -1804,14 +1793,14 @@ func TestIntegrationProvisioning_DeleteRepositoryAndReleaseResources(t *testing.
 	helper.CreateLocalRepo(t, testRepo)
 
 	// Checking resources are there and are managed
-	foundFolders, err := helper.Folders.Resource.List(ctx, metav1.ListOptions{})
+	foundFolders, err := helper.Folders.Resource.List(t.Context(), metav1.ListOptions{})
 	require.NoError(t, err, "can list folders")
 	for _, v := range foundFolders.Items {
 		assert.Contains(t, v.GetAnnotations(), utils.AnnoKeyManagerKind)
 		assert.Contains(t, v.GetAnnotations(), utils.AnnoKeyManagerIdentity)
 	}
 
-	foundDashboards, err := helper.DashboardsV1.Resource.List(ctx, metav1.ListOptions{})
+	foundDashboards, err := helper.DashboardsV1.Resource.List(t.Context(), metav1.ListOptions{})
 	require.NoError(t, err, "can list dashboards")
 	for _, v := range foundDashboards.Items {
 		assert.Contains(t, v.GetAnnotations(), utils.AnnoKeyManagerKind)
@@ -1820,7 +1809,7 @@ func TestIntegrationProvisioning_DeleteRepositoryAndReleaseResources(t *testing.
 		assert.Contains(t, v.GetAnnotations(), utils.AnnoKeySourceChecksum)
 	}
 
-	_, err = helper.Repositories.Resource.Patch(ctx, repo, types.JSONPatchType, []byte(`[
+	_, err = helper.Repositories.Resource.Patch(t.Context(), repo, types.JSONPatchType, []byte(`[
 		{
 			"op": "replace",
 			"path": "/metadata/finalizers",
@@ -1829,17 +1818,16 @@ func TestIntegrationProvisioning_DeleteRepositoryAndReleaseResources(t *testing.
 	]`), metav1.PatchOptions{})
 	require.NoError(t, err, "should successfully patch finalizers")
 
-	err = helper.Repositories.Resource.Delete(ctx, repo, metav1.DeleteOptions{})
+	err = helper.Repositories.Resource.Delete(t.Context(), repo, metav1.DeleteOptions{})
 	require.NoError(t, err, "should delete repository")
 
-	helper.WaitForRepositoryDeleted(t, ctx, repo)
-	common.WaitForResourcesReleased(t, ctx, helper.DashboardsV1.Resource, "dashboards")
-	common.WaitForResourcesReleased(t, ctx, helper.Folders.Resource, "folders")
+	helper.WaitForRepositoryDeleted(t, repo)
+	common.WaitForResourcesReleased(t, helper.DashboardsV1.Resource, "dashboards")
+	common.WaitForResourcesReleased(t, helper.Folders.Resource, "folders")
 }
 
 func TestIntegrationProvisioning_DeleteRepositoryAndCleanupClassicDashboards(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	t.Run("remove-orphan-resources finalizer deletes classic dashboards", func(t *testing.T) {
 		const repo = "finalizer-remove-classic"
@@ -1865,17 +1853,17 @@ func TestIntegrationProvisioning_DeleteRepositoryAndCleanupClassicDashboards(t *
 
 		helper.RequireRepoDashboardCount(t, repo, 1)
 
-		dashboard, err := helper.DashboardsV1.Resource.Get(ctx, "finalizer-remove-classic-uid", metav1.GetOptions{})
+		dashboard, err := helper.DashboardsV1.Resource.Get(t.Context(), "finalizer-remove-classic-uid", metav1.GetOptions{})
 		require.NoError(t, err, "classic dashboard should exist after initial sync")
 		require.Contains(t, dashboard.GetAnnotations(), utils.AnnoKeyManagerKind)
 		require.Contains(t, dashboard.GetAnnotations(), utils.AnnoKeyManagerIdentity)
 
-		err = helper.Repositories.Resource.Delete(ctx, repo, metav1.DeleteOptions{})
+		err = helper.Repositories.Resource.Delete(t.Context(), repo, metav1.DeleteOptions{})
 		require.NoError(t, err, "should delete repository")
 
-		helper.WaitForRepositoryDeleted(t, ctx, repo)
+		helper.WaitForRepositoryDeleted(t, repo)
 
-		_, err = helper.DashboardsV1.Resource.Get(ctx, "finalizer-remove-classic-uid", metav1.GetOptions{})
+		_, err = helper.DashboardsV1.Resource.Get(t.Context(), "finalizer-remove-classic-uid", metav1.GetOptions{})
 		require.Error(t, err, "classic dashboard should be deleted by remove-orphan-resources finalizer")
 		require.True(t, apierrors.IsNotFound(err))
 	})
@@ -1904,22 +1892,22 @@ func TestIntegrationProvisioning_DeleteRepositoryAndCleanupClassicDashboards(t *
 
 		helper.RequireRepoDashboardCount(t, repo, 1)
 
-		dashboard, err := helper.DashboardsV1.Resource.Get(ctx, "finalizer-release-classic-uid", metav1.GetOptions{})
+		dashboard, err := helper.DashboardsV1.Resource.Get(t.Context(), "finalizer-release-classic-uid", metav1.GetOptions{})
 		require.NoError(t, err, "classic dashboard should exist after initial sync")
 		require.Contains(t, dashboard.GetAnnotations(), utils.AnnoKeyManagerKind)
 		require.Contains(t, dashboard.GetAnnotations(), utils.AnnoKeyManagerIdentity)
 
-		_, err = helper.Repositories.Resource.Patch(ctx, repo, types.JSONPatchType, []byte(`[
+		_, err = helper.Repositories.Resource.Patch(t.Context(), repo, types.JSONPatchType, []byte(`[
 			{"op": "replace", "path": "/metadata/finalizers", "value": ["cleanup", "release-orphan-resources"]}
 		]`), metav1.PatchOptions{})
 		require.NoError(t, err, "should successfully patch finalizers")
 
-		err = helper.Repositories.Resource.Delete(ctx, repo, metav1.DeleteOptions{})
+		err = helper.Repositories.Resource.Delete(t.Context(), repo, metav1.DeleteOptions{})
 		require.NoError(t, err, "should delete repository")
 
-		helper.WaitForRepositoryDeleted(t, ctx, repo)
+		helper.WaitForRepositoryDeleted(t, repo)
 
-		dashboard, err = helper.DashboardsV1.Resource.Get(ctx, "finalizer-release-classic-uid", metav1.GetOptions{})
+		dashboard, err = helper.DashboardsV1.Resource.Get(t.Context(), "finalizer-release-classic-uid", metav1.GetOptions{})
 		require.NoError(t, err, "classic dashboard should still exist after release")
 
 		annotations := dashboard.GetAnnotations()
@@ -1932,7 +1920,6 @@ func TestIntegrationProvisioning_DeleteRepositoryAndCleanupClassicDashboards(t *
 
 func TestIntegrationProvisioning_JobPermissions(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	const repo = "job-permissions-test"
 	testRepo := common.TestRepo{
@@ -1963,7 +1950,7 @@ func TestIntegrationProvisioning_JobPermissions(t *testing.T) {
 			SubResource("jobs").
 			Body(editorJobBody).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.NoError(t, result.Error(), "editor should be able to POST jobs")
 		require.Equal(t, http.StatusAccepted, statusCode, "should return 202 Accepted")
@@ -1985,7 +1972,7 @@ func TestIntegrationProvisioning_JobPermissions(t *testing.T) {
 			SubResource("jobs").
 			Body(editorJobBody).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.Error(t, result.Error(), "viewer should not be able to POST jobs")
 		require.Equal(t, http.StatusForbidden, statusCode, "should return 403 Forbidden")
@@ -2001,7 +1988,7 @@ func TestIntegrationProvisioning_JobPermissions(t *testing.T) {
 			SubResource("jobs").
 			Body(adminJobBody).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		// Job might already exist from previous test, which is acceptable
 		if apierrors.IsAlreadyExists(result.Error()) {
@@ -2017,7 +2004,6 @@ func TestIntegrationProvisioning_JobPermissions(t *testing.T) {
 
 func TestIntegrationProvisioning_RefsPermissions(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	const repo = "refs-permissions-test"
 	testRepo := common.TestRepo{
@@ -2038,7 +2024,7 @@ func TestIntegrationProvisioning_RefsPermissions(t *testing.T) {
 			Resource("repositories").
 			Name(repo).
 			SubResource("refs").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.NoError(t, result.Error(), "editor should be able to GET refs")
 		require.Equal(t, http.StatusOK, statusCode, "should return 200 OK")
@@ -2057,7 +2043,7 @@ func TestIntegrationProvisioning_RefsPermissions(t *testing.T) {
 			Resource("repositories").
 			Name(repo).
 			SubResource("refs").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.Error(t, result.Error(), "viewer should not be able to GET refs")
 		require.Equal(t, http.StatusForbidden, statusCode, "should return 403 Forbidden")
@@ -2071,7 +2057,7 @@ func TestIntegrationProvisioning_RefsPermissions(t *testing.T) {
 			Resource("repositories").
 			Name(repo).
 			SubResource("refs").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.NoError(t, result.Error(), "admin should be able to GET refs")
 		require.Equal(t, http.StatusOK, statusCode, "should return 200 OK")
@@ -2080,7 +2066,6 @@ func TestIntegrationProvisioning_RefsPermissions(t *testing.T) {
 
 func TestIntegrationProvisioning_EmptyPath(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	t.Run("repository with empty path syncs from root", func(t *testing.T) {
 		const repo = "empty-path-test"
@@ -2095,15 +2080,15 @@ func TestIntegrationProvisioning_EmptyPath(t *testing.T) {
 		helper.CreateLocalRepo(t, testRepo)
 
 		// Verify the repository has empty path
-		repoObj, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{})
+		repoObj, err := helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{})
 		require.NoError(t, err)
 		path, _, _ := unstructured.NestedString(repoObj.Object, "spec", "github", "path")
 		require.Equal(t, "", path, "repository should have empty path")
 
 		// Clean up
-		err = helper.Repositories.Resource.Delete(ctx, repo, metav1.DeleteOptions{})
+		err = helper.Repositories.Resource.Delete(t.Context(), repo, metav1.DeleteOptions{})
 		require.NoError(t, err)
-		helper.WaitForRepositoryDeleted(t, ctx, repo)
+		helper.WaitForRepositoryDeleted(t, repo)
 	})
 
 	t.Run("multiple repositories with empty path - duplicate sync-enabled root path is rejected", func(t *testing.T) {
@@ -2129,26 +2114,25 @@ func TestIntegrationProvisioning_EmptyPath(t *testing.T) {
 			"SyncTarget":    "folder",
 			"WorkflowsJSON": `[]`,
 		})
-		_, err := helper.Repositories.Resource.Create(ctx, secondRepo, metav1.CreateOptions{})
+		_, err := helper.Repositories.Resource.Create(t.Context(), secondRepo, metav1.CreateOptions{})
 		require.Error(t, err, "Second repository with same URL, branch, and empty path should fail")
 		require.ErrorContains(t, err, provisioningAPIServer.ErrRepositoryDuplicatePath.Error())
 
 		// Verify first repository has empty path
-		repo1Obj, err := helper.Repositories.Resource.Get(ctx, repo1, metav1.GetOptions{})
+		repo1Obj, err := helper.Repositories.Resource.Get(t.Context(), repo1, metav1.GetOptions{})
 		require.NoError(t, err)
 		path1, _, _ := unstructured.NestedString(repo1Obj.Object, "spec", "github", "path")
 		require.Equal(t, "", path1, "repo1 should have empty path")
 
 		// Clean up
-		err = helper.Repositories.Resource.Delete(ctx, repo1, metav1.DeleteOptions{})
+		err = helper.Repositories.Resource.Delete(t.Context(), repo1, metav1.DeleteOptions{})
 		require.NoError(t, err)
-		helper.WaitForRepositoryDeleted(t, ctx, repo1)
+		helper.WaitForRepositoryDeleted(t, repo1)
 	})
 }
 
 func TestIntegrationProvisioning_RepositoryConnection(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 	createOptions := metav1.CreateOptions{FieldValidation: "Strict"}
 	privateKeyBase64 := base64.StdEncoding.EncodeToString([]byte(testPrivateKeyPEM))
 
@@ -2178,13 +2162,13 @@ func TestIntegrationProvisioning_RepositoryConnection(t *testing.T) {
 		},
 	}}
 
-	c, err := helper.CreateGithubConnection(t, ctx, connection)
+	c, err := helper.CreateGithubConnection(t, connection)
 	require.NoError(t, err, "failed to create connection")
 
 	connectionName := c.GetName()
 
 	require.EventuallyWithT(t, func(collectT *assert.CollectT) {
-		c, err := helper.Connections.Resource.Get(ctx, connectionName, metav1.GetOptions{})
+		c, err := helper.Connections.Resource.Get(t.Context(), connectionName, metav1.GetOptions{})
 		require.NoError(collectT, err, "can list values")
 		conn := common.MustFromUnstructured[provisioning.Connection](t, c)
 		require.NotEqual(collectT, 0, conn.Status.ObservedGeneration, "resource should be reconciled at least once")
@@ -2218,11 +2202,11 @@ func TestIntegrationProvisioning_RepositoryConnection(t *testing.T) {
 		},
 	}}
 
-	_, err = helper.Repositories.Resource.Create(ctx, repoWithConnection, createOptions)
+	_, err = helper.Repositories.Resource.Create(t.Context(), repoWithConnection, createOptions)
 	require.NoError(t, err, "failed to create repository with connection")
 
 	require.EventuallyWithT(t, func(collectT *assert.CollectT) {
-		repo, err := helper.Repositories.Resource.Get(ctx, "repo-with-connection", metav1.GetOptions{})
+		repo, err := helper.Repositories.Resource.Get(t.Context(), "repo-with-connection", metav1.GetOptions{})
 		require.NoError(collectT, err, "can get repository")
 		r := common.MustFromUnstructured[provisioning.Repository](t, repo)
 		require.NotEqual(collectT, 0, r.Status.ObservedGeneration, "resource should be reconciled at least once")
@@ -2233,7 +2217,7 @@ func TestIntegrationProvisioning_RepositoryConnection(t *testing.T) {
 		// fieldErrors are populated from testResults and may contain warnings even when healthy
 		require.NotNil(collectT, r.Status.FieldErrors, "fieldErrors field should exist in status")
 
-		decrypted, err := decryptService.Decrypt(ctx, "provisioning.grafana.app", r.GetNamespace(), r.Secure.Token.Name)
+		decrypted, err := decryptService.Decrypt(t.Context(), "provisioning.grafana.app", r.GetNamespace(), r.Secure.Token.Name)
 		require.NoError(collectT, err, "decryption error")
 		require.Len(collectT, decrypted, 1)
 
@@ -2249,7 +2233,7 @@ func TestIntegrationProvisioning_RepositoryConnection(t *testing.T) {
 	var firstReconciledRepo *provisioning.Repository
 	const maxStatusRetries = 5
 	for attempt := range maxStatusRetries {
-		repoUnstructured, err := helper.Repositories.Resource.Get(ctx, "repo-with-connection", metav1.GetOptions{})
+		repoUnstructured, err := helper.Repositories.Resource.Get(t.Context(), "repo-with-connection", metav1.GetOptions{})
 		require.NoError(t, err, "can get repository")
 		firstReconciledRepo = common.MustFromUnstructured[provisioning.Repository](t, repoUnstructured)
 
@@ -2283,7 +2267,7 @@ func TestIntegrationProvisioning_RepositoryConnection(t *testing.T) {
 		}
 		updatedRepo := common.MustToUnstructured(t, firstReconciledRepo)
 		// This should also trigger a reconciliation loop
-		_, err = helper.Repositories.Resource.UpdateStatus(ctx, updatedRepo, metav1.UpdateOptions{})
+		_, err = helper.Repositories.Resource.UpdateStatus(t.Context(), updatedRepo, metav1.UpdateOptions{})
 		if err == nil {
 			break
 		}
@@ -2294,7 +2278,7 @@ func TestIntegrationProvisioning_RepositoryConnection(t *testing.T) {
 	}
 
 	require.EventuallyWithT(t, func(collectT *assert.CollectT) {
-		repo, err := helper.Repositories.Resource.Get(ctx, "repo-with-connection", metav1.GetOptions{})
+		repo, err := helper.Repositories.Resource.Get(t.Context(), "repo-with-connection", metav1.GetOptions{})
 		require.NoError(collectT, err, "can get repository")
 		r := common.MustFromUnstructured[provisioning.Repository](t, repo)
 		// Token should be there
@@ -2307,7 +2291,7 @@ func TestIntegrationProvisioning_RepositoryConnection(t *testing.T) {
 		)
 
 		// Just checking the token is what is going to be returned by the mock GH API
-		decrypted, err := decryptService.Decrypt(ctx, "provisioning.grafana.app", r.GetNamespace(), r.Secure.Token.Name)
+		decrypted, err := decryptService.Decrypt(t.Context(), "provisioning.grafana.app", r.GetNamespace(), r.Secure.Token.Name)
 		require.NoError(collectT, err, "decryption error")
 		require.Len(collectT, decrypted, 1)
 
@@ -2319,7 +2303,6 @@ func TestIntegrationProvisioning_RepositoryConnection(t *testing.T) {
 
 func TestIntegrationProvisioning_RepositoryUnhealthyWithValidationErrors(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 	namespace := "default"
 
 	// Create typed client from REST config
@@ -2352,13 +2335,14 @@ func TestIntegrationProvisioning_RepositoryUnhealthyWithValidationErrors(t *test
 		},
 	}}
 
-	c, err := helper.CreateGithubConnection(t, ctx, connection)
+	c, err := helper.CreateGithubConnection(t, connection)
 	require.NoError(t, err, "failed to create connection")
 
 	connectionName := c.GetName()
 
 	t.Cleanup(func() {
-		_ = helper.Connections.Resource.Delete(ctx, connectionName, metav1.DeleteOptions{})
+		cleanupCtx := context.WithoutCancel(t.Context())
+		_ = helper.Connections.Resource.Delete(cleanupCtx, connectionName, metav1.DeleteOptions{})
 	})
 
 	t.Run("repository with non-existent branch becomes unhealthy with fieldErrors", func(t *testing.T) {
@@ -2387,19 +2371,20 @@ func TestIntegrationProvisioning_RepositoryUnhealthyWithValidationErrors(t *test
 			},
 		}}
 
-		createdUnstructured, err := helper.Repositories.Resource.Create(ctx, repoUnstructured, metav1.CreateOptions{})
+		createdUnstructured, err := helper.Repositories.Resource.Create(t.Context(), repoUnstructured, metav1.CreateOptions{})
 		require.NoError(t, err)
 		require.NotNil(t, createdUnstructured)
 
 		repoName := createdUnstructured.GetName()
 
 		t.Cleanup(func() {
-			_ = helper.Repositories.Resource.Delete(ctx, repoName, metav1.DeleteOptions{})
+			cleanupCtx := context.WithoutCancel(t.Context())
+			_ = helper.Repositories.Resource.Delete(cleanupCtx, repoName, metav1.DeleteOptions{})
 		})
 
 		// Wait for reconciliation - repository should become unhealthy due to invalid branch
 		require.Eventually(t, func() bool {
-			repo, err := repoClient.Get(ctx, repoName, metav1.GetOptions{})
+			repo, err := repoClient.Get(t.Context(), repoName, metav1.GetOptions{})
 			if err != nil {
 				return false
 			}
@@ -2410,7 +2395,7 @@ func TestIntegrationProvisioning_RepositoryUnhealthyWithValidationErrors(t *test
 		}, 15*time.Second, 500*time.Millisecond, "repository should be reconciled and marked unhealthy")
 
 		// Verify the repository is unhealthy and has fieldErrors
-		repo, err := repoClient.Get(ctx, repoName, metav1.GetOptions{})
+		repo, err := repoClient.Get(t.Context(), repoName, metav1.GetOptions{})
 		require.NoError(t, err)
 		assert.False(t, repo.Status.Health.Healthy, "repository should be unhealthy")
 		assert.Equal(t, repo.Generation, repo.Status.ObservedGeneration, "repository should be reconciled")
@@ -2456,19 +2441,20 @@ func TestIntegrationProvisioning_RepositoryUnhealthyWithValidationErrors(t *test
 			},
 		}}
 
-		createdUnstructured, err := helper.Repositories.Resource.Create(ctx, repoUnstructured, metav1.CreateOptions{})
+		createdUnstructured, err := helper.Repositories.Resource.Create(t.Context(), repoUnstructured, metav1.CreateOptions{})
 		require.NoError(t, err)
 		require.NotNil(t, createdUnstructured)
 
 		repoName := createdUnstructured.GetName()
 
 		t.Cleanup(func() {
-			_ = helper.Repositories.Resource.Delete(ctx, repoName, metav1.DeleteOptions{})
+			cleanupCtx := context.WithoutCancel(t.Context())
+			_ = helper.Repositories.Resource.Delete(cleanupCtx, repoName, metav1.DeleteOptions{})
 		})
 
 		// Wait for reconciliation - repository should become unhealthy due to invalid repository URL
 		require.Eventually(t, func() bool {
-			repo, err := repoClient.Get(ctx, repoName, metav1.GetOptions{})
+			repo, err := repoClient.Get(t.Context(), repoName, metav1.GetOptions{})
 			if err != nil {
 				return false
 			}
@@ -2479,7 +2465,7 @@ func TestIntegrationProvisioning_RepositoryUnhealthyWithValidationErrors(t *test
 		}, 15*time.Second, 500*time.Millisecond, "repository should be reconciled and marked unhealthy")
 
 		// Verify the repository is unhealthy and has fieldErrors
-		repo, err := repoClient.Get(ctx, repoName, metav1.GetOptions{})
+		repo, err := repoClient.Get(t.Context(), repoName, metav1.GetOptions{})
 		require.NoError(t, err)
 		assert.False(t, repo.Status.Health.Healthy, "repository should be unhealthy")
 		assert.Equal(t, repo.Generation, repo.Status.ObservedGeneration, "repository should be reconciled")
@@ -2503,7 +2489,6 @@ func TestIntegrationProvisioning_RepositoryUnhealthyWithValidationErrors(t *test
 
 func TestIntegrationRepositoryController_FieldErrorsCleared(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 	namespace := "default"
 
 	// Create typed client from REST config
@@ -2542,17 +2527,18 @@ func TestIntegrationRepositoryController_FieldErrorsCleared(t *testing.T) {
 			},
 		}}
 
-		createdUnstructured, err := helper.Repositories.Resource.Create(ctx, repoUnstructured, metav1.CreateOptions{})
+		createdUnstructured, err := helper.Repositories.Resource.Create(t.Context(), repoUnstructured, metav1.CreateOptions{})
 		require.NoError(t, err)
 		require.NotNil(t, createdUnstructured)
 
 		t.Cleanup(func() {
-			_ = helper.Repositories.Resource.Delete(ctx, repoName, metav1.DeleteOptions{})
+			cleanupCtx := context.WithoutCancel(t.Context())
+			_ = helper.Repositories.Resource.Delete(cleanupCtx, repoName, metav1.DeleteOptions{})
 		})
 
 		// Wait for repository to become healthy
 		require.Eventually(t, func() bool {
-			repo, err := repoClient.Get(ctx, repoName, metav1.GetOptions{})
+			repo, err := repoClient.Get(t.Context(), repoName, metav1.GetOptions{})
 			if err != nil {
 				return false
 			}
@@ -2563,7 +2549,7 @@ func TestIntegrationRepositoryController_FieldErrorsCleared(t *testing.T) {
 		}, 15*time.Second, 500*time.Millisecond, "repository should be healthy")
 
 		// Verify repository is healthy with no fieldErrors
-		repoHealthy, err := repoClient.Get(ctx, repoName, metav1.GetOptions{})
+		repoHealthy, err := repoClient.Get(t.Context(), repoName, metav1.GetOptions{})
 		require.NoError(t, err)
 		assert.True(t, repoHealthy.Status.Health.Healthy, "repository should be healthy")
 		assert.Empty(t, repoHealthy.Status.FieldErrors, "fieldErrors should be empty when healthy")
@@ -2573,17 +2559,17 @@ func TestIntegrationRepositoryController_FieldErrorsCleared(t *testing.T) {
 		require.NoError(t, err)
 
 		// Trigger health check by updating the repository spec
-		latestUnstructured, err := helper.Repositories.Resource.Get(ctx, repoName, metav1.GetOptions{})
+		latestUnstructured, err := helper.Repositories.Resource.Get(t.Context(), repoName, metav1.GetOptions{})
 		require.NoError(t, err)
 		updatedUnstructured := latestUnstructured.DeepCopy()
 		// Update title to trigger reconciliation
 		updatedUnstructured.Object["spec"].(map[string]any)["title"] = "Updated Title"
-		_, err = helper.Repositories.Resource.Update(ctx, updatedUnstructured, metav1.UpdateOptions{})
+		_, err = helper.Repositories.Resource.Update(t.Context(), updatedUnstructured, metav1.UpdateOptions{})
 		require.NoError(t, err)
 
 		// Wait for repository to become unhealthy with fieldErrors
 		require.Eventually(t, func() bool {
-			repo, err := repoClient.Get(ctx, repoName, metav1.GetOptions{})
+			repo, err := repoClient.Get(t.Context(), repoName, metav1.GetOptions{})
 			if err != nil {
 				return false
 			}
@@ -2594,7 +2580,7 @@ func TestIntegrationRepositoryController_FieldErrorsCleared(t *testing.T) {
 		}, 15*time.Second, 500*time.Millisecond, "repository should be unhealthy with fieldErrors")
 
 		// Verify fieldErrors are present
-		repoWithErrors, err := repoClient.Get(ctx, repoName, metav1.GetOptions{})
+		repoWithErrors, err := repoClient.Get(t.Context(), repoName, metav1.GetOptions{})
 		require.NoError(t, err)
 		require.Greater(t, len(repoWithErrors.Status.FieldErrors), 0, "fieldErrors should be present when unhealthy")
 
@@ -2603,17 +2589,17 @@ func TestIntegrationRepositoryController_FieldErrorsCleared(t *testing.T) {
 		require.NoError(t, err)
 
 		// Trigger health check by updating the repository spec again
-		latestUnstructured2, err := helper.Repositories.Resource.Get(ctx, repoName, metav1.GetOptions{})
+		latestUnstructured2, err := helper.Repositories.Resource.Get(t.Context(), repoName, metav1.GetOptions{})
 		require.NoError(t, err)
 		updatedUnstructured2 := latestUnstructured2.DeepCopy()
 		// Update title again to trigger reconciliation
 		updatedUnstructured2.Object["spec"].(map[string]any)["title"] = "Final Title"
-		_, err = helper.Repositories.Resource.Update(ctx, updatedUnstructured2, metav1.UpdateOptions{})
+		_, err = helper.Repositories.Resource.Update(t.Context(), updatedUnstructured2, metav1.UpdateOptions{})
 		require.NoError(t, err)
 
 		// Wait for reconciliation - repository should become healthy and fieldErrors should be cleared
 		require.Eventually(t, func() bool {
-			repo, err := repoClient.Get(ctx, repoName, metav1.GetOptions{})
+			repo, err := repoClient.Get(t.Context(), repoName, metav1.GetOptions{})
 			if err != nil {
 				return false
 			}
@@ -2630,7 +2616,7 @@ func TestIntegrationRepositoryController_FieldErrorsCleared(t *testing.T) {
 		}, 30*time.Second, 1*time.Second, "repository should be healthy with fieldErrors cleared")
 
 		// Verify fieldErrors are cleared
-		repoHealthyAgain, err := repoClient.Get(ctx, repoName, metav1.GetOptions{})
+		repoHealthyAgain, err := repoClient.Get(t.Context(), repoName, metav1.GetOptions{})
 		require.NoError(t, err)
 		assert.True(t, repoHealthyAgain.Status.Health.Healthy, "repository should be healthy")
 		assert.Empty(t, repoHealthyAgain.Status.FieldErrors, "fieldErrors should be cleared when repository becomes healthy")
@@ -2639,7 +2625,6 @@ func TestIntegrationRepositoryController_FieldErrorsCleared(t *testing.T) {
 
 func TestIntegrationRepositoryController_DefaultBranch(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 	namespace := "default"
 	defaultBranchName := "defaultBranchName"
 
@@ -2699,17 +2684,18 @@ func TestIntegrationRepositoryController_DefaultBranch(t *testing.T) {
 			},
 		}}
 
-		createdUnstructured, err := helper.Repositories.Resource.Create(ctx, repoUnstructured, metav1.CreateOptions{})
+		createdUnstructured, err := helper.Repositories.Resource.Create(t.Context(), repoUnstructured, metav1.CreateOptions{})
 		require.NoError(t, err)
 		require.NotNil(t, createdUnstructured)
 
 		t.Cleanup(func() {
-			_ = helper.Repositories.Resource.Delete(ctx, repoName, metav1.DeleteOptions{})
+			cleanupCtx := context.WithoutCancel(t.Context())
+			_ = helper.Repositories.Resource.Delete(cleanupCtx, repoName, metav1.DeleteOptions{})
 		})
 
 		// Wait for reconciliation - repository should have branch name
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
-			repo, err := repoClient.Get(ctx, repoName, metav1.GetOptions{})
+			repo, err := repoClient.Get(t.Context(), repoName, metav1.GetOptions{})
 			require.NoError(collect, err, "issue getting repo")
 			require.Equal(collect, repo.Generation, repo.Status.ObservedGeneration, "repo should be reconciled")
 			require.Equal(collect, defaultBranchName, repo.Spec.GitHub.Branch, "default branch should be set")
@@ -2728,7 +2714,6 @@ func TestIntegrationRepositoryController_DefaultBranch(t *testing.T) {
 //	database is locked (5) (SQLITE_BUSY)
 func TestIntegrationProvisioning_ConcurrentRepositoryCreation(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	// Number of repositories to create concurrently
 	// This simulates what happens with 'grafanactl resources push' when pushing
@@ -2781,7 +2766,7 @@ func TestIntegrationProvisioning_ConcurrentRepositoryCreation(t *testing.T) {
 				},
 			}
 
-			_, err := helper.Repositories.Resource.Create(ctx, repo, metav1.CreateOptions{})
+			_, err := helper.Repositories.Resource.Create(t.Context(), repo, metav1.CreateOptions{})
 			results <- result{name: repoName, err: err}
 		}(i)
 	}
@@ -2821,7 +2806,7 @@ func TestIntegrationProvisioning_ConcurrentRepositoryCreation(t *testing.T) {
 	// Verify all repositories exist and have their secure tokens
 	for i := range numRepos {
 		repoName := fmt.Sprintf("concurrent-repo-%d", i)
-		repo, err := helper.Repositories.Resource.Get(ctx, repoName, metav1.GetOptions{})
+		repo, err := helper.Repositories.Resource.Get(t.Context(), repoName, metav1.GetOptions{})
 		require.NoError(t, err, "Repository %s should exist", repoName)
 
 		// Verify the secure token was created
@@ -2836,7 +2821,6 @@ func TestIntegrationProvisioning_ConcurrentRepositoryCreation(t *testing.T) {
 
 func TestIntegrationProvisioning_FolderTitleUpdatesOnSync(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	const repoName = "folder-title-update-test"
 	const initialTitle = "Initial Folder Title"
@@ -2854,7 +2838,7 @@ func TestIntegrationProvisioning_FolderTitleUpdatesOnSync(t *testing.T) {
 	// Verify the root folder has the initial title.
 	// The root folder for a folder-sync repo has the same name as the repository.
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		folderObj, err := helper.Folders.Resource.Get(ctx, repoName, metav1.GetOptions{})
+		folderObj, err := helper.Folders.Resource.Get(t.Context(), repoName, metav1.GetOptions{})
 		if !assert.NoError(collect, err, "should be able to get the root folder") {
 			return
 		}
@@ -2864,14 +2848,14 @@ func TestIntegrationProvisioning_FolderTitleUpdatesOnSync(t *testing.T) {
 
 	// Update the repository spec.title to a new value.
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		repoObj, err := helper.Repositories.Resource.Get(ctx, repoName, metav1.GetOptions{})
+		repoObj, err := helper.Repositories.Resource.Get(t.Context(), repoName, metav1.GetOptions{})
 		if !assert.NoError(collect, err, "should be able to get repository") {
 			return
 		}
 		err = unstructured.SetNestedField(repoObj.Object, updatedTitle, "spec", "title")
 		require.NoError(t, err, "should be able to set new title")
 
-		_, err = helper.Repositories.Resource.Update(ctx, repoObj, metav1.UpdateOptions{})
+		_, err = helper.Repositories.Resource.Update(t.Context(), repoObj, metav1.UpdateOptions{})
 		assert.NoError(collect, err, "should be able to update repository title")
 	}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "should update repository title")
 
@@ -2880,7 +2864,7 @@ func TestIntegrationProvisioning_FolderTitleUpdatesOnSync(t *testing.T) {
 
 	// Verify the root folder title was updated.
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		folderObj, err := helper.Folders.Resource.Get(ctx, repoName, metav1.GetOptions{})
+		folderObj, err := helper.Folders.Resource.Get(t.Context(), repoName, metav1.GetOptions{})
 		if !assert.NoError(collect, err, "should be able to get the root folder") {
 			return
 		}

--- a/pkg/tests/apis/provisioning/repository/webhook_connection_validation_test.go
+++ b/pkg/tests/apis/provisioning/repository/webhook_connection_validation_test.go
@@ -16,6 +16,7 @@ import (
 // connection has spec.webhook.disabled: true but the repository does not.
 func TestIntegrationProvisioning_RepositoryWebhookConnectionValidation(t *testing.T) {
 	helper := sharedHelper(t)
+
 	privateKeyBase64 := base64.StdEncoding.EncodeToString([]byte(testPrivateKeyPEM))
 
 	connection := &unstructured.Unstructured{Object: map[string]any{

--- a/pkg/tests/apis/provisioning/repository/webhook_connection_validation_test.go
+++ b/pkg/tests/apis/provisioning/repository/webhook_connection_validation_test.go
@@ -1,7 +1,6 @@
 package repository
 
 import (
-	"context"
 	"encoding/base64"
 	"testing"
 
@@ -17,7 +16,6 @@ import (
 // connection has spec.webhook.disabled: true but the repository does not.
 func TestIntegrationProvisioning_RepositoryWebhookConnectionValidation(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 	privateKeyBase64 := base64.StdEncoding.EncodeToString([]byte(testPrivateKeyPEM))
 
 	connection := &unstructured.Unstructured{Object: map[string]any{
@@ -45,7 +43,7 @@ func TestIntegrationProvisioning_RepositoryWebhookConnectionValidation(t *testin
 		},
 	}}
 
-	_, err := helper.CreateGithubConnection(t, ctx, connection)
+	_, err := helper.CreateGithubConnection(t, connection)
 	require.NoError(t, err, "failed to create connection")
 
 	t.Run("repository without webhook disabled is rejected", func(t *testing.T) {
@@ -73,7 +71,7 @@ func TestIntegrationProvisioning_RepositoryWebhookConnectionValidation(t *testin
 			},
 		}}
 
-		_, err := helper.Repositories.Resource.Create(ctx, repo, metav1.CreateOptions{FieldValidation: "Strict"})
+		_, err := helper.Repositories.Resource.Create(t.Context(), repo, metav1.CreateOptions{FieldValidation: "Strict"})
 		require.Error(t, err)
 
 		var statusErr *apierrors.StatusError
@@ -110,7 +108,7 @@ func TestIntegrationProvisioning_RepositoryWebhookConnectionValidation(t *testin
 			},
 		}}
 
-		_, err := helper.Repositories.Resource.Create(ctx, repo, metav1.CreateOptions{FieldValidation: "Strict"})
+		_, err := helper.Repositories.Resource.Create(t.Context(), repo, metav1.CreateOptions{FieldValidation: "Strict"})
 		require.NoError(t, err, "repository with webhook disabled should be accepted when connection also has webhook disabled")
 	})
 }

--- a/pkg/tests/apis/provisioning/repository_conditions_patch_test.go
+++ b/pkg/tests/apis/provisioning/repository_conditions_patch_test.go
@@ -48,7 +48,6 @@ func TestIntegrationProvisioning_ConditionsPatch_AppendDoesNotClobber(t *testing
 		t.Skip("skipping integration test")
 	}
 	helper := sharedHelper(t)
-	ctx := t.Context()
 
 	const repoName = "cond-patch-append"
 	helper.CreateLocalRepo(t, common.TestRepo{
@@ -86,14 +85,14 @@ func TestIntegrationProvisioning_ConditionsPatch_AppendDoesNotClobber(t *testing
 	// Idempotent apply-and-verify: if the narrow empty-cache race does
 	// clobber our append, the next iteration re-adds PullStatus and re-checks.
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		cur, err := readRepositoryConditions(ctx, helper, repoName)
+		cur, err := readRepositoryConditions(t.Context(), helper, repoName)
 		if !assert.NoError(c, err) {
 			return
 		}
 		curTypes := conditionTypeSet(cur)
 
 		if _, has := curTypes[provisioning.ConditionTypePullStatus]; !has {
-			_, err := helper.Repositories.Resource.Patch(ctx, repoName, types.JSONPatchType, addPullStatus, metav1.PatchOptions{}, "status")
+			_, err := helper.Repositories.Resource.Patch(t.Context(), repoName, types.JSONPatchType, addPullStatus, metav1.PatchOptions{}, "status")
 			assert.NoError(c, err, "add /status/conditions/- should succeed against status subresource")
 			return
 		}
@@ -116,7 +115,6 @@ func TestIntegrationProvisioning_ConditionsPatch_ReplaceByIndex(t *testing.T) {
 		t.Skip("skipping integration test")
 	}
 	helper := sharedHelper(t)
-	ctx := t.Context()
 
 	const repoName = "cond-patch-replace"
 	helper.CreateLocalRepo(t, common.TestRepo{
@@ -160,14 +158,14 @@ func TestIntegrationProvisioning_ConditionsPatch_ReplaceByIndex(t *testing.T) {
 	// Everything is re-read fresh from the apiserver each iteration so a
 	// shift in the array between reads is self-healing.
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		cur, err := readRepositoryConditions(ctx, helper, repoName)
+		cur, err := readRepositoryConditions(t.Context(), helper, repoName)
 		if !assert.NoError(c, err) {
 			return
 		}
 
 		idx := indexOfConditionType(cur, provisioning.ConditionTypePullStatus)
 		if idx < 0 {
-			_, err := helper.Repositories.Resource.Patch(ctx, repoName, types.JSONPatchType, seedPullStatus, metav1.PatchOptions{}, "status")
+			_, err := helper.Repositories.Resource.Patch(t.Context(), repoName, types.JSONPatchType, seedPullStatus, metav1.PatchOptions{}, "status")
 			assert.NoError(c, err, "seeding PullStatus should succeed")
 			return
 		}
@@ -182,12 +180,12 @@ func TestIntegrationProvisioning_ConditionsPatch_ReplaceByIndex(t *testing.T) {
 		if !assert.NoError(c, err) {
 			return
 		}
-		_, err = helper.Repositories.Resource.Patch(ctx, repoName, types.JSONPatchType, replacePatch, metav1.PatchOptions{}, "status")
+		_, err = helper.Repositories.Resource.Patch(t.Context(), repoName, types.JSONPatchType, replacePatch, metav1.PatchOptions{}, "status")
 		if !assert.NoError(c, err, "replace /status/conditions/%d should succeed", idx) {
 			return
 		}
 
-		after, err := readRepositoryConditions(ctx, helper, repoName)
+		after, err := readRepositoryConditions(t.Context(), helper, repoName)
 		if !assert.NoError(c, err) {
 			return
 		}
@@ -225,7 +223,6 @@ func TestIntegrationProvisioning_ConditionsPatch_ConcurrentAdds(t *testing.T) {
 		t.Skip("skipping integration test")
 	}
 	helper := sharedHelper(t)
-	ctx := t.Context()
 
 	const repoName = "cond-patch-concurrent"
 	helper.CreateLocalRepo(t, common.TestRepo{
@@ -279,12 +276,12 @@ func TestIntegrationProvisioning_ConditionsPatch_ConcurrentAdds(t *testing.T) {
 	ensurePresent := func(patch []byte, conditionType string) {
 		defer wg.Done()
 		for time.Now().Before(deadline) {
-			cur, err := readRepositoryConditions(ctx, helper, repoName)
+			cur, err := readRepositoryConditions(t.Context(), helper, repoName)
 			if err == nil && indexOfConditionType(cur, conditionType) >= 0 {
 				errs <- nil
 				return
 			}
-			if _, perr := helper.Repositories.Resource.Patch(ctx, repoName, types.JSONPatchType, patch, metav1.PatchOptions{}, "status"); perr != nil {
+			if _, perr := helper.Repositories.Resource.Patch(t.Context(), repoName, types.JSONPatchType, patch, metav1.PatchOptions{}, "status"); perr != nil {
 				// Retry on conflict / transient errors; fall through to sleep.
 				_ = perr
 			}
@@ -304,7 +301,7 @@ func TestIntegrationProvisioning_ConditionsPatch_ConcurrentAdds(t *testing.T) {
 	// Final steady-state check: both neutral conditions must be present
 	// simultaneously (not just individually-eventually).
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		cur, err := readRepositoryConditions(ctx, helper, repoName)
+		cur, err := readRepositoryConditions(t.Context(), helper, repoName)
 		if !assert.NoError(c, err) {
 			return
 		}

--- a/pkg/tests/apis/provisioning/repository_conditions_patch_test.go
+++ b/pkg/tests/apis/provisioning/repository_conditions_patch_test.go
@@ -51,9 +51,8 @@ func TestIntegrationProvisioning_ConditionsPatch_AppendDoesNotClobber(t *testing
 
 	const repoName = "cond-patch-append"
 	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:                   repoName,
-		SkipSync:               true,
-		SkipResourceAssertions: true,
+		Name:     repoName,
+		SkipSync: true,
 	})
 
 	// Wait for the controller to populate Ready and NamespaceQuota so we have
@@ -118,9 +117,8 @@ func TestIntegrationProvisioning_ConditionsPatch_ReplaceByIndex(t *testing.T) {
 
 	const repoName = "cond-patch-replace"
 	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:                   repoName,
-		SkipSync:               true,
-		SkipResourceAssertions: true,
+		Name:     repoName,
+		SkipSync: true,
 	})
 
 	// Wait for the controller to populate Ready and NamespaceQuota so we have
@@ -226,9 +224,8 @@ func TestIntegrationProvisioning_ConditionsPatch_ConcurrentAdds(t *testing.T) {
 
 	const repoName = "cond-patch-concurrent"
 	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:                   repoName,
-		SkipSync:               true,
-		SkipResourceAssertions: true,
+		Name:     repoName,
+		SkipSync: true,
 	})
 
 	// Wait for the controller to populate Ready and NamespaceQuota so we have

--- a/pkg/tests/apis/provisioning/resourcekinds/export_test.go
+++ b/pkg/tests/apis/provisioning/resourcekinds/export_test.go
@@ -31,18 +31,15 @@ func TestIntegrationProvisioning_ResourceKinds_Export(t *testing.T) {
 				_, err := client.Resource.Create(t.Context(), rk.newResource(t, name, title), metav1.CreateOptions{})
 				require.NoError(t, err, "should create %s", name)
 				wantTitles[title] = true
-				t.Cleanup(func() {
-					cleanupCtx := context.WithoutCancel(t.Context())
-					_ = client.Resource.Delete(cleanupCtx, name, metav1.DeleteOptions{})
-				})
+				cleanupCtx := context.WithoutCancel(t.Context())
+				t.Cleanup(func() { _ = client.Resource.Delete(cleanupCtx, name, metav1.DeleteOptions{}) })
 			}
 
 			repo := rk.name + "-export-repo"
 			helper.CreateLocalRepo(t, common.TestRepo{
-				Name:                   repo,
-				SyncTarget:             "folder",
-				Workflows:              []string{"write"},
-				SkipResourceAssertions: true,
+				Name:       repo,
+				SyncTarget: "folder",
+				Workflows:  []string{"write"},
 			})
 
 			helper.TriggerJobAndWaitForSuccess(t, repo, provisioning.JobSpec{
@@ -80,18 +77,15 @@ func TestIntegrationProvisioning_ResourceKinds_SelectiveExport(t *testing.T) {
 				name, title := rk.instance(i)
 				_, err := client.Resource.Create(t.Context(), rk.newResource(t, name, title), metav1.CreateOptions{})
 				require.NoError(t, err, "should create %s", name)
-				t.Cleanup(func() {
-					cleanupCtx := context.WithoutCancel(t.Context())
-					_ = client.Resource.Delete(cleanupCtx, name, metav1.DeleteOptions{})
-				})
+				cleanupCtx := context.WithoutCancel(t.Context())
+				t.Cleanup(func() { _ = client.Resource.Delete(cleanupCtx, name, metav1.DeleteOptions{}) })
 			}
 
 			repo := rk.name + "-selective-export-repo"
 			helper.CreateLocalRepo(t, common.TestRepo{
-				Name:                   repo,
-				SyncTarget:             "folder",
-				Workflows:              []string{"write"},
-				SkipResourceAssertions: true,
+				Name:       repo,
+				SyncTarget: "folder",
+				Workflows:  []string{"write"},
 			})
 
 			// Export only instances 0 and 2; instance 1 must be left out.

--- a/pkg/tests/apis/provisioning/resourcekinds/export_test.go
+++ b/pkg/tests/apis/provisioning/resourcekinds/export_test.go
@@ -18,7 +18,6 @@ import (
 // must not deny the kind's list — a successful multi-resource export is the regression guard.
 func TestIntegrationProvisioning_ResourceKinds_Export(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	for _, rk := range resourceKinds {
 		rk := rk
@@ -29,10 +28,13 @@ func TestIntegrationProvisioning_ResourceKinds_Export(t *testing.T) {
 			wantTitles := map[string]bool{}
 			for i := 0; i < count; i++ {
 				name, title := rk.instance(i)
-				_, err := client.Resource.Create(ctx, rk.newResource(t, name, title), metav1.CreateOptions{})
+				_, err := client.Resource.Create(t.Context(), rk.newResource(t, name, title), metav1.CreateOptions{})
 				require.NoError(t, err, "should create %s", name)
 				wantTitles[title] = true
-				t.Cleanup(func() { _ = client.Resource.Delete(ctx, name, metav1.DeleteOptions{}) })
+				t.Cleanup(func() {
+					cleanupCtx := context.WithoutCancel(t.Context())
+					_ = client.Resource.Delete(cleanupCtx, name, metav1.DeleteOptions{})
+				})
 			}
 
 			repo := rk.name + "-export-repo"
@@ -67,7 +69,6 @@ func TestIntegrationProvisioning_ResourceKinds_Export(t *testing.T) {
 // exercising the generalized selective-export controller for a non-dashboard kind.
 func TestIntegrationProvisioning_ResourceKinds_SelectiveExport(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	for _, rk := range resourceKinds {
 		rk := rk
@@ -77,9 +78,12 @@ func TestIntegrationProvisioning_ResourceKinds_SelectiveExport(t *testing.T) {
 			const count = 3
 			for i := 0; i < count; i++ {
 				name, title := rk.instance(i)
-				_, err := client.Resource.Create(ctx, rk.newResource(t, name, title), metav1.CreateOptions{})
+				_, err := client.Resource.Create(t.Context(), rk.newResource(t, name, title), metav1.CreateOptions{})
 				require.NoError(t, err, "should create %s", name)
-				t.Cleanup(func() { _ = client.Resource.Delete(ctx, name, metav1.DeleteOptions{}) })
+				t.Cleanup(func() {
+					cleanupCtx := context.WithoutCancel(t.Context())
+					_ = client.Resource.Delete(cleanupCtx, name, metav1.DeleteOptions{})
+				})
 			}
 
 			repo := rk.name + "-selective-export-repo"

--- a/pkg/tests/apis/provisioning/resourcekinds/files_test.go
+++ b/pkg/tests/apis/provisioning/resourcekinds/files_test.go
@@ -27,7 +27,6 @@ import (
 // TestIntegrationProvisioning_ResourceKinds_SubdirectoryFolderScope.
 func TestIntegrationProvisioning_ResourceKinds_FilesEndpoint(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	for _, rk := range resourceKinds {
 		rk := rk
@@ -43,12 +42,15 @@ func TestIntegrationProvisioning_ResourceKinds_FilesEndpoint(t *testing.T) {
 				Workflows:              []string{"write"},
 				SkipResourceAssertions: true,
 			})
-			t.Cleanup(func() { _ = client.Resource.Delete(ctx, name, metav1.DeleteOptions{}) })
+			t.Cleanup(func() {
+				cleanupCtx := context.WithoutCancel(t.Context())
+				_ = client.Resource.Delete(cleanupCtx, name, metav1.DeleteOptions{})
+			})
 
 			// Create: stores the file and provisions the resource.
-			postResourceFile(t, ctx, helper, rk, repo, filePath, name, "Files "+rk.kind)
-			require.Contains(t, repositoryFilePaths(t, ctx, helper, repo), filePath, "the file should exist in the repository")
-			got := common.RequireResource(t, ctx, client.Resource, name)
+			postResourceFile(t, helper, rk, repo, filePath, name, "Files "+rk.kind)
+			require.Contains(t, repositoryFilePaths(t, helper, repo), filePath, "the file should exist in the repository")
+			got := common.RequireResource(t, client.Resource, name)
 			title, _, _ := unstructured.NestedString(got.Object, "spec", "title")
 			require.Equal(t, "Files "+rk.kind, title)
 
@@ -60,10 +62,10 @@ func TestIntegrationProvisioning_ResourceKinds_FilesEndpoint(t *testing.T) {
 				SubResource("files", filePath).
 				Body(common.ResourceToJSON(t, rk.newResource(t, name, "Files "+rk.kind+" Updated"))).
 				SetHeader("Content-Type", "application/json").
-				Do(ctx).Error()
+				Do(t.Context()).Error()
 			require.NoError(t, updateErr, "%s update via files PUT should succeed", rk.name)
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {
-				got, err := client.Resource.Get(ctx, name, metav1.GetOptions{})
+				got, err := client.Resource.Get(t.Context(), name, metav1.GetOptions{})
 				if !assert.NoError(collect, err) {
 					return
 				}
@@ -83,11 +85,11 @@ func TestIntegrationProvisioning_ResourceKinds_FilesEndpoint(t *testing.T) {
 			require.NoError(t, moveResp.Body.Close())
 			require.Equalf(t, 200, moveResp.StatusCode, "%s move via files endpoint should succeed; body: %s", rk.name, moveBody)
 
-			repoFiles := repositoryFilePaths(t, ctx, helper, repo)
+			repoFiles := repositoryFilePaths(t, helper, repo)
 			require.NotContains(t, repoFiles, filePath, "the file should no longer be at its original path")
 			require.Contains(t, repoFiles, movedPath, "the file should be at the moved path")
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {
-				got, err := client.Resource.Get(ctx, name, metav1.GetOptions{})
+				got, err := client.Resource.Get(t.Context(), name, metav1.GetOptions{})
 				if !assert.NoError(collect, err) {
 					return
 				}
@@ -99,9 +101,9 @@ func TestIntegrationProvisioning_ResourceKinds_FilesEndpoint(t *testing.T) {
 			delResp := helper.NewFilesClient(repo).Delete(t, movedPath)
 			require.Equal(t, 200, delResp.StatusCode, "deleting a %s file should succeed", rk.name)
 
-			require.NotContains(t, repositoryFilePaths(t, ctx, helper, repo), movedPath, "the file should be removed from the repository")
+			require.NotContains(t, repositoryFilePaths(t, helper, repo), movedPath, "the file should be removed from the repository")
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {
-				_, err := client.Resource.Get(ctx, name, metav1.GetOptions{})
+				_, err := client.Resource.Get(t.Context(), name, metav1.GetOptions{})
 				assert.True(collect, apierrors.IsNotFound(err), "%s should be removed from Grafana after a files DELETE, got: %v", rk.name, err)
 			}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "%s should be deleted after a files DELETE", rk.name)
 		})

--- a/pkg/tests/apis/provisioning/resourcekinds/files_test.go
+++ b/pkg/tests/apis/provisioning/resourcekinds/files_test.go
@@ -37,15 +37,12 @@ func TestIntegrationProvisioning_ResourceKinds_FilesEndpoint(t *testing.T) {
 			filePath := rk.name + "-files.json"
 			name := rk.name + "-files"
 			helper.CreateLocalRepo(t, common.TestRepo{
-				Name:                   repo,
-				SyncTarget:             "folder",
-				Workflows:              []string{"write"},
-				SkipResourceAssertions: true,
+				Name:       repo,
+				SyncTarget: "folder",
+				Workflows:  []string{"write"},
 			})
-			t.Cleanup(func() {
-				cleanupCtx := context.WithoutCancel(t.Context())
-				_ = client.Resource.Delete(cleanupCtx, name, metav1.DeleteOptions{})
-			})
+			cleanupCtx := context.WithoutCancel(t.Context())
+			t.Cleanup(func() { _ = client.Resource.Delete(cleanupCtx, name, metav1.DeleteOptions{}) })
 
 			// Create: stores the file and provisions the resource.
 			postResourceFile(t, helper, rk, repo, filePath, name, "Files "+rk.kind)

--- a/pkg/tests/apis/provisioning/resourcekinds/folder_scope_test.go
+++ b/pkg/tests/apis/provisioning/resourcekinds/folder_scope_test.go
@@ -25,7 +25,6 @@ import (
 // for org-scoped kinds and the harness deliberately kept its writes at the repository root.
 func TestIntegrationProvisioning_ResourceKinds_SubdirectoryFolderScope(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	for _, rk := range resourceKinds {
 		rk := rk
@@ -41,7 +40,10 @@ func TestIntegrationProvisioning_ResourceKinds_SubdirectoryFolderScope(t *testin
 				Workflows:              []string{"write"},
 				SkipResourceAssertions: true,
 			})
-			t.Cleanup(func() { _ = client.Resource.Delete(ctx, name, metav1.DeleteOptions{}) })
+			t.Cleanup(func() {
+				cleanupCtx := context.WithoutCancel(t.Context())
+				_ = client.Resource.Delete(cleanupCtx, name, metav1.DeleteOptions{})
+			})
 
 			// Create the resource inside a subdirectory. For org-scoped kinds this previously
 			// failed because the dual writer stamped a forbidden folder annotation. The files
@@ -55,10 +57,10 @@ func TestIntegrationProvisioning_ResourceKinds_SubdirectoryFolderScope(t *testin
 			createBody, _ := io.ReadAll(createResp.Body)
 			require.NoError(t, createResp.Body.Close())
 			require.Equalf(t, 200, createResp.StatusCode, "%s create in a subdirectory should succeed; body: %s", rk.name, createBody)
-			require.Contains(t, repositoryFilePaths(t, ctx, helper, repo), subPath, "the file should exist in the repository subdirectory")
+			require.Contains(t, repositoryFilePaths(t, helper, repo), subPath, "the file should exist in the repository subdirectory")
 
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {
-				got, err := client.Resource.Get(ctx, name, metav1.GetOptions{})
+				got, err := client.Resource.Get(t.Context(), name, metav1.GetOptions{})
 				if !assert.NoError(collect, err) {
 					return
 				}
@@ -81,7 +83,7 @@ func TestIntegrationProvisioning_ResourceKinds_SubdirectoryFolderScope(t *testin
 			require.Equalf(t, 200, moveResp.StatusCode, "%s move within a subdirectory should succeed", rk.name)
 
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {
-				got, err := client.Resource.Get(ctx, name, metav1.GetOptions{})
+				got, err := client.Resource.Get(t.Context(), name, metav1.GetOptions{})
 				if !assert.NoError(collect, err) {
 					return
 				}

--- a/pkg/tests/apis/provisioning/resourcekinds/folder_scope_test.go
+++ b/pkg/tests/apis/provisioning/resourcekinds/folder_scope_test.go
@@ -35,15 +35,12 @@ func TestIntegrationProvisioning_ResourceKinds_SubdirectoryFolderScope(t *testin
 			name := rk.name + "-folderscope"
 			subPath := "team-a/" + rk.name + ".json"
 			helper.CreateLocalRepo(t, common.TestRepo{
-				Name:                   repo,
-				SyncTarget:             "folder",
-				Workflows:              []string{"write"},
-				SkipResourceAssertions: true,
+				Name:       repo,
+				SyncTarget: "folder",
+				Workflows:  []string{"write"},
 			})
-			t.Cleanup(func() {
-				cleanupCtx := context.WithoutCancel(t.Context())
-				_ = client.Resource.Delete(cleanupCtx, name, metav1.DeleteOptions{})
-			})
+			cleanupCtx := context.WithoutCancel(t.Context())
+			t.Cleanup(func() { _ = client.Resource.Delete(cleanupCtx, name, metav1.DeleteOptions{}) })
 
 			// Create the resource inside a subdirectory. For org-scoped kinds this previously
 			// failed because the dual writer stamped a forbidden folder annotation. The files

--- a/pkg/tests/apis/provisioning/resourcekinds/harness_test.go
+++ b/pkg/tests/apis/provisioning/resourcekinds/harness_test.go
@@ -17,7 +17,6 @@
 package resourcekinds
 
 import (
-	"context"
 	"embed"
 	"encoding/json"
 	"fmt"
@@ -234,7 +233,7 @@ func TestMain(m *testing.M) {
 
 // postResourceFile creates a resource at path via the files endpoint, which both stores the
 // file in the repository and provisions the resource into Grafana.
-func postResourceFile(t *testing.T, ctx context.Context, helper *common.ProvisioningTestHelper, rk resourceKind, repo, filePath, name, title string) {
+func postResourceFile(t *testing.T, helper *common.ProvisioningTestHelper, rk resourceKind, repo, filePath, name, title string) {
 	t.Helper()
 	res := helper.AdminREST.Post().
 		Namespace("default").
@@ -243,14 +242,14 @@ func postResourceFile(t *testing.T, ctx context.Context, helper *common.Provisio
 		SubResource("files", filePath).
 		Body(common.ResourceToJSON(t, rk.newResource(t, name, title))).
 		SetHeader("Content-Type", "application/json").
-		Do(ctx)
+		Do(t.Context())
 	require.NoError(t, res.Error(), "creating %s via the files endpoint should succeed", filePath)
 }
 
 // repositoryFilePaths returns the set of file paths currently in the repository.
-func repositoryFilePaths(t *testing.T, ctx context.Context, helper *common.ProvisioningTestHelper, repo string) []string {
+func repositoryFilePaths(t *testing.T, helper *common.ProvisioningTestHelper, repo string) []string {
 	t.Helper()
-	items := helper.ListRepositoryFiles(t, ctx, repo)
+	items := helper.ListRepositoryFiles(t, repo)
 	paths := make([]string, 0, len(items))
 	for _, item := range items {
 		paths = append(paths, item.Path)

--- a/pkg/tests/apis/provisioning/resourcekinds/jobs_test.go
+++ b/pkg/tests/apis/provisioning/resourcekinds/jobs_test.go
@@ -19,7 +19,6 @@ import (
 // the targeted files from the repository and deprovisions the resources from Grafana.
 func TestIntegrationProvisioning_ResourceKinds_DeleteJob(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	for _, rk := range resourceKinds {
 		rk := rk
@@ -41,9 +40,12 @@ func TestIntegrationProvisioning_ResourceKinds_DeleteJob(t *testing.T) {
 				name, title := rk.instance(i)
 				paths[i] = fmt.Sprintf("del-%s.json", name)
 				names[i] = name
-				postResourceFile(t, ctx, helper, rk, repo, paths[i], name, title)
-				_ = common.RequireResource(t, ctx, client.Resource, name)
-				t.Cleanup(func() { _ = client.Resource.Delete(ctx, name, metav1.DeleteOptions{}) })
+				postResourceFile(t, helper, rk, repo, paths[i], name, title)
+				_ = common.RequireResource(t, client.Resource, name)
+				t.Cleanup(func() {
+					cleanupCtx := context.WithoutCancel(t.Context())
+					_ = client.Resource.Delete(cleanupCtx, name, metav1.DeleteOptions{})
+				})
 			}
 
 			// Bulk delete both files in a single job.
@@ -52,11 +54,11 @@ func TestIntegrationProvisioning_ResourceKinds_DeleteJob(t *testing.T) {
 				Delete: &provisioning.DeleteJobOptions{Paths: paths},
 			})
 
-			repoFiles := repositoryFilePaths(t, ctx, helper, repo)
+			repoFiles := repositoryFilePaths(t, helper, repo)
 			for i := range paths {
 				require.NotContains(t, repoFiles, paths[i], "%s should be deleted from the repository", paths[i])
 				require.EventuallyWithT(t, func(collect *assert.CollectT) {
-					_, err := client.Resource.Get(ctx, names[i], metav1.GetOptions{})
+					_, err := client.Resource.Get(t.Context(), names[i], metav1.GetOptions{})
 					assert.True(collect, apierrors.IsNotFound(err), "%s should be deprovisioned, got: %v", names[i], err)
 				}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "%s should be deleted by the delete job", names[i])
 			}
@@ -69,7 +71,6 @@ func TestIntegrationProvisioning_ResourceKinds_DeleteJob(t *testing.T) {
 // refreshes each moved resource's source-path annotation (git-ui-sync-project#1199).
 func TestIntegrationProvisioning_ResourceKinds_MoveJob(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	for _, rk := range resourceKinds {
 		rk := rk
@@ -91,9 +92,12 @@ func TestIntegrationProvisioning_ResourceKinds_MoveJob(t *testing.T) {
 				name, title := rk.instance(i)
 				paths[i] = fmt.Sprintf("mv-%s.json", name)
 				names[i] = name
-				postResourceFile(t, ctx, helper, rk, repo, paths[i], name, title)
-				_ = common.RequireResource(t, ctx, client.Resource, name)
-				t.Cleanup(func() { _ = client.Resource.Delete(ctx, name, metav1.DeleteOptions{}) })
+				postResourceFile(t, helper, rk, repo, paths[i], name, title)
+				_ = common.RequireResource(t, client.Resource, name)
+				t.Cleanup(func() {
+					cleanupCtx := context.WithoutCancel(t.Context())
+					_ = client.Resource.Delete(cleanupCtx, name, metav1.DeleteOptions{})
+				})
 			}
 
 			// Bulk move both files into a subdirectory in a single job. The move plus its
@@ -103,13 +107,13 @@ func TestIntegrationProvisioning_ResourceKinds_MoveJob(t *testing.T) {
 				Move:   &provisioning.MoveJobOptions{Paths: paths, TargetPath: "archived/"},
 			})
 
-			repoFiles := repositoryFilePaths(t, ctx, helper, repo)
+			repoFiles := repositoryFilePaths(t, helper, repo)
 			for i := range paths {
 				movedPath := "archived/" + paths[i]
 				require.NotContains(t, repoFiles, paths[i], "%s should no longer be at its original path", paths[i])
 				require.Contains(t, repoFiles, movedPath, "%s should be moved under archived/", paths[i])
 				require.EventuallyWithT(t, func(collect *assert.CollectT) {
-					got, err := client.Resource.Get(ctx, names[i], metav1.GetOptions{})
+					got, err := client.Resource.Get(t.Context(), names[i], metav1.GetOptions{})
 					if !assert.NoError(collect, err) {
 						return
 					}

--- a/pkg/tests/apis/provisioning/resourcekinds/jobs_test.go
+++ b/pkg/tests/apis/provisioning/resourcekinds/jobs_test.go
@@ -27,10 +27,9 @@ func TestIntegrationProvisioning_ResourceKinds_DeleteJob(t *testing.T) {
 
 			repo := rk.name + "-delete-job-repo"
 			helper.CreateLocalRepo(t, common.TestRepo{
-				Name:                   repo,
-				SyncTarget:             "folder",
-				Workflows:              []string{"write"},
-				SkipResourceAssertions: true,
+				Name:       repo,
+				SyncTarget: "folder",
+				Workflows:  []string{"write"},
 			})
 
 			const count = 2
@@ -42,10 +41,8 @@ func TestIntegrationProvisioning_ResourceKinds_DeleteJob(t *testing.T) {
 				names[i] = name
 				postResourceFile(t, helper, rk, repo, paths[i], name, title)
 				_ = common.RequireResource(t, client.Resource, name)
-				t.Cleanup(func() {
-					cleanupCtx := context.WithoutCancel(t.Context())
-					_ = client.Resource.Delete(cleanupCtx, name, metav1.DeleteOptions{})
-				})
+				cleanupCtx := context.WithoutCancel(t.Context())
+				t.Cleanup(func() { _ = client.Resource.Delete(cleanupCtx, name, metav1.DeleteOptions{}) })
 			}
 
 			// Bulk delete both files in a single job.
@@ -79,10 +76,9 @@ func TestIntegrationProvisioning_ResourceKinds_MoveJob(t *testing.T) {
 
 			repo := rk.name + "-move-job-repo"
 			helper.CreateLocalRepo(t, common.TestRepo{
-				Name:                   repo,
-				SyncTarget:             "folder",
-				Workflows:              []string{"write"},
-				SkipResourceAssertions: true,
+				Name:       repo,
+				SyncTarget: "folder",
+				Workflows:  []string{"write"},
 			})
 
 			const count = 2
@@ -94,10 +90,8 @@ func TestIntegrationProvisioning_ResourceKinds_MoveJob(t *testing.T) {
 				names[i] = name
 				postResourceFile(t, helper, rk, repo, paths[i], name, title)
 				_ = common.RequireResource(t, client.Resource, name)
-				t.Cleanup(func() {
-					cleanupCtx := context.WithoutCancel(t.Context())
-					_ = client.Resource.Delete(cleanupCtx, name, metav1.DeleteOptions{})
-				})
+				cleanupCtx := context.WithoutCancel(t.Context())
+				t.Cleanup(func() { _ = client.Resource.Delete(cleanupCtx, name, metav1.DeleteOptions{}) })
 			}
 
 			// Bulk move both files into a subdirectory in a single job. The move plus its

--- a/pkg/tests/apis/provisioning/resourcekinds/sync_test.go
+++ b/pkg/tests/apis/provisioning/resourcekinds/sync_test.go
@@ -28,9 +28,8 @@ func TestIntegrationProvisioning_ResourceKinds_Sync(t *testing.T) {
 
 			repo := rk.name + "-sync-repo"
 			helper.CreateLocalRepo(t, common.TestRepo{
-				Name:                   repo,
-				SyncTarget:             "folder",
-				SkipResourceAssertions: true,
+				Name:       repo,
+				SyncTarget: "folder",
 			})
 
 			const count = 3
@@ -45,10 +44,8 @@ func TestIntegrationProvisioning_ResourceKinds_Sync(t *testing.T) {
 					filePath = rk.name + "-folder/" + filePath
 				}
 				helper.WriteToProvisioningPath(t, filePath, common.ResourceToJSON(t, rk.newResource(t, name, title)))
-				t.Cleanup(func() {
-					cleanupCtx := context.WithoutCancel(t.Context())
-					_ = client.Resource.Delete(cleanupCtx, name, metav1.DeleteOptions{})
-				})
+				cleanupCtx := context.WithoutCancel(t.Context())
+				t.Cleanup(func() { _ = client.Resource.Delete(cleanupCtx, name, metav1.DeleteOptions{}) })
 			}
 
 			helper.SyncAndWait(t, repo, nil)

--- a/pkg/tests/apis/provisioning/resourcekinds/sync_test.go
+++ b/pkg/tests/apis/provisioning/resourcekinds/sync_test.go
@@ -20,7 +20,6 @@ import (
 // deleting the repository removes all of them.
 func TestIntegrationProvisioning_ResourceKinds_Sync(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	for _, rk := range resourceKinds {
 		rk := rk
@@ -46,14 +45,17 @@ func TestIntegrationProvisioning_ResourceKinds_Sync(t *testing.T) {
 					filePath = rk.name + "-folder/" + filePath
 				}
 				helper.WriteToProvisioningPath(t, filePath, common.ResourceToJSON(t, rk.newResource(t, name, title)))
-				t.Cleanup(func() { _ = client.Resource.Delete(ctx, name, metav1.DeleteOptions{}) })
+				t.Cleanup(func() {
+					cleanupCtx := context.WithoutCancel(t.Context())
+					_ = client.Resource.Delete(cleanupCtx, name, metav1.DeleteOptions{})
+				})
 			}
 
 			helper.SyncAndWait(t, repo, nil)
 
 			for i, name := range names {
 				_, wantTitle := rk.instance(i)
-				got := common.RequireResource(t, ctx, client.Resource, name)
+				got := common.RequireResource(t, client.Resource, name)
 
 				title, _, _ := unstructured.NestedString(got.Object, "spec", "title")
 				require.Equal(t, wantTitle, title)
@@ -69,11 +71,11 @@ func TestIntegrationProvisioning_ResourceKinds_Sync(t *testing.T) {
 			}
 
 			// Deleting the repository must sweep away every resource it provisioned.
-			require.NoError(t, helper.Repositories.Resource.Delete(ctx, repo, metav1.DeleteOptions{}))
-			helper.WaitForRepositoryDeleted(t, ctx, repo)
+			require.NoError(t, helper.Repositories.Resource.Delete(t.Context(), repo, metav1.DeleteOptions{}))
+			helper.WaitForRepositoryDeleted(t, repo)
 			for _, name := range names {
 				require.EventuallyWithT(t, func(collect *assert.CollectT) {
-					_, err := client.Resource.Get(ctx, name, metav1.GetOptions{})
+					_, err := client.Resource.Get(t.Context(), name, metav1.GetOptions{})
 					assert.True(collect, apierrors.IsNotFound(err), "%s should be removed after repo delete, got: %v", name, err)
 				}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "%s should be deleted with the repository", name)
 			}

--- a/pkg/tests/apis/provisioning/root_folder_sync_modes_test.go
+++ b/pkg/tests/apis/provisioning/root_folder_sync_modes_test.go
@@ -50,9 +50,10 @@ func TestIntegrationProvisioning_RootFolder_FolderMode(t *testing.T) {
 			"testdata/all-panels.json":    "dashboard.json",
 			"testdata/timeline-demo.json": "team/dashboard.json",
 		},
-		ExpectedDashboards: 2,
-		ExpectedFolders:    2,
 	})
+
+	helper.RequireRepoDashboardCount(t, repo, 2)
+	helper.RequireRepoFolderCount(t, repo, 2)
 
 	// The root folder's k8s name is the repository name. Wait for it to be
 	// created and settled (title, empty sourcePath, empty parent) before reading
@@ -94,9 +95,10 @@ func TestIntegrationProvisioning_RootFolder_FolderlessMode(t *testing.T) {
 			"testdata/timeline-demo.json": "platform/dashboard.json",
 			"testdata/text-options.json":  "applications/nested/dashboard.json",
 		},
-		ExpectedDashboards: 3,
-		ExpectedFolders:    3,
 	})
+
+	helper.RequireRepoDashboardCount(t, repo, 3)
+	helper.RequireRepoFolderCount(t, repo, 3)
 
 	// No wrapper folder named after the repository must exist in folderless mode.
 	// CreateLocalRepo already waited for exactly ExpectedFolders to settle, so a

--- a/pkg/tests/apis/provisioning/secrets_test.go
+++ b/pkg/tests/apis/provisioning/secrets_test.go
@@ -1,7 +1,6 @@
 package provisioning
 
 import (
-	"context"
 	"strings"
 	"testing"
 
@@ -16,7 +15,6 @@ import (
 func TestIntegrationProvisioning_InlineSecrets(t *testing.T) {
 	helper := sharedHelper(t)
 	createOptions := metav1.CreateOptions{FieldValidation: "Strict"}
-	ctx := context.Background()
 
 	decryptService := helper.GetEnv().DecryptService
 	require.NotNil(t, decryptService, "decrypt service not wired properly")
@@ -59,7 +57,7 @@ func TestIntegrationProvisioning_InlineSecrets(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			input := helper.RenderObject(t, test.inputFile, test.values)
-			obj, err := helper.Repositories.Resource.Create(ctx, input, createOptions)
+			obj, err := helper.Repositories.Resource.Create(t.Context(), input, createOptions)
 			require.NoError(t, err, "failed to create resource")
 			require.True(t, strings.HasPrefix(obj.GetName(), "test-"), "created a unique name")
 			var created []string
@@ -73,7 +71,7 @@ func TestIntegrationProvisioning_InlineSecrets(t *testing.T) {
 				created = append(created, name)
 
 				if expectedField.DecryptedValue != "" {
-					decrypted, err := decryptService.Decrypt(ctx, "provisioning.grafana.app", obj.GetNamespace(), name)
+					decrypted, err := decryptService.Decrypt(t.Context(), "provisioning.grafana.app", obj.GetNamespace(), name)
 					require.NoError(t, err, "decryption error")
 					require.Len(t, decrypted, 1)
 
@@ -83,17 +81,17 @@ func TestIntegrationProvisioning_InlineSecrets(t *testing.T) {
 				}
 			}
 
-			err = helper.Repositories.Resource.Delete(ctx, obj.GetName(), metav1.DeleteOptions{})
+			err = helper.Repositories.Resource.Delete(t.Context(), obj.GetName(), metav1.DeleteOptions{})
 			require.NoError(t, err, "failed to delete repository")
 
-			helper.WaitForRepositoryDeleted(t, ctx, obj.GetName())
+			helper.WaitForRepositoryDeleted(t, obj.GetName())
 
 			// Inline secrets are cleaned up asynchronously (owner-reference GC
 			// and the secret garbage-collection worker) after the repository
 			// finalizer chain completes, so poll until every secret reports
 			// not found rather than asserting once.
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {
-				results, err := decryptService.Decrypt(ctx, "provisioning.grafana.app", obj.GetNamespace(), created...)
+				results, err := decryptService.Decrypt(t.Context(), "provisioning.grafana.app", obj.GetNamespace(), created...)
 				if !assert.NoError(collect, err, "failed to execute decrypt with removed secrets") {
 					return
 				}

--- a/pkg/tests/apis/provisioning/settings_stats_auth_test.go
+++ b/pkg/tests/apis/provisioning/settings_stats_auth_test.go
@@ -158,12 +158,13 @@ func TestIntegrationProvisioning_StatsAuthorization(t *testing.T) {
 	// Create a repository to ensure stats endpoint has data
 	const repo = "stats-auth-test"
 	helper.CreateLocalRepo(t, common.TestRepo{
-		Name:               repo,
-		SyncTarget:         "folder",
-		Copies:             map[string]string{},
-		ExpectedDashboards: 0,
-		ExpectedFolders:    1,
+		Name:       repo,
+		SyncTarget: "folder",
+		Copies:     map[string]string{},
 	})
+
+	helper.RequireRepoDashboardCount(t, repo, 0)
+	helper.RequireRepoFolderCount(t, repo, 1)
 
 	t.Run("admin can GET stats", func(t *testing.T) {
 		var statusCode int

--- a/pkg/tests/apis/provisioning/settings_stats_auth_test.go
+++ b/pkg/tests/apis/provisioning/settings_stats_auth_test.go
@@ -1,7 +1,6 @@
 package provisioning
 
 import (
-	"context"
 	"net/http"
 	"testing"
 
@@ -15,14 +14,13 @@ import (
 
 func TestIntegrationProvisioning_SettingsAuthorization(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	t.Run("viewer can GET settings", func(t *testing.T) {
 		var statusCode int
 		result := helper.ViewerREST.Get().
 			Namespace("default").
 			Resource("settings").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.NoError(t, result.Error(), "viewer should be able to GET settings")
 		require.Equal(t, http.StatusOK, statusCode, "should return 200 OK")
@@ -33,7 +31,7 @@ func TestIntegrationProvisioning_SettingsAuthorization(t *testing.T) {
 		result := helper.EditorREST.Get().
 			Namespace("default").
 			Resource("settings").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.NoError(t, result.Error(), "editor should be able to GET settings")
 		require.Equal(t, http.StatusOK, statusCode, "should return 200 OK")
@@ -44,7 +42,7 @@ func TestIntegrationProvisioning_SettingsAuthorization(t *testing.T) {
 		result := helper.AdminREST.Get().
 			Namespace("default").
 			Resource("settings").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.NoError(t, result.Error(), "admin should be able to GET settings")
 		require.Equal(t, http.StatusOK, statusCode, "should return 200 OK")
@@ -54,13 +52,12 @@ func TestIntegrationProvisioning_SettingsAuthorization(t *testing.T) {
 		// HACK: Explicitly set to 10 to test default behavior, since we can't distinguish "not set" from "set to 0"
 		helper := sharedHelper(t)
 		helper.SetQuotaStatus(provisioning.QuotaStatus{MaxRepositories: 10}) // Explicitly set to default to test default behavior
-		ctx := context.Background()
 
 		settings := &provisioning.RepositoryViewList{}
 		result := helper.AdminREST.Get().
 			Namespace("default").
 			Resource("settings").
-			Do(ctx)
+			Do(t.Context())
 
 		require.NoError(t, result.Error(), "should be able to GET settings")
 		err := result.Into(settings)
@@ -73,13 +70,12 @@ func TestIntegrationProvisioning_SettingsAuthorization(t *testing.T) {
 	t.Run("settings endpoint returns 0 when unlimited is configured", func(t *testing.T) {
 		helper := sharedHelper(t)
 		helper.SetQuotaStatus(provisioning.QuotaStatus{MaxRepositories: 0}) // 0 means unlimited
-		ctx := context.Background()
 
 		settings := &provisioning.RepositoryViewList{}
 		result := helper.AdminREST.Get().
 			Namespace("default").
 			Resource("settings").
-			Do(ctx)
+			Do(t.Context())
 
 		require.NoError(t, result.Error(), "should be able to GET settings")
 		err := result.Into(settings)
@@ -92,13 +88,12 @@ func TestIntegrationProvisioning_SettingsAuthorization(t *testing.T) {
 	t.Run("settings endpoint returns configured value", func(t *testing.T) {
 		helper := sharedHelper(t)
 		helper.SetQuotaStatus(provisioning.QuotaStatus{MaxRepositories: 1000})
-		ctx := context.Background()
 
 		settings := &provisioning.RepositoryViewList{}
 		result := helper.AdminREST.Get().
 			Namespace("default").
 			Resource("settings").
-			Do(ctx)
+			Do(t.Context())
 
 		require.NoError(t, result.Error(), "should be able to GET settings")
 		err := result.Into(settings)
@@ -113,7 +108,7 @@ func TestIntegrationProvisioning_SettingsAuthorization(t *testing.T) {
 		result := helper.AdminREST.Get().
 			Namespace("default").
 			Resource("settings").
-			Do(ctx)
+			Do(t.Context())
 
 		require.NoError(t, result.Error(), "should be able to GET settings")
 		require.NoError(t, result.Into(settings), "should be able to unmarshal settings response")
@@ -142,13 +137,12 @@ func TestIntegrationProvisioning_SettingsExtraResources(t *testing.T) {
 			"example.grafana.app/Example",
 		}
 	})
-	ctx := context.Background()
 
 	settings := &provisioning.RepositoryViewList{}
 	result := helper.AdminREST.Get().
 		Namespace("default").
 		Resource("settings").
-		Do(ctx)
+		Do(t.Context())
 
 	require.NoError(t, result.Error(), "should be able to GET settings")
 	require.NoError(t, result.Into(settings), "should be able to unmarshal settings response")
@@ -160,7 +154,6 @@ func TestIntegrationProvisioning_SettingsExtraResources(t *testing.T) {
 
 func TestIntegrationProvisioning_StatsAuthorization(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	// Create a repository to ensure stats endpoint has data
 	const repo = "stats-auth-test"
@@ -177,7 +170,7 @@ func TestIntegrationProvisioning_StatsAuthorization(t *testing.T) {
 		result := helper.AdminREST.Get().
 			Namespace("default").
 			Resource("stats").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.NoError(t, result.Error(), "admin should be able to GET stats")
 		require.Equal(t, http.StatusOK, statusCode, "should return 200 OK")
@@ -188,7 +181,7 @@ func TestIntegrationProvisioning_StatsAuthorization(t *testing.T) {
 		result := helper.EditorREST.Get().
 			Namespace("default").
 			Resource("stats").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.Error(t, result.Error(), "editor should not be able to GET stats")
 		require.Equal(t, http.StatusForbidden, statusCode, "should return 403 Forbidden")
@@ -200,7 +193,7 @@ func TestIntegrationProvisioning_StatsAuthorization(t *testing.T) {
 		result := helper.ViewerREST.Get().
 			Namespace("default").
 			Resource("stats").
-			Do(ctx).StatusCode(&statusCode)
+			Do(t.Context()).StatusCode(&statusCode)
 
 		require.Error(t, result.Error(), "viewer should not be able to GET stats")
 		require.Equal(t, http.StatusForbidden, statusCode, "should return 403 Forbidden")

--- a/pkg/tests/apis/provisioning/stats_test.go
+++ b/pkg/tests/apis/provisioning/stats_test.go
@@ -23,10 +23,11 @@ func TestIntegrationProvisioning_Stats(t *testing.T) {
 			"testdata/all-panels.json":   "dashboard1.json",
 			"testdata/text-options.json": "folder/dashboard2.json",
 		},
-		ExpectedDashboards: 2,
-		ExpectedFolders:    2, // folder sync creates a folder for the repo + one nested folder
 	}
 	helper.CreateLocalRepo(t, testRepo)
+
+	helper.RequireRepoDashboardCount(t, repo, 2)
+	helper.RequireRepoFolderCount(t, repo, 2)
 
 	// Create some unmanaged dashboards directly in Grafana
 	unmanagedDash1 := helper.LoadYAMLOrJSONFile("exportunifiedtorepository/dashboard-test-v1.yaml")

--- a/pkg/tests/apis/provisioning/stats_test.go
+++ b/pkg/tests/apis/provisioning/stats_test.go
@@ -1,7 +1,6 @@
 package provisioning
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -14,7 +13,6 @@ import (
 
 func TestIntegrationProvisioning_Stats(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	const repo = "stats-test-repo1"
 
@@ -32,12 +30,12 @@ func TestIntegrationProvisioning_Stats(t *testing.T) {
 
 	// Create some unmanaged dashboards directly in Grafana
 	unmanagedDash1 := helper.LoadYAMLOrJSONFile("exportunifiedtorepository/dashboard-test-v1.yaml")
-	dashboard1Obj, err := helper.DashboardsV1.Resource.Create(ctx, unmanagedDash1, metav1.CreateOptions{})
+	dashboard1Obj, err := helper.DashboardsV1.Resource.Create(t.Context(), unmanagedDash1, metav1.CreateOptions{})
 	require.NoError(t, err, "should be able to create unmanaged dashboard")
 	dashboard1Name := dashboard1Obj.GetName()
 
 	// Verify that the unmanaged dashboard is indeed unmanaged
-	dashboard1, err := helper.DashboardsV1.Resource.Get(ctx, dashboard1Name, metav1.GetOptions{})
+	dashboard1, err := helper.DashboardsV1.Resource.Get(t.Context(), dashboard1Name, metav1.GetOptions{})
 	require.NoError(t, err)
 	manager1, found1 := dashboard1.GetAnnotations()[utils.AnnoKeyManagerIdentity]
 	require.True(t, !found1 || manager1 == "", "dashboard1 should be unmanaged")
@@ -46,7 +44,7 @@ func TestIntegrationProvisioning_Stats(t *testing.T) {
 	result := helper.AdminREST.Get().
 		Namespace("default").
 		Resource("stats").
-		Do(ctx)
+		Do(t.Context())
 	require.NoError(t, result.Error(), "should be able to get global stats")
 
 	statsObj, err := result.Get()

--- a/pkg/tests/apis/provisioning/sync_folder_metadata_flag_disabled_test.go
+++ b/pkg/tests/apis/provisioning/sync_folder_metadata_flag_disabled_test.go
@@ -23,8 +23,7 @@ func TestIntegrationProvisioning_FullSync_MissingFolderMetadata_FlagDisabled(t *
 		Copies: map[string]string{
 			"testdata/all-panels.json": "myfolder/dashboard.json",
 		},
-		SkipSync:               true,
-		SkipResourceAssertions: true,
+		SkipSync: true,
 	})
 
 	job := helper.TriggerJobAndWaitForComplete(t, repo, provisioning.JobSpec{

--- a/pkg/tests/apis/provisioning/v1beta1/connection_test.go
+++ b/pkg/tests/apis/provisioning/v1beta1/connection_test.go
@@ -1,7 +1,6 @@
 package v1beta1
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -28,7 +27,6 @@ func TestIntegrationV1Beta1Connection_Create_GitHub(t *testing.T) {
 	})
 
 	client := common.GetConnectionClientV1Beta1(helper)
-	ctx := context.Background()
 	namespace := "default"
 
 	connection := &provisioning.Connection{
@@ -58,7 +56,7 @@ func TestIntegrationV1Beta1Connection_Create_GitHub(t *testing.T) {
 	unstructuredObj, err := common.ToUnstructured(connection)
 	require.NoError(t, err)
 
-	created, err := client.Resource.Create(ctx, unstructuredObj, metav1.CreateOptions{})
+	created, err := client.Resource.Create(t.Context(), unstructuredObj, metav1.CreateOptions{})
 	require.NoError(t, err)
 	require.NotNil(t, created)
 
@@ -76,7 +74,7 @@ func TestIntegrationV1Beta1Connection_Create_GitHub(t *testing.T) {
 	require.Empty(t, createdConn.Secure.PrivateKey.Create)
 
 	// Clean up
-	err = client.Resource.Delete(ctx, connection.Name, metav1.DeleteOptions{})
+	err = client.Resource.Delete(t.Context(), connection.Name, metav1.DeleteOptions{})
 	require.NoError(t, err)
 }
 
@@ -92,7 +90,6 @@ func TestIntegrationV1Beta1Connection_Create_GitLab(t *testing.T) {
 	})
 
 	client := common.GetConnectionClientV1Beta1(helper)
-	ctx := context.Background()
 	namespace := "default"
 
 	connection := &provisioning.Connection{
@@ -121,7 +118,7 @@ func TestIntegrationV1Beta1Connection_Create_GitLab(t *testing.T) {
 	unstructuredObj, err := common.ToUnstructured(connection)
 	require.NoError(t, err)
 
-	created, err := client.Resource.Create(ctx, unstructuredObj, metav1.CreateOptions{})
+	created, err := client.Resource.Create(t.Context(), unstructuredObj, metav1.CreateOptions{})
 	require.NoError(t, err)
 	require.NotNil(t, created)
 
@@ -131,7 +128,7 @@ func TestIntegrationV1Beta1Connection_Create_GitLab(t *testing.T) {
 	require.Equal(t, "gitlab-client-123", createdConn.Spec.Gitlab.ClientID)
 
 	// Clean up
-	err = client.Resource.Delete(ctx, connection.Name, metav1.DeleteOptions{})
+	err = client.Resource.Delete(t.Context(), connection.Name, metav1.DeleteOptions{})
 	require.NoError(t, err)
 }
 
@@ -147,7 +144,6 @@ func TestIntegrationV1Beta1Connection_Create_Bitbucket(t *testing.T) {
 	})
 
 	client := common.GetConnectionClientV1Beta1(helper)
-	ctx := context.Background()
 	namespace := "default"
 
 	connection := &provisioning.Connection{
@@ -176,7 +172,7 @@ func TestIntegrationV1Beta1Connection_Create_Bitbucket(t *testing.T) {
 	unstructuredObj, err := common.ToUnstructured(connection)
 	require.NoError(t, err)
 
-	created, err := client.Resource.Create(ctx, unstructuredObj, metav1.CreateOptions{})
+	created, err := client.Resource.Create(t.Context(), unstructuredObj, metav1.CreateOptions{})
 	require.NoError(t, err)
 	require.NotNil(t, created)
 
@@ -186,7 +182,7 @@ func TestIntegrationV1Beta1Connection_Create_Bitbucket(t *testing.T) {
 	require.Equal(t, "bitbucket-client-456", createdConn.Spec.Bitbucket.ClientID)
 
 	// Clean up
-	err = client.Resource.Delete(ctx, connection.Name, metav1.DeleteOptions{})
+	err = client.Resource.Delete(t.Context(), connection.Name, metav1.DeleteOptions{})
 	require.NoError(t, err)
 }
 
@@ -201,7 +197,6 @@ func TestIntegrationV1Beta1Connection_Get(t *testing.T) {
 	})
 
 	client := common.GetConnectionClientV1Beta1(helper)
-	ctx := context.Background()
 	namespace := "default"
 
 	// Create a connection first
@@ -232,11 +227,11 @@ func TestIntegrationV1Beta1Connection_Get(t *testing.T) {
 	unstructuredObj, err := common.ToUnstructured(connection)
 	require.NoError(t, err)
 
-	_, err = client.Resource.Create(ctx, unstructuredObj, metav1.CreateOptions{})
+	_, err = client.Resource.Create(t.Context(), unstructuredObj, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	// Get the connection
-	retrieved, err := client.Resource.Get(ctx, "test-get-connection", metav1.GetOptions{})
+	retrieved, err := client.Resource.Get(t.Context(), "test-get-connection", metav1.GetOptions{})
 	require.NoError(t, err)
 	require.NotNil(t, retrieved)
 
@@ -247,7 +242,7 @@ func TestIntegrationV1Beta1Connection_Get(t *testing.T) {
 	require.Equal(t, provisioning.GithubConnectionType, retrievedConn.Spec.Type)
 
 	// Clean up
-	err = client.Resource.Delete(ctx, connection.Name, metav1.DeleteOptions{})
+	err = client.Resource.Delete(t.Context(), connection.Name, metav1.DeleteOptions{})
 	require.NoError(t, err)
 }
 
@@ -262,7 +257,6 @@ func TestIntegrationV1Beta1Connection_List(t *testing.T) {
 	})
 
 	client := common.GetConnectionClientV1Beta1(helper)
-	ctx := context.Background()
 	namespace := "default"
 
 	// Create a connection first
@@ -293,11 +287,11 @@ func TestIntegrationV1Beta1Connection_List(t *testing.T) {
 	unstructuredObj, err := common.ToUnstructured(connection)
 	require.NoError(t, err)
 
-	_, err = client.Resource.Create(ctx, unstructuredObj, metav1.CreateOptions{})
+	_, err = client.Resource.Create(t.Context(), unstructuredObj, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	// List connections
-	list, err := client.Resource.List(ctx, metav1.ListOptions{})
+	list, err := client.Resource.List(t.Context(), metav1.ListOptions{})
 	require.NoError(t, err)
 	require.NotNil(t, list)
 	require.GreaterOrEqual(t, len(list.Items), 1)
@@ -313,7 +307,7 @@ func TestIntegrationV1Beta1Connection_List(t *testing.T) {
 	require.True(t, found, "Created connection should be in the list")
 
 	// Clean up
-	err = client.Resource.Delete(ctx, connection.Name, metav1.DeleteOptions{})
+	err = client.Resource.Delete(t.Context(), connection.Name, metav1.DeleteOptions{})
 	require.NoError(t, err)
 }
 
@@ -328,7 +322,6 @@ func TestIntegrationV1Beta1Connection_Update(t *testing.T) {
 	})
 
 	client := common.GetConnectionClientV1Beta1(helper)
-	ctx := context.Background()
 	namespace := "default"
 
 	// Create a connection first
@@ -359,11 +352,11 @@ func TestIntegrationV1Beta1Connection_Update(t *testing.T) {
 	unstructuredObj, err := common.ToUnstructured(connection)
 	require.NoError(t, err)
 
-	_, err = client.Resource.Create(ctx, unstructuredObj, metav1.CreateOptions{})
+	_, err = client.Resource.Create(t.Context(), unstructuredObj, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	// Get the current object
-	current, err := client.Resource.Get(ctx, "test-update-connection", metav1.GetOptions{})
+	current, err := client.Resource.Get(t.Context(), "test-update-connection", metav1.GetOptions{})
 	require.NoError(t, err)
 
 	currentConn, err := common.FromUnstructured[provisioning.Connection](current)
@@ -375,7 +368,7 @@ func TestIntegrationV1Beta1Connection_Update(t *testing.T) {
 	unstructuredObj, err = common.ToUnstructured(currentConn)
 	require.NoError(t, err)
 
-	updated, err := client.Resource.Update(ctx, unstructuredObj, metav1.UpdateOptions{})
+	updated, err := client.Resource.Update(t.Context(), unstructuredObj, metav1.UpdateOptions{})
 	require.NoError(t, err)
 	require.NotNil(t, updated)
 
@@ -384,14 +377,14 @@ func TestIntegrationV1Beta1Connection_Update(t *testing.T) {
 	require.Equal(t, "999999", updatedConn.Spec.GitHub.AppID)
 
 	// Verify the update persisted
-	retrieved, err := client.Resource.Get(ctx, "test-update-connection", metav1.GetOptions{})
+	retrieved, err := client.Resource.Get(t.Context(), "test-update-connection", metav1.GetOptions{})
 	require.NoError(t, err)
 	retrievedConn, err := common.FromUnstructured[provisioning.Connection](retrieved)
 	require.NoError(t, err)
 	require.Equal(t, "999999", retrievedConn.Spec.GitHub.AppID)
 
 	// Clean up
-	err = client.Resource.Delete(ctx, connection.Name, metav1.DeleteOptions{})
+	err = client.Resource.Delete(t.Context(), connection.Name, metav1.DeleteOptions{})
 	require.NoError(t, err)
 }
 
@@ -406,7 +399,6 @@ func TestIntegrationV1Beta1Connection_Delete(t *testing.T) {
 	})
 
 	client := common.GetConnectionClientV1Beta1(helper)
-	ctx := context.Background()
 	namespace := "default"
 
 	// Create a connection first
@@ -437,15 +429,15 @@ func TestIntegrationV1Beta1Connection_Delete(t *testing.T) {
 	unstructuredObj, err := common.ToUnstructured(connection)
 	require.NoError(t, err)
 
-	_, err = client.Resource.Create(ctx, unstructuredObj, metav1.CreateOptions{})
+	_, err = client.Resource.Create(t.Context(), unstructuredObj, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	// Delete the connection
-	err = client.Resource.Delete(ctx, "test-delete-connection", metav1.DeleteOptions{})
+	err = client.Resource.Delete(t.Context(), "test-delete-connection", metav1.DeleteOptions{})
 	require.NoError(t, err)
 
 	// Verify it's deleted
-	_, err = client.Resource.Get(ctx, "test-delete-connection", metav1.GetOptions{})
+	_, err = client.Resource.Get(t.Context(), "test-delete-connection", metav1.GetOptions{})
 	require.Error(t, err)
 	require.True(t, apierrors.IsNotFound(err), "Expected NotFound error after deletion")
 }

--- a/pkg/tests/apis/provisioning/v1beta1/connection_test.go
+++ b/pkg/tests/apis/provisioning/v1beta1/connection_test.go
@@ -27,6 +27,7 @@ func TestIntegrationV1Beta1Connection_Create_GitHub(t *testing.T) {
 	})
 
 	client := common.GetConnectionClientV1Beta1(helper)
+
 	namespace := "default"
 
 	connection := &provisioning.Connection{
@@ -90,6 +91,7 @@ func TestIntegrationV1Beta1Connection_Create_GitLab(t *testing.T) {
 	})
 
 	client := common.GetConnectionClientV1Beta1(helper)
+
 	namespace := "default"
 
 	connection := &provisioning.Connection{
@@ -144,6 +146,7 @@ func TestIntegrationV1Beta1Connection_Create_Bitbucket(t *testing.T) {
 	})
 
 	client := common.GetConnectionClientV1Beta1(helper)
+
 	namespace := "default"
 
 	connection := &provisioning.Connection{
@@ -197,6 +200,7 @@ func TestIntegrationV1Beta1Connection_Get(t *testing.T) {
 	})
 
 	client := common.GetConnectionClientV1Beta1(helper)
+
 	namespace := "default"
 
 	// Create a connection first
@@ -257,6 +261,7 @@ func TestIntegrationV1Beta1Connection_List(t *testing.T) {
 	})
 
 	client := common.GetConnectionClientV1Beta1(helper)
+
 	namespace := "default"
 
 	// Create a connection first
@@ -322,6 +327,7 @@ func TestIntegrationV1Beta1Connection_Update(t *testing.T) {
 	})
 
 	client := common.GetConnectionClientV1Beta1(helper)
+
 	namespace := "default"
 
 	// Create a connection first
@@ -399,6 +405,7 @@ func TestIntegrationV1Beta1Connection_Delete(t *testing.T) {
 	})
 
 	client := common.GetConnectionClientV1Beta1(helper)
+
 	namespace := "default"
 
 	// Create a connection first

--- a/pkg/tests/apis/provisioning/v1beta1/repository_test.go
+++ b/pkg/tests/apis/provisioning/v1beta1/repository_test.go
@@ -3,7 +3,6 @@
 package v1beta1
 
 import (
-	"context"
 	"encoding/json"
 	"testing"
 	"time"
@@ -16,7 +15,6 @@ import (
 // TestIntegrationV1Beta1RepositoryCRUD tests basic CRUD operations on the v1beta1 Repository resource
 func TestIntegrationV1Beta1RepositoryCRUD(t *testing.T) {
 	helper := sharedHelper(t)
-	ctx := context.Background()
 
 	repoName := "test-v1beta1-repo"
 
@@ -54,7 +52,7 @@ func TestIntegrationV1Beta1RepositoryCRUD(t *testing.T) {
 			AbsPath("/apis/provisioning.grafana.app/v1beta1/namespaces/default/repositories").
 			Body(repoBytes).
 			SetHeader("Content-Type", "application/json").
-			Do(ctx)
+			Do(t.Context())
 
 		require.NoError(t, result.Error(), "should be able to create repository via v1beta1")
 
@@ -70,7 +68,7 @@ func TestIntegrationV1Beta1RepositoryCRUD(t *testing.T) {
 	t.Run("get repository via v1beta1", func(t *testing.T) {
 		result := helper.AdminREST.Get().
 			AbsPath("/apis/provisioning.grafana.app/v1beta1/namespaces/default/repositories/" + repoName).
-			Do(ctx)
+			Do(t.Context())
 
 		require.NoError(t, result.Error(), "should be able to get repository via v1beta1")
 
@@ -90,7 +88,7 @@ func TestIntegrationV1Beta1RepositoryCRUD(t *testing.T) {
 	t.Run("list repositories via v1beta1", func(t *testing.T) {
 		result := helper.AdminREST.Get().
 			AbsPath("/apis/provisioning.grafana.app/v1beta1/namespaces/default/repositories").
-			Do(ctx)
+			Do(t.Context())
 
 		require.NoError(t, result.Error(), "should be able to list repositories via v1beta1")
 
@@ -109,7 +107,7 @@ func TestIntegrationV1Beta1RepositoryCRUD(t *testing.T) {
 	t.Run("delete repository via v1beta1", func(t *testing.T) {
 		result := helper.AdminREST.Delete().
 			AbsPath("/apis/provisioning.grafana.app/v1beta1/namespaces/default/repositories/" + repoName).
-			Do(ctx)
+			Do(t.Context())
 
 		require.NoError(t, result.Error(), "should be able to delete repository via v1beta1")
 
@@ -117,7 +115,7 @@ func TestIntegrationV1Beta1RepositoryCRUD(t *testing.T) {
 		require.Eventually(t, func() bool {
 			result := helper.AdminREST.Get().
 				AbsPath("/apis/provisioning.grafana.app/v1beta1/namespaces/default/repositories/" + repoName).
-				Do(ctx)
+				Do(t.Context())
 			return result.Error() != nil
 		}, 10*time.Second, 100*time.Millisecond, "repository should be deleted")
 


### PR DESCRIPTION
**What is this feature?**

Two related cleanups to the provisioning integration test suite, split into separate commits since the second builds on the first:

1. Standardizes how tests get a cancellation context, using Go's per-test context consistently instead of a manually created one. https://github.com/grafana/grafana/pull/128618/changes/60a1ab9ee4a7ed3afda1d6cbc6d1d71a19a3001f
3. Consolidates how tests verify dashboard/folder counts after a sync, replacing several overlapping ways of doing this with one clear set of helpers. https://github.com/grafana/grafana/pull/128618/changes/c0c8f1d2a07e8ca4063d369aaa7a91b4bec4de60

**Why do we need this feature?**

Dashboard/folder counts were sometimes checked across the whole shared test namespace instead of the specific repository under test. Left-over resources from other tests running earlier could inflate those counts, causing intermittent test failures unrelated to the change actually being tested. This scopes those checks to the repository each test creates, removing that spillover.

**Who is this feature for?**

Internal — engineers working on the provisioning test suite.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

---
Description generated with the help of Claude Code.