### PR TITLE
chore: bump TRIAGE_REF to community-triage main (digest link + slop fixes)

### DIFF
--- a/.github/workflows/external-fr-notify.yml
+++ b/.github/workflows/external-fr-notify.yml
@@ -18,7 +18,7 @@ concurrency:
 env:
   # community-triage logic version this repo is pinned to. Bump deliberately;
   # re-resolve with: git ls-remote https://github.com/grafana/community-triage main
-  TRIAGE_REF: da6b3f7224d74c43d89374af39fc048911ea110b # trufflehog:ignore
+  TRIAGE_REF: e0631a1564a1e905aa5e19148f9ff61c6973b062 # trufflehog:ignore
 
 jobs:
   notify:

--- a/.github/workflows/external-fr-weekly-digest.yml
+++ b/.github/workflows/external-fr-weekly-digest.yml
@@ -31,7 +31,7 @@ concurrency:
 env:
   # community-triage logic version this repo is pinned to. Bump deliberately;
   # re-resolve with: git ls-remote https://github.com/grafana/community-triage main
-  TRIAGE_REF: da6b3f7224d74c43d89374af39fc048911ea110b # trufflehog:ignore
+  TRIAGE_REF: e0631a1564a1e905aa5e19148f9ff61c6973b062 # trufflehog:ignore
 
 jobs:
   digest:

--- a/.github/workflows/external-issue-notify.yml
+++ b/.github/workflows/external-issue-notify.yml
@@ -18,7 +18,7 @@ concurrency:
 env:
   # community-triage logic version this repo is pinned to. Bump deliberately;
   # re-resolve with: git ls-remote https://github.com/grafana/community-triage main
-  TRIAGE_REF: da6b3f7224d74c43d89374af39fc048911ea110b # trufflehog:ignore
+  TRIAGE_REF: e0631a1564a1e905aa5e19148f9ff61c6973b062 # trufflehog:ignore
 
 jobs:
   notify:

--- a/.github/workflows/external-issue-weekly-digest.yml
+++ b/.github/workflows/external-issue-weekly-digest.yml
@@ -31,7 +31,7 @@ concurrency:
 env:
   # community-triage logic version this repo is pinned to. Bump deliberately;
   # re-resolve with: git ls-remote https://github.com/grafana/community-triage main
-  TRIAGE_REF: da6b3f7224d74c43d89374af39fc048911ea110b # trufflehog:ignore
+  TRIAGE_REF: e0631a1564a1e905aa5e19148f9ff61c6973b062 # trufflehog:ignore
 
 jobs:
   digest:

--- a/.github/workflows/external-pr-notify-handler.yml
+++ b/.github/workflows/external-pr-notify-handler.yml
@@ -25,7 +25,7 @@ env:
   # community-triage logic version this repo is pinned to (main as of PR #6).
   # Bump deliberately; re-resolve with:
   #   git ls-remote https://github.com/grafana/community-triage main
-  TRIAGE_REF: da6b3f7224d74c43d89374af39fc048911ea110b # trufflehog:ignore
+  TRIAGE_REF: e0631a1564a1e905aa5e19148f9ff61c6973b062 # trufflehog:ignore
 
 jobs:
   triage:

--- a/.github/workflows/external-pr-weekly-digest.yml
+++ b/.github/workflows/external-pr-weekly-digest.yml
@@ -31,7 +31,7 @@ permissions: {}
 env:
   # community-triage logic version this repo is pinned to. Bump deliberately;
   # re-resolve with: git ls-remote https://github.com/grafana/community-triage main
-  TRIAGE_REF: da6b3f7224d74c43d89374af39fc048911ea110b # trufflehog:ignore
+  TRIAGE_REF: e0631a1564a1e905aa5e19148f9ff61c6973b062 # trufflehog:ignore
   STALE_THRESHOLD_DAYS: ${{ inputs.stale_days || 30 }}
 
 concurrency:


### PR DESCRIPTION
Bumps `TRIAGE_REF` across the six external-triage workflows 