### PR TITLE
chore(annotations): remove temporary default TTL for postgres backend

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1910,8 +1910,9 @@ enabled = false
 # Storage backend for annotations. Options: "legacy-sql" (default), "grpc", or "postgres"
 store_backend = legacy-sql
 
-# Retention TTL for annotations - old data will be cleaned up
-retention_ttl = 2160h
+# Retention TTL for annotations - old data will be cleaned up after this period.
+# 0 disables retention (no cleanup). A positive duration enables it.
+retention_ttl = 0
 
 # Generate and persist grafana.app/legacyID labels for legacy API compatibility.
 enable_legacy_id = false

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -1748,8 +1748,9 @@ default_datasource_uid =
 # Storage backend for annotations. Options: "legacy-sql" (default), "grpc", or "postgres"
 ;store_backend = legacy-sql
 
-# Retention TTL for annotations - old data will be cleaned up
-;retention_ttl = 2160h
+# Retention TTL for annotations - old data will be cleaned up after this period.
+# 0 disables retention (no cleanup). A positive duration enables it.
+;retention_ttl = 0
 
 # Generate and persist grafana.app/legacyID labels for legacy API compatibility.
 ;enable_legacy_id = false

--- a/pkg/registry/apps/annotation/config.go
+++ b/pkg/registry/apps/annotation/config.go
@@ -12,9 +12,10 @@ import (
 const (
 	// cleanupInterval is how often the background cleanup runs
 	cleanupInterval = 24 * time.Hour
-	// defaultRetentionTTL is the default retention period for annotations
-	// TODO: determine appropriate default TTL
-	defaultRetentionTTL = 90 * 24 * time.Hour
+	// defaultRetentionTTL is the default retention period for annotations.
+	// 0 disables cleanup and retention-based write validation; a positive
+	// value opts in to both.
+	defaultRetentionTTL = 0
 	// defaultMaxScopeCount caps how many scopes can be attached to a single
 	// annotation. 0 means no scopes are allowed.
 	defaultMaxScopeCount = 5
@@ -81,14 +82,9 @@ func (c *Config) AddFlags(flags *pflag.FlagSet) {
 }
 
 func newConfigFromSettings(cfg *setting.Cfg) Config {
-	retentionTTL := cfg.AnnotationAppPlatform.RetentionTTL
-	if retentionTTL == 0 {
-		retentionTTL = defaultRetentionTTL
-	}
-
 	return Config{
 		StoreBackend:   cfg.AnnotationAppPlatform.StoreBackend,
-		RetentionTTL:   retentionTTL,
+		RetentionTTL:   cfg.AnnotationAppPlatform.RetentionTTL,
 		EnableLegacyID: cfg.AnnotationAppPlatform.EnableLegacyID,
 		MaxScopeCount:  cfg.AnnotationAppPlatform.MaxScopeCount,
 

--- a/pkg/registry/apps/annotation/k8s_adapter.go
+++ b/pkg/registry/apps/annotation/k8s_adapter.go
@@ -102,7 +102,7 @@ type k8sRESTAdapter struct {
 
 	// retentionTTL bounds how far in the past an annotation's time may be,
 	// matching the cleanup window so we don't accept data that would be
-	// immediately purged.
+	// immediately purged. A zero TTL disables this bound.
 	retentionTTL time.Duration
 
 	tracer  trace.Tracer
@@ -520,15 +520,17 @@ func (s *k8sRESTAdapter) validateScopeCount(a *annotationV0.Annotation) error {
 func (s *k8sRESTAdapter) validateTimes(anno *annotationV0.Annotation) error {
 	now := time.Now().UTC()
 	maxFuture := now.Add(maxFutureWindow).UnixMilli()
-	maxPast := now.Add(-s.retentionTTL).UnixMilli()
 
 	if anno.Spec.Time > maxFuture {
 		return apierrors.NewBadRequest(
 			fmt.Sprintf("%v: time cannot be more than 1 week in the future", ErrInvalidInput))
 	}
-	if anno.Spec.Time < maxPast {
-		return apierrors.NewBadRequest(
-			fmt.Sprintf("%v: time cannot be older than retention TTL (%v)", ErrInvalidInput, s.retentionTTL))
+	if s.retentionTTL > 0 {
+		maxPast := now.Add(-s.retentionTTL).UnixMilli()
+		if anno.Spec.Time < maxPast {
+			return apierrors.NewBadRequest(
+				fmt.Sprintf("%v: time cannot be older than retention TTL (%v)", ErrInvalidInput, s.retentionTTL))
+		}
 	}
 
 	// If timeEnd is set, validate it's after time and within future bounds

--- a/pkg/registry/apps/annotation/k8s_adapter_test.go
+++ b/pkg/registry/apps/annotation/k8s_adapter_test.go
@@ -630,11 +630,12 @@ func TestK8sAdapter_ValidateAnnotation(t *testing.T) {
 	ns := "org-1"
 	allowAll := &fakeAccessClient{fn: func(_ authtypes.BatchCheckItem) bool { return true }}
 
-	const retentionTTL = 90 * 24 * time.Hour
+	const defaultTTL = 90 * 24 * time.Hour
 	now := time.Now().UTC().UnixMilli()
 	second := time.Second.Milliseconds()
 	futureWindowMs := maxFutureWindow.Milliseconds()
-	retentionMs := retentionTTL.Milliseconds()
+	retentionMs := defaultTTL.Milliseconds()
+	veryOldMs := (10 * 365 * 24 * time.Hour).Milliseconds()
 
 	timeEnd := func(ms int64) *int64 { return &ms }
 
@@ -645,25 +646,28 @@ func TestK8sAdapter_ValidateAnnotation(t *testing.T) {
 		time              int64
 		timeEnd           *int64
 		deletionTimestamp *metav1.Time
+		retentionTTL      time.Duration
 		expectErr         bool
 		errContains       string
 	}{
-		{"time is current", now, nil, nil, false, ""},
-		{"recent past within retention", now - retentionMs/2, nil, nil, false, ""},
-		{"inside future bound", now + futureWindowMs - second, nil, nil, false, ""},
-		{"too far in the future", now + futureWindowMs + second, nil, nil, true, "time cannot be more than 1 week in the future"},
-		{"older than retention TTL", now - retentionMs - second, nil, nil, true, "time cannot be older than retention TTL"},
-		{"valid timeEnd after time", now, timeEnd(now + second), nil, false, ""},
-		{"timeEnd before time", now, timeEnd(now - second), nil, true, "timeEnd must be after time"},
-		{"timeEnd too far in the future", now, timeEnd(now + futureWindowMs + second), nil, true, "timeEnd cannot be more than 1 week in the future"},
-		{"deletionTimestamp set on create", now, nil, &deletedAt, true, "metadata.deletionTimestamp cannot be set on create"},
+		{name: "time is current", time: now, retentionTTL: defaultTTL},
+		{name: "recent past within retention", time: now - retentionMs/2, retentionTTL: defaultTTL},
+		{name: "inside future bound", time: now + futureWindowMs - second, retentionTTL: defaultTTL},
+		{name: "too far in the future", time: now + futureWindowMs + second, retentionTTL: defaultTTL, expectErr: true, errContains: "time cannot be more than 1 week in the future"},
+		{name: "older than retention TTL", time: now - retentionMs - second, retentionTTL: defaultTTL, expectErr: true, errContains: "time cannot be older than retention TTL"},
+		{name: "very old time accepted with no retention", time: now - veryOldMs, retentionTTL: 0},
+		{name: "future bound enforced with no retention", time: now + futureWindowMs + second, retentionTTL: 0, expectErr: true, errContains: "time cannot be more than 1 week in the future"},
+		{name: "valid timeEnd after time", time: now, timeEnd: timeEnd(now + second), retentionTTL: defaultTTL},
+		{name: "timeEnd before time", time: now, timeEnd: timeEnd(now - second), retentionTTL: defaultTTL, expectErr: true, errContains: "timeEnd must be after time"},
+		{name: "timeEnd too far in the future", time: now, timeEnd: timeEnd(now + futureWindowMs + second), retentionTTL: defaultTTL, expectErr: true, errContains: "timeEnd cannot be more than 1 week in the future"},
+		{name: "deletionTimestamp set on create", time: now, deletionTimestamp: &deletedAt, retentionTTL: defaultTTL, expectErr: true, errContains: "metadata.deletionTimestamp cannot be set on create"},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			store := NewMemoryStore()
 			adapter := newTestAdapter(store, allowAll)
-			adapter.retentionTTL = retentionTTL
+			adapter.retentionTTL = tc.retentionTTL
 			ctx := k8srequest.WithNamespace(identity.WithServiceIdentityContext(t.Context(), 1), ns)
 
 			name := "anno"

--- a/pkg/registry/apps/annotation/lifecycle.go
+++ b/pkg/registry/apps/annotation/lifecycle.go
@@ -9,7 +9,7 @@ import (
 
 // startCleanup starts a background goroutine that periodically runs cleanup on the store
 func (a *AppInstaller) startCleanup(parentCtx context.Context, lifecycleMgr LifecycleManager, retentionTTL time.Duration) {
-	if retentionTTL == 0 {
+	if retentionTTL <= 0 {
 		a.logger.Info("Annotation cleanup disabled (no retention TTL configured)")
 		return
 	}

--- a/pkg/registry/apps/annotation/lifecycle.go
+++ b/pkg/registry/apps/annotation/lifecycle.go
@@ -9,6 +9,11 @@ import (
 
 // startCleanup starts a background goroutine that periodically runs cleanup on the store
 func (a *AppInstaller) startCleanup(parentCtx context.Context, lifecycleMgr LifecycleManager, retentionTTL time.Duration) {
+	if retentionTTL == 0 {
+		a.logger.Info("Annotation cleanup disabled (no retention TTL configured)")
+		return
+	}
+
 	ctx, cancel := context.WithCancel(parentCtx)
 	a.cleanupCancel = cancel
 

--- a/pkg/setting/setting_annotations.go
+++ b/pkg/setting/setting_annotations.go
@@ -67,7 +67,7 @@ func loadAnnotationAppPlatformSettings(cfg *Cfg) (AnnotationAppPlatformSettings,
 	settings := AnnotationAppPlatformSettings{
 		Enabled:           appPlatformSection.Key("enabled").MustBool(false),
 		StoreBackend:      appPlatformSection.Key("store_backend").MustString("legacy-sql"),
-		RetentionTTL:      appPlatformSection.Key("retention_ttl").MustDuration(2160 * time.Hour),
+		RetentionTTL:      appPlatformSection.Key("retention_ttl").MustDuration(0),
 		EnableLegacyID:    appPlatformSection.Key("enable_legacy_id").MustBool(false),
 		MaxScopeCount:     appPlatformSection.Key("max_scope_count").MustInt(5),
 		APIMigrationPhase: appPlatformSection.Key("api_migration_phase").MustString(AnnotationAPIMigrationPhaseOff),
@@ -90,6 +90,10 @@ func loadAnnotationAppPlatformSettings(cfg *Cfg) (AnnotationAppPlatformSettings,
 
 	if settings.MaxScopeCount < 0 {
 		return AnnotationAppPlatformSettings{}, fmt.Errorf("[annotations.app_platform.max_scope_count] must not be negative")
+	}
+
+	if settings.RetentionTTL < 0 {
+		return AnnotationAppPlatformSettings{}, fmt.Errorf("[annotations.app_platform.retention_ttl] must not be negative")
 	}
 
 	return settings, nil

--- a/pkg/setting/setting_annotations_test.go
+++ b/pkg/setting/setting_annotations_test.go
@@ -2,6 +2,7 @@ package setting
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -41,6 +42,43 @@ func TestLoadAnnotationAppPlatformSettings(t *testing.T) {
 
 				require.NoError(t, err)
 				assert.Equal(t, tc.expectedMaxScopeCount, settings.MaxScopeCount)
+			})
+		}
+	})
+
+	t.Run("RetentionTTL", func(t *testing.T) {
+		cases := []struct {
+			name        string
+			iniValue    *string
+			expectedTTL time.Duration
+			expectErr   bool
+		}{
+			{name: "default when key absent is disabled", expectedTTL: 0},
+			{name: "empty value is disabled", iniValue: new(""), expectedTTL: 0},
+			{name: "zero is disabled", iniValue: new("0"), expectedTTL: 0},
+			{name: "explicit positive", iniValue: new("2160h"), expectedTTL: 2160 * time.Hour},
+			{name: "negative is rejected", iniValue: new("-1h"), expectErr: true},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				iniFile := ini.Empty()
+				if tc.iniValue != nil {
+					section, err := iniFile.NewSection("annotations.app_platform")
+					require.NoError(t, err)
+
+					_, err = section.NewKey("retention_ttl", *tc.iniValue)
+					require.NoError(t, err)
+				}
+
+				settings, err := loadAnnotationAppPlatformSettings(&Cfg{Raw: iniFile})
+				if tc.expectErr {
+					assert.Error(t, err)
+					return
+				}
+
+				require.NoError(t, err)
+				assert.Equal(t, tc.expectedTTL, settings.RetentionTTL)
 			})
 		}
 	})


### PR DESCRIPTION
This PR removes the temporary default TTL for the annotation postgres store. We plan to eventually set a default value in the future, but want to remove this temporary value to avoid any unwanted cleanup of annotation data. It also adds validation to ensure only positive values can be configured for `retention_ttl`.