### PR TITLE
Search: derive free-text query type from the field's mapping

### DIFF
--- a/pkg/storage/unified/proto/search.proto
+++ b/pkg/storage/unified/proto/search.proto
@@ -61,8 +61,8 @@ message ResourceStatsResponse {
   repeated Stats stats = 2;
 }
 
-// This controls what query and analyzers are applied to the specified field
-// See: https://blevesearch.com/docs/Analyzers/
+// Obsolete: the server derives the query and analyzer from how the field is
+// mapped, so this is ignored. Goes away once no client sends it.
 enum QueryFieldType {
   // Picks a reasonable analyzer given the input.  Currently this always uses TEXT
   // In the future, it may change to depend on the indexed field type
@@ -96,6 +96,7 @@ message ResourceSearchRequest {
     // The field name in the index to query
     string name = 1;
 
+    // Obsolete: ignored by the server. Kept because older clients still set it.
     QueryFieldType type = 2;
 
     // Boost value for this field
@@ -139,9 +140,10 @@ message ResourceSearchRequest {
   int64 permission = 12;
 
   // Optionally specify which fields are included in the query.
-  // For non-wildcard queries, type and boost control how each field is searched.
+  // For non-wildcard queries, boost weights how much each field contributes to
+  // the score; the query type comes from the field's mapping.
   // For wildcard queries (containing '*'), only the field name is used;
-  // type and boost are ignored because bleve wildcards don't support analyzers
+  // boost is ignored because bleve wildcards don't support analyzers
   // or meaningful relevance scoring.
   repeated QueryField query_fields = 13;
 

--- a/pkg/storage/unified/resourcepb/search.pb.go
+++ b/pkg/storage/unified/resourcepb/search.pb.go
@@ -21,8 +21,8 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
-// This controls what query and analyzers are applied to the specified field
-// See: https://blevesearch.com/docs/Analyzers/
+// Obsolete: the server derives the query and analyzer from how the field is
+// mapped, so this is ignored. Goes away once no client sends it.
 type QueryFieldType int32
 
 const (
@@ -233,9 +233,10 @@ type ResourceSearchRequest struct {
 	Page       int64 `protobuf:"varint,11,opt,name=page,proto3" json:"page,omitempty"`
 	Permission int64 `protobuf:"varint,12,opt,name=permission,proto3" json:"permission,omitempty"`
 	// Optionally specify which fields are included in the query.
-	// For non-wildcard queries, type and boost control how each field is searched.
+	// For non-wildcard queries, boost weights how much each field contributes to
+	// the score; the query type comes from the field's mapping.
 	// For wildcard queries (containing '*'), only the field name is used;
-	// type and boost are ignored because bleve wildcards don't support analyzers
+	// boost is ignored because bleve wildcards don't support analyzers
 	// or meaningful relevance scoring.
 	QueryFields []*ResourceSearchRequest_QueryField `protobuf:"bytes,13,rep,name=query_fields,json=queryFields,proto3" json:"query_fields,omitempty"`
 	// Sort values for SearchAfter pagination.
@@ -1357,7 +1358,8 @@ func (x *ResourceSearchRequest_Facet) GetLimit() int64 {
 type ResourceSearchRequest_QueryField struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The field name in the index to query
-	Name string         `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	// Obsolete: ignored by the server. Kept because older clients still set it.
 	Type QueryFieldType `protobuf:"varint,2,opt,name=type,proto3,enum=resource.QueryFieldType" json:"type,omitempty"`
 	// Boost value for this field
 	Boost         float32 `protobuf:"fixed32,3,opt,name=boost,proto3" json:"boost,omitempty"`

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -824,6 +824,7 @@ func (b *bleveBackend) BuildIndex(
 	idx := b.newBleveIndex(key, prepared.index, prepared.indexStorage, fields, allFields, standardSearchFields, updater, b.log.New("namespace", key.Namespace, "group", key.Group, "resource", key.Resource))
 	idx.facetFieldByRequestName = facetFieldsForMapping(searchFieldsProvider, key.Group, key.Resource)
 	idx.fieldVariants = fieldVariantsOf(fieldDefinitionsForMapping(searchFieldsProvider, key.Group, key.Resource))
+	idx.textQueryKinds = textQueryKindsForMapping(searchFieldsProvider, key.Group, key.Resource, selectableFields)
 
 	if prepared.source.needsBuild() {
 		// Type-convert so buildIndexFromScratch can call updateResourceVersion after the builder returns.
@@ -1239,6 +1240,7 @@ func (b *bleveBackend) promoteBuildIndexToFile(
 	promoted := b.newBleveIndex(key, fileIndex, indexStorageFile, fields, allFields, standardSearchFields, updater, delegate.logger)
 	promoted.facetFieldByRequestName = delegate.facetFieldByRequestName
 	promoted.fieldVariants = delegate.fieldVariants
+	promoted.textQueryKinds = delegate.textQueryKinds
 	promoted.resourceVersion.Store(delegate.resourceVersion.Load())
 	cleanup = false
 
@@ -1622,6 +1624,9 @@ type bleveIndex struct {
 	// variant fields this kind's mapping declares. Derived from the same
 	// declarations as the mapping, once per index rather than per document.
 	fieldVariants []fieldVariant
+	// textQueryKinds maps physical index field names to the query their
+	// analyzer needs.
+	textQueryKinds map[string]textQueryKind
 
 	indexStorage string // memory or file, used when updating metrics
 
@@ -2524,49 +2529,59 @@ func (b *bleveIndex) buildTextQuery(searchrequest *bleve.SearchRequest, req *res
 	queryFields := b.resolveQueryFields(req.QueryFields)
 
 	for _, field := range queryFields {
-		switch field.Type {
-		case resourcepb.QueryFieldType_TEXT, resourcepb.QueryFieldType_DEFAULT:
+		kind := b.textQueryKindFor(field.Name)
+		switch kind {
+		case textQueryTerm, textQueryTermLowered:
+			// Bleve TermQuery is an exact token lookup: it does not analyze or lowercase the query.
+			term := req.Query
+			if kind == textQueryTermLowered {
+				term = strings.ToLower(term)
+			}
+			q := bleve.NewTermQuery(term)
+			q.SetBoost(float64(field.Boost))
+			q.SetField(field.Name)
+			disjoin.AddQuery(q)
+
+		case textQueryNgram, textQueryStandard:
 			q := bleve.NewMatchQuery(removeSmallTerms(req.Query)) // removeSmallTerms should be part of the analyzer
 			q.SetBoost(float64(field.Boost))
 			q.SetField(field.Name)
-			// Match the analyzer used to index each field: the ngram field
+			// Match the analyzer used to index each field: the ngram variant
 			// must be analyzed with TITLE_ANALYZER, not the standard analyzer
 			// (which splits on punctuation and drops sub-ngram-length fragments).
-			if field.Name == resource.SEARCH_FIELD_TITLE_NGRAM {
+			if kind == textQueryNgram {
 				q.Analyzer = TITLE_ANALYZER
 			} else {
 				q.Analyzer = standard.Name
 			}
 			q.Operator = query.MatchQueryOperatorAnd // all terms must match
 			disjoin.AddQuery(q)
-
-		case resourcepb.QueryFieldType_KEYWORD:
-			// Bleve TermQuery is an exact token lookup: it does not analyze or lowercase the query.
-			q := bleve.NewTermQuery(strings.ToLower(req.Query))
-			q.SetBoost(float64(field.Boost))
-			q.SetField(field.Name)
-			disjoin.AddQuery(q)
-
-		case resourcepb.QueryFieldType_PHRASE:
-			// Bleve phrase queries are different from our title_phrase field: they match adjacent analyzed tokens.
-			q := bleve.NewMatchPhraseQuery(req.Query)
-			q.SetBoost(float64(field.Boost))
-			q.SetField(field.Name)
-			q.Analyzer = standard.Name
-			disjoin.AddQuery(q)
 		}
 	}
 	return disjoin
 }
 
+// textQueryKindFor reports how a physical index field has to be queried.
+func (b *bleveIndex) textQueryKindFor(name string) textQueryKind {
+	if kind, ok := b.textQueryKinds[name]; ok {
+		return kind
+	}
+	if strings.HasPrefix(name, referenceFieldPrefix) {
+		return textQueryTerm
+	}
+	// Undeclared fields (dynamically indexed, or named by a client we don't know
+	// about) keep the analyzed default.
+	return textQueryStandard
+}
+
 // titleQueryFields expands a text query on the logical title field across its
 // three physical variants: exact (title_phrase), word-level (title), and partial
-// (title_ngram), each with the query type its analyzer needs.
+// (title_ngram). The query each variant needs comes from its mapping.
 func titleQueryFields() []*resourcepb.ResourceSearchRequest_QueryField {
 	return []*resourcepb.ResourceSearchRequest_QueryField{
-		{Name: resource.SEARCH_FIELD_TITLE_PHRASE, Type: resourcepb.QueryFieldType_KEYWORD, Boost: 10}, // exact title match (case-insensitive via pre-lowered title_phrase)
-		{Name: resource.SEARCH_FIELD_TITLE, Type: resourcepb.QueryFieldType_TEXT, Boost: 2},            // standard analyzer (word-level matching)
-		{Name: resource.SEARCH_FIELD_TITLE_NGRAM, Type: resourcepb.QueryFieldType_TEXT, Boost: 1},      // ngram analyzer (partial/prefix matching)
+		{Name: resource.SEARCH_FIELD_TITLE_PHRASE, Boost: 10}, // exact title match (case-insensitive via pre-lowered title_phrase)
+		{Name: resource.SEARCH_FIELD_TITLE, Boost: 2},         // standard analyzer (word-level matching)
+		{Name: resource.SEARCH_FIELD_TITLE_NGRAM, Boost: 1},   // ngram analyzer (partial/prefix matching)
 	}
 }
 
@@ -2593,9 +2608,9 @@ func (b *bleveIndex) resolveQueryFields(requested []*resourcepb.ResourceSearchRe
 			out = append(out, titleQueryFields()...)
 			continue
 		}
+		// Type is dropped: the query comes from the field's mapping.
 		out = append(out, &resourcepb.ResourceSearchRequest_QueryField{
 			Name:  resolveFieldName(b.fields, f.Name),
-			Type:  f.Type,
 			Boost: f.Boost,
 		})
 	}

--- a/pkg/storage/unified/search/bleve_mappings.go
+++ b/pkg/storage/unified/search/bleve_mappings.go
@@ -50,6 +50,79 @@ func facetFieldsForMapping(provider resource.SearchFieldsProvider, group, kindRe
 	return fields
 }
 
+// textQueryKind is the free-text query a physical index field needs, so callers
+// don't have to know how the field is analyzed.
+type textQueryKind int
+
+const (
+	textQueryStandard textQueryKind = iota // standard analyzer
+	textQueryNgram                         // ngram analyzer
+	textQueryTerm                          // keyword analyzer, exact token
+	// textQueryTermLowered is a keyword field holding a copy of another field's
+	// value. Those copies are written lowercased, so the term looked up has to
+	// be lowercased too.
+	textQueryTermLowered
+)
+
+// textQueryKindsForMapping derives the query kind of every physical index field
+// from the same declarations that produced the mapping, so the two cannot drift
+// apart (see addCapabilityFieldMappings).
+func textQueryKindsForMapping(provider resource.SearchFieldsProvider, group, kindResource string, selectableFields []string) map[string]textQueryKind {
+	kinds := map[string]textQueryKind{}
+	add := func(def resource.SearchFieldDefinition, prefix string) {
+		// Non-string fields are never analyzed.
+		if def.Type != resource.SearchFieldTypeString {
+			return
+		}
+		if def.HasCapability(resource.SearchCapabilityText) {
+			kinds[prefix+def.Name] = textQueryStandard
+		}
+		if name, ok := ngramVariant(def); ok {
+			kinds[prefix+name] = textQueryNgram
+		}
+		if name, ok := keywordVariant(def); ok {
+			// A keyword form under its own name is the value as indexed; under a
+			// different name it is a lowercased copy (see populateFieldVariants
+			// and UpdateCopyFields for title).
+			kind := textQueryTerm
+			if name != def.Name {
+				kind = textQueryTermLowered
+			}
+			kinds[prefix+name] = kind
+		}
+	}
+
+	for _, def := range resource.StandardSearchFieldDefinitions() {
+		add(def, "")
+	}
+	for _, def := range fieldDefinitionsForMapping(provider, group, kindResource) {
+		add(def, resource.SEARCH_FIELD_PREFIX)
+	}
+	// Selectable fields are keyword-mapped (see getBleveDocMappings).
+	for _, name := range selectableFields {
+		kinds[resource.SEARCH_SELECTABLE_FIELDS_PREFIX+name] = textQueryTerm
+	}
+	for _, name := range keywordSubDocumentFields {
+		kinds[name] = textQueryTerm
+	}
+	return kinds
+}
+
+// keywordSubDocumentFields are keyword-mapped fields that live in sub-documents
+// and so are not modellable as SearchFieldDefinitions yet (see
+// managerSubDocumentMapping and sourceSubDocumentMapping). The labels
+// sub-document is deliberately absent: it has no keyword default analyzer.
+var keywordSubDocumentFields = []string{
+	resource.SEARCH_FIELD_MANAGER_KIND,
+	resource.SEARCH_FIELD_MANAGER_ID,
+	resource.SEARCH_FIELD_SOURCE_PATH,
+	resource.SEARCH_FIELD_SOURCE_CHECKSUM,
+}
+
+// referenceFieldPrefix is the keyword-analyzed reference sub-document. Its keys
+// are resource kinds, so they cannot be enumerated up front.
+const referenceFieldPrefix = "reference."
+
 // addCapabilityFieldMappings adds bleve field mappings to parent for a single
 // declared search field. The field is placed under parent using def.Name as
 // the local name; this helper does not add any sub-document prefix (callers
@@ -331,7 +404,7 @@ func getBleveDocMappings(provider resource.SearchFieldsProvider, group, kindReso
 	// override these on a DocumentMapping — only on individual FieldMappings.
 	referenceMapper := bleve.NewDocumentMapping()
 	referenceMapper.DefaultAnalyzer = keyword.Name
-	mapper.AddSubDocumentMapping("reference", referenceMapper)
+	mapper.AddSubDocumentMapping(strings.TrimSuffix(referenceFieldPrefix, "."), referenceMapper)
 
 	labelMapper := bleve.NewDocumentMapping()
 	mapper.AddSubDocumentMapping(resource.SEARCH_FIELD_LABELS, labelMapper)

--- a/pkg/storage/unified/search/bleve_mappings_internal_test.go
+++ b/pkg/storage/unified/search/bleve_mappings_internal_test.go
@@ -246,6 +246,81 @@ func TestFacetFieldsForMapping(t *testing.T) {
 	assert.NotContains(t, fields, "labels.region")
 }
 
+func TestTextQueryKindsForMapping(t *testing.T) {
+	gvr := schema.GroupVersionResource{Group: "example.grafana.app", Version: "v1", Resource: "widgets"}
+	provider := resource.NewMapProvider(map[schema.GroupVersionResource][]resource.SearchFieldDefinition{
+		gvr: {
+			{
+				Name: "panel_title",
+				Type: resource.SearchFieldTypeString,
+				Capabilities: []resource.SearchCapability{
+					resource.SearchCapabilityText,
+					resource.SearchCapabilityPartial,
+				},
+			},
+			{
+				Name:         "team",
+				Type:         resource.SearchFieldTypeString,
+				Capabilities: []resource.SearchCapability{resource.SearchCapabilityFilter},
+			},
+			{
+				Name:         "summary",
+				Type:         resource.SearchFieldTypeString,
+				Capabilities: []resource.SearchCapability{resource.SearchCapabilityText, resource.SearchCapabilityFilter},
+			},
+			{
+				Name:         "linkCount",
+				Type:         resource.SearchFieldTypeInt64,
+				Capabilities: []resource.SearchCapability{resource.SearchCapabilityFilter},
+			},
+		},
+	}, nil)
+
+	kinds := textQueryKindsForMapping(provider, gvr.Group, gvr.Resource, []string{"spec.slug"})
+
+	// The title trio: each variant gets the query its analyzer needs.
+	assert.Equal(t, textQueryStandard, kinds[resource.SEARCH_FIELD_TITLE])
+	assert.Equal(t, textQueryNgram, kinds[resource.SEARCH_FIELD_TITLE_NGRAM])
+	// title_phrase holds a lowercased copy of the title.
+	assert.Equal(t, textQueryTermLowered, kinds[resource.SEARCH_FIELD_TITLE_PHRASE])
+
+	// Other standard fields.
+	assert.Equal(t, textQueryStandard, kinds[resource.SEARCH_FIELD_DESCRIPTION])
+	assert.Equal(t, textQueryTerm, kinds[resource.SEARCH_FIELD_FOLDER])
+	assert.Equal(t, textQueryTerm, kinds[resource.SEARCH_FIELD_TAGS])
+
+	// Per-kind fields live under fields.*
+	assert.Equal(t, textQueryStandard, kinds["fields.panel_title"])
+	assert.Equal(t, textQueryNgram, kinds["fields.panel_title_ngram"])
+	// team is keyword-mapped in place, so it keeps the value's case, while
+	// summary_keyword is a lowercased copy of the text field.
+	assert.Equal(t, textQueryTerm, kinds["fields.team"])
+	assert.Equal(t, textQueryStandard, kinds["fields.summary"])
+	assert.Equal(t, textQueryTermLowered, kinds["fields.summary_keyword"])
+
+	// Non-string fields are never analyzed, so they are absent.
+	assert.NotContains(t, kinds, "fields.linkCount")
+
+	// Selectable fields are keyword-mapped.
+	assert.Equal(t, textQueryTerm, kinds[resource.SEARCH_SELECTABLE_FIELDS_PREFIX+"spec.slug"])
+
+	// Keyword-mapped sub-document fields, and labels which are not.
+	assert.Equal(t, textQueryTerm, kinds[resource.SEARCH_FIELD_MANAGER_KIND])
+	assert.Equal(t, textQueryTerm, kinds[resource.SEARCH_FIELD_SOURCE_PATH])
+	assert.NotContains(t, kinds, resource.SEARCH_FIELD_LABELS+".region")
+
+	// An index without per-kind fields still knows the standard ones.
+	assert.Equal(t, textQueryTermLowered, textQueryKindsForMapping(nil, "", "", nil)[resource.SEARCH_FIELD_TITLE_PHRASE])
+}
+
+func TestBleveIndex_textQueryKindFor(t *testing.T) {
+	b := &bleveIndex{textQueryKinds: map[string]textQueryKind{resource.SEARCH_FIELD_TITLE_PHRASE: textQueryTerm}}
+	assert.Equal(t, textQueryTerm, b.textQueryKindFor(resource.SEARCH_FIELD_TITLE_PHRASE))
+	// reference keys are dynamic, so the keyword sub-document is matched by prefix.
+	assert.Equal(t, textQueryTerm, b.textQueryKindFor("reference.datasource"))
+	// Undeclared fields fall back to the analyzed query.
+	assert.Equal(t, textQueryStandard, b.textQueryKindFor(resource.SEARCH_FIELD_LABELS+".region"))
+}
 func TestAddCapabilityFieldMappings_RetrieveOnly_StoreOnly(t *testing.T) {
 	// With no dynamic fallback, a retrieve-only field must be stored explicitly.
 	t.Run("int64", func(t *testing.T) {
@@ -490,11 +565,12 @@ func TestBleveIndex_resolveQueryFields(t *testing.T) {
 	// An explicit title field fans out the same way.
 	assert.Equal(t, titleVariants, names(b.resolveQueryFields([]*resourcepb.ResourceSearchRequest_QueryField{{Name: resource.SEARCH_FIELD_TITLE}})))
 
-	// A per-kind field resolves to fields.* and keeps its requested type/boost.
-	got := b.resolveQueryFields([]*resourcepb.ResourceSearchRequest_QueryField{{Name: "panel_title", Type: resourcepb.QueryFieldType_TEXT, Boost: 3}})
+	// A per-kind field resolves to fields.* and keeps its requested boost. The
+	// requested type is dropped: the backend derives it from the mapping.
+	got := b.resolveQueryFields([]*resourcepb.ResourceSearchRequest_QueryField{{Name: "panel_title", Type: resourcepb.QueryFieldType_KEYWORD, Boost: 3}})
 	require.Len(t, got, 1)
 	assert.Equal(t, resource.SEARCH_FIELD_PREFIX+"panel_title", got[0].Name)
-	assert.Equal(t, resourcepb.QueryFieldType_TEXT, got[0].Type)
+	assert.Equal(t, resourcepb.QueryFieldType_DEFAULT, got[0].Type)
 	assert.Equal(t, float32(3), got[0].Boost)
 
 	// title + per-kind field: title variants first, then the resolved field.

--- a/pkg/storage/unified/search/bleve_search_test.go
+++ b/pkg/storage/unified/search/bleve_search_test.go
@@ -767,15 +767,24 @@ func TestPublicFieldNameTextQuery(t *testing.T) {
 		{Action: resource.ActionIndex, Doc: &resource.IndexableDocument{RV: 1, Name: "d2", Title: "Two",
 			Key:    &resourcepb.ResourceKey{Name: "d2", Namespace: key.Namespace, Group: key.Group, Resource: key.Resource},
 			Fields: map[string]any{"team": "blueteam"}}},
+		{Action: resource.ActionIndex, Doc: &resource.IndexableDocument{RV: 1, Name: "d3", Title: "Three",
+			Key:    &resourcepb.ResourceKey{Name: "d3", Namespace: key.Namespace, Group: key.Group, Resource: key.Resource},
+			Fields: map[string]any{"team": "GreenTeam"}}},
 	}}))
 
-	req := &resourcepb.ResourceSearchRequest{
-		Options:     &resourcepb.ListOptions{Key: &resourcepb.ResourceKey{Namespace: key.Namespace, Group: key.Group, Resource: key.Resource}},
-		Query:       "redteam",
-		QueryFields: []*resourcepb.ResourceSearchRequest_QueryField{{Name: "team", Type: resourcepb.QueryFieldType_TEXT, Boost: 1}},
-		Limit:       100000,
+	query := func(text string) *resourcepb.ResourceSearchRequest {
+		return &resourcepb.ResourceSearchRequest{
+			Options:     &resourcepb.ListOptions{Key: &resourcepb.ResourceKey{Namespace: key.Namespace, Group: key.Group, Resource: key.Resource}},
+			Query:       text,
+			QueryFields: []*resourcepb.ResourceSearchRequest_QueryField{{Name: "team", Type: resourcepb.QueryFieldType_TEXT, Boost: 1}},
+			Limit:       100000,
+		}
 	}
-	checkSearchQuery(t, index, req, []string{"d1"})
+
+	checkSearchQuery(t, index, query("redteam"), []string{"d1"})
+	// team is keyword-mapped, so its stored value keeps its case and an exact
+	// query has to match it as written.
+	checkSearchQuery(t, index, query("GreenTeam"), []string{"d3"})
 }
 
 func newTestDashboardsIndex(t testing.TB, threshold int64, size int64, writer resource.BuildFn) resource.ResourceIndex {

--- a/pkg/storage/unified/testing/benchmark.go
+++ b/pkg/storage/unified/testing/benchmark.go
@@ -536,7 +536,6 @@ func runStorageAndSearchBenchmark(
 				QueryFields: []*resourcepb.ResourceSearchRequest_QueryField{
 					{
 						Name: resource.SEARCH_FIELD_TITLE_PHRASE,
-						Type: resourcepb.QueryFieldType_KEYWORD,
 					},
 				},
 				Limit: 10,


### PR DESCRIPTION
`ResourceSearchRequest.QueryFields` carries a per-field `Type` (`TEXT`, `KEYWORD`, `PHRASE`) telling the search backend how to query each field. The backend now works that out for itself and ignores what the client sent. Which query suits a field follows from how it is indexed and analyzed, which the backend already knows, so asking clients for it puts index details into the wire contract and lets a caller ask for a query the field's analyzer cannot serve. Boost stays, since that is a real caller preference.

The derivation reuses the same declarations that build the Bleve mapping, so the two cannot disagree: text fields get an analyzed match, partial variants the ngram analyzer, keyword fields an exact term lookup. Nothing changes for current callers — the title fields keep the same three queries and the same 10 / 2 / 1 weighting, and the dashboard search snapshots that hard-code BM25 scores are unchanged. Free-text queries aimed at keyword-only fields are now matched as a whole value instead of being split into words. The `PHRASE` type is dropped; nothing in grafana or grafana-enterprise ever set it.

Server side only, so it can go out on its own — clients that still send `Type` are unaffected. Follow-up once this has rolled out: stop setting `Type` in the dashboard, IAM and search v1 callers, then remove the field from the proto with its number reserved.

Part of grafana/search-and-storage-team#806, builds on #129080.
