### PR TITLE
Datasources: Extend query-diagnostics frontend Jest coverage

### DIFF
--- a/public/app/features/dashboard-scene/sharing/DownloadDashboardDiagnostics.test.tsx
+++ b/public/app/features/dashboard-scene/sharing/DownloadDashboardDiagnostics.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { act, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { render } from 'test/test-utils';
 
@@ -184,6 +184,138 @@ describe('DownloadDashboardDiagnostics', () => {
     const [panels] = jest.mocked(startDashboardDiagnostics).mock.calls[0];
     expect(panels.map((p) => p.id)).toEqual([3, 3]);
     expect(panels.map((p) => p.title)).toEqual(['Repeated panel', 'Repeated panel']);
+  });
+});
+
+// Mirror the (unexported) polling constants from DownloadDashboardDiagnostics.tsx so the fake-timer
+// tests advance by the same cadence/cap the component uses.
+const POLL_INTERVAL_MS = 1000;
+const MAX_POLL_ATTEMPTS = 300;
+
+describe('DownloadDashboardDiagnostics async generation (progress / poll-timeout / abort)', () => {
+  beforeEach(() => {
+    jest.mocked(startDashboardDiagnostics).mockReset();
+    jest.mocked(getDashboardDiagnosticsStatus).mockReset();
+    jest.mocked(downloadDashboardDiagnostics).mockReset();
+    interpolateVariablesInQueries.mockClear();
+    interpolateVariablesInQueries.mockImplementation((queries: DataQuery[]) => queries);
+  });
+
+  afterEach(() => {
+    // The tests below opt into fake timers individually; make sure we always hand back real timers so
+    // later suites (and the RTL cleanup) aren't left on a frozen clock.
+    jest.useRealTimers();
+  });
+
+  it('advances the capture progress as the job reports more panels done', async () => {
+    jest.useFakeTimers();
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    jest.mocked(startDashboardDiagnostics).mockResolvedValue('job-1');
+    jest
+      .mocked(getDashboardDiagnosticsStatus)
+      .mockResolvedValueOnce({ uid: 'job-1', state: 'pending', panelsDone: 0, panelsTotal: 2 })
+      .mockResolvedValueOnce({ uid: 'job-1', state: 'pending', panelsDone: 1, panelsTotal: 2 })
+      .mockResolvedValue({ uid: 'job-1', state: 'complete', panelsDone: 2, panelsTotal: 2 });
+    jest.mocked(downloadDashboardDiagnostics).mockResolvedValue(undefined);
+    const { tab } = setupScenario();
+
+    render(<tab.Component model={tab} />);
+    await user.click(screen.getByRole('button', { name: 'Download diagnostics' }));
+
+    // Flush the start + first status poll without firing the 1s inter-poll delay: progress shows the
+    // first reported figure.
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(0);
+    });
+    expect(screen.getByText(/Capturing panel 0 of 2/)).toBeInTheDocument();
+
+    // Next poll reports one more panel done.
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+    });
+    expect(screen.getByText(/Capturing panel 1 of 2/)).toBeInTheDocument();
+
+    // Final poll completes: progress disappears and the completed bundle is downloaded.
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+    });
+    expect(screen.getByRole('button', { name: 'Download diagnostics' })).toBeInTheDocument();
+    expect(screen.queryByText(/Capturing panel/)).not.toBeInTheDocument();
+    expect(downloadDashboardDiagnostics).toHaveBeenCalledWith('job-1', expect.anything());
+  });
+
+  it('gives up with a timeout error after the maximum number of poll attempts', async () => {
+    jest.useFakeTimers();
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    jest.mocked(startDashboardDiagnostics).mockResolvedValue('job-1');
+    // The job never leaves the pending state, so the client-side poll loop must give up on its own.
+    jest
+      .mocked(getDashboardDiagnosticsStatus)
+      .mockResolvedValue({ uid: 'job-1', state: 'pending', panelsDone: 0, panelsTotal: 2 });
+    const { tab } = setupScenario();
+
+    render(<tab.Component model={tab} />);
+    await user.click(screen.getByRole('button', { name: 'Download diagnostics' }));
+
+    // Drive every poll interval past the attempt cap.
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(POLL_INTERVAL_MS * (MAX_POLL_ATTEMPTS + 1));
+    });
+
+    expect(screen.getByText('Timed out waiting for diagnostics generation')).toBeInTheDocument();
+    expect(downloadDashboardDiagnostics).not.toHaveBeenCalled();
+  });
+
+  it('stops polling and never downloads when cancelled mid-generation', async () => {
+    jest.useFakeTimers();
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    jest.mocked(startDashboardDiagnostics).mockResolvedValue('job-1');
+    jest
+      .mocked(getDashboardDiagnosticsStatus)
+      .mockResolvedValue({ uid: 'job-1', state: 'pending', panelsDone: 0, panelsTotal: 2 });
+    const onDismiss = jest.fn();
+    const { tab } = setupScenario({ onDismiss });
+
+    render(<tab.Component model={tab} />);
+    await user.click(screen.getByRole('button', { name: 'Download diagnostics' }));
+
+    // Enter the poll loop, then cancel: cancelling aborts the controller, which rejects the pending
+    // inter-poll delay and unwinds the loop before the download step.
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(0);
+    });
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(POLL_INTERVAL_MS * 3);
+    });
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    expect(downloadDashboardDiagnostics).not.toHaveBeenCalled();
+  });
+
+  it('aborts an in-flight generation when the drawer unmounts', async () => {
+    // Park the flow in the interpolation phase (before a job is started) by holding the datasource
+    // lookup, then unmount: the useEffect cleanup must abort the controller created up front so the
+    // flow bails at its aborted-signal check instead of starting a job for a drawer that's gone.
+    let resolveLookup!: () => void;
+    const pendingLookup = new Promise((resolve) => {
+      resolveLookup = () => resolve({ interpolateVariablesInQueries });
+    });
+    jest.mocked(getDataSourceInstance).mockReturnValueOnce(pendingLookup as ReturnType<typeof getDataSourceInstance>);
+    const { tab } = setupScenario();
+
+    const { unmount } = render(<tab.Component model={tab} />);
+    await userEvent.click(screen.getByRole('button', { name: 'Download diagnostics' }));
+    unmount();
+
+    resolveLookup();
+    // Let the (now-unmounted) flow's promise chain settle so it reaches the aborted-signal check.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(startDashboardDiagnostics).not.toHaveBeenCalled();
+    expect(downloadDashboardDiagnostics).not.toHaveBeenCalled();
   });
 });
 

