### PR TITLE
Explore: Add Prometheus metrics explorer sidebar

### DIFF
--- a/packages/grafana-data/src/utils/matchPluginId.test.ts
+++ b/packages/grafana-data/src/utils/matchPluginId.test.ts
@@ -61,4 +61,23 @@ describe('matchPluginId', () => {
     const pluginMeta = createPluginMeta('test-plugin');
     expect(matchPluginId('alias1', pluginMeta)).toBe(false);
   });
+
+  describe('with a partial plugin meta (id/aliasIDs only)', () => {
+    it('should match an exact id', () => {
+      expect(matchPluginId('prometheus', { id: 'prometheus' })).toBe(true);
+    });
+
+    it('should match a Prometheus flavor id', () => {
+      expect(matchPluginId('prometheus', { id: 'grafana-amazonprometheus-datasource' })).toBe(true);
+      expect(matchPluginId('prometheus', { id: 'grafana-azureprometheus-datasource' })).toBe(true);
+    });
+
+    it('should not match a non-Prometheus id', () => {
+      expect(matchPluginId('prometheus', { id: 'loki' })).toBe(false);
+    });
+
+    it('should match against aliasIDs', () => {
+      expect(matchPluginId('alias1', { id: 'test-plugin', aliasIDs: ['alias1'] })).toBe(true);
+    });
+  });
 });

--- a/packages/grafana-data/src/utils/matchPluginId.ts
+++ b/packages/grafana-data/src/utils/matchPluginId.ts
@@ -1,6 +1,6 @@
 import { type PluginMeta } from '../types/plugin';
 
