### PR TITLE
Search: Clean up tenant embeddings on hard delete

### DIFF
--- a/pkg/modules/dependencies.go
+++ b/pkg/modules/dependencies.go
@@ -32,9 +32,11 @@ var dependencyMap = map[string][]string{
 	SearchServer:  {UnifiedBackend, UnifiedVectorBackend, InstrumentationServer, GRPCServer, SearchServerRing},
 
 	// UnifiedBackend publishes resource watch notifications through the NATS
-	// publisher, so NATS must be initialized first.
+	// publisher, so NATS must be initialized first. It also depends on
+	// UnifiedVectorBackend so the vector backend is constructed before
+	// the backend's tenant deleter.
 	NATS:           {InstrumentationServer},
-	UnifiedBackend: {NATS},
+	UnifiedBackend: {NATS, UnifiedVectorBackend},
 
 	ZanzanaServer:           {InstrumentationServer},
 	AuthnServer:             {InstrumentationServer},

--- a/pkg/server/module_server.go
+++ b/pkg/server/module_server.go
@@ -360,7 +360,7 @@ func (s *ModuleServer) initUnifiedBackendModule(storageServerEnabled bool) func(
 			if err != nil {
 				return nil, err
 			}
-			opts := []sql.StorageBackendOption{sql.WithEventPublisher(s.natsPublisher)}
+			opts := []sql.StorageBackendOption{sql.WithEventPublisher(s.natsPublisher), sql.WithVectorBackend(s.vectorBackend)}
 			if s.cfg.NATS.Notifier && s.natsSubscriber != nil {
 				opts = append(opts, sql.WithNatsNotifier(natsEventSubscriber{s.natsSubscriber}))
 			} else if s.cfg.NATS.NotifierShadow && s.natsSubscriber != nil {

--- a/pkg/storage/unified/client.go
+++ b/pkg/storage/unified/client.go
@@ -195,7 +195,7 @@ func newClient(opts options.StorageOptions,
 			return nil, err
 		}
 
-		storageOpts := []sql.StorageBackendOption{sql.WithEventPublisher(eventPublisher)}
+		storageOpts := []sql.StorageBackendOption{sql.WithEventPublisher(eventPublisher), sql.WithVectorBackend(vectorBackend)}
 		if cfg.NATS.Notifier && eventSubscriber != nil {
 			storageOpts = append(storageOpts, sql.WithNatsNotifier(natsEventSubscriber{sub: eventSubscriber}))
 		} else if cfg.NATS.NotifierShadow && eventSubscriber != nil {

--- a/pkg/storage/unified/resource/search_vector_test.go
+++ b/pkg/storage/unified/resource/search_vector_test.go
@@ -109,6 +109,9 @@ func (f *fakeVectorBackend) Delete(context.Context, string, string, string, stri
 func (f *fakeVectorBackend) DeleteSubresources(context.Context, string, string, string, string, []string) error {
 	return nil
 }
+func (f *fakeVectorBackend) DeleteNamespace(context.Context, string) (int64, error) {
+	return 0, nil
+}
 func (f *fakeVectorBackend) GetSubresourceContent(context.Context, string, string, string, string) (map[string]string, string, error) {
 	return nil, "", nil
 }

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -244,6 +244,9 @@ type KVBackendOptions struct {
 	// TenantDeleterConfig, if set, enables periodic deletion of expired pending-delete tenant data.
 	TenantDeleterConfig *TenantDeleterConfig
 
+	// EmbeddingDeleter, if set, deletes vector embeddings on tenant deletion.
+	EmbeddingDeleter EmbeddingDeleter
+
 	// SearchLookback is the duration subtracted from sinceRv in calls to ListModifiedSince.
 	// This guards against concurrent writes that commit slightly out-of-order. 0 means no lookback.
 	SearchLookback time.Duration
@@ -388,7 +391,7 @@ func NewKVStorageBackend(opts KVBackendOptions) (KVBackend, error) {
 
 	// Optionally start the tenant deleter.
 	if opts.TenantDeleterConfig != nil {
-		td := NewTenantDeleter(backend.dataStore, pds, *opts.TenantDeleterConfig)
+		td := NewTenantDeleter(backend.dataStore, pds, *opts.TenantDeleterConfig, opts.EmbeddingDeleter)
 		td.Start(ctx)
 		backend.tenantDeleter = td
 	}

--- a/pkg/storage/unified/resource/tenant_deleter.go
+++ b/pkg/storage/unified/resource/tenant_deleter.go
@@ -56,6 +56,11 @@ func NewTenantDeleterConfig(cfg *setting.Cfg) *TenantDeleterConfig {
 	}
 }
 
+// EmbeddingDeleter removes all vector embeddings for a namespace.
+type EmbeddingDeleter interface {
+	DeleteNamespace(ctx context.Context, namespace string) (int64, error)
+}
+
 // TenantDeleter periodically checks the pending-delete store and removes
 // expired tenant data from the data store.
 type TenantDeleter struct {
@@ -64,17 +69,20 @@ type TenantDeleter struct {
 	dataStore          *dataStore
 	cfg                TenantDeleterConfig
 	gcom               gcom.Service
-	stopCh             chan struct{}
+	// embeddingDeleter is nil when the vector backend is disabled.
+	embeddingDeleter EmbeddingDeleter
+	stopCh           chan struct{}
 }
 
 // NewTenantDeleter creates a new TenantDeleter. It does NOT start the background goroutine.
-func NewTenantDeleter(ds *dataStore, pds *PendingDeleteStore, cfg TenantDeleterConfig) *TenantDeleter {
+func NewTenantDeleter(ds *dataStore, pds *PendingDeleteStore, cfg TenantDeleterConfig, embeddingDeleter EmbeddingDeleter) *TenantDeleter {
 	return &TenantDeleter{
 		log:                cfg.Log,
 		pendingDeleteStore: pds,
 		dataStore:          ds,
 		cfg:                cfg,
 		gcom:               cfg.Gcom,
+		embeddingDeleter:   embeddingDeleter,
 		stopCh:             make(chan struct{}),
 	}
 }
@@ -277,6 +285,20 @@ func (td *TenantDeleter) deleteTenant(ctx context.Context, tenantName string, gr
 			"duration_ms", time.Since(grStart).Milliseconds(),
 		)
 		totalKeys += len(keys)
+	}
+
+	// Remove the tenant's embeddings from the (separate) vector store.
+	if td.embeddingDeleter != nil && !td.cfg.DryRun {
+		deleted, err := td.embeddingDeleter.DeleteNamespace(ctx, tenantName)
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, "deleting tenant embeddings failed")
+			return fmt.Errorf("deleting tenant embeddings: %w", err)
+		}
+		span.SetAttributes(attribute.Int64("embeddings_deleted", deleted))
+		td.log.Info("deleted tenant embeddings", "tenant", tenantName, "embeddings_deleted", deleted)
+	} else if td.embeddingDeleter != nil && td.cfg.DryRun {
+		td.log.Info("dry run: would delete tenant embeddings", "tenant", tenantName)
 	}
 
 	span.SetAttributes(

--- a/pkg/storage/unified/resource/tenant_deleter_test.go
+++ b/pkg/storage/unified/resource/tenant_deleter_test.go
@@ -128,6 +128,20 @@ func (f *failOnceBatchDeleteKV) Batch(ctx context.Context, section string, ops [
 	return f.KV.Batch(ctx, section, ops)
 }
 
+// fakeEmbeddingDeleter records DeleteNamespace calls and optionally returns an error.
+type fakeEmbeddingDeleter struct {
+	calls []string
+	err   error
+}
+
+func (f *fakeEmbeddingDeleter) DeleteNamespace(_ context.Context, namespace string) (int64, error) {
+	f.calls = append(f.calls, namespace)
+	if f.err != nil {
+		return 0, f.err
+	}
+	return int64(len(f.calls)), nil
+}
+
 func newTestTenantDeleter(t *testing.T, dryRun bool) (*TenantDeleter, *dataStore, *PendingDeleteStore) {
 	t.Helper()
 	kv := setupBadgerKV(t)
@@ -146,7 +160,7 @@ func newTestTenantDeleter(t *testing.T, dryRun bool) (*TenantDeleter, *dataStore
 			},
 		},
 	}
-	td := NewTenantDeleter(ds, pds, cfg)
+	td := NewTenantDeleter(ds, pds, cfg, &fakeEmbeddingDeleter{})
 	return td, ds, pds
 }
 
@@ -414,7 +428,7 @@ func TestRunDeletionPass_IdempotentAfterPartialFailure(t *testing.T) {
 			},
 		},
 	}
-	td := NewTenantDeleter(ds, pds, cfg)
+	td := NewTenantDeleter(ds, pds, cfg, nil)
 
 	// Create data across two group/resources.
 	saveTestResource(t, ds, testStacksNS1, "apps", "dashboards", "dash1", 100, nil)
@@ -537,6 +551,100 @@ func TestDeleteTenant_MultipleGroupResources(t *testing.T) {
 	assert.NotEmpty(t, record.DeletedAt, "DeletedAt should be set after successful deletion")
 }
 
+// TestDeleteTenant_DeletesEmbeddings verifies deleteTenant wipes the tenant's
+// embeddings via the vector backend on a real (non-dry) run.
+func TestDeleteTenant_DeletesEmbeddings(t *testing.T) {
+	td, ds, pds := newTestTenantDeleter(t, false)
+	fake := td.embeddingDeleter.(*fakeEmbeddingDeleter)
+
+	saveTestResource(t, ds, testStacksNS1, "apps", "dashboards", "dash1", 100, nil)
+	require.NoError(t, pds.Upsert(t.Context(), testStacksNS1, PendingDeleteRecord{DeleteAfter: pastTime()}))
+
+	groupResources, err := ds.getGroupResources(t.Context())
+	require.NoError(t, err)
+
+	require.NoError(t, td.deleteTenant(t.Context(), testStacksNS1, groupResources))
+	assert.Equal(t, []string{testStacksNS1}, fake.calls, "embeddings should be deleted for the tenant namespace")
+}
+
+// TestDeleteTenant_DryRunSkipsEmbeddings verifies dry-run mode does not touch
+// the vector backend.
+func TestDeleteTenant_DryRunSkipsEmbeddings(t *testing.T) {
+	td, ds, pds := newTestTenantDeleter(t, true)
+	fake := td.embeddingDeleter.(*fakeEmbeddingDeleter)
+
+	saveTestResource(t, ds, testStacksNS1, "apps", "dashboards", "dash1", 100, nil)
+	require.NoError(t, pds.Upsert(t.Context(), testStacksNS1, PendingDeleteRecord{DeleteAfter: pastTime()}))
+
+	groupResources, err := ds.getGroupResources(t.Context())
+	require.NoError(t, err)
+
+	require.NoError(t, td.deleteTenant(t.Context(), testStacksNS1, groupResources))
+	assert.Empty(t, fake.calls, "dry run must not delete embeddings")
+}
+
+// TestDeleteTenant_NilEmbeddingDeleter verifies a nil vector backend (disabled)
+// is a no-op and does not break tenant deletion.
+func TestDeleteTenant_NilEmbeddingDeleter(t *testing.T) {
+	kv := setupBadgerKV(t)
+	ds := newDataStore(kv, nil)
+	pds := newPendingDeleteStore(kv)
+	td := NewTenantDeleter(ds, pds, TenantDeleterConfig{
+		DryRun:   false,
+		Interval: time.Hour,
+		Log:      log.NewNopLogger(),
+	}, nil)
+
+	saveTestResource(t, ds, testStacksNS1, "apps", "dashboards", "dash1", 100, nil)
+	require.NoError(t, pds.Upsert(t.Context(), testStacksNS1, PendingDeleteRecord{DeleteAfter: pastTime()}))
+
+	groupResources, err := ds.getGroupResources(t.Context())
+	require.NoError(t, err)
+
+	require.NoError(t, td.deleteTenant(t.Context(), testStacksNS1, groupResources), "nil embedding deleter must be a no-op")
+}
+
+// TestDeleteTenant_EmbeddingErrorRetries verifies a vector-store failure aborts
+// deleteTenant before the pending record is stamped, so the (idempotent) tenant
+// deletion is retried on a later pass instead of leaving embeddings behind.
+func TestDeleteTenant_EmbeddingErrorRetries(t *testing.T) {
+	td, ds, pds := newTestTenantDeleter(t, false)
+	fake := td.embeddingDeleter.(*fakeEmbeddingDeleter)
+	fake.err = fmt.Errorf("vector store down")
+
+	saveTestResource(t, ds, testStacksNS1, "apps", "dashboards", "dash1", 100, nil)
+	require.NoError(t, pds.Upsert(t.Context(), testStacksNS1, PendingDeleteRecord{DeleteAfter: pastTime()}))
+
+	groupResources, err := ds.getGroupResources(t.Context())
+	require.NoError(t, err)
+
+	require.Error(t, td.deleteTenant(t.Context(), testStacksNS1, groupResources), "embedding failure must abort deletion")
+
+	// KV data deletion runs first and is idempotent, so it is already gone.
+	listKey := ListRequestKey{Group: "apps", Resource: "dashboards", Namespace: testStacksNS1}
+	prefix := listKey.Prefix()
+	var count int
+	for _, err := range ds.kv.Keys(t.Context(), dataSection, ListOptions{StartKey: prefix, EndKey: PrefixRangeEnd(prefix)}) {
+		require.NoError(t, err)
+		count++
+	}
+	assert.Equal(t, 0, count, "KV data should still be deleted despite embedding failure")
+
+	// Pending record must remain unstamped so the tenant is retried.
+	record, err := pds.Get(t.Context(), testStacksNS1)
+	require.NoError(t, err)
+	assert.Empty(t, record.DeletedAt, "DeletedAt must not be set when embedding cleanup fails")
+
+	// A retry with a healthy vector store completes the deletion.
+	fake.err = nil
+	require.NoError(t, td.deleteTenant(t.Context(), testStacksNS1, groupResources))
+	assert.Equal(t, []string{testStacksNS1, testStacksNS1}, fake.calls, "embeddings retried on the second pass")
+
+	record, err = pds.Get(t.Context(), testStacksNS1)
+	require.NoError(t, err)
+	assert.NotEmpty(t, record.DeletedAt, "DeletedAt should be set after a successful retry")
+}
+
 // TestRunDeletionPass_DeletesExpiredOrphanedRecord verifies that the deleter
 // removes both tenant data and the pending-delete record for orphaned tenants.
 func TestRunDeletionPass_DeletesExpiredOrphanedRecord(t *testing.T) {
@@ -585,7 +693,7 @@ func TestRunDeletionPass_AllowsWhenGcomReturnsDeletedStatus(t *testing.T) {
 				return gcom.Instance{ID: 1, Slug: "test", Status: "deleted"}, nil
 			},
 		},
-	})
+	}, nil)
 
 	saveTestResource(t, ds, testStacksNS1, "apps", "dashboards", "dash1", 100, nil)
 	require.NoError(t, pds.Upsert(t.Context(), testStacksNS1, PendingDeleteRecord{DeleteAfter: pastTime()}))
