### PR TITLE
Alerting: wait for rule save success in e2e

### DIFF
--- a/e2e-playwright/alerting-suite/create-grafana-rule.spec.ts
+++ b/e2e-playwright/alerting-suite/create-grafana-rule.spec.ts
@@ -26,7 +26,7 @@ test.describe('Grafana-managed alert rule creation', () => {
     await editor.addLabel('team', 'e2e');
     await editor.setAnnotations({ summary: `${ruleName} summary` });
     await editor.setManualRouting(contactPoint);
-    await editor.save();
+    await editor.saveAndWaitForSuccess('created');
 
     await expect(page).toHaveURL(/\/alerting\/grafana\/[^/]+\/view/);
     alertRules.trackRule(ruleUidFromUrl(page.url()));
@@ -54,7 +54,7 @@ test.describe('Grafana-managed alert rule creation', () => {
     await editor.addLabel('team', 'e2e');
     await editor.setAnnotations({ summary: `${ruleName} summary` });
     await editor.setManualRouting(contactPoint);
-    await editor.save();
+    await editor.saveAndWaitForSuccess('created');
 
     await expect(page).toHaveURL(/\/alerting\/grafana\/[^/]+\/view/);
     alertRules.trackRule(ruleUidFromUrl(page.url()));
@@ -90,7 +90,7 @@ test.describe('Grafana-managed alert rule creation', () => {
       await editor.addLabel('team', 'e2e');
       await editor.setAnnotations({ summary: `${ruleName} summary` });
       await editor.setManualRouting(contactPoint);
-      await editor.save();
+      await editor.saveAndWaitForSuccess('created');
 
       await expect(page).toHaveURL(/\/alerting\/grafana\/[^/]+\/view/);
       alertRules.trackRule(ruleUidFromUrl(page.url()));
@@ -122,7 +122,7 @@ test.describe('Grafana-managed alert rule creation', () => {
       await editor.gotoEdit(seededRuleUid);
 
       await editor.setName(updatedName);
-      await editor.save();
+      await editor.saveAndWaitForSuccess('updated');
 
       await expect(page).toHaveURL(/\/alerting\/grafana\/[^/]+\/view/);
       const viewer = new AlertRuleViewPage(page);
@@ -171,7 +171,7 @@ test.describe('Grafana-managed alert rule creation', () => {
       await expect(editor.selectedGroupText(seededGroup)).toBeVisible();
 
       await editor.setManualRouting(contactPoint);
-      await editor.save();
+      await editor.saveAndWaitForSuccess('created');
 
       // The restored selection actually persists — viewer shows the group breadcrumb.
       await expect(page).toHaveURL(/\/alerting\/grafana\/[^/]+\/view/);
@@ -232,7 +232,7 @@ test.describe('Grafana-managed alert rule creation', () => {
     await editor.createNewEvaluationGroup(newGroup, '5m');
 
     await editor.setManualRouting(contactPoint);
-    await editor.save();
+    await editor.saveAndWaitForSuccess('created');
 
     await expect(page).toHaveURL(/\/alerting\/grafana\/[^/]+\/view/);
     alertRules.trackRule(ruleUidFromUrl(page.url()));

--- a/e2e-playwright/alerting-suite/pages/AlertRuleEditPage.ts
+++ b/e2e-playwright/alerting-suite/pages/AlertRuleEditPage.ts
@@ -128,12 +128,13 @@ export class AlertRuleEditPage {
 
   async save(): Promise<void> {
     await this.saveButton.click();
-    // Wait for the submit to actually settle (button re-enables, or disappears on navigation)
-    // instead of racing ahead of it the way a bare click does.
-    await expect(async () => {
-      const settled = (await this.saveButton.isHidden()) || !(await this.saveButton.isDisabled());
-      expect(settled).toBe(true);
-    }).toPass({ timeout: 30_000 });
+  }
+
+  async saveAndWaitForSuccess(outcome: 'created' | 'updated'): Promise<void> {
+    await this.save();
+
+    const message = outcome === 'created' ? 'Rule added successfully' : 'Rule updated successfully';
+    await expect(this.page.getByRole('status', { name: message })).toBeVisible();
   }
 
   protected get nameInput(): Locator {


### PR DESCRIPTION
## Summary

- Wait for the alert rule save-success notification before continuing E2E assertions.
- Use the explicit success state for rule creation and updates.

## Test plan

- Alerting E2E suite: 22 tests passed locally.