### PR TITLE
Dashboards: Resolve constant __inputs when saving externally-shared exports via the save API

### DIFF
--- a/pkg/registry/apis/dashboard/export_inputs.go
+++ b/pkg/registry/apis/dashboard/export_inputs.go
@@ -1,0 +1,71 @@
+package dashboard
+
+import "strings"
+
+// resolveConstantExportInputs substitutes ${VAR_*} placeholders produced by
+// the classic "Export for sharing externally" flow with the default values
+// embedded in the dashboard's top-level __inputs section.
+//
+// Such exports are import templates: the exporter moves each constant
+// variable's value into __inputs and replaces the variable's query/current
+// with a "${VAR_<NAME>}" placeholder. Only the import API resolves those
+// placeholders, so dashboards written through the regular save APIs (e.g.
+// Terraform, provisioning, direct HTTP calls) would otherwise persist the
+// literal placeholder and later lose the original value when __inputs is
+// dropped during schema migration.
+//
+// Only constant inputs are resolved: they are the only input type that
+// carries its value in the export. Datasource inputs have no default and are
+// left untouched.
+func resolveConstantExportInputs(dash map[string]interface{}) {
+	inputs, ok := dash["__inputs"].([]interface{})
+	if !ok || len(inputs) == 0 {
+		return
+	}
+
+	replacements := map[string]string{}
+	for _, raw := range inputs {
+		input, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		name, _ := input["name"].(string)
+		value, hasValue := input["value"].(string)
+		if input["type"] == "constant" && name != "" && hasValue {
+			replacements["${"+name+"}"] = value
+		}
+	}
+	if len(replacements) == 0 {
+		return
+	}
+
+	for key, child := range dash {
+		// never rewrite the input definitions themselves
+		if key == "__inputs" {
+			continue
+		}
+		dash[key] = substituteExportPlaceholders(child, replacements)
+	}
+}
+
+func substituteExportPlaceholders(node interface{}, replacements map[string]string) interface{} {
+	switch v := node.(type) {
+	case string:
+		for placeholder, value := range replacements {
+			v = strings.ReplaceAll(v, placeholder, value)
+		}
+		return v
+	case map[string]interface{}:
+		for key, child := range v {
+			v[key] = substituteExportPlaceholders(child, replacements)
+		}
+		return v
+	case []interface{}:
+		for i, child := range v {
+			v[i] = substituteExportPlaceholders(child, replacements)
+		}
+		return v
+	default:
+		return node
+	}
+}

