### PR TITLE
Datasources: Embed frontend transform/display evidence in diagnostics bundles

### DIFF
--- a/pkg/api/ds_query_dashboard_diagnostics.go
+++ b/pkg/api/ds_query_dashboard_diagnostics.go
@@ -25,10 +25,12 @@ import (
 )
 
 // NOTE (MVP scope): resource limits are intentionally deferred to a follow-up PR (tracked) to keep
-// this experimental feature small: no panel-count cap, no per-run timeout, and no per-body/
-// per-request byte caps. See the "dashboard-level limits" follow-up. The in-memory job store is
-// still bounded (retention TTL + max-entries + in-flight caps below) so it can't grow without limit;
-// that is a correctness guard against unbounded memory, not one of the deferred resource limits.
+// this experimental feature small: no panel-count cap and no per-run timeout. See the
+// "dashboard-level limits" follow-up. Two bounds are already in place because they guard against
+// unbounded memory rather than merely shaping limits: the in-memory job store (retention TTL +
+// max-entries + in-flight caps below), and the request body (maxDashboardDiagnosticsBodyBytes, see
+// bindDiagnosticsRequest) -- panels carry client-supplied frontend pipeline evidence whose size the
+// server cannot predict, and an async run holds the whole decoded payload until the archive is built.
 
 // diagnosticsEnabled reports whether the grafana.onDemandDiagnostics feature flag is on for the
 // current request. It reuses the shared OpenFeature client (see ds_query_diagnostics.go).
@@ -272,8 +274,8 @@ func (hs *HTTPServer) QueryDashboardDiagnostics(c *contextmodel.ReqContext) resp
 	}
 
 	reqDTO := dashboardDiagnosticsRequest{}
