### PR TITLE
[release-13.1.2] Packaging: Fix error removing bundled plugins dir when upgrading Grafana

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -25,6 +25,9 @@ logs = data/log
 # Directory where grafana will automatically scan and look for plugins
 plugins = data/plugins
 
+# Directory where grafana looks for the plugins bundled with the Grafana distribution
+bundled_plugins = data/plugins-bundled
+
 # folder that contains provisioning config files that grafana will apply on startup and while running.
 provisioning = conf/provisioning
 

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -23,6 +23,9 @@
 # Directory where grafana will automatically scan and look for plugins
 ;plugins = /var/lib/grafana/plugins
 
+# Directory where grafana looks for the plugins bundled with the Grafana distribution
+;bundled_plugins = /var/lib/grafana/plugins-bundled
+
 # folder that contains provisioning config files that grafana will apply on startup and while running.
 ;provisioning = conf/provisioning
 

--- a/packaging/deb/control/postinst
+++ b/packaging/deb/control/postinst
@@ -25,6 +25,13 @@ if [ "$1" = configure ]; then
 
   # Set user permissions on /var/log/grafana, /var/lib/grafana
   mkdir -p /var/log/grafana "$DATA_DIR"
+  # Bundled plugins must live under $DATA_DIR (writable by grafana) so the
+  # plugin auto-updater can replace them. Any copy already at the destination
+  # is stale and safe to clobber; mv alone would fail or nest into it.
+  if [ -d "$GRAFANA_HOME/data/plugins-bundled" ]; then
+    rm -rf "${DATA_DIR:?}/plugins-bundled"
+    mv "$GRAFANA_HOME/data/plugins-bundled" "$DATA_DIR"
+  fi
   chown -R "$GRAFANA_USER":"$GRAFANA_GROUP" /var/log/grafana "$DATA_DIR"
   chmod 755 /var/log/grafana "$DATA_DIR"
 

--- a/packaging/deb/control/postinst
+++ b/packaging/deb/control/postinst
@@ -13,6 +13,7 @@ if [ "$1" = configure ]; then
   [ -z "$GRAFANA_USER" ] && GRAFANA_USER="grafana"
   [ -z "$GRAFANA_GROUP" ] && GRAFANA_GROUP="grafana"
   [ -z "$GRAFANA_HOME" ] && GRAFANA_HOME="/usr/share/grafana"
+  [ -z "$DATA_DIR" ] && DATA_DIR="/var/lib/grafana"
   if ! getent group "$GRAFANA_GROUP" > /dev/null 2>&1 ; then
     addgroup --system "$GRAFANA_GROUP" --quiet
   fi
@@ -25,7 +26,12 @@ if [ "$1" = configure ]; then
   # Set user permissions on /var/log/grafana, /var/lib/grafana
   mkdir -p /var/log/grafana /var/lib/grafana
   # Move plugins-bundled into place, see https://github.com/grafana/grafana/issues/123110
-  mv $GRAFANA_HOME/data/plugins-bundled $DATA_DIR
+  if [ -d "$GRAFANA_HOME/data/plugins-bundled" ]; then
+    mkdir -p "$DATA_DIR"
+    rm -rf "${DATA_DIR:?}/plugins-bundled"
+    mv "$GRAFANA_HOME/data/plugins-bundled" "$DATA_DIR"
+    chown -R "$GRAFANA_USER":"$GRAFANA_GROUP" "$DATA_DIR/plugins-bundled"
+  fi
   chown -R $GRAFANA_USER:$GRAFANA_GROUP /var/log/grafana /var/lib/grafana
   chmod 755 /var/log/grafana /var/lib/grafana
 

--- a/packaging/deb/control/postinst
+++ b/packaging/deb/control/postinst
@@ -25,11 +25,6 @@ if [ "$1" = configure ]; then
 
   # Set user permissions on /var/log/grafana, /var/lib/grafana
   mkdir -p /var/log/grafana "$DATA_DIR"
-  # Move plugins-bundled into place, see https://github.com/grafana/grafana/issues/123110
-  if [ -d "$GRAFANA_HOME/data/plugins-bundled" ]; then
-    rm -rf "${DATA_DIR:?}/plugins-bundled"
-    mv "$GRAFANA_HOME/data/plugins-bundled" "$DATA_DIR"
-  fi
   chown -R "$GRAFANA_USER":"$GRAFANA_GROUP" /var/log/grafana "$DATA_DIR"
   chmod 755 /var/log/grafana "$DATA_DIR"
 

