### PR TITLE
Annotations: allow updates to time/timeEnd when proxying

### DIFF
--- a/pkg/registry/apps/annotation/k8s_adapter.go
+++ b/pkg/registry/apps/annotation/k8s_adapter.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
+	"k8s.io/utils/ptr"
 
 	authtypes "github.com/grafana/authlib/types"
 	annotationV0 "github.com/grafana/grafana/apps/annotation/pkg/apis/annotation/v0alpha1"
@@ -360,6 +361,10 @@ func (s *k8sRESTAdapter) Update(ctx context.Context,
 		return nil, false, goneError(name)
 	}
 
+	if err := validateUpdate(existing, resource); err != nil {
+		return nil, false, err
+	}
+
 	// Preserve legacy data when the caller omits it, mirroring the legacy API's behavior.
 	// An absent annotation keeps the stored value, while a present annotation overwrites or clears it.
 	if _, ok := GetLegacyData(resource); !ok {
@@ -513,6 +518,23 @@ func (s *k8sRESTAdapter) validateScopeCount(a *annotationV0.Annotation) error {
 	if len(a.Spec.Scopes) > s.maxScopeCount {
 		return apierrors.NewBadRequest(fmt.Sprintf(
 			"too many scopes: %d (max allowed %d)", len(a.Spec.Scopes), s.maxScopeCount))
+	}
+	return nil
+}
+
+// validateUpdate rejects updates that attempt to modify immutable fields
+func validateUpdate(existing, updated *annotationV0.Annotation) error {
+	if existing.Spec.Time != updated.Spec.Time {
+		return apierrors.NewBadRequest(fmt.Sprintf("%v: time is immutable", ErrInvalidInput))
+	}
+	if !ptr.Equal(existing.Spec.TimeEnd, updated.Spec.TimeEnd) {
+		return apierrors.NewBadRequest(fmt.Sprintf("%v: timeEnd is immutable", ErrInvalidInput))
+	}
+	if !ptr.Equal(existing.Spec.DashboardUID, updated.Spec.DashboardUID) {
+		return apierrors.NewBadRequest(fmt.Sprintf("%v: dashboardUID is immutable", ErrInvalidInput))
+	}
+	if !ptr.Equal(existing.Spec.PanelID, updated.Spec.PanelID) {
+		return apierrors.NewBadRequest(fmt.Sprintf("%v: panelID is immutable", ErrInvalidInput))
 	}
 	return nil
 }

--- a/pkg/registry/apps/annotation/k8s_adapter_test.go
+++ b/pkg/registry/apps/annotation/k8s_adapter_test.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	k8srequest "k8s.io/apiserver/pkg/endpoints/request"
 	registryrest "k8s.io/apiserver/pkg/registry/rest"
+	"k8s.io/utils/ptr"
 
 	annotationV0 "github.com/grafana/grafana/apps/annotation/pkg/apis/annotation/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
@@ -429,6 +430,41 @@ func TestK8sAdapter_Update(t *testing.T) {
 		}
 		_, _, err = adapter.Update(ctx, "anno", &updatedObjectInfo{obj: incoming}, nil, nil, false, &metav1.UpdateOptions{})
 		assert.True(t, apierrors.IsGone(err), "expected 410 Gone, got %v", err)
+	})
+
+	t.Run("rejects updates to immutable fields", func(t *testing.T) {
+		cases := []struct {
+			name   string
+			mutate func(*annotationV0.Annotation)
+		}{
+			{"time", func(a *annotationV0.Annotation) { a.Spec.Time = 2000 }},
+			{"timeEnd", func(a *annotationV0.Annotation) { a.Spec.TimeEnd = ptr.To(int64(3000)) }},
+			{"dashboardUID", func(a *annotationV0.Annotation) { a.Spec.DashboardUID = ptr.To("dash") }},
+			{"panelID", func(a *annotationV0.Annotation) { a.Spec.PanelID = ptr.To(int64(7)) }},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				adapter, ctx := seedWithData(t)
+				incoming := &annotationV0.Annotation{
+					ObjectMeta: metav1.ObjectMeta{Name: "anno", Namespace: ns},
+					Spec:       annotationV0.AnnotationSpec{Text: "updated", Time: 1000},
+				}
+				tc.mutate(incoming)
+				_, _, err := adapter.Update(ctx, "anno", &updatedObjectInfo{obj: incoming}, nil, nil, false, &metav1.UpdateOptions{})
+				assert.True(t, apierrors.IsBadRequest(err), "expected 400 BadRequest, got %v", err)
+			})
+		}
+	})
+
+	t.Run("allows updates that leave immutable fields unchanged", func(t *testing.T) {
+		adapter, ctx := seedWithData(t)
+		incoming := &annotationV0.Annotation{
+			ObjectMeta: metav1.ObjectMeta{Name: "anno", Namespace: ns},
+			Spec:       annotationV0.AnnotationSpec{Text: "updated text", Time: 1000, Tags: []string{"new"}},
+		}
+		updated, _, err := adapter.Update(ctx, "anno", &updatedObjectInfo{obj: incoming}, nil, nil, false, &metav1.UpdateOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, "updated text", updated.(*annotationV0.Annotation).Spec.Text)
 	})
 }
 

