### PR TITLE
Plugins: Load externalized Canvas plugin via config (frontend)

### DIFF
--- a/public/app/features/plugins/admin/api.ts
+++ b/public/app/features/plugins/admin/api.ts
@@ -27,7 +27,7 @@ export async function getPluginDetails(id: string): Promise<CatalogPluginDetails
     getLocalPluginChangelog(id),
   ]);
 
-  const local = localPlugins.find((p) => p.id === id);
+  const local = localPlugins.find((p) => p.id === id || p.aliasIDs?.includes(id));
   const dependencies = local?.dependencies || remote?.json?.dependencies;
 
   // Add installed version to the list if it's missing (could be deprecated/deleted)

--- a/public/app/features/plugins/admin/api.ts
+++ b/public/app/features/plugins/admin/api.ts
@@ -27,7 +27,8 @@ export async function getPluginDetails(id: string): Promise<CatalogPluginDetails
     getLocalPluginChangelog(id),
   ]);
 
-  const local = localPlugins.find((p) => p.id === id || p.aliasIDs?.includes(id));
+  const matchesIdOrAlias = (p: LocalPlugin) => p.id === id || p.aliasIDs?.includes(id);
+  const local = localPlugins.find(matchesIdOrAlias);
   const dependencies = local?.dependencies || remote?.json?.dependencies;
 
   // Add installed version to the list if it's missing (could be deprecated/deleted)

--- a/public/app/features/plugins/admin/helpers.test.ts
+++ b/public/app/features/plugins/admin/helpers.test.ts
@@ -419,6 +419,22 @@ describe('Plugins/Helpers', () => {
       expect(merged).toHaveLength(1);
       expect(merged[0].error).toBe(PluginErrorCode.invalidSignature);
     });
+
+    test('resolves provisioned status by canonical ID when remote slug is an alias', () => {
+      const oldPluginAdminExternalManageEnabled = config.pluginAdminExternalManageEnabled;
+      config.pluginAdminExternalManageEnabled = true;
+
+      const local = [getLocalPluginMock({ id: 'grafana-canvas-panel', aliasIDs: ['canvas'] })];
+      const remote = [getRemotePluginMock({ slug: 'canvas' })];
+      const provisioned = [{ slug: 'grafana-canvas-panel' }];
+
+      const merged = mergeLocalsAndRemotes({ local, remote, provisioned });
+      expect(merged).toHaveLength(1);
+      expect(merged[0].id).toBe('grafana-canvas-panel');
+      expect(merged[0].isProvisioned).toBe(true);
+
+      config.pluginAdminExternalManageEnabled = oldPluginAdminExternalManageEnabled;
+    });
   });
 
   describe('mapLocalToCatalog()', () => {

--- a/public/app/features/plugins/admin/helpers.test.ts
+++ b/public/app/features/plugins/admin/helpers.test.ts
@@ -377,6 +377,50 @@ describe('Plugins/Helpers', () => {
     });
   });
 
