### PR TITLE
unified/search: make filter and label clauses non-scoring

### DIFF
--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -2323,21 +2323,33 @@ func (b *bleveIndex) toBleveSearchRequest(ctx context.Context, req *resourcepb.R
 	return searchrequest, nil
 }
 
-// combineFilterAndTextQueries assembles the final bleve query from the non-scoring
-// filter clauses and the optional scoring free-text query. Filters go in the
-// boolean Filter slot so they constrain matches without contributing to the score.
+// combineFilterAndTextQueries assembles the final bleve query from the filter
+// clauses and the optional free-text query.
+//
+// Filters are non-scoring only when there is a free-text query to rank by: they
+// go in the boolean Filter slot so text relevance alone drives the score, and the
+// text query drives iteration. Without a free-text query the results are ordered
+// by the sort fields (not score), so the filters go straight into the query,
+// which keeps bleve iterating their posting lists instead of scanning every
+// document (a filter-only boolean query wraps a match-all searcher).
 func combineFilterAndTextQueries(filters []query.Query, textQuery query.Query) query.Query {
-	if len(filters) == 0 {
-		if textQuery == nil {
+	if textQuery == nil {
+		switch len(filters) {
+		case 0:
 			return bleve.NewMatchAllQuery()
+		case 1:
+			return filters[0]
+		default:
+			return bleve.NewConjunctionQuery(filters...)
 		}
+	}
+
+	if len(filters) == 0 {
 		return textQuery
 	}
 
 	bq := bleve.NewBooleanQuery()
-	if textQuery != nil {
-		bq.AddMust(textQuery)
-	}
+	bq.AddMust(textQuery)
 	if len(filters) == 1 {
 		bq.AddFilter(filters[0])
 	} else {

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -2262,24 +2262,15 @@ func (b *bleveIndex) toBleveSearchRequest(ctx context.Context, req *resourcepb.R
 		searchrequest.From = 0
 	}
 
-	// Everything is combined within an AND query: label/field filters plus the
-	// optional free-text clause.
-	queries, errResult := b.filterQueries(req)
+	// Label/field filters are constraints, not relevance signals, so they go into
+	// the boolean Filter clause (scored "none" by bleve) while the free-text query
+	// scores in Must. This keeps ranking driven by text relevance alone.
+	filters, errResult := b.filterQueries(req)
 	if errResult != nil {
 		return nil, errResult
 	}
-	if q := b.buildTextQuery(searchrequest, req); q != nil {
-		queries = append(queries, q)
-	}
-
-	switch len(queries) {
-	case 0:
-		searchrequest.Query = bleve.NewMatchAllQuery()
-	case 1:
-		searchrequest.Query = queries[0]
-	default:
-		searchrequest.Query = bleve.NewConjunctionQuery(queries...) // AND
-	}
+	textQuery := b.buildTextQuery(searchrequest, req)
+	searchrequest.Query = combineFilterAndTextQueries(filters, textQuery)
 
 	// postFilter applies authorization after ranking in runPostFilterAuthz, so
 	// skip the in-searcher wrapper here and let bleve return unfiltered ranked hits.
@@ -2330,6 +2321,29 @@ func (b *bleveIndex) toBleveSearchRequest(ctx context.Context, req *resourcepb.R
 	}
 
 	return searchrequest, nil
+}
+
+// combineFilterAndTextQueries assembles the final bleve query from the non-scoring
+// filter clauses and the optional scoring free-text query. Filters go in the
+// boolean Filter slot so they constrain matches without contributing to the score.
+func combineFilterAndTextQueries(filters []query.Query, textQuery query.Query) query.Query {
+	if len(filters) == 0 {
+		if textQuery == nil {
+			return bleve.NewMatchAllQuery()
+		}
+		return textQuery
+	}
+
+	bq := bleve.NewBooleanQuery()
+	if textQuery != nil {
+		bq.AddMust(textQuery)
+	}
+	if len(filters) == 1 {
+		bq.AddFilter(filters[0])
+	} else {
+		bq.AddFilter(bleve.NewConjunctionQuery(filters...))
+	}
+	return bq
 }
 
 // resolveFieldName maps a public field name to its physical index name. Clients

--- a/pkg/storage/unified/search/bleve_mappings_internal_test.go
+++ b/pkg/storage/unified/search/bleve_mappings_internal_test.go
@@ -526,14 +526,15 @@ func TestCombineFilterAndTextQueries(t *testing.T) {
 	// No filters: the text query is used as-is (it is the only scoring clause).
 	assert.Same(t, text, combineFilterAndTextQueries(nil, text))
 
-	// Filters only: constrain via the non-scoring Filter slot, nothing in Must.
-	bq, ok := combineFilterAndTextQueries([]query.Query{f1}, nil).(*query.BooleanQuery)
+	// Filters only (no text): the filters drive the query directly so bleve
+	// iterates their posting lists rather than scanning every document.
+	assert.Same(t, f1, combineFilterAndTextQueries([]query.Query{f1}, nil))
+	conj, ok := combineFilterAndTextQueries([]query.Query{f1, f2}, nil).(*query.ConjunctionQuery)
 	require.True(t, ok)
-	assert.Nil(t, bq.Must)
-	assert.Same(t, f1, bq.Filter)
+	assert.Equal(t, []query.Query{f1, f2}, conj.Conjuncts)
 
 	// Filters + text: text scores in Must, the filter stays in the Filter slot.
-	bq, ok = combineFilterAndTextQueries([]query.Query{f1}, text).(*query.BooleanQuery)
+	bq, ok := combineFilterAndTextQueries([]query.Query{f1}, text).(*query.BooleanQuery)
 	require.True(t, ok)
 	must, ok := bq.Must.(*query.ConjunctionQuery)
 	require.True(t, ok)

--- a/pkg/storage/unified/search/bleve_mappings_internal_test.go
+++ b/pkg/storage/unified/search/bleve_mappings_internal_test.go
@@ -512,3 +512,38 @@ func TestBleveIndex_resolveQueryFields(t *testing.T) {
 	}
 	assert.Equal(t, titleVariants, names(b.resolveQueryFields(legacy)))
 }
+
+func TestCombineFilterAndTextQueries(t *testing.T) {
+	text := bleve.NewMatchQuery("cpu")
+	f1 := bleve.NewTermQuery("a")
+	f1.SetField("x")
+	f2 := bleve.NewTermQuery("b")
+	f2.SetField("y")
+
+	// No filters and no text query matches everything.
+	assert.IsType(t, &query.MatchAllQuery{}, combineFilterAndTextQueries(nil, nil))
+
+	// No filters: the text query is used as-is (it is the only scoring clause).
+	assert.Same(t, text, combineFilterAndTextQueries(nil, text))
+
+	// Filters only: constrain via the non-scoring Filter slot, nothing in Must.
+	bq, ok := combineFilterAndTextQueries([]query.Query{f1}, nil).(*query.BooleanQuery)
+	require.True(t, ok)
+	assert.Nil(t, bq.Must)
+	assert.Same(t, f1, bq.Filter)
+
+	// Filters + text: text scores in Must, the filter stays in the Filter slot.
+	bq, ok = combineFilterAndTextQueries([]query.Query{f1}, text).(*query.BooleanQuery)
+	require.True(t, ok)
+	must, ok := bq.Must.(*query.ConjunctionQuery)
+	require.True(t, ok)
+	assert.Equal(t, []query.Query{text}, must.Conjuncts)
+	assert.Same(t, f1, bq.Filter)
+
+	// Multiple filters are combined into a single conjunction in the Filter slot.
+	bq, ok = combineFilterAndTextQueries([]query.Query{f1, f2}, text).(*query.BooleanQuery)
+	require.True(t, ok)
+	filter, ok := bq.Filter.(*query.ConjunctionQuery)
+	require.True(t, ok)
+	assert.Equal(t, []query.Query{f1, f2}, filter.Conjuncts)
+}

--- a/pkg/tests/apis/dashboard/testdata/searchV0/t01-query-single-word.json
+++ b/pkg/tests/apis/dashboard/testdata/searchV0/t01-query-single-word.json
@@ -10,7 +10,7 @@
         "panel-tests",
         "graph-ng"
       ],
-      "score": 0.63
+      "score": 0.603
     },
     {
       "resource": "dashboards",
@@ -21,8 +21,8 @@
         "panel-tests",
         "graph-ng"
       ],
-      "score": 0.6
+      "score": 0.573
     }
   ],
