### PR TITLE
Folders: fix Editors missing folders in folder view

### DIFF
--- a/pkg/services/accesscontrol/accesscontrol.go
+++ b/pkg/services/accesscontrol/accesscontrol.go
@@ -43,6 +43,12 @@ type Service interface {
 	SearchUsersPermissions(ctx context.Context, user identity.Requester, options SearchOptions) (map[int64][]Permission, error)
 	// ClearUserPermissionCache removes the permission cache entry for the given user
 	ClearUserPermissionCache(user identity.Requester)
+	// ClearBasicRolePermissionCache removes the cached permissions for a built-in org role
+	// (Viewer/Editor/Admin). Required when managed permissions on that role change; user-direct
+	// cache clears alone leave Editors/Viewers serving stale folder scopes.
+	ClearBasicRolePermissionCache(role string, orgID int64)
+	// ClearTeamPermissionCache removes the cached permissions for a team in an org.
+	ClearTeamPermissionCache(teamID, orgID int64)
 	// SearchUserPermissions returns single user's permissions filtered by an action prefix or an action
 	SearchUserPermissions(ctx context.Context, orgID int64, filterOptions SearchOptions) ([]Permission, error)
 	// DeleteUserPermissions removes all permissions user has in org and all permission to that user

--- a/pkg/services/accesscontrol/acimpl/service.go
+++ b/pkg/services/accesscontrol/acimpl/service.go
@@ -509,6 +509,14 @@ func (s *Service) ClearUserPermissionCache(user identity.Requester) {
 	s.cache.ExclusiveDelete(accesscontrol.GetZanzanaUserPermissionCacheKey(user))
 }
 
+func (s *Service) ClearBasicRolePermissionCache(role string, orgID int64) {
+	s.cache.ExclusiveDelete(accesscontrol.GetBasicRolePermissionCacheKey(role, orgID))
+}
+
+func (s *Service) ClearTeamPermissionCache(teamID, orgID int64) {
+	s.cache.ExclusiveDelete(accesscontrol.GetTeamPermissionCacheKey(teamID, orgID))
+}
+
 func (s *Service) DeleteUserPermissions(ctx context.Context, orgID int64, userID int64) error {
 	ctx, span := tracer.Start(ctx, "accesscontrol.acimpl.DeleteUserPermissions")
 	defer span.End()

--- a/pkg/services/accesscontrol/acimpl/service_test.go
+++ b/pkg/services/accesscontrol/acimpl/service_test.go
@@ -1512,3 +1512,26 @@ func countDBRows(t testing.TB, ctx context.Context, store db.DB, table, where st
 	}))
 	return count
 }
+
+func TestService_ClearBasicRoleAndTeamPermissionCache(t *testing.T) {
+	s := &Service{cache: localcache.ProvideService()}
+	const orgID int64 = 1
+
+	basicKey := accesscontrol.GetBasicRolePermissionCacheKey("Editor", orgID)
+	s.cache.Set(basicKey, []accesscontrol.Permission{{Action: "folders:read", Scope: "folders:uid:old"}}, time.Minute)
+	_, ok := s.cache.Get(basicKey)
+	require.True(t, ok)
+
+	s.ClearBasicRolePermissionCache("Editor", orgID)
+	_, ok = s.cache.Get(basicKey)
+	require.False(t, ok, "basic-role cache should be cleared")
+
+	teamKey := accesscontrol.GetTeamPermissionCacheKey(7, orgID)
+	s.cache.Set(teamKey, []accesscontrol.Permission{{Action: "folders:read", Scope: "folders:uid:team"}}, time.Minute)
+	_, ok = s.cache.Get(teamKey)
+	require.True(t, ok)
+
+	s.ClearTeamPermissionCache(7, orgID)
+	_, ok = s.cache.Get(teamKey)
+	require.False(t, ok, "team cache should be cleared")
+}

