### PR TITLE
Provisioning: Add job worker saturation metrics for autoscaling

### DIFF
--- a/pkg/registry/apis/provisioning/jobs/concurrent_driver.go
+++ b/pkg/registry/apis/provisioning/jobs/concurrent_driver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"sync"
 	"time"
 
@@ -364,6 +365,7 @@ func (c *ConcurrentJobDriver) Run(ctx context.Context) error {
 				c.store,
 				c.repoGetter,
 				c.historicJobs,
+				strconv.Itoa(driverID),
 				c.metrics,
 				c.processed,
 				c.workers...,

--- a/pkg/registry/apis/provisioning/jobs/concurrent_driver_test.go
+++ b/pkg/registry/apis/provisioning/jobs/concurrent_driver_test.go
@@ -133,8 +133,8 @@ func TestConcurrentJobDriver_ClaimedElsewhereIsDropped(t *testing.T) {
 	var claims atomic.Int32
 
 	store := &MockStore{}
-	store.EXPECT().Claim(mock.Anything, "ns1", "job1").
-		RunAndReturn(func(context.Context, string, string) (*provisioning.Job, func(), error) {
+	store.EXPECT().Claim(mock.Anything, "ns1", "job1", "0").
+		RunAndReturn(func(context.Context, string, string, string) (*provisioning.Job, func(), error) {
 			claims.Add(1)
 			return nil, nil, ErrAlreadyClaimed
 		}).Maybe()
@@ -168,8 +168,8 @@ func TestConcurrentJobDriver_TransientErrorsRetryUntilDropped(t *testing.T) {
 	var claims atomic.Int32
 
 	store := &MockStore{}
-	store.EXPECT().Claim(mock.Anything, "ns1", "job1").
-		RunAndReturn(func(context.Context, string, string) (*provisioning.Job, func(), error) {
+	store.EXPECT().Claim(mock.Anything, "ns1", "job1", "0").
+		RunAndReturn(func(context.Context, string, string, string) (*provisioning.Job, func(), error) {
 			claims.Add(1)
 			return nil, nil, errors.New("transient API error")
 		}).Maybe()
@@ -203,8 +203,8 @@ func TestConcurrentJobDriver_ResyncUpdateRecoversDroppedJob(t *testing.T) {
 	var claims atomic.Int32
 
 	store := &MockStore{}
-	store.EXPECT().Claim(mock.Anything, "ns1", "pending-job").
-		RunAndReturn(func(context.Context, string, string) (*provisioning.Job, func(), error) {
+	store.EXPECT().Claim(mock.Anything, "ns1", "pending-job", "0").
+		RunAndReturn(func(context.Context, string, string, string) (*provisioning.Job, func(), error) {
 			claims.Add(1)
 			return nil, nil, ErrAlreadyClaimed
 		}).Maybe()
@@ -242,7 +242,7 @@ func TestConcurrentJobDriver_ProcessesJobEndToEnd(t *testing.T) {
 	completed := make(chan struct{})
 
 	store := &MockStore{}
-	store.EXPECT().Claim(mock.Anything, "test-ns", "test-job").
+	store.EXPECT().Claim(mock.Anything, "test-ns", "test-job", "0").
 		Return(claimedJob, func() { rollbackCalled.Store(true) }, nil).Once()
 	store.EXPECT().Update(mock.Anything, mock.Anything).
 		RunAndReturn(func(_ context.Context, job *provisioning.Job) (*provisioning.Job, error) {
@@ -312,8 +312,8 @@ func TestConcurrentJobDriver_PostClaimFailureDoesNotRerunJob(t *testing.T) {
 	completeCalled := make(chan struct{})
 
 	store := &MockStore{}
-	store.EXPECT().Claim(mock.Anything, "test-ns", "test-job").
-		RunAndReturn(func(context.Context, string, string) (*provisioning.Job, func(), error) {
+	store.EXPECT().Claim(mock.Anything, "test-ns", "test-job", "0").
+		RunAndReturn(func(context.Context, string, string, string) (*provisioning.Job, func(), error) {
 			claims.Add(1)
 			return claimedJob.DeepCopy(), func() {}, nil
 		}).Maybe()
@@ -392,8 +392,8 @@ func TestConcurrentJobDriver_CooldownBlocksDirtyRedeliveryAfterPostClaimFailure(
 	releaseComplete := make(chan struct{})
 
 	store := &MockStore{}
-	store.EXPECT().Claim(mock.Anything, "test-ns", "test-job").
-		RunAndReturn(func(context.Context, string, string) (*provisioning.Job, func(), error) {
+	store.EXPECT().Claim(mock.Anything, "test-ns", "test-job", "0").
+		RunAndReturn(func(context.Context, string, string, string) (*provisioning.Job, func(), error) {
 			if claims.Add(1) > 1 {
 				// Later attempts only need to be counted.
 				return nil, nil, ErrAlreadyClaimed
@@ -475,8 +475,8 @@ func TestConcurrentJobDriver_DuplicateEventsCauseNoDuplicateProcessing(t *testin
 	var claims atomic.Int32
 
 	store := &MockStore{}
-	store.EXPECT().Claim(mock.Anything, "ns1", "job1").
-		RunAndReturn(func(context.Context, string, string) (*provisioning.Job, func(), error) {
+	store.EXPECT().Claim(mock.Anything, "ns1", "job1", "0").
+		RunAndReturn(func(context.Context, string, string, string) (*provisioning.Job, func(), error) {
 			if claims.Add(1) == 1 {
 				close(firstClaimStarted)
 				<-release

--- a/pkg/registry/apis/provisioning/jobs/delete/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/delete/worker.go
@@ -15,7 +15,6 @@ import (
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/jobs"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/resources"
-	"github.com/grafana/grafana/pkg/registry/apis/provisioning/utils"
 )
 
 type Worker struct {
@@ -60,12 +59,6 @@ func (w *Worker) Process(ctx context.Context, repo repository.Repository, job pr
 
 	opts := *job.Spec.Delete
 	paths := opts.Paths
-	start := time.Now()
-	outcome := utils.ErrorOutcome
-	resourcesDeleted := 0
-	defer func() {
-		w.metrics.RecordJob(string(provisioning.JobActionDelete), outcome, resourcesDeleted, time.Since(start).Seconds())
-	}()
 
 	progress.SetTotal(ctx, len(paths)+len(opts.Resources))
 	progress.StrictMaxErrors(1) // Fail fast on any error during deletion
@@ -136,11 +129,9 @@ func (w *Worker) Process(ctx context.Context, repo repository.Repository, job pr
 		}
 	}
 
-	outcome = utils.SuccessOutcome
-	jobStatus := progress.Complete(ctx, nil)
-	for _, summary := range jobStatus.Summary {
-		resourcesDeleted += int(summary.Delete)
-	}
+	// Finalize the progress recorder. The job metric is recorded by the driver from
+	// the job's final status, so the returned status is not needed here.
+	progress.Complete(ctx, nil)
 
 	return nil
 }

--- a/pkg/registry/apis/provisioning/jobs/driver.go
+++ b/pkg/registry/apis/provisioning/jobs/driver.go
@@ -244,7 +244,7 @@ func (d *jobProcessor) processKey(ctx context.Context, namespace, name string, t
 		d.metrics.RecordJob(
 			string(d.currentJob.Spec.Action),
 			string(d.currentJob.Status.State),
-			resourceChangeCount(d.currentJob.Status.Summary),
+			resourceChangeCount(d.currentJob.Spec.Action, d.currentJob.Status.Summary),
 			duration.Seconds(),
 		)
 	}
@@ -502,15 +502,27 @@ func (d *jobProcessor) processJob(ctx context.Context, recorder JobProgressRecor
 	return err
 }
 
-// resourceChangeCount sums the create/update/delete counts across a job's status
-// summaries, giving the total resources changed for the duration histogram bucket.
-func resourceChangeCount(summaries []*provisioning.JobResourceSummary) int {
+// resourceChangeCount totals the resources a job changed, for the duration histogram
+// bucket. It is action-aware to match each worker's original counting: push counts
+// writes; delete counts deletes; move counts creates only (a rename is recorded as
+// both a create and a delete, so summing would double-count); everything else (pull,
+// migrate, ...) sums create+update+delete.
+func resourceChangeCount(action provisioning.JobAction, summaries []*provisioning.JobResourceSummary) int {
 	total := 0
 	for _, s := range summaries {
 		if s == nil {
 			continue
 		}
-		total += int(s.Create + s.Update + s.Delete)
+		switch action {
+		case provisioning.JobActionPush:
+			total += int(s.Write)
+		case provisioning.JobActionDelete:
+			total += int(s.Delete)
+		case provisioning.JobActionMove:
+			total += int(s.Create)
+		default:
+			total += int(s.Create + s.Update + s.Delete)
+		}
 	}
 	return total
 }

--- a/pkg/registry/apis/provisioning/jobs/driver.go
+++ b/pkg/registry/apis/provisioning/jobs/driver.go
@@ -84,6 +84,10 @@ type jobProcessor struct {
 	// Only the first worker who supports the job will process it; the rest are ignored.
 	workers []Worker
 
+	// driverID identifies this worker within the pod, used as the driver_id label on
+	// the in-flight gauge so per-worker saturation can be observed.
+	driverID string
+
 	// metrics for recording job-level Prometheus metrics (warnings, operations, etc.)
 	metrics *JobMetrics
 
@@ -102,6 +106,7 @@ func newJobProcessor(
 	store Store,
 	repoGetter RepoGetter,
 	historicJobs HistoryWriter,
+	driverID string,
 	metrics *JobMetrics,
 	processed *usinformer.ProcessedMetrics,
 	workers ...Worker,
@@ -113,6 +118,7 @@ func newJobProcessor(
 		repoGetter:           repoGetter,
 		historicJobs:         historicJobs,
 		workers:              workers,
+		driverID:             driverID,
 		metrics:              metrics,
 		processed:            processed,
 	}
@@ -156,6 +162,14 @@ func (d *jobProcessor) processKey(ctx context.Context, namespace, name string, t
 	if !enqueuedAt.IsZero() {
 		d.processed.ObserveDeliveryLatency(trigger, enqueuedAt.Sub(claimedJob.CreationTimestamp.Time).Seconds())
 	}
+
+	// Mark this worker slot busy for the whole claim->complete duration. The Inc and
+	// the deferred Dec run on the same goroutine, so the gauge stays balanced across
+	// every return path (timeout, lease loss, shutdown, completion). Methods are
+	// nil-safe for drivers built without metrics in tests.
+	inFlightAction := string(claimedJob.Spec.Action)
+	d.metrics.IncInFlight(d.driverID, inFlightAction)
+	defer d.metrics.DecInFlight(d.driverID, inFlightAction)
 
 	logger = logger.With("job", claimedJob.GetName(), "namespace", namespace, "repository", claimedJob.Spec.Repository, "action", claimedJob.Spec.Action)
 	ctx = logging.Context(ctx, logger)

--- a/pkg/registry/apis/provisioning/jobs/driver.go
+++ b/pkg/registry/apis/provisioning/jobs/driver.go
@@ -145,6 +145,20 @@ func (d *jobProcessor) processKey(ctx context.Context, namespace, name string, t
 		}
 		return apifmt.Errorf("failed to claim job: %w", err)
 	}
+	// Mark this worker slot busy for the whole claim->release window — including job
+	// completion and rollback. This release defer is registered BEFORE the rollback
+	// defer below so LIFO runs rollback first: the slot stays busy (and busy_seconds
+	// keeps accruing) until rollback actually finishes, which matters when the storage
+	// API is slow. busy_seconds thus measures full slot occupancy, not just the worker's
+	// processing time. Metrics methods are nil-safe for drivers built without metrics.
+	inFlightAction := string(claimedJob.Spec.Action)
+	slotStart := time.Now()
+	d.metrics.IncInFlight(d.driverID, inFlightAction)
+	defer func() {
+		d.metrics.DecInFlight(d.driverID, inFlightAction)
+		d.metrics.RecordBusySeconds(d.driverID, inFlightAction, time.Since(slotStart).Seconds())
+	}()
+
 	// Ensure that the job is cleaned up if we fail to complete it.
 	// The rollback function does not care about cancellations.
 	defer rollback()
@@ -162,14 +176,6 @@ func (d *jobProcessor) processKey(ctx context.Context, namespace, name string, t
 	if !enqueuedAt.IsZero() {
 		d.processed.ObserveDeliveryLatency(trigger, enqueuedAt.Sub(claimedJob.CreationTimestamp.Time).Seconds())
 	}
-
-	// Mark this worker slot busy for the whole claim->complete duration. The Inc and
-	// the deferred Dec run on the same goroutine, so the gauge stays balanced across
-	// every return path (timeout, lease loss, shutdown, completion). Methods are
-	// nil-safe for drivers built without metrics in tests.
-	inFlightAction := string(claimedJob.Spec.Action)
-	d.metrics.IncInFlight(d.driverID, inFlightAction)
-	defer d.metrics.DecInFlight(d.driverID, inFlightAction)
 
 	logger = logger.With("job", claimedJob.GetName(), "namespace", namespace, "repository", claimedJob.Spec.Repository, "action", claimedJob.Spec.Action)
 	ctx = logging.Context(ctx, logger)
@@ -247,7 +253,6 @@ func (d *jobProcessor) processKey(ctx context.Context, namespace, name string, t
 			resourceChangeCount(d.currentJob.Spec.Action, d.currentJob.Status.Summary),
 			duration.Seconds(),
 		)
-		d.metrics.RecordBusySeconds(d.driverID, string(d.currentJob.Spec.Action), duration.Seconds())
 	}
 	defer func() {
 		d.currentJob = nil

--- a/pkg/registry/apis/provisioning/jobs/driver.go
+++ b/pkg/registry/apis/provisioning/jobs/driver.go
@@ -33,7 +33,7 @@ type Store interface {
 	// API error if the job no longer exists.
 	//
 	// If err is not nil, the job and rollback values are always nil.
-	Claim(ctx context.Context, namespace, name string) (job *provisioning.Job, rollback func(), err error)
+	Claim(ctx context.Context, namespace, name string, driverID string) (job *provisioning.Job, rollback func(), err error)
 
 	// Complete marks a job as completed and removes it from the active job store.
 	// Callers are responsible for writing the job to history after calling this.
@@ -138,7 +138,7 @@ func (d *jobProcessor) processKey(ctx context.Context, namespace, name string, t
 	logger := logging.FromContext(ctx)
 
 	// Claim the job to work on.
-	claimedJob, rollback, err := d.store.Claim(ctx, namespace, name)
+	claimedJob, rollback, err := d.store.Claim(ctx, namespace, name, d.driverID)
 	if err != nil {
 		if !errors.Is(err, ErrAlreadyClaimed) && !apierrors.IsNotFound(err) {
 			span.RecordError(err)
@@ -247,6 +247,7 @@ func (d *jobProcessor) processKey(ctx context.Context, namespace, name string, t
 			resourceChangeCount(d.currentJob.Spec.Action, d.currentJob.Status.Summary),
 			duration.Seconds(),
 		)
+		d.metrics.RecordBusySeconds(d.driverID, string(d.currentJob.Spec.Action), duration.Seconds())
 	}
 	defer func() {
 		d.currentJob = nil

--- a/pkg/registry/apis/provisioning/jobs/driver.go
+++ b/pkg/registry/apis/provisioning/jobs/driver.go
@@ -235,6 +235,19 @@ func (d *jobProcessor) processKey(ctx context.Context, namespace, name string, t
 	progressUpdates := d.currentJob.Status.ProgressUpdates
 	d.currentJob.Status = recorder.Complete(ctx, err)
 	d.currentJob.Status.ProgressUpdates = progressUpdates + 1
+	// Record the job metric here, from the authoritative final status, rather than in
+	// each worker: this covers every action uniformly, uses the driver-measured
+	// duration (accurate even on timeout), and makes the `outcome` label reflect the
+	// job status (success/warning/error) — so a job that "completed with errors" is
+	// recorded as an error, not a success.
+	if d.metrics != nil {
+		d.metrics.RecordJob(
+			string(d.currentJob.Spec.Action),
+			string(d.currentJob.Status.State),
+			resourceChangeCount(d.currentJob.Status.Summary),
+			duration.Seconds(),
+		)
+	}
 	defer func() {
 		d.currentJob = nil
 		d.mu.Unlock()
@@ -487,6 +500,19 @@ func (d *jobProcessor) processJob(ctx context.Context, recorder JobProgressRecor
 	err := apifmt.Errorf("no workers were registered to handle the job")
 	span.RecordError(err)
 	return err
+}
+
+// resourceChangeCount sums the create/update/delete counts across a job's status
+// summaries, giving the total resources changed for the duration histogram bucket.
+func resourceChangeCount(summaries []*provisioning.JobResourceSummary) int {
+	total := 0
+	for _, s := range summaries {
+		if s == nil {
+			continue
+		}
+		total += int(s.Create + s.Update + s.Delete)
+	}
+	return total
 }
 
 func (d *jobProcessor) onProgress() ProgressFn {

--- a/pkg/registry/apis/provisioning/jobs/driver_test.go
+++ b/pkg/registry/apis/provisioning/jobs/driver_test.go
@@ -28,13 +28,22 @@ func newConflictError() error {
 }
 
 func TestResourceChangeCount(t *testing.T) {
-	require.Equal(t, 0, resourceChangeCount(nil))
-	require.Equal(t, 0, resourceChangeCount([]*provisioning.JobResourceSummary{nil}))
-	require.Equal(t, 6, resourceChangeCount([]*provisioning.JobResourceSummary{
-		{Create: 1, Update: 2},
-		{Delete: 3},
+	summaries := []*provisioning.JobResourceSummary{
+		{Create: 2, Update: 3, Delete: 4, Write: 5},
 		nil,
-	}))
+		{Create: 1, Update: 1, Delete: 1, Write: 1},
+	}
+
+	require.Equal(t, 0, resourceChangeCount(provisioning.JobActionPull, nil))
+
+	// pull (default): create+update+delete = (2+3+4)+(1+1+1) = 12
+	require.Equal(t, 12, resourceChangeCount(provisioning.JobActionPull, summaries))
+	// push: writes only = 5+1
+	require.Equal(t, 6, resourceChangeCount(provisioning.JobActionPush, summaries))
+	// delete: deletes only = 4+1
+	require.Equal(t, 5, resourceChangeCount(provisioning.JobActionDelete, summaries))
+	// move: creates only (a rename is both create+delete; count once) = 2+1
+	require.Equal(t, 3, resourceChangeCount(provisioning.JobActionMove, summaries))
 }
 
 func makeTestJob(rv string) *provisioning.Job {

--- a/pkg/registry/apis/provisioning/jobs/driver_test.go
+++ b/pkg/registry/apis/provisioning/jobs/driver_test.go
@@ -27,6 +27,16 @@ func newConflictError() error {
 	)
 }
 
+func TestResourceChangeCount(t *testing.T) {
+	require.Equal(t, 0, resourceChangeCount(nil))
+	require.Equal(t, 0, resourceChangeCount([]*provisioning.JobResourceSummary{nil}))
+	require.Equal(t, 6, resourceChangeCount([]*provisioning.JobResourceSummary{
+		{Create: 1, Update: 2},
+		{Delete: 3},
+		nil,
+	}))
+}
+
 func makeTestJob(rv string) *provisioning.Job {
 	return &provisioning.Job{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/registry/apis/provisioning/jobs/event_processed_test.go
+++ b/pkg/registry/apis/provisioning/jobs/event_processed_test.go
@@ -211,7 +211,7 @@ func TestConcurrentJobDriver_ProcessingAttributed(t *testing.T) {
 func TestConcurrentJobDriver_AlreadyClaimedNotAttributed(t *testing.T) {
 	store := &MockStore{}
 	claimed := make(chan struct{})
-	store.EXPECT().Claim(mock.Anything, "test-ns", "test-job", "driver-1").
+	store.EXPECT().Claim(mock.Anything, "test-ns", "test-job", "0").
 		RunAndReturn(func(context.Context, string, string, string) (*provisioning.Job, func(), error) {
 			select {
 			case <-claimed:
@@ -260,7 +260,7 @@ func TestConcurrentJobDriver_RecordsDeliveryLatency(t *testing.T) {
 
 	completed := make(chan struct{})
 	store := &MockStore{}
-	store.EXPECT().Claim(mock.Anything, "test-ns", "test-job", "driver-1").Return(claimedJob, func() {}, nil).Once()
+	store.EXPECT().Claim(mock.Anything, "test-ns", "test-job", "0").Return(claimedJob, func() {}, nil).Once()
 	store.EXPECT().Update(mock.Anything, mock.Anything).
 		RunAndReturn(func(_ context.Context, job *provisioning.Job) (*provisioning.Job, error) { return job.DeepCopy(), nil }).Maybe()
 	store.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything).Return(claimedJob.DeepCopy(), nil).Maybe()
@@ -390,7 +390,7 @@ func newSuccessfulJobDriver(t *testing.T, natsBacked bool) (*ConcurrentJobDriver
 	completed := make(chan struct{})
 
 	store := &MockStore{}
-	store.EXPECT().Claim(mock.Anything, "test-ns", "test-job", "driver-1").
+	store.EXPECT().Claim(mock.Anything, "test-ns", "test-job", "0").
 		Return(claimedJob, func() {}, nil).Once()
 	store.EXPECT().Update(mock.Anything, mock.Anything).
 		RunAndReturn(func(_ context.Context, job *provisioning.Job) (*provisioning.Job, error) {

--- a/pkg/registry/apis/provisioning/jobs/event_processed_test.go
+++ b/pkg/registry/apis/provisioning/jobs/event_processed_test.go
@@ -211,8 +211,8 @@ func TestConcurrentJobDriver_ProcessingAttributed(t *testing.T) {
 func TestConcurrentJobDriver_AlreadyClaimedNotAttributed(t *testing.T) {
 	store := &MockStore{}
 	claimed := make(chan struct{})
-	store.EXPECT().Claim(mock.Anything, "test-ns", "test-job").
-		RunAndReturn(func(context.Context, string, string) (*provisioning.Job, func(), error) {
+	store.EXPECT().Claim(mock.Anything, "test-ns", "test-job", "driver-1").
+		RunAndReturn(func(context.Context, string, string, string) (*provisioning.Job, func(), error) {
 			select {
 			case <-claimed:
 			default:
@@ -260,7 +260,7 @@ func TestConcurrentJobDriver_RecordsDeliveryLatency(t *testing.T) {
 
 	completed := make(chan struct{})
 	store := &MockStore{}
-	store.EXPECT().Claim(mock.Anything, "test-ns", "test-job").Return(claimedJob, func() {}, nil).Once()
+	store.EXPECT().Claim(mock.Anything, "test-ns", "test-job", "driver-1").Return(claimedJob, func() {}, nil).Once()
 	store.EXPECT().Update(mock.Anything, mock.Anything).
 		RunAndReturn(func(_ context.Context, job *provisioning.Job) (*provisioning.Job, error) { return job.DeepCopy(), nil }).Maybe()
 	store.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything).Return(claimedJob.DeepCopy(), nil).Maybe()
@@ -390,7 +390,7 @@ func newSuccessfulJobDriver(t *testing.T, natsBacked bool) (*ConcurrentJobDriver
 	completed := make(chan struct{})
 
 	store := &MockStore{}
-	store.EXPECT().Claim(mock.Anything, "test-ns", "test-job").
+	store.EXPECT().Claim(mock.Anything, "test-ns", "test-job", "driver-1").
 		Return(claimedJob, func() {}, nil).Once()
 	store.EXPECT().Update(mock.Anything, mock.Anything).
 		RunAndReturn(func(_ context.Context, job *provisioning.Job) (*provisioning.Job, error) {

--- a/pkg/registry/apis/provisioning/jobs/export/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/export/worker.go
@@ -16,7 +16,6 @@ import (
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/jobs"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/resources"
-	"github.com/grafana/grafana/pkg/registry/apis/provisioning/utils"
 )
 
 //go:generate mockery --name ExportFn --structname MockExportFn --inpackage --filename mock_export_fn.go --with-expecter
@@ -86,12 +85,6 @@ func (r *ExportWorker) Process(ctx context.Context, repo repository.Repository, 
 		attribute.Int("export.resources_count", len(options.Resources)),
 	)
 
-	start := time.Now()
-	outcome := utils.ErrorOutcome
-	resourcesExported := 0
-	defer func() {
-		r.metrics.RecordJob(string(provisioning.JobActionPush), outcome, resourcesExported, time.Since(start).Seconds())
-	}()
 	cfg := repo.Config()
 	// Can write to external branch
 	if err := repository.IsWriteAllowed(cfg, options.Branch); err != nil {
@@ -154,11 +147,9 @@ func (r *ExportWorker) Process(ctx context.Context, repo repository.Repository, 
 		return err
 	}
 
-	outcome = utils.SuccessOutcome
-	jobStatus := progress.Complete(ctx, nil)
-	for _, summary := range jobStatus.Summary {
-		resourcesExported += int(summary.Write)
-	}
+	// Finalize the progress recorder. The job metric is recorded by the driver from
+	// the job's final status, so the returned status is not needed here.
+	progress.Complete(ctx, nil)
 
 	return nil
 }

--- a/pkg/registry/apis/provisioning/jobs/metrics.go
+++ b/pkg/registry/apis/provisioning/jobs/metrics.go
@@ -50,7 +50,7 @@ type QueueMetrics struct {
 	// winning records each loss.
 	claimed         *prometheus.CounterVec // won a CAS race — this driver now owns the job
 	claimConflicts  *prometheus.CounterVec // lost a CAS race — another worker updated the job first
-	claimErrors     *prometheus.CounterVec // claim path failed (identity or non-conflict update error)
+	claimErrors     *prometheus.CounterVec // the claiming update failed with a non-conflict error (not identity/read)
 	claimRoundsCont *prometheus.CounterVec // exhausted the CAS retries — the job was claimed by another worker
 }
 
@@ -109,7 +109,7 @@ func RegisterQueueMetrics(registry prometheus.Registerer) QueueMetrics {
 		claimErrors := prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Name: "grafana_provisioning_jobs_claim_errors_total",
-				Help: "Claim attempts that failed with an identity or non-conflict update error, by driver",
+				Help: "Claim attempts whose claiming update failed with a non-conflict error, by driver (identity/read failures are not counted)",
 			},
 			[]string{"driver_id"},
 		)

--- a/pkg/registry/apis/provisioning/jobs/metrics.go
+++ b/pkg/registry/apis/provisioning/jobs/metrics.go
@@ -54,7 +54,7 @@ const (
 	ClaimOutcomeClaimed   = "claimed"   // a job was claimed
 	ClaimOutcomeEmpty     = "empty"     // no unclaimed jobs were available
 	ClaimOutcomeContended = "contended" // candidates existed but all were claimed by others first
-	ClaimOutcomeError     = "error"     // listing candidates failed
+	ClaimOutcomeError     = "error"     // a claim attempt failed (list, identity, or update error)
 )
 
 // durationBucketUnknown is the resources_changed_bucket used when a job did not

--- a/pkg/registry/apis/provisioning/jobs/metrics.go
+++ b/pkg/registry/apis/provisioning/jobs/metrics.go
@@ -51,7 +51,7 @@ type QueueMetrics struct {
 	claimed         *prometheus.CounterVec // won a CAS race — this driver now owns the job
 	claimConflicts  *prometheus.CounterVec // lost a CAS race — another worker updated the job first
 	claimErrors     *prometheus.CounterVec // the claiming update failed with a non-conflict error (not identity/read)
-	claimRoundsCont *prometheus.CounterVec // exhausted the CAS retries — the job was claimed by another worker
+	claimRoundsCont *prometheus.CounterVec // lost to another worker — job already claimed, or all CAS retries exhausted
 }
 
 // durationBucketUnknown is the resources_changed_bucket used when a job did not
@@ -118,7 +118,7 @@ func RegisterQueueMetrics(registry prometheus.Registerer) QueueMetrics {
 		claimRoundsCont := prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Name: "grafana_provisioning_jobs_claim_rounds_contended_total",
-				Help: "Claims that exhausted their CAS retries because the job was taken by another worker, by driver",
+				Help: "Claim attempts lost to another worker — the job was already claimed, or all CAS retries were exhausted, by driver",
 			},
 			[]string{"driver_id"},
 		)

--- a/pkg/registry/apis/provisioning/jobs/metrics.go
+++ b/pkg/registry/apis/provisioning/jobs/metrics.go
@@ -45,14 +45,13 @@ type QueueMetrics struct {
 	queueSize     *prometheus.GaugeVec
 	queueWaitTime *prometheus.HistogramVec
 
-	// Claim metrics, per driver_id. These count per CAS (compare-and-swap) attempt on
-	// a candidate, not per claim round, so contention is directly visible: a round
-	// that loses several races before winning records each loss.
-	claimed         *prometheus.CounterVec // won a CAS race — this driver now owns a job
-	claimConflicts  *prometheus.CounterVec // lost a CAS race — another worker was faster
-	claimErrors     *prometheus.CounterVec // claim path failed (list, identity, or non-conflict update)
-	claimRoundsCont *prometheus.CounterVec // a whole round listed candidates but won none
-	claimCandidates prometheus.Gauge       // candidates seen by the most recent claim poll
+	// Claim metrics, per driver_id. These count per CAS (compare-and-swap) attempt on a
+	// job, so contention is directly visible: a claim that loses several races before
+	// winning records each loss.
+	claimed         *prometheus.CounterVec // won a CAS race — this driver now owns the job
+	claimConflicts  *prometheus.CounterVec // lost a CAS race — another worker updated the job first
+	claimErrors     *prometheus.CounterVec // claim path failed (identity or non-conflict update error)
+	claimRoundsCont *prometheus.CounterVec // exhausted the CAS retries — the job was claimed by another worker
 }
 
 // durationBucketUnknown is the resources_changed_bucket used when a job did not
@@ -110,7 +109,7 @@ func RegisterQueueMetrics(registry prometheus.Registerer) QueueMetrics {
 		claimErrors := prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Name: "grafana_provisioning_jobs_claim_errors_total",
-				Help: "Claim attempts that failed with a list, identity, or non-conflict update error, by driver",
+				Help: "Claim attempts that failed with an identity or non-conflict update error, by driver",
 			},
 			[]string{"driver_id"},
 		)
@@ -119,24 +118,11 @@ func RegisterQueueMetrics(registry prometheus.Registerer) QueueMetrics {
 		claimRoundsCont := prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Name: "grafana_provisioning_jobs_claim_rounds_contended_total",
-				Help: "Claim rounds that listed candidates but won none (all lost to other workers), by driver",
+				Help: "Claims that exhausted their CAS retries because the job was taken by another worker, by driver",
 			},
 			[]string{"driver_id"},
 		)
 		registry.MustRegister(claimRoundsCont)
-
-		claimCandidates := prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Name: "grafana_provisioning_jobs_claim_candidates_received",
-				// NOTE: this is the number of unclaimed candidates returned by the most
-				// recent claim poll, not the queue depth. It is capped at the claim list
-				// limit (16) and is subject to claim starvation (the list limit is applied
-				// before the in-memory unclaimed filter), so it can read 0 while a backlog
-				// hides behind claimed rows. Gate autoscaler scale-down on low in_flight too.
-				Help: "Unclaimed candidates seen by the most recent claim poll (capped at the list limit; not queue depth)",
-			},
-		)
-		registry.MustRegister(claimCandidates)
 
 		queueMetrics = QueueMetrics{
 			queueSize:       queueSize,
@@ -145,7 +131,6 @@ func RegisterQueueMetrics(registry prometheus.Registerer) QueueMetrics {
 			claimConflicts:  claimConflicts,
 			claimErrors:     claimErrors,
 			claimRoundsCont: claimRoundsCont,
-			claimCandidates: claimCandidates,
 		}
 	})
 	return queueMetrics
@@ -196,14 +181,6 @@ func (m *QueueMetrics) RecordClaimRoundContended(driverID string) {
 		return
 	}
 	m.claimRoundsCont.WithLabelValues(driverID).Inc()
-}
-
-// SetClaimCandidates records how many unclaimed candidates the latest claim poll saw.
-func (m *QueueMetrics) SetClaimCandidates(n int) {
-	if m.claimCandidates == nil {
-		return
-	}
-	m.claimCandidates.Set(float64(n))
 }
 
 func RegisterJobMetrics(registry prometheus.Registerer) JobMetrics {

--- a/pkg/registry/apis/provisioning/jobs/metrics.go
+++ b/pkg/registry/apis/provisioning/jobs/metrics.go
@@ -23,6 +23,7 @@ type JobMetrics struct {
 
 	resourceOpsTotal *prometheus.CounterVec // per-resource outcome counter
 	inFlight         *prometheus.GaugeVec   // jobs currently being processed, by driver + action
+	busySeconds      *prometheus.CounterVec // job duration credited at completion, by driver + action
 }
 
 // claimTrigger records what enqueued the work-queue key that a worker is now
@@ -43,19 +44,16 @@ const resourceLabelJobs = "jobs"
 type QueueMetrics struct {
 	queueSize     *prometheus.GaugeVec
 	queueWaitTime *prometheus.HistogramVec
-	claimTotal    *prometheus.CounterVec
-}
 
-// Claim outcomes recorded on grafana_provisioning_jobs_claim_total. They describe
-// what a single claim attempt found, which is a LIST-free signal of queue demand:
-// mostly "empty" means workers are idle (scale down), while steady "claimed" under
-// high utilization means the queue is backing up (scale up).
-const (
-	ClaimOutcomeClaimed   = "claimed"   // a job was claimed
-	ClaimOutcomeEmpty     = "empty"     // no unclaimed jobs were available
-	ClaimOutcomeContended = "contended" // candidates existed but all were claimed by others first
-	ClaimOutcomeError     = "error"     // a claim attempt failed (list, identity, or update error)
-)
+	// Claim metrics, per driver_id. These count per CAS (compare-and-swap) attempt on
+	// a candidate, not per claim round, so contention is directly visible: a round
+	// that loses several races before winning records each loss.
+	claimed         *prometheus.CounterVec // won a CAS race — this driver now owns a job
+	claimConflicts  *prometheus.CounterVec // lost a CAS race — another worker was faster
+	claimErrors     *prometheus.CounterVec // claim path failed (list, identity, or non-conflict update)
+	claimRoundsCont *prometheus.CounterVec // a whole round listed candidates but won none
+	claimCandidates prometheus.Gauge       // candidates seen by the most recent claim poll
+}
 
 // durationBucketUnknown is the resources_changed_bucket used when a job did not
 // succeed: the resource count is partial and not meaningful, so failed durations are
@@ -91,19 +89,63 @@ func RegisterQueueMetrics(registry prometheus.Registerer) QueueMetrics {
 		)
 		registry.MustRegister(queueWaitTime)
 
-		claimTotal := prometheus.NewCounterVec(
+		claimed := prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: "grafana_provisioning_jobs_claim_total",
-				Help: "Total job claim attempts by outcome (claimed, empty, contended, error)",
+				Name: "grafana_provisioning_jobs_claimed_total",
+				Help: "Jobs successfully claimed (won the compare-and-swap race), by driver",
 			},
-			[]string{"outcome"},
+			[]string{"driver_id"},
 		)
-		registry.MustRegister(claimTotal)
+		registry.MustRegister(claimed)
+
+		claimConflicts := prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "grafana_provisioning_jobs_claim_conflicts_total",
+				Help: "Claim attempts that lost the compare-and-swap race to another worker, by driver",
+			},
+			[]string{"driver_id"},
+		)
+		registry.MustRegister(claimConflicts)
+
+		claimErrors := prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "grafana_provisioning_jobs_claim_errors_total",
+				Help: "Claim attempts that failed with a list, identity, or non-conflict update error, by driver",
+			},
+			[]string{"driver_id"},
+		)
+		registry.MustRegister(claimErrors)
+
+		claimRoundsCont := prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "grafana_provisioning_jobs_claim_rounds_contended_total",
+				Help: "Claim rounds that listed candidates but won none (all lost to other workers), by driver",
+			},
+			[]string{"driver_id"},
+		)
+		registry.MustRegister(claimRoundsCont)
+
+		claimCandidates := prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Name: "grafana_provisioning_jobs_claim_candidates_received",
+				// NOTE: this is the number of unclaimed candidates returned by the most
+				// recent claim poll, not the queue depth. It is capped at the claim list
+				// limit (16) and is subject to claim starvation (the list limit is applied
+				// before the in-memory unclaimed filter), so it can read 0 while a backlog
+				// hides behind claimed rows. Gate autoscaler scale-down on low in_flight too.
+				Help: "Unclaimed candidates seen by the most recent claim poll (capped at the list limit; not queue depth)",
+			},
+		)
+		registry.MustRegister(claimCandidates)
 
 		queueMetrics = QueueMetrics{
-			queueSize:     queueSize,
-			queueWaitTime: queueWaitTime,
-			claimTotal:    claimTotal,
+			queueSize:       queueSize,
+			queueWaitTime:   queueWaitTime,
+			claimed:         claimed,
+			claimConflicts:  claimConflicts,
+			claimErrors:     claimErrors,
+			claimRoundsCont: claimRoundsCont,
+			claimCandidates: claimCandidates,
 		}
 	})
 	return queueMetrics
@@ -121,14 +163,47 @@ func (m *QueueMetrics) RecordWaitTime(action string, waitSeconds float64) {
 	m.queueWaitTime.WithLabelValues(action).Observe(waitSeconds)
 }
 
-// RecordClaim increments the claim-outcome counter. Safe to call on a zero-value
-// QueueMetrics (nil counter) so stores built in tests without registered metrics do
-// not panic.
-func (m *QueueMetrics) RecordClaim(outcome string) {
-	if m.claimTotal == nil {
+// The claim-metric recorders are all safe to call on a zero-value QueueMetrics (nil
+// collectors) so stores built in tests without registered metrics do not panic.
+
+// RecordClaimWon records a successful claim (won the CAS race) by driverID.
+func (m *QueueMetrics) RecordClaimWon(driverID string) {
+	if m.claimed == nil {
 		return
 	}
-	m.claimTotal.WithLabelValues(outcome).Inc()
+	m.claimed.WithLabelValues(driverID).Inc()
+}
+
+// RecordClaimConflict records a claim that lost the CAS race to another worker.
+func (m *QueueMetrics) RecordClaimConflict(driverID string) {
+	if m.claimConflicts == nil {
+		return
+	}
+	m.claimConflicts.WithLabelValues(driverID).Inc()
+}
+
+// RecordClaimError records a claim that failed (list, identity, or non-conflict update).
+func (m *QueueMetrics) RecordClaimError(driverID string) {
+	if m.claimErrors == nil {
+		return
+	}
+	m.claimErrors.WithLabelValues(driverID).Inc()
+}
+
+// RecordClaimRoundContended records a claim round that listed candidates but won none.
+func (m *QueueMetrics) RecordClaimRoundContended(driverID string) {
+	if m.claimRoundsCont == nil {
+		return
+	}
+	m.claimRoundsCont.WithLabelValues(driverID).Inc()
+}
+
+// SetClaimCandidates records how many unclaimed candidates the latest claim poll saw.
+func (m *QueueMetrics) SetClaimCandidates(n int) {
+	if m.claimCandidates == nil {
+		return
+	}
+	m.claimCandidates.Set(float64(n))
 }
 
 func RegisterJobMetrics(registry prometheus.Registerer) JobMetrics {
@@ -200,6 +275,15 @@ func RegisterJobMetrics(registry prometheus.Registerer) JobMetrics {
 		)
 		registry.MustRegister(inFlight)
 
+		busySeconds := prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "grafana_provisioning_jobs_busy_seconds_total",
+				Help: "Total seconds workers spent processing jobs, credited at completion, by driver and action",
+			},
+			[]string{"driver_id", "action"},
+		)
+		registry.MustRegister(busySeconds)
+
 		jobMetrics = JobMetrics{
 			registry:                         registry,
 			processedTotal:                   processedTotal,
@@ -209,6 +293,7 @@ func RegisterJobMetrics(registry prometheus.Registerer) JobMetrics {
 			syncDurationHist:                 syncDurationHist,
 			resourceOpsTotal:                 resourceOpsTotal,
 			inFlight:                         inFlight,
+			busySeconds:                      busySeconds,
 		}
 	})
 	return jobMetrics
@@ -229,6 +314,16 @@ func (m *JobMetrics) DecInFlight(driverID, action string) {
 		return
 	}
 	m.inFlight.WithLabelValues(driverID, action).Dec()
+}
+
+// RecordBusySeconds credits the time a worker slot spent on a job, at completion.
+// Unlike the in_flight gauge (sampled at scrape time, so it aliases on bursts of
+// short jobs), this counter gives scrape-robust time-averaged utilization. Nil-safe.
+func (m *JobMetrics) RecordBusySeconds(driverID, action string, seconds float64) {
+	if m == nil || m.busySeconds == nil {
+		return
+	}
+	m.busySeconds.WithLabelValues(driverID, action).Add(seconds)
 }
 
 func (m *JobMetrics) RecordJob(jobAction string, outcome string, resourceCountChanged int, duration float64) {

--- a/pkg/registry/apis/provisioning/jobs/metrics.go
+++ b/pkg/registry/apis/provisioning/jobs/metrics.go
@@ -235,12 +235,12 @@ func (m *JobMetrics) RecordJob(jobAction string, outcome string, resourceCountCh
 	m.processedTotal.WithLabelValues(jobAction, outcome).Inc()
 
 	// Record duration for every outcome so slow-but-failing jobs are visible (a job
-	// that runs to the timeout then errors is exactly what we want to catch). The
-	// resource-count bucket is only meaningful on success — a failed job's count is
-	// partial — so failures are bucketed under a sentinel.
-	bucket := durationBucketUnknown
-	if outcome == utils.SuccessOutcome {
-		bucket = utils.GetResourceCountBucket(resourceCountChanged)
+	// that runs to the timeout then errors is exactly what we want to catch). Only a
+	// failed job's resource count is unreliable (partial work), so bucket errors under
+	// a sentinel; success and warning keep their size bucket.
+	bucket := utils.GetResourceCountBucket(resourceCountChanged)
+	if outcome == utils.ErrorOutcome {
+		bucket = durationBucketUnknown
 	}
 	m.durationHist.WithLabelValues(jobAction, bucket, outcome).Observe(duration)
 }

--- a/pkg/registry/apis/provisioning/jobs/metrics.go
+++ b/pkg/registry/apis/provisioning/jobs/metrics.go
@@ -22,6 +22,7 @@ type JobMetrics struct {
 	syncDurationHist                 *prometheus.HistogramVec // total sync durations
 
 	resourceOpsTotal *prometheus.CounterVec // per-resource outcome counter
+	inFlight         *prometheus.GaugeVec   // jobs currently being processed, by driver + action
 }
 
 // claimTrigger records what enqueued the work-queue key that a worker is now
@@ -42,7 +43,24 @@ const resourceLabelJobs = "jobs"
 type QueueMetrics struct {
 	queueSize     *prometheus.GaugeVec
 	queueWaitTime *prometheus.HistogramVec
+	claimTotal    *prometheus.CounterVec
 }
+
+// Claim outcomes recorded on grafana_provisioning_jobs_claim_total. They describe
+// what a single claim attempt found, which is a LIST-free signal of queue demand:
+// mostly "empty" means workers are idle (scale down), while steady "claimed" under
+// high utilization means the queue is backing up (scale up).
+const (
+	ClaimOutcomeClaimed   = "claimed"   // a job was claimed
+	ClaimOutcomeEmpty     = "empty"     // no unclaimed jobs were available
+	ClaimOutcomeContended = "contended" // candidates existed but all were claimed by others first
+	ClaimOutcomeError     = "error"     // listing candidates failed
+)
+
+// durationBucketUnknown is the resources_changed_bucket used when a job did not
+// succeed: the resource count is partial and not meaningful, so failed durations are
+// grouped here instead of a misleading count bucket.
+const durationBucketUnknown = "unknown"
 
 var (
 	queueOnce    sync.Once
@@ -73,9 +91,19 @@ func RegisterQueueMetrics(registry prometheus.Registerer) QueueMetrics {
 		)
 		registry.MustRegister(queueWaitTime)
 
+		claimTotal := prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "grafana_provisioning_jobs_claim_total",
+				Help: "Total job claim attempts by outcome (claimed, empty, contended, error)",
+			},
+			[]string{"outcome"},
+		)
+		registry.MustRegister(claimTotal)
+
 		queueMetrics = QueueMetrics{
 			queueSize:     queueSize,
 			queueWaitTime: queueWaitTime,
+			claimTotal:    claimTotal,
 		}
 	})
 	return queueMetrics
@@ -91,6 +119,16 @@ func (m *QueueMetrics) DecreaseQueueSize(action string) {
 
 func (m *QueueMetrics) RecordWaitTime(action string, waitSeconds float64) {
 	m.queueWaitTime.WithLabelValues(action).Observe(waitSeconds)
+}
+
+// RecordClaim increments the claim-outcome counter. Safe to call on a zero-value
+// QueueMetrics (nil counter) so stores built in tests without registered metrics do
+// not panic.
+func (m *QueueMetrics) RecordClaim(outcome string) {
+	if m.claimTotal == nil {
+		return
+	}
+	m.claimTotal.WithLabelValues(outcome).Inc()
 }
 
 func RegisterJobMetrics(registry prometheus.Registerer) JobMetrics {
@@ -110,7 +148,7 @@ func RegisterJobMetrics(registry prometheus.Registerer) JobMetrics {
 				Help:    "Duration of job",
 				Buckets: []float64{5.0, 10.0, 30.0, 60.0, 120.0, 300.0},
 			},
-			[]string{"action", "resources_changed_bucket"},
+			[]string{"action", "resources_changed_bucket", "outcome"},
 		)
 		registry.MustRegister(durationHist)
 
@@ -153,6 +191,15 @@ func RegisterJobMetrics(registry prometheus.Registerer) JobMetrics {
 		)
 		registry.MustRegister(resourceOpsTotal)
 
+		inFlight := prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "grafana_provisioning_jobs_in_flight",
+				Help: "Number of jobs currently being processed (a busy worker slot), by driver and action",
+			},
+			[]string{"driver_id", "action"},
+		)
+		registry.MustRegister(inFlight)
+
 		jobMetrics = JobMetrics{
 			registry:                         registry,
 			processedTotal:                   processedTotal,
@@ -161,18 +208,41 @@ func RegisterJobMetrics(registry prometheus.Registerer) JobMetrics {
 			fullSyncPhaseDurationHist:        fullSyncPhaseDurationHist,
 			syncDurationHist:                 syncDurationHist,
 			resourceOpsTotal:                 resourceOpsTotal,
+			inFlight:                         inFlight,
 		}
 	})
 	return jobMetrics
 }
 
+// IncInFlight marks a worker slot busy: driverID started processing a job of action.
+// Nil-safe so drivers built in tests without registered metrics do not panic.
+func (m *JobMetrics) IncInFlight(driverID, action string) {
+	if m == nil || m.inFlight == nil {
+		return
+	}
+	m.inFlight.WithLabelValues(driverID, action).Inc()
+}
+
+// DecInFlight marks a worker slot free again once the job is done (any outcome).
+func (m *JobMetrics) DecInFlight(driverID, action string) {
+	if m == nil || m.inFlight == nil {
+		return
+	}
+	m.inFlight.WithLabelValues(driverID, action).Dec()
+}
+
 func (m *JobMetrics) RecordJob(jobAction string, outcome string, resourceCountChanged int, duration float64) {
 	m.processedTotal.WithLabelValues(jobAction, outcome).Inc()
 
-	// only record duration when the job was successful. otherwise resource count will be incorrect
+	// Record duration for every outcome so slow-but-failing jobs are visible (a job
+	// that runs to the timeout then errors is exactly what we want to catch). The
+	// resource-count bucket is only meaningful on success — a failed job's count is
+	// partial — so failures are bucketed under a sentinel.
+	bucket := durationBucketUnknown
 	if outcome == utils.SuccessOutcome {
-		m.durationHist.WithLabelValues(jobAction, utils.GetResourceCountBucket(resourceCountChanged)).Observe(duration)
+		bucket = utils.GetResourceCountBucket(resourceCountChanged)
 	}
+	m.durationHist.WithLabelValues(jobAction, bucket, outcome).Observe(duration)
 }
 
 func (m *JobMetrics) RecordIncrementalSyncPhase(phase IncrementalSyncPhase, duration time.Duration) {

--- a/pkg/registry/apis/provisioning/jobs/metrics_inflight_test.go
+++ b/pkg/registry/apis/provisioning/jobs/metrics_inflight_test.go
@@ -1,0 +1,102 @@
+package jobs
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/registry/apis/provisioning/utils"
+)
+
+// histSampleCount returns how many observations a HistogramVec recorded for the given
+// label values.
+func histSampleCount(t *testing.T, h *prometheus.HistogramVec, lvs ...string) uint64 {
+	t.Helper()
+	obs, err := h.GetMetricWithLabelValues(lvs...)
+	require.NoError(t, err)
+	var m dto.Metric
+	require.NoError(t, obs.(prometheus.Metric).Write(&m))
+	return m.GetHistogram().GetSampleCount()
+}
+
+func TestJobMetrics_InFlightIncDec(t *testing.T) {
+	m := &JobMetrics{
+		inFlight: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{Name: "test_jobs_in_flight"},
+			[]string{"driver_id", "action"},
+		),
+	}
+	busy := m.inFlight.WithLabelValues("0", "pull")
+	require.Equal(t, 0.0, testutil.ToFloat64(busy))
+
+	m.IncInFlight("0", "pull")
+	require.Equal(t, 1.0, testutil.ToFloat64(busy))
+
+	m.DecInFlight("0", "pull")
+	require.Equal(t, 0.0, testutil.ToFloat64(busy))
+}
+
+// TestJobMetrics_InFlightNilSafe covers the driver code path where metrics are not
+// wired (e.g. &jobDriver{} in tests) — Inc/Dec must not panic on a nil receiver or a
+// zero-value struct.
+func TestJobMetrics_InFlightNilSafe(t *testing.T) {
+	var nilMetrics *JobMetrics
+	require.NotPanics(t, func() {
+		nilMetrics.IncInFlight("0", "pull")
+		nilMetrics.DecInFlight("0", "pull")
+	})
+
+	zero := &JobMetrics{} // inFlight is nil
+	require.NotPanics(t, func() {
+		zero.IncInFlight("0", "pull")
+		zero.DecInFlight("0", "pull")
+	})
+}
+
+func TestQueueMetrics_RecordClaim(t *testing.T) {
+	m := &QueueMetrics{
+		claimTotal: prometheus.NewCounterVec(
+			prometheus.CounterOpts{Name: "test_jobs_claim_total"},
+			[]string{"outcome"},
+		),
+	}
+	m.RecordClaim(ClaimOutcomeClaimed)
+	m.RecordClaim(ClaimOutcomeClaimed)
+	m.RecordClaim(ClaimOutcomeEmpty)
+
+	require.Equal(t, 2.0, testutil.ToFloat64(m.claimTotal.WithLabelValues(ClaimOutcomeClaimed)))
+	require.Equal(t, 1.0, testutil.ToFloat64(m.claimTotal.WithLabelValues(ClaimOutcomeEmpty)))
+	require.Equal(t, 0.0, testutil.ToFloat64(m.claimTotal.WithLabelValues(ClaimOutcomeContended)))
+}
+
+// TestQueueMetrics_RecordClaimNilSafe covers stores built without a registered claim
+// counter (e.g. QueueMetrics{queueWaitTime: nil} in tests).
+func TestQueueMetrics_RecordClaimNilSafe(t *testing.T) {
+	zero := &QueueMetrics{} // claimTotal is nil
+	require.NotPanics(t, func() { zero.RecordClaim(ClaimOutcomeClaimed) })
+}
+
+// TestJobMetrics_RecordJobDurationOnAllOutcomes verifies duration is observed for
+// failures too (so slow+failing jobs are visible), bucketed under a sentinel since a
+// failed job's resource count is not meaningful.
+func TestJobMetrics_RecordJobDurationOnAllOutcomes(t *testing.T) {
+	m := &JobMetrics{
+		processedTotal: prometheus.NewCounterVec(
+			prometheus.CounterOpts{Name: "test_jobs_processed_total"}, []string{"action", "outcome"}),
+		durationHist: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{Name: "test_jobs_duration_seconds", Buckets: []float64{5, 10}},
+			[]string{"action", "resources_changed_bucket", "outcome"}),
+	}
+
+	m.RecordJob("pull", utils.SuccessOutcome, 3, 2.0)
+	m.RecordJob("pull", utils.ErrorOutcome, 0, 7.0)
+
+	// Both outcomes recorded a duration series (before the fix, only success did).
+	require.Equal(t, 2, testutil.CollectAndCount(m.durationHist))
+	// Success bucketed by resource count; failure under the sentinel bucket.
+	require.Equal(t, uint64(1), histSampleCount(t, m.durationHist, "pull", utils.GetResourceCountBucket(3), utils.SuccessOutcome))
+	require.Equal(t, uint64(1), histSampleCount(t, m.durationHist, "pull", durationBucketUnknown, utils.ErrorOutcome))
+}

--- a/pkg/registry/apis/provisioning/jobs/metrics_inflight_test.go
+++ b/pkg/registry/apis/provisioning/jobs/metrics_inflight_test.go
@@ -93,10 +93,12 @@ func TestJobMetrics_RecordJobDurationOnAllOutcomes(t *testing.T) {
 
 	m.RecordJob("pull", utils.SuccessOutcome, 3, 2.0)
 	m.RecordJob("pull", utils.ErrorOutcome, 0, 7.0)
+	m.RecordJob("pull", "warning", 5, 3.0) // string(provisioning.JobStateWarning)
 
-	// Both outcomes recorded a duration series (before the fix, only success did).
-	require.Equal(t, 2, testutil.CollectAndCount(m.durationHist))
-	// Success bucketed by resource count; failure under the sentinel bucket.
+	// All three outcomes recorded a duration series (before, only success did).
+	require.Equal(t, 3, testutil.CollectAndCount(m.durationHist))
+	// Success and warning keep their resource-count bucket; only failure uses the sentinel.
 	require.Equal(t, uint64(1), histSampleCount(t, m.durationHist, "pull", utils.GetResourceCountBucket(3), utils.SuccessOutcome))
+	require.Equal(t, uint64(1), histSampleCount(t, m.durationHist, "pull", utils.GetResourceCountBucket(5), "warning"))
 	require.Equal(t, uint64(1), histSampleCount(t, m.durationHist, "pull", durationBucketUnknown, utils.ErrorOutcome))
 }

--- a/pkg/registry/apis/provisioning/jobs/metrics_inflight_test.go
+++ b/pkg/registry/apis/provisioning/jobs/metrics_inflight_test.go
@@ -76,7 +76,6 @@ func TestQueueMetrics_RecordClaim(t *testing.T) {
 		claimConflicts:  prometheus.NewCounterVec(prometheus.CounterOpts{Name: "test_claim_conflicts"}, []string{"driver_id"}),
 		claimErrors:     prometheus.NewCounterVec(prometheus.CounterOpts{Name: "test_claim_errors"}, []string{"driver_id"}),
 		claimRoundsCont: prometheus.NewCounterVec(prometheus.CounterOpts{Name: "test_claim_rounds"}, []string{"driver_id"}),
-		claimCandidates: prometheus.NewGauge(prometheus.GaugeOpts{Name: "test_claim_candidates"}),
 	}
 
 	m.RecordClaimWon("0")
@@ -84,14 +83,12 @@ func TestQueueMetrics_RecordClaim(t *testing.T) {
 	m.RecordClaimConflict("0")
 	m.RecordClaimError("1")
 	m.RecordClaimRoundContended("1")
-	m.SetClaimCandidates(7)
 
 	require.Equal(t, 2.0, testutil.ToFloat64(m.claimed.WithLabelValues("0")))
 	require.Equal(t, 1.0, testutil.ToFloat64(m.claimConflicts.WithLabelValues("0")))
 	require.Equal(t, 0.0, testutil.ToFloat64(m.claimed.WithLabelValues("1")))
 	require.Equal(t, 1.0, testutil.ToFloat64(m.claimErrors.WithLabelValues("1")))
 	require.Equal(t, 1.0, testutil.ToFloat64(m.claimRoundsCont.WithLabelValues("1")))
-	require.Equal(t, 7.0, testutil.ToFloat64(m.claimCandidates))
 }
 
 // TestQueueMetrics_RecordClaimNilSafe covers stores built without registered claim
@@ -103,7 +100,6 @@ func TestQueueMetrics_RecordClaimNilSafe(t *testing.T) {
 		zero.RecordClaimConflict("0")
 		zero.RecordClaimError("0")
 		zero.RecordClaimRoundContended("0")
-		zero.SetClaimCandidates(3)
 	})
 }
 

--- a/pkg/registry/apis/provisioning/jobs/metrics_inflight_test.go
+++ b/pkg/registry/apis/provisioning/jobs/metrics_inflight_test.go
@@ -56,27 +56,55 @@ func TestJobMetrics_InFlightNilSafe(t *testing.T) {
 	})
 }
 
-func TestQueueMetrics_RecordClaim(t *testing.T) {
-	m := &QueueMetrics{
-		claimTotal: prometheus.NewCounterVec(
-			prometheus.CounterOpts{Name: "test_jobs_claim_total"},
-			[]string{"outcome"},
-		),
+func TestJobMetrics_RecordBusySeconds(t *testing.T) {
+	m := &JobMetrics{
+		busySeconds: prometheus.NewCounterVec(
+			prometheus.CounterOpts{Name: "test_jobs_busy_seconds"}, []string{"driver_id", "action"}),
 	}
-	m.RecordClaim(ClaimOutcomeClaimed)
-	m.RecordClaim(ClaimOutcomeClaimed)
-	m.RecordClaim(ClaimOutcomeEmpty)
+	m.RecordBusySeconds("0", "pull", 2.5)
+	m.RecordBusySeconds("0", "pull", 1.5)
+	require.Equal(t, 4.0, testutil.ToFloat64(m.busySeconds.WithLabelValues("0", "pull")))
 
-	require.Equal(t, 2.0, testutil.ToFloat64(m.claimTotal.WithLabelValues(ClaimOutcomeClaimed)))
-	require.Equal(t, 1.0, testutil.ToFloat64(m.claimTotal.WithLabelValues(ClaimOutcomeEmpty)))
-	require.Equal(t, 0.0, testutil.ToFloat64(m.claimTotal.WithLabelValues(ClaimOutcomeContended)))
+	var nilMetrics *JobMetrics
+	require.NotPanics(t, func() { nilMetrics.RecordBusySeconds("0", "pull", 1) })
+	require.NotPanics(t, func() { (&JobMetrics{}).RecordBusySeconds("0", "pull", 1) })
 }
 
-// TestQueueMetrics_RecordClaimNilSafe covers stores built without a registered claim
-// counter (e.g. QueueMetrics{queueWaitTime: nil} in tests).
+func TestQueueMetrics_RecordClaim(t *testing.T) {
+	m := &QueueMetrics{
+		claimed:         prometheus.NewCounterVec(prometheus.CounterOpts{Name: "test_claimed"}, []string{"driver_id"}),
+		claimConflicts:  prometheus.NewCounterVec(prometheus.CounterOpts{Name: "test_claim_conflicts"}, []string{"driver_id"}),
+		claimErrors:     prometheus.NewCounterVec(prometheus.CounterOpts{Name: "test_claim_errors"}, []string{"driver_id"}),
+		claimRoundsCont: prometheus.NewCounterVec(prometheus.CounterOpts{Name: "test_claim_rounds"}, []string{"driver_id"}),
+		claimCandidates: prometheus.NewGauge(prometheus.GaugeOpts{Name: "test_claim_candidates"}),
+	}
+
+	m.RecordClaimWon("0")
+	m.RecordClaimWon("0")
+	m.RecordClaimConflict("0")
+	m.RecordClaimError("1")
+	m.RecordClaimRoundContended("1")
+	m.SetClaimCandidates(7)
+
+	require.Equal(t, 2.0, testutil.ToFloat64(m.claimed.WithLabelValues("0")))
+	require.Equal(t, 1.0, testutil.ToFloat64(m.claimConflicts.WithLabelValues("0")))
+	require.Equal(t, 0.0, testutil.ToFloat64(m.claimed.WithLabelValues("1")))
+	require.Equal(t, 1.0, testutil.ToFloat64(m.claimErrors.WithLabelValues("1")))
+	require.Equal(t, 1.0, testutil.ToFloat64(m.claimRoundsCont.WithLabelValues("1")))
+	require.Equal(t, 7.0, testutil.ToFloat64(m.claimCandidates))
+}
+
+// TestQueueMetrics_RecordClaimNilSafe covers stores built without registered claim
+// metrics (zero-value QueueMetrics) — the recorders must not panic.
 func TestQueueMetrics_RecordClaimNilSafe(t *testing.T) {
-	zero := &QueueMetrics{} // claimTotal is nil
-	require.NotPanics(t, func() { zero.RecordClaim(ClaimOutcomeClaimed) })
+	zero := &QueueMetrics{}
+	require.NotPanics(t, func() {
+		zero.RecordClaimWon("0")
+		zero.RecordClaimConflict("0")
+		zero.RecordClaimError("0")
+		zero.RecordClaimRoundContended("0")
+		zero.SetClaimCandidates(3)
+	})
 }
 
 // TestJobMetrics_RecordJobDurationOnAllOutcomes verifies duration is observed for

--- a/pkg/registry/apis/provisioning/jobs/move/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/move/worker.go
@@ -16,7 +16,6 @@ import (
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/jobs"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/resources"
-	"github.com/grafana/grafana/pkg/registry/apis/provisioning/utils"
 )
 
 type Worker struct {
@@ -59,13 +58,6 @@ func (w *Worker) Process(ctx context.Context, repo repository.Repository, job pr
 		attribute.Int("move.paths_count", len(opts.Paths)),
 		attribute.Int("move.resources_count", len(opts.Resources)),
 	)
-
-	outcome := utils.ErrorOutcome
-	start := time.Now()
-	resourcesMoved := 0
-	defer func() {
-		w.metrics.RecordJob(string(provisioning.JobActionMove), outcome, resourcesMoved, time.Since(start).Seconds())
-	}()
 
 	if opts.TargetPath == "" {
 		return errors.New("target path is required for move operation")
@@ -146,12 +138,9 @@ func (w *Worker) Process(ctx context.Context, repo repository.Repository, job pr
 		}
 	}
 
-	outcome = utils.SuccessOutcome
-	jobStatus := progress.Complete(ctx, nil)
-	for _, summary := range jobStatus.Summary {
-		// FileActionRenamed increments both delete & create, use create here
-		resourcesMoved += int(summary.Create)
-	}
+	// Finalize the progress recorder. The job metric is recorded by the driver from
+	// the job's final status, so the returned status is not needed here.
+	progress.Complete(ctx, nil)
 
 	return nil
 }

--- a/pkg/registry/apis/provisioning/jobs/persistentstore.go
+++ b/pkg/registry/apis/provisioning/jobs/persistentstore.go
@@ -119,7 +119,7 @@ func NewJobStore(provisioningClient client.ProvisioningV0alpha1Interface, expiry
 // API error if the job no longer exists (completed and deleted).
 //
 // If err is not nil, the job and rollback values are always nil.
-func (s *persistentStore) Claim(ctx context.Context, namespace, name string) (job *provisioning.Job, rollback func(), err error) {
+func (s *persistentStore) Claim(ctx context.Context, namespace, name string, driverID string) (job *provisioning.Job, rollback func(), err error) {
 	ctx, span := tracing.Start(ctx, "provisioning.jobs.claim")
 	defer func() {
 		if err != nil && !errors.Is(err, ErrAlreadyClaimed) && !apierrors.IsNotFound(err) {
@@ -165,7 +165,7 @@ func (s *persistentStore) Claim(ctx context.Context, namespace, name string) (jo
 			continue
 		}
 		if err != nil {
-			s.queueMetrics.RecordClaim(ClaimOutcomeError)
+			s.queueMetrics.RecordClaimError(driverID)
 			return nil, nil, apifmt.Errorf("failed to claim job '%s' in '%s': %w", name, namespace, err)
 		}
 
@@ -187,7 +187,7 @@ func (s *persistentStore) Claim(ctx context.Context, namespace, name string) (jo
 		// conflicting worker (handled above with continue) must not count, or racing
 		// losers would each record a wait for a job they never claimed.
 		s.queueMetrics.RecordWaitTime(string(updatedJob.Spec.Action), s.clock().Sub(updatedJob.CreationTimestamp.Time).Seconds())
-		s.queueMetrics.RecordClaim(ClaimOutcomeClaimed)
+		s.queueMetrics.RecordClaimWon(driverID)
 
 		return updatedJob.DeepCopy(), func() {
 			// Rolling back does not need to care about the parent's cancellation state.
@@ -234,9 +234,9 @@ func (s *persistentStore) Claim(ctx context.Context, namespace, name string) (jo
 		}, nil
 	}
 
-	// Every attempt conflicted; treat the job as claimed by someone else. If it is in fact
-	// still unclaimed, the informer re-list re-discovers it.
-	s.queueMetrics.RecordClaim(ClaimOutcomeContended)
+	// We failed to claim any jobs: candidates existed (len > 0 above) but every one was
+	// claimed by another worker first — a fully contended round.
+	s.queueMetrics.RecordClaimRoundContended(driverID)
 	logger.Debug("job claim conflicted repeatedly - treating as claimed by another worker")
 	return nil, nil, apifmt.Errorf("failed to claim job '%s' in '%s' after %d conflicts: %w", name, namespace, claimConflictRetries, ErrAlreadyClaimed)
 }

--- a/pkg/registry/apis/provisioning/jobs/persistentstore.go
+++ b/pkg/registry/apis/provisioning/jobs/persistentstore.go
@@ -165,6 +165,7 @@ func (s *persistentStore) Claim(ctx context.Context, namespace, name string) (jo
 			continue
 		}
 		if err != nil {
+			s.queueMetrics.RecordClaim(ClaimOutcomeError)
 			return nil, nil, apifmt.Errorf("failed to claim job '%s' in '%s': %w", name, namespace, err)
 		}
 
@@ -182,6 +183,10 @@ func (s *persistentStore) Claim(ctx context.Context, namespace, name string) (jo
 			attribute.String("job.action", string(updatedJob.Spec.Action)),
 		)
 
+		// Record the wait only now that the claim succeeded: a candidate we lost to a
+		// conflicting worker (handled above with continue) must not count, or racing
+		// losers would each record a wait for a job they never claimed.
+		s.queueMetrics.RecordWaitTime(string(updatedJob.Spec.Action), s.clock().Sub(updatedJob.CreationTimestamp.Time).Seconds())
 		s.queueMetrics.RecordClaim(ClaimOutcomeClaimed)
 
 		return updatedJob.DeepCopy(), func() {

--- a/pkg/registry/apis/provisioning/jobs/persistentstore.go
+++ b/pkg/registry/apis/provisioning/jobs/persistentstore.go
@@ -182,6 +182,8 @@ func (s *persistentStore) Claim(ctx context.Context, namespace, name string) (jo
 			attribute.String("job.action", string(updatedJob.Spec.Action)),
 		)
 
+		s.queueMetrics.RecordClaim(ClaimOutcomeClaimed)
+
 		return updatedJob.DeepCopy(), func() {
 			// Rolling back does not need to care about the parent's cancellation state.
 			// Keep the identity-augmented context so we have permissions to do this.
@@ -229,6 +231,7 @@ func (s *persistentStore) Claim(ctx context.Context, namespace, name string) (jo
 
 	// Every attempt conflicted; treat the job as claimed by someone else. If it is in fact
 	// still unclaimed, the informer re-list re-discovers it.
+	s.queueMetrics.RecordClaim(ClaimOutcomeContended)
 	logger.Debug("job claim conflicted repeatedly - treating as claimed by another worker")
 	return nil, nil, apifmt.Errorf("failed to claim job '%s' in '%s' after %d conflicts: %w", name, namespace, claimConflictRetries, ErrAlreadyClaimed)
 }

--- a/pkg/registry/apis/provisioning/jobs/persistentstore.go
+++ b/pkg/registry/apis/provisioning/jobs/persistentstore.go
@@ -161,15 +161,15 @@ func (s *persistentStore) Claim(ctx context.Context, namespace, name string, dri
 		// This is the desired behavior, as it ensures that claims are atomic.
 		updatedJob, err := s.client.Jobs(namespace).Update(ctx, claimed, metav1.UpdateOptions{})
 		if apierrors.IsConflict(err) {
-			// Re-read and re-evaluate: another worker probably claimed it first.
+			// Lost the CAS race; another worker updated the job first. Record it and
+			// re-read/re-evaluate on the next attempt.
+			s.queueMetrics.RecordClaimConflict(driverID)
 			continue
 		}
 		if err != nil {
 			s.queueMetrics.RecordClaimError(driverID)
 			return nil, nil, apifmt.Errorf("failed to claim job '%s' in '%s': %w", name, namespace, err)
 		}
-
-		s.queueMetrics.RecordWaitTime(string(updatedJob.Spec.Action), s.clock().Sub(updatedJob.CreationTimestamp.Time).Seconds())
 
 		logger.Info("job claim complete",
 			"repository", updatedJob.Spec.Repository,

--- a/pkg/registry/apis/provisioning/jobs/persistentstore.go
+++ b/pkg/registry/apis/provisioning/jobs/persistentstore.go
@@ -146,6 +146,8 @@ func (s *persistentStore) Claim(ctx context.Context, namespace, name string, dri
 			return nil, nil, apifmt.Errorf("failed to get job '%s' in '%s' for claiming: %w", name, namespace, err)
 		}
 		if current.Labels[LabelJobClaim] != "" {
+			// Another worker already holds the claim — the common contention outcome.
+			s.queueMetrics.RecordClaimRoundContended(driverID)
 			return nil, nil, ErrAlreadyClaimed
 		}
 
@@ -186,9 +188,8 @@ func (s *persistentStore) Claim(ctx context.Context, namespace, name string, dri
 			attribute.String("job.action", string(updatedJob.Spec.Action)),
 		)
 
-		// Record the wait only now that the claim succeeded: a candidate we lost to a
-		// conflicting worker (handled above with continue) must not count, or racing
-		// losers would each record a wait for a job they never claimed.
+		// Record the wait only now that the claim succeeded: a conflicting attempt that
+		// retried (the continue above) must not record a wait for a claim it never won.
 		s.queueMetrics.RecordWaitTime(string(updatedJob.Spec.Action), s.clock().Sub(updatedJob.CreationTimestamp.Time).Seconds())
 		s.queueMetrics.RecordClaimWon(driverID)
 
@@ -237,8 +238,10 @@ func (s *persistentStore) Claim(ctx context.Context, namespace, name string, dri
 		}, nil
 	}
 
-	// We failed to claim any jobs: candidates existed (len > 0 above) but every one was
-	// claimed by another worker first — a fully contended round.
+	// Every attempt hit a CAS conflict (the job kept changing under us) and the retries
+	// are now exhausted. Like the already-claimed case above, this counts as contended
+	// (lost to another worker); each individual lost race is also counted by
+	// claim_conflicts_total.
 	s.queueMetrics.RecordClaimRoundContended(driverID)
 	logger.Debug("job claim conflicted repeatedly - treating as claimed by another worker")
 	return nil, nil, apifmt.Errorf("failed to claim job '%s' in '%s' after %d conflicts: %w", name, namespace, claimConflictRetries, ErrAlreadyClaimed)

--- a/pkg/registry/apis/provisioning/jobs/persistentstore.go
+++ b/pkg/registry/apis/provisioning/jobs/persistentstore.go
@@ -167,6 +167,9 @@ func (s *persistentStore) Claim(ctx context.Context, namespace, name string, dri
 			continue
 		}
 		if err != nil {
+			// This records only the failure of the claim itself (the atomic Update that
+			// takes the job). Earlier failures — identity setup and the job Get — return
+			// before this point and are intentionally not counted here.
 			s.queueMetrics.RecordClaimError(driverID)
 			return nil, nil, apifmt.Errorf("failed to claim job '%s' in '%s': %w", name, namespace, err)
 		}

--- a/pkg/registry/apis/provisioning/jobs/persistentstore_test.go
+++ b/pkg/registry/apis/provisioning/jobs/persistentstore_test.go
@@ -77,7 +77,7 @@ func TestClaim_AlreadyClaimed(t *testing.T) {
 	}, metav1.CreateOptions{})
 	require.NoError(t, err)
 
-	claimed, rollback, err := store.Claim(ctx, "stacks-123", "test-job")
+	claimed, rollback, err := store.Claim(ctx, "stacks-123", "test-job", "0")
 	require.ErrorIs(t, err, ErrAlreadyClaimed)
 	assert.Nil(t, claimed)
 	assert.Nil(t, rollback)
@@ -96,7 +96,7 @@ func TestClaim_NotFound(t *testing.T) {
 	ctx, _, err := identity.WithProvisioningIdentity(context.Background(), "stacks-123")
 	require.NoError(t, err)
 
-	claimed, rollback, err := store.Claim(ctx, "stacks-123", "no-such-job")
+	claimed, rollback, err := store.Claim(ctx, "stacks-123", "no-such-job", "0")
 	require.Error(t, err)
 	assert.True(t, apierrors.IsNotFound(err), "expected NotFound, got %v", err)
 	assert.Nil(t, claimed)
@@ -130,7 +130,7 @@ func TestClaim_RetriesOnConflict(t *testing.T) {
 		return false, nil, nil
 	})
 
-	claimed, rollback, err := store.Claim(ctx, "stacks-123", "test-job")
+	claimed, rollback, err := store.Claim(ctx, "stacks-123", "test-job", "0")
 	require.NoError(t, err, "a transient conflict on a still-unclaimed job should be retried")
 	require.NotNil(t, claimed)
 	defer rollback()
@@ -185,7 +185,7 @@ func TestClaim_ConflictThenClaimedByOther(t *testing.T) {
 		return true, nil, apierrors.NewConflict(provisioning.JobResourceInfo.GroupResource(), "test-job", errors.New("simulated conflict"))
 	})
 
-	claimed, rollback, err := store.Claim(ctx, "stacks-123", "test-job")
+	claimed, rollback, err := store.Claim(ctx, "stacks-123", "test-job", "0")
 	require.ErrorIs(t, err, ErrAlreadyClaimed)
 	assert.Nil(t, claimed)
 	assert.Nil(t, rollback)
@@ -420,8 +420,8 @@ func TestClaim_RecordsClaimMetrics(t *testing.T) {
 	require.NoError(t, err)
 
 	// Empty store: nothing to claim -> candidates gauge 0, no win.
-	_, _, err = store.Claim(ctx, "0")
-	require.ErrorIs(t, err, ErrNoJobs)
+	_, _, err = store.Claim(ctx, "stacks-123", "job-1", "0")
+	require.Error(t, err)
 	require.Equal(t, 0.0, testutil.ToFloat64(store.queueMetrics.claimCandidates))
 	require.Equal(t, 0.0, testutil.ToFloat64(store.queueMetrics.claimed.WithLabelValues("0")))
 
@@ -432,7 +432,7 @@ func TestClaim_RecordsClaimMetrics(t *testing.T) {
 	}, metav1.CreateOptions{})
 	require.NoError(t, err)
 
-	claimed, rollback, err := store.Claim(ctx, "0")
+	claimed, rollback, err := store.Claim(ctx, "stacks-123", "job-1", "0")
 	require.NoError(t, err)
 	require.NotNil(t, claimed)
 	defer rollback()
@@ -467,7 +467,7 @@ func TestClaim_WaitRecordedOnlyOnSuccessfulClaim(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	claimed, rollback, err := store.Claim(ctx, "0")
+	claimed, rollback, err := store.Claim(ctx, "stacks-123", "job-a", "0")
 	require.NoError(t, err)
 	require.NotNil(t, claimed)
 	defer rollback()
@@ -497,7 +497,7 @@ func TestClaim_RecordsErrorOnUpdateFailure(t *testing.T) {
 	}, metav1.CreateOptions{})
 	require.NoError(t, err)
 
-	_, _, err = store.Claim(ctx, "0")
+	_, _, err = store.Claim(ctx, "stacks-123", "job-1", "0")
 	require.Error(t, err)
 	require.Equal(t, 1.0, testutil.ToFloat64(store.queueMetrics.claimErrors.WithLabelValues("0")))
 }

--- a/pkg/registry/apis/provisioning/jobs/persistentstore_test.go
+++ b/pkg/registry/apis/provisioning/jobs/persistentstore_test.go
@@ -424,6 +424,83 @@ func TestClaim_RecordsClaimOutcome(t *testing.T) {
 	require.Equal(t, 1.0, testutil.ToFloat64(store.queueMetrics.claimTotal.WithLabelValues(ClaimOutcomeClaimed)))
 }
 
+// newStoreWithFreshQueueMetrics builds a store whose queue metrics are their own
+// (unregistered) collectors, so assertions are isolated from the process-global
+// singletons other tests share.
+func newStoreWithFreshQueueMetrics(client provisioningv0alpha1.ProvisioningV0alpha1Interface) *persistentStore {
+	return &persistentStore{
+		client: client,
+		clock:  time.Now,
+		expiry: 30 * time.Second,
+		queueMetrics: QueueMetrics{
+			queueWaitTime: prometheus.NewHistogramVec(
+				prometheus.HistogramOpts{Name: "test_queue_wait"}, []string{"action"}),
+			claimTotal: prometheus.NewCounterVec(
+				prometheus.CounterOpts{Name: "test_claim_total"}, []string{"outcome"}),
+		},
+	}
+}
+
+// TestClaim_WaitRecordedOnlyOnSuccessfulClaim verifies queue-wait is recorded once —
+// for the job actually claimed — not for a candidate lost to a conflicting worker.
+func TestClaim_WaitRecordedOnlyOnSuccessfulClaim(t *testing.T) {
+	cs := fakeclientset.NewSimpleClientset()
+	var updates int
+	cs.PrependReactor("update", "jobs", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		updates++
+		if updates == 1 {
+			// First candidate loses the race to another worker.
+			return true, nil, apierrors.NewConflict(provisioning.JobResourceInfo.GroupResource(), "", errors.New("claimed by another worker"))
+		}
+		return false, nil, nil // let the tracker perform the real update for the next candidate
+	})
+	store := newStoreWithFreshQueueMetrics(cs.ProvisioningV0alpha1())
+
+	ctx, _, err := identity.WithProvisioningIdentity(context.Background(), "stacks-123")
+	require.NoError(t, err)
+
+	for _, name := range []string{"job-a", "job-b"} {
+		_, err := cs.ProvisioningV0alpha1().Jobs("stacks-123").Create(ctx, &provisioning.Job{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "stacks-123"},
+			Spec:       provisioning.JobSpec{Repository: "repo", Action: provisioning.JobActionPull},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+	}
+
+	claimed, rollback, err := store.Claim(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+	defer rollback()
+	require.Equal(t, 2, updates, "both candidates should have been attempted")
+
+	// Exactly one wait observation despite the first candidate conflicting.
+	require.Equal(t, uint64(1), histSampleCount(t, store.queueMetrics.queueWaitTime, "pull"))
+	require.Equal(t, 1.0, testutil.ToFloat64(store.queueMetrics.claimTotal.WithLabelValues(ClaimOutcomeClaimed)))
+}
+
+// TestClaim_RecordsErrorOnUpdateFailure verifies a non-conflict update failure is
+// recorded as a claim error, completing the claim_total outcome coverage.
+func TestClaim_RecordsErrorOnUpdateFailure(t *testing.T) {
+	cs := fakeclientset.NewSimpleClientset()
+	cs.PrependReactor("update", "jobs", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewInternalError(errors.New("boom"))
+	})
+	store := newStoreWithFreshQueueMetrics(cs.ProvisioningV0alpha1())
+
+	ctx, _, err := identity.WithProvisioningIdentity(context.Background(), "stacks-123")
+	require.NoError(t, err)
+
+	_, err = cs.ProvisioningV0alpha1().Jobs("stacks-123").Create(ctx, &provisioning.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: "job-1", Namespace: "stacks-123"},
+		Spec:       provisioning.JobSpec{Repository: "repo", Action: provisioning.JobActionPull},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	_, _, err = store.Claim(ctx)
+	require.Error(t, err)
+	require.Equal(t, 1.0, testutil.ToFloat64(store.queueMetrics.claimTotal.WithLabelValues(ClaimOutcomeError)))
+}
+
 // TestRenewLease_StaleResourceVersion verifies that after RenewLease, the
 // in-memory job's ResourceVersion matches what K8s actually has.
 //

--- a/pkg/registry/apis/provisioning/jobs/persistentstore_test.go
+++ b/pkg/registry/apis/provisioning/jobs/persistentstore_test.go
@@ -403,15 +403,12 @@ func newStoreWithFreshQueueMetrics(client provisioningv0alpha1.ProvisioningV0alp
 				prometheus.CounterOpts{Name: "test_claim_errors"}, []string{"driver_id"}),
 			claimRoundsCont: prometheus.NewCounterVec(
 				prometheus.CounterOpts{Name: "test_claim_rounds"}, []string{"driver_id"}),
-			claimCandidates: prometheus.NewGauge(
-				prometheus.GaugeOpts{Name: "test_claim_candidates"}),
 		},
 	}
 }
 
-// TestClaim_RecordsClaimMetrics verifies the per-driver claim metrics: an empty poll
-// sets the candidates gauge to 0 and records no win; a successful claim records a win
-// and sets candidates to 1.
+// TestClaim_RecordsClaimMetrics verifies the per-driver claim win counter: claiming a
+// job that exists records a win for the calling driver.
 func TestClaim_RecordsClaimMetrics(t *testing.T) {
 	fakeClient := newTestClientset()
 	store := newStoreWithFreshQueueMetrics(fakeClient)
@@ -419,13 +416,12 @@ func TestClaim_RecordsClaimMetrics(t *testing.T) {
 	ctx, _, err := identity.WithProvisioningIdentity(context.Background(), "stacks-123")
 	require.NoError(t, err)
 
-	// Empty store: nothing to claim -> candidates gauge 0, no win.
+	// Claiming a job that does not exist returns an error and records no win.
 	_, _, err = store.Claim(ctx, "stacks-123", "job-1", "0")
 	require.Error(t, err)
-	require.Equal(t, 0.0, testutil.ToFloat64(store.queueMetrics.claimCandidates))
 	require.Equal(t, 0.0, testutil.ToFloat64(store.queueMetrics.claimed.WithLabelValues("0")))
 
-	// A job is available: claim succeeds -> claimed_total{driver=0} = 1, candidates = 1.
+	// The job exists: claim succeeds -> claimed_total{driver=0} = 1.
 	_, err = fakeClient.Jobs("stacks-123").Create(ctx, &provisioning.Job{
 		ObjectMeta: metav1.ObjectMeta{Name: "job-1", Namespace: "stacks-123"},
 		Spec:       provisioning.JobSpec{Repository: "repo", Action: provisioning.JobActionPull},
@@ -437,7 +433,6 @@ func TestClaim_RecordsClaimMetrics(t *testing.T) {
 	require.NotNil(t, claimed)
 	defer rollback()
 	require.Equal(t, 1.0, testutil.ToFloat64(store.queueMetrics.claimed.WithLabelValues("0")))
-	require.Equal(t, 1.0, testutil.ToFloat64(store.queueMetrics.claimCandidates))
 }
 
 // TestClaim_WaitRecordedOnlyOnSuccessfulClaim verifies queue-wait is recorded once —
@@ -449,31 +444,29 @@ func TestClaim_WaitRecordedOnlyOnSuccessfulClaim(t *testing.T) {
 	cs.PrependReactor("update", "jobs", func(action k8stesting.Action) (bool, runtime.Object, error) {
 		updates++
 		if updates == 1 {
-			// First candidate loses the race to another worker.
+			// First CAS attempt loses the race; Claim re-reads and retries.
 			return true, nil, apierrors.NewConflict(provisioning.JobResourceInfo.GroupResource(), "", errors.New("claimed by another worker"))
 		}
-		return false, nil, nil // let the tracker perform the real update for the next candidate
+		return false, nil, nil // let the tracker perform the real update on the retry
 	})
 	store := newStoreWithFreshQueueMetrics(cs.ProvisioningV0alpha1())
 
 	ctx, _, err := identity.WithProvisioningIdentity(context.Background(), "stacks-123")
 	require.NoError(t, err)
 
-	for _, name := range []string{"job-a", "job-b"} {
-		_, err := cs.ProvisioningV0alpha1().Jobs("stacks-123").Create(ctx, &provisioning.Job{
-			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "stacks-123"},
-			Spec:       provisioning.JobSpec{Repository: "repo", Action: provisioning.JobActionPull},
-		}, metav1.CreateOptions{})
-		require.NoError(t, err)
-	}
+	_, err = cs.ProvisioningV0alpha1().Jobs("stacks-123").Create(ctx, &provisioning.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: "job-a", Namespace: "stacks-123"},
+		Spec:       provisioning.JobSpec{Repository: "repo", Action: provisioning.JobActionPull},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
 
 	claimed, rollback, err := store.Claim(ctx, "stacks-123", "job-a", "0")
 	require.NoError(t, err)
 	require.NotNil(t, claimed)
 	defer rollback()
-	require.Equal(t, 2, updates, "both candidates should have been attempted")
+	require.Equal(t, 2, updates, "expected one conflicting attempt then a successful retry")
 
-	// Exactly one wait observation despite the first candidate conflicting.
+	// Exactly one wait observation despite the first attempt conflicting.
 	require.Equal(t, uint64(1), histSampleCount(t, store.queueMetrics.queueWaitTime, "pull"))
 	require.Equal(t, 1.0, testutil.ToFloat64(store.queueMetrics.claimed.WithLabelValues("0")))
 	require.Equal(t, 1.0, testutil.ToFloat64(store.queueMetrics.claimConflicts.WithLabelValues("0")))

--- a/pkg/registry/apis/provisioning/jobs/persistentstore_test.go
+++ b/pkg/registry/apis/provisioning/jobs/persistentstore_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -381,6 +382,46 @@ func TestComplete_SucceedsForOwner(t *testing.T) {
 func newTestClientset() provisioningv0alpha1.ProvisioningV0alpha1Interface {
 	//nolint:staticcheck // NewSimpleClientset is needed; NewClientset requires schema registration not available for this type.
 	return fakeclientset.NewSimpleClientset().ProvisioningV0alpha1()
+}
+
+// TestClaim_RecordsClaimOutcome verifies Claim increments the claim-outcome counter:
+// "empty" when nothing is available, "claimed" when a job is taken. Uses a store with
+// its own fresh metrics so the assertions are not affected by other tests sharing the
+// process-global counter.
+func TestClaim_RecordsClaimOutcome(t *testing.T) {
+	fakeClient := newTestClientset()
+	store := &persistentStore{
+		client: fakeClient,
+		clock:  time.Now,
+		expiry: 30 * time.Second,
+		queueMetrics: QueueMetrics{
+			queueWaitTime: prometheus.NewHistogramVec(
+				prometheus.HistogramOpts{Name: "test_queue_wait"}, []string{"action"}),
+			claimTotal: prometheus.NewCounterVec(
+				prometheus.CounterOpts{Name: "test_claim_total"}, []string{"outcome"}),
+		},
+	}
+
+	ctx, _, err := identity.WithProvisioningIdentity(context.Background(), "stacks-123")
+	require.NoError(t, err)
+
+	// Empty store: nothing to claim -> "empty".
+	_, _, err = store.Claim(ctx)
+	require.ErrorIs(t, err, ErrNoJobs)
+	require.Equal(t, 1.0, testutil.ToFloat64(store.queueMetrics.claimTotal.WithLabelValues(ClaimOutcomeEmpty)))
+
+	// A job is available: claim succeeds -> "claimed".
+	_, err = fakeClient.Jobs("stacks-123").Create(ctx, &provisioning.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: "job-1", Namespace: "stacks-123"},
+		Spec:       provisioning.JobSpec{Repository: "repo", Action: provisioning.JobActionPull},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	claimed, rollback, err := store.Claim(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+	defer rollback()
+	require.Equal(t, 1.0, testutil.ToFloat64(store.queueMetrics.claimTotal.WithLabelValues(ClaimOutcomeClaimed)))
 }
 
 // TestRenewLease_StaleResourceVersion verifies that after RenewLease, the

--- a/pkg/registry/apis/provisioning/jobs/persistentstore_test.go
+++ b/pkg/registry/apis/provisioning/jobs/persistentstore_test.go
@@ -46,7 +46,7 @@ func TestClaim_StampsOwnerToken(t *testing.T) {
 	}, metav1.CreateOptions{})
 	require.NoError(t, err)
 
-	claimed, rollback, err := store.Claim(ctx, "stacks-123", "test-job")
+	claimed, rollback, err := store.Claim(ctx, "stacks-123", "test-job", "0")
 	require.NoError(t, err)
 	require.NotNil(t, claimed)
 	defer rollback()
@@ -212,7 +212,7 @@ func TestClaim_RollbackSkipsJobOwnedByAnother(t *testing.T) {
 	}, metav1.CreateOptions{})
 	require.NoError(t, err)
 
-	_, rollback, err := store.Claim(ctx, "stacks-123", "test-job")
+	_, rollback, err := store.Claim(ctx, "stacks-123", "test-job", "0")
 	require.NoError(t, err)
 
 	// Simulate another worker taking over the same job name after our claim.
@@ -384,46 +384,6 @@ func newTestClientset() provisioningv0alpha1.ProvisioningV0alpha1Interface {
 	return fakeclientset.NewSimpleClientset().ProvisioningV0alpha1()
 }
 
-// TestClaim_RecordsClaimOutcome verifies Claim increments the claim-outcome counter:
-// "empty" when nothing is available, "claimed" when a job is taken. Uses a store with
-// its own fresh metrics so the assertions are not affected by other tests sharing the
-// process-global counter.
-func TestClaim_RecordsClaimOutcome(t *testing.T) {
-	fakeClient := newTestClientset()
-	store := &persistentStore{
-		client: fakeClient,
-		clock:  time.Now,
-		expiry: 30 * time.Second,
-		queueMetrics: QueueMetrics{
-			queueWaitTime: prometheus.NewHistogramVec(
-				prometheus.HistogramOpts{Name: "test_queue_wait"}, []string{"action"}),
-			claimTotal: prometheus.NewCounterVec(
-				prometheus.CounterOpts{Name: "test_claim_total"}, []string{"outcome"}),
-		},
-	}
-
-	ctx, _, err := identity.WithProvisioningIdentity(context.Background(), "stacks-123")
-	require.NoError(t, err)
-
-	// Empty store: nothing to claim -> "empty".
-	_, _, err = store.Claim(ctx)
-	require.ErrorIs(t, err, ErrNoJobs)
-	require.Equal(t, 1.0, testutil.ToFloat64(store.queueMetrics.claimTotal.WithLabelValues(ClaimOutcomeEmpty)))
-
-	// A job is available: claim succeeds -> "claimed".
-	_, err = fakeClient.Jobs("stacks-123").Create(ctx, &provisioning.Job{
-		ObjectMeta: metav1.ObjectMeta{Name: "job-1", Namespace: "stacks-123"},
-		Spec:       provisioning.JobSpec{Repository: "repo", Action: provisioning.JobActionPull},
-	}, metav1.CreateOptions{})
-	require.NoError(t, err)
-
-	claimed, rollback, err := store.Claim(ctx)
-	require.NoError(t, err)
-	require.NotNil(t, claimed)
-	defer rollback()
-	require.Equal(t, 1.0, testutil.ToFloat64(store.queueMetrics.claimTotal.WithLabelValues(ClaimOutcomeClaimed)))
-}
-
 // newStoreWithFreshQueueMetrics builds a store whose queue metrics are their own
 // (unregistered) collectors, so assertions are isolated from the process-global
 // singletons other tests share.
@@ -435,14 +395,54 @@ func newStoreWithFreshQueueMetrics(client provisioningv0alpha1.ProvisioningV0alp
 		queueMetrics: QueueMetrics{
 			queueWaitTime: prometheus.NewHistogramVec(
 				prometheus.HistogramOpts{Name: "test_queue_wait"}, []string{"action"}),
-			claimTotal: prometheus.NewCounterVec(
-				prometheus.CounterOpts{Name: "test_claim_total"}, []string{"outcome"}),
+			claimed: prometheus.NewCounterVec(
+				prometheus.CounterOpts{Name: "test_claimed"}, []string{"driver_id"}),
+			claimConflicts: prometheus.NewCounterVec(
+				prometheus.CounterOpts{Name: "test_claim_conflicts"}, []string{"driver_id"}),
+			claimErrors: prometheus.NewCounterVec(
+				prometheus.CounterOpts{Name: "test_claim_errors"}, []string{"driver_id"}),
+			claimRoundsCont: prometheus.NewCounterVec(
+				prometheus.CounterOpts{Name: "test_claim_rounds"}, []string{"driver_id"}),
+			claimCandidates: prometheus.NewGauge(
+				prometheus.GaugeOpts{Name: "test_claim_candidates"}),
 		},
 	}
 }
 
+// TestClaim_RecordsClaimMetrics verifies the per-driver claim metrics: an empty poll
+// sets the candidates gauge to 0 and records no win; a successful claim records a win
+// and sets candidates to 1.
+func TestClaim_RecordsClaimMetrics(t *testing.T) {
+	fakeClient := newTestClientset()
+	store := newStoreWithFreshQueueMetrics(fakeClient)
+
+	ctx, _, err := identity.WithProvisioningIdentity(context.Background(), "stacks-123")
+	require.NoError(t, err)
+
+	// Empty store: nothing to claim -> candidates gauge 0, no win.
+	_, _, err = store.Claim(ctx, "0")
+	require.ErrorIs(t, err, ErrNoJobs)
+	require.Equal(t, 0.0, testutil.ToFloat64(store.queueMetrics.claimCandidates))
+	require.Equal(t, 0.0, testutil.ToFloat64(store.queueMetrics.claimed.WithLabelValues("0")))
+
+	// A job is available: claim succeeds -> claimed_total{driver=0} = 1, candidates = 1.
+	_, err = fakeClient.Jobs("stacks-123").Create(ctx, &provisioning.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: "job-1", Namespace: "stacks-123"},
+		Spec:       provisioning.JobSpec{Repository: "repo", Action: provisioning.JobActionPull},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	claimed, rollback, err := store.Claim(ctx, "0")
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+	defer rollback()
+	require.Equal(t, 1.0, testutil.ToFloat64(store.queueMetrics.claimed.WithLabelValues("0")))
+	require.Equal(t, 1.0, testutil.ToFloat64(store.queueMetrics.claimCandidates))
+}
+
 // TestClaim_WaitRecordedOnlyOnSuccessfulClaim verifies queue-wait is recorded once —
-// for the job actually claimed — not for a candidate lost to a conflicting worker.
+// for the job actually claimed — not for a candidate lost to a conflicting worker, and
+// that the lost race is recorded as a claim conflict.
 func TestClaim_WaitRecordedOnlyOnSuccessfulClaim(t *testing.T) {
 	cs := fakeclientset.NewSimpleClientset()
 	var updates int
@@ -467,7 +467,7 @@ func TestClaim_WaitRecordedOnlyOnSuccessfulClaim(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	claimed, rollback, err := store.Claim(ctx)
+	claimed, rollback, err := store.Claim(ctx, "0")
 	require.NoError(t, err)
 	require.NotNil(t, claimed)
 	defer rollback()
@@ -475,11 +475,12 @@ func TestClaim_WaitRecordedOnlyOnSuccessfulClaim(t *testing.T) {
 
 	// Exactly one wait observation despite the first candidate conflicting.
 	require.Equal(t, uint64(1), histSampleCount(t, store.queueMetrics.queueWaitTime, "pull"))
-	require.Equal(t, 1.0, testutil.ToFloat64(store.queueMetrics.claimTotal.WithLabelValues(ClaimOutcomeClaimed)))
+	require.Equal(t, 1.0, testutil.ToFloat64(store.queueMetrics.claimed.WithLabelValues("0")))
+	require.Equal(t, 1.0, testutil.ToFloat64(store.queueMetrics.claimConflicts.WithLabelValues("0")))
 }
 
 // TestClaim_RecordsErrorOnUpdateFailure verifies a non-conflict update failure is
-// recorded as a claim error, completing the claim_total outcome coverage.
+// recorded as a claim error for the calling driver.
 func TestClaim_RecordsErrorOnUpdateFailure(t *testing.T) {
 	cs := fakeclientset.NewSimpleClientset()
 	cs.PrependReactor("update", "jobs", func(action k8stesting.Action) (bool, runtime.Object, error) {
@@ -496,9 +497,9 @@ func TestClaim_RecordsErrorOnUpdateFailure(t *testing.T) {
 	}, metav1.CreateOptions{})
 	require.NoError(t, err)
 
-	_, _, err = store.Claim(ctx)
+	_, _, err = store.Claim(ctx, "0")
 	require.Error(t, err)
-	require.Equal(t, 1.0, testutil.ToFloat64(store.queueMetrics.claimTotal.WithLabelValues(ClaimOutcomeError)))
+	require.Equal(t, 1.0, testutil.ToFloat64(store.queueMetrics.claimErrors.WithLabelValues("0")))
 }
 
 // TestRenewLease_StaleResourceVersion verifies that after RenewLease, the

--- a/pkg/registry/apis/provisioning/jobs/persistentstore_test.go
+++ b/pkg/registry/apis/provisioning/jobs/persistentstore_test.go
@@ -87,6 +87,35 @@ func TestClaim_AlreadyClaimed(t *testing.T) {
 	assert.Equal(t, "owner-B", after.Labels[LabelJobClaimOwner], "the existing claim must be left untouched")
 }
 
+// TestClaim_RecordsContendedWhenAlreadyClaimed verifies that finding the job already
+// held by another worker records claim_rounds_contended (the common contention loss),
+// not just the rare retry-exhaustion tail.
+func TestClaim_RecordsContendedWhenAlreadyClaimed(t *testing.T) {
+	fakeClient := newTestClientset()
+	store := newStoreWithFreshQueueMetrics(fakeClient)
+
+	ctx, _, err := identity.WithProvisioningIdentity(context.Background(), "stacks-123")
+	require.NoError(t, err)
+
+	_, err = fakeClient.Jobs("stacks-123").Create(ctx, &provisioning.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-job",
+			Namespace: "stacks-123",
+			Labels: map[string]string{
+				LabelJobClaim:      "1000000000000",
+				LabelJobClaimOwner: "owner-B",
+			},
+		},
+		Spec: provisioning.JobSpec{Repository: "test-repo", Action: provisioning.JobActionPull},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	_, _, err = store.Claim(ctx, "stacks-123", "test-job", "0")
+	require.ErrorIs(t, err, ErrAlreadyClaimed)
+	require.Equal(t, 1.0, testutil.ToFloat64(store.queueMetrics.claimRoundsCont.WithLabelValues("0")))
+	require.Equal(t, 0.0, testutil.ToFloat64(store.queueMetrics.claimed.WithLabelValues("0")))
+}
+
 // TestClaim_NotFound verifies that claiming a job that no longer exists (e.g.
 // completed and deleted before we got to it) reports NotFound so callers drop it.
 func TestClaim_NotFound(t *testing.T) {

--- a/pkg/registry/apis/provisioning/jobs/shutdown_test.go
+++ b/pkg/registry/apis/provisioning/jobs/shutdown_test.go
@@ -169,8 +169,8 @@ func TestConcurrentJobDriver_Run_AllDriversExitBeforeRunReturns(t *testing.T) {
 	store := &MockStore{}
 	// Claim blocks until ctx is cancelled, simulating drivers that are
 	// mid-claim when the shutdown signal arrives.
-	store.EXPECT().Claim(mock.Anything, mock.Anything, mock.Anything).
-		RunAndReturn(func(ctx context.Context, _, _ string) (*provisioning.Job, func(), error) {
+	store.EXPECT().Claim(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		RunAndReturn(func(ctx context.Context, _, _ string, _ string) (*provisioning.Job, func(), error) {
 			claimActive.Add(1)
 			defer claimActive.Add(-1)
 			<-ctx.Done()

--- a/pkg/registry/apis/provisioning/jobs/store_mock.go
+++ b/pkg/registry/apis/provisioning/jobs/store_mock.go
@@ -23,9 +23,9 @@ func (_m *MockStore) EXPECT() *MockStore_Expecter {
 	return &MockStore_Expecter{mock: &_m.Mock}
 }
 
-// Claim provides a mock function with given fields: ctx, namespace, name
-func (_m *MockStore) Claim(ctx context.Context, namespace string, name string) (*v0alpha1.Job, func(), error) {
-	ret := _m.Called(ctx, namespace, name)
+// Claim provides a mock function with given fields: ctx, namespace, name, driverID
+func (_m *MockStore) Claim(ctx context.Context, namespace string, name string, driverID string) (*v0alpha1.Job, func(), error) {
+	ret := _m.Called(ctx, namespace, name, driverID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Claim")
@@ -34,27 +34,27 @@ func (_m *MockStore) Claim(ctx context.Context, namespace string, name string) (
 	var r0 *v0alpha1.Job
 	var r1 func()
 	var r2 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) (*v0alpha1.Job, func(), error)); ok {
-		return rf(ctx, namespace, name)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) (*v0alpha1.Job, func(), error)); ok {
+		return rf(ctx, namespace, name, driverID)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) *v0alpha1.Job); ok {
-		r0 = rf(ctx, namespace, name)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) *v0alpha1.Job); ok {
+		r0 = rf(ctx, namespace, name, driverID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*v0alpha1.Job)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, string) func()); ok {
-		r1 = rf(ctx, namespace, name)
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, string) func()); ok {
+		r1 = rf(ctx, namespace, name, driverID)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(func())
 		}
 	}
 
-	if rf, ok := ret.Get(2).(func(context.Context, string, string) error); ok {
-		r2 = rf(ctx, namespace, name)
+	if rf, ok := ret.Get(2).(func(context.Context, string, string, string) error); ok {
+		r2 = rf(ctx, namespace, name, driverID)
 	} else {
 		r2 = ret.Error(2)
 	}
@@ -71,13 +71,14 @@ type MockStore_Claim_Call struct {
 //   - ctx context.Context
 //   - namespace string
 //   - name string
-func (_e *MockStore_Expecter) Claim(ctx interface{}, namespace interface{}, name interface{}) *MockStore_Claim_Call {
-	return &MockStore_Claim_Call{Call: _e.mock.On("Claim", ctx, namespace, name)}
+//   - driverID string
+func (_e *MockStore_Expecter) Claim(ctx interface{}, namespace interface{}, name interface{}, driverID interface{}) *MockStore_Claim_Call {
+	return &MockStore_Claim_Call{Call: _e.mock.On("Claim", ctx, namespace, name, driverID)}
 }
 
-func (_c *MockStore_Claim_Call) Run(run func(ctx context.Context, namespace string, name string)) *MockStore_Claim_Call {
+func (_c *MockStore_Claim_Call) Run(run func(ctx context.Context, namespace string, name string, driverID string)) *MockStore_Claim_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string))
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[1].(string))
 	})
 	return _c
 }
@@ -87,7 +88,7 @@ func (_c *MockStore_Claim_Call) Return(job *v0alpha1.Job, rollback func(), err e
 	return _c
 }
 
-func (_c *MockStore_Claim_Call) RunAndReturn(run func(context.Context, string, string) (*v0alpha1.Job, func(), error)) *MockStore_Claim_Call {
+func (_c *MockStore_Claim_Call) RunAndReturn(run func(context.Context, string, string, string) (*v0alpha1.Job, func(), error)) *MockStore_Claim_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/registry/apis/provisioning/jobs/store_mock.go
+++ b/pkg/registry/apis/provisioning/jobs/store_mock.go
@@ -78,7 +78,7 @@ func (_e *MockStore_Expecter) Claim(ctx interface{}, namespace interface{}, name
 
 func (_c *MockStore_Claim_Call) Run(run func(ctx context.Context, namespace string, name string, driverID string)) *MockStore_Claim_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string), args[1].(string))
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string))
 	})
 	return _c
 }

--- a/pkg/registry/apis/provisioning/jobs/sync/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/worker.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"slices"
-	"time"
 
 	"github.com/grafana/grafana-app-sdk/logging"
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
@@ -90,11 +89,9 @@ func (r *SyncWorker) Process(ctx context.Context, repo repository.Repository, jo
 	)
 	defer span.End()
 
-	start := time.Now()
 	outcome := utils.ErrorOutcome
 	totalChangesMade := 0
 	defer func() {
-		r.metrics.RecordJob(string(provisioning.JobActionPull), outcome, totalChangesMade, time.Since(start).Seconds())
 		span.SetAttributes(
 			attribute.String("outcome", outcome),
 			attribute.Int("changes_made", totalChangesMade),


### PR DESCRIPTION
## What

Metrics to autoscale the provisioning **jobqueue controller** on worker saturation, plus a rework of the job outcome/duration metrics so they reflect the real job status. No full queue LIST is used.

### New metrics

Saturation (for autoscaling):
- `grafana_provisioning_jobs_in_flight{driver_id, action}` — gauge of busy worker slots; `Inc` on claim / `Dec` on release in the same goroutine (balanced across every exit path). Instantaneous utilization = `sum(jobs_in_flight) / sum(jobs_concurrent_driver_num_drivers)` (in-flight is disjoint per worker, so `sum` is safe).
- `grafana_provisioning_jobs_busy_seconds_total{driver_id, action}` — counter of full slot occupancy (claim → release, including completion and rollback), credited when the slot is released. Scrape-robust, time-averaged utilization: `sum(rate(jobs_busy_seconds_total[5m])) / sum(jobs_concurrent_driver_num_drivers)` (the gauge aliases on bursts of short jobs; this counter does not).

Claim behaviour — separate per-driver counters, one increment **per CAS attempt** (so contention is directly visible):
- `grafana_provisioning_jobs_claimed_total{driver_id}` — won the compare-and-swap race (this driver now owns the job).
- `grafana_provisioning_jobs_claim_conflicts_total{driver_id}` — lost the CAS race to another worker (retried).
- `grafana_provisioning_jobs_claim_errors_total{driver_id}` — the claiming update failed with a non-conflict error (identity/read failures return earlier and are not counted here).
- `grafana_provisioning_jobs_claim_rounds_contended_total{driver_id}` — lost to another worker: the job was already claimed when read, or all CAS retries were exhausted.

Contention signal: `rate(jobs_claim_conflicts_total) / rate(jobs_claimed_total)`.

### `processed_total` / `duration_seconds` now reflect job status
`grafana_provisioning_jobs_processed_total` and `grafana_provisioning_jobs_duration_seconds` are now recorded **by the driver** from the job's final status (`recorder.Complete`), instead of by each worker from its own return value.

Why:
- The worker-supplied `outcome` only reflected whether `Process` returned an error. A job that **completed with errors** — individual resource operations failed, but `Process` returned `nil` — was recorded as `success`, so slow/failing jobs were invisible. Recording from the job status makes `outcome` = `success` / `warning` / `error`, matching the status reported on the job.
- Only 4 of the workers recorded these metrics at all; recording in the driver covers **every** action uniformly.
- `duration` is driver-measured, so it is accurate even when a job times out.
- `duration_seconds` gained the `outcome` label and records all outcomes (failures use a sentinel `resources_changed_bucket=unknown`), enabling `histogram_quantile(0.95, rate(..._bucket{outcome="error"}[5m]))` to surface slow + failing jobs.

### Claim metric correctness (review fix)
- `queue_wait_seconds` is recorded **only after a successful claim**. It was previously observed before the atomic `Update`, so a worker that lost the claim race still recorded a wait for a job it never claimed — double-counting under contention.

### Not changed
- The existing `queue_size` gauge is left untouched.

## Why

Goal: autoscale the jobqueue controller up/down. A shared-queue worker pool scales on **saturation**, not on queue depth — and utilization (`in_flight` / `busy_seconds`) plus `queue_wait_seconds` latency are all reliable without listing the queue. Per-driver claim counters make contention (many replicas racing over few jobs) directly observable.

## Follow-ups (not in this PR)
- **Exact queue depth** — deliberately not provided: a cross-namespace "unclaimed job count" is expensive on current storage (label filtering is in-memory in apistore, `RemainingItemCount` is unset under selectors, `GetStats`/search can't express `claim DoesNotExist` cross-namespace). Utilization is the pragmatic proxy.
- **Vestigial worker `metrics` field** — the workers no longer use their injected `JobMetrics` for job-level recording (the driver does); the field/constructor param can be removed in a follow-up (kept here to avoid churning ~40 call sites).

## Tests
- `go test -race ./pkg/registry/apis/provisioning/jobs/...`
- `make gofmt`, `make lint-go-diff` — 0 issues

Related to grafana/git-ui-sync-project#1251.

🤖 Generated with [Claude Code](https://claude.com/claude-code)