### PR TITLE
Homepage: Alerts card layout rework

### DIFF
--- a/public/app/features/home/AlertsIncidents/AlertIncidentTabs.test.tsx
+++ b/public/app/features/home/AlertsIncidents/AlertIncidentTabs.test.tsx
@@ -1,0 +1,98 @@
+import { http, HttpResponse } from 'msw';
+import { render, screen, waitFor } from 'test/test-utils';
+
+import { setBackendSrv, setPluginComponentsHook } from '@grafana/runtime';
+import server, { setupMockServer } from '@grafana/test-utils/server';
+import { backendSrv } from 'app/core/services/backend_srv';
+import { contextSrv } from 'app/core/services/context_srv';
+import { AlertState, type AlertmanagerAlert } from 'app/plugins/datasource/alertmanager/types';
+import { AccessControlAction } from 'app/types/accessControl';
+
+import { AlertIncidentTabs } from './AlertIncidentTabs';
+
+jest.mock('../analytics/main', () => ({
+  alertsCardClicked: jest.fn(),
+  incidentsCardClicked: jest.fn(),
+  tabChanged: jest.fn(),
+  clearHistoryClicked: jest.fn(),
+  emptyCtaClicked: jest.fn(),
+}));
+
+setBackendSrv(backendSrv);
+setupMockServer();
+
+function makeAlert(overrides: Partial<AlertmanagerAlert> & { labels: AlertmanagerAlert['labels'] }): AlertmanagerAlert {
+  return {
+    startsAt: new Date(Date.now() - 60_000).toISOString(),
+    updatedAt: new Date().toISOString(),
+    endsAt: '0001-01-01T00:00:00Z',
+    fingerprint: Math.random().toString(36).slice(2),
+    receivers: [{ name: 'default' }],
+    status: { state: AlertState.Active, silencedBy: [], inhibitedBy: [] },
+    annotations: {},
+    ...overrides,
+    labels: { alertname: 'test', ...overrides.labels },
+  };
+}
+
+function mockTeams(teams: Array<{ name: string }>) {
+  server.use(
+    http.get('/api/user/teams', () =>
+      HttpResponse.json(
+        teams.map((t, i) => ({ ...t, id: i + 1, uid: `team-${i}`, orgId: 1, memberCount: 1, isProvisioned: false }))
+      )
+    )
+  );
+}
+
+function mockAlerts(alerts: AlertmanagerAlert[]) {
+  server.use(http.get('/api/alertmanager/:datasourceUid/api/v2/alerts', () => HttpResponse.json(alerts)));
+}
+
+beforeEach(() => {
+  setPluginComponentsHook(() => ({ components: [], isLoading: false }));
+  // Grant alerting permission by default
+  jest
+    .spyOn(contextSrv, 'hasPermission')
+    .mockImplementation((action: string) => action === AccessControlAction.AlertingInstanceRead);
+  mockTeams([]);
+  mockAlerts([]);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('AlertIncidentTabs', () => {
+  it('renders nothing when the user lacks AlertingInstanceRead permission', () => {
+    jest.spyOn(contextSrv, 'hasPermission').mockReturnValue(false);
+
+    const { container } = render(<AlertIncidentTabs />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders the Firing alerts heading and tab when permitted', async () => {
+    mockAlerts([makeAlert({ labels: { alertname: 'CPU Critical', severity: 'critical' } })]);
+
+    render(<AlertIncidentTabs />);
+
+    // Wait for the alert to load so the card content is rendered.
+    expect(await screen.findByText('CPU Critical')).toBeInTheDocument();
+    // The section heading and the inner card both render a "Firing alerts" heading.
+    expect(screen.getAllByRole('heading', { name: 'Firing alerts' }).length).toBeGreaterThan(0);
+    expect(screen.getByRole('tab', { name: /firing alerts/i })).toBeInTheDocument();
+  });
+
+  it('shows a tab counter reflecting the number of firing alerts', async () => {
+    mockAlerts([
+      makeAlert({ labels: { alertname: 'CPU Critical', severity: 'critical' } }),
+      makeAlert({ labels: { alertname: 'Memory High', severity: 'high' } }),
+    ]);
+
+    render(<AlertIncidentTabs />);
+
+    // Counter is undefined while loading, so wait until it reflects the loaded count.
+    const tab = await screen.findByRole('tab', { name: /firing alerts/i });
+    await waitFor(() => expect(tab).toHaveTextContent('2'));
+  });
+});

--- a/public/app/features/home/AlertsIncidents/AlertIncidentTabs.test.tsx
+++ b/public/app/features/home/AlertsIncidents/AlertIncidentTabs.test.tsx
@@ -1,8 +1,9 @@
 import { http, HttpResponse } from 'msw';
-import { render, screen, waitFor } from 'test/test-utils';
+import { act, render, screen, waitFor } from 'test/test-utils';
 
 import { setBackendSrv, setPluginComponentsHook } from '@grafana/runtime';
 import server, { setupMockServer } from '@grafana/test-utils/server';
+import { setTestFlags } from '@grafana/test-utils/unstable';
 import { backendSrv } from 'app/core/services/backend_srv';
 import { contextSrv } from 'app/core/services/context_srv';
 import { AlertState, type AlertmanagerAlert } from 'app/plugins/datasource/alertmanager/types';
@@ -49,7 +50,7 @@ function mockAlerts(alerts: AlertmanagerAlert[]) {
   server.use(http.get('/api/alertmanager/:datasourceUid/api/v2/alerts', () => HttpResponse.json(alerts)));
 }
 
-beforeEach(() => {
+beforeEach(async () => {
   setPluginComponentsHook(() => ({ components: [], isLoading: false }));
   // Grant alerting permission by default
   jest
@@ -57,9 +58,18 @@ beforeEach(() => {
     .mockImplementation((action: string) => action === AccessControlAction.AlertingInstanceRead);
   mockTeams([]);
   mockAlerts([]);
+  // AlertIncidentTabs only ships in the growth-homepage redesign, which is flag-gated,
+  // so exercise it in the same flag state it renders in production.
+  await act(async () => {
+    setTestFlags({ 'grafana.growthHomepage': true });
+  });
 });
 
-afterEach(() => {
+afterEach(async () => {
+  // Wrap in act() because setTestFlags fires OpenFeature events that trigger React state updates.
+  await act(async () => {
+    setTestFlags({});
+  });
   jest.restoreAllMocks();
 });
 
@@ -71,16 +81,18 @@ describe('AlertIncidentTabs', () => {
     expect(container).toBeEmptyDOMElement();
   });
 
-  it('renders the Firing alerts heading and tab when permitted', async () => {
+  it('renders a single Firing alerts heading and tab when permitted', async () => {
     mockAlerts([makeAlert({ labels: { alertname: 'CPU Critical', severity: 'critical' } })]);
 
     render(<AlertIncidentTabs />);
 
     // Wait for the alert to load so the card content is rendered.
     expect(await screen.findByText('CPU Critical')).toBeInTheDocument();
-    // The section heading and the inner card both render a "Firing alerts" heading.
-    expect(screen.getAllByRole('heading', { name: 'Firing alerts' }).length).toBeGreaterThan(0);
+    // In the redesign the inner card header is hidden, so only the section heading remains.
+    expect(screen.getByRole('heading', { name: 'Firing alerts' })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: /firing alerts/i })).toBeInTheDocument();
+    // The severity breakdown badge lives in the card header, which the redesign hides.
+    expect(screen.queryByText(/1 critical/i)).not.toBeInTheDocument();
   });
 
   it('shows a tab counter reflecting the number of firing alerts', async () => {

--- a/public/app/features/home/AlertsIncidents/AlertIncidentTabs.test.tsx
+++ b/public/app/features/home/AlertsIncidents/AlertIncidentTabs.test.tsx
@@ -89,7 +89,7 @@ describe('AlertIncidentTabs', () => {
     // Wait for the alert to load so the card content is rendered.
     expect(await screen.findByText('CPU Critical')).toBeInTheDocument();
     // In the redesign the inner card header is hidden, so only the section heading remains.
-    expect(screen.getByRole('heading', { name: 'Firing alerts' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Alerts & incidents' })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: /firing alerts/i })).toBeInTheDocument();
     // The severity breakdown badge lives in the card header, which the redesign hides.
     expect(screen.queryByText(/1 critical/i)).not.toBeInTheDocument();

--- a/public/app/features/home/AlertsIncidents/AlertIncidentTabs.tsx
+++ b/public/app/features/home/AlertsIncidents/AlertIncidentTabs.tsx
@@ -35,7 +35,7 @@ function AlertIncidentTabsInner() {
   const tabs = [
     {
       id: ALERTS_TAB_ID,
-      label: t('home.alerts-incidents.title', 'Firing alerts'),
+      label: t('home.alerts-incidents.alert-tab-label', 'Firing alerts'),
       // Undefined while loading so the counter doesn't flash 0 before the alerts arrive.
       counter: loading ? undefined : count,
     },
@@ -44,7 +44,7 @@ function AlertIncidentTabsInner() {
     <Stack direction="column" gap={2}>
       <Stack justifyContent="space-between" alignItems="center">
         <Text element="h2" variant="h5">
-          <Trans i18nKey="home.alerts-incidents.title">Firing alerts</Trans>
+          <Trans i18nKey="home.alerts-incidents.title">Alerts & incidents</Trans>
         </Text>
         {/* TODO: team dropdown */}
       </Stack>

--- a/public/app/features/home/AlertsIncidents/AlertIncidentTabs.tsx
+++ b/public/app/features/home/AlertsIncidents/AlertIncidentTabs.tsx
@@ -8,13 +8,16 @@ import { DASHBOARD_TABS_SCROLL_HEIGHT_REDESIGN } from '../DashboardTabs/types';
 import { HomeSection } from '../HomeSection';
 import { tabChanged } from '../analytics/main';
 
-import { canViewFiringAlerts, FiringAlertsCard } from './FiringAlertsCard';
+import { CreateAndViewAlertsButtons } from './CreateAndViewAlertsButtons';
+import { FiringAlertsCardView } from './FiringAlertsCard';
+import { canViewFiringAlerts, useFiringAlerts } from './useFiringAlerts';
 
 const ALERTS_TAB_ID = 'firing-alerts';
 
 export function AlertIncidentTabs() {
   const canViewAlerts = canViewFiringAlerts();
 
+  // TODO: Check for incident plugin and show incidents tab if it is available
   if (!canViewAlerts) {
     return null;
   }
@@ -25,24 +28,33 @@ export function AlertIncidentTabs() {
 function AlertIncidentTabsInner() {
   const [activeTab, setActiveTab] = useState(ALERTS_TAB_ID);
   const styles = useStyles2(getStyles);
+  const alertsData = useFiringAlerts();
+  const { count, hasAlerts, loading, canCreate, newRuleHref, viewAllHref } = alertsData;
 
-  const tabs = [{ id: ALERTS_TAB_ID, label: t('home.firing-alerts-card.title', 'Firing alerts') }];
+  const tabs = [
+    {
+      id: ALERTS_TAB_ID,
+      label: t('home.firing-alerts-card.title', 'Firing alerts'),
+      // Undefined while loading so the counter doesn't flash 0 before the alerts arrive.
+      counter: loading ? undefined : count,
+    },
+  ];
   return (
     <Stack direction="column" gap={2}>
-      <Stack justifyContent="space-between">
+      <Stack justifyContent="space-between" alignItems="center">
         <Text element="h2" variant="h5">
           <Trans i18nKey="home.dashboards.title">Firing alerts</Trans>
         </Text>
       </Stack>
 
-      <HomeSection paddingX={2} paddingY={1}>
+      <HomeSection paddingX={2} paddingY={1} display="flex" direction="column" grow={1}>
         <TabsBar>
           {tabs.map((tab) => (
             <Tab
               key={tab.id}
               label={tab.label}
               active={activeTab === tab.id}
-              //   counter={tab.counter}
+              counter={tab.counter}
               onChangeTab={() => {
                 setActiveTab(tab.id);
                 tabChanged({ tab: tab.id });
@@ -56,9 +68,19 @@ function AlertIncidentTabsInner() {
             maxHeight={`${DASHBOARD_TABS_SCROLL_HEIGHT_REDESIGN}px`}
             minHeight={`${DASHBOARD_TABS_SCROLL_HEIGHT_REDESIGN}px`}
           >
-            {activeTab === ALERTS_TAB_ID && <FiringAlertsCard />}
+            {activeTab === ALERTS_TAB_ID && <FiringAlertsCardView data={alertsData} hideFooterActions />}
           </ScrollContainer>
         </TabContent>
+
+        {/* Alerts tab footer */}
+        {activeTab === ALERTS_TAB_ID && (
+          <CreateAndViewAlertsButtons
+            hasAlerts={hasAlerts}
+            canCreate={canCreate}
+            newRuleHref={newRuleHref}
+            viewAllHref={viewAllHref}
+          />
+        )}
       </HomeSection>
     </Stack>
   );

--- a/public/app/features/home/AlertsIncidents/AlertIncidentTabs.tsx
+++ b/public/app/features/home/AlertsIncidents/AlertIncidentTabs.tsx
@@ -35,7 +35,7 @@ function AlertIncidentTabsInner() {
   const tabs = [
     {
       id: ALERTS_TAB_ID,
-      label: t('home.firing-alerts-card.title', 'Firing alerts'),
+      label: t('home.alerts-incidents.title', 'Firing alerts'),
       // Undefined while loading so the counter doesn't flash 0 before the alerts arrive.
       counter: loading ? undefined : count,
     },

--- a/public/app/features/home/AlertsIncidents/AlertIncidentTabs.tsx
+++ b/public/app/features/home/AlertsIncidents/AlertIncidentTabs.tsx
@@ -1,0 +1,71 @@
+import { css } from '@emotion/css';
+import { useState } from 'react';
+
+import { t, Trans } from '@grafana/i18n';
+import { ScrollContainer, Stack, Tab, TabContent, TabsBar, Text, useStyles2 } from '@grafana/ui';
+
+import { DASHBOARD_TABS_SCROLL_HEIGHT_REDESIGN } from '../DashboardTabs/types';
+import { HomeSection } from '../HomeSection';
+import { tabChanged } from '../analytics/main';
+
+import { canViewFiringAlerts, FiringAlertsCard } from './FiringAlertsCard';
+
+const ALERTS_TAB_ID = 'firing-alerts';
+
+export function AlertIncidentTabs() {
+  const canViewAlerts = canViewFiringAlerts();
+
+  if (!canViewAlerts) {
+    return null;
+  }
+
+  return <AlertIncidentTabsInner />;
+}
+
+function AlertIncidentTabsInner() {
+  const [activeTab, setActiveTab] = useState(ALERTS_TAB_ID);
+  const styles = useStyles2(getStyles);
+
+  const tabs = [{ id: ALERTS_TAB_ID, label: t('home.firing-alerts-card.title', 'Firing alerts') }];
+  return (
+    <Stack direction="column" gap={2}>
+      <Stack justifyContent="space-between">
+        <Text element="h2" variant="h5">
+          <Trans i18nKey="home.dashboards.title">Firing alerts</Trans>
+        </Text>
+      </Stack>
+
+      <HomeSection paddingX={2} paddingY={1}>
+        <TabsBar>
+          {tabs.map((tab) => (
+            <Tab
+              key={tab.id}
+              label={tab.label}
+              active={activeTab === tab.id}
+              //   counter={tab.counter}
+              onChangeTab={() => {
+                setActiveTab(tab.id);
+                tabChanged({ tab: tab.id });
+              }}
+            />
+          ))}
+        </TabsBar>
+        <TabContent className={styles.redesignedTabContent}>
+          <ScrollContainer
+            showScrollIndicators
+            maxHeight={`${DASHBOARD_TABS_SCROLL_HEIGHT_REDESIGN}px`}
+            minHeight={`${DASHBOARD_TABS_SCROLL_HEIGHT_REDESIGN}px`}
+          >
+            {activeTab === ALERTS_TAB_ID && <FiringAlertsCard />}
+          </ScrollContainer>
+        </TabContent>
+      </HomeSection>
+    </Stack>
+  );
+}
+
+const getStyles = () => ({
+  redesignedTabContent: css({
+    // padding: 0,
+  }),
+});

--- a/public/app/features/home/AlertsIncidents/AlertIncidentTabs.tsx
+++ b/public/app/features/home/AlertsIncidents/AlertIncidentTabs.tsx
@@ -29,7 +29,8 @@ function AlertIncidentTabsInner() {
   const [activeTab, setActiveTab] = useState(ALERTS_TAB_ID);
   const styles = useStyles2(getStyles);
   const alertsData = useFiringAlerts();
-  const { count, hasAlerts, loading, canCreate, newRuleHref, viewAllHref } = alertsData;
+  const { count, hasAlerts, loading, canCreate, newRuleHref, viewAllHref, error } = alertsData;
+  const isAlertActionsVisible = !loading && !error && activeTab === ALERTS_TAB_ID;
 
   const tabs = [
     {
@@ -43,8 +44,9 @@ function AlertIncidentTabsInner() {
     <Stack direction="column" gap={2}>
       <Stack justifyContent="space-between" alignItems="center">
         <Text element="h2" variant="h5">
-          <Trans i18nKey="home.dashboards.title">Firing alerts</Trans>
+          <Trans i18nKey="home.alerts-incidents.title">Firing alerts</Trans>
         </Text>
+        {/* TODO: team dropdown */}
       </Stack>
 
       <HomeSection paddingX={2} paddingY={1} display="flex" direction="column" grow={1}>
@@ -70,17 +72,17 @@ function AlertIncidentTabsInner() {
           >
             {activeTab === ALERTS_TAB_ID && <FiringAlertsCardView data={alertsData} hideFooterActions />}
           </ScrollContainer>
-        </TabContent>
 
-        {/* Alerts tab footer */}
-        {activeTab === ALERTS_TAB_ID && (
-          <CreateAndViewAlertsButtons
-            hasAlerts={hasAlerts}
-            canCreate={canCreate}
-            newRuleHref={newRuleHref}
-            viewAllHref={viewAllHref}
-          />
-        )}
+          {/* Alerts tab footer */}
+          {isAlertActionsVisible && (
+            <CreateAndViewAlertsButtons
+              hasAlerts={hasAlerts}
+              canCreate={canCreate}
+              newRuleHref={newRuleHref}
+              viewAllHref={viewAllHref}
+            />
+          )}
+        </TabContent>
       </HomeSection>
     </Stack>
   );
@@ -88,6 +90,6 @@ function AlertIncidentTabsInner() {
 
 const getStyles = () => ({
   redesignedTabContent: css({
-    // padding: 0,
+    padding: 0,
   }),
 });

--- a/public/app/features/home/AlertsIncidents/CreateAndViewAlertsButtons.tsx
+++ b/public/app/features/home/AlertsIncidents/CreateAndViewAlertsButtons.tsx
@@ -1,0 +1,49 @@
+import { Trans } from '@grafana/i18n';
+import { LinkButton, Stack } from '@grafana/ui';
+
+import { alertsCardClicked } from '../analytics/main';
+
+interface Props {
+  hasAlerts: boolean;
+  canCreate: boolean;
+  newRuleHref: string;
+  viewAllHref: string;
+}
+
+export const CreateAndViewAlertsButtons = ({ hasAlerts, canCreate, newRuleHref, viewAllHref }: Props) => {
+  return (
+    <Stack justifyContent="flex-end" wrap="wrap">
+      {hasAlerts && canCreate && (
+        <LinkButton
+          variant="secondary"
+          size="sm"
+          fill="text"
+          icon="plus"
+          href={newRuleHref}
+          onClick={() => alertsCardClicked({ action: 'create_rule', placement: 'footer' })}
+        >
+          <Trans i18nKey="home.firing-alerts-card.create">Create an alert rule</Trans>
+        </LinkButton>
+      )}
+
+      <LinkButton
+        variant="secondary"
+        size="sm"
+        fill="text"
+        href={viewAllHref}
+        onClick={() =>
+          alertsCardClicked({
+            action: hasAlerts ? 'view_all_alerts' : 'view_all_rules',
+            placement: 'footer',
+          })
+        }
+      >
+        {hasAlerts ? (
+          <Trans i18nKey="home.firing-alerts-card.view-all">View all firing alerts</Trans>
+        ) : (
+          <Trans i18nKey="home.firing-alerts-card.view-rules">View all alert rules</Trans>
+        )}
+      </LinkButton>
+    </Stack>
+  );
+};

--- a/public/app/features/home/AlertsIncidents/FiringAlertsCard.tsx
+++ b/public/app/features/home/AlertsIncidents/FiringAlertsCard.tsx
@@ -1,26 +1,14 @@
-import { skipToken } from '@reduxjs/toolkit/query';
-import { escapeRegExp } from 'lodash';
-import { useMemo } from 'react';
-import { useAsync } from 'react-use';
-
 import { t, Trans } from '@grafana/i18n';
-import { getBackendSrv } from '@grafana/runtime';
 import { Badge, LinkButton, Stack, Text } from '@grafana/ui';
-import { contextSrv } from 'app/core/services/context_srv';
-import { alertmanagerApi } from 'app/features/alerting/unified/api/alertmanagerApi';
-import { canonicalSeverity, type SeverityLevel } from 'app/features/alerting/unified/triage/scene/filters/severity';
-import { ALERTMANAGER_NAME_QUERY_KEY, GRAFANA_RULES_SOURCE_NAME } from 'app/features/alerting/unified/utils/constants';
-import { ALERTING_PATHS, alertListPageLink } from 'app/features/alerting/unified/utils/navigation';
-import { createRelativeUrl } from 'app/features/alerting/unified/utils/url';
+import { type SeverityLevel } from 'app/features/alerting/unified/triage/scene/filters/severity';
 import { type AlertmanagerAlert } from 'app/plugins/datasource/alertmanager/types';
-import { AccessControlAction } from 'app/types/accessControl';
-import { type Team } from 'app/types/teams';
 
 import { alertsCardClicked } from '../analytics/main';
 
+import { CreateAndViewAlertsButtons } from './CreateAndViewAlertsButtons';
 import { SummaryCard, SummaryCardAge, SummaryCardTitle } from './SummaryCard';
-import { HOME_CARD_MAX_ITEMS } from './constants';
-import { severityLevelColor, severityLevelRank } from './severity';
+import { severityLevelColor } from './severity';
+import { canViewFiringAlerts, useFiringAlerts, type FiringAlertsData } from './useFiringAlerts';
 
 /** Extract the path (with query string) from an absolute generatorURL, falling back to the raw value. */
 function alertDetailHref(alert: AlertmanagerAlert) {
@@ -34,11 +22,6 @@ function alertDetailHref(alert: AlertmanagerAlert) {
   } catch {
     return raw;
   }
-}
-
-/** Canonical severity level for an alert, tolerant of a missing severity label so the card never crashes. */
-function alertSeverityLevel(alert: AlertmanagerAlert) {
-  return canonicalSeverity(alert.labels.severity ?? '');
 }
 
 function severityLabel(level?: SeverityLevel): string {
@@ -56,16 +39,6 @@ function severityLabel(level?: SeverityLevel): string {
   }
 }
 
-function buildTeamMatchers(teamNames: string[]) {
-  if (teamNames.length === 0) {
-    return [];
-  }
-  return [{ name: 'team', value: teamNames.map(escapeRegExp).join('|'), isRegex: true, isEqual: true }];
-}
-
-// Exported so the homepage skeleton reserves the card slot using the same gate.
-export const canViewFiringAlerts = () => contextSrv.hasPermission(AccessControlAction.AlertingInstanceRead);
-
 export function FiringAlertsCard() {
   if (!canViewFiringAlerts()) {
     return null;
@@ -79,68 +52,37 @@ export function FiringAlertsCard() {
  * the permission gate is in the parent wrapper.
  */
 function FiringAlertsCardInner() {
-  // Fetched once — teams change at login granularity. A failed fetch leaves teams
-  // undefined, so the card intentionally shows all org alerts unfiltered.
-  const { value: teams, loading: teamsLoading } = useAsync(() => getBackendSrv().get<Team[]>('/api/user/teams'), []);
+  const data = useFiringAlerts();
+  return <FiringAlertsCardView data={data} />;
+}
 
-  const teamNames = (teams ?? []).map((t) => t.name);
-  const hasTeams = teamNames.length > 0;
-
-  // Filter to the user's teams when they have any. No memo needed:
-  // RTK Query serializes query args, so referential identity doesn't matter.
-  const matchers = hasTeams ? buildTeamMatchers(teamNames) : [];
-
+/** Render-only card body; data comes from useFiringAlerts so callers control where the hook runs. */
+export function FiringAlertsCardView({
+  data,
+  hideFooterActions = false,
+}: {
+  data: FiringAlertsData;
+  hideFooterActions?: boolean;
+}) {
   const {
-    data: alerts,
-    isLoading: alertsLoading,
-    error: alertsError,
+    count,
+    criticalCount,
+    highCount,
+    displayed,
+    hasAlerts,
+    hasTeams,
+    loading,
+    error,
     refetch,
-  } = alertmanagerApi.useGetAlertmanagerAlertsQuery(
-    teamsLoading
-      ? skipToken
-      : {
-          amSourceName: GRAFANA_RULES_SOURCE_NAME,
-          filter: { active: true, silenced: false, inhibited: false, matchers },
-          showErrorAlert: false,
-        }
-  );
-
-  const loading = teamsLoading || alertsLoading;
-
-  // Severity and timestamp are derived once per alert so the sort comparator,
-  // the badge counts, and the rows don't recompute them.
-  const { displayed, criticalCount, highCount } = useMemo(() => {
-    let criticalCount = 0;
-    let highCount = 0;
-    const decorated = (alerts ?? []).map((alert) => {
-      const level = alertSeverityLevel(alert);
-      if (level === 'critical') {
-        criticalCount++;
-      } else if (level === 'major') {
-        highCount++;
-      }
-      return { alert, level, rank: severityLevelRank(level), startedAt: new Date(alert.startsAt).getTime() };
-    });
-    // Most severe first, most recent first within the same severity
-    decorated.sort((a, b) => b.rank - a.rank || b.startedAt - a.startedAt);
-    // Cap the rendered rows; counts above are over every alert so the badges stay accurate.
-    return { displayed: decorated.slice(0, HOME_CARD_MAX_ITEMS), criticalCount, highCount };
-  }, [alerts]);
-
-  const canCreate = contextSrv.hasPermission(AccessControlAction.AlertingRuleCreate);
-  const hasAlerts = (alerts?.length ?? 0) > 0;
-
-  // Built at render time, not module scope: createRelativeUrl reads config.appSubUrl on call,
-  // and LinkButton emits a plain <a href> with no router to prepend the sub path for us.
-  const newRuleHref = createRelativeUrl('/alerting/new/alerting');
-  const viewAllHref = hasAlerts
-    ? createRelativeUrl(ALERTING_PATHS.ALERT_GROUPS, { [ALERTMANAGER_NAME_QUERY_KEY]: GRAFANA_RULES_SOURCE_NAME })
-    : alertListPageLink({ search: `source:${GRAFANA_RULES_SOURCE_NAME}` });
+    canCreate,
+    newRuleHref,
+    viewAllHref,
+  } = data;
 
   return (
     <SummaryCard
       title={t('home.firing-alerts-card.title', 'Firing alerts')}
-      count={alerts?.length ?? 0}
+      count={count}
       headerExtra={
         <Stack>
           {criticalCount > 0 && (
@@ -167,7 +109,7 @@ function FiringAlertsCardInner() {
       }
       loading={loading}
       error={
-        alertsError
+        error
           ? {
               title: t('home.firing-alerts-card.error-title', 'Could not load firing alerts'),
               onRetry: () => refetch(),
@@ -214,38 +156,14 @@ function FiringAlertsCardInner() {
         ) : undefined
       }
       footer={
-        <>
-          {hasAlerts && canCreate && (
-            <LinkButton
-              variant="secondary"
-              size="sm"
-              fill="text"
-              icon="plus"
-              href={newRuleHref}
-              onClick={() => alertsCardClicked({ action: 'create_rule', placement: 'footer' })}
-            >
-              <Trans i18nKey="home.firing-alerts-card.create">Create an alert rule</Trans>
-            </LinkButton>
-          )}
-          <LinkButton
-            variant="secondary"
-            size="sm"
-            fill="text"
-            href={viewAllHref}
-            onClick={() =>
-              alertsCardClicked({
-                action: hasAlerts ? 'view_all_alerts' : 'view_all_rules',
-                placement: 'footer',
-              })
-            }
-          >
-            {hasAlerts ? (
-              <Trans i18nKey="home.firing-alerts-card.view-all">View all firing alerts</Trans>
-            ) : (
-              <Trans i18nKey="home.firing-alerts-card.view-rules">View all alert rules</Trans>
-            )}
-          </LinkButton>
-        </>
+        !hideFooterActions && (
+          <CreateAndViewAlertsButtons
+            hasAlerts={hasAlerts}
+            canCreate={canCreate}
+            newRuleHref={newRuleHref}
+            viewAllHref={viewAllHref}
+          />
+        )
       }
     />
   );

--- a/public/app/features/home/AlertsIncidents/FiringAlertsCard.tsx
+++ b/public/app/features/home/AlertsIncidents/FiringAlertsCard.tsx
@@ -68,7 +68,7 @@ export function FiringAlertsCardView({
     count,
     criticalCount,
     highCount,
-    displayed,
+    visibleAlerts,
     hasAlerts,
     hasTeams,
     loading,
@@ -121,7 +121,7 @@ export function FiringAlertsCardView({
           ? t('home.firing-alerts-card.empty-teams', 'No firing alerts for your teams.')
           : t('home.firing-alerts-card.empty', 'You have no firing alerts.')
       }
-      items={displayed}
+      items={visibleAlerts}
       getItemKey={({ alert }) => alert.fingerprint}
       renderItem={({ alert, level, startedAt }) => {
         const detailHref = alertDetailHref(alert);

--- a/public/app/features/home/AlertsIncidents/SummaryCard.tsx
+++ b/public/app/features/home/AlertsIncidents/SummaryCard.tsx
@@ -53,7 +53,12 @@ export function SummaryCard<T>({
   const countText = countLimit !== undefined && count >= countLimit ? `${countLimit}+` : String(count);
 
   return (
-    <HomeSection display="flex" direction="column">
+    <HomeSection
+      display="flex"
+      direction="column"
+      paddingY={redesignEnabled ? 1 : undefined}
+      paddingX={redesignEnabled ? 0 : undefined}
+    >
       <Stack direction="column" gap={2} grow={1}>
         <Stack direction="column" gap={2} grow={1}>
           {!redesignEnabled && (
@@ -95,7 +100,7 @@ export function SummaryCard<T>({
           )}
 
           {!loading && !error && items.length > 0 && (
-            <ul className={styles.list}>
+            <ul className={redesignEnabled ? undefined : styles.list}>
               {items.map((item) => (
                 <li key={getItemKey(item)} className={styles.row}>
                   {renderItem(item)}

--- a/public/app/features/home/AlertsIncidents/SummaryCard.tsx
+++ b/public/app/features/home/AlertsIncidents/SummaryCard.tsx
@@ -52,65 +52,70 @@ export function SummaryCard<T>({
 
   const countText = countLimit !== undefined && count >= countLimit ? `${countLimit}+` : String(count);
 
-  return (
-    <HomeSection
-      display="flex"
-      direction="column"
-      paddingY={redesignEnabled ? 1 : undefined}
-      paddingX={redesignEnabled ? 0 : undefined}
-    >
+  const content = (
+    <>
       <Stack direction="column" gap={2} grow={1}>
-        <Stack direction="column" gap={2} grow={1}>
-          {!redesignEnabled && (
-            <Stack alignItems="center" justifyContent="space-between">
-              <Stack alignItems="center">
-                <Text element="h2" variant="h5">
-                  {title}
-                </Text>
-                {!loading && count > 0 && <Badge text={countText} color="red" />}
-              </Stack>
-              {!loading && headerExtra}
+        {!redesignEnabled && (
+          <Stack alignItems="center" justifyContent="space-between">
+            <Stack alignItems="center">
+              <Text element="h2" variant="h5">
+                {title}
+              </Text>
+              {!loading && count > 0 && <Badge text={countText} color="red" />}
             </Stack>
-          )}
+            {!loading && headerExtra}
+          </Stack>
+        )}
 
-          {loading && (
-            <Stack direction="column">
-              {Array.from({ length: 3 }, (_, i) => (
-                <Skeleton key={i} height={20} />
-              ))}
-            </Stack>
-          )}
+        {loading && (
+          <Stack direction="column">
+            {Array.from({ length: 3 }, (_, i) => (
+              <Skeleton key={i} height={20} />
+            ))}
+          </Stack>
+        )}
 
-          {error && (
-            <Alert
-              severity="warning"
-              title={error.title}
-              action={
-                <Button onClick={error.onRetry} variant="secondary" size="sm">
-                  <Trans i18nKey="home.summary-card.retry">Retry</Trans>
-                </Button>
-              }
-            />
-          )}
+        {error && (
+          <Alert
+            severity="warning"
+            title={error.title}
+            action={
+              <Button onClick={error.onRetry} variant="secondary" size="sm">
+                <Trans i18nKey="home.summary-card.retry">Retry</Trans>
+              </Button>
+            }
+          />
+        )}
 
-          {!loading && !error && items.length === 0 && (
-            <Stack direction="column" alignItems="center">
-              {emptyAction ?? <Text color="secondary">{emptyMessage}</Text>}
-            </Stack>
-          )}
+        {!loading && !error && items.length === 0 && (
+          <Stack direction="column" alignItems="center">
+            {emptyAction ?? <Text color="secondary">{emptyMessage}</Text>}
+          </Stack>
+        )}
 
-          {!loading && !error && items.length > 0 && (
-            <ul className={redesignEnabled ? undefined : styles.list}>
-              {items.map((item) => (
-                <li key={getItemKey(item)} className={styles.row}>
-                  {renderItem(item)}
-                </li>
-              ))}
-            </ul>
-          )}
-        </Stack>
+        {!loading && !error && items.length > 0 && (
+          <ul className={redesignEnabled ? undefined : styles.list}>
+            {items.map((item) => (
+              <li key={getItemKey(item)} className={styles.row}>
+                {renderItem(item)}
+              </li>
+            ))}
+          </ul>
+        )}
+      </Stack>
 
-        {!loading && !error && footer && <Stack justifyContent="flex-end">{footer}</Stack>}
+      {!loading && !error && footer && <Stack justifyContent="flex-end">{footer}</Stack>}
+    </>
+  );
+
+  if (redesignEnabled) {
+    return content;
+  }
+
+  return (
+    <HomeSection display="flex" direction="column">
+      <Stack direction="column" gap={2} grow={1}>
+        {content}
       </Stack>
     </HomeSection>
   );

--- a/public/app/features/home/AlertsIncidents/SummaryCard.tsx
+++ b/public/app/features/home/AlertsIncidents/SummaryCard.tsx
@@ -5,6 +5,7 @@ import Skeleton from 'react-loading-skeleton';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
+import { useFlagGrafanaGrowthHomepage } from '@grafana/runtime/internal';
 import { Alert, Badge, Button, Stack, Text, TextLink, useStyles2 } from '@grafana/ui';
 
 import { HomeSection } from '../HomeSection';
@@ -46,6 +47,7 @@ export function SummaryCard<T>({
   renderItem,
   footer,
 }: SummaryCardProps<T>) {
+  const redesignEnabled = useFlagGrafanaGrowthHomepage();
   const styles = useStyles2(getStyles);
 
   const countText = countLimit !== undefined && count >= countLimit ? `${countLimit}+` : String(count);
@@ -54,15 +56,17 @@ export function SummaryCard<T>({
     <HomeSection display="flex" direction="column">
       <Stack direction="column" gap={2} grow={1}>
         <Stack direction="column" gap={2} grow={1}>
-          <Stack alignItems="center" justifyContent="space-between">
-            <Stack alignItems="center">
-              <Text element="h2" variant="h5">
-                {title}
-              </Text>
-              {!loading && count > 0 && <Badge text={countText} color="red" />}
+          {!redesignEnabled && (
+            <Stack alignItems="center" justifyContent="space-between">
+              <Stack alignItems="center">
+                <Text element="h2" variant="h5">
+                  {title}
+                </Text>
+                {!loading && count > 0 && <Badge text={countText} color="red" />}
+              </Stack>
+              {!loading && headerExtra}
             </Stack>
-            {!loading && headerExtra}
-          </Stack>
+          )}
 
           {loading && (
             <Stack direction="column">

--- a/public/app/features/home/AlertsIncidents/SummaryCard.tsx
+++ b/public/app/features/home/AlertsIncidents/SummaryCard.tsx
@@ -88,7 +88,7 @@ export function SummaryCard<T>({
         )}
 
         {!loading && !error && items.length === 0 && (
-          <Stack direction="column" alignItems="center">
+          <Stack direction="column" grow={1} alignItems="center" justifyContent="center">
             {emptyAction ?? <Text color="secondary">{emptyMessage}</Text>}
           </Stack>
         )}

--- a/public/app/features/home/AlertsIncidents/useFiringAlerts.test.ts
+++ b/public/app/features/home/AlertsIncidents/useFiringAlerts.test.ts
@@ -1,0 +1,107 @@
+import { http, HttpResponse } from 'msw';
+import { getWrapper, renderHook, waitFor } from 'test/test-utils';
+
+import { setBackendSrv } from '@grafana/runtime';
+import server, { setupMockServer } from '@grafana/test-utils/server';
+import { backendSrv } from 'app/core/services/backend_srv';
+import { contextSrv } from 'app/core/services/context_srv';
+import { AlertState, type AlertmanagerAlert } from 'app/plugins/datasource/alertmanager/types';
+import { AccessControlAction } from 'app/types/accessControl';
+
+import { canViewFiringAlerts, useFiringAlerts } from './useFiringAlerts';
+
+setBackendSrv(backendSrv);
+setupMockServer();
+
+function makeAlert(overrides: Partial<AlertmanagerAlert> & { labels: AlertmanagerAlert['labels'] }): AlertmanagerAlert {
+  return {
+    startsAt: new Date(Date.now() - 60_000).toISOString(),
+    updatedAt: new Date().toISOString(),
+    endsAt: '0001-01-01T00:00:00Z',
+    fingerprint: Math.random().toString(36).slice(2),
+    receivers: [{ name: 'default' }],
+    status: { state: AlertState.Active, silencedBy: [], inhibitedBy: [] },
+    annotations: {},
+    ...overrides,
+    labels: { alertname: 'test', ...overrides.labels },
+  };
+}
+
+function mockTeams(teams: Array<{ name: string }>) {
+  server.use(
+    http.get('/api/user/teams', () =>
+      HttpResponse.json(
+        teams.map((t, i) => ({ ...t, id: i + 1, uid: `team-${i}`, orgId: 1, memberCount: 1, isProvisioned: false }))
+      )
+    )
+  );
+}
+
+function mockAlerts(alerts: AlertmanagerAlert[]) {
+  server.use(http.get('/api/alertmanager/:datasourceUid/api/v2/alerts', () => HttpResponse.json(alerts)));
+}
+
+beforeEach(() => {
+  jest
+    .spyOn(contextSrv, 'hasPermission')
+    .mockImplementation((action: string) => action === AccessControlAction.AlertingInstanceRead);
+  mockTeams([]);
+  mockAlerts([]);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('canViewFiringAlerts', () => {
+  it('is true when the user has AlertingInstanceRead permission', () => {
+    jest.spyOn(contextSrv, 'hasPermission').mockReturnValue(true);
+    expect(canViewFiringAlerts()).toBe(true);
+  });
+
+  it('is false when the user lacks AlertingInstanceRead permission', () => {
+    jest.spyOn(contextSrv, 'hasPermission').mockReturnValue(false);
+    expect(canViewFiringAlerts()).toBe(false);
+  });
+});
+
+describe('useFiringAlerts', () => {
+  it('derives counts and severity totals from the fetched alerts', async () => {
+    mockAlerts([
+      makeAlert({ labels: { alertname: 'CPU Critical', severity: 'critical' } }),
+      makeAlert({ labels: { alertname: 'Memory High', severity: 'high' } }),
+      makeAlert({ labels: { alertname: 'Disk Warning', severity: 'warning' } }),
+    ]);
+
+    const { result } = renderHook(() => useFiringAlerts(), { wrapper: getWrapper({}) });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.count).toBe(3);
+    expect(result.current.hasAlerts).toBe(true);
+    expect(result.current.criticalCount).toBe(1);
+    expect(result.current.highCount).toBe(1);
+  });
+
+  it('reports no alerts when the query resolves empty', async () => {
+    mockAlerts([]);
+
+    const { result } = renderHook(() => useFiringAlerts(), { wrapper: getWrapper({}) });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.count).toBe(0);
+    expect(result.current.hasAlerts).toBe(false);
+  });
+
+  it('sets hasTeams when the user belongs to teams', async () => {
+    mockTeams([{ name: 'platform' }]);
+    mockAlerts([]);
+
+    const { result } = renderHook(() => useFiringAlerts(), { wrapper: getWrapper({}) });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.hasTeams).toBe(true);
+  });
+});

--- a/public/app/features/home/AlertsIncidents/useFiringAlerts.ts
+++ b/public/app/features/home/AlertsIncidents/useFiringAlerts.ts
@@ -1,0 +1,116 @@
+import { skipToken } from '@reduxjs/toolkit/query';
+import { escapeRegExp } from 'lodash';
+import { useMemo } from 'react';
+import { useAsync } from 'react-use';
+
+import { getBackendSrv } from '@grafana/runtime';
+import { contextSrv } from 'app/core/services/context_srv';
+import { alertmanagerApi } from 'app/features/alerting/unified/api/alertmanagerApi';
+import { canonicalSeverity } from 'app/features/alerting/unified/triage/scene/filters/severity';
+import { ALERTMANAGER_NAME_QUERY_KEY, GRAFANA_RULES_SOURCE_NAME } from 'app/features/alerting/unified/utils/constants';
+import { ALERTING_PATHS, alertListPageLink } from 'app/features/alerting/unified/utils/navigation';
+import { createRelativeUrl } from 'app/features/alerting/unified/utils/url';
+import { type AlertmanagerAlert } from 'app/plugins/datasource/alertmanager/types';
+import { AccessControlAction } from 'app/types/accessControl';
+import { type Team } from 'app/types/teams';
+
+import { HOME_CARD_MAX_ITEMS } from './constants';
+import { severityLevelRank } from './severity';
+
+/** Canonical severity level for an alert, tolerant of a missing severity label so the card never crashes. */
+function alertSeverityLevel(alert: AlertmanagerAlert) {
+  return canonicalSeverity(alert.labels.severity ?? '');
+}
+
+function buildTeamMatchers(teamNames: string[]) {
+  if (teamNames.length === 0) {
+    return [];
+  }
+  return [{ name: 'team', value: teamNames.map(escapeRegExp).join('|'), isRegex: true, isEqual: true }];
+}
+
+// Exported so the homepage skeleton reserves the card slot using the same gate.
+export const canViewFiringAlerts = () => contextSrv.hasPermission(AccessControlAction.AlertingInstanceRead);
+
+export type FiringAlertsData = ReturnType<typeof useFiringAlerts>;
+
+/**
+ * All data fetching and derived state for the homepage Firing alerts view,
+ * shared between the old-layout card and the redesigned tabs.
+ */
+export function useFiringAlerts() {
+  // Fetched once — teams change at login granularity. A failed fetch leaves teams
+  // undefined, so the card intentionally shows all org alerts unfiltered.
+  const { value: teams, loading: teamsLoading } = useAsync(() => getBackendSrv().get<Team[]>('/api/user/teams'), []);
+
+  const teamNames = (teams ?? []).map((t) => t.name);
+  const hasTeams = teamNames.length > 0;
+
+  // Filter to the user's teams when they have any. No memo needed:
+  // RTK Query serializes query args, so referential identity doesn't matter.
+  const matchers = hasTeams ? buildTeamMatchers(teamNames) : [];
+
+  const {
+    data: alerts,
+    isLoading: alertsLoading,
+    error,
+    refetch,
+  } = alertmanagerApi.useGetAlertmanagerAlertsQuery(
+    teamsLoading
+      ? skipToken
+      : {
+          amSourceName: GRAFANA_RULES_SOURCE_NAME,
+          filter: { active: true, silenced: false, inhibited: false, matchers },
+          showErrorAlert: false,
+        }
+  );
+
+  const loading = teamsLoading || alertsLoading;
+
+  // Severity and timestamp are derived once per alert so the sort comparator,
+  // the badge counts, and the rows don't recompute them.
+  const { displayed, criticalCount, highCount } = useMemo(() => {
+    let criticalCount = 0;
+    let highCount = 0;
+    const decorated = (alerts ?? []).map((alert) => {
+      const level = alertSeverityLevel(alert);
+      if (level === 'critical') {
+        criticalCount++;
+      } else if (level === 'major') {
+        highCount++;
+      }
+      return { alert, level, rank: severityLevelRank(level), startedAt: new Date(alert.startsAt).getTime() };
+    });
+    // Most severe first, most recent first within the same severity
+    decorated.sort((a, b) => b.rank - a.rank || b.startedAt - a.startedAt);
+    // Cap the rendered rows; counts above are over every alert so the badges stay accurate.
+    return { displayed: decorated.slice(0, HOME_CARD_MAX_ITEMS), criticalCount, highCount };
+  }, [alerts]);
+
+  const canCreate = contextSrv.hasPermission(AccessControlAction.AlertingRuleCreate);
+  const count = alerts?.length ?? 0;
+  const hasAlerts = count > 0;
+
+  // Built at render time, not module scope: createRelativeUrl reads config.appSubUrl on call,
+  // and LinkButton emits a plain <a href> with no router to prepend the sub path for us.
+  const newRuleHref = createRelativeUrl('/alerting/new/alerting');
+  const viewAllHref = hasAlerts
+    ? createRelativeUrl(ALERTING_PATHS.ALERT_GROUPS, { [ALERTMANAGER_NAME_QUERY_KEY]: GRAFANA_RULES_SOURCE_NAME })
+    : alertListPageLink({ search: `source:${GRAFANA_RULES_SOURCE_NAME}` });
+
+  return {
+    alerts,
+    displayed,
+    count,
+    criticalCount,
+    highCount,
+    hasAlerts,
+    hasTeams,
+    loading,
+    error,
+    refetch,
+    canCreate,
+    newRuleHref,
+    viewAllHref,
+  };
+}

--- a/public/app/features/home/AlertsIncidents/useFiringAlerts.ts
+++ b/public/app/features/home/AlertsIncidents/useFiringAlerts.ts
@@ -69,7 +69,7 @@ export function useFiringAlerts() {
 
   // Severity and timestamp are derived once per alert so the sort comparator,
   // the badge counts, and the rows don't recompute them.
-  const { displayed, criticalCount, highCount } = useMemo(() => {
+  const { visibleAlerts, criticalCount, highCount } = useMemo(() => {
     let criticalCount = 0;
     let highCount = 0;
     const decorated = (alerts ?? []).map((alert) => {
@@ -84,7 +84,7 @@ export function useFiringAlerts() {
     // Most severe first, most recent first within the same severity
     decorated.sort((a, b) => b.rank - a.rank || b.startedAt - a.startedAt);
     // Cap the rendered rows; counts above are over every alert so the badges stay accurate.
-    return { displayed: decorated.slice(0, HOME_CARD_MAX_ITEMS), criticalCount, highCount };
+    return { visibleAlerts: decorated.slice(0, HOME_CARD_MAX_ITEMS), criticalCount, highCount };
   }, [alerts]);
 
   const canCreate = contextSrv.hasPermission(AccessControlAction.AlertingRuleCreate);
@@ -99,8 +99,7 @@ export function useFiringAlerts() {
     : alertListPageLink({ search: `source:${GRAFANA_RULES_SOURCE_NAME}` });
 
   return {
-    alerts,
-    displayed,
+    visibleAlerts,
     count,
     criticalCount,
     highCount,

--- a/public/app/features/home/DashboardTabs/DashboardTabs.tsx
+++ b/public/app/features/home/DashboardTabs/DashboardTabs.tsx
@@ -283,7 +283,7 @@ export function DashboardTabs({ extensionComponents }: Props) {
             </TextLink>
           </Stack>
 
-          <HomeSection paddingX={2} paddingY={1}>
+          <HomeSection paddingX={2} paddingY={1} display="flex" direction="column" grow={1}>
             {renderContent()}
           </HomeSection>
         </>

--- a/public/app/features/home/DashboardTabs/RecentDashboardsClearButton.tsx
+++ b/public/app/features/home/DashboardTabs/RecentDashboardsClearButton.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
-import { Button, useStyles2 } from '@grafana/ui';
+import { Button, Stack, useStyles2 } from '@grafana/ui';
 import impressionSrv from 'app/core/services/impression_srv';
 import { type DashboardQueryResult } from 'app/features/search/service/types';
 
@@ -28,17 +28,21 @@ export function RecentDashboardsClearButton({ dashboards, retry, redesignEnabled
   };
 
   return (
-    <div className={styles.clearButton}>
+    <>
       {redesignEnabled ? (
-        <Button size="sm" fill="text" onClick={handleClearHistory}>
-          <Trans i18nKey="home.recent-dashboards-tab.reset">Reset recent dashboards</Trans>
-        </Button>
+        <Stack justifyContent="flex-end" wrap="wrap">
+          <Button size="sm" fill="text" onClick={handleClearHistory}>
+            <Trans i18nKey="home.recent-dashboards-tab.reset">Reset recent dashboards</Trans>
+          </Button>
+        </Stack>
       ) : (
-        <Button icon="times" size="sm" variant="secondary" fill="text" onClick={handleClearHistory}>
-          <Trans i18nKey="home.recent-dashboards-tab.clear">Clear history</Trans>
-        </Button>
+        <div className={styles.clearButton}>
+          <Button icon="times" size="sm" variant="secondary" fill="text" onClick={handleClearHistory}>
+            <Trans i18nKey="home.recent-dashboards-tab.clear">Clear history</Trans>
+          </Button>
+        </div>
       )}
-    </div>
+    </>
   );
 }
 

--- a/public/app/features/home/HomePage.tsx
+++ b/public/app/features/home/HomePage.tsx
@@ -11,6 +11,7 @@ import { Page } from 'app/core/components/Page/Page';
 import { ASSISTANT_PLUGIN_ID, SETUPGUIDE_PLUGIN_ID } from 'app/core/constants';
 import { isOnPrem } from 'app/core/utils/isOnPrem';
 
+import { AlertIncidentTabs } from './AlertsIncidents/AlertIncidentTabs';
 import { FiringAlertsCard, canViewFiringAlerts } from './AlertsIncidents/FiringAlertsCard';
 import { IncidentsCard } from './AlertsIncidents/IncidentsCard';
 import { DashboardTabs } from './DashboardTabs/DashboardTabs';
@@ -110,7 +111,8 @@ export default function HomePage() {
                     {/* Skip the HomepageTabs extension point for the redesign UI */}
                     <DashboardTabs extensionComponents={[]} />
                     {/* TODO: Alerts and incidents will combine into one card */}
-                    <FiringAlertsCard />
+                    {/* <FiringAlertsCard /> */}
+                    <AlertIncidentTabs />
                   </Grid>
                 </>
               ) : (

--- a/public/app/features/home/HomePage.tsx
+++ b/public/app/features/home/HomePage.tsx
@@ -12,8 +12,9 @@ import { ASSISTANT_PLUGIN_ID, SETUPGUIDE_PLUGIN_ID } from 'app/core/constants';
 import { isOnPrem } from 'app/core/utils/isOnPrem';
 
 import { AlertIncidentTabs } from './AlertsIncidents/AlertIncidentTabs';
-import { FiringAlertsCard, canViewFiringAlerts } from './AlertsIncidents/FiringAlertsCard';
+import { FiringAlertsCard } from './AlertsIncidents/FiringAlertsCard';
 import { IncidentsCard } from './AlertsIncidents/IncidentsCard';
+import { canViewFiringAlerts } from './AlertsIncidents/useFiringAlerts';
 import { DashboardTabs } from './DashboardTabs/DashboardTabs';
 import { type HomepageTabExtensionProps } from './DashboardTabs/types';
 import { HomePageSkeleton } from './HomePageSkeleton';
@@ -110,8 +111,6 @@ export default function HomePage() {
                   <Grid gap={2} columns={{ xs: 1, md: 2 }}>
                     {/* Skip the HomepageTabs extension point for the redesign UI */}
                     <DashboardTabs extensionComponents={[]} />
-                    {/* TODO: Alerts and incidents will combine into one card */}
-                    {/* <FiringAlertsCard /> */}
                     <AlertIncidentTabs />
                   </Grid>
                 </>

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -10824,7 +10824,8 @@
   },
   "home": {
     "alerts-incidents": {
-      "title": "Firing alerts"
+      "alert-tab-label": "Firing alerts",
+      "title": "Alerts & incidents"
     },
     "dashboard-tabs": {
       "most-used": "Most used",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -10823,6 +10823,9 @@
     "name-stacking": "Stacking"
   },
   "home": {
+    "alerts-incidents": {
+      "title": "Firing alerts"
+    },
     "dashboard-tabs": {
       "most-used": "Most used",
       "most-used-active": "Most used dashboards",


### PR DESCRIPTION
**What is this feature?**

PLG homepage Alerts card rework part 1:
- Render alerts in tab view
- Extracted api logics into hook that shared between new (`AlertIncidentTabs`) and old component (`FiringAlertsCard`)
- **TODO In follow up PR**: align item layout with dashboards, team dropdown. 

| old | new (This is just layout update) |
| --- | --- |
| <img width="516" height="324" alt="image" src="https://github.com/user-attachments/assets/e6a66004-bb49-4449-a388-a78f87e04d8e" /> | <img width="526" height="491" alt="image" src="https://github.com/user-attachments/assets/4418e726-025f-4c79-b90a-97a765f37aab" /> Team dropdown and content layout will be separate PR |

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/128630

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
