### PR TITLE
MySQL: Add to default bundled and preinstalled plugins

### DIFF
--- a/pkg/setting/setting_plugins.go
+++ b/pkg/setting/setting_plugins.go
@@ -46,6 +46,7 @@ var (
 		"mssql":                         {ID: "mssql"},
 		"jaeger":                        {ID: "jaeger"},
 		"loki":                          {ID: "loki"},
+		"mysql":                         {ID: "mysql"},
 		"grafana-advisor-app":           {ID: "grafana-advisor-app"},
 		"grafana-postgresql-datasource": {ID: "grafana-postgresql-datasource"},
 		"grafana-pyroscope-datasource":  {ID: "grafana-pyroscope-datasource"},

--- a/scripts/catalog-plugins-defaults
+++ b/scripts/catalog-plugins-defaults
@@ -8,5 +8,6 @@ stackdriver
 mssql
 jaeger
 loki
+mysql
 grafana-postgresql-datasource
 grafana-pyroscope-datasource


### PR DESCRIPTION
**What is this feature?**

Add MySQL to the default plugin lists so on-prem and OSS users continue to have access to it after it is removed from core.
This is the on-prem preparation step before removing MySQL from core. With both core and bundled versions present, nightly builds can validate that the external plugin works correctly as a drop-in replacement.

**Why do we need this feature?**

To be able to remove MySQL from grafana/grafana 

**Who is this feature for?**

Grafana developers

Reference PR:
- https://github.com/grafana/grafana/pull/126842

Please check that:
- [ ] It works as expected from a user's perspective.