### PR TITLE
Back document builders with the shared search-fields registry

### DIFF
--- a/pkg/storage/unified/resource/document.go
+++ b/pkg/storage/unified/resource/document.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/grafana/grafana-app-sdk/app"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -41,14 +40,6 @@ type DocumentBuilderInfo struct {
 
 	// Complicated builders (eg dashboards!) will be declared dynamically and managed by the ResourceServer
 	Namespaced NamespacedDocumentSupplier
-
-	// SearchFieldsProvider is the manifest-driven source of truth for this
-	// builder's search fields. When non-nil, the bleve mapping for
-	// GroupResource is built from the provider's SearchFieldDefinition
-	// declarations. The provider is also the source for the column-definition
-	// view of the kind's fields that the search backend uses for result
-	// metadata and sort-field prefixing (see SearchableFields).
-	SearchFieldsProvider SearchFieldsProvider
 }
 
 // SearchableFieldsFromProvider returns the column-definition view of a kind's
@@ -68,7 +59,7 @@ func SearchableFieldsFromProvider(p SearchFieldsProvider, group, resource string
 }
 
 type DocumentBuilderSupplier interface {
-	GetDocumentBuilders() ([]DocumentBuilderInfo, error)
+	GetDocumentBuilders(registry *SearchFieldsRegistry) ([]DocumentBuilderInfo, error)
 }
 
 // IndexableDocument can be written to a ResourceIndex
@@ -261,28 +252,20 @@ func NewIndexableDocument(key *resourcepb.ResourceKey, rv int64, obj utils.Grafa
 	return doc.UpdateCopyFields()
 }
 
