### PR TITLE
Explore: Fix `panelsSate` typo in extension context type

### DIFF
--- a/public/app/features/explore/extensions/ToolbarExtensionPoint.test.tsx
+++ b/public/app/features/explore/extensions/ToolbarExtensionPoint.test.tsx
@@ -12,7 +12,7 @@ import { type ExplorePanelData, type ExploreState } from 'app/types/explore';
 
 import { createEmptyQueryResponse } from '../state/utils';
 
-import { ToolbarExtensionPoint } from './ToolbarExtensionPoint';
+import { type PluginExtensionExploreContext, ToolbarExtensionPoint } from './ToolbarExtensionPoint';
 
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
@@ -198,6 +198,29 @@ describe('ToolbarExtensionPoint', () => {
       const { context } = options;
 
       expect(context).toHaveProperty('panelsState', panelsState);
+    });
+
+    it('types the extension context with `panelsState` (guards against the `panelsSate` typo)', () => {
+      const panelsState: ExplorePanelsState = {
+        logs: { sortOrder: LogsSortOrder.Ascending, displayedFields: ['time', 'body'] },
+      };
+
+      // Compile-time regression guard (2026-07-02 DataPro code audit, finding #28): assigning a
+      // fresh object literal to `PluginExtensionExploreContext` triggers excess-property checking,
+      // so if the field regresses to the misspelled `panelsSate`, `panelsState` becomes an unknown
+      // property and `yarn typecheck` fails. Extension authors read `context.panelsState`, so the
+      // type must expose it under that name.
+      const context: PluginExtensionExploreContext = {
+        exploreId: 'left',
+        targets: [{ refId: 'A' }],
+        data: createEmptyQueryResponse(),
+        timeRange: { from: 'now-1h', to: 'now' },
+        timeZone: 'browser',
+        shouldShowAddCorrelation: false,
+        panelsState,
+      };
+
+      expect(context.panelsState).toBe(panelsState);
     });
   });
 

--- a/public/app/features/explore/extensions/ToolbarExtensionPoint.tsx
+++ b/public/app/features/explore/extensions/ToolbarExtensionPoint.tsx
@@ -95,7 +95,7 @@ export type PluginExtensionExploreContext = {
   timeRange: RawTimeRange;
   timeZone: TimeZone;
   shouldShowAddCorrelation: boolean;
-  panelsSate?: ExplorePanelsState;
+  panelsState?: ExplorePanelsState;
 };
 
 function useExtensionPointContext(props: Props): PluginExtensionExploreContext {


### PR DESCRIPTION
The exported extension-context type `PluginExtensionExploreContext` declared its
panels-state field with a typo — `panelsSate` — while the runtime object built in
`useExtensionPointContext` correctly provides `panelsState`.

Because the field is optional and no internal code reads `panelsSate`, the
mismatch was silent: extension authors typing against
`PluginExtensionExploreContext` and reading `context.panelsSate` got `undefined`,
even though the value is present at runtime under `panelsState`.

This renames the type field to `panelsState` so the type matches the runtime
object, and adds a compile-time regression test (a typed context literal) so the
excess-property check fails `yarn typecheck` if the name regresses.

`panelsSate` appeared only in this one declaration repo-wide, and
`PluginExtensionExploreContext` is app-internal (not exported from a `@grafana/*`
package), so the change is low-risk.

Fixes #128936

From the 2026-07-02 DataPro code audit (finding #28).

Closes DPRO-226