### PR TITLE
Tempo: Support multiple trace-to-logs destinations

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -524,6 +524,7 @@ i18next.config.ts @grafana/grafana-frontend-platform
 /e2e-playwright/various-suite/solo-route.spec.ts @grafana/dashboards-squad
 /e2e-playwright/various-suite/splash-screen.spec.ts @grafana/grafana-frontend-platform
 /e2e-playwright/various-suite/swagger.spec.ts @grafana/grafana-frontend-platform
+/e2e-playwright/various-suite/trace-to-logs.spec.ts @grafana/observability-traces-and-profiling
 /e2e-playwright/various-suite/trace-view-scrolling.spec.ts @grafana/observability-traces-and-profiling
 /e2e-playwright/various-suite/verify-i18n.spec.ts @grafana/grafana-frontend-platform
 /e2e-playwright/various-suite/visualization-suggestions*.spec.ts @grafana/dataviz-squad

--- a/docs/sources/datasources/jaeger/configure/index.md
+++ b/docs/sources/datasources/jaeger/configure/index.md
@@ -112,18 +112,24 @@ There are two ways to configure trace to logs:
 
 ### Use a simple configuration
 
+1. Click **Add logs destination**.
+1. Enter a **Link label** that identifies the destination in the trace view.
 1. Select the target data source from the drop-down list.
 1. Set **Span start time shift** and **Span end time shift** to widen or shift the time range if log timestamps don't exactly match span timestamps.
 1. Configure **Tags** to use in the logs query. Tags must be present in span attributes or resources for the link to appear. You can remap tag names if the target data source doesn't allow dots in labels (for example, remap `http.status` to `http_status`).
 1. Optionally, toggle on **Filter by trace ID** or **Filter by span ID** to further filter logs.
+1. Repeat these steps to add another logs destination.
 
 ### Configure a custom query
 
+1. Click **Add logs destination**.
+1. Enter a **Link label** that identifies the destination in the trace view.
 1. Select the target data source from the drop-down list.
 1. Set **Span start time shift** and **Span end time shift**.
 1. Optionally, configure **Tags** to map. Use the `${__tags}` variable in your custom query to interpolate mapped tags. If you don't map tags, you can still reference any span tag directly, such as `method="${__span.tags.method}"`.
 1. Toggle on **Use custom query**.
 1. Write a custom query using the variables listed in this table. The link only appears when all variables resolve to non-empty values.
+1. Repeat these steps to add another logs destination.
 
 ### Variables for custom queries
 
@@ -145,6 +151,7 @@ To use a variable, wrap it in `${}`. For example: `${__span.name}`.
 
 | Setting                   | Description                                                                                                                                                                |
 | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Link label**            | The name of the logs destination shown in the trace view.                                                                                                                  |
 | **Data source**           | The target logs data source. You can select Loki or Splunk logs data sources.                                                                                              |
 | **Span start time shift** | Shifts the start time for the logs query based on the span's start time. Use time units such as `5s`, `1m`, `3h`. Use negative values to extend to the past. Default: `0`. |
 | **Span end time shift**   | Shifts the end time for the logs query based on the span's end time. Default: `0`.                                                                                         |
@@ -225,19 +232,30 @@ datasources:
     basicAuthUser: <USERNAME>
     isDefault: false
     jsonData:
-      tracesToLogsV2:
-        datasourceUid: 'loki'
-        spanStartTimeShift: '1h'
-        spanEndTimeShift: '-1h'
-        tags:
-          - key: 'job'
-          - key: 'instance'
-          - key: 'pod'
-          - key: 'namespace'
-        filterByTraceID: false
-        filterBySpanID: false
-        customQuery: true
-        query: 'method="$${__span.tags.method}"'
+      tracesToLogsV3:
+        - name: 'Application logs'
+          datasourceUid: 'loki-app'
+          spanStartTimeShift: '1h'
+          spanEndTimeShift: '-1h'
+          tags:
+            - key: 'job'
+            - key: 'instance'
+            - key: 'pod'
+            - key: 'namespace'
+          filterByTraceID: false
+          filterBySpanID: false
+          customQuery: true
+          query: 'method="$${__span.tags.method}"'
+        - name: 'Audit logs'
+          datasourceUid: 'loki-audit'
+          spanStartTimeShift: '0'
+          spanEndTimeShift: '0'
+          tags:
+            - key: 'service.name'
+              value: 'service_name'
+          filterByTraceID: true
+          filterBySpanID: false
+          customQuery: false
       tracesToMetrics:
         datasourceUid: 'prom'
         spanStartTimeShift: '-2m'

--- a/docs/sources/visualizations/explore/trace-integration.md
+++ b/docs/sources/visualizations/explore/trace-integration.md
@@ -143,7 +143,8 @@ You can navigate from a span in a trace view directly to logs relevant for that 
 This feature is available for the Tempo, Jaeger, and Zipkin data sources.
 Refer to each individual data source's documentation for configuration instructions.
 
-Click the document icon to open a split view in Explore with the configured data source and query relevant logs for the span.
+Click the link icon next to a collapsed span and select a logs destination to open a split view in Explore and query relevant logs for the span.
+When you expand a span, each logs destination appears as a labeled link.
 
 {{< figure src="/media/docs/tempo/screenshot-grafana-trace-view-trace-to-logs.png" class="docs-image--no-shadow" max-width= "900px" caption="Trace to logs" >}}
 

