### PR TITLE
Meticulous: redact datasource query responses in session recordings

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "releaseNotesUrl": "https://grafana.com/docs/grafana/next/release-notes/"
   },
   "devDependencies": {
+    "@alwaysmeticulous/sdk-bundles-api": "2.307.0",
     "@arethetypeswrong/cli": "^0.18.2",
     "@axe-core/playwright": "^4.11.1",
     "@emotion/eslint-plugin": "11.12.0",
@@ -256,6 +257,7 @@
     "zod": "^4.3.0"
   },
   "dependencies": {
+    "@alwaysmeticulous/redaction": "2.283.1",
     "@bsull/augurs": "^0.10.0",
     "@codemirror/autocomplete": "6.20.1",
     "@codemirror/lang-sql": "6.10.0",

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -189,6 +189,19 @@ export class GrafanaApp {
       });
 
       setBackendSrv(backendSrv);
+
+      // The Meticulous recorder snippet is a synchronous <script> in <head>, so
+      // window.Meticulous is already set here when the recorder is enabled. The
+      // dynamic import keeps the redaction module in a separate chunk that is
+      // never fetched when the recorder is off. Awaiting guarantees the
+      // middleware is registered before any datasource query can fire.
+      if (window.Meticulous != null) {
+        const { initMeticulousRedaction } = await import(
+          /* webpackChunkName: "meticulous-redaction" */ './core/services/meticulous-redaction'
+        );
+        initMeticulousRedaction();
+      }
+
       await initEchoSrv();
       // This needs to be done after the `initEchoSrv` since it is being used under the hood.
       startMeasure('frontend_app_init');

--- a/public/app/core/services/meticulous-redaction/index.ts
+++ b/public/app/core/services/meticulous-redaction/index.ts
@@ -1,0 +1,16 @@
+import { createQueryRedactionMiddleware } from './redactionMiddleware';
+
+/**
+ * Registers the query-redaction middleware with the Meticulous recorder. The
+ * recorder reads window.METICULOUS_RECORDER_MIDDLEWARE_V1 lazily each time it
+ * prepares a payload for upload, so registering during app boot covers all
+ * datasource query traffic (queries can only fire after boot).
+ *
+ * The recorder-presence gate lives at the call site (app.ts) so this module —
+ * and its @alwaysmeticulous/redaction dependency — stays in a lazy-loaded
+ * chunk that is never fetched when the recorder is off.
+ */
+export function initMeticulousRedaction(): void {
+  window.METICULOUS_RECORDER_MIDDLEWARE_V1 = window.METICULOUS_RECORDER_MIDDLEWARE_V1 ?? [];
+  window.METICULOUS_RECORDER_MIDDLEWARE_V1.push(createQueryRedactionMiddleware());
+}

