### PR TITLE
TestUtils: Add Path2D copy-constructor shim for canvas tests

### DIFF
--- a/packages/grafana-test-utils/src/canvas/index.ts
+++ b/packages/grafana-test-utils/src/canvas/index.ts
@@ -6,4 +6,6 @@ export {
   type GrafanaUiMeasureTextFn,
 } from './measureText';
 
+export { installCanvasPath2DShim } from './path2d';
+
 export { removeCanvasTransforms } from 'jest-canvas-mock-compare';

--- a/packages/grafana-test-utils/src/canvas/path2d.test.ts
+++ b/packages/grafana-test-utils/src/canvas/path2d.test.ts
@@ -1,0 +1,48 @@
+/**
+ * @jest-environment jsdom
+ */
+import 'jest-canvas-mock';
+
+import { installCanvasPath2DShim } from './path2d';
+
+describe('installCanvasPath2DShim', () => {
+  installCanvasPath2DShim();
+
+  it('preserves geometry through the copy constructor', () => {
+    const stroke = new Path2D();
+    stroke.moveTo(0, 0);
+    stroke.lineTo(10, 10);
+    stroke.lineTo(20, 5);
+
+    const copy = new Path2D(stroke);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((copy as any)._path).toHaveLength((stroke as any)._path.length);
+  });
+
+  it('makes ctx.fill capture the copied path (uPlot area-fill pattern)', () => {
+    const ctx = document.createElement('canvas').getContext('2d')!;
+
+    // Mirror uPlot: build a stroke path, copy it into the fill, extend to a baseline, then fill.
+    const stroke = new Path2D();
+    stroke.moveTo(0, 0);
+    stroke.lineTo(10, 10);
+    stroke.lineTo(20, 5);
+
+    const fill = new Path2D(stroke);
+    fill.lineTo(20, 100);
+    fill.lineTo(0, 100);
+    ctx.fill(fill);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const fillEvent = (ctx as any).__getEvents().find((e: { type: string }) => e.type === 'fill');
+    // 3 from the copied stroke + 2 baseline = 5. Without the shim this would be only the 2 baseline points.
+    expect(fillEvent.props.path).toHaveLength(5);
+  });
+
+  it('is idempotent', () => {
+    const first = globalThis.Path2D;
+    installCanvasPath2DShim();
+    expect(globalThis.Path2D).toBe(first);
+  });
+});

--- a/packages/grafana-test-utils/src/canvas/path2d.ts
+++ b/packages/grafana-test-utils/src/canvas/path2d.ts
@@ -1,47 +1,31 @@
 /**
- * jest-canvas-mock's `Path2D` ignores its constructor argument. Real browsers (and uPlot) rely on the
- * copy constructor `new Path2D(otherPath)` — uPlot builds series area fills as `new Path2D(strokePath)`,
- * then extends them to the baseline. Under the unpatched mock the copied geometry is dropped, so
- * `ctx.fill(path)` records a degenerate path and the fill never appears in the snapshot.
+ * jest-canvas-mock's `Path2D` ignores its constructor argument, so `new Path2D(otherPath)` drops the
+ * copied geometry. uPlot builds series area fills that way (`new Path2D(strokePath)`, then extends them to
+ * the baseline), so without this fix area fills, gradient bands, and markers never appear in canvas
+ * snapshots. This installs a `Path2D` that honors the copy constructor; call once before rendering.
  *
- * This installs a `Path2D` subclass that honors the copy constructor, so copied paths are captured by
- * `ctx.fill` / `ctx.stroke` / `ctx.clip`. Call once before rendering (module scope or `beforeAll`).
- *
- * No-op if already installed, or if `Path2D` is unavailable (e.g. non-canvas-mock environments).
- * SVG path-string construction (`new Path2D('M0 0 L1 1')`) is intentionally not supported — uPlot does
- * not use it, and the unpatched mock already ignored it, so this is not a regression.
+ * SVG path-string construction (`new Path2D('M0 0 L1 1')`) is not supported — uPlot doesn't use it, and the
+ * unpatched mock already ignored it.
  */
