### PR TITLE
Alerting: Check managed routes when deleting a time interval

### DIFF
--- a/pkg/services/ngalert/notifier/legacy_storage/routes.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/routes.go
@@ -341,6 +341,38 @@ func renameReceiverInRoute(oldName, newName string, routes ...*v1.Route) int {
 	return updated
 }
 
+// TimeIntervalUsedByRoutes checks if a time interval is used in any routes.
+func (rev *ConfigRevision) TimeIntervalUsedByRoutes(name string) bool {
+	if isTimeIntervalInUse(name, []*v1.Route{rev.Config.AlertmanagerConfig.Route}) {
+		return true
+	}
+	for _, r := range rev.Config.ManagedRoutes {
+		if isTimeIntervalInUse(name, []*v1.Route{r}) {
+			return true
+		}
+	}
+	return false
+}
+
+// isTimeIntervalInUse checks if a time interval is used in a route or any of its sub-routes.
+func isTimeIntervalInUse(name string, routes []*v1.Route) bool {
+	for _, route := range routes {
+		if route == nil {
+			continue
+		}
+		if slices.Contains(route.MuteTimeIntervals, name) {
+			return true
+		}
+		if slices.Contains(route.ActiveTimeIntervals, name) {
+			return true
+		}
+		if isTimeIntervalInUse(name, route.Routes) {
+			return true
+		}
+	}
+	return false
+}
+
 // RenameTimeIntervalInRoutes renames all references to a time interval in all routes. Returns number of routes that were updated
 func (rev *ConfigRevision) RenameTimeIntervalInRoutes(oldName, newName string) map[*v1.Route]int {
 	res := make(map[*v1.Route]int)

--- a/pkg/services/ngalert/notifier/legacy_storage/routes_test.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/routes_test.go
@@ -521,6 +521,51 @@ func TestConfigRevision_ValidateRoute(t *testing.T) {
 	})
 }
 
