### PR TITLE
PanelChrome: Menu on hover change

### DIFF
--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -217,6 +217,7 @@ export function PanelChrome({
   const headerStyles: CSSProperties = {
     cursor: dragClass ? 'move' : 'auto',
     paddingBottom: subHeaderHeight ? 0 : theme.spacing.gridSize,
+    height: subHeaderHeight ? undefined : theme.spacing.gridSize * theme.components.panel.headerHeight,
   };
 
   const containerStyles: CSSProperties = { width, height: collapsed ? undefined : height };
@@ -570,14 +571,14 @@ const getStyles = (theme: GrafanaTheme2) => {
 
       '.show-on-hover': {
         opacity: '0',
-        visibility: 'hidden',
+        display: 'none',
       },
 
       '&:focus-visible, &:hover': {
         // only show menu icon on hover or focused panel
         '.show-on-hover': {
           opacity: '1',
-          visibility: 'visible',
+          display: 'inline-flex',
         },
       },
 
@@ -586,7 +587,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       // The not:(:focus) clause is so that this rule is only applied when decendants are focused (important otherwise the hover header is visible when panel is clicked).
       '&:focus-within:not(:focus)': {
         '.show-on-hover': {
-          visibility: 'visible',
+          display: 'inline-flex',
           opacity: '1',
         },
       },
@@ -673,10 +674,6 @@ const getStyles = (theme: GrafanaTheme2) => {
     menuItem: css({
       label: 'panel-menu',
       border: 'none',
-      background: theme.colors.secondary.main,
-      '&:hover': {
-        background: theme.colors.secondary.shade,
-      },
     }),
     errorContainerFloating: css({
       label: 'error-container',


### PR DESCRIPTION
The menu button is currently always taking space. The main reason for this is when paired with header actions we do not want those actions to be pushed around. 

But quite a long time ago we introduced the option to always show the menu, just for those cases when PanelChrome has actions (so there is not an empty space on the far right). In dashboards we currently do not have panels with menu and actions so we could change the hover behavior from visibility to display: none. 

This should not impact a11y that much, as the menu is still shown on focus like before. If / when we introduce panel actions in dashboards we can always make this condititional on there being actions or not (ie automatically set showMenuAlways depending on there being actions or not, this is technically something we could do in this PR as well to help scene apps not have to set it when passing actions)  

Before: 
<img width="638" height="257" alt="Screenshot 2026-07-24 at 11 55 23" src="https://github.com/user-attachments/assets/b522d96a-b8fd-4fed-9358-ecac7a34c8c8" />

After:
<img width="630" height="238" alt="Screenshot 2026-07-24 at 11 55 40" src="https://github.com/user-attachments/assets/0744b6a2-92ba-48a5-aea6-c0bcd30632a5" />


https://github.com/user-attachments/assets/6481b0f4-b62c-4ad0-a926-32fc801553cf

