### PR TITLE
Team: share App Platform redirect check

### DIFF
--- a/pkg/services/team/k8s_redirect.go
+++ b/pkg/services/team/k8s_redirect.go
@@ -1,0 +1,26 @@
+package team
+
+import (
+	"context"
+
+	"github.com/open-feature/go-sdk/openfeature"
+
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+)
+
+// IsK8sRedirectEnabled gates team operations on the k8s apiserver path.
+// FIXME: drop the UsersApi requirement once teamk8s no longer needs the k8s users resource for enrichment.
+func IsK8sRedirectEnabled(ctx context.Context, client *openfeature.Client) bool {
+	if client == nil {
+		return false
+	}
+
+	txCtx := openfeature.TransactionContext(ctx)
+	if !client.Boolean(ctx, featuremgmt.FlagKubernetesTeamsApi, false, txCtx) {
+		return false
+	}
+	if !client.Boolean(ctx, featuremgmt.FlagKubernetesTeamsRedirect, false, txCtx) {
+		return false
+	}
+	return client.Boolean(ctx, featuremgmt.FlagKubernetesUsersApi, false, txCtx)
+}

--- a/pkg/services/team/k8s_redirect.go
+++ b/pkg/services/team/k8s_redirect.go
@@ -2,25 +2,34 @@ package team
 
 import (
 	"context"
+	"errors"
 
 	"github.com/open-feature/go-sdk/openfeature"
 
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 )
 
-// IsK8sRedirectEnabled gates team operations on the k8s apiserver path.
+// IsK8sRedirectEnabledForNamespace gates team operations on the k8s apiserver path.
+// The namespace is required because redirect flags may be targeted per stack; evaluating
+// without it could select a non-authoritative Team store for the request.
 // FIXME: drop the UsersApi requirement once teamk8s no longer needs the k8s users resource for enrichment.
-func IsK8sRedirectEnabled(ctx context.Context, client *openfeature.Client) bool {
+func IsK8sRedirectEnabledForNamespace(ctx context.Context, client *openfeature.Client, namespace string) (bool, error) {
+	if namespace == "" {
+		return false, errors.New("namespace is required to evaluate the Team k8s redirect")
+	}
 	if client == nil {
-		return false
+		return false, nil
 	}
 
+	ctx = openfeature.MergeTransactionContext(ctx, openfeature.NewEvaluationContext(namespace, map[string]any{
+		"namespace": namespace,
+	}))
 	txCtx := openfeature.TransactionContext(ctx)
 	if !client.Boolean(ctx, featuremgmt.FlagKubernetesTeamsApi, false, txCtx) {
-		return false
+		return false, nil
 	}
 	if !client.Boolean(ctx, featuremgmt.FlagKubernetesTeamsRedirect, false, txCtx) {
-		return false
+		return false, nil
 	}
-	return client.Boolean(ctx, featuremgmt.FlagKubernetesUsersApi, false, txCtx)
+	return client.Boolean(ctx, featuremgmt.FlagKubernetesUsersApi, false, txCtx), nil
 }

--- a/pkg/services/team/k8s_redirect_test.go
+++ b/pkg/services/team/k8s_redirect_test.go
@@ -1,0 +1,79 @@
+package team
+
+import (
+	"testing"
+
+	"github.com/open-feature/go-sdk/openfeature"
+	"github.com/open-feature/go-sdk/openfeature/memprovider"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+)
+
+func TestIsK8sRedirectEnabled(t *testing.T) {
+	t.Cleanup(func() {
+		require.NoError(t, openfeature.SetProviderAndWait(openfeature.NoopProvider{}))
+	})
+
+	testCases := []struct {
+		name          string
+		teamsAPI      bool
+		teamsRedirect bool
+		usersAPI      bool
+		want          bool
+	}{
+		{
+			name:          "enabled when Teams API, Teams redirect, and Users API are enabled",
+			teamsAPI:      true,
+			teamsRedirect: true,
+			usersAPI:      true,
+			want:          true,
+		},
+		{
+			name:          "disabled when Teams API is disabled",
+			teamsAPI:      false,
+			teamsRedirect: true,
+			usersAPI:      true,
+			want:          false,
+		},
+		{
+			name:          "disabled when Teams redirect is disabled",
+			teamsAPI:      true,
+			teamsRedirect: false,
+			usersAPI:      true,
+			want:          false,
+		},
+		{
+			name:          "disabled when Users API is disabled",
+			teamsAPI:      true,
+			teamsRedirect: true,
+			usersAPI:      false,
+			want:          false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			provider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
+				featuremgmt.FlagKubernetesTeamsApi:      newBooleanFlag(featuremgmt.FlagKubernetesTeamsApi, tc.teamsAPI),
+				featuremgmt.FlagKubernetesTeamsRedirect: newBooleanFlag(featuremgmt.FlagKubernetesTeamsRedirect, tc.teamsRedirect),
+				featuremgmt.FlagKubernetesUsersApi:      newBooleanFlag(featuremgmt.FlagKubernetesUsersApi, tc.usersAPI),
+			})
+			require.NoError(t, openfeature.SetProviderAndWait(provider))
+
+			require.Equal(t, tc.want, IsK8sRedirectEnabled(t.Context(), openfeature.NewDefaultClient()))
+		})
+	}
+
+	t.Run("disabled without an OpenFeature client", func(t *testing.T) {
+		require.False(t, IsK8sRedirectEnabled(t.Context(), nil))
+	})
+}
+
+func newBooleanFlag(name string, value bool) memprovider.InMemoryFlag {
+	return memprovider.InMemoryFlag{
+		Key:            name,
+		DefaultVariant: "default",
+		Variants:       map[string]any{"default": value},
+	}
+}

