### PR TITLE
provisioning: count dashboard tag limit in characters, not UTF-8 bytes

### DIFF
--- a/pkg/registry/apis/dashboard/register.go
+++ b/pkg/registry/apis/dashboard/register.go
@@ -7,6 +7,7 @@ import (
 	"maps"
 	"strconv"
 	"sync"
+	"unicode/utf8"
 
 	"github.com/prometheus/client_golang/prometheus"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -774,6 +775,11 @@ func validateNotV2Object(obj runtime.Object) error {
 }
 
 // validateDashboardTags validates that all dashboard tags are within the maximum length
+// of 50 characters. The count is based on Unicode code points (runes), matching the
+// dashboard_tag.term column schema (VARCHAR(50) with a utf8mb4 charset) and the
+// "max 50 characters" message returned to users. Counting bytes with len(tag) would
+// reject a 50-character tag containing any multi-byte rune (e.g. Cyrillic or CJK) that
+// the database would otherwise accept.
 func validateDashboardTags(obj runtime.Object) error {
 	var tags []string
 
@@ -793,7 +799,7 @@ func validateDashboardTags(obj runtime.Object) error {
 	}
 
 	for _, tag := range tags {
-		if len(tag) > 50 {
+		if utf8.RuneCountInString(tag) > 50 {
 			return dashboards.ErrDashboardTagTooLong
 		}
 	}

--- a/pkg/registry/apis/dashboard/register_test.go
+++ b/pkg/registry/apis/dashboard/register_test.go
@@ -3,6 +3,7 @@ package dashboard
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -14,6 +15,7 @@ import (
 	"k8s.io/apiserver/pkg/admission"
 
 	dashv1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1"
+	dashv2beta1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2beta1"
 	common "github.com/grafana/grafana/pkg/apimachinery/apis/common/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/services/user"
@@ -222,4 +224,62 @@ func (m *mockK8sHandler) GetStats(_ context.Context, _ int64) (*resourcepb.Resou
 }
 func (m *mockK8sHandler) GetUsersFromMeta(_ context.Context, _ []string) (map[string]*user.User, error) {
 	return nil, nil
+}
+
+func TestValidateDashboardTags(t *testing.T) {
+	// A tag whose length in characters is 50 but whose UTF-8 byte length is 51,
+	// because it contains one 2-byte rune (Cyrillic "й"). This tag was rejected by
+	// the previous len(tag) > 50 check even though the error message and the
+	// dashboard_tag.term column (VARCHAR(50), utf8mb4) both count characters.
+	multibyteAtLimit := strings.Repeat("a", 49) + "й"
+	require.Len(t, []rune(multibyteAtLimit), 50)
+	require.Greater(t, len(multibyteAtLimit), 50)
+
+	tests := []struct {
+		name    string
+		tags    []string
+		wantErr bool
+	}{
+		{
+			name:    "accept a tag shorter than 50 characters",
+			tags:    []string{"short-tag"},
+			wantErr: false,
+		},
+		{
+			name:    "accept a tag of exactly 50 ASCII characters",
+			tags:    []string{strings.Repeat("a", 50)},
+			wantErr: false,
+		},
+		{
+			name:    "accept a tag of exactly 50 characters with a multi-byte rune",
+			tags:    []string{multibyteAtLimit},
+			wantErr: false,
+		},
+		{
+			name:    "reject a tag longer than 50 characters",
+			tags:    []string{strings.Repeat("a", 51)},
+			wantErr: true,
+		},
+		{
+			name:    "reject a multi-byte tag longer than 50 characters",
+			tags:    []string{strings.Repeat("a", 49) + "йй"},
+			wantErr: true,
+		},
+		{
+			name:    "reject when any tag among several exceeds the limit",
+			tags:    []string{"ok", strings.Repeat("a", 51)},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateDashboardTags(&dashv2beta1.Dashboard{Spec: dashv2beta1.DashboardSpec{Tags: tt.tags}})
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
 }


### PR DESCRIPTION
validateDashboardTags checked len(tag) > 50, which counts UTF-8 bytes. That rejects a tag of exactly 50 characters whenever it contains a multi-byte rune (e.g. Cyrillic, CJK), even though the error message returned to the user says "max 50 characters" and the dashboard_tag.term column is declared VARCHAR(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci — i.e. the database already stores up to 50 characters.

So the Go validation was stricter than both the message it raised and the column it writes to, rejecting tags the DB would have kept. Reported in #129193.

This switches the check to utf8.RuneCountInString(tag), so a character is counted as a character regardless of how many bytes it takes. The reject path and the "max 50 characters" message are unchanged, so there is no behaviour change for ASCII tags, and the new behaviour only matches what the schema already allowed. I added a table-driven unit test (TestValidateDashboardTags) that fails on the old code for a 50-character tag with a Cyrillic rune and passes with this change, plus cases for under-limit, over-limit ASCII, over-limit multi-byte, and a mixed tag list.