### PR TITLE
IAM: Remove access-policy restriction on users API

### DIFF
--- a/pkg/registry/apis/iam/register.go
+++ b/pkg/registry/apis/iam/register.go
@@ -214,6 +214,7 @@ func NewAPIService(
 	serviceAccountAuthorizer := newServiceAccountAuthorizer(accessClient)
 	teamLBACAuthorizer := teamLBACApiInstaller.GetAuthorizer()
 	resourceAuthorizer := gfauthorizer.NewResourceAuthorizer(accessClient)
+	userAuthorizer := newUserAuthorizer(accessClient)
 
 	resourceParentProvider := iamauthorizer.NewApiParentProvider(
 		iamauthorizer.NewRemoteConfigProvider(authorizerDialConfigs, tokenExchanger),
@@ -298,7 +299,7 @@ func NewAPIService(
 				}
 
 				if a.GetResource() == "users" {
-					return resourceAuthorizer.Authorize(ctx, a)
+					return userAuthorizer.Authorize(ctx, a)
 				}
 
 				if a.GetResource() == iamv0.ServiceAccountResourceInfo.GetName() {

--- a/pkg/registry/apis/iam/register.go
+++ b/pkg/registry/apis/iam/register.go
@@ -298,9 +298,6 @@ func NewAPIService(
 				}
 
 				if a.GetResource() == "users" {
-					if user.GetIdentityType() != types.TypeAccessPolicy {
-						return authorizer.DecisionDeny, "only access policy identities have access for now", nil
-					}
 					return resourceAuthorizer.Authorize(ctx, a)
 				}
 


### PR DESCRIPTION
**What is this feature?**

Removes the access-policy identity-type gate from the MT users API authorizer. All users API operations now delegate to the resource authorizer, which enforces per-resource permissions.

**Why do we need this feature?**

The restriction was a temporary scaffolding measure while the users API was only consumed by access-policy identities (CAPs). With MTEA, authenticated user identities also need to reach this API through the gateway (e.g. `users/~` for the current-user profile). The resource authorizer already enforces the correct permissions, so the identity-type gate is redundant.

**Which issue(s) does this PR fix?**

Part of https://github.com/grafana/identity-access-team/issues/2189