### PR TITLE
TimeSeries tooltip: anchor hover tooltip to panel corner

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin2.tsx
+++ b/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin2.tsx
@@ -671,6 +671,10 @@ export const TooltipPlugin2 = ({
 
         transform = `translateX(${shiftX}px) ${reflectX} translateY(${shiftY}px) ${reflectY}`;
 
+        // Anchor the hover tooltip to the bottom-right corner instead of following the cursor,
+        // so it never occludes the series directly under the pointer.
+        transform = `translateX(calc(100vw - 100% - ${TOOLTIP_OFFSET}px)) translateY(calc(100vh - 100% - ${TOOLTIP_OFFSET}px))`;
+
         if (domRef.current != null) {
           domRef.current.style.transform = transform;
         } else {


### PR DESCRIPTION
Renders the shared crosshair tooltip pinned to the bottom-right corner rather than following the cursor, so it no longer overlaps the data directly under the pointer.