### PR TITLE
SSO Settings: fix Reload panic and improve LDAP error context

### DIFF
--- a/pkg/services/ssosettings/ssosettings.go
+++ b/pkg/services/ssosettings/ssosettings.go
@@ -34,8 +34,11 @@ type Service interface {
 	Patch(ctx context.Context, provider string, data map[string]any, requester identity.Requester) error
 	// RegisterReloadable registers a reloadable for a given provider
 	RegisterReloadable(provider string, reloadable Reloadable)
-	// Reload reloads the settings for a given provider
-	Reload(ctx context.Context, provider string)
+	// Reload triggers an asynchronous reload of the settings for a given provider.
+	// The returned error only covers failures to start the reload (unknown provider,
+	// settings lookup); the reload itself runs in the background and reports failures
+	// via logs and metrics.
+	Reload(ctx context.Context, provider string) error
 }
 
 // Reloadable is an interface that can be implemented by a provider to allow it to be validated and reloaded

--- a/pkg/services/ssosettings/ssosettingsimpl/service.go
+++ b/pkg/services/ssosettings/ssosettingsimpl/service.go
@@ -430,7 +430,19 @@ func (s *Service) reload(reloadable ssosettings.Reloadable, provider string, cur
 }
 
 func (s *Service) Reload(ctx context.Context, provider string) {
-	panic("not implemented") // TODO: Implement
+	reloadable, ok := s.reloadables[provider]
+	if !ok {
+		s.logger.Warn("no reloadable found for provider, skipping reload", "provider", provider)
+		return
+	}
+
+	settings, err := s.GetForProvider(ctx, provider)
+	if err != nil {
+		s.logger.Error("failed to get settings for provider, skipping reload", "provider", provider, "error", err)
+		return
+	}
+
+	go s.reload(reloadable, provider, *settings)
 }
 
 func (s *Service) RegisterReloadable(provider string, reloadable ssosettings.Reloadable) {

--- a/pkg/services/ssosettings/ssosettingsimpl/service.go
+++ b/pkg/services/ssosettings/ssosettingsimpl/service.go
@@ -318,7 +318,7 @@ func (s *Service) Upsert(ctx context.Context, settings *models.SSOSettings, requ
 	reloadSettings := *settings
 	reloadSettings.Settings = overrideMaps(storedSettings.Settings, settingsWithSecrets)
 
-	go s.reload(reloadable, settings.Provider, reloadSettings)
+	go s.reload(context.WithoutCancel(ctx), reloadable, settings.Provider, reloadSettings)
 
 	return nil
 }
@@ -375,7 +375,7 @@ func (s *Service) Patch(ctx context.Context, provider string, data map[string]an
 	reloadSettings := *newSettings
 	reloadSettings.Settings = overrideMaps(storedSettings.Settings, settingsWithSecrets)
 
-	go s.reload(reloadable, provider, reloadSettings)
+	go s.reload(context.WithoutCancel(ctx), reloadable, provider, reloadSettings)
 
 	return nil
 }
@@ -414,35 +414,35 @@ func (s *Service) Delete(ctx context.Context, provider string) error {
 		return nil
 	}
 
-	go s.reload(reloadable, provider, *currentSettings)
+	go s.reload(context.WithoutCancel(ctx), reloadable, provider, *currentSettings)
 
 	return nil
 }
 
