### PR TITLE
IAM: Add retry on concurrent add/remove team member requests

### DIFF
--- a/pkg/registry/apis/iam/team/rest_add_member.go
+++ b/pkg/registry/apis/iam/team/rest_add_member.go
@@ -12,6 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/rest"
+	"k8s.io/client-go/util/retry"
 
 	iamv0alpha1 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
 	iamv0 "github.com/grafana/grafana/pkg/apis/iam/v0alpha1"
@@ -22,8 +23,9 @@ import (
 // helper that turns a single-user request into a Spec.Members write,
 // routed through the team resource's dual-writer storage.
 //
-// Concurrency: single Get + Update, no in-handler retry. RV mismatch
-// surfaces as 409; callers refresh and retry.
+// Concurrency: read-modify-write on Spec.Members wrapped in
+// RetryOnConflict so concurrent add-member requests re-read the latest
+// team and re-apply the member add instead of failing each other.
 type TeamAddMemberREST struct {
 	getter  rest.Getter
 	updater rest.Updater
@@ -109,63 +111,71 @@ func (s *TeamAddMemberREST) Connect(ctx context.Context, name string, _ runtime.
 		// dual-writer Get/Update can resolve it.
 		nsCtx := common.WithSubresourceNamespace(ctx)
 
-		obj, err := s.getter.Get(nsCtx, name, &metav1.GetOptions{})
-		if err != nil {
-			responder.Error(err)
-			return
-		}
-		t, ok := obj.(*iamv0alpha1.Team)
-		if !ok {
-			responder.Error(apierrors.NewInternalError(fmt.Errorf("team store returned unexpected type %T", obj)))
-			return
-		}
 		var (
 			resultingPerm     iamv0alpha1.TeamTeamPermission
 			resultingExternal bool
-			needUpdate        bool
+			alreadyMember     bool
 		)
-		foundIdx := -1
-		for i, m := range t.Spec.Members {
-			if m.Kind == "User" && m.Name == body.Name {
-				foundIdx = i
-				break
+		// Refresh and retry on conflict: concurrent adds race on the team's
+		// resource version and would otherwise reject each other.
+		retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			obj, err := s.getter.Get(nsCtx, name, &metav1.GetOptions{})
+			if err != nil {
+				return err
 			}
-		}
-		alreadyMember := foundIdx >= 0
-		if alreadyMember {
-			// Re-add: update Permission, but leave External untouched —
-			// External records the membership origin (IdP sync vs manual)
-			// and isn't a state /addmember flips.
-			existing := t.Spec.Members[foundIdx]
-			resultingPerm = permStr
-			resultingExternal = existing.External
-			if existing.Permission != permStr {
-				t.Spec.Members[foundIdx].Permission = permStr
+			t, ok := obj.(*iamv0alpha1.Team)
+			if !ok {
+				return apierrors.NewInternalError(fmt.Errorf("team store returned unexpected type %T", obj))
+			}
+			needUpdate := false
+			foundIdx := -1
+			for i, m := range t.Spec.Members {
+				if m.Kind == "User" && m.Name == body.Name {
+					foundIdx = i
+					break
+				}
+			}
+			alreadyMember = foundIdx >= 0
+			if alreadyMember {
+				// Re-add: update Permission, but leave External untouched —
+				// External records the membership origin (IdP sync vs manual)
+				// and isn't a state /addmember flips.
+				existing := t.Spec.Members[foundIdx]
+				resultingPerm = permStr
+				resultingExternal = existing.External
+				if existing.Permission != permStr {
+					t.Spec.Members[foundIdx].Permission = permStr
+					needUpdate = true
+				}
+			} else {
+				resultingPerm = permStr
+				resultingExternal = external
+				t.Spec.Members = append(t.Spec.Members, iamv0alpha1.TeamTeamMember{
+					Kind:       "User",
+					Name:       body.Name,
+					Permission: permStr,
+					External:   external,
+				})
 				needUpdate = true
 			}
-		} else {
-			resultingPerm = permStr
-			resultingExternal = external
-			t.Spec.Members = append(t.Spec.Members, iamv0alpha1.TeamTeamMember{
-				Kind:       "User",
-				Name:       body.Name,
-				Permission: permStr,
-				External:   external,
-			})
-			needUpdate = true
-		}
-		if needUpdate {
-			// 409 surfaces unchanged; SQL deadlocks (which arrive as 500
-			// from unified storage) are converted so RetryOnConflict catches them.
+			if !needUpdate {
+				return nil
+			}
 			if _, _, err := s.updater.Update(nsCtx, name, rest.DefaultUpdatedObjectInfo(t),
 				nil, nil, false, &metav1.UpdateOptions{}); err != nil {
+				// RV mismatches are already 409s RetryOnConflict retries;
+				// SQL deadlocks arrive as a rolled-back 500, so surface them
+				// as conflicts to retry too.
 				if isRetryableTxnError(err) {
-					responder.Error(apierrors.NewConflict(teamResource.GroupResource(), name, err))
-					return
+					return apierrors.NewConflict(teamResource.GroupResource(), name, err)
 				}
-				responder.Error(err)
-				return
+				return err
 			}
+			return nil
+		})
+		if retryErr != nil {
+			responder.Error(retryErr)
+			return
 		}
 
 		// 201 on fresh insert, 200 on idempotent re-add or permission update.

--- a/pkg/registry/apis/iam/team/rest_add_member_test.go
+++ b/pkg/registry/apis/iam/team/rest_add_member_test.go
@@ -15,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/rest"
+	"k8s.io/client-go/util/retry"
 
 	iamv0alpha1 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
@@ -126,6 +127,32 @@ func TestTeamAddMemberREST_RetriesOnConflict(t *testing.T) {
 		require.Equal(t, http.StatusCreated, responder.code)
 		require.Len(t, store.team.Spec.Members, 1)
 		require.Equal(t, "user1", store.team.Spec.Members[0].Name)
+	})
+
+	t.Run("surfaces the conflict when retries are exhausted", func(t *testing.T) {
+		conflict := func() error {
+			return apierrors.NewConflict(teamResource.GroupResource(), "team1", fmt.Errorf("rv mismatch"))
+		}
+		errs := make([]error, 0, retry.DefaultRetry.Steps)
+		for range retry.DefaultRetry.Steps {
+			errs = append(errs, conflict())
+		}
+		store := &scriptedStore{
+			team: &iamv0alpha1.Team{
+				ObjectMeta: metav1.ObjectMeta{Name: "team1", Namespace: "default", ResourceVersion: "1"},
+				Spec:       iamv0alpha1.TeamSpec{Title: "t"},
+			},
+			updateErrs: errs,
+		}
+		handler := NewTeamAddMemberREST(store, tracing.NewNoopTracerService())
+
+		responder := addMemberRequest(t, handler, "team1", "user1", "member")
+
+		require.True(t, responder.called)
+		require.Error(t, responder.err)
+		require.True(t, apierrors.IsConflict(responder.err), "exhausted retries must surface the conflict")
+		require.Equal(t, retry.DefaultRetry.Steps, store.calls, "handler must retry exactly Steps times before giving up")
+		require.Empty(t, store.team.Spec.Members)
 	})
 
 	t.Run("retries a rolled-back SQL deadlock then persists", func(t *testing.T) {

--- a/pkg/registry/apis/iam/team/rest_add_member_test.go
+++ b/pkg/registry/apis/iam/team/rest_add_member_test.go
@@ -1,0 +1,270 @@
+package team
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/registry/rest"
+
+	iamv0alpha1 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/infra/tracing"
+)
+
+// rvStore is an in-memory team store that enforces resource-version based
+// optimistic concurrency, mirroring how unified storage rejects a write
+// whose object was read at a stale RV. It is safe for concurrent use.
+type rvStore struct {
+	mu   sync.Mutex
+	team *iamv0alpha1.Team
+}
+
+func (s *rvStore) New() runtime.Object { return &iamv0alpha1.Team{} }
+func (s *rvStore) Destroy()            {}
+
+func (s *rvStore) Get(_ context.Context, _ string, _ *metav1.GetOptions) (runtime.Object, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.team.DeepCopy(), nil
+}
+
+func (s *rvStore) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, _ rest.ValidateObjectFunc, _ rest.ValidateObjectUpdateFunc, _ bool, _ *metav1.UpdateOptions) (runtime.Object, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	newObj, err := objInfo.UpdatedObject(ctx, s.team.DeepCopy())
+	if err != nil {
+		return nil, false, err
+	}
+	nt := newObj.(*iamv0alpha1.Team)
+	if nt.ResourceVersion != s.team.ResourceVersion {
+		return nil, false, apierrors.NewConflict(teamResource.GroupResource(), name,
+			fmt.Errorf("resource version %q does not match %q", nt.ResourceVersion, s.team.ResourceVersion))
+	}
+	stored := nt.DeepCopy()
+	rv, _ := strconv.Atoi(s.team.ResourceVersion)
+	stored.ResourceVersion = strconv.Itoa(rv + 1)
+	s.team = stored
+	return stored, false, nil
+}
+
+// scriptedStore returns a canned error on the first len(updateErrs) Update
+// calls, then applies the write. Used to exercise the retry path
+// deterministically.
+type scriptedStore struct {
+	mu         sync.Mutex
+	team       *iamv0alpha1.Team
+	updateErrs []error
+	calls      int
+}
+
+func (s *scriptedStore) New() runtime.Object { return &iamv0alpha1.Team{} }
+func (s *scriptedStore) Destroy()            {}
+
+func (s *scriptedStore) Get(_ context.Context, _ string, _ *metav1.GetOptions) (runtime.Object, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.team.DeepCopy(), nil
+}
+
+func (s *scriptedStore) Update(ctx context.Context, _ string, objInfo rest.UpdatedObjectInfo, _ rest.ValidateObjectFunc, _ rest.ValidateObjectUpdateFunc, _ bool, _ *metav1.UpdateOptions) (runtime.Object, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.calls < len(s.updateErrs) {
+		err := s.updateErrs[s.calls]
+		s.calls++
+		return nil, false, err
+	}
+	s.calls++
+	newObj, err := objInfo.UpdatedObject(ctx, s.team.DeepCopy())
+	if err != nil {
+		return nil, false, err
+	}
+	s.team = newObj.(*iamv0alpha1.Team).DeepCopy()
+	return s.team, false, nil
+}
+
+func addMemberRequest(t *testing.T, handler *TeamAddMemberREST, teamName, userUID, permission string) *mockResponder {
+	t.Helper()
+	ctx := identity.WithRequester(context.Background(), &identity.StaticRequester{Namespace: "default"})
+	responder := &mockResponder{}
+	h, err := handler.Connect(ctx, teamName, nil, responder)
+	require.NoError(t, err)
+	body := strings.NewReader(fmt.Sprintf(`{"name":%q,"permission":%q}`, userUID, permission))
+	req := httptest.NewRequest(http.MethodPost, "/addmember", body).WithContext(ctx)
+	h.ServeHTTP(httptest.NewRecorder(), req)
+	return responder
+}
+
+func TestTeamAddMemberREST_RetriesOnConflict(t *testing.T) {
+	t.Run("retries a resource-version conflict then persists", func(t *testing.T) {
+		store := &scriptedStore{
+			team: &iamv0alpha1.Team{
+				ObjectMeta: metav1.ObjectMeta{Name: "team1", Namespace: "default", ResourceVersion: "1"},
+				Spec:       iamv0alpha1.TeamSpec{Title: "t"},
+			},
+			updateErrs: []error{
+				apierrors.NewConflict(teamResource.GroupResource(), "team1", fmt.Errorf("rv mismatch")),
+				apierrors.NewConflict(teamResource.GroupResource(), "team1", fmt.Errorf("rv mismatch")),
+			},
+		}
+		handler := NewTeamAddMemberREST(store, tracing.NewNoopTracerService())
+
+		responder := addMemberRequest(t, handler, "team1", "user1", "member")
+
+		require.True(t, responder.called)
+		require.NoError(t, responder.err)
+		require.Equal(t, http.StatusCreated, responder.code)
+		require.Len(t, store.team.Spec.Members, 1)
+		require.Equal(t, "user1", store.team.Spec.Members[0].Name)
+	})
+
+	t.Run("retries a rolled-back SQL deadlock then persists", func(t *testing.T) {
+		store := &scriptedStore{
+			team: &iamv0alpha1.Team{
+				ObjectMeta: metav1.ObjectMeta{Name: "team1", Namespace: "default", ResourceVersion: "1"},
+				Spec:       iamv0alpha1.TeamSpec{Title: "t"},
+			},
+			// Stringified MySQL deadlock as unified storage would surface it —
+			// a generic 500-shaped error, not an apierrors.Conflict.
+			updateErrs: []error{fmt.Errorf("Exec: Error 1213: Deadlock found when trying to get lock")},
+		}
+		handler := NewTeamAddMemberREST(store, tracing.NewNoopTracerService())
+
+		responder := addMemberRequest(t, handler, "team1", "user1", "admin")
+
+		require.True(t, responder.called)
+		require.NoError(t, responder.err)
+		require.Len(t, store.team.Spec.Members, 1)
+	})
+}
+
+func TestTeamAddMemberREST_Connect(t *testing.T) {
+	newStore := func(members ...iamv0alpha1.TeamTeamMember) *scriptedStore {
+		return &scriptedStore{
+			team: &iamv0alpha1.Team{
+				ObjectMeta: metav1.ObjectMeta{Name: "team1", Namespace: "default", ResourceVersion: "1"},
+				Spec:       iamv0alpha1.TeamSpec{Title: "t", Members: members},
+			},
+		}
+	}
+
+	t.Run("adds a new member and returns 201", func(t *testing.T) {
+		store := newStore()
+		handler := NewTeamAddMemberREST(store, tracing.NewNoopTracerService())
+
+		responder := addMemberRequest(t, handler, "team1", "user1", "member")
+
+		require.NoError(t, responder.err)
+		require.Equal(t, http.StatusCreated, responder.code)
+		require.Equal(t, 1, store.calls)
+		require.Len(t, store.team.Spec.Members, 1)
+	})
+
+	t.Run("idempotent re-add with same permission skips the write and returns 200", func(t *testing.T) {
+		store := newStore(member("user1", "member", false))
+		handler := NewTeamAddMemberREST(store, tracing.NewNoopTracerService())
+
+		responder := addMemberRequest(t, handler, "team1", "user1", "member")
+
+		require.NoError(t, responder.err)
+		require.Equal(t, http.StatusOK, responder.code)
+		require.Equal(t, 0, store.calls, "no Update expected when nothing changes")
+		require.Len(t, store.team.Spec.Members, 1)
+	})
+
+	t.Run("re-add with new permission updates it and returns 200", func(t *testing.T) {
+		store := newStore(member("user1", "member", false))
+		handler := NewTeamAddMemberREST(store, tracing.NewNoopTracerService())
+
+		responder := addMemberRequest(t, handler, "team1", "user1", "admin")
+
+		require.NoError(t, responder.err)
+		require.Equal(t, http.StatusOK, responder.code)
+		require.Equal(t, 1, store.calls)
+		require.Len(t, store.team.Spec.Members, 1)
+		require.Equal(t, iamv0alpha1.TeamTeamPermission("admin"), store.team.Spec.Members[0].Permission)
+	})
+
+	t.Run("non-retryable update error surfaces without retry", func(t *testing.T) {
+		boom := apierrors.NewInternalError(fmt.Errorf("boom"))
+		store := &scriptedStore{
+			team: &iamv0alpha1.Team{
+				ObjectMeta: metav1.ObjectMeta{Name: "team1", Namespace: "default", ResourceVersion: "1"},
+				Spec:       iamv0alpha1.TeamSpec{Title: "t"},
+			},
+			updateErrs: []error{boom},
+		}
+		handler := NewTeamAddMemberREST(store, tracing.NewNoopTracerService())
+
+		responder := addMemberRequest(t, handler, "team1", "user1", "member")
+
+		require.Error(t, responder.err)
+		require.True(t, apierrors.IsInternalError(responder.err))
+		require.Equal(t, 1, store.calls, "non-conflict errors must not be retried")
+	})
+
+	t.Run("rejects an invalid permission with 400", func(t *testing.T) {
+		store := newStore()
+		handler := NewTeamAddMemberREST(store, tracing.NewNoopTracerService())
+
+		responder := addMemberRequest(t, handler, "team1", "user1", "superadmin")
+
+		require.Error(t, responder.err)
+		var se *apierrors.StatusError
+		require.ErrorAs(t, responder.err, &se)
+		require.Equal(t, int32(http.StatusBadRequest), se.ErrStatus.Code)
+		require.Equal(t, 0, store.calls)
+	})
+}
+
+// TestTeamAddMemberREST_ConcurrentAdds reproduces the reported bug: many
+// parallel add-member requests for distinct users racing on the same team's
+// resource version. With the retry loop, every add must persist and none may
+// fail.
+func TestTeamAddMemberREST_ConcurrentAdds(t *testing.T) {
+	store := &rvStore{
+		team: &iamv0alpha1.Team{
+			ObjectMeta: metav1.ObjectMeta{Name: "team1", Namespace: "default", ResourceVersion: "1"},
+			Spec:       iamv0alpha1.TeamSpec{Title: "t"},
+		},
+	}
+	handler := NewTeamAddMemberREST(store, tracing.NewNoopTracerService())
+
+	const n = 10
+	var wg sync.WaitGroup
+	responders := make([]*mockResponder, n)
+	start := make(chan struct{})
+	for i := range n {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			responders[i] = addMemberRequest(t, handler, "team1", fmt.Sprintf("user%d", i), "member")
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	for i, r := range responders {
+		require.Truef(t, r.called, "responder %d not called", i)
+		require.NoErrorf(t, r.err, "add for user%d failed", i)
+	}
+	require.Len(t, store.team.Spec.Members, n, "all concurrent adds must persist")
+	seen := map[string]bool{}
+	for _, m := range store.team.Spec.Members {
+		seen[m.Name] = true
+	}
+	for i := range n {
+		require.Truef(t, seen[fmt.Sprintf("user%d", i)], "user%d was lost", i)
+	}
+}

--- a/pkg/registry/apis/iam/team/rest_remove_member.go
+++ b/pkg/registry/apis/iam/team/rest_remove_member.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/rest"
+	"k8s.io/client-go/util/retry"
 
 	iamv0alpha1 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
 	iamv0 "github.com/grafana/grafana/pkg/apis/iam/v0alpha1"
@@ -22,8 +23,9 @@ import (
 // the team back through the dual-writer storage.
 //
 // Idempotency: removing an already-absent user returns 200 OK.
-// Concurrency: single Get + Update, RV-checked; 409 on race, caller
-// refreshes and re-issues.
+// Concurrency: read-modify-write on Spec.Members wrapped in
+// RetryOnConflict so a concurrent membership change re-reads the latest
+// team and re-applies the removal instead of failing on an RV race.
 type TeamRemoveMemberREST struct {
 	getter  rest.Getter
 	updater rest.Updater
@@ -99,36 +101,44 @@ func (s *TeamRemoveMemberREST) Connect(ctx context.Context, name string, _ runti
 
 		nsCtx := common.WithSubresourceNamespace(ctx)
 
-		obj, err := s.getter.Get(nsCtx, name, &metav1.GetOptions{})
-		if err != nil {
-			responder.Error(err)
-			return
-		}
-		t, ok := obj.(*iamv0alpha1.Team)
-		if !ok {
-			responder.Error(apierrors.NewInternalError(fmt.Errorf("team store returned unexpected type %T", obj)))
-			return
-		}
-		removeIdx := -1
-		for i, m := range t.Spec.Members {
-			if m.Kind == "User" && m.Name == body.Name {
-				removeIdx = i
-				break
+		// Refresh and retry on conflict: a concurrent membership change
+		// races on the team's resource version and would otherwise reject
+		// this removal.
+		retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			obj, err := s.getter.Get(nsCtx, name, &metav1.GetOptions{})
+			if err != nil {
+				return err
 			}
-		}
-		if removeIdx >= 0 {
+			t, ok := obj.(*iamv0alpha1.Team)
+			if !ok {
+				return apierrors.NewInternalError(fmt.Errorf("team store returned unexpected type %T", obj))
+			}
+			removeIdx := -1
+			for i, m := range t.Spec.Members {
+				if m.Kind == "User" && m.Name == body.Name {
+					removeIdx = i
+					break
+				}
+			}
+			if removeIdx < 0 {
+				return nil
+			}
 			t.Spec.Members = append(t.Spec.Members[:removeIdx], t.Spec.Members[removeIdx+1:]...)
-			// 409 surfaces unchanged; SQL deadlocks (which arrive as 500
-			// from unified storage) are converted so RetryOnConflict catches them.
 			if _, _, err := s.updater.Update(nsCtx, name, rest.DefaultUpdatedObjectInfo(t),
 				nil, nil, false, &metav1.UpdateOptions{}); err != nil {
+				// RV mismatches are already 409s RetryOnConflict retries;
+				// SQL deadlocks arrive as a rolled-back 500, so surface them
+				// as conflicts to retry too.
 				if isRetryableTxnError(err) {
-					responder.Error(apierrors.NewConflict(teamResource.GroupResource(), name, err))
-					return
+					return apierrors.NewConflict(teamResource.GroupResource(), name, err)
 				}
-				responder.Error(err)
-				return
+				return err
 			}
+			return nil
+		})
+		if retryErr != nil {
+			responder.Error(retryErr)
+			return
 		}
 
 		// 200 OK whether or not a row existed; the request is idempotent.

--- a/pkg/registry/apis/iam/team/rest_remove_member_test.go
+++ b/pkg/registry/apis/iam/team/rest_remove_member_test.go
@@ -1,0 +1,202 @@
+package team
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
+
+	iamv0alpha1 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/infra/tracing"
+)
+
+func removeMemberRequest(t *testing.T, handler *TeamRemoveMemberREST, teamName, userUID string) *mockResponder {
+	t.Helper()
+	ctx := identity.WithRequester(context.Background(), &identity.StaticRequester{Namespace: "default"})
+	responder := &mockResponder{}
+	h, err := handler.Connect(ctx, teamName, nil, responder)
+	require.NoError(t, err)
+	body := strings.NewReader(fmt.Sprintf(`{"name":%q}`, userUID))
+	req := httptest.NewRequest(http.MethodPost, "/removemember", body).WithContext(ctx)
+	h.ServeHTTP(httptest.NewRecorder(), req)
+	return responder
+}
+
+func TestTeamRemoveMemberREST_RetriesOnConflict(t *testing.T) {
+	t.Run("retries a resource-version conflict then persists removal", func(t *testing.T) {
+		store := &scriptedStore{
+			team: &iamv0alpha1.Team{
+				ObjectMeta: metav1.ObjectMeta{Name: "team1", Namespace: "default", ResourceVersion: "1"},
+				Spec:       iamv0alpha1.TeamSpec{Title: "t", Members: []iamv0alpha1.TeamTeamMember{member("user1", "member", false)}},
+			},
+			updateErrs: []error{
+				apierrors.NewConflict(teamResource.GroupResource(), "team1", fmt.Errorf("rv mismatch")),
+				apierrors.NewConflict(teamResource.GroupResource(), "team1", fmt.Errorf("rv mismatch")),
+			},
+		}
+		handler := NewTeamRemoveMemberREST(store, tracing.NewNoopTracerService())
+
+		responder := removeMemberRequest(t, handler, "team1", "user1")
+
+		require.True(t, responder.called)
+		require.NoError(t, responder.err)
+		require.Equal(t, http.StatusOK, responder.code)
+		require.Empty(t, store.team.Spec.Members)
+	})
+
+	t.Run("retries a rolled-back SQL deadlock then persists", func(t *testing.T) {
+		store := &scriptedStore{
+			team: &iamv0alpha1.Team{
+				ObjectMeta: metav1.ObjectMeta{Name: "team1", Namespace: "default", ResourceVersion: "1"},
+				Spec:       iamv0alpha1.TeamSpec{Title: "t", Members: []iamv0alpha1.TeamTeamMember{member("user1", "member", false)}},
+			},
+			// Stringified MySQL deadlock as unified storage would surface it —
+			// a generic 500-shaped error, not an apierrors.Conflict.
+			updateErrs: []error{fmt.Errorf("Exec: Error 1213: Deadlock found when trying to get lock")},
+		}
+		handler := NewTeamRemoveMemberREST(store, tracing.NewNoopTracerService())
+
+		responder := removeMemberRequest(t, handler, "team1", "user1")
+
+		require.True(t, responder.called)
+		require.NoError(t, responder.err)
+		require.Empty(t, store.team.Spec.Members)
+	})
+
+	t.Run("surfaces the conflict when retries are exhausted", func(t *testing.T) {
+		errs := make([]error, 0, retry.DefaultRetry.Steps)
+		for range retry.DefaultRetry.Steps {
+			errs = append(errs, apierrors.NewConflict(teamResource.GroupResource(), "team1", fmt.Errorf("rv mismatch")))
+		}
+		store := &scriptedStore{
+			team: &iamv0alpha1.Team{
+				ObjectMeta: metav1.ObjectMeta{Name: "team1", Namespace: "default", ResourceVersion: "1"},
+				Spec:       iamv0alpha1.TeamSpec{Title: "t", Members: []iamv0alpha1.TeamTeamMember{member("user1", "member", false)}},
+			},
+			updateErrs: errs,
+		}
+		handler := NewTeamRemoveMemberREST(store, tracing.NewNoopTracerService())
+
+		responder := removeMemberRequest(t, handler, "team1", "user1")
+
+		require.True(t, responder.called)
+		require.Error(t, responder.err)
+		require.True(t, apierrors.IsConflict(responder.err), "exhausted retries must surface the conflict")
+		require.Equal(t, retry.DefaultRetry.Steps, store.calls, "handler must retry exactly Steps times before giving up")
+	})
+}
+
+func TestTeamRemoveMemberREST_Connect(t *testing.T) {
+	newStore := func(members ...iamv0alpha1.TeamTeamMember) *scriptedStore {
+		return &scriptedStore{
+			team: &iamv0alpha1.Team{
+				ObjectMeta: metav1.ObjectMeta{Name: "team1", Namespace: "default", ResourceVersion: "1"},
+				Spec:       iamv0alpha1.TeamSpec{Title: "t", Members: members},
+			},
+		}
+	}
+
+	t.Run("removes an existing member and returns 200", func(t *testing.T) {
+		store := newStore(member("user1", "member", false), member("user2", "admin", false))
+		handler := NewTeamRemoveMemberREST(store, tracing.NewNoopTracerService())
+
+		responder := removeMemberRequest(t, handler, "team1", "user1")
+
+		require.NoError(t, responder.err)
+		require.Equal(t, http.StatusOK, responder.code)
+		require.Equal(t, 1, store.calls)
+		require.Len(t, store.team.Spec.Members, 1)
+		require.Equal(t, "user2", store.team.Spec.Members[0].Name)
+	})
+
+	t.Run("removing an absent user is idempotent: no write, returns 200", func(t *testing.T) {
+		store := newStore(member("user1", "member", false))
+		handler := NewTeamRemoveMemberREST(store, tracing.NewNoopTracerService())
+
+		responder := removeMemberRequest(t, handler, "team1", "ghost")
+
+		require.NoError(t, responder.err)
+		require.Equal(t, http.StatusOK, responder.code)
+		require.Equal(t, 0, store.calls, "no Update expected when the user isn't a member")
+		require.Len(t, store.team.Spec.Members, 1)
+	})
+
+	t.Run("non-retryable update error surfaces without retry", func(t *testing.T) {
+		boom := apierrors.NewInternalError(fmt.Errorf("boom"))
+		store := &scriptedStore{
+			team: &iamv0alpha1.Team{
+				ObjectMeta: metav1.ObjectMeta{Name: "team1", Namespace: "default", ResourceVersion: "1"},
+				Spec:       iamv0alpha1.TeamSpec{Title: "t", Members: []iamv0alpha1.TeamTeamMember{member("user1", "member", false)}},
+			},
+			updateErrs: []error{boom},
+		}
+		handler := NewTeamRemoveMemberREST(store, tracing.NewNoopTracerService())
+
+		responder := removeMemberRequest(t, handler, "team1", "user1")
+
+		require.Error(t, responder.err)
+		require.True(t, apierrors.IsInternalError(responder.err))
+		require.Equal(t, 1, store.calls, "non-conflict errors must not be retried")
+	})
+
+	t.Run("rejects a missing user name with 400", func(t *testing.T) {
+		store := newStore(member("user1", "member", false))
+		handler := NewTeamRemoveMemberREST(store, tracing.NewNoopTracerService())
+
+		responder := removeMemberRequest(t, handler, "team1", "")
+
+		require.Error(t, responder.err)
+		var se *apierrors.StatusError
+		require.ErrorAs(t, responder.err, &se)
+		require.Equal(t, int32(http.StatusBadRequest), se.ErrStatus.Code)
+		require.Equal(t, 0, store.calls)
+	})
+}
+
+// TestTeamRemoveMemberREST_ConcurrentRemoves mirrors the add-member race:
+// many parallel remove-member requests for distinct users contending on the
+// same team's resource version. With the retry loop, every removal must
+// persist and none may fail.
+func TestTeamRemoveMemberREST_ConcurrentRemoves(t *testing.T) {
+	const n = 10
+	members := make([]iamv0alpha1.TeamTeamMember, n)
+	for i := range n {
+		members[i] = member(fmt.Sprintf("user%d", i), "member", false)
+	}
+	store := &rvStore{
+		team: &iamv0alpha1.Team{
+			ObjectMeta: metav1.ObjectMeta{Name: "team1", Namespace: "default", ResourceVersion: "1"},
+			Spec:       iamv0alpha1.TeamSpec{Title: "t", Members: members},
+		},
+	}
+	handler := NewTeamRemoveMemberREST(store, tracing.NewNoopTracerService())
+
+	var wg sync.WaitGroup
+	responders := make([]*mockResponder, n)
+	start := make(chan struct{})
+	for i := range n {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			responders[i] = removeMemberRequest(t, handler, "team1", fmt.Sprintf("user%d", i))
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	for i, r := range responders {
+		require.Truef(t, r.called, "responder %d not called", i)
+		require.NoErrorf(t, r.err, "remove for user%d failed", i)
+	}
+	require.Empty(t, store.team.Spec.Members, "all concurrent removes must persist")
+}


### PR DESCRIPTION
**What is this feature?**

Concurrent `POST /teams/{name}/addmember` and `/removemember` requests no longer return `500` and silently drop updates. Each request now re-reads the latest team and re-applies its change on conflict, so parallel membership writes all persist instead of racing each other.

Both handlers do a read-modify-write on `Team.Spec.Members` (Get → modify → Update). Previously a single attempt meant concurrent writers lost the resource-version race and failed. The fix wraps the Get/modify/Update in `retry.RetryOnConflict(retry.DefaultRetry, …)` so a conflicted writer refreshes and retries.

Key behaviors:

- **Re-adding an existing member** updates `Permission` but leaves the `External` flag untouched (that flag records membership origin, IdP-sync vs manual, and isn't something `/addmember` should flip).
- **`201` on a fresh insert, `200`** on an idempotent re-add or permission-only update.
- **Remove is idempotent** — `200` whether or not the member existed.
- **Rolled-back SQL deadlocks** (which surface as a `500` from unified storage) are converted to `409 Conflict` so they get retried too, instead of leaking a 500.

**Why do we need this feature?**

Bulk membership / provisioning fires many add-member requests at once. With no retry, most lost the RV race and returned 500 with the write discarded.

**Who is this feature for?**

Anyone doing concurrent or bulk team-membership changes

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/identity-access-team/issues/2218

**Special notes for your reviewer:**

- **Deadlock→conflict conversion lives in the handler** because these handlers call the in-process dual-writer storage directly, unlike the peers which go through the k8s client and receive already-normalized apierrors. A raw SQL deadlock would otherwise bubble up as an un-retried 500. The same conversion already exists in this package at `store.go` for the legacy path.
