### PR TITLE
IAM: Fix totalCount on search teams by teamId filter

### DIFF
--- a/pkg/services/team/teamimpl/store.go
+++ b/pkg/services/team/teamimpl/store.go
@@ -266,6 +266,14 @@ func (ss *xormStore) Search(ctx context.Context, query *team.SearchTeamsQuery) (
 			countSess.Where("LOWER(name) = LOWER(?)", query.Name)
 		}
 
+		if len(query.TeamIds) > 0 {
+			countSess.In("team.id", query.TeamIds)
+		}
+
+		if len(query.UIDs) > 0 {
+			countSess.In("team.uid", query.UIDs)
+		}
+
 		// Only count teams user can see
 		countSess.Where(acFilter.Where, acFilter.Args...)
 

--- a/pkg/services/team/teamimpl/store_test.go
+++ b/pkg/services/team/teamimpl/store_test.go
@@ -334,6 +334,15 @@ func TestIntegrationTeamCommandsAndQueries(t *testing.T) {
 				require.EqualValues(t, queryResult.TotalCount, 2)
 				require.Equal(t, queryResult.Teams[0].ID, teamIds[0])
 				require.Equal(t, queryResult.Teams[1].ID, teamIds[1])
+
+				// Filtering by a single team id must also filter TotalCount, not
+				// return the unfiltered org total.
+				singleQuery := &team.SearchTeamsQuery{OrgID: testOrgID, SignedInUser: testUser, TeamIds: []int64{teamIds[0]}}
+				singleQueryResult, err := teamSvc.SearchTeams(context.Background(), singleQuery)
+				require.NoError(t, err)
+				require.Len(t, singleQueryResult.Teams, 1)
+				require.EqualValues(t, singleQueryResult.TotalCount, 1)
+				require.Equal(t, singleQueryResult.Teams[0].ID, teamIds[0])
 			})
 
 			t.Run("Should be able to query teams by UIDs", func(t *testing.T) {
@@ -354,6 +363,15 @@ func TestIntegrationTeamCommandsAndQueries(t *testing.T) {
 				require.EqualValues(t, queryResult.TotalCount, 2)
 				assert.Contains(t, teamUIDs, queryResult.Teams[0].UID)
 				assert.Contains(t, teamUIDs, queryResult.Teams[1].UID)
+
+				// Filtering by a single UID must also filter TotalCount, not
+				// return the unfiltered org total.
+				singleQuery := &team.SearchTeamsQuery{OrgID: testOrgID, SignedInUser: testUser, UIDs: []string{teamUIDs[0]}}
+				singleQueryResult, err := teamSvc.SearchTeams(context.Background(), singleQuery)
+				require.NoError(t, err)
+				require.Len(t, singleQueryResult.Teams, 1)
+				require.EqualValues(t, singleQueryResult.TotalCount, 1)
+				require.Equal(t, singleQueryResult.Teams[0].UID, teamUIDs[0])
 			})
 
 			t.Run("Should be able to return all teams a user is member of", func(t *testing.T) {


### PR DESCRIPTION
**What is this feature?**

Fixes the `totalCount` returned by the team search store when filtering by team ID(s) or UID(s). Previously, `GET /api/teams/search?teamId=<id>` correctly filtered the `teams` array down to the matching team(s), but `totalCount` reported the unfiltered org-wide total. This change applies the `TeamIds` and `UIDs` filters to the count query so `totalCount` matches the returned results.

**Why do we need this feature?**

The count query in `xormStore.Search` only constrained `org_id`, `query`, `name`, and the access-control filter — it was missing the `TeamIds` and `UIDs` predicates that the main results query already applies. As a result, filtering by team ID returned the correct rows but an inflated `totalCount` (the whole org total), which breaks pagination and any client relying on the count. The `?name=` and `?query=` filters were unaffected because they were already mirrored in the count query.

This is a pre-existing bug and reproduces in Mode0.

**Who is this feature for?**

Any user or API consumer of `/api/teams/search` that filters by `teamId` (or by UID), and anything downstream that relies on an accurate `totalCount` for those filtered queries.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/identity-access-team/issues/2221

