### PR TITLE
Unified storage: cap startup GetResourceStats counting on the KV backend

### DIFF
--- a/pkg/storage/unified/resource/datastore.go
+++ b/pkg/storage/unified/resource/datastore.go
@@ -656,30 +656,7 @@ func (d *dataStore) GetResourceStats(ctx context.Context, nsr NamespacedResource
 	))
 	defer span.End()
 
-	// First, get all unique group/resource combinations in the store
-	groupResources, err := d.getGroupResources(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get group resources: %w", err)
-	}
-
-	var stats []ResourceStats
-
-	// Process each group/resource combination
-	for _, groupResource := range groupResources {
-		if nsr.Group != "" && groupResource.Group != nsr.Group {
-			continue
-		}
-		if nsr.Resource != "" && groupResource.Resource != nsr.Resource {
-			continue
-		}
-		groupStats, err := d.processGroupResourceStats(ctx, groupResource, nsr.Namespace, minCount)
-		if err != nil {
-			return nil, fmt.Errorf("failed to process stats for %s/%s: %w", groupResource.Group, groupResource.Resource, err)
-		}
-		stats = append(stats, groupStats...)
-	}
-
-	return stats, nil
+	return d.resourceStats(ctx, nsr, minCount, 0)
 }
 
 // ListStoredResources implements StorageBackend for the KV backend.
@@ -747,87 +724,134 @@ func (d *dataStore) groupResourceExistsInNamespace(ctx context.Context, gr Group
 	return false, nil
 }
 
