### PR TITLE
Transformations: Announce search results to screen readers

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/TransformationTypePicker.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/TransformationTypePicker.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from '@testing-library/react';
+import { screen, waitFor, within } from '@testing-library/react';
 
 import { standardTransformersRegistry } from '@grafana/data';
 import { getStandardTransformers } from 'app/features/transformers/standardTransformers';
@@ -32,5 +32,18 @@ describe('TransformationTypePicker', () => {
     await user.type(search, 'this matches nothing');
 
     await waitFor(() => expect(status).toHaveTextContent('No transformations found'));
+  });
+
+  it('exposes the results as a list so screen readers announce the item count', async () => {
+    const { user } = renderWithQueryEditorProvider(<TransformationTypePicker />);
+
+    const list = screen.getByRole('list', { name: 'Transformations' });
+    const initialCount = within(list).getAllByRole('listitem').length;
+    expect(initialCount).toBeGreaterThan(0);
+
+    const search = screen.getByPlaceholderText('Search for transformation');
+    await user.type(search, 'reduce');
+
+    await waitFor(() => expect(within(list).getAllByRole('listitem').length).toBeLessThan(initialCount));
   });
 });

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/TransformationTypePicker.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/TransformationTypePicker.test.tsx
@@ -1,0 +1,36 @@
+import { screen, waitFor } from '@testing-library/react';
+
+import { standardTransformersRegistry } from '@grafana/data';
+import { getStandardTransformers } from 'app/features/transformers/standardTransformers';
+
+import { renderWithQueryEditorProvider } from '../testUtils';
+
+import { TransformationTypePicker } from './TransformationTypePicker';
+
+describe('TransformationTypePicker', () => {
+  standardTransformersRegistry.setInit(getStandardTransformers);
+
+  it('renders a search input and the transformation cards', () => {
+    renderWithQueryEditorProvider(<TransformationTypePicker />);
+
+    expect(screen.getByPlaceholderText('Search for transformation')).toBeInTheDocument();
+    expect(screen.getByText('Reduce')).toBeInTheDocument();
+  });
+
+  it('announces search results to screen readers via a live region', async () => {
+    const { user } = renderWithQueryEditorProvider(<TransformationTypePicker />);
+
+    const status = screen.getByRole('status');
+    expect(status).toHaveAttribute('aria-live', 'polite');
+
+    const search = screen.getByPlaceholderText('Search for transformation');
+    await user.type(search, 'reduce');
+
+    await waitFor(() => expect(status).toHaveTextContent(/\d+ transformations? found/));
+
+    await user.clear(search);
+    await user.type(search, 'this matches nothing');
+
+    await waitFor(() => expect(status).toHaveTextContent('No transformations found'));
+  });
+});

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/TransformationTypePicker.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/TransformationTypePicker.tsx
@@ -128,13 +128,19 @@ export function TransformationTypePicker() {
           message={t('dashboard.transformation-picker-ng.no-transformations-found', 'No transformations found')}
         />
       ) : (
-        <Grid columns={3} gap={1}>
+        <Grid
+          columns={3}
+          gap={1}
+          role="list"
+          aria-label={t('dashboard.transformation-picker-ng.transformations-list', 'Transformations')}
+        >
           {filteredTransformations.map((item) => (
             <TransformationCard
               key={item.id}
               transform={item}
               data={data?.series ?? []}
               onClick={(id) => finalizePendingTransformation(id)}
+              role="listitem"
               showIllustrations={showIllustrations}
               fullWidth
             />

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/TransformationTypePicker.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/TransformationTypePicker.tsx
@@ -8,6 +8,7 @@ import { reportInteraction } from '@grafana/runtime';
 import { EmptyState, FilterPill, Grid, IconButton, Input, Stack, Switch, useStyles2 } from '@grafana/ui';
 import config from 'app/core/config';
 import { TransformationCard } from 'app/features/dashboard/components/TransformationsEditor/TransformationCard';
+import { TransformationSearchStatus } from 'app/features/dashboard/components/TransformationsEditor/TransformationSearchStatus';
 import { hasBackendDatasource } from 'app/features/dashboard-scene/panel-edit/PanelDataPane/utils';
 import { ExpressionQueryType } from 'app/features/expressions/types';
 
@@ -118,6 +119,8 @@ export function TransformationTypePicker() {
           />
         ))}
       </Stack>
+
+      <TransformationSearchStatus count={filteredTransformations.length} />
 
       {filteredTransformations.length === 0 ? (
         <EmptyState

--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationCard.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationCard.tsx
@@ -16,6 +16,8 @@ export interface TransformationCardProps {
   data?: DataFrame[];
   fullWidth?: boolean;
   onClick: (id: string) => void;
+  /** Set when the card is rendered inside a role="list" container */
+  role?: 'listitem';
   showIllustrations?: boolean;
   showPluginState?: boolean;
   showTags?: boolean;
@@ -26,6 +28,7 @@ export function TransformationCard({
   data = [],
   fullWidth = false,
   onClick,
+  role,
   showIllustrations,
   showPluginState = true,
   showTags = true,
@@ -59,6 +62,7 @@ export function TransformationCard({
       data-testid={selectors.components.TransformTab.newTransform(transform.name)}
       onClick={() => onClick(transform.id)}
       noMargin
+      role={role}
     >
       <Card.Heading>
         <Stack alignItems="center" justifyContent="space-between">

--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationPickerNg.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationPickerNg.tsx
@@ -165,13 +165,19 @@ interface TransformationsGridProps {
 
 function TransformationsGrid({ showIllustrations, transformations, onClick, data }: TransformationsGridProps) {
   return (
-    <Grid columns={3} gap={1}>
+    <Grid
+      columns={3}
+      gap={1}
+      role="list"
+      aria-label={t('dashboard.transformation-picker-ng.transformations-list', 'Transformations')}
+    >
       {transformations.map((transform) => (
         <TransformationCard
           data={data}
           fullWidth
           key={transform.id}
           onClick={onClick}
+          role="listitem"
           showIllustrations={showIllustrations}
           transform={transform}
         />

--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationPickerNg.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationPickerNg.tsx
@@ -5,7 +5,7 @@ import { type DataFrame, type GrafanaTheme2, type TransformerRegistryItem, type 
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
-import { Drawer, FilterPill, Grid, InlineLabel, Input, Stack, Switch, useStyles2 } from '@grafana/ui';
+import { Drawer, EmptyState, FilterPill, Grid, InlineLabel, Input, Stack, Switch, useStyles2 } from '@grafana/ui';
 import config from 'app/core/config';
 import { getCategoriesLabels } from 'app/features/transformers/utils';
 
@@ -114,19 +114,26 @@ export function TransformationPickerNg(props: TransformationPickerNgProps) {
 
         <TransformationSearchStatus count={xforms.length} />
 
-        <TransformationsGrid
-          showIllustrations={showIllustrations}
-          transformations={xforms}
-          data={data}
-          onClick={(id) => {
-            reportInteraction('grafana_panel_transformations_clicked', {
-              context: 'transformations_drawer',
-              type: id,
-              action: 'add',
-            });
-            onTransformationAdd({ value: id });
-          }}
-        />
+        {xforms.length === 0 ? (
+          <EmptyState
+            variant="not-found"
+            message={t('dashboard.transformation-picker-ng.no-transformations-found', 'No transformations found')}
+          />
+        ) : (
+          <TransformationsGrid
+            showIllustrations={showIllustrations}
+            transformations={xforms}
+            data={data}
+            onClick={(id) => {
+              reportInteraction('grafana_panel_transformations_clicked', {
+                context: 'transformations_drawer',
+                type: id,
+                action: 'add',
+              });
+              onTransformationAdd({ value: id });
+            }}
+          />
+        )}
       </Stack>
     </Drawer>
   );

--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationPickerNg.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationPickerNg.tsx
@@ -11,6 +11,7 @@ import { getCategoriesLabels } from 'app/features/transformers/utils';
 
 import { SqlExpressionsBanner } from './SqlExpressions/SqlExpressionsBanner';
 import { TransformationCard } from './TransformationCard';
+import { TransformationSearchStatus } from './TransformationSearchStatus';
 import { type FilterCategory } from './TransformationsEditor';
 
 const VIEW_ALL_VALUE = 'viewAll';
@@ -110,6 +111,8 @@ export function TransformationPickerNg(props: TransformationPickerNgProps) {
             );
           })}
         </Stack>
+
+        <TransformationSearchStatus count={xforms.length} />
 
         <TransformationsGrid
           showIllustrations={showIllustrations}

--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationSearchStatus.test.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationSearchStatus.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react';
+
+import { TransformationSearchStatus } from './TransformationSearchStatus';
+
+describe('TransformationSearchStatus', () => {
+  it('renders a polite live region', () => {
+    render(<TransformationSearchStatus count={5} />);
+
+    expect(screen.getByRole('status')).toHaveAttribute('aria-live', 'polite');
+  });
+
+  it('announces the number of results', async () => {
+    render(<TransformationSearchStatus count={5} />);
+
+    expect(await screen.findByText('5 transformations found')).toBeInTheDocument();
+  });
+
+  it('announces a single result with singular phrasing', async () => {
+    render(<TransformationSearchStatus count={1} />);
+
+    expect(await screen.findByText('1 transformation found')).toBeInTheDocument();
+  });
+
+  it('announces when no results are found', async () => {
+    render(<TransformationSearchStatus count={0} />);
+
+    expect(await screen.findByText('No transformations found')).toBeInTheDocument();
+  });
+
+  it('updates the announcement when the count changes', async () => {
+    const { rerender } = render(<TransformationSearchStatus count={10} />);
+
+    expect(await screen.findByText('10 transformations found')).toBeInTheDocument();
+
+    rerender(<TransformationSearchStatus count={0} />);
+
+    expect(await screen.findByText('No transformations found')).toBeInTheDocument();
+  });
+});

--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationSearchStatus.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationSearchStatus.tsx
@@ -1,0 +1,39 @@
+import { useState } from 'react';
+import { useDebounce } from 'react-use';
+
+import { t } from '@grafana/i18n';
+
+interface TransformationSearchStatusProps {
+  count: number;
+}
+
+/**
+ * Visually hidden live region announcing the number of transformation search results,
+ * so screen readers give feedback as the user searches (WCAG 4.1.3 Status Messages).
+ */
+export function TransformationSearchStatus({ count }: TransformationSearchStatusProps) {
+  const [announcement, setAnnouncement] = useState('');
+
+  // Debounced so screen readers don't announce a new count on every keystroke
+  useDebounce(
+    () => {
+      setAnnouncement(
+        count === 0
+          ? t('dashboard.transformation-search-status.no-results', 'No transformations found')
+          : t('dashboard.transformation-search-status.results-found', '', {
+              count,
+              defaultValue_one: '{{count}} transformation found',
+              defaultValue_other: '{{count}} transformations found',
+            })
+      );
+    },
+    500,
+    [count]
+  );
+
+  return (
+    <div role="status" aria-live="polite" className="sr-only">
+      {announcement}
+    </div>
+  );
+}

--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationsEditor.test.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationsEditor.test.tsx
@@ -94,6 +94,29 @@ describe('TransformationsEditor', () => {
       const list = screen.getByRole('list', { name: 'Transformations' });
       expect(within(list).getAllByRole('listitem').length).toBeGreaterThan(0);
     });
+
+    it('replaces the results list with an empty state when the search matches nothing', async () => {
+      setup([
+        {
+          id: 'reduce',
+          options: {},
+        },
+      ]);
+
+      const addTransformationButton = screen.getByTestId(selectors.components.Transforms.addTransformationButton);
+      await userEvent.click(addTransformationButton);
+
+      const search = screen.getByTestId(selectors.components.Transforms.searchInput);
+      await userEvent.type(search, 'this matches nothing');
+
+      expect(screen.queryByRole('list', { name: 'Transformations' })).not.toBeInTheDocument();
+
+      // The live region announces the same message, so look for the visible empty state specifically
+      const emptyStateMessage = screen
+        .getAllByText('No transformations found')
+        .filter((element) => !element.closest('[role="status"]'));
+      expect(emptyStateMessage).toHaveLength(1);
+    });
   });
 
   describe('actions', () => {

--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationsEditor.test.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationsEditor.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { type DataTransformerConfig, standardTransformersRegistry } from '@grafana/data';
@@ -78,6 +78,21 @@ describe('TransformationsEditor', () => {
       await userEvent.type(search, 'this matches nothing');
 
       await waitFor(() => expect(status).toHaveTextContent('No transformations found'));
+    });
+
+    it('exposes the picker results as a list so screen readers announce the item count', async () => {
+      setup([
+        {
+          id: 'reduce',
+          options: {},
+        },
+      ]);
+
+      const addTransformationButton = screen.getByTestId(selectors.components.Transforms.addTransformationButton);
+      await userEvent.click(addTransformationButton);
+
+      const list = screen.getByRole('list', { name: 'Transformations' });
+      expect(within(list).getAllByRole('listitem').length).toBeGreaterThan(0);
     });
   });
 

--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationsEditor.test.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationsEditor.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { type DataTransformerConfig, standardTransformersRegistry } from '@grafana/data';
@@ -53,6 +53,31 @@ describe('TransformationsEditor', () => {
 
       const search = screen.getByTestId(selectors.components.Transforms.searchInput);
       expect(search).toBeDefined();
+    });
+
+    it('announces search results to screen readers via a live region', async () => {
+      setup([
+        {
+          id: 'reduce',
+          options: {},
+        },
+      ]);
+
+      const addTransformationButton = screen.getByTestId(selectors.components.Transforms.addTransformationButton);
+      await userEvent.click(addTransformationButton);
+
+      const status = screen.getByRole('status');
+      expect(status).toHaveAttribute('aria-live', 'polite');
+
+      const search = screen.getByTestId(selectors.components.Transforms.searchInput);
+      await userEvent.type(search, 'reduce');
+
+      await waitFor(() => expect(status).toHaveTextContent(/\d+ transformations? found/));
+
+      await userEvent.clear(search);
+      await userEvent.type(search, 'this matches nothing');
+
+      await waitFor(() => expect(status).toHaveTextContent('No transformations found'));
     });
   });
 

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -6466,6 +6466,7 @@
       "sql-expressions-message-link": "Learn more",
       "sql-expressions-title": "SQL Expressions",
       "title-add-another-transformation": "Add another transformation",
+      "transformations-list": "Transformations",
       "view-all": "View all"
     },
     "transformation-search-status": {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -6468,6 +6468,11 @@
       "title-add-another-transformation": "Add another transformation",
       "view-all": "View all"
     },
+    "transformation-search-status": {
+      "no-results": "No transformations found",
+      "results-found_one": "{{count}} transformation found",
+      "results-found_other": "{{count}} transformations found"
+    },
     "transformation-type-picker": {
       "sql-cta-button": "Add SQL expression",
       "sql-cta-description": "Prefer SQL? Add a SQL expression to your queries instead."


### PR DESCRIPTION
**What is this feature?**

Adds screen reader feedback to the transformation pickers — both the "Add another transformation" drawer and the transformations view in the new query editor experience. A visually hidden `aria-live` status region announces the number of matching transformations (or "No transformations found") as the user types in the search field, debounced so every keystroke doesn't trigger an announcement. The results grids are also exposed with `role="list"`/`role="listitem"` semantics so screen readers announce the item count and support item navigation.

**Why do we need this feature?**

The screen reader stayed silent after entering text in the transformation search field, giving no feedback about search results — failing WCAG 2.1 SC 4.1.3 Status Messages (Level AA).

**Who is this feature for?**

Screen reader users configuring transformations on dashboard panels.

**Which issue(s) does this PR fix?**:

Fixes #118775

**Special notes for your reviewer:**

Covered by new unit tests for the `TransformationSearchStatus` component plus integration tests exercising the search flow in both pickers.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
