### PR TITLE
RBAC: backfill datasource action set permissions

### DIFF
--- a/pkg/services/sqlstore/migrations/accesscontrol/datasource_action_set_migration.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/datasource_action_set_migration.go
@@ -1,0 +1,132 @@
+package accesscontrol
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
+	"github.com/grafana/grafana/pkg/util/xorm"
+)
+
+const AddDatasourceActionSetMigrationID = "adding datasource action set permissions"
+
+func AddDatasourceActionSetPermissionsMigrator(mg *migrator.Migrator) {
+	mg.AddMigration(AddDatasourceActionSetMigrationID, &datasourceActionSetMigrator{})
+}
+
+type datasourceActionSetMigrator struct {
+	sess     *xorm.Session
+	migrator *migrator.Migrator
+	migrator.MigrationBase
+}
+
+var _ migrator.CodeMigration = new(datasourceActionSetMigrator)
+
+func (m *datasourceActionSetMigrator) SQL(migrator.Dialect) string {
+	return "code migration"
+}
+
+func (m *datasourceActionSetMigrator) Exec(sess *xorm.Session, mg *migrator.Migrator) error {
+	m.sess = sess
+	m.migrator = mg
+	return m.addDatasourceActionSetActions()
+}
+
+func (m *datasourceActionSetMigrator) addDatasourceActionSetActions() error {
+	var results []accesscontrol.Permission
+
+	// Fetch DS granular edit/admin signals and any existing action set tokens for managed roles.
+	// Managed grants are atomic: Edit always includes write (+ delete), Admin always includes
+	// permissions:write (+ permissions:read). So write / permissions:write are sufficient signals.
+	// datasources:query is both the Query granular action and the Query token — no Query backfill.
+	sql := `
+	SELECT permission.role_id, permission.action, permission.scope FROM permission
+		INNER JOIN role ON permission.role_id = role.id
+		WHERE permission.action IN (
+			'datasources:write', 'datasources.permissions:write',
+			'datasources:edit', 'datasources:admin'
+		)
+		AND permission.scope LIKE 'datasources:uid:%'
+		AND role.name LIKE 'managed:%'
+`
+	if err := m.sess.SQL(sql).Find(&results); err != nil {
+		return fmt.Errorf("failed to query datasource permissions: %w", err)
+	}
+
+	// groupedPermissions tracks the highest action set level per (roleID, scope).
+	// hasActionSet tracks pairs that already have a token, so we skip them.
+	groupedPermissions := make(map[int64]map[string]string) // map[roleID][scope] = "edit"|"admin"
+	hasActionSet := make(map[int64]map[string]bool)         // map[roleID][scope] = true
+
+	for _, result := range results {
+		if isDatasourceActionSetToken(result.Action) {
+			if _, ok := hasActionSet[result.RoleID]; !ok {
+				hasActionSet[result.RoleID] = make(map[string]bool)
+			}
+			hasActionSet[result.RoleID][result.Scope] = true
+			// Remove from groupedPermissions if we already queued it — no need to insert.
+			delete(groupedPermissions[result.RoleID], result.Scope)
+			continue
+		}
+
+		// Skip if we already know this pair has a token.
+		if hasActionSet[result.RoleID][result.Scope] {
+			continue
+		}
+
+		if _, ok := groupedPermissions[result.RoleID]; !ok {
+			groupedPermissions[result.RoleID] = make(map[string]string)
+		}
+
+		// Promote to the highest level seen for this (roleID, scope).
+		current := groupedPermissions[result.RoleID][result.Scope]
+		switch result.Action {
+		case "datasources.permissions:write":
+			groupedPermissions[result.RoleID][result.Scope] = "admin"
+		case "datasources:write":
+			if current != "admin" {
+				groupedPermissions[result.RoleID][result.Scope] = "edit"
+			}
+		}
+	}
+
+	toAdd := make([]accesscontrol.Permission, 0, len(groupedPermissions))
+	now := time.Now()
+
+	for roleID, permissions := range groupedPermissions {
+		for scope, level := range permissions {
+			kind, attr, identifier := accesscontrol.SplitScope(scope)
+			toAdd = append(toAdd, accesscontrol.Permission{
+				RoleID:     roleID,
+				Scope:      scope,
+				Action:     "datasources:" + level,
+				Kind:       kind,
+				Attribute:  attr,
+				Identifier: identifier,
+				Created:    now,
+				Updated:    now,
+			})
+		}
+	}
+
+	if len(toAdd) > 0 {
+		err := batch(len(toAdd), batchSize, func(start, end int) error {
+			m.migrator.Logger.Debug(fmt.Sprintf("inserting datasource action set permissions %v", toAdd[start:end]))
+			if _, err := m.sess.InsertMulti(toAdd[start:end]); err != nil {
+				return fmt.Errorf("failed to insert datasource action set permissions: %w", err)
+			}
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+		m.migrator.Logger.Debug("updated managed roles with datasource action set permissions")
+	}
+
+	return nil
+}
+
+func isDatasourceActionSetToken(action string) bool {
+	return action == "datasources:edit" || action == "datasources:admin"
+}

--- a/pkg/services/sqlstore/migrations/accesscontrol/test/datasource_action_set_migration_test.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/test/datasource_action_set_migration_test.go
@@ -1,0 +1,181 @@
+package test
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	acmig "github.com/grafana/grafana/pkg/services/sqlstore/migrations/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+func TestDatasourceActionSetMigration(t *testing.T) {
+	x := setupTestDB(t)
+
+	type migrationTestCase struct {
+		desc               string
+		existingRolePerms  map[string]map[string][]string // roleName -> scope -> actions
+		expectedActionSets map[string]map[string]string   // roleName -> scope -> expected action set token
+	}
+
+	testCases := []migrationTestCase{
+		{
+			desc:              "empty perms — nothing to do",
+			existingRolePerms: map[string]map[string][]string{},
+		},
+		{
+			desc: "non-managed role is skipped",
+			existingRolePerms: map[string]map[string][]string{
+				"my_custom_role": {
+					"datasources:uid:ds1": {"datasources:read", "datasources:query", "datasources:write", "datasources:delete"},
+				},
+			},
+		},
+		{
+			desc: "query-only grant gets no action set token",
+			existingRolePerms: map[string]map[string][]string{
+				"managed:users:1:permissions": {
+					"datasources:uid:ds1": {"datasources:read", "datasources:query"},
+				},
+			},
+		},
+		{
+			desc: "managed edit grant gets datasources:edit token",
+			existingRolePerms: map[string]map[string][]string{
+				"managed:users:1:permissions": {
+					"datasources:uid:ds1": {"datasources:read", "datasources:query", "datasources:write", "datasources:delete"},
+				},
+			},
+			expectedActionSets: map[string]map[string]string{
+				"managed:users:1:permissions": {
+					"datasources:uid:ds1": "datasources:edit",
+				},
+			},
+		},
+		{
+			desc: "managed admin grant gets datasources:admin token",
+			existingRolePerms: map[string]map[string][]string{
+				"managed:users:1:permissions": {
+					"datasources:uid:ds1": {
+						"datasources:read", "datasources:query", "datasources:write", "datasources:delete",
+						"datasources.permissions:read", "datasources.permissions:write",
+					},
+				},
+			},
+			expectedActionSets: map[string]map[string]string{
+				"managed:users:1:permissions": {
+					"datasources:uid:ds1": "datasources:admin",
+				},
+			},
+		},
+		{
+			desc: "existing action set token is not duplicated",
+			existingRolePerms: map[string]map[string][]string{
+				"managed:users:1:permissions": {
+					"datasources:uid:ds1": {"datasources:write", "datasources:delete", "datasources:edit"},
+				},
+			},
+			expectedActionSets: map[string]map[string]string{
+				"managed:users:1:permissions": {
+					"datasources:uid:ds1": "datasources:edit",
+				},
+			},
+		},
+		{
+			desc: "multiple roles and UIDs are handled independently",
+			existingRolePerms: map[string]map[string][]string{
+				"managed:users:1:permissions": {
+					"datasources:uid:ds1": {"datasources:write"},
+					"datasources:uid:ds2": {"datasources:write", "datasources.permissions:write"},
+				},
+				"managed:teams:1:permissions": {
+					"datasources:uid:ds1": {"datasources:write", "datasources.permissions:write"},
+				},
+			},
+			expectedActionSets: map[string]map[string]string{
+				"managed:users:1:permissions": {
+					"datasources:uid:ds1": "datasources:edit",
+					"datasources:uid:ds2": "datasources:admin",
+				},
+				"managed:teams:1:permissions": {
+					"datasources:uid:ds1": "datasources:admin",
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			_, errDeleteMig := x.Exec(`DELETE FROM migration_log WHERE migration_id = ?`, acmig.AddDatasourceActionSetMigrationID)
+			require.NoError(t, errDeleteMig)
+			_, errDeleteRole := x.Exec(`DELETE FROM role`)
+			require.NoError(t, errDeleteRole)
+			_, errDeletePerms := x.Exec(`DELETE FROM permission`)
+			require.NoError(t, errDeletePerms)
+
+			orgID := 1
+			rolePerms := map[string][]rawPermission{}
+			for roleName, permissions := range tc.existingRolePerms {
+				rawPerms := []rawPermission{}
+				for scope, actions := range permissions {
+					for _, action := range actions {
+						rawPerms = append(rawPerms, rawPermission{Scope: scope, Action: action})
+					}
+				}
+				rolePerms[roleName] = rawPerms
+			}
+			putTestPermissions(t, x, map[int64]map[string][]rawPermission{int64(orgID): rolePerms})
+
+			acmigrator := migrator.NewMigrator(x, &setting.Cfg{Logger: log.New("acmigration.test")})
+			acmig.AddDatasourceActionSetPermissionsMigrator(acmigrator)
+
+			require.NoError(t, acmigrator.Start(false, 0))
+
+			for roleName, existingPerms := range tc.existingRolePerms {
+				role := accesscontrol.Role{}
+				hasRole, err := x.Table("role").Where("org_id = ? AND name = ?", orgID, roleName).Get(&role)
+				require.NoError(t, err)
+				require.True(t, hasRole, "expected role to exist: %s", roleName)
+
+				perms := []accesscontrol.Permission{}
+				_, err = x.Table("permission").Where("role_id = ?", role.ID).FindAndCount(&perms)
+				require.NoError(t, err)
+
+				gotByScopeAction := map[string][]string{}
+				for _, p := range perms {
+					gotByScopeAction[p.Scope] = append(gotByScopeAction[p.Scope], p.Action)
+				}
+
+				for scope, originalActions := range existingPerms {
+					got := gotByScopeAction[scope]
+					// All original actions must still be present.
+					for _, a := range originalActions {
+						require.Contains(t, got, a, "original action missing after migration: role=%s scope=%s action=%s", roleName, scope, a)
+					}
+					// Check the expected action set token was added (or was already present).
+					if expectedToken, ok := tc.expectedActionSets[roleName][scope]; ok {
+						require.True(t, slices.Contains(got, expectedToken),
+							"expected action set token %q for role=%s scope=%s; got %v", expectedToken, roleName, scope, got)
+						// Exactly one copy of the token.
+						count := 0
+						for _, a := range got {
+							if a == expectedToken {
+								count++
+							}
+						}
+						require.Equal(t, 1, count, "expected exactly one %q for role=%s scope=%s; got %v", expectedToken, roleName, scope, got)
+					} else {
+						require.False(t, slices.Contains(got, "datasources:edit"),
+							"unexpected datasources:edit for role=%s scope=%s; got %v", roleName, scope, got)
+						require.False(t, slices.Contains(got, "datasources:admin"),
+							"unexpected datasources:admin for role=%s scope=%s; got %v", roleName, scope, got)
+					}
+				}
+			}
+		})
+	}
+}

--- a/pkg/services/sqlstore/migrations/migrations.go
+++ b/pkg/services/sqlstore/migrations/migrations.go
@@ -131,6 +131,8 @@ func (oss *OSSMigrations) AddMigration(mg *Migrator) {
 
 	accesscontrol.AddSAActionSetPermissionsMigrator(mg)
 
+	accesscontrol.AddDatasourceActionSetPermissionsMigrator(mg)
+
 	externalsession.AddMigration(mg)
 
 	accesscontrol.AddReceiverCreateScopeMigration(mg)


### PR DESCRIPTION
## Why the change

Older managed datasource grants may only have granular actions. Before enabling `iam.onlyStoreDatasourceActionSets` (which stores only action-set tokens), we need those tokens present on existing grants so Edit/Admin access is preserved.

## Summary
- Add a SQL code migration that backfills missing `datasources:edit` / `datasources:admin` tokens onto `managed:%` roles for `datasources:uid:%` scopes
- Infer level from `datasources:write` (edit) and `datasources.permissions:write` (admin); skip when a token already exists
- No Query backfill (`datasources:query` is already both the granular action and the token)
- Register after the service-account action-set migrator; cover with migration tests