### PR TITLE
Data: Add toOptions and enumToOptions select helpers

### DIFF
--- a/packages/grafana-data/src/index.ts
+++ b/packages/grafana-data/src/index.ts
@@ -275,7 +275,7 @@ export { getSeriesTimeStep, hasMsResolution } from './utils/series';
 export { BinaryOperationID, type BinaryOperation, binaryOperators } from './utils/binaryOperators';
 export { UnaryOperationID, type UnaryOperation, unaryOperators } from './utils/unaryOperators';
 export { NodeGraphDataFrameFieldNames } from './utils/nodeGraph';
-export { toOption } from './utils/selectUtils';
+export { toOption, toOptions, enumToOptions } from './utils/selectUtils';
 export * as arrayUtils from './utils/arrayUtils';
 export { store, Store } from './utils/store';
 export { LocalStorageValueProvider } from './utils/LocalStorageValueProvider';

--- a/packages/grafana-data/src/utils/selectUtils.test.ts
+++ b/packages/grafana-data/src/utils/selectUtils.test.ts
@@ -1,0 +1,62 @@
+import { enumToOptions, toOption, toOptions } from './selectUtils';
+
+describe('toOption', () => {
+  it('uses the value as its own label', () => {
+    expect(toOption('foo')).toEqual({ label: 'foo', value: 'foo' });
+  });
+
+  it('stringifies non-string values for the label', () => {
+    expect(toOption(42)).toEqual({ label: '42', value: 42 });
+  });
+});
+
+describe('toOptions', () => {
+  it('maps a string array to options', () => {
+    expect(toOptions(['a', 'b'])).toEqual([
+      { label: 'a', value: 'a' },
+      { label: 'b', value: 'b' },
+    ]);
+  });
+
+  it('returns an empty array for an empty input', () => {
+    expect(toOptions([])).toEqual([]);
+  });
+});
+
+describe('enumToOptions', () => {
+  it('converts a string enum', () => {
+    enum Fruit {
+      Apple = 'apple',
+      Banana = 'banana',
+    }
+
+    expect(enumToOptions(Fruit)).toEqual([
+      { label: 'apple', value: 'apple' },
+      { label: 'banana', value: 'banana' },
+    ]);
+  });
+
+  it('drops reverse-mapping keys for numeric enums', () => {
+    enum Size {
+      Small,
+      Large,
+    }
+
+    expect(enumToOptions(Size)).toEqual([
+      { label: '0', value: 0 },
+      { label: '1', value: 1 },
+    ]);
+  });
+
+  it('applies a custom label function', () => {
+    enum Fruit {
+      Apple = 'apple',
+      Banana = 'banana',
+    }
+
+    expect(enumToOptions(Fruit, (v) => v.toUpperCase())).toEqual([
+      { label: 'APPLE', value: 'apple' },
+      { label: 'BANANA', value: 'banana' },
+    ]);
+  });
+});

--- a/packages/grafana-data/src/utils/selectUtils.ts
+++ b/packages/grafana-data/src/utils/selectUtils.ts
@@ -1,3 +1,34 @@
 import { type SelectableValue } from '../types/select';
 
-export const toOption = (value: string): SelectableValue<string> => ({ label: value, value });
+/**
+ * Converts a single value into a `SelectableValue`, using the value itself as the label.
+ * Idiomatic array usage is `values.map(toOption)`; see `toOptions` for a one-call wrapper.
+ */
+export const toOption = <T>(value: T): SelectableValue<T> => ({ label: String(value), value });
+
+/**
+ * Converts an array of values into `SelectableValue` options, using each value as its own label.
+ * Replaces the common inline `values.map((v) => ({ value: v, label: v }))` pattern.
+ */
+export const toOptions = <T>(values: T[]): Array<SelectableValue<T>> => values.map((value) => toOption(value));
+
+/**
+ * Converts a TypeScript enum into `SelectableValue` options.
+ *
+ * Unlike `Object.values(MyEnum).map(toOption)`, this safely handles numeric enums, whose runtime
+ * object contains reverse-mapping keys (e.g. `enum E { A }` yields `{ '0': 'A', A: 0 }`, so
+ * `Object.values(E)` is `['A', 0]`). Those reverse-mapped entries are filtered out here.
+ *
+ * Pass `getLabel` when the label should differ from the value (e.g. a formatted or translated name).
+ */
+export const enumToOptions = <T extends string | number>(
+  enumObject: Record<string, T>,
+  getLabel?: (value: T) => string
+): Array<SelectableValue<T>> =>
+  Object.keys(enumObject)
+    // Numeric enums add reverse-mapping keys ('0', '1', ...); drop them so only members remain.
+    .filter((key) => isNaN(Number(key)))
+    .map((key) => {
+      const value = enumObject[key];
+      return { value, label: getLabel ? getLabel(value) : String(value) };
+    });


### PR DESCRIPTION
## What this PR does / why we need it

Adds two small helpers next to the existing `toOption` in `@grafana/data` to replace a pattern that recurs throughout the frontend: mapping an array or enum into `SelectableValue[]` for a `Select`/`Combobox`, e.g.

```ts
Object.values(CodeLanguage).map((v) => ({ value: v, label: v }))
```

A sweep of `public/app/` + `packages/` found **~120** inline call sites of this shape, of which **~87** are the clean `value === label` case. There was no array/enum wrapper for this — only the single-value `toOption`, whose idiomatic array form is `arr.map(toOption)`.

## Changes

- **`toOption`** is widened from `string`-only to generic. Non-breaking: the label is now `String(value)`, which is identical for the existing string callers. A repo-wide typecheck confirms no callers broke.
- **`toOptions(values)`** — one-call array wrapper (`values.map(toOption)`), the primary consolidation target for the ~87 sites.
- **`enumToOptions(enumObject, getLabel?)`** — converts a TS enum. Its reason to exist over `Object.values(E).map(toOption)` is the **numeric-enum footgun**: `Object.values` of a numeric enum includes the reverse-mapping keys (`enum E { A } → ['A', 0]`), which would otherwise become bogus options. It filters those out and accepts an optional labeler for the cases where the label differs from the value.

All three are exported from `@grafana/data`.

## Scope

This PR is the helper + tests only. Call-site migrations (the ~87 sites) will land as separate, area-scoped follow-up PRs so each squad reviews its own.

## Tests

New `selectUtils.test.ts` (none existed): string arrays, string + numeric enums, reverse-map drop, custom labeler, empty input.

## Release notes

None (additive internal helper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)