--- a/public/app/features/query/diagnostics/downloadDiagnostics.test.ts
+++ b/public/app/features/query/diagnostics/downloadDiagnostics.test.ts
@@ -1,5 +1,5 @@
 import { saveAs } from 'file-saver';
-import { of } from 'rxjs';
+import { of, throwError } from 'rxjs';
 
 import { getBackendSrv } from '@grafana/runtime';
 import { type DataQuery } from '@grafana/schema';
@@ -142,5 +142,97 @@ describe('dashboard diagnostics', () => {
     expect(saveAs).toHaveBeenCalledTimes(1);
     const [, filename] = jest.mocked(saveAs).mock.calls[0];
     expect(filename).toMatch(/^dashboard-diagnostics-\d{8}-\d{6}\.tar\.gz$/);
+  });
+});
+
+// The Content-Disposition parser (fileNameFromContentDisposition) isn't exported, so it's exercised
+// through its only caller-visible surface: the filename saveAs is called with. `undefined` matches
+// (no name parsed -> generated fallback) are asserted separately below.
+describe('Content-Disposition filename parsing', () => {
+  beforeEach(() => {
+    jest.mocked(saveAs).mockClear();
+  });
+
+  it.each([
+    ['a quoted filename', 'attachment; filename="bundle.tar.gz"', 'bundle.tar.gz'],
+    ['an unquoted filename', 'attachment; filename=bundle.tar.gz', 'bundle.tar.gz'],
+    [
+      'an unquoted filename followed by an RFC5987 filename* param (stops at the ";")',
+      "attachment; filename=bundle.tar.gz; filename*=UTF-8''b%C3%BCndle.tar.gz",
+      'bundle.tar.gz',
+    ],
+    ['a case-insensitive header key', 'attachment; FILENAME=Bundle.TAR.gz', 'Bundle.TAR.gz'],
+  ])('uses the parsed name for %s', async (_name, header, expected) => {
+    const blob = new Blob(['bundle'], { type: 'application/gzip' });
+    setupBackendSrv({ data: blob, headers: new Headers({ 'Content-Disposition': header }) });
+
+    await downloadDiagnosticsForQueries([{ refId: 'A' }], '1', '2');
+
+    expect(saveAs).toHaveBeenCalledWith(blob, expected);
+  });
+
+  it.each([
+    // A bare RFC5987 filename* is not decoded here (the parser matches "filename=" literally), so it
+    // falls through to the generated fallback rather than yielding a mangled name.
+    ['a bare RFC5987 filename*', "attachment; filename*=UTF-8''r%C3%A9sum%C3%A9.tar.gz"],
+    ['a header with no filename parameter', 'attachment'],
+    ['an empty header value', ''],
+  ])('falls back to a generated name for %s', async (_name, header) => {
+    const blob = new Blob(['bundle'], { type: 'application/gzip' });
+    setupBackendSrv({ data: blob, headers: new Headers({ 'Content-Disposition': header }) });
+
+    await downloadDiagnosticsForQueries([{ refId: 'A' }], '1', '2');
+
+    expect(saveAs).toHaveBeenCalledTimes(1);
+    const [, filename] = jest.mocked(saveAs).mock.calls[0];
+    expect(filename).toMatch(/^diagnostics-\d{8}-\d{6}\.tar\.gz$/);
+  });
+});
+
+describe('abort signal handling', () => {
+  beforeEach(() => {
+    jest.mocked(saveAs).mockClear();
+  });
+
+  it('forwards the abort signal to the POST fetch when downloading panel diagnostics', async () => {
+    const fetch = setupBackendSrv({ data: new Blob(['x']), headers: new Headers() });
+    const { signal } = new AbortController();
+
+    await downloadDiagnosticsForQueries([{ refId: 'A' }], '1', '2', signal);
+
+    // The drawer's AbortController.signal must reach getBackendSrv so cancel/unmount can abort the
+    // in-flight request; showErrorAlert stays false so the drawer surfaces failures itself.
+    expect(fetch).toHaveBeenCalledWith(expect.objectContaining({ abortSignal: signal, showErrorAlert: false }));
+  });
+
+  it('forwards the abort signal through the whole dashboard job lifecycle', async () => {
+    const { signal } = new AbortController();
+
+    const startFetch = setupBackendSrv({ data: { uid: 'job-1' } });
+    await startDashboardDiagnostics(
+      [{ id: 1, title: 'A', from: '1', to: '2', queries: [{ refId: 'A' }] }],
+      undefined,
+      signal
+    );
+    expect(startFetch).toHaveBeenCalledWith(expect.objectContaining({ abortSignal: signal }));
+
+    const statusFetch = setupBackendSrv({ data: { uid: 'job-1', state: 'complete', panelsTotal: 1, panelsDone: 1 } });
+    await getDashboardDiagnosticsStatus('job-1', signal);
+    expect(statusFetch).toHaveBeenCalledWith(expect.objectContaining({ abortSignal: signal }));
+
+    const downloadFetch = setupBackendSrv({ data: new Blob(['x']), headers: new Headers() });
+    await downloadDashboardDiagnostics('job-1', signal);
+    expect(downloadFetch).toHaveBeenCalledWith(expect.objectContaining({ abortSignal: signal }));
+  });
+
+  it('rejects and saves nothing when the fetch errors (e.g. an aborted request)', async () => {
+    // An aborted in-flight request surfaces as a rejected observable; the flow must reject cleanly and
+    // not attempt to save a file.
+    const err = new DOMException('The user aborted a request.', 'AbortError');
+    const fetch = jest.fn().mockReturnValue(throwError(() => err));
+    jest.mocked(getBackendSrv).mockReturnValue({ fetch } as unknown as ReturnType<typeof getBackendSrv>);
+
+    await expect(downloadDiagnosticsForQueries([{ refId: 'A' }], '1', '2')).rejects.toBe(err);
+    expect(saveAs).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Part of the on-premise enhanced diagnostics effort (grafana/data-sources#1268) — frontend test coverage.

Fills gaps in the existing download-diagnostics Jest tests:

- `downloadDiagnostics`: Content-Disposition filename parsing and abort-signal forwarding on the single-panel POST.
- `DownloadDashboardDiagnostics`: capture-progress advancement, poll-timeout give-up, cancel-mid-generation, unmount-aborts-in-flight-job, and abort-signal forwarding through the full dashboard job lifecycle.

Test-only; no production code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)