### PR TITLE
Send the search manifest watcher token in the Authorization header

### DIFF
--- a/pkg/clientauth/roundtripper.go
+++ b/pkg/clientauth/roundtripper.go
@@ -10,12 +10,15 @@ import (
 )
 
 // tokenExchangeRoundTripper wraps an http.RoundTripper and injects an exchanged
-// access token into outgoing requests via the X-Access-Token header.
+// access token into outgoing requests. The token goes in the X-Access-Token
+// header by default; header can override that (e.g. Authorization for apiservers
+// that authenticate a standard bearer token).
 type tokenExchangeRoundTripper struct {
 	exchanger         authnlib.TokenExchanger
 	transport         http.RoundTripper
 	namespaceProvider NamespaceProvider
 	audienceProvider  AudienceProvider
+	header            string
 }
 
 var _ http.RoundTripper = (*tokenExchangeRoundTripper)(nil)
@@ -36,8 +39,8 @@ func newTokenExchangeRoundTripperWithStrategies(
 	}
 }
 
-// RoundTrip implements http.RoundTripper by exchanging a token and setting it
-// in the X-Access-Token header before forwarding the request.
+// RoundTrip implements http.RoundTripper by exchanging a token and setting it in
+// the configured header (X-Access-Token by default) before forwarding the request.
 func (t *tokenExchangeRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	ctx := req.Context()
 
@@ -52,7 +55,11 @@ func (t *tokenExchangeRoundTripper) RoundTrip(req *http.Request) (*http.Response
 	// Clone the request as RoundTrippers are not expected to mutate the passed request
 	req = utilnet.CloneRequest(req)
 
-	req.Header.Set("X-Access-Token", "Bearer "+tokenResponse.Token)
+	header := t.header
+	if header == "" {
+		header = "X-Access-Token"
+	}
+	req.Header.Set(header, "Bearer "+tokenResponse.Token)
 
 	return t.transport.RoundTrip(req)
 }
@@ -67,6 +74,23 @@ func NewStaticTokenExchangeTransportWrapper(
 ) transport.WrapperFunc {
 	return func(rt http.RoundTripper) http.RoundTripper {
 		return newTokenExchangeRoundTripperWithStrategies(exchanger, rt, NewStaticNamespaceProvider(namespace), NewStaticAudienceProvider(audience))
+	}
+}
+
+// NewStaticTokenExchangeAuthorizationTransportWrapper is like
+// NewStaticTokenExchangeTransportWrapper but sends the exchanged token in the
+// standard Authorization header instead of X-Access-Token. Use it for apiservers
+// that authenticate a bearer token from Authorization (e.g. the app-platform
+// apiserver) rather than the authlib X-Access-Token header.
+func NewStaticTokenExchangeAuthorizationTransportWrapper(
+	exchanger authnlib.TokenExchanger,
+	audience string,
+	namespace string,
+) transport.WrapperFunc {
+	return func(rt http.RoundTripper) http.RoundTripper {
+		t := newTokenExchangeRoundTripperWithStrategies(exchanger, rt, NewStaticNamespaceProvider(namespace), NewStaticAudienceProvider(audience))
+		t.header = "Authorization"
+		return t
 	}
 }
 

--- a/pkg/clientauth/roundtripper_test.go
+++ b/pkg/clientauth/roundtripper_test.go
@@ -197,6 +197,33 @@ func TestNewTokenExchangeTransportWrapper(t *testing.T) {
 	require.Equal(t, "test-namespace", exchanger.gotReq.Namespace)
 }
 
+func TestNewStaticTokenExchangeAuthorizationTransportWrapper(t *testing.T) {
+	exchanger := &fakeExchanger{resp: &authn.TokenExchangeResponse{Token: "wrapped-token"}}
+
+	var authorization, accessToken string
+	baseTransport := roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		authorization = r.Header.Get("Authorization")
+		accessToken = r.Header.Get("X-Access-Token")
+		rr := httptest.NewRecorder()
+		rr.WriteHeader(http.StatusOK)
+		return rr.Result(), nil
+	})
+
+	wrapper := NewStaticTokenExchangeAuthorizationTransportWrapper(exchanger, "test-audience", "test-namespace")
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.org", nil)
+	resp, err := wrapper(baseTransport).RoundTrip(req)
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+
+	// The exchanged token must go in Authorization, not X-Access-Token, for
+	// apiservers that authenticate a standard bearer token.
+	require.Equal(t, "Bearer wrapped-token", authorization)
+	require.Empty(t, accessToken)
+	require.NotNil(t, exchanger.gotReq)
+	require.Equal(t, []string{"test-audience"}, exchanger.gotReq.Audiences)
+	require.Equal(t, "test-namespace", exchanger.gotReq.Namespace)
+}
+
 func TestTokenExchangeRoundTripperWithStrategies(t *testing.T) {
 	tests := []struct {
 		name              string

--- a/pkg/storage/unified/resource/manifest_watcher.go
+++ b/pkg/storage/unified/resource/manifest_watcher.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/transport"
 
 	"github.com/grafana/grafana-app-sdk/app"
 	appmanifestv1alpha2 "github.com/grafana/grafana-app-sdk/app/appmanifest/v1alpha2"
@@ -132,17 +133,24 @@ func newManifestRESTConfig(cfg ManifestWatcherConfig) (*rest.Config, error) {
 		return nil, fmt.Errorf("creating token exchange client: %w", err)
 	}
 
-	// The token audience for an app-platform apiserver is its API group.
 	return &rest.Config{
 		APIPath:       "/apis",
 		Host:          cfg.APIServerURL,
 		Timeout:       manifestPollTimeout,
-		WrapTransport: clientauth.NewStaticTokenExchangeTransportWrapper(tc, appManifestGVR.Group, clientauth.WildcardNamespace),
+		WrapTransport: manifestAuthWrapper(tc),
 		TLSClientConfig: rest.TLSClientConfig{
 			CAFile:   cfg.CAFile,
 			Insecure: cfg.AllowInsecure && cfg.CAFile == "",
 		},
 	}, nil
+}
+
+// manifestAuthWrapper builds the transport wrapper used to reach the app-platform
+// apiserver. That server authenticates a standard bearer token from the
+// Authorization header, so the exchanged token must go there rather than in the
+// authlib X-Access-Token header. The token audience is the API group.
+func manifestAuthWrapper(exchanger authnlib.TokenExchanger) transport.WrapperFunc {
+	return clientauth.NewStaticTokenExchangeAuthorizationTransportWrapper(exchanger, appManifestGVR.Group, clientauth.WildcardNamespace)
 }
 
 // NewManifestWatcher creates a ManifestWatcher as a dskit service. The initial

--- a/pkg/storage/unified/resource/manifest_watcher_test.go
+++ b/pkg/storage/unified/resource/manifest_watcher_test.go
@@ -1,12 +1,17 @@
 package resource
 
 import (
+	"context"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
+	authn "github.com/grafana/authlib/authn"
 	"github.com/grafana/grafana-app-sdk/app"
+	"github.com/grafana/grafana/pkg/clientauth"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -15,6 +20,47 @@ import (
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	k8stesting "k8s.io/client-go/testing"
 )
+
+type fakeTokenExchanger struct {
+	token  string
+	gotReq *authn.TokenExchangeRequest
+}
+
+func (f *fakeTokenExchanger) Exchange(_ context.Context, req authn.TokenExchangeRequest) (*authn.TokenExchangeResponse, error) {
+	f.gotReq = &req
+	return &authn.TokenExchangeResponse{Token: f.token}, nil
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+// The app-platform apiserver authenticates a standard bearer token, so the
+// watcher's transport must send the exchanged token in Authorization, not the
+// authlib X-Access-Token header (which the server ignores, yielding anonymous).
+func TestManifestWatcher_AuthUsesAuthorizationHeader(t *testing.T) {
+	exchanger := &fakeTokenExchanger{token: "exchanged-token"}
+
+	var authorization, accessToken string
+	base := roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		authorization = r.Header.Get("Authorization")
+		accessToken = r.Header.Get("X-Access-Token")
+		rr := httptest.NewRecorder()
+		rr.WriteHeader(http.StatusOK)
+		return rr.Result(), nil
+	})
+
+	req, _ := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.org", nil)
+	resp, err := manifestAuthWrapper(exchanger)(base).RoundTrip(req)
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+
+	require.Equal(t, "Bearer exchanged-token", authorization)
+	require.Empty(t, accessToken)
+	require.NotNil(t, exchanger.gotReq)
+	require.Equal(t, []string{appManifestGVR.Group}, exchanger.gotReq.Audiences)
+	require.Equal(t, clientauth.WildcardNamespace, exchanger.gotReq.Namespace)
+}
 
 // testAppManifestObj builds an unstructured AppManifest (v1alpha2) with one
 // version declaring a single kind and the given search fields.


### PR DESCRIPTION
The search manifest watcher reached the app-platform apiserver with its exchanged token in the X-Access-Token header, the way our own aggregated apiservers expect it. The app-platform apiserver instead authenticates a standard bearer token from the Authorization header, so it never saw a credential and rejected the request as system:anonymous.

This adds an Authorization-header variant of the shared token-exchange transport wrapper and points the watcher at it. Existing callers of the original wrapper keep sending X-Access-Token unchanged. The header is fixed to Authorization for now; the wrapper is parameterized internally, so it can become a config option later if another server needs the other header.

Part of grafana/search-and-storage-team#827.
