### PR TITLE
Sidebar: Fix edit as code pane resisting resize

### DIFF
--- a/packages/grafana-ui/src/components/Sidebar/useSidebar.test.tsx
+++ b/packages/grafana-ui/src/components/Sidebar/useSidebar.test.tsx
@@ -316,4 +316,42 @@ describe('useSidebar', () => {
       expect(style?.paddingRight).toBeLessThan(paneWidth);
     });
   });
+
+  describe('minPaneWidth', () => {
+    test('renders the open pane at minPaneWidth when the persisted width is smaller', () => {
+      // Persisted width defaults to 240, which is below the pane's minimum
+      const { result } = renderHook(() => useSidebar({ hasOpenPane: true, minPaneWidth: 700 }));
+      expect(result.current.paneWidth).toBe(700);
+    });
+
+    test('does not resize the pane below minPaneWidth', () => {
+      const { result } = renderHook(() => useSidebar({ hasOpenPane: true, minPaneWidth: 700 }));
+
+      act(() => {
+        result.current.onResize(-500);
+      });
+
+      expect(result.current.paneWidth).toBe(700);
+    });
+
+    test('allows resizing above minPaneWidth so there is a draggable range', () => {
+      const { result } = renderHook(() => useSidebar({ hasOpenPane: true, minPaneWidth: 700 }));
+
+      act(() => {
+        result.current.onResize(150);
+      });
+
+      expect(result.current.paneWidth).toBe(850);
+    });
+
+    test('keeps the default 100px floor when no minPaneWidth is set', () => {
+      const { result } = renderHook(() => useSidebar({ hasOpenPane: true }));
+
+      act(() => {
+        result.current.onResize(-1000);
+      });
+
+      expect(result.current.paneWidth).toBe(100);
+    });
+  });
 });

--- a/packages/grafana-ui/src/components/Sidebar/useSidebar.tsx
+++ b/packages/grafana-ui/src/components/Sidebar/useSidebar.tsx
@@ -71,6 +71,12 @@ export interface UseSideBarOptions {
    * persistenceKeys (e.g. dashboard view vs edit mode share a single hide preference).
    */
   hiddenPersistenceKey?: string;
+  /**
+   * Minimum width (in px) the open pane needs. When set, the pane is never rendered or
+   * resized below this width, and the resize ceiling is raised so the minimum is always
+   * reachable with room to drag. Typically sourced from the open pane's own `minWidth`.
+   */
+  minPaneWidth?: number;
 }
 
 export const SIDE_BAR_WIDTH_ICON_ONLY = 5;
