### PR TITLE
Dashboards: Raise tag length limit to 255 UTF-8 bytes

### DIFF
--- a/pkg/registry/apis/dashboard/register.go
+++ b/pkg/registry/apis/dashboard/register.go
@@ -793,7 +793,7 @@ func validateDashboardTags(obj runtime.Object) error {
 	}
 
 	for _, tag := range tags {
-		if len(tag) > 50 {
+		if len(tag) > dashboards.DashboardTagMaxLength {
 			return dashboards.ErrDashboardTagTooLong
 		}
 	}

--- a/pkg/services/dashboards/errors.go
+++ b/pkg/services/dashboards/errors.go
@@ -6,6 +6,10 @@ import (
 	"github.com/grafana/grafana/pkg/services/dashboards/dashboardaccess"
 )
 
+// DashboardTagMaxLength is the maximum length of a dashboard tag in UTF-8 bytes.
+// Kept in sync with dashboard_tag.term column length.
+const DashboardTagMaxLength = 255
+
 // Typed errors
 var (
 	ErrDashboardNotFound = dashboardaccess.DashboardErr{
@@ -57,7 +61,7 @@ var (
 		StatusCode: 400,
 	}
 	ErrDashboardTagTooLong = dashboardaccess.DashboardErr{
-		Reason:     "dashboard tag too long, max 50 characters",
+		Reason:     "dashboard tag too long, max 255 UTF-8 bytes",
 		StatusCode: 400,
 		Status:     "tag-too-long",
 	}

--- a/pkg/services/sqlstore/migrations/dashboard_mig.go
+++ b/pkg/services/sqlstore/migrations/dashboard_mig.go
@@ -266,6 +266,10 @@ func addDashboardMigration(mg *Migrator) {
 		Cols: []string{"dashboard_uid"},
 		Type: IndexType,
 	}))
+
+	mg.AddMigration("Increase dashboard_tag.term length to 255", NewRawSQLMigration("").
+		Postgres("ALTER TABLE dashboard_tag ALTER COLUMN term TYPE VARCHAR(255);").
+		Mysql("ALTER TABLE dashboard_tag MODIFY term VARCHAR(255) NOT NULL;"))
 }
 
 type FillDashbordUIDAndOrgIDMigration struct {

--- a/pkg/tests/apis/dashboard/integration/api_validation_test.go
+++ b/pkg/tests/apis/dashboard/integration/api_validation_test.go
@@ -337,26 +337,26 @@ func runDashboardValidationTests(t *testing.T, ctx TestContext) {
 	})
 
 	t.Run("Dashboard tag validations", func(t *testing.T) {
-		t.Run("reject dashboard with tag over 50 characters on creation", func(t *testing.T) {
+		t.Run("reject dashboard with tag over 255 UTF-8 bytes on creation", func(t *testing.T) {
 			dashObj := createDashboardObject(t, "Dashboard with Long Tag", "", 0)
 			meta, _ := utils.MetaAccessor(dashObj)
 			spec, _ := meta.GetSpec()
 			specMap := spec.(map[string]interface{})
-			specMap["tags"] = []string{"this-is-a-very-long-tag-that-exceeds-fifty-characters-limit"}
+			specMap["tags"] = []string{strings.Repeat("a", 256)}
 			_ = meta.SetSpec(specMap)
 			_, err := adminClient.Resource.Create(context.Background(), dashObj, v1.CreateOptions{})
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "tag too long")
 		})
 
-		t.Run("reject dashboard update with tag over 50 characters", func(t *testing.T) {
+		t.Run("reject dashboard update with tag over 255 UTF-8 bytes", func(t *testing.T) {
 			dash, err := createDashboard(t, adminClient, "Valid Dashboard", nil, nil, ctx.Helper)
 			require.NoError(t, err)
 			require.NotNil(t, dash)
 			meta, _ := utils.MetaAccessor(dash)
 			spec, _ := meta.GetSpec()
 			specMap := spec.(map[string]interface{})
-			specMap["tags"] = []string{"this-is-a-very-long-tag-that-exceeds-fifty-characters-limit"}
+			specMap["tags"] = []string{strings.Repeat("a", 256)}
 			_ = meta.SetSpec(specMap)
 			_, err = adminClient.Resource.Update(context.Background(), dash, v1.UpdateOptions{})
 			require.Error(t, err)
@@ -365,12 +365,26 @@ func runDashboardValidationTests(t *testing.T, ctx TestContext) {
 			require.NoError(t, err)
 		})
 
-		t.Run("accept dashboard with tag at 50 characters", func(t *testing.T) {
+		t.Run("accept dashboard with tag at 50 UTF-8 bytes", func(t *testing.T) {
 			dashObj := createDashboardObject(t, "Dashboard with Valid Tag", "", 0)
 			meta, _ := utils.MetaAccessor(dashObj)
 			spec, _ := meta.GetSpec()
 			specMap := spec.(map[string]interface{})
 			specMap["tags"] = []string{"this-tag-is-exactly-fifty-characters-long-12345"}
+			_ = meta.SetSpec(specMap)
+			createdDash, err := adminClient.Resource.Create(context.Background(), dashObj, v1.CreateOptions{})
+			require.NoError(t, err)
+			require.NotNil(t, createdDash)
+			err = adminClient.Resource.Delete(context.Background(), createdDash.GetName(), v1.DeleteOptions{})
+			require.NoError(t, err)
+		})
+
+		t.Run("accept dashboard with tag at 255 UTF-8 bytes", func(t *testing.T) {
+			dashObj := createDashboardObject(t, "Dashboard with Max Length Tag", "", 0)
+			meta, _ := utils.MetaAccessor(dashObj)
+			spec, _ := meta.GetSpec()
+			specMap := spec.(map[string]interface{})
+			specMap["tags"] = []string{strings.Repeat("a", 255)}
 			_ = meta.SetSpec(specMap)
 			createdDash, err := adminClient.Resource.Create(context.Background(), dashObj, v1.CreateOptions{})
 			require.NoError(t, err)
@@ -387,7 +401,7 @@ func runDashboardValidationTests(t *testing.T, ctx TestContext) {
 			specMap["tags"] = []string{
 				"valid-tag",
 				"another-valid-tag",
-				"this-is-a-very-long-tag-that-exceeds-fifty-characters-limit",
+				strings.Repeat("a", 256),
 			}
 			_ = meta.SetSpec(specMap)
 			_, err := adminClient.Resource.Create(context.Background(), dashObj, v1.CreateOptions{})

--- a/public/app/features/dashboard-scene/settings/GeneralSettingsEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/GeneralSettingsEditView.tsx
@@ -302,7 +302,7 @@ function GeneralSettingsEditViewComponent({ model }: SceneComponentProps<General
             />
           </Field>
           <Field noMargin label={t('dashboard-settings.general.tags-label', 'Tags')}>
-            <TagsInput id="tags-input" tags={tags} onChange={model.onTagsChange} width={40} />
+            <TagsInput id="tags-input" tags={tags} onChange={model.onTagsChange} width={40} maxLength={255} />
           </Field>
           {!meta.isDashboardTemplate && (
             <Field noMargin label={t('dashboard-settings.general.folder-label', 'Folder')}>

--- a/public/app/features/manage-dashboards/import/utils/validation.test.ts
+++ b/public/app/features/manage-dashboards/import/utils/validation.test.ts
@@ -7,7 +7,7 @@ import { setDashboardAPI } from 'app/features/dashboard/api/dashboard_api';
 import { type DashboardWithAccessInfo } from 'app/features/dashboard/api/types';
 import { type DashboardDTO } from 'app/types/dashboard';
 
-import { validateUid } from './validation';
+import { validateDashboardJson, validateUid } from './validation';
 
 const legacyDashboard: DashboardDTO = {
   dashboard: {
@@ -39,6 +39,24 @@ const v2Dashboard: DashboardWithAccessInfo<DashboardV2Spec> = {
     title: 'V2 Dashboard',
   },
 };
+
+describe('validateDashboardJson', () => {
+  it('accepts a tag of exactly 255 UTF-8 bytes', () => {
+    const json = JSON.stringify({ tags: ['a'.repeat(255)] });
+    expect(validateDashboardJson(json)).toBe(true);
+  });
+
+  it('rejects a tag over 255 UTF-8 bytes', () => {
+    const json = JSON.stringify({ tags: ['a'.repeat(256)] });
+    expect(validateDashboardJson(json)).toBe('Dashboard tag too long, max 255 UTF-8 bytes');
+  });
+
+  it('rejects a multi-byte tag that exceeds 255 UTF-8 bytes', () => {
+    // 128 Cyrillic 'б' (2 bytes each) = 256 bytes
+    const json = JSON.stringify({ tags: ['б'.repeat(128)] });
+    expect(validateDashboardJson(json)).toBe('Dashboard tag too long, max 255 UTF-8 bytes');
+  });
+});
 
 describe('validateUid', () => {
   beforeAll(() => {

--- a/public/app/features/manage-dashboards/import/utils/validation.ts
+++ b/public/app/features/manage-dashboards/import/utils/validation.ts
@@ -18,9 +18,9 @@ export const validateDashboardJson = (json: string) => {
       if (hasInvalidTag) {
         return t('dashboard.validation.tags-expected-strings', 'tags expected array of strings');
       }
-      const hasTooLongTag = dashboard.tags.some((tag: string) => tag.length > 50);
+      const hasTooLongTag = dashboard.tags.some((tag: string) => new TextEncoder().encode(tag).length > 255);
       if (hasTooLongTag) {
-        return t('dashboard.validation.tag-too-long', 'Dashboard tag too long, max 50 characters');
+        return t('dashboard.validation.tag-too-long', 'Dashboard tag too long, max 255 UTF-8 bytes');
       }
     } else {
       return t('dashboard.validation.tags-expected-array', 'tags expected array');

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -6494,7 +6494,7 @@
     "validation": {
       "invalid-dashboard-id": "Could not find a valid Grafana.com ID",
       "invalid-json": "Not valid JSON",
-      "tag-too-long": "Dashboard tag too long, max 50 characters",
+      "tag-too-long": "Dashboard tag too long, max 255 UTF-8 bytes",
       "tags-expected-array": "tags expected array",
       "tags-expected-strings": "tags expected array of strings"
     },


### PR DESCRIPTION
## What is this feature?

Raises the dashboard tag length limit from 50 to 255 UTF-8 bytes and makes the limit's unit explicit in the error message.

- `dashboard_tag.term` widened from `NVARCHAR(50)` to `VARCHAR(255)` (Postgres/MySQL; SQLite ignores VARCHAR length).
- `validateDashboardTags` now uses a shared `dashboards.DashboardTagMaxLength` constant instead of a bare `50`.
- `ErrDashboardTagTooLong` reads `dashboard tag too long, max 255 UTF-8 bytes` — previously it said "50 characters" while the check counted bytes.
- Frontend import validation measures UTF-8 bytes via `TextEncoder` so it agrees with the backend for non-ASCII tags.
- Dashboard settings passes `maxLength={255}` to `TagsInput`, which otherwise defaults to 50.

## Why do we need this feature?

Fixes #129193. The 50 originated from the legacy `dashboard_tag.term` column and was enforced with Go `len()`, so a 50-*character* tag containing one multi-byteode point (49 ASCII + 1 Cyrillic = 51 bytes) was rejected despite the message promising 50 characters. Tags have no key/value structure, so the conventional `repository: ` prefix consumes 12 of the 50 bytes, leaving ~38 for the actual value. Teams applying uniform ownership metadata across dashboards and alert rules hit this only on dashboards — alerting labels have no length limit at all.

## Which issue(s) does this PR fix?

Fixes #129193

## Special notes for your reviewer

- The migration is appended rather than rewriting the historical create-table migration.
- `TagsInput`'s package-level default stays at 50; only the dashboard settings caller is raised, since other callers (dashlist, panel links, graphite annotations) do not write to `dashboard_tag.term`.
- Existing behaviour at and below 50 bytes is unchanged, so this is backwards compatible.
- Non-English locale strings for `dashboard.validation.tag-too-long` still say "50 characters" and will be picked up by the normal translation sync.

## Test plan

- `go test ./pkg/tests/apis/dashboard/integration/ -run TestIntegrationValidation` — cases now cover accepting 50 and 255 bytes and rejecting 256, on create and update.
- `yarn jest --no-watch public/app/features/manage-dashboards/import/utils/validation.test.ts` — 4 passed, including a multi-byte Cyrillic tag at 256 bytes.
- Migration verified against Postgres and MySQL via `make devenv sources=postgres_tests,mysql_tests && make test-go-integration-postgres`.