### PR TITLE
Theme: Adjust classic palette primary blue shade

### DIFF
--- a/packages/grafana-data/src/themes/createVisualizationColors.ts
+++ b/packages/grafana-data/src/themes/createVisualizationColors.ts
@@ -190,7 +190,7 @@ function getDarkHues(): ThemeVizHue[] {
       shades: [
         { color: '#C0D8FF', name: 'super-light-blue', aliases: [] },
         { color: '#8AB8FF', name: 'light-blue', aliases: [] },
-        { color: '#5794F2', name: 'blue', aliases: [], primary: true },
+        { color: '#4a86ef', name: 'blue', aliases: [], primary: true },
         { color: '#3274D9', name: 'semi-dark-blue', aliases: [] },
         { color: '#1F60C4', name: 'dark-blue', aliases: [] },
       ],


### PR DESCRIPTION
Slightly deepens the primary blue hue used by the classic series palette so lines read a touch better against the dark canvas background.