### PR TITLE
IAM: Populate authLabels on the user search endpoints

### DIFF
--- a/pkg/api/org_users.go
+++ b/pkg/api/org_users.go
@@ -408,21 +408,33 @@ func (hs *HTTPServer) searchOrgUsersUsingK8s(c *contextmodel.ReqContext, query *
 		if query.UserID != 0 && u.ID != query.UserID {
 			continue
 		}
+
+		authLabels := make([]string, 0, len(u.AuthModule))
+		isExternallySynced := false
+		for _, module := range u.AuthModule {
+			authLabels = append(authLabels, login.GetAuthProviderLabel(module))
+			if hs.isExternallySynced(hs.Cfg, module) {
+				isExternallySynced = true
+			}
+		}
+
 		orgUsers = append(orgUsers, &org.OrgUserDTO{
-			OrgID:         query.OrgID,
-			UserID:        u.ID,
-			UID:           u.UID,
-			Email:         u.Email,
-			Name:          u.Name,
-			Login:         u.Login,
-			Role:          u.Role,
-			AvatarURL:     dtos.GetGravatarUrl(hs.Cfg, u.Email),
-			AccessControl: u.AccessControl,
-			LastSeenAt:    u.LastSeenAt,
-			LastSeenAtAge: u.LastSeenAtAge,
-			Created:       u.Created,
-			IsDisabled:    u.IsDisabled,
-			IsProvisioned: u.IsProvisioned,
+			OrgID:              query.OrgID,
+			UserID:             u.ID,
+			UID:                u.UID,
+			Email:              u.Email,
+			Name:               u.Name,
+			Login:              u.Login,
+			Role:               u.Role,
+			AvatarURL:          dtos.GetGravatarUrl(hs.Cfg, u.Email),
+			AccessControl:      u.AccessControl,
+			LastSeenAt:         u.LastSeenAt,
+			LastSeenAtAge:      u.LastSeenAtAge,
+			Created:            u.Created,
+			IsDisabled:         u.IsDisabled,
+			IsProvisioned:      u.IsProvisioned,
+			AuthLabels:         authLabels,
+			IsExternallySynced: isExternallySynced,
 		})
 	}
 

