### PR TITLE
[release-12.4.7] DashboardDS: Fix Mixed panels with a time override stuck in permanent loading

### DIFF
--- a/public/app/plugins/datasource/dashboard/datasource.test.ts
+++ b/public/app/plugins/datasource/dashboard/datasource.test.ts
@@ -23,7 +23,8 @@ import {
   SceneDataTransformer,
   SceneFlexItem,
   SceneFlexLayout,
-  SceneObject,
+  type SceneObject,
+  SceneTimeRange,
   VizPanel,
 } from '@grafana/scenes';
 import { getVizPanelKeyForPanelId } from 'app/features/dashboard-scene/utils/utils';
@@ -198,6 +199,36 @@ describe('DashboardDatasource', () => {
     expect(emissions).toHaveLength(1);
     expect(emissions[0].state).toBe(LoadingState.Done);
     expect(emissions[0].data[0].fields[0].values).toEqual([42]);
+  });
+
+  it('Should still emit Done on the Mixed path when the source range differs from the chain (PanelTimeRange override, #22618)', async () => {
+    // Regression for #22618: a Mixed chain panel where the source (or the chain)
+    // carries a `PanelTimeRange` override observes an upstream range that
+    // legitimately differs from the chain request range. The terminal Done is
+    // fresh — it matches the source panel's own current range — so it must be
+    // emitted. Before the fix it was compared against the chain request range,
+    // never matched, was dropped, and the panel hung in permanent loading.
+    const chainRange = makeRange('2026-05-04T00:00:00Z', '2026-05-08T00:00:00Z');
+    const sourceRange = makeRange('2026-05-04T01:00:00Z', '2026-05-08T01:00:00Z'); // shifted +1h
+
+    const { observable, upstreamStream } = setupWithControllableUpstream(
+      { refId: 'A', panelId: 1 },
+      `${MIXED_REQUEST_PREFIX}1`,
+      chainRange,
+      sourceRange
+    );
+
+    const emissions: DataQueryResponse[] = [];
+    observable.subscribe({ next: (data) => emissions.push(data) });
+
+    // Upstream runs for the source's own (shifted) range: Loading then Done.
+    upstreamStream.next(makeResult(LoadingState.Loading, arrayToDataFrame([1]), sourceRange));
+    upstreamStream.next(makeResult(LoadingState.Done, arrayToDataFrame([2, 3]), sourceRange));
+
+    await waitForDebounce();
+    expect(emissions).toHaveLength(1);
+    expect(emissions[0].state).toBe(LoadingState.Done);
+    expect(emissions[0].data[0].fields[0].values).toEqual([2, 3]);
   });
 
   it('Should not mutate field state in dataframe', () => {
@@ -1017,7 +1048,15 @@ function waitForDebounce() {
   return new Promise((r) => setTimeout(r, 600));
 }
 
-function setupWithControllableUpstream(query: DashboardQuery, requestId: string, range: ReturnType<typeof makeRange>) {
+function setupWithControllableUpstream(
+  query: DashboardQuery,
+  requestId: string,
+  range: ReturnType<typeof makeRange>,
+  // The source panel's own current range. Defaults to the chain request range
+  // (no override). Pass a different value to model a source/chain with a
+  // `PanelTimeRange` override, where the source's range differs from the chain.
+  sourceRange: ReturnType<typeof makeRange> = range
+) {
   // Match production: upstream SceneQueryRunner exposes a ReplaySubject(1) so
   // subscribers attaching after the upstream has already emitted Done get the
   // stale Done replayed synchronously on subscribe.
@@ -1037,6 +1076,13 @@ function setupWithControllableUpstream(query: DashboardQuery, requestId: string,
       new SceneFlexItem({
         body: new VizPanel({
           key: getVizPanelKeyForPanelId(1),
+          // The source panel's effective range — `DashboardDatasource` reads
+          // this via `sceneGraph.getTimeRange` to decide whether an upstream
+          // terminal emission is fresh or a stale replay.
+          $timeRange: new SceneTimeRange({
+            from: sourceRange.from.toISOString(),
+            to: sourceRange.to.toISOString(),
+          }),
           $data: sourceData,
         }),
       }),

--- a/public/app/plugins/datasource/dashboard/datasource.ts
+++ b/public/app/plugins/datasource/dashboard/datasource.ts
@@ -21,7 +21,13 @@ import {
   DataSourceGetDrilldownsApplicabilityOptions,
   DrilldownsApplicability,
 } from '@grafana/data';
-import { isSceneObject, SceneDataProvider, SceneDataTransformer, SceneObject } from '@grafana/scenes';
+import {
+  isSceneObject,
+  sceneGraph,
+  type SceneDataProvider,
+  SceneDataTransformer,
+  type SceneObject,
+} from '@grafana/scenes';
 import {
   activateSceneObjectAndParentTree,
   findVizPanelByKey,
@@ -107,11 +113,7 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
       // Only the Mixed-DS path uses `first(Done || Error)` to complete the
       // substream, so only that path needs to defend against a stale Done
       // replayed from the upstream SceneQueryRunner's ReplaySubject after a
-      // time-range change. The non-Mixed path stays open and naturally
-      // re-emits when the fresh Done arrives, so adding the filter there
-      // could only hurt: a chain panel with a `PanelTimeRange` override
-      // legitimately observes ranges that differ from the upstream and we
-      // would block its terminal emission indefinitely.
+      // time-range change.
       const isMixedDs = options.requestId.includes(MIXED_REQUEST_PREFIX);
 
       return sourceDataProvider!.getResultsStream!().pipe(
@@ -128,7 +130,16 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
           if (!upstreamRange?.from || !upstreamRange?.to) {
             return true;
           }
-          return isSameRange(upstreamRange, options.range);
+          // Drop a terminal emission only when it is stale — i.e. computed for a
+          // range other than the source panel's *current* range. Comparing
+          // against the source's own range (not the chain panel's `options.range`)
+          // is what makes this correct when the source or the chain carries a
+          // `PanelTimeRange` override (`timeFrom`/`timeShift`): such a chain
+          // legitimately observes a range that differs from the chain request,
+          // but the upstream's fresh Done still matches the source's own range,
+          // so we keep it and only drop the genuinely stale replay.
+          const sourceRange = sceneGraph.getTimeRange(sourceDataProvider!).state.value;
+          return isSameRange(upstreamRange, sourceRange);
         }),
         map((result) => {
           return {


### PR DESCRIPTION
Backport 2d08cc7a8940d023470f843301f09eaa7da59ed8 from #125954

---

**What is this feature?**

Fixes a bug where a panel using the **Mixed** datasource with multiple `-- Dashboard --` ("Other Panels") queries stays in permanent loading when the source panel — or the chain panel itself — has a **Time shift** or **Relative time** override set in Query options, even though the query completes and the data arrives.

**Why do we need this feature?**

This is a regression from #124665, which added a stale-`Done` filter on the Mixed-DS path of the Dashboard datasource. After a time-range change the upstream `SceneQueryRunner`'s `ReplaySubject(1)` synchronously replays the previous range's `Done` on subscribe; the filter discards it by requiring the emission's range to match the chain panel's request range (`options.range`), then waits for the fresh `Done`.

That comparison is incorrect when a `PanelTimeRange` override is present: the source panel runs on a range that legitimately differs from the chain panel's request range, so the upstream's *fresh* `Done` never matches `options.range` either. It is dropped on every emission, `emitFirstLoadedDataIfMixedDS`'s `first(Done || Error)` never completes, and the panel spins forever. The issue only affects the Mixed path (2+ subqueries, where the `mixed-` request prefix is applied); a single Dashboard-DS query is resolved directly and is unaffected.

The fix compares the upstream's terminal emission range against the **source panel's own current range** (`sceneGraph.getTimeRange(sourceDataProvider)`) instead of the chain panel's request range. This still drops the genuinely stale replay (its range differs from the source's current range after a time-range change), while keeping the fresh terminal emission, which always matches the source's own range whether or not an override is set.

**Who is this feature for?**

Users building dashboards that chain panels together via the Dashboard ("Other Panels") datasource through a Mixed datasource, combined with per-panel time shift / relative time overrides.

**Which issue(s) does this PR fix?**:

Fixes #125953

**Special notes for your reviewer:**

- Preserves the behavior #124665 introduced (stale-replay skip on time-range change), now scoped correctly so legitimate range differences from a `PanelTimeRange` override aren't dropped. cc @ivanortegaalba for context on the original change.
- Added a regression test for the Mixed + `PanelTimeRange` override case; existing Mixed-DS tests (stale-replay skip, editor-add single `Done`, non-Mixed override) still pass.
- Bug fix — needs a changelog entry; should be backported to the branches that carry #124665 (release-13.0.x, release-12.4.x, release-11.6.x).

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
