### PR TITLE
Plugins: allow renderer to read plugin metadata

### DIFF
--- a/pkg/services/authz/rbac/service.go
+++ b/pkg/services/authz/rbac/service.go
@@ -800,7 +800,7 @@ func (s *Service) getRendererPermissions(ctx context.Context, action string) (ma
 	_, span := s.tracer.Start(ctx, "authz_direct_db.service.getRendererPermissions")
 	defer span.End()
 
-	if action == "dashboards:read" || action == "folders:read" || action == "datasources:read" || action == "datasources:query" {
+	if action == "dashboards:read" || action == "folders:read" || action == "datasources:read" || action == "datasources:query" || action == "plugins.metas:read" {
 		return map[string]bool{"*": true}, nil
 	}
 	return map[string]bool{}, nil

--- a/pkg/services/authz/rbac/service_test.go
+++ b/pkg/services/authz/rbac/service_test.go
@@ -1717,6 +1717,30 @@ func TestService_Check(t *testing.T) {
 			expected: true,
 		},
 		{
+			name: "should allow rendering to read plugin metas",
+			req: &authzv1.CheckRequest{
+				Namespace: "org-12",
+				Subject:   "render:0",
+				Group:     "plugins.grafana.app",
+				Resource:  "metas",
+				Verb:      "get",
+				Name:      "some-plugin",
+			},
+			expected: true,
+		},
+		{
+			name: "should deny rendering write access to plugin metas",
+			req: &authzv1.CheckRequest{
+				Namespace: "org-12",
+				Subject:   "render:0",
+				Group:     "plugins.grafana.app",
+				Resource:  "metas",
+				Verb:      "create",
+				Name:      "some-plugin",
+			},
+			expected: false,
+		},
+		{
 			// Unregistered groups fall back to the K8s-native mapping. The renderer has no
 			// permissions for K8s-native actions, so the check is denied without an error.
 			name: "should deny rendering access to unregistered app resources",
@@ -2435,6 +2459,19 @@ func TestService_List(t *testing.T) {
 				Group:     "dashboard.grafana.app",
 				Resource:  "dashboards",
 				Verb:      "get",
+			},
+			expected: &authzv1.ListResponse{
+				All: true,
+			},
+		},
+		{
+			name: "should list plugin metas for rendering",
+			req: &authzv1.ListRequest{
+				Namespace: "org-12",
+				Subject:   "render:0",
+				Group:     "plugins.grafana.app",
+				Resource:  "metas",
+				Verb:      "list",
 			},
 			expected: &authzv1.ListResponse{
 				All: true,


### PR DESCRIPTION
**What is this feature?**

Adds `plugins.metas:read` to the allowlist in `getRendererPermissions`, so the image renderer identity can read plugin metas.

**Why do we need this feature?**

With `plugins.useMTPlugins` on, every page load fetches `GET /apis/plugins.grafana.app/v0alpha1/namespaces/<ns>/metas`. Renders without a real user resolve permissions from that allowlist, which lacked the action. The request 403s, the frontend swallows it into `{ items: [] }` and falls back to bootdata on `/d-solo/*` renders.

Renders for a real user are unaffected — the render key impersonates that user, and `fixed:plugins.metas:reader` is granted to Viewer, Editor and Admin. Not a regression; the allowlist predates the metas API.

**Who is this feature for?**

Anyone using image rendering (alert screenshots, reporting, shared panel images) with `plugins.useMTPlugins` enabled.

**Which issue(s) does this PR fix?**:

Fixes #129169 

**Special notes for your reviewer:**

Fix as suggested in the issue. Scope kept to `plugins.metas:read`.

**Tests**

Check and List cases added to the existing "Rendering permission check" / "Rendering permission list" tables, plus a negative case asserting `metas` `create` stays denied. Both positive cases fail without the one-line change (verified).

Please check that:
- [X] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
