### PR TITLE
AuthZ: Allow setting experimental flags for openfga

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -156,7 +156,7 @@ require (
 	github.com/openai/openai-go/v3 v3.16.0 // @grafana/grafana-search-and-storage
 	github.com/openfga/api/proto v0.0.0-20260319214821-f153694bfc20 // @grafana/identity-access-team
 	github.com/openfga/language/pkg/go v0.2.1 // @grafana/identity-access-team
-	github.com/openfga/openfga v1.18.0 // @grafana/identity-access-team
+	github.com/openfga/openfga v1.18.1 // @grafana/identity-access-team
 	github.com/patrickmn/go-cache v2.1.0+incompatible // @grafana/alerting-backend
 	github.com/pgvector/pgvector-go v0.3.0 // @grafana/grafana-search-and-storage
 	github.com/pressly/goose/v3 v3.27.2 // @grafana/identity-access-team

--- a/go.sum
+++ b/go.sum
@@ -2151,8 +2151,8 @@ github.com/openfga/api/proto v0.0.0-20260319214821-f153694bfc20 h1:xdVG0EDz9Z9Uh
 github.com/openfga/api/proto v0.0.0-20260319214821-f153694bfc20/go.mod h1:XDX4qYNBUM2Rsa2AbKPh+oocZc2zgme+EF2fFC6amVU=
 github.com/openfga/language/pkg/go v0.2.1 h1:nmVJTPfjvaJC2EWGcy8HrUyL15KkIfjjnmB3VFVeCts=
 github.com/openfga/language/pkg/go v0.2.1/go.mod h1:wg+EuPmYIaM855F2uPygT1hJoWcoUxAoecgYC5akXsw=
-github.com/openfga/openfga v1.18.0 h1:aNQHPNZGDYyf4DqxdTzzTT/5nQM4yAtKw3S3ZFhSPn0=
-github.com/openfga/openfga v1.18.0/go.mod h1:se83OqKfGcb9Ddw/Bk85d2WE7PisFmDv/CeZQh3ZyIM=
+github.com/openfga/openfga v1.18.1 h1:scfXscw1co45EJxPHSWQ9OXso+MnmkkGEdQ3+Y2P4mo=
+github.com/openfga/openfga v1.18.1/go.mod h1:se83OqKfGcb9Ddw/Bk85d2WE7PisFmDv/CeZQh3ZyIM=
 github.com/opentracing-contrib/go-grpc v0.1.2 h1:MP16Ozc59kqqwn1v18aQxpeGZhsBanJ2iurZYaQSZ+g=
 github.com/opentracing-contrib/go-grpc v0.1.2/go.mod h1:glU6rl1Fhfp9aXUHkE36K2mR4ht8vih0ekOVlWKEUHM=
 github.com/opentracing-contrib/go-stdlib v0.0.0-20190519235532-cf7a6c988dc9/go.mod h1:PLldrQSroqzH70Xl+1DQcGnefIbqsKR7UDaiux3zV+w=

--- a/pkg/services/authz/zanzana/server/openfga_server.go
+++ b/pkg/services/authz/zanzana/server/openfga_server.go
@@ -34,6 +34,7 @@ func NewOpenFGAServer(cfg setting.ZanzanaServerSettings, store storage.OpenFGADa
 		server.WithDatastore(store),
 		server.WithLogger(zlogger.New(logger)),
 
+		server.WithExperimentals(cfg.OpenFgaServerSettings.Experimentals...),
 		// Cache settings
 		server.WithCheckCacheLimit(cfg.CacheSettings.CheckCacheLimit),
 		server.WithCacheControllerEnabled(cfg.CacheSettings.CacheControllerEnabled),

--- a/pkg/setting/settings_zanzana.go
+++ b/pkg/setting/settings_zanzana.go
@@ -136,6 +136,9 @@ type ZanzanaServerSettings struct {
 }
 
 type OpenFgaServerSettings struct {
+	// OpenFGA experimental features to enable
+	Experimentals []string
+
 	// ListObjects settings
 	// Max number of concurrent datastore reads for ListObjects queries
 	MaxConcurrentReadsForListObjects uint32
@@ -353,6 +356,7 @@ func (cfg *Cfg) readZanzanaSettings() {
 	zs.CacheSettings.SharedIteratorTTL = serverSec.Key("shared_iterator_ttl").MustDuration(10 * time.Second)
 
 	openfgaSec := cfg.SectionWithEnvOverrides("openfga")
+	zs.OpenFgaServerSettings.Experimentals = openfgaSec.Key("experimentals").Strings(",")
 
 	// ListObjects settings
 	zs.OpenFgaServerSettings.MaxConcurrentReadsForListObjects = uint32(openfgaSec.Key("max_concurrent_reads_for_list_objects").MustUint(0))

--- a/pkg/setting/settings_zanzana_test.go
+++ b/pkg/setting/settings_zanzana_test.go
@@ -88,3 +88,30 @@ folder.grafana.app/folders = 2.0
 		assert.Empty(t, cfg.ZanzanaRollout.ResourcePercentages)
 	})
 }
+
+func TestReadZanzanaSettings_OpenFGAExperimentals(t *testing.T) {
+	t.Run("disabled by default", func(t *testing.T) {
+		cfg, err := NewCfgFromBytes(nil)
+		require.NoError(t, err)
+		assert.Empty(t, cfg.ZanzanaServer.OpenFgaServerSettings.Experimentals)
+	})
+
+	t.Run("reads experimentals from config", func(t *testing.T) {
+		cfg, err := NewCfgFromBytes([]byte(`
+[openfga]
+experimentals = enable-check-optimizations,weighted_graph_check
+`))
+		require.NoError(t, err)
+		assert.Equal(t, []string{"enable-check-optimizations", "weighted_graph_check"}, cfg.ZanzanaServer.OpenFgaServerSettings.Experimentals)
+	})
+
+	t.Run("environment overrides config", func(t *testing.T) {
+		t.Setenv("GF_OPENFGA_EXPERIMENTALS", "weighted_graph_check")
+		cfg, err := NewCfgFromBytes([]byte(`
+[openfga]
+experimentals = enable-check-optimizations
+`))
+		require.NoError(t, err)
+		assert.Equal(t, []string{"weighted_graph_check"}, cfg.ZanzanaServer.OpenFgaServerSettings.Experimentals)
+	})
+}


### PR DESCRIPTION
## What is this feature?

Adds a disabled-by-default `[openfga] experimentals` setting for the embedded Zanzana server. The comma-separated list is passed to OpenFGA and supports Grafana's standard environment override through `GF_OPENFGA_EXPERIMENTALS`.

For example:

```ini
[openfga]
experimentals = enable-check-optimizations,weighted_graph_check
```

Also updates OpenFGA from v1.18.0 to v1.18.1, which extends weighted graph evaluation to BatchCheck and includes additional weighted graph diagnostics.

## Why do we need this feature?

This lets operators selectively enable optimized OpenFGA Check and BatchCheck evaluation without hard-coding experimental features in the embedded server.

## Which issue(s) does this PR fix?

N/A

## Special notes for your reviewer

Validation:

- `go test ./pkg/setting -run '^TestReadZanzanaSettings_OpenFGAExperimentals$' -count=1`
- `go test ./pkg/services/authz/zanzana/server -count=1`
- `go mod verify`
- `git diff --check`