--- a/e2e-playwright/various-suite/trace-to-logs.spec.ts
+++ b/e2e-playwright/various-suite/trace-to-logs.spec.ts
@@ -1,0 +1,96 @@
+import { test, expect } from '@grafana/plugin-e2e';
+
+import traceResponse from '../fixtures/tempo-response.json';
+
+test.describe(
+  'Trace to logs',
+  {
+    tag: ['@various'],
+  },
+  () => {
+    test('shows multiple logs destinations in the trace view', async ({
+      page,
+      selectors,
+      components,
+      createDataSource,
+    }) => {
+      const suffix = Date.now();
+      const applicationLogs = await createDataSource({
+        type: 'loki',
+        name: `Application logs ${suffix}`,
+      });
+      const auditLogs = await createDataSource({
+        type: 'loki',
+        name: `Audit logs ${suffix}`,
+      });
+      const traceDataSourceName = `Traces with multiple logs destinations ${suffix}`;
+
+      await createDataSource({
+        type: 'jaeger',
+        name: traceDataSourceName,
+        jsonData: {
+          tracesToLogsV3: [
+            {
+              name: 'Application logs',
+              datasourceUid: applicationLogs.uid,
+              customQuery: false,
+              filterByTraceID: true,
+            },
+            {
+              name: 'Audit logs',
+              datasourceUid: auditLogs.uid,
+              customQuery: false,
+              filterByTraceID: true,
+            },
+          ],
+        },
+      });
+
+      await page.route('**/api/ds/query?ds_type=jaeger*', async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(traceResponse),
+        });
+      });
+      await page.route('**/api/ds/query?ds_type=loki*', async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ results: { A: { frames: [] } } }),
+        });
+      });
+
+      await page.goto(selectors.pages.Explore.url);
+      await components.dataSourcePicker.set(traceDataSourceName);
+
+      const queryField = page
+        .getByTestId(selectors.components.QueryField.container)
+        .locator('[contenteditable="true"]');
+      await queryField.fill('trace');
+      await queryField.press('Shift+Enter');
+
+      const rootSpan = page.getByRole('switch', { name: /lb HTTP Client/ });
+      await expect(rootSpan).toBeVisible();
+
+      await page.getByRole('button', { name: 'Span links' }).first().click();
+      await expect(page.getByRole('menuitem', { name: 'Application logs' })).toBeVisible();
+      await expect(page.getByRole('menuitem', { name: 'Audit logs' })).toBeVisible();
+
+      await page.keyboard.press('Escape');
+      await rootSpan.click();
+
+      const applicationLogsLink = page.getByRole('link', { name: 'Application logs' });
+      await expect(applicationLogsLink).toBeVisible();
+      await expect(page.getByRole('link', { name: 'Audit logs' })).toBeVisible();
+
+      await applicationLogsLink.click();
+
+      await expect(
+        page
+          .getByTestId(selectors.components.QueryEditorRows.rows)
+          .getByText(`(${applicationLogs.name})`, { exact: true })
+      ).toBeVisible();
+    });
+  }
+);

--- a/packages/grafana-o11y-ds-frontend/src/TraceToLogs/TraceToLogsSettings.test.tsx
+++ b/packages/grafana-o11y-ds-frontend/src/TraceToLogs/TraceToLogsSettings.test.tsx
@@ -1,10 +1,10 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { type DataSourceInstanceSettings, type DataSourceSettings } from '@grafana/data';
 import { type DataSourceSrv, setDataSourceSrv } from '@grafana/runtime';
 
-import { type TraceToLogsData, TraceToLogsSettings } from './TraceToLogsSettings';
+import { getTracesToLogsOptions, type TraceToLogsData, TraceToLogsSettings } from './TraceToLogsSettings';
 
 const defaultOptionsOldFormat: DataSourceSettings<TraceToLogsData> = {
   jsonData: {
@@ -32,6 +32,24 @@ const defaultOptionsNewFormat: DataSourceSettings<TraceToLogsData> = {
       customQuery: true,
       query: '{${__tags}}',
     },
+  },
+} as unknown as DataSourceSettings<TraceToLogsData>;
+
+const defaultOptionsMultipleDestinations: DataSourceSettings<TraceToLogsData> = {
+  jsonData: {
+    tracesToLogsV3: [
+      {
+        name: 'Application logs',
+        datasourceUid: 'loki1_uid',
+        customQuery: false,
+      },
+      {
+        name: 'Audit logs',
+        datasourceUid: 'loki2_uid',
+        customQuery: true,
+        query: '{cluster="audit"}',
+      },
+    ],
   },
 } as unknown as DataSourceSettings<TraceToLogsData>;
 
@@ -64,6 +82,47 @@ describe('TraceToLogsSettings', () => {
     expect(() =>
       render(<TraceToLogsSettings options={defaultOptionsNewFormat} onOptionsChange={() => {}} />)
     ).not.toThrow();
+  });
+
+  it('renders multiple destinations with their trace view labels', () => {
+    render(<TraceToLogsSettings options={defaultOptionsMultipleDestinations} onOptionsChange={() => {}} />);
+
+    expect(screen.getByDisplayValue('Application logs')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Audit logs')).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: /Remove destination/ })).toHaveLength(2);
+    expect(screen.getByRole('group', { name: 'Application logs' })).toBeInTheDocument();
+    expect(screen.getByRole('group', { name: 'Audit logs' })).toBeInTheDocument();
+    expect(screen.getByLabelText('Span start time shift for Application logs')).toBeInTheDocument();
+    expect(screen.getByLabelText('Span start time shift for Audit logs')).toBeInTheDocument();
+  });
+
+  it('returns legacy configuration as a single destination', () => {
+    expect(getTracesToLogsOptions(defaultOptionsOldFormat.jsonData)).toEqual([
+      {
+        customQuery: false,
+        datasourceUid: 'loki1_uid',
+        filterBySpanID: true,
+        filterByTraceID: true,
+        spanEndTimeShift: '1m',
+        spanStartTimeShift: '1m',
+        tags: [{ key: 'someTag' }],
+      },
+    ]);
+  });
+
+  it('returns V2 configuration as a single destination', () => {
+    expect(getTracesToLogsOptions(defaultOptionsNewFormat.jsonData)).toEqual([
+      defaultOptionsNewFormat.jsonData.tracesToLogsV2,
+    ]);
+  });
+
+  it('falls back to V2 configuration when V3 is empty', () => {
+    expect(
+      getTracesToLogsOptions({
+        ...defaultOptionsNewFormat.jsonData,
+        tracesToLogsV3: [],
+      })
+    ).toEqual([defaultOptionsNewFormat.jsonData.tracesToLogsV2]);
   });
 
   it('should render and transform data from old format correctly', () => {
@@ -115,8 +174,74 @@ describe('TraceToLogsSettings', () => {
               },
             ],
           },
+          tracesToLogsV3: [
+            {
+              customQuery: false,
+              datasourceUid: 'loki1_uid',
+              filterBySpanID: true,
+              filterByTraceID: false,
+              spanEndTimeShift: '1m',
+              spanStartTimeShift: '1m',
+              tags: [
+                {
+                  key: 'someTag',
+                },
+              ],
+            },
+          ],
         },
       },
     ]);