--- a/public/app/core/services/meticulous-redaction/redactQueryResponse.test.ts
+++ b/public/app/core/services/meticulous-redaction/redactQueryResponse.test.ts
@@ -1,0 +1,144 @@
+import { FieldType, type DataFrameJSON } from '@grafana/data';
+import { type BackendDataSourceResponse } from '@grafana/runtime';
+
+import { redactQueryResponse } from './redactQueryResponse';
+
+function stringFrame(refId: string, values: string[]): DataFrameJSON {
+  return {
+    schema: { refId, fields: [{ name: 'value', type: FieldType.string }] },
+    data: { values: [values] },
+  };
+}
+
+function requestBody(queries: Array<{ refId: string; type: string }>): string {
+  return JSON.stringify({
+    queries: queries.map(({ refId, type }) => ({ refId, datasource: { uid: `${type}-uid`, type } })),
+    from: 'now-1h',
+    to: 'now',
+  });
+}
+
+function redact(response: BackendDataSourceResponse, body: string | undefined): BackendDataSourceResponse {
+  return redactQueryResponse(response, body) as BackendDataSourceResponse;
+}
+
+describe('redactQueryResponse', () => {
+  it('redacts real datasources and expressions but exempts testdata (including legacy alias)', () => {
+    const response: BackendDataSourceResponse = {
+      results: {
+        A: { frames: [stringFrame('A', ['prom-secret'])] },
+        B: { frames: [stringFrame('B', ['testdata-value'])] },
+        C: { frames: [stringFrame('C', ['alias-value'])] },
+        D: { frames: [stringFrame('D', ['expr-output'])] },
+      },
+    };
+    const output = redact(
+      response,
+      requestBody([
+        { refId: 'A', type: 'prometheus' },
+        { refId: 'B', type: 'grafana-testdata-datasource' },
+        { refId: 'C', type: 'testdata' },
+        { refId: 'D', type: '__expr__' },
+      ])
+    );
+
+    expect(output.results.A.frames![0].data!.values[0][0]).not.toBe('prom-secret');
+    expect(output.results.D.frames![0].data!.values[0][0]).not.toBe('expr-output');
+    // exempt responses pass through by reference
+    expect(output.results.B).toBe(response.results.B);
+    expect(output.results.C).toBe(response.results.C);
+  });
+
+  it('returns the same reference when every refId is exempt', () => {
+    const response: BackendDataSourceResponse = {
+      results: { A: { frames: [stringFrame('A', ['testdata-value'])] } },
+    };
+    const output = redact(response, requestBody([{ refId: 'A', type: 'grafana-testdata-datasource' }]));
+    expect(output).toBe(response);
+  });
+
+  it('redacts everything when the request body is missing or unparseable', () => {
+    const response: BackendDataSourceResponse = {
+      results: { A: { frames: [stringFrame('A', ['testdata-value'])] } },
+    };
+    for (const body of [undefined, 'not-json{{{']) {
+      const output = redact(response, body);
+      expect(output).not.toBe(response);
+      expect(output.results.A.frames![0].data!.values[0][0]).not.toBe('testdata-value');
+    }
+  });
+
+  it('redacts error strings', () => {
+    const response: BackendDataSourceResponse = {
+      results: { A: { error: 'no rows for customer acme-corp', status: 500 } },
+    };
+    const output = redact(response, requestBody([{ refId: 'A', type: 'prometheus' }]));
+    expect(output.results.A.error).toHaveLength('no rows for customer acme-corp'.length);
+    expect(output.results.A.error).not.toBe('no rows for customer acme-corp');
+    expect(output.results.A.status).toBe(500);
+  });
+
+  it('redacts legacy series keeping timestamps', () => {
+    const response: BackendDataSourceResponse = {
+      results: {
+        A: {
+          series: [
+            {
+              target: 'cpu{host=prod-1}',
+              datapoints: [
+                [42.5, 1700000000000],
+                [null, 1700000060000],
+              ],
+            },
+          ],
+        },
+      },
+    };
+    const output = redact(response, requestBody([{ refId: 'A', type: 'old-plugin' }]));
+    const series = output.results.A.series![0];
+    expect(series.target).not.toBe('cpu{host=prod-1}');
+    expect(series.datapoints[0][0]).not.toBe(42.5);
+    expect(series.datapoints[0][1]).toBe(1700000000000);
+    expect(series.datapoints[1][0]).toBeNull();
+    expect(series.datapoints[1][1]).toBe(1700000060000);
+  });
+
+  it('redacts every legacy table cell by runtime type', () => {
+    const response: BackendDataSourceResponse = {
+      results: {
+        A: {
+          tables: [
+            {
+              columns: [{ text: 'host' }, { text: 'count' }],
+              rows: [
+                ['prod-db-1', 12],
+                ['prod-db-2', 7],
+              ],
+            },
+          ],
+        },
+      },
+    };
+    const output = redact(response, requestBody([{ refId: 'A', type: 'old-plugin' }]));
+    const table = output.results.A.tables![0];
+    expect(table.rows[0][0]).not.toBe('prod-db-1');
+    expect(table.rows[0][0]).toHaveLength('prod-db-1'.length);
+    expect(table.rows[0][1]).not.toBe(12);
+  });
+
+  it('fails closed on an unrecognized envelope', () => {
+    const bogus = { unexpected: 'customer-data' };
+    const output = redactQueryResponse(bogus, undefined) as { unexpected: string };
+    expect(output.unexpected).not.toBe('customer-data');
+    expect(output.unexpected).toHaveLength('customer-data'.length);
+  });
+
+  it('does not mutate the input', () => {
+    const response: BackendDataSourceResponse = {
+      results: { A: { frames: [stringFrame('A', ['secret'])] } },
+    };
+    const before = JSON.parse(JSON.stringify(response));
+    redactQueryResponse(response, undefined);
+    expect(response).toEqual(before);
+  });
+});

