### PR TITLE
Dashboards: Fix Internal Server Error after first save for Dashboard Creators

### DIFF
--- a/pkg/registry/apis/dashboard/permissions_default_test.go
+++ b/pkg/registry/apis/dashboard/permissions_default_test.go
@@ -1,0 +1,181 @@
+package dashboard
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
+
+	authlib "github.com/grafana/authlib/types"
+	dashv1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafana/pkg/services/accesscontrol/mock"
+	"github.com/grafana/grafana/pkg/services/folder"
+	"github.com/grafana/grafana/pkg/services/user"
+	resourcepb "github.com/grafana/grafana/pkg/storage/unified/resourcepb"
+)
+
+func TestClearCreatorPermissionCache(t *testing.T) {
+	t.Run("clears cache for user identities", func(t *testing.T) {
+		ac := mock.New()
+		b := &DashboardsAPIBuilder{acService: ac}
+		u := &user.SignedInUser{UserID: 1, OrgID: 1, Login: "creator"}
+		ctx := identity.WithRequester(context.Background(), u)
+
+		b.clearCreatorPermissionCache(ctx)
+
+		require.Len(t, ac.Calls.ClearUserPermissionCache, 1)
+	})
+
+	t.Run("no-ops when acService is nil", func(t *testing.T) {
+		b := &DashboardsAPIBuilder{}
+		u := &user.SignedInUser{UserID: 1, OrgID: 1, Login: "creator"}
+		ctx := identity.WithRequester(context.Background(), u)
+
+		require.NotPanics(t, func() {
+			b.clearCreatorPermissionCache(ctx)
+		})
+	})
+
+	t.Run("skips anonymous identities", func(t *testing.T) {
+		ac := mock.New()
+		b := &DashboardsAPIBuilder{acService: ac}
+		u := &user.SignedInUser{IsAnonymous: true, OrgID: 1}
+		ctx := identity.WithRequester(context.Background(), u)
+
+		b.clearCreatorPermissionCache(ctx)
+
+		require.Empty(t, ac.Calls.ClearUserPermissionCache)
+	})
+}
+
+func TestSetDefaultDashboardPermissions_RootCheck(t *testing.T) {
+	key := &resourcepb.ResourceKey{Namespace: "default", Group: "dashboard.grafana.app", Resource: "dashboards", Name: "dash-1"}
+	creator := &user.SignedInUser{UserID: 1, OrgID: 1, Login: "creator", Name: "1"}
+
+	t.Run("skips nested dashboards without calling the permissions API", func(t *testing.T) {
+		fake := &recordingResourceClient{panicOnCall: true}
+		var iface dynamic.NamespaceableResourceInterface = fake
+		b := &DashboardsAPIBuilder{resourcePermissionsSvc: &iface}
+
+		dash := &dashv1.Dashboard{ObjectMeta: metav1.ObjectMeta{Name: "dash-1", Namespace: "default"}}
+		dash.SetAnnotations(map[string]string{utils.AnnoKeyFolder: "some-folder"})
+		meta, err := utils.MetaAccessor(dash)
+		require.NoError(t, err)
+
+		err = b.setDefaultDashboardPermissions(context.Background(), key, creator, meta)
+		require.NoError(t, err)
+	})
+
+	t.Run("seeds permissions for empty folder and clears creator cache", func(t *testing.T) {
+		ac := mock.New()
+		fake := &recordingResourceClient{getNotFound: true}
+		var iface dynamic.NamespaceableResourceInterface = fake
+		b := &DashboardsAPIBuilder{resourcePermissionsSvc: &iface, acService: ac}
+
+		dash := &dashv1.Dashboard{ObjectMeta: metav1.ObjectMeta{Name: "dash-1", Namespace: "default"}}
+		meta, err := utils.MetaAccessor(dash)
+		require.NoError(t, err)
+		require.True(t, folder.IsRootFolderUID(meta.GetFolder()))
+
+		ctx := identity.WithRequester(context.Background(), creator)
+		err = b.setDefaultDashboardPermissions(ctx, key, creator, meta)
+		require.NoError(t, err)
+		require.Equal(t, 1, fake.createCalls)
+		require.Len(t, ac.Calls.ClearUserPermissionCache, 1)
+	})
+
+	t.Run("seeds permissions for general folder and clears creator cache", func(t *testing.T) {
+		ac := mock.New()
+		fake := &recordingResourceClient{getNotFound: true}
+		var iface dynamic.NamespaceableResourceInterface = fake
+		b := &DashboardsAPIBuilder{resourcePermissionsSvc: &iface, acService: ac}
+
+		dash := &dashv1.Dashboard{ObjectMeta: metav1.ObjectMeta{Name: "dash-1", Namespace: "default"}}
+		dash.SetAnnotations(map[string]string{utils.AnnoKeyFolder: folder.GeneralFolderUID})
+		meta, err := utils.MetaAccessor(dash)
+		require.NoError(t, err)
+		require.True(t, folder.IsRootFolderUID(meta.GetFolder()))
+
+		ctx := identity.WithRequester(context.Background(), creator)
+		err = b.setDefaultDashboardPermissions(ctx, key, creator, meta)
+		require.NoError(t, err)
+		require.Equal(t, 1, fake.createCalls)
+		require.Len(t, ac.Calls.ClearUserPermissionCache, 1)
+	})
+}
+
+// recordingResourceClient is a minimal dynamic client stub for default-permission tests.
+type recordingResourceClient struct {
+	panicOnCall bool
+	getNotFound bool
+	createCalls int
+	updateCalls int
+}
+
+func (r *recordingResourceClient) Namespace(string) dynamic.ResourceInterface {
+	if r.panicOnCall {
+		panic("permissions API should not be called for nested dashboards")
+	}
+	return r
+}
+
+func (r *recordingResourceClient) Create(ctx context.Context, obj *unstructured.Unstructured, options metav1.CreateOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	r.createCalls++
+	return obj, nil
+}
+
+func (r *recordingResourceClient) Update(ctx context.Context, obj *unstructured.Unstructured, options metav1.UpdateOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	r.updateCalls++
+	return obj, nil
+}
+
+func (r *recordingResourceClient) UpdateStatus(ctx context.Context, obj *unstructured.Unstructured, options metav1.UpdateOptions) (*unstructured.Unstructured, error) {
+	return nil, nil
+}
+
+func (r *recordingResourceClient) Delete(ctx context.Context, name string, options metav1.DeleteOptions, subresources ...string) error {
+	return nil
+}
+
+func (r *recordingResourceClient) DeleteCollection(ctx context.Context, options metav1.DeleteOptions, listOptions metav1.ListOptions) error {
+	return nil
+}
+
+func (r *recordingResourceClient) Get(ctx context.Context, name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	if r.getNotFound {
+		return nil, apierrors.NewNotFound(schema.GroupResource{Group: "iam.grafana.app", Resource: "resourcepermissions"}, name)
+	}
+	return &unstructured.Unstructured{}, nil
+}
+
+func (r *recordingResourceClient) List(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	return &unstructured.UnstructuredList{}, nil
+}
+
+func (r *recordingResourceClient) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+	return watch.NewFake(), nil
+}
+
+func (r *recordingResourceClient) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, options metav1.PatchOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	return nil, nil
+}
+
+func (r *recordingResourceClient) Apply(ctx context.Context, name string, obj *unstructured.Unstructured, options metav1.ApplyOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	return nil, nil
+}
+
+func (r *recordingResourceClient) ApplyStatus(ctx context.Context, name string, obj *unstructured.Unstructured, options metav1.ApplyOptions) (*unstructured.Unstructured, error) {
+	return nil, nil
+}
+
+// Ensure SignedInUser satisfies AuthInfo for buildDefaultDashboardPermissions.
+var _ authlib.AuthInfo = (*user.SignedInUser)(nil)

