### PR TITLE
IAM: Add endpoint to fetch the current user

### DIFF
--- a/packages/grafana-api-clients/src/clients/rtkq/iam/v0alpha1/endpoints.gen.ts
+++ b/packages/grafana-api-clients/src/clients/rtkq/iam/v0alpha1/endpoints.gen.ts
@@ -432,6 +432,10 @@ const injectedRtkApi = api
         }),
         providesTags: ['User'],
       }),
+      getCurrentUserDisplay: build.query<GetCurrentUserDisplayApiResponse, GetCurrentUserDisplayApiArg>({
+        query: () => ({ url: `/users/~` }),
+        providesTags: ['Display'],
+      }),
     }),
     overrideExisting: false,
   });
@@ -888,6 +892,8 @@ export type GetUserTeamsApiArg = {
   /** Opaque token from a previous response's metadata.continue; resumes listing after the last team returned. The token is base64 ('+', '/', '=' may appear) — clients MUST URL-encode it when appending to the query string, otherwise '+' will silently decode to a space on the server and pagination will fail. */
   continue?: string;
 };
+export type GetCurrentUserDisplayApiResponse = /** status 200 undefined */ Display;
+export type GetCurrentUserDisplayApiArg = void;
 export type ApiResource = {
   /** categories is a list of the grouped resources this resource belongs to (e.g. 'all') */
   categories?: string[];
@@ -1296,4 +1302,6 @@ export const {
   useUpdateUserStatusMutation,
   useGetUserTeamsQuery,
   useLazyGetUserTeamsQuery,
+  useGetCurrentUserDisplayQuery,
+  useLazyGetCurrentUserDisplayQuery,
 } = injectedRtkApi;

--- a/packages/grafana-openapi/src/apis/iam.grafana.app-v0alpha1.json
+++ b/packages/grafana-openapi/src/apis/iam.grafana.app-v0alpha1.json
@@ -2681,6 +2681,25 @@
           }
         }
       ]
+    },
+    "/users/~": {
+      "get": {
+        "tags": ["Display"],
+        "description": "Show display information for the currently authenticated identity",
+        "operationId": "getCurrentUserDisplay",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Display"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {

--- a/pkg/registry/apis/iam/authorizer.go
+++ b/pkg/registry/apis/iam/authorizer.go
@@ -10,6 +10,7 @@ import (
 	iamv0 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafana/pkg/registry/apis/iam/display"
 	"github.com/grafana/grafana/pkg/registry/apis/iam/legacy"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	gfauthorizer "github.com/grafana/grafana/pkg/services/apiserver/auth/authorizer"
@@ -155,6 +156,23 @@ func newTeamAuthorizer(accessClient authlib.AccessClient) authorizer.Authorizer 
 	return allowListAuthorizer(base)
 }
 
+// allowSelfAuthorizer allows any authenticated identity to GET the current-user
+// endpoint (users/~). That handler only ever returns the caller's own display
+// info derived from context, so it needs no users:read permission.
+func allowSelfAuthorizer(base authorizer.Authorizer) authorizer.Authorizer {
+	return authorizer.AuthorizerFunc(func(ctx context.Context, attr authorizer.Attributes) (authorizer.Decision, string, error) {
+		if attr.IsResourceRequest() && attr.GetResource() == iamv0.UserResourceInfo.GetName() &&
+			attr.GetSubresource() == "" && attr.GetName() == display.CurrentUserName &&
+			attr.GetVerb() == utils.VerbGet {
+			if _, ok := authlib.AuthInfoFrom(ctx); ok {
+				return authorizer.DecisionAllow, "", nil
+			}
+			return authorizer.DecisionDeny, "cannot read current user without an identity", nil
+		}
+		return base.Authorize(ctx, attr)
+	})
+}
+
 // newUserAuthorizer creates an authorizer for users that handles the "teams" and "status" subresources.
 // "teams" is read-only (Connecter/GET), so it checks user get.
 // "status" supports both GET and PUT, so the check verb mirrors the request verb.
@@ -198,7 +216,7 @@ func newUserAuthorizer(accessClient authlib.AccessClient) authorizer.Authorizer 
 		},
 	})
 
-	return allowListAuthorizer(base)
+	return allowSelfAuthorizer(allowListAuthorizer(base))
 }
 
 // newServiceAccountAuthorizer creates an authorizer for service accounts that handles the "tokens" subresource.

