### PR TITLE
fix(folders): escape slashes in folder titles

### DIFF
--- a/pkg/services/folder/folderimpl/folder.go
+++ b/pkg/services/folder/folderimpl/folder.go
@@ -270,9 +270,12 @@ func (s *Service) deleteChildrenInFolder(ctx context.Context, orgID int64, folde
 }
 
 // SplitFullpath splits a fullpath into its component titles on unescaped
-// FULLPATH_SEPARATOR characters. It unescapes escape sequences within each
-// title (\\ -> \ and \/ -> /), so it is the inverse of the escaping applied
-// when a fullpath is built. The resulting array does not contain empty strings.
+// FULLPATH_SEPARATOR characters. It unescapes the escape sequences within each
+// title (\\ -> \ and \/ -> /), so it is the inverse of the escaping applied when
+// a fullpath is built. A backslash that does not form one of those sequences
+// (including a trailing backslash) is treated as a literal character and left
+// untouched, so legacy, unescaped provisioning paths such as "team\ops" pass
+// through unchanged. The resulting array does not contain empty strings.
 func SplitFullpath(s string) []string {
 	result := make([]string, 0)
 	var current strings.Builder
@@ -281,7 +284,11 @@ func SplitFullpath(s string) []string {
 	for _, r := range s {
 		switch {
 		case escaped:
-			// if we have seen an escape sequence, write the next rune no matter what it is
+			// Only "\\" and "\/" are escape sequences. Any other backslash is a literal
+			// character (e.g. legacy unescaped titles such as "team\ops"), so preserve it.
+			if r != '\\' && r != FULLPATH_SEPARATOR {
+				current.WriteRune('\\')
+			}
 			current.WriteRune(r)
 			escaped = false
 		case r == '\\':
@@ -294,6 +301,12 @@ func SplitFullpath(s string) []string {
 		default:
 			current.WriteRune(r)
 		}
+	}
+
+	// A trailing backslash is a literal character, not the start of an escape
+	// sequence, so preserve it (e.g. legacy unescaped title "team\").
+	if escaped {
+		current.WriteRune('\\')
 	}
 
 	// Add the last string to the result

--- a/pkg/services/folder/folderimpl/folder.go
+++ b/pkg/services/folder/folderimpl/folder.go
@@ -32,7 +32,7 @@ import (
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 )
 
-const FULLPATH_SEPARATOR = "/"
+const FULLPATH_SEPARATOR = '/'
 
 var (
 	_ folder.Service = (*Service)(nil)
@@ -269,33 +269,37 @@ func (s *Service) deleteChildrenInFolder(ctx context.Context, orgID int64, folde
 	return nil
 }
 
-// SplitFullpath splits a string into an array of strings using the FULLPATH_SEPARATOR as the delimiter.
-// It handles escape characters by appending the separator and the new string if the current string ends with an escape character.
-// The resulting array does not contain empty strings.
+// SplitFullpath splits a fullpath into its component titles on unescaped
+// FULLPATH_SEPARATOR characters. It unescapes escape sequences within each
+// title (\\ -> \ and \/ -> /), so it is the inverse of the escaping applied
+// when a fullpath is built. The resulting array does not contain empty strings.
 func SplitFullpath(s string) []string {
-	splitStrings := strings.Split(s, FULLPATH_SEPARATOR)
-
 	result := make([]string, 0)
-	current := ""
+	var current strings.Builder
 
-	for _, str := range splitStrings {
-		if strings.HasSuffix(current, "\\") {
-			// If the current string ends with an escape character, append the separator and the new string
-			current = current[:len(current)-1] + FULLPATH_SEPARATOR + str
-		} else {
-			// If the current string does not end with an escape character, append the current string to the result and start a new current string
-			if current != "" {
-				result = append(result, current)
+	escaped := false
+	for _, r := range s {
+		switch {
+		case escaped:
+			// if we have seen an escape sequence, write the next rune no matter what it is
+			current.WriteRune(r)
+			escaped = false
+		case r == '\\':
+			escaped = true
+		case r == FULLPATH_SEPARATOR:
+			if current.Len() > 0 {
+				result = append(result, current.String())
+				current.Reset()
 			}
-			current = str
+		default:
+			current.WriteRune(r)
 		}
 	}
 
-	// Append the last string to the result
-	if current != "" {
-		result = append(result, current)
+	// Add the last string to the result
+	if current.Len() > 0 {
+		result = append(result, current.String())
 	}
-
 	return result
 }
 

--- a/pkg/services/folder/folderimpl/folder_test.go
+++ b/pkg/services/folder/folderimpl/folder_test.go
@@ -212,3 +212,46 @@ func TestGetUIDFromLegacyID(t *testing.T) {
 	require.Equal(t, "resolved-uid", uid)
 	fakeK8s.AssertExpectations(t)
 }
+
+func TestFullpathRoundTrip(t *testing.T) {
+	tests := []struct {
+		name   string
+		titles []string
+	}{
+		{
+			name:   "plain titles",
+			titles: []string{"parent", "child"},
+		},
+		{
+			name:   "titles containing slashes",
+			titles: []string{"a/b", "c/d"},
+		},
+		{
+			name:   "title with backslash in middle",
+			titles: []string{"foo\\bar", "xyz"},
+		},
+		{
+			name:   "title ending in double backslash",
+			titles: []string{"team\\\\", "alerts"},
+		},
+		{
+			name:   "title ending in backslash",
+			titles: []string{"team\\", "alerts"},
+		},
+		{
+			name:   "single dangling backslash",
+			titles: []string{"\\"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parents := make([]*folder.Folder, len(tt.titles))
+			for i, title := range tt.titles {
+				parents[i] = &folder.Folder{Title: title, UID: fmt.Sprintf("uid-%d", i)}
+			}
+			fullpath, _ := computeFullPath(parents)
+			require.Equal(t, tt.titles, SplitFullpath(fullpath))
+		})
+	}
+}

--- a/pkg/services/folder/folderimpl/folder_test.go
+++ b/pkg/services/folder/folderimpl/folder_test.go
@@ -136,6 +136,26 @@ func TestSplitFullpath(t *testing.T) {
 			input:    "folder\\/with\\/slashes/subfolder\\/with\\/slashes",
 			expected: []string{"folder/with/slashes", "subfolder/with/slashes"},
 		},
+		{
+			name:     "escaped backslash",
+			input:    "folder\\\\with/backslash",
+			expected: []string{"folder\\with", "backslash"},
+		},
+		{
+			name:     "unescaped backslash in title is preserved",
+			input:    "team\\ops",
+			expected: []string{"team\\ops"},
+		},
+		{
+			name:     "trailing backslash is preserved",
+			input:    "team\\",
+			expected: []string{"team\\"},
+		},
+		{
+			name:     "unescaped backslash preserved across a separator",
+			input:    "team\\ops/child",
+			expected: []string{"team\\ops", "child"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/services/folder/folderimpl/unifiedstore.go
+++ b/pkg/services/folder/folderimpl/unifiedstore.go
@@ -690,6 +690,7 @@ func computeFullPath(parents []*folder.Folder) (string, string) {
 }
 
 func escapeSlashes(title string) string {
+	title = strings.ReplaceAll(title, "\\", "\\\\")
 	return strings.ReplaceAll(title, "/", "\\/")
 }
 

--- a/pkg/services/folder/folderimpl/unifiedstore.go
+++ b/pkg/services/folder/folderimpl/unifiedstore.go
@@ -683,17 +683,21 @@ func computeFullPath(parents []*folder.Folder) (string, string) {
 	fullpath := make([]string, len(parents))
 	fullpathUIDs := make([]string, len(parents))
 	for i, p := range parents {
-		fullpath[i] = p.Title
+		fullpath[i] = escapeSlashes(p.Title)
 		fullpathUIDs[i] = p.UID
 	}
 	return strings.Join(fullpath, "/"), strings.Join(fullpathUIDs, "/")
+}
+
+func escapeSlashes(title string) string {
+	return strings.ReplaceAll(title, "/", "\\/")
 }
 
 func buildFolderFullPaths(f *folder.Folder, relations map[string]string, folderMap map[string]*folder.Folder) error {
 	titles := make([]string, 0)
 	uids := make([]string, 0)
 
-	titles = append(titles, f.Title)
+	titles = append(titles, escapeSlashes(f.Title))
 	uids = append(uids, f.UID)
 
 	seen := make(map[string]bool)
@@ -716,7 +720,7 @@ func buildFolderFullPaths(f *folder.Folder, relations map[string]string, folderM
 		if !exists {
 			break
 		}
-		titles = append(titles, parentFolder.Title)
+		titles = append(titles, escapeSlashes(parentFolder.Title))
 		uids = append(uids, parentFolder.UID)
 		currentUID = parentFolder.UID
 	}

--- a/pkg/services/folder/folderimpl/unifiedstore_test.go
+++ b/pkg/services/folder/folderimpl/unifiedstore_test.go
@@ -73,7 +73,10 @@ func TestComputeFullPath(t *testing.T) {
 			wantPathUIDs: "grandparent-uid/parent-uid/Element-uid",
 		},
 		{
-			name: "should handle special characters in titles",
+			// Slashes in a title must be escaped so the title is not mistaken
+			// for a path separator. Consumers (backend SplitFullpath, the
+			// alerting frontend) rely on this to match a rule's folder.
+			name: "should escape slashes in titles",
 			parents: []*folder.Folder{
 				{
 					Title: "Parent/With/Slashes",
@@ -84,7 +87,7 @@ func TestComputeFullPath(t *testing.T) {
 					UID:   "Element-uid",
 				},
 			},
-			wantPath:     "Parent/With/Slashes/Element With Spaces",
+			wantPath:     "Parent\\/With\\/Slashes/Element With Spaces",
 			wantPathUIDs: "parent-uid/Element-uid",
 		},
 	}
@@ -1058,6 +1061,33 @@ func TestBuildFolderFullPaths(t *testing.T) {
 				ParentUID:    "parent-uid",
 				Fullpath:     "Grandparent/Parent/Child",
 				FullpathUIDs: "grandparent-uid/parent-uid/child-uid",
+			},
+		},
+		{
+			name: "should escape slashes in folder and parent titles",
+			args: args{
+				f: &folder.Folder{
+					Title:     "Child/With/Slashes",
+					UID:       "child-uid",
+					ParentUID: "parent-uid",
+				},
+				relations: map[string]string{
+					"child-uid":  "parent-uid",
+					"parent-uid": "",
+				},
+				folderMap: map[string]*folder.Folder{
+					"parent-uid": {
+						Title: "Parent/With/Slashes",
+						UID:   "parent-uid",
+					},
+				},
+			},
+			want: &folder.Folder{
+				Title:        "Child/With/Slashes",
+				UID:          "child-uid",
+				ParentUID:    "parent-uid",
+				Fullpath:     "Parent\\/With\\/Slashes/Child\\/With\\/Slashes",
+				FullpathUIDs: "parent-uid/child-uid",
 			},
 		},
 		{

--- a/pkg/services/ngalert/api/api_convert_prometheus.go
+++ b/pkg/services/ngalert/api/api_convert_prometheus.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"mime"
 	"net/http"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -27,6 +26,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/folder"
+	"github.com/grafana/grafana/pkg/services/folder/folderimpl"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/api/validation"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
@@ -807,7 +807,14 @@ func grafanaNamespacesToPrometheus(groups []models.AlertRuleGroupWithFolderFullp
 		// we need to use only the last folder in the full path.
 		// For example, if the current working folder is "general" and the full path is "grafana/some folder/general/production",
 		// we should use the "production" folder.
-		folder := filepath.Base(group.FolderFullpath)
+
+		// SplitFullpath (not filepath.Base) is used because the full path escapes separators
+		// within titles and is OS-independent, whereas filepath.Base treats "\" as a separator
+		// on Windows and would not unescape titles that contain a slash.
+		folder := group.FolderFullpath
+		if titles := folderimpl.SplitFullpath(group.FolderFullpath); len(titles) > 0 {
+			folder = titles[len(titles)-1]
+		}
 
 		promGroup, err := grafanaRuleGroupToPrometheus(group.Title, group.Rules)
 		if err != nil {

--- a/pkg/services/ngalert/api/api_convert_prometheus_test.go
+++ b/pkg/services/ngalert/api/api_convert_prometheus_test.go
@@ -2626,3 +2626,54 @@ func TestRouteConvertPrometheusPromoteAlertmanagerConfig(t *testing.T) {
 		require.Equal(t, http.StatusNotImplemented, response.Status())
 	})
 }
+
+func TestGrafanaNamespacesToPrometheus(t *testing.T) {
+	// mimirtool does not support nested folders, so the exported namespace is the
+	// leaf folder title parsed from the (escaped) folder fullpath. Escaped separators
+	// within a title must be unescaped and must not be treated as path separators
+	// (filepath.Base would mishandle these, especially on Windows where "\" splits).
+	tests := []struct {
+		name           string
+		folderFullpath string
+		wantNamespace  string
+	}{
+		{
+			name:           "single folder",
+			folderFullpath: "production",
+			wantNamespace:  "production",
+		},
+		{
+			name:           "nested folder uses the leaf title",
+			folderFullpath: "grafana/some folder/production",
+			wantNamespace:  "production",
+		},
+		{
+			// leaf folder titled "team/prod" (slash escaped as "\/" in the fullpath)
+			name:           "leaf title containing a slash is preserved",
+			folderFullpath: `grafana/team\/prod`,
+			wantNamespace:  "team/prod",
+		},
+		{
+			// leaf folder titled "team\ops" (backslash escaped as "\\" in the fullpath)
+			name:           "leaf title containing a backslash is preserved",
+			folderFullpath: `grafana/team\\ops`,
+			wantNamespace:  `team\ops`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			groups := []models.AlertRuleGroupWithFolderFullpath{
+				{
+					AlertRuleGroup: &models.AlertRuleGroup{Title: "group-1"},
+					FolderFullpath: tt.folderFullpath,
+				},
+			}
+
+			result, err := grafanaNamespacesToPrometheus(groups)
+			require.NoError(t, err)
+			require.Len(t, result, 1)
+			require.Contains(t, result, tt.wantNamespace)
+		})
+	}
+}

--- a/pkg/tests/api/alerting/api_provisioning_test.go
+++ b/pkg/tests/api/alerting/api_provisioning_test.go
@@ -1311,6 +1311,6 @@ func TestIntegrationFullpath(t *testing.T) {
 		var export definitions.AlertingFileExport
 		require.NoError(t, json.Unmarshal([]byte(response), &export))
 		require.Len(t, export.Groups, 1)
-		assert.Equal(t, "my-namespace/my-other-namespace containing multiple //", export.Groups[0].Folder)
+		assert.Equal(t, "my-namespace/my-other-namespace containing multiple \\/\\/", export.Groups[0].Folder)
 	})
 }


### PR DESCRIPTION
**What is this feature?**

This PR adds logic to escape slashes in the unified storage implementation of the folder service.

**Why do we need this feature?**

Consumers of the folder service rely on this behavior as it is documented in the folder service interface.

**Who is this feature for?**

Consumers of the folder service.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
