### PR TITLE
Plugins: Fix gap below the plugin catalog list

### DIFF
--- a/public/app/features/connections/components/AdvisorRedirectNotice/AdvisorRedirectNotice.tsx
+++ b/public/app/features/connections/components/AdvisorRedirectNotice/AdvisorRedirectNotice.tsx
@@ -9,6 +9,11 @@ import { Alert, LinkButton, useStyles2 } from '@grafana/ui';
 import { contextSrv } from 'app/core/services/context_srv';
 
 const getStyles = (theme: GrafanaTheme2) => ({
+  alert: css({
+    // Alert defaults to flexGrow: 1, which makes the notice absorb free space
+    // when the page content is a flex column (e.g. the plugins catalog)
+    flexGrow: 0,
+  }),
   alertContent: css({
     display: 'flex',
     flexDirection: 'row',
@@ -51,6 +56,7 @@ export function AdvisorRedirectNotice() {
     <Alert
       severity="info"
       title=""
+      className={styles.alert}
       onRemove={() => {
         userStorage.setItem('showNotice', 'false');
         setShowNotice(false);

--- a/public/app/features/connections/pages/AddNewConnectionPage.tsx
+++ b/public/app/features/connections/pages/AddNewConnectionPage.tsx
@@ -16,6 +16,7 @@ const getStyles = () => ({
     overflow: 'hidden',
     '[class*="page-inner"]': {
       minHeight: 0,
+      paddingBottom: 0,
     },
     '[class*="page-content"]': {
       minHeight: 0,

--- a/public/app/features/connections/tabs/ConnectData/ConnectDataLegacy.tsx
+++ b/public/app/features/connections/tabs/ConnectData/ConnectDataLegacy.tsx
@@ -29,7 +29,8 @@ const getStyles = (theme: GrafanaTheme2) => ({
     borderBottom: `1px solid ${theme.colors.border.weak}`,
   }),
   contentWrap: css({
-    height: 'calc(100vh - 350px)',
+    flex: 1,
+    minHeight: 0,
     overflowY: 'auto',
   }),
   spacer: css({

--- a/public/app/features/connections/tabs/ConnectData/ConnectDataLegacy.tsx
+++ b/public/app/features/connections/tabs/ConnectData/ConnectDataLegacy.tsx
@@ -32,12 +32,10 @@ const getStyles = (theme: GrafanaTheme2) => ({
     flex: 1,
     minHeight: 0,
     overflowY: 'auto',
-    // bleed over the page-inner bottom padding so the list clips at the page edge
-    // instead of leaving a visible band below the cards
-    marginBottom: theme.spacing(-2),
+    // page-inner bottom padding is removed by the hosting page so the list
+    // clips at the page edge; keep breathing room at the end of the scroll
     paddingBottom: theme.spacing(2),
     [theme.breakpoints.up('md')]: {
-      marginBottom: theme.spacing(-4),
       paddingBottom: theme.spacing(4),
     },
   }),

--- a/public/app/features/connections/tabs/ConnectData/ConnectDataLegacy.tsx
+++ b/public/app/features/connections/tabs/ConnectData/ConnectDataLegacy.tsx
@@ -32,6 +32,14 @@ const getStyles = (theme: GrafanaTheme2) => ({
     flex: 1,
     minHeight: 0,
     overflowY: 'auto',
+    // bleed over the page-inner bottom padding so the list clips at the page edge
+    // instead of leaving a visible band below the cards
+    marginBottom: theme.spacing(-2),
+    paddingBottom: theme.spacing(2),
+    [theme.breakpoints.up('md')]: {
+      marginBottom: theme.spacing(-4),
+      paddingBottom: theme.spacing(4),
+    },
   }),
   spacer: css({
     height: theme.spacing(2),

--- a/public/app/features/plugins/admin/pages/Browse.tsx
+++ b/public/app/features/plugins/admin/pages/Browse.tsx
@@ -167,6 +167,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     overflow: 'hidden',
     '[class*="page-inner"]': {
       minHeight: 0,
+      paddingBottom: 0,
     },
     '[class*="page-content"]': {
       minHeight: 0,
@@ -184,12 +185,10 @@ const getStyles = (theme: GrafanaTheme2) => ({
     flex: 1,
     minHeight: 0,
     overflowY: 'auto',
-    // bleed over the page-inner bottom padding so the list clips at the page edge
-    // instead of leaving a visible band below the cards
-    marginBottom: theme.spacing(-2),
+    // page-inner bottom padding is removed above so the list clips at the page
+    // edge; keep breathing room at the end of the scroll instead
     paddingBottom: theme.spacing(2),
     [theme.breakpoints.up('md')]: {
-      marginBottom: theme.spacing(-4),
       paddingBottom: theme.spacing(4),
     },
   }),

--- a/public/app/features/plugins/admin/pages/Browse.tsx
+++ b/public/app/features/plugins/admin/pages/Browse.tsx
@@ -165,6 +165,14 @@ const getStyles = (theme: GrafanaTheme2) => ({
   pageContainer: css({
     height: '100vh',
     overflow: 'hidden',
+    '[class*="page-inner"]': {
+      minHeight: 0,
+    },
+    '[class*="page-content"]': {
+      minHeight: 0,
+      display: 'flex',
+      flexDirection: 'column',
+    },
   }),
   searchContainer: css({
     paddingTop: theme.spacing(0.5),
@@ -173,7 +181,8 @@ const getStyles = (theme: GrafanaTheme2) => ({
     marginBottom: theme.spacing(3),
   }),
   listWrap: css({
-    height: 'calc(100vh - 350px)',
+    flex: 1,
+    minHeight: 0,
     overflowY: 'auto',
   }),
   actionBar: css({

--- a/public/app/features/plugins/admin/pages/Browse.tsx
+++ b/public/app/features/plugins/admin/pages/Browse.tsx
@@ -184,6 +184,14 @@ const getStyles = (theme: GrafanaTheme2) => ({
     flex: 1,
     minHeight: 0,
     overflowY: 'auto',
+    // bleed over the page-inner bottom padding so the list clips at the page edge
+    // instead of leaving a visible band below the cards
+    marginBottom: theme.spacing(-2),
+    paddingBottom: theme.spacing(2),
+    [theme.breakpoints.up('md')]: {
+      marginBottom: theme.spacing(-4),
+      paddingBottom: theme.spacing(4),
+    },
   }),
   actionBar: css({
     [theme.breakpoints.up('xl')]: {


### PR DESCRIPTION
The plugin catalog list (and the legacy Add new connection list) sits in a scroll container sized with a hardcoded `height: calc(100vh - 350px)`. The 350px estimate of the chrome above the list is too large, so there is a dead gap between the last visible cards and the bottom of the page. It also breaks the other way: on narrow windows where the filter row wraps, the header is taller than 350px and the bottom of the list gets clipped.

This replaces the magic number with flex sizing. The page content becomes a flex column (same pattern AddNewConnectionPage already uses for the sidebar variant) and the list wrapper gets `flex: 1` with `min-height: 0`, so it always fills exactly the remaining space. The pinned search behavior from #109903 is unchanged.