--- a/public/app/core/services/meticulous-redaction/redactQueryResponse.ts
+++ b/public/app/core/services/meticulous-redaction/redactQueryResponse.ts
@@ -1,0 +1,117 @@
+import { type TableData, type TimeSeries } from '@grafana/data';
+import { type BackendDataSourceResponse, type DataResponse } from '@grafana/runtime';
+
+import { randomizeNumber, randomizeString, redactFrame, redactValueDeep } from './redactValues';
+
+const EXEMPT_DATASOURCE_TYPES = new Set(['grafana-testdata-datasource', 'testdata']);
+
+interface QueryRequestBody {
+  queries?: Array<{
+    refId?: string;
+    datasource?: {
+      type?: string;
+    };
+  }>;
+}
+
+/**
+ * refIds whose query targets a testdata datasource don't contain customer data
+ * and are left intact. Expression queries (`__expr__`) are intentionally not
+ * exempt: their output derives from real datasource data. An unparseable or
+ * missing request body exempts nothing (fail closed).
+ */
+function getExemptRefIds(requestBodyText: string | undefined): Set<string> {
+  const exempt = new Set<string>();
+  if (!requestBodyText) {
+    return exempt;
+  }
+
+  let body: QueryRequestBody;
+  try {
+    body = JSON.parse(requestBodyText);
+  } catch {
+    return exempt;
+  }
+
+  if (!Array.isArray(body?.queries)) {
+    return exempt;
+  }
+  for (const query of body.queries) {
+    if (query?.refId != null && EXEMPT_DATASOURCE_TYPES.has(query?.datasource?.type ?? '')) {
+      exempt.add(query.refId);
+    }
+  }
+  return exempt;
+}
+
+function redactLegacySeries(series: TimeSeries): TimeSeries {
+  return {
+    ...series,
+    target: randomizeString(series.target ?? ''),
+    // datapoints are [value, time] pairs; keep the timestamp so charts render
+    datapoints: series.datapoints?.map(([value, ...rest]) => [value == null ? value : randomizeNumber(value), ...rest]),
+  };
+}
+
+function redactLegacyTable(table: TableData): TableData {
+  return {
+    ...table,
+    // there is no reliable way to identify time columns in the legacy format,
+    // so every cell is redacted by runtime type (fail closed)
+    rows: table.rows?.map((row) => row.map(redactValueDeep)),
+  };
+}
+
+function redactDataResponse(response: DataResponse): DataResponse {
+  return {
+    ...response,
+    ...(response.error != null && { error: randomizeString(response.error) }),
+    ...(response.frames && { frames: response.frames.map(redactFrame) }),
+    ...(response.series && { series: response.series.map(redactLegacySeries) }),
+    ...(response.tables && { tables: response.tables.map(redactLegacyTable) }),
+  };
+}
+
+function isBackendDataSourceResponse(data: unknown): data is BackendDataSourceResponse {
+  return (
+    data != null &&
+    typeof data === 'object' &&
+    'results' in data &&
+    data.results != null &&
+    typeof data.results === 'object'
+  );
+}
+
+/**
+ * Redacts a `/api/ds/query`-shaped response body before it is uploaded to
+ * Meticulous. Returns the input object by reference when nothing needs
+ * redacting — the Meticulous middleware treats an identical reference as a
+ * no-op and keeps the original response bytes.
+ *
+ * Never mutates the input. Intentionally not wrapped in try/catch: an
+ * exception thrown from recorder middleware makes Meticulous abandon the
+ * recording, which is the fail-safe outcome (nothing uploads).
+ */
+export function redactQueryResponse(data: unknown, requestBodyText: string | undefined): unknown {
+  if (!isBackendDataSourceResponse(data)) {
+    // matching URL with an unrecognized envelope: redact everything we can find
+    return redactValueDeep(data);
+  }
+
+  const exemptRefIds = getExemptRefIds(requestBodyText);
+
+  const refIds = Object.keys(data.results);
+  if (refIds.length > 0 && refIds.every((refId) => exemptRefIds.has(refId))) {
+    return data;
+  }
+
+  return {
+    ...data,
+    results: Object.fromEntries(
+      Object.entries(data.results).map(([refId, response]) => [
+        refId,
+        exemptRefIds.has(refId) ? response : redactDataResponse(response),
+      ])
+    ),
+  };
+}

