### PR TITLE
Explore: Consolidate query history filter seeding and fix shared loading/filter bugs

### DIFF
--- a/public/app/features/explore/RichHistory/RichHistory.test.tsx
+++ b/public/app/features/explore/RichHistory/RichHistory.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { TestProvider } from 'test/helpers/TestProvider';
 
@@ -129,5 +129,39 @@ describe('RichHistory', () => {
     // The debounced load fires ~300ms after mount; findBy polls until the rejection settles.
     expect(await screen.findByRole('alert', {}, { timeout: 2000 })).toBeInTheDocument();
     expect(screen.queryByText('Loading results...')).not.toBeInTheDocument();
+  });
+
+  it('does not surface an error when a superseded request rejects after a newer request succeeds', async () => {
+    jest.useFakeTimers();
+    try {
+      const deferreds: Array<{ resolve: () => void; reject: (reason?: unknown) => void }> = [];
+      const loadRichHistory = jest.fn(
+        () => new Promise<void>((resolve, reject) => deferreds.push({ resolve, reject }))
+      );
+      setup({ loadRichHistory });
+
+      // Mount seeds the filters, scheduling the first debounced load. Fire it (request #1).
+      await act(async () => {
+        jest.advanceTimersByTime(300);
+      });
+      expect(loadRichHistory).toHaveBeenCalledTimes(1);
+
+      // A newer filter change schedules a second load (request #2, now the latest).
+      fireEvent.change(screen.getByPlaceholderText(/search queries/i), { target: { value: 'foo' } });
+      await act(async () => {
+        jest.advanceTimersByTime(300);
+      });
+      expect(loadRichHistory).toHaveBeenCalledTimes(2);
+
+      // The newer request settles first; the stale older one rejects afterwards and must be ignored.
+      await act(async () => {
+        deferreds[1].resolve();
+        deferreds[0].reject(new Error('stale'));
+      });
+
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    } finally {
+      jest.useRealTimers();
+    }
   });
 });

--- a/public/app/features/explore/RichHistory/RichHistory.test.tsx
+++ b/public/app/features/explore/RichHistory/RichHistory.test.tsx
@@ -47,7 +47,7 @@ const setup = (propOverrides?: Partial<RichHistoryProps>) => {
     richHistoryTotal: 0,
     firstTab: Tabs.RichHistory,
     deleteRichHistory: jest.fn(),
-    loadRichHistory: jest.fn(),
+    loadRichHistory: jest.fn().mockResolvedValue(undefined),
     loadMoreRichHistory: jest.fn(),
     clearRichHistoryResults: jest.fn(),
     onClose: jest.fn(),
@@ -120,5 +120,14 @@ describe('RichHistory', () => {
     expect(updateHistorySearchFilters).toHaveBeenLastCalledWith(
       expect.objectContaining({ datasourceFilters: [], starred: true })
     );
+  });
+
+  it('clears loading and shows an error when the history fetch rejects', async () => {
+    const loadRichHistory = jest.fn().mockRejectedValue(new Error('boom'));
+    setup({ loadRichHistory });
+
+    // The debounced load fires ~300ms after mount; findBy polls until the rejection settles.
+    expect(await screen.findByRole('alert', {}, { timeout: 2000 })).toBeInTheDocument();
+    expect(screen.queryByText('Loading results...')).not.toBeInTheDocument();
   });
 });

--- a/public/app/features/explore/RichHistory/RichHistory.tsx
+++ b/public/app/features/explore/RichHistory/RichHistory.tsx
@@ -1,5 +1,5 @@
 import { debounce } from 'lodash';
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useMemo, useRef } from 'react';
 
 import { type SelectableValue } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
@@ -62,13 +62,28 @@ export function RichHistory(props: RichHistoryProps) {
     loadRichHistory();
   };
 
