### PR TITLE
Alerting: use namespace name from prom API for instances page

### DIFF
--- a/public/app/features/alerting/unified/hooks/useCombinedRule.test.tsx
+++ b/public/app/features/alerting/unified/hooks/useCombinedRule.test.tsx
@@ -34,6 +34,7 @@ const UseCombinedRuleTestComponent = ({ ruleIdentifier }: { ruleIdentifier: Graf
       <div data-testid="error">{error ? 'has-error' : 'no-error'}</div>
       <div data-testid="result">{result ? 'has-result' : 'no-result'}</div>
       <div data-testid="prom">{result?.promRule ? 'has-prom' : 'no-prom'}</div>
+      <div data-testid="namespace">{result?.namespace.name ?? 'no-namespace'}</div>
     </>
   );
 };
@@ -155,6 +156,39 @@ describe('useCombinedRule', () => {
       // Without aligning to the API's namespace name, the Prometheus rule (and its instances)
       // would land in a separate namespace and never attach, leaving this as 'no-prom'.
       expect(screen.getByTestId('prom')).toHaveTextContent('has-prom');
+    });
+
+    it('falls back to the derived folder namespace when Prometheus returns no rule', async () => {
+      server.use(http.get('/api/ruler/grafana/api/v1/rule/:uid', () => HttpResponse.json(grafanaRulerRule)));
+      server.use(
+        http.get('/api/ruler/grafana/api/v1/rules/:namespace/:group', () => HttpResponse.json(grafanaRulerGroup))
+      );
+      server.use(
+        http.get('/api/folders/:uid', () => HttpResponse.json({ uid: grafanaRulerNamespace.uid, title: 'my/folder' }))
+      );
+      server.use(
+        http.get('/api/prometheus/grafana/api/v1/rules', () =>
+          HttpResponse.json({ status: 'success', data: { groups: [] } })
+        )
+      );
+
+      render(
+        <UseCombinedRuleTestComponent
+          ruleIdentifier={{
+            ruleSourceName: GRAFANA_RULES_SOURCE_NAME,
+            uid: grafanaRulerRule.grafana_alert.uid,
+          }}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('loading')).toHaveTextContent('not-loading');
+      });
+
+      expect(screen.getByTestId('error')).toHaveTextContent('no-error');
+      expect(screen.getByTestId('result')).toHaveTextContent('has-result');
+      expect(screen.getByTestId('prom')).toHaveTextContent('no-prom');
+      expect(screen.getByTestId('namespace')).toHaveTextContent('my\\/folder');
     });
   });
 });

--- a/public/app/features/alerting/unified/hooks/useCombinedRule.test.tsx
+++ b/public/app/features/alerting/unified/hooks/useCombinedRule.test.tsx
@@ -6,8 +6,13 @@ import { AccessControlAction } from 'app/types/accessControl';
 import { type GrafanaRuleIdentifier } from 'app/types/unified-alerting';
 
 import { setupMswServer } from '../mockApi';
-import { grantUserPermissions } from '../mocks';
-import { grafanaRulerNamespace, grafanaRulerRule } from '../mocks/grafanaRulerApi';
+import { grantUserPermissions, mockGrafanaPromAlertingRule } from '../mocks';
+import {
+  grafanaRulerGroup,
+  grafanaRulerGroupName,
+  grafanaRulerNamespace,
+  grafanaRulerRule,
+} from '../mocks/grafanaRulerApi';
 import { GRAFANA_RULES_SOURCE_NAME } from '../utils/datasource';
 
 import { useCombinedRule } from './useCombinedRule';
@@ -28,6 +33,7 @@ const UseCombinedRuleTestComponent = ({ ruleIdentifier }: { ruleIdentifier: Graf
       <div data-testid="loading">{loading ? 'loading' : 'not-loading'}</div>
       <div data-testid="error">{error ? 'has-error' : 'no-error'}</div>
       <div data-testid="result">{result ? 'has-result' : 'no-result'}</div>
+      <div data-testid="prom">{result?.promRule ? 'has-prom' : 'no-prom'}</div>
     </>
   );
 };
@@ -87,6 +93,68 @@ describe('useCombinedRule', () => {
       // Verify that no error notification was shown
       // If showErrorAlert was true, we would see an alert with role="status"
       expect(screen.queryByRole('status')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('combining Grafana Ruler and Prometheus rules', () => {
+    it('attaches the Prometheus rule to the combined rule using the namespace name returned by the API', async () => {
+      // getAlertRule -> ruleLocation (folder UID, group, title)
+      server.use(http.get('/api/ruler/grafana/api/v1/rule/:uid', () => HttpResponse.json(grafanaRulerRule)));
+
+      // Ruler group for the folder
+      server.use(
+        http.get('/api/ruler/grafana/api/v1/rules/:namespace/:group', () => HttpResponse.json(grafanaRulerGroup))
+      );
+
+      // Folder titled "my/folder" -> stringifyFolder() would produce the escaped "my\/folder"
+      server.use(
+        http.get('/api/folders/:uid', () => HttpResponse.json({ uid: grafanaRulerNamespace.uid, title: 'my/folder' }))
+      );
+
+      // Prometheus returns the same folder but with a different namespace name (here the unescaped
+      // "my/folder"), simulating a backend whose fullpath escaping does not byte-match the client's.
+      // The rule must still be paired with its Prometheus counterpart via the name the API returned.
+      server.use(
+        http.get('/api/prometheus/grafana/api/v1/rules', () =>
+          HttpResponse.json({
+            status: 'success',
+            data: {
+              groups: [
+                {
+                  name: grafanaRulerGroupName,
+                  file: 'my/folder',
+                  folderUid: grafanaRulerNamespace.uid,
+                  interval: 60,
+                  rules: [
+                    mockGrafanaPromAlertingRule({
+                      uid: grafanaRulerRule.grafana_alert.uid,
+                      name: grafanaRulerRule.grafana_alert.title,
+                      folderUid: grafanaRulerNamespace.uid,
+                    }),
+                  ],
+                },
+              ],
+            },
+          })
+        )
+      );
+
+      const ruleIdentifier: GrafanaRuleIdentifier = {
+        ruleSourceName: GRAFANA_RULES_SOURCE_NAME,
+        uid: grafanaRulerRule.grafana_alert.uid,
+      };
+
+      render(<UseCombinedRuleTestComponent ruleIdentifier={ruleIdentifier} />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('loading')).toHaveTextContent('not-loading');
+      });
+
+      expect(screen.getByTestId('error')).toHaveTextContent('no-error');
+      expect(screen.getByTestId('result')).toHaveTextContent('has-result');
+      // Without aligning to the API's namespace name, the Prometheus rule (and its instances)
+      // would land in a separate namespace and never attach, leaving this as 'no-prom'.
+      expect(screen.getByTestId('prom')).toHaveTextContent('has-prom');
     });
   });
 });

