### PR TITLE
Docs: Fix profile type selection wording to reflect single-select

### DIFF
--- a/docs/sources/shared/datasources/tempo-traces-to-profiles.md
+++ b/docs/sources/shared/datasources/tempo-traces-to-profiles.md
@@ -61,7 +61,7 @@ To use a basic configuration, follow these steps:
 
    You can optionally configure a new name for the tag. This is useful if the tag has dots in the name and the target data source doesn't allow dots in labels. In that case, you can remap `service.name` to `service_name`.
 
-1. Select one or more profile types to use in the query. Select the drop-down and choose options from the menu.
+1. Select a profile type to use in the query. Select the drop-down and choose an option from the menu.
 
    The profile type or app must be selected for the query to be valid. Grafana doesn't show any data if the profile type or app isn't selected when a query runs.
 
@@ -84,7 +84,7 @@ To use a custom query with the configuration, follow these steps:
 
     You can also configure a name for the tag. Tag names are useful where the tag has dots in the name and the target data source doesn't allow using dots in labels. For example, you can remap `service.name` to `service_name`. If you don't map any tags here, you can still use any tag in the query, for example: `method="${__span.tags.method}"`. Learn more about [custom query variables](/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/configure-tempo-data-source/#custom-query-variables).
 
-1.  Select one or more profile types to use in the query. Select the drop-down and choose options from the menu.
+1.  Select a profile type to use in the query. Select the drop-down and choose an option from the menu.
 1.  Switch on **Use custom query** to enter a custom query.
 1.  Specify a custom query to be used to query profile data. You can use various variables to make that query relevant for current span. The link shows only if all the variables are interpolated with non-empty values to prevent creating an invalid query. You can interpolate the configured tags using the `$__tags` keyword.
 1.  Select **Save and Test**.


### PR DESCRIPTION
**What is this feature?**
This is a documentation fix, not a new feature. It corrects the wording in the Trace to profiles configuration docs, which incorrectly implied that multiple profile types could be selected.

**Why do we need this feature?**
The docs stated "Select one or more profile types to use in the query," but the `profileTypeId` field in the datasource provisioning schema is a singular string, and the UI only supports selecting a single profile type. This mismatch between the documentation and actual behavior was confusing users. This PR updates the wording in both places it appears (basic configuration and custom query configuration) to say "Select a profile type" instead.

**Who is this feature for?**
Grafana users configuring Trace to profiles on a Tempo data source, and anyone reading the docs to understand how profile type selection works.

**Which issue(s) does this PR fix?**:
Fixes #129083

**Special notes for your reviewer:**
Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle. (N/A — docs-only fix)
- [x] The docs are updated, and if this is a notable improvement, it's added to our What's New doc. (N/A — wording correction, not a notable change)

Verified that `profileTypeId` is a singular string field in the codebase, confirming the UI only supports single selection, not multiple.