### PR TITLE
CloudMigration: fix CancelSnapshot cancelFunc data race

### DIFF
--- a/pkg/services/cloudmigration/cloudmigrationimpl/cancel_test.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cancel_test.go
@@ -1,0 +1,71 @@
+package cloudmigrationimpl
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCancelInFlightCancelsRegisteredJob(t *testing.T) {
+	t.Parallel()
+
+	s := &Service{}
+	started := make(chan struct{})
+	finished := make(chan struct{})
+
+	jobCtx, cancel := context.WithCancel(context.Background())
+	s.cancelWG.Add(1)
+	s.setCancelFunc(cancel)
+	go func() {
+		defer s.cancelWG.Done()
+		defer s.clearCancelFunc()
+		close(started)
+		<-jobCtx.Done()
+		close(finished)
+	}()
+
+	<-started
+	require.NoError(t, s.cancelInFlight())
+
+	select {
+	case <-finished:
+	case <-time.After(2 * time.Second):
+		t.Fatal("job did not finish after cancel")
+	}
+}
+
+func TestCancelInFlightNothingToCancel(t *testing.T) {
+	t.Parallel()
+
+	s := &Service{}
+	err := s.cancelInFlight()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "nothing to cancel")
+}
+
+func TestCancelInFlightRace(t *testing.T) {
+	t.Parallel()
+
+	s := &Service{}
+	jobCtx, cancel := context.WithCancel(context.Background())
+	s.cancelWG.Add(1)
+	s.setCancelFunc(cancel)
+	go func() {
+		defer s.cancelWG.Done()
+		defer s.clearCancelFunc()
+		<-jobCtx.Done()
+	}()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = s.cancelInFlight()
+		}()
+	}
+	wg.Wait()
+}

