### PR TITLE
Provisioning: Show job author and origin in recent jobs

### DIFF
--- a/public/app/features/apiserver/types.ts
+++ b/public/app/features/apiserver/types.ts
@@ -67,6 +67,12 @@ export const AnnoKeySavedFromUI = 'grafana.app/saved-from-ui';
 // Grant permissions to the created resource
 export const AnnoKeyGrantPermissions = 'grafana.app/grant-permissions';
 
+// Attribution of provisioning jobs to the identity that triggered them
+export const AnnoKeyProvisioningAuthor = 'provisioning.grafana.app/author';
+export const AnnoKeyProvisioningAuthorEmail = 'provisioning.grafana.app/authorEmail';
+export const AnnoKeyProvisioningAuthorId = 'provisioning.grafana.app/authorId';
+export const AnnoKeyProvisioningAuthorOrigin = 'provisioning.grafana.app/authorOrigin';
+
 /** @deprecated NOT A REAL annotation -- this is just a shim */
 export const AnnoKeySlug = 'grafana.app/slug';
 /** @deprecated NOT A REAL annotation -- this is just a shim */

--- a/public/app/features/provisioning/Job/RecentJobs.test.tsx
+++ b/public/app/features/provisioning/Job/RecentJobs.test.tsx
@@ -72,6 +72,61 @@ describe('RecentJobs', () => {
 
       expect(await screen.findByText('System')).toBeInTheDocument();
     });
