### PR TITLE
feat: block serving from unified unless scheme registered

### DIFF
--- a/pkg/registry/apis/collections/migration_registrar.go
+++ b/pkg/registry/apis/collections/migration_registrar.go
@@ -18,7 +18,7 @@ func StarsMigration(migrator legacy.StarsMigrator) migrations.MigrationDefinitio
 			{
 				GroupResource: starsGR,
 				LockTables:    []string{"star", "user"},
-				TargetVersion: collectionsV1.APIVersion,
+				FloorVersion:  collectionsV1.APIVersion,
 			},
 		},
 		Migrators: map[schema.GroupResource]migrations.MigratorFunc{

--- a/pkg/registry/apis/collections/migration_registrar.go
+++ b/pkg/registry/apis/collections/migration_registrar.go
@@ -15,7 +15,11 @@ func StarsMigration(migrator legacy.StarsMigrator) migrations.MigrationDefinitio
 		ID:          "stars",
 		MigrationID: "stars migration",
 		Resources: []migrations.ResourceInfo{
-			{GroupResource: starsGR, LockTables: []string{"star", "user"}},
+			{
+				GroupResource: starsGR,
+				LockTables:    []string{"star", "user"},
+				TargetVersion: collectionsV1.APIVersion,
+			},
 		},
 		Migrators: map[schema.GroupResource]migrations.MigratorFunc{
 			starsGR: migrator.MigrateStars,

--- a/pkg/registry/apis/dashboard/legacy/sql_dashboards.go
+++ b/pkg/registry/apis/dashboard/legacy/sql_dashboards.go
@@ -17,6 +17,7 @@ import (
 	claims "github.com/grafana/authlib/types"
 	dashboardV0 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v0alpha1"
 	dashboardV1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1"
+	folderV1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
 	"github.com/grafana/grafana/pkg/apimachinery/apis/common/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
@@ -274,7 +275,7 @@ func (a *dashboardSqlAccess) MigrateFolders(ctx context.Context, orgId int64, op
 	// Now send each dashboard
 	for i := 1; rows.Next(); i++ {
 		dash := rows.row.Dash
-		dash.APIVersion = "folder.grafana.app/v1beta1"
+		dash.APIVersion = folderV1.GroupVersion.String()
 		dash.Kind = "Folder"
 		dash.SetNamespace(opts.Namespace)
 		dash.SetResourceVersion("") // it will be filled in by the backend

--- a/pkg/registry/apis/dashboard/legacy/sql_dashboards.go
+++ b/pkg/registry/apis/dashboard/legacy/sql_dashboards.go
@@ -275,7 +275,7 @@ func (a *dashboardSqlAccess) MigrateFolders(ctx context.Context, orgId int64, op
 	// Now send each dashboard
 	for i := 1; rows.Next(); i++ {
 		dash := rows.row.Dash
-		dash.APIVersion = foldersV1beta1.APIVersion
+		dash.APIVersion = foldersV1beta1.APIVERSION
 		dash.Kind = "Folder"
 		dash.SetNamespace(opts.Namespace)
 		dash.SetResourceVersion("") // it will be filled in by the backend

--- a/pkg/registry/apis/dashboard/legacy/sql_dashboards.go
+++ b/pkg/registry/apis/dashboard/legacy/sql_dashboards.go
@@ -17,7 +17,7 @@ import (
 	claims "github.com/grafana/authlib/types"
 	dashboardV0 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v0alpha1"
 	dashboardV1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1"
-	folderV1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
+	foldersV1beta1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
 	"github.com/grafana/grafana/pkg/apimachinery/apis/common/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
@@ -275,7 +275,7 @@ func (a *dashboardSqlAccess) MigrateFolders(ctx context.Context, orgId int64, op
 	// Now send each dashboard
 	for i := 1; rows.Next(); i++ {
 		dash := rows.row.Dash
-		dash.APIVersion = folderV1.GroupVersion.String()
+		dash.APIVersion = foldersV1beta1.APIVersion
 		dash.Kind = "Folder"
 		dash.SetNamespace(opts.Namespace)
 		dash.SetResourceVersion("") // it will be filled in by the backend

--- a/pkg/registry/apis/dashboard/migration_registrar.go
+++ b/pkg/registry/apis/dashboard/migration_registrar.go
@@ -17,8 +17,17 @@ func FoldersDashboardsMigration(migrator migrator.FoldersDashboardsMigrator) mig
 		ID:          migrations.FoldersDashboardsMigrationID,
 		MigrationID: "folders and dashboards migration",
 		Resources: []migrations.ResourceInfo{
-			{GroupResource: folderGR, LockTables: []string{"dashboard", "dashboard_version", "dashboard_provisioning"}},
-			{GroupResource: dashboardGR, LockTables: []string{"dashboard", "dashboard_version", "dashboard_provisioning"}},
+			{
+				GroupResource: folderGR,
+				LockTables:    []string{"dashboard", "dashboard_version", "dashboard_provisioning"},
+				TargetVersion: folders.APIVersion,
+			},
+			{
+				GroupResource: dashboardGR,
+				LockTables:    []string{"dashboard", "dashboard_version", "dashboard_provisioning"},
+				// Per-row api_version (floor v0alpha1, up to v1).
+				TargetVersion: migrations.DynamicTargetVersion,
+			},
 		},
 		Migrators: map[schema.GroupResource]migrations.MigratorFunc{
 			folderGR:    migrator.MigrateFolders,

--- a/pkg/registry/apis/dashboard/migration_registrar.go
+++ b/pkg/registry/apis/dashboard/migration_registrar.go
@@ -3,8 +3,10 @@ package dashboard
 import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	dashV0 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v0alpha1"
 	v1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1"
 	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
+	foldersV1beta1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
 	"github.com/grafana/grafana/pkg/registry/apis/dashboard/migrator"
 	"github.com/grafana/grafana/pkg/storage/unified/migrations"
 )
@@ -20,13 +22,13 @@ func FoldersDashboardsMigration(migrator migrator.FoldersDashboardsMigrator) mig
 			{
 				GroupResource: folderGR,
 				LockTables:    []string{"dashboard", "dashboard_version", "dashboard_provisioning"},
-				TargetVersion: folders.APIVersion,
+				// Earlier migrations left folders as v1beta1 and do not re-run.
+				FloorVersion: foldersV1beta1.APIVersion,
 			},
 			{
 				GroupResource: dashboardGR,
 				LockTables:    []string{"dashboard", "dashboard_version", "dashboard_provisioning"},
-				// Per-row api_version (floor v0alpha1, up to v1).
-				TargetVersion: migrations.DynamicTargetVersion,
+				FloorVersion:  dashV0.VERSION,
 			},
 		},
 		Migrators: map[schema.GroupResource]migrations.MigratorFunc{

--- a/pkg/registry/apis/dashboard/snapshot/migration_registrar.go
+++ b/pkg/registry/apis/dashboard/snapshot/migration_registrar.go
@@ -20,8 +20,8 @@ func SnapshotMigration(m migrator.SnapshotMigrator) migrations.MigrationDefiniti
 		Resources: []migrations.ResourceInfo{
 			{
 				GroupResource: snapshotGR,
-				LockTables:   []string{"dashboard_snapshot"},
-				FloorVersion: dashV0.VERSION,
+				LockTables:    []string{"dashboard_snapshot"},
+				FloorVersion:  dashV0.VERSION,
 			},
 		},
 		Migrators: map[schema.GroupResource]migrations.MigratorFunc{

--- a/pkg/registry/apis/dashboard/snapshot/migration_registrar.go
+++ b/pkg/registry/apis/dashboard/snapshot/migration_registrar.go
@@ -18,7 +18,11 @@ func SnapshotMigration(m migrator.SnapshotMigrator) migrations.MigrationDefiniti
 		ID:          "snapshots",
 		MigrationID: "snapshots migration",
 		Resources: []migrations.ResourceInfo{
-			{GroupResource: snapshotGR, LockTables: []string{"dashboard_snapshot"}},
+			{
+				GroupResource: snapshotGR,
+				LockTables:    []string{"dashboard_snapshot"},
+				TargetVersion: dashV0.VERSION,
+			},
 		},
 		Migrators: map[schema.GroupResource]migrations.MigratorFunc{
 			snapshotGR: m.MigrateSnapshots,

--- a/pkg/registry/apis/dashboard/snapshot/migration_registrar.go
+++ b/pkg/registry/apis/dashboard/snapshot/migration_registrar.go
@@ -20,8 +20,8 @@ func SnapshotMigration(m migrator.SnapshotMigrator) migrations.MigrationDefiniti
 		Resources: []migrations.ResourceInfo{
 			{
 				GroupResource: snapshotGR,
-				LockTables:    []string{"dashboard_snapshot"},
-				TargetVersion: dashV0.VERSION,
+				LockTables:   []string{"dashboard_snapshot"},
+				FloorVersion: dashV0.VERSION,
 			},
 		},
 		Migrators: map[schema.GroupResource]migrations.MigratorFunc{

--- a/pkg/registry/apis/datasource/migration_registrar.go
+++ b/pkg/registry/apis/datasource/migration_registrar.go
@@ -3,6 +3,7 @@ package datasource
 import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	datasourceV0 "github.com/grafana/grafana/pkg/apis/datasource/v0alpha1"
 	"github.com/grafana/grafana/pkg/registry/apis/datasource/migrator"
 	"github.com/grafana/grafana/pkg/storage/unified/migrations"
 )
@@ -20,8 +21,8 @@ func DataSourceMigration(dsMigrator migrator.DataSourceMigrator) migrations.Migr
 			{
 				GroupResource: gr,
 				LockTables:    []string{"data_source"},
-				// Per-plugin group (see ResourceGroupsFunc), v0alpha1 floor.
-				TargetVersion: migrations.DynamicTargetVersion,
+				// Per-plugin group (see ResourceGroupsFunc), all served at the v0alpha1 floor.
+				FloorVersion: datasourceV0.VERSION,
 			},
 		},
 		Migrators: map[schema.GroupResource]migrations.MigratorFunc{

--- a/pkg/registry/apis/datasource/migration_registrar.go
+++ b/pkg/registry/apis/datasource/migration_registrar.go
@@ -17,7 +17,12 @@ func DataSourceMigration(dsMigrator migrator.DataSourceMigrator) migrations.Migr
 		ID:          "datasource",
 		MigrationID: "datasources migration",
 		Resources: []migrations.ResourceInfo{
-			{GroupResource: gr, LockTables: []string{"data_source"}},
+			{
+				GroupResource: gr,
+				LockTables:    []string{"data_source"},
+				// Per-plugin group (see ResourceGroupsFunc), v0alpha1 floor.
+				TargetVersion: migrations.DynamicTargetVersion,
+			},
 		},
 		Migrators: map[schema.GroupResource]migrations.MigratorFunc{
 			gr: dsMigrator.MigrateDataSources,

--- a/pkg/registry/apis/preferences/migration_registrar.go
+++ b/pkg/registry/apis/preferences/migration_registrar.go
@@ -17,8 +17,8 @@ func PreferencesMigration(migrator legacy.PreferencesMigrator) migrations.Migrat
 		Resources: []migrations.ResourceInfo{
 			{
 				GroupResource: preferencesGR,
-				LockTables:    []string{"preferences", "user", "team"},
-				TargetVersion: preferencesV1.APIVersion,
+				LockTables:   []string{"preferences", "user", "team"},
+				FloorVersion: preferencesV1.APIVersion,
 			},
 		},
 		Migrators: map[schema.GroupResource]migrations.MigratorFunc{

--- a/pkg/registry/apis/preferences/migration_registrar.go
+++ b/pkg/registry/apis/preferences/migration_registrar.go
@@ -17,8 +17,8 @@ func PreferencesMigration(migrator legacy.PreferencesMigrator) migrations.Migrat
 		Resources: []migrations.ResourceInfo{
 			{
 				GroupResource: preferencesGR,
-				LockTables:   []string{"preferences", "user", "team"},
-				FloorVersion: preferencesV1.APIVersion,
+				LockTables:    []string{"preferences", "user", "team"},
+				FloorVersion:  preferencesV1.APIVersion,
 			},
 		},
 		Migrators: map[schema.GroupResource]migrations.MigratorFunc{

--- a/pkg/registry/apis/preferences/migration_registrar.go
+++ b/pkg/registry/apis/preferences/migration_registrar.go
@@ -15,7 +15,11 @@ func PreferencesMigration(migrator legacy.PreferencesMigrator) migrations.Migrat
 		ID:          "preferences",
 		MigrationID: "preferences migration",
 		Resources: []migrations.ResourceInfo{
-			{GroupResource: preferencesGR, LockTables: []string{"preferences", "user", "team"}},
+			{
+				GroupResource: preferencesGR,
+				LockTables:    []string{"preferences", "user", "team"},
+				TargetVersion: preferencesV1.APIVersion,
+			},
 		},
 		Migrators: map[schema.GroupResource]migrations.MigratorFunc{
 			preferencesGR: migrator.MigratePreferences,

--- a/pkg/registry/apps/playlist/migration_registrar.go
+++ b/pkg/registry/apps/playlist/migration_registrar.go
@@ -15,7 +15,11 @@ func PlaylistMigration(migrator migrator.PlaylistMigrator) migrations.MigrationD
 		ID:          "playlists",
 		MigrationID: "playlists migration",
 		Resources: []migrations.ResourceInfo{
-			{GroupResource: playlistGR, LockTables: []string{"playlist", "playlist_item"}},
+			{
+				GroupResource: playlistGR,
+				LockTables:    []string{"playlist", "playlist_item"},
+				TargetVersion: playlists.APIVersion,
+			},
 		},
 		Migrators: map[schema.GroupResource]migrations.MigratorFunc{
 			playlistGR: migrator.MigratePlaylists,

--- a/pkg/registry/apps/playlist/migration_registrar.go
+++ b/pkg/registry/apps/playlist/migration_registrar.go
@@ -18,7 +18,7 @@ func PlaylistMigration(migrator migrator.PlaylistMigrator) migrations.MigrationD
 			{
 				GroupResource: playlistGR,
 				LockTables:    []string{"playlist", "playlist_item"},
-				TargetVersion: playlists.APIVersion,
+				FloorVersion:  playlists.APIVersion,
 			},
 		},
 		Migrators: map[schema.GroupResource]migrations.MigratorFunc{

--- a/pkg/registry/apps/querycaching/migration_registrar.go
+++ b/pkg/registry/apps/querycaching/migration_registrar.go
@@ -10,6 +10,7 @@ import (
 const (
 	apiGroup = "querycaching.grafana.app"
 	resource = "querycacheconfigs"
+	version = "v1beta1" // must match the apiVersion the migrator writes
 )
 
 func QueryCacheConfigMigration(m migrator.QueryCacheConfigMigrator) migrations.MigrationDefinition {
@@ -19,7 +20,11 @@ func QueryCacheConfigMigration(m migrator.QueryCacheConfigMigrator) migrations.M
 		ID:          "querycacheconfigs",
 		MigrationID: "querycacheconfigs migration",
 		Resources: []migrations.ResourceInfo{
-			{GroupResource: gr, LockTables: []string{"data_source_cache", "data_source"}},
+			{
+				GroupResource: gr,
+				LockTables:    []string{"data_source_cache", "data_source"},
+				TargetVersion: version,
+			},
 		},
 		Migrators: map[schema.GroupResource]migrations.MigratorFunc{
 			gr: m.MigrateQueryCacheConfigs,

--- a/pkg/registry/apps/querycaching/migration_registrar.go
+++ b/pkg/registry/apps/querycaching/migration_registrar.go
@@ -17,7 +17,7 @@ func QueryCacheConfigMigration(m migrator.QueryCacheConfigMigrator) migrations.M
 			{
 				GroupResource: gr,
 				LockTables:    []string{"data_source_cache", "data_source"},
-				TargetVersion: migrator.APIVersion,
+				FloorVersion:  migrator.APIVersion,
 			},
 		},
 		Migrators: map[schema.GroupResource]migrations.MigratorFunc{

--- a/pkg/registry/apps/querycaching/migration_registrar.go
+++ b/pkg/registry/apps/querycaching/migration_registrar.go
@@ -7,14 +7,8 @@ import (
 	"github.com/grafana/grafana/pkg/storage/unified/migrations"
 )
 
-const (
-	apiGroup = "querycaching.grafana.app"
-	resource = "querycacheconfigs"
-	version = "v1beta1" // must match the apiVersion the migrator writes
-)
-
 func QueryCacheConfigMigration(m migrator.QueryCacheConfigMigrator) migrations.MigrationDefinition {
-	gr := schema.GroupResource{Group: apiGroup, Resource: resource}
+	gr := schema.GroupResource{Group: migrator.APIGroup, Resource: migrator.Resource}
 
 	return migrations.MigrationDefinition{
 		ID:          "querycacheconfigs",
@@ -23,7 +17,7 @@ func QueryCacheConfigMigration(m migrator.QueryCacheConfigMigrator) migrations.M
 			{
 				GroupResource: gr,
 				LockTables:    []string{"data_source_cache", "data_source"},
-				TargetVersion: version,
+				TargetVersion: migrator.APIVersion,
 			},
 		},
 		Migrators: map[schema.GroupResource]migrations.MigratorFunc{

--- a/pkg/registry/apps/querycaching/migrator/migrator.go
+++ b/pkg/registry/apps/querycaching/migrator/migrator.go
@@ -18,9 +18,9 @@ import (
 )
 
 const (
-	apiGroup   = "querycaching.grafana.app"
-	apiVersion = "v1beta1"
-	resource   = "querycacheconfigs"
+	APIGroup   = "querycaching.grafana.app"
+	APIVersion = "v1beta1"
+	Resource   = "querycacheconfigs"
 )
 
 //go:embed query_querycacheconfigs.sql
@@ -71,7 +71,7 @@ func (m *queryCacheConfigMigrator) MigrateQueryCacheConfigs(ctx context.Context,
 
 			name := fmt.Sprintf("%s.%s", row.pluginID, row.dataSourceUID)
 			body, err := json.Marshal(queryCacheConfigObject{
-				TypeMeta:   metav1.TypeMeta{APIVersion: apiGroup + "/" + apiVersion, Kind: "QueryCacheConfig"},
+				TypeMeta:   metav1.TypeMeta{APIVersion: APIGroup + "/" + APIVersion, Kind: "QueryCacheConfig"},
 				ObjectMeta: objectMeta{Name: name, Namespace: opts.Namespace, CreationTimestamp: metav1.NewTime(time.Unix(row.createdEpoch, 0))},
 				Spec: queryCacheConfigSpec{
 					DatasourceUID:  row.dataSourceUID,
@@ -90,8 +90,8 @@ func (m *queryCacheConfigMigrator) MigrateQueryCacheConfigs(ctx context.Context,
 			if err = stream.Send(&resourcepb.BulkRequest{
 				Key: &resourcepb.ResourceKey{
 					Namespace: opts.Namespace,
-					Group:     apiGroup,
-					Resource:  resource,
+					Group:     APIGroup,
+					Resource:  Resource,
 					Name:      name,
 				},
 				Value:  body,

--- a/pkg/registry/apps/shorturl/migration_registrar.go
+++ b/pkg/registry/apps/shorturl/migration_registrar.go
@@ -15,7 +15,11 @@ func ShortURLMigration(migrator migrator.ShortURLMigrator) migrations.MigrationD
 		ID:          "shorturls",
 		MigrationID: "shorturls migration",
 		Resources: []migrations.ResourceInfo{
-			{GroupResource: shortURLGR, LockTables: []string{"short_url"}},
+			{
+				GroupResource: shortURLGR,
+				LockTables:    []string{"short_url"},
+				TargetVersion: shorturl.APIVersion,
+			},
 		},
 		Migrators: map[schema.GroupResource]migrations.MigratorFunc{
 			shortURLGR: migrator.MigrateShortURLs,

--- a/pkg/registry/apps/shorturl/migration_registrar.go
+++ b/pkg/registry/apps/shorturl/migration_registrar.go
@@ -18,7 +18,7 @@ func ShortURLMigration(migrator migrator.ShortURLMigrator) migrations.MigrationD
 			{
 				GroupResource: shortURLGR,
 				LockTables:    []string{"short_url"},
-				TargetVersion: shorturl.APIVersion,
+				FloorVersion:  shorturl.APIVersion,
 			},
 		},
 		Migrators: map[schema.GroupResource]migrations.MigratorFunc{

--- a/pkg/services/apiserver/appinstaller/server.go
+++ b/pkg/services/apiserver/appinstaller/server.go
@@ -39,10 +39,10 @@ type serverWrapper struct {
 func (s *serverWrapper) InstallAPIGroup(apiGroupInfo *genericapiserver.APIGroupInfo) error {
 	log := logging.FromContext(s.ctx)
 	group := s.installer.ManifestData().Group
-	served := make([]schema.GroupVersion, 0, len(apiGroupInfo.VersionedResourcesStorageMap))
-	for ver := range apiGroupInfo.VersionedResourcesStorageMap {
-		served = append(served, schema.GroupVersion{Group: group, Version: ver})
-	}
+	// Derive served versions from the scheme so this matches the classic builder
+	// path (builder/helper.go) and the "registered in the apiserver scheme"
+	// semantic that ValidateServedVersions enforces.
+	served := apiGroupInfo.Scheme.PrioritizedVersionsForGroup(group)
 	for v, storageMap := range apiGroupInfo.VersionedResourcesStorageMap {
 		for storagePath, restStorage := range storageMap {
 			legacyProvider, dualWriteSupported := s.installer.(LegacyStorageProvider)
@@ -65,12 +65,18 @@ func (s *serverWrapper) InstallAPIGroup(apiGroupInfo *genericapiserver.APIGroupI
 				if unifiedStorage, ok := storage.(grafanarest.Storage); ok {
 					log.Debug("Configuring dual writer for storage", "resource", gr.String(), "version", v, "storagePath", storagePath)
 					legacyStorage := legacyProvider.GetLegacyStorage(gr.WithVersion(v))
-					if legacyStorage == nil {
-						log.Debug("Skipping dual writer; no legacy storage", "resource", gr.String(), "version", v, "storagePath", storagePath)
-					} else if err := s.dualWriteService.ValidateServedVersions(s.ctx, gr, served); err != nil {
-						// Fall back to legacy if unified would serve an unregistered apiVersion.
+					// Validate served versions regardless of whether legacy storage exists:
+					// unified must never serve an apiVersion the scheme never registered.
+					// Without a legacy fallback there is nothing safe to serve, so refuse
+					// to install rather than expose the migrated data.
+					if err := s.dualWriteService.ValidateServedVersions(s.ctx, gr, served); err != nil {
+						if legacyStorage == nil {
+							return fmt.Errorf("cannot serve %q from unified storage: %w", gr.String(), err)
+						}
 						log.Warn("serving legacy storage", "resource", gr.String(), "error", err)
 						storage = legacyStorage
+					} else if legacyStorage == nil {
+						log.Debug("Skipping dual writer; no legacy storage", "resource", gr.String(), "version", v, "storagePath", storagePath)
 					} else {
 						storage, err = NewDualWriter(
 							gr,

--- a/pkg/services/apiserver/appinstaller/server.go
+++ b/pkg/services/apiserver/appinstaller/server.go
@@ -37,81 +37,131 @@ type serverWrapper struct {
 }
 
 func (s *serverWrapper) InstallAPIGroup(apiGroupInfo *genericapiserver.APIGroupInfo) error {
-	log := logging.FromContext(s.ctx)
 	group := s.installer.ManifestData().Group
-	// Derive served versions from the scheme so this matches the classic builder
-	// path (builder/helper.go) and the "registered in the apiserver scheme"
-	// semantic that ValidateServedVersions enforces.
-	served := apiGroupInfo.Scheme.PrioritizedVersionsForGroup(group)
+	servedForResource := servedVersionsForResource(apiGroupInfo, group)
+
 	for v, storageMap := range apiGroupInfo.VersionedResourcesStorageMap {
+		// Configure top-level resources before subresources: a subresource inspects its
+		// parent's configured storage, and map iteration order is non-deterministic.
 		for storagePath, restStorage := range storageMap {
-			legacyProvider, dualWriteSupported := s.installer.(LegacyStorageProvider)
-			resource, err := getResourceFromStoragePath(storagePath)
-			if err != nil {
-				return err
-			}
-			gr := schema.GroupResource{
-				Group:    s.installer.ManifestData().Group,
-				Resource: resource,
-			}
-			gvr := gr.WithVersion(v)
-			if s.apiResourceConfig != nil && !s.apiResourceConfig.ResourceEnabled(gvr) {
-				log.Debug("Skipping storage for disabled resource", "gvr", gvr.String(), "storagePath", storagePath)
-				delete(apiGroupInfo.VersionedResourcesStorageMap[v], storagePath)
+			if isSubresourcePath(storagePath) {
 				continue
 			}
-			storage := s.configureStorage(gr, dualWriteSupported, restStorage)
-			if dualWriteSupported {
-				if unifiedStorage, ok := storage.(grafanarest.Storage); ok {
-					log.Debug("Configuring dual writer for storage", "resource", gr.String(), "version", v, "storagePath", storagePath)
-					legacyStorage := legacyProvider.GetLegacyStorage(gr.WithVersion(v))
-					// Validate served versions regardless of whether legacy storage exists:
-					// unified must never serve an apiVersion the scheme never registered.
-					// Without a legacy fallback there is nothing safe to serve, so refuse
-					// to install rather than expose the migrated data.
-					if err := s.dualWriteService.ValidateServedVersions(s.ctx, gr, served); err != nil {
-						if legacyStorage == nil {
-							return fmt.Errorf("cannot serve %q from unified storage: %w", gr.String(), err)
-						}
-						log.Warn("serving legacy storage", "resource", gr.String(), "error", err)
-						storage = legacyStorage
-					} else if legacyStorage == nil {
-						log.Debug("Skipping dual writer; no legacy storage", "resource", gr.String(), "version", v, "storagePath", storagePath)
-					} else {
-						storage, err = NewDualWriter(
-							gr,
-							s.storageOpts,
-							legacyStorage,
-							unifiedStorage,
-							s.dualWriteService,
-							s.builderMetrics,
-						)
-						if err != nil {
-							return err
-						}
-					}
-				} else if statusRest, ok := storage.(*appsdkapiserver.StatusREST); ok {
-					parentPath := strings.TrimSuffix(storagePath, "/status")
-					parentStore, ok := apiGroupInfo.VersionedResourcesStorageMap[v][parentPath]
-					if ok {
-						if _, isMode4or5 := parentStore.(*genericregistry.Store); !isMode4or5 {
-							// When legacy resources have status, the dual writing must be handled explicitly
-							if statusProvider, ok := s.installer.(LegacyStatusProvider); ok {
-								storage = statusProvider.GetLegacyStatus(gr.WithVersion(v), statusRest)
-							} else {
-								log.Warn("skipped registering status sub-resource that does not support dual writing",
-									"resource", gr.String(), "version", v, "storagePath", storagePath)
-								continue
-							}
-						}
-					}
-				}
+			if err := s.configureStoragePath(apiGroupInfo, v, storagePath, restStorage, servedForResource); err != nil {
+				return err
 			}
-			apiGroupInfo.VersionedResourcesStorageMap[v][storagePath] = storage
+		}
+		for storagePath, restStorage := range storageMap {
+			if !isSubresourcePath(storagePath) {
+				continue
+			}
+			if err := s.configureStoragePath(apiGroupInfo, v, storagePath, restStorage, servedForResource); err != nil {
+				return err
+			}
 		}
 	}
 
 	return s.GenericAPIServer.InstallAPIGroup(apiGroupInfo)
+}
+
+// isSubresourcePath reports whether a storage path addresses a subresource (e.g. "shorturls/status").
+func isSubresourcePath(storagePath string) bool {
+	return strings.Contains(storagePath, "/")
+}
+
+// servedVersionsForResource maps each resource to the group versions it is installed under.
+func servedVersionsForResource(apiGroupInfo *genericapiserver.APIGroupInfo, group string) map[string][]schema.GroupVersion {
+	served := make(map[string][]schema.GroupVersion)
+	seen := make(map[string]map[string]struct{})
+	for version, storageMap := range apiGroupInfo.VersionedResourcesStorageMap {
+		for storagePath := range storageMap {
+			resource, err := getResourceFromStoragePath(storagePath)
+			if err != nil {
+				continue
+			}
+			if seen[resource] == nil {
+				seen[resource] = make(map[string]struct{})
+			}
+			if _, ok := seen[resource][version]; ok {
+				continue
+			}
+			seen[resource][version] = struct{}{}
+			served[resource] = append(served[resource], schema.GroupVersion{Group: group, Version: version})
+		}
+	}
+	return served
+}
+
+func (s *serverWrapper) configureStoragePath(
+	apiGroupInfo *genericapiserver.APIGroupInfo,
+	v string,
+	storagePath string,
+	restStorage genericrest.Storage,
+	servedForResource map[string][]schema.GroupVersion,
+) error {
+	log := logging.FromContext(s.ctx)
+	legacyProvider, dualWriteSupported := s.installer.(LegacyStorageProvider)
+	resource, err := getResourceFromStoragePath(storagePath)
+	if err != nil {
+		return err
+	}
+	gr := schema.GroupResource{
+		Group:    s.installer.ManifestData().Group,
+		Resource: resource,
+	}
+	gvr := gr.WithVersion(v)
+	if s.apiResourceConfig != nil && !s.apiResourceConfig.ResourceEnabled(gvr) {
+		log.Debug("Skipping storage for disabled resource", "gvr", gvr.String(), "storagePath", storagePath)
+		delete(apiGroupInfo.VersionedResourcesStorageMap[v], storagePath)
+		return nil
+	}
+	storage := s.configureStorage(gr, dualWriteSupported, restStorage)
+	if dualWriteSupported {
+		if unifiedStorage, ok := storage.(grafanarest.Storage); ok {
+			log.Debug("Configuring dual writer for storage", "resource", gr.String(), "version", v, "storagePath", storagePath)
+			legacyStorage := legacyProvider.GetLegacyStorage(gr.WithVersion(v))
+			// unified must never serve an apiVersion the scheme never registered; with no
+			// legacy fallback there is nothing safe to serve, so refuse to install.
+			if err := s.dualWriteService.ValidateServedVersions(s.ctx, gr, servedForResource[gr.Resource]); err != nil {
+				if legacyStorage == nil {
+					return fmt.Errorf("cannot serve %q from unified storage: %w", gr.String(), err)
+				}
+				log.Warn("serving legacy storage", "resource", gr.String(), "error", err)
+				storage = legacyStorage
+			} else if legacyStorage == nil {
+				log.Debug("Skipping dual writer; no legacy storage", "resource", gr.String(), "version", v, "storagePath", storagePath)
+			} else {
+				storage, err = NewDualWriter(
+					gr,
+					s.storageOpts,
+					legacyStorage,
+					unifiedStorage,
+					s.dualWriteService,
+					s.builderMetrics,
+				)
+				if err != nil {
+					return err
+				}
+			}
+		} else if statusRest, ok := storage.(*appsdkapiserver.StatusREST); ok {
+			parentPath := strings.TrimSuffix(storagePath, "/status")
+			parentStore, ok := apiGroupInfo.VersionedResourcesStorageMap[v][parentPath]
+			if ok {
+				if _, isMode4or5 := parentStore.(*genericregistry.Store); !isMode4or5 {
+					// When legacy resources have status, the dual writing must be handled explicitly
+					if statusProvider, ok := s.installer.(LegacyStatusProvider); ok {
+						storage = statusProvider.GetLegacyStatus(gr.WithVersion(v), statusRest)
+					} else {
+						log.Warn("skipped registering status sub-resource that does not support dual writing",
+							"resource", gr.String(), "version", v, "storagePath", storagePath)
+						return nil
+					}
+				}
+			}
+		}
+	}
+	apiGroupInfo.VersionedResourcesStorageMap[v][storagePath] = storage
+	return nil
 }
 
 func getResourceFromStoragePath(storagePath string) (string, error) {

--- a/pkg/services/apiserver/appinstaller/server.go
+++ b/pkg/services/apiserver/appinstaller/server.go
@@ -38,6 +38,11 @@ type serverWrapper struct {
 
 func (s *serverWrapper) InstallAPIGroup(apiGroupInfo *genericapiserver.APIGroupInfo) error {
 	log := logging.FromContext(s.ctx)
+	group := s.installer.ManifestData().Group
+	served := make([]schema.GroupVersion, 0, len(apiGroupInfo.VersionedResourcesStorageMap))
+	for ver := range apiGroupInfo.VersionedResourcesStorageMap {
+		served = append(served, schema.GroupVersion{Group: group, Version: ver})
+	}
 	for v, storageMap := range apiGroupInfo.VersionedResourcesStorageMap {
 		for storagePath, restStorage := range storageMap {
 			legacyProvider, dualWriteSupported := s.installer.(LegacyStorageProvider)
@@ -62,6 +67,10 @@ func (s *serverWrapper) InstallAPIGroup(apiGroupInfo *genericapiserver.APIGroupI
 					legacyStorage := legacyProvider.GetLegacyStorage(gr.WithVersion(v))
 					if legacyStorage == nil {
 						log.Debug("Skipping dual writer; no legacy storage", "resource", gr.String(), "version", v, "storagePath", storagePath)
+					} else if err := s.dualWriteService.ValidateServedVersions(s.ctx, gr, served); err != nil {
+						// Fall back to legacy if unified would serve an unregistered apiVersion.
+						log.Warn("serving legacy storage", "resource", gr.String(), "error", err)
+						storage = legacyStorage
 					} else {
 						storage, err = NewDualWriter(
 							gr,

--- a/pkg/services/apiserver/appinstaller/server.go
+++ b/pkg/services/apiserver/appinstaller/server.go
@@ -38,6 +38,8 @@ type serverWrapper struct {
 
 func (s *serverWrapper) InstallAPIGroup(apiGroupInfo *genericapiserver.APIGroupInfo) error {
 	group := s.installer.ManifestData().Group
+	// Prune first so servedForResource and the installed storage see the same set.
+	s.pruneDisabledResources(apiGroupInfo, group)
 	servedForResource := servedVersionsForResource(apiGroupInfo, group)
 
 	for v, storageMap := range apiGroupInfo.VersionedResourcesStorageMap {
@@ -61,6 +63,24 @@ func (s *serverWrapper) InstallAPIGroup(apiGroupInfo *genericapiserver.APIGroupI
 // isSubresourcePath reports whether a storage path addresses a subresource (e.g. "shorturls/status").
 func isSubresourcePath(storagePath string) bool {
 	return strings.Contains(storagePath, "/")
+}
+
+// pruneDisabledResources drops storage paths for GVRs disabled via apiResourceConfig. It is the
+// single place resources are removed, keeping every later reader in sync with the installed set.
+func (s *serverWrapper) pruneDisabledResources(apiGroupInfo *genericapiserver.APIGroupInfo, group string) {
+	if s.apiResourceConfig == nil {
+		return
+	}
+	log := logging.FromContext(s.ctx)
+	for version, storageMap := range apiGroupInfo.VersionedResourcesStorageMap {
+		for storagePath := range storageMap {
+			gvr := schema.GroupVersionResource{Group: group, Version: version, Resource: resourceFromStoragePath(storagePath)}
+			if !s.apiResourceConfig.ResourceEnabled(gvr) {
+				log.Debug("Skipping storage for disabled resource", "gvr", gvr.String(), "storagePath", storagePath)
+				delete(storageMap, storagePath)
+			}
+		}
+	}
 }
 
 // servedVersionsForResource maps each resource to the group versions it is installed under.
@@ -94,12 +114,6 @@ func (s *serverWrapper) configureStoragePath(
 	gr := schema.GroupResource{
 		Group:    s.installer.ManifestData().Group,
 		Resource: resourceFromStoragePath(storagePath),
-	}
-	gvr := gr.WithVersion(v)
-	if s.apiResourceConfig != nil && !s.apiResourceConfig.ResourceEnabled(gvr) {
-		log.Debug("Skipping storage for disabled resource", "gvr", gvr.String(), "storagePath", storagePath)
-		delete(apiGroupInfo.VersionedResourcesStorageMap[v], storagePath)
-		return nil
 	}
 	storage := s.configureStorage(gr, dualWriteSupported, restStorage)
 	if dualWriteSupported {

--- a/pkg/services/apiserver/appinstaller/server.go
+++ b/pkg/services/apiserver/appinstaller/server.go
@@ -41,22 +41,16 @@ func (s *serverWrapper) InstallAPIGroup(apiGroupInfo *genericapiserver.APIGroupI
 	servedForResource := servedVersionsForResource(apiGroupInfo, group)
 
 	for v, storageMap := range apiGroupInfo.VersionedResourcesStorageMap {
-		// Configure top-level resources before subresources: a subresource inspects its
-		// parent's configured storage, and map iteration order is non-deterministic.
-		for storagePath, restStorage := range storageMap {
-			if isSubresourcePath(storagePath) {
-				continue
-			}
-			if err := s.configureStoragePath(apiGroupInfo, v, storagePath, restStorage, servedForResource); err != nil {
-				return err
-			}
-		}
-		for storagePath, restStorage := range storageMap {
-			if !isSubresourcePath(storagePath) {
-				continue
-			}
-			if err := s.configureStoragePath(apiGroupInfo, v, storagePath, restStorage, servedForResource); err != nil {
-				return err
+		// Configure top-level resources before their subresources: a subresource inspects
+		// its parent's configured storage, and map iteration order is non-deterministic.
+		for _, subresource := range [...]bool{false, true} {
+			for storagePath, restStorage := range storageMap {
+				if isSubresourcePath(storagePath) != subresource {
+					continue
+				}
+				if err := s.configureStoragePath(apiGroupInfo, v, storagePath, restStorage, servedForResource); err != nil {
+					return err
+				}
 			}
 		}
 	}
@@ -72,20 +66,16 @@ func isSubresourcePath(storagePath string) bool {
 // servedVersionsForResource maps each resource to the group versions it is installed under.
 func servedVersionsForResource(apiGroupInfo *genericapiserver.APIGroupInfo, group string) map[string][]schema.GroupVersion {
 	served := make(map[string][]schema.GroupVersion)
-	seen := make(map[string]map[string]struct{})
 	for version, storageMap := range apiGroupInfo.VersionedResourcesStorageMap {
+		// Distinct resources within one version, deduping subresource paths that share a
+		// resource (e.g. "dashboards" and "dashboards/dto" both count once).
+		seen := make(map[string]struct{}, len(storageMap))
 		for storagePath := range storageMap {
-			resource, err := getResourceFromStoragePath(storagePath)
-			if err != nil {
+			resource := resourceFromStoragePath(storagePath)
+			if _, ok := seen[resource]; ok {
 				continue
 			}
-			if seen[resource] == nil {
-				seen[resource] = make(map[string]struct{})
-			}
-			if _, ok := seen[resource][version]; ok {
-				continue
-			}
-			seen[resource][version] = struct{}{}
+			seen[resource] = struct{}{}
 			served[resource] = append(served[resource], schema.GroupVersion{Group: group, Version: version})
 		}
 	}
@@ -101,13 +91,9 @@ func (s *serverWrapper) configureStoragePath(
 ) error {
 	log := logging.FromContext(s.ctx)
 	legacyProvider, dualWriteSupported := s.installer.(LegacyStorageProvider)
-	resource, err := getResourceFromStoragePath(storagePath)
-	if err != nil {
-		return err
-	}
 	gr := schema.GroupResource{
 		Group:    s.installer.ManifestData().Group,
-		Resource: resource,
+		Resource: resourceFromStoragePath(storagePath),
 	}
 	gvr := gr.WithVersion(v)
 	if s.apiResourceConfig != nil && !s.apiResourceConfig.ResourceEnabled(gvr) {
@@ -164,12 +150,11 @@ func (s *serverWrapper) configureStoragePath(
 	return nil
 }
 
-func getResourceFromStoragePath(storagePath string) (string, error) {
-	parts := strings.Split(storagePath, "/")
-	if len(parts) < 1 {
-		return "", fmt.Errorf("invalid storage path: %s", storagePath)
-	}
-	return parts[0], nil
+// resourceFromStoragePath returns the top-level resource of a storage path, dropping any
+// subresource suffix (e.g. "dashboards/status" → "dashboards").
+func resourceFromStoragePath(storagePath string) string {
+	resource, _, _ := strings.Cut(storagePath, "/")
+	return resource
 }
 
 func (s *serverWrapper) configureStorage(gr schema.GroupResource, dualWriteSupported bool, storage genericrest.Storage) genericrest.Storage {

--- a/pkg/services/apiserver/appinstaller/server_test.go
+++ b/pkg/services/apiserver/appinstaller/server_test.go
@@ -1,12 +1,15 @@
 package appinstaller
 
 import (
+	"context"
 	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	genericrest "k8s.io/apiserver/pkg/registry/rest"
 	genericapiserver "k8s.io/apiserver/pkg/server"
+	serverstorage "k8s.io/apiserver/pkg/server/storage"
 )
 
 func TestIsSubresourcePath(t *testing.T) {
@@ -61,4 +64,47 @@ func TestServedVersionsForResource(t *testing.T) {
 			require.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestPruneDisabledResources(t *testing.T) {
+	const group = "dashboard.grafana.app"
+
+	newStorage := func() map[string]map[string]genericrest.Storage {
+		return map[string]map[string]genericrest.Storage{
+			"v0alpha1": {"dashboards": nil, "dashboards/dto": nil},
+			"v1":       {"dashboards": nil},
+			"v2beta1":  {"dashboards": nil},
+		}
+	}
+
+	t.Run("nil config leaves the storage map untouched", func(t *testing.T) {
+		storage := newStorage()
+		s := &serverWrapper{ctx: context.Background()}
+		s.pruneDisabledResources(&genericapiserver.APIGroupInfo{VersionedResourcesStorageMap: storage}, group)
+
+		require.Equal(t, newStorage(), storage)
+	})
+
+	t.Run("drops storage paths for disabled versions, keeping servedVersionsForResource aligned", func(t *testing.T) {
+		config := serverstorage.NewResourceConfig()
+		config.EnableVersions(schema.GroupVersion{Group: group, Version: "v0alpha1"})
+		config.EnableVersions(schema.GroupVersion{Group: group, Version: "v2beta1"})
+		config.DisableVersions(schema.GroupVersion{Group: group, Version: "v1"})
+
+		storage := newStorage()
+		apiGroupInfo := &genericapiserver.APIGroupInfo{VersionedResourcesStorageMap: storage}
+		s := &serverWrapper{ctx: context.Background(), apiResourceConfig: config}
+		s.pruneDisabledResources(apiGroupInfo, group)
+
+		require.Empty(t, storage["v1"], "disabled version's storage paths should be removed")
+
+		got := map[string][]string{}
+		for resource, gvs := range servedVersionsForResource(apiGroupInfo, group) {
+			for _, gv := range gvs {
+				got[resource] = append(got[resource], gv.Version)
+			}
+			sort.Strings(got[resource])
+		}
+		require.Equal(t, map[string][]string{"dashboards": {"v0alpha1", "v2beta1"}}, got)
+	})
 }

--- a/pkg/services/apiserver/appinstaller/server_test.go
+++ b/pkg/services/apiserver/appinstaller/server_test.go
@@ -1,0 +1,81 @@
+package appinstaller
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	genericrest "k8s.io/apiserver/pkg/registry/rest"
+	genericapiserver "k8s.io/apiserver/pkg/server"
+)
+
+func TestIsSubresourcePath(t *testing.T) {
+	require.False(t, isSubresourcePath("shorturls"))
+	require.True(t, isSubresourcePath("shorturls/status"))
+	require.True(t, isSubresourcePath("dashboards/dto"))
+}
+
+func TestServedVersionsByResource(t *testing.T) {
+	const group = "dashboard.grafana.app"
+
+	apiGroupInfo := &genericapiserver.APIGroupInfo{
+		VersionedResourcesStorageMap: map[string]map[string]genericrest.Storage{
+			"v0alpha1": {
+				"dashboards":        nil,
+				"dashboards/dto":    nil,
+				"librarypanels":     nil,
+				"librarypanels/foo": nil,
+			},
+			"v1": {
+				"dashboards": nil,
+			},
+			"v2beta1": {
+				"dashboards": nil,
+			},
+		},
+	}
+
+	served := servedVersionsForResource(apiGroupInfo, group)
+
+	// dashboards is served under all three versions; subresource paths must not add
+	// duplicate versions.
+	require.ElementsMatch(t, []schema.GroupVersion{
+		{Group: group, Version: "v0alpha1"},
+		{Group: group, Version: "v1"},
+		{Group: group, Version: "v2beta1"},
+	}, served["dashboards"])
+
+	// librarypanels is a distinct resource served only under v0alpha1, even though its
+	// group serves v1 and v2beta1 for dashboards. This is what scopes the guard per
+	// resource instead of per group.
+	require.Equal(t, []schema.GroupVersion{{Group: group, Version: "v0alpha1"}}, served["librarypanels"])
+}
+
+func TestServedVersionsByResource_Empty(t *testing.T) {
+	apiGroupInfo := &genericapiserver.APIGroupInfo{
+		VersionedResourcesStorageMap: map[string]map[string]genericrest.Storage{},
+	}
+	require.Empty(t, servedVersionsForResource(apiGroupInfo, "example.grafana.app"))
+}
+
+// versions is a small helper to make the per-resource assertion order-independent.
+func versions(gvs []schema.GroupVersion) []string {
+	out := make([]string, 0, len(gvs))
+	for _, gv := range gvs {
+		out = append(out, gv.Version)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func TestServedVersionsByResource_Ordering(t *testing.T) {
+	const group = "example.grafana.app"
+	apiGroupInfo := &genericapiserver.APIGroupInfo{
+		VersionedResourcesStorageMap: map[string]map[string]genericrest.Storage{
+			"v1beta1": {"widgets": nil},
+			"v1":      {"widgets": nil},
+		},
+	}
+	require.Equal(t, []string{"v1", "v1beta1"}, versions(servedVersionsForResource(apiGroupInfo, group)["widgets"]))
+}

--- a/pkg/services/apiserver/appinstaller/server_test.go
+++ b/pkg/services/apiserver/appinstaller/server_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	genericrest "k8s.io/apiserver/pkg/registry/rest"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 )
@@ -16,66 +15,50 @@ func TestIsSubresourcePath(t *testing.T) {
 	require.True(t, isSubresourcePath("dashboards/dto"))
 }
 
-func TestServedVersionsByResource(t *testing.T) {
+func TestServedVersionsForResource(t *testing.T) {
 	const group = "dashboard.grafana.app"
 
-	apiGroupInfo := &genericapiserver.APIGroupInfo{
-		VersionedResourcesStorageMap: map[string]map[string]genericrest.Storage{
-			"v0alpha1": {
-				"dashboards":        nil,
-				"dashboards/dto":    nil,
-				"librarypanels":     nil,
-				"librarypanels/foo": nil,
+	tests := []struct {
+		name    string
+		storage map[string]map[string]genericrest.Storage
+		want    map[string][]string
+	}{
+		{
+			name:    "empty map",
+			storage: map[string]map[string]genericrest.Storage{},
+			want:    map[string][]string{},
+		},
+		{
+			// Each resource is scoped to the versions IT is served under: librarypanels
+			// only under v0alpha1, even though the group serves v1/v2beta1 for dashboards.
+			// Subresource paths must not add duplicate versions. This is what scopes the
+			// guard per resource instead of per group.
+			name: "scopes versions per resource, ignoring subresources",
+			storage: map[string]map[string]genericrest.Storage{
+				"v0alpha1": {"dashboards": nil, "dashboards/dto": nil, "librarypanels": nil, "librarypanels/foo": nil},
+				"v1":       {"dashboards": nil},
+				"v2beta1":  {"dashboards": nil},
 			},
-			"v1": {
-				"dashboards": nil,
-			},
-			"v2beta1": {
-				"dashboards": nil,
+			want: map[string][]string{
+				"dashboards":    {"v0alpha1", "v1", "v2beta1"},
+				"librarypanels": {"v0alpha1"},
 			},
 		},
 	}
 
-	served := servedVersionsForResource(apiGroupInfo, group)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			apiGroupInfo := &genericapiserver.APIGroupInfo{VersionedResourcesStorageMap: tt.storage}
 
-	// dashboards is served under all three versions; subresource paths must not add
-	// duplicate versions.
-	require.ElementsMatch(t, []schema.GroupVersion{
-		{Group: group, Version: "v0alpha1"},
-		{Group: group, Version: "v1"},
-		{Group: group, Version: "v2beta1"},
-	}, served["dashboards"])
-
-	// librarypanels is a distinct resource served only under v0alpha1, even though its
-	// group serves v1 and v2beta1 for dashboards. This is what scopes the guard per
-	// resource instead of per group.
-	require.Equal(t, []schema.GroupVersion{{Group: group, Version: "v0alpha1"}}, served["librarypanels"])
-}
-
-func TestServedVersionsByResource_Empty(t *testing.T) {
-	apiGroupInfo := &genericapiserver.APIGroupInfo{
-		VersionedResourcesStorageMap: map[string]map[string]genericrest.Storage{},
+			got := map[string][]string{}
+			for resource, gvs := range servedVersionsForResource(apiGroupInfo, group) {
+				for _, gv := range gvs {
+					require.Equal(t, group, gv.Group)
+					got[resource] = append(got[resource], gv.Version)
+				}
+				sort.Strings(got[resource])
+			}
+			require.Equal(t, tt.want, got)
+		})
 	}
-	require.Empty(t, servedVersionsForResource(apiGroupInfo, "example.grafana.app"))
-}
-
-// versions is a small helper to make the per-resource assertion order-independent.
-func versions(gvs []schema.GroupVersion) []string {
-	out := make([]string, 0, len(gvs))
-	for _, gv := range gvs {
-		out = append(out, gv.Version)
-	}
-	sort.Strings(out)
-	return out
-}
-
-func TestServedVersionsByResource_Ordering(t *testing.T) {
-	const group = "example.grafana.app"
-	apiGroupInfo := &genericapiserver.APIGroupInfo{
-		VersionedResourcesStorageMap: map[string]map[string]genericrest.Storage{
-			"v1beta1": {"widgets": nil},
-			"v1":      {"widgets": nil},
-		},
-	}
-	require.Equal(t, []string{"v1", "v1beta1"}, versions(servedVersionsForResource(apiGroupInfo, group)["widgets"]))
 }

--- a/pkg/services/apiserver/builder/helper.go
+++ b/pkg/services/apiserver/builder/helper.go
@@ -302,8 +302,7 @@ func InstallAPIs(
 			if resourceConfig, ok := storageOpts.UnifiedStorageConfig[key]; ok {
 				builderMetrics.RecordDualWriterTargetMode(gr.Resource, gr.Group, resourceConfig.DualWriterMode)
 			}
-			// Fall back to legacy if unified would serve an apiVersion the scheme never
-			// registered (see the preferences v1 incident).
+			// Fall back to legacy if unified would serve an apiVersion the scheme never registered.
 			served := scheme.PrioritizedVersionsForGroup(gr.Group)
 			if err := dualWriteService.ValidateServedVersions(context.Background(), gr, served); err != nil {
 				klog.Warningf("serving legacy storage: %v", err)

--- a/pkg/services/apiserver/builder/helper.go
+++ b/pkg/services/apiserver/builder/helper.go
@@ -1,6 +1,7 @@
 package builder
 
 import (
+	"context"
 	"encoding/csv"
 	"encoding/json"
 	"errors"
@@ -300,6 +301,13 @@ func InstallAPIs(
 			key := gr.String()
 			if resourceConfig, ok := storageOpts.UnifiedStorageConfig[key]; ok {
 				builderMetrics.RecordDualWriterTargetMode(gr.Resource, gr.Group, resourceConfig.DualWriterMode)
+			}
+			// Fall back to legacy if unified would serve an apiVersion the scheme never
+			// registered (see the preferences v1 incident).
+			served := scheme.PrioritizedVersionsForGroup(gr.Group)
+			if err := dualWriteService.ValidateServedVersions(context.Background(), gr, served); err != nil {
+				klog.Warningf("serving legacy storage: %v", err)
+				return legacy, nil
 			}
 			return dualWriteService.NewStorage(gr, legacy, storage)
 		}

--- a/pkg/services/apiserver/builder/helper.go
+++ b/pkg/services/apiserver/builder/helper.go
@@ -276,6 +276,19 @@ func SetupConfig(
 	return nil
 }
 
+// servedVersionsForResource returns the versions the scheme registers for this resource's
+// kind, falling back to the group's prioritized versions if the kind cannot be resolved.
+func servedVersionsForResource(scheme *runtime.Scheme, gr schema.GroupResource, storage grafanarest.Storage) []schema.GroupVersion {
+	if gvks, _, err := scheme.ObjectKinds(storage.New()); err == nil {
+		for _, gvk := range gvks {
+			if gvk.Group == gr.Group {
+				return scheme.VersionsForGroupKind(gvk.GroupKind())
+			}
+		}
+	}
+	return scheme.PrioritizedVersionsForGroup(gr.Group)
+}
+
 func InstallAPIs(
 	scheme *runtime.Scheme,
 	codecs serializer.CodecFactory,
@@ -302,10 +315,14 @@ func InstallAPIs(
 			if resourceConfig, ok := storageOpts.UnifiedStorageConfig[key]; ok {
 				builderMetrics.RecordDualWriterTargetMode(gr.Resource, gr.Group, resourceConfig.DualWriterMode)
 			}
-			// Fall back to legacy if unified would serve an apiVersion the scheme never registered.
-			served := scheme.PrioritizedVersionsForGroup(gr.Group)
+			// unified must never serve an apiVersion the scheme never registered; with no
+			// legacy fallback there is nothing safe to serve, so refuse to install.
+			served := servedVersionsForResource(scheme, gr, storage)
 			if err := dualWriteService.ValidateServedVersions(context.Background(), gr, served); err != nil {
-				klog.Warningf("serving legacy storage: %v", err)
+				if legacy == nil {
+					return nil, fmt.Errorf("cannot serve %q from unified storage: %w", gr.String(), err)
+				}
+				klog.Warningf("serving legacy storage for %q: %v", gr.String(), err)
 				return legacy, nil
 			}
 			return dualWriteService.NewStorage(gr, legacy, storage)

--- a/pkg/storage/legacysql/dualwrite/mock.go
+++ b/pkg/storage/legacysql/dualwrite/mock.go
@@ -29,6 +29,11 @@ func (m *mockService) NewStorage(gr schema.GroupResource, legacy rest.Storage, s
 	return nil, fmt.Errorf("not implemented")
 }
 
+// ValidateServedVersions implements Service.
+func (m *mockService) ValidateServedVersions(ctx context.Context, gr schema.GroupResource, served []schema.GroupVersion) error {
+	return nil
+}
+
 // ReadFromUnified implements Service.
 func (m *mockService) ReadFromUnified(ctx context.Context, gr schema.GroupResource) (bool, error) {
 	return m.status.ReadUnified, nil

--- a/pkg/storage/legacysql/dualwrite/service.go
+++ b/pkg/storage/legacysql/dualwrite/service.go
@@ -40,7 +40,7 @@ func (f *fakeMigrationStatusReader) GetStorageMode(ctx context.Context, gr schem
 	return mode, nil
 }
 
-func (f *fakeMigrationStatusReader) GetTargetVersion(gr schema.GroupResource) (string, bool) {
+func (f *fakeMigrationStatusReader) GetFloorVersion(gr schema.GroupResource) (string, bool) {
 	return "", false
 }
 

--- a/pkg/storage/legacysql/dualwrite/service.go
+++ b/pkg/storage/legacysql/dualwrite/service.go
@@ -40,6 +40,10 @@ func (f *fakeMigrationStatusReader) GetStorageMode(ctx context.Context, gr schem
 	return mode, nil
 }
 
+func (f *fakeMigrationStatusReader) GetTargetVersion(gr schema.GroupResource) (string, bool) {
+	return "", false
+}
+
 // NewFakeMigrationStatusReader creates a MigrationStatusReader for tests.
 // Accepts pairs of (GroupResource string, StorageMode). Resources not listed default to Legacy.
 // Example: NewFakeMigrationStatusReader("dashboards.dashboard.grafana.app", contract.StorageModeUnified)

--- a/pkg/storage/legacysql/dualwrite/service_mock.go
+++ b/pkg/storage/legacysql/dualwrite/service_mock.go
@@ -84,6 +84,54 @@ func (_c *MockService_NewStorage_Call) RunAndReturn(run func(schema.GroupResourc
 	return _c
 }
 
+// ValidateServedVersions provides a mock function with given fields: ctx, gr, served
+func (_m *MockService) ValidateServedVersions(ctx context.Context, gr schema.GroupResource, served []schema.GroupVersion) error {
+	ret := _m.Called(ctx, gr, served)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ValidateServedVersions")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, schema.GroupResource, []schema.GroupVersion) error); ok {
+		r0 = rf(ctx, gr, served)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockService_ValidateServedVersions_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ValidateServedVersions'
+type MockService_ValidateServedVersions_Call struct {
+	*mock.Call
+}
+
+// ValidateServedVersions is a helper method to define mock.On call
+//   - ctx context.Context
+//   - gr schema.GroupResource
+//   - served []schema.GroupVersion
+func (_e *MockService_Expecter) ValidateServedVersions(ctx interface{}, gr interface{}, served interface{}) *MockService_ValidateServedVersions_Call {
+	return &MockService_ValidateServedVersions_Call{Call: _e.mock.On("ValidateServedVersions", ctx, gr, served)}
+}
+
+func (_c *MockService_ValidateServedVersions_Call) Run(run func(ctx context.Context, gr schema.GroupResource, served []schema.GroupVersion)) *MockService_ValidateServedVersions_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(schema.GroupResource), args[2].([]schema.GroupVersion))
+	})
+	return _c
+}
+
+func (_c *MockService_ValidateServedVersions_Call) Return(_a0 error) *MockService_ValidateServedVersions_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockService_ValidateServedVersions_Call) RunAndReturn(run func(context.Context, schema.GroupResource, []schema.GroupVersion) error) *MockService_ValidateServedVersions_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ReadFromUnified provides a mock function with given fields: ctx, gr
 func (_m *MockService) ReadFromUnified(ctx context.Context, gr schema.GroupResource) (bool, error) {
 	ret := _m.Called(ctx, gr)

--- a/pkg/storage/legacysql/dualwrite/service_test.go
+++ b/pkg/storage/legacysql/dualwrite/service_test.go
@@ -454,7 +454,7 @@ func (f *failingStatusReader) GetStorageMode(_ context.Context, _ schema.GroupRe
 	return f.mode, f.err
 }
 
-func (f *failingStatusReader) GetTargetVersion(_ schema.GroupResource) (string, bool) {
+func (f *failingStatusReader) GetFloorVersion(_ schema.GroupResource) (string, bool) {
 	return "", false
 }
 
@@ -467,6 +467,6 @@ func (s *switchableStatusReader) GetStorageMode(_ context.Context, _ schema.Grou
 	return s.mode, nil
 }
 
-func (s *switchableStatusReader) GetTargetVersion(_ schema.GroupResource) (string, bool) {
+func (s *switchableStatusReader) GetFloorVersion(_ schema.GroupResource) (string, bool) {
 	return "", false
 }

--- a/pkg/storage/legacysql/dualwrite/service_test.go
+++ b/pkg/storage/legacysql/dualwrite/service_test.go
@@ -454,6 +454,10 @@ func (f *failingStatusReader) GetStorageMode(_ context.Context, _ schema.GroupRe
 	return f.mode, f.err
 }
 
+func (f *failingStatusReader) GetTargetVersion(_ schema.GroupResource) (string, bool) {
+	return "", false
+}
+
 // switchableStatusReader returns the current mode field, allowing tests to simulate runtime mode changes.
 type switchableStatusReader struct {
 	mode unifiedmigrations.StorageMode
@@ -461,4 +465,8 @@ type switchableStatusReader struct {
 
 func (s *switchableStatusReader) GetStorageMode(_ context.Context, _ schema.GroupResource) (unifiedmigrations.StorageMode, error) {
 	return s.mode, nil
+}
+
+func (s *switchableStatusReader) GetTargetVersion(_ schema.GroupResource) (string, bool) {
+	return "", false
 }

--- a/pkg/storage/legacysql/dualwrite/storage_mocks_test.go
+++ b/pkg/storage/legacysql/dualwrite/storage_mocks_test.go
@@ -29,6 +29,10 @@ func (r *mutableStatusReader) GetStorageMode(_ context.Context, _ schema.GroupRe
 	return r.mode, nil
 }
 
+func (r *mutableStatusReader) GetTargetVersion(_ schema.GroupResource) (string, bool) {
+	return "", false
+}
+
 func (r *mutableStatusReader) setMode(m unifiedmigrations.StorageMode) {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/pkg/storage/legacysql/dualwrite/storage_mocks_test.go
+++ b/pkg/storage/legacysql/dualwrite/storage_mocks_test.go
@@ -29,7 +29,7 @@ func (r *mutableStatusReader) GetStorageMode(_ context.Context, _ schema.GroupRe
 	return r.mode, nil
 }
 
-func (r *mutableStatusReader) GetTargetVersion(_ schema.GroupResource) (string, bool) {
+func (r *mutableStatusReader) GetFloorVersion(_ schema.GroupResource) (string, bool) {
 	return "", false
 }
 

--- a/pkg/storage/legacysql/dualwrite/storage_service.go
+++ b/pkg/storage/legacysql/dualwrite/storage_service.go
@@ -76,24 +76,25 @@ func (m *storageService) NewStorage(gr schema.GroupResource, legacy rest.Storage
 	}
 }
 
-// ValidateServedVersions guards against serving unified storage under a migrated
-// apiVersion the apiserver never registered.
+// ValidateServedVersions guards against serving unified storage while migrated data
+// carries an apiVersion the apiserver no longer registers. served must be the versions
+// for this specific resource, not the whole group.
 func (m *storageService) ValidateServedVersions(ctx context.Context, gr schema.GroupResource, served []schema.GroupVersion) error {
 	if m.getStorageMode(ctx, gr) == unifiedmigrations.StorageModeLegacy || m.statusReader == nil {
 		return nil
 	}
-	target, ok := m.statusReader.GetTargetVersion(gr)
+	floor, ok := m.statusReader.GetFloorVersion(gr)
 	if !ok {
 		return nil
 	}
 	for _, gv := range served {
-		if gv.Version == target {
+		if gv.Version == floor {
 			return nil
 		}
 	}
 	return fmt.Errorf(
-		"resource %q is served from unified storage under apiVersion %q, but that version is not registered in the apiserver scheme (served versions: %v)",
-		gr.String(), target, servedVersionStrings(served),
+		"resource %q may hold unified-storage objects at apiVersion %q, but that version is not registered for the resource in the apiserver scheme (served versions: %v)",
+		gr.String(), floor, servedVersionStrings(served),
 	)
 }
 

--- a/pkg/storage/legacysql/dualwrite/storage_service.go
+++ b/pkg/storage/legacysql/dualwrite/storage_service.go
@@ -76,6 +76,35 @@ func (m *storageService) NewStorage(gr schema.GroupResource, legacy rest.Storage
 	}
 }
 
+// ValidateServedVersions guards against serving unified storage under a migrated
+// apiVersion the apiserver never registered.
+func (m *storageService) ValidateServedVersions(ctx context.Context, gr schema.GroupResource, served []schema.GroupVersion) error {
+	if m.getStorageMode(ctx, gr) == unifiedmigrations.StorageModeLegacy || m.statusReader == nil {
+		return nil
+	}
+	target, ok := m.statusReader.GetTargetVersion(gr)
+	if !ok {
+		return nil
+	}
+	for _, gv := range served {
+		if gv.Version == target {
+			return nil
+		}
+	}
+	return fmt.Errorf(
+		"resource %q is served from unified storage under apiVersion %q, but that version is not registered in the apiserver scheme (served versions: %v)",
+		gr.String(), target, servedVersionStrings(served),
+	)
+}
+
+func servedVersionStrings(served []schema.GroupVersion) []string {
+	out := make([]string, 0, len(served))
+	for _, gv := range served {
+		out = append(out, gv.Version)
+	}
+	return out
+}
+
 // storageModeFromConfigMode maps a DualWriterMode config value to a StorageMode.
 func storageModeFromConfigMode(mode rest.DualWriterMode) unifiedmigrations.StorageMode {
 	switch {

--- a/pkg/storage/legacysql/dualwrite/types.go
+++ b/pkg/storage/legacysql/dualwrite/types.go
@@ -39,6 +39,10 @@ type Service interface {
 	// Create a managed k8s storage instance
 	NewStorage(gr schema.GroupResource, legacy grafanarest.Storage, storage grafanarest.Storage) (grafanarest.Storage, error)
 
+	// ValidateServedVersions returns an error when a resource written to unified storage
+	// would use a migrated apiVersion that is not among the versions the apiserver serves.
+	ValidateServedVersions(ctx context.Context, gr schema.GroupResource, served []schema.GroupVersion) error
+
 	// Check if the dual writes is reading from unified storage (mode3++)
 	ReadFromUnified(ctx context.Context, gr schema.GroupResource) (bool, error)
 

--- a/pkg/storage/legacysql/dualwrite/types.go
+++ b/pkg/storage/legacysql/dualwrite/types.go
@@ -39,8 +39,8 @@ type Service interface {
 	// Create a managed k8s storage instance
 	NewStorage(gr schema.GroupResource, legacy grafanarest.Storage, storage grafanarest.Storage) (grafanarest.Storage, error)
 
-	// ValidateServedVersions returns an error when a resource written to unified storage
-	// would use a migrated apiVersion that is not among the versions the apiserver serves.
+	// ValidateServedVersions returns an error when a resource's migrated apiVersion is
+	// not among the versions the apiserver serves.
 	ValidateServedVersions(ctx context.Context, gr schema.GroupResource, served []schema.GroupVersion) error
 
 	// Check if the dual writes is reading from unified storage (mode3++)

--- a/pkg/storage/legacysql/dualwrite/validate_served_versions_test.go
+++ b/pkg/storage/legacysql/dualwrite/validate_served_versions_test.go
@@ -15,17 +15,17 @@ import (
 
 // versionedStatusReader is a configurable MigrationStatusReader for validation tests.
 type versionedStatusReader struct {
-	mode          unifiedmigrations.StorageMode
-	targetVersion string
-	hasTarget     bool
+	mode         unifiedmigrations.StorageMode
+	floorVersion string
+	hasFloor     bool
 }
 
 func (r *versionedStatusReader) GetStorageMode(_ context.Context, _ schema.GroupResource) (unifiedmigrations.StorageMode, error) {
 	return r.mode, nil
 }
 
-func (r *versionedStatusReader) GetTargetVersion(_ schema.GroupResource) (string, bool) {
-	return r.targetVersion, r.hasTarget
+func (r *versionedStatusReader) GetFloorVersion(_ schema.GroupResource) (string, bool) {
+	return r.floorVersion, r.hasFloor
 }
 
 func TestValidateServedVersions(t *testing.T) {
@@ -41,29 +41,29 @@ func TestValidateServedVersions(t *testing.T) {
 	}
 
 	t.Run("legacy mode never validates", func(t *testing.T) {
-		svc := newSvc(&versionedStatusReader{mode: unifiedmigrations.StorageModeLegacy, targetVersion: "v1", hasTarget: true})
+		svc := newSvc(&versionedStatusReader{mode: unifiedmigrations.StorageModeLegacy, floorVersion: "v1", hasFloor: true})
 		require.NoError(t, svc.ValidateServedVersions(context.Background(), gr, onlyV1alpha1))
 	})
 
-	t.Run("target version served in unified mode", func(t *testing.T) {
-		svc := newSvc(&versionedStatusReader{mode: unifiedmigrations.StorageModeUnified, targetVersion: "v1", hasTarget: true})
+	t.Run("floor version served in unified mode", func(t *testing.T) {
+		svc := newSvc(&versionedStatusReader{mode: unifiedmigrations.StorageModeUnified, floorVersion: "v1", hasFloor: true})
 		require.NoError(t, svc.ValidateServedVersions(context.Background(), gr, v1))
 	})
 
-	t.Run("target version not served in unified mode returns error", func(t *testing.T) {
-		svc := newSvc(&versionedStatusReader{mode: unifiedmigrations.StorageModeUnified, targetVersion: "v1", hasTarget: true})
+	t.Run("floor version not served in unified mode returns error", func(t *testing.T) {
+		svc := newSvc(&versionedStatusReader{mode: unifiedmigrations.StorageModeUnified, floorVersion: "v1", hasFloor: true})
 		err := svc.ValidateServedVersions(context.Background(), gr, onlyV1alpha1)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "v1")
 	})
 
-	t.Run("target version not served in dual-write mode also returns error", func(t *testing.T) {
-		svc := newSvc(&versionedStatusReader{mode: unifiedmigrations.StorageModeDualWrite, targetVersion: "v1", hasTarget: true})
+	t.Run("floor version not served in dual-write mode also returns error", func(t *testing.T) {
+		svc := newSvc(&versionedStatusReader{mode: unifiedmigrations.StorageModeDualWrite, floorVersion: "v1", hasFloor: true})
 		require.Error(t, svc.ValidateServedVersions(context.Background(), gr, onlyV1alpha1))
 	})
 
-	t.Run("dynamic or undeclared target version is skipped", func(t *testing.T) {
-		svc := newSvc(&versionedStatusReader{mode: unifiedmigrations.StorageModeUnified, hasTarget: false})
+	t.Run("undeclared floor version is skipped", func(t *testing.T) {
+		svc := newSvc(&versionedStatusReader{mode: unifiedmigrations.StorageModeUnified, hasFloor: false})
 		require.NoError(t, svc.ValidateServedVersions(context.Background(), gr, onlyV1alpha1))
 	})
 

--- a/pkg/storage/legacysql/dualwrite/validate_served_versions_test.go
+++ b/pkg/storage/legacysql/dualwrite/validate_served_versions_test.go
@@ -1,0 +1,81 @@
+package dualwrite
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/grafana/grafana/pkg/apiserver/rest"
+	"github.com/grafana/grafana/pkg/setting"
+	unifiedmigrations "github.com/grafana/grafana/pkg/storage/unified/migrations/contract"
+)
+
+// versionedStatusReader is a configurable MigrationStatusReader for validation tests.
+type versionedStatusReader struct {
+	mode          unifiedmigrations.StorageMode
+	targetVersion string
+	hasTarget     bool
+}
+
+func (r *versionedStatusReader) GetStorageMode(_ context.Context, _ schema.GroupResource) (unifiedmigrations.StorageMode, error) {
+	return r.mode, nil
+}
+
+func (r *versionedStatusReader) GetTargetVersion(_ schema.GroupResource) (string, bool) {
+	return r.targetVersion, r.hasTarget
+}
+
+func TestValidateServedVersions(t *testing.T) {
+	gr := schema.GroupResource{Group: "preferences.grafana.app", Resource: "preferences"}
+	v1 := []schema.GroupVersion{{Group: gr.Group, Version: "v1"}}
+	onlyV1alpha1 := []schema.GroupVersion{{Group: gr.Group, Version: "v1alpha1"}}
+
+	newSvc := func(r unifiedmigrations.MigrationStatusReader) *storageService {
+		return &storageService{
+			statusReader: r,
+			metrics:      provideDualWriterMetrics(prometheus.NewRegistry()),
+		}
+	}
+
+	t.Run("legacy mode never validates", func(t *testing.T) {
+		svc := newSvc(&versionedStatusReader{mode: unifiedmigrations.StorageModeLegacy, targetVersion: "v1", hasTarget: true})
+		require.NoError(t, svc.ValidateServedVersions(context.Background(), gr, onlyV1alpha1))
+	})
+
+	t.Run("target version served in unified mode", func(t *testing.T) {
+		svc := newSvc(&versionedStatusReader{mode: unifiedmigrations.StorageModeUnified, targetVersion: "v1", hasTarget: true})
+		require.NoError(t, svc.ValidateServedVersions(context.Background(), gr, v1))
+	})
+
+	t.Run("target version not served in unified mode returns error", func(t *testing.T) {
+		svc := newSvc(&versionedStatusReader{mode: unifiedmigrations.StorageModeUnified, targetVersion: "v1", hasTarget: true})
+		err := svc.ValidateServedVersions(context.Background(), gr, onlyV1alpha1)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "v1")
+	})
+
+	t.Run("target version not served in dual-write mode also returns error", func(t *testing.T) {
+		svc := newSvc(&versionedStatusReader{mode: unifiedmigrations.StorageModeDualWrite, targetVersion: "v1", hasTarget: true})
+		require.Error(t, svc.ValidateServedVersions(context.Background(), gr, onlyV1alpha1))
+	})
+
+	t.Run("dynamic or undeclared target version is skipped", func(t *testing.T) {
+		svc := newSvc(&versionedStatusReader{mode: unifiedmigrations.StorageModeUnified, hasTarget: false})
+		require.NoError(t, svc.ValidateServedVersions(context.Background(), gr, onlyV1alpha1))
+	})
+
+	t.Run("nil status reader is skipped even when unified via config", func(t *testing.T) {
+		// No statusReader: mode is resolved from config. Unified mode with a version
+		// mismatch must still be skipped because the target version is unknowable here.
+		svc := &storageService{
+			cfg: &setting.Cfg{UnifiedStorage: map[string]setting.UnifiedStorageConfig{
+				gr.String(): {DualWriterMode: rest.Mode5},
+			}},
+			metrics: provideDualWriterMetrics(prometheus.NewRegistry()),
+		}
+		require.NoError(t, svc.ValidateServedVersions(context.Background(), gr, onlyV1alpha1))
+	})
+}

--- a/pkg/storage/unified/migrations/contract/migrations.go
+++ b/pkg/storage/unified/migrations/contract/migrations.go
@@ -60,7 +60,7 @@ func (m StorageMode) String() string {
 type MigrationStatusReader interface {
 	GetStorageMode(ctx context.Context, gr schema.GroupResource) (StorageMode, error)
 
-	// GetTargetVersion returns the static apiVersion (e.g. "v1") the migrator writes for
-	// a resource. ok is false when no migration is declared or the version is dynamic.
-	GetTargetVersion(gr schema.GroupResource) (version string, ok bool)
+	// GetFloorVersion returns the oldest apiVersion that may exist in unified storage for a
+	// resource. ok is false when no migration declares a floor, so the guard cannot validate it.
+	GetFloorVersion(gr schema.GroupResource) (version string, ok bool)
 }

--- a/pkg/storage/unified/migrations/contract/migrations.go
+++ b/pkg/storage/unified/migrations/contract/migrations.go
@@ -59,4 +59,8 @@ func (m StorageMode) String() string {
 //  4. Otherwise → Legacy
 type MigrationStatusReader interface {
 	GetStorageMode(ctx context.Context, gr schema.GroupResource) (StorageMode, error)
+
+	// GetTargetVersion returns the static apiVersion (e.g. "v1") the migrator writes for
+	// a resource. ok is false when no migration is declared or the version is dynamic.
+	GetTargetVersion(gr schema.GroupResource) (version string, ok bool)
 }

--- a/pkg/storage/unified/migrations/registry.go
+++ b/pkg/storage/unified/migrations/registry.go
@@ -26,12 +26,27 @@ type ValidatorFactory func(client resourcepb.ResourceIndexClient, driverName str
 // MigratorFunc is the signature for resource migration functions.
 type MigratorFunc = func(ctx context.Context, orgId int64, opts MigrateOptions, stream resourcepb.BulkStore_BulkProcessClient) error
 
+// DynamicTargetVersion is the sentinel TargetVersion for resources whose written
+// apiVersion is resolved per object (dashboards: per-row api_version; datasources:
+// per-plugin group). Gate these on the migrator's floor version, not this value.
+const DynamicTargetVersion = "*"
+
 // ResourceInfo extends GroupResource with additional metadata needed for migration.
 type ResourceInfo struct {
 	schema.GroupResource
 	// LockTables are the legacy database tables to lock during migration.
 	// This must include every table the migrator reads from.
 	LockTables []string
+	// TargetVersion is the apiVersion (version part only, e.g. "v1") the migrator
+	// writes. Per-resource because resources sharing one MigrationDefinition
+	// (folders and dashboards) may target different versions. Use
+	// DynamicTargetVersion when resolved per object.
+	TargetVersion string
+}
+
+// IsDynamicVersion reports whether the written apiVersion is resolved per object.
+func (ri ResourceInfo) IsDynamicVersion() bool {
+	return ri.TargetVersion == DynamicTargetVersion
 }
 
 // MigrationDefinition defines a resource migration.

--- a/pkg/storage/unified/migrations/registry.go
+++ b/pkg/storage/unified/migrations/registry.go
@@ -26,27 +26,16 @@ type ValidatorFactory func(client resourcepb.ResourceIndexClient, driverName str
 // MigratorFunc is the signature for resource migration functions.
 type MigratorFunc = func(ctx context.Context, orgId int64, opts MigrateOptions, stream resourcepb.BulkStore_BulkProcessClient) error
 
-// DynamicTargetVersion is the sentinel TargetVersion for resources whose written
-// apiVersion is resolved per object (dashboards: per-row api_version; datasources:
-// per-plugin group). Gate these on the migrator's floor version, not this value.
-const DynamicTargetVersion = "*"
-
 // ResourceInfo extends GroupResource with additional metadata needed for migration.
 type ResourceInfo struct {
 	schema.GroupResource
 	// LockTables are the legacy database tables to lock during migration.
 	// This must include every table the migrator reads from.
 	LockTables []string
-	// TargetVersion is the apiVersion (version part only, e.g. "v1") the migrator
-	// writes. Per-resource because resources sharing one MigrationDefinition
-	// (folders and dashboards) may target different versions. Use
-	// DynamicTargetVersion when resolved per object.
-	TargetVersion string
-}
-
-// IsDynamicVersion reports whether the written apiVersion is resolved per object.
-func (ri ResourceInfo) IsDynamicVersion() bool {
-	return ri.TargetVersion == DynamicTargetVersion
+	// FloorVersion is the oldest apiVersion (version part only, e.g. "v1beta1") that may
+	// exist in unified storage for this resource. The served-version guard requires it to
+	// stay registered in the scheme, else migrated data still carrying it becomes unservable.
+	FloorVersion string
 }
 
 // MigrationDefinition defines a resource migration.

--- a/pkg/storage/unified/migrations/status_reader.go
+++ b/pkg/storage/unified/migrations/status_reader.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -185,13 +186,25 @@ func (r *migrationStatusReader) findDefinition(gr schema.GroupResource) (Migrati
 func (r *migrationStatusReader) GetFloorVersion(gr schema.GroupResource) (string, bool) {
 	for _, def := range r.registry.All() {
 		for _, ri := range def.Resources {
-			if ri.GroupResource == gr {
-				if ri.FloorVersion == "" {
-					return "", false
-				}
+			if ri.FloorVersion == "" {
+				continue
+			}
+			if floorResourceMatches(gr, ri.GroupResource) {
 				return ri.FloorVersion, true
 			}
 		}
 	}
 	return "", false
+}
+
+// floorResourceMatches reports whether gr is covered by the registered floor
+// GroupResource. Besides an exact match, it accepts plugin-specific subgroups: the
+// datasource migration registers a single "datasource.grafana.app" floor, but dual
+// writing addresses each plugin under its own group (e.g. "prometheus.datasource.grafana.app").
+// Those share the resource and carry the registered group as a suffix.
+func floorResourceMatches(gr, floor schema.GroupResource) bool {
+	if gr == floor {
+		return true
+	}
+	return gr.Resource == floor.Resource && strings.HasSuffix(gr.Group, "."+floor.Group)
 }

--- a/pkg/storage/unified/migrations/status_reader.go
+++ b/pkg/storage/unified/migrations/status_reader.go
@@ -180,3 +180,18 @@ func (r *migrationStatusReader) findDefinition(gr schema.GroupResource) (Migrati
 	}
 	return MigrationDefinition{}, false
 }
+
+// GetTargetVersion implements contract.MigrationStatusReader.
+func (r *migrationStatusReader) GetTargetVersion(gr schema.GroupResource) (string, bool) {
+	for _, def := range r.registry.All() {
+		for _, ri := range def.Resources {
+			if ri.GroupResource == gr {
+				if ri.TargetVersion == "" || ri.IsDynamicVersion() {
+					return "", false
+				}
+				return ri.TargetVersion, true
+			}
+		}
+	}
+	return "", false
+}

--- a/pkg/storage/unified/migrations/status_reader.go
+++ b/pkg/storage/unified/migrations/status_reader.go
@@ -181,15 +181,15 @@ func (r *migrationStatusReader) findDefinition(gr schema.GroupResource) (Migrati
 	return MigrationDefinition{}, false
 }
 
-// GetTargetVersion implements contract.MigrationStatusReader.
-func (r *migrationStatusReader) GetTargetVersion(gr schema.GroupResource) (string, bool) {
+// GetFloorVersion implements contract.MigrationStatusReader.
+func (r *migrationStatusReader) GetFloorVersion(gr schema.GroupResource) (string, bool) {
 	for _, def := range r.registry.All() {
 		for _, ri := range def.Resources {
 			if ri.GroupResource == gr {
-				if ri.TargetVersion == "" || ri.IsDynamicVersion() {
+				if ri.FloorVersion == "" {
 					return "", false
 				}
-				return ri.TargetVersion, true
+				return ri.FloorVersion, true
 			}
 		}
 	}

--- a/pkg/storage/unified/migrations/status_reader_test.go
+++ b/pkg/storage/unified/migrations/status_reader_test.go
@@ -66,9 +66,9 @@ func TestMigrationStatusReader_FindDefinition(t *testing.T) {
 	}
 }
 
-func TestMigrationStatusReader_GetTargetVersion(t *testing.T) {
+func TestMigrationStatusReader_GetFloorVersion(t *testing.T) {
 	staticGR := schema.GroupResource{Resource: "preferences", Group: "preferences.grafana.app"}
-	dynamicGR := schema.GroupResource{Resource: "dashboards", Group: "dashboard.grafana.app"}
+	floorGR := schema.GroupResource{Resource: "dashboards", Group: "dashboard.grafana.app"}
 	emptyGR := schema.GroupResource{Resource: "playlists", Group: "playlist.grafana.app"}
 	unknownGR := schema.GroupResource{Resource: "unknown", Group: "unknown.grafana.app"}
 
@@ -76,12 +76,12 @@ func TestMigrationStatusReader_GetTargetVersion(t *testing.T) {
 	registry.Register(MigrationDefinition{
 		ID:          "preferences",
 		MigrationID: "preferences migration",
-		Resources:   []ResourceInfo{{GroupResource: staticGR, TargetVersion: "v1"}},
+		Resources:   []ResourceInfo{{GroupResource: staticGR, FloorVersion: "v1"}},
 	})
 	registry.Register(MigrationDefinition{
 		ID:          "dashboards",
 		MigrationID: "dashboards migration",
-		Resources:   []ResourceInfo{{GroupResource: dynamicGR, TargetVersion: DynamicTargetVersion}},
+		Resources:   []ResourceInfo{{GroupResource: floorGR, FloorVersion: "v0alpha1"}},
 	})
 	registry.Register(MigrationDefinition{
 		ID:          "playlists",
@@ -98,14 +98,14 @@ func TestMigrationStatusReader_GetTargetVersion(t *testing.T) {
 		wantOK      bool
 	}{
 		{name: "static version returned", gr: staticGR, wantVersion: "v1", wantOK: true},
-		{name: "dynamic version skipped", gr: dynamicGR, wantOK: false},
-		{name: "empty target version skipped", gr: emptyGR, wantOK: false},
+		{name: "floor version returned", gr: floorGR, wantVersion: "v0alpha1", wantOK: true},
+		{name: "empty floor version skipped", gr: emptyGR, wantOK: false},
 		{name: "unregistered resource skipped", gr: unknownGR, wantOK: false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			version, ok := reader.GetTargetVersion(tt.gr)
+			version, ok := reader.GetFloorVersion(tt.gr)
 			require.Equal(t, tt.wantOK, ok)
 			require.Equal(t, tt.wantVersion, version)
 		})

--- a/pkg/storage/unified/migrations/status_reader_test.go
+++ b/pkg/storage/unified/migrations/status_reader_test.go
@@ -66,6 +66,52 @@ func TestMigrationStatusReader_FindDefinition(t *testing.T) {
 	}
 }
 
+func TestMigrationStatusReader_GetTargetVersion(t *testing.T) {
+	staticGR := schema.GroupResource{Resource: "preferences", Group: "preferences.grafana.app"}
+	dynamicGR := schema.GroupResource{Resource: "dashboards", Group: "dashboard.grafana.app"}
+	emptyGR := schema.GroupResource{Resource: "playlists", Group: "playlist.grafana.app"}
+	unknownGR := schema.GroupResource{Resource: "unknown", Group: "unknown.grafana.app"}
+
+	registry := NewMigrationRegistry()
+	registry.Register(MigrationDefinition{
+		ID:          "preferences",
+		MigrationID: "preferences migration",
+		Resources:   []ResourceInfo{{GroupResource: staticGR, TargetVersion: "v1"}},
+	})
+	registry.Register(MigrationDefinition{
+		ID:          "dashboards",
+		MigrationID: "dashboards migration",
+		Resources:   []ResourceInfo{{GroupResource: dynamicGR, TargetVersion: DynamicTargetVersion}},
+	})
+	registry.Register(MigrationDefinition{
+		ID:          "playlists",
+		MigrationID: "playlists migration",
+		Resources:   []ResourceInfo{{GroupResource: emptyGR}},
+	})
+
+	reader := newTestStatusReader(t, &setting.Cfg{}, registry)
+
+	tests := []struct {
+		name        string
+		gr          schema.GroupResource
+		wantVersion string
+		wantOK      bool
+	}{
+		{name: "static version returned", gr: staticGR, wantVersion: "v1", wantOK: true},
+		{name: "dynamic version skipped", gr: dynamicGR, wantOK: false},
+		{name: "empty target version skipped", gr: emptyGR, wantOK: false},
+		{name: "unregistered resource skipped", gr: unknownGR, wantOK: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			version, ok := reader.GetTargetVersion(tt.gr)
+			require.Equal(t, tt.wantOK, ok)
+			require.Equal(t, tt.wantVersion, version)
+		})
+	}
+}
+
 func TestMigrationStatusReader_GetStorageMode_ConfigResolution(t *testing.T) {
 	playlistGR := schema.GroupResource{Resource: "playlists", Group: "playlist.grafana.app"}
 	unknownGR := schema.GroupResource{Resource: "unknown", Group: "unknown.grafana.app"}

--- a/pkg/storage/unified/migrations/status_reader_test.go
+++ b/pkg/storage/unified/migrations/status_reader_test.go
@@ -71,6 +71,11 @@ func TestMigrationStatusReader_GetFloorVersion(t *testing.T) {
 	floorGR := schema.GroupResource{Resource: "dashboards", Group: "dashboard.grafana.app"}
 	emptyGR := schema.GroupResource{Resource: "playlists", Group: "playlist.grafana.app"}
 	unknownGR := schema.GroupResource{Resource: "unknown", Group: "unknown.grafana.app"}
+	// datasource migration registers a single primary group; dual writing addresses
+	// each plugin under its own subgroup (e.g. "prometheus.datasource.grafana.app").
+	dsGR := schema.GroupResource{Resource: "datasources", Group: "datasource.grafana.app"}
+	dsPluginGR := schema.GroupResource{Resource: "datasources", Group: "prometheus.datasource.grafana.app"}
+	dsWrongResourceGR := schema.GroupResource{Resource: "other", Group: "prometheus.datasource.grafana.app"}
 
 	registry := NewMigrationRegistry()
 	registry.Register(MigrationDefinition{
@@ -88,6 +93,11 @@ func TestMigrationStatusReader_GetFloorVersion(t *testing.T) {
 		MigrationID: "playlists migration",
 		Resources:   []ResourceInfo{{GroupResource: emptyGR}},
 	})
+	registry.Register(MigrationDefinition{
+		ID:          "datasources",
+		MigrationID: "datasources migration",
+		Resources:   []ResourceInfo{{GroupResource: dsGR, FloorVersion: "v0alpha1"}},
+	})
 
 	reader := newTestStatusReader(t, &setting.Cfg{}, registry)
 
@@ -101,6 +111,9 @@ func TestMigrationStatusReader_GetFloorVersion(t *testing.T) {
 		{name: "floor version returned", gr: floorGR, wantVersion: "v0alpha1", wantOK: true},
 		{name: "empty floor version skipped", gr: emptyGR, wantOK: false},
 		{name: "unregistered resource skipped", gr: unknownGR, wantOK: false},
+		{name: "primary datasource group returned", gr: dsGR, wantVersion: "v0alpha1", wantOK: true},
+		{name: "plugin datasource subgroup returned", gr: dsPluginGR, wantVersion: "v0alpha1", wantOK: true},
+		{name: "plugin subgroup with mismatched resource skipped", gr: dsWrongResourceGR, wantOK: false},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
1. Add `FloorVersion` for each unified storage resource migration registration.
2. Make dual writer resource api version aware. Fail to move to `DualWriter` or `Unified` mode unless the resource version scheme is successfully registered.

Ticket: https://github.com/grafana/search-and-storage-team/issues/862