### PR TITLE
DataSourceWithBackend: harden against invalid query time ranges

### DIFF
--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
@@ -99,6 +99,18 @@ describe('DataSourceWithBackend', () => {
   });
 
   describe('invalid query time range', () => {
+    test('allows queries with no range (metadata / metric-find style requests)', () => {
+      const { ds, mock } = createMockDatasource();
+
+      ds.query({
+        targets: [{ refId: 'A' }],
+      } as DataQueryRequest);
+
+      expect(mock.calls.length).toBe(1);
+      expect(mock.calls[0][0].data.from).toBeUndefined();
+      expect(mock.calls[0][0].data.to).toBeUndefined();
+    });
+
     test('throws a clear error when range from/to are undefined', () => {
       const { ds, mock } = createMockDatasource();
 

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
@@ -11,6 +11,7 @@ import {
   createDataFrame,
   type AdHocVariableFilter,
   type ScopedVars,
+  dateTime,
   getDefaultTimeRange,
 } from '@grafana/data';
 
@@ -95,6 +96,36 @@ describe('DataSourceWithBackend', () => {
 
   afterEach(() => {
     jest.useRealTimers();
+  });
+
+  describe('invalid query time range', () => {
+    test('throws a clear error when range from/to are undefined', () => {
+      const { ds, mock } = createMockDatasource();
+
+      expect(() =>
+        ds.query({
+          targets: [{ refId: 'A' }],
+          range: { from: undefined, to: undefined, raw: { from: '', to: '' } },
+        } as unknown as DataQueryRequest)
+      ).toThrow('Invalid DateTime in query time range');
+
+      expect(mock.calls.length).toBe(0);
+    });
+
+    test('throws a clear error when range contains invalid DateTimes', () => {
+      const { ds, mock } = createMockDatasource();
+      const from = dateTime(null);
+      const to = dateTime(null);
+
+      expect(() =>
+        ds.query({
+          targets: [{ refId: 'A' }],
+          range: { from, to, raw: { from, to } },
+        } as DataQueryRequest)
+      ).toThrow('Invalid DateTime in query time range');
+
+      expect(mock.calls.length).toBe(0);
+    });
   });
 
   test('check the executed queries', () => {

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
@@ -107,7 +107,7 @@ describe('DataSourceWithBackend', () => {
           targets: [{ refId: 'A' }],
           range: { from: undefined, to: undefined, raw: { from: '', to: '' } },
         } as unknown as DataQueryRequest)
-      ).toThrow('Invalid DateTime in query time range');
+      ).toThrow('Missing DateTime in query time range');
 
       expect(mock.calls.length).toBe(0);
     });

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -60,11 +60,15 @@ export function isExpressionReference(ref?: DataSourceRef | string | null): bool
 }
 
 function getQueryTimeRangeBounds(range?: TimeRange): { from: string; to: string } {
+  if (range?.from == null || range?.to == null) {
+    throw new Error('Missing DateTime in query time range');
+  }
+
   let from: unknown;
   let to: unknown;
   try {
-    from = range?.from.valueOf();
-    to = range?.to.valueOf();
+    from = range.from.valueOf();
+    to = range.to.valueOf();
   } catch {
     throw new Error('Invalid DateTime in query time range');
   }

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -17,6 +17,7 @@ import {
   parseLiveChannelAddress,
   type ScopedVars,
   type AdHocVariableFilter,
+  type TimeRange,
 } from '@grafana/data';
 
 import { reportInteraction } from '../analytics/utils';
@@ -56,6 +57,23 @@ export function isExpressionReference(ref?: DataSourceRef | string | null): bool
   }
   const v = typeof ref === 'string' ? ref : ref.type;
   return v === ExpressionDatasourceRef.type || v === ExpressionDatasourceRef.name || v === '-100'; // -100 was a legacy accident that should be removed
+}
+
+function getQueryTimeRangeBounds(range?: TimeRange): { from: string; to: string } {
+  let from: unknown;
+  let to: unknown;
+  try {
+    from = range?.from.valueOf();
+    to = range?.to.valueOf();
+  } catch {
+    throw new Error('Invalid DateTime in query time range');
+  }
+
+  if (typeof from !== 'number' || typeof to !== 'number' || Number.isNaN(from) || Number.isNaN(to)) {
+    throw new Error('Invalid DateTime in query time range');
+  }
+
+  return { from: from.toString(), to: to.toString() };
 }
 
 export class HealthCheckError extends Error {
@@ -234,10 +252,11 @@ class DataSourceWithBackend<
       return of({ data: [] });
     }
 
+    const { from, to } = getQueryTimeRangeBounds(range);
     const body = {
       queries,
-      from: range?.from.valueOf().toString(),
-      to: range?.to.valueOf().toString(),
+      from,
+      to,
     };
 
     const headers: Record<string, string> = request.headers ?? {};

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -59,8 +59,19 @@ export function isExpressionReference(ref?: DataSourceRef | string | null): bool
   return v === ExpressionDatasourceRef.type || v === ExpressionDatasourceRef.name || v === '-100'; // -100 was a legacy accident that should be removed
 }
 
-function getQueryTimeRangeBounds(range?: TimeRange): { from: string; to: string } {
-  if (range?.from == null || range?.to == null) {
+/**
+ * Converts a request time range into epoch-ms strings for `/api/ds/query`.
+ *
+ * When `range` is omitted entirely (common for metadata / metric-find queries),
+ * returns no bounds — matching the previous `range?.from.valueOf()` short-circuit.
+ * When a range is provided, `from`/`to` must exist and be valid DateTimes.
+ */
+function getQueryTimeRangeBounds(range?: TimeRange): { from?: string; to?: string } {
+  if (range == null) {
+    return {};
+  }
+
+  if (range.from == null || range.to == null) {
     throw new Error('Missing DateTime in query time range');
   }
 
@@ -256,11 +267,9 @@ class DataSourceWithBackend<
       return of({ data: [] });
     }
 
-    const { from, to } = getQueryTimeRangeBounds(range);
     const body = {
       queries,
-      from,
-      to,
+      ...getQueryTimeRangeBounds(range),
     };
 
     const headers: Record<string, string> = request.headers ?? {};

--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -16,7 +16,6 @@ import {
   type DateTime,
   escapeRegex,
   FieldType,
-  getDefaultTimeRange,
   type MetricFindValue,
   type QueryVariableModel,
   type RawTimeRange,
@@ -387,7 +386,6 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
     return lastValueFrom(
       super.query({
         targets: [target],
-        range: getDefaultTimeRange(),
       } as DataQueryRequest)
     ).then(this.toMetricFindValue);
   }
@@ -403,7 +401,6 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
       return lastValueFrom(
         super.query({
           ...(options ?? {}), // includes 'range'
-          range: options?.range ?? getDefaultTimeRange(),
           maxDataPoints: query.maxDataPoints,
           targets: [target],
         })
@@ -450,7 +447,7 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
       withTimeFilter: this.showTagTime,
     });
 
-    return this.metricFindQuery({ refId: 'get-tag-keys', query }, { range: options?.timeRange });
+    return this.metricFindQuery({ refId: 'get-tag-keys', query });
   }
 
   getTagValues(options: DataSourceGetTagValuesOptions<InfluxQuery>) {
@@ -462,7 +459,7 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
       withTimeFilter: this.showTagTime,
     });
 