+
+    it('shows the webhook sender', async () => {
+      setup([
+        createJob({
+          metadata: {
+            name: 'job-1',
+            uid: 'uid-1',
+            annotations: { 'provisioning.grafana.app/webhookSender': 'amalavet' },
+          },
+        }),
+      ]);
+
+      expect(await screen.findByText('amalavet (via Webhook)')).toBeInTheDocument();
+    });
+
+    it('shows webhook attribution in the expanded job specification', async () => {
+      const { user } = setup([
+        createJob({
+          metadata: {
+            name: 'job-1',
+            uid: 'uid-1',
+            annotations: {
+              'provisioning.grafana.app/webhookSender': 'amalavet',
+              'provisioning.grafana.app/webhookSenderId': '12345',
+            },
+          },
+        }),
+      ]);
+
+      await user.click(await screen.findByRole('button', { name: /toggle row expanded/i }));
+
+      expect(await screen.findByText('triggeredBy')).toBeInTheDocument();
+      expect(screen.getByText(/amalavet \(via Webhook\) GitHub ID:12345/)).toBeInTheDocument();
+    });
+
+    it('shows user attribution in the expanded job specification', async () => {
+      const { user } = setup([
+        createJob({
+          metadata: {
+            name: 'job-1',
+            uid: 'uid-1',
+            annotations: {
+              'provisioning.grafana.app/author': 'Ada Lovelace',
+              'provisioning.grafana.app/authorEmail': 'ada@example.com',
+              'grafana.app/createdBy': 'user:abc123',
+            },
+          },
+        }),
+      ]);
+
+      await user.click(await screen.findByRole('button', { name: /toggle row expanded/i }));
+
+      expect(await screen.findByText('triggeredBy')).toBeInTheDocument();
+      expect(screen.getByText(/Ada Lovelace, ada@example\.com, user:abc123/)).toBeInTheDocument();
+    });
   });
 
   describe('with the userAttribution flag disabled', () => {

--- a/public/app/features/provisioning/Job/RecentJobs.test.tsx
+++ b/public/app/features/provisioning/Job/RecentJobs.test.tsx
@@ -68,12 +68,11 @@ describe('RecentJobs', () => {
       expect(await screen.findByText('ada@example.com')).toBeInTheDocument();
     });
 
-    it('leaves the triggered by cell empty when no user triggered the job', async () => {
+    it('shows Grafana for both columns when no user triggered the job', async () => {
       setup([createJob()]);
 
       expect(await screen.findByText('job-1')).toBeInTheDocument();
-      expect(screen.queryByText('System')).not.toBeInTheDocument();
-      expect(screen.getByText('Grafana')).toBeInTheDocument();
+      expect(screen.getAllByText('Grafana')).toHaveLength(2);
     });
 
     it('shows the webhook sender with the provider as the origin', async () => {
@@ -107,8 +106,10 @@ describe('RecentJobs', () => {
 
       await user.click(await screen.findByRole('button', { name: /toggle row expanded/i }));
 
-      expect(await screen.findByText('triggeredBy')).toBeInTheDocument();
-      expect(screen.getByText(/amalavet \(via Webhook\) GitHub ID:12345/)).toBeInTheDocument();
+      expect(await screen.findByText('webhookSender')).toBeInTheDocument();
+      expect(screen.getAllByText(/amalavet/)).toHaveLength(2);
+      expect(screen.getByText('webhookSenderId')).toBeInTheDocument();
+      expect(screen.getByText(/12345/)).toBeInTheDocument();
     });
 
     it('shows user attribution in the expanded job specification', async () => {
@@ -128,8 +129,11 @@ describe('RecentJobs', () => {
 
       await user.click(await screen.findByRole('button', { name: /toggle row expanded/i }));
 
-      expect(await screen.findByText('triggeredBy')).toBeInTheDocument();
-      expect(screen.getByText(/Ada Lovelace, ada@example\.com, user:abc123/)).toBeInTheDocument();
+      expect(await screen.findByText('author')).toBeInTheDocument();
+      expect(screen.getByText('authorEmail')).toBeInTheDocument();
+      expect(screen.getByText('createdBy')).toBeInTheDocument();
+      expect(screen.getByText(/ada@example\.com/)).toBeInTheDocument();
+      expect(screen.getByText(/user:abc123/)).toBeInTheDocument();
     });
   });
 
@@ -138,7 +142,7 @@ describe('RecentJobs', () => {
       setTestFlags({ 'provisioning.userAttribution': false });
     });
 
-    it('hides the triggered by column', async () => {
+    it('hides the by column', async () => {
       setup([
         createJob({
           metadata: {
@@ -150,7 +154,7 @@ describe('RecentJobs', () => {
       ]);
 
       expect(await screen.findByText('job-1')).toBeInTheDocument();
-      expect(screen.queryByText('Triggered by')).not.toBeInTheDocument();
+      expect(screen.queryByText('By')).not.toBeInTheDocument();
       expect(screen.queryByText('Ada Lovelace')).not.toBeInTheDocument();
     });
   });

--- a/public/app/features/provisioning/Job/RecentJobs.test.tsx
+++ b/public/app/features/provisioning/Job/RecentJobs.test.tsx
@@ -121,7 +121,6 @@ describe('RecentJobs', () => {
             annotations: {
               'provisioning.grafana.app/author': 'Ada Lovelace',
               'provisioning.grafana.app/authorEmail': 'ada@example.com',
-              'grafana.app/createdBy': 'user:abc123',
             },
           },
         }),
@@ -131,9 +130,7 @@ describe('RecentJobs', () => {
 
       expect(await screen.findByText('author')).toBeInTheDocument();
       expect(screen.getByText('authorEmail')).toBeInTheDocument();
-      expect(screen.getByText('createdBy')).toBeInTheDocument();
       expect(screen.getByText(/ada@example\.com/)).toBeInTheDocument();
-      expect(screen.getByText(/user:abc123/)).toBeInTheDocument();
     });
   });
 

--- a/public/app/features/provisioning/Job/RecentJobs.test.tsx
+++ b/public/app/features/provisioning/Job/RecentJobs.test.tsx
@@ -71,11 +71,11 @@ describe('RecentJobs', () => {
       expect(await screen.findByText('ada@example.com')).toBeInTheDocument();
     });
 
-    it('shows Grafana as the origin with no author when no user triggered the job', async () => {
+    it('shows Unknown as the origin when the job has no attribution', async () => {
       setup([createJob()]);
 
       expect(await screen.findByText('job-1')).toBeInTheDocument();
-      expect(screen.getByText('Grafana')).toBeInTheDocument();
+      expect(screen.getByText('Unknown')).toBeInTheDocument();
     });
 
     it('shows the webhook sender with the provider as the origin', async () => {

--- a/public/app/features/provisioning/Job/RecentJobs.test.tsx
+++ b/public/app/features/provisioning/Job/RecentJobs.test.tsx
@@ -39,7 +39,7 @@ describe('RecentJobs', () => {
       setTestFlags({ 'provisioning.userAttribution': true });
     });
 
-    it('shows the triggering user', async () => {
+    it('shows the triggering user with Grafana as the origin', async () => {
       setup([
         createJob({
           metadata: {
@@ -51,6 +51,7 @@ describe('RecentJobs', () => {
       ]);
 
       expect(await screen.findByText('Ada Lovelace')).toBeInTheDocument();
+      expect(screen.getByText('Grafana')).toBeInTheDocument();
     });
 
     it('falls back to the author email when the name is missing', async () => {
@@ -67,13 +68,15 @@ describe('RecentJobs', () => {
       expect(await screen.findByText('ada@example.com')).toBeInTheDocument();
     });
 
-    it('shows System when no user triggered the job', async () => {
+    it('leaves the triggered by cell empty when no user triggered the job', async () => {
       setup([createJob()]);
 
-      expect(await screen.findByText('System')).toBeInTheDocument();
+      expect(await screen.findByText('job-1')).toBeInTheDocument();
+      expect(screen.queryByText('System')).not.toBeInTheDocument();
+      expect(screen.getByText('Grafana')).toBeInTheDocument();
     });
 
-    it('shows the webhook sender', async () => {
+    it('shows the webhook sender with the provider as the origin', async () => {
       setup([
         createJob({
           metadata: {
@@ -84,7 +87,8 @@ describe('RecentJobs', () => {
         }),
       ]);
 
-      expect(await screen.findByText('amalavet (via Webhook)')).toBeInTheDocument();
+      expect(await screen.findByText('amalavet')).toBeInTheDocument();
+      expect(screen.getByText('GitHub')).toBeInTheDocument();
     });
 
     it('shows webhook attribution in the expanded job specification', async () => {

--- a/public/app/features/provisioning/Job/RecentJobs.test.tsx
+++ b/public/app/features/provisioning/Job/RecentJobs.test.tsx
@@ -39,19 +39,22 @@ describe('RecentJobs', () => {
       setTestFlags({ 'provisioning.userAttribution': true });
     });
 
-    it('shows the triggering user with Grafana as the origin', async () => {
+    it('shows the triggering user with the recorded origin', async () => {
       setup([
         createJob({
           metadata: {
             name: 'job-1',
             uid: 'uid-1',
-            annotations: { 'provisioning.grafana.app/author': 'Ada Lovelace' },
+            annotations: {
+              'provisioning.grafana.app/author': 'Ada Lovelace',
+              'provisioning.grafana.app/authorOrigin': 'UI',
+            },
           },
         }),
       ]);
 
       expect(await screen.findByText('Ada Lovelace')).toBeInTheDocument();
-      expect(screen.getByText('Grafana')).toBeInTheDocument();
+      expect(screen.getByText('UI')).toBeInTheDocument();
     });
 
     it('falls back to the author email when the name is missing', async () => {
@@ -68,11 +71,11 @@ describe('RecentJobs', () => {
       expect(await screen.findByText('ada@example.com')).toBeInTheDocument();
     });
 
-    it('shows Grafana for both columns when no user triggered the job', async () => {
+    it('shows Grafana as the origin with no author when no user triggered the job', async () => {
       setup([createJob()]);
 
       expect(await screen.findByText('job-1')).toBeInTheDocument();
-      expect(screen.getAllByText('Grafana')).toHaveLength(2);
+      expect(screen.getByText('Grafana')).toBeInTheDocument();
     });
 
     it('shows the webhook sender with the provider as the origin', async () => {
@@ -81,7 +84,10 @@ describe('RecentJobs', () => {
           metadata: {
             name: 'job-1',
             uid: 'uid-1',
-            annotations: { 'provisioning.grafana.app/webhookSender': 'amalavet' },
+            annotations: {
+              'provisioning.grafana.app/author': 'amalavet',
+              'provisioning.grafana.app/authorOrigin': 'github',
+            },
           },
         }),
       ]);
@@ -97,8 +103,9 @@ describe('RecentJobs', () => {
             name: 'job-1',
             uid: 'uid-1',
             annotations: {
-              'provisioning.grafana.app/webhookSender': 'amalavet',
-              'provisioning.grafana.app/webhookSenderId': '12345',
+              'provisioning.grafana.app/author': 'amalavet',
+              'provisioning.grafana.app/authorId': '12345',
+              'provisioning.grafana.app/authorOrigin': 'github',
             },
           },
         }),
@@ -106,10 +113,11 @@ describe('RecentJobs', () => {
 
       await user.click(await screen.findByRole('button', { name: /toggle row expanded/i }));
 
-      expect(await screen.findByText('webhookSender')).toBeInTheDocument();
+      expect(await screen.findByText('author')).toBeInTheDocument();
       expect(screen.getAllByText(/amalavet/)).toHaveLength(2);
-      expect(screen.getByText('webhookSenderId')).toBeInTheDocument();
+      expect(screen.getByText('authorId')).toBeInTheDocument();
       expect(screen.getByText(/12345/)).toBeInTheDocument();
+      expect(screen.getByText('authorOrigin')).toBeInTheDocument();
     });
 
     it('shows user attribution in the expanded job specification', async () => {
@@ -139,7 +147,7 @@ describe('RecentJobs', () => {
       setTestFlags({ 'provisioning.userAttribution': false });
     });
 
-    it('hides the by column', async () => {
+    it('hides the author column', async () => {
       setup([
         createJob({
           metadata: {
@@ -151,7 +159,7 @@ describe('RecentJobs', () => {
       ]);
 
       expect(await screen.findByText('job-1')).toBeInTheDocument();
-      expect(screen.queryByText('By')).not.toBeInTheDocument();
+      expect(screen.queryByText('Author')).not.toBeInTheDocument();
       expect(screen.queryByText('Ada Lovelace')).not.toBeInTheDocument();
     });
   });

--- a/public/app/features/provisioning/Job/RecentJobs.tsx
+++ b/public/app/features/provisioning/Job/RecentJobs.tsx
@@ -28,7 +28,6 @@ interface Props {
   repo: Repository;
 }
 
-
 type JobCell = {
   row: {
     original: Job;

--- a/public/app/features/provisioning/Job/RecentJobs.tsx
+++ b/public/app/features/provisioning/Job/RecentJobs.tsx
@@ -10,8 +10,8 @@ import KeyValuesTable from 'app/features/explore/TraceView/components/TraceTimel
 
 import { ProvisioningAlert } from '../Shared/ProvisioningAlert';
 import { useRepositoryAllJobs } from '../hooks/useRepositoryAllJobs';
+import { type RepoType } from '../Wizard/types';
 import { getStatusColor } from '../utils/repositoryStatus';
-import { getRepositoryTypeConfig } from '../utils/repositoryTypes';
 import { getRepositoryTypeConfig } from '../utils/repositoryTypes';
 import { formatTimestamp } from '../utils/time';
 
@@ -24,8 +24,8 @@ interface Props {
 
 const AnnoAuthor = 'provisioning.grafana.app/author';
 const AnnoAuthorEmail = 'provisioning.grafana.app/authorEmail';
-const AnnoWebhookSender = 'provisioning.grafana.app/webhookSender';
-const AnnoWebhookSenderId = 'provisioning.grafana.app/webhookSenderId';
+const AnnoAuthorId = 'provisioning.grafana.app/authorId';
+const AnnoAuthorOrigin = 'provisioning.grafana.app/authorOrigin';
 
 type JobCell = {
   row: {
@@ -48,7 +48,7 @@ function formatJobDuration(job: Job): string | null {
   return intervalToAbbreviatedDurationString(interval, true);
 }
 
-const getJobColumns = (showAuthor: boolean, repo: Repository) => [
+const getJobColumns = (showAuthor: boolean) => [
   {
     id: 'jobId',
     header: t('provisioning.recent-jobs.column-job-id', 'Job ID'),
@@ -73,29 +73,22 @@ const getJobColumns = (showAuthor: boolean, repo: Repository) => [
   ...(showAuthor
     ? [
         {
-          id: 'by',
-          header: t('provisioning.recent-jobs.column-by', 'By'),
+          id: 'author',
+          header: t('provisioning.recent-jobs.column-author', 'Author'),
           cell: ({ row: { original: job } }: JobCell) => {
             const annotations = job.metadata?.annotations;
-            return (
-              annotations?.[AnnoWebhookSender] ||
-              annotations?.[AnnoAuthor] ||
-              annotations?.[AnnoAuthorEmail] ||
-              t('provisioning.recent-jobs.by-grafana', 'Grafana')
-            );
+            return annotations?.[AnnoAuthor] || annotations?.[AnnoAuthorEmail];
           },
         },
         {
-          id: 'from',
-          header: t('provisioning.recent-jobs.column-from', 'From'),
+          id: 'origin',
+          header: t('provisioning.recent-jobs.column-origin', 'Origin'),
           cell: ({ row: { original: job } }: JobCell) => {
-            if (job.metadata?.annotations?.[AnnoWebhookSender] && repo.spec) {
-              const provider = getRepositoryTypeConfig(repo.spec.type)?.label;
-              if (provider) {
-                return provider;
-              }
+            const origin = job.metadata?.annotations?.[AnnoAuthorOrigin];
+            if (!origin) {
+              return t('provisioning.recent-jobs.origin-grafana', 'Grafana');
             }
-            return t('provisioning.recent-jobs.from-grafana', 'Grafana');
+            return getRepositoryTypeConfig(origin as RepoType)?.label ?? origin;
           },
         },
       ]
@@ -146,10 +139,10 @@ function ExpandedRow({ row }: ExpandedRowProps) {
     };
     const annotations = row.metadata?.annotations;
     for (const [key, anno] of [
-      ['webhookSender', AnnoWebhookSender],
-      ['webhookSenderId', AnnoWebhookSenderId],
       ['author', AnnoAuthor],
       ['authorEmail', AnnoAuthorEmail],
+      ['authorId', AnnoAuthorId],
+      ['authorOrigin', AnnoAuthorOrigin],
     ]) {
       const value = annotations?.[anno];
       if (value) {
@@ -210,7 +203,7 @@ export function RecentJobs({ repo }: Props) {
     repositoryName: repo.metadata?.name ?? 'x',
   });
   const showAuthor = useBooleanFlagValue('provisioning.userAttribution', false);
-  const jobColumns = useMemo(() => getJobColumns(showAuthor, repo), [showAuthor, repo]);
+  const jobColumns = useMemo(() => getJobColumns(showAuthor), [showAuthor]);
   const hasLoadedDataRef = useRef(false);
 
   if (activeQuery.data || historicQuery.data) {

--- a/public/app/features/provisioning/Job/RecentJobs.tsx
+++ b/public/app/features/provisioning/Job/RecentJobs.tsx
@@ -12,6 +12,7 @@ import { ProvisioningAlert } from '../Shared/ProvisioningAlert';
 import { useRepositoryAllJobs } from '../hooks/useRepositoryAllJobs';
 import { getStatusColor } from '../utils/repositoryStatus';
 import { getRepositoryTypeConfig } from '../utils/repositoryTypes';
+import { getRepositoryTypeConfig } from '../utils/repositoryTypes';
 import { formatTimestamp } from '../utils/time';
 
 import { JobAlerts } from './JobAlerts';
@@ -48,7 +49,7 @@ function formatJobDuration(job: Job): string | null {
   return intervalToAbbreviatedDurationString(interval, true);
 }
 
-const getJobColumns = (showAuthor: boolean) => [
+const getJobColumns = (showAuthor: boolean, repo: Repository) => [
   {
     id: 'jobId',
     header: t('provisioning.recent-jobs.column-job-id', 'Job ID'),
@@ -77,12 +78,20 @@ const getJobColumns = (showAuthor: boolean) => [
           header: t('provisioning.recent-jobs.column-triggered-by', 'Triggered by'),
           cell: ({ row: { original: job } }: JobCell) => {
             const annotations = job.metadata?.annotations;
-            const sender = annotations?.[AnnoWebhookSender];
-            if (sender) {
-              return t('provisioning.recent-jobs.triggered-by-webhook', '{{sender}} (via Webhook)', { sender });
+            return annotations?.[AnnoWebhookSender] || annotations?.[AnnoAuthor] || annotations?.[AnnoAuthorEmail];
+          },
+        },
+        {
+          id: 'origin',
+          header: t('provisioning.recent-jobs.column-origin', 'Origin'),
+          cell: ({ row: { original: job } }: JobCell) => {
+            if (job.metadata?.annotations?.[AnnoWebhookSender] && repo.spec) {
+              const provider = getRepositoryTypeConfig(repo.spec.type)?.label;
+              if (provider) {
+                return provider;
+              }
             }
-            const author = annotations?.[AnnoAuthor] || annotations?.[AnnoAuthorEmail];
-            return author || t('provisioning.recent-jobs.triggered-by-system', 'System');
+            return t('provisioning.recent-jobs.origin-grafana', 'Grafana');
           },
         },
       ]
@@ -201,7 +210,7 @@ export function RecentJobs({ repo }: Props) {
     repositoryName: repo.metadata?.name ?? 'x',
   });
   const showAuthor = useBooleanFlagValue('provisioning.userAttribution', false);
-  const jobColumns = useMemo(() => getJobColumns(showAuthor), [showAuthor]);
+  const jobColumns = useMemo(() => getJobColumns(showAuthor, repo), [showAuthor, repo]);
   const hasLoadedDataRef = useRef(false);
 
   if (activeQuery.data || historicQuery.data) {

--- a/public/app/features/provisioning/Job/RecentJobs.tsx
+++ b/public/app/features/provisioning/Job/RecentJobs.tsx
@@ -8,6 +8,12 @@ import { getErrorMessage } from 'app/api/clients/provisioning/utils/httpUtils';
 import { type Job, type Repository } from 'app/api/clients/provisioning/v0alpha1';
 import KeyValuesTable from 'app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/KeyValuesTable';
 
+import {
+  AnnoKeyProvisioningAuthor,
+  AnnoKeyProvisioningAuthorEmail,
+  AnnoKeyProvisioningAuthorId,
+  AnnoKeyProvisioningAuthorOrigin,
+} from '../../apiserver/types';
 import { ProvisioningAlert } from '../Shared/ProvisioningAlert';
 import { type RepoType } from '../Wizard/types';
 import { useRepositoryAllJobs } from '../hooks/useRepositoryAllJobs';
@@ -22,10 +28,6 @@ interface Props {
   repo: Repository;
 }
 
-const AnnoAuthor = 'provisioning.grafana.app/author';
-const AnnoAuthorEmail = 'provisioning.grafana.app/authorEmail';
-const AnnoAuthorId = 'provisioning.grafana.app/authorId';
-const AnnoAuthorOrigin = 'provisioning.grafana.app/authorOrigin';
 
 type JobCell = {
   row: {
@@ -77,16 +79,16 @@ const getJobColumns = (showAuthor: boolean) => [
           header: t('provisioning.recent-jobs.column-author', 'Author'),
           cell: ({ row: { original: job } }: JobCell) => {
             const annotations = job.metadata?.annotations;
-            return annotations?.[AnnoAuthor] || annotations?.[AnnoAuthorEmail];
+            return annotations?.[AnnoKeyProvisioningAuthor] || annotations?.[AnnoKeyProvisioningAuthorEmail];
           },
         },
         {
           id: 'origin',
           header: t('provisioning.recent-jobs.column-origin', 'Origin'),
           cell: ({ row: { original: job } }: JobCell) => {
-            const origin = job.metadata?.annotations?.[AnnoAuthorOrigin];
+            const origin = job.metadata?.annotations?.[AnnoKeyProvisioningAuthorOrigin];
             if (!origin) {
-              return t('provisioning.recent-jobs.origin-grafana', 'Grafana');
+              return t('provisioning.recent-jobs.origin-unknown', 'Unknown');
             }
             return originLabel(origin);
           },
@@ -139,10 +141,10 @@ function ExpandedRow({ row }: ExpandedRowProps) {
     };
     const annotations = row.metadata?.annotations;
     for (const [key, anno] of [
-      ['author', AnnoAuthor],
-      ['authorEmail', AnnoAuthorEmail],
-      ['authorId', AnnoAuthorId],
-      ['authorOrigin', AnnoAuthorOrigin],
+      ['author', AnnoKeyProvisioningAuthor],
+      ['authorEmail', AnnoKeyProvisioningAuthorEmail],
+      ['authorId', AnnoKeyProvisioningAuthorId],
+      ['authorOrigin', AnnoKeyProvisioningAuthorOrigin],
     ]) {
       const value = annotations?.[anno];
       if (value) {

--- a/public/app/features/provisioning/Job/RecentJobs.tsx
+++ b/public/app/features/provisioning/Job/RecentJobs.tsx
@@ -9,8 +9,8 @@ import { type Job, type Repository } from 'app/api/clients/provisioning/v0alpha1
 import KeyValuesTable from 'app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/KeyValuesTable';
 
 import { ProvisioningAlert } from '../Shared/ProvisioningAlert';
-import { useRepositoryAllJobs } from '../hooks/useRepositoryAllJobs';
 import { type RepoType } from '../Wizard/types';
+import { useRepositoryAllJobs } from '../hooks/useRepositoryAllJobs';
 import { getStatusColor } from '../utils/repositoryStatus';
 import { getRepositoryTypeConfig } from '../utils/repositoryTypes';
 import { formatTimestamp } from '../utils/time';
@@ -88,7 +88,7 @@ const getJobColumns = (showAuthor: boolean) => [
             if (!origin) {
               return t('provisioning.recent-jobs.origin-grafana', 'Grafana');
             }
-            return getRepositoryTypeConfig(origin as RepoType)?.label ?? origin;
+            return originLabel(origin);
           },
         },
       ]
@@ -186,6 +186,13 @@ function ExpandedRow({ row }: ExpandedRowProps) {
       </Stack>
     </Box>
   );
+}
+
+const REPO_TYPES: RepoType[] = ['local', 'git', 'github', 'githubEnterprise', 'gitlab', 'bitbucket'];
+
+function originLabel(origin: string): string {
+  const repoType = REPO_TYPES.find((type) => type === origin);
+  return (repoType ? getRepositoryTypeConfig(repoType)?.label : undefined) ?? origin;
 }
 
 function EmptyState() {

--- a/public/app/features/provisioning/Job/RecentJobs.tsx
+++ b/public/app/features/provisioning/Job/RecentJobs.tsx
@@ -26,7 +26,6 @@ const AnnoAuthor = 'provisioning.grafana.app/author';
 const AnnoAuthorEmail = 'provisioning.grafana.app/authorEmail';
 const AnnoWebhookSender = 'provisioning.grafana.app/webhookSender';
 const AnnoWebhookSenderId = 'provisioning.grafana.app/webhookSenderId';
-const AnnoCreatedBy = 'grafana.app/createdBy';
 
 type JobCell = {
   row: {
@@ -151,7 +150,6 @@ function ExpandedRow({ row }: ExpandedRowProps) {
       ['webhookSenderId', AnnoWebhookSenderId],
       ['author', AnnoAuthor],
       ['authorEmail', AnnoAuthorEmail],
-      ['createdBy', AnnoCreatedBy],
     ]) {
       const value = annotations?.[anno];
       if (value) {

--- a/public/app/features/provisioning/Job/RecentJobs.tsx
+++ b/public/app/features/provisioning/Job/RecentJobs.tsx
@@ -74,16 +74,21 @@ const getJobColumns = (showAuthor: boolean, repo: Repository) => [
   ...(showAuthor
     ? [
         {
-          id: 'triggeredBy',
-          header: t('provisioning.recent-jobs.column-triggered-by', 'Triggered by'),
+          id: 'by',
+          header: t('provisioning.recent-jobs.column-by', 'By'),
           cell: ({ row: { original: job } }: JobCell) => {
             const annotations = job.metadata?.annotations;
-            return annotations?.[AnnoWebhookSender] || annotations?.[AnnoAuthor] || annotations?.[AnnoAuthorEmail];
+            return (
+              annotations?.[AnnoWebhookSender] ||
+              annotations?.[AnnoAuthor] ||
+              annotations?.[AnnoAuthorEmail] ||
+              t('provisioning.recent-jobs.by-grafana', 'Grafana')
+            );
           },
         },
         {
-          id: 'origin',
-          header: t('provisioning.recent-jobs.column-origin', 'Origin'),
+          id: 'from',
+          header: t('provisioning.recent-jobs.column-from', 'From'),
           cell: ({ row: { original: job } }: JobCell) => {
             if (job.metadata?.annotations?.[AnnoWebhookSender] && repo.spec) {
               const provider = getRepositoryTypeConfig(repo.spec.type)?.label;
@@ -91,7 +96,7 @@ const getJobColumns = (showAuthor: boolean, repo: Repository) => [
                 return provider;
               }
             }
-            return t('provisioning.recent-jobs.origin-grafana', 'Grafana');
+            return t('provisioning.recent-jobs.from-grafana', 'Grafana');
           },
         },
       ]
@@ -115,10 +120,9 @@ const getJobColumns = (showAuthor: boolean, repo: Repository) => [
 
 interface ExpandedRowProps {
   row: Job;
-  repo: Repository;
 }
 
-function ExpandedRow({ row, repo }: ExpandedRowProps) {
+function ExpandedRow({ row }: ExpandedRowProps) {
   const hasSummary = Boolean(row.status?.summary?.length);
   const hasErrors = Boolean(row.status?.errors?.length);
   const hasWarnings = Boolean(row.status?.warnings?.length);
@@ -142,18 +146,16 @@ function ExpandedRow({ row, repo }: ExpandedRowProps) {
       push: spec.push,
     };
     const annotations = row.metadata?.annotations;
-    const sender = annotations?.[AnnoWebhookSender];
-    const senderId = annotations?.[AnnoWebhookSenderId];
-    if (sender) {
-      const provider = repo.spec ? getRepositoryTypeConfig(repo.spec.type)?.label : undefined;
-      const id = senderId && provider ? ` ${provider} ID:${senderId}` : '';
-      v.push({ key: 'triggeredBy', value: `${sender} (via Webhook)${id}` });
-    } else {
-      const user = [annotations?.[AnnoAuthor], annotations?.[AnnoAuthorEmail], annotations?.[AnnoCreatedBy]]
-        .filter(Boolean)
-        .join(', ');
-      if (user) {
-        v.push({ key: 'triggeredBy', value: user });
+    for (const [key, anno] of [
+      ['webhookSender', AnnoWebhookSender],
+      ['webhookSenderId', AnnoWebhookSenderId],
+      ['author', AnnoAuthor],
+      ['authorEmail', AnnoAuthorEmail],
+      ['createdBy', AnnoCreatedBy],
+    ]) {
+      const value = annotations?.[anno];
+      if (value) {
+        v.push({ key, value });
       }
     }
     const def = actionOptions[action];
@@ -164,7 +166,7 @@ function ExpandedRow({ row, repo }: ExpandedRowProps) {
       v.push({ key, value });
     }
     return v;
-  }, [row.spec, row.metadata?.annotations, repo.spec]);
+  }, [row.spec, row.metadata?.annotations]);
 
   if (!hasSummary && !hasErrors && !hasWarnings && !hasSpec) {
     return null;
@@ -259,7 +261,7 @@ export function RecentJobs({ repo }: Props) {
         data={jobs}
         columns={jobColumns}
         getRowId={(item) => `${item.metadata?.uid}`}
-        renderExpandedRow={(row) => <ExpandedRow row={row} repo={repo} />}
+        renderExpandedRow={(row) => <ExpandedRow row={row} />}
         pageSize={10}
       />
     );

--- a/public/app/features/provisioning/Job/RecentJobs.tsx
+++ b/public/app/features/provisioning/Job/RecentJobs.tsx
@@ -11,6 +11,7 @@ import KeyValuesTable from 'app/features/explore/TraceView/components/TraceTimel
 import { ProvisioningAlert } from '../Shared/ProvisioningAlert';
 import { useRepositoryAllJobs } from '../hooks/useRepositoryAllJobs';
 import { getStatusColor } from '../utils/repositoryStatus';
+import { getRepositoryTypeConfig } from '../utils/repositoryTypes';
 import { formatTimestamp } from '../utils/time';
 
 import { JobAlerts } from './JobAlerts';
@@ -22,6 +23,9 @@ interface Props {
 
 const AnnoAuthor = 'provisioning.grafana.app/author';
 const AnnoAuthorEmail = 'provisioning.grafana.app/authorEmail';
+const AnnoWebhookSender = 'provisioning.grafana.app/webhookSender';
+const AnnoWebhookSenderId = 'provisioning.grafana.app/webhookSenderId';
+const AnnoCreatedBy = 'grafana.app/createdBy';
 
 type JobCell = {
   row: {
@@ -73,6 +77,10 @@ const getJobColumns = (showAuthor: boolean) => [
           header: t('provisioning.recent-jobs.column-triggered-by', 'Triggered by'),
           cell: ({ row: { original: job } }: JobCell) => {
             const annotations = job.metadata?.annotations;
+            const sender = annotations?.[AnnoWebhookSender];
+            if (sender) {
+              return t('provisioning.recent-jobs.triggered-by-webhook', '{{sender}} (via Webhook)', { sender });
+            }
             const author = annotations?.[AnnoAuthor] || annotations?.[AnnoAuthorEmail];
             return author || t('provisioning.recent-jobs.triggered-by-system', 'System');
           },
@@ -98,9 +106,10 @@ const getJobColumns = (showAuthor: boolean) => [
 
 interface ExpandedRowProps {
   row: Job;
+  repo: Repository;
 }
 
-function ExpandedRow({ row }: ExpandedRowProps) {
+function ExpandedRow({ row, repo }: ExpandedRowProps) {
   const hasSummary = Boolean(row.status?.summary?.length);
   const hasErrors = Boolean(row.status?.errors?.length);
   const hasWarnings = Boolean(row.status?.warnings?.length);
@@ -123,6 +132,21 @@ function ExpandedRow({ row }: ExpandedRowProps) {
       pull: spec.pull,
       push: spec.push,
     };
+    const annotations = row.metadata?.annotations;
+    const sender = annotations?.[AnnoWebhookSender];
+    const senderId = annotations?.[AnnoWebhookSenderId];
+    if (sender) {
+      const provider = repo.spec ? getRepositoryTypeConfig(repo.spec.type)?.label : undefined;
+      const id = senderId && provider ? ` ${provider} ID:${senderId}` : '';
+      v.push({ key: 'triggeredBy', value: `${sender} (via Webhook)${id}` });
+    } else {
+      const user = [annotations?.[AnnoAuthor], annotations?.[AnnoAuthorEmail], annotations?.[AnnoCreatedBy]]
+        .filter(Boolean)
+        .join(', ');
+      if (user) {
+        v.push({ key: 'triggeredBy', value: user });
+      }
+    }
     const def = actionOptions[action];
     if (!def) {
       return v;
@@ -131,7 +155,7 @@ function ExpandedRow({ row }: ExpandedRowProps) {
       v.push({ key, value });
     }
     return v;
-  }, [row.spec]);
+  }, [row.spec, row.metadata?.annotations, repo.spec]);
 
   if (!hasSummary && !hasErrors && !hasWarnings && !hasSpec) {
     return null;
@@ -226,7 +250,7 @@ export function RecentJobs({ repo }: Props) {
         data={jobs}
         columns={jobColumns}
         getRowId={(item) => `${item.metadata?.uid}`}
-        renderExpandedRow={(row) => <ExpandedRow row={row} />}
+        renderExpandedRow={(row) => <ExpandedRow row={row} repo={repo} />}
         pageSize={10}
       />
     );

--- a/public/app/features/provisioning/utils/commitMessage.test.ts
+++ b/public/app/features/provisioning/utils/commitMessage.test.ts
@@ -1,3 +1,4 @@
+import { setTestFlags } from '@grafana/test-utils/unstable';
 import { type RepositoryView } from 'app/api/clients/provisioning/v0alpha1';
 
 import { appendSavedByTrailer, getSingleResourceCommitMessage, renderCommitMessage } from './commitMessage';
@@ -135,6 +136,12 @@ describe('appendSavedByTrailer', () => {
     expect(appendSavedByTrailer('Save dashboard: Latency', userVars)).toBe(
       'Save dashboard: Latency\n\nGrafana-saved-by: Ada Lovelace (ada)'
     );
+  });
+
+  it('skips the trailer when user attribution is enabled', () => {
+    setTestFlags({ 'provisioning.userAttribution': true });
+    expect(appendSavedByTrailer('Save dashboard: Latency', userVars)).toBe('Save dashboard: Latency');
+    setTestFlags({});
   });
 
   it('uses login alone when name is missing', () => {

--- a/public/app/features/provisioning/utils/commitMessage.ts
+++ b/public/app/features/provisioning/utils/commitMessage.ts
@@ -1,4 +1,5 @@
 import { t } from '@grafana/i18n';
+import { FlagKeys, getFeatureFlagClient } from '@grafana/runtime/internal';
 import { type RepositoryView } from 'app/api/clients/provisioning/v0alpha1';
 
 import { type ResourceKindKey } from './resourceKinds';
@@ -150,6 +151,9 @@ function buildSavedByTrailer({ userName, userLogin }: SavedByVars): string | und
  * spell it out themselves don't end up with a duplicate).
  */
 export function appendSavedByTrailer(message: string, vars: SavedByVars): string {
+  if (getFeatureFlagClient().getBooleanValue(FlagKeys.ProvisioningUserAttribution, false)) {
+    return message;
+  }
   const trailer = buildSavedByTrailer(vars);
   if (!trailer) {
     return message;

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -13860,18 +13860,19 @@
     "read-only-local-tooltip": "This resource is read-only and provisioned through file provisioning. To make any changes, update the connected repository. To modify the settings go to Administration > Provisioning > Repositories.",
     "read-only-remote-tooltip": "This resource is read-only and provisioned through Git. To make any changes, update the connected repository. To modify the settings go to Administration > Provisioning > Repositories.",
     "recent-jobs": {
+      "by-grafana": "Grafana",
       "column-action": "Action",
+      "column-by": "By",
       "column-duration": "Duration",
+      "column-from": "From",
       "column-job-id": "Job ID",
       "column-message": "Message",
-      "column-origin": "Origin",
       "column-started": "Started",
       "column-status": "Status",
-      "column-triggered-by": "Triggered by",
       "error-loading-active-jobs": "Error loading active jobs",
       "error-loading-historic-jobs": "Error loading historic jobs",
-      "jobs": "Jobs",
-      "origin-grafana": "Grafana"
+      "from-grafana": "Grafana",
+      "jobs": "Jobs"
     },
     "repository-actions": {
       "connection": "Connection",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -13864,14 +13864,14 @@
       "column-duration": "Duration",
       "column-job-id": "Job ID",
       "column-message": "Message",
+      "column-origin": "Origin",
       "column-started": "Started",
       "column-status": "Status",
       "column-triggered-by": "Triggered by",
       "error-loading-active-jobs": "Error loading active jobs",
       "error-loading-historic-jobs": "Error loading historic jobs",
       "jobs": "Jobs",
-      "triggered-by-system": "System",
-      "triggered-by-webhook": "{{sender}} (via Webhook)"
+      "origin-grafana": "Grafana"
     },
     "repository-actions": {
       "connection": "Connection",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -13860,19 +13860,18 @@
     "read-only-local-tooltip": "This resource is read-only and provisioned through file provisioning. To make any changes, update the connected repository. To modify the settings go to Administration > Provisioning > Repositories.",
     "read-only-remote-tooltip": "This resource is read-only and provisioned through Git. To make any changes, update the connected repository. To modify the settings go to Administration > Provisioning > Repositories.",
     "recent-jobs": {
-      "by-grafana": "Grafana",
       "column-action": "Action",
-      "column-by": "By",
+      "column-author": "Author",
       "column-duration": "Duration",
-      "column-from": "From",
       "column-job-id": "Job ID",
       "column-message": "Message",
+      "column-origin": "Origin",
       "column-started": "Started",
       "column-status": "Status",
       "error-loading-active-jobs": "Error loading active jobs",
       "error-loading-historic-jobs": "Error loading historic jobs",
-      "from-grafana": "Grafana",
-      "jobs": "Jobs"
+      "jobs": "Jobs",
+      "origin-grafana": "Grafana"
     },
     "repository-actions": {
       "connection": "Connection",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -13870,7 +13870,8 @@
       "error-loading-active-jobs": "Error loading active jobs",
       "error-loading-historic-jobs": "Error loading historic jobs",
       "jobs": "Jobs",
-      "triggered-by-system": "System"
+      "triggered-by-system": "System",
+      "triggered-by-webhook": "{{sender}} (via Webhook)"
     },
     "repository-actions": {
       "connection": "Connection",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -13871,7 +13871,7 @@
       "error-loading-active-jobs": "Error loading active jobs",
       "error-loading-historic-jobs": "Error loading historic jobs",
       "jobs": "Jobs",
-      "origin-grafana": "Grafana"
+      "origin-unknown": "Unknown"
     },
     "repository-actions": {
       "connection": "Connection",


### PR DESCRIPTION
**What is this feature?**

The recent jobs list now has Author and Origin columns: the person who triggered the job and where it came from (the Git provider for webhook jobs, otherwise Grafana). The expanded job details list the recorded attribution.

When user attribution is enabled, commit messages no longer append the saved-by trailer, since the acting user is already recorded.

Backend counterpart: https://github.com/grafana/grafana/pull/128819

**Why do we need this feature?**

There was no way to see who caused a job to run.

**Who is this feature for?**

Git Sync users auditing repository activity.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/1274
Fixes https://github.com/grafana/git-ui-sync-project/issues/1270

**Special notes for your reviewer:**

The new columns stay behind the existing user attribution feature flag.

---
*Description generated by Claude Code.*