### PR TITLE
datasources: migrate to async functions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -677,6 +677,7 @@ i18next.config.ts @grafana/grafana-frontend-platform
 /packages/grafana-runtime/src/services/pluginMeta @grafana/grafana-frontend-platform
 /packages/grafana-runtime/src/utils/chromeHeaderHeight.ts @grafana/grafana-frontend-navigation
 /packages/grafana-runtime/src/utils/DataSourceWithBackend* @grafana/grafana-datasources-core-services
+/packages/grafana-runtime/src/utils/expressionRef* @grafana/grafana-datasources-core-services
 /packages/grafana-runtime/src/utils/licensing.ts @grafana/grafana-operator-experience-squad
 /packages/grafana-runtime/src/utils/logging.ts @grafana/grafana-frontend-platform
 /packages/grafana-runtime/src/utils/megaMenuOpen.ts @grafana/grafana-frontend-navigation

--- a/packages/grafana-runtime/src/components/DataSourcePicker.tsx
+++ b/packages/grafana-runtime/src/components/DataSourcePicker.tsx
@@ -14,7 +14,7 @@ import { type ActionMeta, PluginSignatureBadge, Select, Stack } from '@grafana/u
 
 import { getDataSourceSrv } from '../services/dataSourceSrv';
 
-import { ExpressionDatasourceRef } from './../utils/DataSourceWithBackend';
+import { ExpressionDatasourceRef } from './../utils/expressionRef';
 
 /**
  * Component props description for the {@link DataSourcePicker}

--- a/packages/grafana-runtime/src/index.ts
+++ b/packages/grafana-runtime/src/index.ts
@@ -34,8 +34,8 @@ export {
   type HealthCheckResultDetails,
   HealthStatus,
   type StreamOptionsProvider,
-  isExpressionReference,
 } from './utils/DataSourceWithBackend';
+export { isExpressionReference } from './utils/expressionRef';
 export {
   toDataQueryResponse,
   frameToMetricFindValue,

--- a/packages/grafana-runtime/src/internal/index.ts
+++ b/packages/grafana-runtime/src/internal/index.ts
@@ -14,7 +14,7 @@ export { setPanelDataErrorView } from '../components/PanelDataErrorView';
 export { setPanelRenderer } from '../components/PanelRenderer';
 export { type PageInfoItem, setPluginPage } from '../components/PluginPage';
 
-export { ExpressionDatasourceRef } from '../utils/DataSourceWithBackend';
+export { ExpressionDatasourceRef } from '../utils/expressionRef';
 export { standardStreamOptionsProvider, toStreamingDataResponse } from '../utils/DataSourceWithBackend';
 
 export {

--- a/packages/grafana-runtime/src/services/dataSource/dataSource.ts
+++ b/packages/grafana-runtime/src/services/dataSource/dataSource.ts
@@ -1,6 +1,6 @@
 import { DataSourceApi, type DataSourceInstanceSettings, type DataSourceRef, type ScopedVars } from '@grafana/data';
 
-import { isExpressionReference } from '../../utils/DataSourceWithBackend';
+import { isExpressionReference } from '../../utils/expressionRef';
 import { UserStorage } from '../../utils/userStorage';
 import { getDataSourceSrv, type RuntimeDataSourceRegistration } from '../dataSourceSrv';
 

--- a/packages/grafana-runtime/src/services/dataSource/settings.ts
+++ b/packages/grafana-runtime/src/services/dataSource/settings.ts
@@ -7,7 +7,7 @@ import {
   matchPluginId,
 } from '@grafana/data';
 
-import { isExpressionReference } from '../../utils/DataSourceWithBackend';
+import { isExpressionReference } from '../../utils/expressionRef';
 import { getCachedPromise, invalidateCachedPromise } from '../../utils/getCachedPromise';
 import { getBackendSrv } from '../backendSrv';
 import { getDataSourceSrv, type GetDataSourceListFilters } from '../dataSourceSrv';

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
@@ -69,6 +69,13 @@ jest.mock('../services', () => ({
     };
   },
 }));
+jest.mock('./../unstable', () => ({
+  ...jest.requireActual('./../unstable'),
+  getDataSourceInstanceSettings: (ref?: DataSourceRef) => ({
+    type: ref?.type ?? '<mocktype>',
+    uid: ref?.uid ?? '<mockuid>',
+  }),
+}));
 jest.mock('./publicDashboardQueryHandler');
 
 const mockIsQueryServiceCompatible = jest.fn().mockReturnValue(false);
@@ -832,15 +839,15 @@ describe('DataSourceWithBackend', () => {
         [{ refId: 'A' }, { refId: 'B', datasource: loki }],
         ['dummy', 'loki'],
       ],
-    ])('%s', (_, targets, expectedTypes) => {
+    ])('%s', async (_, targets, expectedTypes) => {
       const { ds } = createMockDatasource();
 
-      ds.query({
+      await firstValueFrom(ds.query({
         maxDataPoints: 10,
         intervalMs: 5000,
         targets,
         range: getDefaultTimeRange(),
-      } as DataQueryRequest);
+      } as DataQueryRequest));
 
       const { calls } = mockIsQueryServiceCompatible.mock;
       expect(calls).toHaveLength(1);

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
@@ -69,12 +69,15 @@ jest.mock('../services', () => ({
     };
   },
 }));
-jest.mock('./../unstable', () => ({
-  ...jest.requireActual('./../unstable'),
-  getDataSourceInstanceSettings: (ref?: DataSourceRef) => ({
+const mockGetDataSourceInstanceSettings = jest.fn<{ type: string; uid: string } | undefined, [DataSourceRef?]>(
+  (ref) => ({
     type: ref?.type ?? '<mocktype>',
     uid: ref?.uid ?? '<mockuid>',
-  }),
+  })
+);
+jest.mock('./../unstable', () => ({
+  ...jest.requireActual('./../unstable'),
+  getDataSourceInstanceSettings: (ref?: DataSourceRef) => mockGetDataSourceInstanceSettings(ref),
 }));
 jest.mock('./publicDashboardQueryHandler');
 
@@ -173,6 +176,23 @@ describe('DataSourceWithBackend', () => {
         "url": "/api/ds/query?ds_type=dummy",
       }
     `);
+  });
+
+  test('surfaces an error when a query targets an unknown datasource', async () => {
+    const { ds } = createMockDatasource();
+    // the async settings lookup returning undefined means the datasource does not exist
+    mockGetDataSourceInstanceSettings.mockReturnValueOnce(undefined);
+
+    await expect(
+      firstValueFrom(
+        ds.query({
+          maxDataPoints: 10,
+          intervalMs: 5000,
+          targets: [{ refId: 'A', datasource: { type: 'unknown', uid: 'does-not-exist' } }],
+          range: getDefaultTimeRange(),
+        } as DataQueryRequest)
+      )
+    ).rejects.toThrow('Unknown Datasource');
   });
 
   test('correctly passes datasource headers', async () => {
@@ -842,12 +862,14 @@ describe('DataSourceWithBackend', () => {
     ])('%s', async (_, targets, expectedTypes) => {
       const { ds } = createMockDatasource();
 
-      await firstValueFrom(ds.query({
-        maxDataPoints: 10,
-        intervalMs: 5000,
-        targets,
-        range: getDefaultTimeRange(),
-      } as DataQueryRequest));
+      await firstValueFrom(
+        ds.query({
+          maxDataPoints: 10,
+          intervalMs: 5000,
+          targets,
+          range: getDefaultTimeRange(),
+        } as DataQueryRequest)
+      );
 
       const { calls } = mockIsQueryServiceCompatible.mock;
       expect(calls).toHaveLength(1);

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
@@ -1,4 +1,4 @@
-import { of } from 'rxjs';
+import { firstValueFrom, of } from 'rxjs';
 
 import {
   type DataQuery,
@@ -97,18 +97,20 @@ describe('DataSourceWithBackend', () => {
     jest.useRealTimers();
   });
 
-  test('check the executed queries', () => {
+  test('check the executed queries', async () => {
     const { mock, ds } = createMockDatasource();
-    ds.query({
-      maxDataPoints: 10,
-      intervalMs: 5000,
-      targets: [{ refId: 'A' }, { refId: 'B', datasource: { type: 'sample' } }],
-      dashboardUID: 'dashA',
-      panelId: 123,
-      filters: [{ key: 'key1', operator: '=', value: 'val1' }],
-      range: getDefaultTimeRange(),
-      queryGroupId: 'abc',
-    } as DataQueryRequest);
+    await firstValueFrom(
+      ds.query({
+        maxDataPoints: 10,
+        intervalMs: 5000,
+        targets: [{ refId: 'A' }, { refId: 'B', datasource: { type: 'sample' } }],
+        dashboardUID: 'dashA',
+        panelId: 123,
+        filters: [{ key: 'key1', operator: '=', value: 'val1' }],
+        range: getDefaultTimeRange(),
+        queryGroupId: 'abc',
+      } as DataQueryRequest)
+    );
 
     const args = mock.calls[0][0];
 
@@ -166,27 +168,29 @@ describe('DataSourceWithBackend', () => {
     `);
   });
 
-  test('correctly passes datasource headers', () => {
+  test('correctly passes datasource headers', async () => {
     const { mock, ds } = createMockDatasource();
-    ds.query({
-      maxDataPoints: 10,
-      intervalMs: 5000,
-      targets: [{ refId: 'A' }, { refId: 'B', datasource: { type: 'sample' } }],
-      dashboardUID: 'dashA',
-      panelId: 123,
-      filters: [{ key: 'key1', operator: '=', value: 'val1' }],
-      range: getDefaultTimeRange(),
-      queryGroupId: 'abc',
-      interval: '5s',
-      scopedVars: {},
-      timezone: '',
-      requestId: 'request-123',
-      startTime: 0,
-      app: '',
-      headers: {
-        'X-Test-Header': 'test',
-      },
-    });
+    await firstValueFrom(
+      ds.query({
+        maxDataPoints: 10,
+        intervalMs: 5000,
+        targets: [{ refId: 'A' }, { refId: 'B', datasource: { type: 'sample' } }],
+        dashboardUID: 'dashA',
+        panelId: 123,
+        filters: [{ key: 'key1', operator: '=', value: 'val1' }],
+        range: getDefaultTimeRange(),
+        queryGroupId: 'abc',
+        interval: '5s',
+        scopedVars: {},
+        timezone: '',
+        requestId: 'request-123',
+        startTime: 0,
+        app: '',
+        headers: {
+          'X-Test-Header': 'test',
+        },
+      })
+    );
 
     const args = mock.calls[0][0];
 
@@ -245,18 +249,20 @@ describe('DataSourceWithBackend', () => {
     `);
   });
 
-  test('correctly passes dashboard and panel headers', () => {
+  test('correctly passes dashboard and panel headers', async () => {
     const { mock, ds } = createMockDatasource();
-    ds.query({
-      maxDataPoints: 10,
-      intervalMs: 5000,
-      targets: [{ refId: 'A' }],
-      dashboardUID: 'dashA',
-      dashboardTitle: 'My Test Dashboard',
-      panelId: 123,
-      panelName: 'CPU Usage Panel',
-      range: getDefaultTimeRange(),
-    } as DataQueryRequest);
+    await firstValueFrom(
+      ds.query({
+        maxDataPoints: 10,
+        intervalMs: 5000,
+        targets: [{ refId: 'A' }],
+        dashboardUID: 'dashA',
+        dashboardTitle: 'My Test Dashboard',
+        panelId: 123,
+        panelName: 'CPU Usage Panel',
+        range: getDefaultTimeRange(),
+      } as DataQueryRequest)
+    );
 
     const args = mock.calls[0][0];
 
@@ -298,17 +304,19 @@ describe('DataSourceWithBackend', () => {
     `);
   });
 
-  test('correctly creates expression queries', () => {
+  test('correctly creates expression queries', async () => {
     const { mock, ds } = createMockDatasource();
-    ds.query({
-      maxDataPoints: 10,
-      intervalMs: 5000,
-      targets: [{ refId: 'A' }, { refId: 'B', datasource: { type: '__expr__' } }],
-      dashboardUID: 'dashA',
-      panelId: 123,
-      range: getDefaultTimeRange(),
-      queryGroupId: 'abc',
-    } as DataQueryRequest);
+    await firstValueFrom(
+      ds.query({
+        maxDataPoints: 10,
+        intervalMs: 5000,
+        targets: [{ refId: 'A' }, { refId: 'B', datasource: { type: '__expr__' } }],
+        dashboardUID: 'dashA',
+        panelId: 123,
+        range: getDefaultTimeRange(),
+        queryGroupId: 'abc',
+      } as DataQueryRequest)
+    );
 
     const args = mock.calls[0][0];
 
@@ -358,31 +366,35 @@ describe('DataSourceWithBackend', () => {
     `);
   });
 
-  test('should apply template variables only for the current data source', () => {
+  test('should apply template variables only for the current data source', async () => {
     const { mock, ds } = createMockDatasource();
     ds.applyTemplateVariables = jest.fn();
-    ds.query({
-      maxDataPoints: 10,
-      intervalMs: 5000,
-      range: getDefaultTimeRange(),
-      targets: [{ refId: 'A' }, { refId: 'B', datasource: { type: 'sample' } }],
-    } as DataQueryRequest);
+    await firstValueFrom(
+      ds.query({
+        maxDataPoints: 10,
+        intervalMs: 5000,
+        range: getDefaultTimeRange(),
+        targets: [{ refId: 'A' }, { refId: 'B', datasource: { type: 'sample' } }],
+      } as DataQueryRequest)
+    );
 
     expect(mock.calls.length).toBe(1);
     expect(ds.applyTemplateVariables).toHaveBeenCalledTimes(1);
   });
 
-  test('check that the executed queries is hidden from inspector', () => {
+  test('check that the executed queries is hidden from inspector', async () => {
     const { mock, ds } = createMockDatasource();
-    ds.query({
-      maxDataPoints: 10,
-      intervalMs: 5000,
-      targets: [{ refId: 'A' }, { refId: 'B', datasource: { type: 'sample' } }],
-      hideFromInspector: true,
-      dashboardUID: 'dashA',
-      range: getDefaultTimeRange(),
-      panelId: 123,
-    } as DataQueryRequest);
+    await firstValueFrom(
+      ds.query({
+        maxDataPoints: 10,
+        intervalMs: 5000,
+        targets: [{ refId: 'A' }, { refId: 'B', datasource: { type: 'sample' } }],
+        hideFromInspector: true,
+        dashboardUID: 'dashA',
+        range: getDefaultTimeRange(),
+        panelId: 123,
+      } as DataQueryRequest)
+    );
 
     const args = mock.calls[0][0];
 
@@ -635,23 +647,25 @@ describe('DataSourceWithBackend', () => {
     });
   });
 
-  test('check that queries can skip the query cache', () => {
+  test('check that queries can skip the query cache', async () => {
     const { mock, ds } = createMockDatasource();
-    ds.query({
-      maxDataPoints: 10,
-      intervalMs: 5000,
-      targets: [{ refId: 'A' }],
-      dashboardUID: 'dashA',
-      panelId: 123,
-      range: getDefaultTimeRange(),
-      skipQueryCache: true,
-      requestId: 'request-123',
-      interval: '5s',
-      scopedVars: {},
-      timezone: '',
-      app: '',
-      startTime: 0,
-    });
+    await firstValueFrom(
+      ds.query({
+        maxDataPoints: 10,
+        intervalMs: 5000,
+        targets: [{ refId: 'A' }],
+        dashboardUID: 'dashA',
+        panelId: 123,
+        range: getDefaultTimeRange(),
+        skipQueryCache: true,
+        requestId: 'request-123',
+        interval: '5s',
+        scopedVars: {},
+        timezone: '',
+        app: '',
+        startTime: 0,
+      })
+    );
 
     const args = mock.calls[0][0];
 

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
@@ -20,7 +20,6 @@ import {
   DataSourceWithBackend,
   type HealthCheckResult,
   HealthStatus,
-  isExpressionReference,
   standardStreamOptionsProvider,
   toStreamingDataResponse,
 } from './DataSourceWithBackend';
@@ -75,8 +74,8 @@ const mockGetDataSourceInstanceSettings = jest.fn<{ type: string; uid: string } 
     uid: ref?.uid ?? '<mockuid>',
   })
 );
-jest.mock('./../unstable', () => ({
-  ...jest.requireActual('./../unstable'),
+jest.mock('../services/dataSource/settings', () => ({
+  ...jest.requireActual('../services/dataSource/settings'),
   getDataSourceInstanceSettings: (ref?: DataSourceRef) => mockGetDataSourceInstanceSettings(ref),
 }));
 jest.mock('./publicDashboardQueryHandler');
@@ -731,18 +730,6 @@ describe('DataSourceWithBackend', () => {
         "url": "/api/ds/query?ds_type=dummy&requestId=request-123",
       }
     `);
-  });
-
-  describe('isExpressionReference', () => {
-    test('check all possible expression references', () => {
-      expect(isExpressionReference('__expr__')).toBeTruthy(); // New UID
-      expect(isExpressionReference('-100')).toBeTruthy(); // Legacy UID
-      expect(isExpressionReference('Expression')).toBeTruthy(); // Name
-      expect(isExpressionReference({ type: '__expr__' })).toBeTruthy();
-      expect(isExpressionReference({ type: '-100' })).toBeTruthy();
-      expect(isExpressionReference(null)).toBeFalsy();
-      expect(isExpressionReference(undefined)).toBeFalsy();
-    });
   });
 
   describe('public dashboard scope', () => {

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
@@ -68,11 +68,13 @@ jest.mock('../services', () => ({
     };
   },
 }));
-const mockGetDataSourceInstanceSettings = jest.fn<{ type: string; uid: string } | undefined, [DataSourceRef?]>(
-  (ref) => ({
-    type: ref?.type ?? '<mocktype>',
-    uid: ref?.uid ?? '<mockuid>',
-  })
+type MockSettings = { type: string; uid: string } | undefined;
+const defaultInstanceSettings = (ref?: DataSourceRef): MockSettings => ({
+  type: ref?.type ?? '<mocktype>',
+  uid: ref?.uid ?? '<mockuid>',
+});
+const mockGetDataSourceInstanceSettings = jest.fn<MockSettings | Promise<MockSettings>, [DataSourceRef?]>(
+  defaultInstanceSettings
 );
 jest.mock('../services/dataSource/settings', () => ({
   ...jest.requireActual('../services/dataSource/settings'),
@@ -192,6 +194,54 @@ describe('DataSourceWithBackend', () => {
         } as DataQueryRequest)
       )
     ).rejects.toThrow('Unknown Datasource');
+  });
+
+  test('does not prepare the request until the observable is subscribed to', async () => {
+    const { mock, ds } = createMockDatasource();
+
+    const observable = ds.query({
+      maxDataPoints: 10,
+      intervalMs: 5000,
+      targets: [{ refId: 'A', datasource: { type: 'sample', uid: 'sample' } }],
+      range: getDefaultTimeRange(),
+    } as DataQueryRequest);
+
+    expect(mockGetDataSourceInstanceSettings).not.toHaveBeenCalled();
+    expect(mock.calls.length).toBe(0);
+
+    await firstValueFrom(observable);
+
+    expect(mockGetDataSourceInstanceSettings).toHaveBeenCalled();
+    expect(mock.calls.length).toBe(1);
+  });
+
+  test('keeps the routing headers in query order when the settings lookups resolve out of order', async () => {
+    const { mock, ds } = createMockDatasource();
+    mockGetDataSourceInstanceSettings.mockImplementation(async (ref) => {
+      if (ref?.uid === 'slow') {
+        // yield a few times so this lookup settles after the one for the second query
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      }
+      return defaultInstanceSettings(ref);
+    });
+
+    await firstValueFrom(
+      ds.query({
+        maxDataPoints: 10,
+        intervalMs: 5000,
+        targets: [
+          { refId: 'A', datasource: { type: 'slow-type', uid: 'slow' } },
+          { refId: 'B', datasource: { type: 'fast-type', uid: 'fast' } },
+        ],
+        range: getDefaultTimeRange(),
+      } as DataQueryRequest)
+    );
+
+    const args = mock.calls[0][0];
+    expect(args.headers?.['X-Datasource-Uid']).toBe('slow, fast');
+    expect(args.headers?.['X-Plugin-Id']).toBe('slow-type, fast-type');
   });
 
   test('correctly passes datasource headers', async () => {
@@ -846,6 +896,11 @@ describe('DataSourceWithBackend', () => {
         [{ refId: 'A' }, { refId: 'B', datasource: loki }],
         ['dummy', 'loki'],
       ],
+      [
+        'handle a mix of query and no-query data source references, per-query first',
+        [{ refId: 'A', datasource: loki }, { refId: 'B' }],
+        ['loki', 'dummy'],
+      ],
     ])('%s', async (_, targets, expectedTypes) => {
       const { ds } = createMockDatasource();
 
@@ -879,6 +934,7 @@ function createMockDatasource() {
 
   mockDatasourceRequest.mockReset();
   mockDatasourceRequest.mockReturnValue(Promise.resolve({} as FetchResponse));
+  mockGetDataSourceInstanceSettings.mockReset().mockImplementation(defaultInstanceSettings);
 
   const ds = new MyDataSource(settings);
   return { ds, mock: mockDatasourceRequest.mock };

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -27,7 +27,6 @@ import {
   type BackendSrvRequest,
   type FetchResponse,
   getBackendSrv,
-  getDataSourceSrv,
   getGrafanaLiveSrv,
   StreamingFrameAction,
   type StreamingFrameOptions,
@@ -37,6 +36,7 @@ import { publicDashboardQueryHandler } from './publicDashboardQueryHandler';
 import { isQueryServiceCompatible } from './qscheck';
 import { type BackendDataSourceResponse, toDataQueryResponse } from './queryResponse';
 import { UserStorage } from './userStorage';
+import { getDataSourceInstanceSettings } from './../unstable'
 
 /**
  * @internal
@@ -170,7 +170,7 @@ class DataSourceWithBackend<
     const pluginIDs = new Set<string>();
     const dsUIDs = new Set<string>();
     const datasources: DataSourceInstanceSettings[] = [];
-    const queries: DataQuery[] = targets.map((q) => {
+    const queries: DataQuery[] = await Promise.all(targets.map(async (q) => {
       let datasource = this.getRef();
       let datasourceId = this.id;
       let shouldApplyTemplateVariables = true;
@@ -184,7 +184,7 @@ class DataSourceWithBackend<
       }
 
       if (q.datasource) {
-        const ds = getDataSourceSrv().getInstanceSettings(q.datasource, request.scopedVars);
+        const ds = await getDataSourceInstanceSettings(q.datasource, request.scopedVars);
 
         if (!ds) {
           throw new Error(`Unknown Datasource: ${JSON.stringify(q.datasource)}`);
@@ -220,7 +220,7 @@ class DataSourceWithBackend<
         maxDataPoints,
         queryCachingTTL,
       };
-    });
+    }));
 
     const body = {
       queries,

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -1,4 +1,4 @@
-import { lastValueFrom, merge, type Observable, of } from 'rxjs';
+import { from, lastValueFrom, merge, type Observable, of } from 'rxjs';
 import { catchError, switchMap } from 'rxjs/operators';
 
 import {
@@ -162,7 +162,7 @@ class DataSourceWithBackend<
     this.datasourceInstanceSettings = instanceSettings;
   }
 
-  private createBackendRequest(request: DataQueryRequest<TQuery>): [BackendSrvRequest, DataQuery[]]{
+  private async createBackendRequest(request: DataQueryRequest<TQuery>): Promise<[BackendSrvRequest, DataQuery[]]> {
     const { intervalMs, maxDataPoints, queryCachingTTL, range, requestId, hideFromInspector = false } = request;
     let targets = request.targets;
 
@@ -290,7 +290,6 @@ class DataSourceWithBackend<
     ];
   }
 
-
   /**
    * Ideally final -- any other implementation may not work as expected
    */