+  describe('mergeLocalsAndRemotes() - alias deduplication', () => {
+    test('does not deduplicate direct slug matches — only alias matches are deduplicated', () => {
+      // Regression: emittedCanonicalIds must only track alias-matched canonical IDs.
+      // Direct slug matches (remotePlugin.slug === localPlugin.id) must not be deduplicated
+      // as that would break tests and real scenarios relying on duplicate remote entries.
+      const local = [getLocalPluginMock({ id: 'plugin-1' })];
+      const remote = [getRemotePluginMock({ slug: 'plugin-1' }), getRemotePluginMock({ slug: 'plugin-1' })];
+
+      const merged = mergeLocalsAndRemotes({ local, remote });
+      expect(merged).toHaveLength(2);
+      expect(merged.every(({ id }) => id === 'plugin-1')).toBe(true);
+    });
+
+    test('deduplicates when both alias slug and canonical slug appear in remote for same local plugin', () => {
+      const local = [getLocalPluginMock({ id: 'grafana-canvas-panel', aliasIDs: ['canvas'] })];
+      const remote = [getRemotePluginMock({ slug: 'canvas' }), getRemotePluginMock({ slug: 'grafana-canvas-panel' })];
+
+      const merged = mergeLocalsAndRemotes({ local, remote });
+      expect(merged).toHaveLength(1);
+      expect(merged[0].id).toBe('grafana-canvas-panel');
+    });
+
+    test('uses canonical ID when remote slug is an alias', () => {
+      const local = [getLocalPluginMock({ id: 'grafana-canvas-panel', aliasIDs: ['canvas'] })];
+      const remote = [getRemotePluginMock({ slug: 'canvas' })];
+
+      const merged = mergeLocalsAndRemotes({ local, remote });
+      expect(merged).toHaveLength(1);
+      expect(merged[0].id).toBe('grafana-canvas-panel');
+    });
+
+    test('attaches error keyed by canonical ID when remote slug is an alias', () => {
+      const local = [getLocalPluginMock({ id: 'grafana-canvas-panel', aliasIDs: ['canvas'] })];
+      const remote = [getRemotePluginMock({ slug: 'canvas' })];
+      const pluginErrors = [
+        { pluginId: 'grafana-canvas-panel', errorCode: PluginErrorCode.invalidSignature, pluginType: PluginType.panel },
+      ];
+
+      const merged = mergeLocalsAndRemotes({ local, remote, pluginErrors });
+      expect(merged).toHaveLength(1);
+      expect(merged[0].error).toBe(PluginErrorCode.invalidSignature);
+    });
+  });
+
   describe('mapLocalToCatalog()', () => {
     test('maps local response to PluginCatalog', () => {
       expect(mapLocalToCatalog(localPlugin)).toEqual({

--- a/public/app/features/plugins/admin/helpers.test.ts
+++ b/public/app/features/plugins/admin/helpers.test.ts
@@ -477,6 +477,15 @@ describe('Plugins/Helpers', () => {
       expect(mapLocalToCatalog(pluginWithoutDev).isDev).toBe(false);
       expect(mapLocalToCatalog(pluginWithDev).isDev).toBe(true);
     });
+
+    test('propagates aliasIDs when present', () => {
+      const pluginWithAliases = { ...localPlugin, aliasIDs: ['canvas', 'old-canvas'] };
+      expect(mapLocalToCatalog(pluginWithAliases).aliasIDs).toEqual(['canvas', 'old-canvas']);
+    });
+
+    test('aliasIDs is undefined when not set on local plugin', () => {
+      expect(mapLocalToCatalog(localPlugin).aliasIDs).toBeUndefined();
+    });
   });
 
   describe('mapToCatalogPlugin()', () => {
@@ -975,6 +984,45 @@ describe('Plugins/Helpers', () => {
         config.pluginAdminExternalManageEnabled = oldPluginAdminExternalManageEnabled;
         setTestFlags({});
       });
+    });
+  });
+
+  describe('mapToCatalogPlugin() - alias matching', () => {
+    const localWithAlias = getLocalPluginMock({
+      id: 'grafana-canvas-panel',
+      aliasIDs: ['canvas'],
+    });
+    const remoteWithAliasSlug = getRemotePluginMock({ slug: 'canvas', internal: true });
+
+    test('uses canonical local ID when remote slug matches an aliasID', () => {
+      const result = mapToCatalogPlugin(localWithAlias, remoteWithAliasSlug);
+      expect(result.id).toBe('grafana-canvas-panel');
+    });
+
+    test('uses local logos when matched via alias', () => {
+      const result = mapToCatalogPlugin(localWithAlias, remoteWithAliasSlug);
+      expect(result.info.logos).toEqual(localWithAlias.info.logos);
+    });
+
+    test('does not inherit isCore from remote internal flag when matched via alias', () => {
+      const result = mapToCatalogPlugin(localWithAlias, remoteWithAliasSlug);
+      expect(result.isCore).toBe(false);
+    });
+
+    test('propagates aliasIDs from local plugin', () => {
+      const result = mapToCatalogPlugin(localWithAlias, remoteWithAliasSlug);
+      expect(result.aliasIDs).toEqual(['canvas']);
+    });
+
+    test('uses remote slug as ID when no alias match', () => {
+      const result = mapToCatalogPlugin(localPlugin, remotePlugin);
+      expect(result.id).toBe(remotePlugin.slug);
+    });
+
+    test('inherits isCore from remote internal flag when not an alias match', () => {
+      const internalRemote = getRemotePluginMock({ internal: true });
+      const result = mapToCatalogPlugin(undefined, internalRemote);
+      expect(result.isCore).toBe(true);
     });
   });
 

--- a/public/app/features/plugins/admin/helpers.ts
+++ b/public/app/features/plugins/admin/helpers.ts
@@ -36,6 +36,7 @@ export function mergeLocalsAndRemotes({
 
   const remoteSet = new Set<string>(remote?.map((plugin) => plugin.slug));
   const localMap = new Map<string, LocalPlugin>(local.map((plugin) => [plugin.id, plugin]));
+  local.forEach((plugin) => plugin.aliasIDs?.forEach((alias) => localMap.set(alias, plugin)));
   const instancesMap = new Map<string, InstancePlugin>(instance?.map((plugin) => [plugin.pluginSlug, plugin]));
   const provisionedSet = new Set<string>(provisioned?.map((plugin) => plugin.slug));
 
@@ -43,7 +44,7 @@ export function mergeLocalsAndRemotes({
   local.forEach((localPlugin) => {
     const error = errorByPluginId[localPlugin.id];
 
-    if (!remoteSet.has(localPlugin.id)) {
+    if (!remoteSet.has(localPlugin.id) && !localPlugin.aliasIDs?.some((alias) => remoteSet.has(alias))) {
       let catalogPlugin = mergeLocalAndRemote(localPlugin, undefined, error);
       if (config.pluginAdminExternalManageEnabled) {
         catalogPlugin = mergeCloudState(
@@ -225,7 +226,8 @@ export function mapLocalToCatalog(plugin: LocalPlugin, error?: PluginError): Cat
 // TODO: change the signature by removing the optionals for local and remote.
 export function mapToCatalogPlugin(local?: LocalPlugin, remote?: RemotePlugin, error?: PluginError): CatalogPlugin {
   const installedVersion = local?.info.version;
-  const id = remote?.slug || local?.id || '';
+  const matchedViaAlias = remote && local && local.aliasIDs?.includes(remote.slug);
+  const id = matchedViaAlias ? local.id : remote?.slug || local?.id || '';
   const type = local?.type || remote?.typeCode;
   const isDisabled = !!error;
   const keywords = remote?.keywords || local?.info.keywords || [];
@@ -235,12 +237,15 @@ export function mapToCatalogPlugin(local?: LocalPlugin, remote?: RemotePlugin, e
     large: `/public/build/img/icn-${type}.svg`,
   };
 
-  if (remote) {
+  if (matchedViaAlias && local.info.logos) {
+    logos = local.info.logos;
+  } else if (remote) {
+    const remoteSlug = remote.slug || id;
     logos = {
-      small: `${config.appSubUrl}/api/gnet/plugins/${id}/versions/${remote.version}/logos/small`,
-      large: `${config.appSubUrl}/api/gnet/plugins/${id}/versions/${remote.version}/logos/large`,
+      small: `${config.appSubUrl}/api/gnet/plugins/${remoteSlug}/versions/${remote.version}/logos/small`,
+      large: `${config.appSubUrl}/api/gnet/plugins/${remoteSlug}/versions/${remote.version}/logos/large`,
     };
-  } else if (local && local.info.logos) {
+  } else if (local?.info.logos) {
     logos = local.info.logos;
   }
 
@@ -251,6 +256,7 @@ export function mapToCatalogPlugin(local?: LocalPlugin, remote?: RemotePlugin, e
     downloads: remote?.downloads || 0,
     hasUpdate: local?.hasUpdate || false,
     id,
+    aliasIDs: local?.aliasIDs,
     info: {
       logos,
       keywords,

--- a/public/app/features/plugins/admin/helpers.ts
+++ b/public/app/features/plugins/admin/helpers.ts
@@ -213,6 +213,7 @@ export function mapLocalToCatalog(plugin: LocalPlugin, error?: PluginError): Cat
     accessControl: accessControl,
     angularDetected,
     isFullyInstalled: true,
+    aliasIDs: plugin.aliasIDs,
     iam: plugin.iam,
     latestVersion: plugin.latestVersion,
     managed: {

--- a/public/app/features/plugins/admin/helpers.ts
+++ b/public/app/features/plugins/admin/helpers.ts
@@ -271,7 +271,9 @@ export function mapToCatalogPlugin(local?: LocalPlugin, remote?: RemotePlugin, e
       logos,
       keywords,
     },
-    isCore: Boolean(remote?.internal || local?.signature === PluginSignatureStatus.internal),
+    isCore: matchedViaAlias
+      ? local?.signature === PluginSignatureStatus.internal
+      : Boolean(remote?.internal || local?.signature === PluginSignatureStatus.internal),
     isDev: Boolean(local?.dev),
     isEnterprise: remote?.status === RemotePluginStatus.Enterprise,
     isInstalled: Boolean(local) || isDisabled,

--- a/public/app/features/plugins/admin/helpers.ts
+++ b/public/app/features/plugins/admin/helpers.ts
@@ -58,11 +58,19 @@ export function mergeLocalsAndRemotes({
     }
   });
 
+  // Track canonical IDs already emitted from the remote loop to avoid duplicates when
+  // both a legacy alias slug (e.g. "canvas") and the real slug ("grafana-canvas-panel")
+  // appear in the GCOM response and both resolve to the same local plugin.
+  const emittedCanonicalIds = new Set<string>();
+
   // add remote
   remote.forEach((remotePlugin) => {
     const localCounterpart = localMap.get(remotePlugin.slug);
     const error = errorByPluginId[remotePlugin.slug];
-    const shouldSkip = remotePlugin.status === RemotePluginStatus.Deprecated && !localCounterpart; // We are only listing deprecated plugins in case they are installed.
+    const canonicalId = localCounterpart?.id ?? remotePlugin.slug;
+    const shouldSkip =
+      (remotePlugin.status === RemotePluginStatus.Deprecated && !localCounterpart) || // We are only listing deprecated plugins in case they are installed.
+      emittedCanonicalIds.has(canonicalId);
 
     if (!shouldSkip) {
       let catalogPlugin = mergeLocalAndRemote(localCounterpart, remotePlugin, error);
@@ -74,6 +82,7 @@ export function mergeLocalsAndRemotes({
           localMap.has(remotePlugin.slug)
         );
       }
+      emittedCanonicalIds.add(canonicalId);
       catalogPlugins.push(catalogPlugin);
     }
   });

--- a/public/app/features/plugins/admin/helpers.ts
+++ b/public/app/features/plugins/admin/helpers.ts
@@ -66,8 +66,8 @@ export function mergeLocalsAndRemotes({
   // add remote
   remote.forEach((remotePlugin) => {
     const localCounterpart = localMap.get(remotePlugin.slug);
-    const error = errorByPluginId[remotePlugin.slug];
     const canonicalId = localCounterpart?.id ?? remotePlugin.slug;
+    const error = errorByPluginId[canonicalId] ?? errorByPluginId[remotePlugin.slug];
     const shouldSkip =
       (remotePlugin.status === RemotePluginStatus.Deprecated && !localCounterpart) || // We are only listing deprecated plugins in case they are installed.
       emittedCanonicalIds.has(canonicalId);

--- a/public/app/features/plugins/admin/helpers.ts
+++ b/public/app/features/plugins/admin/helpers.ts
@@ -35,8 +35,10 @@ export function mergeLocalsAndRemotes({
   const errorByPluginId = groupErrorsByPluginId(errors);
 
   const remoteSet = new Set<string>(remote?.map((plugin) => plugin.slug));
-  const localMap = new Map<string, LocalPlugin>(local.map((plugin) => [plugin.id, plugin]));
-  local.forEach((plugin) => plugin.aliasIDs?.forEach((alias) => localMap.set(alias, plugin)));
+  const localMap = new Map<string, LocalPlugin>([
+    ...local.map((plugin): [string, LocalPlugin] => [plugin.id, plugin]),
+    ...local.flatMap((plugin) => (plugin.aliasIDs ?? []).map((alias): [string, LocalPlugin] => [alias, plugin])),
+  ]);
   const instancesMap = new Map<string, InstancePlugin>(instance?.map((plugin) => [plugin.pluginSlug, plugin]));
   const provisionedSet = new Set<string>(provisioned?.map((plugin) => plugin.slug));
 
@@ -58,19 +60,16 @@ export function mergeLocalsAndRemotes({
     }
   });
 
-  // Track canonical IDs already emitted from the remote loop to avoid duplicates when
-  // both a legacy alias slug (e.g. "canvas") and the real slug ("grafana-canvas-panel")
-  // appear in the GCOM response and both resolve to the same local plugin.
-  const emittedCanonicalIds = new Set<string>();
+  const seenAliasCanonicalIds = new Set<string>();
 
   // add remote
   remote.forEach((remotePlugin) => {
     const localCounterpart = localMap.get(remotePlugin.slug);
     const canonicalId = localCounterpart?.id ?? remotePlugin.slug;
     const error = errorByPluginId[canonicalId] ?? errorByPluginId[remotePlugin.slug];
-    const shouldSkip =
-      (remotePlugin.status === RemotePluginStatus.Deprecated && !localCounterpart) || // We are only listing deprecated plugins in case they are installed.
-      emittedCanonicalIds.has(canonicalId);
+    const isAliasMatch = Boolean(localCounterpart && localCounterpart.id !== remotePlugin.slug);
+    const isUninstalledDeprecatedPlugin = remotePlugin.status === RemotePluginStatus.Deprecated && !localCounterpart;
+    const shouldSkip = isUninstalledDeprecatedPlugin || seenAliasCanonicalIds.has(canonicalId);
 
     if (!shouldSkip) {
       let catalogPlugin = mergeLocalAndRemote(localCounterpart, remotePlugin, error);
@@ -82,11 +81,8 @@ export function mergeLocalsAndRemotes({
           localMap.has(remotePlugin.slug)
         );
       }
-      // Only track alias-matched canonical IDs for deduplication.
-      // Direct slug matches (remotePlugin.slug === localCounterpart?.id) are not tracked
-      // to preserve existing behaviour where duplicate direct-slug remotes pass through.
-      if (localCounterpart && localCounterpart.id !== remotePlugin.slug) {
-        emittedCanonicalIds.add(canonicalId);
+      if (isAliasMatch) {
+        seenAliasCanonicalIds.add(canonicalId);
       }
       catalogPlugins.push(catalogPlugin);
     }

--- a/public/app/features/plugins/admin/helpers.ts
+++ b/public/app/features/plugins/admin/helpers.ts
@@ -82,7 +82,12 @@ export function mergeLocalsAndRemotes({
           localMap.has(remotePlugin.slug)
         );
       }
-      emittedCanonicalIds.add(canonicalId);
+      // Only track alias-matched canonical IDs for deduplication.
+      // Direct slug matches (remotePlugin.slug === localCounterpart?.id) are not tracked
+      // to preserve existing behaviour where duplicate direct-slug remotes pass through.
+      if (localCounterpart && localCounterpart.id !== remotePlugin.slug) {
+        emittedCanonicalIds.add(canonicalId);
+      }
       catalogPlugins.push(catalogPlugin);
     }
   });

--- a/public/app/features/plugins/admin/helpers.ts
+++ b/public/app/features/plugins/admin/helpers.ts
@@ -74,11 +74,12 @@ export function mergeLocalsAndRemotes({
     if (!shouldSkip) {
       let catalogPlugin = mergeLocalAndRemote(localCounterpart, remotePlugin, error);
       if (config.pluginAdminExternalManageEnabled) {
+        const pluginKey = isAliasMatch ? canonicalId : remotePlugin.slug;
         catalogPlugin = mergeCloudState(
           catalogPlugin,
           instancesMap,
-          provisionedSet.has(remotePlugin.slug),
-          localMap.has(remotePlugin.slug)
+          provisionedSet.has(pluginKey),
+          localMap.has(pluginKey)
         );
       }
       if (isAliasMatch) {

--- a/public/app/features/plugins/admin/state/actions.ts
+++ b/public/app/features/plugins/admin/state/actions.ts
@@ -164,8 +164,8 @@ export const fetchDetails = createAsyncThunk<Update<CatalogPlugin, string>, stri
   `${STATE_PREFIX}/fetchDetails`,
   async (id, thunkApi) => {
     try {
-      const details = await getPluginDetails(id);
       const canonicalId = selectByIdOrAlias(thunkApi.getState(), id)?.id ?? id;
+      const details = await getPluginDetails(canonicalId);
       return {
         id: canonicalId,
         changes: { details },

--- a/public/app/features/plugins/admin/state/actions.ts
+++ b/public/app/features/plugins/admin/state/actions.ts
@@ -176,21 +176,23 @@ export const fetchDetails = createAsyncThunk<Update<CatalogPlugin, string>, stri
   }
 );
 
-export const fetchPluginInsights = createAsyncThunk<Update<CatalogPlugin, string>, { id: string; version?: string }>(
-  `${STATE_PREFIX}/fetchPluginInsights`,
-  async ({ id, version }, thunkApi) => {
-    try {
-      const insights = await getPluginInsights(id, version);
+export const fetchPluginInsights = createAsyncThunk<
+  Update<CatalogPlugin, string>,
+  { id: string; version?: string },
+  { state: PluginCatalogStoreState }
+>(`${STATE_PREFIX}/fetchPluginInsights`, async ({ id, version }, thunkApi) => {
+  try {
+    const canonicalId = selectByIdOrAlias(thunkApi.getState(), id)?.id ?? id;
+    const insights = await getPluginInsights(canonicalId, version);
 
-      return {
-        id,
-        changes: { insights },
-      };
-    } catch (e) {
-      return thunkApi.rejectWithValue('Unknown error.');
-    }
+    return {
+      id: canonicalId,
+      changes: { insights },
+    };
+  } catch (e) {
+    return thunkApi.rejectWithValue('Unknown error.');
   }
-);
+});
 
 export const addPlugins = createAction<CatalogPlugin[]>(`${STATE_PREFIX}/addPlugins`);
 

--- a/public/app/features/plugins/admin/state/actions.ts
+++ b/public/app/features/plugins/admin/state/actions.ts
@@ -27,8 +27,11 @@ import {
   type LocalPlugin,
   type InstancePlugin,
   type ProvisionedPlugin,
+  type PluginCatalogStoreState,
   PluginStatus,
 } from '../types';
+
+import { selectByIdOrAlias } from './selectors';
 
 // Fetches
 export const fetchAll = createAsyncThunk(`${STATE_PREFIX}/fetchAll`, async (_, thunkApi) => {
@@ -157,14 +160,14 @@ export const fetchRemotePlugins = createAsyncThunk<RemotePlugin[], void, { rejec
   }
 );
 
-export const fetchDetails = createAsyncThunk<Update<CatalogPlugin, string>, string>(
+export const fetchDetails = createAsyncThunk<Update<CatalogPlugin, string>, string, { state: PluginCatalogStoreState }>(
   `${STATE_PREFIX}/fetchDetails`,
   async (id, thunkApi) => {
     try {
       const details = await getPluginDetails(id);
-
+      const canonicalId = selectByIdOrAlias(thunkApi.getState(), id)?.id ?? id;
       return {
-        id,
+        id: canonicalId,
         changes: { details },
       };
     } catch (e) {

--- a/public/app/features/plugins/admin/state/hooks.ts
+++ b/public/app/features/plugins/admin/state/hooks.ts
@@ -19,6 +19,7 @@ import {
 import {
   selectPlugins,
   selectById,
+  selectByIdOrAlias,
   selectIsRequestPending,
   selectRequestError,
   selectIsRequestNotFetched,
@@ -57,7 +58,7 @@ export const useGetSingle = (id: string, version?: string): CatalogPlugin | unde
   useFetchAll();
   useFetchDetails(id);
 
-  return useSelector((state) => selectById(state, id));
+  return useSelector((state) => selectByIdOrAlias(state, id));
 };
 
 export const useGetPluginInsights = (id: string, version: string | undefined): CatalogPlugin | undefined => {
@@ -158,7 +159,7 @@ export const useFetchAllLocal = () => {
 
 export const useFetchDetails = (id: string) => {
   const dispatch = useDispatch();
-  const plugin = useSelector((state) => selectById(state, id));
+  const plugin = useSelector((state) => selectByIdOrAlias(state, id));
   const isNotFetching = !useSelector(selectIsRequestPending(fetchDetails.typePrefix));
   const shouldFetch = isNotFetching && plugin && !plugin.details;
 

--- a/public/app/features/plugins/admin/state/hooks.ts
+++ b/public/app/features/plugins/admin/state/hooks.ts
@@ -63,7 +63,7 @@ export const useGetSingle = (id: string, version?: string): CatalogPlugin | unde
 
 export const useGetPluginInsights = (id: string, version: string | undefined): CatalogPlugin | undefined => {
   useFetchPluginInsights(id, version);
-  return useSelector((state) => selectById(state, id));
+  return useSelector((state) => selectByIdOrAlias(state, id));
 };
 
 export const useGetSingleLocalWithoutDetails = (id: string): CatalogPlugin | undefined => {
@@ -170,7 +170,7 @@ export const useFetchDetails = (id: string) => {
 
 export const useFetchPluginInsights = (id: string, version: string | undefined) => {
   const dispatch = useDispatch();
-  const plugin = useSelector((state) => selectById(state, id));
+  const plugin = useSelector((state) => selectByIdOrAlias(state, id));
   const isNotFetching = !useSelector(selectIsRequestPending(fetchPluginInsights.typePrefix));
   const shouldFetch = isNotFetching && plugin && !plugin.insights && version;
 

--- a/public/app/features/plugins/admin/state/selectors.test.ts
+++ b/public/app/features/plugins/admin/state/selectors.test.ts
@@ -3,7 +3,7 @@ import { configureStore } from 'app/store/configureStore';
 
 import { getCatalogPluginMock, getPluginsStateMock } from '../mocks/mockHelpers';
 
-import { selectPlugins } from './selectors';
+import { selectPlugins, selectByIdOrAlias } from './selectors';
 
 describe('Plugins Selectors', () => {
   describe('selectPlugins()', () => {
@@ -94,6 +94,41 @@ describe('Plugins Selectors', () => {
 
       expect(results).toHaveLength(1);
       expect(results[0].name).toBe('Plugin 2');
+    });
+  });
+
+  describe('selectByIdOrAlias()', () => {
+    const store = configureStore({
+      plugins: getPluginsStateMock([
+        getCatalogPluginMock({ id: 'grafana-canvas-panel', aliasIDs: ['canvas'] }),
+        getCatalogPluginMock({ id: 'plugin-2', aliasIDs: undefined }),
+      ]),
+    });
+
+    it('finds a plugin by its direct ID', () => {
+      const result = selectByIdOrAlias(store.getState(), 'grafana-canvas-panel');
+      expect(result?.id).toBe('grafana-canvas-panel');
+    });
+
+    it('finds a plugin by an aliasID when direct lookup fails', () => {
+      const result = selectByIdOrAlias(store.getState(), 'canvas');
+      expect(result?.id).toBe('grafana-canvas-panel');
+    });
+
+    it('returns undefined when neither ID nor alias matches', () => {
+      const result = selectByIdOrAlias(store.getState(), 'non-existent-plugin');
+      expect(result).toBeUndefined();
+    });
+
+    it('returns direct match when both direct and alias match exist', () => {
+      const storeWithBoth = configureStore({
+        plugins: getPluginsStateMock([
+          getCatalogPluginMock({ id: 'canvas', aliasIDs: undefined }),
+          getCatalogPluginMock({ id: 'grafana-canvas-panel', aliasIDs: ['canvas'] }),
+        ]),
+      });
+      const result = selectByIdOrAlias(storeWithBoth.getState(), 'canvas');
+      expect(result?.id).toBe('canvas');
     });
   });
 });

--- a/public/app/features/plugins/admin/state/selectors.ts
+++ b/public/app/features/plugins/admin/state/selectors.ts
@@ -17,6 +17,14 @@ const { selectAll, selectById } = pluginsAdapter.getSelectors(selectItems);
 
 export { selectById };
 
+export const selectByIdOrAlias = (state: PluginCatalogStoreState, id: string) => {
+  const direct = selectById(state, id);
+  if (direct) {
+    return direct;
+  }
+  return selectAll(state).find((p) => p.aliasIDs?.includes(id));
+};
+
 const debouncedTrackSearch = debounce((count) => {
   reportInteraction('plugins_search', {
     resultsCount: count,

--- a/public/app/features/plugins/admin/types.ts
+++ b/public/app/features/plugins/admin/types.ts
@@ -29,6 +29,7 @@ export interface CatalogPlugin extends WithAccessControlMetadata {
   downloads: number;
   hasUpdate: boolean;
   id: string;
+  aliasIDs?: string[];
   info: CatalogPluginInfo;
   isDev: boolean;
   isCore: boolean;
@@ -220,6 +221,7 @@ export type LocalPlugin = WithAccessControlMetadata & {
     updated: string;
   };
   name: string;
+  aliasIDs?: string[];
   pinned: boolean;
   signature: PluginSignatureStatus;
   signatureOrg: string;

--- a/public/app/features/plugins/built_in_plugins.test.ts
+++ b/public/app/features/plugins/built_in_plugins.test.ts
@@ -1,0 +1,25 @@
+describe('built_in_plugins', () => {
+  describe('canvas panel', () => {
+    it('is included when no panel has canvas in aliasIDs', () => {
+      jest.isolateModules(() => {
+        jest.mock('@grafana/runtime/internal', () => ({
+          getPanelPluginMetasMapSync: () => ({}),
+        }));
+        const { default: builtInPlugins } = require('./built_in_plugins');
+        expect(Boolean(builtInPlugins['core:plugin/canvas'])).toBe(true);
+      });
+    });
+
+    it('is excluded when a panel declares canvas in aliasIDs', () => {
+      jest.isolateModules(() => {
+        jest.mock('@grafana/runtime/internal', () => ({
+          getPanelPluginMetasMapSync: () => ({
+            'grafana-canvas-panel': { id: 'grafana-canvas-panel', aliasIDs: ['canvas'] },
+          }),
+        }));
+        const { default: builtInPlugins } = require('./built_in_plugins');
+        expect(Boolean(builtInPlugins['core:plugin/canvas'])).toBe(false);
+      });
+    });
+  });
+});

--- a/public/app/features/plugins/built_in_plugins.ts
+++ b/public/app/features/plugins/built_in_plugins.ts
@@ -1,4 +1,4 @@
-import { getFeatureFlagClient } from '@grafana/runtime/internal';
+import { getFeatureFlagClient, getPanelPluginMetasMapSync } from '@grafana/runtime/internal';
 
 const cloudwatchPlugin = async () =>
   await import(/* webpackChunkName: "cloudwatchPlugin" */ 'app/plugins/datasource/cloudwatch/module');
@@ -86,7 +86,6 @@ const builtInPlugins: Record<string, System.Module | (() => Promise<System.Modul
   'core:plugin/candlestick': candlestickPanel,
   'core:plugin/xychart': xychartPanel,
   'core:plugin/geomap': geomapPanel,
-  'core:plugin/canvas': canvasPanel,
   'core:plugin/dashlist': dashListPanel,
   'core:plugin/alertlist': alertListPanel,
   'core:plugin/annolist': annoListPanel,
@@ -109,6 +108,15 @@ const builtInPlugins: Record<string, System.Module | (() => Promise<System.Modul
   'core:plugin/nodeGraph': nodeGraph,
   'core:plugin/histogram': histogramPanel,
 };
+
+Object.defineProperty(builtInPlugins, 'core:plugin/canvas', {
+  get() {
+    const isExternal = Object.values(getPanelPluginMetasMapSync()).some((p) => p.aliasIDs?.includes('canvas'));
+    return isExternal ? undefined : canvasPanel;
+  },
+  enumerable: true,
+  configurable: true,
+});
 
 export function isBuiltinPluginPath(path: string): path is keyof typeof builtInPlugins {
   return Boolean(builtInPlugins[path]);


### PR DESCRIPTION
**What is this feature?**

This change adds the logic and configuration required to load an externalized Canvas plugin in a way that's gated by `.ini` / environment variable driven configuration.

**Why do we need this feature?**

So that we can externalize core panel plugins.

**Who is this feature for?**

All users of Grafana, eventually.

**Which issue(s) does this PR fix?**:

🎟️ Fixes https://github.com/grafana/grafana/issues/126208

**Special notes for your reviewer:**

To test this out locally, please:

1. Clone the (private) https://github.com/grafana/grafana-canvas-panel repo locally
2. In the `grafana-canvas-panel` repo, run `npm run dev` to build it
3. In your `custom.ini` file, set:

```ini
[paths]
plugins = /path/to/grafana-canvas-panel

[plugins]
allow_loading_unsigned_plugins = grafana-canvas-panel

[plugin.canvas]
as_external = true

[plugin.grafana-canvas-panel]
alias_ids = canvas
```

4. Restart Grafana (`make run` + `yarn start`)
5. Open the browser to http://localhost:3000
6. Verify:
    - Existing dashboards with `canvas` panels still render correctly
        - http://localhost:3000/d/7p7JkqWVz/panel-tests-canvas-examples?orgId=1&from=now-6h&to=now&timezone=browser&editPanel=3
    - The plugin catalogue shows `grafana-canvas-panel` rather than a duplicate `canvas` entry when you search for plugins that include the text `"canvas"`
        - http://localhost:3000/plugins?filterBy=all&filterByType=all&q=canvas
    - The browser console shows no errors related to canvas plugin loading
    - In server logs you should see: `msg="Core plugin replaced by external plugin" pluginID=canvas`
7. To verify the disabled state, comment out `as_external = true` and `alias_ids = canvas` and restart — core canvas should load normally with no external involvement

Please check that:
- [x] It works as expected from a user's perspective.
- 🚫 If this is a pre-GA feature, it is behind a feature toggle. _(Unfortunately, this is not possible.)_
- `N/A` ~The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.~
