### PR TITLE
`extsvc`: Return proper error codes

### DIFF
--- a/pkg/services/serviceaccounts/proxy/service.go
+++ b/pkg/services/serviceaccounts/proxy/service.go
@@ -59,7 +59,7 @@ func (s *ServiceAccountsProxy) AddServiceAccountToken(ctx context.Context, servi
 
 		if serviceaccounts.IsExternalServiceAccount(sa.Login) {
 			s.log.Error("unable to create tokens for external service accounts", "serviceAccountID", serviceAccountID)
-			return nil, extsvcaccounts.ErrCannotCreateToken
+			return nil, extsvcaccounts.ErrCannotCreateToken.Errorf("cannot add token to external service account %d", serviceAccountID)
 		}
 	}
 
@@ -70,7 +70,7 @@ func (s *ServiceAccountsProxy) CreateServiceAccount(ctx context.Context, orgID i
 	if s.isProxyEnabled {
 		if !isNameValid(saForm.Name) {
 			s.log.Error("Unable to create service account with a protected name", "name", saForm.Name)
-			return nil, extsvcaccounts.ErrInvalidName
+			return nil, extsvcaccounts.ErrInvalidName.Errorf("invalid service account name %q", saForm.Name)
 		}
 	}
 	return s.proxiedService.CreateServiceAccount(ctx, orgID, saForm)
@@ -85,7 +85,7 @@ func (s *ServiceAccountsProxy) DeleteServiceAccount(ctx context.Context, orgID, 
 
 		if serviceaccounts.IsExternalServiceAccount(sa.Login) {
 			s.log.Error("unable to delete external service accounts", "serviceAccountID", serviceAccountID)
-			return extsvcaccounts.ErrCannotBeDeleted
+			return extsvcaccounts.ErrCannotBeDeleted.Errorf("cannot delete external service account %d", serviceAccountID)
 		}
 	}
 	return s.proxiedService.DeleteServiceAccount(ctx, orgID, serviceAccountID)
@@ -100,7 +100,7 @@ func (s *ServiceAccountsProxy) DeleteServiceAccountToken(ctx context.Context, or
 
 		if serviceaccounts.IsExternalServiceAccount(sa.Login) {
 			s.log.Error("unable to delete tokens for external service accounts", "serviceAccountID", serviceAccountID)
-			return extsvcaccounts.ErrCannotDeleteToken
+			return extsvcaccounts.ErrCannotDeleteToken.Errorf("cannot delete token for external service account %d", serviceAccountID)
 		}
 	}
 	return s.proxiedService.DeleteServiceAccountToken(ctx, orgID, serviceAccountID, tokenID)
@@ -114,7 +114,7 @@ func (s *ServiceAccountsProxy) EnableServiceAccount(ctx context.Context, orgID i
 		}
 		if serviceaccounts.IsExternalServiceAccount(sa.Login) {
 			s.log.Error("unable to enable/disable external service accounts", "serviceAccountID", serviceAccountID)
-			return extsvcaccounts.ErrCannotBeUpdated
+			return extsvcaccounts.ErrCannotBeUpdated.Errorf("cannot enable/disable external service account %d", serviceAccountID)
 		}
 	}
 	return s.proxiedService.EnableServiceAccount(ctx, orgID, serviceAccountID, enable)
@@ -150,7 +150,7 @@ func (s *ServiceAccountsProxy) UpdateServiceAccount(ctx context.Context, orgID, 
 	if s.isProxyEnabled {
 		if !isNameValid(*saForm.Name) {
 			s.log.Error("Invalid service account name", "name", *saForm.Name)
-			return nil, extsvcaccounts.ErrInvalidName
+			return nil, extsvcaccounts.ErrInvalidName.Errorf("invalid service account name %q", *saForm.Name)
 		}
 		sa, err := s.proxiedService.RetrieveServiceAccount(ctx, &serviceaccounts.GetServiceAccountQuery{OrgID: orgID, ID: serviceAccountID})
 		if err != nil {
@@ -158,7 +158,7 @@ func (s *ServiceAccountsProxy) UpdateServiceAccount(ctx context.Context, orgID, 
 		}
 		if serviceaccounts.IsExternalServiceAccount(sa.Login) {
 			s.log.Error("unable to update external service accounts", "serviceAccountID", serviceAccountID)
-			return nil, extsvcaccounts.ErrCannotBeUpdated
+			return nil, extsvcaccounts.ErrCannotBeUpdated.Errorf("cannot update external service account %d", serviceAccountID)
 		}
 	}
 

--- a/pkg/services/serviceaccounts/proxy/service_test.go
+++ b/pkg/services/serviceaccounts/proxy/service_test.go
@@ -62,7 +62,11 @@ func TestProvideServiceAccount_crudServiceAccount(t *testing.T) {
 			t.Run(tc.description, func(t *testing.T) {
 				tc := tc
 				_, err := svc.CreateServiceAccount(context.Background(), autoAssignOrgID, &tc.form)
-				assert.Equal(t, err, tc.expectedError, tc.description)
+				if tc.expectedError != nil {
+					assert.ErrorIs(t, err, tc.expectedError, tc.description)
+				} else {
+					assert.NoError(t, err, tc.description)
+				}
 			})
 		}
 	})
