### PR TITLE
XYChart: Add color is undefined as a scenario to use the fallback color

### DIFF
--- a/public/app/plugins/panel/xychart/scatter.ts
+++ b/public/app/plugins/panel/xychart/scatter.ts
@@ -138,7 +138,8 @@ export const prepConfig = (xySeries: XYSeries[], theme: GrafanaTheme2) => {
                 if (colorByValue) {
                   if (pointColors[i] !== curColorIdx) {
                     curColorIdx = pointColors[i];
-                    let c = curColorIdx === -1 ? FALLBACK_COLOR : pointPalette[curColorIdx];
+                    let c =
+                      curColorIdx === undefined || curColorIdx === -1 ? FALLBACK_COLOR : pointPalette[curColorIdx];
                     u.ctx.fillStyle = paletteHasAlpha ? c : colorManipulator.alpha(c as string, pointAlpha);
                     u.ctx.strokeStyle = colorManipulator.alpha(c as string, 1);
                   }


### PR DESCRIPTION
Uses a fallback color instead of failing when a color is not defined.

Discovered investigating [#129112](https://github.com/grafana/grafana/pull/129112)

XYChart

x field: t
y field: rssi
color field: color

Use default classic palette

```
"t","rssi","color"
0.208,0.405,50
0.332,0.433,50
0.527,0.612,50
0.153,0.669,50
```

Before
<img width="1043" height="625" alt="Screenshot 2026-07-27 at 9 37 42 AM" src="https://github.com/user-attachments/assets/d8ed2c51-ed23-475e-8834-c3896f189c0a" />

After
<img width="1018" height="612" alt="Screenshot 2026-07-27 at 9 38 22 AM" src="https://github.com/user-attachments/assets/b4c4086e-3fbe-4070-aec3-cf7ab6284642" />
