### PR TITLE
VizTooltip: Tighten tooltip row column gap

### DIFF
--- a/packages/grafana-ui/src/components/VizTooltip/VizTooltipRow.tsx
+++ b/packages/grafana-ui/src/components/VizTooltip/VizTooltipRow.tsx
@@ -237,7 +237,7 @@ const getStyles = (theme: GrafanaTheme2, justify = 'start', marginRight?: string
     maxWidth: '100%',
     alignItems: 'start',
     justifyContent: justify,
-    columnGap: theme.spacing(0.75),
+    columnGap: theme.spacing(0.25),
   }),
   label: css({ display: 'inline' }),
   value: css({


### PR DESCRIPTION
Reduces the horizontal gap between the color indicator, label, and value in tooltip rows for a more compact layout.