### PR TITLE
TimeComparison: Add testing to verify color labels

### DIFF
--- a/packages/grafana-data/src/dataframe/utils.test.ts
+++ b/packages/grafana-data/src/dataframe/utils.test.ts
@@ -178,6 +178,76 @@ describe('alignTimeRangeCompareData', () => {
     expect(frame.fields[0].config.custom?.existingProperty).toBe('existingValue');
     expect(frame.fields[0].config.custom?.timeCompare?.diffMs).toBe(ONE_WEEK_MS);
   });
+
+  // #126189 acceptance criteria — "compare is dashed, current is solid".
+  // The compare frame is the only one passed through alignTimeRangeCompareData; the current-period frame
+  // never gets a lineStyle, so leaving the current frame's config untouched is what keeps it solid.
+  describe('dashed styling for comparison series (#126189)', () => {
+    const DASH_LINE_STYLE = { fill: 'dash', dash: [1, 5, 4, 5] };
+
+    it.each([FieldType.number, FieldType.boolean, FieldType.enum])(
+      'applies the dashed lineStyle to %s value fields',
+      (fieldType) => {
+        const frame = toDataFrame({
+          fields: [
+            { name: 'time', type: FieldType.time, values: [1000, 2000] },
+            { name: 'value', type: fieldType, values: [10, 20] },
+          ],
+        });
+
+        alignTimeRangeCompareData(frame, ONE_DAY_MS, createTheme());
+
+        expect(frame.fields[1].config.custom?.lineStyle).toEqual(DASH_LINE_STYLE);
+      }
+    );
+
+    it('does not add a lineStyle to the time field', () => {
+      const frame = toDataFrame({
+        fields: [
+          { name: 'time', type: FieldType.time, values: [1000, 2000] },
+          { name: 'value', type: FieldType.number, values: [10, 20] },
+        ],
+      });
+
+      alignTimeRangeCompareData(frame, ONE_DAY_MS, createTheme());
+
+      expect(frame.fields[0].config.custom?.lineStyle).toBeUndefined();
+    });
+
+    it('does not add a lineStyle to string fields', () => {
+      const frame = toDataFrame({
+        fields: [
+          { name: 'time', type: FieldType.time, values: [1000, 2000] },
+          { name: 'label', type: FieldType.string, values: ['a', 'b'] },
+          { name: 'value', type: FieldType.number, values: [10, 20] },
+        ],
+      });
+
+      alignTimeRangeCompareData(frame, ONE_DAY_MS, createTheme());
+
+      expect(frame.fields[1].config.custom?.lineStyle).toBeUndefined();
+      expect(frame.fields[2].config.custom?.lineStyle).toEqual(DASH_LINE_STYLE);
+    });
+
+    it('preserves an existing lineStyle-adjacent custom config while adding the dash', () => {
+      const frame = toDataFrame({
+        fields: [
+          { name: 'time', type: FieldType.time, values: [1000, 2000] },
+          {
+            name: 'value',
+            type: FieldType.number,
+            values: [10, 20],
+            config: { custom: { lineWidth: 2 } },
+          },
+        ],
+      });
+
+      alignTimeRangeCompareData(frame, ONE_DAY_MS, createTheme());
+
+      expect(frame.fields[1].config.custom?.lineWidth).toBe(2);
+      expect(frame.fields[1].config.custom?.lineStyle).toEqual(DASH_LINE_STYLE);
+    });
+  });
 });
 
 describe('shouldAlignTimeCompare', () => {

--- a/packages/grafana-data/src/field/fieldState.test.ts
+++ b/packages/grafana-data/src/field/fieldState.test.ts
@@ -60,6 +60,76 @@ describe('getFieldDisplayName', () => {
     expect(getFieldDisplayName(frame.fields[3], frame)).toBe('Value 3 (comparison)');
   });
 
+  // #126189 acceptance criteria — the legend/tooltip should name a compare series
+  // "{series name} (comparison)". These guard the label-derived and no-suffix paths.
+  it('Should add the (comparison) suffix to label-derived names', () => {
+    // A single label across the frame renders as just the label value (e.g. "a"), matching how the
+    // non-comparison legend would name it — the compare series only differs by the suffix.
+    const frame = toDataFrame({
+      meta: { timeCompare: { diffMs: -86400000, isTimeShiftQuery: true } },
+      fields: [
+        { name: TIME_SERIES_TIME_FIELD_NAME, values: [1, 2, 3], type: FieldType.time },
+        { name: TIME_SERIES_VALUE_FIELD_NAME, values: [1, 2, 3], type: FieldType.number, labels: { pod: 'a' } },
+      ],
+    });
+
+    expect(getFieldDisplayName(frame.fields[1], frame, [frame])).toBe('a (comparison)');
+  });
+
+  it('Should add the (comparison) suffix to multi-label names', () => {
+    const frame = toDataFrame({
+      meta: { timeCompare: { diffMs: -86400000, isTimeShiftQuery: true } },
+      fields: [
+        { name: TIME_SERIES_TIME_FIELD_NAME, values: [1, 2, 3], type: FieldType.time },
+        {
+          name: TIME_SERIES_VALUE_FIELD_NAME,
+          values: [1, 2, 3],
+          type: FieldType.number,
+          labels: { pod: 'a', container: 'x' },
+        },
+      ],
+    });
+
+    expect(getFieldDisplayName(frame.fields[1], frame, [frame])).toBe('{container="x", pod="a"} (comparison)');
+  });
+
+  it('Should not add the (comparison) suffix for non-comparison frames', () => {
+    const frame = toDataFrame({
+      fields: [
+        { name: TIME_SERIES_TIME_FIELD_NAME, values: [1, 2, 3], type: FieldType.time },
+        { name: 'Value 1', values: [1, 2, 3], type: FieldType.number, config: { displayName: 'ServerA' } },
+        { name: TIME_SERIES_VALUE_FIELD_NAME, values: [1, 2, 3], type: FieldType.number, labels: { pod: 'a' } },
+      ],
+    });
+
+    expect(getFieldDisplayName(frame.fields[1], frame)).toBe('ServerA');
+    expect(getFieldDisplayName(frame.fields[2], frame, [frame])).not.toContain('(comparison)');
+  });
+
+  it('Should pair a current series and its compare series by name plus a suffix', () => {
+    const currentFrame = toDataFrame({
+      refId: 'A',
+      fields: [
+        { name: TIME_SERIES_TIME_FIELD_NAME, values: [1, 2, 3], type: FieldType.time },
+        { name: 'Value', values: [1, 2, 3], type: FieldType.number, config: { displayName: 'ServerA' } },
+      ],
+    });
+    const compareFrame = toDataFrame({
+      refId: 'A-compare',
+      meta: { timeCompare: { diffMs: -86400000, isTimeShiftQuery: true } },
+      fields: [
+        { name: TIME_SERIES_TIME_FIELD_NAME, values: [1, 2, 3], type: FieldType.time },
+        { name: 'Value', values: [1, 2, 3], type: FieldType.number, config: { displayName: 'ServerA' } },
+      ],
+    });
+
+    const currentName = getFieldDisplayName(currentFrame.fields[1], currentFrame);
+    const compareName = getFieldDisplayName(compareFrame.fields[1], compareFrame);
+
+    expect(currentName).toBe('ServerA');
+    expect(compareName).toBe(`${currentName} (comparison)`);
+  });
+
   it('Should remove common labels', () => {
     const frame = toDataFrame({
       fields: [

--- a/public/app/plugins/panel/timeseries/TimeSeriesTooltip.test.tsx
+++ b/public/app/plugins/panel/timeseries/TimeSeriesTooltip.test.tsx
@@ -1,0 +1,120 @@
+import { render, screen } from '@testing-library/react';
+
+import { type DataFrame, type DisplayProcessor, FieldColorModeId, FieldType, createDataFrame } from '@grafana/data';
+import { SortOrder, TooltipDisplayMode } from '@grafana/schema';
+
+import { TimeSeriesTooltip } from './TimeSeriesTooltip';
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+const ALIGNED_TIME = 2 * ONE_DAY_MS;
+
+// Deterministic display processors so the header/content text is predictable across timezones — the real
+// time processor would format ALIGNED_TIME into a locale/zone-dependent date string.
+const timeDisplay: DisplayProcessor = (v) => ({ text: `T${v}`, numeric: Number(v) });
+const numberDisplay: DisplayProcessor = (v) => ({ text: `${v}`, numeric: Number(v), color: 'red' });
+
+const DASH_LINE_STYLE = { fill: 'dash', dash: [1, 5, 4, 5] };
+
+interface ValueFieldOpts {
+  displayName: string;
+  dashed?: boolean;
+}
+
+// Builds an aligned series frame like the one the panel hands to the tooltip: the compare series' time
+// values have already been shifted forward onto the current window, so the tooltip must shift them back.
+function makeSeries(...valueFields: ValueFieldOpts[]): DataFrame {
+  const frame = createDataFrame({
+    fields: [
+      { name: 'time', type: FieldType.time, values: [ALIGNED_TIME] },
+      ...valueFields.map(({ dashed }, i) => ({
+        name: `value${i}`,
+        type: FieldType.number,
+        values: [10],
+        config: {
+          color: { mode: FieldColorModeId.Fixed, fixedColor: 'red' },
+          custom: dashed ? { lineStyle: DASH_LINE_STYLE } : {},
+        },
+      })),
+    ],
+  });
+
+  frame.fields[0].display = timeDisplay;
+  valueFields.forEach(({ displayName }, i) => {
+    frame.fields[i + 1].display = numberDisplay;
+    frame.fields[i + 1].state = { displayName };
+  });
+
+  return frame;
+}
+
+describe('TimeSeriesTooltip time comparison (#126189)', () => {
+  it('shows the (comparison) suffix for a compare series entry', () => {
+    render(
+      <TimeSeriesTooltip
+        series={makeSeries({ displayName: 'CPU (comparison)', dashed: true })}
+        dataIdxs={[0, 0]}
+        seriesIdx={1}
+        mode={TooltipDisplayMode.Single}
+        sortOrder={SortOrder.None}
+        isPinned={false}
+        dataLinks={[]}
+        compareDiffMs={[0, -ONE_DAY_MS]}
+      />
+    );
+
+    expect(screen.getByText('CPU (comparison)')).toBeInTheDocument();
+  });
+
+  it('shifts the header timestamp back to the compare period', () => {
+    render(
+      <TimeSeriesTooltip
+        series={makeSeries({ displayName: 'CPU (comparison)', dashed: true })}
+        dataIdxs={[0, 0]}
+        seriesIdx={1}
+        mode={TooltipDisplayMode.Single}
+        sortOrder={SortOrder.None}
+        isPinned={false}
+        dataLinks={[]}
+        compareDiffMs={[0, -ONE_DAY_MS]}
+      />
+    );
+
+    // Aligned time sits on the current window; the negative diff shifts it back one day to the compare period.
+    expect(screen.getByText(`T${ALIGNED_TIME - ONE_DAY_MS}`)).toBeInTheDocument();
+  });
+
+  it('does not shift the header timestamp for the current-period series', () => {
+    render(
+      <TimeSeriesTooltip
+        series={makeSeries({ displayName: 'CPU' })}
+        dataIdxs={[0, 0]}
+        seriesIdx={1}
+        mode={TooltipDisplayMode.Single}
+        sortOrder={SortOrder.None}
+        isPinned={false}
+        dataLinks={[]}
+        compareDiffMs={[0, 0]}
+      />
+    );
+
+    expect(screen.getByText(`T${ALIGNED_TIME}`)).toBeInTheDocument();
+  });
+
+  it('lists both the current and compare entries in multi mode', () => {
+    render(
+      <TimeSeriesTooltip
+        series={makeSeries({ displayName: 'CPU' }, { displayName: 'CPU (comparison)', dashed: true })}
+        dataIdxs={[0, 0, 0]}
+        seriesIdx={null}
+        mode={TooltipDisplayMode.Multi}
+        sortOrder={SortOrder.None}
+        isPinned={false}
+        dataLinks={[]}
+        compareDiffMs={[0, 0, -ONE_DAY_MS]}
+      />
+    );
+
+    expect(screen.getByText('CPU')).toBeInTheDocument();
+    expect(screen.getByText('CPU (comparison)')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Adds unit test coverage for how time-comparison series should look across the panel UI, per the acceptance criteria.

Builds on top of https://github.com/grafana/grafana/pull/128566 (high-cardinality color pairing), so the color-index assignment path is already covered there; this fills in the remaining gaps.

Closes https://github.com/grafana/grafana/issues/126189