### PR TITLE
ColorScale: Remove live hoverValue, remove from HeatMap tooltip

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -2978,14 +2978,6 @@
       "count": 1
     }
   },
-  "public/app/plugins/panel/geomap/components/MarkersLegend.tsx": {
-    "@typescript-eslint/consistent-type-assertions": {
-      "count": 2
-    },
-    "@typescript-eslint/no-explicit-any": {
-      "count": 1
-    }
-  },
   "public/app/plugins/panel/geomap/editor/GeomapStyleRulesEditor.tsx": {
     "@typescript-eslint/consistent-type-assertions": {
       "count": 1

--- a/public/app/core/components/ColorScale/ColorScale.test.tsx
+++ b/public/app/core/components/ColorScale/ColorScale.test.tsx
@@ -13,8 +13,7 @@ jest.mock('react-use', () => ({
 
 const palette = ['#0000ff', '#ff0000'];
 
-const getTickLabels = () =>
-  Array.from(document.querySelectorAll('span')).map((tickEl) => tickEl.textContent);
+const getTickLabels = () => Array.from(document.querySelectorAll('span')).map((tickEl) => tickEl.textContent);
 
 describe('ColorScale', () => {
   describe('tick generation', () => {

--- a/public/app/core/components/ColorScale/ColorScale.test.tsx
+++ b/public/app/core/components/ColorScale/ColorScale.test.tsx
@@ -1,0 +1,165 @@
+import { render, screen } from '@testing-library/react';
+
+import { ColorScale } from './ColorScale';
+
+// Controls the measured container width so tick-count decisions are
+// deterministic (real measurement needs layout that jsdom doesn't do).
+let mockMeasuredWidth = 0;
+
+jest.mock('react-use', () => ({
+  ...jest.requireActual('react-use'),
+  useMeasure: () => [jest.fn(), { width: mockMeasuredWidth }],
+}));
+
+const palette = ['#0000ff', '#ff0000'];
+
+const getTickLabels = () =>
+  Array.from(document.querySelectorAll('span')).map((tickEl) => tickEl.textContent);
+
+describe('ColorScale', () => {
+  describe('tick generation', () => {
+    it('renders no tick labels when display is not provided', () => {
+      mockMeasuredWidth = 320;
+      render(<ColorScale colorPalette={palette} min={0} max={100} />);
+
+      expect(document.querySelectorAll('span')).toHaveLength(0);
+    });
+
+    it('renders only min and max before the container is measured (width 0)', () => {
+      mockMeasuredWidth = 0;
+      render(<ColorScale colorPalette={palette} min={0} max={100} display={(v) => `${v}`} />);
+
+      expect(getTickLabels()).toEqual(['0', '100']);
+    });
+
+    it('renders only min and max when the container is too narrow for more', () => {
+      mockMeasuredWidth = 100;
+      render(<ColorScale colorPalette={palette} min={0} max={100} display={(v) => `${v}`} />);
+
+      expect(getTickLabels()).toEqual(['0', '100']);
+    });
+
+    it('adds intermediate ticks at uniform spacing when there is room', () => {
+      mockMeasuredWidth = 320;
+      render(<ColorScale colorPalette={palette} min={0} max={100} display={(v) => `${v}`} />);
+
+      expect(getTickLabels()).toEqual(['0', '25', '50', '75', '100']);
+    });
+
+    it('positions ticks by their value along the scale', () => {
+      mockMeasuredWidth = 320;
+      render(<ColorScale colorPalette={palette} min={0} max={100} display={(v) => `${v}`} />);
+
+      expect(screen.getByText('0').style.left).toBe('0%');
+      expect(screen.getByText('25').style.left).toBe('25%');
+      expect(screen.getByText('50').style.left).toBe('50%');
+      expect(screen.getByText('100').style.left).toBe('100%');
+    });
+
+    it('anchors the first tick left, the last tick right, and centers intermediates', () => {
+      mockMeasuredWidth = 320;
+      render(<ColorScale colorPalette={palette} min={0} max={100} display={(v) => `${v}`} />);
+
+      expect(screen.getByText('0').style.transform).toBe('');
+      expect(screen.getByText('50').style.transform).toBe('translateX(-50%)');
+      expect(screen.getByText('100').style.transform).toBe('translateX(-100%)');
+    });
+  });
+
+  describe('integer ticks', () => {
+    it('snaps intermediate ticks to whole values when min and max are integers', () => {
+      // 1..58 in 4 steps of 14.25 would give 15.25, 29.5, 43.75 -- these
+      // must snap to whole values
+      mockMeasuredWidth = 280;
+      render(<ColorScale colorPalette={palette} min={1} max={58} display={(v) => `${v}`} />);
+
+      expect(getTickLabels()).toEqual(['1', '15', '30', '44', '58']);
+    });
+
+    it('positions snapped ticks where the snapped value falls on the scale', () => {
+      mockMeasuredWidth = 280;
+      render(<ColorScale colorPalette={palette} min={1} max={58} display={(v) => `${v}`} />);
+
+      // (15 - 1) / 57 ~= 24.56%, not the uniform 25%
+      const left = parseFloat(screen.getByText('15').style.left);
+      expect(left).toBeCloseTo((14 / 57) * 100, 5);
+    });
+
+    it('drops ticks that would collapse into duplicate labels after snapping', () => {
+      // 0..2 has room for 7 ticks at this width, but only 3 distinct integers
+      mockMeasuredWidth = 320;
+      render(<ColorScale colorPalette={palette} min={0} max={2} display={(v) => `${v}`} />);
+
+      expect(getTickLabels()).toEqual(['0', '1', '2']);
+    });
+  });
+
+  describe('float ticks', () => {
+    it('renders interpolated fractional ticks when min and max are not integers', () => {
+      mockMeasuredWidth = 320;
+      render(<ColorScale colorPalette={palette} min={0.1} max={0.9} display={(v) => v.toFixed(1)} />);
+
+      expect(getTickLabels()).toEqual(['0.1', '0.3', '0.5', '0.7', '0.9']);
+    });
+
+    it('positions fractional ticks at uniform spacing', () => {
+      mockMeasuredWidth = 320;
+      render(<ColorScale colorPalette={palette} min={0.1} max={0.9} display={(v) => v.toFixed(1)} />);
+
+      // float interpolation can be off by ulps, so compare numerically
+      expect(parseFloat(screen.getByText('0.5').style.left)).toBeCloseTo(50, 6);
+      expect(parseFloat(screen.getByText('0.7').style.left)).toBeCloseTo(75, 6);
+    });
+
+    it('drops ticks that would collapse into duplicate labels under coarse formatting', () => {
+      // toFixed(0) renders every tick in 0.1..0.9 as "0" or "1", so the
+      // count must back off all the way to just min and max
+      mockMeasuredWidth = 320;
+      render(<ColorScale colorPalette={palette} min={0.1} max={0.9} display={(v) => v.toFixed(0)} />);
+
+      expect(getTickLabels()).toEqual(['0', '1']);
+    });
+  });
+
+  describe('tick count vs width for a fixed range', () => {
+    // 0..100 labels are at most 3 chars, so each tick needs a
+    // 3 * APPROX_CHAR_WIDTH + LABEL_GAP = 60px slot
+    it.each([
+      [300, ['0', '25', '50', '75', '100']],
+      [299, ['0', '33', '67', '100']],
+      [240, ['0', '33', '67', '100']],
+      [239, ['0', '50', '100']],
+      [180, ['0', '50', '100']],
+      [179, ['0', '100']],
+      [120, ['0', '100']],
+      [60, ['0', '100']],
+    ])('renders the expected ticks at %ipx', (width, expected) => {
+      mockMeasuredWidth = width;
+      render(<ColorScale colorPalette={palette} min={0} max={100} display={(v) => `${v}`} />);
+
+      expect(getTickLabels()).toEqual(expected);
+    });
+  });
+
+  describe('range changes', () => {
+    it('regenerates ticks when min/max change', () => {
+      mockMeasuredWidth = 320;
+      const display = (v: number) => `${v}`;
+
+      const { rerender } = render(<ColorScale colorPalette={palette} min={0} max={100} display={display} />);
+      expect(getTickLabels()).toEqual(['0', '25', '50', '75', '100']);
+
+      rerender(<ColorScale colorPalette={palette} min={0} max={400} display={display} />);
+      expect(getTickLabels()).toEqual(['0', '100', '200', '300', '400']);
+    });
+
+    it('renders only min and max when the range is empty', () => {
+      mockMeasuredWidth = 320;
+      render(<ColorScale colorPalette={palette} min={5} max={5} display={(v) => `${v}`} />);
+
+      expect(getTickLabels()).toEqual(['5', '5']);
+      expect(screen.getAllByText('5')[0].style.left).toBe('0%');
+      expect(screen.getAllByText('5')[1].style.left).toBe('100%');
+    });
+  });
+});

--- a/public/app/core/components/ColorScale/ColorScale.tsx
+++ b/public/app/core/components/ColorScale/ColorScale.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import { useMemo } from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';
-import { useTheme2 } from '@grafana/ui';
+import { useStyles2 } from '@grafana/ui';
 
 type Props = {
   colorPalette: string[];
@@ -14,20 +14,17 @@ type Props = {
   useStopsPercentage?: boolean;
 };
 
-const GRADIENT_STOPS = 10;
-
 export const ColorScale = ({ colorPalette, min, max, display, useStopsPercentage }: Props) => {
-  const colors = useMemo(
-    () => getGradientStops({ colorArray: colorPalette, stops: GRADIENT_STOPS, useStopsPercentage }),
-    [colorPalette, useStopsPercentage]
-  );
+  const styles = useStyles2(getStyles);
 
-  const theme = useTheme2();
-  const styles = getStyles(theme, colors);
+  const background = useMemo(() => {
+    const colors = getGradientStops(colorPalette, useStopsPercentage);
+    return `linear-gradient(90deg, ${colors.join()})`;
+  }, [colorPalette, useStopsPercentage]);
 
   return (
     <div className={styles.scaleWrapper}>
-      <div className={styles.scaleGradient} />
+      <div className={styles.scaleGradient} style={{ background }} />
       {display && (
         <div className={styles.legendValues}>
           <span className={styles.disabled}>{display(min)}</span>
@@ -38,16 +35,12 @@ export const ColorScale = ({ colorPalette, min, max, display, useStopsPercentage
   );
 };
 
-const getGradientStops = ({
-  colorArray,
-  stops,
-  useStopsPercentage = true,
-}: {
-  colorArray: string[];
-  stops: number;
-  useStopsPercentage?: boolean;
-}): string[] => {
+// max number of stops to sample for smooth gradients
+const GRADIENT_STOPS = 10;
+
+const getGradientStops = (colorArray: string[], useStopsPercentage = true): string[] => {
   const colorCount = colorArray.length;
+
   if (useStopsPercentage && colorCount <= 20) {
     const incr = (1 / colorCount) * 100;
     let per = 0;
@@ -65,7 +58,7 @@ const getGradientStops = ({
   }
 
   const gradientEnd = colorArray[colorCount - 1];
-  const skip = Math.ceil(colorCount / stops);
+  const skip = Math.ceil(colorCount / GRADIENT_STOPS);
   const gradientStops = new Set<string>();
 
   for (let i = 0; i < colorCount; i += skip) {
@@ -77,13 +70,12 @@ const getGradientStops = ({
   return [...gradientStops];
 };
 
-const getStyles = (theme: GrafanaTheme2, colors: string[]) => ({
+const getStyles = (theme: GrafanaTheme2) => ({
   scaleWrapper: css({
     width: '100%',
     fontSize: '11px',
   }),
   scaleGradient: css({
-    background: `linear-gradient(90deg, ${colors.join()})`,
     height: '9px',
     borderRadius: theme.shape.radius.default,
   }),

--- a/public/app/core/components/ColorScale/ColorScale.tsx
+++ b/public/app/core/components/ColorScale/ColorScale.tsx
@@ -1,6 +1,5 @@
 import { css } from '@emotion/css';
-import { useState, useEffect } from 'react';
-import * as React from 'react';
+import { useMemo } from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { useTheme2 } from '@grafana/ui';
@@ -12,67 +11,27 @@ type Props = {
 
   // Show a value as string -- when not defined, the raw values will not be shown
   display?: (v: number) => string;
-  hoverValue?: number;
   useStopsPercentage?: boolean;
-};
-
-type HoverState = {
-  isShown: boolean;
-  value: number;
 };
 
 const GRADIENT_STOPS = 10;
 
-export const ColorScale = ({ colorPalette, min, max, display, hoverValue, useStopsPercentage }: Props) => {
-  const [colors, setColors] = useState<string[]>([]);
-  const [scaleHover, setScaleHover] = useState<HoverState>({ isShown: false, value: 0 });
-  const [percent, setPercent] = useState<number | null>(null); // 0-100 for CSS percentage
+export const ColorScale = ({ colorPalette, min, max, display, useStopsPercentage }: Props) => {
+  const colors = useMemo(
+    () => getGradientStops({ colorArray: colorPalette, stops: GRADIENT_STOPS, useStopsPercentage }),
+    [colorPalette, useStopsPercentage]
+  );
 
   const theme = useTheme2();
   const styles = getStyles(theme, colors);
 
-  useEffect(() => {
-    setColors(getGradientStops({ colorArray: colorPalette, stops: GRADIENT_STOPS, useStopsPercentage }));
-  }, [colorPalette, useStopsPercentage]);
-
-  const onScaleMouseMove = (event: React.MouseEvent<HTMLDivElement>) => {
-    const divOffset = event.nativeEvent.offsetX;
-    const offsetWidth = event.currentTarget.offsetWidth;
-    const normPercentage = Math.floor((divOffset * 100) / offsetWidth + 1);
-    const scaleValue = Math.floor(((max - min) * normPercentage) / 100 + min);
-
-    setScaleHover({ isShown: true, value: scaleValue });
-    setPercent(normPercentage);
-  };
-
-  const onScaleMouseLeave = () => {
-    setScaleHover({ isShown: false, value: 0 });
-  };
-
-  useEffect(() => {
-    setPercent(hoverValue == null ? null : clampPercent100((hoverValue - min) / (max - min)));
-  }, [hoverValue, min, max]);
-
   return (
-    <div className={styles.scaleWrapper} onMouseMove={onScaleMouseMove} onMouseLeave={onScaleMouseLeave}>
-      <div className={styles.scaleGradient}>
-        {display && (scaleHover.isShown || hoverValue !== undefined) && (
-          <div className={styles.followerContainer}>
-            <div className={styles.follower} style={{ left: `${percent}%` }} />
-          </div>
-        )}
-      </div>
+    <div className={styles.scaleWrapper}>
+      <div className={styles.scaleGradient} />
       {display && (
-        <div className={styles.followerContainer}>
-          <div className={styles.legendValues}>
-            <span className={styles.disabled}>{display(min)}</span>
-            <span className={styles.disabled}>{display(max)}</span>
-          </div>
-          {percent != null && (scaleHover.isShown || hoverValue !== undefined) && (
-            <span className={styles.hoverValue} style={{ left: `${percent}%` }}>
-              {display(hoverValue ?? scaleHover.value)}
-            </span>
-          )}
+        <div className={styles.legendValues}>
+          <span className={styles.disabled}>{display(min)}</span>
+          <span className={styles.disabled}>{display(max)}</span>
         </div>
       )}
     </div>
@@ -118,52 +77,19 @@ const getGradientStops = ({
   return [...gradientStops];
 };
 
-function clampPercent100(v: number) {
-  if (v > 1) {
-    return 100;
-  }
-  if (v < 0) {
-    return 0;
-  }
-  return v * 100;
-}
-
 const getStyles = (theme: GrafanaTheme2, colors: string[]) => ({
   scaleWrapper: css({
     width: '100%',
     fontSize: '11px',
-    opacity: 1,
   }),
   scaleGradient: css({
     background: `linear-gradient(90deg, ${colors.join()})`,
     height: '9px',
-    pointerEvents: 'none',
     borderRadius: theme.shape.radius.default,
   }),
   legendValues: css({
     display: 'flex',
     justifyContent: 'space-between',
-    pointerEvents: 'none',
-  }),
-  hoverValue: css({
-    position: 'absolute',
-    marginTop: '-14px',
-    padding: '3px 15px',
-    transform: 'translateX(-50%)',
-  }),
-  followerContainer: css({
-    position: 'relative',
-    pointerEvents: 'none',
-    whiteSpace: 'nowrap',
-  }),
-  follower: css({
-    position: 'absolute',
-    height: '13px',
-    width: '13px',
-    borderRadius: theme.shape.radius.default,
-    transform: 'translateX(-50%) translateY(-50%)',
-    border: `2px solid ${theme.colors.text.primary}`,
-    top: '5px',
   }),
   disabled: css({
     color: theme.colors.text.disabled,

--- a/public/app/core/components/ColorScale/ColorScale.tsx
+++ b/public/app/core/components/ColorScale/ColorScale.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/css';
 import { useMemo } from 'react';
+import { useMeasure } from 'react-use';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { useStyles2 } from '@grafana/ui';
@@ -14,21 +15,87 @@ type Props = {
   useStopsPercentage?: boolean;
 };
 
+// rough glyph width at the 11px font used by the scale
+const APPROX_CHAR_WIDTH = 8;
+// minimum horizontal space between adjacent labels
+const LABEL_GAP = 36;
+
+type Tick = {
+  percent: number;
+  label: string;
+};
+
 export const ColorScale = ({ colorPalette, min, max, display, useStopsPercentage }: Props) => {
   const styles = useStyles2(getStyles);
+  const [ref, { width }] = useMeasure<HTMLDivElement>();
 
   const background = useMemo(() => {
     const colors = getGradientStops(colorPalette, useStopsPercentage);
     return `linear-gradient(90deg, ${colors.join()})`;
   }, [colorPalette, useStopsPercentage]);
 
+  let ticks: Tick[] = [];
+
+  if (display) {
+    const span = max - min;
+    // when the scale bounds are integers, snap intermediate ticks to whole values
+    const snapToInt = Number.isInteger(min) && Number.isInteger(max);
+
+    const genTicks = (count: number) =>
+      Array.from({ length: count }, (_, i): Tick => {
+        let value = min + (i / (count - 1)) * span;
+
+        if (snapToInt) {
+          value = Math.round(value);
+        }
+
+        return {
+          // ticks are placed where their (possibly snapped) value falls on the scale
+          percent: span > 0 ? ((value - min) / span) * 100 : i * 100,
+          label: display(value),
+        };
+      });
+
+    // min and max are always rendered; intermediate ticks are added when the
+    // footprint of the widest rendered label leaves room for them
+    let count = 2;
+
+    if (width > 0 && span > 0) {
+      const slotWidth = Math.max(display(min).length, display(max).length) * APPROX_CHAR_WIDTH + LABEL_GAP;
+      count = Math.max(2, Math.floor(width / slotWidth));
+    }
+
+    ticks = genTicks(count);
+
+    while (count > 2) {
+      const maxLabelLen = Math.max(...ticks.map((tick) => tick.label.length));
+      const fits = count * (maxLabelLen * APPROX_CHAR_WIDTH + LABEL_GAP) <= width;
+      // coarse display formats and integer snapping can collapse adjacent
+      // values into identical labels
+      const distinct = new Set(ticks.map((tick) => tick.label)).size === count;
+
+      if (fits && distinct) {
+        break;
+      }
+
+      ticks = genTicks(--count);
+    }
+  }
+
   return (
-    <div className={styles.scaleWrapper}>
+    <div ref={ref} className={styles.scaleWrapper}>
       <div className={styles.scaleGradient} style={{ background }} />
-      {display && (
+      {ticks.length > 0 && (
         <div className={styles.legendValues}>
-          <span className={styles.disabled}>{display(min)}</span>
-          <span className={styles.disabled}>{display(max)}</span>
+          {ticks.map(({ percent, label }, i) => {
+            const transform = i === 0 ? undefined : i === ticks.length - 1 ? 'translateX(-100%)' : 'translateX(-50%)';
+
+            return (
+              <span key={i} className={styles.legendValue} style={{ left: `${percent}%`, transform }}>
+                {label}
+              </span>
+            );
+          })}
         </div>
       )}
     </div>
@@ -80,10 +147,13 @@ const getStyles = (theme: GrafanaTheme2) => ({
     borderRadius: theme.shape.radius.default,
   }),
   legendValues: css({
-    display: 'flex',
-    justifyContent: 'space-between',
+    position: 'relative',
+    height: theme.spacing(2),
   }),
-  disabled: css({
+  legendValue: css({
+    position: 'absolute',
+    top: 0,
+    whiteSpace: 'nowrap',
     color: theme.colors.text.disabled,
   }),
 });

--- a/public/app/plugins/panel/geomap/GeomapPanel.test.tsx
+++ b/public/app/plugins/panel/geomap/GeomapPanel.test.tsx
@@ -831,7 +831,6 @@ describe('GeomapPanel - View Listener', () => {
           },
           options: { name: 'Test Layer', type: 'test' },
           onChange: jest.fn(),
-          mouseEvents: { next: jest.fn(), subscribe: jest.fn() },
           getName: () => 'Test Layer',
         },
       ] as unknown as typeof panel.layers;

--- a/public/app/plugins/panel/geomap/components/MarkersLegend.tsx
+++ b/public/app/plugins/panel/geomap/components/MarkersLegend.tsx
@@ -15,18 +15,16 @@ export interface MarkersLegendProps {
   styleConfig?: StyleConfigState;
 }
 
-export function MarkersLegend(props: MarkersLegendProps) {
-  const { layerName, styleConfig } = props;
+export function MarkersLegend({ layerName, styleConfig }: MarkersLegendProps) {
   const style = useStyles2(getStyles);
-
-  const colorField = styleConfig?.dims?.color?.field;
 
   if (!styleConfig) {
     return <></>;
   }
 
-  const { color, opacity } = styleConfig?.base ?? {};
-  const symbol = styleConfig?.config.symbol?.fixed;
+  const colorField = styleConfig.dims?.color?.field;
+  const { color, opacity } = styleConfig.base;
+  const symbol = styleConfig.config.symbol?.fixed;
 
   if (color && symbol && !colorField) {
     return (
@@ -64,9 +62,7 @@ export function MarkersLegend(props: MarkersLegendProps) {
     //   ]
     // })
 
-    const display = colorField.display
-      ? (v: number) => formattedValueToString(colorField.display!(v))
-      : (v: number) => `${v}`;
+    const display = colorField.display ? (v: number) => formattedValueToString(colorField.display!(v)) : undefined;
     return (
       <div className={style.infoWrap}>
         <div className={style.layerName}>{layerName}</div>

--- a/public/app/plugins/panel/geomap/components/MarkersLegend.tsx
+++ b/public/app/plugins/panel/geomap/components/MarkersLegend.tsx
@@ -1,56 +1,25 @@
 import { css, cx } from '@emotion/css';
-import type BaseLayer from 'ol/layer/Base';
-import { useMemo } from 'react';
-import { of } from 'rxjs';
 
-import {
-  getMinMaxAndDelta,
-  type DataFrame,
-  formattedValueToString,
-  getFieldColorModeForField,
-  type GrafanaTheme2,
-} from '@grafana/data';
-import { useObservable } from '@grafana/data/unstable';
+import { getMinMaxAndDelta, formattedValueToString, getFieldColorModeForField, type GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 import { useStyles2, type VizLegendItem } from '@grafana/ui';
 import { ColorScale } from 'app/core/components/ColorScale/ColorScale';
 import { SanitizedSVG } from 'app/core/components/SVG/SanitizedSVG';
 import { getThresholdItems } from 'app/core/components/TimelineChart/utils';
-import { type DimensionSupplier } from 'app/features/dimensions/types';
 
 import { type StyleConfigState } from '../style/types';
-import { type MapLayerState } from '../types';
 
 export interface MarkersLegendProps {
-  size?: DimensionSupplier<number>;
   layerName?: string;
   styleConfig?: StyleConfigState;
-  layer?: BaseLayer;
 }
 
 export function MarkersLegend(props: MarkersLegendProps) {
-  const { layerName, styleConfig, layer } = props;
+  const { layerName, styleConfig } = props;
   const style = useStyles2(getStyles);
 
-  const hoverEvent = useObservable(((layer as any)?.__state as MapLayerState)?.mouseEvents ?? of(undefined));
-
   const colorField = styleConfig?.dims?.color?.field;
-  const hoverValue = useMemo(() => {
-    if (!colorField || !hoverEvent) {
-      return undefined;
-    }
-
-    const props = hoverEvent.getProperties();
-    const frame: DataFrame = props.frame;
-
-    if (!frame) {
-      return undefined;
-    }
-
-    const rowIndex: number = props.rowIndex;
-    return colorField.values[rowIndex];
-  }, [hoverEvent, colorField]);
 
   if (!styleConfig) {
     return <></>;
@@ -103,7 +72,6 @@ export function MarkersLegend(props: MarkersLegendProps) {
         <div className={style.layerName}>{layerName}</div>
         <div className={cx(style.layerBody, style.colorScaleWrapper)}>
           <ColorScale
-            hoverValue={hoverValue}
             colorPalette={colors}
             min={colorRange.min ?? 0}
             max={colorRange.max ?? 100}

--- a/public/app/plugins/panel/geomap/components/MarkersLegend.tsx
+++ b/public/app/plugins/panel/geomap/components/MarkersLegend.tsx
@@ -1,6 +1,11 @@
 import { css, cx } from '@emotion/css';
 
-import { getMinMaxAndDelta, formattedValueToString, getFieldColorModeForField, type GrafanaTheme2 } from '@grafana/data';
+import {
+  getMinMaxAndDelta,
+  formattedValueToString,
+  getFieldColorModeForField,
+  type GrafanaTheme2,
+} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 import { useStyles2, type VizLegendItem } from '@grafana/ui';

--- a/public/app/plugins/panel/geomap/layers/data/markersLayer.tsx
+++ b/public/app/plugins/panel/geomap/layers/data/markersLayer.tsx
@@ -113,9 +113,7 @@ export const markersLayer: MapLayerRegistryItem<MarkersConfig> = {
           if (legend) {
             legendProps.next({
               styleConfig: style,
-              size: style.dims?.size,
               layerName: options.name,
-              layer: symbolLayer,
             });
           }
 

--- a/public/app/plugins/panel/geomap/layers/data/networkLayer.tsx
+++ b/public/app/plugins/panel/geomap/layers/data/networkLayer.tsx
@@ -199,9 +199,7 @@ export const networkLayer: MapLayerRegistryItem<NetworkConfig> = {
         if (legend) {
           legendProps.next({
             styleConfig: style,
-            size: style.dims?.size,
             layerName: options.name,
-            layer: vectorLayer,
           });
         }
         const graphFrames = getGraphFrame(data.series);

--- a/public/app/plugins/panel/geomap/types.ts
+++ b/public/app/plugins/panel/geomap/types.ts
@@ -1,8 +1,6 @@
-import { type FeatureLike } from 'ol/Feature';
 import type OpenLayersMap from 'ol/Map';
 import { type Units } from 'ol/control/ScaleLine';
 import type BaseLayer from 'ol/layer/Base';
-import { type Subject } from 'rxjs';
 
 import { type MapLayerHandler, type MapLayerOptions } from '@grafana/data';
 import { type ComparisonOperation } from '@grafana/schema';
@@ -50,5 +48,4 @@ export interface MapLayerState<TConfig = unknown> extends LayerElement {
   layer: BaseLayer; // the openlayers instance
   onChange: (cfg: MapLayerOptions<TConfig>) => void;
   isBasemap?: boolean;
-  mouseEvents: Subject<FeatureLike | undefined>;
 }

--- a/public/app/plugins/panel/geomap/utils/actions.test.ts
+++ b/public/app/plugins/panel/geomap/utils/actions.test.ts
@@ -33,7 +33,6 @@ function layerState(name: string): MapLayerState {
     layer: { name } as unknown as MapLayerState['layer'],
     handler: {} as MapLayerState['handler'],
     onChange: jest.fn(),
-    mouseEvents: {} as MapLayerState['mouseEvents'],
     getName: () => name,
   };
 }

--- a/public/app/plugins/panel/geomap/utils/getLayersExtent.test.ts
+++ b/public/app/plugins/panel/geomap/utils/getLayersExtent.test.ts
@@ -25,7 +25,6 @@ function vectorLayerState(name: string, coordinates: number[][]): MapLayerState 
     layer: new VectorLayer({ source }),
     handler: {} as MapLayerState['handler'],
     onChange: jest.fn(),
-    mouseEvents: {} as MapLayerState['mouseEvents'],
     getName: () => name,
   };
 }

--- a/public/app/plugins/panel/geomap/utils/layers.ts
+++ b/public/app/plugins/panel/geomap/utils/layers.ts
@@ -1,9 +1,7 @@
-import { type FeatureLike } from 'ol/Feature';
 import type OpenLayersMap from 'ol/Map';
 import type BaseLayer from 'ol/layer/Base';
 import LayerGroup from 'ol/layer/Group';
 import WebGLPointsLayer from 'ol/layer/WebGLPoints';
-import { Subject } from 'rxjs';
 
 import { getFrameMatchers, type MapLayerHandler, type MapLayerOptions, type PanelData, textUtil } from '@grafana/data';
 import { config } from '@grafana/runtime';
@@ -148,7 +146,6 @@ export async function initLayer(
     options,
     layer,
     handler,
-    mouseEvents: new Subject<FeatureLike | undefined>(),
 
     getName: () => UID,
 

--- a/public/app/plugins/panel/geomap/utils/tooltip.test.ts
+++ b/public/app/plugins/panel/geomap/utils/tooltip.test.ts
@@ -52,7 +52,6 @@ jest.mock('./layers', () => {
   return {
     getMapLayerState: jest.fn().mockReturnValue({
       options: { tooltip: true },
-      mouseEvents: { next: jest.fn() },
     }),
   };
 });

--- a/public/app/plugins/panel/geomap/utils/tooltip.ts
+++ b/public/app/plugins/panel/geomap/utils/tooltip.ts
@@ -102,10 +102,6 @@ export const pointerMoveListener = (evt: MapBrowserEvent, panel: GeomapPanel) =>
           hoverPayload.data = ttip.data = frame;
           hoverPayload.rowIndex = ttip.rowIndex = props['rowIndex'];
         }
-
-        if (s?.mouseEvents) {
-          s.mouseEvents.next(feature);
-        }
       }
 
       if (s) {
@@ -181,13 +177,6 @@ export const pointerMoveListener = (evt: MapBrowserEvent, panel: GeomapPanel) =>
   // This check optimizes Geomap panel re-render behavior (without it, Geomap renders on every mouse move event)
   if (panel.state.ttip === undefined || panel.state.ttip?.layers !== hoverPayload.layers || hoverPayload.layers) {
     panel.setState({ ttip: { ...hoverPayload } });
-  }
-
-  if (!layers.length) {
-    // clear mouse events
-    panel.layers.forEach((layer) => {
-      layer.mouseEvents.next(undefined);
-    });
   }
 
   const found = Boolean(layers.length);

--- a/public/app/plugins/panel/heatmap/HeatmapPanel.tsx
+++ b/public/app/plugins/panel/heatmap/HeatmapPanel.tsx
@@ -174,23 +174,10 @@ const HeatmapPanelViz = ({
       return null;
     }
 
-    let hoverValue: number | undefined = undefined;
-
-    // let heatmapType = dataRef.current?.heatmap?.meta?.type;
-    // let isSparseHeatmap = heatmapType === DataFrameType.HeatmapCells && !isHeatmapCellsDense(dataRef.current?.heatmap!);
-    // let countFieldIdx = !isSparseHeatmap ? 2 : 3;
-    // const countField = info.heatmap.fields[countFieldIdx];
-
-    // seriesIdx: 1 is heatmap layer; 2 is exemplar layer
-    // if (hover && info.heatmap.fields && hover.seriesIdx === 1) {
-    //   hoverValue = countField.values[hover.dataIdx];
-    // }
-
     return (
       <VizLayout.Legend placement="bottom" maxHeight="20%">
         <div className={styles.colorScaleWrapper}>
           <ColorScale
-            hoverValue={hoverValue}
             colorPalette={palette}
             min={dataRef.current.heatmapColors?.minValue!}
             max={dataRef.current.heatmapColors?.maxValue!}
@@ -245,7 +232,6 @@ const HeatmapPanelViz = ({
                       isPinned={isPinned}
                       dismiss={dismiss}
                       showHistogram={options.tooltip.yHistogram}
-                      showColorScale={options.tooltip.showColorScale}
                       panelData={data}
                       annotate={enableAnnotationCreation ? annotate : undefined}
                       maxHeight={options.tooltip.maxHeight}

--- a/public/app/plugins/panel/heatmap/HeatmapPanel.tsx
+++ b/public/app/plugins/panel/heatmap/HeatmapPanel.tsx
@@ -71,7 +71,7 @@ export const HeatmapPanel = (props: HeatmapPanelProps) => {
     );
   }
 
-  return <HeatmapPanelViz {...props} info={info} palette={palette} />;
+  return <HeatmapPanelViz {...props} info={info} />;
 };
 
 const HeatmapPanelViz = ({
@@ -85,8 +85,7 @@ const HeatmapPanelViz = ({
   onChangeTimeRange,
   replaceVariables,
   info,
-  palette,
-}: HeatmapPanelProps & { info: HeatmapDataForViz; palette: string[] }) => {
+}: HeatmapPanelProps & { info: HeatmapDataForViz }) => {
   const theme = useTheme2();
   const styles = useStyles2(getStyles);
   const { sync, eventsScope, canAddAnnotations, onSelectRange, canExecuteActions } = usePanelContext();
@@ -170,7 +169,7 @@ const HeatmapPanelViz = ({
   }, [options, timeZone, data.structureRev, cursorSync, annotationsLength]);
 
   const renderLegend = () => {
-    if (!options.legend.show) {
+    if (!options.legend.show || info.heatmapColors == null) {
       return null;
     }
 
@@ -178,9 +177,9 @@ const HeatmapPanelViz = ({
       <VizLayout.Legend placement="bottom" maxHeight="20%">
         <div className={styles.colorScaleWrapper}>
           <ColorScale
-            colorPalette={palette}
-            min={dataRef.current.heatmapColors?.minValue!}
-            max={dataRef.current.heatmapColors?.maxValue!}
+            colorPalette={info.heatmapColors.palette}
+            min={info.heatmapColors.minValue}
+            max={info.heatmapColors.maxValue}
             display={info.display}
           />
         </div>
@@ -230,9 +229,7 @@ const HeatmapPanelViz = ({
                       seriesIdx={seriesIdx}
                       dataRef={dataRef}
                       isPinned={isPinned}
-                      dismiss={dismiss}
                       showHistogram={options.tooltip.yHistogram}
-                      panelData={data}
                       annotate={enableAnnotationCreation ? annotate : undefined}
                       maxHeight={options.tooltip.maxHeight}
                       maxWidth={options.tooltip.maxWidth}

--- a/public/app/plugins/panel/heatmap/HeatmapTooltip.test.tsx
+++ b/public/app/plugins/panel/heatmap/HeatmapTooltip.test.tsx
@@ -1,14 +1,6 @@
 import { render, screen } from '@testing-library/react';
 
-import {
-  createDataFrame,
-  createTheme,
-  DataFrameType,
-  FieldType,
-  getDefaultTimeRange,
-  getDisplayProcessor,
-  LoadingState,
-} from '@grafana/data';
+import { createDataFrame, createTheme, DataFrameType, FieldType, getDisplayProcessor } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { HeatmapCellLayout, TooltipDisplayMode } from '@grafana/schema';
 
@@ -178,8 +170,6 @@ describe('HeatmapTooltip', () => {
     seriesIdx: 1,
     dataRef: { current: createMinimalHeatmapData() },
     isPinned: false,
-    dismiss: jest.fn(),
-    panelData: { state: LoadingState.Done, series: [], timeRange: getDefaultTimeRange() },
     replaceVariables: (v: string) => v,
   };
 

--- a/public/app/plugins/panel/heatmap/HeatmapTooltip.test.tsx
+++ b/public/app/plugins/panel/heatmap/HeatmapTooltip.test.tsx
@@ -375,15 +375,6 @@ describe('HeatmapTooltip', () => {
     });
   });
 
-  describe('showColorScale', () => {
-    it('renders ColorScale when showColorScale is true', () => {
-      render(<HeatmapTooltip {...defaultProps} showColorScale={true} />);
-
-      expect(screen.getByTestId(selectors.components.Panels.Visualization.Tooltip.Wrapper)).toBeVisible();
-      expect(screen.getByText('count')).toBeVisible();
-    });
-  });
-
   describe('Exemplars', () => {
     it('renders ExemplarTooltip when seriesIdx is 2 and exemplars have display data', () => {
       const exemplarFrame = createDataFrame({

--- a/public/app/plugins/panel/heatmap/HeatmapTooltip.tsx
+++ b/public/app/plugins/panel/heatmap/HeatmapTooltip.tsx
@@ -10,7 +10,6 @@ import {
   getFieldDisplayName,
   type InterpolateFunction,
   type LinkModel,
-  type PanelData,
 } from '@grafana/data';
 import { HeatmapCellLayout } from '@grafana/schema';
 import {
@@ -50,8 +49,6 @@ interface HeatmapTooltipProps {
   dataRef: React.MutableRefObject<HeatmapData>;
   showHistogram?: boolean;
   isPinned: boolean;
-  dismiss: () => void;
-  panelData: PanelData;
   annotate?: () => void;
   maxHeight?: number;
   maxWidth?: number;

--- a/public/app/plugins/panel/heatmap/HeatmapTooltip.tsx
+++ b/public/app/plugins/panel/heatmap/HeatmapTooltip.tsx
@@ -26,7 +26,6 @@ import {
   isTooltipScrollable,
   useTheme2,
 } from '@grafana/ui';
-import { ColorScale } from 'app/core/components/ColorScale/ColorScale';
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
 import { readHeatmapRowsCustomMeta } from 'app/features/transformers/calculateHeatmap/heatmap';
 import { getDisplayValuesAndLinks } from 'app/features/visualization/data-hover/DataHoverView';
@@ -50,7 +49,6 @@ interface HeatmapTooltipProps {
   seriesIdx: number | null | undefined;
   dataRef: React.MutableRefObject<HeatmapData>;
   showHistogram?: boolean;
-  showColorScale?: boolean;
   isPinned: boolean;
   dismiss: () => void;
   panelData: PanelData;
@@ -95,7 +93,6 @@ const HeatmapHoverCell = ({
   dataRef,
   showHistogram,
   isPinned,
-  showColorScale = false,
   mode,
   annotate,
   maxHeight,
@@ -203,7 +200,7 @@ const HeatmapHoverCell = ({
     getData();
   }
 
-  const { cellColor, colorPalette } = getHoverCellColor(data, index);
+  const { cellColor } = getHoverCellColor(data, index);
 
   const getDisplayData = (fromIdx: number, toIdx: number) => {
     let vals = [];
@@ -374,19 +371,6 @@ const HeatmapHoverCell = ({
           height={histCanHeight}
           ref={can}
           style={{ width: histCssWidth + 'px', height: histCssHeight + 'px' }}
-        />
-      );
-    }
-
-    // Color scale
-    if (colorPalette && showColorScale) {
-      customContent.push(
-        <ColorScale
-          colorPalette={colorPalette}
-          min={data.heatmapColors?.minValue!}
-          max={data.heatmapColors?.maxValue!}
-          display={data.display}
-          hoverValue={count}
         />
       );
     }

--- a/public/app/plugins/panel/heatmap/module.tsx
+++ b/public/app/plugins/panel/heatmap/module.tsx
@@ -447,14 +447,6 @@ export const plugin = new PanelPlugin<Options, GraphFieldConfig>(HeatmapPanel)
       showIf: (opts) => opts.tooltip.mode === TooltipDisplayMode.Single,
     });
 
-    builder.addBooleanSwitch({
-      path: 'tooltip.showColorScale',
-      name: t('heatmap.name-show-color-scale', 'Show color scale'),
-      defaultValue: defaultOptions.tooltip.showColorScale,
-      category,
-      showIf: (opts) => opts.tooltip.mode === TooltipDisplayMode.Single,
-    });
-
     builder.addNumberInput({
       path: 'tooltip.maxWidth',
       name: t('heatmap.name-max-width', 'Max width'),

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -10718,7 +10718,6 @@
     "name-reverse": "Reverse",
     "name-scale": "Scale",
     "name-scheme": "Scheme",
-    "name-show-color-scale": "Show color scale",
     "name-show-histogram": "Show histogram (Y axis)",
     "name-show-legend": "Show legend",
     "name-start-color-from-value": "Start color scale from value",


### PR DESCRIPTION
the live-hover indicator was not carrying its weight in code complexity vs usefulness.

we want to introduce [right-positioned legend in Heatmap](https://github.com/grafana/grafana/pull/127943), where the scale orientation needs to become vertical, and having to handle this indicator behavior and positioning in that PR was not justified.

also, in Geomap, there was a bunch of Observable machinery just for this indicator, and it was broken anyways. so that code becomes more straightforward.

now we get more ticks :)

<img width="479" height="51" alt="image" src="https://github.com/user-attachments/assets/fd33d252-c34e-47f2-8758-c1be0f39bed9" />