### PR TITLE
Home: Recommend Metrics and App Observability from the matrix

### DIFF
--- a/public/app/features/home/Recommendations/RecommendationExisting.test.tsx
+++ b/public/app/features/home/Recommendations/RecommendationExisting.test.tsx
@@ -104,7 +104,14 @@ function setSolutionState(
 ) {
   mockUseSolutionState.mockReturnValue({
     value: {
-      state: { metrics: 'inactive', logs: 'inactive', traces: 'inactive', kubernetes: 'inactive', ...overrides },
+      state: {
+        metrics: 'inactive',
+        logs: 'inactive',
+        traces: 'inactive',
+        kubernetes: 'inactive',
+        spanMetrics: 'inactive',
+        ...overrides,
+      },
       lokiDatasource: ds.loki ?? null,
       tempoDatasource: ds.tempo ?? null,
     },

--- a/public/app/features/home/Recommendations/Recommendations.test.tsx
+++ b/public/app/features/home/Recommendations/Recommendations.test.tsx
@@ -73,7 +73,14 @@ const mockUseSolutionState = jest.mocked(useSolutionState);
 function setSolutionState(overrides: Partial<SolutionState>) {
   mockUseSolutionState.mockReturnValue({
     value: {
-      state: { metrics: 'inactive', logs: 'inactive', traces: 'inactive', kubernetes: 'inactive', ...overrides },
+      state: {
+        metrics: 'inactive',
+        logs: 'inactive',
+        traces: 'inactive',
+        kubernetes: 'inactive',
+        spanMetrics: 'inactive',
+        ...overrides,
+      },
       lokiDatasource: null,
       tempoDatasource: null,
     },
@@ -273,8 +280,14 @@ describe('Recommendations', () => {
     expect(screen.queryByRole('region', { name: 'Recommended apps' })).not.toBeInTheDocument();
   });
 
-  it('renders the region left-only with no pills for fully active stacks', async () => {
-    setSolutionState({ metrics: 'active', logs: 'active', traces: 'active', kubernetes: 'active' });
+  it('renders the region left-only with no pills when everything including App O11y is active', async () => {
+    setSolutionState({
+      metrics: 'active',
+      logs: 'active',
+      traces: 'active',
+      kubernetes: 'active',
+      spanMetrics: 'active',
+    });
 
     const { user } = render(<Recommendations />);
 
@@ -287,14 +300,35 @@ describe('Recommendations', () => {
     expect(screen.queryByRole('link', { name: /Enable/ })).not.toBeInTheDocument();
   });
 
+  it('recommends App Observability for OTel starters, suppressed once span metrics exist', async () => {
+    setSolutionState({ metrics: 'active', logs: 'active', traces: 'active' });
+
+    const first = render(<Recommendations />);
+
+    let region = await carouselRegion();
+    const titles = within(region)
+      .getAllByRole('heading', { level: 3, hidden: true })
+      .map((heading) => heading.textContent?.trim());
+    expect(titles).toEqual(['Explore your service map', 'Monitor your Kubernetes fleet']);
+
+    first.unmount();
+    setSolutionState({ metrics: 'active', logs: 'active', traces: 'active', spanMetrics: 'active' });
+    render(<Recommendations />);
+
+    region = await carouselRegion();
+    expect(
+      within(region).queryByRole('link', { name: /Application Observability/, hidden: true })
+    ).not.toBeInTheDocument();
+    expect(
+      within(region).getByRole('link', { name: /Enable Kubernetes Monitoring/, hidden: true })
+    ).toBeInTheDocument();
+  });
+
   it('never renders the removed legacy cards, even installed and disabled', async () => {
     render(<Recommendations />);
 
     const region = await carouselRegion();
     expect(within(region).queryByRole('link', { name: /Synthetic Monitoring/, hidden: true })).not.toBeInTheDocument();
-    expect(
-      within(region).queryByRole('link', { name: /Application Observability/, hidden: true })
-    ).not.toBeInTheDocument();
     expect(
       within(region).queryByRole('link', { name: /Frontend Observability/, hidden: true })
     ).not.toBeInTheDocument();

--- a/public/app/features/home/Recommendations/appPluginIds.ts
+++ b/public/app/features/home/Recommendations/appPluginIds.ts
@@ -1,4 +1,5 @@
 // App plugin ids the homepage recommends and links into.
 export const SYNTHETIC_MONITORING_APP_ID = 'grafana-synthetic-monitoring-app';
+export const APP_OBSERVABILITY_APP_ID = 'grafana-app-observability-app';
 export const HOSTED_TRACES_APP_ID = 'grafana-exploretraces-app';
 export const LOGS_DRILLDOWN_APP_ID = 'grafana-lokiexplore-app';

--- a/public/app/features/home/Recommendations/pluginRecommendations.ts
+++ b/public/app/features/home/Recommendations/pluginRecommendations.ts
@@ -6,7 +6,7 @@ import { createBridgeURL } from 'app/features/alerting/unified/components/Plugin
 import { ROUTES as CONNECTIONS_ROUTES } from 'app/features/connections/constants';
 import { type LocalPlugin } from 'app/features/plugins/admin/types';
 
-import { HOSTED_TRACES_APP_ID } from './appPluginIds';
+import { APP_OBSERVABILITY_APP_ID, HOSTED_TRACES_APP_ID } from './appPluginIds';
 import { KUBERNETES_APP_ID } from './kubernetesData';
 import { type RecommendedCardId } from './solutionsMatrix';
 import { type RecommendationItem } from './types';
@@ -72,6 +72,21 @@ export function getRecommendationCards(): Record<RecommendedCardId, Recommendati
       ),
       action: t('home.recommendations.hosted-traces.action', 'Enable Hosted Traces'),
       setupAction: t('home.recommendations.hosted-traces.setup-action', 'Set up Hosted Traces'),
+    }),
+    'application-observability': pluginCard({
+      id: 'application-observability',
+      pluginId: APP_OBSERVABILITY_APP_ID,
+      appPath: '',
+      icon: 'application-observability',
+      color: (theme) => theme.visualization.getColorByName('green'),
+      title: t('home.recommendations.application-observability.title', 'Explore your service map'),
+      context: t('home.recommendations.application-observability.context', 'Built automatically from your telemetry'),
+      description: t(
+        'home.recommendations.application-observability.description',
+        'Turn OpenTelemetry data into RED metrics, service maps, and correlated traces automatically.'
+      ),
+      action: t('home.recommendations.application-observability.action', 'Enable Application Observability'),
+      setupAction: t('home.recommendations.application-observability.setup-action', 'Set up Application Observability'),
     }),
     'kubernetes-monitoring': pluginCard({
       id: 'kubernetes-monitoring',

--- a/public/app/features/home/Recommendations/solutionState.test.ts
+++ b/public/app/features/home/Recommendations/solutionState.test.ts
@@ -1,8 +1,9 @@
-import { type DataSourceInstanceListItem } from '@grafana/data';
+import { createDataFrame, type DataSourceInstanceListItem, FieldType } from '@grafana/data';
 import { DataSourceWithBackend } from '@grafana/runtime';
 import { getDataSourceInstance, getDataSourceInstanceList } from '@grafana/runtime/unstable';
 
 import { resolveKubernetesDatasource } from './kubernetesData';
+import { runInstantQueries } from './promQuery';
 import { tempoHasTraces } from './solutionDataProbes';
 import {
   CLOUD_UTILITY_LOKI_DATASOURCE_UIDS,
@@ -22,6 +23,11 @@ jest.mock('./solutionDataProbes', () => ({
   tempoHasTraces: jest.fn(),
 }));
 
+jest.mock('./promQuery', () => ({
+  ...jest.requireActual('./promQuery'),
+  runInstantQueries: jest.fn(),
+}));
+
 jest.mock('./kubernetesData', () => ({
   ...jest.requireActual('./kubernetesData'),
   resolveKubernetesDatasource: jest.fn(),
@@ -31,6 +37,7 @@ const listMock = jest.mocked(getDataSourceInstanceList);
 const instanceMock = jest.mocked(getDataSourceInstance);
 const tempoHasTracesMock = jest.mocked(tempoHasTraces);
 const kubernetesMock = jest.mocked(resolveKubernetesDatasource);
+const instantQueriesMock = jest.mocked(runInstantQueries);
 
 const DATA_LOOKBACK_HOURS = 24;
 const SIGNAL_BUDGET_MS = 30_000;
@@ -119,6 +126,9 @@ describe('resolveSolutionState', () => {
     instanceMock.mockReset();
     tempoHasTracesMock.mockReset();
     kubernetesMock.mockReset();
+    instantQueriesMock.mockReset();
+    // Span-metrics probe settles clean-empty unless a test overrides it.
+    instantQueriesMock.mockResolvedValue([]);
     resetSolutionStateResolution();
   });
 
@@ -136,6 +146,7 @@ describe('resolveSolutionState', () => {
       logs: 'inactive',
       traces: 'inactive',
       kubernetes: 'inactive',
+      spanMetrics: 'inactive',
     });
     expect(resolution.lokiDatasource).toBeNull();
     expect(resolution.tempoDatasource).toBeNull();
@@ -158,6 +169,7 @@ describe('resolveSolutionState', () => {
     expect(resolution.state.metrics).toBe('inactive');
     expect(resolution.state.logs).toBe('inactive');
     expect(instanceMock).not.toHaveBeenCalled();
+    expect(instantQueriesMock).not.toHaveBeenCalled();
   });
 
   it('reports active with the winning datasource when a probe finds data', async () => {
@@ -253,6 +265,32 @@ describe('resolveSolutionState', () => {
     expect(resolution.state.metrics).toBe('active');
   });
 
+  it('settles span metrics active when the probe finds series', async () => {
+    freshCloudFixture();
+    instantQueriesMock.mockResolvedValue([
+      createDataFrame({ refId: 'probe', fields: [{ name: 'Value', type: FieldType.number, values: [12] }] }),
+    ]);
+
+    const resolution = await resolveSolutionState();
+
+    expect(resolution.state.spanMetrics).toBe('active');
+    expect(instantQueriesMock).toHaveBeenCalledWith(
+      { probe: expect.stringMatching(/traces_spanmetrics_calls_total.*traces_span_metrics_calls_total/s) },
+      expect.objectContaining({ uid: 'prom-main' }),
+      expect.any(Number)
+    );
+  });
+
+  it('settles span metrics unknown when every candidate query fails, without touching siblings', async () => {
+    freshCloudFixture();
+    instantQueriesMock.mockRejectedValue(new Error('query failed'));
+
+    const resolution = await resolveWithTimers();
+
+    expect(resolution.state.spanMetrics).toBe('unknown');
+    expect(resolution.state.metrics).toBe('inactive');
+  });
+
   it('probes the label endpoints with the lookback window in each datasource unit', async () => {
     const { promResource, lokiResource } = freshCloudFixture();
 
@@ -273,11 +311,12 @@ describe('resolveSolutionState', () => {
     freshCloudFixture();
 
     await Promise.all([resolveSolutionState(), resolveSolutionState()]);
-    expect(listMock).toHaveBeenCalledTimes(3);
+    // prometheus is listed twice (labels probe + span-metrics probe), loki and tempo once.
+    expect(listMock).toHaveBeenCalledTimes(4);
 
     resetSolutionStateResolution();
     await resolveSolutionState();
-    expect(listMock).toHaveBeenCalledTimes(6);
+    expect(listMock).toHaveBeenCalledTimes(8);
   });
 });
 

--- a/public/app/features/home/Recommendations/solutionState.test.ts
+++ b/public/app/features/home/Recommendations/solutionState.test.ts
@@ -281,14 +281,44 @@ describe('resolveSolutionState', () => {
     );
   });
 
-  it('settles span metrics unknown when every candidate query fails, without touching siblings', async () => {
-    freshCloudFixture();
-    instantQueriesMock.mockRejectedValue(new Error('query failed'));
+  it('settles span metrics inactive when a candidate query fails - a dead datasource must not hide the card', async () => {
+    setupFixture({
+      prometheus: [
+        listItem('prometheus', { uid: 'prom-main', name: 'grafanacloud-prom', isDefault: true }),
+        listItem('prometheus', { uid: 'prom-demo', name: 'Prometheus Demo' }),
+      ],
+      loki: [],
+      tempo: [],
+      instances: { 'prom-main': backendInstance(emptyPromResource()) },
+    });
+    tempoHasTracesMock.mockResolvedValue(false);
+    kubernetesMock.mockResolvedValue(null);
+    instantQueriesMock.mockImplementation(async (_queries, ds) => {
+      if (ds.uid === 'prom-demo') {
+        throw new Error('dial tcp: no such host');
+      }
+      return [];
+    });
 
     const resolution = await resolveWithTimers();
 
-    expect(resolution.state.spanMetrics).toBe('unknown');
-    expect(resolution.state.metrics).toBe('inactive');
+    expect(resolution.state.spanMetrics).toBe('inactive');
+    // The core metrics signal keeps the strict direction: errored candidate + no data = unknown.
+    expect(resolution.state.metrics).toBe('unknown');
+  });
+
+  it('still settles span metrics active when a healthy candidate has series beside a broken one', async () => {
+    freshCloudFixture();
+    instantQueriesMock.mockImplementation(async (_queries, ds) => {
+      if (ds.uid !== 'prom-main') {
+        throw new Error('dial tcp: no such host');
+      }
+      return [createDataFrame({ refId: 'probe', fields: [{ name: 'Value', type: FieldType.number, values: [12] }] })];
+    });
+
+    const resolution = await resolveWithTimers();
+
+    expect(resolution.state.spanMetrics).toBe('active');
   });
 
   it('probes the label endpoints with the lookback window in each datasource unit', async () => {

--- a/public/app/features/home/Recommendations/solutionState.ts
+++ b/public/app/features/home/Recommendations/solutionState.ts
@@ -11,8 +11,13 @@ import {
   withRetry,
   withTimeout,
 } from './probeUtils';
+import { readScalar, runInstantQueries } from './promQuery';
 import { DATA_LOOKBACK_HOURS, probeFound, tempoHasTraces } from './solutionDataProbes';
 import { type SignalStatus, type SolutionState } from './solutionsMatrix';
+
+// Span metrics prove Application Observability is in use: the spanmetrics connector emits
+// traces_spanmetrics_*, OTel/Alloy emits traces_span_metrics_*.
+const SPAN_METRICS_PROBE = `count(last_over_time(traces_spanmetrics_calls_total[${DATA_LOOKBACK_HOURS}h])) or count(last_over_time(traces_span_metrics_calls_total[${DATA_LOOKBACK_HOURS}h]))`;
 
 // Cloud utility datasources hold platform telemetry, never the org's product data: excluded
 // from the activity probes unconditionally.
@@ -81,14 +86,21 @@ async function lokiHasRecentLabels(ds: DataSourceInstanceListItem): Promise<bool
   return Array.isArray(res?.data) && res.data.length > 0;
 }
 
+// Throws on query failure so probeFound counts the candidate as errored, not empty.
+async function prometheusHasSpanMetrics(ds: DataSourceInstanceListItem): Promise<boolean> {
+  const frames = await withRetry(() => runInstantQueries({ probe: SPAN_METRICS_PROBE }, ds, PROBE_TIMEOUT_MS));
+  return (readScalar(frames, 'probe') ?? 0) > 0;
+}
+
 // Each signal resolver settles on its own (never rejects), so Promise.all cannot discard
 // sibling results.
 async function resolveAllSignals(): Promise<SolutionStateResolution> {
-  const [metrics, logs, traces, kubernetes] = await Promise.all([
+  const [metrics, logs, traces, kubernetes, spanMetrics] = await Promise.all([
     resolveSignal(() => probeFound('prometheus', prometheusHasRecentLabels, CLOUD_UTILITY_PROM_DATASOURCE_UIDS)),
     resolveSignal(() => probeFound('loki', lokiHasRecentLabels, CLOUD_UTILITY_LOKI_DATASOURCE_UIDS)),
     resolveSignal(() => probeFound('tempo', tempoHasTraces)),
     resolveSignal(resolveKubernetesDatasource),
+    resolveSignal(() => probeFound('prometheus', prometheusHasSpanMetrics, CLOUD_UTILITY_PROM_DATASOURCE_UIDS)),
   ]);
 
   return {
@@ -98,6 +110,7 @@ async function resolveAllSignals(): Promise<SolutionStateResolution> {
       logs: logs.status,
       traces: traces.status,
       kubernetes: kubernetes.status,
+      spanMetrics: spanMetrics.status,
     },
     lokiDatasource: logs.datasource,
     tempoDatasource: traces.datasource,

--- a/public/app/features/home/Recommendations/solutionState.ts
+++ b/public/app/features/home/Recommendations/solutionState.ts
@@ -86,10 +86,16 @@ async function lokiHasRecentLabels(ds: DataSourceInstanceListItem): Promise<bool
   return Array.isArray(res?.data) && res.data.length > 0;
 }
 
-// Throws on query failure so probeFound counts the candidate as errored, not empty.
+// A broken candidate counts as no span metrics (unlike the core-signal probes): one dead
+// datasource must not hide the App Observability card behind an unknown — matches the
+// kubernetes probe's failure direction.
 async function prometheusHasSpanMetrics(ds: DataSourceInstanceListItem): Promise<boolean> {
-  const frames = await withRetry(() => runInstantQueries({ probe: SPAN_METRICS_PROBE }, ds, PROBE_TIMEOUT_MS));
-  return (readScalar(frames, 'probe') ?? 0) > 0;
+  try {
+    const frames = await withRetry(() => runInstantQueries({ probe: SPAN_METRICS_PROBE }, ds, PROBE_TIMEOUT_MS));
+    return (readScalar(frames, 'probe') ?? 0) > 0;
+  } catch {
+    return false;
+  }
 }
 
 // Each signal resolver settles on its own (never rejects), so Promise.all cannot discard

--- a/public/app/features/home/Recommendations/solutionsMatrix.test.ts
+++ b/public/app/features/home/Recommendations/solutionsMatrix.test.ts
@@ -7,33 +7,34 @@ import {
 } from './solutionsMatrix';
 
 function state(m: SignalStatus, l: SignalStatus, t: SignalStatus, k: SignalStatus): SolutionState {
-  return { metrics: m, logs: l, traces: t, kubernetes: k };
+  // spanMetrics inactive = App Observability not in use; specific cases override it.
+  return { metrics: m, logs: l, traces: t, kubernetes: k, spanMetrics: 'inactive' };
 }
 
 const on = 'active' as const;
 const off = 'inactive' as const;
 
 describe('selectRecommendations', () => {
-  // All 12 reachable combinations (kubernetes ⇒ metrics removes 4 of 16).
+  // All 12 reachable core combinations (kubernetes ⇒ metrics removes 4 of 16).
   it.each<[SolutionState, RecommendedCardId[], BaseRow]>([
     [state(off, off, off, off), ['connect-metrics', 'enable-logs', 'hosted-traces'], 'empty'],
-    [state(off, off, on, off), [], 'partial_telemetry'],
-    [state(off, on, off, off), [], 'logs_only'],
-    [state(off, on, on, off), [], 'partial_telemetry'],
+    [state(off, off, on, off), ['connect-metrics'], 'partial_telemetry'],
+    [state(off, on, off, off), ['connect-metrics'], 'logs_only'],
+    [state(off, on, on, off), ['connect-metrics'], 'partial_telemetry'],
     [state(on, off, off, off), ['enable-logs'], 'metrics_only'],
     [state(on, off, on, off), ['enable-logs'], 'metrics_only'],
     [state(on, off, off, on), ['enable-logs-k8s'], 'k8s_no_logs'],
     [state(on, off, on, on), ['enable-logs-k8s'], 'k8s_no_logs'],
     [state(on, on, off, off), ['hosted-traces', 'kubernetes-monitoring'], 'ml_no_traces'],
     [state(on, on, off, on), ['hosted-traces'], 'mlk_no_traces'],
-    [state(on, on, on, off), ['kubernetes-monitoring'], 'mlt'],
-    [state(on, on, on, on), [], 'fully_active'],
+    [state(on, on, on, off), ['application-observability', 'kubernetes-monitoring'], 'mlt'],
+    [state(on, on, on, on), ['application-observability'], 'fully_active'],
   ])('m=%s selects %s (%s)', (input, cards, baseRow) => {
     expect(selectRecommendations(input)).toEqual({ cards, baseRow });
   });
 
-  // A single unknown signal blanks the selection even when the settled signals would produce cards.
-  it.each<keyof SolutionState>(['metrics', 'logs', 'traces', 'kubernetes'])(
+  // A single unknown core signal blanks the selection even when the settled signals would produce cards.
+  it.each<Exclude<keyof SolutionState, 'spanMetrics'>>(['metrics', 'logs', 'traces', 'kubernetes'])(
     'short-circuits to no cards when %s is unknown',
     (signal) => {
       const cardProducing = state(on, on, off, off);
@@ -43,4 +44,29 @@ describe('selectRecommendations', () => {
       });
     }
   );
+
+  it('drops the App Observability card when span metrics show it is already in use', () => {
+    expect(selectRecommendations({ ...state(on, on, on, off), spanMetrics: 'active' })).toEqual({
+      cards: ['kubernetes-monitoring'],
+      baseRow: 'mlt',
+    });
+    expect(selectRecommendations({ ...state(on, on, on, on), spanMetrics: 'active' })).toEqual({
+      cards: [],
+      baseRow: 'fully_active',
+    });
+  });
+
+  it('fails the App Observability card toward hiding on an unknown span-metrics probe, without blanking', () => {
+    expect(selectRecommendations({ ...state(on, on, on, off), spanMetrics: 'unknown' })).toEqual({
+      cards: ['kubernetes-monitoring'],
+      baseRow: 'mlt',
+    });
+  });
+
+  it('ignores span metrics outside the M+L+T rows', () => {
+    expect(selectRecommendations({ ...state(on, on, off, off), spanMetrics: 'active' })).toEqual({
+      cards: ['hosted-traces', 'kubernetes-monitoring'],
+      baseRow: 'ml_no_traces',
+    });
+  });
 });

--- a/public/app/features/home/Recommendations/solutionsMatrix.ts
+++ b/public/app/features/home/Recommendations/solutionsMatrix.ts
@@ -1,6 +1,7 @@
 /**
  * Pure recommendation matrix ("Homepage Led Growth" analytics matrix), scoped to Logs, Traces
- * (Hosted Traces) and Kubernetes Monitoring. No I/O: signal detection lives in solutionState.ts.
+ * (Hosted Traces), Kubernetes Monitoring and Application Observability. No I/O: signal
+ * detection lives in solutionState.ts.
  */
 
 export type SignalStatus = 'active' | 'inactive' | 'unknown';
@@ -10,6 +11,12 @@ export interface SolutionState {
   logs: SignalStatus;
   traces: SignalStatus;
   kubernetes: SignalStatus;
+  /**
+   * Span metrics in the org's Prometheus — the "App Observability in use" signal. Only gates
+   * the application-observability card and fails toward hiding it: unlike the core signals,
+   * 'unknown' never blanks the selection.
+   */
+  spanMetrics: SignalStatus;
 }
 
 export type RecommendedCardId =
@@ -17,7 +24,8 @@ export type RecommendedCardId =
   | 'enable-logs'
   | 'enable-logs-k8s'
   | 'hosted-traces'
-  | 'kubernetes-monitoring';
+  | 'kubernetes-monitoring'
+  | 'application-observability';
 
 /**
  * Matrix row that drove the selection — a selection driver id for analytics
@@ -49,7 +57,8 @@ export interface RecommendationSelection {
  * `metrics` inactive is unreachable — solutionState enforces the invariant.
  */
 export function selectRecommendations(state: SolutionState): RecommendationSelection {
-  const { metrics, logs, traces, kubernetes } = state;
+  const { metrics, logs, traces, kubernetes, spanMetrics } = state;
+  // The core-signal short-circuit deliberately excludes spanMetrics: it only gates one card.
   if (metrics === 'unknown' || logs === 'unknown' || traces === 'unknown' || kubernetes === 'unknown') {
     return { cards: [], baseRow: 'unknown' };
   }
@@ -59,12 +68,12 @@ export function selectRecommendations(state: SolutionState): RecommendationSelec
     if (logs === 'inactive' && traces === 'inactive') {
       return { cards: ['connect-metrics', 'enable-logs', 'hosted-traces'], baseRow: 'empty' };
     }
-    // Partial telemetry without metrics matches no matrix row; the "Logs-only" row
-    // recommends Metrics-first funnels owned by the separate metrics workstream.
+    // Metrics is the foundation gate: the "Logs-only" row recommends Metrics, and partial
+    // telemetry without metrics funnels there too before anything else.
     if (logs === 'active' && traces === 'inactive') {
-      return { cards: [], baseRow: 'logs_only' };
+      return { cards: ['connect-metrics'], baseRow: 'logs_only' };
     }
-    return { cards: [], baseRow: 'partial_telemetry' };
+    return { cards: ['connect-metrics'], baseRow: 'partial_telemetry' };
   }
 
   if (logs === 'inactive') {
@@ -82,7 +91,9 @@ export function selectRecommendations(state: SolutionState): RecommendationSelec
       : { cards: ['hosted-traces', 'kubernetes-monitoring'], baseRow: 'ml_no_traces' };
   }
 
+  // M+L+T (OTel starters): App Observability unless span metrics show it is already in use.
+  const appO11y: RecommendedCardId[] = spanMetrics === 'inactive' ? ['application-observability'] : [];
   return kubernetes === 'active'
-    ? { cards: [], baseRow: 'fully_active' }
-    : { cards: ['kubernetes-monitoring'], baseRow: 'mlt' };
+    ? { cards: appO11y, baseRow: 'fully_active' }
+    : { cards: [...appO11y, 'kubernetes-monitoring'], baseRow: 'mlt' };
 }

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -10970,6 +10970,13 @@
       "reset": "Reset recent dashboards"
     },
     "recommendations": {
+      "application-observability": {
+        "action": "Enable Application Observability",
+        "context": "Built automatically from your telemetry",
+        "description": "Turn OpenTelemetry data into RED metrics, service maps, and correlated traces automatically.",
+        "setup-action": "Set up Application Observability",
+        "title": "Explore your service map"
+      },
       "carousel-label": "Recommended apps",
       "carousel-roledescription": "carousel",
       "connect-metrics": {


### PR DESCRIPTION
**What is this feature?**

Metrics-missing matrix rows now funnel to `connect-metrics`, and M+L+T rows recommend Application Observability, suppressed by a new span-metrics signal that fails toward hiding only that card.