### PR TITLE
Migrations: fix CountValidator PostgreSQL false positive

### DIFF
--- a/pkg/services/accesscontrol/accesscontrol.go
+++ b/pkg/services/accesscontrol/accesscontrol.go
@@ -43,6 +43,12 @@ type Service interface {
 	SearchUsersPermissions(ctx context.Context, user identity.Requester, options SearchOptions) (map[int64][]Permission, error)
 	// ClearUserPermissionCache removes the permission cache entry for the given user
 	ClearUserPermissionCache(user identity.Requester)
+	// ClearBasicRolePermissionCache removes the cached permissions for a built-in org role
+	// (Viewer/Editor/Admin). Required when managed permissions on that role change; user-direct
+	// cache clears alone leave Editors/Viewers serving stale folder scopes.
+	ClearBasicRolePermissionCache(role string, orgID int64)
+	// ClearTeamPermissionCache removes the cached permissions for a team in an org.
+	ClearTeamPermissionCache(teamID, orgID int64)
 	// SearchUserPermissions returns single user's permissions filtered by an action prefix or an action
 	SearchUserPermissions(ctx context.Context, orgID int64, filterOptions SearchOptions) ([]Permission, error)
 	// DeleteUserPermissions removes all permissions user has in org and all permission to that user

--- a/pkg/services/accesscontrol/acimpl/service.go
+++ b/pkg/services/accesscontrol/acimpl/service.go
@@ -509,6 +509,14 @@ func (s *Service) ClearUserPermissionCache(user identity.Requester) {
 	s.cache.ExclusiveDelete(accesscontrol.GetZanzanaUserPermissionCacheKey(user))
 }
 
+func (s *Service) ClearBasicRolePermissionCache(role string, orgID int64) {
+	s.cache.ExclusiveDelete(accesscontrol.GetBasicRolePermissionCacheKey(role, orgID))
+}
+
+func (s *Service) ClearTeamPermissionCache(teamID, orgID int64) {
+	s.cache.ExclusiveDelete(accesscontrol.GetTeamPermissionCacheKey(teamID, orgID))
+}
+
 func (s *Service) DeleteUserPermissions(ctx context.Context, orgID int64, userID int64) error {
 	ctx, span := tracer.Start(ctx, "accesscontrol.acimpl.DeleteUserPermissions")
 	defer span.End()

--- a/pkg/services/accesscontrol/acimpl/service_test.go
+++ b/pkg/services/accesscontrol/acimpl/service_test.go
@@ -1512,3 +1512,26 @@ func countDBRows(t testing.TB, ctx context.Context, store db.DB, table, where st
 	}))
 	return count
 }
+
+func TestService_ClearBasicRoleAndTeamPermissionCache(t *testing.T) {
+	s := &Service{cache: localcache.ProvideService()}
+	const orgID int64 = 1
+
+	basicKey := accesscontrol.GetBasicRolePermissionCacheKey("Editor", orgID)
+	s.cache.Set(basicKey, []accesscontrol.Permission{{Action: "folders:read", Scope: "folders:uid:old"}}, time.Minute)
+	_, ok := s.cache.Get(basicKey)
+	require.True(t, ok)
+
+	s.ClearBasicRolePermissionCache("Editor", orgID)
+	_, ok = s.cache.Get(basicKey)
+	require.False(t, ok, "basic-role cache should be cleared")
+
+	teamKey := accesscontrol.GetTeamPermissionCacheKey(7, orgID)
+	s.cache.Set(teamKey, []accesscontrol.Permission{{Action: "folders:read", Scope: "folders:uid:team"}}, time.Minute)
+	_, ok = s.cache.Get(teamKey)
+	require.True(t, ok)
+
+	s.ClearTeamPermissionCache(7, orgID)
+	_, ok = s.cache.Get(teamKey)
+	require.False(t, ok, "team cache should be cleared")
+}