@@ -625,7 +733,7 @@ func TestRunDeletionPass_SkipsWhenGcomInstanceStillExists(t *testing.T) {
 				return gcom.Instance{ID: 42, Slug: "active-stack", Status: "active"}, nil
 			},
 		},
-	})
+	}, nil)
 
 	saveTestResource(t, ds, testStacksNS1, "apps", "dashboards", "dash1", 100, nil)
 	require.NoError(t, pds.Upsert(t.Context(), testStacksNS1, PendingDeleteRecord{DeleteAfter: pastTime()}))
@@ -664,7 +772,7 @@ func TestRunDeletionPass_SkipsWhenGcomCheckFails(t *testing.T) {
 				return gcom.Instance{}, fmt.Errorf("injected GCOM transport error")
 			},
 		},
-	})
+	}, nil)
 
 	saveTestResource(t, ds, testStacksNS1, "apps", "dashboards", "dash1", 100, nil)
 	require.NoError(t, pds.Upsert(t.Context(), testStacksNS1, PendingDeleteRecord{DeleteAfter: pastTime()}))
@@ -704,7 +812,7 @@ func TestRunDeletionPass_SkipsWhenNamespaceHasNoStackID(t *testing.T) {
 				return gcom.Instance{}, fmt.Errorf("instance not found")
 			},
 		},
