### PR TITLE
FieldOverrides: Skip string fields when assigning series color index

### DIFF
--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -214,8 +214,8 @@ export function applyFieldOverrides(
       field.type = type;
 
       // Some color modes needs series index to assign field color so we count
-      // up series index here but ignore time fields
-      if (field.type !== FieldType.time) {
+      // up series index here but ignore time and string fields
+      if (field.type !== FieldType.time && field.type !== FieldType.string) {
         seriesIndex++;
       }
 


### PR DESCRIPTION
String fields are not colored series, so they should not consume a series color index. Only increment seriesIndex for non-time, non-string fields.