### PR TITLE
Provisioning: Link folder metadata and deleted files in PR comments

### DIFF
--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/changes.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/changes.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	dashboard "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1"
+	folder "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
 	"github.com/grafana/grafana/pkg/cmd/grafana-cli/logger"
@@ -154,6 +155,36 @@ func (e *evaluator) Evaluate(ctx context.Context, repo repository.Reader, opts p
 }
 
 var dashboardKind = dashboard.DashboardResourceInfo.GroupVersionKind().Kind
+var folderKind = folder.FolderResourceInfo.GroupVersionKind().Kind
+
+// grafanaResourceURL builds the Grafana UI link for a provisioned resource that
+// already exists in Grafana. Dashboards live at /d/<uid>/<slug>; folders at
+// /dashboards/f/<uid>/<slug>. Returns "" for kinds without a known view route
+// (so the Resource column falls back to plain text) or when the base URL cannot
+// be parsed.
+func grafanaResourceURL(baseURL, kind, name, title string, orgID int64) string {
+	var pathParts []string
+	switch kind {
+	case dashboardKind:
+		pathParts = []string{"d", name, slugify.Slugify(title)}
+	case folderKind:
+		pathParts = []string{"dashboards", "f", name, slugify.Slugify(title)}
+	default:
+		return ""
+	}
+
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return ""
+	}
+	u = u.JoinPath(pathParts...)
+	if orgID > 0 {
+		query := url.Values{}
+		query.Set("orgId", strconv.FormatInt(orgID, 10))
+		u.RawQuery = query.Encode()
+	}
+	return u.String()
+}
 
 // stripUserinfo removes any embedded credentials (userinfo) from a URL so a
 // repository configured with an HTTPS URL like https://user:token@host/org/repo
@@ -256,7 +287,14 @@ func (e *evaluator) evaluateFile(ctx context.Context, repo repository.Reader, ba
 		info.Error = err.Error()
 	}
 
