### PR TITLE
DashboardLibrary: Show custom template name and description in the card body

### DIFF
--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/DashboardCard.test.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/DashboardCard.test.tsx
@@ -87,14 +87,14 @@ describe('DashboardCard', () => {
     expect(screen.getByText('My custom description')).toBeInTheDocument();
   });
 
-  it('should render fallback text when description is empty', () => {
+  it('should not render a description when it is empty', () => {
     const dashboard = createMockPluginDashboard({ description: '' });
     render(
       <DashboardCard title="Test Dashboard" dashboard={dashboard} onClick={mockOnClick} kind="suggested_dashboard" />
     );
 
     expect(screen.getByRole('heading', { name: 'Test Dashboard' })).toBeInTheDocument();
-    expect(screen.getByTestId('dashboard-card-description')).toHaveTextContent('No description available');
+    expect(screen.queryByTestId('dashboard-card-description')).not.toBeInTheDocument();
   });
 
   describe('Button interactions', () => {
@@ -683,7 +683,7 @@ describe('DashboardCard', () => {
       expect(headings).toHaveLength(1);
     });
 
-    it('should render the description inside the rectangle, not in the bottom section', () => {
+    it('should render the description in the bottom section', () => {
       const dashboard = createMockCustomTemplateDashboard({ description: 'A custom template description' });
       render(
         <DashboardCard
@@ -699,7 +699,7 @@ describe('DashboardCard', () => {
       expect(descriptions[0]).toHaveTextContent('A custom template description');
     });
 
-    it('should not render the "No preview available" placeholder', () => {
+    it('should render the "No preview available" placeholder when there is no image', () => {
       const dashboard = createMockCustomTemplateDashboard();
       render(
         <DashboardCard
@@ -710,6 +710,27 @@ describe('DashboardCard', () => {
         />
       );
 
+      expect(screen.getByText('No preview available')).toBeInTheDocument();
+    });
+
+    it('should render the preview image alongside the title and description in the bottom section', () => {
+      const dashboard = createMockCustomTemplateDashboard({ description: 'A custom template description' });
+      render(
+        <DashboardCard
+          title="My Custom Template"
+          dashboard={dashboard}
+          onClick={mockOnClick}
+          kind="custom_dashboard_template"
+          imageUrl="https://example.com/preview.png"
+        />
+      );
+
+      expect(screen.getByRole('img', { name: 'My Custom Template' })).toHaveAttribute(
+        'src',
+        'https://example.com/preview.png'
+      );
+      expect(screen.getByRole('heading', { name: 'My Custom Template' })).toBeInTheDocument();
+      expect(screen.getByTestId('dashboard-card-description')).toHaveTextContent('A custom template description');
       expect(screen.queryByText('No preview available')).not.toBeInTheDocument();
     });
 
@@ -806,7 +827,7 @@ describe('DashboardCard', () => {
       expect(screen.getByText('team-a')).toBeInTheDocument();
     });
 
-    it('should fall back to "No description available" when description is empty', () => {
+    it('should not render a description when a custom template has none', () => {
       const dashboard = createMockCustomTemplateDashboard({ description: '' });
       render(
         <DashboardCard
@@ -817,7 +838,7 @@ describe('DashboardCard', () => {
         />
       );
 
-      expect(screen.getByTestId('dashboard-card-description')).toHaveTextContent('No description available');
+      expect(screen.queryByTestId('dashboard-card-description')).not.toBeInTheDocument();
     });
 
     it('should call onEdit when the Edit menu item is clicked', async () => {

--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/DashboardCard.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/DashboardCard.tsx
@@ -238,19 +238,6 @@ function DashboardCardComponent({
               e.currentTarget.style.display = 'none';
             }}
           />
-        ) : isCustomTemplate ? (
-          <div className={styles.customTemplateContent}>
-            <h3 className={styles.customTemplateTitle}>
-              <span className={styles.titleText}>{title}</span>
-            </h3>
-            <p
-              data-testid="dashboard-card-description"
-              className={cx(styles.customTemplateDescription, { [styles.noDescription]: !dashboard.description })}
-            >
-              {dashboard.description ||
-                t('dashboard-library.dashboard-card.no-description', 'No description available')}
-            </p>
-          </div>
         ) : (
           <div className={styles.noImage}>
             <Trans i18nKey="dashboard-library.card.no-preview">No preview available </Trans>
@@ -308,15 +295,21 @@ function DashboardCardComponent({
         </div>
       </div>
       <div className={styles.bottomSection}>
-        {!isCustomTemplate && (
+        {isCustomTemplate && (
+          <h3 className={styles.customTemplateTitle}>
+            <span className={styles.titleText}>{title}</span>
+          </h3>
+        )}
+        {dashboard.description && (
           <div title={dashboard.description}>
-            <p
-              data-testid="dashboard-card-description"
-              className={cx(styles.description, { [styles.noDescription]: !dashboard.description })}
-            >
-              {dashboard.description ||
-                t('dashboard-library.dashboard-card.no-description', 'No description available')}
+            <p data-testid="dashboard-card-description" className={styles.description}>
+              {dashboard.description}
             </p>
+          </div>
+        )}
+        {tags && tags.length > 0 && (
+          <div className={styles.tagsContainer}>
+            <TagList tags={tags} className={styles.tagList} />
           </div>
         )}
         {isCustomTemplate && createdByName && (
@@ -326,11 +319,6 @@ function DashboardCardComponent({
             </span>{' '}
             {createdByName}
           </p>
-        )}
-        {tags && tags.length > 0 && (
-          <div className={styles.tagsContainer}>
-            <TagList tags={tags} className={styles.tagList} />
-          </div>
         )}
         {hasCompatActions && (
           <div className={styles.actionsContainer}>
@@ -476,18 +464,6 @@ function getStyles(theme: GrafanaTheme2) {
     },
   });
 
-  const customTemplateContent = css({
-    position: 'absolute',
-    inset: 0,
-    display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'flex-start',
-    justifyContent: 'center',
-    gap: theme.spacing(0.5),
-    padding: theme.spacing(2),
-    pointerEvents: 'none',
-  });
-
   return {
     card: css({
       position: 'relative',
@@ -608,7 +584,6 @@ function getStyles(theme: GrafanaTheme2) {
       height: '100%',
       width: '100%',
     }),
-    customTemplateContent,
     customTemplateThumbnail: css({
       '&::after': {
         content: 'none',
@@ -630,16 +605,6 @@ function getStyles(theme: GrafanaTheme2) {
       overflow: 'hidden',
       textOverflow: 'ellipsis',
       maxWidth: '100%',
-    }),
-    customTemplateDescription: css({
-      display: '-webkit-box',
-      WebkitLineClamp: 3,
-      WebkitBoxOrient: 'vertical',
-      overflow: 'hidden',
-      textOverflow: 'ellipsis',
-      margin: 0,
-      fontSize: theme.typography.bodySmall.fontSize,
-      color: theme.colors.text.secondary,
     }),
     createdBy: css({
       margin: 0,
@@ -689,9 +654,6 @@ function getStyles(theme: GrafanaTheme2) {
       margin: 0,
       fontSize: theme.typography.bodySmall.fontSize,
       color: theme.colors.text.secondary,
-    }),
-    noDescription: css({
-      fontStyle: 'italic',
     }),
     tagsContainer: css({
       paddingTop: theme.spacing(1),

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -6612,8 +6612,7 @@
         "last-update": "Last Update",
         "published-by": "Published By",
         "view-on-grafana-com": "View on Grafana.com"
-      },
-      "no-description": "No description available"
+      }
     },
     "grafana-dashboard-template-modal": {
       "no-results-found": "No template dashboards found"


### PR DESCRIPTION
Paired with grafana/grafana-enterprise#12738 (custom dashboard template preview images).

Custom dashboard template cards showed the title and description only as a text overlay in the thumbnail area, which is hidden once a preview image is present. This moves the title and description into the card's bottom section (next to "Created by:") so they're always visible, and shows the standard "No preview available" placeholder when a template has no image.

<img width="1231" height="562" alt="Screenshot 2026-07-21 at 9 54 12 AM" src="https://github.com/user-attachments/assets/f4903458-3cd6-4491-b62d-ecb44a4ccae8" />

