### PR TITLE
fix(annotations): simplify partition cleanup logic

### DIFF
--- a/pkg/registry/apps/annotation/postgres_lifecycle.go
+++ b/pkg/registry/apps/annotation/postgres_lifecycle.go
@@ -14,6 +14,8 @@ func (s *PostgreSQLStore) Cleanup(ctx context.Context, before time.Time) (int64,
 	// Calculate cutoff timestamp and corresponding partition name
 	cutoffMs := before.UnixMilli()
 	cutoffPartition := getPartitionName(cutoffMs)
+	// Don't drop partitions less than 24 hours old even if they're past TTL
+	minKeepPartition := getPartitionName(time.Now().UTC().Add(-24 * time.Hour).UnixMilli())
 
 	// Get all existing partitions
 	partitions, err := listPartitions(ctx, s.pool)
@@ -25,13 +27,7 @@ func (s *PostgreSQLStore) Cleanup(ctx context.Context, before time.Time) (int64,
 
 	// Iterate through partitions and drop those older than cutoff
 	for _, partition := range partitions {
-		// Skip if partition is newer than or equal to cutoff
-		if partition.Name >= cutoffPartition {
-			continue
-		}
-
-		// Don't drop partitions less than 24 hours old even if they're past TTL
-		if partition.EndTime > time.Now().UTC().Add(-24*time.Hour).UnixMilli() {
+		if partition.Name >= cutoffPartition || partition.Name >= minKeepPartition {
 			continue
 		}
 

--- a/pkg/registry/apps/annotation/postgres_schema.go
+++ b/pkg/registry/apps/annotation/postgres_schema.go
@@ -22,8 +22,6 @@ var embedMigrations embed.FS
 // PartitionInfo contains metadata about a partition
 type PartitionInfo struct {
 	Name       string
-	StartTime  int64
-	EndTime    int64
 	ParentName string
 }
 
@@ -43,9 +41,7 @@ FOR VALUES FROM (%d) TO (%d);
 	createScopesIndexSQL    = `CREATE INDEX IF NOT EXISTS %s ON %s USING GIN (namespace, scopes);`
 
 	listPartitionsSQL = `
-SELECT
-    child.relname AS partition_name,
-    pg_get_expr(child.relpartbound, child.oid) AS partition_bounds
+SELECT child.relname AS partition_name
 FROM pg_inherits
 JOIN pg_class parent ON pg_inherits.inhparent = parent.oid
 JOIN pg_class child ON pg_inherits.inhrelid = child.oid
@@ -138,20 +134,13 @@ func listPartitions(ctx context.Context, pool *pgxpool.Pool) ([]PartitionInfo, e
 
 	var partitions []PartitionInfo
 	for rows.Next() {
-		var name, bounds string
-		if err := rows.Scan(&name, &bounds); err != nil {
+		var name string
+		if err := rows.Scan(&name); err != nil {
 			return nil, fmt.Errorf("failed to scan partition row: %w", err)
-		}
-
-		var start, end int64
-		if _, err := fmt.Sscanf(bounds, "FOR VALUES FROM (%d) TO (%d)", &start, &end); err != nil {
-			return nil, fmt.Errorf("failed to parse partition bounds %q: %w", bounds, err)
 		}
 
 		partitions = append(partitions, PartitionInfo{
 			Name:       name,
-			StartTime:  start,
-			EndTime:    end,
 			ParentName: "annotations",
 		})
 	}

--- a/pkg/registry/apps/annotation/postgres_store_test.go
+++ b/pkg/registry/apps/annotation/postgres_store_test.go
@@ -292,7 +292,7 @@ func TestIntegrationPostgresCleanup(t *testing.T) {
 		store := newTestPostgresStore(t)
 		ctx := k8srequest.WithNamespace(identity.WithServiceIdentityContext(t.Context(), 1), ns)
 
-		now := time.Now().UTC()
+		now := time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC)
 		old := now.AddDate(0, 0, -120)   // past a 90-day cutoff: dropped
 		recent := now.AddDate(0, 0, -30) // within the cutoff: kept
 		seed(t, store, ctx, "old", old)

--- a/pkg/registry/apps/annotation/postgres_store_test.go
+++ b/pkg/registry/apps/annotation/postgres_store_test.go
@@ -1,7 +1,9 @@
 package annotation
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -272,6 +274,68 @@ func TestIntegrationPostgresStore(t *testing.T) {
 			require.NotNil(t, found.DeletionTimestamp, "expected tombstone deletionTimestamp")
 		})
 	})
+}
+
+func TestIntegrationPostgresCleanup(t *testing.T) {
+	ns := metav1.NamespaceDefault
+
+	seed := func(t *testing.T, store *PostgreSQLStore, ctx context.Context, name string, ts time.Time) {
+		t.Helper()
+		_, err := store.Create(ctx, &annotationV0.Annotation{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+			Spec:       annotationV0.AnnotationSpec{Text: name, Time: ts.UnixMilli()},
+		})
+		require.NoError(t, err, "create %s", name)
+	}
+
+	t.Run("drops partitions past the retention cutoff", func(t *testing.T) {
+		store := newTestPostgresStore(t)
+		ctx := k8srequest.WithNamespace(identity.WithServiceIdentityContext(t.Context(), 1), ns)
+
+		now := time.Now().UTC()
+		old := now.AddDate(0, 0, -120)   // past a 90-day cutoff: dropped
+		recent := now.AddDate(0, 0, -30) // within the cutoff: kept
+		seed(t, store, ctx, "old", old)
+		seed(t, store, ctx, "recent", recent)
+
+		deleted, err := store.Cleanup(ctx, now.AddDate(0, 0, -90))
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), deleted, "only the old partition's row should be counted")
+
+		remaining := partitionNameSet(ctx, t, store)
+		assert.NotContains(t, remaining, getPartitionName(old.UnixMilli()), "old partition should be dropped")
+		assert.Contains(t, remaining, getPartitionName(recent.UnixMilli()), "recent partition should be kept")
+	})
+
+	t.Run("keeps recent partitions protected by the 24h floor even when past the cutoff", func(t *testing.T) {
+		store := newTestPostgresStore(t)
+		ctx := k8srequest.WithNamespace(identity.WithServiceIdentityContext(t.Context(), 1), ns)
+
+		now := time.Now().UTC()
+		current := now                // this week: past a 1h cutoff, but inside the 24h floor
+		old := now.AddDate(0, 0, -21) // several weeks back: past both the cutoff and the floor
+		seed(t, store, ctx, "current", current)
+		seed(t, store, ctx, "old", old)
+
+		deleted, err := store.Cleanup(ctx, now.Add(-time.Hour))
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), deleted, "only the old partition's row should be counted")
+
+		remaining := partitionNameSet(ctx, t, store)
+		assert.Contains(t, remaining, getPartitionName(current.UnixMilli()), "current partition should be kept by the 24h floor")
+		assert.NotContains(t, remaining, getPartitionName(old.UnixMilli()), "old partition should be dropped")
+	})
+}
+
+func partitionNameSet(ctx context.Context, t *testing.T, store *PostgreSQLStore) map[string]struct{} {
+	t.Helper()
+	partitions, err := listPartitions(ctx, store.pool)
+	require.NoError(t, err)
+	set := make(map[string]struct{}, len(partitions))
+	for _, p := range partitions {
+		set[p.Name] = struct{}{}
+	}
+	return set
 }
 
 func annotationNames(list *AnnotationList) []string {


### PR DESCRIPTION
The postgres annotation store's partition cleanup was reconstructing partition time bounds by string-parsing `pg_get_expr` output, which is inherently brittle and can fail on engines that render integer bounds as quoted literals (e.g. `'12345'` vs `12345`). This PR reworks cleanup to compare partitions purely by their monotonic `annotations_YYYYwWW` names and adds relevant test coverage.