### PR TITLE
Provisioning: Bitbucket webhook UI

### DIFF
--- a/public/app/features/provisioning/Config/ConfigForm.tsx
+++ b/public/app/features/provisioning/Config/ConfigForm.tsx
@@ -304,7 +304,9 @@ export function ConfigForm({ data }: ConfigFormProps) {
                 <Input
                   {...register('email', {
                     required: gitFields.emailConfig.validation?.required,
+                    pattern: gitFields.emailConfig.validation?.pattern,
                   })}
+                  type="email"
                   placeholder={gitFields.emailConfig.placeholder}
                 />
               </Field>

--- a/public/app/features/provisioning/Config/ConfigForm.tsx
+++ b/public/app/features/provisioning/Config/ConfigForm.tsx
@@ -291,6 +291,23 @@ export function ConfigForm({ data }: ConfigFormProps) {
                 />
               </Field>
             )}
+            {gitFields.emailConfig && (
+              <Field
+                noMargin
+                label={gitFields.emailConfig.label}
+                required={gitFields.emailConfig.required}
+                error={errors?.email?.message}
+                invalid={!!errors?.email}
+                description={gitFields.emailConfig.description}
+              >
+                <Input
+                  {...register('email', {
+                    required: gitFields.emailConfig.validation?.required,
+                  })}
+                  placeholder={gitFields.emailConfig.placeholder}
+                />
+              </Field>
+            )}
             {hasTokenInstructions && <TokenPermissionsInfo type={type} url={watch('url')} />}
             <Field
               noMargin

--- a/public/app/features/provisioning/Config/ConfigForm.tsx
+++ b/public/app/features/provisioning/Config/ConfigForm.tsx
@@ -1,5 +1,5 @@
 import { skipToken } from '@reduxjs/toolkit/query/react';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom-v5-compat';
 
@@ -103,12 +103,24 @@ export function ConfigForm({ data }: ConfigFormProps) {
 
   const selectedConnection = connections.find((c) => c.metadata?.name === watchedConnectionName);
   const connectionWebhookDisabled = Boolean(selectedConnection?.spec?.webhook?.disabled);
+  const emailWebhookDisabled = type === 'bitbucket' && !watch('email');
 
   useEffect(() => {
     if (connectionWebhookDisabled) {
       setValue('webhook.disabled', true);
     }
   }, [connectionWebhookDisabled, setValue]);
+
+  const emailForcedDisabled = useRef(false);
+  useEffect(() => {
+    if (emailWebhookDisabled) {
+      emailForcedDisabled.current = true;
+      setValue('webhook.disabled', true);
+    } else if (emailForcedDisabled.current) {
+      emailForcedDisabled.current = false;
+      setValue('webhook.disabled', false);
+    }
+  }, [emailWebhookDisabled, setValue]);
 
   const {
     data: refsData,
@@ -453,6 +465,14 @@ export function ConfigForm({ data }: ConfigFormProps) {
             name="webhook.baseUrl"
             disabledName="webhook.disabled"
             connectionWebhookDisabled={connectionWebhookDisabled}
+            disabledReason={
+              emailWebhookDisabled
+                ? t(
+                    'provisioning.webhook-section.description-webhook-disabled-email',
+                    'Webhook integration is disabled because the Atlassian account email is not set. Set it above to enable webhooks.'
+                  )
+                : undefined
+            }
             disabledError={errors?.webhook?.disabled?.message}
           />
         )}

--- a/public/app/features/provisioning/Config/ConfigForm.tsx
+++ b/public/app/features/provisioning/Config/ConfigForm.tsx
@@ -111,16 +111,18 @@ export function ConfigForm({ data }: ConfigFormProps) {
     }
   }, [connectionWebhookDisabled, setValue]);
 
