### PR TITLE
[release-12.3.9] alerting: fix ORM table mapping bug causing SELECT alert_rule columns FROM user on PostgreSQL

### DIFF
--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -431,7 +431,7 @@ func (st DBstore) UpdateAlertRules(ctx context.Context, user *ngmodels.UserUID, 
 				return fmt.Errorf("failed to convert alert rule %s to storage model: %w", r.New.UID, err)
 			}
 			// no way to update multiple rules at once
-			if updated, err := sess.ID(r.Existing.ID).AllCols().Omit("rule_guid").Update(converted); err != nil || updated == 0 {
+			if updated, err := sess.Table(alertRule{}).ID(r.Existing.ID).AllCols().Omit("guid").Update(converted); err != nil || updated == 0 {
 				if err != nil {
 					if st.SQLStore.GetDialect().IsUniqueConstraintViolation(err) {
 						return ngmodels.ErrAlertRuleConflict(r.New.UID, r.New.OrgID, err)
@@ -532,7 +532,7 @@ func (st DBstore) preventIntermediateUniqueConstraintViolations(sess *db.Session
 			uniqueTempTitle = r.Title[:AlertRuleMaxTitleLength-len(u)] + uuid.New().String()
 		}
 
-		if updated, err := sess.ID(r.ID).Cols("title").Update(&alertRule{Title: uniqueTempTitle, Version: r.Version}); err != nil || updated == 0 {
+		if updated, err := sess.Table(alertRule{}).ID(r.ID).Cols("title").Update(&alertRule{Title: uniqueTempTitle, Version: r.Version}); err != nil || updated == 0 {
 			if err != nil {
 				return fmt.Errorf("failed to set temporary rule title [%s] %s: %w", r.UID, r.Title, err)
 			}

--- a/pkg/services/ngalert/store/alert_rule_test.go
+++ b/pkg/services/ngalert/store/alert_rule_test.go
@@ -228,6 +228,45 @@ func TestIntegrationUpdateAlertRules(t *testing.T) {
 			require.EqualValues(t, 1, count) // only the current version
 		})
 	})
+
+	t.Run("should preserve guid and use correct table when called inside an outer transaction", func(t *testing.T) {
+		// Regression test for the ORM table inference bug where UpdateAlertRules was
+		// called from callers (UpdateRuleGroup, UpdateAlertRule) that already hold an
+		// outer InTransaction session on the context. A prior query on that shared
+		// session could leave xorm's table state pointing at the wrong model,
+		// causing "SELECT alert_rule columns FROM user" on PostgreSQL.
+		rule := createRule(t, store, gen)
+		require.NotEmpty(t, rule.GUID, "rule must have a guid after insert")
+		originalGUID := rule.GUID
+
+		newRule := models.CopyRule(rule)
+		newRule.Title = util.GenerateShortUID()
+
+		err := sqlStore.InTransaction(context.Background(), func(ctx context.Context) error {
+			// Simulate a prior query on the shared session using a different table,
+			// as would happen when the folder service or provenance store runs on
+			// the same transaction context before UpdateAlertRules is called.
+			_ = sqlStore.WithDbSession(ctx, func(sess *db.Session) error {
+				_, _ = sess.Table("alert_rule_version").Where("1=0").Count()
+				return nil
+			})
+			return store.UpdateAlertRules(ctx, &usr, []models.UpdateRule{{
+				Existing: rule,
+				New:      *newRule,
+			}})
+		})
+		require.NoError(t, err)
+
+		dbrule := &alertRule{}
+		err = sqlStore.WithDbSession(context.Background(), func(sess *db.Session) error {
+			exist, err := sess.Table(alertRule{}).ID(rule.ID).Get(dbrule)
+			require.Truef(t, exist, "rule with ID %d not found after update", rule.ID)
+			return err
+		})
+		require.NoError(t, err)
+		require.Equal(t, originalGUID, dbrule.GUID, "guid must not change on update — it is an immutable identifier")
+		require.Equal(t, newRule.Title, dbrule.Title)
+	})
 }
 
 func TestIntegration_GetAlertRulesForScheduling(t *testing.T) {


### PR DESCRIPTION
Manual backport of https://github.com/grafana/grafana/pull/124935 to 12.3.9, the backport action not working for forks...