### PR TITLE
Provisioning: retry dashboard provisioning while the folder API is unavailable

### DIFF
--- a/pkg/services/dashboards/service/search/search.go
+++ b/pkg/services/dashboards/service/search/search.go
@@ -99,7 +99,9 @@ func ParseResults(result *resourcepb.ResourceSearchResponse, offset int64) (v0al
 	if result == nil {
 		return v0alpha1.SearchResults{}, nil
 	} else if result.Error != nil {
-		return v0alpha1.SearchResults{}, fmt.Errorf("%d error searching: %s: %s", result.Error.Code, result.Error.Message, result.Error.Details)
+		// Wrap via GetError so the status code/reason survives, letting callers
+		// classify transient search failures (e.g. 429/503) as retryable.
+		return v0alpha1.SearchResults{}, fmt.Errorf("error searching: %w", resource.GetError(result.Error))
 	} else if result.Results == nil {
 		return v0alpha1.SearchResults{}, nil
 	}

--- a/pkg/services/dashboards/service/search/search_test.go
+++ b/pkg/services/dashboards/service/search/search_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
@@ -110,6 +111,17 @@ func TestParseResults(t *testing.T) {
 
 		_, err := ParseResults(resSearchResp, 0)
 		require.Error(t, err)
+	})
+
+	t.Run("should preserve the status of a response error", func(t *testing.T) {
+		resSearchResp := &resourcepb.ResourceSearchResponse{
+			Error: resource.AsErrorResult(apierrors.NewServiceUnavailable("search unavailable")),
+		}
+
+		_, err := ParseResults(resSearchResp, 0)
+		require.Error(t, err)
+		// The 503 status must survive so retry classification can detect it.
+		require.True(t, apierrors.IsServiceUnavailable(err))
 	})
 }
 

