### PR TITLE
Datasources: Include panel JSON in dashboard diagnostics bundles

### DIFF
--- a/pkg/services/diagnostics/diagnostics.go
+++ b/pkg/services/diagnostics/diagnostics.go
@@ -209,7 +209,7 @@ func indexElementsByID(elements map[string]json.RawMessage, panelsByID map[int64
 				ID *int64 `json:"id"`
 			} `json:"spec"`
 		}
-		if err := json.Unmarshal(raw, &meta); err != nil || meta.Kind != "Panel" || meta.Spec.ID == nil {
+		if err := json.Unmarshal(raw, &meta); err != nil || (meta.Kind != "Panel" && meta.Kind != "LibraryPanel") || meta.Spec.ID == nil {
 			continue
 		}
 		if _, exists := panelsByID[*meta.Spec.ID]; !exists {

--- a/pkg/services/diagnostics/diagnostics.go
+++ b/pkg/services/diagnostics/diagnostics.go
@@ -114,6 +114,7 @@ func (b *Bundler) BuildDashboard(dashboardJSON json.RawMessage, panels []Dashboa
 	}
 
 	usedDirs := map[string]bool{}
+	panelJSONByID := indexPanelJSON(dashboardJSON)
 	for _, p := range panels {
 		entry := manifestPanelEntry{ID: p.ID, Title: p.Title, Datasources: p.Datasources}
 
@@ -129,7 +130,7 @@ func (b *Bundler) BuildDashboard(dashboardJSON json.RawMessage, panels []Dashboa
 		// separately, so resolve this panel's JSON from that model by id when it wasn't supplied inline.
 		panelJSON := p.PanelJSON
 		if len(panelJSON) == 0 {
-			panelJSON = extractPanelJSON(dashboardJSON, p.ID)
+			panelJSON = panelJSONByID[p.ID]
 		}
 		if len(panelJSON) > 0 {
 			files[dir+"/panel.json"] = indentJSON(panelJSON)
@@ -163,24 +164,24 @@ func (b *Bundler) BuildDashboard(dashboardJSON json.RawMessage, panels []Dashboa
 	return buildTarGz(files)
 }
 
-// extractPanelJSON returns the raw JSON of the panel with the given id from a dashboard save model,
-// or nil if absent. The whole-dashboard client sends the dashboard model once (not each panel's JSON),
-// so per-panel panel.json is resolved here by id. Collapsed rows carry their children in a nested
-// "panels" array, so the search recurses into them.
-func extractPanelJSON(dashboardJSON json.RawMessage, id int64) json.RawMessage {
+// indexPanelJSON indexes the raw panel JSON from a dashboard save model by panel id. Collapsed rows
+// carry their children in a nested "panels" array, so the index includes them recursively.
+func indexPanelJSON(dashboardJSON json.RawMessage) map[int64]json.RawMessage {
+	panelsByID := make(map[int64]json.RawMessage)
 	if len(dashboardJSON) == 0 {
-		return nil
+		return panelsByID
 	}
 	var doc struct {
 		Panels []json.RawMessage `json:"panels"`
 	}
 	if err := json.Unmarshal(dashboardJSON, &doc); err != nil {
-		return nil
+		return panelsByID
 	}
-	return findPanelByID(doc.Panels, id)
+	indexPanelsByID(doc.Panels, panelsByID)
+	return panelsByID
 }
 
-func findPanelByID(panels []json.RawMessage, id int64) json.RawMessage {
+func indexPanelsByID(panels []json.RawMessage, panelsByID map[int64]json.RawMessage) {
 	for _, raw := range panels {
 		var meta struct {
 			ID     *int64            `json:"id"`
@@ -189,14 +190,13 @@ func findPanelByID(panels []json.RawMessage, id int64) json.RawMessage {
 		if err := json.Unmarshal(raw, &meta); err != nil {
 			continue
 		}
-		if meta.ID != nil && *meta.ID == id {
-			return raw
+		if meta.ID != nil {
+			if _, exists := panelsByID[*meta.ID]; !exists {
+				panelsByID[*meta.ID] = raw
+			}
 		}
-		if found := findPanelByID(meta.Panels, id); found != nil {
-			return found
-		}
+		indexPanelsByID(meta.Panels, panelsByID)
 	}
-	return nil
 }
 
 // uniquePanelDir builds a stable, filesystem-safe directory name (panels/<id>-<slug>),

--- a/pkg/services/diagnostics/diagnostics.go
+++ b/pkg/services/diagnostics/diagnostics.go
@@ -165,6 +165,9 @@ func (b *Bundler) BuildDashboard(dashboardJSON json.RawMessage, panels []Dashboa
 }
 
 // indexPanelJSON indexes the raw panel JSON from v1 and v2 dashboard save models by panel id.
+// Each entry is stored as it appears in its own schema, so panel.json shape differs by version:
+// the bare panel object for v1 (from "panels"), and the full {kind, spec} element for v2 (from
+// "elements") -- the same split the bundle's dashboard.json already has.
 // Collapsed v1 rows carry their children in a nested "panels" array, so the index includes them recursively.
 func indexPanelJSON(dashboardJSON json.RawMessage) map[int64]json.RawMessage {
 	panelsByID := make(map[int64]json.RawMessage)
@@ -201,6 +204,9 @@ func indexPanelsByID(panels []json.RawMessage, panelsByID map[int64]json.RawMess
 	}
 }
 
+// indexElementsByID indexes v2 "elements" entries by their spec.id. Both a regular "Panel" and a
+// "LibraryPanel" carry a resolved panel spec with an id, so both are indexed; other element kinds
+// (rows, tabs, ...) have no panel id and are skipped.
 func indexElementsByID(elements map[string]json.RawMessage, panelsByID map[int64]json.RawMessage) {
 	for _, raw := range elements {
 		var meta struct {

--- a/pkg/services/diagnostics/diagnostics.go
+++ b/pkg/services/diagnostics/diagnostics.go
@@ -164,20 +164,22 @@ func (b *Bundler) BuildDashboard(dashboardJSON json.RawMessage, panels []Dashboa
 	return buildTarGz(files)
 }
 
-// indexPanelJSON indexes the raw panel JSON from a dashboard save model by panel id. Collapsed rows
-// carry their children in a nested "panels" array, so the index includes them recursively.
+// indexPanelJSON indexes the raw panel JSON from v1 and v2 dashboard save models by panel id.
+// Collapsed v1 rows carry their children in a nested "panels" array, so the index includes them recursively.
 func indexPanelJSON(dashboardJSON json.RawMessage) map[int64]json.RawMessage {
 	panelsByID := make(map[int64]json.RawMessage)
 	if len(dashboardJSON) == 0 {
 		return panelsByID
 	}
 	var doc struct {
-		Panels []json.RawMessage `json:"panels"`
+		Panels   []json.RawMessage          `json:"panels"`
+		Elements map[string]json.RawMessage `json:"elements"`
 	}
 	if err := json.Unmarshal(dashboardJSON, &doc); err != nil {
 		return panelsByID
 	}
 	indexPanelsByID(doc.Panels, panelsByID)
+	indexElementsByID(doc.Elements, panelsByID)
 	return panelsByID
 }
 
@@ -196,6 +198,23 @@ func indexPanelsByID(panels []json.RawMessage, panelsByID map[int64]json.RawMess
 			}
 		}
 		indexPanelsByID(meta.Panels, panelsByID)
+	}
+}
+
+func indexElementsByID(elements map[string]json.RawMessage, panelsByID map[int64]json.RawMessage) {
+	for _, raw := range elements {
+		var meta struct {
+			Kind string `json:"kind"`
+			Spec struct {
+				ID *int64 `json:"id"`
+			} `json:"spec"`
+		}
+		if err := json.Unmarshal(raw, &meta); err != nil || meta.Kind != "Panel" || meta.Spec.ID == nil {
+			continue
+		}
+		if _, exists := panelsByID[*meta.Spec.ID]; !exists {
+			panelsByID[*meta.Spec.ID] = raw
+		}
 	}
 }
 

--- a/pkg/services/diagnostics/diagnostics.go
+++ b/pkg/services/diagnostics/diagnostics.go
@@ -125,8 +125,14 @@ func (b *Bundler) BuildDashboard(dashboardJSON json.RawMessage, panels []Dashboa
 
 		dir := uniquePanelDir(p.ID, p.Title, usedDirs)
 		entry.Dir = dir
-		if len(p.PanelJSON) > 0 {
-			files[dir+"/panel.json"] = indentJSON(p.PanelJSON)
+		// The whole-dashboard client posts the dashboard save model once rather than each panel's JSON
+		// separately, so resolve this panel's JSON from that model by id when it wasn't supplied inline.
+		panelJSON := p.PanelJSON
+		if len(panelJSON) == 0 {
+			panelJSON = extractPanelJSON(dashboardJSON, p.ID)
+		}
+		if len(panelJSON) > 0 {
+			files[dir+"/panel.json"] = indentJSON(panelJSON)
 		}
 
 		// A single panel's capture that fails to serialize must not sink the whole multi-panel bundle:
@@ -155,6 +161,42 @@ func (b *Bundler) BuildDashboard(dashboardJSON json.RawMessage, panels []Dashboa
 	}
 
 	return buildTarGz(files)
+}
+
+// extractPanelJSON returns the raw JSON of the panel with the given id from a dashboard save model,
+// or nil if absent. The whole-dashboard client sends the dashboard model once (not each panel's JSON),
+// so per-panel panel.json is resolved here by id. Collapsed rows carry their children in a nested
+// "panels" array, so the search recurses into them.
+func extractPanelJSON(dashboardJSON json.RawMessage, id int64) json.RawMessage {
+	if len(dashboardJSON) == 0 {
+		return nil
+	}
+	var doc struct {
+		Panels []json.RawMessage `json:"panels"`
+	}
+	if err := json.Unmarshal(dashboardJSON, &doc); err != nil {
+		return nil
+	}
+	return findPanelByID(doc.Panels, id)
+}
+
+func findPanelByID(panels []json.RawMessage, id int64) json.RawMessage {
+	for _, raw := range panels {
+		var meta struct {
+			ID     *int64            `json:"id"`
+			Panels []json.RawMessage `json:"panels"`
+		}
+		if err := json.Unmarshal(raw, &meta); err != nil {
+			continue
+		}
+		if meta.ID != nil && *meta.ID == id {
+			return raw
+		}
+		if found := findPanelByID(meta.Panels, id); found != nil {
+			return found
+		}
+	}
+	return nil
 }
 
 // uniquePanelDir builds a stable, filesystem-safe directory name (panels/<id>-<slug>),

--- a/pkg/services/diagnostics/diagnostics_test.go
+++ b/pkg/services/diagnostics/diagnostics_test.go
@@ -452,18 +452,25 @@ func TestBuildDashboard_resolvesPanelJSONFromDashboardV2Model(t *testing.T) {
 			"panel-3": {
 				"kind": "Panel",
 				"spec": {"id": 3, "title": "CPU Usage", "vizConfig": {"group": "timeseries"}}
+			},
+			"panel-4": {
+				"kind": "LibraryPanel",
+				"spec": {"id": 4, "title": "Shared Errors", "libraryPanel": {"uid": "shared-errors"}}
 			}
 		}
 	}`)
 	panels := []DashboardPanel{
 		{ID: 3, Title: "CPU Usage", HARBuffer: bufferWithEntry(t, "http://ds/3")},
+		{ID: 4, Title: "Shared Errors", HARBuffer: bufferWithEntry(t, "http://ds/4")},
 	}
 	blob, err := NewBundler().BuildDashboard(dashboardJSON, panels)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
 	require.Contains(t, files, "panels/3-cpu-usage/panel.json")
+	require.Contains(t, files, "panels/4-shared-errors/panel.json")
 	require.Contains(t, string(files["panels/3-cpu-usage/panel.json"]), `"timeseries"`)
+	require.Contains(t, string(files["panels/4-shared-errors/panel.json"]), `"shared-errors"`)
 }
 
 func TestIndexPanelJSON(t *testing.T) {

--- a/pkg/services/diagnostics/diagnostics_test.go
+++ b/pkg/services/diagnostics/diagnostics_test.go
@@ -445,13 +445,14 @@ func TestBuildDashboard_resolvesPanelJSONFromDashboardModel(t *testing.T) {
 	require.Contains(t, string(files["panels/2-logs/panel.json"]), `"logs"`)
 }
 
-func TestExtractPanelJSON(t *testing.T) {
+func TestIndexPanelJSON(t *testing.T) {
 	dash := json.RawMessage(`{"panels":[{"id":1,"type":"a"},{"id":5,"type":"row","panels":[{"id":6,"type":"b"}]}]}`)
-	require.Contains(t, string(extractPanelJSON(dash, 1)), `"a"`)
-	require.Contains(t, string(extractPanelJSON(dash, 6)), `"b"`, "must find panels nested in a row")
-	require.Nil(t, extractPanelJSON(dash, 99), "unknown id -> nil")
-	require.Nil(t, extractPanelJSON(nil, 1), "empty dashboard -> nil")
-	require.Nil(t, extractPanelJSON(json.RawMessage(`not json`), 1), "malformed -> nil, not panic")
+	panelsByID := indexPanelJSON(dash)
+	require.Contains(t, string(panelsByID[1]), `"a"`)
+	require.Contains(t, string(panelsByID[6]), `"b"`, "must index panels nested in a row")
+	require.NotContains(t, panelsByID, int64(99), "unknown id is omitted")
+	require.Empty(t, indexPanelJSON(nil), "empty dashboard produces an empty index")
+	require.Empty(t, indexPanelJSON(json.RawMessage(`not json`)), "malformed dashboard produces an empty index")
 }
 
 func TestBuildDashboard_recordsPanelQueryError(t *testing.T) {

--- a/pkg/services/diagnostics/diagnostics_test.go
+++ b/pkg/services/diagnostics/diagnostics_test.go
@@ -445,6 +445,27 @@ func TestBuildDashboard_resolvesPanelJSONFromDashboardModel(t *testing.T) {
 	require.Contains(t, string(files["panels/2-logs/panel.json"]), `"logs"`)
 }
 
+func TestBuildDashboard_resolvesPanelJSONFromDashboardV2Model(t *testing.T) {
+	dashboardJSON := json.RawMessage(`{
+		"title": "My dash",
+		"elements": {
+			"panel-3": {
+				"kind": "Panel",
+				"spec": {"id": 3, "title": "CPU Usage", "vizConfig": {"group": "timeseries"}}
+			}
+		}
+	}`)
+	panels := []DashboardPanel{
+		{ID: 3, Title: "CPU Usage", HARBuffer: bufferWithEntry(t, "http://ds/3")},
+	}
+	blob, err := NewBundler().BuildDashboard(dashboardJSON, panels)
+	require.NoError(t, err)
+
+	files := readTarGz(t, blob)
+	require.Contains(t, files, "panels/3-cpu-usage/panel.json")
+	require.Contains(t, string(files["panels/3-cpu-usage/panel.json"]), `"timeseries"`)
+}
+
 func TestIndexPanelJSON(t *testing.T) {
 	dash := json.RawMessage(`{"panels":[{"id":1,"type":"a"},{"id":5,"type":"row","panels":[{"id":6,"type":"b"}]}]}`)
 	panelsByID := indexPanelJSON(dash)

--- a/pkg/services/diagnostics/diagnostics_test.go
+++ b/pkg/services/diagnostics/diagnostics_test.go
@@ -417,6 +417,43 @@ func TestBuildDashboard(t *testing.T) {
 	require.Positive(t, m.Panels[0].HARBytes)
 }
 
+// The whole-dashboard client posts the dashboard save model once instead of each panel's JSON, so
+// BuildDashboard must resolve each panel's panel.json from that model by id -- including panels nested
+// inside a collapsed row.
+func TestBuildDashboard_resolvesPanelJSONFromDashboardModel(t *testing.T) {
+	dashboardJSON := json.RawMessage(`{
+		"title": "My dash",
+		"panels": [
+			{"id": 1, "type": "timeseries", "title": "CPU Usage"},
+			{"id": 9, "type": "row", "title": "Row", "panels": [
+				{"id": 2, "type": "logs", "title": "Logs"}
+			]}
+		]
+	}`)
+	// Neither panel carries inline PanelJSON -- it must be extracted from dashboardJSON by id.
+	panels := []DashboardPanel{
+		{ID: 1, Title: "CPU Usage", HARBuffer: bufferWithEntry(t, "http://ds/1")},
+		{ID: 2, Title: "Logs", HARBuffer: bufferWithEntry(t, "http://ds/2")},
+	}
+	blob, err := NewBundler().BuildDashboard(dashboardJSON, panels)
+	require.NoError(t, err)
+
+	files := readTarGz(t, blob)
+	require.Contains(t, files, "panels/1-cpu-usage/panel.json", "top-level panel JSON resolved by id")
+	require.Contains(t, files, "panels/2-logs/panel.json", "panel nested in a collapsed row resolved by id")
+	require.Contains(t, string(files["panels/1-cpu-usage/panel.json"]), `"timeseries"`)
+	require.Contains(t, string(files["panels/2-logs/panel.json"]), `"logs"`)
+}
+
+func TestExtractPanelJSON(t *testing.T) {
+	dash := json.RawMessage(`{"panels":[{"id":1,"type":"a"},{"id":5,"type":"row","panels":[{"id":6,"type":"b"}]}]}`)
+	require.Contains(t, string(extractPanelJSON(dash, 1)), `"a"`)
+	require.Contains(t, string(extractPanelJSON(dash, 6)), `"b"`, "must find panels nested in a row")
+	require.Nil(t, extractPanelJSON(dash, 99), "unknown id -> nil")
+	require.Nil(t, extractPanelJSON(nil, 1), "empty dashboard -> nil")
+	require.Nil(t, extractPanelJSON(json.RawMessage(`not json`), 1), "malformed -> nil, not panic")
+}
+
 func TestBuildDashboard_recordsPanelQueryError(t *testing.T) {
 	panels := []DashboardPanel{
 		{ID: 7, Title: "Broken", QueryErr: errors.New("datasource exploded")},


### PR DESCRIPTION
**What is this feature?**

Ensures whole-dashboard diagnostics bundles include a `panel.json` file for every captured panel.

**Why do we need this feature?**

Without this fallback, whole-dashboard bundles contain `dashboard.json` but omit the individual `panels/<id>-<title>/panel.json` files. That removes useful panel-level context from the artifact.

**Who is this feature for?**

Grafana users and support engineers collecting whole-dashboard diagnostics.
