### PR TITLE
docs: document GitHub 20-webhook-per-event limit for Git Sync

### DIFF
--- a/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/_index.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/_index.md
@@ -247,6 +247,12 @@ In the **Webhook options** menu, you can type in an URL to override the auto-det
 
 You can also check the **Disable webhook integration**. When checked, Grafana doesn't register or receive webhook events, and polls the repository on an interval instead. Use this when your Grafana instance is not reachable from the public internet.
 
+{{< admonition type="note" >}}
+
+GitHub limits each repository to 20 webhooks per event type (for example, `push` and `pull_request`). Because Git Sync registers webhooks per repository connection, syncing the same repository from many Grafana instances can exceed this limit and cause GitHub to reject new webhooks with an `HTTP 422` error. Disable webhook integration for connections that don't need real-time sync to stay under the limit.
+
+{{< /admonition >}}
+
 ### Signed commit option
 
 Starting in Grafana 13.1.0, you can **configure a verified account** with a signing key, allowing you to enforce your users to sign commits so your Git provider can mark them as _Verified_. Git Sync supports GPG, SSH, and S/MIME keys.

--- a/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/set-up-extend.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/set-up-extend.md
@@ -54,7 +54,7 @@ To check the configured webhooks, go to **Administration > General > Provisionin
 
 {{< admonition type="warning" >}}
 
-GitHub limits each repository to **20 webhooks per event type** (for example, `push` and `pull_request`). Git Sync registers its own webhooks for each repository connection, so when several Grafana instances sync the same repository, each connection adds to this total. Once the limit is exceeded, GitHub rejects new webhooks with an error such as:
+GitHub limits each repository to **20 webhooks per event type** (for example, `push` and `pull_request`). Git Sync registers its own webhooks for each repository connection, so when several Grafana instances sync the same repository, each connection adds to this total. After the limit is exceeded, GitHub rejects new webhooks with an error such as:
 
 ```
 GitHub API error (HTTP 422: Validation Failed: The "pull_request" event cannot have more than 20 hooks; The "push" event cannot have more than 20 hooks)

--- a/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/set-up-extend.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/set-up-extend.md
@@ -52,6 +52,18 @@ root_url = https://<PUBLIC_DOMAIN>
 
 To check the configured webhooks, go to **Administration > General > Provisioning** and click the **View** link for your GitHub repository.
 
+{{< admonition type="warning" >}}
+
+GitHub limits each repository to **20 webhooks per event type** (for example, `push` and `pull_request`). Git Sync registers its own webhooks for each repository connection, so when several Grafana instances sync the same repository, each connection adds to this total. Once the limit is exceeded, GitHub rejects new webhooks with an error such as:
+
+```
+GitHub API error (HTTP 422: Validation Failed: The "pull_request" event cannot have more than 20 hooks; The "push" event cannot have more than 20 hooks)
+```
+
+If you hit this limit, remove unused or duplicate webhooks from your repository's **Settings > Webhooks** page, or disable webhook integration for connections that don't need real-time sync so those instances poll on an interval instead. Refer to [Webhook options](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/git-sync-setup/#webhook-options) to disable webhook integration.
+
+{{< /admonition >}}
+
 {{< admonition type="note" >}}
 
 If your `[server] root_url` must point at an internal address (for example, when Grafana runs behind a private ingress in a Kubernetes cluster), set the publicly-reachable URL with `[provisioning] public_root_url` instead. This URL is used both to register webhook callbacks with the Git provider and as the base for screenshot images embedded in pull-request comments, which the Git provider's servers fetch from the public internet.


### PR DESCRIPTION
## What

Documents GitHub's hard limit of **20 webhooks per event type** (`push`, `pull_request`) per repository in the Git Sync provisioning docs. Adds a `warning` admonition to the webhook setup section and a `note` to the **Webhook options** section.

## Why

When multiple Grafana instances sync the same repository, Git Sync registers webhooks per repository connection. Once the total exceeds 20 hooks for an event type, GitHub rejects new webhooks and the repository becomes unhealthy with:

```
GitHub API error (HTTP 422: Validation Failed: The "pull_request" event cannot have more than 20 hooks; The "push" event cannot have more than 20 hooks)
```

This limitation wasn't documented, leaving users without guidance on the cause or the fix. Reported in grafana/grafana#127638 (see [comment](https://github.com/grafana/grafana/issues/127638#issuecomment-5045278603)).

## How

- `git-sync-setup/set-up-extend.md`: added a `warning` admonition after the "Set up webhooks" steps with the full error message and mitigations (remove unused/duplicate webhooks, or disable webhook integration for connections that don't need real-time sync), linking to the Webhook options section.
- `git-sync-setup/_index.md`: added a shorter `note` in the "Webhook options" section, next to the **Disable webhook integration** option (the primary lever to stay under the limit).

Docs-only change.

## Testing

- Reviewed rendered admonition syntax and shortcode/reference link formatting against surrounding docs.

## Checklist
- [ ] Tests added/updated (N/A — docs only)
- [x] Documentation updated
- [x] No breaking changes

🤖 Generated with Claude Code