### PR TITLE
test(e2e): install/uninstall catalog plugins

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -485,6 +485,7 @@ i18next.config.ts @grafana/grafana-frontend-platform
 /e2e-playwright/panels-suite/panelEdit_transforms.spec.ts @grafana/datapro
 /e2e-playwright/panels-suite/logstable.spec.ts @grafana/observability-logs
 /e2e-playwright/plugin-e2e/ @grafana/data-sources-plugins
+/e2e-playwright/plugin-catalog-suite/ @grafana/grafana-frontend-platform
 /e2e-playwright/plugin-e2e/plugin-e2e-api-tests/ @grafana/grafana-catalog
 /e2e-playwright/smoke-tests-suite/ @grafana/grafana-frontend-platform
 /e2e-playwright/start-server @grafana/grafana-frontend-platform

--- a/e2e-playwright/plugin-catalog-suite/tests/installUninstallPlugins.spec.ts
+++ b/e2e-playwright/plugin-catalog-suite/tests/installUninstallPlugins.spec.ts
@@ -1,0 +1,20 @@
+import { test } from '@grafana/plugin-e2e';
+
+import { PLUGINS, assertInstallUninstallRoundtrip, resetInstalled } from './utils';
+
+// Serial so afterEach (which uninstalls all plugins) can't race a peer test.
+test.describe.configure({ mode: 'serial' });
+
+test.afterEach(async ({ request }) => {
+  for (const plugin of PLUGINS) {
+    await resetInstalled(request, plugin.id);
+  }
+});
+
+test.describe('catalog install/uninstall (legacy path)', { tag: ['@plugins'] }, () => {
+  for (const plugin of PLUGINS) {
+    test(`installs and uninstalls the ${plugin.label} plugin via /api/plugins/:id/install`, async ({ page }) => {
+      await assertInstallUninstallRoundtrip(page, plugin.id, false);
+    });
+  }
+});

--- a/e2e-playwright/plugin-catalog-suite/tests/useMTPlugins/installUninstallPlugins.spec.ts
+++ b/e2e-playwright/plugin-catalog-suite/tests/useMTPlugins/installUninstallPlugins.spec.ts
@@ -1,0 +1,23 @@
+import { test } from '@grafana/plugin-e2e';
+
+import { PLUGINS, assertInstallUninstallRoundtrip, resetInstalled } from '../utils';
+
+// MT path: useMTPlugins on -> install/uninstall also hit the PluginMeta apiserver. openFeature is file-level.
+test.use({ openFeature: { flags: { 'plugins.useMTPlugins': true } } });
+
+// Serial so afterEach (which uninstalls all plugins) can't race a peer test.
+test.describe.configure({ mode: 'serial' });
+
+test.afterEach(async ({ request }) => {
+  for (const plugin of PLUGINS) {
+    await resetInstalled(request, plugin.id);
+  }
+});
+
+test.describe('catalog install/uninstall (MT path)', { tag: ['@plugins', '@plugins.useMTPlugins'] }, () => {
+  for (const plugin of PLUGINS) {
+    test(`installs and uninstalls the ${plugin.label} plugin via the PluginMeta apiserver`, async ({ page }) => {
+      await assertInstallUninstallRoundtrip(page, plugin.id, true);
+    });
+  }
+});