--- a/public/app/core/services/meticulous-redaction/redactValues.test.ts
+++ b/public/app/core/services/meticulous-redaction/redactValues.test.ts
@@ -1,0 +1,141 @@
+import { FieldType, type DataFrameJSON } from '@grafana/data';
+
+import { randomizeNumber, randomizeString, redactFrame, redactValueDeep } from './redactValues';
+
+describe('randomizeString', () => {
+  it('preserves length and changes content', () => {
+    const input = 'sensitive-customer-value';
+    const output = randomizeString(input);
+    expect(output).toHaveLength(input.length);
+    expect(output).not.toBe(input);
+    expect(output).toMatch(/^[a-z0-9]+$/);
+  });
+
+  it('handles the empty string', () => {
+    expect(randomizeString('')).toBe('');
+  });
+});
+
+describe('randomizeNumber', () => {
+  it('preserves sign and order of magnitude', () => {
+    for (const input of [123.45, -987, 0.005, -0.5, 1e9]) {
+      const output = randomizeNumber(input);
+      expect(Math.sign(output)).toBe(Math.sign(input));
+      expect(Math.floor(Math.log10(Math.abs(output)))).toBe(Math.floor(Math.log10(Math.abs(input))));
+    }
+  });
+
+  it('passes through zero and non-finite values', () => {
+    expect(randomizeNumber(0)).toBe(0);
+    expect(randomizeNumber(NaN)).toBeNaN();
+    expect(randomizeNumber(Infinity)).toBe(Infinity);
+    expect(randomizeNumber(-Infinity)).toBe(-Infinity);
+  });
+});
+
+describe('redactValueDeep', () => {
+  it('redacts strings and numbers, keeps booleans and nulls, walks arrays and objects', () => {
+    const input = {
+      name: 'customer-pod',
+      count: 42,
+      active: true,
+      missing: null,
+      nested: { ips: ['10.0.0.1', '10.0.0.2'] },
+    };
+    const output = redactValueDeep(input) as typeof input;
+
+    expect(output.name).toHaveLength('customer-pod'.length);
+    expect(output.name).not.toBe('customer-pod');
+    expect(output.count).not.toBe(42);
+    expect(output.active).toBe(true);
+    expect(output.missing).toBeNull();
+    expect(output.nested.ips).toHaveLength(2);
+    expect(output.nested.ips[0]).not.toBe('10.0.0.1');
+    // input untouched
+    expect(input.nested.ips[0]).toBe('10.0.0.1');
+  });
+});
+
+describe('redactFrame', () => {
+  const frame: DataFrameJSON = {
+    schema: {
+      refId: 'A',
+      meta: { executedQueryString: 'SELECT secret FROM customers' },
+      fields: [
+        { name: 'Time', type: FieldType.time },
+        { name: 'value', type: FieldType.number, labels: { pod: 'checkout-7f9' } },
+        { name: 'host', type: FieldType.string },
+        { name: 'up', type: FieldType.boolean },
+        { name: 'level', type: FieldType.enum },
+        { name: 'blob' },
+      ],
+    },
+    data: {
+      values: [
+        [1000, 2000, 3000],
+        [1.5, null, 300],
+        ['host-a', 'host-b', null],
+        [true, false, true],
+        [0, 1, 0],
+        [{ customer: 'acme' }, 'raw-string', null],
+      ],
+      entities: [null, { NaN: [1] }, null, null, null, null],
+      enums: [null, null, null, null, ['error', 'warn'], null],
+      bases: [0, 100, 0, 0, 0, 0],
+    },
+  };
+
+  it('redacts by field type and preserves structure', () => {
+    const output = redactFrame(frame);
+
+    // time and boolean untouched
+    expect(output.data!.values[0]).toEqual([1000, 2000, 3000]);
+    expect(output.data!.values[3]).toEqual([true, false, true]);
+
+    // numbers randomized, nulls preserved
+    expect(output.data!.values[1]).toHaveLength(3);
+    expect(output.data!.values[1][0]).not.toBe(1.5);
+    expect(output.data!.values[1][1]).toBeNull();
+
+    // strings randomized with length preserved
+    expect(output.data!.values[2][0]).toHaveLength('host-a'.length);
+    expect(output.data!.values[2][0]).not.toBe('host-a');
+    expect(output.data!.values[2][2]).toBeNull();
+
+    // enum codes untouched, dictionary randomized
+    expect(output.data!.values[4]).toEqual([0, 1, 0]);
+    expect(output.data!.enums![4]).toHaveLength(2);
+    expect(output.data!.enums![4]![0]).not.toBe('error');
+
+    // missing type fails closed via deep redaction
+    const blob = output.data!.values[5][0] as { customer: string };
+    expect(blob.customer).not.toBe('acme');
+    expect(output.data!.values[5][2]).toBeNull();
+  });
+
+  it('redacts label values but keeps keys and field names', () => {
+    const output = redactFrame(frame);
+    const valueField = output.schema!.fields[1];
+    expect(valueField.name).toBe('value');
+    expect(Object.keys(valueField.labels!)).toEqual(['pod']);
+    expect(valueField.labels!.pod).not.toBe('checkout-7f9');
+  });
+
+  it('redacts executedQueryString and passes through entities and bases', () => {
+    const output = redactFrame(frame);
+    expect(output.schema!.meta!.executedQueryString).not.toBe('SELECT secret FROM customers');
+    expect(output.data!.entities).toBe(frame.data!.entities);
+    expect(output.data!.bases).toBe(frame.data!.bases);
+  });
+
+  it('does not mutate the input frame', () => {
+    const before = JSON.parse(JSON.stringify(frame));
+    redactFrame(frame);
+    expect(frame).toEqual(before);
+  });
+
+  it('handles frames without schema or data', () => {
+    expect(redactFrame({})).toEqual({});
+    expect(redactFrame({ schema: { fields: [] } })).toEqual({ schema: { fields: [] } });
+  });
+});

