### PR TITLE
fix: re-generate featureToggles.gen.ts

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -815,7 +815,7 @@ export interface FeatureToggles {
   */
   alertingJiraIntegration?: boolean;
   /**
-  *
+  * 
   * @default true
   */
   alertingUseNewSimplifiedRoutingHashAlgorithm?: boolean;


### PR DESCRIPTION
A whitespace change made in this file earlier today breaks CI for back-end PRs