### PR TITLE
[Patch slow] Auth: Fix login for Grafana.com users with no basic role on Cloud (#128719)

### DIFF
--- a/pkg/services/authn/authnimpl/sync/rbac_sync.go
+++ b/pkg/services/authn/authnimpl/sync/rbac_sync.go
@@ -232,6 +232,10 @@ func (s *RBACSync) cloudRolesToAddAndRemove(ident *authn.Identity) ([]string, []
 	// Since Cloud Admin/Editor/Viewer roles are not yet implemented one-to-one in the Grafana, it becomes a confusing experience for users,
 	// therefore we are doing granular mapping of all available functionality in the Grafana temporary.
 	var fixedCloudRoles = map[org.RoleType][]string{
+		// A user with no basic role (None) maps to no cloud roles. It is still a
+		// valid role, so login must not be blocked; any previously assigned cloud
+		// roles are removed below.
+		org.RoleNone:   {},
 		org.RoleViewer: {accesscontrol.FixedCloudViewerRole},
 		org.RoleEditor: {accesscontrol.FixedCloudEditorRole},
 		org.RoleAdmin:  {accesscontrol.FixedCloudAdminRole},
@@ -302,6 +306,13 @@ func (s *RBACSync) SyncCloudRoles(ctx context.Context, ident *authn.Identity, r 
 	}
 
 	rolesToAdd, rolesToRemove, err := s.cloudRolesToAddAndRemove(ident)
+	if errors.Is(err, errInvalidCloudRole) {
+		// We have no cloud-role mapping for this org role (e.g. a newly
+		// introduced basic role). Skip syncing rather than blocking login; the
+		// mapping can be added later without causing an outage.
+		s.log.FromContext(ctx).Warn("Skipping cloud role sync; no mapping for org role", "role", ident.GetOrgRole(), "error", err)
+		return nil
+	}
 	if err != nil {
 		return err
 	}

--- a/pkg/services/authn/authnimpl/sync/rbac_sync_test.go
+++ b/pkg/services/authn/authnimpl/sync/rbac_sync_test.go
@@ -312,7 +312,20 @@ func TestRBACSync_SyncCloudRoles(t *testing.T) {
 			expectedCalled: true,
 		},
 		{
-			desc:    "should not call sync when authenticated with grafana com and has invalid role",
+			desc:    "should call sync and not block login when authenticated with grafana com and has none role",
+			module:  login.GrafanaComAuthModule,
+			stackID: "1",
+			identity: &authn.Identity{
+				ID:       "1",
+				Type:     claims.TypeUser,
+				OrgID:    1,
+				OrgRoles: map[int64]org.RoleType{1: org.RoleNone},
+			},
+			expectedErr:    nil,
+			expectedCalled: true,
+		},
+		{
+			desc:    "should not block login when authenticated with grafana com and has an unmapped role",
 			module:  login.GrafanaComAuthModule,
 			stackID: "1",
 			identity: &authn.Identity{
@@ -321,7 +334,7 @@ func TestRBACSync_SyncCloudRoles(t *testing.T) {
 				OrgID:    1,
 				OrgRoles: map[int64]org.RoleType{1: org.RoleType("something else")},
 			},
-			expectedErr:    errInvalidCloudRole,
+			expectedErr:    nil,
 			expectedCalled: false,
 		},
 		{
@@ -488,12 +501,49 @@ func TestRBACSync_cloudRolesToAddAndRemove(t *testing.T) {
 			},
 		},
 		{
-			desc: "should return an error for not supported role",
+			desc: "should map None to no cloud roles and remove all others when support ticket roles are included",
 			identity: &authn.Identity{
 				ID:       "1",
 				Type:     claims.TypeUser,
 				OrgID:    1,
 				OrgRoles: map[int64]org.RoleType{1: org.RoleNone},
+			},
+			includeSupportTicketRoles: true,
+			expectedErr:               nil,
+			expectedRolesToAdd:        []string{},
+			expectedRolesToRemove: []string{
+				accesscontrol.FixedCloudViewerRole,
+				accesscontrol.FixedCloudSupportTicketReader,
+				accesscontrol.FixedCloudEditorRole,
+				accesscontrol.FixedCloudSupportTicketAdmin,
+				accesscontrol.FixedCloudAdminRole,
+				accesscontrol.FixedCloudSupportTicketAdmin,
+			},
+		},
+		{
+			desc: "should map None to no cloud roles and remove only base roles when support ticket roles are excluded",
+			identity: &authn.Identity{
+				ID:       "1",
+				Type:     claims.TypeUser,
+				OrgID:    1,
+				OrgRoles: map[int64]org.RoleType{1: org.RoleNone},
+			},
+			includeSupportTicketRoles: false,
+			expectedErr:               nil,
+			expectedRolesToAdd:        []string{},
+			expectedRolesToRemove: []string{
+				accesscontrol.FixedCloudViewerRole,
+				accesscontrol.FixedCloudEditorRole,
+				accesscontrol.FixedCloudAdminRole,
+			},
+		},
+		{
+			desc: "should return an error for an unrecognized role",
+			identity: &authn.Identity{
+				ID:       "1",
+				Type:     claims.TypeUser,
+				OrgID:    1,
+				OrgRoles: map[int64]org.RoleType{1: org.RoleType("something else")},
 			},
 			includeSupportTicketRoles: true,
 			expectedErr:               errInvalidCloudRole,


### PR DESCRIPTION
Slack ctx: https://grafanalabs.enterprise.slack.com/archives/C0BJYQC3Z08 (🔐) + https://raintank-corp.slack.com/archives/C07NCBRSABU/p1784306832339539 (🔐) 