### PR TITLE
Auth: use legacy database provider for session token store

### DIFF
--- a/pkg/server/bootstrap/wire/wire_gen.go
+++ b/pkg/server/bootstrap/wire/wire_gen.go
@@ -599,7 +599,7 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts server.Options, apiO
 		return nil, err
 	}
 	authinfoimplService := authinfoimpl.ProvideService(loginStore, remoteCache, secretsService)
-	userAuthTokenService, err := authimpl.ProvideUserAuthTokenService(ctx, sqlStore, serverLockService, quotaService, secretsService, configProvider, tracingService, featureToggles)
+	userAuthTokenService, err := authimpl.ProvideUserAuthTokenService(ctx, legacyDatabaseProvider, serverLockService, quotaService, secretsService, configProvider, tracingService, featureToggles)
 	if err != nil {
 		return nil, err
 	}
@@ -1394,7 +1394,7 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 	pluginInstaller := manager4.ProvideInstaller(pluginManagementCfg, inMemory, loaderLoader, repoManager, serviceregistrationService, acimplService)
 	ossProvider := guardian.ProvideGuardian()
 	cacheServiceImpl := service6.ProvideCacheService(cacheService, sqlStore, ossProvider)
-	userAuthTokenService, err := authimpl.ProvideUserAuthTokenService(ctx, sqlStore, serverLockService, quotaService, secretsService, configProvider, tracingService, featureToggles)
+	userAuthTokenService, err := authimpl.ProvideUserAuthTokenService(ctx, legacyDatabaseProvider, serverLockService, quotaService, secretsService, configProvider, tracingService, featureToggles)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/auth/authimpl/auth_token.go
+++ b/pkg/services/auth/authimpl/auth_token.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"net"
-	"strings"
 	"time"
 
 	"github.com/open-feature/go-sdk/openfeature"
@@ -25,6 +24,8 @@ import (
 	"github.com/grafana/grafana/pkg/services/quota"
 	"github.com/grafana/grafana/pkg/services/secrets"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/storage/legacysql"
+	"github.com/grafana/grafana/pkg/storage/unified/sql/sqltemplate"
 	"github.com/grafana/grafana/pkg/util"
 )
 
@@ -38,14 +39,14 @@ const SkipRotationTime = 5 * time.Second
 
 var _ auth.UserTokenService = (*UserAuthTokenService)(nil)
 