@@ -93,7 +97,11 @@ func TestProvideServiceAccount_crudServiceAccount(t *testing.T) {
 			t.Run(tc.description, func(t *testing.T) {
 				serviceMock.ExpectedServiceAccountProfile = tc.expectedServiceAccount
 				err := svc.DeleteServiceAccount(context.Background(), autoAssignOrgID, testServiceAccountId)
-				assert.Equal(t, err, tc.expectedError, tc.description)
+				if tc.expectedError != nil {
+					assert.ErrorIs(t, err, tc.expectedError, tc.description)
+				} else {
+					assert.NoError(t, err, tc.description)
+				}
 			})
 		}
 	})
@@ -124,7 +132,11 @@ func TestProvideServiceAccount_crudServiceAccount(t *testing.T) {
 			t.Run(tc.description, func(t *testing.T) {
 				serviceMock.ExpectedServiceAccountProfile = tc.expectedServiceAccount
 				err := svc.DeleteServiceAccountToken(context.Background(), autoAssignOrgID, testServiceAccountId, testServiceAccountTokenId)
-				assert.Equal(t, err, tc.expectedError, tc.description)
+				if tc.expectedError != nil {
+					assert.ErrorIs(t, err, tc.expectedError, tc.description)
+				} else {
+					assert.NoError(t, err, tc.description)
+				}
 			})
 		}
 	})
@@ -234,7 +246,11 @@ func TestProvideServiceAccount_crudServiceAccount(t *testing.T) {
 				tc := tc
 				serviceMock.ExpectedServiceAccountProfile = tc.expectedServiceAccount
 				_, err := svc.UpdateServiceAccount(context.Background(), autoAssignOrgID, testServiceAccountId, &tc.form)
-				assert.Equal(t, tc.expectedError, err, tc.description)
+				if tc.expectedError != nil {
+					assert.ErrorIs(t, err, tc.expectedError, tc.description)
+				} else {
+					assert.NoError(t, err, tc.description)
+				}
 			})
 		}
 	})
@@ -273,7 +289,11 @@ func TestProvideServiceAccount_crudServiceAccount(t *testing.T) {
 				tc := tc
 				serviceMock.ExpectedServiceAccountProfile = tc.expectedServiceAccount
 				_, err := svc.AddServiceAccountToken(context.Background(), testServiceAccountId, &tc.cmd)
-				assert.Equal(t, tc.expectedError, err, tc.description)
+				if tc.expectedError != nil {
+					assert.ErrorIs(t, err, tc.expectedError, tc.description)
+				} else {
+					assert.NoError(t, err, tc.description)
+				}
 			})
 		}
 	})


### PR DESCRIPTION
## Why the change

`ServiceAccountsProxy` returned `errutil.Base` values directly for external-service-account guard errors. `response.ErrOrFallback` only recognizes instantiated `errutil.Error` values, so those failures fell through to the generic 500 fallback instead of the intended 400 responses (e.g. creating a token on an extsvc account returned 500 instead of `extsvcaccounts.ErrCannotCreateToken`).

```
curl -i -k --basic -u "***:***" -H "Content-Type: application/json" POST 'http://localhost:3000/api/serviceaccounts/saUID/tokens' \
  --data-raw '{"name":"test"}'
curl: (6) Could not resolve host: POST
HTTP/1.1 400 Bad Request
Cache-Control: no-store
Content-Type: application/json
X-Content-Type-Options: nosniff
X-Frame-Options: deny
X-Xss-Protection: 1; mode=block
Date: Mon, 27 Jul 2026 15:07:59 GMT
Content-Length: 122

{"statusCode":400,"messageId":"extsvcaccounts.ErrCannotCreateToken","message":"cannot add external service account token"}
```

## Summary

- Instantiate all external-service-account guard errors in `ServiceAccountsProxy` via `.Errorf(...)`, matching the pattern used elsewhere in the serviceaccounts package.
- Update proxy tests to use `assert.ErrorIs` instead of direct error equality, since `.Errorf()` produces distinct error instances.

## Test plan

- [x] `go test ./pkg/services/serviceaccounts/proxy/...`
- [x] POST `/api/serviceaccounts/{extsvc-id}/tokens` returns 400 with `messageId: extsvcaccounts.ErrCannotCreateToken` (not 500)