### PR TITLE
Alerting docs: Add Builder mode

### DIFF
--- a/docs/sources/alerting/alerting-rules/create-grafana-managed-rule.md
+++ b/docs/sources/alerting/alerting-rules/create-grafana-managed-rule.md
@@ -207,6 +207,8 @@ If you prefer to always use advanced configuration, you can disable the **Defaul
 
 Define a query to get the data you want to measure and a condition that needs to be met before an alert rule fires.
 
+Depending on the data source, the query editor offers a **Builder** and a **Code** option. **Builder** helps you construct a query with a visual interface. The **Builder** option is useful if you have limited experience with the query language, while **Code** lets you write the query directly for more control. Switch between them using the **Builder** and **Code** tabs on the query editor toolbar.
+
 The **Default** option allows to configure one query and one alert condition. The **Advanced** option allows multiple queries and expressions for more complex rule definitions.
 
 {{< collapse title="Default options" >}}

--- a/docs/sources/alerting/configure-notifications/manage-contact-points/_index.md
+++ b/docs/sources/alerting/configure-notifications/manage-contact-points/_index.md
@@ -137,9 +137,9 @@ On the **Contact Points** tab, you can:
 Contact points are assigned to a [specific Alertmanager](ref:configure-alertmanager) and cannot be used by notification policies in other Alertmanagers.
 {{< /admonition >}}
 
-## Grafana Cloud Protected fields
+## Protected fields
 
-For Grafana Cloud users, contact points may contain protected fields that require admin permissions to modify. Protected fields are sensitive configuration settings that affect where notifications are sent, such as:
+For Grafana users, contact points may contain protected fields that require admin permissions to modify. Protected fields are sensitive configuration settings that affect where notifications are sent, such as:
 
 - Target URLs for integrations (webhooks, PagerDuty, Opsgenie, or other integrations.)
 - API endpoints


### PR DESCRIPTION
This PR adds context for the Builder mode (this was missing from docs and is needed for reference in the learning material being built). 
This PR also fixes a H2 that erroneously said "Grafana Cloud" when it's not Cloud-specific.
