### PR TITLE
Datasources: Trim stale HAR capture comments

### DIFF
--- a/pkg/services/diagnostics/diagnostics.go
+++ b/pkg/services/diagnostics/diagnostics.go
@@ -655,16 +655,7 @@ func HasCapturedHAR(resp *backend.QueryDataResponse, harBuffer *harcapture.Buffe
 	return captured
 }
 
-// collectHAR returns the captured HTTP traffic as HAR 1.2 JSON. It merges two sources: the
-// in-process buffer (core plugins) and the __har__ response frame(s) returned by externalized gRPC
-// plugins. Returns (nil, nil) when nothing was captured, and a non-nil error if traffic was
-// captured but could not be serialized (so the caller can fail rather than return an empty bundle).
-//
-// NOTE: the __har__ frame path is inert until the SDK-side HTTP capture middleware that emits those
-// frames ships and Grafana is bumped to that SDK version — until then external (out-of-process)
-// plugin traffic is NOT captured. Externally-sourced frames are merged VERBATIM: redaction is
-// intentionally deferred (see the harcapture package doc), so — exactly like in-process capture —
-// the recorded headers/cookies/query/URLs/bodies are not sanitized.
+// collectHAR returns the captured HTTP traffic as HAR 1.2 JSON.
 func collectHAR(resp *backend.QueryDataResponse, harBuffer *harcapture.Buffer) ([]byte, error) {
 	var bufferDoc []byte
 	if harBuffer != nil && harBuffer.Len() > 0 {

--- a/pkg/services/pluginsintegration/clientmiddleware/http_capture_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/http_capture_middleware.go
@@ -18,14 +18,6 @@ const harCaptureHeader = "X-Grafana-HAR-Capture"
 
 // NewHTTPCaptureMiddleware creates a backend.HandlerMiddleware that captures HTTP traffic
 // for QueryData calls when a harcapture.Buffer is present in the context.
-//
-// For core (in-process) plugins: injects a capturing RoundTripper as contextual middleware
-// so the existing ContextualMiddleware in the HTTP client chain picks it up.
-//
-// For external gRPC plugins: sets X-Grafana-HAR-Capture on the request headers. NOTE: this is
-// currently inert — the SDK-side middleware that reads this header and emits __har__ response frames
-// is not released yet, so out-of-process plugin traffic is NOT captured until Grafana is bumped to
-// an SDK version that includes it. The header is set now only for forward compatibility.
 func NewHTTPCaptureMiddleware() backend.HandlerMiddleware {
 	return backend.HandlerMiddlewareFunc(func(next backend.Handler) backend.Handler {
 		return &HTTPCaptureMiddleware{BaseHandler: backend.NewBaseHandler(next)}


### PR DESCRIPTION
Remove most of the comments' content.