### PR TITLE
Menu: Announce submenu triggers to screen readers

### DIFF
--- a/packages/grafana-ui/src/components/Menu/MenuItem.test.tsx
+++ b/packages/grafana-ui/src/components/Menu/MenuItem.test.tsx
@@ -85,6 +85,31 @@ describe('MenuItem', () => {
     expect(await screen.findByTestId(selectors.components.Menu.SubMenu.container)).toBeInTheDocument();
   });
 
+  it('announces subMenu parents to screen readers via aria-haspopup and aria-expanded', async () => {
+    const childItems = [
+      <MenuItem key="subitem1" label="subitem1" icon="history" />,
+      <MenuItem key="subitem2" label="subitem2" icon="apps" />,
+    ];
+
+    render(getMenuItem({ childItems }));
+
+    const item = screen.getByLabelText(selectors.components.Menu.MenuItem('Test'));
+    expect(item).toHaveAttribute('aria-haspopup', 'menu');
+    expect(item).toHaveAttribute('aria-expanded', 'false');
+
+    await user.hover(item);
+
+    expect(item).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('does not set aria-haspopup or aria-expanded on items without a subMenu', () => {
+    render(getMenuItem({ onClick: jest.fn() }));
+
+    const item = screen.getByLabelText(selectors.components.Menu.MenuItem('Test'));
+    expect(item).not.toHaveAttribute('aria-haspopup');
+    expect(item).not.toHaveAttribute('aria-expanded');
+  });
+
   it('renders with role="menuitem" when URL is passed (default for menu semantics)', () => {
     render(<MenuItem label="URL Item" url="/some-url" />);
     expect(screen.getByRole('menuitem', { name: 'URL Item' })).toBeInTheDocument();

--- a/packages/grafana-ui/src/components/Menu/MenuItem.tsx
+++ b/packages/grafana-ui/src/components/Menu/MenuItem.tsx
@@ -207,6 +207,10 @@ export const MenuItem = React.memo(
         data-testid={testId}
         aria-label={ariaLabel}
         aria-checked={ariaChecked}
+        // Announce to screen readers that this item opens a submenu, and whether it is
+        // currently expanded, so nested items (e.g. under "More...") are discoverable.
+        aria-haspopup={hasSubMenu ? 'menu' : undefined}
+        aria-expanded={hasSubMenu ? isSubMenuOpen : undefined}
         tabIndex={tabIndex}
         {...disabledProps}
       >


### PR DESCRIPTION
## What this PR does

Submenu-parent menu items — such as the panel **"More…"** menu that contains **"Copy"** and **"New alert rule"** — were rendered as ordinary menu items with no `aria-haspopup` or `aria-expanded`. Screen readers therefore gave no signal that the item opens a submenu, and the nested items were not surfaced to assistive technology.

This adds `aria-haspopup="menu"` and `aria-expanded` (reflecting the open/closed state) to menu items that have a submenu.

## Why

WCAG 4.1.2 (Name, Role, Value) failure. The accessible *names* of the items were already correct — the missing piece was the role/state relationship that tells the screen reader the trigger is expandable. The fix lives in the shared `@grafana/ui` `MenuItem`, so it covers every submenu (More, Share, Styles, Inspect) at once.

## Testing

- Added unit tests: submenu parents expose `aria-haspopup="menu"` and toggle `aria-expanded` on open; non-submenu items get neither.
- All Menu tests pass, ESLint and `tsc` clean.
