### PR TITLE
Datasources: Add offline data-baked snapshot (snapshot-backend.json) to diagnostics bundles

### DIFF
--- a/pkg/services/diagnostics/diagnostics.go
+++ b/pkg/services/diagnostics/diagnostics.go
@@ -34,6 +34,11 @@ const (
 	minQueryDataArtifactBytes = 256
 )
 
+// grafanaSnapshotDatasourceRef mirrors the frontend's GRAFANA_DATASOURCE_REF: the built-in Grafana
+// datasource that serves baked snapshot frames offline. A snapshot panel points here so it renders
+// with no live datasource and no query re-run.
+var grafanaSnapshotDatasourceRef = map[string]any{"type": "grafana", "uid": "grafana", "name": "grafana"}
+
 // queryDataArtifactVersion is the schema version stamped into every querydata.json (including its
 // truncated fallbacks) so a reader can tell how to interpret the artifact.
 const queryDataArtifactVersion = 1
@@ -75,6 +80,13 @@ func (b *Bundler) Build(resp *backend.QueryDataResponse, harBuffer *harcapture.B
 	}
 	if queryDataErr != nil {
 		files["querydata-error.txt"] = []byte(queryDataErr.Error() + "\n")
+	}
+
+	// snapshot-backend.json: an importable, data-baked dashboard that renders the plugin's returned
+	// frames offline (no datasource). A convenience artifact -- on failure or when it would exceed the
+	// per-panel budget it is simply omitted; querydata.json remains the authoritative record.
+	if snapshot, err := marshalSnapshotBackendArtifact(panelJSON, resp); err == nil && len(snapshot) > 0 && len(snapshot) <= maxQueryDataArtifactBytes {
+		files["snapshot-backend.json"] = snapshot
 	}
 
 	har, err := collectHAR(resp, harBuffer)
