### PR TITLE
Plugins: Serve the grafana.com plugin API from local fixtures in e2e tests

### DIFF
--- a/e2e-playwright/plugin-catalog-suite/tests/utils.ts
+++ b/e2e-playwright/plugin-catalog-suite/tests/utils.ts
@@ -2,12 +2,32 @@ import { type APIRequestContext, type Page, type Request } from '@playwright/tes
 
 import { expect } from '@grafana/plugin-e2e';
 
+import { type GcomPlugin, mockGcomApi } from '../../utils/gcom-api-mock';
+
 // App must be a pure app (no bundled panel) — bundled panels appear in the viz picker and break panelIcons.spec.ts.
-export const PLUGINS = [
-  { id: 'grafana-llm-app', label: 'app' },
-  { id: 'yesoreyeram-infinity-datasource', label: 'datasource' },
-  { id: 'grafana-clock-panel', label: 'panel' },
+// The versions are pinned because the backend downloads the real package from grafana.com; bump them if a
+// version is ever unpublished.
+const CATALOG_PLUGINS: Array<GcomPlugin & { label: string }> = [
+  { slug: 'grafana-llm-app', name: 'LLM', type: 'app', version: '1.0.8', grafanaDependency: '>=9.5.2', label: 'app' },
+  {
+    slug: 'yesoreyeram-infinity-datasource',
+    name: 'Infinity',
+    type: 'datasource',
+    version: '3.11.1',
+    grafanaDependency: '>=11.6.0-0',
+    label: 'datasource',
+  },
+  {
+    slug: 'grafana-clock-panel',
+    name: 'Clock',
+    type: 'panel',
+    version: '3.2.2',
+    grafanaDependency: '>=11.0.0',
+    label: 'panel',
+  },
 ];
+
+export const PLUGINS = CATALOG_PLUGINS.map(({ slug, label }) => ({ id: slug, label }));
 
 type Action = 'install' | 'uninstall';
 
@@ -66,6 +86,7 @@ async function clickAndAssert(
 
 // Install -> uninstall through the catalog UI, asserting the write paths and button flips (uninstall confirms via modal).
 export async function assertInstallUninstallRoundtrip(page: Page, pluginId: string, mt: boolean): Promise<void> {
+  await mockGcomApi(page, CATALOG_PLUGINS);
   await page.goto(`/plugins/${pluginId}`);
 
   const installButton = page.getByRole('button', { name: 'Install', exact: true });

--- a/e2e-playwright/test-plugins/grafana-test-app/tests/utils.ts
+++ b/e2e-playwright/test-plugins/grafana-test-app/tests/utils.ts
@@ -2,6 +2,8 @@ import { type APIRequestContext, type Locator, type Page } from '@playwright/tes
 
 import { expect } from '@grafana/plugin-e2e';
 
+import { mockGcomApi } from '../../../utils/gcom-api-mock';
+
 type WritePath = 'legacy' | 'mt';
 
 function isLegacyWrite(method: string, url: string, pluginId: string): boolean {
@@ -38,6 +40,8 @@ async function clickAndAssertWrite(page: Page, button: Locator, pluginId: string
 // Drives the disable -> enable round-trip, asserting each write routes through `expected` and the
 // reloaded page reflects the new state (button flip).
 export async function assertEnableDisableRoundtrip(page: Page, pluginId: string, expected: WritePath): Promise<void> {
+  // The test plugin isn't published on grafana.com, so the catalog only needs the 404s the mock serves.
+  await mockGcomApi(page);
   await page.goto(`/plugins/${pluginId}`);
 
   const disableButton = page.getByRole('button', { name: 'Disable', exact: true });

--- a/e2e-playwright/utils/gcom-api-mock.ts
+++ b/e2e-playwright/utils/gcom-api-mock.ts
@@ -1,0 +1,141 @@
+import { type Page, type Route } from '@playwright/test';
+
+/**
+ * A plugin as published on grafana.com, reduced to the fields the plugin catalog reads.
+ */
+export interface GcomPlugin {
+  slug: string;
+  name: string;
+  type: 'app' | 'datasource' | 'panel';
+  /**
+   * Reported as the only (and therefore latest compatible) version. Installing a plugin still
+   * downloads the real package through the Grafana backend, so this has to be a version that
+   * exists on grafana.com.
+   */
+  version: string;
+  grafanaDependency: string;
+  description?: string;
+}
+
+// 1x1 transparent PNG, served for plugin logos so the catalog doesn't render broken images.
+const TRANSPARENT_PIXEL = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==',
+  'base64'
+);
+
+/**
+ * Serves the grafana.com plugin API (proxied by Grafana under `/api/gnet`) from local fixtures.
+ *
+ * The plugin catalog blocks rendering on these requests, so tests that open `/plugins/:id` hang
+ * until they resolve. Going to grafana.com for real makes those tests depend on the CI runner's
+ * connectivity to it, which is where the flakiness comes from. Every `/api/gnet` request is
+ * answered here, including for plugins not listed in `plugins` (grafana.com replies 404 for
+ * plugins that were never published, such as the e2e test plugins).
+ *
+ * Call this before navigating.
+ */
+export async function mockGcomApi(page: Page, plugins: GcomPlugin[] = []): Promise<void> {
+  const pluginsBySlug = new Map(plugins.map((plugin) => [plugin.slug, plugin]));
+
+  await page.route(/\/api\/gnet\//, async (route) => {
+    const path = new URL(route.request().url()).pathname.replace(/^.*\/api\/gnet/, '');
+
+    if (path === '/plugins') {
+      return fulfillJson(route, { items: plugins.map(toRemotePlugin) });
+    }
+
+    const [, slug, rest = ''] = path.match(/^\/plugins\/([^/]+)(\/.*)?$/) ?? [];
+    const plugin = slug ? pluginsBySlug.get(slug) : undefined;
+
+    if (!plugin) {
+      return fulfillNotFound(route);
+    }
+
+    if (rest === '') {
+      return fulfillJson(route, toRemotePlugin(plugin));
+    }
+
+    if (rest === '/versions') {
+      return fulfillJson(route, { items: [toVersion(plugin)] });
+    }
+
+    if (rest === `/versions/${plugin.version}`) {
+      return fulfillJson(route, toVersion(plugin));
+    }
+
+    if (/^\/versions\/[^/]+\/logos\/[^/]+$/.test(rest)) {
+      return route.fulfill({ status: 200, contentType: 'image/png', body: TRANSPARENT_PIXEL });
+    }
+
+    // Insights and entitlements are only available for a subset of plugins on grafana.com, and the
+    // catalog treats a 404 as "no data" rather than as an error.
+    return fulfillNotFound(route);
+  });
+}
+
+function toRemotePlugin(plugin: GcomPlugin) {
+  return {
+    id: 0,
+    slug: plugin.slug,
+    name: plugin.name,
+    description: plugin.description ?? plugin.name,
+    typeCode: plugin.type,
+    typeId: 0,
+    typeName: plugin.type,
+    version: plugin.version,
+    versionStatus: 'active',
+    versionSignatureType: 'grafana',
+    versionSignedByOrg: 'grafana',
+    versionSignedByOrgName: 'Grafana Labs',
+    versionDistributionType: 'catalog',
+    signatureType: 'grafana',
+    status: 'active',
+    statusContext: '',
+    angularDetected: false,
+    internal: false,
+    verified: true,
+    featured: 0,
+    downloads: 0,
+    downloadSlug: plugin.slug,
+    popularity: 0,
+    keywords: [],
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+    orgId: 0,
+    orgName: 'Grafana Labs',
+    orgSlug: 'grafana',
+    orgUrl: 'https://grafana.com',
+    url: 'https://grafana.com',
+    userId: 0,
+    changelog: '',
+    readme: '',
+    links: [],
+    packages: {},
+    managed: { enabled: false },
+    json: { dependencies: { grafanaDependency: plugin.grafanaDependency, plugins: [] }, info: { links: [] } },
+  };
+}
+
+function toVersion(plugin: GcomPlugin) {
+  return {
+    version: plugin.version,
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+    isCompatible: true,
+    grafanaDependency: plugin.grafanaDependency,
+    angularDetected: false,
+    status: 'active',
+  };
+}
+
+function fulfillJson(route: Route, body: unknown) {
+  return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+}
+
+function fulfillNotFound(route: Route) {
+  return route.fulfill({
+    status: 404,
+    contentType: 'application/json',
+    body: JSON.stringify({ message: 'Not found' }),
+  });
+}

--- a/e2e-playwright/various-suite/frontend-sandbox-app.spec.ts
+++ b/e2e-playwright/various-suite/frontend-sandbox-app.spec.ts
@@ -1,5 +1,7 @@
 import { test, expect } from '@grafana/plugin-e2e';
 
+import { mockGcomApi } from '../utils/gcom-api-mock';
+
 const APP_ID = 'sandbox-app-test';
 
 test.describe(
@@ -28,6 +30,8 @@ test.describe(
       });
 
       test('Loads the app configuration with the sandbox div wrapper', async ({ page }) => {
+        // The plugin catalog fetches grafana.com; `networkidle` would wait for that round trip.
+        await mockGcomApi(page);
         await page.goto(`/plugins/${APP_ID}`, { waitUntil: 'networkidle' });
 
         const sandboxDiv = page.locator('div[data-plugin-sandbox="sandbox-app-test"]');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What is this feature?**

The Playwright tests that open a plugin details page (`/plugins/:id`) now answer every `/api/gnet/*` request — the plugin catalog's grafana.com traffic, proxied by the Grafana backend — from local fixtures instead of letting it reach grafana.com.

- New helper `e2e-playwright/utils/gcom-api-mock.ts` serves the catalog list, per-plugin metadata, versions and logos, and replies 404 for anything not in its fixtures (which is what grafana.com does for plugins that were never published, such as the e2e test plugins).
- Used by `plugin-catalog-suite` (install/uninstall, legacy + MT), `test-plugins/grafana-test-app` (enable/disable, legacy + MT), and the sandbox app configuration test in `various-suite`.

**Why do we need this feature?**

These tests have been failing on `main` and blocking CI. Every failure has the same shape: `expect(locator).toBeVisible()` for the Install/Enable button times out after 10s.

The Playwright traces from the failing runs show why. `GET /api/gnet/plugins?includeDeprecated=true` never completes (status `-1`, still pending when the test ends):

```
1-trace.network 200 GET /api/plugins?embedded=include-datasource&accesscontrol=true time=96.5
1-trace.network  -1 GET /api/gnet/plugins?includeDeprecated=true            time=-1
```

`PluginDetailsPage` gates rendering on `useFetchStatus()`, which is `isAllLoading || isLocalLoading || isRemoteLoading`. `isRemoteLoading` stays true until the grafana.com request settles, so a slow grafana.com leaves the page on its loading spinner indefinitely and no button ever renders. `fetchAll` already falls back to local-only data after 500ms for the catalog *list* page, but it never dispatches `fetchRemote/fulfilled`, so the *details* page keeps waiting.

That made three separate test groups depend on how fast the CI runner can reach grafana.com:

| Test | Symptom |
| --- | --- |
| `installUninstallPlugins.spec.ts` (legacy + MT) | `Install` button never visible |
| `enableDisableAppPlugin.spec.ts` (legacy + MT) | `Enable` button never visible after the post-write reload |
| `frontend-sandbox-app.spec.ts` | `waitUntil: 'networkidle'` never settles while the request is pending |

**Who is this feature for?**

Anyone whose PR is blocked by these e2e tests.

**Which issue(s) does this PR fix?**:

Fixes the recurring plugin e2e failures on `main`.

**Special notes for your reviewer:**

Installing a plugin still downloads the real package from grafana.com through the backend, which is the behaviour under test, so the fixtures pin versions that exist on grafana.com (`grafana-llm-app@1.0.8`, `yesoreyeram-infinity-datasource@3.11.1`, `grafana-clock-panel@3.2.2`). Only the browser-side catalog traffic is mocked.

I did not change `PluginDetailsPage` here — the page arguably shouldn't block on grafana.com once it has local data for the plugin — since that's product behaviour and belongs in a separate frontend PR.

Verified by reproducing the CI condition locally: a listener that accepts TLS connections and never responds, with `grafana.com` pointed at it in `/etc/hosts`, so grafana.com hangs exactly as it did in the failing runs.

Before (on `main`, grafana.com hanging) — `installUninstallPlugins` and `enableDisableAppPlugin` both fail, page stuck on the spinner:

[Plugin details page stuck on Loading](https://cursor.com/agents/bc-f7c28586-d123-550f-a47c-6766a7d0011e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbefore_plugin_details_stuck_loading.png)

After (same conditions) — the page renders and the tests pass:

[Plugin details page rendered with Disable button](https://cursor.com/agents/bc-f7c28586-d123-550f-a47c-6766a7d0011e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fafter_plugin_details_renders.png)

```
✓ [various] frontend-sandbox-app.spec.ts › Loads the app page with the sandbox div wrapper
✓ [various] frontend-sandbox-app.spec.ts › Loads the app configuration with the sandbox div wrapper
✓ [grafana-e2etest-app] enableDisableAppPlugin.spec.ts › disables and enables via POST /api/plugins/:id/settings
✓ [grafana-e2etest-app-mt] enableDisableAppPlugin.spec.ts › disables and enables via PATCH /apis/:id/.../app/instance
```

And with grafana.com reachable, the full set of plugin projects passes (15/15), including the three install/uninstall round trips on both the legacy and MT paths.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://raintank-corp.slack.com/archives/C08JKQKQ448/p1785177974115549?thread_ts=1785177974.115549&cid=C08JKQKQ448)

<div><a href="https://cursor.com/agents/bc-f7c28586-d123-550f-a47c-6766a7d0011e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f7c28586-d123-550f-a47c-6766a7d0011e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