--- a/public/app/core/services/meticulous-redaction/redactValues.ts
+++ b/public/app/core/services/meticulous-redaction/redactValues.ts
@@ -1,0 +1,131 @@
+import { FieldType, type DataFrameJSON, type Labels } from '@grafana/data';
+
+const CHARS = 'abcdefghijklmnopqrstuvwxyz0123456789';
+
+export function randomizeString(value: string): string {
+  let out = '';
+  for (let i = 0; i < value.length; i++) {
+    out += CHARS[Math.floor(Math.random() * CHARS.length)];
+  }
+  return out;
+}
+
+export function randomizeNumber(value: number): number {
+  // zero and non-finite values carry no customer information and are load-bearing for rendering
+  if (value === 0 || !Number.isFinite(value)) {
+    return value;
+  }
+  const magnitude = Math.pow(10, Math.floor(Math.log10(Math.abs(value))));
+  return Math.sign(value) * magnitude * (1 + Math.random() * 9);
+}
+
+/**
+ * Fail-closed redactor for values of unknown shape: strings and numbers are
+ * randomized, arrays and objects are walked recursively, everything else
+ * (booleans, nulls) passes through.
+ */
+export function redactValueDeep(value: unknown): unknown {
+  if (typeof value === 'string') {
+    return randomizeString(value);
+  }
+  if (typeof value === 'number') {
+    return randomizeNumber(value);
+  }
+  if (Array.isArray(value)) {
+    return value.map(redactValueDeep);
+  }
+  if (value != null && typeof value === 'object') {
+    return Object.fromEntries(Object.entries(value).map(([key, entry]) => [key, redactValueDeep(entry)]));
+  }
+  return value;
+}
+
+interface FieldRedactionInput {
+  values: unknown[];
+  enums: string[] | null | undefined;
+}
+
+type FieldRedactor = (input: FieldRedactionInput) => FieldRedactionInput;
+
+const passthrough: FieldRedactor = (input) => input;
+
+const mapValues =
+  (redactValue: (value: unknown) => unknown): FieldRedactor =>
+  (input) => ({
+    ...input,
+    // preserve nulls and array length so `entities` index lookups stay valid
+    values: input.values.map((value) => (value == null ? value : redactValue(value))),
+  });
+
+const redactEnumField: FieldRedactor = (input) => ({
+  ...input,
+  // values are integer codes into the enum dictionary; only the dictionary strings are sensitive
+  enums: input.enums == null ? input.enums : input.enums.map(randomizeString),
+});
+
+/**
+ * Per-field-type redaction registry. Types without an entry fall back to the
+ * recursive fail-closed redactor, so unhandled or future field types can never
+ * leak values. Extend by adding an entry (e.g. a nestedFrames redactor that
+ * recurses into child frames).
+ */
+const FIELD_REDACTORS: Partial<Record<FieldType, FieldRedactor>> = {
+  // time and boolean values are not customer data and keep charts rendering
+  [FieldType.time]: passthrough,
+  [FieldType.boolean]: passthrough,
+  // fall back to deep redaction when a value doesn't match its declared field type
+  [FieldType.number]: mapValues((value) =>
+    typeof value === 'number' ? randomizeNumber(value) : redactValueDeep(value)
+  ),
+  [FieldType.string]: mapValues((value) =>
+    typeof value === 'string' ? randomizeString(value) : redactValueDeep(value)
+  ),
+  [FieldType.enum]: redactEnumField,
+};
+
+const failClosedRedactor: FieldRedactor = mapValues(redactValueDeep);
+
+function redactLabels(labels: Labels): Labels {
+  return Object.fromEntries(Object.entries(labels).map(([key, value]) => [key, randomizeString(value)]));
+}
+
+/**
+ * Returns a redacted copy of a DataFrameJSON. Never mutates the input.
+ */
+export function redactFrame(frame: DataFrameJSON): DataFrameJSON {
+  const fields = frame.schema?.fields ?? [];
+
+  const values = frame.data?.values ?? [];
+  const enums = frame.data?.enums;
+  const redactedValues: unknown[][] = [];
+  const redactedEnums: Array<string[] | null> = [];
+
+  for (let i = 0; i < values.length; i++) {
+    const type = fields[i]?.type;
+    const redactor = (type && FIELD_REDACTORS[type]) || failClosedRedactor;
+    const result = redactor({ values: values[i], enums: enums?.[i] });
+    redactedValues.push(result.values);
+    redactedEnums.push(result.enums ?? null);
+  }
+
+  return {
+    ...frame,
+    ...(frame.schema && {
+      schema: {
+        ...frame.schema,
+        ...(frame.schema.meta?.executedQueryString != null && {
+          // query text can embed customer identifiers (label matchers, filters)
+          meta: { ...frame.schema.meta, executedQueryString: randomizeString(frame.schema.meta.executedQueryString) },
+        }),
+        fields: fields.map((field) => (field.labels ? { ...field, labels: redactLabels(field.labels) } : field)),
+      },
+    }),
+    ...(frame.data && {
+      data: {
+        ...frame.data,
+        values: redactedValues,
+        ...(enums && { enums: redactedEnums }),
+      },
+    }),
+  };
+}

