### PR TITLE
Snapshots: Fix inspect data panel

### DIFF
--- a/public/app/features/dashboard-scene/serialization/sceneVariablesSetToVariables.test.ts
+++ b/public/app/features/dashboard-scene/serialization/sceneVariablesSetToVariables.test.ts
@@ -28,6 +28,7 @@ import { type DataSourceRef, VariableHide, VariableRefresh } from '@grafana/sche
 
 import { toControlSourceRef } from '../utils/predefinedVariables';
 
+import { SnapshotVariable } from './custom-variables/SnapshotVariable';
 import { sceneVariablesSetToSchemaV2Variables, sceneVariablesSetToVariables } from './sceneVariablesSetToVariables';
 
 const runRequestMock = jest.fn().mockReturnValue(
@@ -604,6 +605,27 @@ describe('sceneVariablesSetToVariables', () => {
       "type": "adhoc",
     }
     `);
+  });
+
+  it('should skip SnapshotVariable without throwing', () => {
+    const variable = new SnapshotVariable({
+      name: 'test',
+      label: 'test-label',
+      value: 'selected-value',
+      text: 'selected-value-text',
+      options: [{ label: 'selected-value-text', value: 'selected-value' }],
+      hide: VariableHide.dontHide,
+    });
+
+    const set = new SceneVariableSet({
+      variables: [variable],
+    });
+
+    let result: ReturnType<typeof sceneVariablesSetToVariables> = [];
+    expect(() => {
+      result = sceneVariablesSetToVariables(set);
+    }).not.toThrow();
+    expect(result).toHaveLength(0);
   });
 
   describe('should adapt AdHocFiltersVariable filters', () => {
@@ -1600,6 +1622,27 @@ describe('sceneVariablesSetToVariables', () => {
       },
     }
     `);
+    });
+
+    it('should skip SnapshotVariable without throwing', () => {
+      const variable = new SnapshotVariable({
+        name: 'test',
+        label: 'test-label',
+        value: 'selected-value',
+        text: 'selected-value-text',
+        options: [{ label: 'selected-value-text', value: 'selected-value' }],
+        hide: VariableHide.dontHide,
+      });
+
+      const set = new SceneVariableSet({
+        variables: [variable],
+      });
+
+      let result: ReturnType<typeof sceneVariablesSetToSchemaV2Variables> = [];
+      expect(() => {
+        result = sceneVariablesSetToSchemaV2Variables(set);
+      }).not.toThrow();
+      expect(result).toHaveLength(0);
     });
 
     describe('when the dashboardUnifiedDrilldownControls feature toggle is enabled', () => {

--- a/public/app/features/dashboard-scene/serialization/sceneVariablesSetToVariables.ts
+++ b/public/app/features/dashboard-scene/serialization/sceneVariablesSetToVariables.ts
@@ -280,7 +280,7 @@ export function sceneVariablesSetToVariables(
       // Not persisted. Snapshot variables are read-only frozen values; the scene graph
       // interpolates them directly, so there is nothing to serialize here.
     } else {
-      throw new Error('Unsupported variable type');
+      throw new Error('Unsupported variable type: ' + variable.state.type);
     }
   }
 

--- a/public/app/features/dashboard-scene/serialization/sceneVariablesSetToVariables.ts
+++ b/public/app/features/dashboard-scene/serialization/sceneVariablesSetToVariables.ts
@@ -276,8 +276,9 @@ export function sceneVariablesSetToVariables(
           },
         ],
       });
-    } else if (variable.state.type === 'system') {
-      // Not persisted
+    } else if (variable.state.type === 'system' || variable.state.type === 'snapshot') {
+      // Not persisted. Snapshot variables are read-only frozen values; the scene graph
+      // interpolates them directly, so there is nothing to serialize here.
     } else {
       throw new Error('Unsupported variable type');
     }
@@ -621,8 +622,9 @@ export function sceneVariablesSetToSchemaV2Variables(
         },
       };
       variables.push(switchVariable);
-    } else if (variable.state.type === 'system') {
-      // Do nothing
+    } else if (variable.state.type === 'system' || variable.state.type === 'snapshot') {
+      // Not persisted. Snapshot variables are read-only frozen values; the scene graph
+      // interpolates them directly, so there is nothing to serialize here.
     } else {
       throw new Error('Unsupported variable type: ' + variable.state.type);
     }


### PR DESCRIPTION
**What this PR does**

Fixes a crash when opening Inspect → Data (or JSON) on a panel in a dashboard snapshot. The console threw:
```
Error: Unsupported variable type: snapshot
    at sceneVariablesSetToSchemaV2Variables (sceneVariablesSetToVariables.ts)
    at V2DashboardSerializer.getSaveModel (DashboardSceneSerializer.ts)
    at getJsonText (InspectJsonTab.tsx)
```

which prevented the inspect drawer from opening (no CSV download, no panel JSON).

**Why it happened**

When a snapshot loads, every template variable is converted into a read-only SnapshotVariable (state.type === 'snapshot'). InspectJsonTab calls dashboard.getSaveModel() purely to detect whether the dashboard is V1 or V2, and that serializes the whole dashboard — including its variables. Both variable serializers in sceneVariablesSetToVariables.ts dispatch on variable type and throw on any type they don't recognize. There was no case for snapshot, so it hit the else and threw.

**The fix**

Treat snapshot like the existing system case in both the V1 (sceneVariablesSetToVariables) and V2 (sceneVariablesSetToSchemaV2Variables) serializers — skip it, don't persist it.

This is safe because a snapshot is static, read-only data:
 - Its save model is never used to re-save a dashboard.
 - Actual $var interpolation in scenes runs through sceneGraph.interpolate off the live scene graph (the SnapshotVariable objects themselves), not through this serializer, so variable interpolation in the snapshot is unaffected.

**Tests**

Added a case to each serializer's test suite verifying a SnapshotVariable is skipped without throwing.

**How to verify**

1. Open a dashboard with template variables and create a Local Snapshot.
2. In the snapshot, open a panel → Inspect → Data.
3. The data/CSV panel opens with no Unsupported variable type: snapshot console error.

Fixes #118472

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
