### PR TITLE
Canvas: Component tests

### DIFF
--- a/public/app/features/canvas/elements/button.test.tsx
+++ b/public/app/features/canvas/elements/button.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen } from '@testing-library/react';
+
+import { createTheme } from '@grafana/data';
+import { TextDimensionMode } from '@grafana/schema';
+import { mockThemeContext } from '@grafana/ui';
+import { HttpRequestMethod } from 'app/plugins/panel/canvas/panelcfg.gen';
+
+import { type CanvasElementOptions } from '../element';
+import { Align } from '../types';
+
+import { buttonItem, defaultApiConfig, defaultStyleConfig } from './button';
+import { createMockDimensionContext } from './testHelpers';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const prepareData = buttonItem.prepareData!;
+const ButtonDisplay = buttonItem.display;
+
+describe('buttonItem', () => {
+  let restoreThemeContext: () => void;
+
+  beforeAll(() => {
+    restoreThemeContext = mockThemeContext(createTheme());
+  });
+
+  afterAll(() => {
+    restoreThemeContext();
+  });
+
+  describe('exported defaults', () => {
+    it('defaultApiConfig defaults to a POST JSON request', () => {
+      expect(defaultApiConfig.method).toBe(HttpRequestMethod.POST);
+      expect(defaultApiConfig.contentType).toBe('application/json');
+    });
+
+    it('defaultStyleConfig defaults to the primary variant', () => {
+      expect(defaultStyleConfig.variant).toBe('primary');
+    });
+  });
+
+  describe('prepareData', () => {
+    it('fills api method/contentType from defaults and resolves text', () => {
+      const ctx = createMockDimensionContext({ text: 'Go' });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const options: CanvasElementOptions<any> = {
+        name: 'el',
+        type: 'button',
+        config: {
+          text: { mode: TextDimensionMode.Fixed, fixed: 'Go' },
+          align: Align.Center,
+          api: { endpoint: 'http://example.com' },
+        },
+      };
+
+      const data = prepareData(ctx, options);
+
+      expect(data.text).toBe('Go');
+      expect(data.api?.method).toBe(defaultApiConfig.method);
+      expect(data.api?.contentType).toBe(defaultApiConfig.contentType);
+      expect(data.style).toEqual(defaultStyleConfig);
+    });
+
+    it('leaves api undefined and falls back to the default style when config is empty', () => {
+      const ctx = createMockDimensionContext();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const data = prepareData(ctx, { name: 'el', type: 'button', config: undefined } as CanvasElementOptions<any>);
+
+      expect(data.api).toBeUndefined();
+      expect(data.style).toEqual(defaultStyleConfig);
+      expect(data.align).toBe(Align.Center);
+      expect(data.size).toBe(14);
+    });
+  });
+
+  describe('getNewOptions', () => {
+    it('produces defaults with the api and style configs', () => {
+      const options = buttonItem.getNewOptions();
+
+      expect(options.config?.api).toEqual(defaultApiConfig);
+      expect(options.config?.style).toEqual(defaultStyleConfig);
+      expect(options.config?.align).toBe(Align.Center);
+      expect(options.background?.color?.fixed).toBe('transparent');
+      expect(options.placement?.rotation).toBe(0);
+    });
+  });
+
+  describe('display', () => {
+    it('renders a button showing the text', () => {
+      render(<ButtonDisplay config={{ align: Align.Center }} data={{ text: 'Click me', align: Align.Center }} />);
+      expect(screen.getByRole('button')).toHaveTextContent('Click me');
+    });
+  });
+});

--- a/public/app/features/canvas/elements/cloud.test.tsx
+++ b/public/app/features/canvas/elements/cloud.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from '@testing-library/react';
+
+import { ResourceDimensionMode, TextDimensionMode } from '@grafana/schema';
+
+import { type CanvasElementOptions, defaultBgColor } from '../element';
+import { Align, type CanvasElementConfig, type CanvasElementData, VAlign } from '../types';
+
+import { cloudItem } from './cloud';
+import { createMockDimensionContext } from './testHelpers';
+
+const CloudDisplay = cloudItem.display;
+
+const baseData: CanvasElementData = { align: Align.Center, valign: VAlign.Middle };
+
+describe('cloudItem', () => {
+  describe('prepareData', () => {
+    it('resolves text, color, background, border and image', () => {
+      const ctx = createMockDimensionContext({ text: 'cloud', color: '#111111', resource: 'bg.png' });
+      const options: CanvasElementOptions<CanvasElementConfig> = {
+        name: 'el',
+        type: 'cloud',
+        config: {
+          text: { mode: TextDimensionMode.Fixed, fixed: 'cloud' },
+          align: Align.Center,
+          valign: VAlign.Middle,
+          color: { fixed: '#111111' },
+        },
+        background: { color: { fixed: '#222222' }, image: { mode: ResourceDimensionMode.Fixed, fixed: 'bg.png' } },
+        border: { color: { fixed: '#333333' }, width: 3 },
+      };
+
+      const data = cloudItem.prepareData!(ctx, options);
+
+      expect(data.text).toBe('cloud');
+      expect(data.color).toBe('#111111');
+      expect(data.backgroundColor).toBe('#222222');
+      expect(data.borderColor).toBe('#333333');
+      expect(data.borderWidth).toBe(3);
+      expect(data.backgroundImage).toBe('bg.png');
+    });
+
+    it('falls back to defaults when background and border are absent', () => {
+      const ctx = createMockDimensionContext();
+      const data = cloudItem.prepareData!(ctx, { name: 'el', type: 'cloud', config: undefined });
+
+      expect(data.backgroundColor).toBe(defaultBgColor);
+      expect(data.borderColor).toBe(defaultBgColor);
+      expect(data.borderWidth).toBe(0);
+      expect(data.backgroundImage).toBeUndefined();
+    });
+  });
+
+  describe('getNewOptions', () => {
+    it('produces defaults with empty links and zero rotation', () => {
+      const options = cloudItem.getNewOptions();
+
+      expect(options.background?.color?.fixed).toBe(defaultBgColor);
+      expect(options.placement?.rotation).toBe(0);
+      expect(options.links).toEqual([]);
+    });
+  });
+
+  describe('display', () => {
+    it('renders the text inside a path svg', () => {
+      const { container } = render(
+        <CloudDisplay config={{ align: Align.Center, valign: VAlign.Middle }} data={{ ...baseData, text: 'cloud' }} />
+      );
+      expect(screen.getByText('cloud')).toBeInTheDocument();
+      expect(container.querySelector('path')).toBeInTheDocument();
+    });
+  });
+});

