### PR TITLE
fix: persisting disabled operations in loki query builder

### DIFF
--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderContainer.test.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderContainer.test.tsx
@@ -110,6 +110,27 @@ describe('LokiQueryBuilderContainer', () => {
     expect(screen.getAllByText('You have conflicting label filters')).toHaveLength(2);
   });
 
+  it('restores disabled operations that are absent from expr (e.g. after collapse/expand)', async () => {
+    const props = {
+      query: {
+        expr: '{job="testjob"}',
+        refId: 'A',
+        disabledOperations: [{ index: 0, operation: { id: '__line_contains', params: ['error'], disabled: true } }],
+      },
+      datasource: createLokiDatasource(),
+      onChange: jest.fn(),
+      onRunQuery: () => {},
+      showExplain: false,
+    };
+    props.datasource.getDataSamples = jest.fn().mockResolvedValue([]);
+
+    await act(async () => {
+      render(<LokiQueryBuilderContainer {...props} />);
+    });
+
+    expect(await screen.findByText('Line contains')).toBeInTheDocument();
+  });
+
   it('uses <expr> as placeholder for query in explain section', async () => {
     const props = {
       query: {

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderContainer.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderContainer.tsx
@@ -5,7 +5,7 @@ import { type TimeRange } from '@grafana/data';
 
 import { testIds } from '../../components/LokiQueryEditor';
 import { type LokiDatasource } from '../../datasource';
-import { type LokiQuery } from '../../types';
+import { type LokiDisabledOperation, type LokiQuery } from '../../types';
 import { lokiQueryModeller } from '../LokiQueryModeller';
 import { buildVisualQueryFromString } from '../parsing';
 import { type LokiVisualQuery } from '../types';
@@ -46,13 +46,14 @@ export function LokiQueryBuilderContainer(props: Props) {
 
   // Only rebuild visual query if expr changes from outside
   useEffect(() => {
-    dispatch(exprChanged(query.expr));
-  }, [query.expr]);
+    dispatch(exprChanged({ expr: query.expr, disabledOperations: query.disabledOperations }));
+  }, [query.expr, query.disabledOperations]);
 
   const onVisQueryChange = (visQuery: LokiVisualQuery) => {
     const expr = lokiQueryModeller.renderQuery(visQuery);
+    const disabledOperations = getDisabledOperations(visQuery);
     dispatch(visualQueryChange({ visQuery, expr }));
-    onChange({ ...props.query, expr: expr });
+    onChange({ ...props.query, expr, disabledOperations: disabledOperations.length ? disabledOperations : undefined });
   };
 
   if (!state.visQuery) {
@@ -77,6 +78,26 @@ export function LokiQueryBuilderContainer(props: Props) {
 
 const initialState: State = { expr: '' };
 
+function getDisabledOperations(visQuery: LokiVisualQuery): LokiDisabledOperation[] {
+  return visQuery.operations
+    .map((operation, index) => ({ index, operation }))
+    .filter(({ operation }) => operation.disabled);
+}
+
+function applyDisabledOperations(
+  visQuery: LokiVisualQuery,
+  disabledOperations?: LokiDisabledOperation[]
+): LokiVisualQuery {
+  if (!disabledOperations?.length) {
+    return visQuery;
+  }
+  const operations = [...visQuery.operations];
+  for (const { index, operation } of [...disabledOperations].sort((a, b) => a.index - b.index)) {
+    operations.splice(index, 0, operation);
+  }
+  return { ...visQuery, operations };
+}
+
 const stateSlice = createSlice({
   name: 'loki-builder-container',
   initialState,
@@ -85,11 +106,14 @@ const stateSlice = createSlice({
       state.expr = action.payload.expr;
       state.visQuery = action.payload.visQuery;
     },
-    exprChanged: (state, action: PayloadAction<string>) => {
-      if (!state.visQuery || state.expr !== action.payload) {
-        state.expr = action.payload;
-        const parseResult = buildVisualQueryFromString(action.payload);
-        state.visQuery = parseResult.query;
+    exprChanged: (
+      state,
+      action: PayloadAction<{ expr: string; disabledOperations?: LokiDisabledOperation[] }>
+    ) => {
+      if (!state.visQuery || state.expr !== action.payload.expr) {
+        state.expr = action.payload.expr;
+        const parseResult = buildVisualQueryFromString(action.payload.expr);
+        state.visQuery = applyDisabledOperations(parseResult.query, action.payload.disabledOperations);
       }
     },
   },

--- a/public/app/plugins/datasource/loki/types.ts
+++ b/public/app/plugins/datasource/loki/types.ts
@@ -1,4 +1,5 @@
 import { type DataQuery, type DataQueryRequest, type DataSourceJsonData, type TimeRange } from '@grafana/data';
+import { type QueryBuilderOperation } from '@grafana/plugin-ui';
 
 import {
   type LokiDataQuery as LokiQueryFromSchema,
@@ -6,6 +7,11 @@ import {
   type SupportingQueryType,
   type LokiQueryDirection,
 } from './dataquery.gen';
+
+export interface LokiDisabledOperation {
+  index: number;
+  operation: QueryBuilderOperation;
+}
 
 // @todo import from core
 export const DATAPLANE_LABEL_TYPES_NAME = 'labelTypes';
@@ -25,6 +31,7 @@ export interface LokiQuery extends LokiQueryFromSchema {
   // the temporary fix (until this gets improved in the codegen), is to
   // override it here
   queryType?: LokiQueryType;
+  disabledOperations?: LokiDisabledOperation[];
 }
 
 export interface LokiOptions extends DataSourceJsonData {


### PR DESCRIPTION
**What is this feature?**

[Add a brief description of what the feature or update does.]

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

Fixes grafana/grafana-loki-datasource#175

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
