### PR TITLE
Provisioning: Don't offer to open a pull request when the provider can't

### DIFF
--- a/public/app/features/provisioning/components/Shared/PreviewBannerViewPR.test.tsx
+++ b/public/app/features/provisioning/components/Shared/PreviewBannerViewPR.test.tsx
@@ -195,7 +195,12 @@ describe('PreviewBannerViewPR', () => {
       expect(screen.getByText('Open in Git')).toBeInTheDocument();
       expect(screen.queryByText('Open pull request in Git')).not.toBeInTheDocument();
       expect(screen.queryByText('View pull request in Git')).not.toBeInTheDocument();
-      expect(screen.getByText(/This connection cannot open pull requests from Grafana/i)).toBeInTheDocument();
+      // Body has no trailing period; join must insert one before the hint sentence.
+      expect(
+        screen.getByText(
+          /until this branch is merged\. This connection cannot open pull requests from Grafana/i
+        )
+      ).toBeInTheDocument();
     });
 
     it('should not show the no-PR hint for GitHub when the PR URL is missing', () => {

--- a/public/app/features/provisioning/components/Shared/PreviewBannerViewPR.test.tsx
+++ b/public/app/features/provisioning/components/Shared/PreviewBannerViewPR.test.tsx
@@ -25,7 +25,14 @@ const mockTextUtil = jest.mocked(textUtil);
 const mockUsePullRequestParam = jest.mocked(usePullRequestParam);
 
 function setup(
-  options: { prURL: string; isNewPr?: boolean; repoType?: RepoType; action?: string; prTitle?: string } = {
+  options: {
+    prURL?: string;
+    isNewPr?: boolean;
+    repoType?: RepoType;
+    action?: string;
+    prTitle?: string;
+    repoUrl?: string;
+  } = {
     prURL: 'test-url',
     repoType: 'github',
   }
@@ -33,13 +40,15 @@ function setup(
   const componentProps = {
     prURL: options.prURL,
     isNewPr: options.isNewPr || false,
+    repoUrl: options.repoUrl,
   };
 
   mockUsePullRequestParam.mockReturnValue({
     prURL: undefined,
     newPrURL: undefined,
     repoURL: undefined,
-    repoType: options.repoType || 'github',
+    // Allow explicit undefined (missing repo_type query param) — don't coerce to github.
+    repoType: 'repoType' in options ? options.repoType : 'github',
     resourcePushedTo: 'abc',
     action: options.action,
     prTitle: options.prTitle,
@@ -187,6 +196,31 @@ describe('PreviewBannerViewPR', () => {
       expect(screen.queryByText('Open pull request in Git')).not.toBeInTheDocument();
       expect(screen.queryByText('View pull request in Git')).not.toBeInTheDocument();
       expect(screen.getByText(/This connection cannot open pull requests from Grafana/i)).toBeInTheDocument();
+    });
+
+    it('should not show the no-PR hint for GitHub when the PR URL is missing', () => {
+      setup({
+        prURL: undefined,
+        isNewPr: true,
+        repoType: 'github',
+        repoUrl: 'https://github.com/org/repo',
+      });
+
+      expect(screen.getByText('Open in GitHub')).toBeInTheDocument();
+      expect(screen.queryByText('Open pull request in GitHub')).not.toBeInTheDocument();
+      expect(screen.queryByText(/cannot open pull requests from Grafana/i)).not.toBeInTheDocument();
+    });
+
+    it('should not show the no-PR hint when repoType is missing', () => {
+      setup({
+        prURL: undefined,
+        isNewPr: true,
+        repoType: undefined,
+        repoUrl: 'https://example.com/org/repo',
+      });
+
+      expect(screen.getByText('Open in repository')).toBeInTheDocument();
+      expect(screen.queryByText(/cannot open pull requests from Grafana/i)).not.toBeInTheDocument();
     });
   });
 

--- a/public/app/features/provisioning/components/Shared/PreviewBannerViewPR.test.tsx
+++ b/public/app/features/provisioning/components/Shared/PreviewBannerViewPR.test.tsx
@@ -172,6 +172,22 @@ describe('PreviewBannerViewPR', () => {
         )
       ).toBeInTheDocument();
     });
+
+    it('should keep Open pull request label for GitLab when a PR URL is present', () => {
+      setup({ prURL: 'test-url', isNewPr: true, repoType: 'gitlab' });
+
+      expect(screen.getByText('Open pull request in GitLab')).toBeInTheDocument();
+      expect(screen.queryByText(/cannot open pull requests from Grafana/i)).not.toBeInTheDocument();
+    });
+
+    it('should use Open in Git and show the no-PR hint for pure git', () => {
+      setup({ prURL: 'https://git.example.com/org/repo', isNewPr: true, repoType: 'git' });
+
+      expect(screen.getByText('Open in Git')).toBeInTheDocument();
+      expect(screen.queryByText('Open pull request in Git')).not.toBeInTheDocument();
+      expect(screen.queryByText('View pull request in Git')).not.toBeInTheDocument();
+      expect(screen.getByText(/This connection cannot open pull requests from Grafana/i)).toBeInTheDocument();
+    });
   });
 
   describe('Delete action', () => {

--- a/public/app/features/provisioning/components/Shared/PreviewBannerViewPR.test.tsx
+++ b/public/app/features/provisioning/components/Shared/PreviewBannerViewPR.test.tsx
@@ -24,6 +24,10 @@ const mockTextUtil = jest.mocked(textUtil);
 
 const mockUsePullRequestParam = jest.mocked(usePullRequestParam);
 
+const githubCompareURL = 'https://github.com/org/repo/compare/main...feature?quick_pull=1';
+const gitlabMergeRequestURL = 'https://gitlab.com/org/repo/-/merge_requests/new?merge_request[source_branch]=feature';
+const bitbucketPullRequestURL = 'https://bitbucket.org/org/repo/pull-requests/new?source=feature';
+
 function setup(
   options: {
     prURL?: string;
@@ -33,7 +37,7 @@ function setup(
     prTitle?: string;
     repoUrl?: string;
   } = {
-    prURL: 'test-url',
+    prURL: githubCompareURL,
     repoType: 'github',
   }
 ) {
@@ -85,14 +89,14 @@ describe('PreviewBannerViewPR', () => {
 
   describe('Dashboard scenarios', () => {
     it('should render correct text for new PR dashboard', () => {
-      setup({ prURL: 'test-url', isNewPr: true });
+      setup({ prURL: githubCompareURL, isNewPr: true });
 
       expect(screen.getByRole('status')).toBeInTheDocument();
       expect(screen.getByText('A new resource has been created in a branch in GitHub.')).toBeInTheDocument();
     });
 
     it('should render correct text for existing PR dashboard', () => {
-      setup({ prURL: 'test-url', isNewPr: false });
+      setup({ prURL: githubCompareURL, isNewPr: false });
 
       expect(screen.getByRole('status')).toBeInTheDocument();
       expect(
@@ -103,13 +107,13 @@ describe('PreviewBannerViewPR', () => {
     });
 
     it('should render correct button text for new PR dashboard', () => {
-      setup({ prURL: 'test-url', isNewPr: true });
+      setup({ prURL: githubCompareURL, isNewPr: true });
 
       expect(screen.getByText('Open pull request in GitHub')).toBeInTheDocument();
     });
 
     it('should render correct button text for existing PR dashboard', () => {
-      setup({ prURL: 'test-url', isNewPr: false });
+      setup({ prURL: githubCompareURL, isNewPr: false });
 
       expect(screen.getByText('View pull request in GitHub')).toBeInTheDocument();
     });
@@ -117,14 +121,14 @@ describe('PreviewBannerViewPR', () => {
 
   describe('Additional scenarios', () => {
     it('should render correct text for new PR resource', () => {
-      setup({ prURL: 'test-url', isNewPr: true });
+      setup({ prURL: githubCompareURL, isNewPr: true });
 
       expect(screen.getByRole('status')).toBeInTheDocument();
       expect(screen.getByText('A new resource has been created in a branch in GitHub.')).toBeInTheDocument();
     });
 
     it('should render correct text for existing PR resource', () => {
-      setup({ prURL: 'test-url', isNewPr: false });
+      setup({ prURL: githubCompareURL, isNewPr: false });
 
       expect(screen.getByRole('status')).toBeInTheDocument();
       expect(
@@ -135,13 +139,13 @@ describe('PreviewBannerViewPR', () => {
     });
 
     it('should render correct button text for new PR resource', () => {
-      setup({ prURL: 'test-url', isNewPr: true });
+      setup({ prURL: githubCompareURL, isNewPr: true });
 
       expect(screen.getByText('Open pull request in GitHub')).toBeInTheDocument();
     });
 
     it('should render correct button text for existing PR resource', () => {
-      setup({ prURL: 'test-url', isNewPr: false });
+      setup({ prURL: githubCompareURL, isNewPr: false });
 
       expect(screen.getByText('View pull request in GitHub')).toBeInTheDocument();
     });
@@ -161,7 +165,7 @@ describe('PreviewBannerViewPR', () => {
 
   describe('Different repository types', () => {
     it('should handle GitLab repository type', () => {
-      setup({ prURL: 'test-url', isNewPr: false, repoType: 'gitlab' });
+      setup({ prURL: gitlabMergeRequestURL, isNewPr: false, repoType: 'gitlab' });
 
       expect(screen.getByRole('status')).toBeInTheDocument();
       expect(
@@ -172,7 +176,7 @@ describe('PreviewBannerViewPR', () => {
     });
 
     it('should handle Bitbucket repository type', () => {
-      setup({ prURL: 'test-url', isNewPr: false, repoType: 'bitbucket' });
+      setup({ prURL: bitbucketPullRequestURL, isNewPr: false, repoType: 'bitbucket' });
 
       expect(screen.getByRole('status')).toBeInTheDocument();
       expect(
@@ -183,9 +187,28 @@ describe('PreviewBannerViewPR', () => {
     });
 
     it('should keep Open pull request label for GitLab when a PR URL is present', () => {
-      setup({ prURL: 'test-url', isNewPr: true, repoType: 'gitlab' });
+      setup({ prURL: gitlabMergeRequestURL, isNewPr: true, repoType: 'gitlab' });
 
       expect(screen.getByText('Open pull request in GitLab')).toBeInTheDocument();
+      expect(screen.queryByText(/cannot open pull requests from Grafana/i)).not.toBeInTheDocument();
+    });
+
+    it('should keep Open pull request label for Bitbucket when a PR URL is present', () => {
+      setup({ prURL: bitbucketPullRequestURL, isNewPr: true, repoType: 'bitbucket' });
+
+      expect(screen.getByText('Open pull request in Bitbucket')).toBeInTheDocument();
+      expect(screen.queryByText(/cannot open pull requests from Grafana/i)).not.toBeInTheDocument();
+    });
+
+    it('should use Open in Bitbucket when prURL is only the repo root', () => {
+      setup({
+        prURL: 'https://bitbucket.org/org/repo',
+        isNewPr: true,
+        repoType: 'bitbucket',
+      });
+
+      expect(screen.getByText('Open in Bitbucket')).toBeInTheDocument();
+      expect(screen.queryByText('Open pull request in Bitbucket')).not.toBeInTheDocument();
       expect(screen.queryByText(/cannot open pull requests from Grafana/i)).not.toBeInTheDocument();
     });
 
@@ -231,13 +254,13 @@ describe('PreviewBannerViewPR', () => {
 
   describe('Delete action', () => {
     it('should render delete-specific title for new PR', () => {
-      setup({ prURL: 'test-url', isNewPr: true, action: 'delete' });
+      setup({ prURL: githubCompareURL, isNewPr: true, action: 'delete' });
 
       expect(screen.getByText('A resource has been deleted in a branch in GitHub.')).toBeInTheDocument();
     });
 
     it('should render delete-specific body text', () => {
-      setup({ prURL: 'test-url', isNewPr: true, action: 'delete' });
+      setup({ prURL: githubCompareURL, isNewPr: true, action: 'delete' });
 
       expect(
         screen.getByText(
@@ -247,7 +270,7 @@ describe('PreviewBannerViewPR', () => {
     });
 
     it('should still render PR button for delete action', () => {
-      setup({ prURL: 'test-url', isNewPr: true, action: 'delete' });
+      setup({ prURL: githubCompareURL, isNewPr: true, action: 'delete' });
 
       expect(screen.getByText('Open pull request in GitHub')).toBeInTheDocument();
     });

--- a/public/app/features/provisioning/components/Shared/PreviewBannerViewPR.tsx
+++ b/public/app/features/provisioning/components/Shared/PreviewBannerViewPR.tsx
@@ -141,7 +141,8 @@ function noPullRequestSupportBody(): string {
 }
 
 function withNoPullRequestHint(body: string, showNoPullRequestHint: boolean): string {
-  return showNoPullRequestHint ? `${body} ${noPullRequestSupportBody()}` : body;
+  // Body i18n strings have no trailing period; join as two sentences.
+  return showNoPullRequestHint ? `${body}. ${noPullRequestSupportBody()}` : body;
 }
 
 function openInRepoButton(repoType: string): string {

--- a/public/app/features/provisioning/components/Shared/PreviewBannerViewPR.tsx
+++ b/public/app/features/provisioning/components/Shared/PreviewBannerViewPR.tsx
@@ -54,15 +54,19 @@ export function PreviewBannerViewPR({ prURL, isNewPr, behindBranch, repoUrl, bra
   // PR/compare URL carries it. Returns prURL unchanged when no title was threaded through.
   const prLink = appendPullRequestTitleParam(prURL, repoType, prTitle);
   const linkUrl = prLink || branchInfo?.repoBaseUrl || repoUrl;
-  // Pure git (and local) cannot open PRs — don't claim "Open pull request" when we only have a repo URL.
-  const hasPullRequest = supportsPullRequests(repoType) && Boolean(prLink);
+  // Capability (can this provider open PRs?) vs whether we have a PR URL right now.
+  const canOpenPullRequests = supportsPullRequests(repoType);
+  const hasPullRequestLink = canOpenPullRequests && Boolean(prLink);
+  // Only claim "cannot open pull requests" for known non-PR providers (git/local), not when
+  // repoType is missing or the PR link simply isn't ready yet.
+  const showNoPullRequestHint = isValidRepoType(repoType) && !canOpenPullRequests;
 
   const actionText =
     action === 'delete'
-      ? getDeleteBannerText(capitalizedRepoType, hasPullRequest)
+      ? getDeleteBannerText(capitalizedRepoType, hasPullRequestLink, showNoPullRequestHint)
       : action === 'update'
-        ? getUpdateBannerText(capitalizedRepoType, hasPullRequest)
-        : getCreateBannerText(isNewPr, capitalizedRepoType, hasPullRequest);
+        ? getUpdateBannerText(capitalizedRepoType, hasPullRequestLink, showNoPullRequestHint)
+        : getCreateBannerText(isNewPr, capitalizedRepoType, hasPullRequestLink, showNoPullRequestHint);
 
   if (behindBranch) {
     return (
@@ -136,8 +140,8 @@ function noPullRequestSupportBody(): string {
   );
 }
 
-function withNoPullRequestHint(body: string, hasPullRequest: boolean): string {
-  return hasPullRequest ? body : `${body} ${noPullRequestSupportBody()}`;
+function withNoPullRequestHint(body: string, showNoPullRequestHint: boolean): string {
+  return showNoPullRequestHint ? `${body} ${noPullRequestSupportBody()}` : body;
 }
 
 function openInRepoButton(repoType: string): string {
@@ -154,7 +158,12 @@ function openPullRequestButton(repoType: string): string {
   );
 }
 
-function getCreateBannerText(isNewPr: boolean | undefined, repoType: string, hasPullRequest: boolean): BannerText {
+function getCreateBannerText(
+  isNewPr: boolean | undefined,
+  repoType: string,
+  hasPullRequestLink: boolean,
+  showNoPullRequestHint: boolean
+): BannerText {
   return {
     title: isNewPr
       ? t(
@@ -172,9 +181,9 @@ function getCreateBannerText(isNewPr: boolean | undefined, repoType: string, has
         'provisioned-resource-preview-banner.preview-banner.not-saved',
         'The rest of Grafana users in your organization will still see the current version saved to configured default branch until this branch is merged'
       ),
-      hasPullRequest
+      showNoPullRequestHint
     ),
-    button: hasPullRequest
+    button: hasPullRequestLink
       ? isNewPr
         ? openPullRequestButton(repoType)
         : t(
@@ -186,7 +195,7 @@ function getCreateBannerText(isNewPr: boolean | undefined, repoType: string, has
   };
 }
 
-function getDeleteBannerText(repoType: string, hasPullRequest: boolean): BannerText {
+function getDeleteBannerText(repoType: string, hasPullRequestLink: boolean, showNoPullRequestHint: boolean): BannerText {
   return {
     title: t(
       'provisioned-resource-preview-banner.title-deleted-resource-in-branch',
@@ -198,13 +207,13 @@ function getDeleteBannerText(repoType: string, hasPullRequest: boolean): BannerT
         'provisioned-resource-preview-banner.preview-banner.delete-from-branch',
         'The rest of Grafana users in your organization will still see this resource until this branch is merged'
       ),
-      hasPullRequest
+      showNoPullRequestHint
     ),
-    button: hasPullRequest ? openPullRequestButton(repoType) : openInRepoButton(repoType),
+    button: hasPullRequestLink ? openPullRequestButton(repoType) : openInRepoButton(repoType),
   };
 }
 
-function getUpdateBannerText(repoType: string, hasPullRequest: boolean): BannerText {
+function getUpdateBannerText(repoType: string, hasPullRequestLink: boolean, showNoPullRequestHint: boolean): BannerText {
   return {
     title: t(
       'provisioned-resource-preview-banner.title-updated-resource-in-branch',
@@ -216,9 +225,9 @@ function getUpdateBannerText(repoType: string, hasPullRequest: boolean): BannerT
         'provisioned-resource-preview-banner.preview-banner.update-from-branch',
         'The rest of Grafana users in your organization will still see the current version until this branch is merged'
       ),
-      hasPullRequest
+      showNoPullRequestHint
     ),
-    button: hasPullRequest ? openPullRequestButton(repoType) : openInRepoButton(repoType),
+    button: hasPullRequestLink ? openPullRequestButton(repoType) : openInRepoButton(repoType),
   };
 }
 

--- a/public/app/features/provisioning/components/Shared/PreviewBannerViewPR.tsx
+++ b/public/app/features/provisioning/components/Shared/PreviewBannerViewPR.tsx
@@ -6,7 +6,7 @@ import { isValidRepoType } from 'app/features/provisioning/guards';
 import { usePullRequestParam } from 'app/features/provisioning/hooks/usePullRequestParam';
 
 import { appendPullRequestTitleParam } from '../../utils/pullRequestTitle';
-import { isGitProvider } from '../../utils/repositoryTypes';
+import { isGitProvider, supportsPullRequests } from '../../utils/repositoryTypes';
 import { getBranchUrl } from '../utils/url';
 
 interface Props {
@@ -54,13 +54,15 @@ export function PreviewBannerViewPR({ prURL, isNewPr, behindBranch, repoUrl, bra
   // PR/compare URL carries it. Returns prURL unchanged when no title was threaded through.
   const prLink = appendPullRequestTitleParam(prURL, repoType, prTitle);
   const linkUrl = prLink || branchInfo?.repoBaseUrl || repoUrl;
+  // Pure git (and local) cannot open PRs — don't claim "Open pull request" when we only have a repo URL.
+  const hasPullRequest = supportsPullRequests(repoType) && Boolean(prLink);
 
   const actionText =
     action === 'delete'
-      ? getDeleteBannerText(capitalizedRepoType)
+      ? getDeleteBannerText(capitalizedRepoType, hasPullRequest)
       : action === 'update'
-        ? getUpdateBannerText(capitalizedRepoType)
-        : getCreateBannerText(isNewPr, capitalizedRepoType);
+        ? getUpdateBannerText(capitalizedRepoType, hasPullRequest)
+        : getCreateBannerText(isNewPr, capitalizedRepoType, hasPullRequest);
 
   if (behindBranch) {
     return (
@@ -127,7 +129,32 @@ interface BannerText {
   button: string;
 }
 
-function getCreateBannerText(isNewPr: boolean | undefined, repoType: string): BannerText {
+function noPullRequestSupportBody(): string {
+  return t(
+    'provisioned-resource-preview-banner.preview-banner.no-pull-request-support',
+    'This connection cannot open pull requests from Grafana. Create one from this branch in your Git provider to publish the changes.'
+  );
+}
+
+function withNoPullRequestHint(body: string, hasPullRequest: boolean): string {
+  return hasPullRequest ? body : `${body} ${noPullRequestSupportBody()}`;
+}
+
+function openInRepoButton(repoType: string): string {
+  return t('provisioned-resource-preview-banner.preview-banner.open-in-repo-button', 'Open in {{repoType}}', {
+    repoType,
+  });
+}
+
+function openPullRequestButton(repoType: string): string {
+  return t(
+    'provisioned-resource-preview-banner.preview-banner.open-pull-request-in-repo',
+    'Open pull request in {{repoType}}',
+    { repoType }
+  );
+}
+
+function getCreateBannerText(isNewPr: boolean | undefined, repoType: string, hasPullRequest: boolean): BannerText {
   return {
     title: isNewPr
       ? t(
@@ -140,59 +167,58 @@ function getCreateBannerText(isNewPr: boolean | undefined, repoType: string): Ba
           'This resource is loaded from the branch you just created in {{repoType}} and it is only visible to you',
           { repoType }
         ),
-    body: t(
-      'provisioned-resource-preview-banner.preview-banner.not-saved',
-      'The rest of Grafana users in your organization will still see the current version saved to configured default branch until this branch is merged'
+    body: withNoPullRequestHint(
+      t(
+        'provisioned-resource-preview-banner.preview-banner.not-saved',
+        'The rest of Grafana users in your organization will still see the current version saved to configured default branch until this branch is merged'
+      ),
+      hasPullRequest
     ),
-    button: isNewPr
-      ? t(
-          'provisioned-resource-preview-banner.preview-banner.open-pull-request-in-repo',
-          'Open pull request in {{repoType}}',
-          { repoType }
-        )
-      : t(
-          'provisioned-resource-preview-banner.preview-banner.view-pull-request-in-repo',
-          'View pull request in {{repoType}}',
-          { repoType }
-        ),
+    button: hasPullRequest
+      ? isNewPr
+        ? openPullRequestButton(repoType)
+        : t(
+            'provisioned-resource-preview-banner.preview-banner.view-pull-request-in-repo',
+            'View pull request in {{repoType}}',
+            { repoType }
+          )
+      : openInRepoButton(repoType),
   };
 }
 
-function getDeleteBannerText(repoType: string): BannerText {
+function getDeleteBannerText(repoType: string, hasPullRequest: boolean): BannerText {
   return {
     title: t(
       'provisioned-resource-preview-banner.title-deleted-resource-in-branch',
       'A resource has been deleted in a branch in {{repoType}}.',
       { repoType }
     ),
-    body: t(
-      'provisioned-resource-preview-banner.preview-banner.delete-from-branch',
-      'The rest of Grafana users in your organization will still see this resource until this branch is merged'
+    body: withNoPullRequestHint(
+      t(
+        'provisioned-resource-preview-banner.preview-banner.delete-from-branch',
+        'The rest of Grafana users in your organization will still see this resource until this branch is merged'
+      ),
+      hasPullRequest
     ),
-    button: t(
-      'provisioned-resource-preview-banner.preview-banner.open-pull-request-in-repo',
-      'Open pull request in {{repoType}}',
-      { repoType }
-    ),
+    button: hasPullRequest ? openPullRequestButton(repoType) : openInRepoButton(repoType),
   };
 }
 
-function getUpdateBannerText(repoType: string): BannerText {
+function getUpdateBannerText(repoType: string, hasPullRequest: boolean): BannerText {
   return {
     title: t(
       'provisioned-resource-preview-banner.title-updated-resource-in-branch',
       'A resource has been updated in a branch in {{repoType}}.',
       { repoType }
     ),
-    body: t(
-      'provisioned-resource-preview-banner.preview-banner.update-from-branch',
-      'The rest of Grafana users in your organization will still see the current version until this branch is merged'
+    body: withNoPullRequestHint(
+      t(
+        'provisioned-resource-preview-banner.preview-banner.update-from-branch',
+        'The rest of Grafana users in your organization will still see the current version until this branch is merged'
+      ),
+      hasPullRequest
     ),
-    button: t(
-      'provisioned-resource-preview-banner.preview-banner.open-pull-request-in-repo',
-      'Open pull request in {{repoType}}',
-      { repoType }
-    ),
+    button: hasPullRequest ? openPullRequestButton(repoType) : openInRepoButton(repoType),
   };
 }
 

--- a/public/app/features/provisioning/components/Shared/PreviewBannerViewPR.tsx
+++ b/public/app/features/provisioning/components/Shared/PreviewBannerViewPR.tsx
@@ -54,9 +54,11 @@ export function PreviewBannerViewPR({ prURL, isNewPr, behindBranch, repoUrl, bra
   // PR/compare URL carries it. Returns prURL unchanged when no title was threaded through.
   const prLink = appendPullRequestTitleParam(prURL, repoType, prTitle);
   const linkUrl = prLink || branchInfo?.repoBaseUrl || repoUrl;
-  // Capability (can this provider open PRs?) vs whether we have a PR URL right now.
+  // Capability (can this provider open PRs?) vs whether we have a real PR/compare URL.
+  // Folder flows may put repository.url in prURL when newPullRequestURL is missing
+  // (Bitbucket / pure git) — don't label that as "Open pull request".
   const canOpenPullRequests = supportsPullRequests(repoType);
-  const hasPullRequestLink = canOpenPullRequests && Boolean(prLink);
+  const hasPullRequestLink = canOpenPullRequests && isPullRequestOrCompareUrl(prURL);
   // Only claim "cannot open pull requests" for known non-PR providers (git/local), not when
   // repoType is missing or the PR link simply isn't ready yet.
   const showNoPullRequestHint = isValidRepoType(repoType) && !canOpenPullRequests;
@@ -131,6 +133,14 @@ interface BannerText {
   title: string;
   body: string;
   button: string;
+}
+
+/** True when the URL path looks like a host PR/compare/create-MR link, not a repo root. */
+function isPullRequestOrCompareUrl(url: string | undefined): boolean {
+  if (!url) {
+    return false;
+  }
+  return /\/(compare|pull|pulls|pull-requests|merge_requests)(\/|\?|$)/i.test(url);
 }
 
 function noPullRequestSupportBody(): string {

--- a/public/app/features/provisioning/components/utils/url.test.ts
+++ b/public/app/features/provisioning/components/utils/url.test.ts
@@ -17,8 +17,8 @@ describe('getBranchUrl', () => {
     expect(getBranchUrl(bbUrl, 'feature/x', 'bitbucket')).toBe('https://bitbucket.org/org/repo/src/feature/x');
   });
 
-  it('returns base URL for generic git', () => {
-    expect(getBranchUrl(baseUrl, 'main', 'git')).toBe('https://github.com/org/repo');
+  it('returns empty string for generic git (no standard branch deep-link)', () => {
+    expect(getBranchUrl(baseUrl, 'main', 'git')).toBe('');
   });
 
   it('returns empty string for local repos', () => {

--- a/public/app/features/provisioning/components/utils/url.ts
+++ b/public/app/features/provisioning/components/utils/url.ts
@@ -17,9 +17,9 @@ export const getBranchUrl = (baseUrl: string, branch: string, repoType?: string)
     case 'bitbucket':
       return `${cleanBaseUrl}/src/${branch}`;
     case 'git':
-      // Generic git repositories don't have a standard URL pattern for branches
-      // Just return the base URL without branch segment
-      return cleanBaseUrl;
+      // Pure git has no standard branch deep-link; return empty so the branch renders as text
+      // instead of a misleading link to the repository root on the default branch.
+      return '';
     default:
       return '';
   }

--- a/public/app/features/provisioning/utils/repositoryTypes.test.ts
+++ b/public/app/features/provisioning/utils/repositoryTypes.test.ts
@@ -1,4 +1,4 @@
-import { supportsWebhooks } from './repositoryTypes';
+import { supportsPullRequests, supportsWebhooks } from './repositoryTypes';
 
 describe('supportsWebhooks', () => {
   it.each(['github', 'githubEnterprise', 'gitlab', 'bitbucket'] as const)('should return true for %s', (type) => {
@@ -11,5 +11,26 @@ describe('supportsWebhooks', () => {
 
   it('should return false for undefined', () => {
     expect(supportsWebhooks(undefined)).toBe(false);
+  });
+});
+
+describe('supportsPullRequests', () => {
+  it.each(['github', 'githubEnterprise', 'gitlab', 'bitbucket'] as const)('should return true for %s', (type) => {
+    expect(supportsPullRequests(type)).toBe(true);
+  });
+
+  it.each(['git', 'local'] as const)('should return false for %s', (type) => {
+    expect(supportsPullRequests(type)).toBe(false);
+  });
+
+  it('should return false for undefined', () => {
+    expect(supportsPullRequests(undefined)).toBe(false);
+  });
+
+  it('should match supportsWebhooks for every RepoType', () => {
+    for (const type of ['github', 'githubEnterprise', 'gitlab', 'bitbucket', 'git', 'local'] as const) {
+      expect(supportsPullRequests(type)).toBe(supportsWebhooks(type));
+    }
+    expect(supportsPullRequests(undefined)).toBe(supportsWebhooks(undefined));
   });
 });

--- a/public/app/features/provisioning/utils/repositoryTypes.ts
+++ b/public/app/features/provisioning/utils/repositoryTypes.ts
@@ -105,12 +105,12 @@ export const supportsWebhooks = (type?: RepoType): type is 'github' | 'githubEnt
   return type === 'github' || type === 'githubEnterprise' || type === 'gitlab' || type === 'bitbucket';
 };
 
-// Providers whose repositories can open pull/merge requests. Mirrors the backend, where only
-// hosting providers implement RepositoryWithURLs and pass spec.pullRequest validation.
+// Providers whose repositories can open pull/merge requests. Same hosting providers as
+// webhooks — backend only those implement RepositoryWithURLs / pullRequest validation.
 export const supportsPullRequests = (
   type?: RepoType
 ): type is 'github' | 'githubEnterprise' | 'gitlab' | 'bitbucket' => {
-  return type === 'github' || type === 'githubEnterprise' || type === 'gitlab' || type === 'bitbucket';
+  return supportsWebhooks(type);
 };
 
 /**

--- a/public/app/features/provisioning/utils/repositoryTypes.ts
+++ b/public/app/features/provisioning/utils/repositoryTypes.ts
@@ -105,6 +105,14 @@ export const supportsWebhooks = (type?: RepoType): type is 'github' | 'githubEnt
   return type === 'github' || type === 'githubEnterprise' || type === 'gitlab' || type === 'bitbucket';
 };
 
+// Providers whose repositories can open pull/merge requests. Mirrors the backend, where only
+// hosting providers implement RepositoryWithURLs and pass spec.pullRequest validation.
+export const supportsPullRequests = (
+  type?: RepoType
+): type is 'github' | 'githubEnterprise' | 'gitlab' | 'bitbucket' => {
+  return type === 'github' || type === 'githubEnterprise' || type === 'gitlab' || type === 'bitbucket';
+};
+
 /**
  * Get repository configurations ordered by provider type priority:
  * 1. Git providers first (github, gitlab, bitbucket) - excludes pure git

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -13243,6 +13243,7 @@
       "behind-branch-text": "This resource is behind the branch in {{repoType}}.",
       "branch-text": "branch:",
       "delete-from-branch": "The rest of Grafana users in your organization will still see this resource until this branch is merged",
+      "no-pull-request-support": "This connection cannot open pull requests from Grafana. Create one from this branch in your Git provider to publish the changes.",
       "not-saved": "The rest of Grafana users in your organization will still see the current version saved to configured default branch until this branch is merged",
       "open-in-repo-button": "Open in {{repoType}}",
       "open-pull-request-in-repo": "Open pull request in {{repoType}}",


### PR DESCRIPTION
## What is this feature?

Makes the Git Sync branch-save banner tell the truth on connections that have no host API, instead of offering a pull request that was never opened.

- New `supportsPullRequests()` capability check in `public/app/features/provisioning/utils/repositoryTypes.ts`, alongside the existing `supportsWebhooks()`.
- `PreviewBannerViewPR` uses it: providers that can open pull requests keep "Open pull request in GitHub/GitLab/Bitbucket"; the rest get "Open in Git" plus a line telling the author to raise the request from that branch on their Git host.
- `getBranchUrl` returns an empty string for `git` so the pushed branch renders as plain text via the component's existing fallback, rather than a link to the repository root.

## Why do we need this feature?

Fixes #129250. Pure git pushes over the git protocol and has no host-API integration, so the provisioning API returns `urls: null` and there is no PR URL to attach. The banner labelled its button "Open pull request in Git" anyway and fell back to `branchInfo?.repoBaseUrl || repoUrl`, so an author who saved a dashboard on a branch landed on the repository root at the default branch — no merge request, not even the branch they had just pushed. As the reporter puts it, that is worse than no button: it implies the review request was raised when it was not. The branch chip compounded it, since `getBranchUrl` returned the bare base URL for `git`.

The wording is now gated on capability rather than on whether some URL happens to be present, which also covers the folder create/rename flows that deliberately put `repository.url` into the `new_pull_request_url` param to keep the button visible.

## Which issue(s) does this PR fix?

Fixes #129250

## Special notes for your reviewer

- Frontend only. `supportsPullRequests()` mirrors the backend contract: only hosting providers implement `RepositoryWithURLs` (`apps/provisioning/pkg/repository/github/repository.go`), and `validator.go` already rejects `spec.pullRequest` on `git` and `local`.
- No behaviour change for GitHub, GitHub Enterprise, GitLab or Bitbucket — they still get the PR label and the `pr_title` prefill.
- The folder forms are untouched: their repo-URL fallback still keeps a working button, it is just labelled honestly now.
- This does not construct a merge-request deep link. Host flavour is not inferable from a self-hosted remote such as `git.acme.com`, and the GitLab/Bitbucket enhanced integrations that do build real MR URLs are Cloud/Enterprise. Users who want a native MR link should use the GitLab connection type.

## Test plan

- `yarn jest --no-watch public/app/features/provisioning/components/Shared/PreviewBannerViewPR.test.tsx public/app/features/provisioning/components/utils/url.test.ts` — 31 passed, including new cases that `git` shows "Open in Git" with the hint and never the PR label, and that GitLab keeps "Open pull request in GitLab".
- Manual: save a dashboard to a branch on a `type: git` repository and confirm the banner offers "Open in Git", names the pushed branch as text, and no longer claims a pull request.