### PR TITLE
Navigation: Allow pinning top-level nav sections

### DIFF
--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenu.test.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenu.test.tsx
@@ -325,17 +325,35 @@ describe('MegaMenu', () => {
         expect(labels.some((l) => l?.startsWith('Pin '))).toBe(false);
       });
 
-      it('offers a pin control on childless top-level sections but not on parent sections', async () => {
+      it('offers a pin control on all top-level sections, including parents', async () => {
         const { user } = renderMegaMenu();
 
         await user.click(await screen.findByRole('button', { name: 'Customise navigation' }));
         await screen.findByRole('link', { name: 'Dashboards' });
         const labels = screen.getAllByRole('button', { hidden: true }).map((b) => b.getAttribute('aria-label'));
-        // Parent sections (with children) aren't pinnable — you pin their children instead.
-        expect(labels).not.toContain('Pin Dashboards');
-        expect(labels).not.toContain('Pin Administration');
-        // A childless top-level section (Explore) is pinnable.
+        // Parent sections are pinnable as a quick-link (as well as their children being pinnable).
+        expect(labels).toContain('Pin Dashboards');
+        expect(labels).toContain('Pin Administration');
+        // Childless top-level sections (Explore) are pinnable too.
         expect(labels).toContain('Pin Explore');
+      });
+
+      it('pins a top-level parent section as a quick-link and keeps it in the nav', async () => {
+        const { user } = renderMegaMenu();
+
+        await user.click(await screen.findByRole('button', { name: 'Customise navigation' }));
+        const pin = screen
+          .getAllByRole('button', { hidden: true })
+          .find((button) => button.getAttribute('aria-label') === 'Pin Dashboards');
+        await user.click(pin!);
+        await user.click(screen.getByRole('button', { name: 'Done' }));
+
+        await waitFor(() => expect(mockUserPreferences.navbar?.bookmarkUrls).toEqual(['/dashboards']));
+        // Shows in the box as a single breadcrumb quick-link…
+        const pinned = within(await screen.findByRole('list', { name: 'Pinned' }));
+        expect(pinned.getByRole('link', { name: 'Dashboards' })).toBeInTheDocument();
+        // …and still appears in the nav below (pinning duplicates, it doesn't move).
+        expect(screen.getAllByRole('link', { name: 'Dashboards' }).length).toBeGreaterThanOrEqual(2);
       });
 
       it('offers a pin control on the Starred section (special case) but not its dashboards', async () => {
@@ -346,7 +364,7 @@ describe('MegaMenu', () => {
         expect(await screen.findByRole('link', { name: STARRED_DASHBOARD.name })).toBeInTheDocument();
 
         const labels = screen.getAllByRole('button', { hidden: true }).map((b) => b.getAttribute('aria-label'));
-        expect(labels).toContain('Pin Starred'); // top-level section is pinnable as a special case
+        expect(labels).toContain('Pin Starred'); // the Starred section itself is pinnable
         expect(labels).not.toContain(`Pin ${STARRED_DASHBOARD.name}`); // but its sub-dashboards are not
       });
 

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenuItem.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenuItem.tsx
@@ -165,12 +165,11 @@ export function MegaMenuItem({
   }
 
   // Whether to render the bookmark/pin control. With customisation off it's the legacy behaviour:
-  // every item shows it (gating lives in MegaMenuItemText). With it on: non-top-level items are
-  // pinnable, and a top-level section is pinnable when it has no children of its own (a leaf section
-  // like Explore) or is Starred (a special case) — but not a parent section (you pin its children).
+  // every item shows it (gating lives in MegaMenuItemText). With it on, any nav item is pinnable
+  // except Home and the dynamic starred sub-items (`starred/<uid>`) — including top-level sections,
+  // parents and leaves alike. (Bookmarks is already dropped from the tree when customising.)
   const isPinnableItem = link.id !== 'home' && !link.id?.startsWith(ID_PREFIX);
-  const isPinnableTopLevel = level > 0 || link.id === 'starred' || !linkHasChildren(link);
-  const showPin = !canCustomise || (isPinnableTopLevel && isPinnableItem);
+  const showPin = !canCustomise || isPinnableItem;
 
   return (
     <li ref={setItemRef} className={styles.listItem} {...draggableProvided?.draggableProps}>

--- a/public/app/core/components/AppChrome/MegaMenu/utils.test.ts
+++ b/public/app/core/components/AppChrome/MegaMenu/utils.test.ts
@@ -319,6 +319,16 @@ describe('pinning helpers', () => {
       expect(entries[0].line?.ancestors).toEqual(['Dashboards']);
     });
 
+    it('resolves a top-level parent section to a quick-link breadcrumb, not an expandable section', () => {
+      // A parent's children are individually pinnable, so pinning the parent is a plain quick-link
+      // (only Starred, whose children aren't pinnable, renders as an expandable section).
+      const entries = getPinnedEntries(tree, ['/dashboards']);
+      expect(entries).toHaveLength(1);
+      expect(entries[0].section).toBeUndefined();
+      expect(entries[0].line?.item.text).toBe('Dashboards');
+      expect(entries[0].line?.ancestors).toEqual([]);
+    });
+
     it('keeps the stored order and skips urls that match no nav item', () => {
       const entries = getPinnedEntries(tree, ['/admin/settings', '/nope', '/explore']);
       expect(entries.map((e) => e.url)).toEqual(['/admin/settings', '/explore']);


### PR DESCRIPTION
**What is this feature?**

Lets users pin **top-level parent nav sections** (Dashboards, Alerting, Connections, Administration, …) to the Pinned box, not just childless sections (Explore), Starred, and individual child items. Behind the `grafana.customizableMegaMenu` flag.

A pinned parent appears in the Pinned box as a **quick-link breadcrumb** to its landing page (e.g. `Dashboards` → `/dashboards`), consistent with a pinned Explore or child. Starred remains the only pinned entry that renders as an expandable section, since its dynamic children aren't individually pinnable.

Implementation is a one-line relaxation of the pin gating in `MegaMenuItem.tsx` (any item except Home and starred sub-items is now pinnable); `getPinnedEntries` already renders a pinned parent as a breadcrumb, so no rendering change was needed.

**Why do we need this feature?**

Pinning was limited to leaf/childless sections, so users couldn't keep a whole section they live in (e.g. Dashboards or Alerting) one click away at the top of the nav. This closes that gap.

**Who is this feature for?**

Signed-in users customising their navigation who want a top-level section as a persistent shortcut.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Follow-up to the customisable mega menu (original PR #127167, now merged). Frontend only, behind the existing feature toggle. Tests added/updated in `MegaMenu.test.tsx` and `utils.test.ts`.

- [ ] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to What's New.
