### PR TITLE
FieldColor: Add Oranges continuous color scheme

### DIFF
--- a/packages/grafana-data/src/field/fieldColor.ts
+++ b/packages/grafana-data/src/field/fieldColor.ts
@@ -403,6 +403,14 @@ export const fieldColorModeRegistry = new Registry<FieldColorMode>(() => {
       getColors: (theme: GrafanaTheme2) => ['panel-bg', 'dark-purple'],
       group: otherGroup,
     }),
+    new FieldColorSchemeMode({
+      id: FieldColorModeId.ContinuousOranges,
+      name: 'Oranges',
+      isContinuous: true,
+      isByValue: true,
+      getColors: (theme: GrafanaTheme2) => ['panel-bg', 'dark-orange'],
+      group: otherGroup,
+    }),
   ];
 });
 

--- a/packages/grafana-data/src/types/fieldColor.ts
+++ b/packages/grafana-data/src/types/fieldColor.ts
@@ -36,6 +36,7 @@ export enum FieldColorModeId {
   ContinuousReds = 'continuous-reds',
   ContinuousGreens = 'continuous-greens',
   ContinuousPurples = 'continuous-purples',
+  ContinuousOranges = 'continuous-oranges',
   ContinuousViridis = 'continuous-viridis',
   ContinuousMagma = 'continuous-magma',
   ContinuousPlasma = 'continuous-plasma',


### PR DESCRIPTION
Adds a panel-bg to dark-orange continuous scheme alongside the existing Blues/Reds/Greens/Purples options.