### PR TITLE
A11y: Announce toast notifications via live region text content

### DIFF
--- a/e2e-playwright/utils/dashboard-helpers.ts
+++ b/e2e-playwright/utils/dashboard-helpers.ts
@@ -27,8 +27,9 @@ export async function addDashboard(page: Page, title?: string): Promise<string> 
   await expect(saveAsButton).toBeEnabled();
   await saveAsButton.evaluate((btn: HTMLElement) => btn.click());
 
-  // Wait for success notification
-  await expect(page.getByText('Dashboard saved')).toBeVisible();
+  // Wait for success notification. Target the visible toast by role so it is not confused with the
+  // visually-hidden screen-reader announcer, which mirrors the same message text.
+  await expect(page.getByRole('status', { name: 'Dashboard saved' })).toBeVisible();
 
   // Get the dashboard UID from the URL
   const url = page.url();

--- a/public/app/core/components/AppNotifications/AppNotificationList.test.tsx
+++ b/public/app/core/components/AppNotifications/AppNotificationList.test.tsx
@@ -46,7 +46,9 @@ describe('AppNotificationList', () => {
     // so query the document rather than the render container.
     const liveRegion = document.body.querySelector('[aria-live="polite"]');
     expect(liveRegion).toBeInTheDocument();
-    expect(liveRegion).toHaveAttribute('aria-label', expect.stringContaining(expectedInfoMessage));
+    // Screen readers announce changes to a live region's text content, not to its attributes,
+    // so the message must live inside the region rather than in aria-label.
+    expect(liveRegion).toHaveTextContent(expectedInfoMessage);
   });
 
   describe('Error notifications', () => {
@@ -54,7 +56,7 @@ describe('AppNotificationList', () => {
       renderWithContext(undefined, '/d/test-dashboard');
       await sendTestNotification(AppEvents.alertError, expectedErrorMessage);
 
-      expect(await screen.findByText(expectedErrorMessage)).toBeInTheDocument();
+      expect(await screen.findByRole('alert', { name: expectedErrorMessage })).toBeInTheDocument();
     });
 
     it('should hide error notifications in kiosk mode on dashboard page', async () => {
@@ -68,7 +70,7 @@ describe('AppNotificationList', () => {
       renderWithContext(KioskMode.Full, '/alerting');
       await sendTestNotification(AppEvents.alertError, expectedErrorMessage);
 
-      expect(await screen.findByText(expectedErrorMessage)).toBeInTheDocument();
+      expect(await screen.findByRole('alert', { name: expectedErrorMessage })).toBeInTheDocument();
     });
 
     it('should hide error notifications in kiosk mode on home dashboard', async () => {
@@ -82,7 +84,7 @@ describe('AppNotificationList', () => {
       renderWithContext(KioskMode.Full, '/');
       await sendTestNotification(AppEvents.alertError, expectedErrorMessage);
 
-      expect(await screen.findByText(expectedErrorMessage)).toBeInTheDocument();
+      expect(await screen.findByRole('alert', { name: expectedErrorMessage })).toBeInTheDocument();
     });
   });
 
@@ -91,21 +93,21 @@ describe('AppNotificationList', () => {
       renderWithContext(KioskMode.Full, '/d/test-dashboard');
       await sendTestNotification(AppEvents.alertSuccess, expectedSuccessMessage);
 
-      expect(await screen.findByText(expectedSuccessMessage)).toBeInTheDocument();
+      expect(await screen.findByRole('status', { name: expectedSuccessMessage })).toBeInTheDocument();
     });
 
     it('should always show warning notifications in kiosk mode on dashboard', async () => {
       renderWithContext(KioskMode.Full, '/d/test-dashboard');
       await sendTestNotification(AppEvents.alertWarning, expectedWarningMessage);
 
-      expect(await screen.findByText(expectedWarningMessage)).toBeInTheDocument();
+      expect(await screen.findByRole('alert', { name: expectedWarningMessage })).toBeInTheDocument();
     });
 
     it('should always show info notifications in kiosk mode on dashboard', async () => {
       renderWithContext(KioskMode.Full, '/d/test-dashboard');
       await sendTestNotification(AppEvents.alertInfo, expectedInfoMessage);
 
-      expect(await screen.findByText(expectedInfoMessage)).toBeInTheDocument();
+      expect(await screen.findByRole('status', { name: expectedInfoMessage })).toBeInTheDocument();
     });
   });
 
@@ -157,7 +159,7 @@ describe('AppNotificationList', () => {
       renderWithContext(undefined, '/d/test-uid/test-slug');
       await sendTestNotification(AppEvents.alertError, expectedErrorMessage);
 
-      expect(await screen.findByText(expectedErrorMessage)).toBeInTheDocument();
+      expect(await screen.findByRole('alert', { name: expectedErrorMessage })).toBeInTheDocument();
     });
 
     it('should hide error in kiosk mode on dashboard page with uid and slug', async () => {
@@ -171,7 +173,7 @@ describe('AppNotificationList', () => {
       renderWithContext(KioskMode.Full, '/dashboard/db/test-dashboard');
       await sendTestNotification(AppEvents.alertError, expectedErrorMessage);
 
-      expect(await screen.findByText(expectedErrorMessage)).toBeInTheDocument();
+      expect(await screen.findByRole('alert', { name: expectedErrorMessage })).toBeInTheDocument();
     });
   });
 });

