### PR TITLE
Homepage: Alerts card list item rework

### DIFF
--- a/public/app/features/home/AlertsIncidents/AlertIncidentTabs.tsx
+++ b/public/app/features/home/AlertsIncidents/AlertIncidentTabs.tsx
@@ -41,7 +41,7 @@ function AlertIncidentTabsInner() {
     },
   ];
   return (
-    <Stack direction="column" gap={2}>
+    <Stack direction="column" gap={2} minWidth={0}>
       <Stack justifyContent="space-between" alignItems="center">
         <Text element="h2" variant="h5">
           <Trans i18nKey="home.alerts-incidents.title">Alerts & incidents</Trans>

--- a/public/app/features/home/AlertsIncidents/FiringAlertsCard.test.tsx
+++ b/public/app/features/home/AlertsIncidents/FiringAlertsCard.test.tsx
@@ -120,7 +120,7 @@ describe('FiringAlertsCard', () => {
 
     render(<FiringAlertsCard />);
 
-    expect(await screen.findByRole('link', { name: 'Linked alert' })).toHaveAttribute(
+    expect(await screen.findByRole('link', { name: /^Linked alert/ })).toHaveAttribute(
       'href',
       '/alerting/grafana/abc123/view?orgId=1'
     );
@@ -356,7 +356,7 @@ describe('FiringAlertsCard', () => {
 
       const { user } = render(<FiringAlertsCard />);
 
-      await user.click(await screen.findByRole('link', { name: 'Linked alert' }));
+      await user.click(await screen.findByRole('link', { name: /^Linked alert/ }));
 
       expect(jest.mocked(alertsCardClicked)).toHaveBeenCalledWith({
         action: 'alert_detail',

--- a/public/app/features/home/AlertsIncidents/FiringAlertsCard.tsx
+++ b/public/app/features/home/AlertsIncidents/FiringAlertsCard.tsx
@@ -133,7 +133,9 @@ export function FiringAlertsCardView({
           <ListRow
             isCompact
             title={alert.labels.alertname}
-            subtitle={alert.labels.team ?? '-'}
+            subtitle={alert.labels.team}
+            // when redesignEnabled is false, we want to show the subtitle inline with the title
+            // when its true, we want to show the subtitle below the title
             oneRow={!redesignEnabled}
             prefix={
               redesignEnabled ? (

--- a/public/app/features/home/AlertsIncidents/FiringAlertsCard.tsx
+++ b/public/app/features/home/AlertsIncidents/FiringAlertsCard.tsx
@@ -140,8 +140,9 @@ export function FiringAlertsCardView({
             prefix={
               redesignEnabled ? (
                 <Tooltip content={severityLabel(level)}>
-                  <span aria-label={severityLabel(level)}>
+                  <span>
                     <SeverityBars level={level} />
+                    <span className="sr-only">{severityLabel(level)}</span>
                   </span>
                 </Tooltip>
               ) : (

--- a/public/app/features/home/AlertsIncidents/FiringAlertsCard.tsx
+++ b/public/app/features/home/AlertsIncidents/FiringAlertsCard.tsx
@@ -132,6 +132,7 @@ export function FiringAlertsCardView({
         return (
           <ListRow
             isCompact
+            showDivider={redesignEnabled}
             title={alert.labels.alertname}
             subtitle={alert.labels.team}
             // when redesignEnabled is false, we want to show the subtitle inline with the title

--- a/public/app/features/home/AlertsIncidents/FiringAlertsCard.tsx
+++ b/public/app/features/home/AlertsIncidents/FiringAlertsCard.tsx
@@ -1,12 +1,15 @@
 import { t, Trans } from '@grafana/i18n';
-import { Badge, LinkButton, Stack, Text } from '@grafana/ui';
+import { useFlagGrafanaGrowthHomepage } from '@grafana/runtime/internal';
+import { Badge, LinkButton, Stack, Tooltip } from '@grafana/ui';
+import { SeverityBars } from 'app/features/alerting/unified/triage/scene/filters/SeverityBars';
 import { type SeverityLevel } from 'app/features/alerting/unified/triage/scene/filters/severity';
 import { type AlertmanagerAlert } from 'app/plugins/datasource/alertmanager/types';
+import { ListRow } from 'app/plugins/panel/dashlist/ListRow';
 
 import { alertsCardClicked } from '../analytics/main';
 
 import { CreateAndViewAlertsButtons } from './CreateAndViewAlertsButtons';
-import { SummaryCard, SummaryCardAge, SummaryCardTitle } from './SummaryCard';
+import { SummaryCard, SummaryCardAge } from './SummaryCard';
 import { severityLevelColor } from './severity';
 import { canViewFiringAlerts, useFiringAlerts, type FiringAlertsData } from './useFiringAlerts';
 
@@ -64,6 +67,7 @@ export function FiringAlertsCardView({
   data: FiringAlertsData;
   hideFooterActions?: boolean;
 }) {
+  const redesignEnabled = useFlagGrafanaGrowthHomepage();
   const {
     count,
     criticalCount,
@@ -126,21 +130,26 @@ export function FiringAlertsCardView({
       renderItem={({ alert, level, startedAt }) => {
         const detailHref = alertDetailHref(alert);
         return (
-          <>
-            <Badge text={severityLabel(level)} color={severityLevelColor(level)} />
-            <SummaryCardTitle
-              href={detailHref}
-              onClick={() => alertsCardClicked({ action: 'alert_detail', placement: 'list', severity: level })}
-            >
-              {alert.labels.alertname}
-            </SummaryCardTitle>
-            {alert.labels.team && (
-              <Text color="secondary" variant="bodySmall" truncate>
-                {alert.labels.team}
-              </Text>
-            )}
-            <SummaryCardAge date={startedAt} />
-          </>
+          <ListRow
+            isCompact
+            title={alert.labels.alertname}
+            subtitle={alert.labels.team ?? '-'}
+            oneRow={!redesignEnabled}
+            prefix={
+              redesignEnabled ? (
+                <Tooltip content={severityLabel(level)}>
+                  <span aria-label={severityLabel(level)}>
+                    <SeverityBars level={level} />
+                  </span>
+                </Tooltip>
+              ) : (
+                <Badge text={severityLabel(level)} color={severityLevelColor(level)} />
+              )
+            }
+            trailing={<SummaryCardAge date={startedAt} />}
+            href={detailHref}
+            onClick={() => alertsCardClicked({ action: 'alert_detail', placement: 'list', severity: level })}
+          />
         );
       }}
       emptyAction={

--- a/public/app/features/home/AlertsIncidents/SummaryCard.tsx
+++ b/public/app/features/home/AlertsIncidents/SummaryCard.tsx
@@ -172,10 +172,11 @@ const getStyles = (theme: GrafanaTheme2) => ({
   row: css({
     display: 'flex',
     alignItems: 'center',
-    gap: theme.spacing(1),
-    padding: theme.spacing(0.5, 0),
+    // gap: theme.spacing(1),
+    // padding: theme.spacing(0.5, 0),
     minWidth: 0,
   }),
+  // this moved to ListRow
   title: css({
     overflow: 'hidden',
     textOverflow: 'ellipsis',

--- a/public/app/features/home/AlertsIncidents/SummaryCard.tsx
+++ b/public/app/features/home/AlertsIncidents/SummaryCard.tsx
@@ -169,11 +169,10 @@ const getStyles = (theme: GrafanaTheme2) => ({
     marginRight: theme.spacing(-2),
     paddingRight: theme.spacing(2),
   }),
+  // TODO: this should be safe to remove once incident card also moved to use ListRow component
   row: css({
     display: 'flex',
     alignItems: 'center',
-    // gap: theme.spacing(1),
-    // padding: theme.spacing(0.5, 0),
     minWidth: 0,
   }),
   // this moved to ListRow

--- a/public/app/features/home/AlertsIncidents/SummaryCard.tsx
+++ b/public/app/features/home/AlertsIncidents/SummaryCard.tsx
@@ -175,7 +175,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     alignItems: 'center',
     minWidth: 0,
   }),
-  // this moved to ListRow
+  // TODO: this should be safe to remove once incident card also moved to use ListRow component
   title: css({
     overflow: 'hidden',
     textOverflow: 'ellipsis',

--- a/public/app/features/home/AlertsIncidents/SummaryCard.tsx
+++ b/public/app/features/home/AlertsIncidents/SummaryCard.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { css, cx } from '@emotion/css';
 import { formatDistanceToNowStrict } from 'date-fns/formatDistanceToNowStrict';
 import { type ReactNode } from 'react';
 import Skeleton from 'react-loading-skeleton';
@@ -96,7 +96,7 @@ export function SummaryCard<T>({
         {!loading && !error && items.length > 0 && (
           <ul className={redesignEnabled ? undefined : styles.list}>
             {items.map((item) => (
-              <li key={getItemKey(item)} className={styles.row}>
+              <li key={getItemKey(item)} className={cx(styles.row, !redesignEnabled && styles.rowPadding)}>
                 {renderItem(item)}
               </li>
             ))}
@@ -113,7 +113,9 @@ export function SummaryCard<T>({
   }
 
   return (
-    <HomeSection display="flex" direction="column">
+    // minWidth={0} lets the card shrink within the homepage grid so a long alert name
+    // can't stretch this column wider than its sibling.
+    <HomeSection display="flex" direction="column" minWidth={0}>
       <Stack direction="column" gap={2} grow={1}>
         {content}
       </Stack>
@@ -173,9 +175,11 @@ const getStyles = (theme: GrafanaTheme2) => ({
   row: css({
     display: 'flex',
     alignItems: 'center',
+    minWidth: 0,
+  }),
+  rowPadding: css({
     gap: theme.spacing(1),
     padding: theme.spacing(0.5, 0),
-    minWidth: 0,
   }),
   // TODO: this should be safe to remove once incident card also moved to use ListRow component
   title: css({

--- a/public/app/features/home/AlertsIncidents/SummaryCard.tsx
+++ b/public/app/features/home/AlertsIncidents/SummaryCard.tsx
@@ -173,6 +173,8 @@ const getStyles = (theme: GrafanaTheme2) => ({
   row: css({
     display: 'flex',
     alignItems: 'center',
+    gap: theme.spacing(1),
+    padding: theme.spacing(0.5, 0),
     minWidth: 0,
   }),
   // TODO: this should be safe to remove once incident card also moved to use ListRow component

--- a/public/app/features/home/DashboardTabs/DashboardTabs.tsx
+++ b/public/app/features/home/DashboardTabs/DashboardTabs.tsx
@@ -271,7 +271,7 @@ export function DashboardTabs({ extensionComponents }: Props) {
     </>
   );
   return (
-    <Stack direction="column" gap={2}>
+    <Stack direction="column" gap={2} minWidth={0}>
       {redesignEnabled ? (
         <>
           <Stack justifyContent="space-between">

--- a/public/app/plugins/panel/dashlist/DashListItem.tsx
+++ b/public/app/plugins/panel/dashlist/DashListItem.tsx
@@ -1,11 +1,10 @@
-import { cx } from '@emotion/css';
-
 import { reportInteraction } from '@grafana/runtime';
 import { Card, Icon, Link, Stack, Text, useStyles2 } from '@grafana/ui';
 import { type LocationInfo } from 'app/features/search/service/types';
 import { StarToolbarButton } from 'app/features/stars/StarToolbarButton';
 
 import { type Dashboard } from './DashList';
+import { ListRow } from './ListRow';
 import { getStyles } from './styles';
 
 interface Props {
@@ -46,23 +45,22 @@ export function DashListItem({
   return (
     <>
       {layoutMode === 'list' ? (
-        <div className={cx(css.dashlistLink, isCompact && css.dashlistLinkCompact)}>
-          <Link href={url} onClick={onCardLinkClick}>
-            <Text element="p">{dashboard.name}</Text>
-            {showFolderNames && locationInfo && (
-              <Text color="secondary" variant="bodySmall" element="p">
-                {locationInfo?.name}
-              </Text>
-            )}
-          </Link>
-          <StarToolbarButton
-            title={dashboard.name}
-            group="dashboard.grafana.app"
-            kind="Dashboard"
-            id={dashboard.uid}
-            onStarChange={onStarChange}
-          />
-        </div>
+        <ListRow
+          isCompact={isCompact}
+          title={dashboard.name}
+          subtitle={showFolderNames && locationInfo ? locationInfo.name : undefined}
+          href={url}
+          onClick={onCardLinkClick}
+          trailing={
+            <StarToolbarButton
+              title={dashboard.name}
+              group="dashboard.grafana.app"
+              kind="Dashboard"
+              id={dashboard.uid}
+              onStarChange={onStarChange}
+            />
+          }
+        />
       ) : (
         <Card noMargin className={css.dashlistCardContainer}>
           <Stack justifyContent="space-between" alignItems="start" height="100%">

--- a/public/app/plugins/panel/dashlist/ListRow.test.tsx
+++ b/public/app/plugins/panel/dashlist/ListRow.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from 'test/test-utils';
+
+import { ListRow } from './ListRow';
+
+describe('ListRow', () => {
+  it('renders the title and subtitle', () => {
+    render(<ListRow title="My title" subtitle="My subtitle" />);
+
+    expect(screen.getByText('My title')).toBeInTheDocument();
+    expect(screen.getByText('My subtitle')).toBeInTheDocument();
+  });
+
+  it('does not render a subtitle when it is omitted', () => {
+    render(<ListRow title="My title" />);
+
+    expect(screen.getByText('My title')).toBeInTheDocument();
+    expect(screen.queryByText('My subtitle')).not.toBeInTheDocument();
+  });
+
+  it('renders prefix and trailing content', () => {
+    render(<ListRow title="My title" prefix={<span>prefix-content</span>} trailing={<span>trailing-content</span>} />);
+
+    expect(screen.getByText('prefix-content')).toBeInTheDocument();
+    expect(screen.getByText('trailing-content')).toBeInTheDocument();
+  });
+
+  describe('when an href is provided', () => {
+    it('links to the href and uses the title as the accessible name', () => {
+      render(<ListRow title="My title" subtitle="My subtitle" href="/some/path" />);
+
+      expect(screen.getByRole('link', { name: 'My title' })).toHaveAttribute('href', '/some/path');
+    });
+
+    it('calls onClick when the link is clicked', async () => {
+      const onClick = jest.fn();
+      const { user } = render(<ListRow title="My title" href="/some/path" onClick={onClick} />);
+
+      await user.click(screen.getByRole('link', { name: 'My title' }));
+
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('when no href is provided', () => {
+    it('renders the title as plain text without a link', () => {
+      render(<ListRow title="My title" />);
+
+      expect(screen.getByText('My title')).toBeInTheDocument();
+      expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/public/app/plugins/panel/dashlist/ListRow.test.tsx
+++ b/public/app/plugins/panel/dashlist/ListRow.test.tsx
@@ -25,10 +25,10 @@ describe('ListRow', () => {
   });
 
   describe('when an href is provided', () => {
-    it('links to the href and uses the title as the accessible name', () => {
+    it('links to the href and exposes the title and subtitle as its accessible name', () => {
       render(<ListRow title="My title" subtitle="My subtitle" href="/some/path" />);
 
-      expect(screen.getByRole('link', { name: 'My title' })).toHaveAttribute('href', '/some/path');
+      expect(screen.getByRole('link', { name: 'My title My subtitle' })).toHaveAttribute('href', '/some/path');
     });
 
     it('calls onClick when the link is clicked', async () => {

--- a/public/app/plugins/panel/dashlist/ListRow.tsx
+++ b/public/app/plugins/panel/dashlist/ListRow.tsx
@@ -57,7 +57,7 @@ export function ListRow({ title, subtitle, trailing, isCompact, oneRow, href, on
         )}
       </Stack>
 
-      <div>{trailing}</div>
+      {trailing && <div>{trailing}</div>}
     </div>
   );
 }

--- a/public/app/plugins/panel/dashlist/ListRow.tsx
+++ b/public/app/plugins/panel/dashlist/ListRow.tsx
@@ -20,14 +20,10 @@ interface ListRowProps {
 export function ListRow({ title, subtitle, trailing, isCompact, oneRow, href, onClick, prefix }: ListRowProps) {
   const styles = useStyles2(getStyles);
 
-  const subtitleDisplay = (
-    <>
-      {subtitle && (
-        <Text truncate color="secondary" variant="bodySmall" element="p">
-          {subtitle}
-        </Text>
-      )}
-    </>
+  const subtitleDisplay = subtitle && (
+    <Text truncate color="secondary" variant="bodySmall" element="p">
+      {subtitle}
+    </Text>
   );
   return (
     <div className={cx(styles.row, isCompact && styles.listCompact)}>

--- a/public/app/plugins/panel/dashlist/ListRow.tsx
+++ b/public/app/plugins/panel/dashlist/ListRow.tsx
@@ -45,7 +45,7 @@ export function ListRow({ title, subtitle, trailing, isCompact, oneRow, href, on
 
   return (
     <div className={cx(styles.row, isCompact && styles.listCompact)}>
-      <Stack direction="row" alignItems="center" gap={1} grow={1} minWidth={0}>
+      <Stack direction="row" alignItems="center" gap={1.5} grow={1} minWidth={0}>
         {prefix && <div>{prefix}</div>}
 
         {href ? (

--- a/public/app/plugins/panel/dashlist/ListRow.tsx
+++ b/public/app/plugins/panel/dashlist/ListRow.tsx
@@ -25,7 +25,7 @@ export function ListRow({ title, subtitle, trailing, isCompact, oneRow, href, on
         <div>{prefix}</div>
 
         {href ? (
-          <Link href={href} onClick={onClick} color="primary" className={styles.titleLink}>
+          <Link href={href} onClick={onClick} color="primary" className={styles.titleLink} aria-label={title}>
             <Stack
               direction={oneRow ? 'row' : 'column'}
               gap={oneRow ? 1 : 0}

--- a/public/app/plugins/panel/dashlist/ListRow.tsx
+++ b/public/app/plugins/panel/dashlist/ListRow.tsx
@@ -1,0 +1,79 @@
+import { css, cx } from '@emotion/css';
+import type { ReactNode } from 'react';
+
+import type { GrafanaTheme2 } from '@grafana/data';
+import { TextLink, useStyles2, Text, Stack } from '@grafana/ui';
+
+interface ListRowProps {
+  title: string;
+  subtitle?: string;
+  prefix?: ReactNode;
+  trailing?: ReactNode;
+  // isCompact is used to make the row leaner (less spacing)
+  isCompact?: boolean;
+  // oneRow is used to make the row only one row (subtitle will be inline with title)
+  oneRow?: boolean;
+  href?: string;
+  onClick?: () => void;
+}
+
+export function ListRow({ title, subtitle, trailing, isCompact, oneRow, href, onClick, prefix }: ListRowProps) {
+  const styles = useStyles2(getStyles);
+  return (
+    <div className={cx(styles.row, isCompact && styles.dashlistLinkCompact)}>
+      <Stack direction="row" alignItems="center" gap={1}>
+        <div>{prefix}</div>
+
+        <Stack direction={oneRow ? 'row' : 'column'} gap={oneRow ? 1 : 0} alignItems={oneRow ? 'center' : 'flex-start'}>
+          {/* Title */}
+          {href ? (
+            <TextLink href={href} onClick={onClick} inline={false} color="primary" className={styles.title}>
+              {title}
+            </TextLink>
+          ) : (
+            <Text truncate>{title}</Text>
+          )}
+          {/* Subtitle */}
+          <Text truncate color="secondary" variant="bodySmall">
+            {subtitle ?? '-'}
+          </Text>
+        </Stack>
+      </Stack>
+
+      <div>{trailing}</div>
+    </div>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  row: css({
+    display: 'flex',
+    borderBottom: `1px solid ${theme.colors.border.weak}`,
+    margin: theme.spacing(1),
+    padding: theme.spacing(1),
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    width: '100%',
+
+    a: {
+      flex: 1,
+
+      '&:hover': {
+        '> p': {
+          '&:first-child': {
+            color: theme.colors.text.link,
+            textDecoration: 'underline',
+          },
+        },
+      },
+    },
+  }),
+  dashlistLinkCompact: css({
+    margin: 0,
+  }),
+  title: css({
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  }),
+});

--- a/public/app/plugins/panel/dashlist/ListRow.tsx
+++ b/public/app/plugins/panel/dashlist/ListRow.tsx
@@ -19,8 +19,18 @@ interface ListRowProps {
 
 export function ListRow({ title, subtitle, trailing, isCompact, oneRow, href, onClick, prefix }: ListRowProps) {
   const styles = useStyles2(getStyles);
+
+  const subtitleDisplay = (
+    <>
+      {subtitle && (
+        <Text truncate color="secondary" variant="bodySmall" element="p">
+          {subtitle}
+        </Text>
+      )}
+    </>
+  );
   return (
-    <div className={cx(styles.row, isCompact && styles.dashlistLinkCompact)}>
+    <div className={cx(styles.row, isCompact && styles.listCompact)}>
       <Stack direction="row" alignItems="center" gap={1} grow={1}>
         <div>{prefix}</div>
 
@@ -36,9 +46,7 @@ export function ListRow({ title, subtitle, trailing, isCompact, oneRow, href, on
                 {title}
               </Text>
               {/* Subtitle */}
-              <Text truncate color="secondary" variant="bodySmall" element="p">
-                {subtitle ?? ''}
-              </Text>
+              {subtitleDisplay}
             </Stack>
           </Link>
         ) : (
@@ -50,9 +58,7 @@ export function ListRow({ title, subtitle, trailing, isCompact, oneRow, href, on
           >
             <Text truncate>{title}</Text>
             {/* Subtitle */}
-            <Text truncate color="secondary" variant="bodySmall">
-              {subtitle ?? ''}
-            </Text>
+            {subtitleDisplay}
           </Stack>
         )}
       </Stack>
@@ -72,13 +78,8 @@ const getStyles = (theme: GrafanaTheme2) => ({
     alignItems: 'center',
     width: '100%',
   }),
-  dashlistLinkCompact: css({
+  listCompact: css({
     margin: 0,
-  }),
-  title: css({
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
   }),
   titleLink: css({
     flex: 1,

--- a/public/app/plugins/panel/dashlist/ListRow.tsx
+++ b/public/app/plugins/panel/dashlist/ListRow.tsx
@@ -2,7 +2,7 @@ import { css, cx } from '@emotion/css';
 import type { ReactNode } from 'react';
 
 import type { GrafanaTheme2 } from '@grafana/data';
-import { TextLink, useStyles2, Text, Stack } from '@grafana/ui';
+import { useStyles2, Text, Stack, Link } from '@grafana/ui';
 
 interface ListRowProps {
   title: string;
@@ -21,23 +21,40 @@ export function ListRow({ title, subtitle, trailing, isCompact, oneRow, href, on
   const styles = useStyles2(getStyles);
   return (
     <div className={cx(styles.row, isCompact && styles.dashlistLinkCompact)}>
-      <Stack direction="row" alignItems="center" gap={1}>
+      <Stack direction="row" alignItems="center" gap={1} grow={1}>
         <div>{prefix}</div>
 
-        <Stack direction={oneRow ? 'row' : 'column'} gap={oneRow ? 1 : 0} alignItems={oneRow ? 'center' : 'flex-start'}>
-          {/* Title */}
-          {href ? (
-            <TextLink href={href} onClick={onClick} inline={false} color="primary" className={styles.title}>
-              {title}
-            </TextLink>
-          ) : (
+        {href ? (
+          <Link href={href} onClick={onClick} color="primary" className={styles.titleLink}>
+            <Stack
+              direction={oneRow ? 'row' : 'column'}
+              gap={oneRow ? 1 : 0}
+              alignItems={oneRow ? 'center' : 'flex-start'}
+            >
+              {/* Title */}
+              <Text truncate element="p">
+                {title}
+              </Text>
+              {/* Subtitle */}
+              <Text truncate color="secondary" variant="bodySmall" element="p">
+                {subtitle ?? ''}
+              </Text>
+            </Stack>
+          </Link>
+        ) : (
+          <Stack
+            direction={oneRow ? 'row' : 'column'}
+            gap={oneRow ? 1 : 0}
+            alignItems={oneRow ? 'center' : 'flex-start'}
+            grow={1}
+          >
             <Text truncate>{title}</Text>
-          )}
-          {/* Subtitle */}
-          <Text truncate color="secondary" variant="bodySmall">
-            {subtitle ?? ''}
-          </Text>
-        </Stack>
+            {/* Subtitle */}
+            <Text truncate color="secondary" variant="bodySmall">
+              {subtitle ?? ''}
+            </Text>
+          </Stack>
+        )}
       </Stack>
 
       <div>{trailing}</div>
@@ -62,5 +79,12 @@ const getStyles = (theme: GrafanaTheme2) => ({
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
+  }),
+  titleLink: css({
+    flex: 1,
+    '&:hover > div > p:first-child': {
+      color: theme.colors.text.link,
+      textDecoration: 'underline',
+    },
   }),
 });

--- a/public/app/plugins/panel/dashlist/ListRow.tsx
+++ b/public/app/plugins/panel/dashlist/ListRow.tsx
@@ -15,9 +15,22 @@ interface ListRowProps {
   oneRow?: boolean;
   href?: string;
   onClick?: () => void;
+  // Row divider + padding chrome. Set false for a flush row that matches the
+  // pre-redesign homepage cards. Defaults to true.
+  showDivider?: boolean;
 }
 
-export function ListRow({ title, subtitle, trailing, isCompact, oneRow, href, onClick, prefix }: ListRowProps) {
+export function ListRow({
+  title,
+  subtitle,
+  trailing,
+  isCompact,
+  oneRow,
+  href,
+  onClick,
+  prefix,
+  showDivider = true,
+}: ListRowProps) {
   const styles = useStyles2(getStyles);
 
   const subtitleDisplay = subtitle && (
@@ -44,7 +57,7 @@ export function ListRow({ title, subtitle, trailing, isCompact, oneRow, href, on
   );
 
   return (
-    <div className={cx(styles.row, isCompact && styles.listCompact)}>
+    <div className={cx(styles.row, isCompact && styles.listCompact, !showDivider && styles.flush)}>
       <Stack direction="row" alignItems="center" gap={1.5} grow={1} minWidth={0}>
         {prefix && <div>{prefix}</div>}
 
@@ -75,6 +88,10 @@ const getStyles = (theme: GrafanaTheme2) => ({
   }),
   listCompact: css({
     margin: 0,
+  }),
+  flush: css({
+    borderBottom: 'none',
+    padding: 0,
   }),
   titleLink: css({
     flex: 1,

--- a/public/app/plugins/panel/dashlist/ListRow.tsx
+++ b/public/app/plugins/panel/dashlist/ListRow.tsx
@@ -35,7 +35,7 @@ export function ListRow({ title, subtitle, trailing, isCompact, oneRow, href, on
           )}
           {/* Subtitle */}
           <Text truncate color="secondary" variant="bodySmall">
-            {subtitle ?? '-'}
+            {subtitle ?? ''}
           </Text>
         </Stack>
       </Stack>
@@ -54,19 +54,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
     justifyContent: 'space-between',
     alignItems: 'center',
     width: '100%',
-
-    a: {
-      flex: 1,
-
-      '&:hover': {
-        '> p': {
-          '&:first-child': {
-            color: theme.colors.text.link,
-            textDecoration: 'underline',
-          },
-        },
-      },
-    },
   }),
   dashlistLinkCompact: css({
     margin: 0,

--- a/public/app/plugins/panel/dashlist/ListRow.tsx
+++ b/public/app/plugins/panel/dashlist/ListRow.tsx
@@ -25,37 +25,35 @@ export function ListRow({ title, subtitle, trailing, isCompact, oneRow, href, on
       {subtitle}
     </Text>
   );
+
+  const content = (
+    <Stack
+      direction={oneRow ? 'row' : 'column'}
+      gap={oneRow ? 1 : 0}
+      alignItems={oneRow ? 'center' : 'stretch'}
+      grow={1}
+      minWidth={0}
+    >
+      {/* Title */}
+      <Text truncate element="p">
+        {title}
+      </Text>
+      {/* Subtitle */}
+      {subtitleDisplay}
+    </Stack>
+  );
+
   return (
     <div className={cx(styles.row, isCompact && styles.listCompact)}>
-      <Stack direction="row" alignItems="center" gap={1} grow={1}>
-        <div>{prefix}</div>
+      <Stack direction="row" alignItems="center" gap={1} grow={1} minWidth={0}>
+        {prefix && <div>{prefix}</div>}
 
         {href ? (
-          <Link href={href} onClick={onClick} color="primary" className={styles.titleLink} aria-label={title}>
-            <Stack
-              direction={oneRow ? 'row' : 'column'}
-              gap={oneRow ? 1 : 0}
-              alignItems={oneRow ? 'center' : 'flex-start'}
-            >
-              {/* Title */}
-              <Text truncate element="p">
-                {title}
-              </Text>
-              {/* Subtitle */}
-              {subtitleDisplay}
-            </Stack>
+          <Link href={href} onClick={onClick} color="primary" className={styles.titleLink}>
+            {content}
           </Link>
         ) : (
-          <Stack
-            direction={oneRow ? 'row' : 'column'}
-            gap={oneRow ? 1 : 0}
-            alignItems={oneRow ? 'center' : 'flex-start'}
-            grow={1}
-          >
-            <Text truncate>{title}</Text>
-            {/* Subtitle */}
-            {subtitleDisplay}
-          </Stack>
+          content
         )}
       </Stack>
 
@@ -67,18 +65,20 @@ export function ListRow({ title, subtitle, trailing, isCompact, oneRow, href, on
 const getStyles = (theme: GrafanaTheme2) => ({
   row: css({
     display: 'flex',
+    flex: 1,
+    minWidth: 0,
     borderBottom: `1px solid ${theme.colors.border.weak}`,
     margin: theme.spacing(1),
     padding: theme.spacing(1),
     justifyContent: 'space-between',
     alignItems: 'center',
-    width: '100%',
   }),
   listCompact: css({
     margin: 0,
   }),
   titleLink: css({
     flex: 1,
+    minWidth: 0,
     '&:hover > div > p:first-child': {
       color: theme.colors.text.link,
       textDecoration: 'underline',

--- a/public/app/plugins/panel/dashlist/styles.ts
+++ b/public/app/plugins/panel/dashlist/styles.ts
@@ -10,29 +10,6 @@ export const getStyles = (theme: GrafanaTheme2) => {
   )`;
 
   return {
-    dashlistLink: css({
-      display: 'flex',
-      borderBottom: `1px solid ${theme.colors.border.weak}`,
-      margin: theme.spacing(1),
-      padding: theme.spacing(1),
-      alignItems: 'center',
-
-      a: {
-        flex: 1,
-
-        '&:hover': {
-          '> p': {
-            '&:first-child': {
-              color: theme.colors.text.link,
-              textDecoration: 'underline',
-            },
-          },
-        },
-      },
-    }),
-    dashlistLinkCompact: css({
-      margin: 0,
-    }),
     dashlistCardContainer: css({
       display: 'block',
       height: '100%',


### PR DESCRIPTION
**What is this feature?**

Homepage Alert card list item:
- Now Dashboards card and Alert card shared same `ListRow` component to display item
- Alert card item use severity badge 

| flag on | flag off |
| --- | --- | 
| <img width="551" height="491" alt="image" src="https://github.com/user-attachments/assets/a443e90c-1cfb-4a3f-9cef-126d9ab59b65" /> | <img width="561" height="349" alt="image" src="https://github.com/user-attachments/assets/485f04fe-c10c-4d79-82a2-bdc663534461" /> |


Hover Severity badge to get tooltip:  
<img width="318" height="98" alt="image" src="https://github.com/user-attachments/assets/eaf253cd-2be9-4f7c-a26b-827279a85c26" />. 

Next to dashboard card:  
<img width="1375" height="499" alt="image" src="https://github.com/user-attachments/assets/1a084db4-53ad-4ddf-9165-53ec42eca3f8" />

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/128771

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
