### PR TITLE
Datasources: Add backend unit tests for query diagnostics

### DIFF
--- a/pkg/api/ds_query_diagnostics_test.go
+++ b/pkg/api/ds_query_diagnostics_test.go
@@ -1,13 +1,26 @@
 package api
 
 import (
+	"context"
 	"errors"
 	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	backend "github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/contexthandler/ctxkey"
+	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/datasources"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/query"
+	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/grafana/grafana/pkg/web"
 )
 
 // TestDiagnosticsNoCaptureError guards the status mapping used when a query fails and no HAR was
@@ -42,4 +55,105 @@ func TestDiagnosticsNoCaptureError(t *testing.T) {
 	t.Run("no failure proceeds to bundle assembly (nil)", func(t *testing.T) {
 		require.Nil(t, hs.diagnosticsNoCaptureError(nil, nil))
 	})
+}
+
+// newDiagReqCtx builds a ReqContext posting body to /api/ds/diagnostics, wired into its own request
+// context via ctxkey.Key{} exactly as the real ContextHandler middleware does. Returns the recorder
+// backing c.Resp so a WriteTo can be inspected for headers + body.
+func newDiagReqCtx(t *testing.T, body string, headers map[string]string) (*contextmodel.ReqContext, *httptest.ResponseRecorder) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, "/api/ds/diagnostics", strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	rec := httptest.NewRecorder()
+	c := &contextmodel.ReqContext{
+		Context: &web.Context{
+			Req:  req,
+			Resp: web.NewResponseWriter(req.Method, rec),
+		},
+		SignedInUser: &user.SignedInUser{OrgID: 1, UserUID: "u1"},
+		Logger:       log.New("test"),
+	}
+	req = req.WithContext(context.WithValue(req.Context(), ctxkey.Key{}, c))
+	c.Req = req
+	return c, rec
+}
+
+// diagHARResponse is a QueryData result with a normal refID A frame plus a synthetic __har__ frame
+// carrying a parseable HAR with one entry — so HasCapturedHAR is true and traffic.har is non-empty.
+func diagHARResponse() *backend.QueryDataResponse {
+	r := backend.NewQueryDataResponse()
+	r.Responses["A"] = backend.DataResponse{Frames: data.Frames{data.NewFrame("cpu", data.NewField("v", nil, []float64{1}))}}
+	capture := data.NewFrame("")
+	capture.Meta = &data.FrameMeta{Custom: map[string]interface{}{
+		"har": `{"log":{"entries":[{"request":{"method":"GET","url":"http://x/api"},"response":{"status":200}}]}}`,
+	}}
+	r.Responses["__har__A"] = backend.DataResponse{Frames: data.Frames{capture}}
+	return r
+}
+
+func TestQueryDiagnostics_flagOff_returns404(t *testing.T) {
+	setupOpenFeatureFlag(t, featuremgmt.FlagGrafanaOnDemandDiagnostics, false)
+	hs := &HTTPServer{queryDataService: query.NewFakeQueryService(t)}
+	c, _ := newDiagReqCtx(t, `{"queries":[{"refId":"A"}]}`, nil)
+	require.Equal(t, http.StatusNotFound, hs.QueryDiagnostics(c).Status())
+}
+
+func TestQueryDiagnostics_noQueries_returns400(t *testing.T) {
+	setupOpenFeatureFlag(t, featuremgmt.FlagGrafanaOnDemandDiagnostics, true)
+	hs := &HTTPServer{queryDataService: query.NewFakeQueryService(t)}
+	c, _ := newDiagReqCtx(t, `{"queries":[]}`, nil)
+	require.Equal(t, http.StatusBadRequest, hs.QueryDiagnostics(c).Status())
+}
+
+func TestQueryDiagnostics_success_bundleHeadersAndSkipCache(t *testing.T) {
+	setupOpenFeatureFlag(t, featuremgmt.FlagGrafanaOnDemandDiagnostics, true)
+	fakeQuery := query.NewFakeQueryService(t)
+	fakeQuery.On("QueryData", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(diagHARResponse(), nil)
+	hs := &HTTPServer{queryDataService: fakeQuery}
+	c, rec := newDiagReqCtx(t, `{"queries":[{"refId":"A","datasource":{"uid":"prom"}}]}`, nil)
+
+	resp := hs.QueryDiagnostics(c)
+	require.Equal(t, http.StatusOK, resp.Status())
+	require.True(t, c.SkipQueryCache, "diagnostics must force a live query so HAR capture sees the wire")
+
+	resp.WriteTo(c)
+	require.Equal(t, "application/tar+gzip", rec.Header().Get("Content-Type"))
+	require.Regexp(t, `^attachment; filename="diagnostics-\d{8}-\d{6}\.tar\.gz"$`, rec.Header().Get("Content-Disposition"))
+
+	files := readTarGzFiles(t, rec.Body.Bytes())
+	require.Contains(t, files, "querydata.json")
+	require.Contains(t, files, "traffic.har")
+	require.Contains(t, string(files["querydata.json"]), `"A"`, "the submitted refID must be recorded")
+}
+
+func TestQueryDiagnostics_queryV2Dispatch(t *testing.T) {
+	setupOpenFeatureFlag(t, featuremgmt.FlagGrafanaOnDemandDiagnostics, true)
+	fakeQuery := query.NewFakeQueryService(t)
+	// Only QueryDataNew is stubbed; had the handler dispatched to QueryData the mock would fail the test.
+	fakeQuery.On("QueryDataNew", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(diagHARResponse(), nil)
+	hs := &HTTPServer{queryDataService: fakeQuery}
+	c, _ := newDiagReqCtx(t, `{"queries":[{"refId":"A"}]}`, map[string]string{"X-Query-V2": "true"})
+
+	require.Equal(t, http.StatusOK, hs.QueryDiagnostics(c).Status())
+	fakeQuery.AssertCalled(t, "QueryDataNew", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestQueryDiagnostics_noCapturePerRefIDError_returns400(t *testing.T) {
+	setupOpenFeatureFlag(t, featuremgmt.FlagGrafanaOnDemandDiagnostics, true)
+	fakeQuery := query.NewFakeQueryService(t)
+	errResp := backend.NewQueryDataResponse()
+	errResp.Responses["A"] = backend.DataResponse{Error: errors.New("bad promql")}
+	fakeQuery.On("QueryData", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(errResp, nil)
+	hs := &HTTPServer{queryDataService: fakeQuery}
+	c, _ := newDiagReqCtx(t, `{"queries":[{"refId":"A"}]}`, nil)
+
+	// No HAR captured + a per-refID error -> bare 400, no bundle (matches QueryMetricsV2's per-refID handling).
+	require.Equal(t, http.StatusBadRequest, hs.QueryDiagnostics(c).Status())
 }

--- a/pkg/api/ds_query_diagnostics_test.go
+++ b/pkg/api/ds_query_diagnostics_test.go
@@ -119,8 +119,15 @@ func TestQueryDiagnostics_flagOff_returns404(t *testing.T) {
 func TestQueryDiagnostics_noQueries_returns400(t *testing.T) {
 	setupOpenFeatureFlag(t, featuremgmt.FlagGrafanaOnDemandDiagnostics, true)
 	hs := &HTTPServer{queryDataService: query.NewFakeQueryService(t)}
-	c, _ := newDiagReqCtx(t, `{"queries":[]}`, nil)
-	require.Equal(t, http.StatusBadRequest, hs.QueryDiagnostics(c).Status())
+	c, rec := newDiagReqCtx(t, `{"queries":[]}`, nil)
+
+	resp := hs.QueryDiagnostics(c)
+	require.Equal(t, http.StatusBadRequest, resp.Status())
+
+	// Assert the message, not just the status: a binding failure is also a 400, so a bare status check
+	// would pass even if the body never bound and the empty-queries guard was never reached.
+	resp.WriteTo(c)
+	require.Contains(t, rec.Body.String(), "at least one query is required")
 }
 
 func TestQueryDiagnostics_success_bundleHeadersAndSkipCache(t *testing.T) {
@@ -140,11 +147,37 @@ func TestQueryDiagnostics_success_bundleHeadersAndSkipCache(t *testing.T) {
 
 	files := readTarGzFiles(t, rec.Body.Bytes())
 	require.Contains(t, files, "querydata.json")
-	require.Contains(t, files, "traffic.har")
+	require.Contains(t, string(files["traffic.har"]), "http://x/api", "the captured entry must reach traffic.har")
 	// Assert on the datasource uid, not the refID: the mocked response carries refID "A" too, so a
 	// `"A"` match would still pass if the handler dropped the submitted request entirely. "prom" only
 	// appears in the request the client posted.
 	require.Contains(t, string(files["querydata.json"]), `"uid": "prom"`, "the submitted request must be recorded")
+}
+
+// TestQueryDiagnostics_capturedTrafficWithQueryError_stillBundles covers the fall-through the
+// no-capture guard exists to allow: a query that failed AFTER reaching the wire leaves captured
+// traffic, and that captured failure is exactly what the bundle is for — so it must ship as a 200
+// bundle with query-error.txt, not the bare 400 the no-capture path returns.
+func TestQueryDiagnostics_capturedTrafficWithQueryError_stillBundles(t *testing.T) {
+	setupOpenFeatureFlag(t, featuremgmt.FlagGrafanaOnDemandDiagnostics, true)
+	fakeQuery := query.NewFakeQueryService(t)
+	fakeQuery.On("QueryData", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(func(context.Context, identity.Requester, bool, dtos.MetricRequest) (*backend.QueryDataResponse, error) {
+			r := diagHARResponse()
+			// Same per-refID failure as the no-capture case, but this time traffic was captured.
+			r.Responses["A"] = backend.DataResponse{Error: errors.New("bad promql")}
+			return r, nil
+		})
+	hs := &HTTPServer{queryDataService: fakeQuery}
+	c, rec := newDiagReqCtx(t, `{"queries":[{"refId":"A"}]}`, nil)
+
+	resp := hs.QueryDiagnostics(c)
+	require.Equal(t, http.StatusOK, resp.Status(), "a failure that hit the wire must still ship its captured traffic")
+
+	resp.WriteTo(c)
+	files := readTarGzFiles(t, rec.Body.Bytes())
+	require.Contains(t, string(files["traffic.har"]), "http://x/api")
+	require.Contains(t, string(files["query-error.txt"]), "bad promql", "the failure must be recorded in the bundle")
 }
 
 func TestQueryDiagnostics_queryV2Dispatch(t *testing.T) {

--- a/pkg/api/ds_query_diagnostics_test.go
+++ b/pkg/api/ds_query_diagnostics_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -15,6 +16,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/infra/httpclient/harcapture"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/contexthandler/ctxkey"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
@@ -130,6 +132,21 @@ func TestQueryDiagnostics_noQueries_returns400(t *testing.T) {
 	require.Contains(t, rec.Body.String(), "at least one query is required")
 }
 
+// TestQueryDiagnostics_unparseableBody_returns400 is the other half of the pair above: the two 400s
+// are distinct guards with distinct messages, so pinning both is what makes either assertion mean
+// something.
+func TestQueryDiagnostics_unparseableBody_returns400(t *testing.T) {
+	setupOpenFeatureFlag(t, featuremgmt.FlagGrafanaOnDemandDiagnostics, true)
+	hs := &HTTPServer{queryDataService: query.NewFakeQueryService(t)}
+	c, rec := newDiagReqCtx(t, `{"queries":`, nil)
+
+	resp := hs.QueryDiagnostics(c)
+	require.Equal(t, http.StatusBadRequest, resp.Status())
+
+	resp.WriteTo(c)
+	require.Contains(t, rec.Body.String(), "bad request data")
+}
+
 func TestQueryDiagnostics_success_bundleHeadersAndSkipCache(t *testing.T) {
 	setupOpenFeatureFlag(t, featuremgmt.FlagGrafanaOnDemandDiagnostics, true)
 	fakeQuery := query.NewFakeQueryService(t)
@@ -178,6 +195,65 @@ func TestQueryDiagnostics_capturedTrafficWithQueryError_stillBundles(t *testing.
 	files := readTarGzFiles(t, rec.Body.Bytes())
 	require.Contains(t, string(files["traffic.har"]), "http://x/api")
 	require.Contains(t, string(files["query-error.txt"]), "bad promql", "the failure must be recorded in the bundle")
+}
+
+// TestQueryDiagnostics_capturesInProcessTraffic pins the capture wiring for CORE datasources — the
+// only capture path that works today, since collectHAR's __har__ frame path stays inert until the
+// SDK-side capture middleware ships (see its doc comment). The handler must hand queryData the
+// harcapture-wrapped context; passing the bare request context instead leaves the buffer empty and
+// traffic.har silently dropped, which no test that supplies capture via a __har__ frame can see.
+func TestQueryDiagnostics_capturesInProcessTraffic(t *testing.T) {
+	setupOpenFeatureFlag(t, featuremgmt.FlagGrafanaOnDemandDiagnostics, true)
+	fakeQuery := query.NewFakeQueryService(t)
+	fakeQuery.On("QueryData", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(func(ctx context.Context, _ identity.Requester, _ bool, _ dtos.MetricRequest) (*backend.QueryDataResponse, error) {
+			// Stands in for the datasource's HTTP round trip: the real capture middleware finds the
+			// buffer on the query context exactly this way.
+			buf := harcapture.FromContext(ctx)
+			require.NotNil(t, buf, "queryData must receive the harcapture-wrapped context")
+			httpReq, err := http.NewRequest(http.MethodGet, "http://prom.example/api/v1/query?query=up", nil)
+			require.NoError(t, err)
+			buf.AddEntry(httpReq, &http.Response{StatusCode: http.StatusOK, Header: http.Header{}}, nil, time.Now(), time.Millisecond)
+
+			r := backend.NewQueryDataResponse()
+			r.Responses["A"] = backend.DataResponse{Frames: data.Frames{data.NewFrame("cpu")}}
+			return r, nil
+		})
+	hs := &HTTPServer{queryDataService: fakeQuery}
+	c, rec := newDiagReqCtx(t, `{"queries":[{"refId":"A"}]}`, nil)
+
+	resp := hs.QueryDiagnostics(c)
+	require.Equal(t, http.StatusOK, resp.Status())
+
+	resp.WriteTo(c)
+	files := readTarGzFiles(t, rec.Body.Bytes())
+	require.Contains(t, string(files["traffic.har"]), "prom.example/api/v1/query",
+		"the in-process buffer's entry must reach traffic.har")
+}
+
+// TestQueryDiagnostics_externalPluginSwallowedError_bundlesIt covers the second half of the handler's
+// errors.Join: an externalized (gRPC) plugin returns NO per-refId error — its top-level failure is
+// stashed on the __har__ frame so the captured traffic survives the wire (see
+// diagnostics.PluginCaptureError). Folding in only ResponseError drops it from query-error.txt.
+func TestQueryDiagnostics_externalPluginSwallowedError_bundlesIt(t *testing.T) {
+	setupOpenFeatureFlag(t, featuremgmt.FlagGrafanaOnDemandDiagnostics, true)
+	fakeQuery := query.NewFakeQueryService(t)
+	fakeQuery.On("QueryData", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(func(context.Context, identity.Requester, bool, dtos.MetricRequest) (*backend.QueryDataResponse, error) {
+			r := diagHARResponse()
+			r.Responses["__har__A"].Frames[0].Meta.Custom.(map[string]interface{})["queryError"] = "dial tcp: connection refused"
+			return r, nil
+		})
+	hs := &HTTPServer{queryDataService: fakeQuery}
+	c, rec := newDiagReqCtx(t, `{"queries":[{"refId":"A"}]}`, nil)
+
+	resp := hs.QueryDiagnostics(c)
+	require.Equal(t, http.StatusOK, resp.Status())
+
+	resp.WriteTo(c)
+	files := readTarGzFiles(t, rec.Body.Bytes())
+	require.Contains(t, string(files["query-error.txt"]), "connection refused",
+		"an external plugin's swallowed error must reach query-error.txt")
 }
 
 func TestQueryDiagnostics_queryV2Dispatch(t *testing.T) {

--- a/pkg/api/ds_query_diagnostics_test.go
+++ b/pkg/api/ds_query_diagnostics_test.go
@@ -13,6 +13,8 @@ import (
 
 	backend "github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/grafana/grafana/pkg/api/dtos"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/contexthandler/ctxkey"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
@@ -84,6 +86,9 @@ func newDiagReqCtx(t *testing.T, body string, headers map[string]string) (*conte
 
 // diagHARResponse is a QueryData result with a normal refID A frame plus a synthetic __har__ frame
 // carrying a parseable HAR with one entry — so HasCapturedHAR is true and traffic.har is non-empty.
+//
+// Built fresh per call rather than shared: collectHAR consumes the capture response by deleting it
+// from the map, so handing the same value to two calls would leave the second with no HAR at all.
 func diagHARResponse() *backend.QueryDataResponse {
 	r := backend.NewQueryDataResponse()
 	r.Responses["A"] = backend.DataResponse{Frames: data.Frames{data.NewFrame("cpu", data.NewField("v", nil, []float64{1}))}}
@@ -93,6 +98,15 @@ func diagHARResponse() *backend.QueryDataResponse {
 	}}
 	r.Responses["__har__A"] = backend.DataResponse{Frames: data.Frames{capture}}
 	return r
+}
+
+// returnFreshHARResponse stubs method to hand every call its own diagHARResponse, so a second
+// dispatch can't silently observe a capture frame the first one already consumed.
+func returnFreshHARResponse(fake *query.FakeQueryService, method string) {
+	fake.On(method, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(func(context.Context, identity.Requester, bool, dtos.MetricRequest) (*backend.QueryDataResponse, error) {
+			return diagHARResponse(), nil
+		})
 }
 
 func TestQueryDiagnostics_flagOff_returns404(t *testing.T) {
@@ -112,8 +126,7 @@ func TestQueryDiagnostics_noQueries_returns400(t *testing.T) {
 func TestQueryDiagnostics_success_bundleHeadersAndSkipCache(t *testing.T) {
 	setupOpenFeatureFlag(t, featuremgmt.FlagGrafanaOnDemandDiagnostics, true)
 	fakeQuery := query.NewFakeQueryService(t)
-	fakeQuery.On("QueryData", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-		Return(diagHARResponse(), nil)
+	returnFreshHARResponse(fakeQuery, "QueryData")
 	hs := &HTTPServer{queryDataService: fakeQuery}
 	c, rec := newDiagReqCtx(t, `{"queries":[{"refId":"A","datasource":{"uid":"prom"}}]}`, nil)
 
@@ -128,15 +141,17 @@ func TestQueryDiagnostics_success_bundleHeadersAndSkipCache(t *testing.T) {
 	files := readTarGzFiles(t, rec.Body.Bytes())
 	require.Contains(t, files, "querydata.json")
 	require.Contains(t, files, "traffic.har")
-	require.Contains(t, string(files["querydata.json"]), `"A"`, "the submitted refID must be recorded")
+	// Assert on the datasource uid, not the refID: the mocked response carries refID "A" too, so a
+	// `"A"` match would still pass if the handler dropped the submitted request entirely. "prom" only
+	// appears in the request the client posted.
+	require.Contains(t, string(files["querydata.json"]), `"uid": "prom"`, "the submitted request must be recorded")
 }
 
 func TestQueryDiagnostics_queryV2Dispatch(t *testing.T) {
 	setupOpenFeatureFlag(t, featuremgmt.FlagGrafanaOnDemandDiagnostics, true)
 	fakeQuery := query.NewFakeQueryService(t)
 	// Only QueryDataNew is stubbed; had the handler dispatched to QueryData the mock would fail the test.
-	fakeQuery.On("QueryDataNew", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-		Return(diagHARResponse(), nil)
+	returnFreshHARResponse(fakeQuery, "QueryDataNew")
 	hs := &HTTPServer{queryDataService: fakeQuery}
 	c, _ := newDiagReqCtx(t, `{"queries":[{"refId":"A"}]}`, map[string]string{"X-Query-V2": "true"})
 

--- a/pkg/api/ds_query_diagnostics_test.go
+++ b/pkg/api/ds_query_diagnostics_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/httpclient/harcapture"
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/contexthandler"
 	"github.com/grafana/grafana/pkg/services/contexthandler/ctxkey"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/datasources"
@@ -150,13 +151,29 @@ func TestQueryDiagnostics_unparseableBody_returns400(t *testing.T) {
 func TestQueryDiagnostics_success_bundleHeadersAndSkipCache(t *testing.T) {
 	setupOpenFeatureFlag(t, featuremgmt.FlagGrafanaOnDemandDiagnostics, true)
 	fakeQuery := query.NewFakeQueryService(t)
-	returnFreshHARResponse(fakeQuery, "QueryData")
+	// SkipQueryCache is sampled from INSIDE the query, not after the handler returns: the caching
+	// middleware reads it off the ReqContext while the query runs, so setting the flag after dispatching
+	// would leave cache bypass broken — and a post-hoc `require.True(t, c.SkipQueryCache)` would still
+	// pass. Capturing the ReqContext the query actually saw also pins the handler's claim that it is the
+	// same pointer c, which is what makes mutating c here take effect for this request.
+	var queryReqCtx *contextmodel.ReqContext
+	var skipQueryCacheDuringQuery bool
+	fakeQuery.On("QueryData", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(func(ctx context.Context, _ identity.Requester, _ bool, _ dtos.MetricRequest) (*backend.QueryDataResponse, error) {
+			queryReqCtx = contexthandler.FromContext(ctx)
+			if queryReqCtx != nil {
+				skipQueryCacheDuringQuery = queryReqCtx.SkipQueryCache
+			}
+			return diagHARResponse(), nil
+		})
 	hs := &HTTPServer{queryDataService: fakeQuery}
 	c, rec := newDiagReqCtx(t, `{"queries":[{"refId":"A","datasource":{"uid":"prom"}}]}`, nil)
 
 	resp := hs.QueryDiagnostics(c)
 	require.Equal(t, http.StatusOK, resp.Status())
-	require.True(t, c.SkipQueryCache, "diagnostics must force a live query so HAR capture sees the wire")
+	require.Same(t, c, queryReqCtx, "the query context must carry the same ReqContext the caching middleware reads back")
+	require.True(t, skipQueryCacheDuringQuery,
+		"diagnostics must force a live query BEFORE dispatching, so HAR capture sees the wire")
 
 	resp.WriteTo(c)
 	require.Equal(t, "application/tar+gzip", rec.Header().Get("Content-Type"))
@@ -284,16 +301,33 @@ func TestQueryDiagnostics_externalPluginSwallowedError_bundlesIt(t *testing.T) {
 		"an external plugin's swallowed error must reach query-error.txt")
 }
 
+// TestQueryDiagnostics_queryV2Dispatch pins the header-driven dispatch. The handler compares
+// X-Query-V2 against exactly "true", mirroring QueryMetricsV2, so the negative case is pinned too:
+// loosening the check to any non-empty value would hand Query V2's per-query time ranges to a client
+// that explicitly sent "false", and captured traffic would stop matching the panel.
+//
+// Only the expected method is stubbed per case; a dispatch to the other one fails the test on an
+// unexpected mock call.
 func TestQueryDiagnostics_queryV2Dispatch(t *testing.T) {
-	setupOpenFeatureFlag(t, featuremgmt.FlagGrafanaOnDemandDiagnostics, true)
-	fakeQuery := query.NewFakeQueryService(t)
-	// Only QueryDataNew is stubbed; had the handler dispatched to QueryData the mock would fail the test.
-	returnFreshHARResponse(fakeQuery, "QueryDataNew")
-	hs := &HTTPServer{queryDataService: fakeQuery}
-	c, _ := newDiagReqCtx(t, `{"queries":[{"refId":"A"}]}`, map[string]string{"X-Query-V2": "true"})
+	for _, tc := range []struct {
+		name       string
+		header     string
+		wantMethod string
+	}{
+		{name: `"true" dispatches to QueryDataNew`, header: "true", wantMethod: "QueryDataNew"},
+		{name: "any other value keeps QueryData", header: "false", wantMethod: "QueryData"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			setupOpenFeatureFlag(t, featuremgmt.FlagGrafanaOnDemandDiagnostics, true)
+			fakeQuery := query.NewFakeQueryService(t)
+			returnFreshHARResponse(fakeQuery, tc.wantMethod)
+			hs := &HTTPServer{queryDataService: fakeQuery}
+			c, _ := newDiagReqCtx(t, `{"queries":[{"refId":"A"}]}`, map[string]string{"X-Query-V2": tc.header})
 
-	require.Equal(t, http.StatusOK, hs.QueryDiagnostics(c).Status())
-	fakeQuery.AssertCalled(t, "QueryDataNew", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+			require.Equal(t, http.StatusOK, hs.QueryDiagnostics(c).Status())
+			fakeQuery.AssertCalled(t, tc.wantMethod, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+		})
+	}
 }
 
 func TestQueryDiagnostics_noCapturePerRefIDError_returns400(t *testing.T) {

--- a/pkg/api/ds_query_diagnostics_test.go
+++ b/pkg/api/ds_query_diagnostics_test.go
@@ -171,6 +171,34 @@ func TestQueryDiagnostics_success_bundleHeadersAndSkipCache(t *testing.T) {
 	require.Contains(t, string(files["querydata.json"]), `"uid": "prom"`, "the submitted request must be recorded")
 }
 
+// TestQueryDiagnostics_bundlesPanelAndDashboardJSON pins the passthrough that diagnosticsRequest
+// exists for: the client posts the panel and dashboard definitions it already holds so the bundle
+// doesn't need a dashboard-service lookup. Nothing else asserts these two reach the archive, and
+// they are handed to Build as adjacent same-typed arguments — so a swap would silently ship the
+// dashboard as panel.json and vice versa. The markers are distinct per file for exactly that reason:
+// a shared marker would still match with the two transposed.
+func TestQueryDiagnostics_bundlesPanelAndDashboardJSON(t *testing.T) {
+	setupOpenFeatureFlag(t, featuremgmt.FlagGrafanaOnDemandDiagnostics, true)
+	fakeQuery := query.NewFakeQueryService(t)
+	returnFreshHARResponse(fakeQuery, "QueryData")
+	hs := &HTTPServer{queryDataService: fakeQuery}
+	c, rec := newDiagReqCtx(t, `{
+		"queries":[{"refId":"A"}],
+		"panel":{"id":7,"title":"panel-marker"},
+		"dashboard":{"uid":"d1","title":"dashboard-marker"}
+	}`, nil)
+
+	resp := hs.QueryDiagnostics(c)
+	require.Equal(t, http.StatusOK, resp.Status())
+
+	resp.WriteTo(c)
+	files := readTarGzFiles(t, rec.Body.Bytes())
+	require.Contains(t, string(files["panel.json"]), "panel-marker", "the posted panel must land in panel.json")
+	require.Contains(t, string(files["dashboard.json"]), "dashboard-marker", "the posted dashboard must land in dashboard.json")
+	require.NotContains(t, string(files["panel.json"]), "dashboard-marker", "panel.json must not carry the dashboard")
+	require.NotContains(t, string(files["dashboard.json"]), "panel-marker", "dashboard.json must not carry the panel")
+}
+
 // TestQueryDiagnostics_capturedTrafficWithQueryError_stillBundles covers the fall-through the
 // no-capture guard exists to allow: a query that failed AFTER reaching the wire leaves captured
 // traffic, and that captured failure is exactly what the bundle is for — so it must ship as a 200

--- a/pkg/services/diagnostics/diagnostics_test.go
+++ b/pkg/services/diagnostics/diagnostics_test.go
@@ -896,3 +896,103 @@ func readTarGz(t *testing.T, data []byte) map[string][]byte {
 	}
 	return out
 }
+
+func TestMarshalQueryDataArtifact_truncationTiers(t *testing.T) {
+	// A request large enough that neither the full artifact nor the (request + summary) tier fits,
+	// forcing the ladder past tier 1.
+	bigRequest := json.RawMessage(`{"pad":"` + strings.Repeat("q", 4096) + `"}`)
+
+	t.Run("tier 2 drops the request but keeps the per-refID summary", func(t *testing.T) {
+		resp := backend.NewQueryDataResponse()
+		resp.Responses["A"] = backend.DataResponse{
+			Status: backend.StatusOK,
+			Frames: data.Frames{data.NewFrame("cpu", data.NewField("v", nil, []float64{1, 2, 3}))},
+		}
+		out, _, err := marshalQueryDataArtifactWithLimit(bigRequest, resp, 800)
+		require.NoError(t, err)
+		require.LessOrEqual(t, len(out), 800)
+
+		var art queryDataArtifact
+		require.NoError(t, json.Unmarshal(out, &art))
+		require.True(t, art.Truncated)
+		require.True(t, art.RequestOmitted)
+		require.True(t, art.ResponseOmitted)
+		require.Empty(t, art.Request, "the oversized request must be dropped at tier 2")
+		require.Contains(t, art.ResponseSummary, "A", "the per-refID summary must survive tier 2")
+	})
+
+	t.Run("tier 3 falls back to metadata only when even the summary is too big", func(t *testing.T) {
+		resp := backend.NewQueryDataResponse()
+		resp.Responses["A"] = backend.DataResponse{Error: errors.New(strings.Repeat("e", 4096))}
+		out, _, err := marshalQueryDataArtifactWithLimit(bigRequest, resp, 300)
+		require.NoError(t, err)
+		require.LessOrEqual(t, len(out), 300)
+
+		var art queryDataArtifact
+		require.NoError(t, json.Unmarshal(out, &art))
+		require.True(t, art.Truncated)
+		require.True(t, art.RequestOmitted)
+		require.True(t, art.ResponseOmitted)
+		require.Empty(t, art.Request)
+		require.Empty(t, art.ResponseSummary, "tier 3 drops even the per-refID summary")
+		require.Equal(t, 300, art.LimitBytes)
+		require.Positive(t, art.OriginalBytes)
+	})
+}
+
+func TestSummarizeQueryDataResponse(t *testing.T) {
+	resp := backend.NewQueryDataResponse()
+	longName := strings.Repeat("n", 300)
+	namedFrame := data.NewFrame(longName, data.NewField("v", nil, []float64{1}))
+	// Mismatched field lengths make RowLen() error, which must be recorded as rows = -1.
+	badRows := data.NewFrame("", data.NewField("a", nil, []int64{1, 2}), data.NewField("b", nil, []int64{1}))
+	resp.Responses["A"] = backend.DataResponse{
+		Status: backend.Status(0), // invalid status + a non-nil error -> must normalize to StatusUnknown
+		Error:  errors.New(strings.Repeat("e", 2000)),
+		Frames: data.Frames{namedFrame, badRows},
+	}
+	// __har__ capture responses must be excluded from the summary.
+	hcap := data.NewFrame("")
+	hcap.Meta = &data.FrameMeta{Custom: map[string]interface{}{"har": `{"log":{"entries":[]}}`}}
+	resp.Responses["__har__A"] = backend.DataResponse{Frames: data.Frames{hcap}}
+
+	sum := summarizeQueryDataResponse(resp)
+	require.NotContains(t, sum, "__har__A", "capture frames must be excluded from the summary")
+	a, ok := sum["A"]
+	require.True(t, ok)
+	// An invalid status alongside a non-nil error normalizes to Unknown (not OK), so the summary never
+	// reports success next to an error string.
+	require.Equal(t, backend.StatusUnknown, a.Status, "an invalid status with an error must normalize to Unknown")
+	require.Len(t, a.Error, 1024+len("…"), "error must be truncated to 1024 bytes + ellipsis")
+	require.Equal(t, 256+len("…"), len(a.Frames[0].Name), "frame name must be truncated to 256 bytes + ellipsis")
+
+	var sawNegativeRows bool
+	for _, f := range a.Frames {
+		if f.Rows == -1 {
+			sawNegativeRows = true
+		}
+	}
+	require.True(t, sawNegativeRows, "a frame whose RowLen() errors must record rows = -1")
+}
+
+func TestTruncateDiagnosticString(t *testing.T) {
+	require.Equal(t, "abc", truncateDiagnosticString("abc", 3), "exactly maxBytes is kept verbatim")
+	require.Equal(t, "abc", truncateDiagnosticString("abc", 5), "under maxBytes is kept verbatim")
+	require.Equal(t, "abc…", truncateDiagnosticString("abcdef", 3), "over maxBytes is byte-cut + ellipsis")
+	require.Equal(t, "", truncateDiagnosticString("", 10))
+}
+
+func TestPanelTitleSlug(t *testing.T) {
+	for in, want := range map[string]string{
+		"CPU Usage":             "cpu-usage",
+		"a   b":                 "a-b", // runs of non-alnum collapse to one hyphen
+		"--a--":                 "a",   // leading/trailing separators trimmed
+		"***":                   "",    // all-symbol -> empty slug
+		"Über/CPU!!!":           "ber-cpu",
+		strings.Repeat("a", 50): strings.Repeat("a", 40), // capped at 40
+	} {
+		require.Equalf(t, want, panelTitleSlug(in), "panelTitleSlug(%q)", in)
+	}
+	// An empty slug means the panel dir has no title suffix.
+	require.Equal(t, "panels/7", uniquePanelDir(7, "***", map[string]bool{}))
+}

--- a/pkg/services/diagnostics/diagnostics_test.go
+++ b/pkg/services/diagnostics/diagnostics_test.go
@@ -834,30 +834,62 @@ func frameWithUnencodableMeta(msg string) *data.Frame {
 	return frame
 }
 
-func TestSummarizeQueryDataResponse_errorWithoutStatus(t *testing.T) {
-	// Core datasources run in-process, so nothing normalizes their status the way the SDK does on the
-	// gRPC boundary; several return a bare DataResponse{Error: ...}. Reporting 200 beside an error
-	// string would tell a support engineer the query succeeded.
-	summaries := summarizeQueryDataResponse(&backend.QueryDataResponse{Responses: backend.Responses{
-		"A": {Error: errors.New("influxdb: parse error")},
-		"B": {Frames: data.Frames{data.NewFrame("cpu", data.NewField("value", nil, []float64{42}))}},
-		"C": {Status: backend.StatusBadRequest, Error: errors.New("bad query")},
-	}})
+func TestSummarizeQueryDataResponse(t *testing.T) {
+	t.Run("status never reports success next to an error", func(t *testing.T) {
+		// Core datasources run in-process, so nothing normalizes their status the way the SDK does on the
+		// gRPC boundary; several return a bare DataResponse{Error: ...}. Reporting 200 beside an error
+		// string would tell a support engineer the query succeeded.
+		summaries := summarizeQueryDataResponse(&backend.QueryDataResponse{Responses: backend.Responses{
+			"A": {Error: errors.New("influxdb: parse error")},
+			"B": {Frames: data.Frames{data.NewFrame("cpu", data.NewField("value", nil, []float64{42}))}},
+			"C": {Status: backend.StatusBadRequest, Error: errors.New("bad query")},
+		}})
 
-	require.Equal(t, backend.StatusUnknown, summaries["A"].Status, "an errored response must not be summarized as OK")
-	require.Contains(t, summaries["A"].Error, "parse error")
-	require.Equal(t, backend.StatusOK, summaries["B"].Status, "an error-free response with no status is still OK")
-	require.Equal(t, backend.StatusBadRequest, summaries["C"].Status, "an explicit status is preserved")
+		require.Equal(t, backend.StatusUnknown, summaries["A"].Status, "an errored response must not be summarized as OK")
+		require.Contains(t, summaries["A"].Error, "parse error")
+		require.Equal(t, backend.StatusOK, summaries["B"].Status, "an error-free response with no status is still OK")
+		require.Equal(t, backend.StatusBadRequest, summaries["C"].Status, "an explicit status is preserved")
+	})
+
+	t.Run("oversized strings are truncated and an unmeasurable frame records rows = -1", func(t *testing.T) {
+		namedFrame := data.NewFrame(strings.Repeat("n", 300), data.NewField("v", nil, []float64{1}))
+		// Mismatched field lengths make RowLen() error, which must be recorded as rows = -1.
+		badRows := data.NewFrame("", data.NewField("a", nil, []int64{1, 2}), data.NewField("b", nil, []int64{1}))
+		resp := backend.NewQueryDataResponse()
+		resp.Responses["A"] = backend.DataResponse{
+			Error:  errors.New(strings.Repeat("e", 2000)),
+			Frames: data.Frames{namedFrame, badRows},
+		}
+
+		a := summarizeQueryDataResponse(resp)["A"]
+		require.Len(t, a.Error, 1024+len("…"), "error must be truncated to 1024 bytes + ellipsis")
+		require.Len(t, a.Frames[0].Name, 256+len("…"), "frame name must be truncated to 256 bytes + ellipsis")
+		require.Equal(t, -1, a.Frames[1].Rows, "a frame whose RowLen() errors must record rows = -1")
+	})
+
+	t.Run("capture frames are excluded", func(t *testing.T) {
+		hcap := data.NewFrame("")
+		hcap.Meta = &data.FrameMeta{Custom: map[string]interface{}{"har": `{"log":{"entries":[]}}`}}
+		resp := backend.NewQueryDataResponse()
+		resp.Responses["A"] = backend.DataResponse{Frames: data.Frames{data.NewFrame("cpu")}}
+		resp.Responses["__har__A"] = backend.DataResponse{Frames: data.Frames{hcap}}
+
+		sum := summarizeQueryDataResponse(resp)
+		require.NotContains(t, sum, "__har__A", "capture frames must be excluded from the summary")
+		require.Contains(t, sum, "A")
+	})
 }
 
-func TestTruncateDiagnosticString_runeBoundary(t *testing.T) {
+func TestTruncateDiagnosticString(t *testing.T) {
+	require.Equal(t, "", truncateDiagnosticString("", 10))
+	require.Equal(t, "hello", truncateDiagnosticString("hello", 10), "under maxBytes is kept verbatim")
+	require.Equal(t, "abc", truncateDiagnosticString("abc", 3), "exactly maxBytes is kept verbatim")
+	require.Equal(t, "abc…", truncateDiagnosticString("abcdef", 3), "over maxBytes is byte-cut + ellipsis")
+
 	// A single "世" is 3 bytes; a 4-byte limit lands mid-rune and must back off to the boundary.
 	got := truncateDiagnosticString("世界", 4)
 	require.True(t, utf8.ValidString(got), "truncation must not split a rune")
-	require.Equal(t, "世"+"…", got)
-
-	// ASCII within the limit is returned untouched.
-	require.Equal(t, "hello", truncateDiagnosticString("hello", 10))
+	require.Equal(t, "世…", got)
 }
 
 func TestMarshalQueryDataArtifactWithLimit_reportsTruncation(t *testing.T) {
@@ -876,28 +908,7 @@ func TestMarshalQueryDataArtifactWithLimit_reportsTruncation(t *testing.T) {
 	require.False(t, truncated, "a response that fits must report truncated=false")
 }
 
-func readTarGz(t *testing.T, data []byte) map[string][]byte {
-	t.Helper()
-
-	gz, err := gzip.NewReader(bytes.NewReader(data))
-	require.NoError(t, err)
-
-	tr := tar.NewReader(gz)
-	out := map[string][]byte{}
-	for {
-		hdr, err := tr.Next()
-		if errors.Is(err, io.EOF) {
-			break
-		}
-		require.NoError(t, err)
-		b, err := io.ReadAll(tr)
-		require.NoError(t, err)
-		out[hdr.Name] = b
-	}
-	return out
-}
-
-func TestMarshalQueryDataArtifact_truncationTiers(t *testing.T) {
+func TestMarshalQueryDataArtifactWithLimit_truncationTiers(t *testing.T) {
 	// A request large enough that neither the full artifact nor the (request + summary) tier fits,
 	// forcing the ladder past tier 1.
 	bigRequest := json.RawMessage(`{"pad":"` + strings.Repeat("q", 4096) + `"}`)
@@ -940,48 +951,6 @@ func TestMarshalQueryDataArtifact_truncationTiers(t *testing.T) {
 	})
 }
 
-func TestSummarizeQueryDataResponse(t *testing.T) {
-	resp := backend.NewQueryDataResponse()
-	longName := strings.Repeat("n", 300)
-	namedFrame := data.NewFrame(longName, data.NewField("v", nil, []float64{1}))
-	// Mismatched field lengths make RowLen() error, which must be recorded as rows = -1.
-	badRows := data.NewFrame("", data.NewField("a", nil, []int64{1, 2}), data.NewField("b", nil, []int64{1}))
-	resp.Responses["A"] = backend.DataResponse{
-		Status: backend.Status(0), // invalid status + a non-nil error -> must normalize to StatusUnknown
-		Error:  errors.New(strings.Repeat("e", 2000)),
-		Frames: data.Frames{namedFrame, badRows},
-	}
-	// __har__ capture responses must be excluded from the summary.
-	hcap := data.NewFrame("")
-	hcap.Meta = &data.FrameMeta{Custom: map[string]interface{}{"har": `{"log":{"entries":[]}}`}}
-	resp.Responses["__har__A"] = backend.DataResponse{Frames: data.Frames{hcap}}
-
-	sum := summarizeQueryDataResponse(resp)
-	require.NotContains(t, sum, "__har__A", "capture frames must be excluded from the summary")
-	a, ok := sum["A"]
-	require.True(t, ok)
-	// An invalid status alongside a non-nil error normalizes to Unknown (not OK), so the summary never
-	// reports success next to an error string.
-	require.Equal(t, backend.StatusUnknown, a.Status, "an invalid status with an error must normalize to Unknown")
-	require.Len(t, a.Error, 1024+len("…"), "error must be truncated to 1024 bytes + ellipsis")
-	require.Equal(t, 256+len("…"), len(a.Frames[0].Name), "frame name must be truncated to 256 bytes + ellipsis")
-
-	var sawNegativeRows bool
-	for _, f := range a.Frames {
-		if f.Rows == -1 {
-			sawNegativeRows = true
-		}
-	}
-	require.True(t, sawNegativeRows, "a frame whose RowLen() errors must record rows = -1")
-}
-
-func TestTruncateDiagnosticString(t *testing.T) {
-	require.Equal(t, "abc", truncateDiagnosticString("abc", 3), "exactly maxBytes is kept verbatim")
-	require.Equal(t, "abc", truncateDiagnosticString("abc", 5), "under maxBytes is kept verbatim")
-	require.Equal(t, "abc…", truncateDiagnosticString("abcdef", 3), "over maxBytes is byte-cut + ellipsis")
-	require.Equal(t, "", truncateDiagnosticString("", 10))
-}
-
 func TestPanelTitleSlug(t *testing.T) {
 	for in, want := range map[string]string{
 		"CPU Usage":             "cpu-usage",
@@ -995,4 +964,25 @@ func TestPanelTitleSlug(t *testing.T) {
 	}
 	// An empty slug means the panel dir has no title suffix.
 	require.Equal(t, "panels/7", uniquePanelDir(7, "***", map[string]bool{}))
+}
+
+func readTarGz(t *testing.T, data []byte) map[string][]byte {
+	t.Helper()
+
+	gz, err := gzip.NewReader(bytes.NewReader(data))
+	require.NoError(t, err)
+
+	tr := tar.NewReader(gz)
+	out := map[string][]byte{}
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		require.NoError(t, err)
+		b, err := io.ReadAll(tr)
+		require.NoError(t, err)
+		out[hdr.Name] = b
+	}
+	return out
 }

--- a/pkg/services/diagnostics/diagnostics_test.go
+++ b/pkg/services/diagnostics/diagnostics_test.go
@@ -959,6 +959,8 @@ func TestPanelTitleSlug(t *testing.T) {
 		"***":                   "",    // all-symbol -> empty slug
 		"Über/CPU!!!":           "ber-cpu",
 		strings.Repeat("a", 50): strings.Repeat("a", 40), // capped at 40
+		// A cap that lands on a separator must not leave a trailing hyphen in the directory name.
+		strings.Repeat("a", 39) + " bcd": strings.Repeat("a", 39),
 	} {
 		require.Equalf(t, want, panelTitleSlug(in), "panelTitleSlug(%q)", in)
 	}

--- a/pkg/services/diagnostics/diagnostics_test.go
+++ b/pkg/services/diagnostics/diagnostics_test.go
@@ -853,6 +853,7 @@ func TestSummarizeQueryDataResponse(t *testing.T) {
 
 	t.Run("oversized strings are truncated and an unmeasurable frame records rows = -1", func(t *testing.T) {
 		namedFrame := data.NewFrame(strings.Repeat("n", 300), data.NewField("v", nil, []float64{1}))
+		namedFrame.RefID = strings.Repeat("r", 300) // truncated on its own, independently of Name
 		// Mismatched field lengths make RowLen() error, which must be recorded as rows = -1.
 		badRows := data.NewFrame("", data.NewField("a", nil, []int64{1, 2}), data.NewField("b", nil, []int64{1}))
 		resp := backend.NewQueryDataResponse()
@@ -864,6 +865,7 @@ func TestSummarizeQueryDataResponse(t *testing.T) {
 		a := summarizeQueryDataResponse(resp)["A"]
 		require.Len(t, a.Error, 1024+len("…"), "error must be truncated to 1024 bytes + ellipsis")
 		require.Len(t, a.Frames[0].Name, 256+len("…"), "frame name must be truncated to 256 bytes + ellipsis")
+		require.Len(t, a.Frames[0].RefID, 256+len("…"), "frame refId must be truncated to 256 bytes + ellipsis")
 		require.Equal(t, -1, a.Frames[1].Rows, "a frame whose RowLen() errors must record rows = -1")
 	})
 
@@ -948,6 +950,27 @@ func TestMarshalQueryDataArtifactWithLimit_truncationTiers(t *testing.T) {
 		require.Empty(t, art.ResponseSummary, "tier 3 drops even the per-refID summary")
 		require.Equal(t, 300, art.LimitBytes)
 		require.Positive(t, art.OriginalBytes)
+	})
+
+	// The two omission markers are how a reader tells "this was dropped to fit the cap" from "this was
+	// never supplied", so neither may claim a drop that didn't happen.
+	t.Run("omission markers only flag content that was actually dropped", func(t *testing.T) {
+		bigError := backend.NewQueryDataResponse()
+		bigError.Responses["A"] = backend.DataResponse{Error: errors.New(strings.Repeat("e", 4096))}
+
+		out, _, err := marshalQueryDataArtifactWithLimit(nil, bigError, 300)
+		require.NoError(t, err)
+		var noRequest queryDataArtifact
+		require.NoError(t, json.Unmarshal(out, &noRequest))
+		require.False(t, noRequest.RequestOmitted, "no request was supplied, so none was dropped")
+		require.True(t, noRequest.ResponseOmitted)
+
+		out, _, err = marshalQueryDataArtifactWithLimit(bigRequest, nil, 300)
+		require.NoError(t, err)
+		var noResponse queryDataArtifact
+		require.NoError(t, json.Unmarshal(out, &noResponse))
+		require.True(t, noResponse.RequestOmitted)
+		require.False(t, noResponse.ResponseOmitted, "no response was supplied, so none was dropped")
 	})
 }
 


### PR DESCRIPTION
Adds backend unit tests for the query-diagnostics surface that `main` does not already cover:
- `QueryDiagnostics` handler end-to-end: flag-off 404, empty-queries 400, success bundle + headers + forced `SkipQueryCache`, X-Query-V2 dispatch, no-capture per-refID 400.
- `marshalQueryDataArtifact` truncation tiers, `summarizeQueryDataResponse`, `truncateDiagnosticString`, `panelTitleSlug`.
