### PR TITLE
uPlot: Increase axis grid line contrast

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/config/UPlotAxisBuilder.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotAxisBuilder.ts
@@ -94,7 +94,7 @@ export class UPlotAxisBuilder extends PlotConfigBuilder<AxisProps, Axis> {
 
     const font = `${UPLOT_AXIS_FONT_SIZE}px ${theme.typography.fontFamily}`;
 
-    const gridColor = theme.isDark ? 'rgba(240, 250, 255, 0.09)' : 'rgba(0, 10, 23, 0.09)';
+    const gridColor = theme.isDark ? 'rgba(240, 250, 255, 0.22)' : 'rgba(0, 10, 23, 0.22)';
 
     // TODO: this is pretty flimsy now that scaleKey is composed from multiple parts :/
     if (isBooleanUnit(scaleKey)) {


### PR DESCRIPTION
Raises the axis grid line opacity from 0.09 to 0.22 in both light and dark themes so gridlines are easier to follow across the plot area.