### PR TITLE
ShortURL: Return absolute /goto redirect URL built from root_url

### DIFF
--- a/apps/shorturl/pkg/app/app.go
+++ b/apps/shorturl/pkg/app/app.go
@@ -21,6 +21,14 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 )
 
+// Config carries the app-specific configuration for the shorturl app.
+type Config struct {
+	// AppURL is Grafana's configured root URL (root_url), including any subpath
+	// configured via serve_from_sub_path. It is used to build absolute redirect
+	// URLs for the goto subresource so the redirect preserves the subpath.
+	AppURL string
+}
+
 func New(cfg app.Config) (app.App, error) {
 	cfg.KubeConfig.APIPath = "apis"
 	tmp, err := k8s.NewClientRegistry(cfg.KubeConfig, k8s.DefaultClientConfig()).
@@ -29,6 +37,15 @@ func New(cfg app.Config) (app.App, error) {
 		return nil, fmt.Errorf("unable to create client")
 	}
 	client := shorturlv1beta1.NewShortURLClient(tmp)
+
+	// Grafana's configured root URL. When the app runs in-process this is the
+	// authoritative base for redirects; it includes the subpath. We derive the
+	// base from the request path only as a fallback (e.g. standalone deployments
+	// where SpecificConfig is not provided).
+	var configuredAppURL string
+	if specificConfig, ok := cfg.SpecificConfig.(*Config); ok && specificConfig != nil {
+		configuredAppURL = strings.TrimSuffix(specificConfig.AppURL, "/")
+	}
 
 	simpleConfig := simple.AppConfig{
 		Name:       "shorturl",
@@ -59,9 +76,9 @@ func New(cfg app.Config) (app.App, error) {
 						Method: "GET",
 						Path:   "goto",
 					}: func(ctx context.Context, w app.CustomRouteResponseWriter, req *app.CustomRouteRequest) error {
-						appURL, _, found := strings.Cut(req.URL.Path, "/apis/") // This will be settings.AppURL
-						if !found {
-							return fmt.Errorf("unable to parse request URL")
+						appURL, err := resolveAppURL(configuredAppURL, req.URL.Path)
+						if err != nil {
+							return err
 						}
 						id := resource.Identifier{
 							Namespace: req.ResourceIdentifier.Namespace,
@@ -120,6 +137,25 @@ func New(cfg app.Config) (app.App, error) {
 	}
 
 	return a, nil
+}
+
+// resolveAppURL returns the base URL used to build short URL redirects.
+//
+// It prefers Grafana's configured root URL (which includes any subpath from
+// serve_from_sub_path) so the redirect preserves the subpath. The request path
+// is only a fallback for deployments where the configured URL is unavailable:
+// for the in-process loopback call the path is "/apis/..." with the subpath
+// already stripped, so relying on it there would drop the subpath from the
+// redirect Location.
+func resolveAppURL(configuredAppURL, requestPath string) (string, error) {
+	if configuredAppURL != "" {
+		return configuredAppURL, nil
+	}
+	base, _, found := strings.Cut(requestPath, "/apis/")
+	if !found {
+		return "", fmt.Errorf("unable to parse request URL")
+	}
+	return base, nil
 }
 
 func GetKinds() map[schema.GroupVersion][]resource.Kind {

--- a/apps/shorturl/pkg/app/app_test.go
+++ b/apps/shorturl/pkg/app/app_test.go
@@ -1,0 +1,60 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveAppURL(t *testing.T) {
+	// The in-process loopback client calls the goto subresource with a request
+	// path that has the configured subpath already stripped, e.g.
+	// "/apis/shorturl.grafana.app/v1beta1/namespaces/org-3/shorturls/abc/goto".
+	const loopbackPath = "/apis/shorturl.grafana.app/v1beta1/namespaces/org-3/shorturls/abc/goto"
+
+	tests := []struct {
+		name             string
+		configuredAppURL string
+		requestPath      string
+		want             string
+		wantErr          bool
+	}{
+		{
+			name:             "configured root URL with subpath is preserved",
+			configuredAppURL: "https://fqdn/grafana",
+			requestPath:      loopbackPath,
+			want:             "https://fqdn/grafana",
+		},
+		{
+			name:             "configured root URL without subpath",
+			configuredAppURL: "http://localhost:3000",
+			requestPath:      loopbackPath,
+			want:             "http://localhost:3000",
+		},
+		{
+			name:             "falls back to request path when not configured",
+			configuredAppURL: "",
+			requestPath:      "/grafana" + loopbackPath,
+			want:             "/grafana",
+		},
+		{
+			name:             "fallback errors when request path has no apis segment",
+			configuredAppURL: "",
+			requestPath:      "/not-an-api-path",
+			wantErr:          true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveAppURL(tt.configuredAppURL, tt.requestPath)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/registry/apps/shorturl/register.go
+++ b/pkg/registry/apps/shorturl/register.go
@@ -42,11 +42,15 @@ func RegisterAppInstaller(
 		service:    service,
 		namespacer: request.GetNamespaceMapper(cfg),
 	}
-	provider := simple.NewAppProvider(apis.LocalManifest(), nil, shorturlapp.New)
+	specificConfig := &shorturlapp.Config{
+		AppURL: cfg.AppURL,
+	}
+	provider := simple.NewAppProvider(apis.LocalManifest(), specificConfig, shorturlapp.New)
 
 	appCfg := app.Config{
-		KubeConfig:   restclient.Config{}, // this will be overridden by the installer's InitializeApp method
-		ManifestData: *apis.LocalManifest().ManifestData,
+		KubeConfig:     restclient.Config{}, // this will be overridden by the installer's InitializeApp method
+		ManifestData:   *apis.LocalManifest().ManifestData,
+		SpecificConfig: specificConfig,
 	}
 	i, err := appsdkapiserver.NewDefaultAppInstaller(provider, appCfg, &apis.GoTypeAssociator{})
 	if err != nil {

--- a/pkg/tests/api/shorturl/short_url_test.go
+++ b/pkg/tests/api/shorturl/short_url_test.go
@@ -73,7 +73,7 @@ func TestShortURL(t *testing.T) {
 	defer func() {
 		_ = res.Body.Close()
 	}()
-	assert.Equal(t, "/explore", res.Header.Get("Location"))
+	assert.Equal(t, "http://localhost:3000/explore", res.Header.Get("Location"))
 	assert.Equal(t, http.StatusFound, res.StatusCode)
 
 	// If the go-to does not exist, it should redirect to the home page and return 308.


### PR DESCRIPTION
## What is this feature?

Short URL redirects (`/goto/:uid`) now return an **absolute** URL built from the configured `root_url`, instead of a root-relative path that dropped the host and subpath.

The redirect was migrated to the App Platform (`shorturl.grafana.app/v1beta1`), where the `goto` handler derived its base URL from the request path (`strings.Cut(req.URL.Path, "/apis/")`). That handler runs over an in-process loopback client, so the path is always the bare `/apis/...` and the base resolved to empty — producing `Location: /explore?...` with host and subpath stripped. This injects the configured `AppURL` via `SpecificConfig` and uses it as the base, restoring the pre-migration behavior.

## Why do we need this feature?

Affects short links shared from **Dashboards and Explore**. When `root_url` has a subpath and Grafana sits behind a reverse proxy that only routes that subpath, the browser resolves the old `/goto` redirect to a subpath-less URL the proxy can't route (404). On a direct setup it was masked by the `SubPathRedirect` middleware, which is why it only surfaced behind the proxy. Stored `spec.path` stays relative, so existing short URLs are fixed retroactively — no migration needed.

## Special notes for your reviewer

- `Location` changes from root-relative to absolute (scheme + host + subpath), matching pre-migration behavior. The open-redirect check in `pkg/api/short_url.go` still enforces same-host, and `spec.path` remains validated-relative.
- Backend-only.
- Verified manually on an HTTPS + subpath instance: `/goto/:uid` `Location` goes from `/explore?...` to `https://host/grafana/explore?...`.

Related escalation: https://github.com/grafana/support-escalations/issues/23347

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
