### PR TITLE
CommandPalette: Present search results as semantic ARIA groups

### DIFF
--- a/public/app/features/commandPalette/KBarResults.test.tsx
+++ b/public/app/features/commandPalette/KBarResults.test.tsx
@@ -85,19 +85,22 @@ describe('KBarResults', () => {
       expect(screen.getByRole('option')).toBeInTheDocument();
     });
 
-    it('includes the group name in the accessible name when preceded by a group header', () => {
+    it('wraps options in a group labelled by their section header', () => {
       render(<KBarResults items={['Dashboards', createAction({ id: 'home', name: 'Home' })]} onRender={renderItem} />);
 
-      expect(screen.getByRole('option')).toHaveAccessibleName('Dashboards: Home');
+      const group = screen.getByRole('group', { name: 'Dashboards' });
+      const option = screen.getByRole('option', { name: 'Home' });
+      expect(group).toContainElement(option);
     });
 
-    it('does not add a group prefix when there is no preceding group header', () => {
+    it('does not wrap options in a group when there is no preceding section header', () => {
       render(<KBarResults items={[createAction({ id: 'home', name: 'Home' })]} onRender={renderItem} />);
 
+      expect(screen.queryByRole('group')).not.toBeInTheDocument();
       expect(screen.getByRole('option')).toHaveAccessibleName('Home');
     });
 
-    it('uses the most recent group label when there are multiple groups', () => {
+    it('groups options under their respective sections when there are multiple groups', () => {
       render(
         <KBarResults
           items={[
@@ -110,9 +113,10 @@ describe('KBarResults', () => {
         />
       );
 
-      const options = screen.getAllByRole('option');
-      expect(options[0]).toHaveAccessibleName('Dashboards: Home');
-      expect(options[1]).toHaveAccessibleName('Folders: My Folder');
+      const dashboards = screen.getByRole('group', { name: 'Dashboards' });
+      const folders = screen.getByRole('group', { name: 'Folders' });
+      expect(dashboards).toContainElement(screen.getByRole('option', { name: 'Home' }));
+      expect(folders).toContainElement(screen.getByRole('option', { name: 'My Folder' }));
     });
 
     it('marks the active item with aria-selected="true" and others with aria-selected="false"', () => {

--- a/public/app/features/commandPalette/KBarResults.tsx
+++ b/public/app/features/commandPalette/KBarResults.tsx
@@ -47,9 +47,9 @@ export const KBarResults = (props: KBarResultsProps) => {
   const itemsRef = React.useRef(props.items);
   itemsRef.current = props.items;
 
-  // A11y: Pre-compute the group label for each item so that option items can
-  // announce their section even when the section header has scrolled out of
-  // the virtual window and is no longer in the DOM.
+  // A11y: Pre-compute the section label for each item so the group wrapper can
+  // label itself even when the section header row has scrolled out of the
+  // virtual window and is no longer in the DOM.
   const itemGroupLabels = React.useMemo(() => {
     const labels: Array<string | null> = [];
     let currentGroup: string | null = null;
@@ -202,7 +202,6 @@ export const KBarResults = (props: KBarResultsProps) => {
     // so our url property is secretly there, but completely untyped
     // Preferably this change is upstreamed and ActionImpl has this
     const { target, url } = item;
-    const groupLabel = itemGroupLabels[virtualRow.index];
 
     const handlers = !isStringItem && {
       onPointerMove: () => pointerMoved && activeIndex !== virtualRow.index && query.setActiveIndex(virtualRow.index),
@@ -252,7 +251,6 @@ export const KBarResults = (props: KBarResultsProps) => {
           ref={legacyKeyboard && active ? setActiveRow : undefined}
           {...childProps}
         >
-          {groupLabel ? <span className="sr-only">{groupLabel}: </span> : null}
           {renderedItem}
         </a>
       );
@@ -260,13 +258,48 @@ export const KBarResults = (props: KBarResultsProps) => {
 
     return (
       <div key={virtualRow.index} ref={legacyKeyboard && active ? setActiveRow : undefined} {...childProps}>
-        {groupLabel ? <span className="sr-only">{groupLabel}: </span> : null}
         {renderedItem}
       </div>
     );
   };
 
-  const renderRows = () => rowVirtualizer.virtualItems.map(renderRow);
+  // A11y: present the results as ARIA groups so screen readers announce each
+  // section and its heading, rather than one flat list of options. Consecutive
+  // virtual rows that share a section are wrapped in a `role="group"` labelled
+  // with the section name (via aria-label, so the label survives the section
+  // header scrolling out of the virtual window). Rows before the first section
+  // header have no group and are rendered directly in the listbox. The group
+  // wrapper is unpositioned, so the absolutely-positioned rows inside still
+  // translate relative to the scroll container.
+  const renderRows = () => {
+    const virtualItems = rowVirtualizer.virtualItems;
+    const rendered: React.ReactNode[] = [];
+
+    let index = 0;
+    while (index < virtualItems.length) {
+      const groupLabel = itemGroupLabels[virtualItems[index].index];
+
+      const runStart = index;
+      while (index < virtualItems.length && itemGroupLabels[virtualItems[index].index] === groupLabel) {
+        index++;
+      }
+      const run = virtualItems.slice(runStart, index);
+
+      if (groupLabel === null) {
+        for (const virtualRow of run) {
+          rendered.push(renderRow(virtualRow));
+        }
+      } else {
+        rendered.push(
+          <div key={`group-${groupLabel}-${run[0].index}`} role="group" aria-label={groupLabel}>
+            {run.map(renderRow)}
+          </div>
+        );
+      }
+    }
+
+    return rendered;
+  };
 
   return (
     <div

--- a/public/app/features/commandPalette/KBarResults.tsx
+++ b/public/app/features/commandPalette/KBarResults.tsx
@@ -188,6 +188,86 @@ export const KBarResults = (props: KBarResultsProps) => {
     activeRef.current = element;
   };
 
+  const renderRow = (virtualRow: (typeof rowVirtualizer.virtualItems)[number]) => {
+    const rawItem = itemsRef.current[virtualRow.index];
+    const isStringItem = typeof rawItem === 'string';
+
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    const item = rawItem as ActionImpl & {
+      url?: string | URLCallback;
+      target?: React.HTMLAttributeAnchorTarget;
+    };
+
+    // ActionImpl constructor copies all properties from action onto ActionImpl
+    // so our url property is secretly there, but completely untyped
+    // Preferably this change is upstreamed and ActionImpl has this
+    const { target, url } = item;
+    const groupLabel = itemGroupLabels[virtualRow.index];
+
+    const handlers = !isStringItem && {
+      onPointerMove: () => pointerMoved && activeIndex !== virtualRow.index && query.setActiveIndex(virtualRow.index),
+      onPointerDown: () => query.setActiveIndex(virtualRow.index),
+      onClick: (ev: React.MouseEvent) => {
+        // Report before perform, since perform may close the palette / navigate away
+        props.onItemSelected?.(item, virtualRow.index);
+        execute(ev, item);
+      },
+    };
+    const active = !isStringItem && virtualRow.index === activeIndex;
+
+    const childProps = {
+      ...(isStringItem
+        ? { 'aria-hidden': true }
+        : {
+            id: getListboxItemId(virtualRow.index),
+            role: 'option',
+            'aria-selected': active,
+          }),
+      style: {
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        width: '100%',
+        transform: `translateY(${virtualRow.start}px)`,
+      } as const,
+      ...handlers,
+    };
+
+    const renderedItem = React.cloneElement(
+      props.onRender({
+        item,
+        active,
+      }),
+      {
+        ref: virtualRow.measureRef,
+      }
+    );
+
+    if (url) {
+      return (
+        <a
+          key={virtualRow.index}
+          href={typeof url === 'function' ? url(search) : url}
+          target={target}
+          ref={legacyKeyboard && active ? setActiveRow : undefined}
+          {...childProps}
+        >
+          {groupLabel ? <span className="sr-only">{groupLabel}: </span> : null}
+          {renderedItem}
+        </a>
+      );
+    }
+
+    return (
+      <div key={virtualRow.index} ref={legacyKeyboard && active ? setActiveRow : undefined} {...childProps}>
+        {groupLabel ? <span className="sr-only">{groupLabel}: </span> : null}
+        {renderedItem}
+      </div>
+    );
+  };
+
+  const renderRows = () => rowVirtualizer.virtualItems.map(renderRow);
+
   return (
     <div
       ref={(element) => {
@@ -213,84 +293,7 @@ export const KBarResults = (props: KBarResultsProps) => {
           width: '100%',
         }}
       >
-        {rowVirtualizer.virtualItems.map((virtualRow) => {
-          const rawItem = itemsRef.current[virtualRow.index];
-          const isStringItem = typeof rawItem === 'string';
-
-          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-          const item = rawItem as ActionImpl & {
-            url?: string | URLCallback;
-            target?: React.HTMLAttributeAnchorTarget;
-          };
-
-          // ActionImpl constructor copies all properties from action onto ActionImpl
-          // so our url property is secretly there, but completely untyped
-          // Preferably this change is upstreamed and ActionImpl has this
-          const { target, url } = item;
-          const groupLabel = itemGroupLabels[virtualRow.index];
-
-          const handlers = !isStringItem && {
-            onPointerMove: () =>
-              pointerMoved && activeIndex !== virtualRow.index && query.setActiveIndex(virtualRow.index),
-            onPointerDown: () => query.setActiveIndex(virtualRow.index),
-            onClick: (ev: React.MouseEvent) => {
-              // Report before perform, since perform may close the palette / navigate away
-              props.onItemSelected?.(item, virtualRow.index);
-              execute(ev, item);
-            },
-          };
-          const active = !isStringItem && virtualRow.index === activeIndex;
-
-          const childProps = {
-            ...(isStringItem
-              ? { 'aria-hidden': true }
-              : {
-                  id: getListboxItemId(virtualRow.index),
-                  role: 'option',
-                  'aria-selected': active,
-                }),
-            style: {
-              position: 'absolute',
-              top: 0,
-              left: 0,
-              width: '100%',
-              transform: `translateY(${virtualRow.start}px)`,
-            } as const,
-            ...handlers,
-          };
-
-          const renderedItem = React.cloneElement(
-            props.onRender({
-              item,
-              active,
-            }),
-            {
-              ref: virtualRow.measureRef,
-            }
-          );
-
-          if (url) {
-            return (
-              <a
-                key={virtualRow.index}
-                href={typeof url === 'function' ? url(search) : url}
-                target={target}
-                ref={legacyKeyboard && active ? setActiveRow : undefined}
-                {...childProps}
-              >
-                {groupLabel ? <span className="sr-only">{groupLabel}: </span> : null}
-                {renderedItem}
-              </a>
-            );
-          }
-
-          return (
-            <div key={virtualRow.index} ref={legacyKeyboard && active ? setActiveRow : undefined} {...childProps}>
-              {groupLabel ? <span className="sr-only">{groupLabel}: </span> : null}
-              {renderedItem}
-            </div>
-          );
-        })}
+        {renderRows()}
       </div>
     </div>
   );


### PR DESCRIPTION
**What is this feature?**

This improves the accessibility of the command palette search results. Previously every result carried a visually-hidden "<section>: " prefix so screen readers could tell which section it belonged to; each section's options are now wrapped in a `role="group"` labelled with the section name (via `aria-label`, following the ARIA listbox grouping pattern). The section name is conveyed once per group rather than repeated on every option, and screen readers announce the grouping structure and headings properly. The first commit is a pure, behaviour-preserving refactor extracting the row rendering into `renderRow`/`renderRows`, and the second contains the accessibility change so the diff is easy to review.

**Why do we need this feature?**

Screen readers presented all results as one flat list with no sense of the sections, and the per-option prefix announced the section name verbosely on every single item.

**Who is this feature for?**

Users of the command palette who rely on assistive technology such as screen readers.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
