### PR TITLE
unified-storage: encapsulate TenantWatcher logic in public function

### DIFF
--- a/pkg/storage/unified/resource/tenant_deleter.go
+++ b/pkg/storage/unified/resource/tenant_deleter.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"math/rand/v2"
+	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/grafana/authlib/types"
@@ -39,10 +41,18 @@ func NewTenantDeleterConfig(cfg *setting.Cfg) *TenantDeleterConfig {
 		interval = 1 * time.Hour
 	}
 
+	var gcomClient gcom.Service
+	token := strings.TrimSpace(cfg.GrafanaComSSOAPIToken)
+	apiURL := strings.TrimSpace(cfg.GrafanaComAPIURL)
+	if token != "" && apiURL != "" {
+		gcomClient = gcom.New(gcom.Config{ApiURL: apiURL, Token: token}, &http.Client{Timeout: 30 * time.Second})
+	}
+
 	return &TenantDeleterConfig{
 		DryRun:   cfg.TenantDeleterDryRun,
 		Interval: interval,
 		Log:      log.New("tenant-deleter"),
+		Gcom:     gcomClient,
 	}
 }
 

--- a/pkg/storage/unified/resource/tenant_deleter_test.go
+++ b/pkg/storage/unified/resource/tenant_deleter_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/gcom"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -36,6 +37,56 @@ const (
 	testStacksNS1 = "stacks-1"
 	testStacksNS2 = "stacks-2"
 )
+
+func TestNewTenantDeleterConfig(t *testing.T) {
+	t.Run("returns nil when tenant deleter is disabled", func(t *testing.T) {
+		require.Nil(t, NewTenantDeleterConfig(setting.NewCfg()))
+	})
+
+	tests := []struct {
+		name   string
+		token  string
+		apiURL string
+		want   bool
+	}{
+		{
+			name:   "configures GCOM client when token and API URL are present",
+			token:  " token ",
+			apiURL: " https://grafana.example.com/api ",
+			want:   true,
+		},
+		{
+			name:   "leaves GCOM client nil when token is missing",
+			apiURL: "https://grafana.example.com/api",
+		},
+		{
+			name:  "leaves GCOM client nil when API URL is missing",
+			token: "token",
+		},
+		{
+			name:   "leaves GCOM client nil when settings contain only whitespace",
+			token:  " ",
+			apiURL: "\t",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := setting.NewCfg()
+			cfg.EnableTenantDeleter = true
+			cfg.GrafanaComSSOAPIToken = tt.token
+			cfg.GrafanaComAPIURL = tt.apiURL
+
+			deleterCfg := NewTenantDeleterConfig(cfg)
+			require.NotNil(t, deleterCfg)
+			if tt.want {
+				require.NotNil(t, deleterCfg.Gcom)
+			} else {
+				require.Nil(t, deleterCfg.Gcom)
+			}
+		})
+	}
+}
 
 // failOnceBatchDeleteKV wraps a KV and makes BatchDelete fail on the Nth call,
 // then succeed on all subsequent calls. This simulates a transient failure

--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -8,10 +8,8 @@ import (
 	"iter"
 	"math"
 	"math/rand"
-	"net/http"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -33,7 +31,6 @@ import (
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/apiserver/options"
-	"github.com/grafana/grafana/pkg/services/gcom"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/grafana/grafana/pkg/storage/unified/resource/kv"
@@ -50,18 +47,6 @@ import (
 var tracer = otel.Tracer("github.com/grafana/grafana/pkg/storage/unified/sql")
 
 const defaultPollingInterval = 100 * time.Millisecond
-
-// newTenantDeleterGcomClient returns a GCOM client for tenant-deleter verification when
-// [grafana_com] sso_api_token and api_url are configured.
-func newTenantDeleterGcomClient(cfg *setting.Cfg) gcom.Service {
-	token := strings.TrimSpace(cfg.GrafanaComSSOAPIToken)
-	apiURL := strings.TrimSpace(cfg.GrafanaComAPIURL)
-	if token == "" || apiURL == "" {
-		return nil
-	}
-	hc := &http.Client{Timeout: 30 * time.Second}
-	return gcom.New(gcom.Config{ApiURL: apiURL, Token: token}, hc)
-}
 
 const defaultWatchBufferSize = 100 // number of events to buffer in the watch stream
 const defaultGarbageCollectionBatchWait = 1 * time.Second
@@ -197,13 +182,6 @@ func NewStorageBackend(
 		return nil, fmt.Errorf("unsupported database driver: %s", dbConn.DriverName())
 	}
 
-	tenantDeleterCfg := resource.NewTenantDeleterConfig(cfg)
-	if tenantDeleterCfg != nil {
-		if gcomClient := newTenantDeleterGcomClient(cfg); gcomClient != nil {
-			tenantDeleterCfg.Gcom = gcomClient
-		}
-	}
-
 	kvBackendOpts := resource.KVBackendOptions{
 		KvStore:              kvStore,
 		Reg:                  reg,
@@ -212,7 +190,7 @@ func NewStorageBackend(
 		DBKeepAlive:          eDB,
 		LastImportTimeMaxAge: cfg.MaxFileIndexAge,
 		TenantWatcherConfig:  resource.NewTenantWatcherConfig(cfg),
-		TenantDeleterConfig:  tenantDeleterCfg,
+		TenantDeleterConfig:  resource.NewTenantDeleterConfig(cfg),
 		GCGate:               gcGate,
 		GarbageCollection: resource.GarbageCollectionConfig{
 			Enabled:          cfg.EnableGarbageCollection,


### PR DESCRIPTION
The function now lives in the `resource` package and can be consumed by other packages.
