### PR TITLE
fix(frontend): Show plain-text login_error from MT authn-service

### DIFF
--- a/pkg/services/frontend/frontend_service_test.go
+++ b/pkg/services/frontend/frontend_service_test.go
@@ -213,10 +213,10 @@ func TestFrontendService_LoginErrorCookie(t *testing.T) {
 		service.registerRoutes(mux)
 
 		req := httptest.NewRequest("GET", "/", nil)
-		// Set the login_error cookie (with some encrypted-looking value)
+		// Valid hex string simulates the encrypted cookie written by OSS trySetEncryptedCookie.
 		req.AddCookie(&http.Cookie{
 			Name:  "login_error",
-			Value: "abc123encryptedvalue",
+			Value: "deadbeef0123456789abcdef",
 		})
 		recorder := httptest.NewRecorder()
 
@@ -288,7 +288,7 @@ func TestFrontendService_LoginErrorCookie(t *testing.T) {
 		req := httptest.NewRequest("GET", "/", nil)
 		req.AddCookie(&http.Cookie{
 			Name:  "login_error",
-			Value: "abc123encryptedvalue",
+			Value: "deadbeef0123456789abcdef",
 		})
 		recorder := httptest.NewRecorder()
 
@@ -299,6 +299,30 @@ func TestFrontendService_LoginErrorCookie(t *testing.T) {
 
 		// Check that the custom error message is used
 		assert.Contains(t, body, "Oh no a boo-boo happened!", "Should use custom OAuth error message from config")
+	})
+
+	t.Run("should use plain-text cookie value from multi-tenant authn-service", func(t *testing.T) {
+		service := createTestService(t, cfg)
+
+		mux := web.New()
+		service.addMiddlewares(mux)
+		service.registerRoutes(mux)
+
+		req := httptest.NewRequest("GET", "/", nil)
+		// Non-hex value simulates the plain-text cookie written by the authn-service.
+		req.AddCookie(&http.Cookie{
+			Name:  "login_error",
+			Value: "login provider denied login request",
+		})
+		recorder := httptest.NewRecorder()
+
+		mux.ServeHTTP(recorder, req)
+
+		assert.Equal(t, 200, recorder.Code)
+		body := recorder.Body.String()
+
+		assert.Contains(t, body, "login provider denied login request",
+			"Should use the plain-text error from the cookie")
 	})
 }
 

--- a/pkg/services/frontend/index.go
+++ b/pkg/services/frontend/index.go
@@ -2,6 +2,7 @@ package frontend
 
 import (
 	"embed"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"html/template"
@@ -168,14 +169,19 @@ func (p *IndexProvider) HandleRequest(writer http.ResponseWriter, request *http.
 		LegacyAPIMode:                         legacyAPIMode,
 	}
 
-	// TODO -- reevaluate with mt authnz
-	// Check for login_error cookie and set a generic error message.
-	// The backend sets an encrypted cookie on oauth login failures that we can't read
-	// so we just show a generic error if the cookie is present.
+	// Check for login_error cookie. Two writers exist:
+	//  1. OSS HTTPServer writes hex-encoded encrypted values (trySetEncryptedCookie).
+	//  2. The multi-tenant authn-service writes plain-text error messages.
+	// If the value is valid hex, it's the encrypted form and we can't decrypt it here,
+	// so we fall back to the generic OAuthLoginErrorMessage. Otherwise, use the
+	// plain-text value directly.
 	if cookie, err := request.Cookie("login_error"); err == nil && cookie.Value != "" {
 		p.log.Info("request has login_error cookie")
-		// Defaults to a translation key that the frontend will resolve to a localized message
-		data.Settings.LoginError = p.config.OAuthLoginErrorMessage // TODO: get from request config
+		if _, hexErr := hex.DecodeString(cookie.Value); hexErr != nil {
+			data.Settings.LoginError = cookie.Value
+		} else {
+			data.Settings.LoginError = p.config.OAuthLoginErrorMessage
+		}
 
 		cookiePath := "/"
 		if p.config.AppSubURL != "" {


### PR DESCRIPTION
Part of grafana/identity-access-team#1971.

---

## Why
MT authn-service writes plain-text `login_error` cookies. The frontend index path used to treat any present cookie as an encrypted OSS OAuth failure and always showed the generic message, so MT users never saw the real error.

## What
- Valid hex cookie → keep generic `OAuthLoginErrorMessage` (encrypted OSS cookie)
- Non-hex cookie → surface the plain-text value from MT authn-service
- Unit coverage for the MT path; encrypted-looking fixtures updated to real hex

## Test plan
- [x] `go test ./pkg/services/frontend/ -run TestFrontendService_LoginErrorCookie`

Made with [Cursor](https://cursor.com)