@@ -91,11 +97,16 @@ export function useSidebar({
   canGoBack,
   defaultIsHidden = false,
   hiddenPersistenceKey,
+  minPaneWidth,
 }: UseSideBarOptions): SidebarContextValue {
   const theme = useTheme2();
   const [isDocked, setIsDocked] = useSidebarSavedState(persistenceKey, 'docked', defaultToDocked);
   const [compact, setCompact] = useSidebarSavedState(persistenceKey, 'compact', defaultToCompact);
   const [paneWidth, setPaneWidth] = useSidebarSavedState(persistenceKey, 'size', 240);
+  // The persisted width can be smaller than what the open pane needs (e.g. it was set while a
+  // narrower pane was open). Render at the larger of the two so a pane never appears below its
+  // minimum, without having to mutate (and persist) the stored width just to open the pane.
+  const effectivePaneWidth = minPaneWidth ? Math.max(paneWidth, minPaneWidth) : paneWidth;
   const [isHidden, setIsHidden] = useSidebarSavedState(
     hiddenPersistenceKey ?? persistenceKey,
     'hidden',
@@ -126,7 +137,7 @@ export function useSidebar({
       ? {}
       : {
           style: {
-            [prop]: effectiveIsDocked && hasOpenPane ? paneWidth + toolbarWidth : toolbarWidth,
+            [prop]: effectiveIsDocked && hasOpenPane ? effectivePaneWidth + toolbarWidth : toolbarWidth,
           },
         };
 
@@ -151,11 +162,19 @@ export function useSidebar({
           return prevWidth;
         }
 
-        const maxWidth = Math.max(window.innerWidth * 0.5, 500);
-        return clamp(prevWidth + diff, 100, maxWidth);
+        // Never resize below the open pane's minimum. Keep the ceiling at half the viewport,
+        // but raise it when a pane declares a large minimum so the minimum stays reachable and
+        // there is still room to drag (otherwise min and max collapse to the same value and the
+        // pane appears "stuck").
+        const minWidth = minPaneWidth ?? 100;
+        const maxWidth = Math.max(window.innerWidth * 0.5, minWidth + 300, 500);
+        // Resize from the currently displayed width (which is never below the minimum) so the
+        // first drag after opening a min-constrained pane responds immediately instead of first
+        // eating the gap between the persisted width and the minimum.
+        return clamp(Math.max(prevWidth, minWidth) + diff, minWidth, maxWidth);
       });
     },
-    [hasOpenPane, setCompact, setPaneWidth, compact]
+    [hasOpenPane, setCompact, setPaneWidth, compact, minPaneWidth]
   );
 
   const onToggleIsHidden = useCallback(() => setIsHidden((prev) => !prev), [setIsHidden]);
@@ -170,12 +189,12 @@ export function useSidebar({
     compact,
     hasOpenPane,
     tabsMode,
-    paneWidth,
     edgeMargin,
     bottomMargin,
     contentMargin,
     isHidden: effectiveIsHidden,
     isHiddenPreference: isHidden,
+    paneWidth: effectivePaneWidth,
     onClosePane,
     onGoBack,
     canGoBack,

--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneSplitter.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneSplitter.tsx
@@ -1,5 +1,5 @@
 import { css, cx } from '@emotion/css';
-import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useState } from 'react';
 import { useMedia } from 'react-use';
 
 import { type GrafanaTheme2 } from '@grafana/data';
@@ -8,14 +8,7 @@ import { t } from '@grafana/i18n';
 import { config, useChromeHeaderHeight } from '@grafana/runtime';
 import { useFlagGrafanaVisualDesignRefresh } from '@grafana/runtime/internal';
 import { type VizPanel, useSceneObjectState } from '@grafana/scenes';
-import {
-  ElementSelectionContext,
-  useSidebar,
-  useStyles2,
-  useTheme2,
-  Sidebar,
-  type SidebarContextValue,
-} from '@grafana/ui';
+import { ElementSelectionContext, useSidebar, useStyles2, useTheme2, Sidebar } from '@grafana/ui';
 import { getInternalRadius } from '@grafana/ui/internal';
 import NativeScrollbar, { DivScrollElement } from 'app/core/components/NativeScrollbar';
 import { useGrafana } from 'app/core/context/GrafanaContext';
@@ -36,7 +29,6 @@ import { StarButton } from '../scene/new-toolbar/actions/StarButton';
 import { dynamicDashNavActions } from '../utils/registerDynamicDashNavAction';
 
 import { DashboardEditPaneRenderer } from './DashboardEditPaneRenderer';
-import { type DashboardSidebarPane } from './types';
 
 interface Props {
   dashboard: DashboardScene;
@@ -156,9 +148,8 @@ function DashboardEditPaneSplitterNewLayouts({ dashboard, isEditing, body, contr
     onGoBack: () => editPane.goBackToPrevious(),
     canGoBack: previousState !== undefined,
     defaultIsHidden: isEditing ? false : isMobile,
+    minPaneWidth: openPane?.minWidth,
   });
-
-  useSidebarPaneMinWidth(openPane, sidebarContext);
 
   /**
    * Sync docked state to editPane state
@@ -238,28 +229,6 @@ function DashboardEditPaneSplitterNewLayouts({ dashboard, isEditing, body, contr
       </div>
     </AssistantPopoverContext.Provider>
   );
-}
-
-function useSidebarPaneMinWidth(openPane: DashboardSidebarPane | undefined, sidebarContext: SidebarContextValue) {
-  const originalPaneWidthRef = useRef<number | null>(null);
-  const previousPaneRef = useRef<DashboardSidebarPane | undefined>(undefined);
-
-  useEffect(() => {
-    previousPaneRef.current = openPane;
-
-    if (openPane?.minWidth && sidebarContext.paneWidth < openPane.minWidth) {
-      originalPaneWidthRef.current = sidebarContext.paneWidth;
-      const diff = openPane.minWidth - sidebarContext.paneWidth;
-      sidebarContext.onResize(diff);
-    }
-
-    // If we are switching to a different openPane without minWidth
-    if (openPane && !openPane.minWidth && originalPaneWidthRef.current !== null) {
-      const diff = originalPaneWidthRef.current - sidebarContext.paneWidth;
-      sidebarContext.onResize(diff);
-      originalPaneWidthRef.current = null;
-    }
-  }, [openPane, sidebarContext]);
 }
 
 function useUpdateAppChromeActions(dashboard: DashboardScene) {


### PR DESCRIPTION
**What this PR does**

Fixes the "Edit as code" pane resisting resize: it could not be made smaller or larger and felt like it was fighting the drag.

**Root cause**

The bug was an interaction between the pane's minimum width and the sidebar resize logic, not AutoSizer:

- `DashboardCodePane` declares `minWidth = 700`.
- `useSidebarPaneMinWidth` enforced that minimum by repeatedly calling `onResize`. Its effect depended on the sidebar context object, which is recreated on every render, so it fired on essentially every render and snapped the width back to the minimum mid-drag ("can't make it smaller").
- `onResize` clamped the width to `[100, Math.max(window.innerWidth * 0.5, 500)]`. On any window narrower than ~1400px that ceiling is below 700, so the 700 minimum was unreachable and the clamp and the effect fought each other ("can't make it bigger" either).

**The fix**

Teach the sidebar about the pane's minimum instead of enforcing it with an external effect:

- Add a `minPaneWidth` option to `useSidebar`. `onResize` now clamps to `[minWidth, Math.max(window.innerWidth * 0.5, minWidth + 300, 500)]`, so the minimum is a real floor (the drag simply stops there, no snap-back) and there is always a draggable range above it.
- The pane renders at the larger of the persisted width and the minimum, and resizes from the displayed width, so the first drag after opening responds immediately without first eating the gap up to the minimum.
- Remove `useSidebarPaneMinWidth` and pass `openPane?.minWidth` into `useSidebar`.

Panes without a `minPaneWidth` are unaffected: the floor stays 100 and the ceiling is unchanged.

**Tests**

Added unit tests in `useSidebar.test.tsx` covering: rendering at the minimum when the persisted width is smaller, not resizing below the minimum, allowing resize above the minimum (draggable range), and the unchanged 100px floor when no minimum is set.

**Which issue(s) does this PR fix**

Reported in Slack by @torkelo in #grafana-dashboards-core.
