### PR TITLE
provisioning: return validation error for empty or BOM-only files instead of panicking

### DIFF
--- a/pkg/registry/apis/provisioning/resources/fileformat.go
+++ b/pkg/registry/apis/provisioning/resources/fileformat.go
@@ -38,6 +38,10 @@ func ReadClassicResource(ctx context.Context, info *repository.FileInfo) (*unstr
 	// Strip BOMs from file data before parsing
 	cleanData := util.StripBOMFromBytes(info.Data)
 
+	if len(cleanData) == 0 {
+		return nil, nil, "", ErrUnableToReadResourceBytes
+	}
+
 	// Try parsing as JSON
 	if cleanData[0] == '{' {
 		err := json.Unmarshal(cleanData, &value)

--- a/pkg/registry/apis/provisioning/resources/fileformat_test.go
+++ b/pkg/registry/apis/provisioning/resources/fileformat_test.go
@@ -292,6 +292,24 @@ func TestReadClassicResource_TypeAssertions(t *testing.T) {
 	})
 }
 
+func TestReadClassicResource_EmptyInput(t *testing.T) {
+	t.Run("empty file returns a validation error, not a panic", func(t *testing.T) {
+		_, _, _, err := ReadClassicResource(context.Background(), &repository.FileInfo{
+			Data: []byte{},
+		})
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrUnableToReadResourceBytes)
+	})
+
+	t.Run("BOM-only file returns a validation error, not a panic", func(t *testing.T) {
+		_, _, _, err := ReadClassicResource(context.Background(), &repository.FileInfo{
+			Data: []byte{0xEF, 0xBB, 0xBF},
+		})
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrUnableToReadResourceBytes)
+	})
+}
+
 func TestParseFileResource(t *testing.T) {
 	t.Run("k8s resource parsed directly", func(t *testing.T) {
 		info := &repository.FileInfo{


### PR DESCRIPTION
Fixes #129162

ReadClassicResource unconditionally indexed cleanData[0] after StripBOMFromBytes, panicking with "index out of range [0] with length 0" when the sync job encountered a zero-byte file or a BOM-only file.

Add a length check that returns ErrUnableToReadResourceBytes for empty input. Add regression tests covering empty and BOM-only inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)