### PR TITLE
PublicDashboards: Strip rawQuery from sanitized panel queries

### DIFF
--- a/pkg/services/publicdashboards/internal/service/query.go
+++ b/pkg/services/publicdashboards/internal/service/query.go
@@ -459,6 +459,7 @@ func sanitizeData(data *simplejson.Json) {
 			target.Del("expr")
 			target.Del("query")
 			target.Del("rawSql")
+			target.Del("rawQuery")
 		}
 	}
 }
@@ -475,6 +476,7 @@ func sanitizeDataV2(data *simplejson.Json) {
 			dataQuerySpec.Del("expr")
 			dataQuerySpec.Del("query")
 			dataQuerySpec.Del("rawSql")
+			dataQuerySpec.Del("rawQuery")
 		}
 	}
 }

--- a/pkg/services/publicdashboards/internal/service/query_test.go
+++ b/pkg/services/publicdashboards/internal/service/query_test.go
@@ -1476,6 +1476,45 @@ func TestSanitizeDataV2(t *testing.T) {
 		assert.Equal(t, "A", q3spec.Get("refId").MustString())
 	})
 
+	t.Run("removes rawQuery from query specs", func(t *testing.T) {
+		data := simplejson.NewFromAny(map[string]interface{}{
+			"elements": map[string]interface{}{
+				"panel-1": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"data": map[string]interface{}{
+							"spec": map[string]interface{}{
+								"queries": []interface{}{
+									map[string]interface{}{
+										"spec": map[string]interface{}{
+											"query": map[string]interface{}{
+												"spec": map[string]interface{}{
+													"rawQuery":     "SELECT mean(\"value\") FROM cpu",
+													"refId":        "A",
+													"resultFormat": "time_series",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+
+		sanitizeDataV2(data)
+
+		elements := data.Get("elements").MustMap()
+		queries := simplejson.NewFromAny(elements["panel-1"]).
+			Get("spec").Get("data").Get("spec").Get("queries").MustArray()
+		require.Len(t, queries, 1)
+		spec := simplejson.NewFromAny(queries[0]).Get("spec").Get("query").Get("spec")
+		assert.Empty(t, spec.Get("rawQuery").MustString())
+		assert.Equal(t, "A", spec.Get("refId").MustString())
+		assert.Equal(t, "time_series", spec.Get("resultFormat").MustString())
+	})
+
 	t.Run("does not panic when queries key is missing", func(t *testing.T) {
 		data := simplejson.NewFromAny(map[string]interface{}{
 			"elements": map[string]interface{}{
@@ -1510,6 +1549,81 @@ func TestSanitizeDataV2(t *testing.T) {
 			},
 		})
 		require.NotPanics(t, func() { sanitizeDataV2(data) })
+	})
+}
+
+func TestSanitizeData(t *testing.T) {
+	t.Run("removes raw query fields from panel targets", func(t *testing.T) {
+		data := simplejson.NewFromAny(map[string]interface{}{
+			"panels": []interface{}{
+				map[string]interface{}{
+					"targets": []interface{}{
+						map[string]interface{}{
+							"expr":       "go_goroutines{job=\"grafana\"}",
+							"refId":      "A",
+							"datasource": "prometheus",
+						},
+						map[string]interface{}{
+							"rawSql": "SELECT * FROM metrics",
+							"refId":  "B",
+						},
+						map[string]interface{}{
+							"rawQuery":     "SELECT mean(\"value\") FROM cpu",
+							"query":        "buckets()",
+							"refId":        "C",
+							"resultFormat": "time_series",
+						},
+					},
+				},
+			},
+		})
+
+		sanitizeData(data)
+
+		targets := simplejson.NewFromAny(data.Get("panels").MustArray()[0]).Get("targets").MustArray()
+		require.Len(t, targets, 3)
+
+		t0 := simplejson.NewFromAny(targets[0])
+		assert.Empty(t, t0.Get("expr").MustString())
+		assert.Equal(t, "A", t0.Get("refId").MustString())
+		assert.Equal(t, "prometheus", t0.Get("datasource").MustString())
+
+		t1 := simplejson.NewFromAny(targets[1])
+		assert.Empty(t, t1.Get("rawSql").MustString())
+		assert.Equal(t, "B", t1.Get("refId").MustString())
+
+		t2 := simplejson.NewFromAny(targets[2])
+		assert.Empty(t, t2.Get("rawQuery").MustString())
+		assert.Empty(t, t2.Get("query").MustString())
+		assert.Equal(t, "C", t2.Get("refId").MustString())
+		assert.Equal(t, "time_series", t2.Get("resultFormat").MustString())
+	})
+
+	t.Run("removes raw query fields from panels inside a collapsed row", func(t *testing.T) {
+		data := simplejson.NewFromAny(map[string]interface{}{
+			"panels": []interface{}{
+				map[string]interface{}{
+					"type":      "row",
+					"collapsed": true,
+					"panels": []interface{}{
+						map[string]interface{}{
+							"targets": []interface{}{
+								map[string]interface{}{
+									"rawQuery": "SELECT mean(\"value\") FROM cpu",
+									"refId":    "A",
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+
+		sanitizeData(data)
+
+		row := simplejson.NewFromAny(data.Get("panels").MustArray()[0])
+		target := simplejson.NewFromAny(row.Get("panels").MustArray()[0]).Get("targets").MustArray()[0]
+		assert.Empty(t, simplejson.NewFromAny(target).Get("rawQuery").MustString())
 	})
 }
 


### PR DESCRIPTION
**What is this feature?**

`sanitizeData` and `sanitizeDataV2` strip raw query strings (`expr`, `query`, `rawSql`) from panel targets before public dashboard requests are built. This adds InfluxDB's `rawQuery` field to that list at both call sites.

**Why do we need this feature?**

InfluxDB stores its InfluxQL/Flux query string in `rawQuery`, not `query`. Because that field was never sanitized, the raw query strings were included in the data used to build public dashboard requests and were readable by unauthenticated public dashboard viewers.

Repro: an InfluxDB panel using InfluxQL with rawQuery mode on a public dashboard exposes the `rawQuery` value in the query API request body when viewed logged-out.

**Who is this feature for?**

Anyone sharing public dashboards backed by InfluxDB (and any datasource using `rawQuery`).

**Which issue(s) does this PR fix?**:

Fixes #123845

**Special notes for your reviewer:**

Backend-only change. Added `TestSanitizeData` (the v1 function had no direct unit test) and a `rawQuery` case to `TestSanitizeDataV2`; both fail without the fix. This is scoped to the `rawQuery` gap and does not overlap with #128927, which covers Graphite's `target`/`targetFull` fields.
