### PR TITLE
Logs Datasource: update getDataSourceSrv().get to getDataSourceInstance

### DIFF
--- a/public/app/plugins/datasource/loki/backendResultTransformer.test.ts
+++ b/public/app/plugins/datasource/loki/backendResultTransformer.test.ts
@@ -5,15 +5,11 @@ import { type DataFrame, type DataQueryResponse, type Field, FieldType } from '@
 import { transformBackendResult } from './backendResultTransformer';
 
 // needed because the derived-fields functionality calls it
-jest.mock('@grafana/runtime', () => ({
+jest.mock('@grafana/runtime/unstable', () => ({
   // @ts-ignore
-  ...jest.requireActual('@grafana/runtime'),
-  getDataSourceSrv: () => {
-    return {
-      getInstanceSettings: () => {
-        return { name: 'Loki1' };
-      },
-    };
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getDataSourceInstance: () => {
+    return Promise.resolve({ name: 'Loki1' });
   },
 }));
 
@@ -65,7 +61,7 @@ const inputFrame: DataFrame = {
 };
 
 describe('backendResultTransformer', () => {
-  it('processes a logs dataframe correctly', () => {
+  it('processes a logs dataframe correctly', async () => {
     const response: DataQueryResponse = { data: [cloneDeep(inputFrame)] };
 
     const expectedFrame = cloneDeep(inputFrame);
@@ -81,7 +77,7 @@ describe('backendResultTransformer', () => {
 
     const expected: DataQueryResponse = { data: [expectedFrame] };
 
-    const result = transformBackendResult(
+    const result = await transformBackendResult(
       response,
       [
         {
@@ -94,38 +90,42 @@ describe('backendResultTransformer', () => {
     expect(result).toEqual(expected);
   });
 
-  it('applies maxLines correctly', () => {
+  it('applies maxLines correctly', async () => {
     const response: DataQueryResponse = { data: [cloneDeep(inputFrame)] };
 
-    const frame1: DataFrame = transformBackendResult(
-      response,
-      [
-        {
-          refId: 'A',
-          expr: LOKI_EXPR,
-        },
-      ],
-      []
+    const frame1: DataFrame = (
+      await transformBackendResult(
+        response,
+        [
+          {
+            refId: 'A',
+            expr: LOKI_EXPR,
+          },
+        ],
+        []
+      )
     ).data[0];
 
     expect(frame1.meta?.limit).toBeUndefined();
 
-    const frame2 = transformBackendResult(
-      response,
-      [
-        {
-          refId: 'A',
-          expr: LOKI_EXPR,
-          maxLines: 42,
-        },
-      ],
-      []
+    const frame2 = (
+      await transformBackendResult(
+        response,
+        [
+          {
+            refId: 'A',
+            expr: LOKI_EXPR,
+            maxLines: 42,
+          },
+        ],
+        []
+      )
     ).data[0];
 
     expect(frame2.meta?.limit).toBe(42);
   });
 
-  it('processed derived fields correctly', () => {
+  it('processed derived fields correctly', async () => {
     const input: DataFrame = {
       length: 1,
       fields: [
@@ -144,7 +144,7 @@ describe('backendResultTransformer', () => {
       ],
     };
     const response: DataQueryResponse = { data: [input] };
-    const result = transformBackendResult(
+    const result = await transformBackendResult(
       response,
       [{ refId: 'A', expr: '' }],
       [
@@ -161,7 +161,7 @@ describe('backendResultTransformer', () => {
     ).toBe(1);
   });
 
-  it('handle loki parsing errors', () => {
+  it('handle loki parsing errors', async () => {
     const clonedFrame = cloneDeep(inputFrame);
     clonedFrame.fields[2] = {
       name: 'labels',
@@ -174,7 +174,7 @@ describe('backendResultTransformer', () => {
     };
     const response: DataQueryResponse = { data: [clonedFrame] };
 
-    const result = transformBackendResult(
+    const result = await transformBackendResult(
       response,
       [
         {
@@ -187,7 +187,7 @@ describe('backendResultTransformer', () => {
     expect(result.data[0]?.meta?.custom?.error).toBe('Error when parsing some of the logs');
   });
 
-  it('improve loki escaping error message when query contains escape', () => {
+  it('improve loki escaping error message when query contains escape', async () => {
     const response: DataQueryResponse = {
       data: [],
       error: {
@@ -196,7 +196,7 @@ describe('backendResultTransformer', () => {
       },
     };
 
-    const result = transformBackendResult(
+    const result = await transformBackendResult(
       response,
       [
         {
@@ -211,7 +211,7 @@ describe('backendResultTransformer', () => {
     );
   });
 
-  it('do not change loki escaping error message when query does not contain escape', () => {
+  it('do not change loki escaping error message when query does not contain escape', async () => {
     const response: DataQueryResponse = {
       data: [],
       error: {
@@ -220,7 +220,7 @@ describe('backendResultTransformer', () => {
       },
     };
 
-    const result = transformBackendResult(
+    const result = await transformBackendResult(
       response,
       [
         {
@@ -233,12 +233,12 @@ describe('backendResultTransformer', () => {
     expect(result.error?.message).toBe('parse error at line 1, col 2: invalid char escape');
   });
 
-  it('resolves search words from queries with template variables', () => {
+  it('resolves search words from queries with template variables', async () => {
     const dataFrame = cloneDeep(inputFrame);
     dataFrame.meta = {
       executedQueryString: 'Expr: {service_name="tns-app"} |~ "(?i)template" |= "variable"',
     };
-    const result = transformBackendResult(
+    const result = await transformBackendResult(
       { data: [dataFrame] },
       [
         {

--- a/public/app/plugins/datasource/loki/backendResultTransformer.ts
+++ b/public/app/plugins/datasource/loki/backendResultTransformer.ts
@@ -29,11 +29,11 @@ function setFrameMeta(frame: DataFrame, meta: QueryResultMeta): DataFrame {
   };
 }
 
-function processStreamFrame(
+async function processStreamFrame(
   frame: DataFrame,
   query: LokiQuery | undefined,
   derivedFieldConfigs: DerivedFieldConfig[]
-): DataFrame {
+): Promise<DataFrame> {
   const custom: Record<string, string> = {
     ...frame.meta?.custom, // keep the original meta.custom
     // used by logsModel
@@ -52,7 +52,7 @@ function processStreamFrame(
   };
 
   const newFrame = setFrameMeta(frame, meta);
-  const derivedFields = getDerivedFields(newFrame, derivedFieldConfigs);
+  const derivedFields = await getDerivedFields(newFrame, derivedFieldConfigs);
   return {
     ...newFrame,
     fields: [...newFrame.fields, ...derivedFields],
@@ -63,11 +63,13 @@ function processStreamsFrames(
   frames: DataFrame[],
   queryMap: Map<string, LokiQuery>,
   derivedFieldConfigs: DerivedFieldConfig[]
-): DataFrame[] {
-  return frames.map((frame) => {
-    const query = frame.refId !== undefined ? queryMap.get(frame.refId) : undefined;
-    return processStreamFrame(frame, query, derivedFieldConfigs);
-  });
+): Promise<DataFrame[]> {
+  return Promise.all(
+    frames.map((frame) => {
+      const query = frame.refId !== undefined ? queryMap.get(frame.refId) : undefined;
+      return processStreamFrame(frame, query, derivedFieldConfigs);
+    })
+  );
 }
 
 function processMetricInstantFrames(frames: DataFrame[]): DataFrame[] {
@@ -136,11 +138,11 @@ function improveError(error: DataQueryError | undefined, queryMap: Map<string, L
   return error;
 }
 
-export function transformBackendResult(
+export async function transformBackendResult(
   response: DataQueryResponse,
   queries: LokiQuery[],
   derivedFieldConfigs: DerivedFieldConfig[]
-): DataQueryResponse {
+): Promise<DataQueryResponse> {
   const { data, error, ...rest } = response;
 
   // in the typescript type, data is an array of basically anything.
@@ -173,7 +175,7 @@ export function transformBackendResult(
     data: [
       ...processMetricRangeFrames(metricRangeFrames),
       ...processMetricInstantFrames(metricInstantFrames),
-      ...processStreamsFrames(streamsFrames, queryMap, derivedFieldConfigs),
+      ...(await processStreamsFrames(streamsFrames, queryMap, derivedFieldConfigs)),
     ],
   };
 }

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -1,5 +1,5 @@
 import { cloneDeep, map as lodashMap } from 'lodash';
-import { lastValueFrom, merge, type Observable, of, throwError } from 'rxjs';
+import { from, lastValueFrom, merge, type Observable, of, throwError } from 'rxjs';
 import { catchError, map, switchMap, tap } from 'rxjs/operators';
 
 import {
@@ -390,8 +390,10 @@ export class LokiDatasource
     return super
       .query(fixedRequest)
       .pipe(
-        map((response) =>
-          transformBackendResult(response, fixedRequest.targets, this.instanceSettings.jsonData.derivedFields ?? [])
+        switchMap((response) =>
+          from(
+            transformBackendResult(response, fixedRequest.targets, this.instanceSettings.jsonData.derivedFields ?? [])
+          )
         )
       );
   }

--- a/public/app/plugins/datasource/loki/getDerivedFields.test.ts
+++ b/public/app/plugins/datasource/loki/getDerivedFields.test.ts
@@ -2,27 +2,23 @@ import { createDataFrame } from '@grafana/data';
 
 import { getDerivedFields } from './getDerivedFields';
 
-jest.mock('@grafana/runtime', () => ({
-  ...jest.requireActual('@grafana/runtime'),
-  getDataSourceSrv: () => {
-    return {
-      getInstanceSettings: (datasourceUid?: string) => {
-        switch (datasourceUid) {
-          case 'tempo-datasource-uid':
-            return { name: 'Tempo', type: 'tempo' };
-          case 'xray-datasource-uid':
-            return { name: 'X-ray', type: 'grafana-x-ray-datasource' };
-        }
-        return { name: 'Loki1' };
-      },
-    };
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getDataSourceInstance: (ref?: { uid?: string }) => {
+    switch (ref?.uid) {
+      case 'tempo-datasource-uid':
+        return Promise.resolve({ name: 'Tempo', type: 'tempo' });
+      case 'xray-datasource-uid':
+        return Promise.resolve({ name: 'X-ray', type: 'grafana-x-ray-datasource' });
+    }
+    return Promise.resolve({ name: 'Loki1' });
   },
 }));
 
 describe('getDerivedFields', () => {
-  it('adds links to fields', () => {
+  it('adds links to fields', async () => {
     const df = createDataFrame({ fields: [{ name: 'line', values: ['nothing', 'trace1=1234', 'trace2=foo'] }] });
-    const newFields = getDerivedFields(df, [
+    const newFields = await getDerivedFields(df, [
       {
         matcherRegex: 'trace1=(\\w+)',
         matcherType: 'regex',
@@ -109,14 +105,14 @@ describe('getDerivedFields', () => {
       url: '',
     });
   });
-  it('adds links to fields with labels', () => {
+  it('adds links to fields with labels', async () => {
     const df = createDataFrame({
       fields: [
         { name: 'labels', values: [{ trace3: 'bar', trace4: 'blank' }, { trace3: 'tar' }, {}, null] },
         { name: 'line', values: ['nothing', 'trace1=1234', 'trace2=aa', ''] },
       ],
     });
-    const newFields = getDerivedFields(df, [
+    const newFields = await getDerivedFields(df, [
       {
         matcherRegex: 'trace1=(\\w+)',
         matcherType: 'regex',
@@ -156,9 +152,9 @@ describe('getDerivedFields', () => {
     expect(trace4!.values).toEqual([null, null, null, null]);
   });
 
-  it('adds links to fields with no `matcherType`', () => {
+  it('adds links to fields with no `matcherType`', async () => {
     const df = createDataFrame({ fields: [{ name: 'line', values: ['nothing', 'trace1=1234', 'trace2=foo'] }] });
-    const newFields = getDerivedFields(df, [
+    const newFields = await getDerivedFields(df, [
       {
         matcherRegex: 'trace1=(\\w+)',
         name: 'trace1',
@@ -174,9 +170,9 @@ describe('getDerivedFields', () => {
     });
   });
 
-  it('adds links to fields with `matcherType=regex`', () => {
+  it('adds links to fields with `matcherType=regex`', async () => {
     const df = createDataFrame({ fields: [{ name: 'line', values: ['nothing', 'trace1=1234', 'trace2=foo'] }] });
-    const newFields = getDerivedFields(df, [
+    const newFields = await getDerivedFields(df, [
       {
         matcherRegex: 'trace1=(\\w+)',
         matcherType: 'regex',
@@ -193,14 +189,14 @@ describe('getDerivedFields', () => {
     });
   });
 
-  it('matches label keys using regex when matcherType is label', () => {
+  it('matches label keys using regex when matcherType is label', async () => {
     const df = createDataFrame({
       fields: [
         { name: 'labels', values: [{ traceId: 'abc' }, { traceID: 'xyz' }] },
         { name: 'line', values: ['log1', 'log2'] },
       ],
     });
-    const newFields = getDerivedFields(df, [
+    const newFields = await getDerivedFields(df, [
       {
         matcherRegex: 'traceI(d|D)',
         name: 'traceIdFromLabel',

--- a/public/app/plugins/datasource/loki/getDerivedFields.ts
+++ b/public/app/plugins/datasource/loki/getDerivedFields.ts
@@ -1,17 +1,20 @@
 import { groupBy } from 'lodash';
 
 import { FieldType, type DataFrame, type DataLink, type Field } from '@grafana/data';
-import { getDataSourceSrv } from '@grafana/runtime';
+import { getDataSourceInstance } from '@grafana/runtime/unstable';
 
 import { type DerivedFieldConfig } from './types';
 
-export function getDerivedFields(dataFrame: DataFrame, derivedFieldConfigs: DerivedFieldConfig[]): Field[] {
+export async function getDerivedFields(
+  dataFrame: DataFrame,
+  derivedFieldConfigs: DerivedFieldConfig[]
+): Promise<Field[]> {
   if (!derivedFieldConfigs.length) {
     return [];
   }
   const derivedFieldsGrouped = groupBy(derivedFieldConfigs, 'name');
 
-  const newFields = Object.values(derivedFieldsGrouped).map(fieldFromDerivedFieldConfig);
+  const newFields = await Promise.all(Object.values(derivedFieldsGrouped).map(fieldFromDerivedFieldConfig));
 
   // line-field is the first string-field
   // NOTE: we should create some common log-frame-extra-string-field code somewhere
@@ -68,13 +71,15 @@ export function getDerivedFields(dataFrame: DataFrame, derivedFieldConfigs: Deri
 /**
  * Transform derivedField config into dataframe field with config that contains link.
  */
-function fieldFromDerivedFieldConfig(derivedFieldConfigs: DerivedFieldConfig[]): Field {
-  const dataSourceSrv = getDataSourceSrv();
+async function fieldFromDerivedFieldConfig(derivedFieldConfigs: DerivedFieldConfig[]): Promise<Field> {
+  const dataLinks: DataLink[] = [];
 
-  const dataLinks = derivedFieldConfigs.reduce<DataLink[]>((acc, derivedFieldConfig) => {
+  for (const derivedFieldConfig of derivedFieldConfigs) {
     // Having field.datasourceUid means it is an internal link.
     if (derivedFieldConfig.datasourceUid) {
-      const dsSettings = dataSourceSrv.getInstanceSettings(derivedFieldConfig.datasourceUid);
+      // getDataSourceInstance rejects when the data source cannot be resolved; keep the link
+      // usable and fall back to a placeholder name, matching the previous non-throwing lookup.
+      const dsInstance = await getDataSourceInstance({ uid: derivedFieldConfig.datasourceUid }).catch(() => undefined);
       const queryType = (type: string | undefined): string | undefined => {
         switch (type) {
           case 'tempo':
@@ -86,20 +91,20 @@ function fieldFromDerivedFieldConfig(derivedFieldConfigs: DerivedFieldConfig[]):
         }
       };
 
-      acc.push({
+      dataLinks.push({
         // Will be filled out later
         title: derivedFieldConfig.urlDisplayLabel || '',
         url: '',
         // This is hardcoded for Jaeger or Zipkin not way right now to specify datasource specific query object
         internal: {
-          query: { query: derivedFieldConfig.url, queryType: queryType(dsSettings?.type) },
+          query: { query: derivedFieldConfig.url, queryType: queryType(dsInstance?.type) },
           datasourceUid: derivedFieldConfig.datasourceUid,
-          datasourceName: dsSettings?.name ?? 'Data source not found',
+          datasourceName: dsInstance?.name ?? 'Data source not found',
         },
         targetBlank: derivedFieldConfig.targetBlank,
       });
     } else if (derivedFieldConfig.url) {
-      acc.push({
+      dataLinks.push({
         // We do not know what title to give here so we count on presentation layer to create a title from metadata.
         title: derivedFieldConfig.urlDisplayLabel || '',
         // This is hardcoded for Jaeger or Zipkin not way right now to specify datasource specific query object
@@ -107,8 +112,7 @@ function fieldFromDerivedFieldConfig(derivedFieldConfigs: DerivedFieldConfig[]):
         targetBlank: derivedFieldConfig.targetBlank,
       });
     }
-    return acc;
-  }, []);
+  }
 
   return {
     name: derivedFieldConfigs[0].name,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- Migrates Loki derived fields off the deprecated `getDataSourceSrv().getInstanceSettings()` to
  `getDataSourceInstance` from `@grafana/runtime/unstable` (#127038 — DataSource api migration).
  - Threads the now-async datasource lookup through the call chain: `getDerivedFields` →
  `backendResultTransformer` (`processStreamFrame`/`processStreamsFrames`/`transformBackendResult`) are
  now `async`, and `datasource.ts` `runQuery` consumes the promise via `switchMap(response =>
  from(...))`.
  - Preserves the previous non-throwing behavior: since `getDataSourceInstance` rejects on an
  unresolved datasource (vs. the old sync call returning `undefined`), the internal link falls back to
  `'Data source not found'` via `.catch(() => undefined)`.


<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes

- # https://github.com/grafana/grafana/issues/127038

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
