### PR TITLE
fix(transformations): pass null/undefined string values through unchanged in formatString

### DIFF
--- a/packages/grafana-data/src/transformations/transformers/formatString.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/formatString.test.ts
@@ -21,6 +21,16 @@ const frame = toDataFrame({
   ],
 });
 
+const frameWithNulls = toDataFrame({
+  fields: [
+    {
+      name: 'names',
+      type: FieldType.string,
+      values: ['alice', null, 'BOB', undefined, 'david'],
+    },
+  ],
+});
+
 const fieldMatches = fieldMatchers.get(FieldMatcherID.byName).get('names');
 
 const options = (format: FormatStringOutput, substringStart?: number, substringEnd?: number) => {
@@ -81,5 +91,26 @@ describe('Format String Transformer', () => {
     const newValues = newFrame[0].values;
 
     expect(newValues).toEqual(['ice', 'B', 'cha', 'vid', 'ma ', '']);
+  });
+
+  it('will pass null and undefined values through unchanged', () => {
+    const formats = [
+      FormatStringOutput.UpperCase,
+      FormatStringOutput.LowerCase,
+      FormatStringOutput.TitleCase,
+      FormatStringOutput.Trim,
+      FormatStringOutput.Substring,
+    ];
+
+    for (const format of formats) {
+      const formatter = createStringFormatter(
+        fieldMatches,
+        getFormatStringFunction(options(format, 1, 3))
+      );
+      const newFrame = formatter(frameWithNulls, [frameWithNulls]);
+      const newValues = newFrame[0].values;
+
+      expect(newValues).toEqual(['alice', null, 'BOB', undefined, 'david']);
+    }
   });
 });

--- a/packages/grafana-data/src/transformations/transformers/formatString.ts
+++ b/packages/grafana-data/src/transformations/transformers/formatString.ts
@@ -42,6 +42,9 @@ const splitToCapitalWords = (input: string) => {
 export const getFormatStringFunction = (options: FormatStringTransformerOptions) => {
   return (field: Field) =>
     field.values.map((value: string) => {
+      if (value == null) {
+        return value;
+      }
       switch (options.outputFormat) {
         case FormatStringOutput.UpperCase:
           return value.toUpperCase();


### PR DESCRIPTION
The formatString transformer crashes (TypeError) and blanks the entire panel when a string field contains null or undefined values, because the map callback calls string methods like toUpperCase/trim/substring directly on each value without a null guard.

This adds an early return at the top of the map callback so null and undefined values pass through unchanged. No behavior change for non-null values — only the crash path is affected.

Added a test case to formatString.test.ts that runs the transformer (UpperCase, LowerCase, TitleCase, Trim, Substring) over a fixture frame containing null and undefined values and asserts they survive unchanged.