### PR TITLE
PublicDashboards: Remove Graphite target from sanitized queries

### DIFF
--- a/pkg/services/publicdashboards/internal/service/query.go
+++ b/pkg/services/publicdashboards/internal/service/query.go
@@ -459,6 +459,10 @@ func sanitizeData(data *simplejson.Json) {
 			target.Del("expr")
 			target.Del("query")
 			target.Del("rawSql")
+			// Graphite stores its query text in target/targetFull rather than
+			// the fields above, so both must be removed to avoid leaking it.
+			target.Del("target")
+			target.Del("targetFull")
 		}
 	}
 }
@@ -475,6 +479,8 @@ func sanitizeDataV2(data *simplejson.Json) {
 			dataQuerySpec.Del("expr")
 			dataQuerySpec.Del("query")
 			dataQuerySpec.Del("rawSql")
+			dataQuerySpec.Del("target")
+			dataQuerySpec.Del("targetFull")
 		}
 	}
 }

--- a/pkg/services/publicdashboards/internal/service/query_test.go
+++ b/pkg/services/publicdashboards/internal/service/query_test.go
@@ -1391,6 +1391,85 @@ func buildJsonDataWithTimeRange(from, to, timezone string) *simplejson.Json {
 	})
 }
 
+func TestSanitizeData(t *testing.T) {
+	t.Run("removes query expression fields from panel targets", func(t *testing.T) {
+		data := simplejson.NewFromAny(map[string]interface{}{
+			"panels": []interface{}{
+				map[string]interface{}{
+					"targets": []interface{}{
+						map[string]interface{}{
+							"expr":       "go_goroutines{job=\"grafana\"}",
+							"refId":      "A",
+							"datasource": "prometheus",
+						},
+						map[string]interface{}{
+							"rawSql": "SELECT * FROM metrics",
+							"refId":  "B",
+						},
+						map[string]interface{}{
+							"target":     "aliasByNode(stats.gauges.*, 1)",
+							"targetFull": "aliasByNode(stats.gauges.production, 1)",
+							"refId":      "C",
+						},
+					},
+				},
+			},
+		})
+
+		sanitizeData(data)
+
+		targets := simplejson.NewFromAny(data.Get("panels").MustArray()[0]).Get("targets").MustArray()
+		require.Len(t, targets, 3)
+
+		prometheus := simplejson.NewFromAny(targets[0])
+		assert.Empty(t, prometheus.Get("expr").MustString())
+		assert.Equal(t, "A", prometheus.Get("refId").MustString())
+		assert.Equal(t, "prometheus", prometheus.Get("datasource").MustString())
+
+		sql := simplejson.NewFromAny(targets[1])
+		assert.Empty(t, sql.Get("rawSql").MustString())
+		assert.Equal(t, "B", sql.Get("refId").MustString())
+
+		graphite := simplejson.NewFromAny(targets[2])
+		assert.Empty(t, graphite.Get("target").MustString())
+		assert.Empty(t, graphite.Get("targetFull").MustString())
+		assert.Equal(t, "C", graphite.Get("refId").MustString())
+	})
+
+	t.Run("removes query expression fields from collapsed row panels", func(t *testing.T) {
+		data := simplejson.NewFromAny(map[string]interface{}{
+			"panels": []interface{}{
+				map[string]interface{}{
+					"type":      "row",
+					"collapsed": true,
+					"panels": []interface{}{
+						map[string]interface{}{
+							"targets": []interface{}{
+								map[string]interface{}{
+									"target": "sumSeries(stats.counters.*.count)",
+									"refId":  "A",
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+
+		sanitizeData(data)
+
+		row := simplejson.NewFromAny(data.Get("panels").MustArray()[0])
+		innerTargets := simplejson.NewFromAny(row.Get("panels").MustArray()[0]).Get("targets").MustArray()
+		require.Len(t, innerTargets, 1)
+		assert.Empty(t, simplejson.NewFromAny(innerTargets[0]).Get("target").MustString())
+	})
+
+	t.Run("does not panic when panels key is missing", func(t *testing.T) {
+		data := simplejson.NewFromAny(map[string]interface{}{})
+		require.NotPanics(t, func() { sanitizeData(data) })
+	})
+}
+
 func TestSanitizeDataV2(t *testing.T) {
 	t.Run("removes expr, query, rawSql from query specs", func(t *testing.T) {
 		data := simplejson.NewFromAny(map[string]interface{}{
@@ -1474,6 +1553,44 @@ func TestSanitizeDataV2(t *testing.T) {
 		q3spec := simplejson.NewFromAny(panel2Queries[0]).Get("spec").Get("query").Get("spec")
 		assert.Empty(t, q3spec.Get("query").MustString())
 		assert.Equal(t, "A", q3spec.Get("refId").MustString())
+	})
+
+	t.Run("removes target and targetFull from query specs", func(t *testing.T) {
+		data := simplejson.NewFromAny(map[string]interface{}{
+			"elements": map[string]interface{}{
+				"panel-1": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"data": map[string]interface{}{
+							"spec": map[string]interface{}{
+								"queries": []interface{}{
+									map[string]interface{}{
+										"spec": map[string]interface{}{
+											"query": map[string]interface{}{
+												"spec": map[string]interface{}{
+													"target":     "aliasByNode(stats.gauges.*, 1)",
+													"targetFull": "aliasByNode(stats.gauges.production, 1)",
+													"refId":      "A",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+
+		sanitizeDataV2(data)
+
+		queries := simplejson.NewFromAny(data.Get("elements").MustMap()["panel-1"]).
+			Get("spec").Get("data").Get("spec").Get("queries").MustArray()
+		require.Len(t, queries, 1)
+		qspec := simplejson.NewFromAny(queries[0]).Get("spec").Get("query").Get("spec")
+		assert.Empty(t, qspec.Get("target").MustString())
+		assert.Empty(t, qspec.Get("targetFull").MustString())
+		assert.Equal(t, "A", qspec.Get("refId").MustString())
 	})
 
 	t.Run("does not panic when queries key is missing", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Public dashboard query sanitization stripped `expr`, `query`, and `rawSql` from panel targets but not Graphite's `target`/`targetFull` fields, so raw Graphite queries were served to unauthenticated public-dashboard viewers. This removes both fields at each sanitization call site.

## Root cause

`sanitizeData` and `sanitizeDataV2` in `pkg/services/publicdashboards/internal/service/query.go` delete a fixed set of query-text fields from each panel target: `expr` (Prometheus/Loki), `query` (InfluxDB and others), and `rawSql` (SQL datasources). Graphite does not use any of those. A Graphite query's text lives in `target` (`GraphiteQuery.target`), with an interpolated copy in `targetFull`. Because neither field was removed, the raw Graphite query string stayed in the dashboard data used to build public dashboard requests, which is reachable by unauthenticated viewers.

For clarity on a related field: InfluxDB's `rawQuery` is a boolean that toggles the raw editor mode, not a query-text field. InfluxDB stores its query text in `query`, which was already stripped, so the gap is specific to Graphite's `target`/`targetFull`.

## Fix

Add `target.Del("target")` and `target.Del("targetFull")` to the v1 target loop in `sanitizeData`, and the equivalent on `dataQuerySpec` in `sanitizeDataV2`. This matches the existing deletion approach rather than introducing a datasource lookup, keeping the change consistent with the surrounding code and covering both dashboard schema versions.

## Test plan

Added `TestSanitizeData` (v1) covering panel targets, collapsed-row panels, and a missing-`panels` guard, plus a `target`/`targetFull` subtest to `TestSanitizeDataV2`. The v1 test fails on the base branch (leaks `aliasByNode(stats.gauges.*, 1)`) and passes with the fix.

```
go test -run 'TestSanitizeData$|TestSanitizeDataV2$' ./pkg/services/publicdashboards/internal/service/
ok  	github.com/grafana/grafana/pkg/services/publicdashboards/internal/service	9.042s
```

Full package suite, gofmt, and go vet are clean:

```
go test ./pkg/services/publicdashboards/internal/service/
ok  	github.com/grafana/grafana/pkg/services/publicdashboards/internal/service	5.727s
```

Refs #123673. This covers Graphite `target`/`targetFull`. If other datasources store query text under field names outside `{expr, query, rawSql, target, targetFull}`, those would need the same treatment; I did not find additional ones in the built-in datasource query types.
