### PR TITLE
Navigation: Skip building the server nav tree when the client-built tree is enabled

### DIFF
--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -25,6 +25,8 @@ import (
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/login"
+
+	"github.com/grafana/grafana/pkg/services/navtree"
 	"github.com/grafana/grafana/pkg/services/org"
 	pref "github.com/grafana/grafana/pkg/services/preference"
 	"github.com/grafana/grafana/pkg/setting"
@@ -112,9 +114,25 @@ func (hs *HTTPServer) setIndexViewData(c *contextmodel.ReqContext) (*dtos.IndexV
 	grafanaAssetSriChecks, _ := ofClient.BooleanValue(ctx, featuremgmt.FlagGrafanaAssetSriChecks, false, openfeature.TransactionContext(ctx))
 	newPreferencesPage, _ := ofClient.BooleanValue(ctx, featuremgmt.FlagGrafanaNewPreferencesPage, false, openfeature.TransactionContext(ctx))
 
-	navTree, err := hs.navTreeService.GetNavTree(c, prefs)
-	if err != nil {
-		return nil, err
+	// With the client-built nav tree the frontend only needs the items it cannot
+	// know about (enterprise index-data hooks add theirs to the empty root below,
+	// and the client grafts them in) — skip building the full tree. The
+	// conditions must mirror isClientNavTreeEnabled (buildStaticNavTree.ts):
+	// the frontend falls back to the bootdata tree unless both flags are
+	// enabled, so skipping on a different set here would leave it with an
+	// empty tree.
+	multiTenantNavTree, _ := ofClient.BooleanValue(ctx, featuremgmt.FlagGrafanaMultiTenantNavTree, false, openfeature.TransactionContext(ctx))
+	useMTPlugins, _ := ofClient.BooleanValue(ctx, featuremgmt.FlagPluginsUseMTPlugins, false, openfeature.TransactionContext(ctx))
+	clientNavTree := multiTenantNavTree && useMTPlugins
+	// Children must be non-nil so bootdata serves an empty array rather than
+	// null: frontends that read bootData.navTree directly crash on null.
+	navTree := &navtree.NavTreeRoot{Children: []*navtree.NavLink{}}
+	if !clientNavTree {
+		var err error
+		navTree, err = hs.navTreeService.GetNavTree(c, prefs)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	weekStart := ""

--- a/pkg/api/index_test.go
+++ b/pkg/api/index_test.go
@@ -1,0 +1,144 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/open-feature/go-sdk/openfeature"
+	"github.com/open-feature/go-sdk/openfeature/memprovider"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	accesscontrolmock "github.com/grafana/grafana/pkg/services/accesscontrol/mock"
+	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/hooks"
+	"github.com/grafana/grafana/pkg/services/navtree"
+	"github.com/grafana/grafana/pkg/services/org/orgtest"
+	pref "github.com/grafana/grafana/pkg/services/preference"
+	"github.com/grafana/grafana/pkg/services/preference/preftest"
+	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/util/testutil"
+	"github.com/grafana/grafana/pkg/web"
+)
+
+type fakeNavTreeService struct {
+	called bool
+}
+
+func (f *fakeNavTreeService) GetNavTree(_ *contextmodel.ReqContext, _ *pref.Preference) (*navtree.NavTreeRoot, error) {
+	f.called = true
+	return &navtree.NavTreeRoot{Children: []*navtree.NavLink{{Text: "Dashboards", Id: "dashboards"}}}, nil
+}
+
+// Installs a global in-memory OpenFeature provider so the package-level
+// ofClient resolves the two client-nav-tree flags to the given values.
+func setNavTreeFlags(t *testing.T, multiTenantNavTree, useMTPlugins bool) {
+	t.Helper()
+	boolFlag := func(key string, value bool) memprovider.InMemoryFlag {
+		return memprovider.InMemoryFlag{
+			Key:            key,
+			DefaultVariant: "default",
+			Variants:       map[string]any{"default": value},
+		}
+	}
+	provider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
+		featuremgmt.FlagGrafanaMultiTenantNavTree: boolFlag(featuremgmt.FlagGrafanaMultiTenantNavTree, multiTenantNavTree),
+		featuremgmt.FlagPluginsUseMTPlugins:       boolFlag(featuremgmt.FlagPluginsUseMTPlugins, useMTPlugins),
+	})
+	require.NoError(t, openfeature.SetProviderAndWait(provider))
+	t.Cleanup(func() {
+		require.NoError(t, openfeature.SetProviderAndWait(openfeature.NoopProvider{}))
+	})
+}
+
+func TestIntegrationSetIndexViewData_clientNavTree(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	setup := func(t *testing.T) (*HTTPServer, *fakeNavTreeService, *contextmodel.ReqContext) {
+		t.Helper()
+		cfg := setting.NewCfg()
+		// Dev bypasses the webassets package cache, so the fixture manifest
+		// below is read regardless of what other tests have cached.
+		cfg.Env = setting.Dev
+		cfg.StaticRootPath = "webassets/testdata"
+		cfg.DefaultTheme = "dark"
+
+		_, hs := setupTestEnvironment(t, cfg, featuremgmt.WithFeatures(), nil, nil, nil)
+		navService := &fakeNavTreeService{}
+		hs.navTreeService = navService
+		hs.preferenceService = &preftest.FakePreferenceService{
+			ExpectedPreference: &pref.Preference{JSONData: &pref.PreferenceJSONData{}},
+		}
+		hs.HooksService = hooks.ProvideService()
+		hs.orgService = &orgtest.FakeOrgService{}
+		hs.accesscontrolService = accesscontrolmock.New()
+
+		c := &contextmodel.ReqContext{
+			Context:      &web.Context{Req: httptest.NewRequest(http.MethodGet, "/", nil)},
+			SignedInUser: &user.SignedInUser{OrgID: 1},
+			IsSignedIn:   true,
+			Logger:       log.New("index-test"),
+		}
+		return hs, navService, c
+	}
+
+	tests := []struct {
+		desc               string
+		multiTenantNavTree bool
+		useMTPlugins       bool
+		expectSkip         bool
+	}{
+		{
+			desc:               "builds the server nav tree when both flags are disabled",
+			multiTenantNavTree: false,
+			useMTPlugins:       false,
+			expectSkip:         false,
+		},
+		{
+			desc:               "builds the server nav tree when only grafana.multiTenantNavTree is enabled",
+			multiTenantNavTree: true,
+			useMTPlugins:       false,
+			expectSkip:         false,
+		},
+		{
+			desc:               "builds the server nav tree when only plugins.useMTPlugins is enabled",
+			multiTenantNavTree: false,
+			useMTPlugins:       true,
+			expectSkip:         false,
+		},
+		{
+			desc:               "skips building the server nav tree when both flags are enabled",
+			multiTenantNavTree: true,
+			useMTPlugins:       true,
+			expectSkip:         true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			setNavTreeFlags(t, test.multiTenantNavTree, test.useMTPlugins)
+			hs, navService, c := setup(t)
+
+			data, err := hs.setIndexViewData(c)
+			require.NoError(t, err)
+
+			navTreeJSON, err := json.Marshal(data.NavTree)
+			require.NoError(t, err)
+
+			if test.expectSkip {
+				assert.False(t, navService.called, "nav tree service should not be called when the client builds the tree")
+				// Must serialise as an empty array, not null: frontends that
+				// read bootData.navTree directly crash on null.
+				assert.JSONEq(t, `[]`, string(navTreeJSON))
+			} else {
+				assert.True(t, navService.called, "nav tree service should build the tree")
+				assert.Contains(t, string(navTreeJSON), "Dashboards")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

When `grafana.multiTenantNavTree` and `plugins.useMTPlugins` are both enabled, `setIndexViewData` no longer builds the server nav tree:

- The skip condition mirrors what we'll be doing on the frontend in future PRs, so the client should never be left without a tree from either side
- The skipped tree returns as an empty array rather than `null`, so frontend would degrades to an empty tree instead of crashing at startup.

## Why

`/bootdata` is a single-tenant API we're removing reliance on. With the flags enabled the frontend builds the navigation tree itself (static sections hardcoded client-side, app plugin items from the `plugins.grafana.app` metas API), so building it server-side is wasted work — and skipping it is what proves nothing still depends on it.

## Who is this for

Part of the multi-tenant navigation work. No behaviour change with the flags off (the default).