### PR TITLE
Docs: Explain the Git Sync _folder.json folder metadata file

### DIFF
--- a/docs/sources/as-code/observability-as-code/git-sync/key-concepts.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/key-concepts.md
@@ -124,9 +124,11 @@ your-org/grafana-manifests/
 └── grafana/
     ├── cpu-metrics.json
     └── team-platform/
-        ├── .folder.json
+        ├── _folder.json
         └── memory-usage.json
 ```
+
+The `_folder.json` file stores the `team-platform` folder's stable UID and display name, so the folder keeps its identity and permissions if you move or rename it in the repository. Refer to [The Git Sync folder metadata file](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/use-git-sync/#the-git-sync-folder-metadata-file) for details.
 
 The instance also has content that isn't managed by Git Sync: a manually created **Ops** folder and an **Ad-hoc dashboard**.
 

--- a/docs/sources/as-code/observability-as-code/git-sync/permissions-grafana.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/permissions-grafana.md
@@ -163,9 +163,9 @@ When Git Sync creates a provisioned folder, it assigns these default permissions
 ### Modify folder-level permissions
 
 {{< admonition type="note" >}}
-To safely modify permissions, each provisioned folder should include a `.folder.json` metadata file with the folder's UID. Without this file, folder permissions may be lost if the folder is moved to a different path in the Git repository.
+To safely modify permissions, each provisioned folder should include a `_folder.json` metadata file with the folder's UID. Without this file, folder permissions may be lost if the folder is moved to a different path in the Git repository.
 
-For folders created from the Grafana UI, the metadata file is added automatically. If your folder is missing the metadata file, the UI shows a warning with instructions on how to add it.
+For folders created from the Grafana UI, the metadata file is added automatically. If your folder is missing the metadata file, the UI shows a warning with instructions on how to add it. Refer to [The Git Sync folder metadata file](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/use-git-sync/#the-git-sync-folder-metadata-file) for details about this file and why it exists.
 {{< /admonition >}}
 
 You can customize folder permissions using:

--- a/docs/sources/as-code/observability-as-code/git-sync/use-git-sync.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/use-git-sync.md
@@ -116,9 +116,7 @@ Refer to [Git Sync permissions](https://grafana.com/docs/grafana/<GRAFANA_VERSIO
 ### Modify folder permissions
 
 {{< admonition type="note" >}}
-To modify permissions, each provisioned folder must include the `_folder.json` metadata file with the folder's UID, which defines a stable folder ID used to set folder permissions. Without it, the folder's permissions will be lost if you move that folder to a different path in the Git repository.
-
-For new provisioned folders managed with Git Sync, the metadata file is added automatically if you created the folder from the Grafana UI. If your folder is missing the metadata file, you'll see a warning in the UI with instructions on how to add the missing metadata.
+To modify permissions, each provisioned folder must include the `_folder.json` metadata file, which gives the folder a stable UID. Without it, the folder's permissions are lost if you move or rename that folder in the Git repository. Refer to [The Git Sync folder metadata file](#the-git-sync-folder-metadata-file) for details about this file and why it exists.
 {{< /admonition >}}
 
 To add or modify folder permissions:
@@ -126,9 +124,21 @@ To add or modify folder permissions:
 - From the UI, select **Folder actions > Manage permissions** on the top right corner.
 - Using the API, refer to [Dashboard Permissions API](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developer-resources/api-reference/http-api/dashboard_permissions/).
 
-### The Git Sync folder JSON metadata file
+### The Git Sync folder metadata file
 
-Each folder in a synced repository contains a `_folder.json` file at its root:
+Each provisioned folder in a synced repository contains a `_folder.json` metadata file at its root. This file is the folder's manifest: it stores the folder's stable UID and its display name, so both survive changes to the repository layout.
+
+The file exists because a directory path isn't a stable identity. Without `_folder.json`, Grafana derives the folder UID from a hash of the directory path in the repository. If you move or rename that directory in Git, the hash changes and Grafana treats it as a different folder: everything attached to the old UID, such as custom folder permissions, bookmarks, and API references, is lost. With `_folder.json`, the UID travels with the directory, so you can reorganize your repository without breaking permissions or references.
+
+The file also separates the folder's display name from the directory name. The directory keeps a filesystem-friendly name, for example `team-platform`, while the `spec.title` field holds the name shown in the Grafana UI, for example `Team Platform`.
+
+Grafana manages this file for you:
+
+- When you create a provisioned folder from the Grafana UI, Git Sync commits the `_folder.json` file together with the folder.
+- When you rename a folder in Grafana, Git Sync updates the `spec.title` field in the file.
+- If a folder is missing the file, for example because you created the directory directly in Git, Grafana falls back to the hash-derived UID and shows a warning in the UI with instructions on how to add the missing metadata.
+
+The file has the following format:
 
 ```json
 {
@@ -145,6 +155,6 @@ Each folder in a synced repository contains a `_folder.json` file at its root:
 
 Where:
 
-- `<API_VERSION>` is the version of the API you want to use. For example, `folder.grafana.app/v1`.
-- `<FOLDER_UID>` is the stable folder UID that Grafana uses for permissions, bookmarks, and API references.
-- `<FOLDER_UI_NAME>` is the display name shown in the Grafana UI. This parameter is optional. If not used, the folder name will be passed instead.
+- `<API_VERSION>` is the version of the folders API. For example, `folder.grafana.app/v1`.
+- `<FOLDER_UID>` is the stable folder UID that Grafana uses for permissions, bookmarks, and API references. Treat this value as immutable: Grafana rejects folder UID changes, and changing it directly in Git breaks the link between the directory and the existing Grafana folder, with the same consequences as having no metadata file.
+- `<FOLDER_UI_NAME>` is the display name shown in the Grafana UI. This field is optional. If it's not set, Grafana uses the directory name instead.


### PR DESCRIPTION
## What

Improves the Git Sync documentation around the `_folder.json` folder metadata file:

- Rewrites the "The Git Sync folder JSON metadata file" section in `use-git-sync.md` to explain what the file is and why it exists, instead of only showing its JSON format.
- Fixes an incorrect filename in `key-concepts.md` and `permissions-grafana.md`: they referred to `.folder.json` (dot prefix), but the provisioning code writes `_folder.json` (underscore, see `folderMetadataFileName` in `pkg/registry/apis/provisioning/resources/folder_metadata.go`).
- Adds cross-links to the detailed section from the places that mention the file, and a one-sentence explanation where the file appears in the `key-concepts.md` repository tree example.

## Why

The docs showed the `_folder.json` format but never explained its purpose, and two pages referenced a filename that doesn't exist. Users creating folders directly in Git had no way to understand why the file matters or what breaks without it.

## How

The new section explains, based on the actual provisioning behavior:

- **What it is**: a per-folder manifest storing the stable folder UID (`metadata.name`) and display name (`spec.title`).
- **Why it exists**: without it, Grafana derives the folder UID from a hash of the directory path, so moving or renaming the directory changes the UID and Grafana treats it as a different folder — losing custom permissions, bookmarks, and API references. With the file, the UID travels with the directory.
- It also decouples the display name from the filesystem-friendly directory name.
- **Who manages it**: Grafana writes it automatically for folders created in the UI, updates `spec.title` on rename, and shows a UI warning for folders missing it (falling back to the hash-derived UID).
- **A caution** that the UID is immutable: Grafana rejects UID changes, and editing it directly in Git breaks the folder's identity.

## Testing

- Docs-only change; `prettier --check` passes on all three edited files.

## Checklist

- [x] Documentation updated
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)