--- a/public/app/core/services/meticulous-redaction/redactionMiddleware.test.ts
+++ b/public/app/core/services/meticulous-redaction/redactionMiddleware.test.ts
@@ -1,0 +1,78 @@
+import { type HarResponse } from '@alwaysmeticulous/api';
+import { type NetworkResponseMetadata } from '@alwaysmeticulous/sdk-bundles-api';
+
+import { createQueryRedactionMiddleware, QUERY_URL_REGEX } from './redactionMiddleware';
+
+function harResponse(text: string): HarResponse {
+  return {
+    status: 200,
+    headers: [],
+    content: { mimeType: 'application/json', text },
+  };
+}
+
+function metadata(url: string, postDataText?: string): NetworkResponseMetadata {
+  return {
+    requestStartedAt: 0,
+    responseReceivedAt: 1,
+    request: {
+      method: 'POST',
+      url,
+      headers: [],
+      ...(postDataText != null && { postData: { mimeType: 'application/json', text: postDataText } }),
+    },
+  };
+}
+
+const QUERY_URL = 'https://grafana.example.com/api/ds/query?ds_type=prometheus';
+
+describe('QUERY_URL_REGEX', () => {
+  it.each([
+    ['https://grafana.example.com/api/ds/query?ds_type=prometheus', true],
+    ['https://grafana.example.com/api/ds/query', true],
+    ['https://grafana.example.com/apis/query.grafana.app/v0alpha1/namespaces/default/query?ds_type=loki', true],
+    ['https://grafana.example.com/api/dashboards/uid/abc', false],
+    ['https://grafana.example.com/api/datasources', false],
+  ])('%s -> %s', (url, expected) => {
+    expect(QUERY_URL_REGEX.test(url)).toBe(expected);
+  });
+});
+
+describe('createQueryRedactionMiddleware', () => {
+  const middleware = createQueryRedactionMiddleware();
+
+  it('returns the same response reference for non-query URLs', () => {
+    const response = harResponse(JSON.stringify({ secret: 'value' }));
+    const output = middleware.transformNetworkResponse!(
+      response,
+      metadata('https://grafana.example.com/api/dashboards/uid/abc')
+    );
+    expect(output).toBe(response);
+  });
+
+  it('redacts query responses using the request body for exemptions', () => {
+    const body = JSON.stringify({
+      results: {
+        A: {
+          frames: [{ schema: { refId: 'A', fields: [{ name: 'v', type: 'string' }] }, data: { values: [['secret']] } }],
+        },
+      },
+    });
+    const postData = JSON.stringify({ queries: [{ refId: 'A', datasource: { type: 'prometheus' } }] });
+
+    const output = middleware.transformNetworkResponse!(harResponse(body), metadata(QUERY_URL, postData));
+    const parsed = JSON.parse(output.content.text!);
+    expect(parsed.results.A.frames[0].data.values[0][0]).not.toBe('secret');
+    expect(parsed.results.A.frames[0].data.values[0][0]).toHaveLength('secret'.length);
+  });
+
+  it('replaces non-JSON bodies on query URLs', () => {
+    const output = middleware.transformNetworkResponse!(harResponse('<html>error</html>'), metadata(QUERY_URL));
+    expect(output.content.text).toBe('<REDACTED>');
+  });
+
+  it('drops websocket data', () => {
+    const connection = { url: 'wss://grafana.example.com/api/live/ws', messages: [] };
+    expect(middleware.transformWebSocketConnectionData!(connection as never)).toBeNull();
+  });
+});

