### PR TITLE
chore: remove provisioning flag references from search and storage codebase

### DIFF
--- a/pkg/server/search_server_distributor_test.go
+++ b/pkg/server/search_server_distributor_test.go
@@ -395,7 +395,7 @@ func createBaselineServer(t *testing.T, dbType, dbConnStr string, testNamespaces
 	features := featuremgmt.WithFeatures()
 	support, err := InitializeSearchSupport(cfg, features, tracing.InitializeTracerForTest(), prometheus.NewRegistry())
 	require.NoError(t, err)
-	searchOpts, err := search.NewSearchOptions(features, cfg, support.DocBuilders, nil, nil, nil)
+	searchOpts, err := search.NewSearchOptions(cfg, support.DocBuilders, nil, nil, nil)
 	require.NoError(t, err)
 	cfg.DisablePruner = dbType == "sqlite3"
 	eDB, err := sql.ProvideResourceDB(cfg, nil)

--- a/pkg/storage/unified/client.go
+++ b/pkg/storage/unified/client.go
@@ -190,7 +190,7 @@ func newClient(opts options.StorageOptions,
 		return resource.NewResourceClient(conn, indexConn, cfg, features, tracer)
 
 	default:
-		searchOptions, err := search.NewSearchOptions(features, cfg, docs, indexMetrics, nil, nil)
+		searchOptions, err := search.NewSearchOptions(cfg, docs, indexMetrics, nil, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/storage/unified/migrations/resource_migration_test.go
+++ b/pkg/storage/unified/migrations/resource_migration_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/kvstore"
 	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/storage/legacysql"
@@ -668,7 +667,7 @@ func newRetryTestResourceServerWithSearch(t *testing.T, backend resource.Storage
 		},
 	}
 
-	searchOpts, err := search.NewSearchOptions(featuremgmt.WithFeatures(), cfg, docBuilders, nil, nil, nil)
+	searchOpts, err := search.NewSearchOptions(cfg, docBuilders, nil, nil, nil)
 	require.NoError(t, err)
 
 	return resource.NewResourceServer(resource.ResourceServerOptions{

--- a/pkg/storage/unified/search/bleve_snapshot_test.go
+++ b/pkg/storage/unified/search/bleve_snapshot_test.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
@@ -1117,7 +1116,7 @@ func newConfiguredSnapshotBackend(t *testing.T, bucketURL string) (*bleveBackend
 	cfg.IndexSnapshotBucketURL = bucketURL
 
 	metrics := resource.ProvideIndexMetrics(prometheus.NewRegistry())
-	opts, err := NewSearchOptions(featuremgmt.WithFeatures(), cfg, nil, metrics, nil, nil)
+	opts, err := NewSearchOptions(cfg, nil, metrics, nil, nil)
 	require.NoError(t, err)
 	be, ok := opts.Backend.(*bleveBackend)
 	require.True(t, ok)

--- a/pkg/storage/unified/search/options.go
+++ b/pkg/storage/unified/search/options.go
@@ -14,7 +14,6 @@ import (
 	"github.com/oklog/ulid/v2"
 	"gocloud.dev/blob"
 
-	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 )
@@ -43,15 +42,13 @@ const (
 // that would otherwise be built from cfg.IndexSnapshotBucketURL. Used by
 // the SQL wiring layer to inject a KV-backed store.
 func NewSearchOptions(
-	features featuremgmt.FeatureToggles,
 	cfg *setting.Cfg,
 	docs resource.DocumentBuilderSupplier,
 	indexMetrics *resource.BleveIndexMetrics,
 	ownsIndexFn func(key resource.NamespacedResource) (bool, error),
 	snapshotStore RemoteIndexStore,
 ) (resource.SearchOptions, error) {
-	//nolint:staticcheck // not yet migrated to OpenFeature
-	if cfg.EnableSearch || features.IsEnabledGlobally(featuremgmt.FlagProvisioning) {
+	if cfg.EnableSearch {
 		root := cfg.IndexPath
 		if root == "" {
 			root = filepath.Join(cfg.DataPath, "unified-search", "bleve")

--- a/pkg/storage/unified/search/options_test.go
+++ b/pkg/storage/unified/search/options_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 )
@@ -189,7 +188,7 @@ func TestNewSearchOptionsPassesFileSnapshotStoreToBleveBackend(t *testing.T) {
 	cfg.IndexSnapshotBucketURL = fileBucketURL(t, t.TempDir())
 
 	metrics := resource.ProvideIndexMetrics(prometheus.NewRegistry())
-	opts, err := NewSearchOptions(featuremgmt.WithFeatures(), cfg, nil, metrics, nil, nil)
+	opts, err := NewSearchOptions(cfg, nil, metrics, nil, nil)
 	require.NoError(t, err)
 
 	backend, ok := opts.Backend.(*bleveBackend)

--- a/pkg/storage/unified/sql/service.go
+++ b/pkg/storage/unified/sql/service.go
@@ -396,7 +396,7 @@ func (s *service) registerServer(provider grpcserver.Provider) error {
 		}
 	}
 
-	searchOptions, err := search.NewSearchOptions(s.features, s.cfg, s.docBuilders, s.indexMetrics, s.OwnsIndex, snapshotStore)
+	searchOptions, err := search.NewSearchOptions(s.cfg, s.docBuilders, s.indexMetrics, s.OwnsIndex, snapshotStore)
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/unified/sql/test/integration_test.go
+++ b/pkg/storage/unified/sql/test/integration_test.go
@@ -171,8 +171,7 @@ func newTestResourceServerWithSearch(t *testing.T, backend resource.StorageBacke
 	}
 
 	// Create search options
-	features := featuremgmt.WithFeatures()
-	searchOpts, err := search.NewSearchOptions(features, cfg, docBuilders, nil, nil, nil)
+	searchOpts, err := search.NewSearchOptions(cfg, docBuilders, nil, nil, nil)
 	require.NoError(t, err)
 
 	// Create ResourceServer with search enabled


### PR DESCRIPTION
`provisioning` has been marked ad GA feature for some time now, toggle is enabled by default in on-prem and in all cloud envs. Should be safe to clean up.

This Pr is a part of big cleanup:
oss cleanup: https://github.com/grafana/grafana/pull/129030
fe pr: https://github.com/grafana/grafana/pull/129077