### PR TITLE
[PoC] Scopes: render ScopesDashboards inside the mega menu

### DIFF
--- a/public/app/core/components/AppChrome/AppChrome.tsx
+++ b/public/app/core/components/AppChrome/AppChrome.tsx
@@ -9,12 +9,11 @@ import { type GrafanaTheme2, store } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
 import { locationSearchToObject, locationService, useScopes } from '@grafana/runtime';
 import { useFlagGrafanaVisualDesignRefresh } from '@grafana/runtime/internal';
-import { ErrorBoundaryAlert, floatingUtils, getDragStyles, LinkButton, useStyles2 } from '@grafana/ui';
+import { floatingUtils, getDragStyles, LinkButton, useStyles2 } from '@grafana/ui';
 import { SplashScreenModal } from 'app/core/components/SplashScreenModal/SplashScreenModal';
 import { useGrafana } from 'app/core/context/GrafanaContext';
 import { useMediaQueryMinWidth } from 'app/core/hooks/useMediaQueryMinWidth';
 import { CommandPalette } from 'app/features/commandPalette/CommandPalette';
-import { ScopesDashboards } from 'app/features/scopes/dashboards/ScopesDashboards';
 
 import { AppChromeMenu } from './AppChromeMenu';
 import { type AppChromeService, DOCKED_LOCAL_STORAGE_KEY } from './AppChromeService';
@@ -74,9 +73,6 @@ export function AppChrome({ children }: Props) {
   }, []);
 
   const menuDockedAndOpen = !state.chromeless && state.megaMenuDocked && state.megaMenuOpen;
-  const isScopesDashboardsOpen = Boolean(
-    !state.chromeless && scopes?.state.enabled && scopes?.state.drawerOpened && !scopes?.state.readOnly
-  );
 
   const headerLevels = useChromeHeaderLevels();
   const styles = useStyles2(getStyles, headerLevels, getChromeHeaderLevelHeight(), visualRefreshEnabled);
@@ -175,21 +171,9 @@ export function AppChrome({ children }: Props) {
       )}
       <div className={contentClass}>
         <div className={cx(styles.panes, { [styles.panesWithSidebar]: isExtensionSidebarOpen })}>
-          {!state.chromeless && (
-            <div
-              className={cx(styles.scopesDashboardsContainer, {
-                [styles.scopesDashboardsContainerDocked]: menuDockedAndOpen,
-              })}
-            >
-              <ErrorBoundaryAlert boundaryName="scopes-dashboards">
-                <ScopesDashboards />
-              </ErrorBoundaryAlert>
-            </div>
-          )}
           <main
             className={cx(styles.pageContainer, {
-              [styles.pageContainerMenuDocked]: menuDockedAndOpen || isScopesDashboardsOpen,
-              [styles.pageContainerMenuDockedScopes]: menuDockedAndOpen && isScopesDashboardsOpen,
+              [styles.pageContainerMenuDocked]: menuDockedAndOpen,
               [styles.pageContainerWithSidebar]: !state.chromeless && isExtensionSidebarOpen,
               [contentSizeStyles.contentWidth]: !state.chromeless && isExtensionSidebarOpen && !isSmallScreen,
             })}
@@ -303,14 +287,6 @@ const getStyles = (theme: GrafanaTheme2, headerLevels: number, headerHeight: num
         flexDirection: 'column',
       },
     }),