-func ProvideUserAuthTokenService(ctx context.Context, sqlStore db.DB,
+func ProvideUserAuthTokenService(ctx context.Context, sql legacysql.LegacyDatabaseProvider,
 	serverLockService *serverlock.ServerLockService,
 	quotaService quota.Service, secretService secrets.Service, //nolint:staticcheck // SA1019: Legacy envelope encryption for single-tenant feature
 	cfgProvider configprovider.ConfigProvider, tracer tracing.Tracer,
 	features featuremgmt.FeatureToggles,
 ) (*UserAuthTokenService, error) {
 	s := &UserAuthTokenService{
-		sqlStore:          sqlStore,
+		sql:               sql,
 		serverLockService: serverLockService,
 		cfgProvider:       cfgProvider,
 		log:               log.New("auth"),
@@ -54,7 +55,7 @@ func ProvideUserAuthTokenService(ctx context.Context, sqlStore db.DB,
 		tracer:            tracer,
 	}
 
-	s.externalSessionStore = provideExternalSessionStore(sqlStore, secretService, tracer)
+	s.externalSessionStore = provideExternalSessionStore(sql, secretService, tracer)
 
 	cfg, err := cfgProvider.Get(ctx)
 	if err != nil {
@@ -77,7 +78,8 @@ func ProvideUserAuthTokenService(ctx context.Context, sqlStore db.DB,
 }
 
 type UserAuthTokenService struct {
-	sqlStore             db.DB
+	// sql resolves qualified table names and the shared database.
+	sql                  legacysql.LegacyDatabaseProvider
 	serverLockService    *serverlock.ServerLockService
 	cfgProvider          configprovider.ConfigProvider
 	log                  log.Logger
@@ -121,7 +123,12 @@ func (s *UserAuthTokenService) CreateToken(ctx context.Context, cmd *auth.Create
 		AuthTokenSeen: false,
 	}
 
-	err = s.sqlStore.InTransaction(ctx, func(ctx context.Context) error {
+	dbHelper, err := s.sql(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	err = dbHelper.DB.InTransaction(ctx, func(ctx context.Context) error {
 		if cmd.ExternalSession != nil {
 			inErr := s.externalSessionStore.Create(ctx, cmd.ExternalSession)
 			if inErr != nil {
@@ -130,8 +137,8 @@ func (s *UserAuthTokenService) CreateToken(ctx context.Context, cmd *auth.Create
 			userAuthToken.ExternalSessionId = cmd.ExternalSession.ID
 		}
 
-		inErr := s.sqlStore.WithDbSession(ctx, func(dbSession *db.Session) error {
-			_, err := dbSession.Insert(&userAuthToken)
+		inErr := dbHelper.DB.WithDbSession(ctx, func(dbSession *db.Session) error {
+			_, err := dbSession.Table(dbHelper.Table("user_auth_token")).Insert(&userAuthToken)
 			return err
 		})
 		return inErr
@@ -160,13 +167,19 @@ func (s *UserAuthTokenService) LookupToken(ctx context.Context, unhashedToken st
 		return nil, err
 	}
 
+	dbHelper, err := s.sql(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	hashedToken := hashToken(cfg.SecretKey, unhashedToken)
 	var model userAuthToken
 	var exists bool
-	err = s.sqlStore.WithDbSession(ctx, func(dbSession *db.Session) error {
-		exists, err = dbSession.Where("(auth_token = ? OR prev_auth_token = ?)",
-			hashedToken,
-			hashedToken).
+	err = dbHelper.DB.WithDbSession(ctx, func(dbSession *db.Session) error {
+		exists, err = dbSession.Table(dbHelper.Table("user_auth_token")).
+			Where("(auth_token = ? OR prev_auth_token = ?)",
+				hashedToken,
+				hashedToken).
 			Get(&model)
 
 		return err
@@ -206,11 +219,12 @@ func (s *UserAuthTokenService) LookupToken(ctx context.Context, unhashedToken st
 		model.RotatedAt = getTime().Add(-usertoken.UrgentRotateTime).Unix()
 
 		var affectedRows int64
-		err = s.sqlStore.WithTransactionalDbSession(ctx, func(dbSession *db.Session) error {
-			affectedRows, err = dbSession.Where("id = ? AND prev_auth_token = ? AND rotated_at < ?",
-				model.Id,
-				model.PrevAuthToken,
-				model.RotatedAt).
+		err = dbHelper.DB.WithTransactionalDbSession(ctx, func(dbSession *db.Session) error {
+			affectedRows, err = dbSession.Table(dbHelper.Table("user_auth_token")).
+				Where("id = ? AND prev_auth_token = ? AND rotated_at < ?",
+					model.Id,
+					model.PrevAuthToken,
+					model.RotatedAt).
 				AllCols().Update(&model)
 
 			return err
@@ -242,10 +256,11 @@ func (s *UserAuthTokenService) LookupToken(ctx context.Context, unhashedToken st
 		model.SeenAt = getTime().Unix()
 
 		var affectedRows int64
-		err = s.sqlStore.WithTransactionalDbSession(ctx, func(dbSession *db.Session) error {
-			affectedRows, err = dbSession.Where("id = ? AND auth_token = ?",
-				model.Id,
-				model.AuthToken).
+		err = dbHelper.DB.WithTransactionalDbSession(ctx, func(dbSession *db.Session) error {
+			affectedRows, err = dbSession.Table(dbHelper.Table("user_auth_token")).
+				Where("id = ? AND auth_token = ?",
+					model.Id,
+					model.AuthToken).
 				AllCols().Update(&model)
 
 			return err
@@ -273,9 +288,15 @@ func (s *UserAuthTokenService) GetTokenByExternalSessionID(ctx context.Context, 
 	ctx, span := s.tracer.Start(ctx, "authtoken.GetTokenByExternalSessionID")
 	defer span.End()
 
+	dbHelper, err := s.sql(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	var token userAuthToken
-	err := s.sqlStore.WithDbSession(ctx, func(dbSession *db.Session) error {
-		exists, err := dbSession.Where("external_session_id = ?", externalSessionID).Get(&token)
+	err = dbHelper.DB.WithDbSession(ctx, func(dbSession *db.Session) error {
+		exists, err := dbSession.Table(dbHelper.Table("user_auth_token")).
+			Where("external_session_id = ?", externalSessionID).Get(&token)
 		if err != nil {
 			return err
 		}
@@ -357,8 +378,13 @@ func (s *UserAuthTokenService) RotateToken(ctx context.Context, cmd auth.RotateC
 	}
 
 	res, err, _ := s.singleflight.Do(cmd.UnHashedToken, func() (any, error) {
+		dbHelper, err := s.sql(ctx)
+		if err != nil {
+			return nil, err
+		}
+
 		var token *auth.UserToken
-		err := s.sqlStore.InTransaction(ctx, func(ctx context.Context) error {
+		err = dbHelper.DB.InTransaction(ctx, func(ctx context.Context) error {
 			var err error
 			token, err = rotate(ctx)
 			return err
@@ -372,6 +398,19 @@ func (s *UserAuthTokenService) RotateToken(ctx context.Context, cmd auth.RotateC
 
 	return res.(*auth.UserToken), nil
 }
+
+type rotateTokenQuery struct {
+	sqltemplate.SQLTemplate
+	TokenTable    string
+	UserAgent     string
+	ClientIP      string
+	AuthToken     string
+	AuthTokenSeen any
+	RotatedAt     int64
+	TokenID       int64
+}
+
+func (q rotateTokenQuery) Validate() error { return nil }
 
 func (s *UserAuthTokenService) rotateToken(ctx context.Context, token *auth.UserToken, clientIP net.IP, userAgent string) (*auth.UserToken, error) {
 	ctx, span := s.tracer.Start(ctx, "authtoken.rotateToken")
@@ -392,23 +431,30 @@ func (s *UserAuthTokenService) rotateToken(ctx context.Context, token *auth.User
 		return nil, err
 	}
 
-	sql := `
-		UPDATE user_auth_token
-		SET
-			seen_at = 0,
-			user_agent = ?,
-			client_ip = ?,
-			prev_auth_token = auth_token,
-			auth_token = ?,
-			auth_token_seen = ?,
-			rotated_at = ?
-		WHERE id = ?
-	`
+	dbHelper, err := s.sql(ctx)
+	if err != nil {
+		return nil, err
+	}
 
 	now := getTime()
+	query := rotateTokenQuery{
+		SQLTemplate:   sqltemplate.New(dbHelper.DialectForDriver()),
+		TokenTable:    dbHelper.Table("user_auth_token"),
+		UserAgent:     userAgent,
+		ClientIP:      clientIPStr,
+		AuthToken:     hashedToken,
+		AuthTokenSeen: dbHelper.DB.GetDialect().BooleanValue(false),
+		RotatedAt:     now.Unix(),
+		TokenID:       token.Id,
+	}
+	rawSQL, err := sqltemplate.Execute(rotateTokenTemplate, query)
+	if err != nil {
+		return nil, err
+	}
+
 	var affected int64
-	err = s.sqlStore.WithDbSession(ctx, func(dbSession *db.Session) error {
-		res, err := dbSession.Exec(sql, userAgent, clientIPStr, hashedToken, s.sqlStore.GetDialect().BooleanValue(false), now.Unix(), token.Id)
+	err = dbHelper.DB.WithDbSession(ctx, func(dbSession *db.Session) error {
+		res, err := dbSession.Exec(append([]any{rawSQL}, query.GetArgs()...)...)
 		if err != nil {
 			return err
 		}
@@ -446,19 +492,24 @@ func (s *UserAuthTokenService) RevokeToken(ctx context.Context, token *auth.User
 		return err
 	}
 
+	dbHelper, err := s.sql(ctx)
+	if err != nil {
+		return err
+	}
+
 	ctxLogger := s.log.FromContext(ctx)
 
 	var rowsAffected int64
 
 	if soft {
 		model.RevokedAt = getTime().Unix()
-		err = s.sqlStore.WithDbSession(ctx, func(dbSession *db.Session) error {
-			rowsAffected, err = dbSession.ID(model.Id).Update(model)
+		err = dbHelper.DB.WithDbSession(ctx, func(dbSession *db.Session) error {
+			rowsAffected, err = dbSession.Table(dbHelper.Table("user_auth_token")).ID(model.Id).Update(model)
 			return err
 		})
 	} else {
-		err = s.sqlStore.WithDbSession(ctx, func(dbSession *db.Session) error {
-			rowsAffected, err = dbSession.Delete(model)
+		err = dbHelper.DB.WithDbSession(ctx, func(dbSession *db.Session) error {
+			rowsAffected, err = dbSession.Table(dbHelper.Table("user_auth_token")).Delete(model)
 			return err
 		})
 	}
@@ -485,15 +536,37 @@ func (s *UserAuthTokenService) RevokeToken(ctx context.Context, token *auth.User
 	return nil
 }
 
+type revokeAllUserTokensQuery struct {
+	sqltemplate.SQLTemplate
+	TokenTable string
+	UserID     int64
+}
+
+func (q revokeAllUserTokensQuery) Validate() error { return nil }
+
 func (s *UserAuthTokenService) RevokeAllUserTokens(ctx context.Context, userId int64) error {
 	ctx, span := s.tracer.Start(ctx, "authtoken.RevokeAllUserTokens")
 	defer span.End()
 
-	return s.sqlStore.InTransaction(ctx, func(ctx context.Context) error {
+	dbHelper, err := s.sql(ctx)
+	if err != nil {
+		return err
+	}
+
+	return dbHelper.DB.InTransaction(ctx, func(ctx context.Context) error {
 		ctxLogger := s.log.FromContext(ctx)
-		err := s.sqlStore.WithDbSession(ctx, func(dbSession *db.Session) error {
-			sql := `DELETE from user_auth_token WHERE user_id = ?`
-			res, err := dbSession.Exec(sql, userId)
+		err := dbHelper.DB.WithDbSession(ctx, func(dbSession *db.Session) error {
+			query := revokeAllUserTokensQuery{
+				SQLTemplate: sqltemplate.New(dbHelper.DialectForDriver()),
+				TokenTable:  dbHelper.Table("user_auth_token"),
+				UserID:      userId,
+			}
+			rawSQL, err := sqltemplate.Execute(revokeAllUserTokensTemplate, query)
+			if err != nil {
+				return err
+			}
+
+			res, err := dbSession.Exec(append([]any{rawSQL}, query.GetArgs()...)...)
 			if err != nil {
 				return err
 			}
@@ -520,28 +593,43 @@ func (s *UserAuthTokenService) RevokeAllUserTokens(ctx context.Context, userId i
 	})
 }
 
+type batchRevokeAllUserTokensQuery struct {
+	sqltemplate.SQLTemplate
+	TokenTable string
+	UserIDs    []int64
+}
+
+func (q batchRevokeAllUserTokensQuery) Validate() error { return nil }
+
 func (s *UserAuthTokenService) BatchRevokeAllUserTokens(ctx context.Context, userIds []int64) error {
 	ctx, span := s.tracer.Start(ctx, "authtoken.BatchRevokeAllUserTokens")
 	defer span.End()
 
-	return s.sqlStore.InTransaction(ctx, func(ctx context.Context) error {
+	dbHelper, err := s.sql(ctx)
+	if err != nil {
+		return err
+	}
+
+	return dbHelper.DB.InTransaction(ctx, func(ctx context.Context) error {
 		ctxLogger := s.log.FromContext(ctx)
 		if len(userIds) == 0 {
 			return nil
 		}
 
-		userIdParams := strings.Repeat(",?", len(userIds)-1)
-		sql := "DELETE from user_auth_token WHERE user_id IN (?" + userIdParams + ")"
-
-		params := []any{sql}
-		for _, v := range userIds {
-			params = append(params, v)
-		}
-
 		var affected int64
 
-		err := s.sqlStore.WithDbSession(ctx, func(dbSession *db.Session) error {
-			res, inErr := dbSession.Exec(params...)
+		err := dbHelper.DB.WithDbSession(ctx, func(dbSession *db.Session) error {
+			query := batchRevokeAllUserTokensQuery{
+				SQLTemplate: sqltemplate.New(dbHelper.DialectForDriver()),
+				TokenTable:  dbHelper.Table("user_auth_token"),
+				UserIDs:     userIds,
+			}
+			rawSQL, err := sqltemplate.Execute(batchRevokeAllUserTokensTemplate, query)
+			if err != nil {
+				return err
+			}
+
+			res, inErr := dbSession.Exec(append([]any{rawSQL}, query.GetArgs()...)...)
 			if inErr != nil {
 				return inErr
 			}
@@ -568,10 +656,16 @@ func (s *UserAuthTokenService) GetUserToken(ctx context.Context, userId, userTok
 	ctx, span := s.tracer.Start(ctx, "authtoken.GetUserToken")
 	defer span.End()
 
+	dbHelper, err := s.sql(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	var result auth.UserToken
-	err := s.sqlStore.WithDbSession(ctx, func(dbSession *db.Session) error {
+	err = dbHelper.DB.WithDbSession(ctx, func(dbSession *db.Session) error {
 		var token userAuthToken
-		exists, err := dbSession.Where("id = ? AND user_id = ?", userTokenId, userId).Get(&token)
+		exists, err := dbSession.Table(dbHelper.Table("user_auth_token")).
+			Where("id = ? AND user_id = ?", userTokenId, userId).Get(&token)
 		if err != nil {
 			return err
 		}
@@ -595,13 +689,19 @@ func (s *UserAuthTokenService) GetUserTokens(ctx context.Context, userId int64) 
 		return nil, err
 	}
 
+	dbHelper, err := s.sql(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	result := []*auth.UserToken{}
-	err = s.sqlStore.WithDbSession(ctx, func(dbSession *db.Session) error {
+	err = dbHelper.DB.WithDbSession(ctx, func(dbSession *db.Session) error {
 		var tokens []*userAuthToken
-		err := dbSession.Where("user_id = ? AND created_at > ? AND rotated_at > ? AND revoked_at = 0",
-			userId,
-			s.createdAfterParam(cfg),
-			s.rotatedAfterParam(cfg)).
+		err := dbSession.Table(dbHelper.Table("user_auth_token")).
+			Where("user_id = ? AND created_at > ? AND rotated_at > ? AND revoked_at = 0",
+				userId,
+				s.createdAfterParam(cfg),
+				s.rotatedAfterParam(cfg)).
 			Find(&tokens)
 		if err != nil {
 			return err
@@ -621,6 +721,17 @@ func (s *UserAuthTokenService) GetUserTokens(ctx context.Context, userId int64) 
 	return result, err
 }
 
+type activeTokenCountQuery struct {
+	sqltemplate.SQLTemplate
+	TokenTable   string
+	CreatedAfter int64
+	RotatedAfter int64
+	FilterByUser bool
+	UserID       int64
+}
+
+func (q activeTokenCountQuery) Validate() error { return nil }
+
 // ActiveTokenCount returns the number of active tokens. If userID is nil, the count is for all users.
 func (s *UserAuthTokenService) ActiveTokenCount(ctx context.Context, userID *int64) (int64, error) {
 	ctx, span := s.tracer.Start(ctx, "authtoken.ActiveTokenCount")
@@ -635,28 +746,66 @@ func (s *UserAuthTokenService) ActiveTokenCount(ctx context.Context, userID *int
 		return 0, err
 	}
 
+	dbHelper, err := s.sql(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	query := activeTokenCountQuery{
+		SQLTemplate:  sqltemplate.New(dbHelper.DialectForDriver()),
+		TokenTable:   dbHelper.Table("user_auth_token"),
+		CreatedAfter: s.createdAfterParam(cfg),
+		RotatedAfter: s.rotatedAfterParam(cfg),
+	}
+	if userID != nil {
+		query.FilterByUser = true
+		query.UserID = *userID
+	}
+	rawSQL, err := sqltemplate.Execute(activeTokenCountTemplate, query)
+	if err != nil {
+		return 0, err
+	}
+
 	var count int64
-	err = s.sqlStore.WithDbSession(ctx, func(dbSession *db.Session) error {
-		query := `SELECT COUNT(*) FROM user_auth_token WHERE created_at > ? AND rotated_at > ? AND revoked_at = 0`
-		args := []interface{}{s.createdAfterParam(cfg), s.rotatedAfterParam(cfg)}
-		if userID != nil {
-			query += " AND user_id = ?"
-			args = append(args, *userID)
-		}
-		_, err := dbSession.SQL(query, args...).Get(&count)
+	err = dbHelper.DB.WithDbSession(ctx, func(dbSession *db.Session) error {
+		_, err := dbSession.SQL(rawSQL, query.GetArgs()...).Get(&count)
 		return err
 	})
 
 	return count, err
 }
 
+type deleteUserRevokedTokensQuery struct {
+	sqltemplate.SQLTemplate
+	TokenTable    string
+	UserID        int64
+	RevokedBefore int64
+}
+
+func (q deleteUserRevokedTokensQuery) Validate() error { return nil }
+
 func (s *UserAuthTokenService) DeleteUserRevokedTokens(ctx context.Context, userID int64, window time.Duration) error {
 	ctx, span := s.tracer.Start(ctx, "authtoken.DeleteUserRevokedTokens")
 	defer span.End()
 
-	return s.sqlStore.WithDbSession(ctx, func(sess *db.Session) error {
-		query := "DELETE FROM user_auth_token WHERE user_id = ? AND revoked_at > 0 AND revoked_at <= ?"
-		res, err := sess.Exec(query, userID, time.Now().Add(-window).Unix())
+	dbHelper, err := s.sql(ctx)
+	if err != nil {
+		return err
+	}
+
+	return dbHelper.DB.WithDbSession(ctx, func(sess *db.Session) error {
+		query := deleteUserRevokedTokensQuery{
+			SQLTemplate:   sqltemplate.New(dbHelper.DialectForDriver()),
+			TokenTable:    dbHelper.Table("user_auth_token"),
+			UserID:        userID,
+			RevokedBefore: time.Now().Add(-window).Unix(),
+		}
+		rawSQL, err := sqltemplate.Execute(deleteUserRevokedTokensTemplate, query)
+		if err != nil {
+			return err
+		}
+
+		res, err := sess.Exec(append([]any{rawSQL}, query.GetArgs()...)...)
 		if err != nil {
 			return err
 		}
@@ -675,10 +824,16 @@ func (s *UserAuthTokenService) GetUserRevokedTokens(ctx context.Context, userId 
 	ctx, span := s.tracer.Start(ctx, "authtoken.GetUserRevokedTokens")
 	defer span.End()
 
+	dbHelper, err := s.sql(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	result := []*auth.UserToken{}
-	err := s.sqlStore.WithDbSession(ctx, func(dbSession *db.Session) error {
+	err = dbHelper.DB.WithDbSession(ctx, func(dbSession *db.Session) error {
 		var tokens []*userAuthToken
-		err := dbSession.Where("user_id = ? AND revoked_at > 0", userId).Asc("seen_at").Find(&tokens)
+		err := dbSession.Table(dbHelper.Table("user_auth_token")).
+			Where("user_id = ? AND revoked_at > 0", userId).Asc("seen_at").Find(&tokens)
 		if err != nil {
 			return err
 		}

--- a/pkg/services/auth/authimpl/auth_token_test.go
+++ b/pkg/services/auth/authimpl/auth_token_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/secrets/fakes"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/storage/legacysql"
 	"github.com/grafana/grafana/pkg/tests/testsuite"
 	"github.com/grafana/grafana/pkg/util/testutil"
 )
@@ -888,13 +889,14 @@ func createTestContext(t *testing.T) *testContext {
 		TokenRotationIntervalMinutes: 10,
 	}
 
-	extSessionStore := provideExternalSessionStore(sqlstore, &fakes.FakeSecretsService{}, tracer)
+	sqlProvider := legacysql.NewDatabaseProvider(sqlstore)
+	extSessionStore := provideExternalSessionStore(sqlProvider, &fakes.FakeSecretsService{}, tracer)
 
 	cfgProvider, err := configprovider.ProvideService(cfg)
 	require.NoError(t, err)
 
 	tokenService := &UserAuthTokenService{
-		sqlStore:             sqlstore,
+		sql:                  sqlProvider,
 		cfgProvider:          cfgProvider,
 		log:                  log.New("test-logger"),
 		singleflight:         new(singleflight.Group),

--- a/pkg/services/auth/authimpl/external_session_store.go
+++ b/pkg/services/auth/authimpl/external_session_store.go
@@ -9,22 +9,24 @@ import (
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/auth"
 	"github.com/grafana/grafana/pkg/services/secrets"
+	"github.com/grafana/grafana/pkg/storage/legacysql"
 )
 
 var _ auth.ExternalSessionStore = (*store)(nil)
 
 type store struct {
-	sqlStore       db.DB
+	// sql resolves qualified table names and the shared database.
+	sql            legacysql.LegacyDatabaseProvider
 	secretsService secrets.Service //nolint:staticcheck // SA1019: Legacy envelope encryption for single-tenant feature
 	tracer         tracing.Tracer
 }
 
-func provideExternalSessionStore(sqlStore db.DB,
+func provideExternalSessionStore(sql legacysql.LegacyDatabaseProvider,
 	secretService secrets.Service, //nolint:staticcheck // SA1019: Legacy envelope encryption for single-tenant feature
 	tracer tracing.Tracer,
 ) auth.ExternalSessionStore {
 	return &store{
-		sqlStore:       sqlStore,
+		sql:            sql,
 		secretsService: secretService,
 		tracer:         tracer,
 	}
@@ -34,10 +36,15 @@ func (s *store) Get(ctx context.Context, ID int64) (*auth.ExternalSession, error
 	ctx, span := s.tracer.Start(ctx, "externalsession.Get")
 	defer span.End()
 
+	dbHelper, err := s.sql(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	externalSession := &auth.ExternalSession{ID: ID}
 
-	err := s.sqlStore.WithDbSession(ctx, func(sess *db.Session) error {
-		found, err := sess.Get(externalSession)
+	err = dbHelper.DB.WithDbSession(ctx, func(sess *db.Session) error {
+		found, err := sess.Table(dbHelper.Table("user_external_session")).Get(externalSession)
 		if err != nil {
 			return err
 		}
@@ -87,9 +94,14 @@ func (s *store) List(ctx context.Context, query *auth.ListExternalSessionQuery) 
 		externalSession.NameIDHash = base64.RawStdEncoding.EncodeToString(hash.Sum(nil))
 	}
 
+	dbHelper, err := s.sql(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	queryResult := make([]*auth.ExternalSession, 0)
-	err := s.sqlStore.WithDbSession(ctx, func(sess *db.Session) error {
-		return sess.Desc("id").Find(&queryResult, externalSession)
+	err = dbHelper.DB.WithDbSession(ctx, func(sess *db.Session) error {
+		return sess.Table(dbHelper.Table("user_external_session")).Desc("id").Find(&queryResult, externalSession)
 	})
 	if err != nil {
 		return nil, err
@@ -148,8 +160,13 @@ func (s *store) Create(ctx context.Context, extSession *auth.ExternalSession) er
 		return err
 	}
 
-	err = s.sqlStore.WithDbSession(ctx, func(sess *db.Session) error {
-		_, err := sess.Insert(clone)
+	dbHelper, err := s.sql(ctx)
+	if err != nil {
+		return err
+	}
+
+	err = dbHelper.DB.WithDbSession(ctx, func(sess *db.Session) error {
+		_, err := sess.Table(dbHelper.Table("user_external_session")).Insert(clone)
 		return err
 	})
 	if err != nil {
@@ -187,8 +204,13 @@ func (s *store) Update(ctx context.Context, ID int64, cmd *auth.UpdateExternalSe
 
 	externalSession.ExpiresAt = cmd.Token.Expiry
 
-	err = s.sqlStore.WithDbSession(ctx, func(sess *db.Session) error {
-		_, err := sess.ID(ID).Cols("access_token", "refresh_token", "id_token", "expires_at").Update(externalSession)
+	dbHelper, err := s.sql(ctx)
+	if err != nil {
+		return err
+	}
+
+	err = dbHelper.DB.WithDbSession(ctx, func(sess *db.Session) error {
+		_, err := sess.Table(dbHelper.Table("user_external_session")).ID(ID).Cols("access_token", "refresh_token", "id_token", "expires_at").Update(externalSession)
 		return err
 	})
 	if err != nil {
@@ -202,9 +224,14 @@ func (s *store) Delete(ctx context.Context, ID int64) error {
 	ctx, span := s.tracer.Start(ctx, "externalsession.Delete")
 	defer span.End()
 
+	dbHelper, err := s.sql(ctx)
+	if err != nil {
+		return err
+	}
+
 	externalSession := &auth.ExternalSession{ID: ID}
-	err := s.sqlStore.WithDbSession(ctx, func(sess *db.Session) error {
-		_, err := sess.Delete(externalSession)
+	err = dbHelper.DB.WithDbSession(ctx, func(sess *db.Session) error {
+		_, err := sess.Table(dbHelper.Table("user_external_session")).Delete(externalSession)
 		return err
 	})
 	return err
@@ -214,9 +241,14 @@ func (s *store) DeleteExternalSessionsByUserID(ctx context.Context, userID int64
 	ctx, span := s.tracer.Start(ctx, "externalsession.DeleteExternalSessionsByUserID")
 	defer span.End()
 
+	dbHelper, err := s.sql(ctx)
+	if err != nil {
+		return err
+	}
+
 	externalSession := &auth.ExternalSession{UserID: userID}
-	err := s.sqlStore.WithDbSession(ctx, func(sess *db.Session) error {
-		_, err := sess.Delete(externalSession)
+	err = dbHelper.DB.WithDbSession(ctx, func(sess *db.Session) error {
+		_, err := sess.Table(dbHelper.Table("user_external_session")).Delete(externalSession)
 		return err
 	})
 	return err
@@ -226,9 +258,14 @@ func (s *store) BatchDeleteExternalSessionsByUserIDs(ctx context.Context, userID
 	ctx, span := s.tracer.Start(ctx, "externalsession.BatchDeleteExternalSessionsByUserIDs")
 	defer span.End()
 
+	dbHelper, err := s.sql(ctx)
+	if err != nil {
+		return err
+	}
+
 	externalSession := &auth.ExternalSession{}
-	err := s.sqlStore.WithDbSession(ctx, func(sess *db.Session) error {
-		_, err := sess.In("user_id", userIDs).Delete(externalSession)
+	err = dbHelper.DB.WithDbSession(ctx, func(sess *db.Session) error {
+		_, err := sess.Table(dbHelper.Table("user_external_session")).In("user_id", userIDs).Delete(externalSession)
 		return err
 	})
 	return err

--- a/pkg/services/auth/authimpl/external_session_store_test.go
+++ b/pkg/services/auth/authimpl/external_session_store_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/auth"
 	"github.com/grafana/grafana/pkg/services/secrets/fakes"
+	"github.com/grafana/grafana/pkg/storage/legacysql"
 	"github.com/grafana/grafana/pkg/util/testutil"
 	"github.com/stretchr/testify/require"
 )
@@ -213,6 +214,6 @@ func setupTest(t *testing.T) *store {
 	sqlStore := db.InitTestDB(t)
 	secretService := fakes.NewFakeSecretsService()
 	tracer := tracing.InitializeTracerForTest()
-	externalSessionStore := provideExternalSessionStore(sqlStore, secretService, tracer).(*store)
+	externalSessionStore := provideExternalSessionStore(legacysql.NewDatabaseProvider(sqlStore), secretService, tracer).(*store)
 	return externalSessionStore
 }

--- a/pkg/services/auth/authimpl/queries/active_token_count.sql
+++ b/pkg/services/auth/authimpl/queries/active_token_count.sql
@@ -1,0 +1,8 @@
+SELECT COUNT(*)
+FROM {{ .Ident .TokenTable }}
+WHERE created_at > {{ .Arg .CreatedAfter }}
+  AND rotated_at > {{ .Arg .RotatedAfter }}
+  AND revoked_at = 0
+{{ if .FilterByUser }}
+  AND user_id = {{ .Arg .UserID }}
+{{ end }}

--- a/pkg/services/auth/authimpl/queries/batch_revoke_all_user_tokens.sql
+++ b/pkg/services/auth/authimpl/queries/batch_revoke_all_user_tokens.sql
@@ -1,0 +1,2 @@
+DELETE FROM {{ .Ident .TokenTable }}
+WHERE user_id IN ({{ .ArgList .UserIDs }})

--- a/pkg/services/auth/authimpl/queries/delete_expired_tokens.sql
+++ b/pkg/services/auth/authimpl/queries/delete_expired_tokens.sql
@@ -1,0 +1,3 @@
+DELETE FROM {{ .Ident .TokenTable }}
+WHERE created_at <= {{ .Arg .CreatedBefore }}
+   OR rotated_at <= {{ .Arg .RotatedBefore }}

--- a/pkg/services/auth/authimpl/queries/delete_orphaned_external_sessions.sql
+++ b/pkg/services/auth/authimpl/queries/delete_orphaned_external_sessions.sql
@@ -1,0 +1,6 @@
+DELETE FROM {{ .Ident .ExternalSessionTable }}
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM {{ .Ident .TokenTable }}
+  WHERE {{ .Ident .ExternalSessionTable }}.id = {{ .Ident .TokenTable }}.external_session_id
+)

--- a/pkg/services/auth/authimpl/queries/delete_user_revoked_tokens.sql
+++ b/pkg/services/auth/authimpl/queries/delete_user_revoked_tokens.sql
@@ -1,0 +1,4 @@
+DELETE FROM {{ .Ident .TokenTable }}
+WHERE user_id = {{ .Arg .UserID }}
+  AND revoked_at > 0
+  AND revoked_at <= {{ .Arg .RevokedBefore }}

--- a/pkg/services/auth/authimpl/queries/revoke_all_user_tokens.sql
+++ b/pkg/services/auth/authimpl/queries/revoke_all_user_tokens.sql
@@ -1,0 +1,2 @@
+DELETE FROM {{ .Ident .TokenTable }}
+WHERE user_id = {{ .Arg .UserID }}

--- a/pkg/services/auth/authimpl/queries/rotate_token.sql
+++ b/pkg/services/auth/authimpl/queries/rotate_token.sql
@@ -1,0 +1,10 @@
+UPDATE {{ .Ident .TokenTable }}
+SET
+  seen_at = 0,
+  user_agent = {{ .Arg .UserAgent }},
+  client_ip = {{ .Arg .ClientIP }},
+  prev_auth_token = auth_token,
+  auth_token = {{ .Arg .AuthToken }},
+  auth_token_seen = {{ .Arg .AuthTokenSeen }},
+  rotated_at = {{ .Arg .RotatedAt }}
+WHERE id = {{ .Arg .TokenID }}

--- a/pkg/services/auth/authimpl/templates.go
+++ b/pkg/services/auth/authimpl/templates.go
@@ -1,0 +1,33 @@
+package authimpl
+
+import (
+	"embed"
+	"fmt"
+	"text/template"
+)
+
+// Templates setup.
+var (
+	//go:embed queries/*.sql
+	sqlTemplatesFS embed.FS
+
+	sqlTemplates = template.Must(template.New("sql").ParseFS(sqlTemplatesFS, `queries/*.sql`))
+)
+
+func mustTemplate(filename string) *template.Template {
+	if t := sqlTemplates.Lookup(filename); t != nil {
+		return t
+	}
+	panic(fmt.Sprintf("template file not found: %s", filename))
+}
+
+// Templates.
+var (
+	rotateTokenTemplate                    = mustTemplate("rotate_token.sql")
+	revokeAllUserTokensTemplate            = mustTemplate("revoke_all_user_tokens.sql")
+	batchRevokeAllUserTokensTemplate       = mustTemplate("batch_revoke_all_user_tokens.sql")
+	activeTokenCountTemplate               = mustTemplate("active_token_count.sql")
+	deleteUserRevokedTokensTemplate        = mustTemplate("delete_user_revoked_tokens.sql")
+	deleteExpiredTokensTemplate            = mustTemplate("delete_expired_tokens.sql")
+	deleteOrphanedExternalSessionsTemplate = mustTemplate("delete_orphaned_external_sessions.sql")
+)

--- a/pkg/services/auth/authimpl/templates_test.go
+++ b/pkg/services/auth/authimpl/templates_test.go
@@ -1,0 +1,155 @@
+package authimpl
+
+import (
+	"testing"
+	"text/template"
+
+	"github.com/grafana/grafana/pkg/storage/legacysql"
+	"github.com/grafana/grafana/pkg/storage/unified/sql/sqltemplate"
+	"github.com/grafana/grafana/pkg/storage/unified/sql/sqltemplate/mocks"
+)
+
+func TestTemplates(t *testing.T) {
+	// nodb resolves schema-qualified identifiers so the snapshots prove
+	// .Ident quotes each component correctly for every dialect.
+	nodb := &legacysql.LegacyDatabaseHelper{
+		Table: func(n string) string {
+			return "test_schema." + n
+		},
+	}
+
+	getRotateToken := func() sqltemplate.SQLTemplate {
+		v := rotateTokenQuery{
+			SQLTemplate:   sqltemplate.New(nodb.DialectForDriver()),
+			TokenTable:    nodb.Table("user_auth_token"),
+			UserAgent:     "some-user-agent",
+			ClientIP:      "10.0.0.1",
+			AuthToken:     "hashed-token",
+			AuthTokenSeen: false,
+			RotatedAt:     1700000000,
+			TokenID:       42,
+		}
+		v.SQLTemplate = mocks.NewTestingSQLTemplate()
+		return &v
+	}
+
+	getRevokeAllUserTokens := func() sqltemplate.SQLTemplate {
+		v := revokeAllUserTokensQuery{
+			SQLTemplate: sqltemplate.New(nodb.DialectForDriver()),
+			TokenTable:  nodb.Table("user_auth_token"),
+			UserID:      10,
+		}
+		v.SQLTemplate = mocks.NewTestingSQLTemplate()
+		return &v
+	}
+
+	getBatchRevokeAllUserTokens := func() sqltemplate.SQLTemplate {
+		v := batchRevokeAllUserTokensQuery{
+			SQLTemplate: sqltemplate.New(nodb.DialectForDriver()),
+			TokenTable:  nodb.Table("user_auth_token"),
+			UserIDs:     []int64{10, 11, 12},
+		}
+		v.SQLTemplate = mocks.NewTestingSQLTemplate()
+		return &v
+	}
+
+	getActiveTokenCount := func(filterByUser bool) sqltemplate.SQLTemplate {
+		v := activeTokenCountQuery{
+			SQLTemplate:  sqltemplate.New(nodb.DialectForDriver()),
+			TokenTable:   nodb.Table("user_auth_token"),
+			CreatedAfter: 1600000000,
+			RotatedAfter: 1650000000,
+		}
+		if filterByUser {
+			v.FilterByUser = true
+			v.UserID = 10
+		}
+		v.SQLTemplate = mocks.NewTestingSQLTemplate()
+		return &v
+	}
+
+	getDeleteUserRevokedTokens := func() sqltemplate.SQLTemplate {
+		v := deleteUserRevokedTokensQuery{
+			SQLTemplate:   sqltemplate.New(nodb.DialectForDriver()),
+			TokenTable:    nodb.Table("user_auth_token"),
+			UserID:        10,
+			RevokedBefore: 1700000000,
+		}
+		v.SQLTemplate = mocks.NewTestingSQLTemplate()
+		return &v
+	}
+
+	getDeleteExpiredTokens := func() sqltemplate.SQLTemplate {
+		v := deleteExpiredTokensQuery{
+			SQLTemplate:   sqltemplate.New(nodb.DialectForDriver()),
+			TokenTable:    nodb.Table("user_auth_token"),
+			CreatedBefore: 1600000000,
+			RotatedBefore: 1650000000,
+		}
+		v.SQLTemplate = mocks.NewTestingSQLTemplate()
+		return &v
+	}
+
+	getDeleteOrphanedExternalSessions := func() sqltemplate.SQLTemplate {
+		v := deleteOrphanedExternalSessionsQuery{
+			SQLTemplate:          sqltemplate.New(nodb.DialectForDriver()),
+			ExternalSessionTable: nodb.Table("user_external_session"),
+			TokenTable:           nodb.Table("user_auth_token"),
+		}
+		v.SQLTemplate = mocks.NewTestingSQLTemplate()
+		return &v
+	}
+
+	mocks.CheckQuerySnapshots(t, mocks.TemplateTestSetup{
+		RootDir:        "testdata",
+		SQLTemplatesFS: sqlTemplatesFS,
+		Templates: map[*template.Template][]mocks.TemplateTestCase{
+			rotateTokenTemplate: {
+				{
+					Name: "rotate_token",
+					Data: getRotateToken(),
+				},
+			},
+			revokeAllUserTokensTemplate: {
+				{
+					Name: "revoke_all_user_tokens",
+					Data: getRevokeAllUserTokens(),
+				},
+			},
+			batchRevokeAllUserTokensTemplate: {
+				{
+					Name: "batch_revoke_all_user_tokens",
+					Data: getBatchRevokeAllUserTokens(),
+				},
+			},
+			activeTokenCountTemplate: {
+				{
+					Name: "all_users",
+					Data: getActiveTokenCount(false),
+				},
+				{
+					Name: "single_user",
+					Data: getActiveTokenCount(true),
+				},
+			},
+			deleteUserRevokedTokensTemplate: {
+				{
+					Name: "delete_user_revoked_tokens",
+					Data: getDeleteUserRevokedTokens(),
+				},
+			},
+			deleteExpiredTokensTemplate: {
+				{
+					Name: "delete_expired_tokens",
+					Data: getDeleteExpiredTokens(),
+				},
+			},
+			deleteOrphanedExternalSessionsTemplate: {
+				{
+					Name: "delete_orphaned_external_sessions",
+					Data: getDeleteOrphanedExternalSessions(),
+				},
+			},
+		},
+	})
+}

--- a/pkg/services/auth/authimpl/testdata/mysql--active_token_count-all_users.sql
+++ b/pkg/services/auth/authimpl/testdata/mysql--active_token_count-all_users.sql
@@ -1,0 +1,5 @@
+SELECT COUNT(*)
+FROM `test_schema`.`user_auth_token`
+WHERE created_at > 1600000000
+  AND rotated_at > 1650000000
+  AND revoked_at = 0

--- a/pkg/services/auth/authimpl/testdata/mysql--active_token_count-single_user.sql
+++ b/pkg/services/auth/authimpl/testdata/mysql--active_token_count-single_user.sql
@@ -1,0 +1,6 @@
+SELECT COUNT(*)
+FROM `test_schema`.`user_auth_token`
+WHERE created_at > 1600000000
+  AND rotated_at > 1650000000
+  AND revoked_at = 0
+  AND user_id = 10

--- a/pkg/services/auth/authimpl/testdata/mysql--batch_revoke_all_user_tokens-batch_revoke_all_user_tokens.sql
+++ b/pkg/services/auth/authimpl/testdata/mysql--batch_revoke_all_user_tokens-batch_revoke_all_user_tokens.sql
@@ -1,0 +1,2 @@
+DELETE FROM `test_schema`.`user_auth_token`
+WHERE user_id IN (10, 11, 12)

--- a/pkg/services/auth/authimpl/testdata/mysql--delete_expired_tokens-delete_expired_tokens.sql
+++ b/pkg/services/auth/authimpl/testdata/mysql--delete_expired_tokens-delete_expired_tokens.sql
@@ -1,0 +1,3 @@
+DELETE FROM `test_schema`.`user_auth_token`
+WHERE created_at <= 1600000000
+   OR rotated_at <= 1650000000

--- a/pkg/services/auth/authimpl/testdata/mysql--delete_orphaned_external_sessions-delete_orphaned_external_sessions.sql
+++ b/pkg/services/auth/authimpl/testdata/mysql--delete_orphaned_external_sessions-delete_orphaned_external_sessions.sql
@@ -1,0 +1,6 @@
+DELETE FROM `test_schema`.`user_external_session`
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM `test_schema`.`user_auth_token`
+  WHERE `test_schema`.`user_external_session`.id = `test_schema`.`user_auth_token`.external_session_id
+)

--- a/pkg/services/auth/authimpl/testdata/mysql--delete_user_revoked_tokens-delete_user_revoked_tokens.sql
+++ b/pkg/services/auth/authimpl/testdata/mysql--delete_user_revoked_tokens-delete_user_revoked_tokens.sql
@@ -1,0 +1,4 @@
+DELETE FROM `test_schema`.`user_auth_token`
+WHERE user_id = 10
+  AND revoked_at > 0
+  AND revoked_at <= 1700000000

--- a/pkg/services/auth/authimpl/testdata/mysql--revoke_all_user_tokens-revoke_all_user_tokens.sql
+++ b/pkg/services/auth/authimpl/testdata/mysql--revoke_all_user_tokens-revoke_all_user_tokens.sql
@@ -1,0 +1,2 @@
+DELETE FROM `test_schema`.`user_auth_token`
+WHERE user_id = 10

--- a/pkg/services/auth/authimpl/testdata/mysql--rotate_token-rotate_token.sql
+++ b/pkg/services/auth/authimpl/testdata/mysql--rotate_token-rotate_token.sql
@@ -1,0 +1,10 @@
+UPDATE `test_schema`.`user_auth_token`
+SET
+  seen_at = 0,
+  user_agent = 'some-user-agent',
+  client_ip = '10.0.0.1',
+  prev_auth_token = auth_token,
+  auth_token = 'hashed-token',
+  auth_token_seen = FALSE,
+  rotated_at = 1700000000
+WHERE id = 42

--- a/pkg/services/auth/authimpl/testdata/postgres--active_token_count-all_users.sql
+++ b/pkg/services/auth/authimpl/testdata/postgres--active_token_count-all_users.sql
@@ -1,0 +1,5 @@
+SELECT COUNT(*)
+FROM "test_schema"."user_auth_token"
+WHERE created_at > 1600000000
+  AND rotated_at > 1650000000
+  AND revoked_at = 0

--- a/pkg/services/auth/authimpl/testdata/postgres--active_token_count-single_user.sql
+++ b/pkg/services/auth/authimpl/testdata/postgres--active_token_count-single_user.sql
@@ -1,0 +1,6 @@
+SELECT COUNT(*)
+FROM "test_schema"."user_auth_token"
+WHERE created_at > 1600000000
+  AND rotated_at > 1650000000
+  AND revoked_at = 0
+  AND user_id = 10

--- a/pkg/services/auth/authimpl/testdata/postgres--batch_revoke_all_user_tokens-batch_revoke_all_user_tokens.sql
+++ b/pkg/services/auth/authimpl/testdata/postgres--batch_revoke_all_user_tokens-batch_revoke_all_user_tokens.sql
@@ -1,0 +1,2 @@
+DELETE FROM "test_schema"."user_auth_token"
+WHERE user_id IN (10, 11, 12)

--- a/pkg/services/auth/authimpl/testdata/postgres--delete_expired_tokens-delete_expired_tokens.sql
+++ b/pkg/services/auth/authimpl/testdata/postgres--delete_expired_tokens-delete_expired_tokens.sql
@@ -1,0 +1,3 @@
+DELETE FROM "test_schema"."user_auth_token"
+WHERE created_at <= 1600000000
+   OR rotated_at <= 1650000000

--- a/pkg/services/auth/authimpl/testdata/postgres--delete_orphaned_external_sessions-delete_orphaned_external_sessions.sql
+++ b/pkg/services/auth/authimpl/testdata/postgres--delete_orphaned_external_sessions-delete_orphaned_external_sessions.sql
@@ -1,0 +1,6 @@
+DELETE FROM "test_schema"."user_external_session"
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM "test_schema"."user_auth_token"
+  WHERE "test_schema"."user_external_session".id = "test_schema"."user_auth_token".external_session_id
+)

--- a/pkg/services/auth/authimpl/testdata/postgres--delete_user_revoked_tokens-delete_user_revoked_tokens.sql
+++ b/pkg/services/auth/authimpl/testdata/postgres--delete_user_revoked_tokens-delete_user_revoked_tokens.sql
@@ -1,0 +1,4 @@
+DELETE FROM "test_schema"."user_auth_token"
+WHERE user_id = 10
+  AND revoked_at > 0
+  AND revoked_at <= 1700000000

--- a/pkg/services/auth/authimpl/testdata/postgres--revoke_all_user_tokens-revoke_all_user_tokens.sql
+++ b/pkg/services/auth/authimpl/testdata/postgres--revoke_all_user_tokens-revoke_all_user_tokens.sql
@@ -1,0 +1,2 @@
+DELETE FROM "test_schema"."user_auth_token"
+WHERE user_id = 10

--- a/pkg/services/auth/authimpl/testdata/postgres--rotate_token-rotate_token.sql
+++ b/pkg/services/auth/authimpl/testdata/postgres--rotate_token-rotate_token.sql
@@ -1,0 +1,10 @@
+UPDATE "test_schema"."user_auth_token"
+SET
+  seen_at = 0,
+  user_agent = 'some-user-agent',
+  client_ip = '10.0.0.1',
+  prev_auth_token = auth_token,
+  auth_token = 'hashed-token',
+  auth_token_seen = FALSE,
+  rotated_at = 1700000000
+WHERE id = 42

--- a/pkg/services/auth/authimpl/testdata/sqlite--active_token_count-all_users.sql
+++ b/pkg/services/auth/authimpl/testdata/sqlite--active_token_count-all_users.sql
@@ -1,0 +1,5 @@
+SELECT COUNT(*)
+FROM "test_schema"."user_auth_token"
+WHERE created_at > 1600000000
+  AND rotated_at > 1650000000
+  AND revoked_at = 0

--- a/pkg/services/auth/authimpl/testdata/sqlite--active_token_count-single_user.sql
+++ b/pkg/services/auth/authimpl/testdata/sqlite--active_token_count-single_user.sql
@@ -1,0 +1,6 @@
+SELECT COUNT(*)
+FROM "test_schema"."user_auth_token"
+WHERE created_at > 1600000000
+  AND rotated_at > 1650000000
+  AND revoked_at = 0
+  AND user_id = 10

--- a/pkg/services/auth/authimpl/testdata/sqlite--batch_revoke_all_user_tokens-batch_revoke_all_user_tokens.sql
+++ b/pkg/services/auth/authimpl/testdata/sqlite--batch_revoke_all_user_tokens-batch_revoke_all_user_tokens.sql
@@ -1,0 +1,2 @@
+DELETE FROM "test_schema"."user_auth_token"
+WHERE user_id IN (10, 11, 12)

--- a/pkg/services/auth/authimpl/testdata/sqlite--delete_expired_tokens-delete_expired_tokens.sql
+++ b/pkg/services/auth/authimpl/testdata/sqlite--delete_expired_tokens-delete_expired_tokens.sql
@@ -1,0 +1,3 @@
+DELETE FROM "test_schema"."user_auth_token"
+WHERE created_at <= 1600000000
+   OR rotated_at <= 1650000000

--- a/pkg/services/auth/authimpl/testdata/sqlite--delete_orphaned_external_sessions-delete_orphaned_external_sessions.sql
+++ b/pkg/services/auth/authimpl/testdata/sqlite--delete_orphaned_external_sessions-delete_orphaned_external_sessions.sql
@@ -1,0 +1,6 @@
+DELETE FROM "test_schema"."user_external_session"
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM "test_schema"."user_auth_token"
+  WHERE "test_schema"."user_external_session".id = "test_schema"."user_auth_token".external_session_id
+)

--- a/pkg/services/auth/authimpl/testdata/sqlite--delete_user_revoked_tokens-delete_user_revoked_tokens.sql
+++ b/pkg/services/auth/authimpl/testdata/sqlite--delete_user_revoked_tokens-delete_user_revoked_tokens.sql
@@ -1,0 +1,4 @@
+DELETE FROM "test_schema"."user_auth_token"
+WHERE user_id = 10
+  AND revoked_at > 0
+  AND revoked_at <= 1700000000

--- a/pkg/services/auth/authimpl/testdata/sqlite--revoke_all_user_tokens-revoke_all_user_tokens.sql
+++ b/pkg/services/auth/authimpl/testdata/sqlite--revoke_all_user_tokens-revoke_all_user_tokens.sql
@@ -1,0 +1,2 @@
+DELETE FROM "test_schema"."user_auth_token"
+WHERE user_id = 10

--- a/pkg/services/auth/authimpl/testdata/sqlite--rotate_token-rotate_token.sql
+++ b/pkg/services/auth/authimpl/testdata/sqlite--rotate_token-rotate_token.sql
@@ -1,0 +1,10 @@
+UPDATE "test_schema"."user_auth_token"
+SET
+  seen_at = 0,
+  user_agent = 'some-user-agent',
+  client_ip = '10.0.0.1',
+  prev_auth_token = auth_token,
+  auth_token = 'hashed-token',
+  auth_token_seen = FALSE,
+  rotated_at = 1700000000
+WHERE id = 42

--- a/pkg/services/auth/authimpl/token_cleanup.go
+++ b/pkg/services/auth/authimpl/token_cleanup.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/storage/unified/sql/sqltemplate"
 )
 
 func (s *UserAuthTokenService) Run(ctx context.Context) error {
@@ -49,16 +50,40 @@ func (s *UserAuthTokenService) Run(ctx context.Context) error {
 	}
 }
 
+type deleteExpiredTokensQuery struct {
+	sqltemplate.SQLTemplate
+	TokenTable    string
+	CreatedBefore int64
+	RotatedBefore int64
+}
+
+func (q deleteExpiredTokensQuery) Validate() error { return nil }
+
 func (s *UserAuthTokenService) deleteExpiredTokens(ctx context.Context, maxInactiveLifetime, maxLifetime time.Duration) (int64, error) {
 	createdBefore := getTime().Add(-maxLifetime)
 	rotatedBefore := getTime().Add(-maxInactiveLifetime)
 
 	s.log.Debug("Starting cleanup of expired auth tokens", "createdBefore", createdBefore, "rotatedBefore", rotatedBefore)
 
+	dbHelper, err := s.sql(ctx)
+	if err != nil {
+		return 0, err
+	}
+
 	var affected int64
-	err := s.sqlStore.WithDbSession(ctx, func(dbSession *db.Session) error {
-		sql := `DELETE from user_auth_token WHERE created_at <= ? OR rotated_at <= ?`
-		res, err := dbSession.Exec(sql, createdBefore.Unix(), rotatedBefore.Unix())
+	err = dbHelper.DB.WithDbSession(ctx, func(dbSession *db.Session) error {
+		query := deleteExpiredTokensQuery{
+			SQLTemplate:   sqltemplate.New(dbHelper.DialectForDriver()),
+			TokenTable:    dbHelper.Table("user_auth_token"),
+			CreatedBefore: createdBefore.Unix(),
+			RotatedBefore: rotatedBefore.Unix(),
+		}
+		rawSQL, err := sqltemplate.Execute(deleteExpiredTokensTemplate, query)
+		if err != nil {
+			return err
+		}
+
+		res, err := dbSession.Exec(append([]any{rawSQL}, query.GetArgs()...)...)
 		if err != nil {
 			return err
 		}
@@ -77,14 +102,35 @@ func (s *UserAuthTokenService) deleteExpiredTokens(ctx context.Context, maxInact
 	return affected, err
 }
 
+type deleteOrphanedExternalSessionsQuery struct {
+	sqltemplate.SQLTemplate
+	ExternalSessionTable string
+	TokenTable           string
+}
+
+func (q deleteOrphanedExternalSessionsQuery) Validate() error { return nil }
+
 func (s *UserAuthTokenService) deleteOrphanedExternalSessions(ctx context.Context) error {
 	s.log.Debug("Starting cleanup of external sessions")
 
-	var affected int64
-	err := s.sqlStore.WithDbSession(ctx, func(dbSession *db.Session) error {
-		sql := `DELETE FROM user_external_session WHERE NOT EXISTS (SELECT 1 FROM user_auth_token WHERE user_external_session.id = user_auth_token.external_session_id)`
+	dbHelper, err := s.sql(ctx)
+	if err != nil {
+		return err
+	}
 
-		res, err := dbSession.Exec(sql)
+	var affected int64
+	err = dbHelper.DB.WithDbSession(ctx, func(dbSession *db.Session) error {
+		query := deleteOrphanedExternalSessionsQuery{
+			SQLTemplate:          sqltemplate.New(dbHelper.DialectForDriver()),
+			ExternalSessionTable: dbHelper.Table("user_external_session"),
+			TokenTable:           dbHelper.Table("user_auth_token"),
+		}
+		rawSQL, err := sqltemplate.Execute(deleteOrphanedExternalSessionsTemplate, query)
+		if err != nil {
+			return err
+		}
+
+		res, err := dbSession.Exec(append([]any{rawSQL}, query.GetArgs()...)...)
 		if err != nil {
 			return err
 		}

--- a/pkg/services/quota/quotaimpl/quota_test.go
+++ b/pkg/services/quota/quotaimpl/quota_test.go
@@ -500,7 +500,7 @@ func setupEnv(t *testing.T, sqlStore db.DB, cfg *setting.Cfg, b bus.Bus, quotaSe
 	tracer := tracing.InitializeTracerForTest()
 	_, err = apikeyimpl.ProvideService(sqlStore, cfg, quotaService)
 	require.NoError(t, err)
-	_, err = authimpl.ProvideUserAuthTokenService(t.Context(), sqlStore, nil, quotaService, fakes.NewFakeSecretsService(), cfgProvider, tracing.InitializeTracerForTest(), featuremgmt.WithFeatures())
+	_, err = authimpl.ProvideUserAuthTokenService(t.Context(), legacysql.NewDatabaseProvider(sqlStore), nil, quotaService, fakes.NewFakeSecretsService(), cfgProvider, tracing.InitializeTracerForTest(), featuremgmt.WithFeatures())
 	require.NoError(t, err)
 	ac := acimpl.ProvideAccessControl(featuremgmt.WithFeatures())
 	emptySearchResponse := &resourcepb.ResourceSearchResponse{TotalHits: 0}


### PR DESCRIPTION
## Summary

Migrates `authimpl` (user auth tokens and external sessions) toward the legacy SQL provider and template pattern used by other stores. This is scoped to stay small and reviewable: the raw SQL statements become templates now, while the XORM fluent queries are table-qualified and converted to templates in a follow-up.

- `authimpl.ProvideUserAuthTokenService` and the external-session store now accept `legacysql.LegacyDatabaseProvider`.
- Each database operation resolves its helper from the operation context.
- Token rotation, revoke-all, batch revoke, active-token count, revoked-token cleanup, expired-token cleanup, and orphaned external-session cleanup are rendered from embedded SQL templates.
- Remaining XORM fluent queries qualify their table via `.Table(dbHelper.Table(...))`; converting them to templates is deferred to a follow-up.
- Table identifiers are resolved through `LegacyDatabaseHelper.Table` and dialect-quoted with `{{ .Ident ... }}`; runtime values are bound with `{{ .Arg ... }}`.
- Standard construction sites use `legacysql.NewDatabaseProvider`; Wire output was regenerated.

The session-client wiring rationale is documented in the companion Enterprise PR: https://github.com/grafana/grafana-enterprise/pull/12787

## Prior Art

This follows established patterns in the repository:

- `pkg/registry/apis/collections/legacy` for resolving a legacy database provider at operation time.
- `pkg/services/authz/rbac/store` for provider-backed query construction and execution.
- `pkg/extensions/apiserver/registry/iam/role/legacy` for embedded SQL templates and cross-dialect snapshot coverage.

## Testing

- `go test ./pkg/services/auth/authimpl -count=1`
- `go test ./pkg/services/quota/quotaimpl -count=1`
- `make gen-go`

The auth tests include MySQL, PostgreSQL, and SQLite SQL-rendering snapshots using qualified test identifiers, and the existing token and external-session integration tests exercised through the injected provider.
