### PR TITLE
Datasources: Capture per-stage server-side expression evidence in diagnostics bundles

### DIFF
--- a/pkg/api/ds_query_dashboard_diagnostics.go
+++ b/pkg/api/ds_query_dashboard_diagnostics.go
@@ -15,6 +15,7 @@ import (
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/expr/exprcapture"
 	"github.com/grafana/grafana/pkg/infra/httpclient/harcapture"
 	"github.com/grafana/grafana/pkg/services/contexthandler"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
@@ -406,8 +407,10 @@ func (hs *HTTPServer) buildDashboardDiagnosticsArchive(ctx context.Context, user
 		}
 
 		pctx, harBuffer := harcapture.WithCapture(ctx) // capture each panel independently
+		pctx, exprBuffer := exprcapture.WithCapture(pctx)
 		resp, err := queryData(pctx, user, skipDSCache, p.MetricRequest)
 		panel.HARBuffer = harBuffer
+		panel.ExpressionStages = exprBuffer.Stages()
 		panel.Resp = resp // carries external (gRPC) plugins' __har__ capture frames, merged in BuildDashboard
 		// A datasource query usually fails per-refId (DataResponse.Error) with no top-level error
 		// (see diagnostics.ResponseError doc) -- capture that too, or a failed panel would be recorded

--- a/pkg/api/ds_query_diagnostics.go
+++ b/pkg/api/ds_query_diagnostics.go
@@ -110,7 +110,16 @@ func (hs *HTTPServer) QueryDiagnostics(c *contextmodel.ReqContext) response.Resp
 	if marshalErr != nil {
 		queryRequestJSON = nil
 	}
-	bundle, err := diagnostics.NewBundler().Build(resp, harBuffer, reqDTO.Panel, reqDTO.Dashboard, queryRequestJSON, exprBuffer.Stages(), marshalErr, bundleErr)
+	bundle, err := diagnostics.NewBundler().Build(diagnostics.BundleInput{
+		Resp:             resp,
+		HARBuffer:        harBuffer,
+		PanelJSON:        reqDTO.Panel,
+		DashboardJSON:    reqDTO.Dashboard,
+		QueryRequestJSON: queryRequestJSON,
+		ExpressionStages: exprBuffer.Stages(),
+		QueryRequestErr:  marshalErr,
+		QueryErr:         bundleErr,
+	})
 	if err != nil {
 		return response.Error(http.StatusInternalServerError, "failed to build diagnostics bundle", err)
 	}

--- a/pkg/api/ds_query_diagnostics.go
+++ b/pkg/api/ds_query_diagnostics.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/api/response"
+	"github.com/grafana/grafana/pkg/expr/exprcapture"
 	"github.com/grafana/grafana/pkg/infra/httpclient/harcapture"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/diagnostics"
@@ -53,6 +54,7 @@ func (hs *HTTPServer) QueryDiagnostics(c *contextmodel.ReqContext) response.Resp
 	}
 
 	captureCtx, harBuffer := harcapture.WithCapture(ctx)
+	captureCtx, exprBuffer := exprcapture.WithCapture(captureCtx)
 
 	// Force a live query: a query-result cache hit returns without a datasource round trip, so HTTP
 	// capture would run on nothing and traffic.har would be silently empty. Diagnostics must capture
@@ -108,7 +110,7 @@ func (hs *HTTPServer) QueryDiagnostics(c *contextmodel.ReqContext) response.Resp
 	if marshalErr != nil {
 		queryRequestJSON = nil
 	}
-	bundle, err := diagnostics.NewBundler().Build(resp, harBuffer, reqDTO.Panel, reqDTO.Dashboard, queryRequestJSON, marshalErr, bundleErr)
+	bundle, err := diagnostics.NewBundler().Build(resp, harBuffer, reqDTO.Panel, reqDTO.Dashboard, queryRequestJSON, exprBuffer.Stages(), marshalErr, bundleErr)
 	if err != nil {
 		return response.Error(http.StatusInternalServerError, "failed to build diagnostics bundle", err)
 	}

