### PR TITLE
Folders: Authorize contained alert rules and library elements on cascade delete

### DIFF
--- a/pkg/registry/apis/folders/cascade_delete_storage.go
+++ b/pkg/registry/apis/folders/cascade_delete_storage.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/client-go/dynamic"
 
 	authlib "github.com/grafana/authlib/types"
+	"github.com/grafana/grafana-app-sdk/logging"
 	dashv1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1"
 	foldersv1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
@@ -215,6 +216,9 @@ func (s *cascadeDeleteStorage) cascadeDelete(ctx context.Context, user identity.
 			}
 			return nil, false, err
 		}
+	} else {
+		logging.FromContext(ctx).Debug("Skipping in-process alert rule and library element cleanup",
+			"folder", name, "has_contents_deleter", s.contentsDeleter != nil, "dry_run", len(options.DryRun) > 0)
 	}
 
 	// Delete this folder last. NotFound is success for children (idempotent), but the requested
@@ -377,6 +381,7 @@ func (s *cascadeDeleteStorage) checkFolderContentsAccess(ctx context.Context, us
 	if s.accessClient == nil {
 		return nil
 	}
+	logging.FromContext(ctx).Debug("Evaluating contained-resource delete permissions", "folder", folderUID)
 	folderGVR := foldersv1.FolderResourceInfo.GroupVersionResource()
 	// Root folders carry an empty parent annotation; RBAC treats "" as no folder context, so a user
 	// who only inherits folders:write from General would be wrongly denied. Normalize to General.

--- a/pkg/registry/apis/folders/cascade_delete_storage.go
+++ b/pkg/registry/apis/folders/cascade_delete_storage.go
@@ -176,16 +176,17 @@ func checkDeletePreconditions(obj runtime.Object, options *metav1.DeleteOptions)
 // NotFound errors for children, since they might be already deleted or a stale search-index entry,
 // but we keep the error for the user-requested folder.
 func (s *cascadeDeleteStorage) cascadeDelete(ctx context.Context, user identity.Requester, namespace, parentUID, name string, options *metav1.DeleteOptions, requested bool) (runtime.Object, bool, error) {
-	// Authorize the requester to delete this folder's alert rules and library elements before touching
-	// it, mirroring the per-folder permissions legacy enforced.
-	if err := s.checkFolderContentsAccess(ctx, user, namespace, name, parentUID); err != nil {
-		return nil, false, err
-	}
-
 	if err := s.markTerminating(ctx, name, options); err != nil {
 		if apierrors.IsNotFound(err) && !requested {
 			return nil, false, nil
 		}
+		return nil, false, err
+	}
+
+	// Authorize the requester to delete this folder's alert rules and library elements, mirroring the
+	// per-folder permissions legacy enforced. Runs after the NotFound skip so a stale or already-deleted
+	// child folder is skipped idempotently instead of 403-ing on an un-walkable inheritance chain.
+	if err := s.checkFolderContentsAccess(ctx, user, namespace, name, parentUID); err != nil {
 		return nil, false, err
 	}
 

--- a/pkg/registry/apis/folders/cascade_delete_storage.go
+++ b/pkg/registry/apis/folders/cascade_delete_storage.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/client-go/dynamic"
 
+	authlib "github.com/grafana/authlib/types"
 	dashv1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1"
 	foldersv1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
@@ -53,13 +54,16 @@ type cascadeDeleteStorage struct {
 	// contentsDeleter removes alert rules and library elements in each folder; nil when not wired
 	// (e.g. MT), in which case that cleanup is skipped.
 	contentsDeleter FolderContentsDeleter
+	// accessClient authorizes the requester against contained resources before the cascade; nil skips
+	// the pre-flight (e.g. tests).
+	accessClient authlib.AccessClient
 }
 
 // newCascadeDeleteStorage wraps store, re-exposing the watch/deletecollection interfaces the wrapper
 // would otherwise hide. The wrapped store implements both (MT generic store) or neither
 // (folderStorage), so one check keeps the advertised verbs unchanged.
-func newCascadeDeleteStorage(store grafanarest.Storage, searcher resourcepb.ResourceIndexClient, dashboardClient func(ctx context.Context) (*dynamic.NamespaceableResourceInterface, error), contentsDeleter FolderContentsDeleter) grafanarest.Storage {
-	base := &cascadeDeleteStorage{Storage: store, searcher: searcher, dashboardClient: dashboardClient, contentsDeleter: contentsDeleter}
+func newCascadeDeleteStorage(store grafanarest.Storage, searcher resourcepb.ResourceIndexClient, dashboardClient func(ctx context.Context) (*dynamic.NamespaceableResourceInterface, error), contentsDeleter FolderContentsDeleter, accessClient authlib.AccessClient) grafanarest.Storage {
+	base := &cascadeDeleteStorage{Storage: store, searcher: searcher, dashboardClient: dashboardClient, contentsDeleter: contentsDeleter, accessClient: accessClient}
 	watcher, hasWatch := store.(rest.Watcher)
 	collectionDeleter, hasCollectionDelete := store.(rest.CollectionDeleter)
 	if hasWatch && hasCollectionDelete {
@@ -114,11 +118,22 @@ func (s *cascadeDeleteStorage) Delete(ctx context.Context, name string, deleteVa
 		return nil, false, err
 	}
 
+	// Capture the requester before switching to the service identity, so the per-folder access checks
+	// in the cascade run as the user rather than the service.
+	user, err := identity.GetRequester(ctx)
+	if err != nil {
+		return nil, false, err
+	}
+	rootParent := ""
+	if meta, mErr := utils.MetaAccessor(obj); mErr == nil {
+		rootParent = meta.GetFolder()
+	}
+
 	// Run the cascade under a service identity: searcher.Search is GET-scoped to the requester, so a
 	// user authorized to force-delete the folder but not to see every contained resource would
 	// otherwise enumerate (and thus delete) only the visible subset, orphaning the rest.
 	cascadeCtx := identity.WithServiceIdentityContext(ctx, ns.OrgID)
-	return s.cascadeDelete(cascadeCtx, ns.Value, name, cascadeDeleteOptions(options), true)
+	return s.cascadeDelete(cascadeCtx, user, ns.Value, rootParent, name, cascadeDeleteOptions(options), true)
 }
 
 // cascadeDeleteOptions returns the options reused for descendant deletes, carrying only the
@@ -159,7 +174,13 @@ func checkDeletePreconditions(obj runtime.Object, options *metav1.DeleteOptions)
 // requested param marks whether we are deleting the requested folder or not. We suppress
 // NotFound errors for children, since they might be already deleted or a stale search-index entry,
 // but we keep the error for the user-requested folder.
-func (s *cascadeDeleteStorage) cascadeDelete(ctx context.Context, namespace, name string, options *metav1.DeleteOptions, requested bool) (runtime.Object, bool, error) {
+func (s *cascadeDeleteStorage) cascadeDelete(ctx context.Context, user identity.Requester, namespace, parentUID, name string, options *metav1.DeleteOptions, requested bool) (runtime.Object, bool, error) {
+	// Authorize the requester to delete this folder's alert rules and library elements before touching
+	// it, mirroring the per-folder permissions legacy enforced.
+	if err := s.checkFolderContentsAccess(ctx, user, namespace, name, parentUID); err != nil {
+		return nil, false, err
+	}
+
 	if err := s.markTerminating(ctx, name, options); err != nil {
 		if apierrors.IsNotFound(err) && !requested {
 			return nil, false, nil
@@ -173,7 +194,7 @@ func (s *cascadeDeleteStorage) cascadeDelete(ctx context.Context, namespace, nam
 	}
 
 	for _, child := range children {
-		if _, _, err := s.cascadeDelete(ctx, namespace, child, options, false); err != nil {
+		if _, _, err := s.cascadeDelete(ctx, user, namespace, name, child, options, false); err != nil {
 			return nil, false, err
 		}
 	}
@@ -340,4 +361,44 @@ func (s *cascadeDeleteStorage) childFolders(ctx context.Context, namespace, pare
 	}
 
 	return all, nil
+}
+
+// Legacy folder delete gated contained resources on alert.rules:delete and folders:write; the authz
+// mapper resolves the tuples below to those actions (see pkg/services/authz/rbac/mapper.go).
+const (
+	cascadeAlertRuleGroup    = "rules.alerting.grafana.app"
+	cascadeAlertRuleResource = "alertrules"
+)
+
+// checkFolderContentsAccess denies the delete unless the requester may delete the alert rules
+// (alert.rules:delete) and library elements (folders:write) in folderUID; parentUID lets folder
+// permissions resolve through inheritance. No-op when no access client is wired (e.g. tests).
+func (s *cascadeDeleteStorage) checkFolderContentsAccess(ctx context.Context, user identity.Requester, namespace, folderUID, parentUID string) error {
+	if s.accessClient == nil {
+		return nil
+	}
+	folderGVR := foldersv1.FolderResourceInfo.GroupVersionResource()
+	resp, err := s.accessClient.BatchCheck(ctx, user, authlib.BatchCheckRequest{
+		Namespace: namespace,
+		Checks: []authlib.BatchCheckItem{
+			{CorrelationID: "alertrules", Verb: utils.VerbDelete, Group: cascadeAlertRuleGroup, Resource: cascadeAlertRuleResource, Folder: folderUID},
+			{CorrelationID: "libraryelements", Verb: utils.VerbUpdate, Group: folderGVR.Group, Resource: folderGVR.Resource, Name: folderUID, Folder: parentUID},
+		},
+	})
+	if err != nil {
+		return err
+	}
+	for _, key := range []string{"alertrules", "libraryelements"} {
+		res, ok := resp.Results[key]
+		if !ok {
+			return fmt.Errorf("missing access check result %q for folder %q", key, folderUID)
+		}
+		if res.Error != nil {
+			return res.Error
+		}
+		if !res.Allowed {
+			return apierrors.NewForbidden(foldersv1.FolderResourceInfo.GroupResource(), folderUID, folder.ErrAccessDenied)
+		}
+	}
+	return nil
 }

--- a/pkg/registry/apis/folders/cascade_delete_storage.go
+++ b/pkg/registry/apis/folders/cascade_delete_storage.go
@@ -378,25 +378,21 @@ func (s *cascadeDeleteStorage) checkFolderContentsAccess(ctx context.Context, us
 		return nil
 	}
 	folderGVR := foldersv1.FolderResourceInfo.GroupVersionResource()
-	resp, err := s.accessClient.BatchCheck(ctx, user, authlib.BatchCheckRequest{
-		Namespace: namespace,
-		Checks: []authlib.BatchCheckItem{
-			{CorrelationID: "alertrules", Verb: utils.VerbDelete, Group: cascadeAlertRuleGroup, Resource: cascadeAlertRuleResource, Folder: folderUID},
-			{CorrelationID: "libraryelements", Verb: utils.VerbUpdate, Group: folderGVR.Group, Resource: folderGVR.Resource, Name: folderUID, Folder: parentUID},
-		},
-	})
-	if err != nil {
-		return err
+	// One homogeneous Check per resource: a mixed-resource BatchCheck is routed back to RBAC in
+	// Zanzana rollout mode, so tenants mid-rollout would be evaluated by the wrong engine.
+	checks := []struct {
+		req    authlib.CheckRequest
+		folder string
+	}{
+		{authlib.CheckRequest{Namespace: namespace, Verb: utils.VerbDelete, Group: cascadeAlertRuleGroup, Resource: cascadeAlertRuleResource}, folderUID},
+		{authlib.CheckRequest{Namespace: namespace, Verb: utils.VerbUpdate, Group: folderGVR.Group, Resource: folderGVR.Resource, Name: folderUID}, parentUID},
 	}
-	for _, key := range []string{"alertrules", "libraryelements"} {
-		res, ok := resp.Results[key]
-		if !ok {
-			return fmt.Errorf("missing access check result %q for folder %q", key, folderUID)
+	for _, c := range checks {
+		resp, err := s.accessClient.Check(ctx, user, c.req, c.folder)
+		if err != nil {
+			return err
 		}
-		if res.Error != nil {
-			return res.Error
-		}
-		if !res.Allowed {
+		if !resp.Allowed {
 			return apierrors.NewForbidden(foldersv1.FolderResourceInfo.GroupResource(), folderUID, folder.ErrAccessDenied)
 		}
 	}

--- a/pkg/registry/apis/folders/cascade_delete_storage.go
+++ b/pkg/registry/apis/folders/cascade_delete_storage.go
@@ -378,6 +378,12 @@ func (s *cascadeDeleteStorage) checkFolderContentsAccess(ctx context.Context, us
 		return nil
 	}
 	folderGVR := foldersv1.FolderResourceInfo.GroupVersionResource()
+	// Root folders carry an empty parent annotation; RBAC treats "" as no folder context, so a user
+	// who only inherits folders:write from General would be wrongly denied. Normalize to General.
+	writeParent := parentUID
+	if writeParent == "" {
+		writeParent = folder.GeneralFolderUID
+	}
 	// One homogeneous Check per resource: a mixed-resource BatchCheck is routed back to RBAC in
 	// Zanzana rollout mode, so tenants mid-rollout would be evaluated by the wrong engine.
 	checks := []struct {
@@ -385,7 +391,7 @@ func (s *cascadeDeleteStorage) checkFolderContentsAccess(ctx context.Context, us
 		folder string
 	}{
 		{authlib.CheckRequest{Namespace: namespace, Verb: utils.VerbDelete, Group: cascadeAlertRuleGroup, Resource: cascadeAlertRuleResource}, folderUID},
-		{authlib.CheckRequest{Namespace: namespace, Verb: utils.VerbUpdate, Group: folderGVR.Group, Resource: folderGVR.Resource, Name: folderUID}, parentUID},
+		{authlib.CheckRequest{Namespace: namespace, Verb: utils.VerbUpdate, Group: folderGVR.Group, Resource: folderGVR.Resource, Name: folderUID}, writeParent},
 	}
 	for _, c := range checks {
 		resp, err := s.accessClient.Check(ctx, user, c.req, c.folder)

--- a/pkg/registry/apis/folders/cascade_delete_storage_test.go
+++ b/pkg/registry/apis/folders/cascade_delete_storage_test.go
@@ -190,7 +190,9 @@ func nilDashboardClient(context.Context) (*dynamic.NamespaceableResourceInterfac
 }
 
 func ctxWithNamespace() context.Context {
-	return apirequest.WithNamespace(context.Background(), "default")
+	ctx := apirequest.WithNamespace(context.Background(), "default")
+	// A requester is required now that Delete captures it before the cascade.
+	return identity.WithRequester(ctx, &identity.StaticRequester{})
 }
 
 // forceDelete is the gracePeriodSeconds=0 opt-in required to cascade-delete a non-empty folder.
@@ -523,7 +525,7 @@ func TestCascadeDelete_ForwardsOptionalInterfaces(t *testing.T) {
 	setKubernetesFolderCascadeDeleteToggle(t, false)
 
 	inner := &watchableFolderStorage{fakeFolderStorage: &fakeFolderStorage{existing: map[string]*foldersv1.Folder{}}}
-	s := newCascadeDeleteStorage(inner, &fakeCascadeSearcher{}, nilDashboardClient, nil)
+	s := newCascadeDeleteStorage(inner, &fakeCascadeSearcher{}, nilDashboardClient, nil, nil)
 
 	watcher, ok := s.(rest.Watcher)
 	require.True(t, ok, "watch must be exposed when the wrapped store supports it")
@@ -543,7 +545,7 @@ func TestCascadeDelete_RejectsForcedCollectionDelete(t *testing.T) {
 
 	// A forced collection delete can't cascade, so it's rejected rather than orphaning content.
 	inner := &watchableFolderStorage{fakeFolderStorage: &fakeFolderStorage{existing: map[string]*foldersv1.Folder{}}}
-	deleter := newCascadeDeleteStorage(inner, &fakeCascadeSearcher{}, nilDashboardClient, nil).(rest.CollectionDeleter)
+	deleter := newCascadeDeleteStorage(inner, &fakeCascadeSearcher{}, nilDashboardClient, nil, nil).(rest.CollectionDeleter)
 
 	_, err := deleter.DeleteCollection(ctxWithNamespace(), nil, forceDelete(), nil)
 	require.True(t, apierrors.IsBadRequest(err))
@@ -557,7 +559,7 @@ func TestCascadeDelete_RejectsForcedCollectionDelete(t *testing.T) {
 
 func TestCascadeDelete_OptionalInterfacesNotExposedWhenUnsupported(t *testing.T) {
 	// Wrapped store lacks Watcher/CollectionDeleter: the wrapper must not advertise those verbs.
-	s := newCascadeDeleteStorage(&fakeFolderStorage{}, &fakeCascadeSearcher{}, nilDashboardClient, nil)
+	s := newCascadeDeleteStorage(&fakeFolderStorage{}, &fakeCascadeSearcher{}, nilDashboardClient, nil, nil)
 
 	_, isWatcher := s.(rest.Watcher)
 	require.False(t, isWatcher)

--- a/pkg/registry/apis/folders/register.go
+++ b/pkg/registry/apis/folders/register.go
@@ -253,7 +253,7 @@ func (b *FolderAPIBuilder) storageForVersion(
 
 	// Cascade delete wrapper -- always wired (both ST and MT). Recursively deletes a folder's
 	// subtree on delete; a no-op delegate unless kubernetesFolderCascadeDelete is enabled.
-	b.storage = newCascadeDeleteStorage(b.storage, b.searcher, b.dashboardClient, b.contentsDeleter)
+	b.storage = newCascadeDeleteStorage(b.storage, b.searcher, b.dashboardClient, b.contentsDeleter, b.accessClient)
 
 	storage := map[string]rest.Storage{}
 	storage[folders.StoragePath()] = b.storage


### PR DESCRIPTION
Force-deleting a folder (`kubernetesFolderCascadeDelete`) cascades under a **service identity**, so the requester's permissions on contained resources went unchecked: a user with only `folders:delete` could delete alert rules and library elements they had no rights to. This PR adds a per-folder pre-flight that, as the requester, checks `alert.rules:delete` and `folders:write` across the subtree before deleting (403 on denial), restoring the checks the **legacy folder delete already enforces**. 

| Resource | Legacy check (action @ scope) | apiserver `Check` (verb + group/resource + folder) | Status |
|---|---|---|---|
| Alert rules | `alert.rules:delete` @ `folders:uid:<uid>` | `delete` + `rules.alerting.grafana.app/alertrules`  + `Folder=<uid>` | **Added** |
| Library elements | `folders:write` @ `folders:uid:<uid>` | `update` +  `folder.grafana.app/folders` + `Name=<uid>`, `Folder=<parent>` | **Added** |
| The folder itself | `folders:delete` @ `folders:uid:<uid>` | `delete` +  `folder.grafana.app/folders` | Already enforced |