### PR TITLE
Provisioning: retry read-after-write races in provisioning repo/connection controllers

### DIFF
--- a/pkg/registry/apis/provisioning/controller/connection.go
+++ b/pkg/registry/apis/provisioning/controller/connection.go
@@ -30,11 +30,25 @@ const (
 	// repository whose token secret was written recently but is not yet readable from
 	// the secret store. It is shared by the connection and repository controllers.
 	tokenWriteRetryDelay = 2 * time.Second
+
+	// notObservedRetryDelay is how long to wait before re-checking an object the
+	// reconcile read has not observed yet (informer.ErrNotObserved) — a
+	// read-after-write race under the NATS read seam, where the read is decoupled
+	// from the notification that enqueued the key. maxNotObservedAttempts bounds
+	// those retries; beyond it the key is dropped and left for the next resync, so
+	// delay*attempts is the visibility window tolerated before falling back to
+	// resync. Both are shared by the connection and repository controllers.
+	notObservedRetryDelay  = 500 * time.Millisecond
+	maxNotObservedAttempts = 6
 )
 
 type connectionQueueItem struct {
 	key      string
 	attempts int
+	// notObservedAttempts counts consecutive ErrNotObserved retries so the
+	// read-after-write requeue stays bounded. The same item is re-added on each
+	// retry to carry the count forward.
+	notObservedAttempts int
 }
 
 // ConnectionStatusPatcher defines the interface for updating connection status.
@@ -60,6 +74,9 @@ type ConnectionController struct {
 	queue          workqueue.TypedRateLimitingInterface[*connectionQueueItem]
 	resyncInterval time.Duration
 	drainTimeout   time.Duration
+	// notObservedRetryDelay is the backoff before an ErrNotObserved requeue;
+	// injectable so tests need not wait the production delay.
+	notObservedRetryDelay time.Duration
 }
 
 // NewConnectionController creates a new ConnectionController.
@@ -80,13 +97,14 @@ func NewConnectionController(
 				Name: "provisioningConnectionController",
 			},
 		),
-		statusPatcher:     statusPatcher,
-		healthChecker:     healthChecker,
-		connectionFactory: connectionFactory,
-		tokenMetrics:      registerConnectionTokenMetrics(registry),
-		logger:            logging.DefaultLogger.With("logger", connectionLoggerName),
-		resyncInterval:    resyncInterval,
-		drainTimeout:      drainTimeout,
+		statusPatcher:         statusPatcher,
+		healthChecker:         healthChecker,
+		connectionFactory:     connectionFactory,
+		tokenMetrics:          registerConnectionTokenMetrics(registry),
+		logger:                logging.DefaultLogger.With("logger", connectionLoggerName),
+		resyncInterval:        resyncInterval,
+		drainTimeout:          drainTimeout,
+		notObservedRetryDelay: notObservedRetryDelay,
 	}
 
 	cc.processFn = cc.process
@@ -175,6 +193,25 @@ func (cc *ConnectionController) processNextWorkItem(ctx context.Context) bool {
 		return true
 	}
 
+	// The reconcile read has not observed the connection yet. Under the NATS read
+	// seam the read is decoupled from the notification that enqueued this key, so
+	// this is typically a read-after-write race on a just-created or just-updated
+	// connection. Requeue the same item (carrying its retry count) with a fixed
+	// short delay (bounded) to let the write become visible, rather than dropping
+	// it until the next resync; a genuinely deleted connection exhausts the
+	// retries and is then forgotten.
+	if errors.Is(err, informer.ErrNotObserved) {
+		item.notObservedAttempts++
+		if item.notObservedAttempts >= maxNotObservedAttempts {
+			logger.With("attempts", item.notObservedAttempts).Info("ConnectionController: connection still not observed after retries; leaving for the next resync")
+			cc.queue.Forget(item)
+			return true
+		}
+		logger.With("attempts", item.notObservedAttempts).Debug("ConnectionController: connection not yet observed, requeuing")
+		cc.queue.AddAfter(item, cc.notObservedRetryDelay)
+		return true
+	}
+
 	item.attempts++
 	logger = logger.With("error", err, "attempts", item.attempts)
 	logger.Error("ConnectionController failed to process key")
