### PR TITLE
CI: Skip running tests on push to mirrors / forks

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -28,6 +28,8 @@ concurrency:
 
 jobs:
   run-actionlint:
+    # Run on `grafana/grafana` pushes, or on pull requests, to prevent double-running on mirrors
+    if: (github.event_name == 'pull_request' || (github.event_name == 'push' && github.repository == 'grafana/grafana'))
     name: Lint GitHub Actions files
     runs-on: ubuntu-x64-small
     permissions:

--- a/.github/workflows/backend-code-checks.yml
+++ b/.github/workflows/backend-code-checks.yml
@@ -16,6 +16,8 @@ on:
 
 jobs:
   detect-changes:
+    # Run on `grafana/grafana` pushes, or on pull requests, to prevent double-running on mirrors
+    if: (github.event_name == 'pull_request' || (github.event_name == 'push' && github.repository == 'grafana/grafana'))
     name: Detect whether code changed
     runs-on: ubuntu-arm64-small
     permissions:

--- a/.github/workflows/build-go-matrix.yml
+++ b/.github/workflows/build-go-matrix.yml
@@ -35,6 +35,8 @@ permissions: {}
 
 jobs:
   build-go:
+    # Run on `grafana/grafana` pushes, or on pull requests, to prevent double-running on mirrors
+    if: (github.event_name == 'pull_request' || (github.event_name == 'push' && github.repository == 'grafana/grafana'))
     name: ${{ matrix.name }}
     runs-on: ubuntu-x64-large-io
     permissions:
@@ -84,7 +86,8 @@ jobs:
         run: make build-go
 
   build-go-enterprise:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
+    # Run on pushes to `grafana/grafana` (not mirrors) OR for internal PRs (PRs not from forks)
+    if: (github.event_name == 'push' && github.repository == 'grafana/grafana') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)
     name: ${{ matrix.name }} (enterprise)
     runs-on: ubuntu-x64-large-io
     permissions:
@@ -145,6 +148,8 @@ jobs:
 
   # TODO: Build rpm in another workflow
   verify-rpm-stig:
+    # Run on `grafana/grafana` pushes, or on pull requests, to prevent double-running on mirrors
+    if: (github.event_name == 'pull_request' || (github.event_name == 'push' && github.repository == 'grafana/grafana'))
     name: verify rpm stig (linux/amd64)
     runs-on: ubuntu-x64-large
     permissions:

--- a/.github/workflows/frontend-lint.yml
+++ b/.github/workflows/frontend-lint.yml
@@ -10,6 +10,8 @@ permissions: {}
 
 jobs:
   detect-changes:
+    # Run on `grafana/grafana` pushes, or on pull requests, to prevent double-running on mirrors
+    if: (github.event_name == 'pull_request' || (github.event_name == 'push' && github.repository == 'grafana/grafana'))
     name: Detect whether code changed
     runs-on: ubuntu-arm64-small
     permissions:
@@ -233,8 +235,8 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    # Run this workflow for non-PR events (like pushes to `main` or `release-*`) OR for internal PRs (PRs not from forks)
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
+    # Run this workflow for pushes to `main` or `release-*` on `grafana/grafana` (not mirrors) OR for internal PRs (PRs not from forks)
+    if: (github.event_name == 'push' && github.repository == 'grafana/grafana') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)
     name: Verify API clients (enterprise)
     runs-on: ubuntu-x64
     steps:

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -21,6 +21,8 @@ permissions:
 
 jobs:
   govulncheck:
+    # Run on `grafana/grafana` pushes, or on pull requests, to prevent double-running on mirrors
+    if: (github.event_name == 'pull_request' || (github.event_name == 'push' && github.repository == 'grafana/grafana'))
     runs-on: ubuntu-x64-large
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/policybot.yml
+++ b/.github/workflows/policybot.yml
@@ -25,6 +25,8 @@ concurrency:
 
 jobs:
   check:
+    # Run on `grafana/grafana` pushes, or on pull requests, to prevent double-running on mirrors
+    if: (github.event_name == 'pull_request' || (github.event_name == 'push' && github.repository == 'grafana/grafana'))
     name: Check .policy.yml is valid
     runs-on: ubuntu-arm64-small
     permissions:

--- a/.github/workflows/pr-test-integration-pgvector.yml
+++ b/.github/workflows/pr-test-integration-pgvector.yml
@@ -31,6 +31,8 @@ permissions: {}
 
 jobs:
   pgvector:
