### PR TITLE
XYChart: Implement palette modes

### DIFF
--- a/public/app/plugins/panel/xychart/scatter.ts
+++ b/public/app/plugins/panel/xychart/scatter.ts
@@ -669,6 +669,16 @@ export function fieldValueColors(f: Field, theme: GrafanaTheme2): FieldColorValu
     }
 
     getAll = (vals, min, max) => valuesToFills(vals as number[], index as string[], min!, max!);
+  } else if (f.config.color?.mode?.startsWith('palette')) {
+    const fieldColorMode = getFieldColorModeForField(f);
+    if (fieldColorMode.getColors) {
+      // We need to explicitly add an alpha component here, or hasAlpha will be detected as false,
+      // and the user's opacity setting will be ignored.
+      index = fieldColorMode.getColors(theme).map((color) => color + 'ff');
+      getAll = (vals, min?, max?) => {
+        return (vals as number[]).map((v) => v % index.length);
+      };
+    }
   }
 
   if (conds !== '') {


### PR DESCRIPTION
The palette modes were never implemented for XYChart2, so any attempt at using them would fall through to the entire palette being undefined, with crashes when trying to compute alpha of those values.

I wanted to add a test, but the XYChart color tests are seemingly all broken (they all just check that the color is red, no matter what the mode is).