-	})
+	}, nil)
 
 	const orgStyleNS = "org-999"
 	saveTestResource(t, ds, orgStyleNS, "apps", "dashboards", "dash1", 100, nil)

--- a/pkg/storage/unified/search/embed/backfill/fakes_test.go
+++ b/pkg/storage/unified/search/embed/backfill/fakes_test.go
@@ -254,6 +254,9 @@ func (f *fakeVector) DeleteSubresources(_ context.Context, namespace, model, res
 	f.subresourceDeletes = append(f.subresourceDeletes, deleteSubsCall{namespace, model, res, uid, subs})
 	return nil
 }
+func (f *fakeVector) DeleteNamespace(_ context.Context, _ string) (int64, error) {
+	return 0, nil
+}
 func (f *fakeVector) GetSubresourceContent(_ context.Context, _, _, _, uid string) (map[string]string, string, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/pkg/storage/unified/search/embed/reconciler/fakes_test.go
+++ b/pkg/storage/unified/search/embed/reconciler/fakes_test.go
@@ -289,6 +289,9 @@ func (f *fakeVector) DeleteSubresources(_ context.Context, ns, model, res, uid s
 	}
 	return nil
 }
+func (f *fakeVector) DeleteNamespace(_ context.Context, _ string) (int64, error) {
+	return 0, nil
+}
 func (f *fakeVector) GetSubresourceContent(_ context.Context, ns, model, res, uid string) (map[string]string, string, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/pkg/storage/unified/search/vector/data/vector_namespace_delete_embeddings.sql
+++ b/pkg/storage/unified/search/vector/data/vector_namespace_delete_embeddings.sql
@@ -1,0 +1,3 @@
+DELETE FROM embeddings
+    WHERE {{ .Ident "namespace" }} = {{ .Arg .Namespace }}
+;

--- a/pkg/storage/unified/search/vector/data/vector_namespace_delete_promoted.sql
+++ b/pkg/storage/unified/search/vector/data/vector_namespace_delete_promoted.sql
@@ -1,0 +1,3 @@
+DELETE FROM vector_promoted
+    WHERE {{ .Ident "namespace" }} = {{ .Arg .Namespace }}
+;

--- a/pkg/storage/unified/search/vector/data/vector_namespace_delete_query_cache.sql
+++ b/pkg/storage/unified/search/vector/data/vector_namespace_delete_query_cache.sql
@@ -1,0 +1,3 @@
+DELETE FROM query_embedding_cache
+    WHERE {{ .Ident "namespace" }} = {{ .Arg .Namespace }}
+;

--- a/pkg/storage/unified/search/vector/data/vector_namespace_delete_rate_buckets.sql
+++ b/pkg/storage/unified/search/vector/data/vector_namespace_delete_rate_buckets.sql
@@ -1,0 +1,3 @@
+DELETE FROM vector_search_rate_buckets
+    WHERE {{ .Ident "namespace" }} = {{ .Arg .Namespace }}
+;

--- a/pkg/storage/unified/search/vector/integration_test.go
+++ b/pkg/storage/unified/search/vector/integration_test.go
@@ -89,6 +89,10 @@ func cleanIntegrationState(t *testing.T, engine *xorm.Engine) {
 	_, _ = engine.DB().ExecContext(ctx,
 		`DELETE FROM vector_promoted WHERE namespace LIKE 'integration-test%'`)
 	_, _ = engine.DB().ExecContext(ctx,
+		`DELETE FROM query_embedding_cache WHERE namespace LIKE 'integration-test%'`)
+	_, _ = engine.DB().ExecContext(ctx,
+		`DELETE FROM vector_search_rate_buckets WHERE namespace LIKE 'integration-test%'`)
+	_, _ = engine.DB().ExecContext(ctx,
 		`UPDATE vector_latest_rv SET latest_rv = 0 WHERE id = 1`)
 	_, _ = engine.DB().ExecContext(ctx,
 		`DELETE FROM vector_backfill_jobs WHERE model = $1`, testModel)
@@ -187,6 +191,70 @@ func TestIntegrationVectorDeleteSubresources(t *testing.T) {
 
 	err = backend.Delete(ctx, "integration-test", testModel, testResource, "dash")
 	require.NoError(t, err)
+}
+
+// TestIntegrationDeleteNamespace verifies a tenant wipe removes every row for a
+// namespace across embeddings, query cache, rate buckets, and vector_promoted,
+// while leaving other namespaces untouched.
+func TestIntegrationDeleteNamespace(t *testing.T) {
+	backend, engine, ctx := setupIntegrationTest(t)
+
+	const nsA = "integration-test-a"
+	const nsB = "integration-test-b"
+
+	cache := backend.(QueryEmbeddingCache)
+	limiter := backend.(RateLimiter)
+
+	seed := func(ns string) {
+		require.NoError(t, backend.Upsert(ctx, []Vector{
+			{Namespace: ns, Resource: testResource, UID: "dash", Title: "Dash", Subresource: "panel/1",
+				ResourceVersion: 10, Content: "content", Metadata: json.RawMessage(`{}`),
+				Embedding: makeEmbedding(0.5, 0.5), Model: testModel},
+		}))
+		require.NoError(t, cache.Put(ctx, ns, testModel, fmt.Sprintf("%064d", 1), makeEmbedding(0.5, 0.5)))
+		_, _, err := limiter.Allow(ctx, ns, time.Minute, 100)
+		require.NoError(t, err)
+		_, err = engine.DB().ExecContext(ctx,
+			`INSERT INTO vector_promoted (namespace, resource) VALUES ($1, $2)`, ns, testResource)
+		require.NoError(t, err)
+	}
+	seed(nsA)
+	seed(nsB)
+
+	deleted, err := backend.DeleteNamespace(ctx, nsA)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), deleted, "one embedding row removed for nsA")
+
+	// nsA gone from every table.
+	existsA, err := backend.Exists(ctx, nsA, testModel, testResource, "dash")
+	require.NoError(t, err)
+	assert.False(t, existsA, "nsA embeddings should be gone")
+
+	countA, err := cache.Count(ctx, nsA)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), countA, "nsA query cache should be gone")
+
+	assert.Equal(t, 0, rawCount(t, engine, `SELECT count(*) FROM vector_search_rate_buckets WHERE namespace = $1`, nsA))
+	assert.Equal(t, 0, rawCount(t, engine, `SELECT count(*) FROM vector_promoted WHERE namespace = $1`, nsA))
+
+	// nsB untouched.
+	existsB, err := backend.Exists(ctx, nsB, testModel, testResource, "dash")
+	require.NoError(t, err)
+	assert.True(t, existsB, "nsB embeddings should survive")
+
+	countB, err := cache.Count(ctx, nsB)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), countB, "nsB query cache should survive")
+
+	assert.Equal(t, 1, rawCount(t, engine, `SELECT count(*) FROM vector_search_rate_buckets WHERE namespace = $1`, nsB))
+	assert.Equal(t, 1, rawCount(t, engine, `SELECT count(*) FROM vector_promoted WHERE namespace = $1`, nsB))
+}
+
+func rawCount(t *testing.T, engine *xorm.Engine, query string, args ...any) int {
+	t.Helper()
+	var n int
+	require.NoError(t, engine.DB().QueryRowContext(context.Background(), query, args...).Scan(&n))
+	return n
 }
 
 // TestIntegrationVectorUpsertReplaceSubresources pins the atomic

