### PR TITLE
Trace View: Check for the existence of logs when showing the trace-to-logs button

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -103,6 +103,7 @@ Most [generally available](https://grafana.com/docs/release-life-cycle/#general-
 | `queryEditorNext`                 | Enables next generation query editor experience                                                |
 | `flameGraphWithCallTree`          | Enables the new Flame Graph UI containing the Call Tree view                                   |
 | `splashScreen`                    | Enables the splash screen modal for introducing new Grafana features on first session          |
+| `grafana.dynamicTraceToLogs`      | Check for the existence of logs when linking from the Trace View                               |
 
 ## Development feature toggles
 

--- a/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
@@ -78,7 +78,8 @@ declare module "@openfeature/core" {
     | "grafana.growthHomepage"
     | "grafana.onDemandDiagnostics"
     | "grafana.multiTenantNavTree"
-    | "grafana.exploreMetricsSidebar";
+    | "grafana.exploreMetricsSidebar"
+    | "grafana.dynamicTraceToLogs";
   export type NumberFlagKey = never;
   export type StringFlagKey = never;
   export type ObjectFlagKey = never;

--- a/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
@@ -55,6 +55,8 @@ export const FlagKeys = {
   GrafanaCustomizableMegaMenu: "grafana.customizableMegaMenu",
   /** Redesigns dashboard settings page into Advanced Settings in a modal window */
   GrafanaDashboardSettingsRedesign: "grafana.dashboardSettingsRedesign",
+  /** Check for the existence of logs when linking from the Trace View */
+  GrafanaDynamicTraceToLogs: "grafana.dynamicTraceToLogs",
   /** Enables UI changes for integrations that require a scope to always be selected (for example, hides the scope selector's Remove all button) */
   GrafanaEnableScopesFirstMode: "grafana.enableScopesFirstMode",
   /** Enables the sidebar in Explore metrics (Metrics Drilldown) */
@@ -382,6 +384,17 @@ export const useFlagGrafanaCustomizableMegaMenu = (options?: ReactFlagEvaluation
  */
 export const useFlagGrafanaDashboardSettingsRedesign = (options?: ReactFlagEvaluationOptions): boolean => {
   return useFlag("grafana.dashboardSettingsRedesign", true, options).value;
+};
+
+/**
+ * Check for the existence of logs when linking from the Trace View
+ *
+ * **Details:**
+ * - flag key: `grafana.dynamicTraceToLogs`
+ * - default value: `false`
+ */
+export const useFlagGrafanaDynamicTraceToLogs = (options?: ReactFlagEvaluationOptions): boolean => {
+  return useFlag("grafana.dynamicTraceToLogs", false, options).value;
 };
 
 /**

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -3126,6 +3126,14 @@ var (
 			Expression:  "false",
 			Generate:    Generate{React: true},
 		},
+		{
+			Name:        "grafana.dynamicTraceToLogs",
+			Description: "Check for the existence of logs when linking from the Trace View",
+			Stage:       FeatureStagePublicPreview,
+			Owner:       grafanaObservabilityLogsSquad,
+			Expression:  "false",
+			Generate:    Generate{React: true},
+		},
 		// tl;dr: name your new flag `component.featureName`, specify Go and/or React generation targets, and use with OpenFeature!
 		//
 		// Adding a new feature flag? Be sure to check out the updated docs at /contribute/feature-toggles.md#Steps-to-adding-a-feature-toggle

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -363,3 +363,4 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-07-17,features.bulkFlagEvalFiltering,experimental,@grafana/grafana-backend-services-squad,false,false,false
 2026-07-14,grafana.multiTenantNavTree,experimental,@grafana/grafana-frontend-navigation,false,false,true
 2026-07-20,grafana.exploreMetricsSidebar,experimental,@grafana/datapro,false,false,true
+2026-07-22,grafana.dynamicTraceToLogs,preview,@grafana/observability-logs,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2697,6 +2697,20 @@
     },
     {
       "metadata": {
+        "name": "grafana.dynamicTraceToLogs",
+        "resourceVersion": "1784712177554",
+        "creationTimestamp": "2026-07-22T09:22:57Z"
+      },
+      "spec": {
+        "description": "Check for the existence of logs when linking from the Trace View",
+        "stage": "preview",
+        "codeowner": "@grafana/observability-logs",
+        "frontend": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "grafana.enableScopesFirstMode",
         "resourceVersion": "1779440584464",
         "creationTimestamp": "2026-05-22T09:03:04Z"

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/LogsLink.test.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/LogsLink.test.tsx
@@ -8,7 +8,7 @@ import { setTestFlags } from '@grafana/test-utils/unstable';
 
 import { SpanLinkType, type SpanLinkModel } from '../../types/links';
 
-import { getLogsButtonCTA, getLogsButtonTooltip, LogsLinkButton } from './LogsLink';
+import { getLogsButtonCTA, getLogsButtonTooltip, LogsLinkButton, LogsLinkMenuItem } from './LogsLink';
 
 jest.mock('@grafana/runtime/unstable', () => ({
   ...jest.requireActual('@grafana/runtime/unstable'),
@@ -212,6 +212,130 @@ describe('LogsLinkButton', () => {
     expect(
       screen.queryByText('No related logs found using the trace data source configuration.')
     ).not.toBeInTheDocument();
+  });
+});
+
+describe('LogsLinkMenuItem', () => {
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    useDataSourceInstanceSettingsMock.mockReturnValue({ isLoading: false, settings: undefined });
+    // The presence check is gated behind this flag; enable it so most tests exercise the check.
+    // Wrap in act() because setTestFlags fires OpenFeature events that trigger React state updates.
+    await act(async () => {
+      setTestFlags({ [DYNAMIC_TRACE_TO_LOGS_FLAG]: true });
+    });
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      setTestFlags({});
+    });
+  });
+
+  it('renders the menu item with its CTA copy', () => {
+    render(<LogsLinkMenuItem spanLinkModel={createSpanLinkModel()} />);
+
+    expect(screen.getByRole('menuitem')).toBeInTheDocument();
+    expect(screen.getByText(CTA_RELATED_LOGS)).toBeInTheDocument();
+  });
+
+  it('does not query the datasource when the link has no query', () => {
+    render(<LogsLinkMenuItem spanLinkModel={createSpanLinkModel()} />);
+
+    expect(getDataSourceInstanceMock).not.toHaveBeenCalled();
+  });
+
+  it('does not check for logs when the dynamicTraceToLogs flag is disabled', async () => {
+    await act(async () => {
+      setTestFlags({ [DYNAMIC_TRACE_TO_LOGS_FLAG]: false });
+    });
+    useDataSourceInstanceSettingsMock.mockReturnValue({
+      isLoading: false,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      settings: { jsonData: {} } as any,
+    });
+    mockDatasourceReturningFrames([emptyFrame], 'loki');
+    const interpolatedQuery: DataQuery = { refId: 'A', datasource: { uid: 'logs-ds-uid', type: 'loki' } };
+
+    render(
+      <LogsLinkMenuItem spanLinkModel={createSpanLinkModel({ interpolatedParams: { query: interpolatedQuery } })} />
+    );
+
+    // The datasource is never queried, and the item stays enabled (present).
+    expect(getDataSourceInstanceMock).not.toHaveBeenCalled();
+    expect(screen.getByRole('menuitem')).toBeEnabled();
+  });
+
+  it('runs the query against its datasource to check for logs', async () => {
+    const query = mockDatasourceReturningFrames([logsFrame], 'elasticsearch');
+    const interpolatedQuery: DataQuery = { refId: 'A', datasource: { uid: 'logs-ds-uid', type: 'elasticsearch' } };
+
+    render(
+      <LogsLinkMenuItem spanLinkModel={createSpanLinkModel({ interpolatedParams: { query: interpolatedQuery } })} />
+    );
+
+    await waitFor(() => expect(getDataSourceInstanceMock).toHaveBeenCalledWith(interpolatedQuery.datasource));
+    expect(query).toHaveBeenCalledWith(expect.objectContaining({ targets: [interpolatedQuery] }));
+  });
+
+  it('disables the item when the query returns no rows', async () => {
+    useDataSourceInstanceSettingsMock.mockReturnValue({
+      isLoading: false,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      settings: { jsonData: {} } as any,
+    });
+    mockDatasourceReturningFrames([emptyFrame], 'loki');
+    const interpolatedQuery: DataQuery = { refId: 'A', datasource: { uid: 'logs-ds-uid', type: 'loki' } };
+
+    render(
+      <LogsLinkMenuItem spanLinkModel={createSpanLinkModel({ interpolatedParams: { query: interpolatedQuery } })} />
+    );
+
+    await waitFor(() => expect(screen.getByRole('menuitem')).toBeDisabled());
+  });
+
+  it('keeps the item enabled when the query returns logs', async () => {
+    useDataSourceInstanceSettingsMock.mockReturnValue({
+      isLoading: false,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      settings: { jsonData: {} } as any,
+    });
+    mockDatasourceReturningFrames([logsFrame], 'loki');
+    const interpolatedQuery: DataQuery = { refId: 'A', datasource: { uid: 'logs-ds-uid', type: 'loki' } };
+
+    render(
+      <LogsLinkMenuItem spanLinkModel={createSpanLinkModel({ interpolatedParams: { query: interpolatedQuery } })} />
+    );
+
+    await waitFor(() => expect(getDataSourceInstanceMock).toHaveBeenCalled());
+    expect(screen.getByRole('menuitem')).toBeEnabled();
+  });
+
+  it('fails open (keeps the item enabled) when the presence check errors', async () => {
+    useDataSourceInstanceSettingsMock.mockReturnValue({
+      isLoading: false,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      settings: { jsonData: {} } as any,
+    });
+    const query = jest.fn().mockReturnValue(throwError(() => new Error('boom')));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    getDataSourceInstanceMock.mockResolvedValue({ query } as any);
+    const interpolatedQuery: DataQuery = { refId: 'A', datasource: { uid: 'logs-ds-uid', type: 'loki' } };
+
+    render(
+      <LogsLinkMenuItem spanLinkModel={createSpanLinkModel({ interpolatedParams: { query: interpolatedQuery } })} />
+    );
+
+    await waitFor(() => expect(query).toHaveBeenCalled());
+    expect(screen.getByRole('menuitem')).toBeEnabled();
+  });
+
+  it('invokes the link onClick handler when clicked', async () => {
+    const onClick = jest.fn();
+    render(<LogsLinkMenuItem spanLinkModel={createSpanLinkModel({ onClick })} />);
+
+    await userEvent.click(screen.getByRole('menuitem'));
+    expect(onClick).toHaveBeenCalled();
   });
 });
 

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/LogsLink.test.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/LogsLink.test.tsx
@@ -41,10 +41,10 @@ function createSpanLinkModel(overrides: Partial<LinkModel> = {}): SpanLinkModel 
  * Builds a fake datasource whose `query` emits a single response containing the
  * given frames, so the presence check can resolve deterministically.
  */
-function mockDatasourceReturningFrames(frames: Array<ReturnType<typeof toDataFrame>>) {
+function mockDatasourceReturningFrames(frames: Array<ReturnType<typeof toDataFrame>>, type?: string) {
   const query = jest.fn().mockReturnValue(of({ data: frames }));
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  getDataSourceInstanceMock.mockResolvedValue({ query } as any);
+  getDataSourceInstanceMock.mockResolvedValue({ query, type } as any);
   return query;
 }
 
@@ -87,6 +87,35 @@ describe('LogsLinkButton', () => {
 
     await waitFor(() => expect(getDataSourceInstanceMock).toHaveBeenCalledWith(interpolatedQuery.datasource));
     expect(query).toHaveBeenCalledWith(expect.objectContaining({ targets: [interpolatedQuery] }));
+  });
+
+  it('limits the presence check to a single log line for loki datasources', async () => {
+    const query = mockDatasourceReturningFrames([logsFrame], 'loki');
+    const interpolatedQuery: DataQuery = { refId: 'A', datasource: { uid: 'logs-ds-uid', type: 'loki' } };
+
+    render(
+      <LogsLinkButton spanLinkModel={createSpanLinkModel({ interpolatedParams: { query: interpolatedQuery } })} />
+    );
+
+    await waitFor(() => expect(query).toHaveBeenCalled());
+    expect(query).toHaveBeenCalledWith(
+      expect.objectContaining({ targets: [expect.objectContaining({ ...interpolatedQuery, maxLines: 1 })] })
+    );
+  });
+
+  it('does not set maxLines for non-loki logging datasources', async () => {
+    const query = mockDatasourceReturningFrames([logsFrame], 'elasticsearch');
+    const interpolatedQuery: DataQuery = { refId: 'A', datasource: { uid: 'logs-ds-uid', type: 'elasticsearch' } };
+
+    render(
+      <LogsLinkButton spanLinkModel={createSpanLinkModel({ interpolatedParams: { query: interpolatedQuery } })} />
+    );
+
+    await waitFor(() => expect(query).toHaveBeenCalled());
+    expect(query).toHaveBeenCalledWith(expect.objectContaining({ targets: [interpolatedQuery] }));
+    expect(query).not.toHaveBeenCalledWith(
+      expect.objectContaining({ targets: [expect.objectContaining({ maxLines: expect.anything() })] })
+    );
   });
 
   it('marks the button as absent (no logs) when the query returns no rows', async () => {

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/LogsLink.test.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/LogsLink.test.tsx
@@ -1,11 +1,11 @@
-import { render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import { of, throwError } from 'rxjs';
+import { act, render, screen, userEvent, waitFor } from 'test/test-utils';
+
 
 import { type DataSourceApi, type DataSourceInstanceSettings, type LinkModel, toDataFrame } from '@grafana/data';
-import { useFlagGrafanaDynamicTraceToLogs } from '@grafana/runtime/internal';
 import { getDataSourceInstance, useDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import { type DataQuery } from '@grafana/schema';
+import { setTestFlags } from '@grafana/test-utils/unstable';
 
 import { SpanLinkType, type SpanLinkModel } from '../../types/links';
 
@@ -17,14 +17,10 @@ jest.mock('@grafana/runtime/unstable', () => ({
   useDataSourceInstanceSettings: jest.fn().mockReturnValue({ isLoading: false, settings: undefined }),
 }));
 
-jest.mock('@grafana/runtime/internal', () => ({
-  ...jest.requireActual('@grafana/runtime/internal'),
-  useFlagGrafanaDynamicTraceToLogs: jest.fn(),
-}));
-
 const getDataSourceInstanceMock = jest.mocked(getDataSourceInstance);
 const useDataSourceInstanceSettingsMock = jest.mocked(useDataSourceInstanceSettings);
-const useFlagGrafanaDynamicTraceToLogsMock = jest.mocked(useFlagGrafanaDynamicTraceToLogs);
+
+const DYNAMIC_TRACE_TO_LOGS_FLAG = 'grafana.dynamicTraceToLogs';
 
 const CTA_RELATED_LOGS = 'Related logs';
 
@@ -64,11 +60,20 @@ const logsFrame = toDataFrame({
 const emptyFrame = toDataFrame({ fields: [{ name: 'time', values: [] }] });
 
 describe('LogsLinkButton', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     jest.clearAllMocks();
     useDataSourceInstanceSettingsMock.mockReturnValue({ isLoading: false, settings: undefined });
     // The presence check is gated behind this flag; enable it so most tests exercise the check.
-    useFlagGrafanaDynamicTraceToLogsMock.mockReturnValue(true);
+    // Wrap in act() because setTestFlags fires OpenFeature events that trigger React state updates.
+    await act(async () => {
+      setTestFlags({ [DYNAMIC_TRACE_TO_LOGS_FLAG]: true });
+    });
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      setTestFlags({});
+    });
   });
 
   it('renders the link button with its CTA copy', () => {
@@ -78,14 +83,16 @@ describe('LogsLinkButton', () => {
     expect(screen.getByText(CTA_RELATED_LOGS)).toBeInTheDocument();
   });
 
-  it('does not query the datasource when the link has no interpolated query', () => {
+  it('does not query the datasource when the link has no query', () => {
     render(<LogsLinkButton spanLinkModel={createSpanLinkModel()} />);
 
     expect(getDataSourceInstanceMock).not.toHaveBeenCalled();
   });
 
   it('does not check for logs when the dynamicTraceToLogs flag is disabled', async () => {
-    useFlagGrafanaDynamicTraceToLogsMock.mockReturnValue(false);
+    await act(async () => {
+      setTestFlags({ [DYNAMIC_TRACE_TO_LOGS_FLAG]: false });
+    });
     useDataSourceInstanceSettingsMock.mockReturnValue({
       isLoading: false,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -107,9 +114,9 @@ describe('LogsLinkButton', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('runs the interpolated query against its datasource to check for logs', async () => {
-    const query = mockDatasourceReturningFrames([logsFrame], 'loki');
-    const interpolatedQuery: DataQuery = { refId: 'A', datasource: { uid: 'logs-ds-uid', type: 'loki' } };
+  it('runs the query against its datasource to check for logs', async () => {
+    const query = mockDatasourceReturningFrames([logsFrame], 'elasticsearch');
+    const interpolatedQuery: DataQuery = { refId: 'A', datasource: { uid: 'logs-ds-uid', type: 'elasticsearch' } };
 
     render(
       <LogsLinkButton spanLinkModel={createSpanLinkModel({ interpolatedParams: { query: interpolatedQuery } })} />

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/LogsLink.test.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/LogsLink.test.tsx
@@ -1,7 +1,6 @@
 import { of, throwError } from 'rxjs';
 import { act, render, screen, userEvent, waitFor } from 'test/test-utils';
 
-
 import { type DataSourceApi, type DataSourceInstanceSettings, type LinkModel, toDataFrame } from '@grafana/data';
 import { getDataSourceInstance, useDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import { type DataQuery } from '@grafana/schema';

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/LogsLink.test.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/LogsLink.test.tsx
@@ -1,0 +1,235 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { of, throwError } from 'rxjs';
+
+import { type DataSourceInstanceSettings, type LinkModel, toDataFrame } from '@grafana/data';
+import { getDataSourceInstance, useDataSourceInstanceSettings } from '@grafana/runtime/unstable';
+import { type DataQuery } from '@grafana/schema';
+
+import { SpanLinkType, type SpanLinkModel } from '../../types/links';
+
+import { getLogsButtonCTA, getLogsButtonTooltip, LogsLinkButton } from './LogsLink';
+
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getDataSourceInstance: jest.fn(),
+  useDataSourceInstanceSettings: jest.fn().mockReturnValue({ isLoading: false, settings: undefined }),
+}));
+
+const getDataSourceInstanceMock = jest.mocked(getDataSourceInstance);
+const useDataSourceInstanceSettingsMock = jest.mocked(useDataSourceInstanceSettings);
+
+const CTA_RELATED_LOGS = 'Related logs';
+
+function createSpanLinkModel(overrides: Partial<LinkModel> = {}): SpanLinkModel {
+  return {
+    type: SpanLinkType.Logs,
+    icon: 'gf-logs',
+    traceDatasourceUid: 'trace-ds-uid',
+    linkModel: {
+      href: '/logs',
+      title: CTA_RELATED_LOGS,
+      target: '_blank',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      origin: {} as any,
+      ...overrides,
+    },
+  };
+}
+
+/**
+ * Builds a fake datasource whose `query` emits a single response containing the
+ * given frames, so the presence check can resolve deterministically.
+ */
+function mockDatasourceReturningFrames(frames: Array<ReturnType<typeof toDataFrame>>) {
+  const query = jest.fn().mockReturnValue(of({ data: frames }));
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  getDataSourceInstanceMock.mockResolvedValue({ query } as any);
+  return query;
+}
+
+const logsFrame = toDataFrame({
+  meta: { preferredVisualisationType: 'logs' },
+  fields: [
+    { name: 'time', values: [1] },
+    { name: 'message', values: ['hello'] },
+  ],
+});
+
+const emptyFrame = toDataFrame({ fields: [{ name: 'time', values: [] }] });
+
+describe('LogsLinkButton', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useDataSourceInstanceSettingsMock.mockReturnValue({ isLoading: false, settings: undefined });
+  });
+
+  it('renders the link button with its CTA copy', () => {
+    render(<LogsLinkButton spanLinkModel={createSpanLinkModel()} />);
+
+    expect(screen.getByRole('button')).toBeInTheDocument();
+    expect(screen.getByText(CTA_RELATED_LOGS)).toBeInTheDocument();
+  });
+
+  it('does not query the datasource when the link has no interpolated query', () => {
+    render(<LogsLinkButton spanLinkModel={createSpanLinkModel()} />);
+
+    expect(getDataSourceInstanceMock).not.toHaveBeenCalled();
+  });
+
+  it('runs the interpolated query against its datasource to check for logs', async () => {
+    const query = mockDatasourceReturningFrames([logsFrame]);
+    const interpolatedQuery: DataQuery = { refId: 'A', datasource: { uid: 'logs-ds-uid', type: 'loki' } };
+
+    render(
+      <LogsLinkButton spanLinkModel={createSpanLinkModel({ interpolatedParams: { query: interpolatedQuery } })} />
+    );
+
+    await waitFor(() => expect(getDataSourceInstanceMock).toHaveBeenCalledWith(interpolatedQuery.datasource));
+    expect(query).toHaveBeenCalledWith(expect.objectContaining({ targets: [interpolatedQuery] }));
+  });
+
+  it('marks the button as absent (no logs) when the query returns no rows', async () => {
+    useDataSourceInstanceSettingsMock.mockReturnValue({
+      isLoading: false,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      settings: { jsonData: {} } as any,
+    });
+    mockDatasourceReturningFrames([emptyFrame]);
+    const interpolatedQuery: DataQuery = { refId: 'A', datasource: { uid: 'logs-ds-uid', type: 'loki' } };
+
+    render(
+      <LogsLinkButton spanLinkModel={createSpanLinkModel({ interpolatedParams: { query: interpolatedQuery } })} />
+    );
+
+    await userEvent.hover(await screen.findByRole('button'));
+    expect(
+      await screen.findByText('No related logs found using the trace data source configuration.')
+    ).toBeInTheDocument();
+  });
+
+  it('keeps the button as present when the query returns logs', async () => {
+    useDataSourceInstanceSettingsMock.mockReturnValue({
+      isLoading: false,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      settings: { jsonData: {} } as any,
+    });
+    mockDatasourceReturningFrames([logsFrame]);
+    const interpolatedQuery: DataQuery = { refId: 'A', datasource: { uid: 'logs-ds-uid', type: 'loki' } };
+
+    render(
+      <LogsLinkButton spanLinkModel={createSpanLinkModel({ interpolatedParams: { query: interpolatedQuery } })} />
+    );
+
+    await waitFor(() => expect(getDataSourceInstanceMock).toHaveBeenCalled());
+    await userEvent.hover(screen.getByRole('button'));
+    expect(await screen.findByText('View related logs using the trace data source configuration.')).toBeInTheDocument();
+  });
+
+  it('fails open (keeps the link enabled) when the presence check errors', async () => {
+    useDataSourceInstanceSettingsMock.mockReturnValue({
+      isLoading: false,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      settings: { jsonData: {} } as any,
+    });
+    const query = jest.fn().mockReturnValue(throwError(() => new Error('boom')));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    getDataSourceInstanceMock.mockResolvedValue({ query } as any);
+    const interpolatedQuery: DataQuery = { refId: 'A', datasource: { uid: 'logs-ds-uid', type: 'loki' } };
+
+    render(
+      <LogsLinkButton spanLinkModel={createSpanLinkModel({ interpolatedParams: { query: interpolatedQuery } })} />
+    );
+
+    await waitFor(() => expect(query).toHaveBeenCalled());
+    await userEvent.hover(screen.getByRole('button'));
+    expect(await screen.findByText('View related logs using the trace data source configuration.')).toBeInTheDocument();
+    expect(
+      screen.queryByText('No related logs found using the trace data source configuration.')
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe('getLogsButtonCTA', () => {
+  it.each([
+    {
+      name: 'shows "Related logs" when the datasource has no settings',
+      settings: undefined,
+      expected: 'Related logs',
+    },
+    {
+      name: 'shows "Related logs" when neither filterBySpanID nor filterByTraceID is set',
+      settings: { jsonData: { tracesToLogsV2: { customQuery: false } } },
+      expected: 'Related logs',
+    },
+    {
+      name: 'shows "Logs for this trace" when filterByTraceID is set',
+      settings: { jsonData: { tracesToLogsV2: { customQuery: false, filterByTraceID: true } } },
+      expected: 'Logs for this trace',
+    },
+    {
+      name: 'shows "Logs for this span" when filterBySpanID is set',
+      settings: { jsonData: { tracesToLogsV2: { customQuery: false, filterBySpanID: true } } },
+      expected: 'Logs for this span',
+    },
+    {
+      name: 'prefers "Logs for this span" when both filters are set',
+      settings: { jsonData: { tracesToLogsV2: { customQuery: false, filterBySpanID: true, filterByTraceID: true } } },
+      expected: 'Logs for this span',
+    },
+  ])('$name', ({ settings, expected }) => {
+    expect(getLogsButtonCTA(settings as DataSourceInstanceSettings | undefined)).toBe(expected);
+  });
+});
+
+describe('getLogsButtonTooltip', () => {
+  it('returns the generic tooltip when there are no settings, regardless of presence', () => {
+    expect(getLogsButtonTooltip(undefined, 'present')).toBe(
+      'View related logs using the trace data source configuration.'
+    );
+    expect(getLogsButtonTooltip(undefined, 'absent')).toBe(
+      'View related logs using the trace data source configuration.'
+    );
+  });
+
+  it.each([
+    {
+      name: 'span filter, logs present',
+      settings: { jsonData: { tracesToLogsV2: { customQuery: false, filterBySpanID: true } } },
+      presence: 'present' as const,
+      expected: 'See logs related to this span using the trace data source configuration.',
+    },
+    {
+      name: 'span filter, logs absent',
+      settings: { jsonData: { tracesToLogsV2: { customQuery: false, filterBySpanID: true } } },
+      presence: 'absent' as const,
+      expected: 'No logs found for this span using the trace data source configuration.',
+    },
+    {
+      name: 'trace filter, logs present',
+      settings: { jsonData: { tracesToLogsV2: { customQuery: false, filterByTraceID: true } } },
+      presence: 'present' as const,
+      expected: 'See logs related to this trace using the trace data source configuration.',
+    },
+    {
+      name: 'trace filter, logs absent',
+      settings: { jsonData: { tracesToLogsV2: { customQuery: false, filterByTraceID: true } } },
+      presence: 'absent' as const,
+      expected: 'No logs found for this trace using the trace data source configuration.',
+    },
+    {
+      name: 'no filter, logs absent',
+      settings: { jsonData: {} },
+      presence: 'absent' as const,
+      expected: 'No related logs found using the trace data source configuration.',
+    },
+    {
+      name: 'no filter, logs present',
+      settings: { jsonData: {} },
+      presence: 'present' as const,
+      expected: 'View related logs using the trace data source configuration.',
+    },
+  ])('$name', ({ settings, presence, expected }) => {
+    expect(getLogsButtonTooltip(settings as DataSourceInstanceSettings, presence)).toBe(expected);
+  });
+});

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/LogsLink.test.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/LogsLink.test.tsx
@@ -2,7 +2,8 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { of, throwError } from 'rxjs';
 
-import { type DataSourceInstanceSettings, type LinkModel, toDataFrame } from '@grafana/data';
+import { type DataSourceApi, type DataSourceInstanceSettings, type LinkModel, toDataFrame } from '@grafana/data';
+import { useFlagGrafanaDynamicTraceToLogs } from '@grafana/runtime/internal';
 import { getDataSourceInstance, useDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import { type DataQuery } from '@grafana/schema';
 
@@ -16,8 +17,14 @@ jest.mock('@grafana/runtime/unstable', () => ({
   useDataSourceInstanceSettings: jest.fn().mockReturnValue({ isLoading: false, settings: undefined }),
 }));
 
+jest.mock('@grafana/runtime/internal', () => ({
+  ...jest.requireActual('@grafana/runtime/internal'),
+  useFlagGrafanaDynamicTraceToLogs: jest.fn(),
+}));
+
 const getDataSourceInstanceMock = jest.mocked(getDataSourceInstance);
 const useDataSourceInstanceSettingsMock = jest.mocked(useDataSourceInstanceSettings);
+const useFlagGrafanaDynamicTraceToLogsMock = jest.mocked(useFlagGrafanaDynamicTraceToLogs);
 
 const CTA_RELATED_LOGS = 'Related logs';
 
@@ -30,8 +37,7 @@ function createSpanLinkModel(overrides: Partial<LinkModel> = {}): SpanLinkModel 
       href: '/logs',
       title: CTA_RELATED_LOGS,
       target: '_blank',
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      origin: {} as any,
+      origin: {},
       ...overrides,
     },
   };
@@ -41,10 +47,9 @@ function createSpanLinkModel(overrides: Partial<LinkModel> = {}): SpanLinkModel 
  * Builds a fake datasource whose `query` emits a single response containing the
  * given frames, so the presence check can resolve deterministically.
  */
-function mockDatasourceReturningFrames(frames: Array<ReturnType<typeof toDataFrame>>, type?: string) {
+function mockDatasourceReturningFrames(frames: Array<ReturnType<typeof toDataFrame>>, type: string) {
   const query = jest.fn().mockReturnValue(of({ data: frames }));
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  getDataSourceInstanceMock.mockResolvedValue({ query, type } as any);
+  getDataSourceInstanceMock.mockResolvedValue({ query, type } as unknown as DataSourceApi);
   return query;
 }
 
@@ -62,6 +67,8 @@ describe('LogsLinkButton', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     useDataSourceInstanceSettingsMock.mockReturnValue({ isLoading: false, settings: undefined });
+    // The presence check is gated behind this flag; enable it so most tests exercise the check.
+    useFlagGrafanaDynamicTraceToLogsMock.mockReturnValue(true);
   });
 
   it('renders the link button with its CTA copy', () => {
@@ -77,8 +84,31 @@ describe('LogsLinkButton', () => {
     expect(getDataSourceInstanceMock).not.toHaveBeenCalled();
   });
 
+  it('does not check for logs when the dynamicTraceToLogs flag is disabled', async () => {
+    useFlagGrafanaDynamicTraceToLogsMock.mockReturnValue(false);
+    useDataSourceInstanceSettingsMock.mockReturnValue({
+      isLoading: false,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      settings: { jsonData: {} } as any,
+    });
+    mockDatasourceReturningFrames([emptyFrame], 'loki');
+    const interpolatedQuery: DataQuery = { refId: 'A', datasource: { uid: 'logs-ds-uid', type: 'loki' } };
+
+    render(
+      <LogsLinkButton spanLinkModel={createSpanLinkModel({ interpolatedParams: { query: interpolatedQuery } })} />
+    );
+
+    // The datasource is never queried, and the button stays enabled (present).
+    expect(getDataSourceInstanceMock).not.toHaveBeenCalled();
+    await userEvent.hover(await screen.findByRole('button'));
+    expect(await screen.findByText('View related logs using the trace data source configuration.')).toBeInTheDocument();
+    expect(
+      screen.queryByText('No related logs found using the trace data source configuration.')
+    ).not.toBeInTheDocument();
+  });
+
   it('runs the interpolated query against its datasource to check for logs', async () => {
-    const query = mockDatasourceReturningFrames([logsFrame]);
+    const query = mockDatasourceReturningFrames([logsFrame], 'loki');
     const interpolatedQuery: DataQuery = { refId: 'A', datasource: { uid: 'logs-ds-uid', type: 'loki' } };
 
     render(
@@ -124,7 +154,7 @@ describe('LogsLinkButton', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       settings: { jsonData: {} } as any,
     });
-    mockDatasourceReturningFrames([emptyFrame]);
+    mockDatasourceReturningFrames([emptyFrame], 'loki');
     const interpolatedQuery: DataQuery = { refId: 'A', datasource: { uid: 'logs-ds-uid', type: 'loki' } };
 
     render(
@@ -143,7 +173,7 @@ describe('LogsLinkButton', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       settings: { jsonData: {} } as any,
     });
-    mockDatasourceReturningFrames([logsFrame]);
+    mockDatasourceReturningFrames([logsFrame], 'loki');
     const interpolatedQuery: DataQuery = { refId: 'A', datasource: { uid: 'logs-ds-uid', type: 'loki' } };
 
     render(

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/LogsLink.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/LogsLink.tsx
@@ -60,20 +60,23 @@ type LogsPresence = 'loading' | 'present' | 'absent';
 function useHasLogs(spanLinkModel: SpanLinkModel): LogsPresence {
   const [presence, setPresence] = useState<LogsPresence>('loading');
 
-  useEffect(() => {
-    const interpolatedParams = spanLinkModel.linkModel.interpolatedParams;
-    const query = interpolatedParams?.query;
+  const { query, timeRange } = spanLinkModel.linkModel.interpolatedParams ?? {};
 
+  const queryKey = query ? JSON.stringify(query) : undefined;
+  const timeRangeKey = timeRange ? `${timeRange.from.valueOf()}-${timeRange.to.valueOf()}` : undefined;
+
+  useEffect(() => {
     // Without an interpolated query we can't check, so assume logs may exist and leave the link enabled.
     if (!query) {
       setPresence('present');
       return;
     }
 
-    const timeRange = interpolatedParams?.timeRange ?? getDefaultTimeRange();
+    const effectiveTimeRange = timeRange ?? getDefaultTimeRange();
     let cancelled = false;
 
-    checkForLogs(query, timeRange)
+    setPresence('loading');
+    checkForLogs(query, effectiveTimeRange)
       .then((hasLogs) => {
         if (!cancelled) {
           setPresence(hasLogs ? 'present' : 'absent');
@@ -89,7 +92,10 @@ function useHasLogs(spanLinkModel: SpanLinkModel): LogsPresence {
     return () => {
       cancelled = true;
     };
-  }, [spanLinkModel]);
+    // The trace view re-renders a lot on every event, including mouse over.
+    // `query`/`timeRange` are intentionally omitted; their content is captured by the serialized keys.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [queryKey, timeRangeKey]);
 
   return presence;
 }

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/LogsLink.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/LogsLink.tsx
@@ -6,6 +6,7 @@ import {
   CoreApp,
   type DataFrame,
   type DataQuery,
+  type DataSourceApi,
   type DataSourceInstanceSettings,
   type DataSourceJsonData,
   getDefaultTimeRange,
@@ -17,6 +18,7 @@ import { getTraceToLogsOptions } from '@grafana/o11y-ds-frontend';
 import { getDataSourceInstance, useDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import { useStyles2, DataLinkButton } from '@grafana/ui';
 import { getNextRequestId } from 'app/features/query/state/PanelQueryRunner';
+import { type LokiQuery } from 'app/plugins/datasource/loki/types';
 
 import { type SpanLinkModel } from '../../types/links';
 
@@ -106,24 +108,11 @@ function checkForLogs(query: DataQuery, timeRange: TimeRange): Observable<boolea
     return of(false);
   }
 
-  const request = {
-    requestId: getNextRequestId(),
-    app: CoreApp.Explore,
-    targets: [query],
-    range: timeRange,
-    timezone: 'browser',
-    interval: '1m',
-    intervalMs: 60000,
-    maxDataPoints: 1,
-    scopedVars: {},
-    startTime: Date.now(),
-  };
-
   // Resolving the datasource is async, and `query` can return either an Observable
   // or a Promise, so normalize both with `from`. Returning an Observable lets the
   // caller unsubscribe to cancel the request while it's still in flight.
   return from(getDataSourceInstance(query.datasource)).pipe(
-    switchMap((datasource) => from(datasource.query(request))),
+    switchMap((datasource) => from(datasource.query(getRequest(query, timeRange, datasource)))),
     map((response) => {
       const series: DataFrame[] = response.data ?? [];
       return series.some((frame) => frame.length > 0);
@@ -196,4 +185,27 @@ export function getLogsButtonTooltip(
   }
 
   return defaultCTA;
+}
+
+function getRequest(query: DataQuery, timeRange: TimeRange, datasource: DataSourceApi) {
+  const request = {
+    requestId: getNextRequestId(),
+    app: CoreApp.Explore,
+    targets: [query],
+    range: timeRange,
+    timezone: 'browser',
+    interval: '1m',
+    intervalMs: 60000,
+    maxDataPoints: 1,
+    scopedVars: {},
+    startTime: Date.now(),
+  };
+
+  if (datasource.type === 'loki') {
+    const target: DataQuery & Pick<LokiQuery, 'maxLines'> = { ...query };
+    target.maxLines = 1;
+    request.targets = [target];
+  }
+
+  return request;
 }

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/LogsLink.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/LogsLink.tsx
@@ -155,7 +155,7 @@ export function getLogsButtonTooltip(
   presence: LogsPresence
 ) {
   const defaultCTA = t(
-    'explore.span-detail-link-buttons.related-logs.tooltip',
+    'explore.span-detail-link-buttons.related-logs-tooltip',
     'View related logs using the trace data source configuration.'
   );
   if (!settings) {
@@ -177,7 +177,7 @@ export function getLogsButtonTooltip(
       );
     }
     return t(
-      'explore.span-detail-link-buttons.related-logs.no-logstooltip',
+      'explore.span-detail-link-buttons.related-logs.no-logs-tooltip',
       'No related logs found using the trace data source configuration.'
     );
   }

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/LogsLink.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/LogsLink.tsx
@@ -70,7 +70,7 @@ function useHasLogs(spanLinkModel: SpanLinkModel): LogsPresence {
   const dynamicTraceToLogsEnabled = useFlagGrafanaDynamicTraceToLogs();
   const [presence, setPresence] = useState<LogsPresence>('loading');
 
-  const { query, timeRange } = spanLinkModel.linkModel.interpolatedParams ?? {};  
+  const { query, timeRange } = spanLinkModel.linkModel.interpolatedParams ?? {};
 
   const queryKey = query ? JSON.stringify(query) : undefined;
   const timeRangeKey = timeRange ? `${timeRange.from.valueOf()}-${timeRange.to.valueOf()}` : undefined;

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/LogsLink.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/LogsLink.tsx
@@ -17,7 +17,7 @@ import { t } from '@grafana/i18n';
 import { getTraceToLogsOptions } from '@grafana/o11y-ds-frontend';
 import { useFlagGrafanaDynamicTraceToLogs } from '@grafana/runtime/internal';
 import { getDataSourceInstance, useDataSourceInstanceSettings } from '@grafana/runtime/unstable';
-import { useStyles2, DataLinkButton } from '@grafana/ui';
+import { useStyles2, DataLinkButton, Menu } from '@grafana/ui';
 import { getNextRequestId } from 'app/features/query/state/PanelQueryRunner';
 
 import { type SpanLinkModel } from '../../types/links';
@@ -59,6 +59,27 @@ function getStyles(theme: GrafanaTheme2) {
     },
   });
 }
+
+export const LogsLinkMenuItem = ({ spanLinkModel }: Props) => {
+  const presence = useHasLogs(spanLinkModel);
+  const { linkModel, icon, traceDatasourceUid } = spanLinkModel;
+
+  const { settings } = useDataSourceInstanceSettings(traceDatasourceUid);
+
+  const tooltip = useMemo(() => getLogsButtonTooltip(settings, presence), [presence, settings]);
+
+  const isLoading = presence === 'loading';
+
+  return (
+    <Menu.Item
+      label={linkModel.title}
+      icon={isLoading ? 'spinner' : icon}
+      ariaLabel={tooltip}
+      disabled={presence === 'absent'}
+      onClick={(event: React.MouseEvent) => linkModel.onClick?.(event)}
+    />
+  );
+};
 
 type LogsPresence = 'loading' | 'present' | 'absent';
 

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/LogsLink.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/LogsLink.tsx
@@ -15,10 +15,10 @@ import {
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { getTraceToLogsOptions } from '@grafana/o11y-ds-frontend';
+import { useFlagGrafanaDynamicTraceToLogs } from '@grafana/runtime/internal';
 import { getDataSourceInstance, useDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import { useStyles2, DataLinkButton } from '@grafana/ui';
 import { getNextRequestId } from 'app/features/query/state/PanelQueryRunner';
-import { type LokiQuery } from 'app/plugins/datasource/loki/types';
 
 import { type SpanLinkModel } from '../../types/links';
 
@@ -67,16 +67,17 @@ type LogsPresence = 'loading' | 'present' | 'absent';
  * any logs exist for the span, so the button can be disabled when there is nothing to link to.
  */
 function useHasLogs(spanLinkModel: SpanLinkModel): LogsPresence {
+  const dynamicTraceToLogsEnabled = useFlagGrafanaDynamicTraceToLogs();
   const [presence, setPresence] = useState<LogsPresence>('loading');
 
-  const { query, timeRange } = spanLinkModel.linkModel.interpolatedParams ?? {};
+  const { query, timeRange } = spanLinkModel.linkModel.interpolatedParams ?? {};  
 
   const queryKey = query ? JSON.stringify(query) : undefined;
   const timeRangeKey = timeRange ? `${timeRange.from.valueOf()}-${timeRange.to.valueOf()}` : undefined;
 
   useEffect(() => {
     // Without an interpolated query we can't check, so assume logs may exist and leave the link enabled.
-    if (!query) {
+    if (!query || !dynamicTraceToLogsEnabled) {
       setPresence('present');
       return;
     }
@@ -202,8 +203,7 @@ function getRequest(query: DataQuery, timeRange: TimeRange, datasource: DataSour
   };
 
   if (datasource.type === 'loki') {
-    const target: DataQuery & Pick<LokiQuery, 'maxLines'> = { ...query };
-    target.maxLines = 1;
+    const target = { ...query, maxLines: 1 };
     request.targets = [target];
   }
 

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/LogsLink.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/LogsLink.tsx
@@ -1,16 +1,20 @@
 import { css } from '@emotion/css';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { from, lastValueFrom } from 'rxjs';
 
 import {
   CoreApp,
   type DataFrame,
   type DataQuery,
+  type DataSourceInstanceSettings,
+  type DataSourceJsonData,
   getDefaultTimeRange,
   type GrafanaTheme2,
   type TimeRange,
 } from '@grafana/data';
-import { getDataSourceInstance } from '@grafana/runtime/unstable';
+import { t } from '@grafana/i18n';
+import { getTraceToLogsOptions } from '@grafana/o11y-ds-frontend';
+import { getDataSourceInstance, useDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import { useStyles2, DataLinkButton } from '@grafana/ui';
 import { getNextRequestId } from 'app/features/query/state/PanelQueryRunner';
 
@@ -23,13 +27,17 @@ interface Props {
 export const LogsLinkButton = ({ spanLinkModel }: Props) => {
   const styles = useStyles2(getStyles);
   const presence = useHasLogs(spanLinkModel);
-  const { linkModel, icon, className } = spanLinkModel;
+  const { linkModel, icon, className, traceDatasourceUid } = spanLinkModel;
+
+  const { settings } = useDataSourceInstanceSettings(traceDatasourceUid);
+
+  const tooltip = useMemo(() => getLogsButtonTooltip(settings, presence), [presence, settings]);
 
   return (
     <span className={styles}>
       <DataLinkButton
         link={linkModel}
-        buttonProps={{ icon, className, variant: presence === 'absent' ? 'secondary' : 'primary' }}
+        buttonProps={{ icon, className, variant: presence === 'absent' ? 'secondary' : 'primary', tooltip }}
       ></DataLinkButton>
     </span>
   );
@@ -111,4 +119,71 @@ async function checkForLogs(query: DataQuery, timeRange: TimeRange): Promise<boo
 
   const series: DataFrame[] = response.data ?? [];
   return series.some((frame) => frame.length > 0);
+}
+
+export function getLogsButtonCTA(settings: DataSourceInstanceSettings<DataSourceJsonData> | undefined) {
+  const defaultCTA = t('explore.span-detail-link-buttons.related-logs', 'Related logs');
+  if (!settings) {
+    return defaultCTA;
+  }
+
+  // The trace-to-logs config lives on jsonData; getTraceToLogsOptions also
+  // migrates the legacy `tracesToLogs` shape to the v2 shape.
+  const options = getTraceToLogsOptions(settings.jsonData);
+  if (options?.filterBySpanID) {
+    return t('explore.span-detail-link-buttons.logs-for-this-span.button', 'Logs for this span');
+  }
+  if (options?.filterByTraceID) {
+    return t('explore.span-detail-link-buttons.logs-for-this-trace.button', 'Logs for this trace');
+  }
+
+  return defaultCTA;
+}
+
+function getLogsButtonTooltip(
+  settings: DataSourceInstanceSettings<DataSourceJsonData> | undefined,
+  presence: LogsPresence
+) {
+  const defaultCTA = t(
+    'explore.span-detail-link-buttons.related-logs.tooltip',
+    'View related logs using the trace data source configuration.'
+  );
+  if (!settings) {
+    return defaultCTA;
+  }
+  const options = getTraceToLogsOptions(settings.jsonData);
+
+  if (presence === 'absent') {
+    if (options?.filterBySpanID) {
+      return t(
+        'explore.span-detail-link-buttons.logs-for-this-span.no-logs-tooltip',
+        'No logs found for this span using the trace data source configuration.'
+      );
+    }
+    if (options?.filterByTraceID) {
+      return t(
+        'explore.span-detail-link-buttons.logs-for-this-trace.no-logs-tooltip',
+        'No logs found for this trace using the trace data source configuration.'
+      );
+    }
+    return t(
+      'explore.span-detail-link-buttons.related-logs.no-logstooltip',
+      'No related logs found using the trace data source configuration.'
+    );
+  }
+
+  if (options?.filterBySpanID) {
+    return t(
+      'explore.span-detail-link-buttons.logs-for-this-span.tooltip',
+      'See logs related to this span using the trace data source configuration.'
+    );
+  }
+  if (options?.filterByTraceID) {
+    return t(
+      'explore.span-detail-link-buttons.logs-for-this-trace.tooltip',
+      'See logs related to this trace using the trace data source configuration.'
+    );
+  }
+
+  return defaultCTA;
 }

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/LogsLink.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/LogsLink.tsx
@@ -1,7 +1,6 @@
 import { css } from '@emotion/css';
 import { useEffect, useState } from 'react';
-import { firstValueFrom, timeout } from 'rxjs';
-import { filter } from 'rxjs/operators';
+import { from, lastValueFrom } from 'rxjs';
 
 import {
   CoreApp,
@@ -9,13 +8,11 @@ import {
   type DataQuery,
   getDefaultTimeRange,
   type GrafanaTheme2,
-  LoadingState,
   type TimeRange,
 } from '@grafana/data';
-import { getDataSourceSrv } from '@grafana/runtime';
+import { getDataSourceInstance } from '@grafana/runtime/unstable';
 import { useStyles2, DataLinkButton } from '@grafana/ui';
 import { getNextRequestId } from 'app/features/query/state/PanelQueryRunner';
-import { runRequest } from 'app/features/query/state/runRequest';
 
 import { type SpanLinkModel } from '../../types/links';
 
@@ -46,12 +43,10 @@ function getStyles(theme: GrafanaTheme2) {
   });
 }
 
-const LOGS_CHECK_TIMEOUT_MS = 5_000;
-
 type LogsPresence = 'loading' | 'present' | 'absent';
 
 /**
- * Runs the link's interpolated query against its datasource to determine whether
+ * Runs the link's query against its datasource to determine whether
  * any logs exist for the span, so the button can be disabled when there is nothing to link to.
  */
 function useHasLogs(spanLinkModel: SpanLinkModel): LogsPresence {
@@ -92,7 +87,10 @@ function useHasLogs(spanLinkModel: SpanLinkModel): LogsPresence {
 }
 
 async function checkForLogs(query: DataQuery, timeRange: TimeRange): Promise<boolean> {
-  const datasource = await getDataSourceSrv().get(query.datasource ?? null);
+  if (!query.datasource) {
+    return false;
+  }
+  const datasource = await getDataSourceInstance(query.datasource);
 
   const request = {
     requestId: getNextRequestId(),
@@ -107,13 +105,10 @@ async function checkForLogs(query: DataQuery, timeRange: TimeRange): Promise<boo
     startTime: Date.now(),
   };
 
-  const panelData = await firstValueFrom(
-    runRequest(datasource, request).pipe(
-      filter((data) => data.state === LoadingState.Done || data.state === LoadingState.Error),
-      timeout(LOGS_CHECK_TIMEOUT_MS)
-    )
-  );
+  // `query` can return either an Observable or a Promise, so normalize with `from`
+  // and take the final response once the datasource has finished emitting.
+  const response = await lastValueFrom(from(datasource.query(request)));
 
-  const series: DataFrame[] = panelData.series ?? [];
-  return series.some((frame) => frame.length > 0 && frame.meta?.preferredVisualisationType === 'logs');
+  const series: DataFrame[] = response.data ?? [];
+  return series.some((frame) => frame.length > 0);
 }

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/LogsLink.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/LogsLink.tsx
@@ -1,7 +1,21 @@
 import { css } from '@emotion/css';
+import { useEffect, useState } from 'react';
+import { firstValueFrom, timeout } from 'rxjs';
+import { filter } from 'rxjs/operators';
 
-import { type GrafanaTheme2 } from '@grafana/data';
+import {
+  CoreApp,
+  type DataFrame,
+  type DataQuery,
+  getDefaultTimeRange,
+  type GrafanaTheme2,
+  LoadingState,
+  type TimeRange,
+} from '@grafana/data';
+import { getDataSourceSrv } from '@grafana/runtime';
 import { useStyles2, DataLinkButton } from '@grafana/ui';
+import { getNextRequestId } from 'app/features/query/state/PanelQueryRunner';
+import { runRequest } from 'app/features/query/state/runRequest';
 
 import { type SpanLinkModel } from '../../types/links';
 
@@ -11,10 +25,15 @@ interface Props {
 
 export const LogsLinkButton = ({ spanLinkModel }: Props) => {
   const styles = useStyles2(getStyles);
+  const presence = useHasLogs(spanLinkModel);
   const { linkModel, icon, className } = spanLinkModel;
+
   return (
     <span className={styles}>
-      <DataLinkButton link={linkModel} buttonProps={{ icon, className }}></DataLinkButton>
+      <DataLinkButton
+        link={linkModel}
+        buttonProps={{ icon, className, variant: presence === 'absent' ? 'secondary' : 'primary' }}
+      ></DataLinkButton>
     </span>
   );
 };
@@ -25,4 +44,76 @@ function getStyles(theme: GrafanaTheme2) {
       span: { display: 'none' },
     },
   });
+}
+
+const LOGS_CHECK_TIMEOUT_MS = 5_000;
+
+type LogsPresence = 'loading' | 'present' | 'absent';
+
+/**
+ * Runs the link's interpolated query against its datasource to determine whether
+ * any logs exist for the span, so the button can be disabled when there is nothing to link to.
+ */
+function useHasLogs(spanLinkModel: SpanLinkModel): LogsPresence {
+  const [presence, setPresence] = useState<LogsPresence>('loading');
+
+  useEffect(() => {
+    const interpolatedParams = spanLinkModel.linkModel.interpolatedParams;
+    const query = interpolatedParams?.query;
+
+    // Without an interpolated query we can't check, so assume logs may exist and leave the link enabled.
+    if (!query) {
+      setPresence('present');
+      return;
+    }
+
+    const timeRange = interpolatedParams?.timeRange ?? getDefaultTimeRange();
+    let cancelled = false;
+
+    checkForLogs(query, timeRange)
+      .then((hasLogs) => {
+        if (!cancelled) {
+          setPresence(hasLogs ? 'present' : 'absent');
+        }
+      })
+      .catch(() => {
+        // If the check fails we don't want to hide a potentially valid link, so keep it enabled.
+        if (!cancelled) {
+          setPresence('present');
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [spanLinkModel]);
+
+  return presence;
+}
+
+async function checkForLogs(query: DataQuery, timeRange: TimeRange): Promise<boolean> {
+  const datasource = await getDataSourceSrv().get(query.datasource ?? null);
+
+  const request = {
+    requestId: getNextRequestId(),
+    app: CoreApp.Explore,
+    targets: [query],
+    range: timeRange,
+    timezone: 'browser',
+    interval: '1m',
+    intervalMs: 60000,
+    maxDataPoints: 1,
+    scopedVars: {},
+    startTime: Date.now(),
+  };
+
+  const panelData = await firstValueFrom(
+    runRequest(datasource, request).pipe(
+      filter((data) => data.state === LoadingState.Done || data.state === LoadingState.Error),
+      timeout(LOGS_CHECK_TIMEOUT_MS)
+    )
+  );
+
+  const series: DataFrame[] = panelData.series ?? [];
+  return series.some((frame) => frame.length > 0 && frame.meta?.preferredVisualisationType === 'logs');
 }

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/LogsLink.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/LogsLink.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import { useEffect, useMemo, useState } from 'react';
-import { from, lastValueFrom } from 'rxjs';
+import { from, map, type Observable, of, switchMap } from 'rxjs';
 
 import {
   CoreApp,
@@ -33,11 +33,18 @@ export const LogsLinkButton = ({ spanLinkModel }: Props) => {
 
   const tooltip = useMemo(() => getLogsButtonTooltip(settings, presence), [presence, settings]);
 
+  const isLoading = presence === 'loading';
+
   return (
     <span className={styles}>
       <DataLinkButton
         link={linkModel}
-        buttonProps={{ icon, className, variant: presence === 'absent' ? 'secondary' : 'primary', tooltip }}
+        buttonProps={{
+          icon: isLoading ? 'spinner' : icon,
+          className,
+          variant: presence === 'absent' ? 'secondary' : 'primary',
+          tooltip,
+        }}
       ></DataLinkButton>
     </span>
   );
@@ -73,24 +80,18 @@ function useHasLogs(spanLinkModel: SpanLinkModel): LogsPresence {
     }
 
     const effectiveTimeRange = timeRange ?? getDefaultTimeRange();
-    let cancelled = false;
 
     setPresence('loading');
-    checkForLogs(query, effectiveTimeRange)
-      .then((hasLogs) => {
-        if (!cancelled) {
-          setPresence(hasLogs ? 'present' : 'absent');
-        }
-      })
-      .catch(() => {
-        // If the check fails we don't want to hide a potentially valid link, so keep it enabled.
-        if (!cancelled) {
-          setPresence('present');
-        }
-      });
+    const subscription = checkForLogs(query, effectiveTimeRange).subscribe({
+      next: (hasLogs) => setPresence(hasLogs ? 'present' : 'absent'),
+      // If the check fails we don't want to hide a potentially valid link, so keep it enabled.
+      error: () => setPresence('present'),
+    });
 
+    // Unsubscribing cancels the in-flight datasource request when the component
+    // unmounts or the query changes before the check resolves.
     return () => {
-      cancelled = true;
+      subscription.unsubscribe();
     };
     // The trace view re-renders a lot on every event, including mouse over.
     // `query`/`timeRange` are intentionally omitted; their content is captured by the serialized keys.
@@ -100,11 +101,10 @@ function useHasLogs(spanLinkModel: SpanLinkModel): LogsPresence {
   return presence;
 }
 
-async function checkForLogs(query: DataQuery, timeRange: TimeRange): Promise<boolean> {
+function checkForLogs(query: DataQuery, timeRange: TimeRange): Observable<boolean> {
   if (!query.datasource) {
-    return false;
+    return of(false);
   }
-  const datasource = await getDataSourceInstance(query.datasource);
 
   const request = {
     requestId: getNextRequestId(),
@@ -119,12 +119,16 @@ async function checkForLogs(query: DataQuery, timeRange: TimeRange): Promise<boo
     startTime: Date.now(),
   };
 
-  // `query` can return either an Observable or a Promise, so normalize with `from`
-  // and take the final response once the datasource has finished emitting.
-  const response = await lastValueFrom(from(datasource.query(request)));
-
-  const series: DataFrame[] = response.data ?? [];
-  return series.some((frame) => frame.length > 0);
+  // Resolving the datasource is async, and `query` can return either an Observable
+  // or a Promise, so normalize both with `from`. Returning an Observable lets the
+  // caller unsubscribe to cancel the request while it's still in flight.
+  return from(getDataSourceInstance(query.datasource)).pipe(
+    switchMap((datasource) => from(datasource.query(request))),
+    map((response) => {
+      const series: DataFrame[] = response.data ?? [];
+      return series.some((frame) => frame.length > 0);
+    })
+  );
 }
 
 export function getLogsButtonCTA(settings: DataSourceInstanceSettings<DataSourceJsonData> | undefined) {
@@ -146,7 +150,7 @@ export function getLogsButtonCTA(settings: DataSourceInstanceSettings<DataSource
   return defaultCTA;
 }
 
-function getLogsButtonTooltip(
+export function getLogsButtonTooltip(
   settings: DataSourceInstanceSettings<DataSourceJsonData> | undefined,
   presence: LogsPresence
 ) {

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/LogsLink.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/LogsLink.tsx
@@ -44,6 +44,7 @@ export const LogsLinkButton = ({ spanLinkModel }: Props) => {
         buttonProps={{
           icon: isLoading ? 'spinner' : icon,
           className,
+          disabled: presence === 'absent',
           variant: presence === 'absent' ? 'secondary' : 'primary',
           tooltip,
         }}

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/LogsLink.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/LogsLink.tsx
@@ -1,0 +1,28 @@
+import { css } from '@emotion/css';
+
+import { type GrafanaTheme2 } from '@grafana/data';
+import { useStyles2, DataLinkButton } from '@grafana/ui';
+
+import { type SpanLinkModel } from '../../types/links';
+
+interface Props {
+  spanLinkModel: SpanLinkModel;
+}
+
+export const LogsLinkButton = ({ spanLinkModel }: Props) => {
+  const styles = useStyles2(getStyles);
+  const { linkModel, icon, className } = spanLinkModel;
+  return (
+    <span className={styles}>
+      <DataLinkButton link={linkModel} buttonProps={{ icon, className }}></DataLinkButton>
+    </span>
+  );
+};
+
+function getStyles(theme: GrafanaTheme2) {
+  return css({
+    [theme.breakpoints.down('sm')]: {
+      span: { display: 'none' },
+    },
+  });
+}

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/SpanDetailLinkButtons.test.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/SpanDetailLinkButtons.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 
-import { CoreApp, type TimeRange } from '@grafana/data';
+import { CoreApp, type LinkModel, type TimeRange } from '@grafana/data';
 import { usePluginLinks } from '@grafana/runtime';
 import { useDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 
@@ -17,6 +17,9 @@ jest.mock('@grafana/runtime', () => ({
 jest.mock('@grafana/runtime/unstable', () => ({
   ...jest.requireActual('@grafana/runtime/unstable'),
   useDataSourceInstanceSettings: jest.fn().mockReturnValue({ isLoading: false, settings: undefined }),
+  // LogsLinkButton resolves the query datasource to check for logs; the links used
+  // here have no interpolated query, so this is only a safety net against real calls.
+  getDataSourceInstance: jest.fn().mockResolvedValue({ query: jest.fn() }),
 }));
 
 const span = {
@@ -32,13 +35,22 @@ const timeRange = {
   to: new Date(1000),
 } as unknown as TimeRange;
 
+// The Share button is always rendered by SpanDetailLinkButtons, so every render
+// below produces this button in addition to any link buttons under test.
+const focusSpanLink = {
+  href: '/focus',
+  title: 'Focus',
+  target: '_self',
+  origin: {},
+} as unknown as LinkModel;
+
 describe('SpanDetailLinkButtons', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('should render nothing when createSpanLink is not provided', () => {
-    const { container } = render(
+  it('should render only the share button when createSpanLink is not provided', () => {
+    render(
       <SpanDetailLinkButtons
         span={span}
         createSpanLink={undefined}
@@ -47,10 +59,12 @@ describe('SpanDetailLinkButtons', () => {
         traceToProfilesOptions={undefined}
         timeRange={timeRange}
         app={CoreApp.Explore}
+        focusSpanLink={focusSpanLink}
       />
     );
 
-    expect(container).toBeEmptyDOMElement();
+    expect(screen.getAllByRole('button')).toHaveLength(1);
+    expect(screen.getByText('Share')).toBeInTheDocument();
   });
 
   it('should render log link button when logs link exists', () => {
@@ -65,10 +79,12 @@ describe('SpanDetailLinkButtons', () => {
         traceToProfilesOptions={undefined}
         timeRange={timeRange}
         app={CoreApp.Explore}
+        focusSpanLink={focusSpanLink}
       />
     );
 
-    expect(screen.getAllByRole('button')).toHaveLength(1);
+    // Log link + the always-present share button.
+    expect(screen.getAllByRole('button')).toHaveLength(2);
     expect(screen.getByText('Related logs')).toBeInTheDocument();
   });
 
@@ -114,10 +130,12 @@ describe('SpanDetailLinkButtons', () => {
           traceToProfilesOptions={undefined}
           timeRange={timeRange}
           app={CoreApp.Explore}
+          focusSpanLink={focusSpanLink}
         />
       );
 
-      expect(screen.getAllByRole('button')).toHaveLength(1);
+      // Log link + the always-present share button.
+      expect(screen.getAllByRole('button')).toHaveLength(2);
       expect(screen.getByText(expectedCTA)).toBeInTheDocument();
     });
   });
@@ -138,10 +156,12 @@ describe('SpanDetailLinkButtons', () => {
         }}
         timeRange={timeRange}
         app={CoreApp.Dashboard}
+        focusSpanLink={focusSpanLink}
       />
     );
 
-    expect(screen.getAllByRole('button')).toHaveLength(1);
+    // Profile link + the always-present share button.
+    expect(screen.getAllByRole('button')).toHaveLength(2);
     expect(screen.getByText('Profiles for this span')).toBeInTheDocument();
   });
 
@@ -157,10 +177,12 @@ describe('SpanDetailLinkButtons', () => {
         traceToProfilesOptions={undefined}
         timeRange={timeRange}
         app={CoreApp.Explore}
+        focusSpanLink={focusSpanLink}
       />
     );
 
-    expect(screen.getAllByRole('button')).toHaveLength(1);
+    // Session link + the always-present share button.
+    expect(screen.getAllByRole('button')).toHaveLength(2);
     expect(screen.getByText('Session for this span')).toBeInTheDocument();
   });
 
@@ -190,10 +212,12 @@ describe('SpanDetailLinkButtons', () => {
         }}
         timeRange={timeRange}
         app={CoreApp.Explore}
+        focusSpanLink={focusSpanLink}
       />
     );
 
-    expect(screen.getAllByRole('button')).toHaveLength(2);
+    // Profile link + profiles drilldown link + the always-present share button.
+    expect(screen.getAllByRole('button')).toHaveLength(3);
     expect(screen.getByText('Profiles for this span')).toBeInTheDocument();
     expect(screen.getByText('Open in Profiles Drilldown')).toBeInTheDocument();
   });
@@ -224,10 +248,12 @@ describe('SpanDetailLinkButtons', () => {
         }}
         timeRange={timeRange}
         app={CoreApp.Dashboard}
+        focusSpanLink={focusSpanLink}
       />
     );
 
-    expect(screen.getAllByRole('button')).toHaveLength(1);
+    // Profile link + the always-present share button (no drilldown outside Explore).
+    expect(screen.getAllByRole('button')).toHaveLength(2);
     expect(screen.getByText('Profiles for this span')).toBeInTheDocument();
     expect(screen.queryByText('Open in Profiles Drilldown')).not.toBeInTheDocument();
   });

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/SpanDetailLinkButtons.test.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/SpanDetailLinkButtons.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen } from 'test/test-utils';
 
 import { CoreApp, type LinkModel, type TimeRange } from '@grafana/data';
 import { usePluginLinks } from '@grafana/runtime';

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/SpanDetailLinkButtons.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/SpanDetailLinkButtons.tsx
@@ -4,7 +4,6 @@ import { useMemo } from 'react';
 
 import {
   CoreApp,
-  type DataSourceInstanceSettings,
   type GrafanaTheme2,
   type IconName,
   PluginExtensionPoints,
@@ -12,10 +11,10 @@ import {
   type TimeRange,
 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { getTraceToLogsOptions, type TraceToProfilesOptions } from '@grafana/o11y-ds-frontend';
+import { type TraceToProfilesOptions } from '@grafana/o11y-ds-frontend';
 import { config, locationService, reportInteraction, usePluginLinks } from '@grafana/runtime';
 import { useDataSourceInstanceSettings } from '@grafana/runtime/unstable';
-import { type DataSourceJsonData, type DataSourceRef } from '@grafana/schema';
+import { type DataSourceRef } from '@grafana/schema';
 import { Button, DataLinkButton, Dropdown, Menu, useStyles2 } from '@grafana/ui';
 export const RelatedProfilesTitle = 'Related profiles';
 
@@ -23,7 +22,7 @@ import { pyroscopeProfileIdTagKey } from '../../../createSpanLink';
 import { type SpanLinkDef, type SpanLinkFunc, type SpanLinkModel, SpanLinkType } from '../../types/links';
 import { type TraceSpan } from '../../types/trace';
 
-import { LogsLinkButton } from './LogsLink';
+import { getLogsButtonCTA, LogsLinkButton } from './LogsLink';
 
 export type ProfilesButtonContext = {
   serviceName: string;
@@ -89,7 +88,14 @@ export const SpanDetailLinkButtons = (props: Props) => {
       .filter((link) => link.type !== SpanLinkType.Traces)
       .map((link) => {
         if (link.type === SpanLinkType.Logs) {
-          return createLinkModel(link, SpanLinkType.Logs, getLogsButtonCTA(settings), 'gf-logs', datasourceType);
+          return createLinkModel(
+            link,
+            SpanLinkType.Logs,
+            getLogsButtonCTA(settings),
+            'gf-logs',
+            datasourceType,
+            datasourceUid
+          );
         }
         if (link.type === SpanLinkType.Profiles && link.title === RelatedProfilesTitle) {
           linkToProfiles = link;
@@ -143,7 +149,7 @@ export const SpanDetailLinkButtons = (props: Props) => {
     });
 
     return links;
-  }, [app, createSpanLink, datasourceType, pluginLinks, settings, span]);
+  }, [app, createSpanLink, datasourceType, datasourceUid, pluginLinks, settings, span]);
 
   if (!links.length && !shareButton) {
     return null;
@@ -177,25 +183,6 @@ const styles = {
     gap: '5px',
   }),
 };
-
-function getLogsButtonCTA(settings: DataSourceInstanceSettings<DataSourceJsonData> | undefined) {
-  const defaultCTA = t('explore.span-detail-link-buttons.related-logs', 'Related logs');
-  if (!settings) {
-    return defaultCTA;
-  }
-
-  // The trace-to-logs config lives on jsonData; getTraceToLogsOptions also
-  // migrates the legacy `tracesToLogs` shape to the v2 shape.
-  const options = getTraceToLogsOptions(settings.jsonData);
-  if (options?.filterBySpanID) {
-    return t('explore.span-detail-link-buttons.logs-for-this-span', 'Logs for this span');
-  }
-  if (options?.filterByTraceID) {
-    return t('explore.span-detail-link-buttons.logs-for-this-trace', 'Logs for this trace');
-  }
-
-  return defaultCTA;
-}
 
 function getResponsibleButtonStyles(theme: GrafanaTheme2) {
   return css({
@@ -272,11 +259,10 @@ const createLinkModel = (
   title: string,
   icon: IconName,
   datasourceType: string,
-  className?: string
+  traceDatasourceUid?: string
 ): SpanLinkModel => {
   return {
     icon,
-    className,
     type,
     linkModel: {
       ...link.linkModel,
@@ -317,5 +303,6 @@ const createLinkModel = (
         }
       },
     },
+    traceDatasourceUid,
   };
 };

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/SpanDetailLinkButtons.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/SpanDetailLinkButtons.tsx
@@ -23,7 +23,7 @@ import { pyroscopeProfileIdTagKey } from '../../../createSpanLink';
 import { type SpanLinkDef, type SpanLinkFunc, type SpanLinkModel, SpanLinkType } from '../../types/links';
 import { type TraceSpan } from '../../types/trace';
 
-import { getLogsButtonCTA, LogsLinkButton } from './LogsLink';
+import { getLogsButtonCTA, LogsLinkButton, LogsLinkMenuItem } from './LogsLink';
 import { ShareSpanButton } from './ShareSpanButton';
 
 export type ProfilesButtonContext = {
@@ -214,16 +214,23 @@ const DropDownMenu = ({ links }: { links: SpanLinkModel[] }) => {
   const [_, setIsOpen] = React.useState(false);
   const styles = useStyles2(getResponsibleButtonStyles);
 
-  const menu = (
-    <Menu>
-      {links.map(({ linkModel }, index) => (
-        <Menu.Item
-          key={index}
-          label={linkModel.title}
-          onClick={(event: React.MouseEvent) => linkModel.onClick?.(event)}
-        />
-      ))}
-    </Menu>
+  const menu = useMemo(
+    () => (
+      <Menu>
+        {links.map((spanLinkModel, index) =>
+          spanLinkModel.type === SpanLinkType.Logs ? (
+            <LogsLinkMenuItem spanLinkModel={spanLinkModel} key={index} />
+          ) : (
+            <Menu.Item
+              key={index}
+              label={spanLinkModel.linkModel.title}
+              onClick={(event: React.MouseEvent) => spanLinkModel.linkModel.onClick?.(event)}
+            />
+          )
+        )}
+      </Menu>
+    ),
+    [links]
   );
 
   return (

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/SpanDetailLinkButtons.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/SpanDetailLinkButtons.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import * as React from 'react';
-import { memo, useMemo } from 'react';
+import { useMemo } from 'react';
 
 import {
   CoreApp,

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/SpanDetailLinkButtons.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/SpanDetailLinkButtons.tsx
@@ -1,11 +1,12 @@
 import { css } from '@emotion/css';
 import * as React from 'react';
-import { useMemo } from 'react';
+import { memo, useMemo } from 'react';
 
 import {
   CoreApp,
   type GrafanaTheme2,
   type IconName,
+  type LinkModel,
   PluginExtensionPoints,
   type RawTimeRange,
   type TimeRange,
@@ -23,6 +24,7 @@ import { type SpanLinkDef, type SpanLinkFunc, type SpanLinkModel, SpanLinkType }
 import { type TraceSpan } from '../../types/trace';
 
 import { getLogsButtonCTA, LogsLinkButton } from './LogsLink';
+import { ShareSpanButton } from './ShareSpanButton';
 
 export type ProfilesButtonContext = {
   serviceName: string;
@@ -41,7 +43,7 @@ export type Props = {
   timeRange: TimeRange;
   createSpanLink?: SpanLinkFunc;
   app: CoreApp;
-  shareButton?: React.ReactNode;
+  focusSpanLink: LinkModel;
 };
 
 /**
@@ -64,10 +66,16 @@ const MAX_LINKS = 3;
 
 const ABSOLUTE_LINK_PATTERN = /^https?:\/\//i;
 
-export const SpanDetailLinkButtons = (props: Props) => {
-  const { span, createSpanLink, traceToProfilesOptions, timeRange, datasourceType, datasourceUid, app, shareButton } =
-    props;
-
+export const SpanDetailLinkButtons = ({
+  span,
+  createSpanLink,
+  traceToProfilesOptions,
+  timeRange,
+  datasourceType,
+  datasourceUid,
+  app,
+  focusSpanLink,
+}: Props) => {
   // Hooks must run unconditionally on every render, so fetch the plugin links up front.
   // The context only depends on props, and the fetched links are only consumed below when
   // a profiles link exists and we're in Explore.
@@ -78,10 +86,14 @@ export const SpanDetailLinkButtons = (props: Props) => {
     limitPerPlugin: 1,
   });
 
-  const { settings } = useDataSourceInstanceSettings(datasourceUid);
+  const { settings, isLoading } = useDataSourceInstanceSettings(datasourceUid);
 
   const links = useMemo(() => {
     let linkToProfiles: SpanLinkDef | undefined;
+
+    if (isLoading) {
+      return [];
+    }
 
     const links = (createSpanLink?.(span) || [])
       // Linked spans are shown in a separate section
@@ -149,11 +161,7 @@ export const SpanDetailLinkButtons = (props: Props) => {
     });
 
     return links;
-  }, [app, createSpanLink, datasourceType, datasourceUid, pluginLinks, settings, span]);
-
-  if (!links.length && !shareButton) {
-    return null;
-  }
+  }, [app, createSpanLink, datasourceType, datasourceUid, isLoading, pluginLinks, settings, span]);
 
   return (
     <span className={styles.linksContainer}>
@@ -168,7 +176,7 @@ export const SpanDetailLinkButtons = (props: Props) => {
           )
         )
       )}
-      {shareButton}
+      <ShareSpanButton focusSpanLink={focusSpanLink} />
     </span>
   );
 };

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/SpanDetailLinkButtons.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/SpanDetailLinkButtons.tsx
@@ -7,7 +7,6 @@ import {
   type DataSourceInstanceSettings,
   type GrafanaTheme2,
   type IconName,
-  type LinkModel,
   PluginExtensionPoints,
   type RawTimeRange,
   type TimeRange,
@@ -21,8 +20,10 @@ import { Button, DataLinkButton, Dropdown, Menu, useStyles2 } from '@grafana/ui'
 export const RelatedProfilesTitle = 'Related profiles';
 
 import { pyroscopeProfileIdTagKey } from '../../../createSpanLink';
-import { type SpanLinkDef, type SpanLinkFunc, SpanLinkType } from '../../types/links';
+import { type SpanLinkDef, type SpanLinkFunc, type SpanLinkModel, SpanLinkType } from '../../types/links';
 import { type TraceSpan } from '../../types/trace';
+
+import { LogsLinkButton } from './LogsLink';
 
 export type ProfilesButtonContext = {
   serviceName: string;
@@ -153,7 +154,13 @@ export const SpanDetailLinkButtons = (props: Props) => {
       {links.length > MAX_LINKS ? (
         <DropDownMenu links={links}></DropDownMenu>
       ) : (
-        links.map((spanLinkModel, index) => <SingleLinkButton spanLinkModel={spanLinkModel} key={index} />)
+        links.map((spanLinkModel, index) =>
+          spanLinkModel.type === SpanLinkType.Logs ? (
+            <LogsLinkButton spanLinkModel={spanLinkModel} key={index} />
+          ) : (
+            <SingleLinkButton spanLinkModel={spanLinkModel} key={index} />
+          )
+        )
       )}
       {shareButton}
     </span>
@@ -257,13 +264,6 @@ export const getProfileLinkButtonsContext = (
     datasource: { uid: traceToProfilesOptions?.datasourceUid },
   };
   return context;
-};
-
-type SpanLinkModel = {
-  linkModel: LinkModel;
-  icon: IconName;
-  className?: string;
-  type: SpanLinkType;
 };
 
 const createLinkModel = (

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.tsx
@@ -616,7 +616,7 @@ export default function SpanDetail(props: SpanDetailProps) {
             traceToProfilesOptions={traceToProfilesOptions}
             timeRange={timeRange}
             app={app}
-            shareButton={<ShareSpanButton focusSpanLink={focusSpanLink} />}
+            focusSpanLink={focusSpanLink}
           />
         </div>
         <div className={styles.listWrapper}>

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.tsx
@@ -51,7 +51,6 @@ import AccordionKeyValues from './AccordionKeyValues';
 import AccordionLogs from './AccordionLogs';
 import AccordionReferences from './AccordionReferences';
 import type DetailState from './DetailState';
-import { ShareSpanButton } from './ShareSpanButton';
 import { SpanDetailLinkButtons } from './SpanDetailLinkButtons';
 import SpanFlameGraph from './SpanFlameGraph';
 

--- a/public/app/features/explore/TraceView/components/types/links.ts
+++ b/public/app/features/explore/TraceView/components/types/links.ts
@@ -30,6 +30,7 @@ export type SpanLinkModel = {
   icon: IconName;
   className?: string;
   type: SpanLinkType;
+  traceDatasourceUid?: string;
 };
 
 export type SpanLinkFunc = (span: TraceSpan) => SpanLinkDef[] | undefined;

--- a/public/app/features/explore/TraceView/components/types/links.ts
+++ b/public/app/features/explore/TraceView/components/types/links.ts
@@ -1,6 +1,6 @@
 import type * as React from 'react';
 
-import { type Field, type LinkModel, type LinkTarget } from '@grafana/data';
+import { type IconName, type Field, type LinkModel, type LinkTarget } from '@grafana/data';
 
 import { type TraceSpan } from './trace';
 
@@ -23,6 +23,13 @@ export type SpanLinkDef = {
   type: SpanLinkType;
   target?: LinkTarget;
   linkModel?: LinkModel;
+};
+
+export type SpanLinkModel = {
+  linkModel: LinkModel;
+  icon: IconName;
+  className?: string;
+  type: SpanLinkType;
 };
 
 export type SpanLinkFunc = (span: TraceSpan) => SpanLinkDef[] | undefined;

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -8908,6 +8908,7 @@
       "open-in-profiles-drilldown": "Open in Profiles Drilldown",
       "profiles-for-this-span": "Profiles for this span",
       "related-logs": "Related logs",
+      "related-logs-tooltip": "View related logs using the trace data source configuration.",
       "session-for-this-span": "Session for this span"
     },
     "span-flame-graph": {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -8895,8 +8895,16 @@
       "summary-label": "(summary)"
     },
     "span-detail-link-buttons": {
-      "logs-for-this-span": "Logs for this span",
-      "logs-for-this-trace": "Logs for this trace",
+      "logs-for-this-span": {
+        "button": "Logs for this span",
+        "no-logs-tooltip": "No logs found for this span using the trace data source configuration.",
+        "tooltip": "See logs related to this span using the trace data source configuration."
+      },
+      "logs-for-this-trace": {
+        "button": "Logs for this trace",
+        "no-logs-tooltip": "No logs found for this trace using the trace data source configuration.",
+        "tooltip": "See logs related to this trace using the trace data source configuration."
+      },
       "open-in-profiles-drilldown": "Open in Profiles Drilldown",
       "profiles-for-this-span": "Profiles for this span",
       "related-logs": "Related logs",


### PR DESCRIPTION
This PR adds support for using the interpolated query parameters from Logs links to check for logs.

If logs are not found, the button is disabled and the corresponding tooltip is shown. **The button is not being disabled to allow users to use it to browse logs if they want it**.

Demo:

https://github.com/user-attachments/assets/77c4ae75-7039-4c0c-88be-e99946371667

Menu version:

<img width="320" height="298" alt="Menu" src="https://github.com/user-attachments/assets/1061da1c-4c76-4314-a89f-8dfa674cf322" />

Cancelling requests:

https://github.com/user-attachments/assets/9ae5e5c3-f012-433b-9e71-ea3fb10071fb

Screenshots:

<img width="435" height="114" alt="For span" src="https://github.com/user-attachments/assets/74ab0367-57ee-4d92-a8af-00223810bcba" />

<img width="435" height="124" alt="For trace" src="https://github.com/user-attachments/assets/bb477e23-6ca9-406d-8043-606eebffdbce" />

<img width="431" height="108" alt="For logs" src="https://github.com/user-attachments/assets/b569343a-a85c-40f3-b9aa-8f330419bf45" />

Additional changes address small bits of technical debt where some props used to be optional but not anymore, and other similar fixes.

TODO: 
- [x] Feature flag: `grafana.dynamicTraceToLogs`
