### PR TITLE
Provisioning: Set FileToLarge error as warning instead of error

### DIFF
--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/health.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/health.go
@@ -69,6 +69,9 @@ const (
 	ReasonCompletedWithWarnings = "CompletedWithWarnings"
 	// ReasonResourceInvalid indicates a resource-level issue such as validation errors or ownership conflicts.
 	ReasonResourceInvalid = "ResourceInvalid"
+	// ReasonResourceTooLarge indicates a resource file exceeded the maximum size
+	// the repository will read.
+	ReasonResourceTooLarge = "ResourceTooLarge"
 	// ReasonMissingFolderMetadata indicates the pull completed but some folders are missing
 	// _folder.json metadata files; their UIDs are unstable and may change on re-sync.
 	ReasonMissingFolderMetadata = "MissingFolderMetadata"

--- a/pkg/registry/apis/provisioning/jobs/job_resource_result.go
+++ b/pkg/registry/apis/provisioning/jobs/job_resource_result.go
@@ -3,6 +3,8 @@ package jobs
 import (
 	"errors"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/quotas"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
@@ -69,6 +71,8 @@ func classifyWarning(err error) (string, bool) {
 	switch {
 	case errors.As(err, &quotaExceededErr):
 		return provisioning.ReasonQuotaExceeded, true
+	case apierrors.IsRequestEntityTooLargeError(err):
+		return provisioning.ReasonResourceTooLarge, true
 	case errors.As(err, &validationErr):
 		return provisioning.ReasonResourceInvalid, true
 	case errors.As(err, &ownershipErr):

--- a/pkg/registry/apis/provisioning/jobs/job_resource_result_test.go
+++ b/pkg/registry/apis/provisioning/jobs/job_resource_result_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"testing"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/quotas"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
@@ -169,6 +171,22 @@ func TestNewJobResourceResult_WithErrorAsWarning(t *testing.T) {
 
 	assert.Nil(t, result2.Error(), "Error wrapping ParseError should be stored as warning, not error")
 	assert.NotNil(t, result2.Warning(), "Error wrapping ParseError should be stored as warning")
+}
+
+func TestNewJobResourceResult_WithRequestEntityTooLargeAsWarning(t *testing.T) {
+	tooLarge := apierrors.NewRequestEntityTooLargeError("request body too large: max size 1048576 bytes")
+	wrapped := fmt.Errorf("writing resource from file dashboards/big.json: %w",
+		fmt.Errorf("failed to read file: %w", tooLarge))
+
+	result := NewResourceResult().
+		WithName("big-dashboard").
+		WithAction(repository.FileActionCreated).
+		WithError(wrapped).
+		Build()
+
+	assert.Nil(t, result.Error(), "too-large error should be stored as a warning, not an error")
+	assert.NotNil(t, result.Warning(), "too-large error should be stored as a warning")
+	assert.Equal(t, provisioning.ReasonResourceTooLarge, result.WarningReason())
 }
 
 func TestNewJobResourceResult_WithOwnershipConflictAsWarning(t *testing.T) {

--- a/pkg/tests/apis/provisioning/maxfilesize/files_max_file_size_test.go
+++ b/pkg/tests/apis/provisioning/maxfilesize/files_max_file_size_test.go
@@ -126,9 +126,9 @@ func TestIntegrationProvisioning_MaxFileSize_Write(t *testing.T) {
 
 // TestIntegrationProvisioning_MaxFileSize_Pull exercises the sync-side
 // enforcement: a pull job over a repository that contains a file larger than
-// [provisioning] max_file_size completes with state=error, recording a
-// per-file error for the oversized file. Under-cap files in the same
-// repository are still applied successfully.
+// [provisioning] max_file_size completes with state=warning, recording a
+// per-file warning for the oversized file rather than failing the whole job.
+// Under-cap files in the same repository are still applied successfully.
 func TestIntegrationProvisioning_MaxFileSize_Pull(t *testing.T) {
 	helper := sharedHelper(t)
 
@@ -171,20 +171,22 @@ func TestIntegrationProvisioning_MaxFileSize_Pull(t *testing.T) {
 	jobObj := &provisioning.Job{}
 	require.NoError(t, runtime.DefaultUnstructuredConverter.FromUnstructured(job.Object, jobObj))
 
-	require.Equal(t, provisioning.JobStateError, jobObj.Status.State,
-		"pull should end in error state when a file exceeds max_file_size; job: %+v", jobObj.Status)
-	require.NotEmpty(t, jobObj.Status.Errors,
-		"pull should record a per-file error for the oversized file")
+	require.Equal(t, provisioning.JobStateWarning, jobObj.Status.State,
+		"pull should end in warning state when a file exceeds max_file_size; job: %+v", jobObj.Status)
+	require.Empty(t, jobObj.Status.Errors,
+		"an oversized file must not fail the pull with a hard error")
+	require.NotEmpty(t, jobObj.Status.Warnings,
+		"pull should record a per-file warning for the oversized file")
 
 	var foundOversized bool
-	for _, e := range jobObj.Status.Errors {
-		if strings.Contains(e, "huge.json") && strings.Contains(e, "max allowed") {
+	for _, w := range jobObj.Status.Warnings {
+		if strings.Contains(w, "huge.json") && strings.Contains(w, "max allowed") {
 			foundOversized = true
 			break
 		}
 	}
 	require.True(t, foundOversized,
-		"expected an error mentioning huge.json and the size cap; errors=%v", jobObj.Status.Errors)
+		"expected a warning mentioning huge.json and the size cap; warnings=%v", jobObj.Status.Warnings)
 
 	// Under-cap files in the same repository are still applied — the cap is
 	// enforced per file, not per sync.


### PR DESCRIPTION
**What is this feature?**
A `FileTooLarge` error is a warning instead of an error since it is not fixable by re-running sync. This error also shouldn't contribute to the error budget for a job.

**Why do we need this feature?**
Clearer error handling

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/1298

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