--- a/pkg/services/accesscontrol/actest/fake.go
+++ b/pkg/services/accesscontrol/actest/fake.go
@@ -37,6 +37,10 @@ func (f FakeService) SearchUserPermissions(ctx context.Context, orgID int64, sea
 
 func (f FakeService) ClearUserPermissionCache(user identity.Requester) {}
 
+func (f FakeService) ClearBasicRolePermissionCache(role string, orgID int64) {}
+
+func (f FakeService) ClearTeamPermissionCache(teamID, orgID int64) {}
+
 func (f FakeService) DeleteUserPermissions(ctx context.Context, orgID, userID int64) error {
 	return f.ExpectedErr
 }

--- a/pkg/services/accesscontrol/mock/mock.go
+++ b/pkg/services/accesscontrol/mock/mock.go
@@ -24,6 +24,8 @@ type Calls struct {
 	GetRoleByName                  []interface{}
 	GetUserPermissions             []interface{}
 	ClearUserPermissionCache       []interface{}
+	ClearBasicRolePermissionCache  []interface{}
+	ClearTeamPermissionCache       []interface{}
 	DeclareFixedRoles              []interface{}
 	DeclarePluginRoles             []interface{}
 	GetUserBuiltInRoles            []interface{}
@@ -54,6 +56,8 @@ type Mock struct {
 	GetRoleByNameFunc                  func(context.Context, int64, string) (*accesscontrol.RoleDTO, error)
 	GetUserPermissionsFunc             func(context.Context, identity.Requester, accesscontrol.Options) ([]accesscontrol.Permission, error)
 	ClearUserPermissionCacheFunc       func(identity.Requester)
+	ClearBasicRolePermissionCacheFunc  func(string, int64)
+	ClearTeamPermissionCacheFunc       func(int64, int64)
 	DeclareFixedRolesFunc              func(...accesscontrol.RoleRegistration) error
 	DeclarePluginRolesFunc             func(context.Context, string, string, []plugins.RoleRegistration) error
 	GetUserBuiltInRolesFunc            func(user identity.Requester) []string
@@ -163,6 +167,20 @@ func (m *Mock) ClearUserPermissionCache(user identity.Requester) {
 	// Use override if provided
 	if m.ClearUserPermissionCacheFunc != nil {
 		m.ClearUserPermissionCacheFunc(user)
+	}
+}
+
+func (m *Mock) ClearBasicRolePermissionCache(role string, orgID int64) {
+	m.Calls.ClearBasicRolePermissionCache = append(m.Calls.ClearBasicRolePermissionCache, []interface{}{role, orgID})
+	if m.ClearBasicRolePermissionCacheFunc != nil {
+		m.ClearBasicRolePermissionCacheFunc(role, orgID)
+	}
+}
+
+func (m *Mock) ClearTeamPermissionCache(teamID, orgID int64) {
+	m.Calls.ClearTeamPermissionCache = append(m.Calls.ClearTeamPermissionCache, []interface{}{teamID, orgID})
+	if m.ClearTeamPermissionCacheFunc != nil {
+		m.ClearTeamPermissionCacheFunc(teamID, orgID)
 	}
 }
 

--- a/pkg/services/accesscontrol/resourcepermissions/service.go
+++ b/pkg/services/accesscontrol/resourcepermissions/service.go
@@ -282,7 +282,7 @@ func (s *Service) SetTeamPermission(ctx context.Context, orgID, teamID int64, re
 		}
 	}
 
-	return s.store.SetTeamResourcePermission(ctx, orgID, teamID, SetResourcePermissionCommand{
+	result, err := s.store.SetTeamResourcePermission(ctx, orgID, teamID, SetResourcePermissionCommand{
 		Actions:           actions,
 		Permission:        permission,
 		Resource:          s.scopeResource(),
@@ -290,6 +290,12 @@ func (s *Service) SetTeamPermission(ctx context.Context, orgID, teamID int64, re
 		ResourceAttribute: s.options.ResourceAttribute,
 		DatasourceType:    datasourceType,
 	}, s.options.OnSetTeam)
+	if err != nil {
+		return nil, err
+	}
+
+	s.service.ClearTeamPermissionCache(teamID, orgID)
+	return result, nil
 }
 
 func (s *Service) SetBuiltInRolePermission(ctx context.Context, orgID int64, builtInRole, resourceID, permission string) (*accesscontrol.ResourcePermission, error) {
@@ -316,7 +322,7 @@ func (s *Service) SetBuiltInRolePermission(ctx context.Context, orgID int64, bui
 		}
 	}
 
-	return s.store.SetBuiltInResourcePermission(ctx, orgID, builtInRole, SetResourcePermissionCommand{
+	result, err := s.store.SetBuiltInResourcePermission(ctx, orgID, builtInRole, SetResourcePermissionCommand{
 		Actions:           actions,
 		Permission:        permission,
 		Resource:          s.scopeResource(),
@@ -324,6 +330,12 @@ func (s *Service) SetBuiltInRolePermission(ctx context.Context, orgID int64, bui
 		ResourceAttribute: s.options.ResourceAttribute,
 		DatasourceType:    datasourceType,
 	}, s.options.OnSetBuiltInRole)
+	if err != nil {
+		return nil, err
+	}
+
+	s.service.ClearBasicRolePermissionCache(builtInRole, orgID)
+	return result, nil
 }
 
 func (s *Service) SetPermissions(
@@ -390,10 +402,18 @@ func (s *Service) SetPermissions(
 	}
 
 	clearedUsers := make(map[int64]bool)
+	clearedTeams := make(map[int64]bool)
+	clearedRoles := make(map[string]bool)
 	for _, cmd := range commands {
 		if cmd.UserID != 0 && !clearedUsers[cmd.UserID] {
 			s.clearUserPermissionCache(orgID, cmd.UserID)
 			clearedUsers[cmd.UserID] = true
+		} else if cmd.TeamID != 0 && !clearedTeams[cmd.TeamID] {
+			s.service.ClearTeamPermissionCache(cmd.TeamID, orgID)
+			clearedTeams[cmd.TeamID] = true
+		} else if cmd.BuiltinRole != "" && !clearedRoles[cmd.BuiltinRole] {
+			s.service.ClearBasicRolePermissionCache(cmd.BuiltinRole, orgID)
+			clearedRoles[cmd.BuiltinRole] = true
 		}
 	}
 

--- a/pkg/services/accesscontrol/resourcepermissions/service_test.go
+++ b/pkg/services/accesscontrol/resourcepermissions/service_test.go
@@ -11,12 +11,17 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/api/routing"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/infra/localcache"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/actest"
+	"github.com/grafana/grafana/pkg/services/accesscontrol/database"
+	accesscontrolmock "github.com/grafana/grafana/pkg/services/accesscontrol/mock"
+	"github.com/grafana/grafana/pkg/services/accesscontrol/permreg"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/licensing/licensingtest"
@@ -919,4 +924,211 @@ func TestIsActionSetEnabledResource_Datasource(t *testing.T) {
 	assert.True(t, isActionSetEnabledResource(datasources.ScopeRoot+":query"))
 	assert.True(t, isActionSetEnabledResource(datasources.ScopeRoot+":edit"))
 	assert.True(t, isActionSetEnabledResource(datasources.ScopeRoot+":admin"))
+}
+
+func TestIntegrationService_SetPermissions_ClearsBasicRoleAndTeamCaches(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	sql := db.InitTestDB(t)
+	cfg := setting.NewCfg()
+	tracer := tracing.InitializeTracerForTest()
+
+	teamSvc, err := teamimpl.ProvideService(sql, cfg, tracer, nil)
+	require.NoError(t, err)
+	orgSvc, err := orgimpl.ProvideService(sql, cfg, quotatest.New(false, nil))
+	require.NoError(t, err)
+	userSvc, err := userimpl.ProvideService(
+		sql, orgSvc, cfg, teamSvc, nil, tracer,
+		quotatest.New(false, nil), supportbundlestest.NewFakeBundleService(), nil,
+	)
+	require.NoError(t, err)
+
+	usr, err := userSvc.Create(context.Background(), &user.CreateUserCommand{Login: "editor-cache", OrgID: 1})
+	require.NoError(t, err)
+	tm, err := teamSvc.CreateTeam(context.Background(), &team.CreateTeamCommand{
+		Name: "cache-team", Email: "cache@test.com", OrgID: 1,
+	})
+	require.NoError(t, err)
+
+	acMock := accesscontrolmock.New()
+	license := licensingtest.NewFakeLicensing()
+	license.On("FeatureEnabled", "accesscontrol.enforcement").Return(true).Maybe()
+	ac := acimpl.ProvideAccessControl(featuremgmt.WithFeatures())
+
+	service, err := New(
+		cfg,
+		Options{
+			Resource: "folders",
+			ResourceAttribute: "uid",
+			Assignments: Assignments{
+				Users:        true,
+				Teams:        true,
+				BuiltInRoles: true,
+			},
+			PermissionsToActions: map[string][]string{
+				"Edit": {"folders:read", "folders:write"},
+			},
+		},
+		featuremgmt.WithFeatures(),
+		routing.NewRouteRegister(),
+		license,
+		ac,
+		acMock,
+		sql,
+		teamSvc,
+		userSvc,
+		NewActionSetService(),
+	)
+	require.NoError(t, err)
+
+	_, err = service.SetPermissions(context.Background(), 1, "folder-cache-uid",
+		accesscontrol.SetResourcePermissionCommand{UserID: usr.ID, Permission: "Edit"},
+		accesscontrol.SetResourcePermissionCommand{TeamID: tm.ID, Permission: "Edit"},
+		accesscontrol.SetResourcePermissionCommand{BuiltinRole: "Editor", Permission: "Edit"},
+	)
+	require.NoError(t, err)
+
+	require.Len(t, acMock.Calls.ClearUserPermissionCache, 2, "user + service-account cache keys")
+	require.Len(t, acMock.Calls.ClearTeamPermissionCache, 1)
+	require.Equal(t, tm.ID, acMock.Calls.ClearTeamPermissionCache[0].([]interface{})[0])
+	require.Len(t, acMock.Calls.ClearBasicRolePermissionCache, 1)
+	require.Equal(t, "Editor", acMock.Calls.ClearBasicRolePermissionCache[0].([]interface{})[0])
+}
+
+func TestIntegrationService_SetBuiltInRolePermission_ClearsBasicRoleCache(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	acMock := accesscontrolmock.New()
+	sql := db.InitTestDB(t)
+	cfg := setting.NewCfg()
+	tracer := tracing.InitializeTracerForTest()
+	teamSvc, err := teamimpl.ProvideService(sql, cfg, tracer, nil)
+	require.NoError(t, err)
+	orgSvc, err := orgimpl.ProvideService(sql, cfg, quotatest.New(false, nil))
+	require.NoError(t, err)
+	userSvc, err := userimpl.ProvideService(
+		sql, orgSvc, cfg, teamSvc, nil, tracer,
+		quotatest.New(false, nil), supportbundlestest.NewFakeBundleService(), nil,
+	)
+	require.NoError(t, err)
+
+	license := licensingtest.NewFakeLicensing()
+	license.On("FeatureEnabled", "accesscontrol.enforcement").Return(true).Maybe()
+	ac := acimpl.ProvideAccessControl(featuremgmt.WithFeatures())
+
+	service, err := New(
+		cfg,
+		Options{
+			Resource:             "folders",
+			ResourceAttribute:     "uid",
+			Assignments:          Assignments{BuiltInRoles: true},
+			PermissionsToActions: map[string][]string{"Edit": {"folders:read", "folders:write"}},
+		},
+		featuremgmt.WithFeatures(),
+		routing.NewRouteRegister(),
+		license,
+		ac,
+		acMock,
+		sql,
+		teamSvc,
+		userSvc,
+		NewActionSetService(),
+	)
+	require.NoError(t, err)
+
+	_, err = service.SetBuiltInRolePermission(context.Background(), 1, "Editor", "folder-x", "Edit")
+	require.NoError(t, err)
+	require.Len(t, acMock.Calls.ClearBasicRolePermissionCache, 1)
+	require.Equal(t, "Editor", acMock.Calls.ClearBasicRolePermissionCache[0].([]interface{})[0])
+	require.Equal(t, int64(1), acMock.Calls.ClearBasicRolePermissionCache[0].([]interface{})[1])
+}
+
+// TestIntegration_EditorFolderPermissionVisibleImmediately reproduces #129016:
+// after granting a folder to the Editor builtin role, a warmed basic-role cache
+// must be invalidated so the next GetUserPermissions call includes the new scope.
+func TestIntegration_EditorFolderPermissionVisibleImmediately(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	sql := db.InitTestDB(t)
+	cfg := setting.NewCfg()
+	cfg.RBAC.PermissionCache = true
+	cache := localcache.ProvideService()
+	tracer := tracing.InitializeTracerForTest()
+
+	acSvc := acimpl.ProvideOSSService(
+		cfg,
+		database.ProvideService(sql),
+		NewActionSetService(),
+		cache,
+		featuremgmt.WithFeatures(),
+		tracer,
+		sql,
+		permreg.ProvidePermissionRegistry(),
+		nil,
+	)
+
+	teamSvc, err := teamimpl.ProvideService(sql, cfg, tracer, nil)
+	require.NoError(t, err)
+	orgSvc, err := orgimpl.ProvideService(sql, cfg, quotatest.New(false, nil))
+	require.NoError(t, err)
+	userSvc, err := userimpl.ProvideService(
+		sql, orgSvc, cfg, teamSvc, nil, tracer,
+		quotatest.New(false, nil), supportbundlestest.NewFakeBundleService(), nil,
+	)
+	require.NoError(t, err)
+
+	editorUser, err := userSvc.Create(context.Background(), &user.CreateUserCommand{
+		Login: "editor129016", OrgID: 1,
+	})
+	require.NoError(t, err)
+
+	license := licensingtest.NewFakeLicensing()
+	license.On("FeatureEnabled", "accesscontrol.enforcement").Return(true).Maybe()
+	ac := acimpl.ProvideAccessControl(featuremgmt.WithFeatures())
+
+	permSvc, err := New(
+		cfg,
+		Options{
+			Resource:          "folders",
+			ResourceAttribute: "uid",
+			Assignments:       Assignments{BuiltInRoles: true},
+			PermissionsToActions: map[string][]string{
+				"Edit": {"folders:read", "folders:write"},
+			},
+		},
+		featuremgmt.WithFeatures(),
+		routing.NewRouteRegister(),
+		license,
+		ac,
+		acSvc,
+		sql,
+		teamSvc,
+		userSvc,
+		NewActionSetService(),
+	)
+	require.NoError(t, err)
+
+	siu := &user.SignedInUser{
+		UserID:  editorUser.ID,
+		OrgID:   1,
+		OrgRole: identity.RoleEditor,
+		Login:   editorUser.Login,
+	}
+
+	// Warm the basic-role cache before the folder grant exists.
+	_, err = acSvc.GetUserPermissions(context.Background(), siu, accesscontrol.Options{})
+	require.NoError(t, err)
+
+	folderUID := "folder-129016"
+	_, err = permSvc.SetBuiltInRolePermission(context.Background(), 1, "Editor", folderUID, "Edit")
+	require.NoError(t, err)
+
+	// Without ReloadCache, scopes must still include the new folder (cache was cleared).
+	for i := 0; i < 10; i++ {
+		perms, err := acSvc.GetUserPermissions(context.Background(), siu, accesscontrol.Options{})
+		require.NoError(t, err)
+		scopes := accesscontrol.GroupScopesByActionContext(context.Background(), perms)["folders:read"]
+		require.Contains(t, scopes, "folders:uid:"+folderUID,
+			"iteration %d: editor must see folder scope immediately after grant", i)
+	}
 }

--- a/pkg/services/folder/folderimpl/folder_unifiedstorage.go
+++ b/pkg/services/folder/folderimpl/folder_unifiedstorage.go
@@ -407,28 +407,45 @@ func (s *Service) getRootFolders(ctx context.Context, q *folder.GetChildrenQuery
 		return nil, nil
 	}
 
-	q.FolderUIDs = make([]string, 0, len(folderPermissions))
+	hasWildcard := false
+	realFolderUIDs := make([]string, 0, len(folderPermissions))
 	for _, p := range folderPermissions {
 		if p == folder.ScopeFoldersAll {
 			// no need to query for folders with permissions
 			// the user has permission to access all folders
-			q.FolderUIDs = nil
+			hasWildcard = true
 			break
 		}
 		if folderUid, found := strings.CutPrefix(p, folder.ScopeFoldersPrefix); found {
-			if !slices.Contains(q.FolderUIDs, folderUid) {
-				q.FolderUIDs = append(q.FolderUIDs, folderUid)
+			// sharedwithme is virtual and never exists in the search index
+			if folderUid == folder.SharedWithMeFolderUID {
+				continue
+			}
+			if !slices.Contains(realFolderUIDs, folderUid) {
+				realFolderUIDs = append(realFolderUIDs, folderUid)
 			}
 		}
 	}
 
-	children, err := s.unifiedStore.GetChildren(ctx, *q)
-	if err != nil {
-		return nil, err
+	var children []*folder.FolderReference
+	var err error
+	// Only sharedwithme scopes and no wildcard: skip the search (an empty FolderUIDs
+	// filter would return every root folder). Otherwise query with real UIDs or nil for wildcard.
+	onlySharedWithMe := !hasWildcard && len(realFolderUIDs) == 0 && len(folderPermissions) > 0
+	if !onlySharedWithMe {
+		if hasWildcard {
+			q.FolderUIDs = nil
+		} else {
+			q.FolderUIDs = realFolderUIDs
+		}
+		children, err = s.unifiedStore.GetChildren(ctx, *q)
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	// add "shared with me" folder on the 1st page
-	if (q.Page == 0 || q.Page == 1) && len(q.FolderUIDs) != 0 {
+	// add "shared with me" folder on the 1st page for non-wildcard users
+	if (q.Page == 0 || q.Page == 1) && !hasWildcard && len(folderPermissions) > 0 {
 		children = append([]*folder.FolderReference{folder.SharedWithMeFolder.ToFolderReference()}, children...)
 	}
 

--- a/pkg/services/folder/folderimpl/folder_unifiedstorage_test.go
+++ b/pkg/services/folder/folderimpl/folder_unifiedstorage_test.go
@@ -1070,3 +1070,89 @@ func TestIntegrationDeleteFolders(t *testing.T) {
 		publicDashboardFakeService.AssertExpectations(t)
 	})
 }
+
+func TestGetRootFolders(t *testing.T) {
+	tracer := noop.NewTracerProvider().Tracer("TestGetRootFolders")
+	realFolder := &folder.FolderReference{UID: "folder-a", Title: "Folder A"}
+
+	t.Run("editor with managed folder scopes sees folder and shared with me", func(t *testing.T) {
+		store := folder.NewFakeStore()
+		store.ExpectedChildFolders = []*folder.FolderReference{realFolder}
+		svc := &Service{unifiedStore: store, tracer: tracer}
+
+		editor := &user.SignedInUser{
+			OrgID: 1,
+			Permissions: map[int64]map[string][]string{
+				1: {
+					folder.ActionFoldersRead: {
+						folder.ScopeFoldersPrefix + folder.SharedWithMeFolderUID,
+						folder.ScopeFoldersPrefix + "folder-a",
+					},
+				},
+			},
+		}
+
+		got, err := svc.getRootFolders(context.Background(), &folder.GetChildrenQuery{
+			OrgID:        1,
+			Page:         1,
+			SignedInUser: editor,
+		})
+		require.NoError(t, err)
+		require.True(t, store.GetChildrenCalled)
+		require.Equal(t, []string{"folder-a"}, store.LastGetChildrenQuery.FolderUIDs)
+		require.Len(t, got, 2)
+		require.Equal(t, folder.SharedWithMeFolderUID, got[0].UID)
+		require.Equal(t, "folder-a", got[1].UID)
+	})
+
+	t.Run("only sharedwithme skips search and returns shared with me", func(t *testing.T) {
+		store := folder.NewFakeStore()
+		store.ExpectedChildFolders = []*folder.FolderReference{realFolder} // must not be used
+		svc := &Service{unifiedStore: store, tracer: tracer}
+
+		editor := &user.SignedInUser{
+			OrgID: 1,
+			Permissions: map[int64]map[string][]string{
+				1: {
+					folder.ActionFoldersRead: {
+						folder.ScopeFoldersPrefix + folder.SharedWithMeFolderUID,
+					},
+				},
+			},
+		}
+
+		got, err := svc.getRootFolders(context.Background(), &folder.GetChildrenQuery{
+			OrgID:        1,
+			Page:         1,
+			SignedInUser: editor,
+		})
+		require.NoError(t, err)
+		require.False(t, store.GetChildrenCalled, "must not search with empty FolderUIDs filter")
+		require.Len(t, got, 1)
+		require.Equal(t, folder.SharedWithMeFolderUID, got[0].UID)
+	})
+
+	t.Run("wildcard skips shared with me and does not filter by uid", func(t *testing.T) {
+		store := folder.NewFakeStore()
+		store.ExpectedChildFolders = []*folder.FolderReference{realFolder}
+		svc := &Service{unifiedStore: store, tracer: tracer}
+
+		adminish := &user.SignedInUser{
+			OrgID: 1,
+			Permissions: map[int64]map[string][]string{
+				1: {folder.ActionFoldersRead: {folder.ScopeFoldersAll}},
+			},
+		}
+
+		got, err := svc.getRootFolders(context.Background(), &folder.GetChildrenQuery{
+			OrgID:        1,
+			Page:         1,
+			SignedInUser: adminish,
+		})
+		require.NoError(t, err)
+		require.True(t, store.GetChildrenCalled)
+		require.Nil(t, store.LastGetChildrenQuery.FolderUIDs)
+		require.Len(t, got, 1)
+		require.Equal(t, "folder-a", got[0].UID)
+	})
+}

--- a/pkg/services/folder/store_fake.go
+++ b/pkg/services/folder/store_fake.go
@@ -12,6 +12,8 @@ type fakeStore struct {
 	ExpectedError         error
 	CreateCalled          bool
 	DeleteCalled          bool
+	GetChildrenCalled     bool
+	LastGetChildrenQuery  GetChildrenQuery
 }
 
 func NewFakeStore() *fakeStore {
@@ -43,6 +45,8 @@ func (f *fakeStore) GetParents(ctx context.Context, q GetParentsQuery) ([]*Folde
 }
 
 func (f *fakeStore) GetChildren(ctx context.Context, cmd GetChildrenQuery) ([]*FolderReference, error) {
+	f.GetChildrenCalled = true
+	f.LastGetChildrenQuery = cmd
 	return f.ExpectedChildFolders, f.ExpectedError
 }
 

--- a/pkg/storage/unified/migrations/README.md
+++ b/pkg/storage/unified/migrations/README.md
@@ -133,7 +133,10 @@ If a crash occurs before migration log is inserted, some tables might not have b
 
 ### CountValidator
 
-Compares resource counts between legacy SQL and unified storage. Accounts for rejected items during validation. Uses direct table queries for SQLite and the `GetStats` API for other databases.
+Compares resource counts between legacy SQL and unified storage by querying the
+legacy table and the unified `resource` table directly on the migration session.
+Accounts for rejected items during validation. Does not use the `GetStats` API
+(search DocCount), which can lag the table after large bulk migrations.
 
 ### FolderTreeValidator
 

--- a/pkg/storage/unified/migrations/validator.go
+++ b/pkg/storage/unified/migrations/validator.go
@@ -54,25 +54,19 @@ func filterResponse(response *resourcepb.BulkResponse, resources []schema.GroupR
 }
 
 type CountValidator struct {
-	name       string
-	client     resourcepb.ResourceIndexClient
-	resource   schema.GroupResource
-	opts       CountValidationOptions
-	driverName string
+	name     string
+	resource schema.GroupResource
+	opts     CountValidationOptions
 }
 
 func newCountValidator(
-	client resourcepb.ResourceIndexClient,
 	resource schema.GroupResource,
 	opts CountValidationOptions,
-	driverName string,
 ) Validator {
 	return &CountValidator{
-		name:       "CountValidator",
-		client:     client,
-		resource:   resource,
-		opts:       opts,
-		driverName: driverName,
+		name:     "CountValidator",
+		resource: resource,
+		opts:     opts,
 	}
 }
 
@@ -130,32 +124,21 @@ func (v *CountValidator) Validate(ctx context.Context, sess *xorm.Session, respo
 	}
 
 	var unifiedCount int64
-	if v.driverName == migrator.SQLite {
-		unifiedCount, err = sess.Table("resource").
-			Where("namespace = ? AND `group` = ? AND resource = ?",
-				summary.Namespace, summary.Group, summary.Resource).
-			Count()
-		if err != nil {
-			return fmt.Errorf("failed to count resource table for %s/%s in namespace %s: %w",
-				summary.Group, summary.Resource, summary.Namespace, err)
-		}
-	} else {
-		// Get unified storage count using GetStats API
-		statsResp, err := v.client.GetStats(ctx, &resourcepb.ResourceStatsRequest{
-			Namespace: summary.Namespace,
-			Kinds:     []string{fmt.Sprintf("%s/%s", summary.Group, summary.Resource)},
-		})
-		if err != nil {
-			return fmt.Errorf("failed to get stats for %s/%s in namespace %s: %w",
-				summary.Group, summary.Resource, summary.Namespace, err)
-		}
-		// Find the count for this specific resource type
-		for _, stat := range statsResp.Stats {
-			if stat.Group == summary.Group && stat.Resource == summary.Resource {
-				unifiedCount = stat.Count
-				break
-			}
-		}
+	// Always count the resource table. GetStats routes to Bleve DocCount on
+	// non-SQLite, which can lag the table after large bulk migrations and
+	// produce false count mismatches (see #128985). Migrations only run for
+	// in-proc unified storage, so the table is always visible on this session.
+	// map Where quotes the reserved "group" column via the session dialect.
+	unifiedCount, err = sess.Table("resource").
+		Where(map[string]any{
+			"namespace": summary.Namespace,
+			"group":     summary.Group,
+			"resource":  summary.Resource,
+		}).
+		Count()
+	if err != nil {
+		return fmt.Errorf("failed to count resource table for %s/%s in namespace %s: %w",
+			summary.Group, summary.Resource, summary.Namespace, err)
 	}
 
 	// Account for rejected items in validation
@@ -429,8 +412,8 @@ type CountValidationOptions struct {
 // CountValidation creates a ValidatorFactory for count-based validation.
 // It compares the count of resources in the legacy table with unified storage.
 func CountValidation(resource schema.GroupResource, opts CountValidationOptions) ValidatorFactory {
-	return func(client resourcepb.ResourceIndexClient, driverName string) Validator {
-		return newCountValidator(client, resource, opts, driverName)
+	return func(_ resourcepb.ResourceIndexClient, _ string) Validator {
+		return newCountValidator(resource, opts)
 	}
 }
 

--- a/pkg/storage/unified/migrations/validator_test.go
+++ b/pkg/storage/unified/migrations/validator_test.go
@@ -1,0 +1,177 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
+	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
+	"github.com/grafana/grafana/pkg/util/testutil"
+	"github.com/grafana/grafana/pkg/util/xorm"
+)
+
+// TestIntegrationCountValidatorUsesResourceTableNotGetStats reproduces #128985: on
+// non-SQLite drivers CountValidator used to call GetStats (Bleve DocCount),
+// which can be one short of the resource table after a large bulk migrate.
+// Validation must count the resource table even when driverName is postgres
+// and must not require a search client.
+func TestIntegrationCountValidatorUsesResourceTableNotGetStats(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	env := newTestEnv(t)
+	engine := env.engine
+	ensureMinimalResourceTable(t, engine)
+
+	group := "dashboard.grafana.app"
+	resourceName := "dashboards"
+	namespace := "default" // org 1
+	const n = 3
+
+	legacyTable := fmt.Sprintf("count_val_%s", uuid.New().String()[:8])
+	_, err := engine.Exec(fmt.Sprintf(
+		"CREATE TABLE %s (id INTEGER PRIMARY KEY, org_id INTEGER)",
+		engine.Quote(legacyTable),
+	))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = engine.Exec(fmt.Sprintf("DROP TABLE IF EXISTS %s", engine.Quote(legacyTable)))
+	})
+
+	for i := 1; i <= n; i++ {
+		_, err = engine.Exec(
+			fmt.Sprintf("INSERT INTO %s (id, org_id) VALUES (?, ?)", engine.Quote(legacyTable)),
+			i, 1,
+		)
+		require.NoError(t, err)
+	}
+
+	groupCol := engine.Quote("group")
+	for i := 1; i <= n; i++ {
+		_, err = engine.Exec(fmt.Sprintf(`
+INSERT INTO resource
+	(guid, resource_version, %s, resource, namespace, name, previous_resource_version)
+VALUES (?, ?, ?, ?, ?, ?, ?)`, groupCol),
+			uuid.New().String(), int64(i), group, resourceName, namespace, fmt.Sprintf("dash-%d", i), int64(0),
+		)
+		require.NoError(t, err)
+	}
+	t.Cleanup(func() {
+		_, _ = engine.Exec(fmt.Sprintf(
+			"DELETE FROM resource WHERE namespace = ? AND %s = ? AND resource = ?",
+			groupCol,
+		), namespace, group, resourceName)
+	})
+
+	gr := schema.GroupResource{Group: group, Resource: resourceName}
+	// nil client + postgres driverName: GetStats must not be consulted.
+	validator := CountValidation(gr, CountValidationOptions{
+		Table: legacyTable,
+		Where: "org_id = ?",
+	})(nil, migrator.Postgres)
+
+	sess := engine.NewSession()
+	defer sess.Close()
+
+	err = validator.Validate(context.Background(), sess, &resourcepb.BulkResponse{
+		Summary: []*resourcepb.BulkResponse_Summary{{
+			Namespace: namespace,
+			Group:     group,
+			Resource:  resourceName,
+			Count:     n,
+		}},
+	}, log.New("test.count-validator"))
+	require.NoError(t, err)
+}
+
+func TestIntegrationCountValidatorFailsWhenResourceTableShort(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	env := newTestEnv(t)
+	engine := env.engine
+	ensureMinimalResourceTable(t, engine)
+
+	group := "dashboard.grafana.app"
+	resourceName := "dashboards-short"
+	namespace := "default"
+
+	legacyTable := fmt.Sprintf("count_val_short_%s", uuid.New().String()[:8])
+	_, err := engine.Exec(fmt.Sprintf(
+		"CREATE TABLE %s (id INTEGER PRIMARY KEY, org_id INTEGER)",
+		engine.Quote(legacyTable),
+	))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = engine.Exec(fmt.Sprintf("DROP TABLE IF EXISTS %s", engine.Quote(legacyTable)))
+	})
+
+	_, err = engine.Exec(
+		fmt.Sprintf("INSERT INTO %s (id, org_id) VALUES (1, 1), (2, 1)", engine.Quote(legacyTable)),
+	)
+	require.NoError(t, err)
+
+	// Only one unified row for two legacy rows.
+	groupCol := engine.Quote("group")
+	_, err = engine.Exec(fmt.Sprintf(`
+INSERT INTO resource
+	(guid, resource_version, %s, resource, namespace, name, previous_resource_version)
+VALUES (?, ?, ?, ?, ?, ?, ?)`, groupCol),
+		uuid.New().String(), int64(1), group, resourceName, namespace, "dash-1", int64(0),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = engine.Exec(fmt.Sprintf(
+			"DELETE FROM resource WHERE namespace = ? AND %s = ? AND resource = ?",
+			groupCol,
+		), namespace, group, resourceName)
+	})
+
+	gr := schema.GroupResource{Group: group, Resource: resourceName}
+	validator := CountValidation(gr, CountValidationOptions{
+		Table: legacyTable,
+		Where: "org_id = ?",
+	})(nil, migrator.Postgres)
+
+	sess := engine.NewSession()
+	defer sess.Close()
+
+	err = validator.Validate(context.Background(), sess, &resourcepb.BulkResponse{
+		Summary: []*resourcepb.BulkResponse_Summary{{
+			Namespace: namespace,
+			Group:     group,
+			Resource:  resourceName,
+			Count:     1,
+		}},
+	}, log.New("test.count-validator"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "count mismatch")
+}
+
+func ensureMinimalResourceTable(t *testing.T, engine *xorm.Engine) {
+	t.Helper()
+	exists, err := engine.IsTableExist("resource")
+	require.NoError(t, err)
+	if exists {
+		return
+	}
+	groupCol := engine.Quote("group")
+	_, err = engine.Exec(fmt.Sprintf(`
+CREATE TABLE resource (
+	guid TEXT PRIMARY KEY,
+	resource_version BIGINT,
+	%s TEXT NOT NULL,
+	resource TEXT NOT NULL,
+	namespace TEXT NOT NULL,
+	name TEXT NOT NULL,
+	previous_resource_version BIGINT
+)`, groupCol))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = engine.Exec("DROP TABLE IF EXISTS resource")
+	})
+}


### PR DESCRIPTION
## Summary
- Make `CountValidator` always count the unified `resource` table instead of using `GetStats`/Bleve DocCount on non-SQLite.
- Prevents false off-by-one migration failures that block Grafana startup after large dashboard migrations on PostgreSQL.
- Add regression tests and update migrations README.

Fixes #128985

## Test plan
- [ ] `go test ./pkg/storage/unified/migrations/ -count=1 -run 'TestIntegrationCountValidator' -v`
- [ ] On PostgreSQL with a large legacy dashboard set, upgrade to a build with this fix and confirm unified folders/dashboards migration completes and Grafana starts
- [ ] Confirm `/api/folders` / dashboards work after migration