### PR TITLE
Command palette: Add target to events

### DIFF
--- a/public/app/features/commandPalette/CommandPalette.test.tsx
+++ b/public/app/features/commandPalette/CommandPalette.test.tsx
@@ -15,6 +15,7 @@ import { backendSrv } from 'app/core/services/backend_srv';
 import { getObservablePluginLinks } from '../plugins/extensions/getPluginExtensions';
 
 import { CommandPalette } from './CommandPalette';
+import { type CommandPaletteAction } from './types';
 
 setPluginLinksHook(() => ({
   links: [],
@@ -357,6 +358,44 @@ describe('CommandPalette', () => {
           isDeepSearchLoaded: true,
           deepSearchItemsCount: 2,
           itemsCount: expect.any(Number),
+          target: '/d/dash-1',
+        })
+      );
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('reports the destination url as target when a navigational keyword result is clicked', async () => {
+      // Clicking the row's real <a href> makes jsdom log an (unimplemented)
+      // navigation error — suppress it; we only care about the report
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const actions: CommandPaletteAction[] = [
+        {
+          id: 'test/latency-dashboard',
+          name: 'Latency overview',
+          section: 'Dashboards',
+          sectionId: 'dashboards',
+          priority: 1,
+          url: '/d/abc123',
+        },
+      ];
+      render(
+        <KBarProvider actions={actions}>
+          <CommandPalette />
+        </KBarProvider>
+      );
+      const user = userEvent.setup();
+      await user.type(screen.getByPlaceholderText('Search or jump to...'), 'Latency overview');
+
+      const option = await screen.findByRole('option', { name: /Latency overview/ }, { timeout: 3000 });
+      await user.click(option);
+
+      expect(reportInteraction).toHaveBeenCalledWith(
+        'command_palette_action_selected',
+        expect.objectContaining({
+          actionId: 'test/latency-dashboard',
+          section: 'dashboards',
+          isDeepSearchAction: false,
+          target: '/d/abc123',
         })
       );
       consoleErrorSpy.mockRestore();
@@ -380,6 +419,8 @@ describe('CommandPalette', () => {
           // Stable slug, not the translated section header ("Preferences")
           section: 'preferences',
           itemsCount: expect.any(Number),
+          // Change theme executes in place — no destination to report
+          target: undefined,
         })
       );
     });

--- a/public/app/features/commandPalette/CommandPalette.tsx
+++ b/public/app/features/commandPalette/CommandPalette.tsx
@@ -257,7 +257,14 @@ const RenderResults = ({
   // Analytics: single place to assemble the command_palette_action_selected payload,
   // shared by the keyword list and the deep search column.
   const reportActionSelected = useCallback(
-    (params: { actionId?: string; actionName?: string; index: number; section?: string; deepSearch: boolean }) => {
+    (params: {
+      actionId?: string;
+      actionName?: string;
+      index: number;
+      section?: string;
+      deepSearch: boolean;
+      url?: string;
+    }) => {
       reportInteraction('command_palette_action_selected', {
         actionId: params.actionId,
         actionName: params.actionName,
@@ -266,6 +273,8 @@ const RenderResults = ({
         // Stable, language-agnostic section slug from the action's sectionId, e.g.
         // "recent-dashboards" / "pages" / "deep-search"
         section: params.section,
+        // Destination URL of the dashboard/page, unset for actions that don't navigate
+        target: params.url,
         isDeepSearchEnabled: deepSearchEnabled,
         isDeepSearchAction: params.deepSearch,
         // Whether the deep search column had finished loading at selection time
@@ -485,13 +494,14 @@ const RenderResults = ({
             maxHeight={650}
             scrollRef={keywordListRef}
             legacyKeyboard={!deepSearchEnabled}
-            onItemSelected={(item, rawIndex) =>
+            onItemSelected={(item, rawIndex, url) =>
               reportActionSelected({
                 actionId: item.id,
                 actionName: item.name,
                 index: items.slice(0, rawIndex).filter((entry) => typeof entry !== 'string').length,
                 section: getActionSectionId(item),
                 deepSearch: false,
+                url,
               })
             }
             onRender={({ item, active }) => {
@@ -522,6 +532,7 @@ const RenderResults = ({
                 index,
                 section: SECTION_DEEP_SEARCH,
                 deepSearch: true,
+                url: deepSearchResults[index]?.url,
               })
             }
             navRef={deepSearchNavRef}

--- a/public/app/features/commandPalette/KBarResults.tsx
+++ b/public/app/features/commandPalette/KBarResults.tsx
@@ -23,9 +23,10 @@ interface KBarResultsProps {
   scrollRef?: React.MutableRefObject<HTMLDivElement | null>;
   /**
    * Called when an item is selected (click or keyboard Enter, which dispatches a
-   * click on the row). Receives the raw index into `items`, for analytics.
+   * click on the row). Receives the raw index into `items` and, for navigation
+   * items, the resolved destination url (same value as the row's href), for analytics.
    */
-  onItemSelected?: (item: ActionImpl, index: number) => void;
+  onItemSelected?: (item: ActionImpl, index: number, url?: string) => void;
   /**
    * Use the legacy (pre-deep-search) keyboard model: this component owns
    * arrow/Enter navigation over the single list and auto-selects the first item.
@@ -235,7 +236,7 @@ export const KBarResults = (props: KBarResultsProps) => {
             onPointerDown: () => query.setActiveIndex(virtualRow.index),
             onClick: (ev: React.MouseEvent) => {
               // Report before perform, since perform may close the palette / navigate away
-              props.onItemSelected?.(item, virtualRow.index);
+              props.onItemSelected?.(item, virtualRow.index, typeof url === 'function' ? url(search) : url);
               execute(ev, item);
             },
           };


### PR DESCRIPTION
This should allow us to directly join click events to page view events and then make it easier to compute bounce rate from search.