### PR TITLE
docs: fix for support escalation #23380

### DIFF
--- a/docs/sources/setup-grafana/configure-access/configure-authentication/_index.md
+++ b/docs/sources/setup-grafana/configure-access/configure-authentication/_index.md
@@ -18,23 +18,23 @@ weight: 100
 
 Grafana provides many ways to authenticate users. Some authentication integrations also enable syncing user permissions and org memberships.
 
-The following table shows all supported authentication methods and the features available for them. [Team sync](../configure-team-sync/) and [active sync](enhanced-ldap/#active-ldap-synchronization) are only available in Grafana Enterprise.
+The following table shows all supported authentication methods and the features available for them. [Team sync](../configure-team-sync/) and [active sync](enhanced-ldap/#active-ldap-synchronization) are available in Grafana Enterprise and Grafana Cloud. They aren't available in Grafana OSS.
 
-| Authentication method               | Multi Org Mapping | Enforce Sync | Role Mapping | Grafana Admin Mapping | Team Sync | Allowed groups | Active Sync | Skip OrgRole mapping | Auto Login | Single Logout | SCIM support |
-| :---------------------------------- | :---------------- | :----------- | :----------- | :-------------------- | :-------- | :------------- | :---------- | :------------------- | :--------- | :------------ | :----------- |
-| [Anonymous access](anonymous-auth/) | N/A               | N/A          | N/A          | N/A                   | N/A       | N/A            | N/A         | N/A                  | N/A        | N/A           | N/A          |
-| [Auth Proxy](auth-proxy/)           | no                | yes          | yes          | no                    | yes       | no             | N/A         | no                   | N/A        | N/A           | N/A          |
-| [Entra ID OAuth](azuread/)          | yes               | yes          | yes          | yes                   | yes       | yes            | N/A         | yes                  | yes        | yes           | N/A          |
-| [Basic auth](grafana/)              | yes               | N/A          | yes          | yes                   | N/A       | N/A            | N/A         | N/A                  | N/A        | N/A           | N/A          |
-| [Generic OAuth](generic-oauth/)     | yes               | yes          | yes          | yes                   | yes       | no             | N/A         | yes                  | yes        | yes           | N/A          |
-| [GitHub OAuth](github/)             | yes               | yes          | yes          | yes                   | yes       | yes            | N/A         | yes                  | yes        | yes           | N/A          |
-| [GitLab OAuth](gitlab/)             | yes               | yes          | yes          | yes                   | yes       | yes            | N/A         | yes                  | yes        | yes           | N/A          |
-| [Google OAuth](google/)             | yes               | no           | no           | no                    | yes       | no             | N/A         | no                   | yes        | yes           | N/A          |
-| [Grafana.com OAuth](grafana-cloud/) | no                | no           | yes          | no                    | N/A       | N/A            | N/A         | yes                  | yes        | yes           | N/A          |
-| [Okta OAuth](okta/)                 | yes               | yes          | yes          | yes                   | yes       | yes            | N/A         | yes                  | yes        | yes           | N/A          |
-| [SAML](saml/) (Enterprise only)     | yes               | yes          | yes          | yes                   | yes       | yes            | N/A         | yes                  | yes        | yes           | yes          |
-| [LDAP](ldap/)                       | yes               | yes          | yes          | yes                   | yes       | yes            | yes         | no                   | N/A        | N/A           | N/A          |
-| [JWT Proxy](jwt/)                   | no                | yes          | yes          | yes                   | no        | no             | N/A         | no                   | N/A        | N/A           | N/A          |
+| Authentication method                | Multi Org Mapping | Enforce Sync | Role Mapping | Grafana Admin Mapping | Team Sync | Allowed groups | Active Sync | Skip OrgRole mapping | Auto Login | Single Logout | SCIM support |
+| :----------------------------------- | :---------------- | :----------- | :----------- | :-------------------- | :-------- | :------------- | :---------- | :------------------- | :--------- | :------------ | :----------- |
+| [Anonymous access](anonymous-auth/)  | N/A               | N/A          | N/A          | N/A                   | N/A       | N/A            | N/A         | N/A                  | N/A        | N/A           | N/A          |
+| [Auth Proxy](auth-proxy/)            | no                | yes          | yes          | no                    | yes       | no             | N/A         | no                   | N/A        | N/A           | N/A          |
+| [Entra ID OAuth](azuread/)           | yes               | yes          | yes          | yes                   | yes       | yes            | N/A         | yes                  | yes        | yes           | N/A          |
+| [Basic auth](grafana/)               | yes               | N/A          | yes          | yes                   | N/A       | N/A            | N/A         | N/A                  | N/A        | N/A           | N/A          |
+| [Generic OAuth](generic-oauth/)      | yes               | yes          | yes          | yes                   | yes       | no             | N/A         | yes                  | yes        | yes           | N/A          |
+| [GitHub OAuth](github/)              | yes               | yes          | yes          | yes                   | yes       | yes            | N/A         | yes                  | yes        | yes           | N/A          |
+| [GitLab OAuth](gitlab/)              | yes               | yes          | yes          | yes                   | yes       | yes            | N/A         | yes                  | yes        | yes           | N/A          |
+| [Google OAuth](google/)              | yes               | no           | no           | no                    | yes       | no             | N/A         | no                   | yes        | yes           | N/A          |
+| [Grafana.com OAuth](grafana-cloud/)  | no                | no           | yes          | no                    | N/A       | N/A            | N/A         | yes                  | yes        | yes           | N/A          |
+| [Okta OAuth](okta/)                  | yes               | yes          | yes          | yes                   | yes       | yes            | N/A         | yes                  | yes        | yes           | N/A          |
+| [SAML](saml/) (Enterprise and Cloud) | yes               | yes          | yes          | yes                   | yes       | yes            | N/A         | yes                  | yes        | yes           | yes          |
+| [LDAP](ldap/)                        | yes               | yes          | yes          | yes                   | yes       | yes            | yes         | no                   | N/A        | N/A           | N/A          |
+| [JWT Proxy](jwt/)                    | no                | yes          | yes          | yes                   | no        | no             | N/A         | no                   | N/A        | N/A           | N/A          |
 
 Fields explanation:
 
@@ -63,7 +63,7 @@ Fields explanation:
 ## Configuring multiple identity providers
 
 Grafana allows you to configure more than one authentication provider, however it is not possible to configure the same type of authentication provider twice.
-For example, you can have [SAML](saml/) (Enterprise only) and [Generic OAuth](generic-oauth/) configured, but you can not have two different [Generic OAuth](generic-oauth/) configurations.
+For example, you can have [SAML](saml/) (Enterprise and Cloud) and [Generic OAuth](generic-oauth/) configured, but you can not have two different [Generic OAuth](generic-oauth/) configurations.
 
 > Note: Grafana does not support multiple identity providers resolving the same user. Make sure no user account overlaps between the different providers.
 
@@ -71,7 +71,7 @@ In scenarios where you have multiple identity providers of the same type, there 
 
 - Use different Grafana instances, each configured with a given identity provider.
 - Check if the identity provider supports account federation. In such cases, you can configure it once and let your identity provider federate the accounts from different providers.
-- If SAML is supported by the identity provider, you can configure one [Generic OAuth](generic-oauth/) and one [SAML](saml/) (Enterprise only).
+- If SAML is supported by the identity provider, you can configure one [Generic OAuth](generic-oauth/) and one [SAML](saml/) (Enterprise and Cloud).
 
 ## Using the same email address to login with different identity providers
 

--- a/docs/sources/setup-grafana/configure-access/configure-authentication/_index.md
+++ b/docs/sources/setup-grafana/configure-access/configure-authentication/_index.md
@@ -63,7 +63,7 @@ Fields explanation:
 ## Configuring multiple identity providers
 
 Grafana allows you to configure more than one authentication provider, however it is not possible to configure the same type of authentication provider twice.
-For example, you can have [SAML](saml/) (Enterprise and Cloud) and [Generic OAuth](generic-oauth/) configured, but you can not have two different [Generic OAuth](generic-oauth/) configurations.
+For example, you can have [SAML](saml/) (Enterprise and Cloud) and [Generic OAuth](generic-oauth/) configured, but you cannot have two different [Generic OAuth](generic-oauth/) configurations.
 
 > Note: Grafana does not support multiple identity providers resolving the same user. Make sure no user account overlaps between the different providers.
 

--- a/docs/sources/setup-grafana/configure-access/configure-authentication/_index.md
+++ b/docs/sources/setup-grafana/configure-access/configure-authentication/_index.md
@@ -18,7 +18,7 @@ weight: 100
 
 Grafana provides many ways to authenticate users. Some authentication integrations also enable syncing user permissions and org memberships.
 
-The following table shows all supported authentication methods and the features available for them. [Team sync](../configure-team-sync/) and [active sync](enhanced-ldap/#active-ldap-synchronization) are available in Grafana Enterprise and Grafana Cloud. They aren't available in Grafana OSS.
+The following table shows all supported authentication methods and the features available for them. [Team sync](../configure-team-sync/), [active sync](enhanced-ldap/#active-ldap-synchronization), and [SAML](saml/) are available in Grafana Enterprise and Grafana Cloud. They aren't available in Grafana open source.
 
 | Authentication method                | Multi Org Mapping | Enforce Sync | Role Mapping | Grafana Admin Mapping | Team Sync | Allowed groups | Active Sync | Skip OrgRole mapping | Auto Login | Single Logout | SCIM support |
 | :----------------------------------- | :---------------- | :----------- | :----------- | :-------------------- | :-------- | :------------- | :---------- | :------------------- | :--------- | :------------ | :----------- |

--- a/docs/sources/setup-grafana/configure-access/configure-authentication/_index.md
+++ b/docs/sources/setup-grafana/configure-access/configure-authentication/_index.md
@@ -20,7 +20,7 @@ Grafana provides many ways to authenticate users. Some authentication integratio
 
 The following table shows all supported authentication methods and the features available for them. [Team sync](../configure-team-sync/), [active sync](enhanced-ldap/#active-ldap-synchronization), and [SAML](saml/) are available in Grafana Enterprise and Grafana Cloud. They aren't available in Grafana open source.
 
-| Authentication method                | Multi Org Mapping | Enforce Sync | Role Mapping | Grafana Admin Mapping | Team Sync | Allowed groups | Active Sync | Skip OrgRole mapping | Auto Login | Single Logout | SCIM support |
+| Authentication method                | Multi Org Mapping | Enforce Sync | Role Mapping | Grafana Admin Mapping | Team Sync | Allowed groups | Active Sync | Skip OrgRole Sync | Auto Login | Single Logout | SCIM support |
 | :----------------------------------- | :---------------- | :----------- | :----------- | :-------------------- | :-------- | :------------- | :---------- | :------------------- | :--------- | :------------ | :----------- |
 | [Anonymous access](anonymous-auth/)  | N/A               | N/A          | N/A          | N/A                   | N/A       | N/A            | N/A         | N/A                  | N/A        | N/A           | N/A          |
 | [Auth Proxy](auth-proxy/)            | no                | yes          | yes          | no                    | yes       | no             | N/A         | no                   | N/A        | N/A           | N/A          |

--- a/docs/sources/setup-grafana/configure-access/configure-authentication/_index.md
+++ b/docs/sources/setup-grafana/configure-access/configure-authentication/_index.md
@@ -21,20 +21,20 @@ Grafana provides many ways to authenticate users. Some authentication integratio
 The following table shows all supported authentication methods and the features available for them. [Team sync](../configure-team-sync/), [active sync](enhanced-ldap/#active-ldap-synchronization), and [SAML](saml/) are available in Grafana Enterprise and Grafana Cloud. They aren't available in Grafana open source.
 
 | Authentication method                | Multi Org Mapping | Enforce Sync | Role Mapping | Grafana Admin Mapping | Team Sync | Allowed groups | Active Sync | Skip OrgRole Sync | Auto Login | Single Logout | SCIM support |
-| :----------------------------------- | :---------------- | :----------- | :----------- | :-------------------- | :-------- | :------------- | :---------- | :------------------- | :--------- | :------------ | :----------- |
-| [Anonymous access](anonymous-auth/)  | N/A               | N/A          | N/A          | N/A                   | N/A       | N/A            | N/A         | N/A                  | N/A        | N/A           | N/A          |
-| [Auth Proxy](auth-proxy/)            | no                | yes          | yes          | no                    | yes       | no             | N/A         | no                   | N/A        | N/A           | N/A          |
-| [Entra ID OAuth](azuread/)           | yes               | yes          | yes          | yes                   | yes       | yes            | N/A         | yes                  | yes        | yes           | N/A          |
-| [Basic auth](grafana/)               | yes               | N/A          | yes          | yes                   | N/A       | N/A            | N/A         | N/A                  | N/A        | N/A           | N/A          |
-| [Generic OAuth](generic-oauth/)      | yes               | yes          | yes          | yes                   | yes       | no             | N/A         | yes                  | yes        | yes           | N/A          |
-| [GitHub OAuth](github/)              | yes               | yes          | yes          | yes                   | yes       | yes            | N/A         | yes                  | yes        | yes           | N/A          |
-| [GitLab OAuth](gitlab/)              | yes               | yes          | yes          | yes                   | yes       | yes            | N/A         | yes                  | yes        | yes           | N/A          |
-| [Google OAuth](google/)              | yes               | no           | no           | no                    | yes       | no             | N/A         | no                   | yes        | yes           | N/A          |
-| [Grafana.com OAuth](grafana-cloud/)  | no                | no           | yes          | no                    | N/A       | N/A            | N/A         | yes                  | yes        | yes           | N/A          |
-| [Okta OAuth](okta/)                  | yes               | yes          | yes          | yes                   | yes       | yes            | N/A         | yes                  | yes        | yes           | N/A          |
-| [SAML](saml/) (Enterprise and Cloud) | yes               | yes          | yes          | yes                   | yes       | yes            | N/A         | yes                  | yes        | yes           | yes          |
-| [LDAP](ldap/)                        | yes               | yes          | yes          | yes                   | yes       | yes            | yes         | no                   | N/A        | N/A           | N/A          |
-| [JWT Proxy](jwt/)                    | no                | yes          | yes          | yes                   | no        | no             | N/A         | no                   | N/A        | N/A           | N/A          |
+| :----------------------------------- | :---------------- | :----------- | :----------- | :-------------------- | :-------- | :------------- | :---------- | :---------------- | :--------- | :------------ | :----------- |
+| [Anonymous access](anonymous-auth/)  | N/A               | N/A          | N/A          | N/A                   | N/A       | N/A            | N/A         | N/A               | N/A        | N/A           | N/A          |
+| [Auth Proxy](auth-proxy/)            | no                | yes          | yes          | no                    | yes       | no             | N/A         | no                | N/A        | N/A           | N/A          |
+| [Entra ID OAuth](azuread/)           | yes               | yes          | yes          | yes                   | yes       | yes            | N/A         | yes               | yes        | yes           | N/A          |
+| [Basic auth](grafana/)               | yes               | N/A          | yes          | yes                   | N/A       | N/A            | N/A         | N/A               | N/A        | N/A           | N/A          |
+| [Generic OAuth](generic-oauth/)      | yes               | yes          | yes          | yes                   | yes       | no             | N/A         | yes               | yes        | yes           | N/A          |
+| [GitHub OAuth](github/)              | yes               | yes          | yes          | yes                   | yes       | yes            | N/A         | yes               | yes        | yes           | N/A          |
+| [GitLab OAuth](gitlab/)              | yes               | yes          | yes          | yes                   | yes       | yes            | N/A         | yes               | yes        | yes           | N/A          |
+| [Google OAuth](google/)              | yes               | no           | no           | no                    | yes       | no             | N/A         | no                | yes        | yes           | N/A          |
+| [Grafana.com OAuth](grafana-cloud/)  | no                | no           | yes          | no                    | N/A       | N/A            | N/A         | yes               | yes        | yes           | N/A          |
+| [Okta OAuth](okta/)                  | yes               | yes          | yes          | yes                   | yes       | yes            | N/A         | yes               | yes        | yes           | N/A          |
+| [SAML](saml/) (Enterprise and Cloud) | yes               | yes          | yes          | yes                   | yes       | yes            | N/A         | yes               | yes        | yes           | yes          |
+| [LDAP](ldap/)                        | yes               | yes          | yes          | yes                   | yes       | yes            | yes         | no                | N/A        | N/A           | N/A          |
+| [JWT Proxy](jwt/)                    | no                | yes          | yes          | yes                   | no        | no             | N/A         | no                | N/A        | N/A           | N/A          |
 
 Fields explanation:
 


### PR DESCRIPTION
## Draft doc fix

Drafted from a P5 documentation escalation: https://github.com/grafana/support-escalations/issues/23380
Document: https://grafana.com/docs/grafana/latest/setup-grafana/configure-access/configure-authentication/#configure-authentication

Closes grafana/support-escalations#23380

> [!IMPORTANT]
> Machine-assisted draft — verify accuracy, tone, and style before merging.