### PR TITLE
Home: Add no-data recommendation card for empty stacks

### DIFF
--- a/public/app/features/home/Recommendations/NoDataCard.test.tsx
+++ b/public/app/features/home/Recommendations/NoDataCard.test.tsx
@@ -1,5 +1,7 @@
 import { render, screen } from 'test/test-utils';
 
+import { type AppPluginConfig } from '@grafana/runtime';
+import { useAppPluginMetas } from '@grafana/runtime/internal';
 import { interceptLinkClicks } from 'app/core/navigation/patch/interceptLinkClicks';
 
 import { noDataCtaClicked } from '../analytics/main';
@@ -10,17 +12,55 @@ jest.mock('../analytics/main', () => ({
   noDataCtaClicked: jest.fn(),
 }));
 
+jest.mock('@grafana/runtime/internal', () => ({
+  ...jest.requireActual('@grafana/runtime/internal'),
+  useAppPluginMetas: jest.fn(),
+}));
+
+const mockUseAppPluginMetas = jest.mocked(useAppPluginMetas);
+
+function setAvailableApps(pluginIds: string[]) {
+  mockUseAppPluginMetas.mockReturnValue({
+    loading: false,
+    error: undefined,
+    value: pluginIds.map((id) => ({ id }) as AppPluginConfig),
+  });
+}
+
+beforeEach(() => {
+  setAvailableApps([]);
+});
+
 describe('NoDataCard', () => {
   it('renders the empty-state copy', () => {
     render(<NoDataCard />);
 
-    expect(screen.getByText('No solution enabled')).toBeInTheDocument();
+    expect(screen.getByText('Getting started')).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'No data flowing yet', level: 3 })).toBeInTheDocument();
     expect(screen.getByText(/Connect a data source to light up your dashboards and alerts/)).toBeInTheDocument();
     expect(screen.getByText('Popular solutions')).toBeInTheDocument();
   });
 
