### PR TITLE
Dashboards: Lazy-load scripted dashboards dependencies

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1688,11 +1688,6 @@
       "count": 1
     }
   },
-  "public/app/features/dashboard/services/DashboardLoaderSrv.ts": {
-    "@typescript-eslint/no-explicit-any": {
-      "count": 3
-    }
-  },
   "public/app/features/dashboard/state/DashboardMigrator.test.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 10

--- a/public/app/features/dashboard/services/DashboardLoaderSrv.ts
+++ b/public/app/features/dashboard/services/DashboardLoaderSrv.ts
@@ -1,13 +1,10 @@
-import $ from 'jquery';
-import _, { isFunction } from 'lodash'; // eslint-disable-line lodash/import-scope
-import moment from 'moment'; // eslint-disable-line no-restricted-imports
+import { isFunction } from 'lodash'; // eslint-disable-line lodash/import-scope
 
 import { AppEvents, dateMath, type UrlQueryMap, type UrlQueryValue } from '@grafana/data';
 import { getBackendSrv, isFetchError, locationService } from '@grafana/runtime';
 import { type Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.grafana.app/v2';
 import { backendSrv } from 'app/core/services/backend_srv';
 import impressionSrv from 'app/core/services/impression_srv';
-import kbn from 'app/core/utils/kbn';
 import { getDashboardScenePageStateManager } from 'app/features/dashboard-scene/pages/DashboardScenePageStateManager';
 import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
 import { type DashboardDTO } from 'app/types/dashboard';
@@ -68,7 +65,15 @@ abstract class DashboardLoaderSrvBase<T> implements DashboardLoaderSrvLike<T> {
       );
   }
 