--- a/public/app/core/services/meticulous-redaction/redactionMiddleware.ts
+++ b/public/app/core/services/meticulous-redaction/redactionMiddleware.ts
@@ -1,0 +1,28 @@
+import { transformJsonResponse } from '@alwaysmeticulous/redaction';
+import { type RecorderMiddleware } from '@alwaysmeticulous/sdk-bundles-api';
+
+import { redactQueryResponse } from './redactQueryResponse';
+
+export const QUERY_URL_REGEX =
+  /\/api\/ds\/query(\?|$)|\/apis\/query\.grafana\.app\/v0alpha1\/namespaces\/[^/]+\/query(\?|$)/;
+
+/**
+ * Recorder middleware that redacts datasource query responses before session
+ * payloads are uploaded to Meticulous.
+ *
+ * Streaming fetch/XHR response data is dropped automatically by the recorder
+ * because this middleware defines transformNetworkResponse without the
+ * streaming hooks.
+ */
+export function createQueryRedactionMiddleware(): RecorderMiddleware {
+  return {
+    ...transformJsonResponse<unknown>({
+      urlRegExp: QUERY_URL_REGEX,
+      // fail closed: a non-JSON body on a query URL is replaced with "<REDACTED>"
+      skipRedactionIfNotValidJSON: false,
+      transform: (data, metadata) => redactQueryResponse(data, metadata.request.postData?.text),
+    }),
+    // Grafana Live / Loki live tail frames would otherwise upload unredacted
+    transformWebSocketConnectionData: () => null,
+  };
+}

