### PR TITLE
DataSources: Preserve downstream error sources in query responses

### DIFF
--- a/pkg/registry/apis/datasource/sub_query.go
+++ b/pkg/registry/apis/datasource/sub_query.go
@@ -156,26 +156,36 @@ func (r *subQueryREST) Connect(ctx context.Context, name string, opts runtime.Ob
 		})
 		querySpan.End()
 
-		// all errors get converted into k8s errors when sent in responder.Error and lose important context like downstream info
-		var e errutil.Error
-		if errors.As(err, &e) && e.Source == errutil.SourceDownstream {
-			_ = tracing.Error(reqSpan, err)
-			m.SetError()
-			responder.Object(int(backend.StatusBadRequest),
-				&dsV0.QueryDataResponse{QueryDataResponse: backend.QueryDataResponse{Responses: map[string]backend.DataResponse{
-					"A": {
-						Error:       errors.New(e.LogMessage),
-						ErrorSource: backend.ErrorSourceDownstream,
-						Status:      backend.StatusBadRequest,
-					},
-				}}},
-			)
-			return
-		}
-
 		if err != nil {
 			_ = tracing.Error(reqSpan, err)
 			m.SetError()
+
+			// responder.Error converts errors into Kubernetes Status responses, which do not
+			// preserve the datasource error source. Return downstream errors as QDR instead.
+			if errorMessage, ok := downstreamErrorMessage(err); ok {
+				responses := make(map[string]backend.DataResponse, len(queries))
+				dataResponse := backend.ErrDataResponseWithSource(
+					backend.StatusBadRequest,
+					backend.ErrorSourceDownstream,
+					errorMessage,
+				)
+				for _, query := range queries {
+					refID := query.RefID
+					if refID == "" {
+						refID = "A"
+					}
+					responses[refID] = dataResponse
+				}
+				if len(responses) == 0 {
+					responses["A"] = dataResponse
+				}
+
+				responder.Object(int(backend.StatusBadRequest), &dsV0.QueryDataResponse{
+					QueryDataResponse: backend.QueryDataResponse{Responses: responses},
+				})
+				return
+			}
+
 			responder.Error(err)
 			return
 		}
@@ -184,4 +194,20 @@ func (r *subQueryREST) Connect(ctx context.Context, name string, opts runtime.Ob
 			&dsV0.QueryDataResponse{QueryDataResponse: *rsp},
 		)
 	}), nil
+}
+
+func downstreamErrorMessage(err error) (string, bool) {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return "", false
+	}
+
+	var sourceErr backend.ErrorWithSource
+	isDownstreamError := errors.As(err, &sourceErr) && sourceErr.ErrorSource() == backend.ErrorSourceDownstream
+
+	var grafanaErr errutil.Error
+	if errors.As(err, &grafanaErr) && grafanaErr.Source.IsDownstream() {
+		return grafanaErr.LogMessage, true
+	}
+
+	return err.Error(), isDownstreamError
 }