-func (s *Service) reload(reloadable ssosettings.Reloadable, provider string, currentSettings models.SSOSettings) {
+func (s *Service) reload(ctx context.Context, reloadable ssosettings.Reloadable, provider string, currentSettings models.SSOSettings) {
 	s.updateCachedSSOSettings(provider, &currentSettings)
 
-	err := reloadable.Reload(context.Background(), currentSettings)
+	err := reloadable.Reload(ctx, currentSettings)
 	if err != nil {
 		s.metrics.reloadFailures.WithLabelValues(provider).Inc()
 		s.logger.Error("failed to reload the provider", "provider", provider, "error", err)
 	}
 }
 
-func (s *Service) Reload(ctx context.Context, provider string) {
+func (s *Service) Reload(ctx context.Context, provider string) error {
 	reloadable, ok := s.reloadables[provider]
 	if !ok {
-		s.logger.Warn("no reloadable found for provider, skipping reload", "provider", provider)
-		return
+		return ssosettings.ErrInvalidProvider.Errorf("provider %s not found in reloadables", provider)
 	}
 
 	settings, err := s.GetForProvider(ctx, provider)
 	if err != nil {
-		s.logger.Error("failed to get settings for provider, skipping reload", "provider", provider, "error", err)
-		return
+		return fmt.Errorf("failed to get settings for provider %s: %w", provider, err)
 	}
 
-	go s.reload(reloadable, provider, *settings)
+	go s.reload(context.WithoutCancel(ctx), reloadable, provider, *settings)
+
+	return nil
 }
 
 func (s *Service) RegisterReloadable(provider string, reloadable ssosettings.Reloadable) {

--- a/pkg/services/ssosettings/ssosettingsimpl/service.go
+++ b/pkg/services/ssosettings/ssosettingsimpl/service.go
@@ -455,7 +455,19 @@ func (s *Service) reload(reloadable ssosettings.Reloadable, provider string, cur
 }
 
 func (s *Service) Reload(ctx context.Context, provider string) {
-	panic("not implemented") // TODO: Implement
+	reloadable, ok := s.reloadables[provider]
+	if !ok {
+		s.logger.Warn("no reloadable found for provider, skipping reload", "provider", provider)
+		return
+	}
+
+	settings, err := s.GetForProvider(ctx, provider)
+	if err != nil {
+		s.logger.Error("failed to get settings for provider, skipping reload", "provider", provider, "error", err)
+		return
+	}
+
+	go s.reload(reloadable, provider, *settings)
 }
 
 func (s *Service) RegisterReloadable(provider string, reloadable ssosettings.Reloadable) {

--- a/pkg/services/ssosettings/ssosettingsimpl/service.go
+++ b/pkg/services/ssosettings/ssosettingsimpl/service.go
@@ -343,7 +343,7 @@ func (s *Service) Upsert(ctx context.Context, settings *models.SSOSettings, requ
 	reloadSettings := *settings
 	reloadSettings.Settings = overrideMaps(storedSettings.Settings, settingsWithSecrets)
 
-	go s.reload(reloadable, settings.Provider, reloadSettings)
+	go s.reload(context.WithoutCancel(ctx), reloadable, settings.Provider, reloadSettings)
 
 	return nil
 }
@@ -400,7 +400,7 @@ func (s *Service) Patch(ctx context.Context, provider string, data map[string]an
 	reloadSettings := *newSettings
 	reloadSettings.Settings = overrideMaps(storedSettings.Settings, settingsWithSecrets)
 
-	go s.reload(reloadable, provider, reloadSettings)
+	go s.reload(context.WithoutCancel(ctx), reloadable, provider, reloadSettings)
 
 	return nil
 }
@@ -439,35 +439,35 @@ func (s *Service) Delete(ctx context.Context, provider string) error {
 		return nil
 	}
 
-	go s.reload(reloadable, provider, *currentSettings)
+	go s.reload(context.WithoutCancel(ctx), reloadable, provider, *currentSettings)
 
 	return nil
 }
 
-func (s *Service) reload(reloadable ssosettings.Reloadable, provider string, currentSettings models.SSOSettings) {
+func (s *Service) reload(ctx context.Context, reloadable ssosettings.Reloadable, provider string, currentSettings models.SSOSettings) {
 	s.updateCachedSSOSettings(provider, &currentSettings)
 
-	err := reloadable.Reload(context.Background(), currentSettings)
+	err := reloadable.Reload(ctx, currentSettings)
 	if err != nil {
 		s.metrics.reloadFailures.WithLabelValues(provider).Inc()
 		s.logger.Error("failed to reload the provider", "provider", provider, "error", err)
 	}
 }
 
-func (s *Service) Reload(ctx context.Context, provider string) {
+func (s *Service) Reload(ctx context.Context, provider string) error {
 	reloadable, ok := s.reloadables[provider]
 	if !ok {
-		s.logger.Warn("no reloadable found for provider, skipping reload", "provider", provider)
-		return
+		return ssosettings.ErrInvalidProvider.Errorf("provider %s not found in reloadables", provider)
 	}
 
 	settings, err := s.GetForProvider(ctx, provider)
 	if err != nil {
-		s.logger.Error("failed to get settings for provider, skipping reload", "provider", provider, "error", err)
-		return
+		return fmt.Errorf("failed to get settings for provider %s: %w", provider, err)
 	}
 
-	go s.reload(reloadable, provider, *settings)
+	go s.reload(context.WithoutCancel(ctx), reloadable, provider, *settings)
+
+	return nil
 }
 
 func (s *Service) RegisterReloadable(provider string, reloadable ssosettings.Reloadable) {

--- a/pkg/services/ssosettings/ssosettingsimpl/service_test.go
+++ b/pkg/services/ssosettings/ssosettingsimpl/service_test.go
@@ -2390,35 +2390,35 @@ func TestService_Reload(t *testing.T) {
 		})).Return(nil).Once()
 		env.reloadables[provider] = reloadable
 
-		env.service.Reload(context.Background(), provider)
+		err := env.service.Reload(context.Background(), provider)
+		require.NoError(t, err)
 
 		wg.Wait()
 	})
 
-	t.Run("no-op when no reloadable is registered for the provider", func(t *testing.T) {
+	t.Run("returns an error when no reloadable is registered for the provider", func(t *testing.T) {
 		t.Parallel()
 
 		env := setupTestEnv(t, false, false, false)
 
-		require.NotPanics(t, func() {
-			env.service.Reload(context.Background(), "unknown-provider")
-		})
+		err := env.service.Reload(context.Background(), "unknown-provider")
+		require.ErrorIs(t, err, ssosettings.ErrInvalidProvider)
 	})
 
-	t.Run("no-op when GetForProvider returns an error", func(t *testing.T) {
+	t.Run("returns an error when GetForProvider fails", func(t *testing.T) {
 		t.Parallel()
 
 		env := setupTestEnv(t, false, false, false)
 		provider := social.AzureADProviderName
 
-		env.store.ExpectedError = errors.New("failed fetching the settings")
+		expectedErr := errors.New("failed fetching the settings")
+		env.store.ExpectedError = expectedErr
 
 		reloadable := ssosettingstests.NewMockReloadable(t)
 		env.reloadables[provider] = reloadable
 
-		require.NotPanics(t, func() {
-			env.service.Reload(context.Background(), provider)
-		})
+		err := env.service.Reload(context.Background(), provider)
+		require.ErrorIs(t, err, expectedErr)
 	})
 }
 

--- a/pkg/services/ssosettings/ssosettingsimpl/service_test.go
+++ b/pkg/services/ssosettings/ssosettingsimpl/service_test.go
@@ -2365,6 +2365,63 @@ func TestService_DoReload(t *testing.T) {
 	})
 }
 
+func TestService_Reload(t *testing.T) {
+	t.Parallel()
+
+	t.Run("triggers reload for the requested provider", func(t *testing.T) {
+		t.Parallel()
+
+		env := setupTestEnv(t, false, false, false)
+		provider := social.AzureADProviderName
+
+		env.store.ExpectedSSOSetting = &models.SSOSettings{
+			Provider: provider,
+			Settings: map[string]any{"enabled": true},
+			Source:   models.DB,
+		}
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+
+		reloadable := ssosettingstests.NewMockReloadable(t)
+		reloadable.On("Reload", mock.Anything, mock.MatchedBy(func(settings models.SSOSettings) bool {
+			defer wg.Done()
+			return settings.Provider == provider && settings.Settings["enabled"] == true
+		})).Return(nil).Once()
+		env.reloadables[provider] = reloadable
+
+		env.service.Reload(context.Background(), provider)
+
+		wg.Wait()
+	})
+
+	t.Run("no-op when no reloadable is registered for the provider", func(t *testing.T) {
+		t.Parallel()
+
+		env := setupTestEnv(t, false, false, false)
+
+		require.NotPanics(t, func() {
+			env.service.Reload(context.Background(), "unknown-provider")
+		})
+	})
+
+	t.Run("no-op when GetForProvider returns an error", func(t *testing.T) {
+		t.Parallel()
+
+		env := setupTestEnv(t, false, false, false)
+		provider := social.AzureADProviderName
+
+		env.store.ExpectedError = errors.New("failed fetching the settings")
+
+		reloadable := ssosettingstests.NewMockReloadable(t)
+		env.reloadables[provider] = reloadable
+
+		require.NotPanics(t, func() {
+			env.service.Reload(context.Background(), provider)
+		})
+	})
+}
+
 func TestService_decryptSecrets(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/ssosettings/ssosettingsimpl/service_test.go
+++ b/pkg/services/ssosettings/ssosettingsimpl/service_test.go
@@ -2392,35 +2392,35 @@ func TestService_Reload(t *testing.T) {
 		})).Return(nil).Once()
 		env.reloadables[provider] = reloadable
 
-		env.service.Reload(context.Background(), provider)
+		err := env.service.Reload(context.Background(), provider)
+		require.NoError(t, err)
 
 		wg.Wait()
 	})
 