@@ -303,23 +302,25 @@ class DataSourceWithBackend<
       return of({ data: [] });
     }
 
-    const [req, queries] = this.createBackendRequest(request)
-
-    return getBackendSrv()
-      .fetch<BackendDataSourceResponse>(req)
-      .pipe(
-        switchMap((raw) => {
-          const rsp = toDataQueryResponse(raw, queries);
-          // Check if any response should subscribe to a live stream
-          if (rsp.data?.length && rsp.data.find((f: DataFrame) => f.meta?.channel)) {
-            return toStreamingDataResponse(rsp, request, this.streamOptionsProvider);
-          }
-          return of(rsp);
-        }),
-        catchError((err) => {
-          return of(toDataQueryResponse(err));
-        })
-      );
+    return from(this.createBackendRequest(request)).pipe(
+      switchMap(([req, queries]) =>
+        getBackendSrv()
+          .fetch<BackendDataSourceResponse>(req)
+          .pipe(
+            switchMap((raw) => {
+              const rsp = toDataQueryResponse(raw, queries);
+              // Check if any response should subscribe to a live stream
+              if (rsp.data?.length && rsp.data.find((f: DataFrame) => f.meta?.channel)) {
+                return toStreamingDataResponse(rsp, request, this.streamOptionsProvider);
+              }
+              return of(rsp);
+            })
+          )
+      ),
+      catchError((err) => {
+        return of(toDataQueryResponse(err));
+      })
+    );
   }
 
   /** Get request headers with plugin ID+UID set */

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -32,11 +32,11 @@ import {
   type StreamingFrameOptions,
 } from '../services';
 
