### PR TITLE
[release-12.4.7] CI: Skip running tests on push to mirrors / forks

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -20,6 +20,8 @@ concurrency:
 
 jobs:
   run-actionlint:
+    # Run on `grafana/grafana` pushes, or on pull requests, to prevent double-running on mirrors
+    if: (github.event_name == 'pull_request' || (github.event_name == 'push' && github.repository == 'grafana/grafana'))
     name: Lint GitHub Actions files
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/backend-code-checks.yml
+++ b/.github/workflows/backend-code-checks.yml
@@ -16,6 +16,8 @@ on:
 
 jobs:
   detect-changes:
+    # Run on `grafana/grafana` pushes, or on pull requests, to prevent double-running on mirrors
+    if: (github.event_name == 'pull_request' || (github.event_name == 'push' && github.repository == 'grafana/grafana'))
     name: Detect whether code changed
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -26,6 +26,8 @@ permissions:
 
 jobs:
   detect-changes:
+    # Only run in `grafana/grafana` (analyze is repo-guarded too) to prevent double-running on mirrors
+    if: github.repository == 'grafana/grafana'
     name: Detect whether code changed
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/frontend-lint.yml
+++ b/.github/workflows/frontend-lint.yml
@@ -10,6 +10,8 @@ permissions: {}
 
 jobs:
   detect-changes:
+    # Run on `grafana/grafana` pushes, or on pull requests, to prevent double-running on mirrors
+    if: (github.event_name == 'pull_request' || (github.event_name == 'push' && github.repository == 'grafana/grafana'))
     name: Detect whether code changed
     runs-on: ubuntu-arm64-small
     permissions:
@@ -160,8 +162,8 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    # Run this workflow for non-PR events (like pushes to `main` or `release-*`) OR for internal PRs (PRs not from forks)
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
+    # Run this workflow for pushes to `main` or `release-*` on `grafana/grafana` (not mirrors) OR for internal PRs (PRs not from forks)
+    if: (github.event_name == 'push' && github.repository == 'grafana/grafana') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)
     name: Verify API clients (enterprise)
     runs-on: ubuntu-x64
     steps:

--- a/.github/workflows/run-schema-v2-e2e.yml
+++ b/.github/workflows/run-schema-v2-e2e.yml
@@ -15,7 +15,8 @@ jobs:
   dashboard-schema-v2-e2e:
     runs-on: ubuntu-latest-8-cores
     continue-on-error: true
-    if: github.event.pull_request.draft == false
+    # Run on `grafana/grafana` pushes (not mirrors), or on non-draft pull requests
+    if: (github.event_name == 'push' && github.repository == 'grafana/grafana') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/storybook-a11y.yml
+++ b/.github/workflows/storybook-a11y.yml
@@ -10,6 +10,8 @@ permissions: {}
 
 jobs:
   detect-changes:
+    # Run on `grafana/grafana` pushes, or on pull requests, to prevent double-running on mirrors
+    if: (github.event_name == 'pull_request' || (github.event_name == 'push' && github.repository == 'grafana/grafana'))
     name: Detect whether code changed
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/sync-mirror-event.yml
+++ b/.github/workflows/sync-mirror-event.yml
@@ -14,6 +14,8 @@ permissions: {}
 # This is run after the pull request has been merged, so we'll run against the target branch
 jobs:
   dispatch-job:
+    # Only dispatch from `grafana/grafana` — this workflow is also mirrored, but must not run there
+    if: github.repository == 'grafana/grafana'
     runs-on: ubuntu-arm64-small
     permissions:
       id-token: write
@@ -32,7 +34,6 @@ jobs:
           permission_set: ${{ github.ref_name == 'main' && 'main' || 'release' }} # different branches require different permission sets
 
       - uses: actions/github-script@v8
-        if: github.repository == 'grafana/grafana'
         with:
           github-token: ${{ steps.get-github-app-token.outputs.token }}
           script: |

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -14,6 +14,8 @@ on:
 
 jobs:
   trivy-scan:
+    # Run on `grafana/grafana` pushes, or on pull requests, to prevent double-running on mirrors
+    if: (github.event_name == 'pull_request' || (github.event_name == 'push' && github.repository == 'grafana/grafana'))
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v5

--- a/.github/workflows/update-schema-types.yml
+++ b/.github/workflows/update-schema-types.yml
@@ -15,6 +15,8 @@ permissions:
 
 jobs:
   bundle-schema-types:
+    # Only run in `grafana/grafana` to prevent double-running on mirrors
+    if: github.repository == 'grafana/grafana'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
Backport of: https://github.com/grafana/grafana/pull/129163

This skips running tests on `push` event to mirrors / forks. For mirrors, this is especially useful as we don't monitor the results, so they end up being wasteful.