### PR TITLE
Chore: Use `lokiGrammar` from @grafana/lezer-logql package

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -21,6 +21,7 @@ npmPreapprovedPackages:
   - "@grafana/plugin-e2e"
   - "@grafana/plugin-ui"
   - "@grafana/llm"
+  - "@grafana/lezer-logql"
 
 packageExtensions:
   croact-css-styled@1.1.9:

--- a/package.json
+++ b/package.json
@@ -279,6 +279,7 @@
     "@grafana/faro-web-tracing": "^2.8.2",
     "@grafana/flamegraph": "workspace:*",
     "@grafana/i18n": "workspace:*",
+    "@grafana/lezer-logql": "0.4.0",
     "@grafana/llm": "1.0.9",
     "@grafana/o11y-ds-frontend": "workspace:*",
     "@grafana/plugin-ui": "^0.13.1",

--- a/public/app/features/alerting/unified/components/Expression.tsx
+++ b/public/app/features/alerting/unified/components/Expression.tsx
@@ -3,9 +3,9 @@ import Prism, { type Grammar, type Token, type TokenStream } from 'prismjs';
 import { type FC, Fragment, type ReactNode, useMemo } from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';
+import { lokiGrammar } from '@grafana/lezer-logql';
 import { promqlGrammar } from '@grafana/prometheus';
 import { useStyles2 } from '@grafana/ui';
-import LogqlSyntax from 'app/plugins/datasource/loki/syntax';
 import { type RulesSource } from 'app/types/unified-alerting';
 
 import { DataSourceType, isCloudRulesSource } from '../utils/datasource';
@@ -19,7 +19,7 @@ interface Props {
 
 const GRAMMARS: Record<'promql' | 'logql', Grammar> = {
   promql: promqlGrammar,
-  logql: LogqlSyntax,
+  logql: lokiGrammar,
 };
 
 // Render Prism's token stream as elements (mirroring the class names Prism's own stringify emits)

--- a/public/app/features/alerting/unified/components/rule-viewer/tabs/Query/LokiQueryPreview.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/tabs/Query/LokiQueryPreview.tsx
@@ -1,5 +1,5 @@
+import { lokiGrammar } from '@grafana/lezer-logql';
 import { RawQuery } from '@grafana/plugin-ui';
-import lokiGrammar from 'app/plugins/datasource/loki/syntax';
 
 interface Props {
   query: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2547,6 +2547,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@grafana/lezer-logql@npm:0.4.0":
+  version: 0.4.0
+  resolution: "@grafana/lezer-logql@npm:0.4.0"
+  peerDependencies:
+    "@lezer/lr": 1.4.10
+  checksum: 10/451f3b62e636dd2384b7942dbe5846de442cd6f641ef4896c4a5f4cec09ea037d38e470582ff16b88b07e696a06adf21bb1fd278297757fcff4b759077723492
+  languageName: node
+  linkType: hard
+
 "@grafana/llm@npm:1.0.9":
   version: 1.0.9
   resolution: "@grafana/llm@npm:1.0.9"
@@ -18562,6 +18571,7 @@ __metadata:
     "@grafana/flamegraph": "workspace:*"
     "@grafana/i18n": "workspace:*"
     "@grafana/levitate": "npm:0.17.2"
+    "@grafana/lezer-logql": "npm:0.4.0"
     "@grafana/llm": "npm:1.0.9"
     "@grafana/o11y-ds-frontend": "workspace:*"
     "@grafana/plugin-e2e": "npm:^3.10.0"


### PR DESCRIPTION
**What is this feature?**

This is a prerequisite for removing loki datasource from grafana/grafana as it was moved to https://github.com/grafana/grafana-loki-datasource

With this we decouple grafana/grafana to loki datasource

**Why do we need this feature?**

To be able to remove loki safely

**Who is this feature for?**

grafana developers

