### PR TITLE
FeatureToggles: Remove deprecated dashboards.filterablePanels

### DIFF
--- a/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
@@ -27,7 +27,6 @@ declare module "@openfeature/core" {
     | "grafana.secretsReferenceValueUI"
     | "sqlExpressionsColumnAutoComplete"
     | "sqlExpressionsCodeMirror"
-    | "dashboards.filterablePanels"
     | "grafana.filterablePanels"
     | "grafana.savedQueriesPage"
     | "newSavedQueriesExperience"

--- a/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
@@ -33,8 +33,6 @@ export const FlagKeys = {
   DashboardSectionVariables: "dashboardSectionVariables",
   /** Enables the Assistant button in the dashboard templates card */
   DashboardTemplatesAssistantButton: "dashboardTemplatesAssistantButton",
-  /** Enables interactive grouped-label filtering through the tooltip in state timeline, status history and histogram panels */
-  DashboardsFilterablePanels: "dashboards.filterablePanels",
   /** Use the new datasource API groups for datasource resource requests, frontend flag */
   DatasourcesApiserverUseNewAPIsForDatasourceResources: "datasources.apiserver.useNewAPIsForDatasourceResources",
   /** Use the new datasource API groups for datasource CRUD requests, frontend flag */
@@ -263,17 +261,6 @@ export const useFlagDashboardSectionVariables = (options?: ReactFlagEvaluationOp
  */
 export const useFlagDashboardTemplatesAssistantButton = (options?: ReactFlagEvaluationOptions): boolean => {
   return useFlag("dashboardTemplatesAssistantButton", false, options).value;
-};
-
-/**
- * Enables interactive grouped-label filtering through the tooltip in state timeline, status history and histogram panels
- *
- * **Details:**
- * - flag key: `dashboards.filterablePanels`
- * - default value: `false`
- */
-export const useFlagDashboardsFilterablePanels = (options?: ReactFlagEvaluationOptions): boolean => {
-  return useFlag("dashboards.filterablePanels", false, options).value;
 };
 
 /**

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -975,14 +975,6 @@ var (
 			Expression:   "true",
 		},
 		{
-			Name:        "dashboards.filterablePanels",
-			Description: "Enables interactive grouped-label filtering through the tooltip in state timeline, status history and histogram panels",
-			Stage:       FeatureStageExperimental,
-			Generate:    Generate{React: true},
-			Owner:       grafanaDashboardsSquad,
-			Expression:  "false",
-		},
-		{
 			Name:        "grafana.filterablePanels",
 			Description: "Enables interactive grouped-label filtering through the tooltip in state timeline, status history and histogram panels",
 			Stage:       FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -111,7 +111,6 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2025-11-19,refreshTokenRequired,experimental,@grafana/identity-access-team,false,false,false
 2024-04-04,newDashboardWithFiltersAndGroupBy,experimental,@grafana/dashboards-squad,false,false,false
 2026-03-09,dashboardUnifiedDrilldownControls,GA,@grafana/dashboards-squad,false,false,true
-2026-07-17,dashboards.filterablePanels,experimental,@grafana/dashboards-squad,false,false,true
 2026-07-21,grafana.filterablePanels,experimental,@grafana/dashboards-squad,false,false,true
 2024-04-05,cloudWatchNewLabelParsing,GA,@grafana/data-sources-plugins,false,false,false
 2024-04-16,disableNumericMetricsSortingInExpressions,experimental,@grafana/data-sources-plugins,false,true,false

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1773,7 +1773,8 @@
       "metadata": {
         "name": "dashboards.filterablePanels",
         "resourceVersion": "1784277442129",
-        "creationTimestamp": "2026-07-17T08:37:22Z"
+        "creationTimestamp": "2026-07-17T08:37:22Z",
+        "deletionTimestamp": "2026-07-22T08:31:47Z"
       },
       "spec": {
         "description": "Enables interactive grouped-label filtering through the tooltip in state timeline, status history and histogram panels",


### PR DESCRIPTION
**What is this feature?**

Removes the deprecated `dashboards.filterablePanels` feature toggle registration and its generated artifacts. The flag was renamed to `grafana.filterablePanels` in #128879 (it violated the `grafana.`-prefix naming convention for core OpenFeature flags) and the frontend switched to the new key in #128880, so nothing reads the old key anymore.

**Special notes for your reviewer:**

Single PR (no FE/BE split): after #128880 there are no consumers of the old key or its generated constant on either side, and the toggle codegen check requires the registry and generated artifacts to move together. `toggles_gen.json` keeps the tombstoned entry with a `deletionTimestamp`, as the generator prescribes for flags that shipped.

If any environment explicitly enabled `dashboards.filterablePanels` in config, it should switch to `grafana.filterablePanels`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)