### PR TITLE
TimeSeries: Render fills, gradient bands, and point markers in canvas tests

### DIFF
--- a/packages/grafana-test-utils/src/canvas/index.ts
+++ b/packages/grafana-test-utils/src/canvas/index.ts
@@ -6,4 +6,6 @@ export {
   type GrafanaUiMeasureTextFn,
 } from './measureText';
 
+export { installCanvasPath2DShim } from './path2d';
+
 export { removeCanvasTransforms } from 'jest-canvas-mock-compare';

--- a/packages/grafana-test-utils/src/canvas/path2d.test.ts
+++ b/packages/grafana-test-utils/src/canvas/path2d.test.ts
@@ -1,0 +1,48 @@
+/**
+ * @jest-environment jsdom
+ */
+import 'jest-canvas-mock';
+
+import { installCanvasPath2DShim } from './path2d';
+
+describe('installCanvasPath2DShim', () => {
+  installCanvasPath2DShim();
+
+  it('preserves geometry through the copy constructor', () => {
+    const stroke = new Path2D();
+    stroke.moveTo(0, 0);
+    stroke.lineTo(10, 10);
+    stroke.lineTo(20, 5);
+
+    const copy = new Path2D(stroke);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((copy as any)._path).toHaveLength((stroke as any)._path.length);
+  });
+
+  it('makes ctx.fill capture the copied path (uPlot area-fill pattern)', () => {
+    const ctx = document.createElement('canvas').getContext('2d')!;
+
+    // Mirror uPlot: build a stroke path, copy it into the fill, extend to a baseline, then fill.
+    const stroke = new Path2D();
+    stroke.moveTo(0, 0);
+    stroke.lineTo(10, 10);
+    stroke.lineTo(20, 5);
+
+    const fill = new Path2D(stroke);
+    fill.lineTo(20, 100);
+    fill.lineTo(0, 100);
+    ctx.fill(fill);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const fillEvent = (ctx as any).__getEvents().find((e: { type: string }) => e.type === 'fill');
+    // 3 from the copied stroke + 2 baseline = 5. Without the shim this would be only the 2 baseline points.
+    expect(fillEvent.props.path).toHaveLength(5);
+  });
+
+  it('is idempotent', () => {
+    const first = globalThis.Path2D;
+    installCanvasPath2DShim();
+    expect(globalThis.Path2D).toBe(first);
+  });
+});

--- a/packages/grafana-test-utils/src/canvas/path2d.ts
+++ b/packages/grafana-test-utils/src/canvas/path2d.ts
@@ -1,47 +1,31 @@
 /**
- * jest-canvas-mock's `Path2D` ignores its constructor argument. Real browsers (and uPlot) rely on the
- * copy constructor `new Path2D(otherPath)` — uPlot builds series area fills as `new Path2D(strokePath)`,
- * then extends them to the baseline. Under the unpatched mock the copied geometry is dropped, so
- * `ctx.fill(path)` records a degenerate path and the fill never appears in the snapshot.
+ * jest-canvas-mock's `Path2D` ignores its constructor argument, so `new Path2D(otherPath)` drops the
+ * copied geometry. uPlot builds series area fills that way (`new Path2D(strokePath)`, then extends them to
+ * the baseline), so without this fix area fills, gradient bands, and markers never appear in canvas
+ * snapshots. This installs a `Path2D` that honors the copy constructor; call once before rendering.
  *
- * This installs a `Path2D` subclass that honors the copy constructor, so copied paths are captured by
- * `ctx.fill` / `ctx.stroke` / `ctx.clip`. Call once before rendering (module scope or `beforeAll`).
- *
- * No-op if already installed, or if `Path2D` is unavailable (e.g. non-canvas-mock environments).
- * SVG path-string construction (`new Path2D('M0 0 L1 1')`) is intentionally not supported — uPlot does
- * not use it, and the unpatched mock already ignored it, so this is not a regression.
+ * SVG path-string construction (`new Path2D('M0 0 L1 1')`) is not supported — uPlot doesn't use it, and the
+ * unpatched mock already ignored it.
  */
