### PR TITLE
Logs Table: Fix mixed usage of field name and display name

### DIFF
--- a/public/app/plugins/panel/logstable/fieldSelector/buildColumnsWithMeta.test.ts
+++ b/public/app/plugins/panel/logstable/fieldSelector/buildColumnsWithMeta.test.ts
@@ -50,6 +50,55 @@ describe('buildColumnsWithMeta', () => {
     expect(fieldNameMeta['backend']).toMatchObject({ active: false, index: undefined, percentOfLinesWithLabel: 50 });
   });
 
+  it('supports fields with a configured displayName', () => {
+    const dataFrameWithDisplayNames = toDataFrame({
+      meta: {
+        type: DataFrameType.LogLines,
+      },
+      fields: [
+        {
+          name: LOGS_DATAPLANE_TIMESTAMP_NAME,
+          type: FieldType.time,
+          values: [1, 2],
+          config: { displayName: 'Time (display)' },
+        },
+        {
+          name: LOGS_DATAPLANE_BODY_NAME,
+          type: FieldType.string,
+          values: ['log 1', 'log 2'],
+          config: { displayName: 'Body (display)' },
+        },
+        { name: 'service', type: FieldType.string, values: ['service 1', 'service 2'], config: { displayName: 'Svc' } },
+        { name: 'backend', type: FieldType.string, values: ['backend 1', null], config: { displayName: 'BE' } },
+      ],
+    });
+    const logsFrameWithDisplayNames = parseLogsFrame(dataFrameWithDisplayNames) as LogsFrame;
+
+    let fieldNameMeta;
+    expect(() => {
+      fieldNameMeta = buildColumnsWithMeta(
+        {
+          severityField: logsFrameWithDisplayNames.severityField,
+          extraFields: logsFrameWithDisplayNames.extraFields,
+          timeField: logsFrameWithDisplayNames.timeField,
+          bodyField: logsFrameWithDisplayNames.bodyField,
+        },
+        dataFrameWithDisplayNames,
+        ['service']
+      );
+    }).not.toThrow();
+
+    // Keys must be the field name, never the display name
+    expect(fieldNameMeta).toHaveProperty(logsFrameWithDisplayNames.timeField.name);
+    expect(fieldNameMeta).toHaveProperty(logsFrameWithDisplayNames.bodyField.name);
+    expect(fieldNameMeta).toHaveProperty('service');
+    expect(fieldNameMeta).toHaveProperty('backend');
+    expect(fieldNameMeta).not.toHaveProperty('Time (display)');
+    expect(fieldNameMeta).not.toHaveProperty('Body (display)');
+    expect(fieldNameMeta).not.toHaveProperty('Svc');
+    expect(fieldNameMeta!['service']).toMatchObject({ active: true, index: 0 });
+  });
+
   it('respects displayed fields', () => {
     const fieldNameMeta = buildColumnsWithMeta(
       {

--- a/public/app/plugins/panel/logstable/fieldSelector/buildColumnsWithMeta.ts
+++ b/public/app/plugins/panel/logstable/fieldSelector/buildColumnsWithMeta.ts
@@ -1,4 +1,4 @@
-import { type DataFrame, type FieldWithIndex, getFieldDisplayName } from '@grafana/data';
+import { type DataFrame, type FieldWithIndex } from '@grafana/data';
 import { type FieldNameMeta, type FieldNameMetaStore } from 'app/features/explore/Logs/LogsTableWrap';
 import { LOG_LINE_BODY_FIELD_NAME } from 'app/features/logs/components/fieldSelector/logFields';
 
@@ -42,7 +42,7 @@ export const buildColumnsWithMeta = (
   if (dataFrame.fields.length && numberOfLogLines) {
     // Iterate through all of fields
     dataFrame.fields.forEach((field) => {
-      const fieldName = getFieldDisplayName(field);
+      const fieldName = field.name;
       // Count the valid values
       const countOfValues = field.values.reduce((acc: number, value) => {
         if (value !== undefined && value !== null) {
@@ -72,7 +72,7 @@ export const buildColumnsWithMeta = (
 
   // Normalize the other fields
   otherFields.forEach((field) => {
-    const fieldName = getFieldDisplayName(field);
+    const fieldName = field.name;
     const isActive = pendingLabelState[fieldName]?.active;
     const index = pendingLabelState[fieldName]?.index;
     if (isActive && index !== undefined) {
@@ -101,8 +101,8 @@ export const buildColumnsWithMeta = (
       pendingLabelState[fieldName].active = true;
       pendingLabelState[fieldName].index = idx;
     } else if (fieldName === LOG_LINE_BODY_FIELD_NAME && logsFrameFields?.bodyField?.name) {
-      pendingLabelState[logsFrameFields.bodyField?.name].active = true;
-      pendingLabelState[logsFrameFields.bodyField?.name].index = idx;
+      pendingLabelState[logsFrameFields.bodyField.name].active = true;
+      pendingLabelState[logsFrameFields.bodyField.name].index = idx;
     } else {
       console.error(`Unknown field ${fieldName}`, { pendingLabelState, displayedFields });
     }


### PR DESCRIPTION
Keeping field name, which is what's used by all the related components, and proposing https://github.com/grafana/grafana/pull/128674 to consider supporting displayName in the table Field Selector.

Fixes #128642