### PR TITLE
feat(ngalert): Map 429 TooManyRequests to ErrRateLimited

### DIFF
--- a/pkg/services/ngalert/writer/prom.go
+++ b/pkg/services/ngalert/writer/prom.go
@@ -117,6 +117,7 @@ var (
 	ErrDatasourceUnauthorized = errors.New("failed to authenticate in datasource")
 	ErrDatasourceForbidden    = errors.New("failed to authorize in datasource")
 	ErrConnectionFailure      = errors.New("failed to connect to remote write endpoint")
+	ErrRateLimited            = errors.New("write rejected due to rate limit")
 
 	// IgnoredErrors don't cause the Write to fail, but are still logged.
 	IgnoredErrors = []string{
@@ -435,6 +436,10 @@ func checkWriteError(writeErr promremote.WriteError) (err error, ignored bool) {
 	if writeErr.StatusCode() == 403 {
 		actual := extractActualError(writeErr)
 		return fmt.Errorf("%w: %s", ErrDatasourceForbidden, actual), false
+	}
+	if writeErr.StatusCode() == 429 {
+		actual := extractActualError(writeErr)
+		return fmt.Errorf("%w: %s", ErrRateLimited, actual), false
 	}
 
 	// All other errors which do not fit into the above categories are also unexpected.

--- a/pkg/services/ngalert/writer/prom_test.go
+++ b/pkg/services/ngalert/writer/prom_test.go
@@ -269,6 +269,24 @@ func TestPrometheusWriter_Write(t *testing.T) {
 		require.ErrorIs(t, err, ErrRejectedWrite)
 		require.NotErrorIs(t, err, ErrNonRetryableWrite)
 	})
+
+	t.Run("a 429 response is classified as rate limited", func(t *testing.T) {
+		msg := "too many requests"
+		clientErr := testClientWriteError{
+			statusCode: http.StatusTooManyRequests,
+			msg:        &msg,
+		}
+		client.writeSeriesFunc = func(ctx context.Context, ts promremote.TSList, opts promremote.WriteOptions) (promremote.WriteResult, promremote.WriteError) {
+			return promremote.WriteResult{}, clientErr
+		}
+
+		err := writer.Write(ctx, "test", now, frames, 1, map[string]string{"extra": "label"})
+
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrRateLimited)
+		require.NotErrorIs(t, err, ErrUnexpectedWriteFailure)
+		require.NotErrorIs(t, err, ErrNonRetryableWrite)
+	})
 }
 
 func TestExtractActualError(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Properly map `TooManyRequests` errors when trying to write, avoiding the catch-all `Unexpected`

**Why do we need this feature?**

Some observed failures are then not categorized properly, because of the `Unexpected` error.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
