### PR TITLE
Dashboards: Migrate dashboardNewLayouts to OpenFeature

### DIFF
--- a/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
@@ -22,6 +22,7 @@ declare module "@openfeature/core" {
     | "grafana.kubernetesAnnotationsClient"
     | "grafana.newPanelQueryErrorsUI"
     | "useKubernetesShortURLsAPI"
+    | "dashboardNewLayouts"
     | "dashboard.notebooks"
     | "stateTimeline.nameAboveBars"
     | "grafana.secretsReferenceValueUI"

--- a/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
@@ -29,6 +29,8 @@ export const FlagKeys = {
   DashboardNotebooks: "dashboard.notebooks",
   /** Exposes the semantic (vector) search endpoint for dashboards under the dashboard API */
   DashboardVectorSearch: "dashboard.vectorSearch",
+  /** Enables new dashboard layouts */
+  DashboardNewLayouts: "dashboardNewLayouts",
   /** Enables support for section level variables (rows and tabs) */
   DashboardSectionVariables: "dashboardSectionVariables",
   /** Enables the Assistant button in the dashboard templates card */
@@ -239,6 +241,17 @@ export const useFlagDashboardNotebooks = (options?: ReactFlagEvaluationOptions):
  */
 export const useFlagDashboardVectorSearch = (options?: ReactFlagEvaluationOptions): boolean => {
   return useFlag("dashboard.vectorSearch", false, options).value;
+};
+
+/**
+ * Enables new dashboard layouts
+ *
+ * **Details:**
+ * - flag key: `dashboardNewLayouts`
+ * - default value: `true`
+ */
+export const useFlagDashboardNewLayouts = (options?: ReactFlagEvaluationOptions): boolean => {
+  return useFlag("dashboardNewLayouts", true, options).value;
 };
 
 /**

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -658,7 +658,7 @@ var (
 			Name:        "dashboardNewLayouts",
 			Description: "Enables new dashboard layouts",
 			Stage:       FeatureStageGeneralAvailability,
-			Generate:    Generate{LegacyFrontend: true},
+			Generate:    Generate{LegacyFrontend: true, React: true}, // legacy frontend for old naming convention
 			Owner:       grafanaDashboardsSquad,
 			Expression:  "true",
 		},

--- a/public/app/core/components/AppChrome/TopBar/useChromeHeaderHeight.ts
+++ b/public/app/core/components/AppChrome/TopBar/useChromeHeaderHeight.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 
 import { config, useScopes } from '@grafana/runtime';
+import { FlagKeys, getFeatureFlagClient } from '@grafana/runtime/internal';
 import { useGrafana } from 'app/core/context/GrafanaContext';
 import { useMediaQueryMinWidth } from 'app/core/hooks/useMediaQueryMinWidth';
 
@@ -93,5 +94,8 @@ export function useChromeHeaderHeight() {
  **/
 export function getChromeHeaderLevelHeight() {
   // Waiting with switch to 48 until we have a story for scopes
-  return config.featureToggles.unifiedNavbars || config.featureToggles.dashboardNewLayouts ? 48 : 40;
+  return config.featureToggles.unifiedNavbars ||
+    getFeatureFlagClient().getBooleanValue(FlagKeys.DashboardNewLayouts, false)
+    ? 48
+    : 40;
 }

--- a/public/app/core/components/Select/DashboardPicker.test.tsx
+++ b/public/app/core/components/Select/DashboardPicker.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, testWithFeatureToggles } from 'test/test-utils';
 
 import { setBackendSrv } from '@grafana/runtime';
 import { setupMockServer } from '@grafana/test-utils/server';
-import { getFolderFixtures } from '@grafana/test-utils/unstable';
+import { getFolderFixtures, setTestFlags } from '@grafana/test-utils/unstable';
 import { backendSrv } from 'app/core/services/backend_srv';
 
 import { DashboardPicker } from './DashboardPicker';
@@ -48,7 +48,12 @@ describe('DashboardPicker', () => {
   });
 
   xdescribe('dashboard v2 (v2beta1 API)', () => {
-    testWithFeatureToggles({ enable: ['dashboardNewLayouts'] });
+    beforeEach(() => {
+      setTestFlags({ dashboardNewLayouts: true });
+    });
+    afterEach(() => {
+      setTestFlags({});
+    });
     it('renders dashboard correctly', async () => {
       render(<DashboardPicker value="v2-special-case-override" />);
       expect(await screen.findByText('TODO')).toBeInTheDocument();

--- a/public/app/features/dashboard-scene/addToDashboard/addPanelsOnLoadBehavior.test.ts
+++ b/public/app/features/dashboard-scene/addToDashboard/addPanelsOnLoadBehavior.test.ts
@@ -1,6 +1,6 @@
 import { store } from '@grafana/data';
-import { config } from '@grafana/runtime';
 import { SceneGridLayout, SceneTimeRange, VizPanel } from '@grafana/scenes';
+import { setTestFlags } from '@grafana/test-utils/unstable';
 import { DASHBOARD_FROM_LS_KEY, type DashboardDTO } from 'app/types/dashboard';
 
 import { DashboardScene } from '../scene/DashboardScene';
@@ -33,14 +33,12 @@ function buildTestScene(): DashboardScene {
 }
 
 describe('addPanelsOnLoadBehavior', () => {
-  const originalFT = config.featureToggles.dashboardNewLayouts;
-
   beforeEach(() => {
-    config.featureToggles.dashboardNewLayouts = true;
+    setTestFlags({ dashboardNewLayouts: true });
   });
 
   afterEach(() => {
-    config.featureToggles.dashboardNewLayouts = originalFT;
+    setTestFlags({});
     store.delete(DASHBOARD_FROM_LS_KEY);
   });
 

--- a/public/app/features/dashboard-scene/addToDashboard/addPanelsOnLoadBehavior.ts
+++ b/public/app/features/dashboard-scene/addToDashboard/addPanelsOnLoadBehavior.ts
@@ -1,5 +1,6 @@
 import { store } from '@grafana/data';
-import { config, reportInteraction } from '@grafana/runtime';
+import { reportInteraction } from '@grafana/runtime';
+import { FlagKeys, getFeatureFlagClient } from '@grafana/runtime/internal';
 import { SceneTimeRange } from '@grafana/scenes';
 import { DashboardModel } from 'app/features/dashboard/state/DashboardModel';
 import { DASHBOARD_FROM_LS_KEY, type DashboardDTO } from 'app/types/dashboard';
@@ -38,7 +39,7 @@ export function addPanelsOnLoadBehavior(scene: DashboardScene) {
     }
   };
 
-  if (!config.featureToggles.dashboardNewLayouts) {
+  if (!getFeatureFlagClient().getBooleanValue(FlagKeys.DashboardNewLayouts, false)) {
     addPanels();
     return;
   }

--- a/public/app/features/dashboard-scene/assistant/PanelAssistantHint.test.tsx
+++ b/public/app/features/dashboard-scene/assistant/PanelAssistantHint.test.tsx
@@ -1,6 +1,7 @@
 import { getPanelPlugin } from '@grafana/data/test';
-import { config, setPluginImportUtils } from '@grafana/runtime';
+import { setPluginImportUtils } from '@grafana/runtime';
 import { SceneDataTransformer, SceneGridLayout, VizPanel, sceneGraph } from '@grafana/scenes';
+import { setTestFlags } from '@grafana/test-utils/unstable';
 
 import { DashboardScene } from '../scene/DashboardScene';
 import { DashboardGridItem } from '../scene/layout-default/DashboardGridItem';
@@ -28,7 +29,7 @@ setPluginImportUtils({
 
 describe('PanelAssistantHint', () => {
   beforeEach(() => {
-    config.featureToggles.dashboardNewLayouts = true;
+    setTestFlags({ dashboardNewLayouts: true });
   });
 
   describe('addAssistantHintToPanel', () => {
@@ -116,7 +117,7 @@ function buildTestSceneWithPanels() {
     }),
   });
 
-  config.featureToggles.dashboardNewLayouts = true;
+  setTestFlags({ dashboardNewLayouts: true });
   activateFullSceneTree(scene);
 
   return scene;

--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPane.test.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPane.test.tsx
@@ -1,5 +1,5 @@
 import { getPanelPlugin } from '@grafana/data/test';
-import { config, setPluginImportUtils } from '@grafana/runtime';
+import { setPluginImportUtils } from '@grafana/runtime';
 import {
   ConstantVariable,
   CustomVariable,
@@ -10,6 +10,7 @@ import {
   TestVariable,
   VizPanel,
 } from '@grafana/scenes';
+import { setTestFlags } from '@grafana/test-utils/unstable';
 import { ALL_VARIABLE_TEXT, ALL_VARIABLE_VALUE } from 'app/features/variables/constants';
 
 import { DashboardScene } from '../scene/DashboardScene';
@@ -601,7 +602,7 @@ describe('DashboardEditPane', () => {
         isEditing: true,
         body: new TabsLayoutManager({ tabs: [tabWithPanel] }),
       });
-      config.featureToggles.dashboardNewLayouts = true;
+      setTestFlags({ dashboardNewLayouts: true });
       activateFullSceneTree(sourceDashboard);
       sourceDashboard.copyPanel(panel);
 
@@ -619,7 +620,7 @@ function buildTestScene() {
     tags: ['tag1', 'tag2'],
     editable: true,
   });
-  config.featureToggles.dashboardNewLayouts = true;
+  setTestFlags({ dashboardNewLayouts: true });
   activateFullSceneTree(scene);
 
   return scene;
@@ -681,7 +682,7 @@ function setupEmptyDashboard(): {
     isEditing: true,
     body: AutoGridLayoutManager.createEmpty(),
   });
-  config.featureToggles.dashboardNewLayouts = true;
+  setTestFlags({ dashboardNewLayouts: true });
   activateFullSceneTree(dashboard);
   return { dashboard, editPane: dashboard.state.editPane };
 }
@@ -705,7 +706,7 @@ function setupWithTwoTabs(): {
     isEditing: true,
     body: new TabsLayoutManager({ tabs: [tab1, tab2] }),
   });
-  config.featureToggles.dashboardNewLayouts = true;
+  setTestFlags({ dashboardNewLayouts: true });
   activateFullSceneTree(dashboard);
   return { dashboard, tab1, tab2, tab1Viz: panel, editPane: dashboard.state.editPane };
 }
@@ -729,7 +730,7 @@ function setupWithTwoRows(): {
     isEditing: true,
     body: new RowsLayoutManager({ rows: [row1, row2] }),
   });
-  config.featureToggles.dashboardNewLayouts = true;
+  setTestFlags({ dashboardNewLayouts: true });
   activateFullSceneTree(dashboard);
   return { dashboard, row1, row2, row1Viz: panel, editPane: dashboard.state.editPane };
 }

--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneRenderer.test.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneRenderer.test.tsx
@@ -4,8 +4,9 @@ import { render } from 'test/test-utils';
 
 import { getPanelPlugin } from '@grafana/data/test';
 import { selectors } from '@grafana/e2e-selectors';
-import { setPluginImportUtils, config } from '@grafana/runtime';
+import { setPluginImportUtils } from '@grafana/runtime';
 import { SceneGridLayout, SceneTimeRange, SceneVariableSet, VizPanel } from '@grafana/scenes';
+import { setTestFlags } from '@grafana/test-utils/unstable';
 
 import { DashboardDataLayerSet } from '../scene/DashboardDataLayerSet';
 import { DashboardScene } from '../scene/DashboardScene';
@@ -76,7 +77,7 @@ export function buildTestScene() {
 
 describe('DashboardEditPaneRenderer', () => {
   beforeEach(() => {
-    config.featureToggles.dashboardNewLayouts = true;
+    setTestFlags({ dashboardNewLayouts: true });
     // Sidebar state is persisted to localStorage — clear between tests so each test
     // starts with the default visibility/dock state.
     window.localStorage.clear();

--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneRenderer.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneRenderer.tsx
@@ -5,6 +5,7 @@ import { type GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
+import { useFlagDashboardNewLayouts } from '@grafana/runtime/internal';
 import { sceneGraph, type SceneVariable, useSceneObjectState } from '@grafana/scenes';
 import { Sidebar, useStyles2, useSidebarContext } from '@grafana/ui';
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
@@ -34,6 +35,7 @@ export interface Props {
  */
 export function DashboardEditPaneRenderer({ dashboard }: Props) {
   const editPane = dashboard.state.editPane;
+  const dashboardNewLayouts = useFlagDashboardNewLayouts();
   const { openPane, selectionContext, outlinePane } = useSceneObjectState(editPane, {
     shouldActivateOrKeepAlive: true,
   });
@@ -139,7 +141,7 @@ export function DashboardEditPaneRenderer({ dashboard }: Props) {
             data-testid={selectors.pages.Dashboard.Sidebar.outlineButton}
             active={openPane instanceof DashboardOutline}
           />
-          {config.featureToggles.dashboardNewLayouts && config.featureToggles.dashboardUnifiedDrilldownControls && (
+          {dashboardNewLayouts && config.featureToggles.dashboardUnifiedDrilldownControls && (
             <FiltersOverviewButton editPane={editPane} openPane={openPane} />
           )}
           {dashboard.isManaged() && Boolean(meta.canEdit) && <ManagedDashboardNavBarBadge dashboard={dashboard} />}

--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneSplitter.test.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneSplitter.test.tsx
@@ -4,8 +4,9 @@ import { render } from 'test/test-utils';
 
 import { getPanelPlugin } from '@grafana/data/test';
 import { selectors } from '@grafana/e2e-selectors';
-import { setPluginImportUtils, config } from '@grafana/runtime';
+import { setPluginImportUtils } from '@grafana/runtime';
 import { SceneGridLayout, SceneTimeRange, SceneVariableSet, VizPanel } from '@grafana/scenes';
+import { setTestFlags } from '@grafana/test-utils/unstable';
 
 import { DashboardDataLayerSet } from '../scene/DashboardDataLayerSet';
 import { DashboardScene } from '../scene/DashboardScene';
@@ -29,7 +30,7 @@ const autoLayoutInputs = [
 
 describe('DashboardEditPaneSplitter', () => {
   beforeEach(() => {
-    config.featureToggles.dashboardNewLayouts = true;
+    setTestFlags({ dashboardNewLayouts: true });
   });
 
   it('should switch between custom and auto layout', async () => {

--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneSplitter.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneSplitter.tsx
@@ -5,8 +5,8 @@ import { useMedia } from 'react-use';
 import { type GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
-import { config, useChromeHeaderHeight } from '@grafana/runtime';
-import { useFlagGrafanaVisualDesignRefresh } from '@grafana/runtime/internal';
+import { useChromeHeaderHeight } from '@grafana/runtime';
+import { useFlagDashboardNewLayouts, useFlagGrafanaVisualDesignRefresh } from '@grafana/runtime/internal';
 import { type VizPanel, useSceneObjectState } from '@grafana/scenes';
 import {
   ElementSelectionContext,
@@ -46,7 +46,8 @@ interface Props {
 }
 
 export function DashboardEditPaneSplitter(props: Props) {
-  if (config.featureToggles.dashboardNewLayouts) {
+  const dashboardNewLayouts = useFlagDashboardNewLayouts();
+  if (dashboardNewLayouts) {
     return <DashboardEditPaneSplitterNewLayouts {...props} />;
   } else {
     return <DashboardEditPaneSplitterLegacy {...props} />;

--- a/public/app/features/dashboard-scene/edit-pane/dashboard/DashboardBasicOptions.test.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/dashboard/DashboardBasicOptions.test.tsx
@@ -2,7 +2,7 @@ import { act, fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { TestProvider } from 'test/helpers/TestProvider';
 
-import { config } from '@grafana/runtime';
+import { setTestFlags } from '@grafana/test-utils/unstable';
 
 import { type DashboardScene } from '../../scene/DashboardScene';
 import { type DashboardSceneState } from '../../scene/types/dashboard';
@@ -113,7 +113,7 @@ function setup(overrides?: Partial<DashboardSceneState>) {
   // Clear any data layers
   dashboard.setState({ $data: undefined });
 
-  config.featureToggles.dashboardNewLayouts = true;
+  setTestFlags({ dashboardNewLayouts: true });
   activateFullSceneTree(dashboard);
 
   dashboard.onEnterEditMode();

--- a/public/app/features/dashboard-scene/mutation-api/commands/layoutCommands.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/layoutCommands.test.ts
@@ -1,4 +1,3 @@
-import { config } from '@grafana/runtime';
 import { CustomVariable, SceneVariableSet, VizPanel } from '@grafana/scenes';
 import { setTestFlags } from '@grafana/test-utils/unstable';
 
@@ -225,15 +224,12 @@ function buildSceneWithLayoutParent(
 }
 
 describe('Layout mutation commands', () => {
-  let originalToggle: boolean | undefined;
-
   beforeEach(() => {
-    originalToggle = config.featureToggles.dashboardNewLayouts;
-    config.featureToggles.dashboardNewLayouts = true;
+    setTestFlags({ dashboardNewLayouts: true });
   });
 
   afterEach(() => {
-    config.featureToggles.dashboardNewLayouts = originalToggle;
+    setTestFlags({});
   });
 
   describe('ADD_ROW', () => {
@@ -748,7 +744,7 @@ describe('Layout mutation commands', () => {
     });
 
     it('is rejected when feature toggle is disabled', async () => {
-      config.featureToggles.dashboardNewLayouts = false;
+      setTestFlags({ dashboardNewLayouts: false });
       const scene = buildRowsScene(['Row']);
       const executor = new DashboardMutationClient(scene);
 
@@ -2070,7 +2066,7 @@ describe('Layout mutation commands', () => {
     });
 
     it('ADD_ROW applies spec.variables when dashboardSectionVariables is enabled', async () => {
-      setTestFlags({ dashboardSectionVariables: true });
+      setTestFlags({ dashboardNewLayouts: true, dashboardSectionVariables: true });
       const scene = buildRowsScene(['Existing']);
       const executor = new DashboardMutationClient(scene);
 
@@ -2089,7 +2085,7 @@ describe('Layout mutation commands', () => {
     });
 
     it('ADD_ROW ignores spec.variables when dashboardSectionVariables is disabled', async () => {
-      setTestFlags({ dashboardSectionVariables: false });
+      setTestFlags({ dashboardNewLayouts: true, dashboardSectionVariables: false });
       const scene = buildRowsScene(['Existing']);
       const executor = new DashboardMutationClient(scene);
 
@@ -2107,7 +2103,7 @@ describe('Layout mutation commands', () => {
     });
 
     it('ADD_TAB applies spec.variables when dashboardSectionVariables is enabled', async () => {
-      setTestFlags({ dashboardSectionVariables: true });
+      setTestFlags({ dashboardNewLayouts: true, dashboardSectionVariables: true });
       const scene = buildTabsScene(['Existing']);
       const executor = new DashboardMutationClient(scene);
 
@@ -2125,7 +2121,7 @@ describe('Layout mutation commands', () => {
     });
 
     it('UPDATE_ROW clears section variables with variables: [] when flag is on', async () => {
-      setTestFlags({ dashboardSectionVariables: true });
+      setTestFlags({ dashboardNewLayouts: true, dashboardSectionVariables: true });
       const row = new RowItem({
         title: 'R',
         layout: DefaultGridLayoutManager.fromVizPanels([]),
@@ -2147,7 +2143,7 @@ describe('Layout mutation commands', () => {
     });
 
     it('UPDATE_TAB clears section variables with variables: [] when flag is on', async () => {
-      setTestFlags({ dashboardSectionVariables: true });
+      setTestFlags({ dashboardNewLayouts: true, dashboardSectionVariables: true });
       const tab = new TabItem({
         title: 'T',
         layout: DefaultGridLayoutManager.fromVizPanels([]),
@@ -2169,7 +2165,7 @@ describe('Layout mutation commands', () => {
     });
 
     it('UPDATE_ROW ignores spec.variables when dashboardSectionVariables is disabled', async () => {
-      setTestFlags({ dashboardSectionVariables: false });
+      setTestFlags({ dashboardNewLayouts: true, dashboardSectionVariables: false });
       const row = new RowItem({
         title: 'R',
         layout: DefaultGridLayoutManager.fromVizPanels([]),
@@ -2191,7 +2187,7 @@ describe('Layout mutation commands', () => {
     });
 
     it('UPDATE_TAB ignores spec.variables when dashboardSectionVariables is disabled', async () => {
-      setTestFlags({ dashboardSectionVariables: false });
+      setTestFlags({ dashboardNewLayouts: true, dashboardSectionVariables: false });
       const tab = new TabItem({
         title: 'T',
         layout: DefaultGridLayoutManager.fromVizPanels([]),
@@ -2329,7 +2325,7 @@ describe('Layout mutation commands', () => {
 
   describe('feature toggle gate', () => {
     it('rejects layout commands when dashboardNewLayouts is disabled', async () => {
-      config.featureToggles.dashboardNewLayouts = false;
+      setTestFlags({ dashboardNewLayouts: false });
       const scene = buildRowsScene(['A']);
       const executor = new DashboardMutationClient(scene);
 

--- a/public/app/features/dashboard-scene/mutation-api/commands/panelCommands.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/panelCommands.test.ts
@@ -7,8 +7,8 @@ import {
   type PanelPlugin,
   toDataFrame,
 } from '@grafana/data';
-import { config } from '@grafana/runtime';
 import { SceneDataNode, SceneDataTransformer, sceneGraph, type VizPanel } from '@grafana/scenes';
+import { setTestFlags } from '@grafana/test-utils/unstable';
 
 import type { DashboardScene } from '../../scene/DashboardScene';
 import { type AutoGridItem } from '../../scene/layout-auto-grid/AutoGridItem';
@@ -1230,15 +1230,12 @@ describe('Panel mutation commands', () => {
   });
 
   describe('MOVE_PANEL', () => {
-    let originalToggle: boolean | undefined;
-
     beforeEach(() => {
-      originalToggle = config.featureToggles.dashboardNewLayouts;
-      config.featureToggles.dashboardNewLayouts = true;
+      setTestFlags({ dashboardNewLayouts: true });
     });
 
     afterEach(() => {
-      config.featureToggles.dashboardNewLayouts = originalToggle;
+      setTestFlags({});
     });
 
     it('repositions panel within current group using layoutItem', async () => {

--- a/public/app/features/dashboard-scene/mutation-api/commands/types.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/types.ts
@@ -7,7 +7,7 @@
 
 import { type z } from 'zod';
 
-import { config } from '@grafana/runtime';
+import { FlagKeys, getFeatureFlagClient } from '@grafana/runtime/internal';
 
 import type { DashboardScene } from '../../scene/DashboardScene';
 import type { MutationResult } from '../types';
@@ -66,7 +66,7 @@ export function readOnly(_scene: DashboardScene): PermissionCheckResult {
  * Used by all layout mutation commands (row/tab CRUD, panel movement).
  */
 export function requiresNewDashboardLayouts(scene: DashboardScene): PermissionCheckResult {
-  if (!config.featureToggles.dashboardNewLayouts) {
+  if (!getFeatureFlagClient().getBooleanValue(FlagKeys.DashboardNewLayouts, false)) {
     return {
       allowed: false,
       error: 'Layout management requires the "dashboardNewLayouts" feature toggle to be enabled.',
@@ -80,7 +80,7 @@ export function requiresNewDashboardLayouts(scene: DashboardScene): PermissionCh
  * Used by GET_LAYOUT and other read-only layout commands.
  */
 export function requiresNewDashboardLayoutsReadOnly(_scene: DashboardScene): PermissionCheckResult {
-  if (!config.featureToggles.dashboardNewLayouts) {
+  if (!getFeatureFlagClient().getBooleanValue(FlagKeys.DashboardNewLayouts, false)) {
     return {
       allowed: false,
       error: 'Layout management requires the "dashboardNewLayouts" feature toggle to be enabled.',

--- a/public/app/features/dashboard-scene/pages/DashboardScenePage.test.tsx
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePage.test.tsx
@@ -19,7 +19,7 @@ import {
 import { setGetObservablePluginLinks, setPanelPluginMetas } from '@grafana/runtime/internal';
 import { VizPanel } from '@grafana/scenes';
 import { type Dashboard } from '@grafana/schema';
-import { getTestFeatureFlagClient } from '@grafana/test-utils/unstable';
+import { getTestFeatureFlagClient, setTestFlags } from '@grafana/test-utils/unstable';
 import { getRouteComponentProps } from 'app/core/navigation/mocks/routeProps';
 import { type GrafanaRouteComponentProps } from 'app/core/navigation/types';
 import { type DashboardLoaderSrv, setDashboardLoaderSrv } from 'app/features/dashboard/services/DashboardLoaderSrv';
@@ -348,6 +348,10 @@ describe('DashboardScenePage', () => {
   });
 
   describe('empty state', () => {
+    beforeEach(() => {
+      setTestFlags({ dashboardNewLayouts: false });
+    });
+
     it('Shows empty state when dashboard is empty', async () => {
       loadDashboardMock.mockResolvedValue({ dashboard: { uid: 'my-dash-uid', panels: [] }, meta: {} });
       setup();

--- a/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.test.ts
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.test.ts
@@ -2016,7 +2016,7 @@ describe('DashboardScenePageStateManager v2', () => {
 describe('UnifiedDashboardScenePageStateManager', () => {
   afterEach(() => {
     store.delete(DASHBOARD_FROM_LS_KEY);
-    config.featureToggles.dashboardNewLayouts = false;
+    setTestFlags({ dashboardNewLayouts: false });
   });
 
   describe('when fetching/loading a dashboard', () => {
@@ -2609,7 +2609,7 @@ describe('UnifiedDashboardScenePageStateManager', () => {
 
   describe('New dashboards', () => {
     it('should use v1 manager for new dashboards when dashboardNewLayouts feature toggle is disabled', async () => {
-      config.featureToggles.dashboardNewLayouts = false;
+      setTestFlags({ dashboardNewLayouts: false });
 
       const manager = new UnifiedDashboardScenePageStateManager({});
       manager.setActiveManager('v2');
@@ -2623,7 +2623,7 @@ describe('UnifiedDashboardScenePageStateManager', () => {
     });
 
     it('should use v2 manager for new dashboards when dashboardNewLayouts feature toggle is enabled', async () => {
-      config.featureToggles.dashboardNewLayouts = true;
+      setTestFlags({ dashboardNewLayouts: true });
 
       const manager = new UnifiedDashboardScenePageStateManager({});
       manager.setActiveManager('v1');
@@ -2637,7 +2637,7 @@ describe('UnifiedDashboardScenePageStateManager', () => {
     });
 
     it('should maintain manager version for subsequent loads based on feature toggle', async () => {
-      config.featureToggles.dashboardNewLayouts = false;
+      setTestFlags({ dashboardNewLayouts: false });
       const manager1 = new UnifiedDashboardScenePageStateManager({});
       manager1.setActiveManager('v2');
       await manager1.loadDashboard({ uid: '', route: DashboardRoutes.New });
@@ -2647,7 +2647,7 @@ describe('UnifiedDashboardScenePageStateManager', () => {
       await manager1.loadDashboard({ uid: '', route: DashboardRoutes.New });
       expect(manager1['activeManager']).toBeInstanceOf(DashboardScenePageStateManager);
 
-      config.featureToggles.dashboardNewLayouts = true;
+      setTestFlags({ dashboardNewLayouts: true });
       const manager2 = new UnifiedDashboardScenePageStateManager({});
       manager2.setActiveManager('v1');
       await manager2.loadDashboard({ uid: '', route: DashboardRoutes.New });
@@ -2679,7 +2679,7 @@ describe('UnifiedDashboardScenePageStateManager', () => {
     });
 
     it('should always use v1 manager for Grafana dashboard templates even when dashboardNewLayouts is enabled', async () => {
-      config.featureToggles.dashboardNewLayouts = true;
+      setTestFlags({ dashboardNewLayouts: true });
       config.featureToggles.suggestedDashboards = true;
 
       // Mock location service with gnetId and mappings parameters
@@ -2715,7 +2715,7 @@ describe('UnifiedDashboardScenePageStateManager', () => {
     });
 
     it('should reset to V2 manager when loading a new dashboard after template', async () => {
-      config.featureToggles.dashboardNewLayouts = true;
+      setTestFlags({ dashboardNewLayouts: true });
       config.featureToggles.suggestedDashboards = true;
 
       // Mock locationService for this test too

--- a/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
@@ -1320,7 +1320,7 @@ export class DashboardScenePageStateManagerV2 extends DashboardScenePageStateMan
 }
 
 function shouldForceV2API(): boolean {
-  return Boolean(config.featureToggles.dashboardNewLayouts);
+  return Boolean(getFeatureFlagClient().getBooleanValue(FlagKeys.DashboardNewLayouts, false));
 }
 
 export class UnifiedDashboardScenePageStateManager extends DashboardScenePageStateManagerBase<

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditor.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditor.tsx
@@ -143,7 +143,10 @@ export class PanelEditor extends SceneObjectBase<PanelEditorState> {
     const originalState = this._layoutItemState!;
 
     // Temp fix for old edit mode
-    if (this._layoutItem instanceof DashboardGridItem && !config.featureToggles.dashboardNewLayouts) {
+    if (
+      this._layoutItem instanceof DashboardGridItem &&
+      !getFeatureFlagClient().getBooleanValue(FlagKeys.DashboardNewLayouts, false)
+    ) {
       this._layoutItem.handleEditChange();
       return;
     }

--- a/public/app/features/dashboard-scene/scene/DashboardControls.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardControls.test.tsx
@@ -165,6 +165,7 @@ describe('DashboardControls', () => {
     });
 
     it('should render with hidden controls', async () => {
+      setTestFlags({ dashboardNewLayouts: false });
       const scene = buildTestScene({
         hideTimeControls: true,
         hideVariableControls: true,
@@ -179,7 +180,7 @@ describe('DashboardControls', () => {
     it('should not render an empty controls container in kiosk mode when controls are hidden', () => {
       const originalFeatureToggles = { ...config.featureToggles };
       try {
-        config.featureToggles.dashboardNewLayouts = true;
+        setTestFlags({ dashboardNewLayouts: true });
 
         const scene = buildTestScene({
           hideTimeControls: true,
@@ -199,7 +200,7 @@ describe('DashboardControls', () => {
     it('in edit mode, should render the "Add variable" button when hasControls returns false and time controls are hidden', async () => {
       const originalFeatureToggles = { ...config.featureToggles };
       try {
-        config.featureToggles.dashboardNewLayouts = true;
+        setTestFlags({ dashboardNewLayouts: true });
 
         const controls = buildTestSceneWithEditable({
           editable: true,
@@ -464,13 +465,13 @@ describe('DashboardControls', () => {
     const originalFeatureToggles = { ...config.featureToggles };
 
     beforeEach(() => {
-      config.featureToggles.dashboardNewLayouts = true;
+      setTestFlags({ dashboardNewLayouts: true });
       jest.mocked(playlistSrv.useState).mockReturnValue({ isPlaying: false });
     });
 
     afterEach(() => {
       config.featureToggles = originalFeatureToggles;
-      jest.resetAllMocks();
+      jest.clearAllMocks();
     });
 
     it('should show EditDashboardSwitch when editable is true', async () => {
@@ -551,12 +552,12 @@ describe('DashboardControls', () => {
 
     beforeEach(() => {
       jest.mocked(playlistSrv.useState).mockReturnValue({ isPlaying: false });
-      config.featureToggles.dashboardNewLayouts = true;
+      setTestFlags({ dashboardNewLayouts: true });
     });
 
     afterEach(() => {
       config.featureToggles = originalFeatureToggles;
-      jest.resetAllMocks();
+      jest.clearAllMocks();
     });
 
     it('should hide Edit and Share buttons in kiosk mode', async () => {
@@ -580,7 +581,7 @@ describe('DashboardControls', () => {
     const mockedContextSrv = jest.mocked(contextSrv);
 
     beforeEach(() => {
-      config.featureToggles.dashboardNewLayouts = true;
+      setTestFlags({ dashboardNewLayouts: true });
       jest.mocked(playlistSrv.useState).mockReturnValue({ isPlaying: false });
       mockedContextSrv.hasEditPermissionInFolders = false;
     });

--- a/public/app/features/dashboard-scene/scene/DashboardControls.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardControls.tsx
@@ -5,7 +5,7 @@ import { type GrafanaTheme2, VariableHide } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
-import { FlagKeys, getFeatureFlagClient } from '@grafana/runtime/internal';
+import { FlagKeys, getFeatureFlagClient, useFlagDashboardNewLayouts } from '@grafana/runtime/internal';
 import {
   type SceneObjectState,
   SceneObjectBase,
@@ -217,6 +217,7 @@ function DashboardControlsRenderer({ model }: SceneComponentProps<DashboardContr
   } = model.useState();
 
   const dashboard = getDashboardSceneFor(model);
+  const dashboardNewLayouts = useFlagDashboardNewLayouts();
   const { links, editPanel } = dashboard.useState();
   const isQueryEditorNext = Boolean(editPanel?.state.useQueryExperienceNext);
   const styles = useStyles2(getStyles, isQueryEditorNext);
@@ -236,7 +237,7 @@ function DashboardControlsRenderer({ model }: SceneComponentProps<DashboardContr
     // If dynamic dashboards is enabled, we need to show the edit/share/playlist buttons
     // However we shouldn't do it if we're in edit panel view
     // `DashboardControlActions` already check for edit panel view but we need to prevent showing the container as well
-    if (config.featureToggles.dashboardNewLayouts && !editPanel && kioskMode !== KioskMode.Full) {
+    if (dashboardNewLayouts && !editPanel && kioskMode !== KioskMode.Full) {
       return (
         <>
           <div data-testid={selectors.pages.Dashboard.Controls} className={styles.controls}>
@@ -273,12 +274,12 @@ function DashboardControlsRenderer({ model }: SceneComponentProps<DashboardContr
             <refreshPicker.Component model={refreshPicker} />
           </div>
         )}
-        {config.featureToggles.dashboardNewLayouts && (
+        {dashboardNewLayouts && (
           <div className={styles.fixedControls}>
             <DashboardControlActions dashboard={dashboard} hidePlaylistNav={hidePlaylistNav} />
           </div>
         )}
-        {config.featureToggles.dashboardUnifiedDrilldownControls && !config.featureToggles.dashboardNewLayouts && (
+        {config.featureToggles.dashboardUnifiedDrilldownControls && !dashboardNewLayouts && (
           <div className={styles.fixedControls}>
             <DashboardFiltersOverviewPaneToggle dashboard={dashboard} />
           </div>

--- a/public/app/features/dashboard-scene/scene/DashboardLinksControls.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardLinksControls.test.tsx
@@ -1,3 +1,4 @@
+import { OpenFeatureProvider } from '@openfeature/react-sdk';
 import { act, render } from '@testing-library/react';
 import { type ReactNode } from 'react';
 import { getGrafanaContextMock } from 'test/mocks/getGrafanaContextMock';
@@ -5,6 +6,7 @@ import { getGrafanaContextMock } from 'test/mocks/getGrafanaContextMock';
 import { toUtc } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { SceneTimeRange } from '@grafana/scenes';
+import { getTestFeatureFlagClient, setTestFlags } from '@grafana/test-utils/unstable';
 import { GrafanaContext } from 'app/core/context/GrafanaContext';
 
 import { DashboardControls } from './DashboardControls';
@@ -24,6 +26,10 @@ jest.mock('app/features/panel/panellinks/link_srv', () => ({
 }));
 
 describe('DashboardLinksControls', () => {
+  beforeEach(() => {
+    setTestFlags({ dashboardNewLayouts: false });
+  });
+
   it('renders dashboard links correctly', () => {
     const { controls } = buildTestScene();
     const renderer = renderInGrafanaContext(<controls.Component model={controls} />);
@@ -63,7 +69,11 @@ describe('DashboardLinksControls', () => {
 
 function renderInGrafanaContext(child: ReactNode) {
   const context = getGrafanaContextMock();
-  return render(<GrafanaContext.Provider value={context}>{child}</GrafanaContext.Provider>);
+  return render(
+    <OpenFeatureProvider client={getTestFeatureFlagClient()}>
+      <GrafanaContext.Provider value={context}>{child}</GrafanaContext.Provider>
+    </OpenFeatureProvider>
+  );
 }
 
 function buildTestScene(): { controls: DashboardControls; dashboard: DashboardScene } {

--- a/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
@@ -25,6 +25,7 @@ import {
 } from '@grafana/scenes';
 import { type Dashboard, DashboardCursorSync, type LibraryPanel } from '@grafana/schema';
 import { type Spec as DashboardV2Spec, type VariableKind } from '@grafana/schema/apis/dashboard.grafana.app/v2';
+import { setTestFlags } from '@grafana/test-utils/unstable';
 import { appEvents } from 'app/core/app_events';
 import { LS_PANEL_COPY_KEY, LS_STYLES_COPY_KEY } from 'app/core/constants';
 import { AnnoKeyManagerKind, ManagerKind } from 'app/features/apiserver/types';
@@ -324,8 +325,7 @@ describe('DashboardScene', () => {
       });
 
       it('Should exit edit mode after saving from unsaved changes modal when dashboardNewLayouts is enabled', () => {
-        const originalFeatureToggle = config.featureToggles.dashboardNewLayouts;
-        config.featureToggles.dashboardNewLayouts = true;
+        setTestFlags({ dashboardNewLayouts: true });
 
         scene.setState({ meta: { ...scene.state.meta, canSave: true } });
 
@@ -354,12 +354,11 @@ describe('DashboardScene', () => {
 
         publishSpy.mockRestore();
         hasActualSaveChangesSpy.mockRestore();
-        config.featureToggles.dashboardNewLayouts = originalFeatureToggle;
+        setTestFlags({});
       });
 
       it('Should not show Save option in unsaved changes modal when user cannot save', () => {
-        const originalFeatureToggle = config.featureToggles.dashboardNewLayouts;
-        config.featureToggles.dashboardNewLayouts = true;
+        setTestFlags({ dashboardNewLayouts: true });
 
         scene.setState({ meta: { ...scene.state.meta, canSave: false } });
 
@@ -379,7 +378,7 @@ describe('DashboardScene', () => {
 
         publishSpy.mockRestore();
         hasActualSaveChangesSpy.mockRestore();
-        config.featureToggles.dashboardNewLayouts = originalFeatureToggle;
+        setTestFlags({});
       });
 
       it('Should start the detect changes worker', () => {

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -14,7 +14,7 @@ import {
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, locationService, RefreshEvent, reportInteraction } from '@grafana/runtime';
-import { getPanelPluginMeta } from '@grafana/runtime/internal';
+import { FlagKeys, getFeatureFlagClient, getPanelPluginMeta } from '@grafana/runtime/internal';
 import {
   type CancelActivationHandler,
   SceneDataTransformer,
@@ -448,7 +448,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
       return;
     }
 
-    if (config.featureToggles.dashboardNewLayouts) {
+    if (getFeatureFlagClient().getBooleanValue(FlagKeys.DashboardNewLayouts, false)) {
       const canSave = Boolean(this.state.meta.canSave);
 
       appEvents.publish(
@@ -770,7 +770,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
   }
 
   public copyPanel(vizPanel: VizPanel) {
-    if (config.featureToggles.dashboardNewLayouts) {
+    if (getFeatureFlagClient().getBooleanValue(FlagKeys.DashboardNewLayouts, false)) {
       const gridItem = vizPanel.parent;
 
       if (gridItem instanceof AutoGridItem) {
@@ -814,7 +814,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
       return;
     }
 
-    if (config.featureToggles.dashboardNewLayouts) {
+    if (getFeatureFlagClient().getBooleanValue(FlagKeys.DashboardNewLayouts, false)) {
       const layout = getLayoutForObject(this);
       if (layout) {
         layout.pastePanel();

--- a/public/app/features/dashboard-scene/scene/LibraryPanelBehavior.tsx
+++ b/public/app/features/dashboard-scene/scene/LibraryPanelBehavior.tsx
@@ -1,6 +1,7 @@
 import { PanelPlugin, type PanelProps } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
+import { FlagKeys, getFeatureFlagClient } from '@grafana/runtime/internal';
 import {
   type SceneObject,
   SceneObjectBase,
@@ -122,7 +123,9 @@ export class LibraryPanelBehavior extends SceneObjectBase<LibraryPanelBehaviorSt
     const isPublicDashboard = dashboard.state.meta.publicDashboardEnabled === true;
     const isScriptedDashboard = dashboard.state.meta.fromScript === true;
     const shouldSkipRepeatMigration =
-      config.featureToggles.dashboardNewLayouts && !isPublicDashboard && !isScriptedDashboard;
+      getFeatureFlagClient().getBooleanValue(FlagKeys.DashboardNewLayouts, false) &&
+      !isPublicDashboard &&
+      !isScriptedDashboard;
 
     // Migrate repeat options to layout element (only for legacy dashboards, or public/scripted dashboards)
     if (!shouldSkipRepeatMigration && libPanelModel.repeat && layoutElement instanceof DashboardGridItem) {

--- a/public/app/features/dashboard-scene/scene/NavToolbarActions.tsx
+++ b/public/app/features/dashboard-scene/scene/NavToolbarActions.tsx
@@ -4,7 +4,8 @@ import { memo, type ReactNode, useEffect, useState } from 'react';
 import { type GrafanaTheme2, store } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
-import { config, locationService } from '@grafana/runtime';
+import { locationService } from '@grafana/runtime';
+import { useFlagDashboardNewLayouts } from '@grafana/runtime/internal';
 import { Button, ButtonGroup, Dropdown, Icon, Menu, ToolbarButton, ToolbarButtonRow, useStyles2 } from '@grafana/ui';
 import { AppChromeUpdate } from 'app/core/components/AppChrome/AppChromeUpdate';
 import { NavToolbarSeparator } from 'app/core/components/AppChrome/NavToolbar/NavToolbarSeparator';
@@ -39,7 +40,8 @@ interface Props {
 }
 
 export const NavToolbarActions = memo<Props>(({ dashboard }) => {
-  const hasNewToolbar = config.featureToggles.dashboardNewLayouts;
+  const dashboardNewLayouts = useFlagDashboardNewLayouts();
+  const hasNewToolbar = dashboardNewLayouts;
 
   return hasNewToolbar ? (
     <AppChromeUpdate

--- a/public/app/features/dashboard-scene/scene/VariableControls.test.tsx
+++ b/public/app/features/dashboard-scene/scene/VariableControls.test.tsx
@@ -1,5 +1,7 @@
-import { render, screen } from '@testing-library/react';
+import { OpenFeatureProvider } from '@openfeature/react-sdk';
+import { render as RTLRender, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { type ReactNode } from 'react';
 
 import { VariableHide } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
@@ -12,6 +14,7 @@ import {
   ScopesVariable,
   TextBoxVariable,
 } from '@grafana/scenes';
+import { getTestFeatureFlagClient, setTestFlags } from '@grafana/test-utils/unstable';
 
 import { toControlSourceRef } from '../utils/predefinedVariables';
 
@@ -34,7 +37,15 @@ jest.mock('@grafana/runtime', () => {
   };
 });
 
+function render(ui: ReactNode) {
+  return RTLRender(<OpenFeatureProvider client={getTestFeatureFlagClient()}>{ui}</OpenFeatureProvider>);
+}
+
 describe('VariableControls', () => {
+  beforeEach(() => {
+    setTestFlags({ dashboardNewLayouts: false });
+  });
+
   it('should not show scopes variable label but should mount its component', () => {
     const scopesVariable = new ScopesVariable({ hide: VariableHide.hideVariable, name: '__scopes' });
     const variables = [scopesVariable];

--- a/public/app/features/dashboard-scene/scene/VariableControls.tsx
+++ b/public/app/features/dashboard-scene/scene/VariableControls.tsx
@@ -3,7 +3,7 @@ import { useCallback, useMemo } from 'react';
 
 import { type GrafanaTheme2, VariableHide } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
-import { config } from '@grafana/runtime';
+import { useFlagDashboardNewLayouts } from '@grafana/runtime/internal';
 import {
   ControlsLabel,
   type ControlsLayout,
@@ -38,7 +38,8 @@ export function VariableControls({
 }) {
   const { variables: dashboardVariables } = sceneGraph.getVariables(dashboard)!.useState();
   const { isEditing } = dashboard.useState();
-  const isEditingNewLayouts = isEditing && config.featureToggles.dashboardNewLayouts;
+  const dashboardNewLayouts = useFlagDashboardNewLayouts();
+  const isEditingNewLayouts = isEditing && dashboardNewLayouts;
   const variables = variablesOverride ?? dashboardVariables;
 
   const visibleVariables = variables.filter(
@@ -57,7 +58,7 @@ export function VariableControls({
             isEditingNewLayouts={isEditingNewLayouts}
           />
         ))}
-      {config.featureToggles.dashboardNewLayouts ? <AddVariableButton dashboard={dashboard} /> : null}
+      {dashboardNewLayouts ? <AddVariableButton dashboard={dashboard} /> : null}
     </>
   );
 }

--- a/public/app/features/dashboard-scene/scene/dashboard-controls-menu/DashboardControlsMenu.tsx
+++ b/public/app/features/dashboard-scene/scene/dashboard-controls-menu/DashboardControlsMenu.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 
 import { type GrafanaTheme2 } from '@grafana/data';
-import { config } from '@grafana/runtime';
+import { useFlagDashboardNewLayouts } from '@grafana/runtime/internal';
 import { type SceneDataLayerProvider, type SceneVariable } from '@grafana/scenes';
 import { type DashboardLink } from '@grafana/schema';
 import { Menu, ScrollContainer, useStyles2 } from '@grafana/ui';
@@ -29,7 +29,8 @@ export function DashboardControlsMenu({
   isEditing,
   dashboard,
 }: DashboardControlsMenuProps) {
-  const isEditingNewLayouts = isEditing && config.featureToggles.dashboardNewLayouts;
+  const dashboardNewLayouts = useFlagDashboardNewLayouts();
+  const isEditingNewLayouts = isEditing && dashboardNewLayouts;
   const fullLinks = dashboard.state.links ?? [];
   const styles = useStyles2(getStyles);
 

--- a/public/app/features/dashboard-scene/scene/dashboard-controls-menu/DashboardControlsMenuButton.test.tsx
+++ b/public/app/features/dashboard-scene/scene/dashboard-controls-menu/DashboardControlsMenuButton.test.tsx
@@ -1,8 +1,11 @@
-import { render, screen } from '@testing-library/react';
+import { OpenFeatureProvider } from '@openfeature/react-sdk';
+import { render as RTLRender, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { type ReactNode } from 'react';
 
 import { VariableHide } from '@grafana/data';
 import { SceneVariableSet, TextBoxVariable, QueryVariable, CustomVariable, type SceneVariable } from '@grafana/scenes';
+import { getTestFeatureFlagClient, setTestFlags } from '@grafana/test-utils/unstable';
 
 import { DashboardScene } from '../DashboardScene';
 
@@ -12,7 +15,15 @@ import {
   DashboardControlsButton,
 } from './DashboardControlsMenuButton';
 
+function render(ui: ReactNode) {
+  return RTLRender(<OpenFeatureProvider client={getTestFeatureFlagClient()}>{ui}</OpenFeatureProvider>);
+}
+
 describe('DashboardControlsMenu', () => {
+  beforeEach(() => {
+    setTestFlags({ dashboardNewLayouts: false });
+  });
+
   it('should return null and not render anything when there are no variables', () => {
     const { container } = render(<DashboardControlsButton dashboard={getDashboard([])} />);
     expect(container.firstChild).toBeNull();

--- a/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager.tsx
@@ -1,6 +1,7 @@
 import { AppEvents } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { config, getAppEvents } from '@grafana/runtime';
+import { getAppEvents } from '@grafana/runtime';
+import { FlagKeys, getFeatureFlagClient } from '@grafana/runtime/internal';
 import {
   type SceneComponentProps,
   type SceneObject,
@@ -156,7 +157,7 @@ export class AutoGridLayoutManager
       return;
     }
 
-    if (config.featureToggles.dashboardNewLayouts) {
+    if (getFeatureFlagClient().getBooleanValue(FlagKeys.DashboardNewLayouts, false)) {
       dashboardEditActions.edit({
         description: t('dashboard.edit-actions.paste-panel', 'Paste panel'),
         addedObject: panel.state.body,

--- a/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItemEditor.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItemEditor.tsx
@@ -2,7 +2,7 @@ import { useCallback } from 'react';
 
 import { type SelectableValue } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
-import { config } from '@grafana/runtime';
+import { FlagKeys, getFeatureFlagClient } from '@grafana/runtime/internal';
 import { sceneGraph, SceneGridLayout } from '@grafana/scenes';
 import { RadioButtonGroup, Select, TextLink } from '@grafana/ui';
 import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
@@ -75,7 +75,7 @@ export function getDashboardGridItemOptions(gridItem: DashboardGridItem): Option
 
   const options = [repeatCategory];
 
-  if (config.featureToggles.dashboardNewLayouts) {
+  if (getFeatureFlagClient().getBooleanValue(FlagKeys.DashboardNewLayouts, false)) {
     options.push(conditionalRenderingCategory);
   }
 

--- a/public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.tsx
@@ -3,7 +3,8 @@ import { css, cx } from '@emotion/css';
 import { AppEvents, type GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
-import { config, getAppEvents } from '@grafana/runtime';
+import { getAppEvents } from '@grafana/runtime';
+import { FlagKeys, getFeatureFlagClient, useFlagDashboardNewLayouts } from '@grafana/runtime/internal';
 import {
   type SceneObjectState,
   SceneGridLayout,
@@ -128,7 +129,7 @@ export class DefaultGridLayoutManager
   }
 
   private _activationHandler() {
-    if (config.featureToggles.dashboardNewLayouts) {
+    if (getFeatureFlagClient().getBooleanValue(FlagKeys.DashboardNewLayouts, false)) {
       this._subs.add(
         this.subscribeToEvent(SceneGridLayoutDragStartEvent, ({ payload: { evt, panel } }) => {
           const gridItem = panel.parent;
@@ -155,7 +156,7 @@ export class DefaultGridLayoutManager
     vizPanel.clearParent();
 
     // With new edit mode we add panels to the bottom of the grid
-    if (config.featureToggles.dashboardNewLayouts) {
+    if (getFeatureFlagClient().getBooleanValue(FlagKeys.DashboardNewLayouts, false)) {
       const emptySpace = findSpaceForNewPanel(this.state.grid);
       const newGridItem = new DashboardGridItem({
         ...emptySpace,
@@ -203,7 +204,7 @@ export class DefaultGridLayoutManager
       return;
     }
 
-    if (config.featureToggles.dashboardNewLayouts) {
+    if (getFeatureFlagClient().getBooleanValue(FlagKeys.DashboardNewLayouts, false)) {
       dashboardEditActions.edit({
         description: t('dashboard.edit-actions.paste-panel', 'Paste panel'),
         addedObject: newGridItem.state.body,
@@ -247,7 +248,7 @@ export class DefaultGridLayoutManager
       return;
     }
 
-    if (!config.featureToggles.dashboardNewLayouts) {
+    if (!getFeatureFlagClient().getBooleanValue(FlagKeys.DashboardNewLayouts, false)) {
       // No undo/redo support in legacy edit mode
       layout.setState({ children: layout.state.children.filter((child) => child !== gridItem) });
       return;
@@ -306,7 +307,7 @@ export class DefaultGridLayoutManager
     });
 
     // No undo/redo support in legacy edit mode
-    if (!config.featureToggles.dashboardNewLayouts) {
+    if (!getFeatureFlagClient().getBooleanValue(FlagKeys.DashboardNewLayouts, false)) {
       if (gridItem.parent instanceof SceneGridRow) {
         const row = gridItem.parent;
 
@@ -433,7 +434,7 @@ export class DefaultGridLayoutManager
       forceRenderChildren(this.state.grid, true);
     };
 
-    if (config.featureToggles.dashboardNewLayouts) {
+    if (getFeatureFlagClient().getBooleanValue(FlagKeys.DashboardNewLayouts, false)) {
       // We do this in a timeout to wait a bit with enabling dragging as dragging enables grid animations
       // if we show the edit pane without animations it opens much faster and feels more responsive
       setTimeout(updateResizeAndDragging, 10);
@@ -664,7 +665,8 @@ function DefaultGridLayoutManagerRenderer({ model }: SceneComponentProps<Default
   const { isEditing } = dashboard.useState();
   const hasClonedParents = isRepeatCloneOrChildOf(model);
   const styles = useStyles2(getStyles);
-  const showCanvasActions = isEditing && config.featureToggles.dashboardNewLayouts && !hasClonedParents;
+  const dashboardNewLayouts = useFlagDashboardNewLayouts();
+  const showCanvasActions = isEditing && dashboardNewLayouts && !hasClonedParents;
   const soloPanelContext = useSoloPanelContext();
 
   if (soloPanelContext) {

--- a/public/app/features/dashboard-scene/scene/layouts-shared/addNew.test.ts
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/addNew.test.ts
@@ -1,5 +1,5 @@
-import { config } from '@grafana/runtime';
 import { VizPanel } from '@grafana/scenes';
+import { setTestFlags } from '@grafana/test-utils/unstable';
 
 import { DashboardScene } from '../DashboardScene';
 import { DefaultGridLayoutManager } from '../layout-default/DefaultGridLayoutManager';
@@ -99,15 +99,12 @@ describe('addNewTabTo', () => {
 });
 
 describe('addNewRowTo', () => {
-  let originalDashboardNewLayouts: boolean | undefined;
-
   beforeAll(() => {
-    originalDashboardNewLayouts = config.featureToggles.dashboardNewLayouts;
-    config.featureToggles.dashboardNewLayouts = true;
+    setTestFlags({ dashboardNewLayouts: true });
   });
 
   afterAll(() => {
-    config.featureToggles.dashboardNewLayouts = originalDashboardNewLayouts;
+    setTestFlags({});
   });
 
   describe('when layout has no rows', () => {

--- a/public/app/features/dashboard-scene/scene/layouts-shared/addNew.ts
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/addNew.ts
@@ -1,4 +1,4 @@
-import { config } from '@grafana/runtime';
+import { FlagKeys, getFeatureFlagClient } from '@grafana/runtime/internal';
 import { type SceneGridRow } from '@grafana/scenes';
 
 import { NewObjectAddedToCanvasEvent } from '../../edit-pane/events';
@@ -36,7 +36,7 @@ export function addNewRowTo(layout: DashboardLayoutManager): RowItem | SceneGrid
   /**
    * If new layouts feature is disabled we add old school rows to the custom grid layout
    */
-  if (!config.featureToggles.dashboardNewLayouts) {
+  if (!getFeatureFlagClient().getBooleanValue(FlagKeys.DashboardNewLayouts, false)) {
     if (layout instanceof DefaultGridLayoutManager) {
       return layout.addNewRow();
     } else {

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.test.ts
@@ -21,6 +21,7 @@ import {
   type RowPanel,
   type VariableType,
 } from '@grafana/schema';
+import { setTestFlags } from '@grafana/test-utils/unstable';
 import { contextSrv } from 'app/core/services/context_srv';
 import { DashboardModel } from 'app/features/dashboard/state/DashboardModel';
 import { PanelModel } from 'app/features/dashboard/state/PanelModel';
@@ -838,10 +839,10 @@ describe('transformSaveModelToScene', () => {
   describe('Convert to new rows', () => {
     beforeEach(() => {
       // set feature flag to true
-      config.featureToggles.dashboardNewLayouts = true;
+      setTestFlags({ dashboardNewLayouts: true });
     });
     afterEach(() => {
-      config.featureToggles.dashboardNewLayouts = false;
+      setTestFlags({ dashboardNewLayouts: false });
     });
 
     it('Should convert legacy rows to new rows', () => {

--- a/public/app/features/dashboard-scene/settings/AnnotationsEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/AnnotationsEditView.tsx
@@ -6,8 +6,8 @@ import {
   PageLayoutType,
 } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
-import { config, getDataSourceSrv, locationService } from '@grafana/runtime';
-import { useFlagGrafanaDashboardSettingsRedesign } from '@grafana/runtime/internal';
+import { getDataSourceSrv, locationService } from '@grafana/runtime';
+import { useFlagDashboardNewLayouts, useFlagGrafanaDashboardSettingsRedesign } from '@grafana/runtime/internal';
 import { type SceneComponentProps, SceneObjectBase, type VizPanel, dataLayers } from '@grafana/scenes';
 import { Alert, Button } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
@@ -153,7 +153,7 @@ function AnnotationsSettingsView({ model }: SceneComponentProps<AnnotationsEditV
 
   const annotations: AnnotationQuery[] = dataLayersToAnnotations(annotationLayers);
 
-  const isDynamicDashboardsEnabled = config.featureToggles.dashboardNewLayouts;
+  const isDynamicDashboardsEnabled = useFlagDashboardNewLayouts();
   const isSettingsPageRedesignEnabled = useFlagGrafanaDashboardSettingsRedesign();
 
   const goToSidebar = () => {

--- a/public/app/features/dashboard-scene/settings/VariablesEditView.test.tsx
+++ b/public/app/features/dashboard-scene/settings/VariablesEditView.test.tsx
@@ -16,7 +16,7 @@ import { getPanelPlugin } from '@grafana/data/test';
 import { setPluginImportUtils, setRunRequest } from '@grafana/runtime';
 import { FlagKeys } from '@grafana/runtime/internal';
 import { SceneVariableSet, CustomVariable, VizPanel, AdHocFiltersVariable, SceneTimeRange } from '@grafana/scenes';
-import { setTestFlags } from '@grafana/test-utils/unstable';
+import { getTestFeatureFlagClient, setTestFlags } from '@grafana/test-utils/unstable';
 import { mockDataSource } from 'app/features/alerting/unified/mocks';
 import { LegacyVariableQueryEditor } from 'app/features/variables/editor/LegacyVariableQueryEditor';
 
@@ -29,7 +29,7 @@ import { VariablesEditView } from './VariablesEditView';
 function render(component: React.ReactNode) {
   return RTLRender(
     <TestProvider>
-      <OpenFeatureProvider>{component}</OpenFeatureProvider>
+      <OpenFeatureProvider client={getTestFeatureFlagClient()}>{component}</OpenFeatureProvider>
     </TestProvider>
   );
 }
@@ -81,7 +81,7 @@ setRunRequest(runRequestMock);
 
 describe('VariablesEditView', () => {
   beforeAll(() => {
-    setTestFlags({ [FlagKeys.GrafanaDashboardSettingsRedesign]: false });
+    setTestFlags({ [FlagKeys.GrafanaDashboardSettingsRedesign]: false, dashboardNewLayouts: false });
   });
   afterAll(() => {
     setTestFlags({});

--- a/public/app/features/dashboard-scene/settings/VariablesEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/VariablesEditView.tsx
@@ -2,8 +2,8 @@ import { useMemo } from 'react';
 
 import { type NavModel, type NavModelItem, PageLayoutType, generateUUID } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
-import { config, locationService } from '@grafana/runtime';
-import { useFlagGrafanaDashboardSettingsRedesign } from '@grafana/runtime/internal';
+import { locationService } from '@grafana/runtime';
+import { useFlagDashboardNewLayouts, useFlagGrafanaDashboardSettingsRedesign } from '@grafana/runtime/internal';
 import {
   type SceneComponentProps,
   SceneObjectBase,
@@ -258,7 +258,7 @@ function VariableEditorSettingsListView({ model }: SceneComponentProps<Variables
   const usages = useMemo(() => model.getUsages(), [model]);
   const saveModel = model.getSaveModel();
 
-  const isDynamicDashboardsEnabled = config.featureToggles.dashboardNewLayouts;
+  const isDynamicDashboardsEnabled = useFlagDashboardNewLayouts();
   const isSettingsPageRedesignEnabled = useFlagGrafanaDashboardSettingsRedesign();
 
   const goToSidebar = () => {

--- a/public/app/features/dashboard-scene/sharing/ShareExportTab.test.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareExportTab.test.tsx
@@ -1,10 +1,10 @@
-import { config } from '@grafana/runtime';
 import { SceneTimeRange } from '@grafana/scenes';
 import {
   type Spec as DashboardV2Spec,
   defaultQueryGroupKind,
   defaultVizConfigSpec,
 } from '@grafana/schema/apis/dashboard.grafana.app/v2';
+import { setTestFlags } from '@grafana/test-utils/unstable';
 import {
   AnnoKeyFolder,
   AnnoKeyFolderTitle,
@@ -154,7 +154,7 @@ describe('ShareExportTab', () => {
   let makeExportableV2Spy: jest.SpyInstance;
 
   beforeEach(() => {
-    config.featureToggles.dashboardNewLayouts = false;
+    setTestFlags({ dashboardNewLayouts: false });
 
     makeExportableV1Spy = jest.spyOn(exporters, 'makeExportableV1').mockImplementation(async (dashboard) => dashboard);
     makeExportableV2Spy = jest.spyOn(exporters, 'makeExportableV2').mockImplementation(async (spec) => spec);
@@ -168,7 +168,7 @@ describe('ShareExportTab', () => {
 
   describe('V2Resource export mode', () => {
     beforeEach(() => {
-      config.featureToggles.dashboardNewLayouts = true;
+      setTestFlags({ dashboardNewLayouts: true });
     });
 
     it('should default to V2Resource when dashboardNewLayouts is enabled', async () => {

--- a/public/app/features/dashboard-scene/sharing/ShareExportTab.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareExportTab.tsx
@@ -5,7 +5,7 @@ import { useAsync } from 'react-use';
 import AutoSizer from 'react-virtualized-auto-sizer';
 
 import { Trans, t } from '@grafana/i18n';
-import { config } from '@grafana/runtime';
+import { FlagKeys, getFeatureFlagClient, useFlagDashboardNewLayouts } from '@grafana/runtime/internal';
 import { type SceneComponentProps, SceneObjectBase } from '@grafana/scenes';
 import { type Dashboard } from '@grafana/schema';
 import { type Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.grafana.app/v2';
@@ -49,7 +49,9 @@ export class ShareExportTab extends SceneObjectBase<ShareExportTabState> impleme
       ...state,
       isSharingExternally: false,
       isViewingJSON: false,
-      exportFormat: config.featureToggles.dashboardNewLayouts ? ExportFormat.V2Resource : ExportFormat.Classic,
+      exportFormat: getFeatureFlagClient().getBooleanValue(FlagKeys.DashboardNewLayouts, false)
+        ? ExportFormat.V2Resource
+        : ExportFormat.Classic,
     });
   }
 
@@ -301,6 +303,7 @@ function stripMetadataForExport(metadata: ObjectMeta, isSharingExternally: boole
 
 function ShareExportTabRenderer({ model }: SceneComponentProps<ShareExportTab>) {
   const { isSharingExternally, isViewingJSON, modalRef, exportFormat, isViewingYAML } = model.useState();
+  const dashboardNewLayouts = useFlagDashboardNewLayouts();
 
   const dashboardJson = useAsync(async () => {
     return model.getExportableDashboardJson();
@@ -324,7 +327,7 @@ function ShareExportTabRenderer({ model }: SceneComponentProps<ShareExportTab>) 
             isSharingExternally={isSharingExternally ?? false}
             exportFormat={
               exportFormat ??
-              (config.featureToggles.dashboardNewLayouts ? ExportFormat.V2Resource : ExportFormat.Classic)
+              (dashboardNewLayouts ? ExportFormat.V2Resource : ExportFormat.Classic)
             }
             isViewingYAML={isViewingYAML ?? false}
             onExportFormatChange={model.onExportFormatChange}

--- a/public/app/features/dashboard-scene/utils/utils.ts
+++ b/public/app/features/dashboard-scene/utils/utils.ts
@@ -278,7 +278,7 @@ export function getClosestVizPanel(sceneObject: SceneObject): VizPanel | null {
 }
 
 export function getDefaultPluginId(): string {
-  return config.featureToggles.dashboardNewLayouts ? UNCONFIGURED_PANEL_PLUGIN_ID : 'timeseries';
+  return getFeatureFlagClient().getBooleanValue(FlagKeys.DashboardNewLayouts, false) ? UNCONFIGURED_PANEL_PLUGIN_ID : 'timeseries';
 }
 
 export function getDefaultVizPanel(): VizPanel {

--- a/public/app/features/dashboard/api/dashboard_api.test.ts
+++ b/public/app/features/dashboard/api/dashboard_api.test.ts
@@ -1,4 +1,5 @@
-import { config, getBackendSrv } from '@grafana/runtime';
+import { getBackendSrv } from '@grafana/runtime';
+import { setTestFlags } from '@grafana/test-utils/unstable';
 
 import { dashboardAPIVersionResolver } from './DashboardAPIVersionResolver';
 import { UnifiedDashboardAPI } from './UnifiedDashboardAPI';
@@ -63,7 +64,7 @@ describe('DashboardApi', () => {
 
   describe('when dashboardNewLayouts enabled', () => {
     beforeEach(() => {
-      config.featureToggles.dashboardNewLayouts = true;
+      setTestFlags({ dashboardNewLayouts: true });
     });
 
     it('should use v2 when v2 is passed in the params', async () => {

--- a/public/app/features/dashboard/api/utils.ts
+++ b/public/app/features/dashboard/api/utils.ts
@@ -1,4 +1,4 @@
-import { config } from '@grafana/runtime';
+import { FlagKeys, getFeatureFlagClient } from '@grafana/runtime/internal';
 import { type Dashboard } from '@grafana/schema';
 import { type Status, type Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.grafana.app/v2';
 import { isRecord } from 'app/core/utils/isRecord';
@@ -26,7 +26,7 @@ export function getDashboardsApiVersion(responseFormat?: 'v1' | 'v2') {
   if (responseFormat === 'v1') {
     return 'v1';
   }
-  if (responseFormat === 'v2' || config.featureToggles.dashboardNewLayouts) {
+  if (responseFormat === 'v2' || getFeatureFlagClient().getBooleanValue(FlagKeys.DashboardNewLayouts, false)) {
     return 'v2';
   }
   return 'unified';

--- a/public/app/features/dashboard/dashgrid/DashboardEmpty/DashboardEmpty.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardEmpty/DashboardEmpty.tsx
@@ -5,6 +5,7 @@ import { type GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
+import { useFlagDashboardNewLayouts } from '@grafana/runtime/internal';
 import { Button, useStyles2, Text, Box, Stack, TextLink, Icon, FilterPill, Tooltip } from '@grafana/ui';
 import { type DashboardModel } from 'app/features/dashboard/state/DashboardModel';
 import { AddNewEditPane } from 'app/features/dashboard-scene/edit-pane/add-new/AddNewEditPane';
@@ -34,12 +35,13 @@ const InternalDashboardEmpty = ({
   onImportDashboard,
 }: InternalProps) => {
   const styles = useStyles2(getStyles);
+  const dashboardNewLayouts = useFlagDashboardNewLayouts();
 
   return (
     <>
       <Stack alignItems="center" justifyContent="center">
         <div className={`${styles.wrapper} ${styles.wrapperMaxWidth}`}>
-          {config.featureToggles.dashboardNewLayouts && dashboard instanceof DashboardScene ? (
+          {dashboardNewLayouts && dashboard instanceof DashboardScene ? (
             <NewLayoutEmpty dashboard={dashboard} styles={styles} />
           ) : (
             <OldLayoutEmpty

--- a/public/app/features/manage-dashboards/import/components/DashboardImportK8s.tsx
+++ b/public/app/features/manage-dashboards/import/components/DashboardImportK8s.tsx
@@ -2,7 +2,8 @@ import { useState, useEffect } from 'react';
 
 import { AppEvents, LoadingState } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { config, getBackendSrv, isFetchError, reportInteraction } from '@grafana/runtime';
+import { getBackendSrv, isFetchError, reportInteraction } from '@grafana/runtime';
+import { FlagKeys, getFeatureFlagClient } from '@grafana/runtime/internal';
 import { Spinner, Stack } from '@grafana/ui';
 import { appEvents } from 'app/core/app_events';
 import { Page } from 'app/core/components/Page/Page';
@@ -102,7 +103,10 @@ export function DashboardImportK8s({ queryParams }: Props) {
 
     const json = JSON.parse(formData.dashboardJson);
 
-    if ((json.spec?.elements || json.elements) && !config.featureToggles.dashboardNewLayouts) {
+    if (
+      (json.spec?.elements || json.elements) &&
+      !getFeatureFlagClient().getBooleanValue(FlagKeys.DashboardNewLayouts, false)
+    ) {
       appEvents.emit(AppEvents.alertError, [
         'Import failed',
         'Dashboard using new layout cannot be imported because the feature is not enabled',

--- a/public/app/features/playlist/StartModal.tsx
+++ b/public/app/features/playlist/StartModal.tsx
@@ -2,7 +2,8 @@ import { useState } from 'react';
 
 import { type SelectableValue, type UrlQueryMap, urlUtil } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { config, locationService, reportInteraction } from '@grafana/runtime';
+import { locationService, reportInteraction } from '@grafana/runtime';
+import { useFlagDashboardNewLayouts } from '@grafana/runtime/internal';
 import { Box, Button, Checkbox, Field, FieldSet, Modal, RadioButtonGroup, Stack } from '@grafana/ui';
 
 import { type Playlist } from '../../api/clients/playlist/v1';
@@ -15,6 +16,7 @@ export interface Props {
 }
 
 export const StartModal = ({ playlist, onDismiss }: Props) => {
+  const dashboardNewLayouts = useFlagDashboardNewLayouts();
   const [mode, setMode] = useState<PlaylistMode>(false);
   const [autoFit, setAutofit] = useState(false);
   const [hideLogo, setHideLogo] = useState(false);
@@ -102,7 +104,7 @@ export const StartModal = ({ playlist, onDismiss }: Props) => {
               />
             </Field>
           )}
-          {config.featureToggles.dashboardNewLayouts && (
+          {dashboardNewLayouts && (
             <Field noMargin>
               <Checkbox
                 label={t('playlist.start-modal.label-playlist-nav', 'Navigation buttons')}


### PR DESCRIPTION
Tested locally with `dashboardNewLayouts` enabled and disabled - they're both picked up