### PR TITLE
CI: Report frontend bundle sizes as code stats

### DIFF
--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -398,6 +398,7 @@ jobs:
 
   publish-metrics:
     name: Publish metrics
+    needs: build-frontend # bundle size metrics are read from the built assets manifests
     # Run on `grafana/grafana` main branch only
     if: github.event_name == 'push' && github.repository == 'grafana/grafana' && github.ref_name == 'main'
     permissions:
@@ -420,6 +421,11 @@ jobs:
           cache: 'false' # Don't use setup-node's built in caching, we'll handle it in the yarn-install step
       - name: Install yarn dependencies
         uses: ./.github/actions/yarn-install
+      - name: Download frontend artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: grafana-frontend
+          path: public
       - name: Extract and publish metrics
         run: ./scripts/ci-frontend-metrics.sh | node --experimental-strip-types .github/workflows/scripts/publish-frontend-metrics.mts
         env:

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "plugins:build-bundled": "echo 'bundled plugins are no longer supported'",
     "watch": "yarn start -d watch,start core:start --watchTheme",
     "i18n:stats": "node ./scripts/cli/reportI18nStats.mjs",
+    "bundle-size:stats": "node ./scripts/cli/reportBundleSizeStats.mts",
     "i18n-extract": "LANG=en_US.UTF-8 make i18n-extract",
     "plugin:build": "nx run-many -t build --projects='tag:scope:plugin'",
     "plugin:build:commit": "nx run-many -t build:commit --projects='tag:scope:plugin'",

--- a/scripts/ci-frontend-metrics.sh
+++ b/scripts/ci-frontend-metrics.sh
@@ -46,6 +46,16 @@ do
   I18N_STATS+="\"grafana.ci-code.i18n.${name}\": \"${value}\","
 done <<< "$(yarn i18n:stats)"
 
+# Requires the frontend to have been built (yarn build) so the assets manifests exist.
+# Assigned separately from the herestring below so that set -e catches a failure here.
+BUNDLE_SIZES="$(yarn bundle-size:stats)"
+BUNDLE_SIZE_STATS=""
+while read -r name value
+do
+  BUNDLE_SIZE_STATS+=$'\n  '
+  BUNDLE_SIZE_STATS+="\"grafana.ci-code.bundleSize.${name}\": \"${value}\","
+done <<< "$BUNDLE_SIZES"
+
 THEME_TOKEN_USAGE=""
 while read -r name value
 do
@@ -57,6 +67,7 @@ echo "Metrics: {
   $THEME_TOKEN_USAGE
   $ESLINT_STATS
   $I18N_STATS
+  $BUNDLE_SIZE_STATS
   \"grafana.ci-code.strictErrors\": \"${ERROR_COUNT}\",
   \"grafana.ci-code.directives\": \"${DIRECTIVES}\",
   \"grafana.ci-code.controllers\": \"${CONTROLLERS}\",

--- a/scripts/cli/reportBundleSizeStats.mts
+++ b/scripts/cli/reportBundleSizeStats.mts
@@ -1,0 +1,76 @@
+import { readFile, stat } from 'fs/promises';
+import path, { dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const REPO_ROOT = path.resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const BUILD_DIR = path.join(REPO_ROOT, 'public', 'build');
+
+/**
+ * The two production builds we emit. The names are used as the metric prefix.
+ */
+const MANIFESTS = [
+  { name: 'default', fileName: 'assets-manifest.json' },
+  { name: 'react19', fileName: 'assets-manifest-react19.json' },
+];
+
+interface Entrypoint {
+  assets: Record<string, string[]>;
+}
+
+for (const manifest of MANIFESTS) {
+  const entrypoints = await readEntrypoints(path.join(BUILD_DIR, manifest.fileName));
+
+  for (const [entrypointName, entrypoint] of Object.entries(entrypoints)) {
+    for (const [assetType, assets] of Object.entries(entrypoint.assets)) {
+      // Entrypoints share assets (the webpack runtime, vendor chunks), so these sizes overlap
+      const size = await totalSize(new Set(assets));
+
+      logStat(`${manifest.name}.entrypoints.${entrypointName}.${assetType}`, size);
+    }
+  }
+}
+
+async function readEntrypoints(manifestPath: string): Promise<Record<string, Entrypoint>> {
+  let contents;
+  try {
+    contents = await readFile(manifestPath, 'utf8');
+  } catch (err) {
+    throw new Error(`Could not read ${manifestPath}. Run 'yarn build' first.`, { cause: err });
+  }
+
+  const { entrypoints } = JSON.parse(contents);
+  if (!isEntrypointsMap(entrypoints) || Object.keys(entrypoints).length === 0) {
+    throw new Error(`${manifestPath} has no entrypoints`);
+  }
+
+  return entrypoints;
+}
+
+function isEntrypointsMap(value: unknown): value is Record<string, Entrypoint> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    Object.values(value).every((entry) => typeof entry?.assets === 'object' && entry.assets !== null)
+  );
+}
+
+/**
+ * Asset paths in the manifest include the webpack publicPath (public/build/), which makes them
+ * relative to the repo root.
+ */
+async function totalSize(assetPaths: Iterable<string>) {
+  let size = 0;
+
+  for (const assetPath of assetPaths) {
+    const stats = await stat(path.join(REPO_ROOT, assetPath));
+    size += stats.size;
+  }
+
+  return size;
+}
+
+function logStat(name: string, value: string | number) {
+  // Note that this output format must match the parsing in ci-frontend-metrics.sh
+  // which expects the two values to be separated by a space
+  console.log(`${name} ${value}`);
+}

--- a/scripts/cli/reportBundleSizeStats.mts
+++ b/scripts/cli/reportBundleSizeStats.mts
@@ -38,20 +38,7 @@ async function readEntrypoints(manifestPath: string): Promise<Record<string, Ent
     throw new Error(`Could not read ${manifestPath}. Run 'yarn build' first.`, { cause: err });
   }
 
-  const { entrypoints } = JSON.parse(contents);
-  if (!isEntrypointsMap(entrypoints) || Object.keys(entrypoints).length === 0) {
-    throw new Error(`${manifestPath} has no entrypoints`);
-  }
-
-  return entrypoints;
-}
-
-function isEntrypointsMap(value: unknown): value is Record<string, Entrypoint> {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    Object.values(value).every((entry) => typeof entry?.assets === 'object' && entry.assets !== null)
-  );
+  return JSON.parse(contents).entrypoints;
 }
 
 /**


### PR DESCRIPTION
**What is this feature?**

Adds bundle size metrics to the frontend CI code stats. A new `yarn bundle-size:stats` script reads the entrypoints from the `assets-manifest.json` and `assets-manifest-react19.json` files emitted by the production webpack builds, and reports the total size of each entrypoint's assets by type as `grafana.ci-code.bundleSize.<manifest>.entrypoints.<entrypoint>.<type>`. Because the sizes come from built assets, the `publish-metrics` job now depends on `build-frontend` and downloads its artifact instead of building anything itself.

**Why do we need this feature?**

We have no trend data for how large the initial page load is, so bundle size regressions go unnoticed until someone measures by hand.

**Who is this feature for?**

Grafana developers tracking frontend performance.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Note that entrypoints share assets (the webpack runtime, vendor chunks), so the per-entrypoint numbers overlap — each is that entrypoint's full initial download rather than a disjoint slice. Lazily loaded route chunks are not counted, since the manifests are filtered down to entrypoint assets only.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.