### PR TITLE
SSO Settings: add JWT provider

### DIFF
--- a/pkg/api/common_test.go
+++ b/pkg/api/common_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
 	"github.com/grafana/grafana/pkg/services/annotations/annotationstest"
 	"github.com/grafana/grafana/pkg/services/auth/authtest"
+	"github.com/grafana/grafana/pkg/services/auth/jwt"
 	"github.com/grafana/grafana/pkg/services/authn"
 	"github.com/grafana/grafana/pkg/services/authn/authntest"
 	"github.com/grafana/grafana/pkg/services/contexthandler"
@@ -191,6 +192,7 @@ func getContextHandler(t *testing.T, cfg *setting.Cfg) *contexthandler.ContextHa
 		cfg,
 		&authntest.FakeService{ExpectedIdentity: &authn.Identity{ID: "0", Type: claims.TypeAnonymous, SessionToken: &usertoken.UserToken{}}},
 		featuremgmt.WithFeatures(),
+		jwt.NewFakeJWTService(),
 	)
 }
 

--- a/pkg/api/static/static_test.go
+++ b/pkg/api/static/static_test.go
@@ -10,6 +10,7 @@ import (
 
 	claims "github.com/grafana/authlib/types"
 	"github.com/grafana/grafana/pkg/models/usertoken"
+	"github.com/grafana/grafana/pkg/services/auth/jwt"
 	"github.com/grafana/grafana/pkg/services/authn"
 	"github.com/grafana/grafana/pkg/services/authn/authntest"
 	"github.com/grafana/grafana/pkg/services/contexthandler"
@@ -158,6 +159,7 @@ func getContextHandler(t *testing.T, cfg *setting.Cfg) *contexthandler.ContextHa
 		cfg,
 		&authntest.FakeService{ExpectedIdentity: &authn.Identity{ID: "0", Type: claims.TypeAnonymous, SessionToken: &usertoken.UserToken{}}},
 		featuremgmt.WithFeatures(),
+		jwt.NewFakeJWTService(),
 	)
 }
 

--- a/pkg/login/social/social.go
+++ b/pkg/login/social/social.go
@@ -33,6 +33,7 @@ const (
 	OktaProviderName       = "okta"
 	SAMLProviderName       = "saml"
 	LDAPProviderName       = "ldap"
+	JWTProviderName        = "jwt"
 )
 
 var SocialBaseUrl = "/login/"

--- a/pkg/middleware/auth_test.go
+++ b/pkg/middleware/auth_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log/logtest"
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/actest"
+	"github.com/grafana/grafana/pkg/services/auth/jwt"
 	"github.com/grafana/grafana/pkg/services/authn"
 	"github.com/grafana/grafana/pkg/services/authn/authntest"
 	"github.com/grafana/grafana/pkg/services/contexthandler"
@@ -32,7 +33,7 @@ func setupAuthMiddlewareTest(t *testing.T, identity *authn.Identity, authErr err
 	return contexthandler.ProvideService(setting.NewCfg(), &authntest.FakeService{
 		ExpectedErr:      authErr,
 		ExpectedIdentity: identity,
-	}, featuremgmt.WithFeatures())
+	}, featuremgmt.WithFeatures(), jwt.NewFakeJWTService())
 }
 
 func TestAuth_Middleware(t *testing.T) {

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/infra/fs"
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/auth/jwt"
 	"github.com/grafana/grafana/pkg/services/authn"
 	"github.com/grafana/grafana/pkg/services/authn/authntest"
 	"github.com/grafana/grafana/pkg/services/contexthandler"
@@ -289,5 +290,5 @@ func middlewareScenario(t *testing.T, desc string, fn scenarioFunc, cbs ...func(
 func getContextHandler(t *testing.T, cfg *setting.Cfg, authnService authn.Service) *contexthandler.ContextHandler {
 	t.Helper()
 
-	return contexthandler.ProvideService(cfg, authnService, featuremgmt.WithFeatures())
+	return contexthandler.ProvideService(cfg, authnService, featuremgmt.WithFeatures(), jwt.NewFakeJWTService())
 }

--- a/pkg/server/bootstrap/wire/wire_gen.go
+++ b/pkg/server/bootstrap/wire/wire_gen.go
@@ -704,7 +704,11 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts server.Options, apiO
 	gateway := pushhttp.ProvideService(cfg, grafanaLive)
 	authnimplService := authnimpl.ProvideService(cfg, tracingService, userAuthTokenService, usageStats, registerer, authinfoimplService)
 	authnAuthenticator := authnimpl.ProvideAuthnServiceAuthenticateOnly(authnimplService)
-	contexthandlerContextHandler := contexthandler.ProvideService(cfg, authnAuthenticator, featureToggles)
+	authService, err := jwt.ProvideService(cfg, remoteCache, ssosettingsimplService)
+	if err != nil {
+		return nil, err
+	}
+	contexthandlerContextHandler := contexthandler.ProvideService(cfg, authnAuthenticator, featureToggles, authService)
 	logger := loggermw.Provide(cfg, featureToggles)
 	qsDatasourceClientBuilder := dsquerierclient.NewNullQSDatasourceClientBuilder()
 	exprService := expr.ProvideService(cfg, middlewareHandler, plugincontextProvider, featureToggles, registerer, tracingService, qsDatasourceClientBuilder)
@@ -1001,10 +1005,6 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts server.Options, apiO
 	}
 	teamAPI := teamapi.ProvideTeamAPI(routeRegisterImpl, teamimplService, acimplService, accessControl, teamPermissionsService, userimplService, ossLicensingService, cfg, prefService, k8sHandler, dashboardService, featureToggles, resourceClient, eventualRestConfigProvider)
 	cloudmigrationService, err := cloudmigrationimpl.ProvideService(cfg, httpclientProvider, featureToggles, sqlStore, service13, secretsKVStore, secretsService, routeRegisterImpl, registerer, tracingService, dashboardService, folderimplService, pluginstoreService, service12, accessControl, acimplService, kvStore, libraryElementService, alertNG)
-	if err != nil {
-		return nil, err
-	}
-	authService, err := jwt.ProvideService(cfg, remoteCache)
 	if err != nil {
 		return nil, err
 	}
@@ -1464,7 +1464,11 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 	gateway := pushhttp.ProvideService(cfg, grafanaLive)
 	authnimplService := authnimpl.ProvideService(cfg, tracingService, userAuthTokenService, usageStats, registerer, authinfoimplService)
 	authnAuthenticator := authnimpl.ProvideAuthnServiceAuthenticateOnly(authnimplService)
-	contexthandlerContextHandler := contexthandler.ProvideService(cfg, authnAuthenticator, featureToggles)
+	authService, err := jwt.ProvideService(cfg, remoteCache, ssosettingsimplService)
+	if err != nil {
+		return nil, err
+	}
+	contexthandlerContextHandler := contexthandler.ProvideService(cfg, authnAuthenticator, featureToggles, authService)
 	logger := loggermw.Provide(cfg, featureToggles)
 	qsDatasourceClientBuilder := dsquerierclient.NewNullQSDatasourceClientBuilder()
 	exprService := expr.ProvideService(cfg, middlewareHandler, plugincontextProvider, featureToggles, registerer, tracingService, qsDatasourceClientBuilder)
@@ -1762,10 +1766,6 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 	}
 	teamAPI := teamapi.ProvideTeamAPI(routeRegisterImpl, teamimplService, acimplService, accessControl, teamPermissionsService, userimplService, ossLicensingService, cfg, prefService, k8sHandler, dashboardService, featureToggles, resourceClient, eventualRestConfigProvider)
 	cloudmigrationService, err := cloudmigrationimpl.ProvideService(cfg, httpclientProvider, featureToggles, sqlStore, service13, secretsKVStore, secretsService, routeRegisterImpl, registerer, tracingService, dashboardService, folderimplService, pluginstoreService, service12, accessControl, acimplService, kvStore, libraryElementService, alertNG)
-	if err != nil {
-		return nil, err
-	}
-	authService, err := jwt.ProvideService(cfg, remoteCache)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/bootstrap/wire/wire_gen.go
+++ b/pkg/server/bootstrap/wire/wire_gen.go
@@ -700,7 +700,11 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts server.Options, apiO
 	gateway := pushhttp.ProvideService(cfg, grafanaLive)
 	authnimplService := authnimpl.ProvideService(cfg, tracingService, userAuthTokenService, usageStats, registerer, authinfoimplService)
 	authnAuthenticator := authnimpl.ProvideAuthnServiceAuthenticateOnly(authnimplService)
-	contexthandlerContextHandler := contexthandler.ProvideService(cfg, authnAuthenticator, featureToggles)
+	authService, err := jwt.ProvideService(cfg, remoteCache, ssosettingsimplService)
+	if err != nil {
+		return nil, err
+	}
+	contexthandlerContextHandler := contexthandler.ProvideService(cfg, authnAuthenticator, featureToggles, authService)
 	logger := loggermw.Provide(cfg, featureToggles)
 	qsDatasourceClientBuilder := dsquerierclient.NewNullQSDatasourceClientBuilder()
 	exprService := expr.ProvideService(cfg, middlewareHandler, plugincontextProvider, featureToggles, registerer, tracingService, qsDatasourceClientBuilder)
@@ -995,10 +999,6 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts server.Options, apiO
 	}
 	teamAPI := teamapi.ProvideTeamAPI(routeRegisterImpl, teamimplService, acimplService, accessControl, teamPermissionsService, userimplService, ossLicensingService, cfg, prefService, k8sHandler, dashboardService, featureToggles, resourceClient, eventualRestConfigProvider)
 	cloudmigrationService, err := cloudmigrationimpl.ProvideService(cfg, httpclientProvider, featureToggles, sqlStore, service13, secretsKVStore, secretsService, routeRegisterImpl, registerer, tracingService, dashboardService, folderimplService, pluginstoreService, service12, accessControl, acimplService, kvStore, libraryElementService, alertNG)
-	if err != nil {
-		return nil, err
-	}
-	authService, err := jwt.ProvideService(cfg, remoteCache)
 	if err != nil {
 		return nil, err
 	}
@@ -1460,7 +1460,11 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 	gateway := pushhttp.ProvideService(cfg, grafanaLive)
 	authnimplService := authnimpl.ProvideService(cfg, tracingService, userAuthTokenService, usageStats, registerer, authinfoimplService)
 	authnAuthenticator := authnimpl.ProvideAuthnServiceAuthenticateOnly(authnimplService)
-	contexthandlerContextHandler := contexthandler.ProvideService(cfg, authnAuthenticator, featureToggles)
+	authService, err := jwt.ProvideService(cfg, remoteCache, ssosettingsimplService)
+	if err != nil {
+		return nil, err
+	}
+	contexthandlerContextHandler := contexthandler.ProvideService(cfg, authnAuthenticator, featureToggles, authService)
 	logger := loggermw.Provide(cfg, featureToggles)
 	qsDatasourceClientBuilder := dsquerierclient.NewNullQSDatasourceClientBuilder()
 	exprService := expr.ProvideService(cfg, middlewareHandler, plugincontextProvider, featureToggles, registerer, tracingService, qsDatasourceClientBuilder)
@@ -1756,10 +1760,6 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 	}
 	teamAPI := teamapi.ProvideTeamAPI(routeRegisterImpl, teamimplService, acimplService, accessControl, teamPermissionsService, userimplService, ossLicensingService, cfg, prefService, k8sHandler, dashboardService, featureToggles, resourceClient, eventualRestConfigProvider)
 	cloudmigrationService, err := cloudmigrationimpl.ProvideService(cfg, httpclientProvider, featureToggles, sqlStore, service13, secretsKVStore, secretsService, routeRegisterImpl, registerer, tracingService, dashboardService, folderimplService, pluginstoreService, service12, accessControl, acimplService, kvStore, libraryElementService, alertNG)
