### PR TITLE
Home: Select homepage recommendations from the solutions matrix

### DIFF
--- a/public/app/features/home/Recommendations/RecommendationCard.tsx
+++ b/public/app/features/home/Recommendations/RecommendationCard.tsx
@@ -9,9 +9,10 @@ import type { RecommendationItem } from './types';
 
 interface RecommendationCardProps {
   recommendation: RecommendationItem;
+  startingState: string;
 }
 
-export function RecommendationCard({ recommendation }: RecommendationCardProps) {
+export function RecommendationCard({ recommendation, startingState }: RecommendationCardProps) {
   const styles = useStyles2(getStyles, recommendation.color);
 
   return (
@@ -45,6 +46,7 @@ export function RecommendationCard({ recommendation }: RecommendationCardProps) 
               action: recommendation.cta ?? 'enable',
               placement: 'card',
               recommendation_id: recommendation.id,
+              starting_state: startingState,
             })
           }
         >

--- a/public/app/features/home/Recommendations/RecommendationPill.tsx
+++ b/public/app/features/home/Recommendations/RecommendationPill.tsx
@@ -9,9 +9,10 @@ import type { RecommendationItem } from './types';
 
 interface RecommendationPillProps {
   recommendation: RecommendationItem;
+  startingState: string;
 }
 
-export function RecommendationPill({ recommendation }: RecommendationPillProps) {
+export function RecommendationPill({ recommendation, startingState }: RecommendationPillProps) {
   const styles = useStyles2(getStyles, recommendation.color);
 
   return (
@@ -27,6 +28,7 @@ export function RecommendationPill({ recommendation }: RecommendationPillProps) 
           action: recommendation.cta ?? 'enable',
           placement: 'pill',
           recommendation_id: recommendation.id,
+          starting_state: startingState,
         })
       }
       className={styles.pill}

--- a/public/app/features/home/Recommendations/Recommendations.test.tsx
+++ b/public/app/features/home/Recommendations/Recommendations.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, userEvent, waitFor } from 'test/test-utils';
+import { act, render, screen, userEvent, waitFor, within } from 'test/test-utils';
 
 import { type PluginMeta } from '@grafana/data';
 import { config } from '@grafana/runtime';
@@ -17,7 +17,8 @@ import {
   fetchKubernetesInventory,
   resolveKubernetesDatasource,
 } from './kubernetesData';
