### PR TITLE
Panels: Stop persisting default values for new graph panel options

### DIFF
--- a/packages/grafana-ui/src/options/builder/legend.test.tsx
+++ b/packages/grafana-ui/src/options/builder/legend.test.tsx
@@ -107,8 +107,8 @@ describe('addLegendOptions', () => {
   });
 
   describe('overflow editor', () => {
-    it('defaults to ellipsis', () => {
-      expect(getItem('legend.overflow').defaultValue).toBe('ellipsis');
+    it('has no default value so it is not persisted into panel options unless changed', () => {
+      expect(getItem('legend.overflow').defaultValue).toBeUndefined();
     });
 
     it('offers ellipsis and wrap options', () => {

--- a/packages/grafana-ui/src/options/builder/legend.tsx
+++ b/packages/grafana-ui/src/options/builder/legend.tsx
@@ -84,7 +84,6 @@ export function addLegendOptions<T extends OptionsWithLegend>(
       name: t('grafana-ui.builder.legend.name-overflow', 'Overflow'),
       category,
       description: '',
-      defaultValue: 'ellipsis',
       settings: {
         options: [
           { value: 'ellipsis', label: t('grafana-ui.builder.legend.overflow-options.label-ellipsis', 'Ellipsis') },

--- a/public/app/features/panel/options/builder/annotations.ts
+++ b/public/app/features/panel/options/builder/annotations.ts
@@ -3,7 +3,7 @@ import { t } from '@grafana/i18n';
 import type * as common from '@grafana/schema';
 
 import { CanvasControlsSwitchEditor } from './CanvasControlsSwitchEditor';
-import { ClusteringSwitchEditor, DEFAULT_CLUSTERING_ANNOTATION_SPACING_DISABLED } from './ClusteringSwitchEditor';
+import { ClusteringSwitchEditor } from './ClusteringSwitchEditor';
 
 /**
  * Adds common text control options to a visualization options
@@ -22,7 +22,6 @@ export function addAnnotationOptions<T extends common.OptionsWithAnnotations>(bu
       'grafana-ui.builder.annotations.multi-row-desc',
       'Breaks each annotation frame into a separate row in the visualization'
     ),
-    defaultValue: false,
     showIf: (_, __, annotations) =>
       annotations &&
       annotations?.filter((df) => df.meta?.dataTopic === DataTopic.Annotations && df.length > 0).length > 1,
@@ -38,7 +37,6 @@ export function addAnnotationOptions<T extends common.OptionsWithAnnotations>(bu
       'grafana-ui.builder.annotations.clustering.desc',
       'Combines high density point annotations into region annotations'
     ),
-    defaultValue: DEFAULT_CLUSTERING_ANNOTATION_SPACING_DISABLED,
     showIf: (_, __, annotations) => annotations?.some((df) => df.meta?.dataTopic === DataTopic.Annotations),
   });
 

--- a/public/app/plugins/panel/timeseries/module.tsx
+++ b/public/app/plugins/panel/timeseries/module.tsx
@@ -29,7 +29,6 @@ export const plugin = new PanelPlugin<Options, FieldConfig>(TimeSeriesPanel)
         'timeseries.legend.description-faceted-filter',
         'Enable filter to display series based on labels or names'
       ),
-      defaultValue: false,
       showIf: (c) => c.legend.showLegend,
     });
 


### PR DESCRIPTION
## What

Newly added timeseries/graph panel options were declared with an explicit `defaultValue` in their options-builder entries:

- `legend.enableFacetedFilter`
- `legend.overflow`
- `annotations.multiLane`
- `annotations.clustering`

`PanelPlugin.defaults` collects every builder `defaultValue` into `plugin.defaults`, and `getPanelOptionsWithDefaults` merges those into the saved panel options. As a result, opening and saving any dashboard containing graph panels — **without making any other change** — wrote these fields into every panel's JSON, producing noisy, confusing diffs.

This PR removes the `defaultValue` from those four builder entries so the options are only serialized when a user actually sets them.

## Why runtime behavior is unchanged

Every consumer already falls back to the previous default when the value is `undefined`:

- `enableFacetedFilter` → destructured as `= false` in `PlotLegend`
- `overflow` → `undefined` renders as `nowrap` (ellipsis) in `VizLegendTableItem`
- `multiLane` → guarded by `options.annotations?.multiLane`
- `clustering` → guarded by `options?.clustering && options.clustering > 0`; the switch editor renders `undefined > -1` as off

There is in-repo precedent: `legend.limit` and `legend.width` already have no `defaultValue` for the same reason.

## Tests

- Updated the `legend.overflow` builder test to assert no default value.
- Affected jest suites pass (legend, PlotLegend, TimeSeriesPanel, ClusteringSwitchEditor, CanvasControlsSwitchEditor, AnnotationsPlugin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)