### PR TITLE
fix(transformations): pass null/undefined values through unchanged in formatString

### DIFF
--- a/packages/grafana-data/src/transformations/transformers/formatString.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/formatString.test.ts
@@ -21,6 +21,16 @@ const frame = toDataFrame({
   ],
 });
 
+const frameWithNulls = toDataFrame({
+  fields: [
+    {
+      name: 'names',
+      type: FieldType.string,
+      values: ['alice', null, 'BOB', undefined, 'david'],
+    },
+  ],
+});
+
 const fieldMatches = fieldMatchers.get(FieldMatcherID.byName).get('names');
 
 const options = (format: FormatStringOutput, substringStart?: number, substringEnd?: number) => {
@@ -81,5 +91,26 @@ describe('Format String Transformer', () => {
     const newValues = newFrame[0].values;
 
     expect(newValues).toEqual(['ice', 'B', 'cha', 'vid', 'ma ', '']);
+  });
+
+  it('will pass null and undefined values through unchanged', () => {
+    const formats = [
+      FormatStringOutput.UpperCase,
+      FormatStringOutput.LowerCase,
+      FormatStringOutput.TitleCase,
+      FormatStringOutput.Trim,
+      FormatStringOutput.Substring,
+    ];
+
+    for (const format of formats) {
+      const formatter = createStringFormatter(
+        fieldMatches,
+        getFormatStringFunction(options(format, 1, 3))
+      );
+      const newFrame = formatter(frameWithNulls, [frameWithNulls]);
+      const newValues = newFrame[0].values;
+
+      expect(newValues).toEqual(['alice', null, 'BOB', undefined, 'david']);
+    }
   });
 });

--- a/packages/grafana-data/src/transformations/transformers/formatString.ts
+++ b/packages/grafana-data/src/transformations/transformers/formatString.ts
@@ -42,6 +42,9 @@ const splitToCapitalWords = (input: string) => {
 export const getFormatStringFunction = (options: FormatStringTransformerOptions) => {
   return (field: Field) =>
     field.values.map((value: string) => {
+      if (value == null) {
+        return value;
+      }
       switch (options.outputFormat) {
         case FormatStringOutput.UpperCase:
           return value.toUpperCase();


### PR DESCRIPTION
The formatString transformer (Organize fields > String formatting) maps over field.values and calls string methods like toUpperCase()/toLowerCase() directly on each value. When a string field contains a null or undefined cell — common with sparse data, left joins, or missing measurements — the transformer throws TypeError, which propagates through the rxjs pipeline and blanks the entire panel instead of just skipping that cell.

The fix adds an early `value == null` guard in getFormatStringFunction so null/undefined pass through unchanged, matching how other transformers (e.g. calc, filter) already handle missing values. Added a test case covering all five output formats against a frame with interleaved null/undefined values.