### PR TITLE
Scopes: fetch default scope without requiring scopes-first mode

### DIFF
--- a/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
@@ -85,7 +85,7 @@ export const FlagKeys = {
   GrafanaStarredFolders: "grafana.starredFolders",
   /** Replaces the bundled home dashboard with the unified homepage React page */
   GrafanaUnifiedHomepage: "grafana.unifiedHomepage",
-  /** Use the find default scope endpoint to seed the initial scope selection when none is set and grafana.enableScopesFirstMode is enabled. */
+  /** Use the find default scope endpoint to seed the initial scope selection when none is set. */
   GrafanaUseDefaultScopesEndpoint: "grafana.useDefaultScopesEndpoint",
   /** Enables semantic (vector) dashboard search in the command palette */
   GrafanaVectorSearchCmdk: "grafana.vectorSearchCmdk",
@@ -542,7 +542,7 @@ export const useFlagGrafanaUnifiedHomepage = (options?: ReactFlagEvaluationOptio
 };
 
 /**
- * Use the find default scope endpoint to seed the initial scope selection when none is set and grafana.enableScopesFirstMode is enabled.
+ * Use the find default scope endpoint to seed the initial scope selection when none is set.
  *
  * **Details:**
  * - flag key: `grafana.useDefaultScopesEndpoint`

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -2909,7 +2909,7 @@ var (
 		},
 		{
 			Name:         "grafana.useDefaultScopesEndpoint",
-			Description:  "Use the find default scope endpoint to seed the initial scope selection when none is set and grafana.enableScopesFirstMode is enabled.",
+			Description:  "Use the find default scope endpoint to seed the initial scope selection when none is set.",
 			Stage:        FeatureStageExperimental,
 			Owner:        grafanaOperatorExperienceSquad,
 			HideFromDocs: true,

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2975,11 +2975,14 @@
     {
       "metadata": {
         "name": "grafana.useDefaultScopesEndpoint",
-        "resourceVersion": "1783088074749",
-        "creationTimestamp": "2026-07-03T14:14:34Z"
+        "resourceVersion": "1784292490130",
+        "creationTimestamp": "2026-07-03T14:14:34Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-07-17 12:48:10.130812 +0000 UTC"
+        }
       },
       "spec": {
-        "description": "Use the find default scope endpoint to seed the initial scope selection when none is set and grafana.enableScopesFirstMode is enabled.",
+        "description": "Use the find default scope endpoint to seed the initial scope selection when none is set.",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-operator-experience-squad",
         "frontend": true,

--- a/public/app/features/scopes/ScopesService.test.ts
+++ b/public/app/features/scopes/ScopesService.test.ts
@@ -12,15 +12,6 @@ jest.mock('./selector/ScopesSelectorService');
 jest.mock('./dashboards/ScopesDashboardsService');
 jest.mock('./ScopesApiClient');
 
-jest.mock('@grafana/runtime/internal', () => ({
-  ...jest.requireActual('@grafana/runtime/internal'),
-  getFeatureFlagClient: jest.fn(),
-}));
-
-const { getFeatureFlagClient } = jest.requireMock('@grafana/runtime/internal') as {
-  getFeatureFlagClient: jest.Mock;
-};
-
 describe('ScopesService', () => {
   let service: ScopesService;
   let selectorService: jest.Mocked<ScopesSelectorService>;
@@ -135,10 +126,6 @@ describe('ScopesService', () => {
     apiClient = {
       fetchDefaultScope: jest.fn().mockResolvedValue(undefined),
     } as unknown as jest.Mocked<ScopesApiClient>;
-
-    getFeatureFlagClient.mockReturnValue({
-      getBooleanValue: jest.fn().mockReturnValue(false),
-    });
   });
 
   describe('URL initialization', () => {
@@ -1096,20 +1083,13 @@ describe('ScopesService', () => {
     });
 
     describe('default scope on first mount', () => {
-      const turnOnScopesFirstMode = () =>
-        getFeatureFlagClient.mockReturnValue({
-          getBooleanValue: (flagKey: string, defaultValue: boolean) =>
-            flagKey === 'grafana.enableScopesFirstMode' ? true : defaultValue,
-        });
-
       beforeEach(() => {
         // The ScopesService constructor calls selectorService.changeScopes during URL init.
         // Clear those calls so the assertions below only see the default-scope flow.
         jest.clearAllMocks();
       });
 
-      it('fetches the default scope and applies it when no scope is selected and ScopesFirstMode is on', async () => {
-        turnOnScopesFirstMode();
+      it('fetches the default scope and applies it when no scope is selected', async () => {
         selectorService.state.appliedScopes = [];
         apiClient.fetchDefaultScope = jest.fn().mockResolvedValue('gdev-shoe-org');
 
@@ -1122,18 +1102,7 @@ describe('ScopesService', () => {
         expect(selectorService.changeScopes).toHaveBeenCalledWith(['gdev-shoe-org'], undefined, undefined, true);
       });
 
-      it('does not fetch when ScopesFirstMode is off', () => {
-        getFeatureFlagClient.mockReturnValue({ getBooleanValue: jest.fn().mockReturnValue(false) });
-        selectorService.state.appliedScopes = [];
-        apiClient.fetchDefaultScope = jest.fn();
-
-        service.setEnabled(true);
-
-        expect(apiClient.fetchDefaultScope).not.toHaveBeenCalled();
-      });
-
       it('does not fetch when a scope is already selected', () => {
-        turnOnScopesFirstMode();
         selectorService.state.appliedScopes = [{ scopeId: 'scope1' }];
         selectorService.state.scopes = {
           scope1: { metadata: { name: 'scope1' }, spec: { title: 'Scope 1', filters: [] } },
@@ -1146,7 +1115,6 @@ describe('ScopesService', () => {
       });
 
       it('does not apply when fetchDefaultScope resolves to undefined (endpoint flag off or no default)', async () => {
-        turnOnScopesFirstMode();
         selectorService.state.appliedScopes = [];
         apiClient.fetchDefaultScope = jest.fn().mockResolvedValue(undefined);
 
@@ -1158,7 +1126,6 @@ describe('ScopesService', () => {
       });
 
       it('does not apply if scopes is disabled before the fetch resolves', async () => {
-        turnOnScopesFirstMode();
         selectorService.state.appliedScopes = [];
         apiClient.fetchDefaultScope = jest.fn().mockResolvedValue('gdev-shoe-org');
 
@@ -1172,7 +1139,6 @@ describe('ScopesService', () => {
       });
 
       it('does not apply if the user has picked a scope but not yet applied before the fetch resolves', async () => {
-        turnOnScopesFirstMode();
         selectorService.state.appliedScopes = [];
         selectorService.state.selectedScopes = [];
         apiClient.fetchDefaultScope = jest.fn().mockImplementation(async () => {
@@ -1192,7 +1158,6 @@ describe('ScopesService', () => {
       });
 
       it('logs and does not throw when the apply promise rejects', async () => {
-        turnOnScopesFirstMode();
         selectorService.state.appliedScopes = [];
         selectorService.state.selectedScopes = [];
         apiClient.fetchDefaultScope = jest.fn().mockResolvedValue('gdev-shoe-org');
@@ -1210,7 +1175,6 @@ describe('ScopesService', () => {
       });
 
       it('does not fetch twice when setEnabled(true) is called twice in a row', async () => {
-        turnOnScopesFirstMode();
         selectorService.state.appliedScopes = [];
         apiClient.fetchDefaultScope = jest.fn().mockResolvedValue(undefined);
 

--- a/public/app/features/scopes/ScopesService.ts
+++ b/public/app/features/scopes/ScopesService.ts
@@ -3,7 +3,6 @@ import { BehaviorSubject, type Observable, combineLatest, type Subscription } fr
 import { map, distinctUntilChanged } from 'rxjs/operators';
 
 import { type LocationService, type ScopesContextValue, type ScopesContextValueState } from '@grafana/runtime';
-import { FlagKeys, getFeatureFlagClient } from '@grafana/runtime/internal';
 
 import { type ScopesApiClient } from './ScopesApiClient';
 import { type ScopesDashboardsService } from './dashboards/ScopesDashboardsService';
@@ -251,14 +250,11 @@ export class ScopesService implements ScopesContextValue {
       this.updateState({ enabled });
       if (enabled) {
         const { appliedScopes, scopes } = this.selectorService.state;
-        // When there is no selection yet and ScopesFirstMode is on, fetch the
-        // default scope and apply it. Fire-and-forget so setEnabled stays sync.
-        // fetchDefaultScope is itself gated on grafana.useDefaultScopesEndpoint
-        // and returns undefined when off, so the call is safe here.
-        if (
-          appliedScopes.length === 0 &&
-          getFeatureFlagClient().getBooleanValue(FlagKeys.GrafanaEnableScopesFirstMode, false)
-        ) {
+        // When there is no selection yet, fetch the default scope and apply
+        // it. Fire-and-forget so setEnabled stays sync. fetchDefaultScope is
+        // itself gated on grafana.useDefaultScopesEndpoint and returns
+        // undefined when off, so the call is safe here.
+        if (appliedScopes.length === 0) {
           this.apiClient
             .fetchDefaultScope()
             .then((name) => {

--- a/public/app/features/scopes/tests/defaultScope.test.ts
+++ b/public/app/features/scopes/tests/defaultScope.test.ts
@@ -32,7 +32,6 @@ describe('Default scope', () => {
 
   beforeEach(() => {
     setTestFlags({
-      'grafana.enableScopesFirstMode': true,
       'grafana.useDefaultScopesEndpoint': true,
     });
     window.localStorage.clear();
@@ -77,25 +76,8 @@ describe('Default scope', () => {
     });
   });
 
-  it('does not fetch the default scope when grafana.enableScopesFirstMode is off', async () => {
-    setTestFlags({
-      'grafana.enableScopesFirstMode': false,
-      'grafana.useDefaultScopesEndpoint': true,
-    });
-
-    ({ scopesSelectorService } = await renderDashboard());
-
-    // Give the dashboard a tick to settle.
-    await waitFor(() => {
-      expect(scopesSelectorService.state.tree).toBeDefined();
-    });
-
-    expect(scopesSelectorService.state.appliedScopes).toEqual([]);
-  });
-
   it('does not fetch the default scope when grafana.useDefaultScopesEndpoint is off', async () => {
     setTestFlags({
-      'grafana.enableScopesFirstMode': true,
       'grafana.useDefaultScopesEndpoint': false,
     });
 


### PR DESCRIPTION
Default scope seeding only needs useDefaultScopesEndpoint and an empty selection; remove the enableScopesFirstMode guard.
