### PR TITLE
test: Fix E2E flakiness when drag'n'dropping rows or tabs

### DIFF
--- a/e2e-playwright/dashboard-new-layouts/dashboard-repeats-row-layout.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboard-repeats-row-layout.spec.ts
@@ -522,9 +522,13 @@ test.describe(
       await dashboardPage.getByGrafanaSelector(selectors.components.NavToolbar.editDashboard.editButton).click();
       await moveRow(dashboardPage, page, selectors, `${repeatTitleBase}1`, singleRowTitle);
 
-      let singleRowBox = await getRowBox(dashboardPage, selectors, singleRowTitle);
-      const repeatedRowBox = await getRowBox(dashboardPage, selectors, `${repeatTitleBase}1`);
-      expect(singleRowBox.y).toBeLessThan(repeatedRowBox.y || 0);
+      // The row order is only updated after the drop animation finishes (onDragEnd),
+      // so retry the position check until the reorder has been applied
+      await expect(async () => {
+        const singleRowBox = await getRowBox(dashboardPage, selectors, singleRowTitle);
+        const repeatedRowBox = await getRowBox(dashboardPage, selectors, `${repeatTitleBase}1`);
+        expect(singleRowBox.y).toBeLessThan(repeatedRowBox.y);
+      }).toPass();
 
       // Wait for save button to be active (indicates changes have been applied)
       // since we cannot verify that changes have been applied by checking the JSON diff we have to check the Save button state
@@ -536,7 +540,7 @@ test.describe(
 
       await page.reload();
 
-      singleRowBox = await getRowBox(dashboardPage, selectors, singleRowTitle);
+      const singleRowBox = await getRowBox(dashboardPage, selectors, singleRowTitle);
       for (let i = 1; i <= repeatOptions.length; i++) {
         // verify move by row position
         const repeatedRow = await getRowBox(dashboardPage, selectors, `${repeatTitleBase}${i}`);

--- a/e2e-playwright/dashboard-new-layouts/dashboards-repeats-tabs-layout.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboards-repeats-tabs-layout.spec.ts
@@ -253,13 +253,13 @@ test.describe(
       await dashboardPage.getByGrafanaSelector(selectors.components.NavToolbar.editDashboard.editButton).click();
       await moveTab(dashboardPage, page, selectors, `${repeatTitleBase}${repeatOptions.at(0)}`, 'New tab');
 
-      // playwright too fast - adding intermediate step so that UI has time to update
-      await dashboardPage.getByGrafanaSelector(selectors.components.Tab.title('New tab')).click();
-
-      // verify move by tab position
-      const repeatedTab = await getTabPosition(dashboardPage, selectors, `${repeatTitleBase}${repeatOptions.at(0)}`);
-      const normalTab = await getTabPosition(dashboardPage, selectors, 'New tab');
-      expect(normalTab?.x).toBeLessThan(repeatedTab?.x || 0);
+      // The tab order is only updated after the drop animation finishes (onDragEnd),
+      // so retry the position check until the reorder has been applied
+      await expect(async () => {
+        const repeatedTab = await getTabPosition(dashboardPage, selectors, `${repeatTitleBase}${repeatOptions.at(0)}`);
+        const normalTab = await getTabPosition(dashboardPage, selectors, 'New tab');
+        expect(normalTab?.x).toBeLessThan(repeatedTab!.x);
+      }).toPass();
       await saveDashboard(dashboardPage, page, selectors);
       await page.reload();
 


### PR DESCRIPTION
## Goal

Fix flaky assertions in the "move repeated rows" and "move repeated tabs" E2E tests by making the post-drop position checks resilient to `@hello-pangea/dnd`'s drop animation.

## Problem

Both tests drag an element (a repeated row / a repeated tab) and immediately assert on the new element positions via one-shot `boundingBox()` reads and non-retrying `expect` calls.

However, `@hello-pangea/dnd` only applies the reorder *after* its drop animation completes:
1. on `mouseup` it enters a `DROP_ANIMATING` phase (330–550ms depending on drag distance `minDropTime`/`maxDropTime` in the library), and
2. `onDragEnd`, where Grafana actually calls `moveRow`/`moveTab` on the layout manager (`RowsLayoutManagerRenderer.handleDragEnd`, `DashboardLayoutOrchestrator.stopTabDrag`) only fires on the `transitionend` of that animation.

Any assertion racing that window reads the pre-drop layout and fails intermittently.

The tabs test papered over this with a click on the target tab ("playwright too fast" comment) — a delay not synchronized to the animation, which could itself land on a header still translating mid-animation.

## Approach

Wrap the post-drop position assertions in Playwright's retrying `expect(async () => { ... }).toPass()` blocks (the pattern already used elsewhere in this suite), so the checks poll until the drop animation has finished and the reorder is applied. 

Remove the click-based timing hack in the tabs test.

## 🧪 How to test

- Run each spec repeatedly to check for flakiness:
  - `yarn e2e:pw --project dashboard-new-layouts --reporter list --repeat-each=3 -- dashboard-repeats-row-layout.spec.ts`
  - `yarn e2e:pw --project dashboard-new-layouts --reporter list --repeat-each=3 -- dashboards-repeats-tabs-layout.spec.ts`