+func TestConfigRevision_TimeIntervalUsedByRoutes(t *testing.T) {
+	rev := &ConfigRevision{
+		Config: &v1.AMConfigV1{
+			AlertmanagerConfig: v1.PostableApiAlertingConfig{
+				Config: v1.Config{
+					Route: &v1.Route{
+						Routes: []*v1.Route{
+							{
+								MuteTimeIntervals:   []string{"root-mute"},
+								ActiveTimeIntervals: []string{"root-active"},
+							},
+						},
+					},
+				},
+			},
+			ManagedRoutes: map[string]*v1.Route{
+				"managed": {
+					Routes: []*v1.Route{
+						{
+							MuteTimeIntervals:   []string{"managed-mute"},
+							ActiveTimeIntervals: []string{"managed-active"},
+						},
+					},
+				},
+				"empty": {},
+			},
+		},
+	}
+
+	for _, name := range []string{"root-mute", "root-active", "managed-mute", "managed-active"} {
+		t.Run(fmt.Sprintf("returns true for %s", name), func(t *testing.T) {
+			assert.True(t, rev.TimeIntervalUsedByRoutes(name))
+		})
+	}
+
+	t.Run("returns false if not referenced by any route", func(t *testing.T) {
+		assert.False(t, rev.TimeIntervalUsedByRoutes("unused"))
+	})
+
+	t.Run("returns false if there is no root route", func(t *testing.T) {
+		rev := &ConfigRevision{Config: &v1.AMConfigV1{}}
+		assert.False(t, rev.TimeIntervalUsedByRoutes("unused"))
+	})
+}
+
 func testConfig() *ConfigRevision {
 	rev := &ConfigRevision{
 		Config: policy_exports.Config(),

--- a/pkg/services/ngalert/provisioning/mute_timings.go
+++ b/pkg/services/ngalert/provisioning/mute_timings.go
@@ -303,7 +303,7 @@ func (svc *MuteTimingService) DeleteMuteTiming(ctx context.Context, nameOrUID st
 		return err
 	}
 
-	if isTimeIntervalInUseInRoutes(existing.Name, revision.Config.AlertmanagerConfig.Route) {
+	if revision.TimeIntervalUsedByRoutes(existing.Name) {
 		ns, _ := svc.ruleNotificationsStore.ListContactPointRoutings(ctx, models.ListContactPointRoutingsQuery{OrgID: orgID, TimeIntervalName: existing.Name})
 		// ignore error here because it's not important
 		return MakeErrTimeIntervalInUse(existing.Name, true, slices.Collect(maps.Keys(ns)))
@@ -328,26 +328,6 @@ func (svc *MuteTimingService) DeleteMuteTiming(ctx context.Context, nameOrUID st
 		}
 		return svc.provenanceStore.DeleteProvenance(ctx, &existingInterval, orgID)
 	})
-}
-
-func isTimeIntervalInUseInRoutes(name string, route *v1.Route) bool {
-	if route == nil {
-		return false
-	}
-	if slices.Contains(route.MuteTimeIntervals, name) {
-		return true
-	}
-
-	if slices.Contains(route.ActiveTimeIntervals, name) {
-		return true
-	}
-
-	for _, route := range route.Routes {
-		if isTimeIntervalInUseInRoutes(name, route) {
-			return true
-		}
-	}
-	return false
 }
 
 func (svc *MuteTimingService) getMuteTimingByName(ctx context.Context, revision *legacy_storage.ConfigRevision, orgID int64, name string) (definitions.MuteTimeInterval, bool, error) {

--- a/pkg/services/ngalert/provisioning/mute_timings_test.go
+++ b/pkg/services/ngalert/provisioning/mute_timings_test.go
@@ -912,8 +912,8 @@ func TestUpdateMuteTimings(t *testing.T) {
 
 		revision := store.Calls[1].Args[1].(*legacy_storage.ConfigRevision)
 		assert.EqualValues(t, append(initialConfig().AlertmanagerConfig.TimeIntervals, v1.TimeInterval(interval)), revision.Config.AlertmanagerConfig.TimeIntervals)
-		assert.Falsef(t, isTimeIntervalInUseInRoutes(expected.Name, revision.Config.AlertmanagerConfig.Route), "There are still references to the old time interval")
-		assert.Truef(t, isTimeIntervalInUseInRoutes(interval.Name, revision.Config.AlertmanagerConfig.Route), "There are no references to the new time interval")
+		assert.Falsef(t, revision.TimeIntervalUsedByRoutes(expected.Name), "There are still references to the old time interval")
+		assert.Truef(t, revision.TimeIntervalUsedByRoutes(interval.Name), "There are no references to the new time interval")
 	})
 
 	t.Run("returns ErrTimeIntervalDependentResourcesProvenance if route has different provenance status", func(t *testing.T) {
@@ -1091,6 +1091,8 @@ func TestDeleteMuteTimings(t *testing.T) {
 	correctVersion := calculateMuteTimeIntervalFingerprint(timingToDelete)
 	usedMuteTiming := "used-timing"
 	usedActiveTiming := "used-active-timing"
+	managedRouteMuteTiming := "managed-route-used-timing"
+	managedRouteActiveTiming := "managed-route-used-active-timing"
 	initialConfig := func() *v1.AMConfigV1 {
 		return &v1.AMConfigV1{
 			Templates: nil,
@@ -1105,6 +1107,9 @@ func TestDeleteMuteTimings(t *testing.T) {
 							Name: usedMuteTiming,
 						},
 						timingToDelete,
+						{
+							Name: managedRouteMuteTiming,
+						},
 					},
 					TimeIntervals: []v1.TimeInterval{
 						{
@@ -1113,9 +1118,22 @@ func TestDeleteMuteTimings(t *testing.T) {
 						{
 							Name: "timing-to-delete2",
 						},
+						{
+							Name: managedRouteActiveTiming,
+						},
 					},
 				},
 				Receivers: nil,
+			},
+			ManagedRoutes: map[string]*v1.Route{
+				"managed-route": {
+					Routes: []*v1.Route{
+						{
+							MuteTimeIntervals:   []string{managedRouteMuteTiming},
+							ActiveTimeIntervals: []string{managedRouteActiveTiming},
+						},
+					},
+				},
 			},
 		}
 	}
@@ -1158,6 +1176,38 @@ func TestDeleteMuteTimings(t *testing.T) {
 		prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(models.ProvenanceAPI, nil)
 
 		err := sut.DeleteMuteTiming(context.Background(), usedActiveTiming, orgID, definitions.Provenance(models.ProvenanceAPI), correctVersion)
+
+		require.Len(t, store.Calls, 1)
+		require.Equal(t, "Get", store.Calls[0].Method)
+		require.Equal(t, orgID, store.Calls[0].Args[1])
+		require.ErrorIs(t, err, ErrTimeIntervalInUse)
+	})
+
+	t.Run("returns ErrTimeIntervalInUse if mute timing is used by a managed route", func(t *testing.T) {
+		sut, store, prov := createMuteTimingSvcSut()
+		store.GetFn = func(ctx context.Context, orgID int64) (*legacy_storage.ConfigRevision, error) {
+			return &legacy_storage.ConfigRevision{Config: initialConfig()}, nil
+		}
+		prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(models.ProvenanceAPI, nil)
+
+		version := calculateMuteTimeIntervalFingerprint(v1.MuteTimeInterval{Name: managedRouteMuteTiming})
+		err := sut.DeleteMuteTiming(context.Background(), managedRouteMuteTiming, orgID, definitions.Provenance(models.ProvenanceAPI), version)
+
+		require.Len(t, store.Calls, 1)
+		require.Equal(t, "Get", store.Calls[0].Method)
+		require.Equal(t, orgID, store.Calls[0].Args[1])
+		require.ErrorIs(t, err, ErrTimeIntervalInUse)
+	})
+
+	t.Run("returns ErrTimeIntervalInUse if active timing is used by a managed route", func(t *testing.T) {
+		sut, store, prov := createMuteTimingSvcSut()
+		store.GetFn = func(ctx context.Context, orgID int64) (*legacy_storage.ConfigRevision, error) {
+			return &legacy_storage.ConfigRevision{Config: initialConfig()}, nil
+		}
+		prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(models.ProvenanceAPI, nil)
+
+		version := calculateMuteTimeIntervalFingerprint(v1.MuteTimeInterval{Name: managedRouteActiveTiming})
+		err := sut.DeleteMuteTiming(context.Background(), managedRouteActiveTiming, orgID, definitions.Provenance(models.ProvenanceAPI), version)
 
 		require.Len(t, store.Calls, 1)
 		require.Equal(t, "Get", store.Calls[0].Method)


### PR DESCRIPTION
**What is this feature?**

Fixes a bug in `MuteTimingService.DeleteMuteTiming` where the "is this time interval still in use?" check only looked at the default (root) routing tree. References from managed routing trees (`Config.ManagedRoutes`) were ignored.

- Adds `(*ConfigRevision).TimeIntervalUsedByRoutes(name)` which walks the default route plus every managed route, recursing into sub-routes and checking both `mute_time_intervals` and `active_time_intervals`.

**Why do we need this feature?**

A time interval referenced only from a managed routing tree could be deleted without returning `ErrTimeIntervalInUse`. That leaves the managed tree holding a reference to an interval that no longer exists, causing the alertmanager config to fail to break with failed validations.