### PR TITLE
Display console logs in tests

### DIFF
--- a/public/test/setupTests.ts
+++ b/public/test/setupTests.ts
@@ -19,6 +19,8 @@ if (config.frontend_dev_fail_tests_on_console || process.env.CI) {
     shouldFailOnLog: true,
     shouldFailOnDebug: true,
     shouldFailOnInfo: true,
+    // Print the message for debug. Still fails the tests.
+    shouldPrintMessage: true,
   });
 }
 


### PR DESCRIPTION
By failing tests on console log, we seem to also just hide the message altogether. This means any type of console.log debugging is impossible, which even though a last resort is sometimes still inevitable.