### PR TITLE
Provisioning: only push variable changes to git if save variables is …

### DIFF
--- a/public/app/features/provisioning/components/Dashboards/SaveProvisionedDashboardForm.test.tsx
+++ b/public/app/features/provisioning/components/Dashboards/SaveProvisionedDashboardForm.test.tsx
@@ -394,6 +394,7 @@ describe('SaveProvisionedDashboardForm', () => {
         getSaveModel: jest.fn().mockReturnValue({}),
         saveCompleted: jest.fn(),
         getSaveResource: jest.fn().mockReturnValue(updatedDashboard),
+        getSaveResourceFromSpec: jest.fn().mockReturnValue(updatedDashboard),
         setManager: jest.fn(),
         getRawJsonFromEditor: jest.fn().mockReturnValue(undefined),
       } as unknown as DashboardScene,
@@ -416,6 +417,96 @@ describe('SaveProvisionedDashboardForm', () => {
     expect(request.url.searchParams.get('ref')).toBe('dashboard/2023-01-01-abcde');
     expect(request.url.searchParams.get('message')).toBe('Update dashboard');
     expect(request.body).toEqual(updatedDashboard);
+  });
+
+  // Regression: when updating a git-synced dashboard the committed body must come
+  // from the change-trimmed model (changeInfo.changedSaveModel), not the full scene
+  // save model. Otherwise unsaved variable/time/refresh values leak into the PR even
+  // when the user leaves "Change default variables" unchecked (see issue #127533).
+  it('commits the change-trimmed model, not the full save model, when updating', async () => {
+    server.use(
+      http.put(`${BASE}/repositories/:name/files/*`, async ({ request }) => {
+        const url = new URL(request.url);
+        capturedRequest = { url, body: await request.json() };
+        return saveSuccessResponse('test-dashboard', 'Test Dashboard');
+      })
+    );
+
+    // The trimmed model the drawer would produce with "Change default variables" off.
+    const trimmedResource = {
+      apiVersion: 'dashboard.grafana.app/vXyz',
+      kind: 'Dashboard',
+      metadata: { name: 'test-dashboard' },
+      spec: { title: 'Test Dashboard', templating: { list: [{ name: 'v', current: { value: 'original' } }] } },
+    };
+    const trimmedSaveModel = trimmedResource.spec;
+
+    // getSaveResource would serialize the full scene (current variable value) — the bug.
+    const fullResource = {
+      ...trimmedResource,
+      spec: { title: 'Test Dashboard', templating: { list: [{ name: 'v', current: { value: 'changed' } }] } },
+    };
+
+    const getSaveResourceFromSpec = jest.fn().mockReturnValue(trimmedResource);
+    const getSaveResource = jest.fn().mockReturnValue(fullResource);
+    const saveCompleted = jest.fn();
+    // Full, untrimmed scene model — must NOT be used to baseline after save.
+    const fullSaveModel = {
+      title: 'Test Dashboard',
+      templating: { list: [{ name: 'v', current: { value: 'changed' } }] },
+    };
+    const getSaveModel = jest.fn().mockReturnValue(fullSaveModel);
+
+    const { user } = setup({
+      isNew: false,
+      changeInfo: {
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        changedSaveModel: trimmedSaveModel as unknown as Dashboard,
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        initialSaveModel: trimmedSaveModel as unknown as Dashboard,
+        diffCount: 0,
+        hasChanges: true,
+        hasTimeChanges: false,
+        hasVariableValueChanges: false,
+        hasRefreshChange: false,
+        diffs: {},
+      },
+      dashboard: {
+        state: { meta: { folderUid: 'folder-uid', slug: 'test-dashboard', uid: 'test-dashboard' }, isDirty: true },
+        useState: () => ({
+          meta: { folderUid: 'folder-uid', slug: 'test-dashboard', uid: 'test-dashboard' },
+          isDirty: true,
+        }),
+        setState: jest.fn(),
+        saveCompleted,
+        getSaveModel,
+        getSaveResource,
+        getSaveResourceFromSpec,
+        setManager: jest.fn(),
+        getRawJsonFromEditor: jest.fn().mockReturnValue(undefined),
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      } as unknown as DashboardScene,
+    });
+
+    await user.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() => {
+      expect(capturedRequest).not.toBeNull();
+    });
+
+    // Body must be built from the trimmed changedSaveModel, and getSaveResource
+    // (the full scene serializer) must not be used on the update path.
+    expect(getSaveResourceFromSpec).toHaveBeenCalledWith(trimmedSaveModel);
+    expect(getSaveResource).not.toHaveBeenCalled();
+    const request = requireCapturedRequest(capturedRequest);
+    expect(request.body).toEqual(trimmedResource);
+
+    // saveCompleted must re-baseline against the same trimmed model, not the full
+    // scene model — otherwise change detection treats the omitted values as saved.
+    await waitFor(() => {
+      expect(saveCompleted).toHaveBeenCalledWith(trimmedSaveModel, expect.anything(), expect.anything());
+    });
+    expect(saveCompleted).not.toHaveBeenCalledWith(fullSaveModel, expect.anything(), expect.anything());
   });
 
   it('shows the in-progress state on Save while new dashboard validation is pending', async () => {
@@ -560,6 +651,7 @@ describe('SaveProvisionedDashboardForm', () => {
         setState: jest.fn(),
         closeModal: jest.fn(),
         getSaveResource: jest.fn().mockReturnValue(updatedDashboard),
+        getSaveResourceFromSpec: jest.fn().mockReturnValue(updatedDashboard),
         setManager: jest.fn(),
         getRawJsonFromEditor: jest.fn().mockReturnValue(undefined),
       } as unknown as DashboardScene,
@@ -643,6 +735,7 @@ describe('SaveProvisionedDashboardForm', () => {
         getSaveModel: jest.fn().mockReturnValue({}),
         saveCompleted: jest.fn(),
         getSaveResource: jest.fn().mockReturnValue(updatedDashboard),
+        getSaveResourceFromSpec: jest.fn().mockReturnValue(updatedDashboard),
         setManager: jest.fn(),
         getRawJsonFromEditor: jest.fn().mockReturnValue(undefined),
       } as unknown as DashboardScene,
@@ -731,6 +824,7 @@ describe('SaveProvisionedDashboardForm', () => {
         getSaveModel: jest.fn().mockReturnValue({}),
         saveCompleted: jest.fn(),
         getSaveResource: jest.fn().mockReturnValue(updatedDashboard),
+        getSaveResourceFromSpec: jest.fn().mockReturnValue(updatedDashboard),
         setManager: jest.fn(),
         getRawJsonFromEditor: jest.fn().mockReturnValue(undefined),
       } as unknown as DashboardScene,
@@ -1549,6 +1643,7 @@ describe('SaveProvisionedDashboardForm', () => {
         getSaveModel: jest.fn().mockReturnValue({}),
         saveCompleted: jest.fn(),
         getSaveResource: jest.fn().mockReturnValue(updatedDashboard),
+        getSaveResourceFromSpec: jest.fn().mockReturnValue(updatedDashboard),
         setManager: jest.fn(),
         getRawJsonFromEditor: jest.fn().mockReturnValue(undefined),
       } as unknown as DashboardScene,

--- a/public/app/features/provisioning/components/Dashboards/SaveProvisionedDashboardForm.test.tsx
+++ b/public/app/features/provisioning/components/Dashboards/SaveProvisionedDashboardForm.test.tsx
@@ -462,9 +462,14 @@ describe('SaveProvisionedDashboardForm', () => {
       changeInfo: {
         // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         changedSaveModel: trimmedSaveModel as unknown as Dashboard,
+        // Distinct baseline (old title) so the fixture reads coherently: an existing
+        // dashboard with a real, saved change.
         // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-        initialSaveModel: trimmedSaveModel as unknown as Dashboard,
-        diffCount: 0,
+        initialSaveModel: {
+          title: 'Original Dashboard',
+          templating: { list: [{ name: 'v', current: { value: 'original' } }] },
+        } as unknown as Dashboard,
+        diffCount: 1,
         hasChanges: true,
         hasTimeChanges: false,
         hasVariableValueChanges: false,

--- a/public/app/features/provisioning/components/Dashboards/SaveProvisionedDashboardForm.tsx
+++ b/public/app/features/provisioning/components/Dashboards/SaveProvisionedDashboardForm.tsx
@@ -393,7 +393,7 @@ export function SaveProvisionedDashboardForm({
 
     const body = rawDashboardJSON
       ? dashboard.getSaveResourceFromSpec(rawDashboardJSON)
-      : isNew || saveAsCopy
+      : isNew
         ? dashboard.getSaveResource({
             isNew,
             title,
@@ -408,11 +408,11 @@ export function SaveProvisionedDashboardForm({
           // shown in the drawer. This mirrors the non-provisioned save path.
           dashboard.getSaveResourceFromSpec(changeInfo.changedSaveModel);
 
-    savedSpecRef.current = rawDashboardJSON
-      ? rawDashboardJSON
-      : isNew || saveAsCopy
-        ? dashboard.getSaveAsModel({ isNew, title, description, copyTags, saveAsCopy })
-        : changeInfo.changedSaveModel;
+    // Single source of truth: baseline against exactly the spec we committed, so
+    // post-save change detection matches what was written (handleDismiss → saveCompleted).
+    // Deriving from body.spec avoids re-running getSaveAsModel() on the new/save-as path.
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    savedSpecRef.current = body.spec as Dashboard | DashboardV2Spec;
 
     reportInteraction('grafana_provisioning_dashboard_save_submitted', {
       workflow,

--- a/public/app/features/provisioning/components/Dashboards/SaveProvisionedDashboardForm.tsx
+++ b/public/app/features/provisioning/components/Dashboards/SaveProvisionedDashboardForm.tsx
@@ -6,6 +6,7 @@ import { locationUtil } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { locationService, reportInteraction } from '@grafana/runtime';
 import { type Dashboard } from '@grafana/schema';
+import { type Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.grafana.app/v2';
 import { Button, Field, Input, Stack, TextArea, Switch } from '@grafana/ui';
 import {
   type RepositoryView,
@@ -75,6 +76,11 @@ export function SaveProvisionedDashboardForm({
   const isCreatingFolderRef = useRef(false);
   // Lets an in-flight folder creation know the user backed out, so its result isn't applied after the fact
   const folderCreationCancelledRef = useRef(false);
+  // Snapshot of the spec actually committed by the last submit. saveCompleted must
+  // baseline against this (not getSaveModel()) so post-save change detection matches
+  // what was written — on the update path getSaveModel() would re-include values the
+  // save-option toggles omitted.
+  const savedSpecRef = useRef<Dashboard | DashboardV2Spec | undefined>(undefined);
   const mountedRef = useRef(true);
   useEffect(() => {
     return () => {
@@ -207,7 +213,10 @@ export function SaveProvisionedDashboardForm({
 
   const handleDismiss = useCallback(
     (wrapper: ResourceWrapper) => {
-      const model = dashboard.getSaveModel();
+      // Baseline against exactly what was committed. On the update path that is the
+      // change-trimmed model; getSaveModel() would re-include values the toggles
+      // omitted, so change detection would treat them as already saved until reload.
+      const model = savedSpecRef.current ?? dashboard.getSaveModel();
       const resourceData = wrapper.resource.upsert || wrapper.resource.dryRun;
       const saveResponse = createSaveResponseFromResource(resourceData);
       dashboard.saveCompleted(model, saveResponse, defaultValues.folder?.uid);
@@ -384,13 +393,26 @@ export function SaveProvisionedDashboardForm({
 
     const body = rawDashboardJSON
       ? dashboard.getSaveResourceFromSpec(rawDashboardJSON)
-      : dashboard.getSaveResource({
-          isNew,
-          title,
-          description,
-          copyTags,
-          saveAsCopy,
-        });
+      : isNew || saveAsCopy
+        ? dashboard.getSaveResource({
+            isNew,
+            title,
+            description,
+            copyTags,
+            saveAsCopy,
+          })
+        : // Existing dashboards: commit the change-trimmed model so the "Change default
+          // variables / time range / refresh" toggles are honored. getSaveResource()
+          // serializes the full scene and would re-include the current variable values
+          // (and time/refresh) even when the toggle is left off, diverging from the diff
+          // shown in the drawer. This mirrors the non-provisioned save path.
+          dashboard.getSaveResourceFromSpec(changeInfo.changedSaveModel);
+
+    savedSpecRef.current = rawDashboardJSON
+      ? rawDashboardJSON
+      : isNew || saveAsCopy
+        ? dashboard.getSaveAsModel({ isNew, title, description, copyTags, saveAsCopy })
+        : changeInfo.changedSaveModel;
 
     reportInteraction('grafana_provisioning_dashboard_save_submitted', {
       workflow,


### PR DESCRIPTION
Fixes #127533


https://github.com/user-attachments/assets/e20d120d-67bc-4651-9736-703a51cb0833

## Problem

- Saving a Git Sync dashboard committed unsaved variable values (and time range / refresh) to the PR even when "Change default variables" was left unchecked.
- The drawer's diff view showed no such change, so the committed content didn't match the diff — unintended default changes landed in git.
- Root cause: the provisioned save form built the commit body from the full scene model (`getSaveResource()` → `getSaveAsModel()`), ignoring the save-option toggles, while the diff rendered the change-trimmed `changeInfo.changedSaveModel`.

## Repro

- Git Sync a dashboard that has a template variable.
- Change the variable selection, make an edit, click Save **without** ticking "Change default variables".
- The diff shows no variable change, but the opened PR contains the new variable value.

## Changes

- `SaveProvisionedDashboardForm`: on the **update** path, build the commit body from the change-trimmed `changeInfo.changedSaveModel` via `getSaveResourceFromSpec()` instead of `getSaveResource()`, so the variable/time/refresh toggles are honored and the commit matches the diff. Mirrors the non-provisioned save path.
- **New / save-as-copy** keep `getSaveResource()` — they need form-edited title/description and create-shaped metadata, and the toggle isn't shown there.
- Tests: updated existing update-path tests to mock `getSaveResourceFromSpec`; added a regression test asserting the committed body is the trimmed model and `getSaveResource` is not used on the update path.