--- a/e2e-playwright/plugin-catalog-suite/tests/utils.ts
+++ b/e2e-playwright/plugin-catalog-suite/tests/utils.ts
@@ -1,0 +1,94 @@
+import { type APIRequestContext, type Page, type Request } from '@playwright/test';
+
+import { expect } from '@grafana/plugin-e2e';
+
+// App must be a pure app (no bundled panel) — bundled panels appear in the viz picker and break panelIcons.spec.ts.
+export const PLUGINS = [
+  { id: 'grafana-llm-app', label: 'app' },
+  { id: 'yesoreyeram-infinity-datasource', label: 'datasource' },
+  { id: 'grafana-clock-panel', label: 'panel' },
+];
+
+type Action = 'install' | 'uninstall';
+
+// Legacy REST path (POST /api/plugins/:id/install|uninstall) — always called.
+function isLegacy(action: Action, method: string, url: string, pluginId: string): boolean {
+  return method === 'POST' && url.includes(`/api/plugins/${pluginId}/${action}`);
+}
+
+// K8s PluginMeta path (apis/plugins.grafana.app) — only called when plugins.useMTPlugins is on.
+function isMt(action: Action, method: string, url: string, pluginId: string): boolean {
+  if (!url.includes('/apis/plugins.grafana.app/')) {
+    return false;
+  }
+  return action === 'install'
+    ? method === 'POST' && url.endsWith('/plugins')
+    : method === 'DELETE' && url.endsWith(`/plugins/${pluginId}`);
+}
+
+// Runs `trigger`, then asserts: legacy always ok, MT ok iff `mt`, MT absent if `!mt` (waiters set pre-click; success reloads).
+async function clickAndAssert(
+  page: Page,
+  action: Action,
+  pluginId: string,
+  mt: boolean,
+  trigger: () => Promise<void>
+): Promise<void> {
+  const mtSeen: string[] = [];
+  const record = (req: Request) => {
+    if (isMt(action, req.method(), req.url(), pluginId)) {
+      mtSeen.push(`${req.method()} ${req.url()}`);
+    }
+  };
+  page.on('request', record);
+
+  const legacyPromise = page.waitForResponse((res) => isLegacy(action, res.request().method(), res.url(), pluginId));
+  const mtPromise = mt
+    ? page.waitForResponse((res) => isMt(action, res.request().method(), res.url(), pluginId))
+    : undefined;
+
+  await trigger();
+
+  const legacy = await legacyPromise;
+  expect(legacy.ok(), `${action} legacy ${legacy.url()} returned ${legacy.status()}`).toBeTruthy();
+
+  if (mtPromise) {
+    const mtRes = await mtPromise;
+    expect(mtRes.ok(), `${action} MT ${mtRes.url()} returned ${mtRes.status()}`).toBeTruthy();
+  }
+
+  page.off('request', record);
+
+  if (!mt) {
+    expect(mtSeen, `expected no MT ${action} call (flag off) but saw: ${mtSeen.join(', ')}`).toHaveLength(0);
+  }
+}
+
+// Install -> uninstall through the catalog UI, asserting the write paths and button flips (uninstall confirms via modal).
+export async function assertInstallUninstallRoundtrip(page: Page, pluginId: string, mt: boolean): Promise<void> {
+  await page.goto(`/plugins/${pluginId}`);
+
+  const installButton = page.getByRole('button', { name: 'Install', exact: true });
+  const uninstallButton = page.getByRole('button', { name: 'Uninstall', exact: true });
+  const confirmButton = page.getByRole('button', { name: 'Confirm', exact: true });
+
+  await expect(installButton).toBeVisible();
+  await clickAndAssert(page, 'install', pluginId, mt, async () => {
+    await installButton.click();
+  });
+  await expect(uninstallButton).toBeVisible();
+
+  await clickAndAssert(page, 'uninstall', pluginId, mt, async () => {
+    await uninstallButton.click();
+    await confirmButton.click();
+  });
+  await expect(installButton).toBeVisible();
+}
+
+// afterEach safety net: best-effort uninstall via both paths, ignoring 404s (already uninstalled / no CR).
+export async function resetInstalled(request: APIRequestContext, pluginId: string): Promise<void> {
+  await request.post(`/api/plugins/${pluginId}/uninstall`).catch(() => undefined);
+  await request
+    .delete(`/apis/plugins.grafana.app/v0alpha1/namespaces/default/plugins/${pluginId}`)
+    .catch(() => undefined);
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -192,5 +192,19 @@ export default defineConfig<PluginOptions>({
       name: 'grafana-e2etest-panel',
       testDir: path.join(testDirRoot, '/test-plugins/grafana-test-panel'),
     }),
+    // Install/uninstall real catalog plugins; longer timeout since installs download the package.
+    withAuth({
+      name: 'plugin-catalog',
+      testDir: path.join(testDirRoot, '/plugin-catalog-suite/tests'),
+      testIgnore: /useMTPlugins/,
+      timeout: 60_000,
+    }),
+    withAuth({
+      name: 'plugin-catalog-mt',
+      testDir: path.join(testDirRoot, '/plugin-catalog-suite/tests/useMTPlugins'),
+      timeout: 60_000,
+      // Runs only after plugin-catalog finishes, so the two never install/uninstall at the same time.
+      dependencies: ['plugin-catalog'],
+    }),
   ],
 });


### PR DESCRIPTION
**What is this feature?**

Adds e2e tests that install then uninstall three published Grafana Labs plugins through the catalog UI (a panel `grafana-clock-panel`, a datasource `yesoreyeram-infinity-datasource`, and an app `grafana-llm-app`), covering both the legacy install path (`POST /api/plugins/:id/install`) and the multi-tenant K8s PluginMeta path behind `plugins.useMTPlugins`.

The tests only install and uninstall, so no plugin-specific setup is needed.

To check for flakiness I ran the whole E2E workflow 6x on this branch (the initial run plus 5 re-runs): 6/6 green.

| Run | Result | Comment |
|-----|-----|-----|
|https://github.com/grafana/grafana/actions/runs/29989842320?pr=129068|✅|  |
|https://github.com/grafana/grafana/actions/runs/29989842320/attempts/5?pr=129068|✅|  |
|https://github.com/grafana/grafana/actions/runs/29989842320/attempts/4?pr=129068|✅|  |
|https://github.com/grafana/grafana/actions/runs/29989842320/attempts/3?pr=129068|✅|  |
|https://github.com/grafana/grafana/actions/runs/29989842320/attempts/2?pr=129068|✅|  |
|https://github.com/grafana/grafana/actions/runs/29989842320/attempts/1?pr=129068|✅|  |

**Why do we need this feature?**

So the plugin install/uninstall flow is covered on both the legacy and multi-tenant write paths.

**Who is this feature for?**

Grafana devs

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #126659

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