--- a/public/app/types/window.d.ts
+++ b/public/app/types/window.d.ts
@@ -1,3 +1,5 @@
+import { type RecorderMiddleware } from '@alwaysmeticulous/sdk-bundles-api';
+
 import { type BootData } from '@grafana/data';
 export declare global {
   interface Window {
@@ -37,6 +39,26 @@ export declare global {
      * The image renderer can check this to decide whether to use this mechanism or a fallback.
      */
     __grafanaRenderBindingSupported?: boolean;
+
+    /**
+     * Public API of the Meticulous.ai session recorder, set by the recorder
+     * snippet loaded in index.html when the grafana.meticulousAIMode feature
+     * toggle is enabled. Presence indicates the recorder is active.
+     */
+    Meticulous?: unknown;
+
+    /**
+     * Internal API of the Meticulous.ai session recorder.
+     */
+    __meticulous?: {
+      stopRecording: () => void;
+    };
+
+    /**
+     * Middleware applied by the Meticulous recorder to session payloads before
+     * they are uploaded. Read lazily by the recorder on each upload.
+     */
+    METICULOUS_RECORDER_MIDDLEWARE_V1?: RecorderMiddleware[];
   }
 
   // Augment DOMParser to accept TrustedType sanitised content

--- a/yarn.lock
+++ b/yarn.lock
@@ -62,6 +62,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@alwaysmeticulous/api@npm:2.307.0":
+  version: 2.307.0
+  resolution: "@alwaysmeticulous/api@npm:2.307.0"
+  checksum: 10/131038bd337fa7b0585200d8489ff924bd5d4241cf9c6ffce5def38fb6123d6a5fcb453accbbc0dc04403add399e2889e927acfc3eed8274802cc9f797e8c346
+  languageName: node
+  linkType: hard
+
+"@alwaysmeticulous/redaction@npm:2.283.1":
+  version: 2.283.1
+  resolution: "@alwaysmeticulous/redaction@npm:2.283.1"
+  checksum: 10/d9621d9b3d36ea296ae4bd7ed17398d86d57ea6816fd3937a61f9fce787487793c09ca641a7606d73c144fcc0dcad00c9ce7a67bfd31575c91167a1e035e4449
+  languageName: node
+  linkType: hard
+
+"@alwaysmeticulous/sdk-bundles-api@npm:2.307.0":
+  version: 2.307.0
+  resolution: "@alwaysmeticulous/sdk-bundles-api@npm:2.307.0"
+  dependencies:
+    "@alwaysmeticulous/api": "npm:2.307.0"
+  checksum: 10/9cc22da896559ae275c72392f1b95e87d1df503cb1084a63e2ffb48456d3075776af61ae5fb52d43905c2695c4bf26c27c9ddf3695b1f3df13dc0ef8c86d71b6
+  languageName: node
+  linkType: hard
+
 "@andrewbranch/untar.js@npm:^1.0.3":
   version: 1.0.3
   resolution: "@andrewbranch/untar.js@npm:1.0.3"
@@ -18533,6 +18556,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "grafana@workspace:."
   dependencies:
+    "@alwaysmeticulous/redaction": "npm:2.283.1"
+    "@alwaysmeticulous/sdk-bundles-api": "npm:2.307.0"
     "@arethetypeswrong/cli": "npm:^0.18.2"
     "@axe-core/playwright": "npm:^4.11.1"
     "@bsull/augurs": "npm:^0.10.0"


### PR DESCRIPTION
Registers Meticulous recorder middleware that randomizes string and number field values (and label values) in dataframe responses from /api/ds/query and the query service before payloads upload, exempting only grafana-testdata queries. Unknown field types, unparseable request bodies, and unrecognized envelopes fail closed; websocket data is dropped. The module is gated on recorder presence and loaded as a separate chunk so it adds no bundle cost when the feature is off.

This is a proposed way that we could enable redaction for all data in Meticulous recordings, which would potentially enable local recordings and recordings on ops.
