### PR TITLE
Docs: Warn that webhook URL is not a secured field

### DIFF
--- a/docs/sources/alerting/configure-notifications/manage-contact-points/integrations/webhook-notifier.md
+++ b/docs/sources/alerting/configure-notifications/manage-contact-points/integrations/webhook-notifier.md
@@ -66,6 +66,14 @@ For more details on contact points, including how to test them and enable notifi
 | ------ | ------------------------------------------------------------------------------------------------------------ |
 | URL    | The Webhook URL. This field is [protected](ref:configure-contact-points) from modification in Grafana Cloud. |
 
+{{< admonition type="caution" >}}
+
+The URL is not a secured field. It's stored in plain text and isn't masked when the contact point is read back. Include secrets such as tokens or passwords in the URL at your own risk.
+
+To authenticate to your webhook endpoint, use the authorization fields in the [optional settings](#optional-settings) instead, such as Basic Authentication or the Authorization request header. These fields are stored securely and are masked on read.
+
+{{< /admonition >}}
+
 #### Optional settings
 
 | Option                            | Description                                                                                                                                                                               |


### PR DESCRIPTION
## What this PR does

Adds a caution admonition to the webhook contact point docs clarifying that the **URL field is not secured** — it's stored in plain text and is not masked when the contact point is read back.

Since the URL is readable, the docs now steer users toward the properly-secured authorization fields (Basic Authentication, Authorization request header) for credentials, and note that putting secrets in the URL is at your own risk.

## Why

The URL field being unmasked on read is easy to miss, and it's a natural place users reach for when adding tokens. The open question this answers: *where should webhook credentials go so they aren't exposed on read?*

## Which issue(s) this PR fixes

N/A — documentation clarification.
