### PR TITLE
Chore(deps): Upgrade tar to 7.5.21 to fix CVE

### DIFF
--- a/package.json
+++ b/package.json
@@ -452,7 +452,8 @@
     "@opentelemetry/core": "2.8.0",
     "shell-quote": "1.9.0",
     "tmp": "0.2.7",
-    "yaml@npm:^1.10.0": "1.10.3"
+    "yaml@npm:^1.10.0": "1.10.3",
+    "tar@npm:7.5.11": "7.5.21"
   },
   "workspaces": {
     "packages": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -31093,16 +31093,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:7.5.11, tar@npm:^7.4.3, tar@npm:^7.5.4":
-  version: 7.5.11
-  resolution: "tar@npm:7.5.11"
+"tar@npm:7.5.21, tar@npm:^7.4.3, tar@npm:^7.5.4":
+  version: 7.5.21
+  resolution: "tar@npm:7.5.21"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10/fb2e77ee858a73936c68e066f4a602d428d6f812e6da0cc1e14a41f99498e4f7fd3535e355fa15157240a5538aa416026cfa6306bb0d1d1c1abf314b1f878e9a
+  checksum: 10/a1b7dcee15e4f7dbef7f07c3cf0fe946248efabd1cb029b54c698d817dfc2876c75bcaa164a12dd21191e385759ce3e37fea562cf4aabaa00984ef9ed3c48d17
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**What is this feature?**

Upgrades the transitive `tar` dependency to `7.5.21` to fix a CVE.

`yarn up -R tar` alone was not enough here. `lerna` pins `tar: 7.5.11` exactly, and the latest `lerna` (`9.0.7`) still has that same pin, so the vulnerable version stuck around in `yarn.lock`. Added a `tar@npm:7.5.11` resolution instead.

**Why do we need this feature?**

So we no longer resolve a vulnerable version of `tar`

**Who is this feature for?**

Grafana maintainers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

The resolution can be dropped once `lerna` ships a release that bumps its own `tar` pin.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
