### PR TITLE
Auth: migrate SQL store to templates

### DIFF
--- a/pkg/server/wire_gen.go
+++ b/pkg/server/wire_gen.go
@@ -632,7 +632,7 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts Options, apiOpts api
 		return nil, err
 	}
 	authinfoimplService := authinfoimpl.ProvideService(loginStore, remoteCache, secretsService)
-	userAuthTokenService, err := authimpl.ProvideUserAuthTokenService(ctx, sqlStore, serverLockService, quotaService, secretsService, configProvider, tracingService, featureToggles)
+	userAuthTokenService, err := authimpl.ProvideUserAuthTokenService(ctx, legacyDatabaseProvider, serverLockService, quotaService, secretsService, configProvider, tracingService, featureToggles)
 	if err != nil {
 		return nil, err
 	}
@@ -1419,7 +1419,7 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 	pluginInstaller := manager4.ProvideInstaller(pluginManagementCfg, inMemory, loaderLoader, repoManager, serviceregistrationService, acimplService)
 	ossProvider := guardian.ProvideGuardian()
 	cacheServiceImpl := service6.ProvideCacheService(cacheService, sqlStore, ossProvider)
-	userAuthTokenService, err := authimpl.ProvideUserAuthTokenService(ctx, sqlStore, serverLockService, quotaService, secretsService, configProvider, tracingService, featureToggles)
+	userAuthTokenService, err := authimpl.ProvideUserAuthTokenService(ctx, legacyDatabaseProvider, serverLockService, quotaService, secretsService, configProvider, tracingService, featureToggles)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/auth/authimpl/auth_token.go
+++ b/pkg/services/auth/authimpl/auth_token.go
@@ -5,8 +5,8 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"net"
-	"strings"
 	"time"
 
 	"github.com/open-feature/go-sdk/openfeature"
