### PR TITLE
NodeGraph: Add fit-to-view option

### DIFF
--- a/docs/sources/visualizations/panels-visualizations/visualizations/node-graph/index.md
+++ b/docs/sources/visualizations/panels-visualizations/visualizations/node-graph/index.md
@@ -168,6 +168,10 @@ Choose how the node graph should handle zoom and scroll events:
 - **Cooperative** - Allows you to scroll the visualization normally.
 - **Greedy** - Reacts to all zoom gestures.
 
+#### Fit graph to view
+
+Turn on **Fit graph to view** to automatically fit and center the graph when its layout or panel size changes. You can pan and zoom manually until the graph or panel changes again.
+
 #### Layout algorithm
 
 Choose how the visualization layout is generated:

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -3047,11 +3047,6 @@
       "count": 1
     }
   },
-  "public/app/plugins/panel/nodeGraph/NodeGraph.tsx": {
-    "@typescript-eslint/consistent-type-assertions": {
-      "count": 4
-    }
-  },
   "public/app/plugins/panel/nodeGraph/ViewControls.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1

--- a/packages/grafana-schema/src/raw/composable/nodegraph/panelcfg/x/types.gen.ts
+++ b/packages/grafana-schema/src/raw/composable/nodegraph/panelcfg/x/types.gen.ts
@@ -46,6 +46,10 @@ export interface Options {
     secondaryStatUnit?: string;
   };
   /**
+   * Automatically fit and center the graph when its layout or panel size changes
+   */
+  fitToView?: boolean;
+  /**
    * How to layout the nodes in the node graph
    */
   layoutAlgorithm?: LayoutAlgorithm;

--- a/public/app/plugins/panel/nodeGraph/NodeGraph.test.tsx
+++ b/public/app/plugins/panel/nodeGraph/NodeGraph.test.tsx
@@ -148,6 +148,28 @@ describe('NodeGraph', () => {
     await waitFor(() => expect(getScale()).toBe(maxZoom));
   });
 
