### PR TITLE
Datasources (frontend): Capture server logs in diagnostics bundles

### DIFF
--- a/public/app/features/dashboard-scene/sharing/DiagnosticsDrawerContent.tsx
+++ b/public/app/features/dashboard-scene/sharing/DiagnosticsDrawerContent.tsx
@@ -24,6 +24,8 @@ export function DiagnosticsDrawerContent({
   onDismiss,
 }: DiagnosticsDrawerContentProps) {
   const styles = useStyles2(getStyles);
+  // Default-on here so admins get useful bundles by default; the request helpers default includeLogs
+  // to false, so this drawer selection is the only thing that opts a request into log capture.
   const [includeLogs, setIncludeLogs] = useState(true);
 
   return (
@@ -49,7 +51,7 @@ export function DiagnosticsDrawerContent({
           'dashboard.diagnostics.include-server-logs-description',
           'Adds filtered query logs and a bounded unfiltered server-log window to the bundle.'
         )}
-        checked={includeLogs}
+        value={includeLogs}
         disabled={isGenerating}
         onChange={(event) => setIncludeLogs(event.currentTarget.checked)}
       />

--- a/public/app/features/dashboard-scene/sharing/DiagnosticsDrawerContent.tsx
+++ b/public/app/features/dashboard-scene/sharing/DiagnosticsDrawerContent.tsx
@@ -41,8 +41,9 @@ export function DiagnosticsDrawerContent({
       </Alert>
 
       <Checkbox
-        id="diagnostics-include-server-logs"
         label={t('dashboard.diagnostics.include-server-logs', 'Include server logs')}
+        // Checkbox renders its description inside the wrapping label, so provide the concise
+        // accessible name explicitly instead of including the full description in it.
         aria-label={t('dashboard.diagnostics.include-server-logs', 'Include server logs')}
         description={t(
           'dashboard.diagnostics.include-server-logs-description',

--- a/public/app/features/dashboard-scene/sharing/DiagnosticsDrawerContent.tsx
+++ b/public/app/features/dashboard-scene/sharing/DiagnosticsDrawerContent.tsx
@@ -1,0 +1,103 @@
+import { css } from '@emotion/css';
+import { type ReactNode, useState } from 'react';
+
+import { type GrafanaTheme2 } from '@grafana/data';
+import { Trans, t } from '@grafana/i18n';
+import { isFetchError } from '@grafana/runtime';
+import { Alert, Button, Checkbox, useStyles2 } from '@grafana/ui';
+
+interface DiagnosticsDrawerContentProps {
+  description: ReactNode;
+  progress?: ReactNode;
+  error?: Error;
+  isGenerating: boolean;
+  onDownload: (includeLogs: boolean) => void;
+  onDismiss: () => void;
+}
+
+export function DiagnosticsDrawerContent({
+  description,
+  progress,
+  error,
+  isGenerating,
+  onDownload,
+  onDismiss,
+}: DiagnosticsDrawerContentProps) {
+  const styles = useStyles2(getStyles);
+  const [includeLogs, setIncludeLogs] = useState(true);
+
+  return (
+    <div>
+      <p className={styles.info}>{description}</p>
+
+      <Alert
+        severity="warning"
+        title={t('dashboard.diagnostics.sensitive-warning-title', 'May contain sensitive data')}
+      >
+        <Trans i18nKey="dashboard.diagnostics.sensitive-warning-body">
+          The bundle can include request headers, query parameters, and server log lines. Review it before sharing
+          outside your organization.
+        </Trans>
+      </Alert>
+
+      <Checkbox
+        id="diagnostics-include-server-logs"
+        label={t('dashboard.diagnostics.include-server-logs', 'Include server logs')}
+        aria-label={t('dashboard.diagnostics.include-server-logs', 'Include server logs')}
+        description={t(
+          'dashboard.diagnostics.include-server-logs-description',
+          'Adds filtered query logs and a bounded unfiltered server-log window to the bundle.'
+        )}
+        checked={includeLogs}
+        disabled={isGenerating}
+        onChange={(event) => setIncludeLogs(event.currentTarget.checked)}
+      />
+
+      {progress && <p className={styles.info}>{progress}</p>}
+
+      {error && (
+        <Alert severity="error" title={t('dashboard.diagnostics.error-title', 'Failed to generate diagnostics')}>
+          {diagnosticsErrorMessage(error)}
+        </Alert>
+      )}
+
+      <div
+        className={styles.buttonRow}
+        role="group"
+        aria-label={t('dashboard.diagnostics.actions', 'Diagnostics actions')}
+      >
+        <Button variant="primary" onClick={() => onDownload(includeLogs)} disabled={isGenerating} icon="download-alt">
+          {isGenerating ? (
+            <Trans i18nKey="dashboard.diagnostics.generating-button">Generating…</Trans>
+          ) : (
+            <Trans i18nKey="dashboard.diagnostics.download-button">Download diagnostics</Trans>
+          )}
+        </Button>
+        <Button variant="secondary" onClick={onDismiss} fill="outline">
+          <Trans i18nKey="dashboard.diagnostics.cancel-button">Cancel</Trans>
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// The download uses blob/json fetches whose FetchError carries the detail in status/statusText, so
+// build the message from those rather than error.message (which would leave the alert body empty).
+function diagnosticsErrorMessage(error: Error): string {
+  if (isFetchError(error)) {
+    const parts = [error.status, error.statusText].filter(Boolean);
+    return parts.length ? parts.join(' ') : t('dashboard.diagnostics.request-failed', 'Request failed');
+  }
+  return error.message || t('dashboard.diagnostics.error-title', 'Failed to generate diagnostics');
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  info: css({
+    marginBottom: theme.spacing(2),
+  }),
+  buttonRow: css({
+    display: 'flex',
+    gap: theme.spacing(2),
+    marginTop: theme.spacing(2),
+  }),
+});

--- a/public/app/features/dashboard-scene/sharing/DownloadDashboardDiagnostics.test.tsx
+++ b/public/app/features/dashboard-scene/sharing/DownloadDashboardDiagnostics.test.tsx
@@ -44,6 +44,32 @@ describe('DownloadDashboardDiagnostics', () => {
     expect(screen.getByRole('button', { name: 'Download diagnostics' })).toBeInTheDocument();
   });
 
+  it('includes server logs by default', () => {
+    const { tab } = setupScenario();
+
+    render(<tab.Component model={tab} />);
+
+    expect(screen.getByLabelText('Include server logs')).toBeChecked();
+  });
+
+  it('can exclude server logs from the dashboard bundle', async () => {
+    jest.mocked(startDashboardDiagnostics).mockResolvedValue('job-1');
+    jest
+      .mocked(getDashboardDiagnosticsStatus)
+      .mockResolvedValue({ uid: 'job-1', state: 'complete', panelsDone: 2, panelsTotal: 2 });
+    const { tab } = setupScenario();
+
+    render(<tab.Component model={tab} />);
+    await userEvent.click(screen.getByLabelText('Include server logs'));
+    await userEvent.click(screen.getByRole('button', { name: 'Download diagnostics' }));
+
+    expect(startDashboardDiagnostics).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ includeLogs: false })
+    );
+  });
+
   it('collects every panel with active queries, starts a job, and downloads the completed bundle', async () => {
     jest.mocked(startDashboardDiagnostics).mockResolvedValue('job-1');
     jest

--- a/public/app/features/dashboard-scene/sharing/DownloadDashboardDiagnostics.tsx
+++ b/public/app/features/dashboard-scene/sharing/DownloadDashboardDiagnostics.tsx
@@ -16,7 +16,7 @@ import {
   VizPanel,
 } from '@grafana/scenes';
 import { type DataQuery } from '@grafana/schema';
-import { Alert, Button, useStyles2 } from '@grafana/ui';
+import { Alert, Button, Checkbox, useStyles2 } from '@grafana/ui';
 import {
   type DashboardDiagnosticsPanel,
   downloadDashboardDiagnostics,
@@ -146,6 +146,7 @@ function DownloadDashboardDiagnosticsRenderer({ model }: SceneComponentProps<Dow
   const styles = useStyles2(getStyles);
   const abortRef = useRef<AbortController | null>(null);
   const [progress, setProgress] = useState<{ done: number; total: number } | null>(null);
+  const [includeLogs, setIncludeLogs] = useState(true);
 
   // Abort any in-flight request if the drawer unmounts.
   useEffect(() => () => abortRef.current?.abort(), []);
@@ -166,7 +167,10 @@ function DownloadDashboardDiagnosticsRenderer({ model }: SceneComponentProps<Dow
     abortRef.current = controller;
     setProgress({ done: 0, total: panels.length });
 
-    const uid = await startDashboardDiagnostics(panels, dashboard.getSaveModel(), controller.signal);
+    const uid = await startDashboardDiagnostics(panels, dashboard.getSaveModel(), {
+      includeLogs,
+      signal: controller.signal,
+    });
 
     for (let attempt = 0; ; attempt++) {
       const status = await getDashboardDiagnosticsStatus(uid, controller.signal);
@@ -184,7 +188,7 @@ function DownloadDashboardDiagnosticsRenderer({ model }: SceneComponentProps<Dow
     }
 
     await downloadDashboardDiagnostics(uid, controller.signal);
-  }, [dashboardRef]);
+  }, [dashboardRef, includeLogs]);
 
   const handleDismiss = () => {
     abortRef.current?.abort();
@@ -209,6 +213,19 @@ function DownloadDashboardDiagnosticsRenderer({ model }: SceneComponentProps<Dow
           outside your organization.
         </Trans>
       </Alert>
+
+      <Checkbox
+        id="dashboard-diagnostics-include-server-logs"
+        label={t('dashboard.diagnostics.include-server-logs', 'Include server logs')}
+        aria-label={t('dashboard.diagnostics.include-server-logs', 'Include server logs')}
+        description={t(
+          'dashboard.diagnostics.include-server-logs-description',
+          'Adds filtered query logs and a bounded unfiltered server-log window to the bundle.'
+        )}
+        checked={includeLogs}
+        disabled={isGenerating}
+        onChange={(event) => setIncludeLogs(event.currentTarget.checked)}
+      />
 
       {isGenerating && progress && (
         <p className={styles.info}>

--- a/public/app/features/dashboard-scene/sharing/DownloadDashboardDiagnostics.tsx
+++ b/public/app/features/dashboard-scene/sharing/DownloadDashboardDiagnostics.tsx
@@ -1,22 +1,9 @@
-import { css } from '@emotion/css';
 import { useEffect, useRef, useState } from 'react';
 import { useAsyncFn } from 'react-use';
 
-import { type GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { isFetchError } from '@grafana/runtime';
-import {
-  sceneGraph,
-  type SceneComponentProps,
-  SceneDataTransformer,
-  type SceneObject,
-  SceneObjectBase,
-  type SceneObjectRef,
-  SceneQueryRunner,
-  VizPanel,
-} from '@grafana/scenes';
+import { sceneGraph, type SceneComponentProps, SceneObjectBase, type SceneObjectRef, VizPanel } from '@grafana/scenes';
 import { type DataQuery } from '@grafana/schema';
-import { Alert, Button, Checkbox, useStyles2 } from '@grafana/ui';
 import {
   type DashboardDiagnosticsPanel,
   downloadDashboardDiagnostics,
@@ -26,6 +13,8 @@ import {
 
 import { type DashboardScene } from '../scene/DashboardScene';
 
+import { DiagnosticsDrawerContent } from './DiagnosticsDrawerContent';
+import { getQueryRunnerFor } from './diagnosticsUtils';
 import { type SceneShareTabState, type ShareView } from './types';
 
 // How long to wait between status polls, and the cap on attempts (~5 min, matching the backend's
@@ -55,23 +44,8 @@ export class DownloadDashboardDiagnostics
   }
 }
 
-// Inlined rather than imported from dashboard-scene/utils/utils: that module transitively reaches
-// DashboardScene, which imports ShareDrawer (which imports this view), creating an import cycle.
-function getQueryRunnerFor(sceneObject: SceneObject | undefined): SceneQueryRunner | undefined {
-  if (!sceneObject) {
-    return undefined;
-  }
-  const dataProvider = sceneObject.state.$data ?? sceneObject.parent?.state.$data;
-  if (dataProvider instanceof SceneQueryRunner) {
-    return dataProvider;
-  }
-  if (dataProvider instanceof SceneDataTransformer) {
-    return getQueryRunnerFor(dataProvider);
-  }
-  return undefined;
-}
-
-// panel.state.key is "panel-<id>"; parse the numeric id without importing utils (import cycle, as above).
+// panel.state.key is "panel-<id>"; parse the numeric id without importing utils for the same
+// import-cycle reason documented in diagnosticsUtils.
 // Mirrors getPanelIdForVizPanel in dashboard-scene/utils/utils.ts, including its non-null assertion:
 // every VizPanel in the scene graph is keyed this way, so an undefined key indicates a real bug
 // upstream rather than something to paper over with a fallback id.
@@ -118,16 +92,6 @@ function collectDashboardPanels(dashboard: DashboardScene): DashboardDiagnostics
   return panels;
 }
 
-// The download uses blob/json fetches whose FetchError carries the detail in status/statusText, so
-// build the message from those rather than error.message (which would leave the alert body empty).
-function diagnosticsErrorMessage(error: Error): string {
-  if (isFetchError(error)) {
-    const parts = [error.status, error.statusText].filter(Boolean);
-    return parts.length ? parts.join(' ') : t('dashboard.diagnostics.request-failed', 'Request failed');
-  }
-  return error.message || t('dashboard.diagnostics.error-title', 'Failed to generate diagnostics');
-}
-
 const delay = (ms: number, signal: AbortSignal) =>
   new Promise<void>((resolve, reject) => {
     const id = setTimeout(resolve, ms);
@@ -143,52 +107,55 @@ const delay = (ms: number, signal: AbortSignal) =>
 
 function DownloadDashboardDiagnosticsRenderer({ model }: SceneComponentProps<DownloadDashboardDiagnostics>) {
   const { onDismiss, dashboardRef } = model.useState();
-  const styles = useStyles2(getStyles);
   const abortRef = useRef<AbortController | null>(null);
   const [progress, setProgress] = useState<{ done: number; total: number } | null>(null);
-  const [includeLogs, setIncludeLogs] = useState(true);
 
   // Abort any in-flight request if the drawer unmounts.
   useEffect(() => () => abortRef.current?.abort(), []);
 
-  const [{ loading: isGenerating, error }, onDownload] = useAsyncFn(async () => {
-    const dashboard = dashboardRef?.resolve();
-    if (!dashboard) {
-      return;
-    }
-    const panels = collectDashboardPanels(dashboard);
-    // Known limitation (follow-up): template variables are sent un-interpolated, so captured traffic
-    // won't match panels that use $vars until per-datasource interpolation is applied.
-    if (panels.length === 0) {
-      throw new Error(t('dashboard.diagnostics.no-panels', 'This dashboard has no panels with active queries.'));
-    }
-
-    const controller = new AbortController();
-    abortRef.current = controller;
-    setProgress({ done: 0, total: panels.length });
-
-    const uid = await startDashboardDiagnostics(panels, dashboard.getSaveModel(), {
-      includeLogs,
-      signal: controller.signal,
-    });
-
-    for (let attempt = 0; ; attempt++) {
-      const status = await getDashboardDiagnosticsStatus(uid, controller.signal);
-      setProgress({ done: status.panelsDone, total: status.panelsTotal });
-      if (status.state === 'complete') {
-        break;
+  const [{ loading: isGenerating, error }, onDownload] = useAsyncFn(
+    async (includeLogs: boolean) => {
+      const dashboard = dashboardRef?.resolve();
+      if (!dashboard) {
+        return;
       }
-      if (status.state === 'error') {
-        throw new Error(status.error || t('dashboard.diagnostics.generation-failed', 'Diagnostics generation failed'));
+      const panels = collectDashboardPanels(dashboard);
+      // Known limitation (follow-up): template variables are sent un-interpolated, so captured traffic
+      // won't match panels that use $vars until per-datasource interpolation is applied.
+      if (panels.length === 0) {
+        throw new Error(t('dashboard.diagnostics.no-panels', 'This dashboard has no panels with active queries.'));
       }
-      if (attempt >= MAX_POLL_ATTEMPTS) {
-        throw new Error(t('dashboard.diagnostics.timed-out', 'Timed out waiting for diagnostics generation'));
-      }
-      await delay(POLL_INTERVAL_MS, controller.signal);
-    }
 
-    await downloadDashboardDiagnostics(uid, controller.signal);
-  }, [dashboardRef, includeLogs]);
+      const controller = new AbortController();
+      abortRef.current = controller;
+      setProgress({ done: 0, total: panels.length });
+
+      const uid = await startDashboardDiagnostics(panels, dashboard.getSaveModel(), {
+        includeLogs,
+        signal: controller.signal,
+      });
+
+      for (let attempt = 0; ; attempt++) {
+        const status = await getDashboardDiagnosticsStatus(uid, controller.signal);
+        setProgress({ done: status.panelsDone, total: status.panelsTotal });
+        if (status.state === 'complete') {
+          break;
+        }
+        if (status.state === 'error') {
+          throw new Error(
+            status.error || t('dashboard.diagnostics.generation-failed', 'Diagnostics generation failed')
+          );
+        }
+        if (attempt >= MAX_POLL_ATTEMPTS) {
+          throw new Error(t('dashboard.diagnostics.timed-out', 'Timed out waiting for diagnostics generation'));
+        }
+        await delay(POLL_INTERVAL_MS, controller.signal);
+      }
+
+      await downloadDashboardDiagnostics(uid, controller.signal);
+    },
+    [dashboardRef]
+  );
 
   const handleDismiss = () => {
     abortRef.current?.abort();
@@ -196,78 +163,24 @@ function DownloadDashboardDiagnosticsRenderer({ model }: SceneComponentProps<Dow
   };
 
   return (
-    <div>
-      <p className={styles.info}>
+    <DiagnosticsDrawerContent
+      description={
         <Trans i18nKey="dashboard.diagnostics.info-text-dashboard">
           Generates a diagnostic bundle for the whole dashboard by re-running every panel&apos;s queries with HTTP
           capture active. This runs in the background and may take a while for large dashboards.
         </Trans>
-      </p>
-
-      <Alert
-        severity="warning"
-        title={t('dashboard.diagnostics.sensitive-warning-title', 'May contain sensitive data')}
-      >
-        <Trans i18nKey="dashboard.diagnostics.sensitive-warning-body">
-          The bundle can include request headers, query parameters, and server log lines. Review it before sharing
-          outside your organization.
-        </Trans>
-      </Alert>
-
-      <Checkbox
-        id="dashboard-diagnostics-include-server-logs"
-        label={t('dashboard.diagnostics.include-server-logs', 'Include server logs')}
-        aria-label={t('dashboard.diagnostics.include-server-logs', 'Include server logs')}
-        description={t(
-          'dashboard.diagnostics.include-server-logs-description',
-          'Adds filtered query logs and a bounded unfiltered server-log window to the bundle.'
-        )}
-        checked={includeLogs}
-        disabled={isGenerating}
-        onChange={(event) => setIncludeLogs(event.currentTarget.checked)}
-      />
-
-      {isGenerating && progress && (
-        <p className={styles.info}>
+      }
+      progress={
+        isGenerating && progress ? (
           <Trans i18nKey="dashboard.diagnostics.progress" values={{ done: progress.done, total: progress.total }}>
             Capturing panel {'{{done}}'} of {'{{total}}'}…
           </Trans>
-        </p>
-      )}
-
-      {error && (
-        <Alert severity="error" title={t('dashboard.diagnostics.error-title', 'Failed to generate diagnostics')}>
-          {diagnosticsErrorMessage(error)}
-        </Alert>
-      )}
-
-      <div
-        className={styles.buttonRow}
-        role="group"
-        aria-label={t('dashboard.diagnostics.actions', 'Diagnostics actions')}
-      >
-        <Button variant="primary" onClick={onDownload} disabled={isGenerating} icon="download-alt">
-          {isGenerating ? (
-            <Trans i18nKey="dashboard.diagnostics.generating-button">Generating…</Trans>
-          ) : (
-            <Trans i18nKey="dashboard.diagnostics.download-button">Download diagnostics</Trans>
-          )}
-        </Button>
-        <Button variant="secondary" onClick={handleDismiss} fill="outline">
-          <Trans i18nKey="dashboard.diagnostics.cancel-button">Cancel</Trans>
-        </Button>
-      </div>
-    </div>
+        ) : undefined
+      }
+      error={error}
+      isGenerating={isGenerating}
+      onDownload={onDownload}
+      onDismiss={handleDismiss}
+    />
   );
 }
-
-const getStyles = (theme: GrafanaTheme2) => ({
-  info: css({
-    marginBottom: theme.spacing(2),
-  }),
-  buttonRow: css({
-    display: 'flex',
-    gap: theme.spacing(2),
-    marginTop: theme.spacing(2),
-  }),
-});

--- a/public/app/features/dashboard-scene/sharing/DownloadDiagnostics.test.tsx
+++ b/public/app/features/dashboard-scene/sharing/DownloadDiagnostics.test.tsx
@@ -36,6 +36,29 @@ describe('DownloadDiagnostics', () => {
     expect(screen.getByRole('button', { name: 'Download diagnostics' })).toBeInTheDocument();
   });
 
+  it('includes server logs by default', () => {
+    const { tab } = setupScenario();
+
+    render(<tab.Component model={tab} />);
+
+    expect(screen.getByLabelText('Include server logs')).toBeChecked();
+  });
+
+  it('can exclude server logs from the download', async () => {
+    const { tab } = setupScenario();
+
+    render(<tab.Component model={tab} />);
+    await userEvent.click(screen.getByLabelText('Include server logs'));
+    await userEvent.click(screen.getByRole('button', { name: 'Download diagnostics' }));
+
+    expect(downloadDiagnosticsForQueries).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.any(String),
+      expect.any(String),
+      expect.objectContaining({ includeLogs: false })
+    );
+  });
+
   it('passes the panel visible queries and time range when downloading', async () => {
     const { tab } = setupScenario();
 

--- a/public/app/features/dashboard-scene/sharing/DownloadDiagnostics.tsx
+++ b/public/app/features/dashboard-scene/sharing/DownloadDiagnostics.tsx
@@ -1,24 +1,19 @@
-import { css } from '@emotion/css';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import { useAsyncFn } from 'react-use';
 
-import { type GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { isFetchError } from '@grafana/runtime';
 import {
   sceneGraph,
   type SceneComponentProps,
-  SceneDataTransformer,
-  type SceneObject,
   SceneObjectBase,
   type SceneObjectRef,
-  SceneQueryRunner,
   type VizPanel,
 } from '@grafana/scenes';
 import { type DataQuery } from '@grafana/schema';
-import { Alert, Button, Checkbox, useStyles2 } from '@grafana/ui';
 import { downloadDiagnosticsForQueries } from 'app/features/query/diagnostics/downloadDiagnostics';
 
+import { DiagnosticsDrawerContent } from './DiagnosticsDrawerContent';
+import { getQueryRunnerFor } from './diagnosticsUtils';
 import { type SceneShareTabState, type ShareView } from './types';
 
 export interface DownloadDiagnosticsState extends SceneShareTabState {
@@ -41,69 +36,43 @@ export class DownloadDiagnostics extends SceneObjectBase<DownloadDiagnosticsStat
   }
 }
 
-// Inlined rather than imported from dashboard-scene/utils/utils: that module transitively reaches
-// DashboardScene, which imports ShareDrawer (which imports this view), creating an import cycle.
-function getQueryRunnerFor(sceneObject: SceneObject | undefined): SceneQueryRunner | undefined {
-  if (!sceneObject) {
-    return undefined;
-  }
-  const dataProvider = sceneObject.state.$data ?? sceneObject.parent?.state.$data;
-  if (dataProvider instanceof SceneQueryRunner) {
-    return dataProvider;
-  }
-  if (dataProvider instanceof SceneDataTransformer) {
-    return getQueryRunnerFor(dataProvider);
-  }
-  return undefined;
-}
-
-// The download uses a blob-response fetch, whose FetchError carries the detail in status/statusText
-// (its data is a Blob and message is unset), so build a message from those rather than error.message
-// which would leave the alert body empty.
-function diagnosticsErrorMessage(error: Error): string {
-  if (isFetchError(error)) {
-    const parts = [error.status, error.statusText].filter(Boolean);
-    return parts.length ? parts.join(' ') : t('dashboard.diagnostics.request-failed', 'Request failed');
-  }
-  return error.message || t('dashboard.diagnostics.error-title', 'Failed to generate diagnostics');
-}
-
 function DownloadDiagnosticsRenderer({ model }: SceneComponentProps<DownloadDiagnostics>) {
   const { onDismiss, panelRef } = model.useState();
-  const styles = useStyles2(getStyles);
   const abortRef = useRef<AbortController | null>(null);
-  const [includeLogs, setIncludeLogs] = useState(true);
 
   // Abort any in-flight request if the drawer unmounts.
   useEffect(() => () => abortRef.current?.abort(), []);
 
-  const [{ loading: isGenerating, error }, onDownload] = useAsyncFn(async () => {
-    const panel = panelRef?.resolve();
-    if (!panel) {
-      return;
-    }
-    const runner = getQueryRunnerFor(panel);
-    // Classic panels keep the datasource on the query runner rather than on each target, and unlike
-    // the normal /api/ds/query path nothing fills that in here. Copy the runner-level datasource
-    // onto any query that lacks one so the diagnostics endpoint can still route them.
-    const runnerDatasource = runner?.state.datasource;
-    const queries: DataQuery[] = (runner?.state.queries ?? []).map((query) =>
-      query.datasource ? query : { ...query, datasource: runnerDatasource }
-    );
-    // Known limitation (follow-up): template variables are sent un-interpolated, so captured
-    // traffic won't match a panel that uses $vars until per-datasource interpolation is applied.
-    if (queries.filter((query) => !query.hide).length === 0) {
-      throw new Error(t('dashboard.diagnostics.no-queries', 'This panel has no active queries to capture.'));
-    }
-    const timeRange = sceneGraph.getTimeRange(panel).state.value;
+  const [{ loading: isGenerating, error }, onDownload] = useAsyncFn(
+    async (includeLogs: boolean) => {
+      const panel = panelRef?.resolve();
+      if (!panel) {
+        return;
+      }
+      const runner = getQueryRunnerFor(panel);
+      // Classic panels keep the datasource on the query runner rather than on each target, and unlike
+      // the normal /api/ds/query path nothing fills that in here. Copy the runner-level datasource
+      // onto any query that lacks one so the diagnostics endpoint can still route them.
+      const runnerDatasource = runner?.state.datasource;
+      const queries: DataQuery[] = (runner?.state.queries ?? []).map((query) =>
+        query.datasource ? query : { ...query, datasource: runnerDatasource }
+      );
+      // Known limitation (follow-up): template variables are sent un-interpolated, so captured
+      // traffic won't match a panel that uses $vars until per-datasource interpolation is applied.
+      if (queries.filter((query) => !query.hide).length === 0) {
+        throw new Error(t('dashboard.diagnostics.no-queries', 'This panel has no active queries to capture.'));
+      }
+      const timeRange = sceneGraph.getTimeRange(panel).state.value;
 
-    const controller = new AbortController();
-    abortRef.current = controller;
-    await downloadDiagnosticsForQueries(queries, String(timeRange.from.valueOf()), String(timeRange.to.valueOf()), {
-      includeLogs,
-      signal: controller.signal,
-    });
-  }, [includeLogs, panelRef]);
+      const controller = new AbortController();
+      abortRef.current = controller;
+      await downloadDiagnosticsForQueries(queries, String(timeRange.from.valueOf()), String(timeRange.to.valueOf()), {
+        includeLogs,
+        signal: controller.signal,
+      });
+    },
+    [panelRef]
+  );
 
   const handleDismiss = () => {
     abortRef.current?.abort();
@@ -111,71 +80,17 @@ function DownloadDiagnosticsRenderer({ model }: SceneComponentProps<DownloadDiag
   };
 
   return (
-    <div>
-      <p className={styles.info}>
+    <DiagnosticsDrawerContent
+      description={
         <Trans i18nKey="dashboard.diagnostics.info-text-panel">
           Generates a diagnostic bundle for this panel by re-running its queries with HTTP capture active. The download
           may take a moment while the bundle is generated.
         </Trans>
-      </p>
-
-      {/* Seed warning. Additional warnings (e.g. sensitive-data redaction, large bundles) are added here later. */}
-      <Alert
-        severity="warning"
-        title={t('dashboard.diagnostics.sensitive-warning-title', 'May contain sensitive data')}
-      >
-        <Trans i18nKey="dashboard.diagnostics.sensitive-warning-body">
-          The bundle can include request headers, query parameters, and server log lines. Review it before sharing
-          outside your organization.
-        </Trans>
-      </Alert>
-
-      <Checkbox
-        id="diagnostics-include-server-logs"
-        label={t('dashboard.diagnostics.include-server-logs', 'Include server logs')}
-        aria-label={t('dashboard.diagnostics.include-server-logs', 'Include server logs')}
-        description={t(
-          'dashboard.diagnostics.include-server-logs-description',
-          'Adds filtered query logs and a bounded unfiltered server-log window to the bundle.'
-        )}
-        checked={includeLogs}
-        disabled={isGenerating}
-        onChange={(event) => setIncludeLogs(event.currentTarget.checked)}
-      />
-
-      {error && (
-        <Alert severity="error" title={t('dashboard.diagnostics.error-title', 'Failed to generate diagnostics')}>
-          {diagnosticsErrorMessage(error)}
-        </Alert>
-      )}
-
-      <div
-        className={styles.buttonRow}
-        role="group"
-        aria-label={t('dashboard.diagnostics.actions', 'Diagnostics actions')}
-      >
-        <Button variant="primary" onClick={onDownload} disabled={isGenerating} icon="download-alt">
-          {isGenerating ? (
-            <Trans i18nKey="dashboard.diagnostics.generating-button">Generating…</Trans>
-          ) : (
-            <Trans i18nKey="dashboard.diagnostics.download-button">Download diagnostics</Trans>
-          )}
-        </Button>
-        <Button variant="secondary" onClick={handleDismiss} fill="outline">
-          <Trans i18nKey="dashboard.diagnostics.cancel-button">Cancel</Trans>
-        </Button>
-      </div>
-    </div>
+      }
+      error={error}
+      isGenerating={isGenerating}
+      onDownload={onDownload}
+      onDismiss={handleDismiss}
+    />
   );
 }
-
-const getStyles = (theme: GrafanaTheme2) => ({
-  info: css({
-    marginBottom: theme.spacing(2),
-  }),
-  buttonRow: css({
-    display: 'flex',
-    gap: theme.spacing(2),
-    marginTop: theme.spacing(2),
-  }),
-});

--- a/public/app/features/dashboard-scene/sharing/DownloadDiagnostics.tsx
+++ b/public/app/features/dashboard-scene/sharing/DownloadDiagnostics.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useAsyncFn } from 'react-use';
 
 import { type GrafanaTheme2 } from '@grafana/data';
@@ -16,7 +16,7 @@ import {
   type VizPanel,
 } from '@grafana/scenes';
 import { type DataQuery } from '@grafana/schema';
-import { Alert, Button, useStyles2 } from '@grafana/ui';
+import { Alert, Button, Checkbox, useStyles2 } from '@grafana/ui';
 import { downloadDiagnosticsForQueries } from 'app/features/query/diagnostics/downloadDiagnostics';
 
 import { type SceneShareTabState, type ShareView } from './types';
@@ -72,6 +72,7 @@ function DownloadDiagnosticsRenderer({ model }: SceneComponentProps<DownloadDiag
   const { onDismiss, panelRef } = model.useState();
   const styles = useStyles2(getStyles);
   const abortRef = useRef<AbortController | null>(null);
+  const [includeLogs, setIncludeLogs] = useState(true);
 
   // Abort any in-flight request if the drawer unmounts.
   useEffect(() => () => abortRef.current?.abort(), []);
@@ -98,13 +99,11 @@ function DownloadDiagnosticsRenderer({ model }: SceneComponentProps<DownloadDiag
 
     const controller = new AbortController();
     abortRef.current = controller;
-    await downloadDiagnosticsForQueries(
-      queries,
-      String(timeRange.from.valueOf()),
-      String(timeRange.to.valueOf()),
-      controller.signal
-    );
-  }, [panelRef]);
+    await downloadDiagnosticsForQueries(queries, String(timeRange.from.valueOf()), String(timeRange.to.valueOf()), {
+      includeLogs,
+      signal: controller.signal,
+    });
+  }, [includeLogs, panelRef]);
 
   const handleDismiss = () => {
     abortRef.current?.abort();
@@ -131,7 +130,18 @@ function DownloadDiagnosticsRenderer({ model }: SceneComponentProps<DownloadDiag
         </Trans>
       </Alert>
 
-      {/* Diagnostic options (artifact selection, time range, redaction toggles) will be added here. */}
+      <Checkbox
+        id="diagnostics-include-server-logs"
+        label={t('dashboard.diagnostics.include-server-logs', 'Include server logs')}
+        aria-label={t('dashboard.diagnostics.include-server-logs', 'Include server logs')}
+        description={t(
+          'dashboard.diagnostics.include-server-logs-description',
+          'Adds filtered query logs and a bounded unfiltered server-log window to the bundle.'
+        )}
+        checked={includeLogs}
+        disabled={isGenerating}
+        onChange={(event) => setIncludeLogs(event.currentTarget.checked)}
+      />
 
       {error && (
         <Alert severity="error" title={t('dashboard.diagnostics.error-title', 'Failed to generate diagnostics')}>

--- a/public/app/features/dashboard-scene/sharing/diagnosticsUtils.ts
+++ b/public/app/features/dashboard-scene/sharing/diagnosticsUtils.ts
@@ -1,0 +1,17 @@
+import { SceneDataTransformer, type SceneObject, SceneQueryRunner } from '@grafana/scenes';
+
+// Kept local to the sharing feature rather than imported from dashboard-scene/utils/utils: that
+// module transitively reaches DashboardScene, which imports ShareDrawer, creating an import cycle.
+export function getQueryRunnerFor(sceneObject: SceneObject | undefined): SceneQueryRunner | undefined {
+  if (!sceneObject) {
+    return undefined;
+  }
+  const dataProvider = sceneObject.state.$data ?? sceneObject.parent?.state.$data;
+  if (dataProvider instanceof SceneQueryRunner) {
+    return dataProvider;
+  }
+  if (dataProvider instanceof SceneDataTransformer) {
+    return getQueryRunnerFor(dataProvider);
+  }
+  return undefined;
+}

--- a/public/app/features/query/diagnostics/downloadDiagnostics.test.ts
+++ b/public/app/features/query/diagnostics/downloadDiagnostics.test.ts
@@ -50,7 +50,7 @@ describe('downloadDiagnosticsForQueries', () => {
         method: 'POST',
         responseType: 'blob',
         // Only the visible query is forwarded.
-        data: { from: '100', to: '200', queries: [{ refId: 'A' }], includeLogs: true },
+        data: { from: '100', to: '200', queries: [{ refId: 'A' }], includeLogs: false },
       })
     );
     expect(saveAs).toHaveBeenCalledWith(blob, 'diagnostics-20260101-000000.tar.gz');
@@ -95,7 +95,7 @@ describe('dashboard diagnostics', () => {
         url: '/api/ds/dashboard-diagnostics',
         method: 'POST',
         responseType: 'json',
-        data: { dashboard: undefined, panels, includeLogs: true },
+        data: { dashboard: undefined, panels, includeLogs: false },
       })
     );
   });

--- a/public/app/features/query/diagnostics/downloadDiagnostics.test.ts
+++ b/public/app/features/query/diagnostics/downloadDiagnostics.test.ts
@@ -50,7 +50,7 @@ describe('downloadDiagnosticsForQueries', () => {
         method: 'POST',
         responseType: 'blob',
         // Only the visible query is forwarded.
-        data: { from: '100', to: '200', queries: [{ refId: 'A' }] },
+        data: { from: '100', to: '200', queries: [{ refId: 'A' }], includeLogs: true },
       })
     );
     expect(saveAs).toHaveBeenCalledWith(blob, 'diagnostics-20260101-000000.tar.gz');
@@ -85,7 +85,7 @@ describe('dashboard diagnostics', () => {
         url: '/api/ds/dashboard-diagnostics',
         method: 'POST',
         responseType: 'json',
-        data: { dashboard: undefined, panels },
+        data: { dashboard: undefined, panels, includeLogs: true },
       })
     );
   });

--- a/public/app/features/query/diagnostics/downloadDiagnostics.test.ts
+++ b/public/app/features/query/diagnostics/downloadDiagnostics.test.ts
@@ -66,6 +66,16 @@ describe('downloadDiagnosticsForQueries', () => {
     const [, filename] = jest.mocked(saveAs).mock.calls[0];
     expect(filename).toMatch(/^diagnostics-\d{8}-\d{6}\.tar\.gz$/);
   });
+
+  it('can exclude server logs', async () => {
+    const fetch = setupBackendSrv({ data: new Blob(['bundle']), headers: new Headers() });
+
+    await downloadDiagnosticsForQueries([{ refId: 'A' }], '1', '2', { includeLogs: false });
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { from: '1', to: '2', queries: [{ refId: 'A' }], includeLogs: false } })
+    );
+  });
 });
 
 describe('dashboard diagnostics', () => {
@@ -94,6 +104,17 @@ describe('dashboard diagnostics', () => {
     setupBackendSrv({ data: {} });
     await expect(startDashboardDiagnostics([{ id: 1, title: 'A', from: '1', to: '2', queries: [] }])).rejects.toThrow(
       'Diagnostics job was not created'
+    );
+  });
+
+  it('startDashboardDiagnostics can exclude server logs', async () => {
+    const fetch = setupBackendSrv({ data: { uid: 'job-123' } });
+    const panels = [{ id: 1, title: 'A', from: '1', to: '2', queries: [{ refId: 'A' }] }];
+
+    await startDashboardDiagnostics(panels, undefined, { includeLogs: false });
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { dashboard: undefined, panels, includeLogs: false } })
     );
   });
 

--- a/public/app/features/query/diagnostics/downloadDiagnostics.ts
+++ b/public/app/features/query/diagnostics/downloadDiagnostics.ts
@@ -8,6 +8,11 @@ import { type DataQuery } from '@grafana/schema';
 const DIAGNOSTICS_ENDPOINT = '/api/ds/diagnostics';
 const DASHBOARD_DIAGNOSTICS_ENDPOINT = '/api/ds/dashboard-diagnostics';
 
+export interface DiagnosticsRequestOptions {
+  includeLogs?: boolean;
+  signal?: AbortSignal;
+}
+
 /** Fallback bundle filename, e.g. `diagnostics-20260623-172901.tar.gz` (local time), used when the
  * response carries no Content-Disposition filename. */
 function fallbackFileName(prefix = 'diagnostics'): string {
@@ -35,7 +40,7 @@ export async function downloadDiagnosticsForQueries(
   queries: DataQuery[],
   from: string,
   to: string,
-  signal?: AbortSignal
+  options: DiagnosticsRequestOptions = {}
 ): Promise<void> {
   const visibleQueries = queries.filter((query) => !query.hide);
 
@@ -48,11 +53,11 @@ export async function downloadDiagnosticsForQueries(
       url: DIAGNOSTICS_ENDPOINT,
       method: 'POST',
       responseType: 'blob',
-      data: { from, to, queries: visibleQueries, includeLogs: true },
+      data: { from, to, queries: visibleQueries, includeLogs: options.includeLogs ?? true },
       // Surface failures in the drawer instead of a global toast.
       showErrorAlert: false,
       // Cancelling the drawer aborts the in-flight request.
-      abortSignal: signal,
+      abortSignal: options.signal,
     })
   );
 
@@ -91,16 +96,16 @@ export interface DashboardDiagnosticsStatus {
 export async function startDashboardDiagnostics(
   panels: DashboardDiagnosticsPanel[],
   dashboard?: unknown,
-  signal?: AbortSignal
+  options: DiagnosticsRequestOptions = {}
 ): Promise<string> {
   const response = await lastValueFrom(
     getBackendSrv().fetch<{ uid: string }>({
       url: DASHBOARD_DIAGNOSTICS_ENDPOINT,
       method: 'POST',
       responseType: 'json',
-      data: { dashboard, panels, includeLogs: true },
+      data: { dashboard, panels, includeLogs: options.includeLogs ?? true },
       showErrorAlert: false,
-      abortSignal: signal,
+      abortSignal: options.signal,
     })
   );
   const uid = response.data?.uid;

--- a/public/app/features/query/diagnostics/downloadDiagnostics.ts
+++ b/public/app/features/query/diagnostics/downloadDiagnostics.ts
@@ -53,7 +53,7 @@ export async function downloadDiagnosticsForQueries(
       url: DIAGNOSTICS_ENDPOINT,
       method: 'POST',
       responseType: 'blob',
-      data: { from, to, queries: visibleQueries, includeLogs: options.includeLogs ?? true },
+      data: { from, to, queries: visibleQueries, includeLogs: options.includeLogs ?? false },
       // Surface failures in the drawer instead of a global toast.
       showErrorAlert: false,
       // Cancelling the drawer aborts the in-flight request.
@@ -103,7 +103,7 @@ export async function startDashboardDiagnostics(
       url: DASHBOARD_DIAGNOSTICS_ENDPOINT,
       method: 'POST',
       responseType: 'json',
-      data: { dashboard, panels, includeLogs: options.includeLogs ?? true },
+      data: { dashboard, panels, includeLogs: options.includeLogs ?? false },
       showErrorAlert: false,
       abortSignal: options.signal,
     })

--- a/public/app/features/query/diagnostics/downloadDiagnostics.ts
+++ b/public/app/features/query/diagnostics/downloadDiagnostics.ts
@@ -48,7 +48,7 @@ export async function downloadDiagnosticsForQueries(
       url: DIAGNOSTICS_ENDPOINT,
       method: 'POST',
       responseType: 'blob',
-      data: { from, to, queries: visibleQueries },
+      data: { from, to, queries: visibleQueries, includeLogs: true },
       // Surface failures in the drawer instead of a global toast.
       showErrorAlert: false,
       // Cancelling the drawer aborts the in-flight request.
@@ -98,7 +98,7 @@ export async function startDashboardDiagnostics(
       url: DASHBOARD_DIAGNOSTICS_ENDPOINT,
       method: 'POST',
       responseType: 'json',
-      data: { dashboard, panels },
+      data: { dashboard, panels, includeLogs: true },
       showErrorAlert: false,
       abortSignal: signal,
     })

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -5585,6 +5585,8 @@
       "error-title": "Failed to generate diagnostics",
       "generating-button": "Generating…",
       "generation-failed": "Diagnostics generation failed",
+      "include-server-logs": "Include server logs",
+      "include-server-logs-description": "Adds filtered query logs and a bounded unfiltered server-log window to the bundle.",
       "info-text-dashboard": "Generates a diagnostic bundle for the whole dashboard by re-running every panel's queries with HTTP capture active. This runs in the background and may take a while for large dashboards.",
       "info-text-panel": "Generates a diagnostic bundle for this panel by re-running its queries with HTTP capture active. The download may take a moment while the bundle is generated.",
       "job-not-created": "Diagnostics job was not created",


### PR DESCRIPTION
<!-- Proposed title: Datasources: Include server logs in diagnostics requests -->

**What is this feature?**

Adds an explicit, default-on **Include server logs** control to both on-demand diagnostics flows.

This builds on the whole-dashboard diagnostics frontend introduced in [grafana/grafana#128599](https://github.com/grafana/grafana/pull/128599).
It requires the server-log capture support from [grafana/grafana#128874](https://github.com/grafana/grafana/pull/128874).

- single-panel downloads send the selected `includeLogs` value to `POST /api/ds/diagnostics`;
- whole-dashboard generation sends the selected `includeLogs` value to `POST /api/ds/dashboard-diagnostics`.

Both flows share the common drawer presentation while keeping their execution logic separate. Request helpers default log capture off unless the caller passes the drawer selection explicitly.

Focused tests cover the default-on control, opting out, and the exact request payload for both flows.

**Why do we need this feature?**

The backend keeps log capture default-off for compatibility and only activates it when the caller explicitly opts in. The admin can now make that choice in the existing diagnostics drawer: logs are included by default for useful bundles, while the control makes the broader server-log scope visible and allows opting out.

**Who is this feature for?**

Grafana server administrators generating panel or whole-dashboard diagnostics in self-managed Grafana. The feature remains experimental, on-premises-only, server-admin-only, and gated by `grafana.onDemandDiagnostics`.