### PR TITLE
SQL Migrations: Support Obsolete table Migration

### DIFF
--- a/pkg/services/sqlstore/migrations/common.go
+++ b/pkg/services/sqlstore/migrations/common.go
@@ -6,14 +6,14 @@ import (
 	. "github.com/grafana/grafana/pkg/services/sqlstore/migrator"
 )
 
-func addDropAllIndicesMigrations(mg *Migrator, versionSuffix string, table Table) {
+func addDropAllIndicesMigrations(mg Migrations, versionSuffix string, table Table) {
 	for _, index := range table.Indices {
 		migrationId := fmt.Sprintf("drop index %s - %s", index.XName(table.Name), versionSuffix)
 		mg.AddMigration(migrationId, NewDropIndexMigration(table, index))
 	}
 }
 
-func addTableIndicesMigrations(mg *Migrator, versionSuffix string, table Table) {
+func addTableIndicesMigrations(mg Migrations, versionSuffix string, table Table) {
 	for _, index := range table.Indices {
 		migrationId := fmt.Sprintf("create index %s - %s", index.XName(table.Name), versionSuffix)
 		mg.AddMigration(migrationId, NewAddIndexMigration(table, index))
@@ -22,12 +22,12 @@ func addTableIndicesMigrations(mg *Migrator, versionSuffix string, table Table) 
 
 // addTableRenameMigration may cause breaking changes.
 // DEPRECATED: It should no longer be used. Kept only for legacy reasons.
-func addTableRenameMigration(mg *Migrator, oldName string, newName string, versionSuffix string) {
+func addTableRenameMigration(mg Migrations, oldName string, newName string, versionSuffix string) {
 	migrationId := fmt.Sprintf("Rename table %s to %s - %s", oldName, newName, versionSuffix)
 	mg.AddMigration(migrationId, NewRenameTableMigration(oldName, newName))
 }
 
-func addTableReplaceMigrations(mg *Migrator, from Table, to Table, migrationVersion int64, tableDataMigration map[string]string) {
+func addTableReplaceMigrations(mg Migrations, from Table, to Table, migrationVersion int64, tableDataMigration map[string]string) {
 	fromV := version(migrationVersion - 1)
 	toV := version(migrationVersion)
 	tmpTableName := to.Name + "_tmp_qwerty"

--- a/pkg/services/sqlstore/migrations/migrations.go
+++ b/pkg/services/sqlstore/migrations/migrations.go
@@ -5,6 +5,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrations/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrations/anonservice"
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrations/externalsession"
+	"github.com/grafana/grafana/pkg/services/sqlstore/migrations/obsolete"
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrations/signingkeys"
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrations/ssosettings"
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrations/ualert"
@@ -180,4 +181,6 @@ func (oss *OSSMigrations) AddMigration(mg *Migrator) {
 	addNatsDiscoveryMigrations(mg)
 
 	ualert.AddAlertRuleStateBigIntMigration(mg)
+
+	mg.AddObsoleteMigration(obsolete.PlaylistMigrations())
 }

--- a/pkg/services/sqlstore/migrations/obsolete/playlists_mig.go
+++ b/pkg/services/sqlstore/migrations/obsolete/playlists_mig.go
@@ -1,8 +1,13 @@
-package testcases
+package obsolete
 
 import . "github.com/grafana/grafana/pkg/services/sqlstore/migrator"
 
-func addPlaylistMigrations(mg *Migrator) {
+func PlaylistMigrations() *ObsoleteMigrations {
+	mg := &ObsoleteMigrations{
+		Table:      "playlist",
+		Migrations: make([]Migration, 0),
+	}
+
 	mg.AddMigration("Drop old table playlist table", NewDropTableMigration("playlist"))
 	mg.AddMigration("Drop old table playlist_item table", NewDropTableMigration("playlist_item"))
 
@@ -41,9 +46,7 @@ func addPlaylistMigrations(mg *Migrator) {
 	mg.AddMigration("Add playlist column updated_at", NewAddColumnMigration(playlistV2(), &Column{
 		Name: "updated_at", Type: DB_BigInt, Nullable: false, Default: "0",
 	}))
-}
 
-func addPlaylistUIDMigration(mg *Migrator) {
 	// Replacing auto-incremented playlistIDs with string UIDs
 	mg.AddMigration("Add UID column to playlist", NewAddColumnMigration(playlistV2(), &Column{
 		Name: "uid", Type: DB_NVarchar, Length: 80, Nullable: false, Default: "0",
@@ -58,6 +61,7 @@ func addPlaylistUIDMigration(mg *Migrator) {
 	mg.AddMigration("Add index for uid in playlist", NewAddIndexMigration(playlistV2(), &Index{
 		Cols: []string{"org_id", "uid"}, Type: UniqueIndex,
 	}))
+	return mg
 }
 
 func playlistV2() Table {

--- a/pkg/services/sqlstore/migrator/migrator.go
+++ b/pkg/services/sqlstore/migrator/migrator.go
@@ -35,11 +35,28 @@ var (
 
 var tracer = otel.Tracer("github.com/grafana/grafana/pkg/services/sqlstore/migrator")
 
+type Migrations interface {
+	AddMigration(id string, m Migration)
+}
+
+// ObsoleteMigrations is a container for migrations that are no longer active
+// These will ONLY run if the corresponding table exists.
+type ObsoleteMigrations struct {
+	Table      string
+	Migrations []Migration
+}
+
+func (o *ObsoleteMigrations) AddMigration(id string, mg Migration) {
+	mg.SetId(id)
+	o.Migrations = append(o.Migrations, mg)
+}
+
 type Migrator struct {
 	DBEngine     *xorm.Engine
 	Dialect      Dialect
 	migrations   []Migration
 	migrationIds map[string]struct{}
+	obsolete     map[string]*ObsoleteMigrations // table name -> obsolete migrations
 	Logger       log.Logger
 	Cfg          *setting.Cfg
 	isLocked     atomic.Bool
@@ -153,6 +170,16 @@ func (mg *Migrator) AddMigration(id string, m Migration) {
 	m.SetId(id)
 	mg.migrations = append(mg.migrations, m)
 	mg.migrationIds[id] = struct{}{}
+}
+
+func (mg *Migrator) AddObsoleteMigration(m *ObsoleteMigrations) {
+	if mg.obsolete == nil {
+		mg.obsolete = make(map[string]*ObsoleteMigrations)
+	}
+	if _, ok := mg.obsolete[m.Table]; ok {
+		panic(fmt.Sprintf("obsolete migration table conflict: %s", m.Table))
+	}
+	mg.obsolete[m.Table] = m
 }
 
 func (mg *Migrator) GetMigrationIDs(excludeNotLogged bool) []string {
@@ -288,6 +315,20 @@ func (mg *Migrator) run(ctx context.Context) (err error) {
 	}
 
 	successLabel := prometheus.Labels{"success": "true"}
+
+	// Add obsolete migrations if necessary
+	for _, o := range mg.obsolete {
+		exists, err := mg.DBEngine.IsTableExist(o.Table)
+		if err != nil {
+			return fmt.Errorf("failed to check table existence: %w", err)
+		}
+		if !exists {
+			continue
+		}
+		for _, m := range o.Migrations {
+			mg.AddMigration(m.Id(), m) // Handle obsolete migrations
+		}
+	}
 
 	migrationsPerformed := 0
 	migrationsSkipped := 0

--- a/pkg/services/sqlstore/migrator/migrator.go
+++ b/pkg/services/sqlstore/migrator/migrator.go
@@ -56,7 +56,7 @@ type Migrator struct {
 	Dialect      Dialect
 	migrations   []Migration
 	migrationIds map[string]struct{}
-	obsolete     map[string]*ObsoleteMigrations // table name -> obsolete migrations
+	obsolete     []*ObsoleteMigrations
 	Logger       log.Logger
 	Cfg          *setting.Cfg
 	isLocked     atomic.Bool
@@ -173,13 +173,7 @@ func (mg *Migrator) AddMigration(id string, m Migration) {
 }
 
 func (mg *Migrator) AddObsoleteMigration(m *ObsoleteMigrations) {
-	if mg.obsolete == nil {
-		mg.obsolete = make(map[string]*ObsoleteMigrations)
-	}
-	if _, ok := mg.obsolete[m.Table]; ok {
-		panic(fmt.Sprintf("obsolete migration table conflict: %s", m.Table))
-	}
-	mg.obsolete[m.Table] = m
+	mg.obsolete = append(mg.obsolete, m)
 }
 
 func (mg *Migrator) GetMigrationIDs(excludeNotLogged bool) []string {
@@ -281,6 +275,25 @@ func (mg *Migrator) RunMigrations(ctx context.Context, isDatabaseLockingEnabled 
 	})
 }
 
+func (mg *Migrator) addObsoleteMigrations() error {
+	for _, o := range mg.obsolete {
+		exists, err := mg.DBEngine.IsTableExist(o.Table)
+		if err != nil {
+			return fmt.Errorf("failed to check obsolete table existence: %w", err)
+		}
+		if !exists {
+			continue
+		}
+		for _, m := range o.Migrations {
+			if _, ok := mg.migrationIds[m.Id()]; ok {
+				continue
+			}
+			mg.AddMigration(m.Id(), m)
+		}
+	}
+	return nil
+}
+
 func (mg *Migrator) run(ctx context.Context) (err error) {
 	ctx, span := tracer.Start(ctx, "Migrator.run")
 	defer span.End()
@@ -316,18 +329,8 @@ func (mg *Migrator) run(ctx context.Context) (err error) {
 
 	successLabel := prometheus.Labels{"success": "true"}
 
-	// Add obsolete migrations if necessary
-	for _, o := range mg.obsolete {
-		exists, err := mg.DBEngine.IsTableExist(o.Table)
-		if err != nil {
-			return fmt.Errorf("failed to check table existence: %w", err)
-		}
-		if !exists {
-			continue
-		}
-		for _, m := range o.Migrations {
-			mg.AddMigration(m.Id(), m) // Handle obsolete migrations
-		}
+	if err := mg.addObsoleteMigrations(); err != nil {
+		return err
 	}
 
 	migrationsPerformed := 0

--- a/pkg/services/sqlstore/migrator/obsolete_test.go
+++ b/pkg/services/sqlstore/migrator/obsolete_test.go
@@ -1,0 +1,131 @@
+package migrator
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	_ "github.com/grafana/grafana/pkg/util/sqlite"
+	"github.com/grafana/grafana/pkg/util/xorm"
+)
+
+func newTestEngine(t *testing.T) *xorm.Engine {
+	t.Helper()
+	// An on-disk database in the test's temp dir keeps each test fully isolated
+	// (shared-cache in-memory DBs otherwise leak state across tests in the suite).
+	engine, err := xorm.NewEngine("sqlite3", filepath.Join(t.TempDir(), "test.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = engine.Close() })
+	return engine
+}
+
+func obsoleteFor(t *testing.T, table, id string, m Migration) *ObsoleteMigrations {
+	t.Helper()
+	o := &ObsoleteMigrations{Table: table, Migrations: make([]Migration, 0)}
+	o.AddMigration(id, m)
+	return o
+}
+
+func TestObsoleteMigrations_SkippedWhenTableAbsent(t *testing.T) {
+	engine := newTestEngine(t)
+
+	mg := NewMigrator(engine, nil)
+	mg.AddCreateMigration()
+	// The obsolete migration would create a marker table; it must not run
+	// because its owning table "ghost" does not exist.
+	mg.AddObsoleteMigration(obsoleteFor(t, "ghost", "create marker for ghost",
+		NewRawSQLMigration("CREATE TABLE ghost_marker (id INTEGER)")))
+
+	require.NoError(t, mg.RunMigrations(context.Background(), false, 0))
+
+	exists, err := engine.IsTableExist("ghost_marker")
+	require.NoError(t, err)
+	require.False(t, exists, "obsolete migration must not run when its table is absent")
+
+	_, registered := mg.migrationIds["create marker for ghost"]
+	require.False(t, registered, "obsolete migration must not be registered when its table is absent")
+}
+
+func TestObsoleteMigrations_RunWhenTableExists(t *testing.T) {
+	engine := newTestEngine(t)
+	_, err := engine.Exec("CREATE TABLE widget (id INTEGER)")
+	require.NoError(t, err)
+
+	mg := NewMigrator(engine, nil)
+	mg.AddCreateMigration()
+	mg.AddObsoleteMigration(obsoleteFor(t, "widget", "drop old widget table",
+		NewDropTableMigration("widget")))
+
+	require.NoError(t, mg.RunMigrations(context.Background(), false, 0))
+
+	exists, err := engine.IsTableExist("widget")
+	require.NoError(t, err)
+	require.False(t, exists, "obsolete migration should run when its table exists")
+
+	_, registered := mg.migrationIds["drop old widget table"]
+	require.True(t, registered)
+}
+
+func TestObsoleteMigrations_RegistrationIsIdempotent(t *testing.T) {
+	engine := newTestEngine(t)
+	_, err := engine.Exec("CREATE TABLE keep (id INTEGER)")
+	require.NoError(t, err)
+
+	mg := NewMigrator(engine, nil)
+	mg.AddObsoleteMigration(obsoleteFor(t, "keep", "noop keep", NewRawSQLMigration("")))
+
+	// A retried run re-invokes addObsoleteMigrations; it must not panic on a
+	// duplicate id nor append the migration twice.
+	require.NoError(t, mg.addObsoleteMigrations())
+	require.NotPanics(t, func() { require.NoError(t, mg.addObsoleteMigrations()) })
+
+	count := 0
+	for _, m := range mg.migrations {
+		if m.Id() == "noop keep" {
+			count++
+		}
+	}
+	require.Equal(t, 1, count, "obsolete migration must be registered exactly once")
+}
+
+func TestObsoleteMigrations_PreservesRegistrationOrder(t *testing.T) {
+	engine := newTestEngine(t)
+	for _, table := range []string{"ta", "tb"} {
+		_, err := engine.Exec("CREATE TABLE " + table + " (id INTEGER)")
+		require.NoError(t, err)
+	}
+
+	mg := NewMigrator(engine, nil)
+	// The run list follows the order the obsolete sets were registered in.
+	mg.AddObsoleteMigration(obsoleteFor(t, "tb", "mig tb", NewRawSQLMigration("")))
+	mg.AddObsoleteMigration(obsoleteFor(t, "ta", "mig ta", NewRawSQLMigration("")))
+
+	require.NoError(t, mg.addObsoleteMigrations())
+	require.Len(t, mg.migrations, 2)
+	require.Equal(t, "mig tb", mg.migrations[0].Id())
+	require.Equal(t, "mig ta", mg.migrations[1].Id())
+}
+
+func TestObsoleteMigrations_DedupesAcrossSets(t *testing.T) {
+	engine := newTestEngine(t)
+	_, err := engine.Exec("CREATE TABLE keep (id INTEGER)")
+	require.NoError(t, err)
+
+	mg := NewMigrator(engine, nil)
+	// Two obsolete sets for the same table sharing a migration id: the id must
+	// only be registered once.
+	mg.AddObsoleteMigration(obsoleteFor(t, "keep", "shared id", NewRawSQLMigration("")))
+	mg.AddObsoleteMigration(obsoleteFor(t, "keep", "shared id", NewRawSQLMigration("")))
+
+	require.NoError(t, mg.addObsoleteMigrations())
+
+	count := 0
+	for _, m := range mg.migrations {
+		if m.Id() == "shared id" {
+			count++
+		}
+	}
+	require.Equal(t, 1, count)
+}

--- a/pkg/storage/unified/migrations/testcases/playlists.go
+++ b/pkg/storage/unified/migrations/testcases/playlists.go
@@ -11,6 +11,7 @@ import (
 	authlib "github.com/grafana/authlib/types"
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/registry/apps/playlist"
+	"github.com/grafana/grafana/pkg/services/sqlstore/migrations/obsolete"
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
 	"github.com/grafana/grafana/pkg/tests/apis"
 	"github.com/grafana/grafana/pkg/util"
@@ -51,8 +52,10 @@ func (tc *playlistsTestCase) Resources() []schema.GroupVersionResource {
 }
 
 func (tc *playlistsTestCase) AddLegacySQLMigrations(mg *migrator.Migrator) {
-	// addPlaylistMigrations(mg)
-	// addPlaylistUIDMigration(mg)
+	old := obsolete.PlaylistMigrations()
+	for _, m := range old.Migrations {
+		mg.AddMigration(m.Id(), m)
+	}
 }
 
 func (tc *playlistsTestCase) Setup(t *testing.T, helper *apis.K8sTestHelper) bool {

--- a/pkg/storage/unified/migrations/testcases/playlists.go
+++ b/pkg/storage/unified/migrations/testcases/playlists.go
@@ -51,8 +51,8 @@ func (tc *playlistsTestCase) Resources() []schema.GroupVersionResource {
 }
 
 func (tc *playlistsTestCase) AddLegacySQLMigrations(mg *migrator.Migrator) {
-	addPlaylistMigrations(mg)
-	addPlaylistUIDMigration(mg)
+	// addPlaylistMigrations(mg)
+	// addPlaylistUIDMigration(mg)
 }
 
 func (tc *playlistsTestCase) Setup(t *testing.T, helper *apis.K8sTestHelper) bool {


### PR DESCRIPTION
**What is this feature?**

Introduces a mechanism for **obsolete migrations** — historical SQL migrations that only run when their target table already exists.

- New `ObsoleteMigrations` container (a table name + its migrations) and a `Migrations` interface implemented by both `*Migrator` and `*ObsoleteMigrations`.
- `Migrator.AddObsoleteMigration` registers a set; `run()` applies each set only if its table currently exists, skipping any migration id that is already registered (idempotent, safe on retried runs).
- The playlist migrations move from the test-only `pkg/storage/unified/migrations/testcases` package into a new reusable `pkg/services/sqlstore/migrations/obsolete` package, and are wired into `OSSMigrations` via `AddObsoleteMigration`.

**Why do we need this feature?**

Since the legacy playlist service was removed (#117655), the playlist SQL migrations were only kept as test fixtures. This gives us a first-class way to retain those historical migrations without running them on fresh installs:

- **New installs** never had the `playlist` table, so the migrations are skipped — we don't create a deprecated table just to manage it.
- **Existing installs** already have the table and these ids in `migration_log`, so they remain no-ops.

This establishes the pattern for cleanly retiring SQL-backed resources that are moving to unified/app storage.

**Who is this feature for?**

Grafana developers / maintainers migrating legacy SQL tables to unified storage. No user-facing behavior change.

**Special notes for your reviewer:**

- Obsolete-table existence is evaluated at the **start** of the migration run, before this run's regular migrations execute — correct for the playlist case.
- Registration is idempotent: a migration id already present is skipped rather than re-added, so a retried `run()` won't panic on a duplicate id, and duplicate ids across obsolete sets are de-duplicated.
- Obsolete sets are applied in registration order.
- Unit tests in `pkg/services/sqlstore/migrator/obsolete_test.go` cover: skipped when table absent, run when table exists, idempotent re-registration, registration-order preservation, and dedup across sets.