+  });
+
+  it('adds another destination without changing the existing configuration', async () => {
+    const changeMock = jest.fn();
+    render(<TraceToLogsSettings options={defaultOptionsNewFormat} onOptionsChange={changeMock} />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Add logs destination' }));
+
+    expect(changeMock).toHaveBeenCalledWith({
+      jsonData: {
+        tracesToLogs: undefined,
+        tracesToLogsV2: defaultOptionsNewFormat.jsonData.tracesToLogsV2,
+        tracesToLogsV3: [defaultOptionsNewFormat.jsonData.tracesToLogsV2, { customQuery: false }],
+      },
+    });
+  });
+
+  it('updates a destination other than the first one', () => {
+    const changeMock = jest.fn();
+    render(<TraceToLogsSettings options={defaultOptionsMultipleDestinations} onOptionsChange={changeMock} />);
+
+    fireEvent.change(screen.getByLabelText('Link 2 label'), { target: { value: 'Security logs' } });
+
+    expect(changeMock).toHaveBeenCalledWith({
+      jsonData: {
+        tracesToLogs: undefined,
+        tracesToLogsV2: defaultOptionsMultipleDestinations.jsonData.tracesToLogsV3![0],
+        tracesToLogsV3: [
+          defaultOptionsMultipleDestinations.jsonData.tracesToLogsV3![0],
+          {
+            ...defaultOptionsMultipleDestinations.jsonData.tracesToLogsV3![1],
+            name: 'Security logs',
+          },
+        ],
+      },
+    });
+  });
+
+  it('removes the selected destination', async () => {
+    const changeMock = jest.fn();
+    render(<TraceToLogsSettings options={defaultOptionsMultipleDestinations} onOptionsChange={changeMock} />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Remove destination 1' }));
+
+    expect(changeMock).toHaveBeenCalledWith({
+      jsonData: {
+        tracesToLogs: undefined,
+        tracesToLogsV2: defaultOptionsMultipleDestinations.jsonData.tracesToLogsV3![1],
+        tracesToLogsV3: [defaultOptionsMultipleDestinations.jsonData.tracesToLogsV3![1]],
+      },
+    });
   });
 });

--- a/packages/grafana-o11y-ds-frontend/src/TraceToLogs/TraceToLogsSettings.tsx
+++ b/packages/grafana-o11y-ds-frontend/src/TraceToLogs/TraceToLogsSettings.tsx
@@ -1,15 +1,16 @@
 import { css } from '@emotion/css';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 import * as React from 'react';
 
 import {
   type DataSourceJsonData,
   type DataSourceInstanceSettings,
   type DataSourcePluginOptionsEditorProps,
+  type GrafanaTheme2,
 } from '@grafana/data';
 import { ConfigDescriptionLink, ConfigSection } from '@grafana/plugin-ui';
 import { DataSourcePicker } from '@grafana/runtime';
-import { InlineField, InlineFieldRow, Input, InlineSwitch } from '@grafana/ui';
+import { Button, InlineField, InlineFieldRow, Input, InlineSwitch, useStyles2 } from '@grafana/ui';
 
 import { IntervalInput } from '../IntervalInput/IntervalInput';
 
