### PR TITLE
IAM: Fix team membership in mode5

### DIFF
--- a/pkg/services/accesscontrol/resourcepermissions/api.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api.go
@@ -91,7 +91,15 @@ func (a *api) getFallbackStatus(ctx context.Context) string {
 // unifiedStorageIsAuthoritative returns true when unified storage is the authoritative
 // backend (Mode4 or Mode5). In that case K8s redirect failures must not fall back to legacy.
 func (a *api) unifiedStorageIsAuthoritative(groupResource string) bool {
-	return a.cfg.UnifiedStorageConfig(groupResource).DualWriterMode > grafanarest.Mode3
+	return unifiedStorageIsAuthoritative(a.cfg, groupResource)
+}
+
+// unifiedStorageIsAuthoritative reports whether unified storage is the authoritative
+// backend for the given group resource (Mode4 or Mode5). When true, K8s redirect
+// failures must not fall back to legacy. It's a package helper so the service methods
+// can apply the same rule without depending on the api layer.
+func unifiedStorageIsAuthoritative(cfg *setting.Cfg, groupResource string) bool {
+	return cfg.UnifiedStorageConfig(groupResource).DualWriterMode > grafanarest.Mode3
 }
 
 func (a *api) registerEndpoints() {

--- a/pkg/services/accesscontrol/resourcepermissions/api.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api.go
@@ -95,20 +95,12 @@ func (a *api) unifiedStorageIsAuthoritative(groupResource string) bool {
 }
 
 // unifiedStorageIsAuthoritative reports whether unified storage is the authoritative
-// backend for the given group resource (Mode4 or Mode5). When true, K8s redirect
-// failures must not fall back to legacy. It's a package helper so the service methods
-// can apply the same rule without depending on the api layer.
+// backend for the given group resource (dualWriterMode > Mode3). When true the legacy
+// tables are not written, so a K8s redirect failure must surface instead of falling back
+// to legacy. It takes cfg explicitly so the service methods can apply the same rule
+// without reaching into the api layer.
 func unifiedStorageIsAuthoritative(cfg *setting.Cfg, groupResource string) bool {
 	return cfg.UnifiedStorageConfig(groupResource).DualWriterMode > grafanarest.Mode3
-}
-
-// teamsRedirectOwnsWrites reports whether the service-level teams membership
-// redirect is the sole writer (redirect enabled and unified storage authoritative).
-// When true the legacy store is never written, so handlers must not count a legacy
-// write in the metrics.
-func (a *api) teamsRedirectOwnsWrites(ctx context.Context) bool {
-	return a.service.teamsMembershipRedirectEnabled(ctx) &&
-		a.unifiedStorageIsAuthoritative(iamv0.TeamResourceInfo.GroupResource().String())
 }
 
 func (a *api) registerEndpoints() {
@@ -436,7 +428,7 @@ func (a *api) setUserPermission(c *contextmodel.ReqContext) response.Response {
 		}
 	}
 
-	if !a.teamsRedirectOwnsWrites(ctx) {
+	if !a.service.teamsRedirectOwnsWrites(ctx) {
 		metrics.MAccessResourcePermissionsBackend.WithLabelValues("legacy", "set_user", a.service.options.Resource, a.getFallbackStatus(ctx)).Inc()
 	}
 	_, err = a.service.SetUserPermission(c.Req.Context(), c.GetOrgID(), accesscontrol.User{ID: userID}, resourceID, cmd.Permission)
@@ -691,7 +683,7 @@ func (a *api) setPermissions(c *contextmodel.ReqContext) response.Response {
 		}
 	}
 
-	if !a.teamsRedirectOwnsWrites(ctx) {
+	if !a.service.teamsRedirectOwnsWrites(ctx) {
 		metrics.MAccessResourcePermissionsBackend.WithLabelValues("legacy", "set_bulk", a.service.options.Resource, a.getFallbackStatus(ctx)).Inc()
 	}
 	_, err := a.service.SetPermissions(c.Req.Context(), c.GetOrgID(), resourceID, cmd.Permissions...)

--- a/pkg/services/accesscontrol/resourcepermissions/api.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api.go
@@ -102,6 +102,15 @@ func unifiedStorageIsAuthoritative(cfg *setting.Cfg, groupResource string) bool 
 	return cfg.UnifiedStorageConfig(groupResource).DualWriterMode > grafanarest.Mode3
 }
 
+// teamsRedirectOwnsWrites reports whether the service-level teams membership
+// redirect is the sole writer (redirect enabled and unified storage authoritative).
+// When true the legacy store is never written, so handlers must not count a legacy
+// write in the metrics.
+func (a *api) teamsRedirectOwnsWrites(ctx context.Context) bool {
+	return a.service.teamsMembershipRedirectEnabled(ctx) &&
+		a.unifiedStorageIsAuthoritative(iamv0.TeamResourceInfo.GroupResource().String())
+}
+
 func (a *api) registerEndpoints() {
 	auth := accesscontrol.Middleware(a.ac)
 	licenseMW := a.service.options.LicenseMW
@@ -404,37 +413,9 @@ func (a *api) setUserPermission(c *contextmodel.ReqContext) response.Response {
 		return response.Error(http.StatusBadRequest, "bad request data", err)
 	}
 
-	// teamsRedirectRemovedMember records that the K8s teams redirect below actually removed an
-	// existing member. In dual-write modes (Mode1-3) legacy is the primary target of that write,
-	// so the legacy fallback further down then finds the row already gone. A no-op redirect (the
-	// member wasn't there) leaves this false, so a genuinely-absent member still returns 404.
-	teamsRedirectRemovedMember := false
-
-	// Teams-specific redirect: write the membership to Team.Spec.Members via the K8s API.
-	if a.service.options.Resource == "teams" && ofClient.Boolean(ctx, featuremgmt.FlagKubernetesTeamsRedirect, false, openfeature.TransactionContext(ctx)) {
-		removed, err := a.setUserPermissionInTeamMembers(c, c.Namespace, resourceID, userID, cmd.Permission)
-		if errors.Is(err, ErrExternalTeamMember) {
-			return response.Err(err)
-		}
-		if err != nil {
-			span.RecordError(err)
-			a.logger.Warn("Failed to set user permission via team members k8s API", "error", err, "resourceID", resourceID)
-		} else {
-			teamsRedirectRemovedMember = removed
-			metrics.MAccessResourcePermissionsBackend.WithLabelValues("k8s", "set_user", a.service.options.Resource, "success").Inc()
-		}
-
-		// In Mode4/5 unified storage is authoritative: return the K8s result and do not fall
-		// back to legacy (which would fail for identities that exist only in unified storage).
-		// In Mode0-3 we dual-write, so continue to the legacy path below.
-		if a.unifiedStorageIsAuthoritative(iamv0.TeamResourceInfo.GroupResource().String()) {
-			if err != nil {
-				metrics.MAccessResourcePermissionsBackend.WithLabelValues("k8s", "set_user", a.service.options.Resource, "error").Inc()
-				return response.Err(err)
-			}
-			return permissionSetResponse(cmd)
-		}
-	}
+	// Teams membership writes are redirected to Team.Spec.Members inside
+	// service.SetUserPermission, so every caller (HTTP and in-process) shares a
+	// single redirect; there is no teams-specific K8s path in this handler.
 
 	if a.service.options.Resource != "teams" && a.shouldUseK8sAPIs(ctx) {
 		err := a.setUserPermissionToK8s(c, c.Namespace, resourceID, userID, cmd.Permission)
@@ -455,14 +436,11 @@ func (a *api) setUserPermission(c *contextmodel.ReqContext) response.Response {
 		}
 	}
 
-	metrics.MAccessResourcePermissionsBackend.WithLabelValues("legacy", "set_user", a.service.options.Resource, a.getFallbackStatus(ctx)).Inc()
+	if !a.teamsRedirectOwnsWrites(ctx) {
+		metrics.MAccessResourcePermissionsBackend.WithLabelValues("legacy", "set_user", a.service.options.Resource, a.getFallbackStatus(ctx)).Inc()
+	}
 	_, err = a.service.SetUserPermission(c.Req.Context(), c.GetOrgID(), accesscontrol.User{ID: userID}, resourceID, cmd.Permission)
 	if err != nil {
-		// The teams redirect above already removed the member (and, in dual-write modes, the
-		// legacy team_member row), so this legacy removal finds nothing.
-		if teamsRedirectRemovedMember && errors.Is(err, team.ErrTeamMemberNotFound) {
-			return permissionSetResponse(cmd)
-		}
 		if errors.Is(err, team.ErrTeamMemberNotFound) {
 			return response.Error(http.StatusNotFound, "Team member not found", nil)
 		}
@@ -713,7 +691,9 @@ func (a *api) setPermissions(c *contextmodel.ReqContext) response.Response {
 		}
 	}
 
-	metrics.MAccessResourcePermissionsBackend.WithLabelValues("legacy", "set_bulk", a.service.options.Resource, a.getFallbackStatus(ctx)).Inc()
+	if !a.teamsRedirectOwnsWrites(ctx) {
+		metrics.MAccessResourcePermissionsBackend.WithLabelValues("legacy", "set_bulk", a.service.options.Resource, a.getFallbackStatus(ctx)).Inc()
+	}
 	_, err := a.service.SetPermissions(c.Req.Context(), c.GetOrgID(), resourceID, cmd.Permissions...)
 	if err != nil {
 		return response.Err(err)

--- a/pkg/services/accesscontrol/resourcepermissions/api.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api.go
@@ -664,7 +664,7 @@ func (a *api) setPermissions(c *contextmodel.ReqContext) response.Response {
 		return response.Error(http.StatusBadRequest, "Bad request data: "+err.Error(), err)
 	}
 
-	if a.shouldUseK8sAPIs(ctx) {
+	if a.service.options.Resource != "teams" && a.shouldUseK8sAPIs(ctx) {
 		err := a.setResourcePermissionsToK8s(c, c.Namespace, resourceID, cmd.Permissions)
 		if err != nil {
 			span.RecordError(err)

--- a/pkg/services/accesscontrol/resourcepermissions/api_adapter.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api_adapter.go
@@ -26,6 +26,7 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/apiserver"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/team"
@@ -38,11 +39,19 @@ var ErrRestConfigNotAvailable = errors.New("k8s rest config provider not availab
 const subjectKindUser = "User"
 
 func (a *api) getDynamicClient(c *contextmodel.ReqContext) (dynamic.Interface, error) {
-	if a.restConfigProvider == nil {
+	return newDynamicClient(a.restConfigProvider, c)
+}
+
+// newDynamicClient builds a K8s dynamic client from the direct (loopback) rest
+// config. It's a package helper rather than a method so both the HTTP handlers
+// (via api.getDynamicClient) and the service methods invoked by direct in-process
+// callers can reach the K8s APIs without one layer reaching into the other.
+func newDynamicClient(restConfigProvider apiserver.DirectRestConfigProvider, c *contextmodel.ReqContext) (dynamic.Interface, error) {
+	if restConfigProvider == nil {
 		return nil, ErrRestConfigNotAvailable
 	}
 
-	dynamicClient, err := dynamic.NewForConfig(a.restConfigProvider.GetDirectRestConfig(c))
+	dynamicClient, err := dynamic.NewForConfig(restConfigProvider.GetDirectRestConfig(c))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create dynamic client: %w", err)
 	}
@@ -744,14 +753,15 @@ func (a *api) setUserPermissionInTeamMembers(c *contextmodel.ReqContext, namespa
 	if err != nil {
 		return false, err
 	}
-	return a.setTeamMember(c, dynamicClient, namespace, resourceID, userID, permission)
+	return a.service.setTeamMember(c.Req.Context(), dynamicClient, c.GetOrgID(), namespace, resourceID, userID, permission)
 }
 
-// setTeamMember writes the membership change; the bool reports if an existing member was removed.
-func (a *api) setTeamMember(c *contextmodel.ReqContext, dynamicClient dynamic.Interface, namespace string, resourceID string, userID int64, permission string) (bool, error) {
-	ctx := c.Req.Context()
-
-	userDetails, err := a.service.userService.GetByID(ctx, &user.GetUserByIDQuery{ID: userID})
+// setTeamMember reconciles a single team membership in Team.Spec.Members via the
+// K8s API. It's a service method (not an api method) so both the HTTP handlers and
+// direct in-process callers share one implementation; the deps it needs (team/user
+// services) live on the service. The bool reports whether an existing member was removed.
+func (s *Service) setTeamMember(ctx context.Context, dynamicClient dynamic.Interface, orgID int64, namespace string, resourceID string, userID int64, permission string) (bool, error) {
+	userDetails, err := s.userService.GetByID(ctx, &user.GetUserByIDQuery{ID: userID})
 	if err != nil {
 		return false, fmt.Errorf("failed to get user details: %w", err)
 	}
@@ -761,8 +771,8 @@ func (a *api) setTeamMember(c *contextmodel.ReqContext, dynamicClient dynamic.In
 		return false, fmt.Errorf("invalid team resource ID: %w", err)
 	}
 
-	teamDetails, err := a.service.teamService.GetTeamByID(ctx, &team.GetTeamByIDQuery{
-		OrgID: c.GetOrgID(),
+	teamDetails, err := s.teamService.GetTeamByID(ctx, &team.GetTeamByIDQuery{
+		OrgID: orgID,
 		ID:    teamID,
 	})
 	if err != nil {

--- a/pkg/services/accesscontrol/resourcepermissions/api_adapter.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api_adapter.go
@@ -757,15 +757,24 @@ func (a *api) setUserPermissionInTeamMembers(c *contextmodel.ReqContext, namespa
 }
 
 // setTeamMember reconciles a single team membership in Team.Spec.Members via the
-// K8s API. It's a service method (not an api method) so both the HTTP handlers and
-// direct in-process callers share one implementation; the deps it needs (team/user
-// services) live on the service. The bool reports whether an existing member was removed.
+// K8s API. It's a thin wrapper over setTeamMembers so the single-member HTTP
+// handler path and the batch path share one read-modify-write implementation. The
+// bool reports whether an existing member was removed.
 func (s *Service) setTeamMember(ctx context.Context, dynamicClient dynamic.Interface, orgID int64, namespace string, resourceID string, userID int64, permission string) (bool, error) {
-	userDetails, err := s.userService.GetByID(ctx, &user.GetUserByIDQuery{ID: userID})
-	if err != nil {
-		return false, fmt.Errorf("failed to get user details: %w", err)
-	}
+	return s.setTeamMembers(ctx, dynamicClient, orgID, namespace, resourceID, []accesscontrol.SetResourcePermissionCommand{
+		{UserID: userID, Permission: permission},
+	})
+}
 
+// setTeamMembers reconciles a batch of user membership changes in Team.Spec.Members
+// via the K8s API in a single read-modify-write, so the whole batch commits or fails
+// atomically. It's a service method (not an api method) so both the HTTP handlers and
+// direct in-process callers share one implementation; the deps it needs (team/user
+// services) live on the service. Only user commands are applied; non-user commands
+// are ignored. External members are owned by team-sync, so any command targeting one
+// aborts the batch with ErrExternalTeamMember without persisting a partial update.
+// The bool reports whether any existing member was removed.
+func (s *Service) setTeamMembers(ctx context.Context, dynamicClient dynamic.Interface, orgID int64, namespace string, resourceID string, commands []accesscontrol.SetResourcePermissionCommand) (bool, error) {
 	teamID, err := strconv.ParseInt(resourceID, 10, 64)
 	if err != nil {
 		return false, fmt.Errorf("invalid team resource ID: %w", err)
@@ -779,26 +788,50 @@ func (s *Service) setTeamMember(ctx context.Context, dynamicClient dynamic.Inter
 		return false, fmt.Errorf("failed to get team details: %w", err)
 	}
 
-	var memberPerm iamv0.TeamTeamPermission
-	if permission != "" {
-		mp, err := stringToTeamMemberPermission(permission)
-		if err != nil {
-			return false, err
-		}
-		memberPerm = mp
+	// Resolve each user command to its target member state once; neither the UID
+	// nor the permission changes across read-modify-write retries.
+	type memberChange struct {
+		uid        string
+		permission iamv0.TeamTeamPermission
+		remove     bool
 	}
+	changes := make([]memberChange, 0, len(commands))
+	for _, cmd := range commands {
+		if cmd.UserID == 0 {
+			continue
+		}
+		userDetails, err := s.userService.GetByID(ctx, &user.GetUserByIDQuery{ID: cmd.UserID})
+		if err != nil {
+			return false, fmt.Errorf("failed to get user details: %w", err)
+		}
+		mc := memberChange{uid: userDetails.UID, remove: cmd.Permission == ""}
+		if !mc.remove {
+			mp, err := stringToTeamMemberPermission(cmd.Permission)
+			if err != nil {
+				return false, err
+			}
+			mc.permission = mp
+		}
+		changes = append(changes, mc)
+	}
+
+	if len(changes) == 0 {
+		return false, nil
+	}
+
+	hasAdds := slices.ContainsFunc(changes, func(mc memberChange) bool { return !mc.remove })
 
 	teamResource := dynamicClient.Resource(iamv0.TeamResourceInfo.GroupVersionResource()).Namespace(namespace)
 
-	var removed bool
+	var removedAny bool
 	// Read-modify-write: spec.members is a slice on the Team object so a
 	// concurrent writer can lose updates if we don't refetch on conflict.
 	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		removed = false
+		removedAny = false
 		teamObj, err := teamResource.Get(ctx, teamDetails.UID, metav1.GetOptions{})
 		if err != nil {
-			// Removing a member from a team that no longer exists is a no-op.
-			if k8serrors.IsNotFound(err) && permission == "" {
+			// Removing members from a team that no longer exists is a no-op.
+			if k8serrors.IsNotFound(err) && !hasAdds {
 				return nil
 			}
 			return fmt.Errorf("failed to get team: %w", err)
@@ -809,36 +842,43 @@ func (s *Service) setTeamMember(ctx context.Context, dynamicClient dynamic.Inter
 			return fmt.Errorf("failed to decode team: %w", err)
 		}
 
-		idx := slices.IndexFunc(t.Spec.Members, func(m iamv0.TeamTeamMember) bool {
-			return m.Kind == subjectKindUser && m.Name == userDetails.UID
-		})
+		changed := false
+		for _, mc := range changes {
+			idx := slices.IndexFunc(t.Spec.Members, func(m iamv0.TeamTeamMember) bool {
+				return m.Kind == subjectKindUser && m.Name == mc.uid
+			})
 
-		// External members are owned by team-sync and must not be mutated through
-		// this path. Returning an error (rather than a silent no-op) prevents the
-		// dual-write caller from proceeding with the legacy SQL write, which would
-		// otherwise cause k8s and SQL to diverge until the next reconciliation.
-		if idx >= 0 && t.Spec.Members[idx].External {
-			return ErrExternalTeamMember.Errorf("user %q is externally-synced", userDetails.UID)
+			// External members are owned by team-sync and must not be mutated. Abort
+			// the whole batch (before any Update) rather than partially applying it.
+			if idx >= 0 && t.Spec.Members[idx].External {
+				return ErrExternalTeamMember.Errorf("user %q is externally-synced", mc.uid)
+			}
+
+			switch {
+			case mc.remove && idx < 0:
+				// Nothing to remove.
+			case mc.remove:
+				t.Spec.Members = slices.Delete(t.Spec.Members, idx, idx+1)
+				removedAny = true
+				changed = true
+			case idx >= 0:
+				if t.Spec.Members[idx].Permission != mc.permission {
+					t.Spec.Members[idx].Permission = mc.permission
+					changed = true
+				}
+			default:
+				t.Spec.Members = append(t.Spec.Members, iamv0.TeamTeamMember{
+					Kind:       subjectKindUser,
+					Name:       mc.uid,
+					Permission: mc.permission,
+					External:   false,
+				})
+				changed = true
+			}
 		}
 
-		switch {
-		case permission == "" && idx < 0:
+		if !changed {
 			return nil
-		case permission == "":
-			t.Spec.Members = slices.Delete(t.Spec.Members, idx, idx+1)
-			removed = true
-		case idx >= 0:
-			if t.Spec.Members[idx].Permission == memberPerm {
-				return nil
-			}
-			t.Spec.Members[idx].Permission = memberPerm
-		default:
-			t.Spec.Members = append(t.Spec.Members, iamv0.TeamTeamMember{
-				Kind:       subjectKindUser,
-				Name:       userDetails.UID,
-				Permission: memberPerm,
-				External:   false,
-			})
 		}
 
 		updatedObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&t)
@@ -851,7 +891,7 @@ func (s *Service) setTeamMember(ctx context.Context, dynamicClient dynamic.Inter
 		}
 		return nil
 	})
-	return removed, err
+	return removedAny, err
 }
 
 // teamMemberPermissionToString returns the lowercase schema value ("admin",

--- a/pkg/services/accesscontrol/resourcepermissions/api_adapter.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api_adapter.go
@@ -749,24 +749,25 @@ func (a *api) listTeamMemberPermissions(c *contextmodel.ReqContext, dynamicClien
 }
 
 // setTeamMember reconciles a single team membership in Team.Spec.Members via the
-// K8s API. It's a thin wrapper over setTeamMembers so the single-member HTTP
-// handler path and the batch path share one read-modify-write implementation. The
-// bool reports whether an existing member was removed.
-func (s *Service) setTeamMember(ctx context.Context, dynamicClient dynamic.Interface, orgID int64, namespace string, resourceID string, userID int64, permission string) (bool, error) {
+// K8s API. It's a thin wrapper over setTeamMembers so the single-member path and the
+// batch path share one read-modify-write implementation. The bool reports whether an
+// existing member was removed.
+func (s *Service) setTeamMember(ctx context.Context, dynamicClient dynamic.Interface, orgID int64, namespace string, resourceID string, userID int64, permission string, external bool) (bool, error) {
 	return s.setTeamMembers(ctx, dynamicClient, orgID, namespace, resourceID, []accesscontrol.SetResourcePermissionCommand{
 		{UserID: userID, Permission: permission},
-	})
+	}, external)
 }
 
 // setTeamMembers reconciles a batch of user membership changes in Team.Spec.Members
 // via the K8s API in a single read-modify-write, so the whole batch commits or fails
-// atomically. It's a service method (not an api method) so both the HTTP handlers and
-// direct in-process callers share one implementation; the deps it needs (team/user
-// services) live on the service. Only user commands are applied; non-user commands
-// are ignored. External members are owned by team-sync, so any command targeting one
-// aborts the batch with ErrExternalTeamMember without persisting a partial update.
-// The bool reports whether any existing member was removed.
-func (s *Service) setTeamMembers(ctx context.Context, dynamicClient dynamic.Interface, orgID int64, namespace string, resourceID string, commands []accesscontrol.SetResourcePermissionCommand) (bool, error) {
+// atomically. It's a service method (not an api method) because every caller now
+// reaches it through the service rather than the handler, and the deps it needs
+// (team/user services) live there. Only user commands are applied; non-user commands are
+// ignored. External members are owned by team-sync, so external marks the caller as
+// team-sync: every other caller aborts the batch with ErrExternalTeamMember, without
+// persisting a partial update, as soon as a command targets one. The bool reports
+// whether any existing member was removed.
+func (s *Service) setTeamMembers(ctx context.Context, dynamicClient dynamic.Interface, orgID int64, namespace string, resourceID string, commands []accesscontrol.SetResourcePermissionCommand, external bool) (bool, error) {
 	teamID, err := strconv.ParseInt(resourceID, 10, 64)
 	if err != nil {
 		return false, fmt.Errorf("invalid team resource ID: %w", err)
@@ -840,9 +841,10 @@ func (s *Service) setTeamMembers(ctx context.Context, dynamicClient dynamic.Inte
 				return m.Kind == subjectKindUser && m.Name == mc.uid
 			})
 
-			// External members are owned by team-sync and must not be mutated. Abort
-			// the whole batch (before any Update) rather than partially applying it.
-			if idx >= 0 && t.Spec.Members[idx].External {
+			// External members are owned by team-sync, so only team-sync itself may
+			// mutate them. Abort the whole batch (before any Update) rather than
+			// partially applying it.
+			if idx >= 0 && t.Spec.Members[idx].External && !external {
 				return ErrExternalTeamMember.Errorf("user %q is externally-synced", mc.uid)
 			}
 
@@ -854,6 +856,8 @@ func (s *Service) setTeamMembers(ctx context.Context, dynamicClient dynamic.Inte
 				removedAny = true
 				changed = true
 			case idx >= 0:
+				// External is immutable on update (see the Team admission validation),
+				// so an existing member keeps whichever flag it was created with.
 				if t.Spec.Members[idx].Permission != mc.permission {
 					t.Spec.Members[idx].Permission = mc.permission
 					changed = true
@@ -863,7 +867,7 @@ func (s *Service) setTeamMembers(ctx context.Context, dynamicClient dynamic.Inte
 					Kind:       subjectKindUser,
 					Name:       mc.uid,
 					Permission: mc.permission,
-					External:   false,
+					External:   external,
 				})
 				changed = true
 			}

--- a/pkg/services/accesscontrol/resourcepermissions/api_adapter.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api_adapter.go
@@ -748,14 +748,6 @@ func (a *api) listTeamMemberPermissions(c *contextmodel.ReqContext, dynamicClien
 	return dto, nil
 }
 
-func (a *api) setUserPermissionInTeamMembers(c *contextmodel.ReqContext, namespace string, resourceID string, userID int64, permission string) (bool, error) {
-	dynamicClient, err := a.getDynamicClient(c)
-	if err != nil {
-		return false, err
-	}
-	return a.service.setTeamMember(c.Req.Context(), dynamicClient, c.GetOrgID(), namespace, resourceID, userID, permission)
-}
-
 // setTeamMember reconciles a single team membership in Team.Spec.Members via the
 // K8s API. It's a thin wrapper over setTeamMembers so the single-member HTTP
 // handler path and the batch path share one read-modify-write implementation. The

--- a/pkg/services/accesscontrol/resourcepermissions/api_adapter_test.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api_adapter_test.go
@@ -1606,18 +1606,14 @@ func TestSetTeamMember(t *testing.T) {
 			}
 			fakeClient := &fakeDynamicClient{resourceInterface: fr}
 
-			testApi := &api{
-				cfg:    &setting.Cfg{},
-				logger: log.New("test"),
-				service: &Service{
-					store:       &mockResourcePermissionStore{},
-					teamService: teamtest.NewFakeServiceWithTeamDTO(testTeam),
-					userService: tt.userSvc(),
-					options:     Options{Resource: "teams"},
-				},
+			svc := &Service{
+				store:       &mockResourcePermissionStore{},
+				teamService: teamtest.NewFakeServiceWithTeamDTO(testTeam),
+				userService: tt.userSvc(),
+				options:     Options{Resource: "teams"},
 			}
 
-			removed, err := testApi.setTeamMember(makeReqCtx(), fakeClient, "stacks-123-org-1", "10", tt.userID, tt.permission)
+			removed, err := svc.setTeamMember(context.Background(), fakeClient, 1, "stacks-123-org-1", "10", tt.userID, tt.permission)
 
 			if tt.expectedErrMsg != "" {
 				require.Error(t, err)

--- a/pkg/services/accesscontrol/resourcepermissions/api_adapter_test.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api_adapter_test.go
@@ -1787,7 +1787,7 @@ func TestSetTeamMembers(t *testing.T) {
 	}
 }
 
-// TestTeamMemberWrappers_RestConfigNotAvailable tests that both wrappers return
+// TestTeamMemberWrappers_RestConfigNotAvailable tests that the wrappers return
 // ErrRestConfigNotAvailable when no rest config provider is set, so the caller (api.go)
 // can stop the operation and return the error.
 func TestTeamMemberWrappers_RestConfigNotAvailable(t *testing.T) {
@@ -1795,13 +1795,6 @@ func TestTeamMemberWrappers_RestConfigNotAvailable(t *testing.T) {
 		name string
 		call func(a *api) error
 	}{
-		{
-			name: "setUserPermissionInTeamMembers",
-			call: func(a *api) error {
-				_, err := a.setUserPermissionInTeamMembers(makeReqCtx(), "stacks-123-org-1", "10", 1, "Admin")
-				return err
-			},
-		},
 		{
 			name: "getTeamPermissionsFromMembers",
 			call: func(a *api) error {

--- a/pkg/services/accesscontrol/resourcepermissions/api_adapter_test.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api_adapter_test.go
@@ -1264,6 +1264,7 @@ func TestSetTeamMember(t *testing.T) {
 		name            string
 		permission      string
 		userID          int64
+		external        bool
 		userSvc         func() *usertest.MockService
 		fakeResource    func(t *testing.T) *fakeResourceInterface
 		expectedErrMsg  string
@@ -1517,6 +1518,60 @@ func TestSetTeamMember(t *testing.T) {
 			},
 		},
 		{
+			// Team sync owns externally-synced members, so it is the one caller allowed
+			// to write them and its adds must be marked External.
+			name:       "team sync adds an external member",
+			permission: "Member",
+			userID:     1,
+			external:   true,
+			userSvc: func() *usertest.MockService {
+				svc := &usertest.MockService{}
+				svc.On("GetByID", mock.Anything, &user.GetUserByIDQuery{ID: int64(1)}).Return(testUser, nil)
+				return svc
+			},
+			fakeResource: func(t *testing.T) *fakeResourceInterface {
+				return &fakeResourceInterface{
+					getFunc: func(_ context.Context, _ string, _ metav1.GetOptions, _ ...string) (*unstructured.Unstructured, error) {
+						return makeTeamObj(t), nil
+					},
+					updateFunc: func(_ context.Context, obj *unstructured.Unstructured, _ metav1.UpdateOptions, _ ...string) (*unstructured.Unstructured, error) {
+						return obj, nil
+					},
+				}
+			},
+			expectUpdate: true,
+			validateMembers: func(t *testing.T, members []iamv0.TeamTeamMember) {
+				require.Len(t, members, 1)
+				assert.True(t, members[0].External, "team sync adds must be marked External")
+			},
+		},
+		{
+			name:       "team sync removes an external member",
+			permission: "",
+			userID:     1,
+			external:   true,
+			userSvc: func() *usertest.MockService {
+				svc := &usertest.MockService{}
+				svc.On("GetByID", mock.Anything, &user.GetUserByIDQuery{ID: int64(1)}).Return(testUser, nil)
+				return svc
+			},
+			fakeResource: func(t *testing.T) *fakeResourceInterface {
+				return &fakeResourceInterface{
+					getFunc: func(_ context.Context, _ string, _ metav1.GetOptions, _ ...string) (*unstructured.Unstructured, error) {
+						return makeTeamObj(t, iamv0.TeamTeamMember{Kind: "User", Name: "user-uid-1", Permission: iamv0.TeamTeamPermissionMember, External: true}), nil
+					},
+					updateFunc: func(_ context.Context, obj *unstructured.Unstructured, _ metav1.UpdateOptions, _ ...string) (*unstructured.Unstructured, error) {
+						return obj, nil
+					},
+				}
+			},
+			expectUpdate:  true,
+			expectRemoved: true,
+			validateMembers: func(t *testing.T, members []iamv0.TeamTeamMember) {
+				assert.Empty(t, members)
+			},
+		},
+		{
 			name:       "accepts lowercase permission",
 			permission: "admin",
 			userID:     1,
@@ -1613,7 +1668,7 @@ func TestSetTeamMember(t *testing.T) {
 				options:     Options{Resource: "teams"},
 			}
 
-			removed, err := svc.setTeamMember(context.Background(), fakeClient, 1, "stacks-123-org-1", "10", tt.userID, tt.permission)
+			removed, err := svc.setTeamMember(context.Background(), fakeClient, 1, "stacks-123-org-1", "10", tt.userID, tt.permission, tt.external)
 
 			if tt.expectedErrMsg != "" {
 				require.Error(t, err)
@@ -1717,6 +1772,26 @@ func TestSetTeamMembers(t *testing.T) {
 			},
 		},
 		{
+			// Only the removed member is reported, so the caller keeps running the legacy
+			// membership hook for the rest of the batch.
+			name: "reports only the removed member of a mixed batch",
+			commands: []accesscontrol.SetResourcePermissionCommand{
+				{UserID: 1, Permission: ""},
+				{UserID: 2, Permission: "Admin"},
+			},
+			initialMembers: []iamv0.TeamTeamMember{
+				{Kind: "User", Name: "user-uid-1", Permission: iamv0.TeamTeamPermissionMember},
+				{Kind: "User", Name: "user-uid-2", Permission: iamv0.TeamTeamPermissionMember},
+			},
+			expectUpdate:  true,
+			expectRemoved: true,
+			validateMembers: func(t *testing.T, members []iamv0.TeamTeamMember) {
+				require.Len(t, members, 1)
+				assert.Equal(t, "user-uid-2", members[0].Name)
+				assert.Equal(t, iamv0.TeamTeamPermissionAdmin, members[0].Permission)
+			},
+		},
+		{
 			name: "aborts the whole batch on an external member without updating",
 			commands: []accesscontrol.SetResourcePermissionCommand{
 				{UserID: 1, Permission: "Member"},
@@ -1762,7 +1837,7 @@ func TestSetTeamMembers(t *testing.T) {
 				options:     Options{Resource: "teams"},
 			}
 
-			removed, err := svc.setTeamMembers(context.Background(), fakeClient, 1, "stacks-123-org-1", "10", tt.commands)
+			removed, err := svc.setTeamMembers(context.Background(), fakeClient, 1, "stacks-123-org-1", "10", tt.commands, false)
 
 			if tt.expectedErrMsg != "" {
 				require.Error(t, err)

--- a/pkg/services/accesscontrol/resourcepermissions/api_adapter_test.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api_adapter_test.go
@@ -1642,6 +1642,151 @@ func TestSetTeamMember(t *testing.T) {
 	}
 }
 
+// TestSetTeamMembers covers the batch counterpart of setTeamMember: the whole
+// batch must be applied in a single Team update (atomic), and any external member
+// must abort the batch before any write so no partial update is persisted.
+func TestSetTeamMembers(t *testing.T) {
+	testTeam := &team.TeamDTO{ID: 10, UID: "team-uid-1"}
+
+	makeTeamObj := func(t *testing.T, members ...iamv0.TeamTeamMember) *unstructured.Unstructured {
+		t.Helper()
+		teamObj := iamv0.Team{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: iamv0.TeamResourceInfo.GroupVersion().String(),
+				Kind:       iamv0.TeamResourceInfo.TypeMeta().Kind,
+			},
+			ObjectMeta: metav1.ObjectMeta{Name: "team-uid-1", Namespace: "stacks-123-org-1", ResourceVersion: "42"},
+			Spec:       iamv0.TeamSpec{Members: members},
+		}
+		obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&teamObj)
+		require.NoError(t, err)
+		return &unstructured.Unstructured{Object: obj}
+	}
+	decodeMembers := func(t *testing.T, obj *unstructured.Unstructured) []iamv0.TeamTeamMember {
+		t.Helper()
+		var decoded iamv0.Team
+		require.NoError(t, runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &decoded))
+		return decoded.Spec.Members
+	}
+	// userSvc resolves userID N to UID "user-uid-N".
+	userSvc := func() *usertest.MockService {
+		svc := &usertest.MockService{}
+		svc.On("GetByID", mock.Anything, &user.GetUserByIDQuery{ID: int64(1)}).Return(&user.User{ID: 1, UID: "user-uid-1"}, nil)
+		svc.On("GetByID", mock.Anything, &user.GetUserByIDQuery{ID: int64(2)}).Return(&user.User{ID: 2, UID: "user-uid-2"}, nil)
+		return svc
+	}
+
+	tests := []struct {
+		name            string
+		commands        []accesscontrol.SetResourcePermissionCommand
+		initialMembers  []iamv0.TeamTeamMember
+		expectedErrMsg  string
+		expectUpdate    bool
+		expectRemoved   bool
+		validateMembers func(t *testing.T, members []iamv0.TeamTeamMember)
+	}{
+		{
+			name: "applies the whole batch in a single update",
+			commands: []accesscontrol.SetResourcePermissionCommand{
+				{UserID: 1, Permission: "Member"},
+				{UserID: 2, Permission: "Admin"},
+			},
+			expectUpdate: true,
+			validateMembers: func(t *testing.T, members []iamv0.TeamTeamMember) {
+				require.Len(t, members, 2)
+				assert.Equal(t, "user-uid-1", members[0].Name)
+				assert.Equal(t, iamv0.TeamTeamPermissionMember, members[0].Permission)
+				assert.Equal(t, "user-uid-2", members[1].Name)
+				assert.Equal(t, iamv0.TeamTeamPermissionAdmin, members[1].Permission)
+			},
+		},
+		{
+			name: "removes and adds in one update",
+			commands: []accesscontrol.SetResourcePermissionCommand{
+				{UserID: 1, Permission: ""},
+				{UserID: 2, Permission: "Admin"},
+			},
+			initialMembers: []iamv0.TeamTeamMember{
+				{Kind: "User", Name: "user-uid-1", Permission: iamv0.TeamTeamPermissionMember},
+			},
+			expectUpdate:  true,
+			expectRemoved: true,
+			validateMembers: func(t *testing.T, members []iamv0.TeamTeamMember) {
+				require.Len(t, members, 1)
+				assert.Equal(t, "user-uid-2", members[0].Name)
+			},
+		},
+		{
+			name: "aborts the whole batch on an external member without updating",
+			commands: []accesscontrol.SetResourcePermissionCommand{
+				{UserID: 1, Permission: "Member"},
+				{UserID: 2, Permission: "Member"},
+			},
+			initialMembers: []iamv0.TeamTeamMember{
+				{Kind: "User", Name: "user-uid-2", Permission: iamv0.TeamTeamPermissionMember, External: true},
+			},
+			expectedErrMsg: "externally-synced",
+			expectUpdate:   false,
+		},
+		{
+			name: "no update when removing non-members",
+			commands: []accesscontrol.SetResourcePermissionCommand{
+				{UserID: 1, Permission: ""},
+			},
+			expectUpdate: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var (
+				lastUpdated *unstructured.Unstructured
+				updateCalls int
+			)
+			fr := &fakeResourceInterface{
+				getFunc: func(_ context.Context, _ string, _ metav1.GetOptions, _ ...string) (*unstructured.Unstructured, error) {
+					return makeTeamObj(t, tt.initialMembers...), nil
+				},
+				updateFunc: func(_ context.Context, obj *unstructured.Unstructured, _ metav1.UpdateOptions, _ ...string) (*unstructured.Unstructured, error) {
+					updateCalls++
+					lastUpdated = obj
+					return obj, nil
+				},
+			}
+			fakeClient := &fakeDynamicClient{resourceInterface: fr}
+
+			svc := &Service{
+				store:       &mockResourcePermissionStore{},
+				teamService: teamtest.NewFakeServiceWithTeamDTO(testTeam),
+				userService: userSvc(),
+				options:     Options{Resource: "teams"},
+			}
+
+			removed, err := svc.setTeamMembers(context.Background(), fakeClient, 1, "stacks-123-org-1", "10", tt.commands)
+
+			if tt.expectedErrMsg != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErrMsg)
+				assert.Zero(t, updateCalls, "no update should be persisted when the batch aborts")
+				assert.False(t, removed, "should not report a removal on error")
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectRemoved, removed, "removed return value")
+
+			if tt.expectUpdate {
+				assert.Equal(t, 1, updateCalls, "the batch must be applied in a single update")
+				require.NotNil(t, lastUpdated)
+				if tt.validateMembers != nil {
+					tt.validateMembers(t, decodeMembers(t, lastUpdated))
+				}
+			} else {
+				assert.Zero(t, updateCalls, "expected no update")
+			}
+		})
+	}
+}
+
 // TestTeamMemberWrappers_RestConfigNotAvailable tests that both wrappers return
 // ErrRestConfigNotAvailable when no rest config provider is set, so the caller (api.go)
 // can stop the operation and return the error.

--- a/pkg/services/accesscontrol/resourcepermissions/service.go
+++ b/pkg/services/accesscontrol/resourcepermissions/service.go
@@ -18,6 +18,8 @@ import (
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/pluginutils"
+	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
+	"github.com/grafana/grafana/pkg/services/contexthandler"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -106,6 +108,7 @@ func New(cfg *setting.Cfg,
 	s := &Service{
 		ac:           ac,
 		features:     features,
+		cfg:          cfg,
 		store:        NewStore(cfg, sqlStore, features),
 		options:      options,
 		license:      license,
@@ -139,6 +142,7 @@ type Service struct {
 	api      *api
 	license  licensing.Licensing
 
+	cfg          *setting.Cfg
 	log          log.Logger
 	options      Options
 	permissions  []string
@@ -233,6 +237,38 @@ func (s *Service) SetUserPermission(ctx context.Context, orgID int64, user acces
 		return nil, err
 	}
 
+	// teamsRedirectRemovedMember records that the K8s teams redirect below actually
+	// removed an existing member. In dual-write modes (Mode1-3) legacy is the primary
+	// target of that write, so the legacy write further down then finds the row
+	// already gone. A no-op redirect (the member wasn't there) leaves this false, so
+	// a genuinely-absent member still surfaces the legacy error.
+	teamsRedirectRemovedMember := false
+
+	// Teams-specific redirect: write the membership to Team.Spec.Members via the
+	// K8s API. The HTTP handler (api.setUserPermission) already does this, but
+	// callers that invoke the service directly (not through the handler) need the
+	// same redirect, so it lives here too. In unified-authoritative modes (Mode4/5)
+	// the legacy team_member table has no row to write, so we must not fall back to it.
+	if s.teamsMembershipRedirectEnabled(ctx) {
+		removed, k8sErr := setTeamMembership(s, ctx, orgID, resourceID, user.ID, permission)
+		if errors.Is(k8sErr, ErrExternalTeamMember) {
+			return nil, k8sErr
+		}
+		if k8sErr == nil {
+			teamsRedirectRemovedMember = removed
+		}
+		if s.unifiedTeamStorageIsAuthoritative() {
+			if k8sErr != nil {
+				return nil, k8sErr
+			}
+			s.clearUserPermissionCache(orgID, user.ID)
+			return &accesscontrol.ResourcePermission{Actions: actions, UserID: user.ID}, nil
+		}
+		if k8sErr != nil {
+			s.log.Warn("Failed to set team member via k8s API, falling back to legacy", "error", k8sErr, "resourceID", resourceID)
+		}
+	}
+
 	var datasourceType string
 	if s.options.DatasourceTypeResolver != nil && resourceID != "*" {
 		if t, err := s.options.DatasourceTypeResolver(ctx, orgID, resourceID); err == nil {
@@ -250,6 +286,12 @@ func (s *Service) SetUserPermission(ctx context.Context, orgID int64, user acces
 	}, s.options.OnSetUser)
 
 	if err != nil {
+		// The teams redirect above already removed the member (and, in dual-write
+		// modes, the legacy team_member row), so this legacy removal finds nothing.
+		if teamsRedirectRemovedMember && errors.Is(err, team.ErrTeamMemberNotFound) {
+			s.clearUserPermissionCache(orgID, user.ID)
+			return &accesscontrol.ResourcePermission{Actions: actions, UserID: user.ID}, nil
+		}
 		return nil, err
 	}
 
@@ -380,15 +422,66 @@ func (s *Service) SetPermissions(
 		})
 	}
 
+	// teamsRedirectRemovedMember mirrors SetUserPermission: the K8s teams redirect
+	// below removed at least one existing member, so in dual-write modes the legacy
+	// removals further down find the rows already gone.
+	teamsRedirectRemovedMember := false
+
+	// Teams-specific redirect: reconcile each membership through Team.Spec.Members
+	// via the K8s API (see SetUserPermission for the rationale). Team permissions
+	// only support user assignments (see Assignments in ProvideTeamPermissions), so
+	// only user commands are routed.
+	if s.teamsMembershipRedirectEnabled(ctx) {
+		var k8sErr error
+		for _, cmd := range commands {
+			if cmd.UserID == 0 {
+				continue
+			}
+			removed, err := setTeamMembership(s, ctx, orgID, resourceID, cmd.UserID, cmd.Permission)
+			if err != nil {
+				if errors.Is(err, ErrExternalTeamMember) {
+					return nil, err
+				}
+				k8sErr = err
+				continue
+			}
+			teamsRedirectRemovedMember = teamsRedirectRemovedMember || removed
+		}
+		if s.unifiedTeamStorageIsAuthoritative() {
+			if k8sErr != nil {
+				return nil, k8sErr
+			}
+			s.clearUserPermissionCaches(orgID, commands)
+			return []accesscontrol.ResourcePermission{}, nil
+		}
+		if k8sErr != nil {
+			s.log.Warn("Failed to set team members via k8s API, falling back to legacy", "error", k8sErr, "resourceID", resourceID)
+		}
+	}
+
 	result, err := s.store.SetResourcePermissions(ctx, orgID, dbCommands, ResourceHooks{
 		User:        s.options.OnSetUser,
 		Team:        s.options.OnSetTeam,
 		BuiltInRole: s.options.OnSetBuiltInRole,
 	})
 	if err != nil {
+		// The teams redirect above already removed the member (and, in dual-write
+		// modes, the legacy team_member row), so this legacy removal finds nothing.
+		if teamsRedirectRemovedMember && errors.Is(err, team.ErrTeamMemberNotFound) {
+			s.clearUserPermissionCaches(orgID, commands)
+			return []accesscontrol.ResourcePermission{}, nil
+		}
 		return nil, err
 	}
 
+	s.clearUserPermissionCaches(orgID, commands)
+
+	return result, nil
+}
+
+// clearUserPermissionCaches clears the permission cache of every user assigned by
+// the given commands.
+func (s *Service) clearUserPermissionCaches(orgID int64, commands []accesscontrol.SetResourcePermissionCommand) {
 	clearedUsers := make(map[int64]bool)
 	for _, cmd := range commands {
 		if cmd.UserID != 0 && !clearedUsers[cmd.UserID] {
@@ -396,8 +489,50 @@ func (s *Service) SetPermissions(
 			clearedUsers[cmd.UserID] = true
 		}
 	}
+}
 
-	return result, nil
+// teamsMembershipRedirectEnabled reports whether team membership writes for this
+// service should be routed to Team.Spec.Members via the K8s API instead of the
+// legacy team_member table. It mirrors the gate used by the HTTP handlers
+// (api.setUserPermission) so direct service callers behave identically.
+func (s *Service) teamsMembershipRedirectEnabled(ctx context.Context) bool {
+	return s.options.Resource == "teams" &&
+		ofClient.Boolean(ctx, featuremgmt.FlagKubernetesTeamsRedirect, false, openfeature.TransactionContext(ctx))
+}
+
+// unifiedTeamStorageIsAuthoritative reports whether unified storage is the
+// authoritative backend for teams (dualWriterMode > Mode3). When true, the legacy
+// team_member table is not written, so team membership must succeed against the
+// K8s API and callers must not fall back to legacy.
+func (s *Service) unifiedTeamStorageIsAuthoritative() bool {
+	return unifiedStorageIsAuthoritative(s.cfg, iamv0.TeamResourceInfo.GroupResource().String())
+}
+
+// setTeamMembership writes a single team membership to Team.Spec.Members via the
+// K8s API. The bool reports whether an existing member was removed.
+//
+// Stubbable by tests.
+var setTeamMembership = func(s *Service, ctx context.Context, orgID int64, resourceID string, userID int64, permission string) (bool, error) {
+	return s.setTeamMemberViaK8s(ctx, orgID, resourceID, userID, permission)
+}
+
+// setTeamMemberViaK8s writes a single team membership to Team.Spec.Members via the
+// K8s API for callers that invoke the service directly (not through the HTTP
+// handler). It reuses the same read-modify-write helper as the HTTP teams redirect,
+// building the client from the ReqContext the contexthandler middleware stored on
+// ctx and deriving the namespace from orgID the same way the team K8s service does.
+// The bool reports whether an existing member was removed.
+func (s *Service) setTeamMemberViaK8s(ctx context.Context, orgID int64, resourceID string, userID int64, permission string) (bool, error) {
+	reqCtx := contexthandler.FromContext(ctx)
+	if reqCtx == nil {
+		return false, ErrRestConfigNotAvailable
+	}
+	dynamicClient, err := newDynamicClient(s.options.RestConfigProvider, reqCtx)
+	if err != nil {
+		return false, err
+	}
+	namespace := request.GetNamespaceMapper(s.cfg)(orgID)
+	return s.setTeamMember(ctx, dynamicClient, orgID, namespace, resourceID, userID, permission)
 }
 
 func (s *Service) MapActions(permission accesscontrol.ResourcePermission) string {

--- a/pkg/services/accesscontrol/resourcepermissions/service.go
+++ b/pkg/services/accesscontrol/resourcepermissions/service.go
@@ -237,25 +237,16 @@ func (s *Service) SetUserPermission(ctx context.Context, orgID int64, user acces
 		return nil, err
 	}
 
-	// teamsRedirectRemovedMember records that the K8s teams redirect below actually
-	// removed an existing member. In dual-write modes (Mode1-3) legacy is the primary
-	// target of that write, so the legacy write further down then finds the row
-	// already gone. A no-op redirect (the member wasn't there) leaves this false, so
-	// a genuinely-absent member still surfaces the legacy error.
-	teamsRedirectRemovedMember := false
-
 	// Teams-specific redirect: write the membership to Team.Spec.Members via the
 	// K8s API. The HTTP handler (api.setUserPermission) already does this, but
 	// callers that invoke the service directly (not through the handler) need the
 	// same redirect, so it lives here too. In unified-authoritative modes (Mode4/5)
 	// the legacy team_member table has no row to write, so we must not fall back to it.
+	redirectRemovedMember := false
 	if s.teamsMembershipRedirectEnabled(ctx) {
 		removed, k8sErr := setTeamMembership(s, ctx, orgID, resourceID, user.ID, permission)
 		if errors.Is(k8sErr, ErrExternalTeamMember) {
 			return nil, k8sErr
-		}
-		if k8sErr == nil {
-			teamsRedirectRemovedMember = removed
 		}
 		if s.unifiedTeamStorageIsAuthoritative() {
 			if k8sErr != nil {
@@ -266,6 +257,8 @@ func (s *Service) SetUserPermission(ctx context.Context, orgID int64, user acces
 		}
 		if k8sErr != nil {
 			s.log.Warn("Failed to set team member via k8s API, falling back to legacy", "error", k8sErr, "resourceID", resourceID)
+		} else {
+			redirectRemovedMember = removed
 		}
 	}
 
@@ -276,6 +269,17 @@ func (s *Service) SetUserPermission(ctx context.Context, orgID int64, user acces
 		}
 	}
 
+	// When the redirect already removed the member, it also removed the legacy
+	// team_member row (dual-write). Skip the legacy membership hook: re-running it
+	// would fail with ErrTeamMemberNotFound and roll back the RBAC permission write
+	// in the same transaction, leaving the user with stale permissions. Adds and
+	// no-op removals keep the hook, so a genuinely-absent member still surfaces the
+	// not-found error.
+	onSetUser := s.options.OnSetUser
+	if redirectRemovedMember {
+		onSetUser = nil
+	}
+
 	result, err := s.store.SetUserResourcePermission(ctx, orgID, user, SetResourcePermissionCommand{
 		Actions:           actions,
 		Permission:        permission,
@@ -283,15 +287,8 @@ func (s *Service) SetUserPermission(ctx context.Context, orgID int64, user acces
 		ResourceID:        resourceID,
 		ResourceAttribute: s.options.ResourceAttribute,
 		DatasourceType:    datasourceType,
-	}, s.options.OnSetUser)
-
+	}, onSetUser)
 	if err != nil {
-		// The teams redirect above already removed the member (and, in dual-write
-		// modes, the legacy team_member row), so this legacy removal finds nothing.
-		if teamsRedirectRemovedMember && errors.Is(err, team.ErrTeamMemberNotFound) {
-			s.clearUserPermissionCache(orgID, user.ID)
-			return &accesscontrol.ResourcePermission{Actions: actions, UserID: user.ID}, nil
-		}
 		return nil, err
 	}
 
@@ -422,30 +419,17 @@ func (s *Service) SetPermissions(
 		})
 	}
 
-	// teamsRedirectRemovedMember mirrors SetUserPermission: the K8s teams redirect
-	// below removed at least one existing member, so in dual-write modes the legacy
-	// removals further down find the rows already gone.
-	teamsRedirectRemovedMember := false
-
-	// Teams-specific redirect: reconcile each membership through Team.Spec.Members
-	// via the K8s API (see SetUserPermission for the rationale). Team permissions
-	// only support user assignments (see Assignments in ProvideTeamPermissions), so
-	// only user commands are routed.
+	// Teams-specific redirect: reconcile the batch of memberships through
+	// Team.Spec.Members via the K8s API (see SetUserPermission for the rationale).
+	// Team permissions only support user assignments (see Assignments in
+	// ProvideTeamPermissions), so only user commands are routed. The batch is
+	// applied in a single Team update so it succeeds or fails atomically, matching
+	// the all-or-nothing semantics of the legacy SQL transaction below.
+	redirectRemovedMember := false
 	if s.teamsMembershipRedirectEnabled(ctx) {
-		var k8sErr error
-		for _, cmd := range commands {
-			if cmd.UserID == 0 {
-				continue
-			}
-			removed, err := setTeamMembership(s, ctx, orgID, resourceID, cmd.UserID, cmd.Permission)
-			if err != nil {
-				if errors.Is(err, ErrExternalTeamMember) {
-					return nil, err
-				}
-				k8sErr = err
-				continue
-			}
-			teamsRedirectRemovedMember = teamsRedirectRemovedMember || removed
+		removed, k8sErr := setTeamMemberships(s, ctx, orgID, resourceID, commands)
+		if errors.Is(k8sErr, ErrExternalTeamMember) {
+			return nil, k8sErr
 		}
 		if s.unifiedTeamStorageIsAuthoritative() {
 			if k8sErr != nil {
@@ -456,21 +440,25 @@ func (s *Service) SetPermissions(
 		}
 		if k8sErr != nil {
 			s.log.Warn("Failed to set team members via k8s API, falling back to legacy", "error", k8sErr, "resourceID", resourceID)
+		} else {
+			redirectRemovedMember = removed
 		}
 	}
 
+	// See SetUserPermission: when the redirect removed a member it also removed the
+	// legacy team_member row, so skip the membership hook to avoid rolling back the
+	// RBAC permission writes. Adds and no-op removals keep the hook.
+	userHook := s.options.OnSetUser
+	if redirectRemovedMember {
+		userHook = nil
+	}
+
 	result, err := s.store.SetResourcePermissions(ctx, orgID, dbCommands, ResourceHooks{
-		User:        s.options.OnSetUser,
+		User:        userHook,
 		Team:        s.options.OnSetTeam,
 		BuiltInRole: s.options.OnSetBuiltInRole,
 	})
 	if err != nil {
-		// The teams redirect above already removed the member (and, in dual-write
-		// modes, the legacy team_member row), so this legacy removal finds nothing.
-		if teamsRedirectRemovedMember && errors.Is(err, team.ErrTeamMemberNotFound) {
-			s.clearUserPermissionCaches(orgID, commands)
-			return []accesscontrol.ResourcePermission{}, nil
-		}
 		return nil, err
 	}
 
@@ -533,6 +521,32 @@ func (s *Service) setTeamMemberViaK8s(ctx context.Context, orgID int64, resource
 	}
 	namespace := request.GetNamespaceMapper(s.cfg)(orgID)
 	return s.setTeamMember(ctx, dynamicClient, orgID, namespace, resourceID, userID, permission)
+}
+
+// setTeamMemberships reconciles a batch of team memberships against
+// Team.Spec.Members via the K8s API. The whole batch is applied in a single Team
+// update so it commits or fails atomically. Only user commands are routed. The
+// bool reports whether any existing member was removed.
+//
+// Stubbable by tests.
+var setTeamMemberships = func(s *Service, ctx context.Context, orgID int64, resourceID string, commands []accesscontrol.SetResourcePermissionCommand) (bool, error) {
+	return s.setTeamMembersViaK8s(ctx, orgID, resourceID, commands)
+}
+
+// setTeamMembersViaK8s is the batch counterpart of setTeamMemberViaK8s: it applies
+// every user command in the batch to Team.Spec.Members in one read-modify-write.
+// The bool reports whether any existing member was removed.
+func (s *Service) setTeamMembersViaK8s(ctx context.Context, orgID int64, resourceID string, commands []accesscontrol.SetResourcePermissionCommand) (bool, error) {
+	reqCtx := contexthandler.FromContext(ctx)
+	if reqCtx == nil {
+		return false, ErrRestConfigNotAvailable
+	}
+	dynamicClient, err := newDynamicClient(s.options.RestConfigProvider, reqCtx)
+	if err != nil {
+		return false, err
+	}
+	namespace := request.GetNamespaceMapper(s.cfg)(orgID)
+	return s.setTeamMembers(ctx, dynamicClient, orgID, namespace, resourceID, commands)
 }
 
 func (s *Service) MapActions(permission accesscontrol.ResourcePermission) string {

--- a/pkg/services/accesscontrol/resourcepermissions/service.go
+++ b/pkg/services/accesscontrol/resourcepermissions/service.go
@@ -15,6 +15,7 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/infra/metrics"
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/pluginutils"
@@ -248,8 +249,12 @@ func (s *Service) SetUserPermission(ctx context.Context, orgID int64, user acces
 		if errors.Is(k8sErr, ErrExternalTeamMember) {
 			return nil, k8sErr
 		}
+		if k8sErr == nil {
+			metrics.MAccessResourcePermissionsBackend.WithLabelValues("k8s", "set_user", s.options.Resource, "success").Inc()
+		}
 		if s.unifiedTeamStorageIsAuthoritative() {
 			if k8sErr != nil {
+				metrics.MAccessResourcePermissionsBackend.WithLabelValues("k8s", "set_user", s.options.Resource, "error").Inc()
 				return nil, k8sErr
 			}
 			s.clearUserPermissionCache(orgID, user.ID)
@@ -431,8 +436,12 @@ func (s *Service) SetPermissions(
 		if errors.Is(k8sErr, ErrExternalTeamMember) {
 			return nil, k8sErr
 		}
+		if k8sErr == nil {
+			metrics.MAccessResourcePermissionsBackend.WithLabelValues("k8s", "set_bulk", s.options.Resource, "success").Inc()
+		}
 		if s.unifiedTeamStorageIsAuthoritative() {
 			if k8sErr != nil {
+				metrics.MAccessResourcePermissionsBackend.WithLabelValues("k8s", "set_bulk", s.options.Resource, "error").Inc()
 				return nil, k8sErr
 			}
 			s.clearUserPermissionCaches(orgID, commands)

--- a/pkg/services/accesscontrol/resourcepermissions/service.go
+++ b/pkg/services/accesscontrol/resourcepermissions/service.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/open-feature/go-sdk/openfeature"
+	"k8s.io/client-go/dynamic"
 
 	iamv0 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
 	"github.com/grafana/grafana/pkg/api/routing"
@@ -122,6 +123,7 @@ func New(cfg *setting.Cfg,
 		userService:  userService,
 		actionSetSvc: actionSetService,
 	}
+	s.dynamicClient = s.dynamicClientForContext
 
 	s.api = newApi(cfg, ac, router, s, features, s.options.RestConfigProvider)
 
@@ -152,6 +154,10 @@ type Service struct {
 	teamService  team.Service
 	userService  user.Service
 	actionSetSvc ActionSetService
+
+	// dynamicClient builds the K8s client the teams membership redirect writes
+	// through. A field rather than a direct call so tests can inject a fake client.
+	dynamicClient func(ctx context.Context) (dynamic.Interface, error)
 }
 
 func (s *Service) GetPermissions(ctx context.Context, user identity.Requester, resourceID string) ([]accesscontrol.ResourcePermission, error) {
@@ -239,20 +245,21 @@ func (s *Service) SetUserPermission(ctx context.Context, orgID int64, user acces
 	}
 
 	// Teams-specific redirect: write the membership to Team.Spec.Members via the
-	// K8s API. The HTTP handler (api.setUserPermission) already does this, but
-	// callers that invoke the service directly (not through the handler) need the
-	// same redirect, so it lives here too. In unified-authoritative modes (Mode4/5)
-	// the legacy team_member table has no row to write, so we must not fall back to it.
+	// K8s API. It lives here rather than in api.setUserPermission so that every
+	// caller shares it — HTTP requests reach it through this method, and so do the
+	// in-process callers (SCIM, team-sync, the team-members API) that never touch the
+	// handler. In unified-authoritative modes (Mode4/5) the legacy team_member table
+	// has no row to write, so we must not fall back to it.
 	redirectRemovedMember := false
 	if s.teamsMembershipRedirectEnabled(ctx) {
-		removed, k8sErr := setTeamMembership(s, ctx, orgID, resourceID, user.ID, permission)
+		removed, k8sErr := s.setTeamMemberViaK8s(ctx, orgID, resourceID, user.ID, permission, user.IsExternal)
 		if errors.Is(k8sErr, ErrExternalTeamMember) {
 			return nil, k8sErr
 		}
 		if k8sErr == nil {
 			metrics.MAccessResourcePermissionsBackend.WithLabelValues("k8s", "set_user", s.options.Resource, "success").Inc()
 		}
-		if s.unifiedTeamStorageIsAuthoritative() {
+		if unifiedStorageIsAuthoritative(s.cfg, iamv0.TeamResourceInfo.GroupResource().String()) {
 			if k8sErr != nil {
 				metrics.MAccessResourcePermissionsBackend.WithLabelValues("k8s", "set_user", s.options.Resource, "error").Inc()
 				return nil, k8sErr
@@ -432,14 +439,14 @@ func (s *Service) SetPermissions(
 	// the all-or-nothing semantics of the legacy SQL transaction below.
 	redirectRemovedMember := false
 	if s.teamsMembershipRedirectEnabled(ctx) {
-		removed, k8sErr := setTeamMemberships(s, ctx, orgID, resourceID, commands)
+		removed, k8sErr := s.setTeamMembersViaK8s(ctx, orgID, resourceID, commands)
 		if errors.Is(k8sErr, ErrExternalTeamMember) {
 			return nil, k8sErr
 		}
 		if k8sErr == nil {
 			metrics.MAccessResourcePermissionsBackend.WithLabelValues("k8s", "set_bulk", s.options.Resource, "success").Inc()
 		}
-		if s.unifiedTeamStorageIsAuthoritative() {
+		if unifiedStorageIsAuthoritative(s.cfg, iamv0.TeamResourceInfo.GroupResource().String()) {
 			if k8sErr != nil {
 				metrics.MAccessResourcePermissionsBackend.WithLabelValues("k8s", "set_bulk", s.options.Resource, "error").Inc()
 				return nil, k8sErr
@@ -456,7 +463,8 @@ func (s *Service) SetPermissions(
 
 	// See SetUserPermission: when the redirect removed a member it also removed the
 	// legacy team_member row, so skip the membership hook to avoid rolling back the
-	// RBAC permission writes. Adds and no-op removals keep the hook.
+	// RBAC permission writes. The batch is all-or-nothing, so this covers the whole
+	// batch; the adds in it already have their team_member row from the dual-write.
 	userHook := s.options.OnSetUser
 	if redirectRemovedMember {
 		userHook = nil
@@ -490,72 +498,58 @@ func (s *Service) clearUserPermissionCaches(orgID int64, commands []accesscontro
 
 // teamsMembershipRedirectEnabled reports whether team membership writes for this
 // service should be routed to Team.Spec.Members via the K8s API instead of the
-// legacy team_member table. It mirrors the gate used by the HTTP handlers
-// (api.setUserPermission) so direct service callers behave identically.
+// legacy team_member table. It is the only gate on that redirect: the HTTP handlers
+// no longer check the toggle themselves, so every caller enters through here.
 func (s *Service) teamsMembershipRedirectEnabled(ctx context.Context) bool {
 	return s.options.Resource == "teams" &&
 		ofClient.Boolean(ctx, featuremgmt.FlagKubernetesTeamsRedirect, false, openfeature.TransactionContext(ctx))
 }
 
-// unifiedTeamStorageIsAuthoritative reports whether unified storage is the
-// authoritative backend for teams (dualWriterMode > Mode3). When true, the legacy
-// team_member table is not written, so team membership must succeed against the
-// K8s API and callers must not fall back to legacy.
-func (s *Service) unifiedTeamStorageIsAuthoritative() bool {
-	return unifiedStorageIsAuthoritative(s.cfg, iamv0.TeamResourceInfo.GroupResource().String())
+// teamsRedirectOwnsWrites reports whether the teams membership redirect is the sole
+// writer (redirect enabled and unified storage authoritative). When true the legacy
+// store is never written, so handlers must not count a legacy write in the metrics.
+func (s *Service) teamsRedirectOwnsWrites(ctx context.Context) bool {
+	return s.teamsMembershipRedirectEnabled(ctx) &&
+		unifiedStorageIsAuthoritative(s.cfg, iamv0.TeamResourceInfo.GroupResource().String())
 }
 
-// setTeamMembership writes a single team membership to Team.Spec.Members via the
-// K8s API. The bool reports whether an existing member was removed.
-//
-// Stubbable by tests.
-var setTeamMembership = func(s *Service, ctx context.Context, orgID int64, resourceID string, userID int64, permission string) (bool, error) {
-	return s.setTeamMemberViaK8s(ctx, orgID, resourceID, userID, permission)
+// dynamicClientForContext builds the K8s client the teams membership redirect
+// writes through, using the ReqContext the contexthandler middleware stored on
+// ctx. Callers with no request context (background jobs) cannot reach the K8s
+// APIs, so they get ErrRestConfigNotAvailable and fall back to legacy wherever
+// that is still allowed. Mirrors teamk8s.TeamK8sService.getDynamicClient.
+func (s *Service) dynamicClientForContext(ctx context.Context) (dynamic.Interface, error) {
+	reqCtx := contexthandler.FromContext(ctx)
+	if reqCtx == nil {
+		return nil, ErrRestConfigNotAvailable
+	}
+	return newDynamicClient(s.options.RestConfigProvider, reqCtx)
 }
 
 // setTeamMemberViaK8s writes a single team membership to Team.Spec.Members via the
-// K8s API for callers that invoke the service directly (not through the HTTP
-// handler). It reuses the same read-modify-write helper as the HTTP teams redirect,
-// building the client from the ReqContext the contexthandler middleware stored on
-// ctx and deriving the namespace from orgID the same way the team K8s service does.
-// The bool reports whether an existing member was removed.
-func (s *Service) setTeamMemberViaK8s(ctx context.Context, orgID int64, resourceID string, userID int64, permission string) (bool, error) {
-	reqCtx := contexthandler.FromContext(ctx)
-	if reqCtx == nil {
-		return false, ErrRestConfigNotAvailable
-	}
-	dynamicClient, err := newDynamicClient(s.options.RestConfigProvider, reqCtx)
+// K8s API, deriving the namespace from orgID the same way the team K8s service does.
+// external marks the caller as team-sync. The bool reports whether an existing member
+// was removed.
+func (s *Service) setTeamMemberViaK8s(ctx context.Context, orgID int64, resourceID string, userID int64, permission string, external bool) (bool, error) {
+	dynamicClient, err := s.dynamicClient(ctx)
 	if err != nil {
 		return false, err
 	}
 	namespace := request.GetNamespaceMapper(s.cfg)(orgID)
-	return s.setTeamMember(ctx, dynamicClient, orgID, namespace, resourceID, userID, permission)
-}
-
-// setTeamMemberships reconciles a batch of team memberships against
-// Team.Spec.Members via the K8s API. The whole batch is applied in a single Team
-// update so it commits or fails atomically. Only user commands are routed. The
-// bool reports whether any existing member was removed.
-//
-// Stubbable by tests.
-var setTeamMemberships = func(s *Service, ctx context.Context, orgID int64, resourceID string, commands []accesscontrol.SetResourcePermissionCommand) (bool, error) {
-	return s.setTeamMembersViaK8s(ctx, orgID, resourceID, commands)
+	return s.setTeamMember(ctx, dynamicClient, orgID, namespace, resourceID, userID, permission, external)
 }
 
 // setTeamMembersViaK8s is the batch counterpart of setTeamMemberViaK8s: it applies
-// every user command in the batch to Team.Spec.Members in one read-modify-write.
+// every user command in the batch to Team.Spec.Members in one read-modify-write. Only
+// the single-member path has a team-sync caller, so the batch is never external.
 // The bool reports whether any existing member was removed.
 func (s *Service) setTeamMembersViaK8s(ctx context.Context, orgID int64, resourceID string, commands []accesscontrol.SetResourcePermissionCommand) (bool, error) {
-	reqCtx := contexthandler.FromContext(ctx)
-	if reqCtx == nil {
-		return false, ErrRestConfigNotAvailable
-	}
-	dynamicClient, err := newDynamicClient(s.options.RestConfigProvider, reqCtx)
+	dynamicClient, err := s.dynamicClient(ctx)
 	if err != nil {
 		return false, err
 	}
 	namespace := request.GetNamespaceMapper(s.cfg)(orgID)
-	return s.setTeamMembers(ctx, dynamicClient, orgID, namespace, resourceID, commands)
+	return s.setTeamMembers(ctx, dynamicClient, orgID, namespace, resourceID, commands, false)
 }
 
 func (s *Service) MapActions(permission accesscontrol.ResourcePermission) string {

--- a/pkg/services/accesscontrol/resourcepermissions/service_test.go
+++ b/pkg/services/accesscontrol/resourcepermissions/service_test.go
@@ -1039,9 +1039,11 @@ func TestIntegrationService_SetPermissionsForTeams_Redirect(t *testing.T) {
 
 // TestIntegrationService_SetUserPermissionForTeams_RedirectWrites covers the
 // outcomes of the K8s membership write itself (stubbed): in unified-authoritative
-// modes the K8s result is final and the legacy store is never touched, while in
-// dual-write modes the legacy write still runs — including the case where the
-// redirect already removed the member so the legacy removal finds nothing.
+// modes the K8s result is final and the legacy store is never touched; in
+// dual-write modes a redirect that actually removed the member skips the legacy
+// membership hook (the dual-write already removed team_member, so re-running the
+// hook would fail and roll back the RBAC write), while adds and no-op removals
+// keep the hook so a genuinely-absent member still surfaces the not-found error.
 func TestIntegrationService_SetUserPermissionForTeams_RedirectWrites(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 
@@ -1083,12 +1085,12 @@ func TestIntegrationService_SetUserPermissionForTeams_RedirectWrites(t *testing.
 			expectHookCall: true,
 		},
 		{
-			name:           "Mode3 tolerates a member already removed by the redirect",
-			mode:           grafanarest.Mode3,
-			permission:     "",
-			k8sRemoved:     true,
-			hookErr:        team.ErrTeamMemberNotFound,
-			expectHookCall: true,
+			name:       "Mode3 skips the hook when the redirect removed the member",
+			mode:       grafanarest.Mode3,
+			permission: "",
+			k8sRemoved: true,
+			// hookErr would be returned if the hook ran; it must not, so no error surfaces.
+			hookErr: team.ErrTeamMemberNotFound,
 		},
 		{
 			name:           "Mode3 surfaces not-found when the redirect removed nothing",
@@ -1143,7 +1145,8 @@ func TestIntegrationService_SetUserPermissionForTeams_RedirectWrites(t *testing.
 
 // TestIntegrationService_SetPermissionsForTeams_RedirectWrites is the batch
 // counterpart of TestIntegrationService_SetUserPermissionForTeams_RedirectWrites:
-// every user command is reconciled through the K8s write individually.
+// the whole batch is reconciled through a single atomic K8s write, and the legacy
+// membership hook is skipped only when that write removed a member.
 func TestIntegrationService_SetPermissionsForTeams_RedirectWrites(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 
@@ -1160,7 +1163,7 @@ func TestIntegrationService_SetPermissionsForTeams_RedirectWrites(t *testing.T) 
 		expectHookCall bool
 	}{
 		{
-			name:       "Mode5 reconciles each user command via k8s only",
+			name:       "Mode5 reconciles the batch via k8s only",
 			mode:       grafanarest.Mode5,
 			permission: "Member",
 		},
@@ -1172,24 +1175,30 @@ func TestIntegrationService_SetPermissionsForTeams_RedirectWrites(t *testing.T) 
 			expectErr:  ErrExternalTeamMember,
 		},
 		{
-			name:           "Mode3 falls back to legacy when k8s fails",
+			name:           "Mode3 falls back to legacy when the redirect fails",
 			mode:           grafanarest.Mode3,
 			permission:     "Member",
 			k8sErr:         errK8sUnavailable,
 			expectHookCall: true,
 		},
 		{
-			name:           "Mode3 tolerates members already removed by the redirect",
+			name:           "Mode3 runs the hook when the redirect only added",
 			mode:           grafanarest.Mode3,
-			permission:     "",
-			k8sRemoved:     true,
-			hookErr:        team.ErrTeamMemberNotFound,
+			permission:     "Member",
 			expectHookCall: true,
+		},
+		{
+			name:       "Mode3 skips the hook when the redirect removed members",
+			mode:       grafanarest.Mode3,
+			permission: "",
+			k8sRemoved: true,
+			// hookErr would be returned if the hook ran; it must not, so no error surfaces.
+			hookErr: team.ErrTeamMemberNotFound,
 		},
 	}
 
-	origSetTeamMembership := setTeamMembership
-	t.Cleanup(func() { setTeamMembership = origSetTeamMembership })
+	origSetTeamMemberships := setTeamMemberships
+	t.Cleanup(func() { setTeamMemberships = origSetTeamMemberships })
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1207,7 +1216,7 @@ func TestIntegrationService_SetPermissionsForTeams_RedirectWrites(t *testing.T) 
 			}
 
 			var k8sCalls int
-			setTeamMembership = func(_ *Service, _ context.Context, _ int64, _ string, _ int64, _ string) (bool, error) {
+			setTeamMemberships = func(_ *Service, _ context.Context, _ int64, _ string, _ []accesscontrol.SetResourcePermissionCommand) (bool, error) {
 				k8sCalls++
 				return tt.k8sRemoved, tt.k8sErr
 			}
@@ -1225,12 +1234,11 @@ func TestIntegrationService_SetPermissionsForTeams_RedirectWrites(t *testing.T) 
 			)
 			if tt.expectErr != nil {
 				require.ErrorIs(t, err, tt.expectErr)
-				// external members abort on the first command
-				assert.Equal(t, 1, k8sCalls)
 			} else {
 				require.NoError(t, err)
-				assert.Equal(t, 2, k8sCalls)
 			}
+			// The whole batch is reconciled in a single k8s call regardless of size.
+			assert.Equal(t, 1, k8sCalls)
 			assert.Equal(t, tt.expectHookCall, hookCalled)
 		})
 	}

--- a/pkg/services/accesscontrol/resourcepermissions/service_test.go
+++ b/pkg/services/accesscontrol/resourcepermissions/service_test.go
@@ -11,6 +11,10 @@ import (
 	"github.com/open-feature/go-sdk/openfeature/memprovider"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic"
 
 	iamv0 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
 	"github.com/grafana/grafana/pkg/api/routing"
@@ -1037,60 +1041,85 @@ func TestIntegrationService_SetPermissionsForTeams_Redirect(t *testing.T) {
 	}
 }
 
+// teamObjFor builds the unstructured Team the fake K8s client serves, so the
+// redirect exercises its real read-modify-write against it.
+func teamObjFor(t *testing.T, teamUID string, members ...iamv0.TeamTeamMember) *unstructured.Unstructured {
+	t.Helper()
+	teamObj := iamv0.Team{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: iamv0.TeamResourceInfo.GroupVersion().String(),
+			Kind:       iamv0.TeamResourceInfo.TypeMeta().Kind,
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: teamUID, Namespace: "default", ResourceVersion: "42"},
+		Spec:       iamv0.TeamSpec{Members: members},
+	}
+	obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&teamObj)
+	require.NoError(t, err)
+	return &unstructured.Unstructured{Object: obj}
+}
+
 // TestIntegrationService_SetUserPermissionForTeams_RedirectWrites covers the
-// outcomes of the K8s membership write itself (stubbed): in unified-authoritative
-// modes the K8s result is final and the legacy store is never touched; in
-// dual-write modes a redirect that actually removed the member skips the legacy
-// membership hook (the dual-write already removed team_member, so re-running the
-// hook would fail and roll back the RBAC write), while adds and no-op removals
-// keep the hook so a genuinely-absent member still surfaces the not-found error.
+// outcomes of the K8s membership write itself: in unified-authoritative modes the
+// K8s result is final and the legacy store is never touched; in dual-write modes a
+// redirect that actually removed the member skips the legacy membership hook (the
+// dual-write already removed team_member, so re-running the hook would fail and roll
+// back the RBAC write), while adds and no-op removals keep the hook so a
+// genuinely-absent member still surfaces the not-found error.
 func TestIntegrationService_SetUserPermissionForTeams_RedirectWrites(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 
 	errK8sUnavailable := errors.New("k8s api unavailable")
 
 	tests := []struct {
-		name           string
-		mode           grafanarest.DualWriterMode
-		permission     string
-		k8sRemoved     bool
-		k8sErr         error
+		name string
+		mode grafanarest.DualWriterMode
+		// permission is the membership written; "" removes it.
+		permission string
+		// initialMembers seeds Team.Spec.Members. The placeholder UID "user" is
+		// replaced with the created user's real UID.
+		initialMembers []iamv0.TeamTeamMember
+		updateErr      error
 		hookErr        error
 		expectErr      error
 		expectHookCall bool
+		expectUpdate   bool
 	}{
 		{
-			name:       "Mode5 writes to k8s only",
-			mode:       grafanarest.Mode5,
-			permission: "Member",
+			name:         "Mode5 writes to k8s only",
+			mode:         grafanarest.Mode5,
+			permission:   "Member",
+			expectUpdate: true,
 		},
 		{
-			name:       "Mode5 surfaces k8s errors",
-			mode:       grafanarest.Mode5,
-			permission: "Member",
-			k8sErr:     errK8sUnavailable,
-			expectErr:  errK8sUnavailable,
+			name:         "Mode5 surfaces k8s errors",
+			mode:         grafanarest.Mode5,
+			permission:   "Member",
+			updateErr:    errK8sUnavailable,
+			expectErr:    errK8sUnavailable,
+			expectUpdate: true,
 		},
 		{
-			name:       "externally-synced members are never mutated",
-			mode:       grafanarest.Mode3,
-			permission: "Member",
-			k8sErr:     ErrExternalTeamMember.Errorf("user %q is externally-synced", "test"),
-			expectErr:  ErrExternalTeamMember,
+			name:           "externally-synced members are never mutated",
+			mode:           grafanarest.Mode3,
+			permission:     "Member",
+			initialMembers: []iamv0.TeamTeamMember{{Kind: "User", Name: "user", Permission: iamv0.TeamTeamPermissionMember, External: true}},
+			expectErr:      ErrExternalTeamMember,
 		},
 		{
 			name:           "Mode3 dual-writes to legacy after k8s",
 			mode:           grafanarest.Mode3,
 			permission:     "Member",
 			expectHookCall: true,
+			expectUpdate:   true,
 		},
 		{
-			name:       "Mode3 skips the hook when the redirect removed the member",
-			mode:       grafanarest.Mode3,
-			permission: "",
-			k8sRemoved: true,
+			name:           "Mode3 skips the hook when the redirect removed the member",
+			mode:           grafanarest.Mode3,
+			permission:     "",
+			initialMembers: []iamv0.TeamTeamMember{{Kind: "User", Name: "user", Permission: iamv0.TeamTeamPermissionMember}},
 			// hookErr would be returned if the hook ran; it must not, so no error surfaces.
-			hookErr: team.ErrTeamMemberNotFound,
+			hookErr:      team.ErrTeamMemberNotFound,
+			expectUpdate: true,
 		},
 		{
 			name:           "Mode3 surfaces not-found when the redirect removed nothing",
@@ -1102,9 +1131,6 @@ func TestIntegrationService_SetUserPermissionForTeams_RedirectWrites(t *testing.
 		},
 	}
 
-	origSetTeamMembership := setTeamMembership
-	t.Cleanup(func() { setTeamMembership = origSetTeamMembership })
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			setOpenFeatureFlag(t, featuremgmt.FlagKubernetesTeamsRedirect, true)
@@ -1118,12 +1144,6 @@ func TestIntegrationService_SetUserPermissionForTeams_RedirectWrites(t *testing.
 			service.options.OnSetUser = func(_ *db.Session, _ int64, _ accesscontrol.User, _, _ string) error {
 				hookCalled = true
 				return tt.hookErr
-			}
-
-			var k8sCalls int
-			setTeamMembership = func(_ *Service, _ context.Context, _ int64, _ string, _ int64, _ string) (bool, error) {
-				k8sCalls++
-				return tt.k8sRemoved, tt.k8sErr
 			}
 
 			createdUser, err := usrSvc.Create(context.Background(), &user.CreateUserCommand{Login: "test", OrgID: 1})
@@ -1131,14 +1151,123 @@ func TestIntegrationService_SetUserPermissionForTeams_RedirectWrites(t *testing.
 			createdTeam, err := teamSvc.CreateTeam(context.Background(), &team.CreateTeamCommand{Name: "test", Email: "test@test.com", OrgID: 1})
 			require.NoError(t, err)
 
+			members := make([]iamv0.TeamTeamMember, 0, len(tt.initialMembers))
+			for _, m := range tt.initialMembers {
+				if m.Name == "user" {
+					m.Name = createdUser.UID
+				}
+				members = append(members, m)
+			}
+
+			var updateCalls int
+			fr := &fakeResourceInterface{
+				getFunc: func(_ context.Context, _ string, _ metav1.GetOptions, _ ...string) (*unstructured.Unstructured, error) {
+					return teamObjFor(t, createdTeam.UID, members...), nil
+				},
+				updateFunc: func(_ context.Context, obj *unstructured.Unstructured, _ metav1.UpdateOptions, _ ...string) (*unstructured.Unstructured, error) {
+					updateCalls++
+					if tt.updateErr != nil {
+						return nil, tt.updateErr
+					}
+					return obj, nil
+				},
+			}
+			service.dynamicClient = func(_ context.Context) (dynamic.Interface, error) {
+				return &fakeDynamicClient{resourceInterface: fr}, nil
+			}
+
 			_, err = service.SetUserPermission(context.Background(), 1, accesscontrol.User{ID: createdUser.ID}, strconv.FormatInt(createdTeam.ID, 10), tt.permission)
 			if tt.expectErr != nil {
 				require.ErrorIs(t, err, tt.expectErr)
 			} else {
 				require.NoError(t, err)
 			}
-			assert.Equal(t, 1, k8sCalls)
 			assert.Equal(t, tt.expectHookCall, hookCalled)
+			if tt.expectUpdate {
+				assert.NotZero(t, updateCalls, "expected a k8s Update")
+			} else {
+				assert.Zero(t, updateCalls, "expected no k8s Update")
+			}
+		})
+	}
+}
+
+// TestIntegrationService_SetUserPermissionForTeams_RedirectExternal covers the
+// team-sync caller: it owns externally-synced members, so its writes must be marked
+// External and must not be rejected by the guard that stops every other caller from
+// mutating them.
+func TestIntegrationService_SetUserPermissionForTeams_RedirectExternal(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	tests := []struct {
+		name            string
+		permission      string
+		seedExternal    bool
+		validateMembers func(t *testing.T, members []iamv0.TeamTeamMember)
+	}{
+		{
+			name:       "team sync adds an external member",
+			permission: "Member",
+			validateMembers: func(t *testing.T, members []iamv0.TeamTeamMember) {
+				require.Len(t, members, 1)
+				assert.True(t, members[0].External, "team sync adds must be marked External")
+			},
+		},
+		{
+			name:         "team sync removes an external member",
+			permission:   "",
+			seedExternal: true,
+			validateMembers: func(t *testing.T, members []iamv0.TeamTeamMember) {
+				assert.Empty(t, members)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setOpenFeatureFlag(t, featuremgmt.FlagKubernetesTeamsRedirect, true)
+
+			service, usrSvc, teamSvc, cfg := setupTestEnvironmentWithCfg(t, testOptionsForTeams, featuremgmt.WithFeatures())
+			cfg.UnifiedStorage = map[string]setting.UnifiedStorageConfig{
+				iamv0.TeamResourceInfo.GroupResource().String(): {DualWriterMode: grafanarest.Mode5},
+			}
+
+			createdUser, err := usrSvc.Create(context.Background(), &user.CreateUserCommand{Login: "test", OrgID: 1})
+			require.NoError(t, err)
+			createdTeam, err := teamSvc.CreateTeam(context.Background(), &team.CreateTeamCommand{Name: "test", Email: "test@test.com", OrgID: 1})
+			require.NoError(t, err)
+
+			var members []iamv0.TeamTeamMember
+			if tt.seedExternal {
+				members = []iamv0.TeamTeamMember{
+					{Kind: "User", Name: createdUser.UID, Permission: iamv0.TeamTeamPermissionMember, External: true},
+				}
+			}
+
+			var lastUpdated *unstructured.Unstructured
+			fr := &fakeResourceInterface{
+				getFunc: func(_ context.Context, _ string, _ metav1.GetOptions, _ ...string) (*unstructured.Unstructured, error) {
+					return teamObjFor(t, createdTeam.UID, members...), nil
+				},
+				updateFunc: func(_ context.Context, obj *unstructured.Unstructured, _ metav1.UpdateOptions, _ ...string) (*unstructured.Unstructured, error) {
+					lastUpdated = obj
+					return obj, nil
+				},
+			}
+			service.dynamicClient = func(_ context.Context) (dynamic.Interface, error) {
+				return &fakeDynamicClient{resourceInterface: fr}, nil
+			}
+
+			// IsExternal marks the caller as team-sync.
+			_, err = service.SetUserPermission(context.Background(), 1,
+				accesscontrol.User{ID: createdUser.ID, IsExternal: true},
+				strconv.FormatInt(createdTeam.ID, 10), tt.permission)
+			require.NoError(t, err)
+
+			require.NotNil(t, lastUpdated, "expected a k8s Update")
+			var updated iamv0.Team
+			require.NoError(t, runtime.DefaultUnstructuredConverter.FromUnstructured(lastUpdated.Object, &updated))
+			tt.validateMembers(t, updated.Spec.Members)
 		})
 	}
 }
@@ -1146,59 +1275,97 @@ func TestIntegrationService_SetUserPermissionForTeams_RedirectWrites(t *testing.
 // TestIntegrationService_SetPermissionsForTeams_RedirectWrites is the batch
 // counterpart of TestIntegrationService_SetUserPermissionForTeams_RedirectWrites:
 // the whole batch is reconciled through a single atomic K8s write, and the legacy
-// membership hook is skipped only when that write removed a member.
+// membership hook is skipped when that write removed a member.
 func TestIntegrationService_SetPermissionsForTeams_RedirectWrites(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 
 	errK8sUnavailable := errors.New("k8s api unavailable")
 
-	tests := []struct {
-		name           string
-		mode           grafanarest.DualWriterMode
-		permission     string
-		k8sRemoved     bool
-		k8sErr         error
-		hookErr        error
-		expectErr      error
-		expectHookCall bool
-	}{
-		{
-			name:       "Mode5 reconciles the batch via k8s only",
-			mode:       grafanarest.Mode5,
-			permission: "Member",
-		},
-		{
-			name:       "externally-synced members abort the batch",
-			mode:       grafanarest.Mode3,
-			permission: "Member",
-			k8sErr:     ErrExternalTeamMember.Errorf("user %q is externally-synced", "test"),
-			expectErr:  ErrExternalTeamMember,
-		},
-		{
-			name:           "Mode3 falls back to legacy when the redirect fails",
-			mode:           grafanarest.Mode3,
-			permission:     "Member",
-			k8sErr:         errK8sUnavailable,
-			expectHookCall: true,
-		},
-		{
-			name:           "Mode3 runs the hook when the redirect only added",
-			mode:           grafanarest.Mode3,
-			permission:     "Member",
-			expectHookCall: true,
-		},
-		{
-			name:       "Mode3 skips the hook when the redirect removed members",
-			mode:       grafanarest.Mode3,
-			permission: "",
-			k8sRemoved: true,
-			// hookErr would be returned if the hook ran; it must not, so no error surfaces.
-			hookErr: team.ErrTeamMemberNotFound,
-		},
+	// membership is one command in the batch, keyed by which of the two test users
+	// it targets.
+	type membership struct {
+		second     bool
+		permission string
+		seeded     string // seeded permission in Spec.Members; "" means not a member
 	}
 
-	origSetTeamMemberships := setTeamMemberships
-	t.Cleanup(func() { setTeamMemberships = origSetTeamMemberships })
+	tests := []struct {
+		name string
+		mode grafanarest.DualWriterMode
+		// memberships describes the batch and the state it is applied to.
+		memberships  []membership
+		updateErr    error
+		hookErr      error
+		expectErr    error
+		expectUpdate bool
+		// expectHookCalls is the number of users the legacy membership hook runs for.
+		expectHookCalls int
+	}{
+		{
+			name: "Mode5 reconciles the batch via k8s only",
+			mode: grafanarest.Mode5,
+			memberships: []membership{
+				{permission: "Member"},
+				{second: true, permission: "Admin"},
+			},
+			expectUpdate: true,
+		},
+		{
+			name: "externally-synced members abort the batch",
+			mode: grafanarest.Mode3,
+			memberships: []membership{
+				{permission: "Member"},
+				{second: true, permission: "Member", seeded: "external"},
+			},
+			expectErr: ErrExternalTeamMember,
+		},
+		{
+			name: "Mode3 falls back to legacy when the redirect fails",
+			mode: grafanarest.Mode3,
+			memberships: []membership{
+				{permission: "Member"},
+				{second: true, permission: "Member"},
+			},
+			updateErr:       errK8sUnavailable,
+			expectUpdate:    true,
+			expectHookCalls: 2,
+		},
+		{
+			name: "Mode3 runs the hook when the redirect only added",
+			mode: grafanarest.Mode3,
+			memberships: []membership{
+				{permission: "Member"},
+				{second: true, permission: "Member"},
+			},
+			expectUpdate:    true,
+			expectHookCalls: 2,
+		},
+		{
+			// The redirect's K8s write is all-or-nothing, so one removal in the batch
+			// skips the hook for the whole batch. That is safe: the adds in it already
+			// got their legacy team_member row from the same dual-write.
+			name: "Mode3 skips the hook for the whole batch when the redirect removed a member",
+			mode: grafanarest.Mode3,
+			memberships: []membership{
+				{permission: "", seeded: "Member"},
+				{second: true, permission: "Admin"},
+			},
+			// hookErr would be returned if the hook ran; it must not, so no error surfaces.
+			hookErr:      team.ErrTeamMemberNotFound,
+			expectUpdate: true,
+		},
+		{
+			name: "Mode3 skips the hook when the redirect removed every member",
+			mode: grafanarest.Mode3,
+			memberships: []membership{
+				{permission: "", seeded: "Member"},
+				{second: true, permission: "", seeded: "Member"},
+			},
+			// hookErr would be returned if the hook ran; it must not, so no error surfaces.
+			hookErr:      team.ErrTeamMemberNotFound,
+			expectUpdate: true,
+		},
+	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1209,16 +1376,10 @@ func TestIntegrationService_SetPermissionsForTeams_RedirectWrites(t *testing.T) 
 				iamv0.TeamResourceInfo.GroupResource().String(): {DualWriterMode: tt.mode},
 			}
 
-			var hookCalled bool
-			service.options.OnSetUser = func(_ *db.Session, _ int64, _ accesscontrol.User, _, _ string) error {
-				hookCalled = true
+			hookedUsers := map[int64]bool{}
+			service.options.OnSetUser = func(_ *db.Session, _ int64, u accesscontrol.User, _, _ string) error {
+				hookedUsers[u.ID] = true
 				return tt.hookErr
-			}
-
-			var k8sCalls int
-			setTeamMemberships = func(_ *Service, _ context.Context, _ int64, _ string, _ []accesscontrol.SetResourcePermissionCommand) (bool, error) {
-				k8sCalls++
-				return tt.k8sRemoved, tt.k8sErr
 			}
 
 			firstUser, err := usrSvc.Create(context.Background(), &user.CreateUserCommand{Login: "test1", OrgID: 1})
@@ -1228,18 +1389,55 @@ func TestIntegrationService_SetPermissionsForTeams_RedirectWrites(t *testing.T) 
 			createdTeam, err := teamSvc.CreateTeam(context.Background(), &team.CreateTeamCommand{Name: "test", Email: "test@test.com", OrgID: 1})
 			require.NoError(t, err)
 
-			_, err = service.SetPermissions(context.Background(), 1, strconv.FormatInt(createdTeam.ID, 10),
-				accesscontrol.SetResourcePermissionCommand{UserID: firstUser.ID, Permission: tt.permission},
-				accesscontrol.SetResourcePermissionCommand{UserID: secondUser.ID, Permission: tt.permission},
+			var (
+				members  []iamv0.TeamTeamMember
+				commands []accesscontrol.SetResourcePermissionCommand
 			)
+			for _, m := range tt.memberships {
+				usr := firstUser
+				if m.second {
+					usr = secondUser
+				}
+				commands = append(commands, accesscontrol.SetResourcePermissionCommand{UserID: usr.ID, Permission: m.permission})
+				switch m.seeded {
+				case "":
+				case "external":
+					members = append(members, iamv0.TeamTeamMember{Kind: "User", Name: usr.UID, Permission: iamv0.TeamTeamPermissionMember, External: true})
+				default:
+					members = append(members, iamv0.TeamTeamMember{Kind: "User", Name: usr.UID, Permission: iamv0.TeamTeamPermissionMember})
+				}
+			}
+
+			var updateCalls int
+			fr := &fakeResourceInterface{
+				getFunc: func(_ context.Context, _ string, _ metav1.GetOptions, _ ...string) (*unstructured.Unstructured, error) {
+					return teamObjFor(t, createdTeam.UID, members...), nil
+				},
+				updateFunc: func(_ context.Context, obj *unstructured.Unstructured, _ metav1.UpdateOptions, _ ...string) (*unstructured.Unstructured, error) {
+					updateCalls++
+					if tt.updateErr != nil {
+						return nil, tt.updateErr
+					}
+					return obj, nil
+				},
+			}
+			service.dynamicClient = func(_ context.Context) (dynamic.Interface, error) {
+				return &fakeDynamicClient{resourceInterface: fr}, nil
+			}
+
+			_, err = service.SetPermissions(context.Background(), 1, strconv.FormatInt(createdTeam.ID, 10), commands...)
 			if tt.expectErr != nil {
 				require.ErrorIs(t, err, tt.expectErr)
 			} else {
 				require.NoError(t, err)
 			}
-			// The whole batch is reconciled in a single k8s call regardless of size.
-			assert.Equal(t, 1, k8sCalls)
-			assert.Equal(t, tt.expectHookCall, hookCalled)
+			assert.Len(t, hookedUsers, tt.expectHookCalls)
+			if tt.expectUpdate {
+				// The whole batch is reconciled in a single k8s Update regardless of size.
+				assert.Equal(t, 1, updateCalls, "the batch must be applied in a single update")
+			} else {
+				assert.Zero(t, updateCalls, "expected no k8s Update")
+			}
 		})
 	}
 }

--- a/pkg/services/accesscontrol/resourcepermissions/service_test.go
+++ b/pkg/services/accesscontrol/resourcepermissions/service_test.go
@@ -2,6 +2,8 @@ package resourcepermissions
 
 import (
 	"context"
+	"errors"
+	"strconv"
 	"sync"
 	"testing"
 
@@ -10,13 +12,16 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	iamv0 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
 	"github.com/grafana/grafana/pkg/api/routing"
+	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/actest"
+	"github.com/grafana/grafana/pkg/services/contexthandler/ctxkey"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/licensing/licensingtest"
@@ -920,4 +925,313 @@ func TestIsActionSetEnabledResource_Datasource(t *testing.T) {
 	assert.True(t, isActionSetEnabledResource(datasources.ScopeRoot+":query"))
 	assert.True(t, isActionSetEnabledResource(datasources.ScopeRoot+":edit"))
 	assert.True(t, isActionSetEnabledResource(datasources.ScopeRoot+":admin"))
+}
+
+// TestIntegrationService_SetUserPermissionForTeams_Redirect exercises the teams
+// membership redirect on the service methods directly (not the HTTP handlers) —
+// the path a direct in-process caller takes. When kubernetesTeamsRedirect is on,
+// membership must be written to Team.Spec.Members via the K8s API; in
+// unified-authoritative modes the legacy team_member table has no row, so a K8s
+// failure must surface instead of silently falling back, whereas dual-write modes
+// fall back to legacy.
+func TestIntegrationService_SetUserPermissionForTeams_Redirect(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	tests := []struct {
+		name            string
+		mode            grafanarest.DualWriterMode
+		expectErr       bool
+		expectHookCalls bool // legacy fallback runs the OnSetUser hook; the k8s path does not
+	}{
+		{name: "Mode3 falls back to legacy", mode: grafanarest.Mode3, expectErr: false, expectHookCalls: true},
+		{name: "Mode5 does not fall back", mode: grafanarest.Mode5, expectErr: true, expectHookCalls: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// The teams redirect is gated on the kubernetesTeamsRedirect toggle.
+			setOpenFeatureFlag(t, featuremgmt.FlagKubernetesTeamsRedirect, true)
+
+			service, usrSvc, teamSvc, cfg := setupTestEnvironmentWithCfg(t, testOptionsForTeams, featuremgmt.WithFeatures())
+			cfg.UnifiedStorage = map[string]setting.UnifiedStorageConfig{
+				iamv0.TeamResourceInfo.GroupResource().String(): {DualWriterMode: tt.mode},
+			}
+
+			var hookCalled bool
+			service.options.OnSetUser = func(_ *db.Session, _ int64, _ accesscontrol.User, _, _ string) error {
+				hookCalled = true
+				return nil
+			}
+
+			createdUser, err := usrSvc.Create(context.Background(), &user.CreateUserCommand{Login: "test", OrgID: 1})
+			require.NoError(t, err)
+			createdTeam, err := teamSvc.CreateTeam(context.Background(), &team.CreateTeamCommand{Name: "test", Email: "test@test.com", OrgID: 1})
+			require.NoError(t, err)
+
+			// The redirect builds its K8s client from the ReqContext the contexthandler
+			// middleware stores on ctx (as an in-process request carries). No rest config
+			// provider is wired in the test, so the K8s write fails with
+			// ErrRestConfigNotAvailable — which is exactly what distinguishes the two modes.
+			ctx := ctxkey.Set(context.Background(), makeReqCtx())
+
+			_, err = service.SetUserPermission(ctx, 1, accesscontrol.User{ID: createdUser.ID}, strconv.FormatInt(createdTeam.ID, 10), "Member")
+			if tt.expectErr {
+				require.ErrorIs(t, err, ErrRestConfigNotAvailable)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.expectHookCalls, hookCalled)
+		})
+	}
+}
+
+// TestIntegrationService_SetPermissionsForTeams_Redirect is the batch counterpart
+// of TestIntegrationService_SetUserPermissionForTeams_Redirect — a bulk membership
+// reconcile goes through SetPermissions.
+func TestIntegrationService_SetPermissionsForTeams_Redirect(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	tests := []struct {
+		name            string
+		mode            grafanarest.DualWriterMode
+		expectErr       bool
+		expectHookCalls bool
+	}{
+		{name: "Mode3 falls back to legacy", mode: grafanarest.Mode3, expectErr: false, expectHookCalls: true},
+		{name: "Mode5 does not fall back", mode: grafanarest.Mode5, expectErr: true, expectHookCalls: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setOpenFeatureFlag(t, featuremgmt.FlagKubernetesTeamsRedirect, true)
+
+			service, usrSvc, teamSvc, cfg := setupTestEnvironmentWithCfg(t, testOptionsForTeams, featuremgmt.WithFeatures())
+			cfg.UnifiedStorage = map[string]setting.UnifiedStorageConfig{
+				iamv0.TeamResourceInfo.GroupResource().String(): {DualWriterMode: tt.mode},
+			}
+
+			var hookCalled bool
+			service.options.OnSetUser = func(_ *db.Session, _ int64, _ accesscontrol.User, _, _ string) error {
+				hookCalled = true
+				return nil
+			}
+
+			createdUser, err := usrSvc.Create(context.Background(), &user.CreateUserCommand{Login: "test", OrgID: 1})
+			require.NoError(t, err)
+			createdTeam, err := teamSvc.CreateTeam(context.Background(), &team.CreateTeamCommand{Name: "test", Email: "test@test.com", OrgID: 1})
+			require.NoError(t, err)
+
+			ctx := ctxkey.Set(context.Background(), makeReqCtx())
+
+			_, err = service.SetPermissions(ctx, 1, strconv.FormatInt(createdTeam.ID, 10), accesscontrol.SetResourcePermissionCommand{
+				UserID:     createdUser.ID,
+				Permission: "Member",
+			})
+			if tt.expectErr {
+				require.ErrorIs(t, err, ErrRestConfigNotAvailable)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.expectHookCalls, hookCalled)
+		})
+	}
+}
+
+// TestIntegrationService_SetUserPermissionForTeams_RedirectWrites covers the
+// outcomes of the K8s membership write itself (stubbed): in unified-authoritative
+// modes the K8s result is final and the legacy store is never touched, while in
+// dual-write modes the legacy write still runs — including the case where the
+// redirect already removed the member so the legacy removal finds nothing.
+func TestIntegrationService_SetUserPermissionForTeams_RedirectWrites(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	errK8sUnavailable := errors.New("k8s api unavailable")
+
+	tests := []struct {
+		name           string
+		mode           grafanarest.DualWriterMode
+		permission     string
+		k8sRemoved     bool
+		k8sErr         error
+		hookErr        error
+		expectErr      error
+		expectHookCall bool
+	}{
+		{
+			name:       "Mode5 writes to k8s only",
+			mode:       grafanarest.Mode5,
+			permission: "Member",
+		},
+		{
+			name:       "Mode5 surfaces k8s errors",
+			mode:       grafanarest.Mode5,
+			permission: "Member",
+			k8sErr:     errK8sUnavailable,
+			expectErr:  errK8sUnavailable,
+		},
+		{
+			name:       "externally-synced members are never mutated",
+			mode:       grafanarest.Mode3,
+			permission: "Member",
+			k8sErr:     ErrExternalTeamMember.Errorf("user %q is externally-synced", "test"),
+			expectErr:  ErrExternalTeamMember,
+		},
+		{
+			name:           "Mode3 dual-writes to legacy after k8s",
+			mode:           grafanarest.Mode3,
+			permission:     "Member",
+			expectHookCall: true,
+		},
+		{
+			name:           "Mode3 tolerates a member already removed by the redirect",
+			mode:           grafanarest.Mode3,
+			permission:     "",
+			k8sRemoved:     true,
+			hookErr:        team.ErrTeamMemberNotFound,
+			expectHookCall: true,
+		},
+		{
+			name:           "Mode3 surfaces not-found when the redirect removed nothing",
+			mode:           grafanarest.Mode3,
+			permission:     "",
+			hookErr:        team.ErrTeamMemberNotFound,
+			expectErr:      team.ErrTeamMemberNotFound,
+			expectHookCall: true,
+		},
+	}
+
+	origSetTeamMembership := setTeamMembership
+	t.Cleanup(func() { setTeamMembership = origSetTeamMembership })
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setOpenFeatureFlag(t, featuremgmt.FlagKubernetesTeamsRedirect, true)
+
+			service, usrSvc, teamSvc, cfg := setupTestEnvironmentWithCfg(t, testOptionsForTeams, featuremgmt.WithFeatures())
+			cfg.UnifiedStorage = map[string]setting.UnifiedStorageConfig{
+				iamv0.TeamResourceInfo.GroupResource().String(): {DualWriterMode: tt.mode},
+			}
+
+			var hookCalled bool
+			service.options.OnSetUser = func(_ *db.Session, _ int64, _ accesscontrol.User, _, _ string) error {
+				hookCalled = true
+				return tt.hookErr
+			}
+
+			var k8sCalls int
+			setTeamMembership = func(_ *Service, _ context.Context, _ int64, _ string, _ int64, _ string) (bool, error) {
+				k8sCalls++
+				return tt.k8sRemoved, tt.k8sErr
+			}
+
+			createdUser, err := usrSvc.Create(context.Background(), &user.CreateUserCommand{Login: "test", OrgID: 1})
+			require.NoError(t, err)
+			createdTeam, err := teamSvc.CreateTeam(context.Background(), &team.CreateTeamCommand{Name: "test", Email: "test@test.com", OrgID: 1})
+			require.NoError(t, err)
+
+			_, err = service.SetUserPermission(context.Background(), 1, accesscontrol.User{ID: createdUser.ID}, strconv.FormatInt(createdTeam.ID, 10), tt.permission)
+			if tt.expectErr != nil {
+				require.ErrorIs(t, err, tt.expectErr)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, 1, k8sCalls)
+			assert.Equal(t, tt.expectHookCall, hookCalled)
+		})
+	}
+}
+
+// TestIntegrationService_SetPermissionsForTeams_RedirectWrites is the batch
+// counterpart of TestIntegrationService_SetUserPermissionForTeams_RedirectWrites:
+// every user command is reconciled through the K8s write individually.
+func TestIntegrationService_SetPermissionsForTeams_RedirectWrites(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	errK8sUnavailable := errors.New("k8s api unavailable")
+
+	tests := []struct {
+		name           string
+		mode           grafanarest.DualWriterMode
+		permission     string
+		k8sRemoved     bool
+		k8sErr         error
+		hookErr        error
+		expectErr      error
+		expectHookCall bool
+	}{
+		{
+			name:       "Mode5 reconciles each user command via k8s only",
+			mode:       grafanarest.Mode5,
+			permission: "Member",
+		},
+		{
+			name:       "externally-synced members abort the batch",
+			mode:       grafanarest.Mode3,
+			permission: "Member",
+			k8sErr:     ErrExternalTeamMember.Errorf("user %q is externally-synced", "test"),
+			expectErr:  ErrExternalTeamMember,
+		},
+		{
+			name:           "Mode3 falls back to legacy when k8s fails",
+			mode:           grafanarest.Mode3,
+			permission:     "Member",
+			k8sErr:         errK8sUnavailable,
+			expectHookCall: true,
+		},
+		{
+			name:           "Mode3 tolerates members already removed by the redirect",
+			mode:           grafanarest.Mode3,
+			permission:     "",
+			k8sRemoved:     true,
+			hookErr:        team.ErrTeamMemberNotFound,
+			expectHookCall: true,
+		},
+	}
+
+	origSetTeamMembership := setTeamMembership
+	t.Cleanup(func() { setTeamMembership = origSetTeamMembership })
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setOpenFeatureFlag(t, featuremgmt.FlagKubernetesTeamsRedirect, true)
+
+			service, usrSvc, teamSvc, cfg := setupTestEnvironmentWithCfg(t, testOptionsForTeams, featuremgmt.WithFeatures())
+			cfg.UnifiedStorage = map[string]setting.UnifiedStorageConfig{
+				iamv0.TeamResourceInfo.GroupResource().String(): {DualWriterMode: tt.mode},
+			}
+
+			var hookCalled bool
+			service.options.OnSetUser = func(_ *db.Session, _ int64, _ accesscontrol.User, _, _ string) error {
+				hookCalled = true
+				return tt.hookErr
+			}
+
+			var k8sCalls int
+			setTeamMembership = func(_ *Service, _ context.Context, _ int64, _ string, _ int64, _ string) (bool, error) {
+				k8sCalls++
+				return tt.k8sRemoved, tt.k8sErr
+			}
+
+			firstUser, err := usrSvc.Create(context.Background(), &user.CreateUserCommand{Login: "test1", OrgID: 1})
+			require.NoError(t, err)
+			secondUser, err := usrSvc.Create(context.Background(), &user.CreateUserCommand{Login: "test2", OrgID: 1})
+			require.NoError(t, err)
+			createdTeam, err := teamSvc.CreateTeam(context.Background(), &team.CreateTeamCommand{Name: "test", Email: "test@test.com", OrgID: 1})
+			require.NoError(t, err)
+
+			_, err = service.SetPermissions(context.Background(), 1, strconv.FormatInt(createdTeam.ID, 10),
+				accesscontrol.SetResourcePermissionCommand{UserID: firstUser.ID, Permission: tt.permission},
+				accesscontrol.SetResourcePermissionCommand{UserID: secondUser.ID, Permission: tt.permission},
+			)
+			if tt.expectErr != nil {
+				require.ErrorIs(t, err, tt.expectErr)
+				// external members abort on the first command
+				assert.Equal(t, 1, k8sCalls)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, 2, k8sCalls)
+			}
+			assert.Equal(t, tt.expectHookCall, hookCalled)
+		})
+	}
 }

--- a/pkg/services/team/teamapi/team_members.go
+++ b/pkg/services/team/teamapi/team_members.go
@@ -151,7 +151,7 @@ func (tapi *TeamAPI) updateTeamMember(c *contextmodel.ReqContext) response.Respo
 
 	err = addOrUpdateTeamMember(c.Req.Context(), tapi.teamPermissionsService, userId, orgId, teamId, cmd.Permission.String())
 	if err != nil {
-		return response.Error(http.StatusInternalServerError, "Failed to update team member.", err)
+		return response.ErrOrFallback(http.StatusInternalServerError, "Failed to update team member.", err)
 	}
 	return response.Success("Team member updated")
 }
@@ -333,7 +333,7 @@ func (tapi *TeamAPI) removeTeamMember(c *contextmodel.ReqContext) response.Respo
 			return response.Error(http.StatusNotFound, "Team member not found", nil)
 		}
 
-		return response.Error(http.StatusInternalServerError, "Failed to remove Member from Team", err)
+		return response.ErrOrFallback(http.StatusInternalServerError, "Failed to remove Member from Team", err)
 	}
 	return response.Success("Team Member removed")
 }

--- a/pkg/tests/apis/helper.go
+++ b/pkg/tests/apis/helper.go
@@ -45,7 +45,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/ossaccesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/resourcepermissions"
-	"github.com/grafana/grafana/pkg/services/apiserver"
 	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
 	"github.com/grafana/grafana/pkg/services/apiserver/options"
 	"github.com/grafana/grafana/pkg/services/datasources"
@@ -968,26 +967,28 @@ func (c *K8sTestHelper) SetPermissions(user User, permissions []resourcepermissi
 }
 
 func (c *K8sTestHelper) AddOrUpdateTeamMember(user User, teamID int64, permission team.PermissionType) {
-	teampermissionSvc, err := ossaccesscontrol.ProvideTeamPermissions(
-		c.env.Cfg,
-		c.env.FeatureToggles,
-		c.env.Server.HTTPServer.RouteRegister,
-		c.env.SQLStore,
-		c.env.Server.HTTPServer.AccessControl,
-		c.env.Server.HTTPServer.License,
-		c.env.Server.HTTPServer.AlertNG.AccesscontrolService,
-		c.teamSvc,
-		c.userSvc,
-		resourcepermissions.NewActionSetService(),
-		apiserver.ProvideDirectRestConfigProvider(),
-	)
-	require.NoError(c.t, err)
+	c.t.Helper()
 
 	id, err := user.Identity.GetInternalID()
 	require.NoError(c.t, err)
 
-	teamIDString := strconv.FormatInt(teamID, 10)
-	_, err = teampermissionSvc.SetUserPermission(context.Background(), user.Identity.GetOrgID(), accesscontrol.User{ID: id}, teamIDString, permission.String())
+	actions := ossaccesscontrol.TeamMemberActions
+	if permission == team.PermissionTypeAdmin {
+		actions = ossaccesscontrol.TeamAdminActions
+	}
+
+	// The helper's seeded teams exist only in legacy SQL, so add membership through
+	// the legacy store instead of the redirect-aware TeamPermissionsService.
+	store := resourcepermissions.NewStore(c.env.Cfg, c.env.SQLStore, c.env.FeatureToggles)
+	_, err = store.SetUserResourcePermission(context.Background(), user.Identity.GetOrgID(), accesscontrol.User{ID: id}, resourcepermissions.SetResourcePermissionCommand{
+		Actions:           actions,
+		Permission:        permission.String(),
+		Resource:          "teams",
+		ResourceID:        strconv.FormatInt(teamID, 10),
+		ResourceAttribute: "id",
+	}, func(session *db.Session, orgID int64, u accesscontrol.User, _, _ string) error {
+		return teamimpl.AddOrUpdateTeamMemberHook(session, u.ID, orgID, teamID, false, permission)
+	})
 	require.NoError(c.t, err)
 }
 

--- a/pkg/tests/apis/helper.go
+++ b/pkg/tests/apis/helper.go
@@ -977,6 +977,9 @@ func (c *K8sTestHelper) AddOrUpdateTeamMember(user User, teamID int64, permissio
 		actions = ossaccesscontrol.TeamAdminActions
 	}
 
+	dbHelper, err := legacysql.NewDatabaseProvider(c.env.SQLStore)(context.Background())
+	require.NoError(c.t, err)
+
 	// The helper's seeded teams exist only in legacy SQL, so add membership through
 	// the legacy store instead of the redirect-aware TeamPermissionsService.
 	store := resourcepermissions.NewStore(c.env.Cfg, c.env.SQLStore, c.env.FeatureToggles)
@@ -987,7 +990,7 @@ func (c *K8sTestHelper) AddOrUpdateTeamMember(user User, teamID int64, permissio
 		ResourceID:        strconv.FormatInt(teamID, 10),
 		ResourceAttribute: "id",
 	}, func(session *db.Session, orgID int64, u accesscontrol.User, _, _ string) error {
-		return teamimpl.AddOrUpdateTeamMemberHook(session, u.ID, orgID, teamID, false, permission)
+		return teamimpl.AddOrUpdateTeamMemberHook(dbHelper, session, u.ID, orgID, teamID, false, permission)
 	})
 	require.NoError(c.t, err)
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Team membership writes that go through the permissions service directly  (enterprise features and the team-members API add/remove) now work when teams live only in unified storage (`dualWriterMode=5`). Previously every such operation returned `500` with `"team not found"`.

The teams membership redirect (write to `Team.Spec.Members` via the K8s API instead of the legacy `team_member` table) only existed in the HTTP handler (`api.setUserPermission`). Callers that invoke the service in-process never hit that handler, so their writes went to the legacy store, which has no team row in Mode5. This PR adds the same redirect to the service methods (`SetUserPermission` / `SetPermissions`), sharing the handler's existing read-modify-write helper rather than duplicating it.

**Why do we need this feature?**

Mode5 is the migration end state for teams, and without this SCIM cannot add, remove, or change group members at all post-migration.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Closes https://github.com/grafana/identity-access-team/issues/2194

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
