### PR TITLE
abstract delete modal idea

### DIFF
--- a/public/app/features/alerting/unified/components/ConfirmModalWithError.test.tsx
+++ b/public/app/features/alerting/unified/components/ConfirmModalWithError.test.tsx
@@ -1,0 +1,60 @@
+import { type ReactNode } from 'react';
+import { render, screen, userEvent, waitFor } from 'test/test-utils';
+
+import { useConfirmModalWithError } from './ConfirmModalWithError';
+
+interface TestModalProps {
+  body: ReactNode;
+  onConfirm: () => Promise<unknown>;
+}
+
+function TestModal({ body, onConfirm }: TestModalProps) {
+  const [modal, showModal, isPending] = useConfirmModalWithError({
+    title: 'Test modal',
+    body,
+    onConfirm,
+  });
+
+  return (
+    <>
+      <button type="button" onClick={showModal} disabled={isPending}>
+        Open modal
+      </button>
+      {modal}
+    </>
+  );
+}
+
+describe('useConfirmModalWithError', () => {
+  it('closes after a successful action', async () => {
+    const onConfirm = jest.fn().mockResolvedValue(undefined);
+    const { user } = render(<TestModal body={<div>Modal body</div>} onConfirm={onConfirm} />);
+
+    await user.click(screen.getByRole('button', { name: 'Open modal' }));
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => expect(screen.queryByRole('dialog', { name: 'Test modal' })).not.toBeInTheDocument());
+  });
+
+  it('surfaces errors from promise-returning actions', async () => {
+    let rejectConfirm!: (error: Error) => void;
+    const onConfirm = jest.fn(
+      () =>
+        new Promise<never>((_resolve, reject) => {
+          rejectConfirm = reject;
+        })
+    );
+    const { user } = render(<TestModal body={<div>Modal body</div>} onConfirm={onConfirm} />);
+
+    await user.click(screen.getByRole('button', { name: 'Open modal' }));
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    await waitFor(() => expect(onConfirm).toHaveBeenCalled());
+
+    expect(screen.getByRole('button', { name: 'Open modal' })).toBeDisabled();
+
+    rejectConfirm(new Error('delete failed'));
+
+    expect(await screen.findByRole('dialog', { name: 'Something went wrong' })).toBeInTheDocument();
+    expect(screen.getByText(/delete failed/i)).toBeInTheDocument();
+  });
+});

--- a/public/app/features/alerting/unified/components/ConfirmModalWithError.test.tsx
+++ b/public/app/features/alerting/unified/components/ConfirmModalWithError.test.tsx
@@ -56,5 +56,11 @@ describe('useConfirmModalWithError', () => {
 
     expect(await screen.findByRole('dialog', { name: 'Something went wrong' })).toBeInTheDocument();
     expect(screen.getByText(/delete failed/i)).toBeInTheDocument();
+
+    await user.click(screen.getByText('Close'));
+    expect(screen.queryByRole('dialog', { name: 'Something went wrong' })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Open modal' }));
+    expect(await screen.findByRole('dialog', { name: 'Test modal' })).toBeInTheDocument();
   });
 });

--- a/public/app/features/alerting/unified/components/ConfirmModalWithError.tsx
+++ b/public/app/features/alerting/unified/components/ConfirmModalWithError.tsx
@@ -19,7 +19,7 @@ export interface ConfirmModalWithErrorProps {
   onDismiss: () => void;
 }
 
