### PR TITLE
Dashboards: Fix classic import assigning wrong datasource when inputs share a type

### DIFF
--- a/public/app/features/manage-dashboards/import/utils/inputs.test.ts
+++ b/public/app/features/manage-dashboards/import/utils/inputs.test.ts
@@ -985,6 +985,60 @@ describe('applyV1Inputs', () => {
       expect((result.panels?.[3] as unknown as { type: string }).type).toBe('row');
     });
   });
+
+  it('maps each datasource input to its own form selection when multiple inputs share a pluginId', () => {
+    const dashboard = {
+      title: 'old',
+      uid: 'old',
+      panels: [
+        { datasource: { type: 'influxdb', uid: '${DS_KUBERNETES}' }, targets: [] },
+        { datasource: { type: 'influxdb', uid: '${DS_VANTIQSERVER}' }, targets: [] },
+      ],
+    } as unknown as Dashboard;
+
+    const inputs: DashboardInputs = {
+      dataSources: [
+        {
+          name: 'DS_KUBERNETES',
+          label: 'kubernetes',
+          description: '',
+          info: '',
+          value: '',
+          type: InputType.DataSource,
+          pluginId: 'influxdb',
+        },
+        {
+          name: 'DS_VANTIQSERVER',
+          label: 'vantiqServer',
+          description: '',
+          info: '',
+          value: '',
+          type: InputType.DataSource,
+          pluginId: 'influxdb',
+        },
+      ],
+      constants: [],
+      libraryPanels: [],
+    };
+
+    const form: ImportDashboardDTO = {
+      title: 'new-title',
+      uid: 'new-uid',
+      gnetId: '',
+      constants: [],
+      dataSources: [
+        { uid: 'influx-a-uid', type: 'influxdb', name: 'influx-a' } as DataSourceInstanceSettings,
+        { uid: 'influx-b-uid', type: 'influxdb', name: 'influx-b' } as DataSourceInstanceSettings,
+      ],
+      elements: [],
+      folder: { uid: 'folder' },
+    };
+
+    const result = applyV1Inputs(dashboard, inputs, form);
+
+    expect(result.panels?.[0].datasource?.uid).toBe('influx-a-uid');
+    expect(result.panels?.[1].datasource?.uid).toBe('influx-b-uid');
+  });
 });
 
 describe('interpolateLibraryPanelDatasources', () => {

--- a/public/app/features/manage-dashboards/import/utils/inputs.test.ts
+++ b/public/app/features/manage-dashboards/import/utils/inputs.test.ts
@@ -1941,4 +1941,41 @@ describe('interpolateV1Dashboard', () => {
       ])
     ).toThrow('datasource input "DS_PROMETHEUS" references UID "nonexistent-uid" which was not found');
   });
+
+  it('should map each datasource input to its own mapping when multiple inputs share a pluginId', () => {
+    mockGetDataSourceSrv.getInstanceSettings = jest.fn().mockImplementation((uid: string) => {
+      if (uid === 'influx-a-uid') {
+        return { uid: 'influx-a-uid', type: 'influxdb', name: 'influx-a' };
+      }
+      if (uid === 'influx-b-uid') {
+        return { uid: 'influx-b-uid', type: 'influxdb', name: 'influx-b' };
+      }
+      return undefined;
+    });
+
+    const dashboard = makeDashboard({
+      __inputs: [
+        { name: 'DS_KUBERNETES', type: 'datasource', pluginId: 'influxdb', label: 'kubernetes', description: '', value: '' },
+        { name: 'DS_VANTIQSERVER', type: 'datasource', pluginId: 'influxdb', label: 'vantiqServer', description: '', value: '' },
+      ] as unknown as DashboardJson['__inputs'],
+      panels: [
+        { datasource: { type: 'influxdb', uid: '${DS_KUBERNETES}' }, targets: [], type: 'timeseries' },
+        { datasource: { type: 'influxdb', uid: '${DS_VANTIQSERVER}' }, targets: [], type: 'timeseries' },
+      ] as unknown as DashboardJson['panels'],
+    });
+
+    const result = interpolateV1Dashboard(dashboard, [
+      { name: 'DS_KUBERNETES', type: 'datasource', pluginId: 'influxdb', value: 'influx-a-uid' },
+      { name: 'DS_VANTIQSERVER', type: 'datasource', pluginId: 'influxdb', value: 'influx-b-uid' },
+    ]);
+
+    expect(getPanel(result, 0).datasource!.uid).toBe('influx-a-uid');
+    expect(getPanel(result, 1).datasource!.uid).toBe('influx-b-uid');
+  });
+
+  it('should throw when a datasource input has no matching mapping', () => {
+    expect(() => interpolateV1Dashboard(makeDashboard(), [])).toThrow(
+      'no datasource mapping found for input "DS_PROMETHEUS"'
+    );
+  });
 });

--- a/public/app/features/manage-dashboards/import/utils/inputs.ts
+++ b/public/app/features/manage-dashboards/import/utils/inputs.ts
@@ -778,9 +778,8 @@ function checkUserInputMatch(
   userDsInputs: DataSourceInstanceSettings[]
 ) {
   const dsName = templateizedUid.replace(/\$\{(.*)\}/, '$1');
-  const input = datasourceInputs?.find((ds) => ds.name === dsName);
-  const userInput = input && userDsInputs.find((ds) => ds.type === input.pluginId);
-  return userInput;
+  const index = datasourceInputs?.findIndex((ds) => ds.name === dsName) ?? -1;
+  return index === -1 ? undefined : userDsInputs[index];
 }
 
 function processAnnotation(

--- a/public/app/features/manage-dashboards/import/utils/inputs.ts
+++ b/public/app/features/manage-dashboards/import/utils/inputs.ts
@@ -369,29 +369,19 @@ export function interpolateV1Dashboard(
       }))
     : inputMappings;
 
