### PR TITLE
chore(analytics): remove unused RS event snapshots

### DIFF
--- a/public/app/features/dashboard-scene/sharing/ShareButton/share-snapshot/ShareSnapshot.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareButton/share-snapshot/ShareSnapshot.tsx
@@ -3,7 +3,7 @@ import useAsyncFn from 'react-use/lib/useAsyncFn';
 
 import { selectors as e2eSelectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
-import { config, reportInteraction } from '@grafana/runtime';
+import { config } from '@grafana/runtime';
 import { type SceneComponentProps } from '@grafana/scenes';
 import { Alert, Button, ClipboardButton, Spinner, Stack, TextLink } from '@grafana/ui';
 import { contextSrv } from 'app/core/services/context_srv';
@@ -173,7 +173,6 @@ const UpsertSnapshotActions = ({
         variant="primary"
         fill="outline"
         getText={() => url}
-        onClipboardCopy={() => reportInteraction('sharing_publish_snapshot')}
         data-testid={selectors.copyUrlButton}
       >
         <Trans i18nKey="snapshot.share.copy-link-button">Copy link</Trans>


### PR DESCRIPTION
**What is this feature?**
Remove unused RudderStack events — monthly quota cleanup
More info here: https://github.com/grafana/grafana/issues/127679

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