--- a/pkg/services/team/k8s_redirect_test.go
+++ b/pkg/services/team/k8s_redirect_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 )
 
-func TestIsK8sRedirectEnabled(t *testing.T) {
+func TestIsK8sRedirectEnabledForNamespace(t *testing.T) {
 	t.Cleanup(func() {
 		require.NoError(t, openfeature.SetProviderAndWait(openfeature.NoopProvider{}))
 	})
@@ -61,12 +61,47 @@ func TestIsK8sRedirectEnabled(t *testing.T) {
 			})
 			require.NoError(t, openfeature.SetProviderAndWait(provider))
 
-			require.Equal(t, tc.want, IsK8sRedirectEnabled(t.Context(), openfeature.NewDefaultClient()))
+			got, err := IsK8sRedirectEnabledForNamespace(t.Context(), openfeature.NewDefaultClient(), "stacks-123")
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
 		})
 	}
 
 	t.Run("disabled without an OpenFeature client", func(t *testing.T) {
-		require.False(t, IsK8sRedirectEnabled(t.Context(), nil))
+		got, err := IsK8sRedirectEnabledForNamespace(t.Context(), nil, "stacks-123")
+		require.NoError(t, err)
+		require.False(t, got)
+	})
+
+	t.Run("rejects an empty namespace", func(t *testing.T) {
+		got, err := IsK8sRedirectEnabledForNamespace(t.Context(), openfeature.NewDefaultClient(), "")
+		require.EqualError(t, err, "namespace is required to evaluate the Team k8s redirect")
+		require.False(t, got)
+	})
+
+	t.Run("evaluates flags for the requested namespace", func(t *testing.T) {
+		namespaceEvaluator := func(flag memprovider.InMemoryFlag, flatCtx openfeature.FlattenedContext) (any, openfeature.ProviderResolutionDetail) {
+			enabled := flatCtx[openfeature.TargetingKey] == "stacks-123" && flatCtx["namespace"] == "stacks-123"
+			return enabled, openfeature.ProviderResolutionDetail{}
+		}
+		provider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
+			featuremgmt.FlagKubernetesTeamsApi: {
+				Key:              featuremgmt.FlagKubernetesTeamsApi,
+				DefaultVariant:   "default",
+				Variants:         map[string]any{"default": false},
+				ContextEvaluator: &namespaceEvaluator,
+			},
+			featuremgmt.FlagKubernetesTeamsRedirect: newBooleanFlag(featuremgmt.FlagKubernetesTeamsRedirect, true),
+			featuremgmt.FlagKubernetesUsersApi:      newBooleanFlag(featuremgmt.FlagKubernetesUsersApi, true),
+		})
+		require.NoError(t, openfeature.SetProviderAndWait(provider))
+
+		ctx := openfeature.WithTransactionContext(t.Context(), openfeature.NewEvaluationContext("stacks-old", map[string]any{
+			"namespace": "stacks-old",
+		}))
+		got, err := IsK8sRedirectEnabledForNamespace(ctx, openfeature.NewDefaultClient(), "stacks-123")
+		require.NoError(t, err)
+		require.True(t, got)
 	})
 }
 

