### PR TITLE
PanelDataErrorView: Align empty-state message to top

### DIFF
--- a/public/app/features/panel/components/PanelDataErrorView.tsx
+++ b/public/app/features/panel/components/PanelDataErrorView.tsx
@@ -176,7 +176,7 @@ const getStyles = (theme: GrafanaTheme2) => {
     wrapper: css({
       display: 'flex',
       flexDirection: 'column',
-      justifyContent: 'center',
+      justifyContent: 'flex-start',
       alignItems: 'center',
       height: '100%',
       width: '100%',


### PR DESCRIPTION
Aligns the No data / error message to the top of the panel instead of vertically centering it.