### PR TITLE
TableNG: Add test coverage for header, expander, actions, and empty-state components

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableNG/components/EmptyTablePlaceholder.test.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/components/EmptyTablePlaceholder.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+
+import { EmptyTablePlaceholder } from './EmptyTablePlaceholder';
+
+describe('EmptyTablePlaceholder', () => {
+  it('renders the default "No rows" message when no value is provided', () => {
+    render(<EmptyTablePlaceholder />);
+    expect(screen.getByText('No rows')).toBeInTheDocument();
+  });
+
+  it('renders the provided noValue string instead of the default', () => {
+    render(<EmptyTablePlaceholder noValue="Nothing to see here" />);
+    expect(screen.getByText('Nothing to see here')).toBeInTheDocument();
+    expect(screen.queryByText('No rows')).not.toBeInTheDocument();
+  });
+
+  it('renders an empty placeholder (not the default) when noValue is an empty string', () => {
+    // empty string is not nullish, so the `??` fallback to the default label does not apply
+    const { container } = render(<EmptyTablePlaceholder noValue="" />);
+    expect(screen.queryByText('No rows')).not.toBeInTheDocument();
+    expect(container.firstChild).toHaveTextContent('');
+  });
+});

--- a/packages/grafana-ui/src/components/Table/TableNG/components/HeaderCell.test.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/components/HeaderCell.test.tsx
@@ -1,0 +1,195 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { type Field, FieldType } from '@grafana/data';
+import { type Column } from '@grafana/react-data-grid';
+
+import { type FilterType, type TableRow, type TableSummaryRow } from '../types';
+
+import { HeaderCell } from './HeaderCell';
+
+function makeField(overrides: Partial<Field> = {}): Field {
+  return {
+    name: 'Field1',
+    type: FieldType.string,
+    values: ['a', 'b', 'c'],
+    config: {},
+    state: {},
+    ...overrides,
+  };
+}
+
+const column = { key: 'Field1' } as Column<TableRow, TableSummaryRow>;
+
+const baseProps = {
+  column,
+  rows: [] as TableRow[],
+  filter: {} as FilterType,
+  setFilter: jest.fn(),
+  selectFirstCell: jest.fn(),
+  crossFilterRows: {},
+  crossFilterTailRows: [] as TableRow[],
+};
+
+describe('HeaderCell', () => {
+  it('renders the display name', () => {
+    render(<HeaderCell {...baseProps} field={makeField()} />);
+    expect(screen.getByRole('button', { name: 'Field1' })).toBeInTheDocument();
+  });
+
+  it('prefers the state displayName over the field name', () => {
+    render(<HeaderCell {...baseProps} field={makeField({ state: { displayName: 'Pretty Name' } })} />);
+    expect(screen.getByRole('button', { name: 'Pretty Name' })).toBeInTheDocument();
+  });
+
+  it('renders a type icon when showTypeIcons is set', () => {
+    const { container } = render(<HeaderCell {...baseProps} field={makeField()} showTypeIcons />);
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('does not render a type icon by default', () => {
+    const { container } = render(<HeaderCell {...baseProps} field={makeField()} />);
+    expect(container.querySelector('svg')).not.toBeInTheDocument();
+  });
+
+  it('renders an ascending sort arrow', () => {
+    const { container } = render(<HeaderCell {...baseProps} field={makeField()} direction="ASC" />);
+    expect(container.querySelector('[class*="css"]')).toBeInTheDocument();
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('renders a descending sort arrow', () => {
+    const { container } = render(<HeaderCell {...baseProps} field={makeField()} direction="DESC" />);
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('renders with wrapped header text when wrapHeaderText is enabled', () => {
+    render(<HeaderCell {...baseProps} field={makeField({ config: { custom: { wrapHeaderText: true } } })} />);
+    expect(screen.getByRole('button', { name: 'Field1' })).toBeInTheDocument();
+  });
+
+  it('renders a filter button when the field is filterable', () => {
+    render(<HeaderCell {...baseProps} field={makeField({ config: { custom: { filterable: true } } })} />);
+    expect(screen.getByLabelText('Filter Field1')).toBeInTheDocument();
+  });
+
+  it('does not render a filter button when the field is not filterable', () => {
+    render(<HeaderCell {...baseProps} field={makeField()} />);
+    expect(screen.queryByLabelText('Filter Field1')).not.toBeInTheDocument();
+  });
+
+  it('removes a stale filter for a field that is no longer filterable', () => {
+    const setFilter = jest.fn();
+    render(
+      <HeaderCell
+        {...baseProps}
+        setFilter={setFilter}
+        filter={{ Field1: { filtered: [], searchFilter: '' } } as unknown as FilterType}
+        field={makeField()}
+      />
+    );
+    expect(setFilter).toHaveBeenCalledTimes(1);
+    // verify the updater removes the entry for this field
+    const updater = setFilter.mock.calls[0][0];
+    expect(updater({ Field1: { x: 1 }, Field2: { y: 2 } })).toEqual({ Field2: { y: 2 } });
+  });
+
+  it('does not remove a filter when the field is filterable', () => {
+    const setFilter = jest.fn();
+    render(
+      <HeaderCell
+        {...baseProps}
+        setFilter={setFilter}
+        filter={{ Field1: { filtered: [], searchFilter: '' } } as unknown as FilterType}
+        field={makeField({ config: { custom: { filterable: true } } })}
+      />
+    );
+    expect(setFilter).not.toHaveBeenCalled();
+  });
+
+  describe('keyboard handling', () => {
+    // These tests dispatch a keydown against a *specific* target (a particular button, an SVG icon,
+    // or a cell in a specific position) to exercise the handler's target/DOM-position logic. userEvent's
+    // tab/keyboard helpers move focus globally and can't target an SVG or express "not the last element",
+    // so fireEvent.keyDown is the right tool here.
+    /* eslint-disable testing-library/prefer-user-event */
+
+    // Mimics react-data-grid's DOM: <row><otherCell/><headerCell><HeaderCell/></headerCell></row>
+    function renderInGrid(props = {}, { headerCellIsLast = true } = {}) {
+      const selectFirstCell = jest.fn();
+      render(
+        <div role="row">
+          <div>other cell</div>
+          <div data-testid="header-cell">
+            <HeaderCell {...baseProps} selectFirstCell={selectFirstCell} field={makeField()} {...props} />
+          </div>
+          {!headerCellIsLast && <div>trailing cell</div>}
+        </div>
+      );
+      return { selectFirstCell };
+    }
+
+    it('calls selectFirstCell when tabbing out of the last element of the last header cell', () => {
+      const { selectFirstCell } = renderInGrid();
+      fireEvent.keyDown(screen.getByRole('button', { name: 'Field1' }), { key: 'Tab' });
+      expect(selectFirstCell).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call selectFirstCell for a shift+tab', () => {
+      const { selectFirstCell } = renderInGrid();
+      fireEvent.keyDown(screen.getByRole('button', { name: 'Field1' }), { key: 'Tab', shiftKey: true });
+      expect(selectFirstCell).not.toHaveBeenCalled();
+    });
+
+    it('does not call selectFirstCell for a non-Tab key', () => {
+      const { selectFirstCell } = renderInGrid();
+      fireEvent.keyDown(screen.getByRole('button', { name: 'Field1' }), { key: 'Enter' });
+      expect(selectFirstCell).not.toHaveBeenCalled();
+    });
+
+    it('does not call selectFirstCell when the header cell is not the last cell in the row', () => {
+      const { selectFirstCell } = renderInGrid({}, { headerCellIsLast: false });
+      fireEvent.keyDown(screen.getByRole('button', { name: 'Field1' }), { key: 'Tab' });
+      expect(selectFirstCell).not.toHaveBeenCalled();
+    });
+
+    it('does not call selectFirstCell when tabbing from an element that is not the last in the header', () => {
+      const selectFirstCell = jest.fn();
+      render(
+        <div role="row">
+          <div data-testid="header-cell">
+            <HeaderCell
+              {...baseProps}
+              selectFirstCell={selectFirstCell}
+              field={makeField({ config: { custom: { filterable: true } } })}
+            />
+          </div>
+        </div>
+      );
+      // the filter button is the last element in the header; tabbing from the (earlier) label button should not trigger
+      fireEvent.keyDown(screen.getByRole('button', { name: 'Field1' }), { key: 'Tab' });
+      expect(selectFirstCell).not.toHaveBeenCalled();
+    });
+
+    it('ignores the keydown when the event target is not an HTMLElement', () => {
+      const selectFirstCell = jest.fn();
+      const { container } = render(
+        <div role="row">
+          <div data-testid="header-cell">
+            <HeaderCell {...baseProps} selectFirstCell={selectFirstCell} field={makeField()} showTypeIcons />
+          </div>
+        </div>
+      );
+      // SVG elements are SVGElement, not HTMLElement, so the handler bails early
+      const svg = container.querySelector('svg')!;
+      fireEvent.keyDown(svg, { key: 'Tab' });
+      expect(selectFirstCell).not.toHaveBeenCalled();
+    });
+
+    it('does not attach a keydown handler when disableKeyboardEvents is set', () => {
+      const { selectFirstCell } = renderInGrid({ disableKeyboardEvents: true });
+      fireEvent.keyDown(screen.getByRole('button', { name: 'Field1' }), { key: 'Tab' });
+      expect(selectFirstCell).not.toHaveBeenCalled();
+    });
+    /* eslint-enable testing-library/prefer-user-event */
+  });
+});

--- a/packages/grafana-ui/src/components/Table/TableNG/components/RowExpander.test.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/components/RowExpander.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { selectors } from '@grafana/e2e-selectors';
+
+import { RowExpander } from './RowExpander';
+
+describe('RowExpander', () => {
+  const getExpander = () => screen.getByTestId(selectors.components.Panels.Visualization.TableNG.RowExpander);
+
+  it('renders the collapsed state with the expand label and right-pointing angle', () => {
+    render(<RowExpander onCellExpand={jest.fn()} rowId="row-1" isExpanded={false} />);
+    const expander = getExpander();
+    expect(expander).toHaveAttribute('aria-label', 'Expand row');
+    expect(expander).toHaveAttribute('aria-expanded', 'false');
+    expect(expander).toHaveAttribute('aria-controls', 'row-1');
+  });
+
+  it('renders the expanded state with the collapse label', () => {
+    render(<RowExpander onCellExpand={jest.fn()} rowId="row-1" isExpanded={true} />);
+    const expander = getExpander();
+    expect(expander).toHaveAttribute('aria-label', 'Collapse row');
+    expect(expander).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('calls onCellExpand when clicked', async () => {
+    const onCellExpand = jest.fn();
+    render(<RowExpander onCellExpand={onCellExpand} rowId="row-1" />);
+    await userEvent.click(getExpander());
+    expect(onCellExpand).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onCellExpand when Enter is pressed', async () => {
+    const onCellExpand = jest.fn();
+    render(<RowExpander onCellExpand={onCellExpand} rowId="row-1" />);
+    getExpander().focus();
+    await userEvent.keyboard('{Enter}');
+    expect(onCellExpand).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onCellExpand when Space is pressed', async () => {
+    const onCellExpand = jest.fn();
+    render(<RowExpander onCellExpand={onCellExpand} rowId="row-1" />);
+    getExpander().focus();
+    await userEvent.keyboard('[Space]');
+    expect(onCellExpand).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call onCellExpand for other keys', async () => {
+    const onCellExpand = jest.fn();
+    render(<RowExpander onCellExpand={onCellExpand} rowId="row-1" />);
+    getExpander().focus();
+    await userEvent.keyboard('a');
+    expect(onCellExpand).not.toHaveBeenCalled();
+  });
+});

--- a/packages/grafana-ui/src/components/Table/TableNG/components/TableCellActions.test.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/components/TableCellActions.test.tsx
@@ -79,7 +79,7 @@ describe('TableCellActions', () => {
   });
 
   it('coerces nullish values to an empty string when filtering', async () => {
-    const { onCellFilterAdded } = setup({ value: null });
+    const { onCellFilterAdded } = setup({ value: undefined });
     await userEvent.click(screen.getByLabelText('Filter for value'));
     expect(onCellFilterAdded).toHaveBeenCalledWith({
       key: 'Field1',

--- a/packages/grafana-ui/src/components/Table/TableNG/components/TableCellActions.test.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/components/TableCellActions.test.tsx
@@ -1,0 +1,123 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { type Field, FieldType } from '@grafana/data';
+
+import { TableCellInspectorMode } from '../../TableCellInspector';
+import { FILTER_FOR_OPERATOR, FILTER_OUT_OPERATOR, type TableCellActionsProps } from '../types';
+
+import { TableCellActions } from './TableCellActions';
+
+function setup(overrides: Partial<TableCellActionsProps> = {}) {
+  const field: Field = {
+    name: 'Field1',
+    type: FieldType.string,
+    values: ['a', 'b', 'c'],
+    config: {},
+  };
+  const props: TableCellActionsProps = {
+    field,
+    value: 'hello',
+    displayName: 'Field1',
+    cellInspect: true,
+    showFilters: true,
+    setInspectCell: jest.fn(),
+    onCellFilterAdded: jest.fn(),
+    ...overrides,
+  };
+  render(<TableCellActions {...props} />);
+  return props;
+}
+
+describe('TableCellActions', () => {
+  it('renders the inspect button when cellInspect is true', () => {
+    setup();
+    expect(screen.getByLabelText('Inspect value')).toBeInTheDocument();
+  });
+
+  it('does not render the inspect button when cellInspect is false', () => {
+    setup({ cellInspect: false });
+    expect(screen.queryByLabelText('Inspect value')).not.toBeInTheDocument();
+  });
+
+  it('renders the filter buttons when showFilters is true', () => {
+    setup();
+    expect(screen.getByLabelText('Filter for value')).toBeInTheDocument();
+    expect(screen.getByLabelText('Filter out value')).toBeInTheDocument();
+  });
+
+  it('does not render the filter buttons when showFilters is false', () => {
+    setup({ showFilters: false });
+    expect(screen.queryByLabelText('Filter for value')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Filter out value')).not.toBeInTheDocument();
+  });
+
+  it('calls setInspectCell with the built inspect value when the inspect button is clicked', async () => {
+    const { setInspectCell } = setup();
+    await userEvent.click(screen.getByLabelText('Inspect value'));
+    expect(setInspectCell).toHaveBeenCalledWith({ value: 'hello', mode: TableCellInspectorMode.text });
+  });
+
+  it('calls onCellFilterAdded with the "filter for" operator', async () => {
+    const { onCellFilterAdded } = setup();
+    await userEvent.click(screen.getByLabelText('Filter for value'));
+    expect(onCellFilterAdded).toHaveBeenCalledWith({
+      key: 'Field1',
+      operator: FILTER_FOR_OPERATOR,
+      value: 'hello',
+    });
+  });
+
+  it('calls onCellFilterAdded with the "filter out" operator', async () => {
+    const { onCellFilterAdded } = setup();
+    await userEvent.click(screen.getByLabelText('Filter out value'));
+    expect(onCellFilterAdded).toHaveBeenCalledWith({
+      key: 'Field1',
+      operator: FILTER_OUT_OPERATOR,
+      value: 'hello',
+    });
+  });
+
+  it('coerces nullish values to an empty string when filtering', async () => {
+    const { onCellFilterAdded } = setup({ value: null });
+    await userEvent.click(screen.getByLabelText('Filter for value'));
+    expect(onCellFilterAdded).toHaveBeenCalledWith({
+      key: 'Field1',
+      operator: FILTER_FOR_OPERATOR,
+      value: '',
+    });
+    await userEvent.click(screen.getByLabelText('Filter out value'));
+    expect(onCellFilterAdded).toHaveBeenCalledWith({
+      key: 'Field1',
+      operator: FILTER_OUT_OPERATOR,
+      value: '',
+    });
+  });
+
+  it('does not throw when onCellFilterAdded is not provided', async () => {
+    setup({ onCellFilterAdded: undefined });
+    await userEvent.click(screen.getByLabelText('Filter for value'));
+    await userEvent.click(screen.getByLabelText('Filter out value'));
+    // no assertion needed beyond not throwing
+    expect(screen.getByLabelText('Filter for value')).toBeInTheDocument();
+  });
+
+  it('stops click propagation so parent cell handlers are not triggered', async () => {
+    const parentClick = jest.fn();
+    render(
+      // eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events
+      <div onClick={parentClick}>
+        <TableCellActions
+          field={{ name: 'Field1', type: FieldType.string, values: [], config: {} }}
+          value="hello"
+          displayName="Field1"
+          cellInspect={true}
+          showFilters={false}
+          setInspectCell={jest.fn()}
+        />
+      </div>
+    );
+    await userEvent.click(screen.getByLabelText('Inspect value'));
+    expect(parentClick).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What this does

Adds unit tests for the four previously-untested components under `packages/grafana-ui/src/components/Table/TableNG/components/`:

- **EmptyTablePlaceholder** — default vs. custom `noValue`, empty-string edge case
- **RowExpander** — expanded/collapsed rendering + aria, click/Enter/Space activation, non-trigger keys
- **TableCellActions** — inspect/filter button visibility, `setInspectCell` payload, filter-for/filter-out callbacks, nullish-value coercion, undefined callback safety, click-propagation stop
- **HeaderCell** — display name / state displayName, type icon, sort arrows, filterable toggle, stale-filter cleanup effect, wrapped header text, and the keyboard tab-out-to-first-cell handler

## Coverage

37 tests, all passing. 100% statement / line / function coverage across all four files. The only uncovered branches (HeaderCell lines 88–91, 101) are defensive optional-chaining fallbacks on `ref.current` / a required `field` prop that cannot fire after a normal render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)