### PR TITLE
External PR triage: fire on opened + bump triage logic

### DIFF
--- a/.github/workflows/external-fr-notify.yml
+++ b/.github/workflows/external-fr-notify.yml
@@ -18,7 +18,7 @@ concurrency:
 env:
   # community-triage logic version this repo is pinned to. Bump deliberately;
   # re-resolve with: git ls-remote https://github.com/grafana/community-triage main
-  TRIAGE_REF: 5aae3908f182348b335e6bf141e5a0b347a4d627 # trufflehog:ignore
+  TRIAGE_REF: da6b3f7224d74c43d89374af39fc048911ea110b # trufflehog:ignore
 
 jobs:
   notify:

--- a/.github/workflows/external-fr-weekly-digest.yml
+++ b/.github/workflows/external-fr-weekly-digest.yml
@@ -31,7 +31,7 @@ concurrency:
 env:
   # community-triage logic version this repo is pinned to. Bump deliberately;
   # re-resolve with: git ls-remote https://github.com/grafana/community-triage main
-  TRIAGE_REF: 5aae3908f182348b335e6bf141e5a0b347a4d627 # trufflehog:ignore
+  TRIAGE_REF: da6b3f7224d74c43d89374af39fc048911ea110b # trufflehog:ignore
 
 jobs:
   digest:

--- a/.github/workflows/external-issue-notify.yml
+++ b/.github/workflows/external-issue-notify.yml
@@ -18,7 +18,7 @@ concurrency:
 env:
   # community-triage logic version this repo is pinned to. Bump deliberately;
   # re-resolve with: git ls-remote https://github.com/grafana/community-triage main
-  TRIAGE_REF: 5aae3908f182348b335e6bf141e5a0b347a4d627 # trufflehog:ignore
+  TRIAGE_REF: da6b3f7224d74c43d89374af39fc048911ea110b # trufflehog:ignore
 
 jobs:
   notify:

--- a/.github/workflows/external-issue-weekly-digest.yml
+++ b/.github/workflows/external-issue-weekly-digest.yml
@@ -31,7 +31,7 @@ concurrency:
 env:
   # community-triage logic version this repo is pinned to. Bump deliberately;
   # re-resolve with: git ls-remote https://github.com/grafana/community-triage main
-  TRIAGE_REF: 5aae3908f182348b335e6bf141e5a0b347a4d627 # trufflehog:ignore
+  TRIAGE_REF: da6b3f7224d74c43d89374af39fc048911ea110b # trufflehog:ignore
 
 jobs:
   digest:

--- a/.github/workflows/external-pr-notify-handler.yml
+++ b/.github/workflows/external-pr-notify-handler.yml
@@ -25,7 +25,7 @@ env:
   # community-triage logic version this repo is pinned to (main as of PR #6).
   # Bump deliberately; re-resolve with:
   #   git ls-remote https://github.com/grafana/community-triage main
-  TRIAGE_REF: 5aae3908f182348b335e6bf141e5a0b347a4d627 # trufflehog:ignore
+  TRIAGE_REF: da6b3f7224d74c43d89374af39fc048911ea110b # trufflehog:ignore
 
 jobs:
   triage:

--- a/.github/workflows/external-pr-notify-trigger.yml
+++ b/.github/workflows/external-pr-notify-trigger.yml
@@ -2,7 +2,13 @@ name: External PR Notify Trigger
 
 on:
   pull_request_target:  # zizmor: ignore[dangerous-triggers]
-    types: [labeled]
+    # Fire when an external PR is opened. Previously this keyed off the
+    # 'pr/external' labeled event, but that label is applied downstream (by the
+    # handler, once org membership is confirmed) rather than up front, so the
+    # labeled event no longer arrives. Firing on 'opened' is safe: this job runs
+    # base-ref code only, and the authoritative external check (org-membership)
+    # gates all downstream work in the handler.
+    types: [opened]
 
 permissions:
   contents: read
@@ -19,7 +25,6 @@ jobs:
       contents: read       # checkout champions list
       pull-requests: write # apply community/champion label
     if: |
-      github.event.label.name == 'pr/external' &&
       !contains(github.event.pull_request.labels.*.name, 'pr/auto-triaged') &&
       contains(fromJSON('["NONE", "FIRST_TIME_CONTRIBUTOR", "FIRST_TIMER", "CONTRIBUTOR"]'), github.event.pull_request.author_association)
 

--- a/.github/workflows/external-pr-weekly-digest.yml
+++ b/.github/workflows/external-pr-weekly-digest.yml
@@ -31,7 +31,7 @@ permissions: {}
 env:
   # community-triage logic version this repo is pinned to. Bump deliberately;
   # re-resolve with: git ls-remote https://github.com/grafana/community-triage main
-  TRIAGE_REF: 5aae3908f182348b335e6bf141e5a0b347a4d627 # trufflehog:ignore
+  TRIAGE_REF: da6b3f7224d74c43d89374af39fc048911ea110b # trufflehog:ignore
   STALE_THRESHOLD_DAYS: ${{ inputs.stale_days || 30 }}
 
 concurrency:


### PR DESCRIPTION
## What

Routes external PRs into triage **when they are opened**, instead of waiting on the `pr/external` labeled event, and bumps the pinned `community-triage` logic to pick up the internal-author routing fix.