### PR TITLE
Notifications: Recover from panics in mail.v2 attachment writer

### DIFF
--- a/pkg/services/notifications/smtp.go
+++ b/pkg/services/notifications/smtp.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/mail"
 	"net/textproto"
+	"runtime/debug"
 	"strconv"
 	"strings"
 
@@ -20,11 +21,14 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	gomail "gopkg.in/mail.v2"
 
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
 var tracer = otel.Tracer("github.com/grafana/grafana/pkg/services/notifications")
+
+var smtpLogger = log.New("notifications.smtp")
 
 type SmtpClient struct {
 	cfg setting.SmtpSettings
@@ -143,18 +147,36 @@ func (sc *SmtpClient) setFiles(
 	}
 
 	for _, file := range msg.EmbeddedContents {
-		m.Embed(file.Name, gomail.SetCopyFunc(func(writer io.Writer) error {
-			_, err := writer.Write(file.Content)
-			return err
-		}))
+		m.Embed(file.Name, gomail.SetCopyFunc(copyContentFunc(file.Name, file.Content)))
 	}
 
 	for _, file := range msg.AttachedFiles {
-		file := file
-		m.Attach(file.Name, gomail.SetCopyFunc(func(writer io.Writer) error {
-			_, err := writer.Write(file.Content)
-			return err
-		}))
+		m.Attach(file.Name, gomail.SetCopyFunc(copyContentFunc(file.Name, file.Content)))
+	}
+}
+
+// copyContentFunc copies content to the writer supplied by mail.v2, turning
+// panics into errors. mail.v2's base64LineWriter does not nil-guard its
+// underlying writer and can panic mid-encoding; the copy runs on the caller's
+// notification goroutine, so an unrecovered panic there takes down the whole
+// process. Recovering keeps the failure local to this one message.
+func copyContentFunc(name string, content []byte) func(io.Writer) error {
+	return func(writer io.Writer) (err error) {
+		defer func() {
+			if r := recover(); r != nil {
+				smtpLogger.Error("Panic while writing email attachment", "file", name, "error", r, "stack", string(debug.Stack()))
+				switch theErr := r.(type) {
+				case error:
+					err = fmt.Errorf("panic while writing email attachment %q: %w", name, theErr)
+				case string:
+					err = fmt.Errorf("panic while writing email attachment %q: %s", name, theErr)
+				default:
+					err = fmt.Errorf("panic while writing email attachment %q: %v", name, r)
+				}
+			}
+		}()
+		_, err = writer.Write(content)
+		return err
 	}
 }
 