+import { getDataSourceInstanceSettings } from './../unstable';
 import { publicDashboardQueryHandler } from './publicDashboardQueryHandler';
 import { isQueryServiceCompatible } from './qscheck';
 import { type BackendDataSourceResponse, toDataQueryResponse } from './queryResponse';
 import { UserStorage } from './userStorage';
-import { getDataSourceInstanceSettings } from './../unstable'
 
 /**
  * @internal
@@ -170,57 +170,59 @@ class DataSourceWithBackend<
     const pluginIDs = new Set<string>();
     const dsUIDs = new Set<string>();
     const datasources: DataSourceInstanceSettings[] = [];
-    const queries: DataQuery[] = await Promise.all(targets.map(async (q) => {
-      let datasource = this.getRef();
-      let datasourceId = this.id;
-      let shouldApplyTemplateVariables = true;
+    const queries: DataQuery[] = await Promise.all(
+      targets.map(async (q) => {
+        let datasource = this.getRef();
+        let datasourceId = this.id;
+        let shouldApplyTemplateVariables = true;
 
-      if (isExpressionReference(q.datasource)) {
-        hasExpr = true;
+        if (isExpressionReference(q.datasource)) {
+          hasExpr = true;
+          return {
+            ...q,
+            datasource: ExpressionDatasourceRef,
+          };
+        }
+
+        if (q.datasource) {
+          const ds = await getDataSourceInstanceSettings(q.datasource, request.scopedVars);
+
+          if (!ds) {
+            throw new Error(`Unknown Datasource: ${JSON.stringify(q.datasource)}`);
+          }
+
+          datasources.push(ds);
+
+          const dsRef = ds.rawRef ?? getDataSourceRef(ds);
+          const dsId = ds.id;
+          if (dsRef.uid !== datasource.uid || datasourceId !== dsId) {
+            datasource = dsRef;
+            datasourceId = dsId;
+            // If the query is using a different datasource, we would need to retrieve the datasource
+            // instance (async) and apply the template variables but it seems it's not necessary for now.
+            shouldApplyTemplateVariables = false;
+          }
+        } else {
+          // if there is no per-query datasource, we use the implicit datasource
+          datasources.push(this.datasourceInstanceSettings);
+        }
+        if (datasource.type?.length) {
+          pluginIDs.add(datasource.type);
+        }
+        if (datasource.uid?.length) {
+          dsUIDs.add(datasource.uid);
+        }
+
         return {
-          ...q,
-          datasource: ExpressionDatasourceRef,
+          ...(shouldApplyTemplateVariables ? this.applyTemplateVariables(q, request.scopedVars, request.filters) : q),
+          datasource,
+          datasourceId, // deprecated!
+          intervalMs,
+          maxDataPoints,
+          queryCachingTTL,
         };
-      }
-
-      if (q.datasource) {
-        const ds = await getDataSourceInstanceSettings(q.datasource, request.scopedVars);
-
-        if (!ds) {
-          throw new Error(`Unknown Datasource: ${JSON.stringify(q.datasource)}`);
-        }
-
-        datasources.push(ds);
-
-        const dsRef = ds.rawRef ?? getDataSourceRef(ds);
-        const dsId = ds.id;
-        if (dsRef.uid !== datasource.uid || datasourceId !== dsId) {
-          datasource = dsRef;
-          datasourceId = dsId;
-          // If the query is using a different datasource, we would need to retrieve the datasource
-          // instance (async) and apply the template variables but it seems it's not necessary for now.
-          shouldApplyTemplateVariables = false;
-        }
-      } else {
-        // if there is no per-query datasource, we use the implicit datasource
-        datasources.push(this.datasourceInstanceSettings);
-      }
-      if (datasource.type?.length) {
-        pluginIDs.add(datasource.type);
-      }
-      if (datasource.uid?.length) {
-        dsUIDs.add(datasource.uid);
-      }
-
-      return {
-        ...(shouldApplyTemplateVariables ? this.applyTemplateVariables(q, request.scopedVars, request.filters) : q),
-        datasource,
-        datasourceId, // deprecated!
-        intervalMs,
-        maxDataPoints,
-        queryCachingTTL,
-      };
-    }));
+      })
+    );
 
     const body = {
       queries,
@@ -314,12 +316,15 @@ class DataSourceWithBackend<
                 return toStreamingDataResponse(rsp, request, this.streamOptionsProvider);
               }
               return of(rsp);
+            }),
+            // Only fetch responses are turned into a response object here. toDataQueryResponse cannot
+            // map a plain thrown Error (e.g. an unknown datasource from createBackendRequest) and would
+            // silently produce an empty success, so those errors must propagate to the caller instead.
+            catchError((err) => {
+              return of(toDataQueryResponse(err));
             })
           )
-      ),
-      catchError((err) => {
-        return of(toDataQueryResponse(err));
-      })
+      )
     );
   }
 

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -162,14 +162,7 @@ class DataSourceWithBackend<
     this.datasourceInstanceSettings = instanceSettings;
   }
 
-  /**
-   * Ideally final -- any other implementation may not work as expected
-   */
-  query(request: DataQueryRequest<TQuery>): Observable<DataQueryResponse> {
-    if (config.publicDashboardAccessToken) {
-      return publicDashboardQueryHandler(request);
-    }
-
+  private createBackendRequest(request: DataQueryRequest<TQuery>): [BackendSrvRequest, DataQuery[]]{
     const { intervalMs, maxDataPoints, queryCachingTTL, range, requestId, hideFromInspector = false } = request;
     let targets = request.targets;
 
@@ -229,11 +222,6 @@ class DataSourceWithBackend<
       };
     });
 
