### PR TITLE
Run the search manifest watcher as a managed subservice

### DIFF
--- a/pkg/storage/unified/sql/service.go
+++ b/pkg/storage/unified/sql/service.go
@@ -52,11 +52,6 @@ type service struct {
 	subservicesMngr    *services.Manager
 	subservicesWatcher *services.FailureWatcher
 
-	// manifestWatcher reloads search fields from the app-platform apiserver when
-	// configured. Created in registerServer (it needs the search registry that
-	// NewSearchOptions builds), started in starting(), nil when unconfigured.
-	manifestWatcher *resource.ManifestWatcher
-
 	// -- Shared Components
 	backend       resource.StorageBackend
 	vectorBackend vector.VectorBackend
@@ -131,18 +126,19 @@ func ProvideSearchGRPCService(cfg *setting.Cfg,
 	}
 	s.searchStandalone = true
 	if cfg.EnableSharding {
-		err := s.withRingLifecycle(memberlistKVConfig, httpServerRouter)
-		if err != nil {
+		if err := s.withRingLifecycle(memberlistKVConfig, httpServerRouter); err != nil {
 			return nil, err
-		}
-		err = s.initializeSubservicesManager()
-		if err != nil {
-			return nil, fmt.Errorf("failed to initialize subservices manager: %w", err)
 		}
 	}
 
+	// registerServer may add the manifest watcher to subservices, so it must run
+	// before the manager is built.
 	if err := s.registerServer(provider); err != nil {
 		return nil, err
+	}
+
+	if err := s.initializeSubservicesManager(); err != nil {
+		return nil, fmt.Errorf("failed to initialize subservices manager: %w", err)
 	}
 
 	s.BasicService = services.NewBasicService(s.starting, s.running, s.stopping).WithName(modules.SearchServer)
@@ -199,12 +195,14 @@ func ProvideUnifiedStorageGrpcService(cfg *setting.Cfg,
 		s.subservices = append(s.subservices, s.queue, s.scheduler)
 	}
 
-	if err := s.initializeSubservicesManager(); err != nil {
-		return nil, fmt.Errorf("failed to initialize subservices manager: %w", err)
-	}
-
+	// registerServer may add the manifest watcher to subservices, so it must run
+	// before the manager is built.
 	if err := s.registerServer(provider); err != nil {
 		return nil, err
+	}
+
+	if err := s.initializeSubservicesManager(); err != nil {
+		return nil, fmt.Errorf("failed to initialize subservices manager: %w", err)
 	}
 
 	s.BasicService = services.NewBasicService(s.starting, s.running, s.stopping).WithName(modules.StorageServer)
@@ -355,16 +353,6 @@ func (s *service) starting(ctx context.Context) error {
 		}
 	}
 
-	// Start the manifest watcher directly rather than through subservicesMngr,
-	// which is already built by the time registerServer creates the watcher. We
-	// don't wait for it: the initial poll reaches the apiserver and the periodic
-	// rebuild check applies any change afterwards.
-	if s.manifestWatcher != nil {
-		if err := s.manifestWatcher.StartAsync(ctx); err != nil {
-			return fmt.Errorf("failed to start manifest watcher: %w", err)
-		}
-	}
-
 	// TODO: move to standalone mode once we use sharding in search servers
 	if s.cfg.EnableSharding {
 		s.log.Info("waiting until resource server is JOINING in the ring")
@@ -413,10 +401,10 @@ func (s *service) registerServer(provider grpcserver.Provider) error {
 		return err
 	}
 
-	// Build the manifest watcher here because it reloads into the search registry
-	// that NewSearchOptions just created. registerServer runs at construction time
-	// (from the Provide* constructors), always before the service's starting()
-	// that starts it.
+	// When configured, run the manifest watcher as a subservice. It reloads into
+	// the search registry that NewSearchOptions just created; registerServer runs
+	// before initializeSubservicesManager, so the watcher joins the manager and
+	// its initial poll completes before the index is built.
 	if registry := searchOptions.SearchFields; registry != nil {
 		if mwCfg := resource.NewManifestWatcherConfig(s.cfg); mwCfg != nil {
 			watcher, err := resource.NewManifestWatcher(*mwCfg, func(live []appsdk.Manifest) {
@@ -429,7 +417,7 @@ func (s *service) registerServer(provider grpcserver.Provider) error {
 			if err != nil {
 				return err
 			}
-			s.manifestWatcher = watcher
+			s.subservices = append(s.subservices, watcher)
 		}
 	}
 
@@ -499,12 +487,6 @@ func (s *service) CheckHealth(ctx context.Context) (bool, error) {
 }
 
 func (s *service) stopping(_ error) error {
-	if s.manifestWatcher != nil {
-		s.manifestWatcher.StopAsync()
-		if err := s.manifestWatcher.AwaitTerminated(context.Background()); err != nil {
-			return fmt.Errorf("failed to stop manifest watcher: %w", err)
-		}
-	}
 	if s.subservicesMngr != nil {
 		err := services.StopManagerAndAwaitStopped(context.Background(), s.subservicesMngr)
 		if err != nil {


### PR DESCRIPTION
The search manifest watcher was started and stopped outside the background-service manager, because the code that creates it runs after the manager is already built, so it couldn't join it. This reorders the two service constructors so the watcher is created first and registered as a normal managed service, and drops the separate start/stop.

The reorder also removes a subtle startup cost: the manager starts and waits for its services before the search indexes are built, so the watcher's first read of the manifests now lands before the first index build. Previously that build could run against the compiled-in fields and then get rebuilt once the watcher caught up — a redundant reindex on restart. It only runs when configured, so there's no change by default.

Part of grafana/search-and-storage-team#827.