-export function matchPluginId(idToMatch: string, pluginMeta: PluginMeta) {
+export function matchPluginId(idToMatch: string, pluginMeta: Pick<PluginMeta, 'id' | 'aliasIDs'>) {
   if (pluginMeta.id === idToMatch) {
     return true;
   }

--- a/public/app/features/explore/ContentOutline/ContentOutline.test.tsx
+++ b/public/app/features/explore/ContentOutline/ContentOutline.test.tsx
@@ -9,8 +9,10 @@ jest.mock('./ContentOutlineContext', () => ({
   useContentOutlineContext: jest.fn(),
 }));
 
+const useBooleanFlagValueMock = jest.fn((_: string, defaultValue: boolean) => defaultValue);
+
 jest.mock('@openfeature/react-sdk', () => ({
-  useBooleanFlagValue: jest.fn().mockReturnValue(false),
+  useBooleanFlagValue: (flag: string, defaultValue: boolean) => useBooleanFlagValueMock(flag, defaultValue),
 }));
 
 const scrollIntoViewMock = jest.fn();
@@ -18,7 +20,7 @@ const scrollerMock = document.createElement('div');
 
 const unregisterMock = jest.fn();
 
-const setup = (mergeSingleChild = false) => {
+const setup = (mergeSingleChild = false, showMetricsExplorer = false) => {
   HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;
 
   scrollerMock.scroll = jest.fn();
@@ -73,7 +75,13 @@ const setup = (mergeSingleChild = false) => {
     unregister: unregisterMock,
   });
 
-  return render(<ContentOutline scroller={scrollerMock} panelId="content-outline-container-1" />);
+  return render(
+    <ContentOutline
+      scroller={scrollerMock}
+      panelId="content-outline-container-1"
+      showMetricsExplorer={showMetricsExplorer}
+    />
+  );
 };
 
 describe('<ContentOutline />', () => {
@@ -173,5 +181,40 @@ describe('<ContentOutline />', () => {
     expect(expandContentOutlineButton).toBeInTheDocument();
 
     getBoolMock.mockRestore();
+  });
+
+  describe('metrics explorer', () => {
+    afterEach(() => {
+      useBooleanFlagValueMock.mockImplementation((_: string, defaultValue: boolean) => defaultValue);
+    });
+
+    it('shows the "Outline" title and hides the metrics explorer by default', () => {
+      setup();
+      expect(screen.getByText('Outline')).toBeInTheDocument();
+      expect(screen.queryByText('Datasource explorer')).not.toBeInTheDocument();
+      expect(screen.queryByPlaceholderText('Search metrics')).not.toBeInTheDocument();
+    });
+
+    it('does not render the metrics explorer when the feature toggle is disabled', () => {
+      useBooleanFlagValueMock.mockReturnValue(false);
+      setup(false, true);
+      expect(screen.queryByPlaceholderText('Search metrics')).not.toBeInTheDocument();
+      expect(screen.getByText('Outline')).toBeInTheDocument();
+    });
+
+    it('renders the metrics explorer and "Datasource explorer" title when the toggle is enabled and Prometheus is selected', () => {
+      useBooleanFlagValueMock.mockReturnValue(true);
+      setup(false, true);
+      expect(screen.getByText('Datasource explorer')).toBeInTheDocument();
+      expect(screen.getByPlaceholderText('Search metrics')).toBeInTheDocument();
+      expect(screen.getByText('up')).toBeInTheDocument();
+    });
+
+    it('does not render the metrics explorer when the toggle is enabled but Prometheus is not selected', () => {
+      useBooleanFlagValueMock.mockReturnValue(true);
+      setup(false, false);
+      expect(screen.queryByPlaceholderText('Search metrics')).not.toBeInTheDocument();
+      expect(screen.getByText('Outline')).toBeInTheDocument();
+    });
   });
 });

--- a/public/app/features/explore/ContentOutline/ContentOutline.test.tsx
+++ b/public/app/features/explore/ContentOutline/ContentOutline.test.tsx
@@ -188,18 +188,18 @@ describe('<ContentOutline />', () => {
       useBooleanFlagValueMock.mockImplementation((_: string, defaultValue: boolean) => defaultValue);
     });
 
-    it('shows the "Outline" title and hides the metrics explorer by default', () => {
+    it('hides the header title and the metrics explorer by default (feature toggle off)', () => {
       setup();
-      expect(screen.getByText('Outline')).toBeInTheDocument();
+      expect(screen.queryByText('Outline')).not.toBeInTheDocument();
       expect(screen.queryByText('Datasource explorer')).not.toBeInTheDocument();
       expect(screen.queryByPlaceholderText('Search metrics')).not.toBeInTheDocument();
     });
 
-    it('does not render the metrics explorer when the feature toggle is disabled', () => {
+    it('does not render the metrics explorer or header title when the feature toggle is disabled', () => {
       useBooleanFlagValueMock.mockReturnValue(false);
       setup(false, true);
       expect(screen.queryByPlaceholderText('Search metrics')).not.toBeInTheDocument();
-      expect(screen.getByText('Outline')).toBeInTheDocument();
+      expect(screen.queryByText('Outline')).not.toBeInTheDocument();
     });
 
     it('renders the metrics explorer and "Datasource explorer" title when the toggle is enabled and Prometheus is selected', () => {

--- a/public/app/features/explore/ContentOutline/ContentOutline.test.tsx
+++ b/public/app/features/explore/ContentOutline/ContentOutline.test.tsx
@@ -210,11 +210,12 @@ describe('<ContentOutline />', () => {
       expect(screen.getByText('up')).toBeInTheDocument();
     });
 
-    it('does not render the metrics explorer when the toggle is enabled but Prometheus is not selected', () => {
+    it('does not render the metrics explorer or header title when the toggle is enabled but Prometheus is not selected', () => {
       useBooleanFlagValueMock.mockReturnValue(true);
       setup(false, false);
       expect(screen.queryByPlaceholderText('Search metrics')).not.toBeInTheDocument();
-      expect(screen.getByText('Outline')).toBeInTheDocument();
+      expect(screen.queryByText('Datasource explorer')).not.toBeInTheDocument();
+      expect(screen.queryByText('Outline')).not.toBeInTheDocument();
     });
   });
 });

--- a/public/app/features/explore/ContentOutline/ContentOutline.test.tsx
+++ b/public/app/features/explore/ContentOutline/ContentOutline.test.tsx
@@ -9,6 +9,10 @@ jest.mock('./ContentOutlineContext', () => ({
   useContentOutlineContext: jest.fn(),
 }));
 
+jest.mock('@openfeature/react-sdk', () => ({
+  useBooleanFlagValue: jest.fn().mockReturnValue(false),
+}));
+
 const scrollIntoViewMock = jest.fn();
 const scrollerMock = document.createElement('div');
 

--- a/public/app/features/explore/ContentOutline/ContentOutline.tsx
+++ b/public/app/features/explore/ContentOutline/ContentOutline.tsx
@@ -168,37 +168,41 @@ export function ContentOutline({
     }
   }, [outlineItems, verticalScroll]);
 
+  const toggleButton = (
+    <ContentOutlineItemButton
+      icon={'arrow-from-right'}
+      tooltip={
+        contentOutlineExpanded
+          ? t('explore.content-outline.tooltip-collapse-outline', 'Collapse outline')
+          : t('explore.content-outline.tooltip-expand-outline', 'Expand outline')
+      }
+      tooltipPlacement={contentOutlineExpanded ? 'right' : 'bottom'}
+      onClick={toggle}
+      className={cx(styles.toggleContentOutlineButton, {
+        [styles.justifyCenter]: !contentOutlineExpanded && !outlineItemsShouldIndent,
+      })}
+      aria-expanded={contentOutlineExpanded}
+    />
+  );
+
   return (
     <PanelContainer className={styles.wrapper} id={panelId}>
-      <div className={styles.header}>
-        {metricsExplorerVisible && (
-          <span className={styles.headerTitle}>
-            {t('explore.content-outline.title-datasource-explorer', 'Datasource explorer')}
-          </span>
-        )}
-        <div className={styles.toggleWrapper}>
-          <ContentOutlineItemButton
-            icon={'arrow-from-right'}
-            tooltip={
-              contentOutlineExpanded
-                ? t('explore.content-outline.tooltip-collapse-outline', 'Collapse outline')
-                : t('explore.content-outline.tooltip-expand-outline', 'Expand outline')
-            }
-            tooltipPlacement={contentOutlineExpanded ? 'right' : 'bottom'}
-            onClick={toggle}
-            className={cx(styles.toggleContentOutlineButton, {
-              [styles.justifyCenter]: !contentOutlineExpanded && !outlineItemsShouldIndent,
-            })}
-            aria-expanded={contentOutlineExpanded}
-          />
-        </div>
-      </div>
-
-      {metricsExplorerVisible && <MetricsExplorer />}
+      {metricsExplorerVisible && (
+        <>
+          <div className={styles.header}>
+            <span className={styles.headerTitle}>
+              {t('explore.content-outline.title-datasource-explorer', 'Datasource explorer')}
+            </span>
+            <div className={styles.toggleWrapper}>{toggleButton}</div>
+          </div>
+          <MetricsExplorer />
+        </>
+      )}
 
       <div className={styles.outlineSection}>
         <ScrollContainer>
           <div className={styles.content}>
+            {!metricsExplorerVisible && toggleButton}
             {outlineItems.map((item) => {
               return (
                 <Fragment key={item.id}>
@@ -339,7 +343,7 @@ const getStyles = (theme: GrafanaTheme2, expanded: boolean, metricsExplorerVisib
     }),
     content: css({
       label: 'content',
-      padding: theme.spacing(0.5, 1),
+      padding: theme.spacing(0, 0.5),
       top: 0,
     }),
     buttonStyles: css({
@@ -350,11 +354,11 @@ const getStyles = (theme: GrafanaTheme2, expanded: boolean, metricsExplorerVisib
       },
     }),
     toggleContentOutlineButton: css({
-      justifyContent: 'center',
       '&:hover': {
         color: theme.colors.text.primary,
       },
       transform: expanded ? 'rotate(180deg)' : '',
+      marginRight: expanded ? theme.spacing(0.5) : undefined,
     }),
     indentRoot: css({
       paddingLeft: theme.spacing(3),

--- a/public/app/features/explore/ContentOutline/ContentOutline.tsx
+++ b/public/app/features/explore/ContentOutline/ContentOutline.tsx
@@ -276,7 +276,7 @@ export function ContentOutline({
 }
 
 const getStyles = (theme: GrafanaTheme2, expanded: boolean, metricsExplorerVisible: boolean) => {
-  const expandedWidth = '300px';
+  const expandedWidth = metricsExplorerVisible ? '300px' : '160px';
 
   return {
     wrapper: css({

--- a/public/app/features/explore/ContentOutline/ContentOutline.tsx
+++ b/public/app/features/explore/ContentOutline/ContentOutline.tsx
@@ -6,7 +6,7 @@ import { useToggle, useScroll } from 'react-use';
 import { type GrafanaTheme2, store } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
-import { useStyles2, PanelContainer } from '@grafana/ui';
+import { useStyles2, PanelContainer, ScrollContainer } from '@grafana/ui';
 
 import { type ContentOutlineItemContextProps, useContentOutlineContext } from './ContentOutlineContext';
 import { ContentOutlineItemButton } from './ContentOutlineItemButton';
@@ -197,75 +197,79 @@ export function ContentOutline({
       {metricsExplorerVisible && <MetricsExplorer />}
 
       <div className={styles.outlineSection}>
-        <div className={styles.content}>
-          {outlineItems.map((item) => {
-            return (
-              <Fragment key={item.id}>
-                <ContentOutlineItemButton
-                  key={item.id}
-                  title={contentOutlineExpanded ? item.title : undefined}
-                  contentOutlineExpanded={contentOutlineExpanded}
-                  className={cx(styles.buttonStyles, {
-                    [styles.justifyCenter]: !contentOutlineExpanded && !outlineItemsHaveDeleteButton,
-                    [styles.sectionHighlighter]: isChildActive(item, activeSectionChildId) && !contentOutlineExpanded,
-                  })}
-                  indentStyle={cx({
-                    [styles.indentRoot]: !isCollapsible(item) && outlineItemsShouldIndent,
-                    [styles.sectionHighlighter]:
-                      isChildActive(item, activeSectionChildId) && !contentOutlineExpanded && sectionsExpanded[item.id],
-                  })}
-                  icon={item.icon}
-                  onClick={() => handleItemClicked(item)}
-                  tooltip={item.title}
-                  collapsible={isCollapsible(item)}
-                  collapsed={!sectionsExpanded[item.id]}
-                  toggleCollapsed={() => toggleSection(item.id)}
-                  isActive={shouldBeActive(item, activeSectionId, activeSectionChildId, sectionsExpanded)}
-                  sectionId={item.id}
-                  color={item.color}
-                />
-                <div id={item.id} data-testid={`section-wrapper-${item.id}`}>
-                  {item.children &&
-                    isCollapsible(item) &&
-                    sectionsExpanded[item.id] &&
-                    item.children.map((child, i) => (
-                      <div key={child.id} className={styles.itemWrapper}>
-                        {contentOutlineExpanded && (
-                          <div
-                            className={cx(styles.itemConnector, {
-                              [styles.firstItemConnector]: i === 0,
-                              [styles.lastItemConnector]: i === (item.children?.length || 0) - 1,
+        <ScrollContainer>
+          <div className={styles.content}>
+            {outlineItems.map((item) => {
+              return (
+                <Fragment key={item.id}>
+                  <ContentOutlineItemButton
+                    key={item.id}
+                    title={contentOutlineExpanded ? item.title : undefined}
+                    contentOutlineExpanded={contentOutlineExpanded}
+                    className={cx(styles.buttonStyles, {
+                      [styles.justifyCenter]: !contentOutlineExpanded && !outlineItemsHaveDeleteButton,
+                      [styles.sectionHighlighter]: isChildActive(item, activeSectionChildId) && !contentOutlineExpanded,
+                    })}
+                    indentStyle={cx({
+                      [styles.indentRoot]: !isCollapsible(item) && outlineItemsShouldIndent,
+                      [styles.sectionHighlighter]:
+                        isChildActive(item, activeSectionChildId) &&
+                        !contentOutlineExpanded &&
+                        sectionsExpanded[item.id],
+                    })}
+                    icon={item.icon}
+                    onClick={() => handleItemClicked(item)}
+                    tooltip={item.title}
+                    collapsible={isCollapsible(item)}
+                    collapsed={!sectionsExpanded[item.id]}
+                    toggleCollapsed={() => toggleSection(item.id)}
+                    isActive={shouldBeActive(item, activeSectionId, activeSectionChildId, sectionsExpanded)}
+                    sectionId={item.id}
+                    color={item.color}
+                  />
+                  <div id={item.id} data-testid={`section-wrapper-${item.id}`}>
+                    {item.children &&
+                      isCollapsible(item) &&
+                      sectionsExpanded[item.id] &&
+                      item.children.map((child, i) => (
+                        <div key={child.id} className={styles.itemWrapper}>
+                          {contentOutlineExpanded && (
+                            <div
+                              className={cx(styles.itemConnector, {
+                                [styles.firstItemConnector]: i === 0,
+                                [styles.lastItemConnector]: i === (item.children?.length || 0) - 1,
+                              })}
+                            />
+                          )}
+                          <ContentOutlineItemButton
+                            key={child.id}
+                            title={contentOutlineExpanded ? child.title : undefined}
+                            contentOutlineExpanded={contentOutlineExpanded}
+                            icon={contentOutlineExpanded ? undefined : item.icon}
+                            className={cx(styles.buttonStyles, {
+                              [styles.justifyCenter]: !contentOutlineExpanded && !outlineItemsHaveDeleteButton,
+                              [styles.sectionHighlighter]:
+                                isChildActive(item, activeSectionChildId) && !contentOutlineExpanded,
                             })}
+                            indentStyle={styles.indentChild}
+                            onClick={(e) => {
+                              handleItemClicked(child);
+                              child.onClick?.(e);
+                            }}
+                            tooltip={child.title}
+                            isActive={shouldBeActive(child, activeSectionId, activeSectionChildId, sectionsExpanded)}
+                            extraHighlight={child.highlight}
+                            color={child.color}
+                            onRemove={child.onRemove ? () => child.onRemove?.(child.id) : undefined}
                           />
-                        )}
-                        <ContentOutlineItemButton
-                          key={child.id}
-                          title={contentOutlineExpanded ? child.title : undefined}
-                          contentOutlineExpanded={contentOutlineExpanded}
-                          icon={contentOutlineExpanded ? undefined : item.icon}
-                          className={cx(styles.buttonStyles, {
-                            [styles.justifyCenter]: !contentOutlineExpanded && !outlineItemsHaveDeleteButton,
-                            [styles.sectionHighlighter]:
-                              isChildActive(item, activeSectionChildId) && !contentOutlineExpanded,
-                          })}
-                          indentStyle={styles.indentChild}
-                          onClick={(e) => {
-                            handleItemClicked(child);
-                            child.onClick?.(e);
-                          }}
-                          tooltip={child.title}
-                          isActive={shouldBeActive(child, activeSectionId, activeSectionChildId, sectionsExpanded)}
-                          extraHighlight={child.highlight}
-                          color={child.color}
-                          onRemove={child.onRemove ? () => child.onRemove?.(child.id) : undefined}
-                        />
-                      </div>
-                    ))}
-                </div>
-              </Fragment>
-            );
-          })}
-        </div>
+                        </div>
+                      ))}
+                  </div>
+                </Fragment>
+              );
+            })}
+          </div>
+        </ScrollContainer>
       </div>
     </PanelContainer>
   );
@@ -322,13 +326,15 @@ const getStyles = (theme: GrafanaTheme2, expanded: boolean, metricsExplorerVisib
       minHeight: 0,
       ...(metricsExplorerVisible
         ? {
-            flex: '0 0 auto',
+            // Shrinkable so a tall outline scrolls (via ScrollContainer) instead of
+            // clipping against the wrapper, while still sizing to content and sitting
+            // at the bottom.
+            flex: '0 1 auto',
             marginTop: 'auto',
             borderTop: `1px solid ${theme.colors.border.weak}`,
           }
         : {
             flex: '1 1 auto',
-            overflowY: 'auto',
           }),
     }),
     content: css({

--- a/public/app/features/explore/ContentOutline/ContentOutline.tsx
+++ b/public/app/features/explore/ContentOutline/ContentOutline.tsx
@@ -175,7 +175,7 @@ export function ContentOutline({
   return (
     <PanelContainer className={styles.wrapper} id={panelId}>
       <div className={styles.header}>
-        {contentOutlineExpanded && <span className={styles.headerTitle}>{outlineTitle}</span>}
+        {contentOutlineExpanded && metricsSidebarEnabled && <span className={styles.headerTitle}>{outlineTitle}</span>}
         <div className={styles.toggleWrapper}>
           <ContentOutlineItemButton
             icon={'arrow-from-right'}

--- a/public/app/features/explore/ContentOutline/ContentOutline.tsx
+++ b/public/app/features/explore/ContentOutline/ContentOutline.tsx
@@ -168,14 +168,14 @@ export function ContentOutline({
     }
   }, [outlineItems, verticalScroll]);
 
-  const outlineTitle = metricsExplorerVisible
-    ? t('explore.content-outline.title-datasource-explorer', 'Datasource explorer')
-    : t('explore.content-outline.title-outline', 'Outline');
-
   return (
     <PanelContainer className={styles.wrapper} id={panelId}>
       <div className={styles.header}>
-        {contentOutlineExpanded && metricsSidebarEnabled && <span className={styles.headerTitle}>{outlineTitle}</span>}
+        {metricsExplorerVisible && (
+          <span className={styles.headerTitle}>
+            {t('explore.content-outline.title-datasource-explorer', 'Datasource explorer')}
+          </span>
+        )}
         <div className={styles.toggleWrapper}>
           <ContentOutlineItemButton
             icon={'arrow-from-right'}

--- a/public/app/features/explore/ContentOutline/ContentOutline.tsx
+++ b/public/app/features/explore/ContentOutline/ContentOutline.tsx
@@ -1,14 +1,16 @@
 import { css, cx } from '@emotion/css';
+import { useBooleanFlagValue } from '@openfeature/react-sdk';
 import { Fragment, useEffect, useRef, useState } from 'react';
 import { useToggle, useScroll } from 'react-use';
 
 import { type GrafanaTheme2, store } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
-import { useStyles2, PanelContainer, ScrollContainer } from '@grafana/ui';
+import { useStyles2, PanelContainer } from '@grafana/ui';
 
 import { type ContentOutlineItemContextProps, useContentOutlineContext } from './ContentOutlineContext';
 import { ContentOutlineItemButton } from './ContentOutlineItemButton';
+import { MetricsExplorer } from './MetricsExplorer';
 
 function scrollableChildren(item: ContentOutlineItemContextProps) {
   return item.children?.filter((child) => child.type !== 'filter') || [];
@@ -40,11 +42,24 @@ export const CONTENT_OUTLINE_LOCAL_STORAGE_KEYS = {
   expanded: 'grafana.explore.contentOutline.expanded',
 };
 
-export function ContentOutline({ scroller, panelId }: { scroller: HTMLElement | undefined; panelId: string }) {
+export function ContentOutline({
+  scroller,
+  panelId,
+  showMetricsExplorer = false,
+}: {
+  scroller: HTMLElement | undefined;
+  panelId: string;
+  showMetricsExplorer?: boolean;
+}) {
   const [contentOutlineExpanded, toggleContentOutlineExpanded] = useToggle(
     store.getBool(CONTENT_OUTLINE_LOCAL_STORAGE_KEYS.expanded, true)
   );
-  const styles = useStyles2(getStyles, contentOutlineExpanded);
+  const metricsSidebarEnabled = useBooleanFlagValue('grafana.exploreMetricsSidebar', false, {
+    suspendUntilReady: false,
+    suspendWhileReconciling: false,
+  });
+  const metricsExplorerVisible = metricsSidebarEnabled && showMetricsExplorer && contentOutlineExpanded;
+  const styles = useStyles2(getStyles, contentOutlineExpanded, metricsExplorerVisible);
   const scrollerRef = useRef(scroller || null);
   const { y: verticalScroll } = useScroll(scrollerRef);
   const { outlineItems } = useContentOutlineContext() ?? { outlineItems: [] };
@@ -153,10 +168,15 @@ export function ContentOutline({ scroller, panelId }: { scroller: HTMLElement | 
     }
   }, [outlineItems, verticalScroll]);
 
+  const outlineTitle = metricsExplorerVisible
+    ? t('explore.content-outline.title-datasource-explorer', 'Datasource explorer')
+    : t('explore.content-outline.title-outline', 'Outline');
+
   return (
     <PanelContainer className={styles.wrapper} id={panelId}>
-      <ScrollContainer>
-        <div className={styles.content}>
+      <div className={styles.header}>
+        {contentOutlineExpanded && <span className={styles.headerTitle}>{outlineTitle}</span>}
+        <div className={styles.toggleWrapper}>
           <ContentOutlineItemButton
             icon={'arrow-from-right'}
             tooltip={
@@ -171,7 +191,13 @@ export function ContentOutline({ scroller, panelId }: { scroller: HTMLElement | 
             })}
             aria-expanded={contentOutlineExpanded}
           />
+        </div>
+      </div>
 
+      {metricsExplorerVisible && <MetricsExplorer />}
+
+      <div className={styles.outlineSection}>
+        <div className={styles.content}>
           {outlineItems.map((item) => {
             return (
               <Fragment key={item.id}>
@@ -240,27 +266,74 @@ export function ContentOutline({ scroller, panelId }: { scroller: HTMLElement | 
             );
           })}
         </div>
-      </ScrollContainer>
+      </div>
     </PanelContainer>
   );
 }
 
-const getStyles = (theme: GrafanaTheme2, expanded: boolean) => {
+const getStyles = (theme: GrafanaTheme2, expanded: boolean, metricsExplorerVisible: boolean) => {
+  const expandedWidth = '300px';
+
   return {
     wrapper: css({
       label: 'wrapper',
       position: 'relative',
       display: 'flex',
-      justifyContent: 'center',
+      flexDirection: 'column',
       marginRight: theme.spacing(1),
       height: '100%',
+      overflow: 'hidden',
       backgroundColor: theme.colors.background.primary,
-      width: expanded ? '160px' : undefined,
-      minWidth: expanded ? '160px' : undefined,
+      width: expanded ? expandedWidth : undefined,
+      minWidth: expanded ? expandedWidth : undefined,
+    }),
+    header: css({
+      label: 'content-outline-header',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: expanded ? 'space-between' : 'center',
+      gap: theme.spacing(1),
+      flex: '0 0 auto',
+      padding: expanded ? theme.spacing(1, 1, 0.5, 1) : theme.spacing(1, 0.5),
+    }),
+    headerTitle: css({
+      label: 'content-outline-header-title',
+      flex: '1 1 auto',
+      minWidth: 0,
+      fontSize: theme.typography.h6.fontSize,
+      fontWeight: theme.typography.fontWeightMedium,
+      color: theme.colors.text.primary,
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap',
+    }),
+    toggleWrapper: css({
+      label: 'content-outline-toggle-wrapper',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      flex: '0 0 auto',
+      width: theme.spacing(4),
+    }),
+    outlineSection: css({
+      label: 'outline-section',
+      display: 'flex',
+      flexDirection: 'column',
+      minHeight: 0,
+      ...(metricsExplorerVisible
+        ? {
+            flex: '0 0 auto',
+            marginTop: 'auto',
+            borderTop: `1px solid ${theme.colors.border.weak}`,
+          }
+        : {
+            flex: '1 1 auto',
+            overflowY: 'auto',
+          }),
     }),
     content: css({
       label: 'content',
-      padding: theme.spacing(0, 0.5),
+      padding: theme.spacing(0.5, 1),
       top: 0,
     }),
     buttonStyles: css({
@@ -271,11 +344,11 @@ const getStyles = (theme: GrafanaTheme2, expanded: boolean) => {
       },
     }),
     toggleContentOutlineButton: css({
+      justifyContent: 'center',
       '&:hover': {
         color: theme.colors.text.primary,
       },
       transform: expanded ? 'rotate(180deg)' : '',
-      marginRight: expanded ? theme.spacing(0.5) : undefined,
     }),
     indentRoot: css({
       paddingLeft: theme.spacing(3),

--- a/public/app/features/explore/ContentOutline/MetricsExplorer.test.tsx
+++ b/public/app/features/explore/ContentOutline/MetricsExplorer.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { MetricsExplorer } from './MetricsExplorer';
+
+describe('<MetricsExplorer />', () => {
+  it('renders the metrics title and search input', () => {
+    render(<MetricsExplorer />);
+
+    expect(screen.getByText('Metrics')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Search metrics')).toBeInTheDocument();
+  });
+
+  it('renders the stub metric list', () => {
+    render(<MetricsExplorer />);
+
+    expect(screen.getByText('up')).toBeInTheDocument();
+    expect(screen.getByText('node_cpu_seconds_total')).toBeInTheDocument();
+  });
+
+  it('filters the metric list by the search term', async () => {
+    render(<MetricsExplorer />);
+
+    await userEvent.type(screen.getByPlaceholderText('Search metrics'), 'node_cpu');
+
+    expect(screen.getByText('node_cpu_seconds_total')).toBeInTheDocument();
+    expect(screen.queryByText('up')).not.toBeInTheDocument();
+  });
+
+  it('shows no metrics when the search term matches nothing', async () => {
+    render(<MetricsExplorer />);
+
+    await userEvent.type(screen.getByPlaceholderText('Search metrics'), 'no_such_metric');
+
+    expect(screen.queryByText('up')).not.toBeInTheDocument();
+    expect(screen.queryByText('node_cpu_seconds_total')).not.toBeInTheDocument();
+  });
+});

--- a/public/app/features/explore/ContentOutline/MetricsExplorer.tsx
+++ b/public/app/features/explore/ContentOutline/MetricsExplorer.tsx
@@ -1,0 +1,103 @@
+import { css } from '@emotion/css';
+import { useMemo, useState } from 'react';
+
+import { type GrafanaTheme2 } from '@grafana/data';
+import { t } from '@grafana/i18n';
+import { FilterInput, ScrollContainer, useStyles2 } from '@grafana/ui';
+
+// Static stub list of Prometheus metric names. This is intentionally not fetched
+// from a datasource - it only exists to render the Metrics Explorer UI.
+const STUB_METRICS = [
+  'http_server_requests_seconds_bucket',
+  'http_server_requests_seconds_count',
+  'http_server_requests_seconds_sum',
+  'node_cpu_seconds_total',
+  'node_memory_MemAvailable_bytes',
+  'node_memory_MemTotal_bytes',
+  'process_resident_memory_bytes',
+  'process_cpu_seconds_total',
+  'grpc_server_handled_total',
+  'grpc_server_handling_seconds_bucket',
+  'go_goroutines',
+  'go_gc_duration_seconds',
+  'go_memstats_heap_inuse_bytes',
+  'up',
+  'prometheus_tsdb_head_series',
+  'kube_pod_container_status_running',
+  'container_memory_usage_bytes',
+  'alertmanager_notifications_total',
+];
+
+export function MetricsExplorer() {
+  const styles = useStyles2(getStyles);
+  const [searchTerm, setSearchTerm] = useState('');
+
+  const filteredMetrics = useMemo(() => {
+    const term = searchTerm.trim().toLowerCase();
+    if (!term) {
+      return STUB_METRICS;
+    }
+    return STUB_METRICS.filter((metric) => metric.toLowerCase().includes(term));
+  }, [searchTerm]);
+
+  return (
+    <div className={styles.wrapper}>
+      <div className={styles.title}>{t('explore.metrics-explorer.title-metrics', 'Metrics')}</div>
+      <FilterInput
+        value={searchTerm}
+        onChange={setSearchTerm}
+        escapeRegex={false}
+        placeholder={t('explore.metrics-explorer.search-placeholder', 'Search metrics')}
+      />
+      <ScrollContainer>
+        <ul className={styles.list}>
+          {filteredMetrics.map((metric) => (
+            <li key={metric} className={styles.listItem} title={metric}>
+              {metric}
+            </li>
+          ))}
+        </ul>
+      </ScrollContainer>
+    </div>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => {
+  return {
+    wrapper: css({
+      label: 'metrics-explorer',
+      display: 'flex',
+      flexDirection: 'column',
+      flex: '1 1 auto',
+      minHeight: 0,
+      gap: theme.spacing(1),
+      padding: theme.spacing(0.5, 1, 1, 1),
+    }),
+    title: css({
+      fontSize: theme.typography.body.fontSize,
+      fontWeight: theme.typography.fontWeightMedium,
+      color: theme.colors.text.secondary,
+    }),
+    list: css({
+      listStyle: 'none',
+      margin: 0,
+      padding: 0,
+    }),
+    listItem: css({
+      display: 'block',
+      padding: theme.spacing(0.5, 0.5),
+      borderRadius: theme.shape.radius.default,
+      color: theme.colors.text.secondary,
+      fontSize: theme.typography.bodySmall.fontSize,
+      fontFamily: theme.typography.fontFamilyMonospace,
+      whiteSpace: 'nowrap',
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      cursor: 'pointer',
+      '&:hover': {
+        backgroundColor: theme.colors.background.secondary,
+        color: theme.colors.text.primary,
+      },
+    }),
+  };
+};

--- a/public/app/features/explore/Explore.test.tsx
+++ b/public/app/features/explore/Explore.test.tsx
@@ -254,6 +254,16 @@ describe('Explore', () => {
       expect(showContentOutlineButton).not.toBeInTheDocument();
       getBoolMock.mockRestore();
     });
+
+    it('renders without error when a Mixed datasource contains a Prometheus query', async () => {
+      setup({
+        datasourceInstance: { meta: { mixed: true, metrics: true } } as DataSourceApi,
+        queries: [{ refId: 'A', datasource: { type: 'prometheus', uid: 'prom-uid' } }],
+      });
+
+      await screen.findByTestId(selectors.components.DataSourcePicker.container);
+      expect(screen.getByRole('button', { name: 'Collapse outline' })).toBeInTheDocument();
+    });
   });
 
   describe('Saved Queries Integration', () => {

--- a/public/app/features/explore/Explore.test.tsx
+++ b/public/app/features/explore/Explore.test.tsx
@@ -1,5 +1,5 @@
 import { OpenFeatureProvider } from '@openfeature/react-sdk';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import { type Props as AutoSizerProps } from 'react-virtualized-auto-sizer';
 import { TestProvider } from 'test/helpers/TestProvider';
 
@@ -14,7 +14,7 @@ import {
 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { usePluginLinks } from '@grafana/runtime';
-import { getTestFeatureFlagClient } from '@grafana/test-utils/unstable';
+import { getTestFeatureFlagClient, setTestFlags } from '@grafana/test-utils/unstable';
 import { configureStore } from 'app/store/configureStore';
 
 import { ContentOutlineContextProvider } from './ContentOutline/ContentOutlineContext';
@@ -247,6 +247,12 @@ describe('Explore', () => {
   });
 
   describe('Content Outline', () => {
+    afterEach(() => {
+      act(() => {
+        setTestFlags({});
+      });
+    });
+
     it('should retrieve the last visible state from local storage', async () => {
       const getBoolMock = jest.spyOn(store, 'getBool').mockReturnValue(false);
       setup();
@@ -255,14 +261,25 @@ describe('Explore', () => {
       getBoolMock.mockRestore();
     });
 
-    it('detects a managed Prometheus flavor query in a Mixed datasource', async () => {
+    it('shows the metrics explorer when a Mixed datasource contains a managed Prometheus flavor query', async () => {
+      setTestFlags({ 'grafana.exploreMetricsSidebar': true });
       setup({
         datasourceInstance: { meta: { mixed: true, metrics: true } } as DataSourceApi,
         queries: [{ refId: 'A', datasource: { type: 'grafana-amazonprometheus-datasource', uid: 'amp-uid' } }],
       });
 
+      expect(await screen.findByPlaceholderText('Search metrics')).toBeInTheDocument();
+    });
+
+    it('does not show the metrics explorer for a non-Prometheus Mixed datasource query', async () => {
+      setTestFlags({ 'grafana.exploreMetricsSidebar': true });
+      setup({
+        datasourceInstance: { meta: { mixed: true, metrics: true } } as DataSourceApi,
+        queries: [{ refId: 'A', datasource: { type: 'loki', uid: 'loki-uid' } }],
+      });
+
       await screen.findByTestId(selectors.components.DataSourcePicker.container);
-      expect(screen.getByRole('button', { name: 'Collapse outline' })).toBeInTheDocument();
+      expect(screen.queryByPlaceholderText('Search metrics')).not.toBeInTheDocument();
     });
   });
 

--- a/public/app/features/explore/Explore.test.tsx
+++ b/public/app/features/explore/Explore.test.tsx
@@ -255,10 +255,10 @@ describe('Explore', () => {
       getBoolMock.mockRestore();
     });
 
-    it('renders without error when a Mixed datasource contains a Prometheus query', async () => {
+    it('detects a managed Prometheus flavor query in a Mixed datasource', async () => {
       setup({
         datasourceInstance: { meta: { mixed: true, metrics: true } } as DataSourceApi,
-        queries: [{ refId: 'A', datasource: { type: 'prometheus', uid: 'prom-uid' } }],
+        queries: [{ refId: 'A', datasource: { type: 'grafana-amazonprometheus-datasource', uid: 'amp-uid' } }],
       });
 
       await screen.findByTestId(selectors.components.DataSourcePicker.container);

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -601,7 +601,9 @@ export class Explore extends PureComponent<Props, ExploreState> {
     const { contentOutlineVisible } = this.state;
     const styles = getStyles(theme);
     const isPrometheusSelected = datasourceInstance?.meta.mixed
-      ? this.props.queries.some((q) => q.datasource?.type === 'prometheus')
+      ? this.props.queries.some(
+          (q) => q.datasource?.type != null && matchPluginId('prometheus', { id: q.datasource.type })
+        )
       : !!datasourceInstance && matchPluginId('prometheus', datasourceInstance.meta);
     const showPanels = queryResponse && queryResponse.state !== LoadingState.NotStarted;
     const showNoData =

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -12,6 +12,7 @@ import {
   type GrafanaTheme2,
   hasToggleableQueryFiltersSupport,
   LoadingState,
+  matchPluginId,
   type QueryFixAction,
   type RawTimeRange,
   type SplitOpenOptions,
@@ -599,6 +600,9 @@ export class Explore extends PureComponent<Props, ExploreState> {
     } = this.props;
     const { contentOutlineVisible } = this.state;
     const styles = getStyles(theme);
+    const isPrometheusSelected = datasourceInstance?.meta.mixed
+      ? this.props.queries.some((q) => q.datasource?.type === 'prometheus')
+      : !!datasourceInstance && matchPluginId('prometheus', datasourceInstance.meta);
     const showPanels = queryResponse && queryResponse.state !== LoadingState.NotStarted;
     const showNoData =
       queryResponse.state === LoadingState.Done &&
@@ -686,7 +690,11 @@ export class Explore extends PureComponent<Props, ExploreState> {
         >
           <div className={styles.wrapper}>
             {contentOutlineVisible && !compact && (
-              <ContentOutline scroller={this.scrollElement} panelId={`content-outline-container-${exploreId}`} />
+              <ContentOutline
+                scroller={this.scrollElement}
+                panelId={`content-outline-container-${exploreId}`}
+                showMetricsExplorer={isPrometheusSelected}
+              />
             )}
             <ScrollContainer
               data-testid={selectors.pages.Explore.General.scrollView}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -8424,7 +8424,6 @@
     },
     "content-outline": {
       "title-datasource-explorer": "Datasource explorer",
-      "title-outline": "Outline",
       "tooltip-collapse-outline": "Collapse outline",
       "tooltip-expand-outline": "Expand outline"
     },

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -8423,6 +8423,8 @@
       "open-in-new-tab": "Open in new tab"
     },
     "content-outline": {
+      "title-datasource-explorer": "Datasource explorer",
+      "title-outline": "Outline",
       "tooltip-collapse-outline": "Collapse outline",
       "tooltip-expand-outline": "Expand outline"
     },
@@ -8645,6 +8647,10 @@
     },
     "logs-volumne-panel-list": {
       "body-no-logs-volume-available": "No volume information available for the current queries and time range."
+    },
+    "metrics-explorer": {
+      "search-placeholder": "Search metrics",
+      "title-metrics": "Metrics"
     },
     "next-prev-result": {
       "aria-label-next": "Next result button",


### PR DESCRIPTION
## Description
Adds a Metrics Explorer panel to the Explore content outline sidebar. When a Prometheus datasource is selected (or a Prometheus query exists in a Mixed datasource), the sidebar surfaces a "Datasource explorer" view with a metric search and metric list, while the existing outline (Queries, Graph, Table, Logs, etc.) is pushed to the bottom. The whole feature is gated behind the `grafana.exploreMetricsSidebar` feature toggle. The metric list is currently a static stub (no datasource fetching yet).

## Changes
* Add `MetricsExplorer` component: "Metrics" subtitle, search input (`FilterInput`), and a client-side filtered stub list of Prometheus metric names.
* Gate the Metrics Explorer behind `grafana.exploreMetricsSidebar` using `useBooleanFlagValue` (non-suspending options so the sidebar renders immediately with the default).
* Restructure `ContentOutline` into a flex column: header row (title + collapse/expand toggle), Metrics Explorer on top, existing outline items stuck to the bottom.
* Title switches from "Outline" to "Datasource explorer" when the Metrics Explorer is active.
* Detect Prometheus in `Explore` via `matchPluginId('prometheus', datasourceInstance.meta)` (fork-aware, covers Amazon/Azure managed Prometheus) for the selected datasource, and a `type === 'prometheus'` check across queries for Mixed mode.
* Permanently widen the expanded outline sidebar to 300px and replace the outline `ScrollContainer` with a scrollable container.
* Add i18n strings and update `ContentOutline` unit test to mock the OpenFeature hook.

## Risks
Low. The Metrics Explorer itself is behind the `grafana.exploreMetricsSidebar` toggle (default off) and does not fetch data. The main thing to be aware of is the outline sidebar layout/width change (see reviewer note below). Most likely area to regress: Explore content outline rendering/scrolling.

## Testing Instructions
* Enable the `grafana.exploreMetricsSidebar` feature toggle.
* Open Explore and select a Prometheus (or Amazon/Azure managed Prometheus) datasource.
* Confirm the sidebar shows "Datasource explorer" with a "Metrics" subtitle, a search input, and the stub metric list; typing filters the list; the outline (Queries, Graph, etc.) is pushed to the bottom.
* Switch to a non-Prometheus datasource and confirm the Metrics Explorer disappears and the outline behaves as before.
* In Mixed mode, add a Prometheus query and confirm the Metrics Explorer appears.
* With the toggle off, confirm no Metrics Explorer is shown.

## Reviewer Checklist
- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable

## Note for reviewers
Heads-up on scope: the feature toggle only gates the Metrics Explorer panel and the "Datasource explorer" title. A few structural changes to the content outline currently ship to all Explore users regardless of the toggle — the permanent 300px width (intentional per product ask), the always-visible "Outline" header title, and swapping the outline `ScrollContainer` for a plain scrollable div (which loses the keyboard-focusable scroll region). Please confirm this is acceptable, or let me know and I'll gate the header/layout changes behind the toggle too so the flag-off experience stays byte-for-byte unchanged.

Closes DPRO-216