### PR TITLE
Unified Storage: fix deliver live NATS DELETED as OnDelete, not OnUpdate

### DIFF
--- a/pkg/storage/unified/informer/informer.go
+++ b/pkg/storage/unified/informer/informer.go
@@ -301,15 +301,27 @@ func (n *Informer) onNotification() nats.MessageHandler {
 		n.log.Debug("nats notification received", "subject", subject, "type", evt.Type, "namespace", evt.Namespace, "name", evt.Name, "rv", evt.ResourceVersion)
 
 		obj := n.newObject(evt.Namespace, evt.Name)
-		// ADDED becomes OnAdd; everything else (MODIFIED, or a DELETED whose object
-		// may still exist mid-finalization) becomes OnUpdate. The handlers key off
-		// namespace/name and re-fetch in their reconcile, so old == new is fine and
-		// a delete just enqueues a key whose GET will 404 and be handled there.
-		if evt.Type == resourcepb.WatchNotification_ADDED {
+		// The handlers key off namespace/name and re-fetch the object in their
+		// reconcile, so the minimal object and old == new are both fine.
+		switch evt.Type {
+		case resourcepb.WatchNotification_ADDED:
 			n.dispatch(func(h cache.ResourceEventHandler) { h.OnAdd(obj, false) })
-			return
+		case resourcepb.WatchNotification_DELETED:
+			// A DELETED notification is published only once the object is actually
+			// removed from storage; a delete that merely sets a deletionTimestamp is an
+			// update, delivered as MODIFIED (and that is where finalizers run). So by
+			// the time DELETED arrives the object is gone and a re-fetch can only 404.
+			// Deliver it as OnDelete — the standard delete signal handlers already
+			// ignore or key off — rather than OnUpdate: a re-fetching controller would
+			// otherwise enqueue a key whose only possible outcome is a spurious "not
+			// found" reconcile error. Drop it from the snapshot too, so a
+			// staleness-tolerant reader (e.g. a quota count) stops counting it without
+			// waiting for the next re-list.
+			n.store.Delete(context.Background(), evt.Namespace, evt.Name)
+			n.dispatch(func(h cache.ResourceEventHandler) { h.OnDelete(obj) })
+		default: // MODIFIED
+			n.dispatch(func(h cache.ResourceEventHandler) { h.OnUpdate(obj, obj) })
 		}
-		n.dispatch(func(h cache.ResourceEventHandler) { h.OnUpdate(obj, obj) })
 	}
 }
 

--- a/pkg/storage/unified/informer/informer_test.go
+++ b/pkg/storage/unified/informer/informer_test.go
@@ -205,9 +205,10 @@ func TestInformer_InitialListDeliversAdds(t *testing.T) {
 	})
 }
 
-// A live ADDED goes through OnAdd; a MODIFIED/DELETED through OnUpdate. The
-// delivered object is the minimal one built from the notification's identity —
-// the controllers re-fetch, so the informer does not read the object.
+// A live ADDED goes through OnAdd, a MODIFIED through OnUpdate, and a DELETED
+// through OnDelete. The delivered object is the minimal one built from the
+// notification's identity — the controllers re-fetch, so the informer does not
+// read the object.
 func TestInformer_LiveEventsDispatchMinimalObject(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		sub := newFakeSubscriber()
@@ -221,7 +222,28 @@ func TestInformer_LiveEventsDispatchMinimalObject(t *testing.T) {
 		synctest.Wait()
 
 		assert.Equal(t, []string{"fresh"}, handler.addedNames())
-		assert.Equal(t, []string{"changed", "gone"}, handler.updatedNames())
+		assert.Equal(t, []string{"changed"}, handler.updatedNames())
+		assert.Equal(t, []string{"gone"}, handler.deletedNames())
+	})
+}
+
+// A live DELETED drops the object from the informer's snapshot so a
+// staleness-tolerant reader stops counting it before the next re-list.
+func TestInformer_LiveDeleteEvictsFromStore(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		sub := newFakeSubscriber()
+		handler := &recordingHandler{}
+		n, stop := start(t, sub, []runtime.Object{obj("keep"), obj("gone")}, newObjectFunc, handler)
+		defer stop()
+
+		sub.publish(t, subject(), event(resourcepb.WatchNotification_DELETED, "gone"))
+		synctest.Wait()
+
+		var got []string
+		for _, o := range n.store.List(context.Background()) {
+			got = append(got, o.(*metav1.PartialObjectMetadata).Name)
+		}
+		assert.Equal(t, []string{"keep"}, got)
 	})
 }
 

