### PR TITLE
provisioning: guard ReadClassicResource against empty/BOM-only input

### DIFF
--- a/pkg/registry/apis/provisioning/resources/fileformat.go
+++ b/pkg/registry/apis/provisioning/resources/fileformat.go
@@ -38,6 +38,13 @@ func ReadClassicResource(ctx context.Context, info *repository.FileInfo) (*unstr
 	// Strip BOMs from file data before parsing
 	cleanData := util.StripBOMFromBytes(info.Data)
 
+	// An empty file, or a file containing only a BOM, leaves cleanData empty.
+	// Indexing it below would panic and crash the process; treat it as an
+	// unreadable resource instead.
+	if len(cleanData) == 0 {
+		return nil, nil, "", ErrUnableToReadResourceBytes
+	}
+
 	// Try parsing as JSON
 	if cleanData[0] == '{' {
 		err := json.Unmarshal(cleanData, &value)

--- a/pkg/registry/apis/provisioning/resources/fileformat_test.go
+++ b/pkg/registry/apis/provisioning/resources/fileformat_test.go
@@ -290,6 +290,22 @@ func TestReadClassicResource_TypeAssertions(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "not a string")
 	})
+
+	t.Run("empty file does not panic", func(t *testing.T) {
+		_, _, _, err := ReadClassicResource(context.Background(), &repository.FileInfo{
+			Data: []byte{},
+		})
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrUnableToReadResourceBytes)
+	})
+
+	t.Run("BOM-only file does not panic", func(t *testing.T) {
+		_, _, _, err := ReadClassicResource(context.Background(), &repository.FileInfo{
+			Data: []byte{0xEF, 0xBB, 0xBF},
+		})
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrUnableToReadResourceBytes)
+	})
 }
 
 func TestParseFileResource(t *testing.T) {


### PR DESCRIPTION
Fixes #129162.

ReadClassicResource indexes cleanData[0] immediately after StripBOMFromBytes, so an empty file or a file containing only a UTF-8 BOM panics with "index out of range [0] with length 0" during a provisioning sync and crashes the server. This adds a length check returning the existing ErrUnableToReadResourceBytes, turning the panic into a normal validation error consistent with how the rest of ParseFileResource reports unreadable content.

Added regression tests for both the empty-file and BOM-only cases in TestReadClassicResource_TypeAssertions.