--- a/public/app/core/components/AppNotifications/AppNotificationList.tsx
+++ b/public/app/core/components/AppNotifications/AppNotificationList.tsx
@@ -91,7 +91,9 @@ export function AppNotificationList() {
     // dismiss it — ModalBase treats presses inside the portal container as "inside" the modal.
     <Portal>
       <div className={styles.wrapper}>
-        <div className="sr-only" role="log" aria-live="polite" aria-atomic="true" aria-label={liveRegionMessage} />
+        <div className="sr-only" role="log" aria-live="polite" aria-atomic="true">
+          {liveRegionMessage}
+        </div>
         <Stack direction="column">
           {appNotifications.map((appNotification, index) => {
             return (

--- a/public/app/features/alerting/unified/NotificationPoliciesPage.test.tsx
+++ b/public/app/features/alerting/unified/NotificationPoliciesPage.test.tsx
@@ -282,7 +282,7 @@ describe.each([
     await user.click(await screen.findByRole('button', { name: /update policy/i }));
 
     // wait for it to go out of edit mode
-    expect(await screen.findByText(/updated notification policies/i)).toBeInTheDocument();
+    expect(await screen.findByRole('status', { name: /updated notification policies/i })).toBeInTheDocument();
 
     // check that new config values are rendered
     rootRoute = await getRootRoute();
@@ -320,7 +320,7 @@ describe.each([
     //save
     await user.click(await screen.findByRole('button', { name: /update policy/i }));
 
-    expect(await screen.findByText(/updated notification policies/i)).toBeInTheDocument();
+    expect(await screen.findByRole('status', { name: /updated notification policies/i })).toBeInTheDocument();
 
     const rootRoute = await getRootRoute();
     expect(rootRoute).toHaveTextContent(/delivered to lotsa-emails/i);

--- a/public/app/features/alerting/unified/components/folder-actions/DeleteModal.test.tsx
+++ b/public/app/features/alerting/unified/components/folder-actions/DeleteModal.test.tsx
@@ -47,8 +47,8 @@ describe('DeleteModal', () => {
 
     await confirmDelete(user);
 
-    expect(await screen.findByText(/Failed to delete folder rules/i)).toBeInTheDocument();
-    expect(await screen.findByText(/cannot delete/i)).toBeInTheDocument();
+    const errorAlert = await screen.findByRole('alert', { name: /Failed to delete folder rules/i });
+    expect(errorAlert).toHaveTextContent(/cannot delete/i);
     await waitFor(() => {
       expect(mockTrackFail).toHaveBeenCalledTimes(1);
     });

--- a/public/app/features/alerting/unified/components/receivers/NewReceiverView.test.tsx
+++ b/public/app/features/alerting/unified/components/receivers/NewReceiverView.test.tsx
@@ -134,8 +134,8 @@ describe('new receiver', () => {
 
     await user.click(ui.saveContactButton.get());
 
-    expect(await screen.findByText(/failed to save the contact point/i)).toBeInTheDocument();
-    expect(await screen.findByText(/user not found/i)).toBeInTheDocument();
+    const errorAlert = await screen.findByRole('alert', { name: /failed to save the contact point/i });
+    expect(errorAlert).toHaveTextContent(/user not found/i);
   });
 });
 

--- a/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/AlertRuleForm.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/AlertRuleForm.test.tsx
@@ -133,7 +133,7 @@ describe('AlertRuleForm submit failure handling', () => {
       }
       await user.click(ui.buttons.save.get());
 
-      expect(await screen.findByText(/Failed to save alert rule/i)).toBeInTheDocument();
+      expect(await screen.findByRole('alert', { name: /Failed to save alert rule/i })).toBeInTheDocument();
       expect(screen.queryByText(/Rule added successfully/i)).not.toBeInTheDocument();
 
       await waitFor(() => {
@@ -205,7 +205,7 @@ describe('AlertRuleForm — submit routing by group presence', () => {
       await fillRuleBasics(user);
       await user.click(ui.buttons.save.get());
 
-      expect(await screen.findByText(/Rule added successfully/i)).toBeInTheDocument();
+      expect(await screen.findByRole('status', { name: /Rule added successfully/i })).toBeInTheDocument();
       expect(await appPlatformRequests).toHaveLength(1);
       expect(await legacyRequests).toHaveLength(0);
     });
@@ -250,7 +250,7 @@ describe('AlertRuleForm — submit routing by group presence', () => {
       await switchToNewMode(user);
       await user.click(ui.buttons.save.get());
 
-      expect(await screen.findByText(/Rule updated successfully/i)).toBeInTheDocument();
+      expect(await screen.findByRole('status', { name: /Rule updated successfully/i })).toBeInTheDocument();
 
       const requests = await appPlatformRequests;
       expect(requests).toHaveLength(1);
@@ -287,7 +287,7 @@ describe('AlertRuleForm — submit routing by group presence', () => {
       await switchToNewMode(user);
       await user.click(ui.buttons.save.get());
 
-      expect(await screen.findByText(/Rule updated successfully/i)).toBeInTheDocument();
+      expect(await screen.findByRole('status', { name: /Rule updated successfully/i })).toBeInTheDocument();
       expect(await recordingRequests).toHaveLength(1);
       expect(await alertRequests).toHaveLength(0);
       expect(await legacyRequests).toHaveLength(0);
@@ -310,7 +310,7 @@ describe('AlertRuleForm — submit routing by group presence', () => {
 
       await user.click(ui.buttons.save.get());
 
-      expect(await screen.findByText(/Rule updated successfully/i)).toBeInTheDocument();
+      expect(await screen.findByRole('status', { name: /Rule updated successfully/i })).toBeInTheDocument();
       expect(await appPlatformRequests).toHaveLength(1);
       expect(await legacyRequests).toHaveLength(0);
     });
@@ -325,7 +325,7 @@ describe('AlertRuleForm — submit routing by group presence', () => {
       await switchToNewMode(user);
       await user.click(ui.buttons.save.get());
 
-      expect(await screen.findByText(/Failed to save alert rule/i)).toBeInTheDocument();
+      expect(await screen.findByRole('alert', { name: /Failed to save alert rule/i })).toBeInTheDocument();
       expect(screen.queryByText(/Rule updated successfully/i)).not.toBeInTheDocument();
 
       await waitFor(() => {
@@ -408,7 +408,7 @@ describe('AlertRuleForm — alerting.rulesAPIV2 gate (flag off)', () => {
 
     await user.click(ui.buttons.save.get());
 
-    expect(await screen.findByText(/Failed to save alert rule/i)).toBeInTheDocument();
+    expect(await screen.findByRole('alert', { name: /Failed to save alert rule/i })).toBeInTheDocument();
     expect(screen.queryByText(/Rule added successfully/i)).not.toBeInTheDocument();
 
     await waitFor(() => {

--- a/public/app/features/alerting/unified/group-details/GroupEditPage.test.tsx
+++ b/public/app/features/alerting/unified/group-details/GroupEditPage.test.tsx
@@ -45,7 +45,7 @@ const ui = {
   cancelButton: byRole('link', { name: /Cancel/ }),
   deleteButton: byRole('button', { name: /Delete/ }),
   rules: byTestId('reorder-alert-rule'),
-  successMessage: byText('Successfully updated the rule group'),
+  successMessage: byRole('status', { name: 'Successfully updated the rule group' }),
   errorMessage: byText('Failed to update rule group'),
   confirmDeleteModal: {
     dialog: byRole('dialog'),

--- a/public/app/features/teams/TeamSettings.test.tsx
+++ b/public/app/features/teams/TeamSettings.test.tsx
@@ -63,6 +63,6 @@ describe('Team settings', () => {
     await user.type(screen.getByLabelText(/Email/i), 'team@test.com');
     await user.click(screen.getByRole('button', { name: 'Save team details' }));
 
-    expect(await screen.findByText('Team updated')).toBeInTheDocument();
+    expect(await screen.findByRole('status', { name: 'Team updated' })).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## What this PR does / why we need it

Toast notifications were not announced by screen readers. The clearest user-visible symptom: activating **kiosk mode** shows a "Press ESC to exit kiosk mode" status message, but a screen reader stays silent.

### Root cause

`AppNotificationList` renders a dedicated visually-hidden live region for screen-reader announcements, but it placed the message in the `aria-label` **attribute** of an empty element:

```jsx
<div className="sr-only" role="log" aria-live="polite" aria-atomic="true" aria-label={liveRegionMessage} />
```

ARIA live regions are announced when their **DOM content** (text/child nodes) changes — not when an attribute such as `aria-label` changes. Because the element stayed empty and only its `aria-label` mutated, screen readers (NVDA/JAWS/VoiceOver) detected no content change and never announced anything.

This region was added specifically to announce toasts, because the visible `Alert` uses `role="status"` but mounts together with its content, which screen readers also don't reliably announce. The intent was correct; the implementation didn't trigger announcements.

### The fix

Render the message as the live region's text content instead of `aria-label` — the pattern used by every other live region in the codebase (e.g. `SplashScreenModal`, `ExportAsImage`, `TimeRangePicker`):

```jsx
<div className="sr-only" role="log" aria-live="polite" aria-atomic="true">
  {liveRegionMessage}
</div>
```

The existing test asserted the `aria-label` attribute, so it validated the broken mechanism and passed. It now asserts the announced text content. The "notification is shown" tests were updated to target the visible toast by its ARIA role so they aren't ambiguous with the live region's mirrored text.

## Which issue(s) this PR fixes

Fixes the "Press ESC to exit kiosk mode" status message not being announced by screen readers.

## Special notes for your reviewer

- No behavior change for sighted users; the live region is visually hidden (`sr-only`).
- Verified with `yarn jest public/app/core/components/AppNotifications/AppNotificationList.test.tsx` (14 passing).
