### PR TITLE
Explore: Fix missing paren in ExplorePage split pane calc() height

### DIFF
--- a/public/app/features/explore/ExplorePage.tsx
+++ b/public/app/features/explore/ExplorePage.tsx
@@ -84,7 +84,7 @@ function ExplorePageContent(props: GrafanaRouteComponentProps<{}, ExploreQueryPa
           maxSize={MIN_PANE_WIDTH * -1}
           primary="second"
           splitVisible={hasSplit}
-          parentStyle={showCorrelationEditorBar ? { height: `calc(100% - ${theme.spacing(6)}` } : {}} // button = 4, padding = 1 x 2
+          parentStyle={showCorrelationEditorBar ? { height: `calc(100% - ${theme.spacing(6)})` } : {}} // button = 4, padding = 1 x 2
           paneStyle={{ overflow: 'auto', display: 'flex', flexDirection: 'column' }}
           onDragFinished={(size) => size && updateSplitSize(size)}
         >

--- a/public/app/features/explore/spec/correlationEditorHeight.test.tsx
+++ b/public/app/features/explore/spec/correlationEditorHeight.test.tsx
@@ -1,0 +1,62 @@
+import { act, waitFor } from '@testing-library/react';
+import { type ComponentProps } from 'react';
+import type AutoSizer from 'react-virtualized-auto-sizer';
+
+import { createTheme, EventBusSrv } from '@grafana/data';
+
+import { changeCorrelationEditorDetails } from '../state/main';
+
+import { setupExplore, tearDown } from './helper/setup';
+
+const testEventBus = new EventBusSrv();
+
+jest.mock('app/core/services/context_srv', () => {
+  return {
+    contextSrv: {
+      ...jest.requireActual('app/core/services/context_srv').contextSrv,
+      hasPermission: () => true,
+      getValidIntervals: (defaultIntervals: string[]) => defaultIntervals,
+    },
+  };
+});
+
+jest.mock('react-virtualized-auto-sizer', () => {
+  return {
+    __esModule: true,
+    default(props: ComponentProps<typeof AutoSizer>) {
+      return <div>{props.children({ width: 1000, scaledWidth: 1000, scaledHeight: 1000, height: 1000 })}</div>;
+    },
+  };
+});
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getAppEvents: () => testEventBus,
+}));
+
+jest.mock('../hooks/useExplorePageTitle', () => ({
+  useExplorePageTitle: jest.fn(),
+}));
+
+describe('ExplorePage split pane height in correlation editor mode', () => {
+  afterEach(() => {
+    tearDown();
+  });
+
+  // Pins the `calc()` height applied to the split pane while the correlation editor bar is shown.
+  // A malformed value (e.g. a missing closing paren) is silently dropped by the browser, leaving the
+  // pane without its reduced height, so we assert the applied value is the intended, valid calc().
+  it('applies a valid calc() height that accounts for the correlation editor bar', async () => {
+    const { store, container } = setupExplore();
+
+    act(() => {
+      store.dispatch(changeCorrelationEditorDetails({ editorMode: true }));
+    });
+
+    await waitFor(() => {
+      const splitPane = container.querySelector<HTMLElement>('.SplitPane');
+      expect(splitPane).not.toBeNull();
+      expect(splitPane!.style.height).toBe(`calc(100% - ${createTheme().spacing(6)})`);
+    });
+  });
+});


### PR DESCRIPTION
When the correlation editor bar is shown, `ExplorePage` passes a `parentStyle`
height to `SplitPaneWrapper` built with a `calc()` expression that was missing
its closing parenthesis:

    height: `calc(100% - ${theme.spacing(6)}`

The value evaluated to `calc(100% - 48px` (unbalanced), which is invalid CSS and
is silently dropped by the browser. As a result the split pane kept its full
`100%` height and did not account for the correlation editor bar.

This adds the missing `)` and a regression test that renders `ExplorePage` in
correlation editor mode and asserts the pane receives the intended, valid
`calc()` height.

Fixes #128931

From the 2026-07-02 DataPro code audit (finding #27).

Closes DPRO-223