### PR TITLE
[release-13.0.4] Docs: CloudWatch quarterly update FY27Q2 (#127197)

### DIFF
--- a/docs/sources/datasources/aws-cloudwatch/_index.md
+++ b/docs/sources/datasources/aws-cloudwatch/_index.md
@@ -19,6 +19,7 @@ labels:
 menuTitle: Amazon CloudWatch
 title: Amazon CloudWatch data source
 weight: 200
+review_date: 2026-06-23
 ---
 
 # Amazon CloudWatch data source
@@ -27,12 +28,26 @@ Amazon CloudWatch is the AWS native monitoring and observability service that co
 
 Grafana includes native support for the Amazon CloudWatch plugin, so there's no need to install a plugin.
 
+## Supported features
+
+| Feature     | Supported                                                                                                                                                                       |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Metrics     | Yes                                                                                                                                                                             |
+| Logs        | Yes                                                                                                                                                                             |
+| Traces      | No. Use the [AWS Application Signals data source](https://grafana.com/docs/plugins/grafana-x-ray-datasource/latest/) (formerly the AWS X-Ray data source) for AWS X-Ray traces. |
+| Alerting    | Yes                                                                                                                                                                             |
+| Annotations | Yes                                                                                                                                                                             |
+
+## Get started
+
 The following documents will help you get started working with the CloudWatch data source:
 
 - [Configure the CloudWatch data source](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/aws-cloudwatch/configure/)
 - [CloudWatch query editor](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/aws-cloudwatch/query-editor/)
 - [Templates and variables](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/aws-cloudwatch/template-variables/)
 - [Configure AWS authentication](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/aws-cloudwatch/aws-authentication/)
+- [CloudWatch annotations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/aws-cloudwatch/annotations/)
+- [CloudWatch alerting](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/aws-cloudwatch/alerting/)
 - [Troubleshoot CloudWatch issues](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/aws-cloudwatch/troubleshooting/)
 
 ## Import pre-configured dashboards
@@ -58,7 +73,7 @@ To import curated dashboards:
 
 To customize one of these dashboards, Grafana recommends saving it under a different name; otherwise, Grafana upgrades will overwrite your customizations with the new version.
 
-## Get the most out of the data source
+## Additional features
 
 After installing and configuring the Amazon CloudWatch data source, you can:
 
@@ -92,11 +107,17 @@ Quotas are defined per account and per region.
 
 If you use multiple regions or have configured more than one CloudWatch data source to query against multiple accounts, you must request a quota increase for each account and region in which you reach the limit.
 
-To request a quota increase, visit the [AWS Service Quotas console](https://console.aws.amazon.com/servicequotas/home?r#!/services/monitoring/quotas/L-5E141212).
+To request a quota increase, visit the [AWS Service Quotas console](https://console.aws.amazon.com/servicequotas/home#!/services/monitoring/quotas/L-5E141212).
 For more information, refer to the AWS documentation for [Service Quotas](https://docs.aws.amazon.com/servicequotas/latest/userguide/intro.html) and [CloudWatch limits](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_limits.html).
 
 ## Cross-account observability
 
 The CloudWatch plugin enables you to monitor and troubleshoot applications across multiple regional accounts. Using cross-account observability, you can seamlessly search, visualize and analyze metrics and logs without worrying about account boundaries.
 
-To use this feature, configure a monitoring and source account in the [AWS console under CloudWatch Settings](https://aws.amazon.com/blogs/aws/new-amazon-cloudwatch-cross-account-observability/), and then add the necessary IAM permissions as described above.
+To use this feature, configure a monitoring and source account in the [AWS console under CloudWatch Settings](https://aws.amazon.com/blogs/aws/new-amazon-cloudwatch-cross-account-observability/), and then add the necessary IAM permissions. Refer to [Permissions reference](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/aws-cloudwatch/configure/#permissions-reference) for the cross-account observability actions.
+
+## Related resources
+
+- [Amazon CloudWatch documentation](https://docs.aws.amazon.com/cloudwatch/)
+- [Troubleshoot CloudWatch issues](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/aws-cloudwatch/troubleshooting/)
+- [Grafana community forum](https://community.grafana.com/)

--- a/docs/sources/datasources/aws-cloudwatch/alerting/index.md
+++ b/docs/sources/datasources/aws-cloudwatch/alerting/index.md
@@ -1,0 +1,159 @@
+---
+aliases:
+  - ../../data-sources/aws-cloudwatch/alerting/
+description: Set up alerts using Amazon CloudWatch data in Grafana
+keywords:
+  - grafana
+  - aws
+  - cloudwatch
+  - alerting
+  - alerts
+  - metrics
+  - logs
+labels:
+  products:
+    - cloud
+    - enterprise
+    - oss
+menuTitle: Alerting
+title: Amazon CloudWatch alerting
+weight: 460
+review_date: 2026-06-23
+---
+
+# Amazon CloudWatch alerting
+
+The Amazon CloudWatch data source supports [Grafana Alerting](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/alerting/). You can create alert rules on CloudWatch metrics and CloudWatch Logs, so Grafana notifies you when a metric crosses a threshold or when a log query returns a value that meets your alert condition.
+
+This is Grafana Alerting evaluated by Grafana, not CloudWatch alarms. To visualize the history of existing CloudWatch alarms instead, refer to [Amazon CloudWatch annotations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/aws-cloudwatch/annotations/).
+
+## Before you begin
+
+Before you create alert rules with CloudWatch data, ensure you have:
+
+- A [configured Amazon CloudWatch data source](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/aws-cloudwatch/configure/).
+- Permissions to create alert rules in Grafana.
+- Familiarity with [Grafana Alerting concepts](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/alerting/fundamentals/).
+
+## Supported query types for alerting
+
+Alert rules require queries that return numeric data that Grafana can evaluate against a threshold. CloudWatch supports alerting for the following query types:
+
+| Query type | Use case                                           | Notes                                                          |
+| ---------- | -------------------------------------------------- | -------------------------------------------------------------- |
+| Metrics    | Threshold-based alerts on CloudWatch metrics       | Returns time series data; best suited for alerting.            |
+| Logs       | Alert on log patterns, error counts, or thresholds | Use the `stats` command to aggregate logs into numeric values. |
+
+{{< admonition type="note" >}}
+You can't create an alert rule from a metric math expression that references another query, such as `queryA * 2`. Define the metric directly in the alert query instead.
+{{< /admonition >}}
+
+## Create an alert rule
+
+To create an alert rule using CloudWatch data:
+
+1. Go to **Alerting** > **Alert rules**.
+1. Click **New alert rule**.
+1. Enter a name for your alert rule.
+1. In the **Define query and alert condition** section:
+   - Select your Amazon CloudWatch data source.
+   - Configure your query, for example, a Metrics query for `CPUUtilization` or a Logs query that uses the `stats` command.
+   - Add a **Reduce** expression if your query returns multiple series.
+   - Add a **Threshold** expression to define the alert condition.
+1. Configure the **Set evaluation behavior** section:
+   - Select or create a folder and evaluation group.
+   - Set the evaluation interval.
+   - Set the pending period.
+1. Add labels and annotations to provide context for notifications.
+1. Click **Save rule**.
+
+For detailed instructions, refer to [Create a Grafana-managed alert rule](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/alerting/alerting-rules/create-grafana-managed-rule/).
+
+## Example: metric threshold alert
+
+This example fires when average EC2 CPU utilization exceeds 80%:
+
+1. Create a new alert rule.
+1. Configure the query:
+   - **Namespace**: `AWS/EC2`
+   - **Metric name**: `CPUUtilization`
+   - **Statistic**: `Average`
+   - **Dimensions**: `InstanceId`
+1. Add expressions:
+   - **Reduce**: Last, to get the most recent data point.
+   - **Threshold**: Is above 80.
+1. Set evaluation to run every 1 minute with a 5-minute pending period.
+1. Save the rule.
+
+## Example: log error count alert
+
+This example alerts when the number of log entries that contain `Exception` exceeds a threshold. CloudWatch Logs alerting requires a query that returns numeric data, which you can produce with the `stats` command:
+
+1. Create a new alert rule.
+1. Configure the query:
+   - Select **CloudWatch Logs** as the query mode.
+   - Select the region and log groups to query.
+   - Enter the following query:
+
+     ```
+     filter @message like /Exception/
+         | stats count(*) as exceptionCount by bin(5m)
+     ```
+
+1. Add expressions:
+   - **Reduce**: Max, to get the highest count in the period.
+   - **Threshold**: Is above 10.
+1. Set evaluation to run every 5 minutes.
+1. Save the rule.
+
+{{< admonition type="note" >}}
+If you receive an error such as `input data must be a wide series but got ...`, make sure your query returns numeric data that can render in a time series panel.
+{{< /admonition >}}
+
+## CloudWatch Logs timeouts during alert evaluation
+
+For CloudWatch Logs queries, Grafana polls AWS until the query completes or a timeout is reached. During alert evaluation, the timeout defined in the [Grafana configuration file](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/) takes precedence over the **Query Result Timeout** setting on the data source. Set the configuration timeout high enough for your log queries to finish.
+
+## Best practices
+
+Follow these recommendations to create reliable alerts with CloudWatch data.
+
+### Test queries before alerting
+
+Verify your query returns numeric data before you create an alert:
+
+1. Go to **Explore**.
+1. Select your Amazon CloudWatch data source.
+1. Run the query you plan to use for alerting.
+1. Confirm the result is numeric and suitable for threshold evaluation.
+
+### Reduce multiple series
+
+When a query returns multiple time series, use the **Reduce** expression to aggregate them into a single value with **Last**, **Mean**, **Max**, **Min**, or **Sum**.
+
+### Handle no data conditions
+
+Configure how the rule behaves when no data is returned under **Configure no data and error handling**. Choose **No Data**, **Alerting**, or **OK** based on whether missing data should be treated as a problem.
+
+## Troubleshoot alerting
+
+If your CloudWatch alerts don't work as expected, use the following sections to diagnose common issues.
+
+### Alerts don't fire
+
+- Confirm the query returns numeric data in Explore.
+- Ensure the evaluation interval allows enough time for data to be available.
+- Review the alert rule's health and any error messages in the Alerting UI.
+
+### Log query alerts time out
+
+- Increase the Grafana configuration file timeout, which takes precedence during alert evaluation.
+- Narrow the time range or add filters to reduce the volume of data the query scans.
+
+For more help, refer to [Troubleshoot Amazon CloudWatch](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/aws-cloudwatch/troubleshooting/).
+
+## Related resources
+
+- [Grafana Alerting](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/alerting/)
+- [Create a Grafana-managed alert rule](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/alerting/alerting-rules/create-grafana-managed-rule/)
+- [Amazon CloudWatch query editor](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/aws-cloudwatch/query-editor/)

--- a/docs/sources/datasources/aws-cloudwatch/annotations/index.md
+++ b/docs/sources/datasources/aws-cloudwatch/annotations/index.md
@@ -1,0 +1,130 @@
+---
+aliases:
+  - ../../data-sources/aws-cloudwatch/annotations/
+description: Use annotations with the Amazon CloudWatch data source in Grafana
+keywords:
+  - grafana
+  - aws
+  - cloudwatch
+  - annotations
+  - alarms
+  - events
+labels:
+  products:
+    - cloud
+    - enterprise
+    - oss
+menuTitle: Annotations
+title: Amazon CloudWatch annotations
+weight: 450
+review_date: 2026-06-23
+---
+
+# Amazon CloudWatch annotations
+
+[Annotations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/build-dashboards/annotate-visualizations/) overlay rich event information on top of graphs. With the Amazon CloudWatch data source, annotations are based on [CloudWatch alarm history](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html). Each alarm history item within the dashboard time range—such as a state change, configuration update, or action—becomes an annotation, so you can correlate alarm activity with the rest of your dashboard data.
+
+## Before you begin
+
+Before you create CloudWatch annotations, ensure you have:
+
+- A [configured Amazon CloudWatch data source](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/aws-cloudwatch/configure/).
+- One or more CloudWatch alarms in the AWS account and region you want to query.
+- IAM permissions to describe alarms and alarm history. Refer to [Required permissions](#required-permissions).
+
+## How CloudWatch annotations work
+
+Unlike data sources that build annotations from free-form queries, CloudWatch annotations query existing CloudWatch alarms and return their state-change history. Grafana finds the matching alarms using one of two methods, retrieves each alarm's history with `cloudwatch:DescribeAlarmHistory`, and renders every history item as an annotation:
+
+- **Match alarms by metric:** Grafana calls `cloudwatch:DescribeAlarmsForMetric` to find alarms attached to a specific metric.
+- **Match alarms by prefix:** Grafana calls `cloudwatch:DescribeAlarms` with your alarm name and action prefixes, so AWS returns only alarms whose names and actions start with those prefixes. Grafana then filters the returned alarms by the namespace, metric name, dimensions, statistic, and period you specify.
+
+Each annotation includes the alarm name as its title, the alarm history item type as a tag (for example, `StateUpdate`, `ConfigurationUpdate`, or `Action`), and the history summary as its text.
+
+## Create an annotation query
+
+To add a CloudWatch annotation to a dashboard:
+
+1. Open the dashboard where you want to add annotations.
+1. Click **Edit**, then click **Settings** in the top navigation.
+1. Select the **Annotations** tab.
+1. Click **Add annotation query**.
+1. Enter a **Name** for the annotation, for example, `CloudWatch alarms`.
+1. Select your **Amazon CloudWatch** data source.
+1. Configure the query fields described in the following sections.
+1. Click **Save dashboard**.
+
+The annotation query editor provides the following fields:
+
+| Field                      | Description                                                                                                                           |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| **Region**                 | The AWS region to query for alarms.                                                                                                   |
+| **Namespace**              | The metric namespace, for example, `AWS/EC2`.                                                                                         |
+| **Metric name**            | The name of the metric the alarm watches, for example, `CPUUtilization`.                                                              |
+| **Statistic**              | The statistic the alarm uses, for example, `Average`.                                                                                 |
+| **Dimensions**             | The dimensions that identify the resource, for example, `InstanceId`.                                                                 |
+| **Period**                 | _Optional._ The minimum interval between data points, in seconds. Defaults to `300` when prefix matching is disabled.                 |
+| **Enable Prefix Matching** | _Optional._ Match alarms by name and action prefix instead of by metric.                                                              |
+| **Action**                 | Match only alarms whose actions start with this prefix. Available when prefix matching is enabled, and required for the query to run. |
+| **Alarm Name**             | Match only alarms whose names start with this prefix. Available when prefix matching is enabled, and required for the query to run.   |
+
+### Match alarms by metric
+
+This is the default behavior, used when **Enable Prefix Matching** is off. Grafana returns annotations for any alarm attached to the metric you specify.
+
+When you match by metric, **Region**, **Namespace**, **Metric name**, and **Statistic** are all required. If any of them are missing, the query returns an `invalid annotations query` error. Dimensions are optional, but adding them narrows the results to alarms on a specific resource.
+
+For example, to annotate the history of the CPU utilization alarm on a single EC2 instance, set:
+
+- **Region:** `us-east-1`
+- **Namespace:** `AWS/EC2`
+- **Metric name:** `CPUUtilization`
+- **Statistic:** `Average`
+- **Dimensions:** `InstanceId = i-0123456789abcdef0`
+
+### Match alarms by prefix
+
+Enable **Enable Prefix Matching** to find alarms by name and action prefix rather than by a specific metric. Grafana requests up to 100 alarms from `cloudwatch:DescribeAlarms` using the **Alarm Name** and **Action** prefixes, then filters the returned alarms by the namespace, metric name, dimensions, statistic, and period you specify. You must provide both an **Alarm Name** prefix and an **Action** prefix for the query to run.
+
+Use prefix matching when you want to surface a group of related alarms, for example, all production alarms that trigger a specific SNS action. To do this, set **Enable Prefix Matching** on, then set **Alarm Name** to `prod-` and **Action** to the ARN prefix of your SNS topic, such as `arn:aws:sns:us-east-1:123456789012:prod-`.
+
+## Required permissions
+
+Annotation queries require the following CloudWatch API actions in the IAM policy attached to the role or user running the data source:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowReadingAlarmsFromCloudWatch",
+      "Effect": "Allow",
+      "Action": ["cloudwatch:DescribeAlarms", "cloudwatch:DescribeAlarmsForMetric", "cloudwatch:DescribeAlarmHistory"],
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+The metrics IAM policy on the [configure page](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/aws-cloudwatch/configure/#iam-policy-examples) already includes these actions.
+
+## Troubleshoot annotations
+
+If annotations don't appear as expected, try the following solutions.
+
+### Annotations don't appear
+
+- Verify the alarm has state changes within the dashboard time range. Annotations come from alarm history, so an alarm that never changed state produces no annotations.
+- Confirm the **Region**, **Namespace**, **Metric name**, **Statistic**, and **Dimensions** exactly match an existing alarm.
+- Check that the IAM role or user has the `cloudwatch:DescribeAlarms`, `cloudwatch:DescribeAlarmsForMetric`, and `cloudwatch:DescribeAlarmHistory` permissions.
+
+### `invalid annotations query` error
+
+- This error appears when prefix matching is disabled and the query reaches the backend with an empty **Region**, **Namespace**, **Metric name**, or **Statistic**. Provide all four fields, or enable **Enable Prefix Matching**.
+- In the dashboard annotation editor, an incomplete metric query is often skipped silently and produces no annotations rather than returning this error. If you see no annotations, confirm that all required fields are set.
+
+## Related resources
+
+- [Annotate visualizations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/build-dashboards/annotate-visualizations/)
+- [Amazon CloudWatch query editor](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/aws-cloudwatch/query-editor/)
+- [Configure the Amazon CloudWatch data source](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/aws-cloudwatch/configure/)

--- a/docs/sources/datasources/aws-cloudwatch/aws-authentication/index.md
+++ b/docs/sources/datasources/aws-cloudwatch/aws-authentication/index.md
@@ -15,7 +15,8 @@ labels:
     - oss
 menuTitle: AWS authentication
 title: Configure AWS authentication
-weight: 400
+weight: 150
+review_date: 2026-06-23
 ---
 
 # Configure AWS authentication
@@ -38,7 +39,7 @@ This document explores the following topics:
 
 Available authentication methods depend on your configuration and the environment where Grafana runs.
 
-Open source Grafana enables the `AWS SDK Default`, `Credentials file`, and `Access and secret key` methods by default. Cloud Grafana enables only `Access and secret key` by default. Users with server configuration access can enable or disable specific auth providers as needed. For more information, refer to the [`allowed_auth_providers` documentation](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#allowed_auth_providers).
+Open source Grafana enables the `AWS SDK Default`, `Credentials file`, and `Access & secret key` methods by default. Cloud Grafana enables `Access & secret key` and `Grafana Assume Role` by default. Users with server configuration access can enable or disable specific auth providers as needed. For more information, refer to the [`allowed_auth_providers` documentation](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#allowed_auth_providers).
 
 - `AWS SDK Default` uses the [default provider](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html) from the [AWS SDK for Go](https://github.com/aws/aws-sdk-go) without custom configuration.
   This method requires configuring AWS credentials outside Grafana through [the CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html), or by [attaching credentials directly to an EC2 instance](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html), [in an ECS task](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html), or for a [Service Account in a Kubernetes cluster](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html). You can attach permissions directly to the data source with AWS SDK Default or combine it with the optional [`Assume Role ARN`](#assume-a-role) field.
@@ -46,10 +47,10 @@ Open source Grafana enables the `AWS SDK Default`, `Credentials file`, and `Acce
   This method reads the AWS shared credentials file for a specified profile.
   Unlike `AWS SDK Default` which also reads the shared credentials file, this option lets you specify a profile directly without environment variables.
   This option provides no fallback to other credential providers and fails if the file credentials are invalid.
-- `Access and secret key` corresponds to the [StaticProvider](https://docs.aws.amazon.com/sdk-for-go/api/aws/credentials/#StaticProvider) and authenticates using a specified access key ID and secret key pair.
-  This method doesn't provide fallback authentication and fails if the key pair is invalid. Grafana Cloud uses this as the primary authentication method.
-- `Grafana Assume Role` - With this authentication method, Grafana Cloud users create an AWS IAM role that has a trust relationship with Grafana's AWS account. Grafana uses [STS](https://docs.aws.amazon.com/STS/latest/APIReference/welcome.html) to generate temporary credentials on its behalf. This method eliminates the need to generate secret and access keys for users Refer to [Use Grafana Assume Role](/docs/grafana/latest/datasources/aws-cloudwatch/aws-authentication/#use-grafana-assume-role) for more information.
-- `Workspace IAM role` corresponds to the [EC2RoleProvider](https://docs.aws.amazon.com/sdk-for-go/api/aws/credentials/ec2rolecreds/#EC2RoleProvider).
+- `Access & secret key` corresponds to the [StaticProvider](https://docs.aws.amazon.com/sdk-for-go/api/aws/credentials/#StaticProvider) and authenticates using a specified access key ID and secret key pair.
+  This method doesn't provide fallback authentication and fails if the key pair is invalid. It's available in Grafana Cloud, though `Grafana Assume Role` is recommended there because it avoids managing long-term access keys.
+- `Grafana Assume Role` - With this authentication method, Grafana Cloud users create an AWS IAM role that has a trust relationship with the Grafana AWS account. Grafana uses [STS](https://docs.aws.amazon.com/STS/latest/APIReference/welcome.html) to generate temporary credentials on its behalf. This method eliminates the need to generate secret and access keys for users. Refer to [Use Grafana Assume Role](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/aws-cloudwatch/aws-authentication/#use-grafana-assume-role) for more information.
+- `Workspace IAM Role` corresponds to the [EC2RoleProvider](https://docs.aws.amazon.com/sdk-for-go/api/aws/credentials/ec2rolecreds/#EC2RoleProvider).
   The EC2RoleProvider retrieves credentials from a role attached to the EC2 instance running Grafana.
   While AWS SDK Default can achieve similar results, this option provides no fallback authentication. Amazon Managed Grafana enables this option by default.
 
@@ -104,7 +105,7 @@ region = us-west-2
 
 EKS IAM roles for service accounts (IRSA) are an AWS EKS feature that allows pods to assume IAM roles without storing long-term credentials. When you configure IRSA in your EKS cluster, AWS injects temporary credentials into your pod as projected volume mounts.
 
-In Grafana containers, the process runs as user `472` ("grafana").
+In Grafana containers, the process runs as user `472` (`grafana`).
 By default, Kubernetes mounts the projected credentials with permissions for the root user only.
 
 To grant user `472` permission to access the credentials, and prevent fallback to the IAM role attached to the EC2 instance, set a [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for your pod.
@@ -121,12 +122,16 @@ securityContext:
 ## Use Grafana Assume Role
 
 {{< admonition type="note" >}}
-Grafana Assume Role is only available in Grafana Cloud for Amazon CloudWatch and Athena data sources.
+Grafana Assume Role is available only in Grafana Cloud. It's currently supported only for the Amazon CloudWatch and Amazon Athena data sources.
 {{< /admonition >}}
 
 The Grafana Assume Role authentication provider lets you access AWS without creating or managing long-term AWS IAM users or rotating access keys. Instead, you can create an IAM role that has permissions to access CloudWatch and trusts a Grafana AWS account.
 
 The Grafana AWS account then makes a Security Token Service (STS) request to generate temporary credentials for your AWS data. This request includes an `externalID` unique to your Grafana Cloud account, which ensures users can access only their own AWS resources.
+
+{{< admonition type="note" >}}
+The trust policy names the shared Grafana AWS account as the trusted principal, but this doesn't grant every Grafana customer access to your role. The `sts:ExternalId` condition restricts the trust to your unique external ID, so AWS only allows an assume-role request that presents that exact value. Grafana sends your external ID only for your own data source requests. The external ID isn't a secret, but combined with the account-level trust it ensures one customer can't assume another customer's role. Keep the `sts:ExternalId` condition in the trust policy — removing it would let any account that Grafana trusts assume your role.
+{{< /admonition >}}
 
 For more information, refer to the [AWS documentation on external ID](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html).
 

--- a/docs/sources/datasources/aws-cloudwatch/configure/index.md
+++ b/docs/sources/datasources/aws-cloudwatch/configure/index.md
@@ -20,6 +20,7 @@ labels:
 menuTitle: Configure
 title: Configure CloudWatch
 weight: 100
+review_date: 2026-06-23
 ---
 
 # Configure the Amazon CloudWatch data source
@@ -33,6 +34,19 @@ This document provides instructions for configuring the Amazon CloudWatch data s
 - Grafana comes with a built-in CloudWatch data source plugin, so you do not need to install a plugin.
 
 - Familiarize yourself with your CloudWatch security configuration and gather any necessary security certificates, client certificates, and client keys.
+
+## Key concepts
+
+If you're new to AWS, these terms are used throughout the configuration:
+
+| Term                                  | Description                                                                                                                                                |
+| ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **IAM policy**                        | A JSON document attached to an identity that grants permissions to AWS API actions.                                                                        |
+| **IAM role**                          | An identity with permissions that trusted entities can assume temporarily, instead of using long-lived keys.                                               |
+| **Assume role**                       | An AWS mechanism that lets one identity temporarily take on the permissions of an IAM role, often used for cross-account access.                           |
+| **External ID**                       | A shared value in a role's trust policy that prevents another party from assuming the role on your behalf.                                                 |
+| **STS (Security Token Service)**      | The AWS service that issues the short-lived temporary credentials used when assuming a role.                                                               |
+| **Cross-account observability (OAM)** | An AWS feature, managed through Observability Access Manager, that links monitoring and source accounts so you can query metrics and logs across accounts. |
 
 ## Add the CloudWatch data source
 
@@ -60,9 +74,9 @@ The IAM user or IAM role must have the associated policies to perform certain AP
 
 For authentication options and configuration details, refer to [AWS authentication](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/aws-cloudwatch/aws-authentication/).
 
-| Setting            | Description                                                                                                                                                                                                                  |
-| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Authentication** | Specify which AWS credentials chain to use. A Grafana plugin's requests to AWS are made on behalf of an IAM role or IAM user. The IAM user or IAM role must have the necessary policies to perform the required API actions. |
+| Setting                     | Description                                                                                                                                                                                                                  |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Authentication Provider** | Specify which AWS credentials chain to use. A Grafana plugin's requests to AWS are made on behalf of an IAM role or IAM user. The IAM user or IAM role must have the necessary policies to perform the required API actions. |
 
 **Access & secret key:**
 
@@ -72,6 +86,14 @@ You must use both an access key ID and a secret access key to authenticate.
 | --------------------- | ---------------------------- |
 | **Access Key ID**     | Enter your key ID.           |
 | **Secret Access Key** | Enter the secret access key. |
+
+**Credentials file:**
+
+When you select the **Credentials file** authentication provider, you can specify which profile to read from the AWS shared credentials file.
+
+| Setting                      | Description                                                                                                               |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| **Credentials Profile Name** | The profile name in `~/.aws/credentials`, as specified in the credentials file. Leave blank to use the `default` profile. |
 
 **Assume Role**:
 
@@ -88,11 +110,22 @@ You must use both an access key ID and a secret access key to authenticate.
 | **Default Region**               | Specify the AWS region. Example: If the region is US West (Oregon), use `us-west-2`.                                                                                                                                                                                                                                                                                                                                                                           |
 | **Namespaces of Custom Metrics** | Add one or more custom metric namespaces, separated by commas (for example,`Namespace1,Namespace2`). Grafana can't automatically load custom namespaces using the [CloudWatch GetMetricData API](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_GetMetricData.html). To make custom metrics available in the query editor, manually specify the namespaces in the `Namespaces of Custom Metrics` field in the data source configuration. |
 
+**Proxy configuration:**
+
+The **Proxy Configuration** settings appear only when per-data source HTTP proxy support is enabled with the `per_datasource_http_proxy_enabled` option in the Grafana configuration file. They let each CloudWatch data source use its own outbound HTTP proxy for AWS requests.
+
+| Setting            | Description                                                                                                                                                                                                                                      |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Proxy Type**     | Select how the proxy is configured: `Environment (default)` uses the `HTTP_PROXY` and `HTTPS_PROXY` environment variables, `None` disables the proxy, and `URL` lets you specify a proxy URL. Don't set this when Secure Socks Proxy is enabled. |
+| **Proxy URL**      | _Only when Proxy Type is `URL`._ The proxy URL, for example `https://localhost:3004`. Don't include the username or password in the URL.                                                                                                         |
+| **Proxy Username** | _Only when Proxy Type is `URL`._ _Optional._ The proxy username.                                                                                                                                                                                 |
+| **Proxy Password** | _Only when Proxy Type is `URL`._ _Optional._ The proxy password.                                                                                                                                                                                 |
+
 **CloudWatch Logs**:
 
 | Setting                  | Description                                                                                                                                                                                                                                                                                                                          |
 | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Query timeout result** | Grafana polls CloudWatch Logs every second until AWS returns a `Done` status or the timeout is reached. An error is returned if the timeout is exceeded. For alerting, the timeout defined in the Grafana configuration file takes precedence. Enter a valid duration string, such as `30m`, `30s` or `200ms`. The default is `30m`. |
+| **Query Result Timeout** | Grafana polls CloudWatch Logs every second until AWS returns a `Done` status or the timeout is reached. An error is returned if the timeout is exceeded. For alerting, the timeout defined in the Grafana configuration file takes precedence. Enter a valid duration string, such as `30m`, `30s` or `200ms`. The default is `30m`. |
 | **Default Log Groups**   | _Optional_. Specify the default log groups for CloudWatch Logs queries.                                                                                                                                                                                                                                                              |
 
 **Application Signals trace link:**
@@ -101,7 +134,7 @@ You must use both an access key ID and a secret access key to authenticate.
 | --------------- | ------------------------------------------------------------------- |
 | **Data source** | Select the Application Signals data source from the drop-down menu. |
 
-Grafana automatically creates a link to a trace in Application Signals data source if logs contain the `@xrayTraceId` field. To use this feature, you must already have an Application Signals data source configured. For details, see the [Application Signals data source docs](/docs/plugins/grafana-x-ray-datasource/). To view the Application Signals link, select the log row in either the Explore view or dashboard [Logs panel](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/visualizations/logs/) to view the log details section.
+Grafana automatically creates a link to a trace in Application Signals data source if logs contain the `@xrayTraceId` field. To use this feature, you must already have an Application Signals data source configured. For details, refer to the [Application Signals data source docs](https://grafana.com/docs/plugins/grafana-x-ray-datasource/latest/). To view the Application Signals link, select the log row in either the Explore view or dashboard [Logs panel](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/visualizations/logs/) to view the log details section.
 
 To log the `@xrayTraceId`, refer to the [AWS Application Signals documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Application-Monitoring-Sections.html). To provide the field to Grafana, your log queries must also contain the `@xrayTraceId` field, for example by using the query `fields @message, @xrayTraceId`.
 
@@ -111,7 +144,12 @@ To log the `@xrayTraceId`, refer to the [AWS Application Signals documentation](
 | ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Private data source connect** | Establishes a private, secured connection between a Grafana Cloud stack and data sources within a private network. Use the drop-down to locate the PDC URL. For setup instructions, refer to [Private data source connect (PDC)](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/) and [Configure PDC](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/configure-pdc/#configure-grafana-private-data-source-connect-pdc). Click **Manage private data source connect** to open your PDC connection page and view your configuration details. |
 
-After configuring your Amazon CloudWatch data source options, click **Save & test** at the bottom to test the connection. You should see a confirmation dialog box that says:
+After configuring your Amazon CloudWatch data source options, click **Save & test** at the bottom to test the connection. When the test succeeds, Grafana confirms that it reached both CloudWatch APIs:
+
+```
+1. Successfully queried the CloudWatch metrics API.
+2. Successfully queried the CloudWatch logs API.
+```
 
 {{< figure src="/media/docs/CloudWatch/CloudWatch-config-success-message.png" >}}
 
@@ -275,6 +313,30 @@ Cross-account observability lets you retrieve metrics and logs across different 
 
 For more information on configuring authentication, refer to [Configure AWS authentication](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/aws-cloudwatch/aws-authentication/).
 
+### Permissions reference
+
+The following table explains why each permission is needed and whether it's required, so you can scope a policy to only the features you use. Grant `cloudwatch:GetMetricData` only for metrics, the `logs:` actions only for logs, and the EC2 and tag actions only if you use the related template variables. Granting a permission that you don't use has no effect on functionality.
+
+| Permission                                                                                           | Purpose                                                                                                | Required                                                              |
+| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------- |
+| `cloudwatch:ListMetrics`                                                                             | Lists available metrics and populates the namespace, metric, and dimension fields in the query editor. | Required for metrics queries and metrics template variables.          |
+| `cloudwatch:GetMetricData`                                                                           | Retrieves metric data points for queries and metric math expressions.                                  | Required for metrics queries.                                         |
+| `cloudwatch:GetInsightRuleReport`                                                                    | Retrieves data from CloudWatch Contributor Insights rules.                                             | Optional. Only needed if you query Contributor Insights rules.        |
+| `cloudwatch:DescribeAlarms`, `cloudwatch:DescribeAlarmsForMetric`, `cloudwatch:DescribeAlarmHistory` | Reads CloudWatch alarm configuration and history.                                                      | Optional. Only needed if you display alarm data.                      |
+| `pi:GetResourceMetrics`                                                                              | Retrieves Performance Insights metrics for supported resources, such as RDS databases.                 | Optional. Only needed if you query Performance Insights metrics.      |
+| `logs:DescribeLogGroups`                                                                             | Lists log groups and populates the log group selector.                                                 | Required for logs queries and the Log Groups template variable.       |
+| `logs:StartQuery`, `logs:StopQuery`, `logs:GetQueryResults`                                          | Runs CloudWatch Logs Insights queries and retrieves their results.                                     | Required for logs queries.                                            |
+| `logs:GetLogGroupFields`                                                                             | Retrieves the fields available in a log group for autocomplete.                                        | Optional. Improves the logs query editor experience.                  |
+| `logs:GetLogEvents`                                                                                  | Retrieves individual log events.                                                                       | Optional. Only needed for queries that read raw log events.           |
+| `logs:Unmask`                                                                                        | Reveals data masked by a CloudWatch Logs data protection policy.                                       | Optional. Only needed to view masked sensitive data.                  |
+| `ec2:DescribeRegions`                                                                                | Lists available AWS regions.                                                                           | Optional. Only needed if you rely on dynamic region discovery.        |
+| `ec2:DescribeInstances`, `ec2:DescribeTags`                                                          | Resolves EC2 instance attributes and tags for dimension and EC2 template variables.                    | Optional. Only needed for EC2 Instance Attributes template variables. |
+| `ec2:DescribeVolumes`                                                                                | Resolves EBS volume IDs for the EBS Volume IDs template variable.                                      | Optional. Only needed for EBS Volume IDs template variables.          |
+| `tag:GetResources`                                                                                   | Resolves resource ARNs for the Resource ARNs template variable.                                        | Optional. Only needed for Resource ARNs template variables.           |
+| `oam:ListSinks`, `oam:ListAttachedLinks`                                                             | Discovers linked accounts for CloudWatch cross-account observability.                                  | Optional. Only needed for cross-account observability.                |
+
+When you use an **Assume Role ARN**, attach these query permissions to the assumed role. The primary credentials only need permission to perform `sts:AssumeRole`. For details, refer to [Assume a role](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/aws-cloudwatch/aws-authentication/#assume-a-role).
+
 ### CloudWatch Logs data protection
 
 CloudWatch Logs can protect data by applying log group data protection policies. When data protection is enabled for a log group, any sensitive data that matches the identifiers you select is automatically masked. To view masked data, your IAM role or user must have the `logs:Unmask` permission. For more details, refer to [the AWS guide](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/mask-sensitive-log-data.html) on masking sensitive log data.
@@ -283,11 +345,12 @@ CloudWatch Logs can protect data by applying log group data protection policies.
 
 The Grafana [configuration file](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#aws) includes an `AWS` section where you can configure data source options:
 
-| Configuration option      | Description                                                                                                                                                                                                                                                                                                                                                                                                                                     |
-| ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `allowed_auth_providers`  | Specifies which authentication providers are allowed for the CloudWatch data source. The following providers are enabled by default in open source Grafana: `default` (AWS SDK default), `keys` (Access and secret key), `credentials` (Credentials file), `ec2_IAM_role` (EC2 IAM role).                                                                                                                                                       |
-| `assume_role_enabled`     | Allows you to disable `assume role (ARN)` in the CloudWatch data source. The assume role (ARN) is enabled by default in open source Grafana.                                                                                                                                                                                                                                                                                                    |
-| `list_metrics_page_limit` | Sets the limit of List Metrics API pages. When a custom namespace is specified in the query editor, the [List Metrics API](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_ListMetrics.html) populates the _Metrics_ field and _Dimension_ fields. The API is paginated and returns up to 500 results per page, and the data source also limits the number of pages to 500 by default. This setting customizes that limit. |
+| Configuration option                | Description                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `allowed_auth_providers`            | Specifies which authentication providers are allowed for the CloudWatch data source as a comma-separated list. The default is `default,keys,credentials`: `default` (AWS SDK Default), `keys` (Access and secret key), and `credentials` (Credentials file). The `ec2_iam_role` (EC2 IAM role) provider is also available but isn't enabled by default.                                                                                         |
+| `assume_role_enabled`               | Allows you to disable `assume role (ARN)` in the CloudWatch data source. The assume role (ARN) is enabled by default in open source Grafana.                                                                                                                                                                                                                                                                                                    |
+| `per_datasource_http_proxy_enabled` | Allows each CloudWatch data source instance to use its own HTTP proxy configuration for requests to AWS, instead of a shared proxy. Disabled by default. Set to `true` to enable.                                                                                                                                                                                                                                                               |
+| `list_metrics_page_limit`           | Sets the limit of List Metrics API pages. When a custom namespace is specified in the query editor, the [List Metrics API](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_ListMetrics.html) populates the _Metrics_ field and _Dimension_ fields. The API is paginated and returns up to 500 results per page, and the data source also limits the number of pages to 500 by default. This setting customizes that limit. |
 
 ### Provision the data source
 
@@ -349,3 +412,50 @@ datasources:
       assumeRoleArn: arn:aws:iam::123456789012:root
       defaultRegion: eu-west-2
 ```
+
+### Configure with Terraform
+
+You can configure the CloudWatch data source using [Terraform](https://www.terraform.io/) with the [Grafana Terraform provider](https://registry.terraform.io/providers/grafana/grafana/latest/docs).
+
+For more information about provisioning resources with Terraform, refer to [Grafana as code using Terraform](https://grafana.com/docs/grafana-cloud/developer-resources/infrastructure-as-code/terraform/).
+
+The following example uses the **Access and secret key** authentication method:
+
+```hcl
+resource "grafana_data_source" "cloudwatch" {
+  name = "CloudWatch"
+  type = "cloudwatch"
+
+  json_data_encoded = jsonencode({
+    authType      = "keys"
+    defaultRegion = "eu-west-2"
+  })
+
+  secure_json_data_encoded = jsonencode({
+    accessKey = "<YOUR_ACCESS_KEY>"
+    secretKey = "<YOUR_SECRET_KEY>"
+  })
+}
+```
+
+The following example uses the **AWS SDK Default** authentication method with an assumed role:
+
+```hcl
+resource "grafana_data_source" "cloudwatch" {
+  name = "CloudWatch"
+  type = "cloudwatch"
+
+  json_data_encoded = jsonencode({
+    authType      = "default"
+    assumeRoleArn = "arn:aws:iam::123456789012:role/<ROLE_NAME>"
+    defaultRegion = "eu-west-2"
+  })
+}
+```
+
+Replace the placeholders with your own values:
+
+- `<YOUR_ACCESS_KEY>` and `<YOUR_SECRET_KEY>`: The AWS access key ID and secret access key for the **Access and secret key** method.
+- `<ROLE_NAME>`: The name of the IAM role to assume.
+
+For all available configuration options, refer to the [Grafana provider data source resource documentation](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/data_source).

--- a/docs/sources/datasources/aws-cloudwatch/query-editor/index.md
+++ b/docs/sources/datasources/aws-cloudwatch/query-editor/index.md
@@ -18,11 +18,28 @@ labels:
 menuTitle: Query editor
 title: Amazon CloudWatch query editor
 weight: 200
+review_date: 2026-06-23
 ---
 
 # Amazon CloudWatch query editor
 
 Grafana provides a query editor for the CloudWatch data source, which allows you to query, visualize, and alert on logs and metrics stored in Amazon CloudWatch. It is located on the [Explore](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/explore/) page. For general documentation on querying data sources in Grafana, refer to [Query and transform data](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/query-transform-data/).
+
+## Key concepts
+
+If you're new to CloudWatch, these terms are used throughout this documentation:
+
+| Term                  | Description                                                                                                   |
+| --------------------- | ------------------------------------------------------------------------------------------------------------- |
+| **Namespace**         | A container for CloudWatch metrics, usually one per AWS service, such as `AWS/EC2` or `AWS/Lambda`.           |
+| **Metric**            | A time-ordered set of data points published to CloudWatch, such as `CPUUtilization`.                          |
+| **Dimension**         | A name-value pair that identifies a specific resource for a metric, such as `InstanceId=i-1234567890abcdef0`. |
+| **Statistic**         | An aggregation applied to metric data over a period, such as `Average`, `Sum`, or `Maximum`.                  |
+| **Period**            | The length of time, in seconds, used to aggregate metric data points.                                         |
+| **Metric math**       | Expressions that combine or transform metrics, such as computing a rate or a sum across metrics.              |
+| **Metrics Insights**  | A SQL-like query engine for filtering and aggregating metrics in near real time.                              |
+| **Search expression** | A CloudWatch expression that matches multiple metrics at query time, often used with wildcards.               |
+| **Logs Insights QL**  | The CloudWatch Logs query language used to search and aggregate log data.                                     |
 
 ## Choose a query editing mode
 
@@ -37,30 +54,35 @@ Select the API to query using the drop-down to the right of the **Region** setti
 
 The following are the components of the CloudWatch query editor.
 
-| **Setting**     | **Description**                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Region**      | Select an AWS region if it differs from the default.                                                                                                                                                                                                                                                                                                                                                                                                                        |
-| **Namespace**   | The AWS service namespace. Examples: `AWS/EC2`, `AWS_Lambda`.                                                                                                                                                                                                                                                                                                                                                                                                               |
-| **Metric name** | The name of the metric you want to visualize. Example: `CPUUtilization`.                                                                                                                                                                                                                                                                                                                                                                                                    |
-| **Statistic**   | Choose how to aggregate your data. Examples: `sum`, `average`, `maximum`.                                                                                                                                                                                                                                                                                                                                                                                                   |
-| **Dimensions**  | Select dimensions from the drop-down. Examples: `InstanceId`, `FunctionName`, `latency`. You can add several dimensions to your query.                                                                                                                                                                                                                                                                                                                                      |
-| **Match exact** | _Optional_. When enabled, this option restricts query results to metrics that precisely match the specified dimensions and their values. All dimensions of the queried metric must be explicitly defined in the query to ensure an exact schema match. If disabled, the query will also return metrics that match the defined schema but possess additional dimensions.                                                                                                     |
-| **ID**          | _Optional_. Unique identifier required by the GetMetricData API for referencing queries in math expressions. Must start with a lowercase letter and can include letters, numbers, and underscores. If not specified, Grafana generates an ID using the pattern `query[refId]` (for example, `queryA`for the first query row).                                                                                                                                               |
-| **Period**      | The minimum time interval, in seconds, between data points. The default is `auto`. Valid values are 1, 5, 10, 30, or any multiple of 60. When set to auto or left blank, Grafana calculates the period using time range in seconds / 2000, then rounds up to the next value (60, 300, 900, 3600, 21600, 86400) based on the [CloudWatch retention policy](https://aws.amazon.com/about-aws/whats-new/2016/11/cloudwatch-extends-metrics-retention-and-new-user-interface/). |
-| **Label**       | _Optional_. Add a customized time series legend name. The label field overrides the default metric legend name using CloudWatch dynamic labels. Time-based dynamic labels like ${MIN_MAX_TIME_RANGE} derive legend values from the current timezone in the time range picker. For the full list of label patterns and limitations, refer to [CloudWatch dynamic labels](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/graph-dynamic-labels.html).          |
+| **Setting**     | **Description**                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Region**      | Select an AWS region if it differs from the default.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| **Namespace**   | The AWS service namespace. Examples: `AWS/EC2`, `AWS/Lambda`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| **Metric name** | The name of the metric you want to visualize. Example: `CPUUtilization`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| **Statistic**   | Choose how to aggregate your data. Options are `Average`, `Maximum`, `Minimum`, `Sum`, `SampleCount`, and `IQM`. You can also enter a custom value, such as a percentile like `p99`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| **Dimensions**  | Select dimensions from the drop-down. Examples: `InstanceId`, `FunctionName`, `latency`. You can add several dimensions to your query.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| **Match exact** | _Optional_. When enabled, this option restricts query results to metrics that precisely match the specified dimensions and their values. All dimensions of the queried metric must be explicitly defined in the query to ensure an exact schema match. If disabled, the query will also return metrics that match the defined schema but possess additional dimensions.                                                                                                                                                                                                                                                                                                                   |
+| **ID**          | _Optional_. Unique identifier required by the GetMetricData API for referencing queries in math expressions. Must start with a lowercase letter and can include letters, numbers, and underscores. If not specified, Grafana generates an ID using the pattern `query[refId]` (for example, `queryA`for the first query row).                                                                                                                                                                                                                                                                                                                                                             |
+| **Period**      | The minimum time interval, in seconds, between data points. The default is `auto`. CloudWatch accepts periods of 1, 5, 10, 30, or any multiple of 60 seconds. When set to `auto` or left blank, Grafana calculates the period by dividing the time range in seconds by 2000, then rounding up to the next value among 60, 300, 900, 3600, 21600, and 86400. The available periods depend on the age of the data: because CloudWatch stores older metrics at a lower resolution under its [retention policy](https://aws.amazon.com/about-aws/whats-new/2016/11/cloudwatch-extends-metrics-retention-and-new-user-interface/), the shorter periods aren't available for older time ranges. |
+| **Label**       | _Optional_. Add a customized time series legend name. The label field overrides the default metric legend name using CloudWatch dynamic labels. Time-based dynamic labels like ${MIN_MAX_TIME_RANGE} derive legend values from the current timezone in the time range picker. For the full list of label patterns and limitations, refer to [CloudWatch dynamic labels](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/graph-dynamic-labels.html).                                                                                                                                                                                                                        |
 
-## Use Builder mode
+## Use Builder and Code modes
 
-Create a query in Builder mode:
+Both the Metric Search and Metric Insights query types provide two editing modes. Use the **Builder** and **Code** toggle in the query editor to switch between them.
 
-1. Browse and select a metric namespace, metric name, filter, group, and order options using information from the [Metrics Insights keywords table](#use-metrics-insights-keywords).
-1. For each of these keywords, choose from the list of available options.
+### Builder mode
 
-Grafana constructs a SQL query based on your selections.
+Builder mode lets you construct a query from drop-downs and form fields without writing any syntax:
 
-## Use Code mode
+- For **Metric Search** queries, select the namespace, metric name, statistic, and dimensions.
+- For **Metric Insights** queries, select the namespace, metric name, filter, group, and order options using the [Metrics Insights keywords](#use-metrics-insights-keywords). Grafana constructs a SQL query based on your selections.
 
-You can also write your SQL query directly in a code editor by using Code mode.
+### Code mode
+
+Code mode lets you write your query directly in a code editor:
+
+- For **Metric Search** queries, write a metric math or `SEARCH` expression.
+- For **Metric Insights** queries, write a Metrics Insights SQL query.
 
 The code editor includes a built-in autocomplete feature that suggests keywords, aggregations, namespaces, metrics, labels, and label values.
 Suggestions appear after typing a space, comma, or dollar (`$`) character, or by pressing <key>CTRL</key>+<key>Space</key>.
@@ -75,8 +97,8 @@ To run the query, click **Run query** above the code editor.
 
 You can create two types of queries in the CloudWatch query editor:
 
-- [Metric Search](#metric-search-queries), which help you retrieve and filter available metrics.
-- [Metric Query](#use-metric-insights-syntax), which use the Metrics Insights feature to fetch time series data.
+- [Metric Search](#metric-search-queries), which helps you retrieve and filter available metrics.
+- [Metric Insights](#use-metric-insights-syntax), which uses the Metrics Insights feature to fetch time series data.
 
 The query type you use depends on how you want to interact with AWS metrics. Use the drop-down in the upper middle of the query editor to select which type you want to create.
 
@@ -102,7 +124,7 @@ When `Match Exact` is disabled, you can specify any subset of dimensions for fil
 
 This mode provides more flexible querying but may return metrics with unexpected additional dimensions.
 
-The data source returns up to 100 metrics matching your filter criteria.
+Because the data source retrieves metrics through the CloudWatch `GetMetricData` API, a single query returns data for up to 100 metrics matching your filter criteria, which is the per-request limit that AWS enforces.
 
 Enhance metric queries using template variables to create dynamic, reusable dashboards.
 
@@ -114,7 +136,7 @@ Use the asterisk (`*`) wildcard for dimension values to create dynamic queries t
 
 The query returns the average CPU utilization for all EC2 instances in the default region. With `Match Exact` disabled and `InstanceId` using a wildcard, the query retrieves metrics for any EC2 instance regardless of additional dimensions.
 
-Auto-scaling events add new instances to the graph without manual instance ID tracking. This feature supports up to 100 metrics.
+Auto-scaling events add new instances to the graph without manual instance ID tracking. As with other metric search queries, AWS returns up to 100 metrics per `GetMetricData` request.
 
 Click the [**Query inspector**](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/query-transform-data/#navigate-the-query-tab) button and select **Meta Data** to see the search expression that's automatically built to support wildcards.
 
@@ -210,8 +232,8 @@ The logs query editor helps you write CloudWatch Logs queries across a selected 
 You can query CloudWatch Logs using three supported query language options:
 
 - **Logs Insights QL** - The AWS native query language specifically designed for CloudWatch Logs. It uses a SQL-like syntax with commands like `fields`, `filter`, `stats`, and `sort`. It's optimized for the CloudWatch log structure and offers built-in functions for parsing timestamps, extracting fields from JSON logs, and performing aggregations.
-- **OpenSearch PPL** - The OpenSearch query language is based on Elasticsearch's query DSL (Domain Specific Language). It uses a pipe-based syntax similar to Unix command-line tools or the Splunk search language, and supports complex boolean logic, range queries, wildcard matching, and full-text search capabilities.
 - **OpenSearch SQL** - OpenSearch SQL is a query language that uses a SQL-like syntax for querying data in OpenSearch. It supports standard SQL queries and is designed for users familiar with SQL.
+- **OpenSearch PPL** - The OpenSearch query language is based on Elasticsearch's query DSL (Domain Specific Language). It uses a pipe-based syntax similar to Unix command-line tools or the Splunk search language, and supports complex boolean logic, range queries, wildcard matching, and full-text search capabilities.
 
 **Create a CloudWatch Logs query:**
 
@@ -244,7 +266,7 @@ You must specify a set of log groups to target for your query using one of the f
   Click **Select log groups** to choose the target log groups for your query.
   When the **Monitoring account** badge appears in the query editor header, you can search and select log groups across multiple accounts.
   Use the **Accounts** filter to narrow results by account.
-  For large lists, use prefix search to narrow the selection.
+  For large lists, use prefix search to narrow the selection. The selector loads log groups in pages, so you can scroll to load more results when many log groups are available.
 - **Name prefix**: Select the **Name prefix** query scope and provide up to five log group name prefixes. The query will run against log groups that have names that start with the specified prefixes. Each prefix must be at least three characters and must not include `*`. This option is only available for **Logs Insights QL**.
 - **All log groups**: Select the **All log groups** query scope. This queries all log groups in the selected region. This option is only available for **Logs Insights QL**.
 
@@ -313,6 +335,16 @@ If you receive an error like `input data must be a wide series but got ...` when
 
 For more information on Grafana alerts, refer to [Alerting](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/alerting/).
 
+## Common use cases
+
+The following scenarios show how to combine the query editor's features to solve real monitoring problems.
+
+- **Monitor an EC2 fleet:** Use a Metric Search query for `AWS/EC2` `CPUUtilization` with the `InstanceId` dimension set to a wildcard (`*`) and `Match Exact` disabled. The graph automatically includes new instances as your fleet scales.
+- **Track Lambda errors and invocations:** Query the `AWS/Lambda` namespace for the `Errors` and `Invocations` metrics, then add a metric math expression such as `errors / invocations * 100` to chart an error rate.
+- **Rank the busiest resources:** Use a Metrics Insights query with `ORDER BY` and `LIMIT` to return the top N resources by a metric, for example, the 10 EC2 instances with the highest average CPU utilization.
+- **Investigate application errors:** Use a CloudWatch Logs query with `filter` and `stats` to count errors over time, then correlate the spikes with metric panels on the same dashboard.
+- **Alert on log error rates:** Build a Logs query that returns numeric data with the `stats` command, then create an alert rule on the result. Refer to [Create queries for alerting](#create-queries-for-alerting).
+
 ## Cross-account observability
 
 The CloudWatch plugin monitors and troubleshoots applications that span multiple accounts within a region. Cross-account observability enables seamless searching, visualization, and analysis of metrics and logs across account boundaries.
@@ -321,7 +353,7 @@ To enable cross-account observability, complete the following steps:
 
 1. Go to the [Amazon CloudWatch documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html) and follow the instructions for enabling cross-account observability.
 
-1. Add [two API actions](https://grafana.com/docs/grafana/latest/datasources/aws-cloudwatch/configure/#cross-account-observability-permissions) to the IAM policy attached to the role/user running the plugin.
+1. Add [two API actions](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/aws-cloudwatch/configure/#cross-account-observability-permissions) to the IAM policy attached to the role/user running the plugin.
 
 Cross-account querying is available in the plugin through the **Logs**, **Metric search**, and **Metric Insights** modes.
 After you have configured it, you'll see a **Monitoring account** badge in the query editor header.
@@ -330,4 +362,4 @@ After you have configured it, you'll see a **Monitoring account** badge in the q
 
 ## Query caching
 
-When you enable [query and resource caching](/docs/grafana/<GRAFANA_VERSION>/administration/data-source-management/#query-and-resource-caching), Grafana temporarily stores the results of data source queries and resource requests. Query caching is available in CloudWatch Metrics in Grafana Cloud and Grafana Enterprise. It is not available in CloudWatch Logs Insights due to how query results are polled from AWS.
+When you enable [query and resource caching](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/data-source-management/#query-and-resource-caching), Grafana temporarily stores the results of data source queries and resource requests. Query caching is available in CloudWatch Metrics in Grafana Cloud and Grafana Enterprise. It is not available in CloudWatch Logs Insights due to how query results are polled from AWS.

--- a/docs/sources/datasources/aws-cloudwatch/template-variables/index.md
+++ b/docs/sources/datasources/aws-cloudwatch/template-variables/index.md
@@ -17,20 +17,19 @@ labels:
 menuTitle: Template variables
 title: CloudWatch template variables
 weight: 300
+review_date: 2026-06-23
 ---
 
 # CloudWatch template variables
 
 Instead of hard-coding details such as server, application, and sensor names in metric queries, you can use variables.
-Grafana lists these variables in drop-down select boxes at the top of the dashboard to help you change the data displayed in your dashboard, and they are called template variables
-
-<!-- Grafana refers to such variables as template variables. -->
+Grafana lists these variables in drop-down select boxes at the top of the dashboard to help you change the data displayed in your dashboard. Grafana refers to such variables as template variables.
 
 For an introduction to templating and template variables, refer to [Templating](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/variables/) and [Add and manage variables](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/variables/add-template-variables/).
 
 ## Use query variables
 
-You can specify these CloudWatch data source queries in the Variable edit view's **Query Type** field.
+You can specify these CloudWatch data source queries in the Variable edit view's **Query type** field.
 Use them to fill a variable's options list with values like `regions`, `namespaces`, `metric names`, and `dimension keys/values`.
 
 | Name                        | List returned                                                                                                                                    |
@@ -39,12 +38,15 @@ Use them to fill a variable's options list with values like `regions`, `namespac
 | **Namespaces**              | All namespaces CloudWatch supports.                                                                                                              |
 | **Metrics**                 | Metrics in the namespace. (Specify region or use "default" for custom metrics.)                                                                  |
 | **Dimension Keys**          | Dimension keys in the namespace.                                                                                                                 |
-| **Dimension Values**        | Dimension values matching the specified `region`, `namespace`, `metric`, and `dimension_key`. Use dimension `filters` for more specific results. |
-| **EBS Volume IDs**          | Volume ids matching the specified `region` and `instance_id`.                                                                                    |
-| **EC2 Instance Attributes** | Attributes matching the specified `region`, `attribute_name`, and `filters`.                                                                     |
-| **Resource ARNs**           | ARNs matching the specified `region`, `resource_type`, and `tags`.                                                                               |
+| **Dimension Values**        | Dimension values matching the specified `region`, `namespace`, `metric`, and `dimension key`. Use dimension `filters` for more specific results. |
+| **EBS Volume IDs**          | Volume IDs matching the specified `region` and `instance ID`.                                                                                    |
+| **EC2 Instance Attributes** | Attributes matching the specified `region`, `attribute name`, and `filters`.                                                                     |
+| **Resource ARNs**           | ARNs matching the specified `region`, `resource type`, and `tags`.                                                                               |
 | **Statistics**              | All standard statistics.                                                                                                                         |
-| **LogGroups**               | All log groups matching the specified `region`.                                                                                                  |
+| **Log Groups**              | Log groups matching the specified `region` and optional log group `prefix`. The variable value is the log group ARN.                             |
+| **Accounts**                | The IDs of linked monitoring accounts for the specified `region`. Available only when cross-account observability is enabled.                    |
+
+When cross-account observability is enabled, the **Metrics**, **Dimension Keys**, **Dimension Values**, and **Log Groups** query types also show an optional **Account** field. Use it to target a specific linked monitoring account, or leave it unset to query all linked accounts. For more information, refer to [Cross-account observability](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/aws-cloudwatch/query-editor/#cross-account-observability).
 
 For details on the available dimensions, refer to the [CloudWatch Metrics and Dimensions Reference](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CW_Support_For_AWS.html).
 
@@ -52,23 +54,32 @@ For details about the metrics CloudWatch provides, refer to the [CloudWatch docu
 
 ### Use variables in queries
 
-Use the Grafana variable syntax to include variables in queries. A query variable in dynamically retrieves values from your data source using a query.
+Use the Grafana variable syntax to include variables in queries. A query variable dynamically retrieves values from your data source using a query.
 For details, refer to the [variable syntax documentation](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/variables/variable-syntax/).
 
-## Use ec2_instance_attribute
+CloudWatch metric queries support variables in the **Region**, **Namespace**, **Metric name**, dimension key, and dimension value fields.
 
-The `ec2_instance_attribute` function in template variables allows Grafana to retrieve certain instance metadata from the EC2 metadata service, including `Instance ID` and `region`.
+For example, if you create a variable named `region` with the **Regions** query type and a variable named `instance` with the **EC2 Instance Attributes** query type, you can reference them in a metric query by setting the query editor **Region** to `$region` and a dimension value to `$instance`. The dashboard then updates as you change the selected region and instance.
+
+## Query EC2 instance attributes
+
+The **EC2 Instance Attributes** query type retrieves instance metadata using the AWS [`ec2:DescribeInstances`](http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstances.html) API. Configure it with the following fields in the variable editor:
+
+- **Region:** The AWS region to query.
+- **Attribute name:** The instance attribute to return for each matching instance.
+- **Filters:** _Optional._ Filters that limit which instances are returned.
+
+{{< admonition type="note" >}}
+The earlier `ec2_instance_attribute(region, attributeName, filters)` query syntax is still supported. Grafana automatically migrates existing variables that use it to the EC2 Instance Attributes query type.
+{{< /admonition >}}
 
 ### Filters
 
-The `ec2_instance_attribute` query takes a `filters` parameter, where each key is a filter name (such as a tag or instance property), and each value is a comma-separated list of matching values.
-
-You can specify [pre-defined filters of ec2:DescribeInstances](http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstances.html).
+Each filter has a key and a comma-separated list of matching values. Use the [filters supported by `ec2:DescribeInstances`](http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstances.html), such as instance properties. To filter by tag, use a key in the form `tag:<name>`, for example `tag:Environment`.
 
 ### Select attributes
 
-A query returns only one attribute per instance.
-You can select any attribute that has a single value and isn't an object or array, also known as a `flat attribute`:
+A query returns one attribute per instance. You can select any attribute that has a single value and isn't an object or array, also known as a flat attribute. These attributes mirror the fields of the AWS EC2 [`Instance`](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_Instance.html) object, where you can find a definition of each one. Because the available attributes track the AWS API, the following list might not be exhaustive:
 
 - `AmiLaunchIndex`
 - `Architecture`
@@ -76,7 +87,6 @@ You can select any attribute that has a single value and isn't an object or arra
 - `EbsOptimized`
 - `EnaSupport`
 - `Hypervisor`
-- `IamInstanceProfile`
 - `ImageId`
 - `InstanceId`
 - `InstanceLifecycle`
@@ -99,5 +109,6 @@ You can select any attribute that has a single value and isn't an object or arra
 - `VirtualizationType`
 - `VpcId`
 
-You can select tags by prepending the tag name with `Tags.`.
-For example, select the tag `Name` by using `Tags.Name`.
+Some attributes are objects rather than flat values. To select a nested value, use dot notation, for example `IamInstanceProfile.Arn`.
+
+To select a tag value, prepend the tag name with `Tags.`. For example, select the `Name` tag by using `Tags.Name`.

--- a/docs/sources/datasources/aws-cloudwatch/troubleshooting/index.md
+++ b/docs/sources/datasources/aws-cloudwatch/troubleshooting/index.md
@@ -18,6 +18,7 @@ labels:
 menuTitle: Troubleshooting
 title: Troubleshoot Amazon CloudWatch data source issues
 weight: 500
+review_date: 2026-06-23
 ---
 
 # Troubleshoot Amazon CloudWatch data source issues
@@ -30,7 +31,14 @@ The data source health check validates both metrics and logs permissions. If you
 
 ## Authentication errors
 
-These errors occur when AWS credentials are invalid, missing, or don't have the required permissions.
+These errors occur when AWS credentials are invalid, missing, or don't have the required permissions. Use the following table to match the error message you see to its most likely cause and the section that resolves it.
+
+| Error message                                                                                                  | Likely cause                                                                                            | Refer to                                                                                                                                |
+| -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `AccessDenied: User is not authorized to perform: cloudwatch:...`                                              | The IAM policy is missing required CloudWatch permissions.                                              | [Access Denied or Not authorized to perform this operation](#access-denied-or-not-authorized-to-perform-this-operation)                 |
+| `InvalidClientTokenId` or `UnrecognizedClientException: The security token included in the request is invalid` | Credentials are invalid, deactivated, or rotated, or a transient Grafana Cloud incident is in progress. | [InvalidClientTokenId or UnrecognizedClientException](#invalidclienttokenid-or-unrecognizedclientexception)                             |
+| `AccessDenied: ... not authorized to perform: sts:AssumeRole`                                                  | The role trust relationship, role ARN, or external ID is incorrect.                                     | [Unable to assume role](#unable-to-assume-role)                                                                                         |
+| `AccessDenied: ... no VPC endpoint policy allows the cloudwatch:ListMetrics action`                            | A VPC endpoint policy or service control policy (SCP) blocks the action.                                | [Access blocked by a VPC endpoint policy or service control policy](#access-blocked-by-a-vpc-endpoint-policy-or-service-control-policy) |
 
 ### "Access Denied" or "Not authorized to perform this operation"
 
@@ -42,25 +50,48 @@ These errors occur when AWS credentials are invalid, missing, or don't have the 
 
 **Possible causes and solutions:**
 
-| Cause                                   | Solution                                                                                                                                                                                                                                                                                                                                                                                                                              |
-| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| IAM policy missing required permissions | Attach the appropriate IAM policy to your user or role. For metrics, you need `cloudwatch:ListMetrics`, `cloudwatch:GetMetricData`, and related permissions. For logs, you need `logs:DescribeLogGroups`, `logs:StartQuery`, `logs:GetQueryResults`, and related permissions. Refer to [Configure CloudWatch](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/aws-cloudwatch/configure/) for complete policy examples. |
-| Incorrect access key or secret key      | Verify the credentials in the AWS Console under **IAM** > **Users** > your user > **Security credentials**. Generate new credentials if necessary.                                                                                                                                                                                                                                                                                    |
-| Credentials have expired                | For temporary credentials, generate new ones. For access keys, verify they haven't been deactivated or deleted.                                                                                                                                                                                                                                                                                                                       |
-| Wrong AWS region                        | Verify the default region in the data source configuration matches where your resources are located.                                                                                                                                                                                                                                                                                                                                  |
-| Assume Role ARN is incorrect            | Verify the role ARN format: `arn:aws:iam::<account-id>:role/<role-name>`. Check that the role exists in the AWS Console.                                                                                                                                                                                                                                                                                                              |
+| Cause                                            | Solution                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| IAM policy missing required permissions          | Attach the appropriate IAM policy to your user or role. For metrics, you need `cloudwatch:ListMetrics`, `cloudwatch:GetMetricData`, and related permissions. For logs, you need `logs:DescribeLogGroups`, `logs:StartQuery`, `logs:GetQueryResults`, and related permissions. Refer to [Configure CloudWatch](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/aws-cloudwatch/configure/) for complete policy examples. |
+| Incorrect access key or secret key               | Verify the credentials in the AWS Console under **IAM** > **Users** > your user > **Security credentials**. Generate new credentials if necessary.                                                                                                                                                                                                                                                                                    |
+| Credentials have expired                         | For temporary credentials, generate new ones. For access keys, verify they haven't been deactivated or deleted.                                                                                                                                                                                                                                                                                                                       |
+| Wrong AWS region                                 | Verify the default region in the data source configuration matches where your resources are located.                                                                                                                                                                                                                                                                                                                                  |
+| IAM role lacks permissions in the queried region | AWS evaluates permissions per region. If your role only has CloudWatch access in some regions, querying another region returns `AccessDenied`, and the error might not name the region. Set the data source **Default Region** to a region where your role has permissions, and only query regions your IAM policy allows.                                                                                                            |
+| Assume Role ARN is incorrect                     | Verify the role ARN format: `arn:aws:iam::<account-id>:role/<role-name>`. Check that the role exists in the AWS Console.                                                                                                                                                                                                                                                                                                              |
+
+<!-- vale Grafana.Headings = NO -->
+
+### "InvalidClientTokenId" or "UnrecognizedClientException"
+
+<!-- vale Grafana.Headings = YES -->
+
+**Symptoms:**
+
+- Save & test fails with `InvalidClientTokenId: The security token included in the request is invalid`
+- Queries fail with `UnrecognizedClientException: The security token included in the request is invalid`
+- The error appears suddenly without any configuration change
+
+**Possible causes and solutions:**
+
+| Cause                                             | Solution                                                                                                                                                                                                                                 |
+| ------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Access key or secret key is invalid or mistyped   | Verify the credentials in the AWS Console under **IAM** > **Users** > your user > **Security credentials**. Re-enter them in the data source configuration.                                                                              |
+| Credentials were deactivated, deleted, or rotated | Generate new credentials in AWS and update the data source configuration.                                                                                                                                                                |
+| Temporary credentials expired                     | Generate new temporary credentials, or switch to a long-lived authentication method such as Assume Role.                                                                                                                                 |
+| Transient Grafana Cloud incident                  | If multiple data sources fail at the same time with `InvalidClientTokenId` and your credentials are unchanged, check the [Grafana Cloud status page](https://status.grafana.com/) for an ongoing incident before you rotate credentials. |
 
 ### "Unable to assume role"
 
 **Symptoms:**
 
 - Authentication fails when using Assume Role ARN
-- Error message references STS or AssumeRole
+- Error references STS or AssumeRole, for example, `AccessDenied: User is not authorized to perform: sts:AssumeRole`
 
 **Solutions:**
 
 1. Verify the trust relationship on the IAM role allows the Grafana credentials to assume it.
 1. Check the trust policy includes the correct principal (the user or role running Grafana).
+1. If you use the **Grafana Assume Role** authentication method, confirm the trust policy uses the exact Grafana AWS account ID and external ID shown in the instructions box on the data source's **Settings** tab. Entering a different account ID is a common mistake that causes the assume-role request to fail.
 1. If using an external ID, ensure it matches exactly in both the role's trust policy and the Grafana data source configuration.
 1. Verify the base credentials have the `sts:AssumeRole` permission.
 1. Check that the role ARN is correct and the role exists.
@@ -87,6 +118,52 @@ These errors occur when AWS credentials are invalid, missing, or don't have the 
 }
 ```
 
+### "Save & test" passes but queries return no data
+
+**Symptoms:**
+
+- **Save & test** succeeds, but panels and the query editor return no data
+- Namespaces, metrics, or dimensions don't load even though the connection test passed
+- The issue appears only when you use an **Assume Role ARN**
+
+**Possible causes and solutions:**
+
+| Cause                                                   | Solution                                                                                                                                                                                                                                                                                                                               |
+| ------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| The connection test only validates the assume-role step | When you configure an **Assume Role ARN**, **Save & test** confirms that the primary credentials can perform `sts:AssumeRole`. It doesn't verify that the assumed role has CloudWatch or Logs permissions. Attach the required query permissions to the assumed role, not only to the primary credentials.                             |
+| The assumed role is missing CloudWatch permissions      | Add the metrics and logs actions, such as `cloudwatch:ListMetrics`, `cloudwatch:GetMetricData`, `logs:DescribeLogGroups`, and `logs:StartQuery`, to the assumed role's policy. Refer to [Configure CloudWatch](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/aws-cloudwatch/configure/) for complete policy examples. |
+| Permissions are attached to the wrong identity          | Confirm that the policy is attached to the role named in **Assume Role ARN**, not to the IAM user or role that provides the primary credentials.                                                                                                                                                                                       |
+
+### Data source stops working after about an hour
+
+**Symptoms:**
+
+- The data source works initially, then queries fail after roughly an hour
+- Errors reference an expired or invalid security token
+- Saving the data source again, or restarting Grafana, temporarily restores access until it fails again
+
+**Possible causes and solutions:**
+
+| Cause                                               | Solution                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| --------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Temporary credentials expired and weren't refreshed | Methods that use temporary credentials, such as Assume Role or STS, issue short-lived tokens. If the data source uses static temporary credentials, switch to an authentication method that refreshes automatically, such as Assume Role with long-lived base credentials or an EKS/EC2 instance role. Refer to [AWS authentication](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/aws-cloudwatch/aws-authentication/). |
+
+### Access blocked by a VPC endpoint policy or service control policy
+
+**Symptoms:**
+
+- Credentials are valid and the IAM policy grants the action, but requests still fail with `AccessDenied`
+- The error references a VPC endpoint policy, for example, `AccessDenied: ... no VPC endpoint policy allows the cloudwatch:ListMetrics action`
+- Access fails only from within a VPC or in a restricted account, such as a FedRAMP environment
+
+**Possible causes and solutions:**
+
+| Cause                                                              | Solution                                                                                                                                                                                                |
+| ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| A VPC endpoint policy restricts which actions are allowed          | Update the policy on the CloudWatch, Logs, EC2, or STS VPC endpoints to allow the required actions, such as `cloudwatch:ListMetrics` and `cloudwatch:GetMetricData`.                                    |
+| A service control policy (SCP) explicitly denies a required action | Review the service control policies applied to the account or organizational unit. An explicit `Deny` in an SCP overrides any `Allow` in an IAM policy, so the action must be permitted at both levels. |
+| Requests route through the wrong endpoint                          | Confirm that the data source region and any custom endpoint match the VPC endpoints that permit the required actions.                                                                                   |
+
 ### AWS SDK Default authentication not working
 
 **Symptoms:**
@@ -104,7 +181,7 @@ These errors occur when AWS credentials are invalid, missing, or don't have the 
    - ECS task role (if running in ECS)
    - EKS service account (if running in EKS)
 1. Ensure the Grafana process has permission to read the credentials file.
-1. For EKS with IRSA, set the pod's security context to allow user 472 (grafana) to access the projected token. Refer to [AWS authentication](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/aws-cloudwatch/aws-authentication/) for details.
+1. For EKS with IRSA, set the pod's security context to allow user `472` (`grafana`) to access the projected token. Refer to [AWS authentication](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/aws-cloudwatch/aws-authentication/) for details.
 
 ### Credentials file not found
 
@@ -183,13 +260,15 @@ These errors occur when querying CloudWatch Metrics.
 
 - Expected metrics don't appear in the query editor
 - Metric drop-down is empty for a namespace
+- A specific metric is missing from the drop-down even though it exists in the CloudWatch console
 
 **Solutions:**
 
 1. Verify the metric exists in the selected region.
 1. For custom metrics, add the namespace to **Namespaces of Custom Metrics** in the data source configuration.
 1. Check that the IAM policy includes `cloudwatch:ListMetrics` permission.
-1. CloudWatch limits `ListMetrics` to 500 results per page. To retrieve more metrics, increase the `list_metrics_page_limit` setting in the [Grafana configuration file](https://grafana.com/docs/grafana/latest/datasources/aws-cloudwatch/configure/#configure-the-data-source-with-grafanaini).
+1. CloudWatch limits `ListMetrics` to 500 results per page. To retrieve more metrics, increase the `list_metrics_page_limit` setting in the [Grafana configuration file](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/aws-cloudwatch/configure/#configure-the-data-source-with-grafanaini).
+1. Type the metric name directly into the **Metric name** field. For some AWS namespaces, the data source uses a predefined metric list, so newer or less common metrics might not appear in the drop-down even though you can still query them. If the metric exists in your CloudWatch console, enter its exact name to query it.
 1. Use the Query Inspector to verify the API request and response.
 
 ### Dimension values not loading
@@ -220,6 +299,8 @@ These errors occur when querying CloudWatch Metrics.
 1. Use fewer dimensions or wildcard queries per panel.
 1. Request a quota increase for `GetMetricData` requests per second in the [AWS Service Quotas console](https://console.aws.amazon.com/servicequotas/).
 1. Enable query caching in Grafana to reduce API calls.
+
+This section covers throttling at the query level. For account-wide rate limits and quota increases, refer to [API throttling errors](#api-throttling-errors).
 
 ### Metric math expression errors
 
@@ -264,11 +345,11 @@ These errors occur when querying CloudWatch Logs.
 
 **Solutions:**
 
-1. Increase the **Query timeout result** setting in the data source configuration (default is 30 minutes).
+1. Increase the **Query Result Timeout** setting in the data source configuration (default is 30 minutes).
 1. Narrow the time range to reduce the amount of data scanned.
 1. Add filters to your query to limit results.
 1. Break complex queries into smaller, more focused queries.
-1. For alerting, the timeout defined in the [Grafana configuration file](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#unified_alerting) takes precedence.
+1. For alerting, the timeout defined in the [Grafana configuration file](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#unified_alerting) takes precedence.
 
 ### Log groups not appearing in selector
 
@@ -400,6 +481,8 @@ These issues relate to AWS service quotas and cost management.
 1. Enable query caching in Grafana (available in Grafana Enterprise and Grafana Cloud).
 1. Request a quota increase in the [AWS Service Quotas console](https://console.aws.amazon.com/servicequotas/).
 1. Consider consolidating similar queries using metric math.
+
+If throttling happens because a single query returns too many data points, refer to ["Too many data points" or API throttling](#too-many-data-points-or-api-throttling).
 
 ### Unexpectedly high CloudWatch costs
 


### PR DESCRIPTION
Backport of #127197 to `release-13.0.4`.

Backport 1348d6647be3d3b9f79f005468b0d44bd6acfa94 from #127197.

## Conflict resolution

One conflict in `docs/sources/datasources/aws-cloudwatch/query-editor/index.md` on the **Query inspector** link. The original PR changed a path segment on `main`, but `main` and `release-13.0.4` had diverged on the anchor for the target section:

- Kept the 13.0.4 anchor `#navigate-the-query-tab` (the target heading in 13.0.4 is `Navigate the Queries tab {#navigate-the-query-tab}`; `#navigate-the-query-editor` would be a broken anchor in this version).
- Kept the existing 13.0.4 link path convention to avoid introducing an unrelated change.

All other files from the PR auto-merged cleanly.

<!-- vale = NO -->

Made with [Cursor](https://cursor.com)