### PR TITLE
Global variables: allow folder editors to manage folder-scoped variables

### DIFF
--- a/pkg/registry/apis/dashboard/register.go
+++ b/pkg/registry/apis/dashboard/register.go
@@ -619,7 +619,7 @@ func (b *DashboardsAPIBuilder) validateVariableCreate(ctx context.Context, a adm
 		return apierrors.NewBadRequest(err.Error())
 	}
 
-	if err := b.validateVariableMutationPermissions(ctx, a, folderUID); err != nil {
+	if err := b.validateVariableMutationPermissions(ctx, folderUID, false); err != nil {
 		return err
 	}
 
@@ -670,7 +670,8 @@ func (b *DashboardsAPIBuilder) validateVariableUpdate(ctx context.Context, a adm
 		return apierrors.NewBadRequest("folder scope cannot be changed; delete the variable and create a new one")
 	}
 
-	return b.validateVariableMutationPermissions(ctx, a, oldAccessor.GetFolder())
+	// allowMissingFolder: Editors/Admins can still update variables whose folder was deleted.
+	return b.validateVariableMutationPermissions(ctx, oldAccessor.GetFolder(), true)
 }
 
 func (b *DashboardsAPIBuilder) validateVariableDelete(ctx context.Context, a admission.Attributes) error {
@@ -688,13 +689,17 @@ func (b *DashboardsAPIBuilder) validateVariableDelete(ctx context.Context, a adm
 		return fmt.Errorf("error getting variable meta accessor: %w", err)
 	}
 
-	return b.validateVariableMutationPermissions(ctx, a, accessor.GetFolder())
+	// allowMissingFolder: Editors/Admins can still delete variables whose folder was deleted.
+	return b.validateVariableMutationPermissions(ctx, accessor.GetFolder(), true)
 }
 
 // validateVariableMutationPermissions authorizes variable create/update/delete.
 // Global variables (no folder) require org Editor or Admin. Folder-scoped