-    // Return early if no queries exist
-    if (!queries.length) {
-      return of({ data: [] });
-    }
-
     const body = {
       queries,
       from: range?.from.valueOf().toString(),
@@ -288,15 +276,37 @@ class DataSourceWithBackend<
     if (request.skipQueryCache) {
       headers[PluginRequestHeaders.SkipQueryCache] = 'true';
     }
-    return getBackendSrv()
-      .fetch<BackendDataSourceResponse>({
+
+    return [
+      {
         url,
         method: 'POST',
         data: body,
         requestId,
         hideFromInspector,
         headers,
-      })
+      },
+      queries,
+    ];
+  }
+
+
+  /**
+   * Ideally final -- any other implementation may not work as expected
+   */
+  query(request: DataQueryRequest<TQuery>): Observable<DataQueryResponse> {
+    if (config.publicDashboardAccessToken) {
+      return publicDashboardQueryHandler(request);
+    }
+
+    if (request.targets.length === 0) {
+      return of({ data: [] });
+    }
+
+    const [req, queries] = this.createBackendRequest(request)
+
+    return getBackendSrv()
+      .fetch<BackendDataSourceResponse>(req)
       .pipe(
         switchMap((raw) => {
           const rsp = toDataQueryResponse(raw, queries);

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -1,4 +1,4 @@
-import { from, lastValueFrom, merge, type Observable, of } from 'rxjs';
+import { defer, lastValueFrom, merge, type Observable, of } from 'rxjs';
 import { catchError, switchMap } from 'rxjs/operators';
 
 import {
@@ -11,6 +11,7 @@ import {
   DataSourceApi,
   type DataSourceInstanceSettings,
   type DataSourceJsonData,
+  type DataSourceRef,
   getDataSourceRef,
   makeClassES5Compatible,
   parseLiveChannelAddress,
@@ -123,6 +124,15 @@ function toHealthCheckResult(v: DatasourcesV0HealthCheckResult): HealthCheckResu
   };
 }
 
+interface PreparedQuery {
+  query: DataQuery;
+  /** Absent for expression queries, which are not backed by a data source instance. */
+  resolved?: {
+    settings: DataSourceInstanceSettings;
+    ref: DataSourceRef;
+  };
+}
+
 /**
  * Extend this class to implement a data source plugin that is depending on the Grafana
  * backend API.
@@ -147,10 +157,7 @@ class DataSourceWithBackend<
     let targets = request.targets;
 
     let hasExpr = false;
-    const pluginIDs = new Set<string>();
-    const dsUIDs = new Set<string>();
-    const datasources: DataSourceInstanceSettings[] = [];
-    const queries: DataQuery[] = await Promise.all(
+    const prepared: PreparedQuery[] = await Promise.all(
       targets.map(async (q) => {
         let datasource = this.getRef();
         let datasourceId = this.id;
@@ -159,10 +166,15 @@ class DataSourceWithBackend<
         if (isExpressionReference(q.datasource)) {
           hasExpr = true;
           return {
-            ...q,
-            datasource: ExpressionDatasourceRef,
+            query: {
+              ...q,
+              datasource: ExpressionDatasourceRef,
+            },
           };
         }
+
+        // if there is no per-query datasource, we use the implicit datasource
+        let settings: DataSourceInstanceSettings = this.datasourceInstanceSettings;
 
         if (q.datasource) {
           const ds = await getDataSourceInstanceSettings(q.datasource, request.scopedVars);
@@ -171,7 +183,7 @@ class DataSourceWithBackend<
             throw new Error(`Unknown Datasource: ${JSON.stringify(q.datasource)}`);
           }
 
-          datasources.push(ds);
+          settings = ds;
 
           const dsRef = ds.rawRef ?? getDataSourceRef(ds);
           const dsId = ds.id;
@@ -182,27 +194,44 @@ class DataSourceWithBackend<
             // instance (async) and apply the template variables but it seems it's not necessary for now.
             shouldApplyTemplateVariables = false;
           }
-        } else {
-          // if there is no per-query datasource, we use the implicit datasource
-          datasources.push(this.datasourceInstanceSettings);
-        }
-        if (datasource.type?.length) {
-          pluginIDs.add(datasource.type);
-        }
-        if (datasource.uid?.length) {
-          dsUIDs.add(datasource.uid);
         }
 
         return {
-          ...(shouldApplyTemplateVariables ? this.applyTemplateVariables(q, request.scopedVars, request.filters) : q),
-          datasource,
-          datasourceId, // deprecated!
-          intervalMs,
-          maxDataPoints,
-          queryCachingTTL,
+          query: {
+            ...(shouldApplyTemplateVariables ? this.applyTemplateVariables(q, request.scopedVars, request.filters) : q),
+            datasource,
+            datasourceId, // deprecated!
+            intervalMs,
+            maxDataPoints,
+            queryCachingTTL,
+          },
+          resolved: { settings, ref: datasource },
         };
       })
     );
+
+    // Collected after the fan-out rather than inside it: the settings lookups resolve in an
+    // arbitrary order, so accumulating from within the callbacks would make the routing header
+    // values and the query-service decision depend on resolution order instead of query order.
+    const pluginIDs = new Set<string>();
+    const dsUIDs = new Set<string>();
+    const datasources: DataSourceInstanceSettings[] = [];
+    const queries: DataQuery[] = [];
+
+    for (const { query, resolved } of prepared) {
+      queries.push(query);
+      if (!resolved) {
+        // an expression query is not backed by a datasource instance
+        continue;
+      }
+      datasources.push(resolved.settings);
+      if (resolved.ref.type?.length) {
+        pluginIDs.add(resolved.ref.type);
+      }
+      if (resolved.ref.uid?.length) {
+        dsUIDs.add(resolved.ref.uid);
+      }
+    }
 
     const body = {
       queries,
@@ -284,7 +313,10 @@ class DataSourceWithBackend<
       return of({ data: [] });
     }
 
-    return from(this.createBackendRequest(request)).pipe(
+    // defer keeps the observable cold: without it the request preparation would start when
+    // query() is called rather than when it is subscribed to, and a rejection (e.g. an unknown
+    // datasource) on a never-subscribed observable would surface as an unhandled rejection.
+    return defer(() => this.createBackendRequest(request)).pipe(
       switchMap(([req, queries]) =>
         getBackendSrv()
           .fetch<BackendDataSourceResponse>(req)
@@ -297,9 +329,10 @@ class DataSourceWithBackend<
               }
               return of(rsp);
             }),
-            // Only fetch responses are turned into a response object here. toDataQueryResponse cannot
-            // map a plain thrown Error (e.g. an unknown datasource from createBackendRequest) and would
-            // silently produce an empty success, so those errors must propagate to the caller instead.
+            // Scoped to the fetch chain on purpose: toDataQueryResponse can only map fetch-shaped
+            // errors, and would turn a plain thrown Error (e.g. the unknown-datasource throw in
+            // createBackendRequest) into a silent empty success. Those errors are left to reach the
+            // subscriber, where runRequest turns them into a query error.
             catchError((err) => {
               return of(toDataQueryResponse(err));
             })

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -38,7 +38,6 @@ import { isQueryServiceCompatible } from './qscheck';
 import { type BackendDataSourceResponse, toDataQueryResponse } from './queryResponse';
 import { UserStorage } from './userStorage';
 
-
 export class HealthCheckError extends Error {
   details: HealthCheckResultDetails;
 

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -11,7 +11,6 @@ import {
   DataSourceApi,
   type DataSourceInstanceSettings,
   type DataSourceJsonData,
-  type DataSourceRef,
   getDataSourceRef,
   makeClassES5Compatible,
   parseLiveChannelAddress,
@@ -31,32 +30,14 @@ import {
   StreamingFrameAction,
   type StreamingFrameOptions,
 } from '../services';
+import { getDataSourceInstanceSettings } from '../services/dataSource/settings';
 
-import { getDataSourceInstanceSettings } from './../unstable';
+import { ExpressionDatasourceRef, isExpressionReference } from './expressionRef';
 import { publicDashboardQueryHandler } from './publicDashboardQueryHandler';
 import { isQueryServiceCompatible } from './qscheck';
 import { type BackendDataSourceResponse, toDataQueryResponse } from './queryResponse';
 import { UserStorage } from './userStorage';
 
-/**
- * @internal
- */
-export const ExpressionDatasourceRef = Object.freeze({
-  type: '__expr__',
-  uid: '__expr__',
-  name: 'Expression',
-});
-
-/**
- * @public
- */
-export function isExpressionReference(ref?: DataSourceRef | string | null): boolean {
-  if (!ref) {
-    return false;
-  }
-  const v = typeof ref === 'string' ? ref : ref.type;
-  return v === ExpressionDatasourceRef.type || v === ExpressionDatasourceRef.name || v === '-100'; // -100 was a legacy accident that should be removed
-}
 
 export class HealthCheckError extends Error {
   details: HealthCheckResultDetails;

--- a/packages/grafana-runtime/src/utils/expressionRef.test.ts
+++ b/packages/grafana-runtime/src/utils/expressionRef.test.ts
@@ -1,0 +1,13 @@
+import { isExpressionReference } from './expressionRef';
+
+describe('isExpressionReference', () => {
+  test('check all possible expression references', () => {
+    expect(isExpressionReference('__expr__')).toBeTruthy(); // New UID
+    expect(isExpressionReference('-100')).toBeTruthy(); // Legacy UID
+    expect(isExpressionReference('Expression')).toBeTruthy(); // Name
+    expect(isExpressionReference({ type: '__expr__' })).toBeTruthy();
+    expect(isExpressionReference({ type: '-100' })).toBeTruthy();
+    expect(isExpressionReference(null)).toBeFalsy();
+    expect(isExpressionReference(undefined)).toBeFalsy();
+  });
+});

--- a/packages/grafana-runtime/src/utils/expressionRef.ts
+++ b/packages/grafana-runtime/src/utils/expressionRef.ts
@@ -1,0 +1,21 @@
+import { type DataSourceRef } from '@grafana/data';
+
+/**
+ * @internal
+ */
+export const ExpressionDatasourceRef = Object.freeze({
+  type: '__expr__',
+  uid: '__expr__',
+  name: 'Expression',
+});
+
+/**
+ * @public
+ */
+export function isExpressionReference(ref?: DataSourceRef | string | null): boolean {
+  if (!ref) {
+    return false;
+  }
+  const v = typeof ref === 'string' ? ref : ref.type;
+  return v === ExpressionDatasourceRef.type || v === ExpressionDatasourceRef.name || v === '-100'; // -100 was a legacy accident that should be removed
+}


### PR DESCRIPTION
solves https://github.com/grafana/grafana/issues/127041

we are switching to a new way to access the data-source-instance-settings. the problem is, the new way is async, while the old way was not.

to make the PR easier to follow, i recommend reading it commit by commit:
- commit1: `refactor code in preparation of changes`
    - we extract the first part of the `query` method into a new method named `createBackendRequest`.
- commit2: `switched to async`
    - we switch the extracted `createBackendRequest` method to be `async`, and adjust the caller in `query()` to handle this
- commit3: `switch to getDataSourceInstanceSettings`
    - we switch to use the new `async` function, `getDtaSourceInstanceSettings`