### PR TITLE
fix(influxdb): stop logging cleartext token in Flux debug log

### DIFF
--- a/pkg/tsdb/influxdb/flux/flux.go
+++ b/pkg/tsdb/influxdb/flux/flux.go
@@ -16,6 +16,14 @@ import (
 func Query(ctx context.Context, dsInfo *models.DatasourceInfo, tsdbQuery backend.QueryDataRequest, logger log.Logger) (*backend.QueryDataResponse, error) {
 	logger = logger.FromContext(ctx)
 	tRes := backend.NewQueryDataResponse()
+	refIDs := make([]string, 0, len(tsdbQuery.Queries))
+	for _, q := range tsdbQuery.Queries {
+		refIDs = append(refIDs, q.RefID)
+	}
+	// Log only non-sensitive fields. The previous form logged the entire
+	// backend.QueryDataRequest, which embeds PluginContext.DataSourceInstanceSettings.DecryptedSecureJSONData
+	// and so wrote the InfluxDB API token to the journal at debug level.
+	logger.Debug("Received a query", "numQueries", len(tsdbQuery.Queries), "refIDs", refIDs)
 	r, err := runnerFromDataSource(dsInfo)
 	if err != nil {
 		return &backend.QueryDataResponse{}, err


### PR DESCRIPTION
The InfluxDB Flux datasource logs the entire backend.QueryDataRequest at debug level. That struct embeds PluginContext.DataSourceInstanceSettings.DecryptedSecureJSONData, which for InfluxDB holds the API token in cleartext. Because the SDK debug logger writes to stderr and InfluxDB is an in-process core plugin, those lines bypass GF_LOG_LEVEL and land in the process stderr — on systemd hosts that is thousands of cleartext credential lines per day in the journal (see #129265 for the full impact).

This replaces the whole-request log with the non-sensitive fields the sibling InfluxQL entry point already uses (numQueries), and adds the per-query RefIDs so the line keeps its debug value for correlating query execution. I audited the other in-process core datasources (graphite, loki, cloudwatch, prometheus, elasticsearch) for the same whole-QueryDataRequest pattern and only Flux had it.

Fixes #129265.