--- a/pkg/storage/unified/search/vector/pgvector.go
+++ b/pkg/storage/unified/search/vector/pgvector.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"text/template"
 	"time"
 	"unicode/utf8"
 
@@ -321,6 +322,58 @@ func (b *pgvectorBackend) DeleteSubresources(ctx context.Context, namespace, mod
 	}
 	_, err := dbutil.Exec(ctx, b.db, sqlVectorCollectionDeleteSubresource, req)
 	return err
+}
+
+func (b *pgvectorBackend) DeleteNamespace(ctx context.Context, namespace string) (deleted int64, retErr error) {
+	if namespace == "" {
+		return 0, fmt.Errorf("namespace must not be empty")
+	}
+
+	ctx, span := tracer.Start(ctx, "unified.vector.pgvector.DeleteNamespace")
+	defer func() {
+		if retErr != nil {
+			span.RecordError(retErr)
+			span.SetStatus(codes.Error, retErr.Error())
+		}
+		span.End()
+	}()
+	span.SetAttributes(attribute.String("namespace", namespace))
+
+	// The four tables are keyed by namespace; wipe them atomically so a tenant
+	// leaves no vector data behind.
+	// ponytail: leaves empty per-tenant partial HNSW indexes
+	// (<resource>_<namespace>_hnsw); near-zero storage with 0 matching rows.
+	// Drop via dynamic catalog SQL in a follow-up if they accumulate.
+	templates := []*template.Template{
+		sqlVectorNamespaceDeleteEmbeddings,
+		sqlVectorNamespaceDeleteQueryCache,
+		sqlVectorNamespaceDeleteRateBuckets,
+		sqlVectorNamespaceDeletePromoted,
+	}
+	err := b.db.WithTx(ctx, nil, func(ctx context.Context, tx db.Tx) error {
+		for i, tmpl := range templates {
+			req := &sqlVectorNamespaceDeleteRequest{
+				SQLTemplate: sqltemplate.New(b.dialect),
+				Namespace:   namespace,
+			}
+			res, err := dbutil.Exec(ctx, tx, tmpl, req)
+			if err != nil {
+				return fmt.Errorf("delete namespace %q (%s): %w", namespace, tmpl.Name(), err)
+			}
+			// Report rows removed from the embeddings table (first template).
+			if i == 0 {
+				if n, err := res.RowsAffected(); err == nil {
+					deleted = n
+				}
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return 0, err
+	}
+	span.SetAttributes(attribute.Int64("embeddings_deleted", deleted))
+	return deleted, nil
 }
 
 func (b *pgvectorBackend) GetSubresourceContent(ctx context.Context, namespace, model, resource, uid string) (map[string]string, string, error) {

--- a/pkg/storage/unified/search/vector/queries.go
+++ b/pkg/storage/unified/search/vector/queries.go
@@ -32,6 +32,10 @@ var (
 	sqlVectorCollectionUpsert            = mustTemplate("vector_collection_upsert.sql")
 	sqlVectorCollectionDelete            = mustTemplate("vector_collection_delete.sql")
 	sqlVectorCollectionDeleteSubresource = mustTemplate("vector_collection_delete_subresources.sql")
+	sqlVectorNamespaceDeleteEmbeddings   = mustTemplate("vector_namespace_delete_embeddings.sql")
+	sqlVectorNamespaceDeleteQueryCache   = mustTemplate("vector_namespace_delete_query_cache.sql")
+	sqlVectorNamespaceDeleteRateBuckets  = mustTemplate("vector_namespace_delete_rate_buckets.sql")
+	sqlVectorNamespaceDeletePromoted     = mustTemplate("vector_namespace_delete_promoted.sql")
 	sqlVectorCollectionGetContent        = mustTemplate("vector_collection_get_content.sql")
 	sqlVectorCollectionExists            = mustTemplate("vector_collection_exists.sql")
 	sqlVectorCollectionSearch            = mustTemplate("vector_collection_search.sql")
@@ -105,6 +109,21 @@ func (r *sqlVectorCollectionDeleteSubresourcesRequest) Validate() error {
 
 func (r *sqlVectorCollectionDeleteSubresourcesRequest) SubresourcesSlice() reflect.Value {
 	return reflect.ValueOf(r.Subresources)
+}
+
+// sqlVectorNamespaceDeleteRequest deletes every row for a namespace across all
+// resources/models. Shared by the four namespace-scoped delete templates
+// (embeddings, query_embedding_cache, vector_search_rate_buckets, vector_promoted).
+type sqlVectorNamespaceDeleteRequest struct {
+	sqltemplate.SQLTemplate
+	Namespace string
+}
+
+func (r *sqlVectorNamespaceDeleteRequest) Validate() error {
+	if r.Namespace == "" {
+		return fmt.Errorf("missing namespace")
+	}
+	return nil
 }
 
 type sqlVectorCollectionExistsResponse struct {

--- a/pkg/storage/unified/search/vector/queries_test.go
+++ b/pkg/storage/unified/search/vector/queries_test.go
@@ -67,6 +67,42 @@ func TestVectorQueries(t *testing.T) {
 					},
 				},
 			},
+			sqlVectorNamespaceDeleteEmbeddings: {
+				{
+					Name: "simple",
+					Data: &sqlVectorNamespaceDeleteRequest{
+						SQLTemplate: mocks.NewTestingSQLTemplate(),
+						Namespace:   "stacks-123",
+					},
+				},
+			},
+			sqlVectorNamespaceDeleteQueryCache: {
+				{
+					Name: "simple",
+					Data: &sqlVectorNamespaceDeleteRequest{
+						SQLTemplate: mocks.NewTestingSQLTemplate(),
+						Namespace:   "stacks-123",
+					},
+				},
+			},
+			sqlVectorNamespaceDeleteRateBuckets: {
+				{
+					Name: "simple",
+					Data: &sqlVectorNamespaceDeleteRequest{
+						SQLTemplate: mocks.NewTestingSQLTemplate(),
+						Namespace:   "stacks-123",
+					},
+				},
+			},
+			sqlVectorNamespaceDeletePromoted: {
+				{
+					Name: "simple",
+					Data: &sqlVectorNamespaceDeleteRequest{
+						SQLTemplate: mocks.NewTestingSQLTemplate(),
+						Namespace:   "stacks-123",
+					},
+				},
+			},
 			sqlVectorCollectionGetContent: {
 				{
 					Name: "simple",

--- a/pkg/storage/unified/search/vector/store.go
+++ b/pkg/storage/unified/search/vector/store.go
@@ -53,6 +53,12 @@ type VectorBackend interface {
 	// slice is a no-op. model must be non-empty.
 	DeleteSubresources(ctx context.Context, namespace, model, resource, uid string, subresources []string) error
 
+	// DeleteNamespace removes every row belonging to a namespace across all
+	// resources and models, plus its cached query embeddings, rate buckets, and
+	// promotion log rows. Used when a tenant is hard-deleted. Returns the number
+	// of embedding rows removed. Not scoped by model/resource/uid, unlike Delete.
+	DeleteNamespace(ctx context.Context, namespace string) (int64, error)
+
 	// GetSubresourceContent returns subresource → stored content and the
 	// resource's stored folder ("" when no rows exist; folder is uniform
 	// across a resource's rows). Callers diff content to skip re-embedding

--- a/pkg/storage/unified/search/vector/testdata/postgres--vector_namespace_delete_embeddings-simple.sql
+++ b/pkg/storage/unified/search/vector/testdata/postgres--vector_namespace_delete_embeddings-simple.sql
@@ -1,0 +1,3 @@
+DELETE FROM embeddings
+    WHERE "namespace" = 'stacks-123'
+;

--- a/pkg/storage/unified/search/vector/testdata/postgres--vector_namespace_delete_promoted-simple.sql
+++ b/pkg/storage/unified/search/vector/testdata/postgres--vector_namespace_delete_promoted-simple.sql
@@ -1,0 +1,3 @@
+DELETE FROM vector_promoted
+    WHERE "namespace" = 'stacks-123'
+;

--- a/pkg/storage/unified/search/vector/testdata/postgres--vector_namespace_delete_query_cache-simple.sql
+++ b/pkg/storage/unified/search/vector/testdata/postgres--vector_namespace_delete_query_cache-simple.sql
@@ -1,0 +1,3 @@
+DELETE FROM query_embedding_cache
+    WHERE "namespace" = 'stacks-123'
+;

--- a/pkg/storage/unified/search/vector/testdata/postgres--vector_namespace_delete_rate_buckets-simple.sql
+++ b/pkg/storage/unified/search/vector/testdata/postgres--vector_namespace_delete_rate_buckets-simple.sql
@@ -1,0 +1,3 @@
+DELETE FROM vector_search_rate_buckets
+    WHERE "namespace" = 'stacks-123'
+;

--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -35,6 +35,7 @@ import (
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/grafana/grafana/pkg/storage/unified/resource/kv"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
+	"github.com/grafana/grafana/pkg/storage/unified/search/vector"
 	"github.com/grafana/grafana/pkg/storage/unified/sql/db"
 	"github.com/grafana/grafana/pkg/storage/unified/sql/db/dbimpl"
 	"github.com/grafana/grafana/pkg/storage/unified/sql/dbutil"
@@ -89,6 +90,18 @@ type StorageBackendOption func(*resource.KVBackendOptions)
 // message bus (NATS) via the given publisher. Applies only to the KV backend.
 func WithEventPublisher(p resource.EventPublisher) StorageBackendOption {
 	return func(o *resource.KVBackendOptions) { o.EventPublisher = p }
+}
+
+// WithVectorBackend lets the KV backend's tenant deleter remove a deleted
+// tenant's embeddings from the vector store. A nil vb (vector backend disabled)
+// leaves embedding cleanup off.
+func WithVectorBackend(vb vector.VectorBackend) StorageBackendOption {
+	return func(o *resource.KVBackendOptions) {
+		if vb == nil {
+			return
+		}
+		o.EmbeddingDeleter = vb
+	}
 }
 
 // WithNatsNotifierShadow runs a NATS-backed notifier in shadow mode beside the


### PR DESCRIPTION
**What is this feature?**

The tenant deleter now also wipes a hard-deleted tenant's embeddings from pgvector (the `embeddings`, `query_embedding_cache`, `vector_search_rate_buckets`, and `vector_promoted` tables) by namespace, via a new `VectorBackend.DeleteNamespace`.

**Why do we need this feature?**

Deleted tenants previously left their embeddings behind in the vector DB — a data-retention gap.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/search-and-storage-team/issues/779

**Special notes for your reviewer:**

Skipped when the vector backend is disabled; honors `dry_run`. On failure it aborts before stamping the pending record, so the (idempotent) deletion retries next pass. Empty per-tenant HNSW indexes are intentionally left (near-zero cost). Covered by unit + pgvector integration tests.