-  const formDataSources: DataSourceInstanceSettings[] = [];
-  const seenPluginIds = new Set<string>();
-  for (const mapping of effectiveMappings.filter((m) => m.type === 'datasource')) {
-    const dsInput = dsInputs.find((i) => i.name === mapping.name);
-    const pluginId = mapping.pluginId ?? dsInput?.pluginId;
-    if (!pluginId || seenPluginIds.has(pluginId)) {
-      continue;
-    }
-
-    // Expression datasources are always forced to __expr__ regardless of user input,
-    // matching the backend behavior:
-    //   if inputDefJson.Get("pluginId").MustString() == expr.DatasourceType {
-    //       input = &dashboardimport.ImportDashboardInput{Value: expr.DatasourceType}
-    //   }
-    if (pluginId === ExpressionDatasourceRef.type) {
+  const formDataSources: DataSourceInstanceSettings[] = dsInputs.map((dsInput) => {
+    if (dsInput.pluginId === ExpressionDatasourceRef.type) {
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-      formDataSources.push({
+      return {
         uid: ExpressionDatasourceRef.uid,
         type: ExpressionDatasourceRef.type,
         name: ExpressionDatasourceRef.name,
-      } as DataSourceInstanceSettings);
-      seenPluginIds.add(pluginId);
-      continue;
+      } as DataSourceInstanceSettings;
+    }
+
+    const mapping = effectiveMappings.find((m) => m.type === 'datasource' && m.name === dsInput.name);
+    if (!mapping) {
+      throw new Error(`Dashboard import failed: no datasource mapping found for input "${dsInput.name}"`);
     }
 
     const settings = getDataSourceSrv().getInstanceSettings(mapping.value);
@@ -400,21 +390,8 @@ export function interpolateV1Dashboard(
         `Dashboard import failed: datasource input "${mapping.name}" references UID "${mapping.value}" which was not found`
       );
     }
-    formDataSources.push(settings);
-    seenPluginIds.add(pluginId);
-  }
-  // Ensure expression datasources are included even when not explicitly mapped
-  for (const dsInput of dsInputs) {
-    if (dsInput.pluginId === ExpressionDatasourceRef.type && !seenPluginIds.has(ExpressionDatasourceRef.type)) {
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-      formDataSources.push({
-        uid: ExpressionDatasourceRef.uid,
-        type: ExpressionDatasourceRef.type,
-        name: ExpressionDatasourceRef.name,
-      } as DataSourceInstanceSettings);
-      seenPluginIds.add(ExpressionDatasourceRef.type);
-    }
-  }
+    return settings;
+  });
 
   const constants: DashboardInput[] = constantRawInputs.map((input) => ({
     name: String(input.name ?? ''),


### PR DESCRIPTION
**What this PR does**

Fixes an issue in classic (v1 schema) dashboard imports where panels could be assigned the wrong datasource if two or more `__inputs` entries used the same datasource type (for example, two InfluxDB datasources).

**Which issue(s) does this PR fix?**:

Fixes #128809 

**Root cause**

`checkUserInputMatch` (`public/app/features/manage-dashboards/import/utils/inputs.ts`) matched a panel's datasource placeholder (for example `${DS_FOO}`) to the selected datasource by looking for the first `userDsInputs` entry whose `type` matched the input's `pluginId`.

However, `ImportForm.tsx` renders one datasource picker for each input, using the array index to connect `datasourceInputs` and `userDsInputs`.

When two datasource inputs had the same `pluginId` (for example `DS_KUBERNETES` and `DS_VANTIQSERVER`, both InfluxDB), matching by type always returned the first selection. As a result, the second panel incorrectly used the first datasource.

This only affected classic (v1) dashboard imports. v2 imports already match datasources using unique `grafana.app/export-label` values (fixed in #116617).

**Fix**

- Build `formDataSources` via `dsInputs.map(...)` instead of iterating and deduplicating the mapping list, guarantees 1:1 index alignment with `dsInputs` regardless of duplicate `pluginId`s.
- Match each `dsInput` to its mapping by `name` (the real, reliable key), not positional order of an unrelated list.
- Throw a clear error if an input has no matching mapping, instead of silently skipping it

**Testing**

- Added a regression test in `inputs.test.ts` that covers the case where two datasource inputs share the same `pluginId`. The test verifies that each panel resolves to the correct datasource selected in the import form.
- Added a test for the new throw-on-unmapped-input path.
- Existing `interpolateV1Dashboard` and `applyV1Inputs` test suites pass unchanged.
- Also manually verified the fix by importing a classic (v1) dashboard with two InfluxDB datasource inputs, selecting two different InfluxDB datasources in the import form, and confirming that each panel and target uses the correct datasource.

**Screenshots for reference**

**Before**
<img width="1919" height="1028" alt="repro_1" src="https://github.com/user-attachments/assets/c0496fb7-2e46-4f10-96e0-2eb857d22c7a" />
<img width="1919" height="1030" alt="repro_2" src="https://github.com/user-attachments/assets/d66d9143-790d-4946-92ef-7ead959bcb67" />

**After**
<img width="1919" height="1030" alt="fix_1" src="https://github.com/user-attachments/assets/8af63290-5f5e-40f3-ac94-40a098ca213a" />
<img width="1919" height="1030" alt="fix_2" src="https://github.com/user-attachments/assets/37d90dc3-98b0-4d4d-94e6-f74effb6acbd" />


**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