--- a/public/app/features/alerting/unified/hooks/useCombinedRule.ts
+++ b/public/app/features/alerting/unified/hooks/useCombinedRule.ts
@@ -129,10 +129,19 @@ export function useCombinedRule({ ruleIdentifier, limitAlerts }: Props): Request
       refetchOnMountOrArgChange: true,
     }
   );
-  // in case of Grafana folder, we need to use the folder name instead of uid, as in promrules we don't use uid
   const isGrafanaRule = isGrafanaRulesSource(ruleSourceName);
   const folder = useFolder(isGrafanaRule ? ruleLocation?.namespace : undefined);
-  const namespaceName = isGrafanaRule && folder.folder ? stringifyFolder(folder.folder) : ruleLocation?.namespace;
+  // The Prometheus and Ruler APIs identify a Grafana folder differently: Prometheus uses the
+  // folder's (escaped) fullpath as the namespace name, while the Ruler is queried by folder UID.
+  // To correlate the two, the Ruler group must be keyed under the same namespace name Prometheus
+  // returned. We reuse that name directly rather than re-deriving the fullpath on the client, so
+  // the match no longer depends on the frontend's title escaping byte-matching the backend's.
+  // Falls back to the client-derived fullpath when there is no Prometheus rule yet (e.g. a rule
+  // that hasn't been evaluated), in which case there are no instances to correlate anyway.
+  const promNamespaceName = promRuleNs[0]?.name;
+  const namespaceName = isGrafanaRule
+    ? (promNamespaceName ?? (folder.folder ? stringifyFolder(folder.folder) : ruleLocation?.namespace))
+    : ruleLocation?.namespace;
 
   const [
     fetchRulerRuleGroup,

--- a/public/app/features/alerting/unified/hooks/useCombinedRule.ts
+++ b/public/app/features/alerting/unified/hooks/useCombinedRule.ts
@@ -134,7 +134,7 @@ export function useCombinedRule({ ruleIdentifier, limitAlerts }: Props): Request
   // Use Prometheus's fullpath instead of deriving it in the client to avoid escaping mismatches.
   let namespaceName = ruleLocation?.namespace;
   if (isGrafanaRule) {
-    const promNamespaceName = promRuleNs[0]?.name;
+    const promNamespaceName = promRuleNs.at(0)?.name;
     if (promNamespaceName !== undefined) {
       namespaceName = promNamespaceName;
     } else if (folder.folder) {

--- a/public/app/features/alerting/unified/hooks/useCombinedRule.ts
+++ b/public/app/features/alerting/unified/hooks/useCombinedRule.ts
@@ -131,17 +131,16 @@ export function useCombinedRule({ ruleIdentifier, limitAlerts }: Props): Request
   );
   const isGrafanaRule = isGrafanaRulesSource(ruleSourceName);
   const folder = useFolder(isGrafanaRule ? ruleLocation?.namespace : undefined);
-  // The Prometheus and Ruler APIs identify a Grafana folder differently: Prometheus uses the
-  // folder's (escaped) fullpath as the namespace name, while the Ruler is queried by folder UID.
-  // To correlate the two, the Ruler group must be keyed under the same namespace name Prometheus
-  // returned. We reuse that name directly rather than re-deriving the fullpath on the client, so
-  // the match no longer depends on the frontend's title escaping byte-matching the backend's.
-  // Falls back to the client-derived fullpath when there is no Prometheus rule yet (e.g. a rule
-  // that hasn't been evaluated), in which case there are no instances to correlate anyway.
-  const promNamespaceName = promRuleNs[0]?.name;
-  const namespaceName = isGrafanaRule
-    ? (promNamespaceName ?? (folder.folder ? stringifyFolder(folder.folder) : ruleLocation?.namespace))
-    : ruleLocation?.namespace;
+  // Use Prometheus's fullpath instead of deriving it in the client to avoid escaping mismatches.
+  let namespaceName = ruleLocation?.namespace;
+  if (isGrafanaRule) {
+    const promNamespaceName = promRuleNs[0]?.name;
+    if (promNamespaceName !== undefined) {
+      namespaceName = promNamespaceName;
+    } else if (folder.folder) {
+      namespaceName = stringifyFolder(folder.folder);
+    }
+  }
 
   const [
     fetchRulerRuleGroup,


### PR DESCRIPTION
**What is this feature?**

This PR solves for the folder service not currently escaping slashes in folder titles. This uses the namespace we get from the prom API for the namespace map instead of reconstructing the path on the frontend.

**Why do we need this feature?**

This fixes an issue where the instance page is blank for rules in folders that contain slashes in the title.

**Who is this feature for?**

Alerting users

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
