### PR TITLE
AuthZ: Enforce folder on folder-scoped checks without a resource name

### DIFF
--- a/pkg/services/authz/rbac/service.go
+++ b/pkg/services/authz/rbac/service.go
@@ -959,7 +959,9 @@ func (s *Service) checkPermission(ctx context.Context, scopeMap map[string]bool,
 // translation registered in mapper.go. Behaviour is preserved verbatim from the
 // pre-fork checkPermission.
 func (s *Service) checkPermissionWithMapping(ctx context.Context, scopeMap map[string]bool, req *checkRequest, t Mapping, getTree folderTreeGetter) (bool, error) {
-	if req.Name == "" && req.Verb != utils.VerbCreate {
+	// A request with a folder but no name is a folder-scoped question, not a capabilities probe.
+	folderScoped := req.ParentFolder != "" && t.HasFolderSupport()
+	if req.Name == "" && req.Verb != utils.VerbCreate && !folderScoped {
 		// For resources that require a wildcard scope, we can perform the check immediately
 		if t.Scope("") == "*" {
 			return scopeMap["*"], nil

--- a/pkg/services/authz/rbac/service_test.go
+++ b/pkg/services/authz/rbac/service_test.go
@@ -265,6 +265,143 @@ func TestService_checkPermission(t *testing.T) {
 			expected: true,
 		},
 		{
+			name: "should allow a folder-scoped any check if user has permission on an ancestor folder",
+			permissions: []accesscontrol.Permission{
+				{
+					Action:     "dashboards:read",
+					Scope:      "folders:uid:parent",
+					Kind:       "folders",
+					Attribute:  "uid",
+					Identifier: "parent",
+				},
+			},
+			folders: []store.Folder{
+				{UID: "parent"},
+				{UID: "child", ParentUID: new("parent")},
+			},
+			check: checkRequest{
+				Action:       "dashboards:read",
+				Group:        "dashboard.grafana.app",
+				Resource:     "dashboards",
+				Name:         "",
+				ParentFolder: "child",
+				Verb:         utils.VerbList,
+			},
+			expected: true,
+		},
+		{
+			name: "should deny a folder-scoped any check if user only has permission on an unrelated folder",
+			permissions: []accesscontrol.Permission{
+				{
+					Action:     "dashboards:read",
+					Scope:      "folders:uid:other",
+					Kind:       "folders",
+					Attribute:  "uid",
+					Identifier: "other",
+				},
+			},
+			folders: []store.Folder{
+				{UID: "parent"},
+				{UID: "child", ParentUID: new("parent")},
+				{UID: "other"},
+			},
+			check: checkRequest{
+				Action:       "dashboards:read",
+				Group:        "dashboard.grafana.app",
+				Resource:     "dashboards",
+				Name:         "",
+				ParentFolder: "child",
+				Verb:         utils.VerbList,
+			},
+			expected: false,
+		},
+		{
+			name: "should allow a folder-scoped any check if user has a wildcard folder permission",
+			permissions: []accesscontrol.Permission{
+				{
+					Action:    "dashboards:read",
+					Scope:     "folders:*",
+					Kind:      "folders",
+					Attribute: "*",
+				},
+			},
+			folders: []store.Folder{{UID: "parent"}},
+			check: checkRequest{
+				Action:       "dashboards:read",
+				Group:        "dashboard.grafana.app",
+				Resource:     "dashboards",
+				Name:         "",
+				ParentFolder: "parent",
+				Verb:         utils.VerbList,
+			},
+			expected: true,
+		},
+		{
+			name: "should allow a folder-scoped set_permissions any check only via the folder",
+			permissions: []accesscontrol.Permission{
+				{
+					Action:     "dashboards.permissions:write",
+					Scope:      "folders:uid:parent",
+					Kind:       "folders",
+					Attribute:  "uid",
+					Identifier: "parent",
+				},
+			},
+			folders: []store.Folder{{UID: "parent"}},
+			check: checkRequest{
+				Action:       "dashboards.permissions:write",
+				Group:        "dashboard.grafana.app",
+				Resource:     "dashboards",
+				Name:         "",
+				ParentFolder: "parent",
+				Verb:         utils.VerbSetPermissions,
+			},
+			expected: true,
+		},
+		{
+			name: "should deny a folder-scoped set_permissions any check if the grant is on another folder",
+			permissions: []accesscontrol.Permission{
+				{
+					Action:     "dashboards.permissions:write",
+					Scope:      "folders:uid:other",
+					Kind:       "folders",
+					Attribute:  "uid",
+					Identifier: "other",
+				},
+			},
+			folders: []store.Folder{{UID: "parent"}, {UID: "other"}},
+			check: checkRequest{
+				Action:       "dashboards.permissions:write",
+				Group:        "dashboard.grafana.app",
+				Resource:     "dashboards",
+				Name:         "",
+				ParentFolder: "parent",
+				Verb:         utils.VerbSetPermissions,
+			},
+			expected: false,
+		},
+		{
+			name: "should keep capabilities semantics for any check with a folder on a non folder-supporting resource",
+			permissions: []accesscontrol.Permission{
+				{
+					Action:     "teams:read",
+					Scope:      "teams:uid:some_team",
+					Kind:       "teams",
+					Attribute:  "uid",
+					Identifier: "some_team",
+				},
+			},
+			check: checkRequest{
+				Action:       "teams:read",
+				Group:        "iam.grafana.app",
+				Resource:     "teams",
+				Name:         "",
+				ParentFolder: "some_folder",
+				Verb:         utils.VerbList,
+			},
+			expected: true,
+		},
+		{
 			name: "should return true if user has annotation create permission on dashboard (subresource)",
 			permissions: []accesscontrol.Permission{
 				{


### PR DESCRIPTION
## What is this feature?

In the authz RBAC service, `Check`/`BatchCheck` requests with an **empty resource name** (and verb != create) are answered by a "capabilities" early-return: allow if the user holds the action on *any* scope. This return ignored the request's parent folder, so callers asking a folder-scoped question — "can this user do X **within folder F**?" — got a folder-blind answer.

This PR makes such requests (empty name + non-empty folder, on a folder-supporting resource) fall through to the normal evaluation instead: wildcard grants (`folders:*`) still allow, and folder inheritance enforces the specific folder and its ancestors. Requests without a folder keep the existing capabilities semantics, so UI probes ("show the dashboards menu?") are unchanged. `BatchCheck` routes through the same code path and is covered by the same fix.

## Why do we need this feature?

Two confirmed over-grants flow from the folder-blind early-return (found while reviewing #128579):

1. **Role delegation validation** (enterprise `RolePermissionValidator.checkK8sPermission`): delegating a folder-scoped permission (e.g. `dashboards:read` on `folders:uid:X`) sends `Name="", folder=X`. The early-return allowed any user holding the action on *one* folder to delegate it on *any* folder. It now requires the grant on that folder (or an ancestor, or a wildcard).
2. **Trash visibility** (`checkFolderAdmin` in `pkg/storage/unified/resource/server.go`): sends `verb=set_permissions, Name="", folder=F` to decide folder-admin status when listing deleted items. A user holding set-permissions on any scope was treated as admin of *every* folder. It now requires the grant on that folder.

Both changes are fail-closed tightenings; no caller changes are needed. Mapper-miss (K8s-native) resources already enforce the folder via `checkPermissionWithFolderAuthz` — this aligns mapper-registered resources (dashboards, folders, librarypanels, and alert rules once #128579 lands) with that model.

## Who is this feature for?

Anyone relying on folder-scoped access control: role authors delegating permissions, and users viewing folder trash.

## Which issue(s) does this PR fix?

Related to #128579 (extends folder-aware behavior to alert-rule delegation checks once both land).

## Special notes for your reviewer

- **Behavior change (intentional, fail-closed):** Check with empty name + folder on folder-supporting resources tightens from "holds the action anywhere" to "holds the action on that folder, an ancestor, or a wildcard".
- Blast radius was audited: the only production callers sending empty name + non-empty folder + verb != create are the two listed above.
- Verified: `pkg/services/authz/rbac` (558 tests), `pkg/storage/unified/resource` (1130 tests), and the enterprise `role_permission_validator` package (15 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)