### PR TITLE
Canvas: increase default connection line width

### DIFF
--- a/public/app/plugins/panel/canvas/components/connections/ConnectionSVG.tsx
+++ b/public/app/plugins/panel/canvas/components/connections/ConnectionSVG.tsx
@@ -46,7 +46,7 @@ export const ConnectionSVG = ({
   const CONNECTION_LINE_ID = useMemo(() => `connectionLineId-${headId}`, [headId]);
   const EDITOR_HEAD_ID = useMemo(() => `editorHead-${headId}`, [headId]);
   const defaultArrowColor = config.theme2.colors.text.primary;
-  const defaultArrowSize = 2;
+  const defaultArrowSize = 4;
   const defaultArrowDirection: DirectionDimensionConfig = {
     mode: DirectionDimensionMode.Fixed,
     fixed: ConnectionDirection.Forward,

--- a/public/app/plugins/panel/canvas/components/connections/ConnectionSVG2.tsx
+++ b/public/app/plugins/panel/canvas/components/connections/ConnectionSVG2.tsx
@@ -37,7 +37,7 @@ export const ConnectionSVG = ({ setLineRef, setVertexPathRef, setVertexRef, setC
   const CONNECTION_LINE_ID = useMemo(() => `connectionLineId-${headId}`, [headId]);
   const EDITOR_HEAD_ID = useMemo(() => `editorHead-${headId}`, [headId]);
   const defaultArrowColor = config.theme2.colors.text.primary;
-  const defaultArrowSize = 2;
+  const defaultArrowSize = 4;
   const defaultArrowDirection: DirectionDimensionConfig = {
     mode: DirectionDimensionMode.Fixed,
     fixed: ConnectionDirection.Forward,


### PR DESCRIPTION
Bumps the fallback connection stroke width from 2 to 4 so connections without an explicit size are easier to see.