--- a/pkg/storage/unified/informer/informer_test.go
+++ b/pkg/storage/unified/informer/informer_test.go
@@ -239,8 +239,9 @@ func TestInformer_LiveDeleteEvictsFromStore(t *testing.T) {
 		sub.publish(t, subject(), event(resourcepb.WatchNotification_DELETED, "gone"))
 		synctest.Wait()
 
-		var got []string
-		for _, o := range n.store.List(context.Background()) {
+		snapshot := n.store.List(context.Background())
+		got := make([]string, 0, len(snapshot))
+		for _, o := range snapshot {
 			got = append(got, o.(*metav1.PartialObjectMetadata).Name)
 		}
 		assert.Equal(t, []string{"keep"}, got)

--- a/pkg/storage/unified/resource/notifier_nats_integration_test.go
+++ b/pkg/storage/unified/resource/notifier_nats_integration_test.go
@@ -86,7 +86,17 @@ func TestIntegrationNatsWatchNotificationRoundTrip(t *testing.T) {
 				ResourceVersion: 1,
 				Action:          action,
 			})
-			got := recvEvent(t, out)
+			// Watch subscribes to the whole change stream, so a late warm-up
+			// duplicate (establishInterest publishes many and drains only on a
+			// timeout) can still be queued ahead of ours. Skip anything that is not
+			// the playlist event we just published.
+			var got Event
+			for {
+				got = recvEvent(t, out)
+				if got.Namespace == "default" {
+					break
+				}
+			}
 			assert.Equal(t, action, got.Action, "action %q must survive the round trip", action)
 		}
 	})


### PR DESCRIPTION
## What

Stops the spurious `RepositoryController failed to process key … error="repository not found"` that was logged on **every repository delete** when the provisioning controllers are driven by the NATS notifier.

## Why

A `DELETED` watch notification is published only once a resource is *actually removed* from storage. A delete that merely sets a `deletionTimestamp` is an **update** — it is delivered as `MODIFIED`, and that is where finalizers run. (`pkg/storage/unified/resource/watch_publisher.go`: `DataActionDeleted → DELETED`, `DataActionUpdated → MODIFIED`.)

So the sequence for a normal delete is:

1. delete → `deletionTimestamp` set → **MODIFIED** → controller runs finalizers (remove-orphan-resources, cleanup) and patches them off
2. removing the last finalizer actually deletes the row → storage publishes **DELETED**
3. the informer mapped `DELETED` → `OnUpdate` → re-enqueue → `process` GET → **404** → `errors.New("repository not found")`

By the time `DELETED` arrives the object is already gone and finalizers already ran, so the re-fetch could only ever 404. The re-enqueue was pure noise.

## How

In the NATS informer's `onNotification` (`pkg/storage/unified/informer/informer.go`), dispatch a live `DELETED` as `OnDelete` — the standard k8s delete signal — instead of `OnUpdate`, and evict it from the shared snapshot (`store.Delete`) so a staleness-tolerant reader (e.g. the quota count) stops counting it before the next re-list.

This is safe because **no provisioning consumer registers a `DeleteFunc`** — repository/connection use `AddFunc`+`UpdateFunc`, job/historyjob use `AddFunc`(+`UpdateFunc`). So `OnDelete` is a no-op today; the change simply removes the spurious reconcile. It also matches the re-list path, which already emits `OnDelete` for keys that have vanished since the previous list.

**Deliberately out of scope:** the *create-race* 404 (an `ADDED`/`MODIFIED` whose GET 404s because the event outran cross-replica read visibility) is a different problem that needs a retry, and is handled by the separate reconcile-hints work — not touched here.

## Testing

- `go test ./pkg/storage/unified/informer/` — updated `TestInformer_LiveEventsDispatchMinimalObject` (DELETED now lands as a delete) and added `TestInformer_LiveDeleteEvictsFromStore`
- `go test ./pkg/registry/apis/provisioning/informer/... ./pkg/registry/apis/provisioning/controller/...` — pass
- `go test ./pkg/controller/` (apps/provisioning: job/historyjob consumers) — pass
- gofmt clean

## Checklist
- [x] Tests added/updated
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)