--- a/pkg/api/org_users_test.go
+++ b/pkg/api/org_users_test.go
@@ -784,13 +784,16 @@ func TestSearchOrgUsersUsingK8s(t *testing.T) {
 			Created:       created,
 			IsDisabled:    true,
 			IsProvisioned: true,
+			AuthModule:    user.AuthModuleConversion{login.LDAPAuthModule},
 		},
 		{ID: 99, UID: "uid-two", Login: "other", Role: "Viewer"},
 	}
 
 	newHS := func() *HTTPServer {
+		cfg := setting.NewCfg()
+		cfg.LDAPAuthEnabled = true
 		return &HTTPServer{
-			Cfg: setting.NewCfg(),
+			Cfg: cfg,
 			userService: &usertest.FakeUserService{
 				ExpectedSearchUsers: user.SearchUserQueryResult{TotalCount: 2, Users: hits, Page: 1, PerPage: 50},
 			},
@@ -821,6 +824,13 @@ func TestSearchOrgUsersUsingK8s(t *testing.T) {
 		assert.True(t, got.IsProvisioned)
 		assert.Equal(t, map[string]bool{"org.users:write": true}, got.AccessControl)
 		assert.NotEmpty(t, got.AvatarURL)
+		assert.Equal(t, []string{login.LDAPLabel}, got.AuthLabels)
+		assert.True(t, got.IsExternallySynced)
+
+		// A user without auth modules has no labels and is not externally synced.
+		other := res.OrgUsers[1]
+		assert.Empty(t, other.AuthLabels)
+		assert.False(t, other.IsExternallySynced)
 	})
 
 	t.Run("filters by UserID and adjusts total", func(t *testing.T) {

--- a/pkg/registry/apis/iam/user/legacy_search.go
+++ b/pkg/registry/apis/iam/user/legacy_search.go
@@ -30,14 +30,15 @@ const (
 )
 
 var (
-	_                resourcepb.ResourceIndexClient = (*UserLegacySearchClient)(nil)
-	fieldLogin                                      = fmt.Sprintf("%s%s", resource.SEARCH_FIELD_PREFIX, builders.USER_LOGIN)
-	fieldEmail                                      = fmt.Sprintf("%s%s", resource.SEARCH_FIELD_PREFIX, builders.USER_EMAIL)
-	fieldLastSeenAt                                 = fmt.Sprintf("%s%s", resource.SEARCH_FIELD_PREFIX, builders.USER_LAST_SEEN_AT)
-	fieldRole                                       = fmt.Sprintf("%s%s", resource.SEARCH_FIELD_PREFIX, builders.USER_ROLE)
-	fieldDisabled                                   = fmt.Sprintf("%s%s", resource.SEARCH_FIELD_PREFIX, builders.USER_DISABLED)
-	legacyIDField                                   = resource.SEARCH_FIELD_LABELS + "." + resource.SEARCH_FIELD_LEGACY_ID
-	wildcardsMatcher                                = regexp.MustCompile(`[\*\?\\]`)
+	_                        resourcepb.ResourceIndexClient = (*UserLegacySearchClient)(nil)
+	fieldLogin                                              = fmt.Sprintf("%s%s", resource.SEARCH_FIELD_PREFIX, builders.USER_LOGIN)
+	fieldEmail                                              = fmt.Sprintf("%s%s", resource.SEARCH_FIELD_PREFIX, builders.USER_EMAIL)
+	fieldLastSeenAt                                         = fmt.Sprintf("%s%s", resource.SEARCH_FIELD_PREFIX, builders.USER_LAST_SEEN_AT)
+	fieldRole                                               = fmt.Sprintf("%s%s", resource.SEARCH_FIELD_PREFIX, builders.USER_ROLE)
+	fieldDisabled                                           = fmt.Sprintf("%s%s", resource.SEARCH_FIELD_PREFIX, builders.USER_DISABLED)
+	fieldExternalAuthModules                                = fmt.Sprintf("%s%s", resource.SEARCH_FIELD_PREFIX, builders.USER_EXTERNAL_AUTH_MODULES)
+	legacyIDField                                           = resource.SEARCH_FIELD_LABELS + "." + resource.SEARCH_FIELD_LEGACY_ID
+	wildcardsMatcher                                        = regexp.MustCompile(`[\*\?\\]`)
 
 	userSortFieldMapping = map[string]string{
 		fieldLastSeenAt:             "lastSeenAtAge",

--- a/pkg/registry/apis/iam/user/search.go
+++ b/pkg/registry/apis/iam/user/search.go
@@ -296,7 +296,7 @@ func (s *SearchHandler) DoSearch(w http.ResponseWriter, r *http.Request) {
 			},
 		},
 		Query:  searchQuery,
-		Fields: []string{resource.SEARCH_FIELD_TITLE, fieldEmail, fieldLogin, fieldLastSeenAt, fieldRole, fieldDisabled, resource.SEARCH_FIELD_CREATED, legacyIDField},
+		Fields: []string{resource.SEARCH_FIELD_TITLE, fieldEmail, fieldLogin, fieldLastSeenAt, fieldRole, fieldDisabled, fieldExternalAuthModules, resource.SEARCH_FIELD_CREATED, legacyIDField},
 		// The query is a wildcard (*...*), so only Name is used from each
 		// QueryField to specify which fields to search in (Type and Boost
 		// are ignored for wildcard queries).
@@ -497,6 +497,12 @@ func parseUserHit(row *resourcepb.ResourceTableRow, colIdx map[string]int) iamv0
 	if b := cell(builders.USER_LAST_SEEN_AT); len(b) == 8 {
 		hit.LastSeenAt = int64(binary.BigEndian.Uint64(b))
 		hit.LastSeenAtAge = util.GetAgeString(time.Unix(hit.LastSeenAt, 0))
+	}
+	if b := cell(builders.USER_EXTERNAL_AUTH_MODULES); len(b) > 0 {
+		var modules []string
+		if err := json.Unmarshal(b, &modules); err == nil {
+			hit.ExternalAuthModules = modules
+		}
 	}
 
 	return hit

--- a/pkg/registry/apis/iam/user/search_test.go
+++ b/pkg/registry/apis/iam/user/search_test.go
@@ -487,6 +487,7 @@ func TestParseResults(t *testing.T) {
 		{Name: builders.USER_LAST_SEEN_AT},
 		{Name: builders.USER_ROLE},
 		{Name: builders.USER_DISABLED},
+		{Name: builders.USER_EXTERNAL_AUTH_MODULES},
 		{Name: resource.SEARCH_FIELD_CREATED},
 		{Name: legacyIDField},
 	}
@@ -542,6 +543,7 @@ func TestParseResults(t *testing.T) {
 							i64(lastSeen),
 							[]byte("Admin"),
 							{1},
+							[]byte(`["authproxy","ldap"]`),
 							i64(created),
 							[]byte("42"),
 						},
@@ -549,7 +551,7 @@ func TestParseResults(t *testing.T) {
 					// Second row exercises zero/empty cells -> fields keep zero values.
 					{
 						Key:   &resourcepb.ResourceKey{Name: "uid-2"},
-						Cells: [][]byte{[]byte("Jane"), nil, []byte("jane"), nil, []byte("Viewer"), {0}, nil, nil},
+						Cells: [][]byte{[]byte("Jane"), nil, []byte("jane"), nil, []byte("Viewer"), {0}, nil, nil, nil},
 					},
 				},
 			},
@@ -571,6 +573,7 @@ func TestParseResults(t *testing.T) {
 		assert.Equal(t, lastSeen, full.LastSeenAt)
 		assert.NotEmpty(t, full.LastSeenAtAge)
 		assert.True(t, full.Disabled)
+		assert.Equal(t, []string{"authproxy", "ldap"}, full.ExternalAuthModules)
 		assert.Equal(t, created, full.Created)
 		assert.Equal(t, int64(42), full.InternalId)
 
@@ -583,6 +586,7 @@ func TestParseResults(t *testing.T) {
 		assert.Zero(t, sparse.LastSeenAt)
 		assert.Empty(t, sparse.LastSeenAtAge)
 		assert.False(t, sparse.Disabled)
+		assert.Empty(t, sparse.ExternalAuthModules)
 		assert.Zero(t, sparse.Created)
 		assert.Zero(t, sparse.InternalId)
 	})

--- a/pkg/services/user/userk8s/user.go
+++ b/pkg/services/user/userk8s/user.go
@@ -707,6 +707,7 @@ func (s *UserK8sService) Search(ctx context.Context, cmd *user.SearchUsersQuery)
 			Created:       time.UnixMilli(hit.Created),
 			IsDisabled:    hit.Disabled,
 			IsProvisioned: hit.Provisioned,
+			AuthModule:    user.AuthModuleConversion(hit.ExternalAuthModules),
 		})
 	}
 

