### PR TITLE
Provisioning: Consolidate integration test helpers

### DIFF
--- a/pkg/tests/apis/provisioning/bom_test.go
+++ b/pkg/tests/apis/provisioning/bom_test.go
@@ -231,14 +231,7 @@ func TestIntegrationProvisioning_BOMs(t *testing.T) {
 		require.NoError(t, err)
 
 		// Wait for repository to be deleted (finalizer has completed)
-		require.EventuallyWithT(t, func(collect *assert.CollectT) {
-			_, err = helper.Repositories.Resource.Get(t.Context(), repoName, metav1.GetOptions{})
-			if err == nil {
-				collect.Errorf("repository should be deleted")
-				return
-			}
-			// Repository not found - good!
-		}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "repository should be deleted")
+		helper.WaitForRepositoryDeleted(t, repoName)
 
 		// Verify dashboard STILL EXISTS (released, not deleted)
 		dashboard, err = helper.DashboardsV1.Resource.Get(t.Context(), "bom-deletion-test", metav1.GetOptions{})

--- a/pkg/tests/apis/provisioning/bom_test.go
+++ b/pkg/tests/apis/provisioning/bom_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 )
@@ -219,19 +218,8 @@ func TestIntegrationProvisioning_BOMs(t *testing.T) {
 
 		// Patch repository to add release-orphan-resources finalizer
 		// This causes dashboards to be released (annotations removed) rather than deleted
-		patchData := []byte(`[
-			{"op": "replace", "path": "/metadata/finalizers", "value": ["cleanup", "release-orphan-resources"]}
-		]`)
-		_, err = helper.Repositories.Resource.Patch(t.Context(), repoName, types.JSONPatchType, patchData, metav1.PatchOptions{})
-		require.NoError(t, err, "should successfully patch finalizers")
-
-		// Delete the repository - finalizer will patch dashboard to remove annotations
 		// The key test: PATCH should succeed even though dashboard has BOMs in spec
-		err = helper.Repositories.Resource.Delete(t.Context(), repoName, metav1.DeleteOptions{})
-		require.NoError(t, err)
-
-		// Wait for repository to be deleted (finalizer has completed)
-		helper.WaitForRepositoryDeleted(t, repoName)
+		helper.ReleaseAndDeleteRepository(t, repoName)
 
 		// Verify dashboard STILL EXISTS (released, not deleted)
 		dashboard, err = helper.DashboardsV1.Resource.Get(t.Context(), "bom-deletion-test", metav1.GetOptions{})

--- a/pkg/tests/apis/provisioning/classic_delete_test.go
+++ b/pkg/tests/apis/provisioning/classic_delete_test.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -182,20 +181,7 @@ func TestIntegrationProvisioning_ClassicDashboardDeletion(t *testing.T) {
 		})
 
 		// Verify both dashboards were created
-		require.EventuallyWithT(t, func(collect *assert.CollectT) {
-			count := 0
-			dashboards, err := helper.DashboardsV1.Resource.List(t.Context(), metav1.ListOptions{})
-			if !assert.NoError(collect, err) {
-				return
-			}
-			for _, d := range dashboards.Items {
-				name := d.GetName()
-				if name == "mixed-classic-uid" || name == "mixed-k8s-uid" {
-					count++
-				}
-			}
-			assert.Equal(collect, 2, count, "both dashboards should exist")
-		}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "both dashboards should be created")
+		helper.RequireDashboards(t, "mixed-classic-uid", "mixed-k8s-uid")
 
 		// Delete both files
 		err = os.Remove(filepath.Join(repoPath, "classic.json"))

--- a/pkg/tests/apis/provisioning/common/permissions.go
+++ b/pkg/tests/apis/provisioning/common/permissions.go
@@ -19,6 +19,72 @@ const (
 	FolderPermissionAdmin = 4
 )
 
+// RolePermission is a built-in role → permission level pair for the legacy
+// folder permissions API.
+type RolePermission struct {
+	Role       string
+	Permission int
+}
+
+// SetFolderPermissions replaces the folder's ACL with the given role-based
+// entries via the legacy folder permissions API and asserts the request
+// succeeds.
+func SetFolderPermissions(t *testing.T, helper *ProvisioningTestHelper, folderUID string, items ...RolePermission) {
+	t.Helper()
+	entries := make([]map[string]interface{}, 0, len(items))
+	for _, item := range items {
+		entries = append(entries, map[string]interface{}{
+			"role":       item.Role,
+			"permission": item.Permission,
+		})
+	}
+	_, code, err := PostHelper(t, *helper.K8sTestHelper,
+		fmt.Sprintf("/api/folders/%s/permissions", folderUID),
+		map[string]interface{}{"items": entries},
+		helper.Org1.Admin)
+	require.NoError(t, err, "setting permissions on folder %q should succeed", folderUID)
+	require.Equal(t, http.StatusOK, code)
+}
+
+// RequireRolePermissionSetEqual asserts that the set of (role → permission)
+// mappings is identical between want and got. Entry ordering and non-role
+// fields (which may legitimately change after a move, such as internal
+// parent-folder references) are ignored.
+func RequireRolePermissionSetEqual(t *testing.T, want, got []interface{}) {
+	t.Helper()
+	extractRoleMap := func(perms []interface{}) map[string]int {
+		m := make(map[string]int)
+		for _, p := range perms {
+			entry, ok := p.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			role, _ := entry["role"].(string)
+			if role == "" {
+				continue
+			}
+			level, _ := entry["permission"].(float64)
+			m[role] = int(level)
+		}
+		return m
+	}
+	require.Equal(t, extractRoleMap(want), extractRoleMap(got),
+		"role→permission map must be identical")
+}
+
+// RequireFolderAccessible asserts that GET /api/folders/{folderUID} returns
+// HTTP 200 when performed with the supplied Basic Auth credentials. This
+// exercises real authorization logic, not just the stored ACL data.
+func RequireFolderAccessible(t *testing.T, helper *ProvisioningTestHelper, folderUID, login, password string) {
+	t.Helper()
+	u := fmt.Sprintf("http://%s:%s@%s/api/folders/%s", login, password, folderAddr(helper), folderUID)
+	resp, err := http.Get(u) //nolint:gosec
+	require.NoError(t, err, "GET folder %q as user %q", folderUID, login)
+	defer resp.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusOK, resp.StatusCode,
+		"folder %q should be accessible to %q", folderUID, login)
+}
+
 // FolderPermissions fetches the managed ACL entries for a folder via the legacy
 // folder permissions API using admin credentials. It fails the test if the
 // request does not return 200. The entries are returned as decoded JSON objects

--- a/pkg/tests/apis/provisioning/common/testing.go
+++ b/pkg/tests/apis/provisioning/common/testing.go
@@ -980,11 +980,6 @@ func (h *ProvisioningTestHelper) CreateLocalRepo(t *testing.T, repo TestRepo) {
 	}
 }
 
-// countManagedResources counts resources managed by repoName.
-func countManagedResources(items []unstructured.Unstructured, repoName string) int {
-	return len(filterManagedResources(items, repoName))
-}
-
 // filterManagedResources returns the resources managed by repoName.
 func filterManagedResources(items []unstructured.Unstructured, repoName string) []unstructured.Unstructured {
 	var managed []unstructured.Unstructured
@@ -1109,18 +1104,20 @@ func (h *ProvisioningTestHelper) WaitForConditionReason(t *testing.T, repoName s
 // default wait timeout elapses. Polling is required because SyncAndWait only
 // waits for the sync job resource to complete; the dashboards-list API may
 // not yet reflect newly-created/deleted resources at that instant.
-func (h *ProvisioningTestHelper) RequireRepoDashboardCount(t *testing.T, repoName string, expectedCount int) {
+func (h *ProvisioningTestHelper) RequireRepoDashboardCount(t *testing.T, repoName string, expectedCount int) []unstructured.Unstructured {
 	t.Helper()
+	var managed []unstructured.Unstructured
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		dashboards, err := h.DashboardsV1.Resource.List(t.Context(), metav1.ListOptions{})
 		if !assert.NoError(c, err, "failed to list dashboards") {
 			return
 		}
 
-		count := countManagedResources(dashboards.Items, repoName)
-		assert.Equal(c, expectedCount, count, "unexpected number of dashboards managed by repo %s", repoName)
+		managed = filterManagedResources(dashboards.Items, repoName)
+		assert.Equal(c, expectedCount, len(managed), "unexpected number of dashboards managed by repo %s", repoName)
 	}, WaitTimeoutDefault, WaitIntervalDefault,
 		"expected %d dashboard(s) managed by repo %s", expectedCount, repoName)
+	return managed
 }
 
 // RequireRepoFolderCount polls the folders list until the number of folders
@@ -1128,18 +1125,20 @@ func (h *ProvisioningTestHelper) RequireRepoDashboardCount(t *testing.T, repoNam
 // timeout elapses. Like the dashboard variant, this avoids races where the
 // sync job has completed but the folders-list API has not yet observed the
 // newly-created folders or their grafana.app/managerId annotation.
-func (h *ProvisioningTestHelper) RequireRepoFolderCount(t *testing.T, repoName string, expectedCount int) {
+func (h *ProvisioningTestHelper) RequireRepoFolderCount(t *testing.T, repoName string, expectedCount int) []unstructured.Unstructured {
 	t.Helper()
+	var managed []unstructured.Unstructured
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		folders, err := h.Folders.Resource.List(t.Context(), metav1.ListOptions{})
 		if !assert.NoError(c, err, "failed to list folders") {
 			return
 		}
 
-		count := countManagedResources(folders.Items, repoName)
-		assert.Equal(c, expectedCount, count, "unexpected number of folders managed by repo %s", repoName)
+		managed = filterManagedResources(folders.Items, repoName)
+		assert.Equal(c, expectedCount, len(managed), "unexpected number of folders managed by repo %s", repoName)
 	}, WaitTimeoutDefault, WaitIntervalDefault,
 		"expected %d folder(s) managed by repo %s", expectedCount, repoName)
+	return managed
 }
 
 // RequireSingleRepoFolder polls until exactly one folder is managed by the

--- a/pkg/tests/apis/provisioning/common/testing.go
+++ b/pkg/tests/apis/provisioning/common/testing.go
@@ -1142,6 +1142,47 @@ func (h *ProvisioningTestHelper) RequireRepoFolderCount(t *testing.T, repoName s
 		"expected %d folder(s) managed by repo %s", expectedCount, repoName)
 }
 
+// RequireSingleRepoFolder polls until exactly one folder is managed by the
+// given repo and returns it. Poll-and-return in one step so callers never
+// index into a separately fetched list that may transiently be empty.
+func (h *ProvisioningTestHelper) RequireSingleRepoFolder(t *testing.T, repoName string) *unstructured.Unstructured {
+	t.Helper()
+	var folder unstructured.Unstructured
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		folders, err := h.Folders.Resource.List(t.Context(), metav1.ListOptions{})
+		if !assert.NoError(c, err, "failed to list folders") {
+			return
+		}
+		managed := filterManagedResources(folders.Items, repoName)
+		if !assert.Len(c, managed, 1, "expected exactly one folder managed by repo %s", repoName) {
+			return
+		}
+		folder = managed[0]
+	}, WaitTimeoutDefault, WaitIntervalDefault,
+		"expected exactly one folder managed by repo %s", repoName)
+	return &folder
+}
+
+// RequireSingleRepoDashboard polls until exactly one dashboard is managed by
+// the given repo and returns it.
+func (h *ProvisioningTestHelper) RequireSingleRepoDashboard(t *testing.T, repoName string) *unstructured.Unstructured {
+	t.Helper()
+	var dashboard unstructured.Unstructured
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		dashboards, err := h.DashboardsV1.Resource.List(t.Context(), metav1.ListOptions{})
+		if !assert.NoError(c, err, "failed to list dashboards") {
+			return
+		}
+		managed := filterManagedResources(dashboards.Items, repoName)
+		if !assert.Len(c, managed, 1, "expected exactly one dashboard managed by repo %s", repoName) {
+			return
+		}
+		dashboard = managed[0]
+	}, WaitTimeoutDefault, WaitIntervalDefault,
+		"expected exactly one dashboard managed by repo %s", repoName)
+	return &dashboard
+}
+
 // TriggerConnectionReconciliation forces the controller to re-process a connection
 // by touching its status (aging the health timestamp by 1ms). A merge patch on the
 // status subresource carries no resourceVersion, so it never conflicts with

--- a/pkg/tests/apis/provisioning/common/testing.go
+++ b/pkg/tests/apis/provisioning/common/testing.go
@@ -1058,6 +1058,28 @@ func (h *ProvisioningTestHelper) RequireFolders(t *testing.T, names ...string) [
 	return matched
 }
 
+// RequireDashboardsNotFound polls until every named dashboard is gone.
+func (h *ProvisioningTestHelper) RequireDashboardsNotFound(t *testing.T, names ...string) {
+	t.Helper()
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		for _, name := range names {
+			_, err := h.DashboardsV1.Resource.Get(t.Context(), name, metav1.GetOptions{})
+			assert.True(c, apierrors.IsNotFound(err), "expected dashboard %q to be not found, got: %v", name, err)
+		}
+	}, WaitTimeoutDefault, WaitIntervalDefault, "expected dashboards %v to be deleted", names)
+}
+
+// RequireFoldersNotFound polls until every named folder is gone.
+func (h *ProvisioningTestHelper) RequireFoldersNotFound(t *testing.T, names ...string) {
+	t.Helper()
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		for _, name := range names {
+			_, err := h.Folders.Resource.Get(t.Context(), name, metav1.GetOptions{})
+			assert.True(c, apierrors.IsNotFound(err), "expected folder %q to be not found, got: %v", name, err)
+		}
+	}, WaitTimeoutDefault, WaitIntervalDefault, "expected folders %v to be deleted", names)
+}
+
 // WaitForResourceQuotaLimit waits until the repository's Status.Quota.MaxResourcesPerRepository
 // matches the expected limit.
 func (h *ProvisioningTestHelper) WaitForResourceQuotaLimit(t *testing.T, repoName string, expectedLimit int64) {

--- a/pkg/tests/apis/provisioning/common/testing.go
+++ b/pkg/tests/apis/provisioning/common/testing.go
@@ -982,14 +982,35 @@ func (h *ProvisioningTestHelper) CreateLocalRepo(t *testing.T, repo TestRepo) {
 
 // countManagedResources counts resources managed by repoName.
 func countManagedResources(items []unstructured.Unstructured, repoName string) int {
-	var count int
+	return len(filterManagedResources(items, repoName))
+}
+
+// filterManagedResources returns the resources managed by repoName.
+func filterManagedResources(items []unstructured.Unstructured, repoName string) []unstructured.Unstructured {
+	var managed []unstructured.Unstructured
 	for i := range items {
 		annotations := items[i].GetAnnotations()
 		if annotations["grafana.app/managedBy"] == "repo" && annotations["grafana.app/managerId"] == repoName {
-			count++
+			managed = append(managed, items[i])
 		}
 	}
-	return count
+	return managed
+}
+
+// ListRepoDashboards lists dashboards and returns only those managed by the given repo.
+func (h *ProvisioningTestHelper) ListRepoDashboards(t *testing.T, repoName string) []unstructured.Unstructured {
+	t.Helper()
+	dashboards, err := h.DashboardsV1.Resource.List(t.Context(), metav1.ListOptions{})
+	require.NoError(t, err, "failed to list dashboards")
+	return filterManagedResources(dashboards.Items, repoName)
+}
+
+// ListRepoFolders lists folders and returns only those managed by the given repo.
+func (h *ProvisioningTestHelper) ListRepoFolders(t *testing.T, repoName string) []unstructured.Unstructured {
+	t.Helper()
+	folders, err := h.Folders.Resource.List(t.Context(), metav1.ListOptions{})
+	require.NoError(t, err, "failed to list folders")
+	return filterManagedResources(folders.Items, repoName)
 }
 
 // RequireDashboards polls until every named dashboard exists, regardless of manager.

--- a/pkg/tests/apis/provisioning/common/testing.go
+++ b/pkg/tests/apis/provisioning/common/testing.go
@@ -1008,40 +1008,54 @@ func (h *ProvisioningTestHelper) ListRepoFolders(t *testing.T, repoName string) 
 	return filterManagedResources(folders.Items, repoName)
 }
 
-// RequireDashboards polls until every named dashboard exists, regardless of manager.
-func (h *ProvisioningTestHelper) RequireDashboards(t *testing.T, names ...string) {
+// RequireDashboards polls until every named dashboard exists, regardless of
+// manager, and returns them in the same order as names.
+func (h *ProvisioningTestHelper) RequireDashboards(t *testing.T, names ...string) []unstructured.Unstructured {
 	t.Helper()
+	matched := make([]unstructured.Unstructured, len(names))
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		dashboards, err := h.DashboardsV1.Resource.List(t.Context(), metav1.ListOptions{})
 		if !assert.NoError(c, err, "failed to list dashboards") {
 			return
 		}
-		var found []string
+		byName := make(map[string]unstructured.Unstructured, len(dashboards.Items))
 		for _, d := range dashboards.Items {
-			found = append(found, d.GetName())
+			byName[d.GetName()] = d
 		}
-		for _, name := range names {
-			assert.Contains(c, found, name, "expected dashboard %q to exist", name)
+		for i, name := range names {
+			d, ok := byName[name]
+			if !assert.True(c, ok, "expected dashboard %q to exist", name) {
+				continue
+			}
+			matched[i] = d
 		}
 	}, WaitTimeoutDefault, WaitIntervalDefault, "expected dashboards %v to exist", names)
+	return matched
 }
 
-// RequireFolders polls until every named folder exists, regardless of manager.
-func (h *ProvisioningTestHelper) RequireFolders(t *testing.T, names ...string) {
+// RequireFolders polls until every named folder exists, regardless of manager,
+// and returns them in the same order as names.
+func (h *ProvisioningTestHelper) RequireFolders(t *testing.T, names ...string) []unstructured.Unstructured {
 	t.Helper()
+	matched := make([]unstructured.Unstructured, len(names))
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		folders, err := h.Folders.Resource.List(t.Context(), metav1.ListOptions{})
 		if !assert.NoError(c, err, "failed to list folders") {
 			return
 		}
-		var found []string
+		byName := make(map[string]unstructured.Unstructured, len(folders.Items))
 		for _, f := range folders.Items {
-			found = append(found, f.GetName())
+			byName[f.GetName()] = f
 		}
-		for _, name := range names {
-			assert.Contains(c, found, name, "expected folder %q to exist", name)
+		for i, name := range names {
+			f, ok := byName[name]
+			if !assert.True(c, ok, "expected folder %q to exist", name) {
+				continue
+			}
+			matched[i] = f
 		}
 	}, WaitTimeoutDefault, WaitIntervalDefault, "expected folders %v to exist", names)
+	return matched
 }
 
 // WaitForResourceQuotaLimit waits until the repository's Status.Quota.MaxResourcesPerRepository

--- a/pkg/tests/apis/provisioning/common/testing.go
+++ b/pkg/tests/apis/provisioning/common/testing.go
@@ -1273,6 +1273,39 @@ func (h *ProvisioningTestHelper) WaitForRepositoryDeleted(t *testing.T, name str
 	}, WaitTimeoutDefault, WaitIntervalDefault, "repository %s should be deleted", name)
 }
 
+// ReleaseAndDeleteRepository sets the release-orphan-resources finalizer on the
+// repository, deletes it, and waits until the deletion completes. Managed
+// resources are released (manager annotations stripped) rather than deleted;
+// callers that depend on the release having finished should follow up with
+// WaitForResourcesReleased on the relevant client.
+func (h *ProvisioningTestHelper) ReleaseAndDeleteRepository(t *testing.T, name string) {
+	t.Helper()
+	_, err := h.Repositories.Resource.Patch(t.Context(), name, types.JSONPatchType, []byte(`[
+		{"op": "replace", "path": "/metadata/finalizers", "value": ["cleanup", "release-orphan-resources"]}
+	]`), metav1.PatchOptions{})
+	require.NoError(t, err, "should successfully patch finalizers")
+	require.NoError(t, h.Repositories.Resource.Delete(t.Context(), name, metav1.DeleteOptions{}))
+	h.WaitForRepositoryDeleted(t, name)
+}
+
+// RequireRepoFileExists asserts the repository serves a file at the given path
+// via the files subresource.
+func (h *ProvisioningTestHelper) RequireRepoFileExists(t *testing.T, repo string, path ...string) {
+	t.Helper()
+	subresources := append([]string{"files"}, path...)
+	_, err := h.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, subresources...)
+	require.NoError(t, err, "file %s should exist in repository %s", strings.Join(path, "/"), repo)
+}
+
+// RequireRepoFileNotFound asserts the repository has no file at the given path.
+func (h *ProvisioningTestHelper) RequireRepoFileNotFound(t *testing.T, repo string, path ...string) {
+	t.Helper()
+	subresources := append([]string{"files"}, path...)
+	_, err := h.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, subresources...)
+	require.True(t, apierrors.IsNotFound(err),
+		"file %s should not exist in repository %s, got: %v", strings.Join(path, "/"), repo, err)
+}
+
 // WaitForResourcesReleased polls until every item returned by client no longer
 // carries provisioning-manager annotations — i.e. the release-orphan-resources
 // finalizer has finished handing the objects back to the user.
@@ -2942,6 +2975,19 @@ func NewUnmanagedDashboard(apiVersion, title, folderUID string) *unstructured.Un
 			},
 		},
 	}
+}
+
+// CreateUnmanagedFolderWithName creates a folder with no manager annotations
+// using an explicit name instead of a generated one. Pass "" for parentUID to
+// create a root folder.
+func (h *ProvisioningTestHelper) CreateUnmanagedFolderWithName(t *testing.T, name, title, parentUID string) {
+	t.Helper()
+	folder := NewUnmanagedFolder(title, parentUID)
+	metadata := folder.Object["metadata"].(map[string]interface{})
+	delete(metadata, "generateName")
+	metadata["name"] = name
+	_, err := h.Folders.Resource.Create(t.Context(), folder, metav1.CreateOptions{})
+	require.NoError(t, err, "should create unmanaged folder %q", name)
 }
 
 // CreateUnmanagedFolder creates a folder with no manager annotations under the

--- a/pkg/tests/apis/provisioning/connection/connection_test.go
+++ b/pkg/tests/apis/provisioning/connection/connection_test.go
@@ -723,17 +723,7 @@ func TestIntegrationConnectionController_TokenCreation(t *testing.T) {
 		})
 
 		// Wait for initial reconciliation - controller should update status
-		require.Eventually(t, func() bool {
-			updated, err := connClient.Get(t.Context(), connName, metav1.GetOptions{})
-			if err != nil {
-				return false
-			}
-			readyCondition := meta.FindStatusCondition(updated.Status.Conditions, provisioning.ConditionTypeReady)
-			return updated.Status.ObservedGeneration == updated.Generation &&
-				updated.Status.Health.Checked > 0 &&
-				readyCondition != nil && readyCondition.Status == metav1.ConditionTrue &&
-				updated.Status.Health.Healthy
-		}, 10*time.Second, 500*time.Millisecond, "connection should be reconciled")
+		helper.WaitForHealthyConnection(t, connName)
 
 		// Verify initial health check was set
 		initial, err := connClient.Get(t.Context(), connName, metav1.GetOptions{})
@@ -790,17 +780,7 @@ func TestIntegrationConnectionController_TokenCreation(t *testing.T) {
 		})
 
 		// Wait for initial reconciliation - controller should update status
-		require.Eventually(t, func() bool {
-			updated, err := connClient.Get(t.Context(), connName, metav1.GetOptions{})
-			if err != nil {
-				return false
-			}
-			readyCondition := meta.FindStatusCondition(updated.Status.Conditions, provisioning.ConditionTypeReady)
-			return updated.Status.ObservedGeneration == updated.Generation &&
-				updated.Status.Health.Checked > 0 &&
-				readyCondition != nil && readyCondition.Status == metav1.ConditionTrue &&
-				updated.Status.Health.Healthy
-		}, 10*time.Second, 500*time.Millisecond, "connection should be reconciled")
+		helper.WaitForHealthyConnection(t, connName)
 
 		// Verify initial health check was set
 		initial, err := connClient.Get(t.Context(), connName, metav1.GetOptions{})
@@ -929,17 +909,7 @@ func TestIntegrationConnectionController_HealthCheckUpdates(t *testing.T) {
 		})
 
 		// Wait for initial reconciliation - controller should update status
