### PR TITLE
Logs Table: Add support for displayName in the Field Selector component

### DIFF
--- a/public/app/features/logs/components/fieldSelector/ActiveFields.tsx
+++ b/public/app/features/logs/components/fieldSelector/ActiveFields.tsx
@@ -113,7 +113,7 @@ export const ActiveFields = ({
                           title={t(
                             'logs.field-selector.label-title',
                             `{{fieldName}} appears in {{percentage}}% of log lines`,
-                            { fieldName: field.name, percentage: field.stats.percentOfLinesWithLabel }
+                            { fieldName: field.displayName ?? field.name, percentage: field.stats.percentOfLinesWithLabel }
                           )}
                         >
                           <Field

--- a/public/app/features/logs/components/fieldSelector/AvailableFields.tsx
+++ b/public/app/features/logs/components/fieldSelector/AvailableFields.tsx
@@ -31,7 +31,7 @@ export const AvailableFields = ({ activeFields, fields, toggle, reorder }: Props
             key={field.name}
             className={styles.wrap}
             title={t('logs.field-selector.label-title', `{{fieldName}} appears in {{percentage}}% of log lines`, {
-              fieldName: field.name,
+              fieldName: field.displayName ?? field.name,
               percentage: field.stats.percentOfLinesWithLabel,
             })}
           >

--- a/public/app/features/logs/components/fieldSelector/Field.tsx
+++ b/public/app/features/logs/components/fieldSelector/Field.tsx
@@ -40,7 +40,7 @@ export function Field({
       <div className={styles.contentWrap}>
         <Checkbox
           className={styles.checkboxLabel}
-          label={getNormalizedFieldName(field.name)}
+          label={field.displayName ?? getNormalizedFieldName(field.name)}
           onChange={handleChange}
           checked={active}
         />

--- a/public/app/features/logs/components/fieldSelector/FieldSelector.tsx
+++ b/public/app/features/logs/components/fieldSelector/FieldSelector.tsx
@@ -85,9 +85,6 @@ export const FieldSelector = ({
     return suggestedFields.filter((_, index) => idxs.includes(index));
   }, [searchValue, suggestedFields]);
 
-  console.log(filteredFields);
-  console.log(filteredSuggestedFields);
-
   return (
     <section className={styles.sidebar}>
       <FieldSearch collapse={collapse} onChange={onSearchInputChange} value={searchValue} />

--- a/public/app/features/logs/components/fieldSelector/FieldSelector.tsx
+++ b/public/app/features/logs/components/fieldSelector/FieldSelector.tsx
@@ -22,6 +22,7 @@ interface FieldStats {
 
 export interface FieldWithStats {
   name: string;
+  displayName?: string;
   stats: FieldStats;
 }
 
@@ -67,7 +68,7 @@ export const FieldSelector = ({
       return fields;
     }
     const idxs = fuzzySearch(
-      fields.map((field) => field.name),
+      fields.map((field) => field.displayName ?? field.name),
       searchValue
     );
     return fields.filter((_, index) => idxs.includes(index));
@@ -78,11 +79,14 @@ export const FieldSelector = ({
       return suggestedFields;
     }
     const idxs = fuzzySearch(
-      suggestedFields.map((field) => field.name),
+      suggestedFields.map((field) => field.displayName ?? field.name),
       searchValue
     );
     return suggestedFields.filter((_, index) => idxs.includes(index));
   }, [searchValue, suggestedFields]);
+
+  console.log(filteredFields);
+  console.log(filteredSuggestedFields);
 
   return (
     <section className={styles.sidebar}>

--- a/public/app/features/logs/components/fieldSelector/LogListFieldSelector.tsx
+++ b/public/app/features/logs/components/fieldSelector/LogListFieldSelector.tsx
@@ -13,7 +13,7 @@ import { type LogListModel } from '../panel/processing';
 
 import { FieldSelector, FIELD_SELECTOR_MIN_WIDTH, getDefaultFieldSelectorWidth } from './FieldSelector';
 import { getFieldSelectorWidth } from './fieldSelectorUtils';
-import { getFieldsWithStats } from './getFieldsWithStats';
+import { getFieldDisplayNames, getFieldsWithStats, withDisplayNames } from './getFieldsWithStats';
 import { logsFieldSelectorWrapperStyles } from './styles';
 import { getSuggestedFieldsFromLogList } from './suggestedFields';
 
@@ -110,8 +110,12 @@ export const LogListFieldSelector = ({ containerElement, dataFrames, logs }: Log
   }, [setShowLevel, showLevel]);
 
   const suggestedFields = useMemo(
-    () => getSuggestedFieldsFromLogList(logs, displayedFields, [], otelLogsFormattingEnabled),
-    [displayedFields, logs, otelLogsFormattingEnabled]
+    () =>
+      withDisplayNames(
+        getSuggestedFieldsFromLogList(logs, displayedFields, [], otelLogsFormattingEnabled),
+        getFieldDisplayNames(dataFrames)
+      ),
+    [dataFrames, displayedFields, logs, otelLogsFormattingEnabled]
   );
   const fields = useMemo(() => getFieldsWithStats(dataFrames), [dataFrames]);
 

--- a/public/app/features/logs/components/fieldSelector/LogsTableFieldSelector.tsx
+++ b/public/app/features/logs/components/fieldSelector/LogsTableFieldSelector.tsx
@@ -14,7 +14,7 @@ import {
   getDefaultFieldSelectorWidth,
 } from './FieldSelector';
 import { getFieldSelectorWidth } from './fieldSelectorUtils';
-import { getFieldsWithStats } from './getFieldsWithStats';
+import { getFieldDisplayNames, getFieldsWithStats, withDisplayNames } from './getFieldsWithStats';
 import { getSuggestedFieldsFromTable } from './getSuggestedFieldsFromTable';
 import { LOG_LINE_BODY_FIELD_NAME, OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME } from './logFields';
 import { logsFieldSelectorWrapperStyles } from './styles';
@@ -101,9 +101,10 @@ export const LogsTableFieldSelector = ({
   );
 
   const suggestedFields = useMemo(() => {
-    return getSuggestedFields(dataFrames[0], displayedColumns, defaultColumns).filter(
+    const suggested = getSuggestedFields(dataFrames[0], displayedColumns, defaultColumns).filter(
       (field) => field.name !== LOG_LINE_BODY_FIELD_NAME && field.name !== OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME
     );
+    return withDisplayNames(suggested, getFieldDisplayNames(dataFrames));
   }, [dataFrames, defaultColumns, displayedColumns, getSuggestedFields]);
   const fields = useMemo(() => getFieldsWithStats(dataFrames), [dataFrames]);
 

--- a/public/app/features/logs/components/fieldSelector/getFieldsWithStats.ts
+++ b/public/app/features/logs/components/fieldSelector/getFieldsWithStats.ts
@@ -1,11 +1,40 @@
-import { type DataFrame } from '@grafana/data';
+import { type DataFrame, getFieldDisplayName } from '@grafana/data';
 
 import { parseLogsFrame } from '../../logsFrame';
 
 import { type FieldWithStats } from './FieldSelector';
 
+/**
+ * Maps field name -> display name for every field whose display name differs from
+ * its name (e.g. via displayName/displayNameFromDS config). Covers all frame
+ * fields, including labels, time and body, so suggested fields can reuse it.
+ */
+export function getFieldDisplayNames(dataFrames: DataFrame[]): Map<string, string> {
+  const displayNames = new Map<string, string>();
+  dataFrames.forEach((dataFrame) => {
+    dataFrame.fields.forEach((field) => {
+      const displayName = getFieldDisplayName(field, dataFrame);
+      if (displayName !== field.name) {
+        displayNames.set(field.name, displayName);
+      }
+    });
+  });
+  return displayNames;
+}
+
+/**
+ * Fills in the display name for fields that don't already have one, using the provided map.
+ */
+export function withDisplayNames(fields: FieldWithStats[], displayNames: Map<string, string>): FieldWithStats[] {
+  return fields.map((field) => ({
+    ...field,
+    displayName: field.displayName ?? displayNames.get(field.name),
+  }));
+}
+
 export function getFieldsWithStats(dataFrames: DataFrame[]): FieldWithStats[] {
   const cardinality = new Map<string, number>();
+  const displayNames = getFieldDisplayNames(dataFrames);
   let totalLines = 0;
   const allFields = dataFrames.flatMap((dataFrame) => {
     const logsFrame = parseLogsFrame(dataFrame);
@@ -49,6 +78,7 @@ export function getFieldsWithStats(dataFrames: DataFrame[]): FieldWithStats[] {
 
   return labels.map((label) => ({
     name: label,
+    displayName: displayNames.get(label),
     stats: {
       percentOfLinesWithLabel: Math.ceil((100 * (cardinality.get(label) ?? 0)) / totalLines),
     },


### PR DESCRIPTION
The Logs Table is different from the Grafana Logs Visualization, as it's based on data frame Fields and not logs model.

This PR attempts to support displayName, which can be set for fields.