-	if err != nil {
-		return nil, err
-	}
-	authService, err := jwt.ProvideService(cfg, remoteCache)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/auth/jwt/auth.go
+++ b/pkg/services/auth/jwt/auth.go
@@ -5,23 +5,40 @@ import (
 	"encoding/base64"
 	"errors"
 	"strings"
+	"sync"
 
 	jose "github.com/go-jose/go-jose/v4"
 	"github.com/go-jose/go-jose/v4/jwt"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/remotecache"
+	"github.com/grafana/grafana/pkg/login/social"
+	"github.com/grafana/grafana/pkg/services/ssosettings"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
 const ServiceName = "AuthService"
 
-func ProvideService(cfg *setting.Cfg, remoteCache *remotecache.RemoteCache) (*AuthService, error) {
+func ProvideService(cfg *setting.Cfg, remoteCache *remotecache.RemoteCache, ssoSettings ssosettings.Service) (*AuthService, error) {
 	s := newService(cfg, remoteCache)
-	if err := s.init(); err != nil {
-		return nil, err
+
+	ssoSettings.RegisterReloadable(social.JWTProviderName, s)
+
+	settings, err := ssoSettings.GetForProvider(context.Background(), social.JWTProviderName)
+	if err != nil {
+		s.log.Error("failed to load JWT settings from SSO store, falling back to config file", "error", err)
+		if initErr := s.init(); initErr != nil {
+			s.log.Error("failed to apply JWT config file settings", "error", initErr)
+		}
+		return s, nil
 	}
 
+	if err := s.Reload(context.Background(), *settings); err != nil {
+		s.log.Error("failed to apply JWT settings from SSO store, falling back to config file", "error", err)
+		if initErr := s.init(); initErr != nil {
+			s.log.Error("failed to apply JWT config file settings", "error", initErr)
+		}
+	}
 	return s, nil
 }
 
@@ -33,29 +50,70 @@ func newService(cfg *setting.Cfg, remoteCache *remotecache.RemoteCache) *AuthSer
 	}
 }
 
-func (s *AuthService) init() error {
-	if !s.Cfg.JWTAuth.Enabled {
-		return nil
-	}
-
-	if err := s.initClaimExpectations(); err != nil {
-		return err
-	}
-	if err := s.initKeySet(); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 type AuthService struct {
 	Cfg         *setting.Cfg
 	RemoteCache *remotecache.RemoteCache
+	log         log.Logger
 
+	// mu protects all fields below. Reload swaps the snapshot under Lock;
+	// Verify takes RLock to copy the pointers it needs and drops the lock
+	// before doing any I/O.
+	mu               sync.RWMutex
+	settings         setting.AuthJWTSettings
 	keySet           keySet
-	log              log.Logger
 	expect           map[string]any
 	expectRegistered jwt.Expected
+}
+
+// init applies the file-config (cfg.JWTAuth) as the current effective state.
+// Used as a fallback when no SSO settings store is available.
+func (s *AuthService) init() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.apply(s.Cfg.JWTAuth)
+}
+
+// apply installs a parsed settings struct as the current state.
+// Callers must hold s.mu for writing. The new state is fully built before any
+// field is swapped, so a failed reload leaves the previous working state intact
+// and can't disable verification for a running server.
+func (s *AuthService) apply(next setting.AuthJWTSettings) error {
+	if !next.Enabled {
+		s.settings = next
+		s.keySet = nil
+		s.expect = nil
+		s.expectRegistered = jwt.Expected{}
+		return nil
+	}
+
+	expect, expectRegistered, err := parseClaimExpectations(next.ExpectClaims)
+	if err != nil {
+		return err
+	}
+
+	keySet, err := s.buildKeySet(next)
+	if err != nil {
+		return err
+	}
+
+	s.settings = next
+	s.keySet = keySet
+	s.expect = expect
+	s.expectRegistered = expectRegistered
+	return nil
+}
+
+// Settings returns a snapshot of the current JWT auth settings.
+// The returned struct is safe to use independently of subsequent reloads:
+// the OrgMapping slice is copied so callers can't mutate the live state.
+func (s *AuthService) Settings() setting.AuthJWTSettings {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := s.settings
+	if len(s.settings.OrgMapping) > 0 {
+		out.OrgMapping = append([]string(nil), s.settings.OrgMapping...)
+	}
+	return out
 }
 
 // Sanitize JWT base64 strings to remove paddings everywhere
@@ -69,6 +127,16 @@ func sanitizeJWT(jwtToken string) string {
 func (s *AuthService) Verify(ctx context.Context, strToken string) (map[string]any, error) {
 	s.log.Debug("Parsing JSON Web Token")
 
+	s.mu.RLock()
+	keySet := s.keySet
+	expect := s.expect
+	expectRegistered := s.expectRegistered
+	s.mu.RUnlock()
+
+	if keySet == nil {
+		return nil, errors.New("jwt auth not configured")
+	}
+
 	strToken = sanitizeJWT(strToken)
 	token, err := jwt.ParseSigned(strToken, []jose.SignatureAlgorithm{jose.EdDSA, jose.HS256, jose.HS384,
 		jose.HS512, jose.RS512, jose.RS256, jose.ES256, jose.ES384, jose.ES512, jose.PS256, jose.PS384, jose.PS512})
@@ -76,7 +144,7 @@ func (s *AuthService) Verify(ctx context.Context, strToken string) (map[string]a
 		return nil, err
 	}
 
-	keys, err := s.keySet.Key(ctx, token.Headers[0].KeyID)
+	keys, err := keySet.Key(ctx, token.Headers[0].KeyID)
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +166,7 @@ func (s *AuthService) Verify(ctx context.Context, strToken string) (map[string]a
 
 	s.log.Debug("Validating JSON Web Token claims")
 
-	if err = s.validateClaims(claims); err != nil {
+	if err = validateClaims(claims, expect, expectRegistered); err != nil {
 		return nil, err
 	}
 

--- a/pkg/services/auth/jwt/context.go
+++ b/pkg/services/auth/jwt/context.go
@@ -1,0 +1,23 @@
+package jwt
+
+import (
+	"context"
+
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+type settingsCtxKey struct{}
+
+// WithSettings stores a per-request snapshot of the JWT settings on the context
+// so that authentication and outbound auth-header clearing observe the same
+// values even if a reload changes them concurrently within a request.
+func WithSettings(ctx context.Context, settings setting.AuthJWTSettings) context.Context {
+	return context.WithValue(ctx, settingsCtxKey{}, settings)
+}
+
+// SettingsFromContext returns the JWT settings snapshot stored by WithSettings
+// and whether one was present.
+func SettingsFromContext(ctx context.Context) (setting.AuthJWTSettings, bool) {
+	s, ok := ctx.Value(settingsCtxKey{}).(setting.AuthJWTSettings)
+	return s, ok
+}

--- a/pkg/services/auth/jwt/jwt.go
+++ b/pkg/services/auth/jwt/jwt.go
@@ -2,18 +2,28 @@ package jwt
 
 import (
 	"context"
+
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 type JWTService interface {
 	Verify(ctx context.Context, strToken string) (map[string]any, error)
+	// Settings returns a snapshot of the JWT auth settings currently in effect.
+	// Implementations must be safe to call concurrently with reloads.
+	Settings() setting.AuthJWTSettings
 }
 
 type FakeJWTService struct {
 	VerifyProvider func(context.Context, string) (map[string]any, error)
+	SettingsValue  setting.AuthJWTSettings
 }
 
 func (s *FakeJWTService) Verify(ctx context.Context, token string) (map[string]any, error) {
 	return s.VerifyProvider(ctx, token)
+}
+
+func (s *FakeJWTService) Settings() setting.AuthJWTSettings {
+	return s.SettingsValue
 }
 
 func NewFakeJWTService() *FakeJWTService {

--- a/pkg/services/auth/jwt/key_sets.go
+++ b/pkg/services/auth/jwt/key_sets.go
@@ -51,21 +51,21 @@ type keySetHTTP struct {
 	cacheExpiration time.Duration
 }
 
-func (s *AuthService) checkKeySetConfiguration() error {
+func checkKeySetConfiguration(settings setting.AuthJWTSettings) error {
 	var count int
-	if s.Cfg.JWTAuth.KeyFile != "" {
+	if settings.KeyFile != "" {
 		count++
 	}
-	if s.Cfg.JWTAuth.KeyValue != "" {
+	if settings.KeyValue != "" {
 		count++
 	}
-	if s.Cfg.JWTAuth.JWKSetFile != "" {
+	if settings.JWKSetFile != "" {
 		count++
 	}
-	if s.Cfg.JWTAuth.JWKSetValue != "" {
+	if settings.JWKSetValue != "" {
 		count++
 	}
-	if s.Cfg.JWTAuth.JWKSetURL != "" {
+	if settings.JWKSetURL != "" {
 		count++
 	}
 
@@ -80,56 +80,50 @@ func (s *AuthService) checkKeySetConfiguration() error {
 	return nil
 }
 
-// initKeySet creates a provider for JWKSet from exactly one configured source: a
-// PEM key or JWKS provided as a file or inline value, or a JWKS https endpoint.
-func (s *AuthService) initKeySet() error {
-	if err := s.checkKeySetConfiguration(); err != nil {
-		return err
+// buildKeySet creates a provider for JWKSet from exactly one configured source:
+// a PEM key or JWKS provided as a file or inline value, or a JWKS https endpoint.
+// It reads only the passed settings and does not mutate the service, so apply
+// can build the new key set before swapping state.
+func (s *AuthService) buildKeySet(settings setting.AuthJWTSettings) (keySet, error) {
+	if err := checkKeySetConfiguration(settings); err != nil {
+		return nil, err
 	}
 
 	switch {
-	case s.Cfg.JWTAuth.KeyFile != "":
-		data, err := s.readKeyFile(s.Cfg.JWTAuth.KeyFile)
+	case settings.KeyFile != "":
+		data, err := s.readKeyFile(settings.KeyFile)
 		if err != nil {
-			return err
+			return nil, err
 		}
-		s.keySet, err = parsePEMPublicKey(data, s.Cfg.JWTAuth.KeyID)
-		return err
-	case s.Cfg.JWTAuth.KeyValue != "":
-		data, err := decodeKeyValue(s.Cfg.JWTAuth.KeyValue)
+		return parsePEMPublicKey(data, settings.KeyID)
+	case settings.KeyValue != "":
+		data, err := decodeKeyValue(settings.KeyValue)
 		if err != nil {
-			return err
+			return nil, err
 		}
-		s.keySet, err = parsePEMPublicKey(data, s.Cfg.JWTAuth.KeyID)
-		return err
-	case s.Cfg.JWTAuth.JWKSetFile != "":
-		data, err := s.readKeyFile(s.Cfg.JWTAuth.JWKSetFile)
+		return parsePEMPublicKey(data, settings.KeyID)
+	case settings.JWKSetFile != "":
+		data, err := s.readKeyFile(settings.JWKSetFile)
 		if err != nil {
-			return err
+			return nil, err
 		}
-		s.keySet, err = parseJWKS(data)
-		return err
-	case s.Cfg.JWTAuth.JWKSetValue != "":
-		data, err := decodeKeyValue(s.Cfg.JWTAuth.JWKSetValue)
+		return parseJWKS(data)
+	case settings.JWKSetValue != "":
+		data, err := decodeKeyValue(settings.JWKSetValue)
 		if err != nil {
-			return err
+			return nil, err
 		}
-		s.keySet, err = parseJWKS(data)
-		return err
-	case s.Cfg.JWTAuth.JWKSetURL != "":
-		keySet, err := s.newHTTPKeySet(s.Cfg.JWTAuth.JWKSetURL)
-		if err != nil {
-			return err
-		}
-		s.keySet = keySet
-		return nil
+		return parseJWKS(data)
+	case settings.JWKSetURL != "":
+		return s.newHTTPKeySet(settings, settings.JWKSetURL)
 	}
 
-	return nil
+	return nil, nil
 }
 
 // newHTTPKeySet builds a key set that fetches a JWKS from an https endpoint.
-func (s *AuthService) newHTTPKeySet(urlStr string) (*keySetHTTP, error) {
+// It reads only the passed settings so it can run before apply swaps state.
+func (s *AuthService) newHTTPKeySet(settings setting.AuthJWTSettings, urlStr string) (*keySetHTTP, error) {
 	urlParsed, err := url.Parse(urlStr)
 	if err != nil {
 		return nil, err
@@ -139,26 +133,26 @@ func (s *AuthService) newHTTPKeySet(urlStr string) (*keySetHTTP, error) {
 	}
 
 	var caCertPool *x509.CertPool
-	if s.Cfg.JWTAuth.TlsClientCa != "" {
+	if settings.TlsClientCa != "" {
 		s.log.Debug("reading ca from TlsClientCa path")
 		// nolint:gosec
 		// We can ignore the gosec G304 warning on this one because `tlsClientCa` comes from grafana configuration file
-		caCert, err := os.ReadFile(s.Cfg.JWTAuth.TlsClientCa)
+		caCert, err := os.ReadFile(settings.TlsClientCa)
 		if err != nil {
-			s.log.Error("Failed to read TlsClientCa", "path", s.Cfg.JWTAuth.TlsClientCa, "error", err)
+			s.log.Error("Failed to read TlsClientCa", "path", settings.TlsClientCa, "error", err)
 			return nil, fmt.Errorf("failed to read TlsClientCa: %w", err)
 		}
 
 		caCertPool = x509.NewCertPool()
 		if !caCertPool.AppendCertsFromPEM(caCert) {
-			s.log.Error("failed to decode provided PEM certs", "path", s.Cfg.JWTAuth.TlsClientCa)
+			s.log.Error("failed to decode provided PEM certs", "path", settings.TlsClientCa)
 			return nil, fmt.Errorf("failed to decode provided PEM certs file from TlsClientCa")
 		}
 	}
 
 	// Read Bearer token from file during init
-	if s.Cfg.JWTAuth.JWKSetBearerTokenFile != "" {
-		if _, err := getBearerToken(s.Cfg.JWTAuth.JWKSetBearerTokenFile); err != nil {
+	if settings.JWKSetBearerTokenFile != "" {
+		if _, err := getBearerToken(settings.JWKSetBearerTokenFile); err != nil {
 			return nil, err
 		}
 	}
@@ -166,12 +160,13 @@ func (s *AuthService) newHTTPKeySet(urlStr string) (*keySetHTTP, error) {
 	return &keySetHTTP{
 		url:             urlStr,
 		log:             s.log,
-		bearerTokenPath: s.Cfg.JWTAuth.JWKSetBearerTokenFile,
+		bearerTokenPath: settings.JWKSetBearerTokenFile,
 		client: &http.Client{
 			Transport: &http.Transport{
 				TLSClientConfig: &tls.Config{
+					MinVersion:         tls.VersionTLS12,
 					Renegotiation:      tls.RenegotiateFreelyAsClient,
-					InsecureSkipVerify: s.Cfg.JWTAuth.TlsSkipVerify,
+					InsecureSkipVerify: settings.TlsSkipVerify,
 					RootCAs:            caCertPool,
 				},
 				Proxy: http.ProxyFromEnvironment,
@@ -187,7 +182,7 @@ func (s *AuthService) newHTTPKeySet(urlStr string) (*keySetHTTP, error) {
 			Timeout: time.Second * 30,
 		},
 		cacheKey:        fmt.Sprintf("auth-jwt:jwk-%s", urlStr),
-		cacheExpiration: s.Cfg.JWTAuth.CacheTTL,
+		cacheExpiration: settings.CacheTTL,
 		cache:           s.RemoteCache,
 	}, nil
 }

--- a/pkg/services/auth/jwt/reload.go
+++ b/pkg/services/auth/jwt/reload.go
@@ -1,0 +1,76 @@
+package jwt
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/services/ssosettings"
+	"github.com/grafana/grafana/pkg/services/ssosettings/models"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+var _ ssosettings.Reloadable = (*AuthService)(nil)
+
+func (s *AuthService) Validate(_ context.Context, settings models.SSOSettings, _ models.SSOSettings, _ identity.Requester) error {
+	parsed, err := SettingsFromMap(settings.Settings)
+	if err != nil {
+		return ssosettings.ErrInvalidSettings.Errorf("%w", err)
+	}
+	if err := validateJWTSettings(parsed, s.Cfg.Env); err != nil {
+		return ssosettings.ErrInvalidSettings.Errorf("%w", err)
+	}
+	return nil
+}
+
+func (s *AuthService) Reload(_ context.Context, settings models.SSOSettings) error {
+	parsed, err := SettingsFromMap(settings.Settings)
+	if err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.apply(parsed)
+}
+
+// validateJWKSetURL parses the URL and rejects non-https outside Dev mode.
+// Empty input is a no-op so callers can pass through unconditionally.
+func validateJWKSetURL(rawURL, env string) error {
+	if rawURL == "" {
+		return nil
+	}
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid jwk_set_url: %w", err)
+	}
+	if u.Scheme != "https" && env != setting.Dev {
+		return ErrJWTSetURLMustHaveHTTPSScheme
+	}
+	return nil
+}
+
+func validateJWTSettings(parsed setting.AuthJWTSettings, env string) error {
+	if !parsed.Enabled {
+		return nil
+	}
+
+	if parsed.HeaderName == "" && !parsed.URLLogin {
+		return fmt.Errorf("either header_name must be set or url_login must be enabled")
+	}
+
+	if err := checkKeySetConfiguration(parsed); err != nil {
+		return err
+	}
+
+	if err := validateJWKSetURL(parsed.JWKSetURL, env); err != nil {
+		return err
+	}
+
+	if _, _, err := parseClaimExpectations(parsed.ExpectClaims); err != nil {
+		return fmt.Errorf("invalid expect_claims: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/services/auth/jwt/reload_test.go
+++ b/pkg/services/auth/jwt/reload_test.go
@@ -1,0 +1,225 @@
+package jwt
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/ssosettings"
+	"github.com/grafana/grafana/pkg/services/ssosettings/models"
+	"github.com/grafana/grafana/pkg/services/ssosettings/ssosettingstests"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+func TestSettings_RoundTrip(t *testing.T) {
+	src := setting.AuthJWTSettings{
+		Enabled:                 true,
+		HeaderName:              "X-JWT-Assertion",
+		EmailClaim:              "email",
+		UsernameClaim:           "sub",
+		ExpectClaims:            `{"iss":"https://example.com"}`,
+		JWKSetURL:               "https://example.com/.well-known/jwks.json",
+		CacheTTL:                30 * time.Minute,
+		AutoSignUp:              true,
+		RoleAttributePath:       "roles[0]",
+		RoleAttributeStrict:     true,
+		AllowAssignGrafanaAdmin: false,
+		SkipOrgRoleSync:         false,
+		OrgMapping:              []string{"team-a:1:Editor", "team-b:2:Viewer"},
+		OrgAttributePath:        "groups",
+	}
+
+	got, err := SettingsFromMap(SettingsToMap(src))
+	require.NoError(t, err)
+	require.Equal(t, src, got)
+}
+
+func TestSettingsFromMap_RejectsTypeMismatch(t *testing.T) {
+	_, err := SettingsFromMap(map[string]any{"header_name": 42})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "header_name")
+}
+
+func TestSettingsFromMap_RejectsInvalidCacheTTL(t *testing.T) {
+	_, err := SettingsFromMap(map[string]any{"cache_ttl": "not-a-duration"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cache_ttl")
+}
+
+func TestValidate_NoOpWhenDisabled(t *testing.T) {
+	s := &AuthService{Cfg: &setting.Cfg{}}
+
+	err := s.Validate(context.Background(), models.SSOSettings{
+		Settings: map[string]any{"enabled": false},
+	}, models.SSOSettings{}, nil)
+	require.NoError(t, err)
+}
+
+func TestValidate_RequiresHeaderOrURLLogin(t *testing.T) {
+	s := &AuthService{Cfg: &setting.Cfg{}}
+
+	err := s.Validate(context.Background(), models.SSOSettings{
+		Settings: map[string]any{
+			"enabled":     true,
+			"jwk_set_url": "https://example.com/.well-known/jwks.json",
+		},
+	}, models.SSOSettings{}, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "header_name")
+}
+
+func TestValidate_RejectsAmbiguousKeySource(t *testing.T) {
+	s := &AuthService{Cfg: &setting.Cfg{}}
+
+	err := s.Validate(context.Background(), models.SSOSettings{
+		Settings: map[string]any{
+			"enabled":      true,
+			"header_name":  "X-JWT",
+			"jwk_set_url":  "https://example.com/.well-known/jwks.json",
+			"jwk_set_file": "/tmp/jwks.json",
+		},
+	}, models.SSOSettings{}, nil)
+	require.ErrorIs(t, err, ErrKeySetConfigurationAmbiguous)
+}
+
+func TestValidate_RequiresHTTPSJWKSetURL(t *testing.T) {
+	s := &AuthService{Cfg: &setting.Cfg{Env: setting.Prod}}
+
+	err := s.Validate(context.Background(), models.SSOSettings{
+		Settings: map[string]any{
+			"enabled":     true,
+			"header_name": "X-JWT",
+			"jwk_set_url": "http://example.com/.well-known/jwks.json",
+		},
+	}, models.SSOSettings{}, nil)
+	require.ErrorIs(t, err, ErrJWTSetURLMustHaveHTTPSScheme)
+}
+
+func TestValidate_RejectsInvalidExpectClaims(t *testing.T) {
+	s := &AuthService{Cfg: &setting.Cfg{}}
+
+	err := s.Validate(context.Background(), models.SSOSettings{
+		Settings: map[string]any{
+			"enabled":       true,
+			"header_name":   "X-JWT",
+			"jwk_set_url":   "https://example.com/.well-known/jwks.json",
+			"expect_claims": "{not-json",
+		},
+	}, models.SSOSettings{}, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "expect_claims")
+}
+
+func TestValidate_RejectsInvalidExpectClaimTypes(t *testing.T) {
+	s := &AuthService{Cfg: &setting.Cfg{}}
+
+	err := s.Validate(context.Background(), models.SSOSettings{
+		Settings: map[string]any{
+			"enabled":       true,
+			"header_name":   "X-JWT",
+			"jwk_set_url":   "https://example.com/.well-known/jwks.json",
+			"expect_claims": `{"iss": 123}`,
+		},
+	}, models.SSOSettings{}, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "expect_claims")
+}
+
+func TestReload_DisabledClearsKeyset(t *testing.T) {
+	s := &AuthService{Cfg: &setting.Cfg{}, log: log.New("test")}
+
+	err := s.Reload(context.Background(), models.SSOSettings{
+		Settings: map[string]any{"enabled": false},
+	})
+	require.NoError(t, err)
+	require.False(t, s.Settings().Enabled)
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	require.Nil(t, s.keySet)
+}
+
+func TestReload_EmptyExpectClaims(t *testing.T) {
+	s := &AuthService{Cfg: &setting.Cfg{}, log: log.New("test")}
+
+	err := s.Reload(context.Background(), models.SSOSettings{
+		Settings: map[string]any{
+			"enabled":       true,
+			"header_name":   "X-JWT",
+			"jwk_set_url":   "https://example.com/.well-known/jwks.json",
+			"expect_claims": "",
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, s.Settings().Enabled)
+}
+
+func TestProvideService_ReloadFailureFallsBackToConfigFile(t *testing.T) {
+	cfg := setting.NewCfg()
+	cfg.JWTAuth = setting.AuthJWTSettings{Enabled: false, HeaderName: "X-Config-File-JWT"}
+
+	ssoSettings := &ssosettingstests.FakeService{
+		ExpectedReloadablesRegistry: map[string]ssosettings.Reloadable{},
+		ExpectedSSOSetting: &models.SSOSettings{
+			Settings: map[string]any{
+				"enabled":       true,
+				"header_name":   "X-SSO-JWT",
+				"expect_claims": "{not-json",
+			},
+		},
+	}
+
+	s, err := ProvideService(cfg, nil, ssoSettings)
+	require.NoError(t, err)
+	require.Equal(t, "X-Config-File-JWT", s.Settings().HeaderName)
+	require.False(t, s.Settings().Enabled)
+}
+
+// TestReload_RaceWithVerify exercises Verify against concurrent Reload calls
+// under -race. The mutex contract on AuthService is what keeps Verify's
+// snapshot of keySet/expect/expectRegistered consistent — this test exists to
+// catch any future change that breaks that invariant.
+func TestReload_RaceWithVerify(t *testing.T) {
+	s := &AuthService{Cfg: &setting.Cfg{}, log: log.New("test")}
+
+	disabled := models.SSOSettings{Settings: map[string]any{"enabled": false}}
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				_ = s.Reload(context.Background(), disabled)
+			}
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				// Verify will return an error (no keyset configured) but must
+				// not race or panic against the concurrent Reload.
+				_, _ = s.Verify(context.Background(), "not.a.token")
+			}
+		}
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+}

--- a/pkg/services/auth/jwt/sso_settings.go
+++ b/pkg/services/auth/jwt/sso_settings.go
@@ -1,0 +1,155 @@
+package jwt
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/grafana/grafana/pkg/login/social/connectors"
+	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/util"
+)
+
+// jwtField is a single SSO setting key paired with how to project it to and
+// from setting.AuthJWTSettings. The set of fields lives in jwtFields() so the
+// SSO settings strategy and the reload-from-map path read the same source of
+// truth.
+type jwtField struct {
+	key string
+	get func(s *setting.AuthJWTSettings) any
+	set func(s *setting.AuthJWTSettings, v any) error
+}
+
+func stringField(key string, ptr func(*setting.AuthJWTSettings) *string) jwtField {
+	return jwtField{
+		key: key,
+		get: func(s *setting.AuthJWTSettings) any { return *ptr(s) },
+		set: func(s *setting.AuthJWTSettings, v any) error {
+			if v == nil {
+				return nil
+			}
+			out, ok := v.(string)
+			if !ok {
+				return fmt.Errorf("%s: expected string, got %T", key, v)
+			}
+			*ptr(s) = out
+			return nil
+		},
+	}
+}
+
+func boolField(key string, ptr func(*setting.AuthJWTSettings) *bool) jwtField {
+	return jwtField{
+		key: key,
+		get: func(s *setting.AuthJWTSettings) any { return *ptr(s) },
+		set: func(s *setting.AuthJWTSettings, v any) error {
+			*ptr(s) = connectors.MustBool(v, *ptr(s))
+			return nil
+		},
+	}
+}
+
+func jwtFields() []jwtField {
+	return []jwtField{
+		boolField("enabled", func(s *setting.AuthJWTSettings) *bool { return &s.Enabled }),
+		stringField("header_name", func(s *setting.AuthJWTSettings) *string { return &s.HeaderName }),
+		boolField("url_login", func(s *setting.AuthJWTSettings) *bool { return &s.URLLogin }),
+		stringField("email_claim", func(s *setting.AuthJWTSettings) *string { return &s.EmailClaim }),
+		stringField("username_claim", func(s *setting.AuthJWTSettings) *string { return &s.UsernameClaim }),
+		stringField("expect_claims", func(s *setting.AuthJWTSettings) *string { return &s.ExpectClaims }),
+		stringField("jwk_set_url", func(s *setting.AuthJWTSettings) *string { return &s.JWKSetURL }),
+		stringField("jwk_set_file", func(s *setting.AuthJWTSettings) *string { return &s.JWKSetFile }),
+		stringField("jwk_set_value", func(s *setting.AuthJWTSettings) *string { return &s.JWKSetValue }),
+		stringField("jwk_set_bearer_token_file", func(s *setting.AuthJWTSettings) *string { return &s.JWKSetBearerTokenFile }),
+		stringField("key_file", func(s *setting.AuthJWTSettings) *string { return &s.KeyFile }),
+		stringField("key_value", func(s *setting.AuthJWTSettings) *string { return &s.KeyValue }),
+		stringField("key_id", func(s *setting.AuthJWTSettings) *string { return &s.KeyID }),
+		{
+			key: "cache_ttl",
+			get: func(s *setting.AuthJWTSettings) any { return s.CacheTTL.String() },
+			set: func(s *setting.AuthJWTSettings, v any) error {
+				if v == nil {
+					return nil
+				}
+				str, ok := v.(string)
+				if !ok {
+					return fmt.Errorf("cache_ttl: expected string, got %T", v)
+				}
+				if str == "" {
+					return nil
+				}
+				d, err := time.ParseDuration(str)
+				if err != nil {
+					return fmt.Errorf("invalid cache_ttl: %w", err)
+				}
+				s.CacheTTL = d
+				return nil
+			},
+		},
+		boolField("auto_sign_up", func(s *setting.AuthJWTSettings) *bool { return &s.AutoSignUp }),
+		stringField("role_attribute_path", func(s *setting.AuthJWTSettings) *string { return &s.RoleAttributePath }),
+		boolField("role_attribute_strict", func(s *setting.AuthJWTSettings) *bool { return &s.RoleAttributeStrict }),
+		boolField("allow_assign_grafana_admin", func(s *setting.AuthJWTSettings) *bool { return &s.AllowAssignGrafanaAdmin }),
+		boolField("skip_org_role_sync", func(s *setting.AuthJWTSettings) *bool { return &s.SkipOrgRoleSync }),
+		stringField("groups_attribute_path", func(s *setting.AuthJWTSettings) *string { return &s.GroupsAttributePath }),
+		stringField("email_attribute_path", func(s *setting.AuthJWTSettings) *string { return &s.EmailAttributePath }),
+		stringField("username_attribute_path", func(s *setting.AuthJWTSettings) *string { return &s.UsernameAttributePath }),
+		stringField("org_attribute_path", func(s *setting.AuthJWTSettings) *string { return &s.OrgAttributePath }),
+		{
+			key: "org_mapping",
+			get: func(s *setting.AuthJWTSettings) any { return strings.Join(s.OrgMapping, ",") },
+			set: func(s *setting.AuthJWTSettings, v any) error {
+				if v == nil {
+					return nil
+				}
+				str, ok := v.(string)
+				if !ok {
+					return fmt.Errorf("org_mapping: expected string, got %T", v)
+				}
+				s.OrgMapping = util.SplitString(str)
+				return nil
+			},
+		},
+		stringField("tls_client_ca", func(s *setting.AuthJWTSettings) *string { return &s.TlsClientCa }),
+		boolField("tls_skip_verify_insecure", func(s *setting.AuthJWTSettings) *bool { return &s.TlsSkipVerify }),
+	}
+}
+
+// defaultSettings returns a struct pre-populated with the defaults that
+// setting/setting_jwt.go applies when reading from the ini file.
+func defaultSettings() setting.AuthJWTSettings {
+	return setting.AuthJWTSettings{
+		ExpectClaims: "{}",
+		CacheTTL:     time.Hour,
+	}
+}
+
+// SettingsToMap projects an AuthJWTSettings struct into the map shape used by
+// the SSO settings API (read path).
+func SettingsToMap(s setting.AuthJWTSettings) map[string]any {
+	fields := jwtFields()
+	m := make(map[string]any, len(fields))
+	for _, f := range fields {
+		m[f.key] = f.get(&s)
+	}
+	return m
+}
+
+// SettingsFromMap converts an SSO settings map back into AuthJWTSettings.
+// Missing keys retain their default values.
+func SettingsFromMap(m map[string]any) (setting.AuthJWTSettings, error) {
+	out := defaultSettings()
+	if m == nil {
+		return out, nil
+	}
+	for _, f := range jwtFields() {
+		v, ok := m[f.key]
+		if !ok {
+			continue
+		}
+		if err := f.set(&out, v); err != nil {
+			return setting.AuthJWTSettings{}, err
+		}
+	}
+	return out, nil
+}

--- a/pkg/services/auth/jwt/validation.go
+++ b/pkg/services/auth/jwt/validation.go
@@ -9,50 +9,59 @@ import (
 	"github.com/go-jose/go-jose/v4/jwt"
 )
 
-func (s *AuthService) initClaimExpectations() error {
-	if err := json.Unmarshal([]byte(s.Cfg.JWTAuth.ExpectClaims), &s.expect); err != nil {
-		return err
+// parseClaimExpectations parses the expect_claims JSON into the free-form claim
+// map and the registered-claim expectations, validating the types of the
+// registered claims (iss/sub/aud). An empty input yields empty expectations.
+func parseClaimExpectations(raw string) (map[string]any, jwt.Expected, error) {
+	if raw == "" {
+		return map[string]any{}, jwt.Expected{}, nil
 	}
 
-	for key, value := range s.expect {
+	expect := map[string]any{}
+	if err := json.Unmarshal([]byte(raw), &expect); err != nil {
+		return nil, jwt.Expected{}, err
+	}
+
+	var expectRegistered jwt.Expected
+	for key, value := range expect {
 		switch key {
 		case "iss":
 			if stringValue, ok := value.(string); ok {
-				s.expectRegistered.Issuer = stringValue
+				expectRegistered.Issuer = stringValue
 			} else {
-				return fmt.Errorf("%q expectation has invalid type %T, string expected", key, value)
+				return nil, jwt.Expected{}, fmt.Errorf("%q expectation has invalid type %T, string expected", key, value)
 			}
-			delete(s.expect, key)
+			delete(expect, key)
 		case "sub":
 			if stringValue, ok := value.(string); ok {
-				s.expectRegistered.Subject = stringValue
+				expectRegistered.Subject = stringValue
 			} else {
-				return fmt.Errorf("%q expectation has invalid type %T, string expected", key, value)
+				return nil, jwt.Expected{}, fmt.Errorf("%q expectation has invalid type %T, string expected", key, value)
 			}
-			delete(s.expect, key)
+			delete(expect, key)
 		case "aud":
 			switch value := value.(type) {
 			case []any:
 				for _, val := range value {
 					if v, ok := val.(string); ok {
-						s.expectRegistered.AnyAudience = append(s.expectRegistered.AnyAudience, v)
+						expectRegistered.AnyAudience = append(expectRegistered.AnyAudience, v)
 					} else {
-						return fmt.Errorf("%q expectation contains value with invalid type %T, string expected", key, val)
+						return nil, jwt.Expected{}, fmt.Errorf("%q expectation contains value with invalid type %T, string expected", key, val)
 					}
 				}
 			case string:
-				s.expectRegistered.AnyAudience = []string{value}
+				expectRegistered.AnyAudience = []string{value}
 			default:
-				return fmt.Errorf("%q expectation has invalid type %T, array or string expected", key, value)
+				return nil, jwt.Expected{}, fmt.Errorf("%q expectation has invalid type %T, array or string expected", key, value)
 			}
-			delete(s.expect, key)
+			delete(expect, key)
 		}
 	}
 
-	return nil
+	return expect, expectRegistered, nil
 }
 
-func (s *AuthService) validateClaims(claims map[string]any) error {
+func validateClaims(claims map[string]any, expect map[string]any, expectRegistered jwt.Expected) error {
 	var registeredClaims jwt.Claims
 	for key, value := range claims {
 		switch key {
@@ -116,13 +125,12 @@ func (s *AuthService) validateClaims(claims map[string]any) error {
 		}
 	}
 
-	expectRegistered := s.expectRegistered
 	expectRegistered.Time = time.Now()
 	if err := registeredClaims.Validate(expectRegistered); err != nil {
 		return err
 	}
 
-	for key, expected := range s.expect {
+	for key, expected := range expect {
 		value, ok := claims[key]
 		if !ok {
 			return fmt.Errorf("%q claim is missing", key)

--- a/pkg/services/authn/authnimpl/registration.go
+++ b/pkg/services/authn/authnimpl/registration.go
@@ -94,10 +94,10 @@ func ProvideRegistration(
 		}
 	}
 
-	if cfg.JWTAuth.Enabled {
-		orgRoleMapper := connectors.ProvideOrgRoleMapper(cfg, orgService)
-		authnSvc.RegisterClient(clients.ProvideJWT(jwtService, orgRoleMapper, cfg, tracer))
-	}
+	// Registered unconditionally so it can be enabled through the SSO settings
+	// API without a restart; the client gates on the live Enabled() snapshot.
+	orgRoleMapper := connectors.ProvideOrgRoleMapper(cfg, orgService)
+	authnSvc.RegisterClient(clients.ProvideJWT(jwtService, orgRoleMapper, tracer))
 
 	if cfg.ExtJWTAuth.Enabled {
 		authnSvc.RegisterClient(clients.ProvideExtendedJWT(cfg, tracer))

--- a/pkg/services/authn/authnimpl/registration.go
+++ b/pkg/services/authn/authnimpl/registration.go
@@ -93,10 +93,10 @@ func ProvideRegistration(
 		}
 	}
 
-	if cfg.JWTAuth.Enabled {
-		orgRoleMapper := connectors.ProvideOrgRoleMapper(cfgProvider, orgService)
-		authnSvc.RegisterClient(clients.ProvideJWT(jwtService, orgRoleMapper, cfg, tracer))
-	}
+	// Registered unconditionally so it can be enabled through the SSO settings
+	// API without a restart; the client gates on the live Enabled() snapshot.
+	orgRoleMapper := connectors.ProvideOrgRoleMapper(cfgProvider, orgService)
+	authnSvc.RegisterClient(clients.ProvideJWT(jwtService, orgRoleMapper, tracer))
 
 	if cfg.ExtJWTAuth.Enabled {
 		authnSvc.RegisterClient(clients.ProvideExtendedJWT(cfg, tracer))

--- a/pkg/services/authn/clients/jwt.go
+++ b/pkg/services/authn/clients/jwt.go
@@ -32,24 +32,32 @@ var (
 		"jwt.invalid_role", errutil.WithPublicMessage("Invalid Role in claim"))
 )
 
-func ProvideJWT(jwtService auth.JWTVerifierService, orgRoleMapper *connectors.OrgRoleMapper, cfg *setting.Cfg, tracer trace.Tracer) *JWT {
+func ProvideJWT(jwtService auth.JWTVerifierService, orgRoleMapper *connectors.OrgRoleMapper, tracer trace.Tracer) *JWT {
 	return &JWT{
-		cfg:           cfg,
 		log:           log.New(authn.ClientJWT),
 		jwtService:    jwtService,
 		orgRoleMapper: orgRoleMapper,
-		orgMappingCfg: orgRoleMapper.ParseOrgMappingSettings(context.Background(), cfg.JWTAuth.OrgMapping, cfg.JWTAuth.RoleAttributeStrict),
 		tracer:        tracer,
 	}
 }
 
 type JWT struct {
-	cfg           *setting.Cfg
 	orgRoleMapper *connectors.OrgRoleMapper
-	orgMappingCfg connectors.MappingConfiguration
 	log           log.Logger
 	jwtService    auth.JWTVerifierService
 	tracer        trace.Tracer
+}
+
+// settings returns the JWT settings for the current request. It prefers the
+// per-request snapshot frozen on the context (see jwt.WithSettings) so that
+// authentication and outbound header clearing agree even across a concurrent
+// reload, and falls back to the live snapshot when none was frozen (e.g. paths
+// that do not go through the context handler).
+func (s *JWT) settings(ctx context.Context) setting.AuthJWTSettings {
+	if snapshot, ok := authJWT.SettingsFromContext(ctx); ok {
+		return snapshot
+	}
+	return s.jwtService.Settings()
 }
 
 func (s *JWT) Name() string {
@@ -60,8 +68,10 @@ func (s *JWT) Authenticate(ctx context.Context, r *authn.Request) (*authn.Identi
 	ctx, span := s.tracer.Start(ctx, "authn.jwt.Authenticate")
 	defer span.End()
 
-	jwtToken := s.retrieveToken(r.HTTPRequest)
-	s.stripSensitiveParam(r.HTTPRequest)
+	jwtSettings := s.settings(ctx)
+
+	jwtToken := retrieveToken(r.HTTPRequest, jwtSettings)
+	stripSensitiveParam(r.HTTPRequest, jwtSettings)
 
 	claims, err := s.jwtService.Verify(ctx, jwtToken)
 	if err != nil {
@@ -82,28 +92,28 @@ func (s *JWT) Authenticate(ctx context.Context, r *authn.Request) (*authn.Identi
 			SyncUser:        true,
 			FetchSyncedUser: true,
 			SyncPermissions: true,
-			SyncOrgRoles:    !s.cfg.JWTAuth.SkipOrgRoleSync,
-			AllowSignUp:     s.cfg.JWTAuth.AutoSignUp,
-			SyncTeams:       s.cfg.JWTAuth.GroupsAttributePath != "",
+			SyncOrgRoles:    !jwtSettings.SkipOrgRoleSync,
+			AllowSignUp:     jwtSettings.AutoSignUp,
+			SyncTeams:       jwtSettings.GroupsAttributePath != "",
 		},
 	}
 
-	if key := s.cfg.JWTAuth.UsernameClaim; key != "" {
+	if key := jwtSettings.UsernameClaim; key != "" {
 		id.Login, _ = claims[key].(string)
 		id.ClientParams.LookUpParams.Login = &id.Login
-	} else if key := s.cfg.JWTAuth.UsernameAttributePath; key != "" {
-		id.Login, err = util.SearchJSONForStringAttr(s.cfg.JWTAuth.UsernameAttributePath, claims)
+	} else if key := jwtSettings.UsernameAttributePath; key != "" {
+		id.Login, err = util.SearchJSONForStringAttr(key, claims)
 		if err != nil {
 			return nil, err
 		}
 		id.ClientParams.LookUpParams.Login = &id.Login
 	}
 
-	if key := s.cfg.JWTAuth.EmailClaim; key != "" {
+	if key := jwtSettings.EmailClaim; key != "" {
 		id.Email, _ = claims[key].(string)
 		id.ClientParams.LookUpParams.Email = &id.Email
-	} else if key := s.cfg.JWTAuth.EmailAttributePath; key != "" {
-		id.Email, err = util.SearchJSONForStringAttr(s.cfg.JWTAuth.EmailAttributePath, claims)
+	} else if key := jwtSettings.EmailAttributePath; key != "" {
+		id.Email, err = util.SearchJSONForStringAttr(key, claims)
 		if err != nil {
 			return nil, err
 		}
@@ -114,26 +124,29 @@ func (s *JWT) Authenticate(ctx context.Context, r *authn.Request) (*authn.Identi
 		id.Name = name
 	}
 
-	id.ExternalGroups, err = s.extractGroups(claims)
+	id.ExternalGroups, err = extractGroups(claims, jwtSettings)
 	if err != nil {
 		return nil, err
 	}
 
-	if !s.cfg.JWTAuth.SkipOrgRoleSync {
-		role, grafanaAdmin := s.extractRoleAndAdmin(claims)
+	if !jwtSettings.SkipOrgRoleSync {
+		role, grafanaAdmin := extractRoleAndAdmin(claims, jwtSettings)
 
-		if s.cfg.JWTAuth.AllowAssignGrafanaAdmin {
+		if jwtSettings.AllowAssignGrafanaAdmin {
 			id.IsGrafanaAdmin = &grafanaAdmin
 		}
 
-		externalOrgs, err := s.extractOrgs(claims)
+		externalOrgs, err := extractOrgs(claims, jwtSettings)
 		if err != nil {
 			s.log.Warn("Failed to extract orgs", "err", err)
 			return nil, err
 		}
 
-		id.OrgRoles = s.orgRoleMapper.MapOrgRoles(s.orgMappingCfg, externalOrgs, role)
-		if s.cfg.JWTAuth.RoleAttributeStrict && len(id.OrgRoles) == 0 {
+		// Org mapping is parsed per-call so changes pushed via the SSO settings
+		// API take effect at the next authentication.
+		orgMappingCfg := s.orgRoleMapper.ParseOrgMappingSettings(ctx, jwtSettings.OrgMapping, jwtSettings.RoleAttributeStrict)
+		id.OrgRoles = s.orgRoleMapper.MapOrgRoles(orgMappingCfg, externalOrgs, role)
+		if jwtSettings.RoleAttributeStrict && len(id.OrgRoles) == 0 {
 			return nil, errJWTInvalidRole.Errorf("could not evaluate any valid roles using IdP provided data")
 		}
 	}
@@ -148,13 +161,13 @@ func (s *JWT) Authenticate(ctx context.Context, r *authn.Request) (*authn.Identi
 }
 
 func (s *JWT) IsEnabled() bool {
-	return s.cfg.JWTAuth.Enabled
+	return s.jwtService.Settings().Enabled
 }
 
-// remove sensitive query param
-// avoid JWT URL login passing auth_token in URL
-func (s *JWT) stripSensitiveParam(httpRequest *http.Request) {
-	if s.cfg.JWTAuth.URLLogin {
+// stripSensitiveParam removes the auth_token query parameter when URL login is
+// enabled, so it doesn't leak into logs or metrics.
+func stripSensitiveParam(httpRequest *http.Request, settings setting.AuthJWTSettings) {
+	if settings.URLLogin {
 		params := httpRequest.URL.Query()
 		if params.Has(authQueryParamName) {
 			params.Del(authQueryParamName)
@@ -164,9 +177,9 @@ func (s *JWT) stripSensitiveParam(httpRequest *http.Request) {
 }
 
 // retrieveToken retrieves the JWT token from the request.
-func (s *JWT) retrieveToken(httpRequest *http.Request) string {
-	jwtToken := httpRequest.Header.Get(s.cfg.JWTAuth.HeaderName)
-	if jwtToken == "" && s.cfg.JWTAuth.URLLogin {
+func retrieveToken(httpRequest *http.Request, settings setting.AuthJWTSettings) string {
+	jwtToken := httpRequest.Header.Get(settings.HeaderName)
+	if jwtToken == "" && settings.URLLogin {
 		jwtToken = httpRequest.URL.Query().Get("auth_token")
 	}
 	// Strip the 'Bearer' prefix if it exists.
@@ -174,11 +187,12 @@ func (s *JWT) retrieveToken(httpRequest *http.Request) string {
 }
 
 func (s *JWT) Test(ctx context.Context, r *authn.Request) bool {
-	if !s.cfg.JWTAuth.Enabled || s.cfg.JWTAuth.HeaderName == "" {
+	jwtSettings := s.settings(ctx)
+	if !jwtSettings.Enabled || (jwtSettings.HeaderName == "" && !jwtSettings.URLLogin) {
 		return false
 	}
 
-	jwtToken := s.retrieveToken(r.HTTPRequest)
+	jwtToken := retrieveToken(r.HTTPRequest, jwtSettings)
 
 	if jwtToken == "" {
 		return false
@@ -198,12 +212,12 @@ func (s *JWT) Priority() uint {
 
 const roleGrafanaAdmin = "GrafanaAdmin"
 
-func (s *JWT) extractRoleAndAdmin(claims map[string]any) (org.RoleType, bool) {
-	if s.cfg.JWTAuth.RoleAttributePath == "" {
+func extractRoleAndAdmin(claims map[string]any, settings setting.AuthJWTSettings) (org.RoleType, bool) {
+	if settings.RoleAttributePath == "" {
 		return "", false
 	}
 
-	role, err := util.SearchJSONForStringAttr(s.cfg.JWTAuth.RoleAttributePath, claims)
+	role, err := util.SearchJSONForStringAttr(settings.RoleAttributePath, claims)
 	if err != nil || role == "" {
 		return "", false
 	}
@@ -214,19 +228,19 @@ func (s *JWT) extractRoleAndAdmin(claims map[string]any) (org.RoleType, bool) {
 	return org.RoleType(role), false
 }
 
-func (s *JWT) extractGroups(claims map[string]any) ([]string, error) {
-	if s.cfg.JWTAuth.GroupsAttributePath == "" {
+func extractGroups(claims map[string]any, settings setting.AuthJWTSettings) ([]string, error) {
+	if settings.GroupsAttributePath == "" {
 		return []string{}, nil
 	}
 
-	return util.SearchJSONForStringSliceAttr(s.cfg.JWTAuth.GroupsAttributePath, claims)
+	return util.SearchJSONForStringSliceAttr(settings.GroupsAttributePath, claims)
 }
 
 // This code was copied from the social_base.go file and was adapted to match with the JWT structure
-func (s *JWT) extractOrgs(claims map[string]any) ([]string, error) {
-	if s.cfg.JWTAuth.OrgAttributePath == "" {
+func extractOrgs(claims map[string]any, settings setting.AuthJWTSettings) ([]string, error) {
+	if settings.OrgAttributePath == "" {
 		return []string{}, nil
 	}
 
-	return util.SearchJSONForStringSliceAttr(s.cfg.JWTAuth.OrgAttributePath, claims)
+	return util.SearchJSONForStringSliceAttr(settings.OrgAttributePath, claims)
 }

--- a/pkg/services/authn/clients/jwt.go
+++ b/pkg/services/authn/clients/jwt.go
@@ -33,24 +33,32 @@ var (
 		"jwt.invalid_role", errutil.WithPublicMessage("Invalid Role in claim"))
 )
 
-func ProvideJWT(jwtService auth.JWTVerifierService, orgRoleMapper *connectors.OrgRoleMapper, cfg *setting.Cfg, tracer trace.Tracer) *JWT {
+func ProvideJWT(jwtService auth.JWTVerifierService, orgRoleMapper *connectors.OrgRoleMapper, tracer trace.Tracer) *JWT {
 	return &JWT{
-		cfg:           cfg,
 		log:           log.New(authn.ClientJWT),
 		jwtService:    jwtService,
 		orgRoleMapper: orgRoleMapper,
-		orgMappingCfg: orgRoleMapper.ParseOrgMappingSettings(context.Background(), cfg.JWTAuth.OrgMapping, cfg.JWTAuth.RoleAttributeStrict),
 		tracer:        tracer,
 	}
 }
 
 type JWT struct {
-	cfg           *setting.Cfg
 	orgRoleMapper *connectors.OrgRoleMapper
-	orgMappingCfg connectors.MappingConfiguration
 	log           log.Logger
 	jwtService    auth.JWTVerifierService
 	tracer        trace.Tracer
+}
+
+// settings returns the JWT settings for the current request. It prefers the
+// per-request snapshot frozen on the context (see jwt.WithSettings) so that
+// authentication and outbound header clearing agree even across a concurrent
+// reload, and falls back to the live snapshot when none was frozen (e.g. paths
+// that do not go through the context handler).
+func (s *JWT) settings(ctx context.Context) setting.AuthJWTSettings {
+	if snapshot, ok := authJWT.SettingsFromContext(ctx); ok {
+		return snapshot
+	}
+	return s.jwtService.Settings()
 }
 
 func (s *JWT) Name() string {
@@ -61,8 +69,10 @@ func (s *JWT) Authenticate(ctx context.Context, r *authn.Request) (*authn.Identi
 	ctx, span := s.tracer.Start(ctx, "authn.jwt.Authenticate")
 	defer span.End()
 
-	jwtToken := s.retrieveToken(r.HTTPRequest)
-	s.stripSensitiveParam(r.HTTPRequest)
+	jwtSettings := s.settings(ctx)
+
+	jwtToken := retrieveToken(r.HTTPRequest, jwtSettings)
+	stripSensitiveParam(r.HTTPRequest, jwtSettings)
 
 	claims, err := s.jwtService.Verify(ctx, jwtToken)
 	if err != nil {
@@ -84,28 +94,28 @@ func (s *JWT) Authenticate(ctx context.Context, r *authn.Request) (*authn.Identi
 			SyncUser:        true,
 			FetchSyncedUser: true,
 			SyncPermissions: true,
-			SyncOrgRoles:    !s.cfg.JWTAuth.SkipOrgRoleSync,
-			AllowSignUp:     s.cfg.JWTAuth.AutoSignUp,
-			SyncTeams:       s.cfg.JWTAuth.GroupsAttributePath != "",
+			SyncOrgRoles:    !jwtSettings.SkipOrgRoleSync,
+			AllowSignUp:     jwtSettings.AutoSignUp,
+			SyncTeams:       jwtSettings.GroupsAttributePath != "",
 		},
 	}
 
-	if key := s.cfg.JWTAuth.UsernameClaim; key != "" {
+	if key := jwtSettings.UsernameClaim; key != "" {
 		id.Login, _ = claims[key].(string)
 		id.ClientParams.LookUpParams.Login = &id.Login
-	} else if key := s.cfg.JWTAuth.UsernameAttributePath; key != "" {
-		id.Login, err = util.SearchJSONForStringAttr(s.cfg.JWTAuth.UsernameAttributePath, claims)
+	} else if key := jwtSettings.UsernameAttributePath; key != "" {
+		id.Login, err = util.SearchJSONForStringAttr(key, claims)
 		if err != nil {
 			return nil, err
 		}
 		id.ClientParams.LookUpParams.Login = &id.Login
 	}
 
-	if key := s.cfg.JWTAuth.EmailClaim; key != "" {
+	if key := jwtSettings.EmailClaim; key != "" {
 		id.Email, _ = claims[key].(string)
 		id.ClientParams.LookUpParams.Email = &id.Email
-	} else if key := s.cfg.JWTAuth.EmailAttributePath; key != "" {
-		id.Email, err = util.SearchJSONForStringAttr(s.cfg.JWTAuth.EmailAttributePath, claims)
+	} else if key := jwtSettings.EmailAttributePath; key != "" {
+		id.Email, err = util.SearchJSONForStringAttr(key, claims)
 		if err != nil {
 			return nil, err
 		}
@@ -116,29 +126,32 @@ func (s *JWT) Authenticate(ctx context.Context, r *authn.Request) (*authn.Identi
 		id.Name = name
 	}
 
-	id.ExternalGroups, err = s.extractGroups(claims)
+	id.ExternalGroups, err = extractGroups(claims, jwtSettings)
 	if err != nil {
 		return nil, err
 	}
 
-	if !s.cfg.JWTAuth.SkipOrgRoleSync {
-		role, grafanaAdmin := s.extractRoleAndAdmin(claims)
+	if !jwtSettings.SkipOrgRoleSync {
+		role, grafanaAdmin := extractRoleAndAdmin(claims, jwtSettings)
 
-		if s.cfg.JWTAuth.AllowAssignGrafanaAdmin {
+		if jwtSettings.AllowAssignGrafanaAdmin {
 			id.IsGrafanaAdmin = &grafanaAdmin
 		}
 
-		externalOrgs, err := s.extractOrgs(claims)
+		externalOrgs, err := extractOrgs(claims, jwtSettings)
 		if err != nil {
 			s.log.FromContext(ctx).Warn("Failed to extract orgs", "err", err)
 			return nil, err
 		}
 
-		id.OrgRoles, err = s.orgRoleMapper.MapOrgRolesContext(ctx, s.orgMappingCfg, externalOrgs, role)
+		// Org mapping is parsed per-call so changes pushed via the SSO settings
+		// API take effect at the next authentication.
+		orgMappingCfg := s.orgRoleMapper.ParseOrgMappingSettings(ctx, jwtSettings.OrgMapping, jwtSettings.RoleAttributeStrict)
+		id.OrgRoles, err = s.orgRoleMapper.MapOrgRolesContext(ctx, orgMappingCfg, externalOrgs, role)
 		if err != nil {
 			return nil, fmt.Errorf("map organization roles: %w", err)
 		}
-		if s.cfg.JWTAuth.RoleAttributeStrict && len(id.OrgRoles) == 0 {
+		if jwtSettings.RoleAttributeStrict && len(id.OrgRoles) == 0 {
 			return nil, errJWTInvalidRole.Errorf("could not evaluate any valid roles using IdP provided data")
 		}
 	}
@@ -152,14 +165,14 @@ func (s *JWT) Authenticate(ctx context.Context, r *authn.Request) (*authn.Identi
 	return id, nil
 }
 
-func (s *JWT) IsEnabled(context.Context) bool {
-	return s.cfg.JWTAuth.Enabled
+func (s *JWT) IsEnabled(ctx context.Context) bool {
+	return s.settings(ctx).Enabled
 }
 
-// remove sensitive query param
-// avoid JWT URL login passing auth_token in URL
-func (s *JWT) stripSensitiveParam(httpRequest *http.Request) {
-	if s.cfg.JWTAuth.URLLogin {
+// stripSensitiveParam removes the auth_token query parameter when URL login is
+// enabled, so it doesn't leak into logs or metrics.
+func stripSensitiveParam(httpRequest *http.Request, settings setting.AuthJWTSettings) {
+	if settings.URLLogin {
 		params := httpRequest.URL.Query()
 		if params.Has(authQueryParamName) {
 			params.Del(authQueryParamName)
@@ -169,9 +182,9 @@ func (s *JWT) stripSensitiveParam(httpRequest *http.Request) {
 }
 
 // retrieveToken retrieves the JWT token from the request.
-func (s *JWT) retrieveToken(httpRequest *http.Request) string {
-	jwtToken := httpRequest.Header.Get(s.cfg.JWTAuth.HeaderName)
-	if jwtToken == "" && s.cfg.JWTAuth.URLLogin {
+func retrieveToken(httpRequest *http.Request, settings setting.AuthJWTSettings) string {
+	jwtToken := httpRequest.Header.Get(settings.HeaderName)
+	if jwtToken == "" && settings.URLLogin {
 		jwtToken = httpRequest.URL.Query().Get("auth_token")
 	}
 	// Strip the 'Bearer' prefix if it exists.
@@ -179,11 +192,12 @@ func (s *JWT) retrieveToken(httpRequest *http.Request) string {
 }
 
 func (s *JWT) Test(ctx context.Context, r *authn.Request) bool {
-	if !s.cfg.JWTAuth.Enabled || s.cfg.JWTAuth.HeaderName == "" {
+	jwtSettings := s.settings(ctx)
+	if !jwtSettings.Enabled || (jwtSettings.HeaderName == "" && !jwtSettings.URLLogin) {
 		return false
 	}
 
-	jwtToken := s.retrieveToken(r.HTTPRequest)
+	jwtToken := retrieveToken(r.HTTPRequest, jwtSettings)
 
 	if jwtToken == "" {
 		return false
@@ -203,12 +217,12 @@ func (s *JWT) Priority() uint {
 
 const roleGrafanaAdmin = "GrafanaAdmin"
 
-func (s *JWT) extractRoleAndAdmin(claims map[string]any) (org.RoleType, bool) {
-	if s.cfg.JWTAuth.RoleAttributePath == "" {
+func extractRoleAndAdmin(claims map[string]any, settings setting.AuthJWTSettings) (org.RoleType, bool) {
+	if settings.RoleAttributePath == "" {
 		return "", false
 	}
 
-	role, err := util.SearchJSONForStringAttr(s.cfg.JWTAuth.RoleAttributePath, claims)
+	role, err := util.SearchJSONForStringAttr(settings.RoleAttributePath, claims)
 	if err != nil || role == "" {
 		return "", false
 	}
@@ -219,19 +233,19 @@ func (s *JWT) extractRoleAndAdmin(claims map[string]any) (org.RoleType, bool) {
 	return org.RoleType(role), false
 }
 
-func (s *JWT) extractGroups(claims map[string]any) ([]string, error) {
-	if s.cfg.JWTAuth.GroupsAttributePath == "" {
+func extractGroups(claims map[string]any, settings setting.AuthJWTSettings) ([]string, error) {
+	if settings.GroupsAttributePath == "" {
 		return []string{}, nil
 	}
 
-	return util.SearchJSONForStringSliceAttr(s.cfg.JWTAuth.GroupsAttributePath, claims)
+	return util.SearchJSONForStringSliceAttr(settings.GroupsAttributePath, claims)
 }
 
 // This code was copied from the social_base.go file and was adapted to match with the JWT structure
-func (s *JWT) extractOrgs(claims map[string]any) ([]string, error) {
-	if s.cfg.JWTAuth.OrgAttributePath == "" {
+func extractOrgs(claims map[string]any, settings setting.AuthJWTSettings) ([]string, error) {
+	if settings.OrgAttributePath == "" {
 		return []string{}, nil
 	}
 
-	return util.SearchJSONForStringSliceAttr(s.cfg.JWTAuth.OrgAttributePath, claims)
+	return util.SearchJSONForStringSliceAttr(settings.OrgAttributePath, claims)
 }

--- a/pkg/services/authn/clients/jwt_test.go
+++ b/pkg/services/authn/clients/jwt_test.go
@@ -250,12 +250,13 @@ func TestAuthenticateJWT(t *testing.T) {
 			t.Parallel()
 			jwtService := &jwt.FakeJWTService{
 				VerifyProvider: tc.verifyProvider,
+				SettingsValue:  tc.cfg.JWTAuth,
 			}
 
 			jwtClient := ProvideJWT(jwtService,
 				connectors.ProvideOrgRoleMapper(tc.cfg,
 					&orgtest.FakeOrgService{ExpectedOrgs: []*org.OrgDTO{{ID: 4, Name: "Org4"}, {ID: 5, Name: "Org5"}}}),
-				tc.cfg, tracing.InitializeTracerForTest())
+				tracing.InitializeTracerForTest())
 			validHTTPReq := &http.Request{
 				Header: map[string][]string{
 					jwtHeaderName: {"sample-token"}},
@@ -274,16 +275,14 @@ func TestAuthenticateJWT(t *testing.T) {
 
 func TestJWTClaimConfig(t *testing.T) {
 	t.Parallel()
-	jwtService := &jwt.FakeJWTService{
-		VerifyProvider: func(context.Context, string) (map[string]any, error) {
-			return map[string]any{
-				"sub":                "1234567890",
-				"email":              "eai.doe@cor.po",
-				"preferred_username": "eai-doe",
-				"name":               "Eai Doe",
-				"roles":              "Admin",
-			}, nil
-		},
+	verifyClaims := func(context.Context, string) (map[string]any, error) {
+		return map[string]any{
+			"sub":                "1234567890",
+			"email":              "eai.doe@cor.po",
+			"preferred_username": "eai-doe",
+			"name":               "Eai Doe",
+			"roles":              "Admin",
+		}, nil
 	}
 
 	jwtHeaderName := "X-Forwarded-User"
@@ -371,9 +370,13 @@ func TestJWTClaimConfig(t *testing.T) {
 				Header: map[string][]string{
 					jwtHeaderName: {token}},
 			}
+			jwtService := &jwt.FakeJWTService{
+				VerifyProvider: verifyClaims,
+				SettingsValue:  cfg.JWTAuth,
+			}
 			jwtClient := ProvideJWT(jwtService, connectors.ProvideOrgRoleMapper(cfg,
 				&orgtest.FakeOrgService{ExpectedOrgs: []*org.OrgDTO{{ID: 4, Name: "Org4"}, {ID: 5, Name: "Org5"}}}),
-				cfg, tracing.InitializeTracerForTest())
+				tracing.InitializeTracerForTest())
 			_, err := jwtClient.Authenticate(context.Background(), &authn.Request{
 				OrgID:       1,
 				HTTPRequest: httpReq,
@@ -389,7 +392,6 @@ func TestJWTClaimConfig(t *testing.T) {
 
 func TestJWTTest(t *testing.T) {
 	t.Parallel()
-	jwtService := &jwt.FakeJWTService{}
 	jwtHeaderName := "X-Forwarded-User"
 	// #nosec G101 -- This is dummy/test token
 	validFormatToken := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.XbPfbIHMI6arZ3Y922BhjWgQzWXcXNrz0ogtVhfEd2o"
@@ -483,10 +485,11 @@ func TestJWTTest(t *testing.T) {
 					RoleAttributeStrict:     true,
 				},
 			}
+			jwtService := &jwt.FakeJWTService{SettingsValue: cfg.JWTAuth}
 			jwtClient := ProvideJWT(jwtService,
 				connectors.ProvideOrgRoleMapper(cfg,
 					&orgtest.FakeOrgService{ExpectedOrgs: []*org.OrgDTO{{ID: 4, Name: "Org4"}, {ID: 5, Name: "Org5"}}}),
-				cfg, tracing.InitializeTracerForTest())
+				tracing.InitializeTracerForTest())
 			httpReq := &http.Request{
 				URL: &url.URL{RawQuery: "auth_token=" + tc.token},
 				Header: map[string][]string{
@@ -503,20 +506,32 @@ func TestJWTTest(t *testing.T) {
 	}
 }
 
+func TestJWTUsesRequestScopedSettings(t *testing.T) {
+	// #nosec G101 -- This is a dummy/test token with a non-empty "sub" claim.
+	token := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.XbPfbIHMI6arZ3Y922BhjWgQzWXcXNrz0ogtVhfEd2o"
+
+	cfg := &setting.Cfg{}
+	jwtService := &jwt.FakeJWTService{SettingsValue: setting.AuthJWTSettings{Enabled: true, HeaderName: "X-Service-JWT"}}
+	jwtClient := ProvideJWT(jwtService,
+		connectors.ProvideOrgRoleMapper(cfg, &orgtest.FakeOrgService{}),
+		tracing.InitializeTracerForTest())
+
+	httpReq := &http.Request{Header: http.Header{}}
+	httpReq.Header.Set("X-Ctx-JWT", token)
+	req := &authn.Request{HTTPRequest: httpReq}
+
+	// Without a request-scoped snapshot the live service header (X-Service-JWT) is
+	// used, so the token carried in X-Ctx-JWT is not found.
+	require.False(t, jwtClient.Test(context.Background(), req))
+
+	// A snapshot on the context overrides the header name, so the same request
+	// authenticates against X-Ctx-JWT.
+	ctx := jwt.WithSettings(context.Background(), setting.AuthJWTSettings{Enabled: true, HeaderName: "X-Ctx-JWT"})
+	require.True(t, jwtClient.Test(ctx, req))
+}
+
 func TestJWTStripParam(t *testing.T) {
 	t.Parallel()
-	jwtService := &jwt.FakeJWTService{
-		VerifyProvider: func(context.Context, string) (map[string]any, error) {
-			return map[string]any{
-				"sub":                "1234567890",
-				"email":              "eai.doe@cor.po",
-				"preferred_username": "eai-doe",
-				"name":               "Eai Doe",
-				"roles":              "Admin",
-			}, nil
-		},
-	}
-
 	jwtHeaderName := "X-Forwarded-User"
 
 	cfg := &setting.Cfg{
@@ -533,6 +548,19 @@ func TestJWTStripParam(t *testing.T) {
 		},
 	}
 
+	jwtService := &jwt.FakeJWTService{
+		VerifyProvider: func(context.Context, string) (map[string]any, error) {
+			return map[string]any{
+				"sub":                "1234567890",
+				"email":              "eai.doe@cor.po",
+				"preferred_username": "eai-doe",
+				"name":               "Eai Doe",
+				"roles":              "Admin",
+			}, nil
+		},
+		SettingsValue: cfg.JWTAuth,
+	}
+
 	// #nosec G101 -- This is a dummy/test token
 	token := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.XbPfbIHMI6arZ3Y922BhjWgQzWXcXNrz0ogtVhfEd2o"
 
@@ -542,7 +570,7 @@ func TestJWTStripParam(t *testing.T) {
 	jwtClient := ProvideJWT(jwtService,
 		connectors.ProvideOrgRoleMapper(cfg,
 			&orgtest.FakeOrgService{ExpectedOrgs: []*org.OrgDTO{{ID: 4, Name: "Org4"}, {ID: 5, Name: "Org5"}}}),
-		cfg, tracing.InitializeTracerForTest())
+		tracing.InitializeTracerForTest())
 	_, err := jwtClient.Authenticate(context.Background(), &authn.Request{
 		OrgID:       1,
 		HTTPRequest: httpReq,
@@ -596,12 +624,13 @@ func TestJWTSubClaimsConfig(t *testing.T) {
 		VerifyProvider: func(context.Context, string) (map[string]any, error) {
 			return response, nil
 		},
+		SettingsValue: cfg.JWTAuth,
 	}
 
 	jwtClient := ProvideJWT(jwtService,
 		connectors.ProvideOrgRoleMapper(cfg,
 			&orgtest.FakeOrgService{ExpectedOrgs: []*org.OrgDTO{{ID: 4, Name: "Org4"}, {ID: 5, Name: "Org5"}}}),
-		cfg, tracing.InitializeTracerForTest())
+		tracing.InitializeTracerForTest())
 	identity, err := jwtClient.Authenticate(context.Background(), &authn.Request{
 		OrgID:       1,
 		HTTPRequest: httpReq,

--- a/pkg/services/authn/clients/jwt_test.go
+++ b/pkg/services/authn/clients/jwt_test.go
@@ -250,12 +250,13 @@ func TestAuthenticateJWT(t *testing.T) {
 			t.Parallel()
 			jwtService := &jwt.FakeJWTService{
 				VerifyProvider: tc.verifyProvider,
+				SettingsValue:  tc.cfg.JWTAuth,
 			}
 
 			jwtClient := ProvideJWT(jwtService,
 				connectors.ProvideOrgRoleMapper(testConfigProvider(t, tc.cfg),
 					&orgtest.FakeOrgService{ExpectedOrgs: []*org.OrgDTO{{ID: 4, Name: "Org4"}, {ID: 5, Name: "Org5"}}}),
-				tc.cfg, tracing.InitializeTracerForTest())
+				tracing.InitializeTracerForTest())
 			validHTTPReq := &http.Request{
 				Header: map[string][]string{
 					jwtHeaderName: {"sample-token"}},
@@ -274,16 +275,14 @@ func TestAuthenticateJWT(t *testing.T) {
 
 func TestJWTClaimConfig(t *testing.T) {
 	t.Parallel()
-	jwtService := &jwt.FakeJWTService{
-		VerifyProvider: func(context.Context, string) (map[string]any, error) {
-			return map[string]any{
-				"sub":                "1234567890",
-				"email":              "eai.doe@cor.po",
-				"preferred_username": "eai-doe",
-				"name":               "Eai Doe",
-				"roles":              "Admin",
-			}, nil
-		},
+	verifyClaims := func(context.Context, string) (map[string]any, error) {
+		return map[string]any{
+			"sub":                "1234567890",
+			"email":              "eai.doe@cor.po",
+			"preferred_username": "eai-doe",
+			"name":               "Eai Doe",
+			"roles":              "Admin",
+		}, nil
 	}
 
 	jwtHeaderName := "X-Forwarded-User"
@@ -371,9 +370,13 @@ func TestJWTClaimConfig(t *testing.T) {
 				Header: map[string][]string{
 					jwtHeaderName: {token}},
 			}
+			jwtService := &jwt.FakeJWTService{
+				VerifyProvider: verifyClaims,
+				SettingsValue:  cfg.JWTAuth,
+			}
 			jwtClient := ProvideJWT(jwtService, connectors.ProvideOrgRoleMapper(testConfigProvider(t, cfg),
 				&orgtest.FakeOrgService{ExpectedOrgs: []*org.OrgDTO{{ID: 4, Name: "Org4"}, {ID: 5, Name: "Org5"}}}),
-				cfg, tracing.InitializeTracerForTest())
+				tracing.InitializeTracerForTest())
 			_, err := jwtClient.Authenticate(context.Background(), &authn.Request{
 				OrgID:       1,
 				HTTPRequest: httpReq,
@@ -389,7 +392,6 @@ func TestJWTClaimConfig(t *testing.T) {
 
 func TestJWTTest(t *testing.T) {
 	t.Parallel()
-	jwtService := &jwt.FakeJWTService{}
 	jwtHeaderName := "X-Forwarded-User"
 	// #nosec G101 -- This is dummy/test token
 	validFormatToken := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.XbPfbIHMI6arZ3Y922BhjWgQzWXcXNrz0ogtVhfEd2o"
@@ -483,10 +485,11 @@ func TestJWTTest(t *testing.T) {
 					RoleAttributeStrict:     true,
 				},
 			}
+			jwtService := &jwt.FakeJWTService{SettingsValue: cfg.JWTAuth}
 			jwtClient := ProvideJWT(jwtService,
 				connectors.ProvideOrgRoleMapper(testConfigProvider(t, cfg),
 					&orgtest.FakeOrgService{ExpectedOrgs: []*org.OrgDTO{{ID: 4, Name: "Org4"}, {ID: 5, Name: "Org5"}}}),
-				cfg, tracing.InitializeTracerForTest())
+				tracing.InitializeTracerForTest())
 			httpReq := &http.Request{
 				URL: &url.URL{RawQuery: "auth_token=" + tc.token},
 				Header: map[string][]string{
@@ -503,20 +506,32 @@ func TestJWTTest(t *testing.T) {
 	}
 }
 
+func TestJWTUsesRequestScopedSettings(t *testing.T) {
+	// #nosec G101 -- This is a dummy/test token with a non-empty "sub" claim.
+	token := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.XbPfbIHMI6arZ3Y922BhjWgQzWXcXNrz0ogtVhfEd2o"
+
+	cfg := &setting.Cfg{}
+	jwtService := &jwt.FakeJWTService{SettingsValue: setting.AuthJWTSettings{Enabled: true, HeaderName: "X-Service-JWT"}}
+	jwtClient := ProvideJWT(jwtService,
+		connectors.ProvideOrgRoleMapper(testConfigProvider(t, cfg), &orgtest.FakeOrgService{}),
+		tracing.InitializeTracerForTest())
+
+	httpReq := &http.Request{Header: http.Header{}}
+	httpReq.Header.Set("X-Ctx-JWT", token)
+	req := &authn.Request{HTTPRequest: httpReq}
+
+	// Without a request-scoped snapshot the live service header (X-Service-JWT) is
+	// used, so the token carried in X-Ctx-JWT is not found.
+	require.False(t, jwtClient.Test(context.Background(), req))
+
+	// A snapshot on the context overrides the header name, so the same request
+	// authenticates against X-Ctx-JWT.
+	ctx := jwt.WithSettings(context.Background(), setting.AuthJWTSettings{Enabled: true, HeaderName: "X-Ctx-JWT"})
+	require.True(t, jwtClient.Test(ctx, req))
+}
+
 func TestJWTStripParam(t *testing.T) {
 	t.Parallel()
-	jwtService := &jwt.FakeJWTService{
-		VerifyProvider: func(context.Context, string) (map[string]any, error) {
-			return map[string]any{
-				"sub":                "1234567890",
-				"email":              "eai.doe@cor.po",
-				"preferred_username": "eai-doe",
-				"name":               "Eai Doe",
-				"roles":              "Admin",
-			}, nil
-		},
-	}
-
 	jwtHeaderName := "X-Forwarded-User"
 
 	cfg := &setting.Cfg{
@@ -533,6 +548,19 @@ func TestJWTStripParam(t *testing.T) {
 		},
 	}
 
+	jwtService := &jwt.FakeJWTService{
+		VerifyProvider: func(context.Context, string) (map[string]any, error) {
+			return map[string]any{
+				"sub":                "1234567890",
+				"email":              "eai.doe@cor.po",
+				"preferred_username": "eai-doe",
+				"name":               "Eai Doe",
+				"roles":              "Admin",
+			}, nil
+		},
+		SettingsValue: cfg.JWTAuth,
+	}
+
 	// #nosec G101 -- This is a dummy/test token
 	token := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.XbPfbIHMI6arZ3Y922BhjWgQzWXcXNrz0ogtVhfEd2o"
 
@@ -542,7 +570,7 @@ func TestJWTStripParam(t *testing.T) {
 	jwtClient := ProvideJWT(jwtService,
 		connectors.ProvideOrgRoleMapper(testConfigProvider(t, cfg),
 			&orgtest.FakeOrgService{ExpectedOrgs: []*org.OrgDTO{{ID: 4, Name: "Org4"}, {ID: 5, Name: "Org5"}}}),
-		cfg, tracing.InitializeTracerForTest())
+		tracing.InitializeTracerForTest())
 	_, err := jwtClient.Authenticate(context.Background(), &authn.Request{
 		OrgID:       1,
 		HTTPRequest: httpReq,
@@ -596,12 +624,13 @@ func TestJWTSubClaimsConfig(t *testing.T) {
 		VerifyProvider: func(context.Context, string) (map[string]any, error) {
 			return response, nil
 		},
+		SettingsValue: cfg.JWTAuth,
 	}
 
 	jwtClient := ProvideJWT(jwtService,
 		connectors.ProvideOrgRoleMapper(testConfigProvider(t, cfg),
 			&orgtest.FakeOrgService{ExpectedOrgs: []*org.OrgDTO{{ID: 4, Name: "Org4"}, {ID: 5, Name: "Org5"}}}),
-		cfg, tracing.InitializeTracerForTest())
+		tracing.InitializeTracerForTest())
 	identity, err := jwtClient.Authenticate(context.Background(), &authn.Request{
 		OrgID:       1,
 		HTTPRequest: httpReq,

--- a/pkg/services/contexthandler/contexthandler.go
+++ b/pkg/services/contexthandler/contexthandler.go
@@ -20,6 +20,7 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
+	"github.com/grafana/grafana/pkg/services/auth/jwt"
 	"github.com/grafana/grafana/pkg/services/authn"
 	"github.com/grafana/grafana/pkg/services/contexthandler/ctxkey"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
@@ -30,11 +31,13 @@ import (
 )
 
 func ProvideService(cfg *setting.Cfg, authenticator authn.Authenticator, features featuremgmt.FeatureToggles,
+	jwtService jwt.JWTService,
 ) *ContextHandler {
 	return &ContextHandler{
 		cfg:           cfg,
 		authenticator: authenticator,
 		features:      features,
+		jwtService:    jwtService,
 	}
 }
 
@@ -43,6 +46,7 @@ type ContextHandler struct {
 	cfg           *setting.Cfg
 	authenticator authn.Authenticator
 	features      featuremgmt.FeatureToggles
+	jwtService    jwt.JWTService
 }
 
 type reqContextKey = ctxkey.Key
@@ -119,8 +123,12 @@ func (h *ContextHandler) setRequestContext(ctx context.Context) context.Context 
 
 	// inject ReqContext in the context
 	ctx = context.WithValue(ctx, reqContextKey{}, reqContext)
+	// Snapshot the JWT settings once so authentication and outbound header
+	// clearing observe the same values for the whole request.
+	jwtSettings := h.jwtService.Settings()
+	ctx = jwt.WithSettings(ctx, jwtSettings)
 	// store list of possible auth header in context
-	ctx = WithAuthHTTPHeaders(ctx, h.cfg)
+	ctx = WithAuthHTTPHeaders(ctx, h.cfg, jwtSettings)
 	// Set the context for the http.Request.Context
 	// This modifies both r and reqContext.Req since they point to the same value
 	*reqContext.Req = *reqContext.Req.WithContext(ctx)
@@ -246,7 +254,7 @@ func GetAuthHTTPHeaders(jwtAuth *setting.AuthJWTSettings, authProxy *setting.Aut
 
 // WithAuthHTTPHeaders returns a new context in which all possible configured auth header will be included
 // and later retrievable by AuthHTTPHeaderListFromContext.
-func WithAuthHTTPHeaders(ctx context.Context, cfg *setting.Cfg) context.Context {
+func WithAuthHTTPHeaders(ctx context.Context, cfg *setting.Cfg, jwtAuth setting.AuthJWTSettings) context.Context {
 	list := AuthHTTPHeaderListFromContext(ctx)
 	if list == nil {
 		list = &AuthHTTPHeaderList{
@@ -254,7 +262,7 @@ func WithAuthHTTPHeaders(ctx context.Context, cfg *setting.Cfg) context.Context 
 		}
 	}
 
-	list.Items = append(list.Items, GetAuthHTTPHeaders(&cfg.JWTAuth, &cfg.AuthProxy)...)
+	list.Items = append(list.Items, GetAuthHTTPHeaders(&jwtAuth, &cfg.AuthProxy)...)
 
 	return context.WithValue(ctx, authHTTPHeaderListKey, list)
 }

--- a/pkg/services/contexthandler/contexthandler_test.go
+++ b/pkg/services/contexthandler/contexthandler_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/services/auth/jwt"
 	"github.com/grafana/grafana/pkg/services/authn"
 	"github.com/grafana/grafana/pkg/services/authn/authntest"
 	"github.com/grafana/grafana/pkg/services/contexthandler"
@@ -30,6 +31,7 @@ func TestContextHandler(t *testing.T) {
 			setting.NewCfg(),
 			&authntest.FakeService{ExpectedErr: errors.New("some error")},
 			featuremgmt.WithFeatures(),
+			jwt.NewFakeJWTService(),
 		)
 
 		server := webtest.NewServer(t, routing.NewRouteRegister())
@@ -51,6 +53,7 @@ func TestContextHandler(t *testing.T) {
 			setting.NewCfg(),
 			&authntest.FakeService{ExpectedIdentity: id},
 			featuremgmt.WithFeatures(),
+			jwt.NewFakeJWTService(),
 		)
 
 		server := webtest.NewServer(t, routing.NewRouteRegister())
@@ -76,6 +79,7 @@ func TestContextHandler(t *testing.T) {
 			setting.NewCfg(),
 			&authntest.FakeService{ExpectedIdentity: identity},
 			featuremgmt.WithFeatures(),
+			jwt.NewFakeJWTService(),
 		)
 
 		server := webtest.NewServer(t, routing.NewRouteRegister())
@@ -97,6 +101,7 @@ func TestContextHandler(t *testing.T) {
 			setting.NewCfg(),
 			&authntest.FakeService{ExpectedIdentity: identity},
 			featuremgmt.WithFeatures(),
+			jwt.NewFakeJWTService(),
 		)
 
 		server := webtest.NewServer(t, routing.NewRouteRegister())
@@ -116,7 +121,6 @@ func TestContextHandler(t *testing.T) {
 	t.Run("should store auth header in context", func(t *testing.T) {
 		cfg := setting.NewCfg()
 		cfg.JWTAuth.Enabled = true
-		cfg.JWTAuth.HeaderName = "jwt-header"
 		cfg.AuthProxy.Enabled = true
 		cfg.AuthProxy.HeaderName = "proxy-header"
 		cfg.AuthProxy.Headers = map[string]string{
@@ -127,6 +131,7 @@ func TestContextHandler(t *testing.T) {
 			cfg,
 			&authntest.FakeService{ExpectedIdentity: &authn.Identity{}},
 			featuremgmt.WithFeatures(),
+			&jwt.FakeJWTService{SettingsValue: setting.AuthJWTSettings{Enabled: true, HeaderName: "jwt-header"}},
 		)
 
 		server := webtest.NewServer(t, routing.NewRouteRegister())
@@ -155,6 +160,7 @@ func TestContextHandler(t *testing.T) {
 				cfg,
 				&authntest.FakeService{ExpectedIdentity: &authn.Identity{ID: i, Type: typ}},
 				featuremgmt.WithFeatures(),
+				jwt.NewFakeJWTService(),
 			)
 
 			server := webtest.NewServer(t, routing.NewRouteRegister())
@@ -217,6 +223,7 @@ func TestContextHandler(t *testing.T) {
 			setting.NewCfg(),
 			&authntest.FakeService{ExpectedErr: errors.New("some error")},
 			featuremgmt.WithFeatures(),
+			jwt.NewFakeJWTService(),
 		)
 
 		server := webtest.NewServer(t, routing.NewRouteRegister())
@@ -243,6 +250,7 @@ func TestContextHandler(t *testing.T) {
 				},
 			},
 			featuremgmt.WithFeatures(),
+			jwt.NewFakeJWTService(),
 		)
 
 		server := webtest.NewServer(t, routing.NewRouteRegister())

--- a/pkg/services/pluginsintegration/clientmiddleware/clear_auth_headers_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/clear_auth_headers_middleware.go
@@ -12,20 +12,16 @@ import (
 // NewClearAuthHeadersMiddleware creates a new backend.HandlerMiddleware
 // that will clear any outgoing HTTP headers that was part of the incoming
 // HTTP request and used when authenticating to Grafana.
-func NewClearAuthHeadersMiddleware(cfgJWTAuth *setting.AuthJWTSettings, cfgAuthProxy *setting.AuthProxySettings) backend.HandlerMiddleware {
+func NewClearAuthHeadersMiddleware() backend.HandlerMiddleware {
 	return backend.HandlerMiddlewareFunc(func(next backend.Handler) backend.Handler {
 		return &ClearAuthHeadersMiddleware{
-			BaseHandler:  backend.NewBaseHandler(next),
-			cfgJWTAuth:   cfgJWTAuth,
-			cfgAuthProxy: cfgAuthProxy,
+			BaseHandler: backend.NewBaseHandler(next),
 		}
 	})
 }
 
 type ClearAuthHeadersMiddleware struct {
 	backend.BaseHandler
-	cfgJWTAuth   *setting.AuthJWTSettings
-	cfgAuthProxy *setting.AuthProxySettings
 }
 
 func (m *ClearAuthHeadersMiddleware) clearHeaders(ctx context.Context, h backend.ForwardHTTPHeaders) {
@@ -35,7 +31,15 @@ func (m *ClearAuthHeadersMiddleware) clearHeaders(ctx context.Context, h backend
 		return
 	}
 
-	items := contexthandler.GetAuthHTTPHeaders(m.cfgJWTAuth, m.cfgAuthProxy)
+	// Strip the auth-header snapshot frozen at request start (see
+	// contexthandler.WithAuthHTTPHeaders) so clearing always matches the headers
+	// that authenticated this request, regardless of any concurrent reload. When
+	// no snapshot is present (request paths that bypass the context handler),
+	// fall back to the unconditional auth headers rather than forwarding them.
+	items := contexthandler.GetAuthHTTPHeaders(&setting.AuthJWTSettings{}, &setting.AuthProxySettings{})
+	if list := contexthandler.AuthHTTPHeaderListFromContext(reqCtx.Req.Context()); list != nil {
+		items = list.Items
+	}
 	for _, k := range items {
 		h.DeleteHTTPHeader(k)
 	}

--- a/pkg/services/pluginsintegration/clientmiddleware/clear_auth_headers_middleware_test.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/clear_auth_headers_middleware_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/handlertest"
+	"github.com/grafana/grafana/pkg/services/contexthandler"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 )
@@ -22,7 +23,8 @@ func TestClearAuthHeadersMiddleware(t *testing.T) {
 		cfg := setting.NewCfg()
 		cdt := handlertest.NewHandlerMiddlewareTest(t,
 			WithReqContext(req, &user.SignedInUser{}),
-			handlertest.WithMiddlewares(NewClearAuthHeadersMiddleware(&cfg.JWTAuth, &cfg.AuthProxy)),
+			withAuthHTTPHeaders(req, cfg, setting.AuthJWTSettings{}),
+			handlertest.WithMiddlewares(NewClearAuthHeadersMiddleware()),
 		)
 
 		pluginCtx := backend.PluginContext{
@@ -130,7 +132,8 @@ func TestClearAuthHeadersMiddleware(t *testing.T) {
 		cfg := setting.NewCfg()
 		cdt := handlertest.NewHandlerMiddlewareTest(t,
 			WithReqContext(req, &user.SignedInUser{}),
-			handlertest.WithMiddlewares(NewClearAuthHeadersMiddleware(&cfg.JWTAuth, &cfg.AuthProxy)),
+			withAuthHTTPHeaders(req, cfg, setting.AuthJWTSettings{}),
+			handlertest.WithMiddlewares(NewClearAuthHeadersMiddleware()),
 		)
 
 		req.Header.Set("Authorization", "val")
@@ -237,5 +240,58 @@ func TestClearAuthHeadersMiddleware(t *testing.T) {
 			require.Equal(t, "test", cdt.RunStreamReq.Headers[otherHeader])
 			require.Empty(t, cdt.RunStreamReq.GetHTTPHeaders())
 		})
+	})
+
+	t.Run("Clears the JWT header captured in the request-start snapshot", func(t *testing.T) {
+		cfg := setting.NewCfg()
+		jwtAuth := setting.AuthJWTSettings{Enabled: true, HeaderName: "X-Frozen-JWT"}
+
+		cdt := handlertest.NewHandlerMiddlewareTest(t,
+			WithReqContext(req, &user.SignedInUser{}),
+			withAuthHTTPHeaders(req, cfg, jwtAuth),
+			handlertest.WithMiddlewares(NewClearAuthHeadersMiddleware()),
+		)
+
+		_, err = cdt.MiddlewareHandler.QueryData(req.Context(), &backend.QueryDataRequest{
+			PluginContext: backend.PluginContext{DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{}},
+			Headers: map[string]string{
+				otherHeader:    "test",
+				"X-Frozen-JWT": "secret",
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, cdt.QueryDataReq)
+		require.Empty(t, cdt.QueryDataReq.Headers["X-Frozen-JWT"])
+		require.Equal(t, "test", cdt.QueryDataReq.Headers[otherHeader])
+	})
+
+	t.Run("Fails closed and strips baseline auth headers when no snapshot is present", func(t *testing.T) {
+		cdt := handlertest.NewHandlerMiddlewareTest(t,
+			WithReqContext(req, &user.SignedInUser{}),
+			handlertest.WithMiddlewares(NewClearAuthHeadersMiddleware()),
+		)
+
+		_, err = cdt.MiddlewareHandler.QueryData(req.Context(), &backend.QueryDataRequest{
+			PluginContext: backend.PluginContext{DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{}},
+			Headers: map[string]string{
+				otherHeader:           "test",
+				"Authorization":       "secret",
+				"X-Grafana-Device-Id": "secret",
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, cdt.QueryDataReq)
+		require.Empty(t, cdt.QueryDataReq.Headers["Authorization"])
+		require.Empty(t, cdt.QueryDataReq.Headers["X-Grafana-Device-Id"])
+		require.Equal(t, "test", cdt.QueryDataReq.Headers[otherHeader])
+	})
+}
+
+// withAuthHTTPHeaders seeds the request context with the auth-header snapshot
+// that contexthandler freezes at request start, which the middleware consumes.
+func withAuthHTTPHeaders(req *http.Request, cfg *setting.Cfg, jwtAuth setting.AuthJWTSettings) handlertest.HandlerMiddlewareTestOption {
+	return handlertest.HandlerMiddlewareTestOption(func(*handlertest.HandlerMiddlewareTest) {
+		ctx := contexthandler.WithAuthHTTPHeaders(req.Context(), cfg, jwtAuth)
+		*req = *req.WithContext(ctx)
 	})
 }

--- a/pkg/services/pluginsintegration/clientmiddleware/clear_auth_headers_middleware_test.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/clear_auth_headers_middleware_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/handlertest"
+	"github.com/grafana/grafana/pkg/services/contexthandler"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 )
@@ -22,7 +23,8 @@ func TestClearAuthHeadersMiddleware(t *testing.T) {
 		cfg := setting.NewCfg()
 		cdt := handlertest.NewHandlerMiddlewareTest(t,
 			WithReqContext(req, &user.SignedInUser{}),
-			handlertest.WithMiddlewares(NewClearAuthHeadersMiddleware(&cfg.JWTAuth, &cfg.AuthProxy)),
+			withAuthHTTPHeaders(req, cfg, setting.AuthJWTSettings{}),
+			handlertest.WithMiddlewares(NewClearAuthHeadersMiddleware()),
 		)
 
 		pluginCtx := backend.PluginContext{
@@ -146,7 +148,8 @@ func TestClearAuthHeadersMiddleware(t *testing.T) {
 		cfg := setting.NewCfg()
 		cdt := handlertest.NewHandlerMiddlewareTest(t,
 			WithReqContext(req, &user.SignedInUser{}),
-			handlertest.WithMiddlewares(NewClearAuthHeadersMiddleware(&cfg.JWTAuth, &cfg.AuthProxy)),
+			withAuthHTTPHeaders(req, cfg, setting.AuthJWTSettings{}),
+			handlertest.WithMiddlewares(NewClearAuthHeadersMiddleware()),
 		)
 
 		req.Header.Set("Authorization", "val")
@@ -269,5 +272,58 @@ func TestClearAuthHeadersMiddleware(t *testing.T) {
 			require.Equal(t, "test", cdt.RunStreamReq.Headers[otherHeader])
 			require.Empty(t, cdt.RunStreamReq.GetHTTPHeaders())
 		})
+	})
+
+	t.Run("Clears the JWT header captured in the request-start snapshot", func(t *testing.T) {
+		cfg := setting.NewCfg()
+		jwtAuth := setting.AuthJWTSettings{Enabled: true, HeaderName: "X-Frozen-JWT"}
+
+		cdt := handlertest.NewHandlerMiddlewareTest(t,
+			WithReqContext(req, &user.SignedInUser{}),
+			withAuthHTTPHeaders(req, cfg, jwtAuth),
+			handlertest.WithMiddlewares(NewClearAuthHeadersMiddleware()),
+		)
+
+		_, err = cdt.MiddlewareHandler.QueryData(req.Context(), &backend.QueryDataRequest{
+			PluginContext: backend.PluginContext{DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{}},
+			Headers: map[string]string{
+				otherHeader:    "test",
+				"X-Frozen-JWT": "secret",
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, cdt.QueryDataReq)
+		require.Empty(t, cdt.QueryDataReq.Headers["X-Frozen-JWT"])
+		require.Equal(t, "test", cdt.QueryDataReq.Headers[otherHeader])
+	})
+
+	t.Run("Fails closed and strips baseline auth headers when no snapshot is present", func(t *testing.T) {
+		cdt := handlertest.NewHandlerMiddlewareTest(t,
+			WithReqContext(req, &user.SignedInUser{}),
+			handlertest.WithMiddlewares(NewClearAuthHeadersMiddleware()),
+		)
+
+		_, err = cdt.MiddlewareHandler.QueryData(req.Context(), &backend.QueryDataRequest{
+			PluginContext: backend.PluginContext{DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{}},
+			Headers: map[string]string{
+				otherHeader:           "test",
+				"Authorization":       "secret",
+				"X-Grafana-Device-Id": "secret",
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, cdt.QueryDataReq)
+		require.Empty(t, cdt.QueryDataReq.Headers["Authorization"])
+		require.Empty(t, cdt.QueryDataReq.Headers["X-Grafana-Device-Id"])
+		require.Equal(t, "test", cdt.QueryDataReq.Headers[otherHeader])
+	})
+}
+
+// withAuthHTTPHeaders seeds the request context with the auth-header snapshot
+// that contexthandler freezes at request start, which the middleware consumes.
+func withAuthHTTPHeaders(req *http.Request, cfg *setting.Cfg, jwtAuth setting.AuthJWTSettings) handlertest.HandlerMiddlewareTestOption {
+	return handlertest.HandlerMiddlewareTestOption(func(*handlertest.HandlerMiddlewareTest) {
+		ctx := contexthandler.WithAuthHTTPHeaders(req.Context(), cfg, jwtAuth)
+		*req = *req.WithContext(ctx)
 	})
 }

--- a/pkg/services/pluginsintegration/pluginsintegration.go
+++ b/pkg/services/pluginsintegration/pluginsintegration.go
@@ -199,7 +199,7 @@ func CreateMiddlewares(cfg *setting.Cfg, oAuthTokenService oauthtoken.OAuthToken
 
 	middlewares = append(middlewares,
 		clientmiddleware.NewTracingHeaderMiddleware(),
-		clientmiddleware.NewClearAuthHeadersMiddleware(&cfg.JWTAuth, &cfg.AuthProxy),
+		clientmiddleware.NewClearAuthHeadersMiddleware(),
 		clientmiddleware.NewOAuthTokenMiddleware(oAuthTokenService),
 		clientmiddleware.NewCookiesMiddleware(skipCookiesNames),
 		clientmiddleware.NewCachingMiddleware(cachingServiceClient),

--- a/pkg/services/pluginsintegration/pluginsintegration.go
+++ b/pkg/services/pluginsintegration/pluginsintegration.go
@@ -201,7 +201,7 @@ func CreateMiddlewares(cfg *setting.Cfg, oAuthTokenService oauthtoken.OAuthToken
 
 	middlewares = append(middlewares,
 		clientmiddleware.NewTracingHeaderMiddleware(),
-		clientmiddleware.NewClearAuthHeadersMiddleware(&cfg.JWTAuth, &cfg.AuthProxy),
+		clientmiddleware.NewClearAuthHeadersMiddleware(),
 		clientmiddleware.NewOAuthTokenMiddleware(oAuthTokenService),
 		clientmiddleware.NewCookiesMiddleware(skipCookiesNames),
 		clientmiddleware.NewCachingMiddleware(cachingServiceClient),

--- a/pkg/services/ssosettings/ssosettingsimpl/merge_test.go
+++ b/pkg/services/ssosettings/ssosettingsimpl/merge_test.go
@@ -1,0 +1,70 @@
+package ssosettingsimpl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/login/social"
+)
+
+func TestMergeSettings_JWTKeySourceGroup(t *testing.T) {
+	t.Run("does not backfill a JWT key source that is absent from the stored settings", func(t *testing.T) {
+		stored := map[string]any{"key_file": "/etc/grafana/key.pem"}
+		system := map[string]any{
+			"jwk_set_url":  "https://example.com/jwks.json",
+			"jwk_set_file": "/etc/grafana/jwks.json",
+			"key_value":    "inline-key",
+		}
+
+		merged := mergeSettings(social.JWTProviderName, stored, system)
+
+		require.Equal(t, "/etc/grafana/key.pem", merged["key_file"])
+		require.NotContains(t, merged, "jwk_set_url")
+		require.NotContains(t, merged, "jwk_set_file")
+		require.NotContains(t, merged, "key_value")
+	})
+
+	t.Run("does not overwrite an intentionally empty jwk_set_url for JWT", func(t *testing.T) {
+		stored := map[string]any{
+			"key_file":    "/etc/grafana/key.pem",
+			"jwk_set_url": "",
+		}
+		system := map[string]any{"jwk_set_url": "https://example.com/jwks.json"}
+
+		merged := mergeSettings(social.JWTProviderName, stored, system)
+
+		require.Equal(t, "", merged["jwk_set_url"])
+	})
+
+	t.Run("still backfills the JWT bearer-token modifier, which is not a key source", func(t *testing.T) {
+		stored := map[string]any{"jwk_set_url": "https://example.com/jwks.json"}
+		system := map[string]any{"jwk_set_bearer_token_file": "/etc/grafana/token"}
+
+		merged := mergeSettings(social.JWTProviderName, stored, system)
+
+		require.Equal(t, "/etc/grafana/token", merged["jwk_set_bearer_token_file"])
+	})
+
+	t.Run("still backfills jwk_set_url for OAuth providers", func(t *testing.T) {
+		stored := map[string]any{"client_id": "id"}
+		system := map[string]any{"jwk_set_url": "https://example.com/jwks.json"}
+
+		merged := mergeSettings(social.GenericOAuthProviderName, stored, system)
+
+		require.Equal(t, "https://example.com/jwks.json", merged["jwk_set_url"])
+	})
+
+	t.Run("still merges non key-source fields and backfills non-JWT empty URLs", func(t *testing.T) {
+		stored := map[string]any{"auth_url": ""}
+		system := map[string]any{
+			"auth_url":     "https://example.com/authorize",
+			"auto_sign_up": true,
+		}
+
+		merged := mergeSettings(social.GenericOAuthProviderName, stored, system)
+
+		require.Equal(t, "https://example.com/authorize", merged["auth_url"])
+		require.Equal(t, true, merged["auto_sign_up"])
+	})
+}

--- a/pkg/services/ssosettings/ssosettingsimpl/service.go
+++ b/pkg/services/ssosettings/ssosettingsimpl/service.go
@@ -101,6 +101,7 @@ func ProvideService(cfg *setting.Cfg, sqlStore db.DB, ac ac.AccessControl,
 		strategies.NewOAuthStrategy(cfg),
 		strategies.NewMTSettingsLDAPStrategy(mtSettingsClient, serveReads),
 		strategies.NewLDAPStrategy(cfg),
+		strategies.NewJWTStrategy(cfg),
 	}
 
 	configurableProviders := make(map[string]bool)
@@ -111,6 +112,8 @@ func ProvideService(cfg *setting.Cfg, sqlStore db.DB, ac ac.AccessControl,
 	providersList := ssosettings.AllOAuthProviders
 	providersList = append(providersList, social.LDAPProviderName)
 	configurableProviders[social.LDAPProviderName] = true
+	providersList = append(providersList, social.JWTProviderName)
+	configurableProviders[social.JWTProviderName] = true
 
 	if licensing.FeatureEnabled(social.SAMLProviderName) {
 		fbStrategies = append(fbStrategies, strategies.NewMTSettingsSAMLStrategy(mtSettingsClient, serveReads), strategies.NewSAMLStrategy(settingsProvider))
@@ -338,13 +341,7 @@ func (s *Service) Patch(ctx context.Context, provider string, data map[string]an
 		return err
 	}
 
-	newSettingsMap := make(map[string]any)
-	for k, v := range storedSettings.Settings {
-		newSettingsMap[k] = v
-	}
-	for k, v := range data {
-		newSettingsMap[k] = v
-	}
+	newSettingsMap := overrideMaps(storedSettings.Settings, data)
 
 	newSettings := &models.SSOSettings{
 		Provider: provider,
@@ -434,13 +431,10 @@ func (s *Service) Reload(ctx context.Context, provider string) {
 }
 
 func (s *Service) RegisterReloadable(provider string, reloadable ssosettings.Reloadable) {
-	if s.reloadables == nil {
-		s.reloadables = make(map[string]ssosettings.Reloadable)
-	}
 	s.reloadables[provider] = reloadable
 }
 
-func (s *Service) RegisterFallbackStrategy(providerRegex string, strategy ssosettings.FallbackStrategy) {
+func (s *Service) RegisterFallbackStrategy(_ string, strategy ssosettings.FallbackStrategy) {
 	s.fbStrategies = append(s.fbStrategies, strategy)
 }
 
@@ -579,7 +573,7 @@ func (s *Service) mergeSSOSettings(dbSettings, systemSettings *models.SSOSetting
 	result := &models.SSOSettings{
 		Provider: dbSettings.Provider,
 		Source:   dbSettings.Source,
-		Settings: mergeSettings(dbSettings.Settings, systemSettings.Settings),
+		Settings: mergeSettings(dbSettings.Provider, dbSettings.Settings, systemSettings.Settings),
 		Created:  dbSettings.Created,
 		Updated:  dbSettings.Updated,
 	}
@@ -693,7 +687,7 @@ func getConfigMaps(settings map[string]any) []map[string]any {
 // mergeSettings merges two maps in a way that the values from the first map are preserved
 // and the values from the second map are added only if they don't exist in the first map
 // or if they contain empty URLs.
-func mergeSettings(storedSettings, systemSettings map[string]any) map[string]any {
+func mergeSettings(provider string, storedSettings, systemSettings map[string]any) map[string]any {
 	settings := make(map[string]any)
 
 	for k, v := range storedSettings {
@@ -702,10 +696,10 @@ func mergeSettings(storedSettings, systemSettings map[string]any) map[string]any
 
 	for k, v := range systemSettings {
 		if _, ok := settings[k]; !ok {
-			if isMergingAllowed(k) {
+			if isMergingAllowed(provider, k) {
 				settings[k] = v
 			}
-		} else if isURL(k) && isEmptyString(settings[k]) {
+		} else if isURL(k) && isEmptyString(settings[k]) && isMergingAllowed(provider, k) {
 			// Overwrite all URL settings from the DB containing an empty string with their value
 			// from the system settings. This fixes an issue with empty auth_url, api_url and token_url
 			// from the DB not being replaced with their values defined in the system settings for
@@ -717,16 +711,33 @@ func mergeSettings(storedSettings, systemSettings map[string]any) map[string]any
 	return settings
 }
 
+// jwtKeySourceFields are the mutually exclusive JWT key sources. The DB config
+// already holds exactly one, so none may be merged from the system settings or
+// the key source would become ambiguous on the next load.
+var jwtKeySourceFields = map[string]bool{
+	"jwk_set_url":   true,
+	"jwk_set_file":  true,
+	"jwk_set_value": true,
+	"key_file":      true,
+	"key_value":     true,
+}
+
 // isMergingAllowed returns true if the field provided can be merged from the system settings.
-// It won't allow SAML fields that are part of a group of settings to be merged from system settings
-// because the DB settings already contain one valid setting from each group.
-func isMergingAllowed(fieldName string) bool {
+// It won't allow fields that are part of a mutually exclusive group to be merged from system
+// settings, because the DB settings already contain one valid setting from each group: the SAML
+// certificate/key/metadata groups (any provider) and the JWT key-source group (JWT only, since
+// jwk_set_url is a non-exclusive field for OAuth providers).
+func isMergingAllowed(provider, fieldName string) bool {
 	forbiddenMergePatterns := []string{"certificate", "private_key", "idp_metadata"}
 
 	for _, v := range forbiddenMergePatterns {
-		if strings.Contains(strings.ToLower(fieldName), strings.ToLower(v)) {
+		if strings.Contains(strings.ToLower(fieldName), v) {
 			return false
 		}
+	}
+
+	if provider == social.JWTProviderName && jwtKeySourceFields[fieldName] {
+		return false
 	}
 	return true
 }
@@ -765,10 +776,10 @@ func overrideMaps(maps ...map[string]any) map[string]any {
 	return result
 }
 
+var secretFieldPatterns = []string{"secret", "private", "certificate", "password", "client_key"}
+
 // IsSecretField returns true if the SSO settings field provided is a secret
 func IsSecretField(fieldName string) bool {
-	secretFieldPatterns := []string{"secret", "private", "certificate", "password", "client_key"}
-
 	for _, v := range secretFieldPatterns {
 		if strings.Contains(strings.ToLower(fieldName), strings.ToLower(v)) {
 			return true

--- a/pkg/services/ssosettings/ssosettingsimpl/service.go
+++ b/pkg/services/ssosettings/ssosettingsimpl/service.go
@@ -102,6 +102,7 @@ func ProvideService(cfg *setting.Cfg, cfgProvider configprovider.ConfigProvider,
 		strategies.NewOAuthStrategy(cfgProvider),
 		strategies.NewMTSettingsLDAPStrategy(mtSettingsClient, serveReads),
 		strategies.NewLDAPStrategy(cfg),
+		strategies.NewJWTStrategy(cfg),
 	}
 
 	configurableProviders := make(map[string]bool)
@@ -112,6 +113,8 @@ func ProvideService(cfg *setting.Cfg, cfgProvider configprovider.ConfigProvider,
 	providersList := ssosettings.AllOAuthProviders
 	providersList = append(providersList, social.LDAPProviderName)
 	configurableProviders[social.LDAPProviderName] = true
+	providersList = append(providersList, social.JWTProviderName)
+	configurableProviders[social.JWTProviderName] = true
 
 	if licensing.FeatureEnabled(social.SAMLProviderName) {
 		fbStrategies = append(fbStrategies, strategies.NewMTSettingsSAMLStrategy(mtSettingsClient, serveReads), strategies.NewSAMLStrategy(settingsProvider))
@@ -363,13 +366,7 @@ func (s *Service) Patch(ctx context.Context, provider string, data map[string]an
 		return err
 	}
 
-	newSettingsMap := make(map[string]any)
-	for k, v := range storedSettings.Settings {
-		newSettingsMap[k] = v
-	}
-	for k, v := range data {
-		newSettingsMap[k] = v
-	}
+	newSettingsMap := overrideMaps(storedSettings.Settings, data)
 
 	newSettings := &models.SSOSettings{
 		Provider: provider,
@@ -459,13 +456,10 @@ func (s *Service) Reload(ctx context.Context, provider string) {
 }
 
 func (s *Service) RegisterReloadable(provider string, reloadable ssosettings.Reloadable) {
-	if s.reloadables == nil {
-		s.reloadables = make(map[string]ssosettings.Reloadable)
-	}
 	s.reloadables[provider] = reloadable
 }
 
-func (s *Service) RegisterFallbackStrategy(providerRegex string, strategy ssosettings.FallbackStrategy) {
+func (s *Service) RegisterFallbackStrategy(_ string, strategy ssosettings.FallbackStrategy) {
 	s.fbStrategies = append(s.fbStrategies, strategy)
 }
 
@@ -604,7 +598,7 @@ func (s *Service) mergeSSOSettings(dbSettings, systemSettings *models.SSOSetting
 	result := &models.SSOSettings{
 		Provider: dbSettings.Provider,
 		Source:   dbSettings.Source,
-		Settings: mergeSettings(dbSettings.Settings, systemSettings.Settings),
+		Settings: mergeSettings(dbSettings.Provider, dbSettings.Settings, systemSettings.Settings),
 		Created:  dbSettings.Created,
 		Updated:  dbSettings.Updated,
 	}
@@ -718,7 +712,7 @@ func getConfigMaps(settings map[string]any) []map[string]any {
 // mergeSettings merges two maps in a way that the values from the first map are preserved
 // and the values from the second map are added only if they don't exist in the first map
 // or if they contain empty URLs.
-func mergeSettings(storedSettings, systemSettings map[string]any) map[string]any {
+func mergeSettings(provider string, storedSettings, systemSettings map[string]any) map[string]any {
 	settings := make(map[string]any)
 
 	for k, v := range storedSettings {
@@ -727,10 +721,10 @@ func mergeSettings(storedSettings, systemSettings map[string]any) map[string]any
 
 	for k, v := range systemSettings {
 		if _, ok := settings[k]; !ok {
-			if isMergingAllowed(k) {
+			if isMergingAllowed(provider, k) {
 				settings[k] = v
 			}
-		} else if isURL(k) && isEmptyString(settings[k]) {
+		} else if isURL(k) && isEmptyString(settings[k]) && isMergingAllowed(provider, k) {
 			// Overwrite all URL settings from the DB containing an empty string with their value
 			// from the system settings. This fixes an issue with empty auth_url, api_url and token_url
 			// from the DB not being replaced with their values defined in the system settings for
@@ -742,16 +736,33 @@ func mergeSettings(storedSettings, systemSettings map[string]any) map[string]any
 	return settings
 }
 
+// jwtKeySourceFields are the mutually exclusive JWT key sources. The DB config
+// already holds exactly one, so none may be merged from the system settings or
+// the key source would become ambiguous on the next load.
+var jwtKeySourceFields = map[string]bool{
+	"jwk_set_url":   true,
+	"jwk_set_file":  true,
+	"jwk_set_value": true,
+	"key_file":      true,
+	"key_value":     true,
+}
+
 // isMergingAllowed returns true if the field provided can be merged from the system settings.
-// It won't allow SAML fields that are part of a group of settings to be merged from system settings
-// because the DB settings already contain one valid setting from each group.
-func isMergingAllowed(fieldName string) bool {
+// It won't allow fields that are part of a mutually exclusive group to be merged from system
+// settings, because the DB settings already contain one valid setting from each group: the SAML
+// certificate/key/metadata groups (any provider) and the JWT key-source group (JWT only, since
+// jwk_set_url is a non-exclusive field for OAuth providers).
+func isMergingAllowed(provider, fieldName string) bool {
 	forbiddenMergePatterns := []string{"certificate", "private_key", "idp_metadata"}
 
 	for _, v := range forbiddenMergePatterns {
-		if strings.Contains(strings.ToLower(fieldName), strings.ToLower(v)) {
+		if strings.Contains(strings.ToLower(fieldName), v) {
 			return false
 		}
+	}
+
+	if provider == social.JWTProviderName && jwtKeySourceFields[fieldName] {
+		return false
 	}
 	return true
 }

--- a/pkg/services/ssosettings/ssosettingsimpl/service_test.go
+++ b/pkg/services/ssosettings/ssosettingsimpl/service_test.go
@@ -1039,6 +1039,11 @@ func TestService_List(t *testing.T) {
 					Settings: map[string]any(nil),
 					Source:   models.System,
 				},
+				{
+					Provider: "jwt",
+					Settings: map[string]any(nil),
+					Source:   models.System,
+				},
 			},
 			wantErr: false,
 		},
@@ -1226,6 +1231,11 @@ func TestService_ListWithRedactedSecrets(t *testing.T) {
 					Settings: map[string]any{},
 					Source:   models.System,
 				},
+				{
+					Provider: "jwt",
+					Settings: map[string]any{},
+					Source:   models.System,
+				},
 			},
 			wantErr: false,
 		},
@@ -1348,6 +1358,11 @@ func TestService_ListWithRedactedSecrets(t *testing.T) {
 				},
 				{
 					Provider: "ldap",
+					Settings: map[string]any{},
+					Source:   models.System,
+				},
+				{
+					Provider: "jwt",
 					Settings: map[string]any{},
 					Source:   models.System,
 				},
@@ -2522,12 +2537,14 @@ func Test_ProviderService(t *testing.T) {
 				"azuread",
 				"okta",
 				"ldap",
+				"jwt",
 			},
 			expectedStrategies: []string{
 				"*strategies.MTSettingsOAuthStrategy",
 				"*strategies.OAuthStrategy",
 				"*strategies.MTSettingsLDAPStrategy",
 				"*strategies.LDAPStrategy",
+				"*strategies.JWTStrategy",
 			},
 		},
 		{
@@ -2542,6 +2559,7 @@ func Test_ProviderService(t *testing.T) {
 				"azuread",
 				"okta",
 				"ldap",
+				"jwt",
 				"saml",
 			},
 			expectedStrategies: []string{
@@ -2549,6 +2567,7 @@ func Test_ProviderService(t *testing.T) {
 				"*strategies.OAuthStrategy",
 				"*strategies.MTSettingsLDAPStrategy",
 				"*strategies.LDAPStrategy",
+				"*strategies.JWTStrategy",
 				"*strategies.MTSettingsSAMLStrategy",
 				"*strategies.SAMLStrategy",
 			},

--- a/pkg/services/ssosettings/ssosettingsimpl/service_test.go
+++ b/pkg/services/ssosettings/ssosettingsimpl/service_test.go
@@ -1041,6 +1041,11 @@ func TestService_List(t *testing.T) {
 					Settings: map[string]any(nil),
 					Source:   models.System,
 				},
+				{
+					Provider: "jwt",
+					Settings: map[string]any(nil),
+					Source:   models.System,
+				},
 			},
 			wantErr: false,
 		},
@@ -1228,6 +1233,11 @@ func TestService_ListWithRedactedSecrets(t *testing.T) {
 					Settings: map[string]any{},
 					Source:   models.System,
 				},
+				{
+					Provider: "jwt",
+					Settings: map[string]any{},
+					Source:   models.System,
+				},
 			},
 			wantErr: false,
 		},
@@ -1350,6 +1360,11 @@ func TestService_ListWithRedactedSecrets(t *testing.T) {
 				},
 				{
 					Provider: "ldap",
+					Settings: map[string]any{},
+					Source:   models.System,
+				},
+				{
+					Provider: "jwt",
 					Settings: map[string]any{},
 					Source:   models.System,
 				},
@@ -2524,12 +2539,14 @@ func Test_ProviderService(t *testing.T) {
 				"azuread",
 				"okta",
 				"ldap",
+				"jwt",
 			},
 			expectedStrategies: []string{
 				"*strategies.MTSettingsOAuthStrategy",
 				"*strategies.OAuthStrategy",
 				"*strategies.MTSettingsLDAPStrategy",
 				"*strategies.LDAPStrategy",
+				"*strategies.JWTStrategy",
 			},
 		},
 		{
@@ -2544,6 +2561,7 @@ func Test_ProviderService(t *testing.T) {
 				"azuread",
 				"okta",
 				"ldap",
+				"jwt",
 				"saml",
 			},
 			expectedStrategies: []string{
@@ -2551,6 +2569,7 @@ func Test_ProviderService(t *testing.T) {
 				"*strategies.OAuthStrategy",
 				"*strategies.MTSettingsLDAPStrategy",
 				"*strategies.LDAPStrategy",
+				"*strategies.JWTStrategy",
 				"*strategies.MTSettingsSAMLStrategy",
 				"*strategies.SAMLStrategy",
 			},

--- a/pkg/services/ssosettings/strategies/jwt_strategy.go
+++ b/pkg/services/ssosettings/strategies/jwt_strategy.go
@@ -1,0 +1,28 @@
+package strategies
+
+import (
+	"context"
+
+	"github.com/grafana/grafana/pkg/login/social"
+	"github.com/grafana/grafana/pkg/services/auth/jwt"
+	"github.com/grafana/grafana/pkg/services/ssosettings"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+type JWTStrategy struct {
+	cfg *setting.Cfg
+}
+
+var _ ssosettings.FallbackStrategy = (*JWTStrategy)(nil)
+
+func NewJWTStrategy(cfg *setting.Cfg) *JWTStrategy {
+	return &JWTStrategy{cfg: cfg}
+}
+
+func (s *JWTStrategy) IsMatch(_ context.Context, provider string) bool {
+	return provider == social.JWTProviderName
+}
+
+func (s *JWTStrategy) GetProviderConfig(_ context.Context, _ string) (map[string]any, error) {
+	return jwt.SettingsToMap(s.cfg.JWTAuth), nil
+}

--- a/pkg/services/ssosettings/strategies/jwt_strategy_test.go
+++ b/pkg/services/ssosettings/strategies/jwt_strategy_test.go
@@ -1,0 +1,75 @@
+package strategies
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/ini.v1"
+
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+const jwtConfig = `[auth.jwt]
+enabled = true
+header_name = X-JWT-Assertion
+email_claim = email
+username_claim = sub
+jwk_set_url = https://example.com/.well-known/jwks.json
+cache_ttl = 60m
+expect_claims = {"iss": "https://example.com"}
+role_attribute_path = roles[0]
+role_attribute_strict = true
+allow_assign_grafana_admin = false
+skip_org_role_sync = false
+auto_sign_up = true
+tls_skip_verify_insecure = false`
+
+func TestGetJWTConfig(t *testing.T) {
+	iniFile, err := ini.Load([]byte(jwtConfig))
+	require.NoError(t, err)
+
+	cfg, err := setting.NewCfgFromINIFile(iniFile)
+	require.NoError(t, err)
+
+	strategy := NewJWTStrategy(cfg)
+
+	require.True(t, strategy.IsMatch(context.Background(), "jwt"))
+	require.False(t, strategy.IsMatch(context.Background(), "ldap"))
+	require.False(t, strategy.IsMatch(context.Background(), "generic_oauth"))
+
+	result, err := strategy.GetProviderConfig(context.Background(), "jwt")
+	require.NoError(t, err)
+
+	require.Equal(t, true, result["enabled"])
+	require.Equal(t, "X-JWT-Assertion", result["header_name"])
+	require.Equal(t, "email", result["email_claim"])
+	require.Equal(t, "sub", result["username_claim"])
+	require.Equal(t, "https://example.com/.well-known/jwks.json", result["jwk_set_url"])
+	require.Equal(t, `{"iss": "https://example.com"}`, result["expect_claims"])
+	require.Equal(t, "roles[0]", result["role_attribute_path"])
+	require.Equal(t, true, result["role_attribute_strict"])
+	require.Equal(t, false, result["allow_assign_grafana_admin"])
+	require.Equal(t, false, result["skip_org_role_sync"])
+	require.Equal(t, true, result["auto_sign_up"])
+	require.Equal(t, false, result["tls_skip_verify_insecure"])
+}
+
+func TestGetJWTConfigDefaults(t *testing.T) {
+	// Empty config — should return safe defaults (not error)
+	iniFile, err := ini.Load([]byte("[auth.jwt]"))
+	require.NoError(t, err)
+
+	cfg, err := setting.NewCfgFromINIFile(iniFile)
+	require.NoError(t, err)
+
+	strategy := NewJWTStrategy(cfg)
+	result, err := strategy.GetProviderConfig(context.Background(), "jwt")
+	require.NoError(t, err)
+
+	require.Equal(t, false, result["enabled"])
+	require.Equal(t, "{}", result["expect_claims"])
+	require.Equal(t, false, result["role_attribute_strict"])
+	require.Equal(t, false, result["tls_skip_verify_insecure"])
+	require.Equal(t, false, result["auto_sign_up"])
+}


### PR DESCRIPTION
> Recreated from #120904, which was auto-closed by the stale bot. Branch merged up to the latest `main` (previously ~4200 commits behind); conflicts in the JWT key-set init, authn client group mapping, and the SSO strategy-list test resolved in favour of upstream's current APIs while preserving the reload-aware design.

Adds JWT as a provider in the SSO Settings API. Settings round-trip through the same `Reloadable` shape used by OAuth/LDAP, and user-mapping fields (`org_mapping`, role/email/username paths, etc.) take effect at the next authentication without a restart.

## Behaviour

- `GET /api/v1/sso-settings/jwt` returns the current `auth.jwt` settings merged from the config file and the DB.
- `PUT/PATCH /api/v1/sso-settings/jwt` validates the payload, persists to the DB, and triggers an async reload.
- `DELETE` removes the DB row; the JWT auth service falls back to the config-file values.

## Implementation

- `pkg/services/auth/jwt.AuthService` implements `ssosettings.Reloadable`. A `sync.RWMutex` protects `keySet`, `expect`, `expectRegistered`, and the parsed settings; `Verify` snapshots them under RLock and drops the lock before any I/O.
- `JWTService` gains `Settings() setting.AuthJWTSettings` returning a copy of the live settings. The authn JWT client (`pkg/services/authn/clients/jwt`) reads through this getter instead of the global `cfg.JWTAuth`, so changes pushed via the API take effect at the next authentication.
- The `JWTStrategy` (read fallback) and the `Reload` path share a single field list (`jwtFields()` in `auth/jwt/sso_settings.go`), so the GET shape and the validator can't drift.
- The first commit is an unrelated cleanup of `ssosettingsimpl` (replaces a manual map merge with the existing `overrideMaps`, drops a dead nil-check, blanks an unused parameter, lifts a regex slice to a package var). Happy to split out if preferred.

## Notes

- `cache_ttl` in API responses is the parsed `time.Duration.String()` (e.g. `"1h0m0s"`) rather than the raw ini value (e.g. `"60m"`). Same value, different formatting.
- `org_mapping` is exposed as a comma-joined string, matching the OAuth strategy and the existing ini-file convention.
- `ProvideJWT` (authn client) no longer takes `*setting.Cfg`; it reads everything through the `JWTService.Settings()` snapshot.
