### PR TITLE
SSOSettings: Prevent OpenFeature test-provider race

### DIFF
--- a/pkg/services/ssosettings/strategies/mtsettings_strategy_test.go
+++ b/pkg/services/ssosettings/strategies/mtsettings_strategy_test.go
@@ -35,7 +35,7 @@ func (f *fakeSettingsLister) List(_ context.Context, selector metav1.LabelSelect
 var provider = oftesting.NewTestProvider()
 
 func TestMain(m *testing.M) {
-	if err := openfeature.SetProvider(provider); err != nil {
+	if err := openfeature.SetProviderAndWait(provider); err != nil {
 		panic(err)
 	}
 


### PR DESCRIPTION
## What
Wait for the package test OpenFeature provider to become ready before tests evaluate feature flags.

## Why
Asynchronous provider initialization can return the flag default before it is ready, causing the enabled MT-Settings strategy assertion to fail.

## Verification
- Reproduced the failure in a fresh process with `GOMAXPROCS=1` before the change.
- Passed the same fresh-process probe 1,000 times after the change.
- `go test -run '^TestMTSettingsStrategies_IsMatch$' ./pkg/services/ssosettings/strategies`