-  it('links the popular solutions to their solution pages', () => {
+  it('links the popular solutions to a prefilled catalog search when the apps are not available', () => {
+    setAvailableApps([]);
+
+    render(<NoDataCard />);
+
+    // Catalog search, not per-plugin detail pages: those cannot be assumed to exist on every instance.
+    expect(screen.getByRole('link', { name: 'Kubernetes Monitoring' })).toHaveAttribute(
+      'href',
+      '/plugins?q=kubernetes'
+    );
+    expect(screen.getByRole('link', { name: 'Synthetic Monitoring' })).toHaveAttribute(
+      'href',
+      '/plugins?q=synthetic+monitoring'
+    );
+    expect(screen.getByRole('link', { name: 'k6' })).toHaveAttribute('href', '/plugins?q=k6');
+  });
+
+  it('links the popular solutions into the apps that are available', () => {
+    setAvailableApps(['grafana-k8s-app', 'grafana-synthetic-monitoring-app', 'grafana-k6-app']);
+
     render(<NoDataCard />);
 
     expect(screen.getByRole('link', { name: 'Kubernetes Monitoring' })).toHaveAttribute(
@@ -32,6 +72,21 @@ describe('NoDataCard', () => {
       '/a/grafana-synthetic-monitoring-app/home'
     );
     expect(screen.getByRole('link', { name: 'k6' })).toHaveAttribute('href', '/a/grafana-k6-app');
+  });
+
+  it('mixes app and catalog links when only some apps are available', () => {
+    setAvailableApps(['grafana-k8s-app']);
+
+    render(<NoDataCard />);
+
+    expect(screen.getByRole('link', { name: 'Kubernetes Monitoring' })).toHaveAttribute(
+      'href',
+      '/a/grafana-k8s-app/home'
+    );
+    expect(screen.getByRole('link', { name: 'Synthetic Monitoring' })).toHaveAttribute(
+      'href',
+      '/plugins?q=synthetic+monitoring'
+    );
   });
 
   it('links the connect CTA to add-new-connection', () => {
@@ -63,6 +118,17 @@ describe('NoDataCard', () => {
       expect(jest.mocked(noDataCtaClicked)).toHaveBeenCalledWith({
         cta: 'solution',
         solution_id: 'kubernetes-monitoring',
+      });
+    });
+
+    it('tracks synthetic monitoring with the id shared with plugin recommendations', async () => {
+      const { user } = render(<NoDataCard />);
+
+      await user.click(screen.getByRole('link', { name: 'Synthetic Monitoring' }));
+
+      expect(jest.mocked(noDataCtaClicked)).toHaveBeenCalledWith({
+        cta: 'solution',
+        solution_id: 'synthetic-monitoring',
       });
     });
 

--- a/public/app/features/home/Recommendations/NoDataCard.test.tsx
+++ b/public/app/features/home/Recommendations/NoDataCard.test.tsx
@@ -27,8 +27,11 @@ describe('NoDataCard', () => {
       'href',
       '/a/grafana-k8s-app/home'
     );
-    expect(screen.getByRole('link', { name: 'Infrastructure' })).toHaveAttribute('href', '/connections/infrastructure');
-    expect(screen.getByRole('link', { name: 'Cloud Provider' })).toHaveAttribute('href', '/plugins/grafana-csp-app/');
+    expect(screen.getByRole('link', { name: 'Synthetic Monitoring' })).toHaveAttribute(
+      'href',
+      '/a/grafana-synthetic-monitoring-app/home'
+    );
+    expect(screen.getByRole('link', { name: 'k6' })).toHaveAttribute('href', '/a/grafana-k6-app');
   });
 
   it('links the connect CTA to add-new-connection', () => {

--- a/public/app/features/home/Recommendations/NoDataCard.test.tsx
+++ b/public/app/features/home/Recommendations/NoDataCard.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from 'test/test-utils';
+
+import { interceptLinkClicks } from 'app/core/navigation/patch/interceptLinkClicks';
+
+import { noDataCtaClicked } from '../analytics/main';
+
+import { NoDataCard } from './NoDataCard';
+
+jest.mock('../analytics/main', () => ({
+  noDataCtaClicked: jest.fn(),
+}));
+
+describe('NoDataCard', () => {
+  it('renders the empty-state copy', () => {
+    render(<NoDataCard />);
+
+    expect(screen.getByText('No solution enabled')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'No data flowing yet', level: 3 })).toBeInTheDocument();
+    expect(screen.getByText(/Connect a data source to light up your dashboards and alerts/)).toBeInTheDocument();
+    expect(screen.getByText('Popular solutions')).toBeInTheDocument();
+  });
+
+  it('links the popular solutions to their solution pages', () => {
+    render(<NoDataCard />);
+
+    expect(screen.getByRole('link', { name: 'Kubernetes Monitoring' })).toHaveAttribute(
+      'href',
+      '/a/grafana-k8s-app/home'
+    );
+    expect(screen.getByRole('link', { name: 'Infrastructure' })).toHaveAttribute('href', '/connections/infrastructure');
+    expect(screen.getByRole('link', { name: 'Cloud Provider' })).toHaveAttribute('href', '/plugins/grafana-csp-app/');
+  });
+
+  it('links the connect CTA to add-new-connection', () => {
+    render(<NoDataCard />);
+
+    expect(screen.getByRole('link', { name: 'Connect a data source' })).toHaveAttribute(
+      'href',
+      '/connections/add-new-connection'
+    );
+  });
+
+  describe('analytics', () => {
+    // LinkButton renders a plain <a href>; clicking it would trigger a real jsdom
+    // navigation (console.error -> jest-fail-on-console). Route anchor clicks through
+    // the SPA history the way the app does so the onClick fires without navigating.
+    beforeEach(() => {
+      document.addEventListener('click', interceptLinkClicks);
+    });
+
+    afterEach(() => {
+      document.removeEventListener('click', interceptLinkClicks);
+    });
+
+    it('tracks popular-solution clicks with the solution id', async () => {
+      const { user } = render(<NoDataCard />);
+
+      await user.click(screen.getByRole('link', { name: 'Kubernetes Monitoring' }));
+
+      expect(jest.mocked(noDataCtaClicked)).toHaveBeenCalledWith({
+        cta: 'solution',
+        solution_id: 'kubernetes-monitoring',
+      });
+    });
+
+    it('tracks the connect CTA', async () => {
+      const { user } = render(<NoDataCard />);
+
+      await user.click(screen.getByRole('link', { name: 'Connect a data source' }));
+      expect(jest.mocked(noDataCtaClicked)).toHaveBeenCalledWith({ cta: 'connect_data_source' });
+    });
+  });
+});

--- a/public/app/features/home/Recommendations/NoDataCard.tsx
+++ b/public/app/features/home/Recommendations/NoDataCard.tsx
@@ -1,0 +1,129 @@
+import { css } from '@emotion/css';
+
+import { type GrafanaTheme2, type IconName, locationUtil } from '@grafana/data';
+import { Trans, t } from '@grafana/i18n';
+import { LinkButton, Stack, Text, useStyles2 } from '@grafana/ui';
+import { createBridgeURL } from 'app/features/alerting/unified/components/PluginBridge';
+import { ROUTES as CONNECTIONS_ROUTES } from 'app/features/connections/constants';
+
+import { noDataCtaClicked } from '../analytics/main';
+
+import { KUBERNETES_APP_ID } from './kubernetesData';
+
+interface PopularSolution {
+  id: string; // stable telemetry id (solution_id)
+  label: string;
+  icon: IconName;
+  href: string;
+}
+
+function getPopularSolutions(): PopularSolution[] {
+  return [
+    {
+      id: 'kubernetes-monitoring',
+      label: t('home.recommendations.no-data.solution-kubernetes', 'Kubernetes Monitoring'),
+      icon: 'kubernetes',
+      href: locationUtil.assureBaseUrl(createBridgeURL(KUBERNETES_APP_ID, '/home')),
+    },
+    {
+      id: 'infrastructure',
+      label: t('home.recommendations.no-data.solution-infrastructure', 'Infrastructure'),
+      icon: 'layer-group',
+      href: locationUtil.assureBaseUrl('/connections/infrastructure'),
+    },
+    {
+      id: 'cloud-provider',
+      label: t('home.recommendations.no-data.solution-cloud-provider', 'Cloud Provider'),
+      icon: 'cloud',
+      href: locationUtil.assureBaseUrl('/plugins/grafana-csp-app/'),
+    },
+  ];
+}
+
+/** Left recommendations card for instances where no solution is reporting data yet. */
+export function NoDataCard() {
+  const styles = useStyles2(getStyles);
+
+  return (
+    <Stack direction="column" justifyContent="space-between" gap={2} flex={1} data-testid="recommendation-no-data">
+      <Stack direction="column" gap={2}>
+        <div className={styles.badge}>
+          <Text variant="bodySmall" color="secondary">
+            <span className={styles.uppercase}>
+              <Trans i18nKey="home.recommendations.no-data.badge">No solution enabled</Trans>
+            </span>
+          </Text>
+        </div>
+
+        <Text element="h3" variant="h3" color="primary">
+          <Trans i18nKey="home.recommendations.no-data.title">No data flowing yet</Trans>
+        </Text>
+
+        <Text variant="body">
+          <Trans i18nKey="home.recommendations.no-data.description">
+            Connect a data source to light up your dashboards and alerts, pick from available solutions, or follow a
+            getting started guide.
+          </Trans>
+        </Text>
+
+        <Stack direction="column" gap={1}>
+          <Text variant="bodySmall" color="secondary">
+            <span className={styles.uppercase}>
+              <Trans i18nKey="home.recommendations.no-data.popular-solutions">Popular solutions</Trans>
+            </span>
+          </Text>
+
+          <Stack direction="row" alignItems="center" gap={1} wrap="wrap">
+            {getPopularSolutions().map((solution) => (
+              <LinkButton
+                key={solution.id}
+                variant="secondary"
+                size="sm"
+                fill="solid"
+                icon={solution.icon}
+                href={solution.href}
+                onClick={() => noDataCtaClicked({ cta: 'solution', solution_id: solution.id })}
+                className={styles.pill}
+              >
+                {solution.label}
+              </LinkButton>
+            ))}
+          </Stack>
+        </Stack>
+      </Stack>
+
+      <Stack direction="row" alignItems="center">
+        <LinkButton
+          variant="secondary"
+          size="md"
+          fill="solid"
+          icon="arrow-right"
+          iconPlacement="right"
+          href={locationUtil.assureBaseUrl(CONNECTIONS_ROUTES.AddNewConnection)}
+          onClick={() => noDataCtaClicked({ cta: 'connect_data_source' })}
+        >
+          <Trans i18nKey="home.recommendations.no-data.connect">Connect a data source</Trans>
+        </LinkButton>
+      </Stack>
+    </Stack>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  badge: css({
+    alignSelf: 'flex-start',
+    background: theme.colors.background.secondary,
+    border: `1px solid ${theme.colors.border.medium}`,
+    borderRadius: theme.shape.radius.default,
+    padding: theme.spacing(0.75, 1.5),
+  }),
+  uppercase: css({
+    textTransform: 'uppercase',
+    letterSpacing: theme.spacing(0.125),
+    opacity: 0.75,
+  }),
+  pill: css({
+    borderRadius: theme.shape.radius.pill,
+    border: `1px solid ${theme.colors.border.medium}`,
+  }),
+});

--- a/public/app/features/home/Recommendations/NoDataCard.tsx
+++ b/public/app/features/home/Recommendations/NoDataCard.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 
 import { type GrafanaTheme2, type IconName, locationUtil } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { LinkButton, Stack, Text, useStyles2 } from '@grafana/ui';
+import { Badge, LinkButton, Stack, Text, useStyles2 } from '@grafana/ui';
 import { createBridgeURL } from 'app/features/alerting/unified/components/PluginBridge';
 import { ROUTES as CONNECTIONS_ROUTES } from 'app/features/connections/constants';
 
@@ -26,16 +26,16 @@ function getPopularSolutions(): PopularSolution[] {
       href: locationUtil.assureBaseUrl(createBridgeURL(KUBERNETES_APP_ID, '/home')),
     },
     {
-      id: 'infrastructure',
-      label: t('home.recommendations.no-data.solution-infrastructure', 'Infrastructure'),
-      icon: 'layer-group',
-      href: locationUtil.assureBaseUrl('/connections/infrastructure'),
+      id: 'synthetics',
+      label: t('home.recommendations.no-data.solution-synthetics', 'Synthetic Monitoring'),
+      icon: 'globe',
+      href: locationUtil.assureBaseUrl(createBridgeURL('grafana-synthetic-monitoring-app', '/home')),
     },
     {
-      id: 'cloud-provider',
-      label: t('home.recommendations.no-data.solution-cloud-provider', 'Cloud Provider'),
-      icon: 'cloud',
-      href: locationUtil.assureBaseUrl('/plugins/grafana-csp-app/'),
+      id: 'k6',
+      label: t('home.recommendations.no-data.solution-k6', 'k6'),
+      icon: 'k6',
+      href: locationUtil.assureBaseUrl(createBridgeURL('grafana-k6-app', '')),
     },
   ];
 }
@@ -45,15 +45,13 @@ export function NoDataCard() {
   const styles = useStyles2(getStyles);
 
   return (
-    <Stack direction="column" justifyContent="space-between" gap={2} flex={1} data-testid="recommendation-no-data">
+    <Stack direction="column" justifyContent="space-between" flex={1} data-testid="recommendation-no-data">
       <Stack direction="column" gap={2}>
-        <div className={styles.badge}>
-          <Text variant="bodySmall" color="secondary">
-            <span className={styles.uppercase}>
-              <Trans i18nKey="home.recommendations.no-data.badge">No solution enabled</Trans>
-            </span>
-          </Text>
-        </div>
+        <Badge
+          className={styles.badge}
+          color="darkgrey"
+          text={t('home.recommendations.no-data.badge', 'No solution enabled')}
+        />
 
         <Text element="h3" variant="h3" color="primary">
           <Trans i18nKey="home.recommendations.no-data.title">No data flowing yet</Trans>
@@ -68,9 +66,7 @@ export function NoDataCard() {
 
         <Stack direction="column" gap={1}>
           <Text variant="bodySmall" color="secondary">
-            <span className={styles.uppercase}>
-              <Trans i18nKey="home.recommendations.no-data.popular-solutions">Popular solutions</Trans>
-            </span>
+            <Trans i18nKey="home.recommendations.no-data.popular-solutions">Popular solutions</Trans>
           </Text>
 
           <Stack direction="row" alignItems="center" gap={1} wrap="wrap">
@@ -92,19 +88,21 @@ export function NoDataCard() {
         </Stack>
       </Stack>
 
-      <Stack direction="row" alignItems="center">
-        <LinkButton
-          variant="secondary"
-          size="md"
-          fill="solid"
-          icon="arrow-right"
-          iconPlacement="right"
-          href={locationUtil.assureBaseUrl(CONNECTIONS_ROUTES.AddNewConnection)}
-          onClick={() => noDataCtaClicked({ cta: 'connect_data_source' })}
-        >
-          <Trans i18nKey="home.recommendations.no-data.connect">Connect a data source</Trans>
-        </LinkButton>
-      </Stack>
+      <div className={styles.cta}>
+        <Stack direction="row" alignItems="center">
+          <LinkButton
+            variant="secondary"
+            size="md"
+            fill="solid"
+            icon="arrow-right"
+            iconPlacement="right"
+            href={locationUtil.assureBaseUrl(CONNECTIONS_ROUTES.AddNewConnection)}
+            onClick={() => noDataCtaClicked({ cta: 'connect_data_source' })}
+          >
+            <Trans i18nKey="home.recommendations.no-data.connect">Connect a data source</Trans>
+          </LinkButton>
+        </Stack>
+      </div>
     </Stack>
   );
 }
@@ -112,18 +110,12 @@ export function NoDataCard() {
 const getStyles = (theme: GrafanaTheme2) => ({
   badge: css({
     alignSelf: 'flex-start',
-    background: theme.colors.background.secondary,
-    border: `1px solid ${theme.colors.border.medium}`,
-    borderRadius: theme.shape.radius.default,
-    padding: theme.spacing(0.75, 1.5),
-  }),
-  uppercase: css({
-    textTransform: 'uppercase',
-    letterSpacing: theme.spacing(0.125),
-    opacity: 0.75,
   }),
   pill: css({
     borderRadius: theme.shape.radius.pill,
     border: `1px solid ${theme.colors.border.medium}`,
+  }),
+  cta: css({
+    marginTop: theme.spacing(2),
   }),
 });

--- a/public/app/features/home/Recommendations/NoDataCard.tsx
+++ b/public/app/features/home/Recommendations/NoDataCard.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/css';
 
 import { type GrafanaTheme2, type IconName, locationUtil } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
+import { useAppPluginMetas } from '@grafana/runtime/internal';
 import { Badge, LinkButton, Stack, Text, useStyles2 } from '@grafana/ui';
 import { createBridgeURL } from 'app/features/alerting/unified/components/PluginBridge';
 import { ROUTES as CONNECTIONS_ROUTES } from 'app/features/connections/constants';
@@ -11,46 +12,70 @@ import { noDataCtaClicked } from '../analytics/main';
 import { KUBERNETES_APP_ID } from './kubernetesData';
 
 interface PopularSolution {
-  id: string; // stable telemetry id (solution_id)
+  id: string; // stable telemetry id (solution_id), aligned with pluginRecommendations ids
+  pluginId: string;
   label: string;
   icon: IconName;
-  href: string;
+  appPath: string; // path inside the app, used when the app is available
+  searchTerm: string; // catalog search keyword, deliberately untranslated
 }
 
 function getPopularSolutions(): PopularSolution[] {
   return [
     {
       id: 'kubernetes-monitoring',
+      pluginId: KUBERNETES_APP_ID,
       label: t('home.recommendations.no-data.solution-kubernetes', 'Kubernetes Monitoring'),
       icon: 'kubernetes',
-      href: locationUtil.assureBaseUrl(createBridgeURL(KUBERNETES_APP_ID, '/home')),
+      appPath: '/home',
+      searchTerm: 'kubernetes',
     },
     {
-      id: 'synthetics',
+      id: 'synthetic-monitoring',
+      pluginId: 'grafana-synthetic-monitoring-app',
       label: t('home.recommendations.no-data.solution-synthetics', 'Synthetic Monitoring'),
       icon: 'globe',
-      href: locationUtil.assureBaseUrl(createBridgeURL('grafana-synthetic-monitoring-app', '/home')),
+      appPath: '/home',
+      searchTerm: 'synthetic monitoring',
     },
     {
       id: 'k6',
+      pluginId: 'grafana-k6-app',
       label: t('home.recommendations.no-data.solution-k6', 'k6'),
       icon: 'k6',
-      href: locationUtil.assureBaseUrl(createBridgeURL('grafana-k6-app', '')),
+      appPath: '',
+      searchTerm: 'k6',
     },
   ];
+}
+
+// Available apps link into the app itself (its routes still enforce page-level
+// authorization). Absent apps link to the plugin catalog with the search prefilled:
+// a per-plugin detail page cannot be assumed to exist on every instance (air-gapped
+// or catalog-disabled stacks), and a dead app route is worse than a browsable catalog.
+function getSolutionHref(solution: PopularSolution, appAvailable: boolean): string {
+  if (appAvailable) {
+    return locationUtil.assureBaseUrl(createBridgeURL(solution.pluginId, solution.appPath));
+  }
+  const search = new URLSearchParams({ q: solution.searchTerm });
+  return locationUtil.assureBaseUrl(`/plugins?${search}`);
 }
 
 /** Left recommendations card for instances where no solution is reporting data yet. */
 export function NoDataCard() {
   const styles = useStyles2(getStyles);
+  // Availability only picks the link target; while the lookup is pending the pills
+  // fall back to the catalog, so the card never blocks on it.
+  const { value: appMetas } = useAppPluginMetas();
+  const availableApps = new Set((appMetas ?? []).map((app) => app.id));
 
   return (
-    <Stack direction="column" justifyContent="space-between" flex={1} data-testid="recommendation-no-data">
+    <Stack direction="column" justifyContent="space-between" flex={1}>
       <Stack direction="column" gap={2}>
         <Badge
           className={styles.badge}
           color="darkgrey"
-          text={t('home.recommendations.no-data.badge', 'No solution enabled')}
+          text={t('home.recommendations.no-data.badge', 'Getting started')}
         />
 
         <Text element="h3" variant="h3" color="primary">
@@ -77,7 +102,7 @@ export function NoDataCard() {
                 size="sm"
                 fill="solid"
                 icon={solution.icon}
-                href={solution.href}
+                href={getSolutionHref(solution, availableApps.has(solution.pluginId))}
                 onClick={() => noDataCtaClicked({ cta: 'solution', solution_id: solution.id })}
                 className={styles.pill}
               >
@@ -89,19 +114,17 @@ export function NoDataCard() {
       </Stack>
 
       <div className={styles.cta}>
-        <Stack direction="row" alignItems="center">
-          <LinkButton
-            variant="secondary"
-            size="md"
-            fill="solid"
-            icon="arrow-right"
-            iconPlacement="right"
-            href={locationUtil.assureBaseUrl(CONNECTIONS_ROUTES.AddNewConnection)}
-            onClick={() => noDataCtaClicked({ cta: 'connect_data_source' })}
-          >
-            <Trans i18nKey="home.recommendations.no-data.connect">Connect a data source</Trans>
-          </LinkButton>
-        </Stack>
+        <LinkButton
+          variant="secondary"
+          size="md"
+          fill="solid"
+          icon="arrow-right"
+          iconPlacement="right"
+          href={locationUtil.assureBaseUrl(CONNECTIONS_ROUTES.AddNewConnection)}
+          onClick={() => noDataCtaClicked({ cta: 'connect_data_source' })}
+        >
+          <Trans i18nKey="home.recommendations.no-data.connect">Connect a data source</Trans>
+        </LinkButton>
       </div>
     </Stack>
   );

--- a/public/app/features/home/Recommendations/RecommendationExisting.test.tsx
+++ b/public/app/features/home/Recommendations/RecommendationExisting.test.tsx
@@ -98,45 +98,46 @@ describe('RecommendationExisting', () => {
     expect(screen.queryByRole('heading', { name: 'Kubernetes Monitoring' })).not.toBeInTheDocument();
   });
 
-  it('shows stubs immediately when settings are unavailable without awaiting resolution', async () => {
+  it('shows the no-data card immediately when settings are unavailable without awaiting resolution', async () => {
     mockUsePluginBridge.mockReturnValue({ loading: false, installed: false, settings: undefined });
     mockResolveDatasource.mockImplementation(() => new Promise(() => {}));
 
     render(<RecommendationExisting />);
 
-    expect(await screen.findByRole('heading', { name: 'Hosted Metrics' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: 'No data flowing yet' })).toBeInTheDocument();
     expect(screen.queryByTestId('recommendation-existing-skeleton')).not.toBeInTheDocument();
     expect(mockResolveDatasource).not.toHaveBeenCalled();
   });
 
-  it('shows stubs and never queries Kubernetes when the app is installed but disabled', async () => {
+  it('shows the no-data card and never queries Kubernetes when the app is installed but disabled', async () => {
     mockUsePluginBridge.mockReturnValue({ loading: false, installed: false, settings });
 
     render(<RecommendationExisting />);
 
-    expect(await screen.findByRole('heading', { name: 'Hosted Metrics' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: 'No data flowing yet' })).toBeInTheDocument();
     expect(screen.queryByRole('heading', { name: 'Kubernetes Monitoring' })).not.toBeInTheDocument();
     expect(mockResolveDatasource).not.toHaveBeenCalled();
     expect(mockFetchInventory).not.toHaveBeenCalled();
   });
 
-  it('shows stubs when resolution returns null', async () => {
+  it('shows the no-data card when resolution returns null', async () => {
     mockResolveDatasource.mockResolvedValue(null);
     mockFetchInventory.mockRejectedValue(new Error('No Prometheus datasource with Kubernetes data'));
     mockFetchHealth.mockRejectedValue(new Error('No Prometheus datasource with Kubernetes data'));
 
     render(<RecommendationExisting />);
 
-    expect(await screen.findByRole('heading', { name: 'Hosted Metrics' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: 'No data flowing yet' })).toBeInTheDocument();
     expect(screen.queryByRole('heading', { name: 'Kubernetes Monitoring' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Hosted Metrics' })).not.toBeInTheDocument();
   });
 
-  it('shows stubs when resolution rejects without flashing the Kubernetes title', async () => {
+  it('shows the no-data card when resolution rejects without flashing the Kubernetes title', async () => {
     mockResolveDatasource.mockRejectedValue(new Error('probe failed'));
 
     render(<RecommendationExisting />);
 
-    expect(await screen.findByRole('heading', { name: 'Hosted Metrics' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: 'No data flowing yet' })).toBeInTheDocument();
     expect(screen.queryByRole('heading', { name: 'Kubernetes Monitoring' })).not.toBeInTheDocument();
   });
 

--- a/public/app/features/home/Recommendations/RecommendationExisting.tsx
+++ b/public/app/features/home/Recommendations/RecommendationExisting.tsx
@@ -7,6 +7,7 @@ import { createBridgeURL } from 'app/features/alerting/unified/components/Plugin
 import { canAccessPluginPage, usePluginBridge } from 'app/features/alerting/unified/hooks/usePluginBridge';
 
 import { ExistingSolutionCard } from './ExistingSolutionCard';
+import { NoDataCard } from './NoDataCard';
 import { buildKubernetesItem } from './buildKubernetesItem';
 import { KUBERNETES_APP_ID } from './kubernetesData';
 import { type ExistingItem } from './types';
@@ -49,7 +50,6 @@ const stubbedExisting: ExistingItem[] = [
 
 export function RecommendationExisting() {
   const { settings, installed, loading: settingsLoading } = usePluginBridge(KUBERNETES_APP_ID);
-  const [selectedTitle, setSelectedTitle] = useState<string>();
 
   if (settingsLoading) {
     return <RecommendationExistingSkeleton />;
@@ -57,20 +57,18 @@ export function RecommendationExisting() {
 
   const bridgePath = createBridgeURL(KUBERNETES_APP_ID, '/home');
   if (!installed || !settings || !canAccessPluginPage(settings, bridgePath)) {
-    const selected = stubbedExisting.find((item) => item.title === selectedTitle) ?? stubbedExisting[0];
-    return <ExistingSolutionCard existing={stubbedExisting} selected={selected} onSelect={setSelectedTitle} />;
+    return <NoDataCard />;
   }
 
-  return <LiveSolutionsCard settings={settings} selectedTitle={selectedTitle} onSelect={setSelectedTitle} />;
+  return <LiveSolutionsCard settings={settings} />;
 }
 
 interface LiveSolutionsCardProps {
   settings: PluginMeta<{}>;
-  selectedTitle: string | undefined;
-  onSelect: (title: string) => void;
 }
 
-function LiveSolutionsCard({ settings, selectedTitle, onSelect }: LiveSolutionsCardProps) {
+function LiveSolutionsCard({ settings }: LiveSolutionsCardProps) {
+  const [selectedTitle, setSelectedTitle] = useState<string>();
   const { datasource, resolving, resolutionError, inventory, inventoryLoading, health, cpuSeries, cpuLoading } =
     useKubernetesCardData();
 
@@ -93,9 +91,14 @@ function LiveSolutionsCard({ settings, selectedTitle, onSelect }: LiveSolutionsC
         )
       : null;
 
-  const existing = kubernetesItem ? [kubernetesItem, ...stubbedExisting] : stubbedExisting;
+  // No datasource has Kubernetes data (or the probe failed): nothing live to show.
+  if (!kubernetesItem) {
+    return <NoDataCard />;
+  }
+
+  const existing = [kubernetesItem, ...stubbedExisting];
   const selected = existing.find((item) => item.title === selectedTitle) ?? existing[0];
-  return <ExistingSolutionCard existing={existing} selected={selected} onSelect={onSelect} />;
+  return <ExistingSolutionCard existing={existing} selected={selected} onSelect={setSelectedTitle} />;
 }
 
 // Mirrors the card body (dropdown pill, icon + title, stats, CTA) while the Kubernetes lookups

--- a/public/app/features/home/Recommendations/Recommendations.test.tsx
+++ b/public/app/features/home/Recommendations/Recommendations.test.tsx
@@ -26,8 +26,8 @@ jest.mock('app/features/alerting/unified/hooks/usePluginBridge', () => ({
   usePluginBridge: jest.fn(),
 }));
 
-// The RecommendationExisting child fetches its overview from Prometheus; resolve to an empty
-// cluster so tests exercise the (deterministic) stub entries instead of hitting a datasource.
+// The RecommendationExisting child fetches its overview from Prometheus; resolve to no
+// datasource so tests exercise the (deterministic) no-data card instead of hitting one.
 jest.mock('./kubernetesData', () => ({
   ...jest.requireActual('./kubernetesData'),
   resolveKubernetesDatasource: jest.fn().mockResolvedValue(null),
@@ -86,6 +86,14 @@ describe('Recommendations', () => {
     render(<Recommendations />);
 
     expect(await screen.findByText('Recommendations for your stack')).toBeInTheDocument();
+  });
+
+  it('shows the no-data card when no datasource has Kubernetes data', async () => {
+    render(<Recommendations />);
+
+    expect(await screen.findByRole('heading', { name: 'No data flowing yet' })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Kubernetes Monitoring' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Hosted Metrics' })).not.toBeInTheDocument();
   });
 
   it('renders nothing when the user cannot manage plugins', async () => {

--- a/public/app/features/home/analytics/main.ts
+++ b/public/app/features/home/analytics/main.ts
@@ -5,6 +5,7 @@ import {
   type ClearHistoryClicked,
   type EmptyCtaClicked,
   type IncidentsCardClicked,
+  type NoDataCtaClicked,
   type RecommendationEnableClicked,
   type TabChanged,
 } from './types';
@@ -24,6 +25,9 @@ export const emptyCtaClicked = createHomepageEvent<EmptyCtaClicked>('empty_cta_c
 export const recommendationEnableClicked = createHomepageEvent<RecommendationEnableClicked>(
   'recommendation_enable_clicked'
 );
+
+/** Fired when the user clicks any CTA on the no-data recommendation card. */
+export const noDataCtaClicked = createHomepageEvent<NoDataCtaClicked>('no_data_cta_clicked');
 
 /** Fired when the user clicks any control on the homepage Firing alerts card. */
 export const alertsCardClicked = createHomepageEvent<AlertsCardClicked>('alerts_card_clicked');

--- a/public/app/features/home/analytics/types.ts
+++ b/public/app/features/home/analytics/types.ts
@@ -22,6 +22,13 @@ export interface RecommendationEnableClicked extends EventProperty {
   source: 'card' | 'pill';
 }
 
+export interface NoDataCtaClicked extends EventProperty {
+  /** Which control on the no-data recommendation card was clicked. */
+  cta: 'connect_data_source' | 'solution';
+  /** Stable id of the popular solution (solution clicks only). */
+  solution_id?: string;
+}
+
 export interface AlertsCardClicked extends EventProperty {
   /** Which control on the Firing alerts card was clicked. */
   action: 'alert_detail' | 'create_rule' | 'view_all_alerts' | 'view_all_rules';

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -10977,9 +10977,9 @@
         "connect": "Connect a data source",
         "description": "Connect a data source to light up your dashboards and alerts, pick from available solutions, or follow a getting started guide.",
         "popular-solutions": "Popular solutions",
-        "solution-cloud-provider": "Cloud Provider",
-        "solution-infrastructure": "Infrastructure",
+        "solution-k6": "k6",
         "solution-kubernetes": "Kubernetes Monitoring",
+        "solution-synthetics": "Synthetic Monitoring",
         "title": "No data flowing yet"
       },
       "pause": "Pause",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -10973,7 +10973,7 @@
       },
       "next": "Next",
       "no-data": {
-        "badge": "No solution enabled",
+        "badge": "Getting started",
         "connect": "Connect a data source",
         "description": "Connect a data source to light up your dashboards and alerts, pick from available solutions, or follow a getting started guide.",
         "popular-solutions": "Popular solutions",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -10972,6 +10972,16 @@
         "view": "View"
       },
       "next": "Next",
+      "no-data": {
+        "badge": "No solution enabled",
+        "connect": "Connect a data source",
+        "description": "Connect a data source to light up your dashboards and alerts, pick from available solutions, or follow a getting started guide.",
+        "popular-solutions": "Popular solutions",
+        "solution-cloud-provider": "Cloud Provider",
+        "solution-infrastructure": "Infrastructure",
+        "solution-kubernetes": "Kubernetes Monitoring",
+        "title": "No data flowing yet"
+      },
       "pause": "Pause",
       "previous": "Previous",
       "recommended": "Recommended",


### PR DESCRIPTION
**What is this feature?**

Adds a "No data flowing yet" card to the homepage recommendations section, shown when no enabled solution reports live data. The card replaces the previous hardcoded stub fallbacks with a "Getting started" badge, popular-solution pills (Kubernetes Monitoring, Synthetic Monitoring, k6) that link into the app when it is available and to its plugin catalog page otherwise, and a "Connect a data source" CTA. Clicks are reported through a new `no_data_cta_clicked` analytics event.

**Why do we need this feature?**

Empty stacks previously fell back to fake stubbed stats ("3 clusters / 247 pods"), which is misleading. New users with no data need a clear next step instead of placeholder numbers.



**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana/issues/128468 (closed by the last PR in the stack, #129000)

**Special notes for your reviewer:**

Stacked PR 1/3:

1. #128781 (this PR) — the no-data card
2. #128999 — solution provider registry behind the card's trigger
3. #129000 — data-aware recommendation filtering (recommend enabled-but-silent solutions)

<img width="1216" height="356" alt="Screenshot 2026-07-22 at 16 09 06" src="https://github.com/user-attachments/assets/7cafefd9-2654-4d56-bab7-bf097dc8422e" />
