### PR TITLE
Dashboards: Remove dashboardDefaultLayoutSelector feature toggle from frontend

### DIFF
--- a/public/app/features/dashboard-scene/serialization/buildNewDashboardSaveModel.ts
+++ b/public/app/features/dashboard-scene/serialization/buildNewDashboardSaveModel.ts
@@ -162,12 +162,10 @@ export async function buildNewDashboardSaveModelV2(
   }
 
   // Initialize default preferences to be same as the default layout
-  if (config.featureToggles.dashboardDefaultLayoutSelector) {
-    data.spec.preferences = {
-      ...data.spec.preferences,
-      layout: defaultGridLayoutKind(),
-    };
-  }
+  data.spec.preferences = {
+    ...data.spec.preferences,
+    layout: defaultGridLayoutKind(),
+  };
 
   return data;
 }

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
@@ -197,7 +197,7 @@ export function transformSaveModelSchemaV2ToScene(
     .deserialize(dashboard.layout, dashboard.elements, dashboard.preload);
 
   let templateLayoutManager: DashboardLayoutManager | undefined = undefined;
-  if (config.featureToggles.dashboardDefaultLayoutSelector && dashboard.preferences?.layout) {
+  if (dashboard.preferences?.layout) {
     templateLayoutManager = layoutDeserializerRegistry
       .get(dashboard.preferences.layout.kind)
       .deserialize(dashboard.preferences.layout, {}, false);

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
@@ -93,7 +93,7 @@ export function transformSceneToSaveModelSchemaV2(scene: DashboardScene, isSnaps
 
   let preferences: Preferences | undefined = undefined;
 
-  if (config.featureToggles.dashboardDefaultLayoutSelector && sceneDash.preferences?.defaultLayoutTemplate) {
+  if (sceneDash.preferences?.defaultLayoutTemplate) {
     const template = sceneDash.preferences.defaultLayoutTemplate;
     const serialized = template.serialize();
     if (serialized.kind === 'AutoGridLayout' || serialized.kind === 'GridLayout') {

--- a/public/app/features/dashboard-scene/settings/GeneralSettingsEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/GeneralSettingsEditView.tsx
@@ -337,22 +337,16 @@ function GeneralSettingsEditViewComponent({ model }: SceneComponentProps<General
             <RadioButtonGroup value={editable} options={EDITABLE_OPTIONS} onChange={model.onEditableChange} />
           </Field>
 
-          {config.featureToggles.dashboardDefaultLayoutSelector && (
-            <Field
-              noMargin
-              label={t('dashboard-settings.general.default-grid-label', 'Default grid')}
-              description={t(
-                'dashboard-settings.general.default-grid-description',
-                'Select layout type to be used for new rows and tabs'
-              )}
-            >
-              <RadioButtonGroup
-                value={defaultGrid}
-                options={DEFAULT_GRID_OPTIONS}
-                onChange={model.onDefaultGridChange}
-              />
-            </Field>
-          )}
+          <Field
+            noMargin
+            label={t('dashboard-settings.general.default-grid-label', 'Default grid')}
+            description={t(
+              'dashboard-settings.general.default-grid-description',
+              'Select layout type to be used for new rows and tabs'
+            )}
+          >
+            <RadioButtonGroup value={defaultGrid} options={DEFAULT_GRID_OPTIONS} onChange={model.onDefaultGridChange} />
+          </Field>
         </Box>
 
         <TimePickerSettings

--- a/public/app/features/dashboard-scene/settings/GeneralSettingsEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/GeneralSettingsEditView.tsx
@@ -2,7 +2,6 @@ import { type ChangeEvent } from 'react';
 
 import { PageLayoutType } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { config } from '@grafana/runtime';
 import { type SceneComponentProps, SceneObjectBase, behaviors, sceneGraph } from '@grafana/scenes';
 import { type TimeZone } from '@grafana/schema';
 import {

--- a/public/app/features/dashboard/dashgrid/DashboardEmpty/DashboardEmpty.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardEmpty/DashboardEmpty.tsx
@@ -84,16 +84,12 @@ const NewLayoutEmpty = ({ dashboard, styles }: NewLayoutEmptyProps) => {
 
   const onSelectAutoGrid = () => {
     dashboard.switchLayout(AutoGridLayoutManager.createEmpty());
-    if (config.featureToggles.dashboardDefaultLayoutSelector) {
-      dashboard.updateDefaultLayoutTemplate(AutoGridLayoutManager.createEmpty());
-    }
+    dashboard.updateDefaultLayoutTemplate(AutoGridLayoutManager.createEmpty());
   };
 
   const onSelectCustomGrid = () => {
     dashboard.switchLayout(DefaultGridLayoutManager.createEmpty());
-    if (config.featureToggles.dashboardDefaultLayoutSelector) {
-      dashboard.updateDefaultLayoutTemplate(DefaultGridLayoutManager.createEmpty());
-    }
+    dashboard.updateDefaultLayoutTemplate(DefaultGridLayoutManager.createEmpty());
   };
 
   return (
@@ -110,47 +106,43 @@ const NewLayoutEmpty = ({ dashboard, styles }: NewLayoutEmptyProps) => {
             <Trans i18nKey="dashboard.empty.description">Add a panel to visualize your data</Trans>
           </Text>
         </Box>
-        {config.featureToggles.dashboardDefaultLayoutSelector && (
-          <>
-            <Box marginTop={3} paddingX={4} display="flex" justifyContent="center" alignItems="center" gap={1}>
-              <Text element="p" textAlignment="center" color="secondary">
-                <Trans i18nKey="dashboard.empty.select-layout-header">Select layout</Trans>
-              </Text>
-              <Tooltip
-                placement="top"
-                content={
-                  <Trans i18nKey="dashboard.empty.layout-default-hint">
-                    The selected layout will also be used as the default for all new tabs and rows. You can change this
-                    later in Dashboard Settings &gt; General.
-                  </Trans>
-                }
-              >
-                <Icon name="info-circle" size="sm" />
-              </Tooltip>
-            </Box>
-            <Box marginTop={1} display="flex" justifyContent="center">
-              <Stack gap={1}>
-                <FilterPill
-                  label={t('dashboard.empty.auto-grid', 'Auto grid')}
-                  selected={isAutoGrid}
-                  onClick={onSelectAutoGrid}
-                />
-                <FilterPill
-                  label={t('dashboard.empty.custom-grid', 'Custom grid')}
-                  selected={!isAutoGrid}
-                  onClick={onSelectCustomGrid}
-                />
-              </Stack>
-            </Box>
-            <Box marginTop={1} paddingX={4}>
-              <Text element="p" textAlignment="center" color="secondary">
-                {isAutoGrid
-                  ? t('dashboard.empty.auto-grid-description', 'Panels resize to fit and form uniform grids')
-                  : t('dashboard.empty.custom-grid-description', 'Position and size each panel individually')}
-              </Text>
-            </Box>
-          </>
-        )}
+        <Box marginTop={3} paddingX={4} display="flex" justifyContent="center" alignItems="center" gap={1}>
+          <Text element="p" textAlignment="center" color="secondary">
+            <Trans i18nKey="dashboard.empty.select-layout-header">Select layout</Trans>
+          </Text>
+          <Tooltip
+            placement="top"
+            content={
+              <Trans i18nKey="dashboard.empty.layout-default-hint">
+                The selected layout will also be used as the default for all new tabs and rows. You can change this
+                later in Dashboard Settings &gt; General.
+              </Trans>
+            }
+          >
+            <Icon name="info-circle" size="sm" />
+          </Tooltip>
+        </Box>
+        <Box marginTop={1} display="flex" justifyContent="center">
+          <Stack gap={1}>
+            <FilterPill
+              label={t('dashboard.empty.auto-grid', 'Auto grid')}
+              selected={isAutoGrid}
+              onClick={onSelectAutoGrid}
+            />
+            <FilterPill
+              label={t('dashboard.empty.custom-grid', 'Custom grid')}
+              selected={!isAutoGrid}
+              onClick={onSelectCustomGrid}
+            />
+          </Stack>
+        </Box>
+        <Box marginTop={1} paddingX={4}>
+          <Text element="p" textAlignment="center" color="secondary">
+            {isAutoGrid
+              ? t('dashboard.empty.auto-grid-description', 'Panels resize to fit and form uniform grids')
+              : t('dashboard.empty.custom-grid-description', 'Position and size each panel individually')}
+          </Text>
+        </Box>
       </Box>
     </Stack>
   );


### PR DESCRIPTION
Only FE. Backend registry update [PR](https://github.com/grafana/grafana/pull/129006) is separate due to different release cadence. This has been enabled by default since april. We've had one minor onprem release since then. [Cloud usage is 99.7%](https://ops.grafana-ops.net/goto/srlv92?orgId=stacks-27821) 