### PR TITLE
Alerting: Support Telegram image caption configuration

### DIFF
--- a/pkg/services/ngalert/api/test-data/provisioning_get_responses/all-integrations.json
+++ b/pkg/services/ngalert/api/test-data/provisioning_get_responses/all-integrations.json
@@ -301,6 +301,7 @@
    "chatid": "12345678",
    "disable_notifications": true,
    "disable_web_page_preview": true,
+   "send_message_as_caption": true,
    "message": "test-message",
    "message_thread_id": "13579",
    "parse_mode": "html",

--- a/pkg/services/ngalert/api/test-data/receiver-exports/redacted/all-integrations.hcl
+++ b/pkg/services/ngalert/api/test-data/receiver-exports/redacted/all-integrations.hcl
@@ -233,6 +233,7 @@ resource "grafana_contact_point" "contact_point_2b661702215368fe" {
     disable_web_page_preview = true
     protect_content          = true
     disable_notifications    = true
+    send_message_as_caption  = true
   }
 
   threema {

--- a/pkg/services/ngalert/api/test-data/receiver-exports/redacted/all-integrations.json
+++ b/pkg/services/ngalert/api/test-data/receiver-exports/redacted/all-integrations.json
@@ -637,6 +637,7 @@
       "chatid": "12345678",
       "disable_notifications": true,
       "disable_web_page_preview": true,
+      "send_message_as_caption": true,
       "http_config": {
        "oauth2": {
         "client_id": "test-client-id",

--- a/pkg/services/ngalert/api/test-data/receiver-exports/redacted/all-integrations.yaml
+++ b/pkg/services/ngalert/api/test-data/receiver-exports/redacted/all-integrations.yaml
@@ -751,6 +751,7 @@ contactPoints:
             chatid: "12345678"
             disable_notifications: true
             disable_web_page_preview: true
+            send_message_as_caption: true
             http_config:
                 oauth2:
                     client_id: test-client-id

--- a/pkg/services/ngalert/api/test-data/receiver-exports/unredacted/all-integrations.hcl
+++ b/pkg/services/ngalert/api/test-data/receiver-exports/unredacted/all-integrations.hcl
@@ -215,6 +215,7 @@ resource "grafana_contact_point" "contact_point_2b661702215368fe" {
     disable_web_page_preview = true
     protect_content          = true
     disable_notifications    = true
+    send_message_as_caption  = true
   }
 
   threema {

--- a/pkg/services/ngalert/api/test-data/receiver-exports/unredacted/all-integrations.json
+++ b/pkg/services/ngalert/api/test-data/receiver-exports/unredacted/all-integrations.json
@@ -637,6 +637,7 @@
       "chatid": "12345678",
       "disable_notifications": true,
       "disable_web_page_preview": true,
+      "send_message_as_caption": true,
       "http_config": {
        "oauth2": {
         "client_id": "test-client-id",

--- a/pkg/services/ngalert/api/test-data/receiver-exports/unredacted/all-integrations.yaml
+++ b/pkg/services/ngalert/api/test-data/receiver-exports/unredacted/all-integrations.yaml
@@ -751,6 +751,7 @@ contactPoints:
             chatid: "12345678"
             disable_notifications: true
             disable_web_page_preview: true
+            send_message_as_caption: true
             http_config:
                 oauth2:
                     client_id: test-client-id

--- a/pkg/services/ngalert/api/tooling/definitions/contact_points.go
+++ b/pkg/services/ngalert/api/tooling/definitions/contact_points.go
@@ -272,6 +272,7 @@ type TelegramIntegration struct {
 	DisableWebPagePreview *bool   `json:"disable_web_page_preview,omitempty" yaml:"disable_web_page_preview,omitempty" hcl:"disable_web_page_preview"`
 	ProtectContent        *bool   `json:"protect_content,omitempty" yaml:"protect_content,omitempty" hcl:"protect_content"`
 	DisableNotifications  *bool   `json:"disable_notifications,omitempty" yaml:"disable_notifications,omitempty" hcl:"disable_notifications"`
+	SendMessageAsCaption  *bool   `json:"send_message_as_caption,omitempty" yaml:"send_message_as_caption,omitempty" hcl:"send_message_as_caption"`
 }
 
 type TeamsIntegration struct {

--- a/public/app/features/alerting/unified/mockGrafanaNotifiers.ts
+++ b/public/app/features/alerting/unified/mockGrafanaNotifiers.ts
@@ -1590,6 +1590,24 @@ export const grafanaAlertNotifiers: Record<GrafanaNotifierType, NotifierDTO> = {
         secure: false,
         dependsOn: '',
       },
+      {
+        element: 'checkbox',
+        inputType: '',
+        label: 'Send Message as Image Caption',
+        description:
+          'Sends a single screenshot and the alert text in one message when the text fits in a Telegram caption.',
+        placeholder: '',
+        propertyName: 'send_message_as_caption',
+        selectOptions: null,
+        showWhen: {
+          field: '',
+          is: '',
+        },
+        required: false,
+        validationRule: '',
+        secure: false,
+        dependsOn: '',
+      },
     ],
   },
   webhook: {


### PR DESCRIPTION
**What is this feature?**

Adds an opt-in `send_message_as_caption` setting to Telegram contact points.

When enabled, notifications containing exactly one screenshot and a message within Telegram's 1024-character caption limit are sent as a single photo with the alert text as its caption.

Notifications with no screenshot, multiple screenshots, or longer messages continue using the existing separate-message behavior.

**Why do we need this feature?**

Grafana currently sends Telegram alert text and its screenshot as separate messages. This makes alerts harder to scan and can separate the screenshot from its context in busy channels.

Using Telegram's native photo caption support keeps the alert text and screenshot together without truncating messages or changing existing behavior by default.

**Who is this feature for?**

Grafana Alerting users who send panel screenshots through Telegram contact points and want each alert and its screenshot delivered as one message.

**Which issue(s) does this PR fix?**:

Related to https://github.com/grafana/alerting/issues/123
Historical context: https://github.com/grafana/grafana/issues/10631
Depends on https://github.com/grafana/alerting/pull/642

**Special notes for your reviewer:**

The setting is disabled by default.

The combined delivery path is used only for one unique screenshot and a caption of at most 1024 Unicode characters. All other cases fall back to the existing delivery flow. Parse mode, protected content, silent notifications, and Telegram message thread IDs are preserved.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle. Not applicable; this is an opt-in contact-point setting disabled by default.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc. The setting is described in the contact-point schema and UI; no separate documentation change is included.