-  "maxScore": 0.63
+  "maxScore": 0.603
 }

--- a/pkg/tests/apis/dashboard/testdata/searchV0/t02-query-multiple-words.json
+++ b/pkg/tests/apis/dashboard/testdata/searchV0/t02-query-multiple-words.json
@@ -10,8 +10,8 @@
         "panel-tests",
         "graph-ng"
       ],
-      "score": 0.663
+      "score": 0.636
     }
   ],
-  "maxScore": 0.663
+  "maxScore": 0.636
 }

--- a/pkg/tests/apis/dashboard/testdata/searchV0/t03-with-text-panel.json
+++ b/pkg/tests/apis/dashboard/testdata/searchV0/t03-with-text-panel.json
@@ -14,5 +14,5 @@
       }
     }
   ],
-  "maxScore": 0.373
+  "maxScore": 1
 }

--- a/pkg/tests/apis/dashboard/testdata/searchV0/t03-with-text-panel.json
+++ b/pkg/tests/apis/dashboard/testdata/searchV0/t03-with-text-panel.json
@@ -14,5 +14,5 @@
       }
     }
   ],
-  "maxScore": 1
+  "maxScore": 0.373
 }

--- a/pkg/tests/apis/dashboard/testdata/searchV0/t04-title-ngram-prefix.json
+++ b/pkg/tests/apis/dashboard/testdata/searchV0/t04-title-ngram-prefix.json
@@ -10,8 +10,8 @@
         "panel-tests",
         "graph-ng"
       ],