-	// Dashboards get special handling
+	// Link back to the resource in Grafana when it already exists there.
+	// Dashboards and folders both have view routes; other kinds fall back to
+	// plain text in the comment.
+	if info.Parsed.Existing != nil {
+		info.GrafanaURL = grafanaResourceURL(baseURL, info.Parsed.GVK.Kind, obj.GetName(), info.Title, orgID)
+	}
+
+	// Dashboards additionally get a preview link and (optionally) screenshots.
 	if info.Parsed.GVK.Kind == dashboardKind {
 		// FIXME: extract the logic out of a dashboard URL builder/injector or similar
 		// for testability and decoupling
@@ -265,16 +303,6 @@ func (e *evaluator) evaluateFile(ctx context.Context, repo repository.Reader, ba
 			logger.Warn("Error parsing baseURL", "err", err)
 			info.Error = err.Error()
 			return info
-		}
-
-		if info.Parsed.Existing != nil {
-			grafanaURL := urlBuilder.JoinPath("d", obj.GetName(), slugify.Slugify(info.Title))
-			if orgID > 0 {
-				query := url.Values{}
-				query.Set("orgId", strconv.FormatInt(orgID, 10))
-				grafanaURL.RawQuery = query.Encode()
-			}
-			info.GrafanaURL = grafanaURL.String()
 		}
 
 		// Load this file directly
@@ -320,6 +348,16 @@ func (e *evaluator) evaluateDeletedFile(ctx context.Context, repo repository.Rea
 		return info
 	}
 
+	// Best-effort link back to the file in the git repository. The file no
+	// longer exists on the PR branch, so this points at the previous ref where
+	// it still exists, letting reviewers see what was removed. Repositories that
+	// don't expose web URLs (e.g. non-GitHub backends) leave this empty.
+	if urlsRepo, ok := repo.(repository.RepositoryWithURLs); ok {
+		if urls, urlErr := urlsRepo.ResourceURLs(ctx, fileInfo); urlErr == nil && urls != nil {
+			info.SourceURL = stripUserinfo(urls.SourceURL)
+		}
+	}
+
 	info.Parsed, err = parser.Parse(ctx, fileInfo)
 	if err != nil {
 		return info
@@ -328,20 +366,10 @@ func (e *evaluator) evaluateDeletedFile(ctx context.Context, repo repository.Rea
 	obj := info.Parsed.Obj
 	info.Title = info.Parsed.Meta.FindTitle(obj.GetName())
 
-	if info.Parsed.GVK.Kind == dashboardKind {
-		urlBuilder, err := url.Parse(baseURL)
-		if err != nil {
-			return info
-		}
-		if info.Parsed.Existing != nil {
-			grafanaURL := urlBuilder.JoinPath("d", obj.GetName(), slugify.Slugify(info.Title))
-			if orgID > 0 {
-				query := url.Values{}
-				query.Set("orgId", strconv.FormatInt(orgID, 10))
-				grafanaURL.RawQuery = query.Encode()
-			}
-			info.GrafanaURL = grafanaURL.String()
-		}
+	// Link back to the resource in Grafana when it still exists there (dashboards
+	// and folders both have view routes); other kinds fall back to plain text.
+	if info.Parsed.Existing != nil {
+		info.GrafanaURL = grafanaResourceURL(baseURL, info.Parsed.GVK.Kind, obj.GetName(), info.Title, orgID)
 	}
 
 	return info

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/changes.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/changes.go
@@ -10,12 +10,14 @@ import (
 
 	authlib "github.com/grafana/authlib/types"
 	"github.com/grafana/grafana-app-sdk/logging"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	dashboard "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1"
 	folder "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/cmd/grafana-cli/logger"
 	"github.com/grafana/grafana/pkg/infra/slugify"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/jobs"
@@ -365,6 +367,19 @@ func (e *evaluator) evaluateDeletedFile(ctx context.Context, repo repository.Rea
 
 	obj := info.Parsed.Obj
 	info.Title = info.Parsed.Meta.FindTitle(obj.GetName())
+
+	// Parse only fills Parsed.Existing during DryRun/Run (via a live Get), and
+	// deletions run neither. Fetch the live object directly so we can link back
+	// to it in Grafana: at comment time the resource still exists because the
+	// sync that removes it has not run yet. Best-effort — a missing object or a
+	// permission error just leaves the Resource column as plain text.
+	if info.Parsed.Client != nil {
+		if idCtx, _, idErr := identity.WithProvisioningIdentity(ctx, obj.GetNamespace()); idErr == nil {
+			if existing, getErr := info.Parsed.Client.Get(idCtx, obj.GetName(), metav1.GetOptions{}); getErr == nil {
+				info.Parsed.Existing = existing
+			}
+		}
+	}
 
 	// Link back to the resource in Grafana when it still exists there (dashboards
 	// and folders both have view routes); other kinds fall back to plain text.

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/changes_test.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/changes_test.go
@@ -13,7 +13,9 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
 
 	folder "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
@@ -1663,7 +1665,9 @@ func TestEvaluate_FolderGetsGrafanaAndSourceURL(t *testing.T) {
 
 // A deleted file (e.g. a removed folder metadata file) no longer exists on the
 // PR branch, but the source link should still point at the previous ref so
-// reviewers can see what was removed.
+// reviewers can see what was removed. The folder still exists in Grafana until
+// the sync runs, so the Resource column should link to it — which requires
+// fetching the live object, since Parse (unlike DryRun) never sets Existing.
 func TestEvaluate_DeletedFilePopulatesSourceURL(t *testing.T) {
 	finfo := &repository.FileInfo{
 		Path: "team/_folder.json",
@@ -1674,11 +1678,20 @@ func TestEvaluate_DeletedFilePopulatesSourceURL(t *testing.T) {
 		Object: map[string]interface{}{
 			"apiVersion": folder.FolderResourceInfo.GroupVersion().String(),
 			"kind":       folderKind,
-			"metadata":   map[string]interface{}{"name": "the-uid"},
+			"metadata":   map[string]interface{}{"name": "the-uid", "namespace": "x"},
 			"spec":       map[string]interface{}{"title": "My Team"},
 		},
 	}
 	meta, _ := utils.MetaAccessor(obj)
+
+	// A fake client that returns the live folder object, standing in for the
+	// resource that still exists in Grafana at comment time.
+	folderGVR := schema.GroupVersionResource{Group: folder.GROUP, Version: folder.VERSION, Resource: "folders"}
+	scheme := runtime.NewScheme()
+	require.NoError(t, metav1.AddMetaToScheme(scheme))
+	fakeDynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, map[schema.GroupVersionResource]string{
+		folderGVR: "FolderList",
+	}, obj)
 
 	reader := repository.NewMockReader(t)
 	reader.On("Config").Return(&provisioning.Repository{
@@ -1691,13 +1704,15 @@ func TestEvaluate_DeletedFilePopulatesSourceURL(t *testing.T) {
 	reader.On("Read", mock.Anything, "team/_folder.json", "base-ref").Return(finfo, nil)
 
 	parser := resources.NewMockParser(t)
+	// Existing is intentionally nil: the real parser only populates it during
+	// DryRun/Run, which deletions skip. The evaluator must fetch it via Client.
 	parser.On("Parse", mock.Anything, finfo).Return(&resources.ParsedResource{
-		Info:     finfo,
-		Repo:     provisioning.ResourceRepositoryInfo{Namespace: "x", Name: "y"},
-		GVK:      schema.GroupVersionKind{Kind: folderKind},
-		Obj:      obj,
-		Existing: obj,
-		Meta:     meta,
+		Info:   finfo,
+		Repo:   provisioning.ResourceRepositoryInfo{Namespace: "x", Name: "y"},
+		GVK:    schema.GroupVersionKind{Kind: folderKind},
+		Obj:    obj,
+		Client: fakeDynamicClient.Resource(folderGVR).Namespace("x"),
+		Meta:   meta,
 	}, nil)
 
 	parserFactory := resources.NewMockParserFactory(t)

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/changes_test.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/changes_test.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	folder "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
@@ -1583,6 +1584,152 @@ func TestEvaluate_StripsCredentialsFromURLs(t *testing.T) {
 	require.Len(t, info.Changes, 1)
 	require.Equal(t, "https://github.com/example/repo/blob/ref/path/to/file.json", info.Changes[0].SourceURL)
 	require.NotContains(t, info.Changes[0].SourceURL, "token")
+}
+
+// A folder (_folder.json) that already exists in Grafana should link back to
+// its folder view, just like a dashboard links to /d/..., and its file should
+// render as a source link.
+func TestEvaluate_FolderGetsGrafanaAndSourceURL(t *testing.T) {
+	finfo := &repository.FileInfo{
+		Path: "team/_folder.json",
+		Ref:  "ref",
+		Data: []byte("xxxx"),
+	}
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": folder.FolderResourceInfo.GroupVersion().String(),
+			"kind":       folderKind,
+			"metadata":   map[string]interface{}{"name": "the-uid"},
+			"spec":       map[string]interface{}{"title": "My Team"},
+		},
+	}
+	meta, _ := utils.MetaAccessor(obj)
+
+	reader := repository.NewMockReader(t)
+	reader.On("Config").Return(&provisioning.Repository{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-repo", Namespace: "x"},
+		Spec: provisioning.RepositorySpec{
+			Type:   provisioning.GitHubRepositoryType,
+			GitHub: &provisioning.GitHubRepositoryConfig{URL: "https://github.com/example/repo"},
+		},
+	})
+	reader.On("Read", mock.Anything, "team/_folder.json", "ref").Return(finfo, nil)
+	// Updated files read the base branch to detect stripped metadata; not found is fine.
+	reader.On("Read", mock.Anything, "team/_folder.json", "").Maybe().Return(nil, repository.ErrFileNotFound)
+
+	parser := resources.NewMockParser(t)
+	parser.On("Parse", mock.Anything, finfo).Return(&resources.ParsedResource{
+		Info:           finfo,
+		Repo:           provisioning.ResourceRepositoryInfo{Namespace: "x", Name: "y"},
+		GVK:            schema.GroupVersionKind{Kind: folderKind},
+		Obj:            obj,
+		Existing:       obj,
+		Meta:           meta,
+		DryRunResponse: obj,
+	}, nil)
+
+	parserFactory := resources.NewMockParserFactory(t)
+	parserFactory.On("GetParser", mock.Anything, mock.Anything).Return(parser, nil)
+
+	renderer := NewMockScreenshotRenderer(t)
+	renderer.On("IsAvailable", mock.Anything).Return(false)
+
+	progress := jobs.NewMockJobProgressRecorder(t)
+	progress.On("SetMessage", mock.Anything, "process team/_folder.json").Return()
+
+	evaluator := NewEvaluator(renderer, parserFactory, URLProvider{
+		Internal: func(_ context.Context, _ string) string { return "http://host/" },
+		Public:   func(_ context.Context, _ string) string { return "http://host/" },
+	}, prometheus.NewPedanticRegistry())
+
+	repo := &readerWithURLs{
+		MockReader: reader,
+		sourceURL:  "https://github.com/example/repo/blob/ref/team/_folder.json",
+	}
+
+	info, err := evaluator.Evaluate(context.Background(), repo, provisioning.PullRequestJobOptions{Ref: "ref"}, []repository.VersionedFileChange{{
+		Action: repository.FileActionUpdated,
+		Path:   "team/_folder.json",
+		Ref:    "ref",
+	}}, progress)
+
+	require.NoError(t, err)
+	require.Len(t, info.Changes, 1)
+	require.Equal(t, "http://host/dashboards/f/the-uid/my-team", info.Changes[0].GrafanaURL)
+	require.Equal(t, "https://github.com/example/repo/blob/ref/team/_folder.json", info.Changes[0].SourceURL)
+	// Dashboard-only surfaces stay empty for folders.
+	require.Empty(t, info.Changes[0].PreviewURL)
+}
+
+// A deleted file (e.g. a removed folder metadata file) no longer exists on the
+// PR branch, but the source link should still point at the previous ref so
+// reviewers can see what was removed.
+func TestEvaluate_DeletedFilePopulatesSourceURL(t *testing.T) {
+	finfo := &repository.FileInfo{
+		Path: "team/_folder.json",
+		Ref:  "base-ref",
+		Data: []byte("xxxx"),
+	}
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": folder.FolderResourceInfo.GroupVersion().String(),
+			"kind":       folderKind,
+			"metadata":   map[string]interface{}{"name": "the-uid"},
+			"spec":       map[string]interface{}{"title": "My Team"},
+		},
+	}
+	meta, _ := utils.MetaAccessor(obj)
+
+	reader := repository.NewMockReader(t)
+	reader.On("Config").Return(&provisioning.Repository{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-repo", Namespace: "x"},
+		Spec: provisioning.RepositorySpec{
+			Type:   provisioning.GitHubRepositoryType,
+			GitHub: &provisioning.GitHubRepositoryConfig{URL: "https://github.com/example/repo"},
+		},
+	})
+	reader.On("Read", mock.Anything, "team/_folder.json", "base-ref").Return(finfo, nil)
+
+	parser := resources.NewMockParser(t)
+	parser.On("Parse", mock.Anything, finfo).Return(&resources.ParsedResource{
+		Info:     finfo,
+		Repo:     provisioning.ResourceRepositoryInfo{Namespace: "x", Name: "y"},
+		GVK:      schema.GroupVersionKind{Kind: folderKind},
+		Obj:      obj,
+		Existing: obj,
+		Meta:     meta,
+	}, nil)
+
+	parserFactory := resources.NewMockParserFactory(t)
+	parserFactory.On("GetParser", mock.Anything, mock.Anything).Return(parser, nil)
+
+	renderer := NewMockScreenshotRenderer(t)
+	renderer.On("IsAvailable", mock.Anything).Return(false)
+
+	progress := jobs.NewMockJobProgressRecorder(t)
+	progress.On("SetMessage", mock.Anything, "process team/_folder.json").Return()
+
+	evaluator := NewEvaluator(renderer, parserFactory, URLProvider{
+		Internal: func(_ context.Context, _ string) string { return "http://host/" },
+		Public:   func(_ context.Context, _ string) string { return "http://host/" },
+	}, prometheus.NewPedanticRegistry())
+
+	repo := &readerWithURLs{
+		MockReader: reader,
+		sourceURL:  "https://github.com/example/repo/blob/base-ref/team/_folder.json",
+	}
+
+	info, err := evaluator.Evaluate(context.Background(), repo, provisioning.PullRequestJobOptions{}, []repository.VersionedFileChange{{
+		Action:      repository.FileActionDeleted,
+		Path:        "team/_folder.json",
+		Ref:         "ref",
+		PreviousRef: "base-ref",
+	}}, progress)
+
+	require.NoError(t, err)
+	require.Len(t, info.Changes, 1)
+	require.Equal(t, "https://github.com/example/repo/blob/base-ref/team/_folder.json", info.Changes[0].SourceURL)
+	require.Equal(t, "http://host/dashboards/f/the-uid/my-team", info.Changes[0].GrafanaURL)
 }
 
 func TestEvaluate_GitHubEnterpriseDoesNotPanic(t *testing.T) {


### PR DESCRIPTION
## What

Fixes two gaps in the Git Sync pull request comment table for folder metadata (`_folder.json`) files:

- **Deleted files now render a `[source]` link** in the File column instead of the raw file path. This includes removed `_folder.json` files.
- **Folders now link back to Grafana** in the Resource column, the same way dashboards already do.

## Why

In the PR comment table, a deleted folder metadata file showed its path as plain text (no link), and folder rows never linked to the folder in Grafana — only dashboards did. Reviewers had no quick way to see what was removed or to open the affected folder.

<img width="1233" height="751" alt="Screenshot 2026-07-21 at 09 45 19" src="https://github.com/user-attachments/assets/3e432f7a-8591-404f-ba45-d1057f732152" />



## How

All changes are in `pkg/registry/apis/provisioning/webhooks/pullrequest/changes.go`:

- `evaluateDeletedFile` now computes `SourceURL` via `ResourceURLs`, using the file read at the **previous ref** (where the file still exists), so the `[source]` link points at the pre-deletion version. Non-GitHub backends that don't expose web URLs still fall back to plain text.
- Extracted a shared `grafanaResourceURL` helper that routes the Grafana view link by kind:
  - Dashboard → `/d/<uid>/<slug>` (unchanged behavior)
  - Folder → `/dashboards/f/<uid>/<slug>` (new)
- Applied in both `evaluateFile` and `evaluateDeletedFile`, gated on `Existing != nil` and `orgId`-aware, matching the previous dashboard logic. Dashboard-only preview/screenshot handling is unchanged.

The comment template (`comment.go`) already renders `[source](...)` whenever `SourceURL` is set, so no template change was needed.

## Testing

- Added `TestEvaluate_FolderGetsGrafanaAndSourceURL` — an updated folder produces the Grafana folder link and a source link, and leaves dashboard-only preview surfaces empty.
- Added `TestEvaluate_DeletedFilePopulatesSourceURL` — a deleted folder metadata file produces a source link pointing at the previous ref plus the Grafana folder link.
- Full package tests pass; `go vet` and `gofmt` clean.

## Checklist
- [x] Tests added/updated
- [ ] Documentation updated (n/a — no user-facing docs impact)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)