--- a/public/app/features/canvas/elements/droneFront.test.tsx
+++ b/public/app/features/canvas/elements/droneFront.test.tsx
@@ -1,0 +1,66 @@
+import { render } from '@testing-library/react';
+
+import { createTheme } from '@grafana/data';
+import { mockThemeContext } from '@grafana/ui';
+
+import { type CanvasElementOptions } from '../element';
+
+import { droneFrontItem } from './droneFront';
+import { createMockDimensionContext } from './testHelpers';
+
+const DroneFrontDisplay = droneFrontItem.display;
+
+describe('droneFrontItem', () => {
+  let restoreThemeContext: () => void;
+
+  beforeAll(() => {
+    restoreThemeContext = mockThemeContext(createTheme());
+  });
+
+  afterAll(() => {
+    restoreThemeContext();
+  });
+
+  describe('prepareData', () => {
+    it('resolves the roll angle from the scalar dimension', () => {
+      const ctx = createMockDimensionContext({ scalar: 30 });
+      const data = droneFrontItem.prepareData!(ctx, {
+        name: 'el',
+        type: 'droneFront',
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        config: { rollAngle: { fixed: 30, min: 0, max: 360 } } as any,
+      });
+
+      expect(data.rollAngle).toBe(30);
+      expect(ctx.getScalar).toHaveBeenCalledTimes(1);
+    });
+
+    it('defaults the roll angle to 0 when absent', () => {
+      const ctx = createMockDimensionContext();
+      const data = droneFrontItem.prepareData!(ctx, {
+        name: 'el',
+        type: 'droneFront',
+        config: undefined,
+      } as CanvasElementOptions);
+
+      expect(data.rollAngle).toBe(0);
+    });
+  });
+
+  describe('getNewOptions', () => {
+    it('produces defaults with empty links and zero rotation', () => {
+      const options = droneFrontItem.getNewOptions();
+
+      expect(options.background?.color?.fixed).toBe('transparent');
+      expect(options.placement?.rotation).toBe(0);
+      expect(options.links).toEqual([]);
+    });
+  });
+
+  describe('display', () => {
+    it('renders the drone front svg', () => {
+      const { container } = render(<DroneFrontDisplay config={{}} data={{ rollAngle: 0 }} />);
+      expect(container.querySelector('svg')).toBeInTheDocument();
+    });
+  });
+});

--- a/public/app/features/canvas/elements/droneSide.test.tsx
+++ b/public/app/features/canvas/elements/droneSide.test.tsx
@@ -1,0 +1,66 @@
+import { render } from '@testing-library/react';
+
+import { createTheme } from '@grafana/data';
+import { mockThemeContext } from '@grafana/ui';
+
+import { type CanvasElementOptions } from '../element';
+
+import { droneSideItem } from './droneSide';
+import { createMockDimensionContext } from './testHelpers';
+
+const DroneSideDisplay = droneSideItem.display;
+
+describe('droneSideItem', () => {
+  let restoreThemeContext: () => void;
+
+  beforeAll(() => {
+    restoreThemeContext = mockThemeContext(createTheme());
+  });
+
+  afterAll(() => {
+    restoreThemeContext();
+  });
+
+  describe('prepareData', () => {
+    it('resolves the pitch angle from the scalar dimension', () => {
+      const ctx = createMockDimensionContext({ scalar: 15 });
+      const data = droneSideItem.prepareData!(ctx, {
+        name: 'el',
+        type: 'droneSide',
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        config: { pitchAngle: { fixed: 15, min: 0, max: 360 } } as any,
+      });
+
+      expect(data.pitchAngle).toBe(15);
+      expect(ctx.getScalar).toHaveBeenCalledTimes(1);
+    });
+
+    it('defaults the pitch angle to 0 when absent', () => {
+      const ctx = createMockDimensionContext();
+      const data = droneSideItem.prepareData!(ctx, {
+        name: 'el',
+        type: 'droneSide',
+        config: undefined,
+      } as CanvasElementOptions);
+
+      expect(data.pitchAngle).toBe(0);
+    });
+  });
+
+  describe('getNewOptions', () => {
+    it('produces defaults with empty links and zero rotation', () => {
+      const options = droneSideItem.getNewOptions();
+
+      expect(options.background?.color?.fixed).toBe('transparent');
+      expect(options.placement?.rotation).toBe(0);
+      expect(options.links).toEqual([]);
+    });
+  });
+
+  describe('display', () => {
+    it('renders the drone side svg', () => {
+      const { container } = render(<DroneSideDisplay config={{}} data={{ pitchAngle: 0 }} />);
+      expect(container.querySelector('svg')).toBeInTheDocument();
+    });
+  });
+});

