### PR TITLE
Unified Storage: Use grpc context cancelled status code instead of internal

### DIFF
--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"hash/fnv"
 	"math/rand"
@@ -672,8 +671,8 @@ func (s *searchServer) VectorSearch(ctx context.Context, req *resourcepb.VectorS
 		req.Key.Namespace, s.embedder.Model, req.Key.Resource,
 		dense, limit, translateVectorSearchFilters(req.Filters)...)
 	if err != nil {
-		if ctxErr := statusFromContextError(err); ctxErr != nil {
-			return nil, ctxErr
+		if ctx.Err() != nil {
+			return nil, status.FromContextError(ctx.Err()).Err()
 		}
 		s.log.Error("vector search: backend", "err", err)
 		return nil, status.Error(codes.Internal, "vector search backend")
@@ -689,8 +688,8 @@ func (s *searchServer) VectorSearch(ctx context.Context, req *resourcepb.VectorS
 
 	allowed, err := s.batchCheckVectorSearchResults(ctx, user, req.Key, results)
 	if err != nil {
-		if ctxErr := statusFromContextError(err); ctxErr != nil {
-			return nil, ctxErr
+		if ctx.Err() != nil {
+			return nil, status.FromContextError(ctx.Err()).Err()
 		}
 		s.log.Error("vector search: authz batch check", "err", err)
 		return nil, status.Error(codes.Internal, "authz batch check")
@@ -714,24 +713,6 @@ func (s *searchServer) VectorSearch(ctx context.Context, req *resourcepb.VectorS
 		})
 	}
 	return resp, nil
-}
-
-// statusFromContextError maps cancellation/deadline errors to their gRPC
-// codes (Canceled/DeadlineExceeded) as the gRPC spec requires; returns nil
-// for anything else so callers fall through to their own mapping.
-// Without this, client disconnects surface as Internal and trip error SLOs.
-//
-// Checks two shapes: status errors from gRPC-backed dependencies (which do
-// not unwrap to the context sentinels), then wrapped context errors from
-// HTTP/SQL dependencies.
-func statusFromContextError(err error) error {
-	if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.DeadlineExceeded) {
-		return s.Err()
-	}
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-		return status.FromContextError(err).Err()
-	}
-	return nil
 }
 
 // validateVectorSearchRequest returns a non-nil response with a
@@ -800,8 +781,10 @@ func (s *searchServer) embedVectorSearchQuery(ctx context.Context, namespace, qu
 		Task:      embedder.TaskRetrievalQuery,
 	})
 	if err != nil {
-		if ctxErr := statusFromContextError(err); ctxErr != nil {
-			return nil, ctxErr
+		// Client disconnects/timeouts must map to Canceled/DeadlineExceeded
+		// per the gRPC spec — reporting Internal here trips error SLOs.
+		if ctx.Err() != nil {
+			return nil, status.FromContextError(ctx.Err()).Err()
 		}
 		s.log.Error("vector search: embed query", "err", err)
 		return nil, status.Error(codes.Internal, "embed query")

--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"hash/fnv"
 	"math/rand"
@@ -671,6 +672,9 @@ func (s *searchServer) VectorSearch(ctx context.Context, req *resourcepb.VectorS
 		req.Key.Namespace, s.embedder.Model, req.Key.Resource,
 		dense, limit, translateVectorSearchFilters(req.Filters)...)
 	if err != nil {
+		if ctxErr := statusFromContextError(err); ctxErr != nil {
+			return nil, ctxErr
+		}
 		s.log.Error("vector search: backend", "err", err)
 		return nil, status.Error(codes.Internal, "vector search backend")
 	}
@@ -685,6 +689,9 @@ func (s *searchServer) VectorSearch(ctx context.Context, req *resourcepb.VectorS
 
 	allowed, err := s.batchCheckVectorSearchResults(ctx, user, req.Key, results)
 	if err != nil {
+		if ctxErr := statusFromContextError(err); ctxErr != nil {
+			return nil, ctxErr
+		}
 		s.log.Error("vector search: authz batch check", "err", err)
 		return nil, status.Error(codes.Internal, "authz batch check")
 	}
@@ -707,6 +714,17 @@ func (s *searchServer) VectorSearch(ctx context.Context, req *resourcepb.VectorS
 		})
 	}
 	return resp, nil
+}
+
+// statusFromContextError maps context cancellation/deadline errors to their
+// gRPC codes (Canceled/DeadlineExceeded) as the gRPC spec requires; returns
+// nil for anything else so callers fall through to their own mapping.
+// Without this, client disconnects surface as Internal and trip error SLOs.
+func statusFromContextError(err error) error {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return status.FromContextError(err).Err()
+	}
+	return nil
 }
 
 // validateVectorSearchRequest returns a non-nil response with a