-      "score": 0.059
+      "score": 0.031
     }
   ],
-  "maxScore": 0.059
+  "maxScore": 0.031
 }

--- a/pkg/tests/apis/dashboard/testdata/searchV0/t05-title-ngram-middle-word.json
+++ b/pkg/tests/apis/dashboard/testdata/searchV0/t05-title-ngram-middle-word.json
@@ -10,8 +10,8 @@
         "panel-tests",
         "graph-ng"
       ],
-      "score": 0.214
+      "score": 0.187
     }
   ],
-  "maxScore": 0.214
+  "maxScore": 0.187
 }

--- a/pkg/tests/apis/dashboard/testdata/searchV0/t06-panel-title-orange.json
+++ b/pkg/tests/apis/dashboard/testdata/searchV0/t06-panel-title-orange.json
@@ -10,7 +10,7 @@
         "panel-tests",
         "graph-ng"
       ],
-      "score": 0.112,
+      "score": 0.087,
       "explain": {
         "children": [
           {
@@ -24,107 +24,77 @@
                           {
                             "children": [
                               {
-                                "message": "boost",
-                                "value": 5
-                              },
-                              {
-                                "message": "idf(docFreq=1, maxDocs=17)",
-                                "value": 2.485
-                              },
-                              {
-                                "message": "queryNorm",
-                                "value": 0.025
-                              }
-                            ],
-                            "message": "queryWeight(fields.panel_title:orange^5.000000), product of:",
-                            "value": 0.313
-                          },
-                          {
-                            "children": [
-                              {
-                                "message": "tf(termFreq(fields.panel_title:orange)=3",
-                                "value": 1.732
+                                "children": [
+                                  {
+                                    "message": "boost",
+                                    "value": 5
+                                  },
+                                  {
+                                    "message": "idf(docFreq=1, maxDocs=17)",
+                                    "value": 2.485
+                                  },
+                                  {
+                                    "message": "queryNorm",
+                                    "value": 0.025
+                                  }
+                                ],
+                                "message": "queryWeight(fields.panel_title:orange^5.000000), product of:",
+                                "value": 0.313
                               },
                               {
                                 "children": [
                                   {
-                                    "message": "fieldNorm(field=fields.panel_title), b=0.750000, fieldLength=38.000002, avgFieldLength=13.000000)",
-                                    "value": 2.442
+                                    "message": "tf(termFreq(fields.panel_title:orange)=3",
+                                    "value": 1.732
+                                  },
+                                  {
+                                    "children": [
+                                      {
+                                        "message": "fieldNorm(field=fields.panel_title), b=0.750000, fieldLength=38.000002, avgFieldLength=13.000000)",
+                                        "value": 2.442
+                                      }
+                                    ],
+                                    "message": "saturation(term:), k1=1.200000/(tf=1.732051 + k1*fieldNorm=2.442308))",
+                                    "value": 0.257
+                                  },
+                                  {
+                                    "message": "idf(docFreq=1, maxDocs=17)",
+                                    "value": 2.485
                                   }
                                 ],
-                                "message": "saturation(term:), k1=1.200000/(tf=1.732051 + k1*fieldNorm=2.442308))",
-                                "value": 0.257
-                              },
-                              {
-                                "message": "idf(docFreq=1, maxDocs=17)",
-                                "value": 2.485
+                                "message": "fieldWeight(fields.panel_title:orange in <docID>), as per bm25 model, product of:",
+                                "value": 1.108
                               }
                             ],
-                            "message": "fieldWeight(fields.panel_title:orange in <docID>), as per bm25 model, product of:",
-                            "value": 1.108
+                            "message": "weight(fields.panel_title:orange^5.000000 in <docID>), product of:",
+                            "value": 0.346
                           }
                         ],
-                        "message": "weight(fields.panel_title:orange^5.000000 in <docID>), product of:",
+                        "message": "sum of:",
                         "value": 0.346
                       }
                     ],
                     "message": "sum of:",
                     "value": 0.346
