### PR TITLE
fix(QueryVarEditor): Fix "Run query" button not showing when editing an existing variable

### DIFF
--- a/public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor/ModalEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor/ModalEditor.tsx
@@ -217,7 +217,7 @@ function useModalEditor({ variable, onClose }: ModalEditorProps) {
   const { options, staticOptions = [], staticOptionsOrder } = draftVariable.useState();
   const [queryError, setQueryError] = useState<Error>();
   const [isLoading, setIsLoading] = useState(false);
-  const [hasRunQuery, setHasRunQuery] = useState(false);
+  const [hasRunQuery, setHasRunQuery] = useState(Boolean(initialState.query));
 
   const updateVariable = async (targetVariable: QueryVariable, stateUpdate?: Partial<QueryVariable['state']>) => {
     if (stateUpdate) {


### PR DESCRIPTION
This PR fixes a bug where the “Run query” button does not show when reopening the query variable editor for an existing variable that already has a query.

