### PR TITLE
Docs: document the tracing file exporter

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -2494,7 +2494,7 @@ When set to `false`, the OTLP client will use TLS credentials with the default s
 
 ### `[tracing.opentelemetry.file]`
 
-Capture Grafana's own traces to a local file in OpenTelemetry Protocol (OTLP) JSON format, without running a collector or a tracing backend.
+Grafana can capture its own distributed traces to a local file in OpenTelemetry Protocol (OTLP) JSON format, without running a collector or a tracing backend.
 Capturing stops when the file reaches the size limit or the capture duration elapses, whichever comes first.
 Use this exporter for support: turn it on, reproduce an issue, then collect and share the file.
 

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -2500,15 +2500,15 @@ Use this exporter for support: turn it on, reproduce an issue, then collect and 
 
 #### `path`
 
-The path to the capture file, for example, `/var/lib/grafana/traces/capture.json`. Setting this option turns on the file exporter. The parent directory must already exist and be writable by Grafana. The default value is empty, which turns off the exporter.
+The path to the capture file, for example, `/var/lib/grafana/traces/capture.json`. Setting this option turns on the file exporter. The parent directory must already exist and be writable by Grafana. Default value is empty, which turns off the exporter.
 
 #### `max_file_size_bytes`
 
-The maximum size of the capture file, in bytes. The default value is `104857600` (100 MiB). The value must be greater than `0`.
+The maximum size of the capture file, in bytes. Default value is `104857600` (100 MiB). The value must be greater than `0`.
 
 #### `capture_duration`
 
-How long to capture traces after Grafana starts, expressed as a duration such as `10m`. The default value is `10m`. The value must be greater than `0`.
+How long to capture traces after Grafana starts, expressed as a duration such as `10m`. Default value is `10m`. The value must be greater than `0`.
 
 <hr>
 

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -2492,6 +2492,26 @@ When set to `false`, the OTLP client will use TLS credentials with the default s
 
 <hr>
 
+### `[tracing.opentelemetry.file]`
+
+Capture Grafana's own traces to a local file in OpenTelemetry Protocol (OTLP) JSON format, without running a collector or a tracing backend.
+Capturing stops when the file reaches the size limit or the capture duration elapses, whichever comes first.
+Use this exporter for support: turn it on, reproduce an issue, then collect and share the file.
+
+#### `path`
+
+The path to the capture file, for example, `/var/lib/grafana/traces/capture.json`. Setting this option turns on the file exporter. The parent directory must already exist and be writable by Grafana. The default is empty, which turns off the exporter.
+
+#### `max_file_size_bytes`
+
+The maximum size of the capture file, in bytes. The default is `104857600` (100 MiB). The value must be greater than `0`.
+
+#### `capture_duration`
+
+How long to capture traces after Grafana starts, expressed as a duration such as `10m`. The default is `10m`. The value must be greater than `0`.
+
+<hr>
+
 ### `[external_image_storage]`
 
 These options control how images should be made public so they can be shared on services like Slack or email message.

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -2500,15 +2500,15 @@ Use this exporter for support: turn it on, reproduce an issue, then collect and 
 
 #### `path`
 
-The path to the capture file, for example, `/var/lib/grafana/traces/capture.json`. Setting this option turns on the file exporter. The parent directory must already exist and be writable by Grafana. The default is empty, which turns off the exporter.
+The path to the capture file, for example, `/var/lib/grafana/traces/capture.json`. Setting this option turns on the file exporter. The parent directory must already exist and be writable by Grafana. The default value is empty, which turns off the exporter.
 
 #### `max_file_size_bytes`
 
-The maximum size of the capture file, in bytes. The default is `104857600` (100 MiB). The value must be greater than `0`.
+The maximum size of the capture file, in bytes. The default value is `104857600` (100 MiB). The value must be greater than `0`.
 
 #### `capture_duration`
 
-How long to capture traces after Grafana starts, expressed as a duration such as `10m`. The default is `10m`. The value must be greater than `0`.
+How long to capture traces after Grafana starts, expressed as a duration such as `10m`. The default value is `10m`. The value must be greater than `0`.
 
 <hr>
 

--- a/docs/sources/setup-grafana/configure-grafana/configure-tracing/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/configure-tracing/index.md
@@ -112,3 +112,20 @@ go tool trace <trace file>
 ```
 
 For more information about how to analyze trace files, refer to [Go command trace](https://golang.org/cmd/trace/).
+
+## Export traces to a file
+
+Grafana can write its own distributed traces to a local file in OpenTelemetry Protocol (OTLP) JSON format, without a collector or a tracing backend. This helps you get traces for debugging without setting up the backend: turn on the exporter, reproduce the issue, then collect and share the file. This feature is not intended to be used as a permanent configuration, but as a helper for troubleshooting issues at Grafana.
+
+This is different from the `-tracing` option in the previous section. That option writes a low-level Go runtime execution trace for `go tool trace`, whereas the file exporter emits the same OpenTelemetry spans that Grafana sends to Jaeger or OTLP endpoints, which describe how requests flow through Grafana.
+
+To turn it on, set a `path` in the `[tracing.opentelemetry.file]` section. Grafana uses this exporter only when you haven't configured a `tracing.opentelemetry.jaeger` or `tracing.opentelemetry.otlp` endpoint. Grafana limits each capture by file size and duration to protect disk space.
+
+```ini
+[tracing.opentelemetry.file]
+path = /var/lib/grafana/traces/capture.json
+```
+
+For the available options, refer to [`[tracing.opentelemetry.file]`](../#tracingopentelemetryfile) in the configuration reference.
+
+To view the captured file, open Grafana, go to **Explore**, select a Tempo data source, and select **Import trace**.

--- a/docs/sources/setup-grafana/configure-grafana/configure-tracing/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/configure-tracing/index.md
@@ -115,7 +115,11 @@ For more information about how to analyze trace files, refer to [Go command trac
 
 ## Export traces to a file
 
-Grafana can write its own distributed traces to a local file in OpenTelemetry Protocol (OTLP) JSON format, without a collector or a tracing backend. This helps you get traces for debugging without setting up the backend: turn on the exporter, reproduce the issue, then collect and share the file. This feature is not intended to be used as a permanent configuration, but as a helper for troubleshooting issues at Grafana.
+Grafana can write its own distributed traces to a local file in OpenTelemetry Protocol (OTLP) JSON format, without a collector or a tracing backend. This helps you get traces for debugging without setting up the backend: turn on the exporter, reproduce the issue, then collect and share the file.
+
+{{< admonition type="note" >}}
+Don't use this exporter as a permanent configuration. Use it to troubleshoot issues in Grafana, then turn it off.
+{{< /admonition >}}
 
 This is different from the `-tracing` option in the previous section. That option writes a low-level Go runtime execution trace for `go tool trace`, whereas the file exporter emits the same OpenTelemetry spans that Grafana sends to Jaeger or OTLP endpoints, which describe how requests flow through Grafana.
 


### PR DESCRIPTION
## What

Documents the new `[tracing.opentelemetry.file]` tracing exporter:

- Adds a config reference section under **Configure Grafana** (`path`, `max_file_size_bytes`, `capture_duration`).
- Adds a short **Export traces to a file** section to the **Configure profiling and tracing** page, including how it differs from the existing `-tracing` Go runtime trace, and how to view the captured file (Explore → Import trace).

## Why

Companion docs for the tracing file exporter added in #128679, which lets operators capture Grafana's own traces to an OTLP/JSON file for troubleshooting — no collector or tracing backend required.

## Notes

Docs-only; a deploy preview will render both pages (worth confirming the config-reference anchor link resolves there).