-
-const SHIM_FLAG = '__grafanaCanvasPath2DShim';
-
-// jest-canvas-mock's Path2D stores its recorded ops on a `_path` array.
-interface MockPath2D {
-  _path?: unknown[];
-}
+let installed = false;
 
 export function installCanvasPath2DShim(): void {
-  const Base: typeof Path2D | undefined = globalThis.Path2D;
-
-  if (!Base || (Base as unknown as Record<string, unknown>)[SHIM_FLAG]) {
+  const Base = globalThis.Path2D;
+  if (installed || typeof Base !== 'function') {
     return;
   }
+  installed = true;
 
-  const BaseCtor: typeof Path2D = Base;
-
-  class Path2DWithCopyConstructor extends BaseCtor {
+  globalThis.Path2D = class extends Base {
     constructor(path?: Path2D | string) {
       super();
-
-      if (path instanceof BaseCtor) {
-        const src = path as unknown as MockPath2D;
-        const dest = this as unknown as MockPath2D;
-        if (Array.isArray(src._path) && Array.isArray(dest._path)) {
-          dest._path.push(...src._path);
-        }
+      // jest-canvas-mock records path ops on a private `_path` array; copy the source's when cloning.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const src = path as any;
+      if (path instanceof Base && Array.isArray(src._path)) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (this as any)._path.push(...src._path);
       }
     }
-  }
-
-  Object.defineProperty(Path2DWithCopyConstructor, SHIM_FLAG, { value: true });
-  globalThis.Path2D = Path2DWithCopyConstructor;
+  };
 }

--- a/packages/grafana-test-utils/src/canvas/path2d.ts
+++ b/packages/grafana-test-utils/src/canvas/path2d.ts
@@ -1,0 +1,47 @@
+/**
+ * jest-canvas-mock's `Path2D` ignores its constructor argument. Real browsers (and uPlot) rely on the
+ * copy constructor `new Path2D(otherPath)` — uPlot builds series area fills as `new Path2D(strokePath)`,
+ * then extends them to the baseline. Under the unpatched mock the copied geometry is dropped, so
+ * `ctx.fill(path)` records a degenerate path and the fill never appears in the snapshot.
+ *
+ * This installs a `Path2D` subclass that honors the copy constructor, so copied paths are captured by
+ * `ctx.fill` / `ctx.stroke` / `ctx.clip`. Call once before rendering (module scope or `beforeAll`).
+ *
+ * No-op if already installed, or if `Path2D` is unavailable (e.g. non-canvas-mock environments).
+ * SVG path-string construction (`new Path2D('M0 0 L1 1')`) is intentionally not supported — uPlot does
+ * not use it, and the unpatched mock already ignored it, so this is not a regression.
+ */
+
+const SHIM_FLAG = '__grafanaCanvasPath2DShim';
+
+// jest-canvas-mock's Path2D stores its recorded ops on a `_path` array.
+interface MockPath2D {
+  _path?: unknown[];
+}
+
+export function installCanvasPath2DShim(): void {
+  const Base: typeof Path2D | undefined = globalThis.Path2D;
+
+  if (!Base || (Base as unknown as Record<string, unknown>)[SHIM_FLAG]) {
+    return;
+  }
+
+  const BaseCtor: typeof Path2D = Base;
+
+  class Path2DWithCopyConstructor extends BaseCtor {
+    constructor(path?: Path2D | string) {
+      super();
+
+      if (path instanceof BaseCtor) {
+        const src = path as unknown as MockPath2D;
+        const dest = this as unknown as MockPath2D;
+        if (Array.isArray(src._path) && Array.isArray(dest._path)) {
+          dest._path.push(...src._path);
+        }
+      }
+    }
+  }
+
+  Object.defineProperty(Path2DWithCopyConstructor, SHIM_FLAG, { value: true });
+  globalThis.Path2D = Path2DWithCopyConstructor;
+}

--- a/public/app/plugins/panel/timeseries/TimeSeriesPanel.canvas.test.tsx
+++ b/public/app/plugins/panel/timeseries/TimeSeriesPanel.canvas.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen, waitFor } from '@testing-library/react';
-import { type CanvasRenderingContext2DEvent } from 'jest-canvas-mock';
 import type uPlot from 'uplot';
 
 import {
@@ -30,8 +29,13 @@ import {
   SortOrder,
   StackingMode,
   TooltipDisplayMode,
+  VisibilityMode,
 } from '@grafana/schema';
-import { applyDefaultUPlotAxisMeasureTextMock, removeCanvasTransforms } from '@grafana/test-utils/canvas';
+import {
+  applyDefaultUPlotAxisMeasureTextMock,
+  installCanvasPath2DShim,
+  removeCanvasTransforms,
+} from '@grafana/test-utils/canvas';
 import { measureText as uPlotAxisMeasureText, type UPlotConfigBuilder } from '@grafana/ui';
 import * as timeSeriesUtils from 'app/core/components/TimeSeries/utils';
 
@@ -47,6 +51,10 @@ import { type Options } from './panelcfg.gen';
  * lineWidth, etc.) never reaches `field.config.custom`, so every option permutation renders identically.
  * The registry must carry the time series custom config so `custom.*` defaults are applied.
  */