--- a/pkg/registry/apis/dashboard/register.go
+++ b/pkg/registry/apis/dashboard/register.go
@@ -109,6 +109,7 @@ type DashboardsAPIBuilder struct {
 	dashboardService        dashboards.DashboardService
 	features                featuremgmt.FeatureToggles
 	accessControl           accesscontrol.AccessControl
+	acService               accesscontrol.Service // optional; used to clear creator permission cache after App Platform ACL writes
 	accessClient            authlib.AccessClient
 	legacy                  legacy.DashboardAccessor
 	unified                 resource.ResourceClient
@@ -150,6 +151,7 @@ func RegisterAPIService(
 	dashboardPermissions dashboards.PermissionsRegistrationService,
 	dashboardPermissionsSvc accesscontrol.DashboardPermissionsService,
 	accessControl accesscontrol.AccessControl,
+	acService accesscontrol.Service,
 	accessClient authlib.AccessClient,
 	provisioning provisioning.ProvisioningService,
 	reg prometheus.Registerer,
@@ -192,6 +194,7 @@ func RegisterAPIService(
 		dashboardPermissions:     dashboardPermissions,
 		dashboardPermissionsSvc:  dashboardPermissionsSvc,
 		accessControl:            accessControl,
+		acService:                acService,
 		accessClient:             accessClient,
 		unified:                  unified,
 		search:                   NewSearchHandler(tracing, unified, features),
@@ -244,11 +247,12 @@ func RegisterAPIService(
 	return builder
 }
 
-func NewAPIService(ac authlib.AccessClient, features featuremgmt.FeatureToggles, folderClientProvider client.K8sHandlerProvider, datasourceProvider schemaversion.DataSourceIndexProvider, libraryElementProvider schemaversion.LibraryElementIndexProvider, resourcePermissionsSvc *dynamic.NamespaceableResourceInterface, search *SearchHandler, unified resource.ResourceClient) *DashboardsAPIBuilder {
+func NewAPIService(ac authlib.AccessClient, features featuremgmt.FeatureToggles, folderClientProvider client.K8sHandlerProvider, datasourceProvider schemaversion.DataSourceIndexProvider, libraryElementProvider schemaversion.LibraryElementIndexProvider, resourcePermissionsSvc *dynamic.NamespaceableResourceInterface, search *SearchHandler, unified resource.ResourceClient, acService accesscontrol.Service) *DashboardsAPIBuilder {
 	migration.Initialize(datasourceProvider, libraryElementProvider, migration.DefaultCacheTTL)
 	return &DashboardsAPIBuilder{
 		minRefreshInterval:     "10s",
 		accessClient:           ac,
+		acService:              acService,
 		features:               features,
 		dashboardService:       &dashsvc.DashboardServiceImpl{}, // for validation helpers only
 		folderClientProvider:   folderClientProvider,
@@ -1210,12 +1214,18 @@ func (b *DashboardsAPIBuilder) setDefaultDashboardPermissions(ctx context.Contex
 		return nil
 	}
 
-	if obj.GetFolder() != "" {
+	// only set default permissions for root dashboards ("" or "general")
+	if !folder.IsRootFolderUID(obj.GetFolder()) {
 		return nil
 	}
 
 	log := logging.FromContext(ctx)
 	log.Debug("setting default dashboard permissions", "uid", obj.GetName(), "namespace", obj.GetNamespace())
+
+	// Capture the creator before switching to a service identity so we can clear
+	// their permission cache after the ACL write (they need the new grants on the
+	// next DTO/search call).
+	originalCtx := ctx
 
 	// Setting the default permissions is a system operation triggered by the creation
 	// of the dashboard, not an action the requester performs directly. The creator does
@@ -1256,6 +1266,7 @@ func (b *DashboardsAPIBuilder) setDefaultDashboardPermissions(ctx context.Contex
 			return fmt.Errorf("update dashboard permissions: %w", err)
 		}
 
+		b.clearCreatorPermissionCache(originalCtx)
 		return nil
 	}
 
@@ -1280,7 +1291,23 @@ func (b *DashboardsAPIBuilder) setDefaultDashboardPermissions(ctx context.Contex
 		return fmt.Errorf("create dashboard permissions: %w", err)
 	}
 
+	b.clearCreatorPermissionCache(originalCtx)
 	return nil
+}
+
+// clearCreatorPermissionCache mirrors SetDefaultPermissionsAfterCreate: after seeding
+// ACLs the creator must see the new grants on their next call (DTO load / search).
+func (b *DashboardsAPIBuilder) clearCreatorPermissionCache(ctx context.Context) {
+	if b.acService == nil {
+		return
+	}
+	user, err := identity.GetRequester(ctx)
+	if err != nil {
+		return
+	}
+	if user.IsIdentityType(authlib.TypeUser, authlib.TypeServiceAccount) {
+		b.acService.ClearUserPermissionCache(user)
+	}
 }
 
 func (b *DashboardsAPIBuilder) GetOpenAPIDefinitions() common.GetOpenAPIDefinitions {

--- a/pkg/registry/apis/dashboard/sub_dto.go
+++ b/pkg/registry/apis/dashboard/sub_dto.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/rest"
@@ -200,7 +201,9 @@ func (r *DTOConnector) Connect(ctx context.Context, name string, opts runtime.Ob
 		}
 
 		if !checkRes.Results["dash_read"].Allowed {
-			responder.Error(fmt.Errorf("not allowed to view"))
+			responder.Error(apierrors.NewForbidden(
+				dashv1.DashboardResourceInfo.GroupResource(), name,
+				fmt.Errorf("not allowed to view")))
 			return
 		}
 

--- a/pkg/registry/apis/dashboard/sub_dto_test.go
+++ b/pkg/registry/apis/dashboard/sub_dto_test.go
@@ -1,0 +1,85 @@
+package dashboard
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/endpoints/request"
+
+	authlib "github.com/grafana/authlib/types"
+	"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard"
+	dashv1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/services/user"
+)
+
+type denyReadAccessClient struct{}
+
+func (denyReadAccessClient) Check(context.Context, authlib.AuthInfo, authlib.CheckRequest, string) (authlib.CheckResponse, error) {
+	return authlib.CheckResponse{Allowed: false}, nil
+}
+
+func (denyReadAccessClient) Compile(context.Context, authlib.AuthInfo, authlib.ListRequest) (authlib.ItemChecker, authlib.Zookie, error) {
+	return func(name, folder string) bool { return false }, authlib.NoopZookie{}, nil
+}
+
+func (denyReadAccessClient) BatchCheck(_ context.Context, _ authlib.AuthInfo, req authlib.BatchCheckRequest) (authlib.BatchCheckResponse, error) {
+	results := make(map[string]authlib.BatchCheckResult, len(req.Checks))
+	for _, c := range req.Checks {
+		results[c.CorrelationID] = authlib.BatchCheckResult{Allowed: false}
+	}
+	return authlib.BatchCheckResponse{Results: results}, nil
+}
+
+type fakeGetter struct {
+	obj runtime.Object
+}
+
+func (f *fakeGetter) Get(_ context.Context, _ string, _ *metav1.GetOptions) (runtime.Object, error) {
+	return f.obj, nil
+}
+
+type capturingResponder struct {
+	err error
+}
+
+func (c *capturingResponder) Object(int, runtime.Object) {}
+func (c *capturingResponder) Error(err error)            { c.err = err }
+
+func TestDTOConnector_DeniedReadReturnsForbidden(t *testing.T) {
+	dash := &dashv1.Dashboard{
+		ObjectMeta: metav1.ObjectMeta{Name: "dash-1", Namespace: "default"},
+	}
+	connector, err := NewDTOConnector(
+		&fakeGetter{obj: dash},
+		nil,
+		denyReadAccessClient{},
+		func(obj runtime.Object, access *dashboard.DashboardAccess) (runtime.Object, error) {
+			return obj, nil
+		},
+		nil,
+	)
+	require.NoError(t, err)
+
+	u := &user.SignedInUser{UserID: 1, OrgID: 1, Login: "creator", Namespace: "default"}
+	ctx := identity.WithRequester(context.Background(), u)
+	ctx = authlib.WithAuthInfo(ctx, u)
+	ctx = request.WithNamespace(ctx, "default")
+
+	responder := &capturingResponder{}
+	handler, err := connector.(*DTOConnector).Connect(ctx, "dash-1", nil, responder)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/dto", nil)
+	req = req.WithContext(ctx)
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	require.Error(t, responder.err)
+	require.True(t, apierrors.IsForbidden(responder.err), "expected Forbidden, got %v", responder.err)
+}

--- a/pkg/server/wire_gen.go
+++ b/pkg/server/wire_gen.go
@@ -948,7 +948,7 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts Options, apiOpts api
 	ldapImpl := service11.ProvideService(cfg, featureToggles, ssosettingsimplService)
 	apiService := api3.ProvideService(cfg, routeRegisterImpl, accessControl, userimplService, authinfoimplService, ossGroups, identitySynchronizer, orgService, ldapImpl, userAuthTokenService, bundleregistryService)
 	dashboardActivityChannel := live.ProvideDashboardActivityChannel(grafanaLive)
-	dashboardsAPIBuilder := dashboard.RegisterAPIService(featureToggles, apiserverService, dashboardService, service13, dashboardServiceImpl, dashboardPermissionsService, accessControl, accessClient, provisioningServiceImpl, registerer, sqlStore, tracingService, resourceClient, dualwriteService, quotaService, eventualRestConfigProvider, userimplService, libraryElementService, v4, serviceImpl, dashboardActivityChannel, configProvider)
+	dashboardsAPIBuilder := dashboard.RegisterAPIService(featureToggles, apiserverService, dashboardService, service13, dashboardServiceImpl, dashboardPermissionsService, accessControl, acimplService, accessClient, provisioningServiceImpl, registerer, sqlStore, tracingService, resourceClient, dualwriteService, quotaService, eventualRestConfigProvider, userimplService, libraryElementService, v4, serviceImpl, dashboardActivityChannel, configProvider)
 	scopedPluginDatasourceProvider := datasource.ProvideDefaultPluginConfigs(service13, cacheServiceImpl, plugincontextProvider, cfg)
 	v10 := _wireValue
 	decryptAuthorizer := decrypt.ProvideDecryptAuthorizer(tracer, v10)
@@ -1699,7 +1699,7 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 	ldapImpl := service11.ProvideService(cfg, featureToggles, ssosettingsimplService)
 	apiService := api3.ProvideService(cfg, routeRegisterImpl, accessControl, userimplService, authinfoimplService, ossGroups, identitySynchronizer, orgService, ldapImpl, userAuthTokenService, bundleregistryService)
 	dashboardActivityChannel := live.ProvideDashboardActivityChannel(grafanaLive)
-	dashboardsAPIBuilder := dashboard.RegisterAPIService(featureToggles, apiserverService, dashboardService, service13, dashboardServiceImpl, dashboardPermissionsService, accessControl, accessClient, provisioningServiceImpl, registerer, sqlStore, tracingService, resourceClient, dualwriteService, quotaService, eventualRestConfigProvider, userimplService, libraryElementService, v4, serviceImpl, dashboardActivityChannel, configProvider)
+	dashboardsAPIBuilder := dashboard.RegisterAPIService(featureToggles, apiserverService, dashboardService, service13, dashboardServiceImpl, dashboardPermissionsService, accessControl, acimplService, accessClient, provisioningServiceImpl, registerer, sqlStore, tracingService, resourceClient, dualwriteService, quotaService, eventualRestConfigProvider, userimplService, libraryElementService, v4, serviceImpl, dashboardActivityChannel, configProvider)
 	scopedPluginDatasourceProvider := datasource.ProvideDefaultPluginConfigs(service13, cacheServiceImpl, plugincontextProvider, cfg)
 	v10 := _wireValue
 	decryptAuthorizer := decrypt.ProvideDecryptAuthorizer(tracer, v10)


### PR DESCRIPTION
## What is this feature?

Fixes the success + Internal Server Error when a user with only `fixed:dashboards:creator` saves their first root dashboard.

- Root ACL seeding now uses `folder.IsRootFolderUID` so both `""` and `"general"` get default permissions (creator admin + Viewer/Editor).
- After App Platform ResourcePermission writes, clear the creator’s permission cache (same as legacy `SetDefaultPermissionsAfterCreate`).
- Dashboard DTO returns **403 Forbidden** when read is denied, not 500.

## Why do we need this feature?

Fixes #129211. Creator-only users can create under the root folder but have no `dashboards:read` until default ACLs are applied. Save returned 200 (success toast), then the redirect DTO load denied access and showed Internal Server Error. Search hid the dashboard; Recently Viewed still showed it (client-side).

## Which issue(s) does this PR fix?

Fixes #129211

## Special notes for your reviewer

- Affects the App Platform permission path (`isStandalone` or `kubernetesAuthzResourcePermissionApis`).
- `accesscontrol.Service` is injected into `DashboardsAPIBuilder` for cache clear; Wire regenerated.
- `NewAPIService` takes optional `acService` (nil-safe) for standalone/Cloud.

## Test plan

- [x] `go test ./pkg/registry/apis/dashboard/ -run 'TestClrCreatorPermissionCache|TestSetDefaultDashboardPermissions_RootCheck|TestDTOConnector_DeniedReadReturnsForbidden'`
- [ ] Manual: Viewer + `fixed:dashboards:creator` creates a root dashboard with a panel → save succeeds, DTO loads, dashboard appears in search (no Internal Server Error).