-// processGroupResourceStats processes stats for a specific group/resource combination
-func (d *dataStore) processGroupResourceStats(ctx context.Context, groupResource GroupResource, namespace string, minCount int) ([]ResourceStats, error) {
+// GetResourceStatsWithLimit implements StorageBackend. See the interface docs.
+func (d *dataStore) GetResourceStatsWithLimit(ctx context.Context, nsr NamespacedResource, minCount, countLimit int) ([]ResourceStats, error) {
+	ctx, span := tracer.Start(ctx, "resource.dataStore.GetResourceStatsWithLimit", trace.WithAttributes(
+		attribute.Int("minCount", minCount),
+		attribute.Int("countLimit", countLimit),
+	))
+	defer span.End()
+
+	return d.resourceStats(ctx, nsr, minCount, countLimit)
+}
+
+// resourceStats enumerates the stored group/resources and counts each one per
+// namespace. countLimit is forwarded to processGroupResourceStats (0 = exact).
+func (d *dataStore) resourceStats(ctx context.Context, nsr NamespacedResource, minCount, countLimit int) ([]ResourceStats, error) {
+	groupResources, err := d.getGroupResources(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get group resources: %w", err)
+	}
+
+	var stats []ResourceStats
+	for _, gr := range groupResources {
+		if nsr.Group != "" && gr.Group != nsr.Group {
+			continue
+		}
+		if nsr.Resource != "" && gr.Resource != nsr.Resource {
+			continue
+		}
+		grStats, err := d.processGroupResourceStats(ctx, gr, nsr.Namespace, minCount, countLimit)
+		if err != nil {
+			return nil, fmt.Errorf("failed to process stats for %s/%s: %w", gr.Group, gr.Resource, err)
+		}
+		stats = append(stats, grStats...)
+	}
+	return stats, nil
+}
+
+// processGroupResourceStats counts live resources per namespace for one
+// group/resource. When countLimit > 0 it stops counting a namespace once it
+// reaches countLimit and seeks past the rest of that namespace's keys instead of
+// scanning them, which is cheaper than an exact count on large history; the
+// reported Count is then at least countLimit and ResourceVersion is 0 (the scan
+// may stop before the newest key). countLimit <= 0 produces exact counts.
+func (d *dataStore) processGroupResourceStats(ctx context.Context, gr GroupResource, namespace string, minCount, countLimit int) ([]ResourceStats, error) {
 	ctx, span := tracer.Start(ctx, "resource.dataStore.processGroupResourceStats")
 	defer span.End()
 
-	// Use ListRequestKey to construct the appropriate prefix
-	listKey := ListRequestKey{
-		Group:     groupResource.Group,
-		Resource:  groupResource.Resource,
-		Namespace: namespace, // Empty string if not specified, which will list all namespaces
+	// An empty namespace scans every namespace for this group/resource; the
+	// startup index prebuild relies on this to discover stats across all
+	// namespaces in one pass.
+	basePrefix := gr.Group + "/" + gr.Resource + "/"
+	if namespace != "" {
+		basePrefix += namespace + "/"
 	}
 
-	// Maps to track counts per namespace for this group/resource
-	namespaceCounts := make(map[string]int64)   // namespace -> count of existing resources
-	namespaceVersions := make(map[string]int64) // namespace -> latest resource version
+	var stats []ResourceStats
 
-	// Track current resource being processed
-	var currentResourceKey string
-	var lastDataKey *DataKey
+	// Iterate descending so the first key seen for each name is its latest
+	// version, which decides liveness directly. open distinguishes "not started"
+	// from a cluster-scoped resource (empty namespace).
+	open := false
+	curNS := ""
+	curName := ""
+	var liveCount, maxRV int64
 
-	// Helper function to process the last seen resource
-	processLastResource := func() {
-		if lastDataKey != nil {
-			// Initialize namespace version if not exists
-			if _, exists := namespaceVersions[lastDataKey.Namespace]; !exists {
-				namespaceVersions[lastDataKey.Namespace] = 0
+	emit := func() {
+		if open && liveCount > int64(minCount) {
+			stats = append(stats, ResourceStats{
+				NamespacedResource: NamespacedResource{Namespace: curNS, Group: gr.Group, Resource: gr.Resource},
+				Count:              liveCount,
+				ResourceVersion:    maxRV,
+			})
+		}
+		open, curName, liveCount, maxRV = false, "", 0, 0
+	}
+
+	// endKey is the exclusive upper bound; it shrinks as capped namespaces are
+	// skipped, moving the scan down to the next namespace.
+	endKey := PrefixRangeEnd(basePrefix)
+	for {
+		seeked := false
+		for key, err := range d.kv.Keys(ctx, dataSection, ListOptions{StartKey: basePrefix, EndKey: endKey, Sort: SortOrderDesc}) {
+			if err != nil {
+				return nil, err
+			}
+			dk, err := ParseKey(key)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse key %s: %w", key, err)
 			}
 
-			// If resource exists (not deleted), increment the count for this namespace
-			if lastDataKey.Action != DataActionDeleted {
-				namespaceCounts[lastDataKey.Namespace]++
+			if !open {
+				open, curNS = true, dk.Namespace
+			} else if dk.Namespace != curNS {
+				emit()
+				open, curNS = true, dk.Namespace
+			}
+			if dk.Name == curName {
+				continue // older version of a resource already counted
+			}
+			curName = dk.Name
+			// maxRV is the namespace's latest version, reported as ResourceVersion in
+			// exact mode only; a capped count has no meaningful latest version.
+			if countLimit == 0 && dk.ResourceVersion > maxRV {
+				maxRV = dk.ResourceVersion
+			}
+			if dk.Action != DataActionDeleted {
+				liveCount++
 			}
 
-			// Update to latest resource version seen
-			if lastDataKey.ResourceVersion > namespaceVersions[lastDataKey.Namespace] {
-				namespaceVersions[lastDataKey.Namespace] = lastDataKey.ResourceVersion
+			if countLimit > 0 && liveCount >= int64(countLimit) {
+				ns := curNS
+				emit()
+				// Skip the rest of this namespace by lowering the upper bound to its
+				// prefix. A cluster-scoped resource is one partition under
+				// group/resource, so drop the whole prefix.
+				if ns == "" {
+					endKey = basePrefix
+				} else {
+					endKey = gr.Group + "/" + gr.Resource + "/" + ns + "/"
+				}
+				seeked = true
+				break
 			}
 		}
-	}
-
-	// List all keys using the existing Keys method
-	for dataKey, err := range d.Keys(ctx, listKey, SortOrderAsc) {
-		if err != nil {
-			return nil, err
+		if !seeked {
+			emit()
+			break
 		}
-
-		// Create unique resource identifier (namespace/group/resource/name)
-		resourceKey := fmt.Sprintf("%s/%s/%s/%s", dataKey.Namespace, dataKey.Group, dataKey.Resource, dataKey.Name)
-
-		// If we've moved to a different resource, process the previous one
-		if currentResourceKey != "" && resourceKey != currentResourceKey {
-			processLastResource()
-		}
-
-		// Update tracking variables for the current resource
-		currentResourceKey = resourceKey
-		lastDataKey = &dataKey
 	}
-
-	// Process the final resource
-	processLastResource()
-
-	// Convert namespace counts to ResourceStats
-	stats := make([]ResourceStats, 0, len(namespaceCounts))
-	for ns, count := range namespaceCounts {
-		// Skip if count is below or equal to minimum
-		if count <= int64(minCount) {
-			continue
-		}
-
-		stats = append(stats, ResourceStats{
-			NamespacedResource: NamespacedResource{
-				Namespace: ns,
-				Group:     groupResource.Group,
-				Resource:  groupResource.Resource,
-			},
-			Count:           count,
-			ResourceVersion: namespaceVersions[ns],
-		})
-	}
-
 	return stats, nil
 }
 

--- a/pkg/storage/unified/resource/datastore_test.go
+++ b/pkg/storage/unified/resource/datastore_test.go
@@ -3100,6 +3100,138 @@ func testDataStoreGetGroupResources(t *testing.T, ctx context.Context, ds *dataS
 	}
 }
 
+func TestIntegrationDataStore_GetResourceStatsWithLimit(t *testing.T) {
+	runDataStoreTestWith(t, "badger", setupTestDataStore, testDataStoreGetResourceStatsWithLimit)
+	runDataStoreTestWith(t, "sqlkv", setupTestDataStoreSqlKv, testDataStoreGetResourceStatsWithLimit)
+}
+
+func testDataStoreGetResourceStatsWithLimit(t *testing.T, ctx context.Context, ds *dataStore) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	save := func(ns, name string, action kv.DataAction) {
+		rv := node.Generate().Int64()
+		err := ds.Save(ctx, DataKey{
+			Namespace:       ns,
+			Group:           "apps",
+			Resource:        "deployments",
+			Name:            name,
+			ResourceVersion: rv,
+			Action:          action,
+			Folder:          "f",
+		}, bytes.NewReader([]byte("content")))
+		require.NoError(t, err)
+	}
+
+	// ns-big has 8 live resources; ns-small has 3 live plus one that was deleted.
+	// ns-big sorts before ns-small, so the scan hits the big namespace first.
+	for i := range 8 {
+		save("ns-big", fmt.Sprintf("name-%02d", i), DataActionCreated)
+	}
+	for i := range 3 {
+		save("ns-small", fmt.Sprintf("name-%02d", i), DataActionCreated)
+	}
+	save("ns-small", "gone", DataActionCreated)
+	save("ns-small", "gone", DataActionDeleted)
+	// Recreated resource: latest event is a create, so it counts as live.
+	save("ns-small", "back", DataActionCreated)
+	save("ns-small", "back", DataActionDeleted)
+	save("ns-small", "back", DataActionCreated)
+
+	byNamespace := func(stats []ResourceStats) map[string]int64 {
+		out := map[string]int64{}
+		for _, s := range stats {
+			require.Equal(t, "apps", s.Group)
+			require.Equal(t, "deployments", s.Resource)
+			out[s.Namespace] = s.Count
+		}
+		return out
+	}
+
+	// Exact counts (no limit): deleted resource is excluded.
+	exact, err := ds.GetResourceStats(ctx, NamespacedResource{}, 0)
+	require.NoError(t, err)
+	// ns-small: 3 singles + "gone" (deleted, excluded) + "back" (recreated, live) = 4.
+	require.Equal(t, map[string]int64{"ns-big": 8, "ns-small": 4}, byNamespace(exact))
+
+	// With a limit of 5: ns-big is capped (counted early-exit, not the full 8),
+	// ns-small stays exact because it is below the limit.
+	const countLimit = 5
+	capped, err := ds.GetResourceStatsWithLimit(ctx, NamespacedResource{}, 0, countLimit)
+	require.NoError(t, err)
+	got := byNamespace(capped)
+	require.Contains(t, got, "ns-big")
+	require.Contains(t, got, "ns-small")
+	require.GreaterOrEqual(t, got["ns-big"], int64(countLimit))
+	require.Less(t, got["ns-big"], int64(8), "large namespace should be capped, not fully counted")
+	require.Equal(t, int64(4), got["ns-small"], "namespace below the limit should be exact")
+
+	// minCount still excludes small namespaces when a valid countLimit (> minCount)
+	// caps a large one: ns-big (8 live) is capped and passes, ns-small (4 live) is
+	// excluded.
+	filtered, err := ds.GetResourceStatsWithLimit(ctx, NamespacedResource{}, 4, 6)
+	require.NoError(t, err)
+	gotFiltered := byNamespace(filtered)
+	require.GreaterOrEqual(t, gotFiltered["ns-big"], int64(6))
+	require.Less(t, gotFiltered["ns-big"], int64(8), "large namespace should be capped")
+	require.NotContains(t, gotFiltered, "ns-small", "namespace at or below minCount must be excluded")
+
+	// countLimit <= 0 behaves like the exact path.
+	unlimited, err := ds.GetResourceStatsWithLimit(ctx, NamespacedResource{}, 0, 0)
+	require.NoError(t, err)
+	require.Equal(t, map[string]int64{"ns-big": 8, "ns-small": 4}, byNamespace(unlimited))
+}
+
+func TestIntegrationDataStore_GetResourceStatsWithLimitClusterScoped(t *testing.T) {
+	runDataStoreTestWith(t, "badger", setupTestDataStore, testDataStoreGetResourceStatsWithLimitClusterScoped)
+	runDataStoreTestWith(t, "sqlkv", setupTestDataStoreSqlKv, testDataStoreGetResourceStatsWithLimitClusterScoped)
+}
+
+// Cluster-scoped resources have keys with no namespace segment (Namespace == "").
+// They must be counted by the exact path, and the limited path must cap them and
+// terminate rather than re-scanning the same keys forever.
+func testDataStoreGetResourceStatsWithLimitClusterScoped(t *testing.T, ctx context.Context, ds *dataStore) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	save := func(name string) {
+		rv := node.Generate().Int64()
+		err := ds.Save(ctx, DataKey{
+			Group:           "apps",
+			Resource:        "deployments",
+			Name:            name,
+			ResourceVersion: rv,
+			Action:          DataActionCreated,
+			Folder:          "f",
+		}, bytes.NewReader([]byte("content")))
+		require.NoError(t, err)
+	}
+	for i := range 8 {
+		save(fmt.Sprintf("item-%02d", i))
+	}
+
+	find := func(stats []ResourceStats) *ResourceStats {
+		for i := range stats {
+			if stats[i].Resource == "deployments" {
+				require.Equal(t, "", stats[i].Namespace, "cluster-scoped stats have empty namespace")
+				return &stats[i]
+			}
+		}
+		return nil
+	}
+
+	exact, err := ds.GetResourceStats(ctx, NamespacedResource{}, 0)
+	require.NoError(t, err)
+	cs := find(exact)
+	require.NotNil(t, cs, "cluster-scoped resource must appear in exact stats")
+	require.Equal(t, int64(8), cs.Count)
+
+	capped, err := ds.GetResourceStatsWithLimit(ctx, NamespacedResource{}, 0, 5)
+	require.NoError(t, err)
+	cs = find(capped)
+	require.NotNil(t, cs, "cluster-scoped resource must appear in limited stats")
+	require.GreaterOrEqual(t, cs.Count, int64(5))
+	require.Less(t, cs.Count, int64(8), "cluster-scoped count should be capped")
+}
+
 func TestIntegrationDataStore_BatchDelete(t *testing.T) {
 	runDataStoreTestWith(t, "badger", setupTestDataStore, testDataStoreBatchDelete)
 	runDataStoreTestWith(t, "sqlkv", setupTestDataStoreSqlKv, testDataStoreBatchDelete)

--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -169,6 +169,12 @@ type SearchBackend interface {
 	// TotalDocs returns the total number of documents across all indexes.
 	TotalDocs() int64
 
+	// SnapshotCountThreshold returns the document count at or above which
+	// BuildIndex uses remote snapshots, or 0 when snapshots are inactive (no
+	// store configured). The startup prebuild uses it to cap counting without
+	// changing the snapshot decision.
+	SnapshotCountThreshold() int64
+
 	// GetOpenIndexes returns the list of indexes that are currently open.
 	GetOpenIndexes() []NamespacedResource
 
@@ -1186,9 +1192,18 @@ func (s *searchServer) startupIndexStats(ctx context.Context) ([]ResourceStats, 
 		s.log.FromContext(ctx).Debug("open index stats unavailable, falling back to resource stats")
 	}
 
+	// The prebuild only compares counts against thresholds, so cap counting above
+	// the highest one that consumes the count: init min size, plus the snapshot
+	// threshold when a snapshot store is active.
+	limit := s.initMinSize
+	if t := int(s.search.SnapshotCountThreshold()); t > limit {
+		limit = t
+	}
+	limit++
+
 	start := time.Now()
-	stats, err = s.storage.GetResourceStats(ctx, NamespacedResource{}, s.initMinSize)
-	s.log.Debug("startupIndexStats: got resource stats from storage", "elapsed", time.Since(start).String(), "stats", len(stats), "err", err)
+	stats, err = s.storage.GetResourceStatsWithLimit(ctx, NamespacedResource{}, s.initMinSize, limit)
+	s.log.Debug("startupIndexStats: got resource stats from storage", "elapsed", time.Since(start).String(), "stats", len(stats), "err", err, "countLimit", limit)
 	return stats, err
 }
 

--- a/pkg/storage/unified/resource/search_test.go
+++ b/pkg/storage/unified/resource/search_test.go
@@ -98,6 +98,7 @@ type mockStorageBackend struct {
 	statsCalls      atomic.Int32
 	listStoredCalls atomic.Int32
 	listStoredErr   error
+	lastCountLimit  atomic.Int64
 }
 
 func (m *mockStorageBackend) GetResourceStats(ctx context.Context, nsr NamespacedResource, minCount int) ([]ResourceStats, error) {
@@ -137,6 +138,11 @@ func (m *mockStorageBackend) ListStoredResources(_ context.Context, filter Names
 		result = append(result, stat.NamespacedResource)
 	}
 	return result, nil
+}
+
+func (m *mockStorageBackend) GetResourceStatsWithLimit(ctx context.Context, nsr NamespacedResource, minCount, countLimit int) ([]ResourceStats, error) {
+	m.lastCountLimit.Store(int64(countLimit))
+	return m.GetResourceStats(ctx, nsr, minCount)
 }
 
 func (m *mockStorageBackend) WriteEvent(ctx context.Context, event WriteEvent) (int64, error) {
@@ -181,10 +187,15 @@ func (m *mockStorageBackend) GetResourceLastImportTimes(ctx context.Context) ite
 type mockSearchBackend struct {
 	openIndexes []NamespacedResource
 
-	mu              sync.Mutex
-	buildIndexCalls []buildIndexCall
-	cache           map[NamespacedResource]ResourceIndex
-	stopCalls       atomic.Int32
+	mu                sync.Mutex
+	buildIndexCalls   []buildIndexCall
+	cache             map[NamespacedResource]ResourceIndex
+	stopCalls         atomic.Int32
+	snapshotThreshold int64
+}
+
+func (m *mockSearchBackend) SnapshotCountThreshold() int64 {
+	return m.snapshotThreshold
 }
 
 type buildIndexCall struct {
@@ -194,6 +205,37 @@ type buildIndexCall struct {
 
 func (m *mockSearchBackend) LoadOpenIndexStats(_ time.Time, _ time.Duration) ([]ResourceStats, error) {
 	return nil, nil
+}
+
+// TestStartupIndexStatsCountLimit checks the cap the startup prebuild passes to
+// the backend: init min size + 1, raised to the snapshot threshold + 1 when
+// snapshots are enabled.
+func TestStartupIndexStatsCountLimit(t *testing.T) {
+	cases := []struct {
+		name              string
+		initMinCount      int
+		snapshotThreshold int64 // 0 means no active snapshot store
+		wantLimit         int64
+	}{
+		{"no snapshot store", 5, 0, 6},
+		{"snapshot threshold higher", 5, 100, 101},
+		{"init min higher", 50, 10, 51},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			storage := &mockStorageBackend{}
+			server, err := newSearchServer(SearchOptions{
+				Backend:      &mockSearchBackend{snapshotThreshold: tc.snapshotThreshold},
+				Resources:    &TestDocumentBuilderSupplier{GroupsResources: map[string]string{"group": "resource"}},
+				InitMinCount: tc.initMinCount,
+			}, storage, nil, nil, nil, nil, nil, nil, nil)
+			require.NoError(t, err)
+
+			_, err = server.startupIndexStats(t.Context())
+			require.NoError(t, err)
+			require.Equal(t, tc.wantLimit, storage.lastCountLimit.Load())
+		})
+	}
 }
 
 func (m *mockSearchBackend) WriteOpenIndexStats(_ time.Time) error {

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -182,6 +182,15 @@ type StorageBackend interface {
 	// Get resource stats within the storage backend.  When namespace is empty, it will apply to all
 	GetResourceStats(ctx context.Context, nsr NamespacedResource, minCount int) ([]ResourceStats, error)
 
+	// GetResourceStatsWithLimit is like GetResourceStats but may stop counting a
+	// namespace once it reaches countLimit, letting callers that only compare
+	// counts against thresholds avoid scanning full history. countLimit <= 0 means
+	// no limit; a backend may also ignore it and return exact counts. In limited
+	// mode (countLimit > 0) ResourceVersion is not populated, and countLimit must
+	// be greater than minCount so a namespace is not dropped by the minCount filter
+	// before it is counted.
+	GetResourceStatsWithLimit(ctx context.Context, nsr NamespacedResource, minCount, countLimit int) ([]ResourceStats, error)
+
 	// ListStoredResources discovers which resource identities exist in storage,
 	// without returning counts. It is a cheaper alternative to GetResourceStats
 	// for callers that only need to know what is stored. The filter's Namespace

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -2317,6 +2317,20 @@ func (k *kvStorageBackend) GetResourceStats(ctx context.Context, nsr NamespacedR
 	return k.dataStore.GetResourceStats(ctx, nsr, minCount)
 }
 
+// GetResourceStatsWithLimit is like GetResourceStats but stops counting each
+// namespace at countLimit. See dataStore.GetResourceStatsWithLimit.
+func (k *kvStorageBackend) GetResourceStatsWithLimit(ctx context.Context, nsr NamespacedResource, minCount, countLimit int) ([]ResourceStats, error) {
+	ctx, span := tracer.Start(ctx, "resource.kvStorageBackend.GetResourceStatsWithLimit", trace.WithAttributes(
+		attribute.String("namespace", nsr.Namespace),
+		attribute.String("group", nsr.Group),
+		attribute.String("resource", nsr.Resource),
+		attribute.Int("countLimit", countLimit),
+	))
+	defer span.End()
+
+	return k.dataStore.GetResourceStatsWithLimit(ctx, nsr, minCount, countLimit)
+}
+
 // ListStoredResources discovers resource identities in the storage backend.
 func (k *kvStorageBackend) ListStoredResources(ctx context.Context, filter NamespacedResource) ([]NamespacedResource, error) {
 	ctx, span := tracer.Start(ctx, "resource.kvStorageBackend.ListStoredResources", trace.WithAttributes(

--- a/pkg/storage/unified/resource/unimplemented.go
+++ b/pkg/storage/unified/resource/unimplemented.go
@@ -70,6 +70,10 @@ func (UnimplementedStorageBackend) GetResourceStats(context.Context, NamespacedR
 	return nil, errUnimplemented
 }
 
+func (UnimplementedStorageBackend) GetResourceStatsWithLimit(context.Context, NamespacedResource, int, int) ([]ResourceStats, error) {
+	return nil, errUnimplemented
+}
+
 func (UnimplementedStorageBackend) ListStoredResources(context.Context, NamespacedResource) ([]NamespacedResource, error) {
 	return nil, errUnimplemented
 }

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -1482,6 +1482,16 @@ func isPathWithinRoot(path, absoluteRoot string) bool {
 }
 
 // TotalDocs returns the total number of documents across all indices
+// SnapshotCountThreshold returns the snapshot MinDocCount, or 0 when no snapshot
+// store is configured (in which case BuildIndex never uses snapshots and the
+// count is not consumed by that decision).
+func (b *bleveBackend) SnapshotCountThreshold() int64 {
+	if b.opts.Snapshot.Store == nil {
+		return 0
+	}
+	return b.opts.Snapshot.MinDocCount
+}
+
 func (b *bleveBackend) TotalDocs() int64 {
 	var totalDocs int64
 	// We iterate over keys and call getCachedIndex for each index individually.

--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -793,6 +793,13 @@ func (b *backend) GetResourceStats(ctx context.Context, nsr resource.NamespacedR
 	return res, err
 }
 
+// GetResourceStatsWithLimit ignores countLimit and returns exact counts. The SQL
+// backend's stats query is not a history scan, so early exit is not needed here;
+// exact counts are valid for callers that only compare against thresholds.
+func (b *backend) GetResourceStatsWithLimit(ctx context.Context, nsr resource.NamespacedResource, minCount, _ int) ([]resource.ResourceStats, error) {
+	return b.GetResourceStats(ctx, nsr, minCount)
+}
+
 // ListStoredResources implements Backend.
 func (b *backend) ListStoredResources(ctx context.Context, filter resource.NamespacedResource) ([]resource.NamespacedResource, error) {
 	b.logCall("ListStoredResources")


### PR DESCRIPTION
The startup index prebuild calls `GetResourceStats` to learn which resources exist and roughly how large each index is. On the KV backend that scans resource history and is slow (tens of seconds on larger tenants). The prebuild only needs to know whether each count clears a couple of thresholds, not the exact value, so this adds a `GetResourceStatsWithLimit` variant that stops counting a namespace once it passes the highest relevant threshold. The KV backend seeks past a namespace once it hits the limit; the legacy SQL backend returns exact counts (its query is not a history scan). Startup passes `countLimit = max(snapshot threshold, init min size) + 1`, where the snapshot threshold is 0 when no snapshot store is configured.

Two design points:

- Why both `minCount` and `countLimit`: `minCount` filters which resources are included (skip small ones); `countLimit` caps how far we count for performance. The effective cap is raised to at least `minCount + 1` so it never drops a resource the filter would keep.
- Why a separate method: existing `GetResourceStats` callers stay untouched, and the limited variant's different contract (counts may be capped, `ResourceVersion` not populated) reads more clearly on its own.

Whether this reduces work on the SQL-backed KV depends on data shape and will be confirmed from the startup timing log after rollout; it helps most when a namespace has many live objects.
