### PR TITLE
Annotations: pass subject identity for proxied requests

### DIFF
--- a/pkg/services/annotations/annotationsapi/api_client.go
+++ b/pkg/services/annotations/annotationsapi/api_client.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 
 	authnlib "github.com/grafana/authlib/authn"
+	claims "github.com/grafana/authlib/types"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
 	"github.com/grafana/grafana/pkg/setting"
@@ -299,10 +300,24 @@ func (rt *bearerTokenExchangeRT) RoundTrip(req *http.Request) (*http.Response, e
 		return nil, fmt.Errorf("resolving requester for token exchange: %w", err)
 	}
 
-	resp, err := rt.exchanger.Exchange(ctx, authnlib.TokenExchangeRequest{
+	namespace := rt.nsMapper(requester.GetOrgID())
+
+	exchangeReq := authnlib.TokenExchangeRequest{
 		Audiences: []string{annotationServerAudience},
-		Namespace: rt.nsMapper(requester.GetOrgID()),
-	})
+		Namespace: namespace,
+	}
+
+	// Authenticate with OBO, when possible, so the new API properly attributes annotations.
+	if requester.IsIdentityType(claims.TypeUser, claims.TypeServiceAccount) {
+		exchangeReq.Subject = &authnlib.TokenExchangeSubject{
+			Sub:        requester.GetSubject(),
+			Identifier: requester.GetIdentifier(),
+			Type:       string(requester.GetIdentityType()),
+			Namespace:  namespace,
+		}
+	}
+
+	resp, err := rt.exchanger.Exchange(ctx, exchangeReq)
 	if err != nil {
 		return nil, fmt.Errorf("exchanging token: %w", err)
 	}

--- a/pkg/services/annotations/annotationsapi/api_client_test.go
+++ b/pkg/services/annotations/annotationsapi/api_client_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	authnlib "github.com/grafana/authlib/authn"
+	claims "github.com/grafana/authlib/types"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/stretchr/testify/assert"
@@ -36,23 +37,33 @@ func TestNewAnnotationAPIClient_TokenExchange(t *testing.T) {
 		stackID       string
 		requester     *identity.StaticRequester
 		wantNamespace string
+		wantSubject   *authnlib.TokenExchangeSubject
 		wantErr       bool
 	}{
 		{
-			name:          "scopes to stack namespace when stackID is set",
+			name:          "scopes to stack namespace and asserts the user on behalf of",
 			stackID:       "123",
-			requester:     &identity.StaticRequester{OrgID: 1},
+			requester:     &identity.StaticRequester{Type: claims.TypeUser, UserID: 42, UserUID: "user-uid", OrgID: 1},
 			wantNamespace: "stacks-123",
+			wantSubject:   &authnlib.TokenExchangeSubject{Sub: "user:42", Identifier: "user-uid", Type: "user", Namespace: "stacks-123"},
 		},
 		{
 			name:          "scopes to the default namespace when stackID is not set and orgID is 1",
-			requester:     &identity.StaticRequester{OrgID: 1},
+			requester:     &identity.StaticRequester{Type: claims.TypeUser, UserID: 42, UserUID: "user-uid", OrgID: 1},
 			wantNamespace: "default",
+			wantSubject:   &authnlib.TokenExchangeSubject{Sub: "user:42", Identifier: "user-uid", Type: "user", Namespace: "default"},
 		},
 		{
 			name:          "scopes to the org namespace when stackID is not set and orgID is not 1",
-			requester:     &identity.StaticRequester{OrgID: 7},
+			requester:     &identity.StaticRequester{Type: claims.TypeServiceAccount, UserID: 7, UserUID: "sa-uid", OrgID: 7},
 			wantNamespace: "org-7",
+			wantSubject:   &authnlib.TokenExchangeSubject{Sub: "service-account:7", Identifier: "sa-uid", Type: "service-account", Namespace: "org-7"},
+		},
+		{
+			name:          "access policy has no on-behalf-of subject",
+			requester:     &identity.StaticRequester{Type: claims.TypeAccessPolicy, UserID: 3, UserUID: "ap-uid", OrgID: 1},
+			wantNamespace: "default",
+			wantSubject:   nil,
 		},
 		{
 			name:    "fails when the requester is missing",
@@ -96,6 +107,7 @@ func TestNewAnnotationAPIClient_TokenExchange(t *testing.T) {
 
 			assert.Equal(t, tt.wantNamespace, exchanger.gotRequest.Namespace)
 			assert.Equal(t, []string{annotationServerAudience}, exchanger.gotRequest.Audiences)
+			assert.Equal(t, tt.wantSubject, exchanger.gotRequest.Subject)
 			assert.Equal(t, "signed-token", next.gotToken)
 		})
 	}


### PR DESCRIPTION
This PR updates the annotation API proxy authentication to use OBO authentication, when possible, by passing the Subject identity when performing the token exchange. This fixes an issue where annotations created via the proxy were not being attributed appropriately.