### PR TITLE
Alerting: Add staged configuration summary in import settings page

### DIFF
--- a/public/app/features/alerting/unified/settings/import/ImportSettingsPage.tsx
+++ b/public/app/features/alerting/unified/settings/import/ImportSettingsPage.tsx
@@ -123,7 +123,9 @@ function StagedConfigurationSection() {
         </EmptyState>
       )}
 
-      {!isLoading && !isError && stagedConfig && <StagedConfiguration stagedConfig={stagedConfig} />}
+      {!isLoading && !isError && stagedConfig && (
+        <StagedConfiguration stagedConfig={stagedConfig} liveConfig={data?.alertmanager_config} />
+      )}
     </Stack>
   );
 }

--- a/public/app/features/alerting/unified/settings/import/ImportSettingsPage.tsx
+++ b/public/app/features/alerting/unified/settings/import/ImportSettingsPage.tsx
@@ -16,6 +16,9 @@ import { stringifyErrorLike } from '../../utils/misc';
 import { withPageErrorBoundary } from '../../withPageErrorBoundary';
 import { useSettingsPageNav } from '../navigation';
 
+import { StagedConfiguration } from './StagedConfiguration';
+import { isStagedExtraConfig } from './stagedConfig';
+
 const IMPORT_WIZARD_URL = '/alerting/import-to-gma';
 
 function ImportSettingsPage() {
@@ -64,8 +67,9 @@ function StagedConfigurationSection() {
     }
   }, [isError, error]);
 
-  // A user can have at most one staged configuration at a time.
-  const stagedConfig = data?.extra_config?.[0];
+  // A user can have at most one staged configuration at a time
+  const rawStagedConfig: unknown = data?.extra_config?.[0];
+  const stagedConfig = isStagedExtraConfig(rawStagedConfig) ? rawStagedConfig : undefined;
 
   return (
     <Stack direction="column" gap={1}>
@@ -119,8 +123,7 @@ function StagedConfigurationSection() {
         </EmptyState>
       )}
 
-      {/* Populated summary + accordion is added in a follow-up. */}
-      {!isLoading && !isError && stagedConfig && <Text variant="body">{stagedConfig.identifier}</Text>}
+      {!isLoading && !isError && stagedConfig && <StagedConfiguration stagedConfig={stagedConfig} />}
     </Stack>
   );
 }

