### PR TITLE
Search: don't reuse indexes without resource versions

### DIFF
--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -1535,6 +1535,11 @@ func (b *bleveBackend) findPreviousFileBasedIndex(resourceDir string) (bleve.Ind
 			_ = idx.Close()
 			continue
 		}
+		if indexRV <= 0 {
+			b.log.Warn("index has non-positive rv, not reusing it", "indexDir", indexDir, "rv", indexRV)
+			_ = idx.Close()
+			continue
+		}
 
 		b.registerInFlightBuildDir(indexDir)
 		return idx, indexName, indexRV, nil

--- a/pkg/storage/unified/search/bleve_test.go
+++ b/pkg/storage/unified/search/bleve_test.go
@@ -1364,6 +1364,42 @@ func TestBuildIndex(t *testing.T) {
 	}
 }
 
+func TestBuildIndexDoesNotReuseFileIndexWithoutResourceVersion(t *testing.T) {
+	ns := resource.NamespacedResource{
+		Namespace: "test",
+		Group:     "group",
+		Resource:  "resource",
+	}
+	tmpDir := t.TempDir()
+	backend, _ := setupBleveBackend(t, withRootDir(tmpDir))
+
+	mapper, err := GetBleveMappings(nil, ns.Group, ns.Resource, nil)
+	require.NoError(t, err)
+	resourceDir := backend.getResourceDir(ns)
+	require.NoError(t, os.MkdirAll(resourceDir, 0o750))
+	unfinished, err := newBleveIndex(filepath.Join(resourceDir, formatIndexName(time.Now())), mapper, time.Now(), buildVersion, nil, "")
+	require.NoError(t, err)
+	rv, err := getRV(unfinished)
+	require.NoError(t, err)
+	require.Zero(t, rv)
+	require.NoError(t, unfinished.Close())
+
+	buildCalls := 0
+	builder := func(index resource.ResourceIndex) (int64, error) {
+		buildCalls++
+		return indexTestDocs(ns, 10, 100)(index)
+	}
+	idx, err := backend.BuildIndex(t.Context(), ns, 10, "test", builder, nil, false, time.Time{}, 0)
+	require.NoError(t, err)
+	require.Equal(t, 1, buildCalls)
+
+	count, err := idx.DocCount(t.Context(), "", nil)
+	require.NoError(t, err)
+	require.Equal(t, int64(10), count)
+	require.Equal(t, int64(100), idx.(*bleveIndex).resourceVersion.Load())
+	verifyDirEntriesCount(t, resourceDir, 1)
+}
+
 func TestBuildIndexAdaptivePromotion(t *testing.T) {
 	ns := resource.NamespacedResource{
 		Namespace: "test",


### PR DESCRIPTION
Grafana currently reuses a local search index even when it has no valid resource version. This can happen when Grafana stops unexpectedly during the initial index build because the resource version is only persisted after the build completes.

Without a resource version, there is no checkpoint from which to update the index incrementally. The legacy SQL backend must process all changes from the beginning, effectively rebuilding the index contents, while the KV backend rejects the update. This change skips such incomplete indexes and builds a fresh index instead.