-import { hasSolutionData } from './solutionDataProbes';
+import { useSolutionState } from './solutionState';
+import { type SolutionState } from './solutionsMatrix';
 
 const mockGet = jest.fn();
 jest.mock('@grafana/runtime', () => ({
@@ -49,18 +50,13 @@ jest.mock('./kubernetesData', () => ({
   fetchClusterCpuSeries: jest.fn().mockResolvedValue(null),
 }));
 
-// Enabled solutions report data by default so the pre-probe expectations (enabled -> hidden)
-// keep holding; individual tests flip specific solutions to the no-data state.
-jest.mock('./solutionDataProbes', () => ({
-  hasSolutionData: jest.fn().mockResolvedValue(true),
+jest.mock('./solutionState', () => ({
+  useSolutionState: jest.fn(),
 }));
 
-const APP_IDS = [
-  'grafana-exploretraces-app',
-  'grafana-synthetic-monitoring-app',
-  'grafana-app-observability-app',
-  'grafana-kowalski-app',
-];
+const LEGACY_APP_IDS = ['grafana-synthetic-monitoring-app', 'grafana-app-observability-app', 'grafana-kowalski-app'];
+const APP_IDS = ['grafana-exploretraces-app', 'grafana-k8s-app', ...LEGACY_APP_IDS];
+
 const listItem = (id: string, overrides: Partial<LocalPlugin> = {}) => ({
   id,
   enabled: false,
@@ -69,6 +65,18 @@ const listItem = (id: string, overrides: Partial<LocalPlugin> = {}) => ({
 });
 
 const mockUsePluginBridge = jest.mocked(usePluginBridge);
+const mockUseSolutionState = jest.mocked(useSolutionState);
+
+function setSolutionState(overrides: Partial<SolutionState>) {
+  mockUseSolutionState.mockReturnValue({
+    value: {
+      state: { metrics: 'inactive', logs: 'inactive', traces: 'inactive', kubernetes: 'inactive', ...overrides },
+      lokiDatasource: null,
+      tempoDatasource: null,
+    },
+    loading: false,
+  });
+}
 
 beforeEach(() => {
   window.localStorage.clear();
@@ -81,24 +89,40 @@ beforeEach(() => {
   });
   mockGet.mockReset();
   mockGet.mockResolvedValue(APP_IDS.map((id) => listItem(id)));
-  jest.mocked(hasSolutionData).mockReset();
-  jest.mocked(hasSolutionData).mockResolvedValue(true);
+  mockUseSolutionState.mockReset();
+  // Metrics + Logs, no Traces: the two-card row (hosted-traces, kubernetes-monitoring).
+  setSolutionState({ metrics: 'active', logs: 'active' });
   jest.spyOn(contextSrv, 'hasPermission').mockReturnValue(true);
 });
 
 afterEach(() => jest.restoreAllMocks());
 
+const carouselRegion = async () => screen.findByRole('region', { name: 'Recommended apps' });
+
 describe('Recommendations', () => {
-  it('renders nothing while plugin data is loading', async () => {
-    mockUsePluginBridge.mockReturnValue({ loading: true });
+  it('renders the matrix-selected cards in matrix order for ml_no_traces', async () => {
+    render(<Recommendations />);
 
-    const { container } = render(<Recommendations />);
-
-    await waitFor(() => expect(container).toBeEmptyDOMElement());
+    const region = await carouselRegion();
+    const titles = within(region)
+      .getAllByRole('heading', { level: 3, hidden: true })
+      .map((heading) => heading.textContent?.trim());
+    expect(titles).toEqual(['Trace requests across services', 'Monitor your Kubernetes fleet']);
+    expect(within(region).getByRole('link', { name: /Enable Hosted Traces/ })).toBeInTheDocument();
+    expect(
+      within(region).getByRole('link', { name: /Enable Kubernetes Monitoring/, hidden: true })
+    ).toBeInTheDocument();
   });
 
-  it('holds a skeleton while loading when the section was visible on the last visit', async () => {
-    window.localStorage.setItem('grafana.home.recommendations.was-visible', 'true');
+  it('shows a skeleton while the solution state is resolving', async () => {
+    mockUseSolutionState.mockReturnValue({ value: undefined, loading: true });
+
+    render(<Recommendations />);
+
+    expect(await screen.findByTestId('recommendations-skeleton')).toBeInTheDocument();
+  });
+
+  it('holds the skeleton while a selected plugin card waits on the plugin list', async () => {
     mockGet.mockImplementation(() => new Promise(() => {}));
 
     render(<Recommendations />);
@@ -106,159 +130,24 @@ describe('Recommendations', () => {
     expect(await screen.findByTestId('recommendations-skeleton')).toBeInTheDocument();
   });
 
-  it('shows no skeleton while loading when the section was not visible before', async () => {
-    mockGet.mockImplementation(() => new Promise(() => {}));
-
-    const { container } = render(<Recommendations />);
-
-    await waitFor(() => expect(container).toBeEmptyDOMElement());
-  });
-
-  it('stores the visibility hint when the section renders', async () => {
-    render(<Recommendations />);
-
-    await screen.findByText('Recommendations for your stack');
-    await waitFor(() => expect(window.localStorage.getItem('grafana.home.recommendations.was-visible')).toBe('true'));
-  });
-
-  it('clears the visibility hint when everything settles to zero recommendations', async () => {
-    window.localStorage.setItem('grafana.home.recommendations.was-visible', 'true');
-    // All apps enabled and (per the default mock) receiving data: nothing to recommend.
-    mockGet.mockResolvedValue(APP_IDS.map((id) => listItem(id, { enabled: true })));
-
-    const { container } = render(<Recommendations />);
-
-    await waitFor(() => expect(container).toBeEmptyDOMElement());
-    await waitFor(() => expect(window.localStorage.getItem('grafana.home.recommendations.was-visible')).toBe('false'));
-  });
-
-  it('renders the section even when Kubernetes Monitoring is not installed', async () => {
-    mockUsePluginBridge.mockReturnValue({ loading: false, installed: false });
-
-    render(<Recommendations />);
-
-    expect(await screen.findByText('Recommendations for your stack')).toBeInTheDocument();
-  });
-
-  it('shows the no-data card when no datasource has Kubernetes data', async () => {
-    render(<Recommendations />);
-
-    expect(await screen.findByRole('heading', { name: 'No data flowing yet' })).toBeInTheDocument();
-    expect(screen.queryByRole('heading', { name: 'Kubernetes Monitoring' })).not.toBeInTheDocument();
-    expect(screen.queryByRole('heading', { name: 'Hosted Metrics' })).not.toBeInTheDocument();
-  });
-
-  it('renders nothing when the user cannot manage plugins', async () => {
-    jest.mocked(contextSrv.hasPermission).mockReturnValue(false);
-
-    const { container } = render(<Recommendations />);
-
-    await waitFor(() => expect(container).toBeEmptyDOMElement());
-    expect(mockGet).not.toHaveBeenCalled();
-    expect(mockUsePluginBridge).not.toHaveBeenCalled();
-  });
-
-  it('drops recommendations whose app is already enabled and receiving data', async () => {
-    mockGet.mockResolvedValue(
-      APP_IDS.map((id) =>
-        listItem(id, {
-          enabled: id === 'grafana-exploretraces-app' || id === 'grafana-synthetic-monitoring-app',
-        })
-      )
-    );
-
-    render(<Recommendations />);
-
-    expect(await screen.findByRole('link', { name: /Enable Application Observability/ })).toBeInTheDocument();
-    expect(screen.queryByRole('link', { name: /Enable Hosted Traces/ })).not.toBeInTheDocument();
-  });
-
-  it('keeps recommending an enabled app that has no data, with a setup CTA into the app', async () => {
-    jest
-      .mocked(hasSolutionData)
-      .mockImplementation(async (pluginId: string) => pluginId !== 'grafana-synthetic-monitoring-app');
-    mockGet.mockResolvedValue(APP_IDS.map((id) => listItem(id, { enabled: true })));
-
-    render(<Recommendations />);
-
-    const setupLink = await screen.findByRole('link', { name: /Set up Synthetic Monitoring/, hidden: true });
-    expect(setupLink).toHaveAttribute('href', '/a/grafana-synthetic-monitoring-app/home');
-    expect(screen.queryByRole('link', { name: /Enable Hosted Traces/, hidden: true })).not.toBeInTheDocument();
-    expect(screen.queryByRole('link', { name: /Add Synthetic Monitoring/, hidden: true })).not.toBeInTheDocument();
-  });
-
-  it('renders known cards immediately and appends the setup card when its probe settles', async () => {
-    let resolveProbe: (hasData: boolean) => void = () => {};
-    jest
-      .mocked(hasSolutionData)
-      .mockImplementation((pluginId: string) =>
-        pluginId === 'grafana-synthetic-monitoring-app'
-          ? new Promise((resolve) => (resolveProbe = resolve))
-          : Promise.resolve(true)
-      );
-    mockGet.mockResolvedValue(
-      APP_IDS.map((id) => listItem(id, { enabled: id === 'grafana-synthetic-monitoring-app' }))
-    );
-
-    render(<Recommendations />);
-
-    // Disabled apps render without waiting for the synthetic-monitoring probe.
-    expect(await screen.findByRole('link', { name: /Enable Hosted Traces/, hidden: true })).toBeInTheDocument();
-    expect(screen.queryByRole('link', { name: /Set up Synthetic Monitoring/, hidden: true })).not.toBeInTheDocument();
-
-    resolveProbe(false);
-
-    expect(await screen.findByRole('link', { name: /Set up Synthetic Monitoring/, hidden: true })).toBeInTheDocument();
-  });
-
-  it('keeps the visible slide when an earlier-ordered setup card settles later', async () => {
-    let resolveProbe: (hasData: boolean) => void = () => {};
-    jest
-      .mocked(hasSolutionData)
-      .mockImplementation((pluginId: string) =>
-        pluginId === 'grafana-exploretraces-app'
-          ? new Promise((resolve) => (resolveProbe = resolve))
-          : Promise.resolve(true)
-      );
+  it('gives an enabled-but-silent app a setup CTA into the app', async () => {
     mockGet.mockResolvedValue(APP_IDS.map((id) => listItem(id, { enabled: id === 'grafana-exploretraces-app' })));
 
     render(<Recommendations />);
 
-    // Hosted Traces is still probing; Synthetic Monitoring's enable card leads the deck and is
-    // the visible (non-aria-hidden) slide.
-    expect(await screen.findByRole('link', { name: /Add Synthetic Monitoring/ })).toBeInTheDocument();
+    const setupLink = await screen.findByRole('link', { name: /Set up Hosted Traces/, hidden: true });
+    expect(setupLink).toHaveAttribute('href', '/a/grafana-exploretraces-app');
+    expect(screen.queryByRole('link', { name: /Enable Hosted Traces/, hidden: true })).not.toBeInTheDocument();
 
-    resolveProbe(false);
-
-    // The traces setup card joins the deck without stealing the visible slide.
-    expect(await screen.findByRole('link', { name: /Set up Hosted Traces/, hidden: true })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /Add Synthetic Monitoring/ })).toBeInTheDocument();
-
-    // Late-settling cards append behind cards already showing (never insert in front — the
-    // carousel animates position shifts). getAllByRole returns document order.
-    const links = screen.getAllByRole('link', { hidden: true });
-    const smIndex = links.findIndex((link) => /Add Synthetic Monitoring/.test(link.textContent ?? ''));
-    const tracesIndex = links.findIndex((link) => /Set up Hosted Traces/.test(link.textContent ?? ''));
-    expect(smIndex).toBeGreaterThan(-1);
-    expect(tracesIndex).toBeGreaterThan(smIndex);
-  });
-
-  it('hides the section when every enabled app has data', async () => {
-    mockGet.mockResolvedValue(APP_IDS.map((id) => listItem(id, { enabled: true })));
-
-    const { container } = render(<Recommendations />);
-
-    await waitFor(() => expect(container).toBeEmptyDOMElement());
   });
 
   it('hides the setup card when the user lacks app access to the silent app', async () => {
-    jest.mocked(hasSolutionData).mockResolvedValue(false);
     mockGet.mockResolvedValue(
       APP_IDS.map((id) =>
         listItem(id, {
-          enabled: true,
+          enabled: id === 'grafana-exploretraces-app',
           accessControl:
-            id === 'grafana-synthetic-monitoring-app'
+            id === 'grafana-exploretraces-app'
               ? { [AccessControlAction.PluginsWrite]: true }
               : { [AccessControlAction.PluginsWrite]: true, [AccessControlAction.PluginsAppAccess]: true },
         })
@@ -267,103 +156,176 @@ describe('Recommendations', () => {
 
     render(<Recommendations />);
 
-    expect(await screen.findByRole('link', { name: /Set up Hosted Traces/, hidden: true })).toBeInTheDocument();
-    expect(screen.queryByRole('link', { name: /Set up Synthetic Monitoring/, hidden: true })).not.toBeInTheDocument();
-    // Inaccessible apps are excluded before probing: their probe could never produce a card.
-    expect(jest.mocked(hasSolutionData)).not.toHaveBeenCalledWith('grafana-synthetic-monitoring-app');
+    const region = await carouselRegion();
+    expect(within(region).queryByRole('link', { name: /Hosted Traces/, hidden: true })).not.toBeInTheDocument();
+    expect(
+      within(region).getByRole('link', { name: /Enable Kubernetes Monitoring/, hidden: true })
+    ).toBeInTheDocument();
   });
 
-  it('shows a settled setup card while another probe is still pending', async () => {
-    jest.mocked(hasSolutionData).mockImplementation((pluginId: string) => {
-      if (pluginId === 'grafana-synthetic-monitoring-app') {
-        return Promise.resolve(false);
-      }
-      if (pluginId === 'grafana-exploretraces-app') {
-        return new Promise(() => {}); // Never settles.
-      }
-      return Promise.resolve(true);
-    });
-    mockGet.mockResolvedValue(APP_IDS.map((id) => listItem(id, { enabled: true })));
+  it('renders a single connection card for metrics_only without carousel controls or auto-advance', async () => {
+    jest.useFakeTimers();
+    try {
+      setSolutionState({ metrics: 'active' });
+
+      render(<Recommendations />);
+
+      // Flush the plugin-list fetch inside act; fake timers leave it pending otherwise.
+      await act(async () => {});
+
+      const addLogs = await screen.findByRole('link', { name: /Add Logs/ });
+      expect(addLogs).toHaveAttribute('href', '/connections/add-new-connection');
+      expect(screen.queryByRole('button', { name: 'Next' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Previous' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /Go to recommendation/ })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Pause' })).not.toBeInTheDocument();
+
+      act(() => {
+        jest.advanceTimersByTime(11_000);
+      });
+
+      expect(screen.getByRole('link', { name: /Add Logs/ })).toBeInTheDocument();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('selects the Helm-flavored logs card when kubernetes is active without logs', async () => {
+    setSolutionState({ metrics: 'active', kubernetes: 'active' });
 
     render(<Recommendations />);
 
-    // The settled no-data probe renders its setup card without waiting for the hanging probe.
-    expect(await screen.findByRole('link', { name: /Set up Synthetic Monitoring/, hidden: true })).toBeInTheDocument();
-    expect(screen.queryByRole('link', { name: /Set up Hosted Traces/, hidden: true })).not.toBeInTheDocument();
+    const setupLogs = await screen.findByRole('link', { name: /Set up log collection/ });
+    expect(setupLogs).toHaveAttribute('href', '/connections/add-new-connection');
   });
 
-  it('shows installed-but-disabled cards but hides not-installed cards for a write-only user', async () => {
-    jest.mocked(contextSrv.hasPermission).mockImplementation((action) => action === AccessControlAction.PluginsWrite);
-    mockGet.mockResolvedValue(APP_IDS.filter((id) => id !== 'grafana-exploretraces-app').map((id) => listItem(id)));
+  it('hides connection cards without datasource creation permission', async () => {
+    setSolutionState({ metrics: 'active' });
+    jest
+      .mocked(contextSrv.hasPermission)
+      .mockImplementation((action) => action !== AccessControlAction.DataSourcesCreate);
 
     render(<Recommendations />);
 
     await screen.findByText('Recommendations for your stack');
-    // Cards past the active one are aria-hidden in the carousel, so query with { hidden: true }.
-    expect(screen.queryByRole('link', { name: /Add Synthetic Monitoring/, hidden: true })).toBeInTheDocument();
-    expect(screen.queryByRole('link', { name: /Enable Hosted Traces/, hidden: true })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /Add Logs/, hidden: true })).not.toBeInTheDocument();
+    expect(screen.queryByRole('region', { name: 'Recommended apps' })).not.toBeInTheDocument();
   });
 
-  it('shows not-installed cards but hides installed-but-disabled cards for an install-only user', async () => {
-    jest.mocked(contextSrv.hasPermission).mockImplementation((action) => action === AccessControlAction.PluginsInstall);
-    mockGet.mockResolvedValue(
-      APP_IDS.filter((id) => id !== 'grafana-exploretraces-app').map((id) => listItem(id, { accessControl: {} }))
-    );
-
-    render(<Recommendations />);
-
-    await screen.findByText('Recommendations for your stack');
-    expect(screen.queryByRole('link', { name: /Enable Hosted Traces/, hidden: true })).toBeInTheDocument();
-    expect(screen.queryByRole('link', { name: /Add Synthetic Monitoring/, hidden: true })).not.toBeInTheDocument();
-  });
-
-  it('hides the section when the plugin list cannot be fetched', async () => {
+  it('keeps connection cards when the plugin fetch rejects, while plugin cards fail closed', async () => {
+    // DataSourcesCreate-only user: the plugin list request fails outright.
+    jest
+      .mocked(contextSrv.hasPermission)
+      .mockImplementation((action) => action === AccessControlAction.DataSourcesCreate);
     mockGet.mockRejectedValue(new Error('boom'));
+    setSolutionState({ metrics: 'active' });
 
-    const { container } = render(<Recommendations />);
+    render(<Recommendations />);
 
-    await waitFor(() => expect(container).toBeEmptyDOMElement());
+    expect(await screen.findByRole('link', { name: /Add Logs/ })).toBeInTheDocument();
+
+    // Same failure with a plugin-card selection: nothing renders but the region stays.
+    setSolutionState({ metrics: 'active', logs: 'active' });
+    render(<Recommendations />);
+
+    expect(await screen.findByText('Recommendations for your stack')).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /Hosted Traces/, hidden: true })).not.toBeInTheDocument();
   });
 
-  it('renders nothing when the plugin list is empty', async () => {
+  it('fails plugin cards closed when the plugin list is empty', async () => {
     mockGet.mockResolvedValue([]);
 
-    const { container } = render(<Recommendations />);
+    render(<Recommendations />);
 
-    await waitFor(() => expect(container).toBeEmptyDOMElement());
+    await screen.findByText('Recommendations for your stack');
+    expect(screen.queryByRole('region', { name: 'Recommended apps' })).not.toBeInTheDocument();
   });
 
-  it('renders nothing for legacy Admin roles without plugin permissions', async () => {
-    jest.mocked(contextSrv.hasPermission).mockReturnValue(false);
-    jest.spyOn(contextSrv, 'hasRole').mockImplementation((role) => role === 'Admin');
-
-    const { container } = render(<Recommendations />);
-
-    await waitFor(() => expect(container).toBeEmptyDOMElement());
-  });
-
-  it('only shows disabled cards the user can write', async () => {
-    jest.mocked(contextSrv.hasPermission).mockImplementation((action) => action === AccessControlAction.PluginsWrite);
-    mockGet.mockResolvedValue(
-      APP_IDS.map((id) =>
-        listItem(id, {
-          accessControl: id === 'grafana-exploretraces-app' ? { [AccessControlAction.PluginsWrite]: true } : {},
-        })
-      )
-    );
+  it('renders the region left-only when any signal is unknown', async () => {
+    setSolutionState({ metrics: 'active', logs: 'unknown' });
 
     render(<Recommendations />);
 
-    expect(await screen.findByRole('link', { name: /Enable Hosted Traces/ })).toBeInTheDocument();
-    expect(screen.queryByRole('link', { name: /Add Synthetic Monitoring/ })).not.toBeInTheDocument();
+    await screen.findByText('Recommendations for your stack');
+    expect(await screen.findByRole('heading', { name: 'No data flowing yet' })).toBeInTheDocument();
+    expect(screen.queryByRole('region', { name: 'Recommended apps' })).not.toBeInTheDocument();
+  });
+
+  it('renders the region left-only with no pills for fully active stacks', async () => {
+    setSolutionState({ metrics: 'active', logs: 'active', traces: 'active', kubernetes: 'active' });
+
+    const { user } = render(<Recommendations />);
+
+    await screen.findByText('Recommendations for your stack');
+    expect(screen.queryByRole('region', { name: 'Recommended apps' })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Hide' }));
+
+    // Collapsed with zero recommendations: no pill row either.
+    expect(screen.queryByRole('link', { name: /Enable/ })).not.toBeInTheDocument();
+  });
+
+  it('never renders the removed legacy cards, even installed and disabled', async () => {
+    render(<Recommendations />);
+
+    const region = await carouselRegion();
+    expect(within(region).queryByRole('link', { name: /Synthetic Monitoring/, hidden: true })).not.toBeInTheDocument();
+    expect(
+      within(region).queryByRole('link', { name: /Application Observability/, hidden: true })
+    ).not.toBeInTheDocument();
+    expect(
+      within(region).queryByRole('link', { name: /Frontend Observability/, hidden: true })
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when the user can manage neither plugins nor datasources', async () => {
+    jest.mocked(contextSrv.hasPermission).mockReturnValue(false);
+
+    const { container } = render(<Recommendations />);
+
+    await waitFor(() => expect(container).toBeEmptyDOMElement());
+    expect(mockGet).not.toHaveBeenCalled();
+    expect(mockUseSolutionState).not.toHaveBeenCalled();
+  });
+
+  it('renders the section for a datasource-creation-only user', async () => {
+    jest
+      .mocked(contextSrv.hasPermission)
+      .mockImplementation((action) => action === AccessControlAction.DataSourcesCreate);
+    setSolutionState({ metrics: 'active' });
+
+    render(<Recommendations />);
+
+    expect(await screen.findByRole('link', { name: /Add Logs/ })).toBeInTheDocument();
+  });
+
+  it('shows installed-but-disabled cards only with a scoped write permission', async () => {
+    jest.mocked(contextSrv.hasPermission).mockImplementation((action) => action === AccessControlAction.PluginsWrite);
+    mockGet.mockResolvedValue([
+      listItem('grafana-exploretraces-app'),
+      listItem('grafana-k8s-app', { accessControl: {} }),
+    ]);
+
+    render(<Recommendations />);
+
+    expect(await screen.findByRole('link', { name: /Enable Hosted Traces/, hidden: true })).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /Enable Kubernetes Monitoring/, hidden: true })).not.toBeInTheDocument();
+  });
+
+  it('shows not-installed cards but hides installed-but-disabled ones for an install-only user', async () => {
+    jest.mocked(contextSrv.hasPermission).mockImplementation((action) => action === AccessControlAction.PluginsInstall);
+    mockGet.mockResolvedValue([listItem('grafana-k8s-app', { accessControl: {} })]);
+
+    render(<Recommendations />);
+
+    expect(await screen.findByRole('link', { name: /Enable Hosted Traces/, hidden: true })).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /Enable Kubernetes Monitoring/, hidden: true })).not.toBeInTheDocument();
   });
 
   it('hides install cards when plugin admin is disabled', async () => {
     config.pluginAdminEnabled = false;
     jest.mocked(contextSrv.hasPermission).mockImplementation((action) => action === AccessControlAction.PluginsInstall);
-    mockGet.mockResolvedValue(
-      APP_IDS.filter((id) => id !== 'grafana-exploretraces-app').map((id) => listItem(id, { accessControl: {} }))
-    );
+    mockGet.mockResolvedValue([]);
 
     try {
       const { container } = render(<Recommendations />);
@@ -443,44 +405,27 @@ describe('Recommendations', () => {
     expect(screen.queryByTestId('recommendation-existing-skeleton')).not.toBeInTheDocument();
   });
 
-  it('loads the collapsed state from local storage', async () => {
-    window.localStorage.setItem('grafana.home.recommendations.collapsed', 'true');
-    render(<Recommendations />);
-
-    expect(await screen.findByRole('button', { name: 'Show' })).toBeInTheDocument();
-    expect(screen.getByText('Recommendations for your stack')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Show' })).toHaveAttribute('aria-expanded', 'false');
-  });
-
   it('navigates recommendations with previous/next buttons', async () => {
     const { user } = render(<Recommendations />);
 
+    const region = await carouselRegion();
     const getVisibleHeading = () =>
-      screen.getAllByRole('heading', { level: 3 }).find((heading) => heading.closest('div[aria-hidden="false"]'));
+      within(region)
+        .getAllByRole('heading', { level: 3, hidden: true })
+        .find((heading) => heading.closest('div[aria-hidden="false"]'));
     const getVisibleTitle = () => getVisibleHeading()?.textContent?.trim() ?? '';
-    const getVisibleSlide = () => getVisibleHeading()?.closest('div[aria-hidden="false"]');
 
-    // The enabled lookup resolves async; wait for the carousel before reading slides.
     await screen.findByRole('button', { name: 'Next' });
 
-    const initialVisibleSlide = getVisibleSlide();
-    const initialVisibleTitle = getVisibleTitle();
-
-    expect(initialVisibleSlide).toBeInTheDocument();
-    expect(getVisibleHeading()).toBeInTheDocument();
+    expect(getVisibleTitle()).toBe('Trace requests across services');
 
     await user.click(screen.getByRole('button', { name: 'Next' }));
 
-    expect(getVisibleSlide()).toBeInTheDocument();
-    expect(getVisibleSlide()).not.toBe(initialVisibleSlide);
-    expect(getVisibleTitle()).not.toBe(initialVisibleTitle);
-    expect(getVisibleHeading()).toBeInTheDocument();
+    expect(getVisibleTitle()).toBe('Monitor your Kubernetes fleet');
 
     await user.click(screen.getByRole('button', { name: 'Previous' }));
 
-    expect(getVisibleSlide()).toBe(initialVisibleSlide);
-    expect(getVisibleTitle()).toBe(initialVisibleTitle);
-    expect(getVisibleHeading()).toBeInTheDocument();
+    expect(getVisibleTitle()).toBe('Trace requests across services');
   });
 
   it('navigates recommendations with dots', async () => {
@@ -488,13 +433,11 @@ describe('Recommendations', () => {
 
     expect(await screen.findByRole('button', { name: 'Go to recommendation 2' })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Go to recommendation 1' })).not.toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Go to recommendation 3' })).toBeInTheDocument();
 
-    await user.click(screen.getByRole('button', { name: 'Go to recommendation 3' }));
+    await user.click(screen.getByRole('button', { name: 'Go to recommendation 2' }));
 
     expect(screen.getByRole('button', { name: 'Go to recommendation 1' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Go to recommendation 2' })).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'Go to recommendation 3' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Go to recommendation 2' })).not.toBeInTheDocument();
   });
 
   it('pauses by default when reduced motion is preferred', async () => {
@@ -518,7 +461,7 @@ describe('Recommendations', () => {
     }
   });
 
-  it('pauses and resumes autoplay', async () => {
+  it('auto-advances a multi-card carousel and pauses on demand', async () => {
     jest.useFakeTimers();
 
     try {
@@ -549,10 +492,11 @@ describe('Recommendations', () => {
       jest.useRealTimers();
     }
   });
+
   it('announces the recommendation slides as a carousel region', async () => {
     render(<Recommendations />);
 
-    const region = await screen.findByRole('region', { name: 'Recommended apps' });
+    const region = await carouselRegion();
     expect(region).toHaveAttribute('aria-roledescription', 'carousel');
   });
 
@@ -568,7 +512,7 @@ describe('Recommendations', () => {
       document.removeEventListener('click', interceptLinkClicks);
     });
 
-    it('tracks enable from the active recommendation card', async () => {
+    it('tracks enable with the driving matrix row from the active card', async () => {
       const { user } = render(<Recommendations />);
 
       await user.click(await screen.findByRole('link', { name: /Enable Hosted Traces/ }));
@@ -578,6 +522,23 @@ describe('Recommendations', () => {
         action: 'enable',
         placement: 'card',
         recommendation_id: 'hosted-traces',
+        starting_state: 'ml_no_traces',
+      });
+    });
+
+    it('tracks setup from an enabled-but-silent app card', async () => {
+      mockGet.mockResolvedValue(APP_IDS.map((id) => listItem(id, { enabled: id === 'grafana-exploretraces-app' })));
+
+      const { user } = render(<Recommendations />);
+
+      await user.click(await screen.findByRole('link', { name: /Set up Hosted Traces/ }));
+
+      expect(jest.mocked(ctaClicked)).toHaveBeenCalledWith({
+        surface: 'recommendations',
+        action: 'setup',
+        placement: 'card',
+        recommendation_id: 'hosted-traces',
+        starting_state: 'ml_no_traces',
       });
     });
 
@@ -593,6 +554,7 @@ describe('Recommendations', () => {
         action: 'enable',
         placement: 'pill',
         recommendation_id: 'hosted-traces',
+        starting_state: 'ml_no_traces',
       });
     });
   });

--- a/public/app/features/home/Recommendations/Recommendations.test.tsx
+++ b/public/app/features/home/Recommendations/Recommendations.test.tsx
@@ -11,10 +11,12 @@ import { AccessControlAction } from 'app/types/accessControl';
 import { ctaClicked } from '../analytics/main';
 
 import { Recommendations } from './Recommendations';
+import { HOSTED_TRACES_APP_ID } from './appPluginIds';
 import {
   fetchClusterCpuSeries,
   fetchKubernetesHealth,
   fetchKubernetesInventory,
+  KUBERNETES_APP_ID,
   resolveKubernetesDatasource,
 } from './kubernetesData';
 import { useSolutionState } from './solutionState';
@@ -54,8 +56,9 @@ jest.mock('./solutionState', () => ({
   useSolutionState: jest.fn(),
 }));
 
+// Removed-app ids stay literal: the never-render guard must outlive their deleted constants.
 const LEGACY_APP_IDS = ['grafana-synthetic-monitoring-app', 'grafana-app-observability-app', 'grafana-kowalski-app'];
-const APP_IDS = ['grafana-exploretraces-app', 'grafana-k8s-app', ...LEGACY_APP_IDS];
+const APP_IDS = [HOSTED_TRACES_APP_ID, KUBERNETES_APP_ID, ...LEGACY_APP_IDS];
 
 const listItem = (id: string, overrides: Partial<LocalPlugin> = {}) => ({
   id,

--- a/public/app/features/home/Recommendations/Recommendations.test.tsx
+++ b/public/app/features/home/Recommendations/Recommendations.test.tsx
@@ -138,7 +138,6 @@ describe('Recommendations', () => {
     const setupLink = await screen.findByRole('link', { name: /Set up Hosted Traces/, hidden: true });
     expect(setupLink).toHaveAttribute('href', '/a/grafana-exploretraces-app');
     expect(screen.queryByRole('link', { name: /Enable Hosted Traces/, hidden: true })).not.toBeInTheDocument();
-
   });
 
   it('hides the setup card when the user lacks app access to the silent app', async () => {

--- a/public/app/features/home/Recommendations/Recommendations.tsx
+++ b/public/app/features/home/Recommendations/Recommendations.tsx
@@ -1,7 +1,6 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useMemo } from 'react';
 import { useAsync } from 'react-use';
 
-import { store } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { contextSrv } from 'app/core/services/context_srv';
 import { type LocalPlugin } from 'app/features/plugins/admin/types';
@@ -9,23 +8,19 @@ import { AccessControlAction } from 'app/types/accessControl';
 
 import { RecommendationsSkeleton } from './RecommendationsSkeleton';
 import { RecommendationsView } from './RecommendationsView';
-import { fetchInstalledPlugins, getRecommendations, type PluginRecommendationItem } from './pluginRecommendations';
-import { hasSolutionData } from './solutionDataProbes';
+import { fetchInstalledPlugins, getRecommendationCards, type PluginRecommendationCard } from './pluginRecommendations';
+import { useSolutionState } from './solutionState';
+import { selectRecommendations } from './solutionsMatrix';
 import { type RecommendationItem } from './types';
-
-// Remembers whether the section rendered on the last visit: the loading skeleton only
-// shows for users who actually get recommendations, so stacks that resolve to nothing
-// never flash a skeleton that collapses into empty space.
-const WAS_VISIBLE_KEY = 'grafana.home.recommendations.was-visible';
 
 export function Recommendations() {
   const canInstall = contextSrv.hasPermission(AccessControlAction.PluginsInstall) && config.pluginAdminEnabled;
-  // Unscoped pre-gate only; each disabled card re-checks plugins:write scoped to its own plugin.
-  // Deliberate limitation: users with only app access (no plugins:write/install anywhere) do not
-  // see the section at all — recommendations are a plugin-management surface, and the pre-gate
-  // spares every viewer the /api/plugins fetch and the solution data probes.
+  // Unscoped pre-gate only; each card re-checks its own scoped permission. Recommendations are a
+  // plugin + connection surface: plugin management or datasource creation both qualify, and the
+  // pre-gate spares every other viewer the /api/plugins fetch and the solution probes.
   const canWriteSome = contextSrv.hasPermission(AccessControlAction.PluginsWrite);
-  if (!canInstall && !canWriteSome) {
+  const canCreateDataSources = contextSrv.hasPermission(AccessControlAction.DataSourcesCreate);
+  if (!canInstall && !canWriteSome && !canCreateDataSources) {
     return null;
   }
   return <GatedRecommendations canInstall={canInstall} />;
@@ -35,12 +30,12 @@ interface GatedRecommendationsProps {
   canInstall: boolean;
 }
 
-function toEnableItem(recommendation: PluginRecommendationItem): RecommendationItem {
+function toEnableItem(recommendation: PluginRecommendationCard): RecommendationItem {
   return { ...recommendation, cta: 'enable' };
 }
 
 // Enabled-but-silent app: the CTA leads into the app to finish setup, not to the catalog.
-function toSetupItem(recommendation: PluginRecommendationItem): RecommendationItem {
+function toSetupItem(recommendation: PluginRecommendationCard): RecommendationItem {
   return { ...recommendation, action: recommendation.setupAction, href: recommendation.appHref, cta: 'setup' };
 }
 
@@ -50,101 +45,48 @@ function mapPluginsById(plugins: LocalPlugin[] = []) {
 
 function GatedRecommendations({ canInstall }: GatedRecommendationsProps) {
   const { value: installedPlugins, loading: pluginsLoading } = useAsync(fetchInstalledPlugins, []);
-  // Memoized so the probe effect below can depend on derived values without re-running every render.
   const pluginsById = useMemo(() => mapPluginsById(installedPlugins), [installedPlugins]);
 
-  // Enabled alone does not mean used: probe each enabled recommended solution for live data,
-  // and keep recommending the silent ones (preprovisioned cloud stacks enable apps by default).
-  // Only apps the user can open are worth probing — an inaccessible app can never show a setup
-  // card, and skipping it avoids doomed requests (e.g. a Faro proxy call that can only 403).
-  const probeCandidateIds = useMemo(
-    () =>
-      getRecommendations()
-        .filter((r) => {
-          const plugin = pluginsById.get(r.pluginId);
-          return !!plugin?.enabled && contextSrv.hasPermissionInMetadata(AccessControlAction.PluginsAppAccess, plugin);
-        })
-        .map((r) => r.pluginId),
-    [pluginsById]
-  );
+  const { value: resolution, loading: stateLoading } = useSolutionState();
+  const selection = resolution ? selectRecommendations(resolution.state) : undefined;
 
-  // One entry per probed plugin, landing as each probe settles, so a slow probe never suppresses
-  // an already-settled setup card. hasSolutionData never rejects.
-  const [probeResults, setProbeResults] = useState<Record<string, boolean>>({});
-  useEffect(() => {
-    let cancelled = false;
-    setProbeResults({});
-    for (const pluginId of probeCandidateIds) {
-      hasSolutionData(pluginId).then((hasData) => {
-        if (!cancelled) {
-          setProbeResults((prev) => ({ ...prev, [pluginId]: hasData }));
-        }
-      });
-    }
-    return () => {
-      cancelled = true;
-    };
-  }, [probeCandidateIds]);
+  const cardsById = getRecommendationCards();
+  const selectedCards = selection?.cards.map((id) => cardsById[id]) ?? [];
 
-  // An unavailable plugin list fails closed. /api/plugins always lists at least the core plugins,
-  // so an empty response means the list is unreliable and also fails closed.
+  // An unavailable plugin list fails closed (plugin cards only). /api/plugins always lists at
+  // least the core plugins, so an empty response means the list is unreliable and also fails closed.
   const listReady = !pluginsLoading && !!installedPlugins && installedPlugins.length > 0;
 
-  const recommendations = !listReady
-    ? []
-    : getRecommendations().flatMap((recommendation): RecommendationItem[] => {
-        const plugin = pluginsById.get(recommendation.pluginId);
-        if (!plugin) {
-          // Unlistable plugins take the install-only path.
-          return canInstall ? [toEnableItem(recommendation)] : [];
-        }
-        if (plugin.enabled) {
-          // Setup card only for a probe that settled on "no data" (probed apps are pre-filtered
-          // to ones the user can open). A pending or skipped probe excludes just this card for
-          // the render; enable cards and the left no-data card mount immediately.
-          return probeResults[recommendation.pluginId] === false ? [toSetupItem(recommendation)] : [];
-        }
-        // plugins:write is scoped to this plugin.
-        return contextSrv.hasPermissionInMetadata(AccessControlAction.PluginsWrite, plugin)
-          ? [toEnableItem(recommendation)]
-          : [];
-      });
-
-  // Cards keep the slot they first appeared in; later-settling cards append. A card must never
-  // insert in front of the slide the user is reading — the carousel animates position shifts.
-  // Append-only ref mutation during render: idempotent, so StrictMode replays are harmless.
-  const seenOrder = useRef<string[]>([]);
-  for (const recommendation of recommendations) {
-    if (!seenOrder.current.includes(recommendation.id)) {
-      seenOrder.current.push(recommendation.id);
+  const recommendations = selectedCards.flatMap((card): RecommendationItem[] => {
+    if (card.kind === 'connection') {
+      // Independent of the plugin list: a failing /api/plugins must not hide a connection card.
+      return contextSrv.hasPermission(AccessControlAction.DataSourcesCreate) ? [{ ...card, cta: 'enable' }] : [];
     }
-  }
-  recommendations.sort((a, b) => seenOrder.current.indexOf(a.id) - seenOrder.current.indexOf(b.id));
-
-  const visible = recommendations.length > 0;
-  // Settled empty: everything resolved and there is genuinely nothing to show — as opposed
-  // to a pending plugin list or pending probes that may still produce cards.
-  const allProbesSettled = probeCandidateIds.every((pluginId) => probeResults[pluginId] !== undefined);
-  const settledEmpty = listReady
-    ? !visible && allProbesSettled
-    : !pluginsLoading && (!installedPlugins || installedPlugins.length === 0);
-
-  useEffect(() => {
-    if (visible) {
-      store.set(WAS_VISIBLE_KEY, 'true');
-    } else if (settledEmpty) {
-      store.set(WAS_VISIBLE_KEY, 'false');
+    if (!listReady) {
+      return [];
     }
-  }, [visible, settledEmpty]);
+    const plugin = pluginsById.get(card.pluginId);
+    if (!plugin) {
+      // Unlistable plugins take the install-only path.
+      return canInstall ? [toEnableItem(card)] : [];
+    }
+    if (plugin.enabled) {
+      // Selection already established the solution is silent; the setup CTA leads into the app,
+      // so it only renders for users who can open it.
+      return contextSrv.hasPermissionInMetadata(AccessControlAction.PluginsAppAccess, plugin)
+        ? [toSetupItem(card)]
+        : [];
+    }
+    // plugins:write is scoped to this plugin.
+    return contextSrv.hasPermissionInMetadata(AccessControlAction.PluginsWrite, plugin) ? [toEnableItem(card)] : [];
+  });
 
-  if (visible) {
-    return <RecommendationsView recommendations={recommendations} />;
-  }
-
-  // Hold the section's space while loading, but only for users it rendered for last time.
-  if (!settledEmpty && store.getBool(WAS_VISIBLE_KEY, false)) {
+  // The region always renders once state settles; recommendations only decide the right column.
+  // Hold the skeleton while a selected plugin card still waits on the plugin list.
+  const waitingOnPlugins = pluginsLoading && selectedCards.some((card) => card.kind === 'plugin');
+  if (stateLoading || !selection || waitingOnPlugins) {
     return <RecommendationsSkeleton />;
   }
 
-  return null;
+  return <RecommendationsView recommendations={recommendations} startingState={selection.baseRow} />;
 }

--- a/public/app/features/home/Recommendations/RecommendationsView.tsx
+++ b/public/app/features/home/Recommendations/RecommendationsView.tsx
@@ -9,15 +9,18 @@ import { useStoredBoolean } from 'app/core/hooks/useStoredBoolean';
 import { RecommendationCard } from './RecommendationCard';
 import { RecommendationExisting } from './RecommendationExisting';
 import { RecommendationPill } from './RecommendationPill';
+import { type BaseRow } from './solutionsMatrix';
 import { type RecommendationItem } from './types';
 
 const HOME_RECOMMENDATIONS_COLLAPSED_LOCAL_STORAGE_KEY = 'grafana.home.recommendations.collapsed';
 
 interface RecommendationsViewProps {
   recommendations: RecommendationItem[];
+  /** Matrix row that drove the selection; threaded into cta_clicked as starting_state. */
+  startingState: BaseRow;
 }
 
-export function RecommendationsView({ recommendations }: RecommendationsViewProps) {
+export function RecommendationsView({ recommendations, startingState }: RecommendationsViewProps) {
   const styles = useStyles2(getStyles);
   const [collapsed, setCollapsed] = useStoredBoolean(HOME_RECOMMENDATIONS_COLLAPSED_LOCAL_STORAGE_KEY, false);
 
@@ -35,22 +38,14 @@ export function RecommendationsView({ recommendations }: RecommendationsViewProp
   const [activeId, setActiveId] = useState<string>();
   const [paused, setPaused] = useState(() => window.matchMedia('(prefers-reduced-motion: reduce)').matches);
 
-  // First card while unanchored (mount, or the anchored card disappeared).
-  const foundIndex = recommendations.findIndex((recommendation) => recommendation.id === activeId);
-  const safeIndex = foundIndex === -1 ? 0 : foundIndex;
-  const nextId = recommendations[(safeIndex + 1) % recommendations.length].id;
-
-  // Capture the anchor as soon as a card is showing: without this, activeId stays undefined
-  // until the first interaction and the displayed slide would still track position 0.
-  const firstId = recommendations[0].id;
-  useEffect(() => {
-    if (foundIndex === -1) {
-      setActiveId(firstId);
-    }
-  }, [foundIndex, firstId]);
+  // Clamp during render so a shrinking list cannot select an undefined entry.
+  const safeIndex = Math.min(index, recommendations.length - 1);
+  const hasRecommendations = recommendations.length > 0;
+  // A single card needs no carousel controls and must not auto-advance onto itself.
+  const showControls = recommendations.length > 1;
 
   useEffect(() => {
-    if (collapsed || paused) {
+    if (collapsed || paused || !showControls) {
       return;
     }
 
@@ -59,7 +54,7 @@ export function RecommendationsView({ recommendations }: RecommendationsViewProp
     }, 5000);
 
     return () => clearTimeout(timeout);
-  }, [collapsed, paused, nextId]);
+  }, [collapsed, paused, safeIndex, recommendations.length, showControls]);
 
   return (
     <div>
@@ -68,11 +63,15 @@ export function RecommendationsView({ recommendations }: RecommendationsViewProp
           <Trans i18nKey="home.recommendations.title">Recommendations for your stack</Trans>
         </Text>
 
-        {collapsed && (
+        {collapsed && hasRecommendations && (
           <div className={styles.pills}>
             <Stack direction="row" alignItems="center" gap={1} wrap="wrap">
               {recommendations.map((recommendation) => (
-                <RecommendationPill key={recommendation.id} recommendation={recommendation} />
+                <RecommendationPill
+                  key={recommendation.id}
+                  recommendation={recommendation}
+                  startingState={startingState}
+                />
               ))}
             </Stack>
           </div>
@@ -101,90 +100,99 @@ export function RecommendationsView({ recommendations }: RecommendationsViewProp
 
       {cardsMounted && (
         <div className={styles.cards} hidden={collapsed}>
-          <Grid gap={0} columns={{ xs: 1, md: 2 }}>
+          <Grid gap={0} columns={hasRecommendations ? { xs: 1, md: 2 } : 1}>
             <div className={styles.card}>
               <RecommendationExisting />
 
-              <div className={styles.arrow}>
-                <Icon name="arrow-right" size="xl" />
-              </div>
+              {hasRecommendations && (
+                <div className={styles.arrow}>
+                  <Icon name="arrow-right" size="xl" />
+                </div>
+              )}
             </div>
 
-            <div
-              className={cx(styles.card, styles.recommended)}
-              role="region"
-              aria-roledescription={t('home.recommendations.carousel-roledescription', 'carousel')}
-              aria-label={t('home.recommendations.carousel-label', 'Recommended apps')}
-            >
-              <Stack direction="row" justifyContent="space-between" alignItems="center" gap={2}>
-                <Badge color="brand" icon="bolt" text={t('home.recommendations.recommended', 'Recommended')} />
+            {hasRecommendations && (
+              <div
+                className={cx(styles.card, styles.recommended)}
+                role="region"
+                aria-roledescription={t('home.recommendations.carousel-roledescription', 'carousel')}
+                aria-label={t('home.recommendations.carousel-label', 'Recommended apps')}
+              >
+                <Stack direction="row" justifyContent="space-between" alignItems="center" gap={2}>
+                  <Badge color="brand" icon="bolt" text={t('home.recommendations.recommended', 'Recommended')} />
 
-                <Stack direction="row" alignItems="center" gap={1}>
-                  <Button
-                    variant="secondary"
-                    size="sm"
-                    fill="text"
-                    icon="angle-left"
-                    onClick={() =>
-                      setActiveId(recommendations[(safeIndex - 1 + recommendations.length) % recommendations.length].id)
-                    }
-                    aria-label={t('home.recommendations.previous', 'Previous')}
-                  />
-
-                  {recommendations.map((recommendation, i) =>
-                    i === safeIndex ? (
+                  {showControls && (
+                    <Stack direction="row" alignItems="center" gap={1}>
                       <Button
-                        key={recommendation.id}
                         variant="secondary"
                         size="sm"
-                        fill="solid"
-                        icon={paused ? 'play' : 'pause'}
-                        onClick={() => setPaused(!paused)}
-                        aria-label={
-                          paused ? t('home.recommendations.resume', 'Resume') : t('home.recommendations.pause', 'Pause')
-                        }
-                        data-paused={paused ? true : undefined}
-                        className={cx(styles.dot, styles.active)}
+                        fill="text"
+                        icon="angle-left"
+                        onClick={() => setIndex((safeIndex - 1 + recommendations.length) % recommendations.length)}
+                        aria-label={t('home.recommendations.previous', 'Previous')}
                       />
-                    ) : (
+
+                      {recommendations.map((_, i) =>
+                        i === safeIndex ? (
+                          <Button
+                            key={i}
+                            variant="secondary"
+                            size="sm"
+                            fill="solid"
+                            icon={paused ? 'play' : 'pause'}
+                            onClick={() => setPaused(!paused)}
+                            aria-label={
+                              paused
+                                ? t('home.recommendations.resume', 'Resume')
+                                : t('home.recommendations.pause', 'Pause')
+                            }
+                            data-paused={paused ? true : undefined}
+                            className={cx(styles.dot, styles.active)}
+                          />
+                        ) : (
+                          <Button
+                            key={i}
+                            variant="secondary"
+                            size="sm"
+                            fill="solid"
+                            onClick={() => setIndex(i)}
+                            aria-label={t('home.recommendations.go-to', 'Go to recommendation {{index}}', {
+                              index: i + 1,
+                            })}
+                            className={styles.dot}
+                          />
+                        )
+                      )}
+
                       <Button
-                        key={recommendation.id}
                         variant="secondary"
                         size="sm"
-                        fill="solid"
-                        onClick={() => setActiveId(recommendation.id)}
-                        aria-label={t('home.recommendations.go-to', 'Go to recommendation {{index}}', { index: i + 1 })}
-                        className={styles.dot}
+                        fill="text"
+                        icon="angle-right"
+                        onClick={() => setIndex((safeIndex + 1) % recommendations.length)}
+                        aria-label={t('home.recommendations.next', 'Next')}
                       />
-                    )
+                    </Stack>
                   )}
 
-                  <Button
-                    variant="secondary"
-                    size="sm"
-                    fill="text"
-                    icon="angle-right"
-                    onClick={() => setActiveId(nextId)}
-                    aria-label={t('home.recommendations.next', 'Next')}
-                  />
                 </Stack>
-              </Stack>
 
-              <div className={styles.outer}>
-                <div className={styles.inner} style={{ transform: `translateX(-${safeIndex * 100}%)` }}>
-                  {recommendations.map((recommendation, i) => (
-                    <div
-                      key={recommendation.id}
-                      className={styles.item}
-                      aria-hidden={i !== safeIndex}
-                      {...(i !== safeIndex && { inert: '' })}
-                    >
-                      <RecommendationCard recommendation={recommendation} />
-                    </div>
-                  ))}
+                <div className={styles.outer}>
+                  <div className={styles.inner} style={{ transform: `translateX(-${safeIndex * 100}%)` }}>
+                    {recommendations.map((recommendation, i) => (
+                      <div
+                        key={recommendation.id}
+                        className={styles.item}
+                        aria-hidden={i !== safeIndex}
+                        {...(i !== safeIndex && { inert: '' })}
+                      >
+                        <RecommendationCard recommendation={recommendation} startingState={startingState} />
+                      </div>
+                    ))}
+                  </div>
                 </div>
               </div>
-            </div>
+            )}
           </Grid>
         </div>
       )}

--- a/public/app/features/home/Recommendations/RecommendationsView.tsx
+++ b/public/app/features/home/Recommendations/RecommendationsView.tsx
@@ -172,7 +172,6 @@ export function RecommendationsView({ recommendations, startingState }: Recommen
                       />
                     </Stack>
                   )}
-
                 </Stack>
 
                 <div className={styles.outer}>

--- a/public/app/features/home/Recommendations/RecommendationsView.tsx
+++ b/public/app/features/home/Recommendations/RecommendationsView.tsx
@@ -33,9 +33,7 @@ export function RecommendationsView({ recommendations, startingState }: Recommen
     }
   }, [collapsed]);
 
-  // Anchored by id, not position: probes insert cards in priority order as they settle, and a
-  // late earlier-ordered card must grow the deck without moving the slide the user is reading.
-  const [activeId, setActiveId] = useState<string>();
+  const [index, setIndex] = useState(0);
   const [paused, setPaused] = useState(() => window.matchMedia('(prefers-reduced-motion: reduce)').matches);
 
   // Clamp during render so a shrinking list cannot select an undefined entry.
@@ -50,7 +48,7 @@ export function RecommendationsView({ recommendations, startingState }: Recommen
     }
 
     const timeout = setTimeout(() => {
-      setActiveId(nextId);
+      setIndex((safeIndex + 1) % recommendations.length);
     }, 5000);
 
     return () => clearTimeout(timeout);

--- a/public/app/features/home/Recommendations/pluginRecommendations.ts
+++ b/public/app/features/home/Recommendations/pluginRecommendations.ts
@@ -21,7 +21,7 @@ export interface PluginRecommendationCard extends RecommendationItem {
 }
 
 /** Guided-connection card: never "enabled-but-silent", so no setup variant. */
-export interface ConnectionRecommendationCard extends RecommendationItem {
+interface ConnectionRecommendationCard extends RecommendationItem {
   kind: 'connection';
 }
 

--- a/public/app/features/home/Recommendations/pluginRecommendations.ts
+++ b/public/app/features/home/Recommendations/pluginRecommendations.ts
@@ -3,17 +3,16 @@ import { t } from '@grafana/i18n';
 import { getBackendSrv } from '@grafana/runtime';
 import { accessControlQueryParam } from 'app/core/utils/accessControl';
 import { createBridgeURL } from 'app/features/alerting/unified/components/PluginBridge';
+import { ROUTES as CONNECTIONS_ROUTES } from 'app/features/connections/constants';
 import { type LocalPlugin } from 'app/features/plugins/admin/types';
 
-import {
-  APP_OBSERVABILITY_APP_ID,
-  FRONTEND_OBSERVABILITY_APP_ID,
-  HOSTED_TRACES_APP_ID,
-  SYNTHETIC_MONITORING_APP_ID,
-} from './appPluginIds';
+import { HOSTED_TRACES_APP_ID } from './appPluginIds';
+import { KUBERNETES_APP_ID } from './kubernetesData';
+import { type RecommendedCardId } from './solutionsMatrix';
 import { type RecommendationItem } from './types';
 
-export interface PluginRecommendationItem extends RecommendationItem {
+export interface PluginRecommendationCard extends RecommendationItem {
+  kind: 'plugin';
   pluginId: string;
   /** CTA label when the app is already enabled but not receiving data yet. */
   setupAction: string;
@@ -21,10 +20,31 @@ export interface PluginRecommendationItem extends RecommendationItem {
   appHref: string;
 }
 
-export function getRecommendations(): PluginRecommendationItem[] {
-  // appPath: in-app landing route for the setup CTA; empty when the app's root include is its real entry.
-  const recommendationDefinitions: Array<Omit<PluginRecommendationItem, 'href' | 'appHref'> & { appPath: string }> = [
-    {
+/** Guided-connection card: never "enabled-but-silent", so no setup variant. */
+export interface ConnectionRecommendationCard extends RecommendationItem {
+  kind: 'connection';
+}
+
+export type RecommendationCardDefinition = PluginRecommendationCard | ConnectionRecommendationCard;
+
+// appPath: in-app landing route for the setup CTA; empty when the app's root include is its real entry.
+function pluginCard(
+  definition: Omit<PluginRecommendationCard, 'kind' | 'href' | 'appHref'> & { appPath: string }
+): PluginRecommendationCard {
+  const { appPath, ...card } = definition;
+  return {
+    ...card,
+    kind: 'plugin',
+    href: locationUtil.assureBaseUrl(`/plugins/${card.pluginId}/`),
+    appHref: locationUtil.assureBaseUrl(createBridgeURL(card.pluginId, appPath)),
+  };
+}
+
+/** The cards the matrix can select, keyed by their selection id. */
+export function getRecommendationCards(): Record<RecommendedCardId, RecommendationCardDefinition> {
+  const connectionHref = locationUtil.assureBaseUrl(CONNECTIONS_ROUTES.AddNewConnection);
+  return {
+    'hosted-traces': pluginCard({
       id: 'hosted-traces',
       pluginId: HOSTED_TRACES_APP_ID,
       appPath: '',
@@ -38,59 +58,58 @@ export function getRecommendations(): PluginRecommendationItem[] {
       ),
       action: t('home.recommendations.hosted-traces.action', 'Enable Hosted Traces'),
       setupAction: t('home.recommendations.hosted-traces.setup-action', 'Set up Hosted Traces'),
-    },
-    {
-      id: 'synthetic-monitoring',
-      pluginId: SYNTHETIC_MONITORING_APP_ID,
-      appPath: '/home',
-      icon: 'globe',
-      color: (theme) => theme.visualization.getColorByName('purple'),
-      title: t('home.recommendations.synthetic-monitoring.title', 'Watch your cluster from outside'),
-      context: t('home.recommendations.synthetic-monitoring.context', 'Catch outages before your users do'),
-      description: t(
-        'home.recommendations.synthetic-monitoring.description',
-        'Probe your endpoints from 20+ global locations before your users notice.'
-      ),
-      action: t('home.recommendations.synthetic-monitoring.action', 'Add Synthetic Monitoring'),
-      setupAction: t('home.recommendations.synthetic-monitoring.setup-action', 'Set up Synthetic Monitoring'),
-    },
-    {
-      id: 'application-observability',
-      pluginId: APP_OBSERVABILITY_APP_ID,
+    }),
+    'kubernetes-monitoring': pluginCard({
+      id: 'kubernetes-monitoring',
+      pluginId: KUBERNETES_APP_ID,
       appPath: '',
-      icon: 'application-observability',
-      color: (theme) => theme.visualization.getColorByName('green'),
-      title: t('home.recommendations.application-observability.title', 'Explore your service map'),
-      context: t('home.recommendations.application-observability.context', 'Built automatically from your telemetry'),
-      description: t(
-        'home.recommendations.application-observability.description',
-        'Turn OpenTelemetry data into RED metrics, service maps, and correlated traces automatically.'
-      ),
-      action: t('home.recommendations.application-observability.action', 'Enable Application Observability'),
-      setupAction: t('home.recommendations.application-observability.setup-action', 'Set up Application Observability'),
-    },
-    {
-      id: 'frontend-observability',
-      pluginId: FRONTEND_OBSERVABILITY_APP_ID,
-      appPath: '',
-      icon: 'frontend-observability',
+      icon: 'kubernetes',
       color: (theme) => theme.visualization.getColorByName('blue'),
-      title: t('home.recommendations.frontend-observability.title', 'Measure real user experience'),
-      context: t('home.recommendations.frontend-observability.context', 'Connect the browser to your backend traces'),
-      description: t(
-        'home.recommendations.frontend-observability.description',
-        'Capture Core Web Vitals and errors from the browser and tie them back to backend traces.'
+      title: t('home.recommendations.kubernetes-monitoring.title', 'Monitor your Kubernetes fleet'),
+      context: t(
+        'home.recommendations.kubernetes-monitoring.context',
+        'Cluster health next to your existing telemetry'
       ),
-      action: t('home.recommendations.frontend-observability.action', 'Enable Frontend Observability'),
-      setupAction: t('home.recommendations.frontend-observability.setup-action', 'Set up Frontend Observability'),
+      description: t(
+        'home.recommendations.kubernetes-monitoring.description',
+        'Deploy the Helm chart to get pod, node, and workload health out of the box.'
+      ),
+      action: t('home.recommendations.kubernetes-monitoring.action', 'Enable Kubernetes Monitoring'),
+      setupAction: t('home.recommendations.kubernetes-monitoring.setup-action', 'Set up Kubernetes Monitoring'),
+    }),
+    // Copy is deployment-neutral on purpose: metrics activity does not prove which collector produced it.
+    'enable-logs': {
+      kind: 'connection',
+      id: 'enable-logs',
+      icon: 'gf-logs',
+      color: (theme) => theme.visualization.getColorByName('green'),
+      title: t('home.recommendations.enable-logs.title', 'See the story behind your metrics'),
+      context: t('home.recommendations.enable-logs.context', 'Correlate spikes with the logs that explain them'),
+      description: t(
+        'home.recommendations.enable-logs.description',
+        'Send logs alongside your metrics to explain anomalies. Use your existing collector or follow a guided connection.'
+      ),
+      action: t('home.recommendations.enable-logs.action', 'Add Logs'),
+      href: connectionHref,
     },
-  ];
-
-  return recommendationDefinitions.map(({ appPath, ...recommendation }) => ({
-    ...recommendation,
-    href: locationUtil.assureBaseUrl(`/plugins/${recommendation.pluginId}/`),
-    appHref: locationUtil.assureBaseUrl(createBridgeURL(recommendation.pluginId, appPath)),
-  }));
+    'enable-logs-k8s': {
+      kind: 'connection',
+      id: 'enable-logs-k8s',
+      icon: 'gf-logs',
+      color: (theme) => theme.visualization.getColorByName('green'),
+      title: t('home.recommendations.enable-logs-k8s.title', 'Turn on logs for your clusters'),
+      context: t(
+        'home.recommendations.enable-logs-k8s.context',
+        'Pod logs next to the cluster metrics you already have'
+      ),
+      description: t(
+        'home.recommendations.enable-logs-k8s.description',
+        'Add pod logs alongside your cluster metrics. If you use the Grafana Kubernetes Monitoring Helm chart, log collection is a single values flag.'
+      ),
+      action: t('home.recommendations.enable-logs-k8s.action', 'Set up log collection'),
+      href: connectionHref,
+    },
+  };
 }
 
 // Bypass getLocalPlugins(): it drops hidden plugins, which must still be classified here.

--- a/public/app/features/home/Recommendations/probeUtils.test.ts
+++ b/public/app/features/home/Recommendations/probeUtils.test.ts
@@ -1,4 +1,25 @@
-import { withTimeout } from './probeUtils';
+import { type DataSourceInstanceListItem } from '@grafana/data';
+import { getDataSourceInstanceList } from '@grafana/runtime/unstable';
+
+import { listProbeCandidates, MAX_PROBED_DATASOURCES, withTimeout } from './probeUtils';
+
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getDataSourceInstanceList: jest.fn(),
+}));
+
+const getDataSourceInstanceListMock = jest.mocked(getDataSourceInstanceList);
+
+function listItem(ds: { uid?: string; name: string; isDefault?: boolean }): DataSourceInstanceListItem {
+  return {
+    uid: ds.uid ?? ds.name,
+    name: ds.name,
+    type: 'loki',
+    meta: { id: 'loki' } as DataSourceInstanceListItem['meta'],
+    readOnly: false,
+    isDefault: ds.isDefault ?? false,
+  };
+}
 
 describe('withTimeout', () => {
   it('resolves with the promise value when it settles inside the deadline', async () => {
@@ -13,5 +34,66 @@ describe('withTimeout', () => {
     const hang = new Promise<never>(() => {});
 
     await expect(withTimeout(hang, 20)).rejects.toThrow(/timed out/i);
+  });
+});
+
+describe('listProbeCandidates', () => {
+  beforeEach(() => {
+    getDataSourceInstanceListMock.mockReset();
+  });
+
+  it('drops excluded uids', async () => {
+    getDataSourceInstanceListMock.mockResolvedValue([
+      listItem({ uid: 'excluded', name: 'utility' }),
+      listItem({ uid: 'kept', name: 'product' }),
+    ]);
+
+    const candidates = await listProbeCandidates('loki', undefined, new Set(['excluded']));
+
+    expect(candidates.map((ds) => ds.uid)).toEqual(['kept']);
+  });
+
+  it('never re-admits excluded uids through the utility-name fallback', async () => {
+    // Every datasource is a cloud utility by name: the name fallback re-admits them, but an
+    // excluded uid must stay out even then.
+    getDataSourceInstanceListMock.mockResolvedValue([
+      listItem({ uid: 'usage', name: 'grafanacloud-usage' }),
+      listItem({ uid: 'ml', name: 'grafanacloud-ml-metrics' }),
+    ]);
+
+    const candidates = await listProbeCandidates('prometheus', undefined, new Set(['usage']));
+
+    expect(candidates.map((ds) => ds.uid)).toEqual(['ml']);
+  });
+
+  it('returns empty when exclusions empty the list', async () => {
+    getDataSourceInstanceListMock.mockResolvedValue([listItem({ uid: 'only', name: 'grafanacloud-usage' })]);
+
+    await expect(listProbeCandidates('prometheus', undefined, new Set(['only']))).resolves.toEqual([]);
+  });
+
+  it('skips cloud utility datasources unless they are all there is', async () => {
+    getDataSourceInstanceListMock.mockResolvedValue([
+      listItem({ name: 'grafanacloud-usage' }),
+      listItem({ name: 'product' }),
+    ]);
+
+    await expect(listProbeCandidates('prometheus')).resolves.toEqual([listItem({ name: 'product' })]);
+
+    getDataSourceInstanceListMock.mockResolvedValue([listItem({ name: 'grafanacloud-usage' })]);
+
+    await expect(listProbeCandidates('prometheus')).resolves.toEqual([listItem({ name: 'grafanacloud-usage' })]);
+  });
+
+  it('puts the default datasource first and applies the cap', async () => {
+    getDataSourceInstanceListMock.mockResolvedValue([
+      ...Array.from({ length: MAX_PROBED_DATASOURCES }, (_, i) => listItem({ name: `ds-${i}` })),
+      listItem({ name: 'the-default', isDefault: true }),
+    ]);
+
+    const candidates = await listProbeCandidates('loki');
+
+    expect(candidates).toHaveLength(MAX_PROBED_DATASOURCES);
+    expect(candidates[0].name).toBe('the-default');
   });
 });

--- a/public/app/features/home/Recommendations/probeUtils.ts
+++ b/public/app/features/home/Recommendations/probeUtils.ts
@@ -79,13 +79,15 @@ export function createTtlCachedPromise<T>(fn: () => Promise<T>, ttlMs: number): 
 }
 
 /**
- * Candidate datasources of `type` for a data-existence probe: cloud utility datasources are
+ * Candidate datasources of `type` for a data-existence probe: `excludeUids` are dropped
+ * unconditionally (never re-admitted by any fallback), cloud utility datasources are
  * skipped (unless they are all there is), the default datasource leads, capped for fan-out.
  * Pass an Infinity `cap` when the caller reorders before capping itself.
  */
 export async function listProbeCandidates(
   type: string,
-  cap = MAX_PROBED_DATASOURCES
+  cap = MAX_PROBED_DATASOURCES,
+  excludeUids?: ReadonlySet<string>
 ): Promise<DataSourceInstanceListItem[]> {
   const list = await withRetry(() =>
     getDataSourceInstanceList({
@@ -94,8 +96,9 @@ export async function listProbeCandidates(
       filter: (ds) => ds.meta.id !== 'grafana',
     })
   );
-  const preferred = list.filter((ds) => !CLOUD_UTILITY_DATASOURCE_NAMES[ds.name]);
-  const pool = preferred.length > 0 ? preferred : list;
+  const eligible = excludeUids ? list.filter((ds) => !excludeUids.has(ds.uid)) : list;
+  const preferred = eligible.filter((ds) => !CLOUD_UTILITY_DATASOURCE_NAMES[ds.name]);
+  const pool = preferred.length > 0 ? preferred : eligible;
   const def = pool.find((ds) => ds.isDefault);
   const ordered = def ? [def, ...pool.filter((ds) => ds !== def)] : [...pool];
   return ordered.slice(0, cap);

--- a/public/app/features/home/Recommendations/solutionDataProbes.ts
+++ b/public/app/features/home/Recommendations/solutionDataProbes.ts
@@ -19,16 +19,19 @@ import {
 import { readScalar, runDatasourceQueries, runInstantQueries } from './promQuery';
 
 // "Seen recently" lookback shared by all data probes, tolerating scrape/ingest gaps.
-const DATA_LOOKBACK_HOURS = 24;
+export const DATA_LOOKBACK_HOURS = 24;
 
-// True when any probed candidate datasource of `type` satisfies `hasData`. Throws when nothing
-// was found and any candidate errored: an errored datasource may hold the data, so absence is
-// only settled when every candidate probed clean.
-async function probeFound(
+/**
+ * The first probed candidate datasource of `type` where `hasData` confirms data, or null when
+ * every candidate probed clean-and-empty (or none exist). Throws when nothing was found and any
+ * candidate errored: an errored datasource may hold the data, so absence is not settled.
+ */
+export async function probeFound(
   type: string,
-  hasData: (ds: DataSourceInstanceListItem) => Promise<boolean>
-): Promise<boolean> {
-  const candidates = await listProbeCandidates(type);
+  hasData: (ds: DataSourceInstanceListItem) => Promise<boolean>,
+  excludeUids?: ReadonlySet<string>
+): Promise<DataSourceInstanceListItem | null> {
+  const candidates = await listProbeCandidates(type, undefined, excludeUids);
   let errored = 0;
   // findDatasourceWithData requires a non-throwing callback; count failures for the unknown check.
   const guardedHasData = async (ds: DataSourceInstanceListItem) => {
@@ -41,20 +44,21 @@ async function probeFound(
   };
   const found = await findDatasourceWithData(candidates, guardedHasData);
   if (found) {
-    return true;
+    return found;
   }
   if (errored > 0) {
     throw new Error(`${errored} ${type} datasource probe(s) failed with no data found elsewhere`);
   }
-  return false;
+  return null;
 }
 
 // Any series in the lookback means the solution produces data; which datasource holds it is irrelevant.
 async function prometheusHasMetric(expr: string): Promise<boolean> {
-  return probeFound('prometheus', async (ds) => {
+  const found = await probeFound('prometheus', async (ds) => {
     const frames = await withRetry(() => runInstantQueries({ probe: expr }, ds, PROBE_TIMEOUT_MS));
     return (readScalar(frames, 'probe') ?? 0) > 0;
   });
+  return found !== null;
 }
 
 interface TempoSearchQuery extends DataQuery {
@@ -62,7 +66,7 @@ interface TempoSearchQuery extends DataQuery {
   limit: number;
 }
 
-async function tempoHasTraces(ds: DataSourceInstanceListItem): Promise<boolean> {
+export async function tempoHasTraces(ds: DataSourceInstanceListItem): Promise<boolean> {
   const toTime = dateTime();
   const fromTime = dateTime().subtract(DATA_LOOKBACK_HOURS, 'h');
   const range: TimeRange = {
@@ -100,7 +104,10 @@ const probesBySolution: Record<string, { get(): Promise<boolean>; reset(): void 
       ),
     PROBE_TTL_MS
   ),
-  [HOSTED_TRACES_APP_ID]: createTtlCachedPromise(() => probeFound('tempo', tempoHasTraces), PROBE_TTL_MS),
+  [HOSTED_TRACES_APP_ID]: createTtlCachedPromise(
+    async () => (await probeFound('tempo', tempoHasTraces)) !== null,
+    PROBE_TTL_MS
+  ),
   [FRONTEND_OBSERVABILITY_APP_ID]: createTtlCachedPromise(hasFrontendObservabilityData, PROBE_TTL_MS),
 };
 

--- a/public/app/features/home/Recommendations/solutionState.test.ts
+++ b/public/app/features/home/Recommendations/solutionState.test.ts
@@ -1,0 +1,292 @@
+import { type DataSourceInstanceListItem } from '@grafana/data';
+import { DataSourceWithBackend } from '@grafana/runtime';
+import { getDataSourceInstance, getDataSourceInstanceList } from '@grafana/runtime/unstable';
+
+import { resolveKubernetesDatasource } from './kubernetesData';
+import { tempoHasTraces } from './solutionDataProbes';
+import {
+  CLOUD_UTILITY_LOKI_DATASOURCE_UIDS,
+  CLOUD_UTILITY_PROM_DATASOURCE_UIDS,
+  resetSolutionStateResolution,
+  resolveSolutionState,
+} from './solutionState';
+
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getDataSourceInstanceList: jest.fn(),
+  getDataSourceInstance: jest.fn(),
+}));
+
+jest.mock('./solutionDataProbes', () => ({
+  ...jest.requireActual('./solutionDataProbes'),
+  tempoHasTraces: jest.fn(),
+}));
+
+jest.mock('./kubernetesData', () => ({
+  ...jest.requireActual('./kubernetesData'),
+  resolveKubernetesDatasource: jest.fn(),
+}));
+
+const listMock = jest.mocked(getDataSourceInstanceList);
+const instanceMock = jest.mocked(getDataSourceInstance);
+const tempoHasTracesMock = jest.mocked(tempoHasTraces);
+const kubernetesMock = jest.mocked(resolveKubernetesDatasource);
+
+const DATA_LOOKBACK_HOURS = 24;
+const SIGNAL_BUDGET_MS = 30_000;
+
+function listItem(type: string, ds: { uid: string; name?: string; isDefault?: boolean }): DataSourceInstanceListItem {
+  return {
+    uid: ds.uid,
+    name: ds.name ?? ds.uid,
+    type,
+    meta: { id: type } as DataSourceInstanceListItem['meta'],
+    readOnly: false,
+    isDefault: ds.isDefault ?? false,
+  };
+}
+
+function backendInstance(getResource: jest.Mock): DataSourceWithBackend {
+  const instance: DataSourceWithBackend = Object.create(DataSourceWithBackend.prototype);
+  instance.getResource = getResource;
+  return instance;
+}
+
+interface Fixture {
+  prometheus?: DataSourceInstanceListItem[];
+  loki?: DataSourceInstanceListItem[];
+  tempo?: DataSourceInstanceListItem[];
+  instances?: Record<string, DataSourceWithBackend>;
+}
+
+function setupFixture(fixture: Fixture) {
+  listMock.mockImplementation(async (filters) => {
+    const list = fixture[(filters?.type ?? '') as keyof Omit<Fixture, 'instances'>];
+    if (!list) {
+      throw new Error(`No fixture for type ${filters?.type}`);
+    }
+    return list;
+  });
+  instanceMock.mockImplementation(async (ref) => {
+    const uid = typeof ref === 'string' ? ref : (ref?.uid ?? '');
+    const instance = fixture.instances?.[uid];
+    if (!instance) {
+      throw new Error(`No instance fixture for uid ${uid}`);
+    }
+    return instance;
+  });
+}
+
+const emptyPromResource = () => jest.fn().mockResolvedValue({ data: [] });
+const emptyLokiResource = () => jest.fn().mockResolvedValue({ data: null });
+
+// A fresh cloud stack: every datasource preinstalled, none with product data.
+function freshCloudFixture() {
+  const promResource = emptyPromResource();
+  const lokiResource = emptyLokiResource();
+  setupFixture({
+    prometheus: [
+      listItem('prometheus', { uid: 'grafanacloud-usage', name: 'grafanacloud-usage' }),
+      listItem('prometheus', { uid: 'prom-main', name: 'grafanacloud-prom', isDefault: true }),
+    ],
+    loki: [
+      listItem('loki', { uid: 'grafanacloud-usage-insights' }),
+      listItem('loki', { uid: 'grafanacloud-alert-state-history' }),
+      listItem('loki', { uid: 'loki-main', name: 'grafanacloud-logs' }),
+    ],
+    tempo: [listItem('tempo', { uid: 'tempo-main', name: 'grafanacloud-traces' })],
+    instances: {
+      'prom-main': backendInstance(promResource),
+      'loki-main': backendInstance(lokiResource),
+    },
+  });
+  tempoHasTracesMock.mockResolvedValue(false);
+  kubernetesMock.mockResolvedValue(null);
+  return { promResource, lokiResource };
+}
+
+async function resolveWithTimers() {
+  const promise = resolveSolutionState();
+  await jest.advanceTimersByTimeAsync(SIGNAL_BUDGET_MS + 5_000);
+  return promise;
+}
+
+describe('resolveSolutionState', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-07-24T12:00:00Z'));
+    listMock.mockReset();
+    instanceMock.mockReset();
+    tempoHasTracesMock.mockReset();
+    kubernetesMock.mockReset();
+    resetSolutionStateResolution();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('settles a fresh cloud stack to all-inactive (presence is not usage)', async () => {
+    freshCloudFixture();
+
+    const resolution = await resolveSolutionState();
+
+    expect(resolution.state).toEqual({
+      metrics: 'inactive',
+      logs: 'inactive',
+      traces: 'inactive',
+      kubernetes: 'inactive',
+    });
+    expect(resolution.lokiDatasource).toBeNull();
+    expect(resolution.tempoDatasource).toBeNull();
+  });
+
+  it('never probes cloud utility datasources, even when they are all there is', async () => {
+    setupFixture({
+      prometheus: [listItem('prometheus', { uid: 'grafanacloud-usage', name: 'grafanacloud-usage' })],
+      loki: [
+        listItem('loki', { uid: 'grafanacloud-usage-insights' }),
+        listItem('loki', { uid: 'grafanacloud-alert-state-history' }),
+      ],
+      tempo: [],
+    });
+    tempoHasTracesMock.mockResolvedValue(false);
+    kubernetesMock.mockResolvedValue(null);
+
+    const resolution = await resolveSolutionState();
+
+    expect(resolution.state.metrics).toBe('inactive');
+    expect(resolution.state.logs).toBe('inactive');
+    expect(instanceMock).not.toHaveBeenCalled();
+  });
+
+  it('reports active with the winning datasource when a probe finds data', async () => {
+    const { lokiResource } = freshCloudFixture();
+    lokiResource.mockResolvedValue({ data: ['job', 'service_name'] });
+    tempoHasTracesMock.mockResolvedValue(true);
+
+    const resolution = await resolveSolutionState();
+
+    expect(resolution.state.logs).toBe('active');
+    expect(resolution.lokiDatasource?.uid).toBe('loki-main');
+    expect(resolution.state.traces).toBe('active');
+    expect(resolution.tempoDatasource?.uid).toBe('tempo-main');
+  });
+
+  it('treats an errored candidate as unknown when no data was found elsewhere, active when it was', async () => {
+    const { promResource } = freshCloudFixture();
+    const failing = jest.fn().mockRejectedValue(new Error('gateway blew up'));
+    const withData = jest.fn().mockResolvedValue({ data: ['__name__'] });
+    setupFixture({
+      prometheus: [
+        listItem('prometheus', { uid: 'prom-broken', name: 'broken', isDefault: true }),
+        listItem('prometheus', { uid: 'prom-main', name: 'grafanacloud-prom' }),
+      ],
+      loki: [listItem('loki', { uid: 'loki-main', name: 'grafanacloud-logs' })],
+      tempo: [],
+      instances: {
+        'prom-broken': backendInstance(failing),
+        'prom-main': backendInstance(withData),
+        'loki-main': backendInstance(emptyLokiResource()),
+      },
+    });
+
+    let resolution = await resolveWithTimers();
+    expect(resolution.state.metrics).toBe('active');
+
+    // Same broken candidate, but the healthy one is empty: the errored one may hold data.
+    resetSolutionStateResolution();
+    failing.mockClear();
+    withData.mockResolvedValue({ data: [] });
+
+    resolution = await resolveWithTimers();
+    expect(resolution.state.metrics).toBe('unknown');
+    expect(promResource).not.toHaveBeenCalled();
+  });
+
+  it('maps an all-errored traces probe to unknown without touching the other signals', async () => {
+    freshCloudFixture();
+    tempoHasTracesMock.mockRejectedValue(new Error('tempo down'));
+
+    const resolution = await resolveWithTimers();
+
+    expect(resolution.state.traces).toBe('unknown');
+    expect(resolution.state.logs).toBe('inactive');
+    expect(resolution.state.metrics).toBe('inactive');
+  });
+
+  it('settles a hung probe to unknown within the signal budget, preserving siblings', async () => {
+    const { lokiResource } = freshCloudFixture();
+    lokiResource.mockImplementation(() => new Promise(() => {}));
+
+    const resolution = await resolveWithTimers();
+
+    expect(resolution.state.logs).toBe('unknown');
+    expect(resolution.state.metrics).toBe('inactive');
+    expect(resolution.state.traces).toBe('inactive');
+  });
+
+  it('maps a candidate-list rejection to unknown while the aggregate still resolves', async () => {
+    freshCloudFixture();
+    listMock.mockImplementation(async (filters) => {
+      if (filters?.type === 'loki') {
+        throw new Error('list unavailable');
+      }
+      return filters?.type === 'prometheus'
+        ? [listItem('prometheus', { uid: 'prom-main', name: 'grafanacloud-prom' })]
+        : [];
+    });
+
+    const resolution = await resolveWithTimers();
+
+    expect(resolution.state.logs).toBe('unknown');
+    expect(resolution.state.metrics).toBe('inactive');
+  });
+
+  it('forces metrics active when kubernetes data exists', async () => {
+    freshCloudFixture();
+    kubernetesMock.mockResolvedValue(listItem('prometheus', { uid: 'prom-main', name: 'grafanacloud-prom' }));
+
+    const resolution = await resolveSolutionState();
+
+    expect(resolution.state.kubernetes).toBe('active');
+    expect(resolution.state.metrics).toBe('active');
+  });
+
+  it('probes the label endpoints with the lookback window in each datasource unit', async () => {
+    const { promResource, lokiResource } = freshCloudFixture();
+
+    await resolveSolutionState();
+
+    const nowMs = Date.now();
+    expect(promResource).toHaveBeenCalledWith('api/v1/labels', {
+      start: Math.floor(nowMs / 1000) - DATA_LOOKBACK_HOURS * 3600,
+      end: Math.floor(nowMs / 1000),
+    });
+    expect(lokiResource).toHaveBeenCalledWith('labels', {
+      start: nowMs * 1e6 - DATA_LOOKBACK_HOURS * 3600 * 1e9,
+      end: nowMs * 1e6,
+    });
+  });
+
+  it('fans out once for concurrent callers and re-resolves after a reset', async () => {
+    freshCloudFixture();
+
+    await Promise.all([resolveSolutionState(), resolveSolutionState()]);
+    expect(listMock).toHaveBeenCalledTimes(3);
+
+    resetSolutionStateResolution();
+    await resolveSolutionState();
+    expect(listMock).toHaveBeenCalledTimes(6);
+  });
+});
+
+describe('cloud utility uid sets', () => {
+  it('pin the platform telemetry datasources', () => {
+    expect([...CLOUD_UTILITY_PROM_DATASOURCE_UIDS]).toEqual(['grafanacloud-usage', 'grafanacloud-ml-metrics']);
+    expect([...CLOUD_UTILITY_LOKI_DATASOURCE_UIDS]).toEqual([
+      'grafanacloud-usage-insights',
+      'grafanacloud-alert-state-history',
+    ]);
+  });
+});

--- a/public/app/features/home/Recommendations/solutionState.ts
+++ b/public/app/features/home/Recommendations/solutionState.ts
@@ -1,0 +1,126 @@
+import { useAsync } from 'react-use';
+
+import { type DataSourceInstanceListItem } from '@grafana/data';
+import { DataSourceWithBackend } from '@grafana/runtime';
+import { getDataSourceInstance } from '@grafana/runtime/unstable';
+
+import { resolveKubernetesDatasource } from './kubernetesData';
+import { createTtlCachedPromise, PROBE_TIMEOUT_MS, PROBE_TTL_MS, withRetry, withTimeout } from './probeUtils';
+import { DATA_LOOKBACK_HOURS, probeFound, tempoHasTraces } from './solutionDataProbes';
+import { type SignalStatus, type SolutionState } from './solutionsMatrix';
+
+// Cloud utility datasources hold platform telemetry, never the org's product data: excluded
+// from the activity probes unconditionally.
+export const CLOUD_UTILITY_PROM_DATASOURCE_UIDS: ReadonlySet<string> = new Set([
+  'grafanacloud-usage',
+  'grafanacloud-ml-metrics',
+]);
+export const CLOUD_UTILITY_LOKI_DATASOURCE_UIDS: ReadonlySet<string> = new Set([
+  'grafanacloud-usage-insights',
+  'grafanacloud-alert-state-history',
+]);
+
+// Hard ceiling per signal; the homepage never waits longer than this on one signal.
+const SIGNAL_BUDGET_MS = 30_000;
+
+export interface SolutionStateResolution {
+  state: SolutionState;
+  /** Datasources that won the logs/traces probes; null unless the signal is active. */
+  lokiDatasource: DataSourceInstanceListItem | null;
+  tempoDatasource: DataSourceInstanceListItem | null;
+}
+
+interface SignalResolution {
+  status: SignalStatus;
+  datasource: DataSourceInstanceListItem | null;
+}
+
+// Empty results are definitive 'inactive'; ANY rejection or timeout — transport errors,
+// 401/403, every-candidate-errored — is 'unknown'. The two are never conflated.
+async function resolveSignal(probe: () => Promise<DataSourceInstanceListItem | null>): Promise<SignalResolution> {
+  try {
+    const datasource = await withTimeout(probe(), SIGNAL_BUDGET_MS);
+    return { status: datasource ? 'active' : 'inactive', datasource };
+  } catch {
+    return { status: 'unknown', datasource: null };
+  }
+}
+
+async function getBackendInstance(uid: string): Promise<DataSourceWithBackend | null> {
+  const instance = await getDataSourceInstance({ uid });
+  return instance instanceof DataSourceWithBackend ? instance : null;
+}
+
+// Recent-activity checks ride each datasource's label metadata endpoint: cheap, index-only,
+// and an empty label set within the lookback is a definitive "no data".
+async function prometheusHasRecentLabels(ds: DataSourceInstanceListItem): Promise<boolean> {
+  const instance = await getBackendInstance(ds.uid);
+  if (!instance) {
+    return false;
+  }
+  const end = Math.floor(Date.now() / 1000);
+  const start = end - DATA_LOOKBACK_HOURS * 3600;
+  const res = await withRetry(() =>
+    withTimeout(instance.getResource<{ data?: unknown }>('api/v1/labels', { start, end }), PROBE_TIMEOUT_MS)
+  );
+  return Array.isArray(res?.data) && res.data.length > 0;
+}
+
+async function lokiHasRecentLabels(ds: DataSourceInstanceListItem): Promise<boolean> {
+  const instance = await getBackendInstance(ds.uid);
+  if (!instance) {
+    return false;
+  }
+  // Loki takes nanoseconds; ms * 1e6 mirrors LokiDatasource.getTimeRangeParams (precision loss accepted).
+  const end = Date.now() * 1e6;
+  const start = end - DATA_LOOKBACK_HOURS * 3600 * 1e9;
+  const res = await withRetry(() =>
+    withTimeout(instance.getResource<{ data?: unknown }>('labels', { start, end }), PROBE_TIMEOUT_MS)
+  );
+  // Loki responds data: null when empty.
+  return Array.isArray(res?.data) && res.data.length > 0;
+}
+
+// Each signal resolver settles on its own (never rejects), so Promise.all cannot discard
+// sibling results.
+async function resolveAllSignals(): Promise<SolutionStateResolution> {
+  const [metrics, logs, traces, kubernetes] = await Promise.all([
+    resolveSignal(() => probeFound('prometheus', prometheusHasRecentLabels, CLOUD_UTILITY_PROM_DATASOURCE_UIDS)),
+    resolveSignal(() => probeFound('loki', lokiHasRecentLabels, CLOUD_UTILITY_LOKI_DATASOURCE_UIDS)),
+    resolveSignal(() => probeFound('tempo', tempoHasTraces)),
+    resolveSignal(resolveKubernetesDatasource),
+  ]);
+
+  return {
+    state: {
+      // Kubernetes data lives in a Prometheus (kube-state-metrics), so it proves metrics.
+      metrics: kubernetes.status === 'active' ? 'active' : metrics.status,
+      logs: logs.status,
+      traces: traces.status,
+      kubernetes: kubernetes.status,
+    },
+    lokiDatasource: logs.datasource,
+    tempoDatasource: traces.datasource,
+  };
+}
+
+// Carousel + solution providers mounting together fan out one resolution per TTL window.
+const solutionStateResolution = createTtlCachedPromise(resolveAllSignals, PROBE_TTL_MS);
+
+/**
+ * Settled solution signals plus the datasources that won the logs/traces probes.
+ * Never rejects; every field settles to a SignalStatus.
+ */
+export async function resolveSolutionState(): Promise<SolutionStateResolution> {
+  return solutionStateResolution.get();
+}
+
+/** Reset the cached resolution (test seam). Does NOT reset kubernetesData's own TTL cache. */
+export function resetSolutionStateResolution(): void {
+  solutionStateResolution.reset();
+}
+
+export function useSolutionState(): { value: SolutionStateResolution | undefined; loading: boolean } {
+  const { value, loading } = useAsync(resolveSolutionState, []);
+  return { value, loading };
+}

--- a/public/app/features/home/Recommendations/solutionsMatrix.test.ts
+++ b/public/app/features/home/Recommendations/solutionsMatrix.test.ts
@@ -1,0 +1,46 @@
+import {
+  type BaseRow,
+  type RecommendedCardId,
+  selectRecommendations,
+  type SignalStatus,
+  type SolutionState,
+} from './solutionsMatrix';
+
+function state(m: SignalStatus, l: SignalStatus, t: SignalStatus, k: SignalStatus): SolutionState {
+  return { metrics: m, logs: l, traces: t, kubernetes: k };
+}
+
+const on = 'active' as const;
+const off = 'inactive' as const;
+
+describe('selectRecommendations', () => {
+  // All 12 reachable combinations (kubernetes ⇒ metrics removes 4 of 16).
+  it.each<[SolutionState, RecommendedCardId[], BaseRow]>([
+    [state(off, off, off, off), [], 'empty'],
+    [state(off, off, on, off), [], 'partial_telemetry'],
+    [state(off, on, off, off), [], 'logs_only'],
+    [state(off, on, on, off), [], 'partial_telemetry'],
+    [state(on, off, off, off), ['enable-logs'], 'metrics_only'],
+    [state(on, off, on, off), ['enable-logs'], 'metrics_only'],
+    [state(on, off, off, on), ['enable-logs-k8s'], 'k8s_no_logs'],
+    [state(on, off, on, on), ['enable-logs-k8s'], 'k8s_no_logs'],
+    [state(on, on, off, off), ['hosted-traces', 'kubernetes-monitoring'], 'ml_no_traces'],
+    [state(on, on, off, on), ['hosted-traces'], 'mlk_no_traces'],
+    [state(on, on, on, off), ['kubernetes-monitoring'], 'mlt'],
+    [state(on, on, on, on), [], 'fully_active'],
+  ])('m=%s selects %s (%s)', (input, cards, baseRow) => {
+    expect(selectRecommendations(input)).toEqual({ cards, baseRow });
+  });
+
+  // A single unknown signal blanks the selection even when the settled signals would produce cards.
+  it.each<keyof SolutionState>(['metrics', 'logs', 'traces', 'kubernetes'])(
+    'short-circuits to no cards when %s is unknown',
+    (signal) => {
+      const cardProducing = state(on, on, off, off);
+      expect(selectRecommendations({ ...cardProducing, [signal]: 'unknown' })).toEqual({
+        cards: [],
+        baseRow: 'unknown',
+      });
+    }
+  );
+});

--- a/public/app/features/home/Recommendations/solutionsMatrix.ts
+++ b/public/app/features/home/Recommendations/solutionsMatrix.ts
@@ -1,0 +1,82 @@
+/**
+ * Pure recommendation matrix ("Homepage Led Growth" analytics matrix), scoped to Logs, Traces
+ * (Hosted Traces) and Kubernetes Monitoring. No I/O: signal detection lives in solutionState.ts.
+ */
+
+export type SignalStatus = 'active' | 'inactive' | 'unknown';
+
+export interface SolutionState {
+  metrics: SignalStatus;
+  logs: SignalStatus;
+  traces: SignalStatus;
+  kubernetes: SignalStatus;
+}
+
+export type RecommendedCardId = 'enable-logs' | 'enable-logs-k8s' | 'hosted-traces' | 'kubernetes-monitoring';
+
+/**
+ * Matrix row that drove the selection — a selection driver id for analytics
+ * (`starting_state`), not a full state descriptor.
+ */
+export type BaseRow =
+  | 'empty'
+  | 'logs_only'
+  | 'partial_telemetry'
+  | 'metrics_only'
+  | 'k8s_no_logs'
+  | 'ml_no_traces'
+  | 'mlk_no_traces'
+  | 'mlt'
+  | 'fully_active'
+  | 'unknown';
+
+export interface RecommendationSelection {
+  cards: RecommendedCardId[];
+  baseRow: BaseRow;
+}
+
+/**
+ * Select the recommendation cards for a settled solution state.
+ *
+ * Any `unknown` signal short-circuits to no cards: a transient probe failure must never select
+ * a wrong row or pollute `starting_state`; the probe TTL re-resolves shortly. Kubernetes data
+ * implies metrics (kube-state-metrics live in a Prometheus), so `kubernetes` active with
+ * `metrics` inactive is unreachable — solutionState enforces the invariant.
+ */
+export function selectRecommendations(state: SolutionState): RecommendationSelection {
+  const { metrics, logs, traces, kubernetes } = state;
+  if (metrics === 'unknown' || logs === 'unknown' || traces === 'unknown' || kubernetes === 'unknown') {
+    return { cards: [], baseRow: 'unknown' };
+  }
+
+  if (metrics === 'inactive') {
+    // Without the metrics foundation nothing in scope is recommendable: the "Logs-only" row
+    // recommends Metrics (separate workstream) and gates Traces on confirmed metrics.
+    if (logs === 'inactive' && traces === 'inactive') {
+      return { cards: [], baseRow: 'empty' };
+    }
+    if (logs === 'active' && traces === 'inactive') {
+      return { cards: [], baseRow: 'logs_only' };
+    }
+    return { cards: [], baseRow: 'partial_telemetry' };
+  }
+
+  if (logs === 'inactive') {
+    // Logs is PRIMARY before any traces/k8s recommendation; the K8s row only changes the copy
+    // (Helm values flag). The row's Traces cell is moot when traces are already active.
+    return kubernetes === 'active'
+      ? { cards: ['enable-logs-k8s'], baseRow: 'k8s_no_logs' }
+      : { cards: ['enable-logs'], baseRow: 'metrics_only' };
+  }
+
+  if (traces === 'inactive') {
+    // Distinct rows so Hosted Traces clicks segment by Kubernetes presence.
+    return kubernetes === 'active'
+      ? { cards: ['hosted-traces'], baseRow: 'mlk_no_traces' }
+      : { cards: ['hosted-traces', 'kubernetes-monitoring'], baseRow: 'ml_no_traces' };
+  }
+
+  return kubernetes === 'active'
+    ? { cards: [], baseRow: 'fully_active' }
+    : { cards: ['kubernetes-monitoring'], baseRow: 'mlt' };
+}

--- a/public/app/features/home/analytics/types.ts
+++ b/public/app/features/home/analytics/types.ts
@@ -46,6 +46,11 @@ export interface CtaClicked extends EventProperty {
   placement: 'list' | 'empty_state' | 'footer' | 'card' | 'pill';
   /** Stable id of the recommendation whose Enable CTA was clicked (surface 'recommendations' only). */
   recommendation_id?: string;
+  /**
+   * Matrix base-row id driving the current card selection (surface 'recommendations' only);
+   * values are the BaseRow union in solutionsMatrix.ts.
+   */
+  starting_state?: string;
   /** Stable id of the solution whose control was clicked (surfaces 'existing_solution' and 'no_data_card' only). */
   solution?: string;
 }

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -10970,23 +10970,21 @@
       "reset": "Reset recent dashboards"
     },
     "recommendations": {
-      "application-observability": {
-        "action": "Enable Application Observability",
-        "context": "Built automatically from your telemetry",
-        "description": "Turn OpenTelemetry data into RED metrics, service maps, and correlated traces automatically.",
-        "setup-action": "Set up Application Observability",
-        "title": "Explore your service map"
-      },
       "carousel-label": "Recommended apps",
       "carousel-roledescription": "carousel",
-      "existing": "Enabled solution",
-      "frontend-observability": {
-        "action": "Enable Frontend Observability",
-        "context": "Connect the browser to your backend traces",
-        "description": "Capture Core Web Vitals and errors from the browser and tie them back to backend traces.",
-        "setup-action": "Set up Frontend Observability",
-        "title": "Measure real user experience"
+      "enable-logs": {
+        "action": "Add Logs",
+        "context": "Correlate spikes with the logs that explain them",
+        "description": "Send logs alongside your metrics to explain anomalies. Use your existing collector or follow a guided connection.",
+        "title": "See the story behind your metrics"
       },
+      "enable-logs-k8s": {
+        "action": "Set up log collection",
+        "context": "Pod logs next to the cluster metrics you already have",
+        "description": "Add pod logs alongside your cluster metrics. If you use the Grafana Kubernetes Monitoring Helm chart, log collection is a single values flag.",
+        "title": "Turn on logs for your clusters"
+      },
+      "existing": "Enabled solution",
       "go-to": "Go to recommendation {{index}}",
       "health": {
         "nodes_one": "{{count}} node not ready",
@@ -11017,6 +11015,13 @@
         "title": "Kubernetes Monitoring",
         "view": "View"
       },
+      "kubernetes-monitoring": {
+        "action": "Enable Kubernetes Monitoring",
+        "context": "Cluster health next to your existing telemetry",
+        "description": "Deploy the Helm chart to get pod, node, and workload health out of the box.",
+        "setup-action": "Set up Kubernetes Monitoring",
+        "title": "Monitor your Kubernetes fleet"
+      },
       "next": "Next",
       "no-data": {
         "badge": "Getting started",
@@ -11035,13 +11040,6 @@
       "show": "Show",
       "switch": "Recommendations follow the selected solution",
       "switchSolution": "Switch solution",
-      "synthetic-monitoring": {
-        "action": "Add Synthetic Monitoring",
-        "context": "Catch outages before your users do",
-        "description": "Probe your endpoints from 20+ global locations before your users notice.",
-        "setup-action": "Set up Synthetic Monitoring",
-        "title": "Watch your cluster from outside"
-      },
       "title": "Recommendations for your stack"
     },
     "starred-dashboards-tab": {


### PR DESCRIPTION
**What is this feature?**

- Adds `solutionsMatrix.ts`: the Homepage Led Growth analytics matrix as a pure decision table that maps settled `{metrics, logs, traces, kubernetes}` signals to `{cards, baseRow}`. Any `unknown` signal selects no cards, so a transient probe failure cannot pick a wrong row.
- Adds `solutionState.ts`: live signal detection that feeds the matrix through Prometheus/Loki recent-activity probes and kubernetes detection. The cached resolution never rejects; every signal settles to a status.
- Excludes cloud utility datasources (usage-insights Prometheus/Loki) from probing, since they made every stack register as having metrics and logs. Probes now also expose the winning datasource for later parts of the stack.
- Drives the recommendations region from the matrix instead of the hardcoded card list, and threads the selecting row into `cta_clicked` analytics as `starting_state`.

**Special notes for your reviewer:**

- The `empty`, `logs_only`, and `partial_telemetry` rows intentionally select no cards. The empty-stack onboarding carousel lands in the next PR of the stack; the metrics-first funnels land in part 4.
- Give the matrix rows and the utility-datasource exclusion lists the closest review: a missed utility UID counts as real activity for every org and skews every recommendation.