@@ -320,12 +332,91 @@ type manifestPanelEntry struct {
 	QueryDataBytes     int      `json:"queryDataBytes,omitempty"`
 	QueryDataTruncated bool     `json:"queryDataTruncated,omitempty"`
 	QueryDataError     string   `json:"queryDataError,omitempty"`
+	SnapshotBytes      int      `json:"snapshotBytes,omitempty"`
+	SnapshotError      string   `json:"snapshotError,omitempty"`
 	Skipped            string   `json:"skipped,omitempty"`
 	Error              string   `json:"error,omitempty"`
 	// CaptureError records a failure to serialize this panel's captured traffic. It's kept separate
 	// from Error (a query failure) so one unserializable buffer only loses this panel's traffic.har,
 	// not the whole multi-panel bundle.
 	CaptureError string `json:"captureError,omitempty"`
+}
+
+// marshalSnapshotBackendArtifact builds an importable, data-baked dashboard from the backend
+// QueryDataResponse. It reuses Grafana's snapshot format -- each refID becomes a Grafana-datasource
+// target with queryType "snapshot" carrying the response frames verbatim (the same DataFrameJSON
+// querydata.json records) -- so the dashboard renders OFFLINE, with no live datasource and no query
+// re-run: the "what did the plugin return" view a support engineer can open and see. panelJSON, when
+// present, supplies the panel's visualization + field config so the render matches the real panel;
+// its own datasource/targets are replaced so the imported panel can never re-query.
+//
+// Returns nil (no artifact) when there is no response or no frames to bake.
+func marshalSnapshotBackendArtifact(panelJSON json.RawMessage, resp *backend.QueryDataResponse) ([]byte, error) {
+	if resp == nil {
+		return nil, nil
+	}
+	respJSON, err := queryDataResponseWithoutCaptureFrames(resp).MarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	var parsed struct {
+		Results map[string]struct {
+			Frames []json.RawMessage `json:"frames"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal(respJSON, &parsed); err != nil {
+		return nil, err
+	}
+
+	// Deterministic refID order so the artifact (and its tests) are stable.
+	refIDs := make([]string, 0, len(parsed.Results))
+	for refID := range parsed.Results {
+		refIDs = append(refIDs, refID)
+	}
+	sort.Strings(refIDs)
+
+	targets := make([]map[string]any, 0, len(refIDs))
+	frameCount := 0
+	for _, refID := range refIDs {
+		frames := parsed.Results[refID].Frames
+		frameCount += len(frames)
+		targets = append(targets, map[string]any{
+			"refId":      refID,
+			"datasource": grafanaSnapshotDatasourceRef,
+			"queryType":  "snapshot",
+			"snapshot":   frames,
+		})
+	}
+	if frameCount == 0 {
+		return nil, nil
+	}
+
+	panel := map[string]any{}
+	if len(panelJSON) > 0 {
+		// A malformed panel model shouldn't lose the snapshot; fall back to a minimal panel.
+		if err := json.Unmarshal(panelJSON, &panel); err != nil {
+			panel = map[string]any{}
+		}
+	}
+	if _, ok := panel["type"]; !ok {
+		panel["type"] = "timeseries"
+	}
+	if _, ok := panel["title"]; !ok {
+		panel["title"] = "Diagnostics snapshot (backend / plugin output)"
+	}
+	panel["id"] = 1
+	panel["gridPos"] = map[string]any{"h": 12, "w": 24, "x": 0, "y": 0}
+	panel["datasource"] = grafanaSnapshotDatasourceRef
+	panel["targets"] = targets
+	delete(panel, "snapshotData")
+
+	dashboard := map[string]any{
+		"schemaVersion": 41,
+		"title":         "Diagnostics snapshot (backend / plugin output)",
+		"editable":      true,
+		"panels":        []any{panel},
+	}
+	return json.MarshalIndent(dashboard, "", "  ")
 }
 
 // BuildDashboard assembles a whole-dashboard .tar.gz: a shared dashboard.json and manifest.json plus
@@ -346,6 +437,7 @@ func (b *Bundler) BuildDashboard(dashboardJSON json.RawMessage, panels []Dashboa
 
 	usedDirs := map[string]bool{}
 	queryDataBytesRemaining := maxDashboardQueryDataBytes
+	snapshotBytesRemaining := maxDashboardQueryDataBytes
 	panelJSONByID := indexPanelJSON(dashboardJSON)
 	for _, p := range panels {
 		entry := manifestPanelEntry{ID: p.ID, Title: p.Title, Datasources: p.Datasources}
@@ -404,6 +496,23 @@ func (b *Bundler) BuildDashboard(dashboardJSON json.RawMessage, panels []Dashboa
 		// Joined with "; " rather than errors.Join's newline so the manifest keeps one readable line per
 		// panel instead of embedded \n escapes.
 		entry.QueryDataError = strings.Join(queryDataErrs, "; ")
+
+		// snapshot-backend.json: importable, data-baked view of this panel's returned frames (renders
+		// offline). Convenience artifact, bounded by a shared dashboard budget; omitted on failure or
+		// when it would exceed the remaining budget (querydata.json remains the authoritative record).
+		if p.Resp != nil {
+			if snapshot, err := marshalSnapshotBackendArtifact(panelJSON, p.Resp); err != nil {
+				entry.SnapshotError = err.Error()
+			} else if len(snapshot) > 0 {
+				if len(snapshot) <= min(maxQueryDataArtifactBytes, snapshotBytesRemaining) {
+					files[dir+"/snapshot-backend.json"] = snapshot
+					entry.SnapshotBytes = len(snapshot)
+					snapshotBytesRemaining -= len(snapshot)
+				} else {
+					entry.SnapshotError = "snapshot-backend artifact exceeded its assigned dashboard budget"
+				}
+			}
+		}
 
 		// A single panel's capture that fails to serialize must not sink the whole multi-panel bundle:
 		// record it against this panel in the manifest and keep everything else (dashboard.json, the

--- a/pkg/services/diagnostics/diagnostics.go
+++ b/pkg/services/diagnostics/diagnostics.go
@@ -403,6 +403,12 @@ const snapshotArtifactTitle = "Diagnostics snapshot (backend / plugin output)"
 // supplies the panel's visualization + field config so the render matches the real panel; its own
 // datasource/targets are replaced so the imported panel can never re-query.
 //
+// This is the EXPLORABLE copy of the pipeline: the frames are frozen at the plugin's output, but the
+// panel's transformations ride along so a reader can re-run and tweak them against real data (see
+// snapshotPanel). Its frozen counterpart, snapshot-rendered.json, bakes post-transform frames with the
+// transforms stripped -- what the user actually saw -- and a divergence between the two is a finding
+// in its own right.
+//
 // queryRequestJSON supplies the submitted time range, which is baked into the dashboard: an import
 // with no time range defaults to now-6h, so a bundle read a day later would render an empty panel
 // with the frames sitting outside the window.
@@ -530,10 +536,21 @@ func snapshotPanel(panelJSON json.RawMessage) map[string]any {
 	// A library-panel reference would make the import resolve the panel from a library uid that doesn't
 	// exist in the reader's Grafana, discarding the baked targets along with the panel model.
 	delete(panel, "libraryPanel")
-	// The baked frames are the plugin's output, BEFORE frontend processing. Applying the panel's
-	// transformations on top would render something that is neither the backend response this artifact
-	// records nor the panel's real output; the post-transform view is snapshot-rendered.json's job.
-	delete(panel, "transformations")
+	// Transformations are deliberately KEPT. This is the explorable copy of the pipeline: the frames are
+	// the plugin's output and the panel's transform config sits on top, so a reader can import it, toggle
+	// or edit a transform, and watch the result move -- the dashboard is editable, so stripping them
+	// would be the lossy, irreversible choice (they cannot be added back from the artifact alone,
+	// whereas removing them in the imported panel is two clicks).
+	//
+	// The frozen "what the user saw" view is snapshot-rendered.json's job: it bakes post-transform
+	// frames with the transforms stripped. That split is what makes a divergence between the two
+	// meaningful -- transform replay here vs. what the customer's browser actually produced -- and
+	// stripping transforms here would destroy the signal instead, since the two would then differ
+	// whenever the panel has any transform at all.
+	//
+	// Safe alongside the single-target merge below: frames carry the refId they came from (stamped in
+	// snapshotFrames), so refId-addressed transforms such as filterByRefId and seriesToColumns still
+	// resolve.
 	// The baked dashboard time range is the range the queries actually ran over, and the client reads
 	// it from the PANEL's effective range -- so a relative override has already been resolved into the
 	// absolute timestamps baked below. Leaving the override on the panel applies it a SECOND time: a
@@ -571,10 +588,17 @@ func v2ElementSpec(raw json.RawMessage) json.RawMessage {
 }
 
 // v1PanelFromV2Spec translates the parts of a v2 panel spec that a v1 snapshot dashboard can render:
-// the viz plugin and its options/fieldConfig, plus the panel's identity. Queries are dropped because
-// the snapshot replaces them, and so is anything whose v1 equivalent has a different shape (v2
-// transformations are {kind, spec}, not {id, options}) -- copying the spec wholesale would emit a
-// hybrid object and carry the original datasource refs into an artifact that must not re-query.
+// the viz plugin and its options/fieldConfig, the panel's transformations, and its identity. Queries
+// are dropped because the snapshot replaces them; the spec is translated field by field rather than
+// copied wholesale, which would emit a hybrid v1/v2 object and carry the original datasource refs into
+// an artifact that must not re-query.
+//
+// Transformations come across so the v2 path is as explorable as the v1 one -- a snapshot that kept the
+// pipeline for v1 dashboards and silently dropped it for v2 would make the artifact mean different
+// things depending on the source dashboard's version. Only the v2 WRAPPER differs: a v2
+// TransformationKind is {kind, spec} where kind repeats the transformation id and spec is already a
+// complete v1 DataTransformerConfig ({id, options, disabled, filter, topic}), so lifting each spec is
+// the whole translation.
 //
 // A v2 LibraryPanel element reaches here too (indexPanelJSON indexes both kinds), and its spec is only
 // {id, title, libraryPanel} -- the viz lives in the library, not the dashboard. The whitelist is what
@@ -587,7 +611,14 @@ func v1PanelFromV2Spec(spec json.RawMessage) map[string]any {
 		Title       string `json:"title"`
 		Description string `json:"description"`
 		Transparent bool   `json:"transparent"`
-		VizConfig   struct {
+		Data        struct {
+			Spec struct {
+				Transformations []struct {
+					Spec json.RawMessage `json:"spec"`
+				} `json:"transformations"`
+			} `json:"spec"`
+		} `json:"data"`
+		VizConfig struct {
 			Kind    string `json:"kind"`
 			Group   string `json:"group"`
 			Version string `json:"version"`
@@ -628,6 +659,17 @@ func v1PanelFromV2Spec(spec json.RawMessage) map[string]any {
 	}
 	if len(v2.VizConfig.Spec.FieldConfig) > 0 {
 		panel["fieldConfig"] = v2.VizConfig.Spec.FieldConfig
+	}
+	// Each entry's spec is already a v1 DataTransformerConfig, so it is carried verbatim; the {kind,
+	// spec} wrapper around it is what stays behind.
+	var transformations []json.RawMessage
+	for _, t := range v2.Data.Spec.Transformations {
+		if len(t.Spec) > 0 {
+			transformations = append(transformations, t.Spec)
+		}
+	}
+	if len(transformations) > 0 {
+		panel["transformations"] = transformations
 	}
 	return panel
 }

--- a/pkg/services/diagnostics/diagnostics.go
+++ b/pkg/services/diagnostics/diagnostics.go
@@ -45,13 +45,27 @@ const (
 	maxDashboardQueryDataBytes = 32 << 20
 	// minQueryDataArtifactBytes is the smallest budget worth attempting: below it not even a truncated
 	// artifact (version + omission markers) fits, so the panel's query data is skipped up front.
+	//
+	// The snapshot gate in BuildDashboard reuses it as a floor even though the snapshot has no
+	// truncated form and its own minimum (schemaVersion + title + an empty panel + target) is nearer
+	// 600 bytes. Deliberately loose: the gate exists to avoid re-encoding a whole response once per
+	// remaining panel with no budget left, and a too-low floor only costs one encode that is then
+	// measured and reported as over-budget -- whereas a floor tuned to the empty-snapshot size would
+	// have to track every change to the dashboard scaffold to stay correct.
 	minQueryDataArtifactBytes = 256
 )
 
-// grafanaSnapshotDatasourceRef mirrors the frontend's GRAFANA_DATASOURCE_REF: the built-in Grafana
-// datasource that serves baked snapshot frames offline. A snapshot panel points here so it renders
-// with no live datasource and no query re-run.
-var grafanaSnapshotDatasourceRef = map[string]any{"type": "grafana", "uid": "grafana", "name": "grafana"}
+// grafanaSnapshotDatasourceRef returns the built-in Grafana datasource ref that serves baked snapshot
+// frames offline: a snapshot panel points here so it renders with no live datasource and no query
+// re-run. "grafana" is the built-in plugin's id, so it is the ref's type as well as its uid -- the
+// same ref HelpWizard's debug dashboard uses for its snapshot targets (see
+// public/app/features/dashboard-scene/inspect/HelpWizard/utils.ts).
+//
+// A fresh map per call: the result is embedded in both the panel and its target, and a shared
+// package-level map would alias the two (and be mutable from anywhere in the package).
+func grafanaSnapshotDatasourceRef() map[string]any {
+	return map[string]any{"type": "grafana", "uid": "grafana", "name": "grafana"}
+}
 
 // queryDataArtifactVersion is the schema version stamped into every querydata.json (including its
 // truncated fallbacks) so a reader can tell how to interpret the artifact.
@@ -99,14 +113,24 @@ func (b *Bundler) Build(resp *backend.QueryDataResponse, harBuffer *harcapture.B
 	// snapshot-backend.json: an importable, data-baked dashboard that renders the plugin's returned
 	// frames offline (no datasource). A convenience artifact -- querydata.json remains the authoritative
 	// record -- so a failure or an over-budget artifact costs only the snapshot. Why it went missing is
-	// recorded in snapshot-error.txt, mirroring how the dashboard path records manifest.snapshotError:
-	// omitting it silently leaves a reader unable to tell a failure from a response with no frames.
+	// recorded in snapshot-backend-error.txt, mirroring how the dashboard path records
+	// manifest.snapshotBackendError: omitting it silently leaves a reader unable to tell a failure from
+	// a response with no frames.
+	//
+	// Named for the artifact rather than "snapshot" generically, because the rendered (post-transform)
+	// counterpart lands as snapshot-rendered.json and needs a failure record of its own.
+	//
+	// Encoded in full before it is measured: like querydata.json above (see the note on its allocation
+	// cost) an oversized response is built and then discarded, and the snapshot's frame slice plus the
+	// indented dashboard around it are a second and third copy on top of that peak. Acceptable while
+	// this is experimental, server-admin-only, and off by default; a streaming size check would be the
+	// fix if it ever ships more widely.
 	snapshot, snapshotErr := marshalSnapshotBackendArtifact(panelJSON, queryRequestJSON, resp)
 	switch {
 	case snapshotErr != nil:
-		files["snapshot-error.txt"] = []byte(snapshotErr.Error() + "\n")
+		files["snapshot-backend-error.txt"] = []byte(snapshotErr.Error() + "\n")
 	case len(snapshot) > maxQueryDataArtifactBytes:
-		files["snapshot-error.txt"] = []byte(fmt.Sprintf("snapshot-backend artifact (%d bytes) exceeded the %d-byte limit\n", len(snapshot), maxQueryDataArtifactBytes))
+		files["snapshot-backend-error.txt"] = []byte(fmt.Sprintf("snapshot-backend artifact (%d bytes) exceeded the %d-byte limit\n", len(snapshot), maxQueryDataArtifactBytes))
 	case len(snapshot) > 0:
 		files["snapshot-backend.json"] = snapshot
 	}
@@ -354,10 +378,13 @@ type manifestPanelEntry struct {
 	QueryDataBytes     int      `json:"queryDataBytes,omitempty"`
 	QueryDataTruncated bool     `json:"queryDataTruncated,omitempty"`
 	QueryDataError     string   `json:"queryDataError,omitempty"`
-	SnapshotBytes      int      `json:"snapshotBytes,omitempty"`
-	SnapshotError      string   `json:"snapshotError,omitempty"`
-	Skipped            string   `json:"skipped,omitempty"`
-	Error              string   `json:"error,omitempty"`
+	// SnapshotBackendBytes/SnapshotBackendError are scoped to snapshot-backend.json rather than named
+	// "snapshot" generically: the rendered (post-transform) counterpart lands as snapshot-rendered.json
+	// and needs its own pair, and renaming these later would break readers of an artifact schema.
+	SnapshotBackendBytes int    `json:"snapshotBackendBytes,omitempty"`
+	SnapshotBackendError string `json:"snapshotBackendError,omitempty"`
+	Skipped              string `json:"skipped,omitempty"`
+	Error                string `json:"error,omitempty"`
 	// CaptureError records a failure to serialize this panel's captured traffic. It's kept separate
 	// from Error (a query failure) so one unserializable buffer only loses this panel's traffic.har,
 	// not the whole multi-panel bundle.
@@ -398,7 +425,7 @@ func marshalSnapshotBackendArtifact(panelJSON, queryRequestJSON json.RawMessage,
 	// Prometheus -- so sibling targets collapse onto the same key and all but one are dropped.
 	panel["targets"] = []map[string]any{{
 		"refId":      "A",
-		"datasource": grafanaSnapshotDatasourceRef,
+		"datasource": grafanaSnapshotDatasourceRef(),
 		"queryType":  "snapshot",
 		"snapshot":   frames,
 	}}
@@ -453,6 +480,29 @@ func snapshotFrames(resp *backend.QueryDataResponse) ([]json.RawMessage, error) 
 	return frames, nil
 }
 
+// hasSnapshotFrames reports whether resp holds at least one frame the snapshot could bake, without
+// encoding anything. A non-nil response is not the same as one with frames -- a panel whose queries
+// all failed carries per-refID errors and no frames, which is the common case in a diagnostics bundle
+// -- so BuildDashboard needs this to tell "nothing to bake" (not a failure, exactly as the
+// single-panel path treats it) from "the snapshot didn't fit" BEFORE its budget gate decides which of
+// the two to record.
+func hasSnapshotFrames(resp *backend.QueryDataResponse) bool {
+	if resp == nil {
+		return false
+	}
+	for refID, response := range resp.Responses {
+		if isHARResponse(refID) {
+			continue
+		}
+		for _, frame := range response.Frames {
+			if frame != nil {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // snapshotPanel builds the snapshot dashboard's single panel from the supplied panel model, keeping
 // only what a v1 dashboard can render offline. Callers set the targets.
 func snapshotPanel(panelJSON json.RawMessage) map[string]any {
@@ -475,7 +525,7 @@ func snapshotPanel(panelJSON json.RawMessage) map[string]any {
 	}
 	panel["id"] = 1
 	panel["gridPos"] = map[string]any{"h": 12, "w": 24, "x": 0, "y": 0}
-	panel["datasource"] = grafanaSnapshotDatasourceRef
+	panel["datasource"] = grafanaSnapshotDatasourceRef()
 	delete(panel, "snapshotData")
 	// A library-panel reference would make the import resolve the panel from a library uid that doesn't
 	// exist in the reader's Grafana, discarding the baked targets along with the panel model.
@@ -495,6 +545,16 @@ func snapshotPanel(panelJSON json.RawMessage) map[string]any {
 	delete(panel, "timeShift")
 	delete(panel, "timeCompare")
 	delete(panel, "hideTimeOverride")
+	// Repeat is meaningless here for the same reason: the snapshot dashboard carries no templating, and
+	// one panel's frames are all there is to render. It does not merely no-op -- the repeat processor
+	// substitutes an empty variable for the missing one and binds the panel's clone to the value ""
+	// (see DashboardGridItem.performRepeat), so "$host" in a title or description renders BLANK instead
+	// of showing which series was captured. Kept out so the panel reads as what it is: the one panel
+	// whose queries ran. A repeated panel is the common case here -- the client resolves a clone's save
+	// model back to the source panel, which is the one carrying these fields.
+	delete(panel, "repeat")
+	delete(panel, "repeatDirection")
+	delete(panel, "maxPerRow")
 	return panel
 }
 
@@ -515,6 +575,13 @@ func v2ElementSpec(raw json.RawMessage) json.RawMessage {
 // the snapshot replaces them, and so is anything whose v1 equivalent has a different shape (v2
 // transformations are {kind, spec}, not {id, options}) -- copying the spec wholesale would emit a
 // hybrid object and carry the original datasource refs into an artifact that must not re-query.
+//
+// A v2 LibraryPanel element reaches here too (indexPanelJSON indexes both kinds), and its spec is only
+// {id, title, libraryPanel} -- the viz lives in the library, not the dashboard. The whitelist is what
+// keeps the library ref out of the artifact, so nothing can resolve the panel from a uid the reader's
+// Grafana doesn't have; the cost is no "type", and snapshotPanel's fallback renders the frames as a
+// timeseries. The same trade the v1 path makes by deleting libraryPanel: a generic render of the real
+// data beats no snapshot at all.
 func v1PanelFromV2Spec(spec json.RawMessage) map[string]any {
 	var v2 struct {
 		Title       string `json:"title"`
@@ -570,6 +637,14 @@ func v1PanelFromV2Spec(spec json.RawMessage) map[string]any {
 // time.from/to is parsed as a date expression, not a number; anything else (a relative "now-1h" from
 // a non-browser caller) is passed through verbatim. Returns nil when there is no range to bake, so
 // the import falls back to Grafana's default.
+//
+// Only the request's TOP-LEVEL range is read. Under Query V2 (the X-Query-V2 header, which makes both
+// handlers dispatch to QueryDataNew) an individual query's own "timeRange" overrides that global range
+// for the query that actually ran -- see getTimeRange in pkg/services/query -- so a panel mixing
+// per-query ranges would bake a window its frames may sit outside of. Left as-is deliberately: no
+// client sends that header today, and collapsing several per-query windows into the one range a
+// dashboard can hold (widest span? first query's?) is a decision worth making against a real caller
+// rather than guessed at here.
 func snapshotTimeRange(queryRequestJSON json.RawMessage) map[string]any {
 	if len(queryRequestJSON) == 0 {
 		return nil
@@ -678,23 +753,27 @@ func (b *Bundler) BuildDashboard(dashboardJSON json.RawMessage, panels []Dashboa
 		// offline). Convenience artifact -- querydata.json remains the authoritative record -- so it draws
 		// from what querydata.json left of the shared dashboard budget rather than getting a pool of its
 		// own, and is omitted (with the reason in the manifest) on failure or when the budget is spent.
-		if p.Resp != nil {
+		// Gated on having FRAMES, not merely a response: a panel whose queries all failed carries
+		// per-refID errors and nothing to bake, and that is not a failure of the snapshot (the
+		// single-panel path treats it the same way). Checking first keeps the budget gate below from
+		// reporting such a panel's absent snapshot as dropped-for-budget.
+		if hasSnapshotFrames(p.Resp) {
 			snapshotLimit := min(maxQueryDataArtifactBytes, queryDataBytesRemaining)
 			if snapshotLimit < minQueryDataArtifactBytes {
 				// Checked BEFORE marshalling, mirroring the query-data gate above: the snapshot is
 				// all-or-nothing (there is no truncated form to fall back to), so building one for every
 				// remaining panel just to measure and discard it would re-encode the whole response -- the
 				// largest allocation in this path -- once per panel with no budget left to spend on it.
-				entry.SnapshotError = fmt.Sprintf("remaining dashboard query-data budget (%d bytes) below the %d-byte minimum artifact size", queryDataBytesRemaining, minQueryDataArtifactBytes)
+				entry.SnapshotBackendError = fmt.Sprintf("remaining dashboard query-data budget (%d bytes) below the %d-byte minimum artifact size", queryDataBytesRemaining, minQueryDataArtifactBytes)
 			} else if snapshot, err := marshalSnapshotBackendArtifact(panelJSON, p.QueryRequest, p.Resp); err != nil {
-				entry.SnapshotError = err.Error()
+				entry.SnapshotBackendError = err.Error()
 			} else if len(snapshot) > 0 {
 				if len(snapshot) <= snapshotLimit {
 					files[dir+"/snapshot-backend.json"] = snapshot
-					entry.SnapshotBytes = len(snapshot)
+					entry.SnapshotBackendBytes = len(snapshot)
 					queryDataBytesRemaining -= len(snapshot)
 				} else {
-					entry.SnapshotError = fmt.Sprintf("snapshot-backend artifact (%d bytes) exceeded the remaining dashboard query-data budget (%d bytes)", len(snapshot), snapshotLimit)
+					entry.SnapshotBackendError = fmt.Sprintf("snapshot-backend artifact (%d bytes) exceeded the remaining dashboard query-data budget (%d bytes)", len(snapshot), snapshotLimit)
 				}
 			}
 		}
@@ -768,8 +847,10 @@ func indexPanelsByID(panels []json.RawMessage, panelsByID map[int64]json.RawMess
 }
 
 // indexElementsByID indexes v2 "elements" entries by their spec.id. Both a regular "Panel" and a
-// "LibraryPanel" carry a resolved panel spec with an id, so both are indexed; other element kinds
-// (rows, tabs, ...) have no panel id and are skipped.
+// "LibraryPanel" carry a spec with a panel id, so both are indexed; other element kinds (rows, tabs,
+// ...) have no panel id and are skipped. Only "Panel" carries the panel's viz config, though -- a
+// LibraryPanel spec is just {id, title, libraryPanel} and the model lives in the library -- so a
+// reader of panel.json (and anything deriving from it, e.g. v1PanelFromV2Spec) gets identity only.
 func indexElementsByID(elements map[string]json.RawMessage, panelsByID map[int64]json.RawMessage) {
 	for _, raw := range elements {
 		var meta struct {

--- a/pkg/services/diagnostics/diagnostics.go
+++ b/pkg/services/diagnostics/diagnostics.go
@@ -477,6 +477,17 @@ func snapshotPanel(panelJSON json.RawMessage) map[string]any {
 	// transformations on top would render something that is neither the backend response this artifact
 	// records nor the panel's real output; the post-transform view is snapshot-rendered.json's job.
 	delete(panel, "transformations")
+	// The baked dashboard time range is the range the queries actually ran over, and the client reads
+	// it from the PANEL's effective range -- so a relative override has already been resolved into the
+	// absolute timestamps baked below. Leaving the override on the panel applies it a SECOND time: a
+	// timeShift shifts the absolute range further off the frames and the panel renders empty. Dropped
+	// rather than reconciled, since the override's whole purpose (a window relative to now) is
+	// meaningless once the data is frozen. The v2 path already drops these -- v2 keeps them in
+	// data.spec.queryOptions, which v1PanelFromV2Spec doesn't carry over.
+	delete(panel, "timeFrom")
+	delete(panel, "timeShift")
+	delete(panel, "timeCompare")
+	delete(panel, "hideTimeOverride")
 	return panel
 }
 
@@ -661,15 +672,22 @@ func (b *Bundler) BuildDashboard(dashboardJSON json.RawMessage, panels []Dashboa
 		// from what querydata.json left of the shared dashboard budget rather than getting a pool of its
 		// own, and is omitted (with the reason in the manifest) on failure or when the budget is spent.
 		if p.Resp != nil {
-			if snapshot, err := marshalSnapshotBackendArtifact(panelJSON, p.QueryRequest, p.Resp); err != nil {
+			snapshotLimit := min(maxQueryDataArtifactBytes, queryDataBytesRemaining)
+			if snapshotLimit < minQueryDataArtifactBytes {
+				// Checked BEFORE marshalling, mirroring the query-data gate above: the snapshot is
+				// all-or-nothing (there is no truncated form to fall back to), so building one for every
+				// remaining panel just to measure and discard it would re-encode the whole response -- the
+				// largest allocation in this path -- once per panel with no budget left to spend on it.
+				entry.SnapshotError = fmt.Sprintf("remaining dashboard query-data budget (%d bytes) below the %d-byte minimum artifact size", queryDataBytesRemaining, minQueryDataArtifactBytes)
+			} else if snapshot, err := marshalSnapshotBackendArtifact(panelJSON, p.QueryRequest, p.Resp); err != nil {
 				entry.SnapshotError = err.Error()
 			} else if len(snapshot) > 0 {
-				if len(snapshot) <= min(maxQueryDataArtifactBytes, queryDataBytesRemaining) {
+				if len(snapshot) <= snapshotLimit {
 					files[dir+"/snapshot-backend.json"] = snapshot
 					entry.SnapshotBytes = len(snapshot)
 					queryDataBytesRemaining -= len(snapshot)
 				} else {
-					entry.SnapshotError = "snapshot-backend artifact exceeded the remaining dashboard query-data budget"
+					entry.SnapshotError = fmt.Sprintf("snapshot-backend artifact (%d bytes) exceeded the remaining dashboard query-data budget (%d bytes)", len(snapshot), snapshotLimit)
 				}
 			}
 		}

--- a/pkg/services/diagnostics/diagnostics.go
+++ b/pkg/services/diagnostics/diagnostics.go
@@ -11,12 +11,15 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 	"unicode/utf8"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
 
+	"github.com/grafana/grafana/apps/dashboard/pkg/migration/schemaversion"
 	"github.com/grafana/grafana/pkg/infra/httpclient/harcapture"
 )
 
@@ -26,6 +29,10 @@ type Bundler struct{}
 // Query responses can contain substantially more data than the diagnostic traffic itself. Keep
 // their uncompressed JSON bounded independently so adding querydata.json cannot multiply a large
 // panel/dashboard archive without an explicit truncation marker.
+//
+// maxDashboardQueryDataBytes covers querydata.json AND snapshot-backend.json together: the snapshot
+// re-encodes the same frames, so giving it its own allowance would double a dashboard bundle's
+// uncompressed artifact ceiling for data querydata.json already holds.
 const (
 	maxQueryDataArtifactBytes  = 8 << 20
 	maxDashboardQueryDataBytes = 32 << 20
@@ -83,9 +90,17 @@ func (b *Bundler) Build(resp *backend.QueryDataResponse, harBuffer *harcapture.B
 	}
 
 	// snapshot-backend.json: an importable, data-baked dashboard that renders the plugin's returned
-	// frames offline (no datasource). A convenience artifact -- on failure or when it would exceed the
-	// per-panel budget it is simply omitted; querydata.json remains the authoritative record.
-	if snapshot, err := marshalSnapshotBackendArtifact(panelJSON, resp); err == nil && len(snapshot) > 0 && len(snapshot) <= maxQueryDataArtifactBytes {
+	// frames offline (no datasource). A convenience artifact -- querydata.json remains the authoritative
+	// record -- so a failure or an over-budget artifact costs only the snapshot. Why it went missing is
+	// recorded in snapshot-error.txt, mirroring how the dashboard path records manifest.snapshotError:
+	// omitting it silently leaves a reader unable to tell a failure from a response with no frames.
+	snapshot, snapshotErr := marshalSnapshotBackendArtifact(panelJSON, queryRequestJSON, resp)
+	switch {
+	case snapshotErr != nil:
+		files["snapshot-error.txt"] = []byte(snapshotErr.Error() + "\n")
+	case len(snapshot) > maxQueryDataArtifactBytes:
+		files["snapshot-error.txt"] = []byte(fmt.Sprintf("snapshot-backend artifact (%d bytes) exceeded the %d-byte limit\n", len(snapshot), maxQueryDataArtifactBytes))
+	case len(snapshot) > 0:
 		files["snapshot-backend.json"] = snapshot
 	}
 
@@ -342,59 +357,106 @@ type manifestPanelEntry struct {
 	CaptureError string `json:"captureError,omitempty"`
 }
 
+// snapshotArtifactTitle names both the snapshot dashboard and its panel when the panel model doesn't
+// supply a title of its own.
+const snapshotArtifactTitle = "Diagnostics snapshot (backend / plugin output)"
+
 // marshalSnapshotBackendArtifact builds an importable, data-baked dashboard from the backend
-// QueryDataResponse. It reuses Grafana's snapshot format -- each refID becomes a Grafana-datasource
-// target with queryType "snapshot" carrying the response frames verbatim (the same DataFrameJSON
-// querydata.json records) -- so the dashboard renders OFFLINE, with no live datasource and no query
-// re-run: the "what did the plugin return" view a support engineer can open and see. panelJSON, when
-// present, supplies the panel's visualization + field config so the render matches the real panel;
-// its own datasource/targets are replaced so the imported panel can never re-query.
+// QueryDataResponse. It reuses Grafana's snapshot format -- a Grafana-datasource target with
+// queryType "snapshot" carrying the response frames verbatim (the same DataFrameJSON querydata.json
+// records) -- so the dashboard renders OFFLINE, with no live datasource and no query re-run: the
+// "what did the plugin return" view a support engineer can open and see. panelJSON, when present,
+// supplies the panel's visualization + field config so the render matches the real panel; its own
+// datasource/targets are replaced so the imported panel can never re-query.
+//
+// queryRequestJSON supplies the submitted time range, which is baked into the dashboard: an import
+// with no time range defaults to now-6h, so a bundle read a day later would render an empty panel
+// with the frames sitting outside the window.
 //
 // Returns nil (no artifact) when there is no response or no frames to bake.
-func marshalSnapshotBackendArtifact(panelJSON json.RawMessage, resp *backend.QueryDataResponse) ([]byte, error) {
+func marshalSnapshotBackendArtifact(panelJSON, queryRequestJSON json.RawMessage, resp *backend.QueryDataResponse) ([]byte, error) {
 	if resp == nil {
 		return nil, nil
 	}
-	respJSON, err := queryDataResponseWithoutCaptureFrames(resp).MarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	var parsed struct {
-		Results map[string]struct {
-			Frames []json.RawMessage `json:"frames"`
-		} `json:"results"`
-	}
-	if err := json.Unmarshal(respJSON, &parsed); err != nil {
+	frames, err := snapshotFrames(resp)
+	if err != nil || len(frames) == 0 {
 		return nil, err
 	}
 
-	// Deterministic refID order so the artifact (and its tests) are stable.
-	refIDs := make([]string, 0, len(parsed.Results))
-	for refID := range parsed.Results {
-		refIDs = append(refIDs, refID)
+	panel := snapshotPanel(panelJSON)
+	// One target holding every refID's frames, matching the format's only other producer (the scenes
+	// snapshot serializer). Per-refID targets look tidier but lose data: the Grafana datasource emits
+	// each snapshot target as a keyless response packet, and the query runner then keys packets by the
+	// first frame's refId -- which is omitempty in the SDK and unset by core datasources such as
+	// Prometheus -- so sibling targets collapse onto the same key and all but one are dropped.
+	panel["targets"] = []map[string]any{{
+		"refId":      "A",
+		"datasource": grafanaSnapshotDatasourceRef,
+		"queryType":  "snapshot",
+		"snapshot":   frames,
+	}}
+
+	dashboard := map[string]any{
+		"schemaVersion": schemaversion.LATEST_VERSION,
+		"title":         snapshotArtifactTitle,
+		"editable":      true,
+		"panels":        []any{panel},
+	}
+	if timeRange := snapshotTimeRange(queryRequestJSON); timeRange != nil {
+		dashboard["time"] = timeRange
+	}
+	return json.MarshalIndent(dashboard, "", "  ")
+}
+
+// snapshotFrames encodes every non-capture frame in resp as DataFrameJSON, in deterministic refID
+// order so the artifact (and its tests) are stable. Frames are encoded one at a time rather than by
+// re-marshalling the whole response: the response JSON has already been built once for
+// querydata.json, and a second full encode plus a decode into frames would hold several copies of a
+// large response at peak.
+func snapshotFrames(resp *backend.QueryDataResponse) ([]json.RawMessage, error) {
+	refIDs := make([]string, 0, len(resp.Responses))
+	for refID := range resp.Responses {
+		if !isHARResponse(refID) {
+			refIDs = append(refIDs, refID)
+		}
 	}
 	sort.Strings(refIDs)
 
-	targets := make([]map[string]any, 0, len(refIDs))
-	frameCount := 0
+	var frames []json.RawMessage
 	for _, refID := range refIDs {
-		frames := parsed.Results[refID].Frames
-		frameCount += len(frames)
-		targets = append(targets, map[string]any{
-			"refId":      refID,
-			"datasource": grafanaSnapshotDatasourceRef,
-			"queryType":  "snapshot",
-			"snapshot":   frames,
-		})
+		for _, frame := range resp.Responses[refID].Frames {
+			if frame == nil {
+				continue
+			}
+			// Merging every refID into one target loses the per-refID grouping the response map gave us,
+			// so stamp the refId the frame is missing -- the snapshot format expects the payload itself to
+			// reference the original refIds. Stamped on a copy: resp belongs to the caller, which also
+			// serializes it for querydata.json.
+			stamped := *frame
+			if stamped.RefID == "" {
+				stamped.RefID = refID
+			}
+			encoded, err := data.FrameToJSON(&stamped, data.IncludeAll)
+			if err != nil {
+				return nil, fmt.Errorf("encode frame for refId %s: %w", refID, err)
+			}
+			frames = append(frames, encoded)
+		}
 	}
-	if frameCount == 0 {
-		return nil, nil
-	}
+	return frames, nil
+}
 
+// snapshotPanel builds the snapshot dashboard's single panel from the supplied panel model, keeping
+// only what a v1 dashboard can render offline. Callers set the targets.
+func snapshotPanel(panelJSON json.RawMessage) map[string]any {
 	panel := map[string]any{}
 	if len(panelJSON) > 0 {
-		// A malformed panel model shouldn't lose the snapshot; fall back to a minimal panel.
-		if err := json.Unmarshal(panelJSON, &panel); err != nil {
+		// v2 dashboards store elements as {kind, spec}, and BuildDashboard hands that through verbatim
+		// (see indexPanelJSON), so the wrapper has to be translated rather than unmarshalled as a panel.
+		// A malformed panel model shouldn't lose the snapshot either; both fall back to a minimal panel.
+		if spec := v2ElementSpec(panelJSON); spec != nil {
+			panel = v1PanelFromV2Spec(spec)
+		} else if err := json.Unmarshal(panelJSON, &panel); err != nil {
 			panel = map[string]any{}
 		}
 	}
@@ -402,21 +464,119 @@ func marshalSnapshotBackendArtifact(panelJSON json.RawMessage, resp *backend.Que
 		panel["type"] = "timeseries"
 	}
 	if _, ok := panel["title"]; !ok {
-		panel["title"] = "Diagnostics snapshot (backend / plugin output)"
+		panel["title"] = snapshotArtifactTitle
 	}
 	panel["id"] = 1
 	panel["gridPos"] = map[string]any{"h": 12, "w": 24, "x": 0, "y": 0}
 	panel["datasource"] = grafanaSnapshotDatasourceRef
-	panel["targets"] = targets
 	delete(panel, "snapshotData")
+	// A library-panel reference would make the import resolve the panel from a library uid that doesn't
+	// exist in the reader's Grafana, discarding the baked targets along with the panel model.
+	delete(panel, "libraryPanel")
+	// The baked frames are the plugin's output, BEFORE frontend processing. Applying the panel's
+	// transformations on top would render something that is neither the backend response this artifact
+	// records nor the panel's real output; the post-transform view is snapshot-rendered.json's job.
+	delete(panel, "transformations")
+	return panel
+}
 
-	dashboard := map[string]any{
-		"schemaVersion": 41,
-		"title":         "Diagnostics snapshot (backend / plugin output)",
-		"editable":      true,
-		"panels":        []any{panel},
+// v2ElementSpec returns the spec of a v2 dashboard element ({kind, spec}), or nil if raw isn't one.
+func v2ElementSpec(raw json.RawMessage) json.RawMessage {
+	var element struct {
+		Kind string          `json:"kind"`
+		Spec json.RawMessage `json:"spec"`
 	}
-	return json.MarshalIndent(dashboard, "", "  ")
+	if err := json.Unmarshal(raw, &element); err != nil || element.Kind == "" || len(element.Spec) == 0 {
+		return nil
+	}
+	return element.Spec
+}
+
+// v1PanelFromV2Spec translates the parts of a v2 panel spec that a v1 snapshot dashboard can render:
+// the viz plugin and its options/fieldConfig, plus the panel's identity. Queries are dropped because
+// the snapshot replaces them, and so is anything whose v1 equivalent has a different shape (v2
+// transformations are {kind, spec}, not {id, options}) -- copying the spec wholesale would emit a
+// hybrid object and carry the original datasource refs into an artifact that must not re-query.
+func v1PanelFromV2Spec(spec json.RawMessage) map[string]any {
+	var v2 struct {
+		Title       string `json:"title"`
+		Description string `json:"description"`
+		Transparent bool   `json:"transparent"`
+		VizConfig   struct {
+			Kind    string `json:"kind"`
+			Group   string `json:"group"`
+			Version string `json:"version"`
+			Spec    struct {
+				Options     map[string]any  `json:"options"`
+				FieldConfig json.RawMessage `json:"fieldConfig"`
+			} `json:"spec"`
+		} `json:"vizConfig"`
+	}
+	if err := json.Unmarshal(spec, &v2); err != nil {
+		return map[string]any{}
+	}
+
+	panel := map[string]any{}
+	// v2alpha1 put the plugin id in vizConfig.kind; v2beta1 onwards moved it to vizConfig.group and set
+	// kind to the literal "VizConfig".
+	pluginID := v2.VizConfig.Group
+	if pluginID == "" && v2.VizConfig.Kind != "VizConfig" {
+		pluginID = v2.VizConfig.Kind
+	}
+	if pluginID != "" {
+		panel["type"] = pluginID
+	}
+	if v2.Title != "" {
+		panel["title"] = v2.Title
+	}
+	if v2.Description != "" {
+		panel["description"] = v2.Description
+	}
+	if v2.Transparent {
+		panel["transparent"] = true
+	}
+	if v2.VizConfig.Version != "" {
+		panel["pluginVersion"] = v2.VizConfig.Version
+	}
+	if len(v2.VizConfig.Spec.Options) > 0 {
+		panel["options"] = v2.VizConfig.Spec.Options
+	}
+	if len(v2.VizConfig.Spec.FieldConfig) > 0 {
+		panel["fieldConfig"] = v2.VizConfig.Spec.FieldConfig
+	}
+	return panel
+}
+
+// snapshotTimeRange resolves the submitted MetricRequest's time range for the snapshot dashboard.
+// The client sends epoch milliseconds, which are converted to absolute RFC3339 because a dashboard's
+// time.from/to is parsed as a date expression, not a number; anything else (a relative "now-1h" from
+// a non-browser caller) is passed through verbatim. Returns nil when there is no range to bake, so
+// the import falls back to Grafana's default.
+func snapshotTimeRange(queryRequestJSON json.RawMessage) map[string]any {
+	if len(queryRequestJSON) == 0 {
+		return nil
+	}
+	var request struct {
+		From string `json:"from"`
+		To   string `json:"to"`
+	}
+	if err := json.Unmarshal(queryRequestJSON, &request); err != nil {
+		return nil
+	}
+	if request.From == "" || request.To == "" {
+		return nil
+	}
+	return map[string]any{
+		"from": snapshotTimeValue(request.From),
+		"to":   snapshotTimeValue(request.To),
+	}
+}
+
+func snapshotTimeValue(value string) string {
+	if epochMillis, err := strconv.ParseInt(value, 10, 64); err == nil {
+		return time.UnixMilli(epochMillis).UTC().Format(time.RFC3339Nano)
+	}
+	return value
 }
 
 // BuildDashboard assembles a whole-dashboard .tar.gz: a shared dashboard.json and manifest.json plus
@@ -437,7 +597,6 @@ func (b *Bundler) BuildDashboard(dashboardJSON json.RawMessage, panels []Dashboa
 
 	usedDirs := map[string]bool{}
 	queryDataBytesRemaining := maxDashboardQueryDataBytes
-	snapshotBytesRemaining := maxDashboardQueryDataBytes
 	panelJSONByID := indexPanelJSON(dashboardJSON)
 	for _, p := range panels {
 		entry := manifestPanelEntry{ID: p.ID, Title: p.Title, Datasources: p.Datasources}
@@ -498,18 +657,19 @@ func (b *Bundler) BuildDashboard(dashboardJSON json.RawMessage, panels []Dashboa
 		entry.QueryDataError = strings.Join(queryDataErrs, "; ")
 
 		// snapshot-backend.json: importable, data-baked view of this panel's returned frames (renders
-		// offline). Convenience artifact, bounded by a shared dashboard budget; omitted on failure or
-		// when it would exceed the remaining budget (querydata.json remains the authoritative record).
+		// offline). Convenience artifact -- querydata.json remains the authoritative record -- so it draws
+		// from what querydata.json left of the shared dashboard budget rather than getting a pool of its
+		// own, and is omitted (with the reason in the manifest) on failure or when the budget is spent.
 		if p.Resp != nil {
-			if snapshot, err := marshalSnapshotBackendArtifact(panelJSON, p.Resp); err != nil {
+			if snapshot, err := marshalSnapshotBackendArtifact(panelJSON, p.QueryRequest, p.Resp); err != nil {
 				entry.SnapshotError = err.Error()
 			} else if len(snapshot) > 0 {
-				if len(snapshot) <= min(maxQueryDataArtifactBytes, snapshotBytesRemaining) {
+				if len(snapshot) <= min(maxQueryDataArtifactBytes, queryDataBytesRemaining) {
 					files[dir+"/snapshot-backend.json"] = snapshot
 					entry.SnapshotBytes = len(snapshot)
-					snapshotBytesRemaining -= len(snapshot)
+					queryDataBytesRemaining -= len(snapshot)
 				} else {
-					entry.SnapshotError = "snapshot-backend artifact exceeded its assigned dashboard budget"
+					entry.SnapshotError = "snapshot-backend artifact exceeded the remaining dashboard query-data budget"
 				}
 			}
 		}

--- a/pkg/services/diagnostics/diagnostics.go
+++ b/pkg/services/diagnostics/diagnostics.go
@@ -30,9 +30,16 @@ type Bundler struct{}
 // their uncompressed JSON bounded independently so adding querydata.json cannot multiply a large
 // panel/dashboard archive without an explicit truncation marker.
 //
-// maxDashboardQueryDataBytes covers querydata.json AND snapshot-backend.json together: the snapshot
-// re-encodes the same frames, so giving it its own allowance would double a dashboard bundle's
-// uncompressed artifact ceiling for data querydata.json already holds.
+// querydata.json and snapshot-backend.json hold the same frames twice, so how the two are bounded
+// together differs by path, deliberately:
+//
+//   - BuildDashboard draws both from one shared maxDashboardQueryDataBytes pool. It has a single
+//     running budget spanning every panel, so letting the snapshot claim an allowance of its own
+//     would double the whole archive's ceiling for data querydata.json already holds.
+//   - Build has no running budget -- one panel, one shot -- and applies maxQueryDataArtifactBytes to
+//     each artifact separately, so a single-panel bundle's real ceiling is twice that. Sharing one
+//     allowance here would instead drop the snapshot whenever querydata.json had spent most of it,
+//     losing the offline render on exactly the large responses it exists to make readable.
 const (
 	maxQueryDataArtifactBytes  = 8 << 20
 	maxDashboardQueryDataBytes = 32 << 20

--- a/pkg/services/diagnostics/diagnostics_test.go
+++ b/pkg/services/diagnostics/diagnostics_test.go
@@ -155,6 +155,219 @@ func TestBundler_Build_noSnapshotWithoutResponse(t *testing.T) {
 
 	files := readTarGz(t, blob)
 	require.NotContains(t, files, "snapshot-backend.json")
+	require.NotContains(t, files, "snapshot-error.txt", "nothing to bake is not a failure")
+}
+
+// Every refID's frames go into ONE snapshot target: the Grafana datasource emits each snapshot target
+// as a keyless response packet, so sibling targets collapse onto the same key in the query runner and
+// all but one would be dropped. The merge loses the response map's per-refID grouping, so each frame
+// carries the refId it came from.
+func TestBundler_Build_snapshotMergesRefIDsIntoOneTarget(t *testing.T) {
+	resp := &backend.QueryDataResponse{Responses: backend.Responses{
+		"B": {Frames: data.Frames{data.NewFrame("mem", data.NewField("value", nil, []float64{2}))}},
+		"A": {Frames: data.Frames{data.NewFrame("cpu", data.NewField("value", nil, []float64{1}))}},
+	}}
+
+	blob, err := NewBundler().Build(resp, &harcapture.Buffer{}, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	files := readTarGz(t, blob)
+	var dash struct {
+		Panels []struct {
+			Targets []struct {
+				RefID    string `json:"refId"`
+				Snapshot []struct {
+					Schema struct {
+						Name  string `json:"name"`
+						RefID string `json:"refId"`
+					} `json:"schema"`
+				} `json:"snapshot"`
+			} `json:"targets"`
+		} `json:"panels"`
+	}
+	require.NoError(t, json.Unmarshal(files["snapshot-backend.json"], &dash))
+	require.Len(t, dash.Panels[0].Targets, 1, "one target, not one per refID")
+	require.Equal(t, "A", dash.Panels[0].Targets[0].RefID)
+
+	frames := dash.Panels[0].Targets[0].Snapshot
+	require.Len(t, frames, 2, "both refIDs' frames are baked")
+	// Sorted by refID, so A's frame comes first regardless of response map iteration order.
+	require.Equal(t, "cpu", frames[0].Schema.Name)
+	require.Equal(t, "A", frames[0].Schema.RefID, "the frame carries the refId it came from")
+	require.Equal(t, "mem", frames[1].Schema.Name)
+	require.Equal(t, "B", frames[1].Schema.RefID)
+}
+
+// A frame that already names its refId keeps it, and the caller's response is left untouched (Build
+// also serializes it for querydata.json).
+func TestBundler_Build_snapshotDoesNotMutateResponseFrames(t *testing.T) {
+	frame := data.NewFrame("cpu", data.NewField("value", nil, []float64{42}))
+	frame.RefID = "Q1"
+	resp := &backend.QueryDataResponse{Responses: backend.Responses{"A": {Frames: data.Frames{frame}}}}
+
+	blob, err := NewBundler().Build(resp, &harcapture.Buffer{}, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	require.Equal(t, "Q1", frame.RefID, "the response frame is not stamped in place")
+	require.Contains(t, string(readTarGz(t, blob)["snapshot-backend.json"]), `"refId": "Q1"`)
+}
+
+// Without a baked time range an import defaults to now-6h and the frames sit outside the window, so
+// the panel renders empty. The client submits epoch milliseconds; a dashboard parses time.from/to as
+// a date expression, so they have to be absolute timestamps.
+func TestBundler_Build_snapshotBakesRequestTimeRange(t *testing.T) {
+	frame := data.NewFrame("cpu", data.NewField("value", nil, []float64{42}))
+	resp := &backend.QueryDataResponse{Responses: backend.Responses{"A": {Frames: data.Frames{frame}}}}
+	request := json.RawMessage(`{"from":"1690000000000","to":"1690003600000","queries":[{"refId":"A"}]}`)
+
+	blob, err := NewBundler().Build(resp, &harcapture.Buffer{}, nil, nil, request, nil, nil)
+	require.NoError(t, err)
+
+	var dash struct {
+		Time struct {
+			From string `json:"from"`
+			To   string `json:"to"`
+		} `json:"time"`
+	}
+	require.NoError(t, json.Unmarshal(readTarGz(t, blob)["snapshot-backend.json"], &dash))
+	require.Equal(t, time.UnixMilli(1690000000000).UTC().Format(time.RFC3339Nano), dash.Time.From)
+	require.Equal(t, time.UnixMilli(1690003600000).UTC().Format(time.RFC3339Nano), dash.Time.To)
+}
+
+// A non-browser caller can submit a relative range; it is passed through rather than mangled.
+func TestBundler_Build_snapshotKeepsRelativeTimeRange(t *testing.T) {
+	frame := data.NewFrame("cpu", data.NewField("value", nil, []float64{42}))
+	resp := &backend.QueryDataResponse{Responses: backend.Responses{"A": {Frames: data.Frames{frame}}}}
+	request := json.RawMessage(`{"from":"now-1h","to":"now","queries":[{"refId":"A"}]}`)
+
+	blob, err := NewBundler().Build(resp, &harcapture.Buffer{}, nil, nil, request, nil, nil)
+	require.NoError(t, err)
+
+	require.Contains(t, string(readTarGz(t, blob)["snapshot-backend.json"]), `"from": "now-1h"`)
+}
+
+// v2 dashboards store panels as {kind, spec}. The translatable viz config is lifted into the v1
+// snapshot panel; the query definitions (and the datasource they name) are not carried over.
+func TestBundler_Build_snapshotFlattensV2PanelElement(t *testing.T) {
+	frame := data.NewFrame("cpu", data.NewField("value", nil, []float64{42}))
+	resp := &backend.QueryDataResponse{Responses: backend.Responses{"A": {Frames: data.Frames{frame}}}}
+	panelJSON := json.RawMessage(`{
+		"kind": "Panel",
+		"spec": {
+			"id": 3,
+			"title": "CPU",
+			"description": "how busy",
+			"data": {"kind": "QueryGroup", "spec": {
+				"queries": [{"kind": "PanelQuery", "spec": {"refId": "A", "query": {"kind": "prometheus", "group": "prometheus", "datasource": {"name": "prom-x"}, "spec": {"expr": "up"}}}}],
+				"transformations": [{"kind": "reduce", "group": "reduce", "spec": {"options": {}}}],
+				"queryOptions": {}
+			}},
+			"vizConfig": {"kind": "VizConfig", "group": "stat", "version": "11.0.0", "spec": {
+				"options": {"colorMode": "value"},
+				"fieldConfig": {"defaults": {"unit": "percent"}, "overrides": []}
+			}}
+		}
+	}`)
+
+	blob, err := NewBundler().Build(resp, &harcapture.Buffer{}, panelJSON, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	files := readTarGz(t, blob)
+	snap := string(files["snapshot-backend.json"])
+	var dash struct {
+		Panels []struct {
+			Type          string `json:"type"`
+			Title         string `json:"title"`
+			Description   string `json:"description"`
+			PluginVersion string `json:"pluginVersion"`
+			Options       struct {
+				ColorMode string `json:"colorMode"`
+			} `json:"options"`
+			FieldConfig struct {
+				Defaults struct {
+					Unit string `json:"unit"`
+				} `json:"defaults"`
+			} `json:"fieldConfig"`
+		} `json:"panels"`
+	}
+	require.NoError(t, json.Unmarshal(files["snapshot-backend.json"], &dash))
+	require.Equal(t, "stat", dash.Panels[0].Type, "the plugin id comes from vizConfig.group")
+	require.Equal(t, "CPU", dash.Panels[0].Title)
+	require.Equal(t, "how busy", dash.Panels[0].Description)
+	require.Equal(t, "11.0.0", dash.Panels[0].PluginVersion)
+	require.Equal(t, "value", dash.Panels[0].Options.ColorMode)
+	require.Equal(t, "percent", dash.Panels[0].FieldConfig.Defaults.Unit)
+	require.NotContains(t, snap, "prom-x", "the v2 query's datasource is not carried into the artifact")
+	require.NotContains(t, snap, "vizConfig", "the v2 wrapper is translated, not copied")
+	require.NotContains(t, snap, `"spec"`)
+}
+
+// v2alpha1 named the plugin in vizConfig.kind before it moved to vizConfig.group.
+func TestBundler_Build_snapshotFlattensV2AlphaPanelElement(t *testing.T) {
+	frame := data.NewFrame("cpu", data.NewField("value", nil, []float64{42}))
+	resp := &backend.QueryDataResponse{Responses: backend.Responses{"A": {Frames: data.Frames{frame}}}}
+	panelJSON := json.RawMessage(`{"kind":"Panel","spec":{"id":3,"title":"CPU","vizConfig":{"kind":"gauge","spec":{"options":{},"fieldConfig":{}}}}}`)
+
+	blob, err := NewBundler().Build(resp, &harcapture.Buffer{}, panelJSON, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	var dash struct {
+		Panels []struct {
+			Type string `json:"type"`
+		} `json:"panels"`
+	}
+	require.NoError(t, json.Unmarshal(readTarGz(t, blob)["snapshot-backend.json"], &dash))
+	require.Equal(t, "gauge", dash.Panels[0].Type)
+}
+
+// A library-panel ref would make the import resolve the panel from a uid the reader's Grafana doesn't
+// have, discarding the baked targets. Transformations are dropped too: the baked frames are the
+// plugin's output before frontend processing.
+func TestBundler_Build_snapshotDropsLibraryPanelAndTransformations(t *testing.T) {
+	frame := data.NewFrame("cpu", data.NewField("value", nil, []float64{42}))
+	resp := &backend.QueryDataResponse{Responses: backend.Responses{"A": {Frames: data.Frames{frame}}}}
+	panelJSON := json.RawMessage(`{"type":"stat","title":"CPU","libraryPanel":{"uid":"lib-1","name":"Shared CPU"},"transformations":[{"id":"reduce","options":{}}],"snapshotData":[]}`)
+
+	blob, err := NewBundler().Build(resp, &harcapture.Buffer{}, panelJSON, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	snap := string(readTarGz(t, blob)["snapshot-backend.json"])
+	require.NotContains(t, snap, "libraryPanel")
+	require.NotContains(t, snap, "lib-1")
+	require.NotContains(t, snap, "transformations")
+	require.NotContains(t, snap, "snapshotData")
+	require.Contains(t, snap, `"stat"`, "the rest of the panel model still contributes")
+}
+
+// A frame the SDK cannot encode costs only the snapshot: querydata.json still ships (degraded), and
+// the reason the snapshot is missing is recorded rather than swallowed.
+func TestBundler_Build_recordsSnapshotEncodeFailure(t *testing.T) {
+	frame := data.NewFrame("cpu", data.NewField("value", nil, []float64{42}))
+	frame.Meta = &data.FrameMeta{Custom: math.NaN()}
+	resp := &backend.QueryDataResponse{Responses: backend.Responses{"A": {Frames: data.Frames{frame}}}}
+
+	blob, err := NewBundler().Build(resp, &harcapture.Buffer{}, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	files := readTarGz(t, blob)
+	require.NotContains(t, files, "snapshot-backend.json")
+	require.Contains(t, string(files["snapshot-error.txt"]), "encode frame for refId A")
+	require.Contains(t, files, "querydata.json", "the authoritative record still ships")
+}
+
+// The snapshot is a convenience artifact, but a reader must be able to tell "no frames to bake" from
+// "the snapshot didn't fit" -- the single-panel bundle has no manifest to record it in.
+func TestBundler_Build_recordsOversizedSnapshot(t *testing.T) {
+	frame := data.NewFrame("logs", data.NewField("line", nil, []string{strings.Repeat("x", maxQueryDataArtifactBytes)}))
+	resp := &backend.QueryDataResponse{Responses: backend.Responses{"A": {Frames: data.Frames{frame}}}}
+
+	blob, err := NewBundler().Build(resp, &harcapture.Buffer{}, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	files := readTarGz(t, blob)
+	require.NotContains(t, files, "snapshot-backend.json")
+	require.Contains(t, files, "snapshot-error.txt")
+	require.Contains(t, string(files["snapshot-error.txt"]), "exceeded")
 }
 
 func TestBundler_Build_recordsQueryDataRequest(t *testing.T) {
@@ -661,6 +874,89 @@ func TestBuildDashboard_writesSnapshotPerPanel(t *testing.T) {
 	require.NoError(t, json.Unmarshal(files["manifest.json"], &m))
 	require.Len(t, m.Panels, 1)
 	require.Positive(t, m.Panels[0].SnapshotBytes, "manifest records the snapshot size")
+}
+
+// The per-panel time range comes from that panel's own submitted request.
+func TestBuildDashboard_snapshotBakesPanelTimeRange(t *testing.T) {
+	frame := data.NewFrame("cpu", data.NewField("value", nil, []float64{42}))
+	panels := []DashboardPanel{{
+		ID:           1,
+		Title:        "CPU Usage",
+		QueryRequest: json.RawMessage(`{"from":"1690000000000","to":"1690003600000","queries":[{"refId":"A"}]}`),
+		Resp:         &backend.QueryDataResponse{Responses: backend.Responses{"A": {Frames: data.Frames{frame}}}},
+	}}
+
+	blob, err := NewBundler().BuildDashboard(nil, panels)
+	require.NoError(t, err)
+
+	files := readTarGz(t, blob)
+	require.Contains(t, string(files["panels/1-cpu-usage/snapshot-backend.json"]),
+		`"from": "`+time.UnixMilli(1690000000000).UTC().Format(time.RFC3339Nano)+`"`)
+}
+
+// v2 dashboards post the save model once, so a panel's JSON is resolved from it as a {kind, spec}
+// element -- the shape the snapshot has to translate rather than copy.
+func TestBuildDashboard_snapshotFlattensV2ElementFromDashboardModel(t *testing.T) {
+	dashboardJSON := json.RawMessage(`{"elements":{"panel-1":{"kind":"Panel","spec":{"id":1,"title":"CPU","vizConfig":{"kind":"VizConfig","group":"stat","version":"","spec":{"options":{},"fieldConfig":{}}}}}}}`)
+	frame := data.NewFrame("cpu", data.NewField("value", nil, []float64{42}))
+	panels := []DashboardPanel{{
+		ID:    1,
+		Title: "CPU",
+		Resp:  &backend.QueryDataResponse{Responses: backend.Responses{"A": {Frames: data.Frames{frame}}}},
+	}}
+
+	blob, err := NewBundler().BuildDashboard(dashboardJSON, panels)
+	require.NoError(t, err)
+
+	files := readTarGz(t, blob)
+	var dash struct {
+		Panels []struct {
+			Type string `json:"type"`
+		} `json:"panels"`
+	}
+	require.NoError(t, json.Unmarshal(files["panels/1-cpu/snapshot-backend.json"], &dash))
+	require.Equal(t, "stat", dash.Panels[0].Type)
+	require.NotContains(t, string(files["panels/1-cpu/snapshot-backend.json"]), "vizConfig")
+}
+
+// The snapshot draws from what querydata.json left of the shared dashboard budget instead of getting
+// a pool of its own, which would double the bundle's uncompressed ceiling for the same frames. Once
+// the budget is spent the snapshot is dropped and the manifest says why.
+func TestBuildDashboard_snapshotSharesQueryDataBudget(t *testing.T) {
+	panels := make([]DashboardPanel, 0, 5)
+	for i := 1; i <= 5; i++ {
+		frame := data.NewFrame("logs", data.NewField("line", nil, []string{strings.Repeat("x", maxQueryDataArtifactBytes-4096)}))
+		panels = append(panels, DashboardPanel{
+			ID:    int64(i),
+			Title: "Logs",
+			Resp: &backend.QueryDataResponse{Responses: backend.Responses{
+				"A": {Frames: data.Frames{frame}},
+			}},
+		})
+	}
+
+	blob, err := NewBundler().BuildDashboard(nil, panels)
+	require.NoError(t, err)
+
+	files := readTarGz(t, blob)
+	artifactBytes := 0
+	for name, contents := range files {
+		if strings.HasSuffix(name, "/querydata.json") || strings.HasSuffix(name, "/snapshot-backend.json") {
+			artifactBytes += len(contents)
+		}
+	}
+	require.LessOrEqual(t, artifactBytes, maxDashboardQueryDataBytes, "both artifacts share one budget")
+
+	var m dashboardManifest
+	require.NoError(t, json.Unmarshal(files["manifest.json"], &m))
+	var dropped int
+	for _, p := range m.Panels {
+		if p.SnapshotError != "" {
+			dropped++
+			require.Contains(t, p.SnapshotError, "budget")
+		}
+	}
+	require.Positive(t, dropped, "the panels past the budget record why their snapshot is missing")
 }
 
 func TestBuildDashboard_boundsAggregateQueryData(t *testing.T) {

--- a/pkg/services/diagnostics/diagnostics_test.go
+++ b/pkg/services/diagnostics/diagnostics_test.go
@@ -155,7 +155,7 @@ func TestBundler_Build_noSnapshotWithoutResponse(t *testing.T) {
 
 	files := readTarGz(t, blob)
 	require.NotContains(t, files, "snapshot-backend.json")
-	require.NotContains(t, files, "snapshot-error.txt", "nothing to bake is not a failure")
+	require.NotContains(t, files, "snapshot-backend-error.txt", "nothing to bake is not a failure")
 }
 
 // Every refID's frames go into ONE snapshot target: the Grafana datasource emits each snapshot target
@@ -351,7 +351,7 @@ func TestBundler_Build_recordsSnapshotEncodeFailure(t *testing.T) {
 
 	files := readTarGz(t, blob)
 	require.NotContains(t, files, "snapshot-backend.json")
-	require.Contains(t, string(files["snapshot-error.txt"]), "encode frame for refId A")
+	require.Contains(t, string(files["snapshot-backend-error.txt"]), "encode frame for refId A")
 	require.Contains(t, files, "querydata.json", "the authoritative record still ships")
 }
 
@@ -366,8 +366,8 @@ func TestBundler_Build_recordsOversizedSnapshot(t *testing.T) {
 
 	files := readTarGz(t, blob)
 	require.NotContains(t, files, "snapshot-backend.json")
-	require.Contains(t, files, "snapshot-error.txt")
-	require.Contains(t, string(files["snapshot-error.txt"]), "exceeded")
+	require.Contains(t, files, "snapshot-backend-error.txt")
+	require.Contains(t, string(files["snapshot-backend-error.txt"]), "exceeded")
 }
 
 // A panel-level time override must not survive into the snapshot: the client reads the submitted range
@@ -392,6 +392,94 @@ func TestBundler_Build_snapshotDropsPanelTimeOverride(t *testing.T) {
 	// The baked range still stands on its own, and the rest of the panel model survives.
 	require.Contains(t, snap, `"from": "`+time.UnixMilli(1690000000000).UTC().Format(time.RFC3339Nano)+`"`)
 	require.Contains(t, snap, `"CPU"`)
+}
+
+// Repeat must not survive either, and for a reason a no-op check wouldn't catch: the snapshot dashboard
+// has no templating, so the repeat processor binds the panel to an EMPTY value for the missing variable
+// and "$host" in the title renders blank instead of naming the captured series. A repeated panel is the
+// common case -- the client resolves a clone's save model back to the source panel that carries these.
+func TestBundler_Build_snapshotDropsPanelRepeat(t *testing.T) {
+	frame := data.NewFrame("cpu", data.NewField("value", nil, []float64{42}))
+	resp := &backend.QueryDataResponse{Responses: backend.Responses{"A": {Frames: data.Frames{frame}}}}
+	panelJSON := json.RawMessage(`{"type":"timeseries","title":"CPU $host","repeat":"host","repeatDirection":"h","maxPerRow":2}`)
+
+	blob, err := NewBundler().Build(resp, &harcapture.Buffer{}, panelJSON, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	snap := string(readTarGz(t, blob)["snapshot-backend.json"])
+	require.NotContains(t, snap, "repeat")
+	require.NotContains(t, snap, "repeatDirection")
+	require.NotContains(t, snap, "maxPerRow")
+	// The title is kept verbatim, unresolved variable and all: it says more about what was captured
+	// than the blank the repeat processor would have substituted.
+	require.Contains(t, snap, `"CPU $host"`)
+}
+
+// A panel model that isn't a JSON object at all must cost only the panel's viz, never the snapshot:
+// the frames are the point of the artifact.
+func TestBundler_Build_snapshotFallsBackOnMalformedPanelJSON(t *testing.T) {
+	frame := data.NewFrame("cpu", data.NewField("value", nil, []float64{42}))
+	resp := &backend.QueryDataResponse{Responses: backend.Responses{"A": {Frames: data.Frames{frame}}}}
+
+	for name, panelJSON := range map[string]json.RawMessage{
+		"not json":           json.RawMessage(`{"type":`),
+		"array":              json.RawMessage(`[{"type":"stat"}]`),
+		"v2 spec not object": json.RawMessage(`{"kind":"Panel","spec":"nonsense"}`),
+	} {
+		t.Run(name, func(t *testing.T) {
+			blob, err := NewBundler().Build(resp, &harcapture.Buffer{}, panelJSON, nil, nil, nil, nil)
+			require.NoError(t, err)
+
+			files := readTarGz(t, blob)
+			require.Contains(t, files, "snapshot-backend.json", "a bad panel model must not lose the snapshot")
+			require.NotContains(t, files, "snapshot-backend-error.txt")
+
+			var dash struct {
+				Panels []struct {
+					Type    string `json:"type"`
+					Targets []struct {
+						QueryType string            `json:"queryType"`
+						Snapshot  []json.RawMessage `json:"snapshot"`
+					} `json:"targets"`
+				} `json:"panels"`
+			}
+			require.NoError(t, json.Unmarshal(files["snapshot-backend.json"], &dash))
+			require.Len(t, dash.Panels, 1)
+			require.Equal(t, "timeseries", dash.Panels[0].Type, "falls back to a minimal panel")
+			require.Len(t, dash.Panels[0].Targets, 1)
+			require.Equal(t, "snapshot", dash.Panels[0].Targets[0].QueryType)
+			require.NotEmpty(t, dash.Panels[0].Targets[0].Snapshot, "the frames still make it in")
+		})
+	}
+}
+
+// A v2 LibraryPanel element's spec is only {id, title, libraryPanel} -- the viz lives in the library.
+// The library REF must stay out of the artifact (an import would otherwise resolve the panel from a uid
+// the reader's Grafana doesn't have, discarding the baked frames); the viz type is unavoidably lost, so
+// the frames render with the fallback.
+func TestBundler_Build_snapshotDropsV2LibraryPanelRef(t *testing.T) {
+	frame := data.NewFrame("cpu", data.NewField("value", nil, []float64{42}))
+	resp := &backend.QueryDataResponse{Responses: backend.Responses{"A": {Frames: data.Frames{frame}}}}
+	panelJSON := json.RawMessage(`{"kind":"LibraryPanel","spec":{"id":4,"title":"Shared CPU","libraryPanel":{"uid":"lib-1","name":"Shared CPU"}}}`)
+
+	blob, err := NewBundler().Build(resp, &harcapture.Buffer{}, panelJSON, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	files := readTarGz(t, blob)
+	snap := string(files["snapshot-backend.json"])
+	require.NotContains(t, snap, "libraryPanel")
+	require.NotContains(t, snap, "lib-1")
+
+	var dash struct {
+		Panels []struct {
+			Type  string `json:"type"`
+			Title string `json:"title"`
+		} `json:"panels"`
+	}
+	require.NoError(t, json.Unmarshal(files["snapshot-backend.json"], &dash))
+	require.Equal(t, "Shared CPU", dash.Panels[0].Title, "identity survives")
+	require.Equal(t, "timeseries", dash.Panels[0].Type, "the viz is not in the dashboard model to recover")
+	require.Contains(t, snap, "42", "the frames are what the artifact is for")
 }
 
 func TestBundler_Build_recordsQueryDataRequest(t *testing.T) {
@@ -897,7 +985,7 @@ func TestBuildDashboard_writesSnapshotPerPanel(t *testing.T) {
 	var m dashboardManifest
 	require.NoError(t, json.Unmarshal(files["manifest.json"], &m))
 	require.Len(t, m.Panels, 1)
-	require.Positive(t, m.Panels[0].SnapshotBytes, "manifest records the snapshot size")
+	require.Positive(t, m.Panels[0].SnapshotBackendBytes, "manifest records the snapshot size")
 }
 
 // The per-panel time range comes from that panel's own submitted request.
@@ -973,14 +1061,88 @@ func TestBuildDashboard_snapshotSharesQueryDataBudget(t *testing.T) {
 
 	var m dashboardManifest
 	require.NoError(t, json.Unmarshal(files["manifest.json"], &m))
-	var dropped int
+	// Two distinct reasons a snapshot is dropped for budget, and the manifest has to tell them apart:
+	// the artifact was built and didn't fit what was left, or the budget was already too spent to try.
+	// Asserting only on "budget" would pass with either message, so neither path would be pinned. These
+	// panels are large enough that the budget drains in ~8MB steps and never lands under the minimum,
+	// so this fixture exercises the exceeded path; the default case fails on anything else.
+	var exceeded, belowMinimum int
 	for _, p := range m.Panels {
-		if p.SnapshotError != "" {
-			dropped++
-			require.Contains(t, p.SnapshotError, "budget")
+		switch {
+		case p.SnapshotBackendError == "":
+		case strings.Contains(p.SnapshotBackendError, "exceeded the remaining dashboard query-data budget"):
+			exceeded++
+		case strings.Contains(p.SnapshotBackendError, "below the"):
+			belowMinimum++
+		default:
+			t.Fatalf("unexpected snapshotBackendError: %q", p.SnapshotBackendError)
 		}
 	}
-	require.Positive(t, dropped, "the panels past the budget record why their snapshot is missing")
+	require.Positive(t, exceeded, "a snapshot that outgrew what the budget had left says so")
+	require.Zero(t, belowMinimum)
+}
+
+// BuildDashboard's snapshot gate keys off having FRAMES, not a non-nil response, so that a panel with
+// nothing to bake is never reported as one whose snapshot was dropped for budget. Tested directly: the
+// difference only shows in the manifest once the shared budget has drained below the minimum artifact
+// size, which takes ~32MB of artifacts to reach and is impractical to stage as a fixture.
+func TestHasSnapshotFrames(t *testing.T) {
+	frame := data.NewFrame("cpu", data.NewField("value", nil, []float64{42}))
+
+	for name, tc := range map[string]struct {
+		resp *backend.QueryDataResponse
+		want bool
+	}{
+		"nil response": {resp: nil, want: false},
+		"error only, no frames": {resp: &backend.QueryDataResponse{Responses: backend.Responses{
+			"A": {Error: errors.New("datasource exploded")},
+		}}, want: false},
+		"empty frame slice": {resp: &backend.QueryDataResponse{Responses: backend.Responses{
+			"A": {Frames: data.Frames{}},
+		}}, want: false},
+		"only a nil frame": {resp: &backend.QueryDataResponse{Responses: backend.Responses{
+			"A": {Frames: data.Frames{nil}},
+		}}, want: false},
+		"capture frames only": {resp: &backend.QueryDataResponse{Responses: backend.Responses{
+			"__har__P1": {Frames: data.Frames{frame}},
+		}}, want: false},
+		"one real frame": {resp: &backend.QueryDataResponse{Responses: backend.Responses{
+			"A": {Frames: data.Frames{frame}},
+		}}, want: true},
+		"real frame beside a failed refID": {resp: &backend.QueryDataResponse{Responses: backend.Responses{
+			"A": {Error: errors.New("boom")},
+			"B": {Frames: data.Frames{frame}},
+		}}, want: true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.want, hasSnapshotFrames(tc.resp))
+		})
+	}
+}
+
+// A panel whose queries all failed has a response but no frames: nothing to bake, which is not a
+// snapshot failure. Nothing is written and the manifest stays silent about it -- the query failure is
+// recorded as the panel's error, where a reader expects it.
+func TestBuildDashboard_noSnapshotForFramelessResponse(t *testing.T) {
+	panels := []DashboardPanel{{
+		ID:    99,
+		Title: "Broken",
+		Resp: &backend.QueryDataResponse{Responses: backend.Responses{
+			"A": {Error: errors.New("datasource exploded")},
+		}},
+	}}
+
+	blob, err := NewBundler().BuildDashboard(nil, panels)
+	require.NoError(t, err)
+
+	files := readTarGz(t, blob)
+	require.NotContains(t, files, "panels/99-broken/snapshot-backend.json")
+
+	var m dashboardManifest
+	require.NoError(t, json.Unmarshal(files["manifest.json"], &m))
+	require.Len(t, m.Panels, 1)
+	require.Empty(t, m.Panels[0].SnapshotBackendError, "no frames to bake is not a snapshot failure")
+	require.Zero(t, m.Panels[0].SnapshotBackendBytes)
 }
 
 func TestBuildDashboard_boundsAggregateQueryData(t *testing.T) {

--- a/pkg/services/diagnostics/diagnostics_test.go
+++ b/pkg/services/diagnostics/diagnostics_test.go
@@ -284,7 +284,7 @@ func TestBundler_Build_snapshotFlattensV2PanelElement(t *testing.T) {
 			"description": "how busy",
 			"data": {"kind": "QueryGroup", "spec": {
 				"queries": [{"kind": "PanelQuery", "spec": {"refId": "A", "query": {"kind": "prometheus", "group": "prometheus", "datasource": {"name": "prom-x"}, "spec": {"expr": "up"}}}}],
-				"transformations": [{"kind": "reduce", "group": "reduce", "spec": {"options": {}}}],
+				"transformations": [{"kind": "reduce", "spec": {"id": "reduce", "options": {"reducers": ["mean"]}}}],
 				"queryOptions": {}
 			}},
 			"vizConfig": {"kind": "VizConfig", "group": "stat", "version": "11.0.0", "spec": {
@@ -313,6 +313,12 @@ func TestBundler_Build_snapshotFlattensV2PanelElement(t *testing.T) {
 					Unit string `json:"unit"`
 				} `json:"defaults"`
 			} `json:"fieldConfig"`
+			Transformations []struct {
+				ID      string `json:"id"`
+				Options struct {
+					Reducers []string `json:"reducers"`
+				} `json:"options"`
+			} `json:"transformations"`
 		} `json:"panels"`
 	}
 	require.NoError(t, json.Unmarshal(files["snapshot-backend.json"], &dash))
@@ -322,9 +328,15 @@ func TestBundler_Build_snapshotFlattensV2PanelElement(t *testing.T) {
 	require.Equal(t, "11.0.0", dash.Panels[0].PluginVersion)
 	require.Equal(t, "value", dash.Panels[0].Options.ColorMode)
 	require.Equal(t, "percent", dash.Panels[0].FieldConfig.Defaults.Unit)
+	// The v2 pipeline comes across as v1 transformations, so a v2 dashboard's snapshot is as explorable
+	// as a v1 one. Each entry's spec is already a v1 DataTransformerConfig; only the {kind, spec} wrapper
+	// is left behind.
+	require.Len(t, dash.Panels[0].Transformations, 1)
+	require.Equal(t, "reduce", dash.Panels[0].Transformations[0].ID)
+	require.Equal(t, []string{"mean"}, dash.Panels[0].Transformations[0].Options.Reducers)
 	require.NotContains(t, snap, "prom-x", "the v2 query's datasource is not carried into the artifact")
 	require.NotContains(t, snap, "vizConfig", "the v2 wrapper is translated, not copied")
-	require.NotContains(t, snap, `"spec"`)
+	require.NotContains(t, snap, `"spec"`, "no v2 wrapper survives, transformations included")
 }
 
 // v2alpha1 named the plugin in vizConfig.kind before it moved to vizConfig.group.
@@ -346,12 +358,11 @@ func TestBundler_Build_snapshotFlattensV2AlphaPanelElement(t *testing.T) {
 }
 
 // A library-panel ref would make the import resolve the panel from a uid the reader's Grafana doesn't
-// have, discarding the baked targets. Transformations are dropped too: the baked frames are the
-// plugin's output before frontend processing.
-func TestBundler_Build_snapshotDropsLibraryPanelAndTransformations(t *testing.T) {
+// have, discarding the baked targets. snapshotData is stale v1 panel state the baked target replaces.
+func TestBundler_Build_snapshotDropsLibraryPanelRef(t *testing.T) {
 	frame := data.NewFrame("cpu", data.NewField("value", nil, []float64{42}))
 	resp := &backend.QueryDataResponse{Responses: backend.Responses{"A": {Frames: data.Frames{frame}}}}
-	panelJSON := json.RawMessage(`{"type":"stat","title":"CPU","libraryPanel":{"uid":"lib-1","name":"Shared CPU"},"transformations":[{"id":"reduce","options":{}}],"snapshotData":[]}`)
+	panelJSON := json.RawMessage(`{"type":"stat","title":"CPU","libraryPanel":{"uid":"lib-1","name":"Shared CPU"},"snapshotData":[]}`)
 
 	blob, err := NewBundler().Build(resp, &harcapture.Buffer{}, panelJSON, nil, nil, nil, nil)
 	require.NoError(t, err)
@@ -359,9 +370,38 @@ func TestBundler_Build_snapshotDropsLibraryPanelAndTransformations(t *testing.T)
 	snap := string(readTarGz(t, blob)["snapshot-backend.json"])
 	require.NotContains(t, snap, "libraryPanel")
 	require.NotContains(t, snap, "lib-1")
-	require.NotContains(t, snap, "transformations")
 	require.NotContains(t, snap, "snapshotData")
 	require.Contains(t, snap, `"stat"`, "the rest of the panel model still contributes")
+}
+
+// Transformations are KEPT, unlike every other stripped field. snapshot-backend.json is the explorable
+// copy: frames frozen at the plugin's output with the transform config on top, so a reader can re-run
+// and tweak the pipeline against real data. The frozen "what the user saw" view is
+// snapshot-rendered.json's job, and a divergence between the two is itself a finding -- stripping here
+// would erase that signal, since the two would differ whenever the panel has any transform at all.
+func TestBundler_Build_snapshotKeepsTransformations(t *testing.T) {
+	frame := data.NewFrame("cpu", data.NewField("value", nil, []float64{42}))
+	resp := &backend.QueryDataResponse{Responses: backend.Responses{"A": {Frames: data.Frames{frame}}}}
+	panelJSON := json.RawMessage(`{"type":"stat","title":"CPU","transformations":[{"id":"reduce","options":{"reducers":["mean"]}}]}`)
+
+	blob, err := NewBundler().Build(resp, &harcapture.Buffer{}, panelJSON, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	var dash struct {
+		Panels []struct {
+			Transformations []struct {
+				ID      string `json:"id"`
+				Options struct {
+					Reducers []string `json:"reducers"`
+				} `json:"options"`
+			} `json:"transformations"`
+		} `json:"panels"`
+	}
+	require.NoError(t, json.Unmarshal(readTarGz(t, blob)["snapshot-backend.json"], &dash))
+	require.Len(t, dash.Panels[0].Transformations, 1, "the transform config rides along with the frames")
+	require.Equal(t, "reduce", dash.Panels[0].Transformations[0].ID)
+	require.Equal(t, []string{"mean"}, dash.Panels[0].Transformations[0].Options.Reducers,
+		"carried verbatim, so re-running it in the import reproduces the panel's pipeline")
 }
 
 // A frame the SDK cannot encode costs only the snapshot: querydata.json still ships (degraded), and

--- a/pkg/services/diagnostics/diagnostics_test.go
+++ b/pkg/services/diagnostics/diagnostics_test.go
@@ -93,6 +93,70 @@ func TestBundler_Build_recordsQueryDataResponse(t *testing.T) {
 	require.Contains(t, string(files["querydata.json"]), `42`)
 }
 
+func TestBundler_Build_writesSnapshotBackend(t *testing.T) {
+	// The snapshot must render the returned frames OFFLINE: a Grafana-datasource snapshot query
+	// carrying the frame, with no reference to the original datasource.
+	frame := data.NewFrame("cpu", data.NewField("value", nil, []float64{42}))
+	resp := &backend.QueryDataResponse{Responses: backend.Responses{
+		"A": {Frames: data.Frames{frame}},
+	}}
+
+	blob, err := NewBundler().Build(resp, &harcapture.Buffer{}, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	files := readTarGz(t, blob)
+	require.Contains(t, files, "snapshot-backend.json")
+
+	var dash struct {
+		Panels []struct {
+			Datasource struct {
+				UID string `json:"uid"`
+			} `json:"datasource"`
+			Targets []struct {
+				QueryType  string `json:"queryType"`
+				Datasource struct {
+					UID string `json:"uid"`
+				} `json:"datasource"`
+				Snapshot []json.RawMessage `json:"snapshot"`
+			} `json:"targets"`
+		} `json:"panels"`
+	}
+	require.NoError(t, json.Unmarshal(files["snapshot-backend.json"], &dash))
+	require.Len(t, dash.Panels, 1)
+	require.Equal(t, "grafana", dash.Panels[0].Datasource.UID, "panel points at the Grafana snapshot datasource")
+	require.Len(t, dash.Panels[0].Targets, 1)
+	require.Equal(t, "snapshot", dash.Panels[0].Targets[0].QueryType)
+	require.Equal(t, "grafana", dash.Panels[0].Targets[0].Datasource.UID)
+	require.NotEmpty(t, dash.Panels[0].Targets[0].Snapshot, "baked frames are present")
+	require.Contains(t, string(files["snapshot-backend.json"]), "42", "the baked value is carried")
+}
+
+func TestBundler_Build_snapshotKeepsPanelVizButOverridesDatasource(t *testing.T) {
+	// A supplied panel model contributes its viz/config, but its live datasource + targets are
+	// replaced so the imported snapshot can never re-query.
+	frame := data.NewFrame("cpu", data.NewField("value", nil, []float64{7}))
+	resp := &backend.QueryDataResponse{Responses: backend.Responses{"A": {Frames: data.Frames{frame}}}}
+	panelJSON := json.RawMessage(`{"type":"stat","title":"CPU","datasource":{"type":"prometheus","uid":"prom-x"},"targets":[{"refId":"A","expr":"up"}]}`)
+
+	blob, err := NewBundler().Build(resp, &harcapture.Buffer{}, panelJSON, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	files := readTarGz(t, blob)
+	snap := string(files["snapshot-backend.json"])
+	require.Contains(t, snap, `"stat"`, "keeps the panel viz type")
+	require.NotContains(t, snap, "prom-x", "the original datasource is replaced")
+	require.NotContains(t, snap, `"expr"`, "the live query is replaced by the snapshot query")
+}
+
+func TestBundler_Build_noSnapshotWithoutResponse(t *testing.T) {
+	// A request-only bundle (no response) has no frames to bake, so no snapshot is written.
+	blob, err := NewBundler().Build(nil, &harcapture.Buffer{}, nil, nil, json.RawMessage(`{"queries":[]}`), nil, nil)
+	require.NoError(t, err)
+
+	files := readTarGz(t, blob)
+	require.NotContains(t, files, "snapshot-backend.json")
+}
+
 func TestBundler_Build_recordsQueryDataRequest(t *testing.T) {
 	request := json.RawMessage(`{"from":"now-1h","to":"now","queries":[{"refId":"A","expr":"up"}]}`)
 
@@ -573,6 +637,30 @@ func TestBuildDashboard_recordsQueryDataPerPanel(t *testing.T) {
 	require.Contains(t, files, "panels/1-cpu-usage/querydata.json")
 	require.Contains(t, string(files["panels/1-cpu-usage/querydata.json"]), `"refId": "A"`)
 	require.Contains(t, string(files["panels/1-cpu-usage/querydata.json"]), `42`)
+}
+
+func TestBuildDashboard_writesSnapshotPerPanel(t *testing.T) {
+	frame := data.NewFrame("cpu", data.NewField("value", nil, []float64{42}))
+	panels := []DashboardPanel{{
+		ID:        1,
+		Title:     "CPU Usage",
+		PanelJSON: json.RawMessage(`{"id":1,"type":"timeseries"}`),
+		Resp:      &backend.QueryDataResponse{Responses: backend.Responses{"A": {Frames: data.Frames{frame}}}},
+	}}
+
+	blob, err := NewBundler().BuildDashboard(nil, panels)
+	require.NoError(t, err)
+
+	files := readTarGz(t, blob)
+	require.Contains(t, files, "panels/1-cpu-usage/snapshot-backend.json")
+	snap := string(files["panels/1-cpu-usage/snapshot-backend.json"])
+	require.Contains(t, snap, `"queryType": "snapshot"`)
+	require.Contains(t, snap, "42", "baked value present")
+
+	var m dashboardManifest
+	require.NoError(t, json.Unmarshal(files["manifest.json"], &m))
+	require.Len(t, m.Panels, 1)
+	require.Positive(t, m.Panels[0].SnapshotBytes, "manifest records the snapshot size")
 }
 
 func TestBuildDashboard_boundsAggregateQueryData(t *testing.T) {

--- a/pkg/services/diagnostics/diagnostics_test.go
+++ b/pkg/services/diagnostics/diagnostics_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/grafana/apps/dashboard/pkg/migration/schemaversion"
 	"github.com/grafana/grafana/pkg/infra/httpclient/harcapture"
 )
 
@@ -129,6 +130,30 @@ func TestBundler_Build_writesSnapshotBackend(t *testing.T) {
 	require.Equal(t, "grafana", dash.Panels[0].Targets[0].Datasource.UID)
 	require.NotEmpty(t, dash.Panels[0].Targets[0].Snapshot, "baked frames are present")
 	require.Contains(t, string(files["snapshot-backend.json"]), "42", "the baked value is carried")
+}
+
+// The dashboard scaffold around the panel, which nothing else asserts. schemaVersion is the load-bearing
+// one: it decides whether an import runs migrations over the panel model. The client sends a save model
+// already migrated to the frontend's current version, so the artifact must claim the same version --
+// understating it re-runs migrations over an already-migrated panel, and there is no cheap way to notice
+// either mistake from the rendered result.
+func TestBundler_Build_snapshotDashboardScaffold(t *testing.T) {
+	frame := data.NewFrame("cpu", data.NewField("value", nil, []float64{42}))
+	resp := &backend.QueryDataResponse{Responses: backend.Responses{"A": {Frames: data.Frames{frame}}}}
+
+	blob, err := NewBundler().Build(resp, &harcapture.Buffer{}, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	var dash struct {
+		SchemaVersion int    `json:"schemaVersion"`
+		Title         string `json:"title"`
+		Editable      bool   `json:"editable"`
+	}
+	require.NoError(t, json.Unmarshal(readTarGz(t, blob)["snapshot-backend.json"], &dash))
+	require.Equal(t, schemaversion.LATEST_VERSION, dash.SchemaVersion,
+		"the baked dashboard claims the schema version the client's save model is already at")
+	require.Equal(t, snapshotArtifactTitle, dash.Title)
+	require.True(t, dash.Editable, "a support engineer has to be able to poke at the imported panel")
 }
 
 func TestBundler_Build_snapshotKeepsPanelVizButOverridesDatasource(t *testing.T) {

--- a/pkg/services/diagnostics/diagnostics_test.go
+++ b/pkg/services/diagnostics/diagnostics_test.go
@@ -370,6 +370,30 @@ func TestBundler_Build_recordsOversizedSnapshot(t *testing.T) {
 	require.Contains(t, string(files["snapshot-error.txt"]), "exceeded")
 }
 
+// A panel-level time override must not survive into the snapshot: the client reads the submitted range
+// from the panel's EFFECTIVE range, so the override is already resolved into the absolute timestamps
+// baked into the dashboard. Keeping it applies the override twice -- a timeShift moves the panel's
+// window off the frames entirely and it renders empty.
+func TestBundler_Build_snapshotDropsPanelTimeOverride(t *testing.T) {
+	frame := data.NewFrame("cpu", data.NewField("value", nil, []float64{42}))
+	resp := &backend.QueryDataResponse{Responses: backend.Responses{"A": {Frames: data.Frames{frame}}}}
+	panelJSON := json.RawMessage(`{"type":"timeseries","title":"CPU","timeFrom":"5m","timeShift":"1d","timeCompare":"1h","hideTimeOverride":true}`)
+	// The submitted range is the shifted one the panel actually queried.
+	request := json.RawMessage(`{"from":"1690000000000","to":"1690003600000","queries":[{"refId":"A"}]}`)
+
+	blob, err := NewBundler().Build(resp, &harcapture.Buffer{}, panelJSON, nil, request, nil, nil)
+	require.NoError(t, err)
+
+	snap := string(readTarGz(t, blob)["snapshot-backend.json"])
+	require.NotContains(t, snap, "timeFrom")
+	require.NotContains(t, snap, "timeShift")
+	require.NotContains(t, snap, "timeCompare")
+	require.NotContains(t, snap, "hideTimeOverride")
+	// The baked range still stands on its own, and the rest of the panel model survives.
+	require.Contains(t, snap, `"from": "`+time.UnixMilli(1690000000000).UTC().Format(time.RFC3339Nano)+`"`)
+	require.Contains(t, snap, `"CPU"`)
+}
+
 func TestBundler_Build_recordsQueryDataRequest(t *testing.T) {
 	request := json.RawMessage(`{"from":"now-1h","to":"now","queries":[{"refId":"A","expr":"up"}]}`)
 


### PR DESCRIPTION
Part of the on-premise enhanced diagnostics effort (grafana/data-sources#1268) — offline visual reproduction (WMD7 / G14), backend half.

Bakes the backend `QueryDataResponse` frames into an importable, data-baked Grafana dashboard `snapshot-backend.json` (a `grafana`-datasource `snapshot` query), for single-panel **and** per-panel dashboard bundles. A support engineer with no access to the customer's Grafana/datasource can import it and **see** the plugin's output rendered offline — no live datasource, no query re-run. Bounded by the per-panel + shared dashboard budget; manifest records `snapshotBytes`/`snapshotError`.

The rendered (post-transform) counterpart `snapshot-rendered.json` is a separate follow-up PR (frontend half).

Experimental, behind `grafana.onDemandDiagnostics` (off by default), on-prem only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
