### PR TITLE
fix: handle dashboard export download errors

### DIFF
--- a/public/app/features/dashboard-scene/sharing/ExportButton/ExportAsCode.tsx
+++ b/public/app/features/dashboard-scene/sharing/ExportButton/ExportAsCode.tsx
@@ -8,7 +8,7 @@ import { selectors as e2eSelectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { type SceneComponentProps } from '@grafana/scenes';
 import { Button, ClipboardButton, CodeEditor, Spinner, Stack, useStyles2 } from '@grafana/ui';
-import { createSuccessNotification } from 'app/core/copy/appNotification';
+import { createErrorNotification, createSuccessNotification } from 'app/core/copy/appNotification';
 import { notifyApp } from 'app/core/reducers/appNotification';
 import { ExportFormat } from 'app/features/dashboard/api/types';
 import { dispatch } from 'app/store/store';
@@ -46,9 +46,16 @@ function ExportAsCodeRenderer({ model }: SceneComponentProps<ExportAsCode>) {
     skipInvalid: true,
   });
   const stringifiedDashboard = isViewingYAML ? stringifiedDashboardYAML : stringifiedDashboardJson;
+  const hasExportError = dashboardJson.value?.json && 'error' in dashboardJson.value.json;
 
   const onClickDownload = async () => {
-    await model.onSaveAsFile();
+    const result = await model.onSaveAsFile();
+    if (!result.success) {
+      const message = t('export.json.download-error_toast_message', 'Failed to download dashboard');
+      dispatch(notifyApp(createErrorNotification(message, String(result.error))));
+      return;
+    }
+
     const message = t('export.json.download-successful_toast_message', 'Your JSON has been downloaded');
     dispatch(notifyApp(createSuccessNotification(message)));
   };
@@ -93,6 +100,7 @@ function ExportAsCodeRenderer({ model }: SceneComponentProps<ExportAsCode>) {
             variant="primary"
             icon="download-alt"
             onClick={onClickDownload}
+            disabled={dashboardJson.loading || Boolean(hasExportError)}
           >
             <Trans i18nKey="export.json.download-button">Download file</Trans>
           </Button>

--- a/public/app/features/dashboard-scene/sharing/ShareExportTab.test.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareExportTab.test.tsx
@@ -1,3 +1,5 @@
+import saveAs from 'file-saver';
+
 import { config } from '@grafana/runtime';
 import { SceneTimeRange } from '@grafana/scenes';
 import {
@@ -22,6 +24,7 @@ import { DefaultGridLayoutManager } from '../scene/layout-default/DefaultGridLay
 import { ShareExportTab } from './ShareExportTab';
 
 jest.mock('app/features/dashboard/api/dashboard_api');
+jest.mock('file-saver', () => jest.fn());
 
 const mockV1Spec: DashboardDataDTO = {
   title: 'Test Dashboard V1',
@@ -401,6 +404,32 @@ describe('ShareExportTab', () => {
 
       tab.onExportFormatChange(ExportFormat.V2Resource);
       expect(tab.state.isViewingYAML).toBe(true);
+    });
+  });
+
+  describe('Download', () => {
+    it('should not save an API error as a dashboard file', async () => {
+      const getDashboardAPIMock = dashboardApiModule.getDashboardAPI as jest.Mock;
+      getDashboardAPIMock.mockImplementation(() => ({
+        getDashboardDTO: jest.fn().mockRejectedValue(new Error('API down')),
+      }));
+
+      const tab = buildV1DashboardScenario();
+      const result = await tab.onSaveAsFile();
+
+      expect(result).toEqual({
+        success: false,
+        error: 'Failed to fetch dashboard in classic format. API down',
+      });
+      expect(saveAs).not.toHaveBeenCalled();
+    });
+
+    it('should save a valid dashboard file', async () => {
+      const tab = buildV1DashboardScenario();
+      const result = await tab.onSaveAsFile();
+
+      expect(result).toEqual({ success: true });
+      expect(saveAs).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/public/app/features/dashboard-scene/sharing/ShareExportTab.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareExportTab.tsx
@@ -40,6 +40,8 @@ export interface ShareExportTabState extends SceneShareTabState {
   exportFormat?: ExportFormat;
 }
 
+export type SaveExportResult = { success: true } | { success: false; error: unknown };
+
 export class ShareExportTab extends SceneObjectBase<ShareExportTabState> implements ShareView {
   public tabId = shareDashboardType.export;
   static Component = ShareExportTabRenderer;
@@ -219,8 +221,12 @@ export class ShareExportTab extends SceneObjectBase<ShareExportTabState> impleme
     }
   };
 
-  public onSaveAsFile = async () => {
+  public onSaveAsFile = async (): Promise<SaveExportResult> => {
     const dashboard = await this.getExportableDashboardJson();
+    if ('error' in dashboard.json) {
+      return { success: false, error: dashboard.json.error };
+    }
+
     const dashboardJsonPretty = JSON.stringify(dashboard.json, null, 2);
     const { isSharingExternally, isViewingYAML } = this.state;
 
@@ -243,6 +249,8 @@ export class ShareExportTab extends SceneObjectBase<ShareExportTabState> impleme
       format: isViewingYAML ? 'yaml' : 'json',
       action: 'download',
     });
+
+    return { success: true };
   };
 
   public onClipboardCopy = async () => {


### PR DESCRIPTION
## Summary

- Prevent failed dashboard exports from being downloaded as JSON or YAML files.
- Show an error notification when an export fails instead of a success notification.
- Disable the JSON export download while the preview is loading or contains an error.
- Add regression coverage for failed and successful dashboard downloads.

## Root cause

The export tab attempted to save the API error payload as a dashboard file, while the export button always showed a success notification after the save handler resolved. The save handler now returns an explicit success/error result so the button can report the correct outcome.

## Validation

- `corepack yarn jest --no-watch public/app/features/dashboard-scene/sharing/ShareExportTab.test.tsx --runInBand` — 19 passed
- Prettier check on the three changed files — passed
- ESLint on the three changed files — passed
- Full TypeScript typecheck with an 8 GB Node heap — passed

Fixes https://github.com/grafana/grafana/issues/129202

This change was completed for the OpenJobs bounty marketplace.

OpenJobs listing: https://openjobs.bot/jobs/d70f16b8-46c2-4fbd-aa7f-d09d07d4e4c4
