### PR TITLE
Alerting: Move dedup suffix separator into merge functions

### DIFF
--- a/pkg/services/ngalert/notifier/legacy_storage/imported_test.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/imported_test.go
@@ -68,7 +68,7 @@ receivers:
   - name: dupe-receiver
 `
 		extra := extraConfig(dupeConfig)
-		expectedDedupSuffix := extra.Identifier
+		expectedDedupSuffix := "_" + extra.Identifier
 		rev := getConfigRevisionForTest(withExtraConfig(extra))
 		imported, err = rev.Imported()
 		require.NoError(t, err)
@@ -151,7 +151,7 @@ receivers:
   - name: r1
 `
 		extra := extraConfig(dupeConfig)
-		expectedDedupSuffix := extra.Identifier
+		expectedDedupSuffix := "_" + extra.Identifier
 		rev := getConfigRevisionForTest(withExtraConfig(extra))
 
 		imported, err := rev.Imported()
@@ -231,7 +231,7 @@ mute_time_intervals:
   - name: mute-interval-1
 `
 		extra := extraConfig(dupeConfig)
-		expectedDedupSuffix := extra.Identifier
+		expectedDedupSuffix := "_" + extra.Identifier
 		rev := getConfigRevisionForTest(withExtraConfig(extra))
 
 		imported, err := rev.Imported()

--- a/pkg/services/ngalert/notifier/merge/merge.go
+++ b/pkg/services/ngalert/notifier/merge/merge.go
@@ -101,7 +101,7 @@ func (m MergeResult) LogContext() []any {
 //  1. Resource Deduplication:
 //     When resources (receivers or time intervals) with identical names exist in both configurations,
 //     resources from the extra configuration are renamed according to these rules:
-//     - First, the extra configuration's Identifier is appended to the name
+//     - First, "_" + the extra configuration's Identifier is appended to the name
 //     - If the name is still not unique, a numbered suffix is added (e.g., "_01", "_02")
 //     - All references to renamed resources are automatically updated throughout the configuration
 //
@@ -193,30 +193,32 @@ func MergeExtraConfig(_ context.Context, cfg *v1.AMConfigV1) (v1.AMConfigV1, Mer
 		}, nil
 }
 
-// DeduplicateResources merges existing and incoming resources (receivers and time intervals) and ensures unique names by applying suffixes. Returns renamed resources for tracking adjustments made.
-func DeduplicateResources(a, b v1.PostableApiAlertingConfig, suffix string) RenameResources {
-	_, renamedReceivers, _ := Receivers(a.Receivers, b.Receivers, suffix)
+// DeduplicateResources merges existing and incoming resources (receivers and time intervals) and ensures unique names by
+// appending a suffix derived from identifier. Returns renamed resources for tracking adjustments made.
+func DeduplicateResources(a, b v1.PostableApiAlertingConfig, identifier string) RenameResources {
+	_, renamedReceivers, _ := Receivers(a.Receivers, b.Receivers, identifier)
 	_, renamedTimeIntervals, _ := TimeIntervals(
 		a.MuteTimeIntervals,
 		a.TimeIntervals,
 		b.MuteTimeIntervals,
 		b.TimeIntervals,
-		suffix,
+		identifier,
 	)
 	return RenameResources{Receivers: renamedReceivers, TimeIntervals: renamedTimeIntervals}
 }
 
-// TimeIntervals merges existing and incoming time intervals and mute intervals, ensuring unique names by applying suffixes.
-// It returns a merged list of time intervals, a map of renamed interval names for tracking adjustments made, and the final
-// names of the incoming intervals (post-rename) in their original order (mute intervals first, then time intervals).
-// Mute time intervals are converted to time intervals.
+// TimeIntervals merges existing and incoming time intervals and mute intervals, ensuring unique names by appending a
+// suffix derived from identifier. It returns a merged list of time intervals, a map of renamed interval names for
+// tracking adjustments made, and the final names of the incoming intervals (post-rename) in their original order
+// (mute intervals first, then time intervals). Mute time intervals are converted to time intervals.
 func TimeIntervals(
 	existingMuteIntervals []v1.MuteTimeInterval,
 	existingTimeIntervals []v1.TimeInterval,
 	incomingMuteIntervals []v1.MuteTimeInterval,
 	incomingTimeIntervals []v1.TimeInterval,
-	suffix string,
+	identifier string,
 ) ([]v1.TimeInterval, map[string]string, []string) {
+	dedupSuffix := getDedupSuffix(identifier)
 	// combine all incoming intervals into a single list
 	incomingAll := make([]v1.TimeInterval, 0, len(incomingTimeIntervals)+len(incomingMuteIntervals))
 	for _, interval := range incomingMuteIntervals {
@@ -235,7 +237,7 @@ func TimeIntervals(
 	for idx, interval := range incomingAll {
 		curName := interval.Name
 		if i, ok := usedNames[curName]; ok && i != idx { // if the name is already used by another interval, append a suffix.
-			newName := getUniqueName(curName, suffix, usedNames)
+			newName := getUniqueName(curName, dedupSuffix, usedNames)
 			renames[curName] = newName
 			usedNames[newName] = idx
 			interval.Name = newName
@@ -292,12 +294,13 @@ func RenameResourceUsagesInRoutes(routes []*v1.Route, renames RenameResources) {
 	}
 }
 
-// Receivers merges two lists of PostableApiReceiver objects, ensuring unique names by appending a suffix if necessary.
-// It returns the combined list of receivers, a map of renamed original names to their new unique names, and the incoming
-// receivers in their original order after any renames have been applied.
+// Receivers merges two lists of PostableApiReceiver objects, ensuring unique names by appending a suffix derived from
+// identifier if necessary. It returns the combined list of receivers, a map of renamed original names to their new
+// unique names, and the incoming receivers in their original order after any renames have been applied.
 // The items of the existing list are added to the result list as is whereas the items of incoming list are copied (shallow copy)
 // and renamed if necessary.
-func Receivers(existing, incoming []*v1.PostableApiReceiver, suffix string) ([]*v1.PostableApiReceiver, map[string]string, []string) {
+func Receivers(existing, incoming []*v1.PostableApiReceiver, identifier string) ([]*v1.PostableApiReceiver, map[string]string, []string) {
+	dedupSuffix := getDedupSuffix(identifier)
 	result := make([]*v1.PostableApiReceiver, 0, len(existing)+len(incoming))
 	result = append(result, existing...)
 	usedNames := createIndexReceivers(existing, incoming)
@@ -309,7 +312,7 @@ func Receivers(existing, incoming []*v1.PostableApiReceiver, suffix string) ([]*
 		}
 		cpy := *r
 		if i, ok := usedNames[cpy.Name]; ok && i != idx {
-			newName := getUniqueName(cpy.Name, suffix, usedNames)
+			newName := getUniqueName(cpy.Name, dedupSuffix, usedNames)
 			renames[cpy.Name] = newName
 			cpy.Name = newName
 			usedNames[cpy.Name] = i
@@ -369,12 +372,13 @@ func MergeInhibitionRules(existing map[v1.ResourceUID]v1.InhibitionRule, incomin
 
 // MergeTemplates merges the incoming templates with the existing ones, renaming conflicts.
 // When an incoming Mimir template name collides with an existing Mimir template name, the
-// incoming template is renamed by appending identifier as a suffix (same semantics as Receivers).
+// incoming template is renamed by appending a suffix derived from identifier (same semantics as Receivers).
 // UIDs are derived from a stable hash of (finalName, content, identifier); collisions fall back
 // to a short random UID.
 // Returns the merged map, a rename map (original→final name), the UIDs of added templates,
 // and an error.
 func MergeTemplates(existing map[v1.ResourceUID]v1.TemplateGroup, incoming map[string]string, identifier string) (templates map[v1.ResourceUID]v1.TemplateGroup, renames map[string]string, added []v1.ResourceUID, err error) {
+	dedupSuffix := getDedupSuffix(identifier)
 	// Index existing Mimir template names to detect conflicts.
 	usedNames := make(map[string]struct{}, len(existing))
 	for _, tmpl := range existing {
@@ -392,7 +396,7 @@ func MergeTemplates(existing map[v1.ResourceUID]v1.TemplateGroup, incoming map[s
 		content := incoming[name]
 		finalName := name
 		if _, exists := usedNames[name]; exists {
-			finalName = getUniqueName(name, identifier, usedNames)
+			finalName = getUniqueName(name, dedupSuffix, usedNames)
 			renames[name] = finalName
 		}
 		usedNames[finalName] = struct{}{}
@@ -441,4 +445,8 @@ func getUniqueName[T any](name string, suffix string, usedNames map[string]T) st
 		panic(fmt.Sprintf("unable to find unique name for %s", name))
 	}
 	return result
+}
+
+func getDedupSuffix(identifier string) string {
+	return fmt.Sprintf("_%s", identifier)
 }

--- a/pkg/services/ngalert/notifier/merge/merge_test.go
+++ b/pkg/services/ngalert/notifier/merge/merge_test.go
@@ -26,7 +26,8 @@ func TestReceivers(t *testing.T) {
 		}
 	}
 
-	suffix := "-dupe"
+	identifier := "dupe"
+	suffix := getDedupSuffix(identifier)
 
 	r1 := r("r1")
 	r2 := r("r2")
@@ -126,7 +127,7 @@ func TestReceivers(t *testing.T) {
 				incomingNames = append(incomingNames, r.Name)
 			}
 
-			actual, actualRenames, actualAdded := Receivers(tc.existing, tc.incoming, suffix)
+			actual, actualRenames, actualAdded := Receivers(tc.existing, tc.incoming, identifier)
 			require.Len(t, actual, len(tc.expected))
 			assert.EqualValues(t, tc.expectedRenames, actualRenames)
 			assert.Equal(t, tc.expectedAdded, actualAdded)
@@ -168,7 +169,8 @@ func TestTimeIntervals(t *testing.T) {
 		}
 	}
 
-	suffix := "-dupe"
+	identifier := "dupe"
+	suffix := getDedupSuffix(identifier)
 
 	testCases := []struct {
 		name                  string
@@ -320,7 +322,7 @@ func TestTimeIntervals(t *testing.T) {
 				incomingNames = append(incomingNames, r.Name)
 			}
 
-			actualTimeIntervals, actualRenames, actualAdded := TimeIntervals(tc.existingMuteIntervals, tc.existingTimeIntervals, tc.incomingMuteIntervals, tc.incomingTimeIntervals, suffix)
+			actualTimeIntervals, actualRenames, actualAdded := TimeIntervals(tc.existingMuteIntervals, tc.existingTimeIntervals, tc.incomingMuteIntervals, tc.incomingTimeIntervals, identifier)
 			assert.Equal(t, tc.expected, actualTimeIntervals)
 			assert.EqualValues(t, tc.expectedRenames, actualRenames)
 			assert.Equal(t, tc.expectedAdded, actualAdded)
@@ -449,7 +451,7 @@ func TestMergeExtraConfig(t *testing.T) {
 	t.Run("should append index suffix if rename still collides", func(t *testing.T) {
 		grafana := load(t, fullGrafanaConfig, func(p *v1.PostableApiAlertingConfig) {
 			p.Receivers = append(p.Receivers, &v1.PostableApiReceiver{
-				Receiver: definition.Receiver{Name: "grafana-default-email" + identifier},
+				Receiver: definition.Receiver{Name: "grafana-default-email" + getDedupSuffix(identifier)},
 			})
 		})
 		input := withExtra(t, grafana, fullMimirWithOnlyExtraReceiver)
@@ -524,7 +526,7 @@ func TestMergeExtraConfig(t *testing.T) {
 		_, result, err := MergeExtraConfig(context.Background(), &input)
 		require.NoError(t, err)
 
-		assert.ElementsMatch(t, []string{"recv", "recv2", "grafana-default-email" + identifier}, result.AddedReceivers)
+		assert.ElementsMatch(t, []string{"recv", "recv2", "grafana-default-email" + getDedupSuffix(identifier)}, result.AddedReceivers)
 	})
 
 	t.Run("should report added template names in stats", func(t *testing.T) {
@@ -635,7 +637,7 @@ func TestMergeExtraConfig(t *testing.T) {
 		config, result, err := MergeExtraConfig(context.Background(), &input)
 		require.NoError(t, err)
 
-		renamedName := templateName + identifier
+		renamedName := templateName + getDedupSuffix(identifier)
 		require.Len(t, result.AddedTemplates, 1)
 		assert.Equal(t, renamedName, result.AddedTemplates[0])
 		assert.Equal(t, map[string]string{templateName: renamedName}, result.Templates)
@@ -827,12 +829,12 @@ func TestMergeTemplates(t *testing.T) {
 
 		result, renames, added, err := MergeTemplates(existing, incoming, "suffix")
 		require.NoError(t, err)
-		require.Equal(t, map[string]string{"foo": "foosuffix"}, renames)
+		require.Equal(t, map[string]string{"foo": "foo" + getDedupSuffix("suffix")}, renames)
 		require.Len(t, added, 1)
 		assert.Contains(t, result, v1.ResourceUID("uid1"), "original template should be preserved")
 		tmpl, ok := result[added[0]]
 		require.True(t, ok)
-		assert.Equal(t, "foosuffix", tmpl.Title)
+		assert.Equal(t, "foo"+getDedupSuffix("suffix"), tmpl.Title)
 		assert.Equal(t, v1.TemplateKindMimir, tmpl.Kind)
 	})
 

--- a/pkg/services/ngalert/notifier/merge/testdata/merged_renamed_intervals.json
+++ b/pkg/services/ngalert/notifier/merge/testdata/merged_renamed_intervals.json
@@ -76,7 +76,7 @@
         ]
       },
       {
-        "name": "ti-1mimir-12345",
+        "name": "ti-1_mimir-12345",
         "time_intervals": null
       },
       {
@@ -94,7 +94,7 @@
         ]
       },
       {
-        "name": "mti-1mimir-12345",
+        "name": "mti-1_mimir-12345",
         "time_intervals": null
       }
     ],
@@ -208,10 +208,10 @@
             "label=\"test\""
           ],
           "mute_time_intervals": [
-            "ti-1mimir-12345"
+            "ti-1_mimir-12345"
           ],
           "active_time_intervals": [
-            "mti-1mimir-12345"
+            "mti-1_mimir-12345"
           ]
         }
       ],

--- a/pkg/services/ngalert/notifier/merge/testdata/merged_renamed_receiver.json
+++ b/pkg/services/ngalert/notifier/merge/testdata/merged_renamed_receiver.json
@@ -183,7 +183,7 @@
         ]
       },
       {
-        "name": "grafana-default-emailmimir-12345"
+        "name": "grafana-default-email_mimir-12345"
       }
     ]
   },
@@ -215,7 +215,7 @@
           "repeat_interval": "1m"
         },
         {
-          "receiver": "grafana-default-emailmimir-12345",
+          "receiver": "grafana-default-email_mimir-12345",
           "matchers": [
             "label=\"test\""
           ]

--- a/pkg/services/ngalert/notifier/merge/testdata/merged_suffixed_receiver.json
+++ b/pkg/services/ngalert/notifier/merge/testdata/merged_suffixed_receiver.json
@@ -133,7 +133,7 @@
         ]
       },
       {
-        "name": "grafana-default-emailmimir-12345"
+        "name": "grafana-default-email_mimir-12345"
       },
       {
         "name": "recv",
@@ -186,7 +186,7 @@
         ]
       },
       {
-        "name": "grafana-default-emailmimir-12345_01"
+        "name": "grafana-default-email_mimir-12345_01"
       }
     ]
   },

--- a/pkg/tests/apis/alerting/notifications/timeinterval/imported_test.go
+++ b/pkg/tests/apis/alerting/notifications/timeinterval/imported_test.go
@@ -126,12 +126,13 @@ func TestIntegrationImportedTimeIntervals(t *testing.T) {
 		require.Nil(t, err)
 		require.GreaterOrEqual(t, len(timeIntervals.Items), 3, "should have at least 3 time intervals after creating duplicate name")
 
+		renamedName := "business-hours_" + identifier
 		var foundRenamed bool
 		for _, ti := range timeIntervals.Items {
-			if ti.Spec.Name == "business-hours"+identifier && ti.GetProvenanceStatus() == string(models.ProvenanceConvertedPrometheus) {
+			if ti.Spec.Name == renamedName && ti.GetProvenanceStatus() == string(models.ProvenanceConvertedPrometheus) {
 				foundRenamed = true
 			}
 		}
-		require.True(t, foundRenamed, fmt.Sprintf("expected to find renamed imported time interval with name %q", "business-hours"+identifier))
+		require.True(t, foundRenamed, fmt.Sprintf("expected to find renamed imported time interval with name %q", renamedName))
 	})
 }


### PR DESCRIPTION
## Summary

- `Receivers`, `TimeIntervals`, and `MergeTemplates` in `pkg/services/ngalert/notifier/merge` now derive the `"_"`-prefixed dedup suffix from the `identifier` argument internally (`getDedupSuffix`), instead of requiring the caller to pre-format it before passing it in as `suffix`.