--- a/pkg/registry/apis/datasource/sub_query.go
+++ b/pkg/registry/apis/datasource/sub_query.go
@@ -162,13 +162,8 @@ func (r *subQueryREST) Connect(ctx context.Context, name string, opts runtime.Ob
 
 			// responder.Error converts errors into Kubernetes Status responses, which do not
 			// preserve the datasource error source. Return downstream errors as QDR instead.
-			if errorMessage, ok := downstreamErrorMessage(err); ok {
+			if dataResponse, ok := downstreamDataResponse(err); ok {
 				responses := make(map[string]backend.DataResponse, len(queries))
-				dataResponse := backend.ErrDataResponseWithSource(
-					backend.StatusBadRequest,
-					backend.ErrorSourceDownstream,
-					errorMessage,
-				)
 				for _, query := range queries {
 					refID := query.RefID
 					if refID == "" {
@@ -180,7 +175,7 @@ func (r *subQueryREST) Connect(ctx context.Context, name string, opts runtime.Ob
 					responses["A"] = dataResponse
 				}
 
-				responder.Object(int(backend.StatusBadRequest), &dsV0.QueryDataResponse{
+				responder.Object(int(dataResponse.Status), &dsV0.QueryDataResponse{
 					QueryDataResponse: backend.QueryDataResponse{Responses: responses},
 				})
 				return
@@ -196,18 +191,31 @@ func (r *subQueryREST) Connect(ctx context.Context, name string, opts runtime.Ob
 	}), nil
 }
 
-func downstreamErrorMessage(err error) (string, bool) {
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-		return "", false
+func downstreamDataResponse(err error) (backend.DataResponse, bool) {
+	status := backend.StatusBadRequest
+	message := err.Error()
+
+	switch {
+	case errors.Is(err, context.Canceled):
+		status = backend.Status(499)
+	case errors.Is(err, context.DeadlineExceeded):
+		status = backend.Status(http.StatusRequestTimeout)
+	default:
+		var grafanaErr errutil.Error
+		if errors.As(err, &grafanaErr) && grafanaErr.Source.IsDownstream() {
+			message = grafanaErr.LogMessage
+			break
+		}
+
+		var sourceErr backend.ErrorWithSource
+		if !errors.As(err, &sourceErr) || sourceErr.ErrorSource() != backend.ErrorSourceDownstream {
+			return backend.DataResponse{}, false
+		}
 	}
 
-	var sourceErr backend.ErrorWithSource
-	isDownstreamError := errors.As(err, &sourceErr) && sourceErr.ErrorSource() == backend.ErrorSourceDownstream
-
-	var grafanaErr errutil.Error
-	if errors.As(err, &grafanaErr) && grafanaErr.Source.IsDownstream() {
-		return grafanaErr.LogMessage, true
-	}
-
-	return err.Error(), isDownstreamError
+	return backend.ErrDataResponseWithSource(
+		status,
+		backend.ErrorSourceDownstream,
+		message,
+	), true
 }

--- a/pkg/registry/apis/datasource/sub_query_test.go
+++ b/pkg/registry/apis/datasource/sub_query_test.go
@@ -1,9 +1,12 @@
 package datasource
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -11,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana/pkg/apimachinery/errutil"
 	"github.com/grafana/grafana/pkg/apis/datasource/v0alpha1"
 	"github.com/grafana/grafana/pkg/services/datasources"
 )
@@ -34,13 +38,121 @@ func TestSubQueryConnectWhenDatasourceNotFound(t *testing.T) {
 	require.Equal(t, int32(404), statusErr.Status().Code)
 }
 
+func TestSubQueryConnectReturnsDownstreamErrorsAsQueryDataResponses(t *testing.T) {
+	tests := []struct {
+		name         string
+		queryError   error
+		errorMessage string
+	}{
+		{
+			name:         "plugin SDK downstream error",
+			queryError:   backend.DownstreamError(errors.New("failed to retrieve credentials")),
+			errorMessage: "failed to retrieve credentials",
+		},
+		{
+			name: "Grafana server downstream error",
+			queryError: errutil.Error{
+				Source:     errutil.SourceDownstream,
+				LogMessage: "failed to retrieve server credentials",
+			},
+			errorMessage: "failed to retrieve server credentials",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			responder := executeSubQuery(t, tc.queryError)
+
+			require.NoError(t, responder.err)
+			require.Equal(t, http.StatusBadRequest, responder.statusCode)
+
+			qdr, ok := responder.object.(*v0alpha1.QueryDataResponse)
+			require.True(t, ok)
+			for _, refID := range []string{"A", "B"} {
+				require.Contains(t, qdr.Responses, refID)
+				require.Equal(t, backend.StatusBadRequest, qdr.Responses[refID].Status)
+				require.Equal(t, backend.ErrorSourceDownstream, qdr.Responses[refID].ErrorSource)
+				require.EqualError(t, qdr.Responses[refID].Error, tc.errorMessage)
+			}
+		})
+	}
+}
+
+func TestSubQueryConnectDoesNotConvertOtherErrors(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{name: "untyped", err: errors.New("internal failure")},
+		{name: "explicit plugin", err: backend.PluginError(errors.New("plugin failure"))},
+		{name: "canceled", err: context.Canceled},
+		{name: "downstream-wrapped canceled", err: backend.DownstreamError(context.Canceled)},
+		{name: "deadline exceeded", err: context.DeadlineExceeded},
+		{name: "downstream-wrapped deadline exceeded", err: backend.DownstreamError(context.DeadlineExceeded)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			responder := executeSubQuery(t, tc.err)
+
+			require.ErrorIs(t, responder.err, tc.err)
+			require.Nil(t, responder.object)
+		})
+	}
+}
+
+func executeSubQuery(t *testing.T, queryErr error) *recordingResponder {
+	t.Helper()
+
+	headers := map[string]string{}
+	sqr := subQueryREST{
+		builder: &DataSourceAPIBuilder{
+			client: mockClient{
+				lastCalledWithHeaders: &headers,
+				queryDataError:        queryErr,
+			},
+			datasources:     mockDatasources{},
+			contextProvider: mockContextProvider{},
+		},
+	}
+
+	responder := &recordingResponder{}
+	handler, err := sqr.Connect(context.Background(), "dsname", nil, responder)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(`{
+		"queries": [
+			{
+				"refId": "A",
+				"datasource": {
+					"type": "cloudwatch",
+					"uid": "dsname"
+				}
+			},
+			{
+				"refId": "B",
+				"datasource": {
+					"type": "cloudwatch",
+					"uid": "dsname"
+				}
+			}
+		]
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	return responder
+}
+
 type mockClient struct {
 	lastCalledWithHeaders *map[string]string
+	queryDataError        error
 }
 
 func (m mockClient) QueryData(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
 	*m.lastCalledWithHeaders = req.Headers
-	return nil, fmt.Errorf("mock error")
+	if m.queryDataError == nil {
+		return nil, fmt.Errorf("mock error")
+	}
+	return nil, m.queryDataError
 }
 
 func (m mockClient) QueryChunkedData(ctx context.Context, req *backend.QueryChunkedDataRequest, w backend.ChunkedDataWriter) error {
@@ -69,6 +181,21 @@ func (m mockResponder) Object(statusCode int, obj runtime.Object) {
 
 // Error writes the provided error to the response. This method may only be invoked once.
 func (m mockResponder) Error(err error) {
+}
+
+type recordingResponder struct {
+	statusCode int
+	object     runtime.Object
+	err        error
+}
+
+func (r *recordingResponder) Object(statusCode int, obj runtime.Object) {
+	r.statusCode = statusCode
+	r.object = obj
+}
+
+func (r *recordingResponder) Error(err error) {
+	r.err = err
 }
 
 var _ PluginDatasourceProvider = (*mockDatasources)(nil)

--- a/pkg/registry/apis/datasource/sub_query_test.go
+++ b/pkg/registry/apis/datasource/sub_query_test.go
@@ -78,6 +78,51 @@ func TestSubQueryConnectReturnsDownstreamErrorsAsQueryDataResponses(t *testing.T
 	}
 }
 
+func TestSubQueryConnectReturnsLifecycleErrorsAsDownstreamQueryDataResponses(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		queryError error
+		status     backend.Status
+	}{
+		{
+			name:       "canceled",
+			queryError: context.Canceled,
+			status:     backend.Status(499),
+		},
+		{
+			name:       "downstream-wrapped canceled",
+			queryError: backend.DownstreamError(context.Canceled),
+			status:     backend.Status(499),
+		},
+		{
+			name:       "deadline exceeded",
+			queryError: context.DeadlineExceeded,
+			status:     backend.Status(http.StatusRequestTimeout),
+		},
+		{
+			name:       "downstream-wrapped deadline exceeded",
+			queryError: backend.DownstreamError(context.DeadlineExceeded),
+			status:     backend.Status(http.StatusRequestTimeout),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			responder := executeSubQuery(t, tc.queryError)
+
+			require.NoError(t, responder.err)
+			require.Equal(t, int(tc.status), responder.statusCode)
+
+			qdr, ok := responder.object.(*v0alpha1.QueryDataResponse)
+			require.True(t, ok)
+			for _, refID := range []string{"A", "B"} {
+				require.Contains(t, qdr.Responses, refID)
+				require.Equal(t, tc.status, qdr.Responses[refID].Status)
+				require.Equal(t, backend.ErrorSourceDownstream, qdr.Responses[refID].ErrorSource)
+				require.EqualError(t, qdr.Responses[refID].Error, tc.queryError.Error())
+			}
+		})
+	}
+}
+
 func TestSubQueryConnectDoesNotConvertOtherErrors(t *testing.T) {
 	for _, tc := range []struct {
 		name string
@@ -85,10 +130,6 @@ func TestSubQueryConnectDoesNotConvertOtherErrors(t *testing.T) {
 	}{
 		{name: "untyped", err: errors.New("internal failure")},
 		{name: "explicit plugin", err: backend.PluginError(errors.New("plugin failure"))},
-		{name: "canceled", err: context.Canceled},
-		{name: "downstream-wrapped canceled", err: backend.DownstreamError(context.Canceled)},
-		{name: "deadline exceeded", err: context.DeadlineExceeded},
-		{name: "downstream-wrapped deadline exceeded", err: backend.DownstreamError(context.DeadlineExceeded)},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			responder := executeSubQuery(t, tc.err)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Preserves the source of a datasource error when a downstream system fails before the datasource returns a normal query response.

Explicitly marked downstream errors are returned as a QueryData response for each query reference ID.

**Why do we need this feature?**

The generic API server error response does not preserve the datasource error source. This can make a downstream failure look like a plugin or internal failure to callers.

Returning a normal QueryData response keeps the original downstream classification.

Canceled requests, deadlines, plugin errors, and unclassified errors continue to use the existing behavior.

**Who is this feature for?**

Users of the datasource query API and datasource developers whose queries depend on external services.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

The conversion only applies to errors explicitly marked as downstream.

Because a top-level error happens before any individual query runs, the same error is returned for every query reference ID. This does not change partial responses returned normally by a datasource.

Validation:

- [ ] `go test ./pkg/registry/apis/datasource -count=1`
- [ ] `git diff --check`

Please check that:

- [x] It works as expected from a user's perspective.
- [x] This is not a pre-GA feature or configuration option.
- [x] No documentation update is required because this only changes internal error handling.
