### PR TITLE
feat(navtree): allow Assistant workspace in trials

### DIFF
--- a/pkg/services/navtree/navtreeimpl/applinks.go
+++ b/pkg/services/navtree/navtreeimpl/applinks.go
@@ -29,6 +29,11 @@ var assistantOSSNavigationPaths = map[string]struct{}{
 	"/a/grafana-assistant-app/settings":  {},
 }
 
+var assistantTrialNavigationPaths = map[string]struct{}{
+	assistantAppHomePath:                 {},
+	"/a/grafana-assistant-app/workspace": {},
+}
+
 func (s *ServiceImpl) addAppLinks(treeRoot *navtree.NavTreeRoot, c *contextmodel.ReqContext) error {
 	hasAccess := ac.HasAccess(s.accessControl, c)
 	appLinks := []*navtree.NavLink{}
@@ -333,7 +338,8 @@ func (s *ServiceImpl) shouldIncludeAssistantNavigation(plugin pluginstore.Plugin
 		return true
 	}
 	if trialMode {
-		return include.Path == assistantAppHomePath
+		_, allowed := assistantTrialNavigationPaths[include.Path]
+		return allowed
 	}
 	if s.cfg.IsEnterprise || s.cfg.StackID != "" {
 		return true

--- a/pkg/services/navtree/navtreeimpl/applinks_test.go
+++ b/pkg/services/navtree/navtreeimpl/applinks_test.go
@@ -953,9 +953,12 @@ func TestProcessAssistantAppPlugin(t *testing.T) {
 			},
 		},
 		{
-			name:      "Trial mode only includes the homepage",
+			name:      "Trial mode only includes the homepage and workspace",
 			cfg:       setting.NewCfg(),
 			trialMode: true,
+			wantChildPaths: []string{
+				"/a/grafana-assistant-app/workspace",
+			},
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Allows the Grafana Assistant Workspace navigation entry in trial mode while keeping Settings, Investigations, Automations, and other plugin pages filtered. This is the Grafana core companion to grafana/grafana-assistant-app#8550.

**Testing:**
- `go test ./pkg/services/navtree/navtreeimpl -run TestProcessAssistantAppPlugin`
- `go vet ./pkg/services/navtree/navtreeimpl`
- `git diff --check`