--- a/packaging/deb/control/postinst
+++ b/packaging/deb/control/postinst
@@ -30,9 +30,8 @@ if [ "$1" = configure ]; then
     mkdir -p "$DATA_DIR"
     rm -rf "${DATA_DIR:?}/plugins-bundled"
     mv "$GRAFANA_HOME/data/plugins-bundled" "$DATA_DIR"
-    chown -R "$GRAFANA_USER":"$GRAFANA_GROUP" "$DATA_DIR/plugins-bundled"
   fi
-  chown -R $GRAFANA_USER:$GRAFANA_GROUP /var/log/grafana /var/lib/grafana
+  chown -R "$GRAFANA_USER":"$GRAFANA_GROUP" /var/log/grafana "$DATA_DIR"
   chmod 755 /var/log/grafana /var/lib/grafana
 
   # copy user config files

--- a/packaging/deb/control/postinst
+++ b/packaging/deb/control/postinst
@@ -24,15 +24,14 @@ if [ "$1" = configure ]; then
   fi
 
   # Set user permissions on /var/log/grafana, /var/lib/grafana
-  mkdir -p /var/log/grafana /var/lib/grafana
+  mkdir -p /var/log/grafana "$DATA_DIR"
   # Move plugins-bundled into place, see https://github.com/grafana/grafana/issues/123110
   if [ -d "$GRAFANA_HOME/data/plugins-bundled" ]; then
-    mkdir -p "$DATA_DIR"
     rm -rf "${DATA_DIR:?}/plugins-bundled"
     mv "$GRAFANA_HOME/data/plugins-bundled" "$DATA_DIR"
   fi
   chown -R "$GRAFANA_USER":"$GRAFANA_GROUP" /var/log/grafana "$DATA_DIR"
-  chmod 755 /var/log/grafana /var/lib/grafana
+  chmod 755 /var/log/grafana "$DATA_DIR"
 
   # copy user config files
   if [ ! -f $CONF_FILE ]; then

--- a/packaging/deb/control/postinst
+++ b/packaging/deb/control/postinst
@@ -26,11 +26,13 @@ if [ "$1" = configure ]; then
   # Set user permissions on /var/log/grafana, /var/lib/grafana
   mkdir -p /var/log/grafana "$DATA_DIR"
   # Bundled plugins must live under $DATA_DIR (writable by grafana) so the
-  # plugin auto-updater can replace them. Any copy already at the destination
-  # is stale and safe to clobber; mv alone would fail or nest into it.
+  # plugin auto-updater can replace them; the service points
+  # paths.bundled_plugins there. Copy instead of move so the packaged files
+  # stay in place and `dpkg --verify` stays clean. Any copy already at the
+  # destination is stale and safe to clobber.
   if [ -d "$GRAFANA_HOME/data/plugins-bundled" ]; then
     rm -rf "${DATA_DIR:?}/plugins-bundled"
-    mv "$GRAFANA_HOME/data/plugins-bundled" "$DATA_DIR"
+    cp -a "$GRAFANA_HOME/data/plugins-bundled" "$DATA_DIR"
   fi
   chown -R "$GRAFANA_USER":"$GRAFANA_GROUP" /var/log/grafana "$DATA_DIR"
   chmod 755 /var/log/grafana "$DATA_DIR"

--- a/packaging/deb/init.d/grafana-server
+++ b/packaging/deb/init.d/grafana-server
@@ -56,7 +56,7 @@ if [ -f "$DEFAULT" ]; then
   . "$DEFAULT"
 fi
 
