### PR TITLE
TraceView: default trace-to-logs trace ID filtering to on

### DIFF
--- a/packages/grafana-o11y-ds-frontend/src/TraceToLogs/TraceToLogsSettings.test.tsx
+++ b/packages/grafana-o11y-ds-frontend/src/TraceToLogs/TraceToLogsSettings.test.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { type DataSourceInstanceSettings, type DataSourceSettings } from '@grafana/data';
 import { type DataSourceSrv, setDataSourceSrv } from '@grafana/runtime';
 
-import { type TraceToLogsData, TraceToLogsSettings } from './TraceToLogsSettings';
+import { getTraceToLogsOptions, type TraceToLogsData, TraceToLogsSettings } from './TraceToLogsSettings';
 
 const defaultOptionsOldFormat: DataSourceSettings<TraceToLogsData> = {
   jsonData: {
@@ -118,5 +118,64 @@ describe('TraceToLogsSettings', () => {
         },
       },
     ]);
+  });
+
+  it('defaults the trace ID filter on and leaves the span ID filter off when unset', () => {
+    const options = {
+      jsonData: {
+        tracesToLogsV2: {
+          datasourceUid: 'loki1_uid',
+          customQuery: false,
+        },
+      },
+    } as unknown as DataSourceSettings<TraceToLogsData>;
+    render(<TraceToLogsSettings options={options} onOptionsChange={() => {}} />);
+    expect((screen.getByLabelText('Filter by trace ID') as HTMLInputElement).checked).toBeTruthy();
+    expect((screen.getByLabelText('Filter by span ID') as HTMLInputElement).checked).toBeFalsy();
+  });
+});
+
+describe('getTraceToLogsOptions', () => {
+  it('defaults trace ID filtering on and leaves span ID filtering off when unset (v2)', () => {
+    const result = getTraceToLogsOptions({
+      tracesToLogsV2: { datasourceUid: 'loki1_uid', customQuery: false },
+    });
+    expect(result?.filterByTraceID).toBe(true);
+    expect(result?.filterBySpanID).toBeUndefined();
+  });
+
+  it('preserves an explicit filterByTraceID: false opt-out (v2)', () => {
+    const result = getTraceToLogsOptions({
+      tracesToLogsV2: { datasourceUid: 'loki1_uid', customQuery: false, filterByTraceID: false },
+    });
+    expect(result?.filterByTraceID).toBe(false);
+  });
+
+  it('does not enable span ID filtering by default (v2)', () => {
+    const result = getTraceToLogsOptions({
+      tracesToLogsV2: { datasourceUid: 'loki1_uid', customQuery: false, filterBySpanID: true },
+    });
+    expect(result?.filterBySpanID).toBe(true);
+    expect(result?.filterByTraceID).toBe(true);
+  });
+
+  it('defaults trace ID filtering on through the v1 -> v2 transform', () => {
+    const result = getTraceToLogsOptions({
+      tracesToLogs: { datasourceUid: 'loki1_uid' },
+    });
+    expect(result?.filterByTraceID).toBe(true);
+    expect(result?.filterBySpanID).toBeUndefined();
+  });
+
+  it('preserves an explicit filterByTraceID: false through the v1 -> v2 transform', () => {
+    const result = getTraceToLogsOptions({
+      tracesToLogs: { datasourceUid: 'loki1_uid', filterByTraceID: false },
+    });
+    expect(result?.filterByTraceID).toBe(false);
+  });
+
+  it('returns undefined when no trace-to-logs config is present', () => {
+    expect(getTraceToLogsOptions({})).toBeUndefined();
+    expect(getTraceToLogsOptions(undefined)).toBeUndefined();
   });
 });

