### PR TITLE
Alerting: Combine MuteTimeInterval & TimeInterval in model

### DIFF
--- a/pkg/services/ngalert/api/api_provisioning_test.go
+++ b/pkg/services/ngalert/api/api_provisioning_test.go
@@ -2208,14 +2208,14 @@ func TestApiGetSnapshots(t *testing.T) {
 			Location: &timeinterval.Location{Location: location},
 		}
 	}
-	cfg.AlertmanagerConfig.MuteTimeIntervals = append(cfg.AlertmanagerConfig.MuteTimeIntervals,
-		v1.MuteTimeInterval{
+	cfg.AlertmanagerConfig.TimeIntervals = append(cfg.AlertmanagerConfig.TimeIntervals,
+		v1.TimeInterval{
 			Name: "MuteTimeIntervalA",
 			TimeIntervals: []timeinterval.TimeInterval{
 				timeIntervalExample(),
 			},
 		},
-		v1.MuteTimeInterval{
+		v1.TimeInterval{
 			Name: "MuteTimeIntervalB",
 			TimeIntervals: []timeinterval.TimeInterval{
 				timeIntervalExample(),

--- a/pkg/services/ngalert/notifier/autogen_alertmanager_test.go
+++ b/pkg/services/ngalert/notifier/autogen_alertmanager_test.go
@@ -40,7 +40,7 @@ func TestAddAutogenConfig(t *testing.T) {
 			})
 		}
 		for _, muteInterval := range muteIntervals {
-			cfg.AlertmanagerConfig.MuteTimeIntervals = append(cfg.AlertmanagerConfig.MuteTimeIntervals, v1.MuteTimeInterval{
+			cfg.AlertmanagerConfig.TimeIntervals = append(cfg.AlertmanagerConfig.TimeIntervals, v1.TimeInterval{
 				Name: muteInterval,
 			})
 		}

--- a/pkg/services/ngalert/notifier/compat.go
+++ b/pkg/services/ngalert/notifier/compat.go
@@ -75,7 +75,7 @@ func PostableAPIConfigToNotificationsConfiguration(
 	return alertingNotify.NotificationsConfiguration{
 		RoutingTree:   RouteToAPI(cfg.AlertmanagerConfig.Route),
 		InhibitRules:  append(inhibitionRules, cfg.AlertmanagerConfig.InhibitRules...),
-		TimeIntervals: ModelToTimeIntervals(cfg.AlertmanagerConfig.TimeIntervals, cfg.AlertmanagerConfig.MuteTimeIntervals),
+		TimeIntervals: ModelToTimeIntervals(cfg.AlertmanagerConfig.TimeIntervals),
 		Templates:     ModelToTemplateDefinitions(cfg.SortedTemplates()), // templates are already merged.
 		Receivers:     receivers,
 		Limits:        limits,
@@ -109,15 +109,8 @@ func ModelToReceiverConfig(r *v1.PostableApiReceiver) (alertingModels.ReceiverCo
 	return result, nil
 }
 
-func ModelToTimeIntervals(in []v1.TimeInterval, mute []v1.MuteTimeInterval) []alertingNotify.TimeInterval {
-	// go with mute intervals first, in the case of collision in the alertmanager, the last will will, which is expected behavior.
-	out := make([]alertingNotify.TimeInterval, 0, len(in)+len(mute))
-	for _, t := range mute {
-		out = append(out, config.TimeInterval{
-			Name:          t.Name,
-			TimeIntervals: t.TimeIntervals,
-		})
-	}
+func ModelToTimeIntervals(in []v1.TimeInterval) []alertingNotify.TimeInterval {
+	out := make([]alertingNotify.TimeInterval, 0, len(in))
 	for _, t := range in {
 		out = append(out, config.TimeInterval{
 			Name:          t.Name,

--- a/pkg/services/ngalert/notifier/compat_test.go
+++ b/pkg/services/ngalert/notifier/compat_test.go
@@ -16,9 +16,6 @@ func TestModelToTimeIntervals(t *testing.T) {
 	ti := func(name string, intervals ...timeinterval.TimeInterval) v1.TimeInterval {
 		return v1.TimeInterval{Name: name, TimeIntervals: intervals}
 	}
-	mti := func(name string, intervals ...timeinterval.TimeInterval) v1.MuteTimeInterval {
-		return v1.MuteTimeInterval{Name: name, TimeIntervals: intervals}
-	}
 	want := func(name string, intervals ...timeinterval.TimeInterval) config.TimeInterval {
 		return config.TimeInterval{Name: name, TimeIntervals: intervals}
 	}
@@ -26,36 +23,22 @@ func TestModelToTimeIntervals(t *testing.T) {
 	testCases := []struct {
 		name     string
 		in       []v1.TimeInterval
-		mute     []v1.MuteTimeInterval
 		expected []config.TimeInterval
 	}{
 		{
-			name:     "both empty",
+			name:     "empty",
 			expected: []config.TimeInterval{},
 		},
 		{
-			name:     "only time intervals",
+			name:     "time intervals",
 			in:       []v1.TimeInterval{ti("ti-1"), ti("ti-2")},
 			expected: []config.TimeInterval{want("ti-1"), want("ti-2")},
 		},
 		{
-			name:     "only mute time intervals converted to time intervals",
-			mute:     []v1.MuteTimeInterval{mti("mti-1"), mti("mti-2")},
-			expected: []config.TimeInterval{want("mti-1"), want("mti-2")},
-		},
-		{
-			name:     "mute time intervals come before time intervals",
-			in:       []v1.TimeInterval{ti("ti-1"), ti("ti-2")},
-			mute:     []v1.MuteTimeInterval{mti("mti-1")},
-			expected: []config.TimeInterval{want("mti-1"), want("ti-1"), want("ti-2")},
-		},
-		{
-			name: "preserves TimeIntervals payload",
+			name: "preserves TimeIntervals payload and order",
 			in: []v1.TimeInterval{
-				{Name: "ti-1", TimeIntervals: []timeinterval.TimeInterval{{Weekdays: []timeinterval.WeekdayRange{weekdayRange}}}},
-			},
-			mute: []v1.MuteTimeInterval{
 				{Name: "mti-1", TimeIntervals: []timeinterval.TimeInterval{{Weekdays: []timeinterval.WeekdayRange{weekdayRange}}}},
+				{Name: "ti-1", TimeIntervals: []timeinterval.TimeInterval{{Weekdays: []timeinterval.WeekdayRange{weekdayRange}}}},
 			},
 			expected: []config.TimeInterval{
 				{Name: "mti-1", TimeIntervals: []timeinterval.TimeInterval{{Weekdays: []timeinterval.WeekdayRange{weekdayRange}}}},
@@ -66,7 +49,7 @@ func TestModelToTimeIntervals(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result := ModelToTimeIntervals(tc.in, tc.mute)
+			result := ModelToTimeIntervals(tc.in)
 			assert.Equal(t, tc.expected, result)
 		})
 	}

--- a/pkg/services/ngalert/notifier/legacy_storage/imported.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/imported.go
@@ -64,29 +64,21 @@ func (e ImportedConfigRevision) GetReceivers(uids []string) ([]*models.Receiver,
 	return result, nil
 }
 
-func (e ImportedConfigRevision) GetMuteTimeIntervals() ([]v1.MuteTimeInterval, error) {
+func (e ImportedConfigRevision) GetTimeIntervals() ([]v1.TimeInterval, error) {
 	if e.importedConfig == nil {
 		return nil, nil
 	}
 
 	// Get original imported intervals (before deduplication)
-	importedMute := e.importedConfig.ToGrafanaMuteTimeIntervals()
-	importedTime := e.importedConfig.ToGrafanaTimeIntervals()
-
-	if len(importedMute) == 0 && len(importedTime) == 0 {
+	imported := e.importedConfig.ToGrafanaTimeIntervals()
+	if len(imported) == 0 {
 		return nil, nil
 	}
 
-	// Get Grafana time intervals for merge
-	grafanaMute := e.rev.Config.AlertmanagerConfig.MuteTimeIntervals
-	grafanaTime := e.rev.Config.AlertmanagerConfig.TimeIntervals
-
 	// Merge to get the renames map (only renamed if name collision occurs)
 	timeIntervals, _, added := merge.TimeIntervals(
-		grafanaMute,
-		grafanaTime,
-		importedMute,
-		importedTime,
+		e.rev.Config.AlertmanagerConfig.TimeIntervals,
+		imported,
 		e.identifier,
 	)
 
@@ -96,13 +88,12 @@ func (e ImportedConfigRevision) GetMuteTimeIntervals() ([]v1.MuteTimeInterval, e
 	}
 
 	// Filter to imported intervals
-	result := make([]v1.MuteTimeInterval, 0, len(added))
+	result := make([]v1.TimeInterval, 0, len(added))
 	for _, ti := range timeIntervals {
 		if _, ok := importedTitles[ti.Name]; !ok {
 			continue
 		}
-
-		result = append(result, v1.MuteTimeInterval(ti))
+		result = append(result, ti)
 	}
 
 	return result, nil

--- a/pkg/services/ngalert/notifier/legacy_storage/receivers_test.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/receivers_test.go
@@ -490,8 +490,6 @@ func getConfigRevisionForTest(opts ...opt) *ConfigRevision {
 					Route: &v1.Route{Receiver: "receiver1"},
 					TimeIntervals: []v1.TimeInterval{
 						{Name: "time-interval-1"},
-					},
-					MuteTimeIntervals: []v1.MuteTimeInterval{
 						{Name: "mute-interval-1"},
 					},
 				},

--- a/pkg/services/ngalert/notifier/legacy_storage/routes.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/routes.go
@@ -301,9 +301,6 @@ func (rev *ConfigRevision) validateReceiverReferences(route v1.Route) error {
 
 func (rev *ConfigRevision) validateTimeIntervalReferences(route v1.Route) error {
 	timeIntervals := map[string]struct{}{}
-	for _, mt := range rev.Config.AlertmanagerConfig.MuteTimeIntervals {
-		timeIntervals[mt.Name] = struct{}{}
-	}
 	for _, mt := range rev.Config.AlertmanagerConfig.TimeIntervals {
 		timeIntervals[mt.Name] = struct{}{}
 	}

--- a/pkg/services/ngalert/notifier/legacy_storage/v1/compat.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/v1/compat.go
@@ -41,41 +41,29 @@ func ToModel(in *definitions.PostableUserConfig) *AMConfigV1 {
 func PostableApiAlertingConfigToModel(in definition.PostableApiAlertingConfig) PostableApiAlertingConfig {
 	return PostableApiAlertingConfig{
 		Config: Config{
-			Global:            in.Global,
-			Route:             RouteToModel(in.Route),
-			InhibitRules:      slices.Clone(in.InhibitRules),
-			Templates:         slices.Clone(in.Templates),
-			MuteTimeIntervals: MuteTimeIntervalsToModel(in.MuteTimeIntervals),
-			TimeIntervals:     TimeIntervalsToModel(in.TimeIntervals),
+			Global:        in.Global,
+			Route:         RouteToModel(in.Route),
+			InhibitRules:  slices.Clone(in.InhibitRules),
+			Templates:     slices.Clone(in.Templates),
+			TimeIntervals: TimeIntervalsToModel(in.MuteTimeIntervals, in.TimeIntervals),
 		},
 		Receivers: ReceiversToModel(in.Receivers),
 	}
 }
 
-func MuteTimeIntervalsToModel(in []config.MuteTimeInterval) []MuteTimeInterval {
-	if in == nil {
+func TimeIntervalsToModel(muteIntervals []config.MuteTimeInterval, timeIntervals []config.TimeInterval) []TimeInterval {
+	if muteIntervals == nil && timeIntervals == nil {
 		return nil
 	}
-	out := make([]MuteTimeInterval, 0, len(in))
-	for _, interval := range in {
-		out = append(out, MuteTimeInterval{
-			Name:          interval.Name,
-			TimeIntervals: interval.TimeIntervals,
-		})
+	// Fold mute time intervals into time intervals, mute first. A name cannot appear in both lists
+	// because Config rejects duplicates across them at unmarshal time, so the order only needs to be
+	// stable; mute-first matches what the config was previously flattened to when applied.
+	out := make([]TimeInterval, 0, len(muteIntervals)+len(timeIntervals))
+	for _, interval := range muteIntervals {
+		out = append(out, TimeInterval(interval))
 	}
-	return out
-}
-
-func TimeIntervalsToModel(in []config.TimeInterval) []TimeInterval {
-	if in == nil {
-		return nil
-	}
-	out := make([]TimeInterval, 0, len(in))
-	for _, interval := range in {
-		out = append(out, TimeInterval{
-			Name:          interval.Name,
-			TimeIntervals: interval.TimeIntervals,
-		})
+	for _, interval := range timeIntervals {
+		out = append(out, TimeInterval(interval))
 	}
 	return out
 }
@@ -239,29 +227,14 @@ func ToDBModel(in *AMConfigV1) (*AMConfigDB, error) {
 func PostableApiAlertingConfigToDB(in PostableApiAlertingConfig) definition.PostableApiAlertingConfig {
 	return definition.PostableApiAlertingConfig{
 		Config: definition.Config{
-			Global:            in.Global,
-			Route:             RouteToDB(in.Route),
-			InhibitRules:      slices.Clone(in.InhibitRules),
-			Templates:         slices.Clone(in.Templates),
-			MuteTimeIntervals: MuteTimeIntervalsToDB(in.MuteTimeIntervals),
-			TimeIntervals:     TimeIntervalsToDB(in.TimeIntervals),
+			Global:        in.Global,
+			Route:         RouteToDB(in.Route),
+			InhibitRules:  slices.Clone(in.InhibitRules),
+			Templates:     slices.Clone(in.Templates),
+			TimeIntervals: TimeIntervalsToDB(in.TimeIntervals),
 		},
 		Receivers: ReceiversToDB(in.Receivers),
 	}
-}
-
-func MuteTimeIntervalsToDB(in []MuteTimeInterval) []config.MuteTimeInterval {
-	if in == nil {
-		return nil
-	}
-	out := make([]config.MuteTimeInterval, 0, len(in))
-	for _, interval := range in {
-		out = append(out, config.MuteTimeInterval{
-			Name:          interval.Name,
-			TimeIntervals: interval.TimeIntervals,
-		})
-	}
-	return out
 }
 
 func TimeIntervalsToDB(in []TimeInterval) []config.TimeInterval {

--- a/pkg/services/ngalert/notifier/legacy_storage/v1/compat_test.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/v1/compat_test.go
@@ -11,6 +11,7 @@ import (
 	alertingNotify "github.com/grafana/alerting/notify"
 	emailV0 "github.com/grafana/alerting/receivers/email/v0mimir1"
 	webhookV0 "github.com/grafana/alerting/receivers/webhook/v0mimir1"
+	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/pkg/labels"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -236,15 +237,26 @@ inhibit_rules:
 	require.NoError(t, err)
 	require.NotNil(t, convertedDB)
 
+	// The round-trip is lossless except that deprecated mute_time_intervals are folded into
+	// time_intervals (mute first) by design, so build the expectation from the same fold.
+	folderIntervals := make([]config.TimeInterval, 0, len(originalDB.AlertmanagerConfig.MuteTimeIntervals)+len(originalDB.AlertmanagerConfig.TimeIntervals))
+	for _, mt := range originalDB.AlertmanagerConfig.MuteTimeIntervals {
+		folderIntervals = append(folderIntervals, config.TimeInterval(mt))
+	}
+	originalDB.AlertmanagerConfig.TimeIntervals = append(folderIntervals, originalDB.AlertmanagerConfig.TimeIntervals...)
+	originalDB.AlertmanagerConfig.MuteTimeIntervals = nil
+
 	diff := cmp.Diff(originalDB, convertedDB, cmpopts.IgnoreUnexported(AMConfigDB{}, definition.Route{}, labels.Matcher{}))
 	if diff != "" {
 		t.Errorf("Unexpected change in converted DB: %v", diff)
 	}
 
+	expectedJSON, err := json.Marshal(originalDB)
+	require.NoError(t, err)
 	convertedJSON, err := json.Marshal(convertedDB)
 	require.NoError(t, err)
 
-	require.JSONEq(t, configJSON, string(convertedJSON),
+	require.JSONEq(t, string(expectedJSON), string(convertedJSON),
 		"Round-trip conversion should be lossless")
 }
 

--- a/pkg/services/ngalert/notifier/legacy_storage/v1/model.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/v1/model.go
@@ -120,14 +120,9 @@ func (c *ExtraAlertmanagerConfig) ToGrafanaRoute() *Route {
 	return RouteToModel(definition.AsGrafanaRoute(c.Route))
 }
 
-// ToGrafanaMuteTimeIntervals converts the imported mute time intervals to Grafana's type.
-func (c *ExtraAlertmanagerConfig) ToGrafanaMuteTimeIntervals() []MuteTimeInterval {
-	return MuteTimeIntervalsToModel(c.MuteTimeIntervals)
-}
-
 // ToGrafanaTimeIntervals converts the imported time intervals to Grafana's type.
 func (c *ExtraAlertmanagerConfig) ToGrafanaTimeIntervals() []TimeInterval {
-	return TimeIntervalsToModel(c.TimeIntervals)
+	return TimeIntervalsToModel(c.MuteTimeIntervals, c.TimeIntervals)
 }
 
 // ReceiverNameStubs returns the imported receivers as Grafana receivers populated with only
@@ -281,10 +276,6 @@ func (c *PostableApiAlertingConfig) GetReceivers() []*PostableApiReceiver {
 	return c.Receivers
 }
 
-func (c *PostableApiAlertingConfig) GetMuteTimeIntervals() []MuteTimeInterval {
-	return c.MuteTimeIntervals
-}
-
 func (c *PostableApiAlertingConfig) GetTimeIntervals() []TimeInterval { return c.TimeIntervals }
 
 func (c *PostableApiAlertingConfig) GetRoute() *Route {
@@ -341,10 +332,11 @@ type Config struct {
 	Route        *Route
 	InhibitRules []config.InhibitRule
 
-	// MuteTimeIntervals is deprecated and will be removed before Alertmanager 1.0.
-	MuteTimeIntervals []MuteTimeInterval
-	TimeIntervals     []TimeInterval
-	Templates         []string
+	// TimeIntervals holds both the deprecated mute_time_intervals and time_intervals stored in the
+	// database, folded into one list with the mute intervals first. The split is not preserved: on
+	// save everything is written back as time_intervals.
+	TimeIntervals []TimeInterval
+	Templates     []string
 }
 
 type ObjectMatchers labels.Matchers
@@ -509,22 +501,17 @@ func (r *Route) ResourceID() string {
 
 type Provenance string
 
-type MuteTimeInterval struct {
-	Name          string
-	TimeIntervals []timeinterval.TimeInterval
-}
-
-func (mt *MuteTimeInterval) ResourceType() string {
-	return "muteTimeInterval"
-}
-
-func (mt *MuteTimeInterval) ResourceID() string {
-	return mt.Name
-}
-
 type TimeInterval struct {
 	Name          string
 	TimeIntervals []timeinterval.TimeInterval
+}
+
+func (mt *TimeInterval) ResourceType() string {
+	return "muteTimeInterval" // Intentionally kept as-is for backwards compatibility.
+}
+
+func (mt *TimeInterval) ResourceID() string {
+	return mt.Name
 }
 
 type PostableApiReceiver struct {

--- a/pkg/services/ngalert/notifier/legacy_storage/v1/model_test.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/v1/model_test.go
@@ -148,13 +148,10 @@ func TestExtraAlertmanagerConfig_ToGrafanaTimeIntervals(t *testing.T) {
 		TimeIntervals:     []config.TimeInterval{{Name: "business-hours"}},
 	}
 
-	mutes := c.ToGrafanaMuteTimeIntervals()
-	require.Len(t, mutes, 1)
-	assert.Equal(t, "weekends", mutes[0].Name)
-
 	times := c.ToGrafanaTimeIntervals()
-	require.Len(t, times, 1)
-	assert.Equal(t, "business-hours", times[0].Name)
+	require.Len(t, times, 2)
+	assert.Equal(t, "weekends", times[0].Name)
+	assert.Equal(t, "business-hours", times[1].Name)
 }
 
 func TestExtraAlertmanagerConfig_ReceiverNameStubs(t *testing.T) {

--- a/pkg/services/ngalert/notifier/merge/merge.go
+++ b/pkg/services/ngalert/notifier/merge/merge.go
@@ -141,9 +141,7 @@ func MergeExtraConfig(_ context.Context, cfg *v1.AMConfigV1) (v1.AMConfigV1, Mer
 	mergedReceivers, renamedReceivers, addedReceivers := Receivers(cfg.AlertmanagerConfig.Receivers, importedReceivers, mimirCfg.Identifier)
 
 	mergedTimeIntervals, renamedTimeIntervals, addedTimeIntervals := TimeIntervals(
-		cfg.AlertmanagerConfig.MuteTimeIntervals,
 		cfg.AlertmanagerConfig.TimeIntervals,
-		mcfg.ToGrafanaMuteTimeIntervals(),
 		mcfg.ToGrafanaTimeIntervals(),
 		mimirCfg.Identifier,
 	)
@@ -202,43 +200,28 @@ func MergeExtraConfig(_ context.Context, cfg *v1.AMConfigV1) (v1.AMConfigV1, Mer
 func DeduplicateResources(a v1.PostableApiAlertingConfig, b v1.ExtraAlertmanagerConfig, identifier string) RenameResources {
 	_, renamedReceivers, _ := Receivers(a.Receivers, b.ReceiverNameStubs(), identifier)
 	_, renamedTimeIntervals, _ := TimeIntervals(
-		a.MuteTimeIntervals,
 		a.TimeIntervals,
-		b.ToGrafanaMuteTimeIntervals(),
 		b.ToGrafanaTimeIntervals(),
 		identifier,
 	)
 	return RenameResources{Receivers: renamedReceivers, TimeIntervals: renamedTimeIntervals}
 }
 
-// TimeIntervals merges existing and incoming time intervals and mute intervals, ensuring unique names by appending a
+// TimeIntervals merges existing and incoming time intervals, ensuring unique names by appending a
 // suffix derived from identifier. It returns a merged list of time intervals, a map of renamed interval names for
-// tracking adjustments made, and the final names of the incoming intervals (post-rename) in their original order
-// (mute intervals first, then time intervals). Mute time intervals are converted to time intervals.
+// tracking adjustments made, and the final names of the incoming intervals (post-rename) in their original order.
 func TimeIntervals(
-	existingMuteIntervals []v1.MuteTimeInterval,
-	existingTimeIntervals []v1.TimeInterval,
-	incomingMuteIntervals []v1.MuteTimeInterval,
-	incomingTimeIntervals []v1.TimeInterval,
+	existing []v1.TimeInterval,
+	incoming []v1.TimeInterval,
 	identifier string,
 ) ([]v1.TimeInterval, map[string]string, []string) {
 	dedupSuffix := getDedupSuffix(identifier)
-	// combine all incoming intervals into a single list
-	incomingAll := make([]v1.TimeInterval, 0, len(incomingTimeIntervals)+len(incomingMuteIntervals))
-	for _, interval := range incomingMuteIntervals {
-		incomingAll = append(incomingAll, v1.TimeInterval(interval))
-	}
-	incomingAll = append(incomingAll, incomingTimeIntervals...)
-	usedNames := createIndexTimeIntervals(existingMuteIntervals, existingTimeIntervals, incomingAll)
-	result := make([]v1.TimeInterval, 0, len(existingMuteIntervals)+len(existingTimeIntervals)+len(incomingMuteIntervals)+len(incomingTimeIntervals))
-	// fold mute time intervals into time intervals. The order is important here because during the applying time intervals with the same name win
-	for _, interval := range existingMuteIntervals {
-		result = append(result, v1.TimeInterval(interval))
-	}
-	result = append(result, existingTimeIntervals...)
+	usedNames := createIndexTimeIntervals(existing, incoming)
+	result := make([]v1.TimeInterval, 0, len(existing)+len(incoming))
+	result = append(result, existing...)
 	renames := make(map[string]string)
-	added := make([]string, 0, len(incomingAll))
-	for idx, interval := range incomingAll {
+	added := make([]string, 0, len(incoming))
+	for idx, interval := range incoming {
 		curName := interval.Name
 		if i, ok := usedNames[curName]; ok && i != idx { // if the name is already used by another interval, append a suffix.
 			newName := getUniqueName(curName, dedupSuffix, usedNames)
@@ -253,19 +236,15 @@ func TimeIntervals(
 }
 
 func createIndexTimeIntervals(
-	existingMuteIntervals []v1.MuteTimeInterval,
-	existingTimeIntervals []v1.TimeInterval,
-	incomingTimeIntervals []v1.TimeInterval,
+	existing []v1.TimeInterval,
+	incoming []v1.TimeInterval,
 ) map[string]int {
 	// usedNames is a map of existing interval names where value is the index of the interval that holds the name in the incoming list.
-	usedNames := make(map[string]int, len(existingMuteIntervals)+len(existingTimeIntervals)+len(incomingTimeIntervals))
-	for _, r := range existingMuteIntervals {
+	usedNames := make(map[string]int, len(existing)+len(incoming))
+	for _, r := range existing {
 		usedNames[r.Name] = -1
 	}
-	for _, r := range existingTimeIntervals {
-		usedNames[r.Name] = -1
-	}
-	for idx, r := range incomingTimeIntervals {
+	for idx, r := range incoming {
 		if _, ok := usedNames[r.Name]; !ok {
 			usedNames[r.Name] = idx
 		}

--- a/pkg/services/ngalert/notifier/merge/merge_test.go
+++ b/pkg/services/ngalert/notifier/merge/merge_test.go
@@ -163,38 +163,29 @@ func TestTimeIntervals(t *testing.T) {
 			Name: name,
 		}
 	}
-	mti := func(name string) v1.MuteTimeInterval {
-		return v1.MuteTimeInterval{
-			Name: name,
-		}
-	}
 
 	identifier := "dupe"
 	suffix := getDedupSuffix(identifier)
 
+	// Mute and time intervals are already folded into a single ordered list at the model
+	// boundary (mute intervals first), so these fixtures reflect that combined ordering.
 	testCases := []struct {
-		name                  string
-		existingMuteIntervals []v1.MuteTimeInterval
-		existingTimeIntervals []v1.TimeInterval
-		incomingMuteIntervals []v1.MuteTimeInterval
-		incomingTimeIntervals []v1.TimeInterval
-		expected              []v1.TimeInterval
-		expectedRenames       map[string]string
-		expectedAdded         []string
+		name            string
+		existing        []v1.TimeInterval
+		incoming        []v1.TimeInterval
+		expected        []v1.TimeInterval
+		expectedRenames map[string]string
+		expectedAdded   []string
 	}{
 		{
 			name: "should append copies of incoming to existing time intervals",
-			existingMuteIntervals: []v1.MuteTimeInterval{
-				mti("mti1"),
-			},
-			existingTimeIntervals: []v1.TimeInterval{
+			existing: []v1.TimeInterval{
+				ti("mti1"),
 				ti("ti2"),
 			},
-			incomingTimeIntervals: []v1.TimeInterval{
+			incoming: []v1.TimeInterval{
+				ti("mti3"),
 				ti("ti4"),
-			},
-			incomingMuteIntervals: []v1.MuteTimeInterval{
-				mti("mti3"),
 			},
 			expected: []v1.TimeInterval{
 				ti("mti1"),
@@ -207,17 +198,13 @@ func TestTimeIntervals(t *testing.T) {
 		},
 		{
 			name: "should rename incoming if there is existing",
-			existingMuteIntervals: []v1.MuteTimeInterval{
-				mti("mti1"),
-			},
-			existingTimeIntervals: []v1.TimeInterval{
+			existing: []v1.TimeInterval{
+				ti("mti1"),
 				ti("ti2"),
 			},
-			incomingTimeIntervals: []v1.TimeInterval{
+			incoming: []v1.TimeInterval{
+				ti("ti2"),
 				ti("mti1"),
-			},
-			incomingMuteIntervals: []v1.MuteTimeInterval{
-				mti("ti2"),
 			},
 			expected: []v1.TimeInterval{
 				ti("mti1"),
@@ -233,17 +220,13 @@ func TestTimeIntervals(t *testing.T) {
 		},
 		{
 			name: "should rename incoming if there is existing after dedup",
-			existingMuteIntervals: []v1.MuteTimeInterval{
-				mti("ti1"),
-			},
-			existingTimeIntervals: []v1.TimeInterval{
+			existing: []v1.TimeInterval{
+				ti("ti1"),
 				ti("ti1" + suffix),
 			},
-			incomingTimeIntervals: []v1.TimeInterval{
+			incoming: []v1.TimeInterval{
+				ti("ti1"),
 				ti("ti1" + suffix),
-			},
-			incomingMuteIntervals: []v1.MuteTimeInterval{
-				mti("ti1"),
 			},
 			expected: []v1.TimeInterval{
 				ti("ti1"),
@@ -259,16 +242,14 @@ func TestTimeIntervals(t *testing.T) {
 		},
 		{
 			name: "should rename dupe among incoming",
-			existingTimeIntervals: []v1.TimeInterval{
+			existing: []v1.TimeInterval{
 				ti("ti2"),
 			},
-			incomingTimeIntervals: []v1.TimeInterval{
+			incoming: []v1.TimeInterval{
+				ti("ti2"),
 				ti("ti2"),
 			},
-			incomingMuteIntervals: []v1.MuteTimeInterval{
-				mti("ti2"),
-			},
-			expected: []v1.TimeInterval{ // mute intervals have precedence over time intervals in the case of duplicates (see https://github.com/grafana/alerting/blob/85dab908dcb43f7718a638b4c3cf9c214f7e48da/notify/grafana_alertmanager.go#L676-L685)
+			expected: []v1.TimeInterval{
 				ti("ti2"),
 				ti("ti2" + suffix),
 				ti("ti2" + suffix + "_01"),
@@ -280,18 +261,14 @@ func TestTimeIntervals(t *testing.T) {
 		},
 		{
 			name: "should ensure uniqueness across existing and incoming",
-			existingMuteIntervals: []v1.MuteTimeInterval{
-				mti("ti1"),
-			},
-			existingTimeIntervals: []v1.TimeInterval{
+			existing: []v1.TimeInterval{
+				ti("ti1"),
 				ti("ti1" + suffix),
 			},
-			incomingTimeIntervals: []v1.TimeInterval{
+			incoming: []v1.TimeInterval{
+				ti("ti1" + suffix + "_01"),
 				ti("ti1"),
 				ti("ti2"),
-			},
-			incomingMuteIntervals: []v1.MuteTimeInterval{
-				mti("ti1" + suffix + "_01"),
 			},
 			expected: []v1.TimeInterval{
 				ti("ti1"),
@@ -309,38 +286,26 @@ func TestTimeIntervals(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			var existingNames, incomingNames []string
-			for _, r := range tc.existingMuteIntervals {
+			for _, r := range tc.existing {
 				existingNames = append(existingNames, r.Name)
 			}
-			for _, r := range tc.existingTimeIntervals {
-				existingNames = append(existingNames, r.Name)
-			}
-			for _, r := range tc.incomingTimeIntervals {
-				incomingNames = append(incomingNames, r.Name)
-			}
-			for _, r := range tc.incomingMuteIntervals {
+			for _, r := range tc.incoming {
 				incomingNames = append(incomingNames, r.Name)
 			}
 
-			actualTimeIntervals, actualRenames, actualAdded := TimeIntervals(tc.existingMuteIntervals, tc.existingTimeIntervals, tc.incomingMuteIntervals, tc.incomingTimeIntervals, identifier)
+			actualTimeIntervals, actualRenames, actualAdded := TimeIntervals(tc.existing, tc.incoming, identifier)
 			assert.Equal(t, tc.expected, actualTimeIntervals)
 			assert.EqualValues(t, tc.expectedRenames, actualRenames)
 			assert.Equal(t, tc.expectedAdded, actualAdded)
 
 			// check that existing and incoming lists are not changed
 			var names []string
-			for _, r := range tc.existingMuteIntervals {
-				names = append(names, r.Name)
-			}
-			for _, r := range tc.existingTimeIntervals {
+			for _, r := range tc.existing {
 				names = append(names, r.Name)
 			}
 			assert.Equal(t, existingNames, names)
 			names = nil
-			for _, r := range tc.incomingTimeIntervals {
-				names = append(names, r.Name)
-			}
-			for _, r := range tc.incomingMuteIntervals {
+			for _, r := range tc.incoming {
 				names = append(names, r.Name)
 			}
 			assert.Equal(t, incomingNames, names)

--- a/pkg/services/ngalert/notifier/validation.go
+++ b/pkg/services/ngalert/notifier/validation.go
@@ -69,9 +69,6 @@ func newStaticContactPointValidator(am *v1.AMConfigV1) staticContactPointValidat
 	}
 
 	availableTimeIntervals := make(map[string]struct{})
-	for _, interval := range am.AlertmanagerConfig.MuteTimeIntervals {
-		availableTimeIntervals[interval.Name] = struct{}{}
-	}
 	for _, interval := range am.AlertmanagerConfig.TimeIntervals {
 		availableTimeIntervals[interval.Name] = struct{}{}
 	}

--- a/pkg/services/ngalert/provisioning/mute_timings.go
+++ b/pkg/services/ngalert/provisioning/mute_timings.go
@@ -198,7 +198,7 @@ func (svc *MuteTimingService) CreateMuteTiming(ctx context.Context, mt definitio
 		return definitions.MuteTimeInterval{}, err
 	}
 
-	return newMuteTimingInterval(v1.MuteTimeInterval(mt.MuteTimeInterval), mt.Provenance), nil
+	return newMuteTimingInterval(v1.TimeInterval(mt.MuteTimeInterval), mt.Provenance), nil
 }
 
 // UpdateMuteTiming replaces an existing mute timing within the specified org. The replaced mute timing is returned. If the mute timing does not exist, ErrMuteTimingsNotFound is returned.
@@ -240,7 +240,7 @@ func (svc *MuteTimingService) UpdateMuteTiming(ctx context.Context, mt definitio
 		return definitions.MuteTimeInterval{}, err
 	}
 
-	existingInterval := v1.MuteTimeInterval(existing.MuteTimeInterval)
+	existingInterval := v1.TimeInterval(existing.MuteTimeInterval)
 
 	// check optimistic concurrency
 	if err = svc.checkOptimisticConcurrency(existingInterval, models.Provenance(mt.Provenance), mt.Version, "update"); err != nil {
@@ -264,7 +264,7 @@ func (svc *MuteTimingService) UpdateMuteTiming(ctx context.Context, mt definitio
 				return err
 			}
 		} else {
-			updateTimeInterval(revision, v1.MuteTimeInterval(mt.MuteTimeInterval))
+			updateTimeInterval(revision, v1.TimeInterval(mt.MuteTimeInterval))
 		}
 		if err := svc.configStore.Save(ctx, revision, orgID); err != nil {
 			return err
@@ -275,7 +275,7 @@ func (svc *MuteTimingService) UpdateMuteTiming(ctx context.Context, mt definitio
 		return definitions.MuteTimeInterval{}, err
 	}
 
-	return newMuteTimingInterval(v1.MuteTimeInterval(mt.MuteTimeInterval), mt.Provenance), nil
+	return newMuteTimingInterval(v1.TimeInterval(mt.MuteTimeInterval), mt.Provenance), nil
 }
 
 // DeleteMuteTiming deletes the mute timing with the given name in the given org. If the mute timing does not exist, no error is returned.
@@ -297,7 +297,7 @@ func (svc *MuteTimingService) DeleteMuteTiming(ctx context.Context, nameOrUID st
 		return makeErrMuteTimeIntervalOrigin(existing, "delete")
 	}
 
-	existingInterval := v1.MuteTimeInterval(existing.MuteTimeInterval)
+	existingInterval := v1.TimeInterval(existing.MuteTimeInterval)
 
 	if err := svc.validator(ctx, models.Provenance(existing.Provenance), models.Provenance(provenance)); err != nil {
 		return err
@@ -370,7 +370,7 @@ func (svc *MuteTimingService) getMuteTimingByUID(ctx context.Context, revision *
 	return definitions.MuteTimeInterval{}, false, nil
 }
 
-func (svc *MuteTimingService) getImportedTimeIntervals(rev *legacy_storage.ConfigRevision) []v1.MuteTimeInterval {
+func (svc *MuteTimingService) getImportedTimeIntervals(rev *legacy_storage.ConfigRevision) []v1.TimeInterval {
 	if !svc.includeImported {
 		return nil
 	}
@@ -381,7 +381,7 @@ func (svc *MuteTimingService) getImportedTimeIntervals(rev *legacy_storage.Confi
 		return nil
 	}
 
-	intervals, err := imported.GetMuteTimeIntervals()
+	intervals, err := imported.GetTimeIntervals()
 	if err != nil {
 		svc.log.Warn("failed to get imported mute time intervals", "error", err)
 		return nil
@@ -390,24 +390,20 @@ func (svc *MuteTimingService) getImportedTimeIntervals(rev *legacy_storage.Confi
 	return intervals
 }
 
-func findByName(name string) func(v1.MuteTimeInterval) bool {
-	return func(interval v1.MuteTimeInterval) bool {
+func findByName(name string) func(v1.TimeInterval) bool {
+	return func(interval v1.TimeInterval) bool {
 		return interval.Name == name
 	}
 }
 
-func findByUID(uid string) func(v1.MuteTimeInterval) bool {
-	return func(interval v1.MuteTimeInterval) bool {
+func findByUID(uid string) func(v1.TimeInterval) bool {
+	return func(interval v1.TimeInterval) bool {
 		return legacy_storage.NameToUid(interval.Name) == uid
 	}
 }
 
-func getGrafanaTimeIntervals(rev *legacy_storage.ConfigRevision) []v1.MuteTimeInterval {
-	result := make([]v1.MuteTimeInterval, 0, len(rev.Config.AlertmanagerConfig.TimeIntervals)+len(rev.Config.AlertmanagerConfig.MuteTimeIntervals))
-	for _, interval := range rev.Config.AlertmanagerConfig.TimeIntervals {
-		result = append(result, v1.MuteTimeInterval(interval))
-	}
-	return append(result, rev.Config.AlertmanagerConfig.MuteTimeIntervals...)
+func getGrafanaTimeIntervals(rev *legacy_storage.ConfigRevision) []v1.TimeInterval {
+	return rev.Config.AlertmanagerConfig.TimeIntervals
 }
 
 func grafanaTimeIntervalExists(rev *legacy_storage.ConfigRevision, name string) bool {
@@ -415,29 +411,20 @@ func grafanaTimeIntervalExists(rev *legacy_storage.ConfigRevision, name string) 
 	return slices.IndexFunc(grafanaIntervals, findByName(name)) != -1
 }
 
-func updateTimeInterval(rev *legacy_storage.ConfigRevision, interval v1.MuteTimeInterval) {
-	for idx := range rev.Config.AlertmanagerConfig.MuteTimeIntervals {
-		if rev.Config.AlertmanagerConfig.MuteTimeIntervals[idx].Name == interval.Name {
-			rev.Config.AlertmanagerConfig.MuteTimeIntervals[idx] = interval
-			return
-		}
-	}
+func updateTimeInterval(rev *legacy_storage.ConfigRevision, interval v1.TimeInterval) {
 	for idx := range rev.Config.AlertmanagerConfig.TimeIntervals {
 		if rev.Config.AlertmanagerConfig.TimeIntervals[idx].Name == interval.Name {
-			rev.Config.AlertmanagerConfig.TimeIntervals[idx] = v1.TimeInterval(interval)
+			rev.Config.AlertmanagerConfig.TimeIntervals[idx] = interval
 			return
 		}
 	}
 }
 
-func deleteTimeInterval(rev *legacy_storage.ConfigRevision, interval v1.MuteTimeInterval) {
-	rev.Config.AlertmanagerConfig.MuteTimeIntervals = slices.DeleteFunc(rev.Config.AlertmanagerConfig.MuteTimeIntervals, findByName(interval.Name))
-	rev.Config.AlertmanagerConfig.TimeIntervals = slices.DeleteFunc(rev.Config.AlertmanagerConfig.TimeIntervals, func(i v1.TimeInterval) bool {
-		return i.Name == interval.Name
-	})
+func deleteTimeInterval(rev *legacy_storage.ConfigRevision, interval v1.TimeInterval) {
+	rev.Config.AlertmanagerConfig.TimeIntervals = slices.DeleteFunc(rev.Config.AlertmanagerConfig.TimeIntervals, findByName(interval.Name))
 }
 
-func calculateMuteTimeIntervalFingerprint(interval v1.MuteTimeInterval) string {
+func calculateMuteTimeIntervalFingerprint(interval v1.TimeInterval) string {
 	sum := fnv.New64()
 
 	writeBytes := func(b []byte) {
@@ -492,7 +479,7 @@ func calculateMuteTimeIntervalFingerprint(interval v1.MuteTimeInterval) string {
 	return fmt.Sprintf("%016x", sum.Sum64())
 }
 
-func (svc *MuteTimingService) checkOptimisticConcurrency(current v1.MuteTimeInterval, provenance models.Provenance, desiredVersion string, action string) error {
+func (svc *MuteTimingService) checkOptimisticConcurrency(current v1.TimeInterval, provenance models.Provenance, desiredVersion string, action string) error {
 	if desiredVersion == "" {
 		if provenance != models.ProvenanceFile {
 			// if version is not specified and it's not a file provisioning, emit a log message to reflect that optimistic concurrency is disabled for this request
@@ -539,7 +526,7 @@ func (svc *MuteTimingService) renameTimeIntervalInDependentResources(ctx context
 	return nil
 }
 
-func newMuteTimingInterval(interval v1.MuteTimeInterval, provenance definitions.Provenance) definitions.MuteTimeInterval {
+func newMuteTimingInterval(interval v1.TimeInterval, provenance definitions.Provenance) definitions.MuteTimeInterval {
 	return definitions.MuteTimeInterval{
 		UID:              legacy_storage.NameToUid(interval.Name),
 		MuteTimeInterval: config.MuteTimeInterval(interval),

--- a/pkg/services/ngalert/provisioning/mute_timings_test.go
+++ b/pkg/services/ngalert/provisioning/mute_timings_test.go
@@ -904,7 +904,7 @@ func TestUpdateMuteTimings(t *testing.T) {
 		expectedTimings := slices.DeleteFunc(initialConfig().AlertmanagerConfig.TimeIntervals, func(i v1.TimeInterval) bool {
 			return i.Name == original.Name
 		})
-		expectedTimings = append(expectedTimings, v1.TimeInterval(interval))
+		expectedTimings = append(expectedTimings, interval)
 		assert.EqualValues(t, expectedTimings, revision.Config.AlertmanagerConfig.TimeIntervals)
 		assert.Falsef(t, revision.TimeIntervalUsedByRoutes(expected.Name), "There are still references to the old time interval")
 		assert.Truef(t, revision.TimeIntervalUsedByRoutes(interval.Name), "There are no references to the new time interval")

--- a/pkg/services/ngalert/provisioning/mute_timings_test.go
+++ b/pkg/services/ngalert/provisioning/mute_timings_test.go
@@ -27,7 +27,7 @@ func TestGetMuteTimings(t *testing.T) {
 		Config: &v1.AMConfigV1{
 			AlertmanagerConfig: v1.PostableApiAlertingConfig{
 				Config: v1.Config{
-					MuteTimeIntervals: []v1.MuteTimeInterval{
+					TimeIntervals: []v1.TimeInterval{
 						{
 							Name:          "Test1",
 							TimeIntervals: nil,
@@ -36,8 +36,6 @@ func TestGetMuteTimings(t *testing.T) {
 							Name:          "Test2",
 							TimeIntervals: nil,
 						},
-					},
-					TimeIntervals: []v1.TimeInterval{
 						{
 							Name:          "Test3",
 							TimeIntervals: nil,
@@ -64,7 +62,7 @@ func TestGetMuteTimings(t *testing.T) {
 		result, err := sut.GetMuteTimings(context.Background(), 1)
 
 		require.NoError(t, err)
-		require.Len(t, result, len(revision.Config.AlertmanagerConfig.MuteTimeIntervals)+len(revision.Config.AlertmanagerConfig.TimeIntervals))
+		require.Len(t, result, len(revision.Config.AlertmanagerConfig.TimeIntervals))
 		require.Equal(t, "Test1", result[0].Name)
 		require.EqualValues(t, provenances["Test1"], result[0].Provenance)
 		require.NotEmpty(t, result[0].Version)
@@ -127,10 +125,10 @@ func TestGetMuteTimings(t *testing.T) {
 	})
 
 	t.Run("with imported intervals", func(t *testing.T) {
-		grafanaIntervals := []v1.MuteTimeInterval{
+		grafanaIntervals := []v1.TimeInterval{
 			{Name: "grafana-interval"},
 		}
-		importedIntervals := []v1.MuteTimeInterval{
+		importedIntervals := []v1.TimeInterval{
 			{Name: "imported-interval"},
 		}
 		revision := createConfigWithImportedIntervals(grafanaIntervals, importedIntervals)
@@ -219,13 +217,11 @@ func TestGetMuteTimingByName(t *testing.T) {
 		Config: &v1.AMConfigV1{
 			AlertmanagerConfig: v1.PostableApiAlertingConfig{
 				Config: v1.Config{
-					MuteTimeIntervals: []v1.MuteTimeInterval{
+					TimeIntervals: []v1.TimeInterval{
 						{
 							Name:          "Test1",
 							TimeIntervals: nil,
 						},
-					},
-					TimeIntervals: []v1.TimeInterval{
 						{
 							Name:          "Test2",
 							TimeIntervals: nil,
@@ -306,13 +302,11 @@ func TestGetMuteTimingByUID(t *testing.T) {
 		Config: &v1.AMConfigV1{
 			AlertmanagerConfig: v1.PostableApiAlertingConfig{
 				Config: v1.Config{
-					MuteTimeIntervals: []v1.MuteTimeInterval{
+					TimeIntervals: []v1.TimeInterval{
 						{
 							Name:          "Test1",
 							TimeIntervals: nil,
 						},
-					},
-					TimeIntervals: []v1.TimeInterval{
 						{
 							Name:          "Test2",
 							TimeIntervals: nil,
@@ -383,12 +377,10 @@ func TestCreateMuteTimings(t *testing.T) {
 			Templates: nil,
 			AlertmanagerConfig: v1.PostableApiAlertingConfig{
 				Config: v1.Config{
-					MuteTimeIntervals: []v1.MuteTimeInterval{
+					TimeIntervals: []v1.TimeInterval{
 						{
 							Name: "TEST",
 						},
-					},
-					TimeIntervals: []v1.TimeInterval{
 						{
 							Name: "TEST2",
 						},
@@ -438,7 +430,7 @@ func TestCreateMuteTimings(t *testing.T) {
 		}
 		prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(models.ProvenanceNone, nil)
 
-		existing := initialConfig().AlertmanagerConfig.MuteTimeIntervals[0]
+		existing := initialConfig().AlertmanagerConfig.TimeIntervals[0]
 		timing := definitions.MuteTimeInterval{
 			MuteTimeInterval: definitions.AmMuteTimeInterval(existing),
 			Provenance:       definitions.Provenance(models.ProvenanceFile),
@@ -448,7 +440,7 @@ func TestCreateMuteTimings(t *testing.T) {
 
 		require.Truef(t, ErrTimeIntervalExists.Is(err), "expected ErrTimeIntervalExists but got %s", err)
 
-		existing = v1.MuteTimeInterval(initialConfig().AlertmanagerConfig.TimeIntervals[0])
+		existing = initialConfig().AlertmanagerConfig.TimeIntervals[1]
 		timing = definitions.MuteTimeInterval{
 			MuteTimeInterval: definitions.AmMuteTimeInterval(existing),
 			Provenance:       definitions.Provenance(models.ProvenanceFile),
@@ -554,7 +546,7 @@ func TestCreateMuteTimings(t *testing.T) {
 func TestUpdateMuteTimings(t *testing.T) {
 	orgID := int64(1)
 
-	original := v1.MuteTimeInterval{
+	original := v1.TimeInterval{
 		Name: "Test",
 	}
 	originalVersion := calculateMuteTimeIntervalFingerprint(original)
@@ -563,10 +555,8 @@ func TestUpdateMuteTimings(t *testing.T) {
 			Templates: nil,
 			AlertmanagerConfig: v1.PostableApiAlertingConfig{
 				Config: v1.Config{
-					MuteTimeIntervals: []v1.MuteTimeInterval{
-						original,
-					},
 					TimeIntervals: []v1.TimeInterval{
+						original,
 						{
 							Name: "Test2",
 						},
@@ -584,7 +574,7 @@ func TestUpdateMuteTimings(t *testing.T) {
 		}
 	}
 
-	expected := v1.MuteTimeInterval{
+	expected := v1.TimeInterval{
 		Name: "Test",
 		TimeIntervals: []timeinterval.TimeInterval{
 			{
@@ -755,7 +745,7 @@ func TestUpdateMuteTimings(t *testing.T) {
 		require.Equal(t, orgID, store.Calls[1].Args[2])
 		revision := store.Calls[1].Args[1].(*legacy_storage.ConfigRevision)
 
-		require.EqualValues(t, []v1.MuteTimeInterval{expected}, revision.Config.AlertmanagerConfig.MuteTimeIntervals)
+		require.EqualValues(t, []v1.TimeInterval{expected, {Name: "Test2"}}, revision.Config.AlertmanagerConfig.TimeIntervals)
 
 		prov.AssertCalled(t, "SetProvenance", mock.Anything, &timing, orgID, expectedProvenance)
 
@@ -778,7 +768,7 @@ func TestUpdateMuteTimings(t *testing.T) {
 				Version:    "",
 				Provenance: definitions.Provenance(expectedProvenance),
 			}
-			expectedVersion := calculateMuteTimeIntervalFingerprint(v1.MuteTimeInterval(timing.MuteTimeInterval))
+			expectedVersion := calculateMuteTimeIntervalFingerprint(v1.TimeInterval(timing.MuteTimeInterval))
 
 			result, err := sut.UpdateMuteTiming(context.Background(), timing, orgID)
 			require.NoError(t, err)
@@ -791,7 +781,7 @@ func TestUpdateMuteTimings(t *testing.T) {
 			require.Equal(t, orgID, store.Calls[1].Args[2])
 			revision := store.Calls[1].Args[1].(*legacy_storage.ConfigRevision)
 
-			require.EqualValues(t, []v1.MuteTimeInterval{v1.MuteTimeInterval(timing.MuteTimeInterval)}, revision.Config.AlertmanagerConfig.MuteTimeIntervals)
+			require.EqualValues(t, []v1.TimeInterval{v1.TimeInterval(timing.MuteTimeInterval), {Name: "Test2"}}, revision.Config.AlertmanagerConfig.TimeIntervals)
 		})
 	})
 
@@ -811,7 +801,7 @@ func TestUpdateMuteTimings(t *testing.T) {
 				return nil
 			})
 
-		original := v1.MuteTimeInterval(initialConfig().AlertmanagerConfig.TimeIntervals[0])
+		original := initialConfig().AlertmanagerConfig.TimeIntervals[1]
 
 		expected := expected
 		expected.Name = original.Name
@@ -836,7 +826,7 @@ func TestUpdateMuteTimings(t *testing.T) {
 		require.Equal(t, orgID, store.Calls[1].Args[2])
 		revision := store.Calls[1].Args[1].(*legacy_storage.ConfigRevision)
 
-		require.EqualValues(t, []v1.TimeInterval{v1.TimeInterval(expected)}, revision.Config.AlertmanagerConfig.TimeIntervals)
+		require.EqualValues(t, []v1.TimeInterval{{Name: "Test"}, expected}, revision.Config.AlertmanagerConfig.TimeIntervals)
 
 		prov.AssertCalled(t, "SetProvenance", mock.Anything, &timing, orgID, expectedProvenance)
 	})
@@ -911,7 +901,11 @@ func TestUpdateMuteTimings(t *testing.T) {
 		assert.Equal(t, orgID, store.Calls[1].Args[2])
 
 		revision := store.Calls[1].Args[1].(*legacy_storage.ConfigRevision)
-		assert.EqualValues(t, append(initialConfig().AlertmanagerConfig.TimeIntervals, v1.TimeInterval(interval)), revision.Config.AlertmanagerConfig.TimeIntervals)
+		expectedTimings := slices.DeleteFunc(initialConfig().AlertmanagerConfig.TimeIntervals, func(i v1.TimeInterval) bool {
+			return i.Name == original.Name
+		})
+		expectedTimings = append(expectedTimings, v1.TimeInterval(interval))
+		assert.EqualValues(t, expectedTimings, revision.Config.AlertmanagerConfig.TimeIntervals)
 		assert.Falsef(t, revision.TimeIntervalUsedByRoutes(expected.Name), "There are still references to the old time interval")
 		assert.Truef(t, revision.TimeIntervalUsedByRoutes(interval.Name), "There are no references to the new time interval")
 	})
@@ -1087,7 +1081,7 @@ func TestUpdateMuteTimings(t *testing.T) {
 func TestDeleteMuteTimings(t *testing.T) {
 	orgID := int64(1)
 
-	timingToDelete := v1.MuteTimeInterval{Name: "unused-timing"}
+	timingToDelete := v1.TimeInterval{Name: "unused-timing"}
 	correctVersion := calculateMuteTimeIntervalFingerprint(timingToDelete)
 	usedMuteTiming := "used-timing"
 	usedActiveTiming := "used-active-timing"
@@ -1102,7 +1096,7 @@ func TestDeleteMuteTimings(t *testing.T) {
 						MuteTimeIntervals:   []string{usedMuteTiming},
 						ActiveTimeIntervals: []string{usedActiveTiming},
 					},
-					MuteTimeIntervals: []v1.MuteTimeInterval{
+					TimeIntervals: []v1.TimeInterval{
 						{
 							Name: usedMuteTiming,
 						},
@@ -1110,8 +1104,6 @@ func TestDeleteMuteTimings(t *testing.T) {
 						{
 							Name: managedRouteMuteTiming,
 						},
-					},
-					TimeIntervals: []v1.TimeInterval{
 						{
 							Name: usedActiveTiming,
 						},
@@ -1190,7 +1182,7 @@ func TestDeleteMuteTimings(t *testing.T) {
 		}
 		prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(models.ProvenanceAPI, nil)
 
-		version := calculateMuteTimeIntervalFingerprint(v1.MuteTimeInterval{Name: managedRouteMuteTiming})
+		version := calculateMuteTimeIntervalFingerprint(v1.TimeInterval{Name: managedRouteMuteTiming})
 		err := sut.DeleteMuteTiming(context.Background(), managedRouteMuteTiming, orgID, definitions.Provenance(models.ProvenanceAPI), version)
 
 		require.Len(t, store.Calls, 1)
@@ -1206,7 +1198,7 @@ func TestDeleteMuteTimings(t *testing.T) {
 		}
 		prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(models.ProvenanceAPI, nil)
 
-		version := calculateMuteTimeIntervalFingerprint(v1.MuteTimeInterval{Name: managedRouteActiveTiming})
+		version := calculateMuteTimeIntervalFingerprint(v1.TimeInterval{Name: managedRouteActiveTiming})
 		err := sut.DeleteMuteTiming(context.Background(), managedRouteActiveTiming, orgID, definitions.Provenance(models.ProvenanceAPI), version)
 
 		require.Len(t, store.Calls, 1)
@@ -1291,10 +1283,10 @@ func TestDeleteMuteTimings(t *testing.T) {
 		require.Equal(t, orgID, store.Calls[1].Args[2])
 		revision := store.Calls[1].Args[1].(*legacy_storage.ConfigRevision)
 
-		expectedMuteTimings := slices.DeleteFunc(initialConfig().AlertmanagerConfig.MuteTimeIntervals, func(interval v1.MuteTimeInterval) bool {
+		expectedMuteTimings := slices.DeleteFunc(initialConfig().AlertmanagerConfig.TimeIntervals, func(interval v1.TimeInterval) bool {
 			return interval.Name == timingToDelete.Name
 		})
-		require.EqualValues(t, expectedMuteTimings, revision.Config.AlertmanagerConfig.MuteTimeIntervals)
+		require.EqualValues(t, expectedMuteTimings, revision.Config.AlertmanagerConfig.TimeIntervals)
 
 		prov.AssertCalled(t, "DeleteProvenance", mock.Anything, &timingToDelete, orgID)
 
@@ -1307,10 +1299,10 @@ func TestDeleteMuteTimings(t *testing.T) {
 			require.Equal(t, orgID, store.Calls[1].Args[2])
 			revision := store.Calls[1].Args[1].(*legacy_storage.ConfigRevision)
 
-			expectedMuteTimings := slices.DeleteFunc(initialConfig().AlertmanagerConfig.MuteTimeIntervals, func(interval v1.MuteTimeInterval) bool {
+			expectedMuteTimings := slices.DeleteFunc(initialConfig().AlertmanagerConfig.TimeIntervals, func(interval v1.TimeInterval) bool {
 				return interval.Name == timingToDelete.Name
 			})
-			require.EqualValues(t, expectedMuteTimings, revision.Config.AlertmanagerConfig.MuteTimeIntervals)
+			require.EqualValues(t, expectedMuteTimings, revision.Config.AlertmanagerConfig.TimeIntervals)
 
 			prov.AssertCalled(t, "DeleteProvenance", mock.Anything, mock.MatchedBy(func(mt models.Provisionable) bool { return mt.ResourceID() == timingToDelete.ResourceID() }), orgID)
 		})
@@ -1332,8 +1324,8 @@ func TestDeleteMuteTimings(t *testing.T) {
 				return nil
 			})
 
-		timingToDelete := initialConfig().AlertmanagerConfig.TimeIntervals[1]
-		correctVersion := calculateMuteTimeIntervalFingerprint(v1.MuteTimeInterval(timingToDelete))
+		timingToDelete := initialConfig().AlertmanagerConfig.TimeIntervals[4]
+		correctVersion := calculateMuteTimeIntervalFingerprint(timingToDelete)
 
 		err := sut.DeleteMuteTiming(context.Background(), timingToDelete.Name, orgID, "", correctVersion)
 		require.NoError(t, err)
@@ -1350,7 +1342,6 @@ func TestDeleteMuteTimings(t *testing.T) {
 			return interval.Name == timingToDelete.Name
 		})
 		require.EqualValues(t, expectedMuteTimings, revision.Config.AlertmanagerConfig.TimeIntervals)
-		require.EqualValues(t, initialConfig().AlertmanagerConfig.MuteTimeIntervals, revision.Config.AlertmanagerConfig.MuteTimeIntervals)
 
 		prov.AssertCalled(t, "DeleteProvenance", mock.Anything, mock.MatchedBy(func(mt models.Provisionable) bool { return mt.ResourceID() == timingToDelete.Name }), orgID)
 	})
@@ -1384,10 +1375,10 @@ func TestDeleteMuteTimings(t *testing.T) {
 		require.Equal(t, orgID, store.Calls[1].Args[2])
 		revision := store.Calls[1].Args[1].(*legacy_storage.ConfigRevision)
 
-		expectedMuteTimings := slices.DeleteFunc(initialConfig().AlertmanagerConfig.MuteTimeIntervals, func(interval v1.MuteTimeInterval) bool {
+		expectedMuteTimings := slices.DeleteFunc(initialConfig().AlertmanagerConfig.TimeIntervals, func(interval v1.TimeInterval) bool {
 			return interval.Name == timingToDelete.Name
 		})
-		require.EqualValues(t, expectedMuteTimings, revision.Config.AlertmanagerConfig.MuteTimeIntervals)
+		require.EqualValues(t, expectedMuteTimings, revision.Config.AlertmanagerConfig.TimeIntervals)
 
 		prov.AssertCalled(t, "DeleteProvenance", mock.Anything, mock.MatchedBy(func(mt models.Provisionable) bool { return mt.ResourceID() == timingToDelete.ResourceID() }), orgID)
 	})
@@ -1469,7 +1460,7 @@ func createMuteTimingSvcSut() (*MuteTimingService, *legacy_storage.AlertmanagerC
 // buildMimirAMConfigWithTimeIntervals creates a Mimir alertmanager config YAML string
 // containing the provided time intervals for use in ExtraConfigs.
 // This generates a minimal but valid Prometheus alertmanager config with a route and receiver.
-func buildMimirAMConfigWithTimeIntervals(intervals []v1.MuteTimeInterval) string {
+func buildMimirAMConfigWithTimeIntervals(intervals []v1.TimeInterval) string {
 	if len(intervals) == 0 {
 		return ""
 	}
@@ -1514,11 +1505,11 @@ func buildMimirAMConfigWithTimeIntervals(intervals []v1.MuteTimeInterval) string
 
 // createConfigWithImportedIntervals creates a ConfigRevision with both Grafana and imported
 // Mimir time intervals for testing.
-func createConfigWithImportedIntervals(grafanaIntervals []v1.MuteTimeInterval, importedIntervals []v1.MuteTimeInterval) *legacy_storage.ConfigRevision {
+func createConfigWithImportedIntervals(grafanaIntervals []v1.TimeInterval, importedIntervals []v1.TimeInterval) *legacy_storage.ConfigRevision {
 	cfg := &v1.AMConfigV1{
 		AlertmanagerConfig: v1.PostableApiAlertingConfig{
 			Config: v1.Config{
-				MuteTimeIntervals: grafanaIntervals,
+				TimeIntervals: grafanaIntervals,
 			},
 		},
 	}


### PR DESCRIPTION
**What is this feature?**

Collapses `v1.MuteTimeInterval` and `v1.TimeInterval` into a single `v1.TimeInterval` type in the internal Alertmanager config model.

Alertmanager's config has two separate fields for what is really one resource: the deprecated `mute_time_intervals` and its replacement `time_intervals`. We store both, so until now every consumer of the model had to know about both.

After this change:

- `v1.Config` has a single `TimeIntervals []TimeInterval` field. `MuteTimeInterval` is gone.
- `TimeIntervalsToModel(mute, time)` folds both DB fields into that one list on load, mute intervals first.
- `TimeIntervalsToDB` writes the whole list back out as `time_intervals`.
- `ExtraAlertmanagerConfig` still mirrors upstream Prometheus and keeps both fields; `ToGrafanaMuteTimeIntervals` is removed and `ToGrafanaTimeIntervals` does the fold.

Callers get correspondingly simpler, `merge.TimeIntervals` drops from four slice params to two, and the dual-list handling disappears from `ModelToTimeIntervals`, `DeduplicateResources`, `ImportedConfigRevision.GetTimeIntervals`, route/contact-point reference validation, and the mute timing provisioning service.

`TimeInterval.ResourceType()` still returns `"muteTimeInterval"`, so existing provenance records keep resolving.

**Why do we need this feature?**

The mute/active split is a storage detail of the Alertmanager config format that had leaked into every service touching time intervals. Grafana has no user-facing concept of a "mute time interval" separate from a "time interval". The UI, the provisioning API, and the k8s API all present one resource. Upcoming time-interval refactor work necessitated getting this simplification out of the way.

**Special notes for your reviewer:**

This is intended to be a no-op except for one side effect, which is worth a careful look:

**Time intervals are folded on save.** Because the model no longer distinguishes the two, the next write of an org's Alertmanager config rewrites anything that was under `mute_time_intervals` as `time_intervals`. This shows up in three places: the stored config, the `GET .../config/api/v1/alerts` response, and the payload shipped to a remote Alertmanager.

This should be safe:

- A name cannot already exist in both lists,`definition.Config` validates uniqueness across a *shared* name set spanning both fields at unmarshal, so folding can't produce a duplicate `time_intervals` entry from any config that could have been stored.
- Both Grafana's applier and upstream `GrafanaAlertmanager.buildTimeIntervals` already treat the two lists as a single namespace.

`GetMuteTimings` sorts by name before returning, so the ordering change inside the model isn't user-visible.

Ordering within the imported list *is* potentially important (mute first) and is documented at the fold site.