@@ -15,7 +15,6 @@ import (
 	"golang.org/x/sync/singleflight"
 
 	"github.com/grafana/grafana/pkg/configprovider"
-	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/serverlock"
 	"github.com/grafana/grafana/pkg/infra/tracing"
@@ -24,7 +23,10 @@ import (
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/quota"
 	"github.com/grafana/grafana/pkg/services/secrets"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/storage/legacysql"
+	"github.com/grafana/grafana/pkg/storage/unified/sql/sqltemplate"
 	"github.com/grafana/grafana/pkg/util"
 )
 
@@ -38,14 +40,14 @@ const SkipRotationTime = 5 * time.Second
 
 var _ auth.UserTokenService = (*UserAuthTokenService)(nil)
 
-func ProvideUserAuthTokenService(ctx context.Context, sqlStore db.DB,
+func ProvideUserAuthTokenService(ctx context.Context, sql legacysql.LegacyDatabaseProvider,
 	serverLockService *serverlock.ServerLockService,
 	quotaService quota.Service, secretService secrets.Service, //nolint:staticcheck // SA1019: Legacy envelope encryption for single-tenant feature
 	cfgProvider configprovider.ConfigProvider, tracer tracing.Tracer,
 	features featuremgmt.FeatureToggles,
 ) (*UserAuthTokenService, error) {
 	s := &UserAuthTokenService{
-		sqlStore:          sqlStore,
+		sql:               sql,
 		serverLockService: serverLockService,
 		cfgProvider:       cfgProvider,
 		log:               log.New("auth"),
@@ -54,7 +56,7 @@ func ProvideUserAuthTokenService(ctx context.Context, sqlStore db.DB,
 		tracer:            tracer,
 	}
 
-	s.externalSessionStore = provideExternalSessionStore(sqlStore, secretService, tracer)
+	s.externalSessionStore = provideExternalSessionStore(sql, secretService, tracer)
 
 	cfg, err := cfgProvider.Get(ctx)
 	if err != nil {
@@ -77,7 +79,7 @@ func ProvideUserAuthTokenService(ctx context.Context, sqlStore db.DB,
 }
 
 type UserAuthTokenService struct {
-	sqlStore             db.DB
+	sql                  legacysql.LegacyDatabaseProvider
 	serverLockService    *serverlock.ServerLockService
 	cfgProvider          configprovider.ConfigProvider
 	log                  log.Logger
@@ -121,7 +123,11 @@ func (s *UserAuthTokenService) CreateToken(ctx context.Context, cmd *auth.Create
 		AuthTokenSeen: false,
 	}
 
-	err = s.sqlStore.InTransaction(ctx, func(ctx context.Context) error {
+	dbHelper, err := s.sql(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get legacy DB: %w", err)
+	}
+	err = dbHelper.DB.InTransaction(ctx, func(ctx context.Context) error {
 		if cmd.ExternalSession != nil {
 			inErr := s.externalSessionStore.Create(ctx, cmd.ExternalSession)
 			if inErr != nil {
@@ -130,8 +136,21 @@ func (s *UserAuthTokenService) CreateToken(ctx context.Context, cmd *auth.Create
 			userAuthToken.ExternalSessionId = cmd.ExternalSession.ID
 		}
 
-		inErr := s.sqlStore.WithDbSession(ctx, func(dbSession *db.Session) error {
-			_, err := dbSession.Insert(&userAuthToken)
+		inErr := dbHelper.DB.WithDbSession(ctx, func(dbSession *sqlstore.DBSession) error {
+			query := tokenQuery{SQLTemplate: sqltemplate.New(dbHelper.DialectForDriver()), TokenTable: dbHelper.Table("user_auth_token"), Token: &userAuthToken}
+			querySQL, err := sqltemplate.Execute(insertTokenTemplate, query)
+			if err != nil {
+				return err
+			}
+			if query.DialectName() == "postgres" {
+				_, err = dbSession.SQL(querySQL, query.GetArgs()...).Get(&userAuthToken.Id)
+				return err
+			}
+			res, err := dbSession.Exec(append([]any{querySQL}, query.GetArgs()...)...)
+			if err != nil {
+				return err
+			}
+			userAuthToken.Id, err = res.LastInsertId()
 			return err
 		})
 		return inErr
@@ -163,12 +182,17 @@ func (s *UserAuthTokenService) LookupToken(ctx context.Context, unhashedToken st
 	hashedToken := hashToken(cfg.SecretKey, unhashedToken)
 	var model userAuthToken
 	var exists bool
-	err = s.sqlStore.WithDbSession(ctx, func(dbSession *db.Session) error {
-		exists, err = dbSession.Where("(auth_token = ? OR prev_auth_token = ?)",
-			hashedToken,
-			hashedToken).
-			Get(&model)
-
+	dbHelper, err := s.sql(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get legacy DB: %w", err)
+	}
+	err = dbHelper.DB.WithDbSession(ctx, func(dbSession *sqlstore.DBSession) error {
+		query := tokenQuery{SQLTemplate: sqltemplate.New(dbHelper.DialectForDriver()), TokenTable: dbHelper.Table("user_auth_token"), HashedToken: hashedToken}
+		querySQL, err := sqltemplate.Execute(lookupTokenTemplate, query)
+		if err != nil {
+			return err
+		}
+		exists, err = dbSession.SQL(querySQL, query.GetArgs()...).Get(&model)
 		return err
 	})
 	if err != nil {
@@ -206,13 +230,17 @@ func (s *UserAuthTokenService) LookupToken(ctx context.Context, unhashedToken st
 		model.RotatedAt = getTime().Add(-usertoken.UrgentRotateTime).Unix()
 
 		var affectedRows int64
-		err = s.sqlStore.WithTransactionalDbSession(ctx, func(dbSession *db.Session) error {
-			affectedRows, err = dbSession.Where("id = ? AND prev_auth_token = ? AND rotated_at < ?",
-				model.Id,
-				model.PrevAuthToken,
-				model.RotatedAt).
-				AllCols().Update(&model)
-
+		err = dbHelper.DB.WithTransactionalDbSession(ctx, func(dbSession *sqlstore.DBSession) error {
+			query := tokenQuery{SQLTemplate: sqltemplate.New(dbHelper.DialectForDriver()), TokenTable: dbHelper.Table("user_auth_token"), Token: &model, Previous: true, ExpectedToken: model.PrevAuthToken}
+			querySQL, err := sqltemplate.Execute(updateTokenTemplate, query)
+			if err != nil {
+				return err
+			}
+			res, err := dbSession.Exec(append([]any{querySQL}, query.GetArgs()...)...)
+			if err != nil {
+				return err
+			}
+			affectedRows, err = res.RowsAffected()
 			return err
 		})
 		if err != nil {
@@ -242,12 +270,17 @@ func (s *UserAuthTokenService) LookupToken(ctx context.Context, unhashedToken st
 		model.SeenAt = getTime().Unix()
 
 		var affectedRows int64
-		err = s.sqlStore.WithTransactionalDbSession(ctx, func(dbSession *db.Session) error {
-			affectedRows, err = dbSession.Where("id = ? AND auth_token = ?",
-				model.Id,
-				model.AuthToken).
-				AllCols().Update(&model)
-
+		err = dbHelper.DB.WithTransactionalDbSession(ctx, func(dbSession *sqlstore.DBSession) error {
+			query := tokenQuery{SQLTemplate: sqltemplate.New(dbHelper.DialectForDriver()), TokenTable: dbHelper.Table("user_auth_token"), Token: &model, ExpectedToken: model.AuthToken}
+			querySQL, err := sqltemplate.Execute(updateTokenTemplate, query)
+			if err != nil {
+				return err
+			}
+			res, err := dbSession.Exec(append([]any{querySQL}, query.GetArgs()...)...)
+			if err != nil {
+				return err
+			}
+			affectedRows, err = res.RowsAffected()
 			return err
 		})
 		if err != nil {
@@ -274,8 +307,17 @@ func (s *UserAuthTokenService) GetTokenByExternalSessionID(ctx context.Context, 
 	defer span.End()
 
 	var token userAuthToken
-	err := s.sqlStore.WithDbSession(ctx, func(dbSession *db.Session) error {
-		exists, err := dbSession.Where("external_session_id = ?", externalSessionID).Get(&token)
+	dbHelper, err := s.sql(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get legacy DB: %w", err)
+	}
+	err = dbHelper.DB.WithDbSession(ctx, func(dbSession *sqlstore.DBSession) error {
+		query := tokenQuery{SQLTemplate: sqltemplate.New(dbHelper.DialectForDriver()), TokenTable: dbHelper.Table("user_auth_token"), ExternalSessionID: externalSessionID}
+		querySQL, err := sqltemplate.Execute(getTokenByExternalSessionIDTemplate, query)
+		if err != nil {
+			return err
+		}
+		exists, err := dbSession.SQL(querySQL, query.GetArgs()...).Get(&token)
 		if err != nil {
 			return err
 		}
@@ -358,7 +400,11 @@ func (s *UserAuthTokenService) RotateToken(ctx context.Context, cmd auth.RotateC
 
 	res, err, _ := s.singleflight.Do(cmd.UnHashedToken, func() (any, error) {
 		var token *auth.UserToken
-		err := s.sqlStore.InTransaction(ctx, func(ctx context.Context) error {
+		dbHelper, err := s.sql(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("get legacy DB: %w", err)
+		}
+		err = dbHelper.DB.InTransaction(ctx, func(ctx context.Context) error {
 			var err error
 			token, err = rotate(ctx)
 			return err
@@ -392,23 +438,19 @@ func (s *UserAuthTokenService) rotateToken(ctx context.Context, token *auth.User
 		return nil, err
 	}
 
-	sql := `
-		UPDATE user_auth_token
-		SET
-			seen_at = 0,
-			user_agent = ?,
-			client_ip = ?,
-			prev_auth_token = auth_token,
-			auth_token = ?,
-			auth_token_seen = ?,
-			rotated_at = ?
-		WHERE id = ?
-	`
-
 	now := getTime()
 	var affected int64
-	err = s.sqlStore.WithDbSession(ctx, func(dbSession *db.Session) error {
-		res, err := dbSession.Exec(sql, userAgent, clientIPStr, hashedToken, s.sqlStore.GetDialect().BooleanValue(false), now.Unix(), token.Id)
+	dbHelper, err := s.sql(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get legacy DB: %w", err)
+	}
+	err = dbHelper.DB.WithDbSession(ctx, func(dbSession *sqlstore.DBSession) error {
+		query := tokenQuery{SQLTemplate: sqltemplate.New(dbHelper.DialectForDriver()), TokenTable: dbHelper.Table("user_auth_token"), UserAgent: userAgent, ClientIP: clientIPStr, HashedToken: hashedToken, RotatedAt: now.Unix(), TokenID: token.Id}
+		querySQL, err := sqltemplate.Execute(rotateTokenTemplate, query)
+		if err != nil {
+			return err
+		}
+		res, err := dbSession.Exec(append([]any{querySQL}, query.GetArgs()...)...)
 		if err != nil {
 			return err
 		}
@@ -449,16 +491,38 @@ func (s *UserAuthTokenService) RevokeToken(ctx context.Context, token *auth.User
 	ctxLogger := s.log.FromContext(ctx)
 
 	var rowsAffected int64
+	dbHelper, err := s.sql(ctx)
+	if err != nil {
+		return fmt.Errorf("get legacy DB: %w", err)
+	}
 
 	if soft {
 		model.RevokedAt = getTime().Unix()
-		err = s.sqlStore.WithDbSession(ctx, func(dbSession *db.Session) error {
-			rowsAffected, err = dbSession.ID(model.Id).Update(model)
+		err = dbHelper.DB.WithDbSession(ctx, func(dbSession *sqlstore.DBSession) error {
+			query := tokenQuery{SQLTemplate: sqltemplate.New(dbHelper.DialectForDriver()), TokenTable: dbHelper.Table("user_auth_token"), Token: model}
+			querySQL, err := sqltemplate.Execute(softRevokeTokenTemplate, query)
+			if err != nil {
+				return err
+			}
+			res, err := dbSession.Exec(append([]any{querySQL}, query.GetArgs()...)...)
+			if err != nil {
+				return err
+			}
+			rowsAffected, err = res.RowsAffected()
 			return err
 		})
 	} else {
-		err = s.sqlStore.WithDbSession(ctx, func(dbSession *db.Session) error {
-			rowsAffected, err = dbSession.Delete(model)
+		err = dbHelper.DB.WithDbSession(ctx, func(dbSession *sqlstore.DBSession) error {
+			query := tokenQuery{SQLTemplate: sqltemplate.New(dbHelper.DialectForDriver()), TokenTable: dbHelper.Table("user_auth_token"), TokenID: model.Id}
+			querySQL, err := sqltemplate.Execute(hardRevokeTokenTemplate, query)
+			if err != nil {
+				return err
+			}
+			res, err := dbSession.Exec(append([]any{querySQL}, query.GetArgs()...)...)
+			if err != nil {
+				return err
+			}
+			rowsAffected, err = res.RowsAffected()
 			return err
 		})
 	}
@@ -489,11 +553,19 @@ func (s *UserAuthTokenService) RevokeAllUserTokens(ctx context.Context, userId i
 	ctx, span := s.tracer.Start(ctx, "authtoken.RevokeAllUserTokens")
 	defer span.End()
 
-	return s.sqlStore.InTransaction(ctx, func(ctx context.Context) error {
+	dbHelper, err := s.sql(ctx)
+	if err != nil {
+		return fmt.Errorf("get legacy DB: %w", err)
+	}
+	return dbHelper.DB.InTransaction(ctx, func(ctx context.Context) error {
 		ctxLogger := s.log.FromContext(ctx)
-		err := s.sqlStore.WithDbSession(ctx, func(dbSession *db.Session) error {
-			sql := `DELETE from user_auth_token WHERE user_id = ?`
-			res, err := dbSession.Exec(sql, userId)
+		err := dbHelper.DB.WithDbSession(ctx, func(dbSession *sqlstore.DBSession) error {
+			query := tokenQuery{SQLTemplate: sqltemplate.New(dbHelper.DialectForDriver()), TokenTable: dbHelper.Table("user_auth_token"), UserID: userId}
+			querySQL, err := sqltemplate.Execute(deleteTokensByUserIDTemplate, query)
+			if err != nil {
+				return err
+			}
+			res, err := dbSession.Exec(append([]any{querySQL}, query.GetArgs()...)...)
 			if err != nil {
 				return err
 			}
@@ -524,24 +596,25 @@ func (s *UserAuthTokenService) BatchRevokeAllUserTokens(ctx context.Context, use
 	ctx, span := s.tracer.Start(ctx, "authtoken.BatchRevokeAllUserTokens")
 	defer span.End()
 
-	return s.sqlStore.InTransaction(ctx, func(ctx context.Context) error {
+	dbHelper, err := s.sql(ctx)
+	if err != nil {
+		return fmt.Errorf("get legacy DB: %w", err)
+	}
+	return dbHelper.DB.InTransaction(ctx, func(ctx context.Context) error {
 		ctxLogger := s.log.FromContext(ctx)
 		if len(userIds) == 0 {
 			return nil
 		}
 
-		userIdParams := strings.Repeat(",?", len(userIds)-1)
-		sql := "DELETE from user_auth_token WHERE user_id IN (?" + userIdParams + ")"
-
-		params := []any{sql}
-		for _, v := range userIds {
-			params = append(params, v)
-		}
-
 		var affected int64
 
-		err := s.sqlStore.WithDbSession(ctx, func(dbSession *db.Session) error {
-			res, inErr := dbSession.Exec(params...)
+		err := dbHelper.DB.WithDbSession(ctx, func(dbSession *sqlstore.DBSession) error {
+			query := tokenQuery{SQLTemplate: sqltemplate.New(dbHelper.DialectForDriver()), TokenTable: dbHelper.Table("user_auth_token"), UserIDs: userIds}
+			querySQL, inErr := sqltemplate.Execute(deleteTokensByUserIDsTemplate, query)
+			if inErr != nil {
+				return inErr
+			}
+			res, inErr := dbSession.Exec(append([]any{querySQL}, query.GetArgs()...)...)
 			if inErr != nil {
 				return inErr
 			}
@@ -569,9 +642,18 @@ func (s *UserAuthTokenService) GetUserToken(ctx context.Context, userId, userTok
 	defer span.End()
 
 	var result auth.UserToken
-	err := s.sqlStore.WithDbSession(ctx, func(dbSession *db.Session) error {
+	dbHelper, err := s.sql(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get legacy DB: %w", err)
+	}
+	err = dbHelper.DB.WithDbSession(ctx, func(dbSession *sqlstore.DBSession) error {
 		var token userAuthToken
-		exists, err := dbSession.Where("id = ? AND user_id = ?", userTokenId, userId).Get(&token)
+		query := tokenQuery{SQLTemplate: sqltemplate.New(dbHelper.DialectForDriver()), TokenTable: dbHelper.Table("user_auth_token"), TokenID: userTokenId, UserID: userId}
+		querySQL, err := sqltemplate.Execute(getUserTokenTemplate, query)
+		if err != nil {
+			return err
+		}
+		exists, err := dbSession.SQL(querySQL, query.GetArgs()...).Get(&token)
 		if err != nil {
 			return err
 		}
@@ -596,13 +678,18 @@ func (s *UserAuthTokenService) GetUserTokens(ctx context.Context, userId int64) 
 	}
 
 	result := []*auth.UserToken{}
-	err = s.sqlStore.WithDbSession(ctx, func(dbSession *db.Session) error {
+	dbHelper, err := s.sql(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get legacy DB: %w", err)
+	}
+	err = dbHelper.DB.WithDbSession(ctx, func(dbSession *sqlstore.DBSession) error {
 		var tokens []*userAuthToken
-		err := dbSession.Where("user_id = ? AND created_at > ? AND rotated_at > ? AND revoked_at = 0",
-			userId,
-			s.createdAfterParam(cfg),
-			s.rotatedAfterParam(cfg)).
-			Find(&tokens)
+		query := tokenQuery{SQLTemplate: sqltemplate.New(dbHelper.DialectForDriver()), TokenTable: dbHelper.Table("user_auth_token"), UserID: userId, CreatedAfter: s.createdAfterParam(cfg), RotatedAfter: s.rotatedAfterParam(cfg)}
+		querySQL, err := sqltemplate.Execute(getUserTokensTemplate, query)
+		if err != nil {
+			return err
+		}
+		err = dbSession.SQL(querySQL, query.GetArgs()...).Find(&tokens)
 		if err != nil {
 			return err
 		}
@@ -636,14 +723,21 @@ func (s *UserAuthTokenService) ActiveTokenCount(ctx context.Context, userID *int
 	}
 
 	var count int64
-	err = s.sqlStore.WithDbSession(ctx, func(dbSession *db.Session) error {
-		query := `SELECT COUNT(*) FROM user_auth_token WHERE created_at > ? AND rotated_at > ? AND revoked_at = 0`
-		args := []interface{}{s.createdAfterParam(cfg), s.rotatedAfterParam(cfg)}
+	dbHelper, err := s.sql(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("get legacy DB: %w", err)
+	}
+	err = dbHelper.DB.WithDbSession(ctx, func(dbSession *sqlstore.DBSession) error {
+		query := tokenQuery{SQLTemplate: sqltemplate.New(dbHelper.DialectForDriver()), TokenTable: dbHelper.Table("user_auth_token"), CreatedAfter: s.createdAfterParam(cfg), RotatedAfter: s.rotatedAfterParam(cfg)}
 		if userID != nil {
-			query += " AND user_id = ?"
-			args = append(args, *userID)
+			query.HasUserID = true
+			query.UserID = *userID
 		}
-		_, err := dbSession.SQL(query, args...).Get(&count)
+		querySQL, err := sqltemplate.Execute(countActiveTokensTemplate, query)
+		if err != nil {
+			return err
+		}
+		_, err = dbSession.SQL(querySQL, query.GetArgs()...).Get(&count)
 		return err
 	})
 
@@ -654,9 +748,17 @@ func (s *UserAuthTokenService) DeleteUserRevokedTokens(ctx context.Context, user
 	ctx, span := s.tracer.Start(ctx, "authtoken.DeleteUserRevokedTokens")
 	defer span.End()
 
-	return s.sqlStore.WithDbSession(ctx, func(sess *db.Session) error {
-		query := "DELETE FROM user_auth_token WHERE user_id = ? AND revoked_at > 0 AND revoked_at <= ?"
-		res, err := sess.Exec(query, userID, time.Now().Add(-window).Unix())
+	dbHelper, err := s.sql(ctx)
+	if err != nil {
+		return fmt.Errorf("get legacy DB: %w", err)
+	}
+	return dbHelper.DB.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
+		query := tokenQuery{SQLTemplate: sqltemplate.New(dbHelper.DialectForDriver()), TokenTable: dbHelper.Table("user_auth_token"), UserID: userID, RevokedBefore: time.Now().Add(-window).Unix()}
+		querySQL, err := sqltemplate.Execute(deleteUserRevokedTokensTemplate, query)
+		if err != nil {
+			return err
+		}
+		res, err := sess.Exec(append([]any{querySQL}, query.GetArgs()...)...)
 		if err != nil {
 			return err
 		}
@@ -676,9 +778,18 @@ func (s *UserAuthTokenService) GetUserRevokedTokens(ctx context.Context, userId 
 	defer span.End()
 
 	result := []*auth.UserToken{}
-	err := s.sqlStore.WithDbSession(ctx, func(dbSession *db.Session) error {
+	dbHelper, err := s.sql(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get legacy DB: %w", err)
+	}
+	err = dbHelper.DB.WithDbSession(ctx, func(dbSession *sqlstore.DBSession) error {
 		var tokens []*userAuthToken
-		err := dbSession.Where("user_id = ? AND revoked_at > 0", userId).Asc("seen_at").Find(&tokens)
+		query := tokenQuery{SQLTemplate: sqltemplate.New(dbHelper.DialectForDriver()), TokenTable: dbHelper.Table("user_auth_token"), UserID: userId}
+		querySQL, err := sqltemplate.Execute(getUserRevokedTokensTemplate, query)
+		if err != nil {
+			return err
+		}
+		err = dbSession.SQL(querySQL, query.GetArgs()...).Find(&tokens)
 		if err != nil {
 			return err
 		}

--- a/pkg/services/auth/authimpl/auth_token_test.go
+++ b/pkg/services/auth/authimpl/auth_token_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/secrets/fakes"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/storage/legacysql"
 	"github.com/grafana/grafana/pkg/tests/testsuite"
 	"github.com/grafana/grafana/pkg/util/testutil"
 )
@@ -888,13 +889,14 @@ func createTestContext(t *testing.T) *testContext {
 		TokenRotationIntervalMinutes: 10,
 	}
 
-	extSessionStore := provideExternalSessionStore(sqlstore, &fakes.FakeSecretsService{}, tracer)
+	sql := legacysql.NewDatabaseProvider(sqlstore)
+	extSessionStore := provideExternalSessionStore(sql, &fakes.FakeSecretsService{}, tracer)
 
 	cfgProvider, err := configprovider.ProvideService(cfg)
 	require.NoError(t, err)
 
 	tokenService := &UserAuthTokenService{
-		sqlStore:             sqlstore,
+		sql:                  sql,
 		cfgProvider:          cfgProvider,
 		log:                  log.New("test-logger"),
 		singleflight:         new(singleflight.Group),

--- a/pkg/services/auth/authimpl/external_session_store.go
+++ b/pkg/services/auth/authimpl/external_session_store.go
@@ -4,27 +4,31 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/base64"
+	"fmt"
+	"time"
 
-	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/auth"
 	"github.com/grafana/grafana/pkg/services/secrets"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
+	"github.com/grafana/grafana/pkg/storage/legacysql"
+	"github.com/grafana/grafana/pkg/storage/unified/sql/sqltemplate"
 )
 
 var _ auth.ExternalSessionStore = (*store)(nil)
 
 type store struct {
-	sqlStore       db.DB
+	sql            legacysql.LegacyDatabaseProvider
 	secretsService secrets.Service //nolint:staticcheck // SA1019: Legacy envelope encryption for single-tenant feature
 	tracer         tracing.Tracer
 }
 
-func provideExternalSessionStore(sqlStore db.DB,
+func provideExternalSessionStore(sql legacysql.LegacyDatabaseProvider,
 	secretService secrets.Service, //nolint:staticcheck // SA1019: Legacy envelope encryption for single-tenant feature
 	tracer tracing.Tracer,
 ) auth.ExternalSessionStore {
 	return &store{
-		sqlStore:       sqlStore,
+		sql:            sql,
 		secretsService: secretService,
 		tracer:         tracer,
 	}
@@ -36,8 +40,17 @@ func (s *store) Get(ctx context.Context, ID int64) (*auth.ExternalSession, error
 
 	externalSession := &auth.ExternalSession{ID: ID}
 
-	err := s.sqlStore.WithDbSession(ctx, func(sess *db.Session) error {
-		found, err := sess.Get(externalSession)
+	dbHelper, err := s.sql(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get legacy DB: %w", err)
+	}
+	err = dbHelper.DB.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
+		query := externalSessionQuery{SQLTemplate: sqltemplate.New(dbHelper.DialectForDriver()), ExternalSessionTable: dbHelper.Table("user_external_session"), ID: ID}
+		querySQL, err := sqltemplate.Execute(getExternalSessionTemplate, query)
+		if err != nil {
+			return err
+		}
+		found, err := sess.SQL(querySQL, query.GetArgs()...).Get(externalSession)
 		if err != nil {
 			return err
 		}
@@ -88,8 +101,17 @@ func (s *store) List(ctx context.Context, query *auth.ListExternalSessionQuery) 
 	}
 
 	queryResult := make([]*auth.ExternalSession, 0)
-	err := s.sqlStore.WithDbSession(ctx, func(sess *db.Session) error {
-		return sess.Desc("id").Find(&queryResult, externalSession)
+	dbHelper, err := s.sql(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get legacy DB: %w", err)
+	}
+	err = dbHelper.DB.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
+		sqlQuery := externalSessionQuery{SQLTemplate: sqltemplate.New(dbHelper.DialectForDriver()), ExternalSessionTable: dbHelper.Table("user_external_session"), ID: externalSession.ID, UserID: externalSession.UserID, SessionIDHash: externalSession.SessionIDHash, NameIDHash: externalSession.NameIDHash}
+		querySQL, err := sqltemplate.Execute(listExternalSessionsTemplate, sqlQuery)
+		if err != nil {
+			return err
+		}
+		return sess.SQL(querySQL, sqlQuery.GetArgs()...).Find(&queryResult)
 	})
 	if err != nil {
 		return nil, err
@@ -148,8 +170,32 @@ func (s *store) Create(ctx context.Context, extSession *auth.ExternalSession) er
 		return err
 	}
 
-	err = s.sqlStore.WithDbSession(ctx, func(sess *db.Session) error {
-		_, err := sess.Insert(clone)
+	dbHelper, err := s.sql(ctx)
+	if err != nil {
+		return fmt.Errorf("get legacy DB: %w", err)
+	}
+	err = dbHelper.DB.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
+		dbTZ := dbHelper.DB.GetEngine().DatabaseTZ
+		query := externalSessionQuery{
+			SQLTemplate:          sqltemplate.New(dbHelper.DialectForDriver()),
+			ExternalSessionTable: dbHelper.Table("user_external_session"),
+			Session:              clone,
+			ExpiresAt:            legacysql.NewDBTime(clone.ExpiresAt.In(dbTZ)),
+			CreatedAt:            legacysql.NewDBTime(time.Now().In(dbTZ)),
+		}
+		querySQL, err := sqltemplate.Execute(insertExternalSessionTemplate, query)
+		if err != nil {
+			return err
+		}
+		if query.DialectName() == "postgres" {
+			_, err = sess.SQL(querySQL, query.GetArgs()...).Get(&clone.ID)
+			return err
+		}
+		res, err := sess.Exec(append([]any{querySQL}, query.GetArgs()...)...)
+		if err != nil {
+			return err
+		}
+		clone.ID, err = res.LastInsertId()
 		return err
 	})
 	if err != nil {
@@ -187,8 +233,18 @@ func (s *store) Update(ctx context.Context, ID int64, cmd *auth.UpdateExternalSe
 
 	externalSession.ExpiresAt = cmd.Token.Expiry
 
-	err = s.sqlStore.WithDbSession(ctx, func(sess *db.Session) error {
-		_, err := sess.ID(ID).Cols("access_token", "refresh_token", "id_token", "expires_at").Update(externalSession)
+	dbHelper, err := s.sql(ctx)
+	if err != nil {
+		return fmt.Errorf("get legacy DB: %w", err)
+	}
+	err = dbHelper.DB.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
+		dbTZ := dbHelper.DB.GetEngine().DatabaseTZ
+		query := externalSessionQuery{SQLTemplate: sqltemplate.New(dbHelper.DialectForDriver()), ExternalSessionTable: dbHelper.Table("user_external_session"), Session: externalSession, ID: ID, ExpiresAt: legacysql.NewDBTime(externalSession.ExpiresAt.In(dbTZ))}
+		querySQL, err := sqltemplate.Execute(updateExternalSessionTemplate, query)
+		if err != nil {
+			return err
+		}
+		_, err = sess.Exec(append([]any{querySQL}, query.GetArgs()...)...)
 		return err
 	})
 	if err != nil {
@@ -202,9 +258,17 @@ func (s *store) Delete(ctx context.Context, ID int64) error {
 	ctx, span := s.tracer.Start(ctx, "externalsession.Delete")
 	defer span.End()
 
-	externalSession := &auth.ExternalSession{ID: ID}
-	err := s.sqlStore.WithDbSession(ctx, func(sess *db.Session) error {
-		_, err := sess.Delete(externalSession)
+	dbHelper, err := s.sql(ctx)
+	if err != nil {
+		return fmt.Errorf("get legacy DB: %w", err)
+	}
+	err = dbHelper.DB.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
+		query := externalSessionQuery{SQLTemplate: sqltemplate.New(dbHelper.DialectForDriver()), ExternalSessionTable: dbHelper.Table("user_external_session"), ID: ID}
+		querySQL, err := sqltemplate.Execute(deleteExternalSessionTemplate, query)
+		if err != nil {
+			return err
+		}
+		_, err = sess.Exec(append([]any{querySQL}, query.GetArgs()...)...)
 		return err
 	})
 	return err
@@ -214,9 +278,17 @@ func (s *store) DeleteExternalSessionsByUserID(ctx context.Context, userID int64
 	ctx, span := s.tracer.Start(ctx, "externalsession.DeleteExternalSessionsByUserID")
 	defer span.End()
 
-	externalSession := &auth.ExternalSession{UserID: userID}
-	err := s.sqlStore.WithDbSession(ctx, func(sess *db.Session) error {
-		_, err := sess.Delete(externalSession)
+	dbHelper, err := s.sql(ctx)
+	if err != nil {
+		return fmt.Errorf("get legacy DB: %w", err)
+	}
+	err = dbHelper.DB.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
+		query := externalSessionQuery{SQLTemplate: sqltemplate.New(dbHelper.DialectForDriver()), ExternalSessionTable: dbHelper.Table("user_external_session"), UserID: userID}
+		querySQL, err := sqltemplate.Execute(deleteExternalSessionsByUserIDTemplate, query)
+		if err != nil {
+			return err
+		}
+		_, err = sess.Exec(append([]any{querySQL}, query.GetArgs()...)...)
 		return err
 	})
 	return err
@@ -225,10 +297,21 @@ func (s *store) DeleteExternalSessionsByUserID(ctx context.Context, userID int64
 func (s *store) BatchDeleteExternalSessionsByUserIDs(ctx context.Context, userIDs []int64) error {
 	ctx, span := s.tracer.Start(ctx, "externalsession.BatchDeleteExternalSessionsByUserIDs")
 	defer span.End()
+	if len(userIDs) == 0 {
+		return nil
+	}
 
-	externalSession := &auth.ExternalSession{}
-	err := s.sqlStore.WithDbSession(ctx, func(sess *db.Session) error {
-		_, err := sess.In("user_id", userIDs).Delete(externalSession)
+	dbHelper, err := s.sql(ctx)
+	if err != nil {
+		return fmt.Errorf("get legacy DB: %w", err)
+	}
+	err = dbHelper.DB.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
+		query := externalSessionQuery{SQLTemplate: sqltemplate.New(dbHelper.DialectForDriver()), ExternalSessionTable: dbHelper.Table("user_external_session"), UserIDs: userIDs}
+		querySQL, err := sqltemplate.Execute(deleteExternalSessionsByUserIDsTemplate, query)
+		if err != nil {
+			return err
+		}
+		_, err = sess.Exec(append([]any{querySQL}, query.GetArgs()...)...)
 		return err
 	})
 	return err

--- a/pkg/services/auth/authimpl/external_session_store_test.go
+++ b/pkg/services/auth/authimpl/external_session_store_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/auth"
 	"github.com/grafana/grafana/pkg/services/secrets/fakes"
+	"github.com/grafana/grafana/pkg/storage/legacysql"
 	"github.com/grafana/grafana/pkg/util/testutil"
 	"github.com/stretchr/testify/require"
 )
@@ -207,12 +208,19 @@ func TestIntegrationBatchDeleteExternalSessionsByUserIDs(t *testing.T) {
 		err := store.BatchDeleteExternalSessionsByUserIDs(context.Background(), []int64{999, 1000})
 		require.NoError(t, err)
 	})
+
+	t.Run("returns no error for no user IDs", func(t *testing.T) {
+		store := setupTest(t)
+
+		err := store.BatchDeleteExternalSessionsByUserIDs(context.Background(), nil)
+		require.NoError(t, err)
+	})
 }
 
 func setupTest(t *testing.T) *store {
 	sqlStore := db.InitTestDB(t)
 	secretService := fakes.NewFakeSecretsService()
 	tracer := tracing.InitializeTracerForTest()
-	externalSessionStore := provideExternalSessionStore(sqlStore, secretService, tracer).(*store)
+	externalSessionStore := provideExternalSessionStore(legacysql.NewDatabaseProvider(sqlStore), secretService, tracer).(*store)
 	return externalSessionStore
 }

--- a/pkg/services/auth/authimpl/queries.go
+++ b/pkg/services/auth/authimpl/queries.go
@@ -1,0 +1,84 @@
+package authimpl
+
+import (
+	"strings"
+
+	"github.com/grafana/grafana/pkg/services/auth"
+	"github.com/grafana/grafana/pkg/storage/legacysql"
+	"github.com/grafana/grafana/pkg/storage/unified/sql/sqltemplate"
+)
+
+type tokenQuery struct {
+	sqltemplate.SQLTemplate
+	TokenTable        string
+	Token             *userAuthToken
+	HashedToken       string
+	ExpectedToken     string
+	Previous          bool
+	ExternalSessionID int64
+	UserAgent         string
+	ClientIP          string
+	RotatedAt         int64
+	TokenID           int64
+	UserID            int64
+	UserIDs           []int64
+	CreatedAfter      int64
+	RotatedAfter      int64
+	HasUserID         bool
+	RevokedBefore     int64
+	CreatedBefore     int64
+	RotatedBefore     int64
+}
+
+func (q tokenQuery) Validate() error { return nil }
+
+func (q tokenQuery) TokenColumns() (string, error) {
+	columns := []string{"id", "user_id", "auth_token", "prev_auth_token", "user_agent", "client_ip", "auth_token_seen", "seen_at", "rotated_at", "created_at", "updated_at", "revoked_at", "external_session_id"}
+	quoted := make([]string, len(columns))
+	for i, column := range columns {
+		var err error
+		quoted[i], err = q.Ident(column)
+		if err != nil {
+			return "", err
+		}
+	}
+	return strings.Join(quoted, ", "), nil
+}
+
+type externalSessionQuery struct {
+	sqltemplate.SQLTemplate
+	ExternalSessionTable string
+	Session              *auth.ExternalSession
+	ID                   int64
+	UserID               int64
+	UserIDs              []int64
+	SessionIDHash        string
+	NameIDHash           string
+	ExpiresAt            legacysql.DBTime
+	CreatedAt            legacysql.DBTime
+}
+
+func (q externalSessionQuery) Validate() error { return nil }
+
+func (q externalSessionQuery) ExternalSessionColumns() (string, error) {
+	columns := []string{"id", "user_id", "user_auth_id", "auth_module", "access_token", "id_token", "refresh_token", "session_id", "session_id_hash", "name_id", "name_id_hash", "expires_at", "created_at"}
+	quoted := make([]string, len(columns))
+	for i, column := range columns {
+		var err error
+		quoted[i], err = q.Ident(column)
+		if err != nil {
+			return "", err
+		}
+	}
+	return strings.Join(quoted, ", "), nil
+}
+
+type orphanedExternalSessionsQuery struct {
+	sqltemplate.SQLTemplate
+	ExternalSessionTable         string
+	TokenTable                   string
+	ExternalSessionIDColumn      string
+	TokenExternalSessionIDColumn string
+}
+
+func (q orphanedExternalSessionsQuery) Validate() error { return nil }

--- a/pkg/services/auth/authimpl/queries/count_active_tokens.sql
+++ b/pkg/services/auth/authimpl/queries/count_active_tokens.sql
@@ -1,0 +1,2 @@
+SELECT COUNT(*) FROM {{ .Ident .TokenTable }}
+WHERE {{ .Ident "created_at" }} > {{ .Arg .CreatedAfter }} AND {{ .Ident "rotated_at" }} > {{ .Arg .RotatedAfter }} AND {{ .Ident "revoked_at" }} = {{ .Arg 0 }}{{ if .HasUserID }} AND {{ .Ident "user_id" }} = {{ .Arg .UserID }}{{ end }};

--- a/pkg/services/auth/authimpl/queries/delete_expired_tokens.sql
+++ b/pkg/services/auth/authimpl/queries/delete_expired_tokens.sql
@@ -1,0 +1,1 @@
+DELETE FROM {{ .Ident .TokenTable }} WHERE {{ .Ident "created_at" }} <= {{ .Arg .CreatedBefore }} OR {{ .Ident "rotated_at" }} <= {{ .Arg .RotatedBefore }};

--- a/pkg/services/auth/authimpl/queries/delete_external_session.sql
+++ b/pkg/services/auth/authimpl/queries/delete_external_session.sql
@@ -1,0 +1,1 @@
+DELETE FROM {{ .Ident .ExternalSessionTable }} WHERE {{ .Ident "id" }} = {{ .Arg .ID }};

--- a/pkg/services/auth/authimpl/queries/delete_external_sessions_by_user_id.sql
+++ b/pkg/services/auth/authimpl/queries/delete_external_sessions_by_user_id.sql
@@ -1,0 +1,1 @@
+DELETE FROM {{ .Ident .ExternalSessionTable }} WHERE {{ .Ident "user_id" }} = {{ .Arg .UserID }};

--- a/pkg/services/auth/authimpl/queries/delete_external_sessions_by_user_ids.sql
+++ b/pkg/services/auth/authimpl/queries/delete_external_sessions_by_user_ids.sql
@@ -1,0 +1,1 @@
+DELETE FROM {{ .Ident .ExternalSessionTable }} WHERE {{ .Ident "user_id" }} IN ({{ range $i, $id := .UserIDs }}{{ if $i }}, {{ end }}{{ $.Arg $id }}{{ end }});

--- a/pkg/services/auth/authimpl/queries/delete_orphaned_external_sessions.sql
+++ b/pkg/services/auth/authimpl/queries/delete_orphaned_external_sessions.sql
@@ -1,0 +1,5 @@
+DELETE FROM {{ .Ident .ExternalSessionTable }}
+WHERE NOT EXISTS (
+  SELECT 1 FROM {{ .Ident .TokenTable }} AS {{ .Ident "token" }}
+  WHERE {{ .Ident .ExternalSessionIDColumn }} = {{ .Ident .TokenExternalSessionIDColumn }}
+);

--- a/pkg/services/auth/authimpl/queries/delete_tokens_by_user_id.sql
+++ b/pkg/services/auth/authimpl/queries/delete_tokens_by_user_id.sql
@@ -1,0 +1,1 @@
+DELETE FROM {{ .Ident .TokenTable }} WHERE {{ .Ident "user_id" }} = {{ .Arg .UserID }};

--- a/pkg/services/auth/authimpl/queries/delete_tokens_by_user_ids.sql
+++ b/pkg/services/auth/authimpl/queries/delete_tokens_by_user_ids.sql
@@ -1,0 +1,1 @@
+DELETE FROM {{ .Ident .TokenTable }} WHERE {{ .Ident "user_id" }} IN ({{ range $i, $id := .UserIDs }}{{ if $i }}, {{ end }}{{ $.Arg $id }}{{ end }});

--- a/pkg/services/auth/authimpl/queries/delete_user_revoked_tokens.sql
+++ b/pkg/services/auth/authimpl/queries/delete_user_revoked_tokens.sql
@@ -1,0 +1,1 @@
+DELETE FROM {{ .Ident .TokenTable }} WHERE {{ .Ident "user_id" }} = {{ .Arg .UserID }} AND {{ .Ident "revoked_at" }} > {{ .Arg 0 }} AND {{ .Ident "revoked_at" }} <= {{ .Arg .RevokedBefore }};

--- a/pkg/services/auth/authimpl/queries/get_external_session.sql
+++ b/pkg/services/auth/authimpl/queries/get_external_session.sql
@@ -1,0 +1,1 @@
+SELECT {{ .ExternalSessionColumns }} FROM {{ .Ident .ExternalSessionTable }} WHERE {{ .Ident "id" }} = {{ .Arg .ID }};

--- a/pkg/services/auth/authimpl/queries/get_token_by_external_session_id.sql
+++ b/pkg/services/auth/authimpl/queries/get_token_by_external_session_id.sql
@@ -1,0 +1,2 @@
+SELECT {{ .TokenColumns }} FROM {{ .Ident .TokenTable }}
+WHERE {{ .Ident "external_session_id" }} = {{ .Arg .ExternalSessionID }};

--- a/pkg/services/auth/authimpl/queries/get_user_revoked_tokens.sql
+++ b/pkg/services/auth/authimpl/queries/get_user_revoked_tokens.sql
@@ -1,0 +1,2 @@
+SELECT {{ .TokenColumns }} FROM {{ .Ident .TokenTable }}
+WHERE {{ .Ident "user_id" }} = {{ .Arg .UserID }} AND {{ .Ident "revoked_at" }} > {{ .Arg 0 }} ORDER BY {{ .Ident "seen_at" }} ASC;

--- a/pkg/services/auth/authimpl/queries/get_user_token.sql
+++ b/pkg/services/auth/authimpl/queries/get_user_token.sql
@@ -1,0 +1,2 @@
+SELECT {{ .TokenColumns }} FROM {{ .Ident .TokenTable }}
+WHERE {{ .Ident "id" }} = {{ .Arg .TokenID }} AND {{ .Ident "user_id" }} = {{ .Arg .UserID }};

--- a/pkg/services/auth/authimpl/queries/get_user_tokens.sql
+++ b/pkg/services/auth/authimpl/queries/get_user_tokens.sql
@@ -1,0 +1,2 @@
+SELECT {{ .TokenColumns }} FROM {{ .Ident .TokenTable }}
+WHERE {{ .Ident "user_id" }} = {{ .Arg .UserID }} AND {{ .Ident "created_at" }} > {{ .Arg .CreatedAfter }} AND {{ .Ident "rotated_at" }} > {{ .Arg .RotatedAfter }} AND {{ .Ident "revoked_at" }} = {{ .Arg 0 }};

--- a/pkg/services/auth/authimpl/queries/hard_revoke_token.sql
+++ b/pkg/services/auth/authimpl/queries/hard_revoke_token.sql
@@ -1,0 +1,1 @@
+DELETE FROM {{ .Ident .TokenTable }} WHERE {{ .Ident "id" }} = {{ .Arg .TokenID }};

--- a/pkg/services/auth/authimpl/queries/insert_external_session.sql
+++ b/pkg/services/auth/authimpl/queries/insert_external_session.sql
@@ -1,0 +1,11 @@
+INSERT INTO {{ .Ident .ExternalSessionTable }} (
+  {{ .Ident "user_id" }}, {{ .Ident "user_auth_id" }}, {{ .Ident "auth_module" }},
+  {{ .Ident "access_token" }}, {{ .Ident "id_token" }}, {{ .Ident "refresh_token" }},
+  {{ .Ident "session_id" }}, {{ .Ident "session_id_hash" }}, {{ .Ident "name_id" }},
+  {{ .Ident "name_id_hash" }}, {{ .Ident "expires_at" }}, {{ .Ident "created_at" }}
+) VALUES (
+  {{ .Arg .Session.UserID }}, {{ .Arg .Session.UserAuthID }}, {{ .Arg .Session.AuthModule }},
+  {{ .Arg .Session.AccessToken }}, {{ .Arg .Session.IDToken }}, {{ .Arg .Session.RefreshToken }},
+  {{ .Arg .Session.SessionID }}, {{ .Arg .Session.SessionIDHash }}, {{ .Arg .Session.NameID }},
+  {{ .Arg .Session.NameIDHash }}, {{ .Arg .ExpiresAt }}, {{ .Arg .CreatedAt }}
+){{ if eq .DialectName "postgres" }} RETURNING {{ .Ident "id" }}{{ end }};

--- a/pkg/services/auth/authimpl/queries/insert_token.sql
+++ b/pkg/services/auth/authimpl/queries/insert_token.sql
@@ -1,0 +1,11 @@
+INSERT INTO {{ .Ident .TokenTable }} (
+  {{ .Ident "user_id" }}, {{ .Ident "auth_token" }}, {{ .Ident "prev_auth_token" }},
+  {{ .Ident "user_agent" }}, {{ .Ident "client_ip" }}, {{ .Ident "auth_token_seen" }},
+  {{ .Ident "seen_at" }}, {{ .Ident "rotated_at" }}, {{ .Ident "created_at" }},
+  {{ .Ident "updated_at" }}, {{ .Ident "revoked_at" }}, {{ .Ident "external_session_id" }}
+) VALUES (
+  {{ .Arg .Token.UserId }}, {{ .Arg .Token.AuthToken }}, {{ .Arg .Token.PrevAuthToken }},
+  {{ .Arg .Token.UserAgent }}, {{ .Arg .Token.ClientIp }}, {{ .Arg .Token.AuthTokenSeen }},
+  {{ .Arg .Token.SeenAt }}, {{ .Arg .Token.RotatedAt }}, {{ .Arg .Token.CreatedAt }},
+  {{ .Arg .Token.UpdatedAt }}, {{ .Arg .Token.RevokedAt }}, {{ .Arg .Token.ExternalSessionId }}
+){{ if eq .DialectName "postgres" }} RETURNING {{ .Ident "id" }}{{ end }};

--- a/pkg/services/auth/authimpl/queries/list_external_sessions.sql
+++ b/pkg/services/auth/authimpl/queries/list_external_sessions.sql
@@ -1,0 +1,8 @@
+SELECT {{ .ExternalSessionColumns }} FROM {{ .Ident .ExternalSessionTable }}
+{{ if or .ID .UserID .SessionIDHash .NameIDHash }}WHERE {{ end }}
+{{- $and := false -}}
+{{- if .ID }}{{ .Ident "id" }} = {{ .Arg .ID }}{{ $and = true }}{{ end -}}
+{{- if .UserID }}{{ if $and }} AND {{ end }}{{ .Ident "user_id" }} = {{ .Arg .UserID }}{{ $and = true }}{{ end -}}
+{{- if .SessionIDHash }}{{ if $and }} AND {{ end }}{{ .Ident "session_id_hash" }} = {{ .Arg .SessionIDHash }}{{ $and = true }}{{ end -}}
+{{- if .NameIDHash }}{{ if $and }} AND {{ end }}{{ .Ident "name_id_hash" }} = {{ .Arg .NameIDHash }}{{ end }}
+ORDER BY {{ .Ident "id" }} DESC;

--- a/pkg/services/auth/authimpl/queries/lookup_token.sql
+++ b/pkg/services/auth/authimpl/queries/lookup_token.sql
@@ -1,0 +1,3 @@
+SELECT {{ .TokenColumns }}
+FROM {{ .Ident .TokenTable }}
+WHERE ({{ .Ident "auth_token" }} = {{ .Arg .HashedToken }} OR {{ .Ident "prev_auth_token" }} = {{ .Arg .HashedToken }});

--- a/pkg/services/auth/authimpl/queries/rotate_token.sql
+++ b/pkg/services/auth/authimpl/queries/rotate_token.sql
@@ -1,0 +1,9 @@
+UPDATE {{ .Ident .TokenTable }} SET
+  {{ .Ident "seen_at" }} = {{ .Arg 0 }},
+  {{ .Ident "user_agent" }} = {{ .Arg .UserAgent }},
+  {{ .Ident "client_ip" }} = {{ .Arg .ClientIP }},
+  {{ .Ident "prev_auth_token" }} = {{ .Ident "auth_token" }},
+  {{ .Ident "auth_token" }} = {{ .Arg .HashedToken }},
+  {{ .Ident "auth_token_seen" }} = {{ .Arg false }},
+  {{ .Ident "rotated_at" }} = {{ .Arg .RotatedAt }}
+WHERE {{ .Ident "id" }} = {{ .Arg .TokenID }};

--- a/pkg/services/auth/authimpl/queries/soft_revoke_token.sql
+++ b/pkg/services/auth/authimpl/queries/soft_revoke_token.sql
@@ -1,0 +1,15 @@
+UPDATE {{ .Ident .TokenTable }} SET
+  {{- $sep := "" -}}
+  {{- if ne .Token.UserId 0 }}{{ $sep }} {{ .Ident "user_id" }} = {{ .Arg .Token.UserId }}{{ $sep = "," }}{{ end -}}
+  {{- if ne .Token.AuthToken "" }}{{ $sep }} {{ .Ident "auth_token" }} = {{ .Arg .Token.AuthToken }}{{ $sep = "," }}{{ end -}}
+  {{- if ne .Token.PrevAuthToken "" }}{{ $sep }} {{ .Ident "prev_auth_token" }} = {{ .Arg .Token.PrevAuthToken }}{{ $sep = "," }}{{ end -}}
+  {{- if ne .Token.UserAgent "" }}{{ $sep }} {{ .Ident "user_agent" }} = {{ .Arg .Token.UserAgent }}{{ $sep = "," }}{{ end -}}
+  {{- if ne .Token.ClientIp "" }}{{ $sep }} {{ .Ident "client_ip" }} = {{ .Arg .Token.ClientIp }}{{ $sep = "," }}{{ end -}}
+  {{- if .Token.AuthTokenSeen }}{{ $sep }} {{ .Ident "auth_token_seen" }} = {{ .Arg .Token.AuthTokenSeen }}{{ $sep = "," }}{{ end -}}
+  {{- if ne .Token.SeenAt 0 }}{{ $sep }} {{ .Ident "seen_at" }} = {{ .Arg .Token.SeenAt }}{{ $sep = "," }}{{ end -}}
+  {{- if ne .Token.RotatedAt 0 }}{{ $sep }} {{ .Ident "rotated_at" }} = {{ .Arg .Token.RotatedAt }}{{ $sep = "," }}{{ end -}}
+  {{- if ne .Token.CreatedAt 0 }}{{ $sep }} {{ .Ident "created_at" }} = {{ .Arg .Token.CreatedAt }}{{ $sep = "," }}{{ end -}}
+  {{- if ne .Token.UpdatedAt 0 }}{{ $sep }} {{ .Ident "updated_at" }} = {{ .Arg .Token.UpdatedAt }}{{ $sep = "," }}{{ end -}}
+  {{- if ne .Token.RevokedAt 0 }}{{ $sep }} {{ .Ident "revoked_at" }} = {{ .Arg .Token.RevokedAt }}{{ $sep = "," }}{{ end -}}
+  {{- if ne .Token.ExternalSessionId 0 }}{{ $sep }} {{ .Ident "external_session_id" }} = {{ .Arg .Token.ExternalSessionId }}{{ end }}
+WHERE {{ .Ident "id" }} = {{ .Arg .Token.Id }};

--- a/pkg/services/auth/authimpl/queries/update_external_session.sql
+++ b/pkg/services/auth/authimpl/queries/update_external_session.sql
@@ -1,0 +1,6 @@
+UPDATE {{ .Ident .ExternalSessionTable }} SET
+  {{ .Ident "access_token" }} = {{ .Arg .Session.AccessToken }},
+  {{ .Ident "refresh_token" }} = {{ .Arg .Session.RefreshToken }},
+  {{ .Ident "id_token" }} = {{ .Arg .Session.IDToken }},
+  {{ .Ident "expires_at" }} = {{ .Arg .ExpiresAt }}
+WHERE {{ .Ident "id" }} = {{ .Arg .ID }};

--- a/pkg/services/auth/authimpl/queries/update_token.sql
+++ b/pkg/services/auth/authimpl/queries/update_token.sql
@@ -1,0 +1,14 @@
+UPDATE {{ .Ident .TokenTable }} SET
+  {{ .Ident "user_id" }} = {{ .Arg .Token.UserId }},
+  {{ .Ident "auth_token" }} = {{ .Arg .Token.AuthToken }},
+  {{ .Ident "prev_auth_token" }} = {{ .Arg .Token.PrevAuthToken }},
+  {{ .Ident "user_agent" }} = {{ .Arg .Token.UserAgent }},
+  {{ .Ident "client_ip" }} = {{ .Arg .Token.ClientIp }},
+  {{ .Ident "auth_token_seen" }} = {{ .Arg .Token.AuthTokenSeen }},
+  {{ .Ident "seen_at" }} = {{ .Arg .Token.SeenAt }},
+  {{ .Ident "rotated_at" }} = {{ .Arg .Token.RotatedAt }},
+  {{ .Ident "created_at" }} = {{ .Arg .Token.CreatedAt }},
+  {{ .Ident "updated_at" }} = {{ .Arg .Token.UpdatedAt }},
+  {{ .Ident "revoked_at" }} = {{ .Arg .Token.RevokedAt }},
+  {{ .Ident "external_session_id" }} = {{ .Arg .Token.ExternalSessionId }}
+WHERE {{ .Ident "id" }} = {{ .Arg .Token.Id }} AND {{ if .Previous }}{{ .Ident "prev_auth_token" }} = {{ .Arg .ExpectedToken }} AND {{ .Ident "rotated_at" }} < {{ .Arg .Token.RotatedAt }}{{ else }}{{ .Ident "auth_token" }} = {{ .Arg .ExpectedToken }}{{ end }};

--- a/pkg/services/auth/authimpl/runtime_sql_test.go
+++ b/pkg/services/auth/authimpl/runtime_sql_test.go
@@ -1,0 +1,151 @@
+package authimpl
+
+import (
+	"context"
+	"regexp"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/configprovider"
+	"github.com/grafana/grafana/pkg/infra/db/dbtest"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/infra/tracing"
+	"github.com/grafana/grafana/pkg/services/secrets/fakes"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
+	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/storage/legacysql"
+	"github.com/grafana/grafana/pkg/util/xorm"
+	"github.com/grafana/grafana/pkg/util/xorm/core"
+)
+
+var registerAuthSQLMockDriverOnce sync.Once
+
+type authSQLMockDriver struct{}
+
+func (authSQLMockDriver) Parse(string, string) (*core.Uri, error) {
+	return &core.Uri{DbType: core.SQLITE}, nil
+}
+
+type authSQLMockDB struct {
+	dbtest.FakeDB
+	engine *xorm.Engine
+}
+
+func (d *authSQLMockDB) WithDbSession(ctx context.Context, callback sqlstore.DBTransactionFunc) error {
+	sess := &sqlstore.DBSession{Session: d.engine.NewSession()}
+	defer sess.Close()
+	return callback(sess)
+}
+
+func (d *authSQLMockDB) GetDBType() core.DbType  { return core.SQLITE }
+func (d *authSQLMockDB) GetEngine() *xorm.Engine { return d.engine }
+
+type runtimeContextKey struct{}
+
+func newRuntimeSQLTest(t *testing.T) (sqlmock.Sqlmock, legacysql.LegacyDatabaseProvider) {
+	t.Helper()
+	registerAuthSQLMockDriverOnce.Do(func() {
+		if core.QueryDriver("sqlmock") == nil {
+			core.RegisterDriver("sqlmock", authSQLMockDriver{})
+		}
+	})
+
+	dsn := t.Name()
+	mockDB, mock, err := sqlmock.NewWithDSN(dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = mockDB.Close() })
+	engine, err := xorm.NewEngine("sqlmock", dsn)
+	require.NoError(t, err)
+	engine.DatabaseTZ = time.UTC
+	t.Cleanup(func() { _ = engine.Close() })
+
+	providerCalls := 0
+	provider := func(ctx context.Context) (*legacysql.LegacyDatabaseHelper, error) {
+		require.Equal(t, "request-context", ctx.Value(runtimeContextKey{}))
+		providerCalls++
+		return &legacysql.LegacyDatabaseHelper{
+			DB: &authSQLMockDB{engine: engine},
+			Table: func(name string) string {
+				return "test_schema." + name
+			},
+		}, nil
+	}
+	t.Cleanup(func() { require.Equal(t, 1, providerCalls) })
+	return mock, provider
+}
+
+func TestRuntimeSQLUsesRequestProviderAndQualifiedTables(t *testing.T) {
+	ctx := context.WithValue(context.Background(), runtimeContextKey{}, "request-context")
+
+	t.Run("token query", func(t *testing.T) {
+		mock, provider := newRuntimeSQLTest(t)
+		query := `SELECT "id", "user_id", "auth_token", "prev_auth_token", "user_agent", "client_ip", "auth_token_seen", "seen_at", "rotated_at", "created_at", "updated_at", "revoked_at", "external_session_id" FROM "test_schema"."user_auth_token"
+WHERE "id" = ? AND "user_id" = ?;`
+		mock.ExpectQuery(regexp.QuoteMeta(query)).WithArgs(int64(11), int64(22)).WillReturnRows(sqlmock.NewRows([]string{"id", "user_id"}).AddRow(11, 22))
+		svc := &UserAuthTokenService{sql: provider, tracer: tracing.InitializeTracerForTest()}
+		token, err := svc.GetUserToken(ctx, 22, 11)
+		require.NoError(t, err)
+		require.Equal(t, int64(11), token.Id)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("token lookup repeats the hash argument", func(t *testing.T) {
+		mock, provider := newRuntimeSQLTest(t)
+		cfgProvider, err := configprovider.ProvideService(&setting.Cfg{SecretKey: "secret"})
+		require.NoError(t, err)
+		hashedToken := hashToken("secret", "plain-token")
+		query := `SELECT "id", "user_id", "auth_token", "prev_auth_token", "user_agent", "client_ip", "auth_token_seen", "seen_at", "rotated_at", "created_at", "updated_at", "revoked_at", "external_session_id"
+FROM "test_schema"."user_auth_token"
+WHERE ("auth_token" = ? OR "prev_auth_token" = ?);`
+		mock.ExpectQuery(regexp.QuoteMeta(query)).WithArgs(hashedToken, hashedToken).WillReturnRows(
+			sqlmock.NewRows([]string{"id", "user_id", "auth_token", "prev_auth_token", "revoked_at"}).AddRow(11, 22, hashedToken, hashedToken, 1),
+		)
+		svc := &UserAuthTokenService{sql: provider, cfgProvider: cfgProvider, log: log.NewNopLogger(), tracer: tracing.InitializeTracerForTest()}
+		_, err = svc.LookupToken(ctx, "plain-token")
+		require.Error(t, err)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("external session query", func(t *testing.T) {
+		mock, provider := newRuntimeSQLTest(t)
+		query := `SELECT "id", "user_id", "user_auth_id", "auth_module", "access_token", "id_token", "refresh_token", "session_id", "session_id_hash", "name_id", "name_id_hash", "expires_at", "created_at" FROM "test_schema"."user_external_session" WHERE "id" = ?;`
+		mock.ExpectQuery(regexp.QuoteMeta(query)).WithArgs(int64(9)).WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(9))
+		store := provideExternalSessionStore(provider, fakes.NewFakeSecretsService(), tracing.InitializeTracerForTest())
+		session, err := store.Get(ctx, 9)
+		require.NoError(t, err)
+		require.Equal(t, int64(9), session.ID)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("cleanup query", func(t *testing.T) {
+		mock, provider := newRuntimeSQLTest(t)
+		now := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+		oldGetTime := getTime
+		getTime = func() time.Time { return now }
+		t.Cleanup(func() { getTime = oldGetTime })
+		query := `DELETE FROM "test_schema"."user_auth_token" WHERE "created_at" <= ? OR "rotated_at" <= ?;`
+		mock.ExpectExec(regexp.QuoteMeta(query)).WithArgs(now.Add(-2*time.Hour).Unix(), now.Add(-time.Hour).Unix()).WillReturnResult(sqlmock.NewResult(0, 3))
+		svc := &UserAuthTokenService{sql: provider, log: log.NewNopLogger()}
+		affected, err := svc.deleteExpiredTokens(ctx, time.Hour, 2*time.Hour)
+		require.NoError(t, err)
+		require.Equal(t, int64(3), affected)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("orphan query", func(t *testing.T) {
+		mock, provider := newRuntimeSQLTest(t)
+		query := `DELETE FROM "test_schema"."user_external_session"
+WHERE NOT EXISTS (
+  SELECT 1 FROM "test_schema"."user_auth_token" AS "token"
+  WHERE "user_external_session"."id" = "token"."external_session_id"
+);`
+		mock.ExpectExec(regexp.QuoteMeta(query)).WillReturnResult(sqlmock.NewResult(0, 1))
+		svc := &UserAuthTokenService{sql: provider, log: log.NewNopLogger()}
+		require.NoError(t, svc.deleteOrphanedExternalSessions(ctx))
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+}

--- a/pkg/services/auth/authimpl/templates.go
+++ b/pkg/services/auth/authimpl/templates.go
@@ -1,0 +1,45 @@
+package authimpl
+
+import (
+	"embed"
+	"fmt"
+	"text/template"
+)
+
+//go:embed queries/*.sql
+var sqlTemplatesFS embed.FS
+
+var sqlTemplates = template.Must(template.New("sql").ParseFS(sqlTemplatesFS, "queries/*.sql"))
+
+func mustTemplate(filename string) *template.Template {
+	if tmpl := sqlTemplates.Lookup(filename); tmpl != nil {
+		return tmpl
+	}
+	panic(fmt.Sprintf("template file not found: %s", filename))
+}
+
+var (
+	insertTokenTemplate                     = mustTemplate("insert_token.sql")
+	lookupTokenTemplate                     = mustTemplate("lookup_token.sql")
+	updateTokenTemplate                     = mustTemplate("update_token.sql")
+	getTokenByExternalSessionIDTemplate     = mustTemplate("get_token_by_external_session_id.sql")
+	rotateTokenTemplate                     = mustTemplate("rotate_token.sql")
+	softRevokeTokenTemplate                 = mustTemplate("soft_revoke_token.sql")
+	hardRevokeTokenTemplate                 = mustTemplate("hard_revoke_token.sql")
+	deleteTokensByUserIDTemplate            = mustTemplate("delete_tokens_by_user_id.sql")
+	deleteTokensByUserIDsTemplate           = mustTemplate("delete_tokens_by_user_ids.sql")
+	getUserTokenTemplate                    = mustTemplate("get_user_token.sql")
+	getUserTokensTemplate                   = mustTemplate("get_user_tokens.sql")
+	countActiveTokensTemplate               = mustTemplate("count_active_tokens.sql")
+	deleteUserRevokedTokensTemplate         = mustTemplate("delete_user_revoked_tokens.sql")
+	getUserRevokedTokensTemplate            = mustTemplate("get_user_revoked_tokens.sql")
+	getExternalSessionTemplate              = mustTemplate("get_external_session.sql")
+	listExternalSessionsTemplate            = mustTemplate("list_external_sessions.sql")
+	insertExternalSessionTemplate           = mustTemplate("insert_external_session.sql")
+	updateExternalSessionTemplate           = mustTemplate("update_external_session.sql")
+	deleteExternalSessionTemplate           = mustTemplate("delete_external_session.sql")
+	deleteExternalSessionsByUserIDTemplate  = mustTemplate("delete_external_sessions_by_user_id.sql")
+	deleteExternalSessionsByUserIDsTemplate = mustTemplate("delete_external_sessions_by_user_ids.sql")
+	deleteExpiredTokensTemplate             = mustTemplate("delete_expired_tokens.sql")
+	deleteOrphanedExternalSessionsTemplate  = mustTemplate("delete_orphaned_external_sessions.sql")
+)

--- a/pkg/services/auth/authimpl/templates_test.go
+++ b/pkg/services/auth/authimpl/templates_test.go
@@ -1,0 +1,80 @@
+package authimpl
+
+import (
+	"testing"
+	"text/template"
+	"time"
+
+	"github.com/grafana/grafana/pkg/services/auth"
+	"github.com/grafana/grafana/pkg/storage/legacysql"
+	"github.com/grafana/grafana/pkg/storage/unified/sql/sqltemplate"
+	"github.com/grafana/grafana/pkg/storage/unified/sql/sqltemplate/mocks"
+)
+
+func TestTemplates(t *testing.T) {
+	tokenTable := "test_schema.user_auth_token"
+	externalSessionTable := "test_schema.user_external_session"
+	newSQLTemplate := func() sqltemplate.SQLTemplate { return mocks.NewTestingSQLTemplate() }
+	token := &userAuthToken{Id: 1, UserId: 2, AuthToken: "token", PrevAuthToken: "previous", UserAgent: "agent", ClientIp: "127.0.0.1", AuthTokenSeen: true, SeenAt: 3, RotatedAt: 4, CreatedAt: 5, UpdatedAt: 6, RevokedAt: 7, ExternalSessionId: 8}
+	now := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+	session := &auth.ExternalSession{UserID: 2, UserAuthID: 3, AuthModule: "oauth", AccessToken: "access", IDToken: "id", RefreshToken: "refresh", SessionID: "session", SessionIDHash: "session-hash", NameID: "name", NameIDHash: "name-hash"}
+	tokenCase := func(name string, mutate func(*tokenQuery)) mocks.TemplateTestCase {
+		query := tokenQuery{SQLTemplate: newSQLTemplate(), TokenTable: tokenTable, Token: token, HashedToken: "hash", ExpectedToken: "expected", ExternalSessionID: 8, UserAgent: "agent", ClientIP: "127.0.0.1", RotatedAt: 4, TokenID: 1, UserID: 2, UserIDs: []int64{2, 4}, CreatedAfter: 5, RotatedAfter: 6, RevokedBefore: 7, CreatedBefore: 8, RotatedBefore: 9}
+		if mutate != nil {
+			mutate(&query)
+		}
+		return mocks.TemplateTestCase{Name: name, Data: query}
+	}
+	externalCase := func(name string, mutate func(*externalSessionQuery)) mocks.TemplateTestCase {
+		query := externalSessionQuery{SQLTemplate: newSQLTemplate(), ExternalSessionTable: externalSessionTable, Session: session, ID: 1, UserID: 2, UserIDs: []int64{2, 4}, SessionIDHash: "session-hash", NameIDHash: "name-hash", ExpiresAt: legacysql.NewDBTime(now), CreatedAt: legacysql.NewDBTime(now)}
+		if mutate != nil {
+			mutate(&query)
+		}
+		return mocks.TemplateTestCase{Name: name, Data: query}
+	}
+
+	mocks.CheckQuerySnapshots(t, mocks.TemplateTestSetup{
+		RootDir:        "testdata",
+		SQLTemplatesFS: sqlTemplatesFS,
+		Templates: map[*template.Template][]mocks.TemplateTestCase{
+			insertTokenTemplate:                 {tokenCase("insert", nil)},
+			lookupTokenTemplate:                 {tokenCase("lookup", nil)},
+			updateTokenTemplate:                 {tokenCase("current", nil), tokenCase("previous", func(q *tokenQuery) { q.Previous = true })},
+			getTokenByExternalSessionIDTemplate: {tokenCase("by_external_session", nil)},
+			rotateTokenTemplate:                 {tokenCase("rotate", nil)},
+			softRevokeTokenTemplate:             {tokenCase("soft_revoke", nil)},
+			hardRevokeTokenTemplate:             {tokenCase("hard_revoke", nil)},
+			deleteTokensByUserIDTemplate:        {tokenCase("one_user", nil)},
+			deleteTokensByUserIDsTemplate:       {tokenCase("multiple_users", nil)},
+			getUserTokenTemplate:                {tokenCase("one_token", nil)},
+			getUserTokensTemplate:               {tokenCase("active_tokens", nil)},
+			countActiveTokensTemplate: {
+				tokenCase("all_users", nil),
+				tokenCase("one_user", func(q *tokenQuery) { q.HasUserID = true }),
+			},
+			deleteUserRevokedTokensTemplate: {tokenCase("delete_revoked", nil)},
+			getUserRevokedTokensTemplate:    {tokenCase("revoked_tokens", nil)},
+			getExternalSessionTemplate:      {externalCase("get", nil)},
+			listExternalSessionsTemplate: {
+				externalCase("all", func(q *externalSessionQuery) { q.ID, q.UserID, q.SessionIDHash, q.NameIDHash = 0, 0, "", "" }),
+				externalCase("filtered", nil),
+			},
+			insertExternalSessionTemplate:           {externalCase("insert", nil)},
+			updateExternalSessionTemplate:           {externalCase("update", nil)},
+			deleteExternalSessionTemplate:           {externalCase("delete", nil)},
+			deleteExternalSessionsByUserIDTemplate:  {externalCase("one_user", nil)},
+			deleteExternalSessionsByUserIDsTemplate: {externalCase("multiple_users", nil)},
+			deleteExpiredTokensTemplate:             {tokenCase("expired", nil)},
+			deleteOrphanedExternalSessionsTemplate: {{
+				Name: "orphaned",
+				Data: orphanedExternalSessionsQuery{
+					SQLTemplate:                  newSQLTemplate(),
+					ExternalSessionTable:         externalSessionTable,
+					TokenTable:                   tokenTable,
+					ExternalSessionIDColumn:      "user_external_session.id",
+					TokenExternalSessionIDColumn: "token.external_session_id",
+				},
+			}},
+		},
+	})
+}

--- a/pkg/services/auth/authimpl/testdata/mysql--count_active_tokens-all_users.sql
+++ b/pkg/services/auth/authimpl/testdata/mysql--count_active_tokens-all_users.sql
@@ -1,0 +1,2 @@
+SELECT COUNT(*) FROM `test_schema`.`user_auth_token`
+WHERE `created_at` > 5 AND `rotated_at` > 6 AND `revoked_at` = 0;

--- a/pkg/services/auth/authimpl/testdata/mysql--count_active_tokens-one_user.sql
+++ b/pkg/services/auth/authimpl/testdata/mysql--count_active_tokens-one_user.sql
@@ -1,0 +1,2 @@
+SELECT COUNT(*) FROM `test_schema`.`user_auth_token`
+WHERE `created_at` > 5 AND `rotated_at` > 6 AND `revoked_at` = 0 AND `user_id` = 2;

--- a/pkg/services/auth/authimpl/testdata/mysql--delete_expired_tokens-expired.sql
+++ b/pkg/services/auth/authimpl/testdata/mysql--delete_expired_tokens-expired.sql
@@ -1,0 +1,1 @@
+DELETE FROM `test_schema`.`user_auth_token` WHERE `created_at` <= 8 OR `rotated_at` <= 9;

--- a/pkg/services/auth/authimpl/testdata/mysql--delete_external_session-delete.sql
+++ b/pkg/services/auth/authimpl/testdata/mysql--delete_external_session-delete.sql
@@ -1,0 +1,1 @@
+DELETE FROM `test_schema`.`user_external_session` WHERE `id` = 1;

--- a/pkg/services/auth/authimpl/testdata/mysql--delete_external_sessions_by_user_id-one_user.sql
+++ b/pkg/services/auth/authimpl/testdata/mysql--delete_external_sessions_by_user_id-one_user.sql
@@ -1,0 +1,1 @@
+DELETE FROM `test_schema`.`user_external_session` WHERE `user_id` = 2;

--- a/pkg/services/auth/authimpl/testdata/mysql--delete_external_sessions_by_user_ids-multiple_users.sql
+++ b/pkg/services/auth/authimpl/testdata/mysql--delete_external_sessions_by_user_ids-multiple_users.sql
@@ -1,0 +1,1 @@
+DELETE FROM `test_schema`.`user_external_session` WHERE `user_id` IN (2, 4);

--- a/pkg/services/auth/authimpl/testdata/mysql--delete_orphaned_external_sessions-orphaned.sql
+++ b/pkg/services/auth/authimpl/testdata/mysql--delete_orphaned_external_sessions-orphaned.sql
@@ -1,0 +1,5 @@
+DELETE FROM `test_schema`.`user_external_session`
+WHERE NOT EXISTS (
+  SELECT 1 FROM `test_schema`.`user_auth_token` AS `token`
+  WHERE `user_external_session`.`id` = `token`.`external_session_id`
+);

--- a/pkg/services/auth/authimpl/testdata/mysql--delete_tokens_by_user_id-one_user.sql
+++ b/pkg/services/auth/authimpl/testdata/mysql--delete_tokens_by_user_id-one_user.sql
@@ -1,0 +1,1 @@
+DELETE FROM `test_schema`.`user_auth_token` WHERE `user_id` = 2;

--- a/pkg/services/auth/authimpl/testdata/mysql--delete_tokens_by_user_ids-multiple_users.sql
+++ b/pkg/services/auth/authimpl/testdata/mysql--delete_tokens_by_user_ids-multiple_users.sql
@@ -1,0 +1,1 @@
+DELETE FROM `test_schema`.`user_auth_token` WHERE `user_id` IN (2, 4);

--- a/pkg/services/auth/authimpl/testdata/mysql--delete_user_revoked_tokens-delete_revoked.sql
+++ b/pkg/services/auth/authimpl/testdata/mysql--delete_user_revoked_tokens-delete_revoked.sql
@@ -1,0 +1,1 @@
+DELETE FROM `test_schema`.`user_auth_token` WHERE `user_id` = 2 AND `revoked_at` > 0 AND `revoked_at` <= 7;

--- a/pkg/services/auth/authimpl/testdata/mysql--get_external_session-get.sql
+++ b/pkg/services/auth/authimpl/testdata/mysql--get_external_session-get.sql
@@ -1,0 +1,1 @@
+SELECT `id`, `user_id`, `user_auth_id`, `auth_module`, `access_token`, `id_token`, `refresh_token`, `session_id`, `session_id_hash`, `name_id`, `name_id_hash`, `expires_at`, `created_at` FROM `test_schema`.`user_external_session` WHERE `id` = 1;

--- a/pkg/services/auth/authimpl/testdata/mysql--get_token_by_external_session_id-by_external_session.sql
+++ b/pkg/services/auth/authimpl/testdata/mysql--get_token_by_external_session_id-by_external_session.sql
@@ -1,0 +1,2 @@
+SELECT `id`, `user_id`, `auth_token`, `prev_auth_token`, `user_agent`, `client_ip`, `auth_token_seen`, `seen_at`, `rotated_at`, `created_at`, `updated_at`, `revoked_at`, `external_session_id` FROM `test_schema`.`user_auth_token`
+WHERE `external_session_id` = 8;

--- a/pkg/services/auth/authimpl/testdata/mysql--get_user_revoked_tokens-revoked_tokens.sql
+++ b/pkg/services/auth/authimpl/testdata/mysql--get_user_revoked_tokens-revoked_tokens.sql
@@ -1,0 +1,2 @@
+SELECT `id`, `user_id`, `auth_token`, `prev_auth_token`, `user_agent`, `client_ip`, `auth_token_seen`, `seen_at`, `rotated_at`, `created_at`, `updated_at`, `revoked_at`, `external_session_id` FROM `test_schema`.`user_auth_token`
+WHERE `user_id` = 2 AND `revoked_at` > 0 ORDER BY `seen_at` ASC;

--- a/pkg/services/auth/authimpl/testdata/mysql--get_user_token-one_token.sql
+++ b/pkg/services/auth/authimpl/testdata/mysql--get_user_token-one_token.sql
@@ -1,0 +1,2 @@
+SELECT `id`, `user_id`, `auth_token`, `prev_auth_token`, `user_agent`, `client_ip`, `auth_token_seen`, `seen_at`, `rotated_at`, `created_at`, `updated_at`, `revoked_at`, `external_session_id` FROM `test_schema`.`user_auth_token`
+WHERE `id` = 1 AND `user_id` = 2;

--- a/pkg/services/auth/authimpl/testdata/mysql--get_user_tokens-active_tokens.sql
+++ b/pkg/services/auth/authimpl/testdata/mysql--get_user_tokens-active_tokens.sql
@@ -1,0 +1,2 @@
+SELECT `id`, `user_id`, `auth_token`, `prev_auth_token`, `user_agent`, `client_ip`, `auth_token_seen`, `seen_at`, `rotated_at`, `created_at`, `updated_at`, `revoked_at`, `external_session_id` FROM `test_schema`.`user_auth_token`
+WHERE `user_id` = 2 AND `created_at` > 5 AND `rotated_at` > 6 AND `revoked_at` = 0;

--- a/pkg/services/auth/authimpl/testdata/mysql--hard_revoke_token-hard_revoke.sql
+++ b/pkg/services/auth/authimpl/testdata/mysql--hard_revoke_token-hard_revoke.sql
@@ -1,0 +1,1 @@
+DELETE FROM `test_schema`.`user_auth_token` WHERE `id` = 1;

--- a/pkg/services/auth/authimpl/testdata/mysql--insert_external_session-insert.sql
+++ b/pkg/services/auth/authimpl/testdata/mysql--insert_external_session-insert.sql
@@ -1,0 +1,11 @@
+INSERT INTO `test_schema`.`user_external_session` (
+  `user_id`, `user_auth_id`, `auth_module`,
+  `access_token`, `id_token`, `refresh_token`,
+  `session_id`, `session_id_hash`, `name_id`,
+  `name_id_hash`, `expires_at`, `created_at`
+) VALUES (
+  2, 3, 'oauth',
+  'access', 'id', 'refresh',
+  'session', 'session-hash', 'name',
+  'name-hash', '2026-07-21 12:00:00', '2026-07-21 12:00:00'
+);

--- a/pkg/services/auth/authimpl/testdata/mysql--insert_token-insert.sql
+++ b/pkg/services/auth/authimpl/testdata/mysql--insert_token-insert.sql
@@ -1,0 +1,11 @@
+INSERT INTO `test_schema`.`user_auth_token` (
+  `user_id`, `auth_token`, `prev_auth_token`,
+  `user_agent`, `client_ip`, `auth_token_seen`,
+  `seen_at`, `rotated_at`, `created_at`,
+  `updated_at`, `revoked_at`, `external_session_id`
+) VALUES (
+  2, 'token', 'previous',
+  'agent', '127.0.0.1', TRUE,
+  3, 4, 5,
+  6, 7, 8
+);

--- a/pkg/services/auth/authimpl/testdata/mysql--list_external_sessions-all.sql
+++ b/pkg/services/auth/authimpl/testdata/mysql--list_external_sessions-all.sql
@@ -1,0 +1,2 @@
+SELECT `id`, `user_id`, `user_auth_id`, `auth_module`, `access_token`, `id_token`, `refresh_token`, `session_id`, `session_id_hash`, `name_id`, `name_id_hash`, `expires_at`, `created_at` FROM `test_schema`.`user_external_session`
+ORDER BY `id` DESC;

--- a/pkg/services/auth/authimpl/testdata/mysql--list_external_sessions-filtered.sql
+++ b/pkg/services/auth/authimpl/testdata/mysql--list_external_sessions-filtered.sql
@@ -1,0 +1,3 @@
+SELECT `id`, `user_id`, `user_auth_id`, `auth_module`, `access_token`, `id_token`, `refresh_token`, `session_id`, `session_id_hash`, `name_id`, `name_id_hash`, `expires_at`, `created_at` FROM `test_schema`.`user_external_session`
+WHERE `id` = 1 AND `user_id` = 2 AND `session_id_hash` = 'session-hash' AND `name_id_hash` = 'name-hash'
+ORDER BY `id` DESC;

--- a/pkg/services/auth/authimpl/testdata/mysql--lookup_token-lookup.sql
+++ b/pkg/services/auth/authimpl/testdata/mysql--lookup_token-lookup.sql
@@ -1,0 +1,3 @@
+SELECT `id`, `user_id`, `auth_token`, `prev_auth_token`, `user_agent`, `client_ip`, `auth_token_seen`, `seen_at`, `rotated_at`, `created_at`, `updated_at`, `revoked_at`, `external_session_id`
+FROM `test_schema`.`user_auth_token`
+WHERE (`auth_token` = 'hash' OR `prev_auth_token` = 'hash');

--- a/pkg/services/auth/authimpl/testdata/mysql--rotate_token-rotate.sql
+++ b/pkg/services/auth/authimpl/testdata/mysql--rotate_token-rotate.sql
@@ -1,0 +1,9 @@
+UPDATE `test_schema`.`user_auth_token` SET
+  `seen_at` = 0,
+  `user_agent` = 'agent',
+  `client_ip` = '127.0.0.1',
+  `prev_auth_token` = `auth_token`,
+  `auth_token` = 'hash',
+  `auth_token_seen` = FALSE,
+  `rotated_at` = 4
+WHERE `id` = 1;

--- a/pkg/services/auth/authimpl/testdata/mysql--soft_revoke_token-soft_revoke.sql
+++ b/pkg/services/auth/authimpl/testdata/mysql--soft_revoke_token-soft_revoke.sql
@@ -1,0 +1,2 @@
+UPDATE `test_schema`.`user_auth_token` SET `user_id` = 2, `auth_token` = 'token', `prev_auth_token` = 'previous', `user_agent` = 'agent', `client_ip` = '127.0.0.1', `auth_token_seen` = TRUE, `seen_at` = 3, `rotated_at` = 4, `created_at` = 5, `updated_at` = 6, `revoked_at` = 7, `external_session_id` = 8
+WHERE `id` = 1;

--- a/pkg/services/auth/authimpl/testdata/mysql--update_external_session-update.sql
+++ b/pkg/services/auth/authimpl/testdata/mysql--update_external_session-update.sql
@@ -1,0 +1,6 @@
+UPDATE `test_schema`.`user_external_session` SET
+  `access_token` = 'access',
+  `refresh_token` = 'refresh',
+  `id_token` = 'id',
+  `expires_at` = '2026-07-21 12:00:00'
+WHERE `id` = 1;

--- a/pkg/services/auth/authimpl/testdata/mysql--update_token-current.sql
+++ b/pkg/services/auth/authimpl/testdata/mysql--update_token-current.sql
@@ -1,0 +1,14 @@
+UPDATE `test_schema`.`user_auth_token` SET
+  `user_id` = 2,
+  `auth_token` = 'token',
+  `prev_auth_token` = 'previous',
+  `user_agent` = 'agent',
+  `client_ip` = '127.0.0.1',
+  `auth_token_seen` = TRUE,
+  `seen_at` = 3,
+  `rotated_at` = 4,
+  `created_at` = 5,
+  `updated_at` = 6,
+  `revoked_at` = 7,
+  `external_session_id` = 8
+WHERE `id` = 1 AND `auth_token` = 'expected';

--- a/pkg/services/auth/authimpl/testdata/mysql--update_token-previous.sql
+++ b/pkg/services/auth/authimpl/testdata/mysql--update_token-previous.sql
@@ -1,0 +1,14 @@
+UPDATE `test_schema`.`user_auth_token` SET
+  `user_id` = 2,
+  `auth_token` = 'token',
+  `prev_auth_token` = 'previous',
+  `user_agent` = 'agent',
+  `client_ip` = '127.0.0.1',
+  `auth_token_seen` = TRUE,
+  `seen_at` = 3,
+  `rotated_at` = 4,
+  `created_at` = 5,
+  `updated_at` = 6,
+  `revoked_at` = 7,
+  `external_session_id` = 8
+WHERE `id` = 1 AND `prev_auth_token` = 'expected' AND `rotated_at` < 4;

--- a/pkg/services/auth/authimpl/testdata/postgres--count_active_tokens-all_users.sql
+++ b/pkg/services/auth/authimpl/testdata/postgres--count_active_tokens-all_users.sql
@@ -1,0 +1,2 @@
+SELECT COUNT(*) FROM "test_schema"."user_auth_token"
+WHERE "created_at" > 5 AND "rotated_at" > 6 AND "revoked_at" = 0;

--- a/pkg/services/auth/authimpl/testdata/postgres--count_active_tokens-one_user.sql
+++ b/pkg/services/auth/authimpl/testdata/postgres--count_active_tokens-one_user.sql
@@ -1,0 +1,2 @@
+SELECT COUNT(*) FROM "test_schema"."user_auth_token"
+WHERE "created_at" > 5 AND "rotated_at" > 6 AND "revoked_at" = 0 AND "user_id" = 2;

--- a/pkg/services/auth/authimpl/testdata/postgres--delete_expired_tokens-expired.sql
+++ b/pkg/services/auth/authimpl/testdata/postgres--delete_expired_tokens-expired.sql
@@ -1,0 +1,1 @@
+DELETE FROM "test_schema"."user_auth_token" WHERE "created_at" <= 8 OR "rotated_at" <= 9;

--- a/pkg/services/auth/authimpl/testdata/postgres--delete_external_session-delete.sql
+++ b/pkg/services/auth/authimpl/testdata/postgres--delete_external_session-delete.sql
@@ -1,0 +1,1 @@
+DELETE FROM "test_schema"."user_external_session" WHERE "id" = 1;

--- a/pkg/services/auth/authimpl/testdata/postgres--delete_external_sessions_by_user_id-one_user.sql
+++ b/pkg/services/auth/authimpl/testdata/postgres--delete_external_sessions_by_user_id-one_user.sql
@@ -1,0 +1,1 @@
+DELETE FROM "test_schema"."user_external_session" WHERE "user_id" = 2;

--- a/pkg/services/auth/authimpl/testdata/postgres--delete_external_sessions_by_user_ids-multiple_users.sql
+++ b/pkg/services/auth/authimpl/testdata/postgres--delete_external_sessions_by_user_ids-multiple_users.sql
@@ -1,0 +1,1 @@
+DELETE FROM "test_schema"."user_external_session" WHERE "user_id" IN (2, 4);

--- a/pkg/services/auth/authimpl/testdata/postgres--delete_orphaned_external_sessions-orphaned.sql
+++ b/pkg/services/auth/authimpl/testdata/postgres--delete_orphaned_external_sessions-orphaned.sql
@@ -1,0 +1,5 @@
+DELETE FROM "test_schema"."user_external_session"
+WHERE NOT EXISTS (
+  SELECT 1 FROM "test_schema"."user_auth_token" AS "token"
+  WHERE "user_external_session"."id" = "token"."external_session_id"
+);

--- a/pkg/services/auth/authimpl/testdata/postgres--delete_tokens_by_user_id-one_user.sql
+++ b/pkg/services/auth/authimpl/testdata/postgres--delete_tokens_by_user_id-one_user.sql
@@ -1,0 +1,1 @@
+DELETE FROM "test_schema"."user_auth_token" WHERE "user_id" = 2;

--- a/pkg/services/auth/authimpl/testdata/postgres--delete_tokens_by_user_ids-multiple_users.sql
+++ b/pkg/services/auth/authimpl/testdata/postgres--delete_tokens_by_user_ids-multiple_users.sql
@@ -1,0 +1,1 @@
+DELETE FROM "test_schema"."user_auth_token" WHERE "user_id" IN (2, 4);

--- a/pkg/services/auth/authimpl/testdata/postgres--delete_user_revoked_tokens-delete_revoked.sql
+++ b/pkg/services/auth/authimpl/testdata/postgres--delete_user_revoked_tokens-delete_revoked.sql
@@ -1,0 +1,1 @@
+DELETE FROM "test_schema"."user_auth_token" WHERE "user_id" = 2 AND "revoked_at" > 0 AND "revoked_at" <= 7;

--- a/pkg/services/auth/authimpl/testdata/postgres--get_external_session-get.sql
+++ b/pkg/services/auth/authimpl/testdata/postgres--get_external_session-get.sql
@@ -1,0 +1,1 @@
+SELECT "id", "user_id", "user_auth_id", "auth_module", "access_token", "id_token", "refresh_token", "session_id", "session_id_hash", "name_id", "name_id_hash", "expires_at", "created_at" FROM "test_schema"."user_external_session" WHERE "id" = 1;

--- a/pkg/services/auth/authimpl/testdata/postgres--get_token_by_external_session_id-by_external_session.sql
+++ b/pkg/services/auth/authimpl/testdata/postgres--get_token_by_external_session_id-by_external_session.sql
@@ -1,0 +1,2 @@
+SELECT "id", "user_id", "auth_token", "prev_auth_token", "user_agent", "client_ip", "auth_token_seen", "seen_at", "rotated_at", "created_at", "updated_at", "revoked_at", "external_session_id" FROM "test_schema"."user_auth_token"
+WHERE "external_session_id" = 8;

--- a/pkg/services/auth/authimpl/testdata/postgres--get_user_revoked_tokens-revoked_tokens.sql
+++ b/pkg/services/auth/authimpl/testdata/postgres--get_user_revoked_tokens-revoked_tokens.sql
@@ -1,0 +1,2 @@
+SELECT "id", "user_id", "auth_token", "prev_auth_token", "user_agent", "client_ip", "auth_token_seen", "seen_at", "rotated_at", "created_at", "updated_at", "revoked_at", "external_session_id" FROM "test_schema"."user_auth_token"
+WHERE "user_id" = 2 AND "revoked_at" > 0 ORDER BY "seen_at" ASC;

--- a/pkg/services/auth/authimpl/testdata/postgres--get_user_token-one_token.sql
+++ b/pkg/services/auth/authimpl/testdata/postgres--get_user_token-one_token.sql
@@ -1,0 +1,2 @@
+SELECT "id", "user_id", "auth_token", "prev_auth_token", "user_agent", "client_ip", "auth_token_seen", "seen_at", "rotated_at", "created_at", "updated_at", "revoked_at", "external_session_id" FROM "test_schema"."user_auth_token"
+WHERE "id" = 1 AND "user_id" = 2;

--- a/pkg/services/auth/authimpl/testdata/postgres--get_user_tokens-active_tokens.sql
+++ b/pkg/services/auth/authimpl/testdata/postgres--get_user_tokens-active_tokens.sql
@@ -1,0 +1,2 @@
+SELECT "id", "user_id", "auth_token", "prev_auth_token", "user_agent", "client_ip", "auth_token_seen", "seen_at", "rotated_at", "created_at", "updated_at", "revoked_at", "external_session_id" FROM "test_schema"."user_auth_token"
+WHERE "user_id" = 2 AND "created_at" > 5 AND "rotated_at" > 6 AND "revoked_at" = 0;

--- a/pkg/services/auth/authimpl/testdata/postgres--hard_revoke_token-hard_revoke.sql
+++ b/pkg/services/auth/authimpl/testdata/postgres--hard_revoke_token-hard_revoke.sql
@@ -1,0 +1,1 @@
+DELETE FROM "test_schema"."user_auth_token" WHERE "id" = 1;

--- a/pkg/services/auth/authimpl/testdata/postgres--insert_external_session-insert.sql
+++ b/pkg/services/auth/authimpl/testdata/postgres--insert_external_session-insert.sql
@@ -1,0 +1,11 @@
+INSERT INTO "test_schema"."user_external_session" (
+  "user_id", "user_auth_id", "auth_module",
+  "access_token", "id_token", "refresh_token",
+  "session_id", "session_id_hash", "name_id",
+  "name_id_hash", "expires_at", "created_at"
+) VALUES (
+  2, 3, 'oauth',
+  'access', 'id', 'refresh',
+  'session', 'session-hash', 'name',
+  'name-hash', '2026-07-21 12:00:00', '2026-07-21 12:00:00'
+) RETURNING "id";

--- a/pkg/services/auth/authimpl/testdata/postgres--insert_token-insert.sql
+++ b/pkg/services/auth/authimpl/testdata/postgres--insert_token-insert.sql
@@ -1,0 +1,11 @@
+INSERT INTO "test_schema"."user_auth_token" (
+  "user_id", "auth_token", "prev_auth_token",
+  "user_agent", "client_ip", "auth_token_seen",
+  "seen_at", "rotated_at", "created_at",
+  "updated_at", "revoked_at", "external_session_id"
+) VALUES (
+  2, 'token', 'previous',
+  'agent', '127.0.0.1', TRUE,
+  3, 4, 5,
+  6, 7, 8
+) RETURNING "id";

--- a/pkg/services/auth/authimpl/testdata/postgres--list_external_sessions-all.sql
+++ b/pkg/services/auth/authimpl/testdata/postgres--list_external_sessions-all.sql
@@ -1,0 +1,2 @@
+SELECT "id", "user_id", "user_auth_id", "auth_module", "access_token", "id_token", "refresh_token", "session_id", "session_id_hash", "name_id", "name_id_hash", "expires_at", "created_at" FROM "test_schema"."user_external_session"
+ORDER BY "id" DESC;

--- a/pkg/services/auth/authimpl/testdata/postgres--list_external_sessions-filtered.sql
+++ b/pkg/services/auth/authimpl/testdata/postgres--list_external_sessions-filtered.sql
@@ -1,0 +1,3 @@
+SELECT "id", "user_id", "user_auth_id", "auth_module", "access_token", "id_token", "refresh_token", "session_id", "session_id_hash", "name_id", "name_id_hash", "expires_at", "created_at" FROM "test_schema"."user_external_session"
+WHERE "id" = 1 AND "user_id" = 2 AND "session_id_hash" = 'session-hash' AND "name_id_hash" = 'name-hash'
+ORDER BY "id" DESC;

--- a/pkg/services/auth/authimpl/testdata/postgres--lookup_token-lookup.sql
+++ b/pkg/services/auth/authimpl/testdata/postgres--lookup_token-lookup.sql
@@ -1,0 +1,3 @@
+SELECT "id", "user_id", "auth_token", "prev_auth_token", "user_agent", "client_ip", "auth_token_seen", "seen_at", "rotated_at", "created_at", "updated_at", "revoked_at", "external_session_id"
+FROM "test_schema"."user_auth_token"
+WHERE ("auth_token" = 'hash' OR "prev_auth_token" = 'hash');

--- a/pkg/services/auth/authimpl/testdata/postgres--rotate_token-rotate.sql
+++ b/pkg/services/auth/authimpl/testdata/postgres--rotate_token-rotate.sql
@@ -1,0 +1,9 @@
+UPDATE "test_schema"."user_auth_token" SET
+  "seen_at" = 0,
+  "user_agent" = 'agent',
+  "client_ip" = '127.0.0.1',
+  "prev_auth_token" = "auth_token",
+  "auth_token" = 'hash',
+  "auth_token_seen" = FALSE,
+  "rotated_at" = 4
+WHERE "id" = 1;

--- a/pkg/services/auth/authimpl/testdata/postgres--soft_revoke_token-soft_revoke.sql
+++ b/pkg/services/auth/authimpl/testdata/postgres--soft_revoke_token-soft_revoke.sql
@@ -1,0 +1,2 @@
+UPDATE "test_schema"."user_auth_token" SET "user_id" = 2, "auth_token" = 'token', "prev_auth_token" = 'previous', "user_agent" = 'agent', "client_ip" = '127.0.0.1', "auth_token_seen" = TRUE, "seen_at" = 3, "rotated_at" = 4, "created_at" = 5, "updated_at" = 6, "revoked_at" = 7, "external_session_id" = 8
+WHERE "id" = 1;

--- a/pkg/services/auth/authimpl/testdata/postgres--update_external_session-update.sql
+++ b/pkg/services/auth/authimpl/testdata/postgres--update_external_session-update.sql
@@ -1,0 +1,6 @@
+UPDATE "test_schema"."user_external_session" SET
+  "access_token" = 'access',
+  "refresh_token" = 'refresh',
+  "id_token" = 'id',
+  "expires_at" = '2026-07-21 12:00:00'
+WHERE "id" = 1;

--- a/pkg/services/auth/authimpl/testdata/postgres--update_token-current.sql
+++ b/pkg/services/auth/authimpl/testdata/postgres--update_token-current.sql
@@ -1,0 +1,14 @@
+UPDATE "test_schema"."user_auth_token" SET
+  "user_id" = 2,
+  "auth_token" = 'token',
+  "prev_auth_token" = 'previous',
+  "user_agent" = 'agent',
+  "client_ip" = '127.0.0.1',
+  "auth_token_seen" = TRUE,
+  "seen_at" = 3,
+  "rotated_at" = 4,
+  "created_at" = 5,
+  "updated_at" = 6,
+  "revoked_at" = 7,
+  "external_session_id" = 8
+WHERE "id" = 1 AND "auth_token" = 'expected';

--- a/pkg/services/auth/authimpl/testdata/postgres--update_token-previous.sql
+++ b/pkg/services/auth/authimpl/testdata/postgres--update_token-previous.sql
@@ -1,0 +1,14 @@
+UPDATE "test_schema"."user_auth_token" SET
+  "user_id" = 2,
+  "auth_token" = 'token',
+  "prev_auth_token" = 'previous',
+  "user_agent" = 'agent',
+  "client_ip" = '127.0.0.1',
+  "auth_token_seen" = TRUE,
+  "seen_at" = 3,
+  "rotated_at" = 4,
+  "created_at" = 5,
+  "updated_at" = 6,
+  "revoked_at" = 7,
+  "external_session_id" = 8
+WHERE "id" = 1 AND "prev_auth_token" = 'expected' AND "rotated_at" < 4;

--- a/pkg/services/auth/authimpl/testdata/sqlite--count_active_tokens-all_users.sql
+++ b/pkg/services/auth/authimpl/testdata/sqlite--count_active_tokens-all_users.sql
@@ -1,0 +1,2 @@
+SELECT COUNT(*) FROM "test_schema"."user_auth_token"
+WHERE "created_at" > 5 AND "rotated_at" > 6 AND "revoked_at" = 0;

--- a/pkg/services/auth/authimpl/testdata/sqlite--count_active_tokens-one_user.sql
+++ b/pkg/services/auth/authimpl/testdata/sqlite--count_active_tokens-one_user.sql
@@ -1,0 +1,2 @@
+SELECT COUNT(*) FROM "test_schema"."user_auth_token"
+WHERE "created_at" > 5 AND "rotated_at" > 6 AND "revoked_at" = 0 AND "user_id" = 2;

--- a/pkg/services/auth/authimpl/testdata/sqlite--delete_expired_tokens-expired.sql
+++ b/pkg/services/auth/authimpl/testdata/sqlite--delete_expired_tokens-expired.sql
@@ -1,0 +1,1 @@
+DELETE FROM "test_schema"."user_auth_token" WHERE "created_at" <= 8 OR "rotated_at" <= 9;

--- a/pkg/services/auth/authimpl/testdata/sqlite--delete_external_session-delete.sql
+++ b/pkg/services/auth/authimpl/testdata/sqlite--delete_external_session-delete.sql
@@ -1,0 +1,1 @@
+DELETE FROM "test_schema"."user_external_session" WHERE "id" = 1;

--- a/pkg/services/auth/authimpl/testdata/sqlite--delete_external_sessions_by_user_id-one_user.sql
+++ b/pkg/services/auth/authimpl/testdata/sqlite--delete_external_sessions_by_user_id-one_user.sql
@@ -1,0 +1,1 @@
+DELETE FROM "test_schema"."user_external_session" WHERE "user_id" = 2;

--- a/pkg/services/auth/authimpl/testdata/sqlite--delete_external_sessions_by_user_ids-multiple_users.sql
+++ b/pkg/services/auth/authimpl/testdata/sqlite--delete_external_sessions_by_user_ids-multiple_users.sql
@@ -1,0 +1,1 @@
+DELETE FROM "test_schema"."user_external_session" WHERE "user_id" IN (2, 4);

--- a/pkg/services/auth/authimpl/testdata/sqlite--delete_orphaned_external_sessions-orphaned.sql
+++ b/pkg/services/auth/authimpl/testdata/sqlite--delete_orphaned_external_sessions-orphaned.sql
@@ -1,0 +1,5 @@
+DELETE FROM "test_schema"."user_external_session"
+WHERE NOT EXISTS (
+  SELECT 1 FROM "test_schema"."user_auth_token" AS "token"
+  WHERE "user_external_session"."id" = "token"."external_session_id"
+);

--- a/pkg/services/auth/authimpl/testdata/sqlite--delete_tokens_by_user_id-one_user.sql
+++ b/pkg/services/auth/authimpl/testdata/sqlite--delete_tokens_by_user_id-one_user.sql
@@ -1,0 +1,1 @@
+DELETE FROM "test_schema"."user_auth_token" WHERE "user_id" = 2;

--- a/pkg/services/auth/authimpl/testdata/sqlite--delete_tokens_by_user_ids-multiple_users.sql
+++ b/pkg/services/auth/authimpl/testdata/sqlite--delete_tokens_by_user_ids-multiple_users.sql
@@ -1,0 +1,1 @@
+DELETE FROM "test_schema"."user_auth_token" WHERE "user_id" IN (2, 4);

--- a/pkg/services/auth/authimpl/testdata/sqlite--delete_user_revoked_tokens-delete_revoked.sql
+++ b/pkg/services/auth/authimpl/testdata/sqlite--delete_user_revoked_tokens-delete_revoked.sql
@@ -1,0 +1,1 @@
+DELETE FROM "test_schema"."user_auth_token" WHERE "user_id" = 2 AND "revoked_at" > 0 AND "revoked_at" <= 7;

--- a/pkg/services/auth/authimpl/testdata/sqlite--get_external_session-get.sql
+++ b/pkg/services/auth/authimpl/testdata/sqlite--get_external_session-get.sql
@@ -1,0 +1,1 @@
+SELECT "id", "user_id", "user_auth_id", "auth_module", "access_token", "id_token", "refresh_token", "session_id", "session_id_hash", "name_id", "name_id_hash", "expires_at", "created_at" FROM "test_schema"."user_external_session" WHERE "id" = 1;

--- a/pkg/services/auth/authimpl/testdata/sqlite--get_token_by_external_session_id-by_external_session.sql
+++ b/pkg/services/auth/authimpl/testdata/sqlite--get_token_by_external_session_id-by_external_session.sql
@@ -1,0 +1,2 @@
+SELECT "id", "user_id", "auth_token", "prev_auth_token", "user_agent", "client_ip", "auth_token_seen", "seen_at", "rotated_at", "created_at", "updated_at", "revoked_at", "external_session_id" FROM "test_schema"."user_auth_token"
+WHERE "external_session_id" = 8;

--- a/pkg/services/auth/authimpl/testdata/sqlite--get_user_revoked_tokens-revoked_tokens.sql
+++ b/pkg/services/auth/authimpl/testdata/sqlite--get_user_revoked_tokens-revoked_tokens.sql
@@ -1,0 +1,2 @@
+SELECT "id", "user_id", "auth_token", "prev_auth_token", "user_agent", "client_ip", "auth_token_seen", "seen_at", "rotated_at", "created_at", "updated_at", "revoked_at", "external_session_id" FROM "test_schema"."user_auth_token"
+WHERE "user_id" = 2 AND "revoked_at" > 0 ORDER BY "seen_at" ASC;

--- a/pkg/services/auth/authimpl/testdata/sqlite--get_user_token-one_token.sql
+++ b/pkg/services/auth/authimpl/testdata/sqlite--get_user_token-one_token.sql
@@ -1,0 +1,2 @@
+SELECT "id", "user_id", "auth_token", "prev_auth_token", "user_agent", "client_ip", "auth_token_seen", "seen_at", "rotated_at", "created_at", "updated_at", "revoked_at", "external_session_id" FROM "test_schema"."user_auth_token"
+WHERE "id" = 1 AND "user_id" = 2;

--- a/pkg/services/auth/authimpl/testdata/sqlite--get_user_tokens-active_tokens.sql
+++ b/pkg/services/auth/authimpl/testdata/sqlite--get_user_tokens-active_tokens.sql
@@ -1,0 +1,2 @@
+SELECT "id", "user_id", "auth_token", "prev_auth_token", "user_agent", "client_ip", "auth_token_seen", "seen_at", "rotated_at", "created_at", "updated_at", "revoked_at", "external_session_id" FROM "test_schema"."user_auth_token"
+WHERE "user_id" = 2 AND "created_at" > 5 AND "rotated_at" > 6 AND "revoked_at" = 0;

--- a/pkg/services/auth/authimpl/testdata/sqlite--hard_revoke_token-hard_revoke.sql
+++ b/pkg/services/auth/authimpl/testdata/sqlite--hard_revoke_token-hard_revoke.sql
@@ -1,0 +1,1 @@
+DELETE FROM "test_schema"."user_auth_token" WHERE "id" = 1;

--- a/pkg/services/auth/authimpl/testdata/sqlite--insert_external_session-insert.sql
+++ b/pkg/services/auth/authimpl/testdata/sqlite--insert_external_session-insert.sql
@@ -1,0 +1,11 @@
+INSERT INTO "test_schema"."user_external_session" (
+  "user_id", "user_auth_id", "auth_module",
+  "access_token", "id_token", "refresh_token",
+  "session_id", "session_id_hash", "name_id",
+  "name_id_hash", "expires_at", "created_at"
+) VALUES (
+  2, 3, 'oauth',
+  'access', 'id', 'refresh',
+  'session', 'session-hash', 'name',
+  'name-hash', '2026-07-21 12:00:00', '2026-07-21 12:00:00'
+);

--- a/pkg/services/auth/authimpl/testdata/sqlite--insert_token-insert.sql
+++ b/pkg/services/auth/authimpl/testdata/sqlite--insert_token-insert.sql
@@ -1,0 +1,11 @@
+INSERT INTO "test_schema"."user_auth_token" (
+  "user_id", "auth_token", "prev_auth_token",
+  "user_agent", "client_ip", "auth_token_seen",
+  "seen_at", "rotated_at", "created_at",
+  "updated_at", "revoked_at", "external_session_id"
+) VALUES (
+  2, 'token', 'previous',
+  'agent', '127.0.0.1', TRUE,
+  3, 4, 5,
+  6, 7, 8
+);

--- a/pkg/services/auth/authimpl/testdata/sqlite--list_external_sessions-all.sql
+++ b/pkg/services/auth/authimpl/testdata/sqlite--list_external_sessions-all.sql
@@ -1,0 +1,2 @@
+SELECT "id", "user_id", "user_auth_id", "auth_module", "access_token", "id_token", "refresh_token", "session_id", "session_id_hash", "name_id", "name_id_hash", "expires_at", "created_at" FROM "test_schema"."user_external_session"
+ORDER BY "id" DESC;

--- a/pkg/services/auth/authimpl/testdata/sqlite--list_external_sessions-filtered.sql
+++ b/pkg/services/auth/authimpl/testdata/sqlite--list_external_sessions-filtered.sql
@@ -1,0 +1,3 @@
+SELECT "id", "user_id", "user_auth_id", "auth_module", "access_token", "id_token", "refresh_token", "session_id", "session_id_hash", "name_id", "name_id_hash", "expires_at", "created_at" FROM "test_schema"."user_external_session"
+WHERE "id" = 1 AND "user_id" = 2 AND "session_id_hash" = 'session-hash' AND "name_id_hash" = 'name-hash'
+ORDER BY "id" DESC;

--- a/pkg/services/auth/authimpl/testdata/sqlite--lookup_token-lookup.sql
+++ b/pkg/services/auth/authimpl/testdata/sqlite--lookup_token-lookup.sql
@@ -1,0 +1,3 @@
+SELECT "id", "user_id", "auth_token", "prev_auth_token", "user_agent", "client_ip", "auth_token_seen", "seen_at", "rotated_at", "created_at", "updated_at", "revoked_at", "external_session_id"
+FROM "test_schema"."user_auth_token"
+WHERE ("auth_token" = 'hash' OR "prev_auth_token" = 'hash');

--- a/pkg/services/auth/authimpl/testdata/sqlite--rotate_token-rotate.sql
+++ b/pkg/services/auth/authimpl/testdata/sqlite--rotate_token-rotate.sql
@@ -1,0 +1,9 @@
+UPDATE "test_schema"."user_auth_token" SET
+  "seen_at" = 0,
+  "user_agent" = 'agent',
+  "client_ip" = '127.0.0.1',
+  "prev_auth_token" = "auth_token",
+  "auth_token" = 'hash',
+  "auth_token_seen" = FALSE,
+  "rotated_at" = 4
+WHERE "id" = 1;

--- a/pkg/services/auth/authimpl/testdata/sqlite--soft_revoke_token-soft_revoke.sql
+++ b/pkg/services/auth/authimpl/testdata/sqlite--soft_revoke_token-soft_revoke.sql
@@ -1,0 +1,2 @@
+UPDATE "test_schema"."user_auth_token" SET "user_id" = 2, "auth_token" = 'token', "prev_auth_token" = 'previous', "user_agent" = 'agent', "client_ip" = '127.0.0.1', "auth_token_seen" = TRUE, "seen_at" = 3, "rotated_at" = 4, "created_at" = 5, "updated_at" = 6, "revoked_at" = 7, "external_session_id" = 8
+WHERE "id" = 1;

--- a/pkg/services/auth/authimpl/testdata/sqlite--update_external_session-update.sql
+++ b/pkg/services/auth/authimpl/testdata/sqlite--update_external_session-update.sql
@@ -1,0 +1,6 @@
+UPDATE "test_schema"."user_external_session" SET
+  "access_token" = 'access',
+  "refresh_token" = 'refresh',
+  "id_token" = 'id',
+  "expires_at" = '2026-07-21 12:00:00'
+WHERE "id" = 1;

--- a/pkg/services/auth/authimpl/testdata/sqlite--update_token-current.sql
+++ b/pkg/services/auth/authimpl/testdata/sqlite--update_token-current.sql
@@ -1,0 +1,14 @@
+UPDATE "test_schema"."user_auth_token" SET
+  "user_id" = 2,
+  "auth_token" = 'token',
+  "prev_auth_token" = 'previous',
+  "user_agent" = 'agent',
+  "client_ip" = '127.0.0.1',
+  "auth_token_seen" = TRUE,
+  "seen_at" = 3,
+  "rotated_at" = 4,
+  "created_at" = 5,
+  "updated_at" = 6,
+  "revoked_at" = 7,
+  "external_session_id" = 8
+WHERE "id" = 1 AND "auth_token" = 'expected';

--- a/pkg/services/auth/authimpl/testdata/sqlite--update_token-previous.sql
+++ b/pkg/services/auth/authimpl/testdata/sqlite--update_token-previous.sql
@@ -1,0 +1,14 @@
+UPDATE "test_schema"."user_auth_token" SET
+  "user_id" = 2,
+  "auth_token" = 'token',
+  "prev_auth_token" = 'previous',
+  "user_agent" = 'agent',
+  "client_ip" = '127.0.0.1',
+  "auth_token_seen" = TRUE,
+  "seen_at" = 3,
+  "rotated_at" = 4,
+  "created_at" = 5,
+  "updated_at" = 6,
+  "revoked_at" = 7,
+  "external_session_id" = 8
+WHERE "id" = 1 AND "prev_auth_token" = 'expected' AND "rotated_at" < 4;

--- a/pkg/services/auth/authimpl/token_cleanup.go
+++ b/pkg/services/auth/authimpl/token_cleanup.go
@@ -2,9 +2,11 @@ package authimpl
 
 import (
 	"context"
+	"fmt"
 	"time"
 
-	"github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
+	"github.com/grafana/grafana/pkg/storage/unified/sql/sqltemplate"
 )
 
 func (s *UserAuthTokenService) Run(ctx context.Context) error {
@@ -56,9 +58,17 @@ func (s *UserAuthTokenService) deleteExpiredTokens(ctx context.Context, maxInact
 	s.log.Debug("Starting cleanup of expired auth tokens", "createdBefore", createdBefore, "rotatedBefore", rotatedBefore)
 
 	var affected int64
-	err := s.sqlStore.WithDbSession(ctx, func(dbSession *db.Session) error {
-		sql := `DELETE from user_auth_token WHERE created_at <= ? OR rotated_at <= ?`
-		res, err := dbSession.Exec(sql, createdBefore.Unix(), rotatedBefore.Unix())
+	dbHelper, err := s.sql(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("get legacy DB: %w", err)
+	}
+	err = dbHelper.DB.WithDbSession(ctx, func(dbSession *sqlstore.DBSession) error {
+		query := tokenQuery{SQLTemplate: sqltemplate.New(dbHelper.DialectForDriver()), TokenTable: dbHelper.Table("user_auth_token"), CreatedBefore: createdBefore.Unix(), RotatedBefore: rotatedBefore.Unix()}
+		querySQL, err := sqltemplate.Execute(deleteExpiredTokensTemplate, query)
+		if err != nil {
+			return err
+		}
+		res, err := dbSession.Exec(append([]any{querySQL}, query.GetArgs()...)...)
 		if err != nil {
 			return err
 		}
@@ -81,10 +91,23 @@ func (s *UserAuthTokenService) deleteOrphanedExternalSessions(ctx context.Contex
 	s.log.Debug("Starting cleanup of external sessions")
 
 	var affected int64
-	err := s.sqlStore.WithDbSession(ctx, func(dbSession *db.Session) error {
-		sql := `DELETE FROM user_external_session WHERE NOT EXISTS (SELECT 1 FROM user_auth_token WHERE user_external_session.id = user_auth_token.external_session_id)`
-
-		res, err := dbSession.Exec(sql)
+	dbHelper, err := s.sql(ctx)
+	if err != nil {
+		return fmt.Errorf("get legacy DB: %w", err)
+	}
+	err = dbHelper.DB.WithDbSession(ctx, func(dbSession *sqlstore.DBSession) error {
+		query := orphanedExternalSessionsQuery{
+			SQLTemplate:                  sqltemplate.New(dbHelper.DialectForDriver()),
+			ExternalSessionTable:         dbHelper.Table("user_external_session"),
+			TokenTable:                   dbHelper.Table("user_auth_token"),
+			ExternalSessionIDColumn:      "user_external_session.id",
+			TokenExternalSessionIDColumn: "token.external_session_id",
+		}
+		querySQL, err := sqltemplate.Execute(deleteOrphanedExternalSessionsTemplate, query)
+		if err != nil {
+			return err
+		}
+		res, err := dbSession.Exec(append([]any{querySQL}, query.GetArgs()...)...)
 		if err != nil {
 			return err
 		}

--- a/pkg/services/quota/quotaimpl/quota_test.go
+++ b/pkg/services/quota/quotaimpl/quota_test.go
@@ -500,7 +500,7 @@ func setupEnv(t *testing.T, sqlStore db.DB, cfg *setting.Cfg, b bus.Bus, quotaSe
 	tracer := tracing.InitializeTracerForTest()
 	_, err = apikeyimpl.ProvideService(sqlStore, cfg, quotaService)
 	require.NoError(t, err)
-	_, err = authimpl.ProvideUserAuthTokenService(t.Context(), sqlStore, nil, quotaService, fakes.NewFakeSecretsService(), cfgProvider, tracing.InitializeTracerForTest(), featuremgmt.WithFeatures())
+	_, err = authimpl.ProvideUserAuthTokenService(t.Context(), legacysql.NewDatabaseProvider(sqlStore), nil, quotaService, fakes.NewFakeSecretsService(), cfgProvider, tracing.InitializeTracerForTest(), featuremgmt.WithFeatures())
 	require.NoError(t, err)
 	ac := acimpl.ProvideAccessControl(featuremgmt.WithFeatures())
 	emptySearchResponse := &resourcepb.ResourceSearchResponse{TotalHits: 0}


### PR DESCRIPTION
## Summary

Migrates `authimpl` from direct XORM/raw SQL access to the legacy SQL provider and template pattern used by other stores.

- `ProvideUserAuthTokenService` now accepts `legacysql.LegacyDatabaseProvider`.
- Each database operation resolves its helper from the operation context.
- Token lifecycle, cleanup, quota reporting, and external-session operations render their statements from embedded SQL templates.
- Table identifiers are resolved through `LegacyDatabaseHelper.Table` and dialect-quoted with `{{ .Ident ... }}`.
- Runtime values are bound with `{{ .Arg ... }}`.
- Legacy timestamp columns use `legacysql.DBTime` with the resolved database time zone.
- Standard construction sites explicitly use `legacysql.NewDatabaseProvider`.
- Wire output was regenerated.

The AuthN session-client context and Enterprise wiring rationale are documented in the companion Enterprise PR: https://github.com/grafana/grafana-enterprise/pull/12758

## Prior Art

This follows established patterns in the repository:

- `pkg/registry/apis/collections/legacy` for resolving a legacy database provider at operation time.
- `pkg/services/authz/rbac/store` for provider-backed query construction and execution.
- `pkg/extensions/apiserver/registry/iam/role/legacy` for embedded SQL templates and cross-dialect snapshot coverage.

## Testing

- `go test ./pkg/services/auth/authimpl -count=1`
- `go test ./pkg/extensions/auth ./pkg/services/quota/quotaimpl -count=1`
- `go test ./pkg/extensions/authn -count=1`
- `go test ./pkg/server -run '^$' -count=1`
- `go test -tags enterprise ./pkg/extensions/auth ./pkg/extensions/authn -count=1`
- `go test -p 1 -tags enterprise ./pkg/server -run '^$' -count=1`

The auth tests include:

- MySQL, PostgreSQL, and SQLite SQL-rendering snapshots using qualified test identifiers.
- SQL-mock execution coverage that verifies the injected provider receives the request context and that token, external-session, and cleanup queries use resolved table names and expected arguments.
- Existing token lifecycle, transaction, cleanup, and external-session behavior coverage.