-
-const SHIM_FLAG = '__grafanaCanvasPath2DShim';
-
-// jest-canvas-mock's Path2D stores its recorded ops on a `_path` array.
-interface MockPath2D {
-  _path?: unknown[];
-}
+let installed = false;
 
 export function installCanvasPath2DShim(): void {
-  const Base: typeof Path2D | undefined = globalThis.Path2D;
-
-  if (!Base || (Base as unknown as Record<string, unknown>)[SHIM_FLAG]) {
+  const Base = globalThis.Path2D;
+  if (installed || typeof Base !== 'function') {
     return;
   }
+  installed = true;
 
-  const BaseCtor: typeof Path2D = Base;
-
-  class Path2DWithCopyConstructor extends BaseCtor {
+  globalThis.Path2D = class extends Base {
     constructor(path?: Path2D | string) {
       super();
-
-      if (path instanceof BaseCtor) {
-        const src = path as unknown as MockPath2D;
-        const dest = this as unknown as MockPath2D;
-        if (Array.isArray(src._path) && Array.isArray(dest._path)) {
-          dest._path.push(...src._path);
-        }
+      // jest-canvas-mock records path ops on a private `_path` array; copy the source's when cloning.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const src = path as any;
+      if (path instanceof Base && Array.isArray(src._path)) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (this as any)._path.push(...src._path);
       }
     }
-  }
-
-  Object.defineProperty(Path2DWithCopyConstructor, SHIM_FLAG, { value: true });
-  globalThis.Path2D = Path2DWithCopyConstructor;
+  };
 }

--- a/packages/grafana-test-utils/src/canvas/path2d.ts
+++ b/packages/grafana-test-utils/src/canvas/path2d.ts
@@ -1,0 +1,47 @@
+/**
+ * jest-canvas-mock's `Path2D` ignores its constructor argument. Real browsers (and uPlot) rely on the
+ * copy constructor `new Path2D(otherPath)` — uPlot builds series area fills as `new Path2D(strokePath)`,
+ * then extends them to the baseline. Under the unpatched mock the copied geometry is dropped, so
+ * `ctx.fill(path)` records a degenerate path and the fill never appears in the snapshot.
+ *
+ * This installs a `Path2D` subclass that honors the copy constructor, so copied paths are captured by
+ * `ctx.fill` / `ctx.stroke` / `ctx.clip`. Call once before rendering (module scope or `beforeAll`).
+ *
+ * No-op if already installed, or if `Path2D` is unavailable (e.g. non-canvas-mock environments).
+ * SVG path-string construction (`new Path2D('M0 0 L1 1')`) is intentionally not supported — uPlot does
+ * not use it, and the unpatched mock already ignored it, so this is not a regression.
+ */
+
+const SHIM_FLAG = '__grafanaCanvasPath2DShim';
+
+// jest-canvas-mock's Path2D stores its recorded ops on a `_path` array.
+interface MockPath2D {
+  _path?: unknown[];
+}
+
+export function installCanvasPath2DShim(): void {
+  const Base: typeof Path2D | undefined = globalThis.Path2D;
+
+  if (!Base || (Base as unknown as Record<string, unknown>)[SHIM_FLAG]) {
+    return;
+  }
+
+  const BaseCtor: typeof Path2D = Base;
+
+  class Path2DWithCopyConstructor extends BaseCtor {
+    constructor(path?: Path2D | string) {
+      super();
+
+      if (path instanceof BaseCtor) {
+        const src = path as unknown as MockPath2D;
+        const dest = this as unknown as MockPath2D;
+        if (Array.isArray(src._path) && Array.isArray(dest._path)) {
+          dest._path.push(...src._path);
+        }
+      }
+    }
+  }
+
+  Object.defineProperty(Path2DWithCopyConstructor, SHIM_FLAG, { value: true });
+  globalThis.Path2D = Path2DWithCopyConstructor;
+}

--- a/packages/grafana-test-utils/src/canvas/path2d.ts
+++ b/packages/grafana-test-utils/src/canvas/path2d.ts
@@ -22,7 +22,7 @@ export function installCanvasPath2DShim(): void {
       // jest-canvas-mock records path ops on a private `_path` array; copy the source's when cloning.
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const src = path as any;
-      if (path instanceof Base && Array.isArray(src._path)) {
+      if (path instanceof Base) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (this as any)._path.push(...src._path);
       }

--- a/packages/grafana-test-utils/src/canvas/path2d.ts
+++ b/packages/grafana-test-utils/src/canvas/path2d.ts
@@ -6,6 +6,10 @@
  *
  * SVG path-string construction (`new Path2D('M0 0 L1 1')`) is not supported — uPlot doesn't use it, and the
  * unpatched mock already ignored it.
+ *
+ * This reassigns the global `Path2D`, so call it from a suite's setup or a test module's top scope — never
+ * from a global jest setupFile. jest gives each test file its own environment, so the swap stays scoped to
+ * the file that calls it; wiring it globally would patch `Path2D` for every test.
  */
 let installed = false;
 


### PR DESCRIPTION
## Summary

Adds `installCanvasPath2DShim()` to `@grafana/test-utils/canvas` — an opt-in helper that lets canvas snapshot tests capture uPlot **area fills, gradient bands, and point markers**, which are currently dropped.

## What this enables

Canvas snapshot tests (`*.canvas.test.tsx`) record the drawing operations a panel makes, then assert on them.

**Before — these were captured:**
- ✅ Line strokes
- ✅ Bars
- ✅ Axes, grid lines, tick labels

**Before — these silently vanished** (couldn't be asserted or seen in the compare viewer):
- ❌ Area fills (`fillOpacity`)
- ❌ Gradient bands (`gradientMode`)
- ❌ Point markers (`drawStyle: points`)

**After (for tests that opt in):** all of the above are captured, so fills, bands, and markers can be regression-tested and viewed.

<details>
<summary>Why they were dropped</summary>

uPlot builds a series fill by copying the line path — `new Path2D(strokePath)` — then extending it to the baseline. `jest-canvas-mock`'s `Path2D` ignores its constructor argument, so the copied geometry is lost and the recorded fill is empty. The shim replaces the global `Path2D` with a subclass that honors the copy constructor, so those paths flow through to `ctx.fill` / `ctx.stroke` / `ctx.clip`.

</details>

## Usage

Call it once at the top of a canvas test, before rendering:

```ts
import { installCanvasPath2DShim } from '@grafana/test-utils/canvas';

installCanvasPath2DShim();
```

## No side-effects for existing tests

- **Opt-in.** This only adds a new export. `globalThis.Path2D` is replaced **only when a test calls `installCanvasPath2DShim()`** — nothing runs on import.
- **Existing canvas tests are untouched.** Heatmap, xychart, sparkline, etc. don't call it, so their behavior and snapshots are unchanged.
- **No change to existing exports** (`applyDefaultUPlotAxisMeasureTextMock`, `createGrafanaUiMeasureTextJestMock`, `removeCanvasTransforms`).
- Idempotent, and a no-op outside canvas-mock environments.

The first consumer is #127513 (TimeSeries panel canvas tests), which stacks on this PR.

## Test plan

- [ ] `yarn jest --config packages/grafana-test-utils/jest.config.js packages/grafana-test-utils/src/canvas/path2d.test.ts` — 3 passed:
  - copy constructor preserves geometry
  - `ctx.fill` captures the copied path (the uPlot area-fill pattern)
  - idempotent

