### PR TITLE
Plugins: Fix typo in JSON "aliasIDs" in Go unmarshalling for panel plugins

### DIFF
--- a/packages/grafana-runtime/src/services/pluginMeta/test-fixtures/config.panels.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/test-fixtures/config.panels.ts
@@ -249,7 +249,7 @@ export const panels: PanelPluginMetas = structuredClone({
   annolist: {
     id: 'annolist',
     name: 'Annotations list',
-    aliasIds: ['ryantxu-annolist-panel'],
+    aliasIDs: ['ryantxu-annolist-panel'],
     info: {
       author: {
         name: 'Grafana Labs',

--- a/packages/grafana-runtime/src/services/pluginMeta/test-fixtures/v0alpha1Response.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/test-fixtures/v0alpha1Response.ts
@@ -727,6 +727,7 @@ export const v0alpha1Response: PluginMetasResponse = structuredClone({
           loadingStrategy: 'script',
         },
         baseURL: 'app/plugins/panel/annolist',
+        aliasIds: ['ryantxu-annolist-panel'],
         signature: {
           status: 'internal',
         },

--- a/pkg/plugins/models.go
+++ b/pkg/plugins/models.go
@@ -314,7 +314,7 @@ type DataSourceDTO struct {
 type PanelDTO struct {
 	ID              string            `json:"id"`
 	Name            string            `json:"name"`
-	AliasIDs        []string          `json:"aliasIds,omitempty"`
+	AliasIDs        []string          `json:"aliasIDs,omitempty"`
 	Info            Info              `json:"info"`
 	HideFromList    bool              `json:"hideFromList"`
 	Sort            int               `json:"sort"`

--- a/pkg/tests/api/plugins/data/expectedListResp.json
+++ b/pkg/tests/api/plugins/data/expectedListResp.json
@@ -114,6 +114,9 @@
     "name": "Annotations list",
     "type": "panel",
     "id": "annolist",
+    "aliasIDs": [
+      "ryantxu-annolist-panel"
+    ],
     "enabled": true,
     "pinned": false,
     "info": {
@@ -1374,6 +1377,9 @@
     "name": "PostgreSQL",
     "type": "datasource",
     "id": "grafana-postgresql-datasource",
+    "aliasIDs": [
+      "postgres"
+    ],
     "enabled": true,
     "pinned": false,
     "info": {
@@ -1678,6 +1684,9 @@
     "name": "TestData",
     "type": "datasource",
     "id": "grafana-testdata-datasource",
+    "aliasIDs": [
+      "testdata"
+    ],
     "enabled": true,
     "pinned": false,
     "info": {


### PR DESCRIPTION
**What is this feature?**

This PR fixes a typo in JSON ~`aliasIds`~ which _I think_ should have been `aliasIDs` in Go unmarshalling for panel plugins to match what's in `plugin.json` properties:
- https://github.com/search?q=repo%3Agrafana%2Fgrafana+aliasIDs+language%3AJSON&type=code&l=JSON

**Why do we need this feature?**

This bug was causing some trouble when trying to change panel plugin aliases for externalization.

**Who is this feature for?**

All users of Grafana.

**Which issue(s) does this PR fix?**:

Fixes # https://github.com/grafana/grafana/issues/126208 _(Well, this is a fix we needed for that issue to become possible to implement, but not the whole ticket.)_

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- `N/A` If this is a pre-GA feature, it is behind a feature toggle.
- `N/A` The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
