### PR TITLE
Search: fill in keyword and ngram fields for per-kind search fields

### DIFF
--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -823,6 +823,7 @@ func (b *bleveBackend) BuildIndex(
 
 	idx := b.newBleveIndex(key, prepared.index, prepared.indexStorage, fields, allFields, standardSearchFields, updater, b.log.New("namespace", key.Namespace, "group", key.Group, "resource", key.Resource))
 	idx.facetFieldByRequestName = facetFieldsForMapping(searchFieldsProvider, key.Group, key.Resource)
+	idx.fieldVariants = fieldVariantsOf(fieldDefinitionsForMapping(searchFieldsProvider, key.Group, key.Resource))
 
 	if prepared.source.needsBuild() {
 		// Type-convert so buildIndexFromScratch can call updateResourceVersion after the builder returns.
@@ -1237,6 +1238,7 @@ func (b *bleveBackend) promoteBuildIndexToFile(
 
 	promoted := b.newBleveIndex(key, fileIndex, indexStorageFile, fields, allFields, standardSearchFields, updater, delegate.logger)
 	promoted.facetFieldByRequestName = delegate.facetFieldByRequestName
+	promoted.fieldVariants = delegate.fieldVariants
 	promoted.resourceVersion.Store(delegate.resourceVersion.Load())
 	cleanup = false
 
@@ -1616,6 +1618,10 @@ type bleveIndex struct {
 	// facetFieldByRequestName maps ResourceSearchRequest facet field names to
 	// keyword-analyzed Bleve index field names.
 	facetFieldByRequestName map[string]string
+	// fieldVariants drives the index-time copy of per-kind values into the
+	// variant fields this kind's mapping declares. Derived from the same
+	// declarations as the mapping, once per index rather than per document.
+	fieldVariants []fieldVariant
 
 	indexStorage string // memory or file, used when updating metrics
 
@@ -1701,6 +1707,7 @@ func (b *bleveIndex) BulkIndex(req *resource.BulkIndexRequest) error {
 				return fmt.Errorf("missing document")
 			}
 			doc := item.Doc.UpdateCopyFields()
+			populateFieldVariants(doc, b.fieldVariants)
 
 			// The static fields.* mapping drops values written under an undeclared
 			// name; collect them so the loss is logged, not silent.
@@ -1739,7 +1746,18 @@ func (b *bleveIndex) isDeclaredField(name string) bool {
 	if b.fields != nil && b.fields.Field(name) != nil {
 		return true
 	}
-	return b.standard != nil && b.standard.Field(name) != nil
+	if b.standard != nil && b.standard.Field(name) != nil {
+		return true
+	}
+	// Variant fields are mapped but never named by a document builder, so they
+	// only show up here when a document is indexed twice.
+	bare := strings.TrimPrefix(name, resource.SEARCH_FIELD_PREFIX)
+	for _, v := range b.fieldVariants {
+		if bare == v.keyword || bare == v.ngram {
+			return true
+		}
+	}
+	return false
 }
 
 func (b *bleveIndex) updateResourceVersion(rv int64) error {

--- a/pkg/storage/unified/search/bleve_mappings.go
+++ b/pkg/storage/unified/search/bleve_mappings.go
@@ -58,7 +58,7 @@ func facetFieldsForMapping(provider resource.SearchFieldsProvider, group, kindRe
 // Mappings emitted are driven by def.Capabilities:
 //
 //   - filter / facet / sort   → keyword mapping at the keyword variant name
-//     (see keywordVariantName). sort enables DocValues.
+//     (see keywordVariant). sort enables DocValues.
 //   - text                    → standard-analyzer text mapping at def.Name.
 //   - partial                 → ngram mapping at def.Name + "_ngram".
 //   - retrieve                → Store: true on the canonical field
@@ -82,7 +82,6 @@ func addCapabilityFieldMappings(parent *mapping.DocumentMapping, def resource.Se
 	hasText := def.HasCapability(resource.SearchCapabilityText)
 	hasPartial := def.HasCapability(resource.SearchCapabilityPartial)
 	hasSort := def.HasCapability(resource.SearchCapabilitySort)
-	hasFacet := def.HasCapability(resource.SearchCapabilityFacet)
 	hasRetrieve := def.HasCapability(resource.SearchCapabilityRetrieve)
 	hasUnranked := def.HasCapability(resource.SearchCapabilityUnranked)
 
@@ -104,8 +103,7 @@ func addCapabilityFieldMappings(parent *mapping.DocumentMapping, def resource.Se
 		return
 	}
 
-	needKeyword := hasFilter || hasFacet || hasSort
-	keywordName := keywordVariantName(def.Name, hasText)
+	keywordName, needKeyword := keywordVariant(def)
 
 	if needKeyword {
 		m := bleve.NewKeywordFieldMapping()
@@ -130,7 +128,7 @@ func addCapabilityFieldMappings(parent *mapping.DocumentMapping, def resource.Se
 		parent.AddFieldMappingsAt(def.Name, m)
 	}
 
-	if hasPartial {
+	if ngramName, ok := ngramVariant(def); ok {
 		m := bleve.NewTextFieldMapping()
 		m.Analyzer = TITLE_ANALYZER
 		m.IncludeTermVectors = false
@@ -139,7 +137,7 @@ func addCapabilityFieldMappings(parent *mapping.DocumentMapping, def resource.Se
 		// or text variant already stores the value.
 		m.Store = false
 		m.IncludeInAll = false
-		parent.AddFieldMappingsAt(def.Name+"_ngram", m)
+		parent.AddFieldMappingsAt(ngramName, m)
 	}
 
 	// A retrieve-only string has no mapping above, so store it explicitly;
@@ -175,14 +173,11 @@ func typedNonStringFieldMapping(t resource.SearchFieldType) *mapping.FieldMappin
 	}
 }
 
-// keywordVariantName returns the name the keyword analyzer variant of a field
-// should occupy. Rules:
-//
-//   - name == "title" → "title_phrase" (legacy in-tree client compatibility).
-//   - text capability present → name + "_keyword" so the text variant can
-//     take name.
-//   - otherwise → name itself, so filter-only fields keep today's on-disk
-//     shape (no suffix).
+// keywordVariantName returns the name the keyword form of a field is mapped
+// to. "title" keeps the historic "title_phrase" because in-tree clients ask
+// for it by that name. A text-capable field needs a suffix because its
+// analyzed form already occupies the bare name. Everything else keeps the bare
+// name, so filter-only fields hold their current on-disk shape.
 func keywordVariantName(name string, hasText bool) string {
 	if name == resource.SEARCH_FIELD_TITLE {
 		return resource.SEARCH_FIELD_TITLE_PHRASE
@@ -191,6 +186,110 @@ func keywordVariantName(name string, hasText bool) string {
 		return name + "_keyword"
 	}
 	return name
+}
+
+// keywordVariant returns the field def's keyword form is mapped to, and false
+// when def gets no keyword mapping. The mapping builder and the index-time
+// copy both call this, so a mapped variant cannot end up unwritten.
+func keywordVariant(def resource.SearchFieldDefinition) (string, bool) {
+	if def.Type != resource.SearchFieldTypeString {
+		return "", false
+	}
+	if !def.HasCapability(resource.SearchCapabilityFilter) &&
+		!def.HasCapability(resource.SearchCapabilityFacet) &&
+		!def.HasCapability(resource.SearchCapabilitySort) {
+		return "", false
+	}
+	return keywordVariantName(def.Name, def.HasCapability(resource.SearchCapabilityText)), true
+}
+
+// ngramVariant returns the field def's ngram form is mapped to, and false when
+// def gets no ngram mapping.
+func ngramVariant(def resource.SearchFieldDefinition) (string, bool) {
+	if def.Type != resource.SearchFieldTypeString || !def.HasCapability(resource.SearchCapabilityPartial) {
+		return "", false
+	}
+	return def.Name + "_ngram", true
+}
+
+// fieldVariant is a per-kind value that has to be copied into a second field,
+// because the mapping analyzes it differently there.
+type fieldVariant struct {
+	field   string
+	keyword string // empty when the value is keyword-analyzed under field itself
+	ngram   string // empty when the field has no ngram mapping
+}
+
+// fieldVariantsOf lists the copies a kind's declarations call for. Without the
+// copy the mapped variant stays empty and queries against it match nothing.
+func fieldVariantsOf(defs []resource.SearchFieldDefinition) []fieldVariant {
+	var out []fieldVariant
+	for _, def := range defs {
+		v := fieldVariant{field: def.Name}
+		if name, ok := keywordVariant(def); ok && name != def.Name {
+			v.keyword = name
+		}
+		if name, ok := ngramVariant(def); ok {
+			v.ngram = name
+		}
+		if v.keyword != "" || v.ngram != "" {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+// populateFieldVariants fills in the variant fields of a document's per-kind
+// values. Standard fields are left alone: title's variants come from
+// UpdateCopyFields, and no other standard field has one.
+//
+// TODO: fold this together with UpdateCopyFields, so title and per-kind fields
+// get their variants from one declaration-driven pass.
+func populateFieldVariants(doc *resource.IndexableDocument, variants []fieldVariant) {
+	for _, v := range variants {
+		value, ok := doc.Fields[v.field]
+		if !ok {
+			continue
+		}
+		if v.keyword != "" {
+			// Stored pre-lowered like title_phrase, so the query side can
+			// lowercase the term it looks up and still match.
+			if lowered, ok := lowerStrings(value); ok {
+				doc.Fields[v.keyword] = lowered
+			}
+		}
+		if v.ngram != "" {
+			doc.Fields[v.ngram] = value
+		}
+	}
+}
+
+// lowerStrings lowercases a string or a list of strings, keeping the shape: an
+// array's keyword form is the set of whole elements, not one joined string.
+// Anything else is reported as unusable, so a value that does not match its
+// declared type is left alone rather than mangled.
+func lowerStrings(value any) (any, bool) {
+	switch v := value.(type) {
+	case string:
+		return strings.ToLower(v), true
+	case []string:
+		out := make([]string, len(v))
+		for i, s := range v {
+			out[i] = strings.ToLower(s)
+		}
+		return out, true
+	case []any:
+		out := make([]any, 0, len(v))
+		for _, e := range v {
+			s, ok := e.(string)
+			if !ok {
+				return nil, false
+			}
+			out = append(out, strings.ToLower(s))
+		}
+		return out, true
+	}
+	return nil, false
 }
 
 // GetBleveMappings returns the bleve index mapping for a single

--- a/pkg/storage/unified/search/bleve_mappings_internal_test.go
+++ b/pkg/storage/unified/search/bleve_mappings_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"maps"
 	"slices"
 	"testing"
+	"time"
 
 	"github.com/blevesearch/bleve/v2"
 	"github.com/blevesearch/bleve/v2/analysis/analyzer/keyword"
@@ -547,4 +548,242 @@ func TestCombineFilterAndTextQueries(t *testing.T) {
 	filter, ok := bq.Filter.(*query.ConjunctionQuery)
 	require.True(t, ok)
 	assert.Equal(t, []query.Query{f1, f2}, filter.Conjuncts)
+}
+
+// TestBulkIndexPopulatesFieldVariants indexes a document for a synthetic kind
+// that declares a field with both text and filter capabilities. No in-tree
+// kind declares that combination, so the keyword variant it maps can only be
+// exercised with a kind constructed here.
+func TestBulkIndexPopulatesFieldVariants(t *testing.T) {
+	const group, kindResource = "example.test", "widgets"
+	gvr := schema.GroupVersionResource{Group: group, Version: "v1", Resource: kindResource}
+	provider := resource.NewMapProvider(map[schema.GroupVersionResource][]resource.SearchFieldDefinition{
+		gvr: {
+			{
+				Name: "category",
+				Type: resource.SearchFieldTypeString,
+				Capabilities: []resource.SearchCapability{
+					resource.SearchCapabilityText,
+					resource.SearchCapabilityFilter,
+					resource.SearchCapabilityRetrieve,
+				},
+			},
+			{
+				Name:  "owners",
+				Type:  resource.SearchFieldTypeString,
+				Array: true,
+				Capabilities: []resource.SearchCapability{
+					resource.SearchCapabilityText,
+					resource.SearchCapabilityFilter,
+				},
+			},
+			{
+				Name:         "region",
+				Type:         resource.SearchFieldTypeString,
+				Capabilities: []resource.SearchCapability{resource.SearchCapabilityFilter},
+			},
+		},
+	}, map[schema.GroupResource]string{gvr.GroupResource(): gvr.Version})
+
+	key := resource.NamespacedResource{Namespace: "default", Group: group, Resource: kindResource}
+	backend, err := NewBleveBackend(BleveOptions{
+		Root:          t.TempDir(),
+		FileThreshold: 5, // stay in memory
+		SearchFields: resource.NewSearchFieldsRegistry(nil, nil, map[resource.LowerGroupResource]resource.SearchFieldsProvider{
+			resource.NewLowerGroupResource(group, kindResource): provider,
+		}),
+	}, nil)
+	require.NoError(t, err)
+	t.Cleanup(backend.Stop)
+
+	index, err := backend.BuildIndex(t.Context(), key, 1, "test", func(index resource.ResourceIndex) (int64, error) {
+		return 1, index.BulkIndex(&resource.BulkIndexRequest{
+			Items: []*resource.BulkIndexItem{{
+				Action: resource.ActionIndex,
+				Doc: &resource.IndexableDocument{
+					Key:   &resourcepb.ResourceKey{Namespace: key.Namespace, Group: group, Resource: kindResource, Name: "w1"},
+					Title: "Widget one",
+					Fields: map[string]any{
+						"category": "Time Series",
+						"owners":   []string{"Ops Team", "SRE"},
+						"region":   "US West",
+					},
+				},
+			}},
+		})
+	}, nil, false, time.Time{}, 0)
+	require.NoError(t, err)
+
+	bi, ok := index.(*bleveIndex)
+	require.True(t, ok)
+
+	termHits := func(t *testing.T, field, term string) uint64 {
+		t.Helper()
+		q := bleve.NewTermQuery(term)
+		q.SetField(field)
+		res, err := bi.index.Search(bleve.NewSearchRequest(q))
+		require.NoError(t, err)
+		return res.Total
+	}
+
+	t.Run("keyword variant holds the whole value, lowercased", func(t *testing.T) {
+		assert.Equal(t, uint64(1), termHits(t, "fields.category_keyword", "time series"))
+		// The analyzed variant still only matches single tokens, which is why
+		// the keyword variant is needed for exact matching.
+		assert.Equal(t, uint64(0), termHits(t, "fields.category", "time series"))
+		assert.Equal(t, uint64(1), termHits(t, "fields.category", "series"))
+	})
+
+	t.Run("array keyword variant holds whole elements", func(t *testing.T) {
+		assert.Equal(t, uint64(1), termHits(t, "fields.owners_keyword", "ops team"))
+		assert.Equal(t, uint64(1), termHits(t, "fields.owners_keyword", "sre"))
+		assert.Equal(t, uint64(0), termHits(t, "fields.owners_keyword", "ops"))
+	})
+
+	t.Run("filter-only field keeps its own name", func(t *testing.T) {
+		assert.Equal(t, uint64(1), termHits(t, "fields.region", "US West"))
+		assert.Equal(t, uint64(0), termHits(t, "fields.region_keyword", "us west"))
+	})
+
+	// Re-indexing a document sees the variants the previous pass added, so they
+	// must not be mistaken for values written under an undeclared name.
+	t.Run("variant names count as declared", func(t *testing.T) {
+		assert.True(t, bi.isDeclaredField("fields.category_keyword"))
+		assert.True(t, bi.isDeclaredField("owners_keyword"))
+		assert.False(t, bi.isDeclaredField("fields.region_keyword"))
+	})
+}
+
+// TestNoVariantsForDashboards guards the on-disk shape of the kinds that exist
+// today: none of them declares a text field that also filters, sorts or
+// facets, so no extra field is written and no index has to be rebuilt.
+func TestNoVariantsForDashboards(t *testing.T) {
+	provider := DashboardSearchFieldsProviderForTest()
+	assert.Empty(t, fieldVariantsOf(fieldDefinitionsForMapping(provider, "dashboard.grafana.app", "dashboards")))
+}
+
+func TestFieldVariantsOf(t *testing.T) {
+	str := func(caps ...resource.SearchCapability) resource.SearchFieldDefinition {
+		return resource.SearchFieldDefinition{Name: "field", Type: resource.SearchFieldTypeString, Capabilities: caps}
+	}
+
+	tests := []struct {
+		name string
+		def  resource.SearchFieldDefinition
+		want []fieldVariant
+	}{
+		{
+			name: "text and filter",
+			def:  str(resource.SearchCapabilityText, resource.SearchCapabilityFilter),
+			want: []fieldVariant{{field: "field", keyword: "field_keyword"}},
+		},
+		{
+			name: "text and facet",
+			def:  str(resource.SearchCapabilityText, resource.SearchCapabilityFacet),
+			want: []fieldVariant{{field: "field", keyword: "field_keyword"}},
+		},
+		{
+			name: "text and sort",
+			def:  str(resource.SearchCapabilityText, resource.SearchCapabilitySort),
+			want: []fieldVariant{{field: "field", keyword: "field_keyword"}},
+		},
+		{
+			name: "partial",
+			def:  str(resource.SearchCapabilityText, resource.SearchCapabilityPartial),
+			want: []fieldVariant{{field: "field", ngram: "field_ngram"}},
+		},
+		{
+			name: "text, filter and partial",
+			def:  str(resource.SearchCapabilityText, resource.SearchCapabilityFilter, resource.SearchCapabilityPartial),
+			want: []fieldVariant{{field: "field", keyword: "field_keyword", ngram: "field_ngram"}},
+		},
+		{
+			name: "filter only is keyword-analyzed under its own name",
+			def:  str(resource.SearchCapabilityFilter, resource.SearchCapabilityRetrieve),
+		},
+		{
+			name: "text only has no keyword mapping to fill in",
+			def:  str(resource.SearchCapabilityText, resource.SearchCapabilityRetrieve),
+		},
+		{
+			name: "retrieve only",
+			def:  str(resource.SearchCapabilityRetrieve),
+		},
+		{
+			name: "non-string fields keep their native form",
+			def: resource.SearchFieldDefinition{Name: "field", Type: resource.SearchFieldTypeInt64,
+				Capabilities: []resource.SearchCapability{resource.SearchCapabilityFilter, resource.SearchCapabilitySort}},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, fieldVariantsOf([]resource.SearchFieldDefinition{tc.def}))
+		})
+	}
+}
+
+func TestPopulateFieldVariants(t *testing.T) {
+	variants := fieldVariantsOf([]resource.SearchFieldDefinition{
+		{
+			Name:         "category",
+			Type:         resource.SearchFieldTypeString,
+			Capabilities: []resource.SearchCapability{resource.SearchCapabilityText, resource.SearchCapabilityFilter},
+		},
+		{
+			Name:  "owners",
+			Type:  resource.SearchFieldTypeString,
+			Array: true,
+			Capabilities: []resource.SearchCapability{resource.SearchCapabilityText, resource.SearchCapabilityFilter,
+				resource.SearchCapabilityPartial},
+		},
+		{
+			Name:         "region",
+			Type:         resource.SearchFieldTypeString,
+			Capabilities: []resource.SearchCapability{resource.SearchCapabilityFilter},
+		},
+		{
+			Name:         "linkCount",
+			Type:         resource.SearchFieldTypeInt64,
+			Capabilities: []resource.SearchCapability{resource.SearchCapabilityFilter, resource.SearchCapabilitySort},
+		},
+	})
+
+	t.Run("writes lowercased whole values", func(t *testing.T) {
+		doc := &resource.IndexableDocument{Fields: map[string]any{
+			"category":  "Time Series",
+			"owners":    []string{"Ops Team", "SRE"},
+			"region":    "US West",
+			"linkCount": int64(3),
+		}}
+		populateFieldVariants(doc, variants)
+
+		assert.Equal(t, map[string]any{
+			"category":         "Time Series",
+			"category_keyword": "time series",
+			"owners":           []string{"Ops Team", "SRE"},
+			"owners_keyword":   []string{"ops team", "sre"},
+			"owners_ngram":     []string{"Ops Team", "SRE"},
+			"region":           "US West",
+			"linkCount":        int64(3),
+		}, doc.Fields)
+	})
+
+	t.Run("handles the []any shape the path extractor produces", func(t *testing.T) {
+		doc := &resource.IndexableDocument{Fields: map[string]any{"owners": []any{"Ops Team"}}}
+		populateFieldVariants(doc, variants)
+		assert.Equal(t, []any{"ops team"}, doc.Fields["owners_keyword"])
+	})
+
+	t.Run("absent fields stay absent", func(t *testing.T) {
+		doc := &resource.IndexableDocument{Fields: map[string]any{"region": "US West"}}
+		populateFieldVariants(doc, variants)
+		assert.Equal(t, map[string]any{"region": "US West"}, doc.Fields)
+	})
+
+	t.Run("a value that does not match its declared type is left alone", func(t *testing.T) {
+		doc := &resource.IndexableDocument{Fields: map[string]any{"category": 42}}
+		populateFieldVariants(doc, variants)
+		assert.Equal(t, map[string]any{"category": 42}, doc.Fields)
+	})
 }


### PR DESCRIPTION
A search field declared by a kind can be indexed in more than one way. A field asking for both text search and exact filtering is mapped twice: the analyzed form under its own name, and the whole value under `<name>_keyword`. Only the standard `title` field ever had its extra fields filled in, so for a per-kind field that second field was mapped but always empty and queries against it matched nothing.

This writes those values when the document is indexed. The names come from the same two functions the mapping builder uses, so a mapped field cannot end up unwritten. Keyword values are stored lowercased like `title_phrase`, and an array's keyword form is the set of whole elements.

`title` and the query path are unchanged — this only makes the values available for the query-side change that follows.

Existing indexes are not rebuilt. No kind in this repo declares a text field that also filters, sorts or facets, so nothing changes shape and there is nothing to rebuild. A kind declaring that combination through an out-of-repo manifest fills the field in as its documents are updated.

Part of grafana/search-and-storage-team#869.
