### PR TITLE
Dashboards: Guard getFactors against invalid input

### DIFF
--- a/public/app/core/specs/factors.test.ts
+++ b/public/app/core/specs/factors.test.ts
@@ -5,4 +5,10 @@ describe('factors', () => {
     const factors = getFactors(12);
     expect(factors).toEqual([1, 2, 3, 4, 6, 12]);
   });
+
+  it('should return an empty array for non-positive or non-integer values', () => {
+    expect(getFactors(0)).toEqual([]);
+    expect(getFactors(-5)).toEqual([]);
+    expect(getFactors(12.5)).toEqual([]);
+  });
 });

--- a/public/app/core/utils/factors.ts
+++ b/public/app/core/utils/factors.ts
@@ -1,5 +1,9 @@
 // Returns the factors of a number
 // Example getFactors(12) -> [1, 2, 3, 4, 6, 12]
 export default function getFactors(num: number): number[] {
+  if (!Number.isInteger(num) || num < 1) {
+    return [];
+  }
+
   return Array.from(new Array(num + 1), (_, i) => i).filter((i) => num % i === 0);
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This is a defensive fix🙇‍♂️

Guards `getFactors` in `public/app/core/utils/factors.ts` against negative, non-integer, and zero input so it no longer throws `RangeError`. Also adds edge-case tests in `public/app/core/specs/factors.test.ts`.
 
- `getFactors(-5)` returns `[]` (previously threw `RangeError: Invalid array length`)
- `getFactors(12.5)` returns `[]` (previously threw `RangeError: Invalid array length`)
- `getFactors(0)` returns `[]` (previously returned `[]` as a side effect of `0 % 0 === NaN`, now explicit)

**Why do we need this feature?**

`getFactors` is an exported utility used by `DashboardMigrator.ts` and potentially other call sites.
The current implementation passes `num + 1` directly to `new Array(...)`, which throws `RangeError` for negative or non-integer values. For `num = 0`, `0 % 0` evaluates to `NaN`, so the function returns an empty array by accident rather than by design.
Returning an empty array for any non-positive or non-integer input makes the utility defensive and predictable.

**Who is this feature for?**

Grafana frontend developers and maintainers of dashboard migration logic that relies on `getFactors`.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**
 
- `DashboardMigrator.ts` calls `getFactors(GRID_COLUMN_COUNT)` with a positive constant (24), so existing dashboard migration behavior is unchanged.
- `public/app/core/utils/factors.ts` is owned by `@grafana/dashboards-squad` per `CODEOWNERS`.
- Local verification performed on this branch:
  - `yarn lint:fix`: exit 0, no file changes
  - `yarn prettier:write`: exit 0, no file changes
  - `yarn typecheck`: exit 0, "Successfully ran target typecheck for 14 projects"
  - `git status --short` / `git diff --stat` / `git diff`: all empty
  - `yarn jest --no-watch public/app/core/specs/factors.test.ts`: PASS (2 tests)


Before this fix:
 
```text
getFactors(-5) threw RangeError: Invalid array length
getFactors(12.5) threw RangeError: Invalid array length
getFactors(0) = []
```

After this fix:
```text
getFactors(-5) = []
getFactors(12.5) = []
getFactors(0) = []
```

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
