### PR TITLE
Home: Recommend enabled solutions that receive no data

### DIFF
--- a/public/app/features/home/Recommendations/NoDataCard.tsx
+++ b/public/app/features/home/Recommendations/NoDataCard.tsx
@@ -9,6 +9,7 @@ import { ROUTES as CONNECTIONS_ROUTES } from 'app/features/connections/constants
 
 import { ctaClicked } from '../analytics/main';
 
+import { SYNTHETIC_MONITORING_APP_ID } from './appPluginIds';
 import { KUBERNETES_APP_ID } from './kubernetesData';
 
 interface PopularSolution {
@@ -32,7 +33,7 @@ function getPopularSolutions(): PopularSolution[] {
     },
     {
       id: 'synthetic-monitoring',
-      pluginId: 'grafana-synthetic-monitoring-app',
+      pluginId: SYNTHETIC_MONITORING_APP_ID,
       label: t('home.recommendations.no-data.solution-synthetics', 'Synthetic Monitoring'),
       icon: 'globe',
       appPath: '/home',

--- a/public/app/features/home/Recommendations/RecommendationCard.tsx
+++ b/public/app/features/home/Recommendations/RecommendationCard.tsx
@@ -42,7 +42,7 @@ export function RecommendationCard({ recommendation }: RecommendationCardProps) 
           onClick={() =>
             ctaClicked({
               surface: 'recommendations',
-              action: 'enable',
+              action: recommendation.cta ?? 'enable',
               placement: 'card',
               recommendation_id: recommendation.id,
             })

--- a/public/app/features/home/Recommendations/RecommendationPill.tsx
+++ b/public/app/features/home/Recommendations/RecommendationPill.tsx
@@ -24,7 +24,7 @@ export function RecommendationPill({ recommendation }: RecommendationPillProps) 
       onClick={() =>
         ctaClicked({
           surface: 'recommendations',
-          action: 'enable',
+          action: recommendation.cta ?? 'enable',
           placement: 'pill',
           recommendation_id: recommendation.id,
         })

--- a/public/app/features/home/Recommendations/Recommendations.test.tsx
+++ b/public/app/features/home/Recommendations/Recommendations.test.tsx
@@ -17,6 +17,7 @@ import {
   fetchKubernetesInventory,
   resolveKubernetesDatasource,
 } from './kubernetesData';
+import { hasSolutionData } from './solutionDataProbes';
 
 const mockGet = jest.fn();
 jest.mock('@grafana/runtime', () => ({
@@ -48,6 +49,12 @@ jest.mock('./kubernetesData', () => ({
   fetchClusterCpuSeries: jest.fn().mockResolvedValue(null),
 }));
 
+// Enabled solutions report data by default so the pre-probe expectations (enabled -> hidden)
+// keep holding; individual tests flip specific solutions to the no-data state.
+jest.mock('./solutionDataProbes', () => ({
+  hasSolutionData: jest.fn().mockResolvedValue(true),
+}));
+
 const APP_IDS = [
   'grafana-exploretraces-app',
   'grafana-synthetic-monitoring-app',
@@ -57,7 +64,7 @@ const APP_IDS = [
 const listItem = (id: string, overrides: Partial<LocalPlugin> = {}) => ({
   id,
   enabled: false,
-  accessControl: { [AccessControlAction.PluginsWrite]: true },
+  accessControl: { [AccessControlAction.PluginsWrite]: true, [AccessControlAction.PluginsAppAccess]: true },
   ...overrides,
 });
 
@@ -74,6 +81,8 @@ beforeEach(() => {
   });
   mockGet.mockReset();
   mockGet.mockResolvedValue(APP_IDS.map((id) => listItem(id)));
+  jest.mocked(hasSolutionData).mockReset();
+  jest.mocked(hasSolutionData).mockResolvedValue(true);
   jest.spyOn(contextSrv, 'hasPermission').mockReturnValue(true);
 });
 
@@ -114,7 +123,7 @@ describe('Recommendations', () => {
     expect(mockUsePluginBridge).not.toHaveBeenCalled();
   });
 
-  it('drops recommendations whose app is already enabled', async () => {
+  it('drops recommendations whose app is already enabled and receiving data', async () => {
     mockGet.mockResolvedValue(
       APP_IDS.map((id) =>
         listItem(id, {
@@ -127,6 +136,48 @@ describe('Recommendations', () => {
 
     expect(await screen.findByRole('link', { name: /Enable Application Observability/ })).toBeInTheDocument();
     expect(screen.queryByRole('link', { name: /Enable Hosted Traces/ })).not.toBeInTheDocument();
+  });
+
+  it('keeps recommending an enabled app that has no data, with a setup CTA into the app', async () => {
+    jest
+      .mocked(hasSolutionData)
+      .mockImplementation(async (pluginId: string) => pluginId !== 'grafana-synthetic-monitoring-app');
+    mockGet.mockResolvedValue(APP_IDS.map((id) => listItem(id, { enabled: true })));
+
+    render(<Recommendations />);
+
+    const setupLink = await screen.findByRole('link', { name: /Set up Synthetic Monitoring/, hidden: true });
+    expect(setupLink).toHaveAttribute('href', '/a/grafana-synthetic-monitoring-app');
+    expect(screen.queryByRole('link', { name: /Enable Hosted Traces/, hidden: true })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /Add Synthetic Monitoring/, hidden: true })).not.toBeInTheDocument();
+  });
+
+  it('hides the section when every enabled app has data', async () => {
+    mockGet.mockResolvedValue(APP_IDS.map((id) => listItem(id, { enabled: true })));
+
+    const { container } = render(<Recommendations />);
+
+    await waitFor(() => expect(container).toBeEmptyDOMElement());
+  });
+
+  it('hides the setup card when the user lacks app access to the silent app', async () => {
+    jest.mocked(hasSolutionData).mockResolvedValue(false);
+    mockGet.mockResolvedValue(
+      APP_IDS.map((id) =>
+        listItem(id, {
+          enabled: true,
+          accessControl:
+            id === 'grafana-synthetic-monitoring-app'
+              ? { [AccessControlAction.PluginsWrite]: true }
+              : { [AccessControlAction.PluginsWrite]: true, [AccessControlAction.PluginsAppAccess]: true },
+        })
+      )
+    );
+
+    render(<Recommendations />);
+
+    expect(await screen.findByRole('link', { name: /Set up Hosted Traces/, hidden: true })).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /Set up Synthetic Monitoring/, hidden: true })).not.toBeInTheDocument();
   });
 
   it('shows installed-but-disabled cards but hides not-installed cards for a write-only user', async () => {

--- a/public/app/features/home/Recommendations/Recommendations.test.tsx
+++ b/public/app/features/home/Recommendations/Recommendations.test.tsx
@@ -182,7 +182,7 @@ describe('Recommendations', () => {
     render(<Recommendations />);
 
     const setupLink = await screen.findByRole('link', { name: /Set up Synthetic Monitoring/, hidden: true });
-    expect(setupLink).toHaveAttribute('href', '/a/grafana-synthetic-monitoring-app');
+    expect(setupLink).toHaveAttribute('href', '/a/grafana-synthetic-monitoring-app/home');
     expect(screen.queryByRole('link', { name: /Enable Hosted Traces/, hidden: true })).not.toBeInTheDocument();
     expect(screen.queryByRole('link', { name: /Add Synthetic Monitoring/, hidden: true })).not.toBeInTheDocument();
   });

--- a/public/app/features/home/Recommendations/Recommendations.test.tsx
+++ b/public/app/features/home/Recommendations/Recommendations.test.tsx
@@ -97,6 +97,41 @@ describe('Recommendations', () => {
     await waitFor(() => expect(container).toBeEmptyDOMElement());
   });
 
+  it('holds a skeleton while loading when the section was visible on the last visit', async () => {
+    window.localStorage.setItem('grafana.home.recommendations.was-visible', 'true');
+    mockGet.mockImplementation(() => new Promise(() => {}));
+
+    render(<Recommendations />);
+
+    expect(await screen.findByTestId('recommendations-skeleton')).toBeInTheDocument();
+  });
+
+  it('shows no skeleton while loading when the section was not visible before', async () => {
+    mockGet.mockImplementation(() => new Promise(() => {}));
+
+    const { container } = render(<Recommendations />);
+
+    await waitFor(() => expect(container).toBeEmptyDOMElement());
+  });
+
+  it('stores the visibility hint when the section renders', async () => {
+    render(<Recommendations />);
+
+    await screen.findByText('Recommendations for your stack');
+    await waitFor(() => expect(window.localStorage.getItem('grafana.home.recommendations.was-visible')).toBe('true'));
+  });
+
+  it('clears the visibility hint when everything settles to zero recommendations', async () => {
+    window.localStorage.setItem('grafana.home.recommendations.was-visible', 'true');
+    // All apps enabled and (per the default mock) receiving data: nothing to recommend.
+    mockGet.mockResolvedValue(APP_IDS.map((id) => listItem(id, { enabled: true })));
+
+    const { container } = render(<Recommendations />);
+
+    await waitFor(() => expect(container).toBeEmptyDOMElement());
+    await waitFor(() => expect(window.localStorage.getItem('grafana.home.recommendations.was-visible')).toBe('false'));
+  });
+
   it('renders the section even when Kubernetes Monitoring is not installed', async () => {
     mockUsePluginBridge.mockReturnValue({ loading: false, installed: false });
 

--- a/public/app/features/home/Recommendations/Recommendations.test.tsx
+++ b/public/app/features/home/Recommendations/Recommendations.test.tsx
@@ -237,6 +237,27 @@ describe('Recommendations', () => {
 
     expect(await screen.findByRole('link', { name: /Set up Hosted Traces/, hidden: true })).toBeInTheDocument();
     expect(screen.queryByRole('link', { name: /Set up Synthetic Monitoring/, hidden: true })).not.toBeInTheDocument();
+    // Inaccessible apps are excluded before probing: their probe could never produce a card.
+    expect(jest.mocked(hasSolutionData)).not.toHaveBeenCalledWith('grafana-synthetic-monitoring-app');
+  });
+
+  it('shows a settled setup card while another probe is still pending', async () => {
+    jest.mocked(hasSolutionData).mockImplementation((pluginId: string) => {
+      if (pluginId === 'grafana-synthetic-monitoring-app') {
+        return Promise.resolve(false);
+      }
+      if (pluginId === 'grafana-exploretraces-app') {
+        return new Promise(() => {}); // Never settles.
+      }
+      return Promise.resolve(true);
+    });
+    mockGet.mockResolvedValue(APP_IDS.map((id) => listItem(id, { enabled: true })));
+
+    render(<Recommendations />);
+
+    // The settled no-data probe renders its setup card without waiting for the hanging probe.
+    expect(await screen.findByRole('link', { name: /Set up Synthetic Monitoring/, hidden: true })).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /Set up Hosted Traces/, hidden: true })).not.toBeInTheDocument();
   });
 
   it('shows installed-but-disabled cards but hides not-installed cards for a write-only user', async () => {

--- a/public/app/features/home/Recommendations/Recommendations.test.tsx
+++ b/public/app/features/home/Recommendations/Recommendations.test.tsx
@@ -152,6 +152,30 @@ describe('Recommendations', () => {
     expect(screen.queryByRole('link', { name: /Add Synthetic Monitoring/, hidden: true })).not.toBeInTheDocument();
   });
 
+  it('renders known cards immediately and appends the setup card when its probe settles', async () => {
+    let resolveProbe: (hasData: boolean) => void = () => {};
+    jest
+      .mocked(hasSolutionData)
+      .mockImplementation((pluginId: string) =>
+        pluginId === 'grafana-synthetic-monitoring-app'
+          ? new Promise((resolve) => (resolveProbe = resolve))
+          : Promise.resolve(true)
+      );
+    mockGet.mockResolvedValue(
+      APP_IDS.map((id) => listItem(id, { enabled: id === 'grafana-synthetic-monitoring-app' }))
+    );
+
+    render(<Recommendations />);
+
+    // Disabled apps render without waiting for the synthetic-monitoring probe.
+    expect(await screen.findByRole('link', { name: /Enable Hosted Traces/, hidden: true })).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /Set up Synthetic Monitoring/, hidden: true })).not.toBeInTheDocument();
+
+    resolveProbe(false);
+
+    expect(await screen.findByRole('link', { name: /Set up Synthetic Monitoring/, hidden: true })).toBeInTheDocument();
+  });
+
   it('hides the section when every enabled app has data', async () => {
     mockGet.mockResolvedValue(APP_IDS.map((id) => listItem(id, { enabled: true })));
 

--- a/public/app/features/home/Recommendations/Recommendations.test.tsx
+++ b/public/app/features/home/Recommendations/Recommendations.test.tsx
@@ -211,6 +211,30 @@ describe('Recommendations', () => {
     expect(await screen.findByRole('link', { name: /Set up Synthetic Monitoring/, hidden: true })).toBeInTheDocument();
   });
 
+  it('keeps the visible slide when an earlier-ordered setup card settles later', async () => {
+    let resolveProbe: (hasData: boolean) => void = () => {};
+    jest
+      .mocked(hasSolutionData)
+      .mockImplementation((pluginId: string) =>
+        pluginId === 'grafana-exploretraces-app'
+          ? new Promise((resolve) => (resolveProbe = resolve))
+          : Promise.resolve(true)
+      );
+    mockGet.mockResolvedValue(APP_IDS.map((id) => listItem(id, { enabled: id === 'grafana-exploretraces-app' })));
+
+    render(<Recommendations />);
+
+    // Hosted Traces is still probing; Synthetic Monitoring's enable card leads the deck and is
+    // the visible (non-aria-hidden) slide.
+    expect(await screen.findByRole('link', { name: /Add Synthetic Monitoring/ })).toBeInTheDocument();
+
+    resolveProbe(false);
+
+    // The traces setup card joins ahead in priority order without stealing the visible slide.
+    expect(await screen.findByRole('link', { name: /Set up Hosted Traces/, hidden: true })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Add Synthetic Monitoring/ })).toBeInTheDocument();
+  });
+
   it('hides the section when every enabled app has data', async () => {
     mockGet.mockResolvedValue(APP_IDS.map((id) => listItem(id, { enabled: true })));
 

--- a/public/app/features/home/Recommendations/Recommendations.test.tsx
+++ b/public/app/features/home/Recommendations/Recommendations.test.tsx
@@ -230,9 +230,17 @@ describe('Recommendations', () => {
 
     resolveProbe(false);
 
-    // The traces setup card joins ahead in priority order without stealing the visible slide.
+    // The traces setup card joins the deck without stealing the visible slide.
     expect(await screen.findByRole('link', { name: /Set up Hosted Traces/, hidden: true })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Add Synthetic Monitoring/ })).toBeInTheDocument();
+
+    // Late-settling cards append behind cards already showing (never insert in front — the
+    // carousel animates position shifts). getAllByRole returns document order.
+    const links = screen.getAllByRole('link', { hidden: true });
+    const smIndex = links.findIndex((link) => /Add Synthetic Monitoring/.test(link.textContent ?? ''));
+    const tracesIndex = links.findIndex((link) => /Set up Hosted Traces/.test(link.textContent ?? ''));
+    expect(smIndex).toBeGreaterThan(-1);
+    expect(tracesIndex).toBeGreaterThan(smIndex);
   });
 
   it('hides the section when every enabled app has data', async () => {

--- a/public/app/features/home/Recommendations/Recommendations.tsx
+++ b/public/app/features/home/Recommendations/Recommendations.tsx
@@ -1,13 +1,21 @@
+import { useEffect } from 'react';
 import { useAsync } from 'react-use';
 
+import { store } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { contextSrv } from 'app/core/services/context_srv';
 import { AccessControlAction } from 'app/types/accessControl';
 
+import { RecommendationsSkeleton } from './RecommendationsSkeleton';
 import { RecommendationsView } from './RecommendationsView';
 import { fetchInstalledPlugins, getRecommendations, type PluginRecommendationItem } from './pluginRecommendations';
 import { hasSolutionData } from './solutionDataProbes';
 import { type RecommendationItem } from './types';
+
+// Remembers whether the section rendered on the last visit: the loading skeleton only
+// shows for users who actually get recommendations, so stacks that resolve to nothing
+// never flash a skeleton that collapses into empty space.
+const WAS_VISIBLE_KEY = 'grafana.home.recommendations.was-visible';
 
 export function Recommendations() {
   const canInstall = contextSrv.hasPermission(AccessControlAction.PluginsInstall) && config.pluginAdminEnabled;
@@ -54,38 +62,58 @@ function GatedRecommendations({ canInstall }: GatedRecommendationsProps) {
 
   // An unavailable plugin list fails closed. /api/plugins always lists at least the core plugins,
   // so an empty response means the list is unreliable and also fails closed.
-  if (pluginsLoading || !installedPlugins || installedPlugins.length === 0) {
-    return null;
+  const listReady = !pluginsLoading && !!installedPlugins && installedPlugins.length > 0;
+
+  const pluginsById = new Map((installedPlugins ?? []).map((plugin) => [plugin.id, plugin]));
+  const recommendations = !listReady
+    ? []
+    : getRecommendations().flatMap((recommendation): RecommendationItem[] => {
+        const plugin = pluginsById.get(recommendation.pluginId);
+        if (!plugin) {
+          // Unlistable plugins take the install-only path.
+          return canInstall ? [toEnableItem(recommendation)] : [];
+        }
+        if (plugin.enabled) {
+          // Pending probes exclude the card for this render instead of blocking the whole
+          // section: install/enable cards and the left no-data card mount immediately, and
+          // setup cards join once their probe settles.
+          if (probesLoading || !solutionsWithData || solutionsWithData.has(recommendation.pluginId)) {
+            return [];
+          }
+          // The setup CTA opens the app, so app access — not plugins:write — is the relevant permission.
+          return contextSrv.hasPermissionInMetadata(AccessControlAction.PluginsAppAccess, plugin)
+            ? [toSetupItem(recommendation)]
+            : [];
+        }
+        // plugins:write is scoped to this plugin.
+        return contextSrv.hasPermissionInMetadata(AccessControlAction.PluginsWrite, plugin)
+          ? [toEnableItem(recommendation)]
+          : [];
+      });
+
+  const visible = recommendations.length > 0;
+  // Settled empty: everything resolved and there is genuinely nothing to show — as opposed
+  // to a pending plugin list or pending probes that may still produce cards.
+  const settledEmpty = listReady
+    ? !visible && !probesLoading && !!solutionsWithData
+    : !pluginsLoading && (!installedPlugins || installedPlugins.length === 0);
+
+  useEffect(() => {
+    if (visible) {
+      store.set(WAS_VISIBLE_KEY, 'true');
+    } else if (settledEmpty) {
+      store.set(WAS_VISIBLE_KEY, 'false');
+    }
+  }, [visible, settledEmpty]);
+
+  if (visible) {
+    return <RecommendationsView recommendations={recommendations} />;
   }
 
-  const pluginsById = new Map(installedPlugins.map((plugin) => [plugin.id, plugin]));
-  const recommendations = getRecommendations().flatMap((recommendation): RecommendationItem[] => {
-    const plugin = pluginsById.get(recommendation.pluginId);
-    if (!plugin) {
-      // Unlistable plugins take the install-only path.
-      return canInstall ? [toEnableItem(recommendation)] : [];
-    }
-    if (plugin.enabled) {
-      // Pending probes exclude the card for this render instead of blocking the whole
-      // section: install/enable cards and the left no-data card mount immediately, and
-      // setup cards join once their probe settles.
-      if (probesLoading || !solutionsWithData || solutionsWithData.has(recommendation.pluginId)) {
-        return [];
-      }
-      // The setup CTA opens the app, so app access — not plugins:write — is the relevant permission.
-      return contextSrv.hasPermissionInMetadata(AccessControlAction.PluginsAppAccess, plugin)
-        ? [toSetupItem(recommendation)]
-        : [];
-    }
-    // plugins:write is scoped to this plugin.
-    return contextSrv.hasPermissionInMetadata(AccessControlAction.PluginsWrite, plugin)
-      ? [toEnableItem(recommendation)]
-      : [];
-  });
-
-  if (recommendations.length === 0) {
-    return null;
+  // Hold the section's space while loading, but only for users it rendered for last time.
+  if (!settledEmpty && store.getBool(WAS_VISIBLE_KEY, false)) {
+    return <RecommendationsSkeleton />;
   }
 
-  return <RecommendationsView recommendations={recommendations} />;
+  return null;
 }

--- a/public/app/features/home/Recommendations/Recommendations.tsx
+++ b/public/app/features/home/Recommendations/Recommendations.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useAsync } from 'react-use';
 
 import { store } from '@grafana/data';
@@ -50,21 +50,41 @@ function mapPluginsById(plugins: LocalPlugin[] = []) {
 
 function GatedRecommendations({ canInstall }: GatedRecommendationsProps) {
   const { value: installedPlugins, loading: pluginsLoading } = useAsync(fetchInstalledPlugins, []);
-  // Memoized so the probe callback below can depend on it without re-running every render.
+  // Memoized so the probe effect below can depend on derived values without re-running every render.
   const pluginsById = useMemo(() => mapPluginsById(installedPlugins), [installedPlugins]);
 
   // Enabled alone does not mean used: probe each enabled recommended solution for live data,
   // and keep recommending the silent ones (preprovisioned cloud stacks enable apps by default).
-  const { value: solutionsWithData, loading: probesLoading } = useAsync(async () => {
-    if (!installedPlugins) {
-      return undefined;
+  // Only apps the user can open are worth probing — an inaccessible app can never show a setup
+  // card, and skipping it avoids doomed requests (e.g. a Faro proxy call that can only 403).
+  const probeCandidateIds = useMemo(
+    () =>
+      getRecommendations()
+        .filter((r) => {
+          const plugin = pluginsById.get(r.pluginId);
+          return !!plugin?.enabled && contextSrv.hasPermissionInMetadata(AccessControlAction.PluginsAppAccess, plugin);
+        })
+        .map((r) => r.pluginId),
+    [pluginsById]
+  );
+
+  // One entry per probed plugin, landing as each probe settles, so a slow probe never suppresses
+  // an already-settled setup card. hasSolutionData never rejects.
+  const [probeResults, setProbeResults] = useState<Record<string, boolean>>({});
+  useEffect(() => {
+    let cancelled = false;
+    setProbeResults({});
+    for (const pluginId of probeCandidateIds) {
+      hasSolutionData(pluginId).then((hasData) => {
+        if (!cancelled) {
+          setProbeResults((prev) => ({ ...prev, [pluginId]: hasData }));
+        }
+      });
     }
-    const enabled = getRecommendations().filter((r) => pluginsById.get(r.pluginId)?.enabled);
-    const entries = await Promise.all(
-      enabled.map(async (r) => [r.pluginId, await hasSolutionData(r.pluginId)] as const)
-    );
-    return new Set(entries.filter(([, hasData]) => hasData).map(([pluginId]) => pluginId));
-  }, [installedPlugins, pluginsById]);
+    return () => {
+      cancelled = true;
+    };
+  }, [probeCandidateIds]);
 
   // An unavailable plugin list fails closed. /api/plugins always lists at least the core plugins,
   // so an empty response means the list is unreliable and also fails closed.
@@ -79,16 +99,10 @@ function GatedRecommendations({ canInstall }: GatedRecommendationsProps) {
           return canInstall ? [toEnableItem(recommendation)] : [];
         }
         if (plugin.enabled) {
-          // Pending probes exclude the card for this render instead of blocking the whole
-          // section: install/enable cards and the left no-data card mount immediately, and
-          // setup cards join once their probe settles.
-          if (probesLoading || !solutionsWithData || solutionsWithData.has(recommendation.pluginId)) {
-            return [];
-          }
-          // The setup CTA opens the app, so app access — not plugins:write — is the relevant permission.
-          return contextSrv.hasPermissionInMetadata(AccessControlAction.PluginsAppAccess, plugin)
-            ? [toSetupItem(recommendation)]
-            : [];
+          // Setup card only for a probe that settled on "no data" (probed apps are pre-filtered
+          // to ones the user can open). A pending or skipped probe excludes just this card for
+          // the render; enable cards and the left no-data card mount immediately.
+          return probeResults[recommendation.pluginId] === false ? [toSetupItem(recommendation)] : [];
         }
         // plugins:write is scoped to this plugin.
         return contextSrv.hasPermissionInMetadata(AccessControlAction.PluginsWrite, plugin)
@@ -99,8 +113,9 @@ function GatedRecommendations({ canInstall }: GatedRecommendationsProps) {
   const visible = recommendations.length > 0;
   // Settled empty: everything resolved and there is genuinely nothing to show — as opposed
   // to a pending plugin list or pending probes that may still produce cards.
+  const allProbesSettled = probeCandidateIds.every((pluginId) => probeResults[pluginId] !== undefined);
   const settledEmpty = listReady
-    ? !visible && !probesLoading && !!solutionsWithData
+    ? !visible && allProbesSettled
     : !pluginsLoading && (!installedPlugins || installedPlugins.length === 0);
 
   useEffect(() => {

--- a/public/app/features/home/Recommendations/Recommendations.tsx
+++ b/public/app/features/home/Recommendations/Recommendations.tsx
@@ -5,7 +5,9 @@ import { contextSrv } from 'app/core/services/context_srv';
 import { AccessControlAction } from 'app/types/accessControl';
 
 import { RecommendationsView } from './RecommendationsView';
-import { fetchInstalledPlugins, getRecommendations } from './pluginRecommendations';
+import { fetchInstalledPlugins, getRecommendations, type PluginRecommendationItem } from './pluginRecommendations';
+import { hasSolutionData } from './solutionDataProbes';
+import { type RecommendationItem } from './types';
 
 export function Recommendations() {
   const canInstall = contextSrv.hasPermission(AccessControlAction.PluginsInstall) && config.pluginAdminEnabled;
@@ -21,30 +23,60 @@ interface GatedRecommendationsProps {
   canInstall: boolean;
 }
 
+function toEnableItem(recommendation: PluginRecommendationItem): RecommendationItem {
+  return { ...recommendation, cta: 'enable' };
+}
+
+// Enabled-but-silent app: the CTA leads into the app to finish setup, not to the catalog.
+function toSetupItem(recommendation: PluginRecommendationItem): RecommendationItem {
+  return { ...recommendation, action: recommendation.setupAction, href: recommendation.appHref, cta: 'setup' };
+}
+
 function GatedRecommendations({ canInstall }: GatedRecommendationsProps) {
   const { value: installedPlugins, loading: pluginsLoading } = useAsync(fetchInstalledPlugins, []);
 
+  // Enabled alone does not mean used: probe each enabled recommended solution for live data,
+  // and keep recommending the silent ones (preprovisioned cloud stacks enable apps by default).
+  const { value: solutionsWithData, loading: probesLoading } = useAsync(async () => {
+    if (!installedPlugins) {
+      return undefined;
+    }
+    const pluginsById = new Map(installedPlugins.map((plugin) => [plugin.id, plugin]));
+    const enabled = getRecommendations().filter((r) => pluginsById.get(r.pluginId)?.enabled);
+    const entries = await Promise.all(
+      enabled.map(async (r) => [r.pluginId, await hasSolutionData(r.pluginId)] as const)
+    );
+    return new Set(entries.filter(([, hasData]) => hasData).map(([pluginId]) => pluginId));
+  }, [installedPlugins]);
+
   // An unavailable plugin list fails closed. /api/plugins always lists at least the core plugins,
   // so an empty response means the list is unreliable and also fails closed.
-  if (pluginsLoading || !installedPlugins || installedPlugins.length === 0) {
+  if (pluginsLoading || !installedPlugins || installedPlugins.length === 0 || probesLoading || !solutionsWithData) {
     return null;
   }
 
   const pluginsById = new Map(installedPlugins.map((plugin) => [plugin.id, plugin]));
-  const pluginRecommendations = getRecommendations().filter((recommendation) => {
+  const recommendations = getRecommendations().flatMap((recommendation): RecommendationItem[] => {
     const plugin = pluginsById.get(recommendation.pluginId);
     if (!plugin) {
       // Unlistable plugins take the install-only path.
-      return canInstall;
+      return canInstall ? [toEnableItem(recommendation)] : [];
     }
     if (plugin.enabled) {
-      return false;
+      if (solutionsWithData.has(recommendation.pluginId)) {
+        return [];
+      }
+      // The setup CTA opens the app, so app access — not plugins:write — is the relevant permission.
+      return contextSrv.hasPermissionInMetadata(AccessControlAction.PluginsAppAccess, plugin)
+        ? [toSetupItem(recommendation)]
+        : [];
     }
     // plugins:write is scoped to this plugin.
-    return contextSrv.hasPermissionInMetadata(AccessControlAction.PluginsWrite, plugin);
+    return contextSrv.hasPermissionInMetadata(AccessControlAction.PluginsWrite, plugin)
+      ? [toEnableItem(recommendation)]
+      : [];
   });
 
-  const recommendations = pluginRecommendations;
   if (recommendations.length === 0) {
     return null;
   }

--- a/public/app/features/home/Recommendations/Recommendations.tsx
+++ b/public/app/features/home/Recommendations/Recommendations.tsx
@@ -1,9 +1,10 @@
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useAsync } from 'react-use';
 
 import { store } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { contextSrv } from 'app/core/services/context_srv';
+import { type LocalPlugin } from 'app/features/plugins/admin/types';
 import { AccessControlAction } from 'app/types/accessControl';
 
 import { RecommendationsSkeleton } from './RecommendationsSkeleton';
@@ -43,8 +44,14 @@ function toSetupItem(recommendation: PluginRecommendationItem): RecommendationIt
   return { ...recommendation, action: recommendation.setupAction, href: recommendation.appHref, cta: 'setup' };
 }
 
+function mapPluginsById(plugins: LocalPlugin[] = []) {
+  return new Map(plugins.map((plugin) => [plugin.id, plugin]));
+}
+
 function GatedRecommendations({ canInstall }: GatedRecommendationsProps) {
   const { value: installedPlugins, loading: pluginsLoading } = useAsync(fetchInstalledPlugins, []);
+  // Memoized so the probe callback below can depend on it without re-running every render.
+  const pluginsById = useMemo(() => mapPluginsById(installedPlugins), [installedPlugins]);
 
   // Enabled alone does not mean used: probe each enabled recommended solution for live data,
   // and keep recommending the silent ones (preprovisioned cloud stacks enable apps by default).
@@ -52,19 +59,17 @@ function GatedRecommendations({ canInstall }: GatedRecommendationsProps) {
     if (!installedPlugins) {
       return undefined;
     }
-    const pluginsById = new Map(installedPlugins.map((plugin) => [plugin.id, plugin]));
     const enabled = getRecommendations().filter((r) => pluginsById.get(r.pluginId)?.enabled);
     const entries = await Promise.all(
       enabled.map(async (r) => [r.pluginId, await hasSolutionData(r.pluginId)] as const)
     );
     return new Set(entries.filter(([, hasData]) => hasData).map(([pluginId]) => pluginId));
-  }, [installedPlugins]);
+  }, [installedPlugins, pluginsById]);
 
   // An unavailable plugin list fails closed. /api/plugins always lists at least the core plugins,
   // so an empty response means the list is unreliable and also fails closed.
   const listReady = !pluginsLoading && !!installedPlugins && installedPlugins.length > 0;
 
-  const pluginsById = new Map((installedPlugins ?? []).map((plugin) => [plugin.id, plugin]));
   const recommendations = !listReady
     ? []
     : getRecommendations().flatMap((recommendation): RecommendationItem[] => {

--- a/public/app/features/home/Recommendations/Recommendations.tsx
+++ b/public/app/features/home/Recommendations/Recommendations.tsx
@@ -12,6 +12,9 @@ import { type RecommendationItem } from './types';
 export function Recommendations() {
   const canInstall = contextSrv.hasPermission(AccessControlAction.PluginsInstall) && config.pluginAdminEnabled;
   // Unscoped pre-gate only; each disabled card re-checks plugins:write scoped to its own plugin.
+  // Deliberate limitation: users with only app access (no plugins:write/install anywhere) do not
+  // see the section at all — recommendations are a plugin-management surface, and the pre-gate
+  // spares every viewer the /api/plugins fetch and the solution data probes.
   const canWriteSome = contextSrv.hasPermission(AccessControlAction.PluginsWrite);
   if (!canInstall && !canWriteSome) {
     return null;
@@ -51,7 +54,7 @@ function GatedRecommendations({ canInstall }: GatedRecommendationsProps) {
 
   // An unavailable plugin list fails closed. /api/plugins always lists at least the core plugins,
   // so an empty response means the list is unreliable and also fails closed.
-  if (pluginsLoading || !installedPlugins || installedPlugins.length === 0 || probesLoading || !solutionsWithData) {
+  if (pluginsLoading || !installedPlugins || installedPlugins.length === 0) {
     return null;
   }
 
@@ -63,7 +66,10 @@ function GatedRecommendations({ canInstall }: GatedRecommendationsProps) {
       return canInstall ? [toEnableItem(recommendation)] : [];
     }
     if (plugin.enabled) {
-      if (solutionsWithData.has(recommendation.pluginId)) {
+      // Pending probes exclude the card for this render instead of blocking the whole
+      // section: install/enable cards and the left no-data card mount immediately, and
+      // setup cards join once their probe settles.
+      if (probesLoading || !solutionsWithData || solutionsWithData.has(recommendation.pluginId)) {
         return [];
       }
       // The setup CTA opens the app, so app access — not plugins:write — is the relevant permission.

--- a/public/app/features/home/Recommendations/Recommendations.tsx
+++ b/public/app/features/home/Recommendations/Recommendations.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useAsync } from 'react-use';
 
 import { store } from '@grafana/data';
@@ -109,6 +109,17 @@ function GatedRecommendations({ canInstall }: GatedRecommendationsProps) {
           ? [toEnableItem(recommendation)]
           : [];
       });
+
+  // Cards keep the slot they first appeared in; later-settling cards append. A card must never
+  // insert in front of the slide the user is reading — the carousel animates position shifts.
+  // Append-only ref mutation during render: idempotent, so StrictMode replays are harmless.
+  const seenOrder = useRef<string[]>([]);
+  for (const recommendation of recommendations) {
+    if (!seenOrder.current.includes(recommendation.id)) {
+      seenOrder.current.push(recommendation.id);
+    }
+  }
+  recommendations.sort((a, b) => seenOrder.current.indexOf(a.id) - seenOrder.current.indexOf(b.id));
 
   const visible = recommendations.length > 0;
   // Settled empty: everything resolved and there is genuinely nothing to show — as opposed

--- a/public/app/features/home/Recommendations/RecommendationsSkeleton.tsx
+++ b/public/app/features/home/Recommendations/RecommendationsSkeleton.tsx
@@ -18,23 +18,16 @@ export function RecommendationsSkeleton() {
 
       <div className={styles.cards}>
         <Grid gap={0} columns={{ xs: 1, md: 2 }}>
-          <div className={styles.card}>
-            <Stack direction="column" gap={2}>
-              <Skeleton width={160} height={22} />
-              <Skeleton width={240} height={30} />
-              <Skeleton height={20} />
-              <Skeleton width={170} height={32} />
-            </Stack>
-          </div>
-
-          <div className={styles.card}>
-            <Stack direction="column" gap={2}>
-              <Skeleton width={120} height={22} />
-              <Skeleton width={240} height={30} />
-              <Skeleton height={20} />
-              <Skeleton width={170} height={32} />
-            </Stack>
-          </div>
+          {[160, 120].map((contextWidth) => (
+            <div key={contextWidth} className={styles.card}>
+              <Stack direction="column" gap={2}>
+                <Skeleton width={contextWidth} height={22} />
+                <Skeleton width={240} height={30} />
+                <Skeleton height={20} />
+                <Skeleton width={170} height={32} />
+              </Stack>
+            </div>
+          ))}
         </Grid>
       </div>
     </div>

--- a/public/app/features/home/Recommendations/RecommendationsSkeleton.tsx
+++ b/public/app/features/home/Recommendations/RecommendationsSkeleton.tsx
@@ -1,0 +1,55 @@
+import { css } from '@emotion/css';
+import Skeleton from 'react-loading-skeleton';
+
+import { type GrafanaTheme2 } from '@grafana/data';
+import { Grid, Stack, useStyles2 } from '@grafana/ui';
+
+// Mirrors the RecommendationsView shell (heading row + two-column card grid) so the
+// section holds its space while the plugin list and data probes resolve.
+export function RecommendationsSkeleton() {
+  const styles = useStyles2(getStyles);
+
+  return (
+    <div data-testid="recommendations-skeleton">
+      <Stack direction="row" alignItems="center" justifyContent="space-between" gap={2}>
+        <Skeleton width={280} height={24} />
+        <Skeleton width={60} height={24} />
+      </Stack>
+
+      <div className={styles.cards}>
+        <Grid gap={0} columns={{ xs: 1, md: 2 }}>
+          <div className={styles.card}>
+            <Stack direction="column" gap={2}>
+              <Skeleton width={160} height={22} />
+              <Skeleton width={240} height={30} />
+              <Skeleton height={20} />
+              <Skeleton width={170} height={32} />
+            </Stack>
+          </div>
+
+          <div className={styles.card}>
+            <Stack direction="column" gap={2}>
+              <Skeleton width={120} height={22} />
+              <Skeleton width={240} height={30} />
+              <Skeleton height={20} />
+              <Skeleton width={170} height={32} />
+            </Stack>
+          </div>
+        </Grid>
+      </div>
+    </div>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  cards: css({
+    background: theme.colors.background.canvas,
+    borderRadius: theme.shape.radius.default,
+    margin: theme.spacing(2, 0, 0),
+    overflow: 'hidden',
+  }),
+  card: css({
+    padding: theme.spacing(3, 4),
+    minWidth: 0,
+  }),
+});

--- a/public/app/features/home/Recommendations/RecommendationsView.tsx
+++ b/public/app/features/home/Recommendations/RecommendationsView.tsx
@@ -30,11 +30,24 @@ export function RecommendationsView({ recommendations }: RecommendationsViewProp
     }
   }, [collapsed]);
 
-  const [index, setIndex] = useState(0);
+  // Anchored by id, not position: probes insert cards in priority order as they settle, and a
+  // late earlier-ordered card must grow the deck without moving the slide the user is reading.
+  const [activeId, setActiveId] = useState<string>();
   const [paused, setPaused] = useState(() => window.matchMedia('(prefers-reduced-motion: reduce)').matches);
 
-  // Clamp during render so a shrinking list cannot select an undefined entry.
-  const safeIndex = Math.min(index, recommendations.length - 1);
+  // First card while unanchored (mount, or the anchored card disappeared).
+  const foundIndex = recommendations.findIndex((recommendation) => recommendation.id === activeId);
+  const safeIndex = foundIndex === -1 ? 0 : foundIndex;
+  const nextId = recommendations[(safeIndex + 1) % recommendations.length].id;
+
+  // Capture the anchor as soon as a card is showing: without this, activeId stays undefined
+  // until the first interaction and the displayed slide would still track position 0.
+  const firstId = recommendations[0].id;
+  useEffect(() => {
+    if (foundIndex === -1) {
+      setActiveId(firstId);
+    }
+  }, [foundIndex, firstId]);
 
   useEffect(() => {
     if (collapsed || paused) {
@@ -42,11 +55,11 @@ export function RecommendationsView({ recommendations }: RecommendationsViewProp
     }
 
     const timeout = setTimeout(() => {
-      setIndex((safeIndex + 1) % recommendations.length);
+      setActiveId(nextId);
     }, 5000);
 
     return () => clearTimeout(timeout);
-  }, [collapsed, paused, safeIndex, recommendations.length]);
+  }, [collapsed, paused, nextId]);
 
   return (
     <div>
@@ -112,14 +125,16 @@ export function RecommendationsView({ recommendations }: RecommendationsViewProp
                     size="sm"
                     fill="text"
                     icon="angle-left"
-                    onClick={() => setIndex((safeIndex - 1 + recommendations.length) % recommendations.length)}
+                    onClick={() =>
+                      setActiveId(recommendations[(safeIndex - 1 + recommendations.length) % recommendations.length].id)
+                    }
                     aria-label={t('home.recommendations.previous', 'Previous')}
                   />
 
-                  {recommendations.map((_, i) =>
+                  {recommendations.map((recommendation, i) =>
                     i === safeIndex ? (
                       <Button
-                        key={i}
+                        key={recommendation.id}
                         variant="secondary"
                         size="sm"
                         fill="solid"
@@ -133,11 +148,11 @@ export function RecommendationsView({ recommendations }: RecommendationsViewProp
                       />
                     ) : (
                       <Button
-                        key={i}
+                        key={recommendation.id}
                         variant="secondary"
                         size="sm"
                         fill="solid"
-                        onClick={() => setIndex(i)}
+                        onClick={() => setActiveId(recommendation.id)}
                         aria-label={t('home.recommendations.go-to', 'Go to recommendation {{index}}', { index: i + 1 })}
                         className={styles.dot}
                       />
@@ -149,7 +164,7 @@ export function RecommendationsView({ recommendations }: RecommendationsViewProp
                     size="sm"
                     fill="text"
                     icon="angle-right"
-                    onClick={() => setIndex((safeIndex + 1) % recommendations.length)}
+                    onClick={() => setActiveId(nextId)}
                     aria-label={t('home.recommendations.next', 'Next')}
                   />
                 </Stack>

--- a/public/app/features/home/Recommendations/appPluginIds.ts
+++ b/public/app/features/home/Recommendations/appPluginIds.ts
@@ -1,0 +1,5 @@
+// App plugin ids of the solutions the homepage recommends and probes for data.
+export const SYNTHETIC_MONITORING_APP_ID = 'grafana-synthetic-monitoring-app';
+export const APP_OBSERVABILITY_APP_ID = 'grafana-app-observability-app';
+export const HOSTED_TRACES_APP_ID = 'grafana-exploretraces-app';
+export const FRONTEND_OBSERVABILITY_APP_ID = 'grafana-kowalski-app';

--- a/public/app/features/home/Recommendations/frontendObservabilityApi.ts
+++ b/public/app/features/home/Recommendations/frontendObservabilityApi.ts
@@ -1,0 +1,18 @@
+import { getBackendSrv } from '@grafana/runtime';
+
+import { FRONTEND_OBSERVABILITY_APP_ID } from './appPluginIds';
+
+// App plugin route proxy (plugin.json `routes`); one module owns the URL so callers never
+// hardcode plugin paths.
+const pluginProxyUrl = (pluginId: string, path: string) => `/api/plugin-proxy/${pluginId}${path}`;
+
+/**
+ * Apps registered in the Frontend Observability (Faro) app. A non-array response reads as empty
+ * so an API shape change degrades toward showing the recommendation, never toward hiding it.
+ */
+export async function fetchFaroApps(): Promise<unknown[]> {
+  const response = await getBackendSrv().get<unknown>(
+    pluginProxyUrl(FRONTEND_OBSERVABILITY_APP_ID, '/api-proxy/api/v1/app')
+  );
+  return Array.isArray(response) ? response : [];
+}

--- a/public/app/features/home/Recommendations/frontendObservabilityApi.ts
+++ b/public/app/features/home/Recommendations/frontendObservabilityApi.ts
@@ -12,7 +12,11 @@ const pluginProxyUrl = (pluginId: string, path: string) => `/api/plugin-proxy/${
  */
 export async function fetchFaroApps(): Promise<unknown[]> {
   const response = await getBackendSrv().get<unknown>(
-    pluginProxyUrl(FRONTEND_OBSERVABILITY_APP_ID, '/api-proxy/api/v1/app')
+    pluginProxyUrl(FRONTEND_OBSERVABILITY_APP_ID, '/api-proxy/api/v1/app'),
+    undefined,
+    undefined,
+    // Probe failures are expected and handled by the caller; never toast them.
+    { showErrorAlert: false }
   );
   return Array.isArray(response) ? response : [];
 }

--- a/public/app/features/home/Recommendations/kubernetesData.ts
+++ b/public/app/features/home/Recommendations/kubernetesData.ts
@@ -5,8 +5,16 @@ import {
   store,
 } from '@grafana/data';
 import { config } from '@grafana/runtime';
-import { getDataSourceInstanceList } from '@grafana/runtime/unstable';
 
+import {
+  createTtlCachedPromise,
+  findDatasourceWithData,
+  listProbeCandidates,
+  MAX_PROBED_DATASOURCES,
+  PROBE_TIMEOUT_MS,
+  PROBE_TTL_MS,
+  withRetry,
+} from './probeUtils';
 import { readScalar, readSeries, runInstantQueries, runRangeQuery } from './promQuery';
 
 /** Kubernetes Monitoring app plugin ID. @lintignore */
@@ -42,9 +50,6 @@ const HEALTH_QUERIES: Record<string, string> = {
 // Firing alert instances scoped to Kubernetes workloads; heartbeats excluded.
 const ALERTS_MATCHER = '{alertstate="firing", alertname!~"Watchdog|InfoInhibitor", cluster!=""}';
 
-// Cap the probe fan-out: only the first 10 candidates (in priority order) are probed per page load.
-const MAX_PROBED_DATASOURCES = 10;
-
 // Never user-visible (useAsync swallows it) — no i18n. Tests assert this exact message.
 const NO_KUBERNETES_DATA_ERROR = 'No Prometheus datasource with Kubernetes data';
 
@@ -63,21 +68,11 @@ export function hasHealthProblems(h: KubernetesHealth): boolean | null {
 // localStorage key where the k8s app's PrometheusPicker persists the user's datasource choice.
 const K8S_APP_STORAGE_KEY = 'grafana.k8s-app.navigation.storage';
 
-// Exact names of Grafana Cloud's utility Prometheus datasources (billing/ML) — never where kube-state-metrics lives.
-const CLOUD_UTILITY_DATASOURCE_NAMES: Record<string, true> = {
-  'grafanacloud-usage': true,
-  'grafanacloud-ml-metrics': true,
-};
-
 // Priority: the k8s app's stored choice, then — skipping cloud utility datasources — the default, then list order.
 async function orderedCandidates(): Promise<DataSourceInstanceListItem[]> {
-  const list = await withRetry(() =>
-    getDataSourceInstanceList({
-      type: 'prometheus',
-      // Reject the -- Grafana -- builtin by meta.id; a ds.type check would drop prometheus-alias datasources.
-      filter: (ds) => ds.meta.id !== 'grafana',
-    })
-  );
+  // Uncapped: the stored preference must be honored even when it sits past the fan-out cap;
+  // resolveKubernetesPrometheus applies the cap after this reorder.
+  const ordered = await listProbeCandidates('prometheus', { cap: Number.POSITIVE_INFINITY });
   let promName: string | undefined;
   try {
     // store.getObject absorbs missing/corrupt values; the try guards localStorage access itself throwing.
@@ -86,36 +81,8 @@ async function orderedCandidates(): Promise<DataSourceInstanceListItem[]> {
   } catch {
     // Storage access denied — fall through to the heuristic.
   }
-  const preferred = list.filter((ds) => !CLOUD_UTILITY_DATASOURCE_NAMES[ds.name]);
-  const pool = preferred.length > 0 ? preferred : list;
-  const def = pool.find((ds) => ds.isDefault);
-  const ordered = def ? [def, ...pool.filter((ds) => ds !== def)] : [...pool];
-  const storedMatch = promName ? list.find((ds) => ds.name === promName) : undefined;
+  const storedMatch = promName ? ordered.find((ds) => ds.name === promName) : undefined;
   return storedMatch ? [storedMatch, ...ordered.filter((ds) => ds !== storedMatch)] : ordered;
-}
-
-// Spacing between retry attempts: the transient browser-side failures observed on the homepage
-// (connection queuing, gateway blips) can outlast an immediate retry; a short backoff covers
-// them while the region shows its skeleton. 3 attempts total.
-const RETRY_DELAYS_MS = [500, 1500];
-
-// Probes gate the whole card: 3 attempts × 30s meant fallback could wait 92s+. 10s per attempt
-// bounds the leader to ~32s worst case while still outlasting a slow-but-alive datasource.
-const PROBE_TIMEOUT_MS = 10_000;
-
-const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
-
-async function withRetry<T>(fn: () => Promise<T>): Promise<T> {
-  for (let attempt = 0; ; attempt++) {
-    try {
-      return await fn();
-    } catch (err) {
-      if (attempt >= RETRY_DELAYS_MS.length) {
-        throw err;
-      }
-      await sleep(RETRY_DELAYS_MS[attempt]);
-    }
-  }
 }
 
 // "Has Kubernetes data" = namespaces detected; an errored probe retries with backoff, then counts
@@ -129,58 +96,13 @@ async function hasKubernetesNamespaces(ds: Pick<DataSourceInstanceSettings, 'uid
   }
 }
 
-// One shared resolution per TTL window; the TTL lets a later home visit re-resolve after datasource changes.
-const RESOLUTION_TTL_MS = 60_000;
-
-// Owns the cached promise + timestamp in a closure so no module-level binding is mutated.
-function createTtlCachedPromise<T>(fn: () => Promise<T>, ttlMs: number): { get(): Promise<T>; reset(): void } {
-  let cached: Promise<T> | undefined;
-  let cachedAt = 0;
-  return {
-    get() {
-      if (!cached || Date.now() - cachedAt > ttlMs) {
-        cachedAt = Date.now();
-        const next: Promise<T> = fn().catch((err) => {
-          // A transient rejection must not poison the cache for a whole TTL window.
-          if (cached === next) {
-            cached = undefined;
-          }
-          throw err;
-        });
-        cached = next;
-      }
-      return cached;
-    },
-    reset() {
-      cached = undefined;
-      cachedAt = 0;
-    },
-  };
-}
-
-// Probe the top-priority candidate alone first: in the common case (the default has Kubernetes
-// data) this issues 1 query instead of 10, and a transient sibling race can never outrank it.
-// Only when the leader has no data (or errors through its retry) fan out to the rest in parallel.
+// Leader-first probe over the ordered candidates; see findDatasourceWithData for the fan-out rules.
 async function resolveKubernetesPrometheus(): Promise<DataSourceInstanceListItem | null> {
   const candidates = (await orderedCandidates()).slice(0, MAX_PROBED_DATASOURCES);
-  if (candidates.length === 0) {
-    return null;
-  }
-  if (await hasKubernetesNamespaces(candidates[0])) {
-    return candidates[0];
-  }
-  const rest = candidates.slice(1);
-  const probes = rest.map((ds) => hasKubernetesNamespaces(ds));
-  for (let i = 0; i < rest.length; i++) {
-    // Await in priority order: a slow probe delays — never changes — the outcome.
-    if (await probes[i]) {
-      return rest[i];
-    }
-  }
-  return null;
+  return findDatasourceWithData(candidates, hasKubernetesNamespaces);
 }
 
-const kubernetesPrometheusResolution = createTtlCachedPromise(resolveKubernetesPrometheus, RESOLUTION_TTL_MS);
+const kubernetesPrometheusResolution = createTtlCachedPromise(resolveKubernetesPrometheus, PROBE_TTL_MS);
 
 // Reset the cached datasource resolution (test seam).
 export function resetKubernetesPrometheusResolution(): void {

--- a/public/app/features/home/Recommendations/kubernetesData.ts
+++ b/public/app/features/home/Recommendations/kubernetesData.ts
@@ -72,7 +72,7 @@ const K8S_APP_STORAGE_KEY = 'grafana.k8s-app.navigation.storage';
 async function orderedCandidates(): Promise<DataSourceInstanceListItem[]> {
   // Uncapped: the stored preference must be honored even when it sits past the fan-out cap;
   // resolveKubernetesPrometheus applies the cap after this reorder.
-  const ordered = await listProbeCandidates('prometheus', { cap: Number.POSITIVE_INFINITY });
+  const ordered = await listProbeCandidates('prometheus', Number.POSITIVE_INFINITY);
   let promName: string | undefined;
   try {
     // store.getObject absorbs missing/corrupt values; the try guards localStorage access itself throwing.

--- a/public/app/features/home/Recommendations/pluginRecommendations.ts
+++ b/public/app/features/home/Recommendations/pluginRecommendations.ts
@@ -2,16 +2,21 @@ import { locationUtil } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { getBackendSrv } from '@grafana/runtime';
 import { accessControlQueryParam } from 'app/core/utils/accessControl';
+import { createBridgeURL } from 'app/features/alerting/unified/components/PluginBridge';
 import { type LocalPlugin } from 'app/features/plugins/admin/types';
 
 import { type RecommendationItem } from './types';
 
-interface PluginRecommendationItem extends RecommendationItem {
+export interface PluginRecommendationItem extends RecommendationItem {
   pluginId: string;
+  /** CTA label when the app is already enabled but not receiving data yet. */
+  setupAction: string;
+  /** CTA target into the app itself, for the enabled-but-no-data state. */
+  appHref: string;
 }
 
 export function getRecommendations(): PluginRecommendationItem[] {
-  const recommendationDefinitions: Array<Omit<PluginRecommendationItem, 'href'>> = [
+  const recommendationDefinitions: Array<Omit<PluginRecommendationItem, 'href' | 'appHref'>> = [
     {
       id: 'hosted-traces',
       pluginId: 'grafana-exploretraces-app',
@@ -24,6 +29,7 @@ export function getRecommendations(): PluginRecommendationItem[] {
         'Add distributed tracing to see how requests flow between services and where they slow down.'
       ),
       action: t('home.recommendations.hosted-traces.action', 'Enable Hosted Traces'),
+      setupAction: t('home.recommendations.hosted-traces.setup-action', 'Set up Hosted Traces'),
     },
     {
       id: 'synthetic-monitoring',
@@ -37,6 +43,7 @@ export function getRecommendations(): PluginRecommendationItem[] {
         'Probe your endpoints from 20+ global locations before your users notice.'
       ),
       action: t('home.recommendations.synthetic-monitoring.action', 'Add Synthetic Monitoring'),
+      setupAction: t('home.recommendations.synthetic-monitoring.setup-action', 'Set up Synthetic Monitoring'),
     },
     {
       id: 'application-observability',
@@ -50,6 +57,7 @@ export function getRecommendations(): PluginRecommendationItem[] {
         'Turn OpenTelemetry data into RED metrics, service maps, and correlated traces automatically.'
       ),
       action: t('home.recommendations.application-observability.action', 'Enable Application Observability'),
+      setupAction: t('home.recommendations.application-observability.setup-action', 'Set up Application Observability'),
     },
     {
       id: 'frontend-observability',
@@ -63,12 +71,14 @@ export function getRecommendations(): PluginRecommendationItem[] {
         'Capture Core Web Vitals and errors from the browser and tie them back to backend traces.'
       ),
       action: t('home.recommendations.frontend-observability.action', 'Enable Frontend Observability'),
+      setupAction: t('home.recommendations.frontend-observability.setup-action', 'Set up Frontend Observability'),
     },
   ];
 
   return recommendationDefinitions.map((recommendation) => ({
     ...recommendation,
     href: locationUtil.assureBaseUrl(`/plugins/${recommendation.pluginId}/`),
+    appHref: locationUtil.assureBaseUrl(createBridgeURL(recommendation.pluginId, '')),
   }));
 }
 

--- a/public/app/features/home/Recommendations/pluginRecommendations.ts
+++ b/public/app/features/home/Recommendations/pluginRecommendations.ts
@@ -22,10 +22,12 @@ export interface PluginRecommendationItem extends RecommendationItem {
 }
 
 export function getRecommendations(): PluginRecommendationItem[] {
-  const recommendationDefinitions: Array<Omit<PluginRecommendationItem, 'href' | 'appHref'>> = [
+  // appPath: in-app landing route for the setup CTA; empty when the app's root include is its real entry.
+  const recommendationDefinitions: Array<Omit<PluginRecommendationItem, 'href' | 'appHref'> & { appPath: string }> = [
     {
       id: 'hosted-traces',
       pluginId: HOSTED_TRACES_APP_ID,
+      appPath: '',
       icon: 'gf-traces',
       color: (theme) => theme.visualization.getColorByName('orange'),
       title: t('home.recommendations.hosted-traces.title', 'Trace requests across services'),
@@ -40,6 +42,7 @@ export function getRecommendations(): PluginRecommendationItem[] {
     {
       id: 'synthetic-monitoring',
       pluginId: SYNTHETIC_MONITORING_APP_ID,
+      appPath: '/home',
       icon: 'globe',
       color: (theme) => theme.visualization.getColorByName('purple'),
       title: t('home.recommendations.synthetic-monitoring.title', 'Watch your cluster from outside'),
@@ -54,6 +57,7 @@ export function getRecommendations(): PluginRecommendationItem[] {
     {
       id: 'application-observability',
       pluginId: APP_OBSERVABILITY_APP_ID,
+      appPath: '',
       icon: 'application-observability',
       color: (theme) => theme.visualization.getColorByName('green'),
       title: t('home.recommendations.application-observability.title', 'Explore your service map'),
@@ -68,6 +72,7 @@ export function getRecommendations(): PluginRecommendationItem[] {
     {
       id: 'frontend-observability',
       pluginId: FRONTEND_OBSERVABILITY_APP_ID,
+      appPath: '',
       icon: 'frontend-observability',
       color: (theme) => theme.visualization.getColorByName('blue'),
       title: t('home.recommendations.frontend-observability.title', 'Measure real user experience'),
@@ -81,10 +86,10 @@ export function getRecommendations(): PluginRecommendationItem[] {
     },
   ];
 
-  return recommendationDefinitions.map((recommendation) => ({
+  return recommendationDefinitions.map(({ appPath, ...recommendation }) => ({
     ...recommendation,
     href: locationUtil.assureBaseUrl(`/plugins/${recommendation.pluginId}/`),
-    appHref: locationUtil.assureBaseUrl(createBridgeURL(recommendation.pluginId, '')),
+    appHref: locationUtil.assureBaseUrl(createBridgeURL(recommendation.pluginId, appPath)),
   }));
 }
 

--- a/public/app/features/home/Recommendations/pluginRecommendations.ts
+++ b/public/app/features/home/Recommendations/pluginRecommendations.ts
@@ -5,6 +5,12 @@ import { accessControlQueryParam } from 'app/core/utils/accessControl';
 import { createBridgeURL } from 'app/features/alerting/unified/components/PluginBridge';
 import { type LocalPlugin } from 'app/features/plugins/admin/types';
 
+import {
+  APP_OBSERVABILITY_APP_ID,
+  FRONTEND_OBSERVABILITY_APP_ID,
+  HOSTED_TRACES_APP_ID,
+  SYNTHETIC_MONITORING_APP_ID,
+} from './appPluginIds';
 import { type RecommendationItem } from './types';
 
 export interface PluginRecommendationItem extends RecommendationItem {
@@ -19,7 +25,7 @@ export function getRecommendations(): PluginRecommendationItem[] {
   const recommendationDefinitions: Array<Omit<PluginRecommendationItem, 'href' | 'appHref'>> = [
     {
       id: 'hosted-traces',
-      pluginId: 'grafana-exploretraces-app',
+      pluginId: HOSTED_TRACES_APP_ID,
       icon: 'gf-traces',
       color: (theme) => theme.visualization.getColorByName('orange'),
       title: t('home.recommendations.hosted-traces.title', 'Trace requests across services'),
@@ -33,7 +39,7 @@ export function getRecommendations(): PluginRecommendationItem[] {
     },
     {
       id: 'synthetic-monitoring',
-      pluginId: 'grafana-synthetic-monitoring-app',
+      pluginId: SYNTHETIC_MONITORING_APP_ID,
       icon: 'globe',
       color: (theme) => theme.visualization.getColorByName('purple'),
       title: t('home.recommendations.synthetic-monitoring.title', 'Watch your cluster from outside'),
@@ -47,7 +53,7 @@ export function getRecommendations(): PluginRecommendationItem[] {
     },
     {
       id: 'application-observability',
-      pluginId: 'grafana-app-observability-app',
+      pluginId: APP_OBSERVABILITY_APP_ID,
       icon: 'application-observability',
       color: (theme) => theme.visualization.getColorByName('green'),
       title: t('home.recommendations.application-observability.title', 'Explore your service map'),
@@ -61,7 +67,7 @@ export function getRecommendations(): PluginRecommendationItem[] {
     },
     {
       id: 'frontend-observability',
-      pluginId: 'grafana-kowalski-app',
+      pluginId: FRONTEND_OBSERVABILITY_APP_ID,
       icon: 'frontend-observability',
       color: (theme) => theme.visualization.getColorByName('blue'),
       title: t('home.recommendations.frontend-observability.title', 'Measure real user experience'),

--- a/public/app/features/home/Recommendations/probeUtils.test.ts
+++ b/public/app/features/home/Recommendations/probeUtils.test.ts
@@ -1,0 +1,17 @@
+import { withTimeout } from './probeUtils';
+
+describe('withTimeout', () => {
+  it('resolves with the promise value when it settles inside the deadline', async () => {
+    await expect(withTimeout(Promise.resolve('ok'), 50)).resolves.toBe('ok');
+  });
+
+  it('propagates a rejection that happens inside the deadline', async () => {
+    await expect(withTimeout(Promise.reject(new Error('boom')), 50)).rejects.toThrow('boom');
+  });
+
+  it('rejects once the deadline passes while the promise hangs', async () => {
+    const hang = new Promise<never>(() => {});
+
+    await expect(withTimeout(hang, 20)).rejects.toThrow(/timed out/i);
+  });
+});

--- a/public/app/features/home/Recommendations/probeUtils.ts
+++ b/public/app/features/home/Recommendations/probeUtils.ts
@@ -1,0 +1,118 @@
+import { type DataSourceInstanceListItem } from '@grafana/data';
+import { getDataSourceInstanceList } from '@grafana/runtime/unstable';
+
+/** Cap the probe fan-out: only the first N candidates (in priority order) are probed per page load. */
+export const MAX_PROBED_DATASOURCES = 10;
+
+// Probes gate homepage cards: 3 attempts x 30s meant a fallback could wait 92s+. 10s per attempt
+// bounds the leader to ~32s worst case while still outlasting a slow-but-alive datasource.
+export const PROBE_TIMEOUT_MS = 10_000;
+
+/** One shared probe resolution per TTL window; a later home visit re-resolves after datasource changes. */
+export const PROBE_TTL_MS = 60_000;
+
+// Spacing between retry attempts: the transient browser-side failures observed on the homepage
+// (connection queuing, gateway blips) can outlast an immediate retry; a short backoff covers
+// them while the region shows its skeleton. 3 attempts total.
+const RETRY_DELAYS_MS = [500, 1500];
+
+// Exact names of Grafana Cloud's utility Prometheus datasources (billing/ML) — never where product data lives.
+const CLOUD_UTILITY_DATASOURCE_NAMES: Record<string, true> = {
+  'grafanacloud-usage': true,
+  'grafanacloud-ml-metrics': true,
+};
+
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+export async function withRetry<T>(fn: () => Promise<T>): Promise<T> {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      if (attempt >= RETRY_DELAYS_MS.length) {
+        throw err;
+      }
+      await sleep(RETRY_DELAYS_MS[attempt]);
+    }
+  }
+}
+
+/** Owns the cached promise + timestamp in a closure so no module-level binding is mutated. */
+export function createTtlCachedPromise<T>(fn: () => Promise<T>, ttlMs: number): { get(): Promise<T>; reset(): void } {
+  let cached: Promise<T> | undefined;
+  let cachedAt = 0;
+  return {
+    get() {
+      if (!cached || Date.now() - cachedAt > ttlMs) {
+        cachedAt = Date.now();
+        const next: Promise<T> = fn().catch((err) => {
+          // A transient rejection must not poison the cache for a whole TTL window.
+          if (cached === next) {
+            cached = undefined;
+          }
+          throw err;
+        });
+        cached = next;
+      }
+      return cached;
+    },
+    reset() {
+      cached = undefined;
+      cachedAt = 0;
+    },
+  };
+}
+
+interface ListProbeCandidatesOptions {
+  /** Cap on the returned list; pass Infinity when the caller reorders before capping itself. */
+  cap?: number;
+}
+
+/**
+ * Candidate datasources of `type` for a data-existence probe: cloud utility datasources are
+ * skipped (unless they are all there is), the default datasource leads, capped for fan-out.
+ */
+export async function listProbeCandidates(
+  type: string,
+  { cap = MAX_PROBED_DATASOURCES }: ListProbeCandidatesOptions = {}
+): Promise<DataSourceInstanceListItem[]> {
+  const list = await withRetry(() =>
+    getDataSourceInstanceList({
+      type,
+      // Reject the -- Grafana -- builtin by meta.id; a ds.type check would drop alias datasources.
+      filter: (ds) => ds.meta.id !== 'grafana',
+    })
+  );
+  const preferred = list.filter((ds) => !CLOUD_UTILITY_DATASOURCE_NAMES[ds.name]);
+  const pool = preferred.length > 0 ? preferred : list;
+  const def = pool.find((ds) => ds.isDefault);
+  const ordered = def ? [def, ...pool.filter((ds) => ds !== def)] : [...pool];
+  return ordered.slice(0, cap);
+}
+
+/**
+ * Probe the top-priority candidate alone first: in the common case (the default datasource has
+ * the data) this issues 1 query instead of N, and a transient sibling race can never outrank it.
+ * Only when the leader has no data (or errors) fan out to the rest in parallel. `hasData` must
+ * not throw — an unusable datasource counts as no data.
+ */
+export async function findDatasourceWithData(
+  candidates: DataSourceInstanceListItem[],
+  hasData: (ds: DataSourceInstanceListItem) => Promise<boolean>
+): Promise<DataSourceInstanceListItem | null> {
+  if (candidates.length === 0) {
+    return null;
+  }
+  if (await hasData(candidates[0])) {
+    return candidates[0];
+  }
+  const rest = candidates.slice(1);
+  const probes = rest.map((ds) => hasData(ds));
+  for (let i = 0; i < rest.length; i++) {
+    // Await in priority order: a slow probe delays — never changes — the outcome.
+    if (await probes[i]) {
+      return rest[i];
+    }
+  }
+  return null;
+}

--- a/public/app/features/home/Recommendations/probeUtils.ts
+++ b/public/app/features/home/Recommendations/probeUtils.ts
@@ -118,11 +118,10 @@ export async function findDatasourceWithData(
     return candidates[0];
   }
   const rest = candidates.slice(1);
-  const probes = rest.map((ds) => hasData(ds));
-  for (let i = 0; i < rest.length; i++) {
-    // Await in priority order: a slow probe delays — never changes — the outcome.
-    if (await probes[i]) {
-      return rest[i];
+  // Parallel probe for hasData while retaining priority of original list
+  for (const [index, probe] of rest.map(hasData).entries()) {
+    if (await probe) {
+      return rest[index];
     }
   }
   return null;

--- a/public/app/features/home/Recommendations/probeUtils.ts
+++ b/public/app/features/home/Recommendations/probeUtils.ts
@@ -37,6 +37,21 @@ export async function withRetry<T>(fn: () => Promise<T>): Promise<T> {
   }
 }
 
+/** Rejects when `promise` outlasts `ms`; the underlying request keeps running but stops gating the caller. */
+export async function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(`Probe timed out after ${ms}ms`)), ms);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 /** Owns the cached promise + timestamp in a closure so no module-level binding is mutated. */
 export function createTtlCachedPromise<T>(fn: () => Promise<T>, ttlMs: number): { get(): Promise<T>; reset(): void } {
   let cached: Promise<T> | undefined;

--- a/public/app/features/home/Recommendations/probeUtils.ts
+++ b/public/app/features/home/Recommendations/probeUtils.ts
@@ -63,18 +63,14 @@ export function createTtlCachedPromise<T>(fn: () => Promise<T>, ttlMs: number): 
   };
 }
 
-interface ListProbeCandidatesOptions {
-  /** Cap on the returned list; pass Infinity when the caller reorders before capping itself. */
-  cap?: number;
-}
-
 /**
  * Candidate datasources of `type` for a data-existence probe: cloud utility datasources are
  * skipped (unless they are all there is), the default datasource leads, capped for fan-out.
+ * Pass an Infinity `cap` when the caller reorders before capping itself.
  */
 export async function listProbeCandidates(
   type: string,
-  { cap = MAX_PROBED_DATASOURCES }: ListProbeCandidatesOptions = {}
+  cap = MAX_PROBED_DATASOURCES
 ): Promise<DataSourceInstanceListItem[]> {
   const list = await withRetry(() =>
     getDataSourceInstanceList({

--- a/public/app/features/home/Recommendations/promQuery.ts
+++ b/public/app/features/home/Recommendations/promQuery.ts
@@ -3,6 +3,7 @@ import { first } from 'rxjs/operators';
 
 import {
   type DataFrame,
+  type DataQuery,
   type DataSourceInstanceSettings,
   dateTime,
   type Field,
@@ -43,13 +44,13 @@ export function readSeries(frames: DataFrame[], refId: string): FieldSparkline |
 }
 
 /**
- * Run PromQL through the shared {@link createQueryRunner | QueryRunner} against `ds` — core plumbing
- * owns request building, interval math, and frame conversion, and the Prometheus datasource always
- * answers with DataFrames. Throws (surfaced as an error; callers omit the entry) when the query
- * errors or times out.
+ * Run queries through the shared {@link createQueryRunner | QueryRunner} against `ds` — core
+ * plumbing owns request building, interval math, and frame conversion. Works for any datasource
+ * whose targets are expressible as DataQuery (Prometheus PromQL, Tempo TraceQL). Throws (surfaced
+ * as an error; callers omit the entry) when the query errors or times out.
  */
-async function runPromQueries(
-  queries: PromQuery[],
+export async function runDatasourceQueries(
+  queries: DataQuery[],
   range: TimeRange,
   ds: Pick<DataSourceInstanceSettings, 'uid' | 'type'>,
   timeoutMs = 30_000
@@ -96,7 +97,7 @@ export async function runInstantQueries(
     instant: true,
     range: false,
   }));
-  return runPromQueries(targets, getDefaultTimeRange(), ds, timeoutMs);
+  return runDatasourceQueries(targets, getDefaultTimeRange(), ds, timeoutMs);
 }
 
 /**
@@ -112,5 +113,6 @@ export async function runRangeQuery(
   const toTime = dateTime();
   const fromTime = dateTime().subtract(hours, 'h');
   const range: TimeRange = { from: fromTime, to: toTime, raw: { from: `now-${hours}h`, to: 'now' } };
-  return runPromQueries([{ refId, expr, instant: false, range: true }], range, ds);
+  const target: PromQuery = { refId, expr, instant: false, range: true };
+  return runDatasourceQueries([target], range, ds);
 }

--- a/public/app/features/home/Recommendations/solutionDataProbes.test.ts
+++ b/public/app/features/home/Recommendations/solutionDataProbes.test.ts
@@ -113,14 +113,29 @@ describe('hasSolutionData', () => {
       await expect(hasSolutionData('grafana-synthetic-monitoring-app')).resolves.toBe(true);
     }, 15_000);
 
-    it('settles no-data when one datasource errors and the rest probe clean and empty', async () => {
+    it('fails toward hiding when one datasource errors even if the rest probe clean and empty', async () => {
+      // The errored datasource may hold the data, so absence is not established.
       mockList.mockResolvedValue([datasource('prometheus', 'prom-a'), datasource('prometheus', 'prom-b')]);
       mockInstant.mockImplementation(async (_queries, ds) =>
         ds.uid === 'prom-a-uid' ? Promise.reject(new Error('403')) : []
       );
 
-      await expect(hasSolutionData('grafana-synthetic-monitoring-app')).resolves.toBe(false);
+      await expect(hasSolutionData('grafana-synthetic-monitoring-app')).resolves.toBe(true);
     }, 15_000);
+
+    it('probes both span-metric naming schemes for Application Observability', async () => {
+      mockList.mockResolvedValue([datasource('prometheus')]);
+      mockInstant.mockResolvedValue([scalarFrame('probe', 3)]);
+
+      await expect(hasSolutionData('grafana-app-observability-app')).resolves.toBe(true);
+      expect(mockInstant).toHaveBeenCalledWith(
+        {
+          probe: expect.stringMatching(/traces_spanmetrics_calls_total.* or .*traces_span_metrics_calls_total/),
+        },
+        expect.objectContaining({ type: 'prometheus' }),
+        expect.any(Number)
+      );
+    });
   });
 
   describe('Hosted Traces', () => {
@@ -154,7 +169,11 @@ describe('hasSolutionData', () => {
 
       await expect(hasSolutionData('grafana-kowalski-app')).resolves.toBe(true);
       expect(mockGet).toHaveBeenCalledWith(
-        expect.stringContaining('/api/plugin-proxy/grafana-kowalski-app/api-proxy/api/v1/app')
+        expect.stringContaining('/api/plugin-proxy/grafana-kowalski-app/api-proxy/api/v1/app'),
+        undefined,
+        undefined,
+        // Probe failures are expected; a toast per failed attempt would spam the homepage.
+        expect.objectContaining({ showErrorAlert: false })
       );
     });
 

--- a/public/app/features/home/Recommendations/solutionDataProbes.test.ts
+++ b/public/app/features/home/Recommendations/solutionDataProbes.test.ts
@@ -96,6 +96,31 @@ describe('hasSolutionData', () => {
       expect(mockList).toHaveBeenCalledTimes(1);
       expect(mockInstant).toHaveBeenCalledTimes(1);
     });
+
+    it('fails toward hiding the recommendation when every datasource probe errors', async () => {
+      mockList.mockResolvedValue([datasource('prometheus', 'prom-a'), datasource('prometheus', 'prom-b')]);
+      mockInstant.mockRejectedValue(new Error('query timeout'));
+
+      await expect(hasSolutionData('grafana-synthetic-monitoring-app')).resolves.toBe(true);
+    }, 15_000);
+
+    it('reports data when one datasource errors but another has the metric', async () => {
+      mockList.mockResolvedValue([datasource('prometheus', 'prom-a'), datasource('prometheus', 'prom-b')]);
+      mockInstant.mockImplementation(async (_queries, ds) =>
+        ds.uid === 'prom-a-uid' ? Promise.reject(new Error('403')) : [scalarFrame('probe', 7)]
+      );
+
+      await expect(hasSolutionData('grafana-synthetic-monitoring-app')).resolves.toBe(true);
+    }, 15_000);
+
+    it('settles no-data when one datasource errors and the rest probe clean and empty', async () => {
+      mockList.mockResolvedValue([datasource('prometheus', 'prom-a'), datasource('prometheus', 'prom-b')]);
+      mockInstant.mockImplementation(async (_queries, ds) =>
+        ds.uid === 'prom-a-uid' ? Promise.reject(new Error('403')) : []
+      );
+
+      await expect(hasSolutionData('grafana-synthetic-monitoring-app')).resolves.toBe(false);
+    }, 15_000);
   });
 
   describe('Hosted Traces', () => {
@@ -124,15 +149,23 @@ describe('hasSolutionData', () => {
   });
 
   describe('Frontend Observability', () => {
-    it('reports data when the Faro registry has a configured app', async () => {
-      mockGet.mockResolvedValue({ items: [{ metadata: { name: 'my-app' } }] });
+    it('reports data when the Faro app lists a configured app through its proxy route', async () => {
+      mockGet.mockResolvedValue([{ name: 'my-app' }]);
 
       await expect(hasSolutionData('grafana-kowalski-app')).resolves.toBe(true);
-      expect(mockGet).toHaveBeenCalledWith(expect.stringContaining('/faroapps'));
+      expect(mockGet).toHaveBeenCalledWith(
+        expect.stringContaining('/api/plugin-proxy/grafana-kowalski-app/api-proxy/api/v1/app')
+      );
     });
 
-    it('reports no data when the Faro registry is empty', async () => {
-      mockGet.mockResolvedValue({ items: [] });
+    it('reports no data when the Faro app list is empty', async () => {
+      mockGet.mockResolvedValue([]);
+
+      await expect(hasSolutionData('grafana-kowalski-app')).resolves.toBe(false);
+    });
+
+    it('treats a non-array response as no data so the setup card still shows', async () => {
+      mockGet.mockResolvedValue({ items: [{ name: 'my-app' }] });
 
       await expect(hasSolutionData('grafana-kowalski-app')).resolves.toBe(false);
     });

--- a/public/app/features/home/Recommendations/solutionDataProbes.test.ts
+++ b/public/app/features/home/Recommendations/solutionDataProbes.test.ts
@@ -1,0 +1,146 @@
+import { createDataFrame, type DataSourceInstanceListItem, FieldType } from '@grafana/data';
+import { getBackendSrv } from '@grafana/runtime';
+import { getDataSourceInstanceList } from '@grafana/runtime/unstable';
+
+import { runDatasourceQueries, runInstantQueries } from './promQuery';
+import { hasSolutionData, resetSolutionDataProbes } from './solutionDataProbes';
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getBackendSrv: jest.fn(),
+}));
+
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getDataSourceInstanceList: jest.fn(),
+}));
+
+jest.mock('./promQuery', () => ({
+  ...jest.requireActual('./promQuery'),
+  runInstantQueries: jest.fn(),
+  runDatasourceQueries: jest.fn(),
+}));
+
+const mockList = jest.mocked(getDataSourceInstanceList);
+const mockInstant = jest.mocked(runInstantQueries);
+const mockQueries = jest.mocked(runDatasourceQueries);
+const mockGet = jest.fn();
+
+function datasource(type: string, name = `${type}-ds`): DataSourceInstanceListItem {
+  return {
+    uid: `${name}-uid`,
+    name,
+    type,
+    meta: { id: type } as DataSourceInstanceListItem['meta'],
+    readOnly: false,
+    isDefault: false,
+  };
+}
+
+function scalarFrame(refId: string, value: number) {
+  return createDataFrame({
+    refId,
+    fields: [{ name: 'Value', type: FieldType.number, values: [value] }],
+  });
+}
+
+beforeEach(() => {
+  resetSolutionDataProbes();
+  mockList.mockReset();
+  mockInstant.mockReset();
+  mockQueries.mockReset();
+  mockGet.mockReset();
+  jest.mocked(getBackendSrv).mockReturnValue({ get: mockGet } as unknown as ReturnType<typeof getBackendSrv>);
+});
+
+describe('hasSolutionData', () => {
+  it('reports no data for an unknown solution', async () => {
+    await expect(hasSolutionData('some-other-app')).resolves.toBe(false);
+  });
+
+  describe('Prometheus-backed solutions', () => {
+    it('reports no data when there is no Prometheus datasource', async () => {
+      mockList.mockResolvedValue([]);
+
+      await expect(hasSolutionData('grafana-synthetic-monitoring-app')).resolves.toBe(false);
+      expect(mockInstant).not.toHaveBeenCalled();
+    });
+
+    it('reports data when a datasource has the solution metric', async () => {
+      mockList.mockResolvedValue([datasource('prometheus')]);
+      mockInstant.mockResolvedValue([scalarFrame('probe', 12)]);
+
+      await expect(hasSolutionData('grafana-synthetic-monitoring-app')).resolves.toBe(true);
+      expect(mockInstant).toHaveBeenCalledWith(
+        { probe: 'count(last_over_time(sm_check_info[24h]))' },
+        expect.objectContaining({ type: 'prometheus' }),
+        expect.any(Number)
+      );
+    });
+
+    it('reports no data when the metric is absent on every datasource', async () => {
+      mockList.mockResolvedValue([datasource('prometheus', 'prom-a'), datasource('prometheus', 'prom-b')]);
+      mockInstant.mockResolvedValue([]);
+
+      await expect(hasSolutionData('grafana-app-observability-app')).resolves.toBe(false);
+      expect(mockInstant).toHaveBeenCalledTimes(2);
+    });
+
+    it('caches the probe within the TTL window', async () => {
+      mockList.mockResolvedValue([datasource('prometheus')]);
+      mockInstant.mockResolvedValue([scalarFrame('probe', 1)]);
+
+      await hasSolutionData('grafana-synthetic-monitoring-app');
+      await hasSolutionData('grafana-synthetic-monitoring-app');
+
+      expect(mockList).toHaveBeenCalledTimes(1);
+      expect(mockInstant).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Hosted Traces', () => {
+    it('reports data when a Tempo search returns a trace', async () => {
+      mockList.mockResolvedValue([datasource('tempo')]);
+      mockQueries.mockResolvedValue([
+        createDataFrame({ refId: 'traces', fields: [{ name: 'traceID', type: FieldType.string, values: ['abc'] }] }),
+      ]);
+
+      await expect(hasSolutionData('grafana-exploretraces-app')).resolves.toBe(true);
+    });
+
+    it('reports no data when the Tempo search is empty', async () => {
+      mockList.mockResolvedValue([datasource('tempo')]);
+      mockQueries.mockResolvedValue([]);
+
+      await expect(hasSolutionData('grafana-exploretraces-app')).resolves.toBe(false);
+    });
+
+    it('reports no data when there is no Tempo datasource', async () => {
+      mockList.mockResolvedValue([]);
+
+      await expect(hasSolutionData('grafana-exploretraces-app')).resolves.toBe(false);
+      expect(mockQueries).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Frontend Observability', () => {
+    it('reports data when the Faro registry has a configured app', async () => {
+      mockGet.mockResolvedValue({ items: [{ metadata: { name: 'my-app' } }] });
+
+      await expect(hasSolutionData('grafana-kowalski-app')).resolves.toBe(true);
+      expect(mockGet).toHaveBeenCalledWith(expect.stringContaining('/faroapps'));
+    });
+
+    it('reports no data when the Faro registry is empty', async () => {
+      mockGet.mockResolvedValue({ items: [] });
+
+      await expect(hasSolutionData('grafana-kowalski-app')).resolves.toBe(false);
+    });
+
+    it('fails toward hiding the recommendation when the registry is unreachable', async () => {
+      mockGet.mockRejectedValue(new Error('api unavailable'));
+
+      await expect(hasSolutionData('grafana-kowalski-app')).resolves.toBe(true);
+    }, 15_000);
+  });
+});

--- a/public/app/features/home/Recommendations/solutionDataProbes.ts
+++ b/public/app/features/home/Recommendations/solutionDataProbes.ts
@@ -21,15 +21,16 @@ import { readScalar, runDatasourceQueries, runInstantQueries } from './promQuery
 // "Seen recently" lookback shared by all data probes, tolerating scrape/ingest gaps.
 const DATA_LOOKBACK_HOURS = 24;
 
-// True when any probed candidate datasource of `type` satisfies `hasData`. Throws when every
-// candidate errored — no usable datasource means unknown, not settled no-data.
+// True when any probed candidate datasource of `type` satisfies `hasData`. Throws when nothing
+// was found and any candidate errored: an errored datasource may hold the data, so absence is
+// only settled when every candidate probed clean.
 async function probeFound(
   type: string,
   hasData: (ds: DataSourceInstanceListItem) => Promise<boolean>
 ): Promise<boolean> {
   const candidates = await listProbeCandidates(type);
   let errored = 0;
-  // findDatasourceWithData requires a non-throwing callback; count failures for the all-errored check.
+  // findDatasourceWithData requires a non-throwing callback; count failures for the unknown check.
   const guardedHasData = async (ds: DataSourceInstanceListItem) => {
     try {
       return await hasData(ds);
@@ -42,8 +43,8 @@ async function probeFound(
   if (found) {
     return true;
   }
-  if (candidates.length > 0 && errored === candidates.length) {
-    throw new Error(`Every ${type} datasource probe failed`);
+  if (errored > 0) {
+    throw new Error(`${errored} ${type} datasource probe(s) failed with no data found elsewhere`);
   }
   return false;
 }
@@ -90,9 +91,13 @@ const probesBySolution: Record<string, { get(): Promise<boolean>; reset(): void 
     () => prometheusHasMetric(`count(last_over_time(sm_check_info[${DATA_LOOKBACK_HOURS}h]))`),
     PROBE_TTL_MS
   ),
-  // Application Observability is powered by Tempo metrics-generator span metrics.
+  // Application Observability span metrics arrive under two supported naming schemes:
+  // the spanmetrics connector emits traces_spanmetrics_*, OTel/Alloy emits traces_span_metrics_*.
   [APP_OBSERVABILITY_APP_ID]: createTtlCachedPromise(
-    () => prometheusHasMetric(`count(last_over_time(traces_spanmetrics_calls_total[${DATA_LOOKBACK_HOURS}h]))`),
+    () =>
+      prometheusHasMetric(
+        `count(last_over_time(traces_spanmetrics_calls_total[${DATA_LOOKBACK_HOURS}h])) or count(last_over_time(traces_span_metrics_calls_total[${DATA_LOOKBACK_HOURS}h]))`
+      ),
     PROBE_TTL_MS
   ),
   [HOSTED_TRACES_APP_ID]: createTtlCachedPromise(() => probeFound('tempo', tempoHasTraces), PROBE_TTL_MS),
@@ -101,8 +106,8 @@ const probesBySolution: Record<string, { get(): Promise<boolean>; reset(): void 
 
 /**
  * True when the solution already receives data. An empty candidate list (or empty Faro registry)
- * is definitive no-data; an errored probe — including every candidate failing — reports true:
- * unknown fails toward hiding the recommendation.
+ * is definitive no-data; an errored probe — including any candidate failing while no data was
+ * found elsewhere — reports true: unknown fails toward hiding the recommendation.
  */
 export async function hasSolutionData(pluginId: string): Promise<boolean> {
   const probe = probesBySolution[pluginId];

--- a/public/app/features/home/Recommendations/solutionDataProbes.ts
+++ b/public/app/features/home/Recommendations/solutionDataProbes.ts
@@ -1,0 +1,117 @@
+import { type DataQuery, type DataSourceInstanceListItem, dateTime, type TimeRange } from '@grafana/data';
+import { config, getBackendSrv } from '@grafana/runtime';
+
+import {
+  createTtlCachedPromise,
+  findDatasourceWithData,
+  listProbeCandidates,
+  PROBE_TIMEOUT_MS,
+  PROBE_TTL_MS,
+  withRetry,
+} from './probeUtils';
+import { readScalar, runDatasourceQueries, runInstantQueries } from './promQuery';
+
+// "Seen recently" lookback shared by all data probes, tolerating scrape/ingest gaps.
+const DATA_LOOKBACK_HOURS = 24;
+
+// Solution ids these probes cover (the recommended app plugin ids).
+const SYNTHETIC_MONITORING_APP_ID = 'grafana-synthetic-monitoring-app';
+const APP_OBSERVABILITY_APP_ID = 'grafana-app-observability-app';
+const HOSTED_TRACES_APP_ID = 'grafana-exploretraces-app';
+const FRONTEND_OBSERVABILITY_APP_ID = 'grafana-kowalski-app';
+
+// Any series in the lookback means the solution produces data; which datasource holds it is irrelevant.
+async function prometheusHasMetric(expr: string): Promise<boolean> {
+  const candidates = await listProbeCandidates('prometheus');
+  const found = await findDatasourceWithData(candidates, async (ds) => {
+    try {
+      const frames = await withRetry(() => runInstantQueries({ probe: expr }, ds, PROBE_TIMEOUT_MS));
+      return (readScalar(frames, 'probe') ?? 0) > 0;
+    } catch {
+      // An unusable datasource must not decide the probe.
+      return false;
+    }
+  });
+  return found !== null;
+}
+
+// Synthetic Monitoring stores check results as Prometheus metrics; sm_check_info is its info metric.
+async function hasSyntheticMonitoringData(): Promise<boolean> {
+  return prometheusHasMetric(`count(last_over_time(sm_check_info[${DATA_LOOKBACK_HOURS}h]))`);
+}
+
+// Application Observability is powered by Tempo metrics-generator span metrics.
+async function hasAppObservabilityData(): Promise<boolean> {
+  return prometheusHasMetric(`count(last_over_time(traces_spanmetrics_calls_total[${DATA_LOOKBACK_HOURS}h]))`);
+}
+
+interface TempoSearchQuery extends DataQuery {
+  query: string;
+  limit: number;
+}
+
+async function tempoHasTraces(ds: DataSourceInstanceListItem): Promise<boolean> {
+  try {
+    const toTime = dateTime();
+    const fromTime = dateTime().subtract(DATA_LOOKBACK_HOURS, 'h');
+    const range: TimeRange = {
+      from: fromTime,
+      to: toTime,
+      raw: { from: `now-${DATA_LOOKBACK_HOURS}h`, to: 'now' },
+    };
+    // Tempo search target: match-all TraceQL, one result is enough to prove data exists.
+    const target: TempoSearchQuery = { refId: 'traces', queryType: 'traceql', query: '{}', limit: 1 };
+    const frames = await withRetry(() => runDatasourceQueries([target], range, ds, PROBE_TIMEOUT_MS));
+    return frames.some((frame) => frame.length > 0);
+  } catch {
+    return false;
+  }
+}
+
+async function hasTracesData(): Promise<boolean> {
+  const candidates = await listProbeCandidates('tempo');
+  const found = await findDatasourceWithData(candidates, tempoHasTraces);
+  return found !== null;
+}
+
+// Frontend Observability keeps its instrumented apps in the stack-local FaroApp registry; a
+// configured app means the solution is set up (its telemetry lives behind the Faro collector,
+// not in a probeable stack datasource).
+async function hasFrontendObservabilityData(): Promise<boolean> {
+  const response = await withRetry(() =>
+    getBackendSrv().get<{ items?: unknown[] }>(
+      `/apis/faro.ext.grafana.app/v1alpha1/namespaces/${config.namespace}/faroapps`
+    )
+  );
+  return (response.items ?? []).length > 0;
+}
+
+const probesBySolution: Record<string, { get(): Promise<boolean>; reset(): void }> = {
+  [SYNTHETIC_MONITORING_APP_ID]: createTtlCachedPromise(hasSyntheticMonitoringData, PROBE_TTL_MS),
+  [APP_OBSERVABILITY_APP_ID]: createTtlCachedPromise(hasAppObservabilityData, PROBE_TTL_MS),
+  [HOSTED_TRACES_APP_ID]: createTtlCachedPromise(hasTracesData, PROBE_TTL_MS),
+  [FRONTEND_OBSERVABILITY_APP_ID]: createTtlCachedPromise(hasFrontendObservabilityData, PROBE_TTL_MS),
+};
+
+/**
+ * True when the solution already receives data. Failure semantics: an empty candidate list (or
+ * empty Faro registry) is definitive no-data; a probe that errors out reports true — unknown
+ * fails toward hiding the recommendation, matching the pre-probe behavior for enabled apps.
+ */
+export async function hasSolutionData(pluginId: string): Promise<boolean> {
+  const probe = probesBySolution[pluginId];
+  if (!probe) {
+    // No probe defined: data can never be confirmed, so the solution stays recommendable.
+    return false;
+  }
+  try {
+    return await probe.get();
+  } catch {
+    return true;
+  }
+}
+
+// Reset the cached probe resolutions (test seam).
+export function resetSolutionDataProbes(): void {
+  Object.values(probesBySolution).forEach((probe) => probe.reset());
+}

--- a/public/app/features/home/Recommendations/solutionDataProbes.ts
+++ b/public/app/features/home/Recommendations/solutionDataProbes.ts
@@ -2,6 +2,12 @@ import { type DataQuery, type DataSourceInstanceListItem, dateTime, type TimeRan
 import { config, getBackendSrv } from '@grafana/runtime';
 
 import {
+  APP_OBSERVABILITY_APP_ID,
+  FRONTEND_OBSERVABILITY_APP_ID,
+  HOSTED_TRACES_APP_ID,
+  SYNTHETIC_MONITORING_APP_ID,
+} from './appPluginIds';
+import {
   createTtlCachedPromise,
   findDatasourceWithData,
   listProbeCandidates,
@@ -14,16 +20,17 @@ import { readScalar, runDatasourceQueries, runInstantQueries } from './promQuery
 // "Seen recently" lookback shared by all data probes, tolerating scrape/ingest gaps.
 const DATA_LOOKBACK_HOURS = 24;
 
-// Solution ids these probes cover (the recommended app plugin ids).
-const SYNTHETIC_MONITORING_APP_ID = 'grafana-synthetic-monitoring-app';
-const APP_OBSERVABILITY_APP_ID = 'grafana-app-observability-app';
-const HOSTED_TRACES_APP_ID = 'grafana-exploretraces-app';
-const FRONTEND_OBSERVABILITY_APP_ID = 'grafana-kowalski-app';
+// True when any probed candidate datasource of `type` satisfies `hasData`.
+async function probeFound(
+  type: string,
+  hasData: (ds: DataSourceInstanceListItem) => Promise<boolean>
+): Promise<boolean> {
+  return (await findDatasourceWithData(await listProbeCandidates(type), hasData)) !== null;
+}
 
 // Any series in the lookback means the solution produces data; which datasource holds it is irrelevant.
 async function prometheusHasMetric(expr: string): Promise<boolean> {
-  const candidates = await listProbeCandidates('prometheus');
-  const found = await findDatasourceWithData(candidates, async (ds) => {
+  return probeFound('prometheus', async (ds) => {
     try {
       const frames = await withRetry(() => runInstantQueries({ probe: expr }, ds, PROBE_TIMEOUT_MS));
       return (readScalar(frames, 'probe') ?? 0) > 0;
@@ -32,17 +39,6 @@ async function prometheusHasMetric(expr: string): Promise<boolean> {
       return false;
     }
   });
-  return found !== null;
-}
-
-// Synthetic Monitoring stores check results as Prometheus metrics; sm_check_info is its info metric.
-async function hasSyntheticMonitoringData(): Promise<boolean> {
-  return prometheusHasMetric(`count(last_over_time(sm_check_info[${DATA_LOOKBACK_HOURS}h]))`);
-}
-
-// Application Observability is powered by Tempo metrics-generator span metrics.
-async function hasAppObservabilityData(): Promise<boolean> {
-  return prometheusHasMetric(`count(last_over_time(traces_spanmetrics_calls_total[${DATA_LOOKBACK_HOURS}h]))`);
 }
 
 interface TempoSearchQuery extends DataQuery {
@@ -68,12 +64,6 @@ async function tempoHasTraces(ds: DataSourceInstanceListItem): Promise<boolean> 
   }
 }
 
-async function hasTracesData(): Promise<boolean> {
-  const candidates = await listProbeCandidates('tempo');
-  const found = await findDatasourceWithData(candidates, tempoHasTraces);
-  return found !== null;
-}
-
 // Frontend Observability keeps its instrumented apps in the stack-local FaroApp registry; a
 // configured app means the solution is set up (its telemetry lives behind the Faro collector,
 // not in a probeable stack datasource).
@@ -86,10 +76,19 @@ async function hasFrontendObservabilityData(): Promise<boolean> {
   return (response.items ?? []).length > 0;
 }
 
+// Keyed by the recommended app's plugin id.
 const probesBySolution: Record<string, { get(): Promise<boolean>; reset(): void }> = {
-  [SYNTHETIC_MONITORING_APP_ID]: createTtlCachedPromise(hasSyntheticMonitoringData, PROBE_TTL_MS),
-  [APP_OBSERVABILITY_APP_ID]: createTtlCachedPromise(hasAppObservabilityData, PROBE_TTL_MS),
-  [HOSTED_TRACES_APP_ID]: createTtlCachedPromise(hasTracesData, PROBE_TTL_MS),
+  // Synthetic Monitoring stores check results as Prometheus metrics; sm_check_info is its info metric.
+  [SYNTHETIC_MONITORING_APP_ID]: createTtlCachedPromise(
+    () => prometheusHasMetric(`count(last_over_time(sm_check_info[${DATA_LOOKBACK_HOURS}h]))`),
+    PROBE_TTL_MS
+  ),
+  // Application Observability is powered by Tempo metrics-generator span metrics.
+  [APP_OBSERVABILITY_APP_ID]: createTtlCachedPromise(
+    () => prometheusHasMetric(`count(last_over_time(traces_spanmetrics_calls_total[${DATA_LOOKBACK_HOURS}h]))`),
+    PROBE_TTL_MS
+  ),
+  [HOSTED_TRACES_APP_ID]: createTtlCachedPromise(() => probeFound('tempo', tempoHasTraces), PROBE_TTL_MS),
   [FRONTEND_OBSERVABILITY_APP_ID]: createTtlCachedPromise(hasFrontendObservabilityData, PROBE_TTL_MS),
 };
 

--- a/public/app/features/home/Recommendations/solutionDataProbes.ts
+++ b/public/app/features/home/Recommendations/solutionDataProbes.ts
@@ -1,5 +1,4 @@
 import { type DataQuery, type DataSourceInstanceListItem, dateTime, type TimeRange } from '@grafana/data';
-import { config, getBackendSrv } from '@grafana/runtime';
 
 import {
   APP_OBSERVABILITY_APP_ID,
@@ -7,6 +6,7 @@ import {
   HOSTED_TRACES_APP_ID,
   SYNTHETIC_MONITORING_APP_ID,
 } from './appPluginIds';
+import { fetchFaroApps } from './frontendObservabilityApi';
 import {
   createTtlCachedPromise,
   findDatasourceWithData,
@@ -14,30 +14,45 @@ import {
   PROBE_TIMEOUT_MS,
   PROBE_TTL_MS,
   withRetry,
+  withTimeout,
 } from './probeUtils';
 import { readScalar, runDatasourceQueries, runInstantQueries } from './promQuery';
 
 // "Seen recently" lookback shared by all data probes, tolerating scrape/ingest gaps.
 const DATA_LOOKBACK_HOURS = 24;
 
-// True when any probed candidate datasource of `type` satisfies `hasData`.
+// True when any probed candidate datasource of `type` satisfies `hasData`. Throws when every
+// candidate errored — no usable datasource means unknown, not settled no-data.
 async function probeFound(
   type: string,
   hasData: (ds: DataSourceInstanceListItem) => Promise<boolean>
 ): Promise<boolean> {
-  return (await findDatasourceWithData(await listProbeCandidates(type), hasData)) !== null;
+  const candidates = await listProbeCandidates(type);
+  let errored = 0;
+  // findDatasourceWithData requires a non-throwing callback; count failures for the all-errored check.
+  const guardedHasData = async (ds: DataSourceInstanceListItem) => {
+    try {
+      return await hasData(ds);
+    } catch {
+      errored++;
+      return false;
+    }
+  };
+  const found = await findDatasourceWithData(candidates, guardedHasData);
+  if (found) {
+    return true;
+  }
+  if (candidates.length > 0 && errored === candidates.length) {
+    throw new Error(`Every ${type} datasource probe failed`);
+  }
+  return false;
 }
 
 // Any series in the lookback means the solution produces data; which datasource holds it is irrelevant.
 async function prometheusHasMetric(expr: string): Promise<boolean> {
   return probeFound('prometheus', async (ds) => {
-    try {
-      const frames = await withRetry(() => runInstantQueries({ probe: expr }, ds, PROBE_TIMEOUT_MS));
-      return (readScalar(frames, 'probe') ?? 0) > 0;
-    } catch {
-      // An unusable datasource must not decide the probe.
-      return false;
-    }
+    const frames = await withRetry(() => runInstantQueries({ probe: expr }, ds, PROBE_TIMEOUT_MS));
+    return (readScalar(frames, 'probe') ?? 0) > 0;
   });
 }
 
@@ -47,33 +62,25 @@ interface TempoSearchQuery extends DataQuery {
 }
 
 async function tempoHasTraces(ds: DataSourceInstanceListItem): Promise<boolean> {
-  try {
-    const toTime = dateTime();
-    const fromTime = dateTime().subtract(DATA_LOOKBACK_HOURS, 'h');
-    const range: TimeRange = {
-      from: fromTime,
-      to: toTime,
-      raw: { from: `now-${DATA_LOOKBACK_HOURS}h`, to: 'now' },
-    };
-    // Tempo search target: match-all TraceQL, one result is enough to prove data exists.
-    const target: TempoSearchQuery = { refId: 'traces', queryType: 'traceql', query: '{}', limit: 1 };
-    const frames = await withRetry(() => runDatasourceQueries([target], range, ds, PROBE_TIMEOUT_MS));
-    return frames.some((frame) => frame.length > 0);
-  } catch {
-    return false;
-  }
+  const toTime = dateTime();
+  const fromTime = dateTime().subtract(DATA_LOOKBACK_HOURS, 'h');
+  const range: TimeRange = {
+    from: fromTime,
+    to: toTime,
+    raw: { from: `now-${DATA_LOOKBACK_HOURS}h`, to: 'now' },
+  };
+  // Tempo search target: match-all TraceQL, one result is enough to prove data exists.
+  const target: TempoSearchQuery = { refId: 'traces', queryType: 'traceql', query: '{}', limit: 1 };
+  const frames = await withRetry(() => runDatasourceQueries([target], range, ds, PROBE_TIMEOUT_MS));
+  return frames.some((frame) => frame.length > 0);
 }
 
-// Frontend Observability keeps its instrumented apps in the stack-local FaroApp registry; a
-// configured app means the solution is set up (its telemetry lives behind the Faro collector,
-// not in a probeable stack datasource).
+// Frontend Observability telemetry lives behind the Faro collector, not in a probeable stack
+// datasource — a configured app in its registry is what "set up" means. Timeout-bounded so a
+// hung request cannot hold the whole recommendations section.
 async function hasFrontendObservabilityData(): Promise<boolean> {
-  const response = await withRetry(() =>
-    getBackendSrv().get<{ items?: unknown[] }>(
-      `/apis/faro.ext.grafana.app/v1alpha1/namespaces/${config.namespace}/faroapps`
-    )
-  );
-  return (response.items ?? []).length > 0;
+  const apps = await withRetry(() => withTimeout(fetchFaroApps(), PROBE_TIMEOUT_MS));
+  return apps.length > 0;
 }
 
 // Keyed by the recommended app's plugin id.
@@ -93,9 +100,9 @@ const probesBySolution: Record<string, { get(): Promise<boolean>; reset(): void 
 };
 
 /**
- * True when the solution already receives data. Failure semantics: an empty candidate list (or
- * empty Faro registry) is definitive no-data; a probe that errors out reports true — unknown
- * fails toward hiding the recommendation, matching the pre-probe behavior for enabled apps.
+ * True when the solution already receives data. An empty candidate list (or empty Faro registry)
+ * is definitive no-data; an errored probe — including every candidate failing — reports true:
+ * unknown fails toward hiding the recommendation.
  */
 export async function hasSolutionData(pluginId: string): Promise<boolean> {
   const probe = probesBySolution[pluginId];

--- a/public/app/features/home/Recommendations/types.ts
+++ b/public/app/features/home/Recommendations/types.ts
@@ -11,6 +11,8 @@ export interface RecommendationItem {
   description: string;
   action: string; // CTA label, e.g. "Enable Hosted Traces"
   href: string;
+  /** CTA intent for analytics: enable a disabled app (default) or set up an enabled-but-silent one. */
+  cta?: 'enable' | 'setup';
 }
 
 export interface ExistingItem {

--- a/public/app/features/home/analytics/types.ts
+++ b/public/app/features/home/analytics/types.ts
@@ -25,6 +25,7 @@ export interface CtaClicked extends EventProperty {
     | 'create_dashboard'
     | 'browse_dashboards'
     | 'enable'
+    | 'setup'
     | 'open_solution'
     | 'view_alerts'
     | 'switch_solution'

--- a/public/app/types/accessControl.ts
+++ b/public/app/types/accessControl.ts
@@ -181,6 +181,7 @@ export enum AccessControlAction {
 
   PluginsInstall = 'plugins:install',
   PluginsWrite = 'plugins:write',
+  PluginsAppAccess = 'plugins.app:access',
 
   // Settings
   SettingsRead = 'settings:read',

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -10969,6 +10969,7 @@
         "action": "Enable Application Observability",
         "context": "Built automatically from your telemetry",
         "description": "Turn OpenTelemetry data into RED metrics, service maps, and correlated traces automatically.",
+        "setup-action": "Set up Application Observability",
         "title": "Explore your service map"
       },
       "carousel-label": "Recommended apps",
@@ -10978,6 +10979,7 @@
         "action": "Enable Frontend Observability",
         "context": "Connect the browser to your backend traces",
         "description": "Capture Core Web Vitals and errors from the browser and tie them back to backend traces.",
+        "setup-action": "Set up Frontend Observability",
         "title": "Measure real user experience"
       },
       "go-to": "Go to recommendation {{index}}",
@@ -10994,6 +10996,7 @@
         "action": "Enable Hosted Traces",
         "context": "Complete the picture with distributed tracing",
         "description": "Add distributed tracing to see how requests flow between services and where they slow down.",
+        "setup-action": "Set up Hosted Traces",
         "title": "Trace requests across services"
       },
       "kubernetes": {
@@ -11031,6 +11034,7 @@
         "action": "Add Synthetic Monitoring",
         "context": "Catch outages before your users do",
         "description": "Probe your endpoints from 20+ global locations before your users notice.",
+        "setup-action": "Set up Synthetic Monitoring",
         "title": "Watch your cluster from outside"
       },
       "title": "Recommendations for your stack"


### PR DESCRIPTION
**What is this feature?**

Changes the homepage recommendation filter from "hide when the app is enabled" to "hide when the app is enabled AND its solution receives data". Each enabled recommended solution is probed for live data (Synthetic Monitoring via `sm_check_info`, Application Observability via `traces_spanmetrics_calls_total`, Hosted Traces via a match-all TraceQL search, Frontend Observability via the FaroApp registry). Enabled-but-silent solutions stay recommended with a "Set up" CTA leading into the app instead of "Enable" leading to the catalog, and the `recommendation_enable_clicked` event gains a `cta: enable | setup` property.

**Why do we need this feature?**

Preprovisioned cloud stacks enable the recommended apps by default, which hid the whole recommendations section (and the no-data card) on exactly the empty stacks it was built for. Enabled does not mean used.

**Who is this feature for?**

Users on fresh or preprovisioned stacks where apps are enabled but no telemetry flows yet.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/128468

**Special notes for your reviewer:**

Stacked PR 3/3, based on #128999 (provider registry). Probe machinery shared with the Kubernetes card was extracted into `probeUtils.ts` with no behavior change to the Kubernetes probe. Probe failure semantics: an empty candidate list is definitive no-data (recommend); an unreachable registry/list API fails toward hiding, matching pre-probe behavior.

**Stack:** 1. #128781 (no-data card) -> 2. #128999 (provider registry) -> 3. #129000 (this PR)