-func StandardDocumentBuilder(manifests []app.Manifest) DocumentBuilder {
-	return StandardDocumentBuilderWithFields(manifests, nil)
-}
-
-// StandardDocumentBuilderWithFields returns the standard document builder
-// wired with a SearchFieldsProvider. When the provider is non-nil, the
-// builder reads SearchFieldDefinitions for the document's group/version/
-// resource and populates IndexableDocument.Fields from their declared Path
-// values. Path-less definitions are ignored (they require a custom builder).
-// Type mismatches are logged and the field is dropped.
-func StandardDocumentBuilderWithFields(manifests []app.Manifest, provider SearchFieldsProvider) DocumentBuilder {
+// StandardDocumentBuilder returns the standard document builder backed by the
+// shared registry, so a runtime manifest reload is reflected without rebuilding
+// the builder.
+func StandardDocumentBuilder(registry *SearchFieldsRegistry) DocumentBuilder {
 	return &standardDocumentBuilder{
-		selectableFields: SelectableFieldsForManifests(manifests),
-		provider:         provider,
-		log:              log.New("resource.document-builder"),
+		registry: registry,
+		log:      log.New("resource.document-builder"),
 	}
 }
 
 type standardDocumentBuilder struct {
-	selectableFields map[LowerGroupResource][]string
-	// provider supplies declarative search fields; may be nil.
-	provider SearchFieldsProvider
+	// registry is the shared source for selectable fields and search-field
+	// providers; may be nil (then the builder extracts neither).
+	registry *SearchFieldsRegistry
 	log      log.Logger
 }
 
@@ -300,11 +283,16 @@ func (s *standardDocumentBuilder) BuildDocument(ctx context.Context, key *resour
 
 	doc := NewIndexableDocument(key, rv, obj, "")
 
-	sfKey := NewLowerGroupResource(key.GetGroup(), key.GetResource())
-	doc.SelectableFields = getSelectableFieldsFromObject(tmp, s.selectableFields[sfKey])
+	if s.registry == nil {
+		return doc, nil
+	}
 
-	if s.provider != nil {
-		s.extractDeclaredFields(ctx, tmp, key, doc)
+	sfKey := NewLowerGroupResource(key.GetGroup(), key.GetResource())
+	selectable, _, provider := s.registry.For(sfKey)
+	doc.SelectableFields = getSelectableFieldsFromObject(tmp, selectable)
+
+	if provider != nil {
+		s.extractDeclaredFields(provider, tmp, key, doc)
 	}
 
 	return doc, nil
@@ -317,12 +305,12 @@ func (s *standardDocumentBuilder) BuildDocument(ctx context.Context, key *resour
 // fallback can silently extract an old document with a newer version's path
 // declarations when the schema diverges, so the builder leaves that
 // decision to manifest authors.
-func (s *standardDocumentBuilder) extractDeclaredFields(_ context.Context, tmp *unstructured.Unstructured, key *resourcepb.ResourceKey, doc *IndexableDocument) {
-	gvr := gvrForLookup(tmp, key, s.provider)
+func (s *standardDocumentBuilder) extractDeclaredFields(provider SearchFieldsProvider, tmp *unstructured.Unstructured, key *resourcepb.ResourceKey, doc *IndexableDocument) {
+	gvr := gvrForLookup(tmp, key, provider)
 	if gvr.Resource == "" {
 		return
 	}
-	defs := s.provider.Fields(gvr)
+	defs := provider.Fields(gvr)
 	if len(defs) == 0 {
 		return
 	}

--- a/pkg/storage/unified/resource/document_test.go
+++ b/pkg/storage/unified/resource/document_test.go
@@ -61,6 +61,14 @@ func TestStandardDocumentBuilder(t *testing.T) {
 	}`, string(jj))
 }
 
+// registryWithProvider seeds a registry so the standard builder finds the given
+// provider for the kind under test.
+func registryWithProvider(gvr schema.GroupVersionResource, provider SearchFieldsProvider) *SearchFieldsRegistry {
+	return NewSearchFieldsRegistry(nil, nil, map[LowerGroupResource]SearchFieldsProvider{
+		NewLowerGroupResource(gvr.Group, gvr.Resource): provider,
+	})
+}
+
 func TestStandardDocumentBuilder_DeclaredFields(t *testing.T) {
 	ctx := t.Context()
 	gvr := schema.GroupVersionResource{Group: "example.grafana.app", Version: "v1", Resource: "things"}
@@ -96,7 +104,7 @@ func TestStandardDocumentBuilder_DeclaredFields(t *testing.T) {
 				{Name: "member_names", Path: "spec.members[*].name", Type: SearchFieldTypeString, Array: true},
 			},
 		}, nil)
-		builder := StandardDocumentBuilderWithFields(nil, provider)
+		builder := StandardDocumentBuilder(registryWithProvider(gvr, provider))
 		doc, err := builder.BuildDocument(ctx, key, 1, body)
 		require.NoError(t, err)
 		require.Equal(t, "alice@example.com", doc.Fields["email"])
@@ -112,7 +120,7 @@ func TestStandardDocumentBuilder_DeclaredFields(t *testing.T) {
 				{Name: "computed", Type: SearchFieldTypeString},
 			},
 		}, nil)
-		builder := StandardDocumentBuilderWithFields(nil, provider)
+		builder := StandardDocumentBuilder(registryWithProvider(gvr, provider))
 		doc, err := builder.BuildDocument(ctx, key, 1, body)
 		require.NoError(t, err)
 		_, present := doc.Fields["computed"]
@@ -125,7 +133,7 @@ func TestStandardDocumentBuilder_DeclaredFields(t *testing.T) {
 				{Name: "email", Path: "spec.email", Type: SearchFieldTypeInt64},
 			},
 		}, nil)
-		builder := StandardDocumentBuilderWithFields(nil, provider)
+		builder := StandardDocumentBuilder(registryWithProvider(gvr, provider))
 		doc, err := builder.BuildDocument(ctx, key, 1, body)
 		require.NoError(t, err)
 		_, present := doc.Fields["email"]
@@ -138,7 +146,7 @@ func TestStandardDocumentBuilder_DeclaredFields(t *testing.T) {
 				{Name: "absent", Path: "spec.not_there", Type: SearchFieldTypeString},
 			},
 		}, nil)
-		builder := StandardDocumentBuilderWithFields(nil, provider)
+		builder := StandardDocumentBuilder(registryWithProvider(gvr, provider))
 		doc, err := builder.BuildDocument(ctx, key, 1, body)
 		require.NoError(t, err)
 		assert.Empty(t, doc.Fields)
@@ -158,7 +166,7 @@ func TestStandardDocumentBuilder_DeclaredFields(t *testing.T) {
 				{Group: gvr.Group, Resource: gvr.Resource}: "v2",
 			},
 		)
-		builder := StandardDocumentBuilderWithFields(nil, provider)
+		builder := StandardDocumentBuilder(registryWithProvider(gvr, provider))
 		doc, err := builder.BuildDocument(ctx, key, 1, body)
 		require.NoError(t, err)
 		assert.Empty(t, doc.Fields)
@@ -180,7 +188,7 @@ func TestStandardDocumentBuilder_DeclaredFields(t *testing.T) {
 				{Group: gvr.Group, Resource: gvr.Resource}: gvr.Version,
 			},
 		)
-		builder := StandardDocumentBuilderWithFields(nil, provider)
+		builder := StandardDocumentBuilder(registryWithProvider(gvr, provider))
 		doc, err := builder.BuildDocument(ctx, key, 1, bodyNoVersion)
 		require.NoError(t, err)
 		assert.Equal(t, "alice@example.com", doc.Fields["email"])
@@ -209,7 +217,7 @@ func TestStandardDocumentBuilder_DeclaredFields(t *testing.T) {
 				},
 			}, nil,
 		)
-		builder := StandardDocumentBuilderWithFields(nil, provider)
+		builder := StandardDocumentBuilder(registryWithProvider(gvr, provider))
 		doc, err := builder.BuildDocument(ctx, key, 1, bodyEmpty)
 		require.NoError(t, err)
 		assert.Equal(t, false, doc.Fields["flag"])
@@ -230,18 +238,74 @@ func TestStandardDocumentBuilder_DeclaredFields(t *testing.T) {
 		provider := NewMapProvider(map[schema.GroupVersionResource][]SearchFieldDefinition{
 			gvr: {{Name: "email", Path: "spec.email", Type: SearchFieldTypeString}},
 		}, nil)
-		builder := StandardDocumentBuilderWithFields(nil, provider)
+		builder := StandardDocumentBuilder(registryWithProvider(gvr, provider))
 		doc, err := builder.BuildDocument(ctx, key, 1, bodyNoVersion)
 		require.NoError(t, err)
 		assert.Empty(t, doc.Fields)
 	})
 
-	t.Run("nil provider preserves legacy behaviour", func(t *testing.T) {
-		// Constructor without a provider must produce the same shape as
-		// StandardDocumentBuilder(manifests).
-		builder := StandardDocumentBuilderWithFields(nil, nil)
+	t.Run("nil registry preserves base behaviour", func(t *testing.T) {
+		// Without a registry the builder still produces the base document,
+		// just no selectable or declared fields.
+		builder := StandardDocumentBuilder(nil)
 		doc, err := builder.BuildDocument(ctx, key, 1, body)
 		require.NoError(t, err)
 		assert.Empty(t, doc.Fields)
 	})
+}
+
+// TestStandardDocumentBuilder_ReloadThroughRegistry verifies the central
+// reload behavior: one builder, backed by a registry, reflects a Replace of the
+// registry's selectable fields and path-based definitions on the next document
+// without being rebuilt.
+func TestStandardDocumentBuilder_ReloadThroughRegistry(t *testing.T) {
+	ctx := t.Context()
+	gvr := schema.GroupVersionResource{Group: "example.grafana.app", Version: "v1", Resource: "things"}
+	gr := gvr.GroupResource()
+	sfKey := NewLowerGroupResource(gvr.Group, gvr.Resource)
+	key := &resourcepb.ResourceKey{Namespace: "default", Group: gvr.Group, Resource: gvr.Resource, Name: "thing-1"}
+	body := []byte(`{
+		"apiVersion": "example.grafana.app/v1",
+		"kind": "Thing",
+		"metadata": {"name": "thing-1"},
+		"spec": {"a": "AAA", "b": "BBB", "x": "XXX", "y": "YYY"}
+	}`)
+
+	providerFor := func(name, path string) SearchFieldsProvider {
+		return NewMapProvider(
+			map[schema.GroupVersionResource][]SearchFieldDefinition{
+				gvr: {{Name: name, Path: path, Type: SearchFieldTypeString}},
+			},
+			map[schema.GroupResource]string{gr: gvr.Version},
+		)
+	}
+
+	registry := NewSearchFieldsRegistry(
+		map[LowerGroupResource][]string{sfKey: {"spec.x"}},
+		nil,
+		map[LowerGroupResource]SearchFieldsProvider{sfKey: providerFor("a", "spec.a")},
+	)
+	builder := StandardDocumentBuilder(registry)
+
+	doc, err := builder.BuildDocument(ctx, key, 1, body)
+	require.NoError(t, err)
+	require.Equal(t, "AAA", doc.Fields["a"])
+	require.NotContains(t, doc.Fields, "b")
+	require.Contains(t, doc.SelectableFields, "spec.x")
+	require.NotContains(t, doc.SelectableFields, "spec.y")
+
+	// Reload with different declared and selectable fields; the same builder
+	// must reflect them on the next document.
+	registry.Replace(
+		map[LowerGroupResource][]string{sfKey: {"spec.y"}},
+		nil,
+		map[LowerGroupResource]SearchFieldsProvider{sfKey: providerFor("b", "spec.b")},
+	)
+
+	doc, err = builder.BuildDocument(ctx, key, 1, body)
+	require.NoError(t, err)
+	require.Equal(t, "BBB", doc.Fields["b"])
+	require.NotContains(t, doc.Fields, "a")
+	require.Contains(t, doc.SelectableFields, "spec.y")
+	require.NotContains(t, doc.SelectableFields, "spec.x")
 }

--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -311,7 +311,7 @@ func newSearchServer(opts SearchOptions, storage StorageBackend, vectorBackend v
 	s.rebuildQueue = debouncer.NewQueue(combineRebuildRequests)
 	s.inFlightRebuilds = map[NamespacedResource]*rebuildState{}
 
-	info, err := opts.Resources.GetDocumentBuilders()
+	info, err := opts.Resources.GetDocumentBuilders(searchFields)
 	if err != nil {
 		return nil, err
 	}
@@ -2111,7 +2111,7 @@ type TestDocumentBuilderSupplier struct {
 	GroupsResources map[string]string
 }
 
-func (s *TestDocumentBuilderSupplier) GetDocumentBuilders() ([]DocumentBuilderInfo, error) {
+func (s *TestDocumentBuilderSupplier) GetDocumentBuilders(_ *SearchFieldsRegistry) ([]DocumentBuilderInfo, error) {
 	builders := make([]DocumentBuilderInfo, 0, len(s.GroupsResources))
 
 	// Add builders for all possible group/resource combinations

--- a/pkg/storage/unified/search/bleve_lifecycle_test.go
+++ b/pkg/storage/unified/search/bleve_lifecycle_test.go
@@ -1,7 +1,6 @@
 package search
 
 import (
-	"context"
 	"fmt"
 	"math/rand"
 	"os"
@@ -14,11 +13,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
-	"github.com/grafana/grafana/pkg/services/store/kind/dashboard"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
-	"github.com/grafana/grafana/pkg/storage/unified/search/builders"
 )
 
 type expectedDashboardSearchFields struct {
@@ -266,18 +263,8 @@ func dashboardSearchLifecycleSeed(t *testing.T) int64 {
 func newFileBackedDashboardIndex(t *testing.T, key resource.NamespacedResource, docCount int64) *bleveIndex {
 	t.Helper()
 
-	info, err := builders.DashboardBuilder(func(ctx context.Context, namespace string, blob resource.BlobSupport) (resource.DocumentBuilder, error) {
-		return &builders.DashboardDocumentBuilder{
-			Namespace:        namespace,
-			Blob:             blob,
-			Stats:            make(map[string]map[string]int64),
-			DatasourceLookup: dashboard.CreateDatasourceLookup([]*dashboard.DatasourceQueryResult{{}}),
-		}, nil
-	})
-	require.NoError(t, err)
-
 	backend, _ := setupBleveBackend(t, withFileThreshold(0), withSearchFields(resource.NewSearchFieldsRegistry(nil, nil, map[resource.LowerGroupResource]resource.SearchFieldsProvider{
-		resource.NewLowerGroupResource("dashboard.grafana.app", "dashboards"): info.SearchFieldsProvider,
+		resource.NewLowerGroupResource("dashboard.grafana.app", "dashboards"): DashboardSearchFieldsProviderForTest(),
 	})))
 	ctx := identity.WithRequester(t.Context(), &user.SignedInUser{Namespace: key.Namespace})
 

--- a/pkg/storage/unified/search/bleve_mappings_golden_test.go
+++ b/pkg/storage/unified/search/bleve_mappings_golden_test.go
@@ -37,19 +37,15 @@ var updateGolden = flag.Bool("update-golden", false, "regenerate bleve mapping g
 // raw StandardSearchFields column definitions would not add information.
 //
 // The per-kind cases (dashboard, user, team, team_binding,
-// external_group_mapping) call each in-tree builder and feed the resulting
-// DocumentBuilderInfo through GetBleveMappings the same way BuildIndex does
-// in production: the test reads SearchFieldsProvider, Group, and Resource
-// off the builder info and passes them through, exercising the
-// provider-driven mapping path. Each per-kind case sets providerExpected so
-// a future regression in builder wiring (silently dropping the provider) is
-// caught here. Search server and client can deploy separately, so the
-// byte-identical guarantee from these goldens matters.
+// external_group_mapping) take each in-tree kind's Group and Resource from its
+// builder and its provider from a shared manifest-backed provider, matching how
+// production builds the mapping from the registry. Each per-kind case sets
+// providerExpected so a regression that drops a kind's declared fields is caught
+// here. Search server and client can deploy separately, so the byte-identical
+// guarantee from these goldens matters.
 func TestBleveMappingsGoldenJSON(t *testing.T) {
-	// builderInfoFor returns the DocumentBuilderInfo for an in-tree kind so
-	// the test can mirror BuildIndex: pull SearchFieldsProvider, Group, and
-	// Resource off the builder info and pass them through to
-	// GetBleveMappings together.
+	// builderInfoFor returns the DocumentBuilderInfo for an in-tree kind, used
+	// for its Group and Resource.
 	builderInfoFor := func(t *testing.T, fn func() (resource.DocumentBuilderInfo, error)) resource.DocumentBuilderInfo {
 		t.Helper()
 		info, err := fn()
@@ -60,28 +56,30 @@ func TestBleveMappingsGoldenJSON(t *testing.T) {
 		return builderInfoFor(t, func() (resource.DocumentBuilderInfo, error) { return builders.DashboardBuilder(nil) })
 	}
 	userInfo := func(t *testing.T) resource.DocumentBuilderInfo {
-		return builderInfoFor(t, builders.GetUserBuilder)
+		return builderInfoFor(t, func() (resource.DocumentBuilderInfo, error) { return builders.GetUserBuilder(nil) })
 	}
 	teamInfo := func(t *testing.T) resource.DocumentBuilderInfo {
-		return builderInfoFor(t, builders.GetTeamSearchBuilder)
+		return builderInfoFor(t, func() (resource.DocumentBuilderInfo, error) { return builders.GetTeamSearchBuilder(nil) })
 	}
 	teamBindingInfo := func(t *testing.T) resource.DocumentBuilderInfo {
-		return builderInfoFor(t, builders.GetTeamBindingBuilder)
+		return builderInfoFor(t, func() (resource.DocumentBuilderInfo, error) { return builders.GetTeamBindingBuilder(nil) })
 	}
 	externalGroupMappingInfo := func(t *testing.T) resource.DocumentBuilderInfo {
-		return builderInfoFor(t, builders.GetExternalGroupMappingBuilder)
+		return builderInfoFor(t, func() (resource.DocumentBuilderInfo, error) { return builders.GetExternalGroupMappingBuilder(nil) })
 	}
+
+	// In production the mapping's provider comes from the shared registry, built
+	// from the app manifests, not from the builder. Mirror that here.
+	manifestProvider := resource.NewManifestBackedProvider(resource.AppManifests())
 
 	cases := []struct {
 		name string
-		// builder returns the DocumentBuilderInfo for a real in-tree kind.
-		// When set, the test passes info.SearchFieldsProvider,
-		// info.GroupResource.{Group,Resource} to GetBleveMappings,
-		// matching production.
+		// builder returns the DocumentBuilderInfo for a real in-tree kind. When
+		// set, the test takes Group/Resource from it and the provider from the
+		// shared manifest provider, matching production.
 		builder func(t *testing.T) resource.DocumentBuilderInfo
-		// providerExpected, when true, asserts builder() returns a non-nil
-		// SearchFieldsProvider so a future regression in builder wiring
-		// (silently dropping the provider) is caught here.
+		// providerExpected, when true, asserts the manifest provider declares
+		// fields for the kind, so a regression that drops them is caught here.
 		providerExpected bool
 		provider         func(t *testing.T) (resource.SearchFieldsProvider, string, string)
 		selectableFields []string
@@ -162,11 +160,12 @@ func TestBleveMappingsGoldenJSON(t *testing.T) {
 			switch {
 			case tc.builder != nil:
 				info := tc.builder(t)
-				provider = info.SearchFieldsProvider
+				provider = manifestProvider
 				group = info.GroupResource.Group
 				kindResource = info.GroupResource.Resource
 				if tc.providerExpected {
-					require.NotNil(t, provider, "builder for %q must return a non-nil SearchFieldsProvider so the golden exercises the provider-driven mapping path used in production", tc.name)
+					require.NotEmpty(t, provider.Fields(schema.GroupVersionResource{Group: group, Resource: kindResource}),
+						"the manifest provider must declare fields for %q so the golden exercises the provider-driven mapping path used in production", tc.name)
 				}
 			case tc.provider != nil:
 				provider, group, kindResource = tc.provider(t)

--- a/pkg/storage/unified/search/bleve_performance_test.go
+++ b/pkg/storage/unified/search/bleve_performance_test.go
@@ -8,12 +8,10 @@ import (
 	"time"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
-	"github.com/grafana/grafana/pkg/services/store/kind/dashboard"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 	"github.com/grafana/grafana/pkg/storage/unified/search"
-	"github.com/grafana/grafana/pkg/storage/unified/search/builders"
 
 	"github.com/stretchr/testify/require"
 )
@@ -59,22 +57,12 @@ func BenchmarkBleveBuildIndexStorageSelection(b *testing.B) {
 }
 
 func benchmarkBuildIndex(b *testing.B, docs int, fileThreshold int64) {
-	info, err := builders.DashboardBuilder(func(ctx context.Context, namespace string, blob resource.BlobSupport) (resource.DocumentBuilder, error) {
-		return &builders.DashboardDocumentBuilder{
-			Namespace:        namespace,
-			Blob:             blob,
-			Stats:            make(map[string]map[string]int64),
-			DatasourceLookup: dashboard.CreateDatasourceLookup([]*dashboard.DatasourceQueryResult{{}}),
-		}, nil
-	})
-	require.NoError(b, err)
-
 	backend, err := search.NewBleveBackend(search.BleveOptions{
 		Root:          b.TempDir(),
 		FileThreshold: fileThreshold,
 		BuildVersion:  "12.3.45-789",
 		SearchFields: resource.NewSearchFieldsRegistry(nil, nil, map[resource.LowerGroupResource]resource.SearchFieldsProvider{
-			resource.NewLowerGroupResource("dashboard.grafana.app", "dashboards"): info.SearchFieldsProvider,
+			resource.NewLowerGroupResource("dashboard.grafana.app", "dashboards"): search.DashboardSearchFieldsProviderForTest(),
 		}),
 	}, nil)
 	require.NoError(b, err)

--- a/pkg/storage/unified/search/bleve_search_test.go
+++ b/pkg/storage/unified/search/bleve_search_test.go
@@ -13,12 +13,10 @@ import (
 	apischema "k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
-	"github.com/grafana/grafana/pkg/services/store/kind/dashboard"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 	"github.com/grafana/grafana/pkg/storage/unified/search"
-	"github.com/grafana/grafana/pkg/storage/unified/search/builders"
 )
 
 const threshold = 9999
@@ -661,21 +659,11 @@ func newTestDashboardsIndex(t testing.TB, threshold int64, size int64, writer re
 		Group:     "dashboard.grafana.app",
 		Resource:  "dashboards",
 	}
-	info, err := builders.DashboardBuilder(func(ctx context.Context, namespace string, blob resource.BlobSupport) (resource.DocumentBuilder, error) {
-		return &builders.DashboardDocumentBuilder{
-			Namespace:        namespace,
-			Blob:             blob,
-			Stats:            make(map[string]map[string]int64), // empty stats
-			DatasourceLookup: dashboard.CreateDatasourceLookup([]*dashboard.DatasourceQueryResult{{}}),
-		}, nil
-	})
-	require.NoError(t, err)
-
 	backend, err := search.NewBleveBackend(search.BleveOptions{
 		Root:          t.TempDir(),
 		FileThreshold: threshold, // use in-memory for tests
 		SearchFields: resource.NewSearchFieldsRegistry(nil, nil, map[resource.LowerGroupResource]resource.SearchFieldsProvider{
-			resource.NewLowerGroupResource("dashboard.grafana.app", "dashboards"): info.SearchFieldsProvider,
+			resource.NewLowerGroupResource("dashboard.grafana.app", "dashboards"): search.DashboardSearchFieldsProviderForTest(),
 		}),
 	}, nil)
 	require.NoError(t, err)
@@ -1009,23 +997,13 @@ func newTestDashboardsIndexPostRankWithConfig(t testing.TB, size int64, cfg sear
 		Group:     "dashboard.grafana.app",
 		Resource:  "dashboards",
 	}
-	info, err := builders.DashboardBuilder(func(ctx context.Context, namespace string, blob resource.BlobSupport) (resource.DocumentBuilder, error) {
-		return &builders.DashboardDocumentBuilder{
-			Namespace:        namespace,
-			Blob:             blob,
-			Stats:            make(map[string]map[string]int64),
-			DatasourceLookup: dashboard.CreateDatasourceLookup([]*dashboard.DatasourceQueryResult{{}}),
-		}, nil
-	})
-	require.NoError(t, err)
-
 	backend, err := search.NewBleveBackend(search.BleveOptions{
 		Root:                 t.TempDir(),
 		FileThreshold:        threshold, // use in-memory for tests
 		PostRankAuthzEnabled: true,
 		PostRankAuthz:        cfg,
 		SearchFields: resource.NewSearchFieldsRegistry(nil, nil, map[resource.LowerGroupResource]resource.SearchFieldsProvider{
-			resource.NewLowerGroupResource("dashboard.grafana.app", "dashboards"): info.SearchFieldsProvider,
+			resource.NewLowerGroupResource("dashboard.grafana.app", "dashboards"): search.DashboardSearchFieldsProviderForTest(),
 		}),
 	}, nil)
 	require.NoError(t, err)

--- a/pkg/storage/unified/search/bleve_test.go
+++ b/pkg/storage/unified/search/bleve_test.go
@@ -52,14 +52,11 @@ func TestBleveBackend(t *testing.T) {
 
 	// Register the dashboard provider so the static fields.* mapping is built
 	// from declared fields, as in production; without it custom fields drop.
-	dashInfo, err := builders.DashboardBuilder(nil)
-	require.NoError(t, err)
-
 	backend, err := NewBleveBackend(BleveOptions{
 		Root:          tmpdir,
 		FileThreshold: 5, // with more than 5 items we create a file on disk
 		SearchFields: resource.NewSearchFieldsRegistry(nil, nil, map[resource.LowerGroupResource]resource.SearchFieldsProvider{
-			resource.NewLowerGroupResource("dashboard.grafana.app", "dashboards"): dashInfo.SearchFieldsProvider,
+			resource.NewLowerGroupResource("dashboard.grafana.app", "dashboards"): DashboardSearchFieldsProviderForTest(),
 		}),
 	}, nil)
 	require.NoError(t, err)
@@ -74,14 +71,11 @@ func TestBleveSearchRootFolderExpansion(t *testing.T) {
 
 	// Register the dashboard provider so the index is built from declared
 	// fields, as in production.
-	dashInfo, err := builders.DashboardBuilder(nil)
-	require.NoError(t, err)
-
 	backend, err := NewBleveBackend(BleveOptions{
 		Root:          tmpdir,
 		FileThreshold: 5,
 		SearchFields: resource.NewSearchFieldsRegistry(nil, nil, map[resource.LowerGroupResource]resource.SearchFieldsProvider{
-			resource.NewLowerGroupResource("dashboard.grafana.app", "dashboards"): dashInfo.SearchFieldsProvider,
+			resource.NewLowerGroupResource("dashboard.grafana.app", "dashboards"): DashboardSearchFieldsProviderForTest(),
 		}),
 	}, nil)
 	require.NoError(t, err)
@@ -816,9 +810,7 @@ func testBleveBackend(t *testing.T, backend *bleveBackend) {
 }
 
 func TestGetSortFields(t *testing.T) {
-	dashboardInfo, err := builders.DashboardBuilder(nil)
-	require.NoError(t, err)
-	dashboardFields, err := resource.SearchableFieldsFromProvider(dashboardInfo.SearchFieldsProvider, dashboardInfo.GroupResource.Group, dashboardInfo.GroupResource.Resource)
+	dashboardFields, err := resource.SearchableFieldsFromProvider(DashboardSearchFieldsProviderForTest(), "dashboard.grafana.app", "dashboards")
 	require.NoError(t, err)
 
 	t.Run("will prepend 'fields.' to sort fields when they are dashboard fields", func(t *testing.T) {

--- a/pkg/storage/unified/search/builders/alertingrules.go
+++ b/pkg/storage/unified/search/builders/alertingrules.go
@@ -5,10 +5,7 @@ import (
 	"encoding/json"
 	"sort"
 
-	"github.com/grafana/grafana-app-sdk/app"
-
 	rulesv0alpha1 "github.com/grafana/grafana/apps/alerting/rules/pkg/apis/alerting/v0alpha1"
-	rulesmanifest "github.com/grafana/grafana/apps/alerting/rules/pkg/apis/manifestdata"
 	"github.com/grafana/grafana/pkg/expr"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
@@ -25,31 +22,19 @@ const (
 	ruleSearchDatasourceUIDs = "datasourceUIDs"
 )
 
-// rulesManifests carries the rule kinds' manifest, the source of truth for
-// their searchFields (declared in CUE) and their selectable-field declarations.
-var rulesManifests = []app.Manifest{rulesmanifest.LocalManifest()}
-
-// rulesSearchFieldsProvider is the single manifest-backed provider covering
-// every rule kind. It drives both the declared-path extraction (via the
-// standard document builder) and the bleve mapping / column metadata (via
-// DocumentBuilderInfo.SearchFieldsProvider).
-var rulesSearchFieldsProvider = resource.NewManifestBackedProvider(rulesManifests)
-
-func GetAlertRuleSearchBuilder() (resource.DocumentBuilderInfo, error) {
+func GetAlertRuleSearchBuilder(registry *resource.SearchFieldsRegistry) (resource.DocumentBuilderInfo, error) {
 	gr := rulesv0alpha1.AlertRuleKind().GroupVersionResource().GroupResource()
 	return resource.DocumentBuilderInfo{
-		GroupResource:        gr,
-		Builder:              &alertRuleSearchBuilder{declared: resource.StandardDocumentBuilderWithFields(rulesManifests, rulesSearchFieldsProvider)},
-		SearchFieldsProvider: rulesSearchFieldsProvider,
+		GroupResource: gr,
+		Builder:       &alertRuleSearchBuilder{declared: resource.StandardDocumentBuilder(registry)},
 	}, nil
 }
 
-func GetRecordingRuleSearchBuilder() (resource.DocumentBuilderInfo, error) {
+func GetRecordingRuleSearchBuilder(registry *resource.SearchFieldsRegistry) (resource.DocumentBuilderInfo, error) {
 	gr := rulesv0alpha1.RecordingRuleKind().GroupVersionResource().GroupResource()
 	return resource.DocumentBuilderInfo{
-		GroupResource:        gr,
-		Builder:              &recordingRuleSearchBuilder{declared: resource.StandardDocumentBuilderWithFields(rulesManifests, rulesSearchFieldsProvider)},
-		SearchFieldsProvider: rulesSearchFieldsProvider,
+		GroupResource: gr,
+		Builder:       &recordingRuleSearchBuilder{declared: resource.StandardDocumentBuilder(registry)},
 	}, nil
 }
 

--- a/pkg/storage/unified/search/builders/alertingrules_test.go
+++ b/pkg/storage/unified/search/builders/alertingrules_test.go
@@ -4,15 +4,23 @@ import (
 	"context"
 	"testing"
 
+	"github.com/grafana/grafana-app-sdk/app"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	rulesv0alpha1 "github.com/grafana/grafana/apps/alerting/rules/pkg/apis/alerting/v0alpha1"
+	rulesmanifest "github.com/grafana/grafana/apps/alerting/rules/pkg/apis/manifestdata"
 	"github.com/grafana/grafana/pkg/expr"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 )
+
+// rulesManifests is the rule kinds' manifest; the tests derive the rule search
+// fields from it the way the shared registry does in production.
+var rulesManifests = []app.Manifest{rulesmanifest.LocalManifest()}
+
+var rulesSearchFieldsProvider = resource.NewManifestBackedProvider(rulesManifests)
 
 // Field names as declared in apps/alerting/rules/kinds/{alertRule,recordingRule}.cue.
 // Only type, labels, annotations and datasourceUIDs remain as Go constants in
@@ -50,9 +58,18 @@ func recordingRuleKey(name string) *resourcepb.ResourceKey {
 	}
 }
 
+// rulesTestRegistry seeds a registry with the rule kinds' fields so the
+// registry-backed builders extract them, as they do in production.
+func rulesTestRegistry(t *testing.T) *resource.SearchFieldsRegistry {
+	t.Helper()
+	sel, hashes, providers, err := resource.SearchFieldsForManifests(rulesManifests)
+	require.NoError(t, err)
+	return resource.NewSearchFieldsRegistry(sel, hashes, providers)
+}
+
 func buildAlertRuleDoc(t *testing.T, value string) *resource.IndexableDocument {
 	t.Helper()
-	info, err := GetAlertRuleSearchBuilder()
+	info, err := GetAlertRuleSearchBuilder(rulesTestRegistry(t))
 	require.NoError(t, err)
 	doc, err := info.Builder.BuildDocument(context.Background(), alertRuleKey("r1"), 1, []byte(value))
 	require.NoError(t, err)
@@ -61,7 +78,7 @@ func buildAlertRuleDoc(t *testing.T, value string) *resource.IndexableDocument {
 
 func buildRecordingRuleDoc(t *testing.T, value string) *resource.IndexableDocument {
 	t.Helper()
-	info, err := GetRecordingRuleSearchBuilder()
+	info, err := GetRecordingRuleSearchBuilder(rulesTestRegistry(t))
 	require.NoError(t, err)
 	doc, err := info.Builder.BuildDocument(context.Background(), recordingRuleKey("r1"), 1, []byte(value))
 	require.NoError(t, err)
@@ -214,21 +231,20 @@ func TestRecordingRuleBuilder_extracts_and_computes_fields(t *testing.T) {
 	assert.ElementsMatch(t, []string{"team", "team=obs"}, doc.Fields[ruleSearchLabels])
 }
 
-// TestRuleSearchFields_derivedFromManifest verifies the builders expose the
-// manifest-declared search fields and that the column-definition view derived
-// from them (the same view the search backend uses) matches the declared
-// types and capabilities.
+// TestRuleSearchFields_derivedFromManifest verifies the rule kinds' manifest
+// declares the search fields and that the column-definition view derived from
+// them (the same view the search backend uses) matches the declared types and
+// capabilities.
 func TestRuleSearchFields_derivedFromManifest(t *testing.T) {
-	info, err := GetAlertRuleSearchBuilder()
+	info, err := GetAlertRuleSearchBuilder(nil)
 	require.NoError(t, err)
-	require.NotNil(t, info.SearchFieldsProvider)
 
 	gvr := schema.GroupVersionResource{
 		Group:    info.GroupResource.Group,
 		Version:  rulesv0alpha1.AlertRuleKind().GroupVersionResource().Version,
 		Resource: info.GroupResource.Resource,
 	}
-	fields := info.SearchFieldsProvider.Fields(gvr)
+	fields := rulesSearchFieldsProvider.Fields(gvr)
 	require.NotEmpty(t, fields, "alert rule search fields should be declared in the manifest")
 
 	cols := resource.SearchFieldDefinitionsToTableColumns(fields)
@@ -258,17 +274,17 @@ func TestRuleSearchFields_derivedFromManifest(t *testing.T) {
 	assert.True(t, labels.IsArray)
 }
 
-func TestRuleSearchBuilders_expose_search_fields_hash(t *testing.T) {
-	alertInfo, err := GetAlertRuleSearchBuilder()
+// TestRuleSearchFields_hashDiffersPerKind verifies the manifest declares a
+// non-empty search-fields hash for each rule kind and that the two kinds differ.
+func TestRuleSearchFields_hashDiffersPerKind(t *testing.T) {
+	alertInfo, err := GetAlertRuleSearchBuilder(nil)
 	require.NoError(t, err)
-	require.NotNil(t, alertInfo.SearchFieldsProvider)
 
-	recordingInfo, err := GetRecordingRuleSearchBuilder()
+	recordingInfo, err := GetRecordingRuleSearchBuilder(nil)
 	require.NoError(t, err)
-	require.NotNil(t, recordingInfo.SearchFieldsProvider)
 
-	alertHash := alertInfo.SearchFieldsProvider.IndexAffectingHash(alertInfo.GroupResource.Group, alertInfo.GroupResource.Resource)
-	recordingHash := recordingInfo.SearchFieldsProvider.IndexAffectingHash(recordingInfo.GroupResource.Group, recordingInfo.GroupResource.Resource)
+	alertHash := rulesSearchFieldsProvider.IndexAffectingHash(alertInfo.GroupResource.Group, alertInfo.GroupResource.Resource)
+	recordingHash := rulesSearchFieldsProvider.IndexAffectingHash(recordingInfo.GroupResource.Group, recordingInfo.GroupResource.Resource)
 	assert.NotEmpty(t, alertHash)
 	assert.NotEmpty(t, recordingHash)
 

--- a/pkg/storage/unified/search/builders/dashboard.go
+++ b/pkg/storage/unified/search/builders/dashboard.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/grafana/grafana-app-sdk/app"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	dashboardapp "github.com/grafana/grafana/apps/dashboard/pkg/apis"
 	dashV1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1"
@@ -65,21 +64,10 @@ func DashboardBuilder(namespaced resource.NamespacedDocumentSupplier) (resource.
 			}, nil
 		}
 	}
-	gvr := dashV1.DashboardResourceInfo.GroupVersionResource()
-	provider := resource.NewMapProvider(
-		map[schema.GroupVersionResource][]resource.SearchFieldDefinition{
-			gvr: DashboardSearchFields,
-		},
-		map[schema.GroupResource]string{
-			gvr.GroupResource(): gvr.Version,
-		},
-	)
-
 	gr := dashV1.DashboardResourceInfo.GroupResource()
 	return resource.DocumentBuilderInfo{
-		GroupResource:        gr,
-		Namespaced:           namespaced,
-		SearchFieldsProvider: provider,
+		GroupResource: gr,
+		Namespaced:    namespaced,
 	}, nil
 }
 

--- a/pkg/storage/unified/search/builders/document.go
+++ b/pkg/storage/unified/search/builders/document.go
@@ -7,7 +7,6 @@ import (
 
 	claims "github.com/grafana/authlib/types"
 	sdkResource "github.com/grafana/grafana-app-sdk/resource"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/infra/db"
@@ -19,7 +18,7 @@ import (
 
 // All returns all document builders from this package.
 // These builders have dependencies on Grafana apps (dashboard and user).
-func All(sql db.DB, sprinkles DashboardStats) ([]resource.DocumentBuilderInfo, error) {
+func All(registry *resource.SearchFieldsRegistry, sql db.DB, sprinkles DashboardStats) ([]resource.DocumentBuilderInfo, error) {
 	dashboards, err := DashboardBuilder(func(ctx context.Context, namespace string, blob resource.BlobSupport) (resource.DocumentBuilder, error) {
 		logger := log.New("dashboard_builder", "namespace", namespace)
 		dsinfo := []*dashboard.DatasourceQueryResult{{}}
@@ -64,32 +63,32 @@ func All(sql db.DB, sprinkles DashboardStats) ([]resource.DocumentBuilderInfo, e
 		return nil, err
 	}
 
-	users, err := GetUserBuilder()
+	users, err := GetUserBuilder(registry)
 	if err != nil {
 		return nil, err
 	}
 
-	extGroupMappings, err := GetExternalGroupMappingBuilder()
+	extGroupMappings, err := GetExternalGroupMappingBuilder(registry)
 	if err != nil {
 		return nil, err
 	}
 
-	teams, err := GetTeamSearchBuilder()
+	teams, err := GetTeamSearchBuilder(registry)
 	if err != nil {
 		return nil, err
 	}
 
-	teamBindings, err := GetTeamBindingBuilder()
+	teamBindings, err := GetTeamBindingBuilder(registry)
 	if err != nil {
 		return nil, err
 	}
 
-	alertRules, err := GetAlertRuleSearchBuilder()
+	alertRules, err := GetAlertRuleSearchBuilder(registry)
 	if err != nil {
 		return nil, err
 	}
 
-	recordingRules, err := GetRecordingRuleSearchBuilder()
+	recordingRules, err := GetRecordingRuleSearchBuilder(registry)
 	if err != nil {
 		return nil, err
 	}
@@ -98,25 +97,12 @@ func All(sql db.DB, sprinkles DashboardStats) ([]resource.DocumentBuilderInfo, e
 }
 
 // iamBuilder assembles the DocumentBuilderInfo for an IAM kind. Every IAM kind
-// is wired the same way: its search fields come from the generated IAM manifest
-// and its documents are extracted by the standard builder, so only the resource
-// and its field set differ per kind.
-func iamBuilder(ri utils.ResourceInfo, searchFields []resource.SearchFieldDefinition) (resource.DocumentBuilderInfo, error) {
-	gvr := ri.GroupVersionResource()
-	gr := ri.GroupResource()
-	provider := resource.NewMapProvider(
-		map[schema.GroupVersionResource][]resource.SearchFieldDefinition{gvr: searchFields},
-		// The preferred version for this resource. Documents stored with an
-		// apiVersion the server does not recognise fall back to it when their
-		// fields are extracted. IAM kinds serve a single version, so that is the
-		// value here.
-		map[schema.GroupResource]string{gr: gvr.Version},
-	)
-
+// is extracted by the standard builder, which reads its search fields from the
+// shared registry, so only the resource differs per kind.
+func iamBuilder(registry *resource.SearchFieldsRegistry, ri utils.ResourceInfo) (resource.DocumentBuilderInfo, error) {
 	return resource.DocumentBuilderInfo{
-		GroupResource:        gr,
-		Builder:              resource.StandardDocumentBuilderWithFields(iamManifests, provider),
-		SearchFieldsProvider: provider,
+		GroupResource: ri.GroupResource(),
+		Builder:       resource.StandardDocumentBuilder(registry),
 	}, nil
 }
 

--- a/pkg/storage/unified/search/builders/document_test.go
+++ b/pkg/storage/unified/search/builders/document_test.go
@@ -47,8 +47,17 @@ func doSnapshotTests(t *testing.T, builder resource.DocumentBuilder, kind string
 	}
 }
 
+// iamTestRegistry seeds a registry with the IAM kinds' fields so the
+// registry-backed builders extract them, as they do in production.
+func iamTestRegistry(t *testing.T) *resource.SearchFieldsRegistry {
+	t.Helper()
+	sel, hashes, providers, err := resource.SearchFieldsForManifests(iamManifests)
+	require.NoError(t, err)
+	return resource.NewSearchFieldsRegistry(sel, hashes, providers)
+}
+
 func TestUserDocumentBuilder(t *testing.T) {
-	info, err := GetUserBuilder()
+	info, err := GetUserBuilder(iamTestRegistry(t))
 	require.NoError(t, err)
 	doSnapshotTests(t, info.Builder, "user", &resourcepb.ResourceKey{
 		Namespace: "default",
@@ -62,7 +71,7 @@ func TestUserDocumentBuilder(t *testing.T) {
 }
 
 func TestExternalGroupMappingDocumentBuilder(t *testing.T) {
-	info, err := GetExternalGroupMappingBuilder()
+	info, err := GetExternalGroupMappingBuilder(iamTestRegistry(t))
 	require.NoError(t, err)
 	doSnapshotTests(t, info.Builder, "external_group_mapping", &resourcepb.ResourceKey{
 		Namespace: "default",
@@ -74,7 +83,7 @@ func TestExternalGroupMappingDocumentBuilder(t *testing.T) {
 }
 
 func TestTeamSearchBuilder(t *testing.T) {
-	info, err := GetTeamSearchBuilder()
+	info, err := GetTeamSearchBuilder(iamTestRegistry(t))
 	require.NoError(t, err)
 	doSnapshotTests(t, info.Builder, "team", &resourcepb.ResourceKey{
 		Namespace: "default",
@@ -87,7 +96,7 @@ func TestTeamSearchBuilder(t *testing.T) {
 }
 
 func TestTeamBindingSearchBuilder(t *testing.T) {
-	info, err := GetTeamBindingBuilder()
+	info, err := GetTeamBindingBuilder(iamTestRegistry(t))
 	require.NoError(t, err)
 	doSnapshotTests(t, info.Builder, "team_binding", &resourcepb.ResourceKey{
 		Namespace: "default",
@@ -212,7 +221,7 @@ func TestBuildSelectableFields(t *testing.T) {
 }
 
 func TestUserDocumentBuilder_Created(t *testing.T) {
-	info, err := GetUserBuilder()
+	info, err := GetUserBuilder(iamTestRegistry(t))
 	require.NoError(t, err)
 
 	value := []byte(`{

--- a/pkg/storage/unified/search/builders/external_group_mapping.go
+++ b/pkg/storage/unified/search/builders/external_group_mapping.go
@@ -5,12 +5,6 @@ import (
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 )
 
-// externalGroupMappingSearchFields are read from the generated IAM manifest,
-// where they are declared in apps/iam/kinds/externalgroupmapping.cue.
-var externalGroupMappingSearchFields = iamProvider.Fields(
-	iamv0.ExternalGroupMappingResourceInfo.GroupVersionResource(),
-)
-
-func GetExternalGroupMappingBuilder() (resource.DocumentBuilderInfo, error) {
-	return iamBuilder(iamv0.ExternalGroupMappingResourceInfo, externalGroupMappingSearchFields)
+func GetExternalGroupMappingBuilder(registry *resource.SearchFieldsRegistry) (resource.DocumentBuilderInfo, error) {
+	return iamBuilder(registry, iamv0.ExternalGroupMappingResourceInfo)
 }

--- a/pkg/storage/unified/search/builders/team.go
+++ b/pkg/storage/unified/search/builders/team.go
@@ -29,6 +29,6 @@ var TeamSearchFields = iamProvider.Fields(
 	v0alpha1.TeamResourceInfo.GroupVersionResource(),
 )
 
-func GetTeamSearchBuilder() (resource.DocumentBuilderInfo, error) {
-	return iamBuilder(v0alpha1.TeamResourceInfo, TeamSearchFields)
+func GetTeamSearchBuilder(registry *resource.SearchFieldsRegistry) (resource.DocumentBuilderInfo, error) {
+	return iamBuilder(registry, v0alpha1.TeamResourceInfo)
 }

--- a/pkg/storage/unified/search/builders/teambinding.go
+++ b/pkg/storage/unified/search/builders/teambinding.go
@@ -20,6 +20,6 @@ var TeamBindingSearchFields = iamProvider.Fields(
 	iamv0.TeamBindingResourceInfo.GroupVersionResource(),
 )
 
-func GetTeamBindingBuilder() (resource.DocumentBuilderInfo, error) {
-	return iamBuilder(iamv0.TeamBindingResourceInfo, TeamBindingSearchFields)
+func GetTeamBindingBuilder(registry *resource.SearchFieldsRegistry) (resource.DocumentBuilderInfo, error) {
+	return iamBuilder(registry, iamv0.TeamBindingResourceInfo)
 }

--- a/pkg/storage/unified/search/builders/user.go
+++ b/pkg/storage/unified/search/builders/user.go
@@ -48,6 +48,6 @@ var UserSortableExtraFields = []string{
 // Exported for the IAM legacy SQL search backend; do not mutate.
 var UserSearchFields = iamProvider.Fields(iamv0.UserResourceInfo.GroupVersionResource())
 
-func GetUserBuilder() (resource.DocumentBuilderInfo, error) {
-	return iamBuilder(iamv0.UserResourceInfo, UserSearchFields)
+func GetUserBuilder(registry *resource.SearchFieldsRegistry) (resource.DocumentBuilderInfo, error) {
+	return iamBuilder(registry, iamv0.UserResourceInfo)
 }

--- a/pkg/storage/unified/search/document.go
+++ b/pkg/storage/unified/search/document.go
@@ -17,15 +17,15 @@ func ProvideDocumentBuilders(sql db.DB, sprinkles builders.DashboardStats) resou
 	return &StandardDocumentBuilders{sql, sprinkles}
 }
 
-func (s *StandardDocumentBuilders) GetDocumentBuilders() ([]resource.DocumentBuilderInfo, error) {
-	all, err := builders.All(s.sql, s.sprinkles)
+func (s *StandardDocumentBuilders) GetDocumentBuilders(registry *resource.SearchFieldsRegistry) ([]resource.DocumentBuilderInfo, error) {
+	all, err := builders.All(registry, s.sql, s.sprinkles)
 	if err != nil {
 		return nil, err
 	}
 
 	result := []resource.DocumentBuilderInfo{ //nolint:prealloc
 		{
-			Builder: resource.StandardDocumentBuilder(resource.AppManifests()),
+			Builder: resource.StandardDocumentBuilder(registry),
 		},
 	}
 	return append(result, all...), nil

--- a/pkg/storage/unified/search/zz_dashboard_provider_test.go
+++ b/pkg/storage/unified/search/zz_dashboard_provider_test.go
@@ -1,0 +1,15 @@
+package search
+
+import (
+	"github.com/grafana/grafana-app-sdk/app"
+
+	dashboardapp "github.com/grafana/grafana/apps/dashboard/pkg/apis"
+	"github.com/grafana/grafana/pkg/storage/unified/resource"
+)
+
+// dashboardSearchFieldsProvider builds the dashboard kind's search-field
+// provider from its manifest, the way production does, for seeding a test
+// registry.
+func DashboardSearchFieldsProviderForTest() resource.SearchFieldsProvider {
+	return resource.NewManifestBackedProvider([]app.Manifest{dashboardapp.LocalManifest()})
+}

--- a/pkg/storage/unified/testing/benchmark.go
+++ b/pkg/storage/unified/testing/benchmark.go
@@ -488,7 +488,7 @@ func runStorageAndSearchBenchmark(
 	}
 
 	// Discover group/resource pairs from the configured document builders
-	builders, err := searchOpts.Resources.GetDocumentBuilders()
+	builders, err := searchOpts.Resources.GetDocumentBuilders(searchOpts.SearchFields)
 	require.NoError(t, err)
 	require.NotEmpty(t, builders, "search options must have at least one document builder")
 


### PR DESCRIPTION
When search field metadata is reloaded at runtime, the change needs to reach the code that builds the indexed documents. Until now the document builders read their fields from a copy taken at startup, and the default builder had no fields at all, so a reload never affected them and apps relying on the default builder never had their declared fields indexed.

This backs the standard document builder with the shared registry the rest of search already uses: it looks up each kind's fields per document, so a reload takes effect immediately and the default builder now indexes declared fields for any kind. The server hands the registry to the builders, and both the OSS and enterprise paths go through the same place, so no enterprise change is needed.

It also removes a builder field that nothing read anymore, along with the per-kind providers that only fed it. There's no change to what gets indexed for current kinds — the document and mapping golden tests are unchanged.

Part of grafana/search-and-storage-team#827.
