### PR TITLE
TimeSeries: Wait for annotation draw ops before snapshotting canvas tests

### DIFF
--- a/public/app/plugins/panel/timeseries/TimeSeriesPanel.canvasTestUtils.tsx
+++ b/public/app/plugins/panel/timeseries/TimeSeriesPanel.canvasTestUtils.tsx
@@ -232,13 +232,19 @@ export function setupCanvasCapture(): void {
   });
 }
 
-const assertUPlotReady = async () => {
+const assertUPlotReady = async (ready?: () => boolean) => {
   await waitFor(() =>
     expect(screen.getByTestId(selectors.components.VizLayout.container).querySelector('.u-over')).toBeVisible()
   );
-  // Some plugins redraw after their overlay mounts (e.g. the annotations plugin redraws once its markers
-  // are in the DOM). Under parallel test load that redraw can land after the first `.u-over` paint, so wait
-  // for the captured event stream to stabilize (two consecutive polls with the same count) before snapshotting.
+  // Some plugins draw only on a deferred redraw (e.g. the annotations plugin re-renders through React
+  // once uPlot publishes its time range, then draws on the next frame). Count stability alone can be
+  // satisfied BEFORE that redraw has even started, so when the case knows which ops must appear, wait
+  // for them first.
+  if (ready) {
+    await waitFor(() => expect(ready()).toBe(true));
+  }
+  // Under parallel test load a redraw can land after the first `.u-over` paint, so wait for the captured
+  // event stream to stabilize (two consecutive polls with the same count) before snapshotting.
   let previousCount = -1;
   await waitFor(() => {
     const count = uPlotInstance?.ctx.__getEvents().length ?? 0;
@@ -267,7 +273,17 @@ export async function renderCanvasCase(
   layer: 'series' | 'axes' = 'series'
 ): Promise<void> {
   renderTimeSeriesPanel(data, options, panelProps);
-  await assertUPlotReady();
+
+  // The annotations plugin draws its lines/regions on a redraw that fires only after uPlot sets the
+  // x-scale range and React re-renders the plugin (forceUpdate in AnnotationsPlugin). That redraw can
+  // start after the event stream already looks stable, so require the annotation ops — setLineDash is
+  // emitted only by the annotation pass in these suites — before trusting stability.
+  const expectAnnotations = Boolean(data?.annotations?.length);
+  await assertUPlotReady(
+    expectAnnotations
+      ? () => (uPlotInstance?.ctx.__getEvents() ?? []).some((event) => event.type === 'setLineDash')
+      : undefined
+  );
 
   const events = uPlotInstance!.ctx.__getEvents();
   const axisEvents = events.slice(0, axisBoundary);


### PR DESCRIPTION
**What is this feature?**

Makes the new timeseries canvas snapshot tests deterministic: when a case provides annotations, the test now waits for the annotation draw calls (`setLineDash` — emitted only by the annotation pass in these suites) to appear in the captured event stream before checking that the stream is stable and snapshotting.

**Why do we need this feature?**

`TimeSeriesPanel.annotations.canvas.test.tsx` (added in #127513) is flaky on loaded CI runners: `AnnotationsPlugin` draws its lines/regions on a redraw that fires only after uPlot publishes the x-scale range and React re-renders the plugin (`forceUpdate`). The existing "two consecutive polls with the same draw-call count" stability wait can be satisfied before that redraw has even started, so the test snapshots a frame without the annotation ops and fails with `- Snapshot - 162 / + Received + 0`. This reproduced twice in a row on grafana-enterprise CI (which pairs with OSS main) and passed on the third rerun of identical code; it never reproduces on fast local machines because they win the race.

**Who is this feature for?**

Anyone whose PR CI runs the frontend unit test suite — in both grafana and grafana-enterprise (whose CI pairs with OSS main).

**Special notes for your reviewer:**

- The fix only strengthens the wait: with the redraw on time the predicate is already true and nothing changes; with the redraw late the test now waits for it (or fails loudly with a `waitFor` timeout instead of a misleading snapshot diff).
- Verified the predicate is load-bearing by making it momentarily unsatisfiable — the annotation case then fails with a clean timeout; restored, all 34 timeseries suites pass (410 tests, 119 snapshots, unchanged).
