### PR TITLE
Plugins: Convert catalog module hash to SRI format

### DIFF
--- a/apps/plugins/pkg/app/meta/catalog_test.go
+++ b/apps/plugins/pkg/app/meta/catalog_test.go
@@ -48,8 +48,8 @@ func TestCatalogProvider_GetMeta(t *testing.T) {
 				CreatePluginVersion: "4.15.0",
 				Manifest: grafanaComPluginManifest{
 					Files: map[string]string{
-						"module.js":                   "hash123",
-						"test-child-plugin/module.js": "child-hash123",
+						"module.js":                   "deadbeef",
+						"test-child-plugin/module.js": "beefcafe",
 					},
 				},
 				Children: []grafanaComChildPluginVersion{
@@ -80,7 +80,8 @@ func TestCatalogProvider_GetMeta(t *testing.T) {
 		assert.Equal(t, pluginsv0alpha1.MetaV0alpha1SpecSignatureTypeGrafana, *result.Meta.Signature.Type)
 		assert.Equal(t, "grafana", *result.Meta.Signature.Org)
 		assert.Equal(t, result.Meta.Module.Path, "https://cdn.grafana.com/plugins/test-plugin/1.0.0/module.js")
-		assert.Equal(t, "hash123", *result.Meta.Module.Hash)
+		// The manifest stores a raw hex hash; the meta exposes it in SRI format.
+		assert.Equal(t, "sha256-3q2+7w==", *result.Meta.Module.Hash)
 		assert.Equal(t, pluginsv0alpha1.MetaV0alpha1SpecModuleLoadingStrategyScript, result.Meta.Module.LoadingStrategy)
 		assert.Equal(t, "https://cdn.grafana.com/plugins/test-plugin/1.0.0", result.Meta.BaseURL)
 		assert.Equal(t, []string{"test-child-plugin"}, result.Meta.Children)
@@ -110,7 +111,7 @@ func TestCatalogProvider_GetMeta(t *testing.T) {
 
 			// Child has its own module path based on child path
 			assert.Equal(t, "https://cdn.grafana.com/plugins/test-plugin/1.0.0/test-child-plugin/module.js", childResult.Meta.Module.Path)
-			assert.Equal(t, "child-hash123", *childResult.Meta.Module.Hash)
+			assert.Equal(t, "sha256-vu/K/g==", *childResult.Meta.Module.Hash)
 
 			// BaseURL should be constructed from parent CDNURL + child path
 			assert.Equal(t, "https://cdn.grafana.com/plugins/test-plugin/1.0.0/test-child-plugin", childResult.Meta.BaseURL)
@@ -140,7 +141,7 @@ func TestCatalogProvider_GetMeta(t *testing.T) {
 				CreatePluginVersion: "4.15.0",
 				Manifest: grafanaComPluginManifest{
 					Files: map[string]string{
-						"module.js": "hash123",
+						"module.js": "deadbeef",
 					},
 				},
 			}
@@ -349,7 +350,7 @@ func TestCatalogProvider_GetMeta(t *testing.T) {
 						CreatePluginVersion: tc.createPluginVersion,
 						Manifest: grafanaComPluginManifest{
 							Files: map[string]string{
-								"module.js": "hash123",
+								"module.js": "deadbeef",
 							},
 						},
 					}

--- a/apps/plugins/pkg/app/meta/converter.go
+++ b/apps/plugins/pkg/app/meta/converter.go
@@ -1,6 +1,8 @@
 package meta
 
 import (
+	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -804,6 +806,17 @@ func blankPluginPlaceholder(v, placeholder string) string {
 	return v
 }
 
+// convertHashForSRI takes a hex-encoded SHA-256 hash (as stored in the plugin
+// manifest) and returns it in the Subresource Integrity format expected by the
+// browser: "sha256-<base64>".
+func convertHashForSRI(h string) (string, error) {
+	hb, err := hex.DecodeString(h)
+	if err != nil {
+		return "", fmt.Errorf("hex decode string: %w", err)
+	}
+	return "sha256-" + base64.StdEncoding.EncodeToString(hb), nil
+}
+
 // grafanaComPluginVersionMetaToMetaSpec converts a grafanaComPluginVersionMeta to a pluginsv0alpha1.MetaSpec.
 func grafanaComPluginVersionMetaToMetaSpec(logger logging.Logger, gcomMeta grafanaComPluginVersionMeta, pluginRelBasePath string) (pluginsv0alpha1.MetaSpec, error) {
 	metaSpec := pluginsv0alpha1.MetaSpec{
@@ -879,7 +892,14 @@ func grafanaComPluginVersionMetaToMetaSpec(logger logging.Logger, gcomMeta grafa
 		LoadingStrategy: loadingStrategy,
 	}
 	if ok {
-		module.Hash = &moduleHash
+		// The manifest stores the module hash as a raw hex SHA-256, but the frontend
+		// uses it as a Subresource Integrity value, which must be "sha256-<base64>".
+		sri, err := convertHashForSRI(moduleHash)
+		if err != nil {
+			logger.Warn("Failed to convert module hash to SRI format", "pluginId", gcomMeta.PluginSlug, "version", gcomMeta.Version, "error", err)
+		} else {
+			module.Hash = &sri
+		}
 	}
 	metaSpec.Module = module
 	metaSpec.BaseURL = gcomMeta.CDNURL

--- a/apps/plugins/pkg/app/meta/converter_test.go
+++ b/apps/plugins/pkg/app/meta/converter_test.go
@@ -572,7 +572,7 @@ func TestGrafanaComChildPluginVersionToMetaSpec(t *testing.T) {
 			CDNURL:              "https://cdn.grafana.com",
 			CreatePluginVersion: "2023-01-01",
 			Manifest: grafanaComPluginManifest{
-				Files: map[string]string{"child-plugin/module.js": "hash123"},
+				Files: map[string]string{"child-plugin/module.js": "deadbeef"},
 			},
 		}
 
@@ -604,7 +604,7 @@ func TestGrafanaComPluginVersionMetaToMetaSpec(t *testing.T) {
 			CDNURL:              "https://cdn.grafana.com/plugins/test-plugin/1.0.0",
 			CreatePluginVersion: "2023-01-01",
 			Manifest: grafanaComPluginManifest{
-				Files: map[string]string{"test-plugin/module.js": "hash123"},
+				Files: map[string]string{"test-plugin/module.js": "deadbeef"},
 			},
 			Children: []grafanaComChildPluginVersion{
 				{Slug: "child1"},
@@ -620,7 +620,8 @@ func TestGrafanaComPluginVersionMetaToMetaSpec(t *testing.T) {
 		assert.Equal(t, pluginsv0alpha1.MetaV0alpha1SpecSignatureTypeGrafana, *meta.Signature.Type)
 		assert.Equal(t, "grafana", *meta.Signature.Org)
 		assert.Equal(t, "https://cdn.grafana.com/plugins/test-plugin/1.0.0/module.js", meta.Module.Path)
-		assert.Equal(t, "hash123", *meta.Module.Hash)
+		// The manifest stores a raw hex hash; the meta exposes it in SRI format.
+		assert.Equal(t, "sha256-3q2+7w==", *meta.Module.Hash)
 		assert.Equal(t, "https://cdn.grafana.com/plugins/test-plugin/1.0.0", meta.BaseURL)
 		assert.Equal(t, []string{"child1", "child2"}, meta.Children)
 	})
@@ -693,7 +694,7 @@ func TestGrafanaComPluginVersionMetaToMetaSpec(t *testing.T) {
 					CDNURL:              "https://cdn.grafana.com",
 					CreatePluginVersion: "2023-01-01",
 					Manifest: grafanaComPluginManifest{
-						Files: map[string]string{"test-plugin/module.js": "hash123"},
+						Files: map[string]string{"test-plugin/module.js": "deadbeef"},
 					},
 				}
 
@@ -723,6 +724,43 @@ func TestGrafanaComPluginVersionMetaToMetaSpec(t *testing.T) {
 		assert.Nil(t, meta.Module.Hash)
 	})
 
+	t.Run("converts hex module hash from manifest to SRI format", func(t *testing.T) {
+		gcomMeta := grafanaComPluginVersionMeta{
+			PluginSlug:          "test-plugin",
+			Version:             "1.0.0",
+			JSON:                grafanaComPluginVersionMetaJSON{MetaJSONData: pluginsv0alpha1.MetaJSONData{Id: "test-plugin"}},
+			CDNURL:              "https://cdn.grafana.com",
+			CreatePluginVersion: "2023-01-01",
+			Manifest: grafanaComPluginManifest{
+				// Real hex SHA-256 as stored in a plugin MANIFEST.txt.
+				Files: map[string]string{"test-plugin/module.js": "ebe64ea0588179f2affdcb0f7dcb63e323b3852a920d3582bf0f1f070fb75678"},
+			},
+		}
+
+		meta, err := grafanaComPluginVersionMetaToMetaSpec(&logging.NoOpLogger{}, gcomMeta, "test-plugin")
+		require.NoError(t, err)
+		require.NotNil(t, meta.Module.Hash)
+		assert.Equal(t, "sha256-6+ZOoFiBefKv/csPfctj4yOzhSqSDTWCvw8fBw+3Vng=", *meta.Module.Hash)
+	})
+
+	t.Run("handles a non-hex module hash gracefully", func(t *testing.T) {
+		gcomMeta := grafanaComPluginVersionMeta{
+			PluginSlug:          "test-plugin",
+			Version:             "1.0.0",
+			JSON:                grafanaComPluginVersionMetaJSON{MetaJSONData: pluginsv0alpha1.MetaJSONData{Id: "test-plugin"}},
+			CDNURL:              "https://cdn.grafana.com",
+			CreatePluginVersion: "2023-01-01",
+			Manifest: grafanaComPluginManifest{
+				Files: map[string]string{"test-plugin/module.js": "not-a-hex-hash"},
+			},
+		}
+
+		meta, err := grafanaComPluginVersionMetaToMetaSpec(&logging.NoOpLogger{}, gcomMeta, "test-plugin")
+		require.NoError(t, err)
+		require.NotNil(t, meta.Module)
+		assert.Nil(t, meta.Module.Hash)
+	})
+
 	t.Run("extracts aliasIDs from JSON field", func(t *testing.T) {
 		gcomMeta := grafanaComPluginVersionMeta{
 			PluginSlug: "grafana-postgresql-datasource",
@@ -739,7 +777,7 @@ func TestGrafanaComPluginVersionMetaToMetaSpec(t *testing.T) {
 			CDNURL:              "https://cdn.grafana.com/plugins/grafana-postgresql-datasource/5.0.0",
 			CreatePluginVersion: "2023-01-01",
 			Manifest: grafanaComPluginManifest{
-				Files: map[string]string{"module.js": "hash123"},
+				Files: map[string]string{"module.js": "deadbeef"},
 			},
 		}
 
@@ -760,7 +798,7 @@ func TestGrafanaComPluginVersionMetaToMetaSpec(t *testing.T) {
 			CDNURL:              "https://cdn.grafana.com",
 			CreatePluginVersion: "2023-01-01",
 			Manifest: grafanaComPluginManifest{
-				Files: map[string]string{"module.js": "hash123"},
+				Files: map[string]string{"module.js": "deadbeef"},
 			},
 		}
 


### PR DESCRIPTION
## What

The MT plugin meta **catalog provider** (`apps/plugins/pkg/app/meta`) takes the `module.js` hash straight from the grafana.com plugin manifest — where it is stored as a **raw hex SHA-256** — and exposes it as `spec.module.hash`.

The frontend feeds that value to SystemJS as a **Subresource Integrity** value, which must be `sha256-<base64>`. A bare hex string is rejected by the browser:

> Error parsing 'integrity' attribute (...). The hash algorithm must be one of 'sha256', 'sha384', 'sha512', or 'ed21159', followed by a '-' character.

As a result, **every CDN-hosted plugin fails to load** (the module script fails its integrity check) whenever `pluginsSriChecks` is enabled and the plugin meta comes from the catalog provider.

## Why

The single-tenant path already converts the manifest hash before exposing it — see `convertHashForSRI` in `pkg/plugins/pluginassets/modulehash/modulehash.go`. The catalog converter was missing the equivalent step.
