### PR TITLE
Search: remove legacy email/login wildcard default

### DIFF
--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -2410,22 +2410,13 @@ func (b *bleveIndex) buildTextQuery(searchrequest *bleve.SearchRequest, req *res
 		// When QueryFields is set, search across each named field (only Name is
 		// used; Type and Boost are ignored because bleve wildcards don't support
 		// analyzers or meaningful relevance scoring).
-		// When QueryFields is empty, default to title + IAM identity fields
-		// (email, login) for backward compatibility with older clients that
-		// don't set QueryFields.
+		// When QueryFields is empty, default to title.
 		if len(req.QueryFields) > 0 {
 			for _, field := range req.QueryFields {
 				addWildcardQueries(disjoin, req.Query, field.Name)
 			}
 		} else {
-			// Default: search title and IAM identity fields (email, login).
-			// IAM user search wraps queries as "*<query>*" — older clients
-			// may not set QueryFields, so we include email/login here for
-			// backward compatibility during the deployment gap.
-			// TODO: remove email and login fields once IAM only sends requests with QueryFields.
 			addWildcardQueries(disjoin, req.Query, resource.SEARCH_FIELD_TITLE)
-			addWildcardQueries(disjoin, req.Query, resource.SEARCH_FIELD_PREFIX+"email")
-			addWildcardQueries(disjoin, req.Query, resource.SEARCH_FIELD_PREFIX+"login")
 		}
 		return disjoin
 	}

--- a/pkg/storage/unified/search/bleve_search_test.go
+++ b/pkg/storage/unified/search/bleve_search_test.go
@@ -447,7 +447,7 @@ func TestWildcardQuery(t *testing.T) {
 		checkSearchQuery(t, index, newTestQuery("*Dev Overview*"), []string{"name1"})
 	})
 
-	t.Run("default wildcard searches email and login fields", func(t *testing.T) {
+	t.Run("wildcard searches email and login only with explicit QueryFields", func(t *testing.T) {
 		// Use an index with keyword-analyzed email/login fields (matching
 		// production IAM config) so wildcards match full email addresses.
 		index := newTestIndexWithFields(t, key, []*resourcepb.ResourceTableColumnDefinition{
@@ -469,12 +469,26 @@ func TestWildcardQuery(t *testing.T) {
 			},
 		}))
 
-		// Default wildcard (no QueryFields) should match email field
-		checkSearchQuery(t, index, newTestQuery("*uniquemail@grafana.com*"), []string{"user1"})
-		// Default wildcard should match login field
-		checkSearchQuery(t, index, newTestQuery("*secondlogin*"), []string{"user2"})
-		// Wildcard matching domain across both users (order is non-deterministic)
-		res, err := index.Search(context.Background(), nil, newTestQuery("*grafana.com*"), nil, nil)
+		emailField := resource.SEARCH_FIELD_PREFIX + "email"
+		loginField := resource.SEARCH_FIELD_PREFIX + "login"
+
+		// Default wildcard (no QueryFields) searches title only, so email/login queries don't match.
+		checkSearchQuery(t, index, newTestQuery("*uniquemail@grafana.com*"), nil)
+		checkSearchQuery(t, index, newTestQuery("*secondlogin*"), nil)
+
+		// With explicit QueryFields, wildcards match the named identity fields.
+		reqEmail := newTestQuery("*uniquemail@grafana.com*")
+		reqEmail.QueryFields = []*resourcepb.ResourceSearchRequest_QueryField{{Name: emailField}}
+		checkSearchQuery(t, index, reqEmail, []string{"user1"})
+
+		reqLogin := newTestQuery("*secondlogin*")
+		reqLogin.QueryFields = []*resourcepb.ResourceSearchRequest_QueryField{{Name: loginField}}
+		checkSearchQuery(t, index, reqLogin, []string{"user2"})
+
+		// Wildcard on email matching domain across both users (order is non-deterministic).
+		reqDomain := newTestQuery("*grafana.com*")
+		reqDomain.QueryFields = []*resourcepb.ResourceSearchRequest_QueryField{{Name: emailField}}
+		res, err := index.Search(context.Background(), nil, reqDomain, nil, nil)
 		require.NoError(t, err)
 		require.Equal(t, int64(2), res.TotalHits)
 	})


### PR DESCRIPTION
PR #122727 changed wildcard searches to only search fields explicitly listed in `QueryFields`. To avoid breaking the IAM user search during the deployment gap, we kept a fallback: when a wildcard query arrived without `QueryFields`, we defaulted to searching `title`, `email`, and `login`.

The IAM user search was updated in that same PR to always send `QueryFields` explicitly, and it has been deployed that way for months. The fallback is now dead weight, so this removes the `email`/`login` part.

Default wildcard searches (no `QueryFields`) now match `title` only. I verified the other callers that issue wildcard searches without `QueryFields` (folder search and the dashboard service) only care about title and are unaffected.

The test covering the old default was updated to assert the new behavior: a default wildcard no longer matches email/login, while explicit `QueryFields` still does.

Follow-up to #122727.
