### PR TITLE
InfluxDB Flux: stop logging full QueryDataRequest (cleartext token) at debug

### DIFF
--- a/pkg/tsdb/influxdb/flux/flux.go
+++ b/pkg/tsdb/influxdb/flux/flux.go
@@ -16,7 +16,7 @@ import (
 func Query(ctx context.Context, dsInfo *models.DatasourceInfo, tsdbQuery backend.QueryDataRequest, logger log.Logger) (*backend.QueryDataResponse, error) {
 	logger = logger.FromContext(ctx)
 	tRes := backend.NewQueryDataResponse()
-	logger.Debug("Received a query", "query", tsdbQuery)
+	logger.Debug("Received a query request", "numQueries", len(tsdbQuery.Queries))
 	r, err := runnerFromDataSource(dsInfo)
 	if err != nil {
 		return &backend.QueryDataResponse{}, err


### PR DESCRIPTION
## Summary
- The Flux datasource's `Query` function logged the entire `*backend.QueryDataRequest` at debug level via `logger.Debug("Received a query", "query", tsdbQuery)`. That struct includes `PluginContext.DataSourceInstanceSettings.DecryptedSecureJSONData`, which for InfluxDB holds the API token in cleartext.
- Because InfluxDB is an in-process core plugin, this SDK debug logger writes straight to stderr and bypasses Grafana's log pipeline entirely (`GF_LOG_LEVEL`, `[log] filters`, etc. have no effect), so the token ends up in journals/log aggregators regardless of configured log level.
- This mirrors the existing pattern already used by the sibling InfluxQL entrypoint (`pkg/tsdb/influxdb/influxdb.go`), which only logs `numQueries` rather than the full request.

## Fix
Log only the query count instead of the full request struct.

Fixes #129265

## Test plan
- [x] `go build ./pkg/tsdb/influxdb/...`
- [x] `go test ./pkg/tsdb/influxdb/...` (all packages pass)
- [x] Manually confirmed no test asserts on the previous debug log message contents