### PR TITLE
Alerting: Return empty list when contact points config is missing

### DIFF
--- a/pkg/services/ngalert/provisioning/contactpoints.go
+++ b/pkg/services/ngalert/provisioning/contactpoints.go
@@ -117,6 +117,11 @@ func (ecp *ContactPointService) GetContactPoints(ctx context.Context, q ContactP
 
 	res, err := ecp.receiverService.GetReceivers(ctx, receiverQuery, u)
 	if err != nil {
+		// New orgs have no Alertmanager config yet. Listing contact points is a
+		// valid empty state (GET-before-POST reconcilers depend on this).
+		if errors.Is(err, store.ErrNoAlertmanagerConfiguration) || legacy_storage.ErrNoAlertmanagerConfiguration.Is(err) {
+			return []apimodels.EmbeddedContactPoint{}, nil
+		}
 		return nil, convertRecSvcErr(err)
 	}
 	if q.Name != "" && len(res) > 0 {

--- a/pkg/services/ngalert/provisioning/contactpoints_test.go
+++ b/pkg/services/ngalert/provisioning/contactpoints_test.go
@@ -35,6 +35,7 @@ import (
 	v1 "github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage/v1"
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier/routes"
 	"github.com/grafana/grafana/pkg/services/ngalert/provisioning/validation"
+	"github.com/grafana/grafana/pkg/services/ngalert/store"
 	"github.com/grafana/grafana/pkg/services/ngalert/tests/fakes"
 	"github.com/grafana/grafana/pkg/services/secrets"
 	"github.com/grafana/grafana/pkg/services/secrets/database"
@@ -82,6 +83,19 @@ func TestIntegrationContactPointService(t *testing.T) {
 		require.Len(t, cps, 2)
 		require.Equal(t, "grafana-default-email", cps[0].Name)
 		require.Equal(t, "slack receiver", cps[1].Name)
+	})
+
+	t.Run("service returns empty list when org has no Alertmanager config", func(t *testing.T) {
+		cfgStore := fakes.NewFakeAlertmanagerConfigStore("")
+		cfgStore.GetFn = func(ctx context.Context, orgID int64) (*models.AlertConfiguration, error) {
+			return nil, store.ErrNoAlertmanagerConfiguration
+		}
+		sut := createContactPointServiceSutWithConfigStore(t, secretsService, cfgStore)
+
+		cps, err := sut.GetContactPoints(context.Background(), cpsQuery(1), redactedUser)
+		require.NoError(t, err)
+		require.NotNil(t, cps)
+		require.Empty(t, cps)
 	})
 
 	t.Run("service filters contact points by name", func(t *testing.T) {


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips:
1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md
2. Ensure you include and run the appropriate tests as part of your Pull Request.
3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.
6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.
7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.
-->

**What is this feature?**

`GET /api/v1/provisioning/contact-points` now returns an empty list when the organization has no Alertmanager configuration instead of HTTP 500 with `alerting.notification.configMissing`.

**Why do we need this feature?**

A newly created organization has no Alertmanager config yet. Listing contact points is a valid empty state, but the provisioning service treated `ErrNoAlertmanagerConfiguration` as a hard error. That broke GET-before-POST reconcilers trying to create the first contact point.

**Who is this feature for?**

API clients and reconcilers that list contact points against orgs without an existing Alertmanager configuration.

**Which issue(s) does this PR fix?**:

Fixes #128258

**Special notes for your reviewer:**

The fix is in `ContactPointService.GetContactPoints`: when receiver load fails with a missing Alertmanager config, return `[]` instead of converting the error to a 500. Create/update paths are unchanged.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.