### PR TITLE
Docs: Add Git Sync testing sandboxes scenario

### DIFF
--- a/docs/sources/as-code/observability-as-code/git-sync/scenarios/_index.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/scenarios/_index.md
@@ -27,6 +27,7 @@ This guide shows practical deployment scenarios for Grafana’s Git Sync. Learn 
 - [Single instance](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/provision-resources/git-sync-deployment-scenarios/single-instance/)
 - [Git Sync for development and production environments](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/provision-resources/git-sync-deployment-scenarios/dev-prod/)
 - [Git Sync with regional replication](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/provision-resources/git-sync-deployment-scenarios/multi-region/)
+- [Testing sandboxes](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/provision-resources/git-sync-deployment-scenarios/testing-sandboxes/)
 - [High availability](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/provision-resources/git-sync-deployment-scenarios/high-availability/)
 - [Git Sync in a shared Grafana instance](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/provision-resources/git-sync-deployment-scenarios/multi-team/)
 

--- a/docs/sources/as-code/observability-as-code/git-sync/scenarios/testing-sandboxes.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/scenarios/testing-sandboxes.md
@@ -1,0 +1,179 @@
+---
+title: Testing sandboxes Git Sync
+menuTitle: Testing sandboxes
+description: Use dedicated sandbox branches for short-lived projects and personal experimentation before promoting changes to the main branch
+weight: 40
+aliases:
+  - ../../provision-resources/git-sync-deployment-scenarios/testing-sandboxes
+---
+
+# Testing sandboxes with Git Sync
+
+Use dedicated sandbox branches that users can push to directly, without opening a pull request for every change. Sandbox branches are a low-friction space for short-lived projects and personal experimentation, while keeping every dashboard version-controlled in Git. When work is ready, you promote it to the `main` branch.
+
+Each sandbox is a branch in the same repository, synced to Grafana with the [`write` workflow](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/git-sync-setup/set-up-code/#configuration-parameters) enabled. With the `write` workflow, saving a dashboard commits directly to the sandbox branch, so the editing experience feels close to using Grafana without Git Sync. The difference is that every change is still committed to Git, so nothing is lost and history is preserved.
+
+## Use it for
+
+- **Short-lived projects**: You need a temporary space for work that may or may not reach production.
+- **User sandboxes**: Individual users experiment freely without affecting shared dashboards.
+- **Fast iteration**: You want the low-friction editing of a non-provisioned instance, but with the safety of Git history.
+- **Staged promotion**: You develop in a sandbox, then promote finished work to the `main` branch.
+
+## Architecture
+
+```
+┌────────────────────────────────────────────────────────────┐
+│              GitHub Repository                             │
+│   Repository: your-org/grafana-manifests                 │
+│                                                            │
+│   Branch: main            ← Promoted, reviewed work       │
+│   └── grafana/                                             │
+│       ├── dashboard-stable.json                            │
+│       └── dashboard-approved.json                          │
+│                                                            │
+│   Branch: sandbox/alice   ← Direct pushes, experiments    │
+│   └── grafana/                                             │
+│       ├── dashboard-wip.json                               │
+│       └── dashboard-test.json                              │
+└────────────────────────────────────────────────────────────┘
+                        ↕
+              Git Sync (write workflow)
+                        ↕
+              ┌─────────────────────────┐
+              │    Grafana Instance     │
+              │                         │
+              │  Repository Resource:   │
+              │  - branch: sandbox/alice│
+              │  - path: grafana/       │
+              │  - workflows: [write]   │
+              │                         │
+              │  Save = direct commit   │
+              │  to sandbox/alice       │
+              └─────────────────────────┘
+```
+
+## Repository structure
+
+**In Git:**
+
+```
+your-org/grafana-manifests
+├── (branch: main)
+│   └── grafana/
+│       ├── dashboard-stable.json
+│       └── dashboard-approved.json
+└── (branch: sandbox/alice)
+    └── grafana/
+        ├── dashboard-wip.json
+        └── dashboard-test.json
+```
+
+**In Grafana Dashboards view (synced to `sandbox/alice`):**
+
+```
+Dashboards
+└── 📁 grafana-manifests/
+    ├── Work in Progress Dashboard
+    └── Test Dashboard
+```
+
+- A folder named "grafana-manifests" (from the repository name) contains the dashboards synced from the sandbox branch.
+- Only dashboards on the configured branch and path appear in the instance.
+- Saving a dashboard commits directly to the sandbox branch.
+
+## Configuration parameters
+
+Configure the Repository resource to sync with a sandbox branch and enable the `write` workflow:
+
+- **Repository**: `your-org/grafana-manifests`
+- **Branch**: `sandbox/alice`
+- **Path**: `grafana/`
+- **Workflows**: `write`
+
+In the Repository resource, this looks like:
+
+```yaml
+spec:
+  github:
+    url: 'https://github.com/your-org/grafana-manifests'
+    branch: 'sandbox/alice'
+    path: grafana/
+  workflows:
+    - write
+```
+
+{{< admonition type="note" >}}
+
+If you enable only the `write` workflow, saving a dashboard always commits directly to the sandbox branch. To also allow users to open pull requests from Grafana, add the `branch` workflow: `workflows: [write, branch]`. Refer to [Configuration parameters](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/git-sync-setup/set-up-code/#configuration-parameters) for details.
+
+{{< /admonition >}}
+
+## How it works
+
+1. Create a sandbox branch in your repository, for example `sandbox/alice`.
+2. Configure a Repository resource that syncs that branch with the `write` workflow enabled.
+3. Users create and edit dashboards in Grafana. Each save commits directly to the sandbox branch.
+4. The experience feels similar to using Grafana without Git Sync, but every change is committed to Git.
+5. When work is ready, you promote it to the `main` branch. Refer to [Promote a sandbox to main](#promote-a-sandbox-to-main).
+
+## Protect sandbox branches
+
+Even though sandbox branches allow direct pushes, protect them against destructive operations. We recommend blocking force pushes on sandbox branches in your Git provider.
+
+Force pushes rewrite branch history and can silently discard commits that Git Sync relies on. Blocking them keeps history append-only, so Grafana and Git stay consistent and you can always trace how a dashboard reached its current state.
+
+- **GitHub**: Add a branch protection rule (or ruleset) for the sandbox branch pattern (for example, `sandbox/*`) and disable **Allow force pushes**.
+- **GitLab**: Set the sandbox branches as protected and disallow force push.
+- **Bitbucket**: Add a branch permission for the sandbox pattern that prevents rewriting history.
+
+You typically keep pull requests optional on sandbox branches so users can push directly, while still blocking force pushes.
+
+## Promote a sandbox to main
+
+When sandbox work is ready, promote it to the `main` branch. Because everything already lives in Git, promotion is a standard Git operation. Choose the option that fits your review requirements:
+
+### Option 1: Open a pull request from the sandbox branch (recommended)
+
+Use your Git provider to open a pull request from the sandbox branch into `main`.
+
+1. In your Git provider, open a pull request from `sandbox/alice` into `main`.
+2. Review the changes as a normal Git diff and request approvals as needed.
+3. Merge the pull request. The instance syncing `main` picks up the promoted dashboards on its next sync.
+
+This keeps a full review and audit trail for everything that reaches `main`, and is the recommended path when `main` feeds production.
+
+If you also enable the `branch` workflow on the sandbox Repository resource, users can open these pull requests directly from Grafana when they save, instead of switching to the Git provider.
+
+### Option 2: Cherry-pick or merge selected changes
+
+When only some dashboards are ready, promote them selectively instead of merging the whole branch.
+
+1. Cherry-pick the relevant commits from the sandbox branch onto a branch based on `main`, or copy the specific dashboard files.
+2. Open a pull request into `main` and review it.
+3. Merge to complete the promotion.
+
+Use this when a sandbox contains a mix of finished and experimental work.
+
+### Option 3: Promote through a separate instance or path
+
+When `main` is synced to a production instance, treat the sandbox as the development stage of a promotion flow.
+
+1. Develop in the sandbox instance (synced to the sandbox branch with the `write` workflow).
+2. Promote approved dashboards to `main` using a pull request (Option 1) or by copying files into the `main` path.
+3. The production instance syncing `main` updates automatically.
+
+This mirrors the [development and production environments](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/scenarios/dev-prod/) scenario, with the sandbox branch acting as the development stage.
+
+After promotion, you can delete short-lived sandbox branches, or keep long-lived personal sandboxes and continue iterating.
+
+## Learn more
+
+Refer to the following documents to learn more:
+
+- [Git Sync for development and production environments](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/scenarios/dev-prod/)
+- [Git Sync key concepts](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/key-concepts/)
+- [Configure Git Sync as code](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/git-sync-setup/set-up-code/)
+- [Manage provisioned dashboards](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/provisioned-dashboards/)
+</content>
+</invoke>

--- a/docs/sources/as-code/observability-as-code/git-sync/scenarios/testing-sandboxes.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/scenarios/testing-sandboxes.md
@@ -1,7 +1,7 @@
 ---
 title: Testing sandboxes Git Sync
 menuTitle: Testing sandboxes
-description: Use dedicated sandbox branches for short-lived projects and personal experimentation before promoting changes to the main branch
+description: Use a shared sandbox branch for short-lived projects and experimentation before promoting changes to the main branch
 weight: 40
 aliases:
   - ../../provision-resources/git-sync-deployment-scenarios/testing-sandboxes
@@ -9,14 +9,16 @@ aliases:
 
 # Testing sandboxes with Git Sync
 
-Use dedicated sandbox branches that users can push to directly, without opening a pull request for every change. Sandbox branches are a low-friction space for short-lived projects and personal experimentation, while keeping every dashboard version-controlled in Git. When work is ready, you promote it to the `main` branch.
+Use a sandbox branch that users can push to directly, without opening a pull request for every change. A sandbox branch is a low-friction space for short-lived projects and experimentation, while keeping every dashboard version-controlled in Git. When work is ready, you promote it to the `main` branch.
 
-Each sandbox is a branch in the same repository, synced to Grafana with the [`write` workflow](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/git-sync-setup/set-up-code/#configuration-parameters) enabled. With the `write` workflow, saving a dashboard commits directly to the sandbox branch, so the editing experience feels close to using Grafana without Git Sync. The difference is that every change is still committed to Git, so nothing is lost and history is preserved.
+A sandbox is a branch in the same repository, synced to Grafana with the [`write` workflow](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/git-sync-setup/set-up-code/#configuration-parameters) enabled. With the `write` workflow, saving a dashboard commits directly to the sandbox branch, so the editing experience feels close to using Grafana without Git Sync. The difference is that every change is still committed to Git, so nothing is lost and history is preserved.
+
+This scenario uses a single **shared** sandbox branch that everyone works in. A shared sandbox uses only one Repository connection regardless of how many users work in it, which keeps you well within the per-stack limit of 10 repository connections. If you need stricter isolation, you can instead give each user their own sandbox branch. Refer to [Individual or shared sandboxes](#individual-or-shared-sandboxes).
 
 ## Use it for
 
 - **Short-lived projects**: You need a temporary space for work that may or may not reach production.
-- **User sandboxes**: Individual users experiment freely without affecting shared dashboards.
+- **Shared experimentation**: A team experiments freely in one space without affecting shared production dashboards.
 - **Fast iteration**: You want the low-friction editing of a non-provisioned instance, but with the safety of Git history.
 - **Staged promotion**: You develop in a sandbox, then promote finished work to the `main` branch.
 
@@ -27,15 +29,15 @@ Each sandbox is a branch in the same repository, synced to Grafana with the [`wr
 │              GitHub Repository                             │
 │   Repository: your-org/grafana-manifests                 │
 │                                                            │
-│   Branch: main            ← Promoted, reviewed work       │
+│   Branch: main       ← Promoted, reviewed work            │
 │   └── grafana/                                             │
 │       ├── dashboard-stable.json                            │
 │       └── dashboard-approved.json                          │
 │                                                            │
-│   Branch: sandbox/alice   ← Direct pushes, experiments    │
+│   Branch: sandbox    ← Direct pushes, shared experiments  │
 │   └── grafana/                                             │
-│       ├── dashboard-wip.json                               │
-│       └── dashboard-test.json                              │
+│       ├── alice/dashboard-wip.json                         │
+│       └── bob/dashboard-test.json                          │
 └────────────────────────────────────────────────────────────┘
                         ↕
               Git Sync (write workflow)
@@ -44,12 +46,12 @@ Each sandbox is a branch in the same repository, synced to Grafana with the [`wr
               │    Grafana Instance     │
               │                         │
               │  Repository Resource:   │
-              │  - branch: sandbox/alice│
+              │  - branch: sandbox      │
               │  - path: grafana/       │
               │  - workflows: [write]   │
               │                         │
               │  Save = direct commit   │
-              │  to sandbox/alice       │
+              │  to sandbox             │
               └─────────────────────────┘
 ```
 
@@ -63,31 +65,36 @@ your-org/grafana-manifests
 │   └── grafana/
 │       ├── dashboard-stable.json
 │       └── dashboard-approved.json
-└── (branch: sandbox/alice)
+└── (branch: sandbox)
     └── grafana/
-        ├── dashboard-wip.json
-        └── dashboard-test.json
+        ├── alice/
+        │   └── dashboard-wip.json
+        └── bob/
+            └── dashboard-test.json
 ```
 
-**In Grafana Dashboards view (synced to `sandbox/alice`):**
+**In Grafana Dashboards view (synced to `sandbox`):**
 
 ```
 Dashboards
 └── 📁 grafana-manifests/
-    ├── Work in Progress Dashboard
-    └── Test Dashboard
+    ├── 📁 alice/
+    │   └── Work in Progress Dashboard
+    └── 📁 bob/
+        └── Test Dashboard
 ```
 
 - A folder named "grafana-manifests" (from the repository name) contains the dashboards synced from the sandbox branch.
+- Users can create subfolders inside it, such as `alice/` and `bob/`, to keep their work separate within the shared branch. Subfolders map to subdirectories under the synced path, so no extra Repository connection is needed.
 - Only dashboards on the configured branch and path appear in the instance.
 - Saving a dashboard commits directly to the sandbox branch.
 
 ## Configuration parameters
 
-Configure the Repository resource to sync with a sandbox branch and enable the `write` workflow:
+Configure the Repository resource to sync with the sandbox branch and enable the `write` workflow:
 
 - **Repository**: `your-org/grafana-manifests`
-- **Branch**: `sandbox/alice`
+- **Branch**: `sandbox`
 - **Path**: `grafana/`
 - **Workflows**: `write`
 
@@ -97,7 +104,7 @@ In the Repository resource, this looks like:
 spec:
   github:
     url: 'https://github.com/your-org/grafana-manifests'
-    branch: 'sandbox/alice'
+    branch: 'sandbox'
     path: grafana/
   workflows:
     - write
@@ -111,18 +118,18 @@ If you enable only the `write` workflow, saving a dashboard always commits direc
 
 ## How it works
 
-1. Create a sandbox branch in your repository, for example `sandbox/alice`.
+1. Create a sandbox branch in your repository, for example `sandbox`.
 2. Configure a Repository resource that syncs that branch with the `write` workflow enabled.
-3. Users create and edit dashboards in Grafana. Each save commits directly to the sandbox branch.
+3. Users create and edit dashboards in Grafana, optionally in their own subfolder. Each save commits directly to the sandbox branch.
 4. The experience feels similar to using Grafana without Git Sync, but every change is committed to Git.
 5. When work is ready, you promote it to the `main` branch. Refer to [Promote a sandbox to main](#promote-a-sandbox-to-main).
 
 ## Individual or shared sandboxes
 
-A sandbox can be scoped to a single user or shared by everyone. Each sandbox is a branch synced through its own Repository connection, so the choice is shaped by the per-stack limit of 10 repository connections. Refer to [Usage and performance limitations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/usage-limits/) for details.
+A sandbox can be shared by everyone or scoped to a single user. Each sandbox is a branch synced through its own Repository connection, so the choice is shaped by the per-stack limit of 10 repository connections. Refer to [Usage and performance limitations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/usage-limits/) for details.
 
+- **Shared sandbox (recommended)**: Use a single branch, such as `sandbox`, synced through one Repository connection that all users share. This uses only one connection regardless of how many users work in it, so it scales to any number of users. Separate users' work with subfolders (for example, `alice/`, `bob/`) if you want some organization within the shared branch. The trade-off is less isolation, since everyone commits to the same branch. This is the setup described above.
 - **Individual sandboxes**: Give each user their own branch, such as `sandbox/alice` and `sandbox/bob`, each synced through a separate Repository connection. This provides the most isolation, but every sandbox consumes one of your 10 connections, so per-user sandboxes don't scale to many users. Reserve them for a small number of active users or short-lived projects, and delete the branch and its connection when the work is done to free the connection.
-- **Shared sandbox**: Use a single branch, such as `sandbox`, synced through one Repository connection that all users share. This uses only one connection regardless of how many users work in it, so it scales to any number of users. Separate users' work with different paths (for example, `alice/`, `bob/`) if you want some organization within the shared branch. The trade-off is less isolation, since everyone commits to the same branch.
 
 Both approaches promote to `main` the same way. Refer to [Promote a sandbox to main](#promote-a-sandbox-to-main).
 
@@ -132,9 +139,9 @@ Even though sandbox branches allow direct pushes, protect them against destructi
 
 Force pushes rewrite branch history and can silently discard commits that Git Sync relies on. Blocking them keeps history append-only, so Grafana and Git stay consistent and you can always trace how a dashboard reached its current state.
 
-- **GitHub**: Add a branch protection rule (or ruleset) for the sandbox branch pattern (for example, `sandbox/*`) and disable **Allow force pushes**.
+- **GitHub**: Add a branch protection rule (or ruleset) for the sandbox branch (for example, `sandbox` or the pattern `sandbox/*` if you use individual sandboxes) and disable **Allow force pushes**.
 - **GitLab**: Set the sandbox branches as protected and disallow force push.
-- **Bitbucket**: Add a branch permission for the sandbox pattern that prevents rewriting history.
+- **Bitbucket**: Add a branch permission for the sandbox branch that prevents rewriting history.
 
 You typically keep pull requests optional on sandbox branches so users can push directly, while still blocking force pushes.
 
@@ -146,7 +153,7 @@ When sandbox work is ready, promote it to the `main` branch. Because everything 
 
 Use your Git provider to open a pull request from the sandbox branch into `main`.
 
-1. In your Git provider, open a pull request from `sandbox/alice` into `main`.
+1. In your Git provider, open a pull request from `sandbox` into `main`.
 2. Review the changes as a normal Git diff and request approvals as needed.
 3. Merge the pull request. The instance syncing `main` picks up the promoted dashboards on its next sync.
 
@@ -162,7 +169,7 @@ When only some dashboards are ready, promote them selectively instead of merging
 2. Open a pull request into `main` and review it.
 3. Merge to complete the promotion.
 
-Use this when a sandbox contains a mix of finished and experimental work.
+Use this when a shared sandbox contains a mix of finished and experimental work.
 
 ### Option 3: Promote through a separate instance or path
 
@@ -174,7 +181,16 @@ When `main` is synced to a production instance, treat the sandbox as the develop
 
 This mirrors the [development and production environments](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/scenarios/dev-prod/) scenario, with the sandbox branch acting as the development stage.
 
-After promotion, you can delete short-lived sandbox branches, or keep long-lived personal sandboxes and continue iterating.
+### Option 4: Promote from the Grafana UI
+
+If the `main` branch is synced to a folder in the same instance (through a second Repository connection) or to a separate instance, users can move a dashboard into it directly from Grafana, without touching Git:
+
+- **Save a copy**: Open the sandbox dashboard, select **Save as** (save a copy), and choose the folder backed by the `main` branch as the destination. Git Sync commits the copy to `main`.
+- **Import dashboard**: Export the dashboard from the sandbox (**Export** as JSON), then use **Dashboards > New > Import** and save it into the folder backed by the `main` branch. Git Sync commits it to `main`.
+
+This suits users who prefer working entirely in the UI. Note that these paths commit to `main` without a pull request, so use them only when `main` allows direct writes; when `main` requires review, prefer Option 1.
+
+After promotion, you can delete short-lived sandbox branches, or keep a long-lived shared sandbox and continue iterating.
 
 ## Learn more
 
@@ -185,5 +201,3 @@ Refer to the following documents to learn more:
 - [Configure Git Sync as code](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/git-sync-setup/set-up-code/)
 - [Manage provisioned dashboards](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/provisioned-dashboards/)
 - [Usage and performance limitations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/usage-limits/)
-</content>
-</invoke>

--- a/docs/sources/as-code/observability-as-code/git-sync/scenarios/testing-sandboxes.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/scenarios/testing-sandboxes.md
@@ -117,6 +117,15 @@ If you enable only the `write` workflow, saving a dashboard always commits direc
 4. The experience feels similar to using Grafana without Git Sync, but every change is committed to Git.
 5. When work is ready, you promote it to the `main` branch. Refer to [Promote a sandbox to main](#promote-a-sandbox-to-main).
 
+## Individual or shared sandboxes
+
+A sandbox can be scoped to a single user or shared by everyone. Each sandbox is a branch synced through its own Repository connection, so the choice is shaped by the per-stack limit of 10 repository connections. Refer to [Usage and performance limitations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/usage-limits/) for details.
+
+- **Individual sandboxes**: Give each user their own branch, such as `sandbox/alice` and `sandbox/bob`, each synced through a separate Repository connection. This provides the most isolation, but every sandbox consumes one of your 10 connections, so per-user sandboxes don't scale to many users. Reserve them for a small number of active users or short-lived projects, and delete the branch and its connection when the work is done to free the connection.
+- **Shared sandbox**: Use a single branch, such as `sandbox`, synced through one Repository connection that all users share. This uses only one connection regardless of how many users work in it, so it scales to any number of users. Separate users' work with different paths (for example, `alice/`, `bob/`) if you want some organization within the shared branch. The trade-off is less isolation, since everyone commits to the same branch.
+
+Both approaches promote to `main` the same way. Refer to [Promote a sandbox to main](#promote-a-sandbox-to-main).
+
 ## Protect sandbox branches
 
 Even though sandbox branches allow direct pushes, protect them against destructive operations. We recommend blocking force pushes on sandbox branches in your Git provider.
@@ -175,5 +184,6 @@ Refer to the following documents to learn more:
 - [Git Sync key concepts](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/key-concepts/)
 - [Configure Git Sync as code](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/git-sync-setup/set-up-code/)
 - [Manage provisioned dashboards](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/provisioned-dashboards/)
+- [Usage and performance limitations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/usage-limits/)
 </content>
 </invoke>


### PR DESCRIPTION
## What

Adds a new **Testing sandboxes** Git Sync deployment scenario to the docs, and links it from the scenarios index.

## Why

Users need a documented pattern for a low-friction, experiment-first space that is still fully version-controlled in Git — for short-lived projects and personal sandboxes — and clear guidance on how to promote that work to `main`.

## How

New `docs/.../git-sync/scenarios/testing-sandboxes.md` (weight 40), matching the structure and style of the existing scenario docs. It covers:

- **Sandbox branches with the `write` workflow** — saving a dashboard commits directly to the sandbox branch, so editing feels close to using Grafana without Git Sync, while every change stays in Git. Notes that adding the `branch` workflow optionally enables opening PRs from Grafana.
- **Individual vs. shared sandboxes** — framed by the per-stack limit of 10 repository connections: per-user branches give the most isolation but consume a connection each; a single shared sandbox scales to any number of users on one connection (optionally split by path).
- **Protecting sandbox branches** — recommendation to block force pushes (GitHub/GitLab/Bitbucket specifics) and why (force pushes rewrite history and can discard commits Git Sync relies on).
- **Promoting a sandbox to `main`** — three options: pull request from the sandbox branch (recommended), cherry-pick/merge selected changes, or promote through a separate instance/path (dev→prod style).

One-line addition to `scenarios/_index.md` to list the new scenario. Docs-only change.

## Testing

- Docs-only; verified `git diff origin/main...HEAD` contains only the two intended files.
- Frontend deps were not installed in this environment, so `yarn prettier` could not run; formatting follows the conventions of the sibling scenario files.

## Checklist

- [ ] Tests added/updated (N/A — docs only)
- [x] Documentation updated
- [x] No breaking changes

## Review notes

- Example branch naming uses `sandbox/alice` and a `sandbox/*` protection pattern — adjust if there is a preferred convention.
- Cross-links in the new file use the `git-sync/scenarios/` path form (matching newer scenario files); the `_index.md` list keeps its existing `provision-resources/git-sync-deployment-scenarios/` alias form. Each file follows its local convention rather than normalizing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)