### PR TITLE
Zanzana: Wire resource permissions for datasources

### DIFF
--- a/pkg/services/authz/zanzana/common/info.go
+++ b/pkg/services/authz/zanzana/common/info.go
@@ -203,6 +203,13 @@ func (r ResourceInfo) Context() *structpb.Struct {
 }
 
 func (r ResourceInfo) IsValidRelation(relation string) bool {
+	// Generic subresources are represented as resource objects whose identity includes
+	// the subresource path. They use the schema's plain `create` relation rather than
+	// the `resource_create` relation used by typed resources.
+	if r.IsGeneric() && r.HasSubresource() && relation == RelationCreate {
+		return true
+	}
+
 	return isValidRelation(relation, r.relations)
 }
 

--- a/pkg/services/authz/zanzana/common/info_test.go
+++ b/pkg/services/authz/zanzana/common/info_test.go
@@ -123,6 +123,24 @@ func TestResourceInfoIsValidRelation_TypedResources(t *testing.T) {
 	}
 }
 
+func TestResourceInfoIsValidRelation_GenericResource(t *testing.T) {
+	base := NewResourceInfoFromList(&authzv1.ListRequest{
+		Group:    "loki.datasource.grafana.app",
+		Resource: "datasources",
+	})
+	query := NewResourceInfoFromCheck(&authzv1.CheckRequest{
+		Verb:        utils.VerbCreate,
+		Group:       "loki.datasource.grafana.app",
+		Resource:    "datasources",
+		Subresource: "query",
+		Name:        "ds-1",
+	})
+
+	require.Equal(t, TypeResource, base.Type())
+	assert.False(t, base.IsValidRelation(RelationCreate))
+	assert.True(t, query.IsValidRelation(RelationCreate))
+}
+
 func TestNewResourceInfoFromCheck_FolderCreateAtRootUsesGeneral(t *testing.T) {
 	r := &authzv1.CheckRequest{
 		Verb:      utils.VerbCreate,

--- a/pkg/services/authz/zanzana/server/reconciler/namespace_test.go
+++ b/pkg/services/authz/zanzana/server/reconciler/namespace_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	authzextv1 "github.com/grafana/grafana/pkg/services/authz/proto/v1"
 	"github.com/grafana/grafana/pkg/services/authz/zanzana"
+	"github.com/grafana/grafana/pkg/services/authz/zanzana/common"
 )
 
 // mockServerInternal satisfies zanzana.ServerInternal for computeDiffStreaming tests.
@@ -121,6 +122,41 @@ func newTestReconciler(pages [][]*openfgav1.Tuple) *Reconciler {
 
 func TestComputeDiffStreaming(t *testing.T) {
 	ctx := context.Background()
+
+	t.Run("datasource permission downgrade keeps query tuple", func(t *testing.T) {
+		const group = "loki.datasource.grafana.app"
+		currentBase := common.NewResourceTuple("user:u1", "admin", group, "datasources", "", "ds-1")
+		query := common.NewResourceTuple("user:u1", common.RelationCreate, group, "datasources", "query", "ds-1")
+		expectedBase := common.NewResourceTuple("user:u1", "view", group, "datasources", "", "ds-1")
+
+		expectedMap := map[string]*openfgav1.TupleKey{
+			tupleKey(expectedBase): expectedBase,
+			tupleKey(query):        query,
+		}
+		r := newTestReconciler([][]*openfgav1.Tuple{{toTuple(currentBase), toTuple(query)}})
+
+		toAdd, toDelete, err := r.computeDiffStreaming(ctx, "ns", expectedMap)
+		require.NoError(t, err)
+		require.Len(t, toAdd, 1)
+		assert.Equal(t, tupleKey(expectedBase), tupleKey(toAdd[0]))
+		require.Len(t, toDelete, 1)
+		assert.Equal(t, tupleKey(currentBase), tupleKey(toDelete[0]))
+	})
+
+	t.Run("datasource permission removal deletes both tuples", func(t *testing.T) {
+		const group = "loki.datasource.grafana.app"
+		base := common.NewResourceTuple("user:u1", "admin", group, "datasources", "", "ds-1")
+		query := common.NewResourceTuple("user:u1", common.RelationCreate, group, "datasources", "query", "ds-1")
+		r := newTestReconciler([][]*openfgav1.Tuple{{toTuple(base), toTuple(query)}})
+
+		toAdd, toDelete, err := r.computeDiffStreaming(ctx, "ns", map[string]*openfgav1.TupleKey{})
+		require.NoError(t, err)
+		assert.Empty(t, toAdd)
+		assert.ElementsMatch(t,
+			[]string{tupleKey(base), tupleKey(query)},
+			[]string{tupleKey(toDelete[0]), tupleKey(toDelete[1])},
+		)
+	})
 
 	t.Run("all in sync", func(t *testing.T) {
 		a := makeTuple("user:1", "viewer", "doc:1")

--- a/pkg/services/authz/zanzana/server/reconciler/translators.go
+++ b/pkg/services/authz/zanzana/server/reconciler/translators.go
@@ -128,7 +128,7 @@ func TranslateResourcePermissionToTuples(obj *unstructured.Unstructured) ([]*ope
 
 	tuples := make([]*openfgav1.TupleKey, 0, len(rp.Spec.Permissions))
 	for _, perm := range rp.Spec.Permissions {
-		tuple, err := zanzana.GetResourcePermissionWriteTuple(&authzextv1.CreatePermissionOperation{
+		permissionTuples, err := zanzana.GetResourcePermissionWriteTuples(&authzextv1.CreatePermissionOperation{
 			Resource: resource,
 			Permission: &authzextv1.Permission{
 				Kind: string(perm.Kind),
@@ -139,7 +139,7 @@ func TranslateResourcePermissionToTuples(obj *unstructured.Unstructured) ([]*ope
 		if err != nil {
 			return nil, err
 		}
-		tuples = append(tuples, tuple)
+		tuples = append(tuples, permissionTuples...)
 	}
 
 	return tuples, nil

--- a/pkg/services/authz/zanzana/server/reconciler/translators_test.go
+++ b/pkg/services/authz/zanzana/server/reconciler/translators_test.go
@@ -112,6 +112,67 @@ func TestTranslateResourcePermissionToTuples(t *testing.T) {
 	}
 }
 
+func TestTranslateDatasourceResourcePermissionToTuples(t *testing.T) {
+	const (
+		group    = "loki.datasource.grafana.app"
+		resource = "datasources"
+		name     = "ds-1"
+	)
+
+	subjects := []struct {
+		name string
+		kind iamv0.ResourcePermissionSpecPermissionKind
+		id   string
+		user string
+	}{
+		{"user", iamv0.ResourcePermissionSpecPermissionKindUser, "uid1", "user:uid1"},
+		{"service-account", iamv0.ResourcePermissionSpecPermissionKindServiceAccount, "sa1", "service-account:sa1"},
+		{"team", iamv0.ResourcePermissionSpecPermissionKindTeam, "team1", "team:team1#member"},
+		{"basic-role", iamv0.ResourcePermissionSpecPermissionKindBasicRole, "Editor", "role:basic_editor#assignee"},
+	}
+	levels := []struct {
+		name     string
+		verb     string
+		relation string
+	}{
+		{"query", "Query", "view"},
+		{"edit", "Edit", "edit"},
+		{"admin", "Admin", "admin"},
+	}
+
+	for _, subject := range subjects {
+		for _, level := range levels {
+			t.Run(subject.name+"/"+level.name, func(t *testing.T) {
+				rp := &iamv0.ResourcePermission{
+					ObjectMeta: metav1.ObjectMeta{Name: "loki.datasource.grafana.app-datasources-ds-1"},
+					Spec: iamv0.ResourcePermissionSpec{
+						Resource: iamv0.ResourcePermissionspecResource{
+							ApiGroup: group,
+							Resource: resource,
+							Name:     name,
+						},
+						Permissions: []iamv0.ResourcePermissionspecPermission{{
+							Kind: subject.kind,
+							Name: subject.id,
+							Verb: level.verb,
+						}},
+					},
+				}
+
+				tuples, err := TranslateResourcePermissionToTuples(toUnstructured(t, rp))
+				require.NoError(t, err)
+				require.ElementsMatch(t,
+					tupleKeyStrings([]*openfgav1.TupleKey{
+						common.NewResourceTuple(subject.user, level.relation, group, resource, "", name),
+						common.NewResourceTuple(subject.user, common.RelationCreate, group, resource, "query", name),
+					}),
+					tupleKeyStrings(tuples),
+				)
+			})
+		}
+	}
+}
+
 func TestTranslateTeamToMemberTuples(t *testing.T) {
 	t.Run("admin and member", func(t *testing.T) {
 		team := &iamv0.Team{
@@ -825,6 +886,45 @@ func TestTranslatedTuplesAreSchemaValid(t *testing.T) {
 					validateTupleAgainstSchema(t, ts, tuple)
 				}
 			})
+		}
+	})
+
+	t.Run("datasource resource permissions for all levels and subject kinds", func(t *testing.T) {
+		kinds := []struct {
+			kind iamv0.ResourcePermissionSpecPermissionKind
+			name string
+		}{
+			{iamv0.ResourcePermissionSpecPermissionKindUser, "uid1"},
+			{iamv0.ResourcePermissionSpecPermissionKindServiceAccount, "sa1"},
+			{iamv0.ResourcePermissionSpecPermissionKindTeam, "team1"},
+			{iamv0.ResourcePermissionSpecPermissionKindBasicRole, "Editor"},
+		}
+
+		for _, k := range kinds {
+			for _, verb := range []string{"Query", "Edit", "Admin"} {
+				t.Run(string(k.kind)+"/"+verb, func(t *testing.T) {
+					rp := &iamv0.ResourcePermission{
+						ObjectMeta: metav1.ObjectMeta{Name: "rp-datasource-schema-test"},
+						Spec: iamv0.ResourcePermissionSpec{
+							Resource: iamv0.ResourcePermissionspecResource{
+								ApiGroup: "loki.datasource.grafana.app",
+								Resource: "datasources",
+								Name:     "ds-1",
+							},
+							Permissions: []iamv0.ResourcePermissionspecPermission{
+								{Kind: k.kind, Name: k.name, Verb: verb},
+							},
+						},
+					}
+
+					tuples, err := TranslateResourcePermissionToTuples(toUnstructured(t, rp))
+					require.NoError(t, err)
+					require.Len(t, tuples, 2)
+					for _, tuple := range tuples {
+						validateTupleAgainstSchema(t, ts, tuple)
+					}
+				})
+			}
 		}
 	})
 

--- a/pkg/services/authz/zanzana/server/server_check_test.go
+++ b/pkg/services/authz/zanzana/server/server_check_test.go
@@ -329,3 +329,86 @@ func TestIntegrationServerCheck(t *testing.T) {
 		assert.False(t, res.GetAllowed())
 	})
 }
+
+func TestIntegrationServerCheckGenericDatasourceCreate(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	server := setupOpenFGAServer(t)
+	setup(t, server)
+
+	newReq := func(verb, group, resource, subresource, name string) *authzv1.CheckRequest {
+		return &authzv1.CheckRequest{
+			Namespace:   namespace,
+			Subject:     "user:u1",
+			Verb:        verb,
+			Group:       group,
+			Resource:    resource,
+			Subresource: subresource,
+			Name:        name,
+		}
+	}
+
+	t.Run("allows the granted query subresource", func(t *testing.T) {
+		res, err := server.Check(newContextWithNamespace(), newReq(
+			utils.VerbCreate, datasourceGroup, datasourceResource, datasourceQuerySubresource, "ds-1",
+		))
+		require.NoError(t, err)
+		assert.True(t, res.GetAllowed())
+	})
+
+	t.Run("denies another datasource UID", func(t *testing.T) {
+		res, err := server.Check(newContextWithNamespace(), newReq(
+			utils.VerbCreate, datasourceGroup, datasourceResource, datasourceQuerySubresource, "ds-2",
+		))
+		require.NoError(t, err)
+		assert.False(t, res.GetAllowed())
+	})
+
+	t.Run("subresource query tuple does not grant reading the datasource", func(t *testing.T) {
+		res, err := server.Check(newContextWithNamespace(), newReq(
+			utils.VerbGet, datasourceGroup, datasourceResource, "", "ds-1",
+		))
+		require.NoError(t, err)
+		assert.False(t, res.GetAllowed())
+	})
+
+	t.Run("subresource query tuple does not grant creating the datasource", func(t *testing.T) {
+		res, err := server.Check(newContextWithNamespace(), newReq(
+			utils.VerbCreate, datasourceGroup, datasourceResource, "", "ds-1",
+		))
+		require.NoError(t, err)
+		assert.False(t, res.GetAllowed())
+	})
+
+	t.Run("denies another group", func(t *testing.T) {
+		res, err := server.Check(newContextWithNamespace(), newReq(
+			utils.VerbCreate, "prometheus.datasource.grafana.app", datasourceResource, datasourceQuerySubresource, "ds-1",
+		))
+		require.NoError(t, err)
+		assert.False(t, res.GetAllowed())
+	})
+
+	t.Run("denies another resource", func(t *testing.T) {
+		res, err := server.Check(newContextWithNamespace(), newReq(
+			utils.VerbCreate, datasourceGroup, "connections", datasourceQuerySubresource, "ds-1",
+		))
+		require.NoError(t, err)
+		assert.False(t, res.GetAllowed())
+	})
+
+	t.Run("denies another subresource", func(t *testing.T) {
+		res, err := server.Check(newContextWithNamespace(), newReq(
+			utils.VerbCreate, datasourceGroup, datasourceResource, "metadata", "ds-1",
+		))
+		require.NoError(t, err)
+		assert.False(t, res.GetAllowed())
+	})
+
+	t.Run("does not grant group-wide datasource create", func(t *testing.T) {
+		res, err := server.Check(newContextWithNamespace(), newReq(
+			utils.VerbCreate, datasourceGroup, datasourceResource, "", "",
+		))
+		require.NoError(t, err)
+		assert.False(t, res.GetAllowed())
+	})
+}

--- a/pkg/services/authz/zanzana/server/server_mutate_resourcepermissions.go
+++ b/pkg/services/authz/zanzana/server/server_mutate_resourcepermissions.go
@@ -19,17 +19,17 @@ func (s *Server) mutateResourcePermissions(ctx context.Context, store *zanzana.S
 	for _, operation := range operations {
 		switch op := operation.Operation.(type) {
 		case *authzextv1.MutateOperation_CreatePermission:
-			tuple, err := zanzana.GetResourcePermissionWriteTuple(op.CreatePermission)
+			tuples, err := zanzana.GetResourcePermissionWriteTuples(op.CreatePermission)
 			if err != nil {
 				return err
 			}
-			writeTuples = append(writeTuples, tuple)
+			writeTuples = append(writeTuples, tuples...)
 		case *authzextv1.MutateOperation_DeletePermission:
-			tuple, err := zanzana.GetResourcePermissionDeleteTuple(op.DeletePermission)
+			tuples, err := zanzana.GetResourcePermissionDeleteTuples(op.DeletePermission)
 			if err != nil {
 				return err
 			}
-			deleteTuples = append(deleteTuples, tuple)
+			deleteTuples = append(deleteTuples, tuples...)
 		default:
 			s.logger.Debug("unsupported mutate operation", "operation", op)
 		}

--- a/pkg/services/authz/zanzana/server/server_mutate_resourcepermissions_test.go
+++ b/pkg/services/authz/zanzana/server/server_mutate_resourcepermissions_test.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
@@ -11,6 +13,76 @@ import (
 	"github.com/grafana/grafana/pkg/services/authz/zanzana/common"
 	"github.com/grafana/grafana/pkg/util/testutil"
 )
+
+const (
+	lifecycleDatasourceGroup    = "loki.datasource.grafana.app"
+	lifecycleDatasourceResource = "datasources"
+)
+
+func datasourcePermissionOperation(delete bool, kind, subject, verb, uid string) *v1.MutateOperation {
+	permission := &v1.Permission{
+		Kind: string(kind),
+		Name: subject,
+		Verb: verb,
+	}
+	resource := &v1.Resource{
+		Group:    lifecycleDatasourceGroup,
+		Resource: lifecycleDatasourceResource,
+		Name:     uid,
+	}
+
+	if delete {
+		return &v1.MutateOperation{
+			Operation: &v1.MutateOperation_DeletePermission{
+				DeletePermission: &v1.DeletePermissionOperation{
+					Resource:   resource,
+					Permission: permission,
+				},
+			},
+		}
+	}
+
+	return &v1.MutateOperation{
+		Operation: &v1.MutateOperation_CreatePermission{
+			CreatePermission: &v1.CreatePermissionOperation{
+				Resource:   resource,
+				Permission: permission,
+			},
+		},
+	}
+}
+
+func datasourceTupleIdentity(subject, relation, uid, subresource string) string {
+	object := fmt.Sprintf("resource:%s/%s/%s", lifecycleDatasourceGroup, lifecycleDatasourceResource, uid)
+	if subresource != "" {
+		object = fmt.Sprintf("resource:%s/%s/%s/%s", lifecycleDatasourceGroup, lifecycleDatasourceResource, subresource, uid)
+	}
+	return fmt.Sprintf("%s|%s|%s", subject, relation, object)
+}
+
+func requireDatasourceTupleIdentities(t *testing.T, srv *Server, subject, uid string, expected ...string) {
+	t.Helper()
+
+	var actual []string
+	for _, object := range []string{
+		fmt.Sprintf("resource:%s/%s/%s", lifecycleDatasourceGroup, lifecycleDatasourceResource, uid),
+		fmt.Sprintf("resource:%s/%s/query/%s", lifecycleDatasourceGroup, lifecycleDatasourceResource, uid),
+	} {
+		res, err := srv.Read(newContextWithNamespace(), &v1.ReadRequest{
+			Namespace: "default",
+			TupleKey: &v1.ReadRequestTupleKey{
+				User:   subject,
+				Object: object,
+			},
+		})
+		require.NoError(t, err)
+		for _, tuple := range res.Tuples {
+			actual = append(actual, fmt.Sprintf("%s|%s|%s", tuple.Key.User, tuple.Key.Relation, tuple.Key.Object))
+		}
+	}
+
+	require.ElementsMatch(t, expected, actual)
+}
 
 func setupMutateResourcePermissions(t *testing.T, srv *Server) *Server {
 	t.Helper()
@@ -116,4 +188,106 @@ func TestIntegrationServerMutateResourcePermissions(t *testing.T) {
 		require.Equal(t, common.RelationGet, res.Tuples[0].Key.Relation)
 		require.Equal(t, "resource:dashboard.grafana.app/dashboards/1", res.Tuples[0].Key.Object)
 	})
+}
+
+func TestIntegrationServerMutateDatasourcePermissionLifecycle(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	srv := setupOpenFGAServer(t)
+	setupMutateResourcePermissions(t, srv)
+
+	mutate := func(t *testing.T, operations ...*v1.MutateOperation) {
+		t.Helper()
+		_, err := srv.Mutate(newContextWithZanzanaUpdatePermission(), &v1.MutateRequest{
+			Namespace:  "default",
+			Operations: operations,
+		})
+		require.NoError(t, err)
+	}
+
+	t.Run("user permission lifecycle", func(t *testing.T) {
+		const (
+			uid     = "lifecycle-user"
+			subject = "user:query-user"
+		)
+
+		mutate(t, datasourcePermissionOperation(false, string(iamv0.ResourcePermissionSpecPermissionKindUser), "query-user", "Query", uid))
+		requireDatasourceTupleIdentities(t, srv, subject, uid,
+			datasourceTupleIdentity(subject, common.RelationSetView, uid, ""),
+			datasourceTupleIdentity(subject, common.RelationCreate, uid, "query"),
+		)
+
+		mutate(t,
+			datasourcePermissionOperation(true, string(iamv0.ResourcePermissionSpecPermissionKindUser), "query-user", "Query", uid),
+			datasourcePermissionOperation(false, string(iamv0.ResourcePermissionSpecPermissionKindUser), "query-user", "Edit", uid),
+		)
+		requireDatasourceTupleIdentities(t, srv, subject, uid,
+			datasourceTupleIdentity(subject, common.RelationSetEdit, uid, ""),
+			datasourceTupleIdentity(subject, common.RelationCreate, uid, "query"),
+		)
+
+		mutate(t,
+			datasourcePermissionOperation(true, string(iamv0.ResourcePermissionSpecPermissionKindUser), "query-user", "Edit", uid),
+			datasourcePermissionOperation(false, string(iamv0.ResourcePermissionSpecPermissionKindUser), "query-user", "Admin", uid),
+		)
+		requireDatasourceTupleIdentities(t, srv, subject, uid,
+			datasourceTupleIdentity(subject, common.RelationSetAdmin, uid, ""),
+			datasourceTupleIdentity(subject, common.RelationCreate, uid, "query"),
+		)
+
+		mutate(t,
+			datasourcePermissionOperation(true, string(iamv0.ResourcePermissionSpecPermissionKindUser), "query-user", "Admin", uid),
+			datasourcePermissionOperation(false, string(iamv0.ResourcePermissionSpecPermissionKindUser), "query-user", "Query", uid),
+		)
+		requireDatasourceTupleIdentities(t, srv, subject, uid,
+			datasourceTupleIdentity(subject, common.RelationSetView, uid, ""),
+			datasourceTupleIdentity(subject, common.RelationCreate, uid, "query"),
+		)
+
+		const teamSubject = "team:query-team#member"
+		mutate(t,
+			datasourcePermissionOperation(true, string(iamv0.ResourcePermissionSpecPermissionKindUser), "query-user", "Query", uid),
+			datasourcePermissionOperation(false, string(iamv0.ResourcePermissionSpecPermissionKindTeam), "query-team", "Query", uid),
+		)
+		requireDatasourceTupleIdentities(t, srv, subject, uid)
+		requireDatasourceTupleIdentities(t, srv, teamSubject, uid,
+			datasourceTupleIdentity(teamSubject, common.RelationSetView, uid, ""),
+			datasourceTupleIdentity(teamSubject, common.RelationCreate, uid, "query"),
+		)
+
+		mutate(t, datasourcePermissionOperation(true, string(iamv0.ResourcePermissionSpecPermissionKindTeam), "query-team", "Query", uid))
+		requireDatasourceTupleIdentities(t, srv, teamSubject, uid)
+	})
+
+	for _, test := range []struct {
+		name     string
+		kind     iamv0.ResourcePermissionSpecPermissionKind
+		subject  string
+		zSubject string
+	}{
+		{
+			name:     "service account",
+			kind:     iamv0.ResourcePermissionSpecPermissionKindServiceAccount,
+			subject:  "sa-lifecycle",
+			zSubject: "service-account:sa-lifecycle",
+		},
+		{
+			name:     "basic role",
+			kind:     iamv0.ResourcePermissionSpecPermissionKindBasicRole,
+			subject:  "Editor",
+			zSubject: "role:basic_editor#assignee",
+		},
+	} {
+		t.Run(test.name+" create and delete", func(t *testing.T) {
+			uid := "lifecycle-" + strings.ReplaceAll(test.name, " ", "-")
+			mutate(t, datasourcePermissionOperation(false, string(test.kind), test.subject, "Query", uid))
+			requireDatasourceTupleIdentities(t, srv, test.zSubject, uid,
+				datasourceTupleIdentity(test.zSubject, common.RelationSetView, uid, ""),
+				datasourceTupleIdentity(test.zSubject, common.RelationCreate, uid, "query"),
+			)
+
+			mutate(t, datasourcePermissionOperation(true, string(test.kind), test.subject, "Query", uid))
+			requireDatasourceTupleIdentities(t, srv, test.zSubject, uid)
+		})
+	}
 }

--- a/pkg/services/authz/zanzana/server/server_mutate_resourcepermissions_test.go
+++ b/pkg/services/authz/zanzana/server/server_mutate_resourcepermissions_test.go
@@ -21,7 +21,7 @@ const (
 
 func datasourcePermissionOperation(delete bool, kind, subject, verb, uid string) *v1.MutateOperation {
 	permission := &v1.Permission{
-		Kind: string(kind),
+		Kind: kind,
 		Name: subject,
 		Verb: verb,
 	}

--- a/pkg/services/authz/zanzana/server/server_test.go
+++ b/pkg/services/authz/zanzana/server/server_test.go
@@ -40,6 +40,10 @@ const (
 	serviceAccountGroup    = "iam.grafana.app"
 	serviceAccountResource = "serviceaccounts"
 
+	datasourceGroup            = "loki.datasource.grafana.app"
+	datasourceResource         = "datasources"
+	datasourceQuerySubresource = "query"
+
 	statusSubresource = "status"
 )
 
@@ -87,6 +91,7 @@ func setup(t *testing.T, srv *Server) *Server {
 		common.NewResourceTuple("team:ctx-list#member", common.RelationGet, dashboardGroup, dashboardResource, "", "ctx-list-dashboard"),
 		common.NewResourceTuple("team:ctx-batch#member", common.RelationGet, dashboardGroup, dashboardResource, "", "ctx-batch-dashboard"),
 		common.NewResourceTuple("team:ctx-1000#member", common.RelationGet, dashboardGroup, dashboardResource, "", "ctx-1000-dashboard"),
+		common.NewResourceTuple("user:u1", common.RelationCreate, datasourceGroup, datasourceResource, datasourceQuerySubresource, "ds-1"),
 	}
 
 	return setupOpenFGADatabase(t, srv, tuples)

--- a/pkg/services/authz/zanzana/tuple_helpers.go
+++ b/pkg/services/authz/zanzana/tuple_helpers.go
@@ -469,32 +469,65 @@ func GetRoleBindingTuple(subjectKind string, subjectName string, roleName string
 	return tuple, nil
 }
 
-func GetResourcePermissionWriteTuple(req *authzextv1.CreatePermissionOperation) (*openfgav1.TupleKey, error) {
-	resource := req.GetResource()
-	permission := req.GetPermission()
-	object := NewObjectEntry(toZanzanaType(resource.GetGroup()), resource.GetGroup(), resource.GetResource(), "", resource.GetName())
-	tuple, err := NewResourceTuple(object, resource, permission)
-	if err != nil {
-		return nil, err
-	}
-
-	return tuple, nil
+func GetResourcePermissionWriteTuples(req *authzextv1.CreatePermissionOperation) ([]*openfgav1.TupleKey, error) {
+	return resourcePermissionToTuples(req.GetResource(), req.GetPermission())
 }
 
-func GetResourcePermissionDeleteTuple(req *authzextv1.DeletePermissionOperation) (*openfgav1.TupleKeyWithoutCondition, error) {
-	resource := req.GetResource()
-	permission := req.GetPermission()
-	object := NewObjectEntry(toZanzanaType(resource.GetGroup()), resource.GetGroup(), resource.GetResource(), "", resource.GetName())
-	tuple, err := NewResourceTuple(object, resource, permission)
+func GetResourcePermissionDeleteTuples(req *authzextv1.DeletePermissionOperation) ([]*openfgav1.TupleKeyWithoutCondition, error) {
+	tuples, err := resourcePermissionToTuples(req.GetResource(), req.GetPermission())
 	if err != nil {
 		return nil, err
 	}
 
-	return &openfgav1.TupleKeyWithoutCondition{
-		User:     tuple.GetUser(),
-		Relation: tuple.GetRelation(),
-		Object:   tuple.GetObject(),
+	deleteTuples := make([]*openfgav1.TupleKeyWithoutCondition, 0, len(tuples))
+	for _, tuple := range tuples {
+		deleteTuples = append(deleteTuples, &openfgav1.TupleKeyWithoutCondition{
+			User:     tuple.GetUser(),
+			Relation: tuple.GetRelation(),
+			Object:   tuple.GetObject(),
+		})
+	}
+	return deleteTuples, nil
+}
+
+func resourcePermissionToTuples(resource *authzextv1.Resource, permission *authzextv1.Permission) ([]*openfgav1.TupleKey, error) {
+	subject, err := toZanzanaSubject(permission.GetKind(), permission.GetName())
+	if err != nil {
+		return nil, err
+	}
+
+	relation := strings.ToLower(permission.GetVerb())
+	if isDatasourcePermission(resource) {
+		return datasourcePermissionToTuples(subject, relation, resource), nil
+	}
+
+	return []*openfgav1.TupleKey{
+		newResourcePermissionTuple(subject, relation, resource, ""),
 	}, nil
+}
+
+func datasourcePermissionToTuples(subject, relation string, resource *authzextv1.Resource) []*openfgav1.TupleKey {
+	switch relation {
+	case "query":
+		// Query is represented as view on the datasource.
+		relation = RelationSetView
+	case RelationSetEdit, RelationSetAdmin:
+	default:
+		// Preserve granular relations without granting query access.
+		return []*openfgav1.TupleKey{
+			newResourcePermissionTuple(subject, relation, resource, ""),
+		}
+	}
+
+	// Action Sets also grant query access.
+	return []*openfgav1.TupleKey{
+		newResourcePermissionTuple(subject, relation, resource, ""),
+		newResourcePermissionTuple(subject, RelationCreate, resource, "query"),
+	}
+}
+
+func isDatasourcePermission(resource *authzextv1.Resource) bool {
+	return resource.GetResource() == "datasources" && strings.HasSuffix(resource.GetGroup(), ".datasource.grafana.app")
 }
 
 func toZanzanaType(apiGroup string) string {
@@ -504,41 +537,46 @@ func toZanzanaType(apiGroup string) string {
 	return TypeResource
 }
 
-func NewResourceTuple(object string, resource *authzextv1.Resource, perm *authzextv1.Permission) (*openfgav1.TupleKey, error) {
-	// Typ is "folder" or "resource"
-	typ := toZanzanaType(resource.Group)
-
-	// subject
-	subject, err := toZanzanaSubject(perm.GetKind(), perm.GetName())
-	if err != nil {
-		return nil, err
-	}
+func newResourcePermissionTuple(subject, relation string, resource *authzextv1.Resource, subresource string) *openfgav1.TupleKey {
+	typ := toZanzanaType(resource.GetGroup())
 
 	key := &openfgav1.TupleKey{
-		// e.g. "user:{uid}", "serviceaccount:{uid}", "team:{uid}", "basicrole:{viewer|editor|admin}"
+		// e.g. "user:{uid}", "service-account:{uid}", "team:{uid}", "role:basic_{viewer|editor|admin}#assignee"
 		User: subject,
 		// "view", "edit", "admin"
-		Relation: strings.ToLower(perm.Verb),
+		Relation: relation,
 		// e.g. "folder:{name}" or "resource:{apiGroup}/{resource}/{name}"
-		Object: object,
+		// e.g. "resource:{apiGroup}/{resource}/{subresource}/{name}"
+		Object: NewObjectEntry(
+			typ,
+			resource.GetGroup(),
+			resource.GetResource(),
+			subresource,
+			resource.GetName(),
+		),
 	}
 
-	// For resources we add a condition to filter by apiGroup/resource
+	// For generic resources we add a condition to filter by apiGroup/resource[/subresource]
 	// e.g "group_filter": {"group_resource": "dashboard.grafana.app/dashboards"}
+	// e.g "group_filter": {"group_resource": "loki.datasource.grafana.app/datasources/query"}
 	if typ == TypeResource {
+		groupResource := resource.GetResource()
+		if subresource != "" {
+			groupResource += "/" + subresource
+		}
 		key.Condition = &openfgav1.RelationshipCondition{
 			Name: "group_filter",
 			Context: &structpb.Struct{
 				Fields: map[string]*structpb.Value{
 					"group_resource": structpb.NewStringValue(
-						resource.GetGroup() + "/" + resource.GetResource(),
+						resource.GetGroup() + "/" + groupResource,
 					),
 				},
 			},
 		}
 	}
 
-	return key, nil
+	return key
 }
 
 func toZanzanaSubject(kind string, name string) (string, error) {

--- a/pkg/services/authz/zanzana/tuple_helpers_test.go
+++ b/pkg/services/authz/zanzana/tuple_helpers_test.go
@@ -6,6 +6,9 @@ import (
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/structpb"
+
+	iamv0 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
+	authzextv1 "github.com/grafana/grafana/pkg/services/authz/proto/v1"
 )
 
 func TestTupleStringWithoutCondition(t *testing.T) {
@@ -34,6 +37,161 @@ func TestTupleStringWithoutCondition(t *testing.T) {
 	require.Contains(t, result, "user:123")
 	require.Contains(t, result, "view")
 	require.Contains(t, result, "folder:abc")
+}
+
+func TestResourcePermissionWriteTuples(t *testing.T) {
+	const group = "loki.datasource.grafana.app"
+	const resource = "datasources"
+	const uid = "ds-1"
+
+	cases := []struct {
+		name         string
+		verb         string
+		kind         iamv0.ResourcePermissionSpecPermissionKind
+		subject      string
+		baseRelation string
+	}{
+		{"query user", "Query", iamv0.ResourcePermissionSpecPermissionKindUser, "user:u1", "view"},
+		{"query service account", "query", iamv0.ResourcePermissionSpecPermissionKindServiceAccount, "service-account:sa1", "view"},
+		{"query team", "QUERY", iamv0.ResourcePermissionSpecPermissionKindTeam, "team:team1#member", "view"},
+		{"query basic role", "query", iamv0.ResourcePermissionSpecPermissionKindBasicRole, "role:basic_editor#assignee", "view"},
+		{"edit user", "Edit", iamv0.ResourcePermissionSpecPermissionKindUser, "user:u1", "edit"},
+		{"edit service account", "edit", iamv0.ResourcePermissionSpecPermissionKindServiceAccount, "service-account:sa1", "edit"},
+		{"edit team", "EDIT", iamv0.ResourcePermissionSpecPermissionKindTeam, "team:team1#member", "edit"},
+		{"edit basic role", "edit", iamv0.ResourcePermissionSpecPermissionKindBasicRole, "role:basic_editor#assignee", "edit"},
+		{"admin user", "Admin", iamv0.ResourcePermissionSpecPermissionKindUser, "user:u1", "admin"},
+		{"admin service account", "admin", iamv0.ResourcePermissionSpecPermissionKindServiceAccount, "service-account:sa1", "admin"},
+		{"admin team", "ADMIN", iamv0.ResourcePermissionSpecPermissionKindTeam, "team:team1#member", "admin"},
+		{"admin basic role", "admin", iamv0.ResourcePermissionSpecPermissionKindBasicRole, "role:basic_editor#assignee", "admin"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tuple, err := GetResourcePermissionWriteTuples(&authzextv1.CreatePermissionOperation{
+				Resource: &authzextv1.Resource{Group: group, Resource: resource, Name: uid},
+				Permission: &authzextv1.Permission{
+					Kind: string(tc.kind),
+					Name: permissionSubjectName(tc.kind),
+					Verb: tc.verb,
+				},
+			})
+			require.NoError(t, err)
+			require.Len(t, tuple, 2)
+
+			base := findTuple(tuple, tc.baseRelation, "resource:"+group+"/"+resource+"/"+uid)
+			require.NotNil(t, base)
+			require.Equal(t, tc.subject, base.User)
+			requireGroupFilter(t, base, group+"/"+resource)
+
+			query := findTuple(tuple, "create", "resource:"+group+"/"+resource+"/query/"+uid)
+			require.NotNil(t, query)
+			require.Equal(t, tc.subject, query.User)
+			requireGroupFilter(t, query, group+"/"+resource+"/query")
+		})
+	}
+}
+
+func TestResourcePermissionDeleteTuples(t *testing.T) {
+	const group = "loki.datasource.grafana.app"
+	const resource = "datasources"
+
+	target := &authzextv1.Resource{Group: group, Resource: resource, Name: "ds-1"}
+	permission := &authzextv1.Permission{
+		Kind: string(iamv0.ResourcePermissionSpecPermissionKindTeam),
+		Name: "team1",
+		Verb: "Admin",
+	}
+	writes, err := GetResourcePermissionWriteTuples(&authzextv1.CreatePermissionOperation{
+		Resource: target, Permission: permission,
+	})
+	require.NoError(t, err)
+	deletes, err := GetResourcePermissionDeleteTuples(&authzextv1.DeletePermissionOperation{
+		Resource: target, Permission: permission,
+	})
+	require.NoError(t, err)
+	require.Len(t, deletes, 2)
+	require.ElementsMatch(t, []string{
+		"team:team1#member|admin|resource:" + group + "/" + resource + "/ds-1",
+		"team:team1#member|create|resource:" + group + "/" + resource + "/query/ds-1",
+	}, deleteTupleKeys(deletes))
+	for i, key := range deletes {
+		require.Equal(t, writes[i].GetUser(), key.GetUser())
+		require.Equal(t, writes[i].GetRelation(), key.GetRelation())
+		require.Equal(t, writes[i].GetObject(), key.GetObject())
+		require.NotContains(t, key.String(), "condition")
+	}
+}
+
+func TestResourcePermissionTupleRegressionCases(t *testing.T) {
+	tests := []struct {
+		name  string
+		group string
+		res   string
+		verb  string
+		count int
+	}{
+		{"dashboard remains singular", "dashboard.grafana.app", "dashboards", "View", 1},
+		{"folder remains singular", "folder.grafana.app", "folders", "View", 1},
+		{"wrong datasource resource remains singular", "loki.datasource.grafana.app", "queries", "Query", 1},
+		{"unrelated group remains singular", "loki", "datasources", "View", 1},
+		{"granular dashboard get remains singular", "dashboard.grafana.app", "dashboards", "Get", 1},
+		{"granular datasource get remains singular", "loki.datasource.grafana.app", "datasources", "Get", 1},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tuple, err := GetResourcePermissionWriteTuples(&authzextv1.CreatePermissionOperation{
+				Resource: &authzextv1.Resource{Group: tc.group, Resource: tc.res, Name: "obj-1"},
+				Permission: &authzextv1.Permission{
+					Kind: string(iamv0.ResourcePermissionSpecPermissionKindUser),
+					Name: "u1",
+					Verb: tc.verb,
+				},
+			})
+			require.NoError(t, err)
+			require.Len(t, tuple, tc.count)
+		})
+	}
+}
+
+func permissionSubjectName(kind iamv0.ResourcePermissionSpecPermissionKind) string {
+	switch kind {
+	case iamv0.ResourcePermissionSpecPermissionKindUser:
+		return "u1"
+	case iamv0.ResourcePermissionSpecPermissionKindServiceAccount:
+		return "sa1"
+	case iamv0.ResourcePermissionSpecPermissionKindTeam:
+		return "team1"
+	case iamv0.ResourcePermissionSpecPermissionKindBasicRole:
+		return "Editor"
+	default:
+		panic("unknown permission kind")
+	}
+}
+
+func findTuple(tuples []*openfgav1.TupleKey, relation, object string) *openfgav1.TupleKey {
+	for _, tuple := range tuples {
+		if tuple.Relation == relation && tuple.Object == object {
+			return tuple
+		}
+	}
+	return nil
+}
+
+func requireGroupFilter(t *testing.T, tuple *openfgav1.TupleKey, groupFilter string) {
+	t.Helper()
+	require.NotNil(t, tuple)
+	require.NotNil(t, tuple.Condition)
+	require.Equal(t, "group_filter", tuple.Condition.Name)
+	require.Equal(t, groupFilter, tuple.Condition.Context.Fields["group_resource"].GetStringValue())
+}
+
+func deleteTupleKeys(tuples []*openfgav1.TupleKeyWithoutCondition) []string {
+	keys := make([]string, 0, len(tuples))
+	for _, tuple := range tuples {
+		keys = append(keys, tuple.User+"|"+tuple.Relation+"|"+tuple.Object)
+	}
+	return keys
 }
 
 func TestConvertRolePermissionsToTuples(t *testing.T) {


### PR DESCRIPTION
## Why the change

Datasource resource permissions (`Query`, `Edit`, `Admin`) for concrete plugin API groups such as `loki.datasource.grafana.app/datasources` were not represented correctly in Zanzana.

Querying a datasource is modelled as a `create` on its `query` subresource. So a single datasource permission needs to become two tuples: one for the datasource itself, and one that grants querying.

## What it does

Each datasource permission now expands into two per-object tuples:

- a base tuple on the datasource: `view` (for `Query`), `edit` (for `Edit`), or `admin` (for `Admin`);
- a `create` tuple on the datasource's `query` subresource.

The `query` tuple is always `create`, for every level. It never becomes `edit` or `admin`, matching the legacy RBAC mapper, which grants only `datasources:query` on that subresource.

## Example

Permission `Query` for `user:u1` on datasource `ds-1` in group `loki.datasource.grafana.app` expands to:

```text
[
  {
    User:     "user:u1",
    Relation: "view",
    Object:   "resource:loki.datasource.grafana.app/datasources/ds-1",
    Condition: group_filter{
      group_resource: "loki.datasource.grafana.app/datasources",
    },
  },
  {
    User:     "user:u1",
    Relation: "create",
    Object:   "resource:loki.datasource.grafana.app/datasources/query/ds-1",
    Condition: group_filter{
      group_resource: "loki.datasource.grafana.app/datasources/query",
    },
  },
]
```

`Edit` and `Admin` produce the same second (`create`) tuple; only the base relation changes to `edit` or `admin`.

## How

- The shared resource-permission converter detects datasource entries for the `datasources` resource in plugin API groups ending in `.datasource.grafana.app`. It maps `Query` to `view` and adds the `create` tuple on the `query` subresource for `Query`, `Edit`, and `Admin`.
- Live mutations and reconciliation use the same conversion. Delete conversion reuses it so writes and deletes stay symmetric.
- `ResourceInfo.IsValidRelation` allows per-object `create` only for generic subresources. Base datasource objects still cannot be created per object.
- Other resources, such as dashboards and folders, continue to produce one tuple per permission.