@@ -34,6 +35,7 @@ export interface TraceToLogsOptions {
 }
 
 export interface TraceToLogsOptionsV2 {
+  name?: string;
   datasourceUid?: string;
   tags?: TraceToLogsTag[];
   spanStartTimeShift?: string;
@@ -47,6 +49,7 @@ export interface TraceToLogsOptionsV2 {
 export interface TraceToLogsData extends DataSourceJsonData {
   tracesToLogs?: TraceToLogsOptions;
   tracesToLogsV2?: TraceToLogsOptionsV2;
+  tracesToLogsV3?: TraceToLogsOptionsV2[];
 }
 
 /**
@@ -54,6 +57,9 @@ export interface TraceToLogsData extends DataSourceJsonData {
  * version to new and returning that.
  */
 export function getTraceToLogsOptions(data?: TraceToLogsData): TraceToLogsOptionsV2 | undefined {
+  if (data?.tracesToLogsV3?.length) {
+    return data.tracesToLogsV3[0];
+  }
   if (data?.tracesToLogsV2) {
     return data.tracesToLogsV2;
   }
@@ -74,9 +80,19 @@ export function getTraceToLogsOptions(data?: TraceToLogsData): TraceToLogsOption
   return traceToLogs;
 }
 
+export function getTracesToLogsOptions(data?: TraceToLogsData): TraceToLogsOptionsV2[] {
+  if (data?.tracesToLogsV3?.length) {
+    return data.tracesToLogsV3;
+  }
+
+  const traceToLogs = getTraceToLogsOptions(data);
+  return traceToLogs ? [traceToLogs] : [];
+}
+
 interface Props extends DataSourcePluginOptionsEditorProps<TraceToLogsData> {}
 
 export function TraceToLogsSettings({ options, onOptionsChange }: Props) {
+  const styles = useStyles2(getStyles);
   const supportedDataSourceTypes = [
     'loki',
     'elasticsearch',
@@ -87,33 +103,129 @@ export function TraceToLogsSettings({ options, onOptionsChange }: Props) {
     'victoriametrics-logs-datasource', // external
   ];
 
-  const traceToLogs = useMemo(
-    (): TraceToLogsOptionsV2 => getTraceToLogsOptions(options.jsonData) || { customQuery: false },
-    [options.jsonData]
-  );
-  const { query = '', tags, customQuery } = traceToLogs;
+  const tracesToLogs = useMemo(() => getTracesToLogsOptions(options.jsonData), [options.jsonData]);
+  const nextDestinationId = useRef(0);
+  const createDestinationId = useCallback(() => String(nextDestinationId.current++), []);
+  const destinationIds = useRef(tracesToLogs.map(createDestinationId));
 
   const updateTracesToLogs = useCallback(
-    (value: Partial<TraceToLogsOptionsV2>) => {
-      // Cannot use updateDatasourcePluginJsonDataOption here as we need to update 2 keys, and they would overwrite each
-      // other as updateDatasourcePluginJsonDataOption isn't synchronized
+    (value: TraceToLogsOptionsV2[]) => {
       onOptionsChange({
         ...options,
         jsonData: {
           ...options.jsonData,
-          tracesToLogsV2: {
-            ...traceToLogs,
-            ...value,
-          },
+          tracesToLogsV3: value,
           tracesToLogs: undefined,
+          // Older Grafana versions can continue using the first configured destination.
+          tracesToLogsV2: value[0],
         },
       });
     },
-    [onOptionsChange, options, traceToLogs]
+    [onOptionsChange, options]
+  );
+
+  const updateLink = useCallback(
+    (index: number, value: Partial<TraceToLogsOptionsV2>) => {
+      const updated = tracesToLogs.map((link, linkIndex) => (linkIndex === index ? { ...link, ...value } : link));
+      updateTracesToLogs(updated);
+    },
+    [tracesToLogs, updateTracesToLogs]
+  );
+
+  const addDestination = useCallback(() => {
+    destinationIds.current.push(createDestinationId());
+    updateTracesToLogs([...tracesToLogs, { customQuery: false }]);
+  }, [createDestinationId, tracesToLogs, updateTracesToLogs]);
+
+  const removeDestination = useCallback(
+    (index: number) => {
+      destinationIds.current = destinationIds.current.filter((_, destinationIndex) => destinationIndex !== index);
+      updateTracesToLogs(tracesToLogs.filter((_, destinationIndex) => destinationIndex !== index));
+    },
+    [tracesToLogs, updateTracesToLogs]
   );
 
   return (
-    <div className={css({ width: '100%' })}>
+    <div className={styles.wrapper}>
+      {tracesToLogs.map((traceToLogs, index) => (
+        <div
+          key={destinationIds.current[index]}
+          className={styles.destination}
+          role="group"
+          aria-label={traceToLogs.name || `Logs destination ${index + 1}`}
+        >
+          <InlineFieldRow>
+            <InlineField
+              tooltip="Label shown for this destination in the trace view"
+              label="Link label"
+              labelWidth={26}
+            >
+              <Input
+                aria-label={`Link ${index + 1} label`}
+                value={traceToLogs.name ?? ''}
+                width={40}
+                placeholder={`Logs destination ${index + 1}`}
+                onChange={(event) => updateLink(index, { name: event.currentTarget.value })}
+              />
+            </InlineField>
+          </InlineFieldRow>
+
+          <TraceToLogsLinkSettings
+            index={index}
+            traceToLogs={traceToLogs}
+            supportedDataSourceTypes={supportedDataSourceTypes}
+            onChange={(value) => updateLink(index, value)}
+          />
+
+          <Button
+            variant="destructive"
+            fill="text"
+            icon="trash-alt"
+            type="button"
+            aria-label={`Remove destination ${index + 1}`}
+            onClick={() => removeDestination(index)}
+          >
+            Remove destination
+          </Button>
+        </div>
+      ))}
+
+      <Button variant="secondary" icon="plus" type="button" onClick={addDestination}>
+        Add logs destination
+      </Button>
+    </div>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  wrapper: css({
+    width: '100%',
+  }),
+  destination: css({
+    border: `1px solid ${theme.colors.border.weak}`,
+    borderRadius: theme.shape.radius.default,
+    marginBottom: theme.spacing(2),
+    padding: theme.spacing(2),
+  }),
+});
+
+interface TraceToLogsLinkSettingsProps {
+  index: number;
+  traceToLogs: TraceToLogsOptionsV2;
+  supportedDataSourceTypes: string[];
+  onChange: (value: Partial<TraceToLogsOptionsV2>) => void;
+}
+
+function TraceToLogsLinkSettings({
+  index,
+  traceToLogs,
+  supportedDataSourceTypes,
+  onChange,
+}: TraceToLogsLinkSettingsProps) {
+  const { query = '', tags, customQuery } = traceToLogs;
+
+  return (
+    <>
       <InlineFieldRow>
         <InlineField
           tooltip="The logs data source the trace is going to navigate to"
@@ -121,17 +233,17 @@ export function TraceToLogsSettings({ options, onOptionsChange }: Props) {
           labelWidth={26}
         >
           <DataSourcePicker
-            inputId="trace-to-logs-data-source-picker"
+            inputId={`trace-to-logs-data-source-picker-${index}`}
             filter={(ds) => supportedDataSourceTypes.includes(ds.type)}
             current={traceToLogs.datasourceUid}
             noDefault={true}
             width={40}
             onChange={(ds: DataSourceInstanceSettings) =>
-              updateTracesToLogs({
+              onChange({
                 datasourceUid: ds.uid,
               })
             }
-            onClear={() => updateTracesToLogs({ datasourceUid: undefined })}
+            onClear={() => onChange({ datasourceUid: undefined })}
           />
         </InlineField>
       </InlineFieldRow>
@@ -139,10 +251,11 @@ export function TraceToLogsSettings({ options, onOptionsChange }: Props) {
       <InlineFieldRow>
         <IntervalInput
           label={getTimeShiftLabel('start')}
+          ariaLabel={`${getTimeShiftLabel('start')} for ${traceToLogs.name || `logs destination ${index + 1}`}`}
           tooltip={getTimeShiftTooltip('start', '0')}
           value={traceToLogs.spanStartTimeShift || ''}
           onChange={(val) => {
-            updateTracesToLogs({ spanStartTimeShift: val });
+            onChange({ spanStartTimeShift: val });
           }}
           isInvalidError={invalidTimeShiftError}
         />
@@ -151,10 +264,11 @@ export function TraceToLogsSettings({ options, onOptionsChange }: Props) {
       <InlineFieldRow>
         <IntervalInput
           label={getTimeShiftLabel('end')}
+          ariaLabel={`${getTimeShiftLabel('end')} for ${traceToLogs.name || `logs destination ${index + 1}`}`}
           tooltip={getTimeShiftTooltip('end', '0')}
           value={traceToLogs.spanEndTimeShift || ''}
           onChange={(val) => {
-            updateTracesToLogs({ spanEndTimeShift: val });
+            onChange({ spanEndTimeShift: val });
           }}
           isInvalidError={invalidTimeShiftError}
         />
@@ -166,23 +280,23 @@ export function TraceToLogsSettings({ options, onOptionsChange }: Props) {
           label="Tags"
           labelWidth={26}
         >
-          <TagMappingInput values={tags ?? []} onChange={(v) => updateTracesToLogs({ tags: v })} />
+          <TagMappingInput values={tags ?? []} onChange={(v) => onChange({ tags: v })} />
         </InlineField>
       </InlineFieldRow>
 
       <IdFilter
         disabled={customQuery}
         type={'trace'}
-        id={'filterByTraceID'}
+        id={`filterByTraceID-${index}`}
         value={Boolean(traceToLogs.filterByTraceID)}
-        onChange={(val) => updateTracesToLogs({ filterByTraceID: val })}
+        onChange={(val) => onChange({ filterByTraceID: val })}
       />
       <IdFilter
         disabled={customQuery}
         type={'span'}
-        id={'filterBySpanID'}
+        id={`filterBySpanID-${index}`}
         value={Boolean(traceToLogs.filterBySpanID)}
-        onChange={(val) => updateTracesToLogs({ filterBySpanID: val })}
+        onChange={(val) => onChange({ filterBySpanID: val })}
       />
 
       <InlineFieldRow>
@@ -192,10 +306,10 @@ export function TraceToLogsSettings({ options, onOptionsChange }: Props) {
           labelWidth={26}
         >
           <InlineSwitch
-            id={'customQuerySwitch'}
+            id={`customQuerySwitch-${index}`}
             value={customQuery}
             onChange={(event: React.SyntheticEvent<HTMLInputElement>) =>
-              updateTracesToLogs({ customQuery: event.currentTarget.checked })
+              onChange({ customQuery: event.currentTarget.checked })
             }
           />
         </InlineField>
@@ -213,11 +327,11 @@ export function TraceToLogsSettings({ options, onOptionsChange }: Props) {
             type="text"
             allowFullScreen
             value={query}
-            onChange={(e) => updateTracesToLogs({ query: e.currentTarget.value })}
+            onChange={(e) => onChange({ query: e.currentTarget.value })}
           />
         </InlineField>
       )}
-    </div>
+    </>
   );
 }
 

--- a/public/app/features/explore/TraceView/TraceView.tsx
+++ b/public/app/features/explore/TraceView/TraceView.tsx
@@ -18,7 +18,7 @@ import {
   useDataLinksContext,
 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { getTraceToLogsOptions, type TraceToMetricsData, type TraceToProfilesData } from '@grafana/o11y-ds-frontend';
+import { getTracesToLogsOptions, type TraceToMetricsData, type TraceToProfilesData } from '@grafana/o11y-ds-frontend';
 import { getTemplateSrv, useAppPluginInstalled } from '@grafana/runtime';
 import { type DataQuery } from '@grafana/schema';
 import { useStyles2 } from '@grafana/ui';
@@ -152,7 +152,10 @@ export function TraceView(props: Props) {
   );
 
   const instanceSettings = getDatasourceSrv().getInstanceSettings(datasource?.name);
-  const traceToLogsOptions = getTraceToLogsOptions(instanceSettings?.jsonData);
+  const tracesToLogsOptions = useMemo(
+    () => getTracesToLogsOptions(instanceSettings?.jsonData),
+    [instanceSettings?.jsonData]
+  );
   const traceToMetrics: TraceToMetricsData | undefined = instanceSettings?.jsonData;
   const traceToMetricsOptions = traceToMetrics?.tracesToMetrics;
   const traceToProfilesData: TraceToProfilesData | undefined = instanceSettings?.jsonData;
@@ -166,7 +169,7 @@ export function TraceView(props: Props) {
       createSpanLinkFromProps ??
       createSpanLinkFactory({
         splitOpenFn: props.splitOpenFn!,
-        traceToLogsOptions,
+        tracesToLogsOptions,
         traceToMetricsOptions,
         traceToProfilesOptions,
         dataFrame: props.dataFrames[0],
@@ -176,7 +179,7 @@ export function TraceView(props: Props) {
       }),
     [
       props.splitOpenFn,
-      traceToLogsOptions,
+      tracesToLogsOptions,
       traceToMetricsOptions,
       traceToProfilesOptions,
       props.dataFrames,

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanBarRow.test.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanBarRow.test.tsx
@@ -129,6 +129,25 @@ describe('<SpanBarRow>', () => {
     expect(screen.getAllByTestId('SpanLinksMenu')).toHaveLength(1);
   });
 
+  it('renders destination labels in the span links menu', async () => {
+    render(
+      <SpanBarRow
+        {...(props as unknown as SpanBarRowProps)}
+        createSpanLink={() =>
+          [
+            { href: '/application-logs', title: 'Application logs', type: SpanLinkType.Logs },
+            { href: '/audit-logs', title: 'Audit logs', type: SpanLinkType.Logs },
+          ] as SpanLinkDef[]
+        }
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Span links' }));
+
+    expect(screen.getByText('Application logs')).toBeInTheDocument();
+    expect(screen.getByText('Audit logs')).toBeInTheDocument();
+  });
+
   it('render referenced to by single span', () => {
     render(<SpanBarRow {...(props as unknown as SpanBarRowProps)} />);
     const span = Object.assign(

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanBarRow.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanBarRow.tsx
@@ -546,7 +546,10 @@ export const SpanBarRow = memo((props: SpanBarRowProps) => {
   );
 
   const links = useMemo(
-    () => (createSpanLink?.(span) || []).filter((link) => link.type === SpanLinkType.Traces),
+    () =>
+      (createSpanLink?.(span) || []).filter(
+        (link) => link.type === SpanLinkType.Traces || link.type === SpanLinkType.Logs
+      ),
     [createSpanLink, span]
   );
 

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/SpanDetailLinkButtons.test.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/SpanDetailLinkButtons.test.tsx
@@ -72,6 +72,29 @@ describe('SpanDetailLinkButtons', () => {
     expect(screen.getByText('Related logs')).toBeInTheDocument();
   });
 
+  it('uses destination labels for multiple log link buttons', () => {
+    createSpanLink.mockReturnValue([
+      { type: SpanLinkType.Logs, href: '/application-logs', title: 'Application logs' },
+      { type: SpanLinkType.Logs, href: '/audit-logs', title: 'Audit logs' },
+    ]);
+
+    render(
+      <SpanDetailLinkButtons
+        span={span}
+        createSpanLink={createSpanLink}
+        datasourceType="test"
+        datasourceUid="test-datasource-uid"
+        traceToProfilesOptions={undefined}
+        timeRange={timeRange}
+        app={CoreApp.Explore}
+      />
+    );
+
+    expect(screen.getAllByRole('button')).toHaveLength(2);
+    expect(screen.getByText('Application logs')).toBeInTheDocument();
+    expect(screen.getByText('Audit logs')).toBeInTheDocument();
+  });
+
   describe('logs link CTA copy', () => {
     it.each([
       {
@@ -101,9 +124,17 @@ describe('SpanDetailLinkButtons', () => {
         },
         expectedCTA: 'Logs for this span',
       },
-    ])('$name', ({ settings, expectedCTA }) => {
+      {
+        name: 'shows the destination label when it is configured',
+        settings: {
+          jsonData: { tracesToLogsV3: [{ name: 'Application logs', customQuery: false }] },
+        },
+        linkTitle: 'Application logs',
+        expectedCTA: 'Application logs',
+      },
+    ])('$name', ({ settings, linkTitle = 'Logs', expectedCTA }) => {
       (useDataSourceInstanceSettings as jest.Mock).mockReturnValue({ isLoading: false, settings });
-      createSpanLink.mockReturnValue([{ type: SpanLinkType.Logs, href: '/logs', title: 'Logs' }]);
+      createSpanLink.mockReturnValue([{ type: SpanLinkType.Logs, href: '/logs', title: linkTitle }]);
 
       render(
         <SpanDetailLinkButtons

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/SpanDetailLinkButtons.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/SpanDetailLinkButtons.tsx
@@ -13,7 +13,7 @@ import {
   type TimeRange,
 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { getTraceToLogsOptions, type TraceToProfilesOptions } from '@grafana/o11y-ds-frontend';
+import { getTracesToLogsOptions, type TraceToProfilesOptions } from '@grafana/o11y-ds-frontend';
 import { config, locationService, reportInteraction, usePluginLinks } from '@grafana/runtime';
 import { useDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import { type DataSourceJsonData, type DataSourceRef } from '@grafana/schema';
@@ -83,12 +83,20 @@ export const SpanDetailLinkButtons = (props: Props) => {
   const links = useMemo(() => {
     let linkToProfiles: SpanLinkDef | undefined;
 
-    const links = (createSpanLink?.(span) || [])
+    const spanLinks = createSpanLink?.(span) || [];
+    const logsLinkCount = spanLinks.filter((link) => link.type === SpanLinkType.Logs).length;
+    const links = spanLinks
       // Linked spans are shown in a separate section
       .filter((link) => link.type !== SpanLinkType.Traces)
       .map((link) => {
         if (link.type === SpanLinkType.Logs) {
-          return createLinkModel(link, SpanLinkType.Logs, getLogsButtonCTA(settings), 'gf-logs', datasourceType);
+          return createLinkModel(
+            link,
+            SpanLinkType.Logs,
+            getLogsButtonCTA(settings, link, logsLinkCount),
+            'gf-logs',
+            datasourceType
+          );
         }
         if (link.type === SpanLinkType.Profiles && link.title === RelatedProfilesTitle) {
           linkToProfiles = link;
@@ -171,15 +179,24 @@ const styles = {
   }),
 };
 
-function getLogsButtonCTA(settings: DataSourceInstanceSettings<DataSourceJsonData> | undefined) {
+function getLogsButtonCTA(
+  settings: DataSourceInstanceSettings<DataSourceJsonData> | undefined,
+  link: SpanLinkDef,
+  logsLinkCount: number
+) {
   const defaultCTA = t('explore.span-detail-link-buttons.related-logs', 'Related logs');
   if (!settings) {
-    return defaultCTA;
+    return logsLinkCount > 1 ? link.title || defaultCTA : defaultCTA;
   }
 
-  // The trace-to-logs config lives on jsonData; getTraceToLogsOptions also
+  // The trace-to-logs config lives on jsonData; getTracesToLogsOptions also
   // migrates the legacy `tracesToLogs` shape to the v2 shape.
-  const options = getTraceToLogsOptions(settings.jsonData);
+  const destinations = getTracesToLogsOptions(settings.jsonData);
+  if (destinations.length > 1 || destinations[0]?.name) {
+    return link.title || defaultCTA;
+  }
+
+  const options = destinations[0];
   if (options?.filterBySpanID) {
     return t('explore.span-detail-link-buttons.logs-for-this-span', 'Logs for this span');
   }

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanLinks.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanLinks.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/css';
 import { useState } from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';
+import { t } from '@grafana/i18n';
 import { config, reportInteraction } from '@grafana/runtime';
 import { useStyles2, MenuItem, Icon, ContextMenu, useTheme2 } from '@grafana/ui';
 
@@ -61,6 +62,7 @@ export const SpanLinksMenu = ({ links, datasourceType, color }: SpanLinksProps) 
   return (
     <div data-testid="SpanLinksMenu" className={styles.wrapper}>
       <button
+        aria-label={t('explore.span-links-menu.aria-label', 'Span links')}
         onClick={(e) => {
           setIsMenuOpen(true);
           setMenuPosition({

--- a/public/app/features/explore/TraceView/createSpanLink.test.ts
+++ b/public/app/features/explore/TraceView/createSpanLink.test.ts
@@ -79,7 +79,13 @@ describe('createSpanLinkFactory', () => {
   describe('should return loki link', () => {
     beforeAll(() => {
       setDataSourceSrv({
-        getInstanceSettings() {
+        getInstanceSettings(uid: string) {
+          if (uid === 'missing-loki') {
+            return undefined;
+          }
+          if (uid === 'application-loki' || uid === 'audit-loki') {
+            return { uid, name: uid, type: 'loki' } as unknown as DataSourceInstanceSettings;
+          }
           return { uid: 'loki1_uid', name: 'loki1', type: 'loki' } as unknown as DataSourceInstanceSettings;
         },
       } as unknown as DataSourceSrv);
@@ -100,6 +106,105 @@ describe('createSpanLinkFactory', () => {
           '{"range":{"from":"1602637200000","to":"1602637201000"},"datasource":"loki1_uid","queries":[{"expr":"{cluster=\\"cluster1\\", hostname=\\"hostname1\\", service_namespace=\\"namespace1\\"}","refId":"","datasource":{"uid":"loki1_uid"}}]}'
         )}`
       );
+    });
+
+    it('creates distinguishable links for multiple logs destinations', () => {
+      const createLink = createSpanLinkFactory({
+        splitOpenFn: jest.fn(),
+        tracesToLogsOptions: [
+          {
+            name: 'Application logs',
+            customQuery: false,
+            datasourceUid: 'application-loki',
+          },
+          {
+            name: 'Audit logs',
+            customQuery: false,
+            datasourceUid: 'audit-loki',
+          },
+        ],
+        trace: dummyTraceData,
+        dataFrame: dummyDataFrame,
+      });
+
+      const links = createLink!(createTraceSpan());
+
+      expect(links).toHaveLength(2);
+      expect(links?.map(({ title, type }) => ({ title, type }))).toEqual([
+        { title: 'Application logs', type: SpanLinkType.Logs },
+        { title: 'Audit logs', type: SpanLinkType.Logs },
+      ]);
+      expect(decodeURIComponent(links![0].href)).toContain('"datasource":"application-loki"');
+      expect(decodeURIComponent(links![1].href)).toContain('"datasource":"audit-loki"');
+    });
+
+    it('uses datasource names when multiple destinations do not have labels', () => {
+      const createLink = createSpanLinkFactory({
+        splitOpenFn: jest.fn(),
+        tracesToLogsOptions: [
+          {
+            customQuery: false,
+            datasourceUid: 'application-loki',
+          },
+          {
+            customQuery: false,
+            datasourceUid: 'audit-loki',
+          },
+        ],
+        trace: dummyTraceData,
+        dataFrame: dummyDataFrame,
+      });
+
+      const links = createLink!(createTraceSpan());
+
+      expect(links?.map(({ title }) => title)).toEqual(['application-loki', 'audit-loki']);
+    });
+
+    it('distinguishes unnamed destinations that use the same datasource', () => {
+      const createLink = createSpanLinkFactory({
+        splitOpenFn: jest.fn(),
+        tracesToLogsOptions: [
+          {
+            customQuery: false,
+            datasourceUid: 'application-loki',
+          },
+          {
+            customQuery: false,
+            datasourceUid: 'application-loki',
+          },
+        ],
+        trace: dummyTraceData,
+        dataFrame: dummyDataFrame,
+      });
+
+      const links = createLink!(createTraceSpan());
+
+      expect(links?.map(({ title }) => title)).toEqual(['application-loki (1)', 'application-loki (2)']);
+    });
+
+    it('skips destinations whose datasource cannot be resolved', () => {
+      const createLink = createSpanLinkFactory({
+        splitOpenFn: jest.fn(),
+        tracesToLogsOptions: [
+          {
+            name: 'Application logs',
+            customQuery: false,
+            datasourceUid: 'application-loki',
+          },
+          {
+            name: 'Missing logs',
+            customQuery: false,
+            datasourceUid: 'missing-loki',
+          },
+        ],
+        trace: dummyTraceData,
+        dataFrame: dummyDataFrame,
+      });
+
+      const links = createLink!(createTraceSpan());
+
+      expect(links).toHaveLength(1);
+      expect(links?.[0].title).toBe('Application logs');
     });
 
     it('with tags that passed in and without tags that are not in the span', () => {
@@ -1658,11 +1763,13 @@ function setupSpanLinkFactory(
   const splitOpenFn = jest.fn();
   return createSpanLinkFactory({
     splitOpenFn,
-    traceToLogsOptions: {
-      customQuery: false,
-      datasourceUid,
-      ...options,
-    },
+    tracesToLogsOptions: [
+      {
+        customQuery: false,
+        datasourceUid,
+        ...options,
+      },
+    ],
     traceToProfilesOptions: {
       customQuery: false,
       datasourceUid: 'pyroscopeUid',

--- a/public/app/features/explore/TraceView/createSpanLink.tsx
+++ b/public/app/features/explore/TraceView/createSpanLink.tsx
@@ -39,7 +39,7 @@ import { type Trace, type TraceSpan, type TraceSpanReference } from './component
  */
 export function createSpanLinkFactory({
   splitOpenFn,
-  traceToLogsOptions,
+  tracesToLogsOptions,
   traceToMetricsOptions,
   traceToProfilesOptions,
   dataFrame,
@@ -48,7 +48,7 @@ export function createSpanLinkFactory({
   dataLinkPostProcessor,
 }: {
   splitOpenFn: SplitOpen;
-  traceToLogsOptions?: TraceToLogsOptionsV2;
+  tracesToLogsOptions?: TraceToLogsOptionsV2[];
   traceToMetricsOptions?: TraceToMetricsOptions;
   traceToProfilesOptions?: TraceToProfilesOptions;
   dataFrame?: DataFrame;
@@ -67,7 +67,7 @@ export function createSpanLinkFactory({
     splitOpenFn,
     // We need this to make the types happy but for this branch of code it does not matter which field we supply.
     dataFrame.fields[0],
-    traceToLogsOptions,
+    tracesToLogsOptions,
     traceToMetricsOptions,
     createFocusSpanLink,
     scopedVars,
@@ -149,18 +149,26 @@ const feO11yTagKey = 'gf.feo11y.app.id';
 function legacyCreateSpanLinkFactory(
   splitOpenFn: SplitOpen,
   field: Field,
-  traceToLogsOptions?: TraceToLogsOptionsV2,
+  tracesToLogsOptions: TraceToLogsOptionsV2[] = [],
   traceToMetricsOptions?: TraceToMetricsOptions,
   createFocusSpanLink?: (traceId: string, spanId: string) => LinkModel<Field>,
   scopedVars?: ScopedVars,
   dataFrame?: DataFrame,
   dataLinkPostProcessor?: DataLinkPostProcessor
 ) {
-  let logsDataSourceSettings: DataSourceInstanceSettings<DataSourceJsonData> | undefined;
-  if (traceToLogsOptions?.datasourceUid) {
-    logsDataSourceSettings = getDatasourceSrv().getInstanceSettings(traceToLogsOptions.datasourceUid);
-  }
-  const isSplunkDS = logsDataSourceSettings?.type === 'grafana-splunk-datasource';
+  const traceToLogsDestinations = tracesToLogsOptions.map((options) => {
+    const datasource = options.datasourceUid
+      ? getDatasourceSrv().getInstanceSettings(options.datasourceUid)
+      : undefined;
+    return { datasource, options };
+  });
+  const hasMultipleLogsDestinations = traceToLogsDestinations.filter(({ datasource }) => datasource).length > 1;
+  const defaultTitleCounts = traceToLogsDestinations.reduce((counts, { datasource, options }) => {
+    if (datasource && !options.name) {
+      counts.set(datasource.name, (counts.get(datasource.name) ?? 0) + 1);
+    }
+    return counts;
+  }, new Map<string, number>());
 
   let metricsDataSourceSettings: DataSourceInstanceSettings<DataSourceJsonData> | undefined;
   if (traceToMetricsOptions?.datasourceUid) {
@@ -173,42 +181,53 @@ function legacyCreateSpanLinkFactory(
       ...scopedVarsFromSpan(span),
     };
     const links: SpanLinkDef[] = [];
-    let query: DataQuery | undefined;
-    let tags = '';
+    const defaultTitleOccurrences = new Map<string, number>();
 
     // TODO: This should eventually move into specific data sources and added to the data frame as we no longer use the
     //  deprecated blob format and we can map the link easily in data frame.
-    if (logsDataSourceSettings && traceToLogsOptions) {
-      const customQuery = traceToLogsOptions.customQuery ? traceToLogsOptions.query : undefined;
-      const tagsToUse =
-        traceToLogsOptions.tags && traceToLogsOptions.tags.length > 0 ? traceToLogsOptions.tags : defaultKeys;
+    for (const { datasource: logsDataSourceSettings, options } of traceToLogsDestinations) {
+      if (!logsDataSourceSettings) {
+        continue;
+      }
+
+      let defaultTitle = logsDataSourceSettings.name;
+      if (!options.name && (defaultTitleCounts.get(logsDataSourceSettings.name) ?? 0) > 1) {
+        const occurrence = (defaultTitleOccurrences.get(logsDataSourceSettings.name) ?? 0) + 1;
+        defaultTitleOccurrences.set(logsDataSourceSettings.name, occurrence);
+        defaultTitle = `${logsDataSourceSettings.name} (${occurrence})`;
+      }
+
+      let query: DataQuery | undefined;
+      let tags = '';
+      const customQuery = options.customQuery ? options.query : undefined;
+      const tagsToUse = options.tags && options.tags.length > 0 ? options.tags : defaultKeys;
       switch (logsDataSourceSettings?.type) {
         case 'loki':
           tags = getFormattedTags(span, tagsToUse);
-          query = getQueryForLoki(span, traceToLogsOptions, tags, customQuery);
+          query = getQueryForLoki(span, options, tags, customQuery);
           break;
         case 'grafana-splunk-datasource':
           tags = getFormattedTags(span, tagsToUse, { joinBy: ' ' });
-          query = getQueryForSplunk(span, traceToLogsOptions, tags, customQuery);
+          query = getQueryForSplunk(span, options, tags, customQuery);
           break;
         case 'elasticsearch':
         case 'grafana-opensearch-datasource':
           tags = getFormattedTags(span, tagsToUse, { labelValueSign: ':', joinBy: ' AND ' });
-          query = getQueryForElasticsearchOrOpensearch(span, traceToLogsOptions, tags, customQuery);
+          query = getQueryForElasticsearchOrOpensearch(span, options, tags, customQuery);
           break;
         case 'grafana-falconlogscale-datasource':
           tags = getFormattedTags(span, tagsToUse, { joinBy: ' OR ' });
-          query = getQueryForFalconLogScale(span, traceToLogsOptions, tags, customQuery);
+          query = getQueryForFalconLogScale(span, options, tags, customQuery);
           break;
         case 'googlecloud-logging-datasource':
           tags = getFormattedTags(span, tagsToUse, { joinBy: ' AND ' });
-          query = getQueryForGoogleCloudLogging(span, traceToLogsOptions, tags, customQuery);
+          query = getQueryForGoogleCloudLogging(span, options, tags, customQuery);
           break;
         case 'victoriametrics-logs-datasource':
           // Build tag selector using strict equality (":=") required by LogsQL
           // See https://docs.victoriametrics.com/victorialogs/logsql/#exact-filter
           tags = getFormattedTags(span, tagsToUse, { labelValueSign: ':=', joinBy: ' AND ' });
-          query = getQueryForVictoriaLogs(span, traceToLogsOptions, tags, customQuery);
+          query = getQueryForVictoriaLogs(span, options, tags, customQuery);
           break;
       }
 
@@ -225,14 +244,10 @@ function legacyCreateSpanLinkFactory(
             range: getTimeRangeFromSpan(
               span,
               {
-                startMs: traceToLogsOptions.spanStartTimeShift
-                  ? rangeUtil.intervalToMs(traceToLogsOptions.spanStartTimeShift)
-                  : 0,
-                endMs: traceToLogsOptions.spanEndTimeShift
-                  ? rangeUtil.intervalToMs(traceToLogsOptions.spanEndTimeShift)
-                  : 0,
+                startMs: options.spanStartTimeShift ? rangeUtil.intervalToMs(options.spanStartTimeShift) : 0,
+                endMs: options.spanEndTimeShift ? rangeUtil.intervalToMs(options.spanEndTimeShift) : 0,
               },
-              isSplunkDS
+              logsDataSourceSettings.type === 'grafana-splunk-datasource'
             ),
           },
         };
@@ -274,7 +289,11 @@ function legacyCreateSpanLinkFactory(
           links.push({
             href: link.href,
             linkModel: link,
-            title: t('explore.legacy-create-span-link-factory.title.related-logs', 'Related logs'),
+            title:
+              options.name ||
+              (hasMultipleLogsDestinations
+                ? defaultTitle
+                : t('explore.legacy-create-span-link-factory.title.logs-for-this-span', 'Logs for this span')),
             onClick: link.onClick,
             content: (
               <Icon

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -8533,7 +8533,7 @@
         "tags": "Tags"
       },
       "title": {
-        "related-logs": "Related logs",
+        "logs-for-this-span": "Logs for this span",
         "session-for-this-span": "Session for this span"
       },
       "title-explore-metrics-for-this-span": "Explore metrics for this span",
@@ -8848,6 +8848,9 @@
     },
     "span-flame-graph": {
       "flame-graph": "Flame graph"
+    },
+    "span-links-menu": {
+      "aria-label": "Span links"
     },
     "summary-span": {
       "stat-max": "Max",


### PR DESCRIPTION
**What is this feature?**

This adds support for configuring multiple trace-to-logs destinations.

Each destination can define its own:

- Display label
- Logs data source
- Tag mappings
- Time shifts
- Trace and span ID filters
- Custom query

In the trace view, collapsed spans show a link menu containing each destination. Expanded spans show a separate labeled link for each destination.

The first destination is also stored in `tracesToLogsV2` so older Grafana versions can continue using it.

### Screenshots

Collapsed trace view:

![Trace view with trace-to-logs links](https://raw.githubusercontent.com/grafana/grafana/cbd4fcd0419c2ad010a46a7fa613025852f1b9f3/pr-screenshots/91793/trace-view.png)

Destination menu:

![Trace-to-logs destination menu](https://raw.githubusercontent.com/grafana/grafana/cbd4fcd0419c2ad010a46a7fa613025852f1b9f3/pr-screenshots/91793/trace-view-link-menu.png)

Expanded span:

![Expanded span with labeled trace-to-logs links](https://raw.githubusercontent.com/grafana/grafana/cbd4fcd0419c2ad010a46a7fa613025852f1b9f3/pr-screenshots/91793/trace-view-expanded.png)

**Why do we need this feature?**

A single tracing backend can contain traces for services whose logs are stored in multiple Loki clusters or different logging backends.

Previously, trace to logs supported only one destination. Users had to create duplicate tracing data sources to link the same traces to different log backends.

**Who is this feature for?**

Users who:

- Store traces in one Tempo instance.
- Store logs in multiple Loki clusters.
- Use multiple supported logging backends, such as Loki and Elasticsearch.

**Which issue(s) does this PR fix?**:

Fixes #91793

**Special notes for your reviewer:**

This PR is intentionally opened as a draft to validate the UX and configuration format before finalizing the implementation.

The Tempo frontend is distributed as a prebuilt plugin. A follow-up PR is required to update its `@grafana/o11y-ds-frontend` dependency and expose the new configuration editor in Tempo. Jaeger consumes the shared editor directly from this repository.

The configuration uses a new `tracesToLogsV3` array. Existing `tracesToLogs` and `tracesToLogsV2` configurations are migrated when edited. An empty V3 configuration falls back to V2 when available.

Testing completed:

- Four Jest suites with 117 tests passing.
- Targeted Playwright trace-to-logs test passing.
- Package and full TypeScript checks passing.
- ESLint and Prettier passing.
- Package build passing.
- i18n extraction completed.
- Manual browser validation with two logs destinations completed.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle. Not applicable because this extends the existing trace-to-logs feature.
- [x] The docs are updated, and if this is a notable improvement, it's added to the What's New doc. The trace integration and Jaeger configuration docs are updated; What's New can be decided after the draft UX is accepted.

