### PR TITLE
test: Migrate E2E to page objects (PR #12)

### DIFF
--- a/e2e-playwright/dashboard-new-layouts/AGENTS.md
+++ b/e2e-playwright/dashboard-new-layouts/AGENTS.md
@@ -6,20 +6,20 @@ This suite contains Playwright E2E tests for the V2 dashboard layout system. Tes
 
 ## Page Objects Reference
 
-All page objects live in `page-objects/` and are re-exported from `page-objects/index.ts`. Every page object extends the abstract `PageObject` base class (`PageObject.ts`), which holds the shared `page`, `dashboardPage`, and `selectors` dependencies as `protected` fields.
+All page objects live in `page-objects/` and are re-exported from `page-objects/index.ts`. Every page object extends the abstract `PageObject` base class (`PageObject.ts`), which holds the shared `page`, `dashboardPage`, `selectors`, and `components` dependencies as `protected` fields.
 
-| Class              | File                          | UI Region                                                              | Key Methods / Getters                                                                                                                                                                                                                   |
-| ------------------ | ----------------------------- | ---------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `PageObject`       | `PageObject.ts`               | _(abstract base — not used directly)_                                  | Shared constructor (`page`, `dashboardPage`, `selectors`)                                                                                                                                                                               |
-| `Controls`         | `Controls.ts`                 | Top nav bar (edit, save, ...) and variable submenu                     | `enterEditMode()`, `exitEditMode()`; `variables` sub-object: `getLabel(variableLabel)`, `selectOption(variableLabel, optionLabel)`, `addFilter(variableLabel, [label, operator, value])`                                                |
-| `Sidebar`          | `sidebar/Sidebar.ts`          | Whole sidebar region (toolbar + open pane)                             | `.toolbar`, `.addOptions`, `.dashboardOptions`, `.panelOptions`, `.variableOptions`, `.contentOutline` sub-objects; `getContainer()`, `clickGoBackButton()`, `getDockToggle()`, `clickCloseButton()`, `clickDeleteButton({ confirm? })` |
-| `Toolbar`          | `sidebar/Toolbar.ts`          | Icon strip — accessed via `sidebar.toolbar`                            | `getButton(name)`, `clickButton(name)`, `getVisibilityToggle()`                                                                                                                                                                         |
-| `AddOptions`       | `sidebar/AddOptions.ts`       | "Add" pane (default pane on new dashboards) — via `sidebar.addOptions` | `clickNewPanelButton()`, `clickNewVariableButton()`                                                                                                                                                                                     |
-| `ContentOutline`   | `sidebar/ContentOutline.ts`   | Content outline pane — via `sidebar.contentOutline`                    | `getTree()`, `clickItem(name)`, `toggleNode(name)`                                                                                                                                                                                      |
-| `DashboardOptions` | `sidebar/DashboardOptions.ts` | Dashboard options pane — via `sidebar.dashboardOptions`                | `getTitleInput()`, `getDescriptionTextarea()`                                                                                                                                                                                           |
-| `PanelOptions`     | `sidebar/PanelOptions.ts`     | Panel options pane — via `sidebar.panelOptions`                        | `getTitleInput()`, `setTitle(title)`, `getDescriptionTextarea()`, `toggleTransparentBackground()`                                                                                                                                       |
-| `VariableOptions`  | `sidebar/VariableOptions.ts`  | Variable edit pane — via `sidebar.variableOptions`                     | `selectVariableType(type)`, `setName(name)`, `setLabel(label)`; type-specific sub-objects: `datasource.selectType(dsType)`, `datasource.setNameFilter(filter)`, `groupby.selectDatasource(ds)`, `adhoc.selectDatasource(ds)`            |
-| `Panel`            | `Panel.ts`                    | A dashboard panel in the edit canvas                                   | `getContainerByTitle()`, `getHeaderByTitle()`, `selectByTitle(title \| titles[])`, `clickMenuItem(panelTitle, menuPath[])`                                                                                                              |
+| Class              | File                          | UI Region                                                              | Key Methods / Getters                                                                                                                                                                                                                                                                                                                                                            |
+| ------------------ | ----------------------------- | ---------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `PageObject`       | `PageObject.ts`               | _(abstract base — not used directly)_                                  | Shared constructor taking a `PageObjectArgs` object (`page`, `dashboardPage`, `selectors`, `components`)                                                                                                                                                                                                                                                                         |
+| `Controls`         | `Controls.ts`                 | Top nav bar (edit, save, ...) and variable submenu                     | `enterEditMode()`, `exitEditMode()`; `variables` sub-object: `getLabel(variableLabel)`, `openDropdown(variableLabel)`, `getOption(optionLabel)`, `selectOption(variableLabel, optionLabel)`, `addFilter(variableLabel, [label, operator, value])`                                                                                                                                |
+| `Sidebar`          | `sidebar/Sidebar.ts`          | Whole sidebar region (toolbar + open pane)                             | `.toolbar`, `.addOptions`, `.dashboardOptions`, `.panelOptions`, `.variableOptions`, `.contentOutline` sub-objects; `getContainer()`, `clickGoBackButton()`, `getDockToggle()`, `clickCloseButton()`, `clickDeleteButton({ confirm? })`                                                                                                                                          |
+| `Toolbar`          | `sidebar/Toolbar.ts`          | Icon strip — accessed via `sidebar.toolbar`                            | `getButton(name)`, `clickButton(name)`, `getVisibilityToggle()`                                                                                                                                                                                                                                                                                                                  |
+| `AddOptions`       | `sidebar/AddOptions.ts`       | "Add" pane (default pane on new dashboards) — via `sidebar.addOptions` | `clickNewPanelButton()`, `clickNewVariableButton()`                                                                                                                                                                                                                                                                                                                              |
+| `ContentOutline`   | `sidebar/ContentOutline.ts`   | Content outline pane — via `sidebar.contentOutline`                    | `getTree()`, `clickItem(name)`, `toggleNode(name)`                                                                                                                                                                                                                                                                                                                               |
+| `DashboardOptions` | `sidebar/DashboardOptions.ts` | Dashboard options pane — via `sidebar.dashboardOptions`                | `getTitleInput()`, `getDescriptionTextarea()`                                                                                                                                                                                                                                                                                                                                    |
+| `PanelOptions`     | `sidebar/PanelOptions.ts`     | Panel options pane — via `sidebar.panelOptions`                        | `getTitleInput()`, `setTitle(title)`, `getDescriptionTextarea()`, `toggleTransparentBackground()`                                                                                                                                                                                                                                                                                |
+| `VariableOptions`  | `sidebar/VariableOptions.ts`  | Variable edit pane — via `sidebar.variableOptions`                     | `selectVariableType(type)`, `setName(name)`, `setLabel(label)`, `getPreviewOptions()`; type-specific sub-objects: `datasource.selectType(dsType)`, `datasource.setNameFilter(filter)`, `groupby.selectDatasource(ds)`, `adhoc.selectDatasource(ds)`, `query.openEditor()`, `query.selectDatasource(ds)`, `query.setQuery(query)`, `query.runQuery()`, `query.clickApplyButton()` |
+| `Panel`            | `Panel.ts`                    | A dashboard panel in the edit canvas                                   | `getContainerByTitle()`, `getHeaderByTitle()`, `selectByTitle(title \| titles[])`, `clickMenuItem(panelTitle, menuPath[])`                                                                                                                                                                                                                                                       |
 
 > The show/hide visibility toggle is a **Toolbar** control (`sidebar.toolbar.getVisibilityToggle()`), even though its selector lives under `components.Sidebar.*`. `Toolbar.getButton(name)` resolves buttons by accessible name, scoped to the sidebar container.
 
@@ -27,27 +27,32 @@ All page objects live in `page-objects/` and are re-exported from `page-objects/
 
 ### Base class & constructor
 
-All page objects inherit from `PageObject`, which provides the shared constructor:
+All page objects inherit from `PageObject`, which provides the shared constructor. It takes a single `PageObjectArgs` object:
 
 ```typescript
 // page-objects/PageObject.ts
+export interface PageObjectArgs {
+  page: Page;
+  dashboardPage: DashboardPage;
+  selectors: E2ESelectorGroups;
+  components: Components;
+}
+
 export abstract class PageObject {
-  constructor(
-    protected page: Page,
-    protected dashboardPage: DashboardPage,
-    protected selectors: E2ESelectorGroups
-  ) {}
+  constructor({ page, dashboardPage, selectors, components }: PageObjectArgs) {
+    // assigned to protected fields
+  }
 }
 ```
 
-Simple page objects (e.g. `Controls`, `Toolbar`) inherit the constructor directly — no override needed. Page objects that compose sub-objects (e.g. `Sidebar`) call `super(page, dashboardPage, selectors)` and initialize their children.
+Simple page objects (e.g. `Controls`, `Toolbar`) inherit the constructor directly — no override needed. Page objects that compose sub-objects (e.g. `Sidebar`) declare `constructor(args: PageObjectArgs)`, call `super(args)`, and pass the same `args` to their children.
 
-All three dependencies come from the Playwright test arguments:
+All four dependencies come from the Playwright test arguments:
 
 ```typescript
-test('example', async ({ gotoDashboardPage, selectors, page }) => {
+test('example', async ({ gotoDashboardPage, selectors, page, components }) => {
   const dashboardPage = await gotoDashboardPage({ uid: 'some-uid' });
-  const controls = new Controls(page, dashboardPage, selectors);
+  const controls = new Controls({ page, dashboardPage, selectors, components });
   // ...
 });
 ```
@@ -69,11 +74,11 @@ test.describe(
     tag: ['@dashboards'],
   },
   () => {
-    test('describes the user-visible behavior', async ({ gotoDashboardPage, selectors, page }) => {
+    test('describes the user-visible behavior', async ({ gotoDashboardPage, selectors, page, components }) => {
       const dashboardPage = await gotoDashboardPage({ uid: 'dashboard-uid' });
 
-      const controls = new Controls(page, dashboardPage, selectors);
-      const sidebar = new Sidebar(page, dashboardPage, selectors);
+      const controls = new Controls({ page, dashboardPage, selectors, components });
+      const sidebar = new Sidebar({ page, dashboardPage, selectors, components });
 
       await controls.enterEditMode();
       // ... test body using page objects (the toolbar is reached via sidebar.toolbar)
@@ -131,7 +136,7 @@ await expect(titleInput).toHaveValue(newTitle);
 
 ## Migration Status
 
-**13 of 30 specs migrated.** Non-migrated specs are listed by descending selectors usage count (a rough proxy for migration effort). "Selectors usage count" is the number of times the spec accesses the `selectors` object (`selectors.components...`, `selectors.pages...`, etc.).
+**14 of 30 specs migrated.** Non-migrated specs are listed by descending selectors usage count (a rough proxy for migration effort). "Selectors usage count" is the number of times the spec accesses the `selectors` object (`selectors.components...`, `selectors.pages...`, etc.).
 
 | Spec                                                  | Status      | Lines of code | Selectors usage count |
 | ----------------------------------------------------- | ----------- | ------------- | --------------------- |
@@ -158,7 +163,7 @@ await expect(titleInput).toHaveValue(newTitle);
 | `dashboards-repeats-snapshots.spec.ts`                | Not started | 117           | 11                    |
 | `dashboards-move-panel.spec.ts`                       | Not started | 120           | 9                     |
 | `dashboard-conditional-rendering-load-change.spec.ts` | Not started | 459           | 8                     |
-| `dashboards-edit-query-variables.spec.ts`             | Not started | 83            | 6                     |
+| `dashboards-edit-query-variables.spec.ts`             | Migrated    | —             | —                     |
 | `dashboard-keybindings.spec.ts`                       | Migrated    | —             | —                     |
 | `dashboards-edit-adhoc-variables.spec.ts`             | Migrated    | —             | —                     |
 | `dashboards-edit-group-by-variables.spec.ts`          | Migrated    | —             | —                     |

--- a/e2e-playwright/dashboard-new-layouts/dashboard-duplicate-panel.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboard-duplicate-panel.spec.ts
@@ -17,12 +17,12 @@ test.describe(
     tag: ['@dashboards'],
   },
   () => {
-    test('can duplicate a panel', async ({ dashboardPage, selectors, page }) => {
+    test('can duplicate a panel', async ({ dashboardPage, selectors, page, components }) => {
       await importTestDashboard(page, selectors, 'Paste tab');
 
-      const controls = new Controls(page, dashboardPage, selectors);
-      const panel = new Panel(page, dashboardPage, selectors);
-      const sidebar = new Sidebar(page, dashboardPage, selectors);
+      const controls = new Controls({ page, dashboardPage, selectors, components });
+      const panel = new Panel({ page, dashboardPage, selectors, components });
+      const sidebar = new Sidebar({ page, dashboardPage, selectors, components });
 
       await controls.enterEditMode();
 

--- a/e2e-playwright/dashboard-new-layouts/dashboard-hide-sidebar.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboard-hide-sidebar.spec.ts
@@ -17,18 +17,28 @@ test.describe(
     tag: ['@dashboards'],
   },
   () => {
-    test('hide button is available in view mode on desktop', async ({ gotoDashboardPage, selectors, page }) => {
+    test('hide button is available in view mode on desktop', async ({
+      gotoDashboardPage,
+      selectors,
+      page,
+      components,
+    }) => {
       const dashboardPage = await gotoDashboardPage({ uid: PAGE_UNDER_TEST });
-      const sidebar = new Sidebar(page, dashboardPage, selectors);
+      const sidebar = new Sidebar({ page, dashboardPage, selectors, components });
 
       await expect(sidebar.getContainer()).toBeVisible();
       await expect(sidebar.toolbar.getVisibilityToggle()).toBeVisible();
     });
 
-    test('hide button is available in edit mode on desktop', async ({ gotoDashboardPage, selectors, page }) => {
+    test('hide button is available in edit mode on desktop', async ({
+      gotoDashboardPage,
+      selectors,
+      page,
+      components,
+    }) => {
       const dashboardPage = await gotoDashboardPage({ uid: PAGE_UNDER_TEST });
-      const controls = new Controls(page, dashboardPage, selectors);
-      const sidebar = new Sidebar(page, dashboardPage, selectors);
+      const controls = new Controls({ page, dashboardPage, selectors, components });
+      const sidebar = new Sidebar({ page, dashboardPage, selectors, components });
 
       await controls.enterEditMode();
 
@@ -40,9 +50,10 @@ test.describe(
       gotoDashboardPage,
       selectors,
       page,
+      components,
     }) => {
       const dashboardPage = await gotoDashboardPage({ uid: PAGE_UNDER_TEST });
-      const sidebar = new Sidebar(page, dashboardPage, selectors);
+      const sidebar = new Sidebar({ page, dashboardPage, selectors, components });
 
       await sidebar.toolbar.getVisibilityToggle().click();
 
@@ -51,9 +62,14 @@ test.describe(
       await expect(sidebar.toolbar.getVisibilityToggle()).toBeVisible();
     });
 
-    test('clicking show re-displays the sidebar after hiding it', async ({ gotoDashboardPage, selectors, page }) => {
+    test('clicking show re-displays the sidebar after hiding it', async ({
+      gotoDashboardPage,
+      selectors,
+      page,
+      components,
+    }) => {
       const dashboardPage = await gotoDashboardPage({ uid: PAGE_UNDER_TEST });
-      const sidebar = new Sidebar(page, dashboardPage, selectors);
+      const sidebar = new Sidebar({ page, dashboardPage, selectors, components });
 
       await sidebar.toolbar.getVisibilityToggle().click();
       await expect(sidebar.getContainer()).not.toBeVisible();
@@ -62,10 +78,15 @@ test.describe(
       await expect(sidebar.getContainer()).toBeVisible();
     });
 
-    test('hidden state is shared between view mode and edit mode', async ({ gotoDashboardPage, selectors, page }) => {
+    test('hidden state is shared between view mode and edit mode', async ({
+      gotoDashboardPage,
+      selectors,
+      page,
+      components,
+    }) => {
       const dashboardPage = await gotoDashboardPage({ uid: PAGE_UNDER_TEST });
-      const controls = new Controls(page, dashboardPage, selectors);
-      const sidebar = new Sidebar(page, dashboardPage, selectors);
+      const controls = new Controls({ page, dashboardPage, selectors, components });
+      const sidebar = new Sidebar({ page, dashboardPage, selectors, components });
 
       // Hide in view mode
       await sidebar.toolbar.getVisibilityToggle().click();
@@ -81,11 +102,12 @@ test.describe(
       gotoDashboardPage,
       selectors,
       page,
+      components,
     }) => {
       const dashboardPage = await gotoDashboardPage({ uid: PAGE_UNDER_TEST });
-      const controls = new Controls(page, dashboardPage, selectors);
-      const sidebar = new Sidebar(page, dashboardPage, selectors);
-      const panel = new Panel(page, dashboardPage, selectors);
+      const controls = new Controls({ page, dashboardPage, selectors, components });
+      const sidebar = new Sidebar({ page, dashboardPage, selectors, components });
+      const panel = new Panel({ page, dashboardPage, selectors, components });
 
       // Enter edit mode
       await controls.enterEditMode();

--- a/e2e-playwright/dashboard-new-layouts/dashboard-keybindings.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboard-keybindings.spec.ts
@@ -13,9 +13,9 @@ test.describe('Dashboard keybindings with new layouts', { tag: ['@dashboards'] }
     viewport: { width: 1280, height: 1080 },
   });
 
-  test('should collapse and expand all rows', async ({ gotoDashboardPage, page, selectors }) => {
+  test('should collapse and expand all rows', async ({ gotoDashboardPage, page, selectors, components }) => {
     const dashboardPage = await gotoDashboardPage({ uid: 'Repeating-rows-uid/repeating-rows' });
-    const panel = new Panel(page, dashboardPage, selectors);
+    const panel = new Panel({ page, dashboardPage, selectors, components });
 
     const panelContents = dashboardPage.getByGrafanaSelector(selectors.components.Panels.Panel.content);
     await expect(panelContents).toHaveCount(5);
@@ -39,9 +39,9 @@ test.describe('Dashboard keybindings with new layouts', { tag: ['@dashboards'] }
     await expect(page.getByText('server = B, pod = Bob')).toBeVisible();
   });
 
-  test('should open panel inspect', async ({ gotoDashboardPage, page, selectors }) => {
+  test('should open panel inspect', async ({ gotoDashboardPage, page, selectors, components }) => {
     const dashboardPage = await gotoDashboardPage({ uid: 'edediimbjhdz4b/a-tall-dashboard' });
-    const panel = new Panel(page, dashboardPage, selectors);
+    const panel = new Panel({ page, dashboardPage, selectors, components });
 
     const panel1 = panel.getContainerByTitle('Panel #1');
     await expect(panel1).toBeVisible();

--- a/e2e-playwright/dashboard-new-layouts/dashboard-mobile-sidebar.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboard-mobile-sidebar.spec.ts
@@ -16,9 +16,10 @@ test.describe('Mobile sidebar', { tag: ['@dashboards'] }, () => {
     gotoDashboardPage,
     selectors,
     page,
+    components,
   }) => {
     const dashboardPage = await gotoDashboardPage({ uid: PAGE_UNDER_TEST });
-    const sidebar = new Sidebar(page, dashboardPage, selectors);
+    const sidebar = new Sidebar({ page, dashboardPage, selectors, components });
 
     await expect(sidebar.getContainer()).not.toBeVisible();
     await expect(sidebar.toolbar.getVisibilityToggle()).toBeVisible();

--- a/e2e-playwright/dashboard-new-layouts/dashboard-outline.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboard-outline.spec.ts
@@ -18,11 +18,11 @@ test.describe(
     tag: ['@dashboards'],
   },
   () => {
-    test('can use dashboard outline', async ({ gotoDashboardPage, selectors, page }) => {
+    test('can use dashboard outline', async ({ gotoDashboardPage, selectors, page, components }) => {
       const dashboardPage = await gotoDashboardPage({ uid: PAGE_UNDER_TEST });
 
-      const controls = new Controls(page, dashboardPage, selectors);
-      const sidebar = new Sidebar(page, dashboardPage, selectors);
+      const controls = new Controls({ page, dashboardPage, selectors, components });
+      const sidebar = new Sidebar({ page, dashboardPage, selectors, components });
 
       await controls.enterEditMode();
       await sidebar.toolbar.clickButton('Outline');
@@ -46,11 +46,12 @@ test.describe(
       gotoDashboardPage,
       selectors,
       page,
+      components,
     }) => {
       const dashboardPage = await gotoDashboardPage({ uid: PAGE_UNDER_TEST });
 
-      const controls = new Controls(page, dashboardPage, selectors);
-      const sidebar = new Sidebar(page, dashboardPage, selectors);
+      const controls = new Controls({ page, dashboardPage, selectors, components });
+      const sidebar = new Sidebar({ page, dashboardPage, selectors, components });
 
       await controls.enterEditMode();
       await sidebar.toolbar.clickButton('Outline');
@@ -74,11 +75,12 @@ test.describe(
       gotoDashboardPage,
       selectors,
       page,
+      components,
     }) => {
       const dashboardPage = await gotoDashboardPage({ uid: PAGE_UNDER_TEST });
 
-      const controls = new Controls(page, dashboardPage, selectors);
-      const sidebar = new Sidebar(page, dashboardPage, selectors);
+      const controls = new Controls({ page, dashboardPage, selectors, components });
+      const sidebar = new Sidebar({ page, dashboardPage, selectors, components });
 
       await controls.enterEditMode();
       await sidebar.toolbar.clickButton('Outline');

--- a/e2e-playwright/dashboard-new-layouts/dashboard-sidepane.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboard-sidepane.spec.ts
@@ -21,11 +21,11 @@ test.describe(
     tag: ['@dashboards'],
   },
   () => {
-    test('Can go back to previous selection or pane', async ({ gotoDashboardPage, selectors, page }) => {
+    test('Can go back to previous selection or pane', async ({ gotoDashboardPage, selectors, page, components }) => {
       const dashboardPage = await gotoDashboardPage({});
 
-      const sidebar = new Sidebar(page, dashboardPage, selectors);
-      const panel = new Panel(page, dashboardPage, selectors);
+      const sidebar = new Sidebar({ page, dashboardPage, selectors, components });
+      const panel = new Panel({ page, dashboardPage, selectors, components });
 
       await sidebar.addOptions.clickNewPanelButton();
       await sidebar.panelOptions.setTitle('Panel 1');

--- a/e2e-playwright/dashboard-new-layouts/dashboards-edit-adhoc-variables.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboards-edit-adhoc-variables.spec.ts
@@ -21,12 +21,12 @@ test.describe(
     tag: ['@dashboards'],
   },
   () => {
-    test('can add a new adhoc variable', async ({ gotoDashboardPage, selectors, page }) => {
+    test('can add a new adhoc variable', async ({ gotoDashboardPage, selectors, page, components }) => {
       const dashboardPage = await gotoDashboardPage({ uid: PAGE_UNDER_TEST });
       await expect(page.getByText(DASHBOARD_NAME)).toBeVisible();
 
-      const controls = new Controls(page, dashboardPage, selectors);
-      const sidebar = new Sidebar(page, dashboardPage, selectors);
+      const controls = new Controls({ page, dashboardPage, selectors, components });
+      const sidebar = new Sidebar({ page, dashboardPage, selectors, components });
 
       const variable: Variable = {
         type: 'adhoc',

--- a/e2e-playwright/dashboard-new-layouts/dashboards-edit-datasource-variables.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboards-edit-datasource-variables.spec.ts
@@ -20,12 +20,12 @@ test.describe(
     tag: ['@dashboards'],
   },
   () => {
-    test('can add a new datasource variable', async ({ gotoDashboardPage, selectors, page }) => {
+    test('can add a new datasource variable', async ({ gotoDashboardPage, selectors, page, components }) => {
       const dashboardPage = await gotoDashboardPage({ uid: PAGE_UNDER_TEST });
       await expect(page.getByText(DASHBOARD_NAME)).toBeVisible();
 
-      const controls = new Controls(page, dashboardPage, selectors);
-      const sidebar = new Sidebar(page, dashboardPage, selectors);
+      const controls = new Controls({ page, dashboardPage, selectors, components });
+      const sidebar = new Sidebar({ page, dashboardPage, selectors, components });
 
       const variable: Variable = {
         type: 'datasource',

--- a/e2e-playwright/dashboard-new-layouts/dashboards-edit-group-by-variables.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboards-edit-group-by-variables.spec.ts
@@ -20,12 +20,12 @@ test.describe(
     tag: ['@dashboards'],
   },
   () => {
-    test('can add a new group by variable', async ({ gotoDashboardPage, selectors, page }) => {
+    test('can add a new group by variable', async ({ gotoDashboardPage, selectors, page, components }) => {
       const dashboardPage = await gotoDashboardPage({ uid: PAGE_UNDER_TEST });
       await expect(page.getByText(DASHBOARD_NAME)).toBeVisible();
 
-      const controls = new Controls(page, dashboardPage, selectors);
-      const sidebar = new Sidebar(page, dashboardPage, selectors);
+      const controls = new Controls({ page, dashboardPage, selectors, components });
+      const sidebar = new Sidebar({ page, dashboardPage, selectors, components });
 
       const variable: Variable = {
         type: 'groupby',

--- a/e2e-playwright/dashboard-new-layouts/dashboards-edit-panel-title-description.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboards-edit-panel-title-description.spec.ts
@@ -18,12 +18,12 @@ test.describe(
     tag: ['@dashboards'],
   },
   () => {
-    test('can edit panel title and description', async ({ gotoDashboardPage, selectors, page }) => {
+    test('can edit panel title and description', async ({ gotoDashboardPage, selectors, page, components }) => {
       const dashboardPage = await gotoDashboardPage({ uid: PAGE_UNDER_TEST });
 
-      const controls = new Controls(page, dashboardPage, selectors);
-      const panel = new Panel(page, dashboardPage, selectors);
-      const sidebar = new Sidebar(page, dashboardPage, selectors);
+      const controls = new Controls({ page, dashboardPage, selectors, components });
+      const panel = new Panel({ page, dashboardPage, selectors, components });
+      const sidebar = new Sidebar({ page, dashboardPage, selectors, components });
 
       await controls.enterEditMode();
 

--- a/e2e-playwright/dashboard-new-layouts/dashboards-edit-panel-transparent-bg.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboards-edit-panel-transparent-bg.spec.ts
@@ -16,12 +16,12 @@ test.describe(
     tag: ['@dashboards'],
   },
   () => {
-    test('can toggle transparent background switch', async ({ gotoDashboardPage, selectors, page }) => {
+    test('can toggle transparent background switch', async ({ gotoDashboardPage, selectors, page, components }) => {
       const dashboardPage = await gotoDashboardPage({ uid: '5SdHCadmz/panel-tests-graph' });
 
-      const controls = new Controls(page, dashboardPage, selectors);
-      const panel = new Panel(page, dashboardPage, selectors);
-      const sidebar = new Sidebar(page, dashboardPage, selectors);
+      const controls = new Controls({ page, dashboardPage, selectors, components });
+      const panel = new Panel({ page, dashboardPage, selectors, components });
+      const sidebar = new Sidebar({ page, dashboardPage, selectors, components });
 
       await controls.enterEditMode();
 

--- a/e2e-playwright/dashboard-new-layouts/dashboards-edit-query-variables.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboards-edit-query-variables.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@grafana/plugin-e2e';
 
+import { Controls, Sidebar } from './page-objects';
 import { flows, type Variable } from './utils';
 
 test.use({
@@ -28,6 +29,9 @@ test.describe(
       const dashboardPage = await gotoDashboardPage({ uid: PAGE_UNDER_TEST });
       await expect(page.getByText(DASHBOARD_NAME)).toBeVisible();
 
+      const controls = new Controls({ page, dashboardPage, selectors, components });
+      const sidebar = new Sidebar({ page, dashboardPage, selectors, components });
+
       const variable: Variable = {
         type: 'query',
         name: 'VariableUnderTest',
@@ -35,82 +39,56 @@ test.describe(
         label: 'VariableUnderTest',
       };
 
-      // 1. add a new query variable named 'VariableUnderTest'
       await flows.addNewGenericVariable(page, dashboardPage, selectors, variable);
 
-      // 2. Open the variable editor
-      await dashboardPage
-        .getByGrafanaSelector(selectors.pages.Dashboard.Settings.Variables.Edit.QueryVariable.queryOptionsOpenButton)
-        .click();
+      await sidebar.variableOptions.query.openEditor();
 
-      // 3. Select the 'gdev-testdata' data source, type a query, and click "Preview"
-      await components.dataSourcePicker.set('gdev-testdata');
-      const queryInput = dashboardPage.getByGrafanaSelector(
-        selectors.pages.Dashboard.Settings.Variables.Edit.QueryVariable.queryOptionsQueryInput
-      );
-      await queryInput.fill('*');
-      await dashboardPage
-        .getByGrafanaSelector(selectors.pages.Dashboard.Settings.Variables.Edit.QueryVariable.previewButton)
-        .click();
+      // Select the 'gdev-testdata' data source, type a query, and run it
+      await sidebar.variableOptions.query.selectDatasource('gdev-testdata');
+      await sidebar.variableOptions.query.setQuery('*');
+      await sidebar.variableOptions.query.runQuery();
 
-      // 4. Assert that at least 1 option is visible
-      const previewOptions = dashboardPage.getByGrafanaSelector(
-        selectors.pages.Dashboard.Settings.Variables.Edit.General.previewOfValuesOption
-      );
+      // Assert that at least 1 option is visible
+      const previewOptions = sidebar.variableOptions.getPreviewOptions();
       await expect(previewOptions.first()).toBeVisible({ timeout: 15_000 });
 
-      // 5. Click on the "Static options (0)" tab header
+      // Go to the "Static options" tab
       await dashboardPage.getByGrafanaSelector(selectors.components.Tab.title('Static options (0)')).click();
 
-      // 6. Click on the "+ Add new option" button
+      // Click on the "+ Add new option" button
       await dashboardPage
         .getByGrafanaSelector(selectors.pages.Dashboard.Settings.Variables.Edit.StaticOptionsEditor.addButton)
         .click();
 
-      // 7. Type "custom-value-1" then press the tab key then type "Custom value one"
+      // Add two static options and run the query again
       await page.keyboard.type('custom-value-1');
       await page.keyboard.press('Tab');
       await page.keyboard.type('Custom value one');
 
-      // 8. Press the Enter key
       await page.keyboard.press('Enter');
 
-      // 9. Type "custom-value-2" then press the tab key then type "Custom value two"
       await page.keyboard.type('custom-value-2');
       await page.keyboard.press('Tab');
       await page.keyboard.type('Custom value two');
 
-      // 10, Click the "Refresh preview" button
-      await dashboardPage
-        .getByGrafanaSelector(selectors.pages.Dashboard.Settings.Variables.Edit.QueryVariable.previewButton)
-        .click();
+      await sidebar.variableOptions.query.runQuery();
 
-      // 11. Assert that both options have been added
+      // Assert that both options have been added
       await expect(previewOptions.first()).toHaveText('Custom value one');
       await expect(previewOptions.nth(1)).toHaveText('Custom value two');
 
-      // 12. Press the "Apply" button
-      await dashboardPage
-        .getByGrafanaSelector(selectors.pages.Dashboard.Settings.Variables.Edit.QueryVariable.applyButton)
-        .click();
+      // Click the "Apply" button
+      await sidebar.variableOptions.query.clickApplyButton();
 
-      // 13. Open the variable dropdown and verify options
-      const variableLabel = dashboardPage.getByGrafanaSelector(
-        selectors.pages.Dashboard.SubMenu.submenuItemLabels(variable.label!)
-      );
-      const variableDropdown = variableLabel.locator('+ *');
-      await variableDropdown.click();
-      await expect(
-        dashboardPage.getByGrafanaSelector(selectors.components.Select.option).filter({ hasText: 'Custom value one' })
-      ).toBeVisible();
-      await expect(
-        dashboardPage.getByGrafanaSelector(selectors.components.Select.option).filter({ hasText: 'Custom value two' })
-      ).toBeVisible();
+      // Verify that the variable has the static options
+      await controls.variables.openDropdown(variable.label!);
+      await expect(controls.variables.getOption('Custom value one')).toBeVisible();
+      await expect(controls.variables.getOption('Custom value two')).toBeVisible();
 
-      // 14. Close the variable dropdown
+      // Close the variable dropdown
       await page.keyboard.press('Escape');
 
-      // 15. Assert that the markdown panels contain the correct variable values
+      // Assert that the markdown panels contain the correct variable values
       const panelContent = dashboardPage.getByGrafanaSelector(selectors.components.Panels.Panel.content).first();
       await expect(panelContent).toBeVisible();
       const markdownContent = panelContent.locator('.markdown-html');

--- a/e2e-playwright/dashboard-new-layouts/dashboards-remove-panel.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboards-remove-panel.spec.ts
@@ -22,11 +22,11 @@ test.describe(
     tag: ['@dashboards'],
   },
   () => {
-    test('can remove a panel', async ({ gotoDashboardPage, selectors, page }) => {
+    test('can remove a panel', async ({ gotoDashboardPage, selectors, page, components }) => {
       const dashboardPage = await gotoDashboardPage({ uid: PAGE_UNDER_TEST });
-      const controls = new Controls(page, dashboardPage, selectors);
-      const panel = new Panel(page, dashboardPage, selectors);
-      const sidebar = new Sidebar(page, dashboardPage, selectors);
+      const controls = new Controls({ page, dashboardPage, selectors, components });
+      const panel = new Panel({ page, dashboardPage, selectors, components });
+      const sidebar = new Sidebar({ page, dashboardPage, selectors, components });
 
       await controls.enterEditMode();
 
@@ -41,11 +41,11 @@ test.describe(
       await expect(panel.getHeaderByTitle(panelTitle)).toBeHidden();
     });
 
-    test('can remove several panels at once', async ({ gotoDashboardPage, selectors, page }) => {
+    test('can remove several panels at once', async ({ gotoDashboardPage, selectors, page, components }) => {
       const dashboardPage = await gotoDashboardPage({ uid: PAGE_UNDER_TEST });
-      const controls = new Controls(page, dashboardPage, selectors);
-      const panel = new Panel(page, dashboardPage, selectors);
-      const sidebar = new Sidebar(page, dashboardPage, selectors);
+      const controls = new Controls({ page, dashboardPage, selectors, components });
+      const panel = new Panel({ page, dashboardPage, selectors, components });
+      const sidebar = new Sidebar({ page, dashboardPage, selectors, components });
 
       await controls.enterEditMode();
 

--- a/e2e-playwright/dashboard-new-layouts/dashboards-title-description.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboards-title-description.spec.ts
@@ -16,11 +16,11 @@ test.describe(
     tag: ['@dashboards'],
   },
   () => {
-    test('can change dashboard description and title', async ({ gotoDashboardPage, selectors, page }) => {
+    test('can change dashboard description and title', async ({ gotoDashboardPage, selectors, page, components }) => {
       const dashboardPage = await gotoDashboardPage({ uid: 'ed155665/annotation-filtering' });
 
-      const controls = new Controls(page, dashboardPage, selectors);
-      const sidebar = new Sidebar(page, dashboardPage, selectors);
+      const controls = new Controls({ page, dashboardPage, selectors, components });
+      const sidebar = new Sidebar({ page, dashboardPage, selectors, components });
 
       await controls.enterEditMode();
       await sidebar.toolbar.clickButton('Options');

--- a/e2e-playwright/dashboard-new-layouts/page-objects/Controls.ts
+++ b/e2e-playwright/dashboard-new-layouts/page-objects/Controls.ts
@@ -27,17 +27,22 @@ export class Controls extends PageObject {
         this.selectors.pages.Dashboard.SubMenu.submenuItemLabels(variableLabel)
       );
     },
-    selectOption: async (variableLabel: string, optionLabel: string) => {
-      await test.step(`Select option "${optionLabel}" of variable "${variableLabel}"`, async () => {
+    openDropdown: async (variableLabel: string) => {
+      await test.step(`Open dropdown of variable "${variableLabel}"`, async () => {
         // The variable value control is the next sibling of its label
         await this.variables.getLabel(variableLabel).locator('+ *').click();
-        await this.page.getByRole('option', { name: optionLabel, exact: true }).click();
+      });
+    },
+    getOption: (optionLabel: string): Locator => this.page.getByRole('option', { name: optionLabel, exact: true }),
+    selectOption: async (variableLabel: string, optionLabel: string) => {
+      await test.step(`Select option "${optionLabel}" of variable "${variableLabel}"`, async () => {
+        await this.variables.openDropdown(variableLabel);
+        await this.variables.getOption(optionLabel).click();
       });
     },
     addFilter: async (variableLabel: string, filter: [string, string, string]) => {
       await test.step(`Add filter "${filter[0]}${filter[1]}\"${filter[2]}\"" to variable "${variableLabel}"`, async () => {
-        // The variable value control is the next sibling of its label
-        await this.variables.getLabel(variableLabel).locator('+ *').click();
+        await this.variables.openDropdown(variableLabel);
 
         await this.page.getByRole('option', { name: filter[0], exact: true }).click();
         await this.page.getByRole('option', { name: new RegExp(`^${filter[1]} `) }).click();

--- a/e2e-playwright/dashboard-new-layouts/page-objects/PageObject.ts
+++ b/e2e-playwright/dashboard-new-layouts/page-objects/PageObject.ts
@@ -1,11 +1,24 @@
 import { type Page } from '@playwright/test';
 
-import { type DashboardPage, type E2ESelectorGroups } from '@grafana/plugin-e2e';
+import { type Components, type DashboardPage, type E2ESelectorGroups } from '@grafana/plugin-e2e';
+
+export interface PageObjectArgs {
+  page: Page;
+  dashboardPage: DashboardPage;
+  selectors: E2ESelectorGroups;
+  components: Components;
+}
 
 export abstract class PageObject {
-  constructor(
-    protected page: Page,
-    protected dashboardPage: DashboardPage,
-    protected selectors: E2ESelectorGroups
-  ) {}
+  protected page: Page;
+  protected dashboardPage: DashboardPage;
+  protected selectors: E2ESelectorGroups;
+  protected components: Components;
+
+  constructor({ page, dashboardPage, selectors, components }: PageObjectArgs) {
+    this.page = page;
+    this.dashboardPage = dashboardPage;
+    this.selectors = selectors;
+    this.components = components;
+  }
 }

--- a/e2e-playwright/dashboard-new-layouts/page-objects/sidebar/Sidebar.ts
+++ b/e2e-playwright/dashboard-new-layouts/page-objects/sidebar/Sidebar.ts
@@ -1,8 +1,6 @@
-import { test, type Page } from '@playwright/test';
+import { test } from '@playwright/test';
 
-import { type DashboardPage, type E2ESelectorGroups } from '@grafana/plugin-e2e';
-
-import { PageObject } from '../PageObject';
+import { PageObject, type PageObjectArgs } from '../PageObject';
 
 import { AddOptions } from './AddOptions';
 import { ContentOutline } from './ContentOutline';
@@ -21,14 +19,14 @@ export class Sidebar extends PageObject {
   public variableOptions: VariableOptions;
   public panelOptions: PanelOptions;
 
-  constructor(page: Page, dashboardPage: DashboardPage, selectors: E2ESelectorGroups) {
-    super(page, dashboardPage, selectors);
-    this.toolbar = new Toolbar(page, dashboardPage, selectors);
-    this.contentOutline = new ContentOutline(page, dashboardPage, selectors);
-    this.addOptions = new AddOptions(page, dashboardPage, selectors);
-    this.dashboardOptions = new DashboardOptions(page, dashboardPage, selectors);
-    this.variableOptions = new VariableOptions(page, dashboardPage, selectors);
-    this.panelOptions = new PanelOptions(page, dashboardPage, selectors);
+  constructor(args: PageObjectArgs) {
+    super(args);
+    this.toolbar = new Toolbar(args);
+    this.contentOutline = new ContentOutline(args);
+    this.addOptions = new AddOptions(args);
+    this.dashboardOptions = new DashboardOptions(args);
+    this.variableOptions = new VariableOptions(args);
+    this.panelOptions = new PanelOptions(args);
   }
 
   getContainer() {

--- a/e2e-playwright/dashboard-new-layouts/page-objects/sidebar/VariableOptions.ts
+++ b/e2e-playwright/dashboard-new-layouts/page-objects/sidebar/VariableOptions.ts
@@ -1,4 +1,4 @@
-import { test } from '@playwright/test';
+import { test, type Locator } from '@playwright/test';
 
 import { PageObject } from '../PageObject';
 
@@ -33,6 +33,12 @@ export class VariableOptions extends PageObject {
       await input.fill(label);
       await input.blur();
     });
+  }
+
+  getPreviewOptions(): Locator {
+    return this.dashboardPage.getByGrafanaSelector(
+      this.selectors.pages.Dashboard.Settings.Variables.Edit.General.previewOfValuesOption
+    );
   }
 
   readonly datasource = {
@@ -83,6 +89,46 @@ export class VariableOptions extends PageObject {
         await this.page
           .getByRole('alert', { name: /this data source does not support filters/ })
           .waitFor({ state: 'detached' });
+      });
+    },
+  };
+
+  readonly query = {
+    openEditor: async () => {
+      await test.step('Open query variable editor', async () => {
+        await this.dashboardPage
+          .getByGrafanaSelector(
+            this.selectors.pages.Dashboard.Settings.Variables.Edit.QueryVariable.queryOptionsOpenButton
+          )
+          .click();
+      });
+    },
+    selectDatasource: async (dataSource: string) => {
+      await test.step(`Select query datasource "${dataSource}"`, async () => {
+        await this.components.dataSourcePicker.set(dataSource);
+      });
+    },
+    setQuery: async (query: string) => {
+      await test.step(`Set variable query to "${query}"`, async () => {
+        await this.dashboardPage
+          .getByGrafanaSelector(
+            this.selectors.pages.Dashboard.Settings.Variables.Edit.QueryVariable.queryOptionsQueryInput
+          )
+          .fill(query);
+      });
+    },
+    runQuery: async () => {
+      await test.step('Run query', async () => {
+        await this.dashboardPage
+          .getByGrafanaSelector(this.selectors.pages.Dashboard.Settings.Variables.Edit.QueryVariable.previewButton)
+          .click();
+      });
+    },
+    clickApplyButton: async () => {
+      await test.step('Apply variable changes', async () => {
+        await this.dashboardPage
+          .getByGrafanaSelector(this.selectors.pages.Dashboard.Settings.Variables.Edit.QueryVariable.applyButton)
+          .click();
       });
     },
   };

--- a/e2e-playwright/dashboard-new-layouts/utils.ts
+++ b/e2e-playwright/dashboard-new-layouts/utils.ts
@@ -1,7 +1,7 @@
 import { type Page } from '@playwright/test';
 
 import { selectors } from '@grafana/e2e-selectors';
-import { type DashboardPage, type E2ESelectorGroups, expect } from '@grafana/plugin-e2e';
+import { Components, type DashboardPage, type E2ESelectorGroups, expect } from '@grafana/plugin-e2e';
 
 import testV2Dashboard from '../dashboards/TestV2Dashboard.json';
 
@@ -14,8 +14,11 @@ export const flows = {
     selectors: E2ESelectorGroups,
     variable: Variable
   ) {
-    const controls = new Controls(page, dashboardPage, selectors);
-    const sidebar = new Sidebar(page, dashboardPage, selectors);
+    // Keep the flows signature unchanged for unmigrated callers: build the
+    // `components` fixture equivalent from the page context
+    const components = new Components(dashboardPage.ctx);
+    const controls = new Controls({ page, dashboardPage, selectors, components });
+    const sidebar = new Sidebar({ page, dashboardPage, selectors, components });
 
     await controls.enterEditMode();
 

--- a/e2e-playwright/dashboards-suite/dashboard-restore-v1.spec.ts
+++ b/e2e-playwright/dashboards-suite/dashboard-restore-v1.spec.ts
@@ -1,6 +1,6 @@
 import { type Page } from 'playwright-core';
 
-import { test, expect, type DashboardPage, type E2ESelectorGroups } from '@grafana/plugin-e2e';
+import { test, expect, type DashboardPage, type E2ESelectorGroups, type Components } from '@grafana/plugin-e2e';
 
 import { Sidebar } from '../dashboard-new-layouts/page-objects';
 
@@ -8,8 +8,13 @@ import { makeNewDashboardRequestBody } from './utils/makeDashboard';
 
 // New-layouts has no settings toolbar button; settings open from the dashboard edit-pane
 // "Dashboard options" sidebar button, then the "View all settings" button it reveals.
-async function openDashboardSettings(page: Page, dashboardPage: DashboardPage, selectors: E2ESelectorGroups) {
-  const sidebar = new Sidebar(page, dashboardPage, selectors);
+async function openDashboardSettings(
+  page: Page,
+  dashboardPage: DashboardPage,
+  selectors: E2ESelectorGroups,
+  components: Components
+) {
+  const sidebar = new Sidebar({ page, dashboardPage, selectors, components });
   const editButton = dashboardPage.getByGrafanaSelector(selectors.components.NavToolbar.editDashboard.editButton);
   const optionsButton = sidebar.toolbar.getButton('Options');
   // The first edit-button click can be swallowed before the scene is interactive; re-click only
@@ -143,11 +148,12 @@ test.describe(
         gotoDashboardPage,
         page,
         selectors,
+        components,
       }) => {
         const dashboardPage = await gotoDashboardPage({ uid: dashboardUID });
 
         // Enter edit mode then open settings (new-layouts flow)
-        await openDashboardSettings(page, dashboardPage, selectors);
+        await openDashboardSettings(page, dashboardPage, selectors, components);
 
         // Click delete dashboard button (settings-view element — use the grafana selector helper,
         // not getByTestId, which mis-resolves data-testid-prefixed selector values)

--- a/e2e-playwright/dashboards-suite/dashboard-time-zone.spec.ts
+++ b/e2e-playwright/dashboards-suite/dashboard-time-zone.spec.ts
@@ -3,7 +3,7 @@ import { parseISO } from 'date-fns/parseISO';
 import { toDate } from 'date-fns/toDate';
 import { type Page } from 'playwright-core';
 
-import { test, expect, type DashboardPage, type E2ESelectorGroups } from '@grafana/plugin-e2e';
+import { test, expect, type DashboardPage, type E2ESelectorGroups, type Components } from '@grafana/plugin-e2e';
 
 import { Sidebar } from '../dashboard-new-layouts/page-objects';
 
@@ -17,8 +17,13 @@ test.use({
 
 // New-layouts has no settings toolbar button; settings open from the dashboard edit-pane
 // "Dashboard options" sidebar button, then the "View all settings" button it reveals.
-async function openDashboardSettings(page: Page, dashboardPage: DashboardPage, selectors: E2ESelectorGroups) {
-  const sidebar = new Sidebar(page, dashboardPage, selectors);
+async function openDashboardSettings(
+  page: Page,
+  dashboardPage: DashboardPage,
+  selectors: E2ESelectorGroups,
+  components: Components
+) {
+  const sidebar = new Sidebar({ page, dashboardPage, selectors, components });
   const editButton = dashboardPage.getByGrafanaSelector(selectors.components.NavToolbar.editDashboard.editButton);
   const optionsButton = sidebar.toolbar.getButton('Options');
   // The first edit-button click can be swallowed before the scene is interactive, leaving the
@@ -47,7 +52,7 @@ test.describe(
     tag: ['@dashboards'],
   },
   () => {
-    test('Tests dashboard time zone scenarios', async ({ page, gotoDashboardPage, selectors }) => {
+    test('Tests dashboard time zone scenarios', async ({ page, gotoDashboardPage, selectors, components }) => {
       // Opening settings twice via the new-layouts edit-pane flow takes longer than the default budget.
       test.slow();
       const dashboardPage = await gotoDashboardPage({ uid: TIMEZONE_DASHBOARD_UID });
@@ -60,7 +65,7 @@ test.describe(
       await expect(
         dashboardPage.getByGrafanaSelector(selectors.components.Panels.Panel.title(TZ_PANEL_TITLE))
       ).toBeVisible();
-      await openDashboardSettings(page, dashboardPage, selectors);
+      await openDashboardSettings(page, dashboardPage, selectors, components);
 
       // Change timezone to UTC
       await dashboardPage.getByGrafanaSelector(selectors.components.TimeZonePicker.containerV2).click();
@@ -94,7 +99,7 @@ test.describe(
       }
 
       // Open dashboard settings again (new-layouts flow)
-      await openDashboardSettings(page, dashboardPage, selectors);
+      await openDashboardSettings(page, dashboardPage, selectors, components);
 
       // Change timezone to Chicago
       await dashboardPage.getByGrafanaSelector(selectors.components.TimeZonePicker.containerV2).click();


### PR DESCRIPTION
Resolves #126360

### Key changes

- Migration of `dashboards-edit-query-variables.spec.ts`
- New
  - `VariableOptions.query`: `openEditor`, `selectDatasource`, `setQuery`, `runQuery`, `clickApplyButton`
  - `Controls.variables`: `openDropdown`, `getOption`
- The plugin-e2e `components` fixture is now a shared page-object dependency, so page objects can
  wrap component helpers like `dataSourcePicker` (first used by `variables.query.selectDatasource`).
- Refactoring pass: the `PageObject` constructor now takes a single
  `PageObjectArgs` object (`{ page, dashboardPage, selectors, components }`) instead of positional
  parameters. All 14 migrated specs, `Sidebar` (and its 6 sub-objects), and the `flows` bridge were
  updated accordingly.
- Update of `AGENTS.md` (base class & constructor docs, scaffold recipe)

### Notes for reviewers

- This PR touches `utils.ts` shared helpers and the `PageObject` base class, so per the migration
  strategy the full suite should pass CI with `--repeat-each=3` (not just a single run).

Verified locally with `--repeat-each=3`: full `dashboard-new-layouts` suite.