### PR TITLE
Table: Announce correct row count to screen readers in virtualized table

### DIFF
--- a/packages/grafana-ui/src/components/Table/Table.test.tsx
+++ b/packages/grafana-ui/src/components/Table/Table.test.tsx
@@ -216,6 +216,23 @@ describe('Table', () => {
         { time: '2021-01-01 02:00:00', temperature: '12', link: '${__value.text} interpolation' },
       ]);
     });
+
+    it('then the total row count and row indexes should be announced to screen readers', () => {
+      getTestContext();
+      // 4 data rows + 1 header row
+      expect(getTable()).toHaveAttribute('aria-rowcount', '5');
+
+      const rows = within(getTable()).getAllByRole('row');
+      expect(rows.map((row) => row.getAttribute('aria-rowindex'))).toEqual(['1', '2', '3', '4', '5']);
+    });
+
+    it('and noHeader is set, then the header row should be excluded from the row count', () => {
+      getTestContext({ noHeader: true });
+      expect(getTable()).toHaveAttribute('aria-rowcount', '4');
+
+      const rows = within(getTable()).getAllByRole('row');
+      expect(rows.map((row) => row.getAttribute('aria-rowindex'))).toEqual(['1', '2', '3', '4']);
+    });
   });
 
   describe('when mounted with footer', () => {

--- a/packages/grafana-ui/src/components/Table/TableRT/HeaderRow.tsx
+++ b/packages/grafana-ui/src/components/Table/TableRT/HeaderRow.tsx
@@ -31,6 +31,7 @@ export const HeaderRow = (props: HeaderRowProps) => {
             {...headerGroupProps}
             key={key}
             aria-label={e2eSelectorsTable.header}
+            aria-rowindex={1}
             role="row"
           >
             {headerGroup.headers.map((column: Column, index: number) =>

--- a/packages/grafana-ui/src/components/Table/TableRT/RowsList.tsx
+++ b/packages/grafana-ui/src/components/Table/TableRT/RowsList.tsx
@@ -41,6 +41,7 @@ interface RowsListProps {
   headerHeight: number;
   rowHeight: number;
   itemCount: number;
+  noHeader?: boolean;
   pageIndex: number;
   listHeight: number;
   width: number;
@@ -70,6 +71,7 @@ export const RowsList = (props: RowsListProps) => {
     footerPaginationEnabled,
     rowHeight,
     itemCount,
+    noHeader,
     pageIndex,
     tableState,
     prepareRow,
@@ -276,7 +278,12 @@ export const RowsList = (props: RowsListProps) => {
     ({ index, style, rowHighlightIndex }: { index: number; style: CSSProperties; rowHighlightIndex?: number }) => {
       const indexForPagination = rowIndexForPagination(index);
       const row = rows[indexForPagination];
-      let additionalProps: React.HTMLAttributes<HTMLDivElement> = {};
+      const additionalProps: React.HTMLAttributes<HTMLDivElement> = {
+        // ARIA row indexes are 1-based, include the header row and, with pagination,
+        // span all pages. Virtualization only renders the visible rows, so without this
+        // screen readers would announce positions within the rendered subset only.
+        'aria-rowindex': indexForPagination + (noHeader ? 1 : 2),
+      };
       prepareRow(row);
 
       const expandedRowStyle = tableState.expanded[row.id] ? css({ '&:hover': { background: 'inherit' } }) : {};
@@ -284,9 +291,7 @@ export const RowsList = (props: RowsListProps) => {
 
       if (rowHighlightIndex !== undefined && row.index === rowHighlightIndex) {
         style = { ...style, backgroundColor: theme.components.table.rowSelected };
-        additionalProps = {
-          'aria-selected': 'true',
-        };
+        additionalProps['aria-selected'] = 'true';
       }
 
       // Color rows if enabled
@@ -361,6 +366,7 @@ export const RowsList = (props: RowsListProps) => {
     [
       rowIndexForPagination,
       rows,
+      noHeader,
       prepareRow,
       tableState.expanded,
       nestedDataField,

--- a/packages/grafana-ui/src/components/Table/TableRT/Table.tsx
+++ b/packages/grafana-ui/src/components/Table/TableRT/Table.tsx
@@ -283,6 +283,10 @@ export const Table = memo((props: Props) => {
   );
 
   const itemCount = enablePagination ? page.length : rows.length;
+
+  // Virtualization means only the visible rows exist in the DOM, so we announce the real
+  // row count to screen readers. ARIA row counts are 1-based and include the header row.
+  const ariaRowCount = (noHeader ? 0 : 1) + rows.length;
   let paginationEl = null;
   if (enablePagination) {
     const itemsRangeStart = state.pageIndex * state.pageSize + 1;
@@ -338,6 +342,7 @@ export const Table = memo((props: Props) => {
         {...getTableProps()}
         className={tableStyles.table}
         aria-label={ariaLabel}
+        aria-rowcount={ariaRowCount}
         role="table"
         ref={tableDivRef}
         style={{ width, height }}
@@ -361,6 +366,7 @@ export const Table = memo((props: Props) => {
                   headerHeight={headerHeight}
                   rowHeight={tableStyles.rowHeight}
                   itemCount={itemCount}
+                  noHeader={noHeader}
                   pageIndex={state.pageIndex}
                   listHeight={listHeight}
                   listRef={listRef}


### PR DESCRIPTION
**What is this feature?**

Adds `aria-rowcount` to the TableRT table element and `aria-rowindex` to the header row and each data row. Because the table body is virtualized with `react-window`, only the visible rows exist in the DOM, so screen readers previously counted just those and announced an incorrect total (e.g. "row 11 of 11" on much larger tables). With pagination enabled, row indexes now also span all pages rather than resetting per page.

**Why do we need this feature?**

Screen reader users get a wrong picture of how much data a table contains, both in the panel Data tab and in Explore. This is a WCAG 4.1.2 (Name, Role, Value) Level A issue.

**Who is this feature for?**

Screen reader users navigating tables rendered with the TableRT component (table panel data views, Explore).

**Which issue(s) does this PR fix?**:

Fixes #118774

**Special notes for your reviewer:**

 - Browser support for this seems to be inconsistent. Firefox + macOS Voicecver didn't use the `aria-rowcount` - it just still said the number of virtual rows rendered. Chrome + Voiceover correctly said the total count of rows

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
