### PR TITLE
Notifications: Prevent SMTP attachment panics from crashing Grafana

### DIFF
--- a/pkg/services/notifications/smtp.go
+++ b/pkg/services/notifications/smtp.go
@@ -67,16 +67,25 @@ func (sc *SmtpClient) Send(ctx context.Context, messages ...*Message) (int, erro
 	return sentEmailsCount, nil
 }
 
-func (sc *SmtpClient) sendMessage(ctx context.Context, dialer *gomail.Dialer, msg *Message) error {
+func (sc *SmtpClient) sendMessage(ctx context.Context, dialer *gomail.Dialer, msg *Message) (err error) {
 	ctx, span := tracer.Start(ctx, "notifications.SmtpClient.sendMessage", trace.WithAttributes(
 		attribute.String("smtp.sender", msg.From),
 		attribute.StringSlice("smtp.recipients", msg.To),
 	))
 	defer span.End()
 
+	// mail.v2 can panic on some attachment encodings (nil base64LineWriter.w).
+	// Recover so one bad email cannot take down the Grafana process.
+	defer func() {
+		if r := recover(); r != nil {
+			emailsSentFailed.Inc()
+			err = tracing.Errorf(span, "panic while sending email: %v", r)
+		}
+	}()
+
 	m := sc.buildEmail(ctx, msg)
 
-	err := dialer.DialAndSend(m)
+	err = dialer.DialAndSend(m)
 	emailsSentTotal.Inc()
 	if err != nil {
 		// As gomail does not returned typed errors we have to parse the error
@@ -116,12 +125,12 @@ func (sc *SmtpClient) buildEmail(ctx context.Context, msg *Message) *gomail.Mess
 		otel.GetTextMapPropagator().Inject(ctx, gomailHeaderCarrier{m})
 	}
 
-	sc.setFiles(m, msg)
 	for _, replyTo := range msg.ReplyTo {
 		m.SetAddressHeader("Reply-To", replyTo, "")
 	}
-	// loop over content types from settings in reverse order as they are ordered in according to descending
-	// preference while the alternatives should be ordered according to ascending preference
+	// Body parts first so multipart structure is established before attachments.
+	// Content types are stored most-preferred first; alternatives must be
+	// least-preferred first for MIME.
 	for i := len(sc.cfg.ContentTypes) - 1; i >= 0; i-- {
 		if i == len(sc.cfg.ContentTypes)-1 {
 			m.SetBody(sc.cfg.ContentTypes[i], msg.Body[sc.cfg.ContentTypes[i]])
@@ -129,6 +138,7 @@ func (sc *SmtpClient) buildEmail(ctx context.Context, msg *Message) *gomail.Mess
 			m.AddAlternative(sc.cfg.ContentTypes[i], msg.Body[sc.cfg.ContentTypes[i]])
 		}
 	}
+	sc.setFiles(m, msg)
 
 	return m
 }
@@ -139,22 +149,40 @@ func (sc *SmtpClient) setFiles(
 	msg *Message,
 ) {
 	for _, file := range msg.EmbeddedFiles {
+		if file == "" {
+			continue
+		}
 		m.Embed(file)
 	}
 
 	for _, file := range msg.EmbeddedContents {
-		m.Embed(file.Name, gomail.SetCopyFunc(func(writer io.Writer) error {
-			_, err := writer.Write(file.Content)
-			return err
-		}))
+		if file.Name == "" || len(file.Content) == 0 {
+			continue
+		}
+		content := file.Content
+		name := file.Name
+		m.Embed(name, gomail.SetCopyFunc(copyFileContent(content)))
 	}
 
 	for _, file := range msg.AttachedFiles {
-		file := file
-		m.Attach(file.Name, gomail.SetCopyFunc(func(writer io.Writer) error {
-			_, err := writer.Write(file.Content)
-			return err
-		}))
+		if file == nil || file.Name == "" || len(file.Content) == 0 {
+			continue
+		}
+		content := file.Content
+		name := file.Name
+		m.Attach(name, gomail.SetCopyFunc(copyFileContent(content)))
+	}
+}
+
+// copyFileContent returns a gomail copy function that streams content safely.
+// A nil writer must not panic (mail.v2 has historically done so on the base64 path).
+func copyFileContent(content []byte) func(io.Writer) error {
+	return func(w io.Writer) error {
+		if w == nil {
+			return fmt.Errorf("mail attachment writer is nil")
+		}
+		_, err := io.Copy(w, bytes.NewReader(content))
+		return err
 	}
 }
 

--- a/pkg/services/notifications/smtp.go
+++ b/pkg/services/notifications/smtp.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/mail"
 	"net/textproto"
+	"runtime/debug"
 	"strconv"
 	"strings"
 
@@ -78,8 +79,10 @@ func (sc *SmtpClient) sendMessage(ctx context.Context, dialer *gomail.Dialer, ms
 	// Recover so one bad email cannot take down the Grafana process.
 	defer func() {
 		if r := recover(); r != nil {
+			// Match the DialAndSend path: count the attempt, then the failure.
+			emailsSentTotal.Inc()
 			emailsSentFailed.Inc()
-			err = tracing.Errorf(span, "panic while sending email: %v", r)
+			err = tracing.Errorf(span, "panic while sending email: %v\n%s", r, debug.Stack())
 		}
 	}()
 

--- a/pkg/services/notifications/smtp_test.go
+++ b/pkg/services/notifications/smtp_test.go
@@ -59,6 +59,42 @@ func TestBuildMail(t *testing.T) {
 		assert.Less(t, strings.Index(buf.String(), "Some plain text body"), strings.Index(buf.String(), "Some HTML body"))
 	})
 
+	t.Run("builds mail with embedded and attached content", func(t *testing.T) {
+		// PNG-like payload large enough to exercise base64 line wrapping.
+		png := bytes.Repeat([]byte{0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a}, 4096)
+		msg := &Message{
+			To:      []string{"to@address.com"},
+			From:    "from@address.com",
+			Subject: "screenshot",
+			Body: map[string]string{
+				"text/html":  `<html><img src="cid:panel.png"/></html>`,
+				"text/plain": "alert fired",
+			},
+			EmbeddedContents: []EmbeddedContent{
+				{Name: "panel.png", Content: png},
+				{Name: "", Content: []byte("skip-empty-name")},
+				{Name: "empty.png", Content: nil},
+			},
+			AttachedFiles: []*AttachedFile{
+				{Name: "panel-attach.png", Content: png},
+				nil,
+				{Name: "empty-attach.png", Content: []byte{}},
+			},
+		}
+
+		email := sc.buildEmail(ctx, msg)
+		buf := new(bytes.Buffer)
+		_, err := email.WriteTo(buf)
+		require.NoError(t, err)
+
+		raw := buf.String()
+		assert.Contains(t, raw, "Content-Disposition: inline; filename=\"panel.png\"")
+		assert.Contains(t, raw, "Content-Disposition: attachment; filename=\"panel-attach.png\"")
+		assert.NotContains(t, raw, "skip-empty-name")
+		assert.NotContains(t, raw, "empty.png")
+		assert.NotContains(t, raw, "empty-attach.png")
+	})
+
 	t.Run("Skips trace headers when context has no span", func(t *testing.T) {
 		cfg.Smtp.EnableTracing = true
 
@@ -81,6 +117,21 @@ func TestBuildMail(t *testing.T) {
 
 		email := sc.buildEmail(ctx, message)
 		assert.NotEmpty(t, email.GetHeader("traceparent"))
+	})
+}
+
+func TestCopyFileContent(t *testing.T) {
+	t.Run("returns error when writer is nil", func(t *testing.T) {
+		err := copyFileContent([]byte("data"))(nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "nil")
+	})
+
+	t.Run("writes content to writer", func(t *testing.T) {
+		var buf bytes.Buffer
+		err := copyFileContent([]byte("hello"))(&buf)
+		require.NoError(t, err)
+		assert.Equal(t, "hello", buf.String())
 	})
 }
 
@@ -218,6 +269,31 @@ func TestSmtpSend(t *testing.T) {
 		}
 
 		require.True(t, found)
+	})
+
+	t.Run("message with embedded screenshot content sends", func(t *testing.T) {
+		png := bytes.Repeat([]byte{0x89, 0x50, 0x4e, 0x47}, 2048)
+		message := &Message{
+			From:    "from@example.com",
+			To:      []string{"rcpt@example.com"},
+			Subject: "alert with screenshot",
+			Body: map[string]string{
+				"text/html":  `<html><img src="cid:panel.png"/></html>`,
+				"text/plain": "alert",
+			},
+			EmbeddedContents: []EmbeddedContent{
+				{Name: "panel.png", Content: png},
+			},
+		}
+
+		count, err := client.Send(ctx, message)
+		require.NoError(t, err)
+		require.Equal(t, 1, count)
+
+		messages, err := srv.WaitForMessagesAndPurge(1, 5*time.Second)
+		require.NoError(t, err)
+		require.Len(t, messages, 1)
+		assert.Contains(t, messages[0].MsgRequest(), "filename=\"panel.png\"")
 	})
 
 	t.Run("multiple recipients, single message", func(t *testing.T) {


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips:
1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md
2. Ensure you include and run the appropriate tests as part of your Pull Request.
3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.
6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.
7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.
-->

**What is this feature?**

Hardens SMTP email sending so attachment/embed encoding failures no longer crash Grafana. Specifically:

- Recover panics in `SmtpClient.sendMessage` (mail.v2 can panic in `base64LineWriter` when encoding screenshot attachments)
- Stream attachment/embed bytes with `io.Copy` and reject a nil writer instead of unchecked `Write`
- Skip empty embed/attachment entries
- Build message body parts before attaching files

**Why do we need this feature?**

When alert emails include panel screenshots as embeds, a nil pointer panic in `gopkg.in/mail.v2` can take down the entire Grafana process (often many concurrent notification goroutines at once). Operators currently work around this by disabling screenshot capture or uploading screenshots to external storage. Grafana should fail that email send gracefully and keep the process running.

**Who is this feature for?**

Users of Unified Alerting who send email notifications with screenshot capture enabled.

**Which issue(s) does this PR fix?**:

<!--
- Automatically closes linked issue when the Pull Request is merged.
Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"
-->

Fixes #124000

**Special notes for your reviewer:**

The panic originates in mail.v2 (`base64LineWriter.Write` with a nil underlying writer). We do not vendor a patched mail.v2 here; this PR contains the process-safe boundary (recover) plus defensive attachment writing in Grafana's SMTP client. Covered by unit tests for large embeds, empty-file skips, nil writer, and an SMTP mock send with embedded content.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.