### PR TITLE
Query Editor: Replace setTimeout scroll hack with a resize-aware pin to the new expression row

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.test.tsx
@@ -22,6 +22,7 @@ import { selectors } from '@grafana/e2e-selectors';
 import { config } from '@grafana/runtime';
 import { contextSrv } from 'app/core/services/context_srv';
 import { PANEL_EDIT_LAST_USED_DATASOURCE } from 'app/features/dashboard/utils/dashboard';
+import { ExpressionQueryType } from 'app/features/expressions/types';
 import { SHARED_DASHBOARD_QUERY, DASHBOARD_DATASOURCE_PLUGIN_ID } from 'app/plugins/datasource/dashboard/constants';
 import { type DashboardDataDTO } from 'app/types/dashboard';
 
@@ -392,6 +393,16 @@ describe('PanelDataQueriesTab', () => {
       expect(queriesTab.queryRunner.state.queries[1].refId).toBe('B');
       expect(queriesTab.queryRunner.state.queries[1].hide).toBe(false);
       expect(queriesTab.queryRunner.state.queries[1].datasource?.uid).toBe('gdev-testdata');
+    });
+
+    it('returns the refId of a newly added expression, so callers can scroll to it', async () => {
+      const { queriesTab } = await setupScene('panel-1');
+
+      const refId = queriesTab.onAddExpressionOfType(ExpressionQueryType.sql);
+
+      const queries = queriesTab.queryRunner.state.queries;
+      expect(refId).toBe('B');
+      expect(queries[queries.length - 1].refId).toBe('B');
     });
   });
 

--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.tsx
@@ -51,6 +51,8 @@ interface PanelDataQueriesTabState extends SceneObjectState {
   datasource?: DataSourceApi;
   dsSettings?: DataSourceInstanceSettings;
   panelRef: SceneObjectRef<VizPanel>;
+  /** refId of a query row to scroll into view once it renders; cleared after the scroll happens. */
+  scrollToRefId?: string;
 }
 export class PanelDataQueriesTab extends SceneObjectBase<PanelDataQueriesTabState> implements PanelDataPaneTab {
   static Component = PanelDataQueriesTabRendered;
@@ -325,7 +327,7 @@ export class PanelDataQueriesTab extends SceneObjectBase<PanelDataQueriesTabStat
     return (dsSettings.meta.backend || dsSettings.meta.alerting || dsSettings.meta.mixed) === true;
   }
 