-		require.Eventually(t, func() bool {
-			updated, err := connClient.Get(t.Context(), connName, metav1.GetOptions{})
-			if err != nil {
-				return false
-			}
-			readyCondition := meta.FindStatusCondition(updated.Status.Conditions, provisioning.ConditionTypeReady)
-			return updated.Status.ObservedGeneration == updated.Generation &&
-				updated.Status.Health.Checked > 0 &&
-				readyCondition != nil && readyCondition.Status == metav1.ConditionTrue &&
-				updated.Status.Health.Healthy
-		}, 10*time.Second, 500*time.Millisecond, "connection should be initially reconciled with health status")
+		helper.WaitForHealthyConnection(t, connName)
 
 		// Verify initial health check was set
 		initial, err := connClient.Get(t.Context(), connName, metav1.GetOptions{})
@@ -1707,10 +1677,7 @@ func TestIntegrationProvisioning_ConnectionDeleteBlockedByRepository(t *testing.
 		require.NoError(t, err, "failed to delete repository")
 
 		// Wait for the repository to be fully deleted (might have finalizers)
-		require.Eventually(t, func() bool {
-			_, err := helper.Repositories.Resource.Get(t.Context(), "repo-referencing-connection", metav1.GetOptions{})
-			return k8serrors.IsNotFound(err)
-		}, 30*time.Second, 100*time.Millisecond, "repository should be deleted")
+		helper.WaitForRepositoryDeleted(t, "repo-referencing-connection")
 
 		// Now deletion should succeed
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {

--- a/pkg/tests/apis/provisioning/files_test.go
+++ b/pkg/tests/apis/provisioning/files_test.go
@@ -84,9 +84,7 @@ func TestIntegrationProvisioning_DeleteResources(t *testing.T) {
 
 		// Verify the dashboard is removed from Grafana
 		const allPanelsUID = "n1jR8vnnz" // UID from all-panels.json
-		_, err := helper.DashboardsV1.Resource.Get(t.Context(), allPanelsUID, metav1.GetOptions{})
-		require.Error(t, err, "dashboard should be deleted from Grafana")
-		require.True(t, apierrors.IsNotFound(err), "should return NotFound for deleted dashboard")
+		helper.RequireDashboardsNotFound(t, allPanelsUID)
 	})
 
 	t.Run("delete individual dashboard file on branch should succeed", func(t *testing.T) {

--- a/pkg/tests/apis/provisioning/files_test.go
+++ b/pkg/tests/apis/provisioning/files_test.go
@@ -125,8 +125,7 @@ func TestIntegrationProvisioning_DeleteResources(t *testing.T) {
 		require.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode, "should return MethodNotAllowed for configured branch folder delete")
 
 		// Verify a file inside the folder still exists (operation was rejected)
-		_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "folder", "dashboard2.json")
-		require.NoError(t, err, "file inside folder should still exist after rejected delete")
+		helper.RequireRepoFileExists(t, repo, "folder", "dashboard2.json")
 	})
 
 	t.Run("deleting a non-existent file should fail", func(t *testing.T) {
@@ -180,12 +179,10 @@ func TestIntegrationProvisioning_MoveResources(t *testing.T) {
 		require.Equal(t, http.StatusOK, resp.StatusCode, "move operation on configured branch should succeed")
 
 		// Verify file was moved - read from new location
-		_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "moved", "simple-move.json")
-		require.NoError(t, err, "file should exist at new location")
+		helper.RequireRepoFileExists(t, repo, "moved", "simple-move.json")
 
 		// Verify file no longer exists at old location
-		_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "all-panels.json")
-		require.Error(t, err, "file should not exist at old location")
+		helper.RequireRepoFileNotFound(t, repo, "all-panels.json")
 	})
 
 	t.Run("move file without content change on branch should succeed", func(t *testing.T) {
@@ -242,12 +239,10 @@ func TestIntegrationProvisioning_MoveResources(t *testing.T) {
 		require.Equal(t, http.StatusOK, resp.StatusCode, "move operation on configured branch should succeed")
 
 		// File should exist at new location
-		_, err := helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "deep", "nested", "timeline.json")
-		require.NoError(t, err, "file should exist at new nested location")
+		helper.RequireRepoFileExists(t, repo, "deep", "nested", "timeline.json")
 
 		// File should not exist at original location
-		_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", sourceFile)
-		require.Error(t, err, "file should not exist at original location after move")
+		helper.RequireRepoFileNotFound(t, repo, sourceFile)
 	})
 
 	t.Run("move file with content update on configured branch should succeed", func(t *testing.T) {
@@ -282,8 +277,7 @@ func TestIntegrationProvisioning_MoveResources(t *testing.T) {
 		require.Equal(t, "Text options", title, "content should be updated")
 
 		// Source file should not exist anymore
-		_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", sourcePath)
-		require.Error(t, err, "source file should not exist after move")
+		helper.RequireRepoFileNotFound(t, repo, sourcePath)
 	})
 
 	t.Run("move directory on configured branch should return MethodNotAllowed", func(t *testing.T) {
@@ -315,8 +309,7 @@ func TestIntegrationProvisioning_MoveResources(t *testing.T) {
 		require.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode, "directory move on configured branch should return MethodNotAllowed")
 
 		// Verify files in source directory still exist (operation was rejected)
-		_, err := helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "source-dir", "timeline-demo.json")
-		require.NoError(t, err, "file in source directory should still exist after rejected move")
+		helper.RequireRepoFileExists(t, repo, "source-dir", "timeline-demo.json")
 	})
 
 	t.Run("error cases", func(t *testing.T) {
@@ -931,7 +924,7 @@ func TestIntegrationProvisioning_FilesAuthorization(t *testing.T) {
 
 	// Grant view permission to Viewer role for the initial dashboard
 	setDashboardPermissions([]map[string]interface{}{
-		{"role": "Viewer", "permission": 1}, // View permission
+		{"role": "Viewer", "permission": common.FolderPermissionView},
 	})
 
 	t.Run("GET operations", func(t *testing.T) {
@@ -1148,8 +1141,7 @@ func TestIntegrationProvisioning_FilesAuthorization(t *testing.T) {
 			require.True(t, apierrors.IsForbidden(result.Error()), "error should be forbidden")
 
 			// Verify file still exists
-			_, err := helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "delete-viewer-test.json")
-			require.NoError(t, err, "file should still exist after failed delete")
+			helper.RequireRepoFileExists(t, repo, "delete-viewer-test.json")
 		})
 
 		t.Run("editor can DELETE files", func(t *testing.T) {
@@ -1165,9 +1157,7 @@ func TestIntegrationProvisioning_FilesAuthorization(t *testing.T) {
 			require.Equal(t, http.StatusOK, statusCode, "should return 200 OK")
 
 			// Verify file was deleted
-			_, err := helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "delete-editor-test.json")
-			require.Error(t, err, "file should be deleted")
-			require.True(t, apierrors.IsNotFound(err), "should return NotFound for deleted file")
+			helper.RequireRepoFileNotFound(t, repo, "delete-editor-test.json")
 		})
 
 		t.Run("admin can DELETE files", func(t *testing.T) {
@@ -1183,9 +1173,7 @@ func TestIntegrationProvisioning_FilesAuthorization(t *testing.T) {
 			require.Equal(t, http.StatusOK, statusCode, "should return 200 OK")
 
 			// Verify file was deleted
-			_, err := helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "delete-admin-test.json")
-			require.Error(t, err, "file should be deleted")
-			require.True(t, apierrors.IsNotFound(err), "should return NotFound for deleted file")
+			helper.RequireRepoFileNotFound(t, repo, "delete-admin-test.json")
 		})
 	})
 

--- a/pkg/tests/apis/provisioning/files_test.go
+++ b/pkg/tests/apis/provisioning/files_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/tests/apis"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -69,34 +68,10 @@ func TestIntegrationProvisioning_DeleteResources(t *testing.T) {
 		},
 	})
 
-	var dashboards *unstructured.UnstructuredList
-	var folders *unstructured.UnstructuredList
-	var err error
-	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		dashboards, err = helper.DashboardsV1.Resource.List(t.Context(), metav1.ListOptions{})
-		if err != nil {
-			collect.Errorf("could not list dashboards error: %s", err.Error())
-			return
-		}
-		if len(dashboards.Items) != 3 {
-			collect.Errorf("should have the expected dashboards after sync. got: %d. expected: %d", len(dashboards.Items), 2)
-			return
-		}
-		folders, err = helper.Folders.Resource.List(t.Context(), metav1.ListOptions{})
-		if err != nil {
-			collect.Errorf("could not list folders: error: %s", err.Error())
-			return
-		}
-		if len(folders.Items) != 2 {
-			collect.Errorf("should have the expected folders after sync. got: %d. expected: %d", len(folders.Items), 2)
-			return
-		}
+	helper.RequireRepoDashboardCount(t, repo, 3)
+	helper.RequireRepoFolderCount(t, repo, 2)
 
-		assert.Len(collect, dashboards.Items, 3)
-		assert.Len(collect, folders.Items, 2)
-	}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "should have the expected dashboards and folders after sync")
-
-	helper.ValidateManagedDashboardsFolderMetadata(t, repo, dashboards.Items)
+	helper.ValidateManagedDashboardsFolderMetadata(t, repo, helper.ListRepoDashboards(t, repo))
 
 	t.Run("delete individual dashboard file on configured branch should succeed", func(t *testing.T) {
 		result := helper.AdminREST.Delete().
@@ -183,11 +158,7 @@ func TestIntegrationProvisioning_MoveResources(t *testing.T) {
 	helper.RequireRepoFolderCount(t, repo, 0)
 
 	// Validate the dashboard metadata
-	dashboards, err := helper.DashboardsV1.Resource.List(t.Context(), metav1.ListOptions{})
-	require.NoError(t, err)
-	require.Equal(t, 1, len(dashboards.Items))
-
-	helper.ValidateManagedDashboardsFolderMetadata(t, repo, dashboards.Items)
+	helper.ValidateManagedDashboardsFolderMetadata(t, repo, helper.ListRepoDashboards(t, repo))
 
 	// Verify the original dashboard exists in Grafana (using the UID from all-panels.json)
 	const allPanelsUID = "n1jR8vnnz" // This is the UID from the all-panels.json file
@@ -429,40 +400,10 @@ func TestIntegrationProvisioning_FilesOwnershipProtection(t *testing.T) {
 		},
 	})
 
-	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		dashboards, err := helper.DashboardsV1.Resource.List(t.Context(), metav1.ListOptions{})
-		if err != nil {
-			collect.Errorf("could not list dashboards error: %s", err.Error())
-			return
-		}
-		if len(dashboards.Items) != 2 {
-			collect.Errorf("should have the expected dashboards after sync. got: %d. expected: %d", len(dashboards.Items), 2)
-			return
-		}
-		folders, err := helper.Folders.Resource.List(t.Context(), metav1.ListOptions{})
-		if err != nil {
-			collect.Errorf("could not list folders: error: %s", err.Error())
-			return
-		}
-		if len(folders.Items) != 2 {
-			collect.Errorf("should have the expected folders after sync. got: %d. expected: %d", len(folders.Items), 2)
-			return
-		}
-
-		assert.Len(collect, dashboards.Items, 2)
-		assert.Len(collect, folders.Items, 2)
-	}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "should have the expected dashboards and folders after sync")
-
-	allDashboards, err := helper.DashboardsV1.Resource.List(t.Context(), metav1.ListOptions{})
-	require.NoError(t, err)
-	for _, dashboard := range allDashboards.Items {
-		annotations := dashboard.GetAnnotations()
-		// Expect to be managed by repo1 or repo2
-		managerID := annotations["grafana.app/managerId"]
-		if managerID != repo1 && managerID != repo2 {
-			t.Fatalf("dashboard %s is not managed by repo1 or repo2", dashboard.GetName())
-		}
-	}
+	helper.RequireRepoDashboardCount(t, repo1, 1)
+	helper.RequireRepoFolderCount(t, repo1, 1)
+	helper.RequireRepoDashboardCount(t, repo2, 1)
+	helper.RequireRepoFolderCount(t, repo2, 1)
 
 	t.Run("CREATE file with UID already owned by different repository - should fail", func(t *testing.T) {
 		// Try to create a dashboard in repo2 that has the same UID as the one in repo1
@@ -954,21 +895,7 @@ func TestIntegrationProvisioning_FilesAuthorization(t *testing.T) {
 	helper.RequireRepoDashboardCount(t, repo, 1)
 	helper.RequireRepoFolderCount(t, repo, 0)
 
-	// Wait for initial sync to complete
-	var dashboardUID string
-	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		dashboards, err := helper.DashboardsV1.Resource.List(t.Context(), metav1.ListOptions{})
-		if err != nil {
-			collect.Errorf("could not list dashboards error: %s", err.Error())
-			return
-		}
-		if len(dashboards.Items) != 1 {
-			collect.Errorf("should have the expected dashboards after sync. got: %d. expected: %d", len(dashboards.Items), 1)
-			return
-		}
-		assert.Len(collect, dashboards.Items, 1)
-		dashboardUID = dashboards.Items[0].GetName()
-	}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "should have the expected dashboards after sync")
+	dashboardUID := helper.ListRepoDashboards(t, repo)[0].GetName()
 
 	// Grant permissions to Editor user for all dashboards using wildcard
 	// The access checker checks resource-level permissions, so we need to grant them
@@ -1355,18 +1282,7 @@ func TestIntegrationProvisioning_FilesAuthorization(t *testing.T) {
 		require.Equal(t, http.StatusOK, statusCode, "should return 200 OK")
 
 		// Wait for dashboard to be created
-		require.EventuallyWithT(t, func(collect *assert.CollectT) {
-			dashboards, err := helper.DashboardsV1.Resource.List(t.Context(), metav1.ListOptions{})
-			require.NoError(collect, err, "should list dashboards")
-			found := false
-			for _, dash := range dashboards.Items {
-				if dash.GetName() == "security-test-dashboard" {
-					found = true
-					break
-				}
-			}
-			assert.True(collect, found, "security-test-dashboard should exist")
-		}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "dashboard should be created")
+		helper.RequireDashboards(t, "security-test-dashboard")
 
 		// Now try to update the dashboard as Editor, but claim it's in a different folder
 		// The file is at path "security-test.json" (root level, no folder)

--- a/pkg/tests/apis/provisioning/files_test.go
+++ b/pkg/tests/apis/provisioning/files_test.go
@@ -68,10 +68,10 @@ func TestIntegrationProvisioning_DeleteResources(t *testing.T) {
 		},
 	})
 
-	helper.RequireRepoDashboardCount(t, repo, 3)
+	dashboards := helper.RequireRepoDashboardCount(t, repo, 3)
 	helper.RequireRepoFolderCount(t, repo, 2)
 
-	helper.ValidateManagedDashboardsFolderMetadata(t, repo, helper.ListRepoDashboards(t, repo))
+	helper.ValidateManagedDashboardsFolderMetadata(t, repo, dashboards)
 
 	t.Run("delete individual dashboard file on configured branch should succeed", func(t *testing.T) {
 		result := helper.AdminREST.Delete().
@@ -153,11 +153,11 @@ func TestIntegrationProvisioning_MoveResources(t *testing.T) {
 		},
 	})
 
-	helper.RequireRepoDashboardCount(t, repo, 1)
+	movedDashboards := helper.RequireRepoDashboardCount(t, repo, 1)
 	helper.RequireRepoFolderCount(t, repo, 0)
 
 	// Validate the dashboard metadata
-	helper.ValidateManagedDashboardsFolderMetadata(t, repo, helper.ListRepoDashboards(t, repo))
+	helper.ValidateManagedDashboardsFolderMetadata(t, repo, movedDashboards)
 
 	// Verify the original dashboard exists in Grafana (using the UID from all-panels.json)
 	const allPanelsUID = "n1jR8vnnz" // This is the UID from the all-panels.json file

--- a/pkg/tests/apis/provisioning/files_test.go
+++ b/pkg/tests/apis/provisioning/files_test.go
@@ -888,7 +888,7 @@ func TestIntegrationProvisioning_FilesAuthorization(t *testing.T) {
 	helper.RequireRepoDashboardCount(t, repo, 1)
 	helper.RequireRepoFolderCount(t, repo, 0)
 
-	dashboardUID := helper.ListRepoDashboards(t, repo)[0].GetName()
+	dashboardUID := helper.RequireSingleRepoDashboard(t, repo).GetName()
 
 	// Grant permissions to Editor user for all dashboards using wildcard
 	// The access checker checks resource-level permissions, so we need to grant them

--- a/pkg/tests/apis/provisioning/foldermetadata/export_folders_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/export_folders_test.go
@@ -7,55 +7,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 
 	foldersV1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 )