+// uPlot builds series area fills via the Path2D copy constructor, which jest-canvas-mock drops. This shim
+// preserves it so fills/gradient bands/markers land in the captured draw calls (see @grafana/test-utils).
+installCanvasPath2DShim();
+
 const graphFieldConfigRegistry = createFieldConfigRegistry(getGraphFieldConfig(defaultGraphConfig), 'Time series');
 
 /** The default dark theme is argument-free and stable, so build it once for the whole suite. */
@@ -208,8 +216,10 @@ describe('TimeSeriesPanel (canvas)', () => {
   const { preparePlotConfigBuilder: realPreparePlotConfigBuilder } = jest.requireActual(
     'app/core/components/TimeSeries/utils'
   );
-  let uPlotAxisEvents: CanvasRenderingContext2DEvent[] | null = null;
-  let clearAxisEvents = true;
+  // Index that splits the axis/grid pass from the series pass within one captured frame. uPlot draws axes
+  // first (drawAxes), then series (fill/stroke/markers). We reset at the start of each frame (drawClear) and
+  // record the boundary at drawAxes WITHOUT clearing — clearing there dropped the whole series pass.
+  let axisBoundary = 0;
 
   const assertUPlotReady = async () => {
     expect(screen.getByTestId(selectors.components.VizLayout.container)).toBeVisible();
@@ -220,15 +230,16 @@ describe('TimeSeriesPanel (canvas)', () => {
 
   const assertCanvasOutput = async (snapshotSize: { width: number; height: number } = { width, height }) => {
     await assertUPlotReady();
-    expect(removeCanvasTransforms(uPlotInstance!.ctx.__getEvents())).toMatchCanvasSnapshot(
-      uPlotAxisEvents!,
-      snapshotSize
-    );
+    const frame = uPlotInstance!.ctx.__getEvents();
+    const seriesEvents = removeCanvasTransforms(frame.slice(axisBoundary));
+    // Context (axis/grid) events are passed raw for the compare viewer; only the asserted series events are scrubbed.
+    expect(seriesEvents).toMatchCanvasSnapshot(frame.slice(0, axisBoundary), snapshotSize);
   };
 
   const assertAxesOutput = async (snapshotSize: { width: number; height: number } = { width, height }) => {
     await assertUPlotReady();
-    expect(removeCanvasTransforms(uPlotAxisEvents!)).toMatchCanvasSnapshot([], snapshotSize);
+    const axisEvents = removeCanvasTransforms(uPlotInstance!.ctx.__getEvents().slice(0, axisBoundary));
+    expect(axisEvents).toMatchCanvasSnapshot([], snapshotSize);
   };
 
   beforeEach(() => {
@@ -238,14 +249,17 @@ describe('TimeSeriesPanel (canvas)', () => {
       .mockImplementation((...args: Parameters<typeof realPreparePlotConfigBuilder>) => {
         const builder: UPlotConfigBuilder = realPreparePlotConfigBuilder(...args);
 
+        builder.addHook('drawClear', (u: uPlot) => {
+          u.ctx.__clearDrawCalls();
+          u.ctx.__clearEvents();
+          u.ctx.__clearPath();
+        });
         builder.addHook('drawAxes', (u: uPlot) => {
           uPlotInstance = u;
-          uPlotAxisEvents = u.ctx.__getEvents();
-          if (clearAxisEvents) {
-            u.ctx.__clearDrawCalls();
-            u.ctx.__clearEvents();
-            u.ctx.__clearPath();
-          }
+          axisBoundary = u.ctx.__getEvents().length;
+        });
+        builder.addHook('draw', (u: uPlot) => {
+          uPlotInstance = u;
         });
 
         return builder;
@@ -265,7 +279,11 @@ describe('TimeSeriesPanel (canvas)', () => {
         .filter((drawStyle) => drawStyle !== GraphDrawStyle.Line)
         .map((drawStyle) => ({
           name: `drawStyle: ${drawStyle}`,
-          panelProps: customFieldConfig({ drawStyle, fillOpacity: 25 }, fixedBlue),
+          // showPoints/pointSize so the points draw style renders visible markers (default size is invisible).
+          panelProps: customFieldConfig(
+            { drawStyle, fillOpacity: 25, showPoints: VisibilityMode.Always, pointSize: 6 },
+            fixedBlue
+          ),
         })),
       // Linear is the default interpolation, covered by `defaults`.
       ...Object.values(LineInterpolation)

--- a/public/app/plugins/panel/timeseries/__snapshots__/TimeSeriesPanel.canvas.test.tsx.snap
+++ b/public/app/plugins/panel/timeseries/__snapshots__/TimeSeriesPanel.canvas.test.tsx.snap
@@ -670,15 +670,6 @@ exports[`TimeSeriesPanel (canvas) Axes X Axis: defaults 1`] = `
 [
   {
     "props": {
-      "height": 378,
-      "width": 648,
-      "x": 0,
-      "y": 0,
-    },
-    "type": "clearRect",
-  },
-  {
-    "props": {
       "value": "#ccccdc",
     },
     "type": "fillStyle",
@@ -1353,15 +1344,6 @@ exports[`TimeSeriesPanel (canvas) Axes X Axis: defaults 1`] = `
 
 exports[`TimeSeriesPanel (canvas) Axes Y Axis placement: bottom 1`] = `
 [
-  {
-    "props": {
-      "height": 378,
-      "width": 648,
-      "x": 0,
-      "y": 0,
-    },
-    "type": "clearRect",
-  },
   {
     "props": {
       "value": "#ccccdc",
@@ -2719,31 +2701,10 @@ exports[`TimeSeriesPanel (canvas) Axes Y Axis placement: bottom 1`] = `
 ]
 `;
 
-exports[`TimeSeriesPanel (canvas) Axes Y Axis placement: hidden 1`] = `
-[
-  {
-    "props": {
-      "height": 378,
-      "width": 648,
-      "x": 0,
-      "y": 0,
-    },
-    "type": "clearRect",
-  },
-]
-`;
+exports[`TimeSeriesPanel (canvas) Axes Y Axis placement: hidden 1`] = `[]`;
 
 exports[`TimeSeriesPanel (canvas) Axes Y Axis placement: right 1`] = `
 [
-  {
-    "props": {
-      "height": 378,
-      "width": 648,
-      "x": 0,
-      "y": 0,
-    },
-    "type": "clearRect",
-  },
   {
     "props": {
       "value": "#ccccdc",
@@ -3420,15 +3381,6 @@ exports[`TimeSeriesPanel (canvas) Axes Y Axis placement: right 1`] = `
 
 exports[`TimeSeriesPanel (canvas) Axes Y Axis placement: top 1`] = `
 [
-  {
-    "props": {
-      "height": 378,
-      "width": 648,
-      "x": 0,
-      "y": 0,
-    },
-    "type": "clearRect",
-  },
   {
     "props": {
       "value": "#ccccdc",
@@ -4796,15 +4748,6 @@ exports[`TimeSeriesPanel (canvas) Axes Y Axis: hard min/max 1`] = `
 [
   {
     "props": {
-      "height": 378,
-      "width": 648,
-      "x": 0,
-      "y": 0,
-    },
-    "type": "clearRect",
-  },
-  {
-    "props": {
       "value": "#ccccdc",
     },
     "type": "fillStyle",
@@ -5516,15 +5459,6 @@ exports[`TimeSeriesPanel (canvas) Axes Y Axis: hard min/max 1`] = `
 
 exports[`TimeSeriesPanel (canvas) Axes Y Axis: soft min/max 1`] = `
 [
-  {
-    "props": {
-      "height": 378,
-      "width": 648,
-      "x": 0,
-      "y": 0,
-    },
-    "type": "clearRect",
-  },
   {
     "props": {
       "value": "#ccccdc",
@@ -6771,6 +6705,246 @@ exports[`TimeSeriesPanel (canvas) Options drawStyle: bars 1`] = `
     "type": "translate",
   },
   {
+    "props": {
+      "x": 0.5,
+      "y": 0.5,
+    },
+    "type": "translate",
+  },
+  {
+    "props": {
+      "value": "#5794f2",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {},
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {
+            "height": 359,
+            "width": 626,
+            "x": 19,
+            "y": 3,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "clip",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {
+            "x": 129.5,
+            "y": 320,
+          },
+          "type": "moveTo",
+        },
+        {
+          "props": {
+            "anticlockwise": false,
+            "endAngle": 6.283185307179586,
+            "radius": 2.5,
+            "startAngle": 0,
+            "x": 127,
+            "y": 320,
+          },
+          "type": "arc",
+        },
+        {
+          "props": {
+            "x": 231.5,
+            "y": 137,
+          },
+          "type": "moveTo",
+        },
+        {
+          "props": {
+            "anticlockwise": false,
+            "endAngle": 6.283185307179586,
+            "radius": 2.5,
+            "startAngle": 0,
+            "x": 229,
+            "y": 137,
+          },
+          "type": "arc",
+        },
+        {
+          "props": {
+            "x": 334.5,
+            "y": 228,
+          },
+          "type": "moveTo",
+        },
+        {
+          "props": {
+            "anticlockwise": false,
+            "endAngle": 6.283185307179586,
+            "radius": 2.5,
+            "startAngle": 0,
+            "x": 332,
+            "y": 228,
+          },
+          "type": "arc",
+        },
+        {
+          "props": {
+            "x": 437.5,
+            "y": 45,
+          },
+          "type": "moveTo",
+        },
+        {
+          "props": {
+            "anticlockwise": false,
+            "endAngle": 6.283185307179586,
+            "radius": 2.5,
+            "startAngle": 0,
+            "x": 435,
+            "y": 45,
+          },
+          "type": "arc",
+        },
+        {
+          "props": {
+            "x": 539.5,
+            "y": 173,
+          },
+          "type": "moveTo",
+        },
+        {
+          "props": {
+            "anticlockwise": false,
+            "endAngle": 6.283185307179586,
+            "radius": 2.5,
+            "startAngle": 0,
+            "x": 537,
+            "y": 173,
+          },
+          "type": "arc",
+        },
+      ],
+    },
+    "type": "fill",
+  },
+  {
+    "props": {
+      "path": [
+        {
+          "props": {
+            "x": 129.5,
+            "y": 320,
+          },
+          "type": "moveTo",
+        },
+        {
+          "props": {
+            "anticlockwise": false,
+            "endAngle": 6.283185307179586,
+            "radius": 2.5,
+            "startAngle": 0,
+            "x": 127,
+            "y": 320,
+          },
+          "type": "arc",
+        },
+        {
+          "props": {
+            "x": 231.5,
+            "y": 137,
+          },
+          "type": "moveTo",
+        },
+        {
+          "props": {
+            "anticlockwise": false,
+            "endAngle": 6.283185307179586,
+            "radius": 2.5,
+            "startAngle": 0,
+            "x": 229,
+            "y": 137,
+          },
+          "type": "arc",
+        },
+        {
+          "props": {
+            "x": 334.5,
+            "y": 228,
+          },
+          "type": "moveTo",
+        },
+        {
+          "props": {
+            "anticlockwise": false,
+            "endAngle": 6.283185307179586,
+            "radius": 2.5,
+            "startAngle": 0,
+            "x": 332,
+            "y": 228,
+          },
+          "type": "arc",
+        },
+        {
+          "props": {
+            "x": 437.5,
+            "y": 45,
+          },
+          "type": "moveTo",
+        },
+        {
+          "props": {
+            "anticlockwise": false,
+            "endAngle": 6.283185307179586,
+            "radius": 2.5,
+            "startAngle": 0,
+            "x": 435,
+            "y": 45,
+          },
+          "type": "arc",
+        },
+        {
+          "props": {
+            "x": 539.5,
+            "y": 173,
+          },
+          "type": "moveTo",
+        },
+        {
+          "props": {
+            "anticlockwise": false,
+            "endAngle": 6.283185307179586,
+            "radius": 2.5,
+            "startAngle": 0,
+            "x": 537,
+            "y": 173,
+          },
+          "type": "arc",
+        },
+      ],
+    },
+    "type": "stroke",
+  },
+  {
+    "props": {},
+    "type": "restore",
+  },
+  {
+    "props": {
+      "x": -0.5,
+      "y": -0.5,
+    },
+    "type": "translate",
+  },
+  {
     "props": {},
     "type": "save",
   },
@@ -6843,20 +7017,212 @@ exports[`TimeSeriesPanel (canvas) Options drawStyle: points 1`] = `
   {
     "props": {
       "fillRule": "nonzero",
-      "path": [],
+      "path": [
+        {
+          "props": {
+            "height": 359,
+            "width": 626,
+            "x": 19,
+            "y": 3,
+          },
+          "type": "rect",
+        },
+      ],
     },
     "type": "clip",
   },
   {
     "props": {
       "fillRule": "nonzero",
-      "path": [],
+      "path": [
+        {
+          "props": {
+            "x": 129.5,
+            "y": 320,
+          },
+          "type": "moveTo",
+        },
+        {
+          "props": {
+            "anticlockwise": false,
+            "endAngle": 6.283185307179586,
+            "radius": 2.5,
+            "startAngle": 0,
+            "x": 127,
+            "y": 320,
+          },
+          "type": "arc",
+        },
+        {
+          "props": {
+            "x": 231.5,
+            "y": 137,
+          },
+          "type": "moveTo",
+        },
+        {
+          "props": {
+            "anticlockwise": false,
+            "endAngle": 6.283185307179586,
+            "radius": 2.5,
+            "startAngle": 0,
+            "x": 229,
+            "y": 137,
+          },
+          "type": "arc",
+        },
+        {
+          "props": {
+            "x": 334.5,
+            "y": 228,
+          },
+          "type": "moveTo",
+        },
+        {
+          "props": {
+            "anticlockwise": false,
+            "endAngle": 6.283185307179586,
+            "radius": 2.5,
+            "startAngle": 0,
+            "x": 332,
+            "y": 228,
+          },
+          "type": "arc",
+        },
+        {
+          "props": {
+            "x": 437.5,
+            "y": 45,
+          },
+          "type": "moveTo",
+        },
+        {
+          "props": {
+            "anticlockwise": false,
+            "endAngle": 6.283185307179586,
+            "radius": 2.5,
+            "startAngle": 0,
+            "x": 435,
+            "y": 45,
+          },
+          "type": "arc",
+        },
+        {
+          "props": {
+            "x": 539.5,
+            "y": 173,
+          },
+          "type": "moveTo",
+        },
+        {
+          "props": {
+            "anticlockwise": false,
+            "endAngle": 6.283185307179586,
+            "radius": 2.5,
+            "startAngle": 0,
+            "x": 537,
+            "y": 173,
+          },
+          "type": "arc",
+        },
+      ],
     },
     "type": "fill",
   },
   {
     "props": {
-      "path": [],
+      "path": [
+        {
+          "props": {
+            "x": 129.5,
+            "y": 320,
+          },
+          "type": "moveTo",
+        },
+        {
+          "props": {
+            "anticlockwise": false,
+            "endAngle": 6.283185307179586,
+            "radius": 2.5,
+            "startAngle": 0,
+            "x": 127,
+            "y": 320,
+          },
+          "type": "arc",
+        },
+        {
+          "props": {
+            "x": 231.5,
+            "y": 137,
+          },
+          "type": "moveTo",
+        },
+        {
+          "props": {
+            "anticlockwise": false,
+            "endAngle": 6.283185307179586,
+            "radius": 2.5,
+            "startAngle": 0,
+            "x": 229,
+            "y": 137,
+          },
+          "type": "arc",
+        },
+        {
+          "props": {
+            "x": 334.5,
+            "y": 228,
+          },
+          "type": "moveTo",
+        },
+        {
+          "props": {
+            "anticlockwise": false,
+            "endAngle": 6.283185307179586,
+            "radius": 2.5,
+            "startAngle": 0,
+            "x": 332,
+            "y": 228,
+          },
+          "type": "arc",
+        },
+        {
+          "props": {
+            "x": 437.5,
+            "y": 45,
+          },
+          "type": "moveTo",
+        },
+        {
+          "props": {
+            "anticlockwise": false,
+            "endAngle": 6.283185307179586,
+            "radius": 2.5,
+            "startAngle": 0,
+            "x": 435,
+            "y": 45,
+          },
+          "type": "arc",
+        },
+        {
+          "props": {
+            "x": 539.5,
+            "y": 173,
+          },
+          "type": "moveTo",
+        },
+        {
+          "props": {
+            "anticlockwise": false,
+            "endAngle": 6.283185307179586,
+            "radius": 2.5,
+            "startAngle": 0,
+            "x": 537,
+            "y": 173,
+          },
+          "type": "arc",
+        },
+      ],
     },
     "type": "stroke",
   },
@@ -6962,6 +7328,41 @@ exports[`TimeSeriesPanel (canvas) Options fillOpacity: 25 1`] = `
     "props": {
       "fillRule": "nonzero",
       "path": [
+        {
+          "props": {
+            "x": 127,
+            "y": 320,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
+            "x": 229,
+            "y": 137,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
+            "x": 332,
+            "y": 228,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
+            "x": 435,
+            "y": 45,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
+            "x": 537,
+            "y": 173,
+          },
+          "type": "lineTo",
+        },
         {
           "props": {
             "x": 537,
@@ -7174,6 +7575,41 @@ exports[`TimeSeriesPanel (canvas) Options fillOpacity: 50 1`] = `
       "path": [
         {
           "props": {
+            "x": 127,
+            "y": 320,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
+            "x": 229,
+            "y": 137,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
+            "x": 332,
+            "y": 228,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
+            "x": 435,
+            "y": 45,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
+            "x": 537,
+            "y": 173,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
             "x": 537,
             "y": 504,
           },
@@ -7384,6 +7820,41 @@ exports[`TimeSeriesPanel (canvas) Options fillOpacity: 80 1`] = `
       "path": [
         {
           "props": {
+            "x": 127,
+            "y": 320,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
+            "x": 229,
+            "y": 137,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
+            "x": 332,
+            "y": 228,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
+            "x": 435,
+            "y": 45,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
+            "x": 537,
+            "y": 173,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
             "x": 537,
             "y": 504,
           },
@@ -7592,6 +8063,41 @@ exports[`TimeSeriesPanel (canvas) Options fillOpacity: 100 1`] = `
     "props": {
       "fillRule": "nonzero",
       "path": [
+        {
+          "props": {
+            "x": 127,
+            "y": 320,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
+            "x": 229,
+            "y": 137,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
+            "x": 332,
+            "y": 228,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
+            "x": 435,
+            "y": 45,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
+            "x": 537,
+            "y": 173,
+          },
+          "type": "lineTo",
+        },
         {
           "props": {
             "x": 537,
@@ -7844,6 +8350,41 @@ exports[`TimeSeriesPanel (canvas) Options gradientMode: hue 1`] = `
       "path": [
         {
           "props": {
+            "x": 127,
+            "y": 320,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
+            "x": 229,
+            "y": 137,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
+            "x": 332,
+            "y": 228,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
+            "x": 435,
+            "y": 45,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
+            "x": 537,
+            "y": 173,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
             "x": 537,
             "y": 504,
           },
@@ -8083,6 +8624,41 @@ exports[`TimeSeriesPanel (canvas) Options gradientMode: opacity 1`] = `
     "props": {
       "fillRule": "nonzero",
       "path": [
+        {
+          "props": {
+            "x": 127,
+            "y": 320,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
+            "x": 229,
+            "y": 137,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
+            "x": 332,
+            "y": 228,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
+            "x": 435,
+            "y": 45,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
+            "x": 537,
+            "y": 173,
+          },
+          "type": "lineTo",
+        },
         {
           "props": {
             "x": 537,
@@ -8341,6 +8917,41 @@ exports[`TimeSeriesPanel (canvas) Options gradientMode: scheme 1`] = `
     "props": {
       "fillRule": "nonzero",
       "path": [
+        {
+          "props": {
+            "x": 127,
+            "y": 320,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
+            "x": 229,
+            "y": 137,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
+            "x": 332,
+            "y": 228,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
+            "x": 435,
+            "y": 45,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
+            "x": 537,
+            "y": 173,
+          },
+          "type": "lineTo",
+        },
         {
           "props": {
             "x": 537,
@@ -9943,6 +10554,41 @@ exports[`TimeSeriesPanel (canvas) Options stacking: 100% 1`] = `
       "path": [
         {
           "props": {
+            "x": 74,
+            "y": 101,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
+            "x": 109,
+            "y": 99,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
+            "x": 145,
+            "y": 97,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
+            "x": 181,
+            "y": 96,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
+            "x": 216,
+            "y": 95,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
             "x": 216,
             "y": 8,
           },
@@ -10113,6 +10759,41 @@ exports[`TimeSeriesPanel (canvas) Options stacking: 100% 1`] = `
     "props": {
       "fillRule": "nonzero",
       "path": [
+        {
+          "props": {
+            "x": 74,
+            "y": 64,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
+            "x": 109,
+            "y": 62,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
+            "x": 145,
+            "y": 60,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
+            "x": 181,
+            "y": 59,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
+            "x": 216,
+            "y": 58,
+          },
+          "type": "lineTo",
+        },
         {
           "props": {
             "x": 216,
@@ -10475,6 +11156,41 @@ exports[`TimeSeriesPanel (canvas) Options stacking: normal 1`] = `
       "path": [
         {
           "props": {
+            "x": 62,
+            "y": 109,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
+            "x": 100,
+            "y": 107,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
+            "x": 138,
+            "y": 104,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
+            "x": 176,
+            "y": 102,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
+            "x": 214,
+            "y": 99,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
             "x": 214,
             "y": 8,
           },
@@ -10645,6 +11361,41 @@ exports[`TimeSeriesPanel (canvas) Options stacking: normal 1`] = `
     "props": {
       "fillRule": "nonzero",
       "path": [
+        {
+          "props": {
+            "x": 62,
+            "y": 84,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
+            "x": 100,
+            "y": 80,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
+            "x": 138,
+            "y": 75,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
+            "x": 176,
+            "y": 70,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
+            "x": 214,
+            "y": 65,
+          },
+          "type": "lineTo",
+        },
         {
           "props": {
             "x": 214,


### PR DESCRIPTION
## Summary

Wires the TimeSeries panel canvas tests onto the `Path2D` shim (#128734) so they capture **area fills, gradient bands, and point markers** — previously silently dropped.

## What this enables

These snapshot tests record the drawing operations the panel makes, then assert on them.

**Before — captured:**
- ✅ Line strokes
- ✅ Bars
- ✅ Axes, grid lines, tick labels

**Before — silently vanished** (not asserted, not visible in the compare viewer):
- ❌ Area fills (`fillOpacity`)
- ❌ Gradient bands (`gradientMode`)
- ❌ Point markers (`drawStyle: points`)

**After:** all of the above are captured — e.g. an area fill is now 7 path points and a points series is 10 marker arcs, so those options are regression-tested and render in the viewer.

<details>
<summary>What changed to make that work</summary>

- **Install the Path2D shim** (`installCanvasPath2DShim()` from #128734) so uPlot's `new Path2D(strokePath)` fills keep their geometry.
- **Non-clearing frame capture:** reset events at `drawClear`, record the axis/series boundary at `drawAxes` **without clearing** (clearing there dropped the whole series pass), then split the frame at that index — axis/grid → context, series (fill + stroke + markers) → asserted.
- Give the `points` draw style a visible `pointSize` / `showPoints` (default markers are effectively invisible).

Still deterministic draw-call snapshots — no pixel snapshots, no browser.

</details>

## Stacked

- Depends on **#128734** (Path2D shim) — merged into this branch; rebases away once it lands.
- Stacked on **#127513** (the timeseries canvas tests). Base is that branch; the net delta here is the shim wiring, the capture change, and regenerated snapshots.

## Test plan

- [ ] `yarn jest --no-watch public/app/plugins/panel/timeseries/TimeSeriesPanel.canvas.test.tsx` — 28 passed, 28 snapshots (27 unique; Exemplars == defaults is the documented intentional duplicate).