-    scopesDashboardsContainer: css({
-      position: 'fixed',
-      height: `calc(100% - ${headerHeight}px)`,
-      zIndex: 1,
-    }),
-    scopesDashboardsContainerDocked: css({
-      left: MENU_WIDTH,
-    }),
     topNav: css({
       display: 'flex',
       position: 'fixed',
@@ -336,9 +312,6 @@ const getStyles = (theme: GrafanaTheme2, headerLevels: number, headerHeight: num
     }),
     pageContainerMenuDocked: css({
       paddingLeft: MENU_WIDTH,
-    }),
-    pageContainerMenuDockedScopes: css({
-      paddingLeft: `calc(${MENU_WIDTH} * 2)`,
     }),
     pageContainer: css({
       label: 'page-container',

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenu.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenu.tsx
@@ -6,9 +6,11 @@ import { memo, forwardRef, useId } from 'react';
 import { type GrafanaTheme2, type NavModelItem } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
+import { config } from '@grafana/runtime';
 import { useFlagGrafanaVisualDesignRefresh } from '@grafana/runtime/internal';
-import { Icon, ScrollContainer, Text, useStyles2 } from '@grafana/ui';
+import { ErrorBoundaryAlert, Icon, ScrollContainer, Text, useStyles2 } from '@grafana/ui';
 import { useGrafana } from 'app/core/context/GrafanaContext';
+import { ScopesDashboards } from 'app/features/scopes/dashboards/ScopesDashboards';
 import { useSyncStarredItemsInNav } from 'app/features/stars/hooks';
 
 import { MegaMenuCustomiseControls } from './MegaMenuCustomiseControls';
@@ -234,6 +236,11 @@ export const MegaMenu = memo(
           <div className={styles.scrollArea}>
             <ScrollContainer height="100%" overflowX="hidden" showScrollIndicators={!visualRefreshEnabled}>
               <>
+                {config.featureToggles.scopeFilters && (
+                  <ErrorBoundaryAlert boundaryName="megamenu-scopes-dashboards">
+                    <ScopesDashboards inline />
+                  </ErrorBoundaryAlert>
+                )}
                 {isLoading ? (
                   <ul className={styles.itemList} aria-label={navLabel} aria-busy>
                     <MegaMenuSkeleton />

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenu.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenu.tsx
@@ -236,11 +236,6 @@ export const MegaMenu = memo(
           <div className={styles.scrollArea}>
             <ScrollContainer height="100%" overflowX="hidden" showScrollIndicators={!visualRefreshEnabled}>
               <>
-                {config.featureToggles.scopeFilters && (
-                  <ErrorBoundaryAlert boundaryName="megamenu-scopes-dashboards">
-                    <ScopesDashboards inline />
-                  </ErrorBoundaryAlert>
-                )}
                 {isLoading ? (
                   <ul className={styles.itemList} aria-label={navLabel} aria-busy>
                     <MegaMenuSkeleton />
@@ -256,6 +251,11 @@ export const MegaMenu = memo(
                   </ul>
                 )}
                 <MegaMenuExtensionPoint />
+                {config.featureToggles.scopeFilters && (
+                  <ErrorBoundaryAlert boundaryName="megamenu-scopes-dashboards">
+                    <ScopesDashboards inline />
+                  </ErrorBoundaryAlert>
+                )}
               </>
             </ScrollContainer>
           </div>

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenu.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenu.tsx
@@ -6,11 +6,9 @@ import { memo, forwardRef, useId } from 'react';
 import { type GrafanaTheme2, type NavModelItem } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
-import { config } from '@grafana/runtime';
 import { useFlagGrafanaVisualDesignRefresh } from '@grafana/runtime/internal';
-import { ErrorBoundaryAlert, Icon, ScrollContainer, Text, useStyles2 } from '@grafana/ui';
+import { Icon, ScrollContainer, Text, useStyles2 } from '@grafana/ui';
 import { useGrafana } from 'app/core/context/GrafanaContext';
-import { ScopesDashboards } from 'app/features/scopes/dashboards/ScopesDashboards';
 import { useSyncStarredItemsInNav } from 'app/features/stars/hooks';
 
 import { MegaMenuCustomiseControls } from './MegaMenuCustomiseControls';
@@ -251,11 +249,6 @@ export const MegaMenu = memo(
                   </ul>
                 )}
                 <MegaMenuExtensionPoint />
-                {config.featureToggles.scopeFilters && (
-                  <ErrorBoundaryAlert boundaryName="megamenu-scopes-dashboards">
-                    <ScopesDashboards inline />
-                  </ErrorBoundaryAlert>
-                )}
               </>
             </ScrollContainer>
           </div>

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenuItem.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenuItem.tsx
@@ -8,9 +8,11 @@ import { useLocalStorage } from 'react-use';
 
 import { FeatureState, type GrafanaTheme2, type NavModelItem, toIconName } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { useStyles2, Text, IconButton, Icon, Stack, FeatureBadge, Box } from '@grafana/ui';
+import { config } from '@grafana/runtime';
+import { useStyles2, Text, IconButton, Icon, Stack, FeatureBadge, Box, ErrorBoundaryAlert } from '@grafana/ui';
 import { useGrafana } from 'app/core/context/GrafanaContext';
 import { ID_PREFIX } from 'app/core/reducers/navBarTree';
+import { ScopesDashboards } from 'app/features/scopes/dashboards/ScopesDashboards';
 
 import { Indent } from '../../Indent/Indent';
 
@@ -256,6 +258,11 @@ export function MegaMenuItem({
           )}
         </div>
       </div>
+      {childrenVisible && link.id === 'dashboards/browse' && config.featureToggles.scopeFilters && (
+        <ErrorBoundaryAlert boundaryName="megamenu-scopes-dashboards">
+          <ScopesDashboards inline />
+        </ErrorBoundaryAlert>
+      )}
       {childrenVisible && (
         <ul className={styles.children}>
           {linkHasChildren(link) ? (

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenuItem.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenuItem.tsx
@@ -258,11 +258,6 @@ export function MegaMenuItem({
           )}
         </div>
       </div>
-      {childrenVisible && link.id === 'dashboards/browse' && config.featureToggles.scopeFilters && (
-        <ErrorBoundaryAlert boundaryName="megamenu-scopes-dashboards">
-          <ScopesDashboards inline />
-        </ErrorBoundaryAlert>
-      )}
       {childrenVisible && (
         <ul className={styles.children}>
           {linkHasChildren(link) ? (
@@ -313,6 +308,11 @@ export function MegaMenuItem({
             </div>
           )}
         </ul>
+      )}
+      {childrenVisible && link.id === 'dashboards/browse' && config.featureToggles.scopeFilters && (
+        <ErrorBoundaryAlert boundaryName="megamenu-scopes-dashboards">
+          <ScopesDashboards inline />
+        </ErrorBoundaryAlert>
       )}
     </li>
   );

--- a/public/app/features/dashboard-scene/scene/DashboardControls.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardControls.tsx
@@ -26,7 +26,6 @@ import { Box, Button, ButtonGroup, useStyles2 } from '@grafana/ui';
 import { useGrafana } from 'app/core/context/GrafanaContext';
 import { contextSrv } from 'app/core/services/context_srv';
 import { playlistSrv } from 'app/features/playlist/PlaylistSrv';
-import { ContextualNavigationPaneToggle } from 'app/features/scopes/dashboards/ContextualNavigationPaneToggle';
 import { KioskMode } from 'app/types/dashboard';
 
 import { PanelEditControls } from '../panel-edit/PanelEditControls';
@@ -284,9 +283,6 @@ function DashboardControlsRenderer({ model }: SceneComponentProps<DashboardContr
           </div>
         )}
       </div>
-      {config.featureToggles.scopeFilters && !editPanel && (
-        <ContextualNavigationPaneToggle className={styles.contextualNavToggle} hideWhenOpen={true} />
-      )}
       {!hideVariableControls && (
         <>
           <VariableControls dashboard={dashboard} variablesOverride={panelEditVariables} />
@@ -486,10 +482,6 @@ function getStyles(theme: GrafanaTheme2, isQueryEditorNext: boolean) {
     rightControlsWrap: css({
       flexWrap: 'wrap',
       marginLeft: 'auto',
-    }),
-    contextualNavToggle: css({
-      display: 'inline-flex',
-      margin: theme.spacing(0, 1, 1, 0),
     }),
   };
 }

--- a/public/app/features/scopes/dashboards/ScopesDashboards.tsx
+++ b/public/app/features/scopes/dashboards/ScopesDashboards.tsx
@@ -5,15 +5,19 @@ import { type GrafanaTheme2 } from '@grafana/data';
 import { useObservable } from '@grafana/data/unstable';
 import { Trans, t } from '@grafana/i18n';
 import { useScopes } from '@grafana/runtime';
-import { Button, LoadingPlaceholder, ScrollContainer, useStyles2 } from '@grafana/ui';
+import { Button, Divider, LoadingPlaceholder, ScrollContainer, useStyles2 } from '@grafana/ui';
 
 import { useScopesServices } from '../ScopesContextProvider';
 
 import { ScopesDashboardsTree } from './ScopesDashboardsTree';
 import { ScopesDashboardsTreeSearch } from './ScopesDashboardsTreeSearch';
 
-export function ScopesDashboards() {
-  const styles = useStyles2(getStyles);
+interface ScopesDashboardsProps {
+  inline?: boolean;
+}
+
+export function ScopesDashboards({ inline = false }: ScopesDashboardsProps = {}) {
+  const styles = useStyles2(getStyles, inline);
   const scopes = useScopes();
   const scopeServices = useScopesServices();
 
@@ -22,7 +26,11 @@ export function ScopesDashboards() {
     scopeServices?.scopesDashboardsService.state
   );
 
-  if (!scopeServices || !scopes || !scopes.state.enabled || !scopes.state.drawerOpened || scopes.state.readOnly) {
+  if (!scopeServices || !scopes || !scopes.state.enabled || scopes.state.readOnly) {
+    return null;
+  }
+
+  if (!inline && !scopes.state.drawerOpened) {
     return null;
   }
 
@@ -33,6 +41,9 @@ export function ScopesDashboards() {
 
   if (!loading) {
     if (forScopeNames.length === 0) {
+      if (inline) {
+        return null;
+      }
       return (
         <div className={styles.container} data-testid="scopes-dashboards-container">
           <ScopesDashboardsTreeSearch disabled={loading} query={searchQuery} onChange={changeSearchQuery} />
@@ -44,65 +55,71 @@ export function ScopesDashboards() {
       );
     } else if (dashboards.length === 0 && scopeNavigations.length === 0) {
       return (
-        <div className={styles.container} data-testid="scopes-dashboards-container">
-          <div className={styles.noResultsContainer} data-testid="scopes-dashboards-notFoundForScope">
-            <Trans i18nKey="scopes.dashboards.noResultsForScopes">
-              No dashboards or links found for the selected scopes
-            </Trans>
+        <>
+          <div className={styles.container} data-testid="scopes-dashboards-container">
+            <div className={styles.noResultsContainer} data-testid="scopes-dashboards-notFoundForScope">
+              <Trans i18nKey="scopes.dashboards.noResultsForScopes">
+                No dashboards or links found for the selected scopes
+              </Trans>
+            </div>
           </div>
-        </div>
+          {inline && <Divider spacing={1} />}
+        </>
       );
     }
   }
 
   return (
-    <div className={styles.container} data-testid="scopes-dashboards-container">
-      <ScopesDashboardsTreeSearch disabled={loading} query={searchQuery} onChange={changeSearchQuery} />
+    <>
+      <div className={styles.container} data-testid="scopes-dashboards-container">
+        <ScopesDashboardsTreeSearch disabled={loading} query={searchQuery} onChange={changeSearchQuery} />
 
-      {loading ? (
-        <LoadingPlaceholder
-          className={styles.loadingIndicator}
-          text={t('scopes.dashboards.loading', 'Loading dashboards')}
-          data-testid="scopes-dashboards-loading"
-        />
-      ) : filteredFolders[''] ? (
-        <ScrollContainer>
-          <ScopesDashboardsTree
-            folders={filteredFolders}
-            folderPath={['']}
-            subScopePath={[]}
-            onFolderUpdate={updateFolder}
+        {loading ? (
+          <LoadingPlaceholder
+            className={styles.loadingIndicator}
+            text={t('scopes.dashboards.loading', 'Loading dashboards')}
+            data-testid="scopes-dashboards-loading"
           />
-        </ScrollContainer>
-      ) : (
-        <p className={styles.noResultsContainer} data-testid="scopes-dashboards-notFoundForFilter">
-          <Trans i18nKey="scopes.dashboards.noResultsForFilter">No results found for your query</Trans>
+        ) : filteredFolders[''] ? (
+          <ScrollContainer>
+            <ScopesDashboardsTree
+              folders={filteredFolders}
+              folderPath={['']}
+              subScopePath={[]}
+              onFolderUpdate={updateFolder}
+            />
+          </ScrollContainer>
+        ) : (
+          <p className={styles.noResultsContainer} data-testid="scopes-dashboards-notFoundForFilter">
+            <Trans i18nKey="scopes.dashboards.noResultsForFilter">No results found for your query</Trans>
 
-          <Button
-            variant="secondary"
-            onClick={clearSearchQuery}
-            data-testid="scopes-dashboards-notFoundForFilter-clear"
-          >
-            <Trans i18nKey="scopes.dashboards.noResultsForFilterClear">Clear search</Trans>
-          </Button>
-        </p>
-      )}
-    </div>
+            <Button
+              variant="secondary"
+              onClick={clearSearchQuery}
+              data-testid="scopes-dashboards-notFoundForFilter-clear"
+            >
+              <Trans i18nKey="scopes.dashboards.noResultsForFilterClear">Clear search</Trans>
+            </Button>
+          </p>
+        )}
+      </div>
+      {inline && <Divider spacing={1} />}
+    </>
   );
 }
 
-const getStyles = (theme: GrafanaTheme2) => {
+const getStyles = (theme: GrafanaTheme2, inline: boolean) => {
   return {
     container: css({
-      backgroundColor: theme.colors.background.canvas,
-      borderRight: `1px solid ${theme.colors.border.weak}`,
+      backgroundColor: inline ? 'transparent' : theme.colors.background.canvas,
+      borderRight: inline ? undefined : `1px solid ${theme.colors.border.weak}`,
       display: 'flex',
       flexDirection: 'column',
-      height: '100%',
+      height: inline ? undefined : '100%',
       gap: theme.spacing(1),
-      padding: theme.spacing(0, 2),
-      margin: theme.spacing(2, 0),
-      width: theme.spacing(37.5),
+      padding: inline ? theme.spacing(0, 1) : theme.spacing(0, 2),
+      margin: inline ? theme.spacing(1, 0) : theme.spacing(2, 0),
+      width: inline ? undefined : theme.spacing(37.5),
     }),
     noResultsContainer: css({
       alignItems: 'center',

--- a/public/app/features/scopes/dashboards/ScopesDashboards.tsx
+++ b/public/app/features/scopes/dashboards/ScopesDashboards.tsx
@@ -56,7 +56,6 @@ export function ScopesDashboards({ inline = false }: ScopesDashboardsProps = {})
     } else if (dashboards.length === 0 && scopeNavigations.length === 0) {
       return (
         <>
-          {inline && <Divider spacing={1} />}
           <div className={styles.container} data-testid="scopes-dashboards-container">
             <div className={styles.noResultsContainer} data-testid="scopes-dashboards-notFoundForScope">
               <Trans i18nKey="scopes.dashboards.noResultsForScopes">
@@ -64,6 +63,7 @@ export function ScopesDashboards({ inline = false }: ScopesDashboardsProps = {})
               </Trans>
             </div>
           </div>
+          {inline && <Divider spacing={1} />}
         </>
       );
     }
@@ -71,7 +71,6 @@ export function ScopesDashboards({ inline = false }: ScopesDashboardsProps = {})
 
   return (
     <>
-      {inline && <Divider spacing={1} />}
       <div className={styles.container} data-testid="scopes-dashboards-container">
         <ScopesDashboardsTreeSearch disabled={loading} query={searchQuery} onChange={changeSearchQuery} />
 
@@ -104,6 +103,7 @@ export function ScopesDashboards({ inline = false }: ScopesDashboardsProps = {})
           </p>
         )}
       </div>
+      {inline && <Divider spacing={1} />}
     </>
   );
 }

--- a/public/app/features/scopes/dashboards/ScopesDashboards.tsx
+++ b/public/app/features/scopes/dashboards/ScopesDashboards.tsx
@@ -56,6 +56,7 @@ export function ScopesDashboards({ inline = false }: ScopesDashboardsProps = {})
     } else if (dashboards.length === 0 && scopeNavigations.length === 0) {
       return (
         <>
+          {inline && <Divider spacing={1} />}
           <div className={styles.container} data-testid="scopes-dashboards-container">
             <div className={styles.noResultsContainer} data-testid="scopes-dashboards-notFoundForScope">
               <Trans i18nKey="scopes.dashboards.noResultsForScopes">
@@ -63,7 +64,6 @@ export function ScopesDashboards({ inline = false }: ScopesDashboardsProps = {})
               </Trans>
             </div>
           </div>
-          {inline && <Divider spacing={1} />}
         </>
       );
     }
@@ -71,6 +71,7 @@ export function ScopesDashboards({ inline = false }: ScopesDashboardsProps = {})
 
   return (
     <>
+      {inline && <Divider spacing={1} />}
       <div className={styles.container} data-testid="scopes-dashboards-container">
         <ScopesDashboardsTreeSearch disabled={loading} query={searchQuery} onChange={changeSearchQuery} />
 
@@ -103,7 +104,6 @@ export function ScopesDashboards({ inline = false }: ScopesDashboardsProps = {})
           </p>
         )}
       </div>
-      {inline && <Divider spacing={1} />}
     </>
   );
 }

--- a/public/app/features/scopes/dashboards/ScopesDashboardsTreeSearch.tsx
+++ b/public/app/features/scopes/dashboards/ScopesDashboardsTreeSearch.tsx
@@ -6,8 +6,6 @@ import { type GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { FilterInput, useStyles2 } from '@grafana/ui';
 
-import { ContextualNavigationPaneToggle } from './ContextualNavigationPaneToggle';
-
 export interface ScopesDashboardsTreeSearchProps {
   disabled: boolean;
   query: string;
@@ -44,7 +42,6 @@ export function ScopesDashboardsTreeSearch({ disabled, query, onChange }: Scopes
         data-testid="scopes-dashboards-search"
         onChange={(value) => setInputState({ value, dirty: true })}
       />
-      <ContextualNavigationPaneToggle />
     </div>
   );
 }


### PR DESCRIPTION
Draft PoC — not for merge.

Related: https://github.com/grafana/hyperion-planning/issues/694

## What

Explores placing `ScopesDashboards` directly inside the mega menu instead of the separate docked drawer next to it. Adds an `inline` prop to `ScopesDashboards` that:

- Bypasses the `drawerOpened` gate (always renders when a scope is selected).
- Returns `null` when no scope is selected (no empty "No scopes selected" state in the menu).
- Drops the fixed 37.5rem width / border / margin so it fits in the 320px mega menu.
- Renders a `<Divider />` alongside itself for visual separation.

Also removes the docked-drawer container from `AppChrome` and the `ContextualNavigationPaneToggle` icon (the drawer no longer exists).

## Placement variants

Each variant is a separate commit on top of the base so it's easy to switch with \`git reset --hard <sha>\`:

1. \`Scopes: PoC base — inline mode for ScopesDashboards\` — shared setup, no placement.
2. \`Scopes PoC: placement — top of mega menu\` — above pinned/nav sections.
3. \`Scopes PoC: placement — bottom of mega menu\` — after the plugin extension point.
4. \`Scopes PoC: placement — top of Dashboards nav section\` — inside \`MegaMenuItem\`'s expanded body, above the section's sub-items.
5. \`Scopes PoC: placement — bottom of Dashboards nav section\` — same, but below the sub-items.

Current HEAD is variant 5. To try another: \`git reset --hard <sha>\`.

## How to test

1. Enable \`scopeFilters\` feature toggle.
2. Open the mega menu, select a scope.
3. Confirm the dashboards tree appears in the position matching the current commit.
4. Clear the scope — the section disappears.