### PR TITLE
Analytics: PostHog Init Bugfix

### DIFF
--- a/public/app/core/services/echo/backends/analytics/PostHogBackend.ts
+++ b/public/app/core/services/echo/backends/analytics/PostHogBackend.ts
@@ -46,21 +46,29 @@ export class PostHogBackend implements EchoBackend<PageviewEchoEvent, PostHogBac
     const apiHost = options.postHogHost || DEFAULT_POSTHOG_HOST;
 
     if (!(window.posthog && window.posthog.__loaded)) {
-      // loadScript is not awaited (constructors can't be async), so init/identify/capture
-      // are called before the SDK has loaded. These stubs queue calls for the real SDK to replay.
+      // loadScript is not awaited (constructors can't be async), so identify/capture are
+      // called before the SDK has loaded. These stubs queue those calls for the SDK to replay.
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions, @typescript-eslint/no-explicit-any
       const tempPosthog: any[] = ((window as Record<string, any>).posthog = []);
-      for (const method of ['init', 'identify', 'capture']) {
+      for (const method of ['identify', 'capture']) {
         // eslint-disable-next-line @typescript-eslint/consistent-type-assertions, @typescript-eslint/no-explicit-any
         (tempPosthog as Record<string, any>)[method] = function (...args: unknown[]) {
           tempPosthog.push([method, ...args]);
         };
       }
 
-      loadScript(`${apiHost}/static/array.js`, true);
-    }
+      // array.js replays pending init() calls from the standard snippet's _i queue rather than
+      // from the array above, so register init in that format or the token is silently dropped.
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions, @typescript-eslint/no-explicit-any
+      const ph = tempPosthog as Record<string, any>;
+      ph.__SV = 1;
+      ph._i = ph._i || [];
+      ph._i.push([options.postHogToken, { api_host: apiHost }, '']);
 
-    window.posthog?.init?.(options.postHogToken, { api_host: apiHost });
+      loadScript(`${apiHost}/static/array.js`, true);
+    } else {
+      window.posthog.init?.(options.postHogToken, { api_host: apiHost });
+    }
 
     if (options.user) {
       window.posthog?.identify?.(options.user.analytics.identifier, {

--- a/public/app/core/services/echo/backends/analytics/PostHogBackend.ts
+++ b/public/app/core/services/echo/backends/analytics/PostHogBackend.ts
@@ -48,21 +48,18 @@ export class PostHogBackend implements EchoBackend<PageviewEchoEvent, PostHogBac
     if (!(window.posthog && window.posthog.__loaded)) {
       // loadScript is not awaited (constructors can't be async), so identify/capture are
       // called before the SDK has loaded. These stubs queue those calls for the SDK to replay.
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions, @typescript-eslint/no-explicit-any
-      const tempPosthog: any[] = ((window as Record<string, any>).posthog = []);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const tempPosthog: any = (window.posthog = []);
       for (const method of ['identify', 'capture']) {
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions, @typescript-eslint/no-explicit-any
-        (tempPosthog as Record<string, any>)[method] = function (...args: unknown[]) {
+        tempPosthog[method] = function (...args: unknown[]) {
           tempPosthog.push([method, ...args]);
         };
       }
 
       // array.js replays pending init() calls from the standard snippet's _i queue rather than
       // from the array above, so register init in that format or the token is silently dropped.
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions, @typescript-eslint/no-explicit-any
-      (tempPosthog as Record<string, any>).__SV = 1;
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions, @typescript-eslint/no-explicit-any
-      (tempPosthog as Record<string, any>)._i = [[options.postHogToken, { api_host: apiHost }, 'posthog']];
+      tempPosthog.__SV = 1;
+      tempPosthog._i = [[options.postHogToken, { api_host: apiHost }, 'posthog']];
 
       loadScript(`${apiHost}/static/array.js`, true);
     } else {

--- a/public/app/core/services/echo/backends/analytics/PostHogBackend.ts
+++ b/public/app/core/services/echo/backends/analytics/PostHogBackend.ts
@@ -60,10 +60,9 @@ export class PostHogBackend implements EchoBackend<PageviewEchoEvent, PostHogBac
       // array.js replays pending init() calls from the standard snippet's _i queue rather than
       // from the array above, so register init in that format or the token is silently dropped.
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions, @typescript-eslint/no-explicit-any
-      const ph = tempPosthog as Record<string, any>;
-      ph.__SV = 1;
-      ph._i = ph._i || [];
-      ph._i.push([options.postHogToken, { api_host: apiHost }, '']);
+      (tempPosthog as Record<string, any>).__SV = 1;
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions, @typescript-eslint/no-explicit-any
+      (tempPosthog as Record<string, any>)._i = [[options.postHogToken, { api_host: apiHost }, '']];
 
       loadScript(`${apiHost}/static/array.js`, true);
     } else {

--- a/public/app/core/services/echo/backends/analytics/PostHogBackend.ts
+++ b/public/app/core/services/echo/backends/analytics/PostHogBackend.ts
@@ -49,7 +49,8 @@ export class PostHogBackend implements EchoBackend<PageviewEchoEvent, PostHogBac
       // loadScript is not awaited (constructors can't be async), so identify/capture are
       // called before the SDK has loaded. These stubs queue those calls for the SDK to replay.
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const tempPosthog: any = (window.posthog = []);
+      const tempPosthog: any = [];
+      window.posthog = tempPosthog;
       for (const method of ['identify', 'capture']) {
         tempPosthog[method] = function (...args: unknown[]) {
           tempPosthog.push([method, ...args]);

--- a/public/app/core/services/echo/backends/analytics/PostHogBackend.ts
+++ b/public/app/core/services/echo/backends/analytics/PostHogBackend.ts
@@ -62,7 +62,7 @@ export class PostHogBackend implements EchoBackend<PageviewEchoEvent, PostHogBac
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions, @typescript-eslint/no-explicit-any
       (tempPosthog as Record<string, any>).__SV = 1;
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions, @typescript-eslint/no-explicit-any
-      (tempPosthog as Record<string, any>)._i = [[options.postHogToken, { api_host: apiHost }, '']];
+      (tempPosthog as Record<string, any>)._i = [[options.postHogToken, { api_host: apiHost }, 'posthog']];
 
       loadScript(`${apiHost}/static/array.js`, true);
     } else {


### PR DESCRIPTION
**What is this feature?**

Resolves an issue with PostHog analytics integration where the token would not be populated, so the PostHog SDK was not able to send events.

**Why do we need this feature?**

So PostHog analytics work correctly.

**Who is this feature for?**

Anyone who uses the PostHog integration.

**Which issue(s) does this PR fix?**:

Fixes #128546 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