-export const ConfirmModalWithError = ({
+const ConfirmModalWithError = ({
   isOpen,
   title,
   body,

--- a/public/app/features/alerting/unified/components/ConfirmModalWithError.tsx
+++ b/public/app/features/alerting/unified/components/ConfirmModalWithError.tsx
@@ -1,0 +1,83 @@
+import { noop } from 'lodash';
+import { type ReactNode, useState } from 'react';
+
+import { t } from '@grafana/i18n';
+import { Button, type ButtonProps, Modal } from '@grafana/ui';
+
+import { type AsyncState, isError, isLoading } from '../hooks/useAsync';
+
+import { ErrorModal } from './ErrorModal';
+
+export interface ConfirmModalWithErrorProps {
+  isOpen: boolean;
+  title: string;
+  body: ReactNode;
+  confirmText?: string;
+  confirmingText?: string;
+  cancelText?: string;
+  confirmVariant?: ButtonProps['variant'];
+  state: AsyncState<unknown>;
+  onConfirm: () => Promise<unknown>;
+  onDismiss: () => void;
+}
+
+export const ConfirmModalWithError = ({
+  isOpen,
+  title,
+  body,
+  confirmText = t('alerting.common.delete', 'Delete'),
+  confirmingText = t('alerting.common.deleting', 'Deleting...'),
+  cancelText = t('alerting.common.cancel', 'Cancel'),
+  confirmVariant = 'destructive',
+  state,
+  onConfirm,
+  onDismiss,
+}: ConfirmModalWithErrorProps) => {
+  const isRunning = isLoading(state);
+
+  const handleDismiss = isRunning ? noop : onDismiss;
+
+  const handleConfirm = async () => {
+    onConfirm().then(() => handleDismiss());
+  };
+
+  if (isError(state)) {
+    return <ErrorModal isOpen onDismiss={onDismiss} error={state.error} />;
+  }
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      title={title}
+      onDismiss={handleDismiss}
+      closeOnBackdropClick={!isRunning}
+      closeOnEscape={!isRunning}
+    >
+      <p>{body}</p>
+      <Modal.ButtonRow>
+        <Button type="button" variant="secondary" onClick={handleDismiss} disabled={isRunning}>
+          {cancelText}
+        </Button>
+        <Button type="button" variant={confirmVariant} onClick={handleConfirm} disabled={isRunning}>
+          {isRunning ? (confirmingText ?? confirmText) : confirmText}
+        </Button>
+      </Modal.ButtonRow>
+    </Modal>
+  );
+};
+
+export type UseConfirmModalWithErrorProps = Omit<ConfirmModalWithErrorProps, 'isOpen' | 'onDismiss'>;
+
+/**
+ * Owns the open/closed state for `ConfirmModalWithError` so callers don't have to.
+ */
+export const useConfirmModalWithError = (props: UseConfirmModalWithErrorProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const showModal = () => setIsOpen(true);
+  const dismissModal = () => setIsOpen(false);
+
+  const modal = <ConfirmModalWithError {...props} isOpen={isOpen} onDismiss={dismissModal} />;
+
+  return [modal, showModal, props.state] as const;
+};

--- a/public/app/features/alerting/unified/components/ConfirmModalWithError.tsx
+++ b/public/app/features/alerting/unified/components/ConfirmModalWithError.tsx
@@ -1,10 +1,7 @@
-import { noop } from 'lodash';
 import { type ReactNode, useState } from 'react';
 
 import { t } from '@grafana/i18n';
 import { Button, type ButtonProps, Modal } from '@grafana/ui';
-
-import { type AsyncState, isError, isLoading } from '../hooks/useAsync';
 
 import { ErrorModal } from './ErrorModal';
 
@@ -16,11 +13,10 @@ export interface ConfirmModalWithErrorProps {
   confirmingText?: string;
   cancelText?: string;
   confirmVariant?: ButtonProps['variant'];
-  state: AsyncState<unknown>;
-  onConfirm: () => Promise<unknown>;
+  isPending: boolean;
+  error: unknown | undefined;
+  onConfirm: () => void;
   onDismiss: () => void;
-  /** Called alongside `onDismiss` to clear the error state once the user acknowledges it. */
-  onReset: () => void;
 }
 
 export const ConfirmModalWithError = ({
@@ -31,26 +27,19 @@ export const ConfirmModalWithError = ({
   confirmingText = t('alerting.common.deleting', 'Deleting...'),
   cancelText = t('alerting.common.cancel', 'Cancel'),
   confirmVariant = 'destructive',
-  state,
+  isPending,
+  error,
   onConfirm,
   onDismiss,
-  onReset,
 }: ConfirmModalWithErrorProps) => {
-  const isRunning = isLoading(state);
-
-  const handleDismiss = isRunning ? noop : onDismiss;
-
-  const handleConfirm = async () => {
-    onConfirm().then(() => handleDismiss());
+  const handleDismiss = () => {
+    if (!isPending) {
+      onDismiss();
+    }
   };
 
-  const handleErrorDismiss = () => {
-    onReset();
-    onDismiss();
-  };
-
-  if (isError(state)) {
-    return <ErrorModal isOpen onDismiss={handleErrorDismiss} error={state.error} />;
+  if (error !== undefined) {
+    return <ErrorModal isOpen={isOpen} onDismiss={onDismiss} error={error} />;
   }
 
   return (
@@ -58,34 +47,73 @@ export const ConfirmModalWithError = ({
       isOpen={isOpen}
       title={title}
       onDismiss={handleDismiss}
-      closeOnBackdropClick={!isRunning}
-      closeOnEscape={!isRunning}
+      closeOnBackdropClick={!isPending}
+      closeOnEscape={!isPending}
     >
-      <p>{body}</p>
+      {body}
       <Modal.ButtonRow>
-        <Button type="button" variant="secondary" onClick={handleDismiss} disabled={isRunning}>
+        <Button type="button" variant="secondary" onClick={handleDismiss} disabled={isPending}>
           {cancelText}
         </Button>
-        <Button type="button" variant={confirmVariant} onClick={handleConfirm} disabled={isRunning}>
-          {isRunning ? (confirmingText ?? confirmText) : confirmText}
+        <Button type="button" variant={confirmVariant} onClick={onConfirm} disabled={isPending}>
+          {isPending ? confirmingText : confirmText}
         </Button>
       </Modal.ButtonRow>
     </Modal>
   );
 };
 
-export type UseConfirmModalWithErrorProps = Omit<ConfirmModalWithErrorProps, 'isOpen' | 'onDismiss'>;
+export type UseConfirmModalWithErrorProps = Omit<
+  ConfirmModalWithErrorProps,
+  'isOpen' | 'isPending' | 'error' | 'onConfirm' | 'onDismiss'
+> & {
+  onConfirm: () => Promise<unknown>;
+};
 
-/**
- * Owns the open/closed state for `ConfirmModalWithError` so callers don't have to.
- */
-export const useConfirmModalWithError = (props: UseConfirmModalWithErrorProps) => {
+export const useConfirmModalWithError = ({ onConfirm, ...props }: UseConfirmModalWithErrorProps) => {
   const [isOpen, setIsOpen] = useState(false);
+  const [isPending, setIsPending] = useState(false);
+  const [error, setError] = useState<unknown>();
 
-  const showModal = () => setIsOpen(true);
-  const dismissModal = () => setIsOpen(false);
+  const closeModal = () => {
+    setError(undefined);
+    setIsOpen(false);
+  };
 
-  const modal = <ConfirmModalWithError {...props} isOpen={isOpen} onDismiss={dismissModal} />;
+  const dismissModal = () => {
+    if (!isPending) {
+      closeModal();
+    }
+  };
 
-  return [modal, showModal, props.state] as const;
+  const confirmModal = async () => {
+    setIsPending(true);
+
+    try {
+      await onConfirm();
+      closeModal();
+    } catch (error) {
+      setError(error);
+    } finally {
+      setIsPending(false);
+    }
+  };
+
+  const showModal = () => {
+    setError(undefined);
+    setIsOpen(true);
+  };
+
+  const modal = (
+    <ConfirmModalWithError
+      {...props}
+      isOpen={isOpen}
+      isPending={isPending}
+      error={error}
+      onConfirm={confirmModal}
+      onDismiss={dismissModal}
+    />
+  );
+
+  return [modal, showModal, isPending] as const;
 };

--- a/public/app/features/alerting/unified/components/ConfirmModalWithError.tsx
+++ b/public/app/features/alerting/unified/components/ConfirmModalWithError.tsx
@@ -19,6 +19,8 @@ export interface ConfirmModalWithErrorProps {
   state: AsyncState<unknown>;
   onConfirm: () => Promise<unknown>;
   onDismiss: () => void;
+  /** Called alongside `onDismiss` to clear the error state once the user acknowledges it. */
+  onReset: () => void;
 }
 
 export const ConfirmModalWithError = ({
@@ -32,6 +34,7 @@ export const ConfirmModalWithError = ({
   state,
   onConfirm,
   onDismiss,
+  onReset,
 }: ConfirmModalWithErrorProps) => {
   const isRunning = isLoading(state);
 
@@ -41,8 +44,13 @@ export const ConfirmModalWithError = ({
     onConfirm().then(() => handleDismiss());
   };
 
+  const handleErrorDismiss = () => {
+    onReset();
+    onDismiss();
+  };
+
   if (isError(state)) {
-    return <ErrorModal isOpen onDismiss={onDismiss} error={state.error} />;
+    return <ErrorModal isOpen onDismiss={handleErrorDismiss} error={state.error} />;
   }
 
   return (

--- a/public/app/features/alerting/unified/components/ErrorModal.tsx
+++ b/public/app/features/alerting/unified/components/ErrorModal.tsx
@@ -1,5 +1,5 @@
 import { Trans, t } from '@grafana/i18n';
-import { Modal, type ModalProps } from '@grafana/ui';
+import { Button, Modal, type ModalProps } from '@grafana/ui';
 
 import { stringifyErrorLike } from '../utils/misc';
 
@@ -24,6 +24,11 @@ export const ErrorModal = ({ isOpen, onDismiss, error }: ErrorModalProps) => {
       <pre>
         <code>{stringifyErrorLike(error)}</code>
       </pre>
+      <Modal.ButtonRow>
+        <Button type="button" variant="secondary" onClick={onDismiss}>
+          {t('alerting.common.close', 'Close')}
+        </Button>
+      </Modal.ButtonRow>
     </Modal>
   );
 };

--- a/public/app/features/alerting/unified/components/mute-timings/DeleteMuteTimingModal.tsx
+++ b/public/app/features/alerting/unified/components/mute-timings/DeleteMuteTimingModal.tsx
@@ -1,69 +1,25 @@
-import { useState } from 'react';
-
 import { t } from '@grafana/i18n';
-import { Button, Modal } from '@grafana/ui';
 
-import { ErrorModal } from '../ErrorModal';
+import { useConfirmModalWithError } from '../ConfirmModalWithError';
 
 import { type MuteTiming, useDeleteMuteTiming } from './useMuteTimings';
 
-export interface DeleteMuteTimingModalProps {
+export interface UseDeleteMuteTimingModalOptions {
   muteTiming: MuteTiming;
   alertManagerSourceName: string;
-  onDismiss: () => void;
 }
 
-export const DeleteMuteTimingModal = ({
-  muteTiming,
-  alertManagerSourceName,
-  onDismiss,
-}: DeleteMuteTimingModalProps) => {
+export const useDeleteMuteTimingModal = ({ muteTiming, alertManagerSourceName }: UseDeleteMuteTimingModalOptions) => {
   const [deleteMuteTiming, deleteMuteTimingState] = useDeleteMuteTiming({ alertmanager: alertManagerSourceName });
-  const [deleteError, setDeleteError] = useState<unknown>();
-  const isDeleting = deleteMuteTimingState.status === 'loading';
 
-  const handleDismiss = () => {
-    if (!isDeleting) {
-      onDismiss();
-    }
-  };
-
-  const handleConfirm = async () => {
-    try {
-      await deleteMuteTiming.execute({ name: muteTiming?.metadata?.name ?? muteTiming.name });
-      onDismiss();
-    } catch (error) {
-      setDeleteError(error);
-    }
-  };
-
-  if (deleteError !== undefined) {
-    return <ErrorModal isOpen onDismiss={handleDismiss} error={deleteError} />;
-  }
-
-  return (
-    <Modal
-      isOpen
-      title={t('alerting.mute-timing-actions-buttons.title-delete-mute-timing', 'Delete mute timing')}
-      onDismiss={handleDismiss}
-      closeOnBackdropClick={!isDeleting}
-      closeOnEscape={!isDeleting}
-    >
-      <p>
-        {t(
-          'alerting.mute-timing-actions-button.body-delete-mute-timing',
-          'Are you sure you would like to delete "{{muteTiming}}"?',
-          { muteTiming: muteTiming.name }
-        )}
-      </p>
-      <Modal.ButtonRow>
-        <Button type="button" variant="secondary" onClick={handleDismiss} disabled={isDeleting}>
-          {t('alerting.common.cancel', 'Cancel')}
-        </Button>
-        <Button type="button" variant="destructive" onClick={handleConfirm} disabled={isDeleting}>
-          {isDeleting ? t('alerting.common.deleting', 'Deleting...') : t('alerting.common.delete', 'Delete')}
-        </Button>
-      </Modal.ButtonRow>
-    </Modal>
-  );
+  return useConfirmModalWithError({
+    title: t('alerting.mute-timing-actions-buttons.title-delete-mute-timing', 'Delete mute timing'),
+    body: t(
+      'alerting.mute-timing-actions-button.body-delete-mute-timing',
+      'Are you sure you would like to delete "{{muteTiming}}"?',
+      { muteTiming: muteTiming.name }
+    ),
+    state: deleteMuteTimingState,
+    onConfirm: () => deleteMuteTiming.execute({ name: muteTiming?.metadata?.name ?? muteTiming.name }),
+  });
 };

--- a/public/app/features/alerting/unified/components/mute-timings/DeleteMuteTimingModal.tsx
+++ b/public/app/features/alerting/unified/components/mute-timings/DeleteMuteTimingModal.tsx
@@ -21,5 +21,6 @@ export const useDeleteMuteTimingModal = ({ muteTiming, alertManagerSourceName }:
     ),
     state: deleteMuteTimingState,
     onConfirm: () => deleteMuteTiming.execute({ name: muteTiming?.metadata?.name ?? muteTiming.name }),
+    onReset: deleteMuteTiming.reset,
   });
 };

--- a/public/app/features/alerting/unified/components/mute-timings/DeleteMuteTimingModal.tsx
+++ b/public/app/features/alerting/unified/components/mute-timings/DeleteMuteTimingModal.tsx
@@ -10,17 +10,19 @@ export interface UseDeleteMuteTimingModalOptions {
 }
 
 export const useDeleteMuteTimingModal = ({ muteTiming, alertManagerSourceName }: UseDeleteMuteTimingModalOptions) => {
-  const [deleteMuteTiming, deleteMuteTimingState] = useDeleteMuteTiming({ alertmanager: alertManagerSourceName });
+  const [deleteMuteTiming] = useDeleteMuteTiming({ alertmanager: alertManagerSourceName });
 
   return useConfirmModalWithError({
     title: t('alerting.mute-timing-actions-buttons.title-delete-mute-timing', 'Delete mute timing'),
-    body: t(
-      'alerting.mute-timing-actions-button.body-delete-mute-timing',
-      'Are you sure you would like to delete "{{muteTiming}}"?',
-      { muteTiming: muteTiming.name }
+    body: (
+      <p>
+        {t(
+          'alerting.mute-timing-actions-button.body-delete-mute-timing',
+          'Are you sure you would like to delete "{{muteTiming}}"?',
+          { muteTiming: muteTiming.name }
+        )}
+      </p>
     ),
-    state: deleteMuteTimingState,
     onConfirm: () => deleteMuteTiming.execute({ name: muteTiming?.metadata?.name ?? muteTiming.name }),
-    onReset: deleteMuteTiming.reset,
   });
 };

--- a/public/app/features/alerting/unified/components/mute-timings/MuteTimingActionsButtons.tsx
+++ b/public/app/features/alerting/unified/components/mute-timings/MuteTimingActionsButtons.tsx
@@ -5,7 +5,6 @@ import { useExportMuteTimingsDrawer } from 'app/features/alerting/unified/compon
 import { isGranted, isProvisioned, isSupported } from '../../hooks/abilities/abilityUtils';
 import { useTimeIntervalAbility } from '../../hooks/abilities/alertmanager/useTimeIntervalAbility';
 import { TimeIntervalAction } from '../../hooks/abilities/types';
-import { isLoading } from '../../hooks/useAsync';
 import { GRAFANA_RULES_SOURCE_NAME } from '../../utils/datasource';
 import { makeAMLink } from '../../utils/misc';
 import { isDisabled } from '../../utils/mute-timings';
@@ -20,7 +19,7 @@ interface MuteTimingActionsButtonsProps {
 
 export const MuteTimingActionsButtons = ({ muteTiming, alertManagerSourceName }: MuteTimingActionsButtonsProps) => {
   const [ExportDrawer, showExportDrawer] = useExportMuteTimingsDrawer();
-  const [deleteModal, showDeleteModal, deleteMuteTimingState] = useDeleteMuteTimingModal({
+  const [deleteModal, showDeleteModal, isDeleting] = useDeleteMuteTimingModal({
     muteTiming,
     alertManagerSourceName,
   });
@@ -66,13 +65,7 @@ export const MuteTimingActionsButtons = ({ muteTiming, alertManagerSourceName }:
         )}
 
         {!muteTiming.provisioned && isGranted(deleteAbility) && (
-          <LinkButton
-            icon="trash-alt"
-            variant="secondary"
-            size="sm"
-            disabled={isLoading(deleteMuteTimingState)}
-            onClick={showDeleteModal}
-          >
+          <LinkButton icon="trash-alt" variant="secondary" size="sm" disabled={isDeleting} onClick={showDeleteModal}>
             <Trans i18nKey="alerting.common.delete">Delete</Trans>
           </LinkButton>
         )}

--- a/public/app/features/alerting/unified/components/mute-timings/MuteTimingActionsButtons.tsx
+++ b/public/app/features/alerting/unified/components/mute-timings/MuteTimingActionsButtons.tsx
@@ -1,17 +1,16 @@
-import { useContext } from 'react';
-
 import { Trans, t } from '@grafana/i18n';
-import { Badge, LinkButton, ModalsContext, Stack } from '@grafana/ui';
+import { Badge, LinkButton, Stack } from '@grafana/ui';
 import { useExportMuteTimingsDrawer } from 'app/features/alerting/unified/components/mute-timings/useExportMuteTimingsDrawer';
 
 import { isGranted, isProvisioned, isSupported } from '../../hooks/abilities/abilityUtils';
 import { useTimeIntervalAbility } from '../../hooks/abilities/alertmanager/useTimeIntervalAbility';
 import { TimeIntervalAction } from '../../hooks/abilities/types';
+import { isLoading } from '../../hooks/useAsync';
 import { GRAFANA_RULES_SOURCE_NAME } from '../../utils/datasource';
 import { makeAMLink } from '../../utils/misc';
 import { isDisabled } from '../../utils/mute-timings';
 
-import { DeleteMuteTimingModal } from './DeleteMuteTimingModal';
+import { useDeleteMuteTimingModal } from './DeleteMuteTimingModal';
 import { type MuteTiming } from './useMuteTimings';
 
 interface MuteTimingActionsButtonsProps {
@@ -20,11 +19,12 @@ interface MuteTimingActionsButtonsProps {
 }
 
 export const MuteTimingActionsButtons = ({ muteTiming, alertManagerSourceName }: MuteTimingActionsButtonsProps) => {
-  const { showModal, hideModal } = useContext(ModalsContext);
   const [ExportDrawer, showExportDrawer] = useExportMuteTimingsDrawer();
+  const [deleteModal, showDeleteModal, deleteMuteTimingState] = useDeleteMuteTimingModal({
+    muteTiming,
+    alertManagerSourceName,
+  });
 
-  const showDeleteModal = () =>
-    showModal(DeleteMuteTimingModal, { muteTiming, alertManagerSourceName, onDismiss: hideModal });
   const updateAbility = useTimeIntervalAbility({ action: TimeIntervalAction.Update, context: muteTiming });
   const deleteAbility = useTimeIntervalAbility({ action: TimeIntervalAction.Delete, context: muteTiming });
   const exportAbility = useTimeIntervalAbility({ action: TimeIntervalAction.Export });
@@ -66,12 +66,19 @@ export const MuteTimingActionsButtons = ({ muteTiming, alertManagerSourceName }:
         )}
 
         {!muteTiming.provisioned && isGranted(deleteAbility) && (
-          <LinkButton icon="trash-alt" variant="secondary" size="sm" onClick={showDeleteModal}>
+          <LinkButton
+            icon="trash-alt"
+            variant="secondary"
+            size="sm"
+            disabled={isLoading(deleteMuteTimingState)}
+            onClick={showDeleteModal}
+          >
             <Trans i18nKey="alerting.common.delete">Delete</Trans>
           </LinkButton>
         )}
       </Stack>
       {ExportDrawer}
+      {deleteModal}
     </>
   );
 };

--- a/public/app/features/alerting/unified/components/mute-timings/MuteTimingsTable.test.tsx
+++ b/public/app/features/alerting/unified/components/mute-timings/MuteTimingsTable.test.tsx
@@ -26,8 +26,7 @@ const renderWithProvider = (alertManagerSource = GRAFANA_RULES_SOURCE_NAME) => {
   return render(
     <AlertmanagerProvider accessType={'notification'} alertmanagerSourceName={alertManagerSource}>
       <TimeIntervalsTable />
-    </AlertmanagerProvider>,
-    { withModalRoot: true }
+    </AlertmanagerProvider>
   );
 };
 
@@ -149,11 +148,13 @@ describe('MuteTimingsTable', () => {
         })
       );
       const { user } = renderWithProvider();
+      const deleteButton = (await screen.findAllByText(/delete/i))[0];
 
-      await user.click((await screen.findAllByText(/delete/i))[0]);
+      await user.click(deleteButton);
       await user.click(await screen.findByRole('button', { name: /delete/i }));
       await waitFor(() => expect(resolveDelete).toBeDefined());
 
+      expect(deleteButton.closest('a')).toHaveAttribute('aria-disabled', 'true');
       expect(screen.getByRole('button', { name: /deleting/i })).toBeDisabled();
       expect(screen.getByRole('button', { name: /cancel/i })).toBeDisabled();
       expect(screen.getByRole('dialog', { name: /delete mute timing/i })).toBeInTheDocument();

--- a/public/test/test-utils.tsx
+++ b/public/test/test-utils.tsx
@@ -20,7 +20,6 @@ import {
   setLocationService,
 } from '@grafana/runtime';
 import { getTestFeatureFlagClient } from '@grafana/test-utils/unstable';
-import { ModalRoot } from '@grafana/ui';
 import { GrafanaContext, type GrafanaContextType } from 'app/core/context/GrafanaContext';
 import { ModalsContextProvider } from 'app/core/context/ModalsContextProvider';
 import { configureStore } from 'app/store/configureStore';
@@ -46,10 +45,6 @@ interface ExtendedRenderOptions extends RenderOptions {
    * Props to pass to `createMemoryHistory`, if being used
    */
   historyOptions?: MemoryHistoryBuildOptions;
-  /**
-   * Render the app-level modal root as a sibling of the UI under test.
-   */
-  withModalRoot?: boolean;
 }
 
 /**
@@ -61,7 +56,6 @@ const getWrapper = ({
   renderWithRouter,
   historyOptions,
   grafanaContext,
-  withModalRoot,
 }: ExtendedRenderOptions & {
   grafanaContext?: Partial<GrafanaContextType>;
 }) => {
@@ -99,10 +93,7 @@ const getWrapper = ({
             <PotentialRouter>
               <LocationServiceProvider service={locationService}>
                 <PotentialCompatRouter>
-                  <ModalsContextProvider>
-                    {children}
-                    {withModalRoot && <ModalRoot />}
-                  </ModalsContextProvider>
+                  <ModalsContextProvider>{children}</ModalsContextProvider>
                 </PotentialCompatRouter>
               </LocationServiceProvider>
             </PotentialRouter>
@@ -120,12 +111,11 @@ const getWrapper = ({
  */
 const customRender = (
   ui: React.ReactElement,
-  { renderWithRouter = true, withModalRoot = false, ...renderOptions }: ExtendedRenderOptions = {}
+  { renderWithRouter = true, ...renderOptions }: ExtendedRenderOptions = {}
 ) => {
   const user = userEvent.setup();
   const store = renderOptions.preloadedState ? configureStore(renderOptions?.preloadedState) : undefined;
-  const AllTheProviders =
-    renderOptions.wrapper || getWrapper({ store, renderWithRouter, withModalRoot, ...renderOptions });
+  const AllTheProviders = renderOptions.wrapper || getWrapper({ store, renderWithRouter, ...renderOptions });
 
   setChromeHeaderHeightHook(() => 40);
 


### PR DESCRIPTION
**What is this feature?**

Exploring some options to simplify Modal juggling with the goals to;

1. Make sure we never unintentionally hide error states
2. Reduce boilerplate for specific Modal wrappers
3. Allow us to to and control our own Modal(s)

Managing the modal state in the abstract hook also frees us from having to use the `RootModal` as long as the Modal is a sibling DOM node.

Couple of things I don't like about this approach that I'll highlight as PR comments.