### PR TITLE
fix(annotations): align new store read ordering with legacy

### DIFF
--- a/pkg/registry/apps/annotation/memory_store.go
+++ b/pkg/registry/apps/annotation/memory_store.go
@@ -1,8 +1,10 @@
 package annotation
 
 import (
+	"cmp"
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
 
@@ -51,63 +53,74 @@ func (m *memoryStore) List(ctx context.Context, namespace string, opts ListOptio
 	var result []annotationV0.Annotation // no, we can't pre-alloc it, we don't know the size yet
 
 	for _, anno := range m.data {
-		if anno.Namespace != namespace {
-			continue
-		}
-		deleted := anno.DeletionTimestamp != nil
-		if deleted && filter == DeletedExclude {
-			continue
-		}
-		if !deleted && filter == DeletedOnly {
-			continue
-		}
-
-		if opts.DashboardUID != "" && (anno.Spec.DashboardUID == nil || *anno.Spec.DashboardUID != opts.DashboardUID) {
-			continue
-		}
-
-		if opts.PanelID != 0 && (anno.Spec.PanelID == nil || *anno.Spec.PanelID != opts.PanelID) {
-			continue
-		}
-
-		if opts.From > 0 && anno.Spec.Time < opts.From {
-			continue
-		}
-
-		if opts.To > 0 && anno.Spec.Time > opts.To {
-			continue
-		}
-
-		if len(opts.Tags) > 0 {
-			if !matchTags(anno.Spec.Tags, opts.Tags, opts.TagsMatchAny) {
-				continue
-			}
-		}
-
-		if len(opts.Scopes) > 0 {
-			if !matchScopes(anno.Spec.Scopes, opts.Scopes, opts.ScopesMatchAny) {
-				continue
-			}
-		}
-
-		if opts.CreatedBy != "" && anno.GetCreatedBy() != opts.CreatedBy {
-			continue
-		}
-
-		if opts.LegacyID > 0 {
-			if GetLegacyID(anno) != opts.LegacyID {
-				continue
-			}
-		}
-
-		result = append(result, *anno.DeepCopy())
-
-		if opts.Limit > 0 && int64(len(result)) >= opts.Limit {
-			break
+		if matchesList(anno, namespace, filter, opts) {
+			result = append(result, *anno.DeepCopy())
 		}
 	}
 
+	sortByEndTime(result)
+
+	if opts.Limit > 0 && int64(len(result)) > opts.Limit {
+		result = result[:opts.Limit]
+	}
+
 	return &AnnotationList{Items: result}, nil
+}
+
+func matchesList(anno *annotationV0.Annotation, namespace string, filter DeletedFilter, opts ListOptions) bool {
+	if anno.Namespace != namespace {
+		return false
+	}
+	deleted := anno.DeletionTimestamp != nil
+	if deleted && filter == DeletedExclude {
+		return false
+	}
+	if !deleted && filter == DeletedOnly {
+		return false
+	}
+	if opts.DashboardUID != "" && (anno.Spec.DashboardUID == nil || *anno.Spec.DashboardUID != opts.DashboardUID) {
+		return false
+	}
+	if opts.PanelID != 0 && (anno.Spec.PanelID == nil || *anno.Spec.PanelID != opts.PanelID) {
+		return false
+	}
+	if opts.From > 0 && anno.Spec.Time < opts.From {
+		return false
+	}
+	if opts.To > 0 && anno.Spec.Time > opts.To {
+		return false
+	}
+	if len(opts.Tags) > 0 && !matchTags(anno.Spec.Tags, opts.Tags, opts.TagsMatchAny) {
+		return false
+	}
+	if len(opts.Scopes) > 0 && !matchScopes(anno.Spec.Scopes, opts.Scopes, opts.ScopesMatchAny) {
+		return false
+	}
+	if opts.CreatedBy != "" && anno.GetCreatedBy() != opts.CreatedBy {
+		return false
+	}
+	if opts.LegacyID > 0 && GetLegacyID(anno) != opts.LegacyID {
+		return false
+	}
+	return true
+}
+
+func sortByEndTime(items []annotationV0.Annotation) {
+	endTime := func(a annotationV0.Annotation) int64 {
+		if a.Spec.TimeEnd != nil {
+			return *a.Spec.TimeEnd
+		}
+		return a.Spec.Time
+	}
+	slices.SortFunc(items, func(a, b annotationV0.Annotation) int {
+		if n := cmp.Compare(endTime(b), endTime(a)); n != 0 {
+			return n
+		}
+		if n := cmp.Compare(b.Spec.Time, a.Spec.Time); n != 0 {
+			return n
+		}
+		return cmp.Compare(a.Name, b.Name)
+	})
 }
 
 func matchTags(annoTags []string, filterTags []string, matchAny bool) bool {

--- a/pkg/registry/apps/annotation/postgres_partitioned.go
+++ b/pkg/registry/apps/annotation/postgres_partitioned.go
@@ -423,18 +423,29 @@ func buildListQuery(namespace string, opts ListOptions, offset, limit int64) (st
 		argNum++
 	}
 
-	// Construct query
-	query := `
-		SELECT namespace, name, time, time_end, dashboard_uid, panel_id,
-		       text, tags, scopes, created_by, created_at, legacy_id, legacy_data, deleted_at
-		FROM annotations
-		WHERE ` + strings.Join(conditions, " AND ") + `
-		ORDER BY time DESC, name
-	`
+	// Points and ranges are fetched separately so each is able to leverage its own index (time vs time_end)
+	// with results unioned. Each set is capped at offset+limit+1 candidates so the outer query
+	// is able to sort and paginate the merged set.
+	cols := `namespace, name, time, time_end, dashboard_uid, panel_id,
+	         text, tags, scopes, created_by, created_at, legacy_id, legacy_data, deleted_at`
+	where := strings.Join(conditions, " AND ")
 
-	// Add pagination
-	query += fmt.Sprintf(" LIMIT $%d OFFSET $%d", argNum, argNum+1)
-	args = append(args, limit+1, offset) // Request one extra to detect more results for pagination
+	innerLimit := offset + limit + 1
+	query := fmt.Sprintf(`
+		SELECT * FROM (
+			(SELECT %[1]s FROM annotations
+			 WHERE %[2]s AND time_end IS NULL
+			 ORDER BY time DESC, name LIMIT $%[3]d)
+			UNION ALL
+			(SELECT %[1]s FROM annotations
+			 WHERE %[2]s AND time_end IS NOT NULL
+			 ORDER BY time_end DESC, time DESC, name LIMIT $%[3]d)
+		) merged
+		ORDER BY COALESCE(time_end, time) DESC, time DESC, name
+		LIMIT $%[4]d OFFSET $%[5]d
+	`, cols, where, argNum, argNum+1, argNum+2)
+
+	args = append(args, innerLimit, limit+1, offset)
 
 	return query, args
 }

--- a/pkg/registry/apps/annotation/postgres_partitioned.go
+++ b/pkg/registry/apps/annotation/postgres_partitioned.go
@@ -424,8 +424,8 @@ func buildListQuery(namespace string, opts ListOptions, offset, limit int64) (st
 	}
 
 	// Points and ranges are fetched separately so each is able to leverage its own index (time vs time_end)
-	// with results unioned. Each set is capped at offset+limit+1 candidates so the outer query
-	// is able to sort and paginate the merged set.
+	// with results unioned. Either subquery could supply the entire page on its own, so each must return enough
+	// to cover the outer query's offset+limit, plus one extra row to detect whether a next page exists.
 	cols := `namespace, name, time, time_end, dashboard_uid, panel_id,
 	         text, tags, scopes, created_by, created_at, legacy_id, legacy_data, deleted_at`
 	where := strings.Join(conditions, " AND ")

--- a/pkg/registry/apps/annotation/postgres_store_test.go
+++ b/pkg/registry/apps/annotation/postgres_store_test.go
@@ -196,6 +196,31 @@ func TestIntegrationPostgresStore(t *testing.T) {
 			all := append(annotationNames(first), annotationNames(second)...)
 			assert.ElementsMatch(t, []string{"page-a", "page-b", "page-c"}, all)
 		})
+
+		t.Run("Orders a limited list by end time across points and tied ranges", func(t *testing.T) {
+			ordDash := "ord-dash"
+			at := func(start int64, end ...int64) func(*annotationV0.Annotation) {
+				return func(a *annotationV0.Annotation) {
+					a.Spec.Time = start
+					a.Spec.DashboardUID = &ordDash
+					if len(end) > 0 {
+						a.Spec.TimeEnd = &end[0]
+					}
+				}
+			}
+			create(t, "a-point-hi", at(1000))
+			create(t, "win-800", at(800, 900))
+			create(t, "win-500", at(500, 900))
+			create(t, "drop-300", at(300, 900))
+			create(t, "drop-100", at(100, 900))
+			create(t, "drop-50", at(50, 900))
+			create(t, "b-point-lo", at(400))
+
+			list, err := store.List(ctx, ns, ListOptions{DashboardUID: ordDash, Limit: 3})
+			require.NoError(t, err)
+
+			assert.Equal(t, []string{"a-point-hi", "win-800", "win-500"}, annotationNames(list))
+		})
 	})
 
 	t.Run("Delete of a missing annotation returns ErrNotFound", func(t *testing.T) {

--- a/pkg/services/annotations/annotationsapi/handler.go
+++ b/pkg/services/annotations/annotationsapi/handler.go
@@ -255,7 +255,8 @@ func annoToItemDTO(anno *annotationV0.Annotation) (*annotations.ItemDTO, error) 
 	if anno.Spec.TimeEnd != nil {
 		dto.TimeEnd = *anno.Spec.TimeEnd
 	} else {
-		// Set TimeEnd to Time for point annotations to align with the legacy API response.
+		// Set TimeEnd to Time for point annotations to align with the legacy API response,
+		// so the downsteam Merge sorts new-store and legacy-store points consistently.
 		dto.TimeEnd = anno.Spec.Time
 	}
 	if anno.Spec.PanelID != nil {

--- a/pkg/services/annotations/annotationsapi/handler.go
+++ b/pkg/services/annotations/annotationsapi/handler.go
@@ -254,6 +254,9 @@ func annoToItemDTO(anno *annotationV0.Annotation) (*annotations.ItemDTO, error) 
 	}
 	if anno.Spec.TimeEnd != nil {
 		dto.TimeEnd = *anno.Spec.TimeEnd
+	} else {
+		// Set TimeEnd to Time for point annotations to align with the legacy API response.
+		dto.TimeEnd = anno.Spec.Time
 	}
 	if anno.Spec.PanelID != nil {
 		dto.PanelID = *anno.Spec.PanelID

--- a/pkg/services/annotations/annotationsapi/handler_test.go
+++ b/pkg/services/annotations/annotationsapi/handler_test.go
@@ -57,6 +57,13 @@ func TestMerge(t *testing.T) {
 			limit:  0,
 			want:   []*annotations.ItemDTO{item(1, 30), item(2, 20), item(3, 10)},
 		},
+		{
+			name:   "new-store point interleaves with legacy by end time",
+			new:    []*annotations.ItemDTO{{ID: 1, Time: 20, TimeEnd: 20}},
+			legacy: []*annotations.ItemDTO{item(2, 30), item(3, 10)},
+			limit:  10,
+			want:   []*annotations.ItemDTO{item(2, 30), {ID: 1, Time: 20, TimeEnd: 20}, item(3, 10)},
+		},
 	}
 
 	for _, tt := range tests {
@@ -103,6 +110,28 @@ func TestItemAnnotationConversion(t *testing.T) {
 		dto, err := annoToItemDTO(anno)
 		require.NoError(t, err)
 		require.Nil(t, dto.Data)
+	})
+
+	t.Run("point annotation reads back TimeEnd == Time", func(t *testing.T) {
+		anno, err := itemToAnnotation(&annotations.Item{Text: "hello", Epoch: 1234})
+		require.NoError(t, err)
+		require.Nil(t, anno.Spec.TimeEnd, "a point annotation has no spec TimeEnd")
+
+		dto, err := annoToItemDTO(anno)
+		require.NoError(t, err)
+		require.Equal(t, int64(1234), dto.Time)
+		require.Equal(t, int64(1234), dto.TimeEnd, "point TimeEnd must match Time to align with legacy")
+	})
+
+	t.Run("range annotation preserves a distinct TimeEnd", func(t *testing.T) {
+		anno, err := itemToAnnotation(&annotations.Item{Text: "hello", Epoch: 1000, EpochEnd: 2000})
+		require.NoError(t, err)
+		require.NotNil(t, anno.Spec.TimeEnd)
+
+		dto, err := annoToItemDTO(anno)
+		require.NoError(t, err)
+		require.Equal(t, int64(1000), dto.Time)
+		require.Equal(t, int64(2000), dto.TimeEnd)
 	})
 
 	t.Run("malformed stored legacy data returns a partialDecodeError and a usable DTO", func(t *testing.T) {

--- a/pkg/services/annotations/annotationsapi/migration_repository.go
+++ b/pkg/services/annotations/annotationsapi/migration_repository.go
@@ -61,8 +61,6 @@ func (r *migrationRepository) Find(ctx context.Context, query *annotations.ItemQ
 }
 
 // search lists from the new store and merges in whatever legacy still owns for this query.
-// TODO: the stores order by different keys but share one limit, so a range annotation near the
-// boundary can be dropped after the merge. Tracked for a follow-up PR.
 func (r *migrationRepository) search(ctx context.Context, query *annotations.ItemQuery) ([]*annotations.ItemDTO, error) {
 	// The new store filters users by UID, so translate the query's legacy user ID first.
 	r.resolveUserUID(ctx, query)


### PR DESCRIPTION
This PR aligns the new annotation store's read ordering with the legacy API (by end time rather than start time) so that proxied reads merge and truncate consistently across both stores. This resolves the merge-truncation TODO in the migration proxy, where range annotations near the limit boundary could potentially be dropped.

The Postgres store's List query was changed from a single `ORDER BY time DESC` to a union of two distinct subqueries, ultimately ordered by end time. Splitting the queries allows each annotation type (point vs range) to still be backed by its own relevant index.

Closes: https://github.com/grafana/grafana-org/issues/956