--- a/pkg/services/annotations/annotationsapi/api_client.go
+++ b/pkg/services/annotations/annotationsapi/api_client.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -153,17 +154,17 @@ func (s *annotationAPIClient) GetByLegacyID(ctx context.Context, orgID int64, an
 		return nil, ErrNotFound
 	}
 
-	// Return the first non-deleted annotation, or the tombstone if all are deleted.
-	var tombstone *annotationV0.Annotation
-	for i := range list.Items {
-		if list.Items[i].GetDeletionTimestamp() == nil {
-			return &list.Items[i], nil
-		}
-		if tombstone == nil {
-			tombstone = &list.Items[i]
-		}
+	// Return the newest live annotation, or the tombstone if all are deleted.
+	live := slices.DeleteFunc(slices.Clone(list.Items), func(a annotationV0.Annotation) bool {
+		return a.GetDeletionTimestamp() != nil
+	})
+	if len(live) > 0 {
+		newest := slices.MaxFunc(live, func(a, b annotationV0.Annotation) int {
+			return a.GetCreationTimestamp().Compare(b.GetCreationTimestamp().Time)
+		})
+		return &newest, nil
 	}
-	return tombstone, nil
+	return &list.Items[0], nil
 }
 
 func (s *annotationAPIClient) GetUsersFromMeta(ctx context.Context, usersMeta []string) (map[string]*user.User, error) {

--- a/pkg/services/annotations/annotationsapi/api_client.go
+++ b/pkg/services/annotations/annotationsapi/api_client.go
@@ -152,7 +152,18 @@ func (s *annotationAPIClient) GetByLegacyID(ctx context.Context, orgID int64, an
 	if len(list.Items) == 0 {
 		return nil, ErrNotFound
 	}
-	return &list.Items[0], nil
+
+	// Return the first non-deleted annotation, or the tombstone if all are deleted.
+	var tombstone *annotationV0.Annotation
+	for i := range list.Items {
+		if list.Items[i].GetDeletionTimestamp() == nil {
+			return &list.Items[i], nil
+		}
+		if tombstone == nil {
+			tombstone = &list.Items[i]
+		}
+	}
+	return tombstone, nil
 }
 
 func (s *annotationAPIClient) GetUsersFromMeta(ctx context.Context, usersMeta []string) (map[string]*user.User, error) {

--- a/pkg/services/annotations/annotationsapi/api_client.go
+++ b/pkg/services/annotations/annotationsapi/api_client.go
@@ -29,6 +29,18 @@ import (
 
 const annotationServerAudience = "annotation.grafana.app"
 
+// annotationClient defines the interface for interacting with the annotation API server.
+type annotationClient interface {
+	Create(ctx context.Context, orgID int64, anno *annotationV0.Annotation) (*annotationV0.Annotation, error)
+	Update(ctx context.Context, orgID int64, anno *annotationV0.Annotation) (*annotationV0.Annotation, error)
+	Delete(ctx context.Context, orgID int64, name string) error
+	GetByLegacyID(ctx context.Context, orgID int64, annotationID int64) (*annotationV0.Annotation, error)
+	GetUsersFromMeta(ctx context.Context, usersMeta []string) (map[string]*user.User, error)
+	Search(ctx context.Context, orgID int64, query *annotations.ItemQuery) ([]*annotationV0.Annotation, error)
+}
+
+var _ annotationClient = (*annotationAPIClient)(nil)
+
 // TODO: consider replacing k8sClient with a rest.RESTClient built from restCfg for consistency -
 // CRUD ops (Create, Update, Delete, also GetByLegacyID) currently go through k8sClient (dynamic),
 // while Search uses rest.RESTClient directly.

--- a/pkg/services/annotations/annotationsapi/handler.go
+++ b/pkg/services/annotations/annotationsapi/handler.go
@@ -180,11 +180,18 @@ func (h *MigrationProxy) Update(ctx context.Context, orgID int64, annotationID i
 	anno.SetResourceVersion(existing.GetResourceVersion())
 	annotationpkg.SetLegacyID(anno, annotationID)
 	// Preserve fields absent from the update command so the PUT doesn't clear them.
+	// This aligns with the legacy API behavior where only the fields present in the request are updated.
 	if anno.Spec.DashboardUID == nil {
 		anno.Spec.DashboardUID = existing.Spec.DashboardUID
 	}
 	if anno.Spec.PanelID == nil {
 		anno.Spec.PanelID = existing.Spec.PanelID
+	}
+	if item.Epoch == 0 {
+		anno.Spec.Time = existing.Spec.Time
+	}
+	if item.EpochEnd == 0 {
+		anno.Spec.TimeEnd = existing.Spec.TimeEnd
 	}
 
 	// If time or timeEnd changed, re-create the annotation as the new API does not support updates to time/timeEnd

--- a/pkg/services/annotations/annotationsapi/handler.go
+++ b/pkg/services/annotations/annotationsapi/handler.go
@@ -183,7 +183,7 @@ func (h *MigrationProxy) Update(ctx context.Context, orgID int64, annotationID i
 	// Legacy API treats a point annotation as having EpochEnd == Epoch, so if the caller
 	// sends EpochEnd == Epoch, we treat it as a point and clear the end time. This prevents
 	// it from changing to a range when the caller only intended to move the point in time.
-	isPoint := existing.Spec.TimeEnd == nil && item.EpochEnd == existing.Spec.Time
+	isPoint := existing.Spec.TimeEnd == nil && (item.EpochEnd == existing.Spec.Time || item.EpochEnd == anno.Spec.Time)
 	if isPoint {
 		anno.Spec.TimeEnd = nil
 	} else if item.EpochEnd != 0 {

--- a/pkg/services/annotations/annotationsapi/handler.go
+++ b/pkg/services/annotations/annotationsapi/handler.go
@@ -180,12 +180,14 @@ func (h *MigrationProxy) Update(ctx context.Context, orgID int64, annotationID i
 	if item.Epoch != 0 {
 		anno.Spec.Time = item.Epoch
 	}
-	if item.EpochEnd != 0 {
-		anno.Spec.TimeEnd = &item.EpochEnd
-	}
-	// An end time at or before the start is a point and the new store represents that by omitting TimeEnd.
-	if anno.Spec.TimeEnd != nil && *anno.Spec.TimeEnd <= anno.Spec.Time {
+	// Legacy API treats a point annotation as having EpochEnd == Epoch, so if the caller
+	// sends EpochEnd == Epoch, we treat it as a point and clear the end time. This prevents
+	// it from changing to a range when the caller only intended to move the point in time.
+	isPoint := existing.Spec.TimeEnd == nil && item.EpochEnd == existing.Spec.Time
+	if isPoint {
 		anno.Spec.TimeEnd = nil
+	} else if item.EpochEnd != 0 {
+		anno.Spec.TimeEnd = &item.EpochEnd
 	}
 	if item.Data != nil {
 		raw, err := item.Data.Encode()

--- a/pkg/services/annotations/annotationsapi/handler.go
+++ b/pkg/services/annotations/annotationsapi/handler.go
@@ -180,8 +180,12 @@ func (h *MigrationProxy) Update(ctx context.Context, orgID int64, annotationID i
 	if item.Epoch != 0 {
 		anno.Spec.Time = item.Epoch
 	}
-	if item.EpochEnd != 0 && item.EpochEnd != anno.Spec.Time {
+	if item.EpochEnd != 0 {
 		anno.Spec.TimeEnd = &item.EpochEnd
+	}
+	// An end time at or before the start is a point and the new store represents that by omitting TimeEnd.
+	if anno.Spec.TimeEnd != nil && *anno.Spec.TimeEnd <= anno.Spec.Time {
+		anno.Spec.TimeEnd = nil
 	}
 	if item.Data != nil {
 		raw, err := item.Data.Encode()
@@ -315,8 +319,7 @@ func itemToAnnotation(item *annotations.Item) (*annotationV0.Annotation, error) 
 		Time: item.Epoch,
 		Tags: item.Tags,
 	}
-	if item.EpochEnd != 0 && item.EpochEnd != item.Epoch {
-		// Only set TimeEnd if it's non-zero and different from Time
+	if item.EpochEnd != 0 {
 		spec.TimeEnd = &item.EpochEnd
 	}
 	if item.DashboardUID != "" {

--- a/pkg/services/annotations/annotationsapi/handler.go
+++ b/pkg/services/annotations/annotationsapi/handler.go
@@ -172,26 +172,23 @@ func (h *MigrationProxy) Update(ctx context.Context, orgID int64, annotationID i
 	if existing.GetDeletionTimestamp() != nil {
 		return ErrGone
 	}
-	anno, err := itemToAnnotation(item)
-	if err != nil {
-		return err
-	}
-	anno.SetName(existing.GetName())
-	anno.SetResourceVersion(existing.GetResourceVersion())
-	annotationpkg.SetLegacyID(anno, annotationID)
-	// Preserve fields absent from the update command so the PUT doesn't clear them.
+	// Mutate a copy of the stored record and apply only the fields the caller supplied.
 	// This aligns with the legacy API behavior where only the fields present in the request are updated.
-	if anno.Spec.DashboardUID == nil {
-		anno.Spec.DashboardUID = existing.Spec.DashboardUID
+	anno := existing.DeepCopy()
+	anno.Spec.Text = item.Text
+	anno.Spec.Tags = item.Tags
+	if item.Epoch != 0 {
+		anno.Spec.Time = item.Epoch
 	}
-	if anno.Spec.PanelID == nil {
-		anno.Spec.PanelID = existing.Spec.PanelID
+	if item.EpochEnd != 0 && item.EpochEnd != anno.Spec.Time {
+		anno.Spec.TimeEnd = &item.EpochEnd
 	}
-	if item.Epoch == 0 {
-		anno.Spec.Time = existing.Spec.Time
-	}
-	if item.EpochEnd == 0 {
-		anno.Spec.TimeEnd = existing.Spec.TimeEnd
+	if item.Data != nil {
+		raw, err := item.Data.Encode()
+		if err != nil {
+			return fmt.Errorf("encoding legacy data: %w", err)
+		}
+		annotationpkg.SetLegacyData(anno, string(raw))
 	}
 
 	// If time or timeEnd changed, re-create the annotation as the new API does not support updates to time/timeEnd
@@ -212,6 +209,7 @@ func (h *MigrationProxy) Update(ctx context.Context, orgID int64, annotationID i
 // the annotation becomes attributed to that user instead.
 func (h *MigrationProxy) recreateWithNewTime(ctx context.Context, orgID int64, existing, anno *annotationV0.Annotation) error {
 	anno.SetName("")
+	anno.SetGenerateName("a-")
 	anno.SetResourceVersion("")
 	if _, err := h.client.Create(ctx, orgID, anno); err != nil {
 		return err
@@ -317,7 +315,8 @@ func itemToAnnotation(item *annotations.Item) (*annotationV0.Annotation, error) 
 		Time: item.Epoch,
 		Tags: item.Tags,
 	}
-	if item.EpochEnd != 0 {
+	if item.EpochEnd != 0 && item.EpochEnd != item.Epoch {
+		// Only set TimeEnd if it's non-zero and different from Time
 		spec.TimeEnd = &item.EpochEnd
 	}
 	if item.DashboardUID != "" {

--- a/pkg/services/annotations/annotationsapi/handler.go
+++ b/pkg/services/annotations/annotationsapi/handler.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 )
 
 // ErrNotFound is returned by proxy methods when the annotation is not in the new storage
@@ -43,7 +44,7 @@ func (e *partialDecodeError) Unwrap() error { return e.Err }
 
 // MigrationProxy routes annotation writes to the new API server.
 type MigrationProxy struct {
-	client *annotationAPIClient
+	client annotationClient
 	logger log.Logger
 }
 
@@ -163,7 +164,6 @@ func (h *MigrationProxy) Create(ctx context.Context, orgID int64, item *annotati
 }
 
 // Update writes to new store. Returns ErrNotFound if the record is not there yet, caller falls back to legacy.
-// TODO: only text/tags are updated; editing time needs annotation delete + re-insert since the store partitions on time.
 func (h *MigrationProxy) Update(ctx context.Context, orgID int64, annotationID int64, item *annotations.Item) error {
 	existing, err := h.client.GetByLegacyID(ctx, orgID, annotationID)
 	if err != nil {
@@ -186,8 +186,37 @@ func (h *MigrationProxy) Update(ctx context.Context, orgID int64, annotationID i
 	if anno.Spec.PanelID == nil {
 		anno.Spec.PanelID = existing.Spec.PanelID
 	}
+
+	// If time or timeEnd changed, re-create the annotation as the new API does not support updates to time/timeEnd
+	timeChanged := existing.Spec.Time != anno.Spec.Time || !ptr.Equal(existing.Spec.TimeEnd, anno.Spec.TimeEnd)
+	if timeChanged {
+		return h.recreateWithNewTime(ctx, orgID, existing, anno)
+	}
+
 	_, err = h.client.Update(ctx, orgID, anno)
 	return err
+}
+
+// recreateWithNewTime moves an annotation to a new time by creating a new record and then
+// deleting the old one. The new record keeps the same legacy ID, so the change is transparent to the
+// legacy API.
+//
+// Note: A potential side-effect of this is that if a user other than the creator edits an annotation,
+// the annotation becomes attributed to that user instead.
+func (h *MigrationProxy) recreateWithNewTime(ctx context.Context, orgID int64, existing, anno *annotationV0.Annotation) error {
+	anno.SetName("")
+	anno.SetResourceVersion("")
+	if _, err := h.client.Create(ctx, orgID, anno); err != nil {
+		return err
+	}
+
+	if err := h.client.Delete(ctx, orgID, existing.GetName()); err != nil {
+		// Best-effort delete. If this fails, there would be two live records
+		// with different k8s resource names in the new store.
+		h.logger.Warn("failed to delete old annotation after time edit",
+			"orgID", orgID, "name", existing.GetName(), "err", err)
+	}
+	return nil
 }
 
 // Delete soft-deletes in the new store. Returns ErrNotFound if the record is not

--- a/pkg/services/annotations/annotationsapi/handler_test.go
+++ b/pkg/services/annotations/annotationsapi/handler_test.go
@@ -278,6 +278,36 @@ func TestMigrationProxy(t *testing.T) {
 			assert.Equal(t, int64(3000), *client.created.Spec.TimeEnd)
 		})
 
+		t.Run("moving a point to an earlier time keeps it a point", func(t *testing.T) {
+			existing := existingAnno("anno-1") // Time: 1000, TimeEnd: nil (a point)
+			client := &fakeClient{existing: existing}
+			proxy := newProxy(client)
+
+			// The stale coerced end (1000) now exceeds the new start (500), but the caller
+			// only moved the time, so it stays a point rather than becoming a range.
+			err := proxy.Update(context.Background(), orgID, legacyID, &annotations.Item{Text: "after", Epoch: 500, EpochEnd: 1000})
+			require.NoError(t, err)
+
+			require.NotNil(t, client.created)
+			assert.Equal(t, int64(500), client.created.Spec.Time)
+			assert.Nil(t, client.created.Spec.TimeEnd, "a point edit stays a point in any direction")
+		})
+
+		t.Run("editing a range preserves its end", func(t *testing.T) {
+			existing := existingAnno("anno-1")
+			existing.Spec.TimeEnd = ptr.To(int64(2000)) // range 1000->2000
+			client := &fakeClient{existing: existing}
+			proxy := newProxy(client)
+
+			// PATCH fills EpochEnd from the stored range; a text-only edit must keep the range.
+			err := proxy.Update(context.Background(), orgID, legacyID, &annotations.Item{Text: "after", Epoch: 1000, EpochEnd: 2000})
+			require.NoError(t, err)
+
+			require.NotNil(t, client.updated, "an in-place range edit updates, not re-creates")
+			require.NotNil(t, client.updated.Spec.TimeEnd, "the range end is preserved")
+			assert.Equal(t, int64(2000), *client.updated.Spec.TimeEnd)
+		})
+
 		t.Run("time change with omitted data preserves the stored legacy data", func(t *testing.T) {
 			existing := existingAnno("anno-1")
 			annotationpkg.SetLegacyData(existing, `{"foo":"bar"}`)

--- a/pkg/services/annotations/annotationsapi/handler_test.go
+++ b/pkg/services/annotations/annotationsapi/handler_test.go
@@ -265,8 +265,21 @@ func TestMigrationProxy(t *testing.T) {
 			assert.Equal(t, []string{"anno-1"}, client.deletedNames)
 		})
 
+		t.Run("moving a point with the end matching the new start keeps it a point", func(t *testing.T) {
+			existing := existingAnno("anno-1")
+			client := &fakeClient{existing: existing}
+			proxy := newProxy(client)
+
+			err := proxy.Update(context.Background(), orgID, legacyID, &annotations.Item{Text: "after", Epoch: 5000, EpochEnd: 5000})
+			require.NoError(t, err)
+
+			require.NotNil(t, client.created)
+			assert.Equal(t, int64(5000), client.created.Spec.Time)
+			assert.Nil(t, client.created.Spec.TimeEnd, "the point stays a point, not a zero-length range")
+		})
+
 		t.Run("widening a point into a genuine range is honored", func(t *testing.T) {
-			existing := existingAnno("anno-1") // Time: 1000, TimeEnd: nil (a point)
+			existing := existingAnno("anno-1")
 			client := &fakeClient{existing: existing}
 			proxy := newProxy(client)
 
@@ -279,12 +292,10 @@ func TestMigrationProxy(t *testing.T) {
 		})
 
 		t.Run("moving a point to an earlier time keeps it a point", func(t *testing.T) {
-			existing := existingAnno("anno-1") // Time: 1000, TimeEnd: nil (a point)
+			existing := existingAnno("anno-1")
 			client := &fakeClient{existing: existing}
 			proxy := newProxy(client)
 
-			// The stale coerced end (1000) now exceeds the new start (500), but the caller
-			// only moved the time, so it stays a point rather than becoming a range.
 			err := proxy.Update(context.Background(), orgID, legacyID, &annotations.Item{Text: "after", Epoch: 500, EpochEnd: 1000})
 			require.NoError(t, err)
 
@@ -295,11 +306,10 @@ func TestMigrationProxy(t *testing.T) {
 
 		t.Run("editing a range preserves its end", func(t *testing.T) {
 			existing := existingAnno("anno-1")
-			existing.Spec.TimeEnd = ptr.To(int64(2000)) // range 1000->2000
+			existing.Spec.TimeEnd = ptr.To(int64(2000))
 			client := &fakeClient{existing: existing}
 			proxy := newProxy(client)
 
-			// PATCH fills EpochEnd from the stored range; a text-only edit must keep the range.
 			err := proxy.Update(context.Background(), orgID, legacyID, &annotations.Item{Text: "after", Epoch: 1000, EpochEnd: 2000})
 			require.NoError(t, err)
 

--- a/pkg/services/annotations/annotationsapi/handler_test.go
+++ b/pkg/services/annotations/annotationsapi/handler_test.go
@@ -1,11 +1,16 @@
 package annotationsapi
 
 import (
+	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	annotationV0 "github.com/grafana/grafana/apps/annotation/pkg/apis/annotation/v0alpha1"
 	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/infra/log"
 	annotationpkg "github.com/grafana/grafana/pkg/registry/apps/annotation"
 	"github.com/grafana/grafana/pkg/services/annotations"
 )
@@ -150,5 +155,118 @@ func TestItemAnnotationConversion(t *testing.T) {
 		require.NotNil(t, dto)
 		require.Equal(t, "hello", dto.Text)
 		require.Nil(t, dto.Data)
+	})
+}
+
+// fakeClient records the create/update/delete calls MigrationProxy makes against
+// the new store, letting the tests below observe the re-create path.
+type fakeClient struct {
+	annotationClient
+
+	existing *annotationV0.Annotation
+
+	created *annotationV0.Annotation
+	updated *annotationV0.Annotation
+
+	deletedNames []string
+	deleteErr    error
+	createErr    error
+}
+
+func (f *fakeClient) GetByLegacyID(context.Context, int64, int64) (*annotationV0.Annotation, error) {
+	return f.existing, nil
+}
+func (f *fakeClient) Create(_ context.Context, _ int64, anno *annotationV0.Annotation) (*annotationV0.Annotation, error) {
+	f.created = anno
+	return anno, f.createErr
+}
+func (f *fakeClient) Update(_ context.Context, _ int64, anno *annotationV0.Annotation) (*annotationV0.Annotation, error) {
+	f.updated = anno
+	return anno, nil
+}
+func (f *fakeClient) Delete(_ context.Context, _ int64, name string) error {
+	f.deletedNames = append(f.deletedNames, name)
+	return f.deleteErr
+}
+
+func TestMigrationProxy(t *testing.T) {
+	t.Run("Update", func(t *testing.T) {
+		const orgID, legacyID = int64(1), int64(42)
+
+		existingAnno := func(name string) *annotationV0.Annotation {
+			anno := &annotationV0.Annotation{
+				ObjectMeta: metav1.ObjectMeta{Name: name, ResourceVersion: "7"},
+				Spec:       annotationV0.AnnotationSpec{Text: "before", Time: 1000},
+			}
+			annotationpkg.SetLegacyID(anno, legacyID)
+			return anno
+		}
+
+		newProxy := func(client annotationClient) *MigrationProxy {
+			return &MigrationProxy{client: client, logger: log.New("test")}
+		}
+
+		t.Run("time unchanged updates in place, no re-create", func(t *testing.T) {
+			client := &fakeClient{existing: existingAnno("anno-1")}
+			proxy := newProxy(client)
+
+			err := proxy.Update(context.Background(), orgID, legacyID, &annotations.Item{Text: "after", Epoch: 1000})
+			require.NoError(t, err)
+
+			require.NotNil(t, client.updated, "an in-place edit must call Update")
+			assert.Equal(t, "anno-1", client.updated.GetName(), "in-place edit reuses the stored k8s name")
+			assert.Nil(t, client.created, "no re-create when the time is unchanged")
+			assert.Empty(t, client.deletedNames, "no delete when the time is unchanged")
+		})
+
+		t.Run("time change re-creates under a new name and deletes the old record", func(t *testing.T) {
+			client := &fakeClient{existing: existingAnno("anno-1")}
+			proxy := newProxy(client)
+
+			err := proxy.Update(context.Background(), orgID, legacyID, &annotations.Item{Text: "before", Epoch: 5000})
+			require.NoError(t, err)
+
+			require.NotNil(t, client.created, "a time edit must create a new record")
+			assert.Empty(t, client.created.GetName(), "the new record must not carry the old k8s name")
+			assert.Empty(t, client.created.GetResourceVersion(), "the new record must not carry the old resourceVersion")
+			assert.Equal(t, int64(5000), client.created.Spec.Time, "the new record carries the new time")
+			assert.Equal(t, legacyID, annotationpkg.GetLegacyID(client.created), "the legacy ID is preserved across the re-create")
+
+			assert.Nil(t, client.updated, "a time edit must not update in place")
+			assert.Equal(t, []string{"anno-1"}, client.deletedNames, "the old record must be deleted")
+		})
+
+		t.Run("timeEnd change re-creates as well", func(t *testing.T) {
+			client := &fakeClient{existing: existingAnno("anno-1")}
+			proxy := newProxy(client)
+
+			err := proxy.Update(context.Background(), orgID, legacyID, &annotations.Item{Text: "before", Epoch: 1000, EpochEnd: 2000})
+			require.NoError(t, err)
+
+			require.NotNil(t, client.created)
+			require.NotNil(t, client.created.Spec.TimeEnd)
+			assert.Equal(t, int64(2000), *client.created.Spec.TimeEnd)
+			assert.Equal(t, []string{"anno-1"}, client.deletedNames)
+		})
+
+		t.Run("re-create succeeds even when the best-effort delete of the old record fails", func(t *testing.T) {
+			client := &fakeClient{existing: existingAnno("anno-1"), deleteErr: assert.AnError}
+			proxy := newProxy(client)
+
+			err := proxy.Update(context.Background(), orgID, legacyID, &annotations.Item{Text: "before", Epoch: 5000})
+			require.NoError(t, err, "a failed cleanup delete must not fail the update")
+
+			require.NotNil(t, client.created, "the new record is still created")
+			assert.Equal(t, []string{"anno-1"}, client.deletedNames, "the delete was attempted")
+		})
+
+		t.Run("re-create propagates a failure to create the new record", func(t *testing.T) {
+			client := &fakeClient{existing: existingAnno("anno-1"), createErr: assert.AnError}
+			proxy := newProxy(client)
+
+			err := proxy.Update(context.Background(), orgID, legacyID, &annotations.Item{Text: "before", Epoch: 5000})
+			require.ErrorIs(t, err, assert.AnError)
+			assert.Empty(t, client.deletedNames, "the old record must not be deleted if the new one was not created")
+		})
 	})
 }

--- a/pkg/services/annotations/annotationsapi/handler_test.go
+++ b/pkg/services/annotations/annotationsapi/handler_test.go
@@ -129,12 +129,6 @@ func TestItemAnnotationConversion(t *testing.T) {
 		require.Equal(t, int64(1234), dto.TimeEnd, "point TimeEnd must match Time to align with legacy")
 	})
 
-	t.Run("EpochEnd equal to Epoch produces a point annotation", func(t *testing.T) {
-		anno, err := itemToAnnotation(&annotations.Item{Text: "hello", Epoch: 1234, EpochEnd: 1234})
-		require.NoError(t, err)
-		require.Nil(t, anno.Spec.TimeEnd, "EpochEnd == Epoch is a point, not a range")
-	})
-
 	t.Run("range annotation preserves a distinct TimeEnd", func(t *testing.T) {
 		anno, err := itemToAnnotation(&annotations.Item{Text: "hello", Epoch: 1000, EpochEnd: 2000})
 		require.NoError(t, err)
@@ -244,7 +238,7 @@ func TestMigrationProxy(t *testing.T) {
 		})
 
 		t.Run("point-annotation PATCH round-trip does not falsely detect a time change", func(t *testing.T) {
-			existing := existingAnno("anno-1") // Time: 1000, TimeEnd: nil (a point)
+			existing := existingAnno("anno-1")
 			client := &fakeClient{existing: existing}
 			proxy := newProxy(client)
 
@@ -255,6 +249,33 @@ func TestMigrationProxy(t *testing.T) {
 			assert.Nil(t, client.updated.Spec.TimeEnd, "the point must stay a point, not become a range")
 			assert.Nil(t, client.created, "no re-create for an unchanged point")
 			assert.Empty(t, client.deletedNames)
+		})
+
+		t.Run("moving a point to a later time keeps it a point", func(t *testing.T) {
+			existing := existingAnno("anno-1")
+			client := &fakeClient{existing: existing}
+			proxy := newProxy(client)
+
+			err := proxy.Update(context.Background(), orgID, legacyID, &annotations.Item{Text: "after", Epoch: 5000, EpochEnd: 1000})
+			require.NoError(t, err)
+
+			require.NotNil(t, client.created, "moving the time re-creates the record")
+			assert.Equal(t, int64(5000), client.created.Spec.Time, "the new start is applied")
+			assert.Nil(t, client.created.Spec.TimeEnd, "the point stays a point, not a backwards range")
+			assert.Equal(t, []string{"anno-1"}, client.deletedNames)
+		})
+
+		t.Run("widening a point into a genuine range is honored", func(t *testing.T) {
+			existing := existingAnno("anno-1") // Time: 1000, TimeEnd: nil (a point)
+			client := &fakeClient{existing: existing}
+			proxy := newProxy(client)
+
+			err := proxy.Update(context.Background(), orgID, legacyID, &annotations.Item{Text: "after", Epoch: 1000, EpochEnd: 3000})
+			require.NoError(t, err)
+
+			require.NotNil(t, client.created, "adding a distinct end changes the time shape, so it re-creates")
+			require.NotNil(t, client.created.Spec.TimeEnd, "a strictly-later end makes it a range")
+			assert.Equal(t, int64(3000), *client.created.Spec.TimeEnd)
 		})
 
 		t.Run("time change with omitted data preserves the stored legacy data", func(t *testing.T) {

--- a/pkg/services/annotations/annotationsapi/handler_test.go
+++ b/pkg/services/annotations/annotationsapi/handler_test.go
@@ -129,6 +129,12 @@ func TestItemAnnotationConversion(t *testing.T) {
 		require.Equal(t, int64(1234), dto.TimeEnd, "point TimeEnd must match Time to align with legacy")
 	})
 
+	t.Run("EpochEnd equal to Epoch produces a point annotation", func(t *testing.T) {
+		anno, err := itemToAnnotation(&annotations.Item{Text: "hello", Epoch: 1234, EpochEnd: 1234})
+		require.NoError(t, err)
+		require.Nil(t, anno.Spec.TimeEnd, "EpochEnd == Epoch is a point, not a range")
+	})
+
 	t.Run("range annotation preserves a distinct TimeEnd", func(t *testing.T) {
 		anno, err := itemToAnnotation(&annotations.Item{Text: "hello", Epoch: 1000, EpochEnd: 2000})
 		require.NoError(t, err)
@@ -237,6 +243,35 @@ func TestMigrationProxy(t *testing.T) {
 			assert.Empty(t, client.deletedNames, "no delete when the times are omitted")
 		})
 
+		t.Run("point-annotation PATCH round-trip does not falsely detect a time change", func(t *testing.T) {
+			existing := existingAnno("anno-1") // Time: 1000, TimeEnd: nil (a point)
+			client := &fakeClient{existing: existing}
+			proxy := newProxy(client)
+
+			err := proxy.Update(context.Background(), orgID, legacyID, &annotations.Item{Text: "after", Epoch: 1000, EpochEnd: 1000})
+			require.NoError(t, err)
+
+			require.NotNil(t, client.updated, "a point edit must update in place, not re-create")
+			assert.Nil(t, client.updated.Spec.TimeEnd, "the point must stay a point, not become a range")
+			assert.Nil(t, client.created, "no re-create for an unchanged point")
+			assert.Empty(t, client.deletedNames)
+		})
+
+		t.Run("time change with omitted data preserves the stored legacy data", func(t *testing.T) {
+			existing := existingAnno("anno-1")
+			annotationpkg.SetLegacyData(existing, `{"foo":"bar"}`)
+			client := &fakeClient{existing: existing}
+			proxy := newProxy(client)
+
+			err := proxy.Update(context.Background(), orgID, legacyID, &annotations.Item{Text: "before", Epoch: 5000})
+			require.NoError(t, err)
+
+			require.NotNil(t, client.created, "a time edit re-creates the record")
+			stored, ok := annotationpkg.GetLegacyData(client.created)
+			require.True(t, ok, "legacy data must be carried onto the re-created record")
+			assert.JSONEq(t, `{"foo":"bar"}`, stored)
+		})
+
 		t.Run("time change re-creates under a new name and deletes the old record", func(t *testing.T) {
 			client := &fakeClient{existing: existingAnno("anno-1")}
 			proxy := newProxy(client)
@@ -246,6 +281,7 @@ func TestMigrationProxy(t *testing.T) {
 
 			require.NotNil(t, client.created, "a time edit must create a new record")
 			assert.Empty(t, client.created.GetName(), "the new record must not carry the old k8s name")
+			assert.Equal(t, "a-", client.created.GetGenerateName(), "the new record must ask the store for a fresh name")
 			assert.Empty(t, client.created.GetResourceVersion(), "the new record must not carry the old resourceVersion")
 			assert.Equal(t, int64(5000), client.created.Spec.Time, "the new record carries the new time")
 			assert.Equal(t, legacyID, annotationpkg.GetLegacyID(client.created), "the legacy ID is preserved across the re-create")

--- a/pkg/services/annotations/annotationsapi/handler_test.go
+++ b/pkg/services/annotations/annotationsapi/handler_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	annotationV0 "github.com/grafana/grafana/apps/annotation/pkg/apis/annotation/v0alpha1"
 	"github.com/grafana/grafana/pkg/components/simplejson"
@@ -217,6 +218,23 @@ func TestMigrationProxy(t *testing.T) {
 			assert.Equal(t, "anno-1", client.updated.GetName(), "in-place edit reuses the stored k8s name")
 			assert.Nil(t, client.created, "no re-create when the time is unchanged")
 			assert.Empty(t, client.deletedNames, "no delete when the time is unchanged")
+		})
+
+		t.Run("text-only PUT with omitted times updates in place and preserves the stored time range", func(t *testing.T) {
+			existing := existingAnno("anno-1")
+			existing.Spec.TimeEnd = ptr.To(int64(2000))
+			client := &fakeClient{existing: existing}
+			proxy := newProxy(client)
+
+			err := proxy.Update(context.Background(), orgID, legacyID, &annotations.Item{Text: "after"})
+			require.NoError(t, err)
+
+			require.NotNil(t, client.updated, "omitted times must not trigger a re-create")
+			assert.Equal(t, int64(1000), client.updated.Spec.Time, "the stored time is preserved")
+			require.NotNil(t, client.updated.Spec.TimeEnd, "the stored timeEnd is preserved, not dropped")
+			assert.Equal(t, int64(2000), *client.updated.Spec.TimeEnd)
+			assert.Nil(t, client.created, "no re-create when the times are omitted")
+			assert.Empty(t, client.deletedNames, "no delete when the times are omitted")
 		})
 
 		t.Run("time change re-creates under a new name and deletes the old record", func(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR addresses a TODO from the annotation migration proxy around updating time/timeEnd. The new annotation API does not support updates to time/timeEnd, so to maintain support for this in the legacy API when proxying, we detect if the time/timeEnd is being updated and if so delete and re-create the annotation in the new API.

This PR also adds some basic validation to the new API's Update path to ensure only mutable fields are being modified and will reject updates that try to modify fields that are not.

**Why do we need this feature?**

We want to maintain support for all legacy API behavior while migrating over to the new API. This allows us to do that for edits to time/timeEnd.

**Who is this feature for?**



**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana-org/issues/954

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