--- a/public/app/features/alerting/unified/settings/import/StagedConfiguration.test.tsx
+++ b/public/app/features/alerting/unified/settings/import/StagedConfiguration.test.tsx
@@ -1,0 +1,128 @@
+import { within } from '@testing-library/react';
+import { render, screen } from 'test/test-utils';
+import { byRole, byText } from 'testing-library-selector';
+
+import { base64UrlEncode } from '@grafana/alerting';
+
+import { StagedConfiguration } from './StagedConfiguration';
+
+const alertmanagerConfig = `
+route:
+  receiver: default
+  routes:
+    - receiver: slack-platform
+      object_matchers:
+        - [team, "=", platform]
+receivers:
+  - name: default
+  - name: slack-platform
+templates:
+  - my-template.tmpl
+time_intervals:
+  - name: weekends
+inhibit_rules:
+  - equal: [alertname]
+`;
+
+const stagedConfig = {
+  identifier: 'prometheus-prod',
+  alertmanager_config: alertmanagerConfig,
+  template_files: {},
+};
+
+// A routing tree with a direct child ("a") that itself has two nested routes. Only the root and the
+// direct child are listed, so the section count must be 2 — not the recursive descendant total.
+const nestedPoliciesConfig = {
+  identifier: 'nested',
+  alertmanager_config: `
+route:
+  receiver: root
+  routes:
+    - receiver: a
+      routes:
+        - receiver: a1
+        - receiver: a2
+receivers:
+  - name: root
+  - name: a
+  - name: a1
+  - name: a2
+`,
+};
+
+const ui = {
+  heading: byRole('heading', { name: 'prometheus-prod' }),
+  badge: byText(/staged · read-only/i),
+  contactPointsSection: byRole('button', { name: /contact points/i }),
+  notificationPoliciesSection: byRole('button', { name: /notification policies/i }),
+  expandAll: byRole('button', { name: /expand all/i }),
+  parseError: byText(/couldn't read the staged configuration/i),
+};
+
+describe('StagedConfiguration', () => {
+  it('renders the identifier, staged badge and resource sections', () => {
+    render(<StagedConfiguration stagedConfig={stagedConfig} />);
+
+    expect(ui.heading.get()).toBeInTheDocument();
+    expect(ui.badge.get()).toBeInTheDocument();
+    expect(ui.contactPointsSection.get()).toBeInTheDocument();
+  });
+
+  it('expands a section to reveal resource names', async () => {
+    const { user } = render(<StagedConfiguration stagedConfig={stagedConfig} />);
+
+    await user.click(ui.contactPointsSection.get());
+
+    expect(screen.getByText('default')).toBeInTheDocument();
+    expect(screen.getByText('slack-platform')).toBeInTheDocument();
+  });
+
+  it('reveals every section when Expand all is clicked', async () => {
+    const { user } = render(<StagedConfiguration stagedConfig={stagedConfig} />);
+
+    await user.click(ui.expandAll.get());
+
+    expect(screen.getByText('my-template.tmpl')).toBeInTheDocument();
+    expect(screen.getByText('weekends')).toBeInTheDocument();
+  });
+
+  it('links each resource to its detail/list page', async () => {
+    const { user } = render(<StagedConfiguration stagedConfig={stagedConfig} />);
+
+    await user.click(ui.expandAll.get());
+
+    const hrefs = screen.getAllByRole('link', { name: /view/i }).map((link) => link.getAttribute('href'));
+
+    // Contact points are addressed by base64url(name).
+    expect(hrefs.some((href) => href?.includes(`/receivers/${base64UrlEncode('default')}/edit`))).toBe(true);
+    // Time intervals use the raw name.
+    expect(hrefs.some((href) => href?.includes('/mute-timing/edit') && href?.includes('muteName=weekends'))).toBe(true);
+    // Templates have no per-item detail page, so they link to the templates list.
+    expect(hrefs.some((href) => href?.includes('/alerting/notifications/templates') && !href.includes('/edit'))).toBe(
+      true
+    );
+    // Notification policies filter the routes tree by matcher query string.
+    expect(hrefs.some((href) => href?.includes('/alerting/routes') && href?.includes('team'))).toBe(true);
+  });
+
+  it('shows inhibition rule details inline (no link)', async () => {
+    const { user } = render(<StagedConfiguration stagedConfig={stagedConfig} />);
+
+    await user.click(ui.expandAll.get());
+
+    expect(screen.getByText(/equal:\s*alertname/i)).toBeInTheDocument();
+  });
+
+  it('counts the notification policies section by root and direct children only, not nested routes', () => {
+    render(<StagedConfiguration stagedConfig={nestedPoliciesConfig} />);
+
+    // "Default policy" + one direct child ("a") = 2; the two routes nested under "a" are not counted.
+    expect(within(ui.notificationPoliciesSection.get()).getByText('2')).toBeInTheDocument();
+  });
+
+  it('shows an error when the configuration cannot be parsed', () => {
+    render(<StagedConfiguration stagedConfig={{ identifier: 'broken', alertmanager_config: 'foo: [bar' }} />);
+
+    expect(ui.parseError.get()).toBeInTheDocument();
+  });
+});

--- a/public/app/features/alerting/unified/settings/import/StagedConfiguration.test.tsx
+++ b/public/app/features/alerting/unified/settings/import/StagedConfiguration.test.tsx
@@ -30,8 +30,9 @@ const stagedConfig = {
   template_files: {},
 };
 
-// A routing tree with a direct child ("a") that itself has two nested routes. Only the root and the
-// direct child are listed, so the section count must be 2 — not the recursive descendant total.
+// A routing tree with two direct children, one of which has two nested routes of its own. The import is one
+// tree, so the section count is 1 and the tree's own route count is its two direct children — the same number
+// the notification policies page shows for it, not the four descendants.
 const nestedPoliciesConfig = {
   identifier: 'nested',
   alertmanager_config: `
@@ -42,11 +43,13 @@ route:
       routes:
         - receiver: a1
         - receiver: a2
+    - receiver: b
 receivers:
   - name: root
   - name: a
   - name: a1
   - name: a2
+  - name: b
 `,
 };
 
@@ -54,7 +57,8 @@ const ui = {
   heading: byRole('heading', { name: 'prometheus-prod' }),
   badge: byText(/staged · read-only/i),
   contactPointsSection: byRole('button', { name: /contact points/i }),
-  notificationPoliciesSection: byRole('button', { name: /notification policies/i }),
+  notificationPoliciesSection: byRole('button', { name: /notification polic/i }),
+  notificationPoliciesContent: byRole('region', { name: /notification polic/i }),
   expandAll: byRole('button', { name: /expand all/i }),
   parseError: byText(/couldn't read the staged configuration/i),
 };
@@ -151,11 +155,28 @@ describe('StagedConfiguration', () => {
     expect(screen.getByText(/equal:\s*alertname/i)).toBeInTheDocument();
   });
 
-  it('counts the notification policies section by root and direct children only, not nested routes', () => {
-    render(<StagedConfiguration stagedConfig={nestedPoliciesConfig} />);
+  it('presents the import as a single routing tree named after the identifier', async () => {
+    const { user } = render(<StagedConfiguration stagedConfig={nestedPoliciesConfig} />);
 
-    // "Default policy" + one direct child ("a") = 2; the two routes nested under "a" are not counted.
-    expect(within(ui.notificationPoliciesSection.get()).getByText('2')).toBeInTheDocument();
+    // One import contributes one routing tree, so the section count is 1 regardless of the tree's size.
+    expect(within(ui.notificationPoliciesSection.get()).getByText('1')).toBeInTheDocument();
+
+    await user.click(ui.notificationPoliciesSection.get());
+    const section = ui.notificationPoliciesContent.get();
+
+    // The tree row is named after the identifier and reports its two direct children — the routes nested
+    // under "a" are not counted, matching the notification policies page.
+    expect(within(section).getByText('nested')).toBeInTheDocument();
+    expect(within(section).getByText(/→ root · 2 routes/)).toBeInTheDocument();
+  });
+
+  it('does not label the imported root as the default policy', async () => {
+    const { user } = render(<StagedConfiguration stagedConfig={stagedConfig} />);
+
+    await user.click(ui.notificationPoliciesSection.get());
+
+    // The imported root is the root of managed route "prometheus-prod", not the Grafana default policy.
+    expect(screen.queryByText(/default policy/i)).not.toBeInTheDocument();
   });
 
   it('shows an error when the configuration cannot be parsed', () => {

--- a/public/app/features/alerting/unified/settings/import/StagedConfiguration.test.tsx
+++ b/public/app/features/alerting/unified/settings/import/StagedConfiguration.test.tsx
@@ -102,14 +102,45 @@ describe('StagedConfiguration', () => {
       true
     );
     // Notification policies filter the routes tree by matcher query string, pinned to the Grafana
-    // Alertmanager so the link always opens the staged config (not whichever AM is in localStorage).
-    const routeHrefs = hrefs.filter((href) => href?.includes('/alerting/routes'));
+    // Alertmanager so the link always opens the staged config (not whichever AM is in localStorage),
+    // and to the staged config's own routing tree so live trees are not listed alongside it.
+    // Matched on the trailing "?" so the /alerting/routes/mute-timing/edit link is not picked up here.
+    const routeHrefs = hrefs.filter((href) => href?.includes('/alerting/routes?'));
     expect(routeHrefs.length).toBeGreaterThan(0);
-    routeHrefs.forEach((href) => expect(href).toContain('alertmanager=grafana'));
+    routeHrefs.forEach((href) => {
+      expect(href).toContain('alertmanager=grafana');
+      expect(href).toContain('includeTree=prometheus-prod');
+    });
     // The child route's matcher value is quoted so the routes filter parses it back intact.
     const childPolicyHref = routeHrefs.find((href) => href?.includes('queryString'));
     const policyParams = new URLSearchParams(childPolicyHref?.split('?')[1]);
     expect(policyParams.get('queryString')).toBe('team="platform"');
+  });
+
+  it('links resources renamed by the merge under their post-merge name', async () => {
+    // "default" and "weekends" are already taken in the live config, so the backend addresses the staged
+    // copies as "<name>_<identifier>". "slack-platform" is free and keeps its name.
+    const { user } = render(
+      <StagedConfiguration
+        stagedConfig={stagedConfig}
+        liveConfig={{ receivers: [{ name: 'default' }], time_intervals: [{ name: 'weekends', time_intervals: [] }] }}
+      />
+    );
+
+    await user.click(ui.expandAll.get());
+
+    const hrefs = screen.getAllByRole('link', { name: /view/i }).map((link) => link.getAttribute('href'));
+
+    expect(hrefs).toContainEqual(
+      expect.stringContaining(`/receivers/${base64UrlEncode('default_prometheus-prod')}/edit`)
+    );
+    expect(hrefs).not.toContainEqual(expect.stringContaining(`/receivers/${base64UrlEncode('default')}/edit`));
+    expect(hrefs).toContainEqual(expect.stringContaining('muteName=weekends_prometheus-prod'));
+    // Unaffected resources keep their original name.
+    expect(hrefs).toContainEqual(expect.stringContaining(`/receivers/${base64UrlEncode('slack-platform')}/edit`));
+    // The labels still show the staged config's own names — only the link targets are the merged ones.
+    expect(screen.queryByText('default_prometheus-prod')).not.toBeInTheDocument();
+    expect(screen.queryByText('weekends_prometheus-prod')).not.toBeInTheDocument();
   });
 
   it('shows inhibition rule details inline (no link)', async () => {

--- a/public/app/features/alerting/unified/settings/import/StagedConfiguration.test.tsx
+++ b/public/app/features/alerting/unified/settings/import/StagedConfiguration.test.tsx
@@ -101,8 +101,15 @@ describe('StagedConfiguration', () => {
     expect(hrefs.some((href) => href?.includes('/alerting/notifications/templates') && !href.includes('/edit'))).toBe(
       true
     );
-    // Notification policies filter the routes tree by matcher query string.
-    expect(hrefs.some((href) => href?.includes('/alerting/routes') && href?.includes('team'))).toBe(true);
+    // Notification policies filter the routes tree by matcher query string, pinned to the Grafana
+    // Alertmanager so the link always opens the staged config (not whichever AM is in localStorage).
+    const routeHrefs = hrefs.filter((href) => href?.includes('/alerting/routes'));
+    expect(routeHrefs.length).toBeGreaterThan(0);
+    routeHrefs.forEach((href) => expect(href).toContain('alertmanager=grafana'));
+    // The child route's matcher value is quoted so the routes filter parses it back intact.
+    const childPolicyHref = routeHrefs.find((href) => href?.includes('queryString'));
+    const policyParams = new URLSearchParams(childPolicyHref?.split('?')[1]);
+    expect(policyParams.get('queryString')).toBe('team="platform"');
   });
 
   it('shows inhibition rule details inline (no link)', async () => {

--- a/public/app/features/alerting/unified/settings/import/StagedConfiguration.tsx
+++ b/public/app/features/alerting/unified/settings/import/StagedConfiguration.tsx
@@ -1,0 +1,369 @@
+import { css } from '@emotion/css';
+import { useState } from 'react';
+
+import { base64UrlEncode } from '@grafana/alerting';
+import { type GrafanaTheme2, type IconName } from '@grafana/data';
+import { Trans, t } from '@grafana/i18n';
+import { Alert, Badge, Button, Icon, LinkButton, Stack, Text, useStyles2 } from '@grafana/ui';
+
+import { GRAFANA_RULES_SOURCE_NAME } from '../../utils/datasource';
+import { makeEditContactPointLink, makeEditTimeIntervalLink } from '../../utils/misc';
+import { createRelativeUrl } from '../../utils/url';
+
+import {
+  type StagedExtraConfig,
+  getReceiverIntegrationTypes,
+  parseStagedAlertmanagerConfig,
+  summarizeMatchRecord,
+  summarizeRouteMatchers,
+  summarizeStagedConfig,
+} from './stagedConfig';
+
+const GRAFANA_AM = { alertmanager: GRAFANA_RULES_SOURCE_NAME };
+
+// Contact points are k8s resources addressed by a UID that is the base64url encoding of their name,
+// so we derive it to deep-link into the (read-only) contact point view page.
+function makeViewContactPointLink(name: string): string {
+  return makeEditContactPointLink(base64UrlEncode(name), GRAFANA_AM);
+}
+
+// Time intervals (mute timings) are addressed by their raw name in the edit route.
+function makeViewTimeIntervalLink(name: string): string {
+  return makeEditTimeIntervalLink(name, GRAFANA_AM);
+}
+
+// Templates are addressed by a hashed UID that can't be derived from the name, so we link to the
+// templates list where the imported template appears (read-only) rather than a per-item detail page.
+function makeViewTemplatesLink(): string {
+  return createRelativeUrl('/alerting/notifications/templates', GRAFANA_AM);
+}
+
+/** Filter the notification policies tree to a policy by its matchers; unfiltered when there are none. */
+function makeViewPolicyLink(matchers: string): string {
+  return createRelativeUrl('/alerting/routes', matchers ? { queryString: matchers } : {});
+}
+
+interface AccordionSection {
+  key: string;
+  icon: IconName;
+  label: string;
+  count: number;
+  content: React.ReactNode;
+}
+
+interface Props {
+  stagedConfig: StagedExtraConfig;
+}
+
+export function StagedConfiguration({ stagedConfig }: Props) {
+  const styles = useStyles2(getStyles);
+  const config = parseStagedAlertmanagerConfig(stagedConfig.alertmanager_config);
+
+  if (!config) {
+    return (
+      <Alert
+        severity="error"
+        title={t('alerting.settings.import.parse-error-title', "Couldn't read the staged configuration")}
+      >
+        <Trans i18nKey="alerting.settings.import.parse-error-body">
+          The imported Alertmanager configuration could not be parsed.
+        </Trans>
+      </Alert>
+    );
+  }
+
+  const summary = summarizeStagedConfig(config, stagedConfig.template_files);
+  const receivers = config.receivers ?? [];
+  const childRoutes = config.route?.routes ?? [];
+  const inhibitRules = config.inhibit_rules ?? [];
+
+  const sections: AccordionSection[] = [];
+
+  if (receivers.length > 0) {
+    sections.push({
+      key: 'contact-points',
+      icon: 'comment-alt',
+      label: t('alerting.settings.import.section.contact-points', 'Contact points'),
+      count: receivers.length,
+      content: receivers.map((receiver) => (
+        <ResourceRow
+          key={receiver.name}
+          label={receiver.name}
+          meta={getReceiverIntegrationTypes(receiver).join(', ')}
+          href={makeViewContactPointLink(receiver.name)}
+        />
+      )),
+    });
+  }
+
+  if (summary.hasRoutingTree) {
+    sections.push({
+      key: 'notification-policies',
+      icon: 'sitemap',
+      label: t('alerting.settings.import.section.notification-policies', 'Notification policies'),
+      // Root "Default policy" row + the direct child routes we render below (nested routes aren't listed).
+      count: childRoutes.length + 1,
+      content: (
+        <>
+          <ResourceRow
+            label={t('alerting.settings.import.default-policy', 'Default policy')}
+            plainLabel
+            meta={config.route?.receiver ?? undefined}
+            href={makeViewPolicyLink('')}
+          />
+          {childRoutes.map((route, index) => {
+            const matchers = summarizeRouteMatchers(route);
+            return (
+              <ResourceRow
+                key={`${matchers}|${route.receiver ?? ''}|${index}`}
+                label={matchers || t('alerting.settings.import.no-matchers', '(no matchers)')}
+                meta={route.receiver ? `→ ${route.receiver}` : undefined}
+                href={makeViewPolicyLink(matchers)}
+              />
+            );
+          })}
+        </>
+      ),
+    });
+  }
+
+  if (summary.templates.length > 0) {
+    sections.push({
+      key: 'templates',
+      icon: 'file-alt',
+      label: t('alerting.settings.import.section.templates', 'Templates'),
+      count: summary.templates.length,
+      content: summary.templates.map((name) => <ResourceRow key={name} label={name} href={makeViewTemplatesLink()} />),
+    });
+  }
+
+  if (summary.timeIntervals.length > 0) {
+    sections.push({
+      key: 'time-intervals',
+      icon: 'history',
+      label: t('alerting.settings.import.section.time-intervals', 'Time intervals'),
+      count: summary.timeIntervals.length,
+      content: summary.timeIntervals.map((name) => (
+        <ResourceRow key={name} label={name} href={makeViewTimeIntervalLink(name)} />
+      )),
+    });
+  }
+
+  if (inhibitRules.length > 0) {
+    sections.push({
+      key: 'inhibition-rules',
+      icon: 'shield',
+      label: t('alerting.settings.import.section.inhibition-rules', 'Inhibition rules'),
+      count: inhibitRules.length,
+      // Inhibition rules are raw Alertmanager config with no dedicated management page, so we show
+      // their details inline (source → target, and the labels that must be equal) rather than a link.
+      content: inhibitRules.map((rule, index) => {
+        const source = summarizeMatchRecord(rule.source_match, rule.source_match_re, rule.source_matchers);
+        const target = summarizeMatchRecord(rule.target_match, rule.target_match_re, rule.target_matchers);
+        return (
+          <div key={`${source}|${target}|${index}`} className={styles.row}>
+            <span className={styles.mono}>{source || t('alerting.settings.import.any', 'any')}</span>
+            <Icon name="arrow-right" size="sm" />
+            <span className={styles.mono}>{target || t('alerting.settings.import.any', 'any')}</span>
+            {rule.equal?.length ? (
+              <span className={styles.meta}>
+                <Trans i18nKey="alerting.settings.import.inhibition-equal" values={{ labels: rule.equal.join(', ') }}>
+                  equal: {'{{labels}}'}
+                </Trans>
+              </span>
+            ) : null}
+          </div>
+        );
+      }),
+    });
+  }
+
+  return (
+    <div className={styles.card}>
+      <Stack direction="row" alignItems="center" gap={1}>
+        <Text element="h3" variant="h5">
+          {stagedConfig.identifier}
+        </Text>
+        <Badge
+          color="blue"
+          icon="cloud-upload"
+          text={t('alerting.settings.import.staged-badge', 'Staged · read-only')}
+        />
+      </Stack>
+      <ResourceAccordion sections={sections} />
+    </div>
+  );
+}
+
+interface ResourceRowProps {
+  label: string;
+  meta?: string;
+  href?: string;
+  /** Render the label in the default font instead of monospace (used for the "Default policy" row). */
+  plainLabel?: boolean;
+}
+
+function ResourceRow({ label, meta, href, plainLabel }: ResourceRowProps) {
+  const styles = useStyles2(getStyles);
+  return (
+    <div className={styles.row}>
+      <span className={plainLabel ? styles.plainLabel : styles.mono}>{label}</span>
+      {meta && <span className={styles.meta}>{meta}</span>}
+      <span className={styles.spacer} />
+      {href && (
+        <LinkButton href={href} variant="secondary" size="sm" icon="eye">
+          {t('alerting.settings.import.view', 'View')}
+        </LinkButton>
+      )}
+    </div>
+  );
+}
+
+function ResourceAccordion({ sections }: { sections: AccordionSection[] }) {
+  const styles = useStyles2(getStyles);
+  const [openKeys, setOpenKeys] = useState<Set<string>>(new Set());
+
+  const allOpen = sections.length > 0 && sections.every((section) => openKeys.has(section.key));
+
+  const toggleAll = () => {
+    setOpenKeys(allOpen ? new Set() : new Set(sections.map((section) => section.key)));
+  };
+
+  const toggle = (key: string) => {
+    setOpenKeys((previous) => {
+      const next = new Set(previous);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+      return next;
+    });
+  };
+
+  return (
+    <Stack direction="column" gap={1}>
+      <div className={styles.resourcesHeader}>
+        <Text variant="bodySmall" color="secondary" weight="medium">
+          <Trans i18nKey="alerting.settings.import.resources">Resources</Trans>
+        </Text>
+        <Button
+          variant="secondary"
+          fill="outline"
+          size="sm"
+          icon={allOpen ? 'angle-up' : 'angle-down'}
+          onClick={toggleAll}
+        >
+          {allOpen ? (
+            <Trans i18nKey="alerting.settings.import.collapse-all">Collapse all</Trans>
+          ) : (
+            <Trans i18nKey="alerting.settings.import.expand-all">Expand all</Trans>
+          )}
+        </Button>
+      </div>
+
+      {sections.map((section) => {
+        const isOpen = openKeys.has(section.key);
+        const headerId = `staged-section-${section.key}-header`;
+        const contentId = `staged-section-${section.key}-content`;
+        return (
+          <div key={section.key} className={styles.section}>
+            <button
+              type="button"
+              id={headerId}
+              className={styles.sectionHeader}
+              aria-expanded={isOpen}
+              aria-controls={contentId}
+              onClick={() => toggle(section.key)}
+            >
+              <Icon name={section.icon} size="sm" />
+              <Text variant="bodySmall" weight="medium">
+                {section.label}
+              </Text>
+              <span className={styles.count}>{section.count}</span>
+              <span className={styles.spacer} />
+              <Icon name={isOpen ? 'angle-down' : 'angle-right'} />
+            </button>
+            {isOpen && (
+              <div id={contentId} role="region" aria-labelledby={headerId} className={styles.sectionContent}>
+                {section.content}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </Stack>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  card: css({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(1),
+    padding: theme.spacing(2),
+    border: `1px solid ${theme.colors.border.weak}`,
+    borderRadius: theme.shape.radius.default,
+    background: theme.colors.background.primary,
+  }),
+  resourcesHeader: css({
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginTop: theme.spacing(1),
+  }),
+  section: css({
+    border: `1px solid ${theme.colors.border.weak}`,
+    borderRadius: theme.shape.radius.default,
+    overflow: 'hidden',
+  }),
+  sectionHeader: css({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+    width: '100%',
+    padding: theme.spacing(1, 1.5),
+    background: theme.colors.background.secondary,
+    border: 'none',
+    cursor: 'pointer',
+    textAlign: 'left',
+    color: theme.colors.text.primary,
+  }),
+  sectionContent: css({
+    display: 'flex',
+    flexDirection: 'column',
+    borderTop: `1px solid ${theme.colors.border.weak}`,
+  }),
+  row: css({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+    padding: theme.spacing(1, 1.5),
+    borderTop: `1px solid ${theme.colors.border.weak}`,
+    '&:first-child': {
+      borderTop: 'none',
+    },
+  }),
+  mono: css({
+    fontFamily: theme.typography.fontFamilyMonospace,
+    fontSize: theme.typography.bodySmall.fontSize,
+    color: theme.colors.text.primary,
+  }),
+  plainLabel: css({
+    fontSize: theme.typography.bodySmall.fontSize,
+    color: theme.colors.text.secondary,
+  }),
+  meta: css({
+    fontFamily: theme.typography.fontFamilyMonospace,
+    fontSize: theme.typography.bodySmall.fontSize,
+    color: theme.colors.text.secondary,
+  }),
+  count: css({
+    fontFamily: theme.typography.fontFamilyMonospace,
+    fontSize: theme.typography.bodySmall.fontSize,
+    color: theme.colors.text.secondary,
+  }),
+  spacer: css({
+    flex: 1,
+  }),
+});

--- a/public/app/features/alerting/unified/settings/import/StagedConfiguration.tsx
+++ b/public/app/features/alerting/unified/settings/import/StagedConfiguration.tsx
@@ -5,6 +5,7 @@ import { base64UrlEncode } from '@grafana/alerting';
 import { type GrafanaTheme2, type IconName } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { Alert, Badge, Button, Icon, LinkButton, Stack, Text, useStyles2 } from '@grafana/ui';
+import { type AlertmanagerConfig } from 'app/plugins/datasource/alertmanager/types';
 
 import { GRAFANA_RULES_SOURCE_NAME } from '../../utils/datasource';
 import { makeEditContactPointLink, makeEditTimeIntervalLink } from '../../utils/misc';
@@ -14,7 +15,9 @@ import {
   type StagedExtraConfig,
   encodeRouteMatchersQuery,
   getReceiverIntegrationTypes,
+  getTimeIntervalNames,
   parseStagedAlertmanagerConfig,
+  resolveMergedNames,
   summarizeMatchRecord,
   summarizeRouteMatchers,
   summarizeStagedConfig,
@@ -39,9 +42,17 @@ function makeViewTemplatesLink(): string {
   return createRelativeUrl('/alerting/notifications/templates', GRAFANA_AM);
 }
 
-/** Filter the notification policies tree to a policy by its matchers; unfiltered when there are none. */
-function makeViewPolicyLink(matchers: string): string {
-  return createRelativeUrl('/alerting/routes', matchers ? { ...GRAFANA_AM, queryString: matchers } : GRAFANA_AM);
+/**
+ * Filter the notification policies page to the staged config's own routing tree — the staged import is
+ * exposed as a managed tree named after the config identifier — and, when there are matchers, to a single
+ * policy within it. Without `includeTree` the page lists every tree, live ones included.
+ */
+function makeViewPolicyLink(treeName: string, matchers: string): string {
+  return createRelativeUrl('/alerting/routes', {
+    ...GRAFANA_AM,
+    includeTree: treeName,
+    ...(matchers ? { queryString: matchers } : {}),
+  });
 }
 
 interface AccordionSection {
@@ -54,9 +65,14 @@ interface AccordionSection {
 
 interface Props {
   stagedConfig: StagedExtraConfig;
+  /**
+   * The live Grafana Alertmanager config the staged one is merged against. Needed to work out which staged
+   * resources the backend renames on a name collision, so their View links address the staged copy.
+   */
+  liveConfig?: AlertmanagerConfig;
 }
 
-export function StagedConfiguration({ stagedConfig }: Props) {
+export function StagedConfiguration({ stagedConfig, liveConfig }: Props) {
   const styles = useStyles2(getStyles);
   const config = parseStagedAlertmanagerConfig(stagedConfig.alertmanager_config);
 
@@ -78,6 +94,19 @@ export function StagedConfiguration({ stagedConfig }: Props) {
   const childRoutes = config.route?.routes ?? [];
   const inhibitRules = config.inhibit_rules ?? [];
 
+  // Link targets, which are the post-merge names — they differ from the labels below (the staged config's
+  // own names) whenever a staged resource collides with a live one.
+  const receiverLinkNames = resolveMergedNames(
+    summary.receivers,
+    (liveConfig?.receivers ?? []).map((receiver) => receiver.name),
+    stagedConfig.identifier
+  );
+  const timeIntervalLinkNames = resolveMergedNames(
+    summary.timeIntervals,
+    liveConfig ? getTimeIntervalNames(liveConfig) : [],
+    stagedConfig.identifier
+  );
+
   const sections: AccordionSection[] = [];
 
   if (receivers.length > 0) {
@@ -86,12 +115,12 @@ export function StagedConfiguration({ stagedConfig }: Props) {
       icon: 'comment-alt',
       label: t('alerting.settings.import.section.contact-points', 'Contact points'),
       count: receivers.length,
-      content: receivers.map((receiver) => (
+      content: receivers.map((receiver, index) => (
         <ResourceRow
-          key={receiver.name}
+          key={receiverLinkNames[index]}
           label={receiver.name}
           meta={getReceiverIntegrationTypes(receiver).join(', ')}
-          href={makeViewContactPointLink(receiver.name)}
+          href={makeViewContactPointLink(receiverLinkNames[index])}
         />
       )),
     });
@@ -110,7 +139,7 @@ export function StagedConfiguration({ stagedConfig }: Props) {
             label={t('alerting.settings.import.default-policy', 'Default policy')}
             plainLabel
             meta={config.route?.receiver ?? undefined}
-            href={makeViewPolicyLink('')}
+            href={makeViewPolicyLink(stagedConfig.identifier, '')}
           />
           {childRoutes.map((route, index) => {
             const matchers = summarizeRouteMatchers(route);
@@ -119,7 +148,7 @@ export function StagedConfiguration({ stagedConfig }: Props) {
                 key={`${matchers}|${route.receiver ?? ''}|${index}`}
                 label={matchers || t('alerting.settings.import.no-matchers', '(no matchers)')}
                 meta={route.receiver ? `→ ${route.receiver}` : undefined}
-                href={makeViewPolicyLink(encodeRouteMatchersQuery(route))}
+                href={makeViewPolicyLink(stagedConfig.identifier, encodeRouteMatchersQuery(route))}
               />
             );
           })}
@@ -144,8 +173,12 @@ export function StagedConfiguration({ stagedConfig }: Props) {
       icon: 'history',
       label: t('alerting.settings.import.section.time-intervals', 'Time intervals'),
       count: summary.timeIntervals.length,
-      content: summary.timeIntervals.map((name) => (
-        <ResourceRow key={name} label={name} href={makeViewTimeIntervalLink(name)} />
+      content: summary.timeIntervals.map((name, index) => (
+        <ResourceRow
+          key={timeIntervalLinkNames[index]}
+          label={name}
+          href={makeViewTimeIntervalLink(timeIntervalLinkNames[index])}
+        />
       )),
     });
   }

--- a/public/app/features/alerting/unified/settings/import/StagedConfiguration.tsx
+++ b/public/app/features/alerting/unified/settings/import/StagedConfiguration.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { css, cx } from '@emotion/css';
 import { useState } from 'react';
 
 import { base64UrlEncode } from '@grafana/alerting';
@@ -128,17 +128,17 @@ export function StagedConfiguration({ stagedConfig, liveConfig }: Props) {
 
   if (summary.hasRoutingTree) {
     sections.push({
-      key: 'notification-policies',
+      key: 'notification-policy',
       icon: 'sitemap',
-      label: t('alerting.settings.import.section.notification-policies', 'Notification policies'),
-      // Root "Default policy" row + the direct child routes we render below (nested routes aren't listed).
-      count: childRoutes.length + 1,
+      // One import contributes exactly one routing tree — the backend adds it as a managed route named after
+      // the identifier rather than merging it into the default policy.
+      label: t('alerting.settings.import.section.notification-policy', 'Notification policy'),
+      count: 1,
       content: (
         <>
           <ResourceRow
-            label={t('alerting.settings.import.default-policy', 'Default policy')}
-            plainLabel
-            meta={config.route?.receiver ?? undefined}
+            label={stagedConfig.identifier}
+            meta={<RoutingTreeMeta receiver={config.route?.receiver} routeCount={childRoutes.length} />}
             href={makeViewPolicyLink(stagedConfig.identifier, '')}
           />
           {childRoutes.map((route, index) => {
@@ -146,6 +146,7 @@ export function StagedConfiguration({ stagedConfig, liveConfig }: Props) {
             return (
               <ResourceRow
                 key={`${matchers}|${route.receiver ?? ''}|${index}`}
+                indented
                 label={matchers || t('alerting.settings.import.no-matchers', '(no matchers)')}
                 meta={route.receiver ? `→ ${route.receiver}` : undefined}
                 href={makeViewPolicyLink(stagedConfig.identifier, encodeRouteMatchersQuery(route))}
@@ -229,19 +230,45 @@ export function StagedConfiguration({ stagedConfig, liveConfig }: Props) {
   );
 }
 
-interface ResourceRowProps {
-  label: string;
-  meta?: string;
-  href?: string;
-  /** Render the label in the default font instead of monospace (used for the "Default policy" row). */
-  plainLabel?: boolean;
+interface RoutingTreeMetaProps {
+  /** Nullable to match `Route['receiver']`, which the Alertmanager config may omit or null out. */
+  receiver?: string | null;
+  routeCount: number;
 }
 
-function ResourceRow({ label, meta, href, plainLabel }: ResourceRowProps) {
+/**
+ * Contact point and size of the imported routing tree. Counts direct children only, matching what the
+ * notification policies page shows for the tree, so the number doesn't change when View is followed.
+ */
+function RoutingTreeMeta({ receiver, routeCount }: RoutingTreeMetaProps) {
+  const receiverPrefix = receiver ? `→ ${receiver} · ` : '';
+  return (
+    <>
+      {receiverPrefix}
+      <Trans
+        i18nKey="alerting.settings.import.policy-tree-routes"
+        count={routeCount}
+        tOptions={{ defaultValue_one: '{{count}} route', defaultValue_other: '{{count}} routes' }}
+      >
+        {'{{count}}'} route
+      </Trans>
+    </>
+  );
+}
+
+interface ResourceRowProps {
+  label: string;
+  meta?: React.ReactNode;
+  href?: string;
+  /** Mark the row as a sub-policy of the row above it. */
+  indented?: boolean;
+}
+
+function ResourceRow({ label, meta, href, indented }: ResourceRowProps) {
   const styles = useStyles2(getStyles);
   return (
-    <div className={styles.row}>
-      <span className={plainLabel ? styles.plainLabel : styles.mono}>{label}</span>
+    <div className={cx(styles.row, indented && styles.childRow)}>
+      <span className={styles.mono}>{label}</span>
       {meta && <span className={styles.meta}>{meta}</span>}
       <span className={styles.spacer} />
       {href && (
@@ -378,14 +405,30 @@ const getStyles = (theme: GrafanaTheme2) => ({
       borderTop: 'none',
     },
   }),
+  childRow: css({
+    position: 'relative',
+    paddingLeft: theme.spacing(4),
+    '&::before': {
+      content: '""',
+      position: 'absolute',
+      left: theme.spacing(2),
+      top: 0,
+      bottom: 0,
+      borderLeft: `1px solid ${theme.colors.border.weak}`,
+    },
+    '&::after': {
+      content: '""',
+      position: 'absolute',
+      left: theme.spacing(2),
+      top: '50%',
+      width: theme.spacing(1),
+      borderTop: `1px solid ${theme.colors.border.weak}`,
+    },
+  }),
   mono: css({
     fontFamily: theme.typography.fontFamilyMonospace,
     fontSize: theme.typography.bodySmall.fontSize,
     color: theme.colors.text.primary,
-  }),
-  plainLabel: css({
-    fontSize: theme.typography.bodySmall.fontSize,
-    color: theme.colors.text.secondary,
   }),
   meta: css({
     fontFamily: theme.typography.fontFamilyMonospace,

--- a/public/app/features/alerting/unified/settings/import/StagedConfiguration.tsx
+++ b/public/app/features/alerting/unified/settings/import/StagedConfiguration.tsx
@@ -12,6 +12,7 @@ import { createRelativeUrl } from '../../utils/url';
 
 import {
   type StagedExtraConfig,
+  encodeRouteMatchersQuery,
   getReceiverIntegrationTypes,
   parseStagedAlertmanagerConfig,
   summarizeMatchRecord,
@@ -40,7 +41,7 @@ function makeViewTemplatesLink(): string {
 
 /** Filter the notification policies tree to a policy by its matchers; unfiltered when there are none. */
 function makeViewPolicyLink(matchers: string): string {
-  return createRelativeUrl('/alerting/routes', matchers ? { queryString: matchers } : {});
+  return createRelativeUrl('/alerting/routes', matchers ? { ...GRAFANA_AM, queryString: matchers } : GRAFANA_AM);
 }
 
 interface AccordionSection {
@@ -118,7 +119,7 @@ export function StagedConfiguration({ stagedConfig }: Props) {
                 key={`${matchers}|${route.receiver ?? ''}|${index}`}
                 label={matchers || t('alerting.settings.import.no-matchers', '(no matchers)')}
                 meta={route.receiver ? `→ ${route.receiver}` : undefined}
-                href={makeViewPolicyLink(matchers)}
+                href={makeViewPolicyLink(encodeRouteMatchersQuery(route))}
               />
             );
           })}

--- a/public/app/features/alerting/unified/settings/import/stagedConfig.test.ts
+++ b/public/app/features/alerting/unified/settings/import/stagedConfig.test.ts
@@ -1,0 +1,106 @@
+import { MatcherOperator } from 'app/plugins/datasource/alertmanager/types';
+
+import {
+  getReceiverIntegrationTypes,
+  parseStagedAlertmanagerConfig,
+  summarizeMatchRecord,
+  summarizeRouteMatchers,
+  summarizeStagedConfig,
+} from './stagedConfig';
+
+describe('parseStagedAlertmanagerConfig', () => {
+  it('returns undefined for empty input', () => {
+    expect(parseStagedAlertmanagerConfig(undefined)).toBeUndefined();
+    expect(parseStagedAlertmanagerConfig('')).toBeUndefined();
+  });
+
+  it('returns undefined for invalid YAML', () => {
+    expect(parseStagedAlertmanagerConfig('foo: [bar')).toBeUndefined();
+  });
+
+  it('parses a valid config', () => {
+    const config = parseStagedAlertmanagerConfig('route:\n  receiver: default\nreceivers:\n  - name: default');
+    expect(config?.receivers?.[0].name).toBe('default');
+  });
+});
+
+describe('summarizeStagedConfig', () => {
+  it('summarizes resources and preserves receiver order (not alphabetised)', () => {
+    const summary = summarizeStagedConfig({
+      receivers: [{ name: 'zeta' }, { name: 'alpha' }],
+      route: {
+        receiver: 'zeta',
+        routes: [{ receiver: 'alpha' }, { receiver: 'zeta', routes: [{ receiver: 'alpha' }] }],
+      },
+      templates: ['t1'],
+      time_intervals: [{ name: 'weekends', time_intervals: [] }],
+      mute_time_intervals: [{ name: 'holidays', time_intervals: [] }],
+      inhibit_rules: [{ equal: ['alertname'] }],
+    });
+
+    expect(summary.receivers).toEqual(['zeta', 'alpha']);
+    expect(summary.hasRoutingTree).toBe(true);
+    expect(summary.templates).toEqual(['t1']);
+    expect(summary.timeIntervals).toEqual(['weekends', 'holidays']);
+    expect(summary.inhibitionRuleCount).toBe(1);
+  });
+
+  it('falls back to template file names when the config has no templates list', () => {
+    const summary = summarizeStagedConfig({ receivers: [] }, { 'file.tmpl': '...' });
+    expect(summary.templates).toEqual(['file.tmpl']);
+  });
+});
+
+describe('summarizeRouteMatchers', () => {
+  it('prefers object_matchers', () => {
+    expect(summarizeRouteMatchers({ object_matchers: [['team', MatcherOperator.equal, 'platform']] })).toBe(
+      'team=platform'
+    );
+  });
+
+  it('falls back to matchers, then match', () => {
+    expect(summarizeRouteMatchers({ matchers: ['team=data'] })).toBe('team=data');
+    expect(summarizeRouteMatchers({ match: { severity: 'critical' } })).toBe('severity=critical');
+  });
+
+  it('includes regex match_re entries', () => {
+    expect(summarizeRouteMatchers({ match_re: { team: 'plat.*' } })).toBe('team=~plat.*');
+  });
+
+  it('returns an empty string when there are no matchers', () => {
+    expect(summarizeRouteMatchers({})).toBe('');
+  });
+});
+
+describe('getReceiverIntegrationTypes', () => {
+  it('maps *_configs keys to human-readable labels', () => {
+    expect(getReceiverIntegrationTypes({ name: 'r', pagerduty_configs: [{}], slack_configs: [{}] })).toEqual([
+      'PagerDuty',
+      'Slack',
+    ]);
+  });
+
+  it('falls back to the raw base name for unknown integrations', () => {
+    expect(getReceiverIntegrationTypes({ name: 'r', custom_configs: [{}] })).toEqual(['custom']);
+  });
+
+  it('returns an empty array when the receiver has no integrations', () => {
+    expect(getReceiverIntegrationTypes({ name: 'r' })).toEqual([]);
+  });
+});
+
+describe('summarizeMatchRecord', () => {
+  it('combines exact and regex matches', () => {
+    expect(summarizeMatchRecord({ severity: 'critical' }, { team: 'plat.*' })).toBe('severity=critical, team=~plat.*');
+  });
+
+  it('includes Prometheus-style matcher lists (source_matchers/target_matchers)', () => {
+    expect(summarizeMatchRecord(undefined, undefined, ['severity=critical', 'source=infra'])).toBe(
+      'severity=critical, source=infra'
+    );
+  });
+
+  it('returns an empty string when nothing is set', () => {
+    expect(summarizeMatchRecord()).toBe('');
+  });
+});

--- a/public/app/features/alerting/unified/settings/import/stagedConfig.test.ts
+++ b/public/app/features/alerting/unified/settings/import/stagedConfig.test.ts
@@ -1,6 +1,9 @@
 import { MatcherOperator } from 'app/plugins/datasource/alertmanager/types';
 
+import { parsePromQLStyleMatcherLooseSafe } from '../../utils/matchers';
+
 import {
+  encodeRouteMatchersQuery,
   getReceiverIntegrationTypes,
   parseStagedAlertmanagerConfig,
   summarizeMatchRecord,
@@ -69,6 +72,29 @@ describe('summarizeRouteMatchers', () => {
 
   it('returns an empty string when there are no matchers', () => {
     expect(summarizeRouteMatchers({})).toBe('');
+  });
+});
+
+describe('encodeRouteMatchersQuery', () => {
+  it('quotes values so the routes filter parses them back correctly', () => {
+    const query = encodeRouteMatchersQuery({ object_matchers: [['team', MatcherOperator.equal, 'platform']] });
+    expect(query).toBe('team="platform"');
+    expect(parsePromQLStyleMatcherLooseSafe(query)).toEqual([
+      { name: 'team', value: 'platform', isRegex: false, isEqual: true },
+    ]);
+  });
+
+  it('keeps values containing commas intact through the filter parser', () => {
+    // Unquoted, the filter would split on the comma and drop the matcher; quoting keeps it as one value.
+    const query = encodeRouteMatchersQuery({ object_matchers: [['region', MatcherOperator.equal, 'us-east,us-west']] });
+    expect(query).toBe('region="us-east,us-west"');
+    expect(parsePromQLStyleMatcherLooseSafe(query)).toEqual([
+      { name: 'region', value: 'us-east,us-west', isRegex: false, isEqual: true },
+    ]);
+  });
+
+  it('returns an empty string when there are no matchers', () => {
+    expect(encodeRouteMatchersQuery({})).toBe('');
   });
 });
 

--- a/public/app/features/alerting/unified/settings/import/stagedConfig.test.ts
+++ b/public/app/features/alerting/unified/settings/import/stagedConfig.test.ts
@@ -6,6 +6,7 @@ import {
   encodeRouteMatchersQuery,
   getReceiverIntegrationTypes,
   parseStagedAlertmanagerConfig,
+  resolveMergedNames,
   summarizeMatchRecord,
   summarizeRouteMatchers,
   summarizeStagedConfig,
@@ -24,6 +25,33 @@ describe('parseStagedAlertmanagerConfig', () => {
   it('parses a valid config', () => {
     const config = parseStagedAlertmanagerConfig('route:\n  receiver: default\nreceivers:\n  - name: default');
     expect(config?.receivers?.[0].name).toBe('default');
+  });
+});
+
+describe('resolveMergedNames', () => {
+  it('keeps names the live config does not already own', () => {
+    expect(resolveMergedNames(['slack', 'pagerduty'], ['email'], 'prom-prod')).toEqual(['slack', 'pagerduty']);
+  });
+
+  it('suffixes names that collide with the live config', () => {
+    expect(resolveMergedNames(['default', 'slack'], ['default'], 'prom-prod')).toEqual(['default_prom-prod', 'slack']);
+  });
+
+  it('appends a counter when the suffixed name is also taken', () => {
+    expect(resolveMergedNames(['default'], ['default', 'default_prom-prod'], 'prom-prod')).toEqual([
+      'default_prom-prod_01',
+    ]);
+    expect(
+      resolveMergedNames(['default'], ['default', 'default_prom-prod', 'default_prom-prod_01'], 'prom-prod')
+    ).toEqual(['default_prom-prod_02']);
+  });
+
+  it('renames only the later of two staged resources sharing a name', () => {
+    expect(resolveMergedNames(['dupe', 'dupe'], [], 'prom-prod')).toEqual(['dupe', 'dupe_prom-prod']);
+  });
+
+  it('returns names unchanged when there is no live config to collide with', () => {
+    expect(resolveMergedNames(['a', 'b'], [], 'prom-prod')).toEqual(['a', 'b']);
   });
 });
 

--- a/public/app/features/alerting/unified/settings/import/stagedConfig.ts
+++ b/public/app/features/alerting/unified/settings/import/stagedConfig.ts
@@ -1,0 +1,156 @@
+import { load } from 'js-yaml';
+
+import { type MuteTimeInterval, type Receiver, type Route } from 'app/plugins/datasource/alertmanager/types';
+
+import { normalizeMatchers } from '../../utils/matchers';
+
+/**
+ * The single staged Alertmanager configuration, as carried on `AlertManagerCortexConfig.extra_config[]`.
+ * Declared locally because the shared `ExtraConfiguration` type doesn't (yet) model the config payload.
+ */
+export interface StagedExtraConfig {
+  identifier: string;
+  /** The imported Alertmanager configuration, as a YAML string. */
+  alertmanager_config?: string;
+  template_files?: Record<string, string>;
+}
+
+export function isStagedExtraConfig(value: unknown): value is StagedExtraConfig {
+  return typeof value === 'object' && value !== null && 'identifier' in value;
+}
+
+/**
+ * An inhibition rule supporting both the legacy `*_match`/`*_match_re` maps and the modern
+ * Prometheus-style `*_matchers` lists. Declared locally so we don't extend the shared `InhibitRule`.
+ */
+export interface StagedInhibitRule {
+  source_match?: Record<string, string>;
+  source_match_re?: Record<string, string>;
+  source_matchers?: string[];
+  target_match?: Record<string, string>;
+  target_match_re?: Record<string, string>;
+  target_matchers?: string[];
+  equal?: string[];
+}
+
+/**
+ * The parsed staged Alertmanager config. Mirrors the shared `AlertmanagerConfig` for the fields we read,
+ * but uses the local {@link StagedInhibitRule} so we can surface `*_matchers` without touching shared types.
+ */
+export interface StagedAlertmanagerConfig {
+  receivers?: Receiver[];
+  route?: Route;
+  templates?: string[];
+  time_intervals?: MuteTimeInterval[];
+  mute_time_intervals?: MuteTimeInterval[];
+  inhibit_rules?: StagedInhibitRule[];
+}
+
+/** Pretty labels for the common Alertmanager `*_configs` integration keys. */
+const INTEGRATION_LABELS: Record<string, string> = {
+  pagerduty: 'PagerDuty',
+  slack: 'Slack',
+  email: 'Email',
+  webhook: 'Webhook',
+  opsgenie: 'Opsgenie',
+  victorops: 'VictorOps',
+  pushover: 'Pushover',
+  wechat: 'WeChat',
+  webex: 'Webex',
+  discord: 'Discord',
+  telegram: 'Telegram',
+  sns: 'SNS',
+  msteams: 'Microsoft Teams',
+};
+
+const CONFIGS_SUFFIX = '_configs';
+
+export interface StagedConfigSummary {
+  /** Contact point (receiver) names, kept in configuration order — Alertmanager contact points are not alphabetised. */
+  receivers: string[];
+  hasRoutingTree: boolean;
+  templates: string[];
+  timeIntervals: string[];
+  inhibitionRuleCount: number;
+}
+
+/**
+ * Parse the imported Alertmanager configuration (a YAML string carried on the staged config).
+ * Returns undefined when the input is empty or cannot be parsed into an object.
+ */
+function isStagedAlertmanagerConfig(value: unknown): value is StagedAlertmanagerConfig {
+  return typeof value === 'object' && value !== null;
+}
+
+export function parseStagedAlertmanagerConfig(yamlConfig: string | undefined): StagedAlertmanagerConfig | undefined {
+  if (!yamlConfig) {
+    return undefined;
+  }
+
+  try {
+    const parsed = load(yamlConfig);
+    return isStagedAlertmanagerConfig(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function summarizeStagedConfig(
+  config: StagedAlertmanagerConfig,
+  templateFiles?: Record<string, string>
+): StagedConfigSummary {
+  const receivers = (config.receivers ?? []).map((receiver) => receiver.name);
+  const timeIntervals = [...(config.time_intervals ?? []), ...(config.mute_time_intervals ?? [])].map(
+    (interval) => interval.name
+  );
+  // Grafana template groups are the imported `template_files` entries; the AM config's `templates`
+  // field is only a list of file globs, so prefer the file names and fall back to the globs.
+  const templateFileNames = Object.keys(templateFiles ?? {});
+  const templates = templateFileNames.length > 0 ? templateFileNames : (config.templates ?? []);
+
+  return {
+    receivers,
+    hasRoutingTree: Boolean(config.route),
+    templates,
+    timeIntervals,
+    inhibitionRuleCount: (config.inhibit_rules ?? []).length,
+  };
+}
+
+/** Integration types configured on a receiver, derived from its `*_configs` keys (e.g. "PagerDuty", "Slack"). */
+export function getReceiverIntegrationTypes(receiver: Receiver): string[] {
+  return Object.keys(receiver)
+    .filter((key) => key.endsWith(CONFIGS_SUFFIX))
+    .map((key) => {
+      const base = key.slice(0, -CONFIGS_SUFFIX.length);
+      return INTEGRATION_LABELS[base] ?? base;
+    });
+}
+
+/**
+ * Render one side of an inhibition rule as a compact, human-readable matcher string. Supports both the
+ * legacy `*_match`/`*_match_re` maps and the modern Prometheus-style `*_matchers` list.
+ */
+export function summarizeMatchRecord(
+  match?: Record<string, string>,
+  matchRe?: Record<string, string>,
+  matchers?: string[]
+): string {
+  const exact = Object.entries(match ?? {}).map(([name, value]) => `${name}=${value}`);
+  const regex = Object.entries(matchRe ?? {}).map(([name, value]) => `${name}=~${value}`);
+  return [...exact, ...regex, ...(matchers ?? [])].join(', ');
+}
+
+/**
+ * Human-readable matcher summary for a route. Reuses {@link normalizeMatchers} so every matcher
+ * representation (matchers, object_matchers, match, match_re) is covered; returns '' on malformed input.
+ */
+export function summarizeRouteMatchers(route: Route): string {
+  try {
+    return normalizeMatchers(route)
+      .map(([name, operator, value]) => `${name}${operator}${value}`)
+      .join(', ');
+  } catch {
+    return '';
+  }
+}

--- a/public/app/features/alerting/unified/settings/import/stagedConfig.ts
+++ b/public/app/features/alerting/unified/settings/import/stagedConfig.ts
@@ -23,7 +23,7 @@ export function isStagedExtraConfig(value: unknown): value is StagedExtraConfig 
  * An inhibition rule supporting both the legacy `*_match`/`*_match_re` maps and the modern
  * Prometheus-style `*_matchers` lists. Declared locally so we don't extend the shared `InhibitRule`.
  */
-export interface StagedInhibitRule {
+interface StagedInhibitRule {
   source_match?: Record<string, string>;
   source_match_re?: Record<string, string>;
   source_matchers?: string[];

--- a/public/app/features/alerting/unified/settings/import/stagedConfig.ts
+++ b/public/app/features/alerting/unified/settings/import/stagedConfig.ts
@@ -2,7 +2,7 @@ import { load } from 'js-yaml';
 
 import { type MuteTimeInterval, type Receiver, type Route } from 'app/plugins/datasource/alertmanager/types';
 
-import { normalizeMatchers } from '../../utils/matchers';
+import { encodeMatcher, normalizeMatchers } from '../../utils/matchers';
 
 /**
  * The single staged Alertmanager configuration, as carried on `AlertManagerCortexConfig.extra_config[]`.
@@ -150,6 +150,21 @@ export function summarizeRouteMatchers(route: Route): string {
     return normalizeMatchers(route)
       .map(([name, operator, value]) => `${name}${operator}${value}`)
       .join(', ');
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Route matchers encoded as a PromQL-style string safe for the notification-policies `queryString` filter.
+ * Unlike {@link summarizeRouteMatchers} (which produces a readable label), values are quoted so matchers
+ * containing commas or other reserved characters survive the filter's comma-splitting parser.
+ */
+export function encodeRouteMatchersQuery(route: Route): string {
+  try {
+    return normalizeMatchers(route)
+      .map(([name, operator, value]) => encodeMatcher({ name, operator, value }))
+      .join(',');
   } catch {
     return '';
   }

--- a/public/app/features/alerting/unified/settings/import/stagedConfig.ts
+++ b/public/app/features/alerting/unified/settings/import/stagedConfig.ts
@@ -95,14 +95,51 @@ export function parseStagedAlertmanagerConfig(yamlConfig: string | undefined): S
   }
 }
 
+/** Time interval names in an Alertmanager config; they can arrive under either of two fields. */
+export function getTimeIntervalNames(config: {
+  time_intervals?: MuteTimeInterval[];
+  mute_time_intervals?: MuteTimeInterval[];
+}): string[] {
+  return [...(config.time_intervals ?? []), ...(config.mute_time_intervals ?? [])].map((interval) => interval.name);
+}
+
+/**
+ * The names the backend addresses staged resources under. A staged name already owned by the live config — or
+ * by an earlier staged resource of the same kind — gets suffixed with `_<identifier>` (then `_<identifier>_NN`),
+ * and the staged copy is only reachable under that suffixed name. Mirrors the backend merge so deep links
+ * open the staged resource rather than the live one it collided with.
+ *
+ * Names are returned positionally so callers can pair them with the staged resources they render.
+ */
+export function resolveMergedNames(staged: string[], live: string[], identifier: string): string[] {
+  // Who owns each name: -1 for the live config, otherwise the index of the staged resource holding it.
+  const owner = new Map<string, number>();
+  live.forEach((name) => owner.set(name, -1));
+  staged.forEach((name, index) => {
+    if (!owner.has(name)) {
+      owner.set(name, index);
+    }
+  });
+
+  return staged.map((name, index) => {
+    if (owner.get(name) === index) {
+      return name;
+    }
+    let candidate = `${name}_${identifier}`;
+    for (let attempt = 1; owner.has(candidate); attempt++) {
+      candidate = `${name}_${identifier}_${String(attempt).padStart(2, '0')}`;
+    }
+    owner.set(candidate, index);
+    return candidate;
+  });
+}
+
 export function summarizeStagedConfig(
   config: StagedAlertmanagerConfig,
   templateFiles?: Record<string, string>
 ): StagedConfigSummary {
   const receivers = (config.receivers ?? []).map((receiver) => receiver.name);
-  const timeIntervals = [...(config.time_intervals ?? []), ...(config.mute_time_intervals ?? [])].map(
-    (interval) => interval.name
-  );
+  const timeIntervals = getTimeIntervalNames(config);
   // Grafana template groups are the imported `template_files` entries; the AM config's `templates`
   // field is only a list of file globs, so prefer the file names and fall back to the globs.
   const templateFileNames = Object.keys(templateFiles ?? {});

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -3291,6 +3291,9 @@
         "title": "Auto-sync configuration"
       },
       "import": {
+        "any": "any",
+        "collapse-all": "Collapse all",
+        "default-policy": "Default policy",
         "empty-body": "Import an Alertmanager configuration to stage it here as a safe, reversible copy. Review what it contains, then promote it into your live Grafana Alertmanager when you're ready.",
         "empty-cta": "Import Alertmanager configuration",
         "empty-learn-more": "Learn more about importing configurations",
@@ -3298,9 +3301,24 @@
         "error-body": "The request to the Alerting API failed. Check your connection and try again.",
         "error-retry": "Retry",
         "error-title": "Couldn't load imported configurations",
+        "expand-all": "Expand all",
+        "inhibition-equal": "equal: {{labels}}",
         "loading": "Loading imported configurations…",
+        "no-matchers": "(no matchers)",
+        "parse-error-body": "The imported Alertmanager configuration could not be parsed.",
+        "parse-error-title": "Couldn't read the staged configuration",
+        "resources": "Resources",
+        "section": {
+          "contact-points": "Contact points",
+          "inhibition-rules": "Inhibition rules",
+          "notification-policies": "Notification policies",
+          "templates": "Templates",
+          "time-intervals": "Time intervals"
+        },
+        "staged-badge": "Staged · read-only",
         "staged-description": "A read-only, reversible copy of an imported Alertmanager config. Promote it to merge into your live config, or revert to remove it.",
-        "staged-title": "Staged configuration"
+        "staged-title": "Staged configuration",
+        "view": "View"
       },
       "tabs": {
         "alert-managers": "Alert managers",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -3293,7 +3293,6 @@
       "import": {
         "any": "any",
         "collapse-all": "Collapse all",
-        "default-policy": "Default policy",
         "empty-body": "Import an Alertmanager configuration to stage it here as a safe, reversible copy. Review what it contains, then promote it into your live Grafana Alertmanager when you're ready.",
         "empty-cta": "Import Alertmanager configuration",
         "empty-learn-more": "Learn more about importing configurations",
@@ -3307,11 +3306,13 @@
         "no-matchers": "(no matchers)",
         "parse-error-body": "The imported Alertmanager configuration could not be parsed.",
         "parse-error-title": "Couldn't read the staged configuration",
+        "policy-tree-routes_one": "{{count}} route",
+        "policy-tree-routes_other": "{{count}} routes",
         "resources": "Resources",
         "section": {
           "contact-points": "Contact points",
           "inhibition-rules": "Inhibition rules",
-          "notification-policies": "Notification policies",
+          "notification-policy": "Notification policy",
           "templates": "Templates",
           "time-intervals": "Time intervals"
         },


### PR DESCRIPTION
**What is this feature?**

This PR adds a section in the import tab in the alerting settings page where the user can see a summary of their staged alertmanager import.


https://github.com/user-attachments/assets/c8902c26-b0f3-4fc7-867e-d1ebf50308d3


**Why do we need this feature?**

Alerting users need to have an overview of their ongoing import so in the future they can promote that import (merging them with their grafana alertmanager) or easily remove it so they can re-start the import process.

**Who is this feature for?**

Alerting users

**Which issue(s) does this PR fix?**:

Relates to https://github.com/grafana/alerting-squad/issues/1863

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
