### PR TITLE
Server Lock: migrate SQL store to templates

### DIFF
--- a/apps/advisor/go.sum
+++ b/apps/advisor/go.sum
@@ -85,6 +85,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
+github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/Machiel/slugify v1.0.1 h1:EfWSlRWstMadsgzmiV7d0yVd2IFlagWH68Q+DcYCm4E=
 github.com/Machiel/slugify v1.0.1/go.mod h1:fTFGn5uWEynW4CUMG7sWkYXOf1UgDxyTM3DbR6Qfg3k=

--- a/apps/dashvalidator/go.sum
+++ b/apps/dashvalidator/go.sum
@@ -108,6 +108,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
+github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.32.0 h1:rIkQfkCOVKc1OiRCNcSDD8ml5RJlZbH/Xsq7lbpynwc=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.32.0/go.mod h1:RD2SsorTmYhF6HkTmDw7KmPYQk8OBYwTkuasChwv7R4=

--- a/pkg/api/folder_bench_test.go
+++ b/pkg/api/folder_bench_test.go
@@ -54,6 +54,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/services/user/userimpl"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/storage/legacysql"
 	"github.com/grafana/grafana/pkg/storage/legacysql/dualwrite"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	resourcepb "github.com/grafana/grafana/pkg/storage/unified/resourcepb"