-
-func createUnmanagedFolder(t *testing.T, helper *common.ProvisioningTestHelper, name, title string) {
-	t.Helper()
-	obj := &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"apiVersion": "folder.grafana.app/v1",
-			"kind":       "Folder",
-			"metadata": map[string]interface{}{
-				"name":      name,
-				"namespace": "default",
-			},
-			"spec": map[string]interface{}{
-				"title": title,
-			},
-		},
-	}
-	_, err := helper.Folders.Resource.Create(t.Context(), obj, metav1.CreateOptions{})
-	require.NoError(t, err)
-}
-
-func createUnmanagedFolderWithParent(t *testing.T, helper *common.ProvisioningTestHelper, name, title, parentUID string) {
-	t.Helper()
-	obj := &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"apiVersion": "folder.grafana.app/v1",
-			"kind":       "Folder",
-			"metadata": map[string]interface{}{
-				"name":      name,
-				"namespace": "default",
-				"annotations": map[string]interface{}{
-					"grafana.app/folder": parentUID,
-				},
-			},
-			"spec": map[string]interface{}{
-				"title": title,
-			},
-		},
-	}
-	_, err := helper.Folders.Resource.Create(t.Context(), obj, metav1.CreateOptions{})
-	require.NoError(t, err)
-}
 
 func triggerExport(t *testing.T, helper *common.ProvisioningTestHelper, repo string) *provisioning.Job {
 	t.Helper()
@@ -87,7 +44,7 @@ func TestIntegrationProvisioning_ExportJob_FolderMetadataFlag(t *testing.T) {
 			folderUID   = "export-meta-folder-uid"
 			folderTitle = "export-meta-folder"
 		)
-		createUnmanagedFolder(t, helper, folderUID, folderTitle)
+		helper.CreateUnmanagedFolderWithName(t, folderUID, folderTitle, "")
 
 		job := triggerExport(t, helper, repo)
 		require.Equal(t, provisioning.JobStateSuccess, job.Status.State, "export job should succeed")
@@ -122,7 +79,7 @@ func TestIntegrationProvisioning_ExportJob_FolderMetadataFlag(t *testing.T) {
 		err := os.MkdirAll(filepath.Join(helper.ProvisioningPath, folderTitle), 0o750)
 		require.NoError(t, err, "should be able to pre-create folder directory")
 
-		createUnmanagedFolder(t, helper, "existing-folder-uid", folderTitle)
+		helper.CreateUnmanagedFolderWithName(t, "existing-folder-uid", folderTitle, "")
 
 		job := triggerExport(t, helper, repo)
 		require.Equal(t, provisioning.JobStateSuccess, job.Status.State, "export job should succeed")
@@ -174,9 +131,9 @@ func TestIntegrationProvisioning_ExportJob_NestedFolders(t *testing.T) {
 		err := os.MkdirAll(filepath.Join(helper.ProvisioningPath, grandparentTitle, middleTitle), 0o750)
 		require.NoError(t, err, "should be able to pre-create grandparent and middle folder directories")
 
-		createUnmanagedFolder(t, helper, grandparentUID, grandparentTitle)
-		createUnmanagedFolderWithParent(t, helper, middleUID, middleTitle, grandparentUID)
-		createUnmanagedFolderWithParent(t, helper, childUID, childTitle, middleUID)
+		helper.CreateUnmanagedFolderWithName(t, grandparentUID, grandparentTitle, "")
+		helper.CreateUnmanagedFolderWithName(t, middleUID, middleTitle, grandparentUID)
+		helper.CreateUnmanagedFolderWithName(t, childUID, childTitle, middleUID)
 
 		job := triggerExport(t, helper, repo)
 		require.Equal(t, provisioning.JobStateSuccess, job.Status.State, "export job should succeed")
@@ -217,8 +174,8 @@ func TestIntegrationProvisioning_ExportJob_NestedFolders(t *testing.T) {
 			childUID    = "two-level-child-uid"
 			childTitle  = "two-level-child"
 		)
-		createUnmanagedFolder(t, helper, parentUID, parentTitle)
-		createUnmanagedFolderWithParent(t, helper, childUID, childTitle, parentUID)
+		helper.CreateUnmanagedFolderWithName(t, parentUID, parentTitle, "")
+		helper.CreateUnmanagedFolderWithName(t, childUID, childTitle, parentUID)
 
 		job := triggerExport(t, helper, repo)
 		require.Equal(t, provisioning.JobStateSuccess, job.Status.State, "export job should succeed")
@@ -256,9 +213,9 @@ func TestIntegrationProvisioning_ExportJob_NestedFolders(t *testing.T) {
 			childUID         = "three-level-child-uid"
 			childTitle       = "three-level-child"
 		)
-		createUnmanagedFolder(t, helper, grandparentUID, grandparentTitle)
-		createUnmanagedFolderWithParent(t, helper, parentUID, parentTitle, grandparentUID)
-		createUnmanagedFolderWithParent(t, helper, childUID, childTitle, parentUID)
+		helper.CreateUnmanagedFolderWithName(t, grandparentUID, grandparentTitle, "")
+		helper.CreateUnmanagedFolderWithName(t, parentUID, parentTitle, grandparentUID)
+		helper.CreateUnmanagedFolderWithName(t, childUID, childTitle, parentUID)
 
 		job := triggerExport(t, helper, repo)
 		require.Equal(t, provisioning.JobStateSuccess, job.Status.State, "export job should succeed")
@@ -302,9 +259,9 @@ func TestIntegrationProvisioning_ExportJob_NestedFolders(t *testing.T) {
 			siblingBUID   = "sibling-b-uid"
 			siblingBTitle = "sibling-b"
 		)
-		createUnmanagedFolder(t, helper, parentUID, parentTitle)
-		createUnmanagedFolderWithParent(t, helper, siblingAUID, siblingATitle, parentUID)
-		createUnmanagedFolderWithParent(t, helper, siblingBUID, siblingBTitle, parentUID)
+		helper.CreateUnmanagedFolderWithName(t, parentUID, parentTitle, "")
+		helper.CreateUnmanagedFolderWithName(t, siblingAUID, siblingATitle, parentUID)
+		helper.CreateUnmanagedFolderWithName(t, siblingBUID, siblingBTitle, parentUID)
 
 		job := triggerExport(t, helper, repo)
 		require.Equal(t, provisioning.JobStateSuccess, job.Status.State, "export job should succeed")
@@ -361,8 +318,8 @@ func TestIntegrationProvisioning_ExportJob_GenerateNewFolderIDs(t *testing.T) {
 			Workflows:  []string{"write"},
 			SkipSync:   true,
 		})
-		createUnmanagedFolder(t, helper, parentUID, parentTitle)
-		createUnmanagedFolderWithParent(t, helper, childUID, childTitle, parentUID)
+		helper.CreateUnmanagedFolderWithName(t, parentUID, parentTitle, "")
+		helper.CreateUnmanagedFolderWithName(t, childUID, childTitle, parentUID)
 		return helper
 	}
 
@@ -452,9 +409,9 @@ func TestIntegrationProvisioning_ExportJob_SelectiveGeneratesFolderMetadata(t *t
 		unrelatedUID   = "selective-meta-unrelated-uid"
 		unrelatedTitle = "selective-meta-unrelated"
 	)
-	createUnmanagedFolder(t, helper, parentUID, parentTitle)
-	createUnmanagedFolderWithParent(t, helper, childUID, childTitle, parentUID)
-	createUnmanagedFolder(t, helper, unrelatedUID, unrelatedTitle)
+	helper.CreateUnmanagedFolderWithName(t, parentUID, parentTitle, "")
+	helper.CreateUnmanagedFolderWithName(t, childUID, childTitle, parentUID)
+	helper.CreateUnmanagedFolderWithName(t, unrelatedUID, unrelatedTitle, "")
 
 	// The dashboard lives in the child folder; only it is named in the export.
 	selectedDash := helper.CreateUnmanagedDashboard(t, "selective-meta-dash", childUID)

--- a/pkg/tests/apis/provisioning/foldermetadata/export_git_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/export_git_test.go
@@ -24,7 +24,7 @@ func TestIntegrationProvisioning_ExportJob_GitRepo_FolderMetadataEnabled(t *test
 	)
 	helper.CreateExportGitRepo(t, repoName, nil)
 
-	createUnmanagedFolder(t, helper.ProvisioningTestHelper, folderUID, folderTitle)
+	helper.CreateUnmanagedFolderWithName(t, folderUID, folderTitle, "")
 
 	job := triggerExport(t, helper.ProvisioningTestHelper, repoName)
 	require.Equal(t, provisioning.JobStateSuccess, job.Status.State, "export job should succeed")

--- a/pkg/tests/apis/provisioning/foldermetadata/folder_authorization_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/folder_authorization_test.go
@@ -60,7 +60,7 @@ func TestIntegrationProvisioning_CrossFolderWriteDeniedWithoutDestinationAccess(
 		"/api/folders/inner-a-uid/permissions",
 		map[string]interface{}{
 			"items": []map[string]interface{}{
-				{"userId": viewerUserID, "permission": 2},
+				{"userId": viewerUserID, "permission": common.FolderPermissionEdit},
 			},
 		},
 		helper.Org1.Admin,

--- a/pkg/tests/apis/provisioning/foldermetadata/folder_permissions_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/folder_permissions_test.go
@@ -19,8 +19,7 @@ func TestIntegrationFolderPermissions_ProvisionedFolders_WithFlag(t *testing.T) 
 		},
 	})
 	t.Run("should succeed updating permissions for provisioned nested folder when flag is enabled", func(t *testing.T) {
-		helper.RequireRepoFolderCount(t, repoName, 3) // root, folder, subfolder
-		provisionedFolders := helper.ListRepoFolders(t, repoName)
+		provisionedFolders := helper.RequireRepoFolderCount(t, repoName, 3) // root, folder, subfolder
 
 		// Test that permission updates succeed for all provisioned folders when the flag is enabled
 		for _, folder := range provisionedFolders {

--- a/pkg/tests/apis/provisioning/foldermetadata/folder_permissions_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/folder_permissions_test.go
@@ -6,10 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 )
 
@@ -26,21 +23,8 @@ func TestIntegrationFolderPermissions_ProvisionedFolders_WithFlag(t *testing.T) 
 		},
 	})
 	t.Run("should succeed updating permissions for provisioned nested folder when flag is enabled", func(t *testing.T) {
-		folders, err := helper.Folders.Resource.List(t.Context(), metav1.ListOptions{})
-		require.NoError(t, err)
 		helper.RequireRepoFolderCount(t, repoName, 3) // root, folder, subfolder
-
-		// Find all folders managed by provisioning
-		var provisionedFolders []*unstructured.Unstructured
-		for i := range folders.Items {
-			annotations := folders.Items[i].GetAnnotations()
-			if _, hasManagerKind := annotations[utils.AnnoKeyManagerKind]; hasManagerKind {
-				if _, hasManagerIdentity := annotations[utils.AnnoKeyManagerIdentity]; hasManagerIdentity {
-					provisionedFolders = append(provisionedFolders, &folders.Items[i])
-				}
-			}
-		}
-		require.Greater(t, len(provisionedFolders), 0, "should have at least one provisioned folder")
+		provisionedFolders := helper.ListRepoFolders(t, repoName)
 
 		permissionsPayload := map[string]interface{}{
 			"items": []map[string]interface{}{

--- a/pkg/tests/apis/provisioning/foldermetadata/folder_permissions_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/folder_permissions_test.go
@@ -1,11 +1,7 @@
 package foldermetadata
 
 import (
-	"fmt"
-	"net/http"
 	"testing"
-
-	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 )
@@ -26,23 +22,9 @@ func TestIntegrationFolderPermissions_ProvisionedFolders_WithFlag(t *testing.T) 
 		helper.RequireRepoFolderCount(t, repoName, 3) // root, folder, subfolder
 		provisionedFolders := helper.ListRepoFolders(t, repoName)
 
-		permissionsPayload := map[string]interface{}{
-			"items": []map[string]interface{}{
-				{
-					"role":       "Viewer",
-					"permission": 1, // View permission
-				},
-			},
-		}
-
 		// Test that permission updates succeed for all provisioned folders when the flag is enabled
 		for _, folder := range provisionedFolders {
-			folderName := folder.GetName()
-			permissionsURL := fmt.Sprintf("/api/folders/%s/permissions", folderName)
-			permissionsData, code, err := common.PostHelper(t, *helper.K8sTestHelper, permissionsURL, permissionsPayload, helper.Org1.Admin)
-			require.NoError(t, err, "should succeed updating permissions for folder %s", folderName)
-			require.Equal(t, http.StatusOK, code, "should return OK status for folder %s", folderName)
-			require.NotNil(t, permissionsData, "should have response data for folder %s", folderName)
+			common.SetFolderPermissions(t, helper, folder.GetName(), common.RolePermission{Role: "Viewer", Permission: common.FolderPermissionView})
 		}
 	})
 }

--- a/pkg/tests/apis/provisioning/foldermetadata/folder_title_normalization_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/folder_title_normalization_test.go
@@ -75,10 +75,10 @@ func TestIntegrationProvisioning_MigrateFolderTitleNormalization(t *testing.T) {
 		deltaTitle = "🚀🎉"
 	)
 
-	createUnmanagedFolder(t, helper, alphaUID, alphaTitle)
-	createUnmanagedFolderWithParent(t, helper, betaUID, betaTitle, alphaUID)
-	createUnmanagedFolderWithParent(t, helper, gammaUID, gammaTitle, betaUID)
-	createUnmanagedFolderWithParent(t, helper, deltaUID, deltaTitle, gammaUID)
+	helper.CreateUnmanagedFolderWithName(t, alphaUID, alphaTitle, "")
+	helper.CreateUnmanagedFolderWithName(t, betaUID, betaTitle, alphaUID)
+	helper.CreateUnmanagedFolderWithName(t, gammaUID, gammaTitle, betaUID)
+	helper.CreateUnmanagedFolderWithName(t, deltaUID, deltaTitle, gammaUID)
 	dashName := helper.CreateUnmanagedDashboard(t, "Sample Dashboard", deltaUID)
 
 	const repo = "folder-title-normalization-repo"
@@ -282,8 +282,8 @@ func TestIntegrationProvisioning_PullFoldersWithSpaces(t *testing.T) {
 func TestIntegrationProvisioning_MigrateFolderTitleCollisionFails(t *testing.T) {
 	helper := sharedHelper(t)
 
-	createUnmanagedFolder(t, helper, "collision-a", "» Reports")
-	createUnmanagedFolder(t, helper, "collision-b", "Reports")
+	helper.CreateUnmanagedFolderWithName(t, "collision-a", "» Reports", "")
+	helper.CreateUnmanagedFolderWithName(t, "collision-b", "Reports", "")
 
 	const repo = "folder-title-collision-repo"
 	helper.CreateLocalRepo(t, common.TestRepo{

--- a/pkg/tests/apis/provisioning/foldermetadata/full/export_folders_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/full/export_folders_test.go
@@ -6,31 +6,11 @@ import (
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 )
-
-func createUnmanagedFolder(t *testing.T, helper *common.GitTestHelper, name, title string) {
-	t.Helper()
-	obj := &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"apiVersion": "folder.grafana.app/v1",
-			"kind":       "Folder",
-			"metadata": map[string]interface{}{
-				"name":      name,
-				"namespace": "default",
-			},
-			"spec": map[string]interface{}{
-				"title": title,
-			},
-		},
-	}
-	_, err := helper.Folders.Resource.Create(t.Context(), obj, metav1.CreateOptions{})
-	require.NoError(t, err)
-}
 
 func triggerExport(t *testing.T, helper *common.GitTestHelper, repo string) *provisioning.Job {
 	t.Helper()
@@ -53,7 +33,7 @@ func TestIntegrationProvisioning_ExportJob_GitRepo_FolderMetadataDisabled(t *tes
 	const repoName = "git-export-no-meta"
 	helper.CreateExportGitRepo(t, repoName, nil)
 
-	createUnmanagedFolder(t, helper, "git-no-meta-uid", "git-no-meta-folder")
+	helper.CreateUnmanagedFolderWithName(t, "git-no-meta-uid", "git-no-meta-folder", "")
 
 	job := triggerExport(t, helper, repoName)
 	require.Equal(t, provisioning.JobStateSuccess, job.Status.State, "export job should succeed")

--- a/pkg/tests/apis/provisioning/foldermetadata/full_permissions_move_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/full_permissions_move_test.go
@@ -1,9 +1,6 @@
 package foldermetadata
 
 import (
-	"encoding/json"
-	"fmt"
-	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -32,44 +29,26 @@ func TestIntegrationProvisioning_FullSync_FolderMovePreservesPermissions(t *test
 	common.RequireFolderState(t, helper.Folders, "team-a-uid", "Team A", "teamA", repo)
 	common.RequireFolderState(t, helper.Folders, "team-b-uid", "Team B", "teamB", repo)
 
-	addr := helper.GetEnv().Server.HTTPServer.Listener.Addr().String()
-
 	// Set a known ACL on teamA (check 4) so we can assert it is not touched when
 	// a child folder is moved into it.
-	_, code, err := common.PostHelper(t, *helper.K8sTestHelper,
-		"/api/folders/team-a-uid/permissions",
-		map[string]interface{}{
-			"items": []map[string]interface{}{
-				{"role": "Admin", "permission": 4},
-			},
-		},
-		helper.Org1.Admin)
-	require.NoError(t, err, "setting permissions on teamA folder should succeed")
-	require.Equal(t, http.StatusOK, code)
+	common.SetFolderPermissions(t, helper, "team-a-uid", common.RolePermission{Role: "Admin", Permission: common.FolderPermissionAdmin})
 
 	// Set multiple role-based ACL entries on teamB (check 3):
 	// Viewer → View (1) and Editor → Edit (2).
-	_, code, err = common.PostHelper(t, *helper.K8sTestHelper,
-		"/api/folders/team-b-uid/permissions",
-		map[string]interface{}{
-			"items": []map[string]interface{}{
-				{"role": "Viewer", "permission": 1},
-				{"role": "Editor", "permission": 2},
-			},
-		},
-		helper.Org1.Admin)
-	require.NoError(t, err, "setting permissions on teamB folder should succeed")
-	require.Equal(t, http.StatusOK, code)
+	common.SetFolderPermissions(t, helper, "team-b-uid",
+		common.RolePermission{Role: "Viewer", Permission: common.FolderPermissionView},
+		common.RolePermission{Role: "Editor", Permission: common.FolderPermissionEdit},
+	)
 
 	// Snapshot permissions before the move and verify the expected entries are present.
 	// The GET endpoint returns only explicitly-managed ACL entries, so this also
 	// confirms the POSTs were actually persisted and are readable via the API.
-	teamAPermsBefore := snapshotFolderPermissions(t, addr, "team-a-uid")
-	requirePermissionsContainRole(t, teamAPermsBefore, "Admin", 4)
+	teamAPermsBefore := common.FolderPermissions(t, helper, "team-a-uid")
+	common.RequirePermissionContainsRole(t, teamAPermsBefore, "Admin", common.FolderPermissionAdmin)
 
-	teamBPermsBefore := snapshotFolderPermissions(t, addr, "team-b-uid")
-	requirePermissionsContainRole(t, teamBPermsBefore, "Viewer", 1)
-	requirePermissionsContainRole(t, teamBPermsBefore, "Editor", 2)
+	teamBPermsBefore := common.FolderPermissions(t, helper, "team-b-uid")
+	common.RequirePermissionContainsRole(t, teamBPermsBefore, "Viewer", common.FolderPermissionView)
+	common.RequirePermissionContainsRole(t, teamBPermsBefore, "Editor", common.FolderPermissionEdit)
 
 	// Move teamB inside teamA and trigger a sync.
 	moveInProvisioningPath(t, helper, "teamB", "teamA/teamB")
@@ -78,7 +57,7 @@ func TestIntegrationProvisioning_FullSync_FolderMovePreservesPermissions(t *test
 	// teamB should now live under teamA with the same stable UID.
 	common.RequireFolderState(t, helper.Folders, "team-b-uid", "Team B", "teamA/teamB", "team-a-uid")
 
-	teamBPermsAfter := snapshotFolderPermissions(t, addr, "team-b-uid")
+	teamBPermsAfter := common.FolderPermissions(t, helper, "team-b-uid")
 
 	// Check 1: The ACL entry count must not change after the move.
 	require.Equal(t, len(teamBPermsBefore), len(teamBPermsAfter),
@@ -86,18 +65,18 @@ func TestIntegrationProvisioning_FullSync_FolderMovePreservesPermissions(t *test
 
 	// Check 2 & 3: The full (role → permission) map must be identical before and after.
 	// This verifies all entries (Viewer and Editor) survive the move.
-	requireRolePermissionSetEqual(t, teamBPermsBefore, teamBPermsAfter)
-	requirePermissionsContainRole(t, teamBPermsAfter, "Viewer", 1)
-	requirePermissionsContainRole(t, teamBPermsAfter, "Editor", 2)
+	common.RequireRolePermissionSetEqual(t, teamBPermsBefore, teamBPermsAfter)
+	common.RequirePermissionContainsRole(t, teamBPermsAfter, "Viewer", common.FolderPermissionView)
+	common.RequirePermissionContainsRole(t, teamBPermsAfter, "Editor", common.FolderPermissionEdit)
 
 	// Check 4: teamA's own ACL must be unaffected by moving a child into it.
-	teamAPermsAfter := snapshotFolderPermissions(t, addr, "team-a-uid")
-	requireRolePermissionSetEqual(t, teamAPermsBefore, teamAPermsAfter)
+	teamAPermsAfter := common.FolderPermissions(t, helper, "team-a-uid")
+	common.RequireRolePermissionSetEqual(t, teamAPermsBefore, teamAPermsAfter)
 
 	// Check 5: The moved folder must still be effectively accessible to a user
 	// carrying the granted role. The Viewer org role was granted explicit view access
 	// on teamB; after the move a request authenticated as that user must still get 200.
-	requireFolderAccessible(t, addr, "team-b-uid", "viewer", "viewer")
+	common.RequireFolderAccessible(t, helper, "team-b-uid", "viewer", "viewer")
 }
 
 // TestIntegrationProvisioning_FullSync_FolderMoveDoesNotPreservePermissionsForLegacyFolder
@@ -125,23 +104,12 @@ func TestIntegrationProvisioning_FullSync_FolderMoveDoesNotPreservePermissionsFo
 	plainUID := findFolderUIDBySourcePath(t, helper, repo, "plain")
 	require.NotEmpty(t, plainUID)
 
-	addr := helper.GetEnv().Server.HTTPServer.Listener.Addr().String()
-
 	// Set a Viewer permission on the legacy (no-metadata) folder.
 	// With the FlagProvisioningFolderMetadata feature enabled, this is allowed.
-	_, code, err := common.PostHelper(t, *helper.K8sTestHelper,
-		fmt.Sprintf("/api/folders/%s/permissions", plainUID),
-		map[string]interface{}{
-			"items": []map[string]interface{}{
-				{"role": "Viewer", "permission": 1},
-			},
-		},
-		helper.Org1.Admin)
-	require.NoError(t, err, "setting permissions on plain folder should succeed")
-	require.Equal(t, http.StatusOK, code)
+	common.SetFolderPermissions(t, helper, plainUID, common.RolePermission{Role: "Viewer", Permission: common.FolderPermissionView})
 
-	plainPermsBefore := snapshotFolderPermissions(t, addr, plainUID)
-	requirePermissionsContainRole(t, plainPermsBefore, "Viewer", 1)
+	plainPermsBefore := common.FolderPermissions(t, helper, plainUID)
+	common.RequirePermissionContainsRole(t, plainPermsBefore, "Viewer", common.FolderPermissionView)
 
 	// Move the legacy folder under the parent and sync.
 	moveInProvisioningPath(t, helper, "plain", "parent/plain")
@@ -159,7 +127,7 @@ func TestIntegrationProvisioning_FullSync_FolderMoveDoesNotPreservePermissionsFo
 
 	// The new folder must NOT carry the Viewer permission from the old object.
 	// It is a brand-new resource; the old ACL entries do not transfer.
-	newPlainPerms := snapshotFolderPermissions(t, addr, newPlainUID)
+	newPlainPerms := common.FolderPermissions(t, helper, newPlainUID)
 	for _, p := range newPlainPerms {
 		entry, ok := p.(map[string]interface{})
 		if !ok {
@@ -197,22 +165,11 @@ func TestIntegrationProvisioning_FullSync_NestedFolderMovePreservesPermissions(t
 	common.RequireFolderState(t, helper.Folders, "child-uid", "Child", "root/child", "root-uid")
 	common.RequireFolderState(t, helper.Folders, "grandchild-uid", "Grandchild", "root/child/grandchild", "child-uid")
 
-	addr := helper.GetEnv().Server.HTTPServer.Listener.Addr().String()
-
 	// Grant Editor permission on the deepest (grandchild) folder.
-	_, code, err := common.PostHelper(t, *helper.K8sTestHelper,
-		"/api/folders/grandchild-uid/permissions",
-		map[string]interface{}{
-			"items": []map[string]interface{}{
-				{"role": "Editor", "permission": 2},
-			},
-		},
-		helper.Org1.Admin)
-	require.NoError(t, err, "setting permissions on grandchild folder should succeed")
-	require.Equal(t, http.StatusOK, code)
+	common.SetFolderPermissions(t, helper, "grandchild-uid", common.RolePermission{Role: "Editor", Permission: common.FolderPermissionEdit})
 
-	grandchildPermsBefore := snapshotFolderPermissions(t, addr, "grandchild-uid")
-	requirePermissionsContainRole(t, grandchildPermsBefore, "Editor", 2)
+	grandchildPermsBefore := common.FolderPermissions(t, helper, "grandchild-uid")
+	common.RequirePermissionContainsRole(t, grandchildPermsBefore, "Editor", common.FolderPermissionEdit)
 
 	// Move the child subtree (carrying grandchild with it) under destination.
 	moveInProvisioningPath(t, helper, "root/child", "destination/child")
@@ -223,11 +180,11 @@ func TestIntegrationProvisioning_FullSync_NestedFolderMovePreservesPermissions(t
 	common.RequireFolderState(t, helper.Folders, "child-uid", "Child", "destination/child", destUID)
 	common.RequireFolderState(t, helper.Folders, "grandchild-uid", "Grandchild", "destination/child/grandchild", "child-uid")
 
-	grandchildPermsAfter := snapshotFolderPermissions(t, addr, "grandchild-uid")
+	grandchildPermsAfter := common.FolderPermissions(t, helper, "grandchild-uid")
 	require.Equal(t, len(grandchildPermsBefore), len(grandchildPermsAfter),
 		"ACL entry count must not change after nested folder move")
-	requireRolePermissionSetEqual(t, grandchildPermsBefore, grandchildPermsAfter)
-	requirePermissionsContainRole(t, grandchildPermsAfter, "Editor", 2)
+	common.RequireRolePermissionSetEqual(t, grandchildPermsBefore, grandchildPermsAfter)
+	common.RequirePermissionContainsRole(t, grandchildPermsAfter, "Editor", common.FolderPermissionEdit)
 }
 
 // TestIntegrationProvisioning_FullSync_RootToLeafMovePreservesPermissions verifies that
@@ -252,22 +209,11 @@ func TestIntegrationProvisioning_FullSync_RootToLeafMovePreservesPermissions(t *
 	common.RequireFolderState(t, helper.Folders, "container-uid", "Container", "container", repo)
 	common.RequireFolderState(t, helper.Folders, "inner-uid", "Inner", "container/inner", "container-uid")
 
-	addr := helper.GetEnv().Server.HTTPServer.Listener.Addr().String()
-
 	// Grant Viewer permission on the root-level "top" folder before the move.
-	_, code, err := common.PostHelper(t, *helper.K8sTestHelper,
-		"/api/folders/top-uid/permissions",
-		map[string]interface{}{
-			"items": []map[string]interface{}{
-				{"role": "Viewer", "permission": 1},
-			},
-		},
-		helper.Org1.Admin)
-	require.NoError(t, err, "setting permissions on top folder should succeed")
-	require.Equal(t, http.StatusOK, code)
+	common.SetFolderPermissions(t, helper, "top-uid", common.RolePermission{Role: "Viewer", Permission: common.FolderPermissionView})
 
-	topPermsBefore := snapshotFolderPermissions(t, addr, "top-uid")
-	requirePermissionsContainRole(t, topPermsBefore, "Viewer", 1)
+	topPermsBefore := common.FolderPermissions(t, helper, "top-uid")
+	common.RequirePermissionContainsRole(t, topPermsBefore, "Viewer", common.FolderPermissionView)
 
 	// Move "top" under container/inner, making it a leaf three levels deep.
 	moveInProvisioningPath(t, helper, "top", "container/inner/top")
@@ -275,12 +221,12 @@ func TestIntegrationProvisioning_FullSync_RootToLeafMovePreservesPermissions(t *
 
 	common.RequireFolderState(t, helper.Folders, "top-uid", "Top", "container/inner/top", "inner-uid")
 
-	topPermsAfter := snapshotFolderPermissions(t, addr, "top-uid")
+	topPermsAfter := common.FolderPermissions(t, helper, "top-uid")
 	require.Equal(t, len(topPermsBefore), len(topPermsAfter),
 		"ACL entry count must not change when moving a root folder to a leaf position")
-	requireRolePermissionSetEqual(t, topPermsBefore, topPermsAfter)
-	requirePermissionsContainRole(t, topPermsAfter, "Viewer", 1)
-	requireFolderAccessible(t, addr, "top-uid", "viewer", "viewer")
+	common.RequireRolePermissionSetEqual(t, topPermsBefore, topPermsAfter)
+	common.RequirePermissionContainsRole(t, topPermsAfter, "Viewer", common.FolderPermissionView)
+	common.RequireFolderAccessible(t, helper, "top-uid", "viewer", "viewer")
 }
 
 // TestIntegrationProvisioning_FullSync_LeafToRootMovePreservesPermissions verifies that
@@ -305,22 +251,11 @@ func TestIntegrationProvisioning_FullSync_LeafToRootMovePreservesPermissions(t *
 	common.RequireFolderState(t, helper.Folders, "deep-uid", "Deep", "parent/deep", "parent-uid")
 	common.RequireFolderState(t, helper.Folders, "leaf-uid", "Leaf", "parent/deep/leaf", "deep-uid")
 
-	addr := helper.GetEnv().Server.HTTPServer.Listener.Addr().String()
-
 	// Grant Editor permission on the deeply nested leaf folder.
-	_, code, err := common.PostHelper(t, *helper.K8sTestHelper,
-		"/api/folders/leaf-uid/permissions",
-		map[string]interface{}{
-			"items": []map[string]interface{}{
-				{"role": "Editor", "permission": 2},
-			},
-		},
-		helper.Org1.Admin)
-	require.NoError(t, err, "setting permissions on leaf folder should succeed")
-	require.Equal(t, http.StatusOK, code)
+	common.SetFolderPermissions(t, helper, "leaf-uid", common.RolePermission{Role: "Editor", Permission: common.FolderPermissionEdit})
 
-	leafPermsBefore := snapshotFolderPermissions(t, addr, "leaf-uid")
-	requirePermissionsContainRole(t, leafPermsBefore, "Editor", 2)
+	leafPermsBefore := common.FolderPermissions(t, helper, "leaf-uid")
+	common.RequirePermissionContainsRole(t, leafPermsBefore, "Editor", common.FolderPermissionEdit)
 
 	// Promote the leaf to the repository root level.
 	moveInProvisioningPath(t, helper, "parent/deep/leaf", "leaf")
@@ -328,11 +263,11 @@ func TestIntegrationProvisioning_FullSync_LeafToRootMovePreservesPermissions(t *
 
 	common.RequireFolderState(t, helper.Folders, "leaf-uid", "Leaf", "leaf", repo)
 
-	leafPermsAfter := snapshotFolderPermissions(t, addr, "leaf-uid")
+	leafPermsAfter := common.FolderPermissions(t, helper, "leaf-uid")
 	require.Equal(t, len(leafPermsBefore), len(leafPermsAfter),
 		"ACL entry count must not change when a leaf folder is promoted to root")
-	requireRolePermissionSetEqual(t, leafPermsBefore, leafPermsAfter)
-	requirePermissionsContainRole(t, leafPermsAfter, "Editor", 2)
+	common.RequireRolePermissionSetEqual(t, leafPermsBefore, leafPermsAfter)
+	common.RequirePermissionContainsRole(t, leafPermsAfter, "Editor", common.FolderPermissionEdit)
 }
 
 // TestIntegrationProvisioning_FullSync_MetadataFolderMovedUnderLegacyPreservesPermissions
@@ -359,22 +294,11 @@ func TestIntegrationProvisioning_FullSync_MetadataFolderMovedUnderLegacyPreserve
 	legacyParentUID := findFolderUIDBySourcePath(t, helper, repo, "legacy-parent")
 	require.NotEmpty(t, legacyParentUID)
 
-	addr := helper.GetEnv().Server.HTTPServer.Listener.Addr().String()
-
 	// Set Viewer permission on the metadata-backed child folder.
-	_, code, err := common.PostHelper(t, *helper.K8sTestHelper,
-		"/api/folders/child-meta-uid/permissions",
-		map[string]interface{}{
-			"items": []map[string]interface{}{
-				{"role": "Viewer", "permission": 1},
-			},
-		},
-		helper.Org1.Admin)
-	require.NoError(t, err, "setting permissions on child-with-meta folder should succeed")
-	require.Equal(t, http.StatusOK, code)
+	common.SetFolderPermissions(t, helper, "child-meta-uid", common.RolePermission{Role: "Viewer", Permission: common.FolderPermissionView})
 
-	childPermsBefore := snapshotFolderPermissions(t, addr, "child-meta-uid")
-	requirePermissionsContainRole(t, childPermsBefore, "Viewer", 1)
+	childPermsBefore := common.FolderPermissions(t, helper, "child-meta-uid")
+	common.RequirePermissionContainsRole(t, childPermsBefore, "Viewer", common.FolderPermissionView)
 
 	// Move the metadata child under the legacy (no _folder.json) parent.
 	// The legacy parent's path does not change so its UID remains stable.
@@ -387,84 +311,10 @@ func TestIntegrationProvisioning_FullSync_MetadataFolderMovedUnderLegacyPreserve
 	// The metadata child retains its stable UID and is now under the legacy parent.
 	common.RequireFolderState(t, helper.Folders, "child-meta-uid", "Child With Meta", "legacy-parent/child-with-meta", legacyParentUID)
 
-	childPermsAfter := snapshotFolderPermissions(t, addr, "child-meta-uid")
+	childPermsAfter := common.FolderPermissions(t, helper, "child-meta-uid")
 	require.Equal(t, len(childPermsBefore), len(childPermsAfter),
 		"ACL entry count must not change when metadata folder is moved under a legacy parent")
-	requireRolePermissionSetEqual(t, childPermsBefore, childPermsAfter)
-	requirePermissionsContainRole(t, childPermsAfter, "Viewer", 1)
-	requireFolderAccessible(t, addr, "child-meta-uid", "viewer", "viewer")
-}
-
-// snapshotFolderPermissions performs a single GET to /api/folders/{uid}/permissions
-// and returns the raw decoded JSON array. The test fails immediately if the request
-// itself errors out, but an empty array is a valid (non-error) response.
-func snapshotFolderPermissions(t *testing.T, addr, folderUID string) []interface{} {
-	t.Helper()
-	u := fmt.Sprintf("http://admin:admin@%s/api/folders/%s/permissions", addr, folderUID)
-	resp, err := http.Get(u) //nolint:gosec
-	require.NoError(t, err, "GET folder permissions for %q", folderUID)
-	defer resp.Body.Close() //nolint:errcheck
-	require.Equal(t, http.StatusOK, resp.StatusCode, "unexpected status from permissions endpoint for %q", folderUID)
-	var perms []interface{}
-	require.NoError(t, json.NewDecoder(resp.Body).Decode(&perms), "decode permissions response for %q", folderUID)
-	return perms
-}
-
-// requirePermissionsContainRole asserts that perms contains at least one entry
-// matching the given built-in role and numeric permission level.
-// JSON numbers are decoded as float64, so the comparison is done via float64.
-func requirePermissionsContainRole(t *testing.T, perms []interface{}, expectedRole string, expectedPermission int) {
-	t.Helper()
-	for _, p := range perms {
-		entry, ok := p.(map[string]interface{})
-		if !ok {
-			continue
-		}
-		role, _ := entry["role"].(string)
-		// JSON numbers unmarshal as float64.
-		level, _ := entry["permission"].(float64)
-		if role == expectedRole && int(level) == expectedPermission {
-			return
-		}
-	}
-	require.Failf(t, "permission not found",
-		"expected role=%q permission=%d in ACL entries; got: %v", expectedRole, expectedPermission, perms)
-}
-
-// requireRolePermissionSetEqual asserts that the set of (role → permission) mappings
-// is identical between want and got. Entry ordering and non-role fields (which may
-// legitimately change after a move, such as internal parent-folder references) are ignored.
-func requireRolePermissionSetEqual(t *testing.T, want, got []interface{}) {
-	t.Helper()
-	extractRoleMap := func(perms []interface{}) map[string]int {
-		m := make(map[string]int)
-		for _, p := range perms {
-			entry, ok := p.(map[string]interface{})
-			if !ok {
-				continue
-			}
-			role, _ := entry["role"].(string)
-			if role == "" {
-				continue
-			}
-			level, _ := entry["permission"].(float64)
-			m[role] = int(level)
-		}
-		return m
-	}
-	require.Equal(t, extractRoleMap(want), extractRoleMap(got),
-		"role→permission map must be identical before and after the move")
-}
-
-// requireFolderAccessible asserts that GET /api/folders/{folderUID} returns HTTP 200
-// when performed with the supplied Basic Auth credentials. This exercises real
-// authorization logic, not just the stored ACL data.
-func requireFolderAccessible(t *testing.T, addr, folderUID, login, password string) {
-	t.Helper()
-	u := fmt.Sprintf("http://%s:%s@%s/api/folders/%s", login, password, addr, folderUID)
-	resp, err := http.Get(u) //nolint:gosec
-	require.NoError(t, err, "GET folder %q as user %q", folderUID, login)
-	defer resp.Body.Close() //nolint:errcheck
-	require.Equal(t, http.StatusOK, resp.StatusCode,
-		"folder %q should be accessible to %q after the move", folderUID, login)
+	common.RequireRolePermissionSetEqual(t, childPermsBefore, childPermsAfter)
+	common.RequirePermissionContainsRole(t, childPermsAfter, "Viewer", common.FolderPermissionView)
+	common.RequireFolderAccessible(t, helper, "child-meta-uid", "viewer", "viewer")
 }

--- a/pkg/tests/apis/provisioning/foldermetadata/incremental/incremental_folder_metadata_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/incremental/incremental_folder_metadata_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -429,11 +428,9 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataCreation(t *testi
 
 		common.SyncAndWait(t, helper, common.Repo(repoName), common.Incremental, common.Succeeded())
 
-		_, err = helper.Folders.Resource.Get(t.Context(), oldParentUID, metav1.GetOptions{})
-		require.True(t, apierrors.IsNotFound(err), "old parent folder should be deleted")
+		helper.RequireFoldersNotFound(t, oldParentUID)
 
-		_, err = helper.Folders.Resource.Get(t.Context(), oldChildUID, metav1.GetOptions{})
-		require.True(t, apierrors.IsNotFound(err), "old child folder should be deleted")
+		helper.RequireFoldersNotFound(t, oldChildUID)
 
 		common.RequireFolderState(t, helper.Folders, "p-new", "Parent", "parent", "")
 		common.RequireFolderState(t, helper.Folders, "c-new", "Child", "parent/child", "p-new")
@@ -906,8 +903,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderUIDChange(t *testing.T) {
 		title, _, _ := unstructured.NestedString(folderAfter.Object, "spec", "title")
 		require.Equal(t, "Alpha", title)
 
-		_, err = helper.Folders.Resource.Get(t.Context(), oldUID, metav1.GetOptions{})
-		require.True(t, apierrors.IsNotFound(err), "old folder UID should be deleted after UID change")
+		helper.RequireFoldersNotFound(t, oldUID)
 
 		common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 			"uid-dash-001": {Title: "Alpha Dashboard", SourcePath: "alpha/dash.json", Folder: newUID},
@@ -954,8 +950,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderUIDChange(t *testing.T) {
 		_, err = helper.Folders.Resource.Get(t.Context(), parentNewUID, metav1.GetOptions{})
 		require.NoError(t, err, "parent folder with new UID should exist")
 
-		_, err = helper.Folders.Resource.Get(t.Context(), parentOldUID, metav1.GetOptions{})
-		require.True(t, apierrors.IsNotFound(err), "old parent folder UID should be deleted after UID change")
+		helper.RequireFoldersNotFound(t, parentOldUID)
 
 		childAfter, err := helper.Folders.Resource.Get(t.Context(), childUID, metav1.GetOptions{})
 		require.NoError(t, err, "child folder should still exist")
@@ -1001,8 +996,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderUIDChange(t *testing.T) {
 		title, _, _ := unstructured.NestedString(folderAfter.Object, "spec", "title")
 		require.Equal(t, "Team Rebranded", title)
 
-		_, err = helper.Folders.Resource.Get(t.Context(), oldUID, metav1.GetOptions{})
-		require.True(t, apierrors.IsNotFound(err), "old folder UID should be deleted after UID change")
+		helper.RequireFoldersNotFound(t, oldUID)
 
 		common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 			"uid-combo-001": {Title: "Updated Dashboard", SourcePath: "team/dash.json", Folder: newUID},
@@ -1035,8 +1029,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderUIDChange(t *testing.T) {
 
 		_, err = helper.Folders.Resource.Get(t.Context(), "uid-v2", metav1.GetOptions{})
 		require.NoError(t, err, "v2 folder should exist")
-		_, err = helper.Folders.Resource.Get(t.Context(), "uid-v1", metav1.GetOptions{})
-		require.True(t, apierrors.IsNotFound(err), "v1 folder should be deleted")
+		helper.RequireFoldersNotFound(t, "uid-v1")
 		helper.RequireRepoFolderCount(t, repoName, 1)
 
 		// v2 -> v3
@@ -1052,10 +1045,8 @@ func TestIntegrationProvisioning_IncrementalSync_FolderUIDChange(t *testing.T) {
 
 		_, err = helper.Folders.Resource.Get(t.Context(), "uid-v3", metav1.GetOptions{})
 		require.NoError(t, err, "v3 folder should exist")
-		_, err = helper.Folders.Resource.Get(t.Context(), "uid-v2", metav1.GetOptions{})
-		require.True(t, apierrors.IsNotFound(err), "v2 folder should be deleted")
-		_, err = helper.Folders.Resource.Get(t.Context(), "uid-v1", metav1.GetOptions{})
-		require.True(t, apierrors.IsNotFound(err), "v1 folder should still be deleted")
+		helper.RequireFoldersNotFound(t, "uid-v2")
+		helper.RequireFoldersNotFound(t, "uid-v1")
 		helper.RequireRepoFolderCount(t, repoName, 1)
 
 		common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
@@ -1094,8 +1085,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderUIDChange(t *testing.T) {
 
 		_, err = helper.Folders.Resource.Get(t.Context(), "cleanup-v2", metav1.GetOptions{})
 		require.NoError(t, err, "current folder should still exist")
-		_, err = helper.Folders.Resource.Get(t.Context(), "cleanup-v1", metav1.GetOptions{})
-		require.True(t, apierrors.IsNotFound(err), "old folder should not reappear")
+		helper.RequireFoldersNotFound(t, "cleanup-v1")
 
 		common.RequireDashboards(t, helper.DashboardsV1, map[string]common.ExpectedDashboard{
 			"cleanup-dash": {Title: "Dashboard", SourcePath: "team/dash.json", Folder: "cleanup-v2"},
@@ -1144,8 +1134,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataDeletion(t *testi
 		})
 
 		// Old stable UID folder should be deleted
-		_, err = helper.Folders.Resource.Get(t.Context(), stableUID, metav1.GetOptions{})
-		require.True(t, apierrors.IsNotFound(err), "old stable UID folder should be deleted after metadata deletion")
+		helper.RequireFoldersNotFound(t, stableUID)
 
 		// New folder should exist with hash-based UID and directory name as title
 		newFolderUID := common.RequireRepoFolderTitle(t, helper.Folders, repoName, "alpha")
@@ -1192,8 +1181,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataDeletion(t *testi
 		})
 
 		// Old parent folder should be gone
-		_, err = helper.Folders.Resource.Get(t.Context(), parentStableUID, metav1.GetOptions{})
-		require.True(t, apierrors.IsNotFound(err), "old parent folder should be deleted")
+		helper.RequireFoldersNotFound(t, parentStableUID)
 
 		// New parent folder should exist with hash-based UID
 		newParentUID := common.RequireRepoFolderTitle(t, helper.Folders, repoName, "parent")
@@ -1259,8 +1247,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataDeletion(t *testi
 		})
 
 		// Old stable UID folder should be deleted
-		_, err = helper.Folders.Resource.Get(t.Context(), stableUID, metav1.GetOptions{})
-		require.True(t, apierrors.IsNotFound(err), "old stable UID folder should be deleted")
+		helper.RequireFoldersNotFound(t, stableUID)
 
 		// New folder should exist with hash-based UID
 		newFolderUID := common.RequireRepoFolderTitle(t, helper.Folders, repoName, "team")
@@ -1311,8 +1298,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMetadataDeletion(t *testi
 		})
 
 		// Old folder should be gone
-		_, err = helper.Folders.Resource.Get(t.Context(), stableUID, metav1.GetOptions{})
-		require.True(t, apierrors.IsNotFound(err), "old stable UID folder should be deleted")
+		helper.RequireFoldersNotFound(t, stableUID)
 
 		// New folder with hash-based UID
 		newFolderUID := common.RequireRepoFolderTitle(t, helper.Folders, repoName, "team")

--- a/pkg/tests/apis/provisioning/foldermetadata/incremental/incremental_invalid_folder_metadata_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/incremental/incremental_invalid_folder_metadata_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -252,9 +251,7 @@ func TestIntegrationProvisioning_IncrementalSync_InvalidFolderMetadata(t *testin
 		common.RequireRepoDashboardParent(t, helper.DashboardsV1, repoName, "parent/child/dashboard.json", childUID)
 		common.RequireRepoDashboardParent(t, helper.DashboardsV1, repoName, "parent/child/second-dash.json", childUID)
 
-		_, err = helper.Folders.Resource.Get(t.Context(), oldParentUID, metav1.GetOptions{})
-		require.Error(t, err)
-		require.True(t, apierrors.IsNotFound(err), "old unstable parent folder should be deleted")
+		helper.RequireFoldersNotFound(t, oldParentUID)
 
 		common.RequireRepoFolderUID(t, helper.Folders, repoName, oldBrokenUID)
 	})
@@ -376,9 +373,7 @@ func TestIntegrationProvisioning_IncrementalSync_InvalidFolderMetadata(t *testin
 		require.Equal(t, provisioning.JobStateWarning, jobObj.Status.State)
 		requireInvalidFolderMetadataWarning(t, jobObj, "moved/", repository.FileActionCreated)
 
-		_, err = helper.Folders.Resource.Get(t.Context(), stableUID, metav1.GetOptions{})
-		require.Error(t, err)
-		require.True(t, apierrors.IsNotFound(err))
+		helper.RequireFoldersNotFound(t, stableUID)
 
 		newUID := common.RequireRepoFolderTitle(t, helper.Folders, repoName, "moved")
 		require.NotEqual(t, stableUID, newUID)

--- a/pkg/tests/apis/provisioning/foldermetadata/incremental/incremental_permissions_move_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/incremental/incremental_permissions_move_test.go
@@ -1,9 +1,6 @@
 package incremental
 
 import (
-	"encoding/json"
-	"fmt"
-	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,8 +23,6 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMovePermissions(t *testin
 
 	helper := sharedGitHelper(t)
 
-	addr := helper.GetEnv().Server.HTTPServer.Listener.Addr().String()
-
 	// FolderMovePreservesPermissions verifies that custom permissions set on a
 	// provisioned folder are preserved after the folder is moved to a different
 	// location via git mv and an incremental sync is performed.
@@ -46,41 +41,25 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMovePermissions(t *testin
 
 		// Set a known ACL on teamA (check 4) so we can assert it is not touched when
 		// a child folder is moved into it.
-		_, code, err := common.PostHelper(t, *helper.K8sTestHelper,
-			"/api/folders/team-a-uid/permissions",
-			map[string]interface{}{
-				"items": []map[string]interface{}{
-					{"role": "Admin", "permission": 4},
-				},
-			},
-			helper.Org1.Admin)
-		require.NoError(t, err, "setting permissions on teamA folder should succeed")
-		require.Equal(t, http.StatusOK, code)
+		common.SetFolderPermissions(t, helper.ProvisioningTestHelper, "team-a-uid", common.RolePermission{Role: "Admin", Permission: common.FolderPermissionAdmin})
 
 		// Set multiple role-based ACL entries on teamB (check 3):
 		// Viewer → View (1) and Editor → Edit (2).
-		_, code, err = common.PostHelper(t, *helper.K8sTestHelper,
-			"/api/folders/team-b-uid/permissions",
-			map[string]interface{}{
-				"items": []map[string]interface{}{
-					{"role": "Viewer", "permission": 1},
-					{"role": "Editor", "permission": 2},
-				},
-			},
-			helper.Org1.Admin)
-		require.NoError(t, err, "setting permissions on teamB folder should succeed")
-		require.Equal(t, http.StatusOK, code)
+		common.SetFolderPermissions(t, helper.ProvisioningTestHelper, "team-b-uid",
+			common.RolePermission{Role: "Viewer", Permission: common.FolderPermissionView},
+			common.RolePermission{Role: "Editor", Permission: common.FolderPermissionEdit},
+		)
 
 		// Snapshot permissions before the move and verify the expected entries are present.
-		teamAPermsBefore := snapshotFolderPermissions(t, addr, "team-a-uid")
-		requirePermissionsContainRole(t, teamAPermsBefore, "Admin", 4)
+		teamAPermsBefore := common.FolderPermissions(t, helper.ProvisioningTestHelper, "team-a-uid")
+		common.RequirePermissionContainsRole(t, teamAPermsBefore, "Admin", common.FolderPermissionAdmin)
 
-		teamBPermsBefore := snapshotFolderPermissions(t, addr, "team-b-uid")
-		requirePermissionsContainRole(t, teamBPermsBefore, "Viewer", 1)
-		requirePermissionsContainRole(t, teamBPermsBefore, "Editor", 2)
+		teamBPermsBefore := common.FolderPermissions(t, helper.ProvisioningTestHelper, "team-b-uid")
+		common.RequirePermissionContainsRole(t, teamBPermsBefore, "Viewer", common.FolderPermissionView)
+		common.RequirePermissionContainsRole(t, teamBPermsBefore, "Editor", common.FolderPermissionEdit)
 
 		// Move teamB inside teamA via git mv, commit, and push.
-		_, err = local.Git("mv", "teamB", "teamA/teamB")
+		_, err := local.Git("mv", "teamB", "teamA/teamB")
 		require.NoError(t, err)
 		_, err = local.Git("commit", "-m", "move teamB into teamA")
 		require.NoError(t, err)
@@ -92,24 +71,24 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMovePermissions(t *testin
 		// teamB should now live under teamA with the same stable UID.
 		requireGitFolderState(t, helper, "team-b-uid", "Team B", "teamA/teamB", "team-a-uid")
 
-		teamBPermsAfter := snapshotFolderPermissions(t, addr, "team-b-uid")
+		teamBPermsAfter := common.FolderPermissions(t, helper.ProvisioningTestHelper, "team-b-uid")
 
 		// Check 1: The ACL entry count must not change after the move.
 		require.Equal(t, len(teamBPermsBefore), len(teamBPermsAfter),
 			"ACL entry count must not change after folder move")
 
 		// Check 2 & 3: The full (role → permission) map must be identical before and after.
-		requireRolePermissionSetEqual(t, teamBPermsBefore, teamBPermsAfter)
-		requirePermissionsContainRole(t, teamBPermsAfter, "Viewer", 1)
-		requirePermissionsContainRole(t, teamBPermsAfter, "Editor", 2)
+		common.RequireRolePermissionSetEqual(t, teamBPermsBefore, teamBPermsAfter)
+		common.RequirePermissionContainsRole(t, teamBPermsAfter, "Viewer", common.FolderPermissionView)
+		common.RequirePermissionContainsRole(t, teamBPermsAfter, "Editor", common.FolderPermissionEdit)
 
 		// Check 4: teamA's own ACL must be unaffected by moving a child into it.
-		teamAPermsAfter := snapshotFolderPermissions(t, addr, "team-a-uid")
-		requireRolePermissionSetEqual(t, teamAPermsBefore, teamAPermsAfter)
+		teamAPermsAfter := common.FolderPermissions(t, helper.ProvisioningTestHelper, "team-a-uid")
+		common.RequireRolePermissionSetEqual(t, teamAPermsBefore, teamAPermsAfter)
 
 		// Check 5: The moved folder must still be effectively accessible to a user
 		// carrying the granted role.
-		requireFolderAccessible(t, addr, "team-b-uid", "viewer", "viewer")
+		common.RequireFolderAccessible(t, helper.ProvisioningTestHelper, "team-b-uid", "viewer", "viewer")
 	})
 
 	// FolderMoveDoesNotPreservePermissionsForLegacyFolder contrasts with the
@@ -133,22 +112,13 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMovePermissions(t *testin
 		require.NotEmpty(t, plainUID)
 
 		// Set a Viewer permission on the legacy (no-metadata) folder.
-		_, code, err := common.PostHelper(t, *helper.K8sTestHelper,
-			fmt.Sprintf("/api/folders/%s/permissions", plainUID),
-			map[string]interface{}{
-				"items": []map[string]interface{}{
-					{"role": "Viewer", "permission": 1},
-				},
-			},
-			helper.Org1.Admin)
-		require.NoError(t, err, "setting permissions on plain folder should succeed")
-		require.Equal(t, http.StatusOK, code)
+		common.SetFolderPermissions(t, helper.ProvisioningTestHelper, plainUID, common.RolePermission{Role: "Viewer", Permission: common.FolderPermissionView})
 
-		plainPermsBefore := snapshotFolderPermissions(t, addr, plainUID)
-		requirePermissionsContainRole(t, plainPermsBefore, "Viewer", 1)
+		plainPermsBefore := common.FolderPermissions(t, helper.ProvisioningTestHelper, plainUID)
+		common.RequirePermissionContainsRole(t, plainPermsBefore, "Viewer", common.FolderPermissionView)
 
 		// Move the legacy folder under the parent via git mv, commit, and push.
-		_, err = local.Git("mv", "plain", "parent/plain")
+		_, err := local.Git("mv", "plain", "parent/plain")
 		require.NoError(t, err)
 		_, err = local.Git("commit", "-m", "move plain folder under parent")
 		require.NoError(t, err)
@@ -170,7 +140,7 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMovePermissions(t *testin
 			"legacy folder must get a new UID when its path changes")
 
 		// The new folder must NOT carry the Viewer permission from the old object.
-		newPlainPerms := snapshotFolderPermissions(t, addr, newPlainUID)
+		newPlainPerms := common.FolderPermissions(t, helper.ProvisioningTestHelper, newPlainUID)
 		for _, p := range newPlainPerms {
 			entry, ok := p.(map[string]interface{})
 			if !ok {
@@ -206,22 +176,13 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMovePermissions(t *testin
 		requireGitFolderState(t, helper, "destination-uid", "Destination", "destination", repoName)
 
 		// Grant Editor permission on the deepest (grandchild) folder.
-		_, code, err := common.PostHelper(t, *helper.K8sTestHelper,
-			"/api/folders/grandchild-uid/permissions",
-			map[string]interface{}{
-				"items": []map[string]interface{}{
-					{"role": "Editor", "permission": 2},
-				},
-			},
-			helper.Org1.Admin)
-		require.NoError(t, err, "setting permissions on grandchild folder should succeed")
-		require.Equal(t, http.StatusOK, code)
+		common.SetFolderPermissions(t, helper.ProvisioningTestHelper, "grandchild-uid", common.RolePermission{Role: "Editor", Permission: common.FolderPermissionEdit})
 
-		grandchildPermsBefore := snapshotFolderPermissions(t, addr, "grandchild-uid")
-		requirePermissionsContainRole(t, grandchildPermsBefore, "Editor", 2)
+		grandchildPermsBefore := common.FolderPermissions(t, helper.ProvisioningTestHelper, "grandchild-uid")
+		common.RequirePermissionContainsRole(t, grandchildPermsBefore, "Editor", common.FolderPermissionEdit)
 
 		// Move the child subtree (carrying grandchild with it) under destination via git mv.
-		_, err = local.Git("mv", "root/child", "destination/child")
+		_, err := local.Git("mv", "root/child", "destination/child")
 		require.NoError(t, err)
 		_, err = local.Git("commit", "-m", "move child subtree into destination")
 		require.NoError(t, err)
@@ -234,11 +195,11 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMovePermissions(t *testin
 		requireGitFolderState(t, helper, "child-uid", "Child", "destination/child", "destination-uid")
 		requireGitFolderState(t, helper, "grandchild-uid", "Grandchild", "destination/child/grandchild", "child-uid")
 
-		grandchildPermsAfter := snapshotFolderPermissions(t, addr, "grandchild-uid")
+		grandchildPermsAfter := common.FolderPermissions(t, helper.ProvisioningTestHelper, "grandchild-uid")
 		require.Equal(t, len(grandchildPermsBefore), len(grandchildPermsAfter),
 			"ACL entry count must not change after nested folder move")
-		requireRolePermissionSetEqual(t, grandchildPermsBefore, grandchildPermsAfter)
-		requirePermissionsContainRole(t, grandchildPermsAfter, "Editor", 2)
+		common.RequireRolePermissionSetEqual(t, grandchildPermsBefore, grandchildPermsAfter)
+		common.RequirePermissionContainsRole(t, grandchildPermsAfter, "Editor", common.FolderPermissionEdit)
 	})
 
 	// RootToLeafMovePreservesPermissions verifies that a top-level (root) folder
@@ -259,22 +220,13 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMovePermissions(t *testin
 		requireGitFolderState(t, helper, "inner-uid", "Inner", "container/inner", "container-uid")
 
 		// Grant Viewer permission on the root-level "top" folder before the move.
-		_, code, err := common.PostHelper(t, *helper.K8sTestHelper,
-			"/api/folders/top-uid/permissions",
-			map[string]interface{}{
-				"items": []map[string]interface{}{
-					{"role": "Viewer", "permission": 1},
-				},
-			},
-			helper.Org1.Admin)
-		require.NoError(t, err, "setting permissions on top folder should succeed")
-		require.Equal(t, http.StatusOK, code)
+		common.SetFolderPermissions(t, helper.ProvisioningTestHelper, "top-uid", common.RolePermission{Role: "Viewer", Permission: common.FolderPermissionView})
 
-		topPermsBefore := snapshotFolderPermissions(t, addr, "top-uid")
-		requirePermissionsContainRole(t, topPermsBefore, "Viewer", 1)
+		topPermsBefore := common.FolderPermissions(t, helper.ProvisioningTestHelper, "top-uid")
+		common.RequirePermissionContainsRole(t, topPermsBefore, "Viewer", common.FolderPermissionView)
 
 		// Move "top" under container/inner, making it a leaf three levels deep.
-		_, err = local.Git("mv", "top", "container/inner/top")
+		_, err := local.Git("mv", "top", "container/inner/top")
 		require.NoError(t, err)
 		_, err = local.Git("commit", "-m", "move top folder to leaf position under container/inner")
 		require.NoError(t, err)
@@ -285,12 +237,12 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMovePermissions(t *testin
 
 		requireGitFolderState(t, helper, "top-uid", "Top", "container/inner/top", "inner-uid")
 
-		topPermsAfter := snapshotFolderPermissions(t, addr, "top-uid")
+		topPermsAfter := common.FolderPermissions(t, helper.ProvisioningTestHelper, "top-uid")
 		require.Equal(t, len(topPermsBefore), len(topPermsAfter),
 			"ACL entry count must not change when moving a root folder to a leaf position")
-		requireRolePermissionSetEqual(t, topPermsBefore, topPermsAfter)
-		requirePermissionsContainRole(t, topPermsAfter, "Viewer", 1)
-		requireFolderAccessible(t, addr, "top-uid", "viewer", "viewer")
+		common.RequireRolePermissionSetEqual(t, topPermsBefore, topPermsAfter)
+		common.RequirePermissionContainsRole(t, topPermsAfter, "Viewer", common.FolderPermissionView)
+		common.RequireFolderAccessible(t, helper.ProvisioningTestHelper, "top-uid", "viewer", "viewer")
 	})
 
 	// LeafToRootMovePreservesPermissions verifies that a deeply nested folder
@@ -315,22 +267,13 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMovePermissions(t *testin
 		requireGitFolderState(t, helper, "ltroot-leaf-uid", "Leaf", "parent/deep/leaf", "ltroot-deep-uid")
 
 		// Grant Editor permission on the deeply nested leaf folder.
-		_, code, err := common.PostHelper(t, *helper.K8sTestHelper,
-			"/api/folders/ltroot-leaf-uid/permissions",
-			map[string]interface{}{
-				"items": []map[string]interface{}{
-					{"role": "Editor", "permission": 2},
-				},
-			},
-			helper.Org1.Admin)
-		require.NoError(t, err, "setting permissions on leaf folder should succeed")
-		require.Equal(t, http.StatusOK, code)
+		common.SetFolderPermissions(t, helper.ProvisioningTestHelper, "ltroot-leaf-uid", common.RolePermission{Role: "Editor", Permission: common.FolderPermissionEdit})
 
-		leafPermsBefore := snapshotFolderPermissions(t, addr, "ltroot-leaf-uid")
-		requirePermissionsContainRole(t, leafPermsBefore, "Editor", 2)
+		leafPermsBefore := common.FolderPermissions(t, helper.ProvisioningTestHelper, "ltroot-leaf-uid")
+		common.RequirePermissionContainsRole(t, leafPermsBefore, "Editor", common.FolderPermissionEdit)
 
 		// Promote the leaf to the repository root level via git mv.
-		_, err = local.Git("mv", "parent/deep/leaf", "leaf")
+		_, err := local.Git("mv", "parent/deep/leaf", "leaf")
 		require.NoError(t, err)
 		_, err = local.Git("commit", "-m", "promote leaf folder to root level")
 		require.NoError(t, err)
@@ -341,11 +284,11 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMovePermissions(t *testin
 
 		requireGitFolderState(t, helper, "ltroot-leaf-uid", "Leaf", "leaf", repoName)
 
-		leafPermsAfter := snapshotFolderPermissions(t, addr, "ltroot-leaf-uid")
+		leafPermsAfter := common.FolderPermissions(t, helper.ProvisioningTestHelper, "ltroot-leaf-uid")
 		require.Equal(t, len(leafPermsBefore), len(leafPermsAfter),
 			"ACL entry count must not change when a leaf folder is promoted to root")
-		requireRolePermissionSetEqual(t, leafPermsBefore, leafPermsAfter)
-		requirePermissionsContainRole(t, leafPermsAfter, "Editor", 2)
+		common.RequireRolePermissionSetEqual(t, leafPermsBefore, leafPermsAfter)
+		common.RequirePermissionContainsRole(t, leafPermsAfter, "Editor", common.FolderPermissionEdit)
 	})
 
 	// MetadataFolderMovedUnderLegacyPreservesPermissions verifies that a folder
@@ -367,22 +310,13 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMovePermissions(t *testin
 		require.NotEmpty(t, legacyParentUID)
 
 		// Set Viewer permission on the metadata-backed child folder.
-		_, code, err := common.PostHelper(t, *helper.K8sTestHelper,
-			"/api/folders/child-meta-uid/permissions",
-			map[string]interface{}{
-				"items": []map[string]interface{}{
-					{"role": "Viewer", "permission": 1},
-				},
-			},
-			helper.Org1.Admin)
-		require.NoError(t, err, "setting permissions on child-with-meta folder should succeed")
-		require.Equal(t, http.StatusOK, code)
+		common.SetFolderPermissions(t, helper.ProvisioningTestHelper, "child-meta-uid", common.RolePermission{Role: "Viewer", Permission: common.FolderPermissionView})
 
-		childPermsBefore := snapshotFolderPermissions(t, addr, "child-meta-uid")
-		requirePermissionsContainRole(t, childPermsBefore, "Viewer", 1)
+		childPermsBefore := common.FolderPermissions(t, helper.ProvisioningTestHelper, "child-meta-uid")
+		common.RequirePermissionContainsRole(t, childPermsBefore, "Viewer", common.FolderPermissionView)
 
 		// Move the metadata child under the legacy (no _folder.json) parent via git mv.
-		_, err = local.Git("mv", "child-with-meta", "legacy-parent/child-with-meta")
+		_, err := local.Git("mv", "child-with-meta", "legacy-parent/child-with-meta")
 		require.NoError(t, err)
 		_, err = local.Git("commit", "-m", "move child-with-meta under legacy-parent")
 		require.NoError(t, err)
@@ -399,12 +333,12 @@ func TestIntegrationProvisioning_IncrementalSync_FolderMovePermissions(t *testin
 		// The metadata child retains its stable UID and is now under the legacy parent.
 		requireGitFolderState(t, helper, "child-meta-uid", "Child With Meta", "legacy-parent/child-with-meta", legacyParentUID)
 
-		childPermsAfter := snapshotFolderPermissions(t, addr, "child-meta-uid")
+		childPermsAfter := common.FolderPermissions(t, helper.ProvisioningTestHelper, "child-meta-uid")
 		require.Equal(t, len(childPermsBefore), len(childPermsAfter),
 			"ACL entry count must not change when metadata folder is moved under a legacy parent")
-		requireRolePermissionSetEqual(t, childPermsBefore, childPermsAfter)
-		requirePermissionsContainRole(t, childPermsAfter, "Viewer", 1)
-		requireFolderAccessible(t, addr, "child-meta-uid", "viewer", "viewer")
+		common.RequireRolePermissionSetEqual(t, childPermsBefore, childPermsAfter)
+		common.RequirePermissionContainsRole(t, childPermsAfter, "Viewer", common.FolderPermissionView)
+		common.RequireFolderAccessible(t, helper.ProvisioningTestHelper, "child-meta-uid", "viewer", "viewer")
 	})
 }
 
@@ -470,78 +404,4 @@ func assertGitFolderAbsent(t *testing.T, h *common.GitTestHelper, folderUID stri
 		assert.True(c, apierrors.IsNotFound(err),
 			"expected NotFound error for folder %q, got: %v", folderUID, err)
 	}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "folder %q should be deleted", folderUID)
-}
-
-// snapshotFolderPermissions performs a single GET to /api/folders/{uid}/permissions and
-// returns the raw decoded JSON array. The test fails immediately if the request errors.
-func snapshotFolderPermissions(t *testing.T, addr, folderUID string) []interface{} {
-	t.Helper()
-	u := fmt.Sprintf("http://admin:admin@%s/api/folders/%s/permissions", addr, folderUID)
-	resp, err := http.Get(u) //nolint:gosec
-	require.NoError(t, err, "GET folder permissions for %q", folderUID)
-	defer resp.Body.Close() //nolint:errcheck
-	require.Equal(t, http.StatusOK, resp.StatusCode,
-		"unexpected status from permissions endpoint for %q", folderUID)
-	var perms []interface{}
-	require.NoError(t, json.NewDecoder(resp.Body).Decode(&perms),
-		"decode permissions response for %q", folderUID)
-	return perms
-}
-
-// requirePermissionsContainRole asserts that perms contains at least one entry matching
-// the given built-in role and numeric permission level.
-// JSON numbers are decoded as float64, so the comparison is done via float64.
-func requirePermissionsContainRole(t *testing.T, perms []interface{}, expectedRole string, expectedPermission int) {
-	t.Helper()
-	for _, p := range perms {
-		entry, ok := p.(map[string]interface{})
-		if !ok {
-			continue
-		}
-		role, _ := entry["role"].(string)
-		level, _ := entry["permission"].(float64)
-		if role == expectedRole && int(level) == expectedPermission {
-			return
-		}
-	}
-	require.Failf(t, "permission not found",
-		"expected role=%q permission=%d in ACL entries; got: %v",
-		expectedRole, expectedPermission, perms)
-}
-
-// requireRolePermissionSetEqual asserts that the set of (role → permission) mappings is
-// identical between want and got. Entry ordering and non-role fields (which may legitimately
-// change after a move, such as internal parent-folder references) are ignored.
-func requireRolePermissionSetEqual(t *testing.T, want, got []interface{}) {
-	t.Helper()
-	extractRoleMap := func(perms []interface{}) map[string]int {
-		m := make(map[string]int)
-		for _, p := range perms {
-			entry, ok := p.(map[string]interface{})
-			if !ok {
-				continue
-			}
-			role, _ := entry["role"].(string)
-			if role == "" {
-				continue
-			}
-			level, _ := entry["permission"].(float64)
-			m[role] = int(level)
-		}
-		return m
-	}
-	require.Equal(t, extractRoleMap(want), extractRoleMap(got),
-		"role→permission map must be identical before and after the move")
-}
-
-// requireFolderAccessible asserts that GET /api/folders/{folderUID} returns HTTP 200
-// when performed with the supplied Basic Auth credentials.
-func requireFolderAccessible(t *testing.T, addr, folderUID, login, password string) {
-	t.Helper()
-	u := fmt.Sprintf("http://%s:%s@%s/api/folders/%s", login, password, addr, folderUID)
-	resp, err := http.Get(u) //nolint:gosec
-	require.NoError(t, err, "GET folder %q as user %q", folderUID, login)
-	defer resp.Body.Close() //nolint:errcheck
-	require.Equal(t, http.StatusOK, resp.StatusCode,
-		"folder %q should be accessible to %q after the move", folderUID, login)
 }

--- a/pkg/tests/apis/provisioning/foldermetadata/migrate_folder_ids_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/migrate_folder_ids_test.go
@@ -52,8 +52,8 @@ func TestIntegrationProvisioning_MigrateJob_GenerateNewFolderIDs(t *testing.T) {
 		Workflows:  []string{"write"},
 	})
 
-	createUnmanagedFolder(t, helper, parentUID, parentTitle)
-	createUnmanagedFolderWithParent(t, helper, childUID, childTitle, parentUID)
+	helper.CreateUnmanagedFolderWithName(t, parentUID, parentTitle, "")
+	helper.CreateUnmanagedFolderWithName(t, childUID, childTitle, parentUID)
 
 	helper.TriggerJobAndWaitForSuccess(t, repo, provisioning.JobSpec{
 		Action: provisioning.JobActionMigrate,

--- a/pkg/tests/apis/provisioning/folderownerrefs_test.go
+++ b/pkg/tests/apis/provisioning/folderownerrefs_test.go
@@ -72,20 +72,10 @@ func TestIntegrationFolderOwnerRefs_UnprovisionedFolders(t *testing.T) {
 	t.Run("should set ownerReferences when folder is released", func(t *testing.T) {
 		managedFolderName := helper.ListRepoFolders(t, repo)[0].GetName()
 
-		_, err := helper.Repositories.Resource.Patch(t.Context(), repo, types.JSONPatchType, []byte(`[
-		{
-			"op": "replace",
-			"path": "/metadata/finalizers",
-			"value": ["cleanup", "release-orphan-resources"]
-		}
-		]`), metav1.PatchOptions{})
-		require.NoError(t, err, "should successfully patch finalizers")
-
-		require.NoError(t, helper.Repositories.Resource.Delete(t.Context(), repo, metav1.DeleteOptions{}))
-		helper.WaitForRepositoryDeleted(t, repo)
+		helper.ReleaseAndDeleteRepository(t, repo)
 		common.WaitForResourcesReleased(t, helper.Folders.Resource, "folders")
 
-		_, err = helper.Folders.Resource.Patch(t.Context(), managedFolderName, types.JSONPatchType, ownerRefsPatch, metav1.PatchOptions{})
+		_, err := helper.Folders.Resource.Patch(t.Context(), managedFolderName, types.JSONPatchType, ownerRefsPatch, metav1.PatchOptions{})
 		require.NoError(t, err, "should set ownerReferences on released folder")
 
 		updated, err := helper.Folders.Resource.Get(t.Context(), managedFolderName, metav1.GetOptions{})

--- a/pkg/tests/apis/provisioning/folderownerrefs_test.go
+++ b/pkg/tests/apis/provisioning/folderownerrefs_test.go
@@ -34,7 +34,7 @@ func TestIntegrationFolderOwnerRefs_ProvisionedFolders(t *testing.T) {
 	helper.RequireRepoFolderCount(t, "test-repo", 1)
 
 	t.Run("should fail to set ownerReferences on provisioned folder via patch", func(t *testing.T) {
-		managedFolder := helper.ListRepoFolders(t, "test-repo")[0]
+		managedFolder := helper.RequireSingleRepoFolder(t, "test-repo")
 
 		_, err := helper.Folders.Resource.Patch(t.Context(), managedFolder.GetName(), types.JSONPatchType, ownerRefsPatch, metav1.PatchOptions{})
 		require.Error(t, err, "should fail to set ownerReferences on managed folder")
@@ -43,7 +43,7 @@ func TestIntegrationFolderOwnerRefs_ProvisionedFolders(t *testing.T) {
 	})
 
 	t.Run("should fail to set ownerReferences on provisioned folder via update", func(t *testing.T) {
-		managedFolder := helper.ListRepoFolders(t, "test-repo")[0].DeepCopy()
+		managedFolder := helper.RequireSingleRepoFolder(t, "test-repo").DeepCopy()
 		managedFolder.SetOwnerReferences([]metav1.OwnerReference{{
 			APIVersion: "iam.grafana.app/v0alpha1",
 			Kind:       "Team",
@@ -70,7 +70,7 @@ func TestIntegrationFolderOwnerRefs_UnprovisionedFolders(t *testing.T) {
 	helper.RequireRepoFolderCount(t, repo, 1)
 
 	t.Run("should set ownerReferences when folder is released", func(t *testing.T) {
-		managedFolderName := helper.ListRepoFolders(t, repo)[0].GetName()
+		managedFolderName := helper.RequireSingleRepoFolder(t, repo).GetName()
 
 		helper.ReleaseAndDeleteRepository(t, repo)
 		common.WaitForResourcesReleased(t, helper.Folders.Resource, "folders")

--- a/pkg/tests/apis/provisioning/folderownerrefs_test.go
+++ b/pkg/tests/apis/provisioning/folderownerrefs_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	foldersV1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
-	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -35,26 +34,16 @@ func TestIntegrationFolderOwnerRefs_ProvisionedFolders(t *testing.T) {
 	helper.RequireRepoFolderCount(t, "test-repo", 1)
 
 	t.Run("should fail to set ownerReferences on provisioned folder via patch", func(t *testing.T) {
-		folders, err := helper.Folders.Resource.List(t.Context(), metav1.ListOptions{})
-		require.NoError(t, err)
-		require.Len(t, folders.Items, 1)
+		managedFolder := helper.ListRepoFolders(t, "test-repo")[0]
 
-		managedFolder := folders.Items[0]
-		require.Contains(t, managedFolder.GetAnnotations(), utils.AnnoKeyManagerKind, "folder should be managed")
-		require.Contains(t, managedFolder.GetAnnotations(), utils.AnnoKeyManagerIdentity, "folder should be managed")
-
-		_, err = helper.Folders.Resource.Patch(t.Context(), managedFolder.GetName(), types.JSONPatchType, ownerRefsPatch, metav1.PatchOptions{})
+		_, err := helper.Folders.Resource.Patch(t.Context(), managedFolder.GetName(), types.JSONPatchType, ownerRefsPatch, metav1.PatchOptions{})
 		require.Error(t, err, "should fail to set ownerReferences on managed folder")
 		require.True(t, apierrors.IsForbidden(err), "expected Forbidden status error, got: %v", err)
 		require.Contains(t, err.Error(), "cannot set owner references on folders managed by a repository")
 	})
 
 	t.Run("should fail to set ownerReferences on provisioned folder via update", func(t *testing.T) {
-		folders, err := helper.Folders.Resource.List(t.Context(), metav1.ListOptions{})
-		require.NoError(t, err)
-		require.Len(t, folders.Items, 1)
-
-		managedFolder := folders.Items[0].DeepCopy()
+		managedFolder := helper.ListRepoFolders(t, "test-repo")[0].DeepCopy()
 		managedFolder.SetOwnerReferences([]metav1.OwnerReference{{
 			APIVersion: "iam.grafana.app/v0alpha1",
 			Kind:       "Team",
@@ -62,7 +51,7 @@ func TestIntegrationFolderOwnerRefs_ProvisionedFolders(t *testing.T) {
 			UID:        "00000000-0000-0000-0000-000000000001",
 		}})
 
-		_, err = helper.Folders.Resource.Update(t.Context(), managedFolder, metav1.UpdateOptions{})
+		_, err := helper.Folders.Resource.Update(t.Context(), managedFolder, metav1.UpdateOptions{})
 		require.Error(t, err, "should fail to set ownerReferences on managed folder via update")
 		require.True(t, apierrors.IsForbidden(err), "expected Forbidden status error, got: %v", err)
 		require.Contains(t, err.Error(), "cannot set owner references on folders managed by a repository")
@@ -81,14 +70,9 @@ func TestIntegrationFolderOwnerRefs_UnprovisionedFolders(t *testing.T) {
 	helper.RequireRepoFolderCount(t, repo, 1)
 
 	t.Run("should set ownerReferences when folder is released", func(t *testing.T) {
-		folders, err := helper.Folders.Resource.List(t.Context(), metav1.ListOptions{})
-		require.NoError(t, err)
-		require.Len(t, folders.Items, 1)
-		managedFolderName := folders.Items[0].GetName()
-		require.Contains(t, folders.Items[0].GetAnnotations(), utils.AnnoKeyManagerKind, "folder should be managed")
-		require.Contains(t, folders.Items[0].GetAnnotations(), utils.AnnoKeyManagerIdentity, "folder should be managed")
+		managedFolderName := helper.ListRepoFolders(t, repo)[0].GetName()
 
-		_, err = helper.Repositories.Resource.Patch(t.Context(), repo, types.JSONPatchType, []byte(`[
+		_, err := helper.Repositories.Resource.Patch(t.Context(), repo, types.JSONPatchType, []byte(`[
 		{
 			"op": "replace",
 			"path": "/metadata/finalizers",

--- a/pkg/tests/apis/provisioning/folderpermissions_test.go
+++ b/pkg/tests/apis/provisioning/folderpermissions_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	foldersV1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
-	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -26,21 +25,8 @@ func TestIntegrationFolderPermissions_ProvisionedFolders(t *testing.T) {
 		},
 	})
 	t.Run("should fail to update permissions for provisioned nested folder", func(t *testing.T) {
-		folders, err := helper.Folders.Resource.List(t.Context(), metav1.ListOptions{})
-		require.NoError(t, err)
-		require.GreaterOrEqual(t, len(folders.Items), 2, "should have 2 folders (root and nested)")
-
-		// Find all folders managed by provisioning
-		var provisionedFolders []*unstructured.Unstructured
-		for i := range folders.Items {
-			annotations := folders.Items[i].GetAnnotations()
-			if _, hasManagerKind := annotations[utils.AnnoKeyManagerKind]; hasManagerKind {
-				if _, hasManagerIdentity := annotations[utils.AnnoKeyManagerIdentity]; hasManagerIdentity {
-					provisionedFolders = append(provisionedFolders, &folders.Items[i])
-				}
-			}
-		}
-		require.Greater(t, len(provisionedFolders), 0, "should have at least one provisioned folder")
+		helper.RequireRepoFolderCount(t, repoName, 3)
+		provisionedFolders := helper.ListRepoFolders(t, repoName)
 
 		permissionsPayload := map[string]interface{}{
 			"items": []map[string]interface{}{
@@ -76,14 +62,9 @@ func TestIntegrationFolderPermissions_UnprovisionedFolders(t *testing.T) {
 	helper.RequireRepoFolderCount(t, repo, 1)
 
 	t.Run("should update permissions when folder is released", func(t *testing.T) {
-		folders, err := helper.Folders.Resource.List(t.Context(), metav1.ListOptions{})
-		require.NoError(t, err)
-		require.Len(t, folders.Items, 1)
-		managedFolderName := folders.Items[0].GetName()
-		require.Contains(t, folders.Items[0].GetAnnotations(), utils.AnnoKeyManagerKind, "folder should be managed")
-		require.Contains(t, folders.Items[0].GetAnnotations(), utils.AnnoKeyManagerIdentity, "folder should be managed")
+		managedFolderName := helper.ListRepoFolders(t, repo)[0].GetName()
 
-		_, err = helper.Repositories.Resource.Patch(t.Context(), repo, types.JSONPatchType, []byte(`[
+		_, err := helper.Repositories.Resource.Patch(t.Context(), repo, types.JSONPatchType, []byte(`[
 		{
 			"op": "replace",
 			"path": "/metadata/finalizers",

--- a/pkg/tests/apis/provisioning/folderpermissions_test.go
+++ b/pkg/tests/apis/provisioning/folderpermissions_test.go
@@ -24,8 +24,7 @@ func TestIntegrationFolderPermissions_ProvisionedFolders(t *testing.T) {
 		},
 	})
 	t.Run("should fail to update permissions for provisioned nested folder", func(t *testing.T) {
-		helper.RequireRepoFolderCount(t, repoName, 3)
-		provisionedFolders := helper.ListRepoFolders(t, repoName)
+		provisionedFolders := helper.RequireRepoFolderCount(t, repoName, 3)
 
 		permissionsPayload := map[string]interface{}{
 			"items": []map[string]interface{}{

--- a/pkg/tests/apis/provisioning/folderpermissions_test.go
+++ b/pkg/tests/apis/provisioning/folderpermissions_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 // We currently block permission updates for folders managed by provisioning.
@@ -32,7 +31,7 @@ func TestIntegrationFolderPermissions_ProvisionedFolders(t *testing.T) {
 			"items": []map[string]interface{}{
 				{
 					"role":       "Viewer",
-					"permission": 1, // View permission
+					"permission": common.FolderPermissionView,
 				},
 			},
 		}
@@ -64,32 +63,10 @@ func TestIntegrationFolderPermissions_UnprovisionedFolders(t *testing.T) {
 	t.Run("should update permissions when folder is released", func(t *testing.T) {
 		managedFolderName := helper.ListRepoFolders(t, repo)[0].GetName()
 
-		_, err := helper.Repositories.Resource.Patch(t.Context(), repo, types.JSONPatchType, []byte(`[
-		{
-			"op": "replace",
-			"path": "/metadata/finalizers",
-			"value": ["cleanup", "release-orphan-resources"]
-		}
-		]`), metav1.PatchOptions{})
-		require.NoError(t, err, "should successfully patch finalizers")
-
-		require.NoError(t, helper.Repositories.Resource.Delete(t.Context(), repo, metav1.DeleteOptions{}))
-		helper.WaitForRepositoryDeleted(t, repo)
+		helper.ReleaseAndDeleteRepository(t, repo)
 		common.WaitForResourcesReleased(t, helper.Folders.Resource, "folders")
 
-		permissionsPayload := map[string]interface{}{
-			"items": []map[string]interface{}{
-				{
-					"role":       "Viewer",
-					"permission": 1, // View permission
-				},
-			},
-		}
-		permissionsURL := fmt.Sprintf("/api/folders/%s/permissions", managedFolderName)
-		permissionsData, code, err := common.PostHelper(t, *helper.K8sTestHelper, permissionsURL, permissionsPayload, helper.Org1.Admin)
-		require.NoError(t, err)
-		require.Equal(t, http.StatusOK, code)
-		require.NotNil(t, permissionsData)
+		common.SetFolderPermissions(t, helper, managedFolderName, common.RolePermission{Role: "Viewer", Permission: common.FolderPermissionView})
 	})
 
 	t.Run("should update permissions for unmanaged folder", func(t *testing.T) {
@@ -109,19 +86,6 @@ func TestIntegrationFolderPermissions_UnprovisionedFolders(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, createdFolder)
 
-		unmanagedFolderName := createdFolder.GetName()
-		permissionsPayload := map[string]interface{}{
-			"items": []map[string]interface{}{
-				{
-					"role":       "Editor",
-					"permission": 2, // Edit permission
-				},
-			},
-		}
-		permissionsURL := fmt.Sprintf("/api/folders/%s/permissions", unmanagedFolderName)
-		permissionsData, code, err := common.PostHelper(t, *helper.K8sTestHelper, permissionsURL, permissionsPayload, helper.Org1.Admin)
-		require.NoError(t, err)
-		require.Equal(t, http.StatusOK, code)
-		require.NotNil(t, permissionsData)
+		common.SetFolderPermissions(t, helper, createdFolder.GetName(), common.RolePermission{Role: "Editor", Permission: common.FolderPermissionEdit})
 	})
 }

--- a/pkg/tests/apis/provisioning/folderpermissions_test.go
+++ b/pkg/tests/apis/provisioning/folderpermissions_test.go
@@ -61,7 +61,7 @@ func TestIntegrationFolderPermissions_UnprovisionedFolders(t *testing.T) {
 	helper.RequireRepoFolderCount(t, repo, 1)
 
 	t.Run("should update permissions when folder is released", func(t *testing.T) {
-		managedFolderName := helper.ListRepoFolders(t, repo)[0].GetName()
+		managedFolderName := helper.RequireSingleRepoFolder(t, repo).GetName()
 
 		helper.ReleaseAndDeleteRepository(t, repo)
 		common.WaitForResourcesReleased(t, helper.Folders.Resource, "folders")

--- a/pkg/tests/apis/provisioning/git/files_test.go
+++ b/pkg/tests/apis/provisioning/git/files_test.go
@@ -49,9 +49,7 @@ func TestIntegrationGitFiles_CreateFile(t *testing.T) {
 		require.NoError(t, result.Error(), "should create file on default branch")
 
 		// Verify file exists in repository
-		fileObj, err := helper.Repositories.Resource.Get(t.Context(), repoName, metav1.GetOptions{}, "files", "dashboard1.json")
-		require.NoError(t, err, "file should exist in repository")
-		require.NotNil(t, fileObj)
+		helper.RequireRepoFileExists(t, repoName, "dashboard1.json")
 
 		// Trigger sync and verify dashboard is created
 		helper.SyncAndWait(t, repoName)
@@ -318,11 +316,8 @@ func TestIntegrationGitFiles_MoveFile(t *testing.T) {
 		require.Equal(t, http.StatusOK, resp.StatusCode, "should move file on default branch")
 
 		// Verify file moved
-		_, err = helper.Repositories.Resource.Get(t.Context(), repoName, metav1.GetOptions{}, "files", "moved", "dashboard.json")
-		require.NoError(t, err, "file should exist at new location")
-
-		_, err = helper.Repositories.Resource.Get(t.Context(), repoName, metav1.GetOptions{}, "files", "dashboard.json")
-		require.Error(t, err, "file should not exist at old location")
+		helper.RequireRepoFileExists(t, repoName, "moved", "dashboard.json")
+		helper.RequireRepoFileNotFound(t, repoName, "dashboard.json")
 	})
 }
 

--- a/pkg/tests/apis/provisioning/git/files_test.go
+++ b/pkg/tests/apis/provisioning/git/files_test.go
@@ -54,9 +54,7 @@ func TestIntegrationGitFiles_CreateFile(t *testing.T) {
 		// Trigger sync and verify dashboard is created
 		helper.SyncAndWait(t, repoName)
 
-		helper.RequireDashboards(t, "test-dashboard-1")
-		dash, err := helper.DashboardsV1.Resource.Get(t.Context(), "test-dashboard-1", metav1.GetOptions{})
-		require.NoError(t, err)
+		dash := helper.RequireDashboards(t, "test-dashboard-1")[0]
 		require.Equal(t, repoName, dash.GetAnnotations()[utils.AnnoKeyManagerIdentity])
 	})
 

--- a/pkg/tests/apis/provisioning/git/files_test.go
+++ b/pkg/tests/apis/provisioning/git/files_test.go
@@ -56,22 +56,10 @@ func TestIntegrationGitFiles_CreateFile(t *testing.T) {
 		// Trigger sync and verify dashboard is created
 		helper.SyncAndWait(t, repoName)
 
-		require.EventuallyWithT(t, func(collect *assert.CollectT) {
-			dashboards, err := helper.DashboardsV1.Resource.List(t.Context(), metav1.ListOptions{})
-			if !assert.NoError(collect, err) {
-				return
-			}
-
-			found := false
-			for _, dash := range dashboards.Items {
-				if dash.GetName() == "test-dashboard-1" {
-					found = true
-					assert.Equal(collect, repoName, dash.GetAnnotations()[utils.AnnoKeyManagerIdentity])
-					break
-				}
-			}
-			assert.True(collect, found, "dashboard should be synced to Grafana")
-		}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "dashboard should appear after sync")
+		helper.RequireDashboards(t, "test-dashboard-1")
+		dash, err := helper.DashboardsV1.Resource.Get(t.Context(), "test-dashboard-1", metav1.GetOptions{})
+		require.NoError(t, err)
+		require.Equal(t, repoName, dash.GetAnnotations()[utils.AnnoKeyManagerIdentity])
 	})
 
 	t.Run("create file on new branch", func(t *testing.T) {

--- a/pkg/tests/apis/provisioning/jobs/deletejob_test.go
+++ b/pkg/tests/apis/provisioning/jobs/deletejob_test.go
@@ -9,8 +9,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
@@ -182,15 +180,8 @@ func TestIntegrationProvisioning_DeleteJob(t *testing.T) {
 			}
 			helper.TriggerJobAndWaitForSuccess(t, repo, spec)
 
-			// FIXME: use helpers
 			// Verify both dashboards are removed from Grafana
-			_, err := helper.DashboardsV1.Resource.Get(t.Context(), "resourceref2", metav1.GetOptions{})
-			require.Error(t, err, "text-options dashboard should be deleted")
-			require.True(t, apierrors.IsNotFound(err))
-
-			_, err = helper.DashboardsV1.Resource.Get(t.Context(), "resourceref3", metav1.GetOptions{})
-			require.Error(t, err, "timeline-demo dashboard should be deleted")
-			require.True(t, apierrors.IsNotFound(err))
+			helper.RequireDashboardsNotFound(t, "resourceref2", "resourceref3")
 
 			// Verify corresponding files are deleted from repository
 			helper.RequireRepoFileNotFound(t, repo, "resource-test-2.json")
@@ -233,17 +224,11 @@ func TestIntegrationProvisioning_DeleteJob(t *testing.T) {
 
 			helper.TriggerJobAndWaitForSuccess(t, repo, spec)
 
-			// FIXME: use the helpers
 			// Verify both targeted resources are deleted from Grafana
-			_, err := helper.DashboardsV1.Resource.Get(t.Context(), "resourceref1", metav1.GetOptions{})
-			require.Error(t, err, "dashboard deleted by path should be removed")
-
-			_, err = helper.DashboardsV1.Resource.Get(t.Context(), "resourceref2", metav1.GetOptions{})
-			require.Error(t, err, "dashboard deleted by resource ref should be removed")
+			helper.RequireDashboardsNotFound(t, "resourceref1", "resourceref2")
 
 			// Verify the untargeted resource still exists
-			_, err = helper.DashboardsV1.Resource.Get(t.Context(), "resourceref3", metav1.GetOptions{})
-			require.NoError(t, err, "untargeted dashboard should still exist")
+			helper.RequireDashboards(t, "resourceref3")
 
 			// Verify files are properly deleted/preserved in repository
 			helper.RequireRepoFileNotFound(t, repo, "mixed-test-1.json")
@@ -292,11 +277,8 @@ func TestIntegrationProvisioning_DeleteJob(t *testing.T) {
 			}
 			helper.TriggerJobAndWaitForSuccess(t, repo, spec)
 
-			// FIXME: use helpers
 			// Verify folder is deleted from Grafana
-			_, err := helper.Folders.Resource.Get(t.Context(), testFolderName, metav1.GetOptions{})
-			require.Error(t, err, "folder should be deleted from Grafana")
-			require.True(t, apierrors.IsNotFound(err), "should be not found error")
+			helper.RequireFoldersNotFound(t, testFolderName)
 
 			// Verify folder contents are also deleted from repository
 			helper.RequireRepoFileNotFound(t, repo, "test-folder", "dashboard-in-folder.json")

--- a/pkg/tests/apis/provisioning/jobs/deletejob_test.go
+++ b/pkg/tests/apis/provisioning/jobs/deletejob_test.go
@@ -270,9 +270,7 @@ func TestIntegrationProvisioning_DeleteJob(t *testing.T) {
 			// Verify folder was created in Grafana as a Folder resource.
 			// Folder names are generated with suffixes, so resolve the folder
 			// through the dashboard that lives inside it.
-			helper.RequireDashboards(t, "folder-dash")
-			dash, err := helper.DashboardsV1.Resource.Get(t.Context(), "folder-dash", metav1.GetOptions{})
-			require.NoError(t, err)
+			dash := helper.RequireDashboards(t, "folder-dash")[0]
 			testFolderName := dash.GetAnnotations()[utils.AnnoKeyFolder]
 			require.True(t, strings.HasPrefix(testFolderName, "test-folder"), "test-folder should exist as a Folder resource")
 
@@ -295,7 +293,7 @@ func TestIntegrationProvisioning_DeleteJob(t *testing.T) {
 
 			// FIXME: use helpers
 			// Verify folder is deleted from Grafana
-			_, err = helper.Folders.Resource.Get(t.Context(), testFolderName, metav1.GetOptions{})
+			_, err := helper.Folders.Resource.Get(t.Context(), testFolderName, metav1.GetOptions{})
 			require.Error(t, err, "folder should be deleted from Grafana")
 			require.True(t, apierrors.IsNotFound(err), "should be not found error")
 

--- a/pkg/tests/apis/provisioning/jobs/deletejob_test.go
+++ b/pkg/tests/apis/provisioning/jobs/deletejob_test.go
@@ -80,11 +80,8 @@ func TestIntegrationProvisioning_DeleteJob(t *testing.T) {
 		require.Error(t, err, "file should be deleted from repository")
 		require.True(t, apierrors.IsNotFound(err), "should be not found error")
 
-		// FIXME: create a helper to verify grafana resources
 		// Verify dashboard is removed from Grafana after sync
-		dashboards, err := helper.DashboardsV1.Resource.List(t.Context(), metav1.ListOptions{})
-		require.NoError(t, err)
-		require.Equal(t, 2, len(dashboards.Items), "should have 2 dashboards after delete")
+		helper.RequireRepoDashboardCount(t, repo, 2)
 
 		// Verify other files still exist
 		_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "dashboard2.json")
@@ -113,9 +110,7 @@ func TestIntegrationProvisioning_DeleteJob(t *testing.T) {
 		require.True(t, apierrors.IsNotFound(err))
 
 		// Verify all dashboards are removed from Grafana after sync
-		dashboards, err := helper.DashboardsV1.Resource.List(t.Context(), metav1.ListOptions{})
-		require.NoError(t, err)
-		require.Equal(t, 0, len(dashboards.Items), "should have 0 dashboards after deleting all")
+		helper.RequireRepoDashboardCount(t, repo, 0)
 	})
 
 	t.Run("delete by resource reference", func(t *testing.T) {
@@ -151,14 +146,7 @@ func TestIntegrationProvisioning_DeleteJob(t *testing.T) {
 		helper.SyncAndWait(t, repo, nil)
 
 		// Verify the new resources are created
-		dashboards, err := helper.DashboardsV1.Resource.List(t.Context(), metav1.ListOptions{})
-		require.NoError(t, err)
-		require.GreaterOrEqual(t, len(dashboards.Items), 3, "should have at least 3 dashboards after adding test resources")
-
-		// Debug: print the actual dashboard names/UIDs to verify they match our expectations
-		for i, dashboard := range dashboards.Items {
-			t.Logf("Dashboard %d: name=%s, UID=%s", i+1, dashboard.GetName(), dashboard.GetUID())
-		}
+		helper.RequireRepoDashboardCount(t, repo, 3)
 
 		t.Run("delete single dashboard by resource reference", func(t *testing.T) {
 			spec := provisioning.JobSpec{
@@ -178,14 +166,12 @@ func TestIntegrationProvisioning_DeleteJob(t *testing.T) {
 
 			// FIXME: use helpers
 			// Verify corresponding file is deleted from repository
-			_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "resource-test-1.json")
+			_, err := helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "resource-test-1.json")
 			require.Error(t, err, "file should be deleted from repository")
 			require.True(t, apierrors.IsNotFound(err), "should be not found error")
 
 			// Verify dashboard is removed from Grafana (check count like other successful tests)
-			dashboards, err = helper.DashboardsV1.Resource.List(t.Context(), metav1.ListOptions{})
-			require.NoError(t, err)
-			require.Equal(t, 2, len(dashboards.Items), "should have 2 dashboards after deleting 1 from 3")
+			helper.RequireRepoDashboardCount(t, repo, 2)
 
 			// Verify other resources still exist
 			_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "resource-test-2.json")
@@ -216,7 +202,7 @@ func TestIntegrationProvisioning_DeleteJob(t *testing.T) {
 
 			// FIXME: use helpers
 			// Verify both dashboards are removed from Grafana
-			_, err = helper.DashboardsV1.Resource.Get(t.Context(), "resourceref2", metav1.GetOptions{})
+			_, err := helper.DashboardsV1.Resource.Get(t.Context(), "resourceref2", metav1.GetOptions{})
 			require.Error(t, err, "text-options dashboard should be deleted")
 			require.True(t, apierrors.IsNotFound(err))
 
@@ -232,9 +218,7 @@ func TestIntegrationProvisioning_DeleteJob(t *testing.T) {
 			require.Error(t, err, "nested/resource-test-3.json should be deleted")
 
 			// Verify specific dashboards are removed from Grafana
-			dashboards, err = helper.DashboardsV1.Resource.List(t.Context(), metav1.ListOptions{})
-			require.NoError(t, err)
-			require.Equal(t, 0, len(dashboards.Items), "should have 0 dashboards after deleting 2 more (2 -> 0)")
+			helper.RequireRepoDashboardCount(t, repo, 0)
 		})
 
 		t.Run("mixed deletion - paths and resources", func(t *testing.T) {
@@ -272,7 +256,7 @@ func TestIntegrationProvisioning_DeleteJob(t *testing.T) {
 
 			// FIXME: use the helpers
 			// Verify both targeted resources are deleted from Grafana
-			_, err = helper.DashboardsV1.Resource.Get(t.Context(), "resourceref1", metav1.GetOptions{})
+			_, err := helper.DashboardsV1.Resource.Get(t.Context(), "resourceref1", metav1.GetOptions{})
 			require.Error(t, err, "dashboard deleted by path should be removed")
 
 			_, err = helper.DashboardsV1.Resource.Get(t.Context(), "resourceref2", metav1.GetOptions{})
@@ -310,11 +294,8 @@ func TestIntegrationProvisioning_DeleteJob(t *testing.T) {
 			helper.SyncAndWait(t, repo, nil)
 
 			// Verify folder was created in Grafana as a Folder resource
-			folders, err := helper.Folders.Resource.List(t.Context(), metav1.ListOptions{})
-			require.NoError(t, err)
-
 			var testFolder *unstructured.Unstructured
-			for _, folder := range folders.Items {
+			for _, folder := range helper.ListRepoFolders(t, repo) {
 				// Folder names are generated with suffixes, so check if it starts with "test-folder"
 				if strings.HasPrefix(folder.GetName(), "test-folder") {
 					testFolder = &folder
@@ -325,7 +306,7 @@ func TestIntegrationProvisioning_DeleteJob(t *testing.T) {
 			testFolderName := testFolder.GetName()
 
 			// Verify dashboard inside the folder exists
-			_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "test-folder", "dashboard-in-folder.json")
+			_, err := helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "test-folder", "dashboard-in-folder.json")
 			require.NoError(t, err, "dashboard inside folder should exist")
 
 			spec := provisioning.JobSpec{

--- a/pkg/tests/apis/provisioning/jobs/deletejob_test.go
+++ b/pkg/tests/apis/provisioning/jobs/deletejob_test.go
@@ -273,6 +273,7 @@ func TestIntegrationProvisioning_DeleteJob(t *testing.T) {
 			dash := helper.RequireDashboards(t, "folder-dash")[0]
 			testFolderName := dash.GetAnnotations()[utils.AnnoKeyFolder]
 			require.True(t, strings.HasPrefix(testFolderName, "test-folder"), "test-folder should exist as a Folder resource")
+			helper.RequireFolders(t, testFolderName)
 
 			// Verify dashboard inside the folder exists
 			helper.RequireRepoFileExists(t, repo, "test-folder", "dashboard-in-folder.json")

--- a/pkg/tests/apis/provisioning/jobs/deletejob_test.go
+++ b/pkg/tests/apis/provisioning/jobs/deletejob_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 )
 
@@ -267,17 +267,14 @@ func TestIntegrationProvisioning_DeleteJob(t *testing.T) {
 			// Sync to create the folder and its contents
 			helper.SyncAndWait(t, repo, nil)
 
-			// Verify folder was created in Grafana as a Folder resource
-			var testFolder *unstructured.Unstructured
-			for _, folder := range helper.ListRepoFolders(t, repo) {
-				// Folder names are generated with suffixes, so check if it starts with "test-folder"
-				if strings.HasPrefix(folder.GetName(), "test-folder") {
-					testFolder = &folder
-					break
-				}
-			}
-			require.NotNil(t, testFolder, "test-folder should exist as a Folder resource")
-			testFolderName := testFolder.GetName()
+			// Verify folder was created in Grafana as a Folder resource.
+			// Folder names are generated with suffixes, so resolve the folder
+			// through the dashboard that lives inside it.
+			helper.RequireDashboards(t, "folder-dash")
+			dash, err := helper.DashboardsV1.Resource.Get(t.Context(), "folder-dash", metav1.GetOptions{})
+			require.NoError(t, err)
+			testFolderName := dash.GetAnnotations()[utils.AnnoKeyFolder]
+			require.True(t, strings.HasPrefix(testFolderName, "test-folder"), "test-folder should exist as a Folder resource")
 
 			// Verify dashboard inside the folder exists
 			helper.RequireRepoFileExists(t, repo, "test-folder", "dashboard-in-folder.json")
@@ -298,7 +295,7 @@ func TestIntegrationProvisioning_DeleteJob(t *testing.T) {
 
 			// FIXME: use helpers
 			// Verify folder is deleted from Grafana
-			_, err := helper.Folders.Resource.Get(t.Context(), testFolderName, metav1.GetOptions{})
+			_, err = helper.Folders.Resource.Get(t.Context(), testFolderName, metav1.GetOptions{})
 			require.Error(t, err, "folder should be deleted from Grafana")
 			require.True(t, apierrors.IsNotFound(err), "should be not found error")
 

--- a/pkg/tests/apis/provisioning/jobs/deletejob_test.go
+++ b/pkg/tests/apis/provisioning/jobs/deletejob_test.go
@@ -58,8 +58,7 @@ func TestIntegrationProvisioning_DeleteJob(t *testing.T) {
 		helper.DebugState(t, repo, "BEFORE DELETE")
 
 		// Verify file exists in repository before attempting delete
-		_, err := helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "dashboard1.json")
-		require.NoError(t, err, "dashboard1.json should exist in repository before delete")
+		helper.RequireRepoFileExists(t, repo, "dashboard1.json")
 
 		spec := provisioning.JobSpec{
 			Action: provisioning.JobActionDelete,
@@ -73,21 +72,15 @@ func TestIntegrationProvisioning_DeleteJob(t *testing.T) {
 		// Debug state after successful delete
 		helper.DebugState(t, repo, "AFTER DELETE")
 
-		// FIXME: create a helper to verify repository files
-
 		// Verify file is deleted from repository
-		_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "dashboard1.json")
-		require.Error(t, err, "file should be deleted from repository")
-		require.True(t, apierrors.IsNotFound(err), "should be not found error")
+		helper.RequireRepoFileNotFound(t, repo, "dashboard1.json")
 
 		// Verify dashboard is removed from Grafana after sync
 		helper.RequireRepoDashboardCount(t, repo, 2)
 
 		// Verify other files still exist
-		_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "dashboard2.json")
-		require.NoError(t, err, "other files should still exist")
-		_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "folder", "dashboard3.json")
-		require.NoError(t, err, "nested files should still exist")
+		helper.RequireRepoFileExists(t, repo, "dashboard2.json")
+		helper.RequireRepoFileExists(t, repo, "folder", "dashboard3.json")
 	})
 
 	t.Run("delete multiple files", func(t *testing.T) {
@@ -99,15 +92,9 @@ func TestIntegrationProvisioning_DeleteJob(t *testing.T) {
 		}
 		helper.TriggerJobAndWaitForSuccess(t, repo, spec)
 
-		// FIXME: use helper
 		// Verify files are deleted from repository
-		_, err := helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "dashboard2.json")
-		require.Error(t, err, "dashboard2.json should be deleted")
-		require.True(t, apierrors.IsNotFound(err))
-
-		_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "folder", "dashboard3.json")
-		require.Error(t, err, "folder/dashboard3.json should be deleted")
-		require.True(t, apierrors.IsNotFound(err))
+		helper.RequireRepoFileNotFound(t, repo, "dashboard2.json")
+		helper.RequireRepoFileNotFound(t, repo, "folder", "dashboard3.json")
 
 		// Verify all dashboards are removed from Grafana after sync
 		helper.RequireRepoDashboardCount(t, repo, 0)
@@ -164,20 +151,15 @@ func TestIntegrationProvisioning_DeleteJob(t *testing.T) {
 
 			helper.TriggerJobAndWaitForSuccess(t, repo, spec)
 
-			// FIXME: use helpers
 			// Verify corresponding file is deleted from repository
-			_, err := helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "resource-test-1.json")
-			require.Error(t, err, "file should be deleted from repository")
-			require.True(t, apierrors.IsNotFound(err), "should be not found error")
+			helper.RequireRepoFileNotFound(t, repo, "resource-test-1.json")
 
 			// Verify dashboard is removed from Grafana (check count like other successful tests)
 			helper.RequireRepoDashboardCount(t, repo, 2)
 
 			// Verify other resources still exist
-			_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "resource-test-2.json")
-			require.NoError(t, err, "other files should still exist")
-			_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "nested", "resource-test-3.json")
-			require.NoError(t, err, "nested files should still exist")
+			helper.RequireRepoFileExists(t, repo, "resource-test-2.json")
+			helper.RequireRepoFileExists(t, repo, "nested", "resource-test-3.json")
 		})
 
 		t.Run("delete multiple resources by reference", func(t *testing.T) {
@@ -211,11 +193,8 @@ func TestIntegrationProvisioning_DeleteJob(t *testing.T) {
 			require.True(t, apierrors.IsNotFound(err))
 
 			// Verify corresponding files are deleted from repository
-			_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "resource-test-2.json")
-			require.Error(t, err, "resource-test-2.json should be deleted")
-
-			_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "nested", "resource-test-3.json")
-			require.Error(t, err, "nested/resource-test-3.json should be deleted")
+			helper.RequireRepoFileNotFound(t, repo, "resource-test-2.json")
+			helper.RequireRepoFileNotFound(t, repo, "nested", "resource-test-3.json")
 
 			// Verify specific dashboards are removed from Grafana
 			helper.RequireRepoDashboardCount(t, repo, 0)
@@ -267,14 +246,9 @@ func TestIntegrationProvisioning_DeleteJob(t *testing.T) {
 			require.NoError(t, err, "untargeted dashboard should still exist")
 
 			// Verify files are properly deleted/preserved in repository
-			_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "mixed-test-1.json")
-			require.Error(t, err, "file deleted by path should be removed")
-
-			_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "mixed-test-2.json")
-			require.Error(t, err, "file for resource deleted by ref should be removed")
-
-			_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "mixed-test-3.json")
-			require.NoError(t, err, "untargeted file should still exist")
+			helper.RequireRepoFileNotFound(t, repo, "mixed-test-1.json")
+			helper.RequireRepoFileNotFound(t, repo, "mixed-test-2.json")
+			helper.RequireRepoFileExists(t, repo, "mixed-test-3.json")
 		})
 
 		t.Run("delete folder by resource reference", func(t *testing.T) {
@@ -306,8 +280,7 @@ func TestIntegrationProvisioning_DeleteJob(t *testing.T) {
 			testFolderName := testFolder.GetName()
 
 			// Verify dashboard inside the folder exists
-			_, err := helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "test-folder", "dashboard-in-folder.json")
-			require.NoError(t, err, "dashboard inside folder should exist")
+			helper.RequireRepoFileExists(t, repo, "test-folder", "dashboard-in-folder.json")
 
 			spec := provisioning.JobSpec{
 				Action: provisioning.JobActionDelete,
@@ -325,14 +298,12 @@ func TestIntegrationProvisioning_DeleteJob(t *testing.T) {
 
 			// FIXME: use helpers
 			// Verify folder is deleted from Grafana
-			_, err = helper.Folders.Resource.Get(t.Context(), testFolderName, metav1.GetOptions{})
+			_, err := helper.Folders.Resource.Get(t.Context(), testFolderName, metav1.GetOptions{})
 			require.Error(t, err, "folder should be deleted from Grafana")
 			require.True(t, apierrors.IsNotFound(err), "should be not found error")
 
 			// Verify folder contents are also deleted from repository
-			_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "test-folder", "dashboard-in-folder.json")
-			require.Error(t, err, "dashboard inside deleted folder should also be deleted")
-			require.True(t, apierrors.IsNotFound(err), "should be not found error")
+			helper.RequireRepoFileNotFound(t, repo, "test-folder", "dashboard-in-folder.json")
 		})
 
 		t.Run("delete non-existent resource by reference", func(t *testing.T) {

--- a/pkg/tests/apis/provisioning/jobs/export_folders_flag_disabled_test.go
+++ b/pkg/tests/apis/provisioning/jobs/export_folders_flag_disabled_test.go
@@ -6,54 +6,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 )
-
-func createUnmanagedFolder(t *testing.T, helper *common.ProvisioningTestHelper, name, title string) {
-	t.Helper()
-	obj := &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"apiVersion": "folder.grafana.app/v1",
-			"kind":       "Folder",
-			"metadata": map[string]interface{}{
-				"name":      name,
-				"namespace": "default",
-			},
-			"spec": map[string]interface{}{
-				"title": title,
-			},
-		},
-	}
-	_, err := helper.Folders.Resource.Create(t.Context(), obj, metav1.CreateOptions{})
-	require.NoError(t, err)
-}
-
-func createUnmanagedFolderWithParent(t *testing.T, helper *common.ProvisioningTestHelper, name, title, parentUID string) {
-	t.Helper()
-	obj := &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"apiVersion": "folder.grafana.app/v1",
-			"kind":       "Folder",
-			"metadata": map[string]interface{}{
-				"name":      name,
-				"namespace": "default",
-				"annotations": map[string]interface{}{
-					"grafana.app/folder": parentUID,
-				},
-			},
-			"spec": map[string]interface{}{
-				"title": title,
-			},
-		},
-	}
-	_, err := helper.Folders.Resource.Create(t.Context(), obj, metav1.CreateOptions{})
-	require.NoError(t, err)
-}
 
 func triggerExport(t *testing.T, helper *common.ProvisioningTestHelper, repo string) *provisioning.Job {
 	t.Helper()
@@ -81,7 +38,7 @@ func TestIntegrationProvisioning_ExportJob_FolderMetadataFlagDisabled(t *testing
 			SkipSync:   true,
 		})
 
-		createUnmanagedFolder(t, helper, "no-meta-folder-uid", "no-meta-folder")
+		helper.CreateUnmanagedFolderWithName(t, "no-meta-folder-uid", "no-meta-folder", "")
 
 		job := triggerExport(t, helper, repo)
 		require.Equal(t, provisioning.JobStateSuccess, job.Status.State, "export job should succeed")
@@ -111,8 +68,8 @@ func TestIntegrationProvisioning_ExportJob_FolderMetadataFlagDisabled(t *testing
 			childUID    = "nested-no-meta-child-uid"
 			childTitle  = "nested-no-meta-child"
 		)
-		createUnmanagedFolder(t, helper, parentUID, parentTitle)
-		createUnmanagedFolderWithParent(t, helper, childUID, childTitle, parentUID)
+		helper.CreateUnmanagedFolderWithName(t, parentUID, parentTitle, "")
+		helper.CreateUnmanagedFolderWithName(t, childUID, childTitle, parentUID)
 
 		job := triggerExport(t, helper, repo)
 		require.Equal(t, provisioning.JobStateSuccess, job.Status.State, "export job should succeed")

--- a/pkg/tests/apis/provisioning/jobs/folderless_test.go
+++ b/pkg/tests/apis/provisioning/jobs/folderless_test.go
@@ -48,10 +48,7 @@ func TestIntegrationProvisioning_FolderlessSyncPlacement(t *testing.T) {
 		"folderless must not create a wrapper folder named after the repository")
 
 	// The single folder is the top-level folder derived from the subdirectory.
-	folders, err := helper.Folders.Resource.List(t.Context(), metav1.ListOptions{})
-	require.NoError(t, err)
-	require.Len(t, folders.Items, 1, "only the subdirectory should become a folder")
-	subFolder := folders.Items[0]
+	subFolder := helper.ListRepoFolders(t, repo)[0]
 	require.NotEqual(t, repo, subFolder.GetName(), "the folder must not be the repo wrapper folder")
 	require.Empty(t, subFolder.GetAnnotations()[utils.AnnoKeyFolder],
 		"the subdirectory folder must be at the top level (no parent)")

--- a/pkg/tests/apis/provisioning/jobs/folderless_test.go
+++ b/pkg/tests/apis/provisioning/jobs/folderless_test.go
@@ -48,7 +48,7 @@ func TestIntegrationProvisioning_FolderlessSyncPlacement(t *testing.T) {
 		"folderless must not create a wrapper folder named after the repository")
 
 	// The single folder is the top-level folder derived from the subdirectory.
-	subFolder := helper.ListRepoFolders(t, repo)[0]
+	subFolder := helper.RequireSingleRepoFolder(t, repo)
 	require.NotEqual(t, repo, subFolder.GetName(), "the folder must not be the repo wrapper folder")
 	require.Empty(t, subFolder.GetAnnotations()[utils.AnnoKeyFolder],
 		"the subdirectory folder must be at the top level (no parent)")

--- a/pkg/tests/apis/provisioning/jobs/movejob_test.go
+++ b/pkg/tests/apis/provisioning/jobs/movejob_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
@@ -48,21 +47,15 @@ func TestIntegrationProvisioning_MoveJob(t *testing.T) {
 		// TODO: This additional sync should not be necessary - the move job should handle sync properly
 		helper.SyncAndWait(t, repo, nil)
 
-		// FIXME: use the helpers for assertions
 		// Verify file is moved in repository
-		_, err := helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "moved", "dashboard1.json")
-		require.NoError(t, err, "file should exist at new location in repository")
+		helper.RequireRepoFileExists(t, repo, "moved", "dashboard1.json")
 
 		// Verify original file is gone from repository
-		_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "dashboard1.json")
-		require.Error(t, err, "original file should be gone from repository")
-		require.True(t, apierrors.IsNotFound(err), "should be not found error")
+		helper.RequireRepoFileNotFound(t, repo, "dashboard1.json")
 
 		// Verify other files still exist at original locations
-		_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "dashboard2.json")
-		require.NoError(t, err, "other files should still exist")
-		_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "folder", "dashboard3.json")
-		require.NoError(t, err, "nested files should still exist")
+		helper.RequireRepoFileExists(t, repo, "dashboard2.json")
+		helper.RequireRepoFileExists(t, repo, "folder", "dashboard3.json")
 
 		// Verify dashboard still exists in Grafana after sync
 		helper.RequireRepoDashboardCount(t, repo, 3)
@@ -96,19 +89,12 @@ func TestIntegrationProvisioning_MoveJob(t *testing.T) {
 		helper.SyncAndWait(t, repo, nil)
 
 		// Verify files are moved in repository
-		_, err := helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "archived", "dashboard2.json")
-		require.NoError(t, err, "dashboard2.json should exist at new location")
-		_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "archived", "folder", "dashboard3.json")
-		require.NoError(t, err, "folder/dashboard3.json should exist at new nested location")
+		helper.RequireRepoFileExists(t, repo, "archived", "dashboard2.json")
+		helper.RequireRepoFileExists(t, repo, "archived", "folder", "dashboard3.json")
 
 		// Verify original files are gone from repository
-		_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "dashboard2.json")
-		require.Error(t, err, "dashboard2.json should be gone from original location")
-		require.True(t, apierrors.IsNotFound(err))
-
-		_, err = helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "folder", "dashboard3.json")
-		require.Error(t, err, "folder should be gone from original location")
-		require.True(t, apierrors.IsNotFound(err), err.Error())
+		helper.RequireRepoFileNotFound(t, repo, "dashboard2.json")
+		helper.RequireRepoFileNotFound(t, repo, "folder", "dashboard3.json")
 
 		// Verify dashboards still exist in Grafana after sync
 		// Note: Since dashboard1.json was moved in the previous test, we now expect all 3 dashboards
@@ -252,13 +238,10 @@ func TestIntegrationProvisioning_MoveJob(t *testing.T) {
 
 			helper.TriggerJobAndWaitForSuccess(t, refRepo, spec)
 			// Verify corresponding file is moved in repository
-			_, err = helper.Repositories.Resource.Get(t.Context(), refRepo, metav1.GetOptions{}, "files", "moved-by-ref", "move-source-1.json")
-			require.NoError(t, err, "file should be moved to new location in repository")
+			helper.RequireRepoFileExists(t, refRepo, "moved-by-ref", "move-source-1.json")
 
 			// Verify original file is deleted from repository
-			_, err = helper.Repositories.Resource.Get(t.Context(), refRepo, metav1.GetOptions{}, "files", "move-source-1.json")
-			require.Error(t, err, "original file should be deleted from repository")
-			require.True(t, apierrors.IsNotFound(err), "should be not found error")
+			helper.RequireRepoFileNotFound(t, refRepo, "move-source-1.json")
 
 			// Verify dashboard still exists in Grafana (should be updated after sync)
 			helper.SyncAndWait(t, refRepo, nil)
@@ -266,8 +249,7 @@ func TestIntegrationProvisioning_MoveJob(t *testing.T) {
 			require.NoError(t, err, "dashboard should still exist in Grafana after move")
 
 			// Verify other resource still exists in original location
-			_, err = helper.Repositories.Resource.Get(t.Context(), refRepo, metav1.GetOptions{}, "files", "move-source-2.json")
-			require.NoError(t, err, "other files should still exist in original location")
+			helper.RequireRepoFileExists(t, refRepo, "move-source-2.json")
 		})
 
 		t.Run("move multiple resources by reference", func(t *testing.T) {
@@ -287,13 +269,10 @@ func TestIntegrationProvisioning_MoveJob(t *testing.T) {
 			helper.TriggerJobAndWaitForSuccess(t, refRepo, spec)
 
 			// Verify file is moved in repository
-			_, err = helper.Repositories.Resource.Get(t.Context(), refRepo, metav1.GetOptions{}, "files", "archived-by-ref", "move-source-2.json")
-			require.NoError(t, err, "file should be moved to new location")
+			helper.RequireRepoFileExists(t, refRepo, "archived-by-ref", "move-source-2.json")
 
 			// Verify original file is deleted from repository
-			_, err = helper.Repositories.Resource.Get(t.Context(), refRepo, metav1.GetOptions{}, "files", "move-source-2.json")
-			require.Error(t, err, "original file should be deleted from repository")
-			require.True(t, apierrors.IsNotFound(err), "should be not found error")
+			helper.RequireRepoFileNotFound(t, refRepo, "move-source-2.json")
 
 			// Verify dashboard still exists in Grafana after sync
 			helper.SyncAndWait(t, refRepo, nil)
@@ -315,8 +294,7 @@ func TestIntegrationProvisioning_MoveJob(t *testing.T) {
 			// Verify dashboard exists before the move
 			_, err = helper.DashboardsV1.Resource.Get(t.Context(), "movetoroot1", metav1.GetOptions{})
 			require.NoError(t, err, "dashboard should exist before move")
-			_, err = helper.Repositories.Resource.Get(t.Context(), refRepo, metav1.GetOptions{}, "files", "inner-folder", "move-to-root.json")
-			require.NoError(t, err, "file should exist in nested folder before move")
+			helper.RequireRepoFileExists(t, refRepo, "inner-folder", "move-to-root.json")
 
 			spec := provisioning.JobSpec{
 				Action: provisioning.JobActionMove,
@@ -340,13 +318,10 @@ func TestIntegrationProvisioning_MoveJob(t *testing.T) {
 			require.NoError(t, err, "dashboard should NOT be deleted when moving to root path '/'")
 
 			// The file should now live at the repository root
-			_, err = helper.Repositories.Resource.Get(t.Context(), refRepo, metav1.GetOptions{}, "files", "move-to-root.json")
-			require.NoError(t, err, "file should exist at root level after move to '/'")
+			helper.RequireRepoFileExists(t, refRepo, "move-to-root.json")
 
 			// The file should be gone from the nested folder
-			_, err = helper.Repositories.Resource.Get(t.Context(), refRepo, metav1.GetOptions{}, "files", "inner-folder", "move-to-root.json")
-			require.Error(t, err, "file should be gone from nested folder after move")
-			require.True(t, apierrors.IsNotFound(err), "should be not found error")
+			helper.RequireRepoFileNotFound(t, refRepo, "inner-folder", "move-to-root.json")
 		})
 
 		t.Run("mixed move - paths and resources", func(t *testing.T) {
@@ -383,18 +358,12 @@ func TestIntegrationProvisioning_MoveJob(t *testing.T) {
 			helper.TriggerJobAndWaitForSuccess(t, refRepo, spec)
 
 			// Verify both targeted resources are moved in repository
-			_, err = helper.Repositories.Resource.Get(t.Context(), refRepo, metav1.GetOptions{}, "files", "mixed-target", "mixed-move-1.json")
-			require.NoError(t, err, "file moved by path should exist at new location")
-
-			_, err = helper.Repositories.Resource.Get(t.Context(), refRepo, metav1.GetOptions{}, "files", "mixed-target", "mixed-move-2.json")
-			require.NoError(t, err, "file moved by resource ref should exist at new location")
+			helper.RequireRepoFileExists(t, refRepo, "mixed-target", "mixed-move-1.json")
+			helper.RequireRepoFileExists(t, refRepo, "mixed-target", "mixed-move-2.json")
 
 			// Verify files are deleted from original locations
-			_, err = helper.Repositories.Resource.Get(t.Context(), refRepo, metav1.GetOptions{}, "files", "mixed-move-1.json")
-			require.Error(t, err, "file moved by path should be deleted from original location")
-
-			_, err = helper.Repositories.Resource.Get(t.Context(), refRepo, metav1.GetOptions{}, "files", "mixed-move-2.json")
-			require.Error(t, err, "file moved by resource ref should be deleted from original location")
+			helper.RequireRepoFileNotFound(t, refRepo, "mixed-move-1.json")
+			helper.RequireRepoFileNotFound(t, refRepo, "mixed-move-2.json")
 
 			// Verify dashboards still exist in Grafana after sync
 			helper.SyncAndWait(t, refRepo, nil)

--- a/pkg/tests/apis/provisioning/jobs/movejob_test.go
+++ b/pkg/tests/apis/provisioning/jobs/movejob_test.go
@@ -58,10 +58,9 @@ func TestIntegrationProvisioning_MoveJob(t *testing.T) {
 		helper.RequireRepoFileExists(t, repo, "folder", "dashboard3.json")
 
 		// Verify dashboard still exists in Grafana after sync
-		helper.RequireRepoDashboardCount(t, repo, 3)
 		// Verify that dashboards have the correct source paths
 		foundPaths := make(map[string]bool)
-		for _, dashboard := range helper.ListRepoDashboards(t, repo) {
+		for _, dashboard := range helper.RequireRepoDashboardCount(t, repo, 3) {
 			sourcePath := dashboard.GetAnnotations()["grafana.app/sourcePath"]
 			foundPaths[sourcePath] = true
 		}
@@ -99,11 +98,9 @@ func TestIntegrationProvisioning_MoveJob(t *testing.T) {
 		// Verify dashboards still exist in Grafana after sync
 		// Note: Since dashboard1.json was moved in the previous test, we now expect all 3 dashboards
 		// to be accessible from their moved locations (dashboard1 from moved/, dashboard2 and dashboard3 from archived/)
-		helper.RequireRepoDashboardCount(t, repo, 3)
-
 		// Verify that dashboards have the correct source paths after cumulative moves
 		foundPaths := make(map[string]bool)
-		for _, dashboard := range helper.ListRepoDashboards(t, repo) {
+		for _, dashboard := range helper.RequireRepoDashboardCount(t, repo, 3) {
 			sourcePath := dashboard.GetAnnotations()["grafana.app/sourcePath"]
 			foundPaths[sourcePath] = true
 		}

--- a/pkg/tests/apis/provisioning/jobs/movejob_test.go
+++ b/pkg/tests/apis/provisioning/jobs/movejob_test.go
@@ -65,12 +65,10 @@ func TestIntegrationProvisioning_MoveJob(t *testing.T) {
 		require.NoError(t, err, "nested files should still exist")
 
 		// Verify dashboard still exists in Grafana after sync
-		dashboards, err := helper.DashboardsV1.Resource.List(t.Context(), metav1.ListOptions{})
-		require.NoError(t, err)
-		require.Len(t, dashboards.Items, 3, "should still have 3 dashboards after move")
+		helper.RequireRepoDashboardCount(t, repo, 3)
 		// Verify that dashboards have the correct source paths
 		foundPaths := make(map[string]bool)
-		for _, dashboard := range dashboards.Items {
+		for _, dashboard := range helper.ListRepoDashboards(t, repo) {
 			sourcePath := dashboard.GetAnnotations()["grafana.app/sourcePath"]
 			foundPaths[sourcePath] = true
 		}
@@ -115,13 +113,11 @@ func TestIntegrationProvisioning_MoveJob(t *testing.T) {
 		// Verify dashboards still exist in Grafana after sync
 		// Note: Since dashboard1.json was moved in the previous test, we now expect all 3 dashboards
 		// to be accessible from their moved locations (dashboard1 from moved/, dashboard2 and dashboard3 from archived/)
-		dashboards, err := helper.DashboardsV1.Resource.List(t.Context(), metav1.ListOptions{})
-		require.NoError(t, err)
-		require.Len(t, dashboards.Items, 3, "should still have 3 dashboards after move")
+		helper.RequireRepoDashboardCount(t, repo, 3)
 
 		// Verify that dashboards have the correct source paths after cumulative moves
 		foundPaths := make(map[string]bool)
-		for _, dashboard := range dashboards.Items {
+		for _, dashboard := range helper.ListRepoDashboards(t, repo) {
 			sourcePath := dashboard.GetAnnotations()["grafana.app/sourcePath"]
 			foundPaths[sourcePath] = true
 		}

--- a/pkg/tests/apis/provisioning/jobs/pending_delete_test.go
+++ b/pkg/tests/apis/provisioning/jobs/pending_delete_test.go
@@ -73,10 +73,7 @@ func TestIntegrationProvisioning_JobPendingDeleteLabel_SkipsExecution(t *testing
 		"skipped job should complete with a warning")
 
 	// The dashboard must still exist because the pull was skipped.
-	dashboards, err := helper.DashboardsV1.Resource.List(t.Context(), metav1.ListOptions{})
-	require.NoError(t, err)
-	require.Len(t, dashboards.Items, 1,
-		"dashboard should be preserved because the pull job was skipped")
+	helper.RequireRepoDashboardCount(t, repoName, 1)
 
 	// Sanity-check: removing the label lets the next pull run normally and remove
 	// the dashboard that is no longer on disk.
@@ -95,8 +92,5 @@ func TestIntegrationProvisioning_JobPendingDeleteLabel_SkipsExecution(t *testing
 		Pull:   &provisioning.SyncJobOptions{},
 	})
 
-	dashboards, err = helper.DashboardsV1.Resource.List(t.Context(), metav1.ListOptions{})
-	require.NoError(t, err)
-	require.Empty(t, dashboards.Items,
-		"dashboard should be deleted once the pull job runs without the pending-delete label (the repository root folder remains)")
+	helper.RequireRepoDashboardCount(t, repoName, 0)
 }

--- a/pkg/tests/apis/provisioning/jobs/pulljob_test.go
+++ b/pkg/tests/apis/provisioning/jobs/pulljob_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
@@ -165,13 +164,7 @@ func TestIntegrationProvisioning_PullJobUnmanagedRootConflict(t *testing.T) {
 
 	// Mimic "Delete and keep resources" from the UI: ensure the
 	// release-orphan-resources finalizer is set, then delete the repo.
-	_, err = helper.Repositories.Resource.Patch(t.Context(), repo, types.JSONPatchType, []byte(`[
-		{"op": "replace", "path": "/metadata/finalizers", "value": ["cleanup", "release-orphan-resources"]}
-	]`), metav1.PatchOptions{})
-	require.NoError(t, err, "should patch finalizers")
-
-	require.NoError(t, helper.Repositories.Resource.Delete(t.Context(), repo, metav1.DeleteOptions{}))
-	helper.WaitForRepositoryDeleted(t, repo)
+	helper.ReleaseAndDeleteRepository(t, repo)
 	common.WaitForResourcesReleased(t, helper.Folders.Resource, "folders")
 
 	orphan, err := helper.Folders.Resource.Get(t.Context(), repo, metav1.GetOptions{})

--- a/pkg/tests/apis/provisioning/jobs/pulljob_test.go
+++ b/pkg/tests/apis/provisioning/jobs/pulljob_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -42,29 +41,10 @@ func TestIntegrationProvisioning_PullJobOwnershipProtection(t *testing.T) {
 		},
 	})
 
-	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		dashboards, err := helper.DashboardsV1.Resource.List(t.Context(), metav1.ListOptions{})
-		if err != nil {
-			collect.Errorf("could not list dashboards error: %s", err.Error())
-			return
-		}
-		if len(dashboards.Items) != 2 {
-			collect.Errorf("should have the expected dashboards after sync. got: %d. expected: %d", len(dashboards.Items), 2)
-			return
-		}
-		folders, err := helper.Folders.Resource.List(t.Context(), metav1.ListOptions{})
-		if err != nil {
-			collect.Errorf("could not list folders: error: %s", err.Error())
-			return
-		}
-		if len(folders.Items) != 2 {
-			collect.Errorf("should have the expected folders after sync. got: %d. expected: %d", len(folders.Items), 2)
-			return
-		}
-
-		assert.Len(collect, dashboards.Items, 2)
-		assert.Len(collect, folders.Items, 2)
-	}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "should have the expected dashboards and folders after sync")
+	helper.RequireRepoDashboardCount(t, repo1, 1)
+	helper.RequireRepoFolderCount(t, repo1, 1)
+	helper.RequireRepoDashboardCount(t, repo2, 1)
+	helper.RequireRepoFolderCount(t, repo2, 1)
 
 	// Test: Pull job should fail when trying to manage resources owned by another repository
 	t.Run("pull job should fail when trying to manage resources owned by another repository", func(t *testing.T) {

--- a/pkg/tests/apis/provisioning/librarypanels_test.go
+++ b/pkg/tests/apis/provisioning/librarypanels_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 // waitForSingleFolder waits until the repo's folder is listable and returns it.
@@ -137,17 +136,7 @@ func TestIntegrationLibraryPanels_UnprovisionedFolders(t *testing.T) {
 		require.Contains(t, managedFolder.GetAnnotations(), utils.AnnoKeyManagerKind, "folder should be managed")
 		require.Contains(t, managedFolder.GetAnnotations(), utils.AnnoKeyManagerIdentity, "folder should be managed")
 
-		_, err := helper.Repositories.Resource.Patch(t.Context(), repo, types.JSONPatchType, []byte(`[
-		{
-			"op": "replace",
-			"path": "/metadata/finalizers",
-			"value": ["cleanup", "release-orphan-resources"]
-		}
-		]`), metav1.PatchOptions{})
-		require.NoError(t, err, "should successfully patch finalizers")
-
-		require.NoError(t, helper.Repositories.Resource.Delete(t.Context(), repo, metav1.DeleteOptions{}))
-		helper.WaitForRepositoryDeleted(t, repo)
+		helper.ReleaseAndDeleteRepository(t, repo)
 		common.WaitForResourcesReleased(t, helper.Folders.Resource, "folders")
 
 		libraryElement := map[string]interface{}{

--- a/pkg/tests/apis/provisioning/librarypanels_test.go
+++ b/pkg/tests/apis/provisioning/librarypanels_test.go
@@ -9,32 +9,21 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/resourcepermissions"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 )
 
-// waitForSingleFolder waits until the folder List reports exactly one folder and
-// returns it. The folder List is served by the eventually-consistent search
-// index, which can briefly report zero right after an initial sync completes —
-// even though CreateLocalRepo already observed the folder — so callers must poll
-// rather than read once.
-func waitForSingleFolder(t *testing.T, helper *common.ProvisioningTestHelper) *unstructured.Unstructured {
+// waitForSingleFolder waits until the repo's folder is listable and returns it.
+// The folder List is served by the eventually-consistent search index, which
+// can briefly report zero right after an initial sync completes — even though
+// CreateLocalRepo already observed the folder — so callers must poll rather
+// than read once.
+func waitForSingleFolder(t *testing.T, helper *common.ProvisioningTestHelper, repo string) *unstructured.Unstructured {
 	t.Helper()
-	var folder *unstructured.Unstructured
-	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		folders, err := helper.Folders.Resource.List(t.Context(), metav1.ListOptions{})
-		if !assert.NoError(collect, err) {
-			return
-		}
-		if !assert.Len(collect, folders.Items, 1) {
-			return
-		}
-		folder = &folders.Items[0]
-	}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "expected exactly one folder to be listable after sync")
-	return folder
+	helper.RequireRepoFolderCount(t, repo, 1)
+	return &helper.ListRepoFolders(t, repo)[0]
 }
 
 // We currently block the creation of library panels in provisioned folders.
@@ -49,7 +38,7 @@ func TestIntegrationLibraryPanels_ProvisionedFolders(t *testing.T) {
 	helper.RequireRepoFolderCount(t, "test-repo", 1)
 
 	t.Run("should fail to create library element in provisioned folder", func(t *testing.T) {
-		managedFolderName := waitForSingleFolder(t, helper).GetName()
+		managedFolderName := waitForSingleFolder(t, helper, "test-repo").GetName()
 		libraryElement := map[string]interface{}{
 			"kind":      1,
 			"name":      "Library Panel",
@@ -69,7 +58,7 @@ func TestIntegrationLibraryPanels_ProvisionedFolders(t *testing.T) {
 
 	t.Run("should fail to patch library element, moving it in a provisioned folder", func(t *testing.T) {
 		// Getting managed folder
-		managedFolderName := waitForSingleFolder(t, helper).GetName()
+		managedFolderName := waitForSingleFolder(t, helper, "test-repo").GetName()
 
 		unmanagedFolder := &unstructured.Unstructured{
 			Object: map[string]interface{}{
@@ -143,7 +132,7 @@ func TestIntegrationLibraryPanels_UnprovisionedFolders(t *testing.T) {
 	helper.RequireRepoFolderCount(t, repo, 1)
 
 	t.Run("should create library element when folder is released", func(t *testing.T) {
-		managedFolder := waitForSingleFolder(t, helper)
+		managedFolder := waitForSingleFolder(t, helper, repo)
 		managedFolderName := managedFolder.GetName()
 		require.Contains(t, managedFolder.GetAnnotations(), utils.AnnoKeyManagerKind, "folder should be managed")
 		require.Contains(t, managedFolder.GetAnnotations(), utils.AnnoKeyManagerIdentity, "folder should be managed")

--- a/pkg/tests/apis/provisioning/librarypanels_test.go
+++ b/pkg/tests/apis/provisioning/librarypanels_test.go
@@ -14,17 +14,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-// waitForSingleFolder waits until the repo's folder is listable and returns it.
-// The folder List is served by the eventually-consistent search index, which
-// can briefly report zero right after an initial sync completes — even though
-// CreateLocalRepo already observed the folder — so callers must poll rather
-// than read once.
-func waitForSingleFolder(t *testing.T, helper *common.ProvisioningTestHelper, repo string) *unstructured.Unstructured {
-	t.Helper()
-	helper.RequireRepoFolderCount(t, repo, 1)
-	return &helper.ListRepoFolders(t, repo)[0]
-}
-
 // We currently block the creation of library panels in provisioned folders.
 func TestIntegrationLibraryPanels_ProvisionedFolders(t *testing.T) {
 	helper := sharedHelper(t)
@@ -37,7 +26,7 @@ func TestIntegrationLibraryPanels_ProvisionedFolders(t *testing.T) {
 	helper.RequireRepoFolderCount(t, "test-repo", 1)
 
 	t.Run("should fail to create library element in provisioned folder", func(t *testing.T) {
-		managedFolderName := waitForSingleFolder(t, helper, "test-repo").GetName()
+		managedFolderName := helper.RequireSingleRepoFolder(t, "test-repo").GetName()
 		libraryElement := map[string]interface{}{
 			"kind":      1,
 			"name":      "Library Panel",
@@ -57,7 +46,7 @@ func TestIntegrationLibraryPanels_ProvisionedFolders(t *testing.T) {
 
 	t.Run("should fail to patch library element, moving it in a provisioned folder", func(t *testing.T) {
 		// Getting managed folder
-		managedFolderName := waitForSingleFolder(t, helper, "test-repo").GetName()
+		managedFolderName := helper.RequireSingleRepoFolder(t, "test-repo").GetName()
 
 		unmanagedFolder := &unstructured.Unstructured{
 			Object: map[string]interface{}{
@@ -131,7 +120,7 @@ func TestIntegrationLibraryPanels_UnprovisionedFolders(t *testing.T) {
 	helper.RequireRepoFolderCount(t, repo, 1)
 
 	t.Run("should create library element when folder is released", func(t *testing.T) {
-		managedFolder := waitForSingleFolder(t, helper, repo)
+		managedFolder := helper.RequireSingleRepoFolder(t, repo)
 		managedFolderName := managedFolder.GetName()
 		require.Contains(t, managedFolder.GetAnnotations(), utils.AnnoKeyManagerKind, "folder should be managed")
 		require.Contains(t, managedFolder.GetAnnotations(), utils.AnnoKeyManagerIdentity, "folder should be managed")

--- a/pkg/tests/apis/provisioning/managed_test.go
+++ b/pkg/tests/apis/provisioning/managed_test.go
@@ -35,23 +35,7 @@ func TestIntegrationFolderManagerConsistency(t *testing.T) {
 	helper.RequireRepoFolderCount(t, repoName, 1)
 
 	// Find the managed folder created by the repo sync.
-	var managedFolderName string
-	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		folders, err := helper.Folders.Resource.List(t.Context(), metav1.ListOptions{})
-		if !assert.NoError(collect, err) {
-			return
-		}
-		for i := range folders.Items {
-			annotations := folders.Items[i].GetAnnotations()
-			if annotations[utils.AnnoKeyManagerIdentity] == repoName {
-				managedFolderName = folders.Items[i].GetName()
-				return
-			}
-		}
-		assert.Fail(collect, "managed folder not found")
-	}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "should find a folder managed by the repo")
-
-	require.NotEmpty(t, managedFolderName, "managed folder name should be set")
+	managedFolderName := helper.ListRepoFolders(t, repoName)[0].GetName()
 	t.Logf("Managed folder: %s (managed by repo %s)", managedFolderName, repoName)
 
 	t.Run("reject unmanaged dashboard in managed folder", func(t *testing.T) {

--- a/pkg/tests/apis/provisioning/managed_test.go
+++ b/pkg/tests/apis/provisioning/managed_test.go
@@ -35,7 +35,7 @@ func TestIntegrationFolderManagerConsistency(t *testing.T) {
 	helper.RequireRepoFolderCount(t, repoName, 1)
 
 	// Find the managed folder created by the repo sync.
-	managedFolderName := helper.ListRepoFolders(t, repoName)[0].GetName()
+	managedFolderName := helper.RequireSingleRepoFolder(t, repoName).GetName()
 	t.Logf("Managed folder: %s (managed by repo %s)", managedFolderName, repoName)
 
 	t.Run("reject unmanaged dashboard in managed folder", func(t *testing.T) {

--- a/pkg/tests/apis/provisioning/quota/sync_quota_test.go
+++ b/pkg/tests/apis/provisioning/quota/sync_quota_test.go
@@ -6,10 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
@@ -237,14 +235,7 @@ func TestIntegrationProvisioning_SyncQuotaHandling(t *testing.T) {
 			"exactly 1 of the 2 new dashboards should be skipped due to quota")
 
 		// Step 5: Verify partial sync — 1 new dashboard was created (total 2), 1 was skipped
-		require.EventuallyWithT(t, func(collect *assert.CollectT) {
-			dashboards, err := helper.DashboardsV1.Resource.List(t.Context(), metav1.ListOptions{})
-			if !assert.NoError(collect, err) {
-				return
-			}
-			assert.Len(collect, dashboards.Items, 2,
-				"should have 2 dashboards: the original + 1 new (the other was skipped)")
-		}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
+		helper.RequireRepoDashboardCount(t, repo, 2)
 
 		// Step 6: Verify the repo is now at quota (1 folder + 2 dashboards = 3/3)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)
@@ -332,21 +323,7 @@ func TestIntegrationProvisioning_SyncQuotaHandling(t *testing.T) {
 		// Step 5: Verify no new dashboards were created. One new folder consumes the last quota slot,
 		// so its sibling dashboard is skipped due to quota. The other folder fails creation,
 		// so its child dashboard is skipped because the parent folder could not be created.
-		require.EventuallyWithT(t, func(collect *assert.CollectT) {
-			dashboards, err := helper.DashboardsV1.Resource.List(t.Context(), metav1.ListOptions{})
-			if !assert.NoError(collect, err) {
-				return
-			}
-			var repoDashboardCount int
-			for _, d := range dashboards.Items {
-				managerID, _, _ := unstructured.NestedString(d.Object, "metadata", "annotations", "grafana.app/managerId")
-				if managerID == repo {
-					repoDashboardCount++
-				}
-			}
-			assert.Equal(collect, 2, repoDashboardCount,
-				"should still have only 2 dashboards: both new dashboards were skipped due to quota")
-		}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
+		helper.RequireRepoDashboardCount(t, repo, 2)
 
 		// Should have 4 folders: root + subfolder + subfolder/nested + 1 new (the other was skipped)
 		helper.RequireRepoFolderCount(t, repo, 4)

--- a/pkg/tests/apis/provisioning/repository/repository_test.go
+++ b/pkg/tests/apis/provisioning/repository/repository_test.go
@@ -1012,9 +1012,7 @@ func TestIntegrationProvisioning_FailInvalidSchema(t *testing.T) {
 	require.Equal(t, status.Message, "Dry run failed: Dashboard.dashboard.grafana.app \"invalid-schema-uid\" is invalid: [spec.panels.0.repeatDirection: Invalid value: conflicting values \"h\" and \"this is not an allowed value\", spec.panels.0.repeatDirection: Invalid value: conflicting values \"v\" and \"this is not an allowed value\"]")
 
 	const invalidSchemaUid = "invalid-schema-uid"
-	_, err = helper.DashboardsV1.Resource.Get(t.Context(), invalidSchemaUid, metav1.GetOptions{})
-	require.Error(t, err, "invalid dashboard shouldn't exist")
-	require.True(t, apierrors.IsNotFound(err))
+	helper.RequireDashboardsNotFound(t, invalidSchemaUid)
 
 	helper.DebugState(t, repo, "BEFORE PULL JOB WITH INVALID SCHEMA")
 
@@ -1032,9 +1030,7 @@ func TestIntegrationProvisioning_FailInvalidSchema(t *testing.T) {
 	assert.Equal(t, job.Status.Message, "completed with errors")
 	assert.Equal(t, job.Status.Errors[0], "Dashboard.dashboard.grafana.app \"invalid-schema-uid\" is invalid: [spec.panels.0.repeatDirection: Invalid value: conflicting values \"h\" and \"this is not an allowed value\", spec.panels.0.repeatDirection: Invalid value: conflicting values \"v\" and \"this is not an allowed value\"]")
 
-	_, err = helper.DashboardsV1.Resource.Get(t.Context(), invalidSchemaUid, metav1.GetOptions{})
-	require.Error(t, err, "invalid dashboard shouldn't have been created")
-	require.True(t, apierrors.IsNotFound(err))
+	helper.RequireDashboardsNotFound(t, invalidSchemaUid)
 
 	err = helper.Repositories.Resource.Delete(t.Context(), repo, metav1.DeleteOptions{}, "files", "invalid-dashboard-schema.json")
 	require.NoError(t, err, "should delete the resource file")
@@ -1710,9 +1706,7 @@ func TestIntegrationProvisioning_ImportAllPanelsFromLocalRepository(t *testing.T
 
 	// The dashboard shouldn't exist yet
 	const allPanels = "n1jR8vnnz"
-	_, err := helper.DashboardsV1.Resource.Get(t.Context(), allPanels, metav1.GetOptions{})
-	require.Error(t, err, "no all-panels dashboard should exist")
-	require.True(t, apierrors.IsNotFound(err))
+	helper.RequireDashboardsNotFound(t, allPanels)
 
 	const repo = "local-tmp"
 	// Set up the repository and the file to import.
@@ -1766,9 +1760,7 @@ func TestIntegrationProvisioning_ImportAllPanelsFromLocalRepository(t *testing.T
 	err = helper.DashboardsV1.Resource.Delete(t.Context(), allPanels, metav1.DeleteOptions{})
 	require.NoError(t, err, "user can delete")
 
-	_, err = helper.DashboardsV1.Resource.Get(t.Context(), allPanels, metav1.GetOptions{})
-	require.Error(t, err, "should delete the internal resource")
-	require.True(t, apierrors.IsNotFound(err))
+	helper.RequireDashboardsNotFound(t, allPanels)
 }
 
 func TestIntegrationProvisioning_DeleteRepositoryAndReleaseResources(t *testing.T) {
@@ -1845,9 +1837,7 @@ func TestIntegrationProvisioning_DeleteRepositoryAndCleanupClassicDashboards(t *
 
 		helper.WaitForRepositoryDeleted(t, repo)
 
-		_, err = helper.DashboardsV1.Resource.Get(t.Context(), "finalizer-remove-classic-uid", metav1.GetOptions{})
-		require.Error(t, err, "classic dashboard should be deleted by remove-orphan-resources finalizer")
-		require.True(t, apierrors.IsNotFound(err))
+		helper.RequireDashboardsNotFound(t, "finalizer-remove-classic-uid")
 	})
 
 	t.Run("release-orphan-resources finalizer releases classic dashboards", func(t *testing.T) {

--- a/pkg/tests/apis/provisioning/repository/repository_test.go
+++ b/pkg/tests/apis/provisioning/repository/repository_test.go
@@ -1118,19 +1118,9 @@ func TestIntegrationProvisioning_CreatingGitHubRepository(t *testing.T) {
 
 	// By now, we should have synced, meaning we have data to read in the local Grafana instance!
 
-	found, err := helper.DashboardsV1.Resource.List(t.Context(), metav1.ListOptions{})
-	require.NoError(t, err, "can list values")
+	helper.RequireDashboards(t, "adg5vbj", "admfz74", "adn5mxb")
 
-	names := make([]string, 0, len(found.Items))
-	for _, v := range found.Items {
-		names = append(names, v.GetName())
-	}
-	require.Len(t, names, 3, "should have three dashboards")
-	assert.Contains(t, names, "adg5vbj", "should contain dashboard.json's contents")
-	assert.Contains(t, names, "admfz74", "should contain dashboard2.yaml's contents")
-	assert.Contains(t, names, "adn5mxb", "should contain dashboard2.yaml's contents")
-
-	err = helper.Repositories.Resource.Delete(t.Context(), repo, metav1.DeleteOptions{})
+	err := helper.Repositories.Resource.Delete(t.Context(), repo, metav1.DeleteOptions{})
 	require.NoError(t, err, "should delete values")
 
 	common.WaitForResourcesDeleted(t, helper.DashboardsV1.Resource, "dashboards")

--- a/pkg/tests/apis/provisioning/repository/repository_test.go
+++ b/pkg/tests/apis/provisioning/repository/repository_test.go
@@ -1111,12 +1111,16 @@ func TestIntegrationProvisioning_CreatingGitHubRepository(t *testing.T) {
 
 	helper.CreateLocalRepo(t, testRepo)
 
-	helper.RequireRepoDashboardCount(t, repo, 3)
+	dashboards := helper.RequireRepoDashboardCount(t, repo, 3)
 	helper.RequireRepoFolderCount(t, repo, 3)
 
 	// By now, we should have synced, meaning we have data to read in the local Grafana instance!
 
-	helper.RequireDashboards(t, "adg5vbj", "admfz74", "adn5mxb")
+	names := make([]string, 0, len(dashboards))
+	for _, d := range dashboards {
+		names = append(names, d.GetName())
+	}
+	require.ElementsMatch(t, []string{"adg5vbj", "admfz74", "adn5mxb"}, names)
 
 	err := helper.Repositories.Resource.Delete(t.Context(), repo, metav1.DeleteOptions{})
 	require.NoError(t, err, "should delete values")

--- a/pkg/tests/apis/provisioning/repository/repository_test.go
+++ b/pkg/tests/apis/provisioning/repository/repository_test.go
@@ -23,7 +23,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	clientset "github.com/grafana/grafana/apps/provisioning/pkg/generated/clientset/versioned"
@@ -1068,8 +1067,7 @@ func TestIntegrationProvisioning_DashboardStrictValidationExempted(t *testing.T)
 
 	// The dry run through the files endpoint must succeed despite the unknown
 	// field, because dashboards are exempt from strict validation.
-	_, err := helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{}, "files", "dashboard-unknown-field.json")
-	require.NoError(t, err, "dry run of a dashboard with an unknown field should succeed while dashboards are exempt from strict validation")
+	helper.RequireRepoFileExists(t, repo, "dashboard-unknown-field.json")
 
 	// The dashboard must exist in Grafana after sync.
 	const dashboardUID = "dashboard-unknown-field"
@@ -1802,19 +1800,7 @@ func TestIntegrationProvisioning_DeleteRepositoryAndReleaseResources(t *testing.
 		assert.Contains(t, v.GetAnnotations(), utils.AnnoKeySourceChecksum)
 	}
 
-	_, err = helper.Repositories.Resource.Patch(t.Context(), repo, types.JSONPatchType, []byte(`[
-		{
-			"op": "replace",
-			"path": "/metadata/finalizers",
-			"value": ["cleanup", "release-orphan-resources"]
-		}
-	]`), metav1.PatchOptions{})
-	require.NoError(t, err, "should successfully patch finalizers")
-
-	err = helper.Repositories.Resource.Delete(t.Context(), repo, metav1.DeleteOptions{})
-	require.NoError(t, err, "should delete repository")
-
-	helper.WaitForRepositoryDeleted(t, repo)
+	helper.ReleaseAndDeleteRepository(t, repo)
 	common.WaitForResourcesReleased(t, helper.DashboardsV1.Resource, "dashboards")
 	common.WaitForResourcesReleased(t, helper.Folders.Resource, "folders")
 }
@@ -1888,15 +1874,7 @@ func TestIntegrationProvisioning_DeleteRepositoryAndCleanupClassicDashboards(t *
 		require.Contains(t, dashboard.GetAnnotations(), utils.AnnoKeyManagerKind)
 		require.Contains(t, dashboard.GetAnnotations(), utils.AnnoKeyManagerIdentity)
 
-		_, err = helper.Repositories.Resource.Patch(t.Context(), repo, types.JSONPatchType, []byte(`[
-			{"op": "replace", "path": "/metadata/finalizers", "value": ["cleanup", "release-orphan-resources"]}
-		]`), metav1.PatchOptions{})
-		require.NoError(t, err, "should successfully patch finalizers")
-
-		err = helper.Repositories.Resource.Delete(t.Context(), repo, metav1.DeleteOptions{})
-		require.NoError(t, err, "should delete repository")
-
-		helper.WaitForRepositoryDeleted(t, repo)
+		helper.ReleaseAndDeleteRepository(t, repo)
 
 		dashboard, err = helper.DashboardsV1.Resource.Get(t.Context(), "finalizer-release-classic-uid", metav1.GetOptions{})
 		require.NoError(t, err, "classic dashboard should still exist after release")


### PR DESCRIPTION
**What is this feature?**

Test-only cleanup of the provisioning integration suite. Replaces hand-rolled polling loops, resource counting, and repeated setup/assertion blocks with shared helpers in the common test package, and removes duplicated local copies of those helpers across test files.

**Why do we need this feature?**

Many tests asserted on instance-wide state instead of scoping to the repository under test, which caused flakes when leftover resources from other tests were present. The same logic was also reimplemented slightly differently in dozens of places, making tests harder to read and maintain. Scoping assertions to the owning repository and sharing one implementation fixes both.

**Note on assertion timing:** some assertions that previously did a single immediate check now poll with the shared wait timeout (60s). A genuinely wrong resource count used to fail instantly; it now retries until the timeout before failing. This is intentional: the instant failures were frequently false positives caused by the eventually-consistent list APIs lagging behind a completed sync, which is exactly the failure mode behind a long run of flake fixes in this suite (#127778, #127763, #127523, #127456, #126780, #128618). Real failures still report expected vs actual, they just take up to a minute longer to surface.

**Who is this feature for?**

Grafana developers who hate it when tests flake on them ❤️ 
Future developers writing new tests can use the helpers