@@ -775,6 +793,9 @@ func (s *searchServer) embedVectorSearchQuery(ctx context.Context, namespace, qu
 		Task:      embedder.TaskRetrievalQuery,
 	})
 	if err != nil {
+		if ctxErr := statusFromContextError(err); ctxErr != nil {
+			return nil, ctxErr
+		}
 		s.log.Error("vector search: embed query", "err", err)
 		return nil, status.Error(codes.Internal, "embed query")
 	}

--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -716,11 +716,18 @@ func (s *searchServer) VectorSearch(ctx context.Context, req *resourcepb.VectorS
 	return resp, nil
 }
 
-// statusFromContextError maps context cancellation/deadline errors to their
-// gRPC codes (Canceled/DeadlineExceeded) as the gRPC spec requires; returns
-// nil for anything else so callers fall through to their own mapping.
+// statusFromContextError maps cancellation/deadline errors to their gRPC
+// codes (Canceled/DeadlineExceeded) as the gRPC spec requires; returns nil
+// for anything else so callers fall through to their own mapping.
 // Without this, client disconnects surface as Internal and trip error SLOs.
+//
+// Checks two shapes: status errors from gRPC-backed dependencies (which do
+// not unwrap to the context sentinels), then wrapped context errors from
+// HTTP/SQL dependencies.
 func statusFromContextError(err error) error {
+	if s, ok := status.FromError(err); ok && (s.Code() == codes.Canceled || s.Code() == codes.DeadlineExceeded) {
+		return s.Err()
+	}
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return status.FromContextError(err).Err()
 	}

--- a/pkg/storage/unified/resource/search_vector_test.go
+++ b/pkg/storage/unified/resource/search_vector_test.go
@@ -329,12 +329,20 @@ func TestVectorSearch_BackendErrorReturnsInternal(t *testing.T) {
 	assert.Equal(t, codes.Internal, status.Code(err))
 }
 