+  it('zooms immediately after fit-to-view is disabled', async () => {
+    mockDimensions = { width: 100, height: 200 };
+    const nodes = makeFixedNodesDataFrame(
+      [
+        { x: -1000, y: 0 },
+        { x: 1000, y: 0 },
+      ],
+      [40, 40]
+    );
+    const props = { dataFrames: [nodes], getLinks: () => [] };
+    const { rerender } = render(<NodeGraph {...props} fitToView={true} />);
+
+    await screen.findByLabelText('Node: service:0');
+    await waitFor(() => expect(getScale()).toBeLessThan(minZoom));
+
+    rerender(<NodeGraph {...props} fitToView={false} />);
+    await waitFor(() => expect(getScale()).toBe(minZoom));
+
+    await userEvent.click(screen.getByLabelText(/Zoom in/));
+    expect(getScale()).toBeCloseTo(minZoom * 1.5);
+  });
+
   it('can zoom while pressing ctrl/command key with cooperative zoom mode', async () => {
     render(
       <NodeGraph

--- a/public/app/plugins/panel/nodeGraph/NodeGraph.test.tsx
+++ b/public/app/plugins/panel/nodeGraph/NodeGraph.test.tsx
@@ -59,6 +59,29 @@ describe('NodeGraph', () => {
     expect(getScale()).toBe(1);
   });
 
+  it('restores the previous zoom after stepping past the limit', async () => {
+    render(
+      <NodeGraph
+        dataFrames={[makeNodesDataFrame(2), makeEdgesDataFrame([{ source: '0', target: '1' }])]}
+        getLinks={() => []}
+        layoutAlgorithm={LayoutAlgorithm.Force}
+      />
+    );
+
+    await screen.findByLabelText('Node: service:1');
+
+    for (let i = 0; i < 10; i++) {
+      scrollView({ deltaY: -4, ctrlKey: true });
+    }
+    expect(getScale()).toBeCloseTo(1.6);
+
+    await userEvent.click(screen.getByLabelText(/Zoom in/));
+    expect(getScale()).toBe(maxZoom);
+
+    await userEvent.click(screen.getByLabelText(/Zoom out/));
+    expect(getScale()).toBeCloseTo(1.6);
+  });
+
   it('fits the graph again when the panel size changes', async () => {
     const dataFrames = [
       makeNodesDataFrame(3),
@@ -97,6 +120,45 @@ describe('NodeGraph', () => {
       expect(getScale()).toBeLessThan(minZoom);
       expect(Math.abs(position.x)).toBeLessThanOrEqual(1);
       expect(Math.abs(position.y)).toBeLessThanOrEqual(1);
+    });
+  });
+
+  it('preserves the manual view until refreshed data changes the bounds', async () => {
+    const makeDataFrames = (verticalOffset = 0) => [
+      makeFixedNodesDataFrame(
+        [
+          { x: -500, y: -verticalOffset },
+          { x: 500, y: verticalOffset },
+        ],
+        [40, 40]
+      ),
+    ];
+    const props = { fitToView: true, getLinks: () => [] };
+    const { rerender } = render(<NodeGraph {...props} dataFrames={makeDataFrames()} />);
+
+    await screen.findByLabelText('Node: service:0');
+    await waitFor(() => expect(getScale()).toBeLessThan(1));
+    const fittedScale = getScale();
+
+    await userEvent.click(screen.getByLabelText(/Zoom in/));
+    panView({ x: 20, y: 0 });
+    await waitFor(() => expect(getTranslate().x).toBeGreaterThan(0));
+
+    const manualScale = getScale();
+    const manualPosition = getTranslate();
+
+    rerender(<NodeGraph {...props} dataFrames={makeDataFrames()} />);
+
+    await waitFor(() => {
+      expect(getScale()).toBeCloseTo(manualScale);
+      expect(getTranslate()).toEqual(manualPosition);
+    });
+
+    rerender(<NodeGraph {...props} dataFrames={makeDataFrames(100)} />);
+
+    await waitFor(() => {
+      expect(getScale()).toBeCloseTo(fittedScale);
+      expect(getTranslate()).toEqual({ x: 0, y: 0 });
     });
   });
 

--- a/public/app/plugins/panel/nodeGraph/NodeGraph.test.tsx
+++ b/public/app/plugins/panel/nodeGraph/NodeGraph.test.tsx
@@ -1,9 +1,14 @@
 import { render, screen, fireEvent, waitFor, getByText } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
+import { FieldType, NodeGraphDataFrameFieldNames } from '@grafana/data';
+
 import { NodeGraph } from './NodeGraph';
 import { LayoutAlgorithm, ZoomMode } from './panelcfg.gen';
+import { maxZoom, minZoom } from './useZoom';
 import { makeEdgesDataFrame, makeNodesDataFrame } from './utils';
+
+let mockDimensions = { width: 500, height: 200 };
 
 jest.mock('./layout', () => {
   const actual = jest.requireActual('./layout');
@@ -20,12 +25,16 @@ jest.mock('react-use/lib/useMeasure', () => {
   return {
     __esModule: true,
     default: () => {
-      return [() => {}, { width: 500, height: 200 }];
+      return [() => {}, mockDimensions];
     },
   };
 });
 
 describe('NodeGraph', () => {
+  beforeEach(() => {
+    mockDimensions = { width: 500, height: 200 };
+  });
+
   it('shows no data message without any data', async () => {
     render(<NodeGraph dataFrames={[]} getLinks={() => []} />);
 
@@ -48,6 +57,95 @@ describe('NodeGraph', () => {
     expect(getScale()).toBe(1.5);
     await userEvent.click(zoomOut);
     expect(getScale()).toBe(1);
+  });
+
+  it('fits the graph again when the panel size changes', async () => {
+    const dataFrames = [
+      makeNodesDataFrame(3),
+      makeEdgesDataFrame([
+        { source: '0', target: '1' },
+        { source: '1', target: '2' },
+      ]),
+    ];
+    const props = {
+      dataFrames,
+      fitToView: true,
+      getLinks: () => [],
+      layoutAlgorithm: LayoutAlgorithm.Force,
+    };
+    const { rerender } = render(<NodeGraph {...props} />);
+
+    await screen.findByLabelText('Node: service:1');
+    await waitFor(() => expect(getScale()).toBeLessThan(1));
+    const fittedScale = getScale();
+
+    const zoomIn = screen.getByLabelText(/Zoom in/);
+    await userEvent.click(zoomIn);
+    expect(getScale()).toBeCloseTo(fittedScale * 1.5);
+
+    panView({ x: 10, y: 0 });
+    await waitFor(() => {
+      expect(getScale()).toBeCloseTo(fittedScale * 1.5);
+      expect(getTranslate().x).toBeGreaterThan(0);
+    });
+
+    mockDimensions = { width: 100, height: 200 };
+    rerender(<NodeGraph {...props} />);
+
+    await waitFor(() => {
+      const position = getTranslate();
+      expect(getScale()).toBeLessThan(minZoom);
+      expect(Math.abs(position.x)).toBeLessThanOrEqual(1);
+      expect(Math.abs(position.y)).toBeLessThanOrEqual(1);
+    });
+  });
+
+  it('includes custom node radii when fitting the graph', async () => {
+    const radius = 200;
+    const nodes = makeNodesDataFrame(1, [{ [NodeGraphDataFrameFieldNames.nodeRadius]: radius }]);
+
+    render(<NodeGraph dataFrames={[nodes]} fitToView={true} getLinks={() => []} />);
+
+    const node = await screen.findByTestId('node-circle-0');
+    await waitFor(() => {
+      expect(parseFloat(node.getAttribute('r') ?? '0') * 2 * getScale()).toBeLessThanOrEqual(
+        mockDimensions.height - 40
+      );
+    });
+  });
+
+  it('centers a graph with fixed positions', async () => {
+    const nodes = makeFixedNodesDataFrame(
+      [
+        { x: 1000, y: -500 },
+        { x: 1200, y: -300 },
+      ],
+      [40, 40]
+    );
+
+    render(<NodeGraph dataFrames={[nodes]} fitToView={true} getLinks={() => []} />);
+
+    await screen.findByLabelText('Node: service:0');
+    await waitFor(() => {
+      const position = getTranslate();
+      expect(Math.abs(position.x + 1100)).toBeLessThanOrEqual(1);
+      expect(Math.abs(position.y - 400)).toBeLessThanOrEqual(1);
+    });
+  });
+
+  it('waits for panel dimensions before fitting and caps the zoom level', async () => {
+    mockDimensions = { width: 0, height: 0 };
+    const nodes = makeFixedNodesDataFrame([{ x: 0, y: 0 }], [40]);
+    const props = { dataFrames: [nodes], fitToView: true, getLinks: () => [] };
+    const { rerender } = render(<NodeGraph {...props} />);
+
+    await screen.findByLabelText('Node: service:0');
+    expect(getScale()).toBe(1);
+
+    mockDimensions = { width: 1000, height: 1000 };
+    rerender(<NodeGraph {...props} />);
+
+    await waitFor(() => expect(getScale()).toBe(maxZoom));
   });
 
   it('can zoom while pressing ctrl/command key with cooperative zoom mode', async () => {
@@ -315,7 +413,7 @@ function getScale() {
 }
 
 function getTranslate() {
-  const matches = getTransform().match(/translate\((\d+)px, (\d+)px\)/);
+  const matches = getTransform().match(/translate\((-?\d+)px, (-?\d+)px\)/);
   return {
     x: parseFloat(matches![1]),
     y: parseFloat(matches![2]),
@@ -327,4 +425,26 @@ function getXY(e: Element) {
     x: parseFloat(e.attributes.getNamedItem('cx')?.value || ''),
     y: parseFloat(e.attributes.getNamedItem('cy')?.value || ''),
   };
+}
+
+function makeFixedNodesDataFrame(positions: Array<{ x: number; y: number }>, radii: number[]) {
+  const nodes = makeNodesDataFrame(
+    positions.length,
+    radii.map((radius) => ({ [NodeGraphDataFrameFieldNames.nodeRadius]: radius }))
+  );
+  nodes.fields.push(
+    {
+      name: NodeGraphDataFrameFieldNames.fixedX,
+      type: FieldType.number,
+      values: positions.map((position) => position.x),
+      config: {},
+    },
+    {
+      name: NodeGraphDataFrameFieldNames.fixedY,
+      type: FieldType.number,
+      values: positions.map((position) => position.y),
+      config: {},
+    }
+  );
+  return nodes;
 }

--- a/public/app/plugins/panel/nodeGraph/NodeGraph.tsx
+++ b/public/app/plugins/panel/nodeGraph/NodeGraph.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import cx from 'clsx';
-import { memo, type MouseEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { memo, type MouseEvent, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import useMeasure from 'react-use/lib/useMeasure';
 
 import { type DataFrame, type GrafanaTheme2, type LinkModel } from '@grafana/data';
@@ -512,12 +512,15 @@ function usePanAndZoom(
   viewport?: Viewport,
   contentPadding?: number
 ) {
-  const fit = useMemo(
-    () => (viewport && contentPadding ? getFitToView(bounds, viewport, contentPadding) : undefined),
-    [bounds, contentPadding, viewport]
-  );
+  const { bottom, left, right, top } = bounds;
+  const viewportHeight = viewport?.height;
+  const viewportWidth = viewport?.width;
+  const fit = viewport && contentPadding ? getFitToView(bounds, viewport, contentPadding) : undefined;
+  const fitScale = fit?.scale;
+  const fitPositionX = fit?.position.x;
+  const fitPositionY = fit?.position.y;
   const { scale, onStepDown, onStepUp, ref, isMax, isMin, setScale } = useZoom({
-    min: fit ? Math.min(fit.scale, minZoom) : minZoom,
+    min: fitScale !== undefined ? Math.min(fitScale, minZoom) : minZoom,
     zoomMode,
   });
   const {
@@ -530,12 +533,25 @@ function usePanAndZoom(
     focus,
   });
 
-  useEffect(() => {
-    if (fit) {
-      setScale(fit.scale);
-      setPosition(fit.position);
+  useLayoutEffect(() => {
+    if (fitScale !== undefined && fitPositionX !== undefined && fitPositionY !== undefined) {
+      setScale(fitScale);
+      setPosition({ x: fitPositionX, y: fitPositionY });
     }
-  }, [fit, setPosition, setScale]);
+  }, [
+    bottom,
+    contentPadding,
+    fitPositionX,
+    fitPositionY,
+    fitScale,
+    left,
+    right,
+    setPosition,
+    setScale,
+    top,
+    viewportHeight,
+    viewportWidth,
+  ]);
 
   const { position, isPanning } = panningState;
   return { zoomRef: ref, panRef, position, isPanning, scale, onStepDown, onStepUp, isMaxZoom: isMax, isMinZoom: isMin };

--- a/public/app/plugins/panel/nodeGraph/NodeGraph.tsx
+++ b/public/app/plugins/panel/nodeGraph/NodeGraph.tsx
@@ -11,7 +11,7 @@ import { Edge } from './Edge';
 import { EdgeLabel } from './EdgeLabel';
 import { Legend } from './Legend';
 import { Marker } from './Marker';
-import { Node } from './Node';
+import { Node, nodeR } from './Node';
 import { ViewControls } from './ViewControls';
 import { type Config, defaultConfig, useLayout, type LayoutCache } from './layout';
 import { LayoutAlgorithm, type ZoomMode } from './panelcfg.gen';
@@ -21,7 +21,7 @@ import { useContextMenu } from './useContextMenu';
 import { useFocusPositionOnLayout } from './useFocusPositionOnLayout';
 import { useHighlight } from './useHighlight';
 import { usePanning } from './usePanning';
-import { useZoom } from './useZoom';
+import { maxZoom, minZoom, useZoom } from './useZoom';
 import { processNodes, type Bounds, findConnectedNodesForEdge, findConnectedNodesForNode } from './utils';
 
 const getStyles = (theme: GrafanaTheme2) => ({
@@ -125,8 +125,9 @@ interface Props {
   panelId?: string;
   zoomMode?: ZoomMode;
   layoutAlgorithm?: LayoutAlgorithm;
+  fitToView?: boolean;
 }
-export function NodeGraph({ getLinks, dataFrames, nodeLimit, panelId, zoomMode, layoutAlgorithm }: Props) {
+export function NodeGraph({ getLinks, dataFrames, nodeLimit, panelId, zoomMode, layoutAlgorithm, fitToView }: Props) {
   const nodeCountLimit = nodeLimit || defaultNodeCountLimit;
   const { edges: edgesDataFrames, nodes: nodesDataFrames } = useCategorizeFrames(dataFrames);
 
@@ -201,10 +202,17 @@ export function NodeGraph({ getLinks, dataFrames, nodeLimit, panelId, zoomMode, 
   // If we move from grid to graph layout, and we have focused node lets get its position to center there. We want to
   // do it specifically only in that case.
   const focusPosition = useFocusPositionOnLayout(config, nodes, focusedNodeId);
+  const fitViewport = useMemo(
+    () => (fitToView && nodes.length > 0 && width > 0 && height > 0 ? { width, height } : undefined),
+    [fitToView, height, nodes.length, width]
+  );
+  const graphContentPadding = useMemo(() => getGraphContentPadding(nodes), [nodes]);
   const { panRef, zoomRef, onStepUp, onStepDown, isPanning, position, scale, isMaxZoom, isMinZoom } = usePanAndZoom(
     bounds,
     focusPosition,
-    zoomMode
+    zoomMode,
+    fitViewport,
+    graphContentPadding
   );
 
   const { onEdgeOpen, onNodeOpen, MenuComponent } = useContextMenu(
@@ -456,8 +464,8 @@ const Edges = memo(function Edges(props: EdgesProps) {
             key={`${e.id}-${e.source.y ?? ''}-${props.processedNodesLength}-${props.processedEdgesLength}-${index}`}
             edge={e}
             hovering={
-              (e.source as NodeDatum).id === props.nodeHoveringId ||
-              (e.target as NodeDatum).id === props.nodeHoveringId ||
+              e.source.id === props.nodeHoveringId ||
+              e.target.id === props.nodeHoveringId ||
               props.edgeHoveringId === e.id
             }
             onClick={props.onClick}
@@ -483,9 +491,7 @@ const EdgeLabels = memo(function EdgeLabels(props: EdgeLabelsProps) {
         // We show the edge label in case user hovers over the edge directly or if they hover over node edge is
         // connected to.
         const shouldShow =
-          (e.source as NodeDatum).id === props.nodeHoveringId ||
-          (e.target as NodeDatum).id === props.nodeHoveringId ||
-          props.edgeHoveringId === e.id;
+          e.source.id === props.nodeHoveringId || e.target.id === props.nodeHoveringId || props.edgeHoveringId === e.id;
 
         const hasStats = e.mainStat || e.secondaryStat;
         return shouldShow && hasStats && <EdgeLabel key={e.id} edge={e} />;
@@ -494,15 +500,72 @@ const EdgeLabels = memo(function EdgeLabels(props: EdgeLabelsProps) {
   );
 });
 
-function usePanAndZoom(bounds: Bounds, focus?: { x: number; y: number }, zoomMode?: ZoomMode) {
-  const { scale, onStepDown, onStepUp, ref, isMax, isMin } = useZoom({ zoomMode });
-  const { state: panningState, ref: panRef } = usePanning<SVGSVGElement>({
+interface Viewport {
+  width: number;
+  height: number;
+}
+
+function usePanAndZoom(
+  bounds: Bounds,
+  focus?: { x: number; y: number },
+  zoomMode?: ZoomMode,
+  viewport?: Viewport,
+  contentPadding?: number
+) {
+  const fit = useMemo(
+    () => (viewport && contentPadding ? getFitToView(bounds, viewport, contentPadding) : undefined),
+    [bounds, contentPadding, viewport]
+  );
+  const { scale, onStepDown, onStepUp, ref, isMax, isMin, setScale } = useZoom({
+    min: fit ? Math.min(fit.scale, minZoom) : minZoom,
+    zoomMode,
+  });
+  const {
+    state: panningState,
+    ref: panRef,
+    setPosition,
+  } = usePanning<SVGSVGElement>({
     scale,
     bounds,
     focus,
   });
+
+  useEffect(() => {
+    if (fit) {
+      setScale(fit.scale);
+      setPosition(fit.position);
+    }
+  }, [fit, setPosition, setScale]);
+
   const { position, isPanning } = panningState;
   return { zoomRef: ref, panRef, position, isPanning, scale, onStepDown, onStepUp, isMaxZoom: isMax, isMinZoom: isMin };
+}
+
+const fitToViewPadding = 20;
+const defaultGraphContentPadding = nodeR * 2;
+
+function getFitToView(bounds: Bounds, viewport: Viewport, contentPadding: number) {
+  const availableWidth = Math.max(viewport.width - fitToViewPadding * 2, 1);
+  const availableHeight = Math.max(viewport.height - fitToViewPadding * 2, 1);
+  const graphWidth = bounds.right - bounds.left + contentPadding * 2;
+  const graphHeight = bounds.bottom - bounds.top + contentPadding * 2;
+
+  return {
+    scale: Math.min(maxZoom, availableWidth / graphWidth, availableHeight / graphHeight),
+    position: {
+      x: -bounds.center.x,
+      y: -bounds.center.y,
+    },
+  };
+}
+
+function getGraphContentPadding(nodes: NodeDatum[]) {
+  return nodes.reduce((padding, node) => {
+    const radius = node.nodeRadius?.values[node.dataFrameRowIndex];
+    return typeof radius === 'number' && Number.isFinite(radius) && radius > 0
+      ? Math.max(padding, radius + nodeR)
+      : padding;
+  }, defaultGraphContentPadding);
 }
 
 function useHover() {

--- a/public/app/plugins/panel/nodeGraph/NodeGraphPanel.tsx
+++ b/public/app/plugins/panel/nodeGraph/NodeGraphPanel.tsx
@@ -33,6 +33,7 @@ export const NodeGraphPanel = ({ width, height, data, options }: PanelProps<Node
         panelId={panelId}
         zoomMode={options.zoomMode}
         layoutAlgorithm={options.layoutAlgorithm}
+        fitToView={options.fitToView}
       />
     </div>
   );

--- a/public/app/plugins/panel/nodeGraph/module.tsx
+++ b/public/app/plugins/panel/nodeGraph/module.tsx
@@ -57,6 +57,16 @@ export const plugin = new PanelPlugin<NodeGraphOptions>(NodeGraphPanel)
         ],
       },
     });
+    builder.addBooleanSwitch({
+      name: t('node-graph.name-fit-to-view', 'Fit graph to view'),
+      description: t(
+        'node-graph.description-fit-to-view',
+        'Automatically fit and center the graph when its layout or panel size changes'
+      ),
+      category,
+      path: 'fitToView',
+      defaultValue: false,
+    });
     builder.addNestedOptions({
       category: [t('node-graph.category-nodes', 'Nodes')],
       path: 'nodes',

--- a/public/app/plugins/panel/nodeGraph/panelcfg.cue
+++ b/public/app/plugins/panel/nodeGraph/panelcfg.cue
@@ -52,6 +52,8 @@ composableKinds: PanelCfg: {
 					zoomMode?: ZoomMode
 					// How to layout the nodes in the node graph
 					layoutAlgorithm?: LayoutAlgorithm
+					// Automatically fit and center the graph when its layout or panel size changes
+					fitToView?: bool
 				} @cuetsy(kind="interface")
 			}
 		}]

--- a/public/app/plugins/panel/nodeGraph/panelcfg.gen.ts
+++ b/public/app/plugins/panel/nodeGraph/panelcfg.gen.ts
@@ -44,6 +44,10 @@ export interface Options {
     secondaryStatUnit?: string;
   };
   /**
+   * Automatically fit and center the graph when its layout or panel size changes
+   */
+  fitToView?: boolean;
+  /**
    * How to layout the nodes in the node graph
    */
   layoutAlgorithm?: LayoutAlgorithm;

--- a/public/app/plugins/panel/nodeGraph/usePanning.ts
+++ b/public/app/plugins/panel/nodeGraph/usePanning.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, type RefObject, useState, useMemo } from 'react';
+import { useCallback, useEffect, useRef, type RefObject, useState, useMemo } from 'react';
 import useMountedState from 'react-use/lib/useMountedState';
 import usePrevious from 'react-use/lib/usePrevious';
 
@@ -32,6 +32,7 @@ interface Options {
 export function usePanning<T extends Element>({ scale = 1, bounds, focus }: Options = {}): {
   state: State;
   ref: RefObject<T>;
+  setPosition: (position: State['position']) => void;
 } {
   const isMounted = useMountedState();
   const isPanning = useRef(false);
@@ -62,6 +63,15 @@ export function usePanning<T extends Element>({ scale = 1, bounds, focus }: Opti
     isPanning: false,
     position: initial,
   });
+
+  const setPosition = useCallback((position: State['position']) => {
+    currentPosition.current = position;
+    prevPosition.current = position;
+    setState({
+      position,
+      isPanning: false,
+    });
+  }, []);
 
   useEffect(() => {
     const startPanning = (event: Event) => {
@@ -150,15 +160,9 @@ export function usePanning<T extends Element>({ scale = 1, bounds, focus }: Opti
         x: inBounds(focus.x, viewBounds.left, viewBounds.right),
         y: inBounds(focus.y, viewBounds.top, viewBounds.bottom),
       };
-      setState({
-        position,
-        isPanning: false,
-      });
-
-      currentPosition.current = position;
-      prevPosition.current = position;
+      setPosition(position);
     }
-  }, [focus, previousFocus, viewBounds, currentPosition, prevPosition]);
+  }, [focus, previousFocus, setPosition, viewBounds]);
 
   let position = state.position;
   // This part prevents an ugly jump from initial position to the focused one as the set state in the effects is after
@@ -176,6 +180,7 @@ export function usePanning<T extends Element>({ scale = 1, bounds, focus }: Opti
       },
     },
     ref: panRef,
+    setPosition,
   };
 }
 

--- a/public/app/plugins/panel/nodeGraph/useZoom.ts
+++ b/public/app/plugins/panel/nodeGraph/useZoom.ts
@@ -21,8 +21,7 @@ interface Options {
   stepDown?: (scale: number) => number;
 
   /**
-   * Set max and min values. If stepUp/down overshoots these bounds this will return min or max but internal scale value
-   * will still be what ever the step functions returned last.
+   * Set max and min values. Scale updates are clamped to these bounds.
    */
   min?: number;
   max?: number;
@@ -44,19 +43,32 @@ export function useZoom(options: Options = defaultOptions) {
   const stepDown = options.stepDown ?? defaultOptions.stepDown;
 
   const ref = useRef<HTMLElement | null>(null);
-  const [scale, setScale] = useState(1);
+  const [storedScale, setStoredScale] = useState(1);
+  const scale = clampScale(storedScale, min, max);
+  const setScale = useCallback(
+    (nextScale: number) => {
+      setStoredScale(clampScale(nextScale, min, max));
+    },
+    [min, max]
+  );
+
+  useEffect(() => {
+    if (storedScale !== scale) {
+      setStoredScale(scale);
+    }
+  }, [scale, storedScale]);
 
   const onStepUp = useCallback(() => {
     if (scale < (max ?? Infinity)) {
       setScale(stepUp(scale));
     }
-  }, [scale, stepUp, max]);
+  }, [max, scale, setScale, stepUp]);
 
   const onStepDown = useCallback(() => {
     if (scale > (min ?? -Infinity)) {
       setScale(stepDown(scale));
     }
-  }, [scale, stepDown, min]);
+  }, [min, scale, setScale, stepDown]);
 
   const onWheel = useCallback(
     function (wheelEvent: WheelEvent) {
@@ -78,7 +90,7 @@ export function useZoom(options: Options = defaultOptions) {
         }
       }
     },
-    [min, max, scale, zoomMode]
+    [max, min, scale, setScale, zoomMode]
   );
 
   useEffect(() => {
@@ -101,10 +113,14 @@ export function useZoom(options: Options = defaultOptions) {
   return {
     onStepUp,
     onStepDown,
-    scale: Math.max(Math.min(scale, max ?? Infinity), min ?? -Infinity),
+    scale,
     isMax: scale >= (max ?? Infinity),
     isMin: scale <= (min ?? -Infinity),
     ref,
     setScale,
   };
+}
+
+function clampScale(scale: number, min?: number, max?: number) {
+  return Math.max(Math.min(scale, max ?? Infinity), min ?? -Infinity);
 }

--- a/public/app/plugins/panel/nodeGraph/useZoom.ts
+++ b/public/app/plugins/panel/nodeGraph/useZoom.ts
@@ -2,11 +2,14 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { ZoomMode } from './panelcfg.gen';
 
+export const minZoom = 0.13;
+export const maxZoom = 2.25;
+
 const defaultOptions: Required<Options> = {
   stepUp: (s) => s * 1.5,
   stepDown: (s) => s / 1.5,
-  min: 0.13,
-  max: 2.25,
+  min: minZoom,
+  max: maxZoom,
   zoomMode: ZoomMode.Cooperative,
 };
 
@@ -102,5 +105,6 @@ export function useZoom(options: Options = defaultOptions) {
     isMax: scale >= (max ?? Infinity),
     isMin: scale <= (min ?? -Infinity),
     ref,
+    setScale,
   };
 }

--- a/public/app/plugins/panel/nodeGraph/useZoom.ts
+++ b/public/app/plugins/panel/nodeGraph/useZoom.ts
@@ -21,7 +21,8 @@ interface Options {
   stepDown?: (scale: number) => number;
 
   /**
-   * Set max and min values. Scale updates are clamped to these bounds.
+   * Set max and min values. If stepUp/down overshoots these bounds this will return min or max, but the internal scale
+   * value will remain whatever the step function returned.
    */
   min?: number;
   max?: number;
@@ -43,32 +44,23 @@ export function useZoom(options: Options = defaultOptions) {
   const stepDown = options.stepDown ?? defaultOptions.stepDown;
 
   const ref = useRef<HTMLElement | null>(null);
-  const [storedScale, setStoredScale] = useState(1);
-  const scale = clampScale(storedScale, min, max);
-  const setScale = useCallback(
-    (nextScale: number) => {
-      setStoredScale(clampScale(nextScale, min, max));
-    },
-    [min, max]
-  );
+  const [scale, setScale] = useState(1);
 
   useEffect(() => {
-    if (storedScale !== scale) {
-      setStoredScale(scale);
-    }
-  }, [scale, storedScale]);
+    setScale((scale) => clampScale(scale, min, max));
+  }, [max, min]);
 
   const onStepUp = useCallback(() => {
     if (scale < (max ?? Infinity)) {
       setScale(stepUp(scale));
     }
-  }, [max, scale, setScale, stepUp]);
+  }, [max, scale, stepUp]);
 
   const onStepDown = useCallback(() => {
     if (scale > (min ?? -Infinity)) {
       setScale(stepDown(scale));
     }
-  }, [min, scale, setScale, stepDown]);
+  }, [min, scale, stepDown]);
 
   const onWheel = useCallback(
     function (wheelEvent: WheelEvent) {
@@ -90,7 +82,7 @@ export function useZoom(options: Options = defaultOptions) {
         }
       }
     },
-    [max, min, scale, setScale, zoomMode]
+    [max, min, scale, zoomMode]
   );
 
   useEffect(() => {
@@ -113,7 +105,7 @@ export function useZoom(options: Options = defaultOptions) {
   return {
     onStepUp,
     onStepDown,
-    scale,
+    scale: clampScale(scale, min, max),
     isMax: scale >= (max ?? Infinity),
     isMin: scale <= (min ?? -Infinity),
     ref,

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12485,6 +12485,7 @@
     "category-edges": "Edges",
     "category-node-graph": "Node graph",
     "category-nodes": "Nodes",
+    "description-fit-to-view": "Automatically fit and center the graph when its layout or panel size changes",
     "layout-algorithm-options": {
       "description-force": "Use a force-directed layout",
       "description-grid": "Use a grid layout",
@@ -12494,6 +12495,7 @@
       "label-layered": "Layered"
     },
     "name-arc-sections": "Arc sections",
+    "name-fit-to-view": "Fit graph to view",
     "name-layout-algorithm": "Layout algorithm",
     "name-main-stat-unit": "Main stat unit",
     "name-secondary-stat-unit": "Secondary stat unit",


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Adds an opt-in **Fit graph to view** option to the Node Graph panel. When enabled, Grafana scales and centers the graph when its bounds or the panel dimensions change. Manual panning and zooming remain available between these changes.

**Why do we need this feature?**

Large or unusually positioned node graphs can initially render outside the visible panel area, requiring users to manually zoom out and recenter them. This option makes the complete graph visible automatically while preserving the existing behavior by default.

**Who is this feature for?**

Users who display large or dynamically changing node graphs.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #128622 

**Special notes for your reviewer:**

The option is disabled by default to avoid changing existing dashboards. The fit calculation:

- Accounts for node bounds and custom node radii.
- Recalculates when the graph bounds or panel size changes.
- Supports scales below the normal manual minimum for particularly large graphs.
- Retains the existing maximum zoom limit.
- Handles initially unavailable panel dimensions.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