--- a/packages/grafana-o11y-ds-frontend/src/TraceToLogs/TraceToLogsSettings.tsx
+++ b/packages/grafana-o11y-ds-frontend/src/TraceToLogs/TraceToLogsSettings.tsx
@@ -52,10 +52,17 @@ export interface TraceToLogsData extends DataSourceJsonData {
 /**
  * Gets new version of the traceToLogs config from the json data either returning directly or transforming the old
  * version to new and returning that.
+ *
+ * Trace ID filtering defaults to on when unset so the link returns logs for the trace rather than all logs for the
+ * service. trace_id is present in far more logging setups than span_id, so it is the safer default and avoids empty
+ * results. An explicit `false` means the user opted out and is preserved. span ID filtering is left off by default.
  */
 export function getTraceToLogsOptions(data?: TraceToLogsData): TraceToLogsOptionsV2 | undefined {
   if (data?.tracesToLogsV2) {
-    return data.tracesToLogsV2;
+    return {
+      ...data.tracesToLogsV2,
+      filterByTraceID: data.tracesToLogsV2.filterByTraceID ?? true,
+    };
   }
   if (!data?.tracesToLogs) {
     return undefined;
@@ -67,7 +74,7 @@ export function getTraceToLogsOptions(data?: TraceToLogsData): TraceToLogsOption
   traceToLogs.tags = data.tracesToLogs.mapTagNamesEnabled
     ? data.tracesToLogs.mappedTags
     : data.tracesToLogs.tags?.map((tag) => ({ key: tag }));
-  traceToLogs.filterByTraceID = data.tracesToLogs.filterByTraceID;
+  traceToLogs.filterByTraceID = data.tracesToLogs.filterByTraceID ?? true;
   traceToLogs.filterBySpanID = data.tracesToLogs.filterBySpanID;
   traceToLogs.spanStartTimeShift = data.tracesToLogs.spanStartTimeShift;
   traceToLogs.spanEndTimeShift = data.tracesToLogs.spanEndTimeShift;

--- a/public/app/features/explore/TraceView/TraceView.tsx
+++ b/public/app/features/explore/TraceView/TraceView.tsx
@@ -152,7 +152,12 @@ export function TraceView(props: Props) {
   );
 
   const instanceSettings = getDatasourceSrv().getInstanceSettings(datasource?.name);
-  const traceToLogsOptions = getTraceToLogsOptions(instanceSettings?.jsonData);
+  // getTraceToLogsOptions applies defaults and returns a fresh object, so memoize to keep the
+  // createSpanLink useMemo below stable across renders.
+  const traceToLogsOptions = useMemo(
+    () => getTraceToLogsOptions(instanceSettings?.jsonData),
+    [instanceSettings?.jsonData]
+  );
   const traceToMetrics: TraceToMetricsData | undefined = instanceSettings?.jsonData;
   const traceToMetricsOptions = traceToMetrics?.tracesToMetrics;
   const traceToProfilesData: TraceToProfilesData | undefined = instanceSettings?.jsonData;

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/SpanDetailLinkButtons.test.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/SpanDetailLinkButtons.test.tsx
@@ -80,9 +80,9 @@ describe('SpanDetailLinkButtons', () => {
         expectedCTA: 'Related logs',
       },
       {
-        name: 'shows "Related logs" when neither filterBySpanID nor filterByTraceID is set',
+        name: 'shows "Logs for this trace" when neither filter is set (trace ID filtering defaults on)',
         settings: { jsonData: { tracesToLogsV2: { customQuery: false } } },
-        expectedCTA: 'Related logs',
+        expectedCTA: 'Logs for this trace',
       },
       {
         name: 'shows "Logs for this trace" when filterByTraceID is set',


### PR DESCRIPTION
## What this PR does / why we need it

Trace-to-logs filters were off by default, so the "Logs for this trace" button (relabeled in #128041 to reflect the datasource config) returned service-scoped logs for the default config. This defaults `filterByTraceID` on when unset, so the button returns logs for the trace out of the box — matching what it now says.

`trace_id` is present in far more logging setups than `span_id`, so it is the safer default and avoids empty results. `filterBySpanID` is intentionally left off — span IDs are rarely present in logs, so defaulting them on would strand users with empty results.

## Which issue(s) this PR fixes

Part of #126968, complementing the honest-label change in #128041. A tooltip explaining that the button reflects the datasource config, and a check to hide the button when no logs exist, are related follow-ups tracked separately.

## Scope / who is affected

Applied at read time in `getTraceToLogsOptions` (no stored migration). Core's `TraceView` calls it for any tracing datasource **without gating on datasource type**, so it affects any datasource carrying trace-to-logs config whose `filterByTraceID` is unset — Tempo, Jaeger, and Zipkin (all now externalized), configured via the config editor or via provisioning. An explicit `false` is preserved as an opt-out.

Because the tracing datasource plugins are externalized and bundle their own `@grafana/o11y-ds-frontend`, their config-editor toggle **display** only reflects the new default once they bump that dependency; core's runtime behavior (and the generated query) changes immediately regardless.

## Known edges (accepted)

- A config that explicitly enabled span-only filtering (`filterBySpanID: true`, `filterByTraceID` unset) will also gain trace filtering. This is consistent with "trace on by default"; opt out with `filterByTraceID: false`.
- For a datasource using a custom query with `filterByTraceID` unset, the button label reads "Logs for this trace" while the custom query itself is unchanged. The label is derived from config in #128041's `getLogsButtonCTA` and does not consider `customQuery` — pre-existing label-layer behavior, not a query change. Candidate follow-up for the datasource owners.

## Test plan

- `yarn jest TraceToLogsSettings SpanDetailLinkButtons createSpanLink TraceView` — 99 pass, including the updated CTA-copy case (unset config now shows "Logs for this trace") and new `getTraceToLogsOptions` unit tests.
- `yarn typecheck`, `yarn prettier --check` — clean.

Generated with [Claude Code](https://claude.com/claude-code)
