### PR TITLE
chore: cleanup datasourceAPIServers feature toggle 

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -119,11 +119,6 @@ export interface FeatureToggles {
   */
   mlExpressions?: boolean;
   /**
-  * Expose some datasources as apiservers.
-  * @default false
-  */
-  datasourceAPIServers?: boolean;
-  /**
   * Register experimental APIs with the k8s API server, including all datasources
   * @default false
   */

--- a/packages/grafana-runtime/src/utils/migrationHandler.ts
+++ b/packages/grafana-runtime/src/utils/migrationHandler.ts
@@ -1,9 +1,6 @@
 import { type DataQueryRequest } from '@grafana/data';
 import { type DataQuery } from '@grafana/schema';
 
-import { config } from '../config';
-import { getBackendSrv } from '../services';
-
 import { DataSourceWithBackend } from './DataSourceWithBackend';
 
 /**
@@ -18,55 +15,22 @@ export function isMigrationHandler(object: unknown): object is MigrationHandler 
   return object instanceof DataSourceWithBackend && 'hasBackendMigration' in object && 'shouldMigrate' in object;
 }
 
-async function postMigrateRequest<TQuery extends DataQuery>(queries: TQuery[]): Promise<TQuery[]> {
-  if (!(config.featureToggles.grafanaAPIServerWithExperimentalAPIs || config.featureToggles.datasourceAPIServers)) {
-    console.warn('migrateQuery is only available with the experimental API server');
-    return queries;
-  }
-
-  // Obtaining the GroupName from the plugin ID as done in the backend, this is temporary until we have a better way to obtain it
-  // https://github.com/grafana/grafana/blob/e013cd427cb0457177e11f19ebd30bc523b36c76/pkg/plugins/apiserver.go#L10
-  const dsnameURL = queries[0].datasource?.type?.replace(/^(grafana-)?(.*?)(-datasource)?$/, '$2');
-  const groupName = `${dsnameURL}.datasource.grafana.app`;
-  // Asuming apiVersion is v0alpha1, we'll need to obtain it from a trusted source
-  const apiVersion = 'v0alpha1';
-  const url = `/apis/${groupName}/${apiVersion}/namespaces/${config.namespace}/queryconvert`;
-  const request = {
-    queries: queries.map((query) => {
-      return {
-        ...query,
-        JSON: query, // JSON is not part of the type but it should be what holds the query
-      };
-    }),
-  };
-  const res = await getBackendSrv().post(url, request);
-  return res.queries.map((query: { JSON: TQuery }) => query.JSON);
-}
-
 /**
- * @alpha Experimental: Calls migration endpoint with one query. Requires grafanaAPIServerWithExperimentalAPIs or datasourceAPIServers feature toggle.
+ * @alpha Experimental: Migrates a single query. Currently a no-op pending migration endpoint implementation.
  */
 export async function migrateQuery<TQuery extends DataQuery>(
   datasource: MigrationHandler,
   query: TQuery
 ): Promise<TQuery> {
-  if (!datasource.hasBackendMigration || !datasource.shouldMigrate(query)) {
-    return query;
-  }
-  const res = await postMigrateRequest([query]);
-  return res[0];
+  return query;
 }
 
 /**
- * @alpha Experimental: Calls migration endpoint with multiple queries. Requires grafanaAPIServerWithExperimentalAPIs or datasourceAPIServers feature toggle.
+ * @alpha Experimental: Migrates all queries in a request. Currently a no-op pending migration endpoint implementation.
  */
 export async function migrateRequest<TQuery extends DataQuery>(
   datasource: MigrationHandler,
   request: DataQueryRequest<TQuery>
 ): Promise<DataQueryRequest<TQuery>> {
-  if (!datasource.hasBackendMigration || !request.targets.some((query) => datasource.shouldMigrate(query))) {
-    return request;
-  }
-  const res = await postMigrateRequest(request.targets);
-  return { ...request, targets: res };
+  return request;
 }

--- a/packages/grafana-runtime/src/utils/migrationHandler.ts
+++ b/packages/grafana-runtime/src/utils/migrationHandler.ts
@@ -1,10 +1,13 @@
 import { type DataQueryRequest } from '@grafana/data';
 import { type DataQuery } from '@grafana/schema';
 
+import { config } from '../config';
+import { getBackendSrv } from '../services';
+
 import { DataSourceWithBackend } from './DataSourceWithBackend';
 
 /**
- * @alpha Experimental: Plugins implementing MigrationHandler interface will automatically have their queries migrated.
+ * @alpha Plugins implementing MigrationHandler interface will automatically have their queries migrated.
  */
 export interface MigrationHandler {
   hasBackendMigration: boolean;
@@ -15,22 +18,50 @@ export function isMigrationHandler(object: unknown): object is MigrationHandler 
   return object instanceof DataSourceWithBackend && 'hasBackendMigration' in object && 'shouldMigrate' in object;
 }
 
+async function postMigrateRequest<TQuery extends DataQuery>(queries: TQuery[]): Promise<TQuery[]> {
+  // Obtaining the GroupName from the plugin ID as done in the backend, this is temporary until we have a better way to obtain it
+  // https://github.com/grafana/grafana/blob/e013cd427cb0457177e11f19ebd30bc523b36c76/pkg/plugins/apiserver.go#L10
+  const dsnameURL = queries[0].datasource?.type?.replace(/^(grafana-)?(.*?)(-datasource)?$/, '$2');
+  const groupName = `${dsnameURL}.datasource.grafana.app`;
+  // Asuming apiVersion is v0alpha1, we'll need to obtain it from a trusted source
+  const apiVersion = 'v0alpha1';
+  const url = `/apis/${groupName}/${apiVersion}/namespaces/${config.namespace}/queryconvert`;
+  const request = {
+    queries: queries.map((query) => {
+      return {
+        ...query,
+        JSON: query, // JSON is not part of the type but it should be what holds the query
+      };
+    }),
+  };
+  const res = await getBackendSrv().post(url, request);
+  return res.queries.map((query: { JSON: TQuery }) => query.JSON);
+}
+
 /**
- * @alpha Experimental: Migrates a single query. Currently a no-op pending migration endpoint implementation.
+ * @alpha Calls migration endpoint with one query.
  */
 export async function migrateQuery<TQuery extends DataQuery>(
   datasource: MigrationHandler,
   query: TQuery
 ): Promise<TQuery> {
-  return query;
+  if (!datasource.hasBackendMigration || !datasource.shouldMigrate(query)) {
+    return query;
+  }
+  const res = await postMigrateRequest([query]);
+  return res[0];
 }
 
 /**
- * @alpha Experimental: Migrates all queries in a request. Currently a no-op pending migration endpoint implementation.
+ * @alpha Calls migration endpoint with multiple queries.
  */
 export async function migrateRequest<TQuery extends DataQuery>(
   datasource: MigrationHandler,
   request: DataQueryRequest<TQuery>
 ): Promise<DataQueryRequest<TQuery>> {
-  return request;
+  if (!datasource.hasBackendMigration || !request.targets.some((query) => datasource.shouldMigrate(query))) {
+    return request;
+  }
+  const res = await postMigrateRequest(request.targets);
+  return { ...request, targets: res };
 }

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -226,15 +226,6 @@ var (
 			Expression:  "false",
 		},
 		{
-			Name:            "datasourceAPIServers",
-			Description:     "Expose some datasources as apiservers.",
-			Stage:           FeatureStageExperimental,
-			Owner:           grafanaAppPlatformSquad,
-			RequiresRestart: true, // changes the API routing
-			Expression:      "false",
-			Generate:        Generate{LegacyGo: true, LegacyFrontend: true},
-		},
-		{
 			Name:            "grafanaAPIServerWithExperimentalAPIs",
 			Description:     "Register experimental APIs with the k8s API server, including all datasources",
 			Stage:           FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -24,7 +24,6 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2023-07-06,awsDatasourcesTempCredentials,GA,@grafana/data-sources-plugins,false,false,false
 2026-07-14,awsAssumeRolePerDatasourceExternalId,experimental,@grafana/data-sources-plugins,false,false,false
 2023-07-13,mlExpressions,experimental,@grafana/alerting-squad,false,false,false
-2024-09-19,datasourceAPIServers,experimental,@grafana/grafana-app-platform-squad,false,true,false
 2023-10-06,grafanaAPIServerWithExperimentalAPIs,experimental,@grafana/grafana-app-platform-squad,true,true,false
 2024-11-22,provisioning,GA,@grafana/grafana-app-platform-squad,false,true,false
 2026-05-22,provisioningFolderMetadata,GA,@grafana/grafana-app-platform-squad,false,true,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -75,10 +75,6 @@ const (
 	// Enable support for Machine Learning in server-side expressions
 	FlagMlExpressions = "mlExpressions"
 
-	// FlagDatasourceAPIServers
-	// Expose some datasources as apiservers.
-	FlagDatasourceAPIServers = "datasourceAPIServers"
-
 	// FlagGrafanaAPIServerWithExperimentalAPIs
 	// Register experimental APIs with the k8s API server, including all datasources
 	FlagGrafanaAPIServerWithExperimentalAPIs = "grafanaAPIServerWithExperimentalAPIs"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1815,7 +1815,8 @@
       "metadata": {
         "name": "datasourceAPIServers",
         "resourceVersion": "1779440584464",
-        "creationTimestamp": "2024-09-19T08:28:27Z"
+        "creationTimestamp": "2024-09-19T08:28:27Z",
+        "deletionTimestamp": "2026-07-21T07:41:20Z"
       },
       "spec": {
         "description": "Expose some datasources as apiservers.",


### PR DESCRIPTION
The datasourceAPIServers toggle gated the query migration path in the frontend — postMigrateRequest would early-return if the toggle was off. The toggle is no longer needed and this PR removes it.

#### What was done
**Backend**
- Removed `datasourceAPIServers` toggle from `registry.go`

**Frontend (`migrationHandler.ts`)**
- Removed the feature toggle guard from `postMigrateRequest` — migration is now unconditionally enabled for any datasource that opts in via the `MigrationHandler` interface
- Dropped `Experimental` qualifier and feature toggle requirement notes from JSDoc comments