### PR TITLE
SqlExpressions: Upgrade to new-style feature flag format

### DIFF
--- a/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
@@ -25,6 +25,7 @@ declare module "@openfeature/core" {
     | "dashboard.notebooks"
     | "stateTimeline.nameAboveBars"
     | "grafana.secretsReferenceValueUI"
+    | "sqlExpressionsColumnAutoComplete"
     | "sqlExpressionsCodeMirror"
     | "dashboards.filterablePanels"
     | "grafana.filterablePanels"

--- a/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
@@ -141,6 +141,8 @@ export const FlagKeys = {
   SplashScreen: "splashScreen",
   /** Enables CodeMirror editor for SQL Expressions */
   SqlExpressionsCodeMirror: "sqlExpressionsCodeMirror",
+  /** Enables column autocomplete for SQL Expressions */
+  SqlExpressionsColumnAutoComplete: "sqlExpressionsColumnAutoComplete",
   /** Enables option to position series names above bars in the state timeline panel */
   StateTimelineNameAboveBars: "stateTimeline.nameAboveBars",
   /** Enables the 'Customize with Assistant' button on suggested dashboard cards */
@@ -855,6 +857,17 @@ export const useFlagSplashScreen = (options?: ReactFlagEvaluationOptions): boole
  */
 export const useFlagSqlExpressionsCodeMirror = (options?: ReactFlagEvaluationOptions): boolean => {
   return useFlag("sqlExpressionsCodeMirror", false, options).value;
+};
+
+/**
+ * Enables column autocomplete for SQL Expressions
+ *
+ * **Details:**
+ * - flag key: `sqlExpressionsColumnAutoComplete`
+ * - default value: `false`
+ */
+export const useFlagSqlExpressionsColumnAutoComplete = (options?: ReactFlagEvaluationOptions): boolean => {
+  return useFlag("sqlExpressionsColumnAutoComplete", false, options).value;
 };
 
 /**

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -889,7 +889,7 @@ var (
 			Name:        "sqlExpressionsColumnAutoComplete",
 			Description: "Enables column autocomplete for SQL Expressions",
 			Stage:       FeatureStageExperimental,
-			Generate:    Generate{LegacyFrontend: true},
+			Generate:    Generate{LegacyFrontend: true, React: true},
 			Owner:       grafanaDataProSquad,
 			Expression:  "false",
 		},

--- a/public/app/features/expressions/components/SqlExpressions/CompletionProvider/sqlCompletionProvider.ts
+++ b/public/app/features/expressions/components/SqlExpressions/CompletionProvider/sqlCompletionProvider.ts
@@ -5,7 +5,6 @@ import {
   type TableDefinition,
   type TableIdentifier,
 } from '@grafana/plugin-ui';
-import { config } from '@grafana/runtime';
 import { quoteIdentifierIfNecessary } from '@grafana/sql';
 
 import { ALLOWED_FUNCTIONS } from '../../../utils/metaSqlExpr';
@@ -14,6 +13,7 @@ import { SQL_EXPRESSIONS_DIALECT } from '../../../utils/sqlIdentifier';
 interface CompletionProviderGetterArgs {
   getFields: (t: TableIdentifier) => Promise<ColumnDefinition[]>;
   refIds: Array<SelectableValue<string>>;
+  columnAutoCompleteEnabled: boolean;
 }
 
 export const getSqlCompletionProvider: (args: CompletionProviderGetterArgs) => LanguageCompletionProvider =
@@ -35,7 +35,7 @@ export const getSqlCompletionProvider: (args: CompletionProviderGetterArgs) => L
     },
     columns: {
       resolve: async (t?: TableIdentifier) => {
-        if (config.featureToggles.sqlExpressionsColumnAutoComplete) {
+        if (args.columnAutoCompleteEnabled) {
           try {
             return await args.getFields({ table: t?.table });
           } catch {

--- a/public/app/features/expressions/components/SqlExpressions/SqlExpr.test.tsx
+++ b/public/app/features/expressions/components/SqlExpressions/SqlExpr.test.tsx
@@ -296,8 +296,6 @@ describe('SqlExpr', () => {
   });
 
   describe('autocomplete metadata', () => {
-    testWithFeatureToggles({ enable: ['sqlExpressionsColumnAutoComplete'] });
-
     afterEach(() => {
       jest.restoreAllMocks();
       mockDataSourceSrv.get.mockResolvedValue({
@@ -306,7 +304,7 @@ describe('SqlExpr', () => {
     });
 
     it('uses interpolated source queries for column autocomplete', async () => {
-      setTestFlags({ sqlExpressionsCodeMirror: true });
+      setTestFlags({ sqlExpressionsCodeMirror: true, sqlExpressionsColumnAutoComplete: true });
 
       const onChange = jest.fn();
       const sourceQuery = {
@@ -382,8 +380,6 @@ describe('SqlExpr', () => {
   });
 
   describe('autocomplete completions', () => {
-    testWithFeatureToggles({ enable: ['sqlExpressionsColumnAutoComplete'] });
-
     afterEach(() => {
       jest.restoreAllMocks();
       mockDataSourceSrv.get.mockResolvedValue({
@@ -392,7 +388,7 @@ describe('SqlExpr', () => {
     });
 
     it('returns no column completions when the field fetch fails', async () => {
-      setTestFlags({ sqlExpressionsCodeMirror: true });
+      setTestFlags({ sqlExpressionsCodeMirror: true, sqlExpressionsColumnAutoComplete: true });
 
       jest.spyOn(dataSource, 'runMetaSQLExprQuery').mockRejectedValue(new Error('boom'));
 
@@ -414,7 +410,7 @@ describe('SqlExpr', () => {
     });
 
     it('maps fetched fields to column completions', async () => {
-      setTestFlags({ sqlExpressionsCodeMirror: true });
+      setTestFlags({ sqlExpressionsCodeMirror: true, sqlExpressionsColumnAutoComplete: true });
 
       jest.spyOn(dataSource, 'runMetaSQLExprQuery').mockResolvedValue({
         fields: [{ name: 'cpu', type: 'number', config: {}, values: [] }],
@@ -441,7 +437,7 @@ describe('SqlExpr', () => {
     });
 
     it('maps fetched fields to column completions for table names with spaces', async () => {
-      setTestFlags({ sqlExpressionsCodeMirror: true });
+      setTestFlags({ sqlExpressionsCodeMirror: true, sqlExpressionsColumnAutoComplete: true });
 
       const runMetaSQLExprQuery = jest.spyOn(dataSource, 'runMetaSQLExprQuery').mockResolvedValue({
         fields: [
@@ -474,6 +470,8 @@ describe('SqlExpr', () => {
     });
 
     it('maps fetched fields to legacy editor column completions', async () => {
+      setTestFlags({ sqlExpressionsColumnAutoComplete: true });
+
       const runMetaSQLExprQuery = jest.spyOn(dataSource, 'runMetaSQLExprQuery').mockResolvedValue({
         fields: [{ name: 'metric value', type: 'number', config: {}, values: [] }],
         length: 1,

--- a/public/app/features/expressions/components/SqlExpressions/SqlExpr.tsx
+++ b/public/app/features/expressions/components/SqlExpressions/SqlExpr.tsx
@@ -7,7 +7,8 @@ import AutoSizer, { type Size } from 'react-virtualized-auto-sizer';
 import { type GrafanaTheme2, type SelectableValue } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
 import { CompletionItemKind, type TableIdentifier } from '@grafana/plugin-ui';
-import { config, reportInteraction } from '@grafana/runtime';
+import { reportInteraction } from '@grafana/runtime';
+import { useFlagSqlExpressionsColumnAutoComplete } from '@grafana/runtime/internal';
 import { type DataQuery } from '@grafana/schema';
 import { formatSQL, quoteIdentifierIfNecessary } from '@grafana/sql';
 import { Button, Stack, useStyles2 } from '@grafana/ui';
@@ -53,6 +54,7 @@ export const SqlExpr = ({ onChange, refIds, query, alerting = false, queries, me
   const interpolationFilters = metadata?.data?.request?.filters;
   const interpolationRange = metadata?.range;
   const useCodeMirrorEditor = useBooleanFlagValue('sqlExpressionsCodeMirror', false);
+  const columnAutoCompleteEnabled = useFlagSqlExpressionsColumnAutoComplete();
 
   // Signature metadata is large, so it is loaded lazily only for the CodeMirror path.
   const functionSignatures = useFunctionSignatures(useCodeMirrorEditor);
@@ -72,7 +74,7 @@ export const SqlExpr = ({ onChange, refIds, query, alerting = false, queries, me
           };
         }),
       columns: async ({ table }) => {
-        if (!config.featureToggles.sqlExpressionsColumnAutoComplete) {
+        if (!columnAutoCompleteEnabled) {
           return [];
         }
 
@@ -93,7 +95,7 @@ export const SqlExpr = ({ onChange, refIds, query, alerting = false, queries, me
           kind: 'function',
         })),
     }),
-    [interpolationFilters, interpolationRange, interpolationScopedVars, queries, refIds]
+    [columnAutoCompleteEnabled, interpolationFilters, interpolationRange, interpolationScopedVars, queries, refIds]
   );
 
   const legacyCompletionProvider = useMemo(
@@ -106,8 +108,9 @@ export const SqlExpr = ({ onChange, refIds, query, alerting = false, queries, me
             filters: interpolationFilters,
           }),
         refIds,
+        columnAutoCompleteEnabled,
       }),
-    [interpolationFilters, interpolationRange, interpolationScopedVars, queries, refIds]
+    [columnAutoCompleteEnabled, interpolationFilters, interpolationRange, interpolationScopedVars, queries, refIds]
   );
 
   // Define the language definition for MySQL syntax highlighting and autocomplete


### PR DESCRIPTION
## Motivation

This PR closes [DPRO-230](https://linear.app/grafana/issue/DPRO-230/convert-column-autocomplete-flag-to-openfeature-format) / closes https://github.com/grafana/grafana/issues/128951.

## What is this PR doing?

This PR updates the way we consume `sqlExpressionsColumnAutoComplete`, from the legacy feature toggle setup to the modern [OpenFeature-driven](https://enghub.grafana-ops.net/docs/default/component/grafana-backend-services-docs/openfeature/feature-flags-with-open-feature) setup.

## How to test

Given the unit & integration tests, I don't think there's a compelling reason to test this locally. The CI should pass.