### PR TITLE
Provisioning: Add show/hide reveal toggle to SecretInput (fixes Git Sync token paste in Edge)

### DIFF
--- a/packages/grafana-ui/src/components/SecretInput/SecretInput.mdx
+++ b/packages/grafana-ui/src/components/SecretInput/SecretInput.mdx
@@ -9,6 +9,11 @@ Used for secret/password input. It has 2 states: **_configured_** and **_not con
   clear the input and make it accessible.
 - In non configured state it behaves like a normal password input.
 
+Set `revealable` to show an eye icon button that toggles the secret between masked and plain text.
+This also helps when browser extensions block pasting into password fields. Note that `revealable`
+cannot be combined with the `suffix` prop, as the toggle occupies the input's suffix slot. While
+`loading` is true, the loading spinner takes priority and temporarily replaces the toggle.
+
 This is used for passwords or anything that is encrypted on the server and is
 later returned encrypted to the user (like datasource passwords).
 

--- a/packages/grafana-ui/src/components/SecretInput/SecretInput.story.tsx
+++ b/packages/grafana-ui/src/components/SecretInput/SecretInput.story.tsx
@@ -39,19 +39,21 @@ const meta: Meta<typeof SecretInput> = {
 
 export default meta;
 
-const Template: StoryFn<typeof SecretInput> = (args) => {
+const Template: StoryFn<typeof SecretInput> = ({ revealable, ...args }) => {
   const [secret, setSecret] = useState('');
+
+  const sharedProps = {
+    width: args.width,
+    value: secret,
+    isConfigured: args.isConfigured,
+    placeholder: args.placeholder,
+    onChange: (event: ChangeEvent<HTMLInputElement>) => setSecret(event.target.value.trim()),
+    onReset: () => setSecret(''),
+  };
 
   return (
     <Field label="Your secret password">
-      <SecretInput
-        width={args.width}
-        value={secret}
-        isConfigured={args.isConfigured}
-        placeholder={args.placeholder}
-        onChange={(event: ChangeEvent<HTMLInputElement>) => setSecret(event.target.value.trim())}
-        onReset={() => setSecret('')}
-      />
+      {revealable ? <SecretInput revealable={true} {...sharedProps} /> : <SecretInput {...sharedProps} />}
     </Field>
   );
 };
@@ -60,6 +62,14 @@ export const basic = Template.bind({});
 
 basic.args = {
   isConfigured: false,
+  revealable: false,
+};
+
+export const revealable = Template.bind({});
+
+revealable.args = {
+  isConfigured: false,
+  revealable: true,
 };
 
 export const secretIsConfigured = Template.bind({});

--- a/packages/grafana-ui/src/components/SecretInput/SecretInput.story.tsx
+++ b/packages/grafana-ui/src/components/SecretInput/SecretInput.story.tsx
@@ -39,21 +39,20 @@ const meta: Meta<typeof SecretInput> = {
 
 export default meta;
 
-const Template: StoryFn<typeof SecretInput> = ({ revealable, ...args }) => {
+const Template: StoryFn<typeof SecretInput> = (args) => {
   const [secret, setSecret] = useState('');
-
-  const sharedProps = {
-    width: args.width,
-    value: secret,
-    isConfigured: args.isConfigured,
-    placeholder: args.placeholder,
-    onChange: (event: ChangeEvent<HTMLInputElement>) => setSecret(event.target.value.trim()),
-    onReset: () => setSecret(''),
-  };
 
   return (
     <Field label="Your secret password">
-      {revealable ? <SecretInput revealable={true} {...sharedProps} /> : <SecretInput {...sharedProps} />}
+      <SecretInput
+        width={args.width}
+        value={secret}
+        isConfigured={args.isConfigured}
+        revealable={args.revealable}
+        placeholder={args.placeholder}
+        onChange={(event: ChangeEvent<HTMLInputElement>) => setSecret(event.target.value.trim())}
+        onReset={() => setSecret('')}
+      />
     </Field>
   );
 };

--- a/packages/grafana-ui/src/components/SecretInput/SecretInput.test.tsx
+++ b/packages/grafana-ui/src/components/SecretInput/SecretInput.test.tsx
@@ -62,4 +62,45 @@ describe('<SecretInput />', () => {
     expect(onChange).toHaveBeenCalled();
     expect(input).toHaveValue('Foo');
   });
+
+  it('should toggle the visibility of the secret between password and text', async () => {
+    render(<SecretInput isConfigured={false} onChange={() => {}} onReset={() => {}} placeholder={PLACEHOLDER_TEXT} />);
+
+    const input = screen.getByPlaceholderText(PLACEHOLDER_TEXT);
+
+    // The secret should be masked by default
+    expect(input).toHaveAttribute('type', 'password');
+
+    const toggle = screen.getByRole('switch');
+    expect(toggle).not.toBeChecked();
+
+    // Reveal the secret
+    await userEvent.click(toggle);
+    expect(input).toHaveAttribute('type', 'text');
+    expect(toggle).toBeChecked();
+
+    // Hide the secret again
+    await userEvent.click(toggle);
+    expect(input).toHaveAttribute('type', 'password');
+    expect(toggle).not.toBeChecked();
+  });
+
+  it('should allow pasting a value after the secret is revealed', async () => {
+    const onChange = jest.fn();
+
+    render(<SecretInput isConfigured={false} onChange={onChange} onReset={() => {}} placeholder={PLACEHOLDER_TEXT} />);
+
+    const input = screen.getByPlaceholderText(PLACEHOLDER_TEXT);
+
+    // Reveal the secret so it becomes a real text input
+    await userEvent.click(screen.getByRole('switch'));
+    expect(input).toHaveAttribute('type', 'text');
+
+    // Paste a value into the revealed field
+    input.focus();
+    await userEvent.paste('pasted-secret');
+
+    expect(onChange).toHaveBeenCalled();
+    expect(input).toHaveValue('pasted-secret');
+  });
 });

--- a/packages/grafana-ui/src/components/SecretInput/SecretInput.test.tsx
+++ b/packages/grafana-ui/src/components/SecretInput/SecretInput.test.tsx
@@ -63,8 +63,23 @@ describe('<SecretInput />', () => {
     expect(input).toHaveValue('Foo');
   });
 
-  it('should toggle the visibility of the secret between password and text', async () => {
+  it('should not render a visibility toggle by default', () => {
     render(<SecretInput isConfigured={false} onChange={() => {}} onReset={() => {}} placeholder={PLACEHOLDER_TEXT} />);
+
+    expect(screen.getByPlaceholderText(PLACEHOLDER_TEXT)).toHaveAttribute('type', 'password');
+    expect(screen.queryByRole('switch')).not.toBeInTheDocument();
+  });
+
+  it('should toggle the visibility of the secret between password and text', async () => {
+    render(
+      <SecretInput
+        revealable={true}
+        isConfigured={false}
+        onChange={() => {}}
+        onReset={() => {}}
+        placeholder={PLACEHOLDER_TEXT}
+      />
+    );
 
     const input = screen.getByPlaceholderText(PLACEHOLDER_TEXT);
 
@@ -85,10 +100,49 @@ describe('<SecretInput />', () => {
     expect(toggle).not.toBeChecked();
   });
 
+  it('should show the loading spinner instead of the visibility toggle while loading', () => {
+    render(
+      <SecretInput
+        revealable={true}
+        loading={true}
+        isConfigured={false}
+        onChange={() => {}}
+        onReset={() => {}}
+        placeholder={PLACEHOLDER_TEXT}
+      />
+    );
+
+    expect(screen.getByTestId('Spinner')).toBeInTheDocument();
+    expect(screen.queryByRole('switch')).not.toBeInTheDocument();
+  });
+
+  it('should not render a visibility toggle when the secret is configured', () => {
+    render(
+      <SecretInput
+        revealable={true}
+        isConfigured={true}
+        onChange={() => {}}
+        onReset={() => {}}
+        placeholder={PLACEHOLDER_TEXT}
+      />
+    );
+
+    expect(screen.getByPlaceholderText(PLACEHOLDER_TEXT)).toBeDisabled();
+    expect(screen.queryByRole('switch')).not.toBeInTheDocument();
+  });
+
   it('should allow pasting a value after the secret is revealed', async () => {
     const onChange = jest.fn();
 
-    render(<SecretInput isConfigured={false} onChange={onChange} onReset={() => {}} placeholder={PLACEHOLDER_TEXT} />);
+    render(
+      <SecretInput
+        revealable={true}
+        isConfigured={false}
+        onChange={onChange}
+        onReset={() => {}}
+        placeholder={PLACEHOLDER_TEXT}
+      />
+    );
 
     const input = screen.getByPlaceholderText(PLACEHOLDER_TEXT);
 

--- a/packages/grafana-ui/src/components/SecretInput/SecretInput.tsx
+++ b/packages/grafana-ui/src/components/SecretInput/SecretInput.tsx
@@ -44,6 +44,7 @@ export const SecretInput = ({ isConfigured, onReset, ...props }: Props) => {
               aria-checked={visible}
               onClick={() => setVisible(!visible)}
               tooltip={toggleLabel}
+              size="sm"
             />
           }
         />

--- a/packages/grafana-ui/src/components/SecretInput/SecretInput.tsx
+++ b/packages/grafana-ui/src/components/SecretInput/SecretInput.tsx
@@ -7,12 +7,27 @@ import { IconButton } from '../IconButton/IconButton';
 import { Input } from '../Input/Input';
 import { Stack } from '../Layout/Stack/Stack';
 
-export type Props = React.ComponentProps<typeof Input> & {
+type BaseProps = React.ComponentProps<typeof Input> & {
   /** TRUE if the secret was already configured. (It is needed as often the backend doesn't send back the actual secret, only the information that it was configured) */
   isConfigured: boolean;
   /** Called when the user clicks on the "Reset" button in order to clear the secret */
   onReset: () => void;
 };
+
+type RevealableProps = {
+  /**
+   * Shows an eye icon button that toggles the secret between masked and plain text.
+   * The toggle occupies the input's suffix slot, so `suffix` cannot be used together with it.
+   */
+  revealable: true;
+  suffix?: never;
+};
+
+type NonRevealableProps = {
+  revealable?: false;
+};
+
+export type Props = BaseProps & (RevealableProps | NonRevealableProps);
 
 export const CONFIGURED_TEXT = 'configured';
 export const RESET_BUTTON_TEXT = 'Reset';
@@ -22,8 +37,7 @@ export const RESET_BUTTON_TEXT = 'Reset';
  *
  * https://developers.grafana.com/ui/latest/index.html?path=/docs/inputs-secretinput--docs
  */
-export const SecretInput = ({ isConfigured, onReset, ...props }: Props) => {
-  // Some browser extensions block pasting from the clipboard into password fields. This is a workaround to bypass this limitation.
+export const SecretInput = ({ isConfigured, onReset, revealable, ...props }: Props) => {
   const [visible, setVisible] = useState(false);
   const toggleLabel = visible
     ? t('grafana-ui.secret-input.hide', 'Hide secret')
@@ -34,17 +48,22 @@ export const SecretInput = ({ isConfigured, onReset, ...props }: Props) => {
       {!isConfigured && (
         <Input
           {...props}
-          type={visible ? 'text' : 'password'}
+          type={revealable && visible ? 'text' : 'password'}
           suffix={
-            <IconButton
-              name={visible ? 'eye-slash' : 'eye'}
-              aria-controls={props.id}
-              role="switch"
-              aria-checked={visible}
-              onClick={() => setVisible(!visible)}
-              tooltip={toggleLabel}
-              size="sm"
-            />
+            // While loading, leave the suffix slot empty so Input's built-in spinner takes over.
+            revealable && !props.loading ? (
+              <IconButton
+                name={visible ? 'eye-slash' : 'eye'}
+                aria-controls={props.id}
+                role="switch"
+                aria-checked={visible}
+                onClick={() => setVisible(!visible)}
+                tooltip={toggleLabel}
+                size="sm"
+              />
+            ) : (
+              props.suffix
+            )
           }
         />
       )}

--- a/packages/grafana-ui/src/components/SecretInput/SecretInput.tsx
+++ b/packages/grafana-ui/src/components/SecretInput/SecretInput.tsx
@@ -23,7 +23,7 @@ export const RESET_BUTTON_TEXT = 'Reset';
  * https://developers.grafana.com/ui/latest/index.html?path=/docs/inputs-secretinput--docs
  */
 export const SecretInput = ({ isConfigured, onReset, ...props }: Props) => {
-  // Some browser extensions block paste from clipboard to password fields. This is a workaround to allow bypass this limitation.
+  // Some browser extensions block pasting from the clipboard into password fields. This is a workaround to bypass this limitation.
   const [visible, setVisible] = useState(false);
   const toggleLabel = visible
     ? t('grafana-ui.secret-input.hide', 'Hide secret')

--- a/packages/grafana-ui/src/components/SecretInput/SecretInput.tsx
+++ b/packages/grafana-ui/src/components/SecretInput/SecretInput.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { useState } from 'react';
 
 import { t } from '@grafana/i18n';

--- a/packages/grafana-ui/src/components/SecretInput/SecretInput.tsx
+++ b/packages/grafana-ui/src/components/SecretInput/SecretInput.tsx
@@ -1,6 +1,10 @@
 import * as React from 'react';
+import { useState } from 'react';
+
+import { t } from '@grafana/i18n';
 
 import { Button } from '../Button/Button';
+import { IconButton } from '../IconButton/IconButton';
 import { Input } from '../Input/Input';
 import { Stack } from '../Layout/Stack/Stack';
 
@@ -19,16 +23,39 @@ export const RESET_BUTTON_TEXT = 'Reset';
  *
  * https://developers.grafana.com/ui/latest/index.html?path=/docs/inputs-secretinput--docs
  */
-export const SecretInput = ({ isConfigured, onReset, ...props }: Props) => (
-  <Stack>
-    {!isConfigured && <Input {...props} type="password" />}
-    {isConfigured && (
-      <>
-        <Input {...props} type="text" disabled={true} value={CONFIGURED_TEXT} />
-        <Button onClick={onReset} variant="secondary">
-          {RESET_BUTTON_TEXT}
-        </Button>
-      </>
-    )}
-  </Stack>
-);
+export const SecretInput = ({ isConfigured, onReset, ...props }: Props) => {
+  // Some browser extensions block paste from clipboard to password fields. This is a workaround to allow bypass this limitation.
+  const [visible, setVisible] = useState(false);
+  const toggleLabel = visible
+    ? t('grafana-ui.secret-input.hide', 'Hide secret')
+    : t('grafana-ui.secret-input.show', 'Show secret');
+
+  return (
+    <Stack>
+      {!isConfigured && (
+        <Input
+          {...props}
+          type={visible ? 'text' : 'password'}
+          suffix={
+            <IconButton
+              name={visible ? 'eye-slash' : 'eye'}
+              aria-controls={props.id}
+              role="switch"
+              aria-checked={visible}
+              onClick={() => setVisible(!visible)}
+              tooltip={toggleLabel}
+            />
+          }
+        />
+      )}
+      {isConfigured && (
+        <>
+          <Input {...props} type="text" disabled={true} value={CONFIGURED_TEXT} />
+          <Button onClick={onReset} variant="secondary">
+            {RESET_BUTTON_TEXT}
+          </Button>
+        </>
+      )}
+    </Stack>
+  );
+};

--- a/public/app/features/provisioning/Config/ConfigForm.tsx
+++ b/public/app/features/provisioning/Config/ConfigForm.tsx
@@ -264,6 +264,7 @@ export function ConfigForm({ data }: ConfigFormProps) {
                         id={'token'}
                         placeholder={gitFields.tokenConfig.placeholder}
                         isConfigured={tokenConfigured}
+                        revealable
                         onReset={() => {
                           setValue('token', '');
                           setTokenConfigured(false);

--- a/public/app/features/provisioning/Wizard/components/RepositoryTokenInput.tsx
+++ b/public/app/features/provisioning/Wizard/components/RepositoryTokenInput.tsx
@@ -51,6 +51,7 @@ export function RepositoryTokenInput() {
               id="token"
               placeholder={gitFields.tokenConfig.placeholder}
               isConfigured={tokenConfigured}
+              revealable
               invalid={!!errors?.repository?.token?.message}
               onReset={() => {
                 setValue('repository.token', '');

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -10429,6 +10429,10 @@
     "secret-form-field": {
       "reset": "Reset"
     },
+    "secret-input": {
+      "hide": "Hide secret",
+      "show": "Show secret"
+    },
     "secret-text-area": {
       "hide-content": "Hide secret content",
       "show-content": "Show secret content"


### PR DESCRIPTION
**What is this feature?**

- Secret fields now show an eye icon that lets you reveal or hide the value user is typing. (This is already supported in `SecretTextArea` )
- When revealed, user can paste into the field even in environments (e.g. Edge on Windows Server with corporate/DLP policies) that block pasting into masked password fields.
<img width="1007" height="152" alt="image" src="https://github.com/user-attachments/assets/be1edb73-ca92-41e4-bcc4-d870fa93f9a5" />

**Recording:**  

https://github.com/user-attachments/assets/33f59928-f51a-4ac9-aa08-1527586c74f5



**Why do we need this feature?**

- Some corporate browser policies and extensions block clipboard paste specifically into masked password inputs. Users configuring the Git Sync token had no way to paste their token and got stuck, since the field offered no way to reveal it.


**Who is this feature for?**

Git sync users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/126658

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
