### PR TITLE
Provisioning: recheck claim on delete conflict in CleanupQueue

### DIFF
--- a/pkg/registry/apis/provisioning/jobs/cleanup_queue_test.go
+++ b/pkg/registry/apis/provisioning/jobs/cleanup_queue_test.go
@@ -145,6 +145,83 @@ func TestCleanupQueue_DeletesJobsMatchedBySpecRepository(t *testing.T) {
 	assert.Empty(t, remaining.Items)
 }
 
+// TestCleanupQueue_RetriesDeleteWhenConflictIsNotAClaim verifies that a delete
+// conflict caused by something other than a worker claim -- e.g. an unrelated
+// update to a still-pending job, or a delete+recreate of the deterministic job
+// name between the List and the Delete -- does not leave the job behind. On
+// conflict the store re-fetches, sees no claim label, and retries the delete.
+func TestCleanupQueue_RetriesDeleteWhenConflictIsNotAClaim(t *testing.T) {
+	fakeClient := newFilteringClientset()
+	store := newTestStore(fakeClient.ProvisioningV0alpha1())
+
+	ctx, _, err := identity.WithProvisioningIdentity(context.Background(), "stacks-123")
+	require.NoError(t, err)
+
+	createJob(ctx, t, fakeClient, "stacks-123", "repo-a-pending", "repo-a", false)
+
+	// Fail the first delete with a conflict (RV moved on), then let the retry
+	// through to the tracker. The re-fetch returns the still-unclaimed job.
+	var deleteCalls int
+	fakeClient.PrependReactor("delete", "jobs", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		deleteCalls++
+		if deleteCalls == 1 {
+			return true, nil, newConflictError()
+		}
+		return false, nil, nil
+	})
+
+	deleted, err := store.CleanupQueue(ctx, "stacks-123", "repo-a")
+	require.NoError(t, err)
+	assert.Equal(t, 1, deleted)
+	assert.Equal(t, 2, deleteCalls, "expected a retry after the conflict")
+
+	remaining, err := fakeClient.ProvisioningV0alpha1().Jobs("stacks-123").List(ctx, metav1.ListOptions{})
+	require.NoError(t, err)
+	assert.Empty(t, remaining.Items)
+}
+
+// TestCleanupQueue_SkipsJobClaimedAfterList verifies that a job claimed by a
+// worker between the List and the Delete is left in place: on the delete
+// conflict the store re-fetches, finds the claim label, and skips it.
+func TestCleanupQueue_SkipsJobClaimedAfterList(t *testing.T) {
+	fakeClient := newFilteringClientset()
+	store := newTestStore(fakeClient.ProvisioningV0alpha1())
+
+	ctx, _, err := identity.WithProvisioningIdentity(context.Background(), "stacks-123")
+	require.NoError(t, err)
+
+	createJob(ctx, t, fakeClient, "stacks-123", "repo-a-pending", "repo-a", false)
+
+	// The delete always conflicts, and the re-fetch reports the job as claimed,
+	// simulating a worker that grabbed it after our List.
+	fakeClient.PrependReactor("delete", "jobs", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, newConflictError()
+	})
+	fakeClient.PrependReactor("get", "jobs", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		return true, &provisioning.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "repo-a-pending",
+				Namespace: "stacks-123",
+				Labels: map[string]string{
+					LabelRepository:    "repo-a",
+					LabelJobClaim:      "123456789",
+					LabelJobClaimOwner: "worker-1",
+				},
+			},
+			Spec: provisioning.JobSpec{Repository: "repo-a", Action: provisioning.JobActionPull},
+		}, nil
+	})
+
+	deleted, err := store.CleanupQueue(ctx, "stacks-123", "repo-a")
+	require.NoError(t, err)
+	assert.Equal(t, 0, deleted)
+
+	remaining, err := fakeClient.ProvisioningV0alpha1().Jobs("stacks-123").List(ctx, metav1.ListOptions{})
+	require.NoError(t, err)
+	require.Len(t, remaining.Items, 1)
+	assert.Equal(t, "repo-a-pending", remaining.Items[0].GetName())
+}
+
 // TestCleanupQueue_PreservesOrphanCleanupJobs verifies that releaseResources and
 // deleteResources jobs are left in the queue: an admin may enqueue them against a
 // terminating repository as a recovery path, so clearing them would defeat it.

--- a/pkg/registry/apis/provisioning/jobs/persistentstore.go
+++ b/pkg/registry/apis/provisioning/jobs/persistentstore.go
@@ -644,33 +644,78 @@ func (s *persistentStore) CleanupQueue(ctx context.Context, namespace, repositor
 			continue
 		}
 
-		// Guard against the race where a worker claims the job between the List
-		// and the Delete: the ResourceVersion precondition makes the delete fail
-		// with a conflict if the job changed, so an executing job is never removed.
-		rv := job.ResourceVersion
-		err := s.client.Jobs(namespace).Delete(ctx, job.GetName(), metav1.DeleteOptions{
-			Preconditions: &metav1.Preconditions{ResourceVersion: &rv},
-		})
-		switch {
-		case apierrors.IsNotFound(err):
-			// Already completed and removed by a worker; nothing to do.
-			continue
-		case apierrors.IsConflict(err):
-			// Claimed after we listed it; leave it for the worker to finish.
-			logger.Debug("skipping job claimed during queue clean-up", "job", job.GetName())
-			continue
-		case err != nil:
+		removed, err := s.deleteUnclaimedJob(ctx, namespace, job)
+		if err != nil {
 			span.RecordError(err)
 			return deleted, apifmt.Errorf("failed to delete job '%s' in '%s': %w", job.GetName(), namespace, err)
 		}
-
-		s.queueMetrics.DecreaseQueueSize(string(job.Spec.Action))
-		deleted++
+		if removed {
+			s.queueMetrics.DecreaseQueueSize(string(job.Spec.Action))
+			deleted++
+		}
 	}
 
 	span.SetAttributes(attribute.Int("jobs_deleted", deleted))
 	logger.Info("cleanup queue complete", "deleted", deleted)
 	return deleted, nil
