### PR TITLE
App platform: Add PATCH to the client

### DIFF
--- a/pkg/registry/apis/dashboard/register_test.go
+++ b/pkg/registry/apis/dashboard/register_test.go
@@ -10,6 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	types "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apiserver/pkg/admission"
 
 	dashv1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1"
@@ -199,6 +200,9 @@ func (m *mockK8sHandler) Create(_ context.Context, _ *unstructured.Unstructured,
 	return nil, nil
 }
 func (m *mockK8sHandler) Update(_ context.Context, _ *unstructured.Unstructured, _ int64, _ metav1.UpdateOptions) (*unstructured.Unstructured, error) {
+	return nil, nil
+}
+func (m *mockK8sHandler) Patch(_ context.Context, _ string, _ types.PatchType, _ []byte, _ int64, _ metav1.PatchOptions) (*unstructured.Unstructured, error) {
 	return nil, nil
 }
 func (m *mockK8sHandler) Delete(_ context.Context, _ string, _ int64, _ metav1.DeleteOptions) error {

--- a/pkg/registry/apis/dashboard/variable_test.go
+++ b/pkg/registry/apis/dashboard/variable_test.go
@@ -10,6 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	types "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apiserver/pkg/admission"
 	k8srequest "k8s.io/apiserver/pkg/endpoints/request"
 
@@ -426,6 +427,9 @@ func (h *variableFolderAccessHandler) Create(_ context.Context, _ *unstructured.
 	return nil, nil
 }
 func (h *variableFolderAccessHandler) Update(_ context.Context, _ *unstructured.Unstructured, _ int64, _ metav1.UpdateOptions) (*unstructured.Unstructured, error) {
+	return nil, nil
+}
+func (m *variableFolderAccessHandler) Patch(_ context.Context, _ string, _ types.PatchType, _ []byte, _ int64, _ metav1.PatchOptions) (*unstructured.Unstructured, error) {
 	return nil, nil
 }
 func (h *variableFolderAccessHandler) Delete(_ context.Context, _ string, _ int64, _ metav1.DeleteOptions) error {

--- a/pkg/services/apiserver/client/client.go
+++ b/pkg/services/apiserver/client/client.go
@@ -29,6 +29,7 @@ type K8sHandler interface {
 	Get(ctx context.Context, name string, orgID int64, options v1.GetOptions, subresource ...string) (*unstructured.Unstructured, error)
 	Create(ctx context.Context, obj *unstructured.Unstructured, orgID int64, opts v1.CreateOptions) (*unstructured.Unstructured, error)
 	Update(ctx context.Context, obj *unstructured.Unstructured, orgID int64, opts v1.UpdateOptions) (*unstructured.Unstructured, error)
+	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, orgID int64, opts v1.PatchOptions) (*unstructured.Unstructured, error)
 	Delete(ctx context.Context, name string, orgID int64, options v1.DeleteOptions) error
 	DeleteCollection(ctx context.Context, orgID int64, listOptions v1.ListOptions) error
 	List(ctx context.Context, orgID int64, options v1.ListOptions) (*unstructured.UnstructuredList, error)

--- a/pkg/services/apiserver/client/client.go
+++ b/pkg/services/apiserver/client/client.go
@@ -9,6 +9,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	types "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 
@@ -86,6 +87,14 @@ func (h *k8sHandler) Update(ctx context.Context, obj *unstructured.Unstructured,
 	}
 
 	return client.Update(ctx, obj, opts)
+}
+
+func (h *k8sHandler) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, orgID int64, opts v1.PatchOptions) (*unstructured.Unstructured, error) {
+	client, err := h.getClient(ctx, orgID)
+	if err != nil {
+		return nil, err
+	}
+	return client.Patch(ctx, name, pt, data, opts)
 }
 
 func (h *k8sHandler) Delete(ctx context.Context, name string, orgID int64, options v1.DeleteOptions) error {

--- a/pkg/services/apiserver/client/client_mock.go
+++ b/pkg/services/apiserver/client/client_mock.go
@@ -10,6 +10,7 @@ import (
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	types "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
 )
 
@@ -47,6 +48,14 @@ func (m *MockK8sHandler) Create(ctx context.Context, obj *unstructured.Unstructu
 
 func (m *MockK8sHandler) Update(ctx context.Context, obj *unstructured.Unstructured, orgID int64, opts v1.UpdateOptions) (*unstructured.Unstructured, error) {
 	args := m.Called(ctx, obj, orgID, opts)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*unstructured.Unstructured), args.Error(1)
+}
+
+func (m *MockK8sHandler) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, orgID int64, opts v1.PatchOptions) (*unstructured.Unstructured, error) {
+	args := m.Called(ctx, name, pt, data, orgID, opts)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}

--- a/pkg/services/authn/authnimpl/sync/user_sync_test.go
+++ b/pkg/services/authn/authnimpl/sync/user_sync_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	types "k8s.io/apimachinery/pkg/types"
 
 	claims "github.com/grafana/authlib/types"
 	iamv0alpha1 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
@@ -1830,6 +1831,14 @@ func (m *MockK8sHandler) Create(ctx context.Context, obj *unstructured.Unstructu
 
 func (m *MockK8sHandler) Update(ctx context.Context, obj *unstructured.Unstructured, orgID int64, opts metav1.UpdateOptions) (*unstructured.Unstructured, error) {
 	args := m.Called(ctx, obj, orgID, opts)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*unstructured.Unstructured), args.Error(1)
+}
+
+func (m *MockK8sHandler) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, orgID int64, opts metav1.PatchOptions) (*unstructured.Unstructured, error) {
+	args := m.Called(ctx, name, pt, data, orgID, opts)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}

--- a/pkg/services/scimutil/scim_util_test.go
+++ b/pkg/services/scimutil/scim_util_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	types "k8s.io/apimachinery/pkg/types"
 
 	"github.com/grafana/grafana/pkg/services/apiserver/client"
 	"github.com/grafana/grafana/pkg/services/user"
@@ -43,6 +44,14 @@ func (m *MockK8sHandler) Create(ctx context.Context, obj *unstructured.Unstructu
 
 func (m *MockK8sHandler) Update(ctx context.Context, obj *unstructured.Unstructured, orgID int64, opts metav1.UpdateOptions) (*unstructured.Unstructured, error) {
 	args := m.Called(ctx, obj, orgID, opts)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*unstructured.Unstructured), args.Error(1)
+}
+
+func (m *MockK8sHandler) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, orgID int64, opts metav1.PatchOptions) (*unstructured.Unstructured, error) {
+	args := m.Called(ctx, name, pt, data, orgID, opts)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}


### PR DESCRIPTION
I would like to have the option to PATCH from the backend, so I can match what the generated frontend client code does.

At the time it was generated, the frontend update function used PATCH https://github.com/grafana/grafana/blob/main/packages/grafana-api-clients/src/clients/rtkq/correlations/v0alpha1/endpoints.gen.ts#L108

Overall, I found this to work really well. However, it can be more complicated to think about the differences between the various code paths when we use PATCH on the frontend and the backend does not have it as an option.

This adds the PATCH option for future use.