-	if err := web.Bind(c.Req, &reqDTO); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+	if r := bindDiagnosticsRequest(c, maxDashboardDiagnosticsBodyBytes, &reqDTO); r != nil {
+		return r
 	}
 	if len(reqDTO.Panels) == 0 {
 		return response.Error(http.StatusBadRequest, "at least one panel is required", nil)

--- a/pkg/api/ds_query_dashboard_diagnostics.go
+++ b/pkg/api/ds_query_dashboard_diagnostics.go
@@ -49,6 +49,9 @@ type panelDiagnosticsSpec struct {
 	ID                 int64           `json:"id"`
 	Title              string          `json:"title"`
 	Panel              json.RawMessage `json:"panel"`
+	// PostProcessing carries this panel's client-captured frontend pipeline evidence (see
+	// diagnosticsRequest.PostProcessing).
+	PostProcessing json.RawMessage `json:"postProcessing"`
 }
 
 // ---- async job store (in-memory; mirrors the support-bundle create/pending/complete model) -------
@@ -383,10 +386,11 @@ func (hs *HTTPServer) buildDashboardDiagnosticsArchive(ctx context.Context, user
 			return nil, err
 		}
 		panel := diagnostics.DashboardPanel{
-			ID:          p.ID,
-			Title:       p.Title,
-			PanelJSON:   p.Panel,
-			Datasources: panelDatasourceUIDs(p.MetricRequest),
+			ID:             p.ID,
+			Title:          p.Title,
+			PanelJSON:      p.Panel,
+			PostProcessing: p.PostProcessing,
+			Datasources:    panelDatasourceUIDs(p.MetricRequest),
 		}
 
 		// A single panel's unserializable query request must not abort the whole archive: record it

--- a/pkg/api/ds_query_dashboard_diagnostics_test.go
+++ b/pkg/api/ds_query_dashboard_diagnostics_test.go
@@ -211,6 +211,55 @@ func TestBuildDashboardDiagnosticsArchive_recordsSubmittedQueryRequest(t *testin
 	require.Contains(t, string(files["panels/1-panel-1/querydata.json"]), `"expr": "up"`)
 }
 
+// TestBuildDashboardDiagnosticsArchive_forwardsPostProcessing covers the wiring for the frontend
+// pipeline evidence: it is the one artifact the backend cannot reconstruct, so if the per-panel
+// postProcessing field stops reaching diagnostics.DashboardPanel the bundle silently loses it with
+// every other artifact still present and nothing failing.
+func TestBuildDashboardDiagnosticsArchive_forwardsPostProcessing(t *testing.T) {
+	fakeQuery := query.NewFakeQueryService(t)
+	fakeQuery.On("QueryData", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(backend.NewQueryDataResponse(), nil)
+	hs := &HTTPServer{queryDataService: fakeQuery}
+
+	reqDTO := dashboardDiagnosticsRequest{
+		Panels: []panelDiagnosticsSpec{{
+			ID:             1,
+			Title:          "Panel 1",
+			PostProcessing: json.RawMessage(`{"transformations":[{"id":"reduce"}],"display":{"pluginId":"stat"}}`),
+			MetricRequest: dtos.MetricRequest{
+				Queries: []*simplejson.Json{simplejson.NewFromAny(map[string]any{"refId": "A"})},
+			},
+		}},
+	}
+
+	archive, err := hs.buildDashboardDiagnosticsArchive(context.Background(), &user.SignedInUser{OrgID: 1, UserUID: "u1"}, false, false, reqDTO, "job-postprocessing")
+	require.NoError(t, err)
+
+	files := readTarGzFiles(t, archive)
+	require.Contains(t, files, "panels/1-panel-1/frontend-processing.json")
+	body := string(files["panels/1-panel-1/frontend-processing.json"])
+	require.Contains(t, body, `"reduce"`)
+	require.Contains(t, body, `"stat"`)
+	require.Contains(t, string(files["manifest.json"]), `"postProcessingBytes"`,
+		"the manifest records the artifact so a reader sees it without unpacking the panel dir")
+}
+
+// TestPanelDiagnosticsSpec_bindsPostProcessing pins the wire contract: the field is client-supplied,
+// so a rename or a missing tag would leave it silently empty on every request.
+func TestPanelDiagnosticsSpec_bindsPostProcessing(t *testing.T) {
+	body := `{"dashboard":{"title":"d"},"panels":[{"id":7,"title":"P","postProcessing":{"transformations":[{"id":"reduce"}]}}]}`
+
+	var req dashboardDiagnosticsRequest
+	require.NoError(t, json.Unmarshal([]byte(body), &req))
+	require.Len(t, req.Panels, 1)
+	require.JSONEq(t, `{"transformations":[{"id":"reduce"}]}`, string(req.Panels[0].PostProcessing))
+
+	// The single-panel request carries the same field under the same name.
+	var single diagnosticsRequest
+	require.NoError(t, json.Unmarshal([]byte(`{"postProcessing":{"display":{"pluginId":"stat"}}}`), &single))
+	require.JSONEq(t, `{"display":{"pluginId":"stat"}}`, string(single.PostProcessing))
+}
+
 // TestBuildDashboardDiagnosticsArchive_queryV2Dispatch guards against a regression where the
 // dashboard-level path always called QueryData, ignoring the X-Query-V2 signal that QueryDiagnostics
 // (the single-panel path) honors -- so captured traffic wouldn't match a panel using Query V2's

--- a/pkg/api/ds_query_dashboard_diagnostics_test.go
+++ b/pkg/api/ds_query_dashboard_diagnostics_test.go
@@ -166,21 +166,30 @@ func TestQueryDashboardDiagnostics_rejectsWhenInFlightCapReached(t *testing.T) {
 func TestQueryDiagnostics_rejectsOversizedBody(t *testing.T) {
 	setupOpenFeatureFlag(t, featuremgmt.FlagGrafanaOnDemandDiagnostics, true)
 
-	// Padding inside postProcessing rather than a bare blob: that is the client-supplied field with no
-	// server-side bound, and it must be the body cap -- not the artifact cap -- that rejects it.
-	oversized := func(maxBytes int64) string {
-		return `{"panels":[{"id":1,"queries":[{"refId":"A"}],"postProcessing":{"pad":"` +
-			strings.Repeat("x", int(maxBytes)+1024) + `"}}],` +
-			`"queries":[{"refId":"A"}],"postProcessing":{"pad":"x"}}`
-	}
-
 	tests := []struct {
 		name     string
 		maxBytes int64
-		call     func(*HTTPServer, *contextmodel.ReqContext) response.Response
+		// prefix/suffix bracket the padding so it lands inside the postProcessing THAT ENDPOINT binds,
+		// rather than a bare blob or a field the other endpoint's struct ignores: that is the
+		// client-supplied field with no server-side bound, and it must be the body cap -- not the
+		// artifact cap -- that rejects it.
+		prefix, suffix string
+		call           func(*HTTPServer, *contextmodel.ReqContext) response.Response
 	}{
-		{"single panel", maxDiagnosticsBodyBytes, (*HTTPServer).QueryDiagnostics},
-		{"whole dashboard", maxDashboardDiagnosticsBodyBytes, (*HTTPServer).QueryDashboardDiagnostics},
+		{
+			name:     "single panel",
+			maxBytes: maxDiagnosticsBodyBytes,
+			prefix:   `{"queries":[{"refId":"A"}],"postProcessing":{"pad":"`,
+			suffix:   `"}}`,
+			call:     (*HTTPServer).QueryDiagnostics,
+		},
+		{
+			name:     "whole dashboard",
+			maxBytes: maxDashboardDiagnosticsBodyBytes,
+			prefix:   `{"panels":[{"id":1,"queries":[{"refId":"A"}],"postProcessing":{"pad":"`,
+			suffix:   `"}}]}`,
+			call:     (*HTTPServer).QueryDashboardDiagnostics,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -188,7 +197,14 @@ func TestQueryDiagnostics_rejectsOversizedBody(t *testing.T) {
 			// and a nil one would panic loudly if that stopped being true.
 			hs := &HTTPServer{}
 
-			req, err := http.NewRequest(http.MethodPost, "/api/ds/diagnostics", strings.NewReader(oversized(tc.maxBytes)))
+			// Streamed rather than built with strings.Repeat: materializing a body past the 64 MiB
+			// dashboard cap costs ~130 MiB of test strings, in a package whose tests already run wide.
+			body := io.MultiReader(
+				strings.NewReader(tc.prefix),
+				io.LimitReader(padReader{}, tc.maxBytes+1024),
+				strings.NewReader(tc.suffix),
+			)
+			req, err := http.NewRequest(http.MethodPost, "/api/ds/diagnostics", body)
 			require.NoError(t, err)
 			req.Header.Set("Content-Type", "application/json")
 			c := &contextmodel.ReqContext{
@@ -222,8 +238,11 @@ func TestQueryDiagnostics_acceptsBodyWithinCap(t *testing.T) {
 		Return(backend.NewQueryDataResponse(), nil)
 	hs := &HTTPServer{queryDataService: fakeQuery}
 
-	// Comfortably under the cap, comfortably over anything a hand-written body would reach.
-	body := `{"queries":[{"refId":"A"}],"postProcessing":{"pad":"` + strings.Repeat("x", 8<<20) + `"}}`
+	// Comfortably over anything a hand-written body would reach, and under both bounds it has to clear:
+	// the body cap here and the per-artifact cap in the bundler, so the capture reaches the bundle whole.
+	const padBytes = 1 << 20
+	require.Less(t, padBytes, int(maxDiagnosticsBodyBytes))
+	body := `{"queries":[{"refId":"A"}],"postProcessing":{"pad":"` + strings.Repeat("x", padBytes) + `"}}`
 	req, err := http.NewRequest(http.MethodPost, "/api/ds/diagnostics", strings.NewReader(body))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
@@ -240,6 +259,20 @@ func TestQueryDiagnostics_acceptsBodyWithinCap(t *testing.T) {
 	resp := hs.QueryDiagnostics(c)
 	require.Equal(t, http.StatusOK, resp.Status(),
 		"a large but in-cap capture is accepted and bundled")
+	// A 200 alone would also pass if the capture were dropped somewhere between binding and assembly,
+	// which is the failure this test is really about, so check it reached the bundle.
+	require.Contains(t, readTarGzFiles(t, resp.Body()), "frontend-processing.json")
+}
+
+// padReader yields an endless run of 'x'. Used to stream an over-cap request body instead of building
+// it with strings.Repeat, which for the 64 MiB dashboard cap would allocate the padding twice over.
+type padReader struct{}
+
+func (padReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = 'x'
+	}
+	return len(p), nil
 }
 
 // TestBuildDashboardDiagnosticsArchive_recordsPerRefIDQueryError guards against a regression where

--- a/pkg/api/ds_query_dashboard_diagnostics_test.go
+++ b/pkg/api/ds_query_dashboard_diagnostics_test.go
@@ -21,6 +21,7 @@ import (
 
 	backend "github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana/pkg/api/dtos"
+	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/contexthandler"
@@ -152,6 +153,93 @@ func TestQueryDashboardDiagnostics_rejectsWhenInFlightCapReached(t *testing.T) {
 	// The rejected request must not have created a job.
 	require.Len(t, dashboardDiagnosticsJobs.jobs, diagnosticsMaxInFlightJobs,
 		"a rejected request must not add a job to the store")
+}
+
+// TestQueryDiagnostics_rejectsOversizedBody pins the per-endpoint body cap on both diagnostics
+// handlers. The interesting part is the status: an over-cap body surfaces from web.Bind as
+// *http.MaxBytesError, and if that stops being unwrapped the request degrades to a generic 400 "bad
+// request data", telling a caller their JSON is malformed when the real problem is its size.
+//
+// It also guards the cap itself. web.Bind applies the generic web.MaxBindBodyBytes (100 MiB) to every
+// endpoint, so dropping these calls would leave the handlers accepting bodies several times larger
+// than they need, each one held resident for the whole run (an async one, for the dashboard path).
+func TestQueryDiagnostics_rejectsOversizedBody(t *testing.T) {
+	setupOpenFeatureFlag(t, featuremgmt.FlagGrafanaOnDemandDiagnostics, true)
+
+	// Padding inside postProcessing rather than a bare blob: that is the client-supplied field with no
+	// server-side bound, and it must be the body cap -- not the artifact cap -- that rejects it.
+	oversized := func(maxBytes int64) string {
+		return `{"panels":[{"id":1,"queries":[{"refId":"A"}],"postProcessing":{"pad":"` +
+			strings.Repeat("x", int(maxBytes)+1024) + `"}}],` +
+			`"queries":[{"refId":"A"}],"postProcessing":{"pad":"x"}}`
+	}
+
+	tests := []struct {
+		name     string
+		maxBytes int64
+		call     func(*HTTPServer, *contextmodel.ReqContext) response.Response
+	}{
+		{"single panel", maxDiagnosticsBodyBytes, (*HTTPServer).QueryDiagnostics},
+		{"whole dashboard", maxDashboardDiagnosticsBodyBytes, (*HTTPServer).QueryDashboardDiagnostics},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// The cap trips during binding, before any query runs, so no fake queryDataService is needed --
+			// and a nil one would panic loudly if that stopped being true.
+			hs := &HTTPServer{}
+
+			req, err := http.NewRequest(http.MethodPost, "/api/ds/diagnostics", strings.NewReader(oversized(tc.maxBytes)))
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+			c := &contextmodel.ReqContext{
+				Context: &web.Context{
+					Req:  req,
+					Resp: web.NewResponseWriter(req.Method, httptest.NewRecorder()),
+				},
+				SignedInUser: &user.SignedInUser{OrgID: 1, UserUID: "u1"},
+				Logger:       log.New("test"),
+			}
+			c.Req = req
+
+			resp := tc.call(hs, c)
+			require.Equal(t, http.StatusRequestEntityTooLarge, resp.Status(),
+				"an over-cap body is a 413, not a 400 that reads as malformed JSON")
+		})
+	}
+}
+
+// TestQueryDiagnostics_acceptsBodyWithinCap is the other half: the cap must not reject a body that
+// merely carries a large-but-legitimate frontend pipeline capture, or the feature loses the evidence
+// it exists to collect on exactly the panels that need it most.
+//
+// Exercised on the single-panel path because it is synchronous. The dashboard handler would answer 202
+// and leave a detached goroutine writing to the process-wide job store past the end of the test.
+func TestQueryDiagnostics_acceptsBodyWithinCap(t *testing.T) {
+	setupOpenFeatureFlag(t, featuremgmt.FlagGrafanaOnDemandDiagnostics, true)
+
+	fakeQuery := query.NewFakeQueryService(t)
+	fakeQuery.On("QueryData", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(backend.NewQueryDataResponse(), nil)
+	hs := &HTTPServer{queryDataService: fakeQuery}
+
+	// Comfortably under the cap, comfortably over anything a hand-written body would reach.
+	body := `{"queries":[{"refId":"A"}],"postProcessing":{"pad":"` + strings.Repeat("x", 8<<20) + `"}}`
+	req, err := http.NewRequest(http.MethodPost, "/api/ds/diagnostics", strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	c := &contextmodel.ReqContext{
+		Context: &web.Context{
+			Req:  req,
+			Resp: web.NewResponseWriter(req.Method, httptest.NewRecorder()),
+		},
+		SignedInUser: &user.SignedInUser{OrgID: 1, UserUID: "u1"},
+		Logger:       log.New("test"),
+	}
+	c.Req = req
+
+	resp := hs.QueryDiagnostics(c)
+	require.Equal(t, http.StatusOK, resp.Status(),
+		"a large but in-cap capture is accepted and bundled")
 }
 
 // TestBuildDashboardDiagnosticsArchive_recordsPerRefIDQueryError guards against a regression where

--- a/pkg/api/ds_query_diagnostics.go
+++ b/pkg/api/ds_query_diagnostics.go
@@ -36,6 +36,39 @@ type diagnosticsRequest struct {
 // (staticcheck SA1019) and slated for removal.
 var diagnosticsFeatureClient = openfeature.NewDefaultClient()
 
+const (
+	// maxDiagnosticsBodyBytes caps the single-panel diagnostics request body. web.Bind already applies
+	// the generic web.MaxBindBodyBytes (100 MiB), which is far more than this endpoint needs -- the body
+	// carries one panel's queries, its panel/dashboard JSON, and the client-captured frontend pipeline
+	// evidence. Scoping it down bounds what a run holds resident: the decoded payload lives for the whole
+	// request, and PostProcessing in particular is client-supplied with no size the server can predict.
+	maxDiagnosticsBodyBytes = 32 << 20
+	// maxDashboardDiagnosticsBodyBytes is the whole-dashboard equivalent, larger because the body
+	// legitimately scales with panel count (each panel carries its own queries and frontend evidence).
+	// It matters more there: generation is asynchronous, so the decoded payload stays resident until the
+	// archive is assembled, multiplied by up to diagnosticsMaxInFlightJobs concurrent runs.
+	maxDashboardDiagnosticsBodyBytes = 64 << 20
+)
+
+// bindDiagnosticsRequest caps the request body at maxBytes before decoding it into v.
+//
+// An over-cap body surfaces from web.Bind as *http.MaxBytesError rather than a decode failure, so it is
+// reported as 413 instead of the generic 400 -- a "bad request data" on a too-large body reads as
+// malformed JSON and sends a caller looking for a syntax error that isn't there.
+func bindDiagnosticsRequest(c *contextmodel.ReqContext, maxBytes int64, v any) response.Response {
+	c.Req.Body = http.MaxBytesReader(c.Resp, c.Req.Body, maxBytes)
+	err := web.Bind(c.Req, v)
+	if err == nil {
+		return nil
+	}
+	var tooLarge *http.MaxBytesError
+	if errors.As(err, &tooLarge) {
+		return response.Error(http.StatusRequestEntityTooLarge,
+			fmt.Sprintf("diagnostics request body exceeds the %d-byte limit", tooLarge.Limit), nil)
+	}
+	return response.Error(http.StatusBadRequest, "bad request data", err)
+}
+
 // QueryDiagnostics executes the supplied datasource queries with HAR capture active and returns a
 // .tar.gz diagnostic bundle (captured traffic and the panel/dashboard JSON). Bundle assembly lives
 // in the diagnostics service; this handler owns the HTTP concerns: gating, request binding, running
@@ -49,8 +82,8 @@ func (hs *HTTPServer) QueryDiagnostics(c *contextmodel.ReqContext) response.Resp
 	}
 
 	reqDTO := diagnosticsRequest{}
-	if err := web.Bind(c.Req, &reqDTO); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+	if r := bindDiagnosticsRequest(c, maxDiagnosticsBodyBytes, &reqDTO); r != nil {
+		return r
 	}
 	if len(reqDTO.Queries) == 0 {
 		return response.Error(http.StatusBadRequest, "at least one query is required", nil)

--- a/pkg/api/ds_query_diagnostics.go
+++ b/pkg/api/ds_query_diagnostics.go
@@ -112,7 +112,16 @@ func (hs *HTTPServer) QueryDiagnostics(c *contextmodel.ReqContext) response.Resp
 	if marshalErr != nil {
 		queryRequestJSON = nil
 	}
-	bundle, err := diagnostics.NewBundler().Build(resp, harBuffer, reqDTO.Panel, reqDTO.Dashboard, queryRequestJSON, reqDTO.PostProcessing, marshalErr, bundleErr)
+	bundle, err := diagnostics.NewBundler().Build(diagnostics.BuildInput{
+		Resp:             resp,
+		HARBuffer:        harBuffer,
+		PanelJSON:        reqDTO.Panel,
+		DashboardJSON:    reqDTO.Dashboard,
+		QueryRequestJSON: queryRequestJSON,
+		PostProcessing:   reqDTO.PostProcessing,
+		QueryRequestErr:  marshalErr,
+		QueryErr:         bundleErr,
+	})
 	if err != nil {
 		return response.Error(http.StatusInternalServerError, "failed to build diagnostics bundle", err)
 	}

--- a/pkg/api/ds_query_diagnostics.go
+++ b/pkg/api/ds_query_diagnostics.go
@@ -28,6 +28,17 @@ type diagnosticsRequest struct {
 	// PostProcessing carries the client-captured frontend pipeline evidence (transformation
 	// input/output frames + applied display context) that /api/ds/query never sees because
 	// transformations and field config run in the browser.
+	//
+	// Contract for the capture side: omit the field, or send {}, when nothing was captured. The
+	// server's emptiness check is shallow (see diagnostics.hasJSONContent), so a structurally empty
+	// object -- {"input":[],"output":[],"display":null} -- is treated as evidence: it earns an artifact
+	// carrying nothing, and on a non-data panel a manifest error claiming evidence was discarded.
+	//
+	// The shape is otherwise the client's own document, embedded verbatim when it fits. Only the
+	// top-level "transformations", "display", "input" and "output" keys are understood, and only to
+	// decide what to drop first when a payload is over budget (see
+	// diagnostics.fitPostProcessingArtifact) -- a payload using other names still round-trips intact,
+	// it just degrades to markers instead of keeping its transform config.
 	PostProcessing json.RawMessage `json:"postProcessing"`
 }
 
@@ -47,6 +58,12 @@ const (
 	// legitimately scales with panel count (each panel carries its own queries and frontend evidence).
 	// It matters more there: generation is asynchronous, so the decoded payload stays resident until the
 	// archive is assembled, multiplied by up to diagnosticsMaxInFlightJobs concurrent runs.
+	//
+	// Note this cap is all-or-nothing where the artifact budgets in pkg/services/diagnostics degrade:
+	// there is no panel-count cap yet, so a wide dashboard whose per-panel captures add up past this
+	// gets a 413 and no bundle at all, rather than a bundle with truncated evidence. The capture side
+	// therefore needs its own per-panel/whole-dashboard budget to stay under it -- part of the
+	// "dashboard-level limits" follow-up together with the panel-count cap.
 	maxDashboardDiagnosticsBodyBytes = 64 << 20
 )
 

--- a/pkg/api/ds_query_diagnostics.go
+++ b/pkg/api/ds_query_diagnostics.go
@@ -25,6 +25,10 @@ type diagnosticsRequest struct {
 	dtos.MetricRequest
 	Dashboard json.RawMessage `json:"dashboard"`
 	Panel     json.RawMessage `json:"panel"`
+	// PostProcessing carries the client-captured frontend pipeline evidence (transformation
+	// input/output frames + applied display context) that /api/ds/query never sees because
+	// transformations and field config run in the browser.
+	PostProcessing json.RawMessage `json:"postProcessing"`
 }
 
 // diagnosticsFeatureClient is a shared OpenFeature client reused across requests. Flags are
@@ -108,7 +112,7 @@ func (hs *HTTPServer) QueryDiagnostics(c *contextmodel.ReqContext) response.Resp
 	if marshalErr != nil {
 		queryRequestJSON = nil
 	}
-	bundle, err := diagnostics.NewBundler().Build(resp, harBuffer, reqDTO.Panel, reqDTO.Dashboard, queryRequestJSON, marshalErr, bundleErr)
+	bundle, err := diagnostics.NewBundler().Build(resp, harBuffer, reqDTO.Panel, reqDTO.Dashboard, queryRequestJSON, reqDTO.PostProcessing, marshalErr, bundleErr)
 	if err != nil {
 		return response.Error(http.StatusInternalServerError, "failed to build diagnostics bundle", err)
 	}

--- a/pkg/services/diagnostics/diagnostics.go
+++ b/pkg/services/diagnostics/diagnostics.go
@@ -40,7 +40,9 @@ const (
 	// bundle, the way maxDashboardQueryDataBytes does for querydata.json -- without it a per-panel cap
 	// alone lets an N-panel dashboard contribute N * maxPostProcessingArtifactBytes, all resident at once
 	// while the archive is assembled. It matters more here than for query data: this payload is
-	// client-supplied and the request body is not yet capped (see the MVP NOTE in pkg/api).
+	// client-supplied, so unlike a query response its size is not a function of anything the server
+	// controls. The request body is capped too (maxDashboardDiagnosticsBodyBytes in pkg/api), but that
+	// bounds the whole request, not this artifact's share of the archive.
 	//
 	// Budgeted separately rather than drawn from the query-data pool because the two artifacts answer
 	// different questions and a reader usually needs both: sharing one pool would let a data-heavy

--- a/pkg/services/diagnostics/diagnostics.go
+++ b/pkg/services/diagnostics/diagnostics.go
@@ -31,9 +31,14 @@ type Bundler struct{}
 const (
 	maxQueryDataArtifactBytes  = 8 << 20
 	maxDashboardQueryDataBytes = 32 << 20
+	// maxPostProcessingArtifactBytes caps a single frontend-processing.json, the way
+	// maxQueryDataArtifactBytes does querydata.json. Named separately rather than reusing that constant
+	// because the two artifacts are budgeted independently and only happen to share a value today --
+	// tuning one must not silently move the other.
+	maxPostProcessingArtifactBytes = 8 << 20
 	// maxDashboardPostProcessingBytes bounds the TOTAL frontend-processing.json across a whole-dashboard
 	// bundle, the way maxDashboardQueryDataBytes does for querydata.json -- without it a per-panel cap
-	// alone lets an N-panel dashboard contribute N * maxQueryDataArtifactBytes, all resident at once
+	// alone lets an N-panel dashboard contribute N * maxPostProcessingArtifactBytes, all resident at once
 	// while the archive is assembled. It matters more here than for query data: this payload is
 	// client-supplied and the request body is not yet capped (see the MVP NOTE in pkg/api).
 	//
@@ -117,7 +122,7 @@ func (b *Bundler) Build(in BuildInput) ([]byte, error) {
 
 	// No dashboard-wide budget applies on the single-panel path: there is exactly one artifact, so the
 	// per-artifact cap is the whole bound.
-	if fp, _ := marshalPostProcessingArtifact(in.PostProcessing, maxQueryDataArtifactBytes); len(fp) > 0 {
+	if fp, _ := marshalPostProcessingArtifact(in.PostProcessing, maxPostProcessingArtifactBytes); len(fp) > 0 {
 		files["frontend-processing.json"] = fp
 	}
 
@@ -229,7 +234,7 @@ func marshalQueryDataArtifactWithLimit(request json.RawMessage, resp *backend.Qu
 
 // fitQueryDataArtifact encodes artifact with progressively less content -- request kept, request
 // omitted, summary dropped, then markers only -- and returns the first encoding within maxBytes. The
-// last rung holds only fixed-size markers, which keeps it under minQueryDataArtifactBytes so the
+// last rung holds only fixed-size markers, which keeps it under minDiagnosticArtifactBytes so the
 // budget gate in BuildDashboard stays meaningful; it is returned even when it somehow still doesn't
 // fit, because there is nothing further to drop, and callers enforcing a hard budget re-check length.
 func fitQueryDataArtifact(artifact queryDataArtifact, request json.RawMessage, maxBytes int) ([]byte, error) {
@@ -409,7 +414,7 @@ func (b *Bundler) BuildDashboard(dashboardJSON json.RawMessage, panels []Dashboa
 			// panel has no query results and therefore no transform pipeline, so the client should not be
 			// sending evidence for one -- but if it does, say so in the manifest rather than discarding it
 			// without a trace.
-			if hasPostProcessing(p.PostProcessing) {
+			if hasJSONContent(p.PostProcessing) {
 				entry.PostProcessingError = "frontend pipeline evidence discarded: panel was not executed"
 			}
 			manifest.Panels = append(manifest.Panels, entry)
@@ -468,8 +473,8 @@ func (b *Bundler) BuildDashboard(dashboardJSON json.RawMessage, panels []Dashboa
 		// frontend-processing.json draws on its own dashboard-wide pool (see
 		// maxDashboardPostProcessingBytes) so a large payload on early panels cannot leave later panels
 		// with nothing, and N panels cannot multiply the per-panel cap into the whole archive.
-		if hasPostProcessing(p.PostProcessing) {
-			ppLimit := min(maxQueryDataArtifactBytes, postProcessingBytesRemaining)
+		if hasJSONContent(p.PostProcessing) {
+			ppLimit := min(maxPostProcessingArtifactBytes, postProcessingBytesRemaining)
 			switch {
 			case ppLimit < minDiagnosticArtifactBytes:
 				entry.PostProcessingTruncated = true
@@ -940,36 +945,53 @@ type postProcessingArtifact struct {
 	// LimitBytes was compared against. Both are reported because they differ -- a client that already
 	// pretty-prints can even shrink under re-indentation -- so a reader checking the artifact against
 	// the request body would otherwise be comparing against the wrong number.
-	OriginalBytes int  `json:"originalBytes"`
-	IndentedBytes int  `json:"indentedBytes"`
-	LimitBytes    int  `json:"limitBytes"`
-	FramesOmitted bool `json:"framesOmitted,omitempty"`
-	// TransformationsOmitted/DisplayOmitted record that even the small fields had to be dropped, so a
-	// reader can tell "the client never sent it" from "it didn't fit".
+	OriginalBytes int `json:"originalBytes"`
+	IndentedBytes int `json:"indentedBytes"`
+	LimitBytes    int `json:"limitBytes"`
+	// The *Omitted flags all mean "the client sent this and it had to be dropped", never "it isn't
+	// here": each is set from what the payload actually carried, so a reader can tell a field that
+	// didn't fit from one that was never captured and doesn't go hunting for the latter.
+	FramesOmitted          bool `json:"framesOmitted,omitempty"`
 	TransformationsOmitted bool `json:"transformationsOmitted,omitempty"`
 	DisplayOmitted         bool `json:"displayOmitted,omitempty"`
 }
 
-// jsonNullLiteral is compared against with bytes.Equal rather than string(payload) == "null", which
-// would copy the whole (potentially multi-megabyte) payload just to reject four bytes.
-var jsonNullLiteral = []byte("null")
+// jsonEmptyLiterals are the payloads that are syntactically present but carry nothing: a client with
+// nothing to report sends one of these as readily as it omits the field, and an "empty capture"
+// artifact (or a manifest error claiming evidence was discarded) is worse than no artifact at all.
+//
+// Compared with bytes.Equal rather than string(payload) == "null", which would copy the whole
+// (potentially multi-megabyte) payload just to reject a few bytes. Interior whitespace ("{ }") is not
+// normalized away, since no JSON encoder emits it for an empty container.
+var jsonEmptyLiterals = [][]byte{[]byte("null"), []byte("{}"), []byte("[]"), []byte(`""`)}
 
-// hasPostProcessing reports whether the client actually sent frontend pipeline evidence. Shared with
-// marshalPostProcessingArtifact so BuildDashboard's budget gate agrees with it on what "nothing" is
-// and doesn't record a budget failure against a panel that sent no evidence at all.
-func hasPostProcessing(raw json.RawMessage) bool {
+// hasJSONContent reports whether a raw JSON value carries something worth recording. Shared by
+// BuildDashboard's budget gate, marshalPostProcessingArtifact, and the per-field omission flags in
+// fitPostProcessingArtifact, so all of them agree on what "nothing" is -- otherwise the gate records a
+// budget failure against a panel that sent no evidence, or a flag claims a field didn't fit when the
+// client never sent it.
+func hasJSONContent(raw json.RawMessage) bool {
 	trimmed := bytes.TrimSpace(raw)
-	return len(trimmed) > 0 && !bytes.Equal(trimmed, jsonNullLiteral)
+	if len(trimmed) == 0 {
+		return false
+	}
+	for _, empty := range jsonEmptyLiterals {
+		if bytes.Equal(trimmed, empty) {
+			return false
+		}
+	}
+	return true
 }
 
 // marshalPostProcessingArtifact returns the frontend-processing.json bytes for the client-captured
 // pipeline evidence plus whether content had to be dropped to fit maxBytes, or (nil, false) when the
-// client sent nothing. The payload is embedded verbatim (pretty-printed) when it fits; when it does
-// not, it degrades through fitPostProcessingArtifact rather than vanishing behind a bare marker.
+// client sent nothing -- an empty container included (see hasJSONContent). The payload is embedded
+// verbatim (pretty-printed) when it fits; when it does not, it degrades through
+// fitPostProcessingArtifact rather than vanishing behind a bare marker.
 //
 // Transient peak serialization memory is not yet strictly bounded (same limitation as querydata.json).
 func marshalPostProcessingArtifact(raw json.RawMessage, maxBytes int) ([]byte, bool) {
-	if !hasPostProcessing(raw) {
+	if !hasJSONContent(raw) {
 		return nil, false
 	}
 	trimmed := bytes.TrimSpace(raw)
@@ -999,7 +1021,6 @@ func fitPostProcessingArtifact(trimmed json.RawMessage, indentedBytes, maxBytes 
 		OriginalBytes: len(trimmed),
 		IndentedBytes: indentedBytes,
 		LimitBytes:    maxBytes,
-		FramesOmitted: true,
 	}
 
 	// Only a JSON object can carry the fields worth keeping; any other shape (array, string, number)
@@ -1007,10 +1028,23 @@ func fitPostProcessingArtifact(trimmed json.RawMessage, indentedBytes, maxBytes 
 	var fields struct {
 		Transformations json.RawMessage `json:"transformations"`
 		Display         json.RawMessage `json:"display"`
+		Input           json.RawMessage `json:"input"`
+		Output          json.RawMessage `json:"output"`
 	}
 	if err := json.Unmarshal(trimmed, &fields); err == nil {
-		artifact.Transformations = fields.Transformations
-		artifact.Display = fields.Display
+		// Derived from what the payload actually carried rather than assumed: the frames are the bulk this
+		// rung drops, but a payload whose weight sits in some other field never had any, and marking them
+		// omitted would send a reader looking for evidence the client never captured.
+		artifact.FramesOmitted = hasJSONContent(fields.Input) || hasJSONContent(fields.Output)
+		// Only content worth keeping is carried over. An empty or null field is not evidence, and
+		// embedding it would also make the *Omitted flags below report it as "didn't fit" when the client
+		// never sent it -- the exact distinction those flags exist to draw.
+		if hasJSONContent(fields.Transformations) {
+			artifact.Transformations = fields.Transformations
+		}
+		if hasJSONContent(fields.Display) {
+			artifact.Display = fields.Display
+		}
 		if out, err := json.MarshalIndent(artifact, "", "  "); err == nil && len(out) <= maxBytes {
 			return out
 		}
@@ -1018,14 +1052,14 @@ func fitPostProcessingArtifact(trimmed json.RawMessage, indentedBytes, maxBytes 
 		// Display is dropped before the transformation config: a panel's field config and overrides can
 		// themselves be sizeable, while the transform list is the more direct answer to "did a frontend
 		// transform do this?".
+		artifact.DisplayOmitted = len(artifact.Display) > 0
 		artifact.Display = nil
-		artifact.DisplayOmitted = len(fields.Display) > 0
 		if out, err := json.MarshalIndent(artifact, "", "  "); err == nil && len(out) <= maxBytes {
 			return out
 		}
 
+		artifact.TransformationsOmitted = len(artifact.Transformations) > 0
 		artifact.Transformations = nil
-		artifact.TransformationsOmitted = len(fields.Transformations) > 0
 	}
 
 	return []byte(fmt.Sprintf(`{
@@ -1034,9 +1068,9 @@ func fitPostProcessingArtifact(trimmed json.RawMessage, indentedBytes, maxBytes 
   "originalBytes": %d,
   "indentedBytes": %d,
   "limitBytes": %d,
-  "framesOmitted": true,
+  "framesOmitted": %t,
   "transformationsOmitted": %t,
   "displayOmitted": %t
 }`, postProcessingArtifactVersion, len(trimmed), indentedBytes, maxBytes,
-		artifact.TransformationsOmitted, artifact.DisplayOmitted))
+		artifact.FramesOmitted, artifact.TransformationsOmitted, artifact.DisplayOmitted))
 }

--- a/pkg/services/diagnostics/diagnostics.go
+++ b/pkg/services/diagnostics/diagnostics.go
@@ -972,6 +972,13 @@ var jsonEmptyLiterals = [][]byte{[]byte("null"), []byte("{}"), []byte("[]"), []b
 // fitPostProcessingArtifact, so all of them agree on what "nothing" is -- otherwise the gate records a
 // budget failure against a panel that sent no evidence, or a flag claims a field didn't fit when the
 // client never sent it.
+//
+// The check is deliberately shallow: it recognizes an empty value, not a structurally empty one. An
+// object whose members are all empty ({"input":[],"output":[],"display":null}) counts as content and
+// gets an artifact -- and, on a skipped panel, a manifest error saying evidence was discarded. Going
+// deeper would mean parsing every payload just to answer the gate, on the hot path for a multi-megabyte
+// capture, so the contract is on the client instead: omit postProcessing (or send {}) when nothing was
+// captured. See the field doc on diagnosticsRequest.PostProcessing in pkg/api.
 func hasJSONContent(raw json.RawMessage) bool {
 	trimmed := bytes.TrimSpace(raw)
 	if len(trimmed) == 0 {
@@ -1012,10 +1019,11 @@ func marshalPostProcessingArtifact(raw json.RawMessage, maxBytes int) ([]byte, b
 // lose the cheap, high-signal evidence in exactly the data-heavy cases this artifact exists to
 // explain, the same reasoning marshalQueryDataArtifactWithLimit applies to the submitted query.
 //
-// The last rung holds only fixed-size markers (well under minDiagnosticArtifactBytes) and is built
-// from a fixed template so it cannot fail to encode -- the rungs above embed client JSON verbatim and
-// can. It is returned even if it somehow still doesn't fit, because there is nothing further to drop;
-// callers enforcing a hard budget re-check the length.
+// The last rung holds only fixed-size markers (well under minDiagnosticArtifactBytes -- pinned by
+// TestFitPostProcessingArtifact_markerFloorFitsMinimumBudget) and cannot fail to encode: every
+// remaining field is an int or a bool, unlike the rungs above, which embed client JSON verbatim. It is
+// returned even if it somehow still doesn't fit, because there is nothing further to drop; callers
+// enforcing a hard budget re-check the length.
 func fitPostProcessingArtifact(trimmed json.RawMessage, indentedBytes, maxBytes int) []byte {
 	artifact := postProcessingArtifact{
 		Version:       postProcessingArtifactVersion,
@@ -1064,15 +1072,10 @@ func fitPostProcessingArtifact(trimmed json.RawMessage, indentedBytes, maxBytes 
 		artifact.Transformations = nil
 	}
 
-	return []byte(fmt.Sprintf(`{
-  "version": %d,
-  "truncated": true,
-  "originalBytes": %d,
-  "indentedBytes": %d,
-  "limitBytes": %d,
-  "framesOmitted": %t,
-  "transformationsOmitted": %t,
-  "displayOmitted": %t
-}`, postProcessingArtifactVersion, len(trimmed), indentedBytes, maxBytes,
-		artifact.FramesOmitted, artifact.TransformationsOmitted, artifact.DisplayOmitted))
+	// Markers only: both json.RawMessage fields are nil here (either cleared by the ladder above or
+	// never set, when the payload wasn't an object), leaving nothing but ints and bools -- so this
+	// encode cannot fail and the error is discarded rather than papered over with a literal template
+	// that would have to restate every field name and drift from the tags above.
+	out, _ := json.MarshalIndent(artifact, "", "  ")
+	return out
 }

--- a/pkg/services/diagnostics/diagnostics.go
+++ b/pkg/services/diagnostics/diagnostics.go
@@ -49,7 +49,7 @@ func NewBundler() *Bundler {
 //
 // Server logs are intentionally omitted because they are not scoped to this request and would leak
 // unrelated activity into a bundle meant for external sharing; they will be tackled in a follow-up.
-func (b *Bundler) Build(resp *backend.QueryDataResponse, harBuffer *harcapture.Buffer, panelJSON, dashboardJSON, queryRequestJSON json.RawMessage, queryRequestErr, queryErr error) ([]byte, error) {
+func (b *Bundler) Build(resp *backend.QueryDataResponse, harBuffer *harcapture.Buffer, panelJSON, dashboardJSON, queryRequestJSON, postProcessingJSON json.RawMessage, queryRequestErr, queryErr error) ([]byte, error) {
 	files := map[string][]byte{}
 
 	// queryRequestErr is the caller's failure to serialize the request into queryRequestJSON. Record it
@@ -75,6 +75,10 @@ func (b *Bundler) Build(resp *backend.QueryDataResponse, harBuffer *harcapture.B
 	}
 	if queryDataErr != nil {
 		files["querydata-error.txt"] = []byte(queryDataErr.Error() + "\n")
+	}
+
+	if fp := marshalPostProcessingArtifact(postProcessingJSON, maxQueryDataArtifactBytes); len(fp) > 0 {
+		files["frontend-processing.json"] = fp
 	}
 
 	har, err := collectHAR(resp, harBuffer)
@@ -298,6 +302,7 @@ type DashboardPanel struct {
 	Datasources     []string                   // datasource UIDs the panel references (for the manifest)
 	Resp            *backend.QueryDataResponse // query response, carries external plugins' __har__ frames
 	HARBuffer       *harcapture.Buffer         // in-process capture buffer for this panel's queries
+	PostProcessing  json.RawMessage            // client-captured frontend pipeline evidence (transform IO + display)
 	QueryErr        error                      // top-level error running the panel's queries, if any
 	Skipped         string                     // non-empty => panel was not executed (e.g. non-data panel)
 }
@@ -404,6 +409,10 @@ func (b *Bundler) BuildDashboard(dashboardJSON json.RawMessage, panels []Dashboa
 		// Joined with "; " rather than errors.Join's newline so the manifest keeps one readable line per
 		// panel instead of embedded \n escapes.
 		entry.QueryDataError = strings.Join(queryDataErrs, "; ")
+
+		if fp := marshalPostProcessingArtifact(p.PostProcessing, maxQueryDataArtifactBytes); len(fp) > 0 {
+			files[dir+"/frontend-processing.json"] = fp
+		}
 
 		// A single panel's capture that fails to serialize must not sink the whole multi-panel bundle:
 		// record it against this panel in the manifest and keep everything else (dashboard.json, the
@@ -829,4 +838,29 @@ func indentJSON(raw []byte) []byte {
 		return raw
 	}
 	return out.Bytes()
+}
+
+// marshalPostProcessingArtifact returns the frontend-processing.json bytes for the client-captured
+// pipeline evidence, or nil when the client sent nothing. The payload is embedded verbatim (pretty-
+// printed); if it exceeds maxBytes it is replaced with an explicit truncation marker so a large
+// transform result cannot bloat the archive without a visible signal. Transient peak serialization
+// memory is not yet strictly bounded (same limitation as querydata.json).
+func marshalPostProcessingArtifact(raw json.RawMessage, maxBytes int) []byte {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || string(trimmed) == "null" {
+		return nil
+	}
+	pretty := indentJSON(raw)
+	if len(pretty) <= maxBytes {
+		return pretty
+	}
+	marker, err := json.MarshalIndent(struct {
+		Truncated     bool `json:"truncated"`
+		OriginalBytes int  `json:"originalBytes"`
+		LimitBytes    int  `json:"limitBytes"`
+	}{Truncated: true, OriginalBytes: len(pretty), LimitBytes: maxBytes}, "", "  ")
+	if err != nil {
+		return nil
+	}
+	return marker
 }

--- a/pkg/services/diagnostics/diagnostics.go
+++ b/pkg/services/diagnostics/diagnostics.go
@@ -1,6 +1,8 @@
 // Package diagnostics assembles on-demand datasource diagnostic bundles: captured HTTP traffic
-// (HAR), QueryData request/results, and the panel/dashboard JSON. The HTTP handler in pkg/api runs
-// the queries with capture active and delegates bundle assembly here.
+// (HAR), QueryData request/results, the panel/dashboard JSON, and the client-captured frontend
+// pipeline evidence (transformation input/output frames + applied display context, which only exist
+// in the browser). The HTTP handler in pkg/api runs the queries with capture active and delegates
+// bundle assembly here.
 package diagnostics
 
 import (
@@ -29,9 +31,22 @@ type Bundler struct{}
 const (
 	maxQueryDataArtifactBytes  = 8 << 20
 	maxDashboardQueryDataBytes = 32 << 20
-	// minQueryDataArtifactBytes is the smallest budget worth attempting: below it not even a truncated
-	// artifact (version + omission markers) fits, so the panel's query data is skipped up front.
-	minQueryDataArtifactBytes = 256
+	// maxDashboardPostProcessingBytes bounds the TOTAL frontend-processing.json across a whole-dashboard
+	// bundle, the way maxDashboardQueryDataBytes does for querydata.json -- without it a per-panel cap
+	// alone lets an N-panel dashboard contribute N * maxQueryDataArtifactBytes, all resident at once
+	// while the archive is assembled. It matters more here than for query data: this payload is
+	// client-supplied and the request body is not yet capped (see the MVP NOTE in pkg/api).
+	//
+	// Budgeted separately rather than drawn from the query-data pool because the two artifacts answer
+	// different questions and a reader usually needs both: sharing one pool would let a data-heavy
+	// dashboard consume it on query data (written first) and silently leave every panel's transform
+	// evidence out, which is exactly the evidence this artifact exists to provide.
+	maxDashboardPostProcessingBytes = 32 << 20
+	// minDiagnosticArtifactBytes is the smallest budget worth attempting for a size-bounded artifact:
+	// below it not even a truncated form (version + omission markers) fits, so the panel's artifact is
+	// skipped up front. Shared by querydata.json and frontend-processing.json, whose marker-only
+	// fallbacks are both well under it.
+	minDiagnosticArtifactBytes = 256
 )
 
 // queryDataArtifactVersion is the schema version stamped into every querydata.json (including its
@@ -43,21 +58,44 @@ func NewBundler() *Bundler {
 	return &Bundler{}
 }
 
-// Build assembles a .tar.gz bundle from the query response, the captured HAR buffer, and the
-// optional panel/dashboard JSON the client supplied. traffic.har is omitted when nothing was
-// captured.
+// BuildInput is the caller-supplied content for a single-panel bundle. Every field is optional: the
+// bundle holds whatever was supplied and omits the rest.
+//
+// A struct rather than positional parameters because most fields are mutually assignable
+// (json.RawMessage, error), so a transposed argument would silently produce a wrong bundle -- the
+// panel JSON filed as the frontend evidence, say -- with nothing for the compiler to catch.
+type BuildInput struct {
+	Resp      *backend.QueryDataResponse // query response, carries external plugins' __har__ frames
+	HARBuffer *harcapture.Buffer         // in-process capture buffer for this request's queries
+
+	PanelJSON        json.RawMessage
+	DashboardJSON    json.RawMessage
+	QueryRequestJSON json.RawMessage // MetricRequest submitted for this request
+	PostProcessing   json.RawMessage // client-captured frontend pipeline evidence (transform IO + display)
+
+	// QueryRequestErr is the caller's failure to serialize the request into QueryRequestJSON. Kept
+	// separate from QueryErr so it can be recorded rather than silently omitting the request JSON.
+	QueryRequestErr error
+	QueryErr        error // top-level error running the queries, if any
+}
+
+// Build assembles a .tar.gz bundle from the query response, the captured HAR buffer, and the optional
+// panel/dashboard JSON and frontend pipeline evidence the client supplied. traffic.har is omitted
+// when nothing was captured.
 //
 // Server logs are intentionally omitted because they are not scoped to this request and would leak
 // unrelated activity into a bundle meant for external sharing; they will be tackled in a follow-up.
-func (b *Bundler) Build(resp *backend.QueryDataResponse, harBuffer *harcapture.Buffer, panelJSON, dashboardJSON, queryRequestJSON, postProcessingJSON json.RawMessage, queryRequestErr, queryErr error) ([]byte, error) {
+func (b *Bundler) Build(in BuildInput) ([]byte, error) {
+	resp, harBuffer := in.Resp, in.HARBuffer
+	queryRequestJSON := in.QueryRequestJSON
 	files := map[string][]byte{}
 
 	// queryRequestErr is the caller's failure to serialize the request into queryRequestJSON. Record it
 	// so a support engineer can tell the request JSON was omitted because serialization failed rather
 	// than silently dropped, mirroring how the per-panel dashboard path records manifest.queryDataError.
 	var queryDataErr error
-	if queryRequestErr != nil {
-		queryDataErr = fmt.Errorf("serialize query request: %w", queryRequestErr)
+	if in.QueryRequestErr != nil {
+		queryDataErr = fmt.Errorf("serialize query request: %w", in.QueryRequestErr)
 	}
 	if resp != nil || len(queryRequestJSON) > 0 {
 		queryData, err := marshalQueryDataArtifact(queryRequestJSON, resp)
@@ -77,7 +115,9 @@ func (b *Bundler) Build(resp *backend.QueryDataResponse, harBuffer *harcapture.B
 		files["querydata-error.txt"] = []byte(queryDataErr.Error() + "\n")
 	}
 
-	if fp := marshalPostProcessingArtifact(postProcessingJSON, maxQueryDataArtifactBytes); len(fp) > 0 {
+	// No dashboard-wide budget applies on the single-panel path: there is exactly one artifact, so the
+	// per-artifact cap is the whole bound.
+	if fp, _ := marshalPostProcessingArtifact(in.PostProcessing, maxQueryDataArtifactBytes); len(fp) > 0 {
 		files["frontend-processing.json"] = fp
 	}
 
@@ -89,17 +129,17 @@ func (b *Bundler) Build(resp *backend.QueryDataResponse, harBuffer *harcapture.B
 		files["traffic.har"] = har
 	}
 
-	if len(panelJSON) > 0 {
-		files["panel.json"] = indentJSON(panelJSON)
+	if len(in.PanelJSON) > 0 {
+		files["panel.json"] = indentJSON(in.PanelJSON)
 	}
-	if len(dashboardJSON) > 0 {
-		files["dashboard.json"] = indentJSON(dashboardJSON)
+	if len(in.DashboardJSON) > 0 {
+		files["dashboard.json"] = indentJSON(in.DashboardJSON)
 	}
 
-	if queryErr != nil {
+	if in.QueryErr != nil {
 		// Recorded verbatim -- redaction is intentionally deferred for this experimental feature
 		// (see the harcapture package doc); the error text can embed a request URL with credentials.
-		files["query-error.txt"] = []byte(queryErr.Error() + "\n")
+		files["query-error.txt"] = []byte(in.QueryErr.Error() + "\n")
 	}
 
 	return buildTarGz(files)
@@ -325,8 +365,14 @@ type manifestPanelEntry struct {
 	QueryDataBytes     int      `json:"queryDataBytes,omitempty"`
 	QueryDataTruncated bool     `json:"queryDataTruncated,omitempty"`
 	QueryDataError     string   `json:"queryDataError,omitempty"`
-	Skipped            string   `json:"skipped,omitempty"`
-	Error              string   `json:"error,omitempty"`
+	// PostProcessing* mirror the QueryData* trio for frontend-processing.json, so a reader can see
+	// which panels carry frontend pipeline evidence -- and which had it truncated or dropped -- from
+	// manifest.json alone, without unpacking every panel directory.
+	PostProcessingBytes     int    `json:"postProcessingBytes,omitempty"`
+	PostProcessingTruncated bool   `json:"postProcessingTruncated,omitempty"`
+	PostProcessingError     string `json:"postProcessingError,omitempty"`
+	Skipped                 string `json:"skipped,omitempty"`
+	Error                   string `json:"error,omitempty"`
 	// CaptureError records a failure to serialize this panel's captured traffic. It's kept separate
 	// from Error (a query failure) so one unserializable buffer only loses this panel's traffic.har,
 	// not the whole multi-panel bundle.
@@ -334,7 +380,8 @@ type manifestPanelEntry struct {
 }
 
 // BuildDashboard assembles a whole-dashboard .tar.gz: a shared dashboard.json and manifest.json plus
-// per-panel panels/<id>-<slug>/{panel.json, querydata.json, traffic.har, query-error.txt}.
+// per-panel panels/<id>-<slug>/{panel.json, querydata.json, frontend-processing.json, traffic.har,
+// query-error.txt}.
 //
 // Like Build, captured traffic and error text are recorded VERBATIM -- redaction is intentionally
 // deferred (see the harcapture package doc) -- and server logs are omitted (not request-scoped).
@@ -351,12 +398,20 @@ func (b *Bundler) BuildDashboard(dashboardJSON json.RawMessage, panels []Dashboa
 
 	usedDirs := map[string]bool{}
 	queryDataBytesRemaining := maxDashboardQueryDataBytes
+	postProcessingBytesRemaining := maxDashboardPostProcessingBytes
 	panelJSONByID := indexPanelJSON(dashboardJSON)
 	for _, p := range panels {
 		entry := manifestPanelEntry{ID: p.ID, Title: p.Title, Datasources: p.Datasources}
 
 		if p.Skipped != "" {
 			entry.Skipped = p.Skipped
+			// A skipped panel gets no directory, so there is nowhere to write its artifacts. A non-data
+			// panel has no query results and therefore no transform pipeline, so the client should not be
+			// sending evidence for one -- but if it does, say so in the manifest rather than discarding it
+			// without a trace.
+			if hasPostProcessing(p.PostProcessing) {
+				entry.PostProcessingError = "frontend pipeline evidence discarded: panel was not executed"
+			}
 			manifest.Panels = append(manifest.Panels, entry)
 			continue
 		}
@@ -382,9 +437,9 @@ func (b *Bundler) BuildDashboard(dashboardJSON json.RawMessage, panels []Dashboa
 		}
 		if p.Resp != nil || len(p.QueryRequest) > 0 {
 			queryDataLimit := min(maxQueryDataArtifactBytes, queryDataBytesRemaining)
-			if queryDataLimit < minQueryDataArtifactBytes {
+			if queryDataLimit < minDiagnosticArtifactBytes {
 				entry.QueryDataTruncated = true
-				queryDataErrs = append(queryDataErrs, fmt.Sprintf("remaining dashboard query-data budget (%d bytes) below the %d-byte minimum artifact size", queryDataBytesRemaining, minQueryDataArtifactBytes))
+				queryDataErrs = append(queryDataErrs, fmt.Sprintf("remaining dashboard query-data budget (%d bytes) below the %d-byte minimum artifact size", queryDataBytesRemaining, minDiagnosticArtifactBytes))
 			} else {
 				queryData, truncated, err := marshalQueryDataArtifactWithLimit(p.QueryRequest, p.Resp, queryDataLimit)
 				if err != nil {
@@ -410,8 +465,33 @@ func (b *Bundler) BuildDashboard(dashboardJSON json.RawMessage, panels []Dashboa
 		// panel instead of embedded \n escapes.
 		entry.QueryDataError = strings.Join(queryDataErrs, "; ")
 
-		if fp := marshalPostProcessingArtifact(p.PostProcessing, maxQueryDataArtifactBytes); len(fp) > 0 {
-			files[dir+"/frontend-processing.json"] = fp
+		// frontend-processing.json draws on its own dashboard-wide pool (see
+		// maxDashboardPostProcessingBytes) so a large payload on early panels cannot leave later panels
+		// with nothing, and N panels cannot multiply the per-panel cap into the whole archive.
+		if hasPostProcessing(p.PostProcessing) {
+			ppLimit := min(maxQueryDataArtifactBytes, postProcessingBytesRemaining)
+			switch {
+			case ppLimit < minDiagnosticArtifactBytes:
+				entry.PostProcessingTruncated = true
+				entry.PostProcessingError = fmt.Sprintf("remaining dashboard post-processing budget (%d bytes) below the %d-byte minimum artifact size", postProcessingBytesRemaining, minDiagnosticArtifactBytes)
+			default:
+				fp, truncated := marshalPostProcessingArtifact(p.PostProcessing, ppLimit)
+				switch {
+				case len(fp) == 0:
+					// Nothing encodable survived; there is no partial form left to write.
+					entry.PostProcessingError = "frontend pipeline evidence could not be encoded"
+				case len(fp) > ppLimit:
+					// The marker-only rung is returned even when it doesn't fit, because there is nothing
+					// further to drop -- so enforce the budget here rather than blowing past it.
+					entry.PostProcessingTruncated = true
+					entry.PostProcessingError = "frontend-processing artifact exceeded its assigned dashboard budget"
+				default:
+					files[dir+"/frontend-processing.json"] = fp
+					entry.PostProcessingBytes = len(fp)
+					entry.PostProcessingTruncated = truncated
+					postProcessingBytesRemaining -= len(fp)
+				}
+			}
 		}
 
 		// A single panel's capture that fails to serialize must not sink the whole multi-panel bundle:
@@ -840,27 +920,123 @@ func indentJSON(raw []byte) []byte {
 	return out.Bytes()
 }
 
-// marshalPostProcessingArtifact returns the frontend-processing.json bytes for the client-captured
-// pipeline evidence, or nil when the client sent nothing. The payload is embedded verbatim (pretty-
-// printed); if it exceeds maxBytes it is replaced with an explicit truncation marker so a large
-// transform result cannot bloat the archive without a visible signal. Transient peak serialization
-// memory is not yet strictly bounded (same limitation as querydata.json).
-func marshalPostProcessingArtifact(raw json.RawMessage, maxBytes int) []byte {
+// postProcessingArtifactVersion is the schema version stamped into the DEGRADED forms of
+// frontend-processing.json. An untruncated artifact is the client's own document embedded verbatim and
+// is versioned (if at all) by the client, so only the fallbacks below carry this stamp -- which is
+// also how a reader distinguishes a Grafana-generated fallback from a client payload that happens to
+// have a "truncated" key of its own.
+const postProcessingArtifactVersion = 1
+
+// postProcessingArtifact is the degraded form of frontend-processing.json. The frames (input/output)
+// are what make the payload large, while the transformation config and display context are small and
+// are the fields that let a reader decide "wrong transform config" vs "bad datasource data" -- so they
+// are kept verbatim as long as they fit.
+type postProcessingArtifact struct {
+	Version         int             `json:"version"`
+	Transformations json.RawMessage `json:"transformations,omitempty"`
+	Display         json.RawMessage `json:"display,omitempty"`
+	Truncated       bool            `json:"truncated"`
+	// OriginalBytes is the payload as received; IndentedBytes is its pretty-printed size, which is what
+	// LimitBytes was compared against. Both are reported because they differ -- a client that already
+	// pretty-prints can even shrink under re-indentation -- so a reader checking the artifact against
+	// the request body would otherwise be comparing against the wrong number.
+	OriginalBytes int  `json:"originalBytes"`
+	IndentedBytes int  `json:"indentedBytes"`
+	LimitBytes    int  `json:"limitBytes"`
+	FramesOmitted bool `json:"framesOmitted,omitempty"`
+	// TransformationsOmitted/DisplayOmitted record that even the small fields had to be dropped, so a
+	// reader can tell "the client never sent it" from "it didn't fit".
+	TransformationsOmitted bool `json:"transformationsOmitted,omitempty"`
+	DisplayOmitted         bool `json:"displayOmitted,omitempty"`
+}
+
+// jsonNullLiteral is compared against with bytes.Equal rather than string(payload) == "null", which
+// would copy the whole (potentially multi-megabyte) payload just to reject four bytes.
+var jsonNullLiteral = []byte("null")
+
+// hasPostProcessing reports whether the client actually sent frontend pipeline evidence. Shared with
+// marshalPostProcessingArtifact so BuildDashboard's budget gate agrees with it on what "nothing" is
+// and doesn't record a budget failure against a panel that sent no evidence at all.
+func hasPostProcessing(raw json.RawMessage) bool {
 	trimmed := bytes.TrimSpace(raw)
-	if len(trimmed) == 0 || string(trimmed) == "null" {
-		return nil
+	return len(trimmed) > 0 && !bytes.Equal(trimmed, jsonNullLiteral)
+}
+
+// marshalPostProcessingArtifact returns the frontend-processing.json bytes for the client-captured
+// pipeline evidence plus whether content had to be dropped to fit maxBytes, or (nil, false) when the
+// client sent nothing. The payload is embedded verbatim (pretty-printed) when it fits; when it does
+// not, it degrades through fitPostProcessingArtifact rather than vanishing behind a bare marker.
+//
+// Transient peak serialization memory is not yet strictly bounded (same limitation as querydata.json).
+func marshalPostProcessingArtifact(raw json.RawMessage, maxBytes int) ([]byte, bool) {
+	if !hasPostProcessing(raw) {
+		return nil, false
 	}
-	pretty := indentJSON(raw)
+	trimmed := bytes.TrimSpace(raw)
+	pretty := indentJSON(trimmed)
 	if len(pretty) <= maxBytes {
-		return pretty
+		return pretty, false
 	}
-	marker, err := json.MarshalIndent(struct {
-		Truncated     bool `json:"truncated"`
-		OriginalBytes int  `json:"originalBytes"`
-		LimitBytes    int  `json:"limitBytes"`
-	}{Truncated: true, OriginalBytes: len(pretty), LimitBytes: maxBytes}, "", "  ")
-	if err != nil {
-		return nil
+	return fitPostProcessingArtifact(trimmed, len(pretty), maxBytes), true
+}
+
+// fitPostProcessingArtifact encodes progressively less of the payload -- frames dropped, then display,
+// then the transformation config -- and returns the first encoding within maxBytes.
+//
+// The frames go first because they are the bulk, and the transformation config goes last because it is
+// the field that localizes a transform bug: dropping everything the moment the frames don't fit would
+// lose the cheap, high-signal evidence in exactly the data-heavy cases this artifact exists to
+// explain, the same reasoning marshalQueryDataArtifactWithLimit applies to the submitted query.
+//
+// The last rung holds only fixed-size markers (well under minDiagnosticArtifactBytes) and is built
+// from a fixed template so it cannot fail to encode -- the rungs above embed client JSON verbatim and
+// can. It is returned even if it somehow still doesn't fit, because there is nothing further to drop;
+// callers enforcing a hard budget re-check the length.
+func fitPostProcessingArtifact(trimmed json.RawMessage, indentedBytes, maxBytes int) []byte {
+	artifact := postProcessingArtifact{
+		Version:       postProcessingArtifactVersion,
+		Truncated:     true,
+		OriginalBytes: len(trimmed),
+		IndentedBytes: indentedBytes,
+		LimitBytes:    maxBytes,
+		FramesOmitted: true,
 	}
-	return marker
+
+	// Only a JSON object can carry the fields worth keeping; any other shape (array, string, number)
+	// has no separable small part, so it goes straight to markers.
+	var fields struct {
+		Transformations json.RawMessage `json:"transformations"`
+		Display         json.RawMessage `json:"display"`
+	}
+	if err := json.Unmarshal(trimmed, &fields); err == nil {
+		artifact.Transformations = fields.Transformations
+		artifact.Display = fields.Display
+		if out, err := json.MarshalIndent(artifact, "", "  "); err == nil && len(out) <= maxBytes {
+			return out
+		}
+
+		// Display is dropped before the transformation config: a panel's field config and overrides can
+		// themselves be sizeable, while the transform list is the more direct answer to "did a frontend
+		// transform do this?".
+		artifact.Display = nil
+		artifact.DisplayOmitted = len(fields.Display) > 0
+		if out, err := json.MarshalIndent(artifact, "", "  "); err == nil && len(out) <= maxBytes {
+			return out
+		}
+
+		artifact.Transformations = nil
+		artifact.TransformationsOmitted = len(fields.Transformations) > 0
+	}
+
+	return []byte(fmt.Sprintf(`{
+  "version": %d,
+  "truncated": true,
+  "originalBytes": %d,
+  "indentedBytes": %d,
+  "limitBytes": %d,
+  "framesOmitted": true,
+  "transformationsOmitted": %t,
+  "displayOmitted": %t
+}`, postProcessingArtifactVersion, len(trimmed), indentedBytes, maxBytes,
+		artifact.TransformationsOmitted, artifact.DisplayOmitted))
 }

--- a/pkg/services/diagnostics/diagnostics_postprocessing_test.go
+++ b/pkg/services/diagnostics/diagnostics_postprocessing_test.go
@@ -173,15 +173,38 @@ func TestMarshalPostProcessingArtifact_omissionFlagsReflectWhatWasSent(t *testin
 
 // TestFitPostProcessingArtifact_markerFloorFitsMinimumBudget pins the assumption BuildDashboard's
 // budget gate rests on: the marker-only floor stays under minDiagnosticArtifactBytes. The byte counts
-// are interpolated, so the widest possible values are what has to fit -- a floor that outgrew the gate
-// would make a near-exhausted panel trip the "exceeded its assigned budget" path and lose everything.
+// are rendered into it, so the widest possible values are what has to fit -- a floor that outgrew the
+// gate would make a near-exhausted panel trip the "exceeded its assigned budget" path and lose
+// everything.
+//
+// Both extremes are covered because they are mutually exclusive and each grows a different part of the
+// floor: the byte counts are widest when the budget is enormous, which is also when no omission flag is
+// set (the ladder's first rung fits and the floor is never reached), while the flags are all set only
+// when the budget is too small to hold them -- and they are omitempty, so their keys appear only then.
 func TestFitPostProcessingArtifact_markerFloorFitsMinimumBudget(t *testing.T) {
-	floor := fitPostProcessingArtifact(json.RawMessage(`[]`), math.MaxInt, math.MaxInt)
-	require.Less(t, len(floor), minDiagnosticArtifactBytes)
+	t.Run("widest byte counts", func(t *testing.T) {
+		floor := fitPostProcessingArtifact(json.RawMessage(`[]`), math.MaxInt, math.MaxInt)
+		require.Less(t, len(floor), minDiagnosticArtifactBytes)
 
-	var bare postProcessingArtifact
-	require.NoError(t, json.Unmarshal(floor, &bare), "the floor is valid JSON even at extreme sizes")
-	require.True(t, bare.Truncated)
+		var bare postProcessingArtifact
+		require.NoError(t, json.Unmarshal(floor, &bare), "the floor is valid JSON even at extreme sizes")
+		require.True(t, bare.Truncated)
+	})
+
+	t.Run("every omission flag set", func(t *testing.T) {
+		// Content in all three droppable fields, and a budget below even the transform config, so the
+		// ladder runs out and every flag key is present alongside a realistically wide payload size.
+		payload := json.RawMessage(`{"transformations":[{"id":"` + strings.Repeat("t", 4096) + `"}],` +
+			`"display":{"pluginId":"stat"},"input":[{"a":1}],"output":[{"b":2}]}`)
+		floor := fitPostProcessingArtifact(payload, math.MaxInt32, 64)
+		require.Less(t, len(floor), minDiagnosticArtifactBytes)
+
+		var bare postProcessingArtifact
+		require.NoError(t, json.Unmarshal(floor, &bare))
+		require.True(t, bare.FramesOmitted)
+		require.True(t, bare.TransformationsOmitted)
+		require.True(t, bare.DisplayOmitted)
+	})
 }
 
 // ---- whole-dashboard path -----------------------------------------------------------------------

--- a/pkg/services/diagnostics/diagnostics_postprocessing_test.go
+++ b/pkg/services/diagnostics/diagnostics_postprocessing_test.go
@@ -3,6 +3,7 @@ package diagnostics
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"strings"
 	"testing"
 
@@ -43,8 +44,15 @@ func TestBundler_Build_recordsFrontendProcessing(t *testing.T) {
 	require.NotContains(t, body, `"truncated"`, "an artifact that fits carries no truncation markers")
 }
 
+// TestBundler_Build_omitsEmptyFrontendProcessing covers the shapes a client sends when it captured
+// nothing. An empty container is as much "no evidence" as an absent field -- shipping a 2-byte `{}`
+// artifact tells a reader the capture ran and found nothing, which is the opposite of the truth.
 func TestBundler_Build_omitsEmptyFrontendProcessing(t *testing.T) {
-	for _, raw := range []json.RawMessage{nil, json.RawMessage(""), json.RawMessage("  "), json.RawMessage("null")} {
+	empty := []json.RawMessage{
+		nil, json.RawMessage(""), json.RawMessage("  "), json.RawMessage("null"),
+		json.RawMessage("{}"), json.RawMessage("[]"), json.RawMessage(`""`), json.RawMessage(" {} "),
+	}
+	for _, raw := range empty {
 		blob, err := NewBundler().Build(BuildInput{HARBuffer: &harcapture.Buffer{}, PanelJSON: json.RawMessage(`{"id":1}`), PostProcessing: raw})
 		require.NoError(t, err)
 		files := readTarGz(t, blob)
@@ -129,7 +137,51 @@ func TestMarshalPostProcessingArtifact_nonObjectPayload(t *testing.T) {
 	require.True(t, artifact.Truncated)
 	require.Empty(t, artifact.Transformations)
 	require.False(t, artifact.TransformationsOmitted, "nothing was sent to omit")
+	require.False(t, artifact.FramesOmitted, "an unparseable shape carried no identifiable frames to omit")
 	require.NotContains(t, string(out), strings.Repeat("x", 100))
+}
+
+// TestMarshalPostProcessingArtifact_omissionFlagsReflectWhatWasSent pins the distinction the flags
+// exist to draw: they mean "this didn't fit", not "this isn't here". A payload whose bulk sits outside
+// input/output must not claim the frames were dropped, and a field the client sent as null or empty
+// must not be reported as omitted -- either way a reader goes hunting for evidence that never existed.
+func TestMarshalPostProcessingArtifact_omissionFlagsReflectWhatWasSent(t *testing.T) {
+	// Bulk in an unrelated field, no frames and no display sent at all.
+	noFrames := json.RawMessage(`{"transformations":[{"id":"reduce"}],"somethingElse":"` + strings.Repeat("x", 3000) + `"}`)
+	out, truncated := marshalPostProcessingArtifact(noFrames, 300)
+	require.True(t, truncated)
+
+	var artifact postProcessingArtifact
+	require.NoError(t, json.Unmarshal(out, &artifact))
+	require.False(t, artifact.FramesOmitted, "the payload carried no frames, so none were omitted")
+	require.False(t, artifact.DisplayOmitted, "no display context was sent")
+
+	// Empty/null fields beside real frames: the frames are genuinely dropped, the empty ones are not
+	// "omitted" and are not embedded either.
+	emptyFields := json.RawMessage(`{"transformations":[{"id":"reduce"}],"display":null,` +
+		`"output":[{"schema":{"name":"out"},"data":{"values":[["` + strings.Repeat("x", 3000) + `"]]}}]}`)
+	out, truncated = marshalPostProcessingArtifact(emptyFields, 400)
+	require.True(t, truncated)
+	require.NotContains(t, string(out), `"display"`, "a null display context is not embedded as evidence")
+
+	artifact = postProcessingArtifact{}
+	require.NoError(t, json.Unmarshal(out, &artifact))
+	require.True(t, artifact.FramesOmitted, "output frames were present and dropped")
+	require.False(t, artifact.DisplayOmitted, "a null display context was never sent, so it wasn't omitted")
+	require.NotEmpty(t, artifact.Transformations)
+}
+
+// TestFitPostProcessingArtifact_markerFloorFitsMinimumBudget pins the assumption BuildDashboard's
+// budget gate rests on: the marker-only floor stays under minDiagnosticArtifactBytes. The byte counts
+// are interpolated, so the widest possible values are what has to fit -- a floor that outgrew the gate
+// would make a near-exhausted panel trip the "exceeded its assigned budget" path and lose everything.
+func TestFitPostProcessingArtifact_markerFloorFitsMinimumBudget(t *testing.T) {
+	floor := fitPostProcessingArtifact(json.RawMessage(`[]`), math.MaxInt, math.MaxInt)
+	require.Less(t, len(floor), minDiagnosticArtifactBytes)
+
+	var bare postProcessingArtifact
+	require.NoError(t, json.Unmarshal(floor, &bare), "the floor is valid JSON even at extreme sizes")
+	require.True(t, bare.Truncated)
 }
 
 // ---- whole-dashboard path -----------------------------------------------------------------------
@@ -166,7 +218,7 @@ func TestBundler_BuildDashboard_boundsTotalFrontendProcessing(t *testing.T) {
 	// the total and the test would pass without exercising the budget at all.
 	const panelCount = 12
 	const frameBytes = maxDashboardPostProcessingBytes / 8
-	require.Less(t, frameBytes, maxQueryDataArtifactBytes, "each panel must fit its own cap")
+	require.Less(t, frameBytes, maxPostProcessingArtifactBytes, "each panel must fit its own cap")
 	require.Greater(t, panelCount*frameBytes, maxDashboardPostProcessingBytes, "together they must overrun the pool")
 
 	panels := make([]DashboardPanel, 0, panelCount)
@@ -213,7 +265,7 @@ func TestBundler_BuildDashboard_boundsTotalFrontendProcessing(t *testing.T) {
 // the dashboard-wide pool: one enormous panel degrades on its own, without consuming the whole pool.
 func TestBundler_BuildDashboard_perPanelCapStillApplies(t *testing.T) {
 	blob, err := NewBundler().BuildDashboard(nil, []DashboardPanel{
-		{ID: 1, Title: "huge", PostProcessing: postProcessingPayload(t, maxQueryDataArtifactBytes+1024)},
+		{ID: 1, Title: "huge", PostProcessing: postProcessingPayload(t, maxPostProcessingArtifactBytes+1024)},
 		{ID: 2, Title: "small", PostProcessing: json.RawMessage(`{"transformations":[{"id":"reduce"}]}`)},
 	})
 	require.NoError(t, err)
@@ -221,7 +273,7 @@ func TestBundler_BuildDashboard_perPanelCapStillApplies(t *testing.T) {
 	files := readTarGz(t, blob)
 	byID := manifestPanelsByID(t, files)
 	require.True(t, byID[1].PostProcessingTruncated, "the oversized panel is truncated by the per-panel cap")
-	require.LessOrEqual(t, byID[1].PostProcessingBytes, maxQueryDataArtifactBytes)
+	require.LessOrEqual(t, byID[1].PostProcessingBytes, maxPostProcessingArtifactBytes)
 	require.Contains(t, string(files["panels/1-huge/frontend-processing.json"]), `"reduce"`,
 		"the truncated artifact still carries the transformation config")
 
@@ -248,6 +300,19 @@ func TestBundler_BuildDashboard_recordsDiscardedPostProcessingForSkippedPanel(t 
 	byID := manifestPanelsByID(t, files)
 	require.Contains(t, byID[1].PostProcessingError, "discarded")
 	require.Empty(t, byID[2].PostProcessingError, "a skipped panel that sent nothing records nothing")
+}
+
+// TestBundler_BuildDashboard_skippedPanelWithEmptyPostProcessing is the flip side: a client that posts
+// an empty capture for every panel (the likely shape for a row or text panel) must not have each one
+// reported as evidence Grafana threw away.
+func TestBundler_BuildDashboard_skippedPanelWithEmptyPostProcessing(t *testing.T) {
+	blob, err := NewBundler().BuildDashboard(nil, []DashboardPanel{
+		{ID: 1, Title: "Row", Skipped: "no queries (non-data panel)", PostProcessing: json.RawMessage(`{}`)},
+	})
+	require.NoError(t, err)
+
+	byID := manifestPanelsByID(t, readTarGz(t, blob))
+	require.Empty(t, byID[1].PostProcessingError, "an empty capture is not discarded evidence")
 }
 
 // manifestPanelsByID decodes manifest.json and indexes its panel entries by id.

--- a/pkg/services/diagnostics/diagnostics_postprocessing_test.go
+++ b/pkg/services/diagnostics/diagnostics_postprocessing_test.go
@@ -1,0 +1,60 @@
+package diagnostics
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/infra/httpclient/harcapture"
+)
+
+func TestBundler_Build_recordsFrontendProcessing(t *testing.T) {
+	pp := json.RawMessage(`{"transformations":[{"id":"reduce","options":{}}],` +
+		`"input":[{"schema":{"name":"in"}}],"output":[{"schema":{"name":"out"}}],` +
+		`"display":{"pluginId":"timeseries"}}`)
+
+	blob, err := NewBundler().Build(nil, &harcapture.Buffer{}, nil, nil, nil, pp, nil, nil)
+	require.NoError(t, err)
+
+	files := readTarGz(t, blob)
+	require.Contains(t, files, "frontend-processing.json")
+	body := string(files["frontend-processing.json"])
+	require.Contains(t, body, `"transformations"`)
+	require.Contains(t, body, `"reduce"`)
+	require.Contains(t, body, `"input"`)
+	require.Contains(t, body, `"output"`)
+	require.Contains(t, body, `"timeseries"`)
+}
+
+func TestBundler_Build_omitsEmptyFrontendProcessing(t *testing.T) {
+	for _, raw := range []json.RawMessage{nil, json.RawMessage(""), json.RawMessage("  "), json.RawMessage("null")} {
+		blob, err := NewBundler().Build(nil, &harcapture.Buffer{}, json.RawMessage(`{"id":1}`), nil, nil, raw, nil, nil)
+		require.NoError(t, err)
+		files := readTarGz(t, blob)
+		require.NotContains(t, files, "frontend-processing.json",
+			"no artifact when the client sent no post-processing evidence (%q)", string(raw))
+	}
+}
+
+func TestMarshalPostProcessingArtifact_truncatesOverBudget(t *testing.T) {
+	big := make([]byte, 0, 4096)
+	big = append(big, []byte(`{"output":[{"schema":{"name":"`)...)
+	big = append(big, []byte(strings.Repeat("x", 2000))...)
+	big = append(big, []byte(`"}}]}`)...)
+
+	out := marshalPostProcessingArtifact(json.RawMessage(big), 512)
+	require.NotEmpty(t, out)
+
+	var marker struct {
+		Truncated     bool `json:"truncated"`
+		OriginalBytes int  `json:"originalBytes"`
+		LimitBytes    int  `json:"limitBytes"`
+	}
+	require.NoError(t, json.Unmarshal(out, &marker))
+	require.True(t, marker.Truncated)
+	require.Equal(t, 512, marker.LimitBytes)
+	require.Greater(t, marker.OriginalBytes, 512)
+	require.NotContains(t, string(out), strings.Repeat("x", 100), "the oversized payload itself is not embedded")
+}

--- a/pkg/services/diagnostics/diagnostics_postprocessing_test.go
+++ b/pkg/services/diagnostics/diagnostics_postprocessing_test.go
@@ -2,6 +2,7 @@ package diagnostics
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -10,12 +11,25 @@ import (
 	"github.com/grafana/grafana/pkg/infra/httpclient/harcapture"
 )
 
+// postProcessingPayload builds a plausible frontend pipeline capture: a small transformation config
+// and display context beside frames of the requested size, which is the shape the size ladder in
+// fitPostProcessingArtifact is built around.
+func postProcessingPayload(t *testing.T, frameBytes int) json.RawMessage {
+	t.Helper()
+	return json.RawMessage(fmt.Sprintf(
+		`{"transformations":[{"id":"reduce","options":{"reducers":["mean"]}}],`+
+			`"input":[{"schema":{"name":"in"},"data":{"values":[["%s"]]}}],`+
+			`"output":[{"schema":{"name":"out"}}],`+
+			`"display":{"pluginId":"timeseries"}}`,
+		strings.Repeat("x", frameBytes)))
+}
+
 func TestBundler_Build_recordsFrontendProcessing(t *testing.T) {
 	pp := json.RawMessage(`{"transformations":[{"id":"reduce","options":{}}],` +
 		`"input":[{"schema":{"name":"in"}}],"output":[{"schema":{"name":"out"}}],` +
 		`"display":{"pluginId":"timeseries"}}`)
 
-	blob, err := NewBundler().Build(nil, &harcapture.Buffer{}, nil, nil, nil, pp, nil, nil)
+	blob, err := NewBundler().Build(BuildInput{HARBuffer: &harcapture.Buffer{}, PostProcessing: pp})
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -26,11 +40,12 @@ func TestBundler_Build_recordsFrontendProcessing(t *testing.T) {
 	require.Contains(t, body, `"input"`)
 	require.Contains(t, body, `"output"`)
 	require.Contains(t, body, `"timeseries"`)
+	require.NotContains(t, body, `"truncated"`, "an artifact that fits carries no truncation markers")
 }
 
 func TestBundler_Build_omitsEmptyFrontendProcessing(t *testing.T) {
 	for _, raw := range []json.RawMessage{nil, json.RawMessage(""), json.RawMessage("  "), json.RawMessage("null")} {
-		blob, err := NewBundler().Build(nil, &harcapture.Buffer{}, json.RawMessage(`{"id":1}`), nil, nil, raw, nil, nil)
+		blob, err := NewBundler().Build(BuildInput{HARBuffer: &harcapture.Buffer{}, PanelJSON: json.RawMessage(`{"id":1}`), PostProcessing: raw})
 		require.NoError(t, err)
 		files := readTarGz(t, blob)
 		require.NotContains(t, files, "frontend-processing.json",
@@ -38,23 +53,212 @@ func TestBundler_Build_omitsEmptyFrontendProcessing(t *testing.T) {
 	}
 }
 
-func TestMarshalPostProcessingArtifact_truncatesOverBudget(t *testing.T) {
-	big := make([]byte, 0, 4096)
-	big = append(big, []byte(`{"output":[{"schema":{"name":"`)...)
-	big = append(big, []byte(strings.Repeat("x", 2000))...)
-	big = append(big, []byte(`"}}]}`)...)
+// TestMarshalPostProcessingArtifact_keepsTransformConfigWhenFramesDropped is the core of the size
+// ladder: the frames are the bulk, but the transformation config and display context are what let a
+// reader decide "wrong frontend transform" vs "bad datasource data", so an over-budget payload must
+// not degrade to a bare marker that answers neither.
+func TestMarshalPostProcessingArtifact_keepsTransformConfigWhenFramesDropped(t *testing.T) {
+	pp := postProcessingPayload(t, 4096)
 
-	out := marshalPostProcessingArtifact(json.RawMessage(big), 512)
+	out, truncated := marshalPostProcessingArtifact(pp, 1024)
+	require.True(t, truncated)
 	require.NotEmpty(t, out)
+	require.LessOrEqual(t, len(out), 1024)
 
-	var marker struct {
-		Truncated     bool `json:"truncated"`
-		OriginalBytes int  `json:"originalBytes"`
-		LimitBytes    int  `json:"limitBytes"`
+	var artifact postProcessingArtifact
+	require.NoError(t, json.Unmarshal(out, &artifact), "the degraded artifact is valid JSON")
+	require.Equal(t, postProcessingArtifactVersion, artifact.Version)
+	require.True(t, artifact.Truncated)
+	require.True(t, artifact.FramesOmitted)
+	require.JSONEq(t, `[{"id":"reduce","options":{"reducers":["mean"]}}]`, string(artifact.Transformations),
+		"the transformation config survives verbatim")
+	require.JSONEq(t, `{"pluginId":"timeseries"}`, string(artifact.Display), "the display context survives verbatim")
+	require.False(t, artifact.TransformationsOmitted)
+	require.False(t, artifact.DisplayOmitted)
+
+	require.NotContains(t, string(out), strings.Repeat("x", 100), "the oversized frames are not embedded")
+	require.Equal(t, 1024, artifact.LimitBytes)
+	require.Equal(t, len(pp), artifact.OriginalBytes, "originalBytes is the payload as received")
+	require.Greater(t, artifact.IndentedBytes, 1024, "indentedBytes is what the limit was compared against")
+}
+
+// TestMarshalPostProcessingArtifact_dropsSmallFieldsWhenBudgetTiny walks the remaining rungs: display
+// goes before the transformation config, and the marker-only floor is still valid JSON.
+func TestMarshalPostProcessingArtifact_dropsSmallFieldsWhenBudgetTiny(t *testing.T) {
+	pp := json.RawMessage(`{"transformations":[{"id":"reduce","options":{"reducers":["mean","max","min"]}}],` +
+		`"input":[{"data":"` + strings.Repeat("x", 2000) + `"}],` +
+		`"display":{"pluginId":"timeseries","fieldConfig":{"overrides":[{"matcher":{"id":"byName"}}]}}}`)
+
+	// Enough room for the transformation config alone, but not alongside the display context.
+	out, truncated := marshalPostProcessingArtifact(pp, 400)
+	require.True(t, truncated)
+	require.LessOrEqual(t, len(out), 400)
+
+	var artifact postProcessingArtifact
+	require.NoError(t, json.Unmarshal(out, &artifact))
+	require.NotEmpty(t, artifact.Transformations, "the transformation config is the last thing dropped")
+	require.Empty(t, artifact.Display)
+	require.True(t, artifact.DisplayOmitted, "a dropped display context is distinguishable from one never sent")
+
+	// Below the floor nothing but markers fits, and that floor must still parse.
+	floor, truncated := marshalPostProcessingArtifact(pp, 200)
+	require.True(t, truncated)
+	require.NotEmpty(t, floor)
+	var bare postProcessingArtifact
+	require.NoError(t, json.Unmarshal(floor, &bare), "the marker-only floor is valid JSON")
+	require.Equal(t, postProcessingArtifactVersion, bare.Version)
+	require.True(t, bare.Truncated)
+	require.True(t, bare.FramesOmitted)
+	require.True(t, bare.TransformationsOmitted)
+	require.True(t, bare.DisplayOmitted)
+	require.Empty(t, bare.Transformations)
+	require.Less(t, len(floor), minDiagnosticArtifactBytes,
+		"the floor stays under the minimum-budget gate, so that gate remains meaningful")
+}
+
+// TestMarshalPostProcessingArtifact_nonObjectPayload guards the ladder against a payload that isn't a
+// JSON object: there is no separable small part, so it must fall to markers rather than error out.
+func TestMarshalPostProcessingArtifact_nonObjectPayload(t *testing.T) {
+	pp := json.RawMessage(`["` + strings.Repeat("x", 2000) + `"]`)
+
+	out, truncated := marshalPostProcessingArtifact(pp, 512)
+	require.True(t, truncated)
+
+	var artifact postProcessingArtifact
+	require.NoError(t, json.Unmarshal(out, &artifact))
+	require.True(t, artifact.Truncated)
+	require.Empty(t, artifact.Transformations)
+	require.False(t, artifact.TransformationsOmitted, "nothing was sent to omit")
+	require.NotContains(t, string(out), strings.Repeat("x", 100))
+}
+
+// ---- whole-dashboard path -----------------------------------------------------------------------
+
+func TestBundler_BuildDashboard_recordsFrontendProcessingPerPanel(t *testing.T) {
+	blob, err := NewBundler().BuildDashboard(nil, []DashboardPanel{
+		{ID: 1, Title: "CPU", PostProcessing: json.RawMessage(`{"transformations":[{"id":"reduce"}]}`)},
+		{ID: 2, Title: "Memory", PostProcessing: json.RawMessage(`{"display":{"pluginId":"stat"}}`)},
+		{ID: 3, Title: "No evidence"},
+	})
+	require.NoError(t, err)
+
+	files := readTarGz(t, blob)
+	require.Contains(t, files, "panels/1-cpu/frontend-processing.json")
+	require.Contains(t, files, "panels/2-memory/frontend-processing.json")
+	require.NotContains(t, files, "panels/3-no-evidence/frontend-processing.json",
+		"a panel whose client sent no evidence gets no artifact")
+	require.Contains(t, string(files["panels/1-cpu/frontend-processing.json"]), `"reduce"`)
+	require.Contains(t, string(files["panels/2-memory/frontend-processing.json"]), `"stat"`)
+
+	byID := manifestPanelsByID(t, files)
+	require.Positive(t, byID[1].PostProcessingBytes, "the manifest records the artifact size")
+	require.False(t, byID[1].PostProcessingTruncated)
+	require.Empty(t, byID[1].PostProcessingError)
+	require.Zero(t, byID[3].PostProcessingBytes, "a panel with no evidence records no bytes")
+}
+
+// TestBundler_BuildDashboard_boundsTotalFrontendProcessing is the reason the dashboard-wide budget
+// exists: a per-panel cap alone lets N panels multiply into the whole archive, since every panel's
+// artifact is held in memory at once while the tarball is assembled.
+func TestBundler_BuildDashboard_boundsTotalFrontendProcessing(t *testing.T) {
+	// Sized to stay under the per-panel cap (so panel 1 is written in full) while 12 of them together
+	// overrun the dashboard-wide pool -- otherwise the per-panel cap, not the pool, would be what bounds
+	// the total and the test would pass without exercising the budget at all.
+	const panelCount = 12
+	const frameBytes = maxDashboardPostProcessingBytes / 8
+	require.Less(t, frameBytes, maxQueryDataArtifactBytes, "each panel must fit its own cap")
+	require.Greater(t, panelCount*frameBytes, maxDashboardPostProcessingBytes, "together they must overrun the pool")
+
+	panels := make([]DashboardPanel, 0, panelCount)
+	for i := range panelCount {
+		panels = append(panels, DashboardPanel{
+			ID:             int64(i + 1),
+			Title:          fmt.Sprintf("panel %d", i+1),
+			PostProcessing: postProcessingPayload(t, frameBytes),
+		})
 	}
-	require.NoError(t, json.Unmarshal(out, &marker))
-	require.True(t, marker.Truncated)
-	require.Equal(t, 512, marker.LimitBytes)
-	require.Greater(t, marker.OriginalBytes, 512)
-	require.NotContains(t, string(out), strings.Repeat("x", 100), "the oversized payload itself is not embedded")
+
+	blob, err := NewBundler().BuildDashboard(nil, panels)
+	require.NoError(t, err)
+
+	files := readTarGz(t, blob)
+	total := 0
+	for name, body := range files {
+		if strings.HasSuffix(name, "/frontend-processing.json") {
+			total += len(body)
+		}
+	}
+	require.LessOrEqual(t, total, maxDashboardPostProcessingBytes,
+		"the total across panels stays within the dashboard-wide budget")
+
+	// The panels that ran out of budget must say so rather than silently shipping nothing, and the
+	// early panels must still carry their full evidence.
+	byID := manifestPanelsByID(t, files)
+	require.Positive(t, byID[1].PostProcessingBytes, "the first panel fits and is written in full")
+	require.False(t, byID[1].PostProcessingTruncated)
+
+	degraded := 0
+	for _, entry := range byID {
+		if entry.PostProcessingTruncated || entry.PostProcessingError != "" {
+			degraded++
+		}
+	}
+	require.Positive(t, degraded, "panels past the budget are recorded as truncated or errored")
+
+	// Query data has its own pool, so exhausting the post-processing budget must not touch it.
+	require.Empty(t, byID[panelCount].QueryDataError)
+}
+
+// TestBundler_BuildDashboard_perPanelCapStillApplies checks the per-panel cap is enforced alongside
+// the dashboard-wide pool: one enormous panel degrades on its own, without consuming the whole pool.
+func TestBundler_BuildDashboard_perPanelCapStillApplies(t *testing.T) {
+	blob, err := NewBundler().BuildDashboard(nil, []DashboardPanel{
+		{ID: 1, Title: "huge", PostProcessing: postProcessingPayload(t, maxQueryDataArtifactBytes+1024)},
+		{ID: 2, Title: "small", PostProcessing: json.RawMessage(`{"transformations":[{"id":"reduce"}]}`)},
+	})
+	require.NoError(t, err)
+
+	files := readTarGz(t, blob)
+	byID := manifestPanelsByID(t, files)
+	require.True(t, byID[1].PostProcessingTruncated, "the oversized panel is truncated by the per-panel cap")
+	require.LessOrEqual(t, byID[1].PostProcessingBytes, maxQueryDataArtifactBytes)
+	require.Contains(t, string(files["panels/1-huge/frontend-processing.json"]), `"reduce"`,
+		"the truncated artifact still carries the transformation config")
+
+	require.False(t, byID[2].PostProcessingTruncated, "a later small panel is unaffected")
+	require.Contains(t, files, "panels/2-small/frontend-processing.json")
+}
+
+// TestBundler_BuildDashboard_recordsDiscardedPostProcessingForSkippedPanel pins the one case where
+// evidence is intentionally dropped: a skipped panel has no directory to write it to, so the loss
+// must at least be visible in the manifest.
+func TestBundler_BuildDashboard_recordsDiscardedPostProcessingForSkippedPanel(t *testing.T) {
+	blob, err := NewBundler().BuildDashboard(nil, []DashboardPanel{
+		{ID: 1, Title: "Text", Skipped: "no queries (non-data panel)",
+			PostProcessing: json.RawMessage(`{"display":{"pluginId":"text"}}`)},
+		{ID: 2, Title: "Row", Skipped: "no queries (non-data panel)"},
+	})
+	require.NoError(t, err)
+
+	files := readTarGz(t, blob)
+	for name := range files {
+		require.NotContains(t, name, "frontend-processing.json", "a skipped panel has no directory")
+	}
+
+	byID := manifestPanelsByID(t, files)
+	require.Contains(t, byID[1].PostProcessingError, "discarded")
+	require.Empty(t, byID[2].PostProcessingError, "a skipped panel that sent nothing records nothing")
+}
+
+// manifestPanelsByID decodes manifest.json and indexes its panel entries by id.
+func manifestPanelsByID(t *testing.T, files map[string][]byte) map[int64]manifestPanelEntry {
+	t.Helper()
+	require.Contains(t, files, "manifest.json")
+	var manifest dashboardManifest
+	require.NoError(t, json.Unmarshal(files["manifest.json"], &manifest))
+	byID := make(map[int64]manifestPanelEntry, len(manifest.Panels))
+	for _, entry := range manifest.Panels {
+		byID[entry.ID] = entry
+	}
+	return byID
 }

--- a/pkg/services/diagnostics/diagnostics_test.go
+++ b/pkg/services/diagnostics/diagnostics_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestBundler_Build(t *testing.T) {
 	// No HAR captured (empty buffer, nil response) -> traffic.har omitted; only panel.json present.
-	blob, err := NewBundler().Build(nil, &harcapture.Buffer{}, json.RawMessage(`{"id":1}`), nil, nil, nil, nil, nil)
+	blob, err := NewBundler().Build(BuildInput{HARBuffer: &harcapture.Buffer{}, PanelJSON: json.RawMessage(`{"id":1}`)})
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -37,7 +37,7 @@ func TestBundler_Build(t *testing.T) {
 
 func TestBundler_Build_recordsQueryError(t *testing.T) {
 	// A failed query must still produce a bundle, with the error recorded (capture is not discarded).
-	blob, err := NewBundler().Build(nil, &harcapture.Buffer{}, nil, nil, nil, nil, nil, errors.New("datasource timeout"))
+	blob, err := NewBundler().Build(BuildInput{HARBuffer: &harcapture.Buffer{}, QueryErr: errors.New("datasource timeout")})
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -51,7 +51,7 @@ func TestBundler_Build_recordsQueryDataMarshalError(t *testing.T) {
 	// error is recorded and the other artifacts still ship, mirroring the per-panel dashboard path.
 	buf := bufferWithEntry(t, "http://ds/1")
 
-	blob, err := NewBundler().Build(nil, buf, nil, nil, json.RawMessage(`{invalid`), nil, nil, nil)
+	blob, err := NewBundler().Build(BuildInput{HARBuffer: buf, QueryRequestJSON: json.RawMessage(`{invalid`)})
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -67,7 +67,7 @@ func TestBundler_Build_recordsQueryRequestSerializeError(t *testing.T) {
 	// mirroring how the per-panel dashboard path surfaces the same failure via manifest.queryDataError.
 	buf := bufferWithEntry(t, "http://ds/1")
 
-	blob, err := NewBundler().Build(nil, buf, nil, nil, nil, nil, errors.New("unsupported value: +Inf"), nil)
+	blob, err := NewBundler().Build(BuildInput{HARBuffer: buf, QueryRequestErr: errors.New("unsupported value: +Inf")})
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -84,7 +84,7 @@ func TestBundler_Build_recordsQueryDataResponse(t *testing.T) {
 		"A": {Frames: data.Frames{frame}},
 	}}
 
-	blob, err := NewBundler().Build(resp, &harcapture.Buffer{}, nil, nil, nil, nil, nil, nil)
+	blob, err := NewBundler().Build(BuildInput{Resp: resp, HARBuffer: &harcapture.Buffer{}})
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -96,7 +96,7 @@ func TestBundler_Build_recordsQueryDataResponse(t *testing.T) {
 func TestBundler_Build_recordsQueryDataRequest(t *testing.T) {
 	request := json.RawMessage(`{"from":"now-1h","to":"now","queries":[{"refId":"A","expr":"up"}]}`)
 
-	blob, err := NewBundler().Build(nil, &harcapture.Buffer{}, nil, nil, request, nil, nil, nil)
+	blob, err := NewBundler().Build(BuildInput{HARBuffer: &harcapture.Buffer{}, QueryRequestJSON: request})
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -114,7 +114,7 @@ func TestBundler_Build_excludesCaptureFramesFromQueryData(t *testing.T) {
 		"__har__ds": {Frames: data.Frames{capture}},
 	}}
 
-	blob, err := NewBundler().Build(resp, &harcapture.Buffer{}, nil, nil, nil, nil, nil, nil)
+	blob, err := NewBundler().Build(BuildInput{Resp: resp, HARBuffer: &harcapture.Buffer{}})
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -128,7 +128,7 @@ func TestBundler_Build_boundsOversizedQueryData(t *testing.T) {
 		"A": {Frames: data.Frames{frame}},
 	}}
 
-	blob, err := NewBundler().Build(resp, &harcapture.Buffer{}, nil, nil, nil, nil, nil, nil)
+	blob, err := NewBundler().Build(BuildInput{Resp: resp, HARBuffer: &harcapture.Buffer{}})
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -143,7 +143,7 @@ func TestBundler_Build_boundsOversizedRequestWithoutResponse(t *testing.T) {
 	// An oversized request with no response must truncate without claiming a response was omitted.
 	request := json.RawMessage(`{"expr":"` + strings.Repeat("x", maxQueryDataArtifactBytes) + `"}`)
 
-	blob, err := NewBundler().Build(nil, &harcapture.Buffer{}, nil, nil, request, nil, nil, nil)
+	blob, err := NewBundler().Build(BuildInput{HARBuffer: &harcapture.Buffer{}, QueryRequestJSON: request})
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -171,7 +171,7 @@ func TestBundler_Build_preservesUpstreamAndPluginResultsForComparison(t *testing
 	queryResp := &backend.QueryDataResponse{Responses: backend.Responses{
 		"A": {Frames: data.Frames{pluginFrame}},
 	}}
-	blob, err := NewBundler().Build(queryResp, buf, nil, nil, nil, nil, nil, nil)
+	blob, err := NewBundler().Build(BuildInput{Resp: queryResp, HARBuffer: buf})
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -308,7 +308,7 @@ func TestCollectHAR_nilBuffer_noPanic(t *testing.T) {
 	require.Nil(t, out)
 
 	// A nil buffer must also flow through Build without panicking.
-	bundle, err := NewBundler().Build(nil, nil, nil, nil, nil, nil, nil, nil)
+	bundle, err := NewBundler().Build(BuildInput{})
 	require.NoError(t, err)
 	require.NotNil(t, bundle)
 }
@@ -761,7 +761,7 @@ func TestBundler_Build_keepsRequestWhenResponseEncodingFails(t *testing.T) {
 	resp := &backend.QueryDataResponse{Responses: backend.Responses{"A": {Frames: data.Frames{frame}}}}
 	request := json.RawMessage(`{"queries":[{"refId":"A","expr":"up"}]}`)
 
-	blob, err := NewBundler().Build(resp, &harcapture.Buffer{}, nil, nil, request, nil, nil, nil)
+	blob, err := NewBundler().Build(BuildInput{Resp: resp, HARBuffer: &harcapture.Buffer{}, QueryRequestJSON: request})
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -800,7 +800,7 @@ func TestBuildDashboard_keepsRequestWhenResponseEncodingFails(t *testing.T) {
 }
 
 func TestMarshalQueryDataArtifactWithLimit_encodeFailureFitsMinimumBudget(t *testing.T) {
-	// The BuildDashboard budget gate assumes the smallest artifact fits in minQueryDataArtifactBytes.
+	// The BuildDashboard budget gate assumes the smallest artifact fits in minDiagnosticArtifactBytes.
 	// An encode failure adds responseError, which must not push the floor past that assumption --
 	// otherwise a panel reaching the gate with a near-exhausted budget loses everything again.
 	resp := &backend.QueryDataResponse{Responses: backend.Responses{
@@ -808,10 +808,10 @@ func TestMarshalQueryDataArtifactWithLimit_encodeFailureFitsMinimumBudget(t *tes
 	}}
 	request := json.RawMessage(`{"queries":[{"refId":"A","expr":"` + strings.Repeat("x", 4096) + `"}]}`)
 
-	out, _, err := marshalQueryDataArtifactWithLimit(request, resp, minQueryDataArtifactBytes)
+	out, _, err := marshalQueryDataArtifactWithLimit(request, resp, minDiagnosticArtifactBytes)
 	require.Error(t, err, "the response still fails to encode")
 	require.NotEmpty(t, out, "a floor artifact is produced rather than nothing")
-	require.LessOrEqual(t, len(out), minQueryDataArtifactBytes)
+	require.LessOrEqual(t, len(out), minDiagnosticArtifactBytes)
 
 	var artifact queryDataArtifact
 	require.NoError(t, json.Unmarshal(out, &artifact), "the floor artifact is valid JSON")

--- a/pkg/services/diagnostics/diagnostics_test.go
+++ b/pkg/services/diagnostics/diagnostics_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestBundler_Build(t *testing.T) {
 	// No HAR captured (empty buffer, nil response) -> traffic.har omitted; only panel.json present.
-	blob, err := NewBundler().Build(nil, &harcapture.Buffer{}, json.RawMessage(`{"id":1}`), nil, nil, nil, nil)
+	blob, err := NewBundler().Build(nil, &harcapture.Buffer{}, json.RawMessage(`{"id":1}`), nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -37,7 +37,7 @@ func TestBundler_Build(t *testing.T) {
 
 func TestBundler_Build_recordsQueryError(t *testing.T) {
 	// A failed query must still produce a bundle, with the error recorded (capture is not discarded).
-	blob, err := NewBundler().Build(nil, &harcapture.Buffer{}, nil, nil, nil, nil, errors.New("datasource timeout"))
+	blob, err := NewBundler().Build(nil, &harcapture.Buffer{}, nil, nil, nil, nil, nil, errors.New("datasource timeout"))
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -51,7 +51,7 @@ func TestBundler_Build_recordsQueryDataMarshalError(t *testing.T) {
 	// error is recorded and the other artifacts still ship, mirroring the per-panel dashboard path.
 	buf := bufferWithEntry(t, "http://ds/1")
 
-	blob, err := NewBundler().Build(nil, buf, nil, nil, json.RawMessage(`{invalid`), nil, nil)
+	blob, err := NewBundler().Build(nil, buf, nil, nil, json.RawMessage(`{invalid`), nil, nil, nil)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -67,7 +67,7 @@ func TestBundler_Build_recordsQueryRequestSerializeError(t *testing.T) {
 	// mirroring how the per-panel dashboard path surfaces the same failure via manifest.queryDataError.
 	buf := bufferWithEntry(t, "http://ds/1")
 
-	blob, err := NewBundler().Build(nil, buf, nil, nil, nil, errors.New("unsupported value: +Inf"), nil)
+	blob, err := NewBundler().Build(nil, buf, nil, nil, nil, nil, errors.New("unsupported value: +Inf"), nil)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -84,7 +84,7 @@ func TestBundler_Build_recordsQueryDataResponse(t *testing.T) {
 		"A": {Frames: data.Frames{frame}},
 	}}
 
-	blob, err := NewBundler().Build(resp, &harcapture.Buffer{}, nil, nil, nil, nil, nil)
+	blob, err := NewBundler().Build(resp, &harcapture.Buffer{}, nil, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -96,7 +96,7 @@ func TestBundler_Build_recordsQueryDataResponse(t *testing.T) {
 func TestBundler_Build_recordsQueryDataRequest(t *testing.T) {
 	request := json.RawMessage(`{"from":"now-1h","to":"now","queries":[{"refId":"A","expr":"up"}]}`)
 
-	blob, err := NewBundler().Build(nil, &harcapture.Buffer{}, nil, nil, request, nil, nil)
+	blob, err := NewBundler().Build(nil, &harcapture.Buffer{}, nil, nil, request, nil, nil, nil)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -114,7 +114,7 @@ func TestBundler_Build_excludesCaptureFramesFromQueryData(t *testing.T) {
 		"__har__ds": {Frames: data.Frames{capture}},
 	}}
 
-	blob, err := NewBundler().Build(resp, &harcapture.Buffer{}, nil, nil, nil, nil, nil)
+	blob, err := NewBundler().Build(resp, &harcapture.Buffer{}, nil, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -128,7 +128,7 @@ func TestBundler_Build_boundsOversizedQueryData(t *testing.T) {
 		"A": {Frames: data.Frames{frame}},
 	}}
 
-	blob, err := NewBundler().Build(resp, &harcapture.Buffer{}, nil, nil, nil, nil, nil)
+	blob, err := NewBundler().Build(resp, &harcapture.Buffer{}, nil, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -143,7 +143,7 @@ func TestBundler_Build_boundsOversizedRequestWithoutResponse(t *testing.T) {
 	// An oversized request with no response must truncate without claiming a response was omitted.
 	request := json.RawMessage(`{"expr":"` + strings.Repeat("x", maxQueryDataArtifactBytes) + `"}`)
 
-	blob, err := NewBundler().Build(nil, &harcapture.Buffer{}, nil, nil, request, nil, nil)
+	blob, err := NewBundler().Build(nil, &harcapture.Buffer{}, nil, nil, request, nil, nil, nil)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -171,7 +171,7 @@ func TestBundler_Build_preservesUpstreamAndPluginResultsForComparison(t *testing
 	queryResp := &backend.QueryDataResponse{Responses: backend.Responses{
 		"A": {Frames: data.Frames{pluginFrame}},
 	}}
-	blob, err := NewBundler().Build(queryResp, buf, nil, nil, nil, nil, nil)
+	blob, err := NewBundler().Build(queryResp, buf, nil, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -308,7 +308,7 @@ func TestCollectHAR_nilBuffer_noPanic(t *testing.T) {
 	require.Nil(t, out)
 
 	// A nil buffer must also flow through Build without panicking.
-	bundle, err := NewBundler().Build(nil, nil, nil, nil, nil, nil, nil)
+	bundle, err := NewBundler().Build(nil, nil, nil, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 	require.NotNil(t, bundle)
 }
@@ -761,7 +761,7 @@ func TestBundler_Build_keepsRequestWhenResponseEncodingFails(t *testing.T) {
 	resp := &backend.QueryDataResponse{Responses: backend.Responses{"A": {Frames: data.Frames{frame}}}}
 	request := json.RawMessage(`{"queries":[{"refId":"A","expr":"up"}]}`)
 
-	blob, err := NewBundler().Build(resp, &harcapture.Buffer{}, nil, nil, request, nil, nil)
+	blob, err := NewBundler().Build(resp, &harcapture.Buffer{}, nil, nil, request, nil, nil, nil)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)


### PR DESCRIPTION
Part of the on-premise enhanced diagnostics effort (grafana/data-sources#1268) — post-QueryData evidence (WMD2 / G11, backend half).

Accepts a client-supplied `postProcessing` field on the diagnostics request and embeds it in the bundle as `frontend-processing.json` (single-panel + per-panel dashboard, size-guarded). It carries, per panel, the frontend transformation config plus the frames going **into** the transform and coming **out**, and the applied display context — so a reviewer can localize wrong/missing data to a frontend transform vs the datasource.

Size guarding mirrors `querydata.json`: an 8 MiB per-artifact cap plus a 32 MiB dashboard-wide pool (its own, so a data-heavy dashboard can't starve the transform evidence), and an over-budget payload degrades — frames dropped, then display, then the transform config — rather than collapsing to a bare marker, since the transform config is the cheap, high-signal part. `manifest.json` records `postProcessingBytes` / `postProcessingTruncated` / `postProcessingError` per panel.

Backend half of the transform-capture feature (the drawer-side `collectPostProcessing()` capture is a separate follow-up PR).

Experimental, behind `grafana.onDemandDiagnostics` (off by default), on-prem only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