@@ -212,8 +249,15 @@ func (cc *ConnectionController) process(ctx context.Context, item *connectionQue
 	// fresh is the informer.ConnectionGetter's concern, not the controller's.
 	conn, err := cc.conns.Get(ctx, namespace, name)
 	switch {
+	case errors.Is(err, informer.ErrNotObserved):
+		// Retryable: the read seam has not observed the connection yet (a NATS
+		// read-after-write race). processNextWorkItem requeues it with backoff.
+		return err
 	case apierrors.IsNotFound(err):
-		return errors.New("connection not found")
+		// Authoritative delete from the apiserver cache lister: the connection is
+		// gone, so there is nothing to reconcile.
+		logger.Debug("connection not found; already deleted, nothing to reconcile")
+		return nil
 	case err != nil:
 		logger.Error("getting connection", "error", err)
 		return err

--- a/pkg/registry/apis/provisioning/controller/connection_test.go
+++ b/pkg/registry/apis/provisioning/controller/connection_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/util/workqueue"
 
 	"github.com/grafana/grafana-app-sdk/logging"
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
@@ -824,7 +826,9 @@ func TestConnectionController_process(t *testing.T) {
 			errorContains: "failed to update connection status",
 		},
 		{
-			name: "connection not found",
+			// The cache lister is authoritative, so a NotFound means the connection
+			// was deleted: nothing to reconcile, no error, no retry.
+			name: "connection not found (authoritative delete)",
 			setupMocks: func() (*mockConnectionLister, *MockConnectionHealthChecker, *MockConnectionStatusPatcher, *connection.MockFactory) {
 				mockLister := &mockConnectionLister{}
 
@@ -836,7 +840,7 @@ func TestConnectionController_process(t *testing.T) {
 					Namespace: "default",
 				},
 			},
-			expectError: true,
+			expectError: false,
 		},
 		{
 			name: "build connection error",
@@ -1516,3 +1520,46 @@ var _ listers.ConnectionLister = (*mockConnectionLister)(nil)
 
 // Ensure mockConnectionNamespaceLister implements listers.ConnectionNamespaceLister
 var _ listers.ConnectionNamespaceLister = (*mockConnectionNamespaceLister)(nil)
+
+// TestConnectionController_NotObservedRetriesUpToMaxAttempts verifies that an
+// ErrNotObserved from the read seam (a read-after-write race under the NATS
+// informer, where the reconcile read is decoupled from the notification that
+// enqueued the key) is requeued and bounded at maxNotObservedAttempts, rather
+// than dropped on the first attempt — which would leave a just-created connection
+// unreconciled until the next resync — or retried forever.
+func TestConnectionController_NotObservedRetriesUpToMaxAttempts(t *testing.T) {
+	var processCount atomic.Int32
+	allAttemptsDone := make(chan struct{})
+
+	cc := &ConnectionController{
+		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.DefaultTypedControllerRateLimiter[*connectionQueueItem](),
+			workqueue.TypedRateLimitingQueueConfig[*connectionQueueItem]{Name: "test-not-observed"},
+		),
+		logger:                logging.DefaultLogger.With("logger", "test"),
+		drainTimeout:          5 * time.Second,
+		notObservedRetryDelay: 0, // requeue immediately in the test
+	}
+
+	cc.processFn = func(_ context.Context, _ *connectionQueueItem) error {
+		if processCount.Add(1) == maxNotObservedAttempts {
+			close(allAttemptsDone)
+		}
+		return fmt.Errorf("%w: test", informer.ErrNotObserved)
+	}
+
+	cc.queue.Add(&connectionQueueItem{key: "test/conn"})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	runDone := make(chan struct{})
+	go func() {
+		cc.Run(ctx, 1, func() {}, func() {})
+		close(runDone)
+	}()
+
+	<-allAttemptsDone
+	cancel()
+	<-runDone
+	assert.Equal(t, int32(maxNotObservedAttempts), processCount.Load(),
+		"ErrNotObserved should retry exactly maxNotObservedAttempts times then give up")
+}

--- a/pkg/registry/apis/provisioning/controller/repository.go
+++ b/pkg/registry/apis/provisioning/controller/repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/grafana/grafana-app-sdk/logging"
@@ -70,6 +71,15 @@ type RepositoryController struct {
 	resyncInterval  time.Duration
 	minSyncInterval time.Duration
 	drainTimeout    time.Duration
+
+	// notObservedAttempts counts consecutive ErrNotObserved retries per work key so
+	// the read-after-write requeue (scheduled via AddAfter, which the workqueue's
+	// rate limiter does not count) stays bounded. Entries are removed on success,
+	// on a different error, or once maxNotObservedAttempts is reached.
+	notObservedAttempts sync.Map // string -> int
+	// notObservedRetryDelay is the backoff before an ErrNotObserved requeue;
+	// injectable so tests need not wait the production delay.
+	notObservedRetryDelay time.Duration
 
 	registry                      prometheus.Registerer
 	tracer                        tracing.Tracer
@@ -138,6 +148,7 @@ func NewRepositoryController(
 		tokenMetrics:                  repoTokenMetrics,
 		incrementalPolicy:             incrementalPolicy,
 		webhookSecretRotationInterval: webhookSecretRotationInterval,
+		notObservedRetryDelay:         notObservedRetryDelay,
 	}
 
 	rc.processFn = rc.process
@@ -241,8 +252,32 @@ func (rc *RepositoryController) processNextWorkItem(ctx context.Context) bool {
 	err := rc.processFn(key)
 	if err == nil {
 		rc.queue.Forget(key)
+		rc.notObservedAttempts.Delete(key)
 		return true
 	}
+
+	// The reconcile read has not observed the repository yet. Under the NATS read
+	// seam the read is decoupled from the notification that enqueued this key, so
+	// this is typically a read-after-write race on a just-created or just-updated
+	// repository. Requeue with a fixed short delay (bounded) to let the write
+	// become visible, rather than dropping the key until the next resync; a
+	// genuinely deleted repository exhausts the retries and is then forgotten.
+	if errors.Is(err, informer.ErrNotObserved) {
+		prev, _ := rc.notObservedAttempts.Load(key)
+		attempts, _ := prev.(int)
+		attempts++
+		if attempts >= maxNotObservedAttempts {
+			logger.With("attempts", attempts).Info("RepositoryController: repository still not observed after retries; leaving for the next resync")
+			rc.queue.Forget(key)
+			rc.notObservedAttempts.Delete(key)
+			return true
+		}
+		rc.notObservedAttempts.Store(key, attempts)
+		logger.With("attempts", attempts).Debug("RepositoryController: repository not yet observed, requeuing")
+		rc.queue.AddAfter(key, rc.notObservedRetryDelay)
+		return true
+	}
+	rc.notObservedAttempts.Delete(key)
 
 	// NumRequeues counts prior AddRateLimited calls; add 1 for the current attempt.
 	attempts := rc.queue.NumRequeues(key) + 1
@@ -579,8 +614,15 @@ func (rc *RepositoryController) process(key string) error {
 	// fresh is the informer.RepositoryGetter's concern, not the controller's.
 	obj, err := rc.repos.Get(ctx, namespace, name)
 	switch {
+	case errors.Is(err, informer.ErrNotObserved):
+		// Retryable: the read seam has not observed the repository yet (a NATS
+		// read-after-write race). processNextWorkItem requeues it with backoff.
+		return err
 	case apierrors.IsNotFound(err):
-		return errors.New("repository not found")
+		// Authoritative delete from the apiserver cache lister: the repository is
+		// gone, so there is nothing to reconcile.
+		logger.Debug("repository not found; already deleted, nothing to reconcile")
+		return nil
 	case err != nil:
 		return err
 	}

--- a/pkg/registry/apis/provisioning/controller/repository_test.go
+++ b/pkg/registry/apis/provisioning/controller/repository_test.go
@@ -2006,3 +2006,84 @@ func TestRepositoryController_NonRetryableErrorIsNotRetried(t *testing.T) {
 	<-runDone
 	assert.Equal(t, int32(1), processCount.Load(), "non-retryable errors must not be retried")
 }
+
+// stubRepositoryGetter is a RepositoryGetter whose Get returns a fixed error, to
+// drive the controller's read-seam handling in process().
+type stubRepositoryGetter struct {
+	getErr error
+}
+
+func (g stubRepositoryGetter) Get(context.Context, string, string) (*provisioning.Repository, error) {
+	return nil, g.getErr
+}
+
+func (g stubRepositoryGetter) List(context.Context, string) ([]*provisioning.Repository, error) {
+	return nil, nil
+}
+
+// TestRepositoryController_NotObservedRetriesUpToMaxAttempts verifies that an
+// ErrNotObserved from the read seam (a read-after-write race under the NATS
+// informer, where the reconcile read is decoupled from the notification that
+// enqueued the key) is requeued and bounded at maxNotObservedAttempts, rather
+// than dropped on the first attempt — which would leave a just-created repository
+// unreconciled until the next resync — or retried forever.
+func TestRepositoryController_NotObservedRetriesUpToMaxAttempts(t *testing.T) {
+	var processCount atomic.Int32
+	allAttemptsDone := make(chan struct{})
+
+	rc := &RepositoryController{
+		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.DefaultTypedControllerRateLimiter[string](),
+			workqueue.TypedRateLimitingQueueConfig[string]{Name: "test-not-observed"},
+		),
+		logger:                logging.DefaultLogger.With("logger", "test"),
+		drainTimeout:          5 * time.Second,
+		notObservedRetryDelay: 0, // requeue immediately in the test
+	}
+
+	rc.processFn = func(key string) error {
+		if processCount.Add(1) == maxNotObservedAttempts {
+			close(allAttemptsDone)
+		}
+		return fmt.Errorf("%w: test", informer.ErrNotObserved)
+	}
+
+	rc.queue.Add("test/repo")
+
+	ctx, cancel := context.WithCancel(t.Context())
+	runDone := make(chan struct{})
+	go func() {
+		rc.Run(ctx, 1, func() {}, func() {})
+		close(runDone)
+	}()
+
+	<-allAttemptsDone
+	cancel()
+	<-runDone
+	assert.Equal(t, int32(maxNotObservedAttempts), processCount.Load(),
+		"ErrNotObserved should retry exactly maxNotObservedAttempts times then give up")
+}
+
+// TestRepositoryController_process_ReadSeamNotFound verifies the two read-seam
+// outcomes: an authoritative NotFound (apiserver cache lister) is a no-op that
+// returns nil so the key is forgotten with no error, while an ErrNotObserved
+// (NATS fresh read) is propagated so processNextWorkItem requeues it.
+func TestRepositoryController_process_ReadSeamNotFound(t *testing.T) {
+	t.Run("authoritative NotFound returns nil", func(t *testing.T) {
+		rc := &RepositoryController{
+			repos:  stubRepositoryGetter{getErr: apierrors.NewNotFound(schema.GroupResource{Resource: "repositories"}, "gone")},
+			logger: logging.DefaultLogger.With("logger", "test"),
+		}
+		assert.NoError(t, rc.process("ns/gone"))
+	})
+
+	t.Run("ErrNotObserved is propagated", func(t *testing.T) {
+		rc := &RepositoryController{
+			repos:  stubRepositoryGetter{getErr: fmt.Errorf("%w: ns/new", informer.ErrNotObserved)},
+			logger: logging.DefaultLogger.With("logger", "test"),
+		}
+		err := rc.process("ns/new")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, informer.ErrNotObserved)
+	})
+}

--- a/pkg/registry/apis/provisioning/informer/connection.go
+++ b/pkg/registry/apis/provisioning/informer/connection.go
@@ -2,8 +2,10 @@ package informer
 
 import (
 	"context"
+	"fmt"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -80,5 +82,17 @@ type clientConnectionGetter struct {
 }
 
 func (g clientConnectionGetter) Get(ctx context.Context, namespace, name string) (*provisioningapis.Connection, error) {
-	return g.client.Connections(namespace).Get(ctx, name, metav1.GetOptions{})
+	conn, err := g.client.Connections(namespace).Get(ctx, name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		// This read is decoupled from the NATS notification that enqueued the key,
+		// so a 404 is usually a read-after-write race on a just-created connection,
+		// not a deletion. Surface it as ErrNotObserved so the controller retries
+		// (bounded) instead of dropping the key until the next resync; a genuine
+		// delete exhausts the retries and is then forgotten.
+		return nil, fmt.Errorf("%w: %s/%s", ErrNotObserved, namespace, name)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return conn, nil
 }

--- a/pkg/registry/apis/provisioning/informer/informer.go
+++ b/pkg/registry/apis/provisioning/informer/informer.go
@@ -1,8 +1,20 @@
 package informer
 
 import (
+	"errors"
+
 	"k8s.io/client-go/tools/cache"
 )
+
+// ErrNotObserved signals that a reconcile read did not find the object. It is
+// deliberately distinct from an authoritative apierrors NotFound served by an
+// informer's cache lister: it comes from the NATS read seam's fresh API read,
+// which is decoupled from the notification that enqueued the key, so a miss is
+// usually a read-after-write race on a just-created or just-updated object rather
+// than a real deletion. Controllers retry it (bounded) instead of dropping the
+// key until the next resync. The apiserver-backed getters never return it — their
+// lister cache is authoritative, so their NotFound means the object is gone.
+var ErrNotObserved = errors.New("object not yet observed by the read seam")
 
 // DeltaSource is the subset of cache.SharedIndexInformer the controllers use to
 // receive events: register a handler (whose registration reports HasSynced) and

--- a/pkg/registry/apis/provisioning/informer/repository.go
+++ b/pkg/registry/apis/provisioning/informer/repository.go
@@ -2,6 +2,7 @@ package informer
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -102,7 +103,12 @@ func (g clientGetCachedListRepositoryGetter) Get(ctx context.Context, namespace,
 	repo, err := g.client.Repositories(namespace).Get(ctx, name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		g.store.Delete(ctx, namespace, name)
-		return nil, err
+		// This read is decoupled from the NATS notification that enqueued the key,
+		// so a 404 is usually a read-after-write race on a just-created repository,
+		// not a deletion. Surface it as ErrNotObserved so the controller retries
+		// (bounded) instead of dropping the key until the next resync; a genuine
+		// delete exhausts the retries and is then forgotten.
+		return nil, fmt.Errorf("%w: %s/%s", ErrNotObserved, namespace, name)
 	}
 	if err != nil {
 		return nil, err

--- a/pkg/registry/apis/provisioning/informer/repository_test.go
+++ b/pkg/registry/apis/provisioning/informer/repository_test.go
@@ -122,15 +122,18 @@ func TestClientGetCachedListRepositoryGetter_GetWritesThrough(t *testing.T) {
 	assert.Equal(t, "fresh", list[0].Name, "the fresh Get must be reflected in the store")
 }
 
-// A reconcile Get for a vanished object returns NotFound and removes it from the
-// store, so the count drops it without waiting for a re-list.
+// A reconcile Get for an object the API does not return yields ErrNotObserved
+// (not an authoritative NotFound: the fresh read is decoupled from the event that
+// enqueued it, so the controller retries rather than dropping the key) and
+// removes it from the store, so the count drops it without waiting for a re-list.
 func TestClientGetCachedListRepositoryGetter_GetNotFoundRemoves(t *testing.T) {
 	client := fake.NewClientset()
 	store := newFakeStore(repo("ns", "stale"))
 	g := NewClientGetCachedListRepositoryGetter(client.ProvisioningV0alpha1(), store)
 
 	_, err := g.Get(context.Background(), "ns", "stale")
-	require.True(t, apierrors.IsNotFound(err))
+	require.ErrorIs(t, err, ErrNotObserved)
+	require.False(t, apierrors.IsNotFound(err), "must not surface as an authoritative NotFound")
 	assert.Equal(t, []string{"ns/stale"}, store.deleted)
 
 	list, err := g.List(context.Background(), "ns")


### PR DESCRIPTION
## What
Under NATS, the RepositoryController (and ConnectionController) no longer drop a just-created repository/connection when the reconcile read briefly 404s. Instead they requeue with bounded backoff until the write is visible. An authoritative delete is now a silent no-op rather than a misleading `error="repository not found"` log line.

## Why
In prod under a burst of repository creations we saw:
`RepositoryController failed to process key … error="repository not found" attempts=1`

Under the NATS read seam the reconcile `Get` is a fresh API read *decoupled* from the notification that enqueued the key, so during a create burst it can 404 on a repo that was just committed (read-after-write race). The controller treated that 404 as terminal (plain error → not ServiceUnavailable → Forget), so the new repo went unreconciled — no finalizer, webhook, health check, or sync — until the next resync (~5 min). The apiserver-informer path never hit this because OnAdd was delivered from a cache that already contained the object.

## How
Encode the NotFound semantics in the read seam, which is exactly where the two informer modes already diverge, keeping the controllers mode-agnostic:
- **NATS getters**: map a 404 to a new `informer.ErrNotObserved` sentinel → controllers requeue via `AddAfter` with a bounded fixed delay (500ms × up to 6 ≈ 3s coverage), mirroring the existing `tokenWriteRetryDelay` idiom. A genuine delete exhausts the retries and is forgotten.
- **apiserver cache-lister getters**: keep returning an authoritative NotFound → controllers treat it as "gone, nothing to reconcile" (return nil), removing the misleading error log.
- Applied symmetrically to the ConnectionController (same seam, same symptom).

Backend-only; `pkg/storage/unified/` is untouched, so no storage/API compatibility impact.

## Testing
- `go test ./pkg/registry/apis/provisioning/{controller,informer}/` — pass
- New tests: getter returns `ErrNotObserved` (not apierrors NotFound) on 404; `ErrNotObserved` retries exactly `maxNotObservedAttempts` then stops; `process()` returns nil on authoritative NotFound and propagates `ErrNotObserved`.
- `go vet` + `gofmt` clean.

## Checklist
- [x] Tests added/updated
- [x] No breaking changes
- [ ] Backport labels (if this needs to reach a release branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)