### PR TITLE
unified/search: resolve public field names to physical fields in the bleve backend

### DIFF
--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -2222,10 +2222,7 @@ func (b *bleveIndex) toBleveSearchRequest(ctx context.Context, req *resourcepb.R
 	// Skip inputs that already carry the prefix.
 	fields := make([]string, 0, len(req.Fields))
 	for _, f := range req.Fields {
-		if b.fields != nil && !strings.HasPrefix(f, resource.SEARCH_FIELD_PREFIX) && b.fields.Field(f) != nil {
-			f = resource.SEARCH_FIELD_PREFIX + f
-		}
-		fields = append(fields, f)
+		fields = append(fields, resolveFieldName(b.fields, f))
 	}
 
 	size, err := safeInt64ToInt(req.Limit)
@@ -2335,13 +2332,51 @@ func (b *bleveIndex) toBleveSearchRequest(ctx context.Context, req *resourcepb.R
 	return searchrequest, nil
 }
 
+// resolveFieldName maps a public field name to its physical index name. Clients
+// pass public names; only the backend knows that per-kind fields live under the
+// fields.* sub-document. Standard and already-prefixed names are returned as-is.
+func resolveFieldName(fields resource.SearchableDocumentFields, key string) string {
+	if strings.HasPrefix(key, resource.SEARCH_FIELD_PREFIX) ||
+		strings.HasPrefix(key, resource.SEARCH_SELECTABLE_FIELDS_PREFIX) {
+		return key
+	}
+	// Leave reserved top-level names as-is so a per-kind set can't shadow them
+	// into fields.* (callers pass physical title variants directly, e.g. the
+	// legacy QueryFields trio).
+	if isReservedTopLevelField(key) {
+		return key
+	}
+	if fields == nil || fields.Field(key) == nil {
+		return key
+	}
+	return resource.SEARCH_FIELD_PREFIX + key
+}
+
+// isReservedTopLevelField reports whether key is a standard field or an internal
+// top-level variant (title_phrase/title_ngram) that must never be prefixed.
+func isReservedTopLevelField(key string) bool {
+	switch key {
+	case resource.SEARCH_FIELD_TITLE_PHRASE, resource.SEARCH_FIELD_TITLE_NGRAM:
+		return true
+	}
+	return resource.StandardSearchFields().Field(key) != nil
+}
+
 // filterQueries builds the label and field filter clauses (the AND terms that
 // are not the free-text query) for a search request.
 func (b *bleveIndex) filterQueries(req *resourcepb.ResourceSearchRequest) ([]query.Query, *resourcepb.ErrorResult) {
 	queries := []query.Query{}
 	if len(req.Options.Labels) > 0 {
 		for _, v := range req.Options.Labels {
-			q, err := requirementQuery(v, "labels.")
+			// Build a fresh requirement rather than mutate the shared one: Search may
+			// re-run this builder (post-rank authz fallback), which would otherwise
+			// double-prefix the label key.
+			rq := &resourcepb.Requirement{
+				Key:      resource.SEARCH_FIELD_LABELS + "." + v.Key,
+				Operator: v.Operator,
+				Values:   v.Values,
+			}
+			q, err := b.requirementQuery(rq)
 			if err != nil {
 				return nil, err
 			}
@@ -2350,17 +2385,24 @@ func (b *bleveIndex) filterQueries(req *resourcepb.ResourceSearchRequest) ([]que
 	}
 	if len(req.Options.Fields) > 0 {
 		for _, v := range req.Options.Fields {
+			// Fresh requirement (not a proto value copy, which trips the lock check)
+			// so re-running the builder stays idempotent.
+			rq := &resourcepb.Requirement{
+				Key:      resolveFieldName(b.fields, v.Key),
+				Operator: v.Operator,
+				Values:   v.Values,
+			}
 			// Temporarily expand a root-folder filter so it matches both the
 			// legacy empty sentinel ("") and the canonical "general" UID. This
 			// keeps results consistent whether the index was written before or
 			// after the apistore started stamping "general" on root-parented
 			// resources. Done here so every caller stays agnostic of the
 			// sentinel used on disk.
-			if v.Key == resource.SEARCH_FIELD_FOLDER &&
-				(v.Operator == string(selection.Equals) || v.Operator == string(selection.In)) {
+			if rq.Key == resource.SEARCH_FIELD_FOLDER &&
+				(rq.Operator == string(selection.Equals) || rq.Operator == string(selection.In)) {
 				expanded := false
-				values := make([]string, 0, len(v.Values)+1)
-				for _, val := range v.Values {
+				values := make([]string, 0, len(rq.Values)+1)
+				for _, val := range rq.Values {
 					if !foldermodel.IsRootFolderUID(val) {
 						values = append(values, val)
 						continue
@@ -2371,13 +2413,12 @@ func (b *bleveIndex) filterQueries(req *resourcepb.ResourceSearchRequest) ([]que
 					}
 				}
 				if expanded {
-					v.Operator = string(selection.In)
-					v.Values = values
+					rq.Operator = string(selection.In)
+					rq.Values = values
 				}
 			}
 
-			// Fields should already have correct prefix (either "fields." or "selectableFields.")
-			q, err := requirementQuery(v, "")
+			q, err := b.requirementQuery(rq)
 			if err != nil {
 				return nil, err
 			}
@@ -2413,7 +2454,7 @@ func (b *bleveIndex) buildTextQuery(searchrequest *bleve.SearchRequest, req *res
 		// When QueryFields is empty, default to title.
 		if len(req.QueryFields) > 0 {
 			for _, field := range req.QueryFields {
-				addWildcardQueries(disjoin, req.Query, field.Name)
+				addWildcardQueries(disjoin, req.Query, resolveFieldName(b.fields, field.Name))
 			}
 		} else {
 			addWildcardQueries(disjoin, req.Query, resource.SEARCH_FIELD_TITLE)
@@ -2423,24 +2464,7 @@ func (b *bleveIndex) buildTextQuery(searchrequest *bleve.SearchRequest, req *res
 
 	// Free-text search uses explicit query fields so each title field can use the query type that matches its analyzer.
 	searchrequest.Fields = append(searchrequest.Fields, resource.SEARCH_FIELD_SCORE)
-	queryFields := req.QueryFields
-	if len(queryFields) == 0 {
-		queryFields = []*resourcepb.ResourceSearchRequest_QueryField{
-			{
-				Name:  resource.SEARCH_FIELD_TITLE_PHRASE,
-				Type:  resourcepb.QueryFieldType_KEYWORD,
-				Boost: 10, // exact title match (case-insensitive via pre-lowered title_phrase)
-			}, {
-				Name:  resource.SEARCH_FIELD_TITLE,
-				Type:  resourcepb.QueryFieldType_TEXT,
-				Boost: 2, // standard analyzer (word-level matching)
-			}, {
-				Name:  resource.SEARCH_FIELD_TITLE_NGRAM,
-				Type:  resourcepb.QueryFieldType_TEXT,
-				Boost: 1, // ngram analyzer (partial/prefix matching)
-			},
-		}
-	}
+	queryFields := b.resolveQueryFields(req.QueryFields)
 
 	for _, field := range queryFields {
 		switch field.Type {
@@ -2476,6 +2500,49 @@ func (b *bleveIndex) buildTextQuery(searchrequest *bleve.SearchRequest, req *res
 		}
 	}
 	return disjoin
+}
+
+// titleQueryFields expands a text query on the logical title field across its
+// three physical variants: exact (title_phrase), word-level (title), and partial
+// (title_ngram), each with the query type its analyzer needs.
+func titleQueryFields() []*resourcepb.ResourceSearchRequest_QueryField {
+	return []*resourcepb.ResourceSearchRequest_QueryField{
+		{Name: resource.SEARCH_FIELD_TITLE_PHRASE, Type: resourcepb.QueryFieldType_KEYWORD, Boost: 10}, // exact title match (case-insensitive via pre-lowered title_phrase)
+		{Name: resource.SEARCH_FIELD_TITLE, Type: resourcepb.QueryFieldType_TEXT, Boost: 2},            // standard analyzer (word-level matching)
+		{Name: resource.SEARCH_FIELD_TITLE_NGRAM, Type: resourcepb.QueryFieldType_TEXT, Boost: 1},      // ngram analyzer (partial/prefix matching)
+	}
+}
+
+// resolveQueryFields maps the requested (public-named) text query fields to
+// concrete bleve fields: title fans out to its variants, others resolve to their
+// physical name. An empty request defaults to title.
+func (b *bleveIndex) resolveQueryFields(requested []*resourcepb.ResourceSearchRequest_QueryField) []*resourcepb.ResourceSearchRequest_QueryField {
+	if len(requested) == 0 {
+		return titleQueryFields()
+	}
+	// If the caller already named physical title variants (legacy dashboard
+	// search sends all three), don't re-expand the logical title field, or we'd
+	// duplicate the phrase/ngram clauses and skew scoring.
+	hasTitleVariant := false
+	for _, f := range requested {
+		if f.Name == resource.SEARCH_FIELD_TITLE_PHRASE || f.Name == resource.SEARCH_FIELD_TITLE_NGRAM {
+			hasTitleVariant = true
+			break
+		}
+	}
+	out := make([]*resourcepb.ResourceSearchRequest_QueryField, 0, len(requested))
+	for _, f := range requested {
+		if f.Name == resource.SEARCH_FIELD_TITLE && !hasTitleVariant {
+			out = append(out, titleQueryFields()...)
+			continue
+		}
+		out = append(out, &resourcepb.ResourceSearchRequest_QueryField{
+			Name:  resolveFieldName(b.fields, f.Name),
+			Type:  f.Type,
+			Boost: f.Boost,
+		})
+	}
+	return out
 }
 
 func removeSmallTerms(query string) string {
@@ -2673,17 +2740,11 @@ func getSortFields(req *resourcepb.ResourceSearchRequest, fields resource.Search
 	sorting := make([]string, 0, len(req.SortBy)+1)
 	hasNameSort := false
 	for _, sort := range req.SortBy {
-		input := sort.Field
-		if field, ok := textSortFields[input]; ok {
-			input = field
-		}
-
-		// Per-kind sort fields live under the fields.* sub-document, prefix
-		// them by consulting this index's SearchableDocumentFields. Skip
-		// inputs that already carry the prefix (Field() would strip it and
-		// match again, leading to a double prefix).
-		if fields != nil && !strings.HasPrefix(input, resource.SEARCH_FIELD_PREFIX) && fields.Field(input) != nil {
-			input = resource.SEARCH_FIELD_PREFIX + input
+		// title sorts on its populated, doc-valued keyword variant (title_phrase);
+		// other fields sort on their indexed name.
+		input := resolveFieldName(fields, sort.Field)
+		if input == resource.SEARCH_FIELD_TITLE {
+			input = resource.SEARCH_FIELD_TITLE_PHRASE
 		}
 
 		hasNameSort = hasNameSort || input == resource.SEARCH_FIELD_NAME
@@ -2696,11 +2757,6 @@ func getSortFields(req *resourcepb.ResourceSearchRequest, fields resource.Search
 		sorting = append(sorting, resource.SEARCH_FIELD_NAME)
 	}
 	return sorting
-}
-
-// fields that we went to sort by the full text
-var textSortFields = map[string]string{
-	resource.SEARCH_FIELD_TITLE: resource.SEARCH_FIELD_TITLE_PHRASE,
 }
 
 const (
@@ -2719,36 +2775,36 @@ var exactTermQueryFields = []string{
 }
 
 // Convert a "requirement" into a bleve query
-func requirementQuery(req *resourcepb.Requirement, prefix string) (query.Query, *resourcepb.ErrorResult) {
-	useExactTermQuery := slices.Contains(exactTermQueryFields, req.Key) || strings.HasPrefix(req.Key, resource.SEARCH_SELECTABLE_FIELDS_PREFIX)
+func (b *bleveIndex) requirementQuery(req *resourcepb.Requirement) (query.Query, *resourcepb.ErrorResult) {
+	// The exact-term allowlist is keyed by logical (public) field names. Label
+	// requirements arrive with their physical labels.<key> prefix, so match the
+	// allowlist against the logical key while still querying the physical field.
+	allowlistKey := strings.TrimPrefix(req.Key, resource.SEARCH_FIELD_LABELS+".")
+	useExactTermQuery := slices.Contains(exactTermQueryFields, allowlistKey) || strings.HasPrefix(req.Key, resource.SEARCH_SELECTABLE_FIELDS_PREFIX)
 	switch selection.Operator(req.Operator) {
 	case selection.DoubleEquals:
 		// DoubleEquals does exact matching via TermQuery (single value only).
-		// For title, route to the pre-lowered title_phrase field.
 		if len(req.Values) == 1 {
-			key := req.Key
-			value := req.Values[0]
-			if key == resource.SEARCH_FIELD_TITLE {
-				key = resource.SEARCH_FIELD_TITLE_PHRASE
-				value = strings.ToLower(value)
-			}
-			return exactFieldTermQuery(key, value, prefix), nil
+			return b.exactFieldValueQuery(req.Key, req.Values[0]), nil
 		}
 
 	case selection.Equals:
 		return allRequirementValuesQuery(req.Values, func(v string) query.Query {
 			if useExactTermQuery {
-				return exactFieldTermQuery(req.Key, v, prefix)
+				return exactFieldTermQuery(req.Key, v)
 			}
-			return fieldFilterQuery(req.Key, filterValue(req.Key, v), prefix)
+			return fieldFilterQuery(req.Key, filterValue(req.Key, v))
 		}), nil
 
 	case selection.In:
+		// "in" is set membership: exact for the keyword allowlist and for title
+		// (via its populated title_phrase variant); other fields use the analyzed
+		// path, matching legacy behavior.
 		return anyRequirementValueQuery(req.Values, func(v string) query.Query {
-			if useExactTermQuery {
-				return exactFieldTermQuery(req.Key, v, prefix)
+			if useExactTermQuery || req.Key == resource.SEARCH_FIELD_TITLE {
+				return b.exactFieldValueQuery(req.Key, v)
 			}
-			return fieldFilterQuery(req.Key, filterValue(req.Key, v), prefix)
+			return fieldFilterQuery(req.Key, filterValue(req.Key, v))
 		}), nil
 
 	case selection.NotIn:
@@ -2756,7 +2812,14 @@ func requirementQuery(req *resourcepb.Requirement, prefix string) (query.Query, 
 
 		var mustNotQueries []query.Query
 		for _, value := range req.Values {
-			q := fieldFilterQuery(req.Key, filterValue(req.Key, value), prefix)
+			var q query.Query
+			// notin keeps the legacy analyzed path for every field except the
+			// intentional exact-title case (kept consistent with "in" on title).
+			if req.Key == resource.SEARCH_FIELD_TITLE {
+				q = b.exactFieldValueQuery(req.Key, value)
+			} else {
+				q = fieldFilterQuery(req.Key, filterValue(req.Key, value))
+			}
 			mustNotQueries = append(mustNotQueries, q)
 		}
 		boolQuery.AddMustNot(mustNotQueries...)
@@ -2833,55 +2896,67 @@ func addWildcardQueries(disjoin *query.DisjunctionQuery, pattern string, field s
 	}
 }
 
+// exactFieldValueQuery builds an exact term query for one filter value. title
+// routes to its populated keyword variant (title_phrase); other fields match on
+// their indexed field. Custom text fields have no populated keyword variant yet
+// (tracked as a follow-up in the search-v1 epic).
+func (b *bleveIndex) exactFieldValueQuery(key, value string) query.Query {
+	if key == resource.SEARCH_FIELD_TITLE {
+		key = resource.SEARCH_FIELD_TITLE_PHRASE
+		value = strings.ToLower(value) // title_phrase stores pre-lowered values
+	}
+	return exactFieldTermQuery(key, value)
+}
+
 // fieldFilterQuery builds the query for one field-filter value after requirementQuery has handled the selector operator.
 // It applies public field semantics, so a title filter can expand to multiple internal title fields.
-func fieldFilterQuery(key string, value string, prefix string) query.Query {
+func fieldFilterQuery(key string, value string) query.Query {
 	if key == resource.SEARCH_FIELD_TITLE {
-		return titleFieldFilterQuery(value, prefix)
+		return titleFieldFilterQuery(value)
 	}
 	if value == "*" {
 		return bleve.NewMatchAllQuery()
 	}
 	if strings.Contains(value, "*") {
-		return fieldWildcardQuery(key, value, prefix)
+		return fieldWildcardQuery(key, value)
 	}
-	return fieldMatchQuery(key, value, prefix)
+	return fieldMatchQuery(key, value)
 }
 
 // titleFieldFilterQuery expands the public title filter across the internal title fields.
-func titleFieldFilterQuery(value string, prefix string) query.Query {
+func titleFieldFilterQuery(value string) query.Query {
 	// Title exact matching and partial matching live in separate index fields,
 	// but the title filter API predates those internal fields.
 	queries := []query.Query{
-		exactFieldTermQuery(resource.SEARCH_FIELD_TITLE_PHRASE, strings.ToLower(value), prefix),
-		titleFieldTokenQuery(value, prefix),
+		exactFieldTermQuery(resource.SEARCH_FIELD_TITLE_PHRASE, strings.ToLower(value)),
+		titleFieldTokenQuery(value),
 	}
 	// Only use title_ngram for single-token title filters. Multi-word filters are handled by title_phrase/title;
 	// adding title_ngram can broaden them after removeSmallTerms drops short words, for example "what\"s up" becomes "what".
 	if !strings.ContainsAny(value, whitespaceCharacters) {
-		queries = append(queries, titleFieldNgramQuery(value, prefix))
+		queries = append(queries, titleFieldNgramQuery(value))
 	}
 	return bleve.NewDisjunctionQuery(queries...)
 }
 
 // titleFieldTokenQuery builds the part of title filtering that targets the standard-analyzed title field.
-func titleFieldTokenQuery(value string, prefix string) query.Query {
+func titleFieldTokenQuery(value string) query.Query {
 	if value == "*" {
 		return bleve.NewMatchAllQuery()
 	}
 	if strings.Contains(value, "*") {
-		return fieldWildcardQuery(resource.SEARCH_FIELD_TITLE, value, prefix)
+		return fieldWildcardQuery(resource.SEARCH_FIELD_TITLE, value)
 	}
 	if delimiter, ok := firstTermSeparator(value); ok {
-		return fieldAllTokensQuery(resource.SEARCH_FIELD_TITLE, strings.Split(value, delimiter), prefix)
+		return fieldAllTokensQuery(resource.SEARCH_FIELD_TITLE, strings.Split(value, delimiter))
 	}
-	return fieldMatchQuery(resource.SEARCH_FIELD_TITLE, value, prefix)
+	return fieldMatchQuery(resource.SEARCH_FIELD_TITLE, value)
 }
 
 // titleFieldNgramQuery builds the partial-match part of title filtering against title_ngram.
-func titleFieldNgramQuery(value string, prefix string) query.Query {
+func titleFieldNgramQuery(value string) query.Query {
 	q := bleve.NewMatchQuery(removeSmallTerms(splitTermCharacters(value)))
-	q.SetField(prefix + resource.SEARCH_FIELD_TITLE_NGRAM)
+	q.SetField(resource.SEARCH_FIELD_TITLE_NGRAM)
 	q.Analyzer = TITLE_ANALYZER
 	q.Operator = query.MatchQueryOperatorAnd
 	return q
@@ -2896,33 +2971,33 @@ func splitTermCharacters(value string) string {
 }
 
 // fieldWildcardQuery builds a wildcard query against one concrete Bleve field.
-func fieldWildcardQuery(key string, value string, prefix string) query.Query {
+func fieldWildcardQuery(key string, value string) query.Query {
 	// wildcard query is expensive - should be used with caution
 	q := bleve.NewWildcardQuery(value)
-	q.SetField(prefix + key)
+	q.SetField(key)
 	return q
 }
 
 // fieldMatchQuery builds an analyzed match query against one concrete Bleve field.
-func fieldMatchQuery(key string, value string, prefix string) query.Query {
+func fieldMatchQuery(key string, value string) query.Query {
 	q := bleve.NewMatchQuery(value)
-	q.SetField(prefix + key)
+	q.SetField(key)
 	return q
 }
 
 // exactFieldTermQuery uses Bleve TermQuery for exact token matching.
 // The input must already match how the field was indexed; TermQuery does not run an analyzer.
-func exactFieldTermQuery(key string, value string, prefix string) query.Query {
+func exactFieldTermQuery(key string, value string) query.Query {
 	// won't match with ending space
 	value = strings.TrimSuffix(value, " ")
 
 	q := bleve.NewTermQuery(value)
-	q.SetField(prefix + key)
+	q.SetField(key)
 	return q
 }
 
 // fieldAllTokensQuery requires every token from a split filter value to match the same concrete Bleve field.
-func fieldAllTokensQuery(key string, tokens []string, prefix string) query.Query {
+func fieldAllTokensQuery(key string, tokens []string) query.Query {
 	cq := bleve.NewConjunctionQuery()
 	for _, token := range tokens {
 		if token == "" {
@@ -2931,11 +3006,11 @@ func fieldAllTokensQuery(key string, tokens []string, prefix string) query.Query
 		_, ok := firstTermSeparator(token)
 		if ok {
 			tq := bleve.NewTermQuery(token)
-			tq.SetField(prefix + key)
+			tq.SetField(key)
 			cq.AddQuery(tq)
 			continue
 		}
-		cq.AddQuery(fieldMatchQuery(key, token, prefix))
+		cq.AddQuery(fieldMatchQuery(key, token))
 	}
 	return cq
 }

--- a/pkg/storage/unified/search/bleve_mappings_internal_test.go
+++ b/pkg/storage/unified/search/bleve_mappings_internal_test.go
@@ -13,7 +13,10 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	"github.com/blevesearch/bleve/v2/search/query"
+
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
+	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 )
 
 // flatMappings returns the field mappings emitted by the helper for the given
@@ -279,4 +282,233 @@ func TestBleveIndex_isDeclaredField(t *testing.T) {
 	assert.True(t, b.isDeclaredField(resource.SEARCH_FIELD_PREFIX+"email"), "declared per-kind field with fields. prefix")
 	assert.True(t, b.isDeclaredField(resource.SEARCH_FIELD_TITLE), "standard field")
 	assert.False(t, b.isDeclaredField("undeclaredCustomField"), "undeclared field is not reported as declared")
+}
+
+func TestResolveFieldName(t *testing.T) {
+	fields, err := resource.NewSearchableDocumentFields(resource.SearchFieldDefinitionsToTableColumns(
+		[]resource.SearchFieldDefinition{
+			{Name: "panel_type", Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityFilter}},
+		},
+	))
+	require.NoError(t, err)
+
+	// Declared per-kind field gets the fields. prefix so it targets the sub-document.
+	assert.Equal(t, resource.SEARCH_FIELD_PREFIX+"panel_type", resolveFieldName(fields, "panel_type"))
+	// Standard top-level fields are left as-is.
+	assert.Equal(t, resource.SEARCH_FIELD_TITLE, resolveFieldName(fields, resource.SEARCH_FIELD_TITLE))
+	assert.Equal(t, resource.SEARCH_FIELD_FOLDER, resolveFieldName(fields, resource.SEARCH_FIELD_FOLDER))
+	// Already-prefixed keys are passed through untouched.
+	assert.Equal(t, resource.SEARCH_FIELD_PREFIX+"panel_type", resolveFieldName(fields, resource.SEARCH_FIELD_PREFIX+"panel_type"))
+	assert.Equal(t, resource.SEARCH_SELECTABLE_FIELDS_PREFIX+"anything", resolveFieldName(fields, resource.SEARCH_SELECTABLE_FIELDS_PREFIX+"anything"))
+	// Undeclared, unprefixed names are left alone (caller/validation handles them).
+	assert.Equal(t, "undeclared", resolveFieldName(fields, "undeclared"))
+
+	// A nil per-kind field set never prefixes.
+	assert.Equal(t, "panel_type", resolveFieldName(nil, "panel_type"))
+
+	// A per-kind set that also declares a standard name must not shadow it into
+	// fields.* (standard fields stay top-level).
+	shadow, err := resource.NewSearchableDocumentFields(resource.SearchFieldDefinitionsToTableColumns(
+		[]resource.SearchFieldDefinition{
+			{Name: resource.SEARCH_FIELD_TITLE, Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityFilter}},
+		},
+	))
+	require.NoError(t, err)
+	assert.Equal(t, resource.SEARCH_FIELD_TITLE, resolveFieldName(shadow, resource.SEARCH_FIELD_TITLE))
+
+	// Internal title variants are reserved: a per-kind field declaring one can't
+	// shadow the physical field (callers pass these directly, e.g. legacy QueryFields).
+	reserved, err := resource.NewSearchableDocumentFields(resource.SearchFieldDefinitionsToTableColumns(
+		[]resource.SearchFieldDefinition{
+			{Name: resource.SEARCH_FIELD_TITLE_PHRASE, Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityFilter}},
+		},
+	))
+	require.NoError(t, err)
+	assert.Equal(t, resource.SEARCH_FIELD_TITLE_PHRASE, resolveFieldName(reserved, resource.SEARCH_FIELD_TITLE_PHRASE))
+	assert.Equal(t, resource.SEARCH_FIELD_TITLE_NGRAM, resolveFieldName(reserved, resource.SEARCH_FIELD_TITLE_NGRAM))
+}
+
+func TestBleveIndex_exactFieldValueQuery(t *testing.T) {
+	fields, err := resource.NewSearchableDocumentFields(resource.SearchFieldDefinitionsToTableColumns(
+		[]resource.SearchFieldDefinition{
+			{Name: "note", Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityText, resource.SearchCapabilityFilter}},
+			{Name: "tag", Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityFilter}},
+		},
+	))
+	require.NoError(t, err)
+	b := &bleveIndex{fields: fields, standard: resource.StandardSearchFields()}
+
+	termOf := func(q query.Query) *query.TermQuery {
+		tq, ok := q.(*query.TermQuery)
+		require.True(t, ok)
+		return tq
+	}
+
+	// title routes to its populated keyword variant and is pre-lowered.
+	title := termOf(b.exactFieldValueQuery(resource.SEARCH_FIELD_TITLE, "Foo Bar"))
+	assert.Equal(t, resource.SEARCH_FIELD_TITLE_PHRASE, title.Field())
+	assert.Equal(t, "foo bar", title.Term)
+
+	// Custom fields match on their indexed name (their <name>_keyword variant is
+	// not populated at index time), value unchanged. This holds for text+filter
+	// and filter-only fields alike.
+	assert.Equal(t, resource.SEARCH_FIELD_PREFIX+"note", termOf(b.exactFieldValueQuery(resource.SEARCH_FIELD_PREFIX+"note", "Exact")).Field())
+	assert.Equal(t, resource.SEARCH_FIELD_PREFIX+"tag", termOf(b.exactFieldValueQuery(resource.SEARCH_FIELD_PREFIX+"tag", "x")).Field())
+	// A standard non-text field is unchanged.
+	assert.Equal(t, resource.SEARCH_FIELD_FOLDER, termOf(b.exactFieldValueQuery(resource.SEARCH_FIELD_FOLDER, "x")).Field())
+}
+
+func TestRequirementQuery_TextFilterDispatch(t *testing.T) {
+	fields, err := resource.NewSearchableDocumentFields(resource.SearchFieldDefinitionsToTableColumns(
+		[]resource.SearchFieldDefinition{
+			{Name: "note", Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityText, resource.SearchCapabilityFilter}},
+		},
+	))
+	require.NoError(t, err)
+	b := &bleveIndex{fields: fields, standard: resource.StandardSearchFields()}
+
+	// title has a populated keyword variant, so "in" dispatches an exact TermQuery
+	// against title_phrase.
+	q, errRes := b.requirementQuery(&resourcepb.Requirement{Key: resource.SEARCH_FIELD_TITLE, Operator: "in", Values: []string{"Foo Bar"}})
+	require.Nil(t, errRes)
+	tq, ok := q.(*query.TermQuery)
+	require.True(t, ok, "in on title should build an exact TermQuery")
+	assert.Equal(t, resource.SEARCH_FIELD_TITLE_PHRASE, tq.Field())
+	assert.Equal(t, "foo bar", tq.Term)
+
+	// A custom text+filter field has no populated keyword variant, so "in" stays
+	// on the analyzed indexed field (exact set-membership for such fields is a
+	// tracked follow-up that needs index-time keyword population).
+	note := resource.SEARCH_FIELD_PREFIX + "note" // resolved physical name, as filterQueries passes it
+	q, errRes = b.requirementQuery(&resourcepb.Requirement{Key: note, Operator: "in", Values: []string{"Foo Bar"}})
+	require.Nil(t, errRes)
+	mq, ok := q.(*query.MatchQuery)
+	require.True(t, ok, "in on a custom text field should build an analyzed MatchQuery")
+	assert.Equal(t, note, mq.Field())
+}
+
+func TestFilterQueries_LabelExactTermAllowlist(t *testing.T) {
+	b := &bleveIndex{standard: resource.StandardSearchFields()}
+	// A label whose key is in the exact-term allowlist keeps its TermQuery
+	// semantics even though it is hoisted to labels.<key> for the physical query
+	// (labels are standard-analyzed, so the analyzed path would tokenize the value).
+	req := &resourcepb.ResourceSearchRequest{Options: &resourcepb.ListOptions{
+		Labels: []*resourcepb.Requirement{{Key: "login", Operator: "in", Values: []string{"foo-bar"}}},
+	}}
+	queries, e := b.filterQueries(req)
+	require.Nil(t, e)
+	require.Len(t, queries, 1)
+	tq, ok := queries[0].(*query.TermQuery)
+	require.True(t, ok, "login label filter should use an exact TermQuery")
+	assert.Equal(t, resource.SEARCH_FIELD_LABELS+".login", tq.Field())
+	assert.Equal(t, "foo-bar", tq.Term)
+}
+
+func TestFilterQueries_LabelNotInUsesAnalyzedPath(t *testing.T) {
+	b := &bleveIndex{standard: resource.StandardSearchFields()}
+	// notin keeps the legacy analyzed path even for an allowlist label key: only
+	// "="/"in" consult the exact-term allowlist, and title is the sole notin exact
+	// case. A raw TermQuery here would fail to exclude standard-analyzed labels.
+	req := &resourcepb.ResourceSearchRequest{Options: &resourcepb.ListOptions{
+		Labels: []*resourcepb.Requirement{{Key: "login", Operator: "notin", Values: []string{"foo-bar"}}},
+	}}
+	queries, e := b.filterQueries(req)
+	require.Nil(t, e)
+	require.Len(t, queries, 1)
+	bq, ok := queries[0].(*query.BooleanQuery)
+	require.True(t, ok)
+	mustNot, ok := bq.MustNot.(*query.DisjunctionQuery)
+	require.True(t, ok)
+	require.Len(t, mustNot.Disjuncts, 1)
+	_, ok = mustNot.Disjuncts[0].(*query.MatchQuery)
+	require.True(t, ok, "notin on a label should use an analyzed MatchQuery, not a raw TermQuery")
+}
+
+func TestFilterQueries_DoesNotMutateRequest(t *testing.T) {
+	b := &bleveIndex{standard: resource.StandardSearchFields()}
+	req := &resourcepb.ResourceSearchRequest{Options: &resourcepb.ListOptions{
+		Labels: []*resourcepb.Requirement{{Key: "team", Operator: "in", Values: []string{"x"}}},
+		Fields: []*resourcepb.Requirement{{Key: resource.SEARCH_FIELD_FOLDER, Operator: "in", Values: []string{"f1"}}},
+	}}
+
+	// Search can re-run the builder on the post-rank authz cursor fallback, so
+	// two passes must leave the shared requirements untouched (no double-prefix).
+	for range 2 {
+		_, e := b.filterQueries(req)
+		require.Nil(t, e)
+	}
+	assert.Equal(t, "team", req.Options.Labels[0].Key)
+	assert.Equal(t, resource.SEARCH_FIELD_FOLDER, req.Options.Fields[0].Key)
+}
+
+func TestGetSortFields_ResolvesPhysicalNames(t *testing.T) {
+	fields, err := resource.NewSearchableDocumentFields(resource.SearchFieldDefinitionsToTableColumns(
+		[]resource.SearchFieldDefinition{
+			{Name: "note", Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityText, resource.SearchCapabilitySort}},
+			{Name: "num", Type: resource.SearchFieldTypeInt64, Capabilities: []resource.SearchCapability{resource.SearchCapabilitySort}},
+		},
+	))
+	require.NoError(t, err)
+
+	req := &resourcepb.ResourceSearchRequest{SortBy: []*resourcepb.ResourceSearchRequest_Sort{
+		{Field: resource.SEARCH_FIELD_TITLE},           // standard title -> populated title_phrase
+		{Field: "note"},                                // text field -> indexed name (no _keyword)
+		{Field: "num"},                                 // numeric sort field -> its indexed name
+		{Field: resource.SEARCH_FIELD_PREFIX + "note"}, // already-prefixed text-only name is preserved
+	}}
+	// name is appended as a stable tie-breaker.
+	assert.Equal(t, []string{
+		resource.SEARCH_FIELD_TITLE_PHRASE,
+		resource.SEARCH_FIELD_PREFIX + "note",
+		resource.SEARCH_FIELD_PREFIX + "num",
+		resource.SEARCH_FIELD_PREFIX + "note",
+		resource.SEARCH_FIELD_NAME,
+	}, getSortFields(req, fields))
+}
+
+func TestBleveIndex_resolveQueryFields(t *testing.T) {
+	fields, err := resource.NewSearchableDocumentFields(resource.SearchFieldDefinitionsToTableColumns(
+		[]resource.SearchFieldDefinition{
+			{Name: "panel_title", Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityText}},
+		},
+	))
+	require.NoError(t, err)
+	b := &bleveIndex{fields: fields, standard: resource.StandardSearchFields()}
+
+	names := func(qfs []*resourcepb.ResourceSearchRequest_QueryField) []string {
+		out := make([]string, len(qfs))
+		for i, f := range qfs {
+			out[i] = f.Name
+		}
+		return out
+	}
+	titleVariants := []string{resource.SEARCH_FIELD_TITLE_PHRASE, resource.SEARCH_FIELD_TITLE, resource.SEARCH_FIELD_TITLE_NGRAM}
+
+	// An empty request fans out to the three title variants.
+	assert.Equal(t, titleVariants, names(b.resolveQueryFields(nil)))
+	// An explicit title field fans out the same way.
+	assert.Equal(t, titleVariants, names(b.resolveQueryFields([]*resourcepb.ResourceSearchRequest_QueryField{{Name: resource.SEARCH_FIELD_TITLE}})))
+
+	// A per-kind field resolves to fields.* and keeps its requested type/boost.
+	got := b.resolveQueryFields([]*resourcepb.ResourceSearchRequest_QueryField{{Name: "panel_title", Type: resourcepb.QueryFieldType_TEXT, Boost: 3}})
+	require.Len(t, got, 1)
+	assert.Equal(t, resource.SEARCH_FIELD_PREFIX+"panel_title", got[0].Name)
+	assert.Equal(t, resourcepb.QueryFieldType_TEXT, got[0].Type)
+	assert.Equal(t, float32(3), got[0].Boost)
+
+	// title + per-kind field: title variants first, then the resolved field.
+	assert.Equal(t, append(append([]string{}, titleVariants...), resource.SEARCH_FIELD_PREFIX+"panel_title"),
+		names(b.resolveQueryFields([]*resourcepb.ResourceSearchRequest_QueryField{
+			{Name: resource.SEARCH_FIELD_TITLE},
+			{Name: "panel_title", Type: resourcepb.QueryFieldType_TEXT},
+		})))
+
+	// When the caller already names the physical title variants (legacy dashboard
+	// search), the logical title is not re-expanded, so nothing is duplicated.
+	legacy := []*resourcepb.ResourceSearchRequest_QueryField{
+		{Name: resource.SEARCH_FIELD_TITLE_PHRASE, Type: resourcepb.QueryFieldType_KEYWORD, Boost: 10},
+		{Name: resource.SEARCH_FIELD_TITLE, Type: resourcepb.QueryFieldType_TEXT, Boost: 2},
+		{Name: resource.SEARCH_FIELD_TITLE_NGRAM, Type: resourcepb.QueryFieldType_TEXT, Boost: 1},
+	}
+	assert.Equal(t, titleVariants, names(b.resolveQueryFields(legacy)))
 }

--- a/pkg/storage/unified/search/bleve_search_test.go
+++ b/pkg/storage/unified/search/bleve_search_test.go
@@ -669,6 +669,116 @@ func TestDoubleEqualsExactMatch(t *testing.T) {
 	})
 }
 
+func titleFilterQuery(operator string, values ...string) *resourcepb.ResourceSearchRequest {
+	return &resourcepb.ResourceSearchRequest{
+		Options: &resourcepb.ListOptions{
+			Key: &resourcepb.ResourceKey{
+				Namespace: "default",
+				Group:     "dashboard.grafana.app",
+				Resource:  "dashboards",
+			},
+			Fields: []*resourcepb.Requirement{{Key: "title", Operator: operator, Values: values}},
+		},
+		// Sort by name so multi-hit expectations are deterministic (filters alone
+		// impose no order).
+		SortBy: []*resourcepb.ResourceSearchRequest_Sort{{Field: resource.SEARCH_FIELD_NAME}},
+		Limit:  100000,
+	}
+}
+
+// TestTitleSetFilterExactMatch covers the "in"/"notin" title filters the v1
+// search API emits: set membership is exact (whole title, case-insensitive via
+// title_phrase), unlike the fuzzy "=" filter.
+func TestTitleSetFilterExactMatch(t *testing.T) {
+	key := resource.NamespacedResource{
+		Namespace: "default",
+		Group:     "dashboard.grafana.app",
+		Resource:  "dashboards",
+	}
+	seed := func(t *testing.T) resource.ResourceIndex {
+		index := newTestDashboardsIndex(t, threshold, 3, noop)
+		indexDocumentsWithTitles(t, index, key, map[string]string{
+			"name1": "Test",
+			"name2": "Test Team 1",
+			"name3": "Other",
+		})
+		return index
+	}
+
+	t.Run("in on title matches only the exact title", func(t *testing.T) {
+		checkSearchQuery(t, seed(t), titleFilterQuery("in", "Test"), []string{"name1"})
+	})
+
+	t.Run("in on title is case insensitive", func(t *testing.T) {
+		checkSearchQuery(t, seed(t), titleFilterQuery("in", "tEsT"), []string{"name1"})
+	})
+
+	t.Run("in on title matches any listed value", func(t *testing.T) {
+		checkSearchQuery(t, seed(t), titleFilterQuery("in", "Test", "Other"), []string{"name1", "name3"})
+	})
+
+	t.Run("notin on title excludes the exact title only", func(t *testing.T) {
+		checkSearchQuery(t, seed(t), titleFilterQuery("notin", "Test"), []string{"name2", "name3"})
+	})
+}
+
+// TestPublicFieldNameFilter checks the filter path resolves a public field name
+// to its physical fields.* location, so callers don't supply the prefix.
+func TestPublicFieldNameFilter(t *testing.T) {
+	key := resource.NamespacedResource{Namespace: "default", Group: "dashboard.grafana.app", Resource: "dashboards"}
+	index := newTestIndexWithFields(t, key, []*resourcepb.ResourceTableColumnDefinition{
+		{Name: "team", Type: resourcepb.ResourceTableColumnDefinition_STRING, Properties: &resourcepb.ResourceTableColumnDefinition_Properties{Filterable: true}},
+	})
+	require.NoError(t, index.BulkIndex(&resource.BulkIndexRequest{Items: []*resource.BulkIndexItem{
+		{Action: resource.ActionIndex, Doc: &resource.IndexableDocument{RV: 1, Name: "d1", Title: "One",
+			Key:    &resourcepb.ResourceKey{Name: "d1", Namespace: key.Namespace, Group: key.Group, Resource: key.Resource},
+			Fields: map[string]any{"team": "red"}}},
+		{Action: resource.ActionIndex, Doc: &resource.IndexableDocument{RV: 1, Name: "d2", Title: "Two",
+			Key:    &resourcepb.ResourceKey{Name: "d2", Namespace: key.Namespace, Group: key.Group, Resource: key.Resource},
+			Fields: map[string]any{"team": "blue"}}},
+	}}))
+
+	filter := func(field string) *resourcepb.ResourceSearchRequest {
+		return &resourcepb.ResourceSearchRequest{
+			Options: &resourcepb.ListOptions{
+				Key:    &resourcepb.ResourceKey{Namespace: key.Namespace, Group: key.Group, Resource: key.Resource},
+				Fields: []*resourcepb.Requirement{{Key: field, Operator: "in", Values: []string{"red"}}},
+			},
+			Limit: 100000,
+		}
+	}
+
+	// Public name resolves to the fields.* sub-document.
+	checkSearchQuery(t, index, filter("team"), []string{"d1"})
+	// An explicitly prefixed name still works (passthrough).
+	checkSearchQuery(t, index, filter(resource.SEARCH_FIELD_PREFIX+"team"), []string{"d1"})
+}
+
+// TestPublicFieldNameTextQuery checks a free-text query resolves a public
+// QueryField name to its physical fields.* location.
+func TestPublicFieldNameTextQuery(t *testing.T) {
+	key := resource.NamespacedResource{Namespace: "default", Group: "dashboard.grafana.app", Resource: "dashboards"}
+	index := newTestIndexWithFields(t, key, []*resourcepb.ResourceTableColumnDefinition{
+		{Name: "team", Type: resourcepb.ResourceTableColumnDefinition_STRING, Properties: &resourcepb.ResourceTableColumnDefinition_Properties{Filterable: true}},
+	})
+	require.NoError(t, index.BulkIndex(&resource.BulkIndexRequest{Items: []*resource.BulkIndexItem{
+		{Action: resource.ActionIndex, Doc: &resource.IndexableDocument{RV: 1, Name: "d1", Title: "One",
+			Key:    &resourcepb.ResourceKey{Name: "d1", Namespace: key.Namespace, Group: key.Group, Resource: key.Resource},
+			Fields: map[string]any{"team": "redteam"}}},
+		{Action: resource.ActionIndex, Doc: &resource.IndexableDocument{RV: 1, Name: "d2", Title: "Two",
+			Key:    &resourcepb.ResourceKey{Name: "d2", Namespace: key.Namespace, Group: key.Group, Resource: key.Resource},
+			Fields: map[string]any{"team": "blueteam"}}},
+	}}))
+
+	req := &resourcepb.ResourceSearchRequest{
+		Options:     &resourcepb.ListOptions{Key: &resourcepb.ResourceKey{Namespace: key.Namespace, Group: key.Group, Resource: key.Resource}},
+		Query:       "redteam",
+		QueryFields: []*resourcepb.ResourceSearchRequest_QueryField{{Name: "team", Type: resourcepb.QueryFieldType_TEXT, Boost: 1}},
+		Limit:       100000,
+	}
+	checkSearchQuery(t, index, req, []string{"d1"})
+}
+
 func newTestDashboardsIndex(t testing.TB, threshold int64, size int64, writer resource.BuildFn) resource.ResourceIndex {
 	key := &resourcepb.ResourceKey{
 		Namespace: "default",

--- a/pkg/storage/unified/search/fuzz_test.go
+++ b/pkg/storage/unified/search/fuzz_test.go
@@ -48,11 +48,11 @@ func FuzzBleveRequirementQuery(f *testing.F) {
 			values = []string{v1, v2}
 		}
 		req := &resourcepb.Requirement{
-			Key:      key,
+			Key:      prefix + key,
 			Operator: op,
 			Values:   values,
 		}
-		q, errRes := requirementQuery(req, prefix)
+		q, errRes := (&bleveIndex{}).requirementQuery(req)
 		if (q == nil) == (errRes == nil) {
 			t.Fatalf("query/err invariant violated: query=%v err=%v for req=%+v prefix=%q",
 				q, errRes, req, prefix)


### PR DESCRIPTION
The upcoming per-resource Search v1 API sends public field names and set-membership operators (`in`/`notin`), and expects the backend to translate them into whatever the bleve index actually uses. This makes that translation consistent across the query builder, so the API layer never has to know the physical index layout.

What changed:

- A single `resolveFieldName` maps public names to physical names — per-kind fields get the `fields.` sub-document prefix, while standard and internal top-level names (including the `title_phrase`/`title_ngram` variants) are left as-is. It is now applied to filter requirements, the returned field list, sort fields, and text query fields (previously each path did its own thing, and filters assumed callers pre-prefixed).
- A logical `title` text query expands into its three physical variants, and exact `in`/`notin` filters on `title` target the populated `title_phrase` variant (whole-title, case-insensitive). `=` stays fuzzy, `==` stays exact.
- The `prefix` parameter threaded through the query helpers is gone. The `labels.` sub-document prefix is resolved into the key up front, and filter requirements are rebuilt rather than mutated, so re-running the builder (post-rank authz fallback) is idempotent. The exact-term allowlist decision is matched against the logical key so label behavior is preserved.

Behavior for existing callers (legacy dashboard and unified search) is unchanged; new unit and behavioral tests cover the resolution, title exactness, label filters, and non-mutation.

Backend prerequisite for the Search v1 `/search` and `/trash` handlers. Part of grafana/search-and-storage-team#869, which also tracks the follow-ups this intentionally defers (populating custom fields' keyword variants at index time; capability-driven exact-term selection; migrating callers off client-side `fields.` prefixing).
