### PR TITLE
FeatureToggles: Add reporting.redirectReportsToK8SApi flag

### DIFF
--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -3075,6 +3075,14 @@ var (
 			Generate:        Generate{Go: true, LegacyGo: true},
 		},
 		{
+			Name:        "reporting.redirectReportsToK8SApi",
+			Description: "Redirect legacy report CRUD API endpoints to the Kubernetes reporting API",
+			Stage:       FeatureStageExperimental,
+			Owner:       grafanaOperatorExperienceSquad,
+			Expression:  "false",
+			Generate:    Generate{Go: true},
+		},
+		{
 			Name:        "grafana.onDemandDiagnostics",
 			Description: "Adds a 'Download diagnostics' action that bundles diagnostic artifacts such as HTTP traffic (HAR), server log, dashboard and panel JSONs, and more",
 			Stage:       FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -357,6 +357,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-06-30,grafana.dashboardSettingsRedesign,GA,@grafana/dashboards-squad,false,false,true
 2026-07-01,grafana.growthHomepage,experimental,@grafana/grafana-frontend-navigation,false,false,true
 2026-07-01,kubernetesReporting,experimental,@grafana/grafana-operator-experience-squad,false,true,false
+2026-07-28,reporting.redirectReportsToK8SApi,experimental,@grafana/grafana-operator-experience-squad,false,false,false
 2026-06-26,grafana.onDemandDiagnostics,experimental,@grafana/data-sources,false,false,false
 2026-07-08,grafana.frontendLegacyAPIHandling,experimental,@grafana/grafana-frontend-platform,false,false,false
 2026-07-17,features.bulkFlagEvalFiltering,experimental,@grafana/grafana-backend-services-squad,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -966,6 +966,10 @@ const (
 	// Add support for Kubernetes reporting new APIs
 	FlagKubernetesReporting = "kubernetesReporting"
 
+	// FlagReportingRedirectReportsToK8SApi
+	// Redirect legacy report CRUD API endpoints to the Kubernetes reporting API
+	FlagReportingRedirectReportsToK8SApi = "reporting.redirectReportsToK8SApi"
+
 	// FlagGrafanaOnDemandDiagnostics
 	// Adds a 'Download diagnostics' action that bundles diagnostic artifacts such as HTTP traffic (HAR), server log, dashboard and panel JSONs, and more
 	FlagGrafanaOnDemandDiagnostics = "grafana.onDemandDiagnostics"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -5360,6 +5360,33 @@
     },
     {
       "metadata": {
+        "name": "reporting.redirectReportsToK8SApi",
+        "resourceVersion": "1785214026884",
+        "creationTimestamp": "2026-07-28T04:47:06Z"
+      },
+      "spec": {
+        "description": "Redirect legacy report CRUD API endpoints to the Kubernetes reporting API",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-operator-experience-squad",
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
+        "name": "reporting.redirectReportsToK8sApi",
+        "resourceVersion": "1785213945476",
+        "creationTimestamp": "2026-07-28T04:45:45Z",
+        "deletionTimestamp": "2026-07-28T04:47:06Z"
+      },
+      "spec": {
+        "description": "Redirect legacy report CRUD API endpoints to the Kubernetes reporting API",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-operator-experience-squad",
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "reportingFooterSettings",
         "resourceVersion": "1779440584464",
         "creationTimestamp": "2026-05-22T09:03:04Z"


### PR DESCRIPTION
## What is this feature?

Adds the `reporting.redirectReportsToK8SApi` feature toggle (experimental, default off).

When enabled together with `kubernetesReporting`, the legacy `/api/reports` CRUD endpoints in Grafana Enterprise are served by the `reporting.grafana.app/v1beta1` API in process, while the URL surface and response DTO shapes stay unchanged. The flag is evaluated per request via OpenFeature, so toggling it does not require a restart.

## Why do we need this feature?

Part of the reporting App Platform migration (grafana-operator-experience-squad#1882): once the legacy routes flow through the k8s API, admission, conversions, and the dual writer apply regardless of which URL surface a client uses.

The handler implementation lives in Grafana Enterprise (same branch name).

## Who is this feature for?

Grafana Operator Experience squad; not user facing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)