### PR TITLE
Alerting: include underlying error in Provisioning API bad-request responses

### DIFF
--- a/pkg/services/ngalert/api/generated_base_api_provisioning.go
+++ b/pkg/services/ngalert/api/generated_base_api_provisioning.go
@@ -7,6 +7,7 @@
 package api
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/grafana/grafana/pkg/api/response"
@@ -147,7 +148,7 @@ func (f *ProvisioningApiHandler) RoutePostAlertRule(ctx *contextmodel.ReqContext
 	// Parse Request Body
 	conf := apimodels.ProvisionedAlertRule{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+		return response.Error(http.StatusBadRequest, fmt.Sprintf("bad request data: %s", err), err)
 	}
 	return f.handleRoutePostAlertRule(ctx, conf)
 }
@@ -155,7 +156,7 @@ func (f *ProvisioningApiHandler) RoutePostContactpoints(ctx *contextmodel.ReqCon
 	// Parse Request Body
 	conf := apimodels.EmbeddedContactPoint{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+		return response.Error(http.StatusBadRequest, fmt.Sprintf("bad request data: %s", err), err)
 	}
 	return f.handleRoutePostContactpoints(ctx, conf)
 }
@@ -163,7 +164,7 @@ func (f *ProvisioningApiHandler) RoutePostMuteTiming(ctx *contextmodel.ReqContex
 	// Parse Request Body
 	conf := apimodels.MuteTimeInterval{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+		return response.Error(http.StatusBadRequest, fmt.Sprintf("bad request data: %s", err), err)
 	}
 	return f.handleRoutePostMuteTiming(ctx, conf)
 }
@@ -173,7 +174,7 @@ func (f *ProvisioningApiHandler) RoutePutAlertRule(ctx *contextmodel.ReqContext)
 	// Parse Request Body
 	conf := apimodels.ProvisionedAlertRule{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+		return response.Error(http.StatusBadRequest, fmt.Sprintf("bad request data: %s", err), err)
 	}
 	return f.handleRoutePutAlertRule(ctx, conf, uIDParam)
 }
@@ -184,7 +185,7 @@ func (f *ProvisioningApiHandler) RoutePutAlertRuleGroup(ctx *contextmodel.ReqCon
 	// Parse Request Body
 	conf := apimodels.AlertRuleGroup{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+		return response.Error(http.StatusBadRequest, fmt.Sprintf("bad request data: %s", err), err)
 	}
 	return f.handleRoutePutAlertRuleGroup(ctx, conf, folderUIDParam, groupParam)
 }
@@ -194,7 +195,7 @@ func (f *ProvisioningApiHandler) RoutePutContactpoint(ctx *contextmodel.ReqConte
 	// Parse Request Body
 	conf := apimodels.EmbeddedContactPoint{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+		return response.Error(http.StatusBadRequest, fmt.Sprintf("bad request data: %s", err), err)
 	}
 	return f.handleRoutePutContactpoint(ctx, conf, uIDParam)
 }
@@ -204,7 +205,7 @@ func (f *ProvisioningApiHandler) RoutePutMuteTiming(ctx *contextmodel.ReqContext
 	// Parse Request Body
 	conf := apimodels.MuteTimeInterval{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+		return response.Error(http.StatusBadRequest, fmt.Sprintf("bad request data: %s", err), err)
 	}
 	return f.handleRoutePutMuteTiming(ctx, conf, nameParam)
 }
@@ -212,7 +213,7 @@ func (f *ProvisioningApiHandler) RoutePutPolicyTree(ctx *contextmodel.ReqContext
 	// Parse Request Body
 	conf := apimodels.Route{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+		return response.Error(http.StatusBadRequest, fmt.Sprintf("bad request data: %s", err), err)
 	}
 	return f.handleRoutePutPolicyTree(ctx, conf)
 }
@@ -222,7 +223,7 @@ func (f *ProvisioningApiHandler) RoutePutTemplate(ctx *contextmodel.ReqContext) 
 	// Parse Request Body
 	conf := apimodels.NotificationTemplateContent{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+		return response.Error(http.StatusBadRequest, fmt.Sprintf("bad request data: %s", err), err)
 	}
 	return f.handleRoutePutTemplate(ctx, conf, nameParam)
 }

--- a/pkg/services/ngalert/api/tooling/swagger-codegen/templates/controller-api.mustache
+++ b/pkg/services/ngalert/api/tooling/swagger-codegen/templates/controller-api.mustache
@@ -3,6 +3,8 @@ package {{packageName}}
 
 {{#operations}}
 import (
+	"fmt"
+
 	"github.com/go-macaron/binding"
 
 	"github.com/grafana/grafana/pkg/api/routing"
@@ -35,7 +37,7 @@ func (f *{{classname}}Handler) {{nickname}}(ctx *contextmodel.ReqContext) respon
 	// Parse Request Body
 	conf := apimodels.{{dataType}}{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+		return response.Error(http.StatusBadRequest, fmt.Sprintf("bad request data: %s", err), err)
 	}
 	{{/bodyParams}}return f.handle{{nickname}}(ctx{{#bodyParams}}, conf{{/bodyParams}}{{#pathParams}}, {{paramName}}Param{{/pathParams}})
 }


### PR DESCRIPTION
## What this PR does

The Alerting Provisioning API (`/api/v1/provisioning/...`) returns a generic `{"message":"bad request data","traceID":""}` whenever the request body fails to bind (e.g. an invalid `For` duration on an alert rule). The real reason (e.g. `not a valid duration string: \"300\"`) is only ever logged server-side and never reaches the API caller.

Root cause: in `response.Error(status, message, err)` (`pkg/api/response/response.go`), `err` is stored only for internal logging (`resp.err`) and is never included in the JSON response body.

This PR includes the underlying bind error in the response message for the Provisioning API's `web.Bind` failures, across all 9 Post/Put handlers in `generated_base_api_provisioning.go` (alert rule, alert rule group, contact point(s), mute timing, policy tree, notification template):

```go
return response.Error(http.StatusBadRequest, fmt.Sprintf("bad request data: %s", err), err)
```

I also updated the shared codegen template (`pkg/services/ngalert/api/tooling/swagger-codegen/templates/controller-api.mustache`) that generates this file, so the fix stays consistent on the next regeneration.

**Note on the generated file:** `generated_base_api_provisioning.go` is produced by a Docker-based swagger-codegen tool (see `pkg/services/ngalert/api/tooling/Makefile`) that I could not run in my environment. I hand-applied the exact one-line transformation the updated template now produces, rather than leaving the generated file and template out of sync. Happy to have a maintainer re-run `make gen` in that directory to confirm the regenerated output matches byte-for-byte.

Fixes #56387

## Test plan

- [ ] Confirmed no existing test asserts the old literal `"bad request data"` string for these routes (searched the repo for this)
- [ ] Maintainer/CI to confirm `make gen` in `pkg/services/ngalert/api/tooling` reproduces this diff exactly
- [ ] Manual check: PUT/POST an alert rule with an invalid `for` duration and confirm the response body now includes the parse error detail
