### PR TITLE
AuthZ: Section-level settings authorization

### DIFF
--- a/pkg/services/accesscontrol/models.go
+++ b/pkg/services/accesscontrol/models.go
@@ -410,6 +410,7 @@ const (
 	ScopeSettingsAll  = "settings:*"
 	ScopeSettingsSAML = "settings:auth.saml:*"
 	ScopeSettingsSCIM = "settings:auth.scim:*"
+	ScopeSettingsSMTP = "settings:smtp:*"
 
 	// Team related actions
 	ActionTeamsCreate           = "teams:create"

--- a/pkg/services/accesscontrol/roles.go
+++ b/pkg/services/accesscontrol/roles.go
@@ -284,21 +284,10 @@ var (
 		},
 	}
 
-	// Adding a new section X to the kube-style settings API requires:
-	//  1. Define a fixed:<X>.settings:writer role granting both ActionSettingsRead
-	//     and ActionSettingsWrite on settings:<X>:*.
-	//  2. Register it in FixedRoleRegistrations and grant it where appropriate
-	//     (typically org.RoleAdmin).
-	// The role must include the read permission: the wildcard SettingsReaderRole
-	// (settings:*) is only granted to grafana server admins, so a section writer
-	// without an explicit read grant can write the section but not GET/LIST it.
-	// No code change is needed in pkg/extensions/apiserver/registry/setting:
-	// section awareness lives in pkg/services/authz/rbac/mapper.go via
-	// settingTranslation, which extracts the section from "<section>--<key>".
 	smtpSettingsWriterRole = RoleDTO{
 		Name:        "fixed:smtp.settings:writer",
 		DisplayName: "SMTP settings writer",
-		Description: "Read and update SMTP settings.",
+		Description: "Read and update the Grafana instance's SMTP configuration.",
 		Group:       "Settings",
 		Permissions: []Permission{
 			{

--- a/pkg/services/accesscontrol/roles.go
+++ b/pkg/services/accesscontrol/roles.go
@@ -284,6 +284,34 @@ var (
 		},
 	}
 
+	// Adding a new section X to the kube-style settings API requires:
+	//  1. Define a fixed:<X>.settings:writer role granting both ActionSettingsRead
+	//     and ActionSettingsWrite on settings:<X>:*.
+	//  2. Register it in FixedRoleRegistrations and grant it where appropriate
+	//     (typically org.RoleAdmin).
+	// The role must include the read permission: the wildcard SettingsReaderRole
+	// (settings:*) is only granted to grafana server admins, so a section writer
+	// without an explicit read grant can write the section but not GET/LIST it.
+	// No code change is needed in pkg/extensions/apiserver/registry/setting:
+	// section awareness lives in pkg/services/authz/rbac/mapper.go via
+	// settingTranslation, which extracts the section from "<section>--<key>".
+	smtpSettingsWriterRole = RoleDTO{
+		Name:        "fixed:smtp.settings:writer",
+		DisplayName: "SMTP settings writer",
+		Description: "Read and update SMTP settings.",
+		Group:       "Settings",
+		Permissions: []Permission{
+			{
+				Action: ActionSettingsRead,
+				Scope:  ScopeSettingsSMTP,
+			},
+			{
+				Action: ActionSettingsWrite,
+				Scope:  ScopeSettingsSMTP,
+			},
+		},
+	}
+
 	generalAuthConfigWriterRole = RoleDTO{
 		Name:        "fixed:general.auth.config:writer",
 		DisplayName: "General authentication config writer",
@@ -356,6 +384,11 @@ func FixedRoleRegistrations() []RoleRegistration {
 		Grants: []string{RoleGrafanaAdmin},
 	}
 
+	smtpSettingsWriter := RoleRegistration{
+		Role:   smtpSettingsWriterRole,
+		Grants: []string{string(org.RoleAdmin)},
+	}
+
 	usageStatsReader := RoleRegistration{
 		Role:   usagestatsReaderRole,
 		Grants: []string{RoleGrafanaAdmin},
@@ -364,7 +397,7 @@ func FixedRoleRegistrations() []RoleRegistration {
 	return []RoleRegistration{
 		ldapReader, ldapWriter, orgUsersReader, orgUsersWriter,
 		settingsReader, statsReader, usersReader, usersWriter,
-		authenticationConfigWriter, generalAuthConfigWriter, usageStatsReader,
+		authenticationConfigWriter, generalAuthConfigWriter, smtpSettingsWriter, usageStatsReader,
 	}
 }
 


### PR DESCRIPTION
Part of https://github.com/grafana/hosted-grafana/issues/8361

Adds section-level RBAC for the `setting.grafana.app` multi-tenant API so an org Admin can write SMTP settings while being denied on other sections.

- Adds the `fixed:smtp.settings:writer` role (`settings:read`/`settings:write` on `settings:smtp:*`), granted to org Admin.

Adding a new section X to the kube-style settings API requires defining a `fixed:<X>.settings:writer` role (read+write on `settings:<X>:*`) and granting it where appropriate (typically org Admin).