--- a/pkg/tests/apis/iam/user/user_service_integration_test.go
+++ b/pkg/tests/apis/iam/user/user_service_integration_test.go
@@ -1,12 +1,14 @@
 package user
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
@@ -374,12 +376,13 @@ func TestIntegrationUserServiceSearch(t *testing.T) {
 	}
 
 	type searchUserHit struct {
-		ID      int64     `json:"id"`
-		UID     string    `json:"uid"`
-		Name    string    `json:"name"`
-		Login   string    `json:"login"`
-		Email   string    `json:"email"`
-		Created time.Time `json:"created"`
+		ID         int64     `json:"id"`
+		UID        string    `json:"uid"`
+		Name       string    `json:"name"`
+		Login      string    `json:"login"`
+		Email      string    `json:"email"`
+		Created    time.Time `json:"created"`
+		AuthLabels []string  `json:"authLabels"`
 	}
 
 	type searchUsersResponse struct {
@@ -428,6 +431,23 @@ func TestIntegrationUserServiceSearch(t *testing.T) {
 			require.NotEmpty(t, betaUser.Result.UID)
 			require.NotZero(t, betaUser.Result.ID)
 
+			// Give alpha-user an external auth module so the search response carries its provider labels.
+			userClient := helper.GetResourceClient(apis.ResourceClientArgs{
+				User:      helper.Org1.Admin,
+				Namespace: helper.Namespacer(helper.Org1.Admin.Identity.GetOrgID()),
+				GVR:       gvrUsers,
+			})
+			ctx := context.Background()
+			alphaObj, err := userClient.Resource.Get(ctx, alphaUser.Result.UID, metav1.GetOptions{})
+			require.NoError(t, err)
+			alphaSpec := alphaObj.Object["spec"].(map[string]interface{})
+			alphaSpec["externalAuthInfo"] = []interface{}{
+				map[string]interface{}{"module": "ldap", "authID": "alpha-ldap"},
+			}
+			alphaObj.Object["spec"] = alphaSpec
+			_, err = userClient.Resource.Update(ctx, alphaObj, metav1.UpdateOptions{})
+			require.NoError(t, err)
+
 			// Wait for the search index to be populated.
 			time.Sleep(2 * time.Second)
 
@@ -466,6 +486,11 @@ func TestIntegrationUserServiceSearch(t *testing.T) {
 				require.Equal(t, "alpha@example.com", hit.Email)
 				require.Equal(t, alphaUser.Result.ID, hit.ID)
 				require.False(t, hit.Created.IsZero(), "created timestamp should be populated")
+				if mode >= rest.Mode4 {
+					require.Equal(t, []string{"LDAP"}, hit.AuthLabels, "external auth module should map to an auth label")
+				} else {
+					require.Empty(t, hit.AuthLabels, "legacy SQL search does not surface external auth modules")
+				}
 			})
 
 			t.Run("should filter results by query", func(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Consumes the `externalAuthModules` search field (added in https://github.com/grafana/grafana/pull/128876) so `authLabels` and `isExternallySynced` are populated on the user list/search endpoints when `kubernetesUsersRedirect` is on.

**Why do we need this feature?**

Under `kubernetesUsersRedirect`, /api/users, /api/users/search, and /api/org/users* are served from the search index. The index now carries the user's external auth modules, but nothing was reading them, so these responses returned empty `authLabels`. This was a regression vs the legacy SQL path, which derives labels from the `user_auth` table.

**Who is this feature for?**

all users

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
