### PR TITLE
Dashboards: Redirect JSON Model settings to sidebar

### DIFF
--- a/public/app/features/dashboard-scene/settings/JsonModelEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/JsonModelEditView.tsx
@@ -3,6 +3,8 @@ import { useCallback, useState } from 'react';
 
 import { type GrafanaTheme2, PageLayoutType } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
+import { config, locationService } from '@grafana/runtime';
+import { useFlagGrafanaDashboardSettingsRedesign } from '@grafana/runtime/internal';
 import { type SceneComponentProps, sceneGraph, SceneObjectBase, SceneObjectRef, sceneUtils } from '@grafana/scenes';
 import { type Dashboard } from '@grafana/schema';
 import { type Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.grafana.app/v2';
@@ -14,6 +16,7 @@ import { getPrettyJSON } from 'app/features/inspector/utils/utils';
 import { useIsProvisionedNG } from 'app/features/provisioning/hooks/useIsProvisionedNG';
 import { type DashboardDataDTO, type SaveDashboardResponseDTO } from 'app/types/dashboard';
 
+import { DashboardCodePane } from '../edit-pane/DashboardCodePane';
 import { SaveDashboardDrawer } from '../saving/SaveDashboardDrawer';
 import {
   NameAlreadyExistsError,
@@ -27,6 +30,7 @@ import { NavToolbarActions } from '../scene/NavToolbarActions';
 import { type DashboardSceneState } from '../scene/types/dashboard';
 import { transformSaveModelSchemaV2ToScene } from '../serialization/transformSaveModelSchemaV2ToScene';
 import { transformSaveModelToScene } from '../serialization/transformSaveModelToScene';
+import { DashboardInteractions } from '../utils/interactions';
 import { getDashboardSceneFor } from '../utils/utils';
 import { DashboardSchemaEditor, type SchemaEditorFormat } from '../v2schema/DashboardSchemaEditor';
 
@@ -140,6 +144,9 @@ function JsonModelEditViewComponent({ model }: SceneComponentProps<JsonModelEdit
   const canSave = dashboard.useState().meta.canSave;
   const { jsonText } = model.useState();
 
+  const isDynamicDashboardsEnabled = config.featureToggles.dashboardNewLayouts;
+  const isSettingsPageRedesignEnabled = useFlagGrafanaDashboardSettingsRedesign();
+
   const handleValidationChange = useCallback((hasErrors: boolean) => {
     setHasValidationErrors(hasErrors);
   }, []);
@@ -150,6 +157,15 @@ function JsonModelEditViewComponent({ model }: SceneComponentProps<JsonModelEdit
     },
     [model]
   );
+
+  const goToSidebar = () => {
+    // close settings and open the "Edit as code" sidebar pane
+    const dashboard = getDashboardSceneFor(model);
+    dashboard.state.editPane.openPane(new DashboardCodePane({}));
+    locationService.partial({ editview: null });
+
+    DashboardInteractions.takeMeToSidebarClicked({ item: 'json-model' });
+  };
 
   const onSave = async (overwrite: boolean) => {
     if (isProvisionedNG) {
@@ -282,6 +298,25 @@ function JsonModelEditViewComponent({ model }: SceneComponentProps<JsonModelEdit
   }
   // For v2 dashboards, disable save if there are validation errors
   const isSaveDisabled = isV2Dashboard && hasValidationErrors;
+
+  if (isDynamicDashboardsEnabled && isSettingsPageRedesignEnabled) {
+    return (
+      <Page navModel={navModel} pageNav={pageNav} layout={PageLayoutType.Standard}>
+        <NavToolbarActions dashboard={dashboard} />
+        <Alert
+          severity="info"
+          title={t('dashboard-scene.dashboard-settings.json.title-moved', 'Looking for the JSON model?')}
+        >
+          <Trans i18nKey="dashboard-scene.dashboard-settings.json.description-moved">
+            The JSON model has moved to the dashboard&apos;s sidebar, under &quot;Edit as code&quot;.
+          </Trans>
+          <Button onClick={goToSidebar} fill="text" variant="primary" size="md">
+            <Trans i18nKey="dashboard-scene.dashboard-settings.json.button-moved">Take me there</Trans>
+          </Button>
+        </Alert>
+      </Page>
+    );
+  }
 
   return (
     <Page navModel={navModel} pageNav={pageNav} layout={PageLayoutType.Standard}>

--- a/public/app/features/dashboard-scene/utils/interactions.ts
+++ b/public/app/features/dashboard-scene/utils/interactions.ts
@@ -357,8 +357,8 @@ export const DashboardInteractions = {
     reportDashboardInteraction('edit_session_started', properties);
   },
 
-  // click "Take me there" button from the dashboard settings for annotations or variables
-  takeMeToSidebarClicked: (properties: { item: 'annotations' | 'variables' }) => {
+  // click "Take me there" button from the dashboard settings for annotations, variables or the JSON model
+  takeMeToSidebarClicked: (properties: { item: 'annotations' | 'variables' | 'json-model' }) => {
     reportDashboardInteraction('take_me_to_sidebar_clicked', properties);
   },
 

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -6944,6 +6944,11 @@
         "description-moved": "Annotation settings have moved to the dashboard's sidebar.",
         "title-moved": "Looking for annotations?"
       },
+      "json": {
+        "button-moved": "Take me there",
+        "description-moved": "The JSON model has moved to the dashboard's sidebar, under \"Edit as code\".",
+        "title-moved": "Looking for the JSON model?"
+      },
       "variables": {
         "button-moved": "Take me there",
         "description-moved": "Variable settings have moved to the dashboard's sidebar.",


### PR DESCRIPTION
Match the "take me there" behavior inside the JSON model settings tab.

<img width="800" height="519" alt="CleanShot 2026-07-22 at 13 51 41" src="https://github.com/user-attachments/assets/a5b0d2ba-f9bd-4a88-a822-b0b9a06d2e01" />




(I noticed this while working on https://github.com/grafana/grafana/pull/128081)