-DAEMON_OPTS="server --pidfile=${PID_FILE} --config=${CONF_FILE} --packaging=deb cfg:default.paths.provisioning=$PROVISIONING_CFG_DIR cfg:default.paths.data=${DATA_DIR} cfg:default.paths.logs=${LOG_DIR} cfg:default.paths.plugins=${PLUGINS_DIR}"
+DAEMON_OPTS="server --pidfile=${PID_FILE} --config=${CONF_FILE} --packaging=deb cfg:default.paths.provisioning=$PROVISIONING_CFG_DIR cfg:default.paths.data=${DATA_DIR} cfg:default.paths.logs=${LOG_DIR} cfg:default.paths.plugins=${PLUGINS_DIR} cfg:default.paths.bundled_plugins=${DATA_DIR}/plugins-bundled"
 
 function checkUser() {
   if [ `id -u` -ne 0 ]; then

--- a/packaging/deb/systemd/grafana-server.service
+++ b/packaging/deb/systemd/grafana-server.service
@@ -21,7 +21,8 @@ ExecStart=/usr/share/grafana/bin/grafana server                                 
                             cfg:default.paths.logs=${LOG_DIR}                       \
                             cfg:default.paths.data=${DATA_DIR}                      \
                             cfg:default.paths.plugins=${PLUGINS_DIR}                \
-                            cfg:default.paths.provisioning=${PROVISIONING_CFG_DIR}
+                            cfg:default.paths.provisioning=${PROVISIONING_CFG_DIR}  \
+                            cfg:default.paths.bundled_plugins=${DATA_DIR}/plugins-bundled
 
 LimitNOFILE=10000
 TimeoutStopSec=20

--- a/packaging/rpm/control/postinst
+++ b/packaging/rpm/control/postinst
@@ -31,11 +31,6 @@ if [ $1 -eq 1 ] ; then
 
   # Set user permissions on /var/log/grafana, /var/lib/grafana
   mkdir -p /var/log/grafana "$DATA_DIR"
-  # Move plugins-bundled into place - see https://github.com/grafana/grafana/issues/123110
-  if [ -d "$GRAFANA_HOME/data/plugins-bundled" ]; then
-    rm -rf "${DATA_DIR:?}/plugins-bundled"
-    mv "$GRAFANA_HOME/data/plugins-bundled" "$DATA_DIR"
-  fi
   chown -R "$GRAFANA_USER":"$GRAFANA_GROUP" /var/log/grafana "$DATA_DIR"
   chmod 755 /var/log/grafana "$DATA_DIR"
 
@@ -86,14 +81,6 @@ elif [ $1 -ge 2 ] ; then
 
   if [ "$RESTART_ON_UPGRADE" == "true" ]; then
     stopGrafana
-  fi
-
-  # Replace bundled plugins with the new version - see https://github.com/grafana/grafana/issues/123110
-  mkdir -p "$DATA_DIR"
-  if [ -d "$GRAFANA_HOME/data/plugins-bundled" ]; then
-    rm -rf "${DATA_DIR:?}/plugins-bundled"
-    mv "$GRAFANA_HOME/data/plugins-bundled" "$DATA_DIR"
-    chown -R "$GRAFANA_USER":"$GRAFANA_GROUP" "$DATA_DIR/plugins-bundled"
   fi
 
   if [ "$RESTART_ON_UPGRADE" == "true" ]; then

--- a/packaging/rpm/control/postinst
+++ b/packaging/rpm/control/postinst
@@ -31,6 +31,13 @@ if [ $1 -eq 1 ] ; then
 
   # Set user permissions on /var/log/grafana, /var/lib/grafana
   mkdir -p /var/log/grafana "$DATA_DIR"
+  # Bundled plugins must live under $DATA_DIR (writable by grafana) so the
+  # plugin auto-updater can replace them. Any copy already at the destination
+  # is stale and safe to clobber; mv alone would fail or nest into it.
+  if [ -d "$GRAFANA_HOME/data/plugins-bundled" ]; then
+    rm -rf "${DATA_DIR:?}/plugins-bundled"
+    mv "$GRAFANA_HOME/data/plugins-bundled" "$DATA_DIR"
+  fi
   chown -R "$GRAFANA_USER":"$GRAFANA_GROUP" /var/log/grafana "$DATA_DIR"
   chmod 755 /var/log/grafana "$DATA_DIR"
 
@@ -74,6 +81,19 @@ if [ $1 -eq 1 ] ; then
   echo " sudo /bin/systemctl start grafana-server.service"
 
 elif [ $1 -ge 2 ] ; then
+  [ -z "$GRAFANA_USER" ] && GRAFANA_USER="grafana"
+  [ -z "$GRAFANA_GROUP" ] && GRAFANA_GROUP="grafana"
+  [ -z "$GRAFANA_HOME" ] && GRAFANA_HOME="/usr/share/grafana"
+  [ -z "$DATA_DIR" ] && DATA_DIR="/var/lib/grafana"
+
+  # Replace the bundled plugins with the ones shipped in the new package.
+  # See the matching move in the fresh-install branch above.
+  if [ -d "$GRAFANA_HOME/data/plugins-bundled" ]; then
+    rm -rf "${DATA_DIR:?}/plugins-bundled"
+    mv "$GRAFANA_HOME/data/plugins-bundled" "$DATA_DIR"
+    chown -R "$GRAFANA_USER":"$GRAFANA_GROUP" "$DATA_DIR/plugins-bundled"
+  fi
+
   if [ "$RESTART_ON_UPGRADE" == "true" ]; then
     stopGrafana
     startGrafana

--- a/packaging/rpm/control/postinst
+++ b/packaging/rpm/control/postinst
@@ -30,15 +30,14 @@ if [ $1 -eq 1 ] ; then
   fi
 
   # Set user permissions on /var/log/grafana, /var/lib/grafana
-  mkdir -p /var/log/grafana /var/lib/grafana
+  mkdir -p /var/log/grafana "$DATA_DIR"
   # Move plugins-bundled into place - see https://github.com/grafana/grafana/issues/123110
   if [ -d "$GRAFANA_HOME/data/plugins-bundled" ]; then
-    mkdir -p "$DATA_DIR"
     rm -rf "${DATA_DIR:?}/plugins-bundled"
     mv "$GRAFANA_HOME/data/plugins-bundled" "$DATA_DIR"
   fi
   chown -R "$GRAFANA_USER":"$GRAFANA_GROUP" /var/log/grafana "$DATA_DIR"
-  chmod 755 /var/log/grafana /var/lib/grafana
+  chmod 755 /var/log/grafana "$DATA_DIR"
 
   # copy user config files
   if [ ! -f $CONF_FILE ]; then
@@ -90,8 +89,8 @@ elif [ $1 -ge 2 ] ; then
   fi
 
   # Replace bundled plugins with the new version - see https://github.com/grafana/grafana/issues/123110
+  mkdir -p "$DATA_DIR"
   if [ -d "$GRAFANA_HOME/data/plugins-bundled" ]; then
-    mkdir -p "$DATA_DIR"
     rm -rf "${DATA_DIR:?}/plugins-bundled"
     mv "$GRAFANA_HOME/data/plugins-bundled" "$DATA_DIR"
     chown -R "$GRAFANA_USER":"$GRAFANA_GROUP" "$DATA_DIR/plugins-bundled"

--- a/packaging/rpm/control/postinst
+++ b/packaging/rpm/control/postinst
@@ -19,6 +19,8 @@ stopGrafana() {
 if [ $1 -eq 1 ] ; then
   [ -z "$GRAFANA_USER" ] && GRAFANA_USER="grafana"
   [ -z "$GRAFANA_GROUP" ] && GRAFANA_GROUP="grafana"
+  [ -z "$GRAFANA_HOME" ] && GRAFANA_HOME="/usr/share/grafana"
+  [ -z "$DATA_DIR" ] && DATA_DIR="/var/lib/grafana"
   if ! getent group "$GRAFANA_GROUP" > /dev/null 2>&1 ; then
     groupadd -r "$GRAFANA_GROUP"
   fi
@@ -30,7 +32,12 @@ if [ $1 -eq 1 ] ; then
   # Set user permissions on /var/log/grafana, /var/lib/grafana
   mkdir -p /var/log/grafana /var/lib/grafana
   # Move plugins-bundled into place - see https://github.com/grafana/grafana/issues/123110
-  mv $GRAFANA_HOME/data/plugins-bundled $DATA_DIR
+  if [ -d "$GRAFANA_HOME/data/plugins-bundled" ]; then
+    mkdir -p "$DATA_DIR"
+    rm -rf "${DATA_DIR:?}/plugins-bundled"
+    mv "$GRAFANA_HOME/data/plugins-bundled" "$DATA_DIR"
+    chown -R "$GRAFANA_USER":"$GRAFANA_GROUP" "$DATA_DIR/plugins-bundled"
+  fi
   chown -R $GRAFANA_USER:$GRAFANA_GROUP /var/log/grafana /var/lib/grafana
   chmod 755 /var/log/grafana /var/lib/grafana
 
@@ -74,8 +81,24 @@ if [ $1 -eq 1 ] ; then
   echo " sudo /bin/systemctl start grafana-server.service"
 
 elif [ $1 -ge 2 ] ; then
+  [ -z "$GRAFANA_USER" ] && GRAFANA_USER="grafana"
+  [ -z "$GRAFANA_GROUP" ] && GRAFANA_GROUP="grafana"
+  [ -z "$GRAFANA_HOME" ] && GRAFANA_HOME="/usr/share/grafana"
+  [ -z "$DATA_DIR" ] && DATA_DIR="/var/lib/grafana"
+
   if [ "$RESTART_ON_UPGRADE" == "true" ]; then
     stopGrafana
+  fi
+
+  # Replace bundled plugins with the new version - see https://github.com/grafana/grafana/issues/123110
+  if [ -d "$GRAFANA_HOME/data/plugins-bundled" ]; then
+    mkdir -p "$DATA_DIR"
+    rm -rf "${DATA_DIR:?}/plugins-bundled"
+    mv "$GRAFANA_HOME/data/plugins-bundled" "$DATA_DIR"
+    chown -R "$GRAFANA_USER":"$GRAFANA_GROUP" "$DATA_DIR/plugins-bundled"
+  fi
+
+  if [ "$RESTART_ON_UPGRADE" == "true" ]; then
     startGrafana
   fi
 fi

--- a/packaging/rpm/control/postinst
+++ b/packaging/rpm/control/postinst
@@ -89,6 +89,7 @@ elif [ $1 -ge 2 ] ; then
   # Replace the bundled plugins with the ones shipped in the new package.
   # See the matching move in the fresh-install branch above.
   if [ -d "$GRAFANA_HOME/data/plugins-bundled" ]; then
+    mkdir -p "$DATA_DIR"
     rm -rf "${DATA_DIR:?}/plugins-bundled"
     mv "$GRAFANA_HOME/data/plugins-bundled" "$DATA_DIR"
     chown -R "$GRAFANA_USER":"$GRAFANA_GROUP" "$DATA_DIR/plugins-bundled"

--- a/packaging/rpm/control/postinst
+++ b/packaging/rpm/control/postinst
@@ -36,9 +36,8 @@ if [ $1 -eq 1 ] ; then
     mkdir -p "$DATA_DIR"
     rm -rf "${DATA_DIR:?}/plugins-bundled"
     mv "$GRAFANA_HOME/data/plugins-bundled" "$DATA_DIR"
-    chown -R "$GRAFANA_USER":"$GRAFANA_GROUP" "$DATA_DIR/plugins-bundled"
   fi
-  chown -R $GRAFANA_USER:$GRAFANA_GROUP /var/log/grafana /var/lib/grafana
+  chown -R "$GRAFANA_USER":"$GRAFANA_GROUP" /var/log/grafana "$DATA_DIR"
   chmod 755 /var/log/grafana /var/lib/grafana
 
   # copy user config files

--- a/packaging/rpm/control/postinst
+++ b/packaging/rpm/control/postinst
@@ -74,16 +74,8 @@ if [ $1 -eq 1 ] ; then
   echo " sudo /bin/systemctl start grafana-server.service"
 
 elif [ $1 -ge 2 ] ; then
-  [ -z "$GRAFANA_USER" ] && GRAFANA_USER="grafana"
-  [ -z "$GRAFANA_GROUP" ] && GRAFANA_GROUP="grafana"
-  [ -z "$GRAFANA_HOME" ] && GRAFANA_HOME="/usr/share/grafana"
-  [ -z "$DATA_DIR" ] && DATA_DIR="/var/lib/grafana"
-
   if [ "$RESTART_ON_UPGRADE" == "true" ]; then
     stopGrafana
-  fi
-
-  if [ "$RESTART_ON_UPGRADE" == "true" ]; then
     startGrafana
   fi
 fi

--- a/packaging/rpm/control/postinst
+++ b/packaging/rpm/control/postinst
@@ -32,11 +32,13 @@ if [ $1 -eq 1 ] ; then
   # Set user permissions on /var/log/grafana, /var/lib/grafana
   mkdir -p /var/log/grafana "$DATA_DIR"
   # Bundled plugins must live under $DATA_DIR (writable by grafana) so the
-  # plugin auto-updater can replace them. Any copy already at the destination
-  # is stale and safe to clobber; mv alone would fail or nest into it.
+  # plugin auto-updater can replace them; the service points
+  # paths.bundled_plugins there. Copy instead of move so the packaged files
+  # stay in place and `rpm -V` stays clean. Any copy already at the
+  # destination is stale and safe to clobber.
   if [ -d "$GRAFANA_HOME/data/plugins-bundled" ]; then
     rm -rf "${DATA_DIR:?}/plugins-bundled"
-    mv "$GRAFANA_HOME/data/plugins-bundled" "$DATA_DIR"
+    cp -a "$GRAFANA_HOME/data/plugins-bundled" "$DATA_DIR"
   fi
   chown -R "$GRAFANA_USER":"$GRAFANA_GROUP" /var/log/grafana "$DATA_DIR"
   chmod 755 /var/log/grafana "$DATA_DIR"
@@ -87,11 +89,11 @@ elif [ $1 -ge 2 ] ; then
   [ -z "$DATA_DIR" ] && DATA_DIR="/var/lib/grafana"
 
   # Replace the bundled plugins with the ones shipped in the new package.
-  # See the matching move in the fresh-install branch above.
+  # See the matching copy in the fresh-install branch above.
   if [ -d "$GRAFANA_HOME/data/plugins-bundled" ]; then
     mkdir -p "$DATA_DIR"
     rm -rf "${DATA_DIR:?}/plugins-bundled"
-    mv "$GRAFANA_HOME/data/plugins-bundled" "$DATA_DIR"
+    cp -a "$GRAFANA_HOME/data/plugins-bundled" "$DATA_DIR"
     chown -R "$GRAFANA_USER":"$GRAFANA_GROUP" "$DATA_DIR/plugins-bundled"
   fi
 

--- a/packaging/rpm/systemd/grafana-server.service
+++ b/packaging/rpm/systemd/grafana-server.service
@@ -21,7 +21,8 @@ ExecStart=/usr/share/grafana/bin/grafana server                                 
                             cfg:default.paths.logs=${LOG_DIR}                       \
                             cfg:default.paths.data=${DATA_DIR}                      \
                             cfg:default.paths.plugins=${PLUGINS_DIR}                \
-                            cfg:default.paths.provisioning=${PROVISIONING_CFG_DIR}
+                            cfg:default.paths.provisioning=${PROVISIONING_CFG_DIR}  \
+                            cfg:default.paths.bundled_plugins=${DATA_DIR}/plugins-bundled
 
 LimitNOFILE=10000
 TimeoutStopSec=20

--- a/packaging/wrappers/grafana
+++ b/packaging/wrappers/grafana
@@ -37,7 +37,7 @@ if [ "$1" = cli ] || [ "$1" = server ]; then
   OPTS=(
     "--homepath=${GRAFANA_HOME}"
     "--config=${CONF_FILE}"
-    "--configOverrides=cfg:default.paths.provisioning=${PROVISIONING_CFG_DIR} cfg:default.paths.data=${DATA_DIR} cfg:default.paths.logs=${LOG_DIR} cfg:default.paths.plugins=${PLUGINS_DIR}"
+    "--configOverrides=cfg:default.paths.provisioning=${PROVISIONING_CFG_DIR} cfg:default.paths.data=${DATA_DIR} cfg:default.paths.logs=${LOG_DIR} cfg:default.paths.plugins=${PLUGINS_DIR} cfg:default.paths.bundled_plugins=${DATA_DIR}/plugins-bundled"
   )
   # special handling to pass --pluginsDir to cli
   # can remove once it fully supports cfg:default.paths.plugins


### PR DESCRIPTION
The original script worked fine on install because the dir didn't exist, and on first update.  On follow-up upgrades it fails because the dir already exists.

This update removes the dir if it exists before moving the new bundled plugins into the data dir.