-// variables require edit access on that folder, regardless of org role.
-func (b *DashboardsAPIBuilder) validateVariableMutationPermissions(ctx context.Context, a admission.Attributes, folderUID string) error {
+// variables require edit access on that folder, including on dry-run (Variables
+// have no user RBAC authorizer; admission is the authz gate).
+// When allowMissingFolder is true (update/delete), org Editors/Admins may still
+// mutate if the folder no longer exists so orphaned variables can be cleaned up.
+func (b *DashboardsAPIBuilder) validateVariableMutationPermissions(ctx context.Context, folderUID string, allowMissingFolder bool) error {
 	requester, err := identity.GetRequester(ctx)
 	if err != nil {
 		return apierrors.NewForbidden(dashv2beta1.VariableResourceInfo.GroupResource(), "", fmt.Errorf("variable mutation requires editor or admin role"))
@@ -708,11 +713,19 @@ func (b *DashboardsAPIBuilder) validateVariableMutationPermissions(ctx context.C
 		return nil
 	}
 
-	if a.IsDryRun() {
+	err = b.verifyFolderAccessPermissions(ctx, requester, folderUID)
+	if err == nil {
 		return nil
 	}
 
-	return b.verifyFolderAccessPermissions(ctx, requester, folderUID)
+	if allowMissingFolder && apierrors.IsNotFound(err) {
+		role := requester.GetOrgRole()
+		if role == identity.RoleEditor || role == identity.RoleAdmin {
+			return nil
+		}
+	}
+
+	return err
 }
 
 // validateFolderExists checks if a folder exists

--- a/pkg/registry/apis/dashboard/register.go
+++ b/pkg/registry/apis/dashboard/register.go
@@ -385,7 +385,7 @@ func (b *DashboardsAPIBuilder) Validate(ctx context.Context, a admission.Attribu
 		case admission.Update:
 			return b.validateVariableUpdate(ctx, a)
 		case admission.Delete:
-			return b.validateVariableDelete(ctx)
+			return b.validateVariableDelete(ctx, a)
 		case admission.Connect:
 			return nil
 		}
@@ -600,10 +600,6 @@ func (b *DashboardsAPIBuilder) validateUpdate(ctx context.Context, a admission.A
 }
 
 func (b *DashboardsAPIBuilder) validateVariableCreate(ctx context.Context, a admission.Attributes) error {
-	if err := b.validateVariableMutationPermissions(ctx); err != nil {
-		return err
-	}
-
 	variable, ok := a.GetObject().(*dashv2beta1.Variable)
 	if !ok {
 		return fmt.Errorf("unsupported variable version: %T", a.GetObject())
@@ -618,21 +614,22 @@ func (b *DashboardsAPIBuilder) validateVariableCreate(ctx context.Context, a adm
 		return fmt.Errorf("error getting variable meta accessor: %w", err)
 	}
 
-	if err := validateVariableMetadataName(variable.GetName(), getVariableName(variable.Spec), accessor.GetFolder()); err != nil {
+	folderUID := accessor.GetFolder()
+	if err := validateVariableMetadataName(variable.GetName(), getVariableName(variable.Spec), folderUID); err != nil {
 		return apierrors.NewBadRequest(err.Error())
 	}
 
-	if !a.IsDryRun() && accessor.GetFolder() != "" {
+	if err := b.validateVariableMutationPermissions(ctx, a, folderUID); err != nil {
+		return err
+	}
+
+	if !a.IsDryRun() && folderUID != "" {
 		id, err := identity.GetRequester(ctx)
 		if err != nil {
 			return fmt.Errorf("error getting requester: %w", err)
 		}
 
-		if err := b.verifyFolderAccessPermissions(ctx, id, accessor.GetFolder()); err != nil {
-			return err
-		}
-
-		if _, err := b.validateFolderExists(ctx, accessor.GetFolder(), id.GetOrgID()); err != nil {
+		if _, err := b.validateFolderExists(ctx, folderUID, id.GetOrgID()); err != nil {
 			return err
 		}
 	}
@@ -641,10 +638,6 @@ func (b *DashboardsAPIBuilder) validateVariableCreate(ctx context.Context, a adm
 }
 
 func (b *DashboardsAPIBuilder) validateVariableUpdate(ctx context.Context, a admission.Attributes) error {
-	if err := b.validateVariableMutationPermissions(ctx); err != nil {
-		return err
-	}
-
 	newVariable, ok := a.GetObject().(*dashv2beta1.Variable)
 	if !ok {
 		return fmt.Errorf("unsupported variable version: %T", a.GetObject())
@@ -677,25 +670,49 @@ func (b *DashboardsAPIBuilder) validateVariableUpdate(ctx context.Context, a adm
 		return apierrors.NewBadRequest("folder scope cannot be changed; delete the variable and create a new one")
 	}
 
-	return nil
+	return b.validateVariableMutationPermissions(ctx, a, oldAccessor.GetFolder())
 }
 
-func (b *DashboardsAPIBuilder) validateVariableDelete(ctx context.Context) error {
-	return b.validateVariableMutationPermissions(ctx)
+func (b *DashboardsAPIBuilder) validateVariableDelete(ctx context.Context, a admission.Attributes) error {
+	obj := a.GetOldObject()
+	if obj == nil {
+		obj = a.GetObject()
+	}
+	variable, ok := obj.(*dashv2beta1.Variable)
+	if !ok {
+		return fmt.Errorf("unsupported variable version: %T", obj)
+	}
+
+	accessor, err := utils.MetaAccessor(variable)
+	if err != nil {
+		return fmt.Errorf("error getting variable meta accessor: %w", err)
+	}
+
+	return b.validateVariableMutationPermissions(ctx, a, accessor.GetFolder())
 }
 
-func (b *DashboardsAPIBuilder) validateVariableMutationPermissions(ctx context.Context) error {
+// validateVariableMutationPermissions authorizes variable create/update/delete.
+// Global variables (no folder) require org Editor or Admin. Folder-scoped
+// variables require edit access on that folder, regardless of org role.
+func (b *DashboardsAPIBuilder) validateVariableMutationPermissions(ctx context.Context, a admission.Attributes, folderUID string) error {
 	requester, err := identity.GetRequester(ctx)
 	if err != nil {
 		return apierrors.NewForbidden(dashv2beta1.VariableResourceInfo.GroupResource(), "", fmt.Errorf("variable mutation requires editor or admin role"))
 	}
 
-	role := requester.GetOrgRole()
-	if role != identity.RoleEditor && role != identity.RoleAdmin {
-		return apierrors.NewForbidden(dashv2beta1.VariableResourceInfo.GroupResource(), "", fmt.Errorf("variable mutation requires editor or admin role"))
+	if folderUID == "" {
+		role := requester.GetOrgRole()
+		if role != identity.RoleEditor && role != identity.RoleAdmin {
+			return apierrors.NewForbidden(dashv2beta1.VariableResourceInfo.GroupResource(), "", fmt.Errorf("variable mutation requires editor or admin role"))
+		}
+		return nil
 	}
 
-	return nil
+	if a.IsDryRun() {
+		return nil
+	}
+
+	return b.verifyFolderAccessPermissions(ctx, requester, folderUID)
 }
 
 // validateFolderExists checks if a folder exists

--- a/pkg/registry/apis/dashboard/variable_test.go
+++ b/pkg/registry/apis/dashboard/variable_test.go
@@ -254,18 +254,18 @@ func TestVariableMutationPermissionsByRole(t *testing.T) {
 		op       admission.Operation
 		expected bool
 	}{
-		{name: "admin can create", role: identity.RoleAdmin, op: admission.Create, expected: true},
-		{name: "editor can create", role: identity.RoleEditor, op: admission.Create, expected: true},
-		{name: "viewer cannot create", role: identity.RoleViewer, op: admission.Create, expected: false},
-		{name: "none cannot create", role: identity.RoleNone, op: admission.Create, expected: false},
-		{name: "admin can update", role: identity.RoleAdmin, op: admission.Update, expected: true},
-		{name: "editor can update", role: identity.RoleEditor, op: admission.Update, expected: true},
-		{name: "viewer cannot update", role: identity.RoleViewer, op: admission.Update, expected: false},
-		{name: "none cannot update", role: identity.RoleNone, op: admission.Update, expected: false},
-		{name: "admin can delete", role: identity.RoleAdmin, op: admission.Delete, expected: true},
-		{name: "editor can delete", role: identity.RoleEditor, op: admission.Delete, expected: true},
-		{name: "viewer cannot delete", role: identity.RoleViewer, op: admission.Delete, expected: false},
-		{name: "none cannot delete", role: identity.RoleNone, op: admission.Delete, expected: false},
+		{name: "admin can create global", role: identity.RoleAdmin, op: admission.Create, expected: true},
+		{name: "editor can create global", role: identity.RoleEditor, op: admission.Create, expected: true},
+		{name: "viewer cannot create global", role: identity.RoleViewer, op: admission.Create, expected: false},
+		{name: "none cannot create global", role: identity.RoleNone, op: admission.Create, expected: false},
+		{name: "admin can update global", role: identity.RoleAdmin, op: admission.Update, expected: true},
+		{name: "editor can update global", role: identity.RoleEditor, op: admission.Update, expected: true},
+		{name: "viewer cannot update global", role: identity.RoleViewer, op: admission.Update, expected: false},
+		{name: "none cannot update global", role: identity.RoleNone, op: admission.Update, expected: false},
+		{name: "admin can delete global", role: identity.RoleAdmin, op: admission.Delete, expected: true},
+		{name: "editor can delete global", role: identity.RoleEditor, op: admission.Delete, expected: true},
+		{name: "viewer cannot delete global", role: identity.RoleViewer, op: admission.Delete, expected: false},
+		{name: "none cannot delete global", role: identity.RoleNone, op: admission.Delete, expected: false},
 	}
 
 	for _, tc := range tests {
@@ -281,6 +281,60 @@ func TestVariableMutationPermissionsByRole(t *testing.T) {
 
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "variable mutation requires editor or admin role")
+		})
+	}
+}
+
+func TestVariableMutationPermissionsFolderScoped(t *testing.T) {
+	folderUID := "folder-a"
+	oldVariable := newCustomVariable("region", "region--folder-a")
+	oldVariable.SetAnnotations(map[string]string{utils.AnnoKeyFolder: folderUID})
+	newVariable := newCustomVariable("region", "region--folder-a")
+	newVariable.SetAnnotations(map[string]string{utils.AnnoKeyFolder: folderUID})
+
+	tests := []struct {
+		name      string
+		role      identity.RoleType
+		op        admission.Operation
+		forbidden bool
+		expected  bool
+	}{
+		{name: "viewer with folder edit can create", role: identity.RoleViewer, op: admission.Create, expected: true},
+		{name: "viewer with folder edit can update", role: identity.RoleViewer, op: admission.Update, expected: true},
+		{name: "viewer with folder edit can delete", role: identity.RoleViewer, op: admission.Delete, expected: true},
+		{name: "viewer without folder edit cannot create", role: identity.RoleViewer, op: admission.Create, forbidden: true, expected: false},
+		{name: "viewer without folder edit cannot update", role: identity.RoleViewer, op: admission.Update, forbidden: true, expected: false},
+		{name: "viewer without folder edit cannot delete", role: identity.RoleViewer, op: admission.Delete, forbidden: true, expected: false},
+		{name: "none with folder edit can create", role: identity.RoleNone, op: admission.Create, expected: true},
+		{name: "editor with folder edit can create", role: identity.RoleEditor, op: admission.Create, expected: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			folderHandler := &variableFolderAccessHandler{
+				forbiddenAccessSubresource: tc.forbidden,
+			}
+			builder := &DashboardsAPIBuilder{
+				folderClientProvider: &staticHandlerProvider{handler: folderHandler},
+			}
+
+			ctx := k8srequest.WithNamespace(context.Background(), "stacks-1")
+			ctx = identity.WithRequester(ctx, &identity.StaticRequester{
+				OrgRole: tc.role,
+				OrgID:   1,
+			})
+			attrs := buildVariableAttributesForOp(tc.op, newVariable, oldVariable)
+
+			err := builder.Validate(ctx, attrs, nil)
+			if tc.expected {
+				require.NoError(t, err)
+				require.True(t, folderHandler.accessSubresourceChecked)
+				return
+			}
+
+			require.Error(t, err)
+			require.True(t, apierrors.IsForbidden(err))
+			require.True(t, folderHandler.accessSubresourceChecked)
 		})
 	}
 }
@@ -406,9 +460,7 @@ func (h *variableFolderAccessHandler) Get(_ context.Context, name string, _ int6
 
 		return &unstructured.Unstructured{
 			Object: map[string]any{
-				"spec": map[string]any{
-					"canEdit": true,
-				},
+				"canEdit": true,
 			},
 		}, nil
 	}

--- a/pkg/registry/apis/dashboard/variable_test.go
+++ b/pkg/registry/apis/dashboard/variable_test.go
@@ -339,6 +339,110 @@ func TestVariableMutationPermissionsFolderScoped(t *testing.T) {
 	}
 }
 
+func TestVariableMutationPermissionsFolderScopedDryRun(t *testing.T) {
+	folderUID := "folder-a"
+	v := newCustomVariable("region", "region--folder-a")
+	v.SetAnnotations(map[string]string{utils.AnnoKeyFolder: folderUID})
+
+	t.Run("dry-run still checks folder edit access", func(t *testing.T) {
+		folderHandler := &variableFolderAccessHandler{forbiddenAccessSubresource: true}
+		builder := &DashboardsAPIBuilder{
+			folderClientProvider: &staticHandlerProvider{handler: folderHandler},
+		}
+		ctx := k8srequest.WithNamespace(context.Background(), "stacks-1")
+		ctx = identity.WithRequester(ctx, &identity.StaticRequester{OrgRole: identity.RoleViewer, OrgID: 1})
+
+		err := builder.Validate(ctx, admission.NewAttributesRecord(
+			v,
+			nil,
+			dashv2beta1.VariableResourceInfo.GroupVersionKind(),
+			"stacks-1",
+			v.GetName(),
+			dashv2beta1.VariableResourceInfo.GroupVersionResource(),
+			"",
+			admission.Create,
+			&metav1.CreateOptions{},
+			true, // dry-run
+			nil,
+		), nil)
+
+		require.Error(t, err)
+		require.True(t, apierrors.IsForbidden(err))
+		require.True(t, folderHandler.accessSubresourceChecked)
+	})
+
+	t.Run("dry-run allows viewer with folder edit", func(t *testing.T) {
+		folderHandler := &variableFolderAccessHandler{}
+		builder := &DashboardsAPIBuilder{
+			folderClientProvider: &staticHandlerProvider{handler: folderHandler},
+		}
+		ctx := k8srequest.WithNamespace(context.Background(), "stacks-1")
+		ctx = identity.WithRequester(ctx, &identity.StaticRequester{OrgRole: identity.RoleViewer, OrgID: 1})
+
+		err := builder.Validate(ctx, admission.NewAttributesRecord(
+			v,
+			nil,
+			dashv2beta1.VariableResourceInfo.GroupVersionKind(),
+			"stacks-1",
+			v.GetName(),
+			dashv2beta1.VariableResourceInfo.GroupVersionResource(),
+			"",
+			admission.Create,
+			&metav1.CreateOptions{},
+			true, // dry-run
+			nil,
+		), nil)
+
+		require.NoError(t, err)
+		require.True(t, folderHandler.accessSubresourceChecked)
+	})
+}
+
+func TestVariableMutationPermissionsMissingFolder(t *testing.T) {
+	folderUID := "missing-folder"
+	oldVariable := newCustomVariable("region", "region--missing-folder")
+	oldVariable.SetAnnotations(map[string]string{utils.AnnoKeyFolder: folderUID})
+	newVariable := newCustomVariable("region", "region--missing-folder")
+	newVariable.SetAnnotations(map[string]string{utils.AnnoKeyFolder: folderUID})
+
+	tests := []struct {
+		name     string
+		role     identity.RoleType
+		op       admission.Operation
+		expected bool
+	}{
+		{name: "editor can delete orphaned folder variable", role: identity.RoleEditor, op: admission.Delete, expected: true},
+		{name: "admin can update orphaned folder variable", role: identity.RoleAdmin, op: admission.Update, expected: true},
+		{name: "viewer cannot delete orphaned folder variable", role: identity.RoleViewer, op: admission.Delete, expected: false},
+		{name: "editor cannot create into missing folder", role: identity.RoleEditor, op: admission.Create, expected: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			folderHandler := &variableFolderAccessHandler{notFoundAccessSubresource: true}
+			builder := &DashboardsAPIBuilder{
+				folderClientProvider: &staticHandlerProvider{handler: folderHandler},
+			}
+
+			ctx := k8srequest.WithNamespace(context.Background(), "stacks-1")
+			ctx = identity.WithRequester(ctx, &identity.StaticRequester{
+				OrgRole: tc.role,
+				OrgID:   1,
+			})
+			attrs := buildVariableAttributesForOp(tc.op, newVariable, oldVariable)
+
+			err := builder.Validate(ctx, attrs, nil)
+			if tc.expected {
+				require.NoError(t, err)
+				return
+			}
+
+			require.Error(t, err)
+			require.True(t, apierrors.IsNotFound(err) || apierrors.IsForbidden(err))
+		})
+	}
+}
+
 func newCustomVariable(variableName, metadataName string) *dashv2beta1.Variable {
 	customVariable := dashv2beta1.NewDashboardCustomVariableKind()
 	customVariable.Spec.Name = variableName
@@ -449,11 +553,15 @@ func (p *staticHandlerProvider) GetOrCreateHandler(namespace string) client.K8sH
 type variableFolderAccessHandler struct {
 	accessSubresourceChecked   bool
 	forbiddenAccessSubresource bool
+	notFoundAccessSubresource  bool
 }
 
 func (h *variableFolderAccessHandler) Get(_ context.Context, name string, _ int64, _ metav1.GetOptions, subresource ...string) (*unstructured.Unstructured, error) {
 	if len(subresource) > 0 && subresource[0] == "access" {
 		h.accessSubresourceChecked = true
+		if h.notFoundAccessSubresource {
+			return nil, apierrors.NewNotFound(schema.GroupResource{Group: "folder.grafana.app", Resource: "folders"}, name)
+		}
 		if h.forbiddenAccessSubresource {
 			return nil, apierrors.NewForbidden(schema.GroupResource{Group: "folder.grafana.app", Resource: "folders"}, name, nil)
 		}
@@ -463,6 +571,10 @@ func (h *variableFolderAccessHandler) Get(_ context.Context, name string, _ int6
 				"canEdit": true,
 			},
 		}, nil
+	}
+
+	if h.notFoundAccessSubresource {
+		return nil, apierrors.NewNotFound(schema.GroupResource{Group: "folder.grafana.app", Resource: "folders"}, name)
 	}
 
 	return &unstructured.Unstructured{


### PR DESCRIPTION
## Summary
- Variable create/update/delete no longer hard-requires org Editor/Admin for folder-scoped variables
- Folder-scoped mutations authorize via existing folder CanEdit (`verifyFolderAccessPermissions`)
- Global (org-wide) variables still require org Editor or Admin
- Update and delete now also enforce folder edit access (previously create-only)

## Test plan
- [ ] Unit tests: `go test ./pkg/registry/apis/dashboard/ -run 'TestVariableMutation|TestDashboardsAPIBuilderValidateVariable'`
- [ ] As Viewer with folder Admin/Edit: create/update/delete a variable with `grafana.app/folder` set to that folder → succeeds
- [ ] As Viewer: create a global variable (no folder) → 403
- [ ] As Editor/Admin: global and folder-scoped mutations still work

Follow-up FE PR(https://github.com/grafana/grafana/pull/129249) is stacked on this branch to hide global/root in the variables UI for non-editors.