### PR TITLE
Logs Table: Fix missing results when logs stream

### DIFF
--- a/public/app/features/explore/Logs/ExploreLogsTable.test.tsx
+++ b/public/app/features/explore/Logs/ExploreLogsTable.test.tsx
@@ -124,7 +124,7 @@ describe('ExploreLogsTable', () => {
   });
 
   const panelData: PanelData = {
-    state: LoadingState.Loading,
+    state: LoadingState.Done,
     series: [getMockLokiFrame()],
     timeRange: {
       from: toUtc('2019-01-01 10:00:00'),
@@ -240,7 +240,7 @@ describe('ExploreLogsTable', () => {
 
     it('Should respect options.frameIndex', async () => {
       const data: PanelData = {
-        state: LoadingState.Loading,
+        state: LoadingState.Done,
         series: [getMockLokiFrame(), getMockLokiFrameDataPlane()],
         timeRange: {
           from: toUtc('2019-01-01 10:00:00'),

--- a/public/app/plugins/panel/logstable/LogsTable.tsx
+++ b/public/app/plugins/panel/logstable/LogsTable.tsx
@@ -216,7 +216,13 @@ export const LogsTable = ({
   );
 
   // Extract fields transform
-  const { extractedFrame } = useExtractFields({ rawTableFrame, fieldConfig, timeZone, replaceVariables });
+  const { extractedFrame } = useExtractFields({
+    rawTableFrame,
+    fieldConfig,
+    timeZone,
+    replaceVariables,
+    loadingState: data.state,
+  });
 
   // Organize fields transform
   const { organizedFrame } = useOrganizeFields({

--- a/public/app/plugins/panel/logstable/hooks/useExtractFields.test.ts
+++ b/public/app/plugins/panel/logstable/hooks/useExtractFields.test.ts
@@ -6,6 +6,7 @@ import {
   FieldMatcherID,
   FieldType,
   type InterpolateFunction,
+  LoadingState,
   standardEditorsRegistry,
   toDataFrame,
 } from '@grafana/data';
@@ -93,6 +94,7 @@ describe('useExtractFields', () => {
       useExtractFields({
         rawTableFrame: testLogsDataFrame[0],
         timeZone: 'utc',
+        loadingState: LoadingState.Done,
         fieldConfig: {
           defaults: {},
           overrides: [],
@@ -109,11 +111,70 @@ describe('useExtractFields', () => {
     });
   });
 
+  test('does not extract while the query is loading', async () => {
+    const { result } = renderHook(() =>
+      useExtractFields({
+        rawTableFrame: testLogsDataFrame[0],
+        timeZone: 'utc',
+        loadingState: LoadingState.Loading,
+        fieldConfig: {
+          defaults: {},
+          overrides: [],
+        },
+      })
+    );
+
+    // Give any pending async extraction a chance to resolve before asserting nothing happened.
+    await Promise.resolve();
+    expect(result.current.extractedFrame).toBeNull();
+  });
+
+  test('re-extracts when a new frame arrives after loading completes', async () => {
+    const props = {
+      rawTableFrame: testLogsDataFrame[0],
+      timeZone: 'utc',
+      loadingState: LoadingState.Loading,
+      fieldConfig: {
+        defaults: {},
+        overrides: [],
+      },
+    };
+    const { result, rerender } = renderHook((p: typeof props) => useExtractFields(p), { initialProps: props });
+
+    // While loading, nothing is extracted.
+    await Promise.resolve();
+    expect(result.current.extractedFrame).toBeNull();
+
+    // Streaming/done emissions hand us a new frame reference with more rows; the hook must react to it.
+    const streamedFrame = toDataFrame({
+      meta: { type: DataFrameType.LogLines },
+      fields: [
+        { name: LOGS_DATAPLANE_TIMESTAMP_NAME, type: FieldType.time, values: [1, 2, 3] },
+        { name: LOGS_DATAPLANE_BODY_NAME, type: FieldType.string, values: ['log 1', 'log 2', 'log 3'] },
+        {
+          name: 'labels',
+          type: FieldType.other,
+          values: [
+            { service: 'frontend', level: 'info' },
+            { service: 'backend', level: 'info' },
+            { service: 'frontend', level: 'error' },
+          ],
+        },
+      ],
+    });
+    rerender({ ...props, rawTableFrame: streamedFrame, loadingState: LoadingState.Done });
+
+    await waitFor(() => {
+      expect(result.current.extractedFrame?.length).toBe(3);
+    });
+  });
+
   test('applies field override custom.width to extracted label columns', async () => {
     const { result } = renderHook(() =>
       useExtractFields({
         rawTableFrame: testLogsDataFrame[0],
         timeZone: 'utc',
+        loadingState: LoadingState.Done,
         fieldConfig: {
           defaults: {},
           overrides: [
@@ -159,6 +220,7 @@ describe('useExtractFields', () => {
       useExtractFields({
         rawTableFrame: traceLinkTestFrame,
         timeZone: 'utc',
+        loadingState: LoadingState.Done,
         fieldConfig: {
           defaults: {},
           overrides: [],

--- a/public/app/plugins/panel/logstable/hooks/useExtractFields.ts
+++ b/public/app/plugins/panel/logstable/hooks/useExtractFields.ts
@@ -7,6 +7,7 @@ import {
   type DataFrame,
   type FieldConfigSource,
   type InterpolateFunction,
+  LoadingState,
   type TimeZone,
   transformDataFrame,
   useDataLinksContext,
@@ -22,9 +23,10 @@ interface Props {
   fieldConfig?: FieldConfigSource;
   timeZone: TimeZone;
   replaceVariables?: InterpolateFunction;
+  loadingState: LoadingState;
 }
 
-export function useExtractFields({ rawTableFrame, fieldConfig, timeZone, replaceVariables }: Props) {
+export function useExtractFields({ rawTableFrame, fieldConfig, timeZone, replaceVariables, loadingState }: Props) {
   const dataLinksContext = useDataLinksContext();
   const isMounted = useMountedState();
   const dataLinkPostProcessor = dataLinksContext.dataLinkPostProcessor;
@@ -32,7 +34,7 @@ export function useExtractFields({ rawTableFrame, fieldConfig, timeZone, replace
   const theme = useTheme2();
 
   useEffect(() => {
-    if (!fieldConfig) {
+    if (!fieldConfig || loadingState === LoadingState.Loading) {
       return;
     }
 
@@ -61,9 +63,7 @@ export function useExtractFields({ rawTableFrame, fieldConfig, timeZone, replace
       .catch((err) => {
         console.error('LogsTable: Extract fields transform error', err);
       });
-    // @todo hook re-renders unexpectedly when data frame isn't changing if we add `rawTableFrame` as dependency, so we check for changes in the timestamps instead
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dataLinkPostProcessor, fieldConfig, rawTableFrame?.fields[1]?.values, replaceVariables, theme, timeZone]);
+  }, [dataLinkPostProcessor, fieldConfig, isMounted, loadingState, rawTableFrame, replaceVariables, theme, timeZone]);
 
   return { extractedFrame };
 }

--- a/public/app/plugins/panel/logstable/hooks/useOrganizeFields.test.tsx
+++ b/public/app/plugins/panel/logstable/hooks/useOrganizeFields.test.tsx
@@ -1,6 +1,13 @@
 import { renderHook, waitFor } from '@testing-library/react';
 
-import { type DataFrame, DataFrameType, FieldType, standardEditorsRegistry, toDataFrame } from '@grafana/data';
+import {
+  type DataFrame,
+  DataFrameType,
+  FieldType,
+  LoadingState,
+  standardEditorsRegistry,
+  toDataFrame,
+} from '@grafana/data';
 // Internal package imports, but not exposed to end users, how do we expect plugin developers to test anything that contains a transform?
 import { mockTransformationsRegistry, organizeFieldsTransformer } from '@grafana/data/internal';
 import { TableCellDisplayMode } from '@grafana/ui';
@@ -56,6 +63,7 @@ describe('useOrganizeFields', () => {
           defaults: {},
           overrides: [],
         },
+        loadingState: LoadingState.Done,
       })
     );
 


### PR DESCRIPTION
For streaming logs, the Table was only using one of the partial results.

https://github.com/user-attachments/assets/d7460d9e-32c0-41b0-b718-35c93e942c04

Fixes https://github.com/grafana/logs-drilldown/issues/2000