### PR TITLE
PieChart: Add rendering tests and svgLabel test selector

### DIFF
--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -553,6 +553,9 @@ export const versionedComponents = {
         svgSlice: {
           '10.3.0': 'data testid Pie Chart Slice',
         },
+        svgLabel: {
+          '13.2.0': 'data-testid Pie Chart Label',
+        },
       },
       Text: {
         container: { [MIN_GRAFANA_VERSION]: () => '.markdown-html' },

--- a/public/app/plugins/panel/piechart/PieChart.tsx
+++ b/public/app/plugins/panel/piechart/PieChart.tsx
@@ -377,6 +377,7 @@ function PieLabel({ arc, outerRadius, innerRadius, displayLabels, total, color, 
   return (
     <g className={getSvgStyle(highlightState, styles)}>
       <text
+        data-testid={selectors.components.Panels.Visualization.PieChart.svgLabel}
         fill={color}
         x={labelX}
         y={labelY}

--- a/public/app/plugins/panel/piechart/PieChartPanel.test.tsx
+++ b/public/app/plugins/panel/piechart/PieChartPanel.test.tsx
@@ -428,6 +428,48 @@ describe('PieChart mouse interactions', () => {
   });
 });
 
+describe('PieChart panel states', () => {
+  it('renders the error view instead of a chart when there are no data frames', () => {
+    setup({ data: { state: LoadingState.Done, timeRange: getDefaultTimeRange(), series: [] } });
+
+    // No chart: neither the viz layout nor any slice is rendered.
+    expect(screen.queryByTestId(selectors.components.VizLayout.container)).not.toBeInTheDocument();
+    expect(screen.queryAllByTestId('data testid Pie Chart Slice')).toHaveLength(0);
+  });
+
+  it('does not render the legend when showLegend is false', () => {
+    setup({
+      options: buildOptions({
+        legend: { displayMode: LegendDisplayMode.List, showLegend: false, placement: 'right', calcs: [], values: [] },
+      }),
+      data: { series: defaultSliceSeries },
+    });
+
+    // Slices still render; with the legend off and no display labels, series names appear nowhere.
+    expect(screen.getAllByTestId('data testid Pie Chart Slice')).toHaveLength(2);
+    expect(screen.queryByText('Chrome')).not.toBeInTheDocument();
+  });
+
+  it('shows the raw value in the legend when legend values include Value', () => {
+    // Table mode renders the value column; List mode would only show names.
+    setup({
+      options: buildOptions({
+        legend: {
+          displayMode: LegendDisplayMode.Table,
+          showLegend: true,
+          placement: 'right',
+          calcs: [],
+          values: [PieChartLegendValues.Value],
+        },
+      }),
+      data: { series: defaultSliceSeries },
+    });
+
+    expect(screen.getByText('Chrome')).toBeInTheDocument();
+    expect(screen.getByText('60')).toBeInTheDocument();
+  });
+});
+
 describe('comparePieChartItemsByValue', () => {
   const makeFieldDisplay = (n: number) => ({ display: { numeric: n } }) as unknown as FieldDisplay;
 

--- a/public/app/plugins/panel/piechart/PieChartPanel.test.tsx
+++ b/public/app/plugins/panel/piechart/PieChartPanel.test.tsx
@@ -344,7 +344,7 @@ describe('PieChartPanel', () => {
       expect(labels[1]).toHaveTextContent('Firefox4040%');
     });
 
-    it('uses black or white label text (WCAG contrast pick) when gradientFills is active', () => {
+    it('picks black or white label text for readability when gradientFills is active', () => {
       // Color must be set on field.config directly; the panel reads pre-resolved config,
       // it does not apply fieldConfig defaults itself (applyFieldOverrides does that in prod).
       const gradientColor = { mode: FieldColorModeId.Gradient, fixedColor: '#00ff00', gradientColorTo: '#ff0000' };

--- a/public/app/plugins/panel/piechart/PieChartPanel.test.tsx
+++ b/public/app/plugins/panel/piechart/PieChartPanel.test.tsx
@@ -18,7 +18,13 @@ import { selectors } from '@grafana/e2e-selectors';
 import { LegendDisplayMode, SortOrder, TooltipDisplayMode } from '@grafana/schema';
 
 import { PieChartPanel, comparePieChartItemsByValue } from './PieChartPanel';
-import { type Options, PieChartType, PieChartLegendValues, PieChartLabels } from './panelcfg.gen';
+import {
+  type Options,
+  type PieChartLegendOptions,
+  PieChartType,
+  PieChartLegendValues,
+  PieChartLabels,
+} from './panelcfg.gen';
 
 jest.mock('react-use', () => ({
   ...jest.requireActual('react-use'),
@@ -357,9 +363,7 @@ describe('PieChartPanel', () => {
       expect(labelFillColors).toHaveLength(2);
       labelFillColors.forEach((color) => expect(['#ffffff', '#000000']).toContain(color));
     });
-  });
 
-  describe('label rendering', () => {
     it('suppresses the label for a slice too small to fit one (< 0.3 rad)', () => {
       // Tiny is ~1% of the total, well under the 0.3 rad label threshold.
       const seriesWithTinySlice = makeSeries([
@@ -406,15 +410,14 @@ describe('PieChartPanel', () => {
       });
       await userEvent.hover(screen.getAllByTestId('data testid Pie Chart Slice')[0]);
 
+      // Chrome stays; the zero-valued Zero series is not among the tooltip rows.
       const rows = screen.getAllByTestId('SeriesTableRow');
       expect(rows).toHaveLength(1);
       expect(rows[0]).toHaveTextContent('Chrome');
-      expect(rows[0]).toHaveTextContent('60');
+      expect(rows.some((row) => row.textContent?.includes('Zero'))).toBe(false);
     });
-  });
 
-  describe('mouse interactions', () => {
-    it('hides tooltip on mouseout after hover', async () => {
+    it('hides the tooltip on mouseout after hover', async () => {
       setup({ data: { series: defaultSliceSeries } });
       const slices = screen.getAllByTestId('data testid Pie Chart Slice');
 
@@ -438,9 +441,7 @@ describe('PieChartPanel', () => {
 
     it('does not render the legend when showLegend is false', () => {
       setup({
-        options: buildOptions({
-          legend: { displayMode: LegendDisplayMode.List, showLegend: false, placement: 'right', calcs: [], values: [] },
-        }),
+        options: buildOptions({ legend: buildLegend({ showLegend: false }) }),
         data: { series: defaultSliceSeries },
       });
 
@@ -453,13 +454,7 @@ describe('PieChartPanel', () => {
       // Table mode renders the value column; List mode would only show names.
       setup({
         options: buildOptions({
-          legend: {
-            displayMode: LegendDisplayMode.Table,
-            showLegend: true,
-            placement: 'right',
-            calcs: [],
-            values: [PieChartLegendValues.Value],
-          },
+          legend: buildLegend({ displayMode: LegendDisplayMode.Table, values: [PieChartLegendValues.Value] }),
         }),
         data: { series: defaultSliceSeries },
       });
@@ -536,17 +531,20 @@ const defaultSliceSeries = makeSeries([
   { name: 'Firefox', value: 40 },
 ]);
 
+const buildLegend = (overrides: Partial<PieChartLegendOptions> = {}): PieChartLegendOptions => ({
+  displayMode: LegendDisplayMode.List,
+  showLegend: true,
+  placement: 'right',
+  calcs: [],
+  values: [PieChartLegendValues.Percent],
+  ...overrides,
+});
+
 const buildOptions = (overrides: Partial<Options> = {}): Options => ({
   pieType: PieChartType.Pie,
   sort: SortOrder.Descending,
   displayLabels: [],
-  legend: {
-    displayMode: LegendDisplayMode.List,
-    showLegend: true,
-    placement: 'right',
-    calcs: [],
-    values: [PieChartLegendValues.Percent],
-  },
+  legend: buildLegend(),
   reduceOptions: { calcs: [] },
   orientation: VizOrientation.Auto,
   tooltip: { mode: TooltipDisplayMode.Multi, sort: SortOrder.Ascending },

--- a/public/app/plugins/panel/piechart/PieChartPanel.test.tsx
+++ b/public/app/plugins/panel/piechart/PieChartPanel.test.tsx
@@ -333,21 +333,15 @@ describe('PieChart display labels', () => {
     });
     const labels = screen.getAllByTestId(selectors.components.Panels.Visualization.PieChart.svgLabel);
 
-    // Slices/labels render in the panel's sort order (descending here), so Chrome (60)
-    // comes before Firefox (40). Chrome=60, Firefox=40, total=100 → 60% / 40%. The tspan
-    // elements concatenate with no separator (Name, then Value, then Percent), so matching
-    // the joined string proves all three rendered — a missing Value tspan would collapse
-    // "Chrome" + "60" + "60%" down to "Chrome60%", which no longer contains "Chrome6060%".
+    // Labels follow descending sort. Each label is name+value+percent joined without a separator.
     expect(labels).toHaveLength(2);
     expect(labels[0]).toHaveTextContent('Chrome6060%');
     expect(labels[1]).toHaveTextContent('Firefox4040%');
   });
 
   it('uses black or white label text (WCAG contrast pick) when gradientFills is active', () => {
-    // field.config must carry the resolved color directly — PieChartPanel reads
-    // config already merged onto the frame's fields (done upstream by
-    // applyFieldOverrides in the real dashboard renderer); the panel's own
-    // `fieldConfig` prop is only used for override lookups, not to backfill it.
+    // Color must be set on field.config directly; the panel reads pre-resolved config,
+    // it does not apply fieldConfig defaults itself (applyFieldOverrides does that in prod).
     const gradientColor = { mode: FieldColorModeId.Gradient, fixedColor: '#00ff00', gradientColorTo: '#ff0000' };
     const seriesWithGradientColor = makeSeries([
       { name: 'Chrome', value: 60, config: { color: gradientColor } },
@@ -360,16 +354,15 @@ describe('PieChart display labels', () => {
     const labels = screen.getAllByTestId(selectors.components.Panels.Visualization.PieChart.svgLabel);
     const labelFillColors = labels.map((el) => el.getAttribute('fill')?.toLowerCase());
 
+    // Gradient mode picks black or white for contrast; any other color means it didn't run.
     expect(labelFillColors).toHaveLength(2);
-    // mostReadable() only ever returns one of these two — a plain theme color here
-    // would mean the contrast-picking branch (PieChart.tsx) didn't run.
     labelFillColors.forEach((color) => expect(['#ffffff', '#000000']).toContain(color));
   });
 });
 
 describe('PieChart label rendering', () => {
   it('suppresses the label for a slice too small to fit one (< 0.3 rad)', () => {
-    // tiny ~1% of total → arc angle well under the 0.3 rad label threshold.
+    // Tiny is ~1% of the total, well under the 0.3 rad label threshold.
     const seriesWithTinySlice = makeSeries([
       { name: 'Big', value: 990 },
       { name: 'Tiny', value: 10 },
@@ -378,12 +371,9 @@ describe('PieChart label rendering', () => {
       options: buildOptions({ displayLabels: [PieChartLabels.Name] }),
       data: { series: seriesWithTinySlice },
     });
-    // Both slices must still render — only the "Tiny" label should be suppressed, not the slice itself.
+    // Both slices render; only the Tiny label is dropped.
     expect(screen.getAllByTestId('data testid Pie Chart Slice')).toHaveLength(2);
-
     const labels = screen.getAllByTestId(selectors.components.Panels.Visualization.PieChart.svgLabel);
-
-    // Only "Big" is large enough to clear the label-space threshold — "Tiny" gets no label at all.
     expect(labels).toHaveLength(1);
     expect(labels[0]).toHaveTextContent('Big');
   });
@@ -395,9 +385,7 @@ describe('PieChart tooltip modes', () => {
       options: buildOptions({ tooltip: { mode: TooltipDisplayMode.Single, sort: SortOrder.Ascending } }),
       data: { series: defaultSliceSeries },
     });
-    // The panel's sort (options.sort, Descending from buildOptions) orders the slices, so
-    // Chrome (60) is the first slice. tooltip.sort is irrelevant here — single mode shows
-    // only the hovered row.
+    // Descending sort makes Chrome the first slice. Single mode shows only the hovered row.
     await userEvent.hover(screen.getAllByTestId('data testid Pie Chart Slice')[0]);
 
     const rows = screen.getAllByTestId('SeriesTableRow');
@@ -431,7 +419,7 @@ describe('PieChart mouse interactions', () => {
     setup({ data: { series: defaultSliceSeries } });
     const slices = screen.getAllByTestId('data testid Pie Chart Slice');
 
-    // Default tooltip is multi mode, so hovering shows a row for both slices.
+    // Multi mode (the default) shows a row per slice.
     await userEvent.hover(slices[0]);
     expect(screen.getAllByTestId('SeriesTableRow')).toHaveLength(2);
 
@@ -487,8 +475,7 @@ describe('comparePieChartItemsByValue', () => {
 
 const defaultHideFrom = { legend: false, viz: false, tooltip: false };
 
-// Builds a single-frame series from (name, value) slices. Fields default to the
-// standard "don't hide anything" config; pass `config` to override (e.g. gradient color).
+// Builds one frame of numeric fields. Fields default to a visible config; pass config to override.
 const makeSeries = (slices: Array<{ name: string; value: number; config?: FieldConfig }>) => [
   toDataFrame({
     fields: slices.map(({ name, value, config }) => ({

--- a/public/app/plugins/panel/piechart/PieChartPanel.test.tsx
+++ b/public/app/plugins/panel/piechart/PieChartPanel.test.tsx
@@ -395,7 +395,9 @@ describe('PieChart tooltip modes', () => {
       options: buildOptions({ tooltip: { mode: TooltipDisplayMode.Single, sort: SortOrder.Ascending } }),
       data: { series: defaultSliceSeries },
     });
-    // Descending sort puts Chrome (60) ahead of Firefox (40), so it's the first slice.
+    // The panel's sort (options.sort, Descending from buildOptions) orders the slices, so
+    // Chrome (60) is the first slice. tooltip.sort is irrelevant here — single mode shows
+    // only the hovered row.
     await userEvent.hover(screen.getAllByTestId('data testid Pie Chart Slice')[0]);
 
     const rows = screen.getAllByTestId('SeriesTableRow');
@@ -411,7 +413,6 @@ describe('PieChart tooltip modes', () => {
     ]);
     setup({
       options: buildOptions({
-        legend: { displayMode: LegendDisplayMode.List, showLegend: false, placement: 'right', calcs: [], values: [] },
         tooltip: { mode: TooltipDisplayMode.Multi, sort: SortOrder.Ascending, hideZeros: true },
       }),
       data: { series: seriesWithZero },
@@ -430,8 +431,9 @@ describe('PieChart mouse interactions', () => {
     setup({ data: { series: defaultSliceSeries } });
     const slices = screen.getAllByTestId('data testid Pie Chart Slice');
 
+    // Default tooltip is multi mode, so hovering shows a row for both slices.
     await userEvent.hover(slices[0]);
-    expect(screen.getAllByTestId('SeriesTableRow').length).toBeGreaterThan(0);
+    expect(screen.getAllByTestId('SeriesTableRow')).toHaveLength(2);
 
     fireEvent.mouseOut(slices[0]);
     expect(screen.queryAllByTestId('SeriesTableRow')).toHaveLength(0);

--- a/public/app/plugins/panel/piechart/PieChartPanel.test.tsx
+++ b/public/app/plugins/panel/piechart/PieChartPanel.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { type ComponentProps } from 'react';
 
@@ -323,150 +323,152 @@ describe('PieChartPanel', () => {
       });
     });
   });
-});
 
-describe('PieChart display labels', () => {
-  it('renders name, value, and percent text for each slice', () => {
-    setup({
-      options: buildOptions({ displayLabels: [PieChartLabels.Name, PieChartLabels.Value, PieChartLabels.Percent] }),
-      data: { series: defaultSliceSeries },
-    });
-    const labels = screen.getAllByTestId(selectors.components.Panels.Visualization.PieChart.svgLabel);
+  describe('display labels', () => {
+    it('renders name, value, and percent text for each slice', () => {
+      setup({
+        options: buildOptions({ displayLabels: [PieChartLabels.Name, PieChartLabels.Value, PieChartLabels.Percent] }),
+        data: { series: defaultSliceSeries },
+      });
+      const labels = screen.getAllByTestId(selectors.components.Panels.Visualization.PieChart.svgLabel);
 
-    // Labels follow descending sort. Each label is name+value+percent joined without a separator.
-    expect(labels).toHaveLength(2);
-    expect(labels[0]).toHaveTextContent('Chrome6060%');
-    expect(labels[1]).toHaveTextContent('Firefox4040%');
-  });
-
-  it('uses black or white label text (WCAG contrast pick) when gradientFills is active', () => {
-    // Color must be set on field.config directly; the panel reads pre-resolved config,
-    // it does not apply fieldConfig defaults itself (applyFieldOverrides does that in prod).
-    const gradientColor = { mode: FieldColorModeId.Gradient, fixedColor: '#00ff00', gradientColorTo: '#ff0000' };
-    const seriesWithGradientColor = makeSeries([
-      { name: 'Chrome', value: 60, config: { color: gradientColor } },
-      { name: 'Firefox', value: 40, config: { color: gradientColor } },
-    ]);
-    setup({
-      options: buildOptions({ displayLabels: [PieChartLabels.Name] }),
-      data: { series: seriesWithGradientColor },
-    });
-    const labels = screen.getAllByTestId(selectors.components.Panels.Visualization.PieChart.svgLabel);
-    const labelFillColors = labels.map((el) => el.getAttribute('fill')?.toLowerCase());
-
-    // Gradient mode picks black or white for contrast; any other color means it didn't run.
-    expect(labelFillColors).toHaveLength(2);
-    labelFillColors.forEach((color) => expect(['#ffffff', '#000000']).toContain(color));
-  });
-});
-
-describe('PieChart label rendering', () => {
-  it('suppresses the label for a slice too small to fit one (< 0.3 rad)', () => {
-    // Tiny is ~1% of the total, well under the 0.3 rad label threshold.
-    const seriesWithTinySlice = makeSeries([
-      { name: 'Big', value: 990 },
-      { name: 'Tiny', value: 10 },
-    ]);
-    setup({
-      options: buildOptions({ displayLabels: [PieChartLabels.Name] }),
-      data: { series: seriesWithTinySlice },
-    });
-    // Both slices render; only the Tiny label is dropped.
-    expect(screen.getAllByTestId('data testid Pie Chart Slice')).toHaveLength(2);
-    const labels = screen.getAllByTestId(selectors.components.Panels.Visualization.PieChart.svgLabel);
-    expect(labels).toHaveLength(1);
-    expect(labels[0]).toHaveTextContent('Big');
-  });
-});
-
-describe('PieChart tooltip modes', () => {
-  it('shows only the hovered series in single mode, not the whole series list', async () => {
-    setup({
-      options: buildOptions({ tooltip: { mode: TooltipDisplayMode.Single, sort: SortOrder.Ascending } }),
-      data: { series: defaultSliceSeries },
-    });
-    // Descending sort makes Chrome the first slice. Single mode shows only the hovered row.
-    await userEvent.hover(screen.getAllByTestId('data testid Pie Chart Slice')[0]);
-
-    const rows = screen.getAllByTestId('SeriesTableRow');
-    expect(rows).toHaveLength(1);
-    expect(rows[0]).toHaveTextContent('Chrome');
-    expect(rows[0]).toHaveTextContent('60');
-  });
-
-  it('filters zero-value series from multi tooltip when hideZeros is enabled', async () => {
-    const seriesWithZero = makeSeries([
-      { name: 'Chrome', value: 60 },
-      { name: 'Zero', value: 0 },
-    ]);
-    setup({
-      options: buildOptions({
-        tooltip: { mode: TooltipDisplayMode.Multi, sort: SortOrder.Ascending, hideZeros: true },
-      }),
-      data: { series: seriesWithZero },
-    });
-    await userEvent.hover(screen.getAllByTestId('data testid Pie Chart Slice')[0]);
-
-    const rows = screen.getAllByTestId('SeriesTableRow');
-    expect(rows).toHaveLength(1);
-    expect(rows[0]).toHaveTextContent('Chrome');
-    expect(rows[0]).toHaveTextContent('60');
-  });
-});
-
-describe('PieChart mouse interactions', () => {
-  it('hides tooltip on mouseout after hover', async () => {
-    setup({ data: { series: defaultSliceSeries } });
-    const slices = screen.getAllByTestId('data testid Pie Chart Slice');
-
-    // Multi mode (the default) shows a row per slice.
-    await userEvent.hover(slices[0]);
-    expect(screen.getAllByTestId('SeriesTableRow')).toHaveLength(2);
-
-    fireEvent.mouseOut(slices[0]);
-    expect(screen.queryAllByTestId('SeriesTableRow')).toHaveLength(0);
-  });
-});
-
-describe('PieChart panel states', () => {
-  it('renders the error view instead of a chart when there are no data frames', () => {
-    setup({ data: { state: LoadingState.Done, timeRange: getDefaultTimeRange(), series: [] } });
-
-    // No chart: neither the viz layout nor any slice is rendered.
-    expect(screen.queryByTestId(selectors.components.VizLayout.container)).not.toBeInTheDocument();
-    expect(screen.queryAllByTestId('data testid Pie Chart Slice')).toHaveLength(0);
-  });
-
-  it('does not render the legend when showLegend is false', () => {
-    setup({
-      options: buildOptions({
-        legend: { displayMode: LegendDisplayMode.List, showLegend: false, placement: 'right', calcs: [], values: [] },
-      }),
-      data: { series: defaultSliceSeries },
+      // Labels follow descending sort. Each label is name+value+percent joined without a separator.
+      expect(labels).toHaveLength(2);
+      expect(labels[0]).toHaveTextContent('Chrome6060%');
+      expect(labels[1]).toHaveTextContent('Firefox4040%');
     });
 
-    // Slices still render; with the legend off and no display labels, series names appear nowhere.
-    expect(screen.getAllByTestId('data testid Pie Chart Slice')).toHaveLength(2);
-    expect(screen.queryByText('Chrome')).not.toBeInTheDocument();
+    it('uses black or white label text (WCAG contrast pick) when gradientFills is active', () => {
+      // Color must be set on field.config directly; the panel reads pre-resolved config,
+      // it does not apply fieldConfig defaults itself (applyFieldOverrides does that in prod).
+      const gradientColor = { mode: FieldColorModeId.Gradient, fixedColor: '#00ff00', gradientColorTo: '#ff0000' };
+      const seriesWithGradientColor = makeSeries([
+        { name: 'Chrome', value: 60, config: { color: gradientColor } },
+        { name: 'Firefox', value: 40, config: { color: gradientColor } },
+      ]);
+      setup({
+        options: buildOptions({ displayLabels: [PieChartLabels.Name] }),
+        data: { series: seriesWithGradientColor },
+      });
+      const labels = screen.getAllByTestId(selectors.components.Panels.Visualization.PieChart.svgLabel);
+      const labelFillColors = labels.map((el) => el.getAttribute('fill')?.toLowerCase());
+
+      // Gradient mode picks black or white for contrast; any other color means it didn't run.
+      expect(labelFillColors).toHaveLength(2);
+      labelFillColors.forEach((color) => expect(['#ffffff', '#000000']).toContain(color));
+    });
   });
 
-  it('shows the raw value in the legend when legend values include Value', () => {
-    // Table mode renders the value column; List mode would only show names.
-    setup({
-      options: buildOptions({
-        legend: {
-          displayMode: LegendDisplayMode.Table,
-          showLegend: true,
-          placement: 'right',
-          calcs: [],
-          values: [PieChartLegendValues.Value],
-        },
-      }),
-      data: { series: defaultSliceSeries },
+  describe('label rendering', () => {
+    it('suppresses the label for a slice too small to fit one (< 0.3 rad)', () => {
+      // Tiny is ~1% of the total, well under the 0.3 rad label threshold.
+      const seriesWithTinySlice = makeSeries([
+        { name: 'Big', value: 990 },
+        { name: 'Tiny', value: 10 },
+      ]);
+      setup({
+        options: buildOptions({ displayLabels: [PieChartLabels.Name] }),
+        data: { series: seriesWithTinySlice },
+      });
+      // Both slices render; only the Tiny label is dropped.
+      expect(screen.getAllByTestId('data testid Pie Chart Slice')).toHaveLength(2);
+      const labels = screen.getAllByTestId(selectors.components.Panels.Visualization.PieChart.svgLabel);
+      expect(labels).toHaveLength(1);
+      expect(labels[0]).toHaveTextContent('Big');
+    });
+  });
+
+  describe('tooltip modes', () => {
+    it('shows only the hovered series in single mode, not the whole series list', async () => {
+      setup({
+        options: buildOptions({ tooltip: { mode: TooltipDisplayMode.Single, sort: SortOrder.Ascending } }),
+        data: { series: defaultSliceSeries },
+      });
+      // Descending sort makes Chrome the first slice. Single mode shows only the hovered row.
+      await userEvent.hover(screen.getAllByTestId('data testid Pie Chart Slice')[0]);
+
+      const rows = screen.getAllByTestId('SeriesTableRow');
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toHaveTextContent('Chrome');
+      expect(rows[0]).toHaveTextContent('60');
     });
 
-    expect(screen.getByText('Chrome')).toBeInTheDocument();
-    expect(screen.getByText('60')).toBeInTheDocument();
+    it('filters zero-value series from multi tooltip when hideZeros is enabled', async () => {
+      const seriesWithZero = makeSeries([
+        { name: 'Chrome', value: 60 },
+        { name: 'Zero', value: 0 },
+      ]);
+      setup({
+        options: buildOptions({
+          tooltip: { mode: TooltipDisplayMode.Multi, sort: SortOrder.Ascending, hideZeros: true },
+        }),
+        data: { series: seriesWithZero },
+      });
+      await userEvent.hover(screen.getAllByTestId('data testid Pie Chart Slice')[0]);
+
+      const rows = screen.getAllByTestId('SeriesTableRow');
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toHaveTextContent('Chrome');
+      expect(rows[0]).toHaveTextContent('60');
+    });
+  });
+
+  describe('mouse interactions', () => {
+    it('hides tooltip on mouseout after hover', async () => {
+      setup({ data: { series: defaultSliceSeries } });
+      const slices = screen.getAllByTestId('data testid Pie Chart Slice');
+
+      // Multi mode (the default) shows a row per slice.
+      await userEvent.hover(slices[0]);
+      expect(screen.getAllByTestId('SeriesTableRow')).toHaveLength(2);
+
+      fireEvent.mouseOut(slices[0]);
+      expect(screen.queryAllByTestId('SeriesTableRow')).toHaveLength(0);
+    });
+  });
+
+  describe('panel states', () => {
+    it('renders the error view instead of a chart when there are no data frames', () => {
+      setup({ data: { state: LoadingState.Done, timeRange: getDefaultTimeRange(), series: [] } });
+
+      // No chart: neither the viz layout nor any slice is rendered.
+      expect(screen.queryByTestId(selectors.components.VizLayout.container)).not.toBeInTheDocument();
+      expect(screen.queryAllByTestId('data testid Pie Chart Slice')).toHaveLength(0);
+    });
+
+    it('does not render the legend when showLegend is false', () => {
+      setup({
+        options: buildOptions({
+          legend: { displayMode: LegendDisplayMode.List, showLegend: false, placement: 'right', calcs: [], values: [] },
+        }),
+        data: { series: defaultSliceSeries },
+      });
+
+      // Slices still render, but the legend region is not.
+      expect(screen.getAllByTestId('data testid Pie Chart Slice')).toHaveLength(2);
+      expect(screen.queryByTestId(selectors.components.VizLayout.legend)).not.toBeInTheDocument();
+    });
+
+    it('shows the raw value in the legend when legend values include Value', () => {
+      // Table mode renders the value column; List mode would only show names.
+      setup({
+        options: buildOptions({
+          legend: {
+            displayMode: LegendDisplayMode.Table,
+            showLegend: true,
+            placement: 'right',
+            calcs: [],
+            values: [PieChartLegendValues.Value],
+          },
+        }),
+        data: { series: defaultSliceSeries },
+      });
+
+      // Scope to the legend so the value is tied to it, not to a slice label.
+      const legend = screen.getByTestId(selectors.components.VizLayout.legend);
+      expect(within(legend).getByText('Chrome')).toBeInTheDocument();
+      expect(within(legend).getByText('60')).toBeInTheDocument();
+    });
   });
 });
 

--- a/public/app/plugins/panel/piechart/PieChartPanel.test.tsx
+++ b/public/app/plugins/panel/piechart/PieChartPanel.test.tsx
@@ -1,10 +1,12 @@
-import { act, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { type ComponentProps } from 'react';
 
 import {
+  type FieldConfig,
   type FieldConfigSource,
   type FieldDisplay,
+  FieldColorModeId,
   toDataFrame,
   FieldType,
   VizOrientation,
@@ -16,7 +18,7 @@ import { selectors } from '@grafana/e2e-selectors';
 import { LegendDisplayMode, SortOrder, TooltipDisplayMode } from '@grafana/schema';
 
 import { PieChartPanel, comparePieChartItemsByValue } from './PieChartPanel';
-import { type Options, PieChartType, PieChartLegendValues } from './panelcfg.gen';
+import { type Options, PieChartType, PieChartLegendValues, PieChartLabels } from './panelcfg.gen';
 
 jest.mock('react-use', () => ({
   ...jest.requireActual('react-use'),
@@ -323,6 +325,119 @@ describe('PieChartPanel', () => {
   });
 });
 
+describe('PieChart display labels', () => {
+  it('renders name, value, and percent text for each slice', () => {
+    setup({
+      options: buildOptions({ displayLabels: [PieChartLabels.Name, PieChartLabels.Value, PieChartLabels.Percent] }),
+      data: { series: defaultSliceSeries },
+    });
+    const labels = screen.getAllByTestId(selectors.components.Panels.Visualization.PieChart.svgLabel);
+
+    // Slices/labels render in the panel's sort order (descending here), so Chrome (60)
+    // comes before Firefox (40). Chrome=60, Firefox=40, total=100 → 60% / 40%. The tspan
+    // elements concatenate with no separator (Name, then Value, then Percent), so matching
+    // the joined string proves all three rendered — a missing Value tspan would collapse
+    // "Chrome" + "60" + "60%" down to "Chrome60%", which no longer contains "Chrome6060%".
+    expect(labels).toHaveLength(2);
+    expect(labels[0]).toHaveTextContent('Chrome6060%');
+    expect(labels[1]).toHaveTextContent('Firefox4040%');
+  });
+
+  it('uses black or white label text (WCAG contrast pick) when gradientFills is active', () => {
+    // field.config must carry the resolved color directly — PieChartPanel reads
+    // config already merged onto the frame's fields (done upstream by
+    // applyFieldOverrides in the real dashboard renderer); the panel's own
+    // `fieldConfig` prop is only used for override lookups, not to backfill it.
+    const gradientColor = { mode: FieldColorModeId.Gradient, fixedColor: '#00ff00', gradientColorTo: '#ff0000' };
+    const seriesWithGradientColor = makeSeries([
+      { name: 'Chrome', value: 60, config: { color: gradientColor } },
+      { name: 'Firefox', value: 40, config: { color: gradientColor } },
+    ]);
+    setup({
+      options: buildOptions({ displayLabels: [PieChartLabels.Name] }),
+      data: { series: seriesWithGradientColor },
+    });
+    const labels = screen.getAllByTestId(selectors.components.Panels.Visualization.PieChart.svgLabel);
+    const labelFillColors = labels.map((el) => el.getAttribute('fill')?.toLowerCase());
+
+    expect(labelFillColors).toHaveLength(2);
+    // mostReadable() only ever returns one of these two — a plain theme color here
+    // would mean the contrast-picking branch (PieChart.tsx) didn't run.
+    labelFillColors.forEach((color) => expect(['#ffffff', '#000000']).toContain(color));
+  });
+});
+
+describe('PieChart label rendering', () => {
+  it('suppresses the label for a slice too small to fit one (< 0.3 rad)', () => {
+    // tiny ~1% of total → arc angle well under the 0.3 rad label threshold.
+    const seriesWithTinySlice = makeSeries([
+      { name: 'Big', value: 990 },
+      { name: 'Tiny', value: 10 },
+    ]);
+    setup({
+      options: buildOptions({ displayLabels: [PieChartLabels.Name] }),
+      data: { series: seriesWithTinySlice },
+    });
+    // Both slices must still render — only the "Tiny" label should be suppressed, not the slice itself.
+    expect(screen.getAllByTestId('data testid Pie Chart Slice')).toHaveLength(2);
+
+    const labels = screen.getAllByTestId(selectors.components.Panels.Visualization.PieChart.svgLabel);
+
+    // Only "Big" is large enough to clear the label-space threshold — "Tiny" gets no label at all.
+    expect(labels).toHaveLength(1);
+    expect(labels[0]).toHaveTextContent('Big');
+  });
+});
+
+describe('PieChart tooltip modes', () => {
+  it('shows only the hovered series in single mode, not the whole series list', async () => {
+    setup({
+      options: buildOptions({ tooltip: { mode: TooltipDisplayMode.Single, sort: SortOrder.Ascending } }),
+      data: { series: defaultSliceSeries },
+    });
+    // Descending sort puts Chrome (60) ahead of Firefox (40), so it's the first slice.
+    await userEvent.hover(screen.getAllByTestId('data testid Pie Chart Slice')[0]);
+
+    const rows = screen.getAllByTestId('SeriesTableRow');
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toHaveTextContent('Chrome');
+    expect(rows[0]).toHaveTextContent('60');
+  });
+
+  it('filters zero-value series from multi tooltip when hideZeros is enabled', async () => {
+    const seriesWithZero = makeSeries([
+      { name: 'Chrome', value: 60 },
+      { name: 'Zero', value: 0 },
+    ]);
+    setup({
+      options: buildOptions({
+        legend: { displayMode: LegendDisplayMode.List, showLegend: false, placement: 'right', calcs: [], values: [] },
+        tooltip: { mode: TooltipDisplayMode.Multi, sort: SortOrder.Ascending, hideZeros: true },
+      }),
+      data: { series: seriesWithZero },
+    });
+    await userEvent.hover(screen.getAllByTestId('data testid Pie Chart Slice')[0]);
+
+    const rows = screen.getAllByTestId('SeriesTableRow');
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toHaveTextContent('Chrome');
+    expect(rows[0]).toHaveTextContent('60');
+  });
+});
+
+describe('PieChart mouse interactions', () => {
+  it('hides tooltip on mouseout after hover', async () => {
+    setup({ data: { series: defaultSliceSeries } });
+    const slices = screen.getAllByTestId('data testid Pie Chart Slice');
+
+    await userEvent.hover(slices[0]);
+    expect(screen.getAllByTestId('SeriesTableRow').length).toBeGreaterThan(0);
+
+    fireEvent.mouseOut(slices[0]);
+    expect(screen.queryAllByTestId('SeriesTableRow')).toHaveLength(0);
+  });
+});
+
 describe('comparePieChartItemsByValue', () => {
   const makeFieldDisplay = (n: number) => ({ display: { numeric: n } }) as unknown as FieldDisplay;
 
@@ -368,35 +483,54 @@ describe('comparePieChartItemsByValue', () => {
   });
 });
 
+const defaultHideFrom = { legend: false, viz: false, tooltip: false };
+
+// Builds a single-frame series from (name, value) slices. Fields default to the
+// standard "don't hide anything" config; pass `config` to override (e.g. gradient color).
+const makeSeries = (slices: Array<{ name: string; value: number; config?: FieldConfig }>) => [
+  toDataFrame({
+    fields: slices.map(({ name, value, config }) => ({
+      name,
+      type: FieldType.number,
+      values: [value],
+      config: config ?? { custom: { hideFrom: defaultHideFrom } },
+    })),
+  }),
+];
+
+const defaultSliceSeries = makeSeries([
+  { name: 'Chrome', value: 60 },
+  { name: 'Firefox', value: 40 },
+]);
+
+const buildOptions = (overrides: Partial<Options> = {}): Options => ({
+  pieType: PieChartType.Pie,
+  sort: SortOrder.Descending,
+  displayLabels: [],
+  legend: {
+    displayMode: LegendDisplayMode.List,
+    showLegend: true,
+    placement: 'right',
+    calcs: [],
+    values: [PieChartLegendValues.Percent],
+  },
+  reduceOptions: { calcs: [] },
+  orientation: VizOrientation.Auto,
+  tooltip: { mode: TooltipDisplayMode.Multi, sort: SortOrder.Ascending },
+  ...overrides,
+});
+
 const setup = (propsOverrides?: {}) => {
   const fieldConfig: FieldConfigSource = {
     defaults: {},
     overrides: [],
   };
 
-  const options: Options = {
-    pieType: PieChartType.Pie,
-    sort: SortOrder.Descending,
-    displayLabels: [],
-    legend: {
-      displayMode: LegendDisplayMode.List,
-      showLegend: true,
-      placement: 'right',
-      calcs: [],
-      values: [PieChartLegendValues.Percent],
-    },
-    reduceOptions: {
-      calcs: [],
-    },
-    orientation: VizOrientation.Auto,
-    tooltip: { mode: TooltipDisplayMode.Multi, sort: SortOrder.Ascending },
-  };
-
   const props: PieChartPanelProps = {
     id: 1,
     data: { state: LoadingState.Done, timeRange: getDefaultTimeRange(), series: [] },
     timeZone: 'utc',
-    options: options,
+    options: buildOptions(),
     fieldConfig: fieldConfig,
     width: 532,
     height: 250,


### PR DESCRIPTION
**What is this?**

Test coverage for the Pie Chart panel's rendering component (`PieChart.tsx`) and panel wrapper (`PieChartPanel.tsx`).

Coverage:
- `PieChart.tsx`: lines 84.84% to 99.24% (branches 46.61% to 80.5%)
- `PieChartPanel.tsx`: lines 96.55% to 100%

**What's covered**

- **Labels** — name/value/percent rendering, small-slice label suppression, and the readable black/white label color used in gradient mode.
- **Tooltips** — single mode shows only the hovered series; multi mode drops zero-value series when `hideZeros` is set; tooltip hides on mouse-out.
- **Panel states** — no-data error view, `showLegend: false` (no legend region), and the legend Value column.

**Supporting change**

- Adds a `svgLabel` e2e-selector (`packages/grafana-e2e-selectors`) and a `data-testid` on the label `<text>` element in `PieChart.tsx`, so tests assert per-slice label content via a stable selector instead of scraping raw SVG nodes. Follows the existing `svgSlice` sibling convention.

**Scope**

Frontend only. The single production change is the `data-testid`; everything else is test code and the new selector.

**Special notes for the reviewer**

- The only production behavior change is the added `data-testid` on rendered labels — no logic changes.
- The `svgLabel` selector is versioned at `13.2.0`; the resolver strips prerelease suffixes so it resolves under `13.2.0-pre`.
- Verified locally: 51 tests pass across the pie chart and `grafana-e2e-selectors` suites, ESLint clean, whole-repo typecheck green.
