### PR TITLE
Home: Enable unified homepage for all users (remove flag)

### DIFF
--- a/e2e-playwright/various-suite/keybinds.spec.ts
+++ b/e2e-playwright/various-suite/keybinds.spec.ts
@@ -6,12 +6,11 @@ test.describe(
     tag: ['@various'],
   },
   () => {
-    test.beforeEach(async ({ page, selectors }) => {
+    test.beforeEach(async ({ page }) => {
       await page.goto('/');
 
       // Wait for the page to load
-      const panelTitle = page.getByTestId(selectors.components.Panels.Panel.title('Latest from the blog'));
-      await expect(panelTitle).toBeVisible();
+      await expect(page.getByText('Welcome to Grafana')).toBeVisible();
     });
 
     test('sequence shortcuts should work', async ({ page, selectors }) => {
@@ -27,8 +26,7 @@ test.describe(
 
       // Navigate back to home with 'gh' shortcut
       await page.keyboard.type('gh');
-      const panelTitle = page.getByTestId(selectors.components.Panels.Panel.title('Latest from the blog'));
-      await expect(panelTitle).toBeVisible();
+      await expect(page.getByText('Welcome to Grafana')).toBeVisible();
     });
 
     test('ctrl+z should zoom out the time range', async ({ page, selectors }) => {

--- a/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
@@ -59,7 +59,6 @@ declare module "@openfeature/core" {
     | "datasources.apiserver.useNewAPIsForDatasourceResources"
     | "reporting.anyPageReporting"
     | "assistant.frontend.tools.dashboardTemplates"
-    | "grafana.unifiedHomepage"
     | "alerting.syncExternalAlertmanager"
     | "grafana.enableScopesFirstMode"
     | "grafana.useDefaultScopesEndpoint"

--- a/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
@@ -95,8 +95,6 @@ export const FlagKeys = {
   GrafanaStarredFolders: "grafana.starredFolders",
   /** Enables using dashboard variables in panel threshold values */
   GrafanaThresholdsInterpolation: "grafana.thresholdsInterpolation",
-  /** Replaces the bundled home dashboard with the unified homepage React page */
-  GrafanaUnifiedHomepage: "grafana.unifiedHomepage",
   /** Use the find default scope endpoint to seed the initial scope selection when none is set. */
   GrafanaUseDefaultScopesEndpoint: "grafana.useDefaultScopesEndpoint",
   /** Enables semantic (vector) dashboard search in the command palette */
@@ -612,17 +610,6 @@ export const useFlagGrafanaStarredFolders = (options?: ReactFlagEvaluationOption
  */
 export const useFlagGrafanaThresholdsInterpolation = (options?: ReactFlagEvaluationOptions): boolean => {
   return useFlag("grafana.thresholdsInterpolation", false, options).value;
-};
-
-/**
- * Replaces the bundled home dashboard with the unified homepage React page
- *
- * **Details:**
- * - flag key: `grafana.unifiedHomepage`
- * - default value: `false`
- */
-export const useFlagGrafanaUnifiedHomepage = (options?: ReactFlagEvaluationOptions): boolean => {
-  return useFlag("grafana.unifiedHomepage", false, options).value;
 };
 
 /**

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -2844,14 +2844,6 @@ var (
 			Expression:  "false",
 		},
 		{
-			Name:        "grafana.unifiedHomepage",
-			Description: "Replaces the bundled home dashboard with the unified homepage React page",
-			Stage:       FeatureStageExperimental,
-			Owner:       grafanaFrontendNavigation,
-			Generate:    Generate{React: true},
-			Expression:  "false",
-		},
-		{
 			Name:        "preferences.rerouteLegacyAPIs",
 			Description: "Use K8s client implementation for legacy preferences API",
 			Stage:       FeatureStageGeneralAvailability,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -330,7 +330,6 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-05-22,grafana.correlationsSkipLegacy,experimental,@grafana/datapro,false,false,false
 2026-05-22,grafana.meticulousAIMode,experimental,@grafana/dataviz-squad,false,false,false
 2026-05-22,datasources.useNewStackInfoToSettingsCache,GA,@grafana/grafana-datasources-core-services,false,false,false
-2026-05-22,grafana.unifiedHomepage,experimental,@grafana/grafana-frontend-navigation,false,false,true
 2026-05-22,preferences.rerouteLegacyAPIs,GA,@grafana/grafana-frontend-platform,false,false,false
 2026-05-22,plugins.marketplaceLicensing,experimental,@grafana/grafana-catalog,false,true,false
 2026-05-22,alerting.syncExternalAlertmanager,experimental,@grafana/alerting-squad,false,true,false

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -3131,7 +3131,8 @@
       "metadata": {
         "name": "grafana.unifiedHomepage",
         "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "deletionTimestamp": "2026-07-22T21:47:47Z"
       },
       "spec": {
         "description": "Replaces the bundled home dashboard with the unified homepage React page",

--- a/public/app/core/components/SharedPreferences/SharedPreferences.test.tsx
+++ b/public/app/core/components/SharedPreferences/SharedPreferences.test.tsx
@@ -213,7 +213,6 @@ describe('SharedPreferences', () => {
       expect(jest.mocked(homeDashboardChanged)).toHaveBeenCalledWith({
         preferenceType: 'user',
         action: 'set',
-        unifiedHomepageEnabled: false,
       });
     });
   });

--- a/public/app/core/components/SharedPreferences/SharedPreferencesFunctional.test.tsx
+++ b/public/app/core/components/SharedPreferences/SharedPreferencesFunctional.test.tsx
@@ -1,12 +1,12 @@
 import { HttpResponse } from 'msw';
 import { getSelectParent, selectOptionInTest } from 'test/helpers/selectOptionInTest';
-import { act, render, screen, userEvent, waitFor, within } from 'test/test-utils';
+import { render, screen, userEvent, waitFor, within } from 'test/test-utils';
 
 import { setBackendSrv } from '@grafana/runtime';
 import { mockComboboxRect } from '@grafana/test-utils';
 import { preferencesHandlers } from '@grafana/test-utils/handlers';
 import server, { setupMockServer } from '@grafana/test-utils/server';
-import { getFolderFixtures, setTestFlags } from '@grafana/test-utils/unstable';
+import { getFolderFixtures } from '@grafana/test-utils/unstable';
 import { backendSrv } from 'app/core/services/backend_srv';
 import { captureRequests } from 'app/features/alerting/unified/mocks/server/events';
 
@@ -50,14 +50,6 @@ const originalLocation = window.location;
 beforeEach(() => {
   mockReload.mockClear();
   jest.mocked(homeDashboardChanged).mockClear();
-});
-
-afterEach(async () => {
-  // Wrap in act() because setTestFlags fires OpenFeature events that can trigger React state
-  // updates while the component is still mounted (RTL cleanup runs in a separate afterEach).
-  await act(async () => {
-    setTestFlags({});
-  });
 });
 
 beforeAll(() => {
@@ -256,26 +248,6 @@ describe('SharedPreferencesFunctional', () => {
       expect(jest.mocked(homeDashboardChanged)).toHaveBeenCalledWith({
         preferenceType: 'user',
         action: 'set',
-        unifiedHomepageEnabled: false,
-      });
-    });
-  });
-
-  it('reports unifiedHomepageEnabled true when the flag is on', async () => {
-    setTestFlags({ 'grafana.unifiedHomepage': true });
-    const { user } = await setup();
-
-    await selectComboboxOptionInTest(
-      await screen.findByRole('combobox', { name: /home dashboard/i }),
-      new RegExp(dashbdE.item.title)
-    );
-    await user.click(screen.getByText('Save preferences'));
-
-    await waitFor(() => {
-      expect(jest.mocked(homeDashboardChanged)).toHaveBeenCalledWith({
-        preferenceType: 'user',
-        action: 'set',
-        unifiedHomepageEnabled: true,
       });
     });
   });
@@ -304,7 +276,6 @@ describe('SharedPreferencesFunctional', () => {
       expect(jest.mocked(homeDashboardChanged)).toHaveBeenCalledWith({
         preferenceType: 'user',
         action: 'cleared',
-        unifiedHomepageEnabled: false,
       });
     });
   });

--- a/public/app/core/components/SharedPreferences/SharedPreferencesFunctional.tsx
+++ b/public/app/core/components/SharedPreferences/SharedPreferencesFunctional.tsx
@@ -38,7 +38,6 @@ export const SharedPreferencesFunctional = memo((props: Props) => {
     useSharedPreferences(resourceUri);
 
   const isAnalyticsFrameworkEnabled = useBooleanFlagValue('analyticsFramework', true);
-  const unifiedHomepageEnabled = useBooleanFlagValue('grafana.unifiedHomepage', false);
   const [state, setState] = useState<PrefsState>({
     theme: undefined,
     timezone: '',
@@ -108,7 +107,6 @@ export const SharedPreferencesFunctional = memo((props: Props) => {
       homeDashboardChanged({
         preferenceType: props.preferenceType,
         action: nextHomeDashboardUID ? 'set' : 'cleared',
-        unifiedHomepageEnabled,
       });
     }
 

--- a/public/app/core/components/SharedPreferences/SharedPreferencesOld.tsx
+++ b/public/app/core/components/SharedPreferences/SharedPreferencesOld.tsx
@@ -5,7 +5,6 @@ import { FeatureState } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t, Trans } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
-import { FlagKeys, getFeatureFlagClient } from '@grafana/runtime/internal';
 import {
   Button,
   Field,
@@ -114,7 +113,6 @@ class SharedPreferences extends PureComponent<Props, State> {
         homeDashboardChanged({
           preferenceType: this.props.preferenceType,
           action: nextHomeDashboardUID ? 'set' : 'cleared',
-          unifiedHomepageEnabled: getFeatureFlagClient().getBooleanValue(FlagKeys.GrafanaUnifiedHomepage, false),
         });
       }
 

--- a/public/app/core/components/SharedPreferences/analytics/types.ts
+++ b/public/app/core/components/SharedPreferences/analytics/types.ts
@@ -28,6 +28,4 @@ export interface HomeDashboardChanged extends EventProperty {
   preferenceType: 'org' | 'team' | 'user';
   /** Whether a custom home dashboard was set, or the preference was cleared back to the default homepage. */
   action: 'set' | 'cleared';
-  /** Whether the unified homepage (grafana.unifiedHomepage) is enabled for this user. */
-  unifiedHomepageEnabled: boolean;
 }

--- a/public/app/core/hooks/useHomeNav.test.ts
+++ b/public/app/core/hooks/useHomeNav.test.ts
@@ -1,44 +1,19 @@
-import { act, getWrapper, renderHook } from 'test/test-utils';
+import { getWrapper, renderHook } from 'test/test-utils';
 
-import { setTestFlags } from '@grafana/test-utils/unstable';
 import { configureStore } from 'app/store/configureStore';
 
-import { SETUP_GUIDE_HOME_URL, useHomeNav } from './useHomeNav';
+import { useHomeNav } from './useHomeNav';
 
 const renderUseHomeNav = (url: string) => {
   const store = configureStore({
-    navIndex: { home: { id: 'home', text: 'Home', url } },
+    navIndex: { other: { id: 'other', text: 'other', url: '/a/other-app' }, home: { id: 'home', text: 'Home', url } },
   });
   return renderHook(() => useHomeNav(), { wrapper: getWrapper({ store, renderWithRouter: false }) });
 };
 
 describe('useHomeNav', () => {
-  afterEach(async () => {
-    // Wrap in act() because setTestFlags fires OpenFeature events that trigger React state updates
-    await act(async () => {
-      setTestFlags({});
-    });
-  });
-
-  it('flag off → returns the setup guide url unchanged', () => {
-    const { result } = renderUseHomeNav(SETUP_GUIDE_HOME_URL);
-
-    expect(result.current?.url).toBe(SETUP_GUIDE_HOME_URL);
-  });
-
-  it('flag on + setup guide url → rewrites the url to the homepage', () => {
-    setTestFlags({ 'grafana.unifiedHomepage': true });
-
-    const { result } = renderUseHomeNav(SETUP_GUIDE_HOME_URL);
-
-    expect(result.current?.url).toBe('/');
-  });
-
-  it('flag on + other url → returns the url unchanged', () => {
-    setTestFlags({ 'grafana.unifiedHomepage': true });
-
+  it('returns the home url unchanged', () => {
     const { result } = renderUseHomeNav('/d/custom-home');
-
     expect(result.current?.url).toBe('/d/custom-home');
   });
 });

--- a/public/app/core/hooks/useHomeNav.ts
+++ b/public/app/core/hooks/useHomeNav.ts
@@ -1,23 +1,10 @@
 import { type NavModelItem } from '@grafana/data';
-import { config } from '@grafana/runtime';
-import { useFlagGrafanaUnifiedHomepage } from '@grafana/runtime/internal';
 import { HOME_NAV_ID } from 'app/core/reducers/navModel';
 import { useSelector } from 'app/types/store';
 
-export const SETUP_GUIDE_HOME_URL = '/a/grafana-setupguide-app/home';
-
 /**
- * Returns the home nav item. When the unified homepage is enabled, a stale
- * `home_page` config pointing at the setup guide app is superseded by the new
- * homepage, so the link is rewritten to the root URL.
+ * Returns the home nav item.
  */
 export function useHomeNav(): NavModelItem | undefined {
-  const homeNav = useSelector((state) => state.navIndex[HOME_NAV_ID]);
-  const unifiedHomepageEnabled = useFlagGrafanaUnifiedHomepage();
-
-  if (unifiedHomepageEnabled && homeNav?.url === SETUP_GUIDE_HOME_URL) {
-    return { ...homeNav, url: config.appSubUrl + '/' };
-  }
-
-  return homeNav;
+  return useSelector((state) => state.navIndex[HOME_NAV_ID]);
 }

--- a/public/app/features/home/HomeRoute.test.tsx
+++ b/public/app/features/home/HomeRoute.test.tsx
@@ -1,11 +1,10 @@
 import { http, HttpResponse } from 'msw';
 import { type ComponentProps } from 'react';
-import { act, render, screen, waitFor } from 'test/test-utils';
+import { render, screen, waitFor } from 'test/test-utils';
 
 import { locationService, setBackendSrv, setPluginComponentsHook } from '@grafana/runtime';
 import { MERGED_PREFS_URL } from '@grafana/test-utils/handlers';
 import server, { setupMockServer } from '@grafana/test-utils/server';
-import { setTestFlags } from '@grafana/test-utils/unstable';
 import { backendSrv } from 'app/core/services/backend_srv';
 import { contextSrv } from 'app/core/services/context_srv';
 import { useNewsFeed } from 'app/plugins/panel/news/useNewsFeed';
@@ -67,28 +66,12 @@ describe('HomeRoute', () => {
   });
 
   afterEach(async () => {
-    // Wrap in act() because setTestFlags fires OpenFeature events that trigger React state
-    // updates while the component is still mounted (RTL cleanup runs in a separate afterEach).
-    await act(async () => {
-      setTestFlags({});
-    });
     jest.restoreAllMocks();
   });
 
   const props = {} as ComponentProps<typeof HomeRoute>;
 
-  it('flag off → renders dashboard proxy without probing merged preferences', async () => {
-    stubMergedPreferences({ homeDashboardUID: '' });
-
-    render(<HomeRoute {...props} />);
-
-    expect(await screen.findByTestId('dashboard-page-proxy-stub')).toBeInTheDocument();
-    expect(probeCallCount).toBe(0);
-    expect(jest.mocked(homepageViewed)).not.toHaveBeenCalled();
-  });
-
-  it('flag on + homeDashboardUID empty → renders HomePage', async () => {
-    setTestFlags({ 'grafana.unifiedHomepage': true });
+  it('homeDashboardUID empty → renders HomePage', async () => {
     stubMergedPreferences({ homeDashboardUID: '' });
 
     render(<HomeRoute {...props} />);
@@ -97,8 +80,7 @@ describe('HomeRoute', () => {
     expect(jest.mocked(homepageViewed)).toHaveBeenCalledTimes(1);
   });
 
-  it('flag on + homeDashboardUID absent → renders HomePage', async () => {
-    setTestFlags({ 'grafana.unifiedHomepage': true });
+  it('homeDashboardUID absent → renders HomePage', async () => {
     stubMergedPreferences({});
 
     render(<HomeRoute {...props} />);
@@ -107,8 +89,7 @@ describe('HomeRoute', () => {
     expect(jest.mocked(homepageViewed)).toHaveBeenCalledTimes(1);
   });
 
-  it('flag on + homeDashboardUID present → renders dashboard proxy', async () => {
-    setTestFlags({ 'grafana.unifiedHomepage': true });
+  it('homeDashboardUID present → renders dashboard proxy', async () => {
     stubMergedPreferences({ homeDashboardUID: 'abc' });
 
     render(<HomeRoute {...props} />);
@@ -117,8 +98,7 @@ describe('HomeRoute', () => {
     expect(jest.mocked(homepageViewed)).not.toHaveBeenCalled();
   });
 
-  it('flag on + homeDashboardUID: default-home-dashboard → renders dashboard proxy', async () => {
-    setTestFlags({ 'grafana.unifiedHomepage': true });
+  it('homeDashboardUID: default-home-dashboard → renders dashboard proxy', async () => {
     stubMergedPreferences({ homeDashboardUID: 'default-home-dashboard' });
 
     render(<HomeRoute {...props} />);
@@ -127,8 +107,7 @@ describe('HomeRoute', () => {
     expect(jest.mocked(homepageViewed)).not.toHaveBeenCalled();
   });
 
-  it('flag on + merged endpoint returns 500 → renders dashboard proxy', async () => {
-    setTestFlags({ 'grafana.unifiedHomepage': true });
+  it('merged endpoint returns 500 → renders dashboard proxy', async () => {
     server.use(
       http.get(MERGED_PREFS_URL, () => {
         return HttpResponse.json({ message: 'boom' }, { status: 500 });
@@ -141,8 +120,7 @@ describe('HomeRoute', () => {
     expect(jest.mocked(homepageViewed)).not.toHaveBeenCalled();
   });
 
-  it('flag on + homeURL present → calls locationService.replace', async () => {
-    setTestFlags({ 'grafana.unifiedHomepage': true });
+  it('homeURL present → calls locationService.replace', async () => {
     stubMergedPreferences({ homeURL: '/d/abc' });
 
     render(<HomeRoute {...props} />);
@@ -155,19 +133,7 @@ describe('HomeRoute', () => {
     expect(jest.mocked(homepageViewed)).not.toHaveBeenCalled();
   });
 
-  it('flag on + homeURL pointing at the setup guide → renders HomePage without redirecting', async () => {
-    setTestFlags({ 'grafana.unifiedHomepage': true });
-    stubMergedPreferences({ homeURL: '/a/grafana-setupguide-app/home' });
-
-    render(<HomeRoute {...props} />);
-
-    expect(await screen.findByText(/Welcome to Grafana/i)).toBeInTheDocument();
-    expect(locationService.getLocation().pathname).not.toContain('grafana-setupguide-app');
-    expect(jest.mocked(homepageViewed)).toHaveBeenCalledTimes(1);
-  });
-
-  it('flag on + homeDashboardUID and homeURL both present → renders dashboard proxy without redirecting', async () => {
-    setTestFlags({ 'grafana.unifiedHomepage': true });
+  it('homeDashboardUID and homeURL both present → renders dashboard proxy without redirecting', async () => {
     stubMergedPreferences({ homeDashboardUID: 'abc', homeURL: '/d/other' });
 
     render(<HomeRoute {...props} />);

--- a/public/app/features/home/HomeRoute.tsx
+++ b/public/app/features/home/HomeRoute.tsx
@@ -3,9 +3,7 @@ import { lazy, Suspense, useEffect } from 'react';
 import { useMergedPreferencesQuery } from '@grafana/api-clients/rtkq/preferences/v1';
 import { locationUtil } from '@grafana/data';
 import { locationService } from '@grafana/runtime';
-import { useFlagGrafanaUnifiedHomepage } from '@grafana/runtime/internal';
 import { PageLoader } from '@grafana/ui';
-import { SETUP_GUIDE_HOME_URL } from 'app/core/hooks/useHomeNav';
 import { markAsUrlRewrite } from 'app/core/navigation/urlRewrite';
 
 import { type DashboardPageProxyProps } from '../dashboard/containers/DashboardPageProxy';
@@ -16,16 +14,11 @@ const DashboardPageProxy = lazy(
 const HomePage = lazy(() => import(/* webpackChunkName: "HomePage" */ './HomePage'));
 
 function HomeRouteInner(props: DashboardPageProxyProps) {
-  const flagOn = useFlagGrafanaUnifiedHomepage({ suspend: true });
-  return flagOn ? <UnifiedHomeRoute {...props} /> : <DashboardPageProxy {...props} />;
-}
-
-function UnifiedHomeRoute(props: DashboardPageProxyProps) {
   const { data, isLoading, isError } = useMergedPreferencesQuery();
   const redirectUri = data?.spec?.homeURL;
   const homeDashboardUID = data?.spec?.homeDashboardUID;
-  // homeDashboardUID takes precedence over homeURL; the setup guide redirect is superseded by the new homepage
-  const willRedirect = !!redirectUri && !homeDashboardUID && redirectUri !== SETUP_GUIDE_HOME_URL;
+  // homeDashboardUID takes precedence over homeURL
+  const willRedirect = !!redirectUri && !homeDashboardUID;
 
   useEffect(() => {
     if (!willRedirect) {


### PR DESCRIPTION
**What is this feature?**

Enables the new unified homepage experience for all users, removing the feature flag that previously controlled it.

**Why do we need this feature?**

Rolling out the unified homepage to all users.

**Who is this feature for?**

All users.

**Which issue(s) does this PR fix?**:

Closes #125695
Closes #125694
Closes #129055

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
