### PR TITLE
Alerting: Fix custom recovery threshold with "Is equal to" condition

### DIFF
--- a/public/app/features/expressions/components/Threshold.tsx
+++ b/public/app/features/expressions/components/Threshold.tsx
@@ -436,12 +436,14 @@ function RecoveryThresholdRow({ isRange, condition, onError, dispatch, allowOnbl
           </InlineFieldRow>
         );
       case EvalFunction.IsNotEqual:
+        // An "is not equal to X" alert recovers when the value returns to X, so the recovery
+        // condition is "equal to" (matching the IsEqual unload evaluator it generates).
         return (
           <InlineFieldRow className={styles.hysteresis}>
             <InlineField
               label={t(
-                'alerting.rule-form.threshold.recovery.stop-alerting-not-equal',
-                'Stop alerting (or pending state) when not equal to'
+                'alerting.rule-form.threshold.recovery.stop-alerting-equal',
+                'Stop alerting (or pending state) when equal to'
               )}
               labelWidth={'auto'}
               invalid={Boolean(invalidErrorMsg)}

--- a/public/app/features/expressions/components/Threshold.tsx
+++ b/public/app/features/expressions/components/Threshold.tsx
@@ -412,32 +412,11 @@ function RecoveryThresholdRow({ isRange, condition, onError, dispatch, allowOnbl
             </InlineField>
           </InlineFieldRow>
         );
+      // Both equality operators generate an IsEqual unload evaluator: "is equal to X" recovers
+      // when the value reaches the recovery value, and "is not equal to X" recovers when the
+      // value returns to X.
       case EvalFunction.IsEqual:
-        return (
-          <InlineFieldRow className={styles.hysteresis}>
-            <InlineField
-              label={t(
-                'alerting.rule-form.threshold.recovery.stop-alerting-equal',
-                'Stop alerting (or pending state) when equal to'
-              )}
-              labelWidth={'auto'}
-              invalid={Boolean(invalidErrorMsg)}
-              error={invalidErrorMsg}
-            >
-              <Input
-                type="number"
-                width={10}
-                onBlur={(event) => {
-                  allowOnblur.current && onUnloadValueChange(event, 0);
-                }}
-                defaultValue={condition.unloadEvaluator?.params[0]}
-              />
-            </InlineField>
-          </InlineFieldRow>
-        );
       case EvalFunction.IsNotEqual:
-        // An "is not equal to X" alert recovers when the value returns to X, so the recovery
-        // condition is "equal to" (matching the IsEqual unload evaluator it generates).
         return (
           <InlineFieldRow className={styles.hysteresis}>
             <InlineField

--- a/public/app/features/expressions/components/hysteresis.test.ts
+++ b/public/app/features/expressions/components/hysteresis.test.ts
@@ -287,6 +287,58 @@ describe('thresholdReducer', () => {
     expect(newState.conditions[0].unloadEvaluator?.type).toEqual(EvalFunction.IsBelow);
     expect(newState.conditions[0].unloadEvaluator?.params[0]).toEqual(10);
   });
+  it('sets the unloadEvaluator type to IsEqual when checking hysteresis on an "is equal to" threshold', () => {
+    // Equality has no directional opposite: the alert should recover when the value
+    // equals the recovery value, so the unload evaluator must stay IsEqual (not IsNotEqual).
+    const initialState: ThresholdExpressionQuery = {
+      type: ExpressionQueryType.threshold,
+      refId: 'A',
+      conditions: [
+        {
+          ...thresholdCondition,
+          evaluator: { type: EvalFunction.IsEqual, params: [20] },
+          unloadEvaluator: undefined,
+        },
+      ],
+    };
+
+    const newState = thresholdReducer(initialState, updateHysteresisChecked({ hysteresisChecked: true, onError }));
+
+    expect(newState.conditions[0].unloadEvaluator?.type).toEqual(EvalFunction.IsEqual);
+  });
+
+  it('sets the unloadEvaluator type to IsEqual when switching the threshold type to "is equal to" with hysteresis on', () => {
+    const initialState: ThresholdExpressionQuery = {
+      type: ExpressionQueryType.threshold,
+      refId: 'A',
+      conditions: [thresholdCondition],
+    };
+
+    const newState = thresholdReducer(initialState, updateThresholdType({ evalFunction: EvalFunction.IsEqual, onError }));
+
+    expect(newState.conditions[0].evaluator.type).toEqual(EvalFunction.IsEqual);
+    expect(newState.conditions[0].unloadEvaluator?.type).toEqual(EvalFunction.IsEqual);
+  });
+
+  it('sets the unloadEvaluator type to IsEqual when checking hysteresis on an "is not equal to" threshold', () => {
+    // "is not equal to X" recovers when the value returns to X, so the unload evaluator is IsEqual.
+    const initialState: ThresholdExpressionQuery = {
+      type: ExpressionQueryType.threshold,
+      refId: 'A',
+      conditions: [
+        {
+          ...thresholdCondition,
+          evaluator: { type: EvalFunction.IsNotEqual, params: [20] },
+          unloadEvaluator: undefined,
+        },
+      ],
+    };
+
+    const newState = thresholdReducer(initialState, updateHysteresisChecked({ hysteresisChecked: true, onError }));
+
+    expect(newState.conditions[0].unloadEvaluator?.type).toEqual(EvalFunction.IsEqual);
+  });
+
   it('Should update unlooadEvaluator when unchecking hysteresis', () => {
     const initialState: ThresholdExpressionQuery = {
       type: ExpressionQueryType.threshold,

--- a/public/app/features/expressions/components/hysteresis.test.ts
+++ b/public/app/features/expressions/components/hysteresis.test.ts
@@ -307,6 +307,24 @@ describe('thresholdReducer', () => {
     expect(newState.conditions[0].unloadEvaluator?.type).toEqual(EvalFunction.IsEqual);
   });
 
+  it('reports a validation error when checking hysteresis on an "is equal to" threshold', () => {
+    const initialState: ThresholdExpressionQuery = {
+      type: ExpressionQueryType.threshold,
+      refId: 'A',
+      conditions: [
+        {
+          ...thresholdCondition,
+          evaluator: { type: EvalFunction.IsEqual, params: [20] },
+          unloadEvaluator: undefined,
+        },
+      ],
+    };
+
+    thresholdReducer(initialState, updateHysteresisChecked({ hysteresisChecked: true, onError }));
+
+    expect(onError).toHaveBeenCalledWith('Enter a different number than 20');
+  });
+
   it('sets the unloadEvaluator type to IsEqual when switching the threshold type to "is equal to" with hysteresis on', () => {
     const initialState: ThresholdExpressionQuery = {
       type: ExpressionQueryType.threshold,
@@ -314,10 +332,25 @@ describe('thresholdReducer', () => {
       conditions: [thresholdCondition],
     };
 
-    const newState = thresholdReducer(initialState, updateThresholdType({ evalFunction: EvalFunction.IsEqual, onError }));
+    const newState = thresholdReducer(
+      initialState,
+      updateThresholdType({ evalFunction: EvalFunction.IsEqual, onError })
+    );
 
     expect(newState.conditions[0].evaluator.type).toEqual(EvalFunction.IsEqual);
     expect(newState.conditions[0].unloadEvaluator?.type).toEqual(EvalFunction.IsEqual);
+  });
+
+  it('reports a validation error when switching to an "is equal to" threshold with hysteresis on', () => {
+    const initialState: ThresholdExpressionQuery = {
+      type: ExpressionQueryType.threshold,
+      refId: 'A',
+      conditions: [thresholdCondition],
+    };
+
+    thresholdReducer(initialState, updateThresholdType({ evalFunction: EvalFunction.IsEqual, onError }));
+
+    expect(onError).toHaveBeenCalledWith('Enter a different number than 10');
   });
 
   it('sets the unloadEvaluator type to IsEqual when checking hysteresis on an "is not equal to" threshold', () => {

--- a/public/app/features/expressions/components/thresholdReducer.ts
+++ b/public/app/features/expressions/components/thresholdReducer.ts
@@ -121,8 +121,10 @@ function getUnloadEvaluatorTypeFromEvaluatorType(type: EvalFunction) {
   if (type === EvalFunction.IsBelow) {
     return EvalFunction.IsAbove;
   }
+  // Equality has no directional opposite. Both equal/not-equal thresholds recover when the
+  // value equals the recovery value, so the unload evaluator is IsEqual in both cases.
   if (type === EvalFunction.IsEqual) {
-    return EvalFunction.IsNotEqual;
+    return EvalFunction.IsEqual;
   }
   if (type === EvalFunction.IsNotEqual) {
     return EvalFunction.IsEqual;

--- a/public/app/features/expressions/components/thresholdReducer.ts
+++ b/public/app/features/expressions/components/thresholdReducer.ts
@@ -54,21 +54,7 @@ export const thresholdReducer = createReducer<ThresholdExpressionQuery>(
       const hsyteresisIsChecked = Boolean(state.conditions[0].unloadEvaluator);
 
       if (hsyteresisIsChecked) {
-        // when type whas changed and hsyteresIsChecked, we need to update the type for the unload evaluator with the opposite type
-        const updatedUnloadType = getUnloadEvaluatorTypeFromEvaluatorType(state.conditions[0].evaluator.type);
-
-        // set error to undefined when type is changed as we default to the new type that is valid
-        if (onError) {
-          onError(undefined); //clear error
-        }
-        // set newtype in evaluator
-        state.conditions[0].evaluator.type = typeInPayload;
-        // set new type and params in unload evaluator
-        const defaultUnloadEvaluator = {
-          type: updatedUnloadType,
-          params: state.conditions[0].evaluator?.params ?? [0, 0],
-        };
-        state.conditions[0].unloadEvaluator = defaultUnloadEvaluator;
+        applyDefaultUnloadEvaluator(state.conditions[0], onError);
       }
     });
     builder.addCase(updateThresholdParams, (state, action) => {
@@ -83,35 +69,46 @@ export const thresholdReducer = createReducer<ThresholdExpressionQuery>(
           onError(undefined); // clear error
         }
       } else {
-        state.conditions[0].unloadEvaluator = {
-          type: getUnloadEvaluatorTypeFromEvaluatorType(state.conditions[0].evaluator.type),
-          params: state.conditions[0].evaluator?.params ?? [0, 0],
-        };
+        applyDefaultUnloadEvaluator(state.conditions[0], onError);
       }
     });
     builder.addCase(updateUnloadParams, (state, action) => {
       const { param, index, onError } = action.payload;
       // if there is no unload evaluator, we use the default evaluator params
       if (!state.conditions[0].unloadEvaluator) {
-        state.conditions[0].unloadEvaluator = {
-          type: getUnloadEvaluatorTypeFromEvaluatorType(state.conditions[0].evaluator.type),
-          params: state.conditions[0].evaluator?.params ?? [0, 0],
-        };
+        applyDefaultUnloadEvaluator(state.conditions[0], onError);
       } else {
         // only update the param
-        state.conditions[0].unloadEvaluator!.params[index] = param;
-      }
-      // check if is valid for the new unload evaluator params
-      const error = isInvalid(state.conditions[0]);
-      const { errorMsg: invalidErrorMsg, errorMsgFrom, errorMsgTo } = error ?? {};
-      const errorMsg = invalidErrorMsg || errorMsgFrom || errorMsgTo;
-      // set error in form manually as we don't have a field for the unload evaluator
-      if (onError) {
-        onError(errorMsg);
+        state.conditions[0].unloadEvaluator.params[index] = param;
+        reportValidation(state.conditions[0], onError);
       }
     });
   }
 );
+
+type OnError = ((error: string | undefined) => void) | undefined;
+
+// The recovery threshold has no field of its own, so its validation errors have to be pushed into
+// the form manually.
+function reportValidation(condition: ClassicCondition, onError: OnError) {
+  if (!onError) {
+    return;
+  }
+  const { errorMsg, errorMsgFrom, errorMsgTo } = isInvalid(condition) ?? {};
+  onError(errorMsg || errorMsgFrom || errorMsgTo);
+}
+
+// The recovery value defaults to the threshold value, which is not valid for every operator: for
+// "is equal to" an identical value makes the rule flap between Alerting and Normal on every
+// evaluation. So the default has to be validated, not assumed to be valid.
+function applyDefaultUnloadEvaluator(condition: ClassicCondition, onError: OnError) {
+  condition.unloadEvaluator = {
+    type: getUnloadEvaluatorTypeFromEvaluatorType(condition.evaluator.type),
+    // Copied, so that later edits to the threshold don't mutate the recovery value through a shared array.
+    params: [...(condition.evaluator?.params ?? [0, 0])],
+  };
+  reportValidation(condition, onError);
+}
 
 function getUnloadEvaluatorTypeFromEvaluatorType(type: EvalFunction) {
   // we don't let the user change the unload evaluator type. We just change it to the opposite of the evaluator type

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -2943,7 +2943,6 @@
           "stop-alerting-inside-range": "Stop alerting (or pending state) when inside range",
           "stop-alerting-less": "Stop alerting (or pending state) when less than",
           "stop-alerting-more": "Stop alerting (or pending state) when more than",
-          "stop-alerting-not-equal": "Stop alerting (or pending state) when not equal to",
           "stop-alerting-outside-range": "Stop alerting (or pending state) when outside range",
           "title": "Custom recovery threshold"
         }


### PR DESCRIPTION
**What this PR does**

Fixes the custom recovery threshold being ignored when the alert condition uses "Is equal to". The frontend generated the recovery/unload evaluator as the *opposite* operator (`IsEqual → IsNotEqual`), so a rule firing at `== 20` resolved as soon as the value was anything other than the recovery value, instead of only when it equalled it.

- `thresholdReducer.ts`: map `IsEqual` recovery to `IsEqual` (equality has no directional opposite; it recovers when the value equals the recovery value).
- `Threshold.tsx`: correct the misleading `IsNotEqual` recovery label to "when equal to", matching its actual behavior.
- Adds reducer tests covering the eq/ne unload type.

**Note:** Generation-only fix. Existing rules already saved with the wrong `ne` keep it until their threshold type is re-touched and re-saved.

Fixes #126336

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Adding some additional context. Before this fix when I went to create an alert it looked like this in the ui
<img width="600" height="300" alt="Screenshot 2026-07-23 at 12 50 52 PM" src="https://github.com/user-attachments/assets/acf52c48-c239-43a0-8d60-e2818a093351" />
Then I would save the alert and I would see this in the ui which is the opposite?
<img width="580" height="180" alt="Screenshot 2026-07-23 at 12 50 38 PM" src="https://github.com/user-attachments/assets/49e25426-58cc-4c89-9e0b-aea42341f124" />