--- a/pkg/services/notifications/smtp_attachment_panic_test.go
+++ b/pkg/services/notifications/smtp_attachment_panic_test.go
@@ -1,0 +1,94 @@
+package notifications
+
+import (
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Regression for grafana/grafana#124000: a panic inside the writer passed by
+// mail.v2 to the SetCopyFunc closure used to crash the calling alert
+// notification goroutine, taking the whole Grafana process down. The closure
+// must convert the panic into an error so the caller can fail gracefully.
+
+type panickingWriter struct{}
+
+func (panickingWriter) Write([]byte) (int, error) {
+	var w io.Writer
+	// reproduce the mail.v2 base64LineWriter shape: call Write on a nil
+	// embedded io.Writer.
+	return w.Write(nil)
+}
+
+type stubWriter struct {
+	written []byte
+}
+
+func (s *stubWriter) Write(p []byte) (int, error) {
+	s.written = append(s.written, p...)
+	return len(p), nil
+}
+
+type errWriter struct{}
+
+var errBoom = errors.New("boom")
+
+func (errWriter) Write([]byte) (int, error) { return 0, errBoom }
+
+// panicWriter panics with a caller-supplied value, to cover how the recovered
+// value is turned back into an error.
+type panicWriter struct {
+	value any
+}
+
+func (p panicWriter) Write([]byte) (int, error) { panic(p.value) }
+
+func TestCopyContentFunc_RecoversFromWriterPanic(t *testing.T) {
+	fn := copyContentFunc("screenshot.png", []byte("payload"))
+
+	require.NotPanics(t, func() {
+		err := fn(panickingWriter{})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "panic while writing email attachment")
+		require.Contains(t, err.Error(), "screenshot.png")
+	})
+}
+
+func TestCopyContentFunc_HappyPath(t *testing.T) {
+	w := &stubWriter{}
+	fn := copyContentFunc("ok.png", []byte("payload"))
+
+	require.NoError(t, fn(w))
+	require.Equal(t, "payload", string(w.written))
+}
+
+func TestCopyContentFunc_PropagatesWriteError(t *testing.T) {
+	fn := copyContentFunc("err.png", []byte("payload"))
+
+	err := fn(errWriter{})
+	require.ErrorIs(t, err, errBoom)
+	require.False(t, strings.Contains(err.Error(), "panic"),
+		"plain write errors must not be reported as panics")
+}
+
+// A panic carrying an error value must keep that value in the chain, so callers
+// can still match on it with errors.Is/As.
+func TestCopyContentFunc_PanicWithErrorValueIsWrapped(t *testing.T) {
+	fn := copyContentFunc("wrapped.png", []byte("payload"))
+
+	err := fn(panicWriter{value: errBoom})
+	require.ErrorIs(t, err, errBoom)
+	require.Contains(t, err.Error(), "wrapped.png")
+}
+
+func TestCopyContentFunc_PanicWithStringValue(t *testing.T) {
+	fn := copyContentFunc("str.png", []byte("payload"))
+
+	err := fn(panicWriter{value: "kaboom"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "kaboom")
+	require.Contains(t, err.Error(), "str.png")
+}


### PR DESCRIPTION
**What is this feature?**

Recovers from panics raised inside mail.v2's attachment writer, so they are logged and returned as a regular `error` from `DialAndSend` instead of crashing the process.

**Why do we need this feature?**

Sending an alert notification email with an attachment (for example a rendered panel screenshot) can panic with a nil pointer dereference inside mail.v2's `base64LineWriter`, which does not nil-guard its underlying writer.

The copy function runs on the alert notification goroutine, so the panic is not contained: it propagates up and takes down the whole Grafana process. One malformed attachment on one notification is enough to stop the instance, which also means every other pending notification is lost.

With this change the failure stays local — that single email send returns an error, is logged and retried by the existing notification path, and the rest of Grafana keeps running.

**Who is this feature for?**

Operators running Grafana alerting with image rendering enabled, where alert emails carry screenshot attachments.

**Which issue(s) does this PR fix?**:

Fixes #124000

**Special notes for your reviewer:**

The recover is deliberately scoped to the copy closure rather than placed at the goroutine level in `emailSender.SendEmail` or in the notification retry stage. That is the narrowest scope that covers the reported crash: it catches panics raised while mail.v2 writes attachment content, and nothing else. A goroutine-level recover would swallow unrelated bugs and make them harder to find.

This means a panic raised inside mail.v2 *outside* the copy closure — during header parsing, for example — is still not recovered. That is a different code path and out of scope for this issue.

The recovered panic is logged with its stack before being converted, following the existing pattern in `sqleng.DataSourceHandler.handlePanic` and `pkg/services/query`. The underlying mail.v2 bug is still undiagnosed, so dropping the stack here would remove the only evidence of it. The recovered value is unwrapped by type the same way those call sites do, and a panic carrying an `error` is wrapped with `%w` so callers can still match it with `errors.Is`.

Tests in `pkg/services/notifications/smtp_attachment_panic_test.go` cover five cases:
- a panicking writer is converted to an error rather than crashing,
- the happy path still writes attachment content unchanged,
- a plain write error is returned as-is and is not disguised as a panic,
- a panic carrying an `error` value stays matchable with `errors.Is`,
- a panic carrying a string is reported with that string.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle. — n/a, bug fix
- [ ] The docs are updated — n/a, no user-facing surface change
