### PR TITLE
Auth info: migrate SQL store to templates

### DIFF
--- a/pkg/api/user_test.go
+++ b/pkg/api/user_test.go
@@ -55,6 +55,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/user/userimpl"
 	"github.com/grafana/grafana/pkg/services/user/usertest"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/storage/legacysql"
 	"github.com/grafana/grafana/pkg/util/testutil"
 	"github.com/grafana/grafana/pkg/web/webtest"
 )
@@ -85,7 +86,7 @@ func TestIntegrationUserAPIEndpoint_userLoggedIn(t *testing.T) {
 	loggedInUserScenario(t, "When calling GET on", "api/users/1", "api/users/:id", func(sc *scenarioContext) {
 		fakeNow := time.Date(2019, 2, 11, 17, 30, 40, 0, time.UTC)
 		secretsService := secretsManager.SetupTestService(t, database.ProvideSecretsStore(sqlStore))
-		authInfoStore, err := authinfoimpl.ProvideStore(sqlStore, secretsService)
+		authInfoStore, err := authinfoimpl.ProvideStore(context.Background(), legacysql.NewDatabaseProvider(sqlStore), secretsService)
 		require.NoError(t, err)
 		srv := authinfoimpl.ProvideService(
 			authInfoStore, remotecache.NewFakeCacheStorage(), secretsService)

--- a/pkg/server/bootstrap/wire/wire_gen.go
+++ b/pkg/server/bootstrap/wire/wire_gen.go
@@ -585,7 +585,7 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts server.Options, apiO
 	datasourcePermissionsService := ossaccesscontrol.ProvideDatasourcePermissionsService(cfg, featureToggles, sqlStore)
 	orgRoleMapper := connectors.ProvideOrgRoleMapper(cfg, orgService)
 	socialService := socialimpl.ProvideService(cfg, featureToggles, usageStats, bundleregistryService, remoteCache, orgRoleMapper, ssosettingsimplService)
-	loginStore, err := authinfoimpl.ProvideStore(sqlStore, secretsService)
+	loginStore, err := authinfoimpl.ProvideStore(ctx, legacyDatabaseProvider, secretsService)
 	if err != nil {
 		return nil, err
 	}
@@ -1425,7 +1425,7 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 	}
 	orgRoleMapper := connectors.ProvideOrgRoleMapper(cfg, orgService)
 	socialService := socialimpl.ProvideService(cfg, featureToggles, usageStats, bundleregistryService, remoteCache, orgRoleMapper, ssosettingsimplService)
-	loginStore, err := authinfoimpl.ProvideStore(sqlStore, secretsService)
+	loginStore, err := authinfoimpl.ProvideStore(ctx, legacyDatabaseProvider, secretsService)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/login/authinfoimpl/queries/delete_duplicate_user_auth.sql
+++ b/pkg/services/login/authinfoimpl/queries/delete_duplicate_user_auth.sql
@@ -1,0 +1,5 @@
+DELETE FROM {{ .Ident .UserAuthTable }}
+WHERE user_id = {{ .Arg .UserID }}
+  AND auth_module = {{ .Arg .AuthModule }}
+  AND auth_id = {{ .Arg .AuthID }}
+  AND id != {{ .Arg .ID }}

--- a/pkg/services/login/authinfoimpl/queries/delete_user_auth.sql
+++ b/pkg/services/login/authinfoimpl/queries/delete_user_auth.sql
@@ -1,0 +1,2 @@
+DELETE FROM {{ .Ident .UserAuthTable }}
+WHERE user_id = {{ .Arg .UserID }}

--- a/pkg/services/login/authinfoimpl/queries/lookup_duplicate_user_auth.sql
+++ b/pkg/services/login/authinfoimpl/queries/lookup_duplicate_user_auth.sql
@@ -1,0 +1,5 @@
+SELECT id
+FROM {{ .Ident .UserAuthTable }}
+WHERE user_id = {{ .Arg .UserID }}
+  AND auth_module = {{ .Arg .AuthModule }}
+  AND auth_id = {{ .Arg .AuthID }}

--- a/pkg/services/login/authinfoimpl/queries/user_auth_uid_migration.sql
+++ b/pkg/services/login/authinfoimpl/queries/user_auth_uid_migration.sql
@@ -1,0 +1,21 @@
+{{ if eq .DialectName "sqlite" }}
+UPDATE {{ .Ident .UserAuthTable }}
+SET user_uid = (
+  SELECT uid
+  FROM {{ .Ident .UserTable }}
+  WHERE id = user_id
+)
+WHERE user_id IN (SELECT id FROM {{ .Ident .UserTable }})
+  AND user_uid IS NULL
+{{ else if eq .DialectName "postgres" }}
+UPDATE {{ .Ident .UserAuthTable }} AS ua
+SET user_uid = u.uid
+FROM {{ .Ident .UserTable }} AS u
+WHERE u.id = ua.user_id
+  AND ua.user_uid IS NULL
+{{ else if eq .DialectName "mysql" }}
+UPDATE {{ .Ident .UserAuthTable }} AS ua
+INNER JOIN {{ .Ident .UserTable }} AS u ON ua.user_id = u.id
+SET ua.user_uid = u.uid
+WHERE ua.user_uid IS NULL
+{{ end }}

--- a/pkg/services/login/authinfoimpl/store.go
+++ b/pkg/services/login/authinfoimpl/store.go
@@ -3,34 +3,36 @@ package authinfoimpl
 import (
 	"context"
 	"encoding/base64"
+	"fmt"
 	"time"
 
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/login"
 	"github.com/grafana/grafana/pkg/services/secrets"
-	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
 	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/grafana/grafana/pkg/storage/legacysql"
+	"github.com/grafana/grafana/pkg/storage/unified/sql/sqltemplate"
 )
 
 var GetTime = time.Now
 
 type Store struct {
-	sqlStore       db.DB
+	sql            legacysql.LegacyDatabaseProvider
 	secretsService secrets.Service //nolint:staticcheck // SA1019: Legacy envelope encryption for single-tenant feature
 	logger         log.Logger
 }
 
-func ProvideStore(sqlStore db.DB,
+func ProvideStore(ctx context.Context, sql legacysql.LegacyDatabaseProvider,
 	secretsService secrets.Service, //nolint:staticcheck // SA1019: Legacy envelope encryption for single-tenant feature
 ) (login.Store, error) {
 	store := &Store{
-		sqlStore:       sqlStore,
+		sql:            sql,
 		secretsService: secretsService,
 		logger:         log.New("login.authinfo.store"),
 	}
 
-	if err := store.authInfoUserUIDMigration(); err != nil {
+	if err := store.authInfoUserUIDMigration(ctx); err != nil {
 		return nil, err
 	}
 
@@ -53,8 +55,13 @@ func (s *Store) GetAuthInfo(ctx context.Context, query *login.GetAuthInfoQuery) 
 	var has bool
 	var err error
 
-	err = s.sqlStore.WithDbSession(ctx, func(sess *db.Session) error {
-		has, err = sess.Desc("created").Get(userAuth)
+	dbHelper, err := s.sql(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get legacy DB: %w", err)
+	}
+
+	err = dbHelper.DB.WithDbSession(ctx, func(sess *db.Session) error {
+		has, err = sess.Table(dbHelper.Table("user_auth")).Desc("created").Get(userAuth)
 		return err
 	})
 	if err != nil {
@@ -96,8 +103,13 @@ func (s *Store) GetUsersRecentlyUsedLabel(ctx context.Context, query login.GetUs
 		params = append(params, id)
 	}
 
-	err := s.sqlStore.WithDbSession(ctx, func(sess *db.Session) error {
-		return sess.Table("user_auth").In("user_id", params).OrderBy("created").Find(&userAuths)
+	dbHelper, err := s.sql(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get legacy DB: %w", err)
+	}
+
+	err = dbHelper.DB.WithDbSession(ctx, func(sess *db.Session) error {
+		return sess.Table(dbHelper.Table("user_auth")).In("user_id", params).OrderBy("created").Find(&userAuths)
 	})
 	if err != nil {
 		return nil, err
@@ -117,8 +129,13 @@ func (s *Store) GetUserAuthModules(ctx context.Context, userID int64) ([]string,
 	rows := make([]struct {
 		AuthModule string `xorm:"auth_module"`
 	}, 0)
-	err := s.sqlStore.WithDbSession(ctx, func(sess *db.Session) error {
-		return sess.Table("user_auth").Where("user_id = ?", userID).Desc("created").Cols("auth_module").Find(&rows)
+	dbHelper, err := s.sql(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get legacy DB: %w", err)
+	}
+
+	err = dbHelper.DB.WithDbSession(ctx, func(sess *db.Session) error {
+		return sess.Table(dbHelper.Table("user_auth")).Where("user_id = ?", userID).Desc("created").Cols("auth_module").Find(&rows)
 	})
 	if err != nil {
 		return nil, err
@@ -174,11 +191,37 @@ func (s *Store) SetAuthInfo(ctx context.Context, cmd *login.SetAuthInfoCommand) 
 		authUser.OAuthExpiry = cmd.OAuthToken.Expiry
 	}
 
-	return s.sqlStore.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
-		_, err := sess.Insert(authUser)
+	dbHelper, err := s.sql(ctx)
+	if err != nil {
+		return fmt.Errorf("get legacy DB: %w", err)
+	}
+
+	return dbHelper.DB.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
+		_, err := sess.Table(dbHelper.Table("user_auth")).Insert(authUser)
 		return err
 	})
 }
+
+type lookupDuplicateUserAuthQuery struct {
+	sqltemplate.SQLTemplate
+	UserAuthTable string
+	UserID        int64
+	AuthModule    string
+	AuthID        string
+}
+
+func (q lookupDuplicateUserAuthQuery) Validate() error { return nil }
+
+type deleteDuplicateUserAuthQuery struct {
+	sqltemplate.SQLTemplate
+	UserAuthTable string
+	UserID        int64
+	AuthModule    string
+	AuthID        string
+	ID            int64
+}
+
+func (q deleteDuplicateUserAuthQuery) Validate() error { return nil }
 
 func (s *Store) UpdateAuthInfo(ctx context.Context, cmd *login.UpdateAuthInfoCommand) error {
 	authUser := &login.UserAuth{
@@ -218,8 +261,13 @@ func (s *Store) UpdateAuthInfo(ctx context.Context, cmd *login.UpdateAuthInfoCom
 		authUser.OAuthExpiry = cmd.OAuthToken.Expiry
 	}
 
-	return s.sqlStore.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
-		upd, err := sess.MustCols("o_auth_expiry", "o_auth_access_token", "o_auth_refresh_token", "o_auth_id_token", "o_auth_token_type").
+	dbHelper, err := s.sql(ctx)
+	if err != nil {
+		return fmt.Errorf("get legacy DB: %w", err)
+	}
+
+	return dbHelper.DB.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
+		upd, err := sess.Table(dbHelper.Table("user_auth")).MustCols("o_auth_expiry", "o_auth_access_token", "o_auth_refresh_token", "o_auth_id_token", "o_auth_token_type").
 			Where("user_id = ? AND auth_module = ?", cmd.UserId, cmd.AuthModule).
 			Update(authUser)
 
@@ -228,10 +276,19 @@ func (s *Store) UpdateAuthInfo(ctx context.Context, cmd *login.UpdateAuthInfoCom
 		// Clean up duplicated entries
 		if upd > 1 {
 			var id int64
-			ok, err := sess.SQL(
-				"SELECT id FROM user_auth WHERE user_id = ? AND auth_module = ? AND auth_id = ?",
-				cmd.UserId, cmd.AuthModule, cmd.AuthId,
-			).Get(&id)
+			lookupQuery := lookupDuplicateUserAuthQuery{
+				SQLTemplate:   sqltemplate.New(dbHelper.DialectForDriver()),
+				UserAuthTable: dbHelper.Table("user_auth"),
+				UserID:        cmd.UserId,
+				AuthModule:    cmd.AuthModule,
+				AuthID:        cmd.AuthId,
+			}
+			lookupSQL, err := sqltemplate.Execute(lookupDuplicateUserAuthTemplate, lookupQuery)
+			if err != nil {
+				return err
+			}
+
+			ok, err := sess.SQL(lookupSQL, lookupQuery.GetArgs()...).Get(&id)
 			if err != nil {
 				return err
 			}
@@ -240,10 +297,20 @@ func (s *Store) UpdateAuthInfo(ctx context.Context, cmd *login.UpdateAuthInfoCom
 				return nil
 			}
 
-			_, err = sess.Exec(
-				"DELETE FROM user_auth WHERE user_id = ? AND auth_module = ? AND auth_id = ? AND id != ?",
-				cmd.UserId, cmd.AuthModule, cmd.AuthId, id,
-			)
+			deleteQuery := deleteDuplicateUserAuthQuery{
+				SQLTemplate:   sqltemplate.New(dbHelper.DialectForDriver()),
+				UserAuthTable: dbHelper.Table("user_auth"),
+				UserID:        cmd.UserId,
+				AuthModule:    cmd.AuthModule,
+				AuthID:        cmd.AuthId,
+				ID:            id,
+			}
+			deleteSQL, err := sqltemplate.Execute(deleteDuplicateUserAuthTemplate, deleteQuery)
+			if err != nil {
+				return err
+			}
+
+			_, err = sess.Exec(append([]any{deleteSQL}, deleteQuery.GetArgs()...)...)
 			return err
 		}
 
@@ -251,10 +318,32 @@ func (s *Store) UpdateAuthInfo(ctx context.Context, cmd *login.UpdateAuthInfoCom
 	})
 }
 
+type deleteUserAuthQuery struct {
+	sqltemplate.SQLTemplate
+	UserAuthTable string
+	UserID        int64
+}
+
+func (q deleteUserAuthQuery) Validate() error { return nil }
+
 func (s *Store) DeleteUserAuthInfo(ctx context.Context, userID int64) error {
-	return s.sqlStore.WithDbSession(ctx, func(sess *db.Session) error {
-		rawSQL := "DELETE FROM user_auth WHERE user_id = ?"
-		_, err := sess.Exec(rawSQL, userID)
+	dbHelper, err := s.sql(ctx)
+	if err != nil {
+		return fmt.Errorf("get legacy DB: %w", err)
+	}
+
+	return dbHelper.DB.WithDbSession(ctx, func(sess *db.Session) error {
+		query := deleteUserAuthQuery{
+			SQLTemplate:   sqltemplate.New(dbHelper.DialectForDriver()),
+			UserAuthTable: dbHelper.Table("user_auth"),
+			UserID:        userID,
+		}
+		querySQL, err := sqltemplate.Execute(deleteUserAuthTemplate, query)
+		if err != nil {
+			return err
+		}
+
+		_, err = sess.Exec(append([]any{querySQL}, query.GetArgs()...)...)
 		return err
 	})
 }
@@ -286,23 +375,34 @@ func (s *Store) encryptAndEncode(str string) (string, error) {
 	return base64.StdEncoding.EncodeToString(encrypted), nil
 }
 
+type userAuthUIDMigrationQuery struct {
+	sqltemplate.SQLTemplate
+	UserAuthTable string
+	UserTable     string
+}
+
+func (q userAuthUIDMigrationQuery) Validate() error { return nil }
+
 // authInfoUserUIDMigration ensures that all auth_info user_uids are set.
 // To protect against upgrade / downgrade we need to run this for a couple of releases.
-func (s *Store) authInfoUserUIDMigration() error {
-	return s.sqlStore.WithDbSession(context.Background(), func(sess *db.Session) error {
-		switch s.sqlStore.GetDBType() {
-		case migrator.SQLite:
-			_, err := sess.Exec("UPDATE user_auth SET user_uid = (SELECT uid FROM user WHERE user.id = user_auth.user_id) WHERE user_id IN (SELECT id FROM user) AND user_uid IS NULL;")
-			return err
-		case migrator.Postgres:
-			_, err := sess.Exec("UPDATE user_auth SET user_uid = u.uid FROM \"user\" u WHERE u.id = user_auth.user_id AND user_auth.user_uid IS NULL")
-			return err
-		case migrator.MySQL:
-			_, err := sess.Exec("UPDATE user_auth INNER JOIN user ON user_auth.user_id = user.id SET user_auth.user_uid = user.uid WHERE user_auth.user_uid IS NULL")
-			return err
-		default:
-			// this branch should be unreachable
-			return nil
+func (s *Store) authInfoUserUIDMigration(ctx context.Context) error {
+	dbHelper, err := s.sql(ctx)
+	if err != nil {
+		return fmt.Errorf("get legacy DB: %w", err)
+	}
+
+	return dbHelper.DB.WithDbSession(ctx, func(sess *db.Session) error {
+		query := userAuthUIDMigrationQuery{
+			SQLTemplate:   sqltemplate.New(dbHelper.DialectForDriver()),
+			UserAuthTable: dbHelper.Table("user_auth"),
+			UserTable:     dbHelper.Table("user"),
 		}
+		querySQL, err := sqltemplate.Execute(userAuthUIDMigrationTemplate, query)
+		if err != nil {
+			return err
+		}
+
+		_, err = sess.Exec(append([]any{querySQL}, query.GetArgs()...)...)
+		return err
 	})
 }

--- a/pkg/services/login/authinfoimpl/store_test.go
+++ b/pkg/services/login/authinfoimpl/store_test.go
@@ -2,19 +2,30 @@ package authinfoimpl
 
 import (
 	"context"
+	"regexp"
+	"sync"
 	"testing"
+	"text/template"
 	"time"
 
+	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
 
 	"github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/infra/db/dbtest"
 	"github.com/grafana/grafana/pkg/services/login"
 	secretstest "github.com/grafana/grafana/pkg/services/secrets/fakes"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/grafana/grafana/pkg/storage/legacysql"
+	"github.com/grafana/grafana/pkg/storage/unified/sql/sqltemplate"
+	"github.com/grafana/grafana/pkg/storage/unified/sql/sqltemplate/mocks"
 	"github.com/grafana/grafana/pkg/tests/testsuite"
 	"github.com/grafana/grafana/pkg/util/testutil"
+	"github.com/grafana/grafana/pkg/util/xorm"
+	"github.com/grafana/grafana/pkg/util/xorm/core"
 )
 
 func TestMain(m *testing.M) {
@@ -25,7 +36,7 @@ func TestIntegrationAuthInfoStore(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 
 	sql := db.InitTestDB(t)
-	store, err := ProvideStore(sql, secretstest.NewFakeSecretsService())
+	store, err := ProvideStore(context.Background(), legacysql.NewDatabaseProvider(sql), secretstest.NewFakeSecretsService())
 	require.NoError(t, err)
 
 	t.Run("should be able to auth lables for users", func(t *testing.T) {
@@ -132,6 +143,171 @@ func TestIntegrationAuthInfoStore(t *testing.T) {
 
 		count = countEntries(t, sql, setCmd.AuthModule, setCmd.AuthId, setCmd.UserId)
 		require.Equal(t, 1, count)
+	})
+}
+
+var registerAuthInfoSQLMockXormDriverOnce sync.Once
+
+type authInfoSQLMockXormDriver struct{}
+
+func (authInfoSQLMockXormDriver) Parse(string, string) (*core.Uri, error) {
+	return &core.Uri{DbType: core.SQLITE}, nil
+}
+
+type sqlmockAuthInfoDB struct {
+	dbtest.FakeDB
+	engine *xorm.Engine
+}
+
+func (d *sqlmockAuthInfoDB) WithDbSession(_ context.Context, callback sqlstore.DBTransactionFunc) error {
+	return d.withSession(callback)
+}
+
+func (d *sqlmockAuthInfoDB) WithTransactionalDbSession(_ context.Context, callback sqlstore.DBTransactionFunc) error {
+	return d.withSession(callback)
+}
+
+func (d *sqlmockAuthInfoDB) withSession(callback sqlstore.DBTransactionFunc) error {
+	sess := &sqlstore.DBSession{Session: d.engine.NewSession()}
+	defer sess.Close()
+	return callback(sess)
+}
+
+func (d *sqlmockAuthInfoDB) GetDBType() core.DbType {
+	return core.SQLITE
+}
+
+func TestStoreUsesProviderTables(t *testing.T) {
+	registerAuthInfoSQLMockXormDriverOnce.Do(func() {
+		if core.QueryDriver("sqlmock") == nil {
+			core.RegisterDriver("sqlmock", authInfoSQLMockXormDriver{})
+		}
+	})
+
+	dsn := "authinfo-store"
+	mockDB, mock, err := sqlmock.NewWithDSN(dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = mockDB.Close() })
+
+	engine, err := xorm.NewEngine("sqlmock", dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = engine.Close() })
+
+	legacyDB := &sqlmockAuthInfoDB{engine: engine}
+	type contextKey struct{}
+	ctx := context.WithValue(context.Background(), contextKey{}, "provider context")
+	calls := 0
+	tables := make([]string, 0, 4)
+	provider := func(gotCtx context.Context) (*legacysql.LegacyDatabaseHelper, error) {
+		require.Equal(t, "provider context", gotCtx.Value(contextKey{}))
+		calls++
+		return &legacysql.LegacyDatabaseHelper{
+			DB: legacyDB,
+			Table: func(name string) string {
+				tables = append(tables, name)
+				return "test_schema." + name
+			},
+		}, nil
+	}
+
+	mock.ExpectExec(regexp.QuoteMeta(`UPDATE "test_schema"."user_auth"`)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	store, err := ProvideStore(ctx, provider, secretstest.NewFakeSecretsService())
+	require.NoError(t, err)
+
+	mock.ExpectQuery(regexp.QuoteMeta("FROM `test_schema`.`user_auth`")).
+		WithArgs(int64(42)).
+		WillReturnRows(sqlmock.NewRows([]string{"auth_module"}).AddRow(login.LDAPAuthModule))
+	modules, err := store.GetUserAuthModules(ctx, 42)
+	require.NoError(t, err)
+	require.Equal(t, []string{login.LDAPAuthModule}, modules)
+
+	mock.ExpectExec(regexp.QuoteMeta(`DELETE FROM "test_schema"."user_auth" WHERE user_id = ?`)).
+		WithArgs(int64(42)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	require.NoError(t, store.DeleteUserAuthInfo(ctx, 42))
+
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE `test_schema`.`user_auth`")).
+		WillReturnResult(sqlmock.NewResult(0, 2))
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT id FROM "test_schema"."user_auth"`)).
+		WithArgs(int64(42), login.LDAPAuthModule, "auth-id").
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(8)))
+	mock.ExpectExec(regexp.QuoteMeta(`DELETE FROM "test_schema"."user_auth"`)).
+		WithArgs(int64(42), login.LDAPAuthModule, "auth-id", int64(8)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	require.NoError(t, store.UpdateAuthInfo(ctx, &login.UpdateAuthInfoCommand{
+		UserId:     42,
+		AuthModule: login.LDAPAuthModule,
+		AuthId:     "auth-id",
+	}))
+
+	require.Equal(t, 4, calls)
+	require.Equal(t, []string{"user_auth", "user", "user_auth", "user_auth", "user_auth", "user_auth", "user_auth"}, tables)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestTemplates(t *testing.T) {
+	dbHelper := &legacysql.LegacyDatabaseHelper{
+		Table: func(name string) string {
+			return "test_schema." + name
+		},
+	}
+	userAuthTable := dbHelper.Table("user_auth")
+	userTable := dbHelper.Table("user")
+	queryTemplate := func() sqltemplate.SQLTemplate {
+		return mocks.NewTestingSQLTemplate()
+	}
+
+	mocks.CheckQuerySnapshots(t, mocks.TemplateTestSetup{
+		RootDir:        "testdata",
+		SQLTemplatesFS: sqlTemplatesFS,
+		Templates: map[*template.Template][]mocks.TemplateTestCase{
+			lookupDuplicateUserAuthTemplate: {
+				{
+					Name: "lookup_duplicate",
+					Data: lookupDuplicateUserAuthQuery{
+						SQLTemplate:   queryTemplate(),
+						UserAuthTable: userAuthTable,
+						UserID:        42,
+						AuthModule:    "ldap",
+						AuthID:        "auth-id",
+					},
+				},
+			},
+			deleteDuplicateUserAuthTemplate: {
+				{
+					Name: "delete_duplicate",
+					Data: deleteDuplicateUserAuthQuery{
+						SQLTemplate:   queryTemplate(),
+						UserAuthTable: userAuthTable,
+						UserID:        42,
+						AuthModule:    "ldap",
+						AuthID:        "auth-id",
+						ID:            8,
+					},
+				},
+			},
+			deleteUserAuthTemplate: {
+				{
+					Name: "delete_user_auth",
+					Data: deleteUserAuthQuery{
+						SQLTemplate:   queryTemplate(),
+						UserAuthTable: userAuthTable,
+						UserID:        42,
+					},
+				},
+			},
+			userAuthUIDMigrationTemplate: {
+				{
+					Name: "migrate_user_uid",
+					Data: userAuthUIDMigrationQuery{
+						SQLTemplate:   queryTemplate(),
+						UserAuthTable: userAuthTable,
+						UserTable:     userTable,
+					},
+				},
+			},
+		},
 	})
 }
 

--- a/pkg/services/login/authinfoimpl/templates.go
+++ b/pkg/services/login/authinfoimpl/templates.go
@@ -1,0 +1,26 @@
+package authinfoimpl
+
+import (
+	"embed"
+	"fmt"
+	"text/template"
+)
+
+//go:embed queries/*.sql
+var sqlTemplatesFS embed.FS
+
+var sqlTemplates = template.Must(template.New("sql").ParseFS(sqlTemplatesFS, "queries/*.sql"))
+
+func mustTemplate(filename string) *template.Template {
+	if tmpl := sqlTemplates.Lookup(filename); tmpl != nil {
+		return tmpl
+	}
+	panic(fmt.Sprintf("template file not found: %s", filename))
+}
+
+var (
+	lookupDuplicateUserAuthTemplate = mustTemplate("lookup_duplicate_user_auth.sql")
+	deleteDuplicateUserAuthTemplate = mustTemplate("delete_duplicate_user_auth.sql")
+	deleteUserAuthTemplate          = mustTemplate("delete_user_auth.sql")
+	userAuthUIDMigrationTemplate    = mustTemplate("user_auth_uid_migration.sql")
+)

--- a/pkg/services/login/authinfoimpl/testdata/mysql--delete_duplicate_user_auth-delete_duplicate.sql
+++ b/pkg/services/login/authinfoimpl/testdata/mysql--delete_duplicate_user_auth-delete_duplicate.sql
@@ -1,0 +1,5 @@
+DELETE FROM `test_schema`.`user_auth`
+WHERE user_id = 42
+  AND auth_module = 'ldap'
+  AND auth_id = 'auth-id'
+  AND id != 8

--- a/pkg/services/login/authinfoimpl/testdata/mysql--delete_user_auth-delete_user_auth.sql
+++ b/pkg/services/login/authinfoimpl/testdata/mysql--delete_user_auth-delete_user_auth.sql
@@ -1,0 +1,2 @@
+DELETE FROM `test_schema`.`user_auth`
+WHERE user_id = 42

--- a/pkg/services/login/authinfoimpl/testdata/mysql--lookup_duplicate_user_auth-lookup_duplicate.sql
+++ b/pkg/services/login/authinfoimpl/testdata/mysql--lookup_duplicate_user_auth-lookup_duplicate.sql
@@ -1,0 +1,5 @@
+SELECT id
+FROM `test_schema`.`user_auth`
+WHERE user_id = 42
+  AND auth_module = 'ldap'
+  AND auth_id = 'auth-id'

--- a/pkg/services/login/authinfoimpl/testdata/mysql--user_auth_uid_migration-migrate_user_uid.sql
+++ b/pkg/services/login/authinfoimpl/testdata/mysql--user_auth_uid_migration-migrate_user_uid.sql
@@ -1,0 +1,4 @@
+UPDATE `test_schema`.`user_auth` AS ua
+INNER JOIN `test_schema`.`user` AS u ON ua.user_id = u.id
+SET ua.user_uid = u.uid
+WHERE ua.user_uid IS NULL

--- a/pkg/services/login/authinfoimpl/testdata/postgres--delete_duplicate_user_auth-delete_duplicate.sql
+++ b/pkg/services/login/authinfoimpl/testdata/postgres--delete_duplicate_user_auth-delete_duplicate.sql
@@ -1,0 +1,5 @@
+DELETE FROM "test_schema"."user_auth"
+WHERE user_id = 42
+  AND auth_module = 'ldap'
+  AND auth_id = 'auth-id'
+  AND id != 8

--- a/pkg/services/login/authinfoimpl/testdata/postgres--delete_user_auth-delete_user_auth.sql
+++ b/pkg/services/login/authinfoimpl/testdata/postgres--delete_user_auth-delete_user_auth.sql
@@ -1,0 +1,2 @@
+DELETE FROM "test_schema"."user_auth"
+WHERE user_id = 42

--- a/pkg/services/login/authinfoimpl/testdata/postgres--lookup_duplicate_user_auth-lookup_duplicate.sql
+++ b/pkg/services/login/authinfoimpl/testdata/postgres--lookup_duplicate_user_auth-lookup_duplicate.sql
@@ -1,0 +1,5 @@
+SELECT id
+FROM "test_schema"."user_auth"
+WHERE user_id = 42
+  AND auth_module = 'ldap'
+  AND auth_id = 'auth-id'

--- a/pkg/services/login/authinfoimpl/testdata/postgres--user_auth_uid_migration-migrate_user_uid.sql
+++ b/pkg/services/login/authinfoimpl/testdata/postgres--user_auth_uid_migration-migrate_user_uid.sql
@@ -1,0 +1,5 @@
+UPDATE "test_schema"."user_auth" AS ua
+SET user_uid = u.uid
+FROM "test_schema"."user" AS u
+WHERE u.id = ua.user_id
+  AND ua.user_uid IS NULL

--- a/pkg/services/login/authinfoimpl/testdata/sqlite--delete_duplicate_user_auth-delete_duplicate.sql
+++ b/pkg/services/login/authinfoimpl/testdata/sqlite--delete_duplicate_user_auth-delete_duplicate.sql
@@ -1,0 +1,5 @@
+DELETE FROM "test_schema"."user_auth"
+WHERE user_id = 42
+  AND auth_module = 'ldap'
+  AND auth_id = 'auth-id'
+  AND id != 8

--- a/pkg/services/login/authinfoimpl/testdata/sqlite--delete_user_auth-delete_user_auth.sql
+++ b/pkg/services/login/authinfoimpl/testdata/sqlite--delete_user_auth-delete_user_auth.sql
@@ -1,0 +1,2 @@
+DELETE FROM "test_schema"."user_auth"
+WHERE user_id = 42

--- a/pkg/services/login/authinfoimpl/testdata/sqlite--lookup_duplicate_user_auth-lookup_duplicate.sql
+++ b/pkg/services/login/authinfoimpl/testdata/sqlite--lookup_duplicate_user_auth-lookup_duplicate.sql
@@ -1,0 +1,5 @@
+SELECT id
+FROM "test_schema"."user_auth"
+WHERE user_id = 42
+  AND auth_module = 'ldap'
+  AND auth_id = 'auth-id'

--- a/pkg/services/login/authinfoimpl/testdata/sqlite--user_auth_uid_migration-migrate_user_uid.sql
+++ b/pkg/services/login/authinfoimpl/testdata/sqlite--user_auth_uid_migration-migrate_user_uid.sql
@@ -1,0 +1,8 @@
+UPDATE "test_schema"."user_auth"
+SET user_uid = (
+  SELECT uid
+  FROM "test_schema"."user"
+  WHERE id = user_id
+)
+WHERE user_id IN (SELECT id FROM "test_schema"."user")
+  AND user_uid IS NULL

--- a/pkg/tests/web/index_view_test.go
+++ b/pkg/tests/web/index_view_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/secrets/database"
 	secretsManager "github.com/grafana/grafana/pkg/services/secrets/manager"
 	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/grafana/grafana/pkg/storage/legacysql"
 	"github.com/grafana/grafana/pkg/tests/testinfra"
 	"github.com/grafana/grafana/pkg/tests/testsuite"
 	"github.com/grafana/grafana/pkg/util/testutil"
@@ -171,7 +172,7 @@ func TestIntegrationIndexViewAnalytics(t *testing.T) {
 			})
 
 			secretsService := secretsManager.SetupTestService(t, database.ProvideSecretsStore(store))
-			authInfoStore, err := authinfoimpl.ProvideStore(store, secretsService)
+			authInfoStore, err := authinfoimpl.ProvideStore(context.Background(), legacysql.NewDatabaseProvider(store), secretsService)
 			require.NoError(t, err)
 
 			// insert user_auth relationship


### PR DESCRIPTION
## Summary

Migrates `authinfoimpl` to the legacy SQL provider and template pattern used by other stores.

- `authinfoimpl.ProvideStore` accepts a `LegacyDatabaseProvider` and resolves it with the supplied operation context.
- XORM queries remain XORM queries, with explicit `dbHelper.Table("user_auth")` table selection.
- Raw duplicate-cleanup, deletion, and user-UID compatibility-update SQL now use embedded identifier-safe templates.
- The compatibility update renders dialect-specific SQL for MySQL, PostgreSQL, and SQLite.
- Standard construction sites use `legacysql.NewDatabaseProvider`; Wire output is regenerated.

The session-auth wiring rationale is in the companion Enterprise PR: https://github.com/grafana/grafana-enterprise/pull/12776

## Prior Art

- `pkg/registry/apis/collections/legacy` for resolving a legacy database provider at operation time.
- `pkg/services/authz/rbac/store` for provider-backed query execution.
- `pkg/extensions/apiserver/registry/iam/role/legacy` for embedded SQL templates and dialect snapshots.

## Testing

- `go test ./pkg/services/login/authinfoimpl`
- `go test -short ./pkg/extensions/authn`
- `go test -short -run "^$" ./pkg/api`
- `go test -short -run "^$" ./pkg/extensions/saml`
- `go test -short -run "^$" ./pkg/tests/web`
- `go test -p 1 -tags enterprise ./pkg/server -run "^$"`
- `make gen-go`

The auth-info tests include MySQL, PostgreSQL, and SQLite rendering snapshots plus SQL-mock coverage that verifies context-based provider resolution, table qualification, and statement arguments.