--- a/pkg/registry/apis/iam/display/handler.go
+++ b/pkg/registry/apis/iam/display/handler.go
@@ -94,6 +94,11 @@ func (r *DisplayHandler) GetAPIRoutes(defs map[string]common.OpenAPIDefinition) 
 				},
 				Handler: r.handleDisplay,
 			},
+			{
+				Path:    currentUserPath,
+				Spec:    r.selfRouteSpec(),
+				Handler: r.handleSelf,
+			},
 		},
 	}
 }

--- a/pkg/registry/apis/iam/display/self.go
+++ b/pkg/registry/apis/iam/display/self.go
@@ -1,0 +1,102 @@
+package display
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/kube-openapi/pkg/spec3"
+	"k8s.io/kube-openapi/pkg/validation/spec"
+
+	authlib "github.com/grafana/authlib/types"
+	iam "github.com/grafana/grafana/pkg/apis/iam/v0alpha1"
+	"github.com/grafana/grafana/pkg/util/errhttp"
+)
+
+// CurrentUserName is the name token that denotes the calling identity in the "who am I" endpoint.
+const CurrentUserName = "~"
+
+// currentUserPath is the route path for the "who am I" endpoint.
+const currentUserPath = "users/" + CurrentUserName
+
+// selfRouteSpec describes the current-user endpoint for OpenAPI discovery.
+func (r *DisplayHandler) selfRouteSpec() *spec3.PathProps {
+	return &spec3.PathProps{
+		Get: &spec3.Operation{
+			OperationProps: spec3.OperationProps{
+				OperationId: "getCurrentUserDisplay",
+				Tags:        []string{"Display"},
+				Description: "Show display information for the currently authenticated identity",
+				Parameters: []*spec3.Parameter{
+					{
+						ParameterProps: spec3.ParameterProps{
+							Name:        "namespace",
+							In:          "path",
+							Required:    true,
+							Example:     "default",
+							Description: "workspace",
+							Schema:      spec.StringProperty(),
+						},
+					},
+				},
+				Responses: &spec3.Responses{
+					ResponsesProps: spec3.ResponsesProps{
+						StatusCodeResponses: map[int]*spec3.Response{
+							200: {
+								ResponseProps: spec3.ResponseProps{
+									Content: map[string]*spec3.MediaType{
+										"application/json": {
+											MediaTypeProps: spec3.MediaTypeProps{
+												Schema: &spec.Schema{
+													SchemaProps: spec.SchemaProps{
+														Ref: spec.MustCreateRef("#/components/schemas/" + iam.Display{}.OpenAPIModelName()),
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// handleSelf resolves the display information for the caller derived from the request context
+func (r *DisplayHandler) handleSelf(w http.ResponseWriter, req *http.Request) {
+	ctx := req.Context()
+	authInfo, ok := authlib.AuthInfoFrom(ctx)
+	if !ok {
+		errhttp.Write(ctx, apierrors.NewUnauthorized("missing auth info"), w)
+		return
+	}
+
+	ns, err := authlib.ParseNamespace(authInfo.GetNamespace())
+	if err != nil {
+		errhttp.Write(ctx, apierrors.NewBadRequest("missing namespace"), w)
+		return
+	}
+
+	// GetUID() is already in the "<type>:<identifier>" form the resolvers expect
+	// (e.g. "user:u000000001"), so the caller identifies itself purely from context.
+	key := authInfo.GetUID()
+
+	for _, p := range r.resolvers {
+		partial, err := p.GetDisplayList(ctx, ns, []string{key})
+		if err != nil {
+			errhttp.Write(ctx, fmt.Errorf("error calling GetDisplayList %w", err), w) // 500
+			return
+		}
+		if len(partial.Items) > 0 {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(partial.Items[0])
+			return
+		}
+	}
+
+	errhttp.Write(ctx, apierrors.NewNotFound(iam.Resource("users"), authInfo.GetIdentifier()), w)
+}

--- a/pkg/registry/apis/iam/display/self_test.go
+++ b/pkg/registry/apis/iam/display/self_test.go
@@ -1,0 +1,99 @@
+package display
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	authlib "github.com/grafana/authlib/types"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	iam "github.com/grafana/grafana/pkg/apis/iam/v0alpha1"
+)
+
+type fakeResolver struct {
+	gotKeys []string
+	result  *iam.DisplayList
+	err     error
+}
+
+func (f *fakeResolver) GetDisplayList(_ context.Context, _ authlib.NamespaceInfo, keys []string) (*iam.DisplayList, error) {
+	f.gotKeys = keys
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.result, nil
+}
+
+func selfRequest(t *testing.T, auth authlib.AuthInfo) *http.Request {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/apis/iam.grafana.app/v0alpha1/namespaces/default/users/~", nil)
+	if auth != nil {
+		req = req.WithContext(authlib.WithAuthInfo(req.Context(), auth))
+	}
+	return req
+}
+
+func TestDisplayHandler_handleSelf(t *testing.T) {
+	caller := &identity.StaticRequester{
+		Type:      authlib.TypeUser,
+		UserUID:   "u1",
+		UserID:    1,
+		OrgID:     1,
+		Namespace: "default",
+	}
+
+	t.Run("missing auth info returns 401", func(t *testing.T) {
+		h := NewDisplayHandler(&fakeResolver{})
+		rec := httptest.NewRecorder()
+
+		h.handleSelf(rec, selfRequest(t, nil))
+
+		require.Equal(t, http.StatusUnauthorized, rec.Code)
+	})
+
+	t.Run("caller display is resolved from context and returned", func(t *testing.T) {
+		want := iam.Display{
+			Identity:    iam.IdentityRef{Type: authlib.TypeUser, Name: "u1"},
+			DisplayName: "Alice",
+			InternalID:  1,
+		}
+		resolver := &fakeResolver{result: &iam.DisplayList{Items: []iam.Display{want}}}
+		h := NewDisplayHandler(resolver)
+		rec := httptest.NewRecorder()
+
+		h.handleSelf(rec, selfRequest(t, caller))
+
+		require.Equal(t, http.StatusOK, rec.Code)
+		// The caller identifies itself purely from context, no query input.
+		require.Equal(t, []string{"user:u1"}, resolver.gotKeys)
+
+		var got iam.Display
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+		require.Equal(t, want, got)
+	})
+
+	t.Run("unresolved caller returns 404", func(t *testing.T) {
+		resolver := &fakeResolver{result: &iam.DisplayList{}}
+		h := NewDisplayHandler(resolver)
+		rec := httptest.NewRecorder()
+
+		h.handleSelf(rec, selfRequest(t, caller))
+
+		require.Equal(t, http.StatusNotFound, rec.Code)
+	})
+
+	t.Run("resolver error returns 500", func(t *testing.T) {
+		resolver := &fakeResolver{err: errors.New("boom")}
+		h := NewDisplayHandler(resolver)
+		rec := httptest.NewRecorder()
+
+		h.handleSelf(rec, selfRequest(t, caller))
+
+		require.Equal(t, http.StatusInternalServerError, rec.Code)
+	})
+}

--- a/pkg/tests/apis/iam/user/user_integration_test.go
+++ b/pkg/tests/apis/iam/user/user_integration_test.go
@@ -57,6 +57,7 @@ func TestIntegrationUsers(t *testing.T) {
 			doUserFieldSelectorTests(t, helper)
 			doUserStatusUpdateTests(t, helper)
 			doDisplayTests(t, helper)
+			doSelfTests(t, helper)
 
 			if mode < 3 {
 				doUserCRUDTestsUsingTheLegacyAPIs(t, helper)
@@ -719,6 +720,38 @@ func doDisplayTests(t *testing.T, helper *apis.K8sTestHelper) {
 		require.Len(t, res.Items, 1)
 		require.Equal(t, authlib.TypeServiceAccount, res.Items[0].Identity.Type)
 		require.Equal(t, sa.Id, res.Items[0].InternalID)
+	})
+}
+
+func doSelfTests(t *testing.T, helper *apis.K8sTestHelper) {
+	// selfPath is the "who am I" endpoint. A literal `~` token must not be
+	// shadowed by the users/{name} resource route.
+	const selfPath = "/apis/iam.grafana.app/v0alpha1/namespaces/default/users/~"
+
+	t.Run("self endpoint returns the calling user's display info", func(t *testing.T) {
+		res := &iam.Display{}
+		rsp := apis.DoRequest(helper, apis.RequestParams{
+			User:   helper.Org1.Admin,
+			Method: "GET",
+			Path:   selfPath,
+		}, res)
+
+		require.Equal(t, 200, rsp.Response.StatusCode)
+		require.Equal(t, authlib.TypeUser, res.Identity.Type)
+		require.Equal(t, helper.Org1.Admin.Identity.GetRawIdentifier(), res.Identity.Name)
+	})
+
+	t.Run("self endpoint works for a non-admin reading their own info", func(t *testing.T) {
+		res := &iam.Display{}
+		rsp := apis.DoRequest(helper, apis.RequestParams{
+			User:   helper.Org1.Viewer,
+			Method: "GET",
+			Path:   selfPath,
+		}, res)
+
+		require.Equal(t, 200, rsp.Response.StatusCode)
+		require.Equal(t, authlib.TypeUser, res.Identity.Type)
+		require.Equal(t, helper.Org1.Viewer.Identity.GetRawIdentifier(), res.Identity.Name)
 	})
 }
 

--- a/pkg/tests/apis/iam/user/user_integration_test.go
+++ b/pkg/tests/apis/iam/user/user_integration_test.go
@@ -728,30 +728,35 @@ func doSelfTests(t *testing.T, helper *apis.K8sTestHelper) {
 	// shadowed by the users/{name} resource route.
 	const selfPath = "/apis/iam.grafana.app/v0alpha1/namespaces/default/users/~"
 
-	t.Run("self endpoint returns the calling user's display info", func(t *testing.T) {
+	assertSelf := func(t *testing.T, caller apis.User) {
+		t.Helper()
+
 		res := &iam.Display{}
 		rsp := apis.DoRequest(helper, apis.RequestParams{
-			User:   helper.Org1.Admin,
+			User:   caller,
 			Method: "GET",
 			Path:   selfPath,
 		}, res)
-
 		require.Equal(t, 200, rsp.Response.StatusCode)
+
+		wantID, err := identity.UserIdentifier(caller.Identity.GetID())
+		require.NoError(t, err)
+
 		require.Equal(t, authlib.TypeUser, res.Identity.Type)
-		require.Equal(t, helper.Org1.Admin.Identity.GetRawIdentifier(), res.Identity.Name)
+		require.Equal(t, caller.Identity.GetRawIdentifier(), res.Identity.Name)
+		require.Equal(t, caller.Identity.GetName(), res.DisplayName)
+		require.NotEmpty(t, res.DisplayName)
+		require.NotEmpty(t, res.AvatarURL)
+		require.Contains(t, res.AvatarURL, "/avatar/")
+		require.Equal(t, wantID, res.InternalID)
+	}
+
+	t.Run("self endpoint returns the calling user's display info", func(t *testing.T) {
+		assertSelf(t, helper.Org1.Admin)
 	})
 
 	t.Run("self endpoint works for a non-admin reading their own info", func(t *testing.T) {
-		res := &iam.Display{}
-		rsp := apis.DoRequest(helper, apis.RequestParams{
-			User:   helper.Org1.Viewer,
-			Method: "GET",
-			Path:   selfPath,
-		}, res)
-
-		require.Equal(t, 200, rsp.Response.StatusCode)
-		require.Equal(t, authlib.TypeUser, res.Identity.Type)
-		require.Equal(t, helper.Org1.Viewer.Identity.GetRawIdentifier(), res.Identity.Name)
+		assertSelf(t, helper.Org1.Viewer)
 	})
 }
 

--- a/pkg/tests/apis/openapi_snapshots/iam.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/iam.grafana.app-v0alpha1.json
@@ -2931,6 +2931,38 @@
           }
         }
       ]
+    },
+    "/apis/iam.grafana.app/v0alpha1/namespaces/{namespace}/users/~": {
+      "get": {
+        "tags": [
+          "Display"
+        ],
+        "description": "Show display information for the currently authenticated identity",
+        "operationId": "getCurrentUserDisplay",
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "description": "workspace",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "default"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.iam.v0alpha1.Display"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Adds a `who am I` endpoint to the `iam.grafana.app/v0alpha1` API group:

```
GET /apis/iam.grafana.app/v0alpha1/namespaces/{namespace}/users/~
```

It resolves the caller's own identity from the request context and returns a single Display (identity, display name, avatar, internal id), the same shape the existing `/display` endpoint emits.

**Why do we need this feature?**

There was no k8s way to ask `who am I?`. Every `users` lookup needs a known UID and `/display` requires explicit keys. The only self endpoint today is the legacy `GET /api/user`.

**Who is this feature for?**

all users

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/identity-access-team/issues/2045.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
