### PR TITLE
Error page: widen error details container

### DIFF
--- a/public/app/core/navigation/GrafanaRouteError.tsx
+++ b/public/app/core/navigation/GrafanaRouteError.tsx
@@ -62,7 +62,7 @@ export function GrafanaRouteError({ error, errorInfo }: Props) {
 
 const getStyles = (theme: GrafanaTheme2) => ({
   container: css({
-    width: '500px',
+    width: '720px',
     margin: theme.spacing(8, 'auto'),
   }),
 });


### PR DESCRIPTION
Gives the unexpected-error details and stack trace more horizontal room so long messages wrap less on the route error page.