### PR TITLE
Home: add metrics existing-solution card

### DIFF
--- a/public/app/features/home/Recommendations/ExistingSolutionCard.tsx
+++ b/public/app/features/home/Recommendations/ExistingSolutionCard.tsx
@@ -102,9 +102,11 @@ export function ExistingSolutionCard({ existing, selected, onSelect }: ExistingS
                       <Text variant="h2" color="primary">
                         {selected.stats.primary}
                       </Text>
-                      <Text variant="body" color="secondary">
-                        {selected.stats.secondary}
-                      </Text>
+                      {selected.stats.secondary && (
+                        <Text variant="body" color="secondary">
+                          {selected.stats.secondary}
+                        </Text>
+                      )}
                     </Stack>
                   )
                 )}

--- a/public/app/features/home/Recommendations/RecommendationExisting.test.tsx
+++ b/public/app/features/home/Recommendations/RecommendationExisting.test.tsx
@@ -16,6 +16,7 @@ import {
   type KubernetesInventory,
 } from './kubernetesData';
 import { readSeries } from './promQuery';
+import { useMetricsSolution } from './useMetricsSolution';
 
 jest.mock('app/features/alerting/unified/hooks/usePluginBridge', () => ({
   ...jest.requireActual('app/features/alerting/unified/hooks/usePluginBridge'),
@@ -30,6 +31,10 @@ jest.mock('./kubernetesData', () => ({
   fetchClusterCpuSeries: jest.fn(),
 }));
 
+jest.mock('./useMetricsSolution', () => ({
+  useMetricsSolution: jest.fn(),
+}));
+
 jest.mock('../analytics/main', () => ({
   ctaClicked: jest.fn(),
 }));
@@ -39,6 +44,7 @@ const mockResolveDatasource = jest.mocked(resolveKubernetesDatasource);
 const mockFetchInventory = jest.mocked(fetchKubernetesInventory);
 const mockFetchHealth = jest.mocked(fetchKubernetesHealth);
 const mockFetchCpuSeries = jest.mocked(fetchClusterCpuSeries);
+const mockUseMetricsSolution = jest.mocked(useMetricsSolution);
 
 const compactFormatter = new Intl.NumberFormat(undefined, { notation: 'compact', maximumFractionDigits: 1 });
 
@@ -72,6 +78,7 @@ function mockResolvedKubernetes(
 
 beforeEach(() => {
   mockUsePluginBridge.mockReturnValue({ loading: false, installed: true, settings });
+  mockUseMetricsSolution.mockReturnValue({ loading: false, item: null });
   mockResolvedKubernetes();
   mockResolveDatasource.mockClear();
   mockFetchInventory.mockClear();
@@ -88,10 +95,36 @@ describe('RecommendationExisting', () => {
 
     expect(await screen.findByRole('heading', { name: 'Kubernetes Monitoring' })).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: /Switch solution/i }));
-    await user.click(screen.getByRole('menuitem', { name: 'Hosted Metrics' }));
+    await user.click(screen.getByRole('menuitem', { name: 'Hosted Logs' }));
 
-    expect(screen.getByRole('heading', { name: 'Hosted Metrics' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Hosted Logs' })).toBeInTheDocument();
+    expect(screen.getByText('47 GB ingested')).toBeInTheDocument();
+  });
+
+  it('renders a discovered Metrics card without waiting for Kubernetes', async () => {
+    mockResolveDatasource.mockImplementation(() => new Promise(() => {}));
+    mockUseMetricsSolution.mockReturnValue({
+      loading: false,
+      item: {
+        id: 'metrics',
+        title: 'Metrics & infrastructure',
+        icon: 'chart-line',
+        stats: { primary: '4.2M series' },
+        action: 'Open metrics',
+        href: '/a/grafana-metricsdrilldown-app/drilldown',
+      },
+    });
+
+    render(<RecommendationExisting />);
+
+    expect(await screen.findByRole('heading', { name: 'Metrics & infrastructure' })).toBeInTheDocument();
     expect(screen.getByText('4.2M series')).toBeInTheDocument();
+    expect(screen.queryByText(/data points\/min/)).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Open metrics' })).toHaveAttribute(
+      'href',
+      '/a/grafana-metricsdrilldown-app/drilldown'
+    );
+    expect(screen.queryByTestId('recommendation-existing-skeleton')).not.toBeInTheDocument();
   });
 
   it('shows a full-card skeleton while settings are pending', async () => {
@@ -159,7 +192,6 @@ describe('RecommendationExisting', () => {
 
     expect(await screen.findByRole('heading', { name: 'No data flowing yet' })).toBeInTheDocument();
     expect(screen.queryByRole('heading', { name: 'Kubernetes Monitoring' })).not.toBeInTheDocument();
-    expect(screen.queryByRole('heading', { name: 'Hosted Metrics' })).not.toBeInTheDocument();
   });
 
   it('shows the no-data card when resolution rejects without flashing the Kubernetes title', async () => {
@@ -223,7 +255,6 @@ describe('RecommendationExisting', () => {
     expect(await screen.findByRole('heading', { name: 'Kubernetes Monitoring' })).toBeInTheDocument();
     expect(screen.getByText('via k8s-prom')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Open K8s app' })).toBeInTheDocument();
-    expect(screen.queryByRole('heading', { name: 'Hosted Metrics' })).not.toBeInTheDocument();
     expect(screen.queryByTestId('kubernetes-stats-skeleton')).not.toBeInTheDocument();
   });
 
@@ -273,9 +304,9 @@ describe('RecommendationExisting', () => {
 
     expect(await screen.findByTestId('kubernetes-stats-skeleton')).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: /Switch solution/i }));
-    await user.click(screen.getByRole('menuitem', { name: 'Hosted Metrics' }));
+    await user.click(screen.getByRole('menuitem', { name: 'Hosted Logs' }));
 
-    expect(screen.getByText('4.2M series')).toBeInTheDocument();
+    expect(screen.getByText('47 GB ingested')).toBeInTheDocument();
     expect(screen.queryByTestId('kubernetes-stats-skeleton')).not.toBeInTheDocument();
     expect(screen.queryByTestId('kubernetes-sparkline-skeleton')).not.toBeInTheDocument();
   });
@@ -328,7 +359,7 @@ describe('RecommendationExisting', () => {
 
     expect(await screen.findByRole('heading', { name: 'Kubernetes Monitoring' })).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: /Switch solution/i }));
-    await user.click(screen.getByRole('menuitem', { name: 'Hosted Metrics' }));
+    await user.click(screen.getByRole('menuitem', { name: 'Hosted Logs' }));
 
     expect(screen.queryByText(/^via /)).not.toBeInTheDocument();
   });
@@ -385,14 +416,14 @@ describe('RecommendationExisting', () => {
 
       expect(await screen.findByRole('heading', { name: 'Kubernetes Monitoring' })).toBeInTheDocument();
       await user.click(screen.getByRole('button', { name: /Switch solution/i }));
-      await user.click(screen.getByRole('menuitem', { name: 'Hosted Metrics' }));
-      await user.click(await screen.findByRole('link', { name: /Open infrastructure/ }));
+      await user.click(screen.getByRole('menuitem', { name: 'Hosted Logs' }));
+      await user.click(await screen.findByRole('link', { name: /Open Explore \(Logs\)/ }));
 
       expect(jest.mocked(ctaClicked)).toHaveBeenCalledWith({
         surface: 'existing_solution',
         action: 'open_solution',
         placement: 'card',
-        solution: 'hosted-metrics',
+        solution: 'hosted-logs',
       });
     });
 
@@ -401,13 +432,13 @@ describe('RecommendationExisting', () => {
 
       expect(await screen.findByRole('heading', { name: 'Kubernetes Monitoring' })).toBeInTheDocument();
       await user.click(screen.getByRole('button', { name: /Switch solution/i }));
-      await user.click(screen.getByRole('menuitem', { name: 'Hosted Metrics' }));
+      await user.click(screen.getByRole('menuitem', { name: 'Hosted Logs' }));
 
       expect(jest.mocked(ctaClicked)).toHaveBeenCalledWith({
         surface: 'existing_solution',
         action: 'switch_solution',
         placement: 'card',
-        solution: 'hosted-metrics',
+        solution: 'hosted-logs',
       });
     });
 

--- a/public/app/features/home/Recommendations/RecommendationExisting.tsx
+++ b/public/app/features/home/Recommendations/RecommendationExisting.tsx
@@ -10,23 +10,6 @@ import { useExistingSolutions } from './useExistingSolutions';
 
 const stubbedExisting: ExistingItem[] = [
   {
-    id: 'hosted-metrics',
-    title: 'Hosted Metrics',
-    icon: 'chart-line',
-    stats: {
-      primary: '4.2M series',
-      secondary: '12 hosts',
-    },
-    alert: {
-      primary: '3 hosts above 90% disk',
-      details: ['web-03 critical at 96%, ~6 h to full'],
-      action: 'View',
-      href: '#',
-    },
-    action: 'Open infrastructure',
-    href: '#',
-  },
-  {
     id: 'hosted-logs',
     title: 'Hosted Logs',
     icon: 'file-alt',

--- a/public/app/features/home/Recommendations/Recommendations.test.tsx
+++ b/public/app/features/home/Recommendations/Recommendations.test.tsx
@@ -145,7 +145,6 @@ describe('Recommendations', () => {
 
     expect(await screen.findByRole('heading', { name: 'No data flowing yet' })).toBeInTheDocument();
     expect(screen.queryByRole('heading', { name: 'Kubernetes Monitoring' })).not.toBeInTheDocument();
-    expect(screen.queryByRole('heading', { name: 'Hosted Metrics' })).not.toBeInTheDocument();
   });
 
   it('renders nothing when the user cannot manage plugins', async () => {

--- a/public/app/features/home/Recommendations/buildMetricsItem.test.ts
+++ b/public/app/features/home/Recommendations/buildMetricsItem.test.ts
@@ -1,0 +1,64 @@
+import { createDataFrame, FieldType } from '@grafana/data';
+
+import { buildMetricsItem } from './buildMetricsItem';
+import { type MetricsOverview } from './metricsData';
+import { readSeries } from './promQuery';
+
+function overview(dataPointsPerMinute: number | null): MetricsOverview {
+  return {
+    activeSeries: 906_600_000,
+    dataPointsPerMinute,
+    queries: {
+      datasourceUid: 'prometheus',
+      activeSeries: 'sum(prometheus_tsdb_head_series)',
+      dataPointsPerMinute: '60 * sum(rate(prometheus_tsdb_head_samples_appended_total[5m]))',
+    },
+  };
+}
+
+describe('buildMetricsItem', () => {
+  it('builds the formatted Metrics card with history and drilldown link', () => {
+    const history = readSeries(
+      [
+        createDataFrame({
+          refId: 'history',
+          fields: [
+            { name: 'Time', type: FieldType.time, values: [1, 2, 3] },
+            { name: 'Value', type: FieldType.number, values: [100, 110, 120] },
+          ],
+        }),
+      ],
+      'history'
+    );
+    expect(history).not.toBeNull();
+
+    const item = buildMetricsItem(overview(41_940), history, true);
+
+    expect(item).toMatchObject({
+      id: 'metrics',
+      title: 'Metrics & infrastructure',
+      stats: {
+        primary: '907 Mil series',
+        secondary: '41.9 K data points/min',
+      },
+      sparkline: {
+        series: history,
+        caption: 'Active series · last 24h',
+      },
+      sparklineLoading: true,
+      action: 'Open metrics',
+      href: '/a/grafana-metricsdrilldown-app/drilldown',
+    });
+  });
+
+  it.each([null, 0])('omits the secondary stat and sparkline when data points per minute are %s', (value) => {
+    const item = buildMetricsItem(overview(value), null);
+
+    expect(item.stats).toEqual({
+      primary: '907 Mil series',
+      secondary: undefined,
+    });
+    expect(item.sparkline).toBeUndefined();
+    expect(item.sparklineLoading).toBe(false);
+  });
+});

--- a/public/app/features/home/Recommendations/buildMetricsItem.ts
+++ b/public/app/features/home/Recommendations/buildMetricsItem.ts
@@ -1,0 +1,43 @@
+import { type FieldSparkline, formattedValueToString, getValueFormat, locationUtil } from '@grafana/data';
+import { t } from '@grafana/i18n';
+import { createBridgeURL } from 'app/features/alerting/unified/components/PluginBridge';
+
+import { type MetricsOverview, METRICS_DRILLDOWN_APP_ID } from './metricsData';
+import { type ExistingItem } from './types';
+
+const formatUsageNumber = getValueFormat('short');
+
+/** Build the Metrics entry from the best available usage data. */
+export function buildMetricsItem(
+  overview: MetricsOverview,
+  history: FieldSparkline | null,
+  historyLoading = false
+): ExistingItem {
+  const activeSeries = t('home.recommendations.metrics.series', '{{value}} series', {
+    value: formattedValueToString(formatUsageNumber(overview.activeSeries)),
+  });
+  const dataPointsPerMinute =
+    overview.dataPointsPerMinute !== null && overview.dataPointsPerMinute > 0
+      ? t('home.recommendations.metrics.data-points-per-minute', '{{value}} data points/min', {
+          value: formattedValueToString(formatUsageNumber(overview.dataPointsPerMinute)),
+        })
+      : null;
+  return {
+    id: 'metrics',
+    title: t('home.recommendations.metrics.title', 'Metrics & infrastructure'),
+    icon: 'chart-line',
+    stats: {
+      primary: activeSeries,
+      secondary: dataPointsPerMinute ?? undefined,
+    },
+    sparkline: history
+      ? {
+          series: history,
+          caption: t('home.recommendations.metrics.active-series-24h', 'Active series · last 24h'),
+        }
+      : undefined,
+    sparklineLoading: historyLoading,
+    action: t('home.recommendations.metrics.action', 'Open metrics'),
+    href: locationUtil.assureBaseUrl(createBridgeURL(METRICS_DRILLDOWN_APP_ID, '/drilldown')),
+  };
+}

--- a/public/app/features/home/Recommendations/kubernetesData.ts
+++ b/public/app/features/home/Recommendations/kubernetesData.ts
@@ -72,7 +72,7 @@ const K8S_APP_STORAGE_KEY = 'grafana.k8s-app.navigation.storage';
 async function orderedCandidates(): Promise<DataSourceInstanceListItem[]> {
   // Uncapped: the stored preference must be honored even when it sits past the fan-out cap;
   // resolveKubernetesPrometheus applies the cap after this reorder.
-  const ordered = await listProbeCandidates('prometheus', Number.POSITIVE_INFINITY);
+  const ordered = await listProbeCandidates('prometheus', { cap: Number.POSITIVE_INFINITY });
   let promName: string | undefined;
   try {
     // store.getObject absorbs missing/corrupt values; the try guards localStorage access itself throwing.

--- a/public/app/features/home/Recommendations/metricsData.test.ts
+++ b/public/app/features/home/Recommendations/metricsData.test.ts
@@ -1,0 +1,293 @@
+import { of } from 'rxjs';
+
+import { getAPINamespace } from '@grafana/api-clients';
+import {
+  createDataFrame,
+  type DataFrame,
+  type DataSourceInstanceListItem,
+  FieldType,
+  LoadingState,
+  type PanelData,
+  type QueryRunner,
+} from '@grafana/data';
+import { createQueryRunner } from '@grafana/runtime';
+import { getDataSourceInstanceList } from '@grafana/runtime/unstable';
+
+import { fetchMetricsHistory, fetchMetricsOverview, type MetricsOverview } from './metricsData';
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  createQueryRunner: jest.fn(),
+}));
+
+jest.mock('@grafana/api-clients', () => ({
+  ...jest.requireActual('@grafana/api-clients'),
+  getAPINamespace: jest.fn(),
+}));
+
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getDataSourceInstanceList: jest.fn(),
+}));
+
+const mockCreateQueryRunner = jest.mocked(createQueryRunner);
+const mockGetDataSourceInstanceList = jest.mocked(getDataSourceInstanceList);
+const mockGetAPINamespace = jest.mocked(getAPINamespace);
+const run = jest.fn();
+const destroy = jest.fn();
+const CLOUD_USAGE_DATASOURCE_UID = 'grafanacloud-usage';
+
+function usageQueries(stackId: string): MetricsOverview['queries'] {
+  return {
+    datasourceUid: CLOUD_USAGE_DATASOURCE_UID,
+    activeSeries: `sum(grafanacloud_instance_active_series{stack_id="${stackId}"})`,
+    dataPointsPerMinute: `60 * sum(grafanacloud_instance_samples_per_second{stack_id="${stackId}"})`,
+  };
+}
+
+function prometheusQueries(datasourceUid: string): MetricsOverview['queries'] {
+  return {
+    datasourceUid,
+    activeSeries: 'sum(prometheus_tsdb_head_series)',
+    dataPointsPerMinute: '60 * sum(rate(prometheus_tsdb_head_samples_appended_total[5m]))',
+  };
+}
+
+type CapturedRun = {
+  datasource: { uid: string };
+  queries: Array<{ refId: string; expr: string; instant: boolean; range: boolean }>;
+  timeRange: { raw: { from: string } };
+};
+
+const instantValues: Record<string, number | undefined> = {};
+let activeSeries: number | undefined;
+let usageActiveSeries: number | undefined;
+let usageDataPointsPerMinute: number | undefined;
+
+function setDataSources(
+  list: Array<{ uid: string; name: string; isDefault?: boolean; type?: string; metaId?: string }>
+) {
+  const datasources = list.map(
+    ({ metaId, ...datasource }) =>
+      ({
+        ...datasource,
+        type: datasource.type ?? 'prometheus',
+        meta: { id: metaId ?? 'prometheus' },
+        isDefault: datasource.isDefault ?? false,
+      }) as DataSourceInstanceListItem
+  );
+  mockGetDataSourceInstanceList.mockImplementation(async (filters) =>
+    datasources.filter((datasource) => filters?.filter?.(datasource) ?? true)
+  );
+}
+
+function numberFrame(refId: string, values: number[]): DataFrame {
+  return createDataFrame({ refId, fields: [{ name: 'Value', type: FieldType.number, values }] });
+}
+
+beforeEach(() => {
+  Object.assign(instantValues, { activeSeries: 4200000, dataPointsPerMinute: 5160000 });
+  activeSeries = undefined;
+  usageActiveSeries = 4200000;
+  usageDataPointsPerMinute = 5160000;
+  run.mockReset();
+  destroy.mockReset();
+  mockCreateQueryRunner.mockReset();
+  mockGetDataSourceInstanceList.mockReset();
+  mockCreateQueryRunner.mockImplementation(() => {
+    let captured: CapturedRun | undefined;
+    return {
+      run: (options: CapturedRun) => {
+        captured = options;
+        run(options);
+      },
+      get: () => {
+        const queries = captured?.queries ?? [];
+        const series = queries[0]?.range
+          ? [
+              createDataFrame({
+                refId: queries[0].refId,
+                fields: [
+                  { name: 'Time', type: FieldType.time, values: [0, 1000, 2000] },
+                  { name: 'Value', type: FieldType.number, values: [100, 110, 120] },
+                ],
+              }),
+            ]
+          : queries.flatMap((query) => {
+              const value =
+                query.refId === 'activeSeries'
+                  ? captured?.datasource.uid === CLOUD_USAGE_DATASOURCE_UID
+                    ? usageActiveSeries
+                    : activeSeries
+                  : captured?.datasource.uid === CLOUD_USAGE_DATASOURCE_UID
+                    ? usageDataPointsPerMinute
+                    : instantValues[query.refId];
+              return value === undefined ? [] : [numberFrame(query.refId, [value])];
+            });
+        return of({ state: LoadingState.Done, series, timeRange: {} } as PanelData);
+      },
+      cancel: jest.fn(),
+      destroy,
+    } as unknown as QueryRunner;
+  });
+  mockGetAPINamespace.mockReturnValue('default');
+});
+
+afterEach(() => jest.restoreAllMocks());
+
+describe('Metrics data', () => {
+  it('uses stack-scoped usage metrics when the usage datasource is available', async () => {
+    mockGetAPINamespace.mockReturnValue('stacks-12345');
+    setDataSources([
+      { uid: 'team-prom', name: 'team-prom', isDefault: true },
+      { uid: CLOUD_USAGE_DATASOURCE_UID, name: 'grafanacloud-usage' },
+    ]);
+
+    await expect(fetchMetricsOverview()).resolves.toEqual({
+      activeSeries: 4200000,
+      dataPointsPerMinute: 5160000,
+      queries: usageQueries('12345'),
+    });
+
+    const options = run.mock.calls[0][0] as CapturedRun;
+    const { datasourceUid, ...expressions } = usageQueries('12345');
+    expect(options.datasource.uid).toBe(datasourceUid);
+    expect(Object.fromEntries(options.queries.map((query) => [query.refId, query.expr]))).toEqual(expressions);
+    expect(options.queries.every((query) => query.instant && !query.range)).toBe(true);
+  });
+
+  it('uses the default Prometheus datasource for the metrics summary', async () => {
+    setDataSources([
+      { uid: 'other-prom', name: 'other-prom' },
+      { uid: 'team-prom', name: 'team-prom', isDefault: true },
+    ]);
+    activeSeries = 4200000;
+
+    await expect(fetchMetricsOverview()).resolves.toEqual({
+      activeSeries: 4200000,
+      dataPointsPerMinute: 5160000,
+      queries: prometheusQueries('team-prom'),
+    });
+
+    const options = run.mock.calls[0][0] as CapturedRun;
+    const { datasourceUid, ...expressions } = prometheusQueries('team-prom');
+    expect(options.datasource.uid).toBe(datasourceUid);
+    expect(Object.fromEntries(options.queries.map((query) => [query.refId, query.expr]))).toEqual(expressions);
+  });
+
+  it.each(['default', 'stacks-'])(
+    'ignores the usage datasource when namespace %s has no stack ID',
+    async (namespace) => {
+      mockGetAPINamespace.mockReturnValue(namespace);
+      setDataSources([
+        { uid: CLOUD_USAGE_DATASOURCE_UID, name: 'grafanacloud-usage' },
+        { uid: 'team-prom', name: 'team-prom', isDefault: true },
+      ]);
+      activeSeries = 4200000;
+
+      await expect(fetchMetricsOverview()).resolves.toEqual({
+        activeSeries: 4200000,
+        dataPointsPerMinute: 5160000,
+        queries: prometheusQueries('team-prom'),
+      });
+    }
+  );
+
+  it('does not query the usage datasource as ordinary Prometheus when no stack ID is available', async () => {
+    setDataSources([{ uid: CLOUD_USAGE_DATASOURCE_UID, name: 'grafanacloud-usage' }]);
+
+    await expect(fetchMetricsOverview()).resolves.toBeNull();
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the default Prometheus datasource when a Cloud stack has no usage datasource', async () => {
+    mockGetAPINamespace.mockReturnValue('stacks-12345');
+    setDataSources([
+      { uid: 'other-prom', name: 'other-prom' },
+      { uid: 'team-prom', name: 'team-prom', isDefault: true },
+    ]);
+    activeSeries = 4200000;
+
+    await expect(fetchMetricsOverview()).resolves.toEqual({
+      activeSeries: 4200000,
+      dataPointsPerMinute: 5160000,
+      queries: prometheusQueries('team-prom'),
+    });
+  });
+
+  it('keeps the active-series summary when data points per minute are unavailable', async () => {
+    setDataSources([{ uid: 'team-prom', name: 'team-prom', isDefault: true }]);
+    activeSeries = 4200000;
+    instantValues.dataPointsPerMinute = undefined;
+
+    await expect(fetchMetricsOverview()).resolves.toEqual({
+      activeSeries: 4200000,
+      dataPointsPerMinute: null,
+      queries: prometheusQueries('team-prom'),
+    });
+  });
+
+  it('uses the first Prometheus datasource when no default is configured', async () => {
+    setDataSources([
+      { uid: 'first-prom', name: 'first-prom' },
+      { uid: 'second-prom', name: 'second-prom' },
+    ]);
+    activeSeries = 4200000;
+
+    await expect(fetchMetricsOverview()).resolves.toEqual(
+      expect.objectContaining({ queries: prometheusQueries('first-prom') })
+    );
+  });
+
+  it('ignores the built-in Grafana datasource when no Prometheus datasource exists', async () => {
+    setDataSources([{ uid: 'grafana', name: '-- Grafana --', type: 'datasource', metaId: 'grafana' }]);
+
+    await expect(fetchMetricsOverview()).resolves.toBeNull();
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it('does not switch to local metrics when the usage datasource is empty', async () => {
+    mockGetAPINamespace.mockReturnValue('stacks-12345');
+    setDataSources([
+      { uid: CLOUD_USAGE_DATASOURCE_UID, name: 'grafanacloud-usage' },
+      { uid: 'team-prom', name: 'team-prom', isDefault: true },
+    ]);
+    usageActiveSeries = undefined;
+    usageDataPointsPerMinute = undefined;
+
+    const overview = await fetchMetricsOverview();
+
+    expect(overview).toBeNull();
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([undefined, 0])('returns no summary when active series is %s', async (value) => {
+    setDataSources([{ uid: 'team-prom', name: 'team-prom', isDefault: true }]);
+    activeSeries = value;
+
+    await expect(fetchMetricsOverview()).resolves.toBeNull();
+  });
+
+  it('uses the overview datasource and query for 24-hour active-series history', async () => {
+    const overview: MetricsOverview = {
+      activeSeries: 4200000,
+      dataPointsPerMinute: 41940,
+      queries: prometheusQueries('team-prom'),
+    };
+
+    const history = await fetchMetricsHistory(overview);
+
+    expect(history?.y.values).toEqual([100, 110, 120]);
+    const options = run.mock.calls[0][0] as CapturedRun;
+    expect(options.datasource.uid).toBe('team-prom');
+    expect(options.timeRange.raw.from).toBe('now-24h');
+    expect(options.queries).toEqual([
+      expect.objectContaining({
+        refId: 'history',
+        expr: 'sum(prometheus_tsdb_head_series)',
+        instant: false,
+        range: true,
+      }),
+    ]);
+  });
+});

--- a/public/app/features/home/Recommendations/metricsData.ts
+++ b/public/app/features/home/Recommendations/metricsData.ts
@@ -1,0 +1,87 @@
+import { getAPINamespace } from '@grafana/api-clients';
+import { type FieldSparkline } from '@grafana/data';
+
+import { listProbeCandidates, PROBE_TIMEOUT_MS, withRetry } from './probeUtils';
+import { readScalar, readSeries, runInstantQueries, runRangeQuery } from './promQuery';
+
+/** Grafana Metrics Drilldown app plugin ID. @lintignore */
+export const METRICS_DRILLDOWN_APP_ID = 'grafana-metricsdrilldown-app';
+
+const CLOUD_USAGE_DATASOURCE_UID = 'grafanacloud-usage';
+
+export interface MetricsOverview {
+  activeSeries: number;
+  dataPointsPerMinute: number | null;
+  queries: {
+    datasourceUid: string;
+    activeSeries: string;
+    dataPointsPerMinute: string;
+  };
+}
+
+async function resolveMetricsQueries(): Promise<MetricsOverview['queries'] | null> {
+  const namespace = getAPINamespace();
+  const stackId = namespace.startsWith('stacks-') ? namespace.slice('stacks-'.length) : '';
+  const [datasource] = await listProbeCandidates('prometheus', {
+    cap: 1,
+    preferredUids: stackId ? [CLOUD_USAGE_DATASOURCE_UID] : [],
+  });
+  if (!datasource) {
+    // There is no queryable metrics source.
+    return null;
+  }
+
+  if (datasource.uid !== CLOUD_USAGE_DATASOURCE_UID) {
+    // Ordinary Prometheus sources expose their own series and ingestion totals.
+    return {
+      datasourceUid: datasource.uid,
+      activeSeries: 'sum(prometheus_tsdb_head_series)',
+      dataPointsPerMinute: '60 * sum(rate(prometheus_tsdb_head_samples_appended_total[5m]))',
+    };
+  }
+
+  if (datasource.uid === CLOUD_USAGE_DATASOURCE_UID && stackId) {
+    // Cloud usage provides stack-scoped series and ingestion totals.
+    return {
+      datasourceUid: datasource.uid,
+      activeSeries: `sum(grafanacloud_instance_active_series{stack_id="${stackId}"})`,
+      dataPointsPerMinute: `60 * sum(grafanacloud_instance_samples_per_second{stack_id="${stackId}"})`,
+    };
+  }
+
+  // Never query the shared usage datasource without a stack scope.
+  return null;
+}
+
+async function fetchOverview(queries: MetricsOverview['queries']): Promise<MetricsOverview | null> {
+  const { datasourceUid, ...expressions } = queries;
+  const frames = await withRetry(() =>
+    runInstantQueries(expressions, { uid: datasourceUid, type: 'prometheus' }, PROBE_TIMEOUT_MS)
+  );
+  const activeSeries = readScalar(frames, 'activeSeries');
+  const dataPointsPerMinute = readScalar(frames, 'dataPointsPerMinute');
+  if (activeSeries === null || activeSeries <= 0) {
+    return null;
+  }
+
+  return {
+    activeSeries,
+    dataPointsPerMinute,
+    queries,
+  };
+}
+
+/** Metrics usage summary from the Cloud usage datasource, or the first available Prometheus datasource. */
+export async function fetchMetricsOverview(): Promise<MetricsOverview | null> {
+  const queries = await resolveMetricsQueries();
+  return queries ? fetchOverview(queries) : null;
+}
+
+/** Active-series history over the last 24 hours. */
+export async function fetchMetricsHistory(overview: MetricsOverview): Promise<FieldSparkline | null> {
+  const { datasourceUid } = overview.queries;
+  const frames = await withRetry(() =>
+    runRangeQuery('history', overview.queries.activeSeries, 24, { uid: datasourceUid, type: 'prometheus' })
+  );
+  return readSeries(frames, 'history');
+}

--- a/public/app/features/home/Recommendations/probeUtils.test.ts
+++ b/public/app/features/home/Recommendations/probeUtils.test.ts
@@ -1,4 +1,126 @@
-import { withTimeout } from './probeUtils';
+import { type DataSourceInstanceListItem } from '@grafana/data';
+import { getDataSourceInstanceList } from '@grafana/runtime/unstable';
+
+import { listProbeCandidates, withTimeout } from './probeUtils';
+
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getDataSourceInstanceList: jest.fn(),
+}));
+
+const mockGetDataSourceInstanceList = jest.mocked(getDataSourceInstanceList);
+
+function datasource(uid: string, name: string, isDefault = false): DataSourceInstanceListItem {
+  return {
+    uid,
+    name,
+    isDefault,
+    type: 'prometheus',
+    meta: { id: 'prometheus' } as DataSourceInstanceListItem['meta'],
+    readOnly: false,
+  };
+}
+
+beforeEach(() => mockGetDataSourceInstanceList.mockReset());
+
+describe('listProbeCandidates', () => {
+  async function candidateUids(
+    datasources: DataSourceInstanceListItem[],
+    options?: Parameters<typeof listProbeCandidates>[1]
+  ): Promise<string[]> {
+    mockGetDataSourceInstanceList.mockResolvedValue(datasources);
+    const candidates = await listProbeCandidates('prometheus', options);
+    return candidates.map((ds) => ds.uid);
+  }
+
+  it('puts the default before other product datasources and excludes utilities', async () => {
+    const result = await candidateUids([
+      datasource('other', 'other-prom'),
+      datasource('grafanacloud-usage', 'grafanacloud-usage'),
+      datasource('default', 'default-prom', true),
+      datasource('grafanacloud-ml-metrics', 'grafanacloud-ml-metrics'),
+    ]);
+
+    expect(result).toEqual(['default', 'other']);
+  });
+
+  it('preserves list order when no product datasource is default', async () => {
+    const result = await candidateUids([
+      datasource('second', 'second-prom'),
+      datasource('first', 'first-prom'),
+      datasource('grafanacloud-usage', 'grafanacloud-usage'),
+    ]);
+
+    expect(result).toEqual(['second', 'first']);
+  });
+
+  it('falls back to utilities in list order when no product datasource exists', async () => {
+    const result = await candidateUids([
+      datasource('grafanacloud-ml-metrics', 'grafanacloud-ml-metrics'),
+      datasource('grafanacloud-usage', 'grafanacloud-usage'),
+    ]);
+
+    expect(result).toEqual(['grafanacloud-ml-metrics', 'grafanacloud-usage']);
+  });
+
+  it('puts a default utility first when no product datasource exists', async () => {
+    const result = await candidateUids([
+      datasource('grafanacloud-ml-metrics', 'grafanacloud-ml-metrics'),
+      datasource('grafanacloud-usage', 'grafanacloud-usage', true),
+    ]);
+
+    expect(result).toEqual(['grafanacloud-usage', 'grafanacloud-ml-metrics']);
+  });
+
+  it('promotes preferred UIDs in supplied order and applies the cap afterward', async () => {
+    const result = await candidateUids(
+      [
+        datasource('default', 'default-prom', true),
+        datasource('grafanacloud-usage', 'grafanacloud-usage'),
+        datasource('preferred', 'preferred-prom'),
+        datasource('other', 'other-prom'),
+        datasource('grafanacloud-ml-metrics', 'grafanacloud-ml-metrics'),
+      ],
+      {
+        cap: 4,
+        preferredUids: ['preferred', 'grafanacloud-ml-metrics', 'grafanacloud-usage', 'missing'],
+      }
+    );
+
+    expect(result).toEqual(['preferred', 'grafanacloud-ml-metrics', 'grafanacloud-usage', 'default']);
+  });
+
+  it('does not fall back to utilities when the only product datasource is preferred', async () => {
+    const result = await candidateUids(
+      [
+        datasource('grafanacloud-usage', 'grafanacloud-usage'),
+        datasource('preferred', 'preferred-prom'),
+        datasource('grafanacloud-ml-metrics', 'grafanacloud-ml-metrics'),
+      ],
+      { preferredUids: ['preferred'] }
+    );
+
+    expect(result).toEqual(['preferred']);
+  });
+
+  it('puts a preferred utility before remaining utility fallbacks', async () => {
+    const result = await candidateUids(
+      [
+        datasource('grafanacloud-ml-metrics', 'grafanacloud-ml-metrics'),
+        datasource('grafanacloud-usage', 'grafanacloud-usage'),
+      ],
+      { preferredUids: ['grafanacloud-usage'] }
+    );
+
+    expect(result).toEqual(['grafanacloud-usage', 'grafanacloud-ml-metrics']);
+  });
+
+  it('returns an empty list when no datasource is available', async () => {
+    const result = await candidateUids([]);
+
+    expect(result).toEqual([]);
+  });
+});
 
 describe('withTimeout', () => {
   it('resolves with the promise value when it settles inside the deadline', async () => {

--- a/public/app/features/home/Recommendations/probeUtils.ts
+++ b/public/app/features/home/Recommendations/probeUtils.ts
@@ -79,13 +79,13 @@ export function createTtlCachedPromise<T>(fn: () => Promise<T>, ttlMs: number): 
 }
 
 /**
- * Candidate datasources of `type` for a data-existence probe: cloud utility datasources are
- * skipped (unless they are all there is), the default datasource leads, capped for fan-out.
- * Pass an Infinity `cap` when the caller reorders before capping itself.
+ * Candidate datasources of `type` for a data-existence probe. Explicit preferences lead in their
+ * supplied order, followed by the default and remaining datasources, then the list is capped.
+ * Preferred UIDs override the normal exclusion of Cloud utility datasources.
  */
 export async function listProbeCandidates(
   type: string,
-  cap = MAX_PROBED_DATASOURCES
+  { cap = MAX_PROBED_DATASOURCES, preferredUids = [] }: { cap?: number; preferredUids?: string[] } = {}
 ): Promise<DataSourceInstanceListItem[]> {
   const list = await withRetry(() =>
     getDataSourceInstanceList({
@@ -94,10 +94,37 @@ export async function listProbeCandidates(
       filter: (ds) => ds.meta.id !== 'grafana',
     })
   );
-  const preferred = list.filter((ds) => !CLOUD_UTILITY_DATASOURCE_NAMES[ds.name]);
-  const pool = preferred.length > 0 ? preferred : list;
-  const def = pool.find((ds) => ds.isDefault);
-  const ordered = def ? [def, ...pool.filter((ds) => ds !== def)] : [...pool];
+  const preferred: DataSourceInstanceListItem[] = [];
+  const defaultProduct: DataSourceInstanceListItem[] = [];
+  const product: DataSourceInstanceListItem[] = [];
+  const defaultUtility: DataSourceInstanceListItem[] = [];
+  const utility: DataSourceInstanceListItem[] = [];
+  let hasProductDatasource = false;
+  for (const datasource of list) {
+    const isUtility = CLOUD_UTILITY_DATASOURCE_NAMES[datasource.name];
+    if (!isUtility) {
+      hasProductDatasource = true;
+    }
+    if (preferredUids.includes(datasource.uid)) {
+      preferred.push(datasource);
+    } else if (isUtility && datasource.isDefault) {
+      defaultUtility.push(datasource);
+    } else if (isUtility) {
+      utility.push(datasource);
+    } else if (datasource.isDefault) {
+      defaultProduct.push(datasource);
+    } else {
+      product.push(datasource);
+    }
+  }
+
+  preferred.sort((a, b) => preferredUids.indexOf(a.uid) - preferredUids.indexOf(b.uid));
+  const ordered = [
+    ...preferred,
+    ...defaultProduct,
+    ...product,
+    ...(hasProductDatasource ? [] : [...defaultUtility, ...utility]),
+  ];
   return ordered.slice(0, cap);
 }
 

--- a/public/app/features/home/Recommendations/types.ts
+++ b/public/app/features/home/Recommendations/types.ts
@@ -20,7 +20,7 @@ export interface ExistingItem {
   title: string;
   icon: IconName;
   subtitle?: string;
-  stats?: { primary: string; secondary: string };
+  stats?: { primary: string; secondary?: string };
   statsLoading?: boolean;
   sparkline?: SolutionSparklineData;
   sparklineLoading?: boolean;

--- a/public/app/features/home/Recommendations/useExistingSolutions.test.ts
+++ b/public/app/features/home/Recommendations/useExistingSolutions.test.ts
@@ -3,12 +3,18 @@ import { renderHook } from '@testing-library/react';
 import { type ExistingItem } from './types';
 import { useExistingSolutions } from './useExistingSolutions';
 import { useKubernetesSolution } from './useKubernetesSolution';
+import { useMetricsSolution } from './useMetricsSolution';
 
 jest.mock('./useKubernetesSolution', () => ({
   useKubernetesSolution: jest.fn(),
 }));
 
+jest.mock('./useMetricsSolution', () => ({
+  useMetricsSolution: jest.fn(),
+}));
+
 const mockUseKubernetesSolution = jest.mocked(useKubernetesSolution);
+const mockUseMetricsSolution = jest.mocked(useMetricsSolution);
 
 const kubernetesItem: ExistingItem = {
   id: 'kubernetes-monitoring',
@@ -17,6 +23,18 @@ const kubernetesItem: ExistingItem = {
   action: 'Open K8s app',
   href: '#',
 };
+
+const metricsItem: ExistingItem = {
+  id: 'metrics',
+  title: 'Metrics & infrastructure',
+  icon: 'chart-line',
+  action: 'Open metrics',
+  href: '#',
+};
+
+beforeEach(() => {
+  mockUseMetricsSolution.mockReturnValue({ loading: false, item: null });
+});
 
 describe('useExistingSolutions', () => {
   it('reports loading while a provider is still probing and nothing was found', () => {
@@ -41,6 +59,15 @@ describe('useExistingSolutions', () => {
     const { result } = renderHook(() => useExistingSolutions());
 
     expect(result.current).toEqual({ loading: false, solutions: [kubernetesItem] });
+  });
+
+  it('includes a discovered Metrics provider in registry order', () => {
+    mockUseKubernetesSolution.mockReturnValue({ loading: false, item: kubernetesItem });
+    mockUseMetricsSolution.mockReturnValue({ loading: false, item: metricsItem });
+
+    const { result } = renderHook(() => useExistingSolutions());
+
+    expect(result.current).toEqual({ loading: false, solutions: [kubernetesItem, metricsItem] });
   });
 
   it('renders a discovered solution immediately even if a provider still reports loading', () => {

--- a/public/app/features/home/Recommendations/useExistingSolutions.ts
+++ b/public/app/features/home/Recommendations/useExistingSolutions.ts
@@ -1,5 +1,6 @@
 import { type ExistingItem, type ExistingSolutionProviderResult } from './types';
 import { useKubernetesSolution } from './useKubernetesSolution';
+import { useMetricsSolution } from './useMetricsSolution';
 
 export interface ExistingSolutionsResult {
   loading: boolean;
@@ -13,8 +14,9 @@ export interface ExistingSolutionsResult {
  */
 export function useExistingSolutions(): ExistingSolutionsResult {
   const kubernetes = useKubernetesSolution();
+  const metrics = useMetricsSolution();
 
-  const providers: ExistingSolutionProviderResult[] = [kubernetes];
+  const providers: ExistingSolutionProviderResult[] = [kubernetes, metrics];
 
   const solutions = providers.flatMap((provider) => (provider.item ? [provider.item] : []));
   // A discovered solution renders immediately; the empty state waits for every

--- a/public/app/features/home/Recommendations/useMetricsSolution.test.ts
+++ b/public/app/features/home/Recommendations/useMetricsSolution.test.ts
@@ -1,0 +1,125 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+
+import { type PluginMeta } from '@grafana/data';
+import { canAccessPluginPage, usePluginBridge } from 'app/features/alerting/unified/hooks/usePluginBridge';
+
+import {
+  fetchMetricsHistory,
+  fetchMetricsOverview,
+  METRICS_DRILLDOWN_APP_ID,
+  type MetricsOverview,
+} from './metricsData';
+import { useMetricsSolution } from './useMetricsSolution';
+
+jest.mock('app/features/alerting/unified/hooks/usePluginBridge', () => ({
+  ...jest.requireActual('app/features/alerting/unified/hooks/usePluginBridge'),
+  canAccessPluginPage: jest.fn(),
+  usePluginBridge: jest.fn(),
+}));
+
+jest.mock('./metricsData', () => ({
+  ...jest.requireActual('./metricsData'),
+  fetchMetricsHistory: jest.fn(),
+  fetchMetricsOverview: jest.fn(),
+}));
+
+const mockCanAccessPluginPage = jest.mocked(canAccessPluginPage);
+const mockUsePluginBridge = jest.mocked(usePluginBridge);
+const mockFetchMetricsOverview = jest.mocked(fetchMetricsOverview);
+const mockFetchMetricsHistory = jest.mocked(fetchMetricsHistory);
+
+const settings = { id: METRICS_DRILLDOWN_APP_ID } as PluginMeta;
+const overview: MetricsOverview = {
+  activeSeries: 4_200_000,
+  dataPointsPerMinute: 5_160_000,
+  queries: {
+    datasourceUid: 'prometheus',
+    activeSeries: 'sum(prometheus_tsdb_head_series)',
+    dataPointsPerMinute: '60 * sum(rate(prometheus_tsdb_head_samples_appended_total[5m]))',
+  },
+};
+
+beforeEach(() => {
+  mockCanAccessPluginPage.mockReturnValue(true);
+  mockUsePluginBridge.mockReturnValue({ loading: false, installed: true, settings });
+  mockFetchMetricsOverview.mockResolvedValue(null);
+  mockFetchMetricsHistory.mockResolvedValue(null);
+});
+
+afterEach(() => jest.restoreAllMocks());
+
+describe('useMetricsSolution', () => {
+  it('reports bridge loading without querying metrics', async () => {
+    mockUsePluginBridge.mockReturnValue({ loading: true, installed: undefined, settings: undefined });
+
+    const { result } = renderHook(() => useMetricsSolution());
+    await act(async () => {});
+
+    expect(result.current).toEqual({ loading: true, item: null });
+    expect(mockFetchMetricsOverview).not.toHaveBeenCalled();
+  });
+
+  it('settles empty without querying when the app is unavailable or inaccessible', async () => {
+    mockCanAccessPluginPage.mockReturnValue(false);
+
+    const { result } = renderHook(() => useMetricsSolution());
+    await act(async () => {});
+
+    expect(result.current).toEqual({ loading: false, item: null });
+    expect(mockFetchMetricsOverview).not.toHaveBeenCalled();
+  });
+
+  it('reports loading while the overview is pending', async () => {
+    mockFetchMetricsOverview.mockImplementation(() => new Promise(() => {}));
+
+    const { result } = renderHook(() => useMetricsSolution());
+
+    await waitFor(() => expect(mockFetchMetricsOverview).toHaveBeenCalledTimes(1));
+    expect(result.current).toEqual({ loading: true, item: null });
+    expect(mockFetchMetricsHistory).not.toHaveBeenCalled();
+  });
+
+  it('settles empty without fetching history when the overview has no active series', async () => {
+    const { result } = renderHook(() => useMetricsSolution());
+
+    await waitFor(() => expect(result.current).toEqual({ loading: false, item: null }));
+    expect(mockFetchMetricsHistory).not.toHaveBeenCalled();
+  });
+
+  it('settles empty when the overview query rejects', async () => {
+    mockFetchMetricsOverview.mockRejectedValue(new Error('query failed'));
+
+    const { result } = renderHook(() => useMetricsSolution());
+
+    await waitFor(() => expect(result.current).toEqual({ loading: false, item: null }));
+    expect(mockFetchMetricsHistory).not.toHaveBeenCalled();
+  });
+
+  it('keeps the Metrics card when history rejects, removing only the sparkline loading state', async () => {
+    let rejectHistory: (error: Error) => void = () => {};
+    mockFetchMetricsOverview.mockResolvedValue(overview);
+    mockFetchMetricsHistory.mockImplementation(
+      () =>
+        new Promise((_, reject) => {
+          rejectHistory = reject;
+        })
+    );
+
+    const { result } = renderHook(() => useMetricsSolution());
+
+    await waitFor(() => expect(result.current.item?.sparklineLoading).toBe(true));
+    expect(result.current).toMatchObject({
+      loading: false,
+      item: {
+        id: 'metrics',
+        sparkline: undefined,
+      },
+    });
+
+    act(() => rejectHistory(new Error('history failed')));
+
+    await waitFor(() => expect(result.current.item?.sparklineLoading).toBe(false));
+    expect(result.current.item?.id).toBe('metrics');
+    expect(result.current.item?.sparkline).toBeUndefined();
+  });
+});

--- a/public/app/features/home/Recommendations/useMetricsSolution.ts
+++ b/public/app/features/home/Recommendations/useMetricsSolution.ts
@@ -1,0 +1,49 @@
+import { useAsync } from 'react-use';
+
+import { createBridgeURL } from 'app/features/alerting/unified/components/PluginBridge';
+import { canAccessPluginPage, usePluginBridge } from 'app/features/alerting/unified/hooks/usePluginBridge';
+
+import { buildMetricsItem } from './buildMetricsItem';
+import { fetchMetricsHistory, fetchMetricsOverview, METRICS_DRILLDOWN_APP_ID } from './metricsData';
+import { type ExistingSolutionProviderResult } from './types';
+
+/**
+ * Metrics solution provider: exposes the live metrics summary when the drilldown app is
+ * ready and the selected datasource provides one.
+ */
+export function useMetricsSolution(): ExistingSolutionProviderResult {
+  const { settings, installed, loading: settingsLoading } = usePluginBridge(METRICS_DRILLDOWN_APP_ID);
+  const appReady =
+    !settingsLoading &&
+    !!installed &&
+    !!settings &&
+    canAccessPluginPage(settings, createBridgeURL(METRICS_DRILLDOWN_APP_ID, '/drilldown'));
+
+  // Do not query until the drilldown app is ready; the overview result is the data gate.
+  const {
+    value: overview,
+    error: overviewError,
+    loading: overviewLoading,
+  } = useAsync(async () => (appReady ? fetchMetricsOverview() : undefined), [appReady]);
+  const { value: history, loading: historyLoading } = useAsync(
+    () => (appReady && overview ? fetchMetricsHistory(overview) : Promise.resolve(null)),
+    [appReady, overview]
+  );
+
+  if (!appReady || !settings) {
+    return { loading: settingsLoading, item: null };
+  }
+
+  if (overviewError) {
+    return { loading: false, item: null };
+  }
+
+  if (overviewLoading || overview === undefined) {
+    return { loading: true, item: null };
+  }
+
+  return {
+    loading: false,
+    item: overview ? buildMetricsItem(overview, history ?? null, historyLoading) : null,
+  };
+}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -11018,6 +11018,13 @@
         "title": "Kubernetes Monitoring",
         "view": "View"
       },
+      "metrics": {
+        "action": "Open metrics",
+        "active-series-24h": "Active series · last 24h",
+        "data-points-per-minute": "{{value}} data points/min",
+        "series": "{{value}} series",
+        "title": "Metrics & infrastructure"
+      },
       "next": "Next",
       "no-data": {
         "badge": "Getting started",


### PR DESCRIPTION
## Summary

Replaces the placeholder Hosted Metrics solution with a live Metrics & infrastructure card that works across Grafana Cloud and self-managed Grafana.

- shows the current active-series count and its 24-hour history
- shows data points per minute as an optional secondary value
- links directly to Metrics Drilldown
- selects the stack-scoped Cloud usage datasource when available, otherwise uses the default or first Prometheus datasource
- only displays when Metrics Drilldown is accessible and active-series data is available
- degrades gracefully when optional data or history cannot be loaded