+}
+
+// cleanupConflictRetries bounds the re-fetch/retry loop in deleteUnclaimedJob so
+// a job whose ResourceVersion keeps changing cannot spin forever. Reaching the
+// limit leaves the job in place, which is safe: a leftover pending job is picked
+// up and failed by a worker, whereas deleting a possibly-claimed job is not.
+const cleanupConflictRetries = 3
+
+// deleteUnclaimedJob deletes a single pending job under a ResourceVersion
+// precondition, so a job that gets claimed after the List is never removed.
+//
+// A delete conflict only proves the ResourceVersion moved on, not that the job
+// was claimed: a worker claiming it bumps the RV, but so does an unrelated
+// update to a still-pending job or a delete+recreate of the deterministic job
+// name between our List and Delete. Treating every conflict as "claimed" would
+// leave such an unclaimed job behind for a repository that is being deleted. So
+// on conflict we re-fetch and only bail out when the job actually carries the
+// claim label; otherwise we retry the delete against the current RV.
+//
+// Returns true when a job was deleted.
+func (s *persistentStore) deleteUnclaimedJob(ctx context.Context, namespace string, job *provisioning.Job) (bool, error) {
+	logger := logging.FromContext(ctx)
+	name := job.GetName()
+	rv := job.ResourceVersion
+
+	for attempt := 0; attempt < cleanupConflictRetries; attempt++ {
+		err := s.client.Jobs(namespace).Delete(ctx, name, metav1.DeleteOptions{
+			Preconditions: &metav1.Preconditions{ResourceVersion: &rv},
+		})
+		switch {
+		case err == nil:
+			return true, nil
+		case apierrors.IsNotFound(err):
+			// Already completed and removed by a worker; nothing to do.
+			return false, nil
+		case !apierrors.IsConflict(err):
+			return false, err
+		}
+
+		// Conflict: re-fetch to tell a genuine claim apart from an unrelated
+		// change to a job we should still clear.
+		current, getErr := s.client.Jobs(namespace).Get(ctx, name, metav1.GetOptions{})
+		switch {
+		case apierrors.IsNotFound(getErr):
+			return false, nil
+		case getErr != nil:
+			return false, getErr
+		}
+		if _, claimed := current.Labels[LabelJobClaim]; claimed {
+			logger.Debug("skipping job claimed during queue clean-up", "job", name)
+			return false, nil
+		}
+		// Still unclaimed: retry the delete against the current ResourceVersion.
+		rv = current.ResourceVersion
+	}
+
+	logger.Warn("leaving job in queue after repeated delete conflicts", "job", name)
+	return false, nil
 }
 
 // generateJobName creates and updates the job's name to one that fits it.


### PR DESCRIPTION
## What

`CleanupQueue` (which clears a repository's pending jobs during termination) no longer treats every delete conflict as "a worker claimed this job". On conflict it re-fetches the job and only skips it when the job actually carries the claim label; otherwise it retries the delete against the current `ResourceVersion`.

## Why

Follow-up to #129075 ([review comment](https://github.com/grafana/grafana/pull/129075#discussion_r3655993800)).

`CleanupQueue` deletes candidate jobs under a `ResourceVersion` precondition and treated **any** `IsConflict` as proof the job was claimed, leaving it in place. But a conflict only proves the `ResourceVersion` moved on — which also happens when:

- an unrelated update touches a still-pending job, or
- a deterministic-named job (`<repo>-sync`, `<repo>-pr-<n>`) is deleted and recreated between the `List` and the `Delete`.

In those cases an **unclaimed** job was skipped and left behind. Because `handleDelete` runs the finalizer chain once and removes all finalizers on success, there is no second `CleanupQueue` pass — so the job is orphaned against a repository that is being deleted.

## How

- Extracted a `deleteUnclaimedJob` helper. On a delete conflict it re-fetches the job:
  - **claim label present** → genuinely claimed, skip and leave it for the worker;
  - **absent** → retry the delete against the fresh `ResourceVersion`.
- The retry loop is bounded by `cleanupConflictRetries` (3). Reaching the limit leaves the job in place, which is safe: a leftover pending job gets picked up and failed by a worker, whereas deleting a possibly-claimed job is not recoverable.

## Testing

- `go test ./pkg/registry/apis/provisioning/jobs/` (full package) and `go vet` pass.
- Two new table cases via fake-client reactors:
  - `TestCleanupQueue_RetriesDeleteWhenConflictIsNotAClaim` — conflict → re-fetch shows unclaimed → retry deletes it.
  - `TestCleanupQueue_SkipsJobClaimedAfterList` — conflict → re-fetch shows claim label → job left in place.

## Checklist

- [x] Tests added/updated
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)