### PR TITLE
Provisioning: fix flaky path-conflict-on-enable-sync

### DIFF
--- a/pkg/tests/apis/provisioning/repository/repository_test.go
+++ b/pkg/tests/apis/provisioning/repository/repository_test.go
@@ -713,8 +713,6 @@ func TestIntegrationProvisioning_RepositoryValidation(t *testing.T) {
 
 	// Test that enabling sync on a repo with a conflicting path is rejected
 	t.Run("Git repository path conflict detected when enabling sync", func(t *testing.T) {
-		t.Skip("currently blocking many PRs")
-
 		baseURL := "https://github.com/grafana/test-repo-enable-sync-conflict"
 
 		// Create an initial repo with sync enabled and a specific path
@@ -741,9 +739,17 @@ func TestIntegrationProvisioning_RepositoryValidation(t *testing.T) {
 		created, err := helper.Repositories.Resource.Create(t.Context(), secondRepo, metav1.CreateOptions{FieldValidation: "Strict"})
 		require.NoError(t, err, "Second repository with child path should succeed when sync is disabled")
 
-		// Now try to enable sync on the second repo - this should fail due to parent/child conflict
-		created.Object["spec"].(map[string]interface{})["sync"].(map[string]interface{})["enabled"] = true
-		_, err = helper.Repositories.Resource.Update(t.Context(), created, metav1.UpdateOptions{FieldValidation: "Strict"})
+		// Now try to enable sync on the second repo - this should fail due to parent/child conflict.
+		// Always re-Get to avoid stale resourceVersion conflicts from concurrent status updates.
+		err = common.RetryOnConflict(t, func() error {
+			obj, err := helper.Repositories.Resource.Get(t.Context(), created.GetName(), metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			obj.Object["spec"].(map[string]interface{})["sync"].(map[string]interface{})["enabled"] = true
+			_, err = helper.Repositories.Resource.Update(t.Context(), obj, metav1.UpdateOptions{FieldValidation: "Strict"})
+			return err
+		})
 		require.Error(t, err, "Enabling sync should fail due to parent/child path conflict")
 		require.ErrorContains(t, err, provisioningAPIServer.ErrRepositoryParentFolderConflict.Error())
 	})


### PR DESCRIPTION
…ation test

The test flaked with 409 Conflict because the Update reused the stale object returned by Create; the status controller updates the repository in between, so the stale resourceVersion conflicted instead of surfacing the expected admission error. Re-Get the repository inside RetryOnConflict so the Update carries a fresh resourceVersion.

clean

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

[Add a brief description of what the feature or update does.]

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
