### PR TITLE
AlertList: Fixes link color in visual refresh

### DIFF
--- a/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
+++ b/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
@@ -513,13 +513,6 @@ export const getStyles = (theme: GrafanaTheme2) => ({
   customGroupDetails: css({
     marginBottom: theme.spacing(0.5),
   }),
-  link: css({
-    wordBreak: 'break-all',
-    color: theme.colors.primary.text,
-    display: 'flex',
-    alignItems: 'center',
-    gap: theme.spacing(1),
-  }),
   hidden: css({
     display: 'none',
   }),

--- a/public/app/plugins/panel/alertlist/unified-alerting/UngroupedView.tsx
+++ b/public/app/plugins/panel/alertlist/unified-alerting/UngroupedView.tsx
@@ -3,7 +3,7 @@ import { useLocation } from 'react-use';
 
 import { type GrafanaTheme2, intervalToAbbreviatedDurationString } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { Icon, Stack, useStyles2 } from '@grafana/ui';
+import { Icon, TextLink, Stack, useStyles2 } from '@grafana/ui';
 import alertDef from 'app/features/alerting/state/alertDef';
 import { Spacer } from 'app/features/alerting/unified/components/Spacer';
 import { fromCombinedRule, stringifyIdentifier } from 'app/features/alerting/unified/utils/rule-id';
@@ -89,18 +89,16 @@ const UngroupedModeView = ({ rules, options, handleInstancesLimit, limitInstance
                       </div>
                       <Spacer />
                       {href && (
-                        <a
+                        <TextLink
                           href={href}
-                          target="__blank"
-                          className={styles.link}
-                          rel="noopener"
+                          external={true}
+                          inline={false}
                           aria-label={t('alertlist.ungrouped-mode-view.aria-label-view-alert-rule', 'View alert rule')}
                         >
                           <span className={cx({ [styles.hidden]: hideViewRuleLinkText })}>
                             <Trans i18nKey="alertlist.ungrouped-mode-view.view-alert-rule">View alert rule</Trans>
                           </span>
-                          <Icon name={'external-link-alt'} size="sm" />
-                        </a>
+                        </TextLink>
                       )}
                     </Stack>
                     <div className={styles.alertDuration}>


### PR DESCRIPTION
Fixes color "View alert rule" link when visual refresh is enabled. (primary.text is white in visual refresh theme)  

Before
<img width="575" height="296" alt="Screenshot 2026-07-24 at 15 18 46" src="https://github.com/user-attachments/assets/af79c552-c854-4bec-b72e-b0fa09e18212" />

After:
<img width="711" height="321" alt="Screenshot 2026-07-24 at 15 57 59" src="https://github.com/user-attachments/assets/3d9d8d68-fd00-4f6e-b5fc-d4ccc7ce1565" />
