### PR TITLE
Navigation: Report interactions for mega menu hide actions

### DIFF
--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenu.test.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenu.test.tsx
@@ -246,7 +246,11 @@ describe('MegaMenu', () => {
           expect.objectContaining({ path: '/playlists' })
         );
 
-        // While editing it stays visible (greyed) and can be shown again.
+        // While editing it stays visible (greyed) and the control flips to a Show toggle.
+        await user.click(await screen.findByRole('button', { name: 'Show Playlists' }));
+
+        // Revealing flips the control back — the item is no longer marked hidden.
+        await user.click(await screen.findByRole('button', { name: 'Hide Playlists' }));
         expect(await screen.findByRole('button', { name: 'Show Playlists' })).toBeInTheDocument();
 
         await user.click(screen.getByRole('button', { name: 'Done' }));

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenu.test.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenu.test.tsx
@@ -240,6 +240,12 @@ describe('MegaMenu', () => {
         await user.click(await screen.findByRole('button', { name: 'Expand section: Dashboards' }));
         await user.click(await screen.findByRole('button', { name: 'Hide Playlists' }));
 
+        // Hiding reports an interaction (path = the item's url).
+        expect(reportInteraction).toHaveBeenCalledWith(
+          'grafana_nav_item_hidden',
+          expect.objectContaining({ path: '/playlists' })
+        );
+
         // While editing it stays visible (greyed) and can be shown again.
         expect(await screen.findByRole('button', { name: 'Show Playlists' })).toBeInTheDocument();
 
@@ -557,10 +563,11 @@ describe('MegaMenu', () => {
         await user.click(screen.getByRole('button', { name: 'Done' }));
 
         await waitFor(() => expect(mockUserPreferences.navbar?.bookmarkUrls).toEqual(['/playlists']));
-        expect(reportInteraction).toHaveBeenCalledWith('grafana_nav_customise_saved', {
-          hiddenCount: 0,
-          pinnedCount: 1,
-        });
+        // objectContaining: the event also carries the A/B experiment variant stamp.
+        expect(reportInteraction).toHaveBeenCalledWith(
+          'grafana_nav_customise_saved',
+          expect.objectContaining({ hiddenCount: 0, pinnedCount: 1 })
+        );
       });
     });
   });

--- a/public/app/core/components/AppChrome/MegaMenu/hooks.ts
+++ b/public/app/core/components/AppChrome/MegaMenu/hooks.ts
@@ -197,7 +197,7 @@ const usePinning = ({
   // Reorder the pinned entries (staged; persisted on save). Each entry is one pinned url, so this is
   // a plain move within the stored url list.
   const onReorderPinned = useCallback((fromIndex: number, toIndex: number) => {
-    reportInteraction('grafana_nav_pinned_reordered');
+    reportInteraction('grafana_nav_pinned_reordered', { ...getNavExperimentPayload() });
     setDraftPinnedUrls((current) => moveItem(current, fromIndex, toIndex));
   }, []);
 
@@ -244,6 +244,11 @@ const useHiddenSections = ({
   const onToggleHidden = useCallback(
     (item: NavModelItem, effectivelyHidden: boolean) => {
       const key = hiddenKey(item);
+      // effectivelyHidden means the item is currently hidden, so this toggle reveals it; otherwise it hides it.
+      reportInteraction(effectivelyHidden ? 'grafana_nav_item_shown' : 'grafana_nav_item_hidden', {
+        path: item.url ?? item.id,
+        ...getNavExperimentPayload(),
+      });
       setDraftHiddenIds((current) =>
         effectivelyHidden ? revealItem(current, baseItems, key) : hideItem(current, baseItems, key)
       );
@@ -278,7 +283,7 @@ const useSectionOrdering = ({
 
   const onReorderSection = useCallback(
     (fromIndex: number, toIndex: number) => {
-      reportInteraction('grafana_nav_section_reordered');
+      reportInteraction('grafana_nav_section_reordered', { ...getNavExperimentPayload() });
       setDraftSectionOrder((current) => reorderSections(baseItems, current, fromIndex, toIndex));
     },
     [baseItems]
@@ -446,6 +451,7 @@ export const useNavCustomization = () => {
     reportInteraction('grafana_nav_customise_saved', {
       hiddenCount: draftHiddenIds.length,
       pinnedCount: draftPinnedUrls.length,
+      ...getNavExperimentPayload(),
     });
     setEditMode(false);
   }, [commitPinning, commitHiding, commitOrdering, draftHiddenIds, draftPinnedUrls]);
@@ -455,7 +461,7 @@ export const useNavCustomization = () => {
 
   // Stage the reset (cleared on save, discarded on cancel) rather than persisting immediately.
   const onResetToDefault = useCallback(() => {
-    reportInteraction('grafana_nav_customise_reset');
+    reportInteraction('grafana_nav_customise_reset', { ...getNavExperimentPayload() });
     resetPinning();
     resetHiding();
     resetOrdering();


### PR DESCRIPTION
**What is this feature?**

Rounds out the analytics for the customisable mega menu (`grafana.customizableMegaMenu`):

- Adds `grafana_nav_item_hidden` / `grafana_nav_item_shown` interactions, fired when a user hides or reveals a nav item (with the item's `path`).
- Stamps the A/B experiment variant (`experiment_nav_customization`) onto the remaining customisation KPIs — pinned-entry reorder, section reorder, save (Done), and reset — so every customisation action is attributable to the experiment variant, matching the pin/unpin and nav-click events that already carry it.

**Why do we need this feature?**

The Configurable Nav experiment measures whether customisation helps navigation. Hiding was previously untracked, and several customisation actions weren't stamped with the experiment variant, leaving gaps in the KPI/attribution data we're relying on to evaluate the rollout.

**Who is this feature for?**

The frontend-navigation team analysing the Configurable Nav A/B experiment — no user-facing change.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Follow-up to the customisable mega menu (original PR #127167, now merged). Instrumentation only — no behaviour change. Tests updated in `MegaMenu.test.tsx`.

- [ ] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to What's New.
