### PR TITLE
Chore: regenerate enterprise imports for k8s.io/utils/ptr

### DIFF
--- a/pkg/extensions/enterprise_imports.go
+++ b/pkg/extensions/enterprise_imports.go
@@ -802,6 +802,7 @@ import (
 	_ "k8s.io/kube-openapi/pkg/spec3"
 	_ "k8s.io/kube-openapi/pkg/validation/spec"
 	_ "k8s.io/utils/net"
+	_ "k8s.io/utils/ptr"
 	_ "sigs.k8s.io/structured-merge-diff/v6/typed"
 	_ "xorm.io/builder"
 )


### PR DESCRIPTION
## What

Adds `k8s.io/utils/ptr` to the generated enterprise imports manifest.

## Why

The grafana-enterprise reporting app (grafana-enterprise#12719) uses `ptr.To`/`ptr.Deref` in its dual-writer conversion layer. The enterprise imports check requires every package imported by enterprise code to be listed here so the OSS module graph keeps it available.

The matching enterprise branch has the same name, so enterprise CI pins against this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)