### PR TITLE
Datasources: Detect SigV4 Grafana Assume Role for per-datasource external ID

### DIFF
--- a/pkg/services/datasources/awsexternalid/aws_external_id.go
+++ b/pkg/services/datasources/awsexternalid/aws_external_id.go
@@ -14,6 +14,13 @@ const (
 	grafanaAssumeRoleAuthType         = "grafana_assume_role"
 	grafanaExternalIDJSONKey          = "grafanaExternalId"
 	usePerDatasourceExternalIDJSONKey = "usePerDatasourceExternalId"
+
+	// SigV4 datasources (e.g. OpenSearch) that support Grafana Assume Role signal auth via
+	// sigV4AuthType rather than authType, and store the per-datasource ID pair under these
+	// sigV4-prefixed keys instead of the unprefixed native ones.
+	sigV4AuthTypeJSONKey                   = "sigV4AuthType"
+	sigV4GrafanaExternalIDJSONKey          = "sigV4GrafanaExternalId"
+	sigV4UsePerDatasourceExternalIDJSONKey = "sigV4UsePerDatasourceExternalId"
 )
 
 // BeforeSave mints or preserves per-datasource grafanaExternalId on create/update.
@@ -47,12 +54,40 @@ func isValidGrafanaExternalID(id, stackExternalID, datasourceUID string) bool {
 	return id == buildGrafanaExternalID(stackExternalID, datasourceUID)
 }
 
