### PR TITLE
Alerting: Drop @grafana/prometheus runtime import from triage

### DIFF
--- a/public/app/features/alerting/unified/triage/scene/useLabelsBreakdown.ts
+++ b/public/app/features/alerting/unified/triage/scene/useLabelsBreakdown.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 
-import { getPrometheusTime } from '@grafana/prometheus';
+import { type DateTime } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 import { useTimeRange } from '@grafana/scenes-react';
 
@@ -16,6 +16,16 @@ import { isPrometheusDatasource, useQueryFilter } from './utils';
  * has an extremely high cardinality (e.g. 230 MB of JSON ≈ 1.1 M series).
  */
 const MAX_SERIES = 100_000;
+
+/**
+ * Unix timestamp (seconds) for the Prometheus HTTP API.
+ * Inlined equivalent of `getPrometheusTime` from `@grafana/prometheus` for
+ * `DateTime` inputs — a runtime import of that package would pull the whole
+ * query editor into this chunk.
+ */
+function getPrometheusTime(date: DateTime): number {
+  return Math.ceil(date.valueOf() / 1000);
+}
 
 export interface LabelValueCount {
   value: string;
@@ -57,8 +67,8 @@ export function useLabelsBreakdown(): {
       ? `${METRIC_NAME}{alertstate=~"firing|pending",${filter}}`
       : `${METRIC_NAME}{alertstate=~"firing|pending"}`;
 
-    const start = getPrometheusTime(timeRange.from, false).toString();
-    const end = getPrometheusTime(timeRange.to, true).toString();
+    const start = getPrometheusTime(timeRange.from).toString();
+    const end = getPrometheusTime(timeRange.to).toString();
 
     execute(matchSelector, start, end);
   }, [execute, filter, timeRange]);

--- a/public/app/features/alerting/unified/triage/scene/utils.ts
+++ b/public/app/features/alerting/unified/triage/scene/utils.ts
@@ -1,5 +1,5 @@
-import { type TimeRange } from '@grafana/data';
-import { PrometheusDatasource } from '@grafana/prometheus';
+import { DataSourceApi, type TimeRange } from '@grafana/data';
+import { type PrometheusDatasource } from '@grafana/prometheus';
 import {
   AdHocFiltersVariable,
   type SceneDataQuery,
@@ -64,14 +64,22 @@ type AdHocFilterOperator = '=' | '!=' | '=~' | '!~' | '=|' | '!=|';
 
 /**
  * Type guard that narrows an unknown value to `PrometheusDatasource`.
- * The parameter is typed as `unknown` rather than `DataSourceApi` because
- * `PrometheusDatasource` is not structurally assignable to the base class
- * (generic variance in `components`/`annotations` causes a TS2677 error).
- * Using `unknown` is safe here: `instanceof` performs the runtime check and
- * TypeScript narrows the type correctly at every call site.
+ *
+ * Deliberately NOT implemented with `instanceof PrometheusDatasource`:
+ * - a runtime import of `@grafana/prometheus` would pull the entire package
+ *   (query editor, Monaco/PromQL language support) into this chunk, and
+ * - once the prometheus plugin is decoupled and ships its own copy of the
+ *   class, `instanceof` against the core-bundled class would return false.
+ * The structural check below avoids both; only the type is imported.
+ *
+ * The `'prometheus'` literal is intentional too: `DataSourceType.Prometheus`
+ * lives in `utils/datasource.ts`, which transitively imports the alertmanager
+ * RTK Query slice, ability hooks, and alertmanager plugin types — dragging all
+ * of that in here would defeat the purpose. `getDataQuery` above uses the same
+ * literal.
  */
 export function isPrometheusDatasource(ds: unknown): ds is PrometheusDatasource {
-  return ds instanceof PrometheusDatasource;
+  return ds instanceof DataSourceApi && ds.type === 'prometheus';
 }
 
 export function addOrReplaceFilter(


### PR DESCRIPTION
we shouldn't be pulling in the whole prometheus package just for the `instanceof` check.