### PR TITLE
Actions: Add PUT to HTTP request method options

### DIFF
--- a/packages/grafana-data/src/types/action.ts
+++ b/packages/grafana-data/src/types/action.ts
@@ -65,6 +65,7 @@ export enum HttpRequestMethod {
 
 export const httpMethodOptions: SelectableValue[] = [
   { label: HttpRequestMethod.POST, value: HttpRequestMethod.POST },
+  { label: HttpRequestMethod.PUT, value: HttpRequestMethod.PUT },
   { label: HttpRequestMethod.GET, value: HttpRequestMethod.GET },
 ];
 


### PR DESCRIPTION
**What is this feature?**

Adds `PUT` back to the Method picker in the data actions editor (`httpMethodOptions` in `@grafana/data`). The picker currently only offers `POST` and `GET`.

**Why do we need this feature?**

This is a regression: the [documentation](https://grafana.com/docs/grafana/v13.0/visualizations/panels-visualizations/configure-data-links/#add-a-data-link) states the Method options are POST, PUT, GET, and the PUT option was present in Grafana 12.1. The `HttpRequestMethod` enum (and the dashboard schema) still includes `PUT`, so existing dashboards can already contain PUT actions — the editor UI just no longer offers it.

Only `PUT` is added here, to match the documented behavior and restore what was lost. The enum also contains `DELETE`/`PATCH`, but exposing those in the UI would be a new feature rather than a regression fix and can be discussed separately.

**Who is this feature for?**

Dashboard users configuring data actions (e.g. on table panels) that need to call HTTP endpoints with the PUT method.

**Which issue(s) does this PR fix?**:

Fixes #128915

**Special notes for your reviewer:**

This is a one-line option addition mirroring the two existing entries; the action execution path already handles any non-GET method by sending a request body (`public/app/features/actions/utils.ts`), so no other code changes are needed. I was unable to run the full frontend build locally, so this relies on CI for typecheck/tests.

Please check that:

- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
