### PR TITLE
Dashboards: Fix export download filename for v2 resources

### DIFF
--- a/public/app/features/dashboard-scene/sharing/ShareExportTab.test.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareExportTab.test.tsx
@@ -1,3 +1,5 @@
+import saveAs from 'file-saver';
+
 import { config } from '@grafana/runtime';
 import { SceneTimeRange } from '@grafana/scenes';
 import {
@@ -21,6 +23,7 @@ import { DefaultGridLayoutManager } from '../scene/layout-default/DefaultGridLay
 
 import { ShareExportTab } from './ShareExportTab';
 
+jest.mock('file-saver', () => jest.fn());
 jest.mock('app/features/dashboard/api/dashboard_api');
 
 const mockV1Spec: DashboardDataDTO = {
@@ -381,6 +384,35 @@ describe('ShareExportTab', () => {
 
       const result = await tab.getExportableDashboardJson();
       expect(result.json).toHaveProperty('error');
+    });
+  });
+
+  describe('onSaveAsFile filename', () => {
+    afterEach(() => {
+      jest.mocked(saveAs).mockClear();
+    });
+
+    it('should use dashboard title for classic export filename', async () => {
+      const tab = buildV1DashboardScenario();
+      tab.setState({ exportFormat: ExportFormat.Classic });
+
+      await tab.onSaveAsFile();
+
+      expect(saveAs).toHaveBeenCalledTimes(1);
+      const [, filename] = jest.mocked(saveAs).mock.calls[0];
+      expect(filename).toMatch(/^Test Dashboard V1-\d+\.json$/);
+    });
+
+    it('should use dashboard title from spec for v2 resource export filename', async () => {
+      config.featureToggles.dashboardNewLayouts = true;
+      const tab = buildV2DashboardScenario();
+      tab.setState({ exportFormat: ExportFormat.V2Resource });
+
+      await tab.onSaveAsFile();
+
+      expect(saveAs).toHaveBeenCalledTimes(1);
+      const [, filename] = jest.mocked(saveAs).mock.calls[0];
+      expect(filename).toMatch(/^Test Dashboard V2-\d+\.json$/);
     });
   });
 

--- a/public/app/features/dashboard-scene/sharing/ShareExportTab.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareExportTab.tsx
@@ -229,10 +229,7 @@ export class ShareExportTab extends SceneObjectBase<ShareExportTabState> impleme
     });
 
     const time = new Date().getTime();
-    let title = 'dashboard';
-    if ('title' in dashboard.json && dashboard.json.title) {
-      title = dashboard.json.title;
-    }
+    const title = getExportFileTitle(dashboard.json);
     const extension = isViewingYAML ? 'yaml' : 'json';
     saveAs(blob, `${title}-${time}.${extension}`);
 
@@ -261,6 +258,21 @@ export class ShareExportTab extends SceneObjectBase<ShareExportTabState> impleme
 }
 
 const FOLDER_EXPORT_ANNOTATIONS = [AnnoKeyFolder, AnnoKeyFolderTitle, AnnoKeyFolderUrl] as const;
+
+// Classic export JSON has title at the root; v2 resource export nests it under spec.
+function getExportFileTitle(
+  json: Dashboard | DashboardJson | DashboardV2Spec | ExportableResource | { error: unknown }
+): string {
+  if ('title' in json && json.title) {
+    return json.title;
+  }
+
+  if ('spec' in json && json.spec && 'title' in json.spec && json.spec.title) {
+    return json.spec.title;
+  }
+
+  return 'dashboard';
+}
 
 function stripFolderAnnotations(annotations: Record<string, string> | undefined) {
   if (!annotations) {


### PR DESCRIPTION
**What is this feature?**

Restores the dashboard title in the download filename when exporting a v2 resource dashboard.

Before: `dashboard-1777645504766.json`
After: `Environment Home-1777645504766.json`

**Why do we need this feature?**

In Grafana v13, the default export path for dashboards with the new layout is the v2 resource shape (`apiVersion` / `kind` / `metadata` / `spec`). The download filename only checked for a top-level `title`, which does not exist on that wrapper, so every v2 export fell back to `dashboard-<timestamp>.json`. Classic exports still have `title` at the root and were unaffected.

**Who is this feature for?**

Anyone on Grafana v13+ who uses Export → Save to file, especially with the v2 resource format (including IaC workflows that rely on the filename).

**Which issue(s) does this PR fix?**:

Fixes #123961

**Special notes for your reviewer:**

- Classic export still uses the root `title`
- V2 resource export reads `spec.title`
- Fallback remains `dashboard` when neither is present
- Unit coverage in `ShareExportTab.test.tsx` (mock `file-saver`, assert filename)

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle. (N/A  regression fix)
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc. (N/A)