-	t.Run("no-op when no reloadable is registered for the provider", func(t *testing.T) {
+	t.Run("returns an error when no reloadable is registered for the provider", func(t *testing.T) {
 		t.Parallel()
 
 		env := setupTestEnv(t, false, false, false)
 
-		require.NotPanics(t, func() {
-			env.service.Reload(context.Background(), "unknown-provider")
-		})
+		err := env.service.Reload(context.Background(), "unknown-provider")
+		require.ErrorIs(t, err, ssosettings.ErrInvalidProvider)
 	})
 
-	t.Run("no-op when GetForProvider returns an error", func(t *testing.T) {
+	t.Run("returns an error when GetForProvider fails", func(t *testing.T) {
 		t.Parallel()
 
 		env := setupTestEnv(t, false, false, false)
 		provider := social.AzureADProviderName
 
-		env.store.ExpectedError = errors.New("failed fetching the settings")
+		expectedErr := errors.New("failed fetching the settings")
+		env.store.ExpectedError = expectedErr
 
 		reloadable := ssosettingstests.NewMockReloadable(t)
 		env.reloadables[provider] = reloadable
 
-		require.NotPanics(t, func() {
-			env.service.Reload(context.Background(), provider)
-		})
+		err := env.service.Reload(context.Background(), provider)
+		require.ErrorIs(t, err, expectedErr)
 	})
 }
 

--- a/pkg/services/ssosettings/ssosettingsimpl/service_test.go
+++ b/pkg/services/ssosettings/ssosettingsimpl/service_test.go
@@ -2367,6 +2367,63 @@ func TestService_DoReload(t *testing.T) {
 	})
 }
 
+func TestService_Reload(t *testing.T) {
+	t.Parallel()
+
+	t.Run("triggers reload for the requested provider", func(t *testing.T) {
+		t.Parallel()
+
+		env := setupTestEnv(t, false, false, false)
+		provider := social.AzureADProviderName
+
+		env.store.ExpectedSSOSetting = &models.SSOSettings{
+			Provider: provider,
+			Settings: map[string]any{"enabled": true},
+			Source:   models.DB,
+		}
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+
+		reloadable := ssosettingstests.NewMockReloadable(t)
+		reloadable.On("Reload", mock.Anything, mock.MatchedBy(func(settings models.SSOSettings) bool {
+			defer wg.Done()
+			return settings.Provider == provider && settings.Settings["enabled"] == true
+		})).Return(nil).Once()
+		env.reloadables[provider] = reloadable
+
+		env.service.Reload(context.Background(), provider)
+
+		wg.Wait()
+	})
+
+	t.Run("no-op when no reloadable is registered for the provider", func(t *testing.T) {
+		t.Parallel()
+
+		env := setupTestEnv(t, false, false, false)
+
+		require.NotPanics(t, func() {
+			env.service.Reload(context.Background(), "unknown-provider")
+		})
+	})
+
+	t.Run("no-op when GetForProvider returns an error", func(t *testing.T) {
+		t.Parallel()
+
+		env := setupTestEnv(t, false, false, false)
+		provider := social.AzureADProviderName
+
+		env.store.ExpectedError = errors.New("failed fetching the settings")
+
+		reloadable := ssosettingstests.NewMockReloadable(t)
+		env.reloadables[provider] = reloadable
+
+		require.NotPanics(t, func() {
+			env.service.Reload(context.Background(), provider)
+		})
+	})
+}
+
 func TestService_decryptSecrets(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/ssosettings/ssosettingstests/service_fake.go
+++ b/pkg/services/ssosettings/ssosettingstests/service_fake.go
@@ -29,7 +29,7 @@ type FakeService struct {
 	DeleteFn                            func(ctx context.Context, provider string) error
 	PatchFn                             func(ctx context.Context, provider string, data map[string]any, requester identity.Requester) error
 	RegisterReloadableFn                func(provider string, reloadable ssosettings.Reloadable)
-	ReloadFn                            func(ctx context.Context, provider string)
+	ReloadFn                            func(ctx context.Context, provider string) error
 }
 
 func NewFakeService() *FakeService {
@@ -118,11 +118,11 @@ func (f *FakeService) RegisterReloadable(provider string, reloadable ssosettings
 	f.ExpectedReloadablesRegistry[provider] = reloadable
 }
 
-func (f *FakeService) Reload(ctx context.Context, provider string) {
+func (f *FakeService) Reload(ctx context.Context, provider string) error {
 	if f.ReloadFn != nil {
-		f.ReloadFn(ctx, provider)
-		return
+		return f.ReloadFn(ctx, provider)
 	}
 
 	f.ActualProvider = provider
+	return f.ExpectedError
 }

--- a/pkg/services/ssosettings/ssosettingstests/service_mock.go
+++ b/pkg/services/ssosettings/ssosettingstests/service_mock.go
@@ -210,8 +210,21 @@ func (_m *MockService) RegisterReloadable(provider string, reloadable ssosetting
 }
 
 // Reload provides a mock function with given fields: ctx, provider
-func (_m *MockService) Reload(ctx context.Context, provider string) {
-	_m.Called(ctx, provider)
+func (_m *MockService) Reload(ctx context.Context, provider string) error {
+	ret := _m.Called(ctx, provider)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Reload")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = rf(ctx, provider)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
 }
 
 // Upsert provides a mock function with given fields: ctx, settings, requester

--- a/pkg/services/ssosettings/strategies/ldap_strategy.go
+++ b/pkg/services/ssosettings/strategies/ldap_strategy.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"github.com/grafana/grafana/pkg/login/social"
 	"github.com/grafana/grafana/pkg/services/ldap"
@@ -88,17 +89,17 @@ func replaceNumbersInMap(m map[string]any) (map[string]any, error) {
 		case json.Number:
 			result[k], err = v.Int64()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("field %q: %w", k, err)
 			}
 		case []any:
 			result[k], err = replaceNumbersInSlice(v)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("field %q: %w", k, err)
 			}
 		case map[string]any:
 			result[k], err = replaceNumbersInMap(v)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("field %q: %w", k, err)
 			}
 		default:
 			result[k] = v


### PR DESCRIPTION
> Recreated from #120905, which was auto-closed by the stale bot. Branch merged up to the latest `main`; merged cleanly with no conflicts.

Two isolated fixes found during an audit of `pkg/services/ssosettings`.

## Changes

**`Service.Reload` was panicking**
The method was listed on the `Service` interface but never implemented (`panic("not implemented")`). It now follows the same pattern as `Delete`: fetches current settings via `GetForProvider`, then triggers an async reload via the internal `reload` helper.

Following review feedback, `Reload` now returns an `error` instead of only logging: unknown provider returns `ErrInvalidProvider` (same as `Delete`), and a failed settings lookup returns the wrapped error. The reload itself stays asynchronous; the interface comment documents that the returned error only covers failures to start it. The async `reload` helper also takes the caller's context now, detached via `context.WithoutCancel`, so trace/log values propagate to the reloadable without a cancelled request aborting a reload midway.

**`replaceNumbersInMap` returned bare errors**
When a `json.Number` value in the LDAP config couldn't be parsed as `int64`, the error gave no indication of which field failed. Errors now include the field key name.