### PR TITLE
NavTree: Fix nav items injected by hooks missing when parent admin section is empty

### DIFF
--- a/pkg/services/navtree/models.go
+++ b/pkg/services/navtree/models.go
@@ -136,13 +136,16 @@ func (root *NavTreeRoot) Sort() {
 	Sort(root.Children)
 }
 
-// RemoveEmptyAdminSections removes the Users and access section if it has no children
-// (e.g. grafana-auth-app was not injected), then removes the entire Administration
-// section if it ended up empty. This must be called AFTER all hooks have had a chance
-// to add their nav items.
+// RemoveEmptyAdminSections removes the General, Plugins and data, and Users and access
+// sections if they have no children (their children can be injected by hooks, e.g.
+// banner settings, recorded queries or grafana-auth-app), then removes the entire
+// Administration section if it ended up empty. This must be called AFTER all hooks
+// have had a chance to add their nav items.
 func (root *NavTreeRoot) RemoveEmptyAdminSections() {
-	if sec := root.FindById(NavIDCfgAccess); sec != nil && len(sec.Children) == 0 {
-		root.RemoveSectionByID(NavIDCfgAccess)
+	for _, id := range []string{NavIDCfgGeneral, NavIDCfgPlugins, NavIDCfgAccess} {
+		if sec := root.FindById(id); sec != nil && len(sec.Children) == 0 {
+			root.RemoveSectionByID(id)
+		}
 	}
 	if sec := root.FindById(NavIDCfg); sec != nil && len(sec.Children) == 0 {
 		root.RemoveSectionByID(NavIDCfg)

--- a/pkg/services/navtree/models_test.go
+++ b/pkg/services/navtree/models_test.go
@@ -44,4 +44,36 @@ func TestNavTreeRoot(t *testing.T) {
 		require.Equal(t, "2", treeRoot.FindByURL("/org").Id)
 		require.Equal(t, "3", treeRoot.FindByURL("/org/users").Id)
 	})
+
+	t.Run("RemoveEmptyAdminSections removes empty admin subsections", func(t *testing.T) {
+		treeRoot := NavTreeRoot{
+			Children: []*NavLink{
+				{Id: NavIDCfg, Children: []*NavLink{
+					{Id: NavIDCfgGeneral},
+					{Id: NavIDCfgPlugins},
+					{Id: NavIDCfgAccess},
+				}},
+			},
+		}
+		treeRoot.RemoveEmptyAdminSections()
+		require.Nil(t, treeRoot.FindById(NavIDCfgGeneral))
+		require.Nil(t, treeRoot.FindById(NavIDCfgPlugins))
+		require.Nil(t, treeRoot.FindById(NavIDCfgAccess))
+		require.Nil(t, treeRoot.FindById(NavIDCfg))
+	})
+
+	t.Run("RemoveEmptyAdminSections keeps subsections populated by hooks", func(t *testing.T) {
+		treeRoot := NavTreeRoot{
+			Children: []*NavLink{
+				{Id: NavIDCfg, Children: []*NavLink{
+					{Id: NavIDCfgGeneral, Children: []*NavLink{{Id: "banner-settings"}}},
+					{Id: NavIDCfgPlugins},
+				}},
+			},
+		}
+		treeRoot.RemoveEmptyAdminSections()
+		require.NotNil(t, treeRoot.FindById(NavIDCfgGeneral))
+		require.Nil(t, treeRoot.FindById(NavIDCfgPlugins))
+		require.NotNil(t, treeRoot.FindById(NavIDCfg))
+	})
 }

--- a/pkg/services/navtree/navtreeimpl/admin.go
+++ b/pkg/services/navtree/navtreeimpl/admin.go
@@ -73,9 +73,9 @@ func (s *ServiceImpl) getAdminNode(c *contextmodel.ReqContext) (*navtree.NavLink
 		Children: generalNodeLinks,
 	}
 
-	if len(generalNode.Children) > 0 {
-		configNodes = append(configNodes, generalNode)
-	}
+	// Always append: index data hooks can inject children (e.g. banner settings),
+	// so pruning when empty is deferred to RemoveEmptyAdminSections.
+	configNodes = append(configNodes, generalNode)
 
 	pluginsNodeLinks := []*navtree.NavLink{}
 	// FIXME: If plugin admin is disabled or externally managed, server admins still need to access the page, this is why
@@ -119,9 +119,9 @@ func (s *ServiceImpl) getAdminNode(c *contextmodel.ReqContext) (*navtree.NavLink
 		Children: pluginsNodeLinks,
 	}
 
-	if len(pluginsNode.Children) > 0 {
-		configNodes = append(configNodes, pluginsNode)
-	}
+	// Always append: index data hooks can inject children (e.g. recorded queries),
+	// so pruning when empty is deferred to RemoveEmptyAdminSections.
+	configNodes = append(configNodes, pluginsNode)
 
 	accessNodeLinks := []*navtree.NavLink{}
 	if hasAccess(ac.EvalAny(ac.EvalPermission(ac.ActionOrgUsersRead), ac.EvalPermission(ac.ActionUsersRead, ac.ScopeGlobalUsersAll))) {


### PR DESCRIPTION
**What is this feature?**

Always creates the Administration > General (`cfg/general`) and Administration > Plugins and data (`cfg/plugins`) nav sections at build time, and prunes them when empty in `RemoveEmptyAdminSections` instead — after index data hooks have run. This is the same deferred-pruning pattern already used for Users and access (`cfg/access`).

**Why do we need this feature?**

These sections were previously dropped at build time if none of their OSS-defined children qualified, before index data hooks had a chance to inject their nav items. A user whose only relevant permission matched a hook-injected item (e.g. the announcement banner settings page via `fixed:banners:writer`) wouldn't see the item in the nav at all — the hook's `FindById` lookup found no parent section to attach to, and the page was only reachable by direct URL. Confusingly, granting an unrelated permission that qualified one of the OSS children (e.g. `migrationassistant:migrate`) made the hook-injected item appear.

Net behaviour for users with no matching permissions is unchanged: empty sections are still pruned, just after hooks run rather than before.

**Who is this feature for?**

Users granted fine-grained RBAC roles whose admin pages are registered via index data hooks (e.g. announcement banner settings, recorded queries), without a broader admin basic role.

**Which issue(s) does this PR fix?**:

**Special notes for your reviewer:**

Unit tests cover the pruning/ordering logic. Verifying the end-to-end symptom (banner nav item visible with only `fixed:banners:writer`) needs an enterprise build, since the affected nav items are injected by enterprise hooks.