+  // Sequences concurrent loads so a stale resolution can't overwrite state that
+  // belongs to a newer request: an older rejection settling after a newer load,
+  // or an older success clearing an error raised by the latest filter change.
+  const latestLoadId = useRef(0);
+
   const loadRichHistory = debounce(() => {
+    const loadId = ++latestLoadId.current;
     setLoading(true);
     setLoadError(false);
-    props.loadRichHistory().catch(() => {
-      setLoading(false);
-      setLoadError(true);
-    });
+    props.loadRichHistory().then(
+      () => {
+        if (loadId === latestLoadId.current) {
+          setLoading(false);
+        }
+      },
+      () => {
+        if (loadId === latestLoadId.current) {
+          setLoading(false);
+          setLoadError(true);
+        }
+      }
+    );
   }, 300);
 
   const onChangeRetentionPeriod = (retentionPeriod: SelectableValue<number>) => {
@@ -82,11 +97,6 @@ export function RichHistory(props: RichHistoryProps) {
 
   const toggleActiveDatasourcesOnly = () =>
     updateSettings({ activeDatasourcesOnly: !props.richHistorySettings.activeDatasourcesOnly });
-
-  useEffect(() => {
-    setLoading(false);
-    setLoadError(false);
-  }, [richHistory]);
 
   const exploreActiveDS = useSelector(selectExploreDSMaps);
   const {

--- a/public/app/features/explore/RichHistory/RichHistory.tsx
+++ b/public/app/features/explore/RichHistory/RichHistory.tsx
@@ -33,7 +33,7 @@ export interface RichHistoryProps {
   richHistorySearchFilters?: RichHistorySearchFilters;
   updateHistorySettings: (settings: RichHistorySettings) => void;
   updateHistorySearchFilters: (filters: RichHistorySearchFilters) => void;
-  loadRichHistory: () => void;
+  loadRichHistory: () => Promise<void>;
   loadMoreRichHistory: () => void;
   clearRichHistoryResults: () => void;
   deleteRichHistory: () => void;
@@ -46,6 +46,7 @@ export function RichHistory(props: RichHistoryProps) {
   const { richHistory, richHistoryTotal, height, deleteRichHistory, onClose, firstTab } = props;
 
   const [loading, setLoading] = useState(false);
+  const [loadError, setLoadError] = useState(false);
 
   const updateSettings = (settingsToUpdate: Partial<RichHistorySettings>) => {
     props.updateHistorySettings({ ...props.richHistorySettings, ...settingsToUpdate });
@@ -62,8 +63,12 @@ export function RichHistory(props: RichHistoryProps) {
   };
 
   const loadRichHistory = debounce(() => {
-    props.loadRichHistory();
     setLoading(true);
+    setLoadError(false);
+    props.loadRichHistory().catch(() => {
+      setLoading(false);
+      setLoadError(true);
+    });
   }, 300);
 
   const onChangeRetentionPeriod = (retentionPeriod: SelectableValue<number>) => {
@@ -80,10 +85,15 @@ export function RichHistory(props: RichHistoryProps) {
 
   useEffect(() => {
     setLoading(false);
+    setLoadError(false);
   }, [richHistory]);
 
   const exploreActiveDS = useSelector(selectExploreDSMaps);
-  const { items: dataSourceItems, isLoading: isLoadingDatasources } = useDataSourceInstanceList({ mixed: true });
+  const {
+    items: dataSourceItems,
+    isLoading: isLoadingDatasources,
+    error: dsListError,
+  } = useDataSourceInstanceList({ mixed: true });
   const listOfDatasources = useMemo(
     () => dataSourceItems.map((ds) => ({ name: ds.name, uid: ds.uid })),
     [dataSourceItems]
@@ -100,6 +110,7 @@ export function RichHistory(props: RichHistoryProps) {
         queries={richHistory}
         totalQueries={richHistoryTotal || 0}
         loading={loading}
+        loadError={loadError}
         updateFilters={updateFilters}
         clearRichHistoryResults={() => props.clearRichHistoryResults()}
         loadMoreRichHistory={() => props.loadMoreRichHistory()}
@@ -109,6 +120,7 @@ export function RichHistory(props: RichHistoryProps) {
         activeDatasources={activeDatasources}
         listOfDatasources={listOfDatasources}
         isLoadingDatasources={isLoadingDatasources}
+        dsListError={!!dsListError}
       />
     ),
     icon: 'history',
@@ -122,11 +134,16 @@ export function RichHistory(props: RichHistoryProps) {
         queries={richHistory}
         totalQueries={richHistoryTotal || 0}
         loading={loading}
+        loadError={loadError}
         updateFilters={updateFilters}
         clearRichHistoryResults={() => props.clearRichHistoryResults()}
         loadMoreRichHistory={() => props.loadMoreRichHistory()}
         richHistorySettings={props.richHistorySettings}
         richHistorySearchFilters={props.richHistorySearchFilters}
+        activeDatasources={activeDatasources}
+        listOfDatasources={listOfDatasources}
+        isLoadingDatasources={isLoadingDatasources}
+        dsListError={!!dsListError}
       />
     ),
     icon: 'star',

--- a/public/app/features/explore/RichHistory/RichHistoryContainer.tsx
+++ b/public/app/features/explore/RichHistory/RichHistoryContainer.tsx
@@ -109,7 +109,9 @@ export function RichHistoryContainer(props: Props) {
       richHistorySearchFilters={richHistorySearchFilters}
       updateHistorySettings={updateHistorySettings}
       updateHistorySearchFilters={updateHistorySearchFilters}
-      loadRichHistory={loadRichHistory}
+      loadRichHistory={async () => {
+        await loadRichHistory();
+      }}
       loadMoreRichHistory={loadMoreRichHistory}
       clearRichHistoryResults={clearRichHistoryResults}
     />

--- a/public/app/features/explore/RichHistory/RichHistoryQueriesTab.datasourceResolution.test.tsx
+++ b/public/app/features/explore/RichHistory/RichHistoryQueriesTab.datasourceResolution.test.tsx
@@ -38,6 +38,7 @@ const makeProps = (): RichHistoryQueriesTabProps => ({
   queries: [query],
   totalQueries: 1,
   loading: false,
+  loadError: false,
   updateFilters: jest.fn(),
   clearRichHistoryResults: jest.fn(),
   loadMoreRichHistory: jest.fn(),
@@ -48,6 +49,7 @@ const makeProps = (): RichHistoryQueriesTabProps => ({
     { name: 'bad', uid: 'bad-456' },
   ],
   isLoadingDatasources: false,
+  dsListError: false,
   richHistorySearchFilters: {
     search: '',
     sortOrder: SortOrder.Descending,

--- a/public/app/features/explore/RichHistory/RichHistoryQueriesTab.test.tsx
+++ b/public/app/features/explore/RichHistory/RichHistoryQueriesTab.test.tsx
@@ -18,12 +18,14 @@ const makeProps = (propOverrides?: Partial<RichHistoryQueriesTabProps>): RichHis
     queries: [],
     totalQueries: 0,
     loading: false,
+    loadError: false,
     updateFilters: jest.fn(),
     clearRichHistoryResults: jest.fn(),
     loadMoreRichHistory: jest.fn(),
     activeDatasources: ['test-ds'],
     listOfDatasources: [{ name: 'test-ds', uid: 'test-123' }],
     isLoadingDatasources: false,
+    dsListError: false,
     richHistorySearchFilters: {
       search: '',
       sortOrder: SortOrder.Descending,
@@ -127,5 +129,46 @@ describe('RichHistoryQueriesTab', () => {
     // Once resolved, it seeds exactly once, using the now-populated active datasources.
     expect(updateFiltersSpy).toHaveBeenCalledTimes(1);
     expect(updateFiltersSpy).toHaveBeenCalledWith(expect.objectContaining({ datasourceFilters: ['test-ds'] }));
+  });
+
+  it('shows a datasource-list error instead of results when the list fails in active-only mode', () => {
+    setup({
+      dsListError: true,
+      richHistorySettings: {
+        retentionPeriod: 7,
+        starredTabAsFirstTab: false,
+        activeDatasourcesOnly: true,
+        lastUsedDatasourceFilters: [],
+      },
+    });
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+
+  it('hides the partial-results "Load more" footer when loadError is true, even with stale partial results', () => {
+    setup({
+      loadError: true,
+      queries: [
+        {
+          id: '1',
+          createdAt: 1,
+          datasourceUid: 'test-123',
+          datasourceName: 'test-ds',
+          starred: false,
+          comment: '',
+          queries: [],
+        },
+      ],
+      totalQueries: 2,
+      richHistorySearchFilters: {
+        search: '',
+        sortOrder: SortOrder.Descending,
+        datasourceFilters: ['test-ds'],
+        from: 0,
+        to: 30,
+        starred: false,
+      },
+    });
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /load more/i })).not.toBeInTheDocument();
   });
 });

--- a/public/app/features/explore/RichHistory/RichHistoryQueriesTab.test.tsx
+++ b/public/app/features/explore/RichHistory/RichHistoryQueriesTab.test.tsx
@@ -1,7 +1,8 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 // eslint-disable-next-line no-restricted-imports -- wildcard is used to spy on `useAsync`, not `useObservable`
 import * as reactUse from 'react-use';
 import { TestProvider } from 'test/helpers/TestProvider';
+import { selectOptionInTest } from 'test/helpers/selectOptionInTest';
 import { MockDataSourceApi } from 'test/mocks/datasource_srv';
 
 import { type DataSourceSrv, setDataSourceSrv } from '@grafana/runtime';
@@ -129,6 +130,17 @@ describe('RichHistoryQueriesTab', () => {
     // Once resolved, it seeds exactly once, using the now-populated active datasources.
     expect(updateFiltersSpy).toHaveBeenCalledTimes(1);
     expect(updateFiltersSpy).toHaveBeenCalledWith(expect.objectContaining({ datasourceFilters: ['test-ds'] }));
+  });
+
+  it('updates the sort order filter when a new sort option is picked', async () => {
+    const updateFiltersSpy = jest.fn();
+    setup({ updateFilters: updateFiltersSpy });
+    updateFiltersSpy.mockClear(); // ignore the mount seed
+
+    const sortSelect = within(await screen.findByLabelText('Sort queries')).getByRole('combobox');
+    await selectOptionInTest(sortSelect, 'Oldest first');
+
+    expect(updateFiltersSpy).toHaveBeenCalledWith(expect.objectContaining({ sortOrder: SortOrder.Ascending }));
   });
 
   it('shows a datasource-list error instead of results when the list fails in active-only mode', () => {

--- a/public/app/features/explore/RichHistory/RichHistoryQueriesTab.tsx
+++ b/public/app/features/explore/RichHistory/RichHistoryQueriesTab.tsx
@@ -6,18 +6,24 @@ import { type DataSourceApi, type GrafanaTheme2, type SelectableValue } from '@g
 import { Trans, t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 import { getDataSourceInstance } from '@grafana/runtime/unstable';
-import { Button, FilterInput, MultiSelect, RangeSlider, Select, useStyles2 } from '@grafana/ui';
+import { Alert, Button, FilterInput, MultiSelect, RangeSlider, Select, useStyles2 } from '@grafana/ui';
 import { mapNumbertoTimeInSlider, mapQueriesToHeadings } from 'app/core/utils/richHistory';
-import { SortOrder, type RichHistorySearchFilters, type RichHistorySettings } from 'app/core/utils/richHistoryTypes';
+import {
+  type SortOrder,
+  type RichHistorySearchFilters,
+  type RichHistorySettings,
+} from 'app/core/utils/richHistoryTypes';
 import { type RichHistoryQuery } from 'app/types/explore';
 
 import { getSortOrderOptions } from './RichHistory';
 import RichHistoryCard from './RichHistoryCard';
+import { useSeedRichHistoryFilters } from './useSeedRichHistoryFilters';
 
 export interface RichHistoryQueriesTabProps {
   queries: RichHistoryQuery[];
   totalQueries: number;
   loading: boolean;
+  loadError: boolean;
   updateFilters: (filtersToUpdate?: Partial<RichHistorySearchFilters>) => void;
   clearRichHistoryResults: () => void;
   loadMoreRichHistory: () => void;
@@ -26,6 +32,7 @@ export interface RichHistoryQueriesTabProps {
   activeDatasources: string[];
   listOfDatasources: Array<{ name: string; uid: string }>;
   isLoadingDatasources: boolean;
+  dsListError: boolean;
   height: number;
 }
 
@@ -114,6 +121,7 @@ export function RichHistoryQueriesTab(props: RichHistoryQueriesTabProps) {
     queries,
     totalQueries,
     loading,
+    loadError,
     richHistorySearchFilters,
     updateFilters,
     clearRichHistoryResults,
@@ -123,35 +131,19 @@ export function RichHistoryQueriesTab(props: RichHistoryQueriesTabProps) {
     listOfDatasources,
     activeDatasources,
     isLoadingDatasources,
+    dsListError,
   } = props;
 
   const styles = useStyles2(getStyles, height);
 
-  // Set the initial filters once the datasource list has loaded, so active-datasource
-  // names resolve correctly. `isLoadingDatasources` flips false exactly once, so this
-  // runs a single time on mount (the datasource list is fetched asynchronously now).
-  useEffect(() => {
-    if (isLoadingDatasources) {
-      return;
-    }
-    const datasourceFilters =
-      !richHistorySettings.activeDatasourcesOnly && richHistorySettings.lastUsedDatasourceFilters
-        ? richHistorySettings.lastUsedDatasourceFilters
-        : activeDatasources;
-    const filters: RichHistorySearchFilters = {
-      search: '',
-      sortOrder: SortOrder.Descending,
-      datasourceFilters,
-      from: 0,
-      to: richHistorySettings.retentionPeriod,
-      starred: false,
-    };
-    updateFilters(filters);
-    // Intentionally only depends on `isLoadingDatasources` so the initial filters are seeded
-    // exactly once, when the datasource list resolves. Re-running when the other values change
-    // would clobber user-adjusted filters.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isLoadingDatasources]);
+  useSeedRichHistoryFilters({
+    starred: false,
+    isLoadingDatasources,
+    dsListError,
+    activeDatasources,
+    richHistorySettings,
+    updateFilters,
+  });
 
   useEffect(() => {
     return () => {
@@ -177,6 +169,15 @@ export function RichHistoryQueriesTab(props: RichHistoryQueriesTabProps) {
       return [];
     }
   }, [richHistorySearchFilters?.datasourceFilters, listOfDatasources]);
+
+  if (dsListError && richHistorySettings.activeDatasourcesOnly) {
+    return (
+      <Alert
+        severity="error"
+        title={t('explore.rich-history-queries-tab.datasource-list-error', 'Unable to load data sources')}
+      />
+    );
+  }
 
   if (!richHistorySearchFilters) {
     return (
@@ -263,13 +264,16 @@ export function RichHistoryQueriesTab(props: RichHistoryQueriesTabProps) {
           </div>
         </div>
 
-        {(loading || loadingDs) && (
+        {loadError ? (
+          <Alert
+            severity="error"
+            title={t('explore.rich-history-queries-tab.load-error', 'Unable to load query history')}
+          />
+        ) : loading || loadingDs ? (
           <span>
             <Trans i18nKey="explore.rich-history-queries-tab.loading-results">Loading results...</Trans>
           </span>
-        )}
-
-        {!(loading || loadingDs) &&
+        ) : (
           Object.keys(mappedQueriesToHeadings).map((heading) => {
             return (
               <div key={heading}>
@@ -304,8 +308,9 @@ export function RichHistoryQueriesTab(props: RichHistoryQueriesTabProps) {
                 })}
               </div>
             );
-          })}
-        {partialResults ? (
+          })
+        )}
+        {!loadError && partialResults ? (
           <div>
             <Trans
               i18nKey="explore.rich-history-queries-tab.showing-queries"

--- a/public/app/features/explore/RichHistory/RichHistoryStarredTab.test.tsx
+++ b/public/app/features/explore/RichHistory/RichHistoryStarredTab.test.tsx
@@ -1,5 +1,6 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { TestProvider } from 'test/helpers/TestProvider';
+import { selectOptionInTest } from 'test/helpers/selectOptionInTest';
 
 import { SortOrder } from 'app/core/utils/richHistoryTypes';
 
@@ -99,6 +100,28 @@ describe('RichHistoryStarredTab', () => {
     fireEvent.change(input, { target: { value: '|=' } });
 
     expect(updateFiltersSpy).toHaveBeenCalledWith(expect.objectContaining({ search: '|=' }));
+  });
+
+  it('updates the sort order filter when a new sort option is picked', async () => {
+    const updateFiltersSpy = jest.fn();
+    setup({ updateFilters: updateFiltersSpy });
+    updateFiltersSpy.mockClear(); // ignore the mount seed
+
+    const sortSelect = within(await screen.findByLabelText('Sort queries')).getByRole('combobox');
+    await selectOptionInTest(sortSelect, 'Newest first');
+
+    expect(updateFiltersSpy).toHaveBeenCalledWith(expect.objectContaining({ sortOrder: SortOrder.Descending }));
+  });
+
+  it('updates the datasource filter when a datasource is selected', async () => {
+    const updateFiltersSpy = jest.fn();
+    setup({ updateFilters: updateFiltersSpy });
+    updateFiltersSpy.mockClear(); // ignore the mount seed
+
+    const dsSelect = await screen.findByLabelText('Filter queries for data sources(s)');
+    await selectOptionInTest(dsSelect, 'active-ds');
+
+    expect(updateFiltersSpy).toHaveBeenCalledWith(expect.objectContaining({ datasourceFilters: ['active-ds'] }));
   });
 
   it('should show the loading message instead of cards while datasource instances are loading', async () => {

--- a/public/app/features/explore/RichHistory/RichHistoryStarredTab.test.tsx
+++ b/public/app/features/explore/RichHistory/RichHistoryStarredTab.test.tsx
@@ -21,22 +21,15 @@ jest.mock('@grafana/runtime', () => ({
   },
 }));
 
-// Stable identity: a fresh array per render would re-trigger the component's
-// useAsync (which depends on the datasource list) on every render.
-const mockDataSourceItems = [{ name: 'active-ds', uid: 'active-ds-uid' }];
-
 jest.mock('@grafana/runtime/unstable', () => ({
   ...jest.requireActual('@grafana/runtime/unstable'),
-  useDataSourceInstanceList: () => ({
-    isLoading: false,
-    items: mockDataSourceItems,
-  }),
 }));
 
 const setup = (propOverrides?: Partial<RichHistoryStarredTabProps>) => {
   const props: RichHistoryStarredTabProps = {
     queries: [],
     loading: false,
+    loadError: false,
     totalQueries: 0,
     updateFilters: jest.fn(),
     loadMoreRichHistory: jest.fn(),
@@ -55,6 +48,10 @@ const setup = (propOverrides?: Partial<RichHistoryStarredTabProps>) => {
       to: 7,
       starred: false,
     },
+    activeDatasources: ['active-ds'],
+    listOfDatasources: [{ name: 'active-ds', uid: 'active-ds-uid' }],
+    isLoadingDatasources: false,
+    dsListError: false,
   };
 
   Object.assign(props, propOverrides);
@@ -170,5 +167,38 @@ describe('RichHistoryStarredTab', () => {
     expect(updateFiltersSpy).toHaveBeenCalledWith(
       expect.objectContaining({ datasourceFilters: ['active-ds'], starred: true })
     );
+  });
+
+  it('shows a datasource-list error instead of results when the list fails in active-only mode', async () => {
+    setup({
+      dsListError: true,
+      richHistorySettings: {
+        retentionPeriod: 7,
+        starredTabAsFirstTab: false,
+        activeDatasourcesOnly: true,
+        lastUsedDatasourceFilters: [],
+      },
+    });
+    expect(await screen.findByRole('alert')).toBeInTheDocument();
+  });
+
+  it('hides the partial-results "Load more" footer when loadError is true, even with stale partial results', async () => {
+    setup({
+      loadError: true,
+      queries: [
+        {
+          id: '1',
+          createdAt: 1,
+          datasourceUid: 'active-ds-uid',
+          datasourceName: 'active-ds',
+          starred: true,
+          comment: 'starred query comment',
+          queries: [],
+        },
+      ],
+      totalQueries: 2,
+    });
+    expect(await screen.findByRole('alert')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /load more/i })).not.toBeInTheDocument();
   });
 });

--- a/public/app/features/explore/RichHistory/RichHistoryStarredTab.tsx
+++ b/public/app/features/explore/RichHistory/RichHistoryStarredTab.tsx
@@ -1,30 +1,37 @@
 import { css } from '@emotion/css';
-import { useEffect, useMemo } from 'react';
+import { useEffect } from 'react';
 import { useAsync } from 'react-use';
 
 import { type DataSourceApi, type GrafanaTheme2, type SelectableValue } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
-import { getDataSourceInstance, useDataSourceInstanceList } from '@grafana/runtime/unstable';
-import { useStyles2, Select, MultiSelect, FilterInput, Button } from '@grafana/ui';
-import { SortOrder, type RichHistorySearchFilters, type RichHistorySettings } from 'app/core/utils/richHistoryTypes';
+import { getDataSourceInstance } from '@grafana/runtime/unstable';
+import { Alert, useStyles2, Select, MultiSelect, FilterInput, Button } from '@grafana/ui';
+import {
+  type SortOrder,
+  type RichHistorySearchFilters,
+  type RichHistorySettings,
+} from 'app/core/utils/richHistoryTypes';
 import { type RichHistoryQuery } from 'app/types/explore';
-import { useSelector } from 'app/types/store';
-
-import { selectExploreDSMaps } from '../state/selectors';
 
 import { getSortOrderOptions } from './RichHistory';
 import RichHistoryCard from './RichHistoryCard';
+import { useSeedRichHistoryFilters } from './useSeedRichHistoryFilters';
 
 export interface RichHistoryStarredTabProps {
   queries: RichHistoryQuery[];
   totalQueries: number;
   loading: boolean;
-  updateFilters: (filtersToUpdate: Partial<RichHistorySearchFilters>) => void;
+  loadError: boolean;
+  updateFilters: (filtersToUpdate?: Partial<RichHistorySearchFilters>) => void;
   clearRichHistoryResults: () => void;
   loadMoreRichHistory: () => void;
   richHistorySearchFilters?: RichHistorySearchFilters;
   richHistorySettings: RichHistorySettings;
+  activeDatasources: string[];
+  listOfDatasources: Array<{ name: string; uid: string }>;
+  isLoadingDatasources: boolean;
+  dsListError: boolean;
 }
 
 const getStyles = (theme: GrafanaTheme2) => {
@@ -74,45 +81,24 @@ export function RichHistoryStarredTab(props: RichHistoryStarredTabProps) {
     queries,
     totalQueries,
     loading,
+    loadError,
     richHistorySearchFilters,
+    activeDatasources,
+    listOfDatasources,
+    isLoadingDatasources,
+    dsListError,
   } = props;
 
   const styles = useStyles2(getStyles);
-  const exploreActiveDS = useSelector(selectExploreDSMaps);
 
-  const { items: dataSourceItems, isLoading: isLoadingDatasources } = useDataSourceInstanceList({ mixed: true });
-  const listOfDatasources = useMemo(
-    () => dataSourceItems.map((ds) => ({ name: ds.name, uid: ds.uid })),
-    [dataSourceItems]
-  );
-
-  // Set the initial filters once the datasource list has loaded, so active-datasource
-  // names resolve correctly. `isLoadingDatasources` flips false exactly once, so this
-  // runs a single time on mount (the datasource list is fetched asynchronously now).
-  useEffect(() => {
-    if (isLoadingDatasources) {
-      return;
-    }
-    const datasourceFilters =
-      !richHistorySettings.activeDatasourcesOnly && richHistorySettings.lastUsedDatasourceFilters
-        ? richHistorySettings.lastUsedDatasourceFilters
-        : exploreActiveDS.dsToExplore
-            .map((eDs) => listOfDatasources.find((ds) => ds.uid === eDs.datasource?.uid)?.name)
-            .filter((name): name is string => !!name);
-    const filters: RichHistorySearchFilters = {
-      search: '',
-      sortOrder: SortOrder.Descending,
-      datasourceFilters,
-      from: 0,
-      to: richHistorySettings.retentionPeriod,
-      starred: true,
-    };
-    updateFilters(filters);
-    // Intentionally only depends on `isLoadingDatasources` so the initial filters are seeded
-    // exactly once, when the datasource list resolves. Re-running when the other values change
-    // would clobber user-adjusted filters.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isLoadingDatasources]);
+  useSeedRichHistoryFilters({
+    starred: true,
+    isLoadingDatasources,
+    dsListError,
+    activeDatasources,
+    richHistorySettings,
+    updateFilters,
+  });
 
   useEffect(() => {
     return () => {
@@ -142,6 +128,15 @@ export function RichHistoryStarredTab(props: RichHistoryStarredTabProps) {
       return [];
     }
   }, [richHistorySearchFilters?.datasourceFilters, listOfDatasources]);
+
+  if (dsListError && richHistorySettings.activeDatasourcesOnly) {
+    return (
+      <Alert
+        severity="error"
+        title={t('explore.rich-history-starred-tab.datasource-list-error', 'Unable to load data sources')}
+      />
+    );
+  }
 
   if (!richHistorySearchFilters) {
     return (
@@ -197,16 +192,21 @@ export function RichHistoryStarredTab(props: RichHistoryStarredTabProps) {
             />
           </div>
         </div>
-        {(loading || loadingDs) && (
+        {loadError ? (
+          <Alert
+            severity="error"
+            title={t('explore.rich-history-starred-tab.load-error', 'Unable to load query history')}
+          />
+        ) : loading || loadingDs ? (
           <span>
             <Trans i18nKey="explore.rich-history-starred-tab.loading-results">Loading results...</Trans>
           </span>
-        )}
-        {!(loading || loadingDs) &&
+        ) : (
           queries.map((q) => {
             return <RichHistoryCard queryHistoryItem={q} key={q.id} datasourceInstances={datasourceFilterApis} />;
-          })}
-        {queries.length && queries.length !== totalQueries ? (
+          })
+        )}
+        {!loadError && queries.length && queries.length !== totalQueries ? (
           <div>
             <Trans
               i18nKey="explore.rich-history-starred-tab.showing-queries"

--- a/public/app/features/explore/RichHistory/useSeedRichHistoryFilters.test.tsx
+++ b/public/app/features/explore/RichHistory/useSeedRichHistoryFilters.test.tsx
@@ -1,0 +1,78 @@
+import { renderHook } from '@testing-library/react';
+
+import { SortOrder } from 'app/core/utils/richHistoryTypes';
+
+import { useSeedRichHistoryFilters } from './useSeedRichHistoryFilters';
+
+const baseSettings = {
+  retentionPeriod: 7,
+  starredTabAsFirstTab: false,
+  activeDatasourcesOnly: false,
+  lastUsedDatasourceFilters: undefined as string[] | undefined,
+};
+
+function run(overrides: Partial<Parameters<typeof useSeedRichHistoryFilters>[0]> = {}) {
+  const updateFilters = jest.fn();
+  renderHook(() =>
+    useSeedRichHistoryFilters({
+      starred: false,
+      isLoadingDatasources: false,
+      dsListError: false,
+      activeDatasources: ['active-ds'],
+      richHistorySettings: baseSettings,
+      updateFilters,
+      ...overrides,
+    })
+  );
+  return updateFilters;
+}
+
+describe('useSeedRichHistoryFilters', () => {
+  it('does not seed while datasources are loading', () => {
+    const updateFilters = run({ isLoadingDatasources: true });
+    expect(updateFilters).not.toHaveBeenCalled();
+  });
+
+  it('seeds last-used filters when active-only is off and they exist', () => {
+    const updateFilters = run({
+      richHistorySettings: { ...baseSettings, lastUsedDatasourceFilters: ['prometheus'] },
+    });
+    expect(updateFilters).toHaveBeenCalledWith(
+      expect.objectContaining({ datasourceFilters: ['prometheus'], starred: false, sortOrder: SortOrder.Descending })
+    );
+  });
+
+  it('seeds active datasources when active-only is off and no last-used filters', () => {
+    const updateFilters = run();
+    expect(updateFilters).toHaveBeenCalledWith(expect.objectContaining({ datasourceFilters: ['active-ds'] }));
+  });
+
+  it('seeds active datasources (ignoring last-used) when active-only is on', () => {
+    const updateFilters = run({
+      richHistorySettings: {
+        ...baseSettings,
+        activeDatasourcesOnly: true,
+        lastUsedDatasourceFilters: ['prometheus'],
+      },
+    });
+    expect(updateFilters).toHaveBeenCalledWith(expect.objectContaining({ datasourceFilters: ['active-ds'] }));
+  });
+
+  it('passes the starred flag through', () => {
+    const updateFilters = run({ starred: true });
+    expect(updateFilters).toHaveBeenCalledWith(expect.objectContaining({ starred: true }));
+  });
+
+  it('does not seed when the datasource list failed and active-only is on', () => {
+    const updateFilters = run({
+      dsListError: true,
+      richHistorySettings: { ...baseSettings, activeDatasourcesOnly: true },
+    });
+    expect(updateFilters).not.toHaveBeenCalled();
+  });
+
+  it('still seeds when the datasource list failed but active-only is off', () => {
+    const updateFilters = run({ dsListError: true, activeDatasources: [] });
+    expect(updateFilters).toHaveBeenCalledWith(expect.objectContaining({ datasourceFilters: [] }));
+  });
+});

--- a/public/app/features/explore/RichHistory/useSeedRichHistoryFilters.ts
+++ b/public/app/features/explore/RichHistory/useSeedRichHistoryFilters.ts
@@ -1,0 +1,55 @@
+import { useEffect } from 'react';
+
+import { SortOrder, type RichHistorySearchFilters, type RichHistorySettings } from 'app/core/utils/richHistoryTypes';
+
+export interface SeedRichHistoryFiltersOptions {
+  starred: boolean;
+  isLoadingDatasources: boolean;
+  dsListError: boolean;
+  activeDatasources: string[];
+  richHistorySettings: RichHistorySettings;
+  updateFilters: (filtersToUpdate?: Partial<RichHistorySearchFilters>) => void;
+}
+
+/**
+ * Seeds the initial query-history search filters once, when the datasource list resolves.
+ * Shared by the Queries and Starred tabs so the two stay in lockstep (the drift between
+ * copies was the root cause of DPRO-205).
+ */
+export function useSeedRichHistoryFilters({
+  starred,
+  isLoadingDatasources,
+  dsListError,
+  activeDatasources,
+  richHistorySettings,
+  updateFilters,
+}: SeedRichHistoryFiltersOptions) {
+  // `isLoadingDatasources` flips false exactly once, so this seeds a single time on mount
+  // (the datasource list is fetched asynchronously). Re-running on other value changes would
+  // clobber user-adjusted filters.
+  useEffect(() => {
+    if (isLoadingDatasources) {
+      return;
+    }
+    // If the datasource list failed to load and we are restricting to active datasources,
+    // we cannot resolve their names. Seeding [] would silently mean "show everything" — the
+    // opposite of the setting — so skip seeding and let the tab surface the error instead.
+    if (dsListError && richHistorySettings.activeDatasourcesOnly) {
+      return;
+    }
+    const datasourceFilters =
+      !richHistorySettings.activeDatasourcesOnly && richHistorySettings.lastUsedDatasourceFilters
+        ? richHistorySettings.lastUsedDatasourceFilters
+        : activeDatasources;
+    const filters: RichHistorySearchFilters = {
+      search: '',
+      sortOrder: SortOrder.Descending,
+      datasourceFilters,
+      from: 0,
+      to: richHistorySettings.retentionPeriod,
+      starred,
+    };
+    updateFilters(filters);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isLoadingDatasources]);
+}

--- a/public/app/features/explore/state/history.test.ts
+++ b/public/app/features/explore/state/history.test.ts
@@ -1,0 +1,61 @@
+import { configureStore } from 'app/store/configureStore';
+
+import { supportedFeatures } from '../../../core/history/richHistoryStorageProvider';
+import { SortOrder } from '../../../core/utils/richHistoryTypes';
+
+import { updateHistorySearchFilters } from './history';
+
+jest.mock('app/core/utils/richHistory', () => ({
+  ...jest.requireActual('app/core/utils/richHistory'),
+  updateRichHistorySettings: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../../../core/history/richHistoryStorageProvider', () => ({
+  ...jest.requireActual('../../../core/history/richHistoryStorageProvider'),
+  supportedFeatures: jest.fn(),
+}));
+
+const { updateRichHistorySettings } = jest.requireMock('app/core/utils/richHistory');
+
+const baseSettings = {
+  retentionPeriod: 7,
+  starredTabAsFirstTab: false,
+  activeDatasourcesOnly: false,
+  lastUsedDatasourceFilters: ['prometheus'],
+};
+
+const baseFilters = {
+  search: '',
+  sortOrder: SortOrder.Descending,
+  datasourceFilters: ['loki'],
+  from: 0,
+  to: 7,
+  starred: false,
+};
+
+function setup(activeDatasourcesOnly: boolean) {
+  (supportedFeatures as jest.Mock).mockReturnValue({ lastUsedDataSourcesAvailable: true });
+  const store = configureStore({
+    explore: { richHistorySettings: { ...baseSettings, activeDatasourcesOnly } },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any);
+  return store;
+}
+
+describe('updateHistorySearchFilters', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('does not persist lastUsedDatasourceFilters when activeDatasourcesOnly is on', async () => {
+    const store = setup(true);
+    await store.dispatch(updateHistorySearchFilters(baseFilters));
+    expect(updateRichHistorySettings).not.toHaveBeenCalled();
+  });
+
+  it('persists lastUsedDatasourceFilters when activeDatasourcesOnly is off', async () => {
+    const store = setup(false);
+    await store.dispatch(updateHistorySearchFilters(baseFilters));
+    expect(updateRichHistorySettings).toHaveBeenCalledWith(
+      expect.objectContaining({ lastUsedDatasourceFilters: ['loki'] })
+    );
+  });
+});

--- a/public/app/features/explore/state/history.ts
+++ b/public/app/features/explore/state/history.ts
@@ -176,7 +176,11 @@ export const updateHistorySearchFilters = (filters: RichHistorySearchFilters): T
   return async (dispatch, getState) => {
     await dispatch(richHistorySearchFiltersUpdatedAction({ filters: { ...filters } }));
     const currentSettings = getState().explore.richHistorySettings!;
-    if (supportedFeatures().lastUsedDataSourcesAvailable) {
+    // Only persist the datasource filter as "last used" when it reflects a user choice.
+    // In active-datasources-only mode the datasource multiselect is hidden, so the only
+    // writer is the mount-seed forcing the active datasource — persisting it would clobber
+    // the filter the user set while the setting was off.
+    if (supportedFeatures().lastUsedDataSourcesAvailable && !currentSettings.activeDatasourcesOnly) {
       await dispatch(
         updateHistorySettings({
           ...currentSettings,

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -8722,6 +8722,7 @@
       "query-deleted": "Query deleted"
     },
     "rich-history-queries-tab": {
+      "datasource-list-error": "Unable to load data sources",
       "displaying-partial-queries_one": "Displaying {{ count }} queries",
       "displaying-partial-queries_other": "Displaying {{ count }} queries",
       "displaying-queries_one": "{{ count }} queries",
@@ -8730,6 +8731,7 @@
       "filter-history": "Filter history",
       "filter-placeholder": "Filter queries for data sources(s)",
       "history-local": "The history is local to your browser and is not shared with others.",
+      "load-error": "Unable to load query history",
       "loading": "Loading...",
       "loading-results": "Loading results...",
       "search-placeholder": "Search queries",
@@ -8758,8 +8760,10 @@
       }
     },
     "rich-history-starred-tab": {
+      "datasource-list-error": "Unable to load data sources",
       "filter-queries-aria-label": "Filter queries for data sources(s)",
       "filter-queries-placeholder": "Filter queries for data sources(s)",
+      "load-error": "Unable to load query history",
       "loading": "Loading...",
       "loading-results": "Loading results...",
       "local-history-message": "The history is local to your browser and is not shared with others.",


### PR DESCRIPTION
## Description

Consolidates the duplicated filter-seeding logic shared by the Explore **Query history** and **Starred** tabs into a single hook - the copy-drift that caused DPRO-205 - and fixes three pre-existing bugs once in that shared path.

Linear: https://linear.app/grafana/issue/DPRO-206

## Changes

* Extract the byte-identical mount-seeding effect into a shared `useSeedRichHistoryFilters` hook; lift datasource-list data into the parent so both tabs share one prop contract (removes the Starred tab's redundant datasource subscription).
* **Stuck loading:** a rejected history fetch now shows an inline error `Alert` instead of a permanent "Loading results…" spinner.
* **Filter clobber:** seeding no longer overwrites `lastUsedDatasourceFilters` when "active data sources only" is on.
* **Datasource-list failure:** in active-only mode a failed datasource-list load surfaces an error instead of silently showing every datasource's queries.
* Adds regression tests for each fix and two i18n keys.

## Risks

Confined to the Explore query-history drawer (both tabs). The refactor is behavior-preserving (verified line-for-line); the three fixes only add error/guard branches and don't alter the happy path. Local (IndexedDB/localStorage) last-used-filter behavior is the thing to watch; remote mode is unchanged (it intentionally doesn't support last-used filters). No `@grafana/*` public API or `grafana-runtime` changes.

## Demo

<!-- attach 08-activeonly-off.png: filter chip stays "TestData A" after toggling active-only on→off -->

## Testing Instructions

* Explore with local query history (default). Run queries on two datasources so history has entries.
* Open the **Query history** drawer, Settings → ensure "Only show queries for data source currently active in Explore" is **off**.
* Set the datasource filter to a datasource that is **not** the one active in Explore; close and reopen the drawer → filter is preserved.
* Settings → toggle "active data sources only" **on**, then **off**; reopen Query history → your saved filter is still there (not replaced by the active datasource).

## Reviewer Checklist

- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable