### PR TITLE
fix(authn): wait for OpenFeature test provider

### DIFF
--- a/pkg/services/authn/authnimpl/sync/user_sync_test.go
+++ b/pkg/services/authn/authnimpl/sync/user_sync_test.go
@@ -44,7 +44,7 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	if err := openfeature.SetProvider(provider); err != nil {
+	if err := openfeature.SetProviderAndWait(provider); err != nil {
 		panic(err)
 	}
 


### PR DESCRIPTION
## What
Wait for the package test OpenFeature provider to become ready before tests start evaluating feature flags.

## Why
Asynchronous provider initialization can return a flag default before it is ready, letting org sync call `GetUserOrgList` when the test expects the hook to skip.

## Verification
- Reproduced the failure in a fresh process with `GOMAXPROCS=1` before the change.
- Passed the same fresh-process probe 1,000 times after the change.
- `go test -run '^TestOrgSync_SyncOrgRolesHook_SkipsWhenSingleOrgAndKubernetesUsersRedirect$' ./pkg/services/authn/authnimpl/sync`