### PR TITLE
Explore Logs: fix infinite scroll do not rely on loading only

### DIFF
--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -160,6 +160,7 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
     logsVolumeData,
     loadLogsVolumeData,
     loading = false,
+    loadingState,
     onClickFilterLabel,
     onClickFilterOutLabel,
     timeZone,
@@ -939,7 +940,7 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
                   getFieldLinks={getFieldLinks}
                   getRowContextQuery={getRowContextQuery}
                   isLabelFilterActive={props.isFilterLabelActive}
-                  loading={loading}
+                  loadingState={loadingState}
                   loadMore={infiniteScrollAvailable ? loadMoreLogs : undefined}
                   logOptionsStorageKey={SETTING_KEY_ROOT}
                   logs={dedupedRows}

--- a/public/app/features/logs/components/panel/InfiniteScroll.test.tsx
+++ b/public/app/features/logs/components/panel/InfiniteScroll.test.tsx
@@ -311,13 +311,7 @@ describe('InfiniteScroll', () => {
   );
 });
 
-// Regression tests for https://github.com/grafana/grafana/issues/129033: in interval mode the loader
-// loaded more logs only once and then got stuck or wrongly showed "End of the selected time range".
-// The loader resolves a load-more when its request settles (loadingState leaves Loading/Streaming);
-// on Done it waits for the settled rows to propagate (the `logs` prop lags loadingState by a render,
-// since LogList turns it into processedLogs via an effect) and compares against the row count captured
-// when the load-more started (Loki query splitting streams partial pages, growing rows across renders);
-// on Error it returns to idle so the user can retry.
+// Regression tests for https://github.com/grafana/grafana/issues/129033 (infinite scroll stopping early).
 describe('InfiniteScroll consecutive loads (regression #129033)', () => {
   // Page 1 sits early in the range so canScrollBottom returns a valid next window.
   const pageFrom = absoluteRange.from + 2 * SCROLLING_THRESHOLD;
@@ -393,15 +387,13 @@ describe('InfiniteScroll consecutive loads (regression #129033)', () => {
     scroll(element, events, 60, 600);
     expect(loadMoreMock).toHaveBeenCalledTimes(1);
 
-    // In flight: an intermediate emission re-emits the previous rows (same length, new array). The
-    // loader must not latch 'out-of-bounds' here.
+    // In flight: an intermediate same-length emission must not latch 'out-of-bounds'.
     act(() => {
       rerender(ui(createLogs(pageFrom, pageTo), element, loadMoreMock, LoadingState.Loading));
     });
     expect(screen.queryByText('End of the selected time range.')).not.toBeInTheDocument();
 
-    // The larger page arrives and the request settles (Loading -> Done). New rows were returned, so
-    // the loader returns to idle rather than end-of-range.
+    // Settles with new rows -> idle, not end-of-range.
     const grown = [...page1, createLogLine({ entry: 'log line 3', uid: 'log-3', timeEpochMs: pageTo })];
     act(() => {
       rerender(ui(grown, element, loadMoreMock, LoadingState.Done));
@@ -422,8 +414,7 @@ describe('InfiniteScroll consecutive loads (regression #129033)', () => {
     scroll(element, events, 60, 600);
     expect(loadMoreMock).toHaveBeenCalledTimes(1);
 
-    // Settles (Loading -> Done) with the same number of rows → genuine end of range. Each emission is
-    // a fresh array (new reference, same content), as redux/decorate/memoization always produce.
+    // Settles with the same row count -> genuine end of range (fresh array each emission).
     act(() => {
       rerender(ui(createLogs(pageFrom, pageTo), element, loadMoreMock, LoadingState.Loading));
     });
@@ -445,16 +436,14 @@ describe('InfiniteScroll consecutive loads (regression #129033)', () => {
     scroll(element, events, 60, 600);
     expect(loadMoreMock).toHaveBeenCalledTimes(1);
 
-    // Query splitting streams partial pages across several in-flight (Loading) emissions, growing the
-    // rows before the request finishes...
+    // Query splitting grows the rows across in-flight emissions...
     act(() => {
       rerender(ui(makeLogs(4), element, loadMoreMock, LoadingState.Loading));
     });
     act(() => {
       rerender(ui(makeLogs(6), element, loadMoreMock, LoadingState.Loading));
     });
-    // ...and the final Done carries the same fully-merged rows as the last Loading emission. Comparing
-    // against the start count (2 -> 6) correctly returns to idle; comparing against prevLogs would not.
+    // ...and Done carries the same rows as the last emission; comparing against the start count (2 -> 6) -> idle.
     act(() => {
       rerender(ui(makeLogs(6), element, loadMoreMock, LoadingState.Done));
     });
@@ -475,8 +464,7 @@ describe('InfiniteScroll consecutive loads (regression #129033)', () => {
     scroll(element, events, 60, 600);
     expect(loadMoreMock).toHaveBeenCalledTimes(1);
 
-    // Loki query splitting streams partial pages as `Streaming` (not `Loading`). These must count as
-    // in flight — the loader must not settle or flag end-of-range mid-stream.
+    // Streaming emissions must count as in flight — no settle or end-of-range mid-stream.
     act(() => {
       rerender(ui(createLogs(pageFrom, pageTo), element, loadMoreMock, LoadingState.Streaming));
     });
@@ -510,8 +498,7 @@ describe('InfiniteScroll consecutive loads (regression #129033)', () => {
     });
     expect(await screen.findByTestId('Spinner')).toBeInTheDocument();
 
-    // The request errors (no new rows). The loader must leave 'loading' — returning to idle so the
-    // user can retry — rather than getting stuck on the spinner or latching end-of-range.
+    // Errors (no new rows) must return to idle, not stick on the spinner or latch end-of-range.
     act(() => {
       rerender(ui(page1, element, loadMoreMock, LoadingState.Error));
     });

--- a/public/app/features/logs/components/panel/InfiniteScroll.test.tsx
+++ b/public/app/features/logs/components/panel/InfiniteScroll.test.tsx
@@ -311,6 +311,120 @@ describe('InfiniteScroll', () => {
   );
 });
 
+// Regression test for https://github.com/grafana/grafana/issues/129033: in interval mode the loader
+// loaded more logs only once and then got stuck showing "End of the selected time range". While a
+// load-more was in flight, Loki query splitting re-emits the previous response (same rows, new array)
+// with state=Loading; the loader treated that same-length change as "no new logs" and latched
+// 'out-of-bounds' before the real page arrived. The fix waits for the request to settle (loading
+// true -> false) and compares against the row count captured when the load-more started.
+describe('InfiniteScroll consecutive loads (regression #129033)', () => {
+  // Page 1 sits early in the range so canScrollBottom returns a valid next window.
+  const pageFrom = absoluteRange.from + 2 * SCROLLING_THRESHOLD;
+  const pageTo = absoluteRange.from + 50 * SCROLLING_THRESHOLD;
+
+  function ui(
+    currentLogs: LogListModel[],
+    element: ReturnType<typeof getMockElement>['element'],
+    loadMore: jest.Mock,
+    loading = false
+  ) {
+    return (
+      <InfiniteScroll
+        {...defaultProps}
+        sortOrder={LogsSortOrder.Ascending}
+        logs={currentLogs}
+        scrollElement={element as unknown as HTMLDivElement}
+        loadMore={loadMore}
+        loading={loading}
+        infiniteScrollMode="interval"
+      >
+        {({ getItemKey, itemCount, onItemsRendered, Renderer }) => (
+          <VariableSizeList
+            height={100}
+            itemCount={itemCount}
+            itemSize={() => virtualization.getLineHeight()}
+            itemKey={getItemKey}
+            layout="vertical"
+            onItemsRendered={onItemsRendered}
+            style={{ overflow: 'scroll' }}
+            width="100%"
+          >
+            {Renderer}
+          </VariableSizeList>
+        )}
+      </InfiniteScroll>
+    );
+  }
+
+  function scroll(
+    element: { scrollTop: number },
+    events: Record<string, (e: Event | WheelEvent) => void>,
+    position: number,
+    timeStamp: number
+  ) {
+    element.scrollTop = position;
+    act(() => {
+      const event = new Event('scroll');
+      jest.spyOn(event, 'timeStamp', 'get').mockReturnValue(timeStamp);
+      events['scroll'](event);
+    });
+  }
+
+  test('an intermediate same-length emission does not latch out-of-bounds (Ascending)', async () => {
+    const loadMoreMock = jest.fn();
+    const { element, events } = getMockElement(50);
+
+    const page1 = createLogs(pageFrom, pageTo);
+    const { rerender } = render(ui(page1, element, loadMoreMock, false));
+
+    expect(await screen.findByText('log line 1')).toBeInTheDocument();
+
+    // First scroll to the bottom triggers the first load-more.
+    scroll(element, events, 59, 1);
+    scroll(element, events, 60, 600);
+    expect(loadMoreMock).toHaveBeenCalledTimes(1);
+
+    // While the request is loading, Loki query splitting re-emits the previous rows (same length,
+    // new array) with state=Loading. The buggy code latched 'out-of-bounds' here; it must not.
+    act(() => {
+      rerender(ui(createLogs(pageFrom, pageTo), element, loadMoreMock, true));
+    });
+    expect(screen.queryByText('End of the selected time range.')).not.toBeInTheDocument();
+
+    // The real, larger page arrives and the request settles (loading true -> false). Because new
+    // rows were returned, the loader returns to idle rather than end-of-range.
+    const grown = [...page1, createLogLine({ entry: 'log line 3', uid: 'log-3', timeEpochMs: pageTo })];
+    act(() => {
+      rerender(ui(grown, element, loadMoreMock, false));
+    });
+    expect(screen.queryByText('End of the selected time range.')).not.toBeInTheDocument();
+  });
+
+  test('flags out-of-bounds only when a settled load-more returns no new rows (Ascending)', async () => {
+    const loadMoreMock = jest.fn();
+    const { element, events } = getMockElement(50);
+
+    const page1 = createLogs(pageFrom, pageTo);
+    const { rerender } = render(ui(page1, element, loadMoreMock, false));
+
+    expect(await screen.findByText('log line 1')).toBeInTheDocument();
+
+    scroll(element, events, 59, 1);
+    scroll(element, events, 60, 600);
+    expect(loadMoreMock).toHaveBeenCalledTimes(1);
+
+    // Request settles (loading true -> false) with the same number of rows → genuine end of range.
+    act(() => {
+      rerender(ui(page1, element, loadMoreMock, true));
+    });
+    act(() => {
+      rerender(ui(page1, element, loadMoreMock, false));
+    });
+
+    expect(await screen.findByText('End of the selected time range.')).toBeInTheDocument();
+  });
+});
+
 function createLogs(from: number, to: number) {
   const rows = [
     createLogLine({ entry: 'log line 1', uid: 'log-1' }),

--- a/public/app/features/logs/components/panel/InfiniteScroll.test.tsx
+++ b/public/app/features/logs/components/panel/InfiniteScroll.test.tsx
@@ -505,6 +505,33 @@ describe('InfiniteScroll consecutive loads (regression #129033)', () => {
     expect(screen.queryByTestId('Spinner')).not.toBeInTheDocument();
     expect(screen.queryByText('End of the selected time range.')).not.toBeInTheDocument();
   });
+
+  test('re-running the query clears a stale out-of-bounds (Ascending)', async () => {
+    const loadMoreMock = jest.fn();
+    const { element, events } = getMockElement(50);
+
+    const page1 = createLogs(pageFrom, pageTo);
+    const { rerender } = render(ui(page1, element, loadMoreMock, LoadingState.Done));
+
+    expect(await screen.findByText('log line 1')).toBeInTheDocument();
+
+    // Reach out-of-bounds: a settled load-more returns no new rows.
+    scroll(element, events, 59, 1);
+    scroll(element, events, 60, 600);
+    act(() => {
+      rerender(ui(createLogs(pageFrom, pageTo), element, loadMoreMock, LoadingState.Loading));
+    });
+    act(() => {
+      rerender(ui(createLogs(pageFrom, pageTo), element, loadMoreMock, LoadingState.Done));
+    });
+    expect(await screen.findByText('End of the selected time range.')).toBeInTheDocument();
+
+    // Re-running the query replaces the logs (not a load-more); the stale out-of-bounds must clear.
+    act(() => {
+      rerender(ui(makeLogs(3), element, loadMoreMock, LoadingState.Done));
+    });
+    expect(screen.queryByText('End of the selected time range.')).not.toBeInTheDocument();
+  });
 });
 
 function createLogs(from: number, to: number) {

--- a/public/app/features/logs/components/panel/InfiniteScroll.test.tsx
+++ b/public/app/features/logs/components/panel/InfiniteScroll.test.tsx
@@ -462,6 +462,35 @@ describe('InfiniteScroll consecutive loads (regression #129033)', () => {
     expect(screen.queryByText('End of the selected time range.')).not.toBeInTheDocument();
   });
 
+  test('treats Streaming emissions as in flight, settling only on Done (Ascending)', async () => {
+    const loadMoreMock = jest.fn();
+    const { element, events } = getMockElement(50);
+
+    const page1 = createLogs(pageFrom, pageTo);
+    const { rerender } = render(ui(page1, element, loadMoreMock, LoadingState.Done));
+
+    expect(await screen.findByText('log line 1')).toBeInTheDocument();
+
+    scroll(element, events, 59, 1);
+    scroll(element, events, 60, 600);
+    expect(loadMoreMock).toHaveBeenCalledTimes(1);
+
+    // Loki query splitting streams partial pages as `Streaming` (not `Loading`). These must count as
+    // in flight — the loader must not settle or flag end-of-range mid-stream.
+    act(() => {
+      rerender(ui(createLogs(pageFrom, pageTo), element, loadMoreMock, LoadingState.Streaming));
+    });
+    expect(await screen.findByTestId('Spinner')).toBeInTheDocument();
+    expect(screen.queryByText('End of the selected time range.')).not.toBeInTheDocument();
+
+    // Settles on Done with new rows -> idle.
+    const grown = [...page1, createLogLine({ entry: 'log line 3', uid: 'log-3', timeEpochMs: pageTo })];
+    act(() => {
+      rerender(ui(grown, element, loadMoreMock, LoadingState.Done));
+    });
+    expect(screen.queryByText('End of the selected time range.')).not.toBeInTheDocument();
+  });
+
   test('recovers to idle (not stuck) when a load-more errors (Ascending)', async () => {
     const loadMoreMock = jest.fn();
     const { element, events } = getMockElement(50);

--- a/public/app/features/logs/components/panel/InfiniteScroll.test.tsx
+++ b/public/app/features/logs/components/panel/InfiniteScroll.test.tsx
@@ -1,7 +1,7 @@
 import { act, render, screen } from '@testing-library/react';
 import { VariableSizeList } from 'react-window';
 
-import { createTheme, dateTimeForTimeZone, rangeUtil } from '@grafana/data';
+import { createTheme, dateTimeForTimeZone, LoadingState, rangeUtil } from '@grafana/data';
 import { LogsSortOrder } from '@grafana/schema';
 
 import { ScrollDirection, SCROLLING_THRESHOLD } from '../infiniteScrollUtils';
@@ -311,22 +311,31 @@ describe('InfiniteScroll', () => {
   );
 });
 
-// Regression test for https://github.com/grafana/grafana/issues/129033: in interval mode the loader
-// loaded more logs only once and then got stuck showing "End of the selected time range". While a
-// load-more was in flight, Loki query splitting re-emits the previous response (same rows, new array)
-// with state=Loading; the loader treated that same-length change as "no new logs" and latched
-// 'out-of-bounds' before the real page arrived. The fix waits for the request to settle (loading
-// true -> false) and compares against the row count captured when the load-more started.
+// Regression tests for https://github.com/grafana/grafana/issues/129033: in interval mode the loader
+// loaded more logs only once and then got stuck or wrongly showed "End of the selected time range".
+// The loader resolves a load-more when its request settles (loadingState leaves Loading/Streaming);
+// on Done it waits for the settled rows to propagate (the `logs` prop lags loadingState by a render,
+// since LogList turns it into processedLogs via an effect) and compares against the row count captured
+// when the load-more started (Loki query splitting streams partial pages, growing rows across renders);
+// on Error it returns to idle so the user can retry.
 describe('InfiniteScroll consecutive loads (regression #129033)', () => {
   // Page 1 sits early in the range so canScrollBottom returns a valid next window.
   const pageFrom = absoluteRange.from + 2 * SCROLLING_THRESHOLD;
   const pageTo = absoluteRange.from + 50 * SCROLLING_THRESHOLD;
 
+  // n log lines spread across [pageFrom, pageTo] (oldest first), a fresh array each call.
+  function makeLogs(n: number): LogListModel[] {
+    return Array.from({ length: n }, (_, i) => {
+      const ts = pageFrom + Math.round(((pageTo - pageFrom) * i) / Math.max(n - 1, 1));
+      return createLogLine({ entry: `line ${i}`, uid: `log-${i}`, timeEpochMs: ts });
+    });
+  }
+
   function ui(
     currentLogs: LogListModel[],
     element: ReturnType<typeof getMockElement>['element'],
     loadMore: jest.Mock,
-    loading = false
+    loadingState: LoadingState = LoadingState.Done
   ) {
     return (
       <InfiniteScroll
@@ -335,7 +344,7 @@ describe('InfiniteScroll consecutive loads (regression #129033)', () => {
         logs={currentLogs}
         scrollElement={element as unknown as HTMLDivElement}
         loadMore={loadMore}
-        loading={loading}
+        loadingState={loadingState}
         infiniteScrollMode="interval"
       >
         {({ getItemKey, itemCount, onItemsRendered, Renderer }) => (
@@ -370,12 +379,12 @@ describe('InfiniteScroll consecutive loads (regression #129033)', () => {
     });
   }
 
-  test('an intermediate same-length emission does not latch out-of-bounds (Ascending)', async () => {
+  test('resolves to idle when a settled load-more returns new rows (Ascending)', async () => {
     const loadMoreMock = jest.fn();
     const { element, events } = getMockElement(50);
 
     const page1 = createLogs(pageFrom, pageTo);
-    const { rerender } = render(ui(page1, element, loadMoreMock, false));
+    const { rerender } = render(ui(page1, element, loadMoreMock, LoadingState.Done));
 
     expect(await screen.findByText('log line 1')).toBeInTheDocument();
 
@@ -384,18 +393,18 @@ describe('InfiniteScroll consecutive loads (regression #129033)', () => {
     scroll(element, events, 60, 600);
     expect(loadMoreMock).toHaveBeenCalledTimes(1);
 
-    // While the request is loading, Loki query splitting re-emits the previous rows (same length,
-    // new array) with state=Loading. The buggy code latched 'out-of-bounds' here; it must not.
+    // In flight: an intermediate emission re-emits the previous rows (same length, new array). The
+    // loader must not latch 'out-of-bounds' here.
     act(() => {
-      rerender(ui(createLogs(pageFrom, pageTo), element, loadMoreMock, true));
+      rerender(ui(createLogs(pageFrom, pageTo), element, loadMoreMock, LoadingState.Loading));
     });
     expect(screen.queryByText('End of the selected time range.')).not.toBeInTheDocument();
 
-    // The real, larger page arrives and the request settles (loading true -> false). Because new
-    // rows were returned, the loader returns to idle rather than end-of-range.
+    // The larger page arrives and the request settles (Loading -> Done). New rows were returned, so
+    // the loader returns to idle rather than end-of-range.
     const grown = [...page1, createLogLine({ entry: 'log line 3', uid: 'log-3', timeEpochMs: pageTo })];
     act(() => {
-      rerender(ui(grown, element, loadMoreMock, false));
+      rerender(ui(grown, element, loadMoreMock, LoadingState.Done));
     });
     expect(screen.queryByText('End of the selected time range.')).not.toBeInTheDocument();
   });
@@ -405,7 +414,7 @@ describe('InfiniteScroll consecutive loads (regression #129033)', () => {
     const { element, events } = getMockElement(50);
 
     const page1 = createLogs(pageFrom, pageTo);
-    const { rerender } = render(ui(page1, element, loadMoreMock, false));
+    const { rerender } = render(ui(page1, element, loadMoreMock, LoadingState.Done));
 
     expect(await screen.findByText('log line 1')).toBeInTheDocument();
 
@@ -413,15 +422,72 @@ describe('InfiniteScroll consecutive loads (regression #129033)', () => {
     scroll(element, events, 60, 600);
     expect(loadMoreMock).toHaveBeenCalledTimes(1);
 
-    // Request settles (loading true -> false) with the same number of rows → genuine end of range.
+    // Settles (Loading -> Done) with the same number of rows → genuine end of range. Each emission is
+    // a fresh array (new reference, same content), as redux/decorate/memoization always produce.
     act(() => {
-      rerender(ui(page1, element, loadMoreMock, true));
+      rerender(ui(createLogs(pageFrom, pageTo), element, loadMoreMock, LoadingState.Loading));
     });
     act(() => {
-      rerender(ui(page1, element, loadMoreMock, false));
+      rerender(ui(createLogs(pageFrom, pageTo), element, loadMoreMock, LoadingState.Done));
     });
 
     expect(await screen.findByText('End of the selected time range.')).toBeInTheDocument();
+  });
+
+  test('does not flag end-of-range when query splitting grows rows across in-flight emissions (Ascending)', async () => {
+    const loadMoreMock = jest.fn();
+    const { element, events } = getMockElement(50);
+
+    const { rerender } = render(ui(makeLogs(2), element, loadMoreMock, LoadingState.Done));
+    expect(await screen.findByText('line 0')).toBeInTheDocument();
+
+    scroll(element, events, 59, 1);
+    scroll(element, events, 60, 600);
+    expect(loadMoreMock).toHaveBeenCalledTimes(1);
+
+    // Query splitting streams partial pages across several in-flight (Loading) emissions, growing the
+    // rows before the request finishes...
+    act(() => {
+      rerender(ui(makeLogs(4), element, loadMoreMock, LoadingState.Loading));
+    });
+    act(() => {
+      rerender(ui(makeLogs(6), element, loadMoreMock, LoadingState.Loading));
+    });
+    // ...and the final Done carries the same fully-merged rows as the last Loading emission. Comparing
+    // against the start count (2 -> 6) correctly returns to idle; comparing against prevLogs would not.
+    act(() => {
+      rerender(ui(makeLogs(6), element, loadMoreMock, LoadingState.Done));
+    });
+
+    expect(screen.queryByText('End of the selected time range.')).not.toBeInTheDocument();
+  });
+
+  test('recovers to idle (not stuck) when a load-more errors (Ascending)', async () => {
+    const loadMoreMock = jest.fn();
+    const { element, events } = getMockElement(50);
+
+    const page1 = createLogs(pageFrom, pageTo);
+    const { rerender } = render(ui(page1, element, loadMoreMock, LoadingState.Done));
+
+    expect(await screen.findByText('log line 1')).toBeInTheDocument();
+
+    scroll(element, events, 59, 1);
+    scroll(element, events, 60, 600);
+    expect(loadMoreMock).toHaveBeenCalledTimes(1);
+
+    // In flight: the loading spinner is shown.
+    act(() => {
+      rerender(ui(createLogs(pageFrom, pageTo), element, loadMoreMock, LoadingState.Loading));
+    });
+    expect(await screen.findByTestId('Spinner')).toBeInTheDocument();
+
+    // The request errors (no new rows). The loader must leave 'loading' — returning to idle so the
+    // user can retry — rather than getting stuck on the spinner or latching end-of-range.
+    act(() => {
+      rerender(ui(page1, element, loadMoreMock, LoadingState.Error));
+    });
+    expect(screen.queryByTestId('Spinner')).not.toBeInTheDocument();
+    expect(screen.queryByText('End of the selected time range.')).not.toBeInTheDocument();
   });
 });
 

--- a/public/app/features/logs/components/panel/InfiniteScroll.tsx
+++ b/public/app/features/logs/components/panel/InfiniteScroll.tsx
@@ -2,7 +2,7 @@ import { type ReactNode, useCallback, useEffect, useRef, useState, type MouseEve
 import { usePrevious } from 'react-use';
 import { type ListChildComponentProps, type ListOnItemsRenderedProps } from 'react-window';
 
-import { type AbsoluteTimeRange, LogsSortOrder, type TimeRange } from '@grafana/data';
+import { type AbsoluteTimeRange, LoadingState, LogsSortOrder, type TimeRange } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
 import { Spinner, useStyles2 } from '@grafana/ui';
@@ -32,7 +32,7 @@ export interface Props {
   displayedFields: string[];
   handleOverflow: (index: number, id: string, height?: number) => void;
   infiniteScrollMode: InfiniteScrollMode;
-  loading?: boolean;
+  loadingState?: LoadingState;
   loadMore?: LoadMoreLogsType;
   logs: LogListModel[];
   onClick: (e: MouseEvent<HTMLElement>, log: LogListModel) => void;
@@ -57,7 +57,7 @@ export const InfiniteScroll = ({
   displayedFields,
   handleOverflow,
   infiniteScrollMode,
-  loading,
+  loadingState,
   loadMore,
   logs,
   onClick,
@@ -82,8 +82,11 @@ export const InfiniteScroll = ({
   const resetStateTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
   const scrollToLogLineRef = useRef<LogListModel | undefined>(undefined);
   const noScrollRef = useRef<undefined | boolean>(undefined);
-  const prevLoading = usePrevious(loading);
   const loadMoreCountRef = useRef<number | null>(null);
+  const settledRef = useRef(false);
+  // The request backing a load-more is in flight while its state is Loading or Streaming.
+  const requestInFlight = loadingState === LoadingState.Loading || loadingState === LoadingState.Streaming;
+  const prevInFlight = usePrevious(requestInFlight);
 
   useEffect(() => {
     // Fresh logs from a new query (not infinite scrolling): reset paging and scroll.
@@ -92,25 +95,41 @@ export const InfiniteScroll = ({
       setAutoScroll(true);
       return;
     }
-    // Resolve a load-more only once the request has finished. Intermediate emissions
-    // (e.g. Loki query splitting re-emits the previous response with state=Loading
-    // before the new page arrives) carry the same rows, so deciding on every logs
-    // change would prematurely flag "out-of-bounds" and stop infinite scrolling. We
-    // wait for the request to settle (loading true -> false) and compare against the
-    // row count captured when the load-more started.
-    if (infiniteLoaderState === 'loading' && prevLoading && !loading) {
-      const startCount = loadMoreCountRef.current;
-      loadMoreCountRef.current = null;
-      setInfiniteLoaderState(
-        startCount !== null && logs.length === startCount && infiniteScrollMode === 'interval'
-          ? 'out-of-bounds'
-          : 'idle'
-      );
-      if (scrollToLogLineRef.current) {
-        setAutoScroll(true);
+    if (infiniteLoaderState === 'loading') {
+      // Only act once we've observed the request go in flight and then settle (Loading/Streaming ->
+      // not). Requiring that transition ignores the stale/settled states seen right after the
+      // load-more starts (cancelQueries flips the response to Done before the new request begins).
+      if (prevInFlight && !requestInFlight) {
+        settledRef.current = true;
+      }
+      if (!settledRef.current) {
+        return;
+      }
+      if (loadingState === LoadingState.Error) {
+        // The request failed and returns no new rows: return to idle so the user can retry by
+        // scrolling again, rather than getting stuck on the loading indicator.
+        settledRef.current = false;
+        loadMoreCountRef.current = null;
+        setInfiniteLoaderState('idle');
+        return;
+      }
+      // Wait until the settled rows have propagated before deciding. `logs` lags `loadingState` by a
+      // render (LogList turns the `logs` prop into `processedLogs` via an effect), so on the settle
+      // render `logs` still holds the pre-request rows; deciding then would read a stale count and
+      // wrongly flag "out-of-bounds". Compare against the count captured when the load-more started
+      // (not prevLogs): Loki query splitting streams partial pages, growing the rows across renders.
+      if (prevLogs !== logs) {
+        settledRef.current = false;
+        const startCount = loadMoreCountRef.current;
+        loadMoreCountRef.current = null;
+        const outOfBounds = startCount !== null && logs.length === startCount && infiniteScrollMode === 'interval';
+        setInfiniteLoaderState(outOfBounds ? 'out-of-bounds' : 'idle');
+        if (scrollToLogLineRef.current) {
+          setAutoScroll(true);
+        }
       }
     }
-  }, [infiniteLoaderState, infiniteScrollMode, loading, prevLoading, logs, prevLogs]);
+  }, [infiniteLoaderState, infiniteScrollMode, loadingState, requestInFlight, prevInFlight, logs, prevLogs]);
 
   useEffect(() => {
     if (prevSortOrder && prevSortOrder !== sortOrder) {
@@ -119,12 +138,12 @@ export const InfiniteScroll = ({
   }, [prevSortOrder, sortOrder]);
 
   useEffect(() => {
-    if (autoScroll && !loading) {
+    if (autoScroll && !requestInFlight) {
       setInitialScrollPosition(scrollToLogLineRef.current);
       scrollToLogLineRef.current = undefined;
       setAutoScroll(false);
     }
-  }, [autoScroll, loading, setInitialScrollPosition]);
+  }, [autoScroll, requestInFlight, setInitialScrollPosition]);
 
   const onLoadMore = useCallback(
     (scrollDirection: ScrollDirection) => {

--- a/public/app/features/logs/components/panel/InfiniteScroll.tsx
+++ b/public/app/features/logs/components/panel/InfiniteScroll.tsx
@@ -112,7 +112,6 @@ export const InfiniteScroll = ({
         return;
       }
       // New logs have been returned from the load-more request.
-      // Reset tracking so the next scroll can start a fresh load-more.
       if (prevLogs !== logs) {
         const startCount = loadMoreCountRef.current;
         // Reset tracking so the next scroll can start a fresh load-more.

--- a/public/app/features/logs/components/panel/InfiniteScroll.tsx
+++ b/public/app/features/logs/components/panel/InfiniteScroll.tsx
@@ -106,8 +106,6 @@ export const InfiniteScroll = ({
         return;
       }
       if (loadingState === LoadingState.Error) {
-        // The request failed and returns no new rows: reset tracking and return to idle so the user
-        // can retry by scrolling again, rather than getting stuck on the loading indicator.
         settledRef.current = false;
         loadMoreCountRef.current = null;
         setInfiniteLoaderState('idle');

--- a/public/app/features/logs/components/panel/InfiniteScroll.tsx
+++ b/public/app/features/logs/components/panel/InfiniteScroll.tsx
@@ -89,10 +89,14 @@ export const InfiniteScroll = ({
   const prevInFlight = usePrevious(requestInFlight);
 
   useEffect(() => {
-    // Fresh logs from a new query (not infinite scrolling): reset paging and scroll.
+    // Fresh logs from a new query (not infinite scrolling): reset paging, scroll, and clear a stale
+    // 'out-of-bounds' so re-running the query re-enables scrolling instead of latching end-of-range.
     if (prevLogs && prevLogs !== logs && infiniteLoaderState !== 'loading') {
       lastLogOfPage.current = [];
       setAutoScroll(true);
+      if (infiniteLoaderState !== 'idle') {
+        setInfiniteLoaderState('idle');
+      }
       return;
     }
     if (infiniteLoaderState === 'loading') {

--- a/public/app/features/logs/components/panel/InfiniteScroll.tsx
+++ b/public/app/features/logs/components/panel/InfiniteScroll.tsx
@@ -96,9 +96,7 @@ export const InfiniteScroll = ({
       return;
     }
     if (infiniteLoaderState === 'loading') {
-      // Only act once we've observed the request go in flight and then settle (Loading/Streaming ->
-      // not). Requiring that transition ignores the stale/settled states seen right after the
-      // load-more starts (cancelQueries flips the response to Done before the new request begins).
+      // Only resolve after the in-flight -> settled transition, ignoring the transient Done cancelQueries sets at the start.
       if (prevInFlight && !requestInFlight) {
         settledRef.current = true;
       }
@@ -155,8 +153,7 @@ export const InfiniteScroll = ({
         scrollToLogLineRef.current = logs[0];
         lastLogOfPage.current.push(logs[0].uid);
       }
-      // Remember how many logs we had so the completion effect can tell whether the
-      // load-more actually returned new rows (vs. reaching the range boundary).
+      // Snapshot the row count so the completion effect can tell whether new rows arrived.
       loadMoreCountRef.current = logs.length;
       setInfiniteLoaderState('loading');
       loadMore?.(newRange ?? getVisibleRange(logs), scrollDirection);

--- a/public/app/features/logs/components/panel/InfiniteScroll.tsx
+++ b/public/app/features/logs/components/panel/InfiniteScroll.tsx
@@ -82,26 +82,35 @@ export const InfiniteScroll = ({
   const resetStateTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
   const scrollToLogLineRef = useRef<LogListModel | undefined>(undefined);
   const noScrollRef = useRef<undefined | boolean>(undefined);
+  const prevLoading = usePrevious(loading);
+  const loadMoreCountRef = useRef<number | null>(null);
 
   useEffect(() => {
-    // Logs have not changed, ignore effect
-    if (!prevLogs || prevLogs === logs) {
+    // Fresh logs from a new query (not infinite scrolling): reset paging and scroll.
+    if (prevLogs && prevLogs !== logs && infiniteLoaderState !== 'loading') {
+      lastLogOfPage.current = [];
+      setAutoScroll(true);
       return;
     }
-    // New logs are from infinite scrolling
-    if (infiniteLoaderState === 'loading') {
-      // out-of-bounds if no new logs returned
+    // Resolve a load-more only once the request has finished. Intermediate emissions
+    // (e.g. Loki query splitting re-emits the previous response with state=Loading
+    // before the new page arrives) carry the same rows, so deciding on every logs
+    // change would prematurely flag "out-of-bounds" and stop infinite scrolling. We
+    // wait for the request to settle (loading true -> false) and compare against the
+    // row count captured when the load-more started.
+    if (infiniteLoaderState === 'loading' && prevLoading && !loading) {
+      const startCount = loadMoreCountRef.current;
+      loadMoreCountRef.current = null;
       setInfiniteLoaderState(
-        logs.length === prevLogs.length && infiniteScrollMode === 'interval' ? 'out-of-bounds' : 'idle'
+        startCount !== null && logs.length === startCount && infiniteScrollMode === 'interval'
+          ? 'out-of-bounds'
+          : 'idle'
       );
       if (scrollToLogLineRef.current) {
         setAutoScroll(true);
       }
-    } else {
-      lastLogOfPage.current = [];
-      setAutoScroll(true);
     }
-  }, [infiniteLoaderState, infiniteScrollMode, logs, prevLogs]);
+  }, [infiniteLoaderState, infiniteScrollMode, loading, prevLoading, logs, prevLogs]);
 
   useEffect(() => {
     if (prevSortOrder && prevSortOrder !== sortOrder) {
@@ -133,6 +142,9 @@ export const InfiniteScroll = ({
         scrollToLogLineRef.current = logs[0];
         lastLogOfPage.current.push(logs[0].uid);
       }
+      // Remember how many logs we had so the completion effect can tell whether the
+      // load-more actually returned new rows (vs. reaching the range boundary).
+      loadMoreCountRef.current = logs.length;
       setInfiniteLoaderState('loading');
       loadMore?.(newRange ?? getVisibleRange(logs), scrollDirection);
 

--- a/public/app/features/logs/components/panel/InfiniteScroll.tsx
+++ b/public/app/features/logs/components/panel/InfiniteScroll.tsx
@@ -114,7 +114,6 @@ export const InfiniteScroll = ({
       // New logs have been returned from the load-more request.
       if (prevLogs !== logs) {
         const startCount = loadMoreCountRef.current;
-        // Reset tracking so the next scroll can start a fresh load-more.
         settledRef.current = false;
         loadMoreCountRef.current = null;
         const outOfBounds = startCount !== null && logs.length === startCount && infiniteScrollMode === 'interval';

--- a/public/app/features/logs/components/panel/InfiniteScroll.tsx
+++ b/public/app/features/logs/components/panel/InfiniteScroll.tsx
@@ -106,21 +106,19 @@ export const InfiniteScroll = ({
         return;
       }
       if (loadingState === LoadingState.Error) {
-        // The request failed and returns no new rows: return to idle so the user can retry by
-        // scrolling again, rather than getting stuck on the loading indicator.
+        // The request failed and returns no new rows: reset tracking and return to idle so the user
+        // can retry by scrolling again, rather than getting stuck on the loading indicator.
         settledRef.current = false;
         loadMoreCountRef.current = null;
         setInfiniteLoaderState('idle');
         return;
       }
-      // Wait until the settled rows have propagated before deciding. `logs` lags `loadingState` by a
-      // render (LogList turns the `logs` prop into `processedLogs` via an effect), so on the settle
-      // render `logs` still holds the pre-request rows; deciding then would read a stale count and
-      // wrongly flag "out-of-bounds". Compare against the count captured when the load-more started
-      // (not prevLogs): Loki query splitting streams partial pages, growing the rows across renders.
+      // New logs have been returned from the load-more request.
+      // Reset tracking so the next scroll can start a fresh load-more.
       if (prevLogs !== logs) {
-        settledRef.current = false;
         const startCount = loadMoreCountRef.current;
+        // Reset tracking so the next scroll can start a fresh load-more.
+        settledRef.current = false;
         loadMoreCountRef.current = null;
         const outOfBounds = startCount !== null && logs.length === startCount && infiniteScrollMode === 'interval';
         setInfiniteLoaderState(outOfBounds ? 'out-of-bounds' : 'idle');

--- a/public/app/features/logs/components/panel/LogLineContext.test.tsx
+++ b/public/app/features/logs/components/panel/LogLineContext.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor, userEvent } from 'test/test-utils';
 import {
   createDataFrame,
   FieldType,
+  LoadingState,
   LogRowContextQueryDirection,
   LogsSortOrder,
   type SplitOpenOptions,
@@ -18,7 +19,7 @@ import {
   identifyOTelLanguages,
 } from '../otel/formats';
 
-import { DEFAULT_TIME_WINDOW, LogLineContext, PAGE_SIZE } from './LogLineContext';
+import { combineLoadingStates, DEFAULT_TIME_WINDOW, LogLineContext, PAGE_SIZE } from './LogLineContext';
 
 const setBooleanFlags = (flags: Record<string, boolean>) => {
   setTestFlags(flags);
@@ -767,5 +768,27 @@ describe('LogLineContext', () => {
     );
 
     await waitFor(() => expect(getOtelAttributesField).toHaveBeenCalled());
+  });
+});
+
+describe('combineLoadingStates', () => {
+  test('reports in flight while either request is Loading or Streaming', () => {
+    expect(combineLoadingStates(LoadingState.Loading, LoadingState.Done)).toBe(LoadingState.Loading);
+    expect(combineLoadingStates(LoadingState.NotStarted, LoadingState.Loading)).toBe(LoadingState.Loading);
+    // Streaming must count as in flight (preserved), not be mistaken for settled.
+    expect(combineLoadingStates(LoadingState.Streaming, LoadingState.Done)).toBe(LoadingState.Streaming);
+    expect(combineLoadingStates(LoadingState.Loading, LoadingState.Streaming)).toBe(LoadingState.Streaming);
+  });
+
+  test('reports Error when a settled request errored', () => {
+    expect(combineLoadingStates(LoadingState.Error, LoadingState.Done)).toBe(LoadingState.Error);
+    expect(combineLoadingStates(LoadingState.Done, LoadingState.Error)).toBe(LoadingState.Error);
+    // In flight takes precedence over a sibling error (still not settled).
+    expect(combineLoadingStates(LoadingState.Loading, LoadingState.Error)).toBe(LoadingState.Loading);
+  });
+
+  test('reports Done when nothing is in flight or errored', () => {
+    expect(combineLoadingStates(LoadingState.Done, LoadingState.Done)).toBe(LoadingState.Done);
+    expect(combineLoadingStates(LoadingState.NotStarted, LoadingState.NotStarted)).toBe(LoadingState.Done);
   });
 });

--- a/public/app/features/logs/components/panel/LogLineContext.tsx
+++ b/public/app/features/logs/components/panel/LogLineContext.tsx
@@ -71,6 +71,22 @@ interface LogLineContextProps {
 export const PAGE_SIZE = 100;
 export const DEFAULT_TIME_WINDOW = 7200000;
 
+// Collapse the above/below context request states into a single LoadingState for InfiniteScroll:
+// in flight if either is Loading/Streaming (Streaming preserved so it isn't mistaken for settled),
+// errored if either errored, otherwise done.
+export function combineLoadingStates(...states: LoadingState[]): LoadingState {
+  if (states.includes(LoadingState.Streaming)) {
+    return LoadingState.Streaming;
+  }
+  if (states.includes(LoadingState.Loading)) {
+    return LoadingState.Loading;
+  }
+  if (states.includes(LoadingState.Error)) {
+    return LoadingState.Error;
+  }
+  return LoadingState.Done;
+}
+
 export const LogLineContext = memo(
   ({
     log,
@@ -454,11 +470,7 @@ export const LogLineContext = memo(
                 logLineMenuCustomItems={logLineMenuCustomItems}
                 logOptionsStorageKey={logOptionsStorageKey}
                 logs={allLogs}
-                loadingState={
-                  aboveState === LoadingState.Loading || belowState === LoadingState.Loading
-                    ? LoadingState.Loading
-                    : LoadingState.Done
-                }
+                loadingState={combineLoadingStates(aboveState, belowState)}
                 permalinkedLogId={log.uid}
                 onPermalinkClick={onPermalinkClick}
                 onLogOptionsChange={onLogOptionsChange}

--- a/public/app/features/logs/components/panel/LogLineContext.tsx
+++ b/public/app/features/logs/components/panel/LogLineContext.tsx
@@ -454,7 +454,11 @@ export const LogLineContext = memo(
                 logLineMenuCustomItems={logLineMenuCustomItems}
                 logOptionsStorageKey={logOptionsStorageKey}
                 logs={allLogs}
-                loading={aboveState === LoadingState.Loading || belowState === LoadingState.Loading}
+                loadingState={
+                  aboveState === LoadingState.Loading || belowState === LoadingState.Loading
+                    ? LoadingState.Loading
+                    : LoadingState.Done
+                }
                 permalinkedLogId={log.uid}
                 onPermalinkClick={onPermalinkClick}
                 onLogOptionsChange={onLogOptionsChange}

--- a/public/app/features/logs/components/panel/LogLineContext.tsx
+++ b/public/app/features/logs/components/panel/LogLineContext.tsx
@@ -71,9 +71,7 @@ interface LogLineContextProps {
 export const PAGE_SIZE = 100;
 export const DEFAULT_TIME_WINDOW = 7200000;
 
-// Collapse the above/below context request states into a single LoadingState for InfiniteScroll:
-// in flight if either is Loading/Streaming (Streaming preserved so it isn't mistaken for settled),
-// errored if either errored, otherwise done.
+// Merge the above/below context request states into one for InfiniteScroll, preserving Streaming/Error.
 export function combineLoadingStates(...states: LoadingState[]): LoadingState {
   if (states.includes(LoadingState.Streaming)) {
     return LoadingState.Streaming;

--- a/public/app/features/logs/components/panel/LogList.tsx
+++ b/public/app/features/logs/components/panel/LogList.tsx
@@ -11,6 +11,7 @@ import {
   type EventBus,
   EventBusSrv,
   type GrafanaTheme2,
+  type LoadingState,
   type LogLevel,
   type LogRowModel,
   LogsDedupStrategy,
@@ -58,7 +59,7 @@ export interface Props {
   infiniteScrollMode?: InfiniteScrollMode;
   initialScrollPosition?: 'top' | 'bottom';
   isLabelFilterActive?: (key: string, value: string, refId?: string) => Promise<boolean>;
-  loading?: boolean;
+  loadingState?: LoadingState;
   loadMore?: LoadMoreLogsType;
   logLineMenuCustomItems?: LogLineMenuCustomItem[];
   logOptionsStorageKey?: string;
@@ -141,7 +142,7 @@ export const LogList = ({
   infiniteScrollMode,
   initialScrollPosition = 'top',
   isLabelFilterActive,
-  loading,
+  loadingState,
   loadMore,
   logLineMenuCustomItems,
   logs,
@@ -243,7 +244,7 @@ export const LogList = ({
             grammar={grammar}
             initialScrollPosition={initialScrollPosition}
             infiniteScrollMode={infiniteScrollMode}
-            loading={loading}
+            loadingState={loadingState}
             loadMore={loadMore}
             logs={logs}
             showControls={showControls}
@@ -265,7 +266,7 @@ const LogListComponent = ({
   grammar,
   initialScrollPosition = 'top',
   infiniteScrollMode = 'interval',
-  loading,
+  loadingState,
   loadMore,
   logs,
   showControls,
@@ -548,7 +549,7 @@ const LogListComponent = ({
           displayedFields={displayedFields}
           handleOverflow={handleOverflow}
           infiniteScrollMode={infiniteScrollMode}
-          loading={loading}
+          loadingState={loadingState}
           logs={filteredLogs}
           loadMore={loadMore}
           onClick={handleLogLineClick}

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -173,7 +173,7 @@ export const LogsPanel = ({ data, timeZone, fieldConfig, options, onOptionsChang
   const [contextRow, setContextRow] = useState<LogRowModel | null>(null);
   const [scrollElement, setScrollElement] = useState<HTMLDivElement | null>(null);
   const [displayedFields, setDisplayedFields] = useState<string[]>(options.displayedFields ?? []);
-  const [infiniteScrolling, setInfiniteScrolling] = useState(false);
+  const [loadMoreState, setLoadMoreState] = useState<LoadingState>(LoadingState.Done);
   const loadingRef = useRef(false);
   const [panelData, setPanelData] = useState(data);
   const dataSourcesMap = useDatasourcesFromTargets(panelData.request?.targets);
@@ -403,11 +403,12 @@ export const LogsPanel = ({ data, timeZone, fieldConfig, options, onOptionsChang
       }
 
       loadingRef.current = true;
-      setInfiniteScrolling(true);
+      setLoadMoreState(LoadingState.Loading);
 
       const onNewLogsReceivedCallback = isOnNewLogsReceivedType(onNewLogsReceived) ? onNewLogsReceived : undefined;
 
       let newSeries: DataFrame[] = [];
+      let errored = false;
       try {
         newSeries = await requestMoreLogs(dataSourcesMap, panelData, scrollRange, timeZone, onNewLogsReceivedCallback);
         const panel = getDashboardSrv().getCurrent()?.getPanelById(id);
@@ -415,9 +416,10 @@ export const LogsPanel = ({ data, timeZone, fieldConfig, options, onOptionsChang
           newSeries = await lastValueFrom(transformDataFrame(panel?.transformations, newSeries));
         }
       } catch (e) {
+        errored = true;
         console.error(e);
       } finally {
-        setInfiniteScrolling(false);
+        setLoadMoreState(errored ? LoadingState.Error : LoadingState.Done);
         loadingRef.current = false;
       }
 
@@ -508,7 +510,7 @@ export const LogsPanel = ({ data, timeZone, fieldConfig, options, onOptionsChang
             grammar={isGrammar(grammar) ? grammar : undefined}
             isLabelFilterActive={isIsFilterLabelActive(isFilterLabelActive) ? isFilterLabelActive : undefined}
             initialScrollPosition={initialScrollPosition}
-            loadingState={infiniteScrolling ? LoadingState.Loading : LoadingState.Done}
+            loadingState={loadMoreState}
             logLineMenuCustomItems={
               isLogLineMenuCustomItems(logLineMenuCustomItems) ? logLineMenuCustomItems : undefined
             }

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -508,7 +508,7 @@ export const LogsPanel = ({ data, timeZone, fieldConfig, options, onOptionsChang
             grammar={isGrammar(grammar) ? grammar : undefined}
             isLabelFilterActive={isIsFilterLabelActive(isFilterLabelActive) ? isFilterLabelActive : undefined}
             initialScrollPosition={initialScrollPosition}
-            loading={infiniteScrolling}
+            loadingState={infiniteScrolling ? LoadingState.Loading : LoadingState.Done}
             logLineMenuCustomItems={
               isLogLineMenuCustomItems(logLineMenuCustomItems) ? logLineMenuCustomItems : undefined
             }


### PR DESCRIPTION
## Summary 📝

- Fixes https://github.com/grafana/grafana/issues/129033
- **Root cause:** In `interval` mode, infinite scroll loaded one extra page and then showed "End of the selected time range" while logs remained in range. The loader decided end-of-range on the `loading` prop's settle edge, but the `logs` prop lags `loading` by a render — `LogList` turns the `logs` prop into `processedLogs` via a `useEffect`, so `loading` flips to `false` a render before the new rows reach `InfiniteScroll`. It therefore compared against the pre-request (stale) row count and latched `out-of-bounds`. Loki query splitting compounds this: a load-more streams partial pages across several in-flight renders, so the row count must be compared against the count captured when the load-more *started*, not against the previous render.
- **Fix:**
  - Thread `LoadingState` through `LogList` → `InfiniteScroll` (replacing the `loading` boolean) so the loader can distinguish `Loading`/`Streaming` from `Done`/`Error`.
  - Resolve a load-more only after observing its request go in flight and then settle, and once the settled rows have actually propagated (`prevLogs !== logs`) — comparing against the row count captured when the load-more started.
  - On `Error`, return to `idle` so the user can retry by scrolling again instead of getting stuck on the loading indicator.

## Test 🧪

- [x] `yarn jest public/app/features/logs/components/panel/InfiniteScroll.test.tsx` — 30/30 pass, including regression tests for: a settled load-more returning new rows, a genuine end-of-range (no new rows), query-splitting growth across in-flight emissions, and error recovery. The new tests fail on the pre-fix code.
- [x] Verified end-to-end against a real Loki datasource (Explore, `{app="asserts"}`, Line limit = 50, Ascending): multiple consecutive load-mores fire and the page keeps growing — no premature "End of the selected time range".

Locally:
1. Explore → Loki datasource, code editor.
2. Query a busy stream with a Line limit of 50, e.g. `{app="asserts"}`.
3. Ensure the viz is the new Logs panel (default on this branch), sorted Ascending.
4. Scroll to the bottom repeatedly — more logs keep loading.
