### PR TITLE
Provisioning: Preserve the original creator on job history records

### DIFF
--- a/pkg/registry/apis/provisioning/historic_job_storage.go
+++ b/pkg/registry/apis/provisioning/historic_job_storage.go
@@ -1,0 +1,28 @@
+package provisioning
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
+	"k8s.io/apiserver/pkg/registry/rest"
+
+	authlib "github.com/grafana/authlib/types"
+
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	apiutils "github.com/grafana/grafana/pkg/apimachinery/utils"
+)
+
+type historicJobStorage struct {
+	*genericregistry.Store
+}
+
+func (s *historicJobStorage) Create(ctx context.Context, obj runtime.Object, createValidation rest.ValidateObjectFunc, options *metav1.CreateOptions) (runtime.Object, error) {
+	if auth, ok := authlib.AuthInfoFrom(ctx); ok && identity.IsProvisioningServiceIdentity(auth) {
+		if meta, err := apiutils.MetaAccessor(obj); err == nil && meta.GetCreatedBy() != "" {
+			ctx = identity.WithOriginalIdentityUID(ctx, meta.GetCreatedBy())
+		}
+	}
+	return s.Store.Create(ctx, obj, createValidation, options)
+}

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -856,7 +856,7 @@ func (b *APIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver.APIGroupI
 		if err != nil {
 			return fmt.Errorf("create historic job wrapper: %w", err)
 		}
-		storage[provisioning.HistoricJobResourceInfo.StoragePath()] = historicJobStore
+		storage[provisioning.HistoricJobResourceInfo.StoragePath()] = &historicJobStorage{Store: historicJobStore}
 	}
 
 	connectionsStore, err := grafanaregistry.NewRegistryStore(opts.Scheme, provisioning.ConnectionResourceInfo, opts.OptsGetter)

--- a/pkg/tests/apis/provisioning/jobs/historicjobs_createdby_test.go
+++ b/pkg/tests/apis/provisioning/jobs/historicjobs_createdby_test.go
@@ -1,0 +1,57 @@
+package jobs
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
+)
+
+func TestIntegrationProvisioning_HistoricJobsPreserveCreatedBy(t *testing.T) {
+	helper := sharedHelper(t)
+
+	const repo = "historicjobs-createdby-test"
+	testRepo := common.TestRepo{
+		Name:       repo,
+		SyncTarget: "folder",
+		Copies:     map[string]string{},
+	}
+	helper.CreateLocalRepo(t, testRepo)
+
+	jobSpec := provisioning.JobSpec{
+		Action: provisioning.JobActionPull,
+		Pull:   &provisioning.SyncJobOptions{},
+	}
+	body := common.AsJSON(jobSpec)
+
+	var statusCode int
+	result := helper.AdminREST.Post().
+		Namespace("default").
+		Resource("repositories").
+		Name(repo).
+		SubResource("jobs").
+		Body(body).
+		SetHeader("Content-Type", "application/json").
+		Do(t.Context()).StatusCode(&statusCode)
+	require.NoError(t, result.Error(), "should be able to create job")
+	require.Equal(t, http.StatusAccepted, statusCode)
+
+	obj, err := result.Get()
+	require.NoError(t, err)
+	job, ok := obj.(*unstructured.Unstructured)
+	require.True(t, ok, "expecting unstructured object, but got %T", obj)
+
+	jobCreatedBy := job.GetAnnotations()[utils.AnnoKeyCreatedBy]
+	require.True(t, strings.HasPrefix(jobCreatedBy, "user:"), "job should be created by a user, got %q", jobCreatedBy)
+
+	historicJob := helper.AwaitJob(t, job)
+
+	require.Equal(t, jobCreatedBy, historicJob.GetAnnotations()[utils.AnnoKeyCreatedBy],
+		"historic job should keep the original job's createdBy")
+}


### PR DESCRIPTION
**What is this feature?**

When a completed provisioning job is moved into job history, the history record now keeps the identity of the user who originally created the job.

**Why do we need this feature?**

History records were attributed to the internal provisioning service identity instead of the person who triggered the job, so after a job finished it was impossible to tell who started it. Anonymized example of the same job before and after the fix:

Before:
```json
"annotations": {
  "grafana.app/createdBy": "access-policy:provisioning"
}
```

After:
```json
"annotations": {
  "grafana.app/createdBy": "user:abc123xyz789"
}
```

**Who is this feature for?**

Anyone reviewing or auditing job history for provisioned repositories.
