### PR TITLE
Timeseries: Block more flaky tests

### DIFF
--- a/public/app/plugins/panel/timeseries/TimeSeriesPanel.annotations.canvas.test.tsx
+++ b/public/app/plugins/panel/timeseries/TimeSeriesPanel.annotations.canvas.test.tsx
@@ -1,5 +1,4 @@
 import {
-  type CanvasCase,
   createAnnotationFrame,
   DAY_MS,
   renderCanvasCase,
@@ -16,8 +15,8 @@ jest.mock('@grafana/ui/src/utils/measureText', () =>
 describe('TimeSeriesPanel (canvas) — Annotations', () => {
   setupCanvasCapture();
 
-  // TODO: point annotation lines are no longer being drawn to the canvas; skipped
-  // to unblock unrelated PRs while the rendering regression is investigated.
+  // TODO: annotation lines flakily fail to render to the canvas under parallel test load; both cases are
+  // skipped to unblock PRs while the rendering regression is investigated by dataviz.
   it.skip('point annotations', () =>
     renderCanvasCase({
       name: 'point annotations',
@@ -28,14 +27,13 @@ describe('TimeSeriesPanel (canvas) — Annotations', () => {
       },
     }));
 
-  it.each<CanvasCase>([
-    {
+  it.skip('region annotations', () =>
+    renderCanvasCase({
       name: 'region annotations',
       data: {
         annotations: [
           createAnnotationFrame({ timeValues: [START_MS + 1.5 * DAY_MS], timeEnd: [START_MS + 2.5 * DAY_MS] }),
         ],
       },
-    },
-  ])('$name', (testCase) => renderCanvasCase(testCase));
+    }));
 });


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Skips flaky timeseries unit test causing failures in Enterprise (Examples: [1](https://github.com/grafana/grafana-enterprise/actions/runs/29945837566/job/89011652804?pr=12751#step:9:331)

**Why do we need this feature?**
To continue merging PRs

**Who is this feature for?**
Devs

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

Following up as an additional patch from [this PR](https://github.com/grafana/grafana/pull/129027)