### PR TITLE
fix(explore): remove debug console.log left in scanning loop

### DIFF
--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -663,7 +663,6 @@ export const runQueries = createAsyncThunk<void, RunQueriesOptions>(
 
           // Keep scanning for results if this was the last scanning transaction
           if (exploreState!.scanning) {
-            console.log(data.series);
             if (data.state === LoadingState.Done && data.series.length === 0) {
               const range = getShiftedTimeRange(-1, exploreState!.range);
               dispatch(updateTime({ exploreId, absoluteRange: range }));


### PR DESCRIPTION
## Summary
- Removes `console.log(data.series)` in `public/app/features/explore/state/query.ts` that fires on every query response while Explore is in scanning mode.
- Recreated from #124437 by @blackwell-systems, which could not be merged because its commits were unsigned (required for this repo). No code changes from the original — same one-line fix, credited via `Co-authored-by` on the commit.

Closes #123274

## Test plan
- [x] Confirmed the diff is identical to #124437
- [ ] `yarn test public/app/features/explore/state/query.test.ts`
- [ ] Manually verify in Explore: run a log query, click "Scan for older logs", confirm no `console.log` output during scanning