### PR TITLE
Histogram: Skip heatmap cells without native histogram fields

### DIFF
--- a/packages/grafana-data/src/transformations/transformers/histogram.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/histogram.test.ts
@@ -350,6 +350,35 @@ describe('histogram frames frames', () => {
 });
 
 describe('getHistogramFields', () => {
+  it.each([
+    {
+      name: 'without yMax',
+      fields: [
+        { name: 'xMin', type: FieldType.number, values: [1, 2] },
+        { name: 'yMin', type: FieldType.number, values: [10, 20] },
+        { name: 'count', type: FieldType.number, values: [3, 4] },
+      ],
+    },
+    {
+      name: 'without a count field',
+      fields: [
+        { name: 'xMin', type: FieldType.number, values: [1, 2] },
+        { name: 'yMin', type: FieldType.number, values: [10, 20] },
+        { name: 'yMax', type: FieldType.number, values: [20, 30] },
+        { name: 'data', type: FieldType.number, values: [3, 4] },
+      ],
+    },
+  ])('ignores heatmap-cells frames $name', ({ fields }) => {
+    expect(
+      getHistogramFields(
+        toDataFrame({
+          meta: { type: DataFrameType.HeatmapCells },
+          fields,
+        })
+      )
+    ).toBeUndefined();
+  });
+
   it('densifies sparse native histograms (heatmap-cells), integer bounds', () => {
     expect(
       getHistogramFields(

--- a/packages/grafana-data/src/transformations/transformers/histogram.ts
+++ b/packages/grafana-data/src/transformations/transformers/histogram.ts
@@ -190,10 +190,13 @@ export function getHistogramFields(frame: DataFrame): HistogramFields | undefine
   // we ignore xMax (time field) and sum all counts together for each found bucket
   if (frame.meta?.type === DataFrameType.HeatmapCells) {
     // we assume uniform bucket size for now
-    // we assume xMax, yMin, yMax fields
-    let yMinField = frame.fields.find((f) => f.name === 'yMin')!;
-    let yMaxField = frame.fields.find((f) => f.name === 'yMax')!;
-    let countField = frame.fields.find((f) => f.name === 'count')!;
+    const yMinField = frame.fields.find((f) => f.name === 'yMin');
+    const yMaxField = frame.fields.find((f) => f.name === 'yMax');
+    const countField = frame.fields.find((f) => f.name === 'count');
+
+    if (!yMinField || !yMaxField || !countField) {
+      return undefined;
+    }
 
     let uniqueMaxs = [...new Set(yMaxField.values)].sort((a, b) => a - b);
     let uniqueMins = [...new Set(yMinField.values)].sort((a, b) => a - b);


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This prevents the Histogram panel and its visualization suggestion preview from crashing when they receive valid `heatmap-cells` frames that don't contain the fields required by the native histogram conversion.

`getHistogramFields` now checks for `yMin`, `yMax`, and `count` before accessing their values. If the frame doesn't have the native histogram field structure, it returns `undefined` and allows the existing Histogram fallback path to handle the available numeric fields.

Regression tests cover frames without `yMax` and frames whose value field is not named `count`.

**Why do we need this feature?**

The `heatmap-cells` format doesn't require `yMax`, and its value field can have any name. The Histogram conversion previously used non-null assertions for `yMin`, `yMax`, and `count`, then immediately accessed their values.

This caused valid Heatmap data to crash the Histogram panel or its suggestion preview with:

`TypeError: Cannot read properties of undefined (reading 'values')`

**Who is this feature for?**

Users working with heatmap data who open visualization suggestions or switch their visualization to Histogram.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #126200 

**Special notes for your reviewer:**

The change only guards the specialized native histogram conversion. Frames containing the complete `yMin`, `yMax`, and `count` structure continue through the existing conversion and densification behavior unchanged.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
