### PR TITLE
feat(provisioning): limit queued jobs per repository and namespace

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -2582,6 +2582,16 @@ max_incremental_changes = 100
 # non-positive value) for unlimited.
 max_file_size = 5242880
 
+# Maximum number of queued jobs allowed for a single repository. When the limit is
+# reached, new jobs for that repository are rejected with HTTP 429 (Too Many Requests).
+# Default is 0, which means unlimited.
+max_queued_jobs_per_repository = 0
+
+# Maximum number of queued jobs allowed across all repositories in a namespace. When
+# the limit is reached, new jobs in that namespace are rejected with HTTP 429 (Too Many
+# Requests). Default is 0, which means unlimited.
+max_queued_jobs_per_namespace = 0
+
 # Per-resource apply timeout during a repository sync. Bounds how long applying a single
 # resource (or folder) may take before that operation is cancelled. Large resources (e.g.
 # multi-MB dashboards) can exceed a short timeout and fail with "context deadline exceeded"

--- a/docs/sources/as-code/observability-as-code/git-sync/usage-limits.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/usage-limits.md
@@ -104,6 +104,8 @@ On-prem users can customize the limits with the following configuration settings
 
 - Use `max_repositories` to set the amount of repositories you can sync. Refer to [`max_repositories`](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#max_repositories) in the Configure Grafana section to learn more.
 - Use `max_resources_per_repository` to set the amount of resources per repository to sync. Refer to [`max_resources_per_repository`](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#max_resources_per_repository) in the Configure Grafana section to learn more.
+- Use `max_queued_jobs_per_repository` to cap the number of queued jobs (such as sync or migrate jobs) for a single repository. Refer to [`max_queued_jobs_per_repository`](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#max_queued_jobs_per_repository) in the Configure Grafana section to learn more.
+- Use `max_queued_jobs_per_namespace` to cap the number of queued jobs across all repositories in a namespace. Refer to [`max_queued_jobs_per_namespace`](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#max_queued_jobs_per_namespace) in the Configure Grafana section to learn more.
 
 ### Nested folders
 

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -2868,6 +2868,14 @@ Maximum number of repositories allowed. Default is `10`. Set to `0` for unlimite
 
 Maximum number of resources (dashboards, folders, etc.) allowed per repository. Default is `0`, which means unlimited.
 
+#### `max_queued_jobs_per_repository`
+
+Maximum number of queued jobs allowed for a single repository. When the limit is reached, new jobs for that repository are rejected with HTTP 429 (Too Many Requests). Default is `0`, which means unlimited.
+
+#### `max_queued_jobs_per_namespace`
+
+Maximum number of queued jobs allowed across all repositories in a namespace. When the limit is reached, new jobs in that namespace are rejected with HTTP 429 (Too Many Requests). Default is `0`, which means unlimited.
+
 #### `public_root_url`
 
 Public-facing root URL of this Grafana instance, used by provisioning to construct URLs that must be reachable from external systems. When empty, falls back to `[server] root_url`.

--- a/pkg/operators/provisioning/jobqueue_operator.go
+++ b/pkg/operators/provisioning/jobqueue_operator.go
@@ -58,7 +58,7 @@ func RunJobQueueController(ctx context.Context, deps server.OperatorDependencies
 	}
 
 	jobHistoryWriter := jobs.NewAPIClientHistoryWriter(provisioningClient.ProvisioningV0alpha1())
-	jobStore, err := jobs.NewJobStore(provisioningClient.ProvisioningV0alpha1(), jobClaimExpiry, deps.Registerer)
+	jobStore, err := jobs.NewJobStore(provisioningClient.ProvisioningV0alpha1(), jobClaimExpiry, deps.Registerer, deps.Config.ProvisioningMaxQueuedJobsPerRepository, deps.Config.ProvisioningMaxQueuedJobsPerNamespace)
 	if err != nil {
 		return fmt.Errorf("create API client job store: %w", err)
 	}

--- a/pkg/operators/provisioning/jobs_operator.go
+++ b/pkg/operators/provisioning/jobs_operator.go
@@ -65,7 +65,7 @@ func RunJobController(ctx context.Context, deps server.OperatorDependencies) err
 	// }
 
 	jobHistoryWriter := jobs.NewAPIClientHistoryWriter(provisioningClient.ProvisioningV0alpha1())
-	jobStore, err := jobs.NewJobStore(provisioningClient.ProvisioningV0alpha1(), jobClaimExpiry, deps.Registerer)
+	jobStore, err := jobs.NewJobStore(provisioningClient.ProvisioningV0alpha1(), jobClaimExpiry, deps.Registerer, deps.Config.ProvisioningMaxQueuedJobsPerRepository, deps.Config.ProvisioningMaxQueuedJobsPerNamespace)
 	if err != nil {
 		return fmt.Errorf("create API client job store: %w", err)
 	}

--- a/pkg/operators/provisioning/repo_operator.go
+++ b/pkg/operators/provisioning/repo_operator.go
@@ -41,7 +41,7 @@ func RunRepoController(ctx context.Context, deps server.OperatorDependencies) er
 	}
 
 	resourceLister := resources.NewResourceLister(unified)
-	jobs, err := jobs.NewJobStore(provisioningClient.ProvisioningV0alpha1(), jobClaimExpiry, deps.Registerer)
+	jobs, err := jobs.NewJobStore(provisioningClient.ProvisioningV0alpha1(), jobClaimExpiry, deps.Registerer, deps.Config.ProvisioningMaxQueuedJobsPerRepository, deps.Config.ProvisioningMaxQueuedJobsPerNamespace)
 	if err != nil {
 		return fmt.Errorf("create API client job store: %w", err)
 	}

--- a/pkg/registry/apis/provisioning/jobs/persistentstore.go
+++ b/pkg/registry/apis/provisioning/jobs/persistentstore.go
@@ -89,11 +89,21 @@ type persistentStore struct {
 	// If a job is abandoned, it will have its claim cleaned up periodically.
 	expiry time.Duration
 
+	// maxQueuedJobsPerRepository caps the number of queued jobs for a single
+	// repository. 0 (or less) means unlimited.
+	maxQueuedJobsPerRepository int
+	// maxQueuedJobsPerNamespace caps the number of queued jobs across all
+	// repositories in a namespace. 0 (or less) means unlimited.
+	maxQueuedJobsPerNamespace int
+
 	queueMetrics QueueMetrics
 }
 
 // NewJobStore creates a new job queue implementation using the API client.
-func NewJobStore(provisioningClient client.ProvisioningV0alpha1Interface, expiry time.Duration, registry prometheus.Registerer) (*persistentStore, error) {
+//
+// maxQueuedJobsPerRepository and maxQueuedJobsPerNamespace cap the number of
+// queued jobs Insert will accept; 0 (or less) means unlimited.
+func NewJobStore(provisioningClient client.ProvisioningV0alpha1Interface, expiry time.Duration, registry prometheus.Registerer, maxQueuedJobsPerRepository, maxQueuedJobsPerNamespace int) (*persistentStore, error) {
 	if expiry <= 0 {
 		expiry = time.Second * 30
 	}
@@ -101,10 +111,12 @@ func NewJobStore(provisioningClient client.ProvisioningV0alpha1Interface, expiry
 	queueMetrics := RegisterQueueMetrics(registry)
 
 	return &persistentStore{
-		client:       provisioningClient,
-		clock:        time.Now,
-		expiry:       expiry,
-		queueMetrics: queueMetrics,
+		client:                     provisioningClient,
+		clock:                      time.Now,
+		expiry:                     expiry,
+		maxQueuedJobsPerRepository: maxQueuedJobsPerRepository,
+		maxQueuedJobsPerNamespace:  maxQueuedJobsPerNamespace,
+		queueMetrics:               queueMetrics,
 	}, nil
 }
 
@@ -558,6 +570,11 @@ func (s *persistentStore) Insert(ctx context.Context, namespace string, spec pro
 	logger = logger.With("job", job.GetName())
 	span.SetAttributes(attribute.String("job.name", job.GetName()))
 
+	if err := s.enforceQueueLimits(ctx, namespace, spec.Repository, job.GetName()); err != nil {
+		span.RecordError(err)
+		return nil, err
+	}
+
 	created, err := s.client.Jobs(namespace).Create(ctx, job, metav1.CreateOptions{})
 	if apierrors.IsAlreadyExists(err) {
 		span.RecordError(err)
@@ -572,6 +589,55 @@ func (s *persistentStore) Insert(ctx context.Context, namespace string, spec pro
 
 	logger.Info("insert job complete")
 	return created, nil
+}
+
+// enforceQueueLimits rejects an insert that would exceed the configured maximum
+// number of queued jobs for the repository or the namespace. jobName is the
+// deterministic name the job will be created under: a re-insert of a job that is
+// already queued does not grow the queue, so it is let through to Create (which
+// reports AlreadyExists) rather than being rejected by the limit.
+func (s *persistentStore) enforceQueueLimits(ctx context.Context, namespace, repository, jobName string) error {
+	if s.maxQueuedJobsPerRepository <= 0 && s.maxQueuedJobsPerNamespace <= 0 {
+		return nil
+	}
+
+	// Count queued jobs with the provisioning identity, matching the store's
+	// other read paths. This is an internal enforcement check that must not
+	// depend on the caller's list permissions.
+	ctx, _, err := identity.WithProvisioningIdentity(ctx, namespace)
+	if err != nil {
+		return apifmt.Errorf("failed to get provisioning identity for '%s': %w", namespace, err)
+	}
+
+	list, err := s.client.Jobs(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return apifmt.Errorf("failed to list jobs for queue limit check in '%s': %w", namespace, err)
+	}
+
+	namespaceCount := 0
+	repositoryCount := 0
+	for i := range list.Items {
+		job := &list.Items[i]
+		if job.GetName() == jobName {
+			// The job is already queued; re-inserting does not grow the queue.
+			return nil
+		}
+		namespaceCount++
+		if job.Labels[LabelRepository] == repository {
+			repositoryCount++
+		}
+	}
+
+	if limit := s.maxQueuedJobsPerNamespace; limit > 0 && namespaceCount >= limit {
+		return apierrors.NewTooManyRequests(
+			fmt.Sprintf("maximum number of queued jobs (%d) reached for namespace '%s'", limit, namespace), 0)
+	}
+	if limit := s.maxQueuedJobsPerRepository; limit > 0 && repositoryCount >= limit {
+		return apierrors.NewTooManyRequests(
+			fmt.Sprintf("maximum number of queued jobs (%d) reached for repository '%s'", limit, repository), 0)
+	}
+
+	return nil
 }
 
 // generateJobName creates and updates the job's name to one that fits it.

--- a/pkg/registry/apis/provisioning/jobs/persistentstore_test.go
+++ b/pkg/registry/apis/provisioning/jobs/persistentstore_test.go
@@ -397,6 +397,124 @@ func TestRenewLease_ThenUpdateDoesNotConflict(t *testing.T) {
 			"If it does, RenewLease stored a stale ResourceVersion.")
 }
 
+// seedJob creates a pre-existing queued job with the given name and repository
+// label so queue-limit tests can populate the queue directly.
+func seedJob(ctx context.Context, t *testing.T, client provisioningv0alpha1.ProvisioningV0alpha1Interface, namespace, name, repository string) {
+	t.Helper()
+	_, err := client.Jobs(namespace).Create(ctx, &provisioning.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    map[string]string{LabelRepository: repository},
+		},
+		Spec: provisioning.JobSpec{Repository: repository, Action: provisioning.JobActionPull},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+}
+
+func TestInsert_QueueLimits(t *testing.T) {
+	const namespace = "stacks-123"
+
+	t.Run("no limits configured allows insert", func(t *testing.T) {
+		fakeClient := newTestClientset()
+		store := newTestStore(fakeClient)
+
+		ctx, _, err := identity.WithProvisioningIdentity(context.Background(), namespace)
+		require.NoError(t, err)
+		seedJob(ctx, t, fakeClient, namespace, "other-a", "repo-a")
+		seedJob(ctx, t, fakeClient, namespace, "other-b", "repo-a")
+
+		job, err := store.Insert(ctx, namespace, provisioning.JobSpec{
+			Repository: "repo-a",
+			Action:     provisioning.JobActionPull,
+			Pull:       &provisioning.SyncJobOptions{},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "repo-a-sync", job.GetName())
+	})
+
+	t.Run("per-repository limit rejects with TooManyRequests", func(t *testing.T) {
+		fakeClient := newTestClientset()
+		store := newTestStore(fakeClient)
+		store.maxQueuedJobsPerRepository = 2
+
+		ctx, _, err := identity.WithProvisioningIdentity(context.Background(), namespace)
+		require.NoError(t, err)
+		seedJob(ctx, t, fakeClient, namespace, "repo-a-1", "repo-a")
+		seedJob(ctx, t, fakeClient, namespace, "repo-a-2", "repo-a")
+
+		_, err = store.Insert(ctx, namespace, provisioning.JobSpec{
+			Repository: "repo-a",
+			Action:     provisioning.JobActionPull,
+			Pull:       &provisioning.SyncJobOptions{},
+		})
+		require.Error(t, err)
+		assert.True(t, apierrors.IsTooManyRequests(err), "expected TooManyRequests, got %v", err)
+	})
+
+	t.Run("per-repository limit ignores other repositories", func(t *testing.T) {
+		fakeClient := newTestClientset()
+		store := newTestStore(fakeClient)
+		store.maxQueuedJobsPerRepository = 2
+
+		ctx, _, err := identity.WithProvisioningIdentity(context.Background(), namespace)
+		require.NoError(t, err)
+		seedJob(ctx, t, fakeClient, namespace, "repo-b-1", "repo-b")
+		seedJob(ctx, t, fakeClient, namespace, "repo-b-2", "repo-b")
+		seedJob(ctx, t, fakeClient, namespace, "repo-b-3", "repo-b")
+
+		job, err := store.Insert(ctx, namespace, provisioning.JobSpec{
+			Repository: "repo-a",
+			Action:     provisioning.JobActionPull,
+			Pull:       &provisioning.SyncJobOptions{},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "repo-a-sync", job.GetName())
+	})
+
+	t.Run("per-namespace limit rejects with TooManyRequests", func(t *testing.T) {
+		fakeClient := newTestClientset()
+		store := newTestStore(fakeClient)
+		store.maxQueuedJobsPerNamespace = 3
+
+		ctx, _, err := identity.WithProvisioningIdentity(context.Background(), namespace)
+		require.NoError(t, err)
+		seedJob(ctx, t, fakeClient, namespace, "j-1", "repo-a")
+		seedJob(ctx, t, fakeClient, namespace, "j-2", "repo-b")
+		seedJob(ctx, t, fakeClient, namespace, "j-3", "repo-c")
+
+		_, err = store.Insert(ctx, namespace, provisioning.JobSpec{
+			Repository: "repo-d",
+			Action:     provisioning.JobActionPull,
+			Pull:       &provisioning.SyncJobOptions{},
+		})
+		require.Error(t, err)
+		assert.True(t, apierrors.IsTooManyRequests(err), "expected TooManyRequests, got %v", err)
+	})
+
+	t.Run("re-inserting an already-queued job is allowed at the limit", func(t *testing.T) {
+		fakeClient := newTestClientset()
+		store := newTestStore(fakeClient)
+		store.maxQueuedJobsPerRepository = 1
+
+		ctx, _, err := identity.WithProvisioningIdentity(context.Background(), namespace)
+		require.NoError(t, err)
+		// The deterministic sync-job name already occupies the single slot.
+		seedJob(ctx, t, fakeClient, namespace, "repo-a-sync", "repo-a")
+
+		// Re-inserting the same job must not be rejected by the limit; it falls
+		// through to Create, which reports AlreadyExists as before.
+		_, err = store.Insert(ctx, namespace, provisioning.JobSpec{
+			Repository: "repo-a",
+			Action:     provisioning.JobActionPull,
+			Pull:       &provisioning.SyncJobOptions{},
+		})
+		require.Error(t, err)
+		assert.True(t, apierrors.IsAlreadyExists(err), "expected AlreadyExists, got %v", err)
+		assert.False(t, apierrors.IsTooManyRequests(err), "re-insert must not be rejected as TooManyRequests")
+	})
+}
+
 func TestGenerateJobName(t *testing.T) {
 	t.Run("pull and migrate share a deterministic sync name", func(t *testing.T) {
 		pull := &provisioning.Job{Spec: provisioning.JobSpec{Repository: "repo", Action: provisioning.JobActionPull}}

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -167,6 +167,11 @@ type APIBuilder struct {
 	historyExpiration        time.Duration
 	jobPollInterval          time.Duration
 
+	// maxQueuedJobsPerRepository and maxQueuedJobsPerNamespace cap the number of
+	// queued jobs the job store will accept. 0 means unlimited.
+	maxQueuedJobsPerRepository int
+	maxQueuedJobsPerNamespace  int
+
 	// natsSubscriber feeds the controllers' event handlers when NATS is enabled.
 	// Instead of an apiserver-backed informer, each controller's handler is driven
 	// by a NATS-backed informer (see pkg/storage/unified/informer) that signals the
@@ -399,6 +404,8 @@ func RegisterAPIService(
 	builder.controllerResyncInterval = cfg.ProvisioningControllerResyncInterval
 	builder.historyExpiration = cfg.ProvisioningHistoryExpiration
 	builder.jobPollInterval = cfg.ProvisioningJobPollInterval
+	builder.maxQueuedJobsPerRepository = cfg.ProvisioningMaxQueuedJobsPerRepository
+	builder.maxQueuedJobsPerNamespace = cfg.ProvisioningMaxQueuedJobsPerNamespace
 	builder.usageNamespaceLister = usage.UsageNamespaceLister(cfg, orgSvc)
 	builder.natsSubscriber = natsSubscriber
 	apiregistration.RegisterAPI(builder)
@@ -444,6 +451,8 @@ func RegisterAPIService(
 	v1beta1Builder.controllerResyncInterval = cfg.ProvisioningControllerResyncInterval
 	v1beta1Builder.historyExpiration = cfg.ProvisioningHistoryExpiration
 	v1beta1Builder.jobPollInterval = cfg.ProvisioningJobPollInterval
+	v1beta1Builder.maxQueuedJobsPerRepository = cfg.ProvisioningMaxQueuedJobsPerRepository
+	v1beta1Builder.maxQueuedJobsPerNamespace = cfg.ProvisioningMaxQueuedJobsPerNamespace
 	v1beta1Builder.usageNamespaceLister = usage.UsageNamespaceLister(cfg, orgSvc)
 	v1beta1Builder.natsSubscriber = natsSubscriber
 	apiregistration.RegisterAPI(v1beta1Builder)
@@ -971,7 +980,7 @@ func (b *APIBuilder) GetPostStartHooks() (map[string]genericapiserver.PostStartH
 			b.client = c.ProvisioningV0alpha1()
 
 			// Initialize the API client-based job store
-			b.jobs, err = jobs.NewJobStore(b.client, jobClaimExpiry, b.registry)
+			b.jobs, err = jobs.NewJobStore(b.client, jobClaimExpiry, b.registry, b.maxQueuedJobsPerRepository, b.maxQueuedJobsPerNamespace)
 			if err != nil {
 				return fmt.Errorf("create API client job store: %w", err)
 			}

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -198,6 +198,8 @@ type Cfg struct {
 	ProvisioningMaxRepositories               int64         // default 10, 0 in config = unlimited (converted to -1 internally)
 	ProvisioningMaxIncrementalChanges         int           // default 100, 0 in config = unlimited
 	ProvisioningMaxFileSize                   int64         // bytes; default 5 MiB (5242880); <=0 = unlimited
+	ProvisioningMaxQueuedJobsPerRepository    int           // max queued jobs for a single repository; default 0 = unlimited
+	ProvisioningMaxQueuedJobsPerNamespace     int           // max queued jobs across a namespace; default 0 = unlimited
 	ProvisioningSyncResourceTimeout           time.Duration // per-resource apply timeout during sync; default 30s; <=0 = default
 	ProvisioningWebhookSecretRotationInterval time.Duration // default 30 days
 	ProvisioningControllerResyncInterval      time.Duration // informer re-list interval for repo/connection/job controllers; default 60s; <=0 = default
@@ -2560,6 +2562,8 @@ func (cfg *Cfg) readProvisioningSettings(iniFile *ini.File) error {
 	cfg.ProvisioningMaxRepositories = iniFile.Section("provisioning").Key("max_repositories").MustInt64(10)
 	cfg.ProvisioningMaxIncrementalChanges = iniFile.Section("provisioning").Key("max_incremental_changes").MustInt(100)
 	cfg.ProvisioningMaxFileSize = iniFile.Section("provisioning").Key("max_file_size").MustInt64(ProvisioningMaxFileSizeDefault)
+	cfg.ProvisioningMaxQueuedJobsPerRepository = iniFile.Section("provisioning").Key("max_queued_jobs_per_repository").MustInt(0)
+	cfg.ProvisioningMaxQueuedJobsPerNamespace = iniFile.Section("provisioning").Key("max_queued_jobs_per_namespace").MustInt(0)
 	cfg.ProvisioningSyncResourceTimeout = iniFile.Section("provisioning").Key("sync_resource_timeout").MustDuration(ProvisioningSyncResourceTimeoutDefault)
 	cfg.ProvisioningWebhookSecretRotationInterval = iniFile.Section("provisioning").Key("webhook_secret_rotation_interval").MustDuration(30 * 24 * time.Hour)
 	cfg.ProvisioningControllerResyncInterval = iniFile.Section("provisioning").Key("resync_interval").MustDuration(ProvisioningControllerResyncIntervalDefault)


### PR DESCRIPTION
## What

Adds two configurable maximums on the number of queued provisioning jobs, enforced when a job is inserted into the queue:

- `[provisioning] max_queued_jobs_per_repository` — cap per repository
- `[provisioning] max_queued_jobs_per_namespace` — cap across all repositories in a namespace

Both default to `0` (unlimited), so behavior is unchanged unless an operator opts in. When a limit is reached, new job inserts are rejected with HTTP 429 (`TooManyRequests`).

## Why

The provisioning job queue previously had no upper bound on queued jobs. A misbehaving client, a webhook storm, or a large fan-out could enqueue an unbounded number of jobs for a single repository or tenant/namespace, degrading the queue and the workers that drain it. These limits give operators a guardrail to protect the queue per repository and per namespace (tenant).

## How

- `persistentStore` (`pkg/registry/apis/provisioning/jobs/persistentstore.go`) gains `maxQueuedJobsPerRepository` / `maxQueuedJobsPerNamespace`, wired through `NewJobStore`.
- `Insert` calls a new `enforceQueueLimits` before creating the job. It lists active jobs in the namespace (under the provisioning identity, consistent with the store's other read paths), counts namespace-wide and per-repository totals (via the `provisioning.grafana.app/repository` label), and rejects with `apierrors.NewTooManyRequests` when adding the job would exceed a limit.
- **Design note:** a re-insert of an already-queued job (deterministic name, e.g. `<repo>-sync`) is let through to `Create` so it still returns `AlreadyExists` as before — the limit only rejects genuinely *new* jobs. This preserves the behavior the repository controller relies on (`addSyncJob` treats `AlreadyExists` as a no-op).
- Settings parsed in `pkg/setting/setting.go` and threaded through `register.go` (both API versions) and the three standalone operators (`jobs_operator`, `jobqueue_operator`, `repo_operator`).
- Documented in `conf/defaults.ini`, `configure-grafana/_index.md`, and the Git Sync `usage-limits.md`.

Default of `0` (unlimited) was chosen deliberately to avoid breaking existing deployments — notably the perftest path, which intentionally queues many concurrent test jobs against one repository.

## Testing

- `TestInsert_QueueLimits` covers: no limits configured, per-repository rejection, per-repository ignoring other repositories, per-namespace rejection, and the re-insert-at-limit case (must return `AlreadyExists`, not `TooManyRequests`).
- `go test ./pkg/registry/apis/provisioning/jobs/ ./pkg/setting/` passes; `go build ./pkg/...`, `go vet`, and `gofmt` are clean.

## Checklist

- [x] Tests added/updated
- [x] Documentation updated
- [x] No breaking changes (defaults preserve current behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)