### PR TITLE
LogsTable: Fix crash when time/body fields have config.displayName

### DIFF
--- a/public/app/plugins/panel/logstable/LogsTable.tsx
+++ b/public/app/plugins/panel/logstable/LogsTable.tsx
@@ -6,6 +6,7 @@ import {
   CoreApp,
   type DataFrame,
   type FieldConfigSource,
+  getFieldDisplayName,
   type GrafanaTheme2,
   LoadingState,
   LogsSortOrder,
@@ -87,6 +88,9 @@ export const LogsTable = ({
   const timeFieldName = logsFrame?.timeField.name ?? LOGS_DATAPLANE_TIMESTAMP_NAME;
   const levelFieldName = logsFrame?.severityField?.name ?? detectLevelField(logsFrame) ?? DATAPLANE_SEVERITY_NAME;
   const bodyFieldName = logsFrame?.bodyField.name ?? LOGS_DATAPLANE_BODY_NAME;
+  // TableNG matches sortBy.displayName against getDisplayName(field), which follows config.displayName
+  // (e.g. CloudWatch sets displayName "Time" on @timestamp). Keep raw timeFieldName for field transforms.
+  const timeFieldDisplayName = logsFrame?.timeField ? getFieldDisplayName(logsFrame.timeField) : timeFieldName;
   const permalinkedLogId = options.permalinkedLogId ?? getLogsPanelState()?.logs?.id ?? undefined;
   const initialRowIndex = getInitialRowIndex(permalinkedLogId, logsFrame);
 
@@ -102,10 +106,10 @@ export const LogsTable = ({
   // Callbacks
   const handleTableOptionsChange = useCallback(
     (newOptions: Options) => {
-      const pendingOptions = onSortOrderChange(newOptions, options.sortOrder, timeFieldName);
+      const pendingOptions = onSortOrderChange(newOptions, options.sortOrder, timeFieldDisplayName);
       onLogsTableOptionsChange?.(pendingOptions);
     },
-    [onLogsTableOptionsChange, options.sortOrder, timeFieldName]
+    [onLogsTableOptionsChange, options.sortOrder, timeFieldDisplayName]
   );
 
   const handleLogsTableOptionsChange = useCallback(
@@ -246,14 +250,17 @@ export const LogsTable = ({
     () => ({
       sortOrder: options.sortOrder ?? LogsSortOrder.Descending,
       sortBy: [
-        { displayName: timeFieldName, desc: options.sortOrder ? options.sortOrder === LogsSortOrder.Descending : true },
+        {
+          displayName: timeFieldDisplayName,
+          desc: options.sortOrder ? options.sortOrder === LogsSortOrder.Descending : true,
+        },
       ],
       fieldSelectorWidth: options.fieldSelectorWidth ?? getDefaultFieldSelectorWidth(),
       logDetailsWidth: options.logDetailsWidth ? options.logDetailsWidth : getDefaultLogDetailsWidth(),
       ...options,
       wrapText,
     }),
-    [options, timeFieldName, wrapText]
+    [options, timeFieldDisplayName, wrapText]
   );
 
   const logRows = useMemo(() => {

--- a/public/app/plugins/panel/logstable/fieldSelector/buildColumnsWithMeta.test.ts
+++ b/public/app/plugins/panel/logstable/fieldSelector/buildColumnsWithMeta.test.ts
@@ -75,4 +75,57 @@ describe('buildColumnsWithMeta', () => {
     expect(fieldNameMeta['service']).toMatchObject({ active: false, index: undefined, percentOfLinesWithLabel: 100 });
     expect(fieldNameMeta['backend']).toMatchObject({ active: true, index: 0, percentOfLinesWithLabel: 50 });
   });
+
+  it('keys columns by field.name when config.displayName differs (e.g. CloudWatch Logs)', () => {
+    // CloudWatch sets config.displayName "Time" on the time field; previously we keyed the
+    // meta store by getFieldDisplayName and then looked up by field.name — crashing on .type.
+    const frameWithDisplayNames = toDataFrame({
+      meta: {
+        type: DataFrameType.LogLines,
+      },
+      fields: [
+        {
+          name: LOGS_DATAPLANE_TIMESTAMP_NAME,
+          type: FieldType.time,
+          values: [1, 2],
+          config: { displayName: 'Time' },
+        },
+        {
+          name: LOGS_DATAPLANE_BODY_NAME,
+          type: FieldType.string,
+          values: ['log 1', 'log 2'],
+          config: { displayName: 'Line' },
+        },
+        { name: 'service', type: FieldType.string, values: ['svc-a', 'svc-b'] },
+      ],
+    });
+    const logsFrame = parseLogsFrame(frameWithDisplayNames) as LogsFrame;
+
+    const fieldNameMeta = buildColumnsWithMeta(
+      {
+        severityField: logsFrame.severityField,
+        extraFields: logsFrame.extraFields,
+        timeField: logsFrame.timeField,
+        bodyField: logsFrame.bodyField,
+      },
+      frameWithDisplayNames,
+      [LOGS_DATAPLANE_TIMESTAMP_NAME, LOGS_DATAPLANE_BODY_NAME]
+    );
+
+    expect(fieldNameMeta[LOGS_DATAPLANE_TIMESTAMP_NAME]).toMatchObject({
+      active: true,
+      index: 0,
+      type: 'TIME_FIELD',
+      percentOfLinesWithLabel: 100,
+    });
+    expect(fieldNameMeta[LOGS_DATAPLANE_BODY_NAME]).toMatchObject({
+      active: true,
+      index: 1,
+      type: 'BODY_FIELD',
+      percentOfLinesWithLabel: 100,
+    });
+    // Display names must not be used as store keys (would crash when setting .type)
+    expect(fieldNameMeta['Time']).toBeUndefined();
+    expect(fieldNameMeta['Line']).toBeUndefined();
+  });
 });

--- a/public/app/plugins/panel/logstable/fieldSelector/buildColumnsWithMeta.ts
+++ b/public/app/plugins/panel/logstable/fieldSelector/buildColumnsWithMeta.ts
@@ -1,4 +1,4 @@
-import { type DataFrame, type FieldWithIndex, getFieldDisplayName } from '@grafana/data';
+import { type DataFrame, type FieldWithIndex } from '@grafana/data';
 import { type FieldNameMeta, type FieldNameMetaStore } from 'app/features/explore/Logs/LogsTableWrap';
 import { LOG_LINE_BODY_FIELD_NAME } from 'app/features/logs/components/fieldSelector/logFields';
 
@@ -42,7 +42,10 @@ export const buildColumnsWithMeta = (
   if (dataFrame.fields.length && numberOfLogLines) {
     // Iterate through all of fields
     dataFrame.fields.forEach((field) => {
-      const fieldName = getFieldDisplayName(field);
+      // Key by field.name (not displayName) so lookups stay consistent with displayedFields,
+      // organizeFields, and Explore's LogsTableWrap — config.displayName (e.g. CloudWatch "Time")
+      // must not change the store key.
+      const fieldName = field.name;
       // Count the valid values
       const countOfValues = field.values.reduce((acc: number, value) => {
         if (value !== undefined && value !== null) {
@@ -72,7 +75,7 @@ export const buildColumnsWithMeta = (
 
   // Normalize the other fields
   otherFields.forEach((field) => {
-    const fieldName = getFieldDisplayName(field);
+    const fieldName = field.name;
     const isActive = pendingLabelState[fieldName]?.active;
     const index = pendingLabelState[fieldName]?.index;
     if (isActive && index !== undefined) {
@@ -101,8 +104,8 @@ export const buildColumnsWithMeta = (
       pendingLabelState[fieldName].active = true;
       pendingLabelState[fieldName].index = idx;
     } else if (fieldName === LOG_LINE_BODY_FIELD_NAME && logsFrameFields?.bodyField?.name) {
-      pendingLabelState[logsFrameFields.bodyField?.name].active = true;
-      pendingLabelState[logsFrameFields.bodyField?.name].index = idx;
+      pendingLabelState[logsFrameFields.bodyField.name].active = true;
+      pendingLabelState[logsFrameFields.bodyField.name].index = idx;
     } else {
       console.error(`Unknown field ${fieldName}`, { pendingLabelState, displayedFields });
     }
@@ -110,19 +113,25 @@ export const buildColumnsWithMeta = (
 
   // If nothing is selected, then select the default columns
   if (displayedFields.length === 0) {
-    if (logsFrameFields?.bodyField?.name) {
+    if (logsFrameFields?.bodyField?.name && pendingLabelState[logsFrameFields.bodyField.name]) {
       pendingLabelState[logsFrameFields.bodyField.name].index = 1;
       pendingLabelState[logsFrameFields.bodyField.name].active = true;
     }
-    if (logsFrameFields?.timeField?.name) {
+    if (logsFrameFields?.timeField?.name && pendingLabelState[logsFrameFields.timeField.name]) {
       pendingLabelState[logsFrameFields.timeField.name].index = 0;
       pendingLabelState[logsFrameFields.timeField.name].active = true;
     }
   }
 
   if (logsFrameFields?.bodyField?.name && logsFrameFields?.timeField?.name) {
-    pendingLabelState[logsFrameFields.bodyField.name].type = 'BODY_FIELD';
-    pendingLabelState[logsFrameFields.timeField.name].type = 'TIME_FIELD';
+    const bodyKey = logsFrameFields.bodyField.name;
+    const timeKey = logsFrameFields.timeField.name;
+    if (pendingLabelState[bodyKey]) {
+      pendingLabelState[bodyKey].type = 'BODY_FIELD';
+    }
+    if (pendingLabelState[timeKey]) {
+      pendingLabelState[timeKey].type = 'TIME_FIELD';
+    }
   }
 
   return pendingLabelState;


### PR DESCRIPTION
## Summary
- Fixes [#128642](https://github.com/grafana/grafana/issues/128642): logs table panel crashed with `TypeError: Cannot set properties of undefined (setting 'type')` when the time/body field had `config.displayName` set (e.g. CloudWatch Logs `Time` on `@timestamp`).
- `buildColumnsWithMeta` now keys the column meta store by `field.name` (same as Explore’s `LogsTableWrap` and `displayedFields`), instead of `getFieldDisplayName`.
- Default `sortBy` / sort-order updates use the table display name so TableNG can still match the time column when `displayName` differs from `field.name`.

## Test plan
- [x] `yarn jest --no-watch public/app/plugins/panel/logstable/fieldSelector/buildColumnsWithMeta.test.ts`
- [ ] Enable `logsTablePanelNG`, run a CloudWatch Logs Insights query in Explore, switch viz to Table — panel should render (no error boundary)
- [ ] Confirm default time-column sort still applies when the time field has `config.displayName`
- [ ] Confirm field selector still toggles columns correctly


Made with [Cursor](https://cursor.com)