--- a/pkg/services/accesscontrol/actest/fake.go
+++ b/pkg/services/accesscontrol/actest/fake.go
@@ -37,6 +37,10 @@ func (f FakeService) SearchUserPermissions(ctx context.Context, orgID int64, sea
 
 func (f FakeService) ClearUserPermissionCache(user identity.Requester) {}
 
+func (f FakeService) ClearBasicRolePermissionCache(role string, orgID int64) {}
+
+func (f FakeService) ClearTeamPermissionCache(teamID, orgID int64) {}
+
 func (f FakeService) DeleteUserPermissions(ctx context.Context, orgID, userID int64) error {
 	return f.ExpectedErr
 }

--- a/pkg/services/accesscontrol/mock/mock.go
+++ b/pkg/services/accesscontrol/mock/mock.go
@@ -24,6 +24,8 @@ type Calls struct {
 	GetRoleByName                  []interface{}
 	GetUserPermissions             []interface{}
 	ClearUserPermissionCache       []interface{}
+	ClearBasicRolePermissionCache  []interface{}
+	ClearTeamPermissionCache       []interface{}
 	DeclareFixedRoles              []interface{}
 	DeclarePluginRoles             []interface{}
 	GetUserBuiltInRoles            []interface{}
@@ -54,6 +56,8 @@ type Mock struct {
 	GetRoleByNameFunc                  func(context.Context, int64, string) (*accesscontrol.RoleDTO, error)
 	GetUserPermissionsFunc             func(context.Context, identity.Requester, accesscontrol.Options) ([]accesscontrol.Permission, error)
 	ClearUserPermissionCacheFunc       func(identity.Requester)
+	ClearBasicRolePermissionCacheFunc  func(string, int64)
+	ClearTeamPermissionCacheFunc       func(int64, int64)
 	DeclareFixedRolesFunc              func(...accesscontrol.RoleRegistration) error
 	DeclarePluginRolesFunc             func(context.Context, string, string, []plugins.RoleRegistration) error
 	GetUserBuiltInRolesFunc            func(user identity.Requester) []string
@@ -163,6 +167,20 @@ func (m *Mock) ClearUserPermissionCache(user identity.Requester) {
 	// Use override if provided
 	if m.ClearUserPermissionCacheFunc != nil {
 		m.ClearUserPermissionCacheFunc(user)
+	}
+}
+
+func (m *Mock) ClearBasicRolePermissionCache(role string, orgID int64) {
+	m.Calls.ClearBasicRolePermissionCache = append(m.Calls.ClearBasicRolePermissionCache, []interface{}{role, orgID})
+	if m.ClearBasicRolePermissionCacheFunc != nil {
+		m.ClearBasicRolePermissionCacheFunc(role, orgID)
+	}
+}
+
+func (m *Mock) ClearTeamPermissionCache(teamID, orgID int64) {
+	m.Calls.ClearTeamPermissionCache = append(m.Calls.ClearTeamPermissionCache, []interface{}{teamID, orgID})
+	if m.ClearTeamPermissionCacheFunc != nil {
+		m.ClearTeamPermissionCacheFunc(teamID, orgID)
 	}
 }
 

--- a/pkg/services/accesscontrol/resourcepermissions/service.go
+++ b/pkg/services/accesscontrol/resourcepermissions/service.go
@@ -282,7 +282,7 @@ func (s *Service) SetTeamPermission(ctx context.Context, orgID, teamID int64, re
 		}
 	}
 
-	return s.store.SetTeamResourcePermission(ctx, orgID, teamID, SetResourcePermissionCommand{
+	result, err := s.store.SetTeamResourcePermission(ctx, orgID, teamID, SetResourcePermissionCommand{
 		Actions:           actions,
 		Permission:        permission,
 		Resource:          s.scopeResource(),
@@ -290,6 +290,12 @@ func (s *Service) SetTeamPermission(ctx context.Context, orgID, teamID int64, re
 		ResourceAttribute: s.options.ResourceAttribute,
 		DatasourceType:    datasourceType,
 	}, s.options.OnSetTeam)
+	if err != nil {
+		return nil, err
+	}
+
+	s.service.ClearTeamPermissionCache(teamID, orgID)
+	return result, nil
 }
 
 func (s *Service) SetBuiltInRolePermission(ctx context.Context, orgID int64, builtInRole, resourceID, permission string) (*accesscontrol.ResourcePermission, error) {
@@ -316,7 +322,7 @@ func (s *Service) SetBuiltInRolePermission(ctx context.Context, orgID int64, bui
 		}
 	}
 
-	return s.store.SetBuiltInResourcePermission(ctx, orgID, builtInRole, SetResourcePermissionCommand{
+	result, err := s.store.SetBuiltInResourcePermission(ctx, orgID, builtInRole, SetResourcePermissionCommand{
 		Actions:           actions,
 		Permission:        permission,
 		Resource:          s.scopeResource(),
@@ -324,6 +330,12 @@ func (s *Service) SetBuiltInRolePermission(ctx context.Context, orgID int64, bui
 		ResourceAttribute: s.options.ResourceAttribute,
 		DatasourceType:    datasourceType,
 	}, s.options.OnSetBuiltInRole)
+	if err != nil {
+		return nil, err
+	}
+
+	s.service.ClearBasicRolePermissionCache(builtInRole, orgID)
+	return result, nil
 }
 
 func (s *Service) SetPermissions(
@@ -390,10 +402,18 @@ func (s *Service) SetPermissions(
 	}
 
 	clearedUsers := make(map[int64]bool)
+	clearedTeams := make(map[int64]bool)
+	clearedRoles := make(map[string]bool)
 	for _, cmd := range commands {
 		if cmd.UserID != 0 && !clearedUsers[cmd.UserID] {
 			s.clearUserPermissionCache(orgID, cmd.UserID)
 			clearedUsers[cmd.UserID] = true
+		} else if cmd.TeamID != 0 && !clearedTeams[cmd.TeamID] {
+			s.service.ClearTeamPermissionCache(cmd.TeamID, orgID)
+			clearedTeams[cmd.TeamID] = true
+		} else if cmd.BuiltinRole != "" && !clearedRoles[cmd.BuiltinRole] {
+			s.service.ClearBasicRolePermissionCache(cmd.BuiltinRole, orgID)
+			clearedRoles[cmd.BuiltinRole] = true
 		}
 	}
 

--- a/pkg/services/accesscontrol/resourcepermissions/service_test.go
+++ b/pkg/services/accesscontrol/resourcepermissions/service_test.go
@@ -11,12 +11,17 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/api/routing"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/infra/localcache"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/actest"
+	"github.com/grafana/grafana/pkg/services/accesscontrol/database"
+	accesscontrolmock "github.com/grafana/grafana/pkg/services/accesscontrol/mock"
+	"github.com/grafana/grafana/pkg/services/accesscontrol/permreg"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/licensing/licensingtest"
@@ -919,4 +924,211 @@ func TestIsActionSetEnabledResource_Datasource(t *testing.T) {
 	assert.True(t, isActionSetEnabledResource(datasources.ScopeRoot+":query"))
 	assert.True(t, isActionSetEnabledResource(datasources.ScopeRoot+":edit"))
 	assert.True(t, isActionSetEnabledResource(datasources.ScopeRoot+":admin"))
+}
+
+func TestIntegrationService_SetPermissions_ClearsBasicRoleAndTeamCaches(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	sql := db.InitTestDB(t)
+	cfg := setting.NewCfg()
+	tracer := tracing.InitializeTracerForTest()
+
+	teamSvc, err := teamimpl.ProvideService(sql, cfg, tracer, nil)
+	require.NoError(t, err)
+	orgSvc, err := orgimpl.ProvideService(sql, cfg, quotatest.New(false, nil))
+	require.NoError(t, err)
+	userSvc, err := userimpl.ProvideService(
+		sql, orgSvc, cfg, teamSvc, nil, tracer,
+		quotatest.New(false, nil), supportbundlestest.NewFakeBundleService(), nil,
+	)
+	require.NoError(t, err)
+
+	usr, err := userSvc.Create(context.Background(), &user.CreateUserCommand{Login: "editor-cache", OrgID: 1})
+	require.NoError(t, err)
+	tm, err := teamSvc.CreateTeam(context.Background(), &team.CreateTeamCommand{
+		Name: "cache-team", Email: "cache@test.com", OrgID: 1,
+	})
+	require.NoError(t, err)
+
+	acMock := accesscontrolmock.New()
+	license := licensingtest.NewFakeLicensing()
+	license.On("FeatureEnabled", "accesscontrol.enforcement").Return(true).Maybe()
+	ac := acimpl.ProvideAccessControl(featuremgmt.WithFeatures())
+
+	service, err := New(
+		cfg,
+		Options{
+			Resource: "folders",
+			ResourceAttribute: "uid",
+			Assignments: Assignments{
+				Users:        true,
+				Teams:        true,
+				BuiltInRoles: true,
+			},
+			PermissionsToActions: map[string][]string{
+				"Edit": {"folders:read", "folders:write"},
+			},
+		},
+		featuremgmt.WithFeatures(),
+		routing.NewRouteRegister(),
+		license,
+		ac,
+		acMock,
+		sql,
+		teamSvc,
+		userSvc,
+		NewActionSetService(),
+	)
+	require.NoError(t, err)
+
+	_, err = service.SetPermissions(context.Background(), 1, "folder-cache-uid",
+		accesscontrol.SetResourcePermissionCommand{UserID: usr.ID, Permission: "Edit"},
+		accesscontrol.SetResourcePermissionCommand{TeamID: tm.ID, Permission: "Edit"},
+		accesscontrol.SetResourcePermissionCommand{BuiltinRole: "Editor", Permission: "Edit"},
+	)
+	require.NoError(t, err)
+
+	require.Len(t, acMock.Calls.ClearUserPermissionCache, 2, "user + service-account cache keys")
+	require.Len(t, acMock.Calls.ClearTeamPermissionCache, 1)
+	require.Equal(t, tm.ID, acMock.Calls.ClearTeamPermissionCache[0].([]interface{})[0])
+	require.Len(t, acMock.Calls.ClearBasicRolePermissionCache, 1)
+	require.Equal(t, "Editor", acMock.Calls.ClearBasicRolePermissionCache[0].([]interface{})[0])
+}
+
+func TestIntegrationService_SetBuiltInRolePermission_ClearsBasicRoleCache(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	acMock := accesscontrolmock.New()
+	sql := db.InitTestDB(t)
+	cfg := setting.NewCfg()
+	tracer := tracing.InitializeTracerForTest()
+	teamSvc, err := teamimpl.ProvideService(sql, cfg, tracer, nil)
+	require.NoError(t, err)
+	orgSvc, err := orgimpl.ProvideService(sql, cfg, quotatest.New(false, nil))
+	require.NoError(t, err)
+	userSvc, err := userimpl.ProvideService(
+		sql, orgSvc, cfg, teamSvc, nil, tracer,
+		quotatest.New(false, nil), supportbundlestest.NewFakeBundleService(), nil,
+	)
+	require.NoError(t, err)
+
+	license := licensingtest.NewFakeLicensing()
+	license.On("FeatureEnabled", "accesscontrol.enforcement").Return(true).Maybe()
+	ac := acimpl.ProvideAccessControl(featuremgmt.WithFeatures())
+
+	service, err := New(
+		cfg,
+		Options{
+			Resource:             "folders",
+			ResourceAttribute:     "uid",
+			Assignments:          Assignments{BuiltInRoles: true},
+			PermissionsToActions: map[string][]string{"Edit": {"folders:read", "folders:write"}},
+		},
+		featuremgmt.WithFeatures(),
+		routing.NewRouteRegister(),
+		license,
+		ac,
+		acMock,
+		sql,
+		teamSvc,
+		userSvc,
+		NewActionSetService(),
+	)
+	require.NoError(t, err)
+
+	_, err = service.SetBuiltInRolePermission(context.Background(), 1, "Editor", "folder-x", "Edit")
+	require.NoError(t, err)
+	require.Len(t, acMock.Calls.ClearBasicRolePermissionCache, 1)
+	require.Equal(t, "Editor", acMock.Calls.ClearBasicRolePermissionCache[0].([]interface{})[0])
+	require.Equal(t, int64(1), acMock.Calls.ClearBasicRolePermissionCache[0].([]interface{})[1])
+}
+
+// TestIntegration_EditorFolderPermissionVisibleImmediately reproduces #129016:
+// after granting a folder to the Editor builtin role, a warmed basic-role cache
+// must be invalidated so the next GetUserPermissions call includes the new scope.
+func TestIntegration_EditorFolderPermissionVisibleImmediately(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	sql := db.InitTestDB(t)
+	cfg := setting.NewCfg()
+	cfg.RBAC.PermissionCache = true
+	cache := localcache.ProvideService()
+	tracer := tracing.InitializeTracerForTest()
+
+	acSvc := acimpl.ProvideOSSService(
+		cfg,
+		database.ProvideService(sql),
+		NewActionSetService(),
+		cache,
+		featuremgmt.WithFeatures(),
+		tracer,
+		sql,
+		permreg.ProvidePermissionRegistry(),
+		nil,
+	)
+
+	teamSvc, err := teamimpl.ProvideService(sql, cfg, tracer, nil)
+	require.NoError(t, err)
+	orgSvc, err := orgimpl.ProvideService(sql, cfg, quotatest.New(false, nil))
+	require.NoError(t, err)
+	userSvc, err := userimpl.ProvideService(
+		sql, orgSvc, cfg, teamSvc, nil, tracer,
+		quotatest.New(false, nil), supportbundlestest.NewFakeBundleService(), nil,
+	)
+	require.NoError(t, err)
+
+	editorUser, err := userSvc.Create(context.Background(), &user.CreateUserCommand{
+		Login: "editor129016", OrgID: 1,
+	})
+	require.NoError(t, err)
+
+	license := licensingtest.NewFakeLicensing()
+	license.On("FeatureEnabled", "accesscontrol.enforcement").Return(true).Maybe()
+	ac := acimpl.ProvideAccessControl(featuremgmt.WithFeatures())
+
+	permSvc, err := New(
+		cfg,
+		Options{
+			Resource:          "folders",
+			ResourceAttribute: "uid",
+			Assignments:       Assignments{BuiltInRoles: true},
+			PermissionsToActions: map[string][]string{
+				"Edit": {"folders:read", "folders:write"},
+			},
+		},
+		featuremgmt.WithFeatures(),
+		routing.NewRouteRegister(),
+		license,
+		ac,
+		acSvc,
+		sql,
+		teamSvc,
+		userSvc,
+		NewActionSetService(),
+	)
+	require.NoError(t, err)
+
+	siu := &user.SignedInUser{
+		UserID:  editorUser.ID,
+		OrgID:   1,
+		OrgRole: identity.RoleEditor,
+		Login:   editorUser.Login,
+	}
+
+	// Warm the basic-role cache before the folder grant exists.
+	_, err = acSvc.GetUserPermissions(context.Background(), siu, accesscontrol.Options{})
+	require.NoError(t, err)
+
+	folderUID := "folder-129016"
+	_, err = permSvc.SetBuiltInRolePermission(context.Background(), 1, "Editor", folderUID, "Edit")
+	require.NoError(t, err)
+
+	// Without ReloadCache, scopes must still include the new folder (cache was cleared).
+	for i := 0; i < 10; i++ {
+		perms, err := acSvc.GetUserPermissions(context.Background(), siu, accesscontrol.Options{})
+		require.NoError(t, err)
+		scopes := accesscontrol.GroupScopesByActionContext(context.Background(), perms)["folders:read"]
+		require.Contains(t, scopes, "folders:uid:"+folderUID,
+			"iteration %d: editor must see folder scope immediately after grant", i)
+	}
 }

--- a/pkg/services/folder/folderimpl/folder_unifiedstorage.go
+++ b/pkg/services/folder/folderimpl/folder_unifiedstorage.go
@@ -407,28 +407,45 @@ func (s *Service) getRootFolders(ctx context.Context, q *folder.GetChildrenQuery
 		return nil, nil
 	}
 
-	q.FolderUIDs = make([]string, 0, len(folderPermissions))
+	hasWildcard := false
+	realFolderUIDs := make([]string, 0, len(folderPermissions))
 	for _, p := range folderPermissions {
 		if p == folder.ScopeFoldersAll {
 			// no need to query for folders with permissions
 			// the user has permission to access all folders
-			q.FolderUIDs = nil
+			hasWildcard = true
 			break
 		}
 		if folderUid, found := strings.CutPrefix(p, folder.ScopeFoldersPrefix); found {
-			if !slices.Contains(q.FolderUIDs, folderUid) {
-				q.FolderUIDs = append(q.FolderUIDs, folderUid)
+			// sharedwithme is virtual and never exists in the search index
+			if folderUid == folder.SharedWithMeFolderUID {
+				continue
+			}
+			if !slices.Contains(realFolderUIDs, folderUid) {
+				realFolderUIDs = append(realFolderUIDs, folderUid)
 			}
 		}
 	}
 
-	children, err := s.unifiedStore.GetChildren(ctx, *q)
-	if err != nil {
-		return nil, err
+	var children []*folder.FolderReference
+	var err error
+	// Only sharedwithme scopes and no wildcard: skip the search (an empty FolderUIDs
+	// filter would return every root folder). Otherwise query with real UIDs or nil for wildcard.
+	onlySharedWithMe := !hasWildcard && len(realFolderUIDs) == 0 && len(folderPermissions) > 0
+	if !onlySharedWithMe {
+		if hasWildcard {
+			q.FolderUIDs = nil
+		} else {
+			q.FolderUIDs = realFolderUIDs
+		}
+		children, err = s.unifiedStore.GetChildren(ctx, *q)
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	// add "shared with me" folder on the 1st page
-	if (q.Page == 0 || q.Page == 1) && len(q.FolderUIDs) != 0 {
+	// add "shared with me" folder on the 1st page for non-wildcard users
+	if (q.Page == 0 || q.Page == 1) && !hasWildcard && len(folderPermissions) > 0 {
 		children = append([]*folder.FolderReference{folder.SharedWithMeFolder.ToFolderReference()}, children...)
 	}
 

--- a/pkg/services/folder/folderimpl/folder_unifiedstorage_test.go
+++ b/pkg/services/folder/folderimpl/folder_unifiedstorage_test.go
@@ -1070,3 +1070,89 @@ func TestIntegrationDeleteFolders(t *testing.T) {
 		publicDashboardFakeService.AssertExpectations(t)
 	})
 }
+
+func TestGetRootFolders(t *testing.T) {
+	tracer := noop.NewTracerProvider().Tracer("TestGetRootFolders")
+	realFolder := &folder.FolderReference{UID: "folder-a", Title: "Folder A"}
+
+	t.Run("editor with managed folder scopes sees folder and shared with me", func(t *testing.T) {
+		store := folder.NewFakeStore()
+		store.ExpectedChildFolders = []*folder.FolderReference{realFolder}
+		svc := &Service{unifiedStore: store, tracer: tracer}
+
+		editor := &user.SignedInUser{
+			OrgID: 1,
+			Permissions: map[int64]map[string][]string{
+				1: {
+					folder.ActionFoldersRead: {
+						folder.ScopeFoldersPrefix + folder.SharedWithMeFolderUID,
+						folder.ScopeFoldersPrefix + "folder-a",
+					},
+				},
+			},
+		}
+
+		got, err := svc.getRootFolders(context.Background(), &folder.GetChildrenQuery{
+			OrgID:        1,
+			Page:         1,
+			SignedInUser: editor,
+		})
+		require.NoError(t, err)
+		require.True(t, store.GetChildrenCalled)
+		require.Equal(t, []string{"folder-a"}, store.LastGetChildrenQuery.FolderUIDs)
+		require.Len(t, got, 2)
+		require.Equal(t, folder.SharedWithMeFolderUID, got[0].UID)
+		require.Equal(t, "folder-a", got[1].UID)
+	})
+
+	t.Run("only sharedwithme skips search and returns shared with me", func(t *testing.T) {
+		store := folder.NewFakeStore()
+		store.ExpectedChildFolders = []*folder.FolderReference{realFolder} // must not be used
+		svc := &Service{unifiedStore: store, tracer: tracer}
+
+		editor := &user.SignedInUser{
+			OrgID: 1,
+			Permissions: map[int64]map[string][]string{
+				1: {
+					folder.ActionFoldersRead: {
+						folder.ScopeFoldersPrefix + folder.SharedWithMeFolderUID,
+					},
+				},
+			},
+		}
+
+		got, err := svc.getRootFolders(context.Background(), &folder.GetChildrenQuery{
+			OrgID:        1,
+			Page:         1,
+			SignedInUser: editor,
+		})
+		require.NoError(t, err)
+		require.False(t, store.GetChildrenCalled, "must not search with empty FolderUIDs filter")
+		require.Len(t, got, 1)
+		require.Equal(t, folder.SharedWithMeFolderUID, got[0].UID)
+	})
+
+	t.Run("wildcard skips shared with me and does not filter by uid", func(t *testing.T) {
+		store := folder.NewFakeStore()
+		store.ExpectedChildFolders = []*folder.FolderReference{realFolder}
+		svc := &Service{unifiedStore: store, tracer: tracer}
+
+		adminish := &user.SignedInUser{
+			OrgID: 1,
+			Permissions: map[int64]map[string][]string{
+				1: {folder.ActionFoldersRead: {folder.ScopeFoldersAll}},
+			},
+		}
+
+		got, err := svc.getRootFolders(context.Background(), &folder.GetChildrenQuery{
+			OrgID:        1,
+			Page:         1,
+			SignedInUser: adminish,
+		})
+		require.NoError(t, err)
+		require.True(t, store.GetChildrenCalled)
+		require.Nil(t, store.LastGetChildrenQuery.FolderUIDs)
+		require.Len(t, got, 1)
+		require.Equal(t, "folder-a", got[0].UID)
+	})
+}

--- a/pkg/services/folder/store_fake.go
+++ b/pkg/services/folder/store_fake.go
@@ -12,6 +12,8 @@ type fakeStore struct {
 	ExpectedError         error
 	CreateCalled          bool
 	DeleteCalled          bool
+	GetChildrenCalled     bool
+	LastGetChildrenQuery  GetChildrenQuery
 }
 
 func NewFakeStore() *fakeStore {
@@ -43,6 +45,8 @@ func (f *fakeStore) GetParents(ctx context.Context, q GetParentsQuery) ([]*Folde
 }
 
 func (f *fakeStore) GetChildren(ctx context.Context, cmd GetChildrenQuery) ([]*FolderReference, error) {
+	f.GetChildrenCalled = true
+	f.LastGetChildrenQuery = cmd
 	return f.ExpectedChildFolders, f.ExpectedError
 }
 


### PR DESCRIPTION
## Summary
- Invalidate basic-role and team RBAC permission caches when builtin/team resource permissions change, so Editors immediately see newly granted folders in **View by folders**.
- Exclude virtual `sharedwithme` from `getRootFolders` UID search filter; skip the empty-UID search that would otherwise list all root folders.
- Add regression tests covering cache invalidation and `getRootFolders` behavior.

Fixes #129016

## Test plan
- [x] As Admin, create a root folder with a dashboard
- [x] As Org Editor, open Dashboards → **View by folders** and refresh repeatedly; folder should always appear (not only Shared with me)
- [x] **View as list** still works
- [x] `go test ./pkg/services/accesscontrol/resourcepermissions/ -count=1 -run 'ClearsBasicRole|EditorFolderPermission'`
- [x] `go test ./pkg/services/accesscontrol/acimpl/ -count=1 -run 'ClearBasicRoleAndTeam'`
- [x] `go test ./pkg/services/folder/lderimpl/ -count=1 -run 'TestGetRootFolders'`