### PR TITLE
SSOSettings: gate the read path on the SSOSetting kind's storage mode

### DIFF
--- a/pkg/services/ssosettings/ssosettings.go
+++ b/pkg/services/ssosettings/ssosettings.go
@@ -55,6 +55,13 @@ type FallbackStrategy interface {
 	GetProviderConfig(ctx context.Context, provider string) (map[string]any, error)
 }
 
+// MTSettingsFallback marks a FallbackStrategy that reads from MT-Settings. When
+// such a strategy serves a read (past the storage read-flip), MT-Settings wins
+// the read precedence over the legacy database.
+type MTSettingsFallback interface {
+	ServesMTSettings() bool
+}
+
 // Store is a SSO settings store
 //
 //go:generate mockery --name Store --structname MockStore --outpkg ssosettingstests --filename store_mock.go --output ./ssosettingstests/

--- a/pkg/services/ssosettings/ssosettingsimpl/service.go
+++ b/pkg/services/ssosettings/ssosettingsimpl/service.go
@@ -588,7 +588,9 @@ func (s *Service) mergeSSOSettings(dbSettings, systemSettings *models.SSOSetting
 }
 
 // mergeSSOSettingsMTAuthoritative merges with MT-Settings winning and the DB
-// filling gaps — the read precedence past the storage read-flip (mode 3).
+// filling gaps (absent or empty values) — the mode-3 read precedence. Unlike
+// mergeSettings it filters nothing: the merge routes values, validation owns
+// the combined result.
 func (s *Service) mergeSSOSettingsMTAuthoritative(dbSettings, systemSettings *models.SSOSettings) *models.SSOSettings {
 	if dbSettings == nil {
 		return systemSettings
@@ -596,10 +598,20 @@ func (s *Service) mergeSSOSettingsMTAuthoritative(dbSettings, systemSettings *mo
 
 	s.logger.Debug("Merging SSO Settings, MT-Settings authoritative", "systemSettings", removeSecrets(systemSettings.Settings), "dbSettings", removeSecrets(dbSettings.Settings))
 
+	settings := make(map[string]any, len(systemSettings.Settings))
+	for k, v := range systemSettings.Settings {
+		settings[k] = v
+	}
+	for k, v := range dbSettings.Settings {
+		if existing, ok := settings[k]; !ok || isEmptyString(existing) {
+			settings[k] = v
+		}
+	}
+
 	return &models.SSOSettings{
 		Provider: systemSettings.Provider,
 		Source:   systemSettings.Source,
-		Settings: mergeSettings(systemSettings.Settings, dbSettings.Settings),
+		Settings: settings,
 		Created:  dbSettings.Created,
 		Updated:  dbSettings.Updated,
 	}

--- a/pkg/services/ssosettings/ssosettingsimpl/service.go
+++ b/pkg/services/ssosettings/ssosettingsimpl/service.go
@@ -17,6 +17,8 @@ import (
 
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	legacyiamv0 "github.com/grafana/grafana/pkg/apis/iam/v0alpha1"
+	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
@@ -53,6 +55,10 @@ type Service struct {
 	reloadables           map[string]ssosettings.Reloadable
 	cachedSSOSettings     []*models.SSOSettings
 	cacheMutex            sync.RWMutex
+
+	// mtReadAuthoritative drops the legacy DB read when the storage mode reaches
+	// mode 4, leaving MT-Settings as the sole read source.
+	mtReadAuthoritative bool
 }
 
 func ProvideService(cfg *setting.Cfg, sqlStore db.DB, ac ac.AccessControl,
@@ -72,14 +78,28 @@ func ProvideService(cfg *setting.Cfg, sqlStore db.DB, ac ac.AccessControl,
 		logger.Error("Failed to initialize the MT-Settings client", "error", err)
 	}
 
+	// The SSOSetting kind's dual-writer storage mode is the read-behavior lever.
+	// serveReads flips MT-Settings on at mode 3; mtReadAuthoritative drops the
+	// legacy DB read at mode 4. Below mode 3 the MT adapters match nothing.
+	ssoMode := grafanarest.Mode0
+	if resCfg, ok := cfg.UnifiedStorage[legacyiamv0.SSOSettingResourceInfo.GroupResource().String()]; ok {
+		ssoMode = resCfg.DualWriterMode
+	} else {
+		// No storage mode configured for the kind (also the on-prem default, and
+		// where a mistyped config section lands): stay on the legacy read path.
+		logger.Debug("No storage mode configured for the SSOSetting kind, using legacy reads", "mode", ssoMode)
+	}
+	serveReads := ssoMode >= grafanarest.Mode3
+	mtReadAuthoritative := ssoMode >= grafanarest.Mode4
+
 	// Each provider family pairs an MT-Settings adapter with its legacy
 	// strategy. The adapter sits first: while the ssoSettingsToMTSettings
 	// feature toggle is enabled it wins the match for its family, otherwise
 	// it matches nothing and the legacy strategy behaves as before.
 	fbStrategies := []ssosettings.FallbackStrategy{
-		strategies.NewMTSettingsOAuthStrategy(mtSettingsClient),
+		strategies.NewMTSettingsOAuthStrategy(mtSettingsClient, serveReads),
 		strategies.NewOAuthStrategy(cfg),
-		strategies.NewMTSettingsLDAPStrategy(mtSettingsClient),
+		strategies.NewMTSettingsLDAPStrategy(mtSettingsClient, serveReads),
 		strategies.NewLDAPStrategy(cfg),
 	}
 
@@ -93,7 +113,7 @@ func ProvideService(cfg *setting.Cfg, sqlStore db.DB, ac ac.AccessControl,
 	configurableProviders[social.LDAPProviderName] = true
 
 	if licensing.FeatureEnabled(social.SAMLProviderName) {
-		fbStrategies = append(fbStrategies, strategies.NewMTSettingsSAMLStrategy(mtSettingsClient), strategies.NewSAMLStrategy(settingsProvider))
+		fbStrategies = append(fbStrategies, strategies.NewMTSettingsSAMLStrategy(mtSettingsClient, serveReads), strategies.NewSAMLStrategy(settingsProvider))
 		providersList = append(providersList, social.SAMLProviderName)
 		configurableProviders[social.SAMLProviderName] = true
 	}
@@ -113,6 +133,7 @@ func ProvideService(cfg *setting.Cfg, sqlStore db.DB, ac ac.AccessControl,
 		reloadables:           make(map[string]ssosettings.Reloadable),
 		settingsProvider:      settingsProvider,
 		cachedSSOSettings:     make([]*models.SSOSettings, 0),
+		mtReadAuthoritative:   mtReadAuthoritative,
 	}
 
 	usageStats.RegisterMetricsFunc(svc.getUsageStats)
@@ -126,6 +147,16 @@ func ProvideService(cfg *setting.Cfg, sqlStore db.DB, ac ac.AccessControl,
 var _ ssosettings.Service = (*Service)(nil)
 
 func (s *Service) GetForProvider(ctx context.Context, provider string) (*models.SSOSettings, error) {
+	systemSettings, servedByMT, err := s.loadSettingsUsingFallbackStrategy(ctx, provider)
+	if err != nil {
+		return nil, err
+	}
+
+	// Mode 4+: MT-Settings is the sole read source, the legacy DB read is dropped.
+	if servedByMT && s.mtReadAuthoritative {
+		return systemSettings, nil
+	}
+
 	dbSettings, err := s.store.Get(ctx, provider)
 	if err != nil && !errors.Is(err, ssosettings.ErrNotFound) {
 		return nil, err
@@ -139,9 +170,9 @@ func (s *Service) GetForProvider(ctx context.Context, provider string) (*models.
 		}
 	}
 
-	systemSettings, err := s.loadSettingsUsingFallbackStrategy(ctx, provider)
-	if err != nil {
-		return nil, err
+	// Mode 3: MT-Settings wins the merge, the DB fills gaps (rollback window).
+	if servedByMT {
+		return s.mergeSSOSettingsMTAuthoritative(dbSettings, systemSettings), nil
 	}
 
 	return s.mergeSSOSettings(dbSettings, systemSettings), nil
@@ -193,6 +224,17 @@ func (s *Service) List(ctx context.Context) ([]*models.SSOSettings, error) {
 	}
 
 	for _, provider := range s.providersList {
+		fallbackSettings, servedByMT, err := s.loadSettingsUsingFallbackStrategy(ctx, provider)
+		if err != nil {
+			return nil, err
+		}
+
+		// Mode 4+: MT-Settings is the sole read source, the DB is ignored.
+		if servedByMT && s.mtReadAuthoritative {
+			result = append(result, fallbackSettings)
+			continue
+		}
+
 		dbSettings := getSettingByProvider(provider, storedSettings)
 		if dbSettings != nil {
 			// Settings are coming from the database thus secrets are encrypted
@@ -201,9 +243,11 @@ func (s *Service) List(ctx context.Context) ([]*models.SSOSettings, error) {
 				return nil, err
 			}
 		}
-		fallbackSettings, err := s.loadSettingsUsingFallbackStrategy(ctx, provider)
-		if err != nil {
-			return nil, err
+
+		// Mode 3: MT-Settings wins the merge, the DB fills gaps (rollback window).
+		if servedByMT {
+			result = append(result, s.mergeSSOSettingsMTAuthoritative(dbSettings, fallbackSettings))
+			continue
 		}
 
 		result = append(result, s.mergeSSOSettings(dbSettings, fallbackSettings))
@@ -400,27 +444,36 @@ func (s *Service) RegisterFallbackStrategy(providerRegex string, strategy ssoset
 	s.fbStrategies = append(s.fbStrategies, strategy)
 }
 
-func (s *Service) loadSettingsUsingFallbackStrategy(ctx context.Context, provider string) (*models.SSOSettings, error) {
+// loadSettingsUsingFallbackStrategy returns the system settings and whether an
+// MT-Settings adapter served them, which selects the read precedence downstream.
+func (s *Service) loadSettingsUsingFallbackStrategy(ctx context.Context, provider string) (*models.SSOSettings, bool, error) {
 	ctx, span := tracer.Start(ctx, "ssosettings.Service.loadSettingsUsingFallbackStrategy",
 		trace.WithAttributes(attribute.String("provider", provider)))
 	defer span.End()
 
 	loadStrategy, ok := s.getFallbackStrategyFor(ctx, provider)
 	if !ok {
-		return nil, tracing.Errorf(span, "no fallback strategy found for provider: %s", provider)
+		return nil, false, tracing.Errorf(span, "no fallback strategy found for provider: %s", provider)
 	}
 	span.SetAttributes(attribute.String("strategy", fmt.Sprintf("%T", loadStrategy)))
 
 	settingsFromSystem, err := loadStrategy.GetProviderConfig(ctx, provider)
 	if err != nil {
-		return nil, tracing.Error(span, err)
+		return nil, false, tracing.Error(span, err)
 	}
 
 	return &models.SSOSettings{
 		Provider: provider,
 		Source:   models.System,
 		Settings: settingsFromSystem,
-	}, nil
+	}, isMTSettingsFallback(loadStrategy), nil
+}
+
+// isMTSettingsFallback reports whether an MT-Settings adapter served the read.
+// It is true only past the storage read-flip, so it selects MT-wins precedence.
+func isMTSettingsFallback(strategy ssosettings.FallbackStrategy) bool {
+	mt, ok := strategy.(ssosettings.MTSettingsFallback)
+	return ok && mt.ServesMTSettings()
 }
 
 func getSettingByProvider(provider string, settings []*models.SSOSettings) *models.SSOSettings {
@@ -532,6 +585,24 @@ func (s *Service) mergeSSOSettings(dbSettings, systemSettings *models.SSOSetting
 	}
 
 	return result
+}
+
+// mergeSSOSettingsMTAuthoritative merges with MT-Settings winning and the DB
+// filling gaps — the read precedence past the storage read-flip (mode 3).
+func (s *Service) mergeSSOSettingsMTAuthoritative(dbSettings, systemSettings *models.SSOSettings) *models.SSOSettings {
+	if dbSettings == nil {
+		return systemSettings
+	}
+
+	s.logger.Debug("Merging SSO Settings, MT-Settings authoritative", "systemSettings", removeSecrets(systemSettings.Settings), "dbSettings", removeSecrets(dbSettings.Settings))
+
+	return &models.SSOSettings{
+		Provider: systemSettings.Provider,
+		Source:   systemSettings.Source,
+		Settings: mergeSettings(systemSettings.Settings, dbSettings.Settings),
+		Created:  dbSettings.Created,
+		Updated:  dbSettings.Updated,
+	}
 }
 
 func (s *Service) decryptSecrets(ctx context.Context, settings map[string]any) (map[string]any, error) {

--- a/pkg/services/ssosettings/ssosettingsimpl/service_test.go
+++ b/pkg/services/ssosettings/ssosettingsimpl/service_test.go
@@ -367,6 +367,75 @@ func TestService_GetForProvider(t *testing.T) {
 	}
 }
 
+func TestService_GetForProvider_StorageReadMode(t *testing.T) {
+	t.Parallel()
+
+	dbRow := func() *models.SSOSettings {
+		return &models.SSOSettings{
+			Provider: "github",
+			Settings: map[string]any{"client_id": "client_id_db", "db_only": "db_only"},
+			Source:   models.DB,
+		}
+	}
+
+	testCases := []struct {
+		name                string
+		servedByMT          bool
+		mtReadAuthoritative bool
+		want                *models.SSOSettings
+	}{
+		{
+			name:       "below the read-flip the database wins and the fallback fills gaps",
+			servedByMT: false,
+			want: &models.SSOSettings{
+				Provider: "github",
+				Source:   models.DB,
+				Settings: map[string]any{"client_id": "client_id_db", "db_only": "db_only", "mt_only": "mt_only"},
+			},
+		},
+		{
+			name:       "at the read-flip MT-Settings wins and the database fills gaps",
+			servedByMT: true,
+			want: &models.SSOSettings{
+				Provider: "github",
+				Source:   models.System,
+				Settings: map[string]any{"client_id": "client_id_mt", "mt_only": "mt_only", "db_only": "db_only"},
+			},
+		},
+		{
+			name:                "once authoritative MT-Settings is the sole source and the database is not read",
+			servedByMT:          true,
+			mtReadAuthoritative: true,
+			want: &models.SSOSettings{
+				Provider: "github",
+				Source:   models.System,
+				Settings: map[string]any{"client_id": "client_id_mt", "mt_only": "mt_only"},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			env := setupTestEnv(t, false, false, true)
+			env.service.mtReadAuthoritative = tc.mtReadAuthoritative
+			env.fallbackStrategy.ExpectedIsMatch = true
+			env.fallbackStrategy.ExpectedServesMTSettings = tc.servedByMT
+			env.fallbackStrategy.ExpectedConfigs = map[string]map[string]any{
+				"github": {"client_id": "client_id_mt", "mt_only": "mt_only"},
+			}
+			env.store.ExpectedSSOSetting = dbRow()
+
+			actual, err := env.service.GetForProvider(context.Background(), "github")
+
+			require.NoError(t, err)
+			require.Equal(t, tc.want, actual)
+		})
+	}
+}
+
 func TestService_GetForProviderFromCache(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/ssosettings/ssosettingsimpl/service_test.go
+++ b/pkg/services/ssosettings/ssosettingsimpl/service_test.go
@@ -382,6 +382,9 @@ func TestService_GetForProvider_StorageReadMode(t *testing.T) {
 		name                string
 		servedByMT          bool
 		mtReadAuthoritative bool
+		dbSettings          map[string]any // overrides dbRow().Settings when set
+		mtConfig            map[string]any // overrides the default fallback config when set
+		setup               func(env testEnv)
 		want                *models.SSOSettings
 	}{
 		{
@@ -412,6 +415,47 @@ func TestService_GetForProvider_StorageReadMode(t *testing.T) {
 				Settings: map[string]any{"client_id": "client_id_mt", "mt_only": "mt_only"},
 			},
 		},
+		{
+			name:       "the MT-authoritative merge gap-fills credential fields from the database",
+			servedByMT: true,
+			dbSettings: map[string]any{
+				"certificate": base64.RawStdEncoding.EncodeToString([]byte("certificate")),
+				"private_key": base64.RawStdEncoding.EncodeToString([]byte("private_key")),
+			},
+			setup: func(env testEnv) {
+				env.secrets.On("Decrypt", mock.Anything, []byte("certificate"), mock.Anything).Return([]byte("decrypted-certificate"), nil).Once()
+				env.secrets.On("Decrypt", mock.Anything, []byte("private_key"), mock.Anything).Return([]byte("decrypted-private_key"), nil).Once()
+			},
+			want: &models.SSOSettings{
+				Provider: "github",
+				Source:   models.System,
+				Settings: map[string]any{
+					"client_id":   "client_id_mt",
+					"mt_only":     "mt_only",
+					"certificate": "decrypted-certificate",
+					"private_key": "decrypted-private_key",
+				},
+			},
+		},
+		{
+			name:       "the MT-authoritative merge does not resolve variant conflicts, validation owns them",
+			servedByMT: true,
+			mtConfig:   map[string]any{"certificate_path": "/etc/saml/cert.pem"},
+			dbSettings: map[string]any{
+				"certificate": base64.RawStdEncoding.EncodeToString([]byte("certificate")),
+			},
+			setup: func(env testEnv) {
+				env.secrets.On("Decrypt", mock.Anything, []byte("certificate"), mock.Anything).Return([]byte("decrypted-certificate"), nil).Once()
+			},
+			want: &models.SSOSettings{
+				Provider: "github",
+				Source:   models.System,
+				Settings: map[string]any{
+					"certificate_path": "/etc/saml/cert.pem",
+					"certificate":      "decrypted-certificate",
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -423,15 +467,25 @@ func TestService_GetForProvider_StorageReadMode(t *testing.T) {
 			env.service.mtReadAuthoritative = tc.mtReadAuthoritative
 			env.fallbackStrategy.ExpectedIsMatch = true
 			env.fallbackStrategy.ExpectedServesMTSettings = tc.servedByMT
-			env.fallbackStrategy.ExpectedConfigs = map[string]map[string]any{
-				"github": {"client_id": "client_id_mt", "mt_only": "mt_only"},
+			mtConfig := tc.mtConfig
+			if mtConfig == nil {
+				mtConfig = map[string]any{"client_id": "client_id_mt", "mt_only": "mt_only"}
 			}
-			env.store.ExpectedSSOSetting = dbRow()
+			env.fallbackStrategy.ExpectedConfigs = map[string]map[string]any{"github": mtConfig}
+			row := dbRow()
+			if tc.dbSettings != nil {
+				row.Settings = tc.dbSettings
+			}
+			env.store.ExpectedSSOSetting = row
+			if tc.setup != nil {
+				tc.setup(env)
+			}
 
 			actual, err := env.service.GetForProvider(context.Background(), "github")
 
 			require.NoError(t, err)
 			require.Equal(t, tc.want, actual)
+			env.secrets.AssertExpectations(t)
 		})
 	}
 }

--- a/pkg/services/ssosettings/ssosettingstests/fallback_strategy_fake.go
+++ b/pkg/services/ssosettings/ssosettingstests/fallback_strategy_fake.go
@@ -3,10 +3,15 @@ package ssosettingstests
 import context "context"
 
 type FakeFallbackStrategy struct {
-	ExpectedIsMatch bool
-	ExpectedConfigs map[string]map[string]any
+	ExpectedIsMatch          bool
+	ExpectedConfigs          map[string]map[string]any
+	ExpectedServesMTSettings bool
 
 	ExpectedError error
+}
+
+func (f *FakeFallbackStrategy) ServesMTSettings() bool {
+	return f.ExpectedServesMTSettings
 }
 
 func NewFakeFallbackStrategy() *FakeFallbackStrategy {

--- a/pkg/services/ssosettings/strategies/mtsettings_strategy.go
+++ b/pkg/services/ssosettings/strategies/mtsettings_strategy.go
@@ -33,13 +33,23 @@ type SettingsLister interface {
 type mtSettingsStrategy struct {
 	settings SettingsLister
 	matches  func(provider string) bool
+	// serveReads gates matching on the storage mode having reached the read-flip
+	// (mode 3), fixed at construction. Below it the legacy strategy serves.
+	serveReads bool
 }
 
 func (s *mtSettingsStrategy) IsMatch(ctx context.Context, provider string) bool {
+	if !s.serveReads {
+		return false
+	}
 	enabled := openfeature.NewDefaultClient().Boolean(ctx,
 		featuremgmt.FlagGrafanaSsoSettingsToMTSettings, false, openfeature.TransactionContext(ctx))
 	return enabled && s.matches(provider)
 }
+
+// ServesMTSettings marks the adapter as MT-Settings-backed, selecting MT-wins
+// read precedence in the service once it serves a read.
+func (s *mtSettingsStrategy) ServesMTSettings() bool { return true }
 
 // GetProviderConfig loads the provider's settings from the MT-Settings
 // service: the rows of the auth.<provider> section, keyed like the ini keys
@@ -80,9 +90,10 @@ type MTSettingsOAuthStrategy struct {
 
 var _ ssosettings.FallbackStrategy = (*MTSettingsOAuthStrategy)(nil)
 
-func NewMTSettingsOAuthStrategy(settings SettingsLister) *MTSettingsOAuthStrategy {
+func NewMTSettingsOAuthStrategy(settings SettingsLister, serveReads bool) *MTSettingsOAuthStrategy {
 	return &MTSettingsOAuthStrategy{mtSettingsStrategy{
-		settings: settings,
+		settings:   settings,
+		serveReads: serveReads,
 		matches: func(provider string) bool {
 			return slices.Contains(ssosettings.AllOAuthProviders, provider)
 		},
@@ -100,9 +111,12 @@ var _ ssosettings.FallbackStrategy = (*MTSettingsLDAPStrategy)(nil)
 // on the legacy strategy even while the toggle is enabled. Matching with a
 // failing read would poison every provider — Service.List aborts on the
 // first fallback error and doReload stops reloading all providers.
-func NewMTSettingsLDAPStrategy(settings SettingsLister) *MTSettingsLDAPStrategy {
+func NewMTSettingsLDAPStrategy(settings SettingsLister, serveReads bool) *MTSettingsLDAPStrategy {
+	// TODO: serveReads is inert until LDAP matching is implemented; wire it into
+	// matches once the servers-config representation is decided.
 	return &MTSettingsLDAPStrategy{mtSettingsStrategy{
-		settings: settings,
+		settings:   settings,
+		serveReads: serveReads,
 		matches: func(_ string) bool {
 			return false
 		},
@@ -123,9 +137,10 @@ type MTSettingsSAMLStrategy struct {
 
 var _ ssosettings.FallbackStrategy = (*MTSettingsSAMLStrategy)(nil)
 
-func NewMTSettingsSAMLStrategy(settings SettingsLister) *MTSettingsSAMLStrategy {
+func NewMTSettingsSAMLStrategy(settings SettingsLister, serveReads bool) *MTSettingsSAMLStrategy {
 	return &MTSettingsSAMLStrategy{mtSettingsStrategy{
-		settings: settings,
+		settings:   settings,
+		serveReads: serveReads,
 		matches: func(provider string) bool {
 			return provider == social.SAMLProviderName
 		},

--- a/pkg/services/ssosettings/strategies/mtsettings_strategy_test.go
+++ b/pkg/services/ssosettings/strategies/mtsettings_strategy_test.go
@@ -53,9 +53,9 @@ func TestMTSettingsStrategies_IsMatch(t *testing.T) {
 		provider.UsingFlags(t, toggleFlags(false))
 
 		adapters := []ssosettings.FallbackStrategy{
-			NewMTSettingsOAuthStrategy(nil),
-			NewMTSettingsLDAPStrategy(nil),
-			NewMTSettingsSAMLStrategy(nil),
+			NewMTSettingsOAuthStrategy(nil, true),
+			NewMTSettingsLDAPStrategy(nil, true),
+			NewMTSettingsSAMLStrategy(nil, true),
 		}
 		providers := append([]string{}, ssosettings.AllOAuthProviders...)
 		providers = append(providers, social.LDAPProviderName, social.SAMLProviderName)
@@ -70,9 +70,9 @@ func TestMTSettingsStrategies_IsMatch(t *testing.T) {
 	t.Run("each adapter matches exactly its own family when the toggle is enabled", func(t *testing.T) {
 		provider.UsingFlags(t, toggleFlags(true))
 
-		oauth := NewMTSettingsOAuthStrategy(nil)
-		ldap := NewMTSettingsLDAPStrategy(nil)
-		saml := NewMTSettingsSAMLStrategy(nil)
+		oauth := NewMTSettingsOAuthStrategy(nil, true)
+		ldap := NewMTSettingsLDAPStrategy(nil, true)
+		saml := NewMTSettingsSAMLStrategy(nil, true)
 
 		for _, p := range ssosettings.AllOAuthProviders {
 			require.True(t, oauth.IsMatch(t.Context(), p))
@@ -88,9 +88,27 @@ func TestMTSettingsStrategies_IsMatch(t *testing.T) {
 	t.Run("the LDAP adapter matches nothing until its representation is decided", func(t *testing.T) {
 		provider.UsingFlags(t, toggleFlags(true))
 
-		ldap := NewMTSettingsLDAPStrategy(nil)
+		ldap := NewMTSettingsLDAPStrategy(nil, true)
 
 		require.False(t, ldap.IsMatch(t.Context(), social.LDAPProviderName))
+	})
+
+	t.Run("no adapter matches below the storage read-flip even when the toggle is enabled", func(t *testing.T) {
+		provider.UsingFlags(t, toggleFlags(true))
+
+		adapters := []ssosettings.FallbackStrategy{
+			NewMTSettingsOAuthStrategy(nil, false),
+			NewMTSettingsLDAPStrategy(nil, false),
+			NewMTSettingsSAMLStrategy(nil, false),
+		}
+		providers := append([]string{}, ssosettings.AllOAuthProviders...)
+		providers = append(providers, social.LDAPProviderName, social.SAMLProviderName)
+
+		for _, adapter := range adapters {
+			for _, p := range providers {
+				require.False(t, adapter.IsMatch(t.Context(), p))
+			}
+		}
 	})
 }
 
@@ -102,7 +120,7 @@ func TestMTSettingsStrategies_GetProviderConfig(t *testing.T) {
 			{Section: "auth.generic_oauth", Key: "auth_url", Value: "http://localhost:8087/auth"},
 		}}
 
-		config, err := NewMTSettingsOAuthStrategy(lister).GetProviderConfig(context.Background(), social.GenericOAuthProviderName)
+		config, err := NewMTSettingsOAuthStrategy(lister, true).GetProviderConfig(context.Background(), social.GenericOAuthProviderName)
 
 		require.NoError(t, err)
 		require.Equal(t, map[string]any{
@@ -116,7 +134,7 @@ func TestMTSettingsStrategies_GetProviderConfig(t *testing.T) {
 	t.Run("an absent section yields an empty map", func(t *testing.T) {
 		lister := &fakeSettingsLister{}
 
-		config, err := NewMTSettingsSAMLStrategy(lister).GetProviderConfig(context.Background(), social.SAMLProviderName)
+		config, err := NewMTSettingsSAMLStrategy(lister, true).GetProviderConfig(context.Background(), social.SAMLProviderName)
 
 		require.NoError(t, err)
 		require.Empty(t, config)
@@ -130,7 +148,7 @@ func TestMTSettingsStrategies_GetProviderConfig(t *testing.T) {
 			{Section: "auth.generic_oauth", Key: "enabled", Value: "true"},
 		}}
 
-		config, err := NewMTSettingsOAuthStrategy(lister).GetProviderConfig(context.Background(), social.GenericOAuthProviderName)
+		config, err := NewMTSettingsOAuthStrategy(lister, true).GetProviderConfig(context.Background(), social.GenericOAuthProviderName)
 
 		require.NoError(t, err)
 		require.Equal(t, map[string]any{"enabled": "true"}, config)
@@ -140,14 +158,14 @@ func TestMTSettingsStrategies_GetProviderConfig(t *testing.T) {
 		listErr := errors.New("settings service unavailable")
 		lister := &fakeSettingsLister{err: listErr}
 
-		config, err := NewMTSettingsOAuthStrategy(lister).GetProviderConfig(context.Background(), social.GitHubProviderName)
+		config, err := NewMTSettingsOAuthStrategy(lister, true).GetProviderConfig(context.Background(), social.GitHubProviderName)
 
 		require.Nil(t, config)
 		require.ErrorIs(t, err, listErr)
 	})
 
 	t.Run("a missing client fails loudly", func(t *testing.T) {
-		config, err := NewMTSettingsOAuthStrategy(nil).GetProviderConfig(context.Background(), social.GenericOAuthProviderName)
+		config, err := NewMTSettingsOAuthStrategy(nil, true).GetProviderConfig(context.Background(), social.GenericOAuthProviderName)
 
 		require.Nil(t, config)
 		require.ErrorIs(t, err, ssosettings.ErrMTSettingsClientNotConfigured)
@@ -158,7 +176,7 @@ func TestMTSettingsStrategies_GetProviderConfig(t *testing.T) {
 			{Section: "auth.ldap", Key: "enabled", Value: "true"},
 		}}
 
-		config, err := NewMTSettingsLDAPStrategy(lister).GetProviderConfig(context.Background(), social.LDAPProviderName)
+		config, err := NewMTSettingsLDAPStrategy(lister, true).GetProviderConfig(context.Background(), social.LDAPProviderName)
 
 		require.Nil(t, config)
 		require.ErrorIs(t, err, ssosettings.ErrMTSettingsNotImplemented)


### PR DESCRIPTION
Fixes grafana/identity-access-team#2247

## What

The SSOSetting kind's storage mode (`[unified_storage.ssosettings.iam.grafana.app] dualWriterMode`) becomes the read-behavior lever for SSO settings; the `grafana.ssoSettingsToMTSettings` feature toggle stays a reachability switch. Previously the MT-Settings fallback adapters matched on the toggle alone, so with the toggle on and no `sso_setting` row a provider could surface MT-Settings config at mode 0.

Read contract (standard dual-writer semantics):

| Mode | Read behavior |
|---|---|
| 0–2 | Database wins; MT-Settings adapters match nothing (legacy strategies serve, byte-identical to today) |
| 3 | MT-Settings wins the merge, the database fills gaps (rollback window) |
| 4–5 | MT-Settings only; the database read is dropped |

A read error from MT-Settings at mode 3+ fails loudly — no silent fallback to the legacy mechanism.

## Changes

- `strategies/mtsettings_strategy.go`: `serveReads` gate (mode ≥ 3) checked in `IsMatch` before the toggle; `ServesMTSettings()` marker.
- `ssosettingsimpl/service.go`: mode read once at construction (same config key as the kind storage; absent section → mode 0 + debug log); `GetForProvider`/`List` select precedence from which strategy served; `mergeSSOSettingsMTAuthoritative` for the mode-3 merge.
- Tests: strategy-level read-flip coverage; service-level table for the three read behaviors; test fake gains a `ServesMTSettings` toggle.

## Manual testing

Every mode was exercised against a real local MT-Settings service (mt-tilt: setting-apiserver + auth-signer + storage-server + mt-db in k3d). Grafana pointed at the local apiserver via `[settings_service] url`, namespace `stacks-11`. Seeded data: MT-Settings `us`-layer rows for `auth.generic_oauth` (`client_id = local-mt-marker` plus an MT-only `auth_url`) and a database row (`client_id = local-db-id` with a client secret). Grafana restarted per mode (the mode is read at boot).

| Mode | Toggle | Observed |
|---|---|---|
| section absent | on | startup debug line; database row served — legacy path |
| 0 | on | database wins; with no database row the legacy defaults serve (MT-Settings never consulted) |
| 1, 2 | on | identical to mode 0 |
| 3 | on | MT-Settings wins (`local-mt-marker`, MT-only key present), database fills gaps (client secret), `source: system` |
| 3, client unconfigured | on | HTTP 500 `sso.mtSettingsClientNotConfigured` — fail-loud, no silent legacy fallback |
| 3 | off | kill switch — database serves again |
| 4 | on | MT-Settings only; database not read (the database-only secret no longer present) |
| 5 | on | identical to mode 4 |