-// usePerDatasourceExternalID reports whether jsonData sets usePerDatasourceExternalId and its value.
+// isGrafanaAssumeRole reports whether jsonData declares Grafana Assume Role auth, either via
+// the native authType key or the SigV4-prefixed sigV4AuthType key used by SigV4 datasources
+// (e.g. OpenSearch) that support Grafana Assume Role.
+func isGrafanaAssumeRole(jsonData *simplejson.Json) bool {
+	if jsonData == nil {
+		return false
+	}
+	if jsonData.Get("authType").MustString() == grafanaAssumeRoleAuthType {
+		return true
+	}
+	return jsonData.Get(sigV4AuthTypeJSONKey).MustString() == grafanaAssumeRoleAuthType
+}
+
+// externalIDKeys selects the per-datasource ID / mode key pair to operate on.
+// Presence of sigV4AuthType (any value) means the SigV4 key namespace — datasources do not
+// switch between native and SigV4 auth on the same instance, so this stays stable when
+// leaving Grafana Assume Role (e.g. sigV4AuthType becomes "keys").
+func externalIDKeys(jsonData *simplejson.Json) (idKey, modeKey string) {
+	if jsonData != nil {
+		if _, exists := jsonData.CheckGet(sigV4AuthTypeJSONKey); exists {
+			return sigV4GrafanaExternalIDJSONKey, sigV4UsePerDatasourceExternalIDJSONKey
+		}
+	}
+	return grafanaExternalIDJSONKey, usePerDatasourceExternalIDJSONKey
+}
+
+// usePerDatasourceExternalID reports whether jsonData sets its (native or SigV4-prefixed)
+// per-datasource mode key and its value.
 func usePerDatasourceExternalID(jsonData *simplejson.Json) (set bool, enabled bool) {
 	if jsonData == nil {
 		return false, false
 	}
-	v, exists := jsonData.CheckGet(usePerDatasourceExternalIDJSONKey)
+	_, modeKey := externalIDKeys(jsonData)
+	v, exists := jsonData.CheckGet(modeKey)
 	if !exists {
 		return false, false
 	}
@@ -68,7 +103,8 @@ func clearInvalidGrafanaExternalID(uid, stackExternalID string, jsonData *simple
 	if jsonData == nil {
 		return
 	}
-	id := jsonData.Get(grafanaExternalIDJSONKey).MustString()
+	idKey, _ := externalIDKeys(jsonData)
+	id := jsonData.Get(idKey).MustString()
 	if id == "" {
 		return
 	}
@@ -76,14 +112,15 @@ func clearInvalidGrafanaExternalID(uid, stackExternalID string, jsonData *simple
 		return
 	}
 	if !isValidGrafanaExternalID(id, stackExternalID, uid) {
-		jsonData.Del(grafanaExternalIDJSONKey)
+		jsonData.Del(idKey)
 	}
 }
 
 func mintGrafanaExternalID(uid, stackExternalID string, jsonData *simplejson.Json) {
-	jsonData.Set(grafanaExternalIDJSONKey, buildGrafanaExternalID(stackExternalID, uid))
+	idKey, modeKey := externalIDKeys(jsonData)
+	jsonData.Set(idKey, buildGrafanaExternalID(stackExternalID, uid))
 	// Mode must be true: aws-sdk uses the stack ID when the bool is unset/false, even if an ID is stored.
-	jsonData.Set(usePerDatasourceExternalIDJSONKey, true)
+	jsonData.Set(modeKey, true)
 }
 
 func awsAssumeRolePerDatasourceExternalIDEnabled(ctx context.Context) bool {
@@ -107,10 +144,11 @@ func ensureGrafanaExternalID(uid, stackExternalID string, jsonData *simplejson.J
 	if !allowGenerate {
 		return
 	}
-	if jsonData.Get("authType").MustString() != grafanaAssumeRoleAuthType {
+	if !isGrafanaAssumeRole(jsonData) {
 		return
 	}
 
+	idKey, _ := externalIDKeys(jsonData)
 	modeSet, modeOn := usePerDatasourceExternalID(jsonData)
 	if modeSet && !modeOn {
 		return
@@ -119,7 +157,7 @@ func ensureGrafanaExternalID(uid, stackExternalID string, jsonData *simplejson.J
 	if stackExternalID == "" || uid == "" {
 		return
 	}
-	if jsonData.Get(grafanaExternalIDJSONKey).MustString() != "" {
+	if jsonData.Get(idKey).MustString() != "" {
 		return
 	}
 
@@ -144,19 +182,25 @@ func preserveGrafanaExternalID(uid, stackExternalID string, existing, updated *s
 	// Never persist a stolen / mismatched ID from the update payload.
 	clearInvalidGrafanaExternalID(uid, stackExternalID, updated)
 
+	existingIsGAR := isGrafanaAssumeRole(existing)
+	existingIdKey, _ := externalIDKeys(existing)
 	existingID := ""
-	existingAuthType := ""
 	if existing != nil {
-		existingID = existing.Get(grafanaExternalIDJSONKey).MustString()
-		existingAuthType = existing.Get("authType").MustString()
+		existingID = existing.Get(existingIdKey).MustString()
 	}
 
-	updatedAuthType := updated.Get("authType").MustString()
+	updatedIsGAR := isGrafanaAssumeRole(updated)
+	idKey, modeKey := externalIDKeys(updated)
 	modeSet, modeOn := usePerDatasourceExternalID(updated)
 
 	// Leaving Grafana Assume Role: drop the ID when minting is FT-enabled (otherwise leave it).
-	if allowGenerate && updatedAuthType != grafanaAssumeRoleAuthType {
-		updated.Del(grafanaExternalIDJSONKey)
+	// Clear both namespaces so a partial/malformed payload that omits auth type but still
+	// carries a prefixed (or native) ID cannot leave a stale external ID behind.
+	if allowGenerate && !updatedIsGAR {
+		updated.Del(idKey)
+		if existingIdKey != idKey {
+			updated.Del(existingIdKey)
+		}
 		return
 	}
 
@@ -164,12 +208,12 @@ func preserveGrafanaExternalID(uid, stackExternalID string, existing, updated *s
 		(existingID != "" && (stackExternalID == "" || uid == "")) {
 		// Keep a validated ID, or any stored ID when we cannot validate (empty stack/uid)
 		// so a misconfigured AWSExternalId does not wipe a previously minted value.
-		updated.Set(grafanaExternalIDJSONKey, existingID)
+		updated.Set(idKey, existingID)
 		// When the update omits the mode flag, restore the stored value so Terraform/API
 		// updates that only send partial jsonData do not silently fall back to stack ID.
 		if !modeSet {
 			if existingModeSet, existingModeOn := usePerDatasourceExternalID(existing); existingModeSet {
-				updated.Set(usePerDatasourceExternalIDJSONKey, existingModeOn)
+				updated.Set(modeKey, existingModeOn)
 			}
 		}
 		return
@@ -180,7 +224,7 @@ func preserveGrafanaExternalID(uid, stackExternalID string, existing, updated *s
 	if !allowGenerate {
 		return
 	}
-	if updatedAuthType != grafanaAssumeRoleAuthType {
+	if !updatedIsGAR {
 		return
 	}
 	if modeSet && !modeOn {
@@ -189,12 +233,12 @@ func preserveGrafanaExternalID(uid, stackExternalID string, existing, updated *s
 	if stackExternalID == "" || uid == "" {
 		return
 	}
-	if updated.Get(grafanaExternalIDJSONKey).MustString() != "" {
+	if updated.Get(idKey).MustString() != "" {
 		return
 	}
 
 	// Mint when switching into GAR (bool unset defaults to per-DS) or when explicitly opting in.
-	switchingIn := existingAuthType != grafanaAssumeRoleAuthType
+	switchingIn := !existingIsGAR
 	optingIn := modeSet && modeOn
 	if !switchingIn && !optingIn {
 		return

--- a/pkg/services/datasources/awsexternalid/aws_external_id.go
+++ b/pkg/services/datasources/awsexternalid/aws_external_id.go
@@ -218,9 +218,12 @@ func preserveGrafanaExternalID(uid, stackExternalID string, existing, updated *s
 			_, restoreModeKey = externalIDKeys(existing)
 		}
 		updated.Set(restoreIdKey, existingID)
-		// When the update omits the mode flag, restore the stored value so Terraform/API
-		// updates that only send partial jsonData do not silently fall back to stack ID.
-		if !modeSet {
+		// When the update omits the mode flag in the restore namespace, restore the stored
+		// value so Terraform/API updates that only send partial jsonData do not silently
+		// fall back to stack ID. Check restoreModeKey (not updated's selected namespace) so
+		// cross-namespace restores (FT off, auth type omitted) honor an explicit SigV4 mode
+		// on the payload and are not blocked by a native mode key.
+		if _, restoreModeSet := updated.CheckGet(restoreModeKey); !restoreModeSet {
 			if existingModeSet, existingModeOn := usePerDatasourceExternalID(existing); existingModeSet {
 				updated.Set(restoreModeKey, existingModeOn)
 			}

--- a/pkg/services/datasources/awsexternalid/aws_external_id.go
+++ b/pkg/services/datasources/awsexternalid/aws_external_id.go
@@ -208,12 +208,21 @@ func preserveGrafanaExternalID(uid, stackExternalID string, existing, updated *s
 		(existingID != "" && (stackExternalID == "" || uid == "")) {
 		// Keep a validated ID, or any stored ID when we cannot validate (empty stack/uid)
 		// so a misconfigured AWSExternalId does not wipe a previously minted value.
-		updated.Set(idKey, existingID)
+		//
+		// Restore into the existing datasource's namespace when the update selected a
+		// different one (e.g. FT-off path with auth type omitted → updated looks native
+		// while existing is SigV4). Avoids copying a SigV4 ID onto the native keys.
+		restoreIdKey, restoreModeKey := idKey, modeKey
+		if existingIdKey != idKey {
+			restoreIdKey = existingIdKey
+			_, restoreModeKey = externalIDKeys(existing)
+		}
+		updated.Set(restoreIdKey, existingID)
 		// When the update omits the mode flag, restore the stored value so Terraform/API
 		// updates that only send partial jsonData do not silently fall back to stack ID.
 		if !modeSet {
 			if existingModeSet, existingModeOn := usePerDatasourceExternalID(existing); existingModeSet {
-				updated.Set(modeKey, existingModeOn)
+				updated.Set(restoreModeKey, existingModeOn)
 			}
 		}
 		return

--- a/pkg/services/datasources/awsexternalid/aws_external_id_test.go
+++ b/pkg/services/datasources/awsexternalid/aws_external_id_test.go
@@ -235,3 +235,87 @@ func TestPreserveGrafanaExternalID(t *testing.T) {
 		assert.Equal(t, wantID, ftOff.Get(grafanaExternalIDJSONKey).MustString())
 	})
 }
+
+// TestEnsureGrafanaExternalID_SigV4 covers create-time mint/scrub for SigV4 datasources
+// (e.g. OpenSearch) that signal Grafana Assume Role via sigV4AuthType instead of authType.
+// Per the design, SigV4 GAR uses the sigV4-prefixed key pair exclusively; unprefixed keys
+// must never be set for this path.
+func TestEnsureGrafanaExternalID_SigV4(t *testing.T) {
+	const uid, stack = "dsUid1", "stackABC"
+	wantID := stack + "-" + uid
+
+	t.Run("mints sigV4 keys for new SigV4 GAR datasources and does not touch native keys", func(t *testing.T) {
+		jd := simplejson.NewFromAny(map[string]any{sigV4AuthTypeJSONKey: grafanaAssumeRoleAuthType})
+		ensureGrafanaExternalID(uid, stack, jd, true)
+		assert.Equal(t, wantID, jd.Get(sigV4GrafanaExternalIDJSONKey).MustString())
+		assert.True(t, jd.Get(sigV4UsePerDatasourceExternalIDJSONKey).MustBool())
+		assert.Empty(t, jd.Get(grafanaExternalIDJSONKey).MustString())
+		assert.Empty(t, jd.Get(usePerDatasourceExternalIDJSONKey).Interface())
+	})
+
+	t.Run("stack mode does not mint sigV4 ID", func(t *testing.T) {
+		jd := simplejson.NewFromAny(map[string]any{
+			sigV4AuthTypeJSONKey:                   grafanaAssumeRoleAuthType,
+			sigV4UsePerDatasourceExternalIDJSONKey: false,
+		})
+		ensureGrafanaExternalID(uid, stack, jd, true)
+		assert.Empty(t, jd.Get(sigV4GrafanaExternalIDJSONKey).MustString())
+	})
+
+	t.Run("scrubs stolen sigV4GrafanaExternalId", func(t *testing.T) {
+		stolen := stack + "-otherUid"
+		jd := simplejson.NewFromAny(map[string]any{
+			sigV4AuthTypeJSONKey:          grafanaAssumeRoleAuthType,
+			sigV4GrafanaExternalIDJSONKey: stolen,
+		})
+		// FT off: scrub happens regardless, but no remint should occur, so the field stays empty.
+		ensureGrafanaExternalID(uid, stack, jd, false)
+		assert.Empty(t, jd.Get(sigV4GrafanaExternalIDJSONKey).MustString())
+	})
+}
+
+// TestPreserveGrafanaExternalID_SigV4 covers update-time preserve/scrub/clear for the SigV4
+// (sigV4AuthType) path, mirroring TestPreserveGrafanaExternalID's native coverage.
+func TestPreserveGrafanaExternalID_SigV4(t *testing.T) {
+	const uid, stack = "dsUid1", "stackABC"
+	wantID := stack + "-" + uid
+
+	t.Run("update omitting mode/ID preserves existing sigV4 values", func(t *testing.T) {
+		existing := simplejson.NewFromAny(map[string]any{
+			sigV4AuthTypeJSONKey:                   grafanaAssumeRoleAuthType,
+			sigV4UsePerDatasourceExternalIDJSONKey: true,
+			sigV4GrafanaExternalIDJSONKey:          wantID,
+		})
+		updated := simplejson.NewFromAny(map[string]any{sigV4AuthTypeJSONKey: grafanaAssumeRoleAuthType})
+		preserveGrafanaExternalID(uid, stack, existing, updated, true)
+		assert.Equal(t, wantID, updated.Get(sigV4GrafanaExternalIDJSONKey).MustString())
+		assert.True(t, updated.Get(sigV4UsePerDatasourceExternalIDJSONKey).MustBool())
+		assert.Empty(t, updated.Get(grafanaExternalIDJSONKey).MustString())
+	})
+
+	t.Run("leaving SigV4 GAR clears sigV4GrafanaExternalId when FT on", func(t *testing.T) {
+		existing := simplejson.NewFromAny(map[string]any{
+			sigV4AuthTypeJSONKey:          grafanaAssumeRoleAuthType,
+			sigV4GrafanaExternalIDJSONKey: wantID,
+		})
+		updated := simplejson.NewFromAny(map[string]any{sigV4AuthTypeJSONKey: "keys"})
+		preserveGrafanaExternalID(uid, stack, existing, updated, true)
+		assert.Empty(t, updated.Get(sigV4GrafanaExternalIDJSONKey).MustString())
+		assert.Empty(t, updated.Get(grafanaExternalIDJSONKey).MustString())
+	})
+
+	t.Run("leaving GAR with auth type omitted still clears prefixed ID from payload", func(t *testing.T) {
+		// Cloud/API/Terraform can send a partial jsonData blob that drops sigV4AuthType
+		// while still including a previously minted prefixed ID.
+		existing := simplejson.NewFromAny(map[string]any{
+			sigV4AuthTypeJSONKey:          grafanaAssumeRoleAuthType,
+			sigV4GrafanaExternalIDJSONKey: wantID,
+		})
+		updated := simplejson.NewFromAny(map[string]any{
+			sigV4GrafanaExternalIDJSONKey: wantID,
+		})
+		preserveGrafanaExternalID(uid, stack, existing, updated, true)
+		assert.Empty(t, updated.Get(sigV4GrafanaExternalIDJSONKey).MustString())
+		assert.Empty(t, updated.Get(grafanaExternalIDJSONKey).MustString())
+	})
+}

--- a/pkg/services/datasources/awsexternalid/aws_external_id_test.go
+++ b/pkg/services/datasources/awsexternalid/aws_external_id_test.go
@@ -349,6 +349,38 @@ func TestPreserveGrafanaExternalID_SigV4(t *testing.T) {
 		assert.Empty(t, updated.Get(usePerDatasourceExternalIDJSONKey).Interface())
 	})
 
+	t.Run("FT off omit-auth restores SigV4 mode even when native mode key is set", func(t *testing.T) {
+		// Cross-namespace restore must gate on the SigV4 mode key, not the native one that
+		// externalIDKeys(updated) would select when sigV4AuthType is omitted.
+		existing := simplejson.NewFromAny(map[string]any{
+			sigV4AuthTypeJSONKey:                   grafanaAssumeRoleAuthType,
+			sigV4UsePerDatasourceExternalIDJSONKey: true,
+			sigV4GrafanaExternalIDJSONKey:          wantID,
+		})
+		updated := simplejson.NewFromAny(map[string]any{
+			usePerDatasourceExternalIDJSONKey: true,
+		})
+		preserveGrafanaExternalID(uid, stack, existing, updated, false)
+		assert.Equal(t, wantID, updated.Get(sigV4GrafanaExternalIDJSONKey).MustString())
+		assert.True(t, updated.Get(sigV4UsePerDatasourceExternalIDJSONKey).MustBool())
+		assert.Empty(t, updated.Get(grafanaExternalIDJSONKey).MustString())
+	})
+
+	t.Run("FT off omit-auth keeps explicit SigV4 mode on update", func(t *testing.T) {
+		existing := simplejson.NewFromAny(map[string]any{
+			sigV4AuthTypeJSONKey:                   grafanaAssumeRoleAuthType,
+			sigV4UsePerDatasourceExternalIDJSONKey: true,
+			sigV4GrafanaExternalIDJSONKey:          wantID,
+		})
+		updated := simplejson.NewFromAny(map[string]any{
+			sigV4UsePerDatasourceExternalIDJSONKey: false,
+		})
+		preserveGrafanaExternalID(uid, stack, existing, updated, false)
+		assert.Equal(t, wantID, updated.Get(sigV4GrafanaExternalIDJSONKey).MustString())
+		assert.False(t, updated.Get(sigV4UsePerDatasourceExternalIDJSONKey).MustBool())
+		assert.Empty(t, updated.Get(grafanaExternalIDJSONKey).MustString())
+	})
+
 	t.Run("auth switch into SigV4 GAR mints unless stack mode is requested", func(t *testing.T) {
 		keys := simplejson.NewFromAny(map[string]any{sigV4AuthTypeJSONKey: "keys"})
 

--- a/pkg/services/datasources/awsexternalid/aws_external_id_test.go
+++ b/pkg/services/datasources/awsexternalid/aws_external_id_test.go
@@ -304,6 +304,20 @@ func TestPreserveGrafanaExternalID_SigV4(t *testing.T) {
 		assert.Empty(t, updated.Get(grafanaExternalIDJSONKey).MustString())
 	})
 
+	t.Run("leaving SigV4 GAR keeps prefixed ID when FT off", func(t *testing.T) {
+		existing := simplejson.NewFromAny(map[string]any{
+			sigV4AuthTypeJSONKey:                   grafanaAssumeRoleAuthType,
+			sigV4UsePerDatasourceExternalIDJSONKey: true,
+			sigV4GrafanaExternalIDJSONKey:          wantID,
+		})
+		updated := simplejson.NewFromAny(map[string]any{sigV4AuthTypeJSONKey: "keys"})
+		preserveGrafanaExternalID(uid, stack, existing, updated, false)
+		assert.Equal(t, wantID, updated.Get(sigV4GrafanaExternalIDJSONKey).MustString())
+		assert.True(t, updated.Get(sigV4UsePerDatasourceExternalIDJSONKey).MustBool())
+		assert.Empty(t, updated.Get(grafanaExternalIDJSONKey).MustString())
+		assert.Empty(t, updated.Get(usePerDatasourceExternalIDJSONKey).Interface())
+	})
+
 	t.Run("leaving GAR with auth type omitted still clears prefixed ID from payload", func(t *testing.T) {
 		// Cloud/API/Terraform can send a partial jsonData blob that drops sigV4AuthType
 		// while still including a previously minted prefixed ID.
@@ -316,6 +330,51 @@ func TestPreserveGrafanaExternalID_SigV4(t *testing.T) {
 		})
 		preserveGrafanaExternalID(uid, stack, existing, updated, true)
 		assert.Empty(t, updated.Get(sigV4GrafanaExternalIDJSONKey).MustString())
+		assert.Empty(t, updated.Get(grafanaExternalIDJSONKey).MustString())
+	})
+
+	t.Run("FT off with auth type omitted keeps ID on SigV4 keys not native", func(t *testing.T) {
+		existing := simplejson.NewFromAny(map[string]any{
+			sigV4AuthTypeJSONKey:                   grafanaAssumeRoleAuthType,
+			sigV4UsePerDatasourceExternalIDJSONKey: true,
+			sigV4GrafanaExternalIDJSONKey:          wantID,
+		})
+		updated := simplejson.NewFromAny(map[string]any{
+			sigV4GrafanaExternalIDJSONKey: wantID,
+		})
+		preserveGrafanaExternalID(uid, stack, existing, updated, false)
+		assert.Equal(t, wantID, updated.Get(sigV4GrafanaExternalIDJSONKey).MustString())
+		assert.True(t, updated.Get(sigV4UsePerDatasourceExternalIDJSONKey).MustBool())
+		assert.Empty(t, updated.Get(grafanaExternalIDJSONKey).MustString())
+		assert.Empty(t, updated.Get(usePerDatasourceExternalIDJSONKey).Interface())
+	})
+
+	t.Run("auth switch into SigV4 GAR mints unless stack mode is requested", func(t *testing.T) {
+		keys := simplejson.NewFromAny(map[string]any{sigV4AuthTypeJSONKey: "keys"})
+
+		mint := simplejson.NewFromAny(map[string]any{sigV4AuthTypeJSONKey: grafanaAssumeRoleAuthType})
+		preserveGrafanaExternalID(uid, stack, keys, mint, true)
+		assert.Equal(t, wantID, mint.Get(sigV4GrafanaExternalIDJSONKey).MustString())
+		assert.True(t, mint.Get(sigV4UsePerDatasourceExternalIDJSONKey).MustBool())
+		assert.Empty(t, mint.Get(grafanaExternalIDJSONKey).MustString())
+
+		stackMode := simplejson.NewFromAny(map[string]any{
+			sigV4AuthTypeJSONKey:                   grafanaAssumeRoleAuthType,
+			sigV4UsePerDatasourceExternalIDJSONKey: false,
+		})
+		preserveGrafanaExternalID(uid, stack, keys, stackMode, true)
+		assert.Empty(t, stackMode.Get(sigV4GrafanaExternalIDJSONKey).MustString())
+	})
+
+	t.Run("legacy SigV4 GAR opts in and mints", func(t *testing.T) {
+		existing := simplejson.NewFromAny(map[string]any{sigV4AuthTypeJSONKey: grafanaAssumeRoleAuthType})
+		updated := simplejson.NewFromAny(map[string]any{
+			sigV4AuthTypeJSONKey:                   grafanaAssumeRoleAuthType,
+			sigV4UsePerDatasourceExternalIDJSONKey: true,
+		})
+		preserveGrafanaExternalID(uid, stack, existing, updated, true)
+		assert.Equal(t, wantID, updated.Get(sigV4GrafanaExternalIDJSONKey).MustString())
+		assert.True(t, updated.Get(sigV4UsePerDatasourceExternalIDJSONKey).MustBool())
 		assert.Empty(t, updated.Get(grafanaExternalIDJSONKey).MustString())
 	})
 }


### PR DESCRIPTION
## Summary
- Treat `jsonData.sigV4AuthType == grafana_assume_role` as Grafana Assume Role in `awsexternalid`
- When `sigV4AuthType` is present (any value), mint/scrub/preserve the SigV4-prefixed keys (`sigV4GrafanaExternalId`, `sigV4UsePerDatasourceExternalId`) instead of the unprefixed native pair
- On leave GAR (feature toggle on), clear **both** native and SigV4 ID keys so partial Cloud/API/Terraform payloads cannot leave a stale external ID

Enables SigV4 datasources that already support Grafana Assume Role (e.g. OpenSearch) to opt into per-datasource external IDs the same way native AWS datasources do.

### Design notes for reviewers
- **Namespace selection** uses presence of `sigV4AuthType`, not whether its value is currently GAR — datasources do not switch between native and SigV4 auth on the same instance, and leaving GAR for keys/credentials must still scrub the prefixed keys.
- **Dual clear on leave** covers malformed/partial updates that omit auth type but still carry a minted ID.
- Native AWS path (`authType` + unprefixed keys) is unchanged.

## Related PRs
1. [grafana-aws-sdk-react#501](https://github.com/grafana/grafana-aws-sdk-react/pull/501) — UI / `@grafana/aws-sdk` (release first)
2. **This PR** — `awsexternalid` mint/scrub for SigV4 keys
3. [grafana-enterprise#12799](https://github.com/grafana/grafana-enterprise/pull/12799) — dsauth STS reads prefixed keys (stacked on [#12656](https://github.com/grafana/grafana-enterprise/pull/12656))

## Test plan
- [ ] Create/update OpenSearch DS with SigV4 + Grafana Assume Role + per-DS toggle: save mints `sigV4GrafanaExternalId` / `sigV4UsePerDatasourceExternalId`
- [ ] Switching away from GAR scrubs the prefixed keys
- [ ] Partial update that omits auth type but carries a minted ID still clears on leave-GAR path (covered by unit test)
- [ ] Native AWS datasources still mint/scrub unprefixed `grafanaExternalId` / `usePerDatasourceExternalId`
- [ ] Unit tests in `pkg/services/datasources/awsexternalid` pass