### PR TITLE
fix(assistant): fix missing context items in Assistant

### DIFF
--- a/public/app/features/explore/hooks/useExplorePageContext.ts
+++ b/public/app/features/explore/hooks/useExplorePageContext.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 import { createAssistantContextItem, type ChatContextItem, useProvidePageContext } from '@grafana/assistant';
 import { type DataSourceApi } from '@grafana/data';
@@ -7,19 +7,27 @@ import { type DataQuery } from '@grafana/schema';
 import { type ExploreItemState } from 'app/types/explore';
 
 export function useExplorePageContext(panes: Array<[string, ExploreItemState]>): void {
-  const setContext = useProvidePageContext(/^\/explore/);
+  const [items, setItems] = useState<ChatContextItem[]>([]);
 
   useEffect(() => {
     let cancelled = false;
-    buildContext(panes).then((items) => {
+    buildContext(panes).then((built) => {
       if (!cancelled) {
-        setContext(items);
+        setItems(built);
       }
     });
     return () => {
       cancelled = true;
     };
-  }, [panes, setContext]);
+  }, [panes]);
+
+  // Provide the built items as the registration's context. Passing them here
+  // (rather than via the imperative setter) means the assistant SDK both
+  // re-applies them whenever they change and re-creates the registration with
+  // them if it remounts — otherwise the items are lost when the registration
+  // is re-created empty and the effect that set them
+  // doesn't re-run, leaving Explore context missing until an unrelated render.
+  useProvidePageContext(/^\/explore/, items);
 }
 
 async function buildContext(panes: Array<[string, ExploreItemState]>): Promise<ChatContextItem[]> {


### PR DESCRIPTION
**What is this?**

This fixes a bug related to the Assistant occuring on Explore pages: page context is not being set correctly in our new sidebar layout

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
