### PR TITLE
PanelChrome: Fix issues with panel header having normal sized inputs

### DIFF
--- a/packages/grafana-ui/src/components/Combobox/Combobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.tsx
@@ -27,7 +27,7 @@ import { isNewGroup } from './utils';
 interface ComboboxStaticProps<T extends string | number>
   extends Pick<
     InputProps,
-    'placeholder' | 'autoFocus' | 'id' | 'aria-labelledby' | 'disabled' | 'loading' | 'invalid'
+    'placeholder' | 'autoFocus' | 'id' | 'aria-label' | 'aria-labelledby' | 'disabled' | 'loading' | 'invalid'
   > {
   /**
    * Allows the user to set a value which is not in the list of options.
@@ -158,6 +158,7 @@ export const Combobox = <T extends string | number>(props: ComboboxProps<T>) => 
     minWidth,
     maxWidth,
     'aria-labelledby': ariaLabelledBy,
+    'aria-label': ariaLabel,
     'data-testid': dataTestId,
     autoFocus,
     onBlur,
@@ -436,6 +437,7 @@ export const Combobox = <T extends string | number>(props: ComboboxProps<T>) => 
           ref: inputRef,
           onChange: noop, // Empty onCall to avoid TS error https://github.com/downshift-js/downshift/issues/718
           'aria-labelledby': ariaLabelledBy, // Label should be handled with the Field component
+          'aria-label': ariaLabel,
           placeholder,
           'data-testid': dataTestId,
           onKeyDown: (event: React.KeyboardEvent<HTMLInputElement>) => {

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.story.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.story.tsx
@@ -8,6 +8,7 @@ import { LoadingState } from '@grafana/data';
 
 import { DashboardStoryCanvas } from '../../utils/storybook/DashboardStoryCanvas';
 import { Button } from '../Button/Button';
+import { Combobox } from '../Combobox/Combobox';
 import { RadioButtonGroup } from '../Forms/RadioButtonGroup/RadioButtonGroup';
 import { Icon } from '../Icon/Icon';
 import { Stack } from '../Layout/Stack/Stack';
@@ -229,6 +230,15 @@ export const Examples = () => {
             ),
           })}
           {renderPanel('Content', {
+            title: 'Actions with button',
+            subtitle: 'And a is a subtitle that has more detail',
+            actions: (
+              <Button size="sm" variant="secondary" key="A">
+                Breakdown
+              </Button>
+            ),
+          })}
+          {renderPanel('Content', {
             title: 'Panel with two actions',
             actions: [
               <Button size="sm" variant="secondary" key="A">
@@ -276,6 +286,10 @@ export const Examples = () => {
                 Breakdown
               </Button>
             ),
+          })}
+          {renderPanel('Not ideal as the space in header does not fit inputs', {
+            title: 'With select in header',
+            actions: <Combobox value="Hello" options={[{ label: 'hello', value: 'Hello' }]} onChange={() => {}} />,
           })}
         </Stack>
       </div>

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.story.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.story.tsx
@@ -289,7 +289,14 @@ export const Examples = () => {
           })}
           {renderPanel('Not ideal as the space in header does not fit inputs', {
             title: 'With select in header',
-            actions: <Combobox value="Hello" options={[{ label: 'hello', value: 'Hello' }]} onChange={() => {}} />,
+            actions: (
+              <Combobox
+                value="Hello"
+                options={[{ label: 'hello', value: 'Hello' }]}
+                onChange={() => {}}
+                aria-label="Select option"
+              />
+            ),
           })}
         </Stack>
       </div>

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -631,6 +631,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       alignItems: 'center',
       padding: theme.spacing(1, 1, 0, 1),
       gap: theme.spacing(1),
+      maxHeight: theme.spacing.gridSize * theme.components.panel.headerHeight,
     }),
     subHeader: css({
       label: 'panel-sub-header',


### PR DESCRIPTION

PanelChrome actions should ideally just be "sm" sized buttons and radio toggles but sadly we do not have sm sized Select/Combobox so when Logs panel in logs drilldown places a Select inside the header the header extends its bounds (creating less space for the visualization). 

Fixed this by setting a maxHeight on panel header as a temporary fix (but we really need sm sized input and selects)

<img width="439" height="182" alt="Screenshot 2026-07-17 at 13 46 40" src="https://github.com/user-attachments/assets/2bbd6d30-a5a8-4575-83ec-c69fd3984594" />

while not directly buggy, the spacing for the select and the panel boundary is not what we want here (and the placement is not aligned in the corner)

Should look like this 
<img width="423" height="172" alt="Screenshot 2026-07-17 at 13 47 44" src="https://github.com/user-attachments/assets/9b931cb3-7d49-439a-9a79-0e6cd6a7463f" />
