### PR TITLE
Correlations: Change frontend patch type

### DIFF
--- a/packages/grafana-api-clients/src/clients/rtkq/correlations/v0alpha1/index.ts
+++ b/packages/grafana-api-clients/src/clients/rtkq/correlations/v0alpha1/index.ts
@@ -2,4 +2,19 @@ export { BASE_URL, API_GROUP, API_VERSION } from './baseAPI';
 import { generatedAPI as rawAPI } from './endpoints.gen';
 
 export * from './endpoints.gen';
-export const generatedAPI = rawAPI.enhanceEndpoints({});
+export const generatedAPI = rawAPI.enhanceEndpoints({
+  endpoints: {
+    updateCorrelation: (endpointDefinition) => {
+      const originalQuery = endpointDefinition.query;
+      if (!originalQuery) {
+        return;
+      }
+      endpointDefinition.query = (requestOptions) => ({
+        ...originalQuery(requestOptions),
+        headers: {
+          'Content-Type': 'application/merge-patch+json',
+        },
+      });
+    },
+  },
+});

--- a/public/app/api/clients/correlations/v0alpha1/index.ts
+++ b/public/app/api/clients/correlations/v0alpha1/index.ts
@@ -36,25 +36,16 @@ export const correlationsAPIv0alpha1 = generatedAPI.enhanceEndpoints({
         }
       };
     },
-    updateCorrelation: (endpointDefinition) => {
-      const originalQuery = endpointDefinition.query;
-      if (!originalQuery) {
-        return;
-      }
-      endpointDefinition.query = (requestOptions) => ({
-        ...originalQuery(requestOptions),
-        headers: {
-          'Content-Type': 'application/merge-patch+json',
-        },
-      });
-      endpointDefinition.onQueryStarted = async ({}, { queryFulfilled, dispatch }) => {
+    updateCorrelation: {
+      onQueryStarted: async ({}, { queryFulfilled, dispatch }) => {
         try {
           await queryFulfilled;
+
           dispatch(notifyApp(createSuccessNotification(t('correlations.notify.edit-success', 'Correlation updated'))));
         } catch (e) {
           handleError(e, dispatch, t('correlations.notify.edit-error', 'Error updating correlation'));
         }
-      };
+      },
     },
     deleteCorrelation: {
       onQueryStarted: async ({}, { queryFulfilled, dispatch }) => {

--- a/public/app/api/clients/correlations/v0alpha1/index.ts
+++ b/public/app/api/clients/correlations/v0alpha1/index.ts
@@ -36,16 +36,25 @@ export const correlationsAPIv0alpha1 = generatedAPI.enhanceEndpoints({
         }
       };
     },
-    updateCorrelation: {
-      onQueryStarted: async ({}, { queryFulfilled, dispatch }) => {
+    updateCorrelation: (endpointDefinition) => {
+      const originalQuery = endpointDefinition.query;
+      if (!originalQuery) {
+        return;
+      }
+      endpointDefinition.query = (requestOptions) => ({
+        ...originalQuery(requestOptions),
+        headers: {
+          'Content-Type': 'application/merge-patch+json',
+        },
+      });
+      endpointDefinition.onQueryStarted = async ({}, { queryFulfilled, dispatch }) => {
         try {
           await queryFulfilled;
-
           dispatch(notifyApp(createSuccessNotification(t('correlations.notify.edit-success', 'Correlation updated'))));
         } catch (e) {
           handleError(e, dispatch, t('correlations.notify.edit-error', 'Error updating correlation'));
         }
-      },
+      };
     },
     deleteCorrelation: {
       onQueryStarted: async ({}, { queryFulfilled, dispatch }) => {


### PR DESCRIPTION
In work for the migration, we ran into issues where the backend api didn't have a PATCH function exposed, and the default for the frontend client used PATCH https://github.com/grafana/grafana/blob/main/packages/grafana-api-clients/src/clients/rtkq/correlations/v0alpha1/endpoints.gen.ts#L108

This created an issue where migrated correlations that used the backend created correlations with a structure that couldn't be edited from the frontend, and in general, it was extremely confusing for the frontend to use by default an update style the backend didn't support at all.

Even if patch is used for both frontend and backend, another discrepancy that came up was the frontend client code generator's default of using `application/strategic-merge-patch+json` for patch functions. 
https://github.com/grafana/grafana/blob/main/packages/grafana-api-clients/src/clients/rtkq/createBaseQuery.ts#L34 

On the backend, the patch function [was introduced](https://github.com/grafana/grafana/pull/128700), but the strategic merge patch can't be used with the Correlation's target type because it is a map, which crashes when performing the merge operation. 

https://github.com/kubernetes/apimachinery/blob/master/pkg/util/strategicpatch/meta.go#L79
https://github.com/kubernetes/apimachinery/blob/v0.36.2/third_party/forked/golang/json/fields.go#L35

There is a way to annotate in a cue file that a different patch strategy should be used on a specific variable (`// +patchStrategy=replace`), but it's not supported within Grafana's cog library.

So, if we want an update function on the frontend and backend to match, we should use a normal merge patch instead of a strategic merge patch. I will be updating the backend with this in another PR. Since there is no difference in payload structure, we do not require any other code changes. 

It is worth noting that the correlation target, the root of this problem, would only have keys that need to be removed implicitly if we were changing the datasource. This is not possible via the correlations UI, so it will also not matter from a UI perspective either.