+// canceledAuthedCtx returns an authed context that is already canceled,
+// mimicking a client that disconnected mid-request.
+func canceledAuthedCtx() context.Context {
+	ctx, cancel := context.WithCancel(authedCtx())
+	cancel()
+	return ctx
+}
+
 func TestVectorSearch_EmbedderContextCanceledReturnsCanceled(t *testing.T) {
 	// Mimic the bedrock client's wrapping of a client-disconnect cancellation.
 	wantErr := fmt.Errorf("bedrock: invoke: %w", context.Canceled)
 	emb := newTestEmbedder(&fakeTextEmbedder{dim: 4, wantErr: wantErr})
 	s := newTestSearchServer(emb, &fakeVectorBackend{})
-	_, err := s.VectorSearch(authedCtx(), &resourcepb.VectorSearchRequest{
+	_, err := s.VectorSearch(canceledAuthedCtx(), &resourcepb.VectorSearchRequest{
 		Key: validKey(), Query: "q",
 	})
 	require.Error(t, err)
@@ -342,10 +350,12 @@ func TestVectorSearch_EmbedderContextCanceledReturnsCanceled(t *testing.T) {
 }
 
 func TestVectorSearch_EmbedderDeadlineExceededReturnsDeadlineExceeded(t *testing.T) {
+	ctx, cancel := context.WithTimeout(authedCtx(), 0)
+	defer cancel()
 	wantErr := fmt.Errorf("bedrock: invoke: %w", context.DeadlineExceeded)
 	emb := newTestEmbedder(&fakeTextEmbedder{dim: 4, wantErr: wantErr})
 	s := newTestSearchServer(emb, &fakeVectorBackend{})
-	_, err := s.VectorSearch(authedCtx(), &resourcepb.VectorSearchRequest{
+	_, err := s.VectorSearch(ctx, &resourcepb.VectorSearchRequest{
 		Key: validKey(), Query: "q",
 	})
 	require.Error(t, err)
@@ -355,7 +365,7 @@ func TestVectorSearch_EmbedderDeadlineExceededReturnsDeadlineExceeded(t *testing
 func TestVectorSearch_BackendContextCanceledReturnsCanceled(t *testing.T) {
 	backend := &fakeVectorBackend{err: fmt.Errorf("pgvector: %w", context.Canceled)}
 	s := newTestSearchServer(newTestEmbedder(&fakeTextEmbedder{dim: 4}), backend)
-	_, err := s.VectorSearch(authedCtx(), &resourcepb.VectorSearchRequest{
+	_, err := s.VectorSearch(canceledAuthedCtx(), &resourcepb.VectorSearchRequest{
 		Key: validKey(), Query: "q",
 	})
 	require.Error(t, err)
@@ -448,44 +458,31 @@ func TestVectorSearch_NoUserInContextReturnsUnauthenticated(t *testing.T) {
 }
 
 func TestVectorSearch_AuthzContextCanceledReturnsCanceled(t *testing.T) {
-	access := &erroringAccessClient{err: fmt.Errorf("authz: %w", context.Canceled)}
-	backend := &fakeVectorBackend{
-		results: []vector.VectorSearchResult{{UID: "u1", Score: 0.1}},
-	}
-	s := newTestSearchServer(newTestEmbedder(&fakeTextEmbedder{dim: 4}), backend, access)
-	_, err := s.VectorSearch(authedCtx(), &resourcepb.VectorSearchRequest{
-		Key: validKey(), Query: "q",
-	})
-	require.Error(t, err)
-	assert.Equal(t, codes.Canceled, status.Code(err))
-}
-
-func TestVectorSearch_AuthzGrpcStatusCanceledReturnsCanceled(t *testing.T) {
 	// gRPC-backed authz clients surface cancellation as a status error, not
-	// a wrapped context.Canceled sentinel.
-	access := &erroringAccessClient{err: fmt.Errorf("authz: %w", status.Error(codes.Canceled, "context canceled"))}
+	// a wrapped context.Canceled sentinel — the handler must key off the
+	// incoming context, not the error shape.
+	access := &erroringAccessClient{err: status.Error(codes.Canceled, "context canceled")}
 	backend := &fakeVectorBackend{
 		results: []vector.VectorSearchResult{{UID: "u1", Score: 0.1}},
 	}
 	s := newTestSearchServer(newTestEmbedder(&fakeTextEmbedder{dim: 4}), backend, access)
-	_, err := s.VectorSearch(authedCtx(), &resourcepb.VectorSearchRequest{
+	_, err := s.VectorSearch(canceledAuthedCtx(), &resourcepb.VectorSearchRequest{
 		Key: validKey(), Query: "q",
 	})
 	require.Error(t, err)
 	assert.Equal(t, codes.Canceled, status.Code(err))
 }
 
-func TestVectorSearch_AuthzGrpcStatusDeadlineExceededReturnsDeadlineExceeded(t *testing.T) {
-	access := &erroringAccessClient{err: status.Error(codes.DeadlineExceeded, "deadline exceeded")}
-	backend := &fakeVectorBackend{
-		results: []vector.VectorSearchResult{{UID: "u1", Score: 0.1}},
-	}
-	s := newTestSearchServer(newTestEmbedder(&fakeTextEmbedder{dim: 4}), backend, access)
+func TestVectorSearch_DownstreamCanceledErrWithLiveContextReturnsInternal(t *testing.T) {
+	// A downstream cancellation while the caller's context is still live is
+	// a server-side fault, not a client disconnect — stays Internal.
+	backend := &fakeVectorBackend{err: fmt.Errorf("pgvector: %w", context.Canceled)}
+	s := newTestSearchServer(newTestEmbedder(&fakeTextEmbedder{dim: 4}), backend)
 	_, err := s.VectorSearch(authedCtx(), &resourcepb.VectorSearchRequest{
 		Key: validKey(), Query: "q",
 	})
 	require.Error(t, err)
-	assert.Equal(t, codes.DeadlineExceeded, status.Code(err))
+	assert.Equal(t, codes.Internal, status.Code(err))
 }
 
 func TestVectorSearch_AuthzCompileErrorReturnsInternal(t *testing.T) {

--- a/pkg/storage/unified/resource/search_vector_test.go
+++ b/pkg/storage/unified/resource/search_vector_test.go
@@ -329,6 +329,39 @@ func TestVectorSearch_BackendErrorReturnsInternal(t *testing.T) {
 	assert.Equal(t, codes.Internal, status.Code(err))
 }
 
+func TestVectorSearch_EmbedderContextCanceledReturnsCanceled(t *testing.T) {
+	// Mimic the bedrock client's wrapping of a client-disconnect cancellation.
+	wantErr := fmt.Errorf("bedrock: invoke: %w", context.Canceled)
+	emb := newTestEmbedder(&fakeTextEmbedder{dim: 4, wantErr: wantErr})
+	s := newTestSearchServer(emb, &fakeVectorBackend{})
+	_, err := s.VectorSearch(authedCtx(), &resourcepb.VectorSearchRequest{
+		Key: validKey(), Query: "q",
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.Canceled, status.Code(err))
+}
+
+func TestVectorSearch_EmbedderDeadlineExceededReturnsDeadlineExceeded(t *testing.T) {
+	wantErr := fmt.Errorf("bedrock: invoke: %w", context.DeadlineExceeded)
+	emb := newTestEmbedder(&fakeTextEmbedder{dim: 4, wantErr: wantErr})
+	s := newTestSearchServer(emb, &fakeVectorBackend{})
+	_, err := s.VectorSearch(authedCtx(), &resourcepb.VectorSearchRequest{
+		Key: validKey(), Query: "q",
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.DeadlineExceeded, status.Code(err))
+}
+
+func TestVectorSearch_BackendContextCanceledReturnsCanceled(t *testing.T) {
+	backend := &fakeVectorBackend{err: fmt.Errorf("pgvector: %w", context.Canceled)}
+	s := newTestSearchServer(newTestEmbedder(&fakeTextEmbedder{dim: 4}), backend)
+	_, err := s.VectorSearch(authedCtx(), &resourcepb.VectorSearchRequest{
+		Key: validKey(), Query: "q",
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.Canceled, status.Code(err))
+}
+
 // fakeAccessClient implements authlib.AccessClient with a per-row decision
 // function. Used to exercise the post-filter authz path.
 type fakeAccessClient struct {
@@ -412,6 +445,19 @@ func TestVectorSearch_NoUserInContextReturnsUnauthenticated(t *testing.T) {
 	})
 	require.Error(t, err)
 	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+}
+
+func TestVectorSearch_AuthzContextCanceledReturnsCanceled(t *testing.T) {
+	access := &erroringAccessClient{err: fmt.Errorf("authz: %w", context.Canceled)}
+	backend := &fakeVectorBackend{
+		results: []vector.VectorSearchResult{{UID: "u1", Score: 0.1}},
+	}
+	s := newTestSearchServer(newTestEmbedder(&fakeTextEmbedder{dim: 4}), backend, access)
+	_, err := s.VectorSearch(authedCtx(), &resourcepb.VectorSearchRequest{
+		Key: validKey(), Query: "q",
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.Canceled, status.Code(err))
 }
 
 func TestVectorSearch_AuthzCompileErrorReturnsInternal(t *testing.T) {

--- a/pkg/storage/unified/resource/search_vector_test.go
+++ b/pkg/storage/unified/resource/search_vector_test.go
@@ -460,6 +460,34 @@ func TestVectorSearch_AuthzContextCanceledReturnsCanceled(t *testing.T) {
 	assert.Equal(t, codes.Canceled, status.Code(err))
 }
 
+func TestVectorSearch_AuthzGrpcStatusCanceledReturnsCanceled(t *testing.T) {
+	// gRPC-backed authz clients surface cancellation as a status error, not
+	// a wrapped context.Canceled sentinel.
+	access := &erroringAccessClient{err: fmt.Errorf("authz: %w", status.Error(codes.Canceled, "context canceled"))}
+	backend := &fakeVectorBackend{
+		results: []vector.VectorSearchResult{{UID: "u1", Score: 0.1}},
+	}
+	s := newTestSearchServer(newTestEmbedder(&fakeTextEmbedder{dim: 4}), backend, access)
+	_, err := s.VectorSearch(authedCtx(), &resourcepb.VectorSearchRequest{
+		Key: validKey(), Query: "q",
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.Canceled, status.Code(err))
+}
+
+func TestVectorSearch_AuthzGrpcStatusDeadlineExceededReturnsDeadlineExceeded(t *testing.T) {
+	access := &erroringAccessClient{err: status.Error(codes.DeadlineExceeded, "deadline exceeded")}
+	backend := &fakeVectorBackend{
+		results: []vector.VectorSearchResult{{UID: "u1", Score: 0.1}},
+	}
+	s := newTestSearchServer(newTestEmbedder(&fakeTextEmbedder{dim: 4}), backend, access)
+	_, err := s.VectorSearch(authedCtx(), &resourcepb.VectorSearchRequest{
+		Key: validKey(), Query: "q",
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.DeadlineExceeded, status.Code(err))
+}
+
 func TestVectorSearch_AuthzCompileErrorReturnsInternal(t *testing.T) {
 	access := &erroringAccessClient{err: errors.New("authz service is down")}
 	backend := &fakeVectorBackend{


### PR DESCRIPTION
Context cancellations were surfacing as grpc `internal` status codes which count towards error budget.