### PR TITLE
Home: Probe Tempo through its search and metrics APIs

### DIFF
--- a/public/app/features/home/Recommendations/probeUtils.ts
+++ b/public/app/features/home/Recommendations/probeUtils.ts
@@ -1,5 +1,5 @@
 import { type DataSourceInstanceListItem } from '@grafana/data';
-import { DataSourceWithBackend } from '@grafana/runtime';
+import { DataSourceWithBackend, getBackendSrv } from '@grafana/runtime';
 import { getDataSourceInstance, getDataSourceInstanceList } from '@grafana/runtime/unstable';
 
 /** Cap the probe fan-out: only the first N candidates (in priority order) are probed per page load. */
@@ -29,6 +29,18 @@ const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve,
 export async function resolveBackendInstance(uid: string): Promise<DataSourceWithBackend | null> {
   const instance = await getDataSourceInstance({ uid });
   return instance instanceof DataSourceWithBackend ? instance : null;
+}
+
+/**
+ * GET through the classic datasource proxy with the probe retry/timeout policy. Expected to
+ * fail on stacks without the endpoint; never toasts. Some datasource backends (e.g. Tempo)
+ * serve their HTTP API only here, not on the resource router.
+ */
+export async function probeProxyGet<T>(uid: string, path: string, params: Record<string, unknown>): Promise<T> {
+  const url = `/api/datasources/proxy/uid/${encodeURIComponent(uid)}/${path}`;
+  return withRetry(() =>
+    withTimeout(getBackendSrv().get<T>(url, params, undefined, { showErrorAlert: false }), PROBE_TIMEOUT_MS)
+  );
 }
 
 export async function withRetry<T>(fn: () => Promise<T>): Promise<T> {

--- a/public/app/features/home/Recommendations/promQuery.ts
+++ b/public/app/features/home/Recommendations/promQuery.ts
@@ -49,7 +49,7 @@ export function readSeries(frames: DataFrame[], refId: string): FieldSparkline |
  * whose targets are expressible as DataQuery (Prometheus PromQL, Tempo TraceQL). Throws (surfaced
  * as an error; callers omit the entry) when the query errors or times out.
  */
-export async function runDatasourceQueries(
+async function runDatasourceQueries(
   queries: DataQuery[],
   range: TimeRange,
   ds: Pick<DataSourceInstanceSettings, 'uid' | 'type'>,

--- a/public/app/features/home/Recommendations/solutionDataProbes.test.ts
+++ b/public/app/features/home/Recommendations/solutionDataProbes.test.ts
@@ -1,21 +1,21 @@
-import { createDataFrame, type DataSourceInstanceListItem, FieldType } from '@grafana/data';
+import { type DataSourceInstanceListItem } from '@grafana/data';
+import { type BackendSrv, getBackendSrv } from '@grafana/runtime';
 import { getDataSourceInstanceList } from '@grafana/runtime/unstable';
 
-import { runDatasourceQueries } from './promQuery';
 import { probeFound, tempoHasTraces } from './solutionDataProbes';
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getBackendSrv: jest.fn(),
+}));
 
 jest.mock('@grafana/runtime/unstable', () => ({
   ...jest.requireActual('@grafana/runtime/unstable'),
   getDataSourceInstanceList: jest.fn(),
 }));
 
-jest.mock('./promQuery', () => ({
-  ...jest.requireActual('./promQuery'),
-  runDatasourceQueries: jest.fn(),
-}));
-
 const mockList = jest.mocked(getDataSourceInstanceList);