--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration.go
@@ -58,6 +58,7 @@ type Service struct {
 
 	cancelMutex sync.Mutex
 	cancelFunc  context.CancelFunc
+	cancelWG    sync.WaitGroup
 
 	isSyncSnapshotStatusFromGMSRunning int32
 
@@ -523,20 +524,16 @@ func (s *Service) CreateSnapshot(ctx context.Context, signedInUser *user.SignedI
 	}
 
 	// start building the snapshot asynchronously while we return a success response to the client
+	asyncCtx := trace.ContextWithSpanContext(context.Background(), span.SpanContext())
+	asyncCtx, cancelFunc := context.WithCancel(asyncCtx)
+	s.cancelWG.Add(1)
+	s.setCancelFunc(cancelFunc)
 	go func() {
-		s.cancelMutex.Lock()
-		defer func() {
-			s.cancelFunc = nil
-			s.cancelMutex.Unlock()
-		}()
+		defer s.cancelWG.Done()
+		defer s.clearCancelFunc()
 
-		// Create context out the span context to ensure the trace is propagated
-		asyncCtx := trace.ContextWithSpanContext(context.Background(), span.SpanContext())
 		asyncCtx, asyncSpan := s.tracer.Start(asyncCtx, "CloudMigrationService.CreateSnapshotAsync")
 		defer asyncSpan.End()
-
-		asyncCtx, cancelFunc := context.WithCancel(asyncCtx)
-		s.cancelFunc = cancelFunc
 
 		s.report(asyncCtx, session, gmsclient.EventStartBuildingSnapshot, 0, nil, signedInUser.UserUID)
 
@@ -659,13 +656,12 @@ func (s *Service) syncSnapshotStatusFromGMSUntilDone(ctx context.Context, sessio
 		return
 	}
 
-	s.cancelMutex.Lock()
-	defer func() {
-		s.cancelFunc = nil
-		s.cancelMutex.Unlock()
-	}()
+	s.cancelWG.Add(1)
+	defer s.cancelWG.Done()
 
-	ctx, s.cancelFunc = context.WithCancel(ctx)
+	ctx, cancelFunc := context.WithCancel(ctx)
+	s.setCancelFunc(cancelFunc)
+	defer s.clearCancelFunc()
 
 	updatedSnapshot, err := syncStatus(ctx, session, snapshot)
 	if err != nil {
@@ -753,19 +749,16 @@ func (s *Service) UploadSnapshot(ctx context.Context, orgID int64, signedInUser 
 	}
 
 	// start uploading the snapshot asynchronously while we return a success response to the client
+	asyncCtx := trace.ContextWithSpanContext(context.Background(), span.SpanContext())
+	asyncCtx, cancelFunc := context.WithCancel(asyncCtx)
+	s.cancelWG.Add(1)
+	s.setCancelFunc(cancelFunc)
 	go func() {
-		s.cancelMutex.Lock()
-		defer func() {
-			s.cancelFunc = nil
-			s.cancelMutex.Unlock()
-		}()
+		defer s.cancelWG.Done()
+		defer s.clearCancelFunc()
 
-		// Create context out the span context to ensure the trace is propagated
-		asyncCtx := trace.ContextWithSpanContext(context.Background(), span.SpanContext())
 		asyncCtx, asyncSpan := s.tracer.Start(asyncCtx, "CloudMigrationService.UploadSnapshot")
 		defer asyncSpan.End()
-
-		asyncCtx, s.cancelFunc = context.WithCancel(asyncCtx)
 
 		s.report(asyncCtx, session, gmsclient.EventStartUploadingSnapshot, 0, nil, signedInUser.UserUID)
 
@@ -793,7 +786,33 @@ func (s *Service) UploadSnapshot(ctx context.Context, orgID int64, signedInUser 
 	return nil
 }
 
-func (s *Service) CancelSnapshot(ctx context.Context, sessionUid string, snapshotUid string) (err error) {
+func (s *Service) setCancelFunc(fn context.CancelFunc) {
+	s.cancelMutex.Lock()
+	s.cancelFunc = fn
+	s.cancelMutex.Unlock()
+}
+
+func (s *Service) clearCancelFunc() {
+	s.cancelMutex.Lock()
+	s.cancelFunc = nil
+	s.cancelMutex.Unlock()
+}
+
+// cancelInFlight cancels any registered cancel func and waits for the async job to finish.
+func (s *Service) cancelInFlight() error {
+	s.cancelMutex.Lock()
+	fn := s.cancelFunc
+	s.cancelMutex.Unlock()
+	if fn == nil {
+		return fmt.Errorf("nothing to cancel")
+	}
+	fn()
+	s.cancelWG.Wait()
+	s.clearCancelFunc()
+	return nil
+}
+
+func (s *Service) CancelSnapshot(ctx context.Context, sessionUid string, snapshotUid string) error {
 	ctx, span := s.tracer.Start(ctx, "CloudMigrationService.CancelSnapshot",
 		trace.WithAttributes(
 			attribute.String("sessionUid", sessionUid),
@@ -802,19 +821,9 @@ func (s *Service) CancelSnapshot(ctx context.Context, sessionUid string, snapsho
 	)
 	defer span.End()
 
-	// The cancel func itself is protected by a mutex in the async threads, so it may or may not be set by the time CancelSnapshot is called
-	// Attempt to cancel and recover from the panic if the cancel function is nil
-	defer func() {
-		if r := recover(); r != nil {
-			err = fmt.Errorf("nothing to cancel")
-		}
-	}()
-	s.cancelFunc()
-
-	// Canceling will ensure that any goroutines holding the lock finish and release the lock
-	s.cancelMutex.Lock()
-	defer s.cancelMutex.Unlock()
-	s.cancelFunc = nil
+	if err := s.cancelInFlight(); err != nil {
+		return err
+	}
 
 	if err := s.updateSnapshotWithRetries(ctx, cloudmigration.UpdateSnapshotCmd{
 		UID:       snapshotUid,


### PR DESCRIPTION
**What is this feature?**

This PR fixes a concurrency bug in Grafana Cloud Migration’s snapshot cancel path (`CancelSnapshot`).

Previously, async snapshot create/upload goroutines held `cancelMutex` for the entire build/upload, and set `cancelFunc` while holding that lock. `CancelSnapshot` called `s.cancelFunc()` **without** holding the mutex (using panic/recover when it was nil). That caused:

1. A data race on `cancelFunc` under the Go memory model
2. Silent cancel failures when cancel ran before `cancelFunc` was set (nil → panic → recover → still often returned success)
3. Poor cancel latency / odd blocking behavior, because after “cancel” the code tried to take the same mutex the job held for the whole operation

This change restructures cancel coordination:

- `cancelMutex` only protects short get/set of `cancelFunc`
- A `sync.WaitGroup` (`cancelWG`) tracks the in-flight cancelable job
- Create snapshot, upload snapshot, and GMS status-sync register cancel with: create cancelable context → `Add(1)` → set `cancelFunc` under lock → run work without holding the mutex → clear `cancelFunc` + `Done()` on exit
- `CancelSnapshot` uses `cancelInFlight()`: lock → copy `fn` → unlock → if nil return error → `fn()` → `Wait()` → clear → then update snapshot status to canceled
- Removes the panic/recover cancel path

**Why do we need this feature?**

Users canceling a running cloud migration snapshot could get a success response while the snapshot kept building/uploading. That wastes resources and makes UI/API state inconsistent (cancel looked successful, work continued).

The issue’s suggested one-liner (Lock → copy → Unlock → call) alone is not enough with the old design: because the async job held the mutex for the whole job, `CancelSnapshot` would block on `Lock` until the job finished, so cancel would not interrupt promptly. We need short critical sections **and** a WaitGroup so cancel can signal via context cancellation, then wait for the job to exit cleanly before flipping status.

**Who is this feature for?**

- Grafana admins / operators using **Cloud Migration**
- Anyone who cancels an in-progress migration snapshot from the UI or API while create or upload is still running

**Which issue(s) does this PR fix?**:

Fixes #129117

**Special notes for your reviewer:**

Key files:
- `pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration.go` — cancel coordination + `CancelSnapshot`
- `pkg/services/cloudmigration/cloudmigrationimpl/cancel_test.go` — unit tests for `cancelInFlight` (including a `-race` concurrent cancel case)

Suggested verification:
```bash
go test -race ./pkg/services/cloudmigration/cloudmigrationimpl/ -run TestCancelInFlight -count=1