--- a/pkg/api/ds_query_diagnostics_exprcapture_test.go
+++ b/pkg/api/ds_query_diagnostics_exprcapture_test.go
@@ -1,0 +1,119 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/api/dtos"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/expr/exprcapture"
+	"github.com/grafana/grafana/pkg/services/query"
+	"github.com/grafana/grafana/pkg/services/user"
+)
+
+// The seam these tests cover: the handlers must attach the exprcapture buffer to the SAME context
+// they hand to queryData. The expression service records stages into whatever buffer that context
+// carries, so a buffer attached to the wrong context -- to ctx instead of the HAR-wrapped pctx, say --
+// leaves every bundle with an empty pipeline. No unit test in pkg/expr or pkg/services/diagnostics
+// would notice: both packages are correct in isolation, and the fake query service used elsewhere in
+// this package doesn't care what the context holds.
+//
+// recordTwoStages stands in for the expression service: it records into the buffer it finds in ctx,
+// or fails the test if there is none.
+func recordTwoStages(t *testing.T, ctx context.Context) *exprcapture.Buffer {
+	t.Helper()
+	buf := exprcapture.FromContext(ctx)
+	require.NotNil(t, buf, "the context passed to queryData carries no exprcapture buffer")
+	buf.Record([]exprcapture.Stage{
+		{RefID: "A", Type: "datasource", Command: "prometheus"},
+		{RefID: "B", Type: "expression", Command: "reduce", InputRefIDs: []string{"A"}},
+	})
+	return buf
+}
+
+func TestBuildDashboardDiagnosticsArchive_capturesPipelinePerPanel(t *testing.T) {
+	var seen []*exprcapture.Buffer
+	fakeQuery := query.NewFakeQueryService(t)
+	fakeQuery.On("QueryData", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(func(ctx context.Context, _ identity.Requester, _ bool, _ dtos.MetricRequest) (*backend.QueryDataResponse, error) {
+			seen = append(seen, recordTwoStages(t, ctx))
+			return backend.NewQueryDataResponse(), nil
+		})
+	hs := &HTTPServer{queryDataService: fakeQuery}
+
+	panel := func(id int64, title string) panelDiagnosticsSpec {
+		return panelDiagnosticsSpec{
+			ID:    id,
+			Title: title,
+			MetricRequest: dtos.MetricRequest{
+				Queries: []*simplejson.Json{simplejson.NewFromAny(map[string]any{"refId": "A"})},
+			},
+		}
+	}
+	reqDTO := dashboardDiagnosticsRequest{Panels: []panelDiagnosticsSpec{panel(1, "one"), panel(2, "two")}}
+
+	archive, err := hs.buildDashboardDiagnosticsArchive(context.Background(), &user.SignedInUser{OrgID: 1, UserUID: "u1"}, false, false, reqDTO, "job-pipeline")
+	require.NoError(t, err)
+
+	require.Len(t, seen, 2)
+	require.NotSame(t, seen[0], seen[1], "each panel must capture into its own buffer, or panels would pool stages")
+
+	files := readTarGzFiles(t, archive)
+	for _, dir := range []string{"panels/1-one", "panels/2-two"} {
+		name := dir + "/querydata.json"
+		require.Contains(t, files, name)
+
+		var artifact struct {
+			Pipeline []struct {
+				RefID       string   `json:"refId"`
+				Type        string   `json:"type"`
+				Command     string   `json:"command"`
+				InputRefIDs []string `json:"inputRefIds"`
+			} `json:"pipeline"`
+		}
+		require.NoError(t, json.Unmarshal(files[name], &artifact))
+		require.Len(t, artifact.Pipeline, 2, "%s recorded no pipeline", name)
+		require.Equal(t, "A", artifact.Pipeline[0].RefID)
+		require.Equal(t, "datasource", artifact.Pipeline[0].Type)
+		require.Equal(t, "reduce", artifact.Pipeline[1].Command)
+		require.Equal(t, []string{"A"}, artifact.Pipeline[1].InputRefIDs, "the DAG edge B<-A reached the artifact")
+	}
+}
+
+// TestBuildDashboardDiagnosticsArchive_skippedPanelCapturesNothing pins the other half of the
+// per-panel contract: a non-data panel is never executed, so it must not inherit a neighbour's DAG.
+func TestBuildDashboardDiagnosticsArchive_skippedPanelCapturesNothing(t *testing.T) {
+	fakeQuery := query.NewFakeQueryService(t)
+	fakeQuery.On("QueryData", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(func(ctx context.Context, _ identity.Requester, _ bool, _ dtos.MetricRequest) (*backend.QueryDataResponse, error) {
+			recordTwoStages(t, ctx)
+			return backend.NewQueryDataResponse(), nil
+		})
+	hs := &HTTPServer{queryDataService: fakeQuery}
+
+	reqDTO := dashboardDiagnosticsRequest{Panels: []panelDiagnosticsSpec{
+		{
+			ID:    1,
+			Title: "with queries",
+			MetricRequest: dtos.MetricRequest{
+				Queries: []*simplejson.Json{simplejson.NewFromAny(map[string]any{"refId": "A"})},
+			},
+		},
+		{ID: 2, Title: "text panel"}, // no queries -> skipped, never executed
+	}}
+
+	archive, err := hs.buildDashboardDiagnosticsArchive(context.Background(), &user.SignedInUser{OrgID: 1, UserUID: "u1"}, false, false, reqDTO, "job-skipped")
+	require.NoError(t, err)
+
+	files := readTarGzFiles(t, archive)
+	require.Contains(t, files, "panels/1-with-queries/querydata.json")
+	for name := range files {
+		require.NotContains(t, name, "2-text-panel", "a skipped panel must produce no query-data artifact")
+	}
+}

--- a/pkg/api/ds_query_diagnostics_exprcapture_test.go
+++ b/pkg/api/ds_query_diagnostics_exprcapture_test.go
@@ -13,23 +13,35 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/expr/exprcapture"
+	"github.com/grafana/grafana/pkg/infra/httpclient/harcapture"
 	"github.com/grafana/grafana/pkg/services/query"
 	"github.com/grafana/grafana/pkg/services/user"
 )
 
-// The seam these tests cover: the handlers must attach the exprcapture buffer to the SAME context
-// they hand to queryData. The expression service records stages into whatever buffer that context
+// The seam these tests cover: a handler must attach the exprcapture buffer to the SAME context it
+// hands to queryData. The expression service records stages into whatever buffer that context
 // carries, so a buffer attached to the wrong context -- to ctx instead of the HAR-wrapped pctx, say --
 // leaves every bundle with an empty pipeline. No unit test in pkg/expr or pkg/services/diagnostics
 // would notice: both packages are correct in isolation, and the fake query service used elsewhere in
 // this package doesn't care what the context holds.
 //
+// Only the dashboard handler is covered here: QueryDiagnostics has no test harness in this package
+// (nothing invokes it -- it needs the OpenFeature gate, a ReqContext and web.Bind), so its identical
+// two-line wiring is still unguarded. Worth closing when that harness lands.
+//
 // recordTwoStages stands in for the expression service: it records into the buffer it finds in ctx,
 // or fails the test if there is none.
+//
+// It also asserts the HAR buffer is still reachable. The wiring is two nested WithCapture calls, so
+// the likely slip is chaining the second off the ORIGINAL ctx rather than the HAR-wrapped one --
+// which leaves expression capture working and silently empties traffic.har. Asserting only the
+// exprcapture buffer would pass straight through that.
 func recordTwoStages(t *testing.T, ctx context.Context) *exprcapture.Buffer {
 	t.Helper()
 	buf := exprcapture.FromContext(ctx)
 	require.NotNil(t, buf, "the context passed to queryData carries no exprcapture buffer")
+	require.NotNil(t, harcapture.FromContext(ctx),
+		"attaching the exprcapture buffer dropped the HAR buffer from the context handed to queryData")
 	buf.Record([]exprcapture.Stage{
 		{RefID: "A", Type: "datasource", Command: "prometheus"},
 		{RefID: "B", Type: "expression", Command: "reduce", InputRefIDs: []string{"A"}},

--- a/pkg/api/ds_query_diagnostics_exprcapture_test.go
+++ b/pkg/api/ds_query_diagnostics_exprcapture_test.go
@@ -3,7 +3,11 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/stretchr/testify/mock"
@@ -14,8 +18,12 @@ import (
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/expr/exprcapture"
 	"github.com/grafana/grafana/pkg/infra/httpclient/harcapture"
+	"github.com/grafana/grafana/pkg/infra/log"
+	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/query"
 	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/grafana/grafana/pkg/web"
 )
 
 // The seam these tests cover: a handler must attach the exprcapture buffer to the SAME context it
@@ -25,9 +33,8 @@ import (
 // would notice: both packages are correct in isolation, and the fake query service used elsewhere in
 // this package doesn't care what the context holds.
 //
-// Only the dashboard handler is covered here: QueryDiagnostics has no test harness in this package
-// (nothing invokes it -- it needs the OpenFeature gate, a ReqContext and web.Bind), so its identical
-// two-line wiring is still unguarded. Worth closing when that harness lands.
+// Both handlers are covered: QueryDiagnostics (single panel) and buildDashboardDiagnosticsArchive
+// (per panel). They wire the two buffers up independently, so neither one's tests protect the other.
 //
 // recordTwoStages stands in for the expression service: it records into the buffer it finds in ctx,
 // or fails the test if there is none.
@@ -47,6 +54,104 @@ func recordTwoStages(t *testing.T, ctx context.Context) *exprcapture.Buffer {
 		{RefID: "B", Type: "expression", Command: "reduce", InputRefIDs: []string{"A"}},
 	})
 	return buf
+}
+
+// recordTwoStagesAndTraffic records a stage pair into ctx's exprcapture buffer AND one HTTP exchange
+// into its harcapture buffer. Recording through both makes the resulting bundle prove the seam
+// end-to-end: querydata.json's pipeline and traffic.har can only both be present if the two buffers
+// the handler hands to Build are the same two the query saw in its context.
+func recordTwoStagesAndTraffic(t *testing.T, ctx context.Context) {
+	t.Helper()
+	recordTwoStages(t, ctx)
+	harcapture.FromContext(ctx).AddEntry(
+		httptest.NewRequest(http.MethodGet, "http://ds.example/api/v1/query?query=up", nil),
+		&http.Response{StatusCode: http.StatusOK, Header: http.Header{}, Body: http.NoBody},
+		nil, time.Unix(0, 0), time.Millisecond,
+	)
+}
+
+// diagnosticsReqContext builds the ReqContext QueryDiagnostics binds its request off. The body must
+// carry at least one query or the handler short-circuits with 400 before any capture happens.
+func diagnosticsReqContext(t *testing.T, queryV2 bool) *contextmodel.ReqContext {
+	t.Helper()
+	body := `{"from":"now-1h","to":"now","queries":[{"refId":"A","datasource":{"uid":"prom"}}],` +
+		`"panel":{"id":7,"targets":[{"refId":"A","hide":true},{"refId":"B"}]}}`
+	req, err := http.NewRequest(http.MethodPost, "/api/ds/diagnostics", strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	if queryV2 {
+		req.Header.Set("X-Query-V2", "true")
+	}
+	return &contextmodel.ReqContext{
+		Context: &web.Context{
+			Req:  req,
+			Resp: web.NewResponseWriter(req.Method, httptest.NewRecorder()),
+		},
+		SignedInUser: &user.SignedInUser{OrgID: 1, UserUID: "u1"},
+		Logger:       log.New("test"),
+	}
+}
+
+// TestQueryDiagnostics_capturesPipelineIntoBundle covers the single-panel handler's half of the seam.
+// Both dispatch branches are exercised: the handler picks QueryData or QueryDataNew off the X-Query-V2
+// header, and each is a separate call site that has to be handed captureCtx rather than the bare ctx.
+func TestQueryDiagnostics_capturesPipelineIntoBundle(t *testing.T) {
+	setupOpenFeatureFlag(t, featuremgmt.FlagGrafanaOnDemandDiagnostics, true)
+
+	for _, tc := range []struct {
+		name     string
+		queryV2  bool
+		method   string
+		unwanted string
+	}{
+		{name: "v1 dispatch", queryV2: false, method: "QueryData", unwanted: "QueryDataNew"},
+		{name: "v2 dispatch", queryV2: true, method: "QueryDataNew", unwanted: "QueryData"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeQuery := query.NewFakeQueryService(t)
+			fakeQuery.On(tc.method, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+				Return(func(ctx context.Context, _ identity.Requester, _ bool, _ dtos.MetricRequest) (*backend.QueryDataResponse, error) {
+					recordTwoStagesAndTraffic(t, ctx)
+					return backend.NewQueryDataResponse(), nil
+				})
+			hs := &HTTPServer{queryDataService: fakeQuery}
+
+			c := diagnosticsReqContext(t, tc.queryV2)
+			resp := hs.QueryDiagnostics(c)
+			require.Equal(t, http.StatusOK, resp.Status())
+			fakeQuery.AssertNotCalled(t, tc.unwanted, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+
+			// The handler forces a live query: a cache hit returns without a datasource round trip, so
+			// capture would run on nothing and both artifacts below would be empty.
+			require.True(t, c.SkipQueryCache, "diagnostics must bypass the query-result cache")
+
+			files := readTarGzFiles(t, resp.Body())
+			require.Contains(t, files, "traffic.har",
+				"the HAR buffer handed to Build is not the one the query recorded into")
+
+			require.Contains(t, files, "querydata.json")
+			var artifact struct {
+				Pipeline []struct {
+					RefID       string   `json:"refId"`
+					Type        string   `json:"type"`
+					Command     string   `json:"command"`
+					InputRefIDs []string `json:"inputRefIds"`
+				} `json:"pipeline"`
+			}
+			require.NoError(t, json.Unmarshal(files["querydata.json"], &artifact))
+			require.Len(t, artifact.Pipeline, 2, "querydata.json recorded no pipeline")
+			require.Equal(t, "A", artifact.Pipeline[0].RefID)
+			require.Equal(t, "datasource", artifact.Pipeline[0].Type)
+			require.Equal(t, "reduce", artifact.Pipeline[1].Command)
+			require.Equal(t, []string{"A"}, artifact.Pipeline[1].InputRefIDs,
+				"the DAG edge B<-A reached the artifact")
+
+			// panel.json still carries each target's hide flag, which is what lets a reader tell which
+			// captured stages the panel actually drew now that hidden refIds stay in the response.
+			require.Contains(t, files, "panel.json")
+			require.Contains(t, string(files["panel.json"]), `"hide": true`)
+		})
+	}
 }
 
 func TestBuildDashboardDiagnosticsArchive_capturesPipelinePerPanel(t *testing.T) {

--- a/pkg/expr/exprcapture/exprcapture.go
+++ b/pkg/expr/exprcapture/exprcapture.go
@@ -1,0 +1,86 @@
+// Package exprcapture records per-node server-side expression pipeline evidence in memory for the
+// on-demand diagnostics bundle. When a capture Buffer is attached to the request context, the
+// expression service records each pipeline node's output frames, its input dependencies (the refIDs
+// it consumes), its node type/command, and any error. The diagnostics bundle serializes these as an
+// expression-stage view so a support engineer can localize the first processing stage whose output
+// differs from its input.
+//
+// Like the other diagnostics capture buffers, this is a no-op unless a Buffer is present in the
+// context, so the normal query path pays only a context lookup. Captured frames are recorded
+// VERBATIM -- redaction is intentionally deferred for the experimental, admin-only, on-prem,
+// feature-flagged diagnostics endpoint (see the harcapture package doc).
+package exprcapture
+
+import (
+	"context"
+	"sync"
+
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+)
+
+type contextKey struct{}
+
+// Stage is one node of the executed expression pipeline: a datasource query or an expression command.
+// Frames is the node's output; InputRefIDs are the refIDs whose outputs feed this node (its inputs).
+// A reader reconstructs each stage's input from the outputs of its InputRefIDs, so the pipeline can be
+// walked from datasource nodes down to the panel's final expression to find where the data changed.
+type Stage struct {
+	RefID       string
+	Type        string // "datasource", "expression", or "ml"
+	Command     string // expression command (reduce/math/resample/...) or datasource type; may be empty
+	InputRefIDs []string
+	Frames      data.Frames // the node's output frames
+	Error       error       // node error (dependency/execution failure), if any
+}
+
+// Buffer collects expression pipeline stages in execution order.
+type Buffer struct {
+	mu     sync.Mutex
+	stages []Stage
+}
+
+// WithCapture returns a child context carrying a new Buffer and the buffer itself.
+func WithCapture(ctx context.Context) (context.Context, *Buffer) {
+	buf := &Buffer{}
+	return context.WithValue(ctx, contextKey{}, buf), buf
+}
+
+// FromContext returns the Buffer stored in ctx, or nil if absent.
+func FromContext(ctx context.Context) *Buffer {
+	v, _ := ctx.Value(contextKey{}).(*Buffer)
+	return v
+}
+
+// Record appends captured pipeline stages. A pipeline runs once per request, but Record appends
+// (rather than replaces) so a request that evaluates more than one pipeline keeps every stage.
+// Thread-safe.
+func (b *Buffer) Record(stages []Stage) {
+	if b == nil || len(stages) == 0 {
+		return
+	}
+	b.mu.Lock()
+	b.stages = append(b.stages, stages...)
+	b.mu.Unlock()
+}
+
+// Stages returns a copy of the captured stages. Thread-safe.
+func (b *Buffer) Stages() []Stage {
+	if b == nil {
+		return nil
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	out := make([]Stage, len(b.stages))
+	copy(out, b.stages)
+	return out
+}
+
+// Len returns the number of captured stages. Thread-safe.
+func (b *Buffer) Len() int {
+	if b == nil {
+		return 0
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return len(b.stages)
+}

--- a/pkg/expr/exprcapture/exprcapture.go
+++ b/pkg/expr/exprcapture/exprcapture.go
@@ -1,36 +1,42 @@
-// Package exprcapture records per-node server-side expression pipeline evidence in memory for the
-// on-demand diagnostics bundle. When a capture Buffer is attached to the request context, the
-// expression service records each pipeline node's output frames, its input dependencies (the refIDs
-// it consumes), its node type/command, and any error. The diagnostics bundle serializes these as an
+// Package exprcapture records the shape of the executed server-side expression pipeline in memory
+// for the on-demand diagnostics bundle. When a capture Buffer is attached to the request context,
+// the expression service records each pipeline node's refID, node type/command, input dependencies
+// (the refIDs it consumes), and any error. The diagnostics bundle serializes these as an
 // expression-stage view so a support engineer can localize the first processing stage whose output
 // differs from its input.
 //
+// Node OUTPUTS are deliberately not captured here. The expression service returns every executed
+// node -- datasource, expression and ML alike -- as its own refID in the QueryDataResponse, so the
+// bundle's querydata.json already carries each stage's output frames under "response" keyed by
+// refID. What that response cannot express is the DAG: which node is an expression, which command
+// it ran, and which refIDs feed it. That is what this buffer adds, and a reader joins the two on
+// refID. Capturing the frames again would duplicate the response byte-for-byte and halve the
+// artifact's effective size budget.
+//
 // Like the other diagnostics capture buffers, this is a no-op unless a Buffer is present in the
-// context, so the normal query path pays only a context lookup. Captured frames are recorded
-// VERBATIM -- redaction is intentionally deferred for the experimental, admin-only, on-prem,
-// feature-flagged diagnostics endpoint (see the harcapture package doc).
+// context, so the normal query path pays only a context lookup. Stage metadata is recorded VERBATIM
+// -- redaction is intentionally deferred for the experimental, admin-only, on-prem, feature-flagged
+// diagnostics endpoint (see the harcapture package doc).
 package exprcapture
 
 import (
 	"context"
 	"sync"
-
-	"github.com/grafana/grafana-plugin-sdk-go/data"
 )
 
 type contextKey struct{}
 
 // Stage is one node of the executed expression pipeline: a datasource query or an expression command.
-// Frames is the node's output; InputRefIDs are the refIDs whose outputs feed this node (its inputs).
-// A reader reconstructs each stage's input from the outputs of its InputRefIDs, so the pipeline can be
-// walked from datasource nodes down to the panel's final expression to find where the data changed.
+// InputRefIDs are the refIDs whose outputs feed this node (its inputs). A reader pairs each stage
+// with the same refID under querydata.json's "response" to get its output, and reconstructs the
+// stage's input from the outputs of its InputRefIDs -- so the pipeline can be walked from datasource
+// nodes down to the panel's final expression to find where the data changed.
 type Stage struct {
 	RefID       string
 	Type        string // "datasource", "expression", or "ml"
 	Command     string // expression command (reduce/math/resample/...) or datasource type; may be empty
 	InputRefIDs []string
-	Frames      data.Frames // the node's output frames
-	Error       error       // node error (dependency/execution failure), if any
+	Error       error // node error (dependency/execution failure), if any
 }
 
 // Buffer collects expression pipeline stages in execution order.
@@ -73,14 +79,4 @@ func (b *Buffer) Stages() []Stage {
 	out := make([]Stage, len(b.stages))
 	copy(out, b.stages)
 	return out
-}
-
-// Len returns the number of captured stages. Thread-safe.
-func (b *Buffer) Len() int {
-	if b == nil {
-		return 0
-	}
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	return len(b.stages)
 }

--- a/pkg/expr/exprcapture/exprcapture.go
+++ b/pkg/expr/exprcapture/exprcapture.go
@@ -39,7 +39,7 @@ type contextKey struct{}
 // nodes down to the panel's final expression to find where the data changed.
 type Stage struct {
 	RefID       string
-	Type        string // "datasource", "expression", or "ml"
+	Type        string // "datasource", "expression", "ml", or "unknown" for a node kind we don't map
 	Command     string // expression command (reduce/math/resample/...) or datasource type; may be empty
 	InputRefIDs []string
 	Error       error // node error (dependency/execution failure), if any

--- a/pkg/expr/exprcapture/exprcapture.go
+++ b/pkg/expr/exprcapture/exprcapture.go
@@ -13,6 +13,12 @@
 // refID. Capturing the frames again would duplicate the response byte-for-byte and halve the
 // artifact's effective size budget.
 //
+// For that join to resolve for every stage, the presence of a Buffer also makes the expression
+// service keep hidden ("hide": true) nodes in the response it returns, which it otherwise strips
+// after execution -- see expr.Service.TransformData. A hidden datasource query feeding a visible
+// expression is the usual panel shape, and it is precisely the stage whose output a support engineer
+// needs in order to tell a bad datasource result from a bad expression.
+//
 // Like the other diagnostics capture buffers, this is a no-op unless a Buffer is present in the
 // context, so the normal query path pays only a context lookup. Stage metadata is recorded VERBATIM
 // -- redaction is intentionally deferred for the experimental, admin-only, on-prem, feature-flagged
@@ -69,7 +75,9 @@ func (b *Buffer) Record(stages []Stage) {
 	b.mu.Unlock()
 }
 
-// Stages returns a copy of the captured stages. Thread-safe.
+// Stages returns a shallow copy of the captured stages: the slice is fresh, and each Stage's
+// InputRefIDs is already owned by the buffer (the recorder clones it off the pipeline node, which
+// outlives neither the request nor this buffer). Thread-safe.
 func (b *Buffer) Stages() []Stage {
 	if b == nil {
 		return nil

--- a/pkg/expr/graph.go
+++ b/pkg/expr/graph.go
@@ -199,9 +199,10 @@ func captureDiagnosticStages(ctx context.Context, dp DataPipeline, vars mathexp.
 	for _, node := range dp {
 		refID := node.RefID()
 		stage := exprcapture.Stage{
-			RefID:       refID,
-			Type:        diagnosticStageType(node.NodeType()),
-			InputRefIDs: node.NeedsVars(),
+			RefID: refID,
+			Type:  diagnosticStageType(node.NodeType()),
+			// Cloned: NeedsVars returns the command's own slice, and the buffer outlives the pipeline.
+			InputRefIDs: slices.Clone(node.NeedsVars()),
 		}
 		switch n := node.(type) {
 		case *CMDNode:

--- a/pkg/expr/graph.go
+++ b/pkg/expr/graph.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/open-feature/go-sdk/openfeature"
 
+	"github.com/grafana/grafana/pkg/expr/exprcapture"
 	"github.com/grafana/grafana/pkg/expr/mathexp"
 	"github.com/grafana/grafana/pkg/expr/sql"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -163,6 +164,62 @@ func (dp *DataPipeline) execute(c context.Context, now time.Time, s *Service) (m
 		span.End()
 	}
 	return vars, nil
+}
+
+// diagnosticStageType maps a node type to the stable string used in the diagnostics expression-stage
+// artifact.
+func diagnosticStageType(nt NodeType) string {
+	switch nt {
+	case TypeCMDNode:
+		return "expression"
+	case TypeDatasourceNode:
+		return "datasource"
+	case TypeMLNode:
+		return "ml"
+	default:
+		return "unknown"
+	}
+}
+
+// captureDiagnosticStages records each pipeline node's output frames and input dependencies into the
+// exprcapture buffer when one is attached to ctx (the on-demand diagnostics path); it is a no-op
+// otherwise. vars holds every executed node's final result keyed by refID, so iterating the ordered
+// pipeline yields the full DAG -- datasource, expression, and ML nodes alike -- regardless of whether
+// datasource nodes ran grouped or inline.
+func captureDiagnosticStages(ctx context.Context, dp DataPipeline, vars mathexp.Vars) {
+	buf := exprcapture.FromContext(ctx)
+	if buf == nil {
+		return
+	}
+	stages := make([]exprcapture.Stage, 0, len(dp))
+	for _, node := range dp {
+		refID := node.RefID()
+		stage := exprcapture.Stage{
+			RefID:       refID,
+			Type:        diagnosticStageType(node.NodeType()),
+			InputRefIDs: node.NeedsVars(),
+		}
+		switch n := node.(type) {
+		case *CMDNode:
+			if n.Command != nil {
+				stage.Command = n.Command.Type()
+			}
+		case *DSNode:
+			if n.datasource != nil {
+				stage.Command = n.datasource.Type
+			}
+		case *MLNode:
+			if n.command != nil {
+				stage.Command = n.command.Type()
+			}
+		}
+		if res, ok := vars[refID]; ok {
+			stage.Frames = res.Values.AsDataFrames(refID)
+			stage.Error = res.Error
+		}
+		stages = append(stages, stage)
+	}
+	buf.Record(stages)
 }
 
 // GetDatasourceTypes returns an unique list of data source types used in the query. Machine learning node is encoded as `ml_<type>`, e.g. ml_outlier

--- a/pkg/expr/graph.go
+++ b/pkg/expr/graph.go
@@ -181,11 +181,15 @@ func diagnosticStageType(nt NodeType) string {
 	}
 }
 
-// captureDiagnosticStages records each pipeline node's output frames and input dependencies into the
+// captureDiagnosticStages records each pipeline node's identity and input dependencies into the
 // exprcapture buffer when one is attached to ctx (the on-demand diagnostics path); it is a no-op
 // otherwise. vars holds every executed node's final result keyed by refID, so iterating the ordered
 // pipeline yields the full DAG -- datasource, expression, and ML nodes alike -- regardless of whether
 // datasource nodes ran grouped or inline.
+//
+// Only the node's error is taken from vars, not its frames: ExecutePipeline turns every entry in
+// vars into its own refID in the returned QueryDataResponse, so the diagnostics bundle already has
+// each stage's output and joins the two on refID (see the exprcapture package doc).
 func captureDiagnosticStages(ctx context.Context, dp DataPipeline, vars mathexp.Vars) {
 	buf := exprcapture.FromContext(ctx)
 	if buf == nil {
@@ -214,7 +218,6 @@ func captureDiagnosticStages(ctx context.Context, dp DataPipeline, vars mathexp.
 			}
 		}
 		if res, ok := vars[refID]; ok {
-			stage.Frames = res.Values.AsDataFrames(refID)
 			stage.Error = res.Error
 		}
 		stages = append(stages, stage)

--- a/pkg/expr/graph_capture_test.go
+++ b/pkg/expr/graph_capture_test.go
@@ -2,10 +2,9 @@ package expr
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
-
-	"encoding/json"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
@@ -13,6 +12,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/expr/exprcapture"
 	"github.com/grafana/grafana/pkg/services/datasources"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 )
 
 func fptr(f float64) *float64 { return &f }
@@ -29,6 +29,14 @@ func dsQueryA() Query {
 		JSON:      json.RawMessage(`{ "datasource": { "uid": "test" }, "intervalMs": 1000, "maxDataPoints": 1000 }`),
 		TimeRange: AbsoluteTimeRange{From: time.Time{}, To: time.Time{}},
 	}
+}
+
+// dsQuery is dsQueryA for an arbitrary refID, so a test can put two datasource nodes on the same
+// datasource -- the shape executeDSNodesGrouped collapses into one plugin call.
+func dsQuery(refID string) Query {
+	q := dsQueryA()
+	q.RefID = refID
+	return q
 }
 
 func mathQuery(refID, expression string) Query {
@@ -54,7 +62,7 @@ func TestExecutePipeline_capturesExpressionStages(t *testing.T) {
 	pl, err := s.BuildPipeline(t.Context(), req)
 	require.NoError(t, err)
 
-	ctx, buf := exprcapture.WithCapture(context.Background())
+	ctx, buf := exprcapture.WithCapture(t.Context())
 	res, err := s.ExecutePipeline(ctx, time.Now(), pl)
 	require.NoError(t, err)
 
@@ -92,6 +100,53 @@ func TestExecutePipeline_capturesExpressionStages(t *testing.T) {
 	requireResponseValue(t, res, "C", 14.0) // $B + 10
 }
 
+// TestExecutePipeline_capturesStagesWhenDatasourceNodesRunGrouped pins the other half of
+// captureDiagnosticStages' claim: with sseGroupByDatasource on, datasource nodes are executed up front
+// by executeDSNodesGrouped and then SKIPPED by the main loop. The capture walks the pipeline rather
+// than the loop's execution trace, so it must still record them -- were it driven off the executed
+// nodes, every grouped datasource stage would vanish and the DAG would start at the expressions, which
+// is exactly the half a support engineer needs to rule the datasource in or out.
+func TestExecutePipeline_capturesStagesWhenDatasourceNodesRunGrouped(t *testing.T) {
+	frame := func(name string, v float64) *data.Frame {
+		return data.NewFrame(name,
+			data.NewField("time", nil, []time.Time{time.Unix(1, 0)}),
+			data.NewField("value", data.Labels{"host": "a"}, []*float64{fptr(v)}),
+		)
+	}
+	// A and B hit the same datasource ("test"), so they are grouped into a single plugin call.
+	resp := map[string]backend.DataResponse{
+		"A": {Frames: data.Frames{frame("A", 2.0)}},
+		"B": {Frames: data.Frames{frame("B", 3.0)}},
+	}
+	queries := []Query{dsQuery("A"), dsQuery("B"), mathQuery("C", "$A + $B")}
+
+	s, req := newMockQueryService(resp, queries)
+	s.features = featuremgmt.WithFeatures(featuremgmt.FlagSseGroupByDatasource)
+	pl, err := s.BuildPipeline(t.Context(), req)
+	require.NoError(t, err)
+
+	ctx, buf := exprcapture.WithCapture(t.Context())
+	res, err := s.ExecutePipeline(ctx, time.Now(), pl)
+	require.NoError(t, err)
+
+	byRef := map[string]exprcapture.Stage{}
+	for _, st := range buf.Stages() {
+		byRef[st.RefID] = st
+	}
+	require.Len(t, byRef, 3, "the grouped datasource nodes are captured alongside the expression")
+	require.Equal(t, "datasource", byRef["A"].Type)
+	require.Equal(t, "datasource", byRef["B"].Type)
+	require.Equal(t, "test", byRef["A"].Command)
+	require.Equal(t, "expression", byRef["C"].Type)
+	require.ElementsMatch(t, []string{"A", "B"}, byRef["C"].InputRefIDs, "C consumes both grouped nodes")
+
+	// The join still resolves for the grouped nodes, which is what makes their stages usable.
+	for refID := range byRef {
+		require.Contains(t, res.Responses, refID, "stage %s has no response entry to join to", refID)
+	}
+	requireResponseValue(t, res, "C", 5.0) // $A + $B
+}
+
 func TestExecutePipeline_capturesDependencyErrorStage(t *testing.T) {
 	// A fails at the datasource; B depends on A, so B is never executed and carries a dependency error.
 	resp := map[string]backend.DataResponse{"A": {Error: context.DeadlineExceeded}}
@@ -101,7 +156,7 @@ func TestExecutePipeline_capturesDependencyErrorStage(t *testing.T) {
 	pl, err := s.BuildPipeline(t.Context(), req)
 	require.NoError(t, err)
 
-	ctx, buf := exprcapture.WithCapture(context.Background())
+	ctx, buf := exprcapture.WithCapture(t.Context())
 	res, err := s.ExecutePipeline(ctx, time.Now(), pl)
 	require.NoError(t, err)
 
@@ -139,7 +194,7 @@ func TestTransformData_keepsHiddenNodesInResponseWhenCapturing(t *testing.T) {
 		s, req := newMockQueryService(resp, queries)
 		s.cfg.ExpressionsEnabled = true
 
-		ctx, buf := exprcapture.WithCapture(context.Background())
+		ctx, buf := exprcapture.WithCapture(t.Context())
 		res, err := s.TransformData(ctx, time.Now(), req)
 		require.NoError(t, err)
 
@@ -157,7 +212,7 @@ func TestTransformData_keepsHiddenNodesInResponseWhenCapturing(t *testing.T) {
 		s, req := newMockQueryService(resp, queries)
 		s.cfg.ExpressionsEnabled = true
 
-		res, err := s.TransformData(context.Background(), time.Now(), req)
+		res, err := s.TransformData(t.Context(), time.Now(), req)
 		require.NoError(t, err)
 		require.NotContains(t, res.Responses, "A", "the normal query path must keep hiding hidden queries")
 		require.Contains(t, res.Responses, "B")
@@ -182,7 +237,7 @@ func TestExecutePipeline_capturesStagesWhenExecutionFailsHard(t *testing.T) {
 	// all, so the capture must not sit behind ExecutePipeline's error return.
 	s, _ := newMockQueryService(nil, nil)
 
-	ctx, buf := exprcapture.WithCapture(context.Background())
+	ctx, buf := exprcapture.WithCapture(t.Context())
 	_, err := s.ExecutePipeline(ctx, time.Now(), DataPipeline{&unexecutableNode{refID: "A"}})
 	require.Error(t, err, "an unexecutable node fails the pipeline")
 
@@ -202,10 +257,11 @@ func TestExecutePipeline_noCaptureWithoutBuffer(t *testing.T) {
 	pl, err := s.BuildPipeline(t.Context(), req)
 	require.NoError(t, err)
 
-	// context.Background() carries no exprcapture buffer, so this buffer is unreachable from the
-	// pipeline's context and must stay empty.
-	_, unreachable := exprcapture.WithCapture(context.Background())
-	_, err = s.ExecutePipeline(context.Background(), time.Now(), pl)
+	// The buffer lives in a CHILD of t.Context(); the pipeline runs on t.Context() itself, which does
+	// not carry it. So the buffer is unreachable from the pipeline's context and must stay empty --
+	// sharing an ancestor with a capture context must not be enough to start recording.
+	_, unreachable := exprcapture.WithCapture(t.Context())
+	_, err = s.ExecutePipeline(t.Context(), time.Now(), pl)
 	require.NoError(t, err)
 	require.Empty(t, unreachable.Stages(), "a pipeline run without the buffer in its context records nothing")
 }

--- a/pkg/expr/graph_capture_test.go
+++ b/pkg/expr/graph_capture_test.go
@@ -115,6 +115,82 @@ func TestExecutePipeline_capturesDependencyErrorStage(t *testing.T) {
 	require.Empty(t, res.Responses["B"].Frames, "B produced no output")
 }
 
+// hiddenDSQueryA is dsQueryA with "hide": true -- the usual shape for a datasource query that only
+// feeds an expression and is not drawn by the panel.
+func hiddenDSQueryA() Query {
+	q := dsQueryA()
+	q.JSON = json.RawMessage(`{ "datasource": { "uid": "test" }, "hide": true, "intervalMs": 1000, "maxDataPoints": 1000 }`)
+	return q
+}
+
+func TestTransformData_keepsHiddenNodesInResponseWhenCapturing(t *testing.T) {
+	// A stage carries no output of its own, so every captured stage needs a response entry under the
+	// same refID to join to. TransformData normally strips hidden refIDs from the response, which would
+	// leave the hidden datasource stage -- the input side of the first expression, and the whole point
+	// of the capture -- with nothing to join to. A capture buffer in context suppresses that filtering.
+	dsDF := data.NewFrame("A",
+		data.NewField("time", nil, []time.Time{time.Unix(1, 0)}),
+		data.NewField("value", data.Labels{"host": "a"}, []*float64{fptr(2.0)}),
+	)
+	resp := map[string]backend.DataResponse{"A": {Frames: data.Frames{dsDF}}}
+	queries := []Query{hiddenDSQueryA(), mathQuery("B", "$A * 2")}
+
+	t.Run("with a capture buffer the hidden node's output survives", func(t *testing.T) {
+		s, req := newMockQueryService(resp, queries)
+		s.cfg.ExpressionsEnabled = true
+
+		ctx, buf := exprcapture.WithCapture(context.Background())
+		res, err := s.TransformData(ctx, time.Now(), req)
+		require.NoError(t, err)
+
+		stages := buf.Stages()
+		require.Len(t, stages, 2)
+		for _, st := range stages {
+			require.Contains(t, res.Responses, st.RefID, "stage %s has no response entry to join to", st.RefID)
+		}
+		// Both sides of the comparison a support engineer needs: A's raw value and B's derived one.
+		requireResponseValue(t, res, "A", 2.0)
+		requireResponseValue(t, res, "B", 4.0)
+	})
+
+	t.Run("without one the hidden node is still stripped", func(t *testing.T) {
+		s, req := newMockQueryService(resp, queries)
+		s.cfg.ExpressionsEnabled = true
+
+		res, err := s.TransformData(context.Background(), time.Now(), req)
+		require.NoError(t, err)
+		require.NotContains(t, res.Responses, "A", "the normal query path must keep hiding hidden queries")
+		require.Contains(t, res.Responses, "B")
+	})
+}
+
+// unexecutableNode is a pipeline node that is not an ExecutableNode, which makes execute bail out with
+// makeUnexpectedNodeTypeError while still returning the vars it accumulated.
+type unexecutableNode struct{ refID string }
+
+func (n *unexecutableNode) ID() int64                      { return 1 }
+func (n *unexecutableNode) NodeType() NodeType             { return TypeCMDNode }
+func (n *unexecutableNode) RefID() string                  { return n.refID }
+func (n *unexecutableNode) String() string                 { return n.refID }
+func (n *unexecutableNode) NeedsVars() []string            { return []string{} }
+func (n *unexecutableNode) SetInputTo(string)              {}
+func (n *unexecutableNode) IsInputTo() map[string]struct{} { return nil }
+func (n *unexecutableNode) DisabledErr() error             { return nil }
+
+func TestExecutePipeline_capturesStagesWhenExecutionFailsHard(t *testing.T) {
+	// The DAG is worth more, not less, when the pipeline fails outright and produces no response at
+	// all, so the capture must not sit behind ExecutePipeline's error return.
+	s, _ := newMockQueryService(nil, nil)
+
+	ctx, buf := exprcapture.WithCapture(context.Background())
+	_, err := s.ExecutePipeline(ctx, time.Now(), DataPipeline{&unexecutableNode{refID: "A"}})
+	require.Error(t, err, "an unexecutable node fails the pipeline")
+
+	stages := buf.Stages()
+	require.Len(t, stages, 1, "the pipeline's shape is captured despite the failure")
+	require.Equal(t, "A", stages[0].RefID)
+}
+
 func TestExecutePipeline_noCaptureWithoutBuffer(t *testing.T) {
 	// Without a capture buffer in context the pipeline runs normally and records nothing.
 	resp := map[string]backend.DataResponse{"A": {Frames: data.Frames{

--- a/pkg/expr/graph_capture_test.go
+++ b/pkg/expr/graph_capture_test.go
@@ -55,7 +55,7 @@ func TestExecutePipeline_capturesExpressionStages(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx, buf := exprcapture.WithCapture(context.Background())
-	_, err = s.ExecutePipeline(ctx, time.Now(), pl)
+	res, err := s.ExecutePipeline(ctx, time.Now(), pl)
 	require.NoError(t, err)
 
 	stages := buf.Stages()
@@ -69,23 +69,27 @@ func TestExecutePipeline_capturesExpressionStages(t *testing.T) {
 	require.Equal(t, "datasource", byRef["A"].Type)
 	require.Equal(t, "test", byRef["A"].Command)
 	require.Empty(t, byRef["A"].InputRefIDs, "the datasource node consumes no other node")
-	require.NotEmpty(t, byRef["A"].Frames, "the datasource node's output frames are captured")
 	require.NoError(t, byRef["A"].Error)
 
 	require.Equal(t, "expression", byRef["B"].Type)
 	require.Equal(t, "math", byRef["B"].Command)
 	require.Equal(t, []string{"A"}, byRef["B"].InputRefIDs, "B consumes A")
-	require.NotEmpty(t, byRef["B"].Frames)
 
 	require.Equal(t, "expression", byRef["C"].Type)
 	require.Equal(t, []string{"B"}, byRef["C"].InputRefIDs, "C consumes B")
-	require.NotEmpty(t, byRef["C"].Frames)
 
-	// The captured chain lets a reader walk A -> B -> C: each stage's inputs are the outputs of its
-	// InputRefIDs, so the first stage whose output differs from its inputs is localizable.
-	requireStageValue(t, byRef["A"], 2.0)
-	requireStageValue(t, byRef["B"], 4.0)  // $A * 2
-	requireStageValue(t, byRef["C"], 14.0) // $B + 10
+	// The stages carry no frames of their own: every executed node is returned under its own refID,
+	// which is where the diagnostics bundle reads a stage's output from. Assert that join holds for
+	// every captured stage -- the capture is useless without it.
+	for _, st := range stages {
+		require.Contains(t, res.Responses, st.RefID, "stage %s has no response entry to join to", st.RefID)
+	}
+
+	// So a reader can walk A -> B -> C: each stage's inputs are the outputs of its InputRefIDs, and
+	// the first stage whose output differs from its inputs is localizable.
+	requireResponseValue(t, res, "A", 2.0)
+	requireResponseValue(t, res, "B", 4.0)  // $A * 2
+	requireResponseValue(t, res, "C", 14.0) // $B + 10
 }
 
 func TestExecutePipeline_capturesDependencyErrorStage(t *testing.T) {
@@ -98,7 +102,7 @@ func TestExecutePipeline_capturesDependencyErrorStage(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx, buf := exprcapture.WithCapture(context.Background())
-	_, err = s.ExecutePipeline(ctx, time.Now(), pl)
+	res, err := s.ExecutePipeline(ctx, time.Now(), pl)
 	require.NoError(t, err)
 
 	byRef := map[string]exprcapture.Stage{}
@@ -107,8 +111,8 @@ func TestExecutePipeline_capturesDependencyErrorStage(t *testing.T) {
 	}
 	require.Error(t, byRef["A"].Error, "A carries the datasource failure")
 	require.Error(t, byRef["B"].Error, "B carries a dependency error and did not run")
-	require.Empty(t, byRef["B"].Frames, "B produced no output")
 	require.Equal(t, []string{"A"}, byRef["B"].InputRefIDs)
+	require.Empty(t, res.Responses["B"].Frames, "B produced no output")
 }
 
 func TestExecutePipeline_noCaptureWithoutBuffer(t *testing.T) {
@@ -122,17 +126,20 @@ func TestExecutePipeline_noCaptureWithoutBuffer(t *testing.T) {
 	pl, err := s.BuildPipeline(t.Context(), req)
 	require.NoError(t, err)
 
-	// context.Background() carries no exprcapture buffer.
+	// context.Background() carries no exprcapture buffer, so this buffer is unreachable from the
+	// pipeline's context and must stay empty.
+	_, unreachable := exprcapture.WithCapture(context.Background())
 	_, err = s.ExecutePipeline(context.Background(), time.Now(), pl)
 	require.NoError(t, err)
-	require.Nil(t, exprcapture.FromContext(context.Background()))
+	require.Empty(t, unreachable.Stages(), "a pipeline run without the buffer in its context records nothing")
 }
 
-// requireStageValue asserts the single scalar/number value carried by a stage's output frame.
-func requireStageValue(t *testing.T, stage exprcapture.Stage, want float64) {
+// requireResponseValue asserts the single scalar/number value carried by a refID's output frame.
+func requireResponseValue(t *testing.T, res *backend.QueryDataResponse, refID string, want float64) {
 	t.Helper()
-	require.NotEmpty(t, stage.Frames)
-	for _, f := range stage.Frames {
+	frames := res.Responses[refID].Frames
+	require.NotEmpty(t, frames, "no frames for refId %s", refID)
+	for _, f := range frames {
 		for _, field := range f.Fields {
 			if field.Type() != data.FieldTypeNullableFloat64 && field.Type() != data.FieldTypeFloat64 {
 				continue
@@ -148,5 +155,5 @@ func requireStageValue(t *testing.T, stage exprcapture.Stage, want float64) {
 			return
 		}
 	}
-	t.Fatalf("no float value field found in stage %s", stage.RefID)
+	t.Fatalf("no float value field found for refId %s", refID)
 }

--- a/pkg/expr/graph_capture_test.go
+++ b/pkg/expr/graph_capture_test.go
@@ -1,0 +1,152 @@
+package expr
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"encoding/json"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/expr/exprcapture"
+	"github.com/grafana/grafana/pkg/services/datasources"
+)
+
+func fptr(f float64) *float64 { return &f }
+
+// dsQueryA is a datasource query for refID A returning whatever the mock endpoint holds for "A".
+func dsQueryA() Query {
+	return Query{
+		RefID: "A",
+		DataSource: &datasources.DataSource{
+			OrgID: 1,
+			UID:   "test",
+			Type:  "test",
+		},
+		JSON:      json.RawMessage(`{ "datasource": { "uid": "test" }, "intervalMs": 1000, "maxDataPoints": 1000 }`),
+		TimeRange: AbsoluteTimeRange{From: time.Time{}, To: time.Time{}},
+	}
+}
+
+func mathQuery(refID, expression string) Query {
+	return Query{
+		RefID:      refID,
+		DataSource: dataSourceModel(),
+		JSON:       json.RawMessage(`{ "datasource": { "uid": "__expr__", "type": "__expr__"}, "type": "math", "expression": "` + expression + `" }`),
+	}
+}
+
+func TestExecutePipeline_capturesExpressionStages(t *testing.T) {
+	dsDF := data.NewFrame("A",
+		data.NewField("time", nil, []time.Time{time.Unix(1, 0)}),
+		data.NewField("value", data.Labels{"host": "a"}, []*float64{fptr(2.0)}),
+	)
+	resp := map[string]backend.DataResponse{"A": {Frames: data.Frames{dsDF}}}
+
+	// A (datasource) -> B = $A * 2 -> C = $B + 10. A three-stage chain so a reader can localize which
+	// stage changed the data.
+	queries := []Query{dsQueryA(), mathQuery("B", "$A * 2"), mathQuery("C", "$B + 10")}
+
+	s, req := newMockQueryService(resp, queries)
+	pl, err := s.BuildPipeline(t.Context(), req)
+	require.NoError(t, err)
+
+	ctx, buf := exprcapture.WithCapture(context.Background())
+	_, err = s.ExecutePipeline(ctx, time.Now(), pl)
+	require.NoError(t, err)
+
+	stages := buf.Stages()
+	require.Len(t, stages, 3, "one stage per pipeline node")
+
+	byRef := map[string]exprcapture.Stage{}
+	for _, st := range stages {
+		byRef[st.RefID] = st
+	}
+
+	require.Equal(t, "datasource", byRef["A"].Type)
+	require.Equal(t, "test", byRef["A"].Command)
+	require.Empty(t, byRef["A"].InputRefIDs, "the datasource node consumes no other node")
+	require.NotEmpty(t, byRef["A"].Frames, "the datasource node's output frames are captured")
+	require.NoError(t, byRef["A"].Error)
+
+	require.Equal(t, "expression", byRef["B"].Type)
+	require.Equal(t, "math", byRef["B"].Command)
+	require.Equal(t, []string{"A"}, byRef["B"].InputRefIDs, "B consumes A")
+	require.NotEmpty(t, byRef["B"].Frames)
+
+	require.Equal(t, "expression", byRef["C"].Type)
+	require.Equal(t, []string{"B"}, byRef["C"].InputRefIDs, "C consumes B")
+	require.NotEmpty(t, byRef["C"].Frames)
+
+	// The captured chain lets a reader walk A -> B -> C: each stage's inputs are the outputs of its
+	// InputRefIDs, so the first stage whose output differs from its inputs is localizable.
+	requireStageValue(t, byRef["A"], 2.0)
+	requireStageValue(t, byRef["B"], 4.0)  // $A * 2
+	requireStageValue(t, byRef["C"], 14.0) // $B + 10
+}
+
+func TestExecutePipeline_capturesDependencyErrorStage(t *testing.T) {
+	// A fails at the datasource; B depends on A, so B is never executed and carries a dependency error.
+	resp := map[string]backend.DataResponse{"A": {Error: context.DeadlineExceeded}}
+	queries := []Query{dsQueryA(), mathQuery("B", "$A * 2")}
+
+	s, req := newMockQueryService(resp, queries)
+	pl, err := s.BuildPipeline(t.Context(), req)
+	require.NoError(t, err)
+
+	ctx, buf := exprcapture.WithCapture(context.Background())
+	_, err = s.ExecutePipeline(ctx, time.Now(), pl)
+	require.NoError(t, err)
+
+	byRef := map[string]exprcapture.Stage{}
+	for _, st := range buf.Stages() {
+		byRef[st.RefID] = st
+	}
+	require.Error(t, byRef["A"].Error, "A carries the datasource failure")
+	require.Error(t, byRef["B"].Error, "B carries a dependency error and did not run")
+	require.Empty(t, byRef["B"].Frames, "B produced no output")
+	require.Equal(t, []string{"A"}, byRef["B"].InputRefIDs)
+}
+
+func TestExecutePipeline_noCaptureWithoutBuffer(t *testing.T) {
+	// Without a capture buffer in context the pipeline runs normally and records nothing.
+	resp := map[string]backend.DataResponse{"A": {Frames: data.Frames{
+		data.NewFrame("A", data.NewField("value", nil, []*float64{fptr(1.0)})),
+	}}}
+	queries := []Query{dsQueryA(), mathQuery("B", "$A * 2")}
+
+	s, req := newMockQueryService(resp, queries)
+	pl, err := s.BuildPipeline(t.Context(), req)
+	require.NoError(t, err)
+
+	// context.Background() carries no exprcapture buffer.
+	_, err = s.ExecutePipeline(context.Background(), time.Now(), pl)
+	require.NoError(t, err)
+	require.Nil(t, exprcapture.FromContext(context.Background()))
+}
+
+// requireStageValue asserts the single scalar/number value carried by a stage's output frame.
+func requireStageValue(t *testing.T, stage exprcapture.Stage, want float64) {
+	t.Helper()
+	require.NotEmpty(t, stage.Frames)
+	for _, f := range stage.Frames {
+		for _, field := range f.Fields {
+			if field.Type() != data.FieldTypeNullableFloat64 && field.Type() != data.FieldTypeFloat64 {
+				continue
+			}
+			if field.Len() == 0 {
+				continue
+			}
+			v, ok := field.ConcreteAt(field.Len() - 1)
+			if !ok {
+				continue
+			}
+			require.InDelta(t, want, v.(float64), 0.0001)
+			return
+		}
+	}
+	t.Fatalf("no float value field found in stage %s", stage.RefID)
+}

--- a/pkg/expr/service.go
+++ b/pkg/expr/service.go
@@ -134,6 +134,7 @@ func (s *Service) ExecutePipeline(ctx context.Context, now time.Time, pipeline D
 	if err != nil {
 		return nil, err
 	}
+	captureDiagnosticStages(ctx, pipeline, vars)
 	for refID, val := range vars {
 		res.Responses[refID] = backend.DataResponse{
 			Frames: val.Values.AsDataFrames(refID),

--- a/pkg/expr/service.go
+++ b/pkg/expr/service.go
@@ -131,10 +131,13 @@ func (s *Service) ExecutePipeline(ctx context.Context, now time.Time, pipeline D
 	defer span.End()
 	res := backend.NewQueryDataResponse()
 	vars, err := pipeline.execute(ctx, now, s)
+	// Captured before the error check on purpose: execute returns populated vars alongside a hard
+	// failure (an unexpected node type), and the pipeline's shape is worth more to a reader in exactly
+	// that case, where no response is produced at all.
+	captureDiagnosticStages(ctx, pipeline, vars)
 	if err != nil {
 		return nil, err
 	}
-	captureDiagnosticStages(ctx, pipeline, vars)
 	for refID, val := range vars {
 		res.Responses[refID] = backend.DataResponse{
 			Frames: val.Values.AsDataFrames(refID),

--- a/pkg/expr/transform.go
+++ b/pkg/expr/transform.go
@@ -9,6 +9,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/expr/exprcapture"
 	"github.com/grafana/grafana/pkg/services/datasources"
 )
 
@@ -108,7 +109,14 @@ func (s *Service) TransformData(ctx context.Context, now time.Time, req *Request
 		return nil, err
 	}
 
-	if len(hidden) != 0 {
+	// The diagnostics capture path keeps hidden nodes in the response. exprcapture records every
+	// executed node as a stage, and a stage's output is the response entry sharing its refID, so
+	// dropping hidden refIDs here would leave those stages with nothing to join to -- and a hidden
+	// datasource query feeding a visible expression is exactly the stage a support engineer needs, to
+	// tell "the datasource returned the wrong data" from "the expression mangled it". Nothing renders
+	// this response: the diagnostics handlers serialize it into the bundle, and panel.json in the same
+	// bundle carries each target's hide flag, so a reader can still see which nodes the panel drew.
+	if len(hidden) != 0 && exprcapture.FromContext(ctx) == nil {
 		filteredRes := backend.NewQueryDataResponse()
 		for refID, res := range responses.Responses {
 			if _, ok := hidden[refID]; !ok {

--- a/pkg/services/diagnostics/diagnostics.go
+++ b/pkg/services/diagnostics/diagnostics.go
@@ -16,7 +16,6 @@ import (
 	"unicode/utf8"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
-	"github.com/grafana/grafana-plugin-sdk-go/data"
 
 	"github.com/grafana/grafana/pkg/expr/exprcapture"
 	"github.com/grafana/grafana/pkg/infra/httpclient/harcapture"
@@ -104,12 +103,11 @@ func (b *Bundler) Build(resp *backend.QueryDataResponse, harBuffer *harcapture.B
 }
 
 type queryDataArtifact struct {
-	Version            int                                 `json:"version"`
-	Request            json.RawMessage                     `json:"request,omitempty"`
-	Response           json.RawMessage                     `json:"response,omitempty"`
-	Expressions        []queryDataExpressionStage          `json:"expressions,omitempty"`
-	ResponseSummary    map[string]queryDataResponseSummary `json:"responseSummary,omitempty"`
-	ExpressionsSummary []queryDataExpressionStage          `json:"expressionsSummary,omitempty"`
+	Version         int                                 `json:"version"`
+	Request         json.RawMessage                     `json:"request,omitempty"`
+	Response        json.RawMessage                     `json:"response,omitempty"`
+	Expressions     []queryDataExpressionStage          `json:"expressions,omitempty"`
+	ResponseSummary map[string]queryDataResponseSummary `json:"responseSummary,omitempty"`
 	// ResponseError records why the full response is missing when it could not be JSON-encoded, so a
 	// reader can tell an unencodable response from one that was dropped to fit the size cap.
 	ResponseError      string `json:"responseError,omitempty"`
@@ -121,20 +119,24 @@ type queryDataArtifact struct {
 	ExpressionsOmitted bool   `json:"expressionsOmitted,omitempty"`
 }
 
-// queryDataExpressionStage is one node of the executed server-side expression pipeline. It records
-// which refIDs feed the node (InputRefIDs -> the node's inputs) and the node's Output, so a reader
-// can walk the DAG from the datasource nodes down to the panel's final expression and find the first
-// stage whose output differs from its inputs. Output is a datasource-style {status,frames,error}
-// object -- the same shape as the per-refID entries under "response" -- so intermediate stages read
-// identically to a normal query result. In the summarized (truncated) form Output holds a per-frame
-// row/field summary instead of the frame values.
+// queryDataExpressionStage is one node of the executed server-side expression pipeline: the DAG that
+// "response" alone cannot express. It records the node's kind (Type/Command) and which refIDs feed it
+// (InputRefIDs -> the node's inputs), so a reader can walk from the datasource nodes down to the
+// panel's final expression and find the first stage whose output differs from its inputs.
+//
+// A stage carries no output of its own. The expression service returns every executed node under its
+// own refID, so this stage's output is the entry with the same refId under "response".results (or,
+// once the artifact is over budget, under "responseSummary") -- a reader joins the two on refId.
+// Repeating the frames here would duplicate "response" byte-for-byte and halve the effective budget.
+//
+// Error is duplicated from the response entry on purpose: it is bounded, and it lets "which stage
+// failed" be answered from the DAG alone, without the join.
 type queryDataExpressionStage struct {
-	RefID       string          `json:"refId"`
-	Type        string          `json:"type,omitempty"`
-	Command     string          `json:"command,omitempty"`
-	InputRefIDs []string        `json:"inputRefIds,omitempty"`
-	Error       string          `json:"error,omitempty"`
-	Output      json.RawMessage `json:"output,omitempty"`
+	RefID       string   `json:"refId"`
+	Type        string   `json:"type,omitempty"`
+	Command     string   `json:"command,omitempty"`
+	InputRefIDs []string `json:"inputRefIds,omitempty"`
+	Error       string   `json:"error,omitempty"`
 }
 
 type queryDataResponseSummary struct {
@@ -160,14 +162,17 @@ func marshalQueryDataArtifact(request json.RawMessage, resp *backend.QueryDataRe
 // marshalQueryDataArtifactWithLimit returns the encoded querydata.json plus whether it had to drop
 // content to fit maxBytes, so callers don't have to re-parse the result to learn that.
 //
-// The response and the captured expression stages share one budget and one degradation ladder: the
-// full artifact carries both the full response and the full per-stage output frames; over budget (or
-// on an encode failure) both collapse to their summaries (per-refID and per-stage row/field counts)
-// via fitQueryDataArtifact, which then drops the request, both summaries, and finally the free-form
-// responseError -- so a reader always keeps the execution shape (which stage/refID errored or changed
-// frame counts) even when the values can't be kept.
+// The captured expression stages are bounded by the node count and carry no frame values (see
+// queryDataExpressionStage), so they ride along at every tier rather than sharing the response's
+// degradation ladder: over budget, or on an encode failure, the response collapses to its per-refID
+// summary while the DAG survives intact. fitQueryDataArtifact then drops the request, the response
+// summary, the stages, and finally the free-form responseError.
 func marshalQueryDataArtifactWithLimit(request json.RawMessage, resp *backend.QueryDataResponse, stages []exprcapture.Stage, maxBytes int) ([]byte, bool, error) {
-	artifact := queryDataArtifact{Version: queryDataArtifactVersion, Request: request}
+	artifact := queryDataArtifact{
+		Version:     queryDataArtifactVersion,
+		Request:     request,
+		Expressions: buildExpressionStages(stages),
+	}
 	if resp != nil {
 		// The SDK encoder returns a complete byte slice. The artifact/archive is bounded below, but
 		// serializing an oversized response can still temporarily allocate its full JSON size.
@@ -177,19 +182,18 @@ func marshalQueryDataArtifactWithLimit(request json.RawMessage, resp *backend.Qu
 			// usually still has a serializable request beside it. Degrade to the same request + summary
 			// shape the size cap uses instead of dropping both -- losing the submitted query in exactly
 			// the hard-to-encode cases this artifact exists to capture defeats its purpose. The captured
-			// expression stages degrade to their summary alongside it.
+			// expression stages carry no frames, so they survive this tier untouched.
 			//
 			// The error is returned as well, so both callers record it outside the artifact
 			// (querydata-error.txt, manifest.queryDataError). That makes the embedded copy a convenience:
 			// bound it by the budget so a verbose plugin error cannot crowd out the request, which is
 			// recorded nowhere else.
 			out, fallbackErr := fitQueryDataArtifact(queryDataArtifact{
-				Version:            queryDataArtifactVersion,
-				ResponseSummary:    summarizeQueryDataResponse(resp),
-				ExpressionsSummary: summarizeExpressionStages(stages),
-				ResponseError:      truncateDiagnosticString(err.Error(), min(1024, maxBytes/4)),
-				ResponseOmitted:    true,
-				ExpressionsOmitted: len(stages) > 0,
+				Version:         queryDataArtifactVersion,
+				Expressions:     artifact.Expressions,
+				ResponseSummary: summarizeQueryDataResponse(resp),
+				ResponseError:   truncateDiagnosticString(err.Error(), min(1024, maxBytes/4)),
+				ResponseOmitted: true,
 			}, request, maxBytes)
 			if fallbackErr != nil {
 				return nil, false, errors.Join(err, fallbackErr)
@@ -198,49 +202,29 @@ func marshalQueryDataArtifactWithLimit(request json.RawMessage, resp *backend.Qu
 		}
 		artifact.Response = responseJSON
 	}
-	expressions, err := buildExpressionStages(stages)
-	if err != nil {
-		// An expression stage we cannot encode is degraded symmetrically to an unencodable response:
-		// keep every stage's summary (metadata + row/field counts) rather than dropping the whole
-		// artifact. The response degrades to its summary too so the fallback stays uniformly
-		// summary-shaped and bounded, and the error is returned so the caller records it outside the
-		// artifact (querydata-error.txt / manifest.queryDataError).
-		out, fallbackErr := fitQueryDataArtifact(queryDataArtifact{
-			Version:            queryDataArtifactVersion,
-			ResponseSummary:    summarizeQueryDataResponse(resp),
-			ExpressionsSummary: summarizeExpressionStages(stages),
-			ResponseOmitted:    resp != nil,
-			ExpressionsOmitted: len(stages) > 0,
-		}, request, maxBytes)
-		if fallbackErr != nil {
-			return nil, false, errors.Join(err, fallbackErr)
-		}
-		return out, false, err
-	}
-	artifact.Expressions = expressions
 	full, err := json.MarshalIndent(artifact, "", "  ")
 	if err != nil || len(full) <= maxBytes {
 		return full, false, err
 	}
 
 	out, err := fitQueryDataArtifact(queryDataArtifact{
-		Version:            queryDataArtifactVersion,
-		ResponseSummary:    summarizeQueryDataResponse(resp),
-		ExpressionsSummary: summarizeExpressionStages(stages),
-		Truncated:          true,
-		LimitBytes:         maxBytes,
-		OriginalBytes:      len(full),
-		ResponseOmitted:    resp != nil,
-		ExpressionsOmitted: len(stages) > 0,
+		Version:         queryDataArtifactVersion,
+		Expressions:     artifact.Expressions,
+		ResponseSummary: summarizeQueryDataResponse(resp),
+		Truncated:       true,
+		LimitBytes:      maxBytes,
+		OriginalBytes:   len(full),
+		ResponseOmitted: resp != nil,
 	}, request, maxBytes)
 	return out, true, err
 }
 
 // fitQueryDataArtifact encodes artifact with progressively less content -- request kept, request
-// omitted, summary dropped, then markers only -- and returns the first encoding within maxBytes. The
-// last rung holds only fixed-size markers, which keeps it under minQueryDataArtifactBytes so the
-// budget gate in BuildDashboard stays meaningful; it is returned even when it somehow still doesn't
-// fit, because there is nothing further to drop, and callers enforcing a hard budget re-check length.
+// omitted, response summary dropped, expression stages dropped, then markers only -- and returns the
+// first encoding within maxBytes. The last rung holds only fixed-size markers, which keeps it under
+// minQueryDataArtifactBytes so the budget gate in BuildDashboard stays meaningful; it is returned
+// even when it somehow still doesn't fit, because there is nothing further to drop, and callers
+// enforcing a hard budget re-check length.
 func fitQueryDataArtifact(artifact queryDataArtifact, request json.RawMessage, maxBytes int) ([]byte, error) {
 	artifact.Request = request
 	out, err := json.MarshalIndent(artifact, "", "  ")
@@ -261,11 +245,20 @@ func fitQueryDataArtifact(artifact queryDataArtifact, request json.RawMessage, m
 		return out, nil
 	}
 
-	// The per-refID and per-stage summaries are dropped together: both are variable-size "execution
-	// shape without values" content, and the ResponseOmitted/ExpressionsOmitted markers below still
-	// record that they existed.
 	artifact.ResponseSummary = nil
-	artifact.ExpressionsSummary = nil
+	out, err = json.MarshalIndent(artifact, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	if len(out) <= maxBytes {
+		return out, nil
+	}
+
+	// The expression stages outlive the response summary: they are the smaller of the two (bounded by
+	// node count, no per-frame entries) and they are the only record of the pipeline's shape, which
+	// nothing else in the bundle carries. ExpressionsOmitted records that they existed.
+	artifact.ExpressionsOmitted = len(artifact.Expressions) > 0
+	artifact.Expressions = nil
 	out, err = json.MarshalIndent(artifact, "", "  ")
 	if err != nil {
 		return nil, err
@@ -280,39 +273,11 @@ func fitQueryDataArtifact(artifact queryDataArtifact, request json.RawMessage, m
 	return json.MarshalIndent(artifact, "", "  ")
 }
 
-// buildExpressionStages serializes each captured pipeline node into the artifact's expression-stage
-// view. Each node's Output is rendered as a datasource-style {status,frames,error} object (the same
-// shape as a "response" entry) with any synthetic __har__ carrier frames removed, so an expression
-// node reads exactly like a normal query result.
-func buildExpressionStages(stages []exprcapture.Stage) ([]queryDataExpressionStage, error) {
-	if len(stages) == 0 {
-		return nil, nil
-	}
-	out := make([]queryDataExpressionStage, 0, len(stages))
-	for _, s := range stages {
-		stage := queryDataExpressionStage{
-			RefID:       s.RefID,
-			Type:        s.Type,
-			Command:     s.Command,
-			InputRefIDs: s.InputRefIDs,
-		}
-		if s.Error != nil {
-			stage.Error = truncateDiagnosticString(s.Error.Error(), 1024)
-		}
-		dr := backend.DataResponse{Frames: framesWithoutCaptureFrames(s.Frames), Error: s.Error}
-		outputJSON, err := json.Marshal(dr)
-		if err != nil {
-			return nil, err
-		}
-		stage.Output = outputJSON
-		out = append(out, stage)
-	}
-	return out, nil
-}
-
-// summarizeExpressionStages renders each stage without frame values: node metadata, error, and a
-// per-frame row/field summary. Used when the full artifact exceeds its byte budget.
-func summarizeExpressionStages(stages []exprcapture.Stage) []queryDataExpressionStage {
+// buildExpressionStages renders the captured pipeline nodes as the artifact's expression-stage view:
+// the DAG (node kind, command, input refIDs) and each node's error, with outputs left to the
+// response entry sharing the stage's refId. Total size is bounded by the node count, so unlike the
+// response this needs no summarized form.
+func buildExpressionStages(stages []exprcapture.Stage) []queryDataExpressionStage {
 	if len(stages) == 0 {
 		return nil
 	}
@@ -327,44 +292,7 @@ func summarizeExpressionStages(stages []exprcapture.Stage) []queryDataExpression
 		if s.Error != nil {
 			stage.Error = truncateDiagnosticString(s.Error.Error(), 1024)
 		}
-		summaries := make([]queryDataFrameSummary, 0, len(s.Frames))
-		for _, frame := range framesWithoutCaptureFrames(s.Frames) {
-			if frame == nil {
-				continue
-			}
-			rows, err := frame.RowLen()
-			if err != nil {
-				rows = -1
-			}
-			summaries = append(summaries, queryDataFrameSummary{
-				Name:   truncateDiagnosticString(frame.Name, 256),
-				RefID:  truncateDiagnosticString(frame.RefID, 256),
-				Rows:   rows,
-				Fields: len(frame.Fields),
-			})
-		}
-		if len(summaries) > 0 {
-			if raw, err := json.Marshal(summaries); err == nil {
-				stage.Output = raw
-			}
-		}
 		out = append(out, stage)
-	}
-	return out
-}
-
-// framesWithoutCaptureFrames drops the synthetic __har__ capture carrier frames (matched by refID or
-// name prefix) so they don't leak into an expression node's output.
-func framesWithoutCaptureFrames(frames data.Frames) data.Frames {
-	if len(frames) == 0 {
-		return frames
-	}
-	out := make(data.Frames, 0, len(frames))
-	for _, frame := range frames {
-		if frame != nil && (isHARResponse(frame.RefID) || isHARResponse(frame.Name)) {
-			continue
-		}
-		out = append(out, frame)
 	}
 	return out
 }
@@ -522,7 +450,7 @@ func (b *Bundler) BuildDashboard(dashboardJSON json.RawMessage, panels []Dashboa
 		if p.QueryRequestErr != nil {
 			queryDataErrs = append(queryDataErrs, "serialize query request: "+p.QueryRequestErr.Error())
 		}
-		if p.Resp != nil || len(p.QueryRequest) > 0 {
+		if p.Resp != nil || len(p.QueryRequest) > 0 || len(p.ExpressionStages) > 0 {
 			queryDataLimit := min(maxQueryDataArtifactBytes, queryDataBytesRemaining)
 			if queryDataLimit < minQueryDataArtifactBytes {
 				entry.QueryDataTruncated = true

--- a/pkg/services/diagnostics/diagnostics.go
+++ b/pkg/services/diagnostics/diagnostics.go
@@ -16,7 +16,9 @@ import (
 	"unicode/utf8"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
 
+	"github.com/grafana/grafana/pkg/expr/exprcapture"
 	"github.com/grafana/grafana/pkg/infra/httpclient/harcapture"
 )
 
@@ -49,7 +51,7 @@ func NewBundler() *Bundler {
 //
 // Server logs are intentionally omitted because they are not scoped to this request and would leak
 // unrelated activity into a bundle meant for external sharing; they will be tackled in a follow-up.
-func (b *Bundler) Build(resp *backend.QueryDataResponse, harBuffer *harcapture.Buffer, panelJSON, dashboardJSON, queryRequestJSON json.RawMessage, queryRequestErr, queryErr error) ([]byte, error) {
+func (b *Bundler) Build(resp *backend.QueryDataResponse, harBuffer *harcapture.Buffer, panelJSON, dashboardJSON, queryRequestJSON json.RawMessage, expressionStages []exprcapture.Stage, queryRequestErr, queryErr error) ([]byte, error) {
 	files := map[string][]byte{}
 
 	// queryRequestErr is the caller's failure to serialize the request into queryRequestJSON. Record it
@@ -59,8 +61,8 @@ func (b *Bundler) Build(resp *backend.QueryDataResponse, harBuffer *harcapture.B
 	if queryRequestErr != nil {
 		queryDataErr = fmt.Errorf("serialize query request: %w", queryRequestErr)
 	}
-	if resp != nil || len(queryRequestJSON) > 0 {
-		queryData, err := marshalQueryDataArtifact(queryRequestJSON, resp)
+	if resp != nil || len(queryRequestJSON) > 0 || len(expressionStages) > 0 {
+		queryData, err := marshalQueryDataArtifact(queryRequestJSON, resp, expressionStages)
 		if err != nil {
 			// A query-data artifact that cannot be fully JSON-encoded must not sink the whole bundle:
 			// record the failure and still ship HAR and the other artifacts, mirroring how the dashboard
@@ -102,18 +104,37 @@ func (b *Bundler) Build(resp *backend.QueryDataResponse, harBuffer *harcapture.B
 }
 
 type queryDataArtifact struct {
-	Version         int                                 `json:"version"`
-	Request         json.RawMessage                     `json:"request,omitempty"`
-	Response        json.RawMessage                     `json:"response,omitempty"`
-	ResponseSummary map[string]queryDataResponseSummary `json:"responseSummary,omitempty"`
+	Version            int                                 `json:"version"`
+	Request            json.RawMessage                     `json:"request,omitempty"`
+	Response           json.RawMessage                     `json:"response,omitempty"`
+	Expressions        []queryDataExpressionStage          `json:"expressions,omitempty"`
+	ResponseSummary    map[string]queryDataResponseSummary `json:"responseSummary,omitempty"`
+	ExpressionsSummary []queryDataExpressionStage          `json:"expressionsSummary,omitempty"`
 	// ResponseError records why the full response is missing when it could not be JSON-encoded, so a
 	// reader can tell an unencodable response from one that was dropped to fit the size cap.
-	ResponseError   string `json:"responseError,omitempty"`
-	Truncated       bool   `json:"truncated,omitempty"`
-	LimitBytes      int    `json:"limitBytes,omitempty"`
-	OriginalBytes   int    `json:"originalBytes,omitempty"`
-	RequestOmitted  bool   `json:"requestOmitted,omitempty"`
-	ResponseOmitted bool   `json:"responseOmitted,omitempty"`
+	ResponseError      string `json:"responseError,omitempty"`
+	Truncated          bool   `json:"truncated,omitempty"`
+	LimitBytes         int    `json:"limitBytes,omitempty"`
+	OriginalBytes      int    `json:"originalBytes,omitempty"`
+	RequestOmitted     bool   `json:"requestOmitted,omitempty"`
+	ResponseOmitted    bool   `json:"responseOmitted,omitempty"`
+	ExpressionsOmitted bool   `json:"expressionsOmitted,omitempty"`
+}
+
+// queryDataExpressionStage is one node of the executed server-side expression pipeline. It records
+// which refIDs feed the node (InputRefIDs -> the node's inputs) and the node's Output, so a reader
+// can walk the DAG from the datasource nodes down to the panel's final expression and find the first
+// stage whose output differs from its inputs. Output is a datasource-style {status,frames,error}
+// object -- the same shape as the per-refID entries under "response" -- so intermediate stages read
+// identically to a normal query result. In the summarized (truncated) form Output holds a per-frame
+// row/field summary instead of the frame values.
+type queryDataExpressionStage struct {
+	RefID       string          `json:"refId"`
+	Type        string          `json:"type,omitempty"`
+	Command     string          `json:"command,omitempty"`
+	InputRefIDs []string        `json:"inputRefIds,omitempty"`
+	Error       string          `json:"error,omitempty"`
+	Output      json.RawMessage `json:"output,omitempty"`
 }
 
 type queryDataResponseSummary struct {
@@ -131,14 +152,21 @@ type queryDataFrameSummary struct {
 	Fields int    `json:"fields"`
 }
 
-func marshalQueryDataArtifact(request json.RawMessage, resp *backend.QueryDataResponse) ([]byte, error) {
-	data, _, err := marshalQueryDataArtifactWithLimit(request, resp, maxQueryDataArtifactBytes)
+func marshalQueryDataArtifact(request json.RawMessage, resp *backend.QueryDataResponse, stages []exprcapture.Stage) ([]byte, error) {
+	data, _, err := marshalQueryDataArtifactWithLimit(request, resp, stages, maxQueryDataArtifactBytes)
 	return data, err
 }
 
 // marshalQueryDataArtifactWithLimit returns the encoded querydata.json plus whether it had to drop
 // content to fit maxBytes, so callers don't have to re-parse the result to learn that.
-func marshalQueryDataArtifactWithLimit(request json.RawMessage, resp *backend.QueryDataResponse, maxBytes int) ([]byte, bool, error) {
+//
+// The response and the captured expression stages share one budget and one degradation ladder: the
+// full artifact carries both the full response and the full per-stage output frames; over budget (or
+// on an encode failure) both collapse to their summaries (per-refID and per-stage row/field counts)
+// via fitQueryDataArtifact, which then drops the request, both summaries, and finally the free-form
+// responseError -- so a reader always keeps the execution shape (which stage/refID errored or changed
+// frame counts) even when the values can't be kept.
+func marshalQueryDataArtifactWithLimit(request json.RawMessage, resp *backend.QueryDataResponse, stages []exprcapture.Stage, maxBytes int) ([]byte, bool, error) {
 	artifact := queryDataArtifact{Version: queryDataArtifactVersion, Request: request}
 	if resp != nil {
 		// The SDK encoder returns a complete byte slice. The artifact/archive is bounded below, but
@@ -148,17 +176,20 @@ func marshalQueryDataArtifactWithLimit(request json.RawMessage, resp *backend.Qu
 			// A response that cannot be encoded (e.g. an unserializable value in a frame's Meta.Custom)
 			// usually still has a serializable request beside it. Degrade to the same request + summary
 			// shape the size cap uses instead of dropping both -- losing the submitted query in exactly
-			// the hard-to-encode cases this artifact exists to capture defeats its purpose.
+			// the hard-to-encode cases this artifact exists to capture defeats its purpose. The captured
+			// expression stages degrade to their summary alongside it.
 			//
 			// The error is returned as well, so both callers record it outside the artifact
 			// (querydata-error.txt, manifest.queryDataError). That makes the embedded copy a convenience:
 			// bound it by the budget so a verbose plugin error cannot crowd out the request, which is
 			// recorded nowhere else.
 			out, fallbackErr := fitQueryDataArtifact(queryDataArtifact{
-				Version:         queryDataArtifactVersion,
-				ResponseSummary: summarizeQueryDataResponse(resp),
-				ResponseError:   truncateDiagnosticString(err.Error(), min(1024, maxBytes/4)),
-				ResponseOmitted: true,
+				Version:            queryDataArtifactVersion,
+				ResponseSummary:    summarizeQueryDataResponse(resp),
+				ExpressionsSummary: summarizeExpressionStages(stages),
+				ResponseError:      truncateDiagnosticString(err.Error(), min(1024, maxBytes/4)),
+				ResponseOmitted:    true,
+				ExpressionsOmitted: len(stages) > 0,
 			}, request, maxBytes)
 			if fallbackErr != nil {
 				return nil, false, errors.Join(err, fallbackErr)
@@ -167,18 +198,40 @@ func marshalQueryDataArtifactWithLimit(request json.RawMessage, resp *backend.Qu
 		}
 		artifact.Response = responseJSON
 	}
+	expressions, err := buildExpressionStages(stages)
+	if err != nil {
+		// An expression stage we cannot encode is degraded symmetrically to an unencodable response:
+		// keep every stage's summary (metadata + row/field counts) rather than dropping the whole
+		// artifact. The response degrades to its summary too so the fallback stays uniformly
+		// summary-shaped and bounded, and the error is returned so the caller records it outside the
+		// artifact (querydata-error.txt / manifest.queryDataError).
+		out, fallbackErr := fitQueryDataArtifact(queryDataArtifact{
+			Version:            queryDataArtifactVersion,
+			ResponseSummary:    summarizeQueryDataResponse(resp),
+			ExpressionsSummary: summarizeExpressionStages(stages),
+			ResponseOmitted:    resp != nil,
+			ExpressionsOmitted: len(stages) > 0,
+		}, request, maxBytes)
+		if fallbackErr != nil {
+			return nil, false, errors.Join(err, fallbackErr)
+		}
+		return out, false, err
+	}
+	artifact.Expressions = expressions
 	full, err := json.MarshalIndent(artifact, "", "  ")
 	if err != nil || len(full) <= maxBytes {
 		return full, false, err
 	}
 
 	out, err := fitQueryDataArtifact(queryDataArtifact{
-		Version:         queryDataArtifactVersion,
-		ResponseSummary: summarizeQueryDataResponse(resp),
-		Truncated:       true,
-		LimitBytes:      maxBytes,
-		OriginalBytes:   len(full),
-		ResponseOmitted: resp != nil,
+		Version:            queryDataArtifactVersion,
+		ResponseSummary:    summarizeQueryDataResponse(resp),
+		ExpressionsSummary: summarizeExpressionStages(stages),
+		Truncated:          true,
+		LimitBytes:         maxBytes,
+		OriginalBytes:      len(full),
+		ResponseOmitted:    resp != nil,
+		ExpressionsOmitted: len(stages) > 0,
 	}, request, maxBytes)
 	return out, true, err
 }
@@ -208,7 +261,11 @@ func fitQueryDataArtifact(artifact queryDataArtifact, request json.RawMessage, m
 		return out, nil
 	}
 
+	// The per-refID and per-stage summaries are dropped together: both are variable-size "execution
+	// shape without values" content, and the ResponseOmitted/ExpressionsOmitted markers below still
+	// record that they existed.
 	artifact.ResponseSummary = nil
+	artifact.ExpressionsSummary = nil
 	out, err = json.MarshalIndent(artifact, "", "  ")
 	if err != nil {
 		return nil, err
@@ -221,6 +278,95 @@ func fitQueryDataArtifact(artifact queryDataArtifact, request json.RawMessage, m
 	// is recorded outside the artifact, so dropping it leaves markers a reader can still act on.
 	artifact.ResponseError = ""
 	return json.MarshalIndent(artifact, "", "  ")
+}
+
+// buildExpressionStages serializes each captured pipeline node into the artifact's expression-stage
+// view. Each node's Output is rendered as a datasource-style {status,frames,error} object (the same
+// shape as a "response" entry) with any synthetic __har__ carrier frames removed, so an expression
+// node reads exactly like a normal query result.
+func buildExpressionStages(stages []exprcapture.Stage) ([]queryDataExpressionStage, error) {
+	if len(stages) == 0 {
+		return nil, nil
+	}
+	out := make([]queryDataExpressionStage, 0, len(stages))
+	for _, s := range stages {
+		stage := queryDataExpressionStage{
+			RefID:       s.RefID,
+			Type:        s.Type,
+			Command:     s.Command,
+			InputRefIDs: s.InputRefIDs,
+		}
+		if s.Error != nil {
+			stage.Error = truncateDiagnosticString(s.Error.Error(), 1024)
+		}
+		dr := backend.DataResponse{Frames: framesWithoutCaptureFrames(s.Frames), Error: s.Error}
+		outputJSON, err := json.Marshal(dr)
+		if err != nil {
+			return nil, err
+		}
+		stage.Output = outputJSON
+		out = append(out, stage)
+	}
+	return out, nil
+}
+
+// summarizeExpressionStages renders each stage without frame values: node metadata, error, and a
+// per-frame row/field summary. Used when the full artifact exceeds its byte budget.
+func summarizeExpressionStages(stages []exprcapture.Stage) []queryDataExpressionStage {
+	if len(stages) == 0 {
+		return nil
+	}
+	out := make([]queryDataExpressionStage, 0, len(stages))
+	for _, s := range stages {
+		stage := queryDataExpressionStage{
+			RefID:       s.RefID,
+			Type:        s.Type,
+			Command:     s.Command,
+			InputRefIDs: s.InputRefIDs,
+		}
+		if s.Error != nil {
+			stage.Error = truncateDiagnosticString(s.Error.Error(), 1024)
+		}
+		summaries := make([]queryDataFrameSummary, 0, len(s.Frames))
+		for _, frame := range framesWithoutCaptureFrames(s.Frames) {
+			if frame == nil {
+				continue
+			}
+			rows, err := frame.RowLen()
+			if err != nil {
+				rows = -1
+			}
+			summaries = append(summaries, queryDataFrameSummary{
+				Name:   truncateDiagnosticString(frame.Name, 256),
+				RefID:  truncateDiagnosticString(frame.RefID, 256),
+				Rows:   rows,
+				Fields: len(frame.Fields),
+			})
+		}
+		if len(summaries) > 0 {
+			if raw, err := json.Marshal(summaries); err == nil {
+				stage.Output = raw
+			}
+		}
+		out = append(out, stage)
+	}
+	return out
+}
+
+// framesWithoutCaptureFrames drops the synthetic __har__ capture carrier frames (matched by refID or
+// name prefix) so they don't leak into an expression node's output.
+func framesWithoutCaptureFrames(frames data.Frames) data.Frames {
+	if len(frames) == 0 {
+		return frames
+	}
+	out := make(data.Frames, 0, len(frames))
+	for _, frame := range frames {
+		if frame != nil && (isHARResponse(frame.RefID) || isHARResponse(frame.Name)) {
+			continue
+		}
+		out = append(out, frame)
+	}
+	return out
 }
 
 func summarizeQueryDataResponse(resp *backend.QueryDataResponse) map[string]queryDataResponseSummary {
@@ -294,12 +440,13 @@ type DashboardPanel struct {
 	QueryRequest json.RawMessage // MetricRequest submitted for this panel
 	// QueryRequestErr records a failure to serialize this panel's MetricRequest. Kept separate so one
 	// unserializable request only costs this panel its request JSON, not the whole multi-panel bundle.
-	QueryRequestErr error
-	Datasources     []string                   // datasource UIDs the panel references (for the manifest)
-	Resp            *backend.QueryDataResponse // query response, carries external plugins' __har__ frames
-	HARBuffer       *harcapture.Buffer         // in-process capture buffer for this panel's queries
-	QueryErr        error                      // top-level error running the panel's queries, if any
-	Skipped         string                     // non-empty => panel was not executed (e.g. non-data panel)
+	QueryRequestErr  error
+	Datasources      []string                   // datasource UIDs the panel references (for the manifest)
+	Resp             *backend.QueryDataResponse // query response, carries external plugins' __har__ frames
+	HARBuffer        *harcapture.Buffer         // in-process capture buffer for this panel's queries
+	ExpressionStages []exprcapture.Stage        // captured server-side expression pipeline stages, if any
+	QueryErr         error                      // top-level error running the panel's queries, if any
+	Skipped          string                     // non-empty => panel was not executed (e.g. non-data panel)
 }
 
 // dashboardManifest is manifest.json: a machine-readable summary of what the whole-dashboard bundle
@@ -381,7 +528,7 @@ func (b *Bundler) BuildDashboard(dashboardJSON json.RawMessage, panels []Dashboa
 				entry.QueryDataTruncated = true
 				queryDataErrs = append(queryDataErrs, fmt.Sprintf("remaining dashboard query-data budget (%d bytes) below the %d-byte minimum artifact size", queryDataBytesRemaining, minQueryDataArtifactBytes))
 			} else {
-				queryData, truncated, err := marshalQueryDataArtifactWithLimit(p.QueryRequest, p.Resp, queryDataLimit)
+				queryData, truncated, err := marshalQueryDataArtifactWithLimit(p.QueryRequest, p.Resp, p.ExpressionStages, queryDataLimit)
 				if err != nil {
 					queryDataErrs = append(queryDataErrs, err.Error())
 				}

--- a/pkg/services/diagnostics/diagnostics.go
+++ b/pkg/services/diagnostics/diagnostics.go
@@ -264,8 +264,10 @@ func fitQueryDataArtifact(artifact queryDataArtifact, request json.RawMessage, m
 
 	// The stage errors go before the stages themselves: each is free-form text up to 1 KiB, so on a
 	// tight budget they are what pushes the DAG over, and they are the one part of a stage that is
-	// recoverable elsewhere -- responseSummary[refId].error carries the same string, and the failure is
-	// recorded again outside the artifact. Dropping them keeps the pipeline's shape, which nothing else
+	// recoverable elsewhere -- query-error.txt carries the same per-refID failures, folded in by
+	// ResponseError, and the capture path keeps hidden refIDs in the response so even a hidden stage's
+	// error reaches it. Not responseSummary[refId].error: the rung above already dropped the summary,
+	// so by here it is gone. Dropping the stage errors keeps the pipeline's shape, which nothing else
 	// in the bundle records at all.
 	if pipelineHasErrors(artifact.Pipeline) {
 		// Cloned rather than cleared in place: artifact is a value copy, but its Pipeline slice still

--- a/pkg/services/diagnostics/diagnostics.go
+++ b/pkg/services/diagnostics/diagnostics.go
@@ -45,24 +45,48 @@ func NewBundler() *Bundler {
 	return &Bundler{}
 }
 
+// BundleInput is everything the single-panel bundle is assembled from. A struct rather than a
+// parameter list: the fields are mostly optional and several share a type (two json.RawMessage
+// documents, two errors), so positionally they were indistinguishable -- a call site that swapped
+// QueryRequestErr for QueryErr, or panel for dashboard JSON, still compiled and only showed up as a
+// mislabelled file inside the archive.
+type BundleInput struct {
+	// Resp is the query response. It also carries external (gRPC) plugins' __har__ capture frames.
+	Resp *backend.QueryDataResponse
+	// HARBuffer is the in-process HTTP capture for this request. Nil-safe: no traffic.har is written.
+	HARBuffer *harcapture.Buffer
+	// PanelJSON and DashboardJSON are the definitions the client already held, written verbatim.
+	PanelJSON     json.RawMessage
+	DashboardJSON json.RawMessage
+	// QueryRequestJSON is the submitted MetricRequest, recorded under querydata.json's "request".
+	QueryRequestJSON json.RawMessage
+	// ExpressionStages is the captured server-side expression pipeline, if any.
+	ExpressionStages []exprcapture.Stage
+	// QueryRequestErr is the CALLER's failure to serialize QueryRequestJSON -- not a query failure.
+	// Recorded in querydata-error.txt so a reader can tell an omitted request from a dropped one.
+	QueryRequestErr error
+	// QueryErr is the failure running the queries (top-level or folded per-refId), in query-error.txt.
+	QueryErr error
+}
+
 // Build assembles a .tar.gz bundle from the query response, the captured HAR buffer, and the
 // optional panel/dashboard JSON the client supplied. traffic.har is omitted when nothing was
 // captured.
 //
 // Server logs are intentionally omitted because they are not scoped to this request and would leak
 // unrelated activity into a bundle meant for external sharing; they will be tackled in a follow-up.
-func (b *Bundler) Build(resp *backend.QueryDataResponse, harBuffer *harcapture.Buffer, panelJSON, dashboardJSON, queryRequestJSON json.RawMessage, expressionStages []exprcapture.Stage, queryRequestErr, queryErr error) ([]byte, error) {
+func (b *Bundler) Build(in BundleInput) ([]byte, error) {
 	files := map[string][]byte{}
 
-	// queryRequestErr is the caller's failure to serialize the request into queryRequestJSON. Record it
+	// QueryRequestErr is the caller's failure to serialize the request into QueryRequestJSON. Record it
 	// so a support engineer can tell the request JSON was omitted because serialization failed rather
 	// than silently dropped, mirroring how the per-panel dashboard path records manifest.queryDataError.
 	var queryDataErr error
-	if queryRequestErr != nil {
-		queryDataErr = fmt.Errorf("serialize query request: %w", queryRequestErr)
+	if in.QueryRequestErr != nil {
+		queryDataErr = fmt.Errorf("serialize query request: %w", in.QueryRequestErr)
 	}
-	if resp != nil || len(queryRequestJSON) > 0 || len(expressionStages) > 0 {
-		queryData, err := marshalQueryDataArtifact(queryRequestJSON, resp, expressionStages)
+	if in.Resp != nil || len(in.QueryRequestJSON) > 0 || len(in.ExpressionStages) > 0 {
+		queryData, err := marshalQueryDataArtifact(in.QueryRequestJSON, in.Resp, in.ExpressionStages)
 		if err != nil {
 			// A query-data artifact that cannot be fully JSON-encoded must not sink the whole bundle:
 			// record the failure and still ship HAR and the other artifacts, mirroring how the dashboard
@@ -79,7 +103,7 @@ func (b *Bundler) Build(resp *backend.QueryDataResponse, harBuffer *harcapture.B
 		files["querydata-error.txt"] = []byte(queryDataErr.Error() + "\n")
 	}
 
-	har, err := collectHAR(resp, harBuffer)
+	har, err := collectHAR(in.Resp, in.HARBuffer)
 	if err != nil {
 		return nil, err
 	}
@@ -87,17 +111,17 @@ func (b *Bundler) Build(resp *backend.QueryDataResponse, harBuffer *harcapture.B
 		files["traffic.har"] = har
 	}
 
-	if len(panelJSON) > 0 {
-		files["panel.json"] = indentJSON(panelJSON)
+	if len(in.PanelJSON) > 0 {
+		files["panel.json"] = indentJSON(in.PanelJSON)
 	}
-	if len(dashboardJSON) > 0 {
-		files["dashboard.json"] = indentJSON(dashboardJSON)
+	if len(in.DashboardJSON) > 0 {
+		files["dashboard.json"] = indentJSON(in.DashboardJSON)
 	}
 
-	if queryErr != nil {
+	if in.QueryErr != nil {
 		// Recorded verbatim -- redaction is intentionally deferred for this experimental feature
 		// (see the harcapture package doc); the error text can embed a request URL with credentials.
-		files["query-error.txt"] = []byte(queryErr.Error() + "\n")
+		files["query-error.txt"] = []byte(in.QueryErr.Error() + "\n")
 	}
 
 	return buildTarGz(files)

--- a/pkg/services/diagnostics/diagnostics.go
+++ b/pkg/services/diagnostics/diagnostics.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -106,32 +107,39 @@ type queryDataArtifact struct {
 	Version         int                                 `json:"version"`
 	Request         json.RawMessage                     `json:"request,omitempty"`
 	Response        json.RawMessage                     `json:"response,omitempty"`
-	Expressions     []queryDataExpressionStage          `json:"expressions,omitempty"`
+	Pipeline        []queryDataPipelineStage            `json:"pipeline,omitempty"`
 	ResponseSummary map[string]queryDataResponseSummary `json:"responseSummary,omitempty"`
 	// ResponseError records why the full response is missing when it could not be JSON-encoded, so a
 	// reader can tell an unencodable response from one that was dropped to fit the size cap.
-	ResponseError      string `json:"responseError,omitempty"`
-	Truncated          bool   `json:"truncated,omitempty"`
-	LimitBytes         int    `json:"limitBytes,omitempty"`
-	OriginalBytes      int    `json:"originalBytes,omitempty"`
-	RequestOmitted     bool   `json:"requestOmitted,omitempty"`
-	ResponseOmitted    bool   `json:"responseOmitted,omitempty"`
-	ExpressionsOmitted bool   `json:"expressionsOmitted,omitempty"`
+	ResponseError         string `json:"responseError,omitempty"`
+	Truncated             bool   `json:"truncated,omitempty"`
+	LimitBytes            int    `json:"limitBytes,omitempty"`
+	OriginalBytes         int    `json:"originalBytes,omitempty"`
+	RequestOmitted        bool   `json:"requestOmitted,omitempty"`
+	ResponseOmitted       bool   `json:"responseOmitted,omitempty"`
+	PipelineErrorsOmitted bool   `json:"pipelineErrorsOmitted,omitempty"`
+	PipelineOmitted       bool   `json:"pipelineOmitted,omitempty"`
 }
 
-// queryDataExpressionStage is one node of the executed server-side expression pipeline: the DAG that
+// queryDataPipelineStage is one node of the executed server-side expression pipeline: the DAG that
 // "response" alone cannot express. It records the node's kind (Type/Command) and which refIDs feed it
 // (InputRefIDs -> the node's inputs), so a reader can walk from the datasource nodes down to the
 // panel's final expression and find the first stage whose output differs from its inputs.
+//
+// The array is named "pipeline" rather than "expressions" because it holds every node the expression
+// service executed, datasource and ml nodes included -- for those, Command carries the plugin type
+// (e.g. "prometheus") rather than an expression command.
 //
 // A stage carries no output of its own. The expression service returns every executed node under its
 // own refID, so this stage's output is the entry with the same refId under "response".results (or,
 // once the artifact is over budget, under "responseSummary") -- a reader joins the two on refId.
 // Repeating the frames here would duplicate "response" byte-for-byte and halve the effective budget.
+// That join holds for hidden queries too: the diagnostics capture path keeps them in the response
+// (see expr.Service.TransformData), which the panel's own query response would have dropped.
 //
 // Error is duplicated from the response entry on purpose: it is bounded, and it lets "which stage
 // failed" be answered from the DAG alone, without the join.
-type queryDataExpressionStage struct {
+type queryDataPipelineStage struct {
 	RefID       string   `json:"refId"`
 	Type        string   `json:"type,omitempty"`
 	Command     string   `json:"command,omitempty"`
@@ -162,16 +170,16 @@ func marshalQueryDataArtifact(request json.RawMessage, resp *backend.QueryDataRe
 // marshalQueryDataArtifactWithLimit returns the encoded querydata.json plus whether it had to drop
 // content to fit maxBytes, so callers don't have to re-parse the result to learn that.
 //
-// The captured expression stages are bounded by the node count and carry no frame values (see
-// queryDataExpressionStage), so they ride along at every tier rather than sharing the response's
+// The captured pipeline stages are bounded by the node count and carry no frame values (see
+// queryDataPipelineStage), so they ride along at every tier rather than sharing the response's
 // degradation ladder: over budget, or on an encode failure, the response collapses to its per-refID
 // summary while the DAG survives intact. fitQueryDataArtifact then drops the request, the response
-// summary, the stages, and finally the free-form responseError.
+// summary, the stage errors, the stages, and finally the free-form responseError.
 func marshalQueryDataArtifactWithLimit(request json.RawMessage, resp *backend.QueryDataResponse, stages []exprcapture.Stage, maxBytes int) ([]byte, bool, error) {
 	artifact := queryDataArtifact{
-		Version:     queryDataArtifactVersion,
-		Request:     request,
-		Expressions: buildExpressionStages(stages),
+		Version:  queryDataArtifactVersion,
+		Request:  request,
+		Pipeline: buildPipelineStages(stages),
 	}
 	if resp != nil {
 		// The SDK encoder returns a complete byte slice. The artifact/archive is bounded below, but
@@ -190,7 +198,7 @@ func marshalQueryDataArtifactWithLimit(request json.RawMessage, resp *backend.Qu
 			// recorded nowhere else.
 			out, fallbackErr := fitQueryDataArtifact(queryDataArtifact{
 				Version:         queryDataArtifactVersion,
-				Expressions:     artifact.Expressions,
+				Pipeline:        artifact.Pipeline,
 				ResponseSummary: summarizeQueryDataResponse(resp),
 				ResponseError:   truncateDiagnosticString(err.Error(), min(1024, maxBytes/4)),
 				ResponseOmitted: true,
@@ -209,7 +217,7 @@ func marshalQueryDataArtifactWithLimit(request json.RawMessage, resp *backend.Qu
 
 	out, err := fitQueryDataArtifact(queryDataArtifact{
 		Version:         queryDataArtifactVersion,
-		Expressions:     artifact.Expressions,
+		Pipeline:        artifact.Pipeline,
 		ResponseSummary: summarizeQueryDataResponse(resp),
 		Truncated:       true,
 		LimitBytes:      maxBytes,
@@ -220,11 +228,11 @@ func marshalQueryDataArtifactWithLimit(request json.RawMessage, resp *backend.Qu
 }
 
 // fitQueryDataArtifact encodes artifact with progressively less content -- request kept, request
-// omitted, response summary dropped, expression stages dropped, then markers only -- and returns the
-// first encoding within maxBytes. The last rung holds only fixed-size markers, which keeps it under
-// minQueryDataArtifactBytes so the budget gate in BuildDashboard stays meaningful; it is returned
-// even when it somehow still doesn't fit, because there is nothing further to drop, and callers
-// enforcing a hard budget re-check length.
+// omitted, response summary dropped, stage errors dropped, stages dropped, then markers only -- and
+// returns the first encoding within maxBytes. The last rung holds only fixed-size markers, which
+// keeps it under minQueryDataArtifactBytes so the budget gate in BuildDashboard stays meaningful; it
+// is returned even when it somehow still doesn't fit, because there is nothing further to drop, and
+// callers enforcing a hard budget re-check length.
 func fitQueryDataArtifact(artifact queryDataArtifact, request json.RawMessage, maxBytes int) ([]byte, error) {
 	artifact.Request = request
 	out, err := json.MarshalIndent(artifact, "", "  ")
@@ -254,11 +262,34 @@ func fitQueryDataArtifact(artifact queryDataArtifact, request json.RawMessage, m
 		return out, nil
 	}
 
-	// The expression stages outlive the response summary: they are the smaller of the two (bounded by
-	// node count, no per-frame entries) and they are the only record of the pipeline's shape, which
-	// nothing else in the bundle carries. ExpressionsOmitted records that they existed.
-	artifact.ExpressionsOmitted = len(artifact.Expressions) > 0
-	artifact.Expressions = nil
+	// The stage errors go before the stages themselves: each is free-form text up to 1 KiB, so on a
+	// tight budget they are what pushes the DAG over, and they are the one part of a stage that is
+	// recoverable elsewhere -- responseSummary[refId].error carries the same string, and the failure is
+	// recorded again outside the artifact. Dropping them keeps the pipeline's shape, which nothing else
+	// in the bundle records at all.
+	if pipelineHasErrors(artifact.Pipeline) {
+		// Cloned rather than cleared in place: artifact is a value copy, but its Pipeline slice still
+		// shares a backing array with the caller's.
+		artifact.Pipeline = slices.Clone(artifact.Pipeline)
+		for i := range artifact.Pipeline {
+			artifact.Pipeline[i].Error = ""
+		}
+		artifact.PipelineErrorsOmitted = true
+		out, err = json.MarshalIndent(artifact, "", "  ")
+		if err != nil {
+			return nil, err
+		}
+		if len(out) <= maxBytes {
+			return out, nil
+		}
+	}
+
+	// The stages outlive the response summary: they are the smaller of the two (bounded by node count,
+	// no per-frame entries) and they are the only record of the pipeline's shape, which nothing else in
+	// the bundle carries. PipelineOmitted records that they existed, and subsumes the error marker.
+	artifact.PipelineOmitted = len(artifact.Pipeline) > 0
+	artifact.PipelineErrorsOmitted = false
+	artifact.Pipeline = nil
 	out, err = json.MarshalIndent(artifact, "", "  ")
 	if err != nil {
 		return nil, err
@@ -273,17 +304,24 @@ func fitQueryDataArtifact(artifact queryDataArtifact, request json.RawMessage, m
 	return json.MarshalIndent(artifact, "", "  ")
 }
 
-// buildExpressionStages renders the captured pipeline nodes as the artifact's expression-stage view:
-// the DAG (node kind, command, input refIDs) and each node's error, with outputs left to the
-// response entry sharing the stage's refId. Total size is bounded by the node count, so unlike the
-// response this needs no summarized form.
-func buildExpressionStages(stages []exprcapture.Stage) []queryDataExpressionStage {
+// pipelineHasErrors reports whether any stage carries error text worth dropping before the stages
+// themselves.
+func pipelineHasErrors(stages []queryDataPipelineStage) bool {
+	return slices.ContainsFunc(stages, func(s queryDataPipelineStage) bool { return s.Error != "" })
+}
+
+// buildPipelineStages renders the captured nodes as the artifact's pipeline view: the DAG (node kind,
+// command, input refIDs) and each node's error, with outputs left to the response entry sharing the
+// stage's refId. Total size is bounded by the node count, so unlike the response this needs no
+// summarized form -- only the free-form error text is capped, and fitQueryDataArtifact drops it
+// before the stages when even that is too much.
+func buildPipelineStages(stages []exprcapture.Stage) []queryDataPipelineStage {
 	if len(stages) == 0 {
 		return nil
 	}
-	out := make([]queryDataExpressionStage, 0, len(stages))
+	out := make([]queryDataPipelineStage, 0, len(stages))
 	for _, s := range stages {
-		stage := queryDataExpressionStage{
+		stage := queryDataPipelineStage{
 			RefID:       s.RefID,
 			Type:        s.Type,
 			Command:     s.Command,

--- a/pkg/services/diagnostics/diagnostics_expressions_test.go
+++ b/pkg/services/diagnostics/diagnostics_expressions_test.go
@@ -59,7 +59,7 @@ func TestBundler_Build_recordsExpressionStages(t *testing.T) {
 	// refIds.
 	resp := pipelineResponse([]float64{1})
 
-	blob, err := NewBundler().Build(resp, &harcapture.Buffer{}, nil, nil, nil, twoStagePipeline(), nil, nil)
+	blob, err := NewBundler().Build(BundleInput{Resp: resp, HARBuffer: &harcapture.Buffer{}, ExpressionStages: twoStagePipeline()})
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)

--- a/pkg/services/diagnostics/diagnostics_expressions_test.go
+++ b/pkg/services/diagnostics/diagnostics_expressions_test.go
@@ -1,0 +1,162 @@
+package diagnostics
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/expr/exprcapture"
+	"github.com/grafana/grafana/pkg/infra/httpclient/harcapture"
+)
+
+// parseArtifact unmarshals a querydata.json blob into the artifact struct for assertions.
+func parseArtifact(t *testing.T, raw []byte) queryDataArtifact {
+	t.Helper()
+	var a queryDataArtifact
+	require.NoError(t, json.Unmarshal(raw, &a))
+	return a
+}
+
+func stageOutputFrameNames(t *testing.T, stage queryDataExpressionStage) []string {
+	t.Helper()
+	var dr struct {
+		Frames []struct {
+			Schema struct {
+				Name string `json:"name"`
+			} `json:"schema"`
+		} `json:"frames"`
+	}
+	require.NoError(t, json.Unmarshal(stage.Output, &dr))
+	names := make([]string, 0, len(dr.Frames))
+	for _, f := range dr.Frames {
+		names = append(names, f.Schema.Name)
+	}
+	return names
+}
+
+func TestBundler_Build_recordsExpressionStages(t *testing.T) {
+	// A (datasource, 2 series) -> B ($A reduced/last, expression). The captured stages record the DAG
+	// edge B<-A and each node's output so a reader can localize which stage changed the data.
+	dsFrame := data.NewFrame("A",
+		data.NewField("value", data.Labels{"host": "a"}, []float64{1}),
+	)
+	bFrame := data.NewFrame("B", data.NewField("B", nil, []float64{1}))
+	bFrame.RefID = "B"
+
+	stages := []exprcapture.Stage{
+		{RefID: "A", Type: "datasource", Command: "prometheus", Frames: data.Frames{dsFrame}},
+		{RefID: "B", Type: "expression", Command: "reduce", InputRefIDs: []string{"A"}, Frames: data.Frames{bFrame}},
+	}
+
+	blob, err := NewBundler().Build(nil, &harcapture.Buffer{}, nil, nil, nil, stages, nil, nil)
+	require.NoError(t, err)
+
+	files := readTarGz(t, blob)
+	require.Contains(t, files, "querydata.json")
+
+	a := parseArtifact(t, files["querydata.json"])
+	require.Len(t, a.Expressions, 2)
+
+	require.Equal(t, "A", a.Expressions[0].RefID)
+	require.Equal(t, "datasource", a.Expressions[0].Type)
+	require.Empty(t, a.Expressions[0].InputRefIDs)
+
+	require.Equal(t, "B", a.Expressions[1].RefID)
+	require.Equal(t, "expression", a.Expressions[1].Type)
+	require.Equal(t, "reduce", a.Expressions[1].Command)
+	require.Equal(t, []string{"A"}, a.Expressions[1].InputRefIDs, "the DAG edge B<-A is recorded")
+
+	require.NotEmpty(t, a.Expressions[0].Output, "each stage carries its output frames")
+	require.NotEmpty(t, a.Expressions[1].Output)
+	require.False(t, a.Truncated)
+	require.False(t, a.ExpressionsOmitted)
+}
+
+func TestBuildExpressionStages_excludesCaptureFrames(t *testing.T) {
+	// A datasource node's output frames may include the synthetic __har__ carrier frame; it must not
+	// leak into the expression-stage output.
+	realFrame := data.NewFrame("real", data.NewField("value", nil, []float64{1}))
+	harFrame := data.NewFrame("__har__test")
+	harFrame.RefID = "__har__test"
+
+	stages := []exprcapture.Stage{
+		{RefID: "A", Type: "datasource", Frames: data.Frames{realFrame, harFrame}},
+	}
+
+	out, err := buildExpressionStages(stages)
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+
+	names := stageOutputFrameNames(t, out[0])
+	require.Contains(t, names, "real")
+	require.NotContains(t, names, "__har__test", "capture carrier frames are filtered out")
+}
+
+func TestMarshalQueryDataArtifact_expressionStagesDegradeToSummary(t *testing.T) {
+	// A stage carrying a large frame that pushes the artifact over budget must degrade to a per-stage
+	// summary (row/field counts) with the frame values omitted, not silently drop the stage.
+	values := make([]float64, 4096)
+	for i := range values {
+		values[i] = float64(i)
+	}
+	big := data.NewFrame("big", data.NewField("value", nil, values))
+	stages := []exprcapture.Stage{
+		{RefID: "A", Type: "datasource", Frames: data.Frames{big}},
+		{RefID: "B", Type: "expression", Command: "reduce", InputRefIDs: []string{"A"}, Frames: data.Frames{
+			data.NewFrame("B", data.NewField("B", nil, []float64{1})),
+		}},
+	}
+
+	// A budget below the full frame values but above the compact per-stage summary forces the middle
+	// (summary) degrade tier.
+	raw, truncated, err := marshalQueryDataArtifactWithLimit(nil, nil, stages, 4096)
+	require.NoError(t, err)
+	require.True(t, truncated)
+
+	a := parseArtifact(t, raw)
+	require.True(t, a.Truncated)
+	require.True(t, a.ExpressionsOmitted, "full expression frames are omitted over budget")
+	require.Empty(t, a.Expressions, "no full-frame expressions when truncated")
+	require.Len(t, a.ExpressionsSummary, 2, "each stage still appears in the summary")
+
+	// The summary preserves the DAG edge and node metadata even without frame values.
+	var bSummary queryDataExpressionStage
+	for _, s := range a.ExpressionsSummary {
+		if s.RefID == "B" {
+			bSummary = s
+		}
+	}
+	require.Equal(t, "reduce", bSummary.Command)
+	require.Equal(t, []string{"A"}, bSummary.InputRefIDs)
+	require.NotEmpty(t, bSummary.Output, "the summary lists per-frame row/field counts")
+	require.NotContains(t, string(raw), "\"4095\"", "individual large-frame values are not present when summarized")
+}
+
+func TestMarshalQueryDataArtifact_recordsStageError(t *testing.T) {
+	stages := []exprcapture.Stage{
+		{RefID: "A", Type: "datasource", Error: errStub("upstream 500")},
+		{RefID: "B", Type: "expression", Command: "math", InputRefIDs: []string{"A"}, Error: errStub("dependency error")},
+	}
+	raw, err := marshalQueryDataArtifact(nil, nil, stages)
+	require.NoError(t, err)
+
+	a := parseArtifact(t, raw)
+	require.Len(t, a.Expressions, 2)
+	require.Equal(t, "upstream 500", a.Expressions[0].Error)
+	require.Equal(t, "dependency error", a.Expressions[1].Error)
+	require.True(t, strings.Contains(string(a.Expressions[1].Output), "dependency error"),
+		"the stage output object also carries the error")
+}
+
+type errStub string
+
+func (e errStub) Error() string { return string(e) }
+
+var _ error = errStub("")
+
+// ensure backend import is used even if assertions above change.
+var _ = backend.NewQueryDataResponse

--- a/pkg/services/diagnostics/diagnostics_expressions_test.go
+++ b/pkg/services/diagnostics/diagnostics_expressions_test.go
@@ -42,7 +42,7 @@ func pipelineResponse(aValues []float64) *backend.QueryDataResponse {
 	}}
 }
 
-func stageByRefID(t *testing.T, stages []queryDataExpressionStage, refID string) queryDataExpressionStage {
+func stageByRefID(t *testing.T, stages []queryDataPipelineStage, refID string) queryDataPipelineStage {
 	t.Helper()
 	for _, s := range stages {
 		if s.RefID == refID {
@@ -50,7 +50,7 @@ func stageByRefID(t *testing.T, stages []queryDataExpressionStage, refID string)
 		}
 	}
 	t.Fatalf("no stage with refId %q in %v", refID, stages)
-	return queryDataExpressionStage{}
+	return queryDataPipelineStage{}
 }
 
 func TestBundler_Build_recordsExpressionStages(t *testing.T) {
@@ -66,29 +66,29 @@ func TestBundler_Build_recordsExpressionStages(t *testing.T) {
 	require.Contains(t, files, "querydata.json")
 
 	a := parseArtifact(t, files["querydata.json"])
-	require.Len(t, a.Expressions, 2)
+	require.Len(t, a.Pipeline, 2)
 
-	require.Equal(t, "A", a.Expressions[0].RefID)
-	require.Equal(t, "datasource", a.Expressions[0].Type)
-	require.Equal(t, "prometheus", a.Expressions[0].Command)
-	require.Empty(t, a.Expressions[0].InputRefIDs)
+	require.Equal(t, "A", a.Pipeline[0].RefID)
+	require.Equal(t, "datasource", a.Pipeline[0].Type)
+	require.Equal(t, "prometheus", a.Pipeline[0].Command)
+	require.Empty(t, a.Pipeline[0].InputRefIDs)
 
-	require.Equal(t, "B", a.Expressions[1].RefID)
-	require.Equal(t, "expression", a.Expressions[1].Type)
-	require.Equal(t, "reduce", a.Expressions[1].Command)
-	require.Equal(t, []string{"A"}, a.Expressions[1].InputRefIDs, "the DAG edge B<-A is recorded")
+	require.Equal(t, "B", a.Pipeline[1].RefID)
+	require.Equal(t, "expression", a.Pipeline[1].Type)
+	require.Equal(t, "reduce", a.Pipeline[1].Command)
+	require.Equal(t, []string{"A"}, a.Pipeline[1].InputRefIDs, "the DAG edge B<-A is recorded")
 
 	// Every stage's refId resolves to a response entry -- that join is what gives a stage its output.
 	var response struct {
 		Results map[string]json.RawMessage `json:"results"`
 	}
 	require.NoError(t, json.Unmarshal(a.Response, &response))
-	for _, stage := range a.Expressions {
+	for _, stage := range a.Pipeline {
 		require.Contains(t, response.Results, stage.RefID, "stage %s has no response entry to join to", stage.RefID)
 	}
 
 	require.False(t, a.Truncated)
-	require.False(t, a.ExpressionsOmitted)
+	require.False(t, a.PipelineOmitted)
 }
 
 func TestMarshalQueryDataArtifact_stagesDoNotDuplicateResponse(t *testing.T) {
@@ -114,7 +114,7 @@ func TestMarshalQueryDataArtifact_stagesDoNotDuplicateResponse(t *testing.T) {
 		"frame values must appear exactly once, under \"response\"")
 
 	a := parseArtifact(t, withStages)
-	require.Len(t, a.Expressions, 2, "the DAG is still recorded")
+	require.Len(t, a.Pipeline, 2, "the DAG is still recorded")
 }
 
 func TestMarshalQueryDataArtifact_stagesSurviveResponseTruncation(t *testing.T) {
@@ -136,9 +136,9 @@ func TestMarshalQueryDataArtifact_stagesSurviveResponseTruncation(t *testing.T) 
 	require.Empty(t, a.Response)
 	require.NotEmpty(t, a.ResponseSummary, "per-refID row/field counts stand in for the values")
 
-	require.False(t, a.ExpressionsOmitted)
-	require.Len(t, a.Expressions, 2, "the DAG survives the response's degradation")
-	b := stageByRefID(t, a.Expressions, "B")
+	require.False(t, a.PipelineOmitted)
+	require.Len(t, a.Pipeline, 2, "the DAG survives the response's degradation")
+	b := stageByRefID(t, a.Pipeline, "B")
 	require.Equal(t, "reduce", b.Command)
 	require.Equal(t, []string{"A"}, b.InputRefIDs)
 	require.NotContains(t, string(raw), "4095", "individual frame values are not present when summarized")
@@ -154,10 +154,53 @@ func TestFitQueryDataArtifact_dropsStagesAtTheFloor(t *testing.T) {
 	require.LessOrEqual(t, len(raw), minQueryDataArtifactBytes)
 
 	a := parseArtifact(t, raw)
-	require.Empty(t, a.Expressions)
-	require.True(t, a.ExpressionsOmitted, "the marker records that a DAG was captured and dropped")
+	require.Empty(t, a.Pipeline)
+	require.True(t, a.PipelineOmitted, "the marker records that a DAG was captured and dropped")
+	require.False(t, a.PipelineErrorsOmitted, "pipelineOmitted subsumes the error marker")
 	require.Empty(t, a.ResponseSummary)
 	require.True(t, a.ResponseOmitted)
+}
+
+func TestFitQueryDataArtifact_dropsStageErrorsBeforeTheStages(t *testing.T) {
+	// Stage errors are the only free-form text on a stage, and responseSummary[refId].error carries the
+	// same string, so on a budget too small for both they go first -- losing the error text but keeping
+	// the DAG, which nothing else in the bundle records.
+	stages := []exprcapture.Stage{
+		{RefID: "A", Type: "datasource", Command: "prometheus", Error: errStub(strings.Repeat("x", 600))},
+		{RefID: "B", Type: "expression", Command: "reduce", InputRefIDs: []string{"A"}, Error: errStub(strings.Repeat("y", 600))},
+	}
+	resp := pipelineResponse([]float64{1, 2, 3})
+
+	// Sized between "the DAG with its error text" and "the DAG alone".
+	raw, truncated, err := marshalQueryDataArtifactWithLimit(nil, resp, stages, 700)
+	require.NoError(t, err)
+	require.True(t, truncated)
+
+	a := parseArtifact(t, raw)
+	require.Len(t, a.Pipeline, 2, "the DAG outlives its own error text")
+	require.True(t, a.PipelineErrorsOmitted, "the marker records that error text was dropped")
+	require.False(t, a.PipelineOmitted)
+
+	b := stageByRefID(t, a.Pipeline, "B")
+	require.Equal(t, "reduce", b.Command)
+	require.Equal(t, []string{"A"}, b.InputRefIDs, "the DAG edge survives")
+	for _, s := range a.Pipeline {
+		require.Empty(t, s.Error, "stage %s kept its error text", s.RefID)
+	}
+	require.NotContains(t, string(raw), "xxxxx")
+}
+
+func TestFitQueryDataArtifact_clearingStageErrorsDoesNotMutateCaller(t *testing.T) {
+	// fitQueryDataArtifact takes the artifact by value, but its Pipeline slice shares a backing array
+	// with the caller's, so the error-dropping rung must clone before clearing.
+	stages := buildPipelineStages([]exprcapture.Stage{
+		{RefID: "A", Type: "datasource", Error: errStub(strings.Repeat("x", 600))},
+	})
+	require.NotEmpty(t, stages[0].Error)
+
+	_, err := fitQueryDataArtifact(queryDataArtifact{Version: queryDataArtifactVersion, Pipeline: stages}, nil, 200)
+	require.NoError(t, err)
+	require.NotEmpty(t, stages[0].Error, "the caller's stages were cleared in place")
 }
 
 func TestMarshalQueryDataArtifact_recordsStageError(t *testing.T) {
@@ -171,9 +214,9 @@ func TestMarshalQueryDataArtifact_recordsStageError(t *testing.T) {
 	require.NoError(t, err)
 
 	a := parseArtifact(t, raw)
-	require.Len(t, a.Expressions, 2)
-	require.Equal(t, "upstream 500", a.Expressions[0].Error)
-	require.Equal(t, "dependency error", a.Expressions[1].Error)
+	require.Len(t, a.Pipeline, 2)
+	require.Equal(t, "upstream 500", a.Pipeline[0].Error)
+	require.Equal(t, "dependency error", a.Pipeline[1].Error)
 }
 
 func TestBuildDashboard_recordsExpressionStagesWithoutResponse(t *testing.T) {
@@ -198,7 +241,7 @@ func TestBuildDashboard_recordsExpressionStagesWithoutResponse(t *testing.T) {
 	require.NotEmpty(t, found, "the panel's captured stages are recorded, got files %v", files)
 
 	a := parseArtifact(t, files[found])
-	require.Len(t, a.Expressions, 2)
+	require.Len(t, a.Pipeline, 2)
 }
 
 type errStub string

--- a/pkg/services/diagnostics/diagnostics_expressions_test.go
+++ b/pkg/services/diagnostics/diagnostics_expressions_test.go
@@ -21,38 +21,45 @@ func parseArtifact(t *testing.T, raw []byte) queryDataArtifact {
 	return a
 }
 
-func stageOutputFrameNames(t *testing.T, stage queryDataExpressionStage) []string {
+// twoStagePipeline is A (datasource) -> B (reduce), the DAG shared by the tests below.
+func twoStagePipeline() []exprcapture.Stage {
+	return []exprcapture.Stage{
+		{RefID: "A", Type: "datasource", Command: "prometheus"},
+		{RefID: "B", Type: "expression", Command: "reduce", InputRefIDs: []string{"A"}},
+	}
+}
+
+// pipelineResponse is what the expression service returns for twoStagePipeline: every node under its
+// own refID, which is where a stage's output lives.
+func pipelineResponse(aValues []float64) *backend.QueryDataResponse {
+	aFrame := data.NewFrame("A", data.NewField("value", data.Labels{"host": "a"}, aValues))
+	aFrame.RefID = "A"
+	bFrame := data.NewFrame("B", data.NewField("B", nil, []float64{1}))
+	bFrame.RefID = "B"
+	return &backend.QueryDataResponse{Responses: backend.Responses{
+		"A": {Frames: data.Frames{aFrame}},
+		"B": {Frames: data.Frames{bFrame}},
+	}}
+}
+
+func stageByRefID(t *testing.T, stages []queryDataExpressionStage, refID string) queryDataExpressionStage {
 	t.Helper()
-	var dr struct {
-		Frames []struct {
-			Schema struct {
-				Name string `json:"name"`
-			} `json:"schema"`
-		} `json:"frames"`
+	for _, s := range stages {
+		if s.RefID == refID {
+			return s
+		}
 	}
-	require.NoError(t, json.Unmarshal(stage.Output, &dr))
-	names := make([]string, 0, len(dr.Frames))
-	for _, f := range dr.Frames {
-		names = append(names, f.Schema.Name)
-	}
-	return names
+	t.Fatalf("no stage with refId %q in %v", refID, stages)
+	return queryDataExpressionStage{}
 }
 
 func TestBundler_Build_recordsExpressionStages(t *testing.T) {
-	// A (datasource, 2 series) -> B ($A reduced/last, expression). The captured stages record the DAG
-	// edge B<-A and each node's output so a reader can localize which stage changed the data.
-	dsFrame := data.NewFrame("A",
-		data.NewField("value", data.Labels{"host": "a"}, []float64{1}),
-	)
-	bFrame := data.NewFrame("B", data.NewField("B", nil, []float64{1}))
-	bFrame.RefID = "B"
+	// A (datasource) -> B ($A reduced/last, expression). The captured stages record the DAG edge
+	// B<-A and each node's kind; the outputs they refer to live under "response", keyed by the same
+	// refIds.
+	resp := pipelineResponse([]float64{1})
 
-	stages := []exprcapture.Stage{
-		{RefID: "A", Type: "datasource", Command: "prometheus", Frames: data.Frames{dsFrame}},
-		{RefID: "B", Type: "expression", Command: "reduce", InputRefIDs: []string{"A"}, Frames: data.Frames{bFrame}},
-	}
-
-	blob, err := NewBundler().Build(nil, &harcapture.Buffer{}, nil, nil, nil, stages, nil, nil)
+	blob, err := NewBundler().Build(resp, &harcapture.Buffer{}, nil, nil, nil, twoStagePipeline(), nil, nil)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -63,6 +70,7 @@ func TestBundler_Build_recordsExpressionStages(t *testing.T) {
 
 	require.Equal(t, "A", a.Expressions[0].RefID)
 	require.Equal(t, "datasource", a.Expressions[0].Type)
+	require.Equal(t, "prometheus", a.Expressions[0].Command)
 	require.Empty(t, a.Expressions[0].InputRefIDs)
 
 	require.Equal(t, "B", a.Expressions[1].RefID)
@@ -70,73 +78,91 @@ func TestBundler_Build_recordsExpressionStages(t *testing.T) {
 	require.Equal(t, "reduce", a.Expressions[1].Command)
 	require.Equal(t, []string{"A"}, a.Expressions[1].InputRefIDs, "the DAG edge B<-A is recorded")
 
-	require.NotEmpty(t, a.Expressions[0].Output, "each stage carries its output frames")
-	require.NotEmpty(t, a.Expressions[1].Output)
+	// Every stage's refId resolves to a response entry -- that join is what gives a stage its output.
+	var response struct {
+		Results map[string]json.RawMessage `json:"results"`
+	}
+	require.NoError(t, json.Unmarshal(a.Response, &response))
+	for _, stage := range a.Expressions {
+		require.Contains(t, response.Results, stage.RefID, "stage %s has no response entry to join to", stage.RefID)
+	}
+
 	require.False(t, a.Truncated)
 	require.False(t, a.ExpressionsOmitted)
 }
 
-func TestBuildExpressionStages_excludesCaptureFrames(t *testing.T) {
-	// A datasource node's output frames may include the synthetic __har__ carrier frame; it must not
-	// leak into the expression-stage output.
-	realFrame := data.NewFrame("real", data.NewField("value", nil, []float64{1}))
-	harFrame := data.NewFrame("__har__test")
-	harFrame.RefID = "__har__test"
-
-	stages := []exprcapture.Stage{
-		{RefID: "A", Type: "datasource", Frames: data.Frames{realFrame, harFrame}},
-	}
-
-	out, err := buildExpressionStages(stages)
-	require.NoError(t, err)
-	require.Len(t, out, 1)
-
-	names := stageOutputFrameNames(t, out[0])
-	require.Contains(t, names, "real")
-	require.NotContains(t, names, "__har__test", "capture carrier frames are filtered out")
-}
-
-func TestMarshalQueryDataArtifact_expressionStagesDegradeToSummary(t *testing.T) {
-	// A stage carrying a large frame that pushes the artifact over budget must degrade to a per-stage
-	// summary (row/field counts) with the frame values omitted, not silently drop the stage.
+func TestMarshalQueryDataArtifact_stagesDoNotDuplicateResponse(t *testing.T) {
+	// The expression service returns every node under its own refID, so "response" already carries
+	// each stage's output frames. Capturing the DAG must not re-serialize them: doing so doubles
+	// querydata.json and halves the effective size budget.
 	values := make([]float64, 4096)
 	for i := range values {
 		values[i] = float64(i)
 	}
-	big := data.NewFrame("big", data.NewField("value", nil, values))
-	stages := []exprcapture.Stage{
-		{RefID: "A", Type: "datasource", Frames: data.Frames{big}},
-		{RefID: "B", Type: "expression", Command: "reduce", InputRefIDs: []string{"A"}, Frames: data.Frames{
-			data.NewFrame("B", data.NewField("B", nil, []float64{1})),
-		}},
-	}
+	values[0] = 1234.5 // a distinctive value to count occurrences of
+	resp := pipelineResponse(values)
 
-	// A budget below the full frame values but above the compact per-stage summary forces the middle
-	// (summary) degrade tier.
-	raw, truncated, err := marshalQueryDataArtifactWithLimit(nil, nil, stages, 4096)
+	withoutStages, _, err := marshalQueryDataArtifactWithLimit(nil, resp, nil, maxQueryDataArtifactBytes)
+	require.NoError(t, err)
+	withStages, _, err := marshalQueryDataArtifactWithLimit(nil, resp, twoStagePipeline(), maxQueryDataArtifactBytes)
+	require.NoError(t, err)
+
+	require.Less(t, len(withStages), len(withoutStages)+1024,
+		"the DAG is bounded by node count; it must not scale with frame values (got %d vs %d bytes)",
+		len(withStages), len(withoutStages))
+	require.Equal(t, 1, strings.Count(string(withStages), "1234.5"),
+		"frame values must appear exactly once, under \"response\"")
+
+	a := parseArtifact(t, withStages)
+	require.Len(t, a.Expressions, 2, "the DAG is still recorded")
+}
+
+func TestMarshalQueryDataArtifact_stagesSurviveResponseTruncation(t *testing.T) {
+	// Over budget the response collapses to its per-refID summary, but the DAG is small and nothing
+	// else in the bundle records it, so it survives intact.
+	values := make([]float64, 4096)
+	for i := range values {
+		values[i] = float64(i)
+	}
+	resp := pipelineResponse(values)
+
+	raw, truncated, err := marshalQueryDataArtifactWithLimit(nil, resp, twoStagePipeline(), 4096)
 	require.NoError(t, err)
 	require.True(t, truncated)
 
 	a := parseArtifact(t, raw)
 	require.True(t, a.Truncated)
-	require.True(t, a.ExpressionsOmitted, "full expression frames are omitted over budget")
-	require.Empty(t, a.Expressions, "no full-frame expressions when truncated")
-	require.Len(t, a.ExpressionsSummary, 2, "each stage still appears in the summary")
+	require.True(t, a.ResponseOmitted, "the frame values are dropped over budget")
+	require.Empty(t, a.Response)
+	require.NotEmpty(t, a.ResponseSummary, "per-refID row/field counts stand in for the values")
 
-	// The summary preserves the DAG edge and node metadata even without frame values.
-	var bSummary queryDataExpressionStage
-	for _, s := range a.ExpressionsSummary {
-		if s.RefID == "B" {
-			bSummary = s
-		}
-	}
-	require.Equal(t, "reduce", bSummary.Command)
-	require.Equal(t, []string{"A"}, bSummary.InputRefIDs)
-	require.NotEmpty(t, bSummary.Output, "the summary lists per-frame row/field counts")
-	require.NotContains(t, string(raw), "\"4095\"", "individual large-frame values are not present when summarized")
+	require.False(t, a.ExpressionsOmitted)
+	require.Len(t, a.Expressions, 2, "the DAG survives the response's degradation")
+	b := stageByRefID(t, a.Expressions, "B")
+	require.Equal(t, "reduce", b.Command)
+	require.Equal(t, []string{"A"}, b.InputRefIDs)
+	require.NotContains(t, string(raw), "4095", "individual frame values are not present when summarized")
+}
+
+func TestFitQueryDataArtifact_dropsStagesAtTheFloor(t *testing.T) {
+	// A budget too small even for the response summary walks the ladder to the bottom. The stages go
+	// after the summary -- last of the variable-size content -- and leave a marker behind.
+	resp := pipelineResponse([]float64{1, 2, 3})
+
+	raw, _, err := marshalQueryDataArtifactWithLimit(nil, resp, twoStagePipeline(), minQueryDataArtifactBytes)
+	require.NoError(t, err)
+	require.LessOrEqual(t, len(raw), minQueryDataArtifactBytes)
+
+	a := parseArtifact(t, raw)
+	require.Empty(t, a.Expressions)
+	require.True(t, a.ExpressionsOmitted, "the marker records that a DAG was captured and dropped")
+	require.Empty(t, a.ResponseSummary)
+	require.True(t, a.ResponseOmitted)
 }
 
 func TestMarshalQueryDataArtifact_recordsStageError(t *testing.T) {
+	// A stage's error is duplicated from its response entry on purpose, so "which stage failed" is
+	// answerable from the DAG alone.
 	stages := []exprcapture.Stage{
 		{RefID: "A", Type: "datasource", Error: errStub("upstream 500")},
 		{RefID: "B", Type: "expression", Command: "math", InputRefIDs: []string{"A"}, Error: errStub("dependency error")},
@@ -148,8 +174,31 @@ func TestMarshalQueryDataArtifact_recordsStageError(t *testing.T) {
 	require.Len(t, a.Expressions, 2)
 	require.Equal(t, "upstream 500", a.Expressions[0].Error)
 	require.Equal(t, "dependency error", a.Expressions[1].Error)
-	require.True(t, strings.Contains(string(a.Expressions[1].Output), "dependency error"),
-		"the stage output object also carries the error")
+}
+
+func TestBuildDashboard_recordsExpressionStagesWithoutResponse(t *testing.T) {
+	// A panel that captured a DAG but produced neither a response nor a serializable request must
+	// still get a querydata.json -- the per-panel gate matches Build's.
+	panels := []DashboardPanel{{
+		ID:               1,
+		Title:            "expressions",
+		ExpressionStages: twoStagePipeline(),
+	}}
+
+	blob, err := NewBundler().BuildDashboard(nil, panels)
+	require.NoError(t, err)
+
+	files := readTarGz(t, blob)
+	var found string
+	for name := range files {
+		if strings.HasSuffix(name, "/querydata.json") {
+			found = name
+		}
+	}
+	require.NotEmpty(t, found, "the panel's captured stages are recorded, got files %v", files)
+
+	a := parseArtifact(t, files[found])
+	require.Len(t, a.Expressions, 2)
 }
 
 type errStub string
@@ -157,6 +206,3 @@ type errStub string
 func (e errStub) Error() string { return string(e) }
 
 var _ error = errStub("")
-
-// ensure backend import is used even if assertions above change.
-var _ = backend.NewQueryDataResponse

--- a/pkg/services/diagnostics/diagnostics_test.go
+++ b/pkg/services/diagnostics/diagnostics_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestBundler_Build(t *testing.T) {
 	// No HAR captured (empty buffer, nil response) -> traffic.har omitted; only panel.json present.
-	blob, err := NewBundler().Build(nil, &harcapture.Buffer{}, json.RawMessage(`{"id":1}`), nil, nil, nil, nil, nil)
+	blob, err := NewBundler().Build(BundleInput{HARBuffer: &harcapture.Buffer{}, PanelJSON: json.RawMessage(`{"id":1}`)})
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -37,7 +37,7 @@ func TestBundler_Build(t *testing.T) {
 
 func TestBundler_Build_recordsQueryError(t *testing.T) {
 	// A failed query must still produce a bundle, with the error recorded (capture is not discarded).
-	blob, err := NewBundler().Build(nil, &harcapture.Buffer{}, nil, nil, nil, nil, nil, errors.New("datasource timeout"))
+	blob, err := NewBundler().Build(BundleInput{HARBuffer: &harcapture.Buffer{}, QueryErr: errors.New("datasource timeout")})
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -51,7 +51,7 @@ func TestBundler_Build_recordsQueryDataMarshalError(t *testing.T) {
 	// error is recorded and the other artifacts still ship, mirroring the per-panel dashboard path.
 	buf := bufferWithEntry(t, "http://ds/1")
 
-	blob, err := NewBundler().Build(nil, buf, nil, nil, json.RawMessage(`{invalid`), nil, nil, nil)
+	blob, err := NewBundler().Build(BundleInput{HARBuffer: buf, QueryRequestJSON: json.RawMessage(`{invalid`)})
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -67,7 +67,7 @@ func TestBundler_Build_recordsQueryRequestSerializeError(t *testing.T) {
 	// mirroring how the per-panel dashboard path surfaces the same failure via manifest.queryDataError.
 	buf := bufferWithEntry(t, "http://ds/1")
 
-	blob, err := NewBundler().Build(nil, buf, nil, nil, nil, nil, errors.New("unsupported value: +Inf"), nil)
+	blob, err := NewBundler().Build(BundleInput{HARBuffer: buf, QueryRequestErr: errors.New("unsupported value: +Inf")})
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -84,7 +84,7 @@ func TestBundler_Build_recordsQueryDataResponse(t *testing.T) {
 		"A": {Frames: data.Frames{frame}},
 	}}
 
-	blob, err := NewBundler().Build(resp, &harcapture.Buffer{}, nil, nil, nil, nil, nil, nil)
+	blob, err := NewBundler().Build(BundleInput{Resp: resp, HARBuffer: &harcapture.Buffer{}})
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -96,7 +96,7 @@ func TestBundler_Build_recordsQueryDataResponse(t *testing.T) {
 func TestBundler_Build_recordsQueryDataRequest(t *testing.T) {
 	request := json.RawMessage(`{"from":"now-1h","to":"now","queries":[{"refId":"A","expr":"up"}]}`)
 
-	blob, err := NewBundler().Build(nil, &harcapture.Buffer{}, nil, nil, request, nil, nil, nil)
+	blob, err := NewBundler().Build(BundleInput{HARBuffer: &harcapture.Buffer{}, QueryRequestJSON: request})
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -114,7 +114,7 @@ func TestBundler_Build_excludesCaptureFramesFromQueryData(t *testing.T) {
 		"__har__ds": {Frames: data.Frames{capture}},
 	}}
 
-	blob, err := NewBundler().Build(resp, &harcapture.Buffer{}, nil, nil, nil, nil, nil, nil)
+	blob, err := NewBundler().Build(BundleInput{Resp: resp, HARBuffer: &harcapture.Buffer{}})
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -128,7 +128,7 @@ func TestBundler_Build_boundsOversizedQueryData(t *testing.T) {
 		"A": {Frames: data.Frames{frame}},
 	}}
 
-	blob, err := NewBundler().Build(resp, &harcapture.Buffer{}, nil, nil, nil, nil, nil, nil)
+	blob, err := NewBundler().Build(BundleInput{Resp: resp, HARBuffer: &harcapture.Buffer{}})
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -143,7 +143,7 @@ func TestBundler_Build_boundsOversizedRequestWithoutResponse(t *testing.T) {
 	// An oversized request with no response must truncate without claiming a response was omitted.
 	request := json.RawMessage(`{"expr":"` + strings.Repeat("x", maxQueryDataArtifactBytes) + `"}`)
 
-	blob, err := NewBundler().Build(nil, &harcapture.Buffer{}, nil, nil, request, nil, nil, nil)
+	blob, err := NewBundler().Build(BundleInput{HARBuffer: &harcapture.Buffer{}, QueryRequestJSON: request})
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -171,7 +171,7 @@ func TestBundler_Build_preservesUpstreamAndPluginResultsForComparison(t *testing
 	queryResp := &backend.QueryDataResponse{Responses: backend.Responses{
 		"A": {Frames: data.Frames{pluginFrame}},
 	}}
-	blob, err := NewBundler().Build(queryResp, buf, nil, nil, nil, nil, nil, nil)
+	blob, err := NewBundler().Build(BundleInput{Resp: queryResp, HARBuffer: buf})
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -308,7 +308,7 @@ func TestCollectHAR_nilBuffer_noPanic(t *testing.T) {
 	require.Nil(t, out)
 
 	// A nil buffer must also flow through Build without panicking.
-	bundle, err := NewBundler().Build(nil, nil, nil, nil, nil, nil, nil, nil)
+	bundle, err := NewBundler().Build(BundleInput{})
 	require.NoError(t, err)
 	require.NotNil(t, bundle)
 }
@@ -761,7 +761,7 @@ func TestBundler_Build_keepsRequestWhenResponseEncodingFails(t *testing.T) {
 	resp := &backend.QueryDataResponse{Responses: backend.Responses{"A": {Frames: data.Frames{frame}}}}
 	request := json.RawMessage(`{"queries":[{"refId":"A","expr":"up"}]}`)
 
-	blob, err := NewBundler().Build(resp, &harcapture.Buffer{}, nil, nil, request, nil, nil, nil)
+	blob, err := NewBundler().Build(BundleInput{Resp: resp, HARBuffer: &harcapture.Buffer{}, QueryRequestJSON: request})
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)

--- a/pkg/services/diagnostics/diagnostics_test.go
+++ b/pkg/services/diagnostics/diagnostics_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestBundler_Build(t *testing.T) {
 	// No HAR captured (empty buffer, nil response) -> traffic.har omitted; only panel.json present.
-	blob, err := NewBundler().Build(nil, &harcapture.Buffer{}, json.RawMessage(`{"id":1}`), nil, nil, nil, nil)
+	blob, err := NewBundler().Build(nil, &harcapture.Buffer{}, json.RawMessage(`{"id":1}`), nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -37,7 +37,7 @@ func TestBundler_Build(t *testing.T) {
 
 func TestBundler_Build_recordsQueryError(t *testing.T) {
 	// A failed query must still produce a bundle, with the error recorded (capture is not discarded).
-	blob, err := NewBundler().Build(nil, &harcapture.Buffer{}, nil, nil, nil, nil, errors.New("datasource timeout"))
+	blob, err := NewBundler().Build(nil, &harcapture.Buffer{}, nil, nil, nil, nil, nil, errors.New("datasource timeout"))
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -51,7 +51,7 @@ func TestBundler_Build_recordsQueryDataMarshalError(t *testing.T) {
 	// error is recorded and the other artifacts still ship, mirroring the per-panel dashboard path.
 	buf := bufferWithEntry(t, "http://ds/1")
 
-	blob, err := NewBundler().Build(nil, buf, nil, nil, json.RawMessage(`{invalid`), nil, nil)
+	blob, err := NewBundler().Build(nil, buf, nil, nil, json.RawMessage(`{invalid`), nil, nil, nil)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -67,7 +67,7 @@ func TestBundler_Build_recordsQueryRequestSerializeError(t *testing.T) {
 	// mirroring how the per-panel dashboard path surfaces the same failure via manifest.queryDataError.
 	buf := bufferWithEntry(t, "http://ds/1")
 
-	blob, err := NewBundler().Build(nil, buf, nil, nil, nil, errors.New("unsupported value: +Inf"), nil)
+	blob, err := NewBundler().Build(nil, buf, nil, nil, nil, nil, errors.New("unsupported value: +Inf"), nil)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -84,7 +84,7 @@ func TestBundler_Build_recordsQueryDataResponse(t *testing.T) {
 		"A": {Frames: data.Frames{frame}},
 	}}
 
-	blob, err := NewBundler().Build(resp, &harcapture.Buffer{}, nil, nil, nil, nil, nil)
+	blob, err := NewBundler().Build(resp, &harcapture.Buffer{}, nil, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -96,7 +96,7 @@ func TestBundler_Build_recordsQueryDataResponse(t *testing.T) {
 func TestBundler_Build_recordsQueryDataRequest(t *testing.T) {
 	request := json.RawMessage(`{"from":"now-1h","to":"now","queries":[{"refId":"A","expr":"up"}]}`)
 
-	blob, err := NewBundler().Build(nil, &harcapture.Buffer{}, nil, nil, request, nil, nil)
+	blob, err := NewBundler().Build(nil, &harcapture.Buffer{}, nil, nil, request, nil, nil, nil)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -114,7 +114,7 @@ func TestBundler_Build_excludesCaptureFramesFromQueryData(t *testing.T) {
 		"__har__ds": {Frames: data.Frames{capture}},
 	}}
 
-	blob, err := NewBundler().Build(resp, &harcapture.Buffer{}, nil, nil, nil, nil, nil)
+	blob, err := NewBundler().Build(resp, &harcapture.Buffer{}, nil, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -128,7 +128,7 @@ func TestBundler_Build_boundsOversizedQueryData(t *testing.T) {
 		"A": {Frames: data.Frames{frame}},
 	}}
 
-	blob, err := NewBundler().Build(resp, &harcapture.Buffer{}, nil, nil, nil, nil, nil)
+	blob, err := NewBundler().Build(resp, &harcapture.Buffer{}, nil, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -143,7 +143,7 @@ func TestBundler_Build_boundsOversizedRequestWithoutResponse(t *testing.T) {
 	// An oversized request with no response must truncate without claiming a response was omitted.
 	request := json.RawMessage(`{"expr":"` + strings.Repeat("x", maxQueryDataArtifactBytes) + `"}`)
 
-	blob, err := NewBundler().Build(nil, &harcapture.Buffer{}, nil, nil, request, nil, nil)
+	blob, err := NewBundler().Build(nil, &harcapture.Buffer{}, nil, nil, request, nil, nil, nil)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -171,7 +171,7 @@ func TestBundler_Build_preservesUpstreamAndPluginResultsForComparison(t *testing
 	queryResp := &backend.QueryDataResponse{Responses: backend.Responses{
 		"A": {Frames: data.Frames{pluginFrame}},
 	}}
-	blob, err := NewBundler().Build(queryResp, buf, nil, nil, nil, nil, nil)
+	blob, err := NewBundler().Build(queryResp, buf, nil, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -308,7 +308,7 @@ func TestCollectHAR_nilBuffer_noPanic(t *testing.T) {
 	require.Nil(t, out)
 
 	// A nil buffer must also flow through Build without panicking.
-	bundle, err := NewBundler().Build(nil, nil, nil, nil, nil, nil, nil)
+	bundle, err := NewBundler().Build(nil, nil, nil, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 	require.NotNil(t, bundle)
 }
@@ -761,7 +761,7 @@ func TestBundler_Build_keepsRequestWhenResponseEncodingFails(t *testing.T) {
 	resp := &backend.QueryDataResponse{Responses: backend.Responses{"A": {Frames: data.Frames{frame}}}}
 	request := json.RawMessage(`{"queries":[{"refId":"A","expr":"up"}]}`)
 
-	blob, err := NewBundler().Build(resp, &harcapture.Buffer{}, nil, nil, request, nil, nil)
+	blob, err := NewBundler().Build(resp, &harcapture.Buffer{}, nil, nil, request, nil, nil, nil)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -808,7 +808,7 @@ func TestMarshalQueryDataArtifactWithLimit_encodeFailureFitsMinimumBudget(t *tes
 	}}
 	request := json.RawMessage(`{"queries":[{"refId":"A","expr":"` + strings.Repeat("x", 4096) + `"}]}`)
 
-	out, _, err := marshalQueryDataArtifactWithLimit(request, resp, minQueryDataArtifactBytes)
+	out, _, err := marshalQueryDataArtifactWithLimit(request, resp, nil, minQueryDataArtifactBytes)
 	require.Error(t, err, "the response still fails to encode")
 	require.NotEmpty(t, out, "a floor artifact is produced rather than nothing")
 	require.LessOrEqual(t, len(out), minQueryDataArtifactBytes)
@@ -864,14 +864,14 @@ func TestMarshalQueryDataArtifactWithLimit_reportsTruncation(t *testing.T) {
 	frame := data.NewFrame("logs", data.NewField("line", nil, []string{strings.Repeat("x", maxQueryDataArtifactBytes)}))
 	resp := &backend.QueryDataResponse{Responses: backend.Responses{"A": {Frames: data.Frames{frame}}}}
 
-	_, truncated, err := marshalQueryDataArtifactWithLimit(nil, resp, maxQueryDataArtifactBytes)
+	_, truncated, err := marshalQueryDataArtifactWithLimit(nil, resp, nil, maxQueryDataArtifactBytes)
 	require.NoError(t, err)
 	require.True(t, truncated, "an oversized response must report truncated=true")
 
 	small := &backend.QueryDataResponse{Responses: backend.Responses{
 		"A": {Frames: data.Frames{data.NewFrame("cpu", data.NewField("value", nil, []float64{42}))}},
 	}}
-	_, truncated, err = marshalQueryDataArtifactWithLimit(nil, small, maxQueryDataArtifactBytes)
+	_, truncated, err = marshalQueryDataArtifactWithLimit(nil, small, nil, maxQueryDataArtifactBytes)
 	require.NoError(t, err)
 	require.False(t, truncated, "a response that fits must report truncated=false")
 }


### PR DESCRIPTION
_Part of the on-premise enhanced diagnostics effort._

Captures the executed server-side expression (`__expr__`) pipeline in `querydata.json` as an ordered `pipeline` array — one entry per DAG node with its `refId`, `type`, `command`, `inputRefIds` and `error` — so a reviewer can walk the chain from the datasource node to the panel's final expression and find the first stage whose output diverges from its inputs.

A stage carries no output of its own. The expression service returns every executed node under its own refId, so `response.results[refId]` already holds each stage's output frames; `pipeline` records only what the response cannot express — the DAG — and a reader joins the two on `refId`. Duplicating the frames would double `querydata.json` and halve the artifact's effective size budget.

The array is named `pipeline` rather than `expressions` because it holds every node the expression service executed, datasource and ML nodes included; for those, `command` carries the plugin type (e.g. `prometheus`) rather than an expression command.

Experimental, behind `grafana.onDemandDiagnostics` (off by default), on-prem- and admin-only.