-const mockQueries = jest.mocked(runDatasourceQueries);
+const mockProxyGet = jest.fn();
 
 function datasource(type: string, name = `${type}-ds`): DataSourceInstanceListItem {
   return {
@@ -29,8 +29,15 @@ function datasource(type: string, name = `${type}-ds`): DataSourceInstanceListIt
 }
 
 beforeEach(() => {
+  jest.useFakeTimers();
+  jest.setSystemTime(new Date('2026-07-24T12:00:00Z'));
   mockList.mockReset();
-  mockQueries.mockReset();
+  mockProxyGet.mockReset();
+  jest.mocked(getBackendSrv).mockReturnValue({ get: mockProxyGet } as unknown as BackendSrv);
+});
+
+afterEach(() => {
+  jest.useRealTimers();
 });
 
 describe('probeFound', () => {
@@ -82,24 +89,33 @@ describe('probeFound', () => {
 });
 
 describe('tempoHasTraces', () => {
-  it('reports data when a Tempo search returns a trace', async () => {
-    mockQueries.mockResolvedValue([
-      createDataFrame({ refId: 'traces', fields: [{ name: 'traceID', type: FieldType.string, values: ['abc'] }] }),
-    ]);
+  it('reports data when the Tempo search API returns a trace', async () => {
+    mockProxyGet.mockResolvedValue({ traces: [{ traceID: 'abc' }] });
 
     await expect(tempoHasTraces(datasource('tempo'))).resolves.toBe(true);
 
-    expect(mockQueries).toHaveBeenCalledWith(
-      [{ refId: 'traces', queryType: 'traceql', query: '{}', limit: 1 }],
-      expect.objectContaining({ raw: { from: 'now-24h', to: 'now' } }),
-      expect.objectContaining({ type: 'tempo' }),
-      expect.any(Number)
+    const end = Math.floor(Date.now() / 1000);
+    expect(mockProxyGet).toHaveBeenCalledWith(
+      '/api/datasources/proxy/uid/tempo-ds/api/search',
+      { q: '{}', limit: 1, start: end - 24 * 3600, end },
+      undefined,
+      { showErrorAlert: false }
     );
   });
 
   it('reports no data when the Tempo search is empty', async () => {
-    mockQueries.mockResolvedValue([]);
+    mockProxyGet.mockResolvedValue({ traces: [] });
 
     await expect(tempoHasTraces(datasource('tempo'))).resolves.toBe(false);
+  });
+
+  it('throws when the search endpoint keeps failing', async () => {
+    mockProxyGet.mockRejectedValue(new Error('HTTP 404'));
+
+    const promise = tempoHasTraces(datasource('tempo'));
+    // Sink the rejection before the retry sleeps run out, or Jest flags it as unhandled.
+    const outcome = expect(promise).rejects.toThrow('HTTP 404');
+    await jest.advanceTimersByTimeAsync(5_000);
+    await outcome;
   });
 });

--- a/public/app/features/home/Recommendations/solutionDataProbes.ts
+++ b/public/app/features/home/Recommendations/solutionDataProbes.ts
@@ -1,7 +1,6 @@
-import { type DataQuery, type DataSourceInstanceListItem, dateTime, type TimeRange } from '@grafana/data';
+import { type DataSourceInstanceListItem } from '@grafana/data';
 
-import { findDatasourceWithData, listProbeCandidates, PROBE_TIMEOUT_MS, withRetry } from './probeUtils';
-import { runDatasourceQueries } from './promQuery';
+import { findDatasourceWithData, listProbeCandidates, probeProxyGet } from './probeUtils';
 
 // "Seen recently" lookback shared by all data probes, tolerating scrape/ingest gaps.
 export const DATA_LOOKBACK_HOURS = 24;
@@ -37,21 +36,19 @@ export async function probeFound(
   return null;
 }
 
-interface TempoSearchQuery extends DataQuery {
-  query: string;
-  limit: number;
+interface TempoSearchResponse {
+  traces?: unknown[];
 }
 
-export async function tempoHasTraces(ds: DataSourceInstanceListItem): Promise<boolean> {
-  const toTime = dateTime();
-  const fromTime = dateTime().subtract(DATA_LOOKBACK_HOURS, 'h');
-  const range: TimeRange = {
-    from: fromTime,
-    to: toTime,
-    raw: { from: `now-${DATA_LOOKBACK_HOURS}h`, to: 'now' },
-  };
-  // Tempo search target: match-all TraceQL, one result is enough to prove data exists.
-  const target: TempoSearchQuery = { refId: 'traces', queryType: 'traceql', query: '{}', limit: 1 };
-  const frames = await withRetry(() => runDatasourceQueries([target], range, ds, PROBE_TIMEOUT_MS));
-  return frames.some((frame) => frame.length > 0);
+/**
+ * One matching trace in the lookback proves data exists. Probes Tempo's search HTTP API through
+ * the datasource proxy: the frontend query path reads streamed search responses as non-empty
+ * frames on empty stores (observed live with traceQLStreaming), and the resource router 404s
+ * Tempo API paths on cloud stacks.
+ */
+export async function tempoHasTraces(ds: Pick<DataSourceInstanceListItem, 'uid'>): Promise<boolean> {
+  const end = Math.floor(Date.now() / 1000);
+  const start = end - DATA_LOOKBACK_HOURS * 3600;
+  const res = await probeProxyGet<TempoSearchResponse>(ds.uid, 'api/search', { q: '{}', limit: 1, start, end });
+  return Array.isArray(res?.traces) && res.traces.length > 0;
 }

--- a/public/app/features/home/Recommendations/telemetryData.test.ts
+++ b/public/app/features/home/Recommendations/telemetryData.test.ts
@@ -1,8 +1,7 @@
-import { createDataFrame, type DataSourceInstanceListItem, FieldType } from '@grafana/data';
+import { type DataSourceInstanceListItem } from '@grafana/data';
 import { type BackendSrv, type DataSourceWithBackend, getBackendSrv } from '@grafana/runtime';
 
 import { resolveBackendInstance } from './probeUtils';
-import { runDatasourceQueries } from './promQuery';
 import {
   fetchLogsStats,
   fetchLogsVolumeSeries,
@@ -16,25 +15,19 @@ jest.mock('./probeUtils', () => ({
   resolveBackendInstance: jest.fn(),
 }));
 
-jest.mock('./promQuery', () => ({
-  ...jest.requireActual('./promQuery'),
-  runDatasourceQueries: jest.fn(),
-}));
-
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
   getBackendSrv: jest.fn(),
 }));
 
 const mockResolveBackendInstance = jest.mocked(resolveBackendInstance);
-const mockRunDatasourceQueries = jest.mocked(runDatasourceQueries);
 const mockProxyGet = jest.fn();
 
 const DATA_LOOKBACK_HOURS = 24;
 const NS_IN_MS = 1e6;
 
 const loki: Pick<DataSourceInstanceListItem, 'uid'> = { uid: 'loki-uid' };
-const tempo = { uid: 'tempo-uid', type: 'tempo' };
+const tempo = { uid: 'tempo-uid' };
 
 function instanceWith(getResource: jest.Mock): DataSourceWithBackend {
   return { getResource } as unknown as DataSourceWithBackend;
@@ -44,7 +37,6 @@ beforeEach(() => {
   jest.useFakeTimers();
   jest.setSystemTime(new Date('2026-07-24T12:00:00Z'));
   mockResolveBackendInstance.mockReset();
-  mockRunDatasourceQueries.mockReset();
   mockProxyGet.mockReset();
   jest.mocked(getBackendSrv).mockReturnValue({ get: mockProxyGet } as unknown as BackendSrv);
 });
@@ -203,29 +195,35 @@ describe('fetchTracesServices', () => {
 });
 
 describe('fetchTracesActivity', () => {
-  it('reads the throughput series and integrates it into a span count', async () => {
-    const frame = createDataFrame({
-      refId: 'spans',
-      fields: [
-        { name: 'Time', type: FieldType.time, values: [1, 2, 3] },
-        { name: 'Value', type: FieldType.number, values: [100, 200, 300] },
+  it('sums the query_range samples into a span count and throughput series', async () => {
+    mockProxyGet.mockResolvedValue({
+      series: [
+        {
+          samples: [
+            { timestampMs: '1000', value: 100 },
+            { timestampMs: '2000', value: 200 },
+            { timestampMs: '3000', value: 300 },
+          ],
+        },
       ],
     });
-    mockRunDatasourceQueries.mockResolvedValue([frame]);
 
     const activity = await fetchTracesActivity(tempo);
 
     expect(activity.spans).toBe(600);
+    expect(activity.series?.x?.values).toEqual([1000, 2000, 3000]);
     expect(activity.series?.y.values).toEqual([100, 200, 300]);
-    expect(mockRunDatasourceQueries).toHaveBeenCalledWith(
-      [{ refId: 'spans', queryType: 'traceql', query: '{} | count_over_time()', metricsQueryType: 'range' }],
-      expect.objectContaining({ raw: { from: `now-${DATA_LOOKBACK_HOURS}h`, to: 'now' } }),
-      tempo
+    const end = Math.floor(Date.now() / 1000);
+    expect(mockProxyGet).toHaveBeenCalledWith(
+      '/api/datasources/proxy/uid/tempo-uid/api/metrics/query_range',
+      { q: '{} | count_over_time()', start: end - DATA_LOOKBACK_HOURS * 3600, end, step: '30m' },
+      undefined,
+      { showErrorAlert: false }
     );
   });
 
-  it('reports null spans when the query returns no numeric data', async () => {
-    mockRunDatasourceQueries.mockResolvedValue([]);
+  it('reports null spans when the response has no samples', async () => {
+    mockProxyGet.mockResolvedValue({ series: [] });
 
     await expect(fetchTracesActivity(tempo)).resolves.toEqual({ spans: null, series: null });
   });

--- a/public/app/features/home/Recommendations/telemetryData.test.ts
+++ b/public/app/features/home/Recommendations/telemetryData.test.ts
@@ -1,5 +1,5 @@
 import { createDataFrame, type DataSourceInstanceListItem, FieldType } from '@grafana/data';
-import { type DataSourceWithBackend } from '@grafana/runtime';
+import { type BackendSrv, type DataSourceWithBackend, getBackendSrv } from '@grafana/runtime';
 
 import { resolveBackendInstance } from './probeUtils';
 import { runDatasourceQueries } from './promQuery';
@@ -21,8 +21,14 @@ jest.mock('./promQuery', () => ({
   runDatasourceQueries: jest.fn(),
 }));
 
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getBackendSrv: jest.fn(),
+}));
+
 const mockResolveBackendInstance = jest.mocked(resolveBackendInstance);
 const mockRunDatasourceQueries = jest.mocked(runDatasourceQueries);
+const mockProxyGet = jest.fn();
 
 const DATA_LOOKBACK_HOURS = 24;
 const NS_IN_MS = 1e6;
@@ -39,6 +45,8 @@ beforeEach(() => {
   jest.setSystemTime(new Date('2026-07-24T12:00:00Z'));
   mockResolveBackendInstance.mockReset();
   mockRunDatasourceQueries.mockReset();
+  mockProxyGet.mockReset();
+  jest.mocked(getBackendSrv).mockReturnValue({ get: mockProxyGet } as unknown as BackendSrv);
 });
 
 afterEach(() => {
@@ -179,17 +187,18 @@ describe('fetchLogsVolumeSeries', () => {
 });
 
 describe('fetchTracesServices', () => {
-  it('counts tag values over the lookback in unix seconds', async () => {
-    const getResource = jest.fn(async () => ({ tagValues: [{ value: 'a' }, { value: 'b' }] }));
-    mockResolveBackendInstance.mockResolvedValue(instanceWith(getResource));
+  it('counts tag values through the datasource proxy over the lookback in unix seconds', async () => {
+    mockProxyGet.mockResolvedValue({ tagValues: [{ value: 'a' }, { value: 'b' }] });
 
     await expect(fetchTracesServices(tempo)).resolves.toBe(2);
 
     const end = Math.floor(Date.now() / 1000);
-    expect(getResource).toHaveBeenCalledWith('api/v2/search/tag/resource.service.name/values', {
-      start: end - DATA_LOOKBACK_HOURS * 3600,
-      end,
-    });
+    expect(mockProxyGet).toHaveBeenCalledWith(
+      '/api/datasources/proxy/uid/tempo-uid/api/v2/search/tag/resource.service.name/values',
+      { start: end - DATA_LOOKBACK_HOURS * 3600, end },
+      undefined,
+      { showErrorAlert: false }
+    );
   });
 });
 

--- a/public/app/features/home/Recommendations/telemetryData.ts
+++ b/public/app/features/home/Recommendations/telemetryData.ts
@@ -10,7 +10,7 @@ import {
 } from '@grafana/data';
 import { type DataSourceWithBackend } from '@grafana/runtime';
 
-import { PROBE_TIMEOUT_MS, resolveBackendInstance, withRetry, withTimeout } from './probeUtils';
+import { probeProxyGet, PROBE_TIMEOUT_MS, resolveBackendInstance, withRetry, withTimeout } from './probeUtils';
 import { readSeries, runDatasourceQueries } from './promQuery';
 import { DATA_LOOKBACK_HOURS } from './solutionDataProbes';
 
@@ -123,15 +123,14 @@ export async function fetchLogsVolumeSeries(
   return { x, y: { ...y, state: { range: getMinMaxAndDelta(y) } } };
 }
 
-/** Distinct services seen by Tempo in the lookback, or null when the lookup fails. */
+/**
+ * Distinct services seen by Tempo in the lookback, or null when the lookup fails. Uses the
+ * datasource proxy: Tempo's resource router 404s these paths on cloud stacks.
+ */
 export async function fetchTracesServices(ds: Pick<DataSourceInstanceListItem, 'uid'>): Promise<number | null> {
-  const instance = await resolveBackendInstance(ds.uid);
-  if (!instance) {
-    return null;
-  }
   const end = Math.floor(Date.now() / 1000);
   const start = end - DATA_LOOKBACK_HOURS * 3600;
-  const res = await getResource<TempoTagValuesResponse>(instance, 'api/v2/search/tag/resource.service.name/values', {
+  const res = await probeProxyGet<TempoTagValuesResponse>(ds.uid, 'api/v2/search/tag/resource.service.name/values', {
     start,
     end,
   });

--- a/public/app/features/home/Recommendations/telemetryData.ts
+++ b/public/app/features/home/Recommendations/telemetryData.ts
@@ -1,17 +1,13 @@
 import {
-  type DataQuery,
   type DataSourceInstanceListItem,
-  dateTime,
   type Field,
   type FieldSparkline,
   FieldType,
   getMinMaxAndDelta,
-  type TimeRange,
 } from '@grafana/data';
 import { type DataSourceWithBackend } from '@grafana/runtime';
 
 import { probeProxyGet, PROBE_TIMEOUT_MS, resolveBackendInstance, withRetry, withTimeout } from './probeUtils';
-import { readSeries, runDatasourceQueries } from './promQuery';
 import { DATA_LOOKBACK_HOURS } from './solutionDataProbes';
 
 /** Stats window for the logs card (design-fixed), distinct from the 24h sparkline lookback. */
@@ -44,6 +40,17 @@ interface TempoTagValuesResponse {
 
 function getResource<T>(instance: DataSourceWithBackend, path: string, params: Record<string, unknown>): Promise<T> {
   return withRetry(() => withTimeout(instance.getResource<T>(path, params), PROBE_TIMEOUT_MS));
+}
+
+// Points are [unix ms, value]; a real trend needs at least two of them.
+function toSparkline(points: Array<[number, number]>, name: string): FieldSparkline | null {
+  if (points.length < 2) {
+    return null;
+  }
+  const sorted = [...points].sort(([a], [b]) => a - b);
+  const x: Field = { name: 'Time', type: FieldType.time, values: sorted.map(([ts]) => ts), config: {} };
+  const y: Field = { name, type: FieldType.number, values: sorted.map(([, value]) => value), config: {} };
+  return { x, y: { ...y, state: { range: getMinMaxAndDelta(y) } } };
 }
 
 // Loki rejects matcher-less queries; pick the label the org's streams actually carry.
@@ -111,16 +118,10 @@ export async function fetchLogsVolumeSeries(
   const buckets = new Map<number, number>();
   for (const series of res?.data?.result ?? []) {
     for (const [ts, value] of series.values ?? []) {
-      buckets.set(ts, (buckets.get(ts) ?? 0) + (Number(value) || 0));
+      buckets.set(ts * 1000, (buckets.get(ts * 1000) ?? 0) + (Number(value) || 0));
     }
   }
-  const points = [...buckets.entries()].sort(([a], [b]) => a - b);
-  if (points.length < 2) {
-    return null;
-  }
-  const x: Field = { name: 'Time', type: FieldType.time, values: points.map(([ts]) => ts * 1000), config: {} };
-  const y: Field = { name: 'Ingest volume', type: FieldType.number, values: points.map(([, v]) => v), config: {} };
-  return { x, y: { ...y, state: { range: getMinMaxAndDelta(y) } } };
+  return toSparkline([...buckets.entries()], 'Ingest volume');
 }
 
 /**
@@ -137,50 +138,40 @@ export async function fetchTracesServices(ds: Pick<DataSourceInstanceListItem, '
   return Array.isArray(res?.tagValues) ? res.tagValues.length : null;
 }
 
-interface TempoMetricsQuery extends DataQuery {
-  query: string;
-  metricsQueryType: 'range';
+interface TempoQueryRangeResponse {
+  series?: Array<{ samples?: Array<{ timestampMs?: string | number; value?: number }> }>;
 }
 
 /**
- * Span throughput over the last 24h via TraceQL metrics: the summed series feeds the sparkline,
- * its integral is the span count. Needs the metrics-generator; callers fail soft on rejection.
+ * Span throughput over the last 24h via Tempo's TraceQL-metrics HTTP API: the summed series
+ * feeds the sparkline, its integral is the span count. Datasource proxy on purpose — the
+ * frontend query path rebuilds raw targets on some plugin versions. Needs the
+ * metrics-generator; callers fail soft on rejection.
  */
-export async function fetchTracesActivity(
-  ds: Pick<DataSourceInstanceListItem, 'uid' | 'type'>
-): Promise<TracesActivity> {
-  const toTime = dateTime();
-  const fromTime = dateTime().subtract(DATA_LOOKBACK_HOURS, 'h');
-  const range: TimeRange = {
-    from: fromTime,
-    to: toTime,
-    raw: { from: `now-${DATA_LOOKBACK_HOURS}h`, to: 'now' },
-  };
-  const target: TempoMetricsQuery = {
-    refId: 'spans',
-    queryType: 'traceql',
-    query: '{} | count_over_time()',
-    metricsQueryType: 'range',
-  };
-  const frames = await withRetry(() => runDatasourceQueries([target], range, ds));
-  const series = readSeries(frames, 'spans');
+export async function fetchTracesActivity(ds: Pick<DataSourceInstanceListItem, 'uid'>): Promise<TracesActivity> {
+  const end = Math.floor(Date.now() / 1000);
+  const start = end - DATA_LOOKBACK_HOURS * 3600;
+  const res = await probeProxyGet<TempoQueryRangeResponse>(ds.uid, 'api/metrics/query_range', {
+    q: '{} | count_over_time()',
+    start,
+    end,
+    step: '30m',
+  });
+  const buckets = new Map<number, number>();
   let spans = 0;
   let seen = false;
-  for (const frame of frames) {
-    if (frame.refId !== 'spans') {
-      continue;
-    }
-    for (const field of frame.fields) {
-      if (field.type !== FieldType.number) {
+  for (const series of res?.series ?? []) {
+    for (const sample of series.samples ?? []) {
+      // Sparse samples: zero buckets may be omitted; values may arrive as strings.
+      const ts = Number(sample.timestampMs);
+      const value = Number(sample.value ?? 0);
+      if (!Number.isFinite(ts) || !Number.isFinite(value)) {
         continue;
       }
-      for (const value of field.values) {
-        if (typeof value === 'number' && Number.isFinite(value)) {
-          seen = true;
-          spans += value;
-        }
-      }
+      seen = true;
+      spans += value;
+      buckets.set(ts, (buckets.get(ts) ?? 0) + value);
     }
   }
-  return { spans: seen ? spans : null, series };
+  return { spans: seen ? spans : null, series: toSparkline([...buckets.entries()], 'Span throughput') };
 }


### PR DESCRIPTION
**What is this feature?**

The traces signal now probes Tempo's search HTTP API, and span throughput comes from Tempo's metrics API, replacing query paths Tempo does not reliably serve.

**Special notes for your reviewer:**

`runDatasourceQueries` loses its last external consumer here and is unexported to keep knip green.