### PR TITLE
Dashboards: Fix scripted dashboards with rows not displaying panels

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1733,7 +1733,7 @@
       "count": 2
     },
     "@typescript-eslint/no-explicit-any": {
-      "count": 16
+      "count": 13
     }
   },
   "public/app/features/dashboard/state/DashboardModel.repeat.test.ts": {

--- a/public/app/features/dashboard/api/ResponseTransformers.test.ts
+++ b/public/app/features/dashboard/api/ResponseTransformers.test.ts
@@ -1250,4 +1250,62 @@ describe('ResponseTransformers', () => {
       expect(v2.spec.disabledValue).toBe(disabledValue);
     }
   }
+  
+  describe('scripted dashboard with rows (old format)', () => {
+    it('should convert rows to panels for scripted dashboards', () => {
+      const scriptedDashboard: DashboardDTO = {
+        meta: {
+          canSave: false,
+          canEdit: false,
+          canDelete: false,
+          canShare: false,
+          canStar: false,
+          canAdmin: false,
+          url: '',
+          slug: '',
+          fromScript: true,
+        },
+        dashboard: {
+          uid: 'scripted-dash',
+          title: 'Scripted dash',
+          time: {
+            from: 'now-6h',
+            to: 'now',
+          },
+          rows: [
+            {
+              title: 'Chart',
+              height: '300px',
+              panels: [
+                {
+                  id: 1,
+                  title: 'Events',
+                  type: 'timeseries',
+                  span: 12,
+                  targets: [
+                    {
+                      scenarioId: 'random_walk',
+                      refId: 'A',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        } as any,
+      };
+
+      const result = ResponseTransformers.ensureV2Response(scriptedDashboard);
+
+      expect(result.kind).toBe('DashboardWithAccessInfo');
+      expect(result.spec.title).toBe('Scripted dash');
+      expect(Object.keys(result.spec.elements).length).toBe(1);
+      
+      const panelElement = result.spec.elements['panel-1'] as PanelKind;
+      expect(panelElement).toBeDefined();
+      expect(panelElement.kind).toBe('Panel');
+      expect(panelElement.spec.title).toBe('Events');
+      expect(panelElement.spec.vizConfig.group).toBe('timeseries');
+    });
+  });
 });

--- a/public/app/features/dashboard/api/ResponseTransformers.test.ts
+++ b/public/app/features/dashboard/api/ResponseTransformers.test.ts
@@ -1250,7 +1250,7 @@ describe('ResponseTransformers', () => {
       expect(v2.spec.disabledValue).toBe(disabledValue);
     }
   }
-  
+
   describe('scripted dashboard with rows (old format)', () => {
     it('should convert rows to panels for scripted dashboards', () => {
       const scriptedDashboard: DashboardDTO = {
@@ -1300,7 +1300,7 @@ describe('ResponseTransformers', () => {
       expect(result.kind).toBe('DashboardWithAccessInfo');
       expect(result.spec.title).toBe('Scripted dash');
       expect(Object.keys(result.spec.elements).length).toBe(1);
-      
+
       const panelElement = result.spec.elements['panel-1'] as PanelKind;
       expect(panelElement).toBeDefined();
       expect(panelElement.kind).toBe('Panel');

--- a/public/app/features/dashboard/api/ResponseTransformers.test.ts
+++ b/public/app/features/dashboard/api/ResponseTransformers.test.ts
@@ -1251,9 +1251,9 @@ describe('ResponseTransformers', () => {
     }
   }
 
-  describe('scripted dashboard with rows (old format)', () => {
-    it('should convert rows to panels for scripted dashboards', () => {
-      const scriptedDashboard: DashboardDTO = {
+  describe('dashboard with rows (pre-schema-version-16 format)', () => {
+    function buildRowsDashboard(rows: unknown[]): DashboardDTO {
+      return {
         meta: {
           canSave: false,
           canEdit: false,
@@ -1272,40 +1272,86 @@ describe('ResponseTransformers', () => {
             from: 'now-6h',
             to: 'now',
           },
-          rows: [
-            {
-              title: 'Chart',
-              height: '300px',
-              panels: [
-                {
-                  id: 1,
-                  title: 'Events',
-                  type: 'timeseries',
-                  span: 12,
-                  targets: [
-                    {
-                      scenarioId: 'random_walk',
-                      refId: 'A',
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
-        } as any,
+          rows,
+        } as unknown as DashboardDataDTO,
       };
+    }
 
-      const result = ResponseTransformers.ensureV2Response(scriptedDashboard);
+    it('should convert rows to panels', () => {
+      const result = ResponseTransformers.ensureV2Response(
+        buildRowsDashboard([
+          {
+            title: 'Chart',
+            height: '300px',
+            panels: [
+              {
+                id: 1,
+                title: 'Events',
+                type: 'timeseries',
+                span: 12,
+                targets: [{ scenarioId: 'random_walk', refId: 'A' }],
+              },
+            ],
+          },
+        ])
+      );
 
       expect(result.kind).toBe('DashboardWithAccessInfo');
       expect(result.spec.title).toBe('Scripted dash');
       expect(Object.keys(result.spec.elements).length).toBe(1);
 
       const panelElement = result.spec.elements['panel-1'] as PanelKind;
-      expect(panelElement).toBeDefined();
       expect(panelElement.kind).toBe('Panel');
       expect(panelElement.spec.title).toBe('Events');
       expect(panelElement.spec.vizConfig.group).toBe('timeseries');
+
+      const layout = result.spec.layout as GridLayoutKind;
+      expect(layout.kind).toBe('GridLayout');
+      expect(layout.spec.items).toHaveLength(1);
+      expect(layout.spec.items[0].spec).toMatchObject({ x: 0, y: 0, width: 24, height: 8 });
+    });
+
+    it('should lay out panels of the same row side by side', () => {
+      const result = ResponseTransformers.ensureV2Response(
+        buildRowsDashboard([
+          {
+            height: '250px',
+            panels: [
+              { id: 1, title: 'Left', type: 'timeseries', span: 6 },
+              { id: 2, title: 'Right', type: 'timeseries', span: 6 },
+            ],
+          },
+          {
+            height: '250px',
+            panels: [{ id: 3, title: 'Bottom', type: 'timeseries', span: 12 }],
+          },
+        ])
+      );
+
+      const layout = result.spec.layout as GridLayoutKind;
+      expect(layout.spec.items.map((item) => item.spec)).toMatchObject([
+        { x: 0, y: 0, width: 12, height: 7 },
+        { x: 12, y: 0, width: 12, height: 7 },
+        { x: 0, y: 7, width: 24, height: 7 },
+      ]);
+    });
+
+    it('should convert rows with a visible title to a rows layout', () => {
+      const result = ResponseTransformers.ensureV2Response(
+        buildRowsDashboard([
+          {
+            title: 'Row A',
+            showTitle: true,
+            height: '250px',
+            panels: [{ id: 1, title: 'Events', type: 'timeseries', span: 12 }],
+          },
+        ])
+      );
+
+      const layout = result.spec.layout as RowsLayoutKind;
+      expect(layout.kind).toBe('RowsLayout');
+      expect(layout.spec.rows).toHaveLength(1);
+      expect(layout.spec.rows[0].spec.title).toBe('Row A');
     });
   });
 });

--- a/public/app/features/dashboard/api/ResponseTransformers.ts
+++ b/public/app/features/dashboard/api/ResponseTransformers.ts
@@ -176,7 +176,7 @@ export function ensureV2Response(
 
   const timeSettingsDefaults = defaultTimeSettingsSpec();
   const dashboardDefaults = defaultDashboardV2Spec();
-  
+
   // Handle old dashboard format with rows instead of panels (e.g., scripted dashboards)
   // Old format (pre-schema-version-16): { rows: [{ panels: [...] }] }
   // New format: { panels: [...] }
@@ -184,7 +184,7 @@ export function ensureV2Response(
   if (!panels && (dashboard as any).rows) {
     panels = migrateRowsToPanels((dashboard as any).rows);
   }
-  
+
   const [elements, layout] = getElementsFromPanels(panels || []);
   // @ts-expect-error - dashboard.templating.list is VariableModel[] and we need TypedVariableModel[] here
   // that would allow accessing unique properties for each variable type that the API returns
@@ -348,11 +348,11 @@ function migrateRowsToPanels(rows: any[]): Panel[] {
           h: panel.height || 8,
         },
       };
-      
+
       panels.push(panelWithGridPos);
     }
-    
-    yPos += Math.max(...row.panels.map((p: any) => (p.gridPos?.h || p.height || 8)), 8);
+
+    yPos += Math.max(...row.panels.map((p: any) => p.gridPos?.h || p.height || 8), 8);
   }
 
   return panels;

--- a/public/app/features/dashboard/api/ResponseTransformers.ts
+++ b/public/app/features/dashboard/api/ResponseTransformers.ts
@@ -176,7 +176,16 @@ export function ensureV2Response(
 
   const timeSettingsDefaults = defaultTimeSettingsSpec();
   const dashboardDefaults = defaultDashboardV2Spec();
-  const [elements, layout] = getElementsFromPanels(dashboard.panels || []);
+  
+  // Handle old dashboard format with rows instead of panels (e.g., scripted dashboards)
+  // Old format (pre-schema-version-16): { rows: [{ panels: [...] }] }
+  // New format: { panels: [...] }
+  let panels = dashboard.panels;
+  if (!panels && (dashboard as any).rows) {
+    panels = migrateRowsToPanels((dashboard as any).rows);
+  }
+  
+  const [elements, layout] = getElementsFromPanels(panels || []);
   // @ts-expect-error - dashboard.templating.list is VariableModel[] and we need TypedVariableModel[] here
   // that would allow accessing unique properties for each variable type that the API returns
   const variables = getVariables(dashboard.templating?.list || []);
@@ -317,6 +326,36 @@ function getElementsFromPanels(
   }
 
   return [elements, layout];
+}
+
+function migrateRowsToPanels(rows: any[]): Panel[] {
+  const panels: Panel[] = [];
+  let yPos = 0;
+  const widthFactor = 2;
+
+  for (const row of rows) {
+    if (!row.panels) {
+      continue;
+    }
+
+    for (const panel of row.panels) {
+      const panelWithGridPos = {
+        ...panel,
+        gridPos: panel.gridPos || {
+          x: (panel.span || 12) > 12 ? 0 : ((panel.span || 12) - 12) * widthFactor,
+          y: yPos,
+          w: Math.min((panel.span || 12) * widthFactor, 24),
+          h: panel.height || 8,
+        },
+      };
+      
+      panels.push(panelWithGridPos);
+    }
+    
+    yPos += Math.max(...row.panels.map((p: any) => (p.gridPos?.h || p.height || 8)), 8);
+  }
+
+  return panels;
 }
 
 function convertToRowsLayout(

--- a/public/app/features/dashboard/api/ResponseTransformers.ts
+++ b/public/app/features/dashboard/api/ResponseTransformers.ts
@@ -62,6 +62,7 @@ import {
   DeprecatedInternalId,
   type ObjectMeta,
 } from 'app/features/apiserver/types';
+import { convertRowsToGridPanels, type LegacyRow } from 'app/features/dashboard/state/convertRowsToGridPanels';
 import { transformV2ToV1AnnotationQuery } from 'app/features/dashboard-scene/serialization/annotations';
 import { GRID_ROW_HEIGHT } from 'app/features/dashboard-scene/serialization/const';
 import { validateFiltersOrigin } from 'app/features/dashboard-scene/serialization/sceneVariablesSetToVariables';
@@ -177,15 +178,7 @@ export function ensureV2Response(
   const timeSettingsDefaults = defaultTimeSettingsSpec();
   const dashboardDefaults = defaultDashboardV2Spec();
 
-  // Handle old dashboard format with rows instead of panels (e.g., scripted dashboards)
-  // Old format (pre-schema-version-16): { rows: [{ panels: [...] }] }
-  // New format: { panels: [...] }
-  let panels = dashboard.panels;
-  if (!panels && (dashboard as any).rows) {
-    panels = migrateRowsToPanels((dashboard as any).rows);
-  }
-
-  const [elements, layout] = getElementsFromPanels(panels || []);
+  const [elements, layout] = getElementsFromPanels(getPanels(dashboard));
   // @ts-expect-error - dashboard.templating.list is VariableModel[] and we need TypedVariableModel[] here
   // that would allow accessing unique properties for each variable type that the API returns
   const variables = getVariables(dashboard.templating?.list || []);
@@ -328,34 +321,17 @@ function getElementsFromPanels(
   return [elements, layout];
 }
 
-function migrateRowsToPanels(rows: any[]): Panel[] {
-  const panels: Panel[] = [];
-  let yPos = 0;
-  const widthFactor = 2;
-
-  for (const row of rows) {
-    if (!row.panels) {
-      continue;
-    }
-
-    for (const panel of row.panels) {
-      const panelWithGridPos = {
-        ...panel,
-        gridPos: panel.gridPos || {
-          x: (panel.span || 12) > 12 ? 0 : ((panel.span || 12) - 12) * widthFactor,
-          y: yPos,
-          w: Math.min((panel.span || 12) * widthFactor, 24),
-          h: panel.height || 8,
-        },
-      };
-
-      panels.push(panelWithGridPos);
-    }
-
-    yPos += Math.max(...row.panels.map((p: any) => p.gridPos?.h || p.height || 8), 8);
+/**
+ * Dashboards stored on the backend are migrated to the latest schema version before they reach us,
+ * but client side ones (scripted dashboards) are not. Pre-schema-version-16 dashboards keep their
+ * panels inside `rows`, so run the same rows to grid conversion the v16 migration does.
+ */
+function getPanels(dashboard: DashboardDataDTO & { rows?: LegacyRow[] }): Array<Panel | RowPanel> {
+  if (dashboard.panels) {
+    return dashboard.panels;
   }
 
-  return panels;
+  return dashboard.rows ? convertRowsToGridPanels(dashboard.rows) : [];
 }
 
 function convertToRowsLayout(

--- a/public/app/features/dashboard/state/DashboardMigrator.ts
+++ b/public/app/features/dashboard/state/DashboardMigrator.ts
@@ -1,4 +1,4 @@
-import { each, find, findIndex, flattenDeep, isArray, isString, map, max, some } from 'lodash';
+import { each, find, findIndex, isArray, map } from 'lodash';
 
 import {
   type AnnotationQuery,
@@ -32,14 +32,7 @@ import { type DataTransformerConfig } from '@grafana/schema';
 import { AxisPlacement, type GraphFieldConfig } from '@grafana/ui';
 import { migrateTableDisplayModeToCellOptions } from '@grafana/ui/internal';
 import { getAllOptionEditors, getAllStandardFieldConfigs } from 'app/core/components/OptionsUI/registry';
-import {
-  DEFAULT_PANEL_SPAN,
-  DEFAULT_ROW_HEIGHT,
-  GRID_CELL_HEIGHT,
-  GRID_CELL_VMARGIN,
-  GRID_COLUMN_COUNT,
-  MIN_PANEL_HEIGHT,
-} from 'app/core/constants';
+import { GRID_COLUMN_COUNT } from 'app/core/constants';
 import getFactors from 'app/core/utils/factors';
 import kbn from 'app/core/utils/kbn';
 import { DatasourceSrv } from 'app/features/plugins/datasource_srv';
@@ -61,6 +54,7 @@ import {
 
 import { type DashboardModel } from './DashboardModel';
 import { PanelModel } from './PanelModel';
+import { convertRowsToGridPanels } from './convertRowsToGridPanels';
 import { getPanelPluginToMigrateTo } from './getPanelPluginToMigrateTo';
 
 standardEditorsRegistry.setInit(getAllOptionEditors);
@@ -813,187 +807,16 @@ export class DashboardMigrator {
   }
 
   upgradeToGridLayout(old: any) {
-    let yPos = 0;
-    const widthFactor = GRID_COLUMN_COUNT / 12;
-
-    // Find max panel ID from both rows and existing top-level panels
-    // Top-level panels may have been assigned IDs by ensurePanelsHaveUniqueIds
-    const rowPanelIds = flattenDeep(
-      map(old.rows, (row) => {
-        return map(row.panels, 'id');
-      })
-    ).filter((id) => id != null);
-
-    const topLevelPanelIds = map(this.dashboard.panels, 'id').filter((id) => id != null);
-
-    const maxPanelId = max([...rowPanelIds, ...topLevelPanelIds]) || 0;
-    let nextRowId = maxPanelId + 1;
-
     if (!old.rows) {
       return;
     }
 
-    // Add special "row" panels if even one row is collapsed, repeated or has visible title
-    const showRows = some(old.rows, (row) => row.collapse || row.showTitle || row.repeat);
+    // Top-level panels may have been assigned IDs by ensurePanelsHaveUniqueIds
+    const topLevelPanelIds = map(this.dashboard.panels, 'id');
 
-    for (const row of old.rows) {
-      if (row.repeatIteration) {
-        continue;
-      }
-
-      const height = row.height || DEFAULT_ROW_HEIGHT;
-      const rowGridHeight = getGridHeight(height);
-
-      const rowPanel: any = {};
-      let rowPanelModel: PanelModel | undefined;
-
-      if (showRows) {
-        // add special row panel
-        rowPanel.id = nextRowId;
-        rowPanel.type = 'row';
-        rowPanel.title = row.title;
-        rowPanel.collapsed = row.collapse;
-        rowPanel.repeat = row.repeat;
-        rowPanel.panels = [];
-        rowPanel.gridPos = {
-          x: 0,
-          y: yPos,
-          w: GRID_COLUMN_COUNT,
-          h: rowGridHeight,
-        };
-        rowPanelModel = new PanelModel(rowPanel);
-        nextRowId++;
-        yPos++;
-      }
-
-      const rowArea = new RowArea(rowGridHeight, GRID_COLUMN_COUNT, yPos);
-
-      for (const panel of row.panels) {
-        panel.span = panel.span || DEFAULT_PANEL_SPAN;
-        if (panel.minSpan) {
-          panel.minSpan = Math.min(GRID_COLUMN_COUNT, (GRID_COLUMN_COUNT / 12) * panel.minSpan);
-        }
-        const panelWidth = Math.floor(panel.span) * widthFactor;
-        const panelHeight = panel.height ? getGridHeight(panel.height) : rowGridHeight;
-
-        const panelPos = rowArea.getPanelPosition(panelHeight, panelWidth);
-        yPos = rowArea.yPos;
-        panel.gridPos = {
-          x: panelPos.x,
-          y: yPos + panelPos.y,
-          w: panelWidth,
-          h: panelHeight,
-        };
-        rowArea.addPanel(panel.gridPos);
-
-        delete panel.span;
-
-        if (rowPanelModel && rowPanel.collapsed) {
-          rowPanelModel.panels?.push(panel);
-        } else {
-          this.dashboard.panels.push(new PanelModel(panel));
-        }
-      }
-
-      if (rowPanelModel) {
-        this.dashboard.panels.push(rowPanelModel);
-      }
-
-      if (!(rowPanelModel && rowPanel.collapsed)) {
-        yPos += rowGridHeight;
-      }
+    for (const panel of convertRowsToGridPanels(old.rows, topLevelPanelIds)) {
+      this.dashboard.panels.push(new PanelModel(panel));
     }
-  }
-}
-
-function getGridHeight(height: number | string) {
-  if (isString(height)) {
-    height = parseInt(height.replace('px', ''), 10);
-  }
-
-  if (height < MIN_PANEL_HEIGHT) {
-    height = MIN_PANEL_HEIGHT;
-  }
-
-  const gridHeight = Math.ceil(height / (GRID_CELL_HEIGHT + GRID_CELL_VMARGIN));
-  return gridHeight;
-}
-
-/**
- * RowArea represents dashboard row filled by panels
- * area is an array of numbers represented filled column's cells like
- *  -----------------------
- * |******** ****
- * |******** ****
- * |********
- *  -----------------------
- *  33333333 2222 00000 ...
- */
-class RowArea {
-  area: number[];
-  yPos: number;
-  height: number;
-
-  constructor(height: number, width = GRID_COLUMN_COUNT, rowYPos = 0) {
-    this.area = new Array(width).fill(0);
-    this.yPos = rowYPos;
-    this.height = height;
-  }
-
-  reset() {
-    this.area.fill(0);
-  }
-
-  /**
-   * Update area after adding the panel.
-   */
-  addPanel(gridPos: any) {
-    for (let i = gridPos.x; i < gridPos.x + gridPos.w; i++) {
-      if (!this.area[i] || gridPos.y + gridPos.h - this.yPos > this.area[i]) {
-        this.area[i] = gridPos.y + gridPos.h - this.yPos;
-      }
-    }
-    return this.area;
-  }
-
-  /**
-   * Calculate position for the new panel in the row.
-   */
-  getPanelPosition(panelHeight: number, panelWidth: number, callOnce = false): any {
-    let startPlace, endPlace;
-    let place;
-    for (let i = this.area.length - 1; i >= 0; i--) {
-      if (this.height - this.area[i] > 0) {
-        if (endPlace === undefined) {
-          endPlace = i;
-        } else {
-          if (i < this.area.length - 1 && this.area[i] <= this.area[i + 1]) {
-            startPlace = i;
-          } else {
-            break;
-          }
-        }
-      } else {
-        break;
-      }
-    }
-
-    if (startPlace !== undefined && endPlace !== undefined && endPlace - startPlace >= panelWidth - 1) {
-      const yPos = max(this.area.slice(startPlace));
-      place = {
-        x: startPlace,
-        y: yPos,
-      };
-    } else if (!callOnce) {
-      // wrap to next row
-      this.yPos += this.height;
-      this.reset();
-      return this.getPanelPosition(panelHeight, panelWidth, true);
-    } else {
-      return null;
-    }
-
-    return place;
   }
 }
 

--- a/public/app/features/dashboard/state/convertRowsToGridPanels.ts
+++ b/public/app/features/dashboard/state/convertRowsToGridPanels.ts
@@ -1,0 +1,221 @@
+import { flattenDeep, isString, map, max, some } from 'lodash';
+
+import { type GridPos, type Panel, type RowPanel } from '@grafana/schema';
+import {
+  DEFAULT_PANEL_SPAN,
+  DEFAULT_ROW_HEIGHT,
+  GRID_CELL_HEIGHT,
+  GRID_CELL_VMARGIN,
+  GRID_COLUMN_COUNT,
+  MIN_PANEL_HEIGHT,
+} from 'app/core/constants';
+
+/** Panel of a pre-schema-version-16 dashboard, sized with `span` and pixel `height` instead of `gridPos` */
+export interface LegacyPanel extends Panel {
+  span?: number;
+  minSpan?: number;
+  height?: number | string;
+}
+
+/** Row of a pre-schema-version-16 dashboard, before rows became panels of type `row` */
+export interface LegacyRow {
+  title?: string;
+  height?: number | string;
+  collapse?: boolean;
+  showTitle?: boolean;
+  repeat?: string;
+  repeatIteration?: number;
+  panels?: LegacyPanel[];
+}
+
+/**
+ * Converts pre-schema-version-16 `rows` into grid positioned panels. This is the schema v16
+ * migration, shared by `DashboardMigrator` and by `ResponseTransformers`, which has to handle
+ * dashboards that never went through the backend migration (scripted dashboards).
+ *
+ * Panels inside `rows` are mutated in place (`gridPos` set, `span` dropped), and the returned
+ * panels are in grid order.
+ *
+ * @param existingPanelIds ids already taken by top level panels, so generated row ids don't clash
+ */
+export function convertRowsToGridPanels(
+  rows: LegacyRow[],
+  existingPanelIds: Array<number | undefined> = []
+): Array<Panel | RowPanel> {
+  const gridPanels: Array<Panel | RowPanel> = [];
+
+  if (!rows) {
+    return gridPanels;
+  }
+
+  let yPos = 0;
+  const widthFactor = GRID_COLUMN_COUNT / 12;
+
+  const rowPanelIds = flattenDeep(map(rows, (row) => map(row.panels, 'id'))).filter((id) => id != null);
+  const maxPanelId = max([...rowPanelIds, ...existingPanelIds.filter((id) => id != null)]) || 0;
+  let nextRowId = maxPanelId + 1;
+
+  // Add special "row" panels if even one row is collapsed, repeated or has visible title
+  const showRows = some(rows, (row) => row.collapse || row.showTitle || row.repeat);
+
+  for (const row of rows) {
+    if (row.repeatIteration) {
+      continue;
+    }
+
+    const height = row.height || DEFAULT_ROW_HEIGHT;
+    const rowGridHeight = getGridHeight(height);
+
+    let rowPanel: RowPanel | undefined;
+
+    if (showRows) {
+      rowPanel = {
+        id: nextRowId,
+        type: 'row',
+        title: row.title,
+        // left undefined when the row has no `collapse` property, so the save model matches the
+        // one produced by the backend migration
+        collapsed: row.collapse!,
+        repeat: row.repeat,
+        panels: [],
+        gridPos: {
+          x: 0,
+          y: yPos,
+          w: GRID_COLUMN_COUNT,
+          h: rowGridHeight,
+        },
+      };
+      // pushed before its panels so that the result is already in grid order
+      gridPanels.push(rowPanel);
+      nextRowId++;
+      yPos++;
+    }
+
+    const rowArea = new RowArea(rowGridHeight, GRID_COLUMN_COUNT, yPos);
+
+    for (const panel of row.panels ?? []) {
+      panel.span = panel.span || DEFAULT_PANEL_SPAN;
+      if (panel.minSpan) {
+        panel.minSpan = Math.min(GRID_COLUMN_COUNT, (GRID_COLUMN_COUNT / 12) * panel.minSpan);
+      }
+      const panelWidth = Math.floor(panel.span) * widthFactor;
+      const panelHeight = panel.height ? getGridHeight(panel.height) : rowGridHeight;
+
+      const panelPos = rowArea.getPanelPosition(panelWidth);
+      yPos = rowArea.yPos;
+      panel.gridPos = {
+        x: panelPos.x,
+        y: yPos + panelPos.y,
+        w: panelWidth,
+        h: panelHeight,
+      };
+      rowArea.addPanel(panel.gridPos);
+
+      delete panel.span;
+
+      if (rowPanel?.collapsed) {
+        rowPanel.panels.push(panel);
+      } else {
+        gridPanels.push(panel);
+      }
+    }
+
+    if (!rowPanel?.collapsed) {
+      yPos += rowGridHeight;
+    }
+  }
+
+  return gridPanels;
+}
+
+function getGridHeight(height: number | string) {
+  if (isString(height)) {
+    height = parseInt(height.replace('px', ''), 10);
+  }
+
+  if (height < MIN_PANEL_HEIGHT) {
+    height = MIN_PANEL_HEIGHT;
+  }
+
+  const gridHeight = Math.ceil(height / (GRID_CELL_HEIGHT + GRID_CELL_VMARGIN));
+  return gridHeight;
+}
+
+/**
+ * RowArea represents dashboard row filled by panels
+ * area is an array of numbers represented filled column's cells like
+ *  -----------------------
+ * |******** ****
+ * |******** ****
+ * |********
+ *  -----------------------
+ *  33333333 2222 00000 ...
+ */
+class RowArea {
+  area: number[];
+  yPos: number;
+  height: number;
+
+  constructor(height: number, width = GRID_COLUMN_COUNT, rowYPos = 0) {
+    this.area = new Array(width).fill(0);
+    this.yPos = rowYPos;
+    this.height = height;
+  }
+
+  reset() {
+    this.area.fill(0);
+  }
+
+  /**
+   * Update area after adding the panel.
+   */
+  addPanel(gridPos: GridPos) {
+    for (let i = gridPos.x; i < gridPos.x + gridPos.w; i++) {
+      if (!this.area[i] || gridPos.y + gridPos.h - this.yPos > this.area[i]) {
+        this.area[i] = gridPos.y + gridPos.h - this.yPos;
+      }
+    }
+    return this.area;
+  }
+
+  /**
+   * Calculate position for the new panel in the row.
+   */
+  getPanelPosition(panelWidth: number, callOnce = false): { x: number; y: number } {
+    let startPlace, endPlace;
+    let place;
+    for (let i = this.area.length - 1; i >= 0; i--) {
+      if (this.height - this.area[i] > 0) {
+        if (endPlace === undefined) {
+          endPlace = i;
+        } else {
+          if (i < this.area.length - 1 && this.area[i] <= this.area[i + 1]) {
+            startPlace = i;
+          } else {
+            break;
+          }
+        }
+      } else {
+        break;
+      }
+    }
+
+    if (startPlace !== undefined && endPlace !== undefined && endPlace - startPlace >= panelWidth - 1) {
+      const yPos = max(this.area.slice(startPlace)) ?? 0;
+      place = {
+        x: startPlace,
+        y: yPos,
+      };
+    } else if (!callOnce) {
+      // wrap to next row
+      this.yPos += this.height;
+      this.reset();
+      return this.getPanelPosition(panelWidth, true);
+    } else {
+      // the panel does not fit in an empty row either, put it at the start
+      return { x: 0, y: 0 };
+    }
+
+    return place;
+  }
+}

--- a/public/app/features/dashboard/state/convertRowsToGridPanels.ts
+++ b/public/app/features/dashboard/state/convertRowsToGridPanels.ts
@@ -11,7 +11,7 @@ import {
 } from 'app/core/constants';
 
 /** Panel of a pre-schema-version-16 dashboard, sized with `span` and pixel `height` instead of `gridPos` */
-export interface LegacyPanel extends Panel {
+interface LegacyPanel extends Panel {
   span?: number;
   minSpan?: number;
   height?: number | string;


### PR DESCRIPTION
## What is this feature?

Fixes scripted dashboards that use the old rows format (pre schema version 16) showing up empty when loaded through the v2 dashboard loader.

## What problem does this feature solve?

Scripted dashboards (e.g. `http://localhost:3000/dashboard/script/scripted.js`) rendered as "New dashboard" with an "Add a panel to visualize your data" message, even though the script defined panels inside `rows`.

Dashboards stored on the backend are migrated to the latest schema version before they reach the frontend, but scripted dashboards are built client side and never go through that migration. `ResponseTransformers.ensureV2Response()` only looked at `dashboard.panels`, so a dashboard whose panels live in `rows` produced no elements at all.

## How does this feature work?

The rows to grid conversion of the schema v16 migration is extracted out of `DashboardMigrator.upgradeToGridLayout` into a shared `convertRowsToGridPanels` helper, and `ensureV2Response` uses it when the dashboard has `rows` instead of `panels`. Both load paths now produce the same layout: left to right packing within a row, pixel to grid height conversion, and row panels for collapsed, repeated or titled rows.

`DashboardMigrator` keeps its behaviour, it just delegates to the helper.

## Testing

- New `ResponseTransformers` tests: single panel row, two panels laid out side by side, and a titled row converted to a rows layout
- Existing `DashboardMigrator`, `DashboardMigratorToBackend` and `DashboardMigratorSingleVersion` suites pass unchanged, so the frontend still matches the backend v16 migration output
- Manual testing with `http://localhost:3000/dashboard/script/scripted.js`

[Scripted dashboard now shows panel](https://cursor.com/agents/bc-2abb9b83-1814-5739-8f7f-54fd430c289d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscripted_dashboard_working.webp)

## Related Issues

Fixes the issue reported in #grafana-dashboards Slack channel by @joshhunt

[Slack Thread](https://raintank-corp.slack.com/archives/C03KVDHTWAH/p1784737540358919?thread_ts=1784737540.358919&cid=C03KVDHTWAH)
