### PR TITLE
Wire manifest watcher into search field reloads

### DIFF
--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -850,6 +850,11 @@ type Cfg struct {
 	TenantDeleterDryRun           bool
 	TenantDeleterInterval         time.Duration
 
+	ManifestApiServerAddress        string
+	ManifestWatcherAllowInsecureTLS bool
+	ManifestWatcherCAFile           string
+	ManifestWatcherPollInterval     time.Duration
+
 	// Secrets Management
 	SecretsManagement SecretsManagerSettings
 

--- a/pkg/setting/setting_unified_storage.go
+++ b/pkg/setting/setting_unified_storage.go
@@ -233,6 +233,12 @@ func (cfg *Cfg) setUnifiedStorageConfig() {
 	cfg.TenantWatcherUsePolling = section.Key("tenant_watcher_use_polling").MustBool(false)
 	cfg.TenantWatcherPollInterval = section.Key("tenant_watcher_poll_interval").MustDuration(1 * time.Hour)
 
+	// search manifest watcher
+	cfg.ManifestApiServerAddress = section.Key("manifest_api_server_address").String()
+	cfg.ManifestWatcherAllowInsecureTLS = section.Key("manifest_watcher_allow_insecure_tls").MustBool(false)
+	cfg.ManifestWatcherCAFile = section.Key("manifest_watcher_ca_file").String()
+	cfg.ManifestWatcherPollInterval = section.Key("manifest_watcher_poll_interval").MustDuration(1 * time.Hour)
+
 	// tenant deleter
 	cfg.EnableTenantDeleter = section.Key("tenant_deleter_enabled").MustBool(false)
 	cfg.TenantDeleterDryRun = section.Key("tenant_deleter_dry_run").MustBool(true)

--- a/pkg/storage/unified/resource/manifest_watcher.go
+++ b/pkg/storage/unified/resource/manifest_watcher.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -25,6 +26,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/clientauth"
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 // v1alpha2 is the only version with SearchFields.
@@ -55,6 +57,39 @@ type ManifestWatcherConfig struct {
 	// PollInterval is the delay between poll cycles. Defaults to 1 hour if zero.
 	PollInterval time.Duration
 	Log          log.Logger
+}
+
+// NewManifestWatcherConfig builds a ManifestWatcherConfig from Grafana settings
+// and returns nil when the apiserver URL, token, or token exchange URL are
+// unset, so the watcher stays off unless explicitly configured.
+func NewManifestWatcherConfig(cfg *setting.Cfg) *ManifestWatcherConfig {
+	logger := log.New("search-manifest-watcher")
+	if cfg == nil {
+		return nil
+	}
+
+	grpcSection := cfg.SectionWithEnvOverrides("grpc_client_authentication")
+	allowInsecure := cfg.ManifestWatcherAllowInsecureTLS
+	if allowInsecure && cfg.Env != setting.Dev {
+		logger.Error("manifest_watcher_allow_insecure_tls is set but app_mode is not 'development'; enforcing TLS verification", "app_mode", cfg.Env)
+		allowInsecure = false
+	}
+
+	wc := &ManifestWatcherConfig{
+		APIServerURL:     strings.TrimSpace(cfg.ManifestApiServerAddress),
+		Token:            strings.TrimSpace(grpcSection.Key("token").MustString("")),
+		TokenExchangeURL: strings.TrimSpace(grpcSection.Key("token_exchange_url").MustString("")),
+		CAFile:           strings.TrimSpace(cfg.ManifestWatcherCAFile),
+		AllowInsecure:    allowInsecure,
+		PollInterval:     cfg.ManifestWatcherPollInterval,
+		Log:              logger,
+	}
+
+	if wc.APIServerURL == "" || wc.Token == "" || wc.TokenExchangeURL == "" {
+		logger.Warn("manifest watcher not configured - ensure manifest api server address, token, and token exchange url are set")
+		return nil
+	}
+	return wc
 }
 
 // ManifestWatcher polls the app-platform apiserver for AppManifests and keeps a

--- a/pkg/storage/unified/resource/manifest_watcher_test.go
+++ b/pkg/storage/unified/resource/manifest_watcher_test.go
@@ -4,8 +4,10 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/grafana/grafana-app-sdk/app"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -220,4 +222,47 @@ func TestManifestWatcher_SkipsManifestThatFailsToConvert(t *testing.T) {
 	got := w.Manifests()
 	require.Len(t, got, 1)
 	require.Equal(t, "dashboard.grafana.app", got[0].ManifestData.Group)
+}
+
+func TestNewManifestWatcherConfig(t *testing.T) {
+	newCfg := func() *setting.Cfg {
+		cfg := setting.NewCfg()
+		sec, err := cfg.Raw.NewSection("grpc_client_authentication")
+		require.NoError(t, err)
+		_, err = sec.NewKey("token", "tok")
+		require.NoError(t, err)
+		_, err = sec.NewKey("token_exchange_url", "http://exchange")
+		require.NoError(t, err)
+		return cfg
+	}
+
+	t.Run("nil when address missing", func(t *testing.T) {
+		require.Nil(t, NewManifestWatcherConfig(newCfg()))
+	})
+
+	t.Run("nil config returns nil", func(t *testing.T) {
+		require.Nil(t, NewManifestWatcherConfig(nil))
+	})
+
+	t.Run("configured when all set", func(t *testing.T) {
+		cfg := newCfg()
+		cfg.ManifestApiServerAddress = "https://apiserver"
+		cfg.ManifestWatcherPollInterval = 5 * time.Minute
+		wc := NewManifestWatcherConfig(cfg)
+		require.NotNil(t, wc)
+		require.Equal(t, "https://apiserver", wc.APIServerURL)
+		require.Equal(t, "tok", wc.Token)
+		require.Equal(t, "http://exchange", wc.TokenExchangeURL)
+		require.Equal(t, 5*time.Minute, wc.PollInterval)
+	})
+
+	t.Run("insecure TLS ignored outside development", func(t *testing.T) {
+		cfg := newCfg()
+		cfg.ManifestApiServerAddress = "https://apiserver"
+		cfg.ManifestWatcherAllowInsecureTLS = true
+		cfg.Env = setting.Prod
+		wc := NewManifestWatcherConfig(cfg)
+		require.NotNil(t, wc)
+		require.False(t, wc.AllowInsecure)
+	})
 }

--- a/pkg/storage/unified/resource/search_field_manifest.go
+++ b/pkg/storage/unified/resource/search_field_manifest.go
@@ -157,6 +157,19 @@ func SearchFieldsHashesForProviders(providers map[LowerGroupResource]SearchField
 	return out
 }
 
+// ApplyManifests rebuilds the registry from the built-in and live manifest sets
+// and swaps them in. On error the registry is left unchanged, so a bad reload
+// keeps the current search fields.
+func ApplyManifests(registry *SearchFieldsRegistry, builtin, live []app.Manifest) error {
+	merged := MergeManifestsByKind(builtin, live)
+	selectable, hashes, providers, err := SearchFieldsForManifests(merged)
+	if err != nil {
+		return err
+	}
+	registry.Replace(selectable, hashes, providers)
+	return nil
+}
+
 // SearchFieldsForManifests builds a SearchFieldsRegistry's three inputs from one
 // manifest list, so a reload can rebuild them together and keep them consistent.
 func SearchFieldsForManifests(manifests []app.Manifest) (

--- a/pkg/storage/unified/resource/search_field_manifest_test.go
+++ b/pkg/storage/unified/resource/search_field_manifest_test.go
@@ -271,3 +271,35 @@ func TestSearchFieldsForManifests(t *testing.T) {
 	require.NotEmpty(t, hashes)
 	require.NotEmpty(t, selectable)
 }
+
+func TestApplyManifests(t *testing.T) {
+	registry := NewSearchFieldsRegistry(nil, nil, nil)
+	builtin := []app.Manifest{
+		mergeTestManifest("builtin", "a.test", app.ManifestVersion{Name: "v1", Kinds: []app.ManifestVersionKind{mergeTestKind("Foo", "builtinfield")}}),
+	}
+	require.NoError(t, ApplyManifests(registry, builtin, nil))
+
+	key := NewLowerGroupResource("a.test", "foos")
+	gvr := schema.GroupVersionResource{Group: "a.test", Version: "v1", Resource: "foos"}
+	_, hashBuiltin, provider := registry.For(key)
+	require.NotNil(t, provider)
+	require.NotEmpty(t, hashBuiltin)
+
+	// A live source overrides the same kind with a different field. The registry
+	// must reflect the live declaration and its hash must change.
+	live := []app.Manifest{
+		mergeTestManifest("live", "a.test", app.ManifestVersion{Name: "v1", Kinds: []app.ManifestVersionKind{mergeTestKind("Foo", "livefield")}}),
+	}
+	require.NoError(t, ApplyManifests(registry, builtin, live))
+
+	_, hashLive, provider := registry.For(key)
+	require.NotEqual(t, hashBuiltin, hashLive)
+
+	fields := provider.Fields(gvr)
+	names := make([]string, 0, len(fields))
+	for _, f := range fields {
+		names = append(names, f.Name)
+	}
+	require.Contains(t, names, "livefield")
+	require.NotContains(t, names, "builtinfield")
+}

--- a/pkg/storage/unified/sql/service.go
+++ b/pkg/storage/unified/sql/service.go
@@ -22,6 +22,7 @@ import (
 	"github.com/grafana/dskit/netutil"
 	"github.com/grafana/dskit/ring"
 	"github.com/grafana/dskit/services"
+	appsdk "github.com/grafana/grafana-app-sdk/app"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/modules"
 	"github.com/grafana/grafana/pkg/services/authz"
@@ -50,6 +51,11 @@ type service struct {
 	subservices        []services.Service
 	subservicesMngr    *services.Manager
 	subservicesWatcher *services.FailureWatcher
+
+	// manifestWatcher reloads search fields from the app-platform apiserver when
+	// configured. Created in registerServer (it needs the search registry that
+	// NewSearchOptions builds), started in starting(), nil when unconfigured.
+	manifestWatcher *resource.ManifestWatcher
 
 	// -- Shared Components
 	backend       resource.StorageBackend
@@ -349,6 +355,16 @@ func (s *service) starting(ctx context.Context) error {
 		}
 	}
 
+	// Start the manifest watcher directly rather than through subservicesMngr,
+	// which is already built by the time registerServer creates the watcher. We
+	// don't wait for it: the initial poll reaches the apiserver and the periodic
+	// rebuild check applies any change afterwards.
+	if s.manifestWatcher != nil {
+		if err := s.manifestWatcher.StartAsync(ctx); err != nil {
+			return fmt.Errorf("failed to start manifest watcher: %w", err)
+		}
+	}
+
 	// TODO: move to standalone mode once we use sharding in search servers
 	if s.cfg.EnableSharding {
 		s.log.Info("waiting until resource server is JOINING in the ring")
@@ -395,6 +411,26 @@ func (s *service) registerServer(provider grpcserver.Provider) error {
 	searchOptions, err := search.NewSearchOptions(s.features, s.cfg, s.docBuilders, s.indexMetrics, s.OwnsIndex, snapshotStore)
 	if err != nil {
 		return err
+	}
+
+	// Build the manifest watcher here because it reloads into the search registry
+	// that NewSearchOptions just created. registerServer runs at construction time
+	// (from the Provide* constructors), always before the service's starting()
+	// that starts it.
+	if registry := searchOptions.SearchFields; registry != nil {
+		if mwCfg := resource.NewManifestWatcherConfig(s.cfg); mwCfg != nil {
+			watcher, err := resource.NewManifestWatcher(*mwCfg, func(live []appsdk.Manifest) {
+				if err := resource.ApplyManifests(registry, resource.AppManifests(), live); err != nil {
+					s.log.Error("manifest reload failed, keeping current search fields", "error", err)
+					return
+				}
+				s.log.Info("manifest reload applied", "live_manifests", len(live))
+			})
+			if err != nil {
+				return err
+			}
+			s.manifestWatcher = watcher
+		}
 	}
 
 	serverOptions := ServerOptions{
@@ -463,6 +499,12 @@ func (s *service) CheckHealth(ctx context.Context) (bool, error) {
 }
 
 func (s *service) stopping(_ error) error {
+	if s.manifestWatcher != nil {
+		s.manifestWatcher.StopAsync()
+		if err := s.manifestWatcher.AwaitTerminated(context.Background()); err != nil {
+			return fmt.Errorf("failed to stop manifest watcher: %w", err)
+		}
+	}
 	if s.subservicesMngr != nil {
 		err := services.StopManagerAndAwaitStopped(context.Background(), s.subservicesMngr)
 		if err != nil {


### PR DESCRIPTION
This connects the app-platform manifest watcher (added earlier) to search, so that when it is configured, changes to app manifests update the search fields used for indexing without a restart. On each change the live manifests are merged with the ones compiled into the binary — the apiserver wins when both describe the same kind — the field definitions are rebuilt, and swapped into the shared registry the index uses. The existing per-kind rebuild check then reindexes the affected kinds.

A new `[unified_storage]` config block (`manifest_api_server_address` and friends, plus the shared `[grpc_client_authentication]` token) turns it on. When it isn't configured — the default, including OSS and local dev — the watcher never starts and there is no behavior change.

One rough edge left for a follow-up: the watcher is built in `registerServer` (where the search registry is created) and started separately in the service lifecycle, rather than being a normal managed subservice. Cleaning that up needs the registry created earlier, which is a separate change.

A related limitation, tracked for the same follow-up: the reload updates the shared search-field registry (index mapping and rebuild trigger), but the standard document builder still reads its selectable fields from the compile-time manifests, so live changes to selectable fields aren't reflected in built documents until that builder also reads from the registry. The watcher is off unless configured, so current behavior is unaffected.

Part of grafana/search-and-storage-team#827.
