### PR TITLE
Home: Show news card when incident card unavailable

### DIFF
--- a/public/app/core/components/AppChrome/News/NewsWrapper.tsx
+++ b/public/app/core/components/AppChrome/News/NewsWrapper.tsx
@@ -1,6 +1,5 @@
 import { css } from '@emotion/css';
 import { useEffect } from 'react';
-import { useMeasure } from 'react-use';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
@@ -15,7 +14,6 @@ interface NewsWrapperProps {
 export function NewsWrapper({ feedUrl }: NewsWrapperProps) {
   const styles = useStyles2(getStyles);
   const { state, getNews } = useNewsFeed(feedUrl);
-  const [widthRef, widthMeasure] = useMeasure<HTMLDivElement>();
 
   useEffect(() => {
     getNews();
@@ -26,21 +24,20 @@ export function NewsWrapper({ feedUrl }: NewsWrapperProps) {
   }
 
   return (
-    <div ref={widthRef}>
+    <div>
       {state.loading ? (
         <>
-          <News.Skeleton showImage width={widthMeasure.width} />
-          <News.Skeleton showImage width={widthMeasure.width} />
-          <News.Skeleton showImage width={widthMeasure.width} />
-          <News.Skeleton showImage width={widthMeasure.width} />
-          <News.Skeleton showImage width={widthMeasure.width} />
+          <News.Skeleton showImage />
+          <News.Skeleton showImage />
+          <News.Skeleton showImage />
+          <News.Skeleton showImage />
+          <News.Skeleton showImage />
         </>
       ) : (
         <>
-          {widthMeasure.width > 0 &&
-            state.value?.map((_, index) => (
-              <News key={index} index={index} showImage width={widthMeasure.width} data={state.value} />
-            ))}
+          {state.value?.map((_, index) => (
+            <News key={index} index={index} showImage data={state.value} />
+          ))}
         </>
       )}
       <div className={styles.grot}>

--- a/public/app/features/home/AlertsIncidents/IncidentsCard.test.tsx
+++ b/public/app/features/home/AlertsIncidents/IncidentsCard.test.tsx
@@ -74,20 +74,6 @@ afterEach(() => {
 });
 
 describe('IncidentsCard', () => {
-  it('renders nothing when the Incident plugin is not installed', () => {
-    mockUseIrmPlugin.mockReturnValue({ pluginId: SupportedPlugin.Incident, installed: false, loading: false });
-
-    const { container } = render(<IncidentsCard />);
-    expect(container).toBeEmptyDOMElement();
-  });
-
-  it('renders nothing while the plugin availability is still loading', () => {
-    mockUseIrmPlugin.mockReturnValue({ pluginId: SupportedPlugin.Incident, installed: undefined, loading: true });
-
-    const { container } = render(<IncidentsCard />);
-    expect(container).toBeEmptyDOMElement();
-  });
-
   it('lists active incidents with severity, count badge, and detail links', async () => {
     mockIncidents(activeIncidents);
 

--- a/public/app/features/home/AlertsIncidents/IncidentsCard.tsx
+++ b/public/app/features/home/AlertsIncidents/IncidentsCard.tsx
@@ -3,10 +3,8 @@ import { useFlagGrafanaGrowthHomepage } from '@grafana/runtime/internal';
 import { Badge, LinkButton, Tooltip } from '@grafana/ui';
 import { ACTIVE_INCIDENTS_QUERY_LIMIT } from 'app/features/alerting/unified/api/incidentsApi';
 import { createBridgeURL } from 'app/features/alerting/unified/components/PluginBridge';
-import { useIrmPlugin } from 'app/features/alerting/unified/hooks/usePluginBridge';
 import { SeverityBars } from 'app/features/alerting/unified/triage/scene/filters/SeverityBars';
 import { canonicalSeverity } from 'app/features/alerting/unified/triage/scene/filters/severity';
-import { SupportedPlugin } from 'app/features/alerting/unified/types/pluginBridges';
 import { ListRow } from 'app/plugins/panel/dashlist/ListRow';
 
 import { ctaClicked } from '../analytics/main';
@@ -17,22 +15,6 @@ import { severityLevelColor } from './severity';
 import { useIncidents, type IncidentsData } from './useIncidents';
 
 export function IncidentsCard() {
-  const { installed, loading } = useIrmPlugin(SupportedPlugin.Incident);
-
-  // Hide the card whenever the Incident/IRM plugin isn't available — including while the
-  // settings probe is in flight, so the card never flashes in before disappearing.
-  if (loading || !installed) {
-    return null;
-  }
-
-  return <IncidentsCardInner />;
-}
-
-/**
- * Inner component avoids calling hooks conditionally —
- * the availability gate lives in the parent wrapper.
- */
-function IncidentsCardInner() {
   const data = useIncidents();
   return <IncidentsCardView data={data} />;
 }

--- a/public/app/features/home/AlertsIncidents/NewsCard.tsx
+++ b/public/app/features/home/AlertsIncidents/NewsCard.tsx
@@ -1,6 +1,5 @@
 import { css } from '@emotion/css';
 import { useEffect } from 'react';
-import { useMeasure } from 'react-use';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
@@ -17,7 +16,6 @@ import { SummaryCard } from './SummaryCard';
 export function NewsCard() {
   const styles = useStyles2(getStyles);
   const { state, getNews } = useNewsFeed(DEFAULT_FEED_URL);
-  const [widthRef, widthMeasure] = useMeasure<HTMLUListElement>();
 
   useEffect(() => {
     getNews();
@@ -34,13 +32,8 @@ export function NewsCard() {
       }
       emptyMessage={t('home.news-card.empty', 'No recent blog posts.')}
       items={Array.from({ length: state.value?.length ?? 0 }, (_, i) => i)}
-      itemsRef={widthRef}
       getItemKey={(index) => state.value?.get(index)?.link ?? String(index)}
-      renderItem={(index) =>
-        state.value && (
-          <News showImage width={widthMeasure.width} data={state.value} index={index} className={styles.post} />
-        )
-      }
+      renderItem={(index) => state.value && <News showImage data={state.value} index={index} className={styles.post} />}
       footer={
         !!state.value?.length && (
           <FooterActions>

--- a/public/app/features/home/AlertsIncidents/NewsCard.tsx
+++ b/public/app/features/home/AlertsIncidents/NewsCard.tsx
@@ -1,0 +1,72 @@
+import { css } from '@emotion/css';
+import { useEffect } from 'react';
+import { useMeasure } from 'react-use';
+
+import { type GrafanaTheme2 } from '@grafana/data';
+import { t, Trans } from '@grafana/i18n';
+import { useStyles2 } from '@grafana/ui';
+import { News } from 'app/plugins/panel/news/component/News';
+import { DEFAULT_FEED_URL } from 'app/plugins/panel/news/constants';
+import { useNewsFeed } from 'app/plugins/panel/news/useNewsFeed';
+
+import { FooterAction, FooterActions } from '../FooterActions';
+import { ctaClicked } from '../analytics/main';
+
+import { SummaryCard } from './SummaryCard';
+
+export function NewsCard() {
+  const styles = useStyles2(getStyles);
+  const { state, getNews } = useNewsFeed(DEFAULT_FEED_URL);
+  const [widthRef, widthMeasure] = useMeasure<HTMLUListElement>();
+
+  useEffect(() => {
+    getNews();
+  }, [getNews]);
+
+  return (
+    <SummaryCard
+      title={t('home.news-card.title', 'Latest from the blog')}
+      loading={state.loading}
+      error={
+        state.error
+          ? { title: t('home.news-card.error-title', 'Could not load recent blog posts'), onRetry: () => getNews() }
+          : undefined
+      }
+      emptyMessage={t('home.news-card.empty', 'No recent blog posts.')}
+      items={Array.from({ length: state.value?.length ?? 0 }, (_, i) => i)}
+      itemsRef={widthRef}
+      getItemKey={(index) => state.value?.get(index)?.link ?? String(index)}
+      renderItem={(index) =>
+        state.value && (
+          <News showImage width={widthMeasure.width} data={state.value} index={index} className={styles.post} />
+        )
+      }
+      footer={
+        !!state.value?.length && (
+          <FooterActions>
+            <FooterAction
+              icon="rss"
+              href="https://grafana.com/blog/"
+              external
+              onClick={() => ctaClicked({ surface: 'news_card', action: 'read_more_news', placement: 'footer' })}
+            >
+              <Trans i18nKey="home.news-card.read-more">Read more from the Grafana Labs blog</Trans>
+            </FooterAction>
+          </FooterActions>
+        )
+      }
+    />
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  post: css({
+    background: 'none',
+    padding: theme.spacing(0, 0, 1.25),
+    margin: 0,
+
+    'a:has(img)': {
+      alignItems: 'flex-start',
+    },
+  }),
+});

--- a/public/app/features/home/AlertsIncidents/SummaryCard.tsx
+++ b/public/app/features/home/AlertsIncidents/SummaryCard.tsx
@@ -77,7 +77,7 @@ export function SummaryCard<T>({
           </Stack>
         )}
 
-        {error && (
+        {!loading && error && (
           <Alert
             severity="warning"
             title={error.title}

--- a/public/app/features/home/AlertsIncidents/SummaryCard.tsx
+++ b/public/app/features/home/AlertsIncidents/SummaryCard.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import { formatDistanceToNowStrict } from 'date-fns/formatDistanceToNowStrict';
-import { type Ref, type ReactNode } from 'react';
+import { type ReactNode } from 'react';
 import Skeleton from 'react-loading-skeleton';
 
 import { type GrafanaTheme2 } from '@grafana/data';
@@ -27,7 +27,6 @@ interface SummaryCardProps<T> {
   // Rendered in the empty state in place of emptyMessage — a call-to-action button. Caller gates it.
   emptyAction?: ReactNode;
   items: T[];
-  itemsRef?: Ref<HTMLUListElement>;
   getItemKey: (item: T) => string;
   renderItem: (item: T) => ReactNode;
   // Footer element, already gated by the caller. Omit to render no footer.
@@ -44,7 +43,6 @@ export function SummaryCard<T>({
   emptyMessage,
   emptyAction,
   items,
-  itemsRef,
   getItemKey,
   renderItem,
   footer,
@@ -96,7 +94,7 @@ export function SummaryCard<T>({
         )}
 
         {!loading && !error && items.length > 0 && (
-          <ul ref={itemsRef} className={redesignEnabled ? undefined : styles.list}>
+          <ul className={redesignEnabled ? undefined : styles.list}>
             {items.map((item) => (
               <li key={getItemKey(item)} className={!redesignEnabled ? styles.rowPadding : undefined}>
                 {renderItem(item)}

--- a/public/app/features/home/AlertsIncidents/SummaryCard.tsx
+++ b/public/app/features/home/AlertsIncidents/SummaryCard.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import { formatDistanceToNowStrict } from 'date-fns/formatDistanceToNowStrict';
-import { type ReactNode } from 'react';
+import { type Ref, type ReactNode } from 'react';
 import Skeleton from 'react-loading-skeleton';
 
 import { type GrafanaTheme2 } from '@grafana/data';
@@ -16,7 +16,7 @@ interface SummaryCardProps<T> {
   title: string;
   // Header count badge: red when count > 0. When countLimit is set and count >= countLimit the badge
   // reads `${countLimit}+` (server-capped data); otherwise the exact count.
-  count: number;
+  count?: number;
   countLimit?: number;
   // Right-aligned header content (e.g. a severity breakdown). Hidden while loading.
   headerExtra?: ReactNode;
@@ -27,6 +27,7 @@ interface SummaryCardProps<T> {
   // Rendered in the empty state in place of emptyMessage — a call-to-action button. Caller gates it.
   emptyAction?: ReactNode;
   items: T[];
+  itemsRef?: Ref<HTMLUListElement>;
   getItemKey: (item: T) => string;
   renderItem: (item: T) => ReactNode;
   // Footer element, already gated by the caller. Omit to render no footer.
@@ -35,7 +36,7 @@ interface SummaryCardProps<T> {
 
 export function SummaryCard<T>({
   title,
-  count,
+  count = 0,
   countLimit,
   headerExtra,
   loading,
@@ -43,6 +44,7 @@ export function SummaryCard<T>({
   emptyMessage,
   emptyAction,
   items,
+  itemsRef,
   getItemKey,
   renderItem,
   footer,
@@ -94,7 +96,7 @@ export function SummaryCard<T>({
         )}
 
         {!loading && !error && items.length > 0 && (
-          <ul className={redesignEnabled ? undefined : styles.list}>
+          <ul ref={itemsRef} className={redesignEnabled ? undefined : styles.list}>
             {items.map((item) => (
               <li key={getItemKey(item)} className={!redesignEnabled ? styles.rowPadding : undefined}>
                 {renderItem(item)}

--- a/public/app/features/home/DashboardTabs/MostUsedDashboardsTab.tsx
+++ b/public/app/features/home/DashboardTabs/MostUsedDashboardsTab.tsx
@@ -1,6 +1,8 @@
 import { css } from '@emotion/css';
 
+import { type GrafanaTheme2 } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
+import { useFlagGrafanaGrowthHomepage } from '@grafana/runtime/internal';
 import { EmptyState, Stack, useStyles2 } from '@grafana/ui';
 import PageLoader from 'app/core/components/PageLoader/PageLoader';
 import { type DashboardQueryResult, type LocationInfo } from 'app/features/search/service/types';
@@ -18,7 +20,8 @@ interface Props {
 }
 
 export function MostUsedDashboardsTab({ dashboards, loading, error, retry, foldersByUid, density }: Props) {
-  const styles = useStyles2(getStyles);
+  const redesignEnabled = useFlagGrafanaGrowthHomepage();
+  const styles = useStyles2(getStyles, redesignEnabled);
 
   if (loading) {
     return <PageLoader text={t('home.most-used-dashboards-tab.loading', 'Loading most used dashboards...')} />;
@@ -69,10 +72,10 @@ export function MostUsedDashboardsTab({ dashboards, loading, error, retry, folde
   );
 }
 
-const getStyles = () => ({
+const getStyles = (theme: GrafanaTheme2, redesign: boolean) => ({
   list: css({
     listStyle: 'none',
-    padding: 0,
+    padding: theme.spacing(0, redesign ? 0 : 0.5),
     margin: 0,
   }),
 });

--- a/public/app/features/home/DashboardTabs/RecentDashboardsTab.tsx
+++ b/public/app/features/home/DashboardTabs/RecentDashboardsTab.tsx
@@ -1,6 +1,8 @@
 import { css } from '@emotion/css';
 
+import { type GrafanaTheme2 } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
+import { useFlagGrafanaGrowthHomepage } from '@grafana/runtime/internal';
 import { EmptyState, LinkButton, Stack, useStyles2 } from '@grafana/ui';
 import PageLoader from 'app/core/components/PageLoader/PageLoader';
 import { contextSrv } from 'app/core/services/context_srv';
@@ -24,7 +26,8 @@ interface Props {
 }
 
 export function RecentDashboardsTab({ dashboards, loading, error, retry, foldersByUid, onStarChange, density }: Props) {
-  const styles = useStyles2(getStyles);
+  const redesignEnabled = useFlagGrafanaGrowthHomepage();
+  const styles = useStyles2(getStyles, redesignEnabled);
 
   if (loading) {
     return <PageLoader text={t('home.recent-dashboards-tab.loading', 'Loading recently viewed dashboards...')} />;
@@ -106,10 +109,10 @@ export function RecentDashboardsTab({ dashboards, loading, error, retry, folders
   );
 }
 
-const getStyles = () => ({
+const getStyles = (theme: GrafanaTheme2, redesign: boolean) => ({
   list: css({
     listStyle: 'none',
-    padding: 0,
+    padding: theme.spacing(0, redesign ? 0 : 0.5),
     margin: 0,
   }),
 });

--- a/public/app/features/home/DashboardTabs/StarredDashboardsTab.tsx
+++ b/public/app/features/home/DashboardTabs/StarredDashboardsTab.tsx
@@ -1,6 +1,8 @@
 import { css } from '@emotion/css';
 
+import { type GrafanaTheme2 } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
+import { useFlagGrafanaGrowthHomepage } from '@grafana/runtime/internal';
 import { EmptyState, Icon, Stack, useStyles2 } from '@grafana/ui';
 import PageLoader from 'app/core/components/PageLoader/PageLoader';
 import { type DashboardQueryResult, type LocationInfo } from 'app/features/search/service/types';
@@ -18,7 +20,8 @@ interface Props {
 }
 
 export function StarredDashboardsTab({ dashboards, loading, error, retry, foldersByUid, density }: Props) {
-  const styles = useStyles2(getStyles);
+  const redesignEnabled = useFlagGrafanaGrowthHomepage();
+  const styles = useStyles2(getStyles, redesignEnabled);
 
   if (loading) {
     return <PageLoader text={t('home.starred-dashboards-tab.loading', 'Loading starred dashboards...')} />;
@@ -69,10 +72,10 @@ export function StarredDashboardsTab({ dashboards, loading, error, retry, folder
   );
 }
 
-const getStyles = () => ({
+const getStyles = (theme: GrafanaTheme2, redesign: boolean) => ({
   list: css({
     listStyle: 'none',
-    padding: 0,
+    padding: theme.spacing(0, redesign ? 0 : 0.5),
     margin: 0,
   }),
 });

--- a/public/app/features/home/FooterActions.tsx
+++ b/public/app/features/home/FooterActions.tsx
@@ -13,20 +13,29 @@ export function FooterActions({ children }: { children: ReactNode }) {
   );
 }
 
-interface FooterActionProps {
-  /** Renders a TextLink when set; a text Button otherwise, for actions that mutate instead of navigate. */
-  href?: string;
-  onClick: () => void;
+/** Renders a TextLink when href set; a text Button otherwise, for actions that mutate instead of navigate. */
+type FooterActionProps = {
   icon?: IconName;
   children: ReactNode;
-}
+} & (
+  | {
+      href: string;
+      external?: boolean;
+      onClick?: () => void;
+    }
+  | {
+      href?: never;
+      external?: never;
+      onClick: () => void;
+    }
+);
 
 /**
  * Single source of the homepage card footer-action treatment. Semantics follow behavior —
  * navigation renders a real link, everything else a <button>.
  */
-export function FooterAction({ href, onClick, icon, children }: FooterActionProps) {
-  const styles = useStyles2(getStyles);
+export function FooterAction({ href, external, onClick, icon, children }: FooterActionProps) {
+  const styles = useStyles2(getStyles, external);
 
   // Flex centering aligns the icon with the text line — no pixel-nudge margins needed.
   const content = icon ? (
@@ -40,9 +49,18 @@ export function FooterAction({ href, onClick, icon, children }: FooterActionProp
 
   if (href) {
     return (
-      <TextLink inline={false} color="secondary" variant="bodySmall" href={href} onClick={onClick}>
-        {content}
-      </TextLink>
+      <div className={styles.link}>
+        <TextLink
+          inline={false}
+          color="secondary"
+          variant="bodySmall"
+          href={href}
+          external={external}
+          onClick={onClick}
+        >
+          {content}
+        </TextLink>
+      </div>
     );
   }
 
@@ -53,7 +71,15 @@ export function FooterAction({ href, onClick, icon, children }: FooterActionProp
   );
 }
 
-const getStyles = (theme: GrafanaTheme2) => ({
+const getStyles = (theme: GrafanaTheme2, external?: boolean) => ({
+  // Remove default external icon from TextLink
+  link: css({
+    lineHeight: 1,
+
+    '& > a > svg:last-child': {
+      display: external ? 'none' : undefined,
+    },
+  }),
   // Visually align the button with the TextLink footer actions
   button: css({
     '&&': {

--- a/public/app/features/home/HomePage.test.tsx
+++ b/public/app/features/home/HomePage.test.tsx
@@ -12,6 +12,7 @@ import { contextSrv } from 'app/core/services/context_srv';
 import { useIrmPlugin } from 'app/features/alerting/unified/hooks/usePluginBridge';
 import { SupportedPlugin } from 'app/features/alerting/unified/types/pluginBridges';
 import { createComponentWithMeta } from 'app/features/plugins/extensions/usePluginComponents';
+import { useNewsFeed } from 'app/plugins/panel/news/useNewsFeed';
 
 import { type HomepageTabExtensionProps } from './DashboardTabs/types';
 import HomePage from './HomePage';
@@ -21,6 +22,7 @@ jest.mock('app/features/alerting/unified/hooks/usePluginBridge', () => ({
   ...jest.requireActual('app/features/alerting/unified/hooks/usePluginBridge'),
   useIrmPlugin: jest.fn(),
 }));
+
 jest.mock('./analytics/main', () => ({
   ctaClicked: jest.fn(),
   tabChanged: jest.fn(),
@@ -28,15 +30,22 @@ jest.mock('./analytics/main', () => ({
   homepageViewed: jest.fn(),
 }));
 
+jest.mock('app/plugins/panel/news/useNewsFeed');
+
 setBackendSrv(backendSrv);
 setupMockServer();
 
 const mockUseIrmPlugin = jest.mocked(useIrmPlugin);
+const useNewsFeedMock = jest.mocked(useNewsFeed);
 
 beforeEach(() => {
   jest.clearAllMocks();
   setPluginComponentsHook(() => ({ components: [], isLoading: false }));
   mockUseIrmPlugin.mockReturnValue({ pluginId: SupportedPlugin.Incident, installed: false, loading: false });
+  useNewsFeedMock.mockReturnValue({
+    state: { loading: false, error: undefined, value: undefined },
+    getNews: jest.fn(),
+  });
 
   // Deny alerting permission so the FiringAlertsCard renders null
   jest.spyOn(contextSrv, 'hasPermission').mockReturnValue(false);

--- a/public/app/features/home/HomePage.test.tsx
+++ b/public/app/features/home/HomePage.test.tsx
@@ -9,12 +9,18 @@ import server, { setupMockServer } from '@grafana/test-utils/server';
 import { setTestFlags } from '@grafana/test-utils/unstable';
 import { backendSrv } from 'app/core/services/backend_srv';
 import { contextSrv } from 'app/core/services/context_srv';
+import { useIrmPlugin } from 'app/features/alerting/unified/hooks/usePluginBridge';
+import { SupportedPlugin } from 'app/features/alerting/unified/types/pluginBridges';
 import { createComponentWithMeta } from 'app/features/plugins/extensions/usePluginComponents';
 
 import { type HomepageTabExtensionProps } from './DashboardTabs/types';
 import HomePage from './HomePage';
 import { homepageViewed } from './analytics/main';
 
+jest.mock('app/features/alerting/unified/hooks/usePluginBridge', () => ({
+  ...jest.requireActual('app/features/alerting/unified/hooks/usePluginBridge'),
+  useIrmPlugin: jest.fn(),
+}));
 jest.mock('./analytics/main', () => ({
   ctaClicked: jest.fn(),
   tabChanged: jest.fn(),
@@ -25,9 +31,12 @@ jest.mock('./analytics/main', () => ({
 setBackendSrv(backendSrv);
 setupMockServer();
 
+const mockUseIrmPlugin = jest.mocked(useIrmPlugin);
+
 beforeEach(() => {
   jest.clearAllMocks();
   setPluginComponentsHook(() => ({ components: [], isLoading: false }));
+  mockUseIrmPlugin.mockReturnValue({ pluginId: SupportedPlugin.Incident, installed: false, loading: false });
 
   // Deny alerting permission so the FiringAlertsCard renders null
   jest.spyOn(contextSrv, 'hasPermission').mockReturnValue(false);
@@ -175,6 +184,16 @@ describe('HomePage', () => {
 
   it('renders a skeleton instead of the page content while extensions are loading', async () => {
     setPluginComponentsHook(() => ({ components: [], isLoading: true }));
+
+    render(<HomePage />);
+
+    expect(await screen.findByTestId('home-page-skeleton')).toBeInTheDocument();
+    expect(screen.queryByRole('tab')).not.toBeInTheDocument();
+    expect(jest.mocked(homepageViewed)).not.toHaveBeenCalled();
+  });
+
+  it('renders a skeleton instead of the page content while incidents plugin is loading', async () => {
+    mockUseIrmPlugin.mockReturnValue({ pluginId: SupportedPlugin.Incident, installed: undefined, loading: true });
 
     render(<HomePage />);
 

--- a/public/app/features/home/HomePage.tsx
+++ b/public/app/features/home/HomePage.tsx
@@ -11,6 +11,9 @@ import { Page } from 'app/core/components/Page/Page';
 import { ASSISTANT_PLUGIN_ID, SETUPGUIDE_PLUGIN_ID } from 'app/core/constants';
 import { isOnPrem } from 'app/core/utils/isOnPrem';
 
+import { useIrmPlugin } from '../alerting/unified/hooks/usePluginBridge';
+import { SupportedPlugin } from '../alerting/unified/types/pluginBridges';
+
 import { AlertIncidentTabs } from './AlertsIncidents/AlertIncidentTabs';
 import { FiringAlertsCard } from './AlertsIncidents/FiringAlertsCard';
 import { IncidentsCard } from './AlertsIncidents/IncidentsCard';
@@ -65,8 +68,11 @@ export default function HomePage() {
     extensionPointId: PluginExtensionPoints.HomepageTabs,
   });
 
+  const irm = useIrmPlugin(SupportedPlugin.Incident);
+
   const isWaitingForTabs = !redesignEnabled && isLoadingTabs;
-  const isLoadingExtensions = isLoadingAssistant || isLoadingExtra || isWaitingForTabs;
+  const isWaitingForIRM = !redesignEnabled && irm.loading;
+  const isLoadingExtensions = isLoadingAssistant || isLoadingExtra || isWaitingForTabs || isWaitingForIRM;
 
   // The impression counts a rendered homepage, never a skeleton: the tracker mounts inside
   // the Suspense boundary below, so a suspended lazy extension defers it until reveal. The
@@ -156,7 +162,7 @@ export default function HomePage() {
 
                   <Grid gap={2} columns={{ xs: 1, md: 2 }}>
                     <FiringAlertsCard />
-                    <IncidentsCard />
+                    {irm.installed ? <IncidentsCard /> : null}
                   </Grid>
                 </>
               )}

--- a/public/app/features/home/HomePage.tsx
+++ b/public/app/features/home/HomePage.tsx
@@ -17,6 +17,7 @@ import { SupportedPlugin } from '../alerting/unified/types/pluginBridges';
 import { AlertIncidentTabs } from './AlertsIncidents/AlertIncidentTabs';
 import { FiringAlertsCard } from './AlertsIncidents/FiringAlertsCard';
 import { IncidentsCard } from './AlertsIncidents/IncidentsCard';
+import { NewsCard } from './AlertsIncidents/NewsCard';
 import { canViewFiringAlerts } from './AlertsIncidents/useFiringAlerts';
 import { DashboardTabs } from './DashboardTabs/DashboardTabs';
 import { type HomepageTabExtensionProps } from './DashboardTabs/types';
@@ -104,8 +105,14 @@ export default function HomePage() {
   });
   const showExtra = extraContent !== null;
   const showAlertsCard = canViewFiringAlerts();
+  const showIRMNewsCard = irm.loading || irm.installed || config.newsFeedEnabled;
   const skeleton = (
-    <HomePageSkeleton showAlertsCard={showAlertsCard} showExtra={showExtra} redesignEnabled={redesignEnabled} />
+    <HomePageSkeleton
+      showAlertsCard={showAlertsCard}
+      showIRMNewsCard={showIRMNewsCard}
+      showExtra={showExtra}
+      redesignEnabled={redesignEnabled}
+    />
   );
 
   return (
@@ -162,7 +169,7 @@ export default function HomePage() {
 
                   <Grid gap={2} columns={{ xs: 1, md: 2 }}>
                     <FiringAlertsCard />
-                    {irm.installed ? <IncidentsCard /> : null}
+                    {irm.installed ? <IncidentsCard /> : config.newsFeedEnabled && <NewsCard />}
                   </Grid>
                 </>
               )}

--- a/public/app/features/home/HomePageSkeleton.test.tsx
+++ b/public/app/features/home/HomePageSkeleton.test.tsx
@@ -15,6 +15,11 @@ describe('HomePageSkeleton', () => {
     expect(screen.getByTestId('home-page-skeleton-cards')).toBeInTheDocument();
   });
 
+  it('reserves the IRM/news card slot when showIRMNewsCard is set', () => {
+    render(<HomePageSkeleton showIRMNewsCard />);
+    expect(screen.getByTestId('home-page-skeleton-cards')).toBeInTheDocument();
+  });
+
   it('reserves the extra section when showExtra is set', () => {
     render(<HomePageSkeleton showExtra />);
     expect(screen.getByTestId('home-page-skeleton-extra')).toBeInTheDocument();

--- a/public/app/features/home/HomePageSkeleton.tsx
+++ b/public/app/features/home/HomePageSkeleton.tsx
@@ -8,12 +8,13 @@ import { HomeSection } from './HomeSection';
 
 interface Props {
   showAlertsCard?: boolean;
+  showIRMNewsCard?: boolean;
   showExtra?: boolean;
   redesignEnabled?: boolean;
 }
 
 // Opt-in sections so the skeleton never reserves a block the real page won't render.
-export function HomePageSkeleton({ showAlertsCard, showExtra, redesignEnabled }: Props) {
+export function HomePageSkeleton({ showAlertsCard, showIRMNewsCard, showExtra, redesignEnabled }: Props) {
   return (
     <div data-testid="home-page-skeleton">
       <Stack direction="column" gap={2}>
@@ -37,9 +38,10 @@ export function HomePageSkeleton({ showAlertsCard, showExtra, redesignEnabled }:
             <HomeSection direction="column" display="flex" gap={2}>
               <DashboardTabsSkeleton />
             </HomeSection>
-            {showAlertsCard && (
+            {(showAlertsCard || showIRMNewsCard) && (
               <Grid gap={2} columns={{ xs: 1, md: 2 }} data-testid="home-page-skeleton-cards">
-                <CardSkeleton />
+                {showAlertsCard && <CardSkeleton />}
+                {showIRMNewsCard && <CardSkeleton />}
               </Grid>
             )}
           </>

--- a/public/app/features/home/HomeRoute.test.tsx
+++ b/public/app/features/home/HomeRoute.test.tsx
@@ -8,6 +8,7 @@ import server, { setupMockServer } from '@grafana/test-utils/server';
 import { setTestFlags } from '@grafana/test-utils/unstable';
 import { backendSrv } from 'app/core/services/backend_srv';
 import { contextSrv } from 'app/core/services/context_srv';
+import { useNewsFeed } from 'app/plugins/panel/news/useNewsFeed';
 
 import HomeRoute from './HomeRoute';
 import { homepageViewed } from './analytics/main';
@@ -26,8 +27,12 @@ jest.mock('./analytics/main', () => ({
   homepageViewed: jest.fn(),
 }));
 
+jest.mock('app/plugins/panel/news/useNewsFeed');
+
 setBackendSrv(backendSrv);
 setupMockServer();
+
+const useNewsFeedMock = jest.mocked(useNewsFeed);
 
 describe('HomeRoute', () => {
   let probeCallCount = 0;
@@ -45,6 +50,10 @@ describe('HomeRoute', () => {
     jest.clearAllMocks();
     probeCallCount = 0;
     setPluginComponentsHook(() => ({ components: [], isLoading: false }));
+    useNewsFeedMock.mockReturnValue({
+      state: { loading: false, error: undefined, value: undefined },
+      getNews: jest.fn(),
+    });
 
     // Deny alerting permission so the FiringAlertsCard renders null
     jest.spyOn(contextSrv, 'hasPermission').mockReturnValue(false);

--- a/public/app/features/home/analytics/types.ts
+++ b/public/app/features/home/analytics/types.ts
@@ -12,7 +12,14 @@ export interface ClearHistoryClicked extends EventProperty {
 
 export interface CtaClicked extends EventProperty {
   /** Which homepage widget fired the CTA. */
-  surface: 'alerts_card' | 'incidents_card' | 'recent_tab' | 'recommendations' | 'existing_solution' | 'no_data_card';
+  surface:
+    | 'alerts_card'
+    | 'incidents_card'
+    | 'news_card'
+    | 'recent_tab'
+    | 'recommendations'
+    | 'existing_solution'
+    | 'no_data_card';
   /** What the user asked for. Which values are valid depends on the surface (not compiler-enforced). */
   action:
     | 'alert_detail'
@@ -22,6 +29,7 @@ export interface CtaClicked extends EventProperty {
     | 'incident_detail'
     | 'declare_incident'
     | 'view_all_incidents'
+    | 'read_more_news'
     | 'create_dashboard'
     | 'browse_dashboards'
     | 'enable'

--- a/public/app/plugins/panel/news/NewsPanel.tsx
+++ b/public/app/plugins/panel/news/NewsPanel.tsx
@@ -14,7 +14,6 @@ interface NewsPanelProps extends PanelProps<Options> {}
 
 export function NewsPanel(props: NewsPanelProps) {
   const {
-    width,
     options: { feedUrl = DEFAULT_FEED_URL, showImage },
   } = props;
 
@@ -59,7 +58,7 @@ export function NewsPanel(props: NewsPanelProps) {
   return (
     <ScrollContainer minHeight="100%">
       {state.value.map((_, index) => {
-        return <News key={index} index={index} width={width} showImage={showImage} data={state.value} />;
+        return <News key={index} index={index} showImage={showImage} data={state.value} />;
       })}
     </ScrollContainer>
   );

--- a/public/app/plugins/panel/news/component/News.tsx
+++ b/public/app/plugins/panel/news/component/News.tsx
@@ -14,9 +14,10 @@ interface NewsItemProps {
   showImage?: boolean;
   index: number;
   data: DataFrameView<NewsItem>;
+  className?: string;
 }
 
-function NewsComponent({ width, showImage, data, index }: NewsItemProps) {
+function NewsComponent({ width, showImage, data, index, className }: NewsItemProps) {
   const titleId = useId();
   const visualRefreshEnabled = useFlagGrafanaVisualDesignRefresh();
   const styles = useStyles2(getStyles, visualRefreshEnabled);
@@ -24,7 +25,7 @@ function NewsComponent({ width, showImage, data, index }: NewsItemProps) {
   const newsItem = data.get(index);
 
   return (
-    <article aria-labelledby={titleId} className={cx(styles.item, useWideLayout && styles.itemWide)}>
+    <article aria-labelledby={titleId} className={cx(styles.item, useWideLayout && styles.itemWide, className)}>
       {showImage && newsItem.ogImage && (
         <a
           tabIndex={-1}

--- a/public/app/plugins/panel/news/component/News.tsx
+++ b/public/app/plugins/panel/news/component/News.tsx
@@ -10,29 +10,27 @@ import { attachSkeleton, type SkeletonComponent } from '@grafana/ui/unstable';
 import { type NewsItem } from '../types';
 
 interface NewsItemProps {
-  width: number;
   showImage?: boolean;
   index: number;
   data: DataFrameView<NewsItem>;
   className?: string;
 }
 
-function NewsComponent({ width, showImage, data, index, className }: NewsItemProps) {
+function NewsComponent({ showImage, data, index, className }: NewsItemProps) {
   const titleId = useId();
   const visualRefreshEnabled = useFlagGrafanaVisualDesignRefresh();
   const styles = useStyles2(getStyles, visualRefreshEnabled);
-  const useWideLayout = width > 600;
   const newsItem = data.get(index);
 
   return (
-    <article aria-labelledby={titleId} className={cx(styles.item, useWideLayout && styles.itemWide, className)}>
+    <article aria-labelledby={titleId} className={cx(styles.item, className)}>
       {showImage && newsItem.ogImage && (
         <a
           tabIndex={-1}
           href={textUtil.sanitizeUrl(newsItem.link)}
           target="_blank"
           rel="noopener noreferrer"
-          className={cx(styles.socialImage, useWideLayout && styles.socialImageWide)}
+          className={styles.socialImage}
           aria-hidden
         >
           <img src={newsItem.ogImage} alt={newsItem.title} />
@@ -54,23 +52,12 @@ function NewsComponent({ width, showImage, data, index, className }: NewsItemPro
   );
 }
 
-const NewsSkeleton: SkeletonComponent<Pick<NewsItemProps, 'width' | 'showImage'>> = ({
-  width,
-  showImage,
-  rootProps,
-}) => {
+const NewsSkeleton: SkeletonComponent<Pick<NewsItemProps, 'showImage'>> = ({ showImage, rootProps }) => {
   const styles = useStyles2(getStyles);
-  const useWideLayout = width > 600;
 
   return (
-    <div className={cx(styles.item, useWideLayout && styles.itemWide)} {...rootProps}>
-      {showImage && (
-        <Skeleton
-          containerClassName={cx(styles.socialImage, useWideLayout && styles.socialImageWide)}
-          width={useWideLayout ? '250px' : '100%'}
-          height={useWideLayout ? '150px' : width * 0.5}
-        />
-      )}
+    <div className={styles.item} {...rootProps}>
+      {showImage && <Skeleton containerClassName={styles.socialImage} width="100%" style={{ aspectRatio: '16 / 9' }} />}
       <div className={styles.body}>
         <Skeleton containerClassName={styles.date} width={60} />
         <Skeleton containerClassName={styles.title} width={250} />
@@ -89,16 +76,14 @@ const getStyles = (theme: GrafanaTheme2, visualRefreshEnabled?: boolean) => ({
   item: css({
     display: 'flex',
     padding: theme.spacing(1),
+    gap: theme.spacing(2),
     position: 'relative',
     marginBottom: theme.spacing(0.5),
     marginRight: theme.spacing(1),
     borderBottom: `2px solid ${theme.colors.border.weak}`,
     background: visualRefreshEnabled ? theme.components.panel.background : theme.colors.background.primary,
-    flexDirection: 'column',
-    flexShrink: 0,
-  }),
-  itemWide: css({
     flexDirection: 'row',
+    flexShrink: 0,
   }),
   body: css({
     display: 'flex',
@@ -108,17 +93,10 @@ const getStyles = (theme: GrafanaTheme2, visualRefreshEnabled?: boolean) => ({
   socialImage: css({
     display: 'flex',
     alignItems: 'center',
-    marginBottom: theme.spacing(1),
+    width: '33.33%',
+    maxWidth: '250px',
     '> img': {
       width: '100%',
-      borderRadius: `${theme.shape.radius.lg} ${theme.shape.radius.lg} 0 0`,
-    },
-  }),
-  socialImageWide: css({
-    marginRight: theme.spacing(2),
-    marginBottom: 0,
-    '> img': {
-      width: '250px',
       borderRadius: theme.shape.radius.lg,
     },
   }),

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -10954,6 +10954,12 @@
       "error-title": "Could not load most used dashboards",
       "loading": "Loading most used dashboards..."
     },
+    "news-card": {
+      "empty": "No recent blog posts.",
+      "error-title": "Could not load recent blog posts",
+      "read-more": "Read more from the Grafana Labs blog",
+      "title": "Latest from the blog"
+    },
     "recent-dashboards-tab": {
       "browse": "Browse dashboards",
       "clear": "Clear history",


### PR DESCRIPTION
**What is this feature?**

When the incident card is unavailable, show a news card with the latest posts from the blog, similar to the previous homepage.

<img width="4112" height="2438" alt="image" src="https://github.com/user-attachments/assets/8d515bdb-6289-47a7-b3a1-34ff5177fcf0" />

**Why do we need this feature?**

When the incident card is unavailable, as is the case for OSS users, the page feels unbalanced when just alerting is shown.

**Who is this feature for?**

OSS users.

**Which issue(s) does this PR fix?**:

cc https://github.com/grafana/grafana/issues/124136

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