-  public onAddExpressionOfType = (type: ExpressionQueryType) => {
+  public onAddExpressionOfType = (type: ExpressionQueryType): string => {
     const queries = this.getQueries();
     // Create base expression query with the specified type
     const baseQuery = expressionDatasource.newQuery();
@@ -333,7 +335,10 @@ export class PanelDataQueriesTab extends SceneObjectBase<PanelDataQueriesTabStat
     // Apply defaults specific to the expression type
     const queryWithDefaults = getDefaults(queryWithType);
 
-    this.onQueriesChange(addQuery(queries, queryWithDefaults));
+    const newQueries = addQuery(queries, queryWithDefaults);
+    this.onQueriesChange(newQueries);
+
+    return newQueries[newQueries.length - 1].refId;
   };
 
   public renderExtraActions() {
@@ -369,7 +374,7 @@ export class PanelDataQueriesTab extends SceneObjectBase<PanelDataQueriesTabStat
 }
 
 export function PanelDataQueriesTabRendered({ model }: SceneComponentProps<PanelDataQueriesTab>) {
-  const { datasource, dsSettings } = model.useState();
+  const { datasource, dsSettings, scrollToRefId } = model.useState();
   const { data, queries, datasource: datasourceState } = model.queryRunner.useState();
   const { openDrawer: openQueryLibraryDrawer, queryLibraryEnabled } = useQueryLibraryContext();
   const canReadQueries = config.featureToggles.savedQueriesRBAC
@@ -387,6 +392,10 @@ export function PanelDataQueriesTabRendered({ model }: SceneComponentProps<Panel
     },
     [model]
   );
+
+  const handleScrollIntoView = useCallback(() => {
+    model.setState({ scrollToRefId: undefined });
+  }, [model]);
 
   // Determine which expressions should be disabled (for frontend-only datasources)
   const disabledExpressions = useMemo(() => {
@@ -454,6 +463,8 @@ export function PanelDataQueriesTabRendered({ model }: SceneComponentProps<Panel
         onUpdateDatasources={queryLibraryEnabled ? model.updateDatasourceIfNeeded : undefined}
         app={CoreApp.PanelEditor}
         panelRef={model.state.panelRef}
+        scrollToRefId={scrollToRefId}
+        onScrollIntoView={handleScrollIntoView}
       />
 
       <Stack gap={2}>

--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataTransformationsTab.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataTransformationsTab.tsx
@@ -28,9 +28,7 @@ import { PanelDataPane } from './PanelDataPane';
 import { PanelDataQueriesTab } from './PanelDataQueriesTab';
 import { TransformationsDrawer } from './TransformationsDrawer';
 import { type PanelDataPaneTab, type PanelDataTabHeaderProps, TabId } from './types';
-import { scrollToQueryRow } from './utils';
 
-const SET_TIMEOUT = 750;
 const reportTransformationEditInteraction = throttle((context: string, type: string) => {
   reportInteraction('grafana_panel_transformations_clicked', {
     context,
@@ -111,22 +109,12 @@ export function PanelDataTransformationsTabRendered({ model }: SceneComponentPro
     }
 
     // Always create a new SQL expression (it will be added to the end of the queries array)
-    queriesTab.onAddExpressionOfType(ExpressionQueryType.sql);
+    const refId = queriesTab.onAddExpressionOfType(ExpressionQueryType.sql);
 
-    // Navigate to the Queries tab
+    // Navigate to the Queries tab. The tab renders asynchronously (datasource loading),
+    // so the new query row scrolls itself into view once it appears, driven by this state.
     parent.onChangeTab(queriesTab);
-
-    // Scroll to the newly created SQL query after tab renders
-    setTimeout(() => {
-      const queries = queriesTab.getQueries();
-      // The newly added query is the last one in the array
-      if (queries.length > 0) {
-        const newQuery = queries[queries.length - 1];
-        if (newQuery?.refId) {
-          scrollToQueryRow(newQuery.refId);
-        }
-      }
-    }, SET_TIMEOUT);
+    queriesTab.setState({ scrollToRefId: refId });
   }, [model]);
 
   const onAddTransformation = useCallback(

--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/utils.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/utils.ts
@@ -2,22 +2,6 @@ import { getDataSourceSrv } from '@grafana/runtime';
 import { type DataQuery } from '@grafana/schema';
 import { SHARED_DASHBOARD_QUERY } from 'app/plugins/datasource/dashboard/constants';
 
-export function scrollToQueryRow(refId: string) {
-  // Query rows use uniqueId(refId + '_') for their internal id
-  // The aria-controls attribute will be like "A_1" for refId "A"
-  // So we need to search for aria-controls starting with "refId_"
-  const queryRowHeader = document.querySelector(`[aria-controls^="${refId}_"]`);
-
-  if (queryRowHeader) {
-    // Find the parent query row wrapper
-    const queryRow = queryRowHeader.closest('[data-testid="query-editor-row"]');
-
-    if (queryRow instanceof HTMLElement) {
-      queryRow.scrollIntoView({ behavior: 'smooth', block: 'start' });
-    }
-  }
-}
-
 function isBackendDatasource(uid: string): boolean {
   if (uid === SHARED_DASHBOARD_QUERY) {
     return false;

--- a/public/app/features/query/components/QueryEditorRow.test.tsx
+++ b/public/app/features/query/components/QueryEditorRow.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { type PropsWithChildren } from 'react';
 
 import { CoreApp, type DataQueryRequest, dateTime, LoadingState, type PanelData, toDataFrame } from '@grafana/data';
@@ -8,6 +8,13 @@ import { mockDataSource } from 'app/features/alerting/unified/mocks';
 import { ExpressionDatasourceUID } from 'app/features/expressions/types';
 
 import { filterPanelDataToQuery, type Props, QueryEditorRow } from './QueryEditorRow';
+import { pinScrollIntoView } from './pinScrollIntoView';
+
+// Spy on the pin helper while keeping its real behavior, so tests can assert how often a pin starts.
+jest.mock('./pinScrollIntoView', () => {
+  const actual = jest.requireActual('./pinScrollIntoView');
+  return { ...actual, pinScrollIntoView: jest.fn(actual.pinScrollIntoView) };
+});
 
 const mockDS = mockDataSource({
   name: 'test',
@@ -437,6 +444,72 @@ describe('QueryEditorRow', () => {
     render(<QueryEditorRow {...props(data)} />);
     await waitFor(() => {
       expect(screen.queryByText('Error!!')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('scroll into view', () => {
+    let scrollIntoViewSpy: jest.Mock;
+    let originalScrollIntoView: typeof HTMLElement.prototype.scrollIntoView;
+
+    const data: PanelData = {
+      state: LoadingState.Done,
+      series: [],
+      timeRange: { from: dateTime(), to: dateTime(), raw: { from: 'now-1d', to: 'now' } },
+    };
+
+    beforeEach(() => {
+      // jsdom doesn't implement scrollIntoView, so patch the prototype rather than spy on it.
+      originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+      scrollIntoViewSpy = jest.fn();
+      HTMLElement.prototype.scrollIntoView = scrollIntoViewSpy;
+      jest.mocked(pinScrollIntoView).mockClear();
+    });
+
+    afterEach(() => {
+      HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
+    });
+
+    it('scrolls the row into view once it renders (after the datasource loads)', async () => {
+      render(<QueryEditorRow {...props(data)} scrollIntoView />);
+
+      // The row renders nothing until its datasource resolves, so the scroll must wait for that.
+      // The jest-setup ResizeObserver mock may fire an extra re-pin, so assert on the first
+      // (deliberate) call rather than the total count.
+      await waitFor(() => expect(scrollIntoViewSpy).toHaveBeenCalled());
+      expect(scrollIntoViewSpy.mock.instances[0]).toBe(screen.getByTestId(selectors.components.QueryEditorRows.rows));
+      expect(scrollIntoViewSpy).toHaveBeenNthCalledWith(1, { behavior: 'smooth', block: 'start' });
+    });
+
+    it('keeps pinning after the scroll and reports back when the user takes over', async () => {
+      const onScrollIntoView = jest.fn();
+      render(<QueryEditorRow {...props(data)} scrollIntoView onScrollIntoView={onScrollIntoView} />);
+
+      await waitFor(() => expect(scrollIntoViewSpy).toHaveBeenCalled());
+      // The row stays pinned until the layout settles or the user scrolls, so the flag isn't
+      // cleared right after the first scroll.
+      expect(onScrollIntoView).not.toHaveBeenCalled();
+
+      fireEvent.wheel(window);
+
+      expect(onScrollIntoView).toHaveBeenCalledTimes(1);
+    });
+
+    it('starts the pin only once, even as the row keeps re-rendering', async () => {
+      const initialProps = props(data);
+      const { rerender } = render(<QueryEditorRow {...initialProps} scrollIntoView />);
+      await waitFor(() => expect(scrollIntoViewSpy).toHaveBeenCalled());
+
+      rerender(<QueryEditorRow {...initialProps} scrollIntoView data={{ ...data }} />);
+
+      expect(pinScrollIntoView).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not scroll when the flag is not set', async () => {
+      render(<QueryEditorRow {...props(data)} />);
+
+      await waitFor(() => expect(screen.getByTestId(selectors.components.QueryEditorRows.rows)).toBeInTheDocument());
+
+      expect(scrollIntoViewSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -44,6 +44,7 @@ import { type QueryActionComponent, RowActionComponents } from './QueryActionCom
 import { QueryEditorRowHeader } from './QueryEditorRowHeader';
 import { QueryErrorAlert } from './QueryErrorAlert';
 import { QueryLibraryEditingContainer } from './QueryLibraryEditingContainer';
+import { pinScrollIntoView } from './pinScrollIntoView';
 
 export interface Props<TQuery extends DataQuery> {
   data: PanelData;
@@ -82,6 +83,14 @@ export interface Props<TQuery extends DataQuery> {
    * Required to resolve section-scoped (row/tab) datasource variables
    */
   scopedVars?: ScopedVars;
+  /**
+   * When true, scrolls the row into view once it first renders. The row renders nothing until its
+   * datasource loads, so the scroll fires whenever the DOM node actually appears rather than after
+   * a fixed delay.
+   */
+  scrollIntoView?: boolean;
+  /** Called after the scroll happens so the owner can clear the flag. */
+  onScrollIntoView?: () => void;
 }
 
 interface State<TQuery extends DataQuery> {
@@ -98,6 +107,8 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
   dataSourceSrv = getDataSourceSrv();
   id = '';
   editorRef = createRef<HTMLDivElement>();
+  private hasStartedScrollIntoView = false;
+  private cancelScrollPin?: () => void;
 
   state: State<TQuery> = {
     datasource: null,
@@ -113,6 +124,23 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
     this.setState({ data: dataFilteredByRefId });
 
     this.loadDatasource();
+    this.scrollIntoViewIfNeeded();
+  }
+
+  private scrollIntoViewIfNeeded() {
+    if (this.props.scrollIntoView && !this.hasStartedScrollIntoView && this.editorRef.current) {
+      this.hasStartedScrollIntoView = true;
+      // A single scroll is not enough: the other rows' editors load asynchronously and push this
+      // row away as they grow, so keep it pinned until the layout settles or the user scrolls.
+      this.cancelScrollPin = pinScrollIntoView(this.editorRef.current, () => {
+        this.cancelScrollPin = undefined;
+        this.props.onScrollIntoView?.();
+      });
+    }
+  }
+
+  componentWillUnmount() {
+    this.cancelScrollPin?.();
   }
 
   /**
@@ -166,6 +194,8 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
 
       this.setState({ data: dataFilteredByRefId });
     }
+
+    this.scrollIntoViewIfNeeded();
 
     // check if we need to load another datasource
     if (datasource && queriedDataSourceIdentifier !== this.getInterpolatedDataSourceUID()) {

--- a/public/app/features/query/components/QueryEditorRows.tsx
+++ b/public/app/features/query/components/QueryEditorRows.tsx
@@ -50,6 +50,10 @@ export interface Props {
   onCancelQueryLibraryEdit?: () => void;
   isOpen?: boolean;
   panelRef?: SceneObjectRef<VizPanel>;
+  /** refId of a row to scroll into view once it renders (e.g. a freshly added query). */
+  scrollToRefId?: string;
+  /** Called after the row identified by scrollToRefId has been scrolled into view. */
+  onScrollIntoView?: () => void;
 }
 
 export class QueryEditorRows extends PureComponent<Props> {
@@ -253,6 +257,8 @@ export class QueryEditorRows extends PureComponent<Props> {
       onCancelQueryLibraryEdit,
       isOpen,
       panelRef,
+      scrollToRefId,
+      onScrollIntoView,
     } = this.props;
 
     // Scene scope for resolving section-scoped (row/tab) datasource variables, which live on a
@@ -302,6 +308,8 @@ export class QueryEditorRows extends PureComponent<Props> {
                       queryLibraryRef={queryLibraryRef}
                       onCancelQueryLibraryEdit={onCancelQueryLibraryEdit}
                       isOpen={isOpen}
+                      scrollIntoView={scrollToRefId !== undefined && query.refId === scrollToRefId}
+                      onScrollIntoView={onScrollIntoView}
                     />
                   );
 

--- a/public/app/features/query/components/pinScrollIntoView.test.ts
+++ b/public/app/features/query/components/pinScrollIntoView.test.ts
@@ -1,0 +1,167 @@
+import { pinScrollIntoView, SCROLL_PIN_SETTLE_MS } from './pinScrollIntoView';
+
+class MockResizeObserver implements ResizeObserver {
+  static instances: MockResizeObserver[] = [];
+
+  observedTargets: Element[] = [];
+  disconnected = false;
+
+  constructor(public callback: ResizeObserverCallback) {
+    MockResizeObserver.instances.push(this);
+  }
+
+  observe(target: Element) {
+    this.observedTargets.push(target);
+  }
+
+  disconnect() {
+    this.disconnected = true;
+  }
+
+  unobserve() {}
+}
+
+describe('pinScrollIntoView', () => {
+  let scrollIntoViewSpy: jest.Mock;
+  let originalScrollIntoView: typeof HTMLElement.prototype.scrollIntoView;
+  let originalResizeObserver: typeof ResizeObserver;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    // jsdom doesn't implement scrollIntoView, so patch the prototype rather than spy on it.
+    originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+    scrollIntoViewSpy = jest.fn();
+    HTMLElement.prototype.scrollIntoView = scrollIntoViewSpy;
+
+    originalResizeObserver = global.ResizeObserver;
+    MockResizeObserver.instances = [];
+    global.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver;
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
+    global.ResizeObserver = originalResizeObserver;
+  });
+
+  function setup() {
+    const parent = document.createElement('div');
+    const element = document.createElement('div');
+    parent.appendChild(element);
+    document.body.appendChild(parent);
+
+    const onDone = jest.fn();
+    const cancel = pinScrollIntoView(element, onDone);
+    const observer = MockResizeObserver.instances[0];
+
+    return {
+      element,
+      parent,
+      onDone,
+      cancel,
+      observer,
+      // Simulates a ResizeObserver callback reporting the observed target at `height`. jsdom's
+      // getBoundingClientRect returns 0, so the baseline height measured at pin start is 0.
+      fireResize: (height: number) => observer.callback([{ contentRect: { height } } as ResizeObserverEntry], observer),
+    };
+  }
+
+  it('scrolls the element into view immediately, animating the deliberate navigation', () => {
+    const { element, parent, observer } = setup();
+
+    expect(scrollIntoViewSpy).toHaveBeenCalledTimes(1);
+    expect(scrollIntoViewSpy.mock.instances[0]).toBe(element);
+    expect(scrollIntoViewSpy).toHaveBeenCalledWith({ behavior: 'smooth', block: 'start' });
+    // Observes the parent: siblings growing change the parent's size, not the element's.
+    expect(observer.observedTargets).toEqual([parent]);
+  });
+
+  it('ignores observations where the height has not changed, so the animation is not cut short by no-op re-pins', () => {
+    const { fireResize } = setup();
+
+    // ResizeObserver's initial observation right after observe(), with nothing grown yet.
+    fireResize(0);
+
+    expect(scrollIntoViewSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-pins on the initial observation when content already grew in the same frame (cached editors on a re-add)', () => {
+    const { element, fireResize } = setup();
+
+    fireResize(300);
+
+    expect(scrollIntoViewSpy).toHaveBeenCalledTimes(2);
+    expect(scrollIntoViewSpy.mock.instances[1]).toBe(element);
+    // Smooth, so the correction re-targets the in-flight animation instead of jump-cutting.
+    expect(scrollIntoViewSpy).toHaveBeenLastCalledWith({ behavior: 'smooth', block: 'start' });
+  });
+
+  it('re-pins as the surrounding content keeps growing', () => {
+    const { element, fireResize } = setup();
+
+    fireResize(100);
+    fireResize(200);
+
+    expect(scrollIntoViewSpy).toHaveBeenCalledTimes(3);
+    expect(scrollIntoViewSpy.mock.instances[2]).toBe(element);
+    expect(scrollIntoViewSpy).toHaveBeenLastCalledWith({ behavior: 'smooth', block: 'start' });
+  });
+
+  it('does not re-pin when consecutive observations report the same height', () => {
+    const { fireResize } = setup();
+
+    fireResize(100);
+    fireResize(100);
+
+    expect(scrollIntoViewSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('reports done once the layout stays quiet for the settle window', () => {
+    const { onDone, observer } = setup();
+
+    jest.advanceTimersByTime(SCROLL_PIN_SETTLE_MS - 1);
+    expect(onDone).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(1);
+    expect(onDone).toHaveBeenCalledTimes(1);
+    expect(observer.disconnected).toBe(true);
+  });
+
+  it('restarts the settle window on every height change', () => {
+    const { onDone, fireResize } = setup();
+
+    fireResize(100);
+    jest.advanceTimersByTime(SCROLL_PIN_SETTLE_MS - 1);
+    fireResize(200);
+    jest.advanceTimersByTime(SCROLL_PIN_SETTLE_MS - 1);
+    expect(onDone).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(1);
+    expect(onDone).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops pinning and reports done on the first user scroll gesture', () => {
+    const { onDone, observer } = setup();
+
+    window.dispatchEvent(new Event('wheel'));
+
+    expect(onDone).toHaveBeenCalledTimes(1);
+    expect(observer.disconnected).toBe(true);
+
+    // The settle timer must not report done a second time.
+    jest.advanceTimersByTime(SCROLL_PIN_SETTLE_MS);
+    expect(onDone).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancel stops pinning without reporting done', () => {
+    const { onDone, cancel, observer } = setup();
+
+    cancel();
+
+    jest.advanceTimersByTime(SCROLL_PIN_SETTLE_MS);
+    window.dispatchEvent(new Event('wheel'));
+
+    expect(onDone).not.toHaveBeenCalled();
+    expect(observer.disconnected).toBe(true);
+  });
+});

--- a/public/app/features/query/components/pinScrollIntoView.ts
+++ b/public/app/features/query/components/pinScrollIntoView.ts
@@ -1,0 +1,76 @@
+/**
+ * How long the layout must stay quiet (no resizes) before the pinned element is considered
+ * settled. Exported for tests.
+ */
+export const SCROLL_PIN_SETTLE_MS = 1500;
+
+/**
+ * Scrolls an element into view and keeps it pinned there while surrounding content finishes
+ * loading. A single scroll is not enough when siblings render asynchronously (e.g. query rows
+ * loading their datasource editors): content above the element grows after the scroll and pushes
+ * it away, leaving the viewport at a stale offset.
+ *
+ * Re-pinning is driven by a ResizeObserver on the element's parent and ends — calling `onDone` —
+ * once the layout has been quiet for a settle window, or immediately on the first user scroll
+ * gesture, so we never fight deliberate navigation.
+ *
+ * Returns a cancel function that stops pinning without calling `onDone` (for unmount).
+ */
+export function pinScrollIntoView(element: HTMLElement, onDone?: () => void): () => void {
+  element.scrollIntoView({ behavior: 'smooth', block: 'start' });
+
+  let settleTimer: ReturnType<typeof setTimeout> | undefined;
+  let resizeObserver: ResizeObserver | undefined;
+
+  const stop = () => {
+    clearTimeout(settleTimer);
+    resizeObserver?.disconnect();
+    window.removeEventListener('wheel', onUserScroll);
+    window.removeEventListener('touchmove', onUserScroll);
+  };
+
+  const finish = () => {
+    stop();
+    onDone?.();
+  };
+
+  // User-intent events only — not 'scroll', which our own programmatic scrolls would trigger.
+  const onUserScroll = () => finish();
+
+  const restartSettleTimer = () => {
+    clearTimeout(settleTimer);
+    settleTimer = setTimeout(finish, SCROLL_PIN_SETTLE_MS);
+  };
+
+  restartSettleTimer();
+
+  const content = element.parentElement;
+  if (content && typeof ResizeObserver !== 'undefined') {
+    // Re-pin only on actual height changes, comparing against the height measured at pin start.
+    // ResizeObserver reports an initial observation right after observe(): when content already
+    // grew in that same frame (cached editors loading instantly on a re-add), the comparison lets
+    // that first callback correct the scroll; otherwise it's a no-op that leaves the animation
+    // alone.
+    let lastHeight = content.getBoundingClientRect().height;
+    resizeObserver = new ResizeObserver((entries) => {
+      const entry = entries[entries.length - 1];
+      const height = entry.borderBoxSize?.[0]?.blockSize ?? entry.contentRect.height;
+      if (height === lastHeight) {
+        return;
+      }
+      lastHeight = height;
+      // Smooth re-pins re-target the in-flight animation from the current position, so the
+      // navigation stays one continuous glide chasing the row instead of jump-cutting to it.
+      // The chase may briefly lag behind fast growth, but the settle window bounds it and the
+      // last re-pin always lands on the final position.
+      element.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      restartSettleTimer();
+    });
+    resizeObserver.observe(content);
+  }
+
+  window.addEventListener('wheel', onUserScroll, { passive: true });
+  window.addEventListener('touchmove', onUserScroll, { passive: true });
+
+  return stop;
+}


### PR DESCRIPTION
## Description
When adding a SQL expression from the Transformations tab's "Go to queries" action, the panel editor switched to the Queries tab and scrolled to the newly created row after a hard-coded 750ms `setTimeout`. This delay was a guess: too short and the scroll silently did nothing (which was already the case in practice, since two DOM selectors the old code relied on had drifted since the feature launched), too long and the UI feels sluggish. This PR replaces the timeout with a robust, event-driven scroll that reacts to the row actually rendering, rather than hoping a fixed delay was enough.

## Changes
* `PanelDataQueriesTab`: `onAddExpressionOfType` now returns the new query's `refId`; added `scrollToRefId` scene state, cleared once the scroll completes.
* `PanelDataTransformationsTab.onGoToQueries`: removed the `setTimeout`/`SET_TIMEOUT` block; sets `scrollToRefId` on the queries tab instead.
* `QueryEditorRows` / `QueryEditorRow`: threaded `scrollToRefId` down to the matching row via new `scrollIntoView` / `onScrollIntoView` props. The row starts pinning once it actually renders (it renders `null` until its datasource loads, so this fires whenever that resolves, not after a guessed delay).
* New `pinScrollIntoView` helper (`public/app/features/query/components/pinScrollIntoView.ts`): scrolls the row into view and keeps it pinned there via a `ResizeObserver` on its parent, re-scrolling (smoothly, re-targeting the in-flight animation) whenever the container's height actually changes — this compensates for other query rows' datasource editors loading and growing asynchronously above it. Pinning ends, calling back to clear `scrollToRefId`, once the layout is quiet for 1.5s or the user manually scrolls (`wheel`/`touchmove`), so it never fights deliberate navigation.
* `dashboard-scene/panel-edit/PanelDataPane/utils.ts`: removed the now-dead `scrollToQueryRow` helper, which relied on `aria-controls` and `data-testid` selectors that no longer match the current DOM (confirmed via git history — both had drifted after later refactors).
* Added/updated tests: `pinScrollIntoView.test.ts` (new), `QueryEditorRow.test.tsx`, `PanelDataQueriesTab.test.tsx`.

## Risks
* Behavioral change to `QueryEditorRow` and `QueryEditorRows` props (new optional `scrollIntoView`/`onScrollIntoView`/`scrollToRefId` props) — additive and opt-in, so existing callers are unaffected.
* `pinScrollIntoView` adds a `ResizeObserver` and two `window`-level `wheel`/`touchmove` listeners for the duration of the pin (bounded to ≤1.5s of layout quiet, or ended immediately on user scroll); both are removed via a cleanup function and on component unmount.
* Relies on `ResizeObserver`, which is broadly supported in all target browsers; the code degrades gracefully (skips re-pinning, but still performs the initial scroll) if unavailable.
* Only exercised in the old panel editor's "go to queries" flow (SQL expression creation from the Transformations tab) — low blast radius.

## Testing Instructions
* Open a panel with at least 2-3 queries using a datasource with a non-trivial editor (e.g. Prometheus).
* Go to the Transformations tab, click "Go to queries" (or the equivalent SQL-expression entry point) to add a SQL expression.
* Confirm the view scrolls smoothly to the new SQL expression row and lands there, even while the other rows' editors are still loading in above it.
* Remove the SQL expression and re-add it; confirm the scroll still lands correctly (this was the case that exposed the original ResizeObserver initial-observation gap).
* Scroll manually mid-animation; confirm the pin releases immediately rather than fighting your scroll.

## Reviewer Checklist
- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable