### PR TITLE
Advisor: report usage stats on aggregated instances

### DIFF
--- a/pkg/services/pluginsintegration/advisor/advisor.go
+++ b/pkg/services/pluginsintegration/advisor/advisor.go
@@ -9,6 +9,7 @@ import (
 	"github.com/grafana/grafana/apps/advisor/pkg/app/checks"
 	"github.com/grafana/grafana/apps/advisor/pkg/app/checks/datasourcecheck"
 	"github.com/grafana/grafana/apps/advisor/pkg/app/checks/plugincheck"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/services/apiserver"
 	apiserverrequest "github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
 	"github.com/grafana/grafana/pkg/setting"
@@ -73,6 +74,7 @@ func findLatestCheck(checkList []resource.Object, checkType string) *advisorv0al
 }
 
 func (s *Service) ReportSummary(ctx context.Context) (*ReportInfo, error) {
+	ctx = identity.WithServiceIdentityContext(ctx, 1)
 	client, err := s.clientGenerator(ctx)
 	if err != nil {
 		return nil, err

--- a/pkg/services/pluginsintegration/advisor/advisor_test.go
+++ b/pkg/services/pluginsintegration/advisor/advisor_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/grafana/grafana/apps/advisor/pkg/app/checks"
 	"github.com/grafana/grafana/apps/advisor/pkg/app/checks/datasourcecheck"
 	"github.com/grafana/grafana/apps/advisor/pkg/app/checks/plugincheck"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -140,13 +141,31 @@ func TestService_ReportSummary(t *testing.T) {
 	}
 }
 
+func TestService_ReportSummary_SetsServiceIdentity(t *testing.T) {
+	client := &mockClient{}
+	service := &Service{
+		cfg:             &setting.Cfg{StackID: "test-stack"},
+		namespace:       "stacks-0",
+		clientGenerator: func(ctx context.Context) (resource.Client, error) { return client, nil },
+	}
+
+	_, err := service.ReportSummary(context.Background())
+	assert.NoError(t, err)
+
+	requester, err := identity.GetRequester(client.listCtx)
+	assert.NoError(t, err, "expected a requester on the context passed to List")
+	assert.NotNil(t, requester)
+}
+
 type mockClient struct {
 	resource.Client
 	listItems []resource.Object
 	listErr   error
+	listCtx   context.Context
 }
 
 func (m *mockClient) List(ctx context.Context, namespace string, opts resource.ListOptions) (resource.ListObject, error) {
+	m.listCtx = ctx
 	if m.listErr != nil {
 		return nil, m.listErr
 	}


### PR DESCRIPTION
## What

`ReportSummary` (called by the usage-stats collector) now stamps a service identity on the context before listing advisor `Check` resources:

```go
ctx = identity.WithServiceIdentityContext(ctx, 1)
```

## Why

The usage-stats collector calls `ReportSummary` from a **background context with no requester**. While `advisor.grafana.app` is served locally that's fine. But once the group is **aggregated** to the multi-tenant apiserver, the list is proxied using CAP-token auth, which mints the token from the requester in the context. With no requester the proxied read fails, so the `stats.plugins.advisor.*` usage stats (`unhealthy_datasources`, `outdated_plugins`, `deprecated_plugins`) silently stop being reported — they decay to zero for every instance as it moves to aggregation.

Stamping a service identity fixes the aggregated read and is harmless for the local path. This matches what the advisor app already does for its own aggregated calls (`apps/advisor/pkg/app/app.go`).

## Testing

- Added `TestService_ReportSummary_SetsServiceIdentity`, asserting a requester is present on the context passed to the client's `List`.
- Verified end-to-end on an aggregated dev instance: on the identity-less background path the report now includes `stats.plugins.advisor.unhealthy_datasources` (confirmed non-zero), where before it was absent.