### PR TITLE
PanelChrome: Account for header bottom padding in content height

### DIFF
--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.test.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.test.tsx
@@ -67,6 +67,15 @@ it('renders an empty panel without padding', () => {
   expect(screen.getByText("Panel's Content").parentElement).toHaveStyle({ padding: '0px 0px 0px 0px' });
 });
 
+it('reserves space for the header bottom padding when there is no subheader', () => {
+  setup({ title: 'A' });
+
+  // The header has an 8px bottom padding when no subheader is present; the content height must
+  // account for it so the panel content does not overrun the chrome's bottom padding.
+  // innerHeight = height(100) - headerHeight(40 + 8) - panelPadding(16) - border(2) + topPadding(8) = 42
+  expect(screen.getByText("Panel's Content")).toHaveStyle({ height: '42px' });
+});
+
 it('renders an empty panel with padding', () => {
   setup({ padding: 'md' });
 

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -498,8 +498,12 @@ const itemsRenderer = (items: ReactNode[] | ReactNode, renderer: (items: ReactNo
 
 const getHeaderHeight = (theme: GrafanaTheme2, hasHeader: boolean, subHeaderHeight: number) => {
   if (hasHeader) {
-    // To reduce spacing between subHeader and content, we remove some height from the header when subHeader is present.
-    return theme.spacing.gridSize * theme.components.panel.headerHeight + subHeaderHeight;
+    // When there is no subHeader, the header has a bottom padding of one gridSize (see headerStyles);
+    // account for it here so the content height doesn't overrun the chrome's bottom padding.
+    return (
+      theme.spacing.gridSize * theme.components.panel.headerHeight +
+      (subHeaderHeight > 0 ? subHeaderHeight : theme.spacing.gridSize)
+    );
   }
 
   return 0;


### PR DESCRIPTION
## What

`getHeaderHeight` now accounts for the header's own bottom padding when no subheader is present.

## Why

[#128380](https://github.com/grafana/grafana/pull/128380) added an 8px (one gridSize) bottom padding to the panel header for the no-subheader case:

```ts
paddingBottom: subHeaderHeight ? 0 : theme.spacing.gridSize
```

…but `getHeaderHeight` was not updated to reserve that space. As a result the content height (`innerHeight`) was 8px too tall and overran the chrome's bottom padding. This affects **every paneled visualization with a title and no subheader** — timeseries, barchart, heatmap, etc.

## Fix

```ts
return (
  theme.spacing.gridSize * theme.components.panel.headerHeight +
  (subHeaderHeight > 0 ? subHeaderHeight : theme.spacing.gridSize)
);
```

- No-subheader case: reserves the 8px header padding → content no longer overruns.
- Subheader case: unchanged (still adds measured `subHeaderHeight`).

Also replaced a stale comment that described the pre-#128380 behavior.

## Tests

Added a regression test asserting the content height reserves the header padding when there is no subheader (`42px` at height 100, was `50px`). All PanelChrome tests pass.

## Notes

There is a related layout-shift issue (header height depends on the async-measured `subHeaderHeight`) with the same #128380 root cause — not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)