--- a/pkg/services/team/teamimpl/team.go
+++ b/pkg/services/team/teamimpl/team.go
@@ -13,7 +13,6 @@ import (
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/apiserver"
 	"github.com/grafana/grafana/pkg/services/contexthandler"
-	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/team"
 	"github.com/grafana/grafana/pkg/services/team/teamk8s"
 	"github.com/grafana/grafana/pkg/setting"
@@ -51,7 +50,7 @@ func ProvideService(db db.DB, cfg *setting.Cfg, tracer tracing.Tracer, configPro
 }
 
 func (s *Service) CreateTeam(ctx context.Context, cmd *team.CreateTeamCommand) (team.Team, error) {
-	if s.isK8sRedirectEnabled(ctx) {
+	if team.IsK8sRedirectEnabled(ctx, s.openFeatureClient) {
 		return s.k8sService.CreateTeam(ctx, cmd)
 	}
 
@@ -59,7 +58,7 @@ func (s *Service) CreateTeam(ctx context.Context, cmd *team.CreateTeamCommand) (
 }
 
 func (s *Service) UpdateTeam(ctx context.Context, cmd *team.UpdateTeamCommand) error {
-	if s.isK8sRedirectEnabled(ctx) {
+	if team.IsK8sRedirectEnabled(ctx, s.openFeatureClient) {
 		return s.k8sService.UpdateTeam(ctx, cmd)
 	}
 
@@ -67,7 +66,7 @@ func (s *Service) UpdateTeam(ctx context.Context, cmd *team.UpdateTeamCommand) e
 }
 
 func (s *Service) DeleteTeam(ctx context.Context, cmd *team.DeleteTeamCommand) error {
-	if s.isK8sRedirectEnabled(ctx) {
+	if team.IsK8sRedirectEnabled(ctx, s.openFeatureClient) {
 		return s.k8sService.DeleteTeam(ctx, cmd)
 	}
 
@@ -75,7 +74,7 @@ func (s *Service) DeleteTeam(ctx context.Context, cmd *team.DeleteTeamCommand) e
 }
 
 func (s *Service) SearchTeams(ctx context.Context, query *team.SearchTeamsQuery) (team.SearchTeamQueryResult, error) {
-	if s.isK8sRedirectEnabled(ctx) && !s.shouldFallbackToLegacy(ctx) {
+	if team.IsK8sRedirectEnabled(ctx, s.openFeatureClient) && !s.shouldFallbackToLegacy(ctx) {
 		return s.k8sService.SearchTeams(ctx, query)
 	}
 
@@ -83,7 +82,7 @@ func (s *Service) SearchTeams(ctx context.Context, query *team.SearchTeamsQuery)
 }
 
 func (s *Service) GetTeamByID(ctx context.Context, query *team.GetTeamByIDQuery) (*team.TeamDTO, error) {
-	if s.isK8sRedirectEnabled(ctx) && !s.shouldFallbackToLegacy(ctx) {
+	if team.IsK8sRedirectEnabled(ctx, s.openFeatureClient) && !s.shouldFallbackToLegacy(ctx) {
 		return s.k8sService.GetTeamByID(ctx, query)
 	}
 
@@ -99,7 +98,7 @@ func (s *Service) GetTeamsByUser(ctx context.Context, query *team.GetTeamsByUser
 
 	ctxLogger := s.logger.FromContext(ctx)
 
-	if s.isK8sRedirectEnabled(ctx) {
+	if team.IsK8sRedirectEnabled(ctx, s.openFeatureClient) {
 		result, err := s.k8sService.GetTeamsByUser(ctx, query)
 		if err == nil {
 			span.SetAttributes(attribute.Bool("fallback_to_legacy", false))
@@ -126,7 +125,7 @@ func (s *Service) GetTeamIDsByUser(ctx context.Context, query *team.GetTeamIDsBy
 	// the context. The k8s service requires a requester to build the dynamic
 	// client, so skip the k8s attempt for these pre-auth calls to avoid noisy
 	// per-request fallback logs.
-	if s.isK8sRedirectEnabled(ctx) {
+	if team.IsK8sRedirectEnabled(ctx, s.openFeatureClient) {
 		if _, err := identity.GetRequester(ctx); err == nil {
 			ids, uids, err := s.k8sService.GetTeamIDsByUser(ctx, query)
 			if err == nil {
@@ -142,7 +141,7 @@ func (s *Service) GetTeamIDsByUser(ctx context.Context, query *team.GetTeamIDsBy
 }
 
 func (s *Service) IsTeamMember(ctx context.Context, orgId int64, teamId int64, userId int64) (bool, error) {
-	if s.isK8sRedirectEnabled(ctx) {
+	if team.IsK8sRedirectEnabled(ctx, s.openFeatureClient) {
 		return s.k8sService.IsTeamMember(ctx, orgId, teamId, userId)
 	}
 
@@ -163,7 +162,7 @@ func (s *Service) GetUserTeamMemberships(ctx context.Context, orgID, userID int6
 
 	ctxLogger := s.logger.FromContext(ctx)
 
-	if s.isK8sRedirectEnabled(ctx) {
+	if team.IsK8sRedirectEnabled(ctx, s.openFeatureClient) {
 		result, err := s.k8sService.GetUserTeamMemberships(ctx, orgID, userID, external, bypassCache)
 		if err == nil {
 			span.SetAttributes(attribute.Bool("fallback_to_legacy", false))
@@ -177,7 +176,7 @@ func (s *Service) GetUserTeamMemberships(ctx context.Context, orgID, userID int6
 }
 
 func (s *Service) GetTeamMembers(ctx context.Context, query *team.GetTeamMembersQuery) ([]*team.TeamMemberDTO, error) {
-	if s.isK8sRedirectEnabled(ctx) {
+	if team.IsK8sRedirectEnabled(ctx, s.openFeatureClient) {
 		return s.k8sService.GetTeamMembers(ctx, query)
 	}
 
@@ -191,19 +190,6 @@ func (s *Service) RegisterDelete(query string) {
 	// This is called at init time (Wire providers) where no request context
 	// exists, making feature flag evaluation with context.Background() unreliable.
 	s.legacyService.RegisterDelete(query)
-}
-
-// isK8sRedirectEnabled gates team operations on the k8s apiserver path.
-// FIXME: drop the UsersApi requirement once teamk8s no longer needs the k8s users resource for enrichment.
-func (s *Service) isK8sRedirectEnabled(ctx context.Context) bool {
-	if s.openFeatureClient == nil {
-		return false
-	}
-	txCtx := openfeature.TransactionContext(ctx)
-	if !s.openFeatureClient.Boolean(ctx, featuremgmt.FlagKubernetesTeamsRedirect, false, txCtx) {
-		return false
-	}
-	return s.openFeatureClient.Boolean(ctx, featuremgmt.FlagKubernetesUsersApi, false, txCtx)
 }
 
 // shouldFallbackToLegacy determines whether to fallback to the legacy service for a given request.

--- a/pkg/services/team/teamimpl/team.go
+++ b/pkg/services/team/teamimpl/team.go
@@ -2,6 +2,7 @@ package teamimpl
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/open-feature/go-sdk/openfeature"
 	"go.opentelemetry.io/otel/attribute"
@@ -22,6 +23,7 @@ type Service struct {
 	legacyService     team.Service
 	k8sService        team.Service
 	openFeatureClient *openfeature.Client
+	featureNamespace  string
 	logger            log.Logger
 	tracer            tracing.Tracer
 }
@@ -39,18 +41,27 @@ func ProvideService(db db.DB, cfg *setting.Cfg, tracer tracing.Tracer, configPro
 	}
 
 	k8sService := teamk8s.NewTeamK8sService(log.New("team.k8s"), cfg, configProvider, tracer)
+	featureNamespace := "default"
+	if cfg.StackID != "" {
+		featureNamespace = "stacks-" + cfg.StackID
+	}
 
 	return &Service{
 		legacyService:     legacyService,
 		k8sService:        k8sService,
 		openFeatureClient: openfeature.NewDefaultClient(),
+		featureNamespace:  featureNamespace,
 		logger:            log.New("team"),
 		tracer:            tracer,
 	}, nil
 }
 
 func (s *Service) CreateTeam(ctx context.Context, cmd *team.CreateTeamCommand) (team.Team, error) {
-	if team.IsK8sRedirectEnabled(ctx, s.openFeatureClient) {
+	redirectEnabled, err := s.isK8sRedirectEnabled(ctx)
+	if err != nil {
+		return team.Team{}, err
+	}
+	if redirectEnabled {
 		return s.k8sService.CreateTeam(ctx, cmd)
 	}
 
@@ -58,7 +69,11 @@ func (s *Service) CreateTeam(ctx context.Context, cmd *team.CreateTeamCommand) (
 }
 
 func (s *Service) UpdateTeam(ctx context.Context, cmd *team.UpdateTeamCommand) error {
-	if team.IsK8sRedirectEnabled(ctx, s.openFeatureClient) {
+	redirectEnabled, err := s.isK8sRedirectEnabled(ctx)
+	if err != nil {
+		return err
+	}
+	if redirectEnabled {
 		return s.k8sService.UpdateTeam(ctx, cmd)
 	}
 
@@ -66,7 +81,11 @@ func (s *Service) UpdateTeam(ctx context.Context, cmd *team.UpdateTeamCommand) e
 }
 
 func (s *Service) DeleteTeam(ctx context.Context, cmd *team.DeleteTeamCommand) error {
-	if team.IsK8sRedirectEnabled(ctx, s.openFeatureClient) {
+	redirectEnabled, err := s.isK8sRedirectEnabled(ctx)
+	if err != nil {
+		return err
+	}
+	if redirectEnabled {
 		return s.k8sService.DeleteTeam(ctx, cmd)
 	}
 
@@ -74,7 +93,11 @@ func (s *Service) DeleteTeam(ctx context.Context, cmd *team.DeleteTeamCommand) e
 }
 
 func (s *Service) SearchTeams(ctx context.Context, query *team.SearchTeamsQuery) (team.SearchTeamQueryResult, error) {
-	if team.IsK8sRedirectEnabled(ctx, s.openFeatureClient) && !s.shouldFallbackToLegacy(ctx) {
+	redirectEnabled, err := s.isK8sRedirectEnabled(ctx)
+	if err != nil {
+		return team.SearchTeamQueryResult{}, err
+	}
+	if redirectEnabled && !s.shouldFallbackToLegacy(ctx) {
 		return s.k8sService.SearchTeams(ctx, query)
 	}
 
@@ -82,7 +105,11 @@ func (s *Service) SearchTeams(ctx context.Context, query *team.SearchTeamsQuery)
 }
 
 func (s *Service) GetTeamByID(ctx context.Context, query *team.GetTeamByIDQuery) (*team.TeamDTO, error) {
-	if team.IsK8sRedirectEnabled(ctx, s.openFeatureClient) && !s.shouldFallbackToLegacy(ctx) {
+	redirectEnabled, err := s.isK8sRedirectEnabled(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if redirectEnabled && !s.shouldFallbackToLegacy(ctx) {
 		return s.k8sService.GetTeamByID(ctx, query)
 	}
 
@@ -98,7 +125,11 @@ func (s *Service) GetTeamsByUser(ctx context.Context, query *team.GetTeamsByUser
 
 	ctxLogger := s.logger.FromContext(ctx)
 
-	if team.IsK8sRedirectEnabled(ctx, s.openFeatureClient) {
+	redirectEnabled, err := s.isK8sRedirectEnabled(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if redirectEnabled {
 		result, err := s.k8sService.GetTeamsByUser(ctx, query)
 		if err == nil {
 			span.SetAttributes(attribute.Bool("fallback_to_legacy", false))
@@ -119,13 +150,17 @@ func (s *Service) GetTeamIDsByUser(ctx context.Context, query *team.GetTeamIDsBy
 	defer span.End()
 
 	ctxLogger := s.logger.FromContext(ctx)
+	redirectEnabled, err := s.isK8sRedirectEnabled(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	// GetTeamIDsByUser is called during authentication (e.g. middleware that
 	// resolves team-based permissions) before a requester has been attached to
 	// the context. The k8s service requires a requester to build the dynamic
 	// client, so skip the k8s attempt for these pre-auth calls to avoid noisy
 	// per-request fallback logs.
-	if team.IsK8sRedirectEnabled(ctx, s.openFeatureClient) {
+	if redirectEnabled {
 		if _, err := identity.GetRequester(ctx); err == nil {
 			ids, uids, err := s.k8sService.GetTeamIDsByUser(ctx, query)
 			if err == nil {
@@ -141,7 +176,11 @@ func (s *Service) GetTeamIDsByUser(ctx context.Context, query *team.GetTeamIDsBy
 }
 
 func (s *Service) IsTeamMember(ctx context.Context, orgId int64, teamId int64, userId int64) (bool, error) {
-	if team.IsK8sRedirectEnabled(ctx, s.openFeatureClient) {
+	redirectEnabled, err := s.isK8sRedirectEnabled(ctx)
+	if err != nil {
+		return false, err
+	}
+	if redirectEnabled {
 		return s.k8sService.IsTeamMember(ctx, orgId, teamId, userId)
 	}
 
@@ -162,7 +201,11 @@ func (s *Service) GetUserTeamMemberships(ctx context.Context, orgID, userID int6
 
 	ctxLogger := s.logger.FromContext(ctx)
 
-	if team.IsK8sRedirectEnabled(ctx, s.openFeatureClient) {
+	redirectEnabled, err := s.isK8sRedirectEnabled(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if redirectEnabled {
 		result, err := s.k8sService.GetUserTeamMemberships(ctx, orgID, userID, external, bypassCache)
 		if err == nil {
 			span.SetAttributes(attribute.Bool("fallback_to_legacy", false))
@@ -176,7 +219,11 @@ func (s *Service) GetUserTeamMemberships(ctx context.Context, orgID, userID int6
 }
 
 func (s *Service) GetTeamMembers(ctx context.Context, query *team.GetTeamMembersQuery) ([]*team.TeamMemberDTO, error) {
-	if team.IsK8sRedirectEnabled(ctx, s.openFeatureClient) {
+	redirectEnabled, err := s.isK8sRedirectEnabled(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if redirectEnabled {
 		return s.k8sService.GetTeamMembers(ctx, query)
 	}
 
@@ -190,6 +237,19 @@ func (s *Service) RegisterDelete(query string) {
 	// This is called at init time (Wire providers) where no request context
 	// exists, making feature flag evaluation with context.Background() unreliable.
 	s.legacyService.RegisterDelete(query)
+}
+
+func (s *Service) isK8sRedirectEnabled(ctx context.Context) (bool, error) {
+	namespace, _ := openfeature.TransactionContext(ctx).Attributes()["namespace"].(string)
+	if namespace == "" {
+		namespace = s.featureNamespace
+	}
+
+	enabled, err := team.IsK8sRedirectEnabledForNamespace(ctx, s.openFeatureClient, namespace)
+	if err != nil {
+		return false, fmt.Errorf("evaluate Team k8s redirect: %w", err)
+	}
+	return enabled, nil
 }
 
 // shouldFallbackToLegacy determines whether to fallback to the legacy service for a given request.

--- a/pkg/services/team/teamimpl/team_test.go
+++ b/pkg/services/team/teamimpl/team_test.go
@@ -1,0 +1,79 @@
+package teamimpl
+
+import (
+	"context"
+	"testing"
+
+	"github.com/open-feature/go-sdk/openfeature"
+	"github.com/open-feature/go-sdk/openfeature/memprovider"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+)
+
+func TestIsK8sRedirectEnabledUsesTeamNamespace(t *testing.T) {
+	t.Cleanup(func() {
+		require.NoError(t, openfeature.SetProviderAndWait(openfeature.NoopProvider{}))
+	})
+
+	testCases := []struct {
+		name             string
+		ctx              context.Context
+		featureNamespace string
+		wantNamespace    string
+	}{
+		{
+			name:             "uses configured namespace for background calls",
+			ctx:              t.Context(),
+			featureNamespace: "stacks-configured",
+			wantNamespace:    "stacks-configured",
+		},
+		{
+			name: "uses request namespace when present",
+			ctx: openfeature.WithTransactionContext(t.Context(), openfeature.NewEvaluationContext("stacks-request", map[string]any{
+				"namespace": "stacks-request",
+			})),
+			featureNamespace: "stacks-configured",
+			wantNamespace:    "stacks-request",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			namespaceEvaluator := func(_ memprovider.InMemoryFlag, flatCtx openfeature.FlattenedContext) (any, openfeature.ProviderResolutionDetail) {
+				return flatCtx[openfeature.TargetingKey] == tc.wantNamespace && flatCtx["namespace"] == tc.wantNamespace,
+					openfeature.ProviderResolutionDetail{}
+			}
+			provider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
+				featuremgmt.FlagKubernetesTeamsApi:      namespaceFlag(featuremgmt.FlagKubernetesTeamsApi, &namespaceEvaluator),
+				featuremgmt.FlagKubernetesTeamsRedirect: namespaceFlag(featuremgmt.FlagKubernetesTeamsRedirect, &namespaceEvaluator),
+				featuremgmt.FlagKubernetesUsersApi:      namespaceFlag(featuremgmt.FlagKubernetesUsersApi, &namespaceEvaluator),
+			})
+			require.NoError(t, openfeature.SetProviderAndWait(provider))
+
+			svc := &Service{
+				openFeatureClient: openfeature.NewDefaultClient(),
+				featureNamespace:  tc.featureNamespace,
+			}
+			enabled, err := svc.isK8sRedirectEnabled(tc.ctx)
+			require.NoError(t, err)
+			require.True(t, enabled)
+		})
+	}
+
+	t.Run("rejects a service without a request or configured namespace", func(t *testing.T) {
+		svc := &Service{openFeatureClient: openfeature.NewDefaultClient()}
+		enabled, err := svc.isK8sRedirectEnabled(t.Context())
+		require.EqualError(t, err, "evaluate Team k8s redirect: namespace is required to evaluate the Team k8s redirect")
+		require.False(t, enabled)
+	})
+}
+
+func namespaceFlag(name string, evaluator memprovider.ContextEvaluator) memprovider.InMemoryFlag {
+	return memprovider.InMemoryFlag{
+		Key:              name,
+		DefaultVariant:   "default",
+		Variants:         map[string]any{"default": false},
+		ContextEvaluator: evaluator,
+	}
+}


### PR DESCRIPTION
## What

- Extract the Team App Platform redirect predicate into `team.IsK8sRedirectEnabled` so other Team consumers can use the same authority decision.
- Require `kubernetesTeamsApi`, `kubernetesTeamsRedirect`, and `kubernetesUsersApi`. The Teams API check tightens the previous service-local predicate.
- Update `teamimpl.Service` to use the shared helper.
- Add focused coverage for every prerequisite and the nil-client fallback.

## Why

Consumers outside `teamimpl.Service` need to make the same legacy-versus-App-Platform routing decision without duplicating Team rollout requirements. (specifically, Team LBAC)

## Testing

```
go test ./pkg/services/team ./pkg/services/team/teamimpl
```