-  private executeScript(result: any) {
+  private async executeScript(result: any) {
+    // Async-load dependencies used only in scripted dashboards to avoid them being in the main bundle, if not needed
+    const [jQuery, moment, lodash, kbn] = await Promise.all([
+      import('jquery'),
+      import('moment'),
+      import('lodash'),
+      import('app/core/utils/kbn'),
+    ]);
+
     const services = {
       dashboardSrv: getDashboardSrv(),
       datasourceSrv: getDatasourceSrv(),
@@ -90,12 +95,12 @@ abstract class DashboardLoaderSrvBase<T> implements DashboardLoaderSrvLike<T> {
       locationService.getSearchObject(),
       kbn,
       dateMath,
-      _,
+      lodash,
       moment,
       window,
       document,
-      $,
-      $,
+      jQuery,
+      jQuery,
       services
     );
 

--- a/public/app/features/dashboard/services/DashboardLoaderSrv.ts
+++ b/public/app/features/dashboard/services/DashboardLoaderSrv.ts
@@ -17,6 +17,8 @@ import { DashboardVersionError, type DashboardWithAccessInfo } from '../api/type
 import { getDashboardSrv } from './DashboardSrv';
 import { getDashboardSnapshotSrv } from './SnapshotSrv';
 
+type ScriptedDashboardExecution = { data: unknown };
+
 interface DashboardLoaderSrvLike<T> {
   loadDashboard(
     type: UrlQueryValue,
@@ -43,7 +45,7 @@ abstract class DashboardLoaderSrvBase<T> implements DashboardLoaderSrvLike<T> {
       .get(url, undefined, undefined, { validatePath: true })
       .then(this.executeScript.bind(this))
       .then(
-        (result: any) => {
+        (result) => {
           return {
             meta: {
               fromScript: true,
@@ -65,9 +67,9 @@ abstract class DashboardLoaderSrvBase<T> implements DashboardLoaderSrvLike<T> {
       );
   }
 
-  private async executeScript(result: any) {
+  private async executeScript(result: string): Promise<ScriptedDashboardExecution> {
     // Async-load dependencies used only in scripted dashboards to avoid them being in the main bundle, if not needed
-    const [jQuery, moment, lodash, kbn] = await Promise.all([
+    const [{ default: jQuery }, { default: moment }, { default: lodash }, { default: kbn }] = await Promise.all([
       import('jquery'),
       import('moment'),
       import('lodash'),
@@ -91,7 +93,7 @@ abstract class DashboardLoaderSrvBase<T> implements DashboardLoaderSrvLike<T> {
       'services',
       result
     );
-    const scriptResult = scriptFunc(
+    const scriptResult: unknown = scriptFunc(
       locationService.getSearchObject(),
       kbn,
       dateMath,
@@ -107,7 +109,7 @@ abstract class DashboardLoaderSrvBase<T> implements DashboardLoaderSrvLike<T> {
     // Handle async dashboard scripts
     if (isFunction(scriptResult)) {
       return new Promise((resolve) => {
-        scriptResult((dashboard: any) => {
+        scriptResult((dashboard: unknown) => {
           resolve({ data: dashboard });
         });
       });

--- a/public/app/features/dashboard/services/DashboardLoaderSrv.ts
+++ b/public/app/features/dashboard/services/DashboardLoaderSrv.ts
@@ -1,5 +1,3 @@
-import { isFunction } from 'lodash'; // eslint-disable-line lodash/import-scope
-
 import { AppEvents, dateMath, type UrlQueryMap, type UrlQueryValue } from '@grafana/data';
 import { getBackendSrv, isFetchError, locationService } from '@grafana/runtime';
 import { type Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.grafana.app/v2';
@@ -107,7 +105,7 @@ abstract class DashboardLoaderSrvBase<T> implements DashboardLoaderSrvLike<T> {
     );
 
     // Handle async dashboard scripts
-    if (isFunction(scriptResult)) {
+    if (typeof scriptResult === 'function') {
       return new Promise((resolve) => {
         scriptResult((dashboard: unknown) => {
           resolve({ data: dashboard });

--- a/public/app/features/dashboard/services/DashboardLoaderSrv.ts
+++ b/public/app/features/dashboard/services/DashboardLoaderSrv.ts
@@ -5,7 +5,7 @@ import { backendSrv } from 'app/core/services/backend_srv';
 import impressionSrv from 'app/core/services/impression_srv';
 import { getDashboardScenePageStateManager } from 'app/features/dashboard-scene/pages/DashboardScenePageStateManager';
 import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
-import { type DashboardDTO } from 'app/types/dashboard';
+import { type DashboardDataDTO, type DashboardDTO } from 'app/types/dashboard';
 
 import { appEvents } from '../../../core/app_events';
 import { ResponseTransformers } from '../api/ResponseTransformers';
@@ -15,7 +15,13 @@ import { DashboardVersionError, type DashboardWithAccessInfo } from '../api/type
 import { getDashboardSrv } from './DashboardSrv';
 import { getDashboardSnapshotSrv } from './SnapshotSrv';
 
-type ScriptedDashboardExecution = { data: unknown };
+type ScriptedDashboardExecution = { data: DashboardDataDTO };
+
+// Scripted dashboards are arbitrary user code, so nothing has validated what they return.
+// Accept any object and let the rest of the loading pipeline deal with the details.
+function isDashboardData(value: unknown): value is DashboardDataDTO {
+  return typeof value === 'object' && value !== null;
+}
 
 interface DashboardLoaderSrvLike<T> {
   loadDashboard(
@@ -36,7 +42,7 @@ abstract class DashboardLoaderSrvBase<T> implements DashboardLoaderSrvLike<T> {
 
   abstract loadSnapshot(slug: string): Promise<T>;
 
-  protected loadScriptedDashboard(file: string) {
+  protected loadScriptedDashboard(file: string): Promise<DashboardDTO> {
     const url = 'public/dashboards/' + file.replace(/\.(?!js)/, '/') + '?' + new Date().getTime();
 
     return getBackendSrv()
@@ -106,11 +112,20 @@ abstract class DashboardLoaderSrvBase<T> implements DashboardLoaderSrvLike<T> {
 
     // Handle async dashboard scripts
     if (typeof scriptResult === 'function') {
-      return new Promise((resolve) => {
+      return new Promise((resolve, reject) => {
         scriptResult((dashboard: unknown) => {
+          if (!isDashboardData(dashboard)) {
+            reject(new Error('Scripted dashboard did not return a dashboard'));
+            return;
+          }
+
           resolve({ data: dashboard });
         });
       });
+    }
+
+    if (!isDashboardData(scriptResult)) {
+      throw new Error('Scripted dashboard did not return a dashboard');
     }
 
     return { data: scriptResult };


### PR DESCRIPTION
This PR moves the dependencies that are loaded for scripted dashboards to async `import()`s to load them lazily. It covers jQuery, moment, lodash’s `_`, and `app/core/utils/kbn`.

By itself doesn’t really achieve much as these dependencies are included higher up in the dependency graph so they’re already in the main chunks. This just prepares for removing some deps (jQuery) from elsewhere.

 - [ ] Tested by loading `/dashboard/script/scripted.js` in the browser and confirming that the global variables are still present. 

Part of #115870