@@ -441,7 +442,7 @@ func setupServer(b testing.TB, sc benchScenario, features featuremgmt.FeatureTog
 		nil,
 		nil,
 		dualwrite.ProvideTestService(),
-		serverlock.ProvideService(sc.db, tracing.InitializeTracerForTest()),
+		serverlock.ProvideService(legacysql.NewDatabaseProvider(sc.db), tracing.InitializeTracerForTest()),
 		kvstore.NewFakeKVStore(),
 		dashclient.NewK8sClientWithFallback(
 			sc.cfg,

--- a/pkg/infra/serverlock/queries/create_lock.sql
+++ b/pkg/infra/serverlock/queries/create_lock.sql
@@ -1,0 +1,2 @@
+INSERT INTO {{ .Ident .ServerLockTable }} (operation_uid, last_execution, version)
+VALUES ({{ .Arg .OperationUID }}, {{ .Arg .LastExecution }}, {{ .Arg .Version }}){{ if eq .DialectName "postgres" }} ON CONFLICT DO NOTHING RETURNING id{{ end }};

--- a/pkg/infra/serverlock/queries/get_lock.sql
+++ b/pkg/infra/serverlock/queries/get_lock.sql
@@ -1,0 +1,3 @@
+SELECT *
+FROM {{ .Ident .ServerLockTable }}
+WHERE operation_uid = {{ .Arg .OperationUID }};

--- a/pkg/infra/serverlock/queries/get_lock_for_update.sql
+++ b/pkg/infra/serverlock/queries/get_lock_for_update.sql
@@ -1,0 +1,4 @@
+SELECT *
+FROM {{ .Ident .ServerLockTable }}
+WHERE operation_uid = {{ .Arg .OperationUID }}
+{{ .SelectFor "UPDATE" }};

--- a/pkg/infra/serverlock/queries/release_lock.sql
+++ b/pkg/infra/serverlock/queries/release_lock.sql
@@ -1,0 +1,2 @@
+DELETE FROM {{ .Ident .ServerLockTable }}
+WHERE operation_uid = {{ .Arg .OperationUID }};

--- a/pkg/infra/serverlock/queries/update_last_execution.sql
+++ b/pkg/infra/serverlock/queries/update_last_execution.sql
@@ -1,0 +1,3 @@
+UPDATE {{ .Ident .ServerLockTable }}
+SET last_execution = {{ .Arg .LastExecution }}
+WHERE operation_uid = {{ .Arg .OperationUID }};

--- a/pkg/infra/serverlock/queries/update_version.sql
+++ b/pkg/infra/serverlock/queries/update_version.sql
@@ -1,0 +1,5 @@
+UPDATE {{ .Ident .ServerLockTable }}
+SET version = {{ .Arg .Version }},
+    last_execution = {{ .Arg .LastExecution }}
+WHERE operation_uid = {{ .Arg .OperationUID }}
+  AND version = {{ .Arg .PreviousVersion }};

--- a/pkg/infra/serverlock/serverlock.go
+++ b/pkg/infra/serverlock/serverlock.go
@@ -101,20 +101,19 @@ func (sl *ServerLockService) acquireLock(ctx context.Context, serverLock *server
 		return false, fmt.Errorf("get legacy DB: %w", err)
 	}
 
-	query := updateVersionQuery{
-		SQLTemplate:     sqltemplate.New(dbHelper.DialectForDriver()),
-		ServerLockTable: dbHelper.Table("server_lock"),
-		Version:         serverLock.Version + 1,
-		LastExecution:   time.Now().Unix(),
-		OperationUID:    serverLock.OperationUID,
-		PreviousVersion: serverLock.Version,
-	}
-	rawSQL, err := sqltemplate.Execute(updateVersionTemplate, query)
-	if err != nil {
-		return false, err
-	}
-
 	err = dbHelper.DB.WithDbSession(ctx, func(dbSession *db.Session) error {
+		query := updateVersionQuery{
+			SQLTemplate:     sqltemplate.New(dbHelper.DialectForDriver()),
+			ServerLockTable: dbHelper.Table("server_lock"),
+			Version:         serverLock.Version + 1,
+			LastExecution:   time.Now().Unix(),
+			OperationUID:    serverLock.OperationUID,
+			PreviousVersion: serverLock.Version,
+		}
+		rawSQL, err := sqltemplate.Execute(updateVersionTemplate, query)
+		if err != nil {
+			return err
+		}
 		res, err := dbSession.Exec(append([]any{rawSQL}, query.GetArgs()...)...)
 		if err != nil {
 			return err
@@ -149,17 +148,16 @@ func (sl *ServerLockService) getOrCreate(ctx context.Context, actionName string)
 		return nil, fmt.Errorf("get legacy DB: %w", err)
 	}
 
-	query := getLockQuery{
-		SQLTemplate:     sqltemplate.New(dbHelper.DialectForDriver()),
-		ServerLockTable: dbHelper.Table("server_lock"),
-		OperationUID:    actionName,
-	}
-	rawSQL, err := sqltemplate.Execute(getLockTemplate, query)
-	if err != nil {
-		return nil, err
-	}
-
 	err = dbHelper.DB.WithTransactionalDbSession(ctx, func(dbSession *db.Session) error {
+		query := getLockQuery{
+			SQLTemplate:     sqltemplate.New(dbHelper.DialectForDriver()),
+			ServerLockTable: dbHelper.Table("server_lock"),
+			OperationUID:    actionName,
+		}
+		rawSQL, err := sqltemplate.Execute(getLockTemplate, query)
+		if err != nil {
+			return err
+		}
 		sqlRes := &serverLock{}
 		has, err := dbSession.SQL(rawSQL, query.GetArgs()...).Get(sqlRes)
 		if err != nil {
@@ -321,18 +319,17 @@ func (sl *ServerLockService) acquireForRelease(ctx context.Context, actionName s
 		return fmt.Errorf("get legacy DB: %w", err)
 	}
 
-	query := getLockForUpdateQuery{
-		SQLTemplate:     sqltemplate.New(dbHelper.DialectForDriver()),
-		ServerLockTable: dbHelper.Table("server_lock"),
-		OperationUID:    actionName,
-	}
-	rawSQL, err := sqltemplate.Execute(getLockForUpdateTemplate, query)
-	if err != nil {
-		return err
-	}
-
 	// getting the lock - as the action name has a Unique constraint, this will fail if the lock is already on the database
 	err = dbHelper.DB.WithTransactionalDbSession(ctx, func(dbSession *db.Session) error {
+		query := getLockForUpdateQuery{
+			SQLTemplate:     sqltemplate.New(dbHelper.DialectForDriver()),
+			ServerLockTable: dbHelper.Table("server_lock"),
+			OperationUID:    actionName,
+		}
+		rawSQL, err := sqltemplate.Execute(getLockForUpdateTemplate, query)
+		if err != nil {
+			return err
+		}
 		// we need to find if the lock is in the database
 		result := &serverLock{}
 		has, err := dbSession.SQL(rawSQL, query.GetArgs()...).Get(result)
@@ -411,17 +408,16 @@ func (sl *ServerLockService) releaseLock(ctx context.Context, actionName string)
 		return fmt.Errorf("get legacy DB: %w", err)
 	}
 
-	query := releaseLockQuery{
-		SQLTemplate:     sqltemplate.New(dbHelper.DialectForDriver()),
-		ServerLockTable: dbHelper.Table("server_lock"),
-		OperationUID:    actionName,
-	}
-	rawSQL, err := sqltemplate.Execute(releaseLockTemplate, query)
-	if err != nil {
-		return err
-	}
-
 	err = dbHelper.DB.WithDbSession(dbCtx, func(dbSession *db.Session) error {
+		query := releaseLockQuery{
+			SQLTemplate:     sqltemplate.New(dbHelper.DialectForDriver()),
+			ServerLockTable: dbHelper.Table("server_lock"),
+			OperationUID:    actionName,
+		}
+		rawSQL, err := sqltemplate.Execute(releaseLockTemplate, query)
+		if err != nil {
+			return err
+		}
 		res, err := dbSession.Exec(append([]any{rawSQL}, query.GetArgs()...)...)
 		if err != nil {
 			return err

--- a/pkg/infra/serverlock/serverlock.go
+++ b/pkg/infra/serverlock/serverlock.go
@@ -15,14 +15,15 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
-	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
+	"github.com/grafana/grafana/pkg/storage/legacysql"
+	"github.com/grafana/grafana/pkg/storage/unified/sql/sqltemplate"
 )
 
-func ProvideService(sqlStore db.DB, tracer tracing.Tracer) *ServerLockService {
+func ProvideService(sql legacysql.LegacyDatabaseProvider, tracer tracing.Tracer) *ServerLockService {
 	return &ServerLockService{
-		SQLStore: sqlStore,
-		tracer:   tracer,
-		log:      log.New("infra.lockservice"),
+		sql:    sql,
+		tracer: tracer,
+		log:    log.New("infra.lockservice"),
 	}
 }
 
@@ -30,9 +31,9 @@ func ProvideService(sqlStore db.DB, tracer tracing.Tracer) *ServerLockService {
 // It exposes 2 services LockAndExecute and LockExecuteAndRelease, which are intended to be used independently, don't mix
 // them up (ie, use the same actionName for both of them).
 type ServerLockService struct {
-	SQLStore db.DB
-	tracer   tracing.Tracer
-	log      log.Logger
+	sql    legacysql.LegacyDatabaseProvider
+	tracer tracing.Tracer
+	log    log.Logger
 }
 
 // LockAndExecute try to create a lock for this server and only executes the
@@ -82,16 +83,26 @@ func (sl *ServerLockService) acquireLock(ctx context.Context, serverLock *server
 	defer span.End()
 	var result bool
 
-	err := sl.SQLStore.WithDbSession(ctx, func(dbSession *db.Session) error {
-		newVersion := serverLock.Version + 1
-		sql := `UPDATE server_lock SET
-			version = ?,
-			last_execution = ?
-		WHERE
-			operation_uid = ? AND version = ?`
+	dbHelper, err := sl.sql(ctx)
+	if err != nil {
+		return false, fmt.Errorf("get legacy DB: %w", err)
+	}
 
-		res, err := dbSession.Exec(sql, newVersion, time.Now().Unix(),
-			serverLock.OperationUID, serverLock.Version)
+	query := updateVersionQuery{
+		SQLTemplate:     sqltemplate.New(dbHelper.DialectForDriver()),
+		ServerLockTable: dbHelper.Table("server_lock"),
+		Version:         serverLock.Version + 1,
+		LastExecution:   time.Now().Unix(),
+		OperationUID:    serverLock.OperationUID,
+		PreviousVersion: serverLock.Version,
+	}
+	rawSQL, err := sqltemplate.Execute(updateVersionTemplate, query)
+	if err != nil {
+		return false, err
+	}
+
+	err = dbHelper.DB.WithDbSession(ctx, func(dbSession *db.Session) error {
+		res, err := dbSession.Exec(append([]any{rawSQL}, query.GetArgs()...)...)
 		if err != nil {
 			return err
 		}
@@ -110,10 +121,24 @@ func (sl *ServerLockService) getOrCreate(ctx context.Context, actionName string)
 	defer span.End()
 
 	var result *serverLock
-	err := sl.SQLStore.WithTransactionalDbSession(ctx, func(dbSession *db.Session) error {
+	dbHelper, err := sl.sql(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get legacy DB: %w", err)
+	}
+
+	query := getLockQuery{
+		SQLTemplate:     sqltemplate.New(dbHelper.DialectForDriver()),
+		ServerLockTable: dbHelper.Table("server_lock"),
+		OperationUID:    actionName,
+	}
+	rawSQL, err := sqltemplate.Execute(getLockTemplate, query)
+	if err != nil {
+		return nil, err
+	}
+
+	err = dbHelper.DB.WithTransactionalDbSession(ctx, func(dbSession *db.Session) error {
 		sqlRes := &serverLock{}
-		has, err := dbSession.SQL("SELECT * FROM server_lock WHERE operation_uid = ?",
-			actionName).Get(sqlRes)
+		has, err := dbSession.SQL(rawSQL, query.GetArgs()...).Get(sqlRes)
 		if err != nil {
 			return err
 		}
@@ -127,7 +152,7 @@ func (sl *ServerLockService) getOrCreate(ctx context.Context, actionName string)
 			OperationUID:  actionName,
 			LastExecution: 0,
 		}
-		result, err = sl.createLock(ctx, lockRow, dbSession)
+		result, err = sl.createLock(ctx, lockRow, dbHelper, dbSession)
 		return err
 	})
 
@@ -247,18 +272,26 @@ func (sl *ServerLockService) acquireForRelease(ctx context.Context, actionName s
 	ctx, span := sl.tracer.Start(ctx, "ServerLockService.acquireForRelease")
 	defer span.End()
 
+	dbHelper, err := sl.sql(ctx)
+	if err != nil {
+		return fmt.Errorf("get legacy DB: %w", err)
+	}
+
+	query := getLockForUpdateQuery{
+		SQLTemplate:     sqltemplate.New(dbHelper.DialectForDriver()),
+		ServerLockTable: dbHelper.Table("server_lock"),
+		OperationUID:    actionName,
+	}
+	rawSQL, err := sqltemplate.Execute(getLockForUpdateTemplate, query)
+	if err != nil {
+		return err
+	}
+
 	// getting the lock - as the action name has a Unique constraint, this will fail if the lock is already on the database
-	err := sl.SQLStore.WithTransactionalDbSession(ctx, func(dbSession *db.Session) error {
+	err = dbHelper.DB.WithTransactionalDbSession(ctx, func(dbSession *db.Session) error {
 		// we need to find if the lock is in the database
 		result := &serverLock{}
-		sqlRaw := `SELECT * FROM server_lock WHERE operation_uid = ?`
-		if sl.SQLStore.GetDBType() == migrator.MySQL || sl.SQLStore.GetDBType() == migrator.Postgres {
-			sqlRaw += ` FOR UPDATE`
-		}
-
-		has, err := dbSession.SQL(
-			sqlRaw,
-			actionName).Get(result)
+		has, err := dbSession.SQL(rawSQL, query.GetArgs()...).Get(result)
 		if err != nil {
 			return err
 		}
@@ -271,8 +304,17 @@ func (sl *ServerLockService) acquireForRelease(ctx context.Context, actionName s
 			}
 			// lock has timed out, so we update the timestamp
 			result.LastExecution = time.Now().Unix()
-			res, err := dbSession.Exec("UPDATE server_lock SET last_execution = ? WHERE operation_uid = ?",
-				result.LastExecution, actionName)
+			updateQuery := updateLastExecutionQuery{
+				SQLTemplate:     sqltemplate.New(dbHelper.DialectForDriver()),
+				ServerLockTable: dbHelper.Table("server_lock"),
+				LastExecution:   result.LastExecution,
+				OperationUID:    actionName,
+			}
+			updateSQL, err := sqltemplate.Execute(updateLastExecutionTemplate, updateQuery)
+			if err != nil {
+				return err
+			}
+			res, err := dbSession.Exec(append([]any{updateSQL}, updateQuery.GetArgs()...)...)
 			if err != nil {
 				return err
 			}
@@ -294,7 +336,7 @@ func (sl *ServerLockService) acquireForRelease(ctx context.Context, actionName s
 			OperationUID:  actionName,
 			LastExecution: time.Now().Unix(),
 		}
-		_, err = sl.createLock(ctx, lock, dbSession)
+		_, err = sl.createLock(ctx, lock, dbHelper, dbSession)
 		return err
 	})
 
@@ -310,10 +352,23 @@ func (sl *ServerLockService) releaseLock(ctx context.Context, actionName string)
 	// ensure clean up happens even if the context is cancelled
 	dbCtx := context.WithoutCancel(ctx)
 
-	err := sl.SQLStore.WithDbSession(dbCtx, func(dbSession *db.Session) error {
-		sql := `DELETE FROM server_lock WHERE operation_uid=? `
+	dbHelper, err := sl.sql(dbCtx)
+	if err != nil {
+		return fmt.Errorf("get legacy DB: %w", err)
+	}
 
-		res, err := dbSession.Exec(sql, actionName)
+	query := releaseLockQuery{
+		SQLTemplate:     sqltemplate.New(dbHelper.DialectForDriver()),
+		ServerLockTable: dbHelper.Table("server_lock"),
+		OperationUID:    actionName,
+	}
+	rawSQL, err := sqltemplate.Execute(releaseLockTemplate, query)
+	if err != nil {
+		return err
+	}
+
+	err = dbHelper.DB.WithDbSession(dbCtx, func(dbSession *db.Session) error {
+		res, err := dbSession.Exec(append([]any{rawSQL}, query.GetArgs()...)...)
 		if err != nil {
 			return err
 		}
@@ -355,14 +410,23 @@ func (sl *ServerLockService) executeFunc(ctx context.Context, actionName string,
 }
 
 func (sl *ServerLockService) createLock(ctx context.Context,
-	lockRow *serverLock, dbSession *sqlstore.DBSession,
+	lockRow *serverLock, dbHelper *legacysql.LegacyDatabaseHelper, dbSession *sqlstore.DBSession,
 ) (*serverLock, error) {
 	affected := int64(1)
-	rawSQL := `INSERT INTO server_lock (operation_uid, last_execution, version) VALUES (?, ?, ?)`
-	if sl.SQLStore.GetDBType() == migrator.Postgres {
-		rawSQL += ` ON CONFLICT DO NOTHING RETURNING id`
+	query := createLockQuery{
+		SQLTemplate:     sqltemplate.New(dbHelper.DialectForDriver()),
+		ServerLockTable: dbHelper.Table("server_lock"),
+		OperationUID:    lockRow.OperationUID,
+		LastExecution:   lockRow.LastExecution,
+		Version:         0,
+	}
+	rawSQL, err := sqltemplate.Execute(createLockTemplate, query)
+	if err != nil {
+		return nil, err
+	}
+	if query.DialectName() == "postgres" {
 		var id int64
-		_, err := dbSession.SQL(rawSQL, lockRow.OperationUID, lockRow.LastExecution, 0).Get(&id)
+		_, err := dbSession.SQL(rawSQL, query.GetArgs()...).Get(&id)
 		if err != nil {
 			return nil, err
 		}
@@ -377,9 +441,7 @@ func (sl *ServerLockService) createLock(ctx context.Context,
 		}
 		lockRow.Id = id
 	} else {
-		res, err := dbSession.Exec(
-			rawSQL,
-			lockRow.OperationUID, lockRow.LastExecution, 0)
+		res, err := dbSession.Exec(append([]any{rawSQL}, query.GetArgs()...)...)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/infra/serverlock/serverlock.go
+++ b/pkg/infra/serverlock/serverlock.go
@@ -78,6 +78,19 @@ func (sl *ServerLockService) LockAndExecute(ctx context.Context, actionName stri
 	return nil
 }
 
+type updateVersionQuery struct {
+	sqltemplate.SQLTemplate
+	ServerLockTable string
+	Version         int64
+	LastExecution   int64
+	OperationUID    string
+	PreviousVersion int64
+}
+
+func (updateVersionQuery) Validate() error {
+	return nil
+}
+
 func (sl *ServerLockService) acquireLock(ctx context.Context, serverLock *serverLock) (bool, error) {
 	ctx, span := sl.tracer.Start(ctx, "ServerLockService.acquireLock")
 	defer span.End()
@@ -114,6 +127,16 @@ func (sl *ServerLockService) acquireLock(ctx context.Context, serverLock *server
 	})
 
 	return result, err
+}
+
+type getLockQuery struct {
+	sqltemplate.SQLTemplate
+	ServerLockTable string
+	OperationUID    string
+}
+
+func (getLockQuery) Validate() error {
+	return nil
 }
 
 func (sl *ServerLockService) getOrCreate(ctx context.Context, actionName string) (*serverLock, error) {
@@ -266,6 +289,27 @@ func lockWait(minWait time.Duration, maxWait time.Duration) time.Duration {
 	return time.Duration(rand.Int63n(int64(maxWait-minWait)) + int64(minWait))
 }
 
+type getLockForUpdateQuery struct {
+	sqltemplate.SQLTemplate
+	ServerLockTable string
+	OperationUID    string
+}
+
+func (getLockForUpdateQuery) Validate() error {
+	return nil
+}
+
+type updateLastExecutionQuery struct {
+	sqltemplate.SQLTemplate
+	ServerLockTable string
+	LastExecution   int64
+	OperationUID    string
+}
+
+func (updateLastExecutionQuery) Validate() error {
+	return nil
+}
+
 // acquireForRelease will check if the lock is already on the database, if it is, will check with maxInterval if it is
 // timeouted. Returns nil error if the lock was acquired correctly
 func (sl *ServerLockService) acquireForRelease(ctx context.Context, actionName string, maxInterval time.Duration) error {
@@ -343,6 +387,16 @@ func (sl *ServerLockService) acquireForRelease(ctx context.Context, actionName s
 	return err
 }
 
+type releaseLockQuery struct {
+	sqltemplate.SQLTemplate
+	ServerLockTable string
+	OperationUID    string
+}
+
+func (releaseLockQuery) Validate() error {
+	return nil
+}
+
 // releaseLock will delete the row at the database. This is only intended to be used within the scope of LockExecuteAndRelease
 // method, but not as to manually release a Lock
 func (sl *ServerLockService) releaseLock(ctx context.Context, actionName string) error {
@@ -407,6 +461,18 @@ func (sl *ServerLockService) executeFunc(ctx context.Context, actionName string,
 	fn(ctx)
 
 	ctxLogger.Debug("Execution finished", "actionName", actionName, "duration", time.Since(start))
+}
+
+type createLockQuery struct {
+	sqltemplate.SQLTemplate
+	ServerLockTable string
+	OperationUID    string
+	LastExecution   int64
+	Version         int64
+}
+
+func (createLockQuery) Validate() error {
+	return nil
 }
 
 func (sl *ServerLockService) createLock(ctx context.Context,

--- a/pkg/infra/serverlock/serverlock_integration_test.go
+++ b/pkg/infra/serverlock/serverlock_integration_test.go
@@ -14,7 +14,7 @@ import (
 func TestIntegrationServerLock_LockAndExecute(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 
-	sl := createTestableServerLock(t)
+	sl, _ := createTestableServerLock(t)
 
 	counter := 0
 	fn := func(context.Context) { counter++ }
@@ -42,7 +42,7 @@ func TestIntegrationServerLock_LockExecuteAndRelease(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 
 	t.Run("lock is released", func(t *testing.T) {
-		sl := createTestableServerLock(t)
+		sl, _ := createTestableServerLock(t)
 
 		counter := 0
 		fn := func(context.Context) { counter++ }
@@ -65,7 +65,7 @@ func TestIntegrationServerLock_LockExecuteAndRelease(t *testing.T) {
 	})
 
 	t.Run("lock is released when context is cancelled", func(t *testing.T) {
-		sl := createTestableServerLock(t)
+		sl, store := createTestableServerLock(t)
 		operationUID := "test-operation-context-cancel"
 
 		ctx, cancel := context.WithCancel(context.Background())
@@ -76,7 +76,7 @@ func TestIntegrationServerLock_LockExecuteAndRelease(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		err = sl.SQLStore.WithDbSession(context.Background(), func(sess *db.Session) error {
+		err = store.WithDbSession(context.Background(), func(sess *db.Session) error {
 			lockRows := []*serverLock{}
 			err := sess.Where("operation_uid = ?", operationUID).Find(&lockRows)
 			require.NoError(t, err)
@@ -91,7 +91,7 @@ func TestIntegrationServerLock_LockExecuteAndReleaseWithRetries(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 
 	t.Run("retries when lock is already taken", func(t *testing.T) {
-		sl := createTestableServerLock(t)
+		sl, _ := createTestableServerLock(t)
 
 		retries := 0
 		expectedRetries := 10
@@ -150,7 +150,7 @@ func TestIntegrationServerLock_LockExecuteAndReleaseWithRetries(t *testing.T) {
 	})
 
 	t.Run("lock is released when context is cancelled", func(t *testing.T) {
-		sl := createTestableServerLock(t)
+		sl, store := createTestableServerLock(t)
 		operationUID := "test-operation-context-cancel-retries"
 
 		ctx, cancel := context.WithCancel(context.Background())
@@ -167,7 +167,7 @@ func TestIntegrationServerLock_LockExecuteAndReleaseWithRetries(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		err = sl.SQLStore.WithDbSession(context.Background(), func(sess *db.Session) error {
+		err = store.WithDbSession(context.Background(), func(sess *db.Session) error {
 			lockRows := []*serverLock{}
 			err := sess.Where("operation_uid = ?", operationUID).Find(&lockRows)
 			require.NoError(t, err)

--- a/pkg/infra/serverlock/serverlock_sql_test.go
+++ b/pkg/infra/serverlock/serverlock_sql_test.go
@@ -1,0 +1,150 @@
+package serverlock
+
+import (
+	"context"
+	"database/sql/driver"
+	"regexp"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/infra/db/dbtest"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/infra/tracing"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
+	"github.com/grafana/grafana/pkg/storage/legacysql"
+	"github.com/grafana/grafana/pkg/util/xorm"
+	"github.com/grafana/grafana/pkg/util/xorm/core"
+)
+
+var registerServerLockSQLMockXormDriverOnce sync.Once
+
+type serverLockSQLMockXormDriver struct{}
+
+func (serverLockSQLMockXormDriver) Parse(string, string) (*core.Uri, error) {
+	return &core.Uri{DbType: core.SQLITE}, nil
+}
+
+type serverLockSQLMockDB struct {
+	dbtest.FakeDB
+	engine *xorm.Engine
+}
+
+func (d *serverLockSQLMockDB) WithDbSession(ctx context.Context, callback sqlstore.DBTransactionFunc) error {
+	sess := &sqlstore.DBSession{Session: d.engine.NewSession()}
+	defer sess.Close()
+	return callback(sess)
+}
+
+func (d *serverLockSQLMockDB) WithTransactionalDbSession(ctx context.Context, callback sqlstore.DBTransactionFunc) error {
+	sess := &sqlstore.DBSession{Session: d.engine.NewSession()}
+	defer sess.Close()
+	return callback(sess)
+}
+
+func (d *serverLockSQLMockDB) GetDBType() core.DbType {
+	return core.SQLITE
+}
+
+type int64Arg struct{}
+
+func (int64Arg) Match(value driver.Value) bool {
+	_, ok := value.(int64)
+	return ok
+}
+
+func TestServerLockUsesProviderTable(t *testing.T) {
+	registerServerLockSQLMockXormDriverOnce.Do(func() {
+		if core.QueryDriver("sqlmock") == nil {
+			core.RegisterDriver("sqlmock", serverLockSQLMockXormDriver{})
+		}
+	})
+
+	dsn := "serverlock"
+	mockDB, mock, err := sqlmock.NewWithDSN(dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = mockDB.Close() })
+
+	engine, err := xorm.NewEngine("sqlmock", dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = engine.Close() })
+
+	legacyDB := &serverLockSQLMockDB{engine: engine}
+	providerCalls := 0
+	type contextKey struct{}
+	ctx := context.WithValue(context.Background(), contextKey{}, "request-context")
+	svc := &ServerLockService{
+		sql: func(ctx context.Context) (*legacysql.LegacyDatabaseHelper, error) {
+			require.Equal(t, "request-context", ctx.Value(contextKey{}))
+			providerCalls++
+			return &legacysql.LegacyDatabaseHelper{
+				DB: legacyDB,
+				Table: func(n string) string {
+					return "test_schema." + n
+				},
+			}, nil
+		},
+		tracer: tracing.InitializeTracerForTest(),
+		log:    log.New("test-logger"),
+	}
+
+	updateVersionSQL := regexp.QuoteMeta(`UPDATE "test_schema"."server_lock"
+SET version = ?,
+    last_execution = ?
+WHERE operation_uid = ?
+  AND version = ?;`)
+	mock.ExpectExec(updateVersionSQL).
+		WithArgs(int64(3), int64Arg{}, "update", int64(2)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	acquired, err := svc.acquireLock(ctx, &serverLock{OperationUID: "update", Version: 2})
+	require.NoError(t, err)
+	require.True(t, acquired)
+
+	getLockSQL := regexp.QuoteMeta(`SELECT *
+FROM "test_schema"."server_lock"
+WHERE operation_uid = ?;`)
+	mock.ExpectQuery(getLockSQL).
+		WithArgs("create").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "operation_uid", "last_execution", "version"}))
+
+	createLockSQL := regexp.QuoteMeta(`INSERT INTO "test_schema"."server_lock" (operation_uid, last_execution, version)
+VALUES (?, ?, ?);`)
+	mock.ExpectExec(createLockSQL).
+		WithArgs("create", int64(0), int64(0)).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	_, err = svc.getOrCreate(ctx, "create")
+	require.NoError(t, err)
+
+	getLockForUpdateSQL := regexp.QuoteMeta(`SELECT *
+FROM "test_schema"."server_lock"
+WHERE operation_uid = ?
+;`)
+	mock.ExpectQuery(getLockForUpdateSQL).
+		WithArgs("expired").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "operation_uid", "last_execution", "version"}).
+			AddRow(int64(1), "expired", int64(1), int64(0)))
+
+	updateLastExecutionSQL := regexp.QuoteMeta(`UPDATE "test_schema"."server_lock"
+SET last_execution = ?
+WHERE operation_uid = ?;`)
+	mock.ExpectExec(updateLastExecutionSQL).
+		WithArgs(int64Arg{}, "expired").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	require.NoError(t, svc.acquireForRelease(ctx, "expired", time.Hour))
+
+	releaseLockSQL := regexp.QuoteMeta(`DELETE FROM "test_schema"."server_lock"
+WHERE operation_uid = ?;`)
+	mock.ExpectExec(releaseLockSQL).
+		WithArgs("release").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	require.NoError(t, svc.releaseLock(ctx, "release"))
+	require.Equal(t, 4, providerCalls)
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/pkg/infra/serverlock/serverlock_test.go
+++ b/pkg/infra/serverlock/serverlock_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
+	"github.com/grafana/grafana/pkg/storage/legacysql"
 	"github.com/grafana/grafana/pkg/tests/testsuite"
 	"github.com/grafana/grafana/pkg/util/testutil"
 )
@@ -19,22 +20,22 @@ func TestMain(m *testing.M) {
 	testsuite.Run(m)
 }
 
-func createTestableServerLock(t *testing.T) *ServerLockService {
+func createTestableServerLock(t *testing.T) (*ServerLockService, db.DB) {
 	t.Helper()
 
 	store := db.InitTestDB(t)
 
 	return &ServerLockService{
-		SQLStore: store,
-		tracer:   tracing.InitializeTracerForTest(),
-		log:      log.New("test-logger"),
-	}
+		sql:    legacysql.NewDatabaseProvider(store),
+		tracer: tracing.InitializeTracerForTest(),
+		log:    log.New("test-logger"),
+	}, store
 }
 
 func TestIntegrationServerLock(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 
-	sl := createTestableServerLock(t)
+	sl, _ := createTestableServerLock(t)
 	operationUID := "test-operation"
 
 	first, err := sl.getOrCreate(context.Background(), operationUID)
@@ -75,7 +76,7 @@ func TestIntegrationLockAndRelease(t *testing.T) {
 	operationUID := "test-operation-release"
 
 	t.Run("create lock and then release it", func(t *testing.T) {
-		sl := createTestableServerLock(t)
+		sl, _ := createTestableServerLock(t)
 		duration := time.Hour * 5
 
 		err := sl.acquireForRelease(context.Background(), operationUID, duration)
@@ -93,7 +94,7 @@ func TestIntegrationLockAndRelease(t *testing.T) {
 	})
 
 	t.Run("try to acquire a lock which is already locked, get error", func(t *testing.T) {
-		sl := createTestableServerLock(t)
+		sl, _ := createTestableServerLock(t)
 		duration := time.Hour * 5
 
 		err := sl.acquireForRelease(context.Background(), operationUID, duration)
@@ -108,7 +109,7 @@ func TestIntegrationLockAndRelease(t *testing.T) {
 	})
 
 	t.Run("lock already exists but is timeouted", func(t *testing.T) {
-		sl := createTestableServerLock(t)
+		sl, store := createTestableServerLock(t)
 		pastLastExec := time.Now().Add(-time.Hour).Unix()
 		lock := serverLock{
 			OperationUID:  operationUID,
@@ -116,7 +117,7 @@ func TestIntegrationLockAndRelease(t *testing.T) {
 		}
 
 		// inserting a row with lock in the past
-		err := sl.SQLStore.WithTransactionalDbSession(context.Background(), func(sess *db.Session) error {
+		err := store.WithTransactionalDbSession(context.Background(), func(sess *db.Session) error {
 			affectedRows, err := sess.Insert(&lock)
 			require.NoError(t, err)
 			require.Equal(t, int64(1), affectedRows)
@@ -130,7 +131,7 @@ func TestIntegrationLockAndRelease(t *testing.T) {
 		require.NoError(t, err)
 
 		//validate that the lock LastExecution was updated (at least different from the original)
-		err = sl.SQLStore.WithTransactionalDbSession(context.Background(), func(sess *db.Session) error {
+		err = store.WithTransactionalDbSession(context.Background(), func(sess *db.Session) error {
 			lockRows := []*serverLock{}
 			err := sess.Where("operation_uid = ?", operationUID).Find(&lockRows)
 			require.NoError(t, err)

--- a/pkg/infra/serverlock/templates.go
+++ b/pkg/infra/serverlock/templates.go
@@ -4,8 +4,6 @@ import (
 	"embed"
 	"fmt"
 	"text/template"
-
-	"github.com/grafana/grafana/pkg/storage/unified/sql/sqltemplate"
 )
 
 var (
@@ -27,70 +25,4 @@ func mustTemplate(filename string) *template.Template {
 		return tmpl
 	}
 	panic(fmt.Sprintf("template file not found: %s", filename))
-}
-
-type updateVersionQuery struct {
-	sqltemplate.SQLTemplate
-	ServerLockTable string
-	Version         int64
-	LastExecution   int64
-	OperationUID    string
-	PreviousVersion int64
-}
-
-func (updateVersionQuery) Validate() error {
-	return nil
-}
-
-type getLockQuery struct {
-	sqltemplate.SQLTemplate
-	ServerLockTable string
-	OperationUID    string
-}
-
-func (getLockQuery) Validate() error {
-	return nil
-}
-
-type getLockForUpdateQuery struct {
-	sqltemplate.SQLTemplate
-	ServerLockTable string
-	OperationUID    string
-}
-
-func (getLockForUpdateQuery) Validate() error {
-	return nil
-}
-
-type updateLastExecutionQuery struct {
-	sqltemplate.SQLTemplate
-	ServerLockTable string
-	LastExecution   int64
-	OperationUID    string
-}
-
-func (updateLastExecutionQuery) Validate() error {
-	return nil
-}
-
-type releaseLockQuery struct {
-	sqltemplate.SQLTemplate
-	ServerLockTable string
-	OperationUID    string
-}
-
-func (releaseLockQuery) Validate() error {
-	return nil
-}
-
-type createLockQuery struct {
-	sqltemplate.SQLTemplate
-	ServerLockTable string
-	OperationUID    string
-	LastExecution   int64
-	Version         int64
-}
-
-func (createLockQuery) Validate() error {
-	return nil
 }

--- a/pkg/infra/serverlock/templates.go
+++ b/pkg/infra/serverlock/templates.go
@@ -1,0 +1,96 @@
+package serverlock
+
+import (
+	"embed"
+	"fmt"
+	"text/template"
+
+	"github.com/grafana/grafana/pkg/storage/unified/sql/sqltemplate"
+)
+
+var (
+	//go:embed queries/*.sql
+	sqlTemplatesFS embed.FS
+
+	sqlTemplates = template.Must(template.New("sql").ParseFS(sqlTemplatesFS, "queries/*.sql"))
+
+	updateVersionTemplate       = mustTemplate("update_version.sql")
+	getLockTemplate             = mustTemplate("get_lock.sql")
+	getLockForUpdateTemplate    = mustTemplate("get_lock_for_update.sql")
+	updateLastExecutionTemplate = mustTemplate("update_last_execution.sql")
+	releaseLockTemplate         = mustTemplate("release_lock.sql")
+	createLockTemplate          = mustTemplate("create_lock.sql")
+)
+
+func mustTemplate(filename string) *template.Template {
+	if tmpl := sqlTemplates.Lookup(filename); tmpl != nil {
+		return tmpl
+	}
+	panic(fmt.Sprintf("template file not found: %s", filename))
+}
+
+type updateVersionQuery struct {
+	sqltemplate.SQLTemplate
+	ServerLockTable string
+	Version         int64
+	LastExecution   int64
+	OperationUID    string
+	PreviousVersion int64
+}
+
+func (updateVersionQuery) Validate() error {
+	return nil
+}
+
+type getLockQuery struct {
+	sqltemplate.SQLTemplate
+	ServerLockTable string
+	OperationUID    string
+}
+
+func (getLockQuery) Validate() error {
+	return nil
+}
+
+type getLockForUpdateQuery struct {
+	sqltemplate.SQLTemplate
+	ServerLockTable string
+	OperationUID    string
+}
+
+func (getLockForUpdateQuery) Validate() error {
+	return nil
+}
+
+type updateLastExecutionQuery struct {
+	sqltemplate.SQLTemplate
+	ServerLockTable string
+	LastExecution   int64
+	OperationUID    string
+}
+
+func (updateLastExecutionQuery) Validate() error {
+	return nil
+}
+
+type releaseLockQuery struct {
+	sqltemplate.SQLTemplate
+	ServerLockTable string
+	OperationUID    string
+}
+
+func (releaseLockQuery) Validate() error {
+	return nil
+}
+
+type createLockQuery struct {
+	sqltemplate.SQLTemplate
+	ServerLockTable string
+	OperationUID    string
+	LastExecution   int64
+	Version         int64
+}
+
+func (createLockQuery) Validate() error {
+	return nil
+}

--- a/pkg/infra/serverlock/templates_test.go
+++ b/pkg/infra/serverlock/templates_test.go
@@ -1,0 +1,95 @@
+package serverlock
+
+import (
+	"testing"
+	"text/template"
+
+	"github.com/grafana/grafana/pkg/storage/legacysql"
+	"github.com/grafana/grafana/pkg/storage/unified/sql/sqltemplate"
+	"github.com/grafana/grafana/pkg/storage/unified/sql/sqltemplate/mocks"
+)
+
+func TestTemplates(t *testing.T) {
+	nodb := &legacysql.LegacyDatabaseHelper{
+		Table: func(n string) string {
+			return "test_schema." + n
+		},
+	}
+
+	newTemplate := func() sqltemplate.SQLTemplate {
+		return mocks.NewTestingSQLTemplate()
+	}
+
+	mocks.CheckQuerySnapshots(t, mocks.TemplateTestSetup{
+		RootDir:        "testdata",
+		SQLTemplatesFS: sqlTemplatesFS,
+		Templates: map[*template.Template][]mocks.TemplateTestCase{
+			updateVersionTemplate: {
+				{
+					Name: "update_version",
+					Data: &updateVersionQuery{
+						SQLTemplate:     newTemplate(),
+						ServerLockTable: nodb.Table("server_lock"),
+						Version:         2,
+						LastExecution:   123,
+						OperationUID:    "test-operation",
+						PreviousVersion: 1,
+					},
+				},
+			},
+			getLockTemplate: {
+				{
+					Name: "get_lock",
+					Data: &getLockQuery{
+						SQLTemplate:     newTemplate(),
+						ServerLockTable: nodb.Table("server_lock"),
+						OperationUID:    "test-operation",
+					},
+				},
+			},
+			getLockForUpdateTemplate: {
+				{
+					Name: "get_lock_for_update",
+					Data: &getLockForUpdateQuery{
+						SQLTemplate:     newTemplate(),
+						ServerLockTable: nodb.Table("server_lock"),
+						OperationUID:    "test-operation",
+					},
+				},
+			},
+			updateLastExecutionTemplate: {
+				{
+					Name: "update_last_execution",
+					Data: &updateLastExecutionQuery{
+						SQLTemplate:     newTemplate(),
+						ServerLockTable: nodb.Table("server_lock"),
+						LastExecution:   123,
+						OperationUID:    "test-operation",
+					},
+				},
+			},
+			releaseLockTemplate: {
+				{
+					Name: "release_lock",
+					Data: &releaseLockQuery{
+						SQLTemplate:     newTemplate(),
+						ServerLockTable: nodb.Table("server_lock"),
+						OperationUID:    "test-operation",
+					},
+				},
+			},
+			createLockTemplate: {
+				{
+					Name: "create_lock",
+					Data: &createLockQuery{
+						SQLTemplate:     newTemplate(),
+						ServerLockTable: nodb.Table("server_lock"),
+						OperationUID:    "test-operation",
+						LastExecution:   123,
+						Version:         0,
+					},
+				},
+			},
+		},
+	})
+}

--- a/pkg/infra/serverlock/testdata/mysql--create_lock-create_lock.sql
+++ b/pkg/infra/serverlock/testdata/mysql--create_lock-create_lock.sql
@@ -1,0 +1,2 @@
+INSERT INTO `test_schema`.`server_lock` (operation_uid, last_execution, version)
+VALUES ('test-operation', 123, 0);

--- a/pkg/infra/serverlock/testdata/mysql--get_lock-get_lock.sql
+++ b/pkg/infra/serverlock/testdata/mysql--get_lock-get_lock.sql
@@ -1,0 +1,3 @@
+SELECT *
+FROM `test_schema`.`server_lock`
+WHERE operation_uid = 'test-operation';

--- a/pkg/infra/serverlock/testdata/mysql--get_lock_for_update-get_lock_for_update.sql
+++ b/pkg/infra/serverlock/testdata/mysql--get_lock_for_update-get_lock_for_update.sql
@@ -1,0 +1,4 @@
+SELECT *
+FROM `test_schema`.`server_lock`
+WHERE operation_uid = 'test-operation'
+FOR UPDATE;

--- a/pkg/infra/serverlock/testdata/mysql--release_lock-release_lock.sql
+++ b/pkg/infra/serverlock/testdata/mysql--release_lock-release_lock.sql
@@ -1,0 +1,2 @@
+DELETE FROM `test_schema`.`server_lock`
+WHERE operation_uid = 'test-operation';

--- a/pkg/infra/serverlock/testdata/mysql--update_last_execution-update_last_execution.sql
+++ b/pkg/infra/serverlock/testdata/mysql--update_last_execution-update_last_execution.sql
@@ -1,0 +1,3 @@
+UPDATE `test_schema`.`server_lock`
+SET last_execution = 123
+WHERE operation_uid = 'test-operation';

--- a/pkg/infra/serverlock/testdata/mysql--update_version-update_version.sql
+++ b/pkg/infra/serverlock/testdata/mysql--update_version-update_version.sql
@@ -1,0 +1,5 @@
+UPDATE `test_schema`.`server_lock`
+SET version = 2,
+    last_execution = 123
+WHERE operation_uid = 'test-operation'
+  AND version = 1;

--- a/pkg/infra/serverlock/testdata/postgres--create_lock-create_lock.sql
+++ b/pkg/infra/serverlock/testdata/postgres--create_lock-create_lock.sql
@@ -1,0 +1,2 @@
+INSERT INTO "test_schema"."server_lock" (operation_uid, last_execution, version)
+VALUES ('test-operation', 123, 0) ON CONFLICT DO NOTHING RETURNING id;

--- a/pkg/infra/serverlock/testdata/postgres--get_lock-get_lock.sql
+++ b/pkg/infra/serverlock/testdata/postgres--get_lock-get_lock.sql
@@ -1,0 +1,3 @@
+SELECT *
+FROM "test_schema"."server_lock"
+WHERE operation_uid = 'test-operation';

--- a/pkg/infra/serverlock/testdata/postgres--get_lock_for_update-get_lock_for_update.sql
+++ b/pkg/infra/serverlock/testdata/postgres--get_lock_for_update-get_lock_for_update.sql
@@ -1,0 +1,4 @@
+SELECT *
+FROM "test_schema"."server_lock"
+WHERE operation_uid = 'test-operation'
+FOR UPDATE;

--- a/pkg/infra/serverlock/testdata/postgres--release_lock-release_lock.sql
+++ b/pkg/infra/serverlock/testdata/postgres--release_lock-release_lock.sql
@@ -1,0 +1,2 @@
+DELETE FROM "test_schema"."server_lock"
+WHERE operation_uid = 'test-operation';

--- a/pkg/infra/serverlock/testdata/postgres--update_last_execution-update_last_execution.sql
+++ b/pkg/infra/serverlock/testdata/postgres--update_last_execution-update_last_execution.sql
@@ -1,0 +1,3 @@
+UPDATE "test_schema"."server_lock"
+SET last_execution = 123
+WHERE operation_uid = 'test-operation';

--- a/pkg/infra/serverlock/testdata/postgres--update_version-update_version.sql
+++ b/pkg/infra/serverlock/testdata/postgres--update_version-update_version.sql
@@ -1,0 +1,5 @@
+UPDATE "test_schema"."server_lock"
+SET version = 2,
+    last_execution = 123
+WHERE operation_uid = 'test-operation'
+  AND version = 1;

--- a/pkg/infra/serverlock/testdata/sqlite--create_lock-create_lock.sql
+++ b/pkg/infra/serverlock/testdata/sqlite--create_lock-create_lock.sql
@@ -1,0 +1,2 @@
+INSERT INTO "test_schema"."server_lock" (operation_uid, last_execution, version)
+VALUES ('test-operation', 123, 0);

--- a/pkg/infra/serverlock/testdata/sqlite--get_lock-get_lock.sql
+++ b/pkg/infra/serverlock/testdata/sqlite--get_lock-get_lock.sql
@@ -1,0 +1,3 @@
+SELECT *
+FROM "test_schema"."server_lock"
+WHERE operation_uid = 'test-operation';

--- a/pkg/infra/serverlock/testdata/sqlite--get_lock_for_update-get_lock_for_update.sql
+++ b/pkg/infra/serverlock/testdata/sqlite--get_lock_for_update-get_lock_for_update.sql
@@ -1,0 +1,4 @@
+SELECT *
+FROM "test_schema"."server_lock"
+WHERE operation_uid = 'test-operation'
+;

--- a/pkg/infra/serverlock/testdata/sqlite--release_lock-release_lock.sql
+++ b/pkg/infra/serverlock/testdata/sqlite--release_lock-release_lock.sql
@@ -1,0 +1,2 @@
+DELETE FROM "test_schema"."server_lock"
+WHERE operation_uid = 'test-operation';

--- a/pkg/infra/serverlock/testdata/sqlite--update_last_execution-update_last_execution.sql
+++ b/pkg/infra/serverlock/testdata/sqlite--update_last_execution-update_last_execution.sql
@@ -1,0 +1,3 @@
+UPDATE "test_schema"."server_lock"
+SET last_execution = 123
+WHERE operation_uid = 'test-operation';

--- a/pkg/infra/serverlock/testdata/sqlite--update_version-update_version.sql
+++ b/pkg/infra/serverlock/testdata/sqlite--update_version-update_version.sql
@@ -1,0 +1,5 @@
+UPDATE "test_schema"."server_lock"
+SET version = 2,
+    last_execution = 123
+WHERE operation_uid = 'test-operation'
+  AND version = 1;

--- a/pkg/server/bootstrap/wire/wire_gen.go
+++ b/pkg/server/bootstrap/wire/wire_gen.go
@@ -387,7 +387,7 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts server.Options, apiO
 	}
 	actionSetService := resourcepermissions.NewActionSetService()
 	permissionRegistry := permreg.ProvidePermissionRegistry()
-	serverLockService := serverlock.ProvideService(sqlStore, tracingService)
+	serverLockService := serverlock.ProvideService(legacyDatabaseProvider, tracingService)
 	registerer := metrics.ProvideRegisterer()
 	storeProvider := store2.ProvideDefaultStoreProvider()
 	v := authz.ProvideReconcileCRDs()
@@ -1149,7 +1149,7 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 	}
 	actionSetService := resourcepermissions.NewActionSetService()
 	permissionRegistry := permreg.ProvidePermissionRegistry()
-	serverLockService := serverlock.ProvideService(sqlStore, tracingService)
+	serverLockService := serverlock.ProvideService(legacyDatabaseProvider, tracingService)
 	registerer := metrics.ProvideRegistererForTest()
 	storeProvider := store2.ProvideDefaultStoreProvider()
 	v := authz.ProvideReconcileCRDs()
@@ -1884,7 +1884,7 @@ func InitializeForCLI(ctx context.Context, cfg *setting.Cfg) (server.Runner, err
 	secretDBMigrator := migrator.NewWithEngine(sqlStore)
 	actionSetService := resourcepermissions.NewActionSetService()
 	permissionRegistry := permreg.ProvidePermissionRegistry()
-	serverLockService := serverlock.ProvideService(sqlStore, tracingService)
+	serverLockService := serverlock.ProvideService(legacyDatabaseProvider, tracingService)
 	storeProvider := store2.ProvideDefaultStoreProvider()
 	v := authz.ProvideReconcileCRDs()
 	defaultElector := leaderelection.NewDefaultElector()

--- a/pkg/services/dashboards/service/dashboard_service_test.go
+++ b/pkg/services/dashboards/service/dashboard_service_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/storage/legacysql"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 	"github.com/grafana/grafana/pkg/storage/unified/search/builders"
@@ -2212,7 +2213,7 @@ func TestIntegrationK8sDashboardCleanupJob(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// Setup test database and utilities
 			sqlStore, _ := sqlstore.InitTestDB(t)
-			lockService := serverlock.ProvideService(sqlStore, tracing.InitializeTracerForTest())
+			lockService := serverlock.ProvideService(legacysql.NewDatabaseProvider(sqlStore), tracing.InitializeTracerForTest())
 			kv := kvstore.NewFakeKVStore()
 
 			fakePublicDashboardService := publicdashboards.NewFakePublicDashboardServiceWrapper(t)
@@ -2249,7 +2250,7 @@ func TestIntegrationK8sDashboardCleanupJob(t *testing.T) {
 	t.Run("Should start and stop background job correctly", func(t *testing.T) {
 		// Setup test database and utilities
 		sqlStore, _ := sqlstore.InitTestDB(t)
-		lockService := serverlock.ProvideService(sqlStore, tracing.InitializeTracerForTest())
+		lockService := serverlock.ProvideService(legacysql.NewDatabaseProvider(sqlStore), tracing.InitializeTracerForTest())
 
 		cfg := setting.NewCfg()
 		cfg.K8sDashboardCleanup = setting.K8sDashboardCleanupSettings{

--- a/pkg/services/ngalert/testutil/testutil.go
+++ b/pkg/services/ngalert/testutil/testutil.go
@@ -28,6 +28,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/search/sort"
 	"github.com/grafana/grafana/pkg/services/supportbundles/supportbundlestest"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/storage/legacysql"
 	"github.com/grafana/grafana/pkg/storage/legacysql/dualwrite"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	resourcepb "github.com/grafana/grafana/pkg/storage/unified/resourcepb"
@@ -66,7 +67,7 @@ func SetupDashboardService(tb testing.TB, sqlStore db.DB, cfg *setting.Cfg) *das
 		nil,
 		nil,
 		dualwrite.ProvideTestService(),
-		serverlock.ProvideService(sqlStore, tracing.InitializeTracerForTest()),
+		serverlock.ProvideService(legacysql.NewDatabaseProvider(sqlStore), tracing.InitializeTracerForTest()),
 		kvstore.NewFakeKVStore(),
 		dashclient.NewK8sClientWithFallback(
 			cfg,

--- a/pkg/services/oauthtoken/oauth_token_test.go
+++ b/pkg/services/oauthtoken/oauth_token_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/login"
 	"github.com/grafana/grafana/pkg/services/login/authinfotest"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/storage/legacysql"
 	"github.com/grafana/grafana/pkg/tests/testsuite"
 	"github.com/grafana/grafana/pkg/util/testutil"
 )
@@ -331,7 +332,7 @@ func TestIntegration_TryTokenRefresh(t *testing.T) {
 			env := environment{
 				sessionService:  authtest.NewMockUserAuthTokenService(t),
 				authInfoService: authinfotest.NewMockAuthInfoService(t),
-				serverLock:      serverlock.ProvideService(store, tracing.InitializeTracerForTest()),
+				serverLock:      serverlock.ProvideService(legacysql.NewDatabaseProvider(store), tracing.InitializeTracerForTest()),
 				socialConnector: socialConnector,
 				socialService: &socialtest.FakeSocialService{
 					ExpectedConnector: socialConnector,
@@ -631,7 +632,7 @@ func TestIntegration_TryTokenRefresh_WithExternalSessions(t *testing.T) {
 			env := environment{
 				sessionService:  authtest.NewMockUserAuthTokenService(t),
 				authInfoService: authinfotest.NewMockAuthInfoService(t),
-				serverLock:      serverlock.ProvideService(store, tracing.InitializeTracerForTest()),
+				serverLock:      serverlock.ProvideService(legacysql.NewDatabaseProvider(store), tracing.InitializeTracerForTest()),
 				socialConnector: socialConnector,
 				socialService: &socialtest.FakeSocialService{
 					ExpectedConnector: socialConnector,
@@ -1080,7 +1081,7 @@ func TestIntegration_GetCurrentOAuthToken(t *testing.T) {
 			env := environment{
 				sessionService:  authtest.NewMockUserAuthTokenService(t),
 				authInfoService: authinfotest.NewMockAuthInfoService(t),
-				serverLock:      serverlock.ProvideService(store, tracing.InitializeTracerForTest()),
+				serverLock:      serverlock.ProvideService(legacysql.NewDatabaseProvider(store), tracing.InitializeTracerForTest()),
 				socialConnector: socialConnector,
 				socialService: &socialtest.FakeSocialService{
 					ExpectedConnector: socialConnector,
@@ -1380,7 +1381,7 @@ func TestIntegration_GetCurrentOAuthToken_WithExternalSessions(t *testing.T) {
 			env := environment{
 				sessionService:  authtest.NewMockUserAuthTokenService(t),
 				authInfoService: authinfotest.NewMockAuthInfoService(t),
-				serverLock:      serverlock.ProvideService(store, tracing.InitializeTracerForTest()),
+				serverLock:      serverlock.ProvideService(legacysql.NewDatabaseProvider(store), tracing.InitializeTracerForTest()),
 				socialConnector: socialConnector,
 				socialService: &socialtest.FakeSocialService{
 					ExpectedConnector: socialConnector,

--- a/pkg/services/quota/quotaimpl/quota_test.go
+++ b/pkg/services/quota/quotaimpl/quota_test.go
@@ -530,7 +530,7 @@ func setupEnv(t *testing.T, sqlStore db.DB, cfg *setting.Cfg, b bus.Bus, quotaSe
 		orgService,
 		nil,
 		dualwrite.ProvideTestService(),
-		serverlock.ProvideService(sqlStore, tracing.InitializeTracerForTest()),
+		serverlock.ProvideService(legacysql.NewDatabaseProvider(sqlStore), tracing.InitializeTracerForTest()),
 		kvstore.NewFakeKVStore(),
 		dashclient.NewK8sClientWithFallback(
 			cfg,


### PR DESCRIPTION
## Summary

Migrates `serverlock` from direct raw SQL access to the legacy SQL provider and template pattern used by other stores.

- `serverlock.ProvideService` now accepts `legacysql.LegacyDatabaseProvider`.
- Each lock operation resolves its helper from the operation context.
- The lock service renders its reads, updates, inserts, and deletes from embedded SQL templates.
- Table identifiers are resolved through `LegacyDatabaseHelper.Table` and dialect-quoted with `{{ .Ident ... }}`.
- Runtime values are bound with `{{ .Arg ... }}`.
- Dialect-specific row locking and PostgreSQL conflict handling are preserved.
- Standard construction sites explicitly use `legacysql.NewDatabaseProvider`.
- Wire output was regenerated.

The AuthN session-client context and Enterprise wiring rationale are documented in the companion Enterprise PR: https://github.com/grafana/grafana-enterprise/pull/12715

## Prior Art

This follows established patterns in the repository:

- `pkg/registry/apis/collections/legacy` for resolving a legacy database provider at operation time.
- `pkg/services/authz/rbac/store` for provider-backed query construction and execution.
- `pkg/extensions/apiserver/registry/iam/role/legacy` for embedded SQL templates and cross-dialect snapshot coverage.

## Testing

- `go test ./pkg/infra/serverlock`
- `go test ./pkg/server -run "^$"`
- `make gen-go`
- `make update-workspace`

The serverlock tests include:

- MySQL, PostgreSQL, and SQLite SQL-rendering snapshots using qualified test identifiers.
- SQL-mock execution coverage that verifies the injected provider is called with the request context and every lock statement uses its resolved table name and expected arguments.