### PR TITLE
Loki: Update streaming key

### DIFF
--- a/pkg/tsdb/loki/streaming.go
+++ b/pkg/tsdb/loki/streaming.go
@@ -58,6 +58,14 @@ func (s *Service) SubscribeStream(ctx context.Context, req *backend.SubscribeStr
 		}, fmt.Errorf("expected tail in channel path")
 	}
 
+	pluginCfg := backend.PluginConfigFromContext(ctx)
+	namespace := strings.Split(req.Path, "/")[3]
+	if namespace != pluginCfg.Namespace {
+		return &backend.SubscribeStreamResponse{
+			Status: backend.SubscribeStreamStatusPermissionDenied,
+		}, fmt.Errorf("invalid namespace supplied in request")
+	}
+
 	if err := rejectGrafanaSQLStreamPayload(req.Data); err != nil {
 		return &backend.SubscribeStreamResponse{
 			Status: backend.SubscribeStreamStatusPermissionDenied,

--- a/pkg/tsdb/loki/streaming_test.go
+++ b/pkg/tsdb/loki/streaming_test.go
@@ -93,6 +93,7 @@ func TestSubscribeStream(t *testing.T) {
 			featuretoggles.EnabledFeatures: flagLokiExperimentalStreaming,
 		})
 		ctx := config.WithGrafanaConfig(context.Background(), cfg)
+		ctx = backend.WithPluginContext(ctx, backend.PluginContext{Namespace: "stacks-123"})
 
 		grafanaSQLReq := &backend.SubscribeStreamRequest{
 			PluginContext: backend.PluginContext{

--- a/pkg/tsdb/loki/streaming_test.go
+++ b/pkg/tsdb/loki/streaming_test.go
@@ -102,8 +102,9 @@ func TestSubscribeStream(t *testing.T) {
 					Type: "loki",
 					URL:  "http://localhost:3100",
 				},
+				Namespace: "stacks-123",
 			},
-			Path: "tail/test",
+			Path: "tail/dsId/test/stacks-123",
 			Data: []byte(`{"grafanaSql":true,"table":"svc","refId":"A"}`),
 		}
 

--- a/pkg/tsdb/loki/streaming_test.go
+++ b/pkg/tsdb/loki/streaming_test.go
@@ -32,7 +32,7 @@ func TestSubscribeStream(t *testing.T) {
 				URL:  "http://localhost:3100",
 			},
 		},
-		Path: "tail/test",
+		Path: "tail/dsId/test/stacks-1",
 		Data: []byte(`{"expr": "test"}`),
 	}
 
@@ -47,8 +47,35 @@ func TestSubscribeStream(t *testing.T) {
 		require.Equal(t, backend.SubscribeStreamStatusPermissionDenied, resp.Status)
 	})
 
-	t.Run("when feature toggle is enabled", func(t *testing.T) {
+	t.Run("when feature toggle is enabled and namespace matches", func(t *testing.T) {
 		// Create a context with the feature toggle enabled
+		cfg := config.NewGrafanaCfg(map[string]string{
+			featuretoggles.EnabledFeatures: flagLokiExperimentalStreaming,
+		})
+		ctx := config.WithGrafanaConfig(context.Background(), cfg)
+		ctx = backend.WithPluginContext(ctx, backend.PluginContext{Namespace: "stacks-1"})
+
+		resp, err := service.SubscribeStream(ctx, req)
+
+		require.NoError(t, err)
+		require.Equal(t, backend.SubscribeStreamStatusOK, resp.Status)
+	})
+
+	t.Run("when namespace does not match the request path", func(t *testing.T) {
+		cfg := config.NewGrafanaCfg(map[string]string{
+			featuretoggles.EnabledFeatures: flagLokiExperimentalStreaming,
+		})
+		ctx := config.WithGrafanaConfig(context.Background(), cfg)
+		ctx = backend.WithPluginContext(ctx, backend.PluginContext{Namespace: "stacks-2"})
+
+		resp, err := service.SubscribeStream(ctx, req)
+
+		require.Error(t, err)
+		require.Equal(t, "invalid namespace supplied in request", err.Error())
+		require.Equal(t, backend.SubscribeStreamStatusPermissionDenied, resp.Status)
+	})
+
+	t.Run("when namespace is missing from the plugin context", func(t *testing.T) {
 		cfg := config.NewGrafanaCfg(map[string]string{
 			featuretoggles.EnabledFeatures: flagLokiExperimentalStreaming,
 		})
@@ -56,8 +83,9 @@ func TestSubscribeStream(t *testing.T) {
 
 		resp, err := service.SubscribeStream(ctx, req)
 
-		require.NoError(t, err)
-		require.Equal(t, backend.SubscribeStreamStatusOK, resp.Status)
+		require.Error(t, err)
+		require.Equal(t, "invalid namespace supplied in request", err.Error())
+		require.Equal(t, backend.SubscribeStreamStatusPermissionDenied, resp.Status)
 	})
 
 	t.Run("grafana sql payload is rejected when streaming is enabled", func(t *testing.T) {

--- a/public/app/plugins/datasource/loki/streaming.ts
+++ b/public/app/plugins/datasource/loki/streaming.ts
@@ -1,4 +1,4 @@
-import { map, type Observable, defer, mergeMap } from 'rxjs';
+import { defer, map, mergeMap, type Observable } from 'rxjs';
 
 import {
   type DataFrameJSON,
@@ -9,7 +9,7 @@ import {
   LoadingState,
   StreamingDataFrame,
 } from '@grafana/data';
-import { getGrafanaLiveSrv, config } from '@grafana/runtime';
+import { config, getGrafanaLiveSrv } from '@grafana/runtime';
 
 import { type LokiDatasource } from './datasource';
 import { type LokiQuery } from './types';
@@ -25,7 +25,7 @@ async function getLiveStreamKey(query: LokiQuery): Promise<string> {
   const msgUint8 = new TextEncoder().encode(str); // encode as (utf-8) Uint8Array
   const hashBuffer = await crypto.subtle.digest('SHA-1', msgUint8); // hash the message
   const hashArray = Array.from(new Uint8Array(hashBuffer.slice(0, 8))); // first 8 bytes
-  return `${query.datasource?.uid}/${hashArray.map((b) => b.toString(16).padStart(2, '0')).join('')}/${config.bootData.user.orgId}`;
+  return `${query.datasource?.uid}/${hashArray.map((b) => b.toString(16).padStart(2, '0')).join('')}/${config.bootData.settings.namespace}`;
 }
 
 // This will get both v1 and v2 result formats


### PR DESCRIPTION
- Use `namespace` as part of the streaming key.
- Validate `namespace` in streaming requests.
- Update tests.