### PR TITLE
Explore Logs: logs list controls allow overflowY

### DIFF
--- a/public/app/features/logs/components/panel/LogList.tsx
+++ b/public/app/features/logs/components/panel/LogList.tsx
@@ -326,7 +326,7 @@ const LogListComponent = ({
       wrapLogMessage,
     ]
   );
-  const styles = useStyles2(getStyles, dimensions, displayedFields, { unwrappedColumns });
+  const styles = useStyles2(getStyles, dimensions, displayedFields, { unwrappedColumns }, listHeight);
   const otelLogsFormattingEnabled = useBooleanFlagValue('otelLogsFormatting', false);
   const widthContainer = wrapperRef.current ?? containerElement;
   const {
@@ -598,7 +598,8 @@ function getStyles(
   theme: GrafanaTheme2,
   dimensions: LogFieldDimension[],
   displayedFields: string[] = [],
-  { unwrappedColumns }: { unwrappedColumns: boolean }
+  { unwrappedColumns }: { unwrappedColumns: boolean },
+  listHeight: number
 ) {
   return {
     logList: css({
@@ -613,6 +614,8 @@ function getStyles(
     logListContainer: css({
       display: 'flex',
       flexDirection: 'row-reverse',
+      // A definite height is required, otherwise the tallest child sets it and the controls never overflow.
+      height: listHeight,
       // Minimum width to prevent rendering issues and a sausage-like logs panel.
       minWidth: theme.spacing(35),
     }),

--- a/public/app/features/logs/components/panel/LogListControls.tsx
+++ b/public/app/features/logs/components/panel/LogListControls.tsx
@@ -747,6 +747,11 @@ const getStyles = (theme: GrafanaTheme2, controlsExpanded: boolean) => {
       borderLeft: `solid 1px ${theme.colors.border.medium}`,
       minWidth: theme.spacing(4),
       backgroundColor: theme.colors.background.primary,
+      // On small screens / small logs visualizations the controls can be taller than the
+      // available space, hiding options. Allow the toolbar to scroll vertically so every
+      // option stays reachable.
+      overflowY: 'auto',
+      overflowX: 'hidden',
     }),
     scrollToTopButton: css({
       margin: 0,

--- a/public/app/features/logs/components/panel/LogListControls.tsx
+++ b/public/app/features/logs/components/panel/LogListControls.tsx
@@ -736,6 +736,10 @@ const getStyles = (theme: GrafanaTheme2, controlsExpanded: boolean) => {
   return {
     navContainer: css({
       maxHeight: '100%',
+      // Lets the column shrink below its content height so the options scroll instead of overflowing.
+      minHeight: 0,
+      overflowY: 'auto',
+      overflowX: 'hidden',
       display: 'flex',
       flex: '1 0 auto',
       gap: theme.spacing(3),
@@ -747,11 +751,6 @@ const getStyles = (theme: GrafanaTheme2, controlsExpanded: boolean) => {
       borderLeft: `solid 1px ${theme.colors.border.medium}`,
       minWidth: theme.spacing(4),
       backgroundColor: theme.colors.background.primary,
-      // On small screens / small logs visualizations the controls can be taller than the
-      // available space, hiding options. Allow the toolbar to scroll vertically so every
-      // option stays reachable.
-      overflowY: 'auto',
-      overflowX: 'hidden',
     }),
     scrollToTopButton: css({
       margin: 0,


### PR DESCRIPTION
**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

- Fixes [#128757](https://github.com/grafana/grafana/issues/128757) — Log List Controls: add scroll if the options are hidden in small screens with small logs visualizations.
<img width="1744" height="465" alt="Screenshot 2026-07-20 at 2 04 54 PM" src="https://github.com/user-attachments/assets/77243f3f-fe4f-452e-94ba-67dd772f3f6e" />




**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
