### PR TITLE
Connections: Fix duplicated sub-path when navigating from landing page cards

### DIFF
--- a/public/app/features/connections/Connections.test.tsx
+++ b/public/app/features/connections/Connections.test.tsx
@@ -1,8 +1,9 @@
 import { type RenderResult, screen } from '@testing-library/react';
 import { Route, Routes } from 'react-router-dom-v5-compat';
-import { render } from 'test/test-utils';
+import { render, userEvent } from 'test/test-utils';
 
-import { config } from '@grafana/runtime';
+import { locationUtil } from '@grafana/data';
+import { config, locationService } from '@grafana/runtime';
 import { contextSrv } from 'app/core/services/context_srv';
 import * as api from 'app/features/datasources/api';
 import { getMockDataSources } from 'app/features/datasources/mocks/dataSourcesMocks';
@@ -162,5 +163,60 @@ describe('Connections', () => {
     // We expect not to see the text that would be rendered by the core "Add new connection" page
     expect(screen.queryByText('Data sources')).not.toBeInTheDocument();
     expect(screen.queryByText('No results matching your query were found')).not.toBeInTheDocument();
+  });
+
+  describe('when Grafana is served from a sub-path', () => {
+    // Mirrors a sub-path deployment: the backend nav tree prefixes every URL with appSubUrl
+    const subPathStore = () =>
+      configureStore({
+        navIndex: {
+          ...navIndex,
+          connections: {
+            ...navIndex.connections,
+            children: [
+              {
+                id: 'connections-add-new-connection',
+                text: 'Add new connection',
+                url: '/grafana/connections/add-new-connection',
+              },
+              { id: 'connections-datasources', text: 'Data sources', url: '/grafana/connections/datasources' },
+            ],
+          },
+        },
+        plugins: getPluginsStateMock([]),
+      });
+
+    const initLocationUtil = (appSubUrl: string) =>
+      locationUtil.initialize({
+        config: { ...window.grafanaBootData.settings, appSubUrl },
+        getTimeRangeForUrl: jest.fn(),
+        getVariablesUrlParams: jest.fn(),
+      });
+
+    beforeEach(() => {
+      initLocationUtil('/grafana');
+    });
+
+    afterEach(() => {
+      initLocationUtil('');
+    });
+
+    test('applies card metadata even though nav URLs carry the sub-path prefix', async () => {
+      config.pluginAdminExternalManageEnabled = false;
+      renderPage(ROUTES.Base, subPathStore());
+
+      // OSS title/subtitle come from CardMetadata, whose keys have no sub-path prefix
+      expect(await screen.findByText('View configured data sources')).toBeVisible();
+      expect(await screen.findByText('Connect to a new data source')).toBeVisible();
+    });
+
+    test('does not duplicate the sub-path when navigating via a card', async () => {
+      config.pluginAdminExternalManageEnabled = false;
+      renderPage(ROUTES.Base, subPathStore());
+
+      await userEvent.click(await screen.findByText('View configured data sources'));
+
+      expect(locationService.getLocation().pathname).toBe('/connections/datasources');
+    });
   });
 });

--- a/public/app/features/connections/pages/ConnectionsHomePage.tsx
+++ b/public/app/features/connections/pages/ConnectionsHomePage.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 
-import { type GrafanaTheme2, type IconName, isIconName } from '@grafana/data';
+import { type GrafanaTheme2, type IconName, isIconName, locationUtil } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 import { useStyles2 } from '@grafana/ui';
@@ -29,16 +29,21 @@ export default function ConnectionsHomePage() {
   const cardMetadata = getConnectionsCardMetadata(isOnPrem);
   const navIndex = useSelector((state) => state.navIndex);
   const cardsData = (navIndex['connections']?.children ?? [])
-    .filter((item) => item.url)
     .map((item) => {
-      const meta = cardMetadata[item.url!];
+      // Nav tree URLs include the sub-path prefix (appSubUrl). Strip it so the
+      // metadata lookup matches and locationService.push (whose history already
+      // has appSubUrl as basename) does not prepend the prefix a second time.
+      const url = locationUtil.stripBaseFromUrl(item.url ?? '');
+      const meta = cardMetadata[url];
       return {
         ...item,
+        url,
         text: meta?.text ?? item.text,
         icon: resolveIcon(meta?.icon, item.icon),
         subTitle: meta?.subTitle ?? item.subTitle ?? '',
       };
-    });
+    })
+    .filter((item) => item.url);
 
   return (
     <Page
@@ -74,7 +79,7 @@ export default function ConnectionsHomePage() {
                   title={child.text}
                   description={child.subTitle}
                   icon={child.icon}
-                  url={child.url!}
+                  url={child.url}
                   index={index}
                 />
               ))}


### PR DESCRIPTION
**What is this feature?**

Fixes the Connections landing page cards ("Add new connection", "Data sources", plugin pages) navigating to URLs with a duplicated sub-path (e.g. `/grafana/grafana/connections/datasources`, resulting in "Page not found") when Grafana is served under a sub-path. Also restores the cards' icon/title/subtitle metadata, whose lookup silently failed when nav URLs carried the sub-path prefix.

**Why do we need this feature?**

With `GF_SERVER_SERVE_FROM_SUB_PATH=true` the backend nav tree prefixes every URL with `appSubUrl`, and the cards passed those URLs straight to `locationService.push`, whose history already uses `appSubUrl` as basename — so the prefix was applied twice and card clicks ended on a 404 page.

**Who is this feature for?**

Anyone running Grafana behind a reverse proxy under a sub-path.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/128972