+    # Run on `grafana/grafana` pushes, or on pull requests, to prevent double-running on mirrors
+    if: (github.event_name == 'pull_request' || (github.event_name == 'push' && github.repository == 'grafana/grafana'))
     name: pgvector
     runs-on: ubuntu-x64-large-io
     permissions:

--- a/.github/workflows/pr-test-integration.yml
+++ b/.github/workflows/pr-test-integration.yml
@@ -186,8 +186,8 @@ jobs:
 
   #### Enterprise
   sqlite-enterprise:
-    # Run this workflow for non-PR events (like pushes to `main` or `release-*`) OR for internal PRs (PRs not from forks)
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
+    # Run this workflow for pushes to `main` or `release-*` on `grafana/grafana` (not mirrors) OR for internal PRs (PRs not from forks)
+    if: (github.event_name == 'push' && github.repository == 'grafana/grafana') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)
     strategy:
       matrix:
         shard: [
@@ -231,8 +231,8 @@ jobs:
           go test -vet=off -tags=enterprise -timeout=16m -run '^TestIntegration' "${PACKAGES[@]}"
 
   mysql-enterprise:
-    # Run this workflow for non-PR events (like pushes to `main` or `release-*`) OR for internal PRs (PRs not from forks)
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
+    # Run this workflow for pushes to `main` or `release-*` on `grafana/grafana` (not mirrors) OR for internal PRs (PRs not from forks)
+    if: (github.event_name == 'push' && github.repository == 'grafana/grafana') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)
     strategy:
       matrix:
         shard: [
@@ -294,8 +294,8 @@ jobs:
         run: make devenv-down sources=mysql_tests
 
   postgres-enterprise:
-    # Run this workflow for non-PR events (like pushes to `main` or `release-*`) OR for internal PRs (PRs not from forks)
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
+    # Run this workflow for pushes to `main` or `release-*` on `grafana/grafana` (not mirrors) OR for internal PRs (PRs not from forks)
+    if: (github.event_name == 'push' && github.repository == 'grafana/grafana') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)
     strategy:
       matrix:
         shard: [

--- a/.github/workflows/run-schema-v2-e2e.yml
+++ b/.github/workflows/run-schema-v2-e2e.yml
@@ -12,7 +12,8 @@ jobs:
   dashboard-schema-v2-e2e:
     runs-on: ubuntu-x64-large
     continue-on-error: true
-    if: github.event.pull_request.draft == false
+    # Run on `grafana/grafana` pushes (not mirrors), or on non-draft pull requests
+    if: (github.event_name == 'push' && github.repository == 'grafana/grafana') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
     permissions:
       contents: read
     steps:

--- a/.github/workflows/storybook-a11y.yml
+++ b/.github/workflows/storybook-a11y.yml
@@ -10,6 +10,8 @@ permissions: {}
 
 jobs:
   detect-changes:
+    # Run on `grafana/grafana` pushes, or on pull requests, to prevent double-running on mirrors
+    if: (github.event_name == 'pull_request' || (github.event_name == 'push' && github.repository == 'grafana/grafana'))
     name: Detect whether code changed
     runs-on: ubuntu-arm64-small
     permissions:

--- a/.github/workflows/sync-mirror-event.yml
+++ b/.github/workflows/sync-mirror-event.yml
@@ -14,6 +14,8 @@ permissions: {}
 # This is run after the pull request has been merged, so we'll run against the target branch
 jobs:
   dispatch-job:
+    # Only dispatch from `grafana/grafana` — this workflow is also mirrored, but must not run there
+    if: github.repository == 'grafana/grafana'
     runs-on: ubuntu-arm64-small
     permissions:
       id-token: write
@@ -32,7 +34,6 @@ jobs:
           permission_set: ${{ github.ref_name == 'main' && 'main' || 'release' }} # different branches require different permission sets
 
       - uses: actions/github-script@v8
-        if: github.repository == 'grafana/grafana'
         with:
           github-token: ${{ steps.get-github-app-token.outputs.token }}
           script: |

--- a/.github/workflows/update-schema-types.yml
+++ b/.github/workflows/update-schema-types.yml
@@ -12,6 +12,8 @@ permissions: {}
 
 jobs:
   bundle-schema-types:
+    # Only run in `grafana/grafana` to prevent double-running on mirrors
+    if: github.repository == 'grafana/grafana'
     runs-on: ubuntu-arm64-small
     permissions:
       contents: read


### PR DESCRIPTION
This skips running tests on `push` event to mirrors / forks. For mirrors, this is especially useful as we don't monitor the results, so they end up being wasteful.