--- a/pkg/services/provisioning/dashboards/file_reader.go
+++ b/pkg/services/provisioning/dashboards/file_reader.go
@@ -449,7 +449,9 @@ func (fr *FileReader) getOrCreateFolderInternal(ctx context.Context, orgID int64
 	if err == nil && result != nil && result.ManagedBy == "" {
 		result, err = fr.dashboardProvisioningService.UpdateFolderWithManagedByAnnotation(ctx, result, fr.Cfg.Name)
 		if err != nil {
-			return 0, "", fmt.Errorf("unable to update provisioned folder")
+			// Preserve the original error so callers can classify transient
+			// failures (e.g. the folder API being unavailable) as retryable.
+			return 0, "", fmt.Errorf("unable to update provisioned folder: %w", err)
 		}
 	}
 

--- a/pkg/services/provisioning/dashboards/file_reader_test.go
+++ b/pkg/services/provisioning/dashboards/file_reader_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
@@ -568,6 +569,35 @@ func TestIntegrationDashboardFileReader(t *testing.T) {
 		ctx, _ = identity.WithServiceIdentity(ctx, 1)
 		_, _, err = r.getOrCreateFolder(ctx, cfg, cfg.Folder)
 		require.NoError(t, err)
+	})
+
+	t.Run("transient folder update failure preserves the API error for retry", func(t *testing.T) {
+		setup()
+		cfg := &config{
+			Name:    configName,
+			Type:    "file",
+			OrgID:   1,
+			Folder:  "TEAM A",
+			Options: map[string]any{"folder": defaultDashboards},
+		}
+
+		// Pre-existing folder without a ManagedBy annotation triggers the update path.
+		fakeFolder := foldertest.NewFakeService()
+		fakeFolder.ExpectedFolder = &folder.Folder{UID: "team-a"}
+		// Dedicated mock: the shared fakeService has a broader UpdateFolderWithManagedByAnnotation
+		// expectation from another subtest that would otherwise swallow this call.
+		localFake := &dashboards.FakeDashboardProvisioning{}
+		localFake.On("UpdateFolderWithManagedByAnnotation", mock.Anything, mock.Anything, configName).
+			Return(nil, apierrors.NewServiceUnavailable("folder API unavailable"))
+
+		r, err := NewDashboardFileReader(cfg, logger, localFake, fakeStore, fakeFolder, cfgT)
+		require.NoError(t, err)
+
+		ctx := context.Background()
+		ctx, _ = identity.WithServiceIdentity(ctx, 1)
+		_, _, err = r.getOrCreateFolder(ctx, cfg, cfg.Folder)
+		require.Error(t, err)
+		require.True(t, apierrors.IsServiceUnavailable(err), "underlying 503 must survive for retry classification")
 	})
 
 	t.Run("should not create dashboard folder with uid general", func(t *testing.T) {

--- a/pkg/services/provisioning/provisioning.go
+++ b/pkg/services/provisioning/provisioning.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/grafana/dskit/backoff"
 	"github.com/grafana/dskit/services"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -192,23 +193,33 @@ func isRetriableFolderError(err error) bool {
 // returned to the caller, which allow-lists ErrGetOrCreateFolder so a folder
 // outage does not block startup.
 func (ps *ProvisioningServiceImpl) provisionDashboardsWithRetry(ctx context.Context) error {
+	bo := backoff.New(ctx, backoff.Config{
+		// Min==Max keeps the historical fixed backoff between attempts.
+		MinBackoff: ps.dashboardProvisionRetryBackoff,
+		MaxBackoff: ps.dashboardProvisionRetryBackoff,
+		MaxRetries: ps.dashboardProvisionRetries,
+	})
 	var err error
-	for attempt := 0; ; attempt++ {
+	for {
 		err = ps.ProvisionDashboards(ctx)
 		if err == nil || !isRetriableFolderError(err) {
 			return err
 		}
-		if attempt >= ps.dashboardProvisionRetries {
+		if !bo.Ongoing() {
+			// Ongoing() is also false when the context is cancelled; surface the
+			// cancellation rather than the allow-listed folder error in that case.
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return ctxErr
+			}
 			return err
 		}
 		ps.log.Warn("Failed to provision dashboards, folder API unavailable; retrying",
-			"attempt", attempt+1, "maxRetries", ps.dashboardProvisionRetries, "error", err)
-		select {
-		case <-ctx.Done():
+			"attempt", bo.NumRetries()+1, "maxRetries", ps.dashboardProvisionRetries, "error", err)
+		bo.Wait()
+		if ctxErr := ctx.Err(); ctxErr != nil {
 			// Return the cancellation, not the folder error, so an aborted startup
 			// is not allow-listed and reported as success by the caller.
-			return ctx.Err()
-		case <-time.After(ps.dashboardProvisionRetryBackoff):
+			return ctxErr
 		}
 	}
 }

--- a/pkg/services/provisioning/provisioning.go
+++ b/pkg/services/provisioning/provisioning.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/grafana/dskit/services"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/grafana/grafana/pkg/infra/db"
@@ -170,8 +172,18 @@ func isRetriableFolderError(err error) bool {
 	if !errors.Is(err, dashboards.ErrGetOrCreateFolder) {
 		return false
 	}
-	return apierrors.IsServiceUnavailable(err) || apierrors.IsServerTimeout(err) ||
-		apierrors.IsTimeout(err) || apierrors.IsTooManyRequests(err)
+	if apierrors.IsServiceUnavailable(err) || apierrors.IsServerTimeout(err) ||
+		apierrors.IsTimeout(err) || apierrors.IsTooManyRequests(err) {
+		return true
+	}
+	// Folder lookups over unified storage surface raw gRPC status errors from the
+	// search client that the Kubernetes apierrors predicates above do not match.
+	switch status.Code(err) {
+	case codes.Unavailable, codes.DeadlineExceeded, codes.ResourceExhausted:
+		return true
+	default:
+		return false
+	}
 }
 
 // provisionDashboardsWithRetry retries dashboard provisioning while it fails

--- a/pkg/services/provisioning/provisioning.go
+++ b/pkg/services/provisioning/provisioning.go
@@ -179,7 +179,9 @@ func (ps *ProvisioningServiceImpl) provisionDashboardsWithRetry(ctx context.Cont
 			"attempt", attempt+1, "maxRetries", ps.dashboardProvisionRetries, "error", err)
 		select {
 		case <-ctx.Done():
-			return err
+			// Return the cancellation, not the folder error, so an aborted startup
+			// is not allow-listed and reported as success by the caller.
+			return ctx.Err()
 		case <-time.After(ps.dashboardProvisionRetryBackoff):
 		}
 	}

--- a/pkg/services/provisioning/provisioning.go
+++ b/pkg/services/provisioning/provisioning.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"sync"
+	"time"
 
 	"github.com/grafana/dskit/services"
 
@@ -46,6 +47,16 @@ import (
 )
 
 const ServiceName = "provisioning"
+
+// Dashboard provisioning can transiently fail at startup when the folder API is
+// not yet available (e.g. an aggregated folder.grafana.app that is still coming
+// up). Retry a bounded number of times before falling back to the allow-list, so
+// a brief folder outage does not silently leave dashboards unprovisioned until
+// the next restart.
+const (
+	defaultDashboardProvisionRetries      = 5
+	defaultDashboardProvisionRetryBackoff = 15 * time.Second
+)
 
 func ProvideService(
 	ac accesscontrol.AccessControl,
@@ -101,6 +112,9 @@ func ProvideService(
 		dual:                         dual,
 		serverLock:                   serverLockService,
 		routesPermissions:            routesPermissions,
+
+		dashboardProvisionRetries:      defaultDashboardProvisionRetries,
+		dashboardProvisionRetryBackoff: defaultDashboardProvisionRetryBackoff,
 	}
 
 	s.NamedService = services.NewBasicService(s.starting, s.running, nil).WithName(ServiceName)
@@ -136,7 +150,7 @@ func (ps *ProvisioningServiceImpl) starting(ctx context.Context) error {
 		return err
 	}
 
-	if err := ps.ProvisionDashboards(ctx); err != nil {
+	if err := ps.provisionDashboardsWithRetry(ctx); err != nil {
 		ps.log.Error("Failed to provision dashboard", "error", err)
 		// Consider the allow list of errors for which running the provisioning service should not
 		// fail. For now this includes only dashboards.ErrGetOrCreateFolder.
@@ -145,6 +159,30 @@ func (ps *ProvisioningServiceImpl) starting(ctx context.Context) error {
 		}
 	}
 	return nil
+}
+
+// provisionDashboardsWithRetry retries dashboard provisioning while it fails
+// because the folder API is transiently unavailable (ErrGetOrCreateFolder). Any
+// other error returns immediately. The final ErrGetOrCreateFolder is returned to
+// the caller, which allow-lists it so a persistent outage does not block startup.
+func (ps *ProvisioningServiceImpl) provisionDashboardsWithRetry(ctx context.Context) error {
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = ps.ProvisionDashboards(ctx)
+		if err == nil || !errors.Is(err, dashboards.ErrGetOrCreateFolder) {
+			return err
+		}
+		if attempt >= ps.dashboardProvisionRetries {
+			return err
+		}
+		ps.log.Warn("Failed to provision dashboards, folder API unavailable; retrying",
+			"attempt", attempt+1, "maxRetries", ps.dashboardProvisionRetries, "error", err)
+		select {
+		case <-ctx.Done():
+			return err
+		case <-time.After(ps.dashboardProvisionRetryBackoff):
+		}
+	}
 }
 
 func (ps *ProvisioningServiceImpl) running(ctx context.Context) error {
@@ -205,6 +243,9 @@ func newProvisioningServiceImpl(
 		provisionPlugins:        provisionPlugins,
 		Cfg:                     setting.NewCfg(),
 		migratePrometheusType:   migratePrometheusType,
+
+		dashboardProvisionRetries:      defaultDashboardProvisionRetries,
+		dashboardProvisionRetryBackoff: defaultDashboardProvisionRetryBackoff,
 	}
 
 	s.NamedService = services.NewBasicService(s.starting, s.running, nil).WithName(ServiceName)
@@ -249,6 +290,9 @@ type ProvisioningServiceImpl struct {
 	dual                         dualwrite.Service
 	serverLock                   *serverlock.ServerLockService
 	migratePrometheusType        func(context.Context) error
+
+	dashboardProvisionRetries      int
+	dashboardProvisionRetryBackoff time.Duration
 }
 
 func (ps *ProvisioningServiceImpl) RunInitProvisioners(ctx context.Context) error {

--- a/pkg/services/provisioning/provisioning.go
+++ b/pkg/services/provisioning/provisioning.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/grafana/dskit/services"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -161,15 +162,28 @@ func (ps *ProvisioningServiceImpl) starting(ctx context.Context) error {
 	return nil
 }
 
+// isRetriableFolderError reports whether a dashboard provisioning failure is a
+// transient folder-API condition worth retrying (e.g. the aggregated folder API
+// not yet available at startup), as opposed to a permanent configuration error
+// (invalid folder UID, path deeper than the max nested depth) that waiting cannot fix.
+func isRetriableFolderError(err error) bool {
+	if !errors.Is(err, dashboards.ErrGetOrCreateFolder) {
+		return false
+	}
+	return apierrors.IsServiceUnavailable(err) || apierrors.IsServerTimeout(err) ||
+		apierrors.IsTimeout(err) || apierrors.IsTooManyRequests(err)
+}
+
 // provisionDashboardsWithRetry retries dashboard provisioning while it fails
-// because the folder API is transiently unavailable (ErrGetOrCreateFolder). Any
-// other error returns immediately. The final ErrGetOrCreateFolder is returned to
-// the caller, which allow-lists it so a persistent outage does not block startup.
+// because the folder API is transiently unavailable. Any other error (including
+// permanent folder configuration errors) returns immediately. The final error is
+// returned to the caller, which allow-lists ErrGetOrCreateFolder so a folder
+// outage does not block startup.
 func (ps *ProvisioningServiceImpl) provisionDashboardsWithRetry(ctx context.Context) error {
 	var err error
 	for attempt := 0; ; attempt++ {
 		err = ps.ProvisionDashboards(ctx)
-		if err == nil || !errors.Is(err, dashboards.ErrGetOrCreateFolder) {
+		if err == nil || !isRetriableFolderError(err) {
 			return err
 		}
 		if attempt >= ps.dashboardProvisionRetries {

--- a/pkg/services/provisioning/provisioning_test.go
+++ b/pkg/services/provisioning/provisioning_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/grafana/grafana/pkg/infra/serverlock"
 	dashboardstore "github.com/grafana/grafana/pkg/services/dashboards"
@@ -102,7 +103,7 @@ func TestProvisioningServiceImpl(t *testing.T) {
 		serviceTest.mock.ProvisionFunc = func(ctx context.Context) error {
 			calls++
 			if calls < 3 {
-				return fmt.Errorf("%w: Test error", dashboards.ErrGetOrCreateFolder)
+				return fmt.Errorf("%w: %w", dashboards.ErrGetOrCreateFolder, apierrors.NewServiceUnavailable("folder API unavailable"))
 			}
 			return nil
 		}
@@ -120,14 +121,14 @@ func TestProvisioningServiceImpl(t *testing.T) {
 		assert.NoError(t, serviceTest.serviceError, "Service should not have returned an error")
 	})
 
-	t.Run("Should stop retrying and allow-list a persistent folder failure", func(t *testing.T) {
+	t.Run("Should stop retrying and allow-list a persistent folder outage", func(t *testing.T) {
 		serviceTest := setup(t)
 		serviceTest.service.dashboardProvisionRetries = 2
 
 		var calls int
 		serviceTest.mock.ProvisionFunc = func(ctx context.Context) error {
 			calls++
-			return fmt.Errorf("%w: Test error", dashboards.ErrGetOrCreateFolder)
+			return fmt.Errorf("%w: %w", dashboards.ErrGetOrCreateFolder, apierrors.NewServiceUnavailable("folder API unavailable"))
 		}
 
 		serviceTest.startService()
@@ -141,13 +142,36 @@ func TestProvisioningServiceImpl(t *testing.T) {
 		assert.NoError(t, serviceTest.serviceError, "Service should not have returned an error")
 	})
 
+	t.Run("Should not retry a permanent folder configuration error", func(t *testing.T) {
+		serviceTest := setup(t)
+		serviceTest.service.dashboardProvisionRetries = 5
+		// A long backoff would make this test hang if the error were wrongly retried.
+		serviceTest.service.dashboardProvisionRetryBackoff = time.Hour
+
+		var calls int
+		serviceTest.mock.ProvisionFunc = func(ctx context.Context) error {
+			calls++
+			return fmt.Errorf("%w with name %q: max nested folder depth reached", dashboards.ErrGetOrCreateFolder, "general")
+		}
+
+		serviceTest.startService()
+		serviceTest.waitForPollChanges()
+
+		// Permanent config errors must not be retried, and are still allow-listed.
+		assert.Equal(t, 1, calls, "Provision should have been attempted exactly once")
+		serviceTest.cancel()
+		serviceTest.waitForStop()
+
+		assert.NoError(t, serviceTest.serviceError, "Service should not have returned an error")
+	})
+
 	t.Run("Should return context error when cancelled during retry backoff", func(t *testing.T) {
 		serviceTest := setup(t)
 		serviceTest.service.dashboardProvisionRetries = 5
 		serviceTest.service.dashboardProvisionRetryBackoff = time.Hour
 
 		serviceTest.mock.ProvisionFunc = func(ctx context.Context) error {
-			return fmt.Errorf("%w: Test error", dashboards.ErrGetOrCreateFolder)
+			return fmt.Errorf("%w: %w", dashboards.ErrGetOrCreateFolder, apierrors.NewServiceUnavailable("folder API unavailable"))
 		}
 
 		ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/services/provisioning/provisioning_test.go
+++ b/pkg/services/provisioning/provisioning_test.go
@@ -94,6 +94,53 @@ func TestProvisioningServiceImpl(t *testing.T) {
 		assert.NoError(t, serviceTest.serviceError, "Service should not have returned an error")
 	})
 
+	t.Run("Should retry dashboard provisioning while the folder API is unavailable", func(t *testing.T) {
+		serviceTest := setup(t)
+		serviceTest.service.dashboardProvisionRetries = 5
+
+		var calls int
+		serviceTest.mock.ProvisionFunc = func(ctx context.Context) error {
+			calls++
+			if calls < 3 {
+				return fmt.Errorf("%w: Test error", dashboards.ErrGetOrCreateFolder)
+			}
+			return nil
+		}
+
+		serviceTest.startService()
+		serviceTest.waitForPollChanges()
+
+		// Provisioning should have been retried until it succeeded, so polling starts.
+		assert.Equal(t, 3, calls, "Provision should have been retried until it succeeded")
+		assert.Equal(t, 1, len(serviceTest.mock.Calls.PollChanges), "PollChanges should have been called")
+
+		serviceTest.cancel()
+		serviceTest.waitForStop()
+
+		assert.NoError(t, serviceTest.serviceError, "Service should not have returned an error")
+	})
+
+	t.Run("Should stop retrying and allow-list a persistent folder failure", func(t *testing.T) {
+		serviceTest := setup(t)
+		serviceTest.service.dashboardProvisionRetries = 2
+
+		var calls int
+		serviceTest.mock.ProvisionFunc = func(ctx context.Context) error {
+			calls++
+			return fmt.Errorf("%w: Test error", dashboards.ErrGetOrCreateFolder)
+		}
+
+		serviceTest.startService()
+		serviceTest.waitForPollChanges()
+
+		// Initial attempt + dashboardProvisionRetries, then the error is allow-listed.
+		assert.Equal(t, 3, calls, "Provision should have been attempted once plus the configured retries")
+		serviceTest.cancel()
+		serviceTest.waitForStop()
+
+		assert.NoError(t, serviceTest.serviceError, "Service should not have returned an error")
+	})
+
 	t.Run("Should return run error when dashboard provisioning fails for non-allow-listed error", func(t *testing.T) {
 		serviceTest := setup(t)
 		provisioningErr := errors.New("Non-allow-listed error")
@@ -177,6 +224,9 @@ func setup(t *testing.T) *serviceTestStruct {
 	}
 	serviceTest.service = service
 	require.NoError(t, err)
+
+	// Keep retries fast so tests exercising folder failures do not block.
+	serviceTest.service.dashboardProvisionRetryBackoff = time.Millisecond
 
 	ctx, cancel := context.WithCancel(context.Background())
 	serviceTest.cancel = cancel

--- a/pkg/services/provisioning/provisioning_test.go
+++ b/pkg/services/provisioning/provisioning_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/grafana/grafana/pkg/infra/serverlock"
@@ -113,6 +115,31 @@ func TestProvisioningServiceImpl(t *testing.T) {
 
 		// Provisioning should have been retried until it succeeded, so polling starts.
 		assert.Equal(t, 3, calls, "Provision should have been retried until it succeeded")
+		assert.Equal(t, 1, len(serviceTest.mock.Calls.PollChanges), "PollChanges should have been called")
+
+		serviceTest.cancel()
+		serviceTest.waitForStop()
+
+		assert.NoError(t, serviceTest.serviceError, "Service should not have returned an error")
+	})
+
+	t.Run("Should retry transient gRPC search failures from unified storage", func(t *testing.T) {
+		serviceTest := setup(t)
+		serviceTest.service.dashboardProvisionRetries = 5
+
+		var calls int
+		serviceTest.mock.ProvisionFunc = func(ctx context.Context) error {
+			calls++
+			if calls < 3 {
+				return fmt.Errorf("%w: %w", dashboards.ErrGetOrCreateFolder, status.Error(codes.Unavailable, "search unavailable"))
+			}
+			return nil
+		}
+
+		serviceTest.startService()
+		serviceTest.waitForPollChanges()
+
+		assert.Equal(t, 3, calls, "transient gRPC errors should be retried until success")
 		assert.Equal(t, 1, len(serviceTest.mock.Calls.PollChanges), "PollChanges should have been called")
 
 		serviceTest.cancel()

--- a/pkg/services/provisioning/provisioning_test.go
+++ b/pkg/services/provisioning/provisioning_test.go
@@ -141,6 +141,24 @@ func TestProvisioningServiceImpl(t *testing.T) {
 		assert.NoError(t, serviceTest.serviceError, "Service should not have returned an error")
 	})
 
+	t.Run("Should return context error when cancelled during retry backoff", func(t *testing.T) {
+		serviceTest := setup(t)
+		serviceTest.service.dashboardProvisionRetries = 5
+		serviceTest.service.dashboardProvisionRetryBackoff = time.Hour
+
+		serviceTest.mock.ProvisionFunc = func(ctx context.Context) error {
+			return fmt.Errorf("%w: Test error", dashboards.ErrGetOrCreateFolder)
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		err := serviceTest.service.provisionDashboardsWithRetry(ctx)
+		// Cancellation must not be masked as an allow-listed folder failure.
+		require.ErrorIs(t, err, context.Canceled)
+		require.NotErrorIs(t, err, dashboards.ErrGetOrCreateFolder)
+	})
+
 	t.Run("Should return run error when dashboard provisioning fails for non-allow-listed error", func(t *testing.T) {
 		serviceTest := setup(t)
 		provisioningErr := errors.New("Non-allow-listed error")


### PR DESCRIPTION
Dashboard provisioning runs at startup and can fail with `ErrGetOrCreateFolder` when the folder API is transiently unavailable (e.g. an aggregated `folder.grafana.app` still coming up). That error is allow-listed so it doesn't block startup, but with the default file-watcher poll mode it's never retried, leaving dashboards unprovisioned until the next restart.

This PR wraps `ProvisionDashboards` in a bounded retry on `ErrGetOrCreateFolder` (default 5 x 15s backoff) before falling back to the allow-list, so a transient folder outage self-heals at startup. Other errors still fail fast, a persistent outage still doesn't block startup, and the retry honors context cancellation.