-    return this.metricFindQuery({ refId: 'get-tag-values', query }, { range: options?.timeRange });
+    return this.metricFindQuery({ refId: 'get-tag-values', query });
   }
 
   /**

--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -16,6 +16,7 @@ import {
   type DateTime,
   escapeRegex,
   FieldType,
+  getDefaultTimeRange,
   type MetricFindValue,
   type QueryVariableModel,
   type RawTimeRange,
@@ -386,6 +387,7 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
     return lastValueFrom(
       super.query({
         targets: [target],
+        range: getDefaultTimeRange(),
       } as DataQueryRequest)
     ).then(this.toMetricFindValue);
   }
@@ -401,6 +403,7 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
       return lastValueFrom(
         super.query({
           ...(options ?? {}), // includes 'range'
+          range: options?.range ?? getDefaultTimeRange(),
           maxDataPoints: query.maxDataPoints,
           targets: [target],
         })
@@ -447,7 +450,7 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
       withTimeFilter: this.showTagTime,
     });
 
-    return this.metricFindQuery({ refId: 'get-tag-keys', query });
+    return this.metricFindQuery({ refId: 'get-tag-keys', query }, { range: options?.timeRange });
   }
 
   getTagValues(options: DataSourceGetTagValuesOptions<InfluxQuery>) {
@@ -459,7 +462,7 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
       withTimeFilter: this.showTagTime,
     });
 
-    return this.metricFindQuery({ refId: 'get-tag-values', query });
+    return this.metricFindQuery({ refId: 'get-tag-values', query }, { range: options?.timeRange });
   }
 
   /**


### PR DESCRIPTION
## Summary
- Guard `/api/ds/query` time bounds in `DataSourceWithBackend` when a **range is provided**:
  - `Missing DateTime in query time range` if `from`/`to` are absent on the range object
  - `Invalid DateTime in query time range` if they exist but are unusable (e.g. invalid moments → `NaN` from `valueOf()`)
- Primary failure mode: a range object with undefined `from`/`to` (e.g. after empty scene time evaluation) previously threw a cryptic `Cannot read properties of undefined (reading 'valueOf')`.
- Omitted `range` (metadata / metric-find style requests) is still allowed — same as the old optional-chaining short-circuit — so callers like InfluxDB `getTagValues` keep working without datasource-specific workarounds.

## Test plan
- [x] Unit tests: omitted range allowed; missing from/to on range object; invalid DateTimes
- [x] InfluxDB `metric find query › handles multiple frames` passes without Influx changes
- [ ] Smoke: normal panel query still works