### PR TITLE
Geomap: Increase default marker size

### DIFF
--- a/public/app/plugins/panel/geomap/style/types.ts
+++ b/public/app/plugins/panel/geomap/style/types.ts
@@ -39,7 +39,7 @@ export interface StyleConfig {
   rotation?: ScalarDimensionConfig;
 }
 
-export const DEFAULT_SIZE = 5;
+export const DEFAULT_SIZE = 7;
 
 export enum TextAlignment {
   Left = 'left',


### PR DESCRIPTION
Bumps the default point marker size from 5 to 7 so markers are easier to see at default zoom levels.