### PR TITLE
fix(navtree): filter Assistant navigation entries by deployment mode

### DIFF
--- a/pkg/services/navtree/navtreeimpl/applinks.go
+++ b/pkg/services/navtree/navtreeimpl/applinks.go
@@ -21,9 +21,10 @@ const assertsServicesPath = "/a/grafana-asserts-app/services"
 const appObservabilityAppID = "grafana-app-observability-app"
 const assistantAppID = "grafana-assistant-app"
 const assistantOnboardingAppID = "grafana-assistant-onboarding-app"
+const assistantAppHomePath = "/a/" + assistantAppID
 
 var assistantOSSNavigationPaths = map[string]struct{}{
-	"/a/grafana-assistant-app":           {},
+	assistantAppHomePath:                 {},
 	"/a/grafana-assistant-app/workspace": {},
 	"/a/grafana-assistant-app/settings":  {},
 }
@@ -182,6 +183,7 @@ func (s *ServiceImpl) shouldIncludeInvestigations(plugin pluginstore.Plugin, inc
 
 func (s *ServiceImpl) processAppPlugin(plugin pluginstore.Plugin, c *contextmodel.ReqContext, treeRoot *navtree.NavTreeRoot) *navtree.NavLink {
 	hasAccessToInclude := s.hasAccessToInclude(c, plugin.ID)
+	assistantTrialMode := s.isAssistantTrialMode(plugin, c)
 	appLink := &navtree.NavLink{
 		Text:       plugin.Name,
 		Id:         "plugin-page-" + plugin.ID,
@@ -198,7 +200,7 @@ func (s *ServiceImpl) processAppPlugin(plugin pluginstore.Plugin, c *contextmode
 			continue
 		}
 
-		if !s.shouldIncludeAssistantNavigation(plugin, include) {
+		if !s.shouldIncludeAssistantNavigation(plugin, include, assistantTrialMode) {
 			continue
 		}
 
@@ -309,8 +311,31 @@ func (s *ServiceImpl) processAppPlugin(plugin pluginstore.Plugin, c *contextmode
 	return nil
 }
 
-func (s *ServiceImpl) shouldIncludeAssistantNavigation(plugin pluginstore.Plugin, include *plugins.Includes) bool {
-	if plugin.ID != assistantAppID || s.cfg.IsEnterprise || s.cfg.StackID != "" {
+func (s *ServiceImpl) isAssistantTrialMode(plugin pluginstore.Plugin, c *contextmodel.ReqContext) bool {
+	if plugin.ID != assistantAppID {
+		return false
+	}
+
+	ps, err := s.pluginSettings.GetPluginSettingByPluginID(c.Req.Context(), &pluginsettings.GetByPluginIDArgs{
+		PluginID: plugin.ID,
+		OrgID:    c.GetOrgID(),
+	})
+	if err != nil {
+		return false
+	}
+
+	trialMode, ok := ps.JSONData["trialMode"].(bool)
+	return ok && trialMode
+}
+
+func (s *ServiceImpl) shouldIncludeAssistantNavigation(plugin pluginstore.Plugin, include *plugins.Includes, trialMode bool) bool {
+	if plugin.ID != assistantAppID {
+		return true
+	}
+	if trialMode {
+		return include.Path == assistantAppHomePath
+	}
+	if s.cfg.IsEnterprise || s.cfg.StackID != "" {
 		return true
 	}
 

--- a/pkg/services/navtree/navtreeimpl/applinks.go
+++ b/pkg/services/navtree/navtreeimpl/applinks.go
@@ -22,6 +22,12 @@ const appObservabilityAppID = "grafana-app-observability-app"
 const assistantAppID = "grafana-assistant-app"
 const assistantOnboardingAppID = "grafana-assistant-onboarding-app"
 
+var assistantOSSNavigationPaths = map[string]struct{}{
+	"/a/grafana-assistant-app":           {},
+	"/a/grafana-assistant-app/workspace": {},
+	"/a/grafana-assistant-app/settings":  {},
+}
+
 func (s *ServiceImpl) addAppLinks(treeRoot *navtree.NavTreeRoot, c *contextmodel.ReqContext) error {
 	hasAccess := ac.HasAccess(s.accessControl, c)
 	appLinks := []*navtree.NavLink{}
@@ -192,6 +198,10 @@ func (s *ServiceImpl) processAppPlugin(plugin pluginstore.Plugin, c *contextmode
 			continue
 		}
 
+		if !s.shouldIncludeAssistantNavigation(plugin, include) {
+			continue
+		}
+
 		if !s.shouldIncludeInvestigations(plugin, include, c) {
 			continue
 		}
@@ -297,6 +307,15 @@ func (s *ServiceImpl) processAppPlugin(plugin pluginstore.Plugin, c *contextmode
 	}
 
 	return nil
+}
+
+func (s *ServiceImpl) shouldIncludeAssistantNavigation(plugin pluginstore.Plugin, include *plugins.Includes) bool {
+	if plugin.ID != assistantAppID || s.cfg.IsEnterprise || s.cfg.StackID != "" {
+		return true
+	}
+
+	_, allowed := assistantOSSNavigationPaths[include.Path]
+	return allowed
 }
 
 func (s *ServiceImpl) addPluginToSection(c *contextmodel.ReqContext, treeRoot *navtree.NavTreeRoot, plugin pluginstore.Plugin, appLink *navtree.NavLink) {

--- a/pkg/services/navtree/navtreeimpl/applinks_test.go
+++ b/pkg/services/navtree/navtreeimpl/applinks_test.go
@@ -900,6 +900,70 @@ func TestAddAppLinksAccessControl(t *testing.T) {
 	})
 }
 
+func TestProcessAssistantAppPlugin(t *testing.T) {
+	reqCtx := &contextmodel.ReqContext{SignedInUser: &user.SignedInUser{OrgRole: identity.RoleAdmin}}
+	assistantApp := pluginstore.Plugin{
+		JSONData: plugins.JSONData{
+			ID:   assistantAppID,
+			Name: "Assistant",
+			Type: plugins.TypeApp,
+			Includes: []*plugins.Includes{
+				{Name: "Home", Path: "/a/grafana-assistant-app", Type: "page", AddToNav: true, DefaultNav: true},
+				{Name: "Workspace", Path: "/a/grafana-assistant-app/workspace", Type: "page", AddToNav: true},
+				{Name: "Settings", Path: "/a/grafana-assistant-app/settings", Type: "page", AddToNav: true},
+				{Name: "Irrelevant", Path: "/a/grafana-assistant-app/irrelevant", Type: "page", AddToNav: true},
+			},
+		},
+	}
+
+	for _, tt := range []struct {
+		name           string
+		cfg            *setting.Cfg
+		wantChildPaths []string
+	}{
+		{
+			name: "OSS only includes supported entries",
+			cfg:  setting.NewCfg(),
+			wantChildPaths: []string{
+				"/a/grafana-assistant-app/workspace",
+				"/a/grafana-assistant-app/settings",
+			},
+		},
+		{
+			name: "Enterprise includes all entries",
+			cfg:  &setting.Cfg{IsEnterprise: true},
+			wantChildPaths: []string{
+				"/a/grafana-assistant-app/workspace",
+				"/a/grafana-assistant-app/settings",
+				"/a/grafana-assistant-app/irrelevant",
+			},
+		},
+		{
+			name: "Cloud includes all entries",
+			cfg:  &setting.Cfg{StackID: "1"},
+			wantChildPaths: []string{
+				"/a/grafana-assistant-app/workspace",
+				"/a/grafana-assistant-app/settings",
+				"/a/grafana-assistant-app/irrelevant",
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			service := ServiceImpl{cfg: tt.cfg}
+			treeRoot := navtree.NavTreeRoot{}
+			service.processAppPlugin(assistantApp, reqCtx, &treeRoot)
+			appLink := treeRoot.FindById("plugin-page-" + assistantAppID)
+
+			require.NotNil(t, appLink)
+			require.Equal(t, "/a/grafana-assistant-app", appLink.Url)
+			require.Len(t, appLink.Children, len(tt.wantChildPaths))
+			for i, wantPath := range tt.wantChildPaths {
+				require.Equal(t, wantPath, appLink.Children[i].Url)
+			}
+		})
+	}
+}
+
 func TestNestMaintenanceWindowsUnderSLO(t *testing.T) {
 	httpReq, _ := http.NewRequest(http.MethodGet, "", nil)
 	reqCtx := &contextmodel.ReqContext{SignedInUser: &user.SignedInUser{}, Context: &web.Context{Req: httpReq}}

--- a/pkg/services/navtree/navtreeimpl/applinks_test.go
+++ b/pkg/services/navtree/navtreeimpl/applinks_test.go
@@ -901,7 +901,11 @@ func TestAddAppLinksAccessControl(t *testing.T) {
 }
 
 func TestProcessAssistantAppPlugin(t *testing.T) {
-	reqCtx := &contextmodel.ReqContext{SignedInUser: &user.SignedInUser{OrgRole: identity.RoleAdmin}}
+	httpReq, _ := http.NewRequest(http.MethodGet, "", nil)
+	reqCtx := &contextmodel.ReqContext{
+		SignedInUser: &user.SignedInUser{OrgRole: identity.RoleAdmin},
+		Context:      &web.Context{Req: httpReq},
+	}
 	assistantApp := pluginstore.Plugin{
 		JSONData: plugins.JSONData{
 			ID:   assistantAppID,
@@ -919,6 +923,7 @@ func TestProcessAssistantAppPlugin(t *testing.T) {
 	for _, tt := range []struct {
 		name           string
 		cfg            *setting.Cfg
+		trialMode      bool
 		wantChildPaths []string
 	}{
 		{
@@ -947,9 +952,19 @@ func TestProcessAssistantAppPlugin(t *testing.T) {
 				"/a/grafana-assistant-app/irrelevant",
 			},
 		},
+		{
+			name:      "Trial mode only includes the homepage",
+			cfg:       setting.NewCfg(),
+			trialMode: true,
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			service := ServiceImpl{cfg: tt.cfg}
+			service := ServiceImpl{
+				cfg: tt.cfg,
+				pluginSettings: &pluginsettings.FakePluginSettings{Plugins: map[string]*pluginsettings.DTO{
+					assistantAppID: {OrgID: 1, PluginID: assistantAppID, JSONData: map[string]any{"trialMode": tt.trialMode}},
+				}},
+			}
 			treeRoot := navtree.NavTreeRoot{}
 			service.processAppPlugin(assistantApp, reqCtx, &treeRoot)
 			appLink := treeRoot.FindById("plugin-page-" + assistantAppID)


### PR DESCRIPTION
What

- Filter Assistant navigation entries based on OSS, Enterprise and Cloud modes.
- Adds coverage for each navigation mode.

Why

- Prevent unsupported Assistant pages from appearing in OSS deployments.