### PR TITLE
chore: clean up provisioning feature toggle on fe side

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -830,7 +830,7 @@ export interface FeatureToggles {
   */
   alertingJiraIntegration?: boolean;
   /**
-  * 
+  *
   * @default true
   */
   alertingUseNewSimplifiedRoutingHashAlgorithm?: boolean;

--- a/public/app/api/clients/folder/v1beta1/hooks.test.ts
+++ b/public/app/api/clients/folder/v1beta1/hooks.test.ts
@@ -256,6 +256,7 @@ describe('useMoveMultipleFoldersMutationFacade', () => {
     jest.clearAllMocks();
     (useMoveFoldersMutationLegacy as jest.Mock).mockReturnValue([mockMoveFolders]);
     patchSpy.mockReset();
+    dispatchMockFn.mockReturnValue({ data: null });
   });
   afterEach(() => {
     folderAPIVersionResolver.reset();

--- a/public/app/api/clients/folder/v1beta1/utils.ts
+++ b/public/app/api/clients/folder/v1beta1/utils.ts
@@ -1,7 +1,6 @@
 import { type ResourceStats } from '@grafana/api-clients/rtkq/folder/v1beta1';
 import { AppEvents } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { config } from '@grafana/runtime';
 
 import { appEvents } from '../../../../core/app_events';
 import { isProvisionedFolder } from '../../../../features/browse-dashboards/api/isProvisioned';
@@ -14,26 +13,22 @@ export async function isProvisionedFolderCheck(
   folderUID: string,
   options?: { warning?: string }
 ) {
-  if (config.featureToggles.provisioning) {
-    const folder = await dispatch(folderAPI.endpoints.getFolder.initiate({ name: folderUID }));
-    // TODO: taken from browseDashboardAPI as it is, but this error handling should be moved up to UI code.
-    if (folder.data && isProvisionedFolder(folder.data)) {
-      appEvents.publish({
-        type: AppEvents.alertWarning.name,
-        payload: [
-          options?.warning ||
-            t(
-              'folders.api.folder-delete-error-provisioned',
-              'Cannot delete provisioned folder. To remove it, delete it from the repository and synchronise to apply the changes.'
-            ),
-        ],
-      });
-      return true;
-    }
-    return false;
-  } else {
-    return false;
+  const folder = await dispatch(folderAPI.endpoints.getFolder.initiate({ name: folderUID }));
+  // TODO: taken from browseDashboardAPI as it is, but this error handling should be moved up to UI code.
+  if (folder.data && isProvisionedFolder(folder.data)) {
+    appEvents.publish({
+      type: AppEvents.alertWarning.name,
+      payload: [
+        options?.warning ||
+          t(
+            'folders.api.folder-delete-error-provisioned',
+            'Cannot delete provisioned folder. To remove it, delete it from the repository and synchronise to apply the changes.'
+          ),
+      ],
+    });
+    return true;
   }
+  return false;
 }
 
 // Maps legacy resource names emitted by the `sql-fallback` group onto the unified-storage

--- a/public/app/features/browse-dashboards/api/browseDashboardsAPI.test.ts
+++ b/public/app/features/browse-dashboards/api/browseDashboardsAPI.test.ts
@@ -5,7 +5,7 @@ import { testWithFeatureToggles, waitFor } from 'test/test-utils';
 
 import { folderAPIVersionResolver } from '@grafana/api-clients/rtkq/folder/v1beta1';
 import * as quotasAPI from '@grafana/api-clients/rtkq/quotas/v0alpha1';
-import { config, setBackendSrv } from '@grafana/runtime';
+import { setBackendSrv } from '@grafana/runtime';
 import { type Dashboard } from '@grafana/schema';
 import { type Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.grafana.app/v2';
 import server, { setupMockServer } from '@grafana/test-utils/server';
@@ -211,7 +211,6 @@ describe('browseDashboardsAPI', () => {
 
   it('does not check whether a single delete target is provisioned before deleting it', async () => {
     const store = createTestStore();
-    config.featureToggles.provisioning = true;
 
     const getProvisionedFolderSpy = jest.fn();
     const deleteFolderSpy = jest.fn();
@@ -458,7 +457,6 @@ describe('browseDashboardsAPI', () => {
 
     it('does not delete provisioned folders during bulk delete', async () => {
       const store = createTestStore();
-      config.featureToggles.provisioning = true;
 
       const deleteSpy = jest.fn();
 
@@ -506,7 +504,6 @@ describe('browseDashboardsAPI', () => {
     });
 
     it('only un-stars folders that were actually deleted when some are provisioned', async () => {
-      config.featureToggles.provisioning = true;
       const { store, setStarredPayloads } = createStoreWithSetStarredRecorder();
 
       const deletedUids: string[] = [];

--- a/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
+++ b/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
@@ -273,14 +273,12 @@ export const browseDashboardsAPI = createApi({
           const dashboard = isDashboardV2Resource(fullDash) ? fullDash.spec : fullDash.dashboard;
           const k8s = isDashboardV2Resource(fullDash) ? fullDash.metadata : undefined;
 
-          if (config.featureToggles.provisioning) {
-            if (isProvisionedDashboard(fullDash)) {
-              appEvents.publish({
-                type: AppEvents.alertWarning.name,
-                payload: ['Cannot move provisioned dashboard'],
-              });
-              continue;
-            }
+          if (isProvisionedDashboard(fullDash)) {
+            appEvents.publish({
+              type: AppEvents.alertWarning.name,
+              payload: ['Cannot move provisioned dashboard'],
+            });
+            continue;
           }
           await api.saveDashboard({
             dashboard,
@@ -395,17 +393,15 @@ export const browseDashboardsAPI = createApi({
           for (const dashboardUID of dashboardUIDs) {
             // It's not possible to select a mix of provisioned and non-provisioned dashboards
             // from the UI, so this is mostly a guard in case that somehow happens
-            if (config.featureToggles.provisioning) {
-              const dto = await api.getDashboardDTO(dashboardUID);
-              if (isProvisionedDashboard(dto)) {
-                appEvents.publish({
-                  type: AppEvents.alertWarning.name,
-                  payload: [
-                    'Cannot delete provisioned dashboard. To remove it, delete it from the repository and synchronise to apply the changes.',
-                  ],
-                });
-                continue;
-              }
+            const dto = await api.getDashboardDTO(dashboardUID);
+            if (isProvisionedDashboard(dto)) {
+              appEvents.publish({
+                type: AppEvents.alertWarning.name,
+                payload: [
+                  'Cannot delete provisioned dashboard. To remove it, delete it from the repository and synchronise to apply the changes.',
+                ],
+              });
+              continue;
             }
             await api.deleteDashboard(dashboardUID, false);
 

--- a/public/app/features/browse-dashboards/components/BrowseActions/BrowseActions.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseActions/BrowseActions.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 
 import { Trans, t } from '@grafana/i18n';
-import { config, reportInteraction } from '@grafana/runtime';
+import { reportInteraction } from '@grafana/runtime';
 import { Button, Drawer, Stack, Text } from '@grafana/ui';
 import { appEvents } from 'app/core/app_events';
 import { BulkDeleteProvisionedResource } from 'app/features/provisioning/components/BulkActions/BulkDeleteProvisionedResource';
@@ -41,8 +41,6 @@ export function BrowseActions({ folderDTO }: Props) {
   const [moveFolders] = useMoveMultipleFoldersMutationFacade();
   const [moveDashboards] = useMoveDashboardsMutation();
   const [, stateManager] = useSearchStateManager();
-  const provisioningEnabled = config.featureToggles.provisioning;
-
   const { hasProvisioned, hasNonProvisioned } = useSelectionProvisioningStatus(
     selectedItems,
     isItemManagedByRepository(folderDTO)
@@ -79,7 +77,7 @@ export function BrowseActions({ folderDTO }: Props) {
   };
 
   const showMoveModal = () => {
-    if (provisioningEnabled && hasProvisioned && hasNonProvisioned) {
+    if (hasProvisioned && hasNonProvisioned) {
       // Mixed selection
       appEvents.publish(
         new ShowModalReactEvent({
@@ -90,7 +88,7 @@ export function BrowseActions({ folderDTO }: Props) {
       return;
     }
 
-    if (provisioningEnabled && hasProvisioned) {
+    if (hasProvisioned) {
       // Only provisioned items
       setShowBulkMoveProvisionedResource(true);
       return;
@@ -109,7 +107,7 @@ export function BrowseActions({ folderDTO }: Props) {
   };
 
   const showDeleteModal = () => {
-    if (hasProvisioned && hasNonProvisioned && provisioningEnabled) {
+    if (hasProvisioned && hasNonProvisioned) {
       // Mixed selection
       appEvents.publish(
         new ShowModalReactEvent({
@@ -117,7 +115,7 @@ export function BrowseActions({ folderDTO }: Props) {
           props: {},
         })
       );
-    } else if (hasProvisioned && provisioningEnabled) {
+    } else if (hasProvisioned) {
       // Only provisioned items
       setShowBulkDeleteProvisionedResource(true);
     } else {

--- a/public/app/features/browse-dashboards/components/BrowseView.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseView.tsx
@@ -1,11 +1,9 @@
 import { css } from '@emotion/css';
 import { useBooleanFlagValue } from '@openfeature/react-sdk';
-import { skipToken } from '@reduxjs/toolkit/query';
 import { useCallback, useMemo } from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { config } from '@grafana/runtime';
 import { CallToActionCard, EmptyState, LinkButton, TextLink, useStyles2 } from '@grafana/ui';
 import { useGetFrontendSettingsQuery } from 'app/api/clients/provisioning/v0alpha1';
 import { FolderReadmePanel } from 'app/features/provisioning/components/Folders/FolderReadmePanel';
@@ -58,29 +56,24 @@ export function BrowseView({
   const selectedItems = useCheckboxSelectionState();
   const childrenByParentUID = useChildrenByParentUIDState();
   const canSelect = canSelectItems(permissions);
-  const provisioningEnabled = config.featureToggles.provisioning;
-  const { data: settingsData } = useGetFrontendSettingsQuery(!provisioningEnabled ? skipToken : undefined);
+  const { data: settingsData } = useGetFrontendSettingsQuery(undefined);
   const isProvisionedInstance = useIsProvisionedInstance({ settings: settingsData });
   const rootItems = useSelector(rootItemsSelector);
 
   const [, stateManager] = useSearchStateManager();
 
   const excludeUIDs = useMemo(() => {
-    if (isProvisionedInstance || !provisioningEnabled) {
+    if (isProvisionedInstance) {
       return [];
     }
-    if (provisioningEnabled) {
-      // if only one repo folder and no local folders, then don't exclude it from selection
-      if (rootItems?.items.length === 1 && settingsData?.items.length === 1) {
-        return [];
-      }
-      // loop through settingsData to find all available repo name, and exclude them from select all action
-      // repo root folder is not actionable on browse dashboards page
-      return settingsData?.items.map((repo) => repo.name);
+    // if only one repo folder and no local folders, then don't exclude it from selection
+    if (rootItems?.items.length === 1 && settingsData?.items.length === 1) {
+      return [];
     }
-
-    return [];
-  }, [isProvisionedInstance, settingsData, provisioningEnabled, rootItems]);
+    // loop through settingsData to find all available repo name, and exclude them from select all action
+    // repo root folder is not actionable on browse dashboards page
+    return settingsData?.items.map((repo) => repo.name);
+  }, [isProvisionedInstance, settingsData, rootItems]);
 
   const handleFolderClick = useCallback(
     (clickedFolderUID: string, isOpen: boolean) => {

--- a/public/app/features/commandPalette/ResultItem.test.tsx
+++ b/public/app/features/commandPalette/ResultItem.test.tsx
@@ -1,7 +1,6 @@
 import { ActionImpl } from 'kbar';
 import { render, screen } from 'test/test-utils';
 
-import { config } from '@grafana/runtime';
 import { ManagerKind } from 'app/features/apiserver/types';
 
 import { ResultItem } from './ResultItem';
@@ -16,62 +15,34 @@ function createActionImpl(props: Record<string, unknown> = {}): ActionImpl {
 }
 
 describe('ResultItem', () => {
-  let originalProvisioning: boolean | undefined;
-
-  beforeEach(() => {
-    originalProvisioning = config.featureToggles.provisioning;
-  });
-
-  afterEach(() => {
-    config.featureToggles.provisioning = originalProvisioning;
-  });
-
   it('renders the action name', () => {
     const action = createActionImpl();
     render(<ResultItem action={action} active={false} currentRootActionId="" />);
     expect(screen.getByText('Test Dashboard')).toBeInTheDocument();
   });
 
-  it('renders the managed badge when managedBy is Repo and provisioning toggle is on', () => {
-    config.featureToggles.provisioning = true;
+  it('renders the managed badge when managedBy is Repo', () => {
     const action = createActionImpl({ managedBy: ManagerKind.Repo });
     render(<ResultItem action={action} active={false} currentRootActionId="" />);
     expect(screen.getByTestId('icon-exchange-alt')).toBeInTheDocument();
   });
 
   it('does not render the managed badge when managedBy is undefined', () => {
-    config.featureToggles.provisioning = true;
     const action = createActionImpl();
     render(<ResultItem action={action} active={false} currentRootActionId="" />);
     expect(screen.queryByTestId('icon-exchange-alt')).not.toBeInTheDocument();
   });
 
   it('renders the managed badge when managedBy is a non-Repo kind', () => {
-    config.featureToggles.provisioning = true;
     const action = createActionImpl({ managedBy: ManagerKind.Terraform });
     render(<ResultItem action={action} active={false} currentRootActionId="" />);
     expect(screen.getByTestId('icon-exchange-alt')).toBeInTheDocument();
   });
 
   it('renders the managed badge for plugin-managed resources', () => {
-    config.featureToggles.provisioning = true;
     const action = createActionImpl({ managedBy: ManagerKind.Plugin });
     render(<ResultItem action={action} active={false} currentRootActionId="" />);
     expect(screen.getByTestId('icon-exchange-alt')).toBeInTheDocument();
-  });
-
-  it('does not render the managed badge when provisioning toggle is off', () => {
-    config.featureToggles.provisioning = false;
-    const action = createActionImpl({ managedBy: ManagerKind.Repo });
-    render(<ResultItem action={action} active={false} currentRootActionId="" />);
-    expect(screen.queryByTestId('icon-exchange-alt')).not.toBeInTheDocument();
-  });
-
-  it('does not render the managed badge when provisioning toggle is undefined', () => {
-    config.featureToggles.provisioning = undefined;
-    const action = createActionImpl({ managedBy: ManagerKind.Repo });
-    render(<ResultItem action={action} active={false} currentRootActionId="" />);
-    expect(screen.queryByTestId('icon-exchange-alt')).not.toBeInTheDocument();
   });
 
   it('appends an ellipsis to a parent action that has children but no command or link', () => {

--- a/public/app/features/commandPalette/ResultItem.tsx
+++ b/public/app/features/commandPalette/ResultItem.tsx
@@ -3,7 +3,6 @@ import { type ActionId, type ActionImpl } from 'kbar';
 import * as React from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';
-import { config } from '@grafana/runtime';
 import { useStyles2 } from '@grafana/ui';
 import { type ManagerKind } from 'app/features/apiserver/types';
 import { ManagedBadge } from 'app/features/provisioning/components/ManagedBadge';
@@ -41,7 +40,7 @@ export const ResultItem = React.forwardRef(
     // See the same pattern for `url` in KBarResults.tsx and below command url
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     const managedBy = (action as ActionImpl & { managedBy?: ManagerKind }).managedBy;
-    const showProvisionedBadge = config.featureToggles.provisioning && Boolean(managedBy);
+    const showProvisionedBadge = Boolean(managedBy);
 
     let name = action.name;
 

--- a/public/app/features/dashboard-scene/saving/SaveDashboardDrawer.test.tsx
+++ b/public/app/features/dashboard-scene/saving/SaveDashboardDrawer.test.tsx
@@ -230,14 +230,6 @@ describe('SaveDashboardDrawer', () => {
   });
 
   describe('When a dashboard is managed by an external system', () => {
-    beforeEach(() => {
-      config.featureToggles.provisioning = true;
-    });
-
-    afterEach(() => {
-      config.featureToggles.provisioning = false;
-    });
-
     it('It should show the changes tab if the resource can be edited', async () => {
       const { dashboard, openAndRender } = setup({
         meta: {

--- a/public/app/features/dashboard-scene/saving/SaveDashboardDrawer.test.tsx
+++ b/public/app/features/dashboard-scene/saving/SaveDashboardDrawer.test.tsx
@@ -4,7 +4,6 @@ import { TestProvider } from 'test/helpers/TestProvider';
 import { byTestId, byText } from 'testing-library-selector';
 
 import { selectors } from '@grafana/e2e-selectors';
-import { config } from '@grafana/runtime';
 import { ConstantVariable, sceneGraph, SceneRefreshPicker } from '@grafana/scenes';
 import { AnnoKeyManagerKind, ManagerKind } from 'app/features/apiserver/types';
 import { type SaveDashboardResponseDTO } from 'app/types/dashboard';

--- a/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
@@ -1973,14 +1973,6 @@ describe('DashboardScene', () => {
   });
 
   describe('When checking dashboard managed by an external system', () => {
-    beforeEach(() => {
-      config.featureToggles.provisioning = true;
-    });
-
-    afterEach(() => {
-      config.featureToggles.provisioning = false;
-    });
-
     it('should return true if the dashboard is managed', () => {
       const scene = buildTestScene({
         meta: {

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -1390,9 +1390,6 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
   }
 
   isManagedRepository() {
-    if (!config.featureToggles.provisioning) {
-      return false;
-    }
     return Boolean(this.getManagerKind() === ManagerKind.Repo);
   }
 

--- a/public/app/features/dashboard-scene/scene/ManagedDashboardNavBarBadge.test.tsx
+++ b/public/app/features/dashboard-scene/scene/ManagedDashboardNavBarBadge.test.tsx
@@ -1,7 +1,6 @@
 import { HttpResponse, http } from 'msw';
 import { render, screen, waitFor } from 'test/test-utils';
 
-import { config } from '@grafana/runtime';
 import { PROVISIONING_API_BASE as BASE } from '@grafana/test-utils/handlers';
 import server from '@grafana/test-utils/server';
 import { type RepositoryView } from 'app/api/clients/provisioning/v0alpha1';
@@ -32,15 +31,7 @@ function buildDashboard(kind?: ManagerKind, id?: string): DashboardScene {
 }
 
 describe('ManagedDashboardNavBarBadge', () => {
-  let originalProvisioning: boolean | undefined;
-
-  beforeEach(() => {
-    originalProvisioning = config.featureToggles.provisioning;
-    config.featureToggles.provisioning = true;
-  });
-
   afterEach(() => {
-    config.featureToggles.provisioning = originalProvisioning;
     jest.restoreAllMocks();
   });
 

--- a/public/app/features/dashboard-scene/settings/VersionsEditView.test.tsx
+++ b/public/app/features/dashboard-scene/settings/VersionsEditView.test.tsx
@@ -256,12 +256,7 @@ describe('VersionsEditView', () => {
   });
 
   describe('Provisioned dashboards', () => {
-    beforeEach(() => {
-      config.featureToggles.provisioning = true;
-    });
-
     afterEach(() => {
-      config.featureToggles.provisioning = false;
       jest.clearAllMocks();
     });
 

--- a/public/app/features/dashboard-scene/settings/VersionsEditView.test.tsx
+++ b/public/app/features/dashboard-scene/settings/VersionsEditView.test.tsx
@@ -2,7 +2,6 @@ import { render as RTLRender, screen } from '@testing-library/react';
 import * as React from 'react';
 import { TestProvider } from 'test/helpers/TestProvider';
 
-import { config } from '@grafana/runtime';
 import { SceneTimeRange } from '@grafana/scenes';
 import { AnnoKeyManagerKind, ManagerKind } from 'app/features/apiserver/types';
 import { VERSIONS_FETCH_LIMIT } from 'app/features/dashboard/types/revisionModels';

--- a/public/app/features/provisioning/GettingStarted/GettingStarted.tsx
+++ b/public/app/features/provisioning/GettingStarted/GettingStarted.tsx
@@ -1,10 +1,8 @@
 import { css } from '@emotion/css';
-import { skipToken } from '@reduxjs/toolkit/query';
 import { useState } from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { config } from '@grafana/runtime';
 import { Stack, useStyles2 } from '@grafana/ui';
 import { type Repository, useGetFrontendSettingsQuery } from 'app/api/clients/provisioning/v0alpha1';
 
@@ -124,8 +122,7 @@ interface Props {
 
 export default function GettingStarted({ items }: Props) {
   const styles = useStyles2(getStyles);
-  const settingsArg = config.featureToggles.provisioning ? undefined : skipToken;
-  const settingsQuery = useGetFrontendSettingsQuery(settingsArg, {
+  const settingsQuery = useGetFrontendSettingsQuery(undefined, {
     refetchOnMountOrArgChange: true,
   });
   const connectionCount = settingsQuery.data?.items?.length ?? 0;

--- a/public/app/features/provisioning/components/Dashboards/DashboardPreviewBanner.tsx
+++ b/public/app/features/provisioning/components/Dashboards/DashboardPreviewBanner.tsx
@@ -1,5 +1,4 @@
 import { t } from '@grafana/i18n';
-import { config } from '@grafana/runtime';
 import { Alert } from '@grafana/ui';
 import { useGetRepositoryFilesWithPathQuery } from 'app/api/clients/provisioning/v0alpha1';
 import { type DashboardPageRouteSearchParams } from 'app/features/dashboard/containers/types';
@@ -58,8 +57,7 @@ function DashboardPreviewBannerContent({ queryParams, slug, path }: DashboardPre
 }
 
 export function DashboardPreviewBanner({ queryParams, route, slug, path }: DashboardPreviewBannerProps) {
-  const provisioningEnabled = config.featureToggles.provisioning;
-  if (!provisioningEnabled || 'kiosk' in queryParams || !path || route !== DashboardRoutes.Provisioning || !slug) {
+  if ('kiosk' in queryParams || !path || route !== DashboardRoutes.Provisioning || !slug) {
     return null;
   }
 

--- a/public/app/features/provisioning/components/Dashboards/OrphanedDashboardBanner.tsx
+++ b/public/app/features/provisioning/components/Dashboards/OrphanedDashboardBanner.tsx
@@ -1,4 +1,3 @@
-import { config } from '@grafana/runtime';
 import { ManagerKind } from 'app/features/apiserver/types';
 import { type DashboardScene } from 'app/features/dashboard-scene/scene/DashboardScene';
 
@@ -18,7 +17,7 @@ export function OrphanedDashboardBanner({ dashboard }: Props) {
   const kind = dashboard.getManagerKind();
   const name = dashboard.getManagerIdentity();
 
-  const shouldSkip = !config.featureToggles.provisioning || kind !== ManagerKind.Repo || !name;
+  const shouldSkip = kind !== ManagerKind.Repo || !name;
 
   const { status } = useGetResourceRepositoryView({
     name: shouldSkip ? undefined : name,

--- a/public/app/features/provisioning/components/Dashboards/SaveProvisionedDashboardForm.test.tsx
+++ b/public/app/features/provisioning/components/Dashboards/SaveProvisionedDashboardForm.test.tsx
@@ -1462,9 +1462,7 @@ describe('SaveProvisionedDashboardForm', () => {
 
   it('syncs dashboard meta with the created folder so defaults recompute against it', async () => {
     const FOLDER_BASE = '/apis/folder.grafana.app/v1beta1/namespaces/:namespace';
-    server.use(
-      http.get(`${FOLDER_BASE}/folders/:name`, () => HttpResponse.json({ metadata: { annotations: {} } }))
-    );
+    server.use(http.get(`${FOLDER_BASE}/folders/:name`, () => HttpResponse.json({ metadata: { annotations: {} } })));
 
     let dashboardRequest: { url: URL; body: unknown } | null = null;
     server.use(

--- a/public/app/features/provisioning/components/Dashboards/SaveProvisionedDashboardForm.test.tsx
+++ b/public/app/features/provisioning/components/Dashboards/SaveProvisionedDashboardForm.test.tsx
@@ -1461,6 +1461,11 @@ describe('SaveProvisionedDashboardForm', () => {
   });
 
   it('syncs dashboard meta with the created folder so defaults recompute against it', async () => {
+    const FOLDER_BASE = '/apis/folder.grafana.app/v1beta1/namespaces/:namespace';
+    server.use(
+      http.get(`${FOLDER_BASE}/folders/:name`, () => HttpResponse.json({ metadata: { annotations: {} } }))
+    );
+
     let dashboardRequest: { url: URL; body: unknown } | null = null;
     server.use(
       http.post(`${BASE}/repositories/:name/files/*`, async ({ request }) => {

--- a/public/app/features/provisioning/components/Folders/MissingFolderMetadataBanner.test.tsx
+++ b/public/app/features/provisioning/components/Folders/MissingFolderMetadataBanner.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen, testWithFeatureToggles } from 'test/test-utils';
 
-import { config } from '@grafana/runtime';
 import { setTestFlags } from '@grafana/test-utils/unstable';
 
 import { type FolderMetadataStatus } from '../../hooks/useFolderMetadataStatus';
@@ -89,16 +88,6 @@ describe('FolderPermissions', () => {
     expect(permissions).toHaveAttribute('data-can-set', 'true');
     expect(permissions).toHaveAttribute('data-resource-id', 'folder-1');
     expect(useFolderMetadataStatus).not.toHaveBeenCalled();
-  });
-
-  it('renders permissions directly when feature toggles are disabled', () => {
-    config.featureToggles.provisioning = false;
-
-    render(<FolderPermissions folderUID="folder-1" canSetPermissions={true} isProvisionedFolder={true} />);
-
-    const permissions = screen.getByTestId('permissions');
-    expect(permissions).toHaveAttribute('data-can-set', 'true');
-    expect(permissions).toHaveAttribute('data-resource-id', 'folder-1');
   });
 
   it('renders loading state', () => {

--- a/public/app/features/provisioning/components/Folders/MissingFolderMetadataBanner.tsx
+++ b/public/app/features/provisioning/components/Folders/MissingFolderMetadataBanner.tsx
@@ -2,7 +2,6 @@ import { useBooleanFlagValue } from '@openfeature/react-sdk';
 import { useState } from 'react';
 
 import { Trans, t } from '@grafana/i18n';
-import { config } from '@grafana/runtime';
 import { Alert, Button, LoadingPlaceholder } from '@grafana/ui';
 import { Permissions } from 'app/core/components/AccessControl/Permissions';
 
@@ -78,7 +77,7 @@ interface FolderPermissionsProps {
 export function FolderPermissions({ folderUID, canSetPermissions, isProvisionedFolder }: FolderPermissionsProps) {
   const provisioningFolderMetadataEnabled = useBooleanFlagValue('provisioningFolderMetadata', false);
 
-  if (!isProvisionedFolder || !config.featureToggles.provisioning || !provisioningFolderMetadataEnabled) {
+  if (!isProvisionedFolder || !provisioningFolderMetadataEnabled) {
     return <Permissions resource="folders" resourceId={folderUID} canSetPermissions={canSetPermissions} />;
   }
 

--- a/public/app/features/provisioning/components/Folders/ProvisionedFolderPreviewBanner.tsx
+++ b/public/app/features/provisioning/components/Folders/ProvisionedFolderPreviewBanner.tsx
@@ -1,5 +1,5 @@
 import { t, Trans } from '@grafana/i18n';
-import { config, locationService } from '@grafana/runtime';
+import { locationService } from '@grafana/runtime';
 import { Alert } from '@grafana/ui';
 import { type CommonBannerProps } from 'app/features/provisioning/components/Dashboards/DashboardPreviewBanner';
 import { PreviewBannerViewPR } from 'app/features/provisioning/components/Shared/PreviewBannerViewPR';
@@ -8,10 +8,9 @@ import { usePullRequestParam } from 'app/features/provisioning/hooks/usePullRequ
 import { PROVISIONING_URL } from '../../constants';
 
 export function ProvisionedFolderPreviewBanner({ queryParams }: CommonBannerProps) {
-  const provisioningEnabled = config.featureToggles.provisioning;
   const { prURL, newPrURL, repoURL, resourcePushedTo } = usePullRequestParam();
 
-  if (!provisioningEnabled || 'kiosk' in queryParams) {
+  if ('kiosk' in queryParams) {
     return null;
   }
 

--- a/public/app/features/provisioning/components/ManagedBadge.test.tsx
+++ b/public/app/features/provisioning/components/ManagedBadge.test.tsx
@@ -1,7 +1,6 @@
 import { HttpResponse, http } from 'msw';
 import { render, screen, waitFor } from 'test/test-utils';
 
-import { config } from '@grafana/runtime';
 import { PROVISIONING_API_BASE as BASE } from '@grafana/test-utils/handlers';
 import server from '@grafana/test-utils/server';
 import { type RepositoryView } from 'app/api/clients/provisioning/v0alpha1';
@@ -44,19 +43,15 @@ function setPermissions({ isEditor = false, canManageRepositories = false } = {}
 }
 
 describe('ManagedBadge', () => {
-  let originalProvisioning: boolean | undefined;
   let originalIsEditor: boolean;
 
   beforeEach(() => {
-    originalProvisioning = config.featureToggles.provisioning;
     originalIsEditor = contextSrv.isEditor;
-    config.featureToggles.provisioning = true;
     hasPermissionSpy = jest.spyOn(contextSrv, 'hasPermission');
     setPermissions();
   });
 
   afterEach(() => {
-    config.featureToggles.provisioning = originalProvisioning;
     contextSrv.isEditor = originalIsEditor;
     jest.restoreAllMocks();
   });
@@ -242,14 +237,5 @@ describe('ManagedBadge', () => {
       expect(screen.queryByRole('button')).not.toBeInTheDocument();
     });
 
-    it('renders a plain badge when the provisioning feature toggle is off', () => {
-      setPermissions({ isEditor: true, canManageRepositories: true });
-      config.featureToggles.provisioning = false;
-
-      render(<ManagedBadge managerKind={ManagerKind.Repo} repositoryName="my-repo" sourcePath="dashboards/foo.json" />);
-
-      expect(screen.getByTestId('icon-exchange-alt')).toBeInTheDocument();
-      expect(screen.queryByRole('button')).not.toBeInTheDocument();
-    });
   });
 });

--- a/public/app/features/provisioning/components/ManagedBadge.test.tsx
+++ b/public/app/features/provisioning/components/ManagedBadge.test.tsx
@@ -236,6 +236,5 @@ describe('ManagedBadge', () => {
       await waitFor(() => expect(screen.getByTestId('icon-exclamation-triangle')).toBeInTheDocument());
       expect(screen.queryByRole('button')).not.toBeInTheDocument();
     });
-
   });
 });

--- a/public/app/features/provisioning/components/ManagedBadge.tsx
+++ b/public/app/features/provisioning/components/ManagedBadge.tsx
@@ -2,7 +2,6 @@ import { css } from '@emotion/css';
 
 import { type GrafanaTheme2, textUtil } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { config } from '@grafana/runtime';
 import { Badge, type BadgeColor, Dropdown, Icon, type IconName, Menu, Text, useStyles2 } from '@grafana/ui';
 import { contextSrv } from 'app/core/services/context_srv';
 import { ManagerKind } from 'app/features/apiserver/types';
@@ -48,7 +47,7 @@ interface ManagedBadgeProps {
 export function ManagedBadge({ managerKind, name, isOrphaned = false, repositoryName, sourcePath }: ManagedBadgeProps) {
   // The interactive variant is a separate component so the RTK Query hook only runs (and only
   // requires a store context) when a repository lookup can actually yield actions.
-  if (config.featureToggles.provisioning && managerKind === ManagerKind.Repo && repositoryName && !isOrphaned) {
+  if (managerKind === ManagerKind.Repo && repositoryName && !isOrphaned) {
     return <RepoManagedBadge name={name} repositoryName={repositoryName} sourcePath={sourcePath} />;
   }
 

--- a/public/app/features/provisioning/components/Shared/ProvisioningAwareFolderPicker.test.tsx
+++ b/public/app/features/provisioning/components/Shared/ProvisioningAwareFolderPicker.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen } from '@testing-library/react';
 
-import { config } from '@grafana/runtime';
 import { useGetFrontendSettingsQuery } from 'app/api/clients/provisioning/v0alpha1';
 
 import { useIsProvisionedInstance } from '../../hooks/useIsProvisionedInstance';
@@ -54,8 +53,6 @@ describe('ProvisioningAwareFolderPicker', () => {
       error: undefined,
       refetch: jest.fn(),
     });
-
-    config.featureToggles = { provisioning: true };
   });
 
   describe('Provisioned Instance', () => {
@@ -91,19 +88,6 @@ describe('ProvisioningAwareFolderPicker', () => {
 
       const excludeUIDs = JSON.parse(screen.getByTestId('exclude-uids').textContent || '[]');
       expect(excludeUIDs).toEqual(['repo1', 'repo2', 'repo3', 'custom1']);
-    });
-  });
-
-  describe('Feature Toggle Disabled', () => {
-    beforeEach(() => {
-      mockUseIsProvisionedInstance.mockReturnValue(false);
-      config.featureToggles.provisioning = false;
-    });
-
-    it('should not apply restrictions', () => {
-      setup({ isNonProvisionedFolder: true });
-      expect(screen.getByTestId('root-folder-uid')).toHaveTextContent('undefined');
-      expect(screen.getByTestId('exclude-uids')).toHaveTextContent('[]');
     });
   });
 

--- a/public/app/features/provisioning/components/Shared/ProvisioningAwareFolderPicker.tsx
+++ b/public/app/features/provisioning/components/Shared/ProvisioningAwareFolderPicker.tsx
@@ -1,6 +1,3 @@
-import { skipToken } from '@reduxjs/toolkit/query';
-
-import { config } from '@grafana/runtime';
 import {
   type RepositoryView,
   type RepositoryViewList,
@@ -21,19 +18,16 @@ interface Props extends NestedFolderPickerProps {
 
 export function ProvisioningAwareFolderPicker({ repositoryName, showAllFolders, ...props }: Props) {
   const isProvisionedInstance = useIsProvisionedInstance();
-  const provisioningEnabled = config.featureToggles.provisioning;
-  const { data: settingsData } = useGetFrontendSettingsQuery(provisioningEnabled ? undefined : skipToken);
+  const { data: settingsData } = useGetFrontendSettingsQuery(undefined);
   const isNonProvisionedResource = !repositoryName;
 
   const rootFolderUID = getRootFolderUID({
     isProvisionedInstance,
-    provisioningEnabled,
     repositoryName,
   });
   const excludeUIDs = getExcludeUIDs({
     isProvisionedInstance,
     isNonProvisionedResource,
-    provisioningEnabled,
     settingsData,
   });
   const rootFolderDisplayItem = getRootFolderDisplayItem({
@@ -54,18 +48,16 @@ export function ProvisioningAwareFolderPicker({ repositoryName, showAllFolders, 
 
 function getRootFolderUID({
   isProvisionedInstance,
-  provisioningEnabled,
   repositoryName,
 }: {
   isProvisionedInstance?: boolean;
-  provisioningEnabled?: boolean;
   repositoryName?: string;
 }) {
   if (isProvisionedInstance) {
     return undefined;
   }
 
-  if (provisioningEnabled && repositoryName) {
+  if (repositoryName) {
     return repositoryName;
   }
 
@@ -75,12 +67,10 @@ function getRootFolderUID({
 function getExcludeUIDs({
   isProvisionedInstance,
   isNonProvisionedResource,
-  provisioningEnabled,
   settingsData,
 }: {
   isProvisionedInstance?: boolean;
   isNonProvisionedResource?: boolean;
-  provisioningEnabled?: boolean;
   settingsData?: RepositoryViewList;
 }) {
   if (isProvisionedInstance) {
@@ -88,11 +78,6 @@ function getExcludeUIDs({
   }
 
   if (isNonProvisionedResource) {
-    // If provisioning is disabled, we don't want to exclude any folders
-    if (!provisioningEnabled) {
-      return [];
-    }
-    // If provisioning is enabled, we want to exclude all provisioned folders
     return settingsData?.items.map((repo) => repo.name) || [];
   }
 

--- a/public/app/features/provisioning/components/utils/getProvisionedMeta.ts
+++ b/public/app/features/provisioning/components/utils/getProvisionedMeta.ts
@@ -1,4 +1,3 @@
-import { config } from '@grafana/runtime';
 import { folderAPIv1beta1 as folderAPI } from 'app/api/clients/folder/v1beta1';
 import { AnnoKeyManagerIdentity, AnnoKeyManagerKind, ManagerKind } from 'app/features/apiserver/types';
 import { dispatch } from 'app/store/store';
@@ -7,7 +6,7 @@ import { dispatch } from 'app/store/store';
  * Get k8s dashboard metadata based on the selected folder
  */
 export async function getProvisionedMeta(folderUid?: string) {
-  if (!folderUid || !config.featureToggles.provisioning) {
+  if (!folderUid) {
     return {};
   }
   const folderQuery = await dispatch(folderAPI.endpoints.getFolder.initiate({ name: folderUid })).unwrap();

--- a/public/app/features/provisioning/hooks/useGetResourceRepositoryView.test.ts
+++ b/public/app/features/provisioning/hooks/useGetResourceRepositoryView.test.ts
@@ -413,6 +413,5 @@ describe('useGetResourceRepositoryView', () => {
       expect(result.current.status).toBe(RepoViewStatus.Error);
       expect(result.current.isMissingRepo).toBe(true);
     });
-
   });
 });

--- a/public/app/features/provisioning/hooks/useGetResourceRepositoryView.test.ts
+++ b/public/app/features/provisioning/hooks/useGetResourceRepositoryView.test.ts
@@ -78,18 +78,6 @@ describe('useGetResourceRepositoryView', () => {
     config.featureToggles = originalToggles;
   });
 
-  describe('provisioning disabled', () => {
-    it('returns Disabled status', () => {
-      config.featureToggles = { ...originalToggles, provisioning: false };
-      setupMocks();
-
-      const { result } = renderHook(() => useGetResourceRepositoryView({ folderName: 'some-folder' }));
-
-      expect(result.current.status).toBe(RepoViewStatus.Disabled);
-      expect(result.current.isLoading).toBe(false);
-    });
-  });
-
   describe('loading states', () => {
     it('returns Loading when settings are loading', () => {
       setupMocks({ settingsLoading: true });
@@ -426,14 +414,5 @@ describe('useGetResourceRepositoryView', () => {
       expect(result.current.isMissingRepo).toBe(true);
     });
 
-    it('is true when provisioning is disabled (no repository can exist)', () => {
-      config.featureToggles = { ...originalToggles, provisioning: false };
-      setupMocks();
-
-      const { result } = renderHook(() => useGetResourceRepositoryView({ folderName: 'some-folder' }));
-
-      expect(result.current.status).toBe(RepoViewStatus.Disabled);
-      expect(result.current.isMissingRepo).toBe(true);
-    });
   });
 });

--- a/public/app/features/provisioning/hooks/useGetResourceRepositoryView.ts
+++ b/public/app/features/provisioning/hooks/useGetResourceRepositoryView.ts
@@ -1,6 +1,6 @@
 import { skipToken } from '@reduxjs/toolkit/query/react';
 
-import { config, isFetchError } from '@grafana/runtime';
+import { isFetchError } from '@grafana/runtime';
 import { type Folder, useGetFolderQuery } from 'app/api/clients/folder/v1beta1';
 import { type RepositoryView, useGetFrontendSettingsQuery } from 'app/api/clients/provisioning/v0alpha1';
 
@@ -56,11 +56,10 @@ const useResourceRepositoryViewData = ({
   skipQuery,
   includeInstance,
 }: GetResourceRepositoryArgs): Omit<RepositoryViewData, 'isMissingRepo'> => {
-  const provisioningEnabled = config.featureToggles.provisioning;
   // Skip when caller has no target. This query is shared across many
   // components, so a failing fetch would cycle all of them through retries.
   // `includeInstance` overrides the skip for root-level instance lookups.
-  const shouldSkipSettings = !provisioningEnabled || skipQuery || (!name && !folderName && !includeInstance);
+  const shouldSkipSettings = skipQuery || (!name && !folderName && !includeInstance);
   const settingsQueryArg = shouldSkipSettings ? skipToken : undefined;
 
   const {
@@ -69,21 +68,12 @@ const useResourceRepositoryViewData = ({
     error: settingsError,
   } = useGetFrontendSettingsQuery(settingsQueryArg);
 
-  const skipFolderQuery = !folderName || !provisioningEnabled || skipQuery;
+  const skipFolderQuery = !folderName || skipQuery;
   const {
     data: folder,
     isLoading: isFolderLoading,
     error: folderError,
   } = useGetFolderQuery(skipFolderQuery ? skipToken : { name: folderName });
-
-  if (!provisioningEnabled) {
-    return {
-      isLoading: false,
-      isInstanceManaged: false,
-      isReadOnlyRepo: false,
-      status: RepoViewStatus.Disabled,
-    };
-  }
 
   if (isSettingsLoading || isFolderLoading) {
     return {

--- a/public/app/features/provisioning/hooks/useIsProvisionedInstance.ts
+++ b/public/app/features/provisioning/hooks/useIsProvisionedInstance.ts
@@ -1,6 +1,5 @@
 import { skipToken } from '@reduxjs/toolkit/query';
 
-import { config } from '@grafana/runtime';
 import { type RepositoryViewList, useGetFrontendSettingsQuery } from 'app/api/clients/provisioning/v0alpha1';
 
 interface UseIsProvisionedInstanceOptions {
@@ -10,9 +9,8 @@ interface UseIsProvisionedInstanceOptions {
 
 export function useIsProvisionedInstance(options: UseIsProvisionedInstanceOptions = {}) {
   const { settings, skip: skipQuery } = options;
-  const skip = !config.featureToggles.provisioning || skipQuery;
 
-  const settingsQuery = useGetFrontendSettingsQuery(settings || skip ? skipToken : undefined);
+  const settingsQuery = useGetFrontendSettingsQuery(settings || skipQuery ? skipToken : undefined);
 
   if (settingsQuery.isError) {
     return false;

--- a/public/app/features/provisioning/hooks/useIsProvisionedNG.ts
+++ b/public/app/features/provisioning/hooks/useIsProvisionedNG.ts
@@ -1,5 +1,3 @@
-import { config } from '@grafana/runtime';
-
 import { type DashboardScene } from '../../dashboard-scene/scene/DashboardScene';
 
 import { useGetResourceRepositoryView } from './useGetResourceRepositoryView';
@@ -10,8 +8,5 @@ export function useIsProvisionedNG(dashboard: DashboardScene): boolean {
 
   const { repository, isInstanceManaged } = useGetResourceRepositoryView({ folderName });
 
-  if (!config.featureToggles.provisioning) {
-    return false;
-  }
   return dashboard.isManagedRepository() || Boolean(repository) || isInstanceManaged;
 }

--- a/public/app/features/provisioning/hooks/useProvisionedDashboardData.test.ts
+++ b/public/app/features/provisioning/hooks/useProvisionedDashboardData.test.ts
@@ -2,7 +2,6 @@ import { renderHook, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { getWrapper } from 'test/test-utils';
 
-import { config } from '@grafana/runtime';
 import { PROVISIONING_API_BASE as BASE } from '@grafana/test-utils/handlers';
 import server from '@grafana/test-utils/server';
 import {
@@ -62,14 +61,6 @@ const mockMeta = {
     },
   },
 };
-
-beforeEach(() => {
-  config.featureToggles.provisioning = true;
-});
-
-afterEach(() => {
-  config.featureToggles.provisioning = false;
-});
 
 describe('useDefaultValues', () => {
   it('returns Loading while settings are being fetched', async () => {

--- a/public/app/features/provisioning/hooks/useResourceRepositorySelection.test.ts
+++ b/public/app/features/provisioning/hooks/useResourceRepositorySelection.test.ts
@@ -1,6 +1,5 @@
 import { renderHook } from '@testing-library/react';
 
-import { config } from '@grafana/runtime';
 import { useGetFrontendSettingsQuery } from 'app/api/clients/provisioning/v0alpha1';
 
 import { resourceKindInfos } from '../utils/resourceKinds';
@@ -18,14 +17,7 @@ const repo = { name: 'r1', title: 'R1', target: 'instance', type: 'git', workflo
 
 describe('useResourceRepositorySelection', () => {
   beforeEach(() => {
-    config.featureToggles.provisioning = true;
     mockQuery.mockReturnValue({ data: undefined });
-  });
-
-  it('is unavailable when provisioning is disabled', () => {
-    config.featureToggles.provisioning = false;
-    const { result } = renderHook(() => useResourceRepositorySelection(resourceKindInfos.playlist));
-    expect(result.current.isAvailable).toBe(false);
   });
 
   it('is unavailable when the kind is not declared in availableResources', () => {

--- a/public/app/features/provisioning/hooks/useResourceRepositorySelection.ts
+++ b/public/app/features/provisioning/hooks/useResourceRepositorySelection.ts
@@ -1,6 +1,3 @@
-import { skipToken } from '@reduxjs/toolkit/query/react';
-
-import { config } from '@grafana/runtime';
 import { type RepositoryView, useGetFrontendSettingsQuery } from 'app/api/clients/provisioning/v0alpha1';
 
 import { isResourceKindAvailable, type ResourceKindInfo } from '../utils/resourceKinds';
@@ -25,14 +22,13 @@ export interface ResourceRepositorySelection {
  * settings response doesn't fall back to "all kinds available").
  */
 export function useResourceRepositorySelection(info: ResourceKindInfo): ResourceRepositorySelection {
-  const provisioningEnabled = Boolean(config.featureToggles.provisioning);
-  const { data } = useGetFrontendSettingsQuery(provisioningEnabled ? undefined : skipToken);
+  const { data } = useGetFrontendSettingsQuery(undefined);
 
   const repositories = data?.items ?? [];
   const kindEnabled = isResourceKindAvailable(info, data?.availableResources ?? []);
 
   return {
-    isAvailable: provisioningEnabled && kindEnabled && repositories.length > 0,
+    isAvailable: kindEnabled && repositories.length > 0,
     repositories,
   };
 }

--- a/public/app/features/provisioning/hooks/useSelectionProvisioningStatus.ts
+++ b/public/app/features/provisioning/hooks/useSelectionProvisioningStatus.ts
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
-import { config } from '@grafana/runtime';
 import { ScopedResourceClient } from 'app/features/apiserver/client';
 import { isProvisionedDashboard as isProvisionedDashboardFromMeta } from 'app/features/browse-dashboards/api/isProvisioned';
 import { getDashboardAPI } from 'app/features/dashboard/api/dashboard_api';
@@ -22,8 +21,6 @@ export function useSelectionProvisioningStatus(
   const isProvisionedInstance = useIsProvisionedInstance();
   const [, stateManager] = useSearchStateManager();
   const isSearching = stateManager.hasSearchFilters();
-  const provisioningEnabled = config.featureToggles.provisioning;
-
   const [status, setStatus] = useState({ hasProvisioned: false, hasNonProvisioned: false });
   const [folderCache, setFolderCache] = useState<Record<string, boolean>>({});
   const [dashboardCache, setDashboardCache] = useState<Record<string, boolean>>({});
@@ -112,11 +109,6 @@ export function useSelectionProvisioningStatus(
         return;
       }
 
-      if (!provisioningEnabled) {
-        setStatus({ hasProvisioned: false, hasNonProvisioned: true });
-        return;
-      }
-
       const folders = Object.keys(selectedItems.folder).filter((uid) => selectedItems.folder[uid]);
       const dashboards = Object.keys(selectedItems.dashboard).filter((uid) => selectedItems.dashboard[uid]);
 
@@ -153,7 +145,7 @@ export function useSelectionProvisioningStatus(
     };
 
     checkProvisioningStatus();
-  }, [selectedItems, isProvisionedInstance, isParentProvisioned, checkItemProvisioning, provisioningEnabled]);
+  }, [selectedItems, isProvisionedInstance, isParentProvisioned, checkItemProvisioning]);
 
   return {
     hasProvisioned: status.hasProvisioned,

--- a/public/app/features/provisioning/hooks/useSelectionRepoValidation.ts
+++ b/public/app/features/provisioning/hooks/useSelectionRepoValidation.ts
@@ -1,6 +1,3 @@
-import { skipToken } from '@reduxjs/toolkit/query';
-
-import { config } from '@grafana/runtime';
 import { useGetFrontendSettingsQuery } from 'app/api/clients/provisioning/v0alpha1';
 import { findItem } from 'app/features/browse-dashboards/state/utils';
 import { type DashboardTreeSelection } from 'app/features/browse-dashboards/types';
@@ -12,12 +9,11 @@ import { useChildrenByParentUIDState, rootItemsSelector } from '../../browse-das
 
 // This hook is responsible for validating if all selected resources (dashboard folders and dashboards) are in the same repository
 export function useSelectionRepoValidation(selectedItems: Omit<DashboardTreeSelection, 'panel' | '$all'>) {
-  const provisioningEnabled = config.featureToggles.provisioning;
   const childrenByParentUID = useChildrenByParentUIDState();
   const rootItems = useSelector(rootItemsSelector)?.items ?? [];
   const isProvisionedInstance = useIsProvisionedInstance();
 
-  const { data: settingsData } = useGetFrontendSettingsQuery(!provisioningEnabled ? skipToken : undefined);
+  const { data: settingsData } = useGetFrontendSettingsQuery(undefined);
   // Function to grab repository configuration by UID
   const getRepositoryByUid = (repoUid: string) => {
     if (!settingsData?.items || repoUid === 'non_provisioned') {

--- a/public/app/features/provisioning/utils/routes.tsx
+++ b/public/app/features/provisioning/utils/routes.tsx
@@ -1,6 +1,5 @@
 import { Navigate, useLocation, useParams } from 'react-router-dom-v5-compat';
 
-import { config } from '@grafana/runtime';
 import { SafeDynamicImport } from 'app/core/components/DynamicImports/SafeDynamicImport';
 import { type RouteDescriptor } from 'app/core/navigation/types';
 import { contextSrv } from 'app/core/services/context_srv';
@@ -29,11 +28,6 @@ const connectionRoles = () =>
   ]);
 
 export function getProvisioningRoutes(): RouteDescriptor[] {
-  const featureToggles = config.featureToggles || {};
-  if (!featureToggles.provisioning) {
-    return [];
-  }
-
   if (!checkRequiredFeatures()) {
     return [
       {


### PR DESCRIPTION
Feature is in GA, we can safely remove all the toggle references toggle

oss cleanup: https://github.com/grafana/grafana/pull/129030
search and storage cleanup: https://github.com/grafana/grafana/pull/129120