### PR TITLE
Alerting: Decouple ExtraConfig.GetAlertmanagerConfig type from AMConfigV1

### DIFF
--- a/pkg/services/ngalert/notifier/legacy_storage/imported.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/imported.go
@@ -12,7 +12,7 @@ import (
 type ImportedConfigRevision struct {
 	identifier     string
 	rev            *ConfigRevision
-	importedConfig *v1.PostableApiAlertingConfig
+	importedConfig *v1.ExtraAlertmanagerConfig
 }
 
 func (rev *ConfigRevision) Imported() (ImportedConfigRevision, error) {

--- a/pkg/services/ngalert/notifier/legacy_storage/imported.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/imported.go
@@ -37,8 +37,12 @@ func (e ImportedConfigRevision) GetReceivers(uids []string) ([]*models.Receiver,
 	if e.importedConfig == nil {
 		return nil, nil
 	}
+	imported, err := e.importedConfig.ToGrafanaReceivers()
+	if err != nil {
+		return nil, err
+	}
 	original := e.rev.Config.AlertmanagerConfig.GetReceivers()
-	merged, _, _ := merge.Receivers(original, e.importedConfig.GetReceivers(), e.identifier)
+	merged, _, _ := merge.Receivers(original, imported, e.identifier)
 
 	capacity := len(uids)
 	if capacity == 0 {
@@ -66,8 +70,8 @@ func (e ImportedConfigRevision) GetMuteTimeIntervals() ([]v1.MuteTimeInterval, e
 	}
 
 	// Get original imported intervals (before deduplication)
-	importedMute := e.importedConfig.GetMuteTimeIntervals()
-	importedTime := e.importedConfig.GetTimeIntervals()
+	importedMute := e.importedConfig.ToGrafanaMuteTimeIntervals()
+	importedTime := e.importedConfig.ToGrafanaTimeIntervals()
 
 	if len(importedMute) == 0 && len(importedTime) == 0 {
 		return nil, nil
@@ -113,8 +117,8 @@ func (e ImportedConfigRevision) ReceiverUseByName() map[string]int {
 		return nil
 	}
 	m := make(map[string]int)
-	receiverUseCounts([]*v1.Route{e.importedConfig.Route}, m)
-	_, renames, _ := merge.Receivers(e.rev.Config.AlertmanagerConfig.GetReceivers(), e.importedConfig.GetReceivers(), e.identifier)
+	receiverUseCounts([]*v1.Route{e.importedConfig.ToGrafanaRoute()}, m)
+	_, renames, _ := merge.Receivers(e.rev.Config.AlertmanagerConfig.GetReceivers(), e.importedConfig.ReceiverNameStubs(), e.identifier)
 	for original, renamed := range renames {
 		if cnt, ok := m[original]; ok {
 			delete(m, original)
@@ -129,11 +133,13 @@ func (e ImportedConfigRevision) GetManagedRoute() (*ManagedRoute, error) {
 		return nil, nil
 	}
 
+	route := e.importedConfig.ToGrafanaRoute()
+
 	renamed := merge.DeduplicateResources(e.rev.Config.AlertmanagerConfig, *e.importedConfig, e.identifier)
 
-	merge.RenameResourceUsagesInRoutes([]*v1.Route{e.importedConfig.Route}, renamed)
+	merge.RenameResourceUsagesInRoutes([]*v1.Route{route}, renamed)
 
-	mr := NewManagedRoute(e.identifier, e.importedConfig.Route)
+	mr := NewManagedRoute(e.identifier, route)
 	mr.Provenance = models.ProvenanceConvertedPrometheus
 	mr.Origin = models.ResourceOriginImported
 	return mr, nil

--- a/pkg/services/ngalert/notifier/legacy_storage/routes.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/routes.go
@@ -296,9 +296,7 @@ func (rev *ConfigRevision) ValidateRoute(route v1.Route) error {
 }
 
 func (rev *ConfigRevision) validateReceiverReferences(route v1.Route) error {
-	receivers := rev.GetReceiversNames()
-	receivers[""] = struct{}{} // Allow empty receiver (inheriting from parent)
-	return route.ValidateReceivers(receivers)
+	return route.ValidateReceivers(rev.GetReceiversNames())
 }
 
 func (rev *ConfigRevision) validateTimeIntervalReferences(route v1.Route) error {

--- a/pkg/services/ngalert/notifier/legacy_storage/v1/model.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/v1/model.go
@@ -83,6 +83,64 @@ func (c *AMConfigV1) Validate() error {
 
 type ManagedRoutes map[string]*Route
 
+type ExtraAlertmanagerConfig struct {
+	Global       *config.GlobalConfig
+	Route        *Route
+	InhibitRules []config.InhibitRule
+
+	// MuteTimeIntervals is deprecated and will be removed before Alertmanager 1.0.
+	MuteTimeIntervals []MuteTimeInterval
+	TimeIntervals     []TimeInterval
+	Templates         []string
+
+	Receivers []*PostableApiReceiver
+}
+
+func (c *ExtraAlertmanagerConfig) GetReceivers() []*PostableApiReceiver {
+	return c.Receivers
+}
+
+func (c *ExtraAlertmanagerConfig) GetMuteTimeIntervals() []MuteTimeInterval {
+	return c.MuteTimeIntervals
+}
+
+func (c *ExtraAlertmanagerConfig) GetTimeIntervals() []TimeInterval { return c.TimeIntervals }
+
+func (c *ExtraAlertmanagerConfig) GetRoute() *Route {
+	return c.Route
+}
+
+// Validate ensures that the two routing trees use the correct receiver types.
+func (c *ExtraAlertmanagerConfig) Validate() error {
+	receivers := make(map[string]struct{}, len(c.Receivers))
+
+	for _, r := range c.Receivers {
+		receivers[r.Name] = struct{}{}
+	}
+
+	// Taken from https://github.com/prometheus/alertmanager/blob/14cbe6301c732658d6fe877ec55ad5b738abcf06/config/config.go#L171-L192
+	// Check if we have a root route. We cannot check for it in the
+	// UnmarshalYAML method because it won't be called if the input is empty
+	// (e.g. the config file is empty or only contains whitespace).
+	if c.Route == nil {
+		return fmt.Errorf("no route provided in config")
+	}
+
+	// Check if continue in root route.
+	if c.Route.Continue {
+		return fmt.Errorf("cannot have continue in root route")
+	}
+
+	for _, receiver := range AllReceivers(c.Route) {
+		_, ok := receivers[receiver]
+		if !ok {
+			return fmt.Errorf("unexpected receiver (%s) is undefined", receiver)
+		}
+	}
+
+	return nil
+}
+
 type ExtraConfiguration struct {
 	Identifier         string
 	TemplateFiles      map[string]string
@@ -91,10 +149,10 @@ type ExtraConfiguration struct {
 
 // GetAlertmanagerConfig parses the stored Prometheus/Mimir alertmanager YAML and converts it
 // to Grafana's PostableApiAlertingConfig, including route wrapping and receiver format conversion.
-func (c *ExtraConfiguration) GetAlertmanagerConfig() (PostableApiAlertingConfig, error) {
+func (c *ExtraConfiguration) GetAlertmanagerConfig() (ExtraAlertmanagerConfig, error) {
 	prometheusConfig, err := c.parsePrometheusConfig()
 	if err != nil {
-		return PostableApiAlertingConfig{}, err
+		return ExtraAlertmanagerConfig{}, err
 	}
 	cfg, _, err := alertmanagerConfigFromPrometheus(prometheusConfig)
 	return cfg, err
@@ -103,17 +161,15 @@ func (c *ExtraConfiguration) GetAlertmanagerConfig() (PostableApiAlertingConfig,
 // alertmanagerConfigFromPrometheus converts a parsed Prometheus/Mimir config to
 // Grafana's PostableApiAlertingConfig. It also returns the intermediate
 // definition-format receivers (index-aligned) so callers can reuse the conversion.
-func alertmanagerConfigFromPrometheus(prometheusConfig config.Config) (PostableApiAlertingConfig, []definition.Receiver, error) {
-	config := PostableApiAlertingConfig{
-		Config: Config{
-			Global:            prometheusConfig.Global,
-			Route:             RouteToModel(definition.AsGrafanaRoute(prometheusConfig.Route)),
-			InhibitRules:      prometheusConfig.InhibitRules,
-			TimeIntervals:     TimeIntervalsToModel(prometheusConfig.TimeIntervals),
-			MuteTimeIntervals: MuteTimeIntervalsToModel(prometheusConfig.MuteTimeIntervals),
-			Templates:         prometheusConfig.Templates,
-		},
-		Receivers: make([]*PostableApiReceiver, 0, len(prometheusConfig.Receivers)),
+func alertmanagerConfigFromPrometheus(prometheusConfig config.Config) (ExtraAlertmanagerConfig, []definition.Receiver, error) {
+	config := ExtraAlertmanagerConfig{
+		Global:            prometheusConfig.Global,
+		Route:             RouteToModel(definition.AsGrafanaRoute(prometheusConfig.Route)),
+		InhibitRules:      prometheusConfig.InhibitRules,
+		TimeIntervals:     TimeIntervalsToModel(prometheusConfig.TimeIntervals),
+		MuteTimeIntervals: MuteTimeIntervalsToModel(prometheusConfig.MuteTimeIntervals),
+		Templates:         prometheusConfig.Templates,
+		Receivers:         make([]*PostableApiReceiver, 0, len(prometheusConfig.Receivers)),
 	}
 	defs := make([]definition.Receiver, 0, len(prometheusConfig.Receivers))
 	for _, receiver := range prometheusConfig.Receivers {
@@ -121,7 +177,7 @@ func alertmanagerConfigFromPrometheus(prometheusConfig config.Config) (PostableA
 		defs = append(defs, def)
 		grafana, err := PostableMimirReceiverToPostableGrafanaReceiver(&PostableApiReceiver{Receiver: def})
 		if err != nil {
-			return PostableApiAlertingConfig{}, nil, fmt.Errorf("failed to convert Mimir receiver %s to Grafana receiver: %w", def.Name, err)
+			return ExtraAlertmanagerConfig{}, nil, fmt.Errorf("failed to convert Mimir receiver %s to Grafana receiver: %w", def.Name, err)
 		}
 		config.Receivers = append(config.Receivers, grafana)
 	}

--- a/pkg/services/ngalert/notifier/legacy_storage/v1/model.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/v1/model.go
@@ -83,34 +83,65 @@ func (c *AMConfigV1) Validate() error {
 
 type ManagedRoutes map[string]*Route
 
+// ExtraAlertmanagerConfig is a parsed imported Prometheus/Mimir Alertmanager configuration.
+// It preserves the upstream config types; conversion to Grafana's wire format is left to
+// callers via the ToGrafana* helpers.
 type ExtraAlertmanagerConfig struct {
 	Global       *config.GlobalConfig
-	Route        *Route
+	Route        *config.Route
 	InhibitRules []config.InhibitRule
 
 	// MuteTimeIntervals is deprecated and will be removed before Alertmanager 1.0.
-	MuteTimeIntervals []MuteTimeInterval
-	TimeIntervals     []TimeInterval
+	MuteTimeIntervals []config.MuteTimeInterval
+	TimeIntervals     []config.TimeInterval
 	Templates         []string
 
-	Receivers []*PostableApiReceiver
+	Receivers []config.Receiver
 }
 
-func (c *ExtraAlertmanagerConfig) GetReceivers() []*PostableApiReceiver {
-	return c.Receivers
+// ToGrafanaReceivers converts the imported receivers to Grafana's PostableApiReceiver form,
+// including Mimir integration conversion. It is fallible because not all upstream integrations
+// can be represented in Grafana's format.
+func (c *ExtraAlertmanagerConfig) ToGrafanaReceivers() ([]*PostableApiReceiver, error) {
+	receivers := make([]*PostableApiReceiver, 0, len(c.Receivers))
+	for _, receiver := range c.Receivers {
+		def := compat.UpstreamReceiverToDefinitionReceiver(receiver)
+		grafana, err := PostableMimirReceiverToPostableGrafanaReceiver(&PostableApiReceiver{Receiver: def})
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert Mimir receiver %s to Grafana receiver: %w", def.Name, err)
+		}
+		receivers = append(receivers, grafana)
+	}
+	return receivers, nil
 }
 
-func (c *ExtraAlertmanagerConfig) GetMuteTimeIntervals() []MuteTimeInterval {
-	return c.MuteTimeIntervals
+// ToGrafanaRoute converts the imported route to Grafana's Route type.
+func (c *ExtraAlertmanagerConfig) ToGrafanaRoute() *Route {
+	return RouteToModel(definition.AsGrafanaRoute(c.Route))
 }
 
-func (c *ExtraAlertmanagerConfig) GetTimeIntervals() []TimeInterval { return c.TimeIntervals }
-
-func (c *ExtraAlertmanagerConfig) GetRoute() *Route {
-	return c.Route
+// ToGrafanaMuteTimeIntervals converts the imported mute time intervals to Grafana's type.
+func (c *ExtraAlertmanagerConfig) ToGrafanaMuteTimeIntervals() []MuteTimeInterval {
+	return MuteTimeIntervalsToModel(c.MuteTimeIntervals)
 }
 
-// Validate ensures that the two routing trees use the correct receiver types.
+// ToGrafanaTimeIntervals converts the imported time intervals to Grafana's type.
+func (c *ExtraAlertmanagerConfig) ToGrafanaTimeIntervals() []TimeInterval {
+	return TimeIntervalsToModel(c.TimeIntervals)
+}
+
+// ReceiverNameStubs returns the imported receivers as Grafana receivers populated with only
+// their names. Merge deduplication is name-based and ignores receiver contents, so these stand
+// in for the full (fallible) conversion when only receiver renames need to be computed.
+func (c *ExtraAlertmanagerConfig) ReceiverNameStubs() []*PostableApiReceiver {
+	stubs := make([]*PostableApiReceiver, 0, len(c.Receivers))
+	for _, receiver := range c.Receivers {
+		stubs = append(stubs, &PostableApiReceiver{Receiver: definition.Receiver{Name: receiver.Name}})
+	}
+	return stubs
+}
+
+// Validate ensures that the routing tree only references receivers that are defined.
 func (c *ExtraAlertmanagerConfig) Validate() error {
 	receivers := make(map[string]struct{}, len(c.Receivers))
 
@@ -131,7 +162,7 @@ func (c *ExtraAlertmanagerConfig) Validate() error {
 		return fmt.Errorf("cannot have continue in root route")
 	}
 
-	for _, receiver := range AllReceivers(c.Route) {
+	for _, receiver := range allReceivers(c.Route) {
 		_, ok := receivers[receiver]
 		if !ok {
 			return fmt.Errorf("unexpected receiver (%s) is undefined", receiver)
@@ -147,41 +178,29 @@ type ExtraConfiguration struct {
 	AlertmanagerConfig string
 }
 
-// GetAlertmanagerConfig parses the stored Prometheus/Mimir alertmanager YAML and converts it
-// to Grafana's PostableApiAlertingConfig, including route wrapping and receiver format conversion.
+// GetAlertmanagerConfig parses the stored Prometheus/Mimir alertmanager YAML into
+// ExtraAlertmanagerConfig, preserving the upstream config types. Callers convert to Grafana's
+// wire format where needed via the ToGrafana* helpers.
 func (c *ExtraConfiguration) GetAlertmanagerConfig() (ExtraAlertmanagerConfig, error) {
 	prometheusConfig, err := c.parsePrometheusConfig()
 	if err != nil {
 		return ExtraAlertmanagerConfig{}, err
 	}
-	cfg, _, err := alertmanagerConfigFromPrometheus(prometheusConfig)
-	return cfg, err
+	return alertmanagerConfigFromPrometheus(prometheusConfig), nil
 }
 
-// alertmanagerConfigFromPrometheus converts a parsed Prometheus/Mimir config to
-// Grafana's PostableApiAlertingConfig. It also returns the intermediate
-// definition-format receivers (index-aligned) so callers can reuse the conversion.
-func alertmanagerConfigFromPrometheus(prometheusConfig config.Config) (ExtraAlertmanagerConfig, []definition.Receiver, error) {
-	config := ExtraAlertmanagerConfig{
+// alertmanagerConfigFromPrometheus restructures a parsed Prometheus/Mimir config into
+// ExtraAlertmanagerConfig without converting the field types.
+func alertmanagerConfigFromPrometheus(prometheusConfig config.Config) ExtraAlertmanagerConfig {
+	return ExtraAlertmanagerConfig{
 		Global:            prometheusConfig.Global,
-		Route:             RouteToModel(definition.AsGrafanaRoute(prometheusConfig.Route)),
+		Route:             prometheusConfig.Route,
 		InhibitRules:      prometheusConfig.InhibitRules,
-		TimeIntervals:     TimeIntervalsToModel(prometheusConfig.TimeIntervals),
-		MuteTimeIntervals: MuteTimeIntervalsToModel(prometheusConfig.MuteTimeIntervals),
+		TimeIntervals:     prometheusConfig.TimeIntervals,
+		MuteTimeIntervals: prometheusConfig.MuteTimeIntervals,
 		Templates:         prometheusConfig.Templates,
-		Receivers:         make([]*PostableApiReceiver, 0, len(prometheusConfig.Receivers)),
+		Receivers:         prometheusConfig.Receivers,
 	}
-	defs := make([]definition.Receiver, 0, len(prometheusConfig.Receivers))
-	for _, receiver := range prometheusConfig.Receivers {
-		def := compat.UpstreamReceiverToDefinitionReceiver(receiver)
-		defs = append(defs, def)
-		grafana, err := PostableMimirReceiverToPostableGrafanaReceiver(&PostableApiReceiver{Receiver: def})
-		if err != nil {
-			return ExtraAlertmanagerConfig{}, nil, fmt.Errorf("failed to convert Mimir receiver %s to Grafana receiver: %w", def.Name, err)
-		}
-		config.Receivers = append(config.Receivers, grafana)
-	}
-	return config, defs, nil
 }
 
 func (c *ExtraConfiguration) parsePrometheusConfig() (config.Config, error) {
@@ -223,16 +242,14 @@ func (c ExtraConfiguration) Validate() error {
 		return errInvalidExtraConfiguration(fmt.Errorf("failed to parse alertmanager config: %w", err))
 	}
 
-	cfg, defs, err := alertmanagerConfigFromPrometheus(prometheusConfig)
-	if err != nil {
-		return errInvalidExtraConfiguration(fmt.Errorf("failed to parse alertmanager config: %w", err))
-	}
+	cfg := alertmanagerConfigFromPrometheus(prometheusConfig)
 
 	// Reject fields Grafana can't represent (e.g. *_file / *_ref) that conversion
 	// would silently drop. Collect across all receivers to report them at once.
 	var unsupported []unsupportedReceiverFields
-	for i, def := range defs {
-		fields, err := findUnsupportedReceiverFields(prometheusConfig.Receivers[i], def)
+	for _, receiver := range cfg.Receivers {
+		def := compat.UpstreamReceiverToDefinitionReceiver(receiver)
+		fields, err := findUnsupportedReceiverFields(receiver, def)
 		if err != nil {
 			return errInvalidExtraConfiguration(err)
 		}
@@ -243,8 +260,13 @@ func (c ExtraConfiguration) Validate() error {
 	if len(unsupported) > 0 {
 		return errUnsupportedReceiverFields(unsupported)
 	}
-	err = cfg.Validate()
-	if err != nil {
+
+	// Ensure the receivers can be converted to Grafana's format.
+	if _, err := cfg.ToGrafanaReceivers(); err != nil {
+		return errInvalidExtraConfiguration(fmt.Errorf("failed to parse alertmanager config: %w", err))
+	}
+
+	if err := cfg.Validate(); err != nil {
 		return errInvalidExtraConfiguration(fmt.Errorf("invalid alertmanager config: %w", err))
 	}
 	return nil
@@ -290,19 +312,16 @@ func (c *PostableApiAlertingConfig) Validate() error {
 		return fmt.Errorf("cannot have continue in root route")
 	}
 
-	for _, receiver := range AllReceivers(c.Route) {
-		_, ok := receivers[receiver]
-		if !ok {
-			return fmt.Errorf("unexpected receiver (%s) is undefined", receiver)
-		}
+	if err := c.Route.ValidateReceivers(receivers); err != nil {
+		return err
 	}
 
 	return nil
 }
 
-// AllReceivers will recursively walk a routing tree and return a list of all the
+// allReceivers will recursively walk a routing tree and return a list of all the
 // referenced receiver names.
-func AllReceivers(route *Route) (res []string) {
+func allReceivers(route *config.Route) (res []string) {
 	if route == nil {
 		return res
 	}
@@ -312,7 +331,7 @@ func AllReceivers(route *Route) (res []string) {
 	}
 
 	for _, subRoute := range route.Routes {
-		res = append(res, AllReceivers(subRoute)...)
+		res = append(res, allReceivers(subRoute)...)
 	}
 	return res
 }

--- a/pkg/services/ngalert/notifier/legacy_storage/v1/model.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/v1/model.go
@@ -449,7 +449,7 @@ func (r *Route) Validate() error {
 }
 
 func (r *Route) ValidateReceivers(receivers map[string]struct{}) error {
-	if _, exists := receivers[r.Receiver]; !exists {
+	if _, exists := receivers[r.Receiver]; r.Receiver != "" && !exists {
 		return fmt.Errorf("receiver '%s' does not exist", r.Receiver)
 	}
 	for _, children := range r.Routes {

--- a/pkg/services/ngalert/notifier/legacy_storage/v1/model_test.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/v1/model_test.go
@@ -3,6 +3,7 @@ package v1
 import (
 	"testing"
 
+	"github.com/prometheus/alertmanager/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -63,7 +64,7 @@ mute_time_intervals:
 		assert.Equal(t, "weekends", cfg.MuteTimeIntervals[0].Name)
 	})
 
-	t.Run("converts receivers to Grafana format", func(t *testing.T) {
+	t.Run("preserves upstream receivers and converts to Grafana format on demand", func(t *testing.T) {
 		const yaml = `
 route:
   receiver: recv1
@@ -79,7 +80,96 @@ receivers:
 		require.Len(t, cfg.Receivers, 1)
 		recv := cfg.Receivers[0]
 		assert.Equal(t, "recv1", recv.Name)
-		require.Len(t, recv.GrafanaManagedReceivers, 1)
-		assert.Equal(t, "webhook", recv.GrafanaManagedReceivers[0].Type)
+		require.Len(t, recv.WebhookConfigs, 1)
 	})
+}
+
+func TestExtraAlertmanagerConfig_ToGrafanaReceivers(t *testing.T) {
+	t.Run("empty receivers", func(t *testing.T) {
+		c := ExtraAlertmanagerConfig{}
+		got, err := c.ToGrafanaReceivers()
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("receiver without integrations passes through", func(t *testing.T) {
+		c := ExtraAlertmanagerConfig{Receivers: []config.Receiver{{Name: "recv1"}}}
+		got, err := c.ToGrafanaReceivers()
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		assert.Equal(t, "recv1", got[0].Name)
+		assert.Empty(t, got[0].GrafanaManagedReceivers)
+	})
+
+	t.Run("Mimir integrations are converted to Grafana receivers", func(t *testing.T) {
+		const yaml = `
+route:
+  receiver: recv1
+receivers:
+  - name: recv1
+    webhook_configs:
+      - url: "http://localhost/"
+`
+		c := ExtraConfiguration{Identifier: "test", AlertmanagerConfig: yaml}
+		cfg, err := c.GetAlertmanagerConfig()
+		require.NoError(t, err)
+
+		got, err := cfg.ToGrafanaReceivers()
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		assert.Equal(t, "recv1", got[0].Name)
+		require.Len(t, got[0].GrafanaManagedReceivers, 1)
+		assert.Equal(t, "webhook", got[0].GrafanaManagedReceivers[0].Type)
+	})
+}
+
+func TestExtraAlertmanagerConfig_ToGrafanaRoute(t *testing.T) {
+	c := ExtraAlertmanagerConfig{
+		Route: &config.Route{
+			Receiver:          "root",
+			MuteTimeIntervals: []string{"weekends"},
+			Routes: []*config.Route{
+				{Receiver: "child"},
+			},
+		},
+	}
+
+	route := c.ToGrafanaRoute()
+	require.NotNil(t, route)
+	assert.Equal(t, "root", route.Receiver)
+	assert.Equal(t, []string{"weekends"}, route.MuteTimeIntervals)
+	require.Len(t, route.Routes, 1)
+	assert.Equal(t, "child", route.Routes[0].Receiver)
+}
+
+func TestExtraAlertmanagerConfig_ToGrafanaTimeIntervals(t *testing.T) {
+	c := ExtraAlertmanagerConfig{
+		MuteTimeIntervals: []config.MuteTimeInterval{{Name: "weekends"}},
+		TimeIntervals:     []config.TimeInterval{{Name: "business-hours"}},
+	}
+
+	mutes := c.ToGrafanaMuteTimeIntervals()
+	require.Len(t, mutes, 1)
+	assert.Equal(t, "weekends", mutes[0].Name)
+
+	times := c.ToGrafanaTimeIntervals()
+	require.Len(t, times, 1)
+	assert.Equal(t, "business-hours", times[0].Name)
+}
+
+func TestExtraAlertmanagerConfig_ReceiverNameStubs(t *testing.T) {
+	c := ExtraAlertmanagerConfig{
+		Receivers: []config.Receiver{
+			{Name: "recv1", WebhookConfigs: []*config.WebhookConfig{{}}},
+			{Name: "recv2"},
+		},
+	}
+
+	stubs := c.ReceiverNameStubs()
+	require.Len(t, stubs, 2)
+	assert.Equal(t, "recv1", stubs[0].Name)
+	assert.Equal(t, "recv2", stubs[1].Name)
+	// Only names are carried over; receiver contents are dropped.
+	assert.False(t, stubs[0].HasMimirIntegrations())
+	assert.Empty(t, stubs[0].GrafanaManagedReceivers)
 }

--- a/pkg/services/ngalert/notifier/merge/merge.go
+++ b/pkg/services/ngalert/notifier/merge/merge.go
@@ -195,7 +195,7 @@ func MergeExtraConfig(_ context.Context, cfg *v1.AMConfigV1) (v1.AMConfigV1, Mer
 
 // DeduplicateResources merges existing and incoming resources (receivers and time intervals) and ensures unique names by
 // appending a suffix derived from identifier. Returns renamed resources for tracking adjustments made.
-func DeduplicateResources(a, b v1.PostableApiAlertingConfig, identifier string) RenameResources {
+func DeduplicateResources(a v1.PostableApiAlertingConfig, b v1.ExtraAlertmanagerConfig, identifier string) RenameResources {
 	_, renamedReceivers, _ := Receivers(a.Receivers, b.Receivers, identifier)
 	_, renamedTimeIntervals, _ := TimeIntervals(
 		a.MuteTimeIntervals,

--- a/pkg/services/ngalert/notifier/merge/merge.go
+++ b/pkg/services/ngalert/notifier/merge/merge.go
@@ -134,20 +134,24 @@ func MergeExtraConfig(_ context.Context, cfg *v1.AMConfigV1) (v1.AMConfigV1, Mer
 		return v1.AMConfigV1{}, MergeResult{}, fmt.Errorf("cannot merge because config %s because it conflicts with existing managed route", mimirCfg.Identifier)
 	}
 
-	mergedReceivers, renamedReceivers, addedReceivers := Receivers(cfg.AlertmanagerConfig.Receivers, mcfg.Receivers, mimirCfg.Identifier)
+	importedReceivers, err := mcfg.ToGrafanaReceivers()
+	if err != nil {
+		return v1.AMConfigV1{}, MergeResult{}, fmt.Errorf("failed to convert imported receivers: %w", err)
+	}
+	mergedReceivers, renamedReceivers, addedReceivers := Receivers(cfg.AlertmanagerConfig.Receivers, importedReceivers, mimirCfg.Identifier)
 
 	mergedTimeIntervals, renamedTimeIntervals, addedTimeIntervals := TimeIntervals(
 		cfg.AlertmanagerConfig.MuteTimeIntervals,
 		cfg.AlertmanagerConfig.TimeIntervals,
-		mcfg.MuteTimeIntervals,
-		mcfg.TimeIntervals,
+		mcfg.ToGrafanaMuteTimeIntervals(),
+		mcfg.ToGrafanaTimeIntervals(),
 		mimirCfg.Identifier,
 	)
 
 	managedRoutes := make(v1.ManagedRoutes, len(cfg.ManagedRoutes)+1)
 	{
 		maps.Copy(managedRoutes, cfg.ManagedRoutes)
-		extraRoute := mcfg.Route
+		extraRoute := mcfg.ToGrafanaRoute()
 		RenameResourceUsagesInRoutes([]*v1.Route{extraRoute}, RenameResources{Receivers: renamedReceivers, TimeIntervals: renamedTimeIntervals})
 		managedRoutes[mimirCfg.Identifier] = extraRoute
 	}
@@ -196,12 +200,12 @@ func MergeExtraConfig(_ context.Context, cfg *v1.AMConfigV1) (v1.AMConfigV1, Mer
 // DeduplicateResources merges existing and incoming resources (receivers and time intervals) and ensures unique names by
 // appending a suffix derived from identifier. Returns renamed resources for tracking adjustments made.
 func DeduplicateResources(a v1.PostableApiAlertingConfig, b v1.ExtraAlertmanagerConfig, identifier string) RenameResources {
-	_, renamedReceivers, _ := Receivers(a.Receivers, b.Receivers, identifier)
+	_, renamedReceivers, _ := Receivers(a.Receivers, b.ReceiverNameStubs(), identifier)
 	_, renamedTimeIntervals, _ := TimeIntervals(
 		a.MuteTimeIntervals,
 		a.TimeIntervals,
-		b.MuteTimeIntervals,
-		b.TimeIntervals,
+		b.ToGrafanaMuteTimeIntervals(),
+		b.ToGrafanaTimeIntervals(),
 		identifier,
 	)
 	return RenameResources{Receivers: renamedReceivers, TimeIntervals: renamedTimeIntervals}


### PR DESCRIPTION
No-op refactor in preparation for `TimeInterval` model update.

Introduces a new type `v1.ExtraAlertmanagerConfig` based on `v1.PostableApiAlertingConfig` that is used as the return from `ExtraConfig.GetAlertmanagerConfig`.

This allows future changes to `AMConfigV1` to not necessarily affect how `ExtraConfig.AlertmanagerConfig` is parsed, which is useful since it's based on vanilla upstream rather than the grafana structs.