### PR TITLE
Alerting: Add Import tab in alerting settings page

### DIFF
--- a/public/app/features/alerting/routes.tsx
+++ b/public/app/features/alerting/routes.tsx
@@ -412,6 +412,18 @@ export function getAlertingRoutes(cfg = config): RouteDescriptor[] {
         () => import(/* webpackChunkName: "AlertingSettings" */ 'app/features/alerting/unified/Settings')
       ),
     },
+    {
+      path: '/alerting/admin/import',
+      roles: () => ['Admin'],
+      component: cfg.featureToggles.alertingMigrationWizardUI
+        ? importAlertingComponent(
+            () =>
+              import(
+                /* webpackChunkName: "AlertingImportSettings" */ 'app/features/alerting/unified/settings/import/ImportSettingsPage'
+              )
+          )
+        : () => <Navigate replace to="/alerting/admin/alertmanager" />,
+    },
   ];
 
   if (cfg.featureToggles.alertingTriage) {

--- a/public/app/features/alerting/unified/Settings.test.tsx
+++ b/public/app/features/alerting/unified/Settings.test.tsx
@@ -1,5 +1,5 @@
 import { screen, waitFor, within } from '@testing-library/react';
-import { render, testWithFeatureToggles } from 'test/test-utils';
+import { render } from 'test/test-utils';
 import { byRole, byTestId, byText } from 'testing-library-selector';
 
 import SettingsPage from './Settings';
@@ -8,7 +8,6 @@ import { setupGrafanaManagedServer, withExternalOnlySetting } from './components
 import { setupMswServer } from './mockApi';
 import { grantUserRole } from './mocks';
 import { addSettingsSection } from './settings/extensions';
-import { setupDataSources } from './testSetup/datasources';
 
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
@@ -20,7 +19,6 @@ const server = setupMswServer();
 const ui = {
   builtInAlertmanagerSection: byText('Built-in Alertmanager'),
   otherAlertmanagerSection: byText('Other Alertmanagers'),
-  autoSyncCard: byRole('region', { name: /auto-sync configuration/i }),
 
   alertmanagerCard: (name: string) => byTestId(`alertmanager-card-${name}`),
   builtInAlertmanagerCard: byTestId('alertmanager-card-Grafana built-in'),
@@ -260,32 +258,5 @@ describe('Alerting settings', () => {
     expect(ui.alertmanagerTab.get()).toBeInTheDocument();
     expect(ui.enrichmentTab.query()).not.toBeInTheDocument();
     expect(ui.notificationsTab.query()).not.toBeInTheDocument();
-  });
-
-  it('should not render the auto-sync configuration card when the feature flag is off', async () => {
-    render(<SettingsPage />);
-
-    await waitFor(() => expect(ui.builtInAlertmanagerSection.get()).toBeInTheDocument());
-    expect(ui.autoSyncCard.query()).not.toBeInTheDocument();
-  });
-
-  describe('with alerting.syncExternalAlertmanager feature flag enabled', () => {
-    testWithFeatureToggles({ enable: ['alerting.syncExternalAlertmanager'] });
-
-    it('renders the auto-sync configuration card above the Built-in Alertmanager section', async () => {
-      // DataSourcePicker reads from getDataSourceSrv(); initialise it (empty list is fine here).
-      setupDataSources();
-      render(<SettingsPage />);
-
-      await waitFor(() => expect(ui.builtInAlertmanagerSection.get()).toBeInTheDocument());
-
-      const card = await ui.autoSyncCard.find();
-      expect(card).toBeInTheDocument();
-
-      // The card should precede the Built-in Alertmanager heading in document order.
-      const builtInHeading = ui.builtInAlertmanagerSection.get();
-      // eslint-disable-next-line no-bitwise
-      expect(card.compareDocumentPosition(builtInHeading) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-    });
   });
 });

--- a/public/app/features/alerting/unified/Settings.tsx
+++ b/public/app/features/alerting/unified/Settings.tsx
@@ -1,10 +1,8 @@
 import { Trans, t } from '@grafana/i18n';
-import { config } from '@grafana/runtime';
 import { LinkButton, Stack, Text } from '@grafana/ui';
 
 import { AlertingPageWrapper } from './components/AlertingPageWrapper';
 import { WithReturnButton } from './components/WithReturnButton';
-import { AutoSyncConfiguration } from './components/settings/AutoSyncConfiguration';
 import { useEditConfigurationDrawer } from './components/settings/ConfigurationDrawer';
 import { ExternalAlertmanagers } from './components/settings/ExternalAlertmanagers';
 import InternalAlertmanager from './components/settings/InternalAlertmanager';
@@ -23,7 +21,6 @@ function AlertmanagerSettingsPage() {
 function AlertmanagerSettingsContent() {
   const [configurationDrawer, showConfiguration] = useEditConfigurationDrawer();
   const { isLoading } = useSettings();
-  const isAutoSyncEnabled = config.featureToggles['alerting.syncExternalAlertmanager'];
 
   const { navId, pageNav } = useSettingsPageNav();
 
@@ -45,7 +42,6 @@ function AlertmanagerSettingsContent() {
       ]}
     >
       <Stack direction="column" gap={2}>
-        {isAutoSyncEnabled && <AutoSyncConfiguration />}
         {/* Grafana built-in Alertmanager */}
         <Text variant="h5">
           <Trans i18nKey="alerting.settings-content.builtin-alertmanager">Built-in Alertmanager</Trans>

--- a/public/app/features/alerting/unified/components/import-to-gma/ImportToGMA.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/ImportToGMA.tsx
@@ -37,7 +37,7 @@ import {
 import { fetchAlertManagerConfig } from '../../api/alertmanager';
 import { useIsAutoSyncActive } from '../../hooks/useIsAutoSyncActive';
 import { getAlertRulesNavId } from '../../navigation/useAlertRulesNav';
-import { ALERTING_SETTINGS_URL } from '../../settings/navigation';
+import { ALERTING_IMPORT_SETTINGS_URL } from '../../settings/navigation';
 import { type Folder } from '../../types/rule-form';
 import { DOCS_URL_ALERTING_MIGRATION } from '../../utils/docs';
 import { stringifyErrorLike } from '../../utils/misc';
@@ -173,7 +173,7 @@ function AutoSyncActiveBlock() {
             </TextLink>
           )}
           {canManageAutoSync && (
-            <TextLink href={ALERTING_SETTINGS_URL} icon="cog">
+            <TextLink href={ALERTING_IMPORT_SETTINGS_URL} icon="cog">
               {t('alerting.import-to-gma.autosync-active-block.go-to-settings', 'Go to Alerting settings')}
             </TextLink>
           )}

--- a/public/app/features/alerting/unified/settings/import/ImportSettingsPage.test.tsx
+++ b/public/app/features/alerting/unified/settings/import/ImportSettingsPage.test.tsx
@@ -1,0 +1,69 @@
+import { render, testWithFeatureToggles } from 'test/test-utils';
+import { byRole, byText } from 'testing-library-selector';
+
+import { AccessControlAction } from 'app/types/accessControl';
+
+import { setupGrafanaManagedServer } from '../../components/settings/mocks/server';
+import { setupMswServer } from '../../mockApi';
+import { grantUserPermissions, grantUserRole } from '../../mocks';
+import { setupDataSources } from '../../testSetup/datasources';
+
+import ImportSettingsPage from './ImportSettingsPage';
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  useReturnToPrevious: jest.fn(),
+}));
+
+const server = setupMswServer();
+
+const ui = {
+  autoSyncCard: byRole('region', { name: /auto-sync configuration/i }),
+  emptyState: byText(/no configuration imported yet/i),
+  importCta: byRole('link', { name: /import alertmanager configuration/i }),
+  learnMoreLink: byRole('link', { name: /learn more about importing configurations/i }),
+  noPermission: byText(/don't have permission to view imported configurations/i),
+};
+
+describe('Import settings tab', () => {
+  beforeEach(() => {
+    grantUserRole('ServerAdmin');
+    grantUserPermissions([AccessControlAction.AlertingNotificationsExternalRead]);
+    setupGrafanaManagedServer(server);
+    // DataSourcePicker (auto-sync) reads from getDataSourceSrv(); initialise it.
+    setupDataSources();
+  });
+
+  it('shows the empty state with an import CTA and learn-more link when no configuration is staged', async () => {
+    render(<ImportSettingsPage />);
+
+    expect(await ui.emptyState.find()).toBeInTheDocument();
+    expect(ui.importCta.get()).toBeInTheDocument();
+    expect(ui.learnMoreLink.get()).toBeInTheDocument();
+  });
+
+  it('shows a permission notice instead of the empty state when the user cannot view configurations', async () => {
+    grantUserPermissions([]);
+    render(<ImportSettingsPage />);
+
+    expect(await ui.noPermission.find()).toBeInTheDocument();
+    expect(ui.emptyState.query()).not.toBeInTheDocument();
+  });
+
+  it('does not render the relocated auto-sync card when the sync flag is off', async () => {
+    render(<ImportSettingsPage />);
+
+    await ui.emptyState.find();
+    expect(ui.autoSyncCard.query()).not.toBeInTheDocument();
+  });
+
+  describe('with alerting.syncExternalAlertmanager enabled', () => {
+    testWithFeatureToggles({ enable: ['alerting.syncExternalAlertmanager'] });
+
+    it('renders the relocated auto-sync card', async () => {
+      render(<ImportSettingsPage />);
+
+      expect(await ui.autoSyncCard.find()).toBeInTheDocument();
+    });
+  });
+});

--- a/public/app/features/alerting/unified/settings/import/ImportSettingsPage.test.tsx
+++ b/public/app/features/alerting/unified/settings/import/ImportSettingsPage.test.tsx
@@ -22,13 +22,12 @@ const ui = {
   emptyState: byText(/no configuration imported yet/i),
   importCta: byRole('link', { name: /import alertmanager configuration/i }),
   learnMoreLink: byRole('link', { name: /learn more about importing configurations/i }),
-  noPermission: byText(/don't have permission to view imported configurations/i),
 };
 
 describe('Import settings tab', () => {
   beforeEach(() => {
     grantUserRole('ServerAdmin');
-    grantUserPermissions([AccessControlAction.AlertingNotificationsExternalRead]);
+    grantUserPermissions([AccessControlAction.AlertingNotificationsRead]);
     setupGrafanaManagedServer(server);
     // DataSourcePicker (auto-sync) reads from getDataSourceSrv(); initialise it.
     setupDataSources();
@@ -40,14 +39,6 @@ describe('Import settings tab', () => {
     expect(await ui.emptyState.find()).toBeInTheDocument();
     expect(ui.importCta.get()).toBeInTheDocument();
     expect(ui.learnMoreLink.get()).toBeInTheDocument();
-  });
-
-  it('shows a permission notice instead of the empty state when the user cannot view configurations', async () => {
-    grantUserPermissions([]);
-    render(<ImportSettingsPage />);
-
-    expect(await ui.noPermission.find()).toBeInTheDocument();
-    expect(ui.emptyState.query()).not.toBeInTheDocument();
   });
 
   it('does not render the relocated auto-sync card when the sync flag is off', async () => {

--- a/public/app/features/alerting/unified/settings/import/ImportSettingsPage.tsx
+++ b/public/app/features/alerting/unified/settings/import/ImportSettingsPage.tsx
@@ -1,0 +1,150 @@
+import { useEffect } from 'react';
+
+import { Trans, t } from '@grafana/i18n';
+import { config } from '@grafana/runtime';
+import { Alert, Button, EmptyState, LinkButton, LoadingPlaceholder, Stack, Text, TextLink } from '@grafana/ui';
+
+import { logError } from '../../Analytics';
+import { AlertingPageWrapper } from '../../components/AlertingPageWrapper';
+import { WithReturnButton } from '../../components/WithReturnButton';
+import { AutoSyncConfiguration } from '../../components/settings/AutoSyncConfiguration';
+import { AlertmanagerAction, useAlertmanagerAbility } from '../../hooks/useAbilities';
+import { useAlertmanagerConfig } from '../../hooks/useAlertmanagerConfig';
+import { AlertmanagerProvider } from '../../state/AlertmanagerContext';
+import { GRAFANA_RULES_SOURCE_NAME } from '../../utils/datasource';
+import { DOCS_URL_ALERTING_MIGRATION } from '../../utils/docs';
+import { stringifyErrorLike } from '../../utils/misc';
+import { withPageErrorBoundary } from '../../withPageErrorBoundary';
+import { useSettingsPageNav } from '../navigation';
+
+const IMPORT_WIZARD_URL = '/alerting/import-to-gma';
+
+function ImportSettingsPage() {
+  const { navId, pageNav } = useSettingsPageNav();
+
+  return (
+    <AlertingPageWrapper
+      navId={navId}
+      pageNav={pageNav}
+      actions={[
+        <WithReturnButton
+          key="add-alertmanager"
+          title={t('alerting.settings-content.title-alerting-settings', 'Alerting settings')}
+          component={
+            <LinkButton href="/connections/datasources/alertmanager" icon="plus" variant="primary">
+              <Trans i18nKey="alerting.settings-content.add-new-alertmanager">Add new Alertmanager</Trans>
+            </LinkButton>
+          }
+        />,
+      ]}
+    >
+      <AlertmanagerProvider accessType="notification" alertmanagerSourceName={GRAFANA_RULES_SOURCE_NAME}>
+        <ImportSettingsContent />
+      </AlertmanagerProvider>
+    </AlertingPageWrapper>
+  );
+}
+
+function ImportSettingsContent() {
+  const isAutoSyncEnabled = config.featureToggles['alerting.syncExternalAlertmanager'];
+
+  return (
+    <Stack direction="column" gap={2}>
+      {isAutoSyncEnabled && <AutoSyncConfiguration />}
+      <StagedConfigurationSection />
+    </Stack>
+  );
+}
+
+function StagedConfigurationSection() {
+  const [, canView] = useAlertmanagerAbility(AlertmanagerAction.ViewExternalConfiguration);
+  const { data, isLoading, isError, error, refetch } = useAlertmanagerConfig(
+    canView ? GRAFANA_RULES_SOURCE_NAME : undefined
+  );
+
+  useEffect(() => {
+    if (isError) {
+      logError(new Error(stringifyErrorLike(error)));
+    }
+  }, [isError, error]);
+
+  // A user can have at most one staged configuration at a time.
+  const stagedConfig = data?.extra_config?.[0];
+
+  return (
+    <Stack direction="column" gap={1}>
+      <Text variant="h4">
+        <Trans i18nKey="alerting.settings.import.staged-title">Staged configuration</Trans>
+      </Text>
+      <Text variant="bodySmall" color="secondary">
+        <Trans i18nKey="alerting.settings.import.staged-description">
+          A read-only, reversible copy of an imported Alertmanager config. Promote it to merge into your live config, or
+          revert to remove it.
+        </Trans>
+      </Text>
+
+      {!canView ? (
+        <Alert
+          severity="info"
+          title={t(
+            'alerting.settings.import.no-permission-title',
+            "You don't have permission to view imported configurations"
+          )}
+        >
+          <Trans i18nKey="alerting.settings.import.no-permission-body">
+            Contact your administrator to request access to imported Alertmanager configurations.
+          </Trans>
+        </Alert>
+      ) : (
+        <>
+          {isLoading && (
+            <LoadingPlaceholder text={t('alerting.settings.import.loading', 'Loading imported configurations…')} />
+          )}
+
+          {isError && (
+            <Alert
+              severity="error"
+              title={t('alerting.settings.import.error-title', "Couldn't load imported configurations")}
+            >
+              <Stack direction="column" gap={2} alignItems="flex-start">
+                <Trans i18nKey="alerting.settings.import.error-body">
+                  The request to the Alerting API failed. Check your connection and try again.
+                </Trans>
+                <Button variant="secondary" fill="outline" icon="sync" onClick={() => refetch()}>
+                  <Trans i18nKey="alerting.settings.import.error-retry">Retry</Trans>
+                </Button>
+              </Stack>
+            </Alert>
+          )}
+
+          {!isLoading && !isError && !stagedConfig && (
+            <EmptyState
+              variant="call-to-action"
+              message={t('alerting.settings.import.empty-title', 'No configuration imported yet')}
+              button={
+                <LinkButton icon="cloud-upload" size="lg" href={IMPORT_WIZARD_URL}>
+                  <Trans i18nKey="alerting.settings.import.empty-cta">Import Alertmanager configuration</Trans>
+                </LinkButton>
+              }
+            >
+              <Trans i18nKey="alerting.settings.import.empty-body">
+                Import an Alertmanager configuration to stage it here as a safe, reversible copy. Review what it
+                contains, then promote it into your live Grafana Alertmanager when you&apos;re ready.
+              </Trans>{' '}
+              <TextLink href={DOCS_URL_ALERTING_MIGRATION} external>
+                <Trans i18nKey="alerting.settings.import.empty-learn-more">
+                  Learn more about importing configurations
+                </Trans>
+              </TextLink>
+            </EmptyState>
+          )}
+
+          {/* Populated summary + accordion is added in a follow-up. */}
+          {!isLoading && !isError && stagedConfig && <Text variant="body">{stagedConfig.identifier}</Text>}
+        </>
+      )}
+    </Stack>
+  );
+}
+
+export default withPageErrorBoundary(ImportSettingsPage);

--- a/public/app/features/alerting/unified/settings/import/ImportSettingsPage.tsx
+++ b/public/app/features/alerting/unified/settings/import/ImportSettingsPage.tsx
@@ -8,7 +8,6 @@ import { logError } from '../../Analytics';
 import { AlertingPageWrapper } from '../../components/AlertingPageWrapper';
 import { WithReturnButton } from '../../components/WithReturnButton';
 import { AutoSyncConfiguration } from '../../components/settings/AutoSyncConfiguration';
-import { AlertmanagerAction, useAlertmanagerAbility } from '../../hooks/useAbilities';
 import { useAlertmanagerConfig } from '../../hooks/useAlertmanagerConfig';
 import { AlertmanagerProvider } from '../../state/AlertmanagerContext';
 import { GRAFANA_RULES_SOURCE_NAME } from '../../utils/datasource';
@@ -57,10 +56,7 @@ function ImportSettingsContent() {
 }
 
 function StagedConfigurationSection() {
-  const [, canView] = useAlertmanagerAbility(AlertmanagerAction.ViewExternalConfiguration);
-  const { data, isLoading, isError, error, refetch } = useAlertmanagerConfig(
-    canView ? GRAFANA_RULES_SOURCE_NAME : undefined
-  );
+  const { data, isLoading, isError, error, refetch } = useAlertmanagerConfig(GRAFANA_RULES_SOURCE_NAME);
 
   useEffect(() => {
     if (isError) {
@@ -83,66 +79,48 @@ function StagedConfigurationSection() {
         </Trans>
       </Text>
 
-      {!canView ? (
-        <Alert
-          severity="info"
-          title={t(
-            'alerting.settings.import.no-permission-title',
-            "You don't have permission to view imported configurations"
-          )}
-        >
-          <Trans i18nKey="alerting.settings.import.no-permission-body">
-            Contact your administrator to request access to imported Alertmanager configurations.
-          </Trans>
-        </Alert>
-      ) : (
-        <>
-          {isLoading && (
-            <LoadingPlaceholder text={t('alerting.settings.import.loading', 'Loading imported configurations…')} />
-          )}
-
-          {isError && (
-            <Alert
-              severity="error"
-              title={t('alerting.settings.import.error-title', "Couldn't load imported configurations")}
-            >
-              <Stack direction="column" gap={2} alignItems="flex-start">
-                <Trans i18nKey="alerting.settings.import.error-body">
-                  The request to the Alerting API failed. Check your connection and try again.
-                </Trans>
-                <Button variant="secondary" fill="outline" icon="sync" onClick={() => refetch()}>
-                  <Trans i18nKey="alerting.settings.import.error-retry">Retry</Trans>
-                </Button>
-              </Stack>
-            </Alert>
-          )}
-
-          {!isLoading && !isError && !stagedConfig && (
-            <EmptyState
-              variant="call-to-action"
-              message={t('alerting.settings.import.empty-title', 'No configuration imported yet')}
-              button={
-                <LinkButton icon="cloud-upload" size="lg" href={IMPORT_WIZARD_URL}>
-                  <Trans i18nKey="alerting.settings.import.empty-cta">Import Alertmanager configuration</Trans>
-                </LinkButton>
-              }
-            >
-              <Trans i18nKey="alerting.settings.import.empty-body">
-                Import an Alertmanager configuration to stage it here as a safe, reversible copy. Review what it
-                contains, then promote it into your live Grafana Alertmanager when you&apos;re ready.
-              </Trans>{' '}
-              <TextLink href={DOCS_URL_ALERTING_MIGRATION} external>
-                <Trans i18nKey="alerting.settings.import.empty-learn-more">
-                  Learn more about importing configurations
-                </Trans>
-              </TextLink>
-            </EmptyState>
-          )}
-
-          {/* Populated summary + accordion is added in a follow-up. */}
-          {!isLoading && !isError && stagedConfig && <Text variant="body">{stagedConfig.identifier}</Text>}
-        </>
+      {isLoading && (
+        <LoadingPlaceholder text={t('alerting.settings.import.loading', 'Loading imported configurations…')} />
       )}
+
+      {isError && (
+        <Alert
+          severity="error"
+          title={t('alerting.settings.import.error-title', "Couldn't load imported configurations")}
+        >
+          <Stack direction="column" gap={2} alignItems="flex-start">
+            <Trans i18nKey="alerting.settings.import.error-body">
+              The request to the Alerting API failed. Check your connection and try again.
+            </Trans>
+            <Button variant="secondary" fill="outline" icon="sync" onClick={() => refetch()}>
+              <Trans i18nKey="alerting.settings.import.error-retry">Retry</Trans>
+            </Button>
+          </Stack>
+        </Alert>
+      )}
+
+      {!isLoading && !isError && !stagedConfig && (
+        <EmptyState
+          variant="call-to-action"
+          message={t('alerting.settings.import.empty-title', 'No configuration imported yet')}
+          button={
+            <LinkButton icon="cloud-upload" size="lg" href={IMPORT_WIZARD_URL}>
+              <Trans i18nKey="alerting.settings.import.empty-cta">Import Alertmanager configuration</Trans>
+            </LinkButton>
+          }
+        >
+          <Trans i18nKey="alerting.settings.import.empty-body">
+            Import an Alertmanager configuration to stage it here as a safe, reversible copy. Review what it contains,
+            then promote it into your live Grafana Alertmanager when you&apos;re ready.
+          </Trans>{' '}
+          <TextLink href={DOCS_URL_ALERTING_MIGRATION} external>
+            <Trans i18nKey="alerting.settings.import.empty-learn-more">Learn more about importing configurations</Trans>
+          </TextLink>
+        </EmptyState>
+      )}
+
+      {/* Populated summary + accordion is added in a follow-up. */}
+      {!isLoading && !isError && stagedConfig && <Text variant="body">{stagedConfig.identifier}</Text>}
     </Stack>
   );
 }

--- a/public/app/features/alerting/unified/settings/navigation.ts
+++ b/public/app/features/alerting/unified/settings/navigation.ts
@@ -8,7 +8,7 @@ import { useSelector } from 'app/types/store';
 import { useSettingsExtensionsNav } from './extensions';
 
 /** Deep-link target for the Alerting settings Alertmanager tab. */
-export const ALERTING_SETTINGS_URL = '/alerting/admin/alertmanager';
+const ALERTING_SETTINGS_URL = '/alerting/admin/alertmanager';
 
 /** Deep-link target for the Alerting settings Import tab (auto-sync + staged config live here). */
 export const ALERTING_IMPORT_SETTINGS_URL = '/alerting/admin/import';
@@ -40,6 +40,9 @@ export function useSettingsPageNav() {
       icon: 'cloud',
       parentItem: settingsNav,
     },
+    // alertingMigrationWizardUI and alerting.syncExternalAlertmanager always ship together, so gating the
+    // Import tab (which now hosts the auto-sync card) on the wizard flag never hides auto-sync from an
+    // instance that has sync enabled.
     ...(config.featureToggles.alertingMigrationWizardUI ? [importTab] : []),
     ...extensionTabs,
   ];

--- a/public/app/features/alerting/unified/settings/navigation.ts
+++ b/public/app/features/alerting/unified/settings/navigation.ts
@@ -2,12 +2,16 @@ import { useLocation } from 'react-router-dom-v5-compat';
 
 import { type NavModelItem } from '@grafana/data';
 import { t } from '@grafana/i18n';
+import { config } from '@grafana/runtime';
 import { useSelector } from 'app/types/store';
 
 import { useSettingsExtensionsNav } from './extensions';
 
-/** Deep-link target for the Alerting settings Alertmanager tab (auto-sync configuration lives here). */
+/** Deep-link target for the Alerting settings Alertmanager tab. */
 export const ALERTING_SETTINGS_URL = '/alerting/admin/alertmanager';
+
+/** Deep-link target for the Alerting settings Import tab (auto-sync + staged config live here). */
+export const ALERTING_IMPORT_SETTINGS_URL = '/alerting/admin/import';
 
 export function useSettingsPageNav() {
   const location = useLocation();
@@ -16,6 +20,15 @@ export function useSettingsPageNav() {
   const settingsNav = navIndex['alerting-admin'];
 
   const extensionTabs = useSettingsExtensionsNav();
+
+  const importTab: NavModelItem = {
+    id: 'import',
+    text: t('alerting.settings.tabs.import', 'Import'),
+    url: ALERTING_IMPORT_SETTINGS_URL,
+    active: location.pathname === ALERTING_IMPORT_SETTINGS_URL,
+    icon: 'cloud-upload',
+    parentItem: settingsNav,
+  };
 
   // All available tabs including the main alertmanager tab
   const allTabs: NavModelItem[] = [
@@ -27,6 +40,7 @@ export function useSettingsPageNav() {
       icon: 'cloud',
       parentItem: settingsNav,
     },
+    ...(config.featureToggles.alertingMigrationWizardUI ? [importTab] : []),
     ...extensionTabs,
   ];
 

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -3298,8 +3298,6 @@
         "error-retry": "Retry",
         "error-title": "Couldn't load imported configurations",
         "loading": "Loading imported configurations…",
-        "no-permission-body": "Contact your administrator to request access to imported Alertmanager configurations.",
-        "no-permission-title": "You don't have permission to view imported configurations",
         "staged-description": "A read-only, reversible copy of an imported Alertmanager config. Promote it to merge into your live config, or revert to remove it.",
         "staged-title": "Staged configuration"
       },

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -3289,8 +3289,23 @@
         "save-success": "Mimir Alertmanager auto-sync enabled",
         "title": "Auto-sync configuration"
       },
+      "import": {
+        "empty-body": "Import an Alertmanager configuration to stage it here as a safe, reversible copy. Review what it contains, then promote it into your live Grafana Alertmanager when you're ready.",
+        "empty-cta": "Import Alertmanager configuration",
+        "empty-learn-more": "Learn more about importing configurations",
+        "empty-title": "No configuration imported yet",
+        "error-body": "The request to the Alerting API failed. Check your connection and try again.",
+        "error-retry": "Retry",
+        "error-title": "Couldn't load imported configurations",
+        "loading": "Loading imported configurations…",
+        "no-permission-body": "Contact your administrator to request access to imported Alertmanager configurations.",
+        "no-permission-title": "You don't have permission to view imported configurations",
+        "staged-description": "A read-only, reversible copy of an imported Alertmanager config. Promote it to merge into your live config, or revert to remove it.",
+        "staged-title": "Staged configuration"
+      },
       "tabs": {
-        "alert-managers": "Alert managers"
+        "alert-managers": "Alert managers",
+        "import": "Import"
       }
     },
     "settings-content": {


### PR DESCRIPTION
**What is this feature?**

This PR adds a new tab called Import in the alerting settings page and moves the auto sync component to that tab, as well as an empty state.
<img width="1524" height="927" alt="Screenshot 2026-07-22 at 5 27 20 PM" src="https://github.com/user-attachments/assets/9e78f95b-ab43-4962-bdd4-ae00b67c4e42" />


**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Relates to https://github.com/grafana/alerting-squad/issues/1863

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
