### PR TITLE
Dashboards: Expose element key and type attributes on rows and tabs

### DIFF
--- a/public/app/features/dashboard-scene/mutation-api/commands/updateVariable.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/updateVariable.ts
@@ -64,6 +64,9 @@ export const updateVariableCommand: MutationCommand<UpdateVariablePayload> = {
 
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Zod output is structurally compatible with VariableKind
       const newSceneVariable = createSceneVariableFromVariableModel(variableKind as VariableKind);
+      // Preserve scene identity across the replacement - element pickers, highlight
+      // overlays, and attached assistant context address the variable by scene key.
+      newSceneVariable.setState({ key: previousState.key });
       currentVariables[existingIndex] = newSceneVariable;
 
       replaceScopeVariableSet(scopeOwner, currentVariables);

--- a/public/app/features/dashboard-scene/mutation-api/commands/updateVariable.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/updateVariable.ts
@@ -71,6 +71,15 @@ export const updateVariableCommand: MutationCommand<UpdateVariablePayload> = {
 
       replaceScopeVariableSet(scopeOwner, currentVariables);
 
+      // The element edit pane memoizes its editable element per selection, so a pane
+      // open on the replaced variable would keep editing the detached object.
+      // Re-selecting the successor (same key, force) remounts the pane against it.
+      const editPane = scene.state.sidebar;
+      const selected = editPane?.state.selectionContext.selected;
+      if (selected?.length === 1 && selected[0].id === previousState.key) {
+        editPane.selectObject(newSceneVariable, { force: true });
+      }
+
       const changePath = buildVariableChangePath(layoutPathPrefix, name);
 
       return {

--- a/public/app/features/dashboard-scene/mutation-api/commands/variableCommands.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/variableCommands.test.ts
@@ -183,6 +183,28 @@ describe('Variable mutation commands', () => {
     expect(result.changes[0].path).toBe('/variables/env');
   });
 
+  it('UPDATE_VARIABLE preserves the scene key across the replacement', async () => {
+    await client.execute({
+      type: 'ADD_VARIABLE',
+      payload: {
+        variable: { kind: 'CustomVariable', spec: { name: 'env', query: 'dev,prod' } },
+      },
+    });
+    const keyBefore = scene.state.$variables?.state.variables.find((v) => v.state.name === 'env')?.state.key;
+    expect(keyBefore).toBeDefined();
+
+    await client.execute({
+      type: 'UPDATE_VARIABLE',
+      payload: {
+        name: 'env',
+        variable: { kind: 'CustomVariable', spec: { name: 'env', query: 'dev,prod,canary' } },
+      },
+    });
+
+    const keyAfter = scene.state.$variables?.state.variables.find((v) => v.state.name === 'env')?.state.key;
+    expect(keyAfter).toBe(keyBefore);
+  });
+
   it('UPDATE_VARIABLE returns error when variable not found', async () => {
     const result = await client.execute({
       type: 'UPDATE_VARIABLE',

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItemRenderer.test.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItemRenderer.test.tsx
@@ -26,6 +26,22 @@ function renderRow({ collapse = false, title = 'My row' } = {}) {
 }
 
 describe('RowItemRenderer', () => {
+  it('stamps data-dashboard-element-key and data-dashboard-element-type on the row header', () => {
+    renderRow({ collapse: false });
+
+    const header = document.querySelector('[data-dashboard-element-key="row-1"]');
+    expect(header).toBeInTheDocument();
+    expect(header).toHaveAttribute('data-dashboard-element-type', 'row');
+  });
+
+  it('stamps the row header when the row is collapsed', () => {
+    renderRow({ collapse: true });
+
+    const header = document.querySelector('[data-dashboard-element-key="row-1"]');
+    expect(header).toBeInTheDocument();
+    expect(header).toHaveAttribute('data-dashboard-element-type', 'row');
+  });
+
   it('exposes aria-expanded=true on the toggle button when the row is expanded', () => {
     const { row } = renderRow({ collapse: false });
 

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItemRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItemRenderer.tsx
@@ -141,6 +141,8 @@ export function RowItemRenderer({ model }: SceneComponentProps<RowItem>) {
               className={cx(styles.rowHeader, 'dashboard-row-header')}
               onMouseEnter={isSelectable ? onHeaderEnter : undefined}
               onMouseLeave={isSelectable ? onHeaderLeave : undefined}
+              data-dashboard-element-key={key}
+              data-dashboard-element-type="row"
               {...dragProvided.dragHandleProps}
             >
               <button

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabItemRenderer.test.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabItemRenderer.test.tsx
@@ -1,0 +1,49 @@
+import { screen } from '@testing-library/react';
+import { render } from 'test/test-utils';
+
+import { SceneTimeRange } from '@grafana/scenes';
+
+import { DashboardScene } from '../DashboardScene';
+import { AutoGridLayoutManager } from '../layout-auto-grid/AutoGridLayoutManager';
+
+import { TabItem } from './TabItem';
+import { TabsLayoutManager } from './TabsLayoutManager';
+
+function renderTab({ title = 'Overview', key = 'tab-1' } = {}) {
+  const tab = new TabItem({
+    key,
+    title,
+    layout: AutoGridLayoutManager.createEmpty(),
+  });
+  const tabsLayout = new TabsLayoutManager({ key: 'tabs-layout', tabs: [tab] });
+  const scene = new DashboardScene({
+    $timeRange: new SceneTimeRange({ from: 'now-6h', to: 'now' }),
+    body: tabsLayout,
+  });
+  render(<scene.Component model={scene} />);
+  return { tab, tabsLayout };
+}
+
+describe('TabItemRenderer', () => {
+  it('stamps data-dashboard-element-key and data-dashboard-element-type on the tab', () => {
+    renderTab({ key: 'tab-1', title: 'Overview' });
+
+    const tabEl = document.querySelector('[data-dashboard-element-key="tab-1"]');
+    expect(tabEl).toBeInTheDocument();
+    expect(tabEl).toHaveAttribute('data-dashboard-element-type', 'tab');
+  });
+
+  it('stamps the element key for a second tab', () => {
+    renderTab({ key: 'tab-abc', title: 'Performance' });
+
+    const tabEl = document.querySelector('[data-dashboard-element-key="tab-abc"]');
+    expect(tabEl).toBeInTheDocument();
+    expect(tabEl).toHaveAttribute('data-dashboard-element-type', 'tab');
+  });
+
+  it('renders the tab title in the accessible label', () => {
+    renderTab({ title: 'Overview' });
+
+    expect(screen.getByRole('tab', { name: /Overview/i })).toBeInTheDocument();
+  });
+});

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabItemRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabItemRenderer.tsx
@@ -140,6 +140,8 @@ export function TabItemRenderer({ model }: SceneComponentProps<TabItem>) {
             }}
             label={titleInterpolated}
             data-tab-activation-key={key}
+            data-dashboard-element-key={key}
+            data-dashboard-element-type="tab"
             {...titleCollisionProps}
           />
         </div>

--- a/public/app/features/dashboard-scene/sidebar/ElementEditPane.test.tsx
+++ b/public/app/features/dashboard-scene/sidebar/ElementEditPane.test.tsx
@@ -1,0 +1,85 @@
+import { act, render, screen } from 'test/test-utils';
+
+import { getPanelPlugin } from '@grafana/data/test';
+import { setPluginImportUtils } from '@grafana/runtime';
+import { CustomVariable, SceneTimeRange, SceneVariableSet, useSceneObjectState } from '@grafana/scenes';
+
+import { DashboardMutationClient } from '../mutation-api/DashboardMutationClient';
+import { DashboardScene } from '../scene/DashboardScene';
+import { AutoGridLayoutManager } from '../scene/layout-auto-grid/AutoGridLayoutManager';
+import { activateFullSceneTree } from '../utils/test-utils';
+
+import { type DashboardSidebarLike } from './types';
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getDataSourceSrv: () => ({
+    getInstanceSettings: (_uid: string | null) => ({ uid: 'ds1' }),
+  }),
+}));
+
+// Header is sidebar chrome (needs Sidebar context); irrelevant to the stale-element question
+jest.mock('./ElementEditPaneHeader', () => ({
+  ElementEditPaneHeader: () => null,
+}));
+
+setPluginImportUtils({
+  importPanelPlugin: () => Promise.resolve(getPanelPlugin({})),
+  getPanelPluginFromCache: () => undefined,
+});
+
+// Mirrors DashboardEditPaneRenderer: renders the current openPane keyed by its scene key
+function PaneHost({ editPane }: { editPane: DashboardSidebarLike }) {
+  const { openPane } = useSceneObjectState(editPane, { shouldActivateOrKeepAlive: true });
+  return openPane ? <openPane.Component key={openPane.state.key} model={openPane} /> : null;
+}
+
+describe('ElementEditPane after UPDATE_VARIABLE mutation', () => {
+  it('rebinds the open pane to the replacement variable', async () => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const variable = new CustomVariable({ name: 'region', query: 'a,b,c', label: 'OLD-LABEL' });
+    const variableSet = new SceneVariableSet({ variables: [variable] });
+    const dashboard = new DashboardScene({
+      uid: 'test-dash',
+      meta: { canEdit: true, canSave: true },
+      $timeRange: new SceneTimeRange({ from: 'now-6h', to: 'now' }),
+      $variables: variableSet,
+      isEditing: true,
+      body: AutoGridLayoutManager.createEmpty(),
+    });
+
+    activateFullSceneTree(dashboard);
+
+    const editPane = dashboard.state.sidebar;
+    editPane.selectObject(variable, { force: true });
+
+    render(<PaneHost editPane={editPane} />);
+
+    // Sanity: pane shows the original definition
+    expect(await screen.findByDisplayValue('OLD-LABEL')).toBeInTheDocument();
+
+    const client = new DashboardMutationClient(dashboard);
+    let success = false;
+    await act(async () => {
+      const result = await client.execute({
+        type: 'UPDATE_VARIABLE',
+        payload: {
+          name: 'region',
+          variable: { kind: 'CustomVariable', spec: { name: 'region', query: 'x,y,z', label: 'NEW-LABEL' } },
+        },
+      });
+      success = result.success;
+    });
+    expect(success).toBe(true);
+
+    // The live scene must hold a NEW object with the PRESERVED key
+    const live = dashboard.state.$variables!.getByName('region')!;
+    expect(live).not.toBe(variable);
+    expect(live.state.key).toBe(variable.state.key);
+
+    // The pane must show the replacement, not the detached original
+    expect(await screen.findByDisplayValue('NEW-LABEL')).toBeInTheDocument();
+    expect(screen.queryByDisplayValue('OLD-LABEL')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What

Three changes for Assistant element selection:

1. Stamps `data-dashboard-element-key` / `data-dashboard-element-type` on row headers and tabs, extending [#128950](https://github.com/grafana/grafana/pull/128950) (variables/annotations).
2. `UPDATE_VARIABLE` preserves the variable's scene key across the object replacement.
3. `UPDATE_VARIABLE` re-selects the replacement variable when its edit pane is open, so the pane rebinds instead of editing the detached object.

## Why

The Assistant element picker resolves elements by scene key via these attributes (consumer: [grafana/grafana-assistant-app#8510](https://github.com/grafana/grafana-assistant-app/pull/8510)); rows and tabs are the next pickable types after variables/annotations.

Key preservation: the update swap regenerated the key, orphaning everything that addresses the variable by identity (picker context, highlight overlays). Update semantics should preserve identity - the swap is an implementation detail. Reviewer note: renderers keyed by scene key now keep their DOM node and get a new model as props instead of remounting - please bless that consciously.

Pane rebinding: the edit pane memoizes its editable element per selection, so a pane open on the variable kept editing the detached object (pre-existing staleness, surfaced by Bugbot below). Re-selecting the successor remounts the pane against the live object.

## How to test

- `yarn jest RowItemRenderer TabItemRenderer variableCommands ElementEditPane`
- Full flow: run the assistant plugin PR against this build - pick rows/tabs/variables in the element picker, edit a variable via the Assistant while its edit pane is open, confirm the highlight overlay keeps tracking and the pane shows the updated definition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)