### PR TITLE
Logs Explore: pass props getFieldLinks to context modal

### DIFF
--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -791,6 +791,7 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
           getRowContext={(row, options) => getRowContext(row, contextRow, options)}
           getRowContextQuery={getRowContextQuery}
           getLogRowContextUi={getLogRowContextUi}
+          getFieldLinks={getFieldLinks}
           logOptionsStorageKey={SETTING_KEY_ROOT}
           timeZone={timeZone}
           displayedFields={displayedFields}

--- a/public/app/features/logs/components/panel/LogLineContext.links.test.tsx
+++ b/public/app/features/logs/components/panel/LogLineContext.links.test.tsx
@@ -1,0 +1,87 @@
+import { render, waitFor } from 'test/test-utils';
+
+import { createDataFrame, FieldType, LogsSortOrder } from '@grafana/data';
+import { setTestFlags } from '@grafana/test-utils/unstable';
+import { type GetFieldLinksFn } from 'app/plugins/panel/logs/types';
+
+import { dataFrameToLogsModel } from '../../logsModel';
+
+import { LogLineContext } from './LogLineContext';
+import { LogList } from './LogList';
+
+// Render LogList as a stub so we can inspect the props LogLineContext forwards to it
+// without depending on virtualized rendering of log lines.
+jest.mock('./LogList', () => ({
+  ...jest.requireActual('./LogList'),
+  LogList: jest.fn(() => <div>LogList</div>),
+}));
+
+jest.mock('@grafana/assistant', () => ({
+  ...jest.requireActual('@grafana/assistant'),
+  useAssistant: jest.fn().mockReturnValue({
+    isLoading: false,
+    isAvailable: true,
+    openAssistant: jest.fn(),
+  }),
+}));
+
+const dispatchMock = jest.fn();
+jest.mock('app/types/store', () => ({
+  ...jest.requireActual('app/types/store'),
+  useDispatch: () => dispatchMock,
+}));
+
+const dfNow = createDataFrame({
+  fields: [
+    { name: 'time', type: FieldType.time, values: ['2019-04-26T09:28:11.352440161Z'] },
+    { name: 'message', type: FieldType.string, values: ['foo123'] },
+  ],
+});
+const row = dataFrameToLogsModel([dfNow]).rows[0];
+const timeZone = 'UTC';
+
+const getRowContext = jest.fn().mockResolvedValue({ data: [] });
+
+const getLastLogListProps = () => jest.mocked(LogList).mock.calls.at(-1)?.[0];
+
+describe('LogLineContext data links', () => {
+  beforeEach(() => {
+    setTestFlags({});
+    jest.mocked(LogList).mockClear();
+  });
+
+  test('forwards getFieldLinks to LogList so derived-field links can be resolved in the context modal', async () => {
+    const getFieldLinks: GetFieldLinksFn = jest.fn(() => []);
+
+    render(
+      <LogLineContext
+        log={row}
+        open={true}
+        onClose={() => {}}
+        getRowContext={getRowContext}
+        getFieldLinks={getFieldLinks}
+        timeZone={timeZone}
+        sortOrder={LogsSortOrder.Descending}
+      />
+    );
+
+    await waitFor(() => expect(LogList).toHaveBeenCalled());
+    expect(getLastLogListProps()?.getFieldLinks).toBe(getFieldLinks);
+  });
+
+  test('does not set getFieldLinks on LogList when none is provided', async () => {
+    render(
+      <LogLineContext
+        log={row}
+        open={true}
+        onClose={() => {}}
+        getRowContext={getRowContext}
+        timeZone={timeZone}
+        sortOrder={LogsSortOrder.Descending}
+      />
+    );
+
+    await waitFor(() => expect(LogList).toHaveBeenCalled());
+    expect(getLastLogListProps()?.getFieldLinks).toBeUndefined();
+  });
+});

--- a/public/app/features/logs/components/panel/LogLineContext.tsx
+++ b/public/app/features/logs/components/panel/LogLineContext.tsx
@@ -31,6 +31,7 @@ import { getDataSourceInstance } from '@grafana/runtime/unstable';
 import { type DataQuery, type TimeZone } from '@grafana/schema';
 import { Button, Collapse, Combobox, type ComboboxOption, InlineLabel, Modal, Stack, useTheme2 } from '@grafana/ui';
 import { splitOpen } from 'app/features/explore/state/main';
+import { type GetFieldLinksFn } from 'app/plugins/panel/logs/types';
 import { useDispatch } from 'app/types/store';
 
 import { dataFrameToLogsModel } from '../../logsModel';
@@ -56,6 +57,7 @@ interface LogLineContextProps {
     options?: LogRowContextOptions,
     cacheFilters?: boolean
   ) => Promise<DataQuery | null>;
+  getFieldLinks?: GetFieldLinksFn;
   sortOrder?: LogsSortOrder;
   runContextQuery?: () => void;
   getLogRowContextUi?: DataSourceWithLogsContextSupport['getLogRowContextUi'];
@@ -80,6 +82,7 @@ export const LogLineContext = memo(
     timeZone,
     getLogRowContextUi,
     getRowContextQuery,
+    getFieldLinks,
     onClose,
     getRowContext,
     displayedFields: displayedFieldsProp = [],
@@ -445,6 +448,7 @@ export const LogLineContext = memo(
                 displayedFields={displayedFields}
                 enableLogDetails={true}
                 eventBus={eventBusRef.current}
+                getFieldLinks={getFieldLinks}
                 infiniteScrollMode="unlimited"
                 loadMore={handleLoadMore}
                 logLineMenuCustomItems={logLineMenuCustomItems}

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -478,6 +478,7 @@ export const LogsPanel = ({ data, timeZone, fieldConfig, options, onOptionsChang
           onClose={onCloseContext}
           getRowContext={(row, options) => getLogRowContext(row, contextRow, options)}
           getLogRowContextUi={getLogRowContextUi}
+          getFieldLinks={getFieldLinks}
           logOptionsStorageKey={storageKey}
           logLineMenuCustomItems={isLogLineMenuCustomItems(logLineMenuCustomItems) ? logLineMenuCustomItems : undefined}
           timeZone={timeZone}


### PR DESCRIPTION
**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes 
- https://github.com/grafana/grafana/issues/128271

# Test
Manual browser repro for reviewers (Loki with the provisioned `traceID` derived field):
1. Explore → `gdev-loki` → query logs containing `traceID=…`.
2. Expand a line → **Links** section shows the derived-field button.
3. **Show context** → expand a line in the modal → **Links** section now appears (previously missing). Reproduce in both Explore and a dashboard Logs panel.

Before
<img width="1889" height="898" alt="Screenshot 2026-07-16 at 8 26 26 PM" src="https://github.com/user-attachments/assets/4b5e8e13-d268-4767-901e-a6d4d37fe97f" />

After
<img width="1880" height="965" alt="Screenshot 2026-07-16 at 8 23 57 PM" src="https://github.com/user-attachments/assets/dc9eb75c-448b-4f31-a9cb-dbcc14578a7a" />


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
