### PR TITLE
Chore: Route datasource/athena label to AWS Datasources project

### DIFF
--- a/.github/commands.json
+++ b/.github/commands.json
@@ -1085,6 +1085,14 @@
   },
   {
     "type": "label",
+    "name": "datasource/athena",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/97"
+    }
+  },
+  {
+    "type": "label",
     "name": "datasource/OpenSearch",
     "action": "addToProject",
     "addToProject": {


### PR DESCRIPTION
The `datasource/athena` label wasn't routed to any project board. The other AWS data source labels (CloudWatch, X-Ray, Timestream, OpenSearch) all add issues to the [AWS Datasources project](https://github.com/orgs/grafana/projects/97), so this adds the same routing for athena.