--- a/public/app/features/canvas/elements/droneTop.test.tsx
+++ b/public/app/features/canvas/elements/droneTop.test.tsx
@@ -1,0 +1,89 @@
+import { render } from '@testing-library/react';
+
+import { createTheme } from '@grafana/data';
+import { mockThemeContext } from '@grafana/ui';
+
+import { type CanvasElementOptions } from '../element';
+
+import { droneTopItem } from './droneTop';
+import { createMockDimensionContext } from './testHelpers';
+
+const DroneTopDisplay = droneTopItem.display;
+
+const ROTOR_KEYS = ['bRightRotorRPM', 'bLeftRotorRPM', 'fRightRotorRPM', 'fLeftRotorRPM', 'yawAngle'] as const;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const scalarConfig = (): any =>
+  ROTOR_KEYS.reduce((acc, key) => ({ ...acc, [key]: { fixed: 7, min: 0, max: 100 } }), {});
+
+describe('droneTopItem', () => {
+  let restoreThemeContext: () => void;
+
+  beforeAll(() => {
+    restoreThemeContext = mockThemeContext(createTheme());
+  });
+
+  afterAll(() => {
+    restoreThemeContext();
+  });
+
+  describe('prepareData', () => {
+    it('resolves all five scalars', () => {
+      const ctx = createMockDimensionContext({ scalar: 7 });
+      const data = droneTopItem.prepareData!(ctx, { name: 'el', type: 'droneTop', config: scalarConfig() });
+
+      for (const key of ROTOR_KEYS) {
+        expect(data[key]).toBe(7);
+      }
+      expect(ctx.getScalar).toHaveBeenCalledTimes(5);
+    });
+
+    it('defaults every scalar to 0 when config is empty', () => {
+      const ctx = createMockDimensionContext();
+      const data = droneTopItem.prepareData!(ctx, {
+        name: 'el',
+        type: 'droneTop',
+        config: undefined,
+      } as CanvasElementOptions);
+
+      for (const key of ROTOR_KEYS) {
+        expect(data[key]).toBe(0);
+      }
+      expect(ctx.getScalar).not.toHaveBeenCalled();
+    });
+
+    it('resolves each scalar independently', () => {
+      const ctx = createMockDimensionContext({ scalar: 9 });
+      const data = droneTopItem.prepareData!(ctx, {
+        name: 'el',
+        type: 'droneTop',
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        config: { yawAngle: { fixed: 9, min: 0, max: 360 } } as any,
+      });
+
+      expect(data.yawAngle).toBe(9);
+      expect(data.bRightRotorRPM).toBe(0);
+      expect(data.bLeftRotorRPM).toBe(0);
+      expect(data.fRightRotorRPM).toBe(0);
+      expect(data.fLeftRotorRPM).toBe(0);
+      expect(ctx.getScalar).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getNewOptions', () => {
+    it('produces valid options with empty links despite omitting a placement block', () => {
+      const options = droneTopItem.getNewOptions();
+
+      expect(options.background?.color?.fixed).toBe('transparent');
+      expect(options.links).toEqual([]);
+      expect(options.placement).toBeUndefined();
+    });
+  });
+
+  describe('display', () => {
+    it('renders the drone top svg', () => {
+      const { container } = render(<DroneTopDisplay config={{}} data={{ yawAngle: 0 }} />);
+      expect(container.querySelector('svg')).toBeInTheDocument();
+    });
+  });
+});

--- a/public/app/features/canvas/elements/ellipse.test.tsx
+++ b/public/app/features/canvas/elements/ellipse.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from '@testing-library/react';
+
+import { ResourceDimensionMode, TextDimensionMode } from '@grafana/schema';
+
+import { type CanvasElementOptions, defaultBgColor } from '../element';
+import { Align, type CanvasElementConfig, type CanvasElementData, VAlign } from '../types';
+
+import { ellipseItem } from './ellipse';
+import { createMockDimensionContext } from './testHelpers';
+
+const EllipseDisplay = ellipseItem.display;
+
+const baseData: CanvasElementData = { align: Align.Center, valign: VAlign.Middle };
+
+describe('ellipseItem', () => {
+  describe('prepareData', () => {
+    it('resolves text, color, background, border and image', () => {
+      const ctx = createMockDimensionContext({ text: 'oval', color: '#111111', resource: 'bg.png' });
+      const options: CanvasElementOptions<CanvasElementConfig> = {
+        name: 'el',
+        type: 'ellipse',
+        config: {
+          text: { mode: TextDimensionMode.Fixed, fixed: 'oval' },
+          align: Align.Center,
+          valign: VAlign.Middle,
+          color: { fixed: '#111111' },
+        },
+        background: { color: { fixed: '#222222' }, image: { mode: ResourceDimensionMode.Fixed, fixed: 'bg.png' } },
+        border: { color: { fixed: '#333333' }, width: 4 },
+      };
+
+      const data = ellipseItem.prepareData!(ctx, options);
+
+      expect(data.text).toBe('oval');
+      expect(data.color).toBe('#111111');
+      // background color, border color and background image each resolve from their own config
+      expect(data.backgroundColor).toBe('#222222');
+      expect(data.borderColor).toBe('#333333');
+      expect(data.borderWidth).toBe(4);
+      expect(data.backgroundImage).toBe('bg.png');
+    });
+
+    it('falls back to defaults when background and border are absent', () => {
+      const ctx = createMockDimensionContext();
+      const data = ellipseItem.prepareData!(ctx, { name: 'el', type: 'ellipse', config: undefined });
+
+      expect(data.backgroundColor).toBe(defaultBgColor);
+      expect(data.borderColor).toBe(defaultBgColor);
+      expect(data.borderWidth).toBe(0);
+      expect(data.backgroundImage).toBeUndefined();
+    });
+  });
+
+  describe('getNewOptions', () => {
+    it('produces defaults with empty links and zero rotation', () => {
+      const options = ellipseItem.getNewOptions();
+
+      expect(options.background?.color?.fixed).toBe(defaultBgColor);
+      expect(options.placement?.rotation).toBe(0);
+      expect(options.links).toEqual([]);
+    });
+  });
+
+  describe('display', () => {
+    it('renders the text inside an ellipse svg', () => {
+      const { container } = render(
+        <EllipseDisplay config={{ align: Align.Center, valign: VAlign.Middle }} data={{ ...baseData, text: 'oval' }} />
+      );
+      expect(screen.getByText('oval')).toBeInTheDocument();
+      expect(container.querySelector('ellipse')).toBeInTheDocument();
+    });
+  });
+});

--- a/public/app/features/canvas/elements/icon.test.tsx
+++ b/public/app/features/canvas/elements/icon.test.tsx
@@ -1,0 +1,90 @@
+import { render } from '@testing-library/react';
+
+import { ResourceDimensionMode } from '@grafana/schema';
+
+import { type CanvasElementOptions, defaultBgColor } from '../element';
+
+import { iconItem, type IconConfig } from './icon';
+import { createMockDimensionContext } from './testHelpers';
+
+const IconDisplay = iconItem.display;
+
+describe('iconItem', () => {
+  describe('prepareData', () => {
+    it('resolves the resource path and defaults the fill color', () => {
+      const ctx = createMockDimensionContext({ resource: 'my-icon.svg' });
+      const options: CanvasElementOptions<IconConfig> = {
+        name: 'el',
+        type: 'icon',
+        config: { path: { mode: ResourceDimensionMode.Fixed, fixed: 'my-icon.svg' } },
+      };
+
+      const data = iconItem.prepareData!(ctx, options);
+
+      expect(data.path).toBe('my-icon.svg');
+      expect(data.fill).toBe(defaultBgColor);
+      expect(ctx.getResource).toHaveBeenCalledTimes(1);
+    });
+
+    it('resolves the fill color when config.fill is present', () => {
+      const ctx = createMockDimensionContext({ color: '#abcabc', resource: 'my-icon.svg' });
+      const data = iconItem.prepareData!(ctx, {
+        name: 'el',
+        type: 'icon',
+        config: { path: { mode: ResourceDimensionMode.Fixed, fixed: 'my-icon.svg' }, fill: { fixed: '#abcabc' } },
+      });
+
+      expect(data.fill).toBe('#abcabc');
+    });
+
+    it('falls back to question-circle.svg when the path is missing', () => {
+      const ctx = createMockDimensionContext();
+      const data = iconItem.prepareData!(ctx, { name: 'el', type: 'icon', config: undefined });
+
+      expect(data.path).toContain('question-circle.svg');
+      expect(ctx.getResource).not.toHaveBeenCalled();
+    });
+
+    it('sets stroke only when stroke.width > 0', () => {
+      const ctx = createMockDimensionContext({ color: '#ff0000' });
+      const withStroke = iconItem.prepareData!(ctx, {
+        name: 'el',
+        type: 'icon',
+        config: { stroke: { color: { fixed: '#ff0000' }, width: 3 } },
+      });
+      expect(withStroke.stroke).toBe(3);
+      expect(withStroke.strokeColor).toBe('#ff0000');
+
+      const noStroke = iconItem.prepareData!(ctx, {
+        name: 'el',
+        type: 'icon',
+        config: { stroke: { color: { fixed: '#ff0000' }, width: 0 } },
+      });
+      expect(noStroke.stroke).toBeUndefined();
+      expect(noStroke.strokeColor).toBeUndefined();
+    });
+  });
+
+  describe('getNewOptions', () => {
+    it('produces defaults with empty links and zero rotation', () => {
+      const options = iconItem.getNewOptions();
+
+      expect(options.config?.path?.fixed).toContain('question-circle.svg');
+      expect(options.background?.color?.fixed).toBe('transparent');
+      expect(options.placement?.rotation).toBe(0);
+      expect(options.links).toEqual([]);
+    });
+  });
+
+  describe('display', () => {
+    it('renders an svg for a resolved path', () => {
+      const { container } = render(<IconDisplay config={{}} data={{ path: 'my-icon.svg', fill: defaultBgColor }} />);
+      expect(container.querySelector('svg')).toBeInTheDocument();
+    });
+
+    it('returns null when there is no path', () => {
+      const { container } = render(<IconDisplay config={{}} data={{ path: '', fill: defaultBgColor }} />);
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+});

--- a/public/app/features/canvas/elements/metricValue.test.tsx
+++ b/public/app/features/canvas/elements/metricValue.test.tsx
@@ -1,0 +1,169 @@
+import { render, screen } from '@testing-library/react';
+import { type ReactNode } from 'react';
+import { of } from 'rxjs';
+
+import { createTheme, EventBusSrv, toDataFrame } from '@grafana/data';
+import { TextDimensionMode } from '@grafana/schema';
+import { mockThemeContext, PanelContextProvider } from '@grafana/ui';
+
+import { type CanvasElementOptions } from '../element';
+import { Align, type TextConfig, type TextData, VAlign } from '../types';
+
+import { metricValueItem } from './metricValue';
+import { createMockDimensionContext } from './testHelpers';
+
+const MetricValueDisplay = metricValueItem.display;
+
+/** Renders the display component inside a PanelContextProvider so usePanelContext() does not throw. */
+const renderDisplay = (
+  props: { config: TextConfig; data?: TextData; isSelected?: boolean },
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  instanceState?: any
+) => {
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <PanelContextProvider value={{ eventsScope: 'test', eventBus: new EventBusSrv(), instanceState }}>
+      {children}
+    </PanelContextProvider>
+  );
+  return render(<MetricValueDisplay {...props} />, { wrapper: Wrapper });
+};
+
+const baseConfig: TextConfig = {
+  align: Align.Center,
+  valign: VAlign.Middle,
+};
+
+const baseData: TextData = {
+  align: Align.Center,
+  valign: VAlign.Middle,
+};
+
+describe('metricValueItem', () => {
+  let restoreThemeContext: () => void;
+
+  beforeAll(() => {
+    restoreThemeContext = mockThemeContext(createTheme());
+  });
+
+  afterAll(() => {
+    restoreThemeContext();
+  });
+
+  describe('prepareData', () => {
+    it('resolves text from the dimension context and applies alignment', () => {
+      const ctx = createMockDimensionContext({ text: 'resolved' });
+      const options: CanvasElementOptions<TextConfig> = {
+        name: 'el',
+        type: 'metric-value',
+        config: {
+          text: { mode: TextDimensionMode.Fixed, fixed: 'resolved' },
+          align: Align.Left,
+          valign: VAlign.Top,
+          size: 24,
+        },
+      };
+
+      const data = metricValueItem.prepareData!(ctx, options);
+
+      expect(data.text).toBe('resolved');
+      expect(data.align).toBe(Align.Left);
+      expect(data.valign).toBe(VAlign.Top);
+      expect(data.size).toBe(24);
+      expect(ctx.getText).toHaveBeenCalledTimes(1);
+    });
+
+    it('defaults align/valign and skips the color getter when config is empty', () => {
+      const ctx = createMockDimensionContext();
+      const options: CanvasElementOptions<TextConfig> = {
+        name: 'el',
+        type: 'metric-value',
+        config: undefined,
+      };
+
+      const data = metricValueItem.prepareData!(ctx, options);
+
+      expect(data.text).toBe('');
+      expect(data.align).toBe(Align.Center);
+      expect(data.valign).toBe(VAlign.Middle);
+      expect(data.color).toBeUndefined();
+      expect(ctx.getText).not.toHaveBeenCalled();
+      expect(ctx.getColor).not.toHaveBeenCalled();
+    });
+
+    it('resolves color only when config.color is present', () => {
+      const ctx = createMockDimensionContext({ color: '#abcdef' });
+      const options: CanvasElementOptions<TextConfig> = {
+        name: 'el',
+        type: 'metric-value',
+        config: { align: Align.Center, valign: VAlign.Middle, color: { fixed: '#abcdef' } },
+      };
+
+      const data = metricValueItem.prepareData!(ctx, options);
+
+      expect(data.color).toBe('#abcdef');
+      expect(ctx.getColor).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getNewOptions', () => {
+    it('produces defaults with empty links and zero rotation', () => {
+      const options = metricValueItem.getNewOptions();
+
+      expect(options.config?.align).toBe(Align.Center);
+      expect(options.config?.valign).toBe(VAlign.Middle);
+      expect(options.config?.size).toBe(20);
+      expect(options.background?.color?.fixed).toBeDefined();
+      expect(options.placement?.top).toBe(100);
+      expect(options.placement?.left).toBe(100);
+      expect(options.placement?.rotation).toBe(0);
+      expect(options.links).toEqual([]);
+    });
+
+    it('honors placement overrides', () => {
+      const options = metricValueItem.getNewOptions({
+        name: 'el',
+        type: 'metric-value',
+        placement: { top: 5, left: 7, rotation: 90 },
+      });
+
+      expect(options.placement?.top).toBe(5);
+      expect(options.placement?.left).toBe(7);
+      expect(options.placement?.rotation).toBe(90);
+    });
+  });
+
+  describe('display', () => {
+    it('renders the resolved value', () => {
+      renderDisplay({ config: baseConfig, data: { ...baseData, text: '42' } });
+      expect(screen.getByText('42')).toBeInTheDocument();
+    });
+
+    it('shows the placeholder when there is no value and no panel data', () => {
+      renderDisplay({ config: baseConfig, data: { ...baseData, text: '' } });
+      expect(screen.getByText('Double click to set field')).toBeInTheDocument();
+    });
+
+    it('shows "No data" when the field exists but resolves to nothing', () => {
+      const series = [toDataFrame({ fields: [{ name: 'a', values: [1] }] })];
+      const config: TextConfig = { ...baseConfig, text: { mode: TextDimensionMode.Field, fixed: '', field: 'a' } };
+      renderDisplay(
+        { config, data: { ...baseData, text: '' } },
+        { scene: { data: { series }, editModeEnabled: of(false) } }
+      );
+      expect(screen.getByText('No data')).toBeInTheDocument();
+    });
+
+    it('shows "Field not found" when the configured field is missing from the data', () => {
+      const series = [toDataFrame({ fields: [{ name: 'a', values: [1] }] })];
+      const config: TextConfig = {
+        ...baseConfig,
+        text: { mode: TextDimensionMode.Field, fixed: '', field: 'missing' },
+      };
+      renderDisplay(
+        { config, data: { ...baseData, text: '' } },
+        { scene: { data: { series }, editModeEnabled: of(false) } }
+      );
+      expect(screen.getByText('Field not found')).toBeInTheDocument();
+    });
+  });
+});

--- a/public/app/features/canvas/elements/notFound.test.tsx
+++ b/public/app/features/canvas/elements/notFound.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react';
+
+import { createTheme } from '@grafana/data';
+import { mockThemeContext } from '@grafana/ui';
+
+import { notFoundItem } from './notFound';
+
+const NotFoundDisplay = notFoundItem.display;
+
+describe('notFoundItem', () => {
+  let restoreThemeContext: () => void;
+
+  beforeAll(() => {
+    restoreThemeContext = mockThemeContext(createTheme());
+  });
+
+  afterAll(() => {
+    restoreThemeContext();
+  });
+
+  describe('getNewOptions', () => {
+    it('produces an empty config', () => {
+      expect(notFoundItem.getNewOptions().config).toEqual({});
+    });
+  });
+
+  describe('display', () => {
+    it('renders the not-found message and the serialized config', () => {
+      const config = { type: 'mystery-element', name: 'broken' };
+      const { container } = render(<NotFoundDisplay config={config} />);
+
+      expect(screen.getByText(/Not found/)).toBeInTheDocument();
+      // the unknown element's config is dumped as JSON so users can see what failed to resolve
+      expect(container.textContent).toContain('mystery-element');
+    });
+  });
+});

--- a/public/app/features/canvas/elements/parallelogram.test.tsx
+++ b/public/app/features/canvas/elements/parallelogram.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from '@testing-library/react';
+
+import { ResourceDimensionMode, TextDimensionMode } from '@grafana/schema';
+
+import { type CanvasElementOptions, defaultBgColor } from '../element';
+import { Align, type CanvasElementConfig, type CanvasElementData, VAlign } from '../types';
+
+import { parallelogramItem } from './parallelogram';
+import { createMockDimensionContext } from './testHelpers';
+
+const ParallelogramDisplay = parallelogramItem.display;
+
+const baseData: CanvasElementData = { align: Align.Center, valign: VAlign.Middle };
+
+describe('parallelogramItem', () => {
+  describe('prepareData', () => {
+    it('resolves text, color, background, border and image', () => {
+      const ctx = createMockDimensionContext({ text: 'para', color: '#111111', resource: 'bg.png' });
+      const options: CanvasElementOptions<CanvasElementConfig> = {
+        name: 'el',
+        type: 'parallelogram',
+        config: {
+          text: { mode: TextDimensionMode.Fixed, fixed: 'para' },
+          align: Align.Center,
+          valign: VAlign.Middle,
+          color: { fixed: '#111111' },
+        },
+        background: { color: { fixed: '#222222' }, image: { mode: ResourceDimensionMode.Fixed, fixed: 'bg.png' } },
+        border: { color: { fixed: '#333333' }, width: 5 },
+      };
+
+      const data = parallelogramItem.prepareData!(ctx, options);
+
+      expect(data.text).toBe('para');
+      expect(data.color).toBe('#111111');
+      expect(data.backgroundColor).toBe('#222222');
+      expect(data.borderColor).toBe('#333333');
+      expect(data.borderWidth).toBe(5);
+      expect(data.backgroundImage).toBe('bg.png');
+    });
+
+    it('falls back to defaults when background and border are absent', () => {
+      const ctx = createMockDimensionContext();
+      const data = parallelogramItem.prepareData!(ctx, { name: 'el', type: 'parallelogram', config: undefined });
+
+      expect(data.backgroundColor).toBe(defaultBgColor);
+      expect(data.borderColor).toBe(defaultBgColor);
+      expect(data.borderWidth).toBe(0);
+      expect(data.backgroundImage).toBeUndefined();
+    });
+  });
+
+  describe('getNewOptions', () => {
+    it('produces defaults with empty links and zero rotation', () => {
+      const options = parallelogramItem.getNewOptions();
+
+      expect(options.background?.color?.fixed).toBe(defaultBgColor);
+      expect(options.placement?.rotation).toBe(0);
+      expect(options.links).toEqual([]);
+    });
+  });
+
+  describe('display', () => {
+    it('renders the text inside a polygon svg', () => {
+      const { container } = render(
+        <ParallelogramDisplay
+          config={{ align: Align.Center, valign: VAlign.Middle }}
+          data={{ ...baseData, text: 'para' }}
+        />
+      );
+      expect(screen.getByText('para')).toBeInTheDocument();
+      expect(container.querySelector('polygon')).toBeInTheDocument();
+    });
+  });
+});

--- a/public/app/features/canvas/elements/rectangle.test.tsx
+++ b/public/app/features/canvas/elements/rectangle.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from '@testing-library/react';
+
+import { createTheme } from '@grafana/data';
+import { TextDimensionMode } from '@grafana/schema';
+import { mockThemeContext } from '@grafana/ui';
+
+import { type CanvasElementOptions } from '../element';
+import { Align, type TextConfig, type TextData, VAlign } from '../types';
+
+import { rectangleItem } from './rectangle';
+import { createMockDimensionContext } from './testHelpers';
+
+const RectangleDisplay = rectangleItem.display;
+
+const baseData: TextData = { align: Align.Center, valign: VAlign.Middle };
+
+describe('rectangleItem', () => {
+  let restoreThemeContext: () => void;
+
+  beforeAll(() => {
+    restoreThemeContext = mockThemeContext(createTheme());
+  });
+
+  afterAll(() => {
+    restoreThemeContext();
+  });
+
+  describe('prepareData', () => {
+    it('resolves text and color', () => {
+      const ctx = createMockDimensionContext({ text: 'rect', color: '#00ff00' });
+      const options: CanvasElementOptions<TextConfig> = {
+        name: 'el',
+        type: 'rectangle',
+        config: {
+          text: { mode: TextDimensionMode.Fixed, fixed: 'rect' },
+          align: Align.Left,
+          valign: VAlign.Top,
+          color: { fixed: '#00ff00' },
+        },
+      };
+
+      const data = rectangleItem.prepareData!(ctx, options);
+
+      expect(data.text).toBe('rect');
+      expect(data.color).toBe('#00ff00');
+      expect(data.align).toBe(Align.Left);
+      expect(data.valign).toBe(VAlign.Top);
+    });
+
+    it('defaults alignment and skips getters when config is empty', () => {
+      const ctx = createMockDimensionContext();
+      const data = rectangleItem.prepareData!(ctx, { name: 'el', type: 'rectangle', config: undefined });
+
+      expect(data.text).toBe('');
+      expect(data.align).toBe(Align.Center);
+      expect(data.valign).toBe(VAlign.Middle);
+      expect(data.color).toBeUndefined();
+      expect(ctx.getText).not.toHaveBeenCalled();
+      expect(ctx.getColor).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getNewOptions', () => {
+    it('produces defaults with a background color and empty links', () => {
+      const options = rectangleItem.getNewOptions();
+
+      expect(options.config?.align).toBe(Align.Center);
+      expect(options.config?.valign).toBe(VAlign.Middle);
+      expect(options.background?.color?.fixed).toBeDefined();
+      expect(options.links).toEqual([]);
+    });
+  });
+
+  describe('display', () => {
+    it('renders the text', () => {
+      render(
+        <RectangleDisplay config={{ align: Align.Center, valign: VAlign.Middle }} data={{ ...baseData, text: 'box' }} />
+      );
+      expect(screen.getByText('box')).toBeInTheDocument();
+    });
+  });
+});

--- a/public/app/features/canvas/elements/server/server.test.tsx
+++ b/public/app/features/canvas/elements/server/server.test.tsx
@@ -1,0 +1,90 @@
+import { render } from '@testing-library/react';
+
+import { createTheme } from '@grafana/data';
+import { mockThemeContext } from '@grafana/ui';
+
+import { type CanvasElementOptions } from '../../element';
+import { createMockDimensionContext } from '../testHelpers';
+
+import { serverItem } from './server';
+
+const ServerDisplay = serverItem.display;
+
+// ServerType/ServerConfig/ServerData are not exported; the display only reads data.type, so
+// loose typing keyed by the string value is enough for these render smoke tests.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const serverData = (type: string): any => ({ type });
+
+describe('serverItem', () => {
+  let restoreThemeContext: () => void;
+
+  beforeAll(() => {
+    restoreThemeContext = mockThemeContext(createTheme());
+  });
+
+  afterAll(() => {
+    restoreThemeContext();
+  });
+
+  describe('prepareData', () => {
+    it('applies defaults when config is empty', () => {
+      const ctx = createMockDimensionContext();
+      const data = serverItem.prepareData!(ctx, {
+        name: 'el',
+        type: 'server',
+        config: undefined,
+      } as CanvasElementOptions);
+
+      expect(data.blinkRate).toBe(0);
+      expect(data.statusColor).toBe('transparent');
+      expect(data.bulbColor).toBe('green');
+      expect(data.type).toBe('Single');
+      expect(ctx.getScalar).not.toHaveBeenCalled();
+      expect(ctx.getColor).not.toHaveBeenCalled();
+    });
+
+    it('resolves blink rate and colors from the dimension context', () => {
+      const ctx = createMockDimensionContext({ scalar: 5, color: '#ff0000' });
+      const data = serverItem.prepareData!(ctx, {
+        name: 'el',
+        type: 'server',
+        config: {
+          type: 'Stack' as never,
+          blinkRate: { fixed: 5, min: 0, max: 100 },
+          statusColor: { fixed: '#ff0000' },
+          bulbColor: { fixed: '#ff0000' },
+        },
+      });
+
+      expect(data.blinkRate).toBe(5);
+      expect(data.statusColor).toBe('#ff0000');
+      expect(data.bulbColor).toBe('#ff0000');
+      expect(data.type).toBe('Stack');
+    });
+  });
+
+  describe('getNewOptions', () => {
+    it('produces defaults with the Single type, empty links and zero rotation', () => {
+      const options = serverItem.getNewOptions();
+
+      expect(options.config?.type).toBe('Single');
+      expect(options.background?.color?.fixed).toBe('transparent');
+      expect(options.placement?.rotation).toBe(0);
+      expect(options.links).toEqual([]);
+    });
+  });
+
+  describe('display', () => {
+    it.each(['Single', 'Stack', 'Database', 'Terminal'])('renders the %s sub-component', (type) => {
+      const { container } = render(<ServerDisplay config={serverData(type)} data={serverData(type)} />);
+      const svg = container.querySelector('svg');
+      expect(svg).toBeInTheDocument();
+      expect(svg?.querySelector('path')).toBeInTheDocument();
+    });
+
+    it('renders nothing when data is undefined', () => {
+      const { container } = render(<ServerDisplay config={serverData('Single')} data={undefined} />);
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+});

--- a/public/app/features/canvas/elements/testHelpers.ts
+++ b/public/app/features/canvas/elements/testHelpers.ts
@@ -1,0 +1,47 @@
+import { ConnectionDirection } from '@grafana/schema';
+
+import { type DimensionContext } from '../../dimensions/context';
+import { type DimensionSupplier } from '../../dimensions/types';
+
+/** Values each dimension getter resolves to. Override per-test to exercise a branch. */
+export interface MockDimensionValues {
+  color: string;
+  text: string;
+  scalar: number;
+  scale: number;
+  resource: string;
+  direction: ConnectionDirection;
+}
+
+const defaultValues: MockDimensionValues = {
+  color: '#ffffff',
+  text: 'hello',
+  scalar: 1,
+  scale: 1,
+  resource: 'img.svg',
+  direction: ConnectionDirection.Forward,
+};
+
+function makeSupplier<T>(value: T): DimensionSupplier<T> {
+  return { value: () => value, get: () => value };
+}
+
+/**
+ * Builds a fake `DimensionContext` whose getters are jest mocks returning fixed-value suppliers.
+ * Element `prepareData` functions only ever call `.value()`, so a single resolved value per
+ * dimension is enough; the mocks also let tests assert which getters were invoked.
+ */
+export function createMockDimensionContext(overrides: Partial<MockDimensionValues> = {}): DimensionContext {
+  const values = { ...defaultValues, ...overrides };
+
+  return {
+    // Echo the configured fixed color so tests can distinguish text/background/border colors.
+    getColor: jest.fn((config) => makeSupplier(config?.fixed ?? values.color)),
+    getScale: jest.fn(() => makeSupplier(values.scale)),
+    getScalar: jest.fn(() => makeSupplier(values.scalar)),
+    getText: jest.fn(() => makeSupplier(values.text)),
+    getResource: jest.fn(() => makeSupplier(values.resource)),
+    getDirection: jest.fn(() => makeSupplier(values.direction)),
+    getPanelData: jest.fn(() => undefined),
+  };
+}

--- a/public/app/features/canvas/elements/text.test.tsx
+++ b/public/app/features/canvas/elements/text.test.tsx
@@ -1,0 +1,128 @@
+import { render, screen } from '@testing-library/react';
+import { type ReactNode } from 'react';
+
+import { createTheme, EventBusSrv } from '@grafana/data';
+import { TextDimensionMode } from '@grafana/schema';
+import { mockThemeContext, PanelContextProvider } from '@grafana/ui';
+
+import { type CanvasElementOptions } from '../element';
+import { Align, type TextConfig, type TextData, VAlign } from '../types';
+
+import { createMockDimensionContext } from './testHelpers';
+import { textItem } from './text';
+
+const TextDisplay = textItem.display;
+
+const renderDisplay = (props: { config: TextConfig; data?: TextData; isSelected?: boolean }) => {
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <PanelContextProvider value={{ eventsScope: 'test', eventBus: new EventBusSrv() }}>{children}</PanelContextProvider>
+  );
+  return render(<TextDisplay {...props} />, { wrapper: Wrapper });
+};
+
+const baseConfig: TextConfig = {
+  align: Align.Center,
+  valign: VAlign.Middle,
+};
+
+const baseData: TextData = {
+  align: Align.Center,
+  valign: VAlign.Middle,
+};
+
+describe('textItem', () => {
+  let restoreThemeContext: () => void;
+
+  beforeAll(() => {
+    restoreThemeContext = mockThemeContext(createTheme());
+  });
+
+  afterAll(() => {
+    restoreThemeContext();
+  });
+
+  describe('prepareData', () => {
+    it('resolves text and applies configured alignment', () => {
+      const ctx = createMockDimensionContext({ text: 'resolved' });
+      const options: CanvasElementOptions<TextConfig> = {
+        name: 'el',
+        type: 'text',
+        config: {
+          text: { mode: TextDimensionMode.Fixed, fixed: 'resolved' },
+          align: Align.Right,
+          valign: VAlign.Bottom,
+          size: 12,
+        },
+      };
+
+      const data = textItem.prepareData!(ctx, options);
+
+      expect(data.text).toBe('resolved');
+      expect(data.align).toBe(Align.Right);
+      expect(data.valign).toBe(VAlign.Bottom);
+      expect(ctx.getText).toHaveBeenCalledTimes(1);
+    });
+
+    it('defaults align/valign and skips getters when config is empty', () => {
+      const ctx = createMockDimensionContext();
+      const data = textItem.prepareData!(ctx, { name: 'el', type: 'text', config: undefined });
+
+      expect(data.text).toBe('');
+      expect(data.align).toBe(Align.Center);
+      expect(data.valign).toBe(VAlign.Middle);
+      expect(data.color).toBeUndefined();
+      expect(ctx.getText).not.toHaveBeenCalled();
+      expect(ctx.getColor).not.toHaveBeenCalled();
+    });
+
+    it('resolves color when config.color is present', () => {
+      const ctx = createMockDimensionContext({ color: '#123456' });
+      const data = textItem.prepareData!(ctx, {
+        name: 'el',
+        type: 'text',
+        config: { align: Align.Center, valign: VAlign.Middle, color: { fixed: '#123456' } },
+      });
+
+      expect(data.color).toBe('#123456');
+      expect(ctx.getColor).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getNewOptions', () => {
+    it('produces defaults with empty links and zero rotation', () => {
+      const options = textItem.getNewOptions();
+
+      expect(options.config?.align).toBe(Align.Center);
+      expect(options.config?.valign).toBe(VAlign.Middle);
+      expect(options.config?.size).toBe(16);
+      expect(options.placement?.width).toBe(100);
+      expect(options.placement?.height).toBe(100);
+      expect(options.placement?.rotation).toBe(0);
+      expect(options.links).toEqual([]);
+    });
+
+    it('honors placement overrides', () => {
+      const options = textItem.getNewOptions({
+        name: 'el',
+        type: 'text',
+        placement: { width: 20, height: 30, rotation: 45 },
+      });
+
+      expect(options.placement?.width).toBe(20);
+      expect(options.placement?.height).toBe(30);
+      expect(options.placement?.rotation).toBe(45);
+    });
+  });
+
+  describe('display', () => {
+    it('renders the resolved text value', () => {
+      renderDisplay({ config: baseConfig, data: { ...baseData, text: 'Hello' } });
+      expect(screen.getByText('Hello')).toBeInTheDocument();
+    });
+
+    it('renders the placeholder when there is no text', () => {
+      renderDisplay({ config: baseConfig, data: { ...baseData, text: '' } });
+      expect(screen.getByText('Double click to set text')).toBeInTheDocument();
+    });
+  });
+});

--- a/public/app/features/canvas/elements/triangle.test.tsx
+++ b/public/app/features/canvas/elements/triangle.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from '@testing-library/react';
+
+import { ResourceDimensionMode, TextDimensionMode } from '@grafana/schema';
+
+import { type CanvasElementOptions, defaultBgColor } from '../element';
+import { Align, type CanvasElementConfig, type CanvasElementData, VAlign } from '../types';
+
+import { createMockDimensionContext } from './testHelpers';
+import { triangleItem } from './triangle';
+
+const TriangleDisplay = triangleItem.display;
+
+const baseData: CanvasElementData = { align: Align.Center, valign: VAlign.Middle };
+
+describe('triangleItem', () => {
+  describe('prepareData', () => {
+    it('resolves text, color, background, border and image', () => {
+      const ctx = createMockDimensionContext({ text: 'tri', color: '#111111', resource: 'bg.png' });
+      const options: CanvasElementOptions<CanvasElementConfig> = {
+        name: 'el',
+        type: 'triangle',
+        config: {
+          text: { mode: TextDimensionMode.Fixed, fixed: 'tri' },
+          align: Align.Center,
+          valign: VAlign.Middle,
+          color: { fixed: '#111111' },
+        },
+        background: { color: { fixed: '#222222' }, image: { mode: ResourceDimensionMode.Fixed, fixed: 'bg.png' } },
+        border: { color: { fixed: '#333333' }, width: 2 },
+      };
+
+      const data = triangleItem.prepareData!(ctx, options);
+
+      expect(data.text).toBe('tri');
+      expect(data.color).toBe('#111111');
+      expect(data.backgroundColor).toBe('#222222');
+      expect(data.borderColor).toBe('#333333');
+      expect(data.borderWidth).toBe(2);
+      expect(data.backgroundImage).toBe('bg.png');
+    });
+
+    it('falls back to defaults when background and border are absent', () => {
+      const ctx = createMockDimensionContext();
+      const data = triangleItem.prepareData!(ctx, { name: 'el', type: 'triangle', config: undefined });
+
+      expect(data.backgroundColor).toBe(defaultBgColor);
+      expect(data.borderColor).toBe(defaultBgColor);
+      expect(data.borderWidth).toBe(0);
+      expect(data.backgroundImage).toBeUndefined();
+    });
+  });
+
+  describe('getNewOptions', () => {
+    it('produces defaults with empty links and zero rotation', () => {
+      const options = triangleItem.getNewOptions();
+
+      expect(options.background?.color?.fixed).toBe(defaultBgColor);
+      expect(options.placement?.rotation).toBe(0);
+      expect(options.links).toEqual([]);
+    });
+  });
+
+  describe('display', () => {
+    it('renders the text inside a polygon svg', () => {
+      const { container } = render(
+        <TriangleDisplay config={{ align: Align.Center, valign: VAlign.Middle }} data={{ ...baseData, text: 'tri' }} />
+      );
+      expect(screen.getByText('tri')).toBeInTheDocument();
+      expect(container.querySelector('polygon')).toBeInTheDocument();
+    });
+  });
+});

--- a/public/app/features/canvas/elements/windTurbine.test.tsx
+++ b/public/app/features/canvas/elements/windTurbine.test.tsx
@@ -1,0 +1,68 @@
+import { render } from '@testing-library/react';
+
+import { createTheme } from '@grafana/data';
+import { mockThemeContext } from '@grafana/ui';
+
+import { type CanvasElementOptions } from '../element';
+
+import { createMockDimensionContext } from './testHelpers';
+import { windTurbineItem } from './windTurbine';
+
+const WindTurbineDisplay = windTurbineItem.display;
+
+describe('windTurbineItem', () => {
+  let restoreThemeContext: () => void;
+
+  beforeAll(() => {
+    restoreThemeContext = mockThemeContext(createTheme());
+  });
+
+  afterAll(() => {
+    restoreThemeContext();
+  });
+
+  describe('prepareData', () => {
+    it('resolves rpm from the scalar dimension', () => {
+      const ctx = createMockDimensionContext({ scalar: 42 });
+      const data = windTurbineItem.prepareData!(ctx, {
+        name: 'el',
+        type: 'windTurbine',
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        config: { rpm: { fixed: 42, min: 0, max: 100 } } as any,
+      });
+
+      expect(data.rpm).toBe(42);
+      expect(ctx.getScalar).toHaveBeenCalledTimes(1);
+    });
+
+    it('defaults rpm to 0 when absent', () => {
+      const ctx = createMockDimensionContext();
+      const data = windTurbineItem.prepareData!(ctx, {
+        name: 'el',
+        type: 'windTurbine',
+        config: undefined,
+      } as CanvasElementOptions);
+
+      expect(data.rpm).toBe(0);
+      expect(ctx.getScalar).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getNewOptions', () => {
+    it('produces defaults with empty links and zero rotation', () => {
+      const options = windTurbineItem.getNewOptions();
+
+      expect(options.background?.color?.fixed).toBe('transparent');
+      expect(options.placement?.rotation).toBe(0);
+      expect(options.links).toEqual([]);
+    });
+  });
+
+  describe('display', () => {
+    it('renders the turbine svg', () => {
+      const { container } = render(<WindTurbineDisplay config={{}} data={{ rpm: 10 }} />);
+      expect(container.querySelector('svg')).toBeInTheDocument();
+      expect(container.querySelector('[id="blade"]')).toBeInTheDocument();
+    });
+  });
+});

--- a/public/app/features/canvas/registry.test.ts
+++ b/public/app/features/canvas/registry.test.ts
@@ -1,0 +1,84 @@
+import { buttonItem } from './elements/button';
+import { cloudItem } from './elements/cloud';
+import { droneFrontItem } from './elements/droneFront';
+import { droneSideItem } from './elements/droneSide';
+import { droneTopItem } from './elements/droneTop';
+import { ellipseItem } from './elements/ellipse';
+import { iconItem } from './elements/icon';
+import { metricValueItem } from './elements/metricValue';
+import { notFoundItem } from './elements/notFound';
+import { parallelogramItem } from './elements/parallelogram';
+import { rectangleItem } from './elements/rectangle';
+import { serverItem } from './elements/server/server';
+import { textItem } from './elements/text';
+import { triangleItem } from './elements/triangle';
+import { windTurbineItem } from './elements/windTurbine';
+import {
+  advancedElementItems,
+  canvasElementRegistry,
+  DEFAULT_CANVAS_ELEMENT_CONFIG,
+  defaultElementItems,
+} from './registry';
+
+describe('canvasElementRegistry', () => {
+  it('registers all 14 built-in elements with unique ids', () => {
+    const items = canvasElementRegistry.list();
+    expect(items).toHaveLength(14);
+
+    const ids = items.map((item) => item.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('every registered item exposes the required fields', () => {
+    for (const item of canvasElementRegistry.list()) {
+      expect(item.id).toBeTruthy();
+      expect(item.name).toBeTruthy();
+      expect(item.display).toBeDefined();
+      expect(typeof item.getNewOptions).toBe('function');
+    }
+  });
+
+  it('lists the 9 default elements in order', () => {
+    expect(defaultElementItems).toEqual([
+      metricValueItem,
+      textItem,
+      ellipseItem,
+      rectangleItem,
+      iconItem,
+      serverItem,
+      triangleItem,
+      cloudItem,
+      parallelogramItem,
+    ]);
+  });
+
+  it('lists the 5 advanced elements in order', () => {
+    expect(advancedElementItems).toEqual([buttonItem, windTurbineItem, droneTopItem, droneFrontItem, droneSideItem]);
+  });
+
+  it('registers the default items followed by the advanced items', () => {
+    expect(canvasElementRegistry.list()).toEqual([...defaultElementItems, ...advancedElementItems]);
+  });
+
+  it('does not register the notFound item', () => {
+    const ids = canvasElementRegistry.list().map((item) => item.id);
+    expect(ids).not.toContain(notFoundItem.id);
+    expect(() => canvasElementRegistry.getIfExists(notFoundItem.id)).not.toThrow();
+    expect(canvasElementRegistry.getIfExists(notFoundItem.id)).toBeUndefined();
+  });
+
+  describe('DEFAULT_CANVAS_ELEMENT_CONFIG', () => {
+    it('defaults to the metric value element', () => {
+      expect(DEFAULT_CANVAS_ELEMENT_CONFIG.type).toBe(metricValueItem.id);
+      expect(DEFAULT_CANVAS_ELEMENT_CONFIG.name).toBe('Element 1');
+    });
+
+    it('merges the metric value default size into placement', () => {
+      expect(DEFAULT_CANVAS_ELEMENT_CONFIG.placement).toMatchObject({
+        width: metricValueItem.defaultSize!.width,
+        height: metricValueItem.defaultSize!.height,
+        rotation: 0,
+      });
+    });
+  });
+});


### PR DESCRIPTION
**What is this feature?**

Quick and dirty canvas tests.

**Special notes for your reviewer:**
Smoke tests for one of dataviz's biggest buckets of untested code. 

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