-                  }
-                ],
-                "message": "sum of:",
-                "value": 0.346
-              },
-              {
-                "message": "coord(1/4)",
-                "value": 0.25
-              }
-            ],
-            "message": "product of:",
-            "partial_match": true,
-            "value": 0.087
-          },
-          {
-            "children": [
-              {
-                "children": [
+                  },
                   {
-                    "children": [
-                      {
-                        "children": [
-                          {
-                            "message": "boost",
-                            "value": 1
-                          },
-                          {
-                            "message": "queryNorm",
-                            "value": 0.025
-                          }
-                        ],
-                        "message": "ConstantScore()^1.000000, product of:",
-                        "value": 0.025
-                      },
-                      {
-                        "message": "ConstantScore()",
-                        "value": 1
-                      }
-                    ],
-                    "message": "weight(^1.000000), product of:",
-                    "value": 0.025
+                    "message": "coord(1/4)",
+                    "value": 0.25
                   }
                 ],
-                "message": "sum of:",
-                "value": 0.025
+                "message": "product of:",
+                "partial_match": true,
+                "value": 0.087
               }
             ],
             "message": "sum of:",
-            "value": 0.025
+            "value": 0.087
           }
         ],
         "message": "sum of:",
-        "value": 0.112
+        "value": 0.087
       }
     }
   ],
-  "maxScore": 0.112
+  "maxScore": 0.087
 }


### PR DESCRIPTION
Filter and label clauses were combined with the free-text query in a single conjunction, and bleve sums the scores of every conjunct — so filter clauses were influencing relevance ranking. Filters are constraints, not relevance signals; whether a document matched a `where` clause shouldn't change how relevant it is.

This puts the free-text query in the boolean `Must` clause (scoring) and the filters in the boolean `Filter` clause, which bleve evaluates with scoring disabled as a pure membership check. Ranking is now driven by text relevance alone. Filter-only searches (no text query) still return all matching documents and fall back to the title/name sort as before.

The change is small and localized to how the final query is assembled; the filter builders themselves are untouched. It applies to all callers of the search backend (legacy dashboard search, unified search, and the upcoming Search v1 API) — filters affecting relevance was never intended, and for exact/keyword filters the relative ordering is essentially unchanged.

Backend prerequisite for the Search v1 `/search` and `/trash` handlers. Part of grafana/search-and-storage-team#869.
