### PR TITLE
Explore: Fix trace view copy button failing in insecure contexts

### DIFF
--- a/public/app/features/explore/TraceView/components/common/CopyIcon.test.tsx
+++ b/public/app/features/explore/TraceView/components/common/CopyIcon.test.tsx
@@ -43,12 +43,44 @@ describe('<CopyIcon />', () => {
     expect(() => render(<CopyIcon {...props} />)).not.toThrow();
   });
 
-  it('copies when clicked', async () => {
-    render(<CopyIcon {...props} />);
+  describe('in a secure context', () => {
+    beforeEach(() => {
+      Object.defineProperty(window, 'isSecureContext', { value: true, configurable: true });
+    });
 
-    const button = screen.getByRole('button');
-    await userEvent.click(button);
+    it('copies via the Clipboard API when clicked', async () => {
+      render(<CopyIcon {...props} />);
 
-    expect(copySpy).toHaveBeenCalledWith(props.copyText);
+      const button = screen.getByRole('button');
+      await userEvent.click(button);
+
+      expect(copySpy).toHaveBeenCalledWith(props.copyText);
+    });
+  });
+
+   describe('in an insecure context', () => {
+    beforeEach(() => {
+      Object.defineProperty(window, 'isSecureContext', { value: false, configurable: true });
+      document.execCommand = jest.fn();
+    });
+
+    it('falls back to execCommand and does not throw', async () => {
+      render(<CopyIcon {...props} />);
+
+      const button = screen.getByRole('button');
+      await userEvent.click(button);
+
+      expect(document.execCommand).toHaveBeenCalledWith('copy');
+      expect(copySpy).not.toHaveBeenCalled();
+    });
+
+    it('restores focus to the previously active element after copying', async () => {
+      render(<CopyIcon {...props} />);
+
+      const button = screen.getByRole('button');
+      await userEvent.click(button);
+
+      expect(document.activeElement).toBe(button);
+    });
   });
 });

--- a/public/app/features/explore/TraceView/components/common/CopyIcon.test.tsx
+++ b/public/app/features/explore/TraceView/components/common/CopyIcon.test.tsx
@@ -58,7 +58,7 @@ describe('<CopyIcon />', () => {
     });
   });
 
-   describe('in an insecure context', () => {
+  describe('in an insecure context', () => {
     beforeEach(() => {
       Object.defineProperty(window, 'isSecureContext', { value: false, configurable: true });
       document.execCommand = jest.fn();

--- a/public/app/features/explore/TraceView/components/common/CopyIcon.test.tsx
+++ b/public/app/features/explore/TraceView/components/common/CopyIcon.test.tsx
@@ -74,12 +74,24 @@ describe('<CopyIcon />', () => {
       expect(copySpy).not.toHaveBeenCalled();
     });
 
-    it('restores focus to the previously active element after copying', async () => {
+    it('restores focus to the previously active element after the fallback copy', async () => {
       render(<CopyIcon {...props} />);
 
       const button = screen.getByRole('button');
+      const focusOrder: string[] = [];
+      const recordFocus = (event: Event) => {
+        focusOrder.push((event.target as HTMLElement).tagName);
+      };
+      document.addEventListener('focusin', recordFocus);
+
       await userEvent.click(button);
 
+      document.removeEventListener('focusin', recordFocus);
+
+      // The fallback textarea steals focus, so the last thing focused must be the button again,
+      // otherwise the Tooltip closes on blur and the "Copied" state is never visible.
+      expect(focusOrder).toContain('TEXTAREA');
+      expect(focusOrder.at(-1)).toBe('BUTTON');
       expect(document.activeElement).toBe(button);
     });
   });

--- a/public/app/features/explore/TraceView/components/common/CopyIcon.tsx
+++ b/public/app/features/explore/TraceView/components/common/CopyIcon.tsx
@@ -45,7 +45,22 @@ export default function CopyIcon({ className, copyText, icon = 'copy', tooltipTi
   const [hasCopied, setHasCopied] = useState(false);
 
   const handleClick = () => {
-    navigator.clipboard.writeText(copyText);
+    if (navigator.clipboard && window.isSecureContext) {
+      navigator.clipboard.writeText(copyText);
+    } else {
+      // Fallback for insecure contexts (no HTTPS/localhost) where the Clipboard API is unavailable.
+      const previousActiveElement = document.activeElement;
+      const textarea = document.createElement('textarea');
+      document.body.appendChild(textarea);
+      textarea.value = copyText;
+      textarea.focus();
+      textarea.select();
+      document.execCommand('copy');
+      textarea.remove();
+      if (previousActiveElement instanceof HTMLElement) {
+        previousActiveElement.focus();
+      }
+    }
     setHasCopied(true);
   };
 

--- a/public/app/features/explore/TraceView/components/common/CopyIcon.tsx
+++ b/public/app/features/explore/TraceView/components/common/CopyIcon.tsx
@@ -44,9 +44,14 @@ export default function CopyIcon({ className, copyText, icon = 'copy', tooltipTi
 
   const [hasCopied, setHasCopied] = useState(false);
 
-  const handleClick = () => {
+  const handleClick = async () => {
     if (navigator.clipboard && window.isSecureContext) {
-      navigator.clipboard.writeText(copyText);
+      try {
+        await navigator.clipboard.writeText(copyText);
+        setHasCopied(true);
+      } catch {
+        setHasCopied(false);
+      }
     } else {
       // Fallback for insecure contexts (no HTTPS/localhost) where the Clipboard API is unavailable.
       const previousActiveElement = document.activeElement;
@@ -55,13 +60,13 @@ export default function CopyIcon({ className, copyText, icon = 'copy', tooltipTi
       textarea.value = copyText;
       textarea.focus();
       textarea.select();
-      document.execCommand('copy');
+      const didCopy = document.execCommand('copy');
       textarea.remove();
       if (previousActiveElement instanceof HTMLElement) {
         previousActiveElement.focus();
       }
+      setHasCopied(didCopy);
     }
-    setHasCopied(true);
   };
 
   return (


### PR DESCRIPTION
**What does this PR do?**

Fixes the copy button in trace view span/resource attribute tables (`KeyValuesTable` → `CopyIcon`) not working when Grafana is served over plain HTTP from a non-localhost origin, e.g behind a Kubernetes ingress without TLS.

**Root Cause**

`CopyIcon` called `navigator.clipboard.writeText(copyText)` directly. `navigator.clipboard` is only exposed in secure contexts (HTTPS, or `localhost`/loopback regardless of scheme). In an insecure context it's `undefined`, so the call threw a `TypeError` before `setHasCopied` even ran & the button appeared to do nothing, no error visible to the user.

**Fix**

- Check `navigator.clipboard && window.isSecureContext` before using the Clipboard API, matching the pattern already used by `ClipboardButton` in `@grafana/ui`.
- Fall back to a hidden `<textarea>` + `document.execCommand('copy')` for insecure contexts.
- Since the fallback temporarily steals focus to the textarea, restore focus to the previously-focused element afterward. Without this, the Tooltip's `useFocus` interaction closes on blur and doesn't reopen from hover alone, so the "Copied" tooltip flashed and vanished instead of staying visible.

**Testing**

- Reproduced by serving Grafana over HTTP from a non-loopback origin (WSL LAN IP instead of `localhost`), confirmed the original crash in the console, then confirmed the fix copies correctly and the tooltip stays visible on hover, matching secure-context behavior.
- Added test coverage in `CopyIcon.test.tsx` for both the secure-context and insecure-context code paths.

**Which issue(s) does this PR fix?**:

Fixes #128581 

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