--- a/pkg/registry/apis/dashboard/export_inputs_test.go
+++ b/pkg/registry/apis/dashboard/export_inputs_test.go
@@ -1,0 +1,158 @@
+package dashboard
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/admission"
+
+	dashv1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1"
+	"github.com/grafana/grafana/apps/dashboard/pkg/migration"
+	"github.com/grafana/grafana/apps/dashboard/pkg/migration/schemaversion"
+	"github.com/grafana/grafana/apps/dashboard/pkg/migration/testutil"
+	common "github.com/grafana/grafana/pkg/apimachinery/apis/common/v0alpha1"
+)
+
+// externallySharedExport mirrors the shape produced by the classic
+// "Export for sharing externally" flow for a dashboard with a constant
+// variable (name: speed, value: 100) used by a text panel.
+func externallySharedExport() map[string]interface{} {
+	return map[string]interface{}{
+		"__inputs": []interface{}{
+			map[string]interface{}{
+				"name":        "VAR_SPEED",
+				"type":        "constant",
+				"label":       "speed",
+				"value":       "100",
+				"description": "",
+			},
+			map[string]interface{}{
+				"name":     "DS_PROMETHEUS",
+				"type":     "datasource",
+				"label":    "Prometheus",
+				"pluginId": "prometheus",
+			},
+		},
+		"title":         "speed",
+		"schemaVersion": schemaversion.LATEST_VERSION,
+		"panels": []interface{}{
+			map[string]interface{}{
+				"id":   float64(1),
+				"type": "text",
+				"options": map[string]interface{}{
+					"content": "value is ${speed}",
+				},
+				"datasource": map[string]interface{}{
+					"type": "prometheus",
+					"uid":  "${DS_PROMETHEUS}",
+				},
+			},
+		},
+		"templating": map[string]interface{}{
+			"list": []interface{}{
+				map[string]interface{}{
+					"name":  "speed",
+					"type":  "constant",
+					"query": "${VAR_SPEED}",
+					"current": map[string]interface{}{
+						"text":  "${VAR_SPEED}",
+						"value": "${VAR_SPEED}",
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestResolveConstantExportInputs(t *testing.T) {
+	t.Run("substitutes constant placeholders everywhere except __inputs", func(t *testing.T) {
+		dash := externallySharedExport()
+		resolveConstantExportInputs(dash)
+
+		variable := dash["templating"].(map[string]interface{})["list"].([]interface{})[0].(map[string]interface{})
+		require.Equal(t, "100", variable["query"])
+		require.Equal(t, "100", variable["current"].(map[string]interface{})["text"])
+		require.Equal(t, "100", variable["current"].(map[string]interface{})["value"])
+
+		// input definitions themselves are left untouched
+		constantInput := dash["__inputs"].([]interface{})[0].(map[string]interface{})
+		require.Equal(t, "100", constantInput["value"])
+	})
+
+	t.Run("leaves datasource inputs unresolved", func(t *testing.T) {
+		dash := externallySharedExport()
+		resolveConstantExportInputs(dash)
+
+		panel := dash["panels"].([]interface{})[0].(map[string]interface{})
+		require.Equal(t, "${DS_PROMETHEUS}", panel["datasource"].(map[string]interface{})["uid"])
+	})
+
+	t.Run("no-op without __inputs", func(t *testing.T) {
+		dash := map[string]interface{}{
+			"title": "plain",
+			"templating": map[string]interface{}{
+				"list": []interface{}{
+					map[string]interface{}{"name": "speed", "type": "constant", "query": "${VAR_SPEED}"},
+				},
+			},
+		}
+		resolveConstantExportInputs(dash)
+
+		variable := dash["templating"].(map[string]interface{})["list"].([]interface{})[0].(map[string]interface{})
+		require.Equal(t, "${VAR_SPEED}", variable["query"])
+	})
+
+	t.Run("ignores constant inputs without a string value", func(t *testing.T) {
+		dash := map[string]interface{}{
+			"__inputs": []interface{}{
+				map[string]interface{}{"name": "VAR_SPEED", "type": "constant"},
+			},
+			"query": "${VAR_SPEED}",
+		}
+		resolveConstantExportInputs(dash)
+		require.Equal(t, "${VAR_SPEED}", dash["query"])
+	})
+
+	t.Run("substitutes multiple occurrences within one string", func(t *testing.T) {
+		dash := map[string]interface{}{
+			"__inputs": []interface{}{
+				map[string]interface{}{"name": "VAR_SPEED", "type": "constant", "value": "100"},
+			},
+			"description": "from ${VAR_SPEED} to ${VAR_SPEED}",
+		}
+		resolveConstantExportInputs(dash)
+		require.Equal(t, "from 100 to 100", dash["description"])
+	})
+}
+
+func TestMutateResolvesConstantExportInputs(t *testing.T) {
+	migration.Initialize(testutil.NewDataSourceProvider(testutil.StandardTestConfig), testutil.NewLibraryElementProvider(), migration.DefaultCacheTTL)
+
+	obj := &dashv1.Dashboard{
+		Spec: common.Unstructured{Object: externallySharedExport()},
+	}
+
+	b := &DashboardsAPIBuilder{}
+	err := b.Mutate(context.Background(), admission.NewAttributesRecord(
+		obj,
+		nil,
+		dashv1.DashboardResourceInfo.GroupVersionKind(),
+		"",
+		"test",
+		dashv1.DashboardResourceInfo.GroupVersionResource(),
+		"",
+		admission.Create,
+		&metav1.CreateOptions{FieldValidation: metav1.FieldValidationIgnore},
+		false,
+		nil,
+	), nil)
+	require.NoError(t, err)
+
+	variable := obj.Spec.Object["templating"].(map[string]interface{})["list"].([]interface{})[0].(map[string]interface{})
+	require.Equal(t, "100", variable["query"], "constant placeholder should be resolved from __inputs before migration drops them")
+
+	_, hasInputs := obj.Spec.Object["__inputs"]
+	require.False(t, hasInputs, "__inputs should be removed by schema migration")
+}

--- a/pkg/registry/apis/dashboard/mutate.go
+++ b/pkg/registry/apis/dashboard/mutate.go
@@ -78,6 +78,7 @@ func (b *DashboardsAPIBuilder) mutateDashboard(ctx context.Context, a admission.
 		}
 		// Strip BOMs from all string values in the dashboard spec
 		v.Spec.Object = util.StripBOMFromInterface(v.Spec.Object).(map[string]any)
+		resolveConstantExportInputs(v.Spec.Object)
 		resourceInfo = dashboardV0.DashboardResourceInfo
 
 	case *dashboardV1.Dashboard:
@@ -89,6 +90,8 @@ func (b *DashboardsAPIBuilder) mutateDashboard(ctx context.Context, a admission.
 		}
 		// Strip BOMs from all string values in the dashboard spec
 		v.Spec.Object = util.StripBOMFromInterface(v.Spec.Object).(map[string]any)
+		// Resolve export-template constants before Migrate drops __inputs
+		resolveConstantExportInputs(v.Spec.Object)
 		resourceInfo = dashboardV1.DashboardResourceInfo
 		migrationErr = migration.Migrate(ctx, v.Spec.Object, schemaversion.LATEST_VERSION)
 		if migrationErr != nil {


### PR DESCRIPTION
## Goal

Dashboards exported with **"Export for sharing externally"** (Classic model) keep working when applied through the regular save APIs — e.g. Terraform's `grafana_dashboard` resource, provisioning, or a direct `POST /api/dashboards/db` — instead of displaying literal `${VAR_*}` placeholders.

Fixes https://github.com/grafana/support-escalations/issues/23430

## Problem

The classic "Export for sharing externally" flow produces an **import template**, not a directly-saveable dashboard: each constant variable's value is moved into the top-level `__inputs` section and the variable's `query`/`current` are replaced with a `${VAR_<NAME>}` placeholder.

Those placeholders are only resolved by the import API (`POST /api/dashboards/import`, backed by `DashTemplateEvaluator`). Any other write path stores the placeholder literally, so a constant variable `speed = 100` ends up as the string `${VAR_SPEED}` and panels render the placeholder.

This got worse with dashboards stored in the V2 schema: the V1→V2 schema migration deletes `__inputs` outright (`apps/dashboard/pkg/migration/migrate.go`), so the original value (`100`) is permanently lost from the stored dashboard, and any subsequent export emits `"value": "${VAR_SPEED}"`.

## Approach

Resolve constant `__inputs` at **write time**, in the dashboard admission mutation hook (`pkg/registry/apis/dashboard/mutate.go`). Before the schema migration drops `__inputs`, `${VAR_*}` placeholders are substituted with the default values embedded in the export. The hook already performs this kind of write-time payload normalization (strips `id`/`uid`/`version`, BOMs), and it covers every v0/v1 dashboard write: legacy REST API, k8s API, Terraform, provisioning.

Only **constant** inputs are resolved — they are the only input type that carries its value in the export. Datasource inputs (`DS_*`) have no default and are intentionally left untouched (unchanged behavior).

## Key changes

1. `pkg/registry/apis/dashboard/export_inputs.go` (new) — `resolveConstantExportInputs` builds a `${NAME} → value` map from constant `__inputs` entries and recursively substitutes string occurrences in the spec. The `__inputs` subtree itself is skipped so the input definitions are never rewritten.
2. `pkg/registry/apis/dashboard/mutate.go` — calls the resolver in both the `v0alpha1` and `v1beta1` branches. For v1 it runs **before** `migration.Migrate`, which deletes `__inputs`; that ordering is what prevents the data loss.
3. `pkg/registry/apis/dashboard/export_inputs_test.go` (new) — unit tests using a fixture mirroring the escalation's export (constant + datasource input), plus an end-to-end `Mutate` test asserting the variable resolves to `100` and `__inputs` is subsequently dropped by migration.

Notes for reviewers:

- **Why not in `migrate.go`?** Backend migration output is compared byte-for-byte against the frontend `DashboardMigrator` by the parity suite (`DashboardMigratorToBackend.test.ts` consumes the backend golden files). The frontend cannot mirror a substitution step (`DashboardModel` drops `__inputs`; `updateSchema` early-returns for latest-version dashboards), so a `migrate.go` placement would structurally break parity. The admission hook is backend-only by nature. Trade-off: dashboards stored broken in the V1-storage era (placeholder + retained `__inputs`) are healed on their next write, not on read.
- **Known limitation (intentional):** unresolved `DS_*` datasource inputs and `__elements` (library panels) still save silently with dangling references, as before. Rejecting those with an actionable error is a candidate follow-up, but it is a behavior change with rollout implications (e.g. file provisioning), so it is kept out of this fix.
- Existing migration goldens are unaffected: no corpus file contains constant inputs with values.

## How to test

Setup: create a dashboard with a Constant variable `speed = 100` and a Text panel containing `${speed}`; export it as **Classic** with "Export the dashboard to use in another instance" enabled, saved as `speed.json`.

- Apply the export through the save API (what Terraform does):
  `jq '{dashboard: (del(.id) | .uid = "speed-tf" | .title = "speed (terraform)"), overwrite: true}' speed.json | curl -s -u admin:admin -H 'Content-Type: application/json' -X POST http://localhost:3000/api/dashboards/db -d @-`
  → the new dashboard's Text panel displays `100` (before this PR: `${VAR_SPEED}`).
- Re-export the created dashboard as Classic + externally shared → `__inputs` contains `"value": "100"` (before: `"${VAR_SPEED}"`).
- Regression — import path unchanged: import the same `speed.json` via **Dashboards > New > Import** → still prompts for `speed` prefilled with `100` and imports correctly.
- Regression — datasource inputs unchanged: an export containing `DS_*` inputs applied via the save API still stores `${DS_*}` uids (unresolved, as before this PR).
- Edge case: an export where a constant input has no `value` → placeholder is left as-is, save succeeds.