-  const emailForcedDisabled = useRef(false);
+  const preEmailWebhookDisabled = useRef<boolean | null>(null);
   useEffect(() => {
     if (emailWebhookDisabled) {
-      emailForcedDisabled.current = true;
+      if (preEmailWebhookDisabled.current === null) {
+        preEmailWebhookDisabled.current = Boolean(getValues('webhook.disabled'));
+      }
       setValue('webhook.disabled', true);
-    } else if (emailForcedDisabled.current) {
-      emailForcedDisabled.current = false;
-      setValue('webhook.disabled', false);
+    } else if (preEmailWebhookDisabled.current !== null) {
+      setValue('webhook.disabled', preEmailWebhookDisabled.current);
+      preEmailWebhookDisabled.current = null;
     }
-  }, [emailWebhookDisabled, setValue]);
+  }, [emailWebhookDisabled, setValue, getValues]);
 
   const {
     data: refsData,

--- a/public/app/features/provisioning/Config/ConfigForm.tsx
+++ b/public/app/features/provisioning/Config/ConfigForm.tsx
@@ -1,5 +1,5 @@
 import { skipToken } from '@reduxjs/toolkit/query/react';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom-v5-compat';
 
@@ -103,26 +103,13 @@ export function ConfigForm({ data }: ConfigFormProps) {
 
   const selectedConnection = connections.find((c) => c.metadata?.name === watchedConnectionName);
   const connectionWebhookDisabled = Boolean(selectedConnection?.spec?.webhook?.disabled);
-  const emailWebhookDisabled = type === 'bitbucket' && !watch('email');
+  const emailWebhookDisabled = type === 'bitbucket' && !watch('email')?.trim();
 
   useEffect(() => {
     if (connectionWebhookDisabled) {
       setValue('webhook.disabled', true);
     }
   }, [connectionWebhookDisabled, setValue]);
-
-  const preEmailWebhookDisabled = useRef<boolean | null>(null);
-  useEffect(() => {
-    if (emailWebhookDisabled) {
-      if (preEmailWebhookDisabled.current === null) {
-        preEmailWebhookDisabled.current = Boolean(getValues('webhook.disabled'));
-      }
-      setValue('webhook.disabled', true);
-    } else if (preEmailWebhookDisabled.current !== null) {
-      setValue('webhook.disabled', preEmailWebhookDisabled.current);
-      preEmailWebhookDisabled.current = null;
-    }
-  }, [emailWebhookDisabled, setValue, getValues]);
 
   const {
     data: refsData,

--- a/public/app/features/provisioning/Config/WebhookSection.test.tsx
+++ b/public/app/features/provisioning/Config/WebhookSection.test.tsx
@@ -128,6 +128,7 @@ describe('WebhookSection', () => {
       await user.click(screen.getByText('Webhook options'));
 
       expect(screen.getByRole('checkbox', { name: /disable webhook integration/i })).toBeDisabled();
+      expect(screen.getByRole('checkbox', { name: /disable webhook integration/i })).toBeChecked();
       expect(screen.getByRole('textbox')).toBeDisabled();
       expect(screen.getByText('Webhooks need an email.')).toBeInTheDocument();
     });

--- a/public/app/features/provisioning/Config/WebhookSection.test.tsx
+++ b/public/app/features/provisioning/Config/WebhookSection.test.tsx
@@ -122,6 +122,19 @@ describe('WebhookSection', () => {
   });
 
   describe('disabledReason', () => {
+    it('restores the stored value when the disabled reason goes away', async () => {
+      const { user, rerender } = render(<Wrapper />);
+
+      await user.click(screen.getByText('Webhook options'));
+      expect(screen.getByRole('checkbox', { name: /disable webhook integration/i })).not.toBeChecked();
+
+      rerender(<Wrapper disabledReason="Webhooks need an email." />);
+      expect(screen.getByRole('checkbox', { name: /disable webhook integration/i })).toBeChecked();
+
+      rerender(<Wrapper />);
+      expect(screen.getByRole('checkbox', { name: /disable webhook integration/i })).not.toBeChecked();
+    });
+
     it('disables the checkbox and URL input and shows the reason', async () => {
       const { user } = render(<Wrapper disabledReason="Webhooks need an email." />);
 

--- a/public/app/features/provisioning/Config/WebhookSection.test.tsx
+++ b/public/app/features/provisioning/Config/WebhookSection.test.tsx
@@ -7,7 +7,13 @@ import { type RepositoryFormData } from '../types';
 
 import { WebhookSection } from './WebhookSection';
 
-function Wrapper({ connectionWebhookDisabled }: { connectionWebhookDisabled?: boolean }) {
+function Wrapper({
+  connectionWebhookDisabled,
+  disabledReason,
+}: {
+  connectionWebhookDisabled?: boolean;
+  disabledReason?: string;
+}) {
   const { register, control } = useForm<RepositoryFormData>();
   return (
     <WebhookSection
@@ -16,6 +22,7 @@ function Wrapper({ connectionWebhookDisabled }: { connectionWebhookDisabled?: bo
       name="webhook.baseUrl"
       disabledName="webhook.disabled"
       connectionWebhookDisabled={connectionWebhookDisabled}
+      disabledReason={disabledReason}
     />
   );
 }
@@ -103,6 +110,26 @@ describe('WebhookSection', () => {
       expect(
         screen.getByText(/when checked, grafana will not register or receive webhook events/i)
       ).toBeInTheDocument();
+    });
+
+    it('shows the forced description when connectionWebhookDisabled is true', async () => {
+      const { user } = render(<Wrapper connectionWebhookDisabled={true} />);
+
+      await user.click(screen.getByText('Webhook options'));
+
+      expect(screen.getByText(/disabled because the referenced github app connection/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('disabledReason', () => {
+    it('disables the checkbox and URL input and shows the reason', async () => {
+      const { user } = render(<Wrapper disabledReason="Webhooks need an email." />);
+
+      await user.click(screen.getByText('Webhook options'));
+
+      expect(screen.getByRole('checkbox', { name: /disable webhook integration/i })).toBeDisabled();
+      expect(screen.getByRole('textbox')).toBeDisabled();
+      expect(screen.getByText('Webhooks need an email.')).toBeInTheDocument();
     });
   });
 

--- a/public/app/features/provisioning/Config/WebhookSection.tsx
+++ b/public/app/features/provisioning/Config/WebhookSection.tsx
@@ -36,6 +36,7 @@ export function WebhookSection<T extends FieldValues>({
         <Field noMargin invalid={!!disabledError} error={disabledError}>
           {forcedDisabled ? (
             <Checkbox
+              key="forced"
               disabled
               checked
               label={t('provisioning.webhook-section.label-webhook-disabled', 'Disable webhook integration')}
@@ -50,6 +51,7 @@ export function WebhookSection<T extends FieldValues>({
             />
           ) : (
             <Checkbox
+              key="user"
               {...register(disabledName)}
               label={t('provisioning.webhook-section.label-webhook-disabled', 'Disable webhook integration')}
               description={t(

--- a/public/app/features/provisioning/Config/WebhookSection.tsx
+++ b/public/app/features/provisioning/Config/WebhookSection.tsx
@@ -12,6 +12,7 @@ export interface WebhookSectionProps<T extends FieldValues> {
   name: Path<T>;
   disabledName: Path<T>;
   connectionWebhookDisabled?: boolean;
+  disabledReason?: string;
   disabledError?: string;
 }
 
@@ -21,39 +22,33 @@ export function WebhookSection<T extends FieldValues>({
   name,
   disabledName,
   connectionWebhookDisabled,
+  disabledReason,
   disabledError,
 }: WebhookSectionProps<T>) {
   const isPublic = checkPublicAccess();
   const webhookDisabled = Boolean(useWatch({ control, name: disabledName }));
-  const urlDisabled = webhookDisabled || Boolean(connectionWebhookDisabled);
+  const forcedDisabled = Boolean(connectionWebhookDisabled) || Boolean(disabledReason);
+  const urlDisabled = webhookDisabled || forcedDisabled;
 
   return (
     <ControlledCollapse label={t('provisioning.webhook-section.label-webhook', 'Webhook options')} isOpen={false}>
       <Stack direction="column" gap={2}>
-        <Field
-          noMargin
-          invalid={!!disabledError}
-          error={disabledError}
-          description={
-            connectionWebhookDisabled
-              ? t(
-                  'provisioning.webhook-section.description-webhook-disabled-forced',
-                  'Webhook integration is disabled because the referenced GitHub App connection has webhook integration disabled.'
-                )
-              : undefined
-          }
-        >
+        <Field noMargin invalid={!!disabledError} error={disabledError}>
           <Checkbox
             {...register(disabledName)}
-            disabled={connectionWebhookDisabled}
+            disabled={forcedDisabled}
             label={t('provisioning.webhook-section.label-webhook-disabled', 'Disable webhook integration')}
             description={
               connectionWebhookDisabled
-                ? undefined
-                : t(
+                ? t(
+                    'provisioning.webhook-section.description-webhook-disabled-forced',
+                    'Webhook integration is disabled because the referenced GitHub App connection has webhook integration disabled.'
+                  )
+                : (disabledReason ??
+                  t(
                     'provisioning.webhook-section.description-webhook-disabled',
                     'When checked, Grafana will not register or receive webhook events and will poll the repository on an interval instead. Use this when Grafana is not reachable from the public internet.'
-                  )
+                  ))
             }
           />
         </Field>

--- a/public/app/features/provisioning/Config/WebhookSection.tsx
+++ b/public/app/features/provisioning/Config/WebhookSection.tsx
@@ -34,23 +34,30 @@ export function WebhookSection<T extends FieldValues>({
     <ControlledCollapse label={t('provisioning.webhook-section.label-webhook', 'Webhook options')} isOpen={false}>
       <Stack direction="column" gap={2}>
         <Field noMargin invalid={!!disabledError} error={disabledError}>
-          <Checkbox
-            {...register(disabledName)}
-            disabled={forcedDisabled}
-            label={t('provisioning.webhook-section.label-webhook-disabled', 'Disable webhook integration')}
-            description={
-              connectionWebhookDisabled
-                ? t(
-                    'provisioning.webhook-section.description-webhook-disabled-forced',
-                    'Webhook integration is disabled because the referenced GitHub App connection has webhook integration disabled.'
-                  )
-                : (disabledReason ??
-                  t(
-                    'provisioning.webhook-section.description-webhook-disabled',
-                    'When checked, Grafana will not register or receive webhook events and will poll the repository on an interval instead. Use this when Grafana is not reachable from the public internet.'
-                  ))
-            }
-          />
+          {forcedDisabled ? (
+            <Checkbox
+              disabled
+              checked
+              label={t('provisioning.webhook-section.label-webhook-disabled', 'Disable webhook integration')}
+              description={
+                connectionWebhookDisabled
+                  ? t(
+                      'provisioning.webhook-section.description-webhook-disabled-forced',
+                      'Webhook integration is disabled because the referenced GitHub App connection has webhook integration disabled.'
+                    )
+                  : disabledReason
+              }
+            />
+          ) : (
+            <Checkbox
+              {...register(disabledName)}
+              label={t('provisioning.webhook-section.label-webhook-disabled', 'Disable webhook integration')}
+              description={t(
+                'provisioning.webhook-section.description-webhook-disabled',
+                'When checked, Grafana will not register or receive webhook events and will poll the repository on an interval instead. Use this when Grafana is not reachable from the public internet.'
+              )}
+            />
+          )}
         </Field>
         <Field
           noMargin

--- a/public/app/features/provisioning/Repository/RepositoryOverview.test.tsx
+++ b/public/app/features/provisioning/Repository/RepositoryOverview.test.tsx
@@ -21,7 +21,10 @@ jest.mock('./RepositoryPullStatusCard', () => ({
   RepositoryPullStatusCard: () => null,
 }));
 
-const createMockRepository = (spec: Partial<RepositorySpec>): Repository => ({
+const createMockRepository = (
+  spec: Partial<RepositorySpec>,
+  webhook: NonNullable<Repository['status']>['webhook'] = { id: 42, url: 'https://grafana.example/webhook' }
+): Repository => ({
   metadata: { name: 'test-repo' },
   spec: {
     title: 'Test Repository',
@@ -34,7 +37,7 @@ const createMockRepository = (spec: Partial<RepositorySpec>): Repository => ({
     health: { healthy: true, checked: Date.now() },
     sync: { state: 'success', message: [] },
     observedGeneration: 1,
-    webhook: { id: 42, url: 'https://grafana.example/webhook' },
+    webhook,
   },
 });
 
@@ -77,6 +80,35 @@ describe('RepositoryOverview', () => {
         'href',
         'https://gitlab.com/org/repo/-/hooks/42/edit'
       );
+    });
+
+    it('should link to Bitbucket webhook settings for bitbucket repositories', () => {
+      const repo = createMockRepository(
+        {
+          type: 'bitbucket',
+          bitbucket: { url: 'https://bitbucket.org/org/repo', branch: 'main' },
+        },
+        { uuid: '{9a41cbfa-9b26-45f6-8b1a-ce8f7c78b6f0}', url: 'https://grafana.example/webhook' }
+      );
+      render(<RepositoryOverview repo={repo} />);
+
+      expect(screen.getByRole('link', { name: 'View Webhook' })).toHaveAttribute(
+        'href',
+        'https://bitbucket.org/org/repo/admin/webhooks/9a41cbfa-9b26-45f6-8b1a-ce8f7c78b6f0/edit'
+      );
+    });
+
+    it('should display the webhook UUID without braces for bitbucket repositories', () => {
+      const repo = createMockRepository(
+        {
+          type: 'bitbucket',
+          bitbucket: { url: 'https://bitbucket.org/org/repo', branch: 'main' },
+        },
+        { uuid: '{9a41cbfa-9b26-45f6-8b1a-ce8f7c78b6f0}', url: 'https://grafana.example/webhook' }
+      );
+      render(<RepositoryOverview repo={repo} />);
+
+      expect(screen.getByText('9a41cbfa-9b26-45f6-8b1a-ce8f7c78b6f0')).toBeInTheDocument();
     });
 
     it('should not render the webhook link for repositories without webhook support', () => {

--- a/public/app/features/provisioning/Repository/RepositoryOverview.test.tsx
+++ b/public/app/features/provisioning/Repository/RepositoryOverview.test.tsx
@@ -94,7 +94,7 @@ describe('RepositoryOverview', () => {
 
       expect(screen.getByRole('link', { name: 'View Webhook' })).toHaveAttribute(
         'href',
-        'https://bitbucket.org/org/repo/admin/webhooks/9a41cbfa-9b26-45f6-8b1a-ce8f7c78b6f0/edit'
+        'https://bitbucket.org/org/repo/admin/webhooks/%7B9a41cbfa-9b26-45f6-8b1a-ce8f7c78b6f0%7D/edit'
       );
     });
 

--- a/public/app/features/provisioning/Repository/RepositoryOverview.tsx
+++ b/public/app/features/provisioning/Repository/RepositoryOverview.tsx
@@ -145,7 +145,9 @@ export function RepositoryOverview({ repo }: { repo: Repository }) {
                       </Text>
                     </div>
                     <div className={styles.valueColumn}>
-                      <Text variant="body">{status?.webhook?.id || status?.webhook?.uuid?.replace(/[{}]/g, '') || 'N/A'}</Text>
+                      <Text variant="body">
+                        {status?.webhook?.id || status?.webhook?.uuid?.replace(/[{}]/g, '') || 'N/A'}
+                      </Text>
                     </div>
                     <div className={styles.labelColumn}>
                       <Text color="secondary">

--- a/public/app/features/provisioning/Repository/RepositoryOverview.tsx
+++ b/public/app/features/provisioning/Repository/RepositoryOverview.tsx
@@ -250,7 +250,7 @@ function getWebhookURL(repo: Repository) {
   }
   if (spec?.type === 'bitbucket' && status?.webhook?.uuid && spec.bitbucket?.url) {
     return textUtil.sanitizeUrl(
-      `${spec.bitbucket.url}/admin/webhooks/${encodeURIComponent(status.webhook.uuid.replace(/[{}]/g, ''))}/edit`
+      `${spec.bitbucket.url}/admin/webhooks/${encodeURIComponent(status.webhook.uuid)}/edit`
     );
   }
   return undefined;

--- a/public/app/features/provisioning/Repository/RepositoryOverview.tsx
+++ b/public/app/features/provisioning/Repository/RepositoryOverview.tsx
@@ -145,7 +145,7 @@ export function RepositoryOverview({ repo }: { repo: Repository }) {
                       </Text>
                     </div>
                     <div className={styles.valueColumn}>
-                      <Text variant="body">{status?.webhook?.id ?? 'N/A'}</Text>
+                      <Text variant="body">{status?.webhook?.id || status?.webhook?.uuid?.replace(/[{}]/g, '') || 'N/A'}</Text>
                     </div>
                     <div className={styles.labelColumn}>
                       <Text color="secondary">
@@ -245,6 +245,9 @@ function getWebhookURL(repo: Repository) {
   }
   if (spec?.type === 'gitlab' && status?.webhook?.url && repoUrl) {
     return textUtil.sanitizeUrl(`${repoUrl}/-/hooks/${status.webhook?.id}/edit`);
+  }
+  if (spec?.type === 'bitbucket' && status?.webhook?.uuid && spec.bitbucket?.url) {
+    return textUtil.sanitizeUrl(`${spec.bitbucket.url}/admin/webhooks/${encodeURIComponent(status.webhook.uuid)}/edit`);
   }
   return undefined;
 }

--- a/public/app/features/provisioning/Repository/RepositoryOverview.tsx
+++ b/public/app/features/provisioning/Repository/RepositoryOverview.tsx
@@ -146,7 +146,7 @@ export function RepositoryOverview({ repo }: { repo: Repository }) {
                     </div>
                     <div className={styles.valueColumn}>
                       <Text variant="body">
-                        {status?.webhook?.id || status?.webhook?.uuid?.replace(/[{}]/g, '') || 'N/A'}
+                        {status?.webhook?.id ?? status?.webhook?.uuid?.replace(/[{}]/g, '') ?? 'N/A'}
                       </Text>
                     </div>
                     <div className={styles.labelColumn}>
@@ -249,7 +249,9 @@ function getWebhookURL(repo: Repository) {
     return textUtil.sanitizeUrl(`${repoUrl}/-/hooks/${status.webhook?.id}/edit`);
   }
   if (spec?.type === 'bitbucket' && status?.webhook?.uuid && spec.bitbucket?.url) {
-    return textUtil.sanitizeUrl(`${spec.bitbucket.url}/admin/webhooks/${encodeURIComponent(status.webhook.uuid)}/edit`);
+    return textUtil.sanitizeUrl(
+      `${spec.bitbucket.url}/admin/webhooks/${encodeURIComponent(status.webhook.uuid.replace(/[{}]/g, ''))}/edit`
+    );
   }
   return undefined;
 }

--- a/public/app/features/provisioning/Repository/RepositoryOverview.tsx
+++ b/public/app/features/provisioning/Repository/RepositoryOverview.tsx
@@ -249,9 +249,7 @@ function getWebhookURL(repo: Repository) {
     return textUtil.sanitizeUrl(`${repoUrl}/-/hooks/${status.webhook?.id}/edit`);
   }
   if (spec?.type === 'bitbucket' && status?.webhook?.uuid && spec.bitbucket?.url) {
-    return textUtil.sanitizeUrl(
-      `${spec.bitbucket.url}/admin/webhooks/${encodeURIComponent(status.webhook.uuid)}/edit`
-    );
+    return textUtil.sanitizeUrl(`${spec.bitbucket.url}/admin/webhooks/${encodeURIComponent(status.webhook.uuid)}/edit`);
   }
   return undefined;
 }

--- a/public/app/features/provisioning/Wizard/FinishStep.test.tsx
+++ b/public/app/features/provisioning/Wizard/FinishStep.test.tsx
@@ -114,6 +114,15 @@ describe('FinishStep', () => {
       expect(await screen.findByText('Webhook options')).toBeInTheDocument();
     });
 
+    it('forces webhooks off for a Bitbucket repository without an email', async () => {
+      const { user } = setup('bitbucket');
+
+      await user.click(await screen.findByText('Webhook options'));
+
+      expect(screen.getByRole('checkbox', { name: /disable webhook integration/i })).toBeDisabled();
+      expect(screen.getByText(/atlassian account email is not set/i)).toBeInTheDocument();
+    });
+
     it('does not show the webhook section for a git provider without webhooks', async () => {
       setup('git');
 

--- a/public/app/features/provisioning/Wizard/FinishStep.test.tsx
+++ b/public/app/features/provisioning/Wizard/FinishStep.test.tsx
@@ -108,10 +108,16 @@ describe('FinishStep', () => {
       expect(await screen.findByText('Webhook options')).toBeInTheDocument();
     });
 
-    it('does not show the webhook section for a git provider without webhooks', async () => {
+    it('shows the webhook section for a Bitbucket repository', async () => {
       setup('bitbucket');
 
-      expect(await screen.findByText(PR_LABEL)).toBeInTheDocument();
+      expect(await screen.findByText('Webhook options')).toBeInTheDocument();
+    });
+
+    it('does not show the webhook section for a git provider without webhooks', async () => {
+      setup('git');
+
+      expect(await screen.findByText(BRANCH_LABEL)).toBeInTheDocument();
       expect(screen.queryByText('Webhook options')).not.toBeInTheDocument();
     });
   });

--- a/public/app/features/provisioning/Wizard/FinishStep.tsx
+++ b/public/app/features/provisioning/Wizard/FinishStep.tsx
@@ -24,6 +24,7 @@ export const FinishStep = memo(function FinishStep() {
     control,
     watch,
     setValue,
+    getValues,
     formState: { errors },
   } = useFormContext<WizardFormData>();
 
@@ -60,16 +61,18 @@ export const FinishStep = memo(function FinishStep() {
     }
   }, [connectionWebhookDisabled, setValue]);
 
-  const emailForcedDisabled = useRef(false);
+  const preEmailWebhookDisabled = useRef<boolean | null>(null);
   useEffect(() => {
     if (emailWebhookDisabled) {
-      emailForcedDisabled.current = true;
+      if (preEmailWebhookDisabled.current === null) {
+        preEmailWebhookDisabled.current = Boolean(getValues('repository.webhook.disabled'));
+      }
       setValue('repository.webhook.disabled', true);
-    } else if (emailForcedDisabled.current) {
-      emailForcedDisabled.current = false;
-      setValue('repository.webhook.disabled', false);
+    } else if (preEmailWebhookDisabled.current !== null) {
+      setValue('repository.webhook.disabled', preEmailWebhookDisabled.current);
+      preEmailWebhookDisabled.current = null;
     }
-  }, [emailWebhookDisabled, setValue]);
+  }, [emailWebhookDisabled, setValue, getValues]);
 
   useEffect(() => {
     if (!hasStepError) {

--- a/public/app/features/provisioning/Wizard/FinishStep.tsx
+++ b/public/app/features/provisioning/Wizard/FinishStep.tsx
@@ -1,5 +1,5 @@
 import { skipToken } from '@reduxjs/toolkit/query';
-import { memo, useEffect, useMemo, useRef } from 'react';
+import { memo, useEffect, useMemo } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import { t } from '@grafana/i18n';
@@ -24,7 +24,6 @@ export const FinishStep = memo(function FinishStep() {
     control,
     watch,
     setValue,
-    getValues,
     formState: { errors },
   } = useFormContext<WizardFormData>();
 
@@ -36,7 +35,7 @@ export const FinishStep = memo(function FinishStep() {
     'repository.email',
   ]);
 
-  const emailWebhookDisabled = type === 'bitbucket' && !email;
+  const emailWebhookDisabled = type === 'bitbucket' && !email?.trim();
 
   const isGitBased = isGitProvider(type);
 
@@ -60,19 +59,6 @@ export const FinishStep = memo(function FinishStep() {
       setValue('repository.webhook.disabled', true);
     }
   }, [connectionWebhookDisabled, setValue]);
-
-  const preEmailWebhookDisabled = useRef<boolean | null>(null);
-  useEffect(() => {
-    if (emailWebhookDisabled) {
-      if (preEmailWebhookDisabled.current === null) {
-        preEmailWebhookDisabled.current = Boolean(getValues('repository.webhook.disabled'));
-      }
-      setValue('repository.webhook.disabled', true);
-    } else if (preEmailWebhookDisabled.current !== null) {
-      setValue('repository.webhook.disabled', preEmailWebhookDisabled.current);
-      preEmailWebhookDisabled.current = null;
-    }
-  }, [emailWebhookDisabled, setValue, getValues]);
 
   useEffect(() => {
     if (!hasStepError) {
@@ -197,7 +183,7 @@ export const FinishStep = memo(function FinishStep() {
             emailWebhookDisabled
               ? t(
                   'provisioning.webhook-section.description-webhook-disabled-email-step',
-                  'Webhook integration is disabled because the Atlassian account email is not set. Set it in the connection step to enable webhooks.'
+                  'Webhook integration is disabled because the Atlassian account email is not set. Set it in the Connect step to enable webhooks.'
                 )
               : undefined
           }

--- a/public/app/features/provisioning/Wizard/FinishStep.tsx
+++ b/public/app/features/provisioning/Wizard/FinishStep.tsx
@@ -1,5 +1,5 @@
 import { skipToken } from '@reduxjs/toolkit/query';
-import { memo, useEffect, useMemo } from 'react';
+import { memo, useEffect, useMemo, useRef } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import { t } from '@grafana/i18n';
@@ -27,12 +27,15 @@ export const FinishStep = memo(function FinishStep() {
     formState: { errors },
   } = useFormContext<WizardFormData>();
 
-  const [type, readOnly, wizardConnectionName, githubAuthType] = watch([
+  const [type, readOnly, wizardConnectionName, githubAuthType, email] = watch([
     'repository.type',
     'repository.readOnly',
     'githubApp.connectionName',
     'githubAuthType',
+    'repository.email',
   ]);
+
+  const emailWebhookDisabled = type === 'bitbucket' && !email;
 
   const isGitBased = isGitProvider(type);
 
@@ -56,6 +59,17 @@ export const FinishStep = memo(function FinishStep() {
       setValue('repository.webhook.disabled', true);
     }
   }, [connectionWebhookDisabled, setValue]);
+
+  const emailForcedDisabled = useRef(false);
+  useEffect(() => {
+    if (emailWebhookDisabled) {
+      emailForcedDisabled.current = true;
+      setValue('repository.webhook.disabled', true);
+    } else if (emailForcedDisabled.current) {
+      emailForcedDisabled.current = false;
+      setValue('repository.webhook.disabled', false);
+    }
+  }, [emailWebhookDisabled, setValue]);
 
   useEffect(() => {
     if (!hasStepError) {
@@ -176,6 +190,14 @@ export const FinishStep = memo(function FinishStep() {
           name="repository.webhook.baseUrl"
           disabledName="repository.webhook.disabled"
           connectionWebhookDisabled={connectionWebhookDisabled}
+          disabledReason={
+            emailWebhookDisabled
+              ? t(
+                  'provisioning.webhook-section.description-webhook-disabled-email-step',
+                  'Webhook integration is disabled because the Atlassian account email is not set. Set it in the connection step to enable webhooks.'
+                )
+              : undefined
+          }
           disabledError={errors?.repository?.webhook?.disabled?.message}
         />
       )}

--- a/public/app/features/provisioning/Wizard/components/RepositoryTokenInput.test.tsx
+++ b/public/app/features/provisioning/Wizard/components/RepositoryTokenInput.test.tsx
@@ -1,8 +1,7 @@
 import { FormProvider, useForm } from 'react-hook-form';
 import { render, screen } from 'test/test-utils';
 
-import { type RepoType } from '../types';
-import { type WizardFormData } from '../types';
+import { type RepoType, type WizardFormData } from '../types';
 
 import { RepositoryTokenInput } from './RepositoryTokenInput';
 

--- a/public/app/features/provisioning/Wizard/components/RepositoryTokenInput.test.tsx
+++ b/public/app/features/provisioning/Wizard/components/RepositoryTokenInput.test.tsx
@@ -1,0 +1,67 @@
+import { FormProvider, useForm } from 'react-hook-form';
+import { render, screen } from 'test/test-utils';
+
+import { type RepoType } from '../types';
+import { type WizardFormData } from '../types';
+
+import { RepositoryTokenInput } from './RepositoryTokenInput';
+
+function Wrapper({ type }: { type: RepoType }) {
+  const methods = useForm<WizardFormData>({
+    defaultValues: {
+      repository: { type, token: 'token' },
+    },
+  });
+  return (
+    <FormProvider {...methods}>
+      <RepositoryTokenInput />
+      <button onClick={methods.handleSubmit(() => {})}>Submit</button>
+    </FormProvider>
+  );
+}
+
+function setup(type: RepoType) {
+  return render(<Wrapper type={type} />);
+}
+
+describe('RepositoryTokenInput', () => {
+  it('does not render the email field for github repositories', () => {
+    setup('github');
+
+    expect(screen.queryByLabelText(/Atlassian account email/)).not.toBeInTheDocument();
+  });
+
+  describe('bitbucket email', () => {
+    it('renders the email field', () => {
+      setup('bitbucket');
+
+      expect(screen.getByLabelText(/Atlassian account email/)).toBeInTheDocument();
+    });
+
+    it('rejects an invalid email', async () => {
+      const { user } = setup('bitbucket');
+
+      await user.type(screen.getByLabelText(/Atlassian account email/), 'not-an-email');
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+      expect(await screen.findByText('Enter a valid email address')).toBeInTheDocument();
+    });
+
+    it('accepts a valid email', async () => {
+      const { user } = setup('bitbucket');
+
+      await user.type(screen.getByLabelText(/Atlassian account email/), 'you@example.com');
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+      expect(screen.queryByText('Enter a valid email address')).not.toBeInTheDocument();
+    });
+
+    it('accepts an empty email', async () => {
+      const { user } = setup('bitbucket');
+
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+      expect(screen.queryByText('Enter a valid email address')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/public/app/features/provisioning/Wizard/components/RepositoryTokenInput.tsx
+++ b/public/app/features/provisioning/Wizard/components/RepositoryTokenInput.tsx
@@ -89,6 +89,7 @@ export function RepositoryTokenInput() {
           <Input
             {...register('repository.email', gitFields.emailConfig.validation)}
             id="email"
+            type="email"
             placeholder={gitFields.emailConfig.placeholder}
           />
         </Field>

--- a/public/app/features/provisioning/Wizard/components/RepositoryTokenInput.tsx
+++ b/public/app/features/provisioning/Wizard/components/RepositoryTokenInput.tsx
@@ -77,6 +77,22 @@ export function RepositoryTokenInput() {
           />
         </Field>
       )}
+      {gitFields.emailConfig && (
+        <Field
+          noMargin
+          label={gitFields.emailConfig.label}
+          required={gitFields.emailConfig.required}
+          description={gitFields.emailConfig.description}
+          error={errors?.repository?.email?.message}
+          invalid={!!errors?.repository?.email?.message}
+        >
+          <Input
+            {...register('repository.email', gitFields.emailConfig.validation)}
+            id="email"
+            placeholder={gitFields.emailConfig.placeholder}
+          />
+        </Field>
+      )}
     </>
   );
 }

--- a/public/app/features/provisioning/Wizard/fields.ts
+++ b/public/app/features/provisioning/Wizard/fields.ts
@@ -1,5 +1,7 @@
 import { t } from '@grafana/i18n';
 
+import { w3cStandardEmailValidator } from 'app/features/admin/utils';
+
 import { type RepositoryFormData } from '../types';
 import { validateNoUserInfoInUrl } from '../utils/validators';
 
@@ -232,6 +234,12 @@ const getProviderConfigs = (): Record<RepoType, Record<string, FieldConfig>> => 
         // eslint-disable-next-line @grafana/i18n/no-untranslated-strings
         placeholder: 'you@example.com',
         required: false,
+        validation: {
+          pattern: {
+            value: w3cStandardEmailValidator,
+            message: t('provisioning.bitbucket.email-invalid', 'Enter a valid email address'),
+          },
+        },
       },
       url: {
         ...shared.url,

--- a/public/app/features/provisioning/Wizard/fields.ts
+++ b/public/app/features/provisioning/Wizard/fields.ts
@@ -223,6 +223,19 @@ const getProviderConfigs = (): Record<RepoType, Record<string, FieldConfig>> => 
           required: t('provisioning.bitbucket.token-user-required', 'Username is required'),
         },
       },
+      email: {
+        label: t('provisioning.bitbucket.email-label', 'Atlassian account email'),
+        description: t(
+          'provisioning.bitbucket.email-description',
+          'The Atlassian account email used to authenticate the Bitbucket API. Required to enable webhooks.'
+        ),
+        // eslint-disable-next-line @grafana/i18n/no-untranslated-strings
+        placeholder: 'you@example.com',
+        required: true,
+        validation: {
+          required: t('provisioning.bitbucket.email-required', 'Email is required'),
+        },
+      },
       url: {
         ...shared.url,
         description: t('provisioning.bitbucket.url-description', 'The Bitbucket repository URL'),
@@ -343,6 +356,7 @@ export const getGitProviderFields = (
   | {
       tokenConfig: FieldConfig;
       tokenUserConfig?: FieldConfig;
+      emailConfig?: FieldConfig;
       signingMethodConfig?: FieldConfig;
       signingKeyConfig?: FieldConfig;
       smimeCertificateConfig?: FieldConfig;
@@ -363,6 +377,7 @@ export const getGitProviderFields = (
   // For git providers, these fields are guaranteed to exist
   const tokenConfig = configs.token;
   const tokenUserConfig = configs.tokenUser; // Optional field, only for some providers
+  const emailConfig = configs.email; // Optional field, only for Bitbucket
   const signingMethodConfig = configs.signingMethod; // Optional, only for git-based providers
   const signingKeyConfig = configs.commitSigningKey; // Optional, only for git-based providers
   const smimeCertificateConfig = configs.smimeCertificate; // Paired with commitSigningKey when format is smime
@@ -381,6 +396,7 @@ export const getGitProviderFields = (
   return {
     tokenConfig,
     tokenUserConfig,
+    emailConfig,
     signingMethodConfig,
     signingKeyConfig,
     smimeCertificateConfig,

--- a/public/app/features/provisioning/Wizard/fields.ts
+++ b/public/app/features/provisioning/Wizard/fields.ts
@@ -1,5 +1,4 @@
 import { t } from '@grafana/i18n';
-
 import { w3cStandardEmailValidator } from 'app/features/admin/utils';
 
 import { type RepositoryFormData } from '../types';

--- a/public/app/features/provisioning/Wizard/fields.ts
+++ b/public/app/features/provisioning/Wizard/fields.ts
@@ -231,10 +231,7 @@ const getProviderConfigs = (): Record<RepoType, Record<string, FieldConfig>> => 
         ),
         // eslint-disable-next-line @grafana/i18n/no-untranslated-strings
         placeholder: 'you@example.com',
-        required: true,
-        validation: {
-          required: t('provisioning.bitbucket.email-required', 'Email is required'),
-        },
+        required: false,
       },
       url: {
         ...shared.url,

--- a/public/app/features/provisioning/Wizard/utils/getSteps.ts
+++ b/public/app/features/provisioning/Wizard/utils/getSteps.ts
@@ -16,7 +16,7 @@ export const getSteps = (type: RepoType): Array<Step<WizardStep>> => {
       name: authStepText,
       title: authStepText,
       submitOnNext: true,
-      formFields: ['repository.url', 'repository.token', 'repository.tokenUser'],
+      formFields: ['repository.url', 'repository.token', 'repository.tokenUser', 'repository.email'],
     },
     {
       id: 'connection',
@@ -125,7 +125,7 @@ export function getSyncStepStatus(state: SyncStepState): StepStatusInfo {
   return { status: 'idle' };
 }
 
-const AUTH_TYPE_FIELDS = new Set(['repository.token', 'repository.tokenUser', 'repository.url']);
+const AUTH_TYPE_FIELDS = new Set(['repository.token', 'repository.tokenUser', 'repository.url', 'repository.email']);
 
 function getEarliestErrorStep(fieldErrors: ErrorDetails[]): WizardStep {
   const formErrors = getFormErrors(fieldErrors);

--- a/public/app/features/provisioning/utils/data.ts
+++ b/public/app/features/provisioning/utils/data.ts
@@ -152,6 +152,7 @@ export const dataToSpec = (data: RepositoryFormData, connectionName?: string): R
       spec.bitbucket = {
         ...baseConfig,
         tokenUser: data.tokenUser,
+        email: data.email,
       };
       break;
     case 'git':

--- a/public/app/features/provisioning/utils/data.ts
+++ b/public/app/features/provisioning/utils/data.ts
@@ -152,7 +152,7 @@ export const dataToSpec = (data: RepositoryFormData, connectionName?: string): R
       spec.bitbucket = {
         ...baseConfig,
         tokenUser: data.tokenUser,
-        email: data.email,
+        email: data.email?.trim() || undefined,
       };
       break;
     case 'git':

--- a/public/app/features/provisioning/utils/repositoryTypes.test.ts
+++ b/public/app/features/provisioning/utils/repositoryTypes.test.ts
@@ -1,11 +1,11 @@
 import { supportsWebhooks } from './repositoryTypes';
 
 describe('supportsWebhooks', () => {
-  it.each(['github', 'githubEnterprise', 'gitlab'] as const)('should return true for %s', (type) => {
+  it.each(['github', 'githubEnterprise', 'gitlab', 'bitbucket'] as const)('should return true for %s', (type) => {
     expect(supportsWebhooks(type)).toBe(true);
   });
 
-  it.each(['bitbucket', 'git', 'local'] as const)('should return false for %s', (type) => {
+  it.each(['git', 'local'] as const)('should return false for %s', (type) => {
     expect(supportsWebhooks(type)).toBe(false);
   });
 

--- a/public/app/features/provisioning/utils/repositoryTypes.ts
+++ b/public/app/features/provisioning/utils/repositoryTypes.ts
@@ -101,8 +101,8 @@ export const isGitHubBased = (type?: RepoType): type is 'github' | 'githubEnterp
 };
 
 // Providers whose repositories can register and receive webhooks.
-export const supportsWebhooks = (type?: RepoType): type is 'github' | 'githubEnterprise' | 'gitlab' => {
-  return type === 'github' || type === 'githubEnterprise' || type === 'gitlab';
+export const supportsWebhooks = (type?: RepoType): type is 'github' | 'githubEnterprise' | 'gitlab' | 'bitbucket' => {
+  return type === 'github' || type === 'githubEnterprise' || type === 'gitlab' || type === 'bitbucket';
 };
 
 /**

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -13188,7 +13188,6 @@
       "branch-required": "Branch is required",
       "email-description": "The Atlassian account email used to authenticate the Bitbucket API. Required to enable webhooks.",
       "email-label": "Atlassian account email",
-      "email-required": "Email is required",
       "permissions": {
         "pull-requests-label": "Pull requests",
         "pull-requests-read-write": "Read and write",
@@ -14065,6 +14064,8 @@
     },
     "webhook-section": {
       "description-webhook-disabled": "When checked, Grafana will not register or receive webhook events and will poll the repository on an interval instead. Use this when Grafana is not reachable from the public internet.",
+      "description-webhook-disabled-email": "Webhook integration is disabled because the Atlassian account email is not set. Set it above to enable webhooks.",
+      "description-webhook-disabled-email-step": "Webhook integration is disabled because the Atlassian account email is not set. Set it in the connection step to enable webhooks.",
       "description-webhook-disabled-forced": "Webhook integration is disabled because the referenced GitHub App connection has webhook integration disabled.",
       "description-webhook-url": "Overrides the auto-detected URL for registering webhooks.",
       "description-webhook-url-learn-more": "Learn more",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -14065,7 +14065,7 @@
     "webhook-section": {
       "description-webhook-disabled": "When checked, Grafana will not register or receive webhook events and will poll the repository on an interval instead. Use this when Grafana is not reachable from the public internet.",
       "description-webhook-disabled-email": "Webhook integration is disabled because the Atlassian account email is not set. Set it above to enable webhooks.",
-      "description-webhook-disabled-email-step": "Webhook integration is disabled because the Atlassian account email is not set. Set it in the connection step to enable webhooks.",
+      "description-webhook-disabled-email-step": "Webhook integration is disabled because the Atlassian account email is not set. Set it in the Connect step to enable webhooks.",
       "description-webhook-disabled-forced": "Webhook integration is disabled because the referenced GitHub App connection has webhook integration disabled.",
       "description-webhook-url": "Overrides the auto-detected URL for registering webhooks.",
       "description-webhook-url-learn-more": "Learn more",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -13187,6 +13187,7 @@
     "bitbucket": {
       "branch-required": "Branch is required",
       "email-description": "The Atlassian account email used to authenticate the Bitbucket API. Required to enable webhooks.",
+      "email-invalid": "Enter a valid email address",
       "email-label": "Atlassian account email",
       "permissions": {
         "pull-requests-label": "Pull requests",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -13186,6 +13186,9 @@
   "provisioning": {
     "bitbucket": {
       "branch-required": "Branch is required",
+      "email-description": "The Atlassian account email used to authenticate the Bitbucket API. Required to enable webhooks.",
+      "email-label": "Atlassian account email",
+      "email-required": "Email is required",
       "permissions": {
         "pull-requests-label": "Pull requests",
         "pull-requests-read-write": "Read and write",


### PR DESCRIPTION
Frontend for grafana/grafana#127221, stacked on that branch.

- The Bitbucket setup wizard and repository settings gain an optional Atlassian account email input, needed for webhooks.
- Webhook options now show for Bitbucket repositories. When the email is missing, the options are greyed out with a note explaining why and where to set the email.
- The repository overview shows the Bitbucket webhook identifier and links to the webhook settings page on Bitbucket.

_PR description generated by Claude Code._
