### PR TITLE
Home: Harden solution probes and polish recommendation cards

### DIFF
--- a/public/app/features/datasources/utils.ts
+++ b/public/app/features/datasources/utils.ts
@@ -1,6 +1,6 @@
-import { type DataSourceJsonData, type DataSourceSettings, urlUtil, locationUtil } from '@grafana/data';
+import { type DataSourceSettings, urlUtil, locationUtil } from '@grafana/data';
 
-export const constructDataSourceExploreUrl = (dataSource: DataSourceSettings<DataSourceJsonData, {}>) => {
+export const constructDataSourceExploreUrl = (dataSource: Pick<DataSourceSettings, 'name'>) => {
   const exploreState = JSON.stringify({ datasource: dataSource.name, context: 'explore' });
   const exploreUrl = urlUtil.renderUrl(locationUtil.assureBaseUrl('/explore'), { left: exploreState });
 

--- a/public/app/features/home/Recommendations/NoDataCard.test.tsx
+++ b/public/app/features/home/Recommendations/NoDataCard.test.tsx
@@ -41,6 +41,14 @@ describe('NoDataCard', () => {
     expect(screen.getByText('Popular solutions')).toBeInTheDocument();
   });
 
+  it('renders the softened copy for the partial variant, keeping the connect CTA', () => {
+    render(<NoDataCard variant="partial" />);
+
+    expect(screen.getByRole('heading', { name: 'Add more telemetry', level: 3 })).toBeInTheDocument();
+    expect(screen.getByText(/Some signals are already flowing/)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Connect a data source/ })).toBeInTheDocument();
+  });
+
   it('links the popular solutions to a prefilled catalog search when the apps are not available', () => {
     setAvailableApps([]);
 

--- a/public/app/features/home/Recommendations/NoDataCard.tsx
+++ b/public/app/features/home/Recommendations/NoDataCard.tsx
@@ -62,8 +62,13 @@ function getSolutionHref(solution: PopularSolution, appAvailable: boolean): stri
   return locationUtil.assureBaseUrl(`/plugins?${search}`);
 }
 
+interface NoDataCardProps {
+  /** 'partial': telemetry flows (or detection was inconclusive) but nothing is renderable. */
+  variant?: 'empty' | 'partial';
+}
+
 /** Left recommendations card for instances where no solution is reporting data yet. */
-export function NoDataCard() {
+export function NoDataCard({ variant = 'empty' }: NoDataCardProps) {
   const styles = useStyles2(getStyles);
   // Availability only picks the link target; while the lookup is pending the pills
   // fall back to the catalog, so the card never blocks on it.
@@ -80,14 +85,21 @@ export function NoDataCard() {
         />
 
         <Text element="h3" variant="h3" color="primary">
-          <Trans i18nKey="home.recommendations.no-data.title">No data flowing yet</Trans>
+          {variant === 'partial'
+            ? t('home.recommendations.no-data.title-partial', 'Add more telemetry')
+            : t('home.recommendations.no-data.title', 'No data flowing yet')}
         </Text>
 
         <Text variant="body">
-          <Trans i18nKey="home.recommendations.no-data.description">
-            Connect a data source to light up your dashboards and alerts, pick from available solutions, or follow a
-            getting started guide.
-          </Trans>
+          {variant === 'partial'
+            ? t(
+                'home.recommendations.no-data.description-partial',
+                'Some signals are already flowing. Connect more data sources or pick a solution to see live stats here.'
+              )
+            : t(
+                'home.recommendations.no-data.description',
+                'Connect a data source to light up your dashboards and alerts, pick from available solutions, or follow a getting started guide.'
+              )}
         </Text>
 
         <Stack direction="column" gap={1}>

--- a/public/app/features/home/Recommendations/RecommendationExisting.test.tsx
+++ b/public/app/features/home/Recommendations/RecommendationExisting.test.tsx
@@ -20,7 +20,7 @@ import {
 import { readSeries } from './promQuery';
 import { useSolutionState } from './solutionState';
 import { type SolutionState } from './solutionsMatrix';
-import { fetchLogsStats, fetchLogsVolumeSeries, fetchTracesActivity, fetchTracesServices } from './telemetryData';
+import { fetchLogsActivity, fetchTracesActivity, fetchTracesServices } from './telemetryData';
 
 jest.mock('app/features/alerting/unified/hooks/usePluginBridge', () => ({
   ...jest.requireActual('app/features/alerting/unified/hooks/usePluginBridge'),
@@ -45,8 +45,7 @@ jest.mock('./solutionState', () => ({
 
 jest.mock('./telemetryData', () => ({
   ...jest.requireActual('./telemetryData'),
-  fetchLogsStats: jest.fn(),
-  fetchLogsVolumeSeries: jest.fn(),
+  fetchLogsActivity: jest.fn(),
   fetchTracesActivity: jest.fn(),
   fetchTracesServices: jest.fn(),
 }));
@@ -63,8 +62,7 @@ const mockFetchHealth = jest.mocked(fetchKubernetesHealth);
 const mockFetchCpuSeries = jest.mocked(fetchClusterCpuSeries);
 const mockUseSolutionState = jest.mocked(useSolutionState);
 const mockUseAppPluginMetas = jest.mocked(useAppPluginMetas);
-const mockFetchLogsStats = jest.mocked(fetchLogsStats);
-const mockFetchLogsVolumeSeries = jest.mocked(fetchLogsVolumeSeries);
+const mockFetchLogsActivity = jest.mocked(fetchLogsActivity);
 const mockFetchTracesActivity = jest.mocked(fetchTracesActivity);
 const mockFetchTracesServices = jest.mocked(fetchTracesServices);
 
@@ -121,8 +119,7 @@ function setSolutionState(
 
 function mockActiveLogs() {
   setSolutionState({ metrics: 'active', logs: 'active' }, { loki: lokiDatasource });
-  mockFetchLogsStats.mockResolvedValue({ bytes: 47_000_000_000, sources: 8 });
-  mockFetchLogsVolumeSeries.mockResolvedValue(null);
+  mockFetchLogsActivity.mockResolvedValue({ bytes: 47_000_000_000, sources: 8, series: null });
 }
 
 function mockActiveTraces() {
@@ -160,10 +157,8 @@ beforeEach(() => {
   mockUseSolutionState.mockReset();
   setSolutionState({});
   mockUseAppPluginMetas.mockReturnValue({ loading: false, error: undefined, value: [] });
-  mockFetchLogsStats.mockReset();
-  mockFetchLogsStats.mockResolvedValue({ bytes: null, sources: null });
-  mockFetchLogsVolumeSeries.mockReset();
-  mockFetchLogsVolumeSeries.mockResolvedValue(null);
+  mockFetchLogsActivity.mockReset();
+  mockFetchLogsActivity.mockResolvedValue({ bytes: null, sources: null, series: null });
   mockFetchTracesActivity.mockReset();
   mockFetchTracesActivity.mockResolvedValue({ spans: null, series: null });
   mockFetchTracesServices.mockReset();
@@ -264,7 +259,7 @@ describe('RecommendationExisting', () => {
     expect(await screen.findByRole('heading', { name: 'No data flowing yet' })).toBeInTheDocument();
     expect(screen.queryByRole('heading', { name: 'Hosted Logs' })).not.toBeInTheDocument();
     expect(screen.queryByRole('heading', { name: 'Hosted Traces' })).not.toBeInTheDocument();
-    expect(mockFetchLogsStats).not.toHaveBeenCalled();
+    expect(mockFetchLogsActivity).not.toHaveBeenCalled();
     expect(mockFetchTracesActivity).not.toHaveBeenCalled();
   });
 

--- a/public/app/features/home/Recommendations/RecommendationExisting.test.tsx
+++ b/public/app/features/home/Recommendations/RecommendationExisting.test.tsx
@@ -228,7 +228,10 @@ describe('RecommendationExisting', () => {
     render(<RecommendationExisting />);
 
     expect(await screen.findByRole('heading', { name: 'Hosted Logs' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /Open Explore \(Logs\)/ })).toHaveAttribute('href', '/explore');
+    const href = screen.getByRole('link', { name: /Open in Explore/ }).getAttribute('href') ?? '';
+    expect(href).toMatch(/^\/explore\?left=/);
+    const left = new URLSearchParams(href.split('?')[1]).get('left') ?? '';
+    expect(JSON.parse(left)).toEqual({ datasource: 'grafanacloud-logs', context: 'explore' });
   });
 
   it('links the logs entry into Logs Drilldown when the app is available', async () => {
@@ -586,7 +589,7 @@ describe('RecommendationExisting', () => {
       expect(await screen.findByRole('heading', { name: 'Kubernetes Monitoring' })).toBeInTheDocument();
       await user.click(screen.getByRole('button', { name: /Switch solution/i }));
       await user.click(screen.getByRole('menuitem', { name: 'Hosted Logs' }));
-      await user.click(await screen.findByRole('link', { name: /Open Explore \(Logs\)/ }));
+      await user.click(await screen.findByRole('link', { name: /Open in Explore/ }));
 
       expect(jest.mocked(ctaClicked)).toHaveBeenCalledWith({
         surface: 'existing_solution',

--- a/public/app/features/home/Recommendations/RecommendationExisting.test.tsx
+++ b/public/app/features/home/Recommendations/RecommendationExisting.test.tsx
@@ -259,7 +259,7 @@ describe('RecommendationExisting', () => {
 
     render(<RecommendationExisting />);
 
-    expect(await screen.findByRole('heading', { name: 'No data flowing yet' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: 'Add more telemetry' })).toBeInTheDocument();
     expect(screen.queryByRole('heading', { name: 'Hosted Logs' })).not.toBeInTheDocument();
     expect(screen.queryByRole('heading', { name: 'Hosted Traces' })).not.toBeInTheDocument();
     expect(mockFetchLogsActivity).not.toHaveBeenCalled();
@@ -280,10 +280,20 @@ describe('RecommendationExisting', () => {
 
     render(<RecommendationExisting />);
 
-    expect(await screen.findByRole('heading', { name: 'No data flowing yet' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: 'Add more telemetry' })).toBeInTheDocument();
     expect(screen.queryByRole('heading', { name: 'Hosted Logs' })).not.toBeInTheDocument();
     // The services count alone renders nothing, so it cannot carry the traces card.
     expect(screen.queryByRole('heading', { name: 'Hosted Traces' })).not.toBeInTheDocument();
+  });
+
+  it('softens the no-data claim for a metrics-only org with nothing renderable', async () => {
+    mockUsePluginBridge.mockReturnValue({ loading: false, installed: false, settings: undefined });
+    setSolutionState({ metrics: 'active' });
+
+    render(<RecommendationExisting />);
+
+    expect(await screen.findByRole('heading', { name: 'Add more telemetry' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Connect a data source/ })).toBeInTheDocument();
   });
 
   it('keeps an entry whose sparkline failed but whose stats resolved', async () => {

--- a/public/app/features/home/Recommendations/RecommendationExisting.test.tsx
+++ b/public/app/features/home/Recommendations/RecommendationExisting.test.tsx
@@ -263,6 +263,36 @@ describe('RecommendationExisting', () => {
     expect(mockFetchTracesActivity).not.toHaveBeenCalled();
   });
 
+  it('drops an active entry when every detail fetch came back empty', async () => {
+    mockUsePluginBridge.mockReturnValue({ loading: false, installed: false, settings: undefined });
+    setSolutionState(
+      { metrics: 'active', logs: 'active', traces: 'active' },
+      { loki: lokiDatasource, tempo: tempoDatasource }
+    );
+    // Signals are active but stats and sparklines all failed soft: a bare title card reads
+    // as broken, so neither solution renders.
+    mockFetchLogsActivity.mockResolvedValue({ bytes: null, sources: null, series: null });
+    mockFetchTracesActivity.mockResolvedValue({ spans: null, series: null });
+    mockFetchTracesServices.mockResolvedValue(34);
+
+    render(<RecommendationExisting />);
+
+    expect(await screen.findByRole('heading', { name: 'No data flowing yet' })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Hosted Logs' })).not.toBeInTheDocument();
+    // The services count alone renders nothing, so it cannot carry the traces card.
+    expect(screen.queryByRole('heading', { name: 'Hosted Traces' })).not.toBeInTheDocument();
+  });
+
+  it('keeps an entry whose sparkline failed but whose stats resolved', async () => {
+    mockUsePluginBridge.mockReturnValue({ loading: false, installed: false, settings: undefined });
+    mockActiveLogs();
+
+    render(<RecommendationExisting />);
+
+    expect(await screen.findByRole('heading', { name: 'Hosted Logs' })).toBeInTheDocument();
+    expect(await screen.findByText('47 GB')).toBeInTheDocument();
+  });
+
   it('shows a full-card skeleton while settings are pending', async () => {
     mockUsePluginBridge.mockReturnValue({ loading: true, installed: true, settings: undefined });
     mockResolveDatasource.mockImplementation(() => new Promise(() => {}));

--- a/public/app/features/home/Recommendations/RecommendationExisting.test.tsx
+++ b/public/app/features/home/Recommendations/RecommendationExisting.test.tsx
@@ -178,7 +178,7 @@ describe('RecommendationExisting', () => {
 
     expect(screen.getByRole('heading', { name: 'Hosted Logs' })).toBeInTheDocument();
     expect(await screen.findByText('47 GB')).toBeInTheDocument();
-    expect(screen.getByText('ingested · 7d · 8 sources')).toBeInTheDocument();
+    expect(screen.getByText('ingested · 7d · ~8 sources')).toBeInTheDocument();
   });
 
   it('lists live solutions in registry order with no stub entries', async () => {

--- a/public/app/features/home/Recommendations/RecommendationExisting.tsx
+++ b/public/app/features/home/Recommendations/RecommendationExisting.tsx
@@ -5,18 +5,30 @@ import { Stack } from '@grafana/ui';
 
 import { ExistingSolutionCard } from './ExistingSolutionCard';
 import { NoDataCard } from './NoDataCard';
+import { useSolutionState } from './solutionState';
 import { useExistingSolutions } from './useExistingSolutions';
 
 export function RecommendationExisting() {
   const [selectedTitle, setSelectedTitle] = useState<string>();
   const { loading, solutions } = useExistingSolutions();
+  // Shares the TTL-cached resolution with useExistingSolutions — no extra probes.
+  const { value: resolution } = useSolutionState();
 
   if (loading) {
     return <RecommendationExistingSkeleton />;
   }
 
   if (solutions.length === 0) {
-    return <NoDataCard />;
+    // NoDataCard's hard claim is only true when every core signal settled inactive; anything
+    // else (active-but-no-entry, unknown) gets the softened variant.
+    const s = resolution?.state;
+    const allInactive =
+      !!s &&
+      s.metrics === 'inactive' &&
+      s.logs === 'inactive' &&
+      s.traces === 'inactive' &&
+      s.kubernetes === 'inactive';
+    return <NoDataCard variant={allInactive ? 'empty' : 'partial'} />;
   }
 
   const selected = solutions.find((item) => item.title === selectedTitle) ?? solutions[0];

--- a/public/app/features/home/Recommendations/Recommendations.test.tsx
+++ b/public/app/features/home/Recommendations/Recommendations.test.tsx
@@ -233,17 +233,15 @@ describe('Recommendations', () => {
     expect(setupLogs).toHaveAttribute('href', '/connections/add-new-connection');
   });
 
-  it('hides connection cards without datasource creation permission', async () => {
+  it('hides the whole region when permissions filter out every card', async () => {
     setSolutionState({ metrics: 'active' });
     jest
       .mocked(contextSrv.hasPermission)
       .mockImplementation((action) => action !== AccessControlAction.DataSourcesCreate);
 
-    render(<Recommendations />);
+    const { container } = render(<Recommendations />);
 
-    await screen.findByText('Recommendations for your stack');
-    expect(screen.queryByRole('link', { name: /Add Logs/, hidden: true })).not.toBeInTheDocument();
-    expect(screen.queryByRole('region', { name: 'Recommended apps' })).not.toBeInTheDocument();
+    await waitFor(() => expect(container).toBeEmptyDOMElement());
   });
 
   it('keeps connection cards when the plugin fetch rejects, while plugin cards fail closed', async () => {
@@ -258,34 +256,30 @@ describe('Recommendations', () => {
 
     expect(await screen.findByRole('link', { name: /Add Logs/ })).toBeInTheDocument();
 
-    // Same failure with a plugin-card selection: nothing renders but the region stays.
+    // Same failure with a plugin-card selection: both cards fail closed and the whole region hides.
     setSolutionState({ metrics: 'active', logs: 'active' });
-    render(<Recommendations />);
+    const { container: second } = render(<Recommendations />);
 
-    expect(await screen.findByText('Recommendations for your stack')).toBeInTheDocument();
-    expect(screen.queryByRole('link', { name: /Hosted Traces/, hidden: true })).not.toBeInTheDocument();
+    await waitFor(() => expect(second).toBeEmptyDOMElement());
   });
 
-  it('fails plugin cards closed when the plugin list is empty', async () => {
+  it('hides the whole region when the plugin list is empty and every card is plugin-kind', async () => {
     mockGet.mockResolvedValue([]);
 
-    render(<Recommendations />);
+    const { container } = render(<Recommendations />);
 
-    await screen.findByText('Recommendations for your stack');
-    expect(screen.queryByRole('region', { name: 'Recommended apps' })).not.toBeInTheDocument();
+    await waitFor(() => expect(container).toBeEmptyDOMElement());
   });
 
-  it('renders the region left-only when any signal is unknown', async () => {
+  it('hides the whole region when any signal is unknown', async () => {
     setSolutionState({ metrics: 'active', logs: 'unknown' });
 
-    render(<Recommendations />);
+    const { container } = render(<Recommendations />);
 
-    await screen.findByText('Recommendations for your stack');
-    expect(await screen.findByRole('heading', { name: 'Add more telemetry' })).toBeInTheDocument();
-    expect(screen.queryByRole('region', { name: 'Recommended apps' })).not.toBeInTheDocument();
+    await waitFor(() => expect(container).toBeEmptyDOMElement());
   });
 
-  it('renders the region left-only with no pills when everything including App O11y is active', async () => {
+  it('hides the whole region when there is nothing left to recommend', async () => {
     setSolutionState({
       metrics: 'active',
       logs: 'active',
@@ -294,15 +288,9 @@ describe('Recommendations', () => {
       spanMetrics: 'active',
     });
 
-    const { user } = render(<Recommendations />);
+    const { container } = render(<Recommendations />);
 
-    await screen.findByText('Recommendations for your stack');
-    expect(screen.queryByRole('region', { name: 'Recommended apps' })).not.toBeInTheDocument();
-
-    await user.click(screen.getByRole('button', { name: 'Hide' }));
-
-    // Collapsed with zero recommendations: no pill row either.
-    expect(screen.queryByRole('link', { name: /Enable/ })).not.toBeInTheDocument();
+    await waitFor(() => expect(container).toBeEmptyDOMElement());
   });
 
   it('recommends App Observability for OTel starters, suppressed once span metrics exist', async () => {

--- a/public/app/features/home/Recommendations/Recommendations.test.tsx
+++ b/public/app/features/home/Recommendations/Recommendations.test.tsx
@@ -71,21 +71,26 @@ const mockUsePluginBridge = jest.mocked(usePluginBridge);
 const mockUseSolutionState = jest.mocked(useSolutionState);
 
 function setSolutionState(overrides: Partial<SolutionState>) {
-  mockUseSolutionState.mockReturnValue({
-    value: {
-      state: {
-        metrics: 'inactive',
-        logs: 'inactive',
-        traces: 'inactive',
-        kubernetes: 'inactive',
-        spanMetrics: 'inactive',
-        ...overrides,
-      },
-      lokiDatasource: null,
-      tempoDatasource: null,
-    },
-    loading: false,
-  });
+  // Honor the enabled gate like the real hook: a collapsed region resolves nothing.
+  mockUseSolutionState.mockImplementation((enabled = true) =>
+    enabled
+      ? {
+          value: {
+            state: {
+              metrics: 'inactive',
+              logs: 'inactive',
+              traces: 'inactive',
+              kubernetes: 'inactive',
+              spanMetrics: 'inactive',
+              ...overrides,
+            },
+            lokiDatasource: null,
+            tempoDatasource: null,
+          },
+          loading: false,
+        }
+      : { value: undefined, loading: false }
+  );
 }
 
 beforeEach(() => {
@@ -454,11 +459,32 @@ describe('Recommendations', () => {
     await user.click(await screen.findByRole('button', { name: 'Show' }));
     await waitFor(() => expect(mockResolve).toHaveBeenCalledTimes(1));
 
+    // Let the remounted view settle before toggling; a click mid-remount can hit a detached node.
+    await screen.findByRole('button', { name: 'Next' });
     await user.click(screen.getByRole('button', { name: 'Hide' }));
     await screen.findByRole('button', { name: 'Show' });
     await user.click(screen.getByRole('button', { name: 'Show' }));
     expect(mockResolve).toHaveBeenCalledTimes(1);
     expect(screen.queryByTestId('recommendation-existing-skeleton')).not.toBeInTheDocument();
+  });
+
+  it('resolves no solution state and fetches no plugins while collapsed from a stored preference', async () => {
+    window.localStorage.setItem('grafana.home.recommendations.collapsed', 'true');
+
+    const { user } = render(<Recommendations />);
+
+    // The region renders header-only: no skeleton, no probes, no plugin fetch, no pills.
+    expect(await screen.findByRole('button', { name: 'Show' })).toBeInTheDocument();
+    expect(screen.queryByTestId('recommendations-skeleton')).not.toBeInTheDocument();
+    expect(mockUseSolutionState).toHaveBeenLastCalledWith(false);
+    expect(mockGet).not.toHaveBeenCalled();
+    expect(screen.queryByRole('link', { name: /Enable/ })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Show' }));
+
+    expect(mockUseSolutionState).toHaveBeenCalledWith(true);
+    expect(await screen.findByRole('link', { name: /Enable Hosted Traces/ })).toBeInTheDocument();
+    await waitFor(() => expect(mockGet).toHaveBeenCalled());
   });
 
   it('navigates recommendations with previous/next buttons', async () => {
@@ -599,9 +625,11 @@ describe('Recommendations', () => {
     });
 
     it('tracks enable from a pill when the section is collapsed', async () => {
-      window.localStorage.setItem('grafana.home.recommendations.collapsed', 'true');
-
       const { user } = render(<Recommendations />);
+
+      // Pills only exist for in-session collapses: a stored preference gates the probes off.
+      await screen.findByRole('link', { name: /Enable Hosted Traces/ });
+      await user.click(screen.getByRole('button', { name: 'Hide' }));
 
       await user.click(await screen.findByRole('link', { name: /Enable Hosted Traces/ }));
 

--- a/public/app/features/home/Recommendations/Recommendations.test.tsx
+++ b/public/app/features/home/Recommendations/Recommendations.test.tsx
@@ -281,7 +281,7 @@ describe('Recommendations', () => {
     render(<Recommendations />);
 
     await screen.findByText('Recommendations for your stack');
-    expect(await screen.findByRole('heading', { name: 'No data flowing yet' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: 'Add more telemetry' })).toBeInTheDocument();
     expect(screen.queryByRole('region', { name: 'Recommended apps' })).not.toBeInTheDocument();
   });
 

--- a/public/app/features/home/Recommendations/Recommendations.tsx
+++ b/public/app/features/home/Recommendations/Recommendations.tsx
@@ -1,9 +1,7 @@
-import { useMemo } from 'react';
 import { useAsync } from 'react-use';
 
 import { config } from '@grafana/runtime';
 import { contextSrv } from 'app/core/services/context_srv';
-import { type LocalPlugin } from 'app/features/plugins/admin/types';
 import { AccessControlAction } from 'app/types/accessControl';
 
 import { RecommendationsSkeleton } from './RecommendationsSkeleton';
@@ -39,13 +37,9 @@ function toSetupItem(recommendation: PluginRecommendationCard): RecommendationIt
   return { ...recommendation, action: recommendation.setupAction, href: recommendation.appHref, cta: 'setup' };
 }
 
-function mapPluginsById(plugins: LocalPlugin[] = []) {
-  return new Map(plugins.map((plugin) => [plugin.id, plugin]));
-}
-
 function GatedRecommendations({ canInstall }: GatedRecommendationsProps) {
   const { value: installedPlugins, loading: pluginsLoading } = useAsync(fetchInstalledPlugins, []);
-  const pluginsById = useMemo(() => mapPluginsById(installedPlugins), [installedPlugins]);
+  const pluginsById = new Map((installedPlugins ?? []).map((plugin) => [plugin.id, plugin]));
 
   const { value: resolution, loading: stateLoading } = useSolutionState();
   const selection = resolution ? selectRecommendations(resolution.state) : undefined;

--- a/public/app/features/home/Recommendations/Recommendations.tsx
+++ b/public/app/features/home/Recommendations/Recommendations.tsx
@@ -1,6 +1,8 @@
+import { useRef } from 'react';
 import { useAsync } from 'react-use';
 
 import { config } from '@grafana/runtime';
+import { useStoredBoolean } from 'app/core/hooks/useStoredBoolean';
 import { contextSrv } from 'app/core/services/context_srv';
 import { AccessControlAction } from 'app/types/accessControl';
 
@@ -11,11 +13,12 @@ import { useSolutionState } from './solutionState';
 import { selectRecommendations } from './solutionsMatrix';
 import { type RecommendationItem } from './types';
 
+const HOME_RECOMMENDATIONS_COLLAPSED_LOCAL_STORAGE_KEY = 'grafana.home.recommendations.collapsed';
+
 export function Recommendations() {
   const canInstall = contextSrv.hasPermission(AccessControlAction.PluginsInstall) && config.pluginAdminEnabled;
-  // Unscoped pre-gate only; each card re-checks its own scoped permission. Recommendations are a
-  // plugin + connection surface: plugin management or datasource creation both qualify, and the
-  // pre-gate spares every other viewer the /api/plugins fetch and the solution probes.
+  // Unscoped pre-gate; each card re-checks its scoped permission. Plugin management or
+  // datasource creation qualifies — everyone else is spared the fetches and probes.
   const canWriteSome = contextSrv.hasPermission(AccessControlAction.PluginsWrite);
   const canCreateDataSources = contextSrv.hasPermission(AccessControlAction.DataSourcesCreate);
   if (!canInstall && !canWriteSome && !canCreateDataSources) {
@@ -38,10 +41,22 @@ function toSetupItem(recommendation: PluginRecommendationCard): RecommendationIt
 }
 
 function GatedRecommendations({ canInstall }: GatedRecommendationsProps) {
-  const { value: installedPlugins, loading: pluginsLoading } = useAsync(fetchInstalledPlugins, []);
-  const pluginsById = new Map((installedPlugins ?? []).map((plugin) => [plugin.id, plugin]));
+  const [collapsed, setCollapsed] = useStoredBoolean(HOME_RECOMMENDATIONS_COLLAPSED_LOCAL_STORAGE_KEY, false);
+  // A stored collapsed preference must not fire the probes or the plugin fetch. Monotonic
+  // render-time latch: expanding never commits an ungated frame, re-collapsing never refetches.
+  const everExpanded = useRef(!collapsed);
+  if (!collapsed) {
+    everExpanded.current = true;
+  }
+  const probesEnabled = everExpanded.current;
 
-  const { value: resolution, loading: stateLoading } = useSolutionState();
+  const plugins = useAsync(async () => (probesEnabled ? fetchInstalledPlugins() : undefined), [probesEnabled]);
+  const pluginsById = new Map((plugins.value ?? []).map((plugin) => [plugin.id, plugin]));
+  // Derived from the settled value, not the loading flag: on the probesEnabled flip, useAsync
+  // still reports the gated run's state for one frame, which must read as pending.
+  const pluginsSettled = !!plugins.value || !!plugins.error;
+
+  const { value: resolution } = useSolutionState(probesEnabled);
   const selection = resolution ? selectRecommendations(resolution.state) : undefined;
 
   const cardsById = getRecommendationCards();
@@ -49,7 +64,7 @@ function GatedRecommendations({ canInstall }: GatedRecommendationsProps) {
 
   // An unavailable plugin list fails closed (plugin cards only). /api/plugins always lists at
   // least the core plugins, so an empty response means the list is unreliable and also fails closed.
-  const listReady = !pluginsLoading && !!installedPlugins && installedPlugins.length > 0;
+  const listReady = !!plugins.value && plugins.value.length > 0;
 
   const recommendations = selectedCards.flatMap((card): RecommendationItem[] => {
     if (card.kind === 'connection') {
@@ -75,12 +90,19 @@ function GatedRecommendations({ canInstall }: GatedRecommendationsProps) {
     return contextSrv.hasPermissionInMetadata(AccessControlAction.PluginsWrite, plugin) ? [toEnableItem(card)] : [];
   });
 
-  // The region always renders once state settles; recommendations only decide the right column.
-  // Hold the skeleton while a selected plugin card still waits on the plugin list.
-  const waitingOnPlugins = pluginsLoading && selectedCards.some((card) => card.kind === 'plugin');
-  if (stateLoading || !selection || waitingOnPlugins) {
+  // The region renders once state settles; recommendations only decide the right column.
+  // Collapsed (gated-off) renders immediately as just the header row.
+  const waitingOnPlugins = !pluginsSettled && selectedCards.some((card) => card.kind === 'plugin');
+  if (probesEnabled && (!selection || waitingOnPlugins)) {
     return <RecommendationsSkeleton />;
   }
 
-  return <RecommendationsView recommendations={recommendations} startingState={selection.baseRow} />;
+  return (
+    <RecommendationsView
+      recommendations={recommendations}
+      startingState={selection?.baseRow ?? 'unknown'}
+      collapsed={collapsed}
+      setCollapsed={setCollapsed}
+    />
+  );
 }

--- a/public/app/features/home/Recommendations/Recommendations.tsx
+++ b/public/app/features/home/Recommendations/Recommendations.tsx
@@ -97,6 +97,14 @@ function GatedRecommendations({ canInstall }: GatedRecommendationsProps) {
     return <RecommendationsSkeleton />;
   }
 
+  // All-or-nothing: the region never renders one column alone. An empty right column —
+  // inconclusive detection (the matrix's unknown short-circuit), nothing left to recommend,
+  // or every card failing closed — hides the whole region. The collapsed-gated render
+  // (probesEnabled false) keeps its header row: with probes off, emptiness is unknowable.
+  if (probesEnabled && recommendations.length === 0) {
+    return null;
+  }
+
   return (
     <RecommendationsView
       recommendations={recommendations}

--- a/public/app/features/home/Recommendations/RecommendationsView.tsx
+++ b/public/app/features/home/Recommendations/RecommendationsView.tsx
@@ -4,7 +4,6 @@ import { useEffect, useLayoutEffect, useState } from 'react';
 import { type GrafanaTheme2 } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
 import { Badge, Button, Grid, Icon, Stack, Text, useStyles2 } from '@grafana/ui';
-import { useStoredBoolean } from 'app/core/hooks/useStoredBoolean';
 
 import { RecommendationCard } from './RecommendationCard';
 import { RecommendationExisting } from './RecommendationExisting';
@@ -12,17 +11,22 @@ import { RecommendationPill } from './RecommendationPill';
 import { type BaseRow } from './solutionsMatrix';
 import { type RecommendationItem } from './types';
 
-const HOME_RECOMMENDATIONS_COLLAPSED_LOCAL_STORAGE_KEY = 'grafana.home.recommendations.collapsed';
-
 interface RecommendationsViewProps {
   recommendations: RecommendationItem[];
   /** Matrix row that drove the selection; threaded into cta_clicked as starting_state. */
   startingState: BaseRow;
+  /** Owned by the parent: the stored preference also gates the solution probes there. */
+  collapsed: boolean;
+  setCollapsed: (collapsed: boolean) => void;
 }
 
-export function RecommendationsView({ recommendations, startingState }: RecommendationsViewProps) {
+export function RecommendationsView({
+  recommendations,
+  startingState,
+  collapsed,
+  setCollapsed,
+}: RecommendationsViewProps) {
   const styles = useStyles2(getStyles);
-  const [collapsed, setCollapsed] = useStoredBoolean(HOME_RECOMMENDATIONS_COLLAPSED_LOCAL_STORAGE_KEY, false);
 
   // Lazy-mount: a persisted collapsed preference must not fire the Kubernetes queries.
   // Once expanded, stay mounted so collapse/expand never refetches (hidden preserves state).

--- a/public/app/features/home/Recommendations/buildTelemetryItems.ts
+++ b/public/app/features/home/Recommendations/buildTelemetryItems.ts
@@ -31,10 +31,12 @@ export function buildLogsItem(parts: LogsItemParts): ExistingItem {
             primary: formattedValueToString(getValueFormat('decbytes')(bytes)),
             secondary:
               sources != null
-                ? t('home.recommendations.logs.stats-sources', '', {
+                ? // '~': Loki label-values may scan a wider window than requested, so the count can
+                  // include stale sources.
+                  t('home.recommendations.logs.stats-sources', '', {
                     count: sources,
-                    defaultValue_one: 'ingested · 7d · {{count}} source',
-                    defaultValue_other: 'ingested · 7d · {{count}} sources',
+                    defaultValue_one: 'ingested · 7d · ~{{count}} source',
+                    defaultValue_other: 'ingested · 7d · ~{{count}} sources',
                   })
                 : t('home.recommendations.logs.stats', 'ingested · 7d'),
           }

--- a/public/app/features/home/Recommendations/buildTelemetryItems.ts
+++ b/public/app/features/home/Recommendations/buildTelemetryItems.ts
@@ -2,25 +2,23 @@ import { type FieldSparkline, formattedValueToString, getValueFormat, locationUt
 import { t } from '@grafana/i18n';
 
 import { HOSTED_TRACES_APP_ID, LOGS_DRILLDOWN_APP_ID } from './appPluginIds';
-import { type LogsStats } from './telemetryData';
 import { type ExistingItem } from './types';
 
 // Browser locale is the deliberate choice: the homepage number format follows the user's environment.
 const compactFormatter = new Intl.NumberFormat(undefined, { notation: 'compact', maximumFractionDigits: 1 });
 
 export interface LogsItemParts {
-  stats: LogsStats | undefined;
-  statsLoading: boolean;
+  bytes: number | null | undefined;
+  sources: number | null | undefined;
+  activityLoading: boolean;
   volumeSeries: FieldSparkline | null | undefined;
-  volumeLoading: boolean;
   datasourceName: string;
   drilldownAvailable: boolean;
 }
 
 /** Build the Hosted Logs entry from live Loki data. */
 export function buildLogsItem(parts: LogsItemParts): ExistingItem {
-  const bytes = parts.stats?.bytes;
-  const sources = parts.stats?.sources;
+  const { bytes, sources } = parts;
   return {
     id: 'logs',
     title: t('home.recommendations.logs.title', 'Hosted Logs'),
@@ -40,14 +38,14 @@ export function buildLogsItem(parts: LogsItemParts): ExistingItem {
                 : t('home.recommendations.logs.stats', 'ingested · 7d'),
           }
         : undefined,
-    statsLoading: parts.statsLoading,
+    statsLoading: parts.activityLoading,
     sparkline: parts.volumeSeries
       ? {
           series: parts.volumeSeries,
           caption: t('home.recommendations.logs.volume', 'Ingest volume · last 24h'),
         }
       : undefined,
-    sparklineLoading: parts.volumeLoading,
+    sparklineLoading: parts.activityLoading,
     action: t('home.recommendations.logs.action', 'Open Explore (Logs)'),
     href: locationUtil.assureBaseUrl(parts.drilldownAvailable ? `/a/${LOGS_DRILLDOWN_APP_ID}` : '/explore'),
   };

--- a/public/app/features/home/Recommendations/buildTelemetryItems.ts
+++ b/public/app/features/home/Recommendations/buildTelemetryItems.ts
@@ -8,15 +8,14 @@ import { type ExistingItem } from './types';
 const compactFormatter = new Intl.NumberFormat(undefined, { notation: 'compact', maximumFractionDigits: 1 });
 
 export interface LogsItemParts {
-  bytes: number | null | undefined;
-  sources: number | null | undefined;
-  activityLoading: boolean;
-  volumeSeries: FieldSparkline | null | undefined;
+  bytes: number | null;
+  sources: number | null;
+  volumeSeries: FieldSparkline | null;
   datasourceName: string;
   drilldownAvailable: boolean;
 }
 
-/** Build the Hosted Logs entry from live Loki data. */
+/** Build the Hosted Logs entry from live Loki data; the caller guarantees something to show. */
 export function buildLogsItem(parts: LogsItemParts): ExistingItem {
   const { bytes, sources } = parts;
   return {
@@ -38,29 +37,26 @@ export function buildLogsItem(parts: LogsItemParts): ExistingItem {
                 : t('home.recommendations.logs.stats', 'ingested · 7d'),
           }
         : undefined,
-    statsLoading: parts.activityLoading,
     sparkline: parts.volumeSeries
       ? {
           series: parts.volumeSeries,
           caption: t('home.recommendations.logs.volume', 'Ingest volume · last 24h'),
         }
       : undefined,
-    sparklineLoading: parts.activityLoading,
     action: t('home.recommendations.logs.action', 'Open Explore (Logs)'),
     href: locationUtil.assureBaseUrl(parts.drilldownAvailable ? `/a/${LOGS_DRILLDOWN_APP_ID}` : '/explore'),
   };
 }
 
 export interface TracesItemParts {
-  spans: number | null | undefined;
-  services: number | null | undefined;
-  activityLoading: boolean;
-  throughputSeries: FieldSparkline | null | undefined;
+  spans: number | null;
+  services: number | null;
+  throughputSeries: FieldSparkline | null;
   datasourceName: string;
   drilldownAvailable: boolean;
 }
 
-/** Build the Hosted Traces entry from live Tempo data. */
+/** Build the Hosted Traces entry from live Tempo data; the caller guarantees something to show. */
 export function buildTracesItem(parts: TracesItemParts): ExistingItem {
   const { spans, services } = parts;
   return {
@@ -87,14 +83,12 @@ export function buildTracesItem(parts: TracesItemParts): ExistingItem {
                 : t('home.recommendations.traces.stats', 'traced · 24h'),
           }
         : undefined,
-    statsLoading: parts.activityLoading,
     sparkline: parts.throughputSeries
       ? {
           series: parts.throughputSeries,
           caption: t('home.recommendations.traces.throughput', 'Span throughput · last 24h'),
         }
       : undefined,
-    sparklineLoading: parts.activityLoading,
     action: t('home.recommendations.traces.action', 'Open Traces Drilldown'),
     href: locationUtil.assureBaseUrl(parts.drilldownAvailable ? `/a/${HOSTED_TRACES_APP_ID}` : '/explore'),
   };

--- a/public/app/features/home/Recommendations/buildTelemetryItems.ts
+++ b/public/app/features/home/Recommendations/buildTelemetryItems.ts
@@ -1,5 +1,6 @@
 import { type FieldSparkline, formattedValueToString, getValueFormat, locationUtil } from '@grafana/data';
 import { t } from '@grafana/i18n';
+import { constructDataSourceExploreUrl } from 'app/features/datasources/utils';
 
 import { HOSTED_TRACES_APP_ID, LOGS_DRILLDOWN_APP_ID } from './appPluginIds';
 import { type ExistingItem } from './types';
@@ -18,6 +19,7 @@ export interface LogsItemParts {
 /** Build the Hosted Logs entry from live Loki data; the caller guarantees something to show. */
 export function buildLogsItem(parts: LogsItemParts): ExistingItem {
   const { bytes, sources } = parts;
+  const drilldown = parts.drilldownAvailable;
   return {
     id: 'logs',
     title: t('home.recommendations.logs.title', 'Hosted Logs'),
@@ -43,8 +45,12 @@ export function buildLogsItem(parts: LogsItemParts): ExistingItem {
           caption: t('home.recommendations.logs.volume', 'Ingest volume · last 24h'),
         }
       : undefined,
-    action: t('home.recommendations.logs.action', 'Open Explore (Logs)'),
-    href: locationUtil.assureBaseUrl(parts.drilldownAvailable ? `/a/${LOGS_DRILLDOWN_APP_ID}` : '/explore'),
+    action: drilldown
+      ? t('home.recommendations.logs.action', 'Open Explore (Logs)')
+      : t('home.recommendations.logs.action-explore', 'Open in Explore'),
+    href: drilldown
+      ? locationUtil.assureBaseUrl(`/a/${LOGS_DRILLDOWN_APP_ID}`)
+      : constructDataSourceExploreUrl({ name: parts.datasourceName }),
   };
 }
 
@@ -59,6 +65,7 @@ export interface TracesItemParts {
 /** Build the Hosted Traces entry from live Tempo data; the caller guarantees something to show. */
 export function buildTracesItem(parts: TracesItemParts): ExistingItem {
   const { spans, services } = parts;
+  const drilldown = parts.drilldownAvailable;
   return {
     id: 'traces',
     title: t('home.recommendations.traces.title', 'Hosted Traces'),
@@ -89,7 +96,11 @@ export function buildTracesItem(parts: TracesItemParts): ExistingItem {
           caption: t('home.recommendations.traces.throughput', 'Span throughput · last 24h'),
         }
       : undefined,
-    action: t('home.recommendations.traces.action', 'Open Traces Drilldown'),
-    href: locationUtil.assureBaseUrl(parts.drilldownAvailable ? `/a/${HOSTED_TRACES_APP_ID}` : '/explore'),
+    action: drilldown
+      ? t('home.recommendations.traces.action', 'Open Traces Drilldown')
+      : t('home.recommendations.traces.action-explore', 'Open in Explore'),
+    href: drilldown
+      ? locationUtil.assureBaseUrl(`/a/${HOSTED_TRACES_APP_ID}`)
+      : constructDataSourceExploreUrl({ name: parts.datasourceName }),
   };
 }

--- a/public/app/features/home/Recommendations/kubernetesData.test.ts
+++ b/public/app/features/home/Recommendations/kubernetesData.test.ts
@@ -458,7 +458,7 @@ describe('Kubernetes Prometheus resolution', () => {
     }
   });
 
-  it('retries an errored probe so a transient failure keeps the default', async () => {
+  it('an errored leader probe falls through to the fan-out without retrying', async () => {
     setDataSources([
       { uid: 'default-uid', name: 'default-prom', isDefault: true },
       { uid: 'team-uid', name: 'team-prom' },
@@ -466,19 +466,13 @@ describe('Kubernetes Prometheus resolution', () => {
     dataByUid = { 'default-uid': 5, 'team-uid': 1 };
     probeFailuresByUid = { 'default-uid': 1 };
 
-    jest.useFakeTimers();
-    try {
-      const inventoryPromise = fetchKubernetesInventory();
-      const healthPromise = fetchKubernetesHealth();
-      await jest.advanceTimersByTimeAsync(10_000);
-      const inventory = await inventoryPromise;
-      await healthPromise;
+    const inventory = await fetchKubernetesInventory();
+    await fetchKubernetesHealth();
 
-      expect(inventoryCalls()[0][0].datasource.uid).toBe('default-uid');
-      expect(inventory.clusters).toBe(5);
-    } finally {
-      jest.useRealTimers();
-    }
+    expect(inventoryCalls()[0][0].datasource.uid).toBe('team-uid');
+    expect(inventory.clusters).toBe(1);
+    // Exactly one attempt per candidate: the probe never retries.
+    expect(probeAttempts).toEqual({ 'default-uid': 1, 'team-uid': 1 });
   });
 
   it('rejects when every probe errors', async () => {
@@ -489,17 +483,8 @@ describe('Kubernetes Prometheus resolution', () => {
     dataByUid = { 'a-uid': 3, 'b-uid': 3 };
     probeErrorUids = new Set(['a-uid', 'b-uid']);
 
-    jest.useFakeTimers();
-    try {
-      const assertion = expect(fetchKubernetesInventory()).rejects.toThrow(
-        'No Prometheus datasource with Kubernetes data'
-      );
-      await jest.advanceTimersByTimeAsync(10_000);
-      await assertion;
-      expect(inventoryCalls()).toHaveLength(0);
-    } finally {
-      jest.useRealTimers();
-    }
+    await expect(fetchKubernetesInventory()).rejects.toThrow(/prometheus datasource probe\(s\) failed/);
+    expect(inventoryCalls()).toHaveLength(0);
   });
 
   it('probes only the leader when the top-priority datasource has data', async () => {
@@ -616,29 +601,6 @@ describe('Kubernetes Prometheus resolution', () => {
 
       expect(inventory.clusters).toBe(2);
       expect(inventoryCalls()).toHaveLength(3);
-    } finally {
-      jest.useRealTimers();
-    }
-  });
-
-  it('keeps the default when its probe fails twice then succeeds', async () => {
-    setDataSources([
-      { uid: 'default-uid', name: 'default-prom', isDefault: true },
-      { uid: 'team-uid', name: 'team-prom' },
-    ]);
-    dataByUid = { 'default-uid': 5, 'team-uid': 1 };
-    probeFailuresByUid = { 'default-uid': 2 };
-
-    jest.useFakeTimers();
-    try {
-      const inventoryPromise = fetchKubernetesInventory();
-      await jest.advanceTimersByTimeAsync(10_000);
-      const inventory = await inventoryPromise;
-
-      expect(inventoryCalls()[0][0].datasource.uid).toBe('default-uid');
-      expect(inventory.clusters).toBe(5);
-      expect(probeAttempts['default-uid']).toBe(3);
-      expect(probeCalls().map(([o]) => o.datasource.uid)).not.toContain('team-uid');
     } finally {
       jest.useRealTimers();
     }

--- a/public/app/features/home/Recommendations/kubernetesData.ts
+++ b/public/app/features/home/Recommendations/kubernetesData.ts
@@ -8,7 +8,7 @@ import { config } from '@grafana/runtime';
 
 import {
   createTtlCachedPromise,
-  findDatasourceWithData,
+  findDatasourceWithDataStrict,
   listProbeCandidates,
   MAX_PROBED_DATASOURCES,
   PROBE_TIMEOUT_MS,
@@ -85,21 +85,18 @@ async function orderedCandidates(): Promise<DataSourceInstanceListItem[]> {
   return storedMatch ? [storedMatch, ...ordered.filter((ds) => ds !== storedMatch)] : ordered;
 }
 
-// "Has Kubernetes data" = namespaces detected; an errored probe retries with backoff, then counts
-// as no data — an unusable datasource must not win the probe.
+// Single attempt so the solution-state signal budget outlasts leader + fan-out; errors
+// propagate so an all-errored scan reads inconclusive, not "no data".
 async function hasKubernetesNamespaces(ds: Pick<DataSourceInstanceSettings, 'uid' | 'type'>): Promise<boolean> {
-  try {
-    const frames = await withRetry(() => runInstantQueries({ namespaces: NAMESPACE_PROBE }, ds, PROBE_TIMEOUT_MS));
-    return (readScalar(frames, 'namespaces') ?? 0) > 0;
-  } catch {
-    return false;
-  }
+  const frames = await runInstantQueries({ namespaces: NAMESPACE_PROBE }, ds, PROBE_TIMEOUT_MS);
+  return (readScalar(frames, 'namespaces') ?? 0) > 0;
 }
 
-// Leader-first probe over the ordered candidates; see findDatasourceWithData for the fan-out rules.
+// Leader-first strict scan over the ordered candidates; rejects when nothing was found and any
+// probe errored, so an inconclusive scan never settles as "no data".
 async function resolveKubernetesPrometheus(): Promise<DataSourceInstanceListItem | null> {
   const candidates = (await orderedCandidates()).slice(0, MAX_PROBED_DATASOURCES);
-  return findDatasourceWithData(candidates, hasKubernetesNamespaces);
+  return findDatasourceWithDataStrict(candidates, hasKubernetesNamespaces, 'prometheus');
 }
 
 const kubernetesPrometheusResolution = createTtlCachedPromise(resolveKubernetesPrometheus, PROBE_TTL_MS);

--- a/public/app/features/home/Recommendations/probeUtils.ts
+++ b/public/app/features/home/Recommendations/probeUtils.ts
@@ -153,3 +153,33 @@ export async function findDatasourceWithData(
   }
   return null;
 }
+
+/**
+ * findDatasourceWithData with error accounting: null only when every candidate probed
+ * clean-and-empty; throws when nothing was found and any candidate errored (an errored
+ * datasource may hold the data). Unlike findDatasourceWithData, hasData may throw.
+ */
+export async function findDatasourceWithDataStrict(
+  candidates: DataSourceInstanceListItem[],
+  hasData: (ds: DataSourceInstanceListItem) => Promise<boolean>,
+  type: string
+): Promise<DataSourceInstanceListItem | null> {
+  let errored = 0;
+  // findDatasourceWithData requires a non-throwing callback; count failures for the unknown check.
+  const guardedHasData = async (ds: DataSourceInstanceListItem) => {
+    try {
+      return await hasData(ds);
+    } catch {
+      errored++;
+      return false;
+    }
+  };
+  const found = await findDatasourceWithData(candidates, guardedHasData);
+  if (found) {
+    return found;
+  }
+  if (errored > 0) {
+    throw new Error(`${errored} ${type} datasource probe(s) failed with no data found elsewhere`);
+  }
+  return null;
+}

--- a/public/app/features/home/Recommendations/probeUtils.ts
+++ b/public/app/features/home/Recommendations/probeUtils.ts
@@ -32,15 +32,20 @@ export async function resolveBackendInstance(uid: string): Promise<DataSourceWit
 }
 
 /**
- * GET through the classic datasource proxy with the probe retry/timeout policy. Expected to
- * fail on stacks without the endpoint; never toasts. Some datasource backends (e.g. Tempo)
- * serve their HTTP API only here, not on the resource router.
+ * GET through the classic datasource proxy, timeout-bounded, never toasts. Some datasource
+ * backends (e.g. Tempo) serve their HTTP API only here, not on the resource router.
+ * `retry: false` keeps a probe inside its caller's deadline.
  */
-export async function probeProxyGet<T>(uid: string, path: string, params: Record<string, unknown>): Promise<T> {
+export async function probeProxyGet<T>(
+  uid: string,
+  path: string,
+  params: Record<string, unknown>,
+  { retry = true } = {}
+): Promise<T> {
   const url = `/api/datasources/proxy/uid/${encodeURIComponent(uid)}/${path}`;
-  return withRetry(() =>
-    withTimeout(getBackendSrv().get<T>(url, params, undefined, { showErrorAlert: false }), PROBE_TIMEOUT_MS)
-  );
+  const call = () =>
+    withTimeout(getBackendSrv().get<T>(url, params, undefined, { showErrorAlert: false }), PROBE_TIMEOUT_MS);
+  return retry ? withRetry(call) : call();
 }
 
 export async function withRetry<T>(fn: () => Promise<T>): Promise<T> {

--- a/public/app/features/home/Recommendations/probeUtils.ts
+++ b/public/app/features/home/Recommendations/probeUtils.ts
@@ -134,7 +134,7 @@ export async function listProbeCandidates(
  * Only when the leader has no data (or errors) fan out to the rest in parallel. `hasData` must
  * not throw — an unusable datasource counts as no data.
  */
-export async function findDatasourceWithData(
+async function findDatasourceWithData(
   candidates: DataSourceInstanceListItem[],
   hasData: (ds: DataSourceInstanceListItem) => Promise<boolean>
 ): Promise<DataSourceInstanceListItem | null> {

--- a/public/app/features/home/Recommendations/solutionDataProbes.ts
+++ b/public/app/features/home/Recommendations/solutionDataProbes.ts
@@ -41,14 +41,19 @@ interface TempoSearchResponse {
 }
 
 /**
- * One matching trace in the lookback proves data exists. Probes Tempo's search HTTP API through
- * the datasource proxy: the frontend query path reads streamed search responses as non-empty
- * frames on empty stores (observed live with traceQLStreaming), and the resource router 404s
- * Tempo API paths on cloud stacks.
+ * One matching trace in the lookback proves data exists. Uses Tempo's search HTTP API via the
+ * datasource proxy: the frontend query path misreads streamed empty results as data (observed
+ * live with traceQLStreaming) and the resource router 404s Tempo paths on cloud stacks.
  */
 export async function tempoHasTraces(ds: Pick<DataSourceInstanceListItem, 'uid'>): Promise<boolean> {
   const end = Math.floor(Date.now() / 1000);
   const start = end - DATA_LOOKBACK_HOURS * 3600;
-  const res = await probeProxyGet<TempoSearchResponse>(ds.uid, 'api/search', { q: '{}', limit: 1, start, end });
+  // Single attempt so the traces signal budget outlasts the whole probe (see solutionState).
+  const res = await probeProxyGet<TempoSearchResponse>(
+    ds.uid,
+    'api/search',
+    { q: '{}', limit: 1, start, end },
+    { retry: false }
+  );
   return Array.isArray(res?.traces) && res.traces.length > 0;
 }

--- a/public/app/features/home/Recommendations/solutionDataProbes.ts
+++ b/public/app/features/home/Recommendations/solutionDataProbes.ts
@@ -1,6 +1,6 @@
 import { type DataSourceInstanceListItem } from '@grafana/data';
 
-import { findDatasourceWithData, listProbeCandidates, probeProxyGet } from './probeUtils';
+import { findDatasourceWithDataStrict, listProbeCandidates, probeProxyGet } from './probeUtils';
 
 // "Seen recently" lookback shared by all data probes, tolerating scrape/ingest gaps.
 export const DATA_LOOKBACK_HOURS = 24;
@@ -16,24 +16,7 @@ export async function probeFound(
   excludeUids?: ReadonlySet<string>
 ): Promise<DataSourceInstanceListItem | null> {
   const candidates = await listProbeCandidates(type, undefined, excludeUids);
-  let errored = 0;
-  // findDatasourceWithData requires a non-throwing callback; count failures for the unknown check.
-  const guardedHasData = async (ds: DataSourceInstanceListItem) => {
-    try {
-      return await hasData(ds);
-    } catch {
-      errored++;
-      return false;
-    }
-  };
-  const found = await findDatasourceWithData(candidates, guardedHasData);
-  if (found) {
-    return found;
-  }
-  if (errored > 0) {
-    throw new Error(`${errored} ${type} datasource probe(s) failed with no data found elsewhere`);
-  }
-  return null;
+  return findDatasourceWithDataStrict(candidates, hasData, type);
 }
 
 interface TempoSearchResponse {

--- a/public/app/features/home/Recommendations/solutionState.test.ts
+++ b/public/app/features/home/Recommendations/solutionState.test.ts
@@ -222,6 +222,17 @@ describe('resolveSolutionState', () => {
     expect(resolution.state.metrics).toBe('inactive');
   });
 
+  it('maps a rejecting kubernetes resolution to unknown without forcing metrics', async () => {
+    freshCloudFixture();
+    kubernetesMock.mockRejectedValue(new Error('all probes failed'));
+
+    const resolution = await resolveWithTimers();
+
+    expect(resolution.state.kubernetes).toBe('unknown');
+    // The k8s ⇒ metrics invariant must not fire on unknown.
+    expect(resolution.state.metrics).toBe('inactive');
+  });
+
   it('settles a hung probe to unknown within the signal budget, preserving siblings', async () => {
     const { lokiResource } = freshCloudFixture();
     lokiResource.mockImplementation(() => new Promise(() => {}));

--- a/public/app/features/home/Recommendations/solutionState.test.ts
+++ b/public/app/features/home/Recommendations/solutionState.test.ts
@@ -322,14 +322,17 @@ describe('resolveSolutionState', () => {
     await resolveSolutionState();
 
     const nowMs = Date.now();
-    expect(promResource).toHaveBeenCalledWith('api/v1/labels', {
-      start: Math.floor(nowMs / 1000) - DATA_LOOKBACK_HOURS * 3600,
-      end: Math.floor(nowMs / 1000),
-    });
-    expect(lokiResource).toHaveBeenCalledWith('labels', {
-      start: nowMs * 1e6 - DATA_LOOKBACK_HOURS * 3600 * 1e9,
-      end: nowMs * 1e6,
-    });
+    const silent = { showErrorAlert: false };
+    expect(promResource).toHaveBeenCalledWith(
+      'api/v1/labels',
+      { start: Math.floor(nowMs / 1000) - DATA_LOOKBACK_HOURS * 3600, end: Math.floor(nowMs / 1000) },
+      silent
+    );
+    expect(lokiResource).toHaveBeenCalledWith(
+      'labels',
+      { start: nowMs * 1e6 - DATA_LOOKBACK_HOURS * 3600 * 1e9, end: nowMs * 1e6 },
+      silent
+    );
   });
 
   it('fans out once for concurrent callers and re-resolves after a reset', async () => {

--- a/public/app/features/home/Recommendations/solutionState.test.ts
+++ b/public/app/features/home/Recommendations/solutionState.test.ts
@@ -5,12 +5,7 @@ import { getDataSourceInstance, getDataSourceInstanceList } from '@grafana/runti
 import { resolveKubernetesDatasource } from './kubernetesData';
 import { runInstantQueries } from './promQuery';
 import { tempoHasTraces } from './solutionDataProbes';
-import {
-  CLOUD_UTILITY_LOKI_DATASOURCE_UIDS,
-  CLOUD_UTILITY_PROM_DATASOURCE_UIDS,
-  resetSolutionStateResolution,
-  resolveSolutionState,
-} from './solutionState';
+import { resetSolutionStateResolution, resolveSolutionState } from './solutionState';
 
 jest.mock('@grafana/runtime/unstable', () => ({
   ...jest.requireActual('@grafana/runtime/unstable'),
@@ -347,15 +342,5 @@ describe('resolveSolutionState', () => {
     resetSolutionStateResolution();
     await resolveSolutionState();
     expect(listMock).toHaveBeenCalledTimes(8);
-  });
-});
-
-describe('cloud utility uid sets', () => {
-  it('pin the platform telemetry datasources', () => {
-    expect([...CLOUD_UTILITY_PROM_DATASOURCE_UIDS]).toEqual(['grafanacloud-usage', 'grafanacloud-ml-metrics']);
-    expect([...CLOUD_UTILITY_LOKI_DATASOURCE_UIDS]).toEqual([
-      'grafanacloud-usage-insights',
-      'grafanacloud-alert-state-history',
-    ]);
   });
 });

--- a/public/app/features/home/Recommendations/solutionState.ts
+++ b/public/app/features/home/Recommendations/solutionState.ts
@@ -139,6 +139,7 @@ export function resetSolutionStateResolution(): void {
   solutionStateResolution.reset();
 }
 
-export function useSolutionState(): { value?: SolutionStateResolution; loading: boolean } {
-  return useAsync(resolveSolutionState, []);
+/** Gate inside the callback (Rules of Hooks): a disabled caller never triggers the probes. */
+export function useSolutionState(enabled = true): { value?: SolutionStateResolution; loading: boolean } {
+  return useAsync(async () => (enabled ? resolveSolutionState() : undefined), [enabled]);
 }

--- a/public/app/features/home/Recommendations/solutionState.ts
+++ b/public/app/features/home/Recommendations/solutionState.ts
@@ -8,19 +8,16 @@ import {
   PROBE_TIMEOUT_MS,
   PROBE_TTL_MS,
   resolveBackendInstance,
-  withRetry,
   withTimeout,
 } from './probeUtils';
 import { readScalar, runInstantQueries } from './promQuery';
 import { DATA_LOOKBACK_HOURS, probeFound, tempoHasTraces } from './solutionDataProbes';
 import { type SignalStatus, type SolutionState } from './solutionsMatrix';
 
-// Span metrics prove Application Observability is in use: the spanmetrics connector emits
-// traces_spanmetrics_*, OTel/Alloy emits traces_span_metrics_*.
+// Span metrics prove App O11y is in use; both emitter namings (spanmetrics connector, OTel/Alloy).
 const SPAN_METRICS_PROBE = `count(last_over_time(traces_spanmetrics_calls_total[${DATA_LOOKBACK_HOURS}h])) or count(last_over_time(traces_span_metrics_calls_total[${DATA_LOOKBACK_HOURS}h]))`;
 
-// Cloud utility datasources hold platform telemetry, never the org's product data: excluded
-// from the activity probes unconditionally.
+// Platform telemetry, never the org's product data: excluded unconditionally.
 const CLOUD_UTILITY_PROM_DATASOURCE_UIDS: ReadonlySet<string> = new Set([
   'grafanacloud-usage',
   'grafanacloud-ml-metrics',
@@ -30,7 +27,8 @@ const CLOUD_UTILITY_LOKI_DATASOURCE_UIDS: ReadonlySet<string> = new Set([
   'grafanacloud-alert-state-history',
 ]);
 
-// Hard ceiling per signal; the homepage never waits longer than this on one signal.
+// Hard ceiling per signal. Candidates are single-attempt (leader + fan-out ≤ 2x10s), so no
+// request outlives an unknown; transient failures self-heal on the next TTL cycle.
 const SIGNAL_BUDGET_MS = 30_000;
 
 export interface SolutionStateResolution {
@@ -56,8 +54,8 @@ async function resolveSignal(probe: () => Promise<DataSourceInstanceListItem | n
   }
 }
 
-// Recent-activity checks ride each datasource's label metadata endpoint: cheap, index-only,
-// and an empty label set within the lookback is a definitive "no data".
+// Label metadata is a cheap, index-only recency check; empty within the lookback is definitive
+// "no data". Failures are expected (dead datasources, 403s) — never toast.
 async function prometheusHasRecentLabels(ds: DataSourceInstanceListItem): Promise<boolean> {
   const instance = await resolveBackendInstance(ds.uid);
   if (!instance) {
@@ -65,8 +63,9 @@ async function prometheusHasRecentLabels(ds: DataSourceInstanceListItem): Promis
   }
   const end = Math.floor(Date.now() / 1000);
   const start = end - DATA_LOOKBACK_HOURS * 3600;
-  const res = await withRetry(() =>
-    withTimeout(instance.getResource<{ data?: unknown }>('api/v1/labels', { start, end }), PROBE_TIMEOUT_MS)
+  const res = await withTimeout(
+    instance.getResource<{ data?: unknown }>('api/v1/labels', { start, end }, { showErrorAlert: false }),
+    PROBE_TIMEOUT_MS
   );
   return Array.isArray(res?.data) && res.data.length > 0;
 }
@@ -79,19 +78,19 @@ async function lokiHasRecentLabels(ds: DataSourceInstanceListItem): Promise<bool
   // Loki takes nanoseconds; ms * 1e6 mirrors LokiDatasource.getTimeRangeParams (precision loss accepted).
   const end = Date.now() * 1e6;
   const start = end - DATA_LOOKBACK_HOURS * 3600 * 1e9;
-  const res = await withRetry(() =>
-    withTimeout(instance.getResource<{ data?: unknown }>('labels', { start, end }), PROBE_TIMEOUT_MS)
+  const res = await withTimeout(
+    instance.getResource<{ data?: unknown }>('labels', { start, end }, { showErrorAlert: false }),
+    PROBE_TIMEOUT_MS
   );
   // Loki responds data: null when empty.
   return Array.isArray(res?.data) && res.data.length > 0;
 }
 
-// A broken candidate counts as no span metrics (unlike the core-signal probes): one dead
-// datasource must not hide the App Observability card behind an unknown — matches the
-// kubernetes probe's failure direction.
+// A broken candidate counts as no span metrics: one dead datasource must not hide the App O11y
+// card behind an unknown (the kubernetes probe's failure direction; core signals stay strict).
 async function prometheusHasSpanMetrics(ds: DataSourceInstanceListItem): Promise<boolean> {
   try {
-    const frames = await withRetry(() => runInstantQueries({ probe: SPAN_METRICS_PROBE }, ds, PROBE_TIMEOUT_MS));
+    const frames = await runInstantQueries({ probe: SPAN_METRICS_PROBE }, ds, PROBE_TIMEOUT_MS);
     return (readScalar(frames, 'probe') ?? 0) > 0;
   } catch {
     return false;

--- a/public/app/features/home/Recommendations/solutionState.ts
+++ b/public/app/features/home/Recommendations/solutionState.ts
@@ -21,11 +21,11 @@ const SPAN_METRICS_PROBE = `count(last_over_time(traces_spanmetrics_calls_total[
 
 // Cloud utility datasources hold platform telemetry, never the org's product data: excluded
 // from the activity probes unconditionally.
-export const CLOUD_UTILITY_PROM_DATASOURCE_UIDS: ReadonlySet<string> = new Set([
+const CLOUD_UTILITY_PROM_DATASOURCE_UIDS: ReadonlySet<string> = new Set([
   'grafanacloud-usage',
   'grafanacloud-ml-metrics',
 ]);
-export const CLOUD_UTILITY_LOKI_DATASOURCE_UIDS: ReadonlySet<string> = new Set([
+const CLOUD_UTILITY_LOKI_DATASOURCE_UIDS: ReadonlySet<string> = new Set([
   'grafanacloud-usage-insights',
   'grafanacloud-alert-state-history',
 ]);
@@ -139,7 +139,6 @@ export function resetSolutionStateResolution(): void {
   solutionStateResolution.reset();
 }
 
-export function useSolutionState(): { value: SolutionStateResolution | undefined; loading: boolean } {
-  const { value, loading } = useAsync(resolveSolutionState, []);
-  return { value, loading };
+export function useSolutionState(): { value?: SolutionStateResolution; loading: boolean } {
+  return useAsync(resolveSolutionState, []);
 }

--- a/public/app/features/home/Recommendations/telemetryData.test.ts
+++ b/public/app/features/home/Recommendations/telemetryData.test.ts
@@ -93,20 +93,26 @@ describe('fetchLogsActivity', () => {
 
     const end = Date.now() * NS_IN_MS;
     const statsStart = end - LOGS_STATS_LOOKBACK_DAYS * 24 * 3600 * 1e9;
-    expect(getResource).toHaveBeenCalledWith('labels', { start: statsStart, end });
-    expect(getResource).toHaveBeenCalledWith('index/volume', {
-      query: '{service_name=~".+"}',
-      start: statsStart,
-      end,
-      limit: 1000,
-    });
-    expect(getResource).toHaveBeenCalledWith('label/service_name/values', { start: statsStart, end });
-    expect(getResource).toHaveBeenCalledWith('index/volume_range', {
-      query: '{service_name=~".+"}',
-      start: end - DATA_LOOKBACK_HOURS * 3600 * 1e9,
-      end,
-      step: '30m',
-    });
+    const silent = { showErrorAlert: false };
+    expect(getResource).toHaveBeenCalledWith('labels', { start: statsStart, end }, silent);
+    expect(getResource).toHaveBeenCalledWith(
+      'index/volume',
+      { query: '{service_name=~".+"}', start: statsStart, end, aggregateBy: 'labels', targetLabels: 'service_name' },
+      silent
+    );
+    expect(getResource).toHaveBeenCalledWith('label/service_name/values', { start: statsStart, end }, silent);
+    expect(getResource).toHaveBeenCalledWith(
+      'index/volume_range',
+      {
+        query: '{service_name=~".+"}',
+        start: end - DATA_LOOKBACK_HOURS * 3600 * 1e9,
+        end,
+        step: '30m',
+        aggregateBy: 'labels',
+        targetLabels: 'service_name',
+      },
+      silent
+    );
   });
 
   it('falls back to job when service_name is absent', async () => {
@@ -125,7 +131,7 @@ describe('fetchLogsActivity', () => {
     mockResolveBackendInstance.mockResolvedValue(instanceWith(getResource));
 
     await expect(fetchLogsActivity(loki)).resolves.toEqual({ bytes: 0, sources: 1, series: null });
-    expect(getResource).toHaveBeenCalledWith('label/job/values', expect.anything());
+    expect(getResource).toHaveBeenCalledWith('label/job/values', expect.anything(), expect.anything());
   });
 
   it('keeps the other fields when one endpoint is unavailable', async () => {

--- a/public/app/features/home/Recommendations/telemetryData.test.ts
+++ b/public/app/features/home/Recommendations/telemetryData.test.ts
@@ -2,13 +2,7 @@ import { type DataSourceInstanceListItem } from '@grafana/data';
 import { type BackendSrv, type DataSourceWithBackend, getBackendSrv } from '@grafana/runtime';
 
 import { resolveBackendInstance } from './probeUtils';
-import {
-  fetchLogsStats,
-  fetchLogsVolumeSeries,
-  fetchTracesActivity,
-  fetchTracesServices,
-  LOGS_STATS_LOOKBACK_DAYS,
-} from './telemetryData';
+import { fetchLogsActivity, fetchTracesActivity, fetchTracesServices, LOGS_STATS_LOOKBACK_DAYS } from './telemetryData';
 
 jest.mock('./probeUtils', () => ({
   ...jest.requireActual('./probeUtils'),
@@ -45,8 +39,8 @@ afterEach(() => {
   jest.useRealTimers();
 });
 
-describe('fetchLogsStats', () => {
-  it('sums index volume and counts sources over the stats window in nanoseconds', async () => {
+describe('fetchLogsActivity', () => {
+  it('sums index volume, counts sources, and builds the ingest series over the right windows', async () => {
     const getResource = jest.fn(async (path: string) => {
       if (path === 'labels') {
         return { data: ['filename', 'job', 'service_name'] };
@@ -61,6 +55,28 @@ describe('fetchLogsStats', () => {
           },
         };
       }
+      if (path === 'index/volume_range') {
+        return {
+          data: {
+            result: [
+              {
+                metric: { service_name: 'a' },
+                values: [
+                  [1_000, '10'],
+                  [1_060, '20'],
+                ],
+              },
+              {
+                metric: { service_name: 'b' },
+                values: [
+                  [1_000, '5'],
+                  [1_060, '15'],
+                ],
+              },
+            ],
+          },
+        };
+      }
       if (path === 'label/service_name/values') {
         return { data: ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'] };
       }
@@ -68,18 +84,29 @@ describe('fetchLogsStats', () => {
     });
     mockResolveBackendInstance.mockResolvedValue(instanceWith(getResource));
 
-    await expect(fetchLogsStats(loki)).resolves.toEqual({ bytes: 47_000_000_000, sources: 8 });
+    const activity = await fetchLogsActivity(loki);
+
+    expect(activity.bytes).toBe(47_000_000_000);
+    expect(activity.sources).toBe(8);
+    expect(activity.series?.x?.values).toEqual([1_000_000, 1_060_000]);
+    expect(activity.series?.y.values).toEqual([15, 35]);
 
     const end = Date.now() * NS_IN_MS;
-    const start = end - LOGS_STATS_LOOKBACK_DAYS * 24 * 3600 * 1e9;
-    expect(getResource).toHaveBeenCalledWith('labels', { start, end });
+    const statsStart = end - LOGS_STATS_LOOKBACK_DAYS * 24 * 3600 * 1e9;
+    expect(getResource).toHaveBeenCalledWith('labels', { start: statsStart, end });
     expect(getResource).toHaveBeenCalledWith('index/volume', {
       query: '{service_name=~".+"}',
-      start,
+      start: statsStart,
       end,
       limit: 1000,
     });
-    expect(getResource).toHaveBeenCalledWith('label/service_name/values', { start, end });
+    expect(getResource).toHaveBeenCalledWith('label/service_name/values', { start: statsStart, end });
+    expect(getResource).toHaveBeenCalledWith('index/volume_range', {
+      query: '{service_name=~".+"}',
+      start: end - DATA_LOOKBACK_HOURS * 3600 * 1e9,
+      end,
+      step: '30m',
+    });
   });
 
   it('falls back to job when service_name is absent', async () => {
@@ -90,91 +117,59 @@ describe('fetchLogsStats', () => {
       if (path === 'index/volume') {
         return { data: { result: [] } };
       }
+      if (path === 'index/volume_range') {
+        return { data: { result: [] } };
+      }
       return { data: ['a'] };
     });
     mockResolveBackendInstance.mockResolvedValue(instanceWith(getResource));
 
-    await expect(fetchLogsStats(loki)).resolves.toEqual({ bytes: 0, sources: 1 });
+    await expect(fetchLogsActivity(loki)).resolves.toEqual({ bytes: 0, sources: 1, series: null });
     expect(getResource).toHaveBeenCalledWith('label/job/values', expect.anything());
   });
 
-  it('keeps the sources count when the volume endpoint is unavailable', async () => {
+  it('keeps the other fields when one endpoint is unavailable', async () => {
     const getResource = jest.fn(async (path: string) => {
       if (path === 'labels') {
         return { data: ['job'] };
       }
-      if (path === 'index/volume') {
+      if (path === 'index/volume' || path === 'index/volume_range') {
         throw new Error('volume disabled');
       }
       return { data: ['a', 'b'] };
     });
     mockResolveBackendInstance.mockResolvedValue(instanceWith(getResource));
 
-    const promise = fetchLogsStats(loki);
+    const promise = fetchLogsActivity(loki);
     // withRetry sleeps between volume attempts; drive the fake timers past them.
     await jest.advanceTimersByTimeAsync(5_000);
 
-    await expect(promise).resolves.toEqual({ bytes: null, sources: 2 });
+    await expect(promise).resolves.toEqual({ bytes: null, sources: 2, series: null });
   });
 
   it('reports nulls when no usable label exists', async () => {
     const getResource = jest.fn(async () => ({ data: ['__stream_shard__'] }));
     mockResolveBackendInstance.mockResolvedValue(instanceWith(getResource));
 
-    await expect(fetchLogsStats(loki)).resolves.toEqual({ bytes: null, sources: null });
+    await expect(fetchLogsActivity(loki)).resolves.toEqual({ bytes: null, sources: null, series: null });
     expect(getResource).toHaveBeenCalledTimes(1);
   });
-});
 
-describe('fetchLogsVolumeSeries', () => {
-  it('sums the volume matrix across labels into one series', async () => {
+  it('drops a single-point series', async () => {
     const getResource = jest.fn(async (path: string) => {
       if (path === 'labels') {
-        return { data: ['service_name'] };
+        return { data: ['job'] };
       }
-      return {
-        data: {
-          result: [
-            {
-              metric: { service_name: 'a' },
-              values: [
-                [1_000, '10'],
-                [1_060, '20'],
-              ],
-            },
-            {
-              metric: { service_name: 'b' },
-              values: [
-                [1_000, '5'],
-                [1_060, '15'],
-              ],
-            },
-          ],
-        },
-      };
+      if (path === 'index/volume_range') {
+        return { data: { result: [{ metric: {}, values: [[1_000, '10']] }] } };
+      }
+      return { data: [] };
     });
     mockResolveBackendInstance.mockResolvedValue(instanceWith(getResource));
 
-    const series = await fetchLogsVolumeSeries(loki);
+    const activity = await fetchLogsActivity(loki);
 
-    expect(series?.x?.values).toEqual([1_000_000, 1_060_000]);
-    expect(series?.y.values).toEqual([15, 35]);
-    const end = Date.now() * NS_IN_MS;
-    expect(getResource).toHaveBeenCalledWith('index/volume_range', {
-      query: '{service_name=~".+"}',
-      start: end - DATA_LOOKBACK_HOURS * 3600 * 1e9,
-      end,
-      step: '30m',
-    });
-  });
-
-  it('returns null for a single-point series', async () => {
-    const getResource = jest.fn(async (path: string) =>
-      path === 'labels' ? { data: ['job'] } : { data: { result: [{ metric: {}, values: [[1_000, '10']] }] } }
-    );
-    mockResolveBackendInstance.mockResolvedValue(instanceWith(getResource));
-
-    await expect(fetchLogsVolumeSeries(loki)).resolves.toBeNull();
+    expect(activity.series).toBeNull();
   });
 });
 

--- a/public/app/features/home/Recommendations/telemetryData.ts
+++ b/public/app/features/home/Recommendations/telemetryData.ts
@@ -16,9 +16,10 @@ export const LOGS_STATS_LOOKBACK_DAYS = 7;
 const NS_IN_MS = 1e6;
 const NS_IN_S = 1e9;
 
-export interface LogsStats {
+export interface LogsActivity {
   bytes: number | null;
   sources: number | null;
+  series: FieldSparkline | null;
 }
 
 export interface TracesActivity {
@@ -47,9 +48,9 @@ function toSparkline(points: Array<[number, number]>, name: string): FieldSparkl
   if (points.length < 2) {
     return null;
   }
-  const sorted = [...points].sort(([a], [b]) => a - b);
-  const x: Field = { name: 'Time', type: FieldType.time, values: sorted.map(([ts]) => ts), config: {} };
-  const y: Field = { name, type: FieldType.number, values: sorted.map(([, value]) => value), config: {} };
+  points.sort(([a], [b]) => a - b);
+  const x: Field = { name: 'Time', type: FieldType.time, values: points.map(([ts]) => ts), config: {} };
+  const y: Field = { name, type: FieldType.number, values: points.map(([, value]) => value), config: {} };
   return { x, y: { ...y, state: { range: getMinMaxAndDelta(y) } } };
 }
 
@@ -62,66 +63,51 @@ async function resolveLogsLabel(instance: DataSourceWithBackend, start: number, 
   return ['service_name', 'job'].find((preferred) => labels.includes(preferred)) ?? labels[0] ?? null;
 }
 
-/** Ingested bytes and distinct sources over the stats window; null fields when unavailable. */
-export async function fetchLogsStats(ds: Pick<DataSourceInstanceListItem, 'uid'>): Promise<LogsStats> {
+/**
+ * Ingested bytes and distinct sources over the stats window plus the 24h ingest-volume
+ * sparkline, all riding Loki's index (cheap even over 7d). Each field fails soft to null.
+ */
+export async function fetchLogsActivity(ds: Pick<DataSourceInstanceListItem, 'uid'>): Promise<LogsActivity> {
+  const empty: LogsActivity = { bytes: null, sources: null, series: null };
   const instance = await resolveBackendInstance(ds.uid);
   if (!instance) {
-    return { bytes: null, sources: null };
+    return empty;
   }
   const end = Date.now() * NS_IN_MS;
-  const start = end - LOGS_STATS_LOOKBACK_DAYS * 24 * 3600 * NS_IN_S;
-  const label = await resolveLogsLabel(instance, start, end);
+  const statsStart = end - LOGS_STATS_LOOKBACK_DAYS * 24 * 3600 * NS_IN_S;
+  const label = await resolveLogsLabel(instance, statsStart, end);
   if (!label) {
-    return { bytes: null, sources: null };
+    return empty;
   }
-  // Volume rides the index (cheap even over 7d); a disabled volume endpoint fails soft to null.
-  const [volume, values] = await Promise.all([
-    getResource<LokiVolumeResponse>(instance, 'index/volume', {
-      query: `{${label}=~".+"}`,
-      start,
-      end,
-      limit: 1000,
-    }).catch(() => null),
-    getResource<{ data?: unknown }>(instance, `label/${encodeURIComponent(label)}/values`, { start, end }).catch(
+  const query = `{${label}=~".+"}`;
+  const [volume, values, volumeRange] = await Promise.all([
+    getResource<LokiVolumeResponse>(instance, 'index/volume', { query, start: statsStart, end, limit: 1000 }).catch(
       () => null
     ),
+    getResource<{ data?: unknown }>(instance, `label/${encodeURIComponent(label)}/values`, {
+      start: statsStart,
+      end,
+    }).catch(() => null),
+    getResource<LokiVolumeRangeResponse>(instance, 'index/volume_range', {
+      query,
+      start: end - DATA_LOOKBACK_HOURS * 3600 * NS_IN_S,
+      end,
+      step: '30m',
+    }).catch(() => null),
   ]);
   const volumes = volume?.data?.result;
-  const bytes = Array.isArray(volumes)
-    ? volumes.reduce((total, entry) => total + (Number(entry.value?.[1]) || 0), 0)
-    : null;
-  const sources = Array.isArray(values?.data) ? values.data.length : null;
-  return { bytes, sources };
-}
-
-/** Ingest-volume sparkline over the last 24h, or null when the series cannot be built. */
-export async function fetchLogsVolumeSeries(
-  ds: Pick<DataSourceInstanceListItem, 'uid'>
-): Promise<FieldSparkline | null> {
-  const instance = await resolveBackendInstance(ds.uid);
-  if (!instance) {
-    return null;
-  }
-  const end = Date.now() * NS_IN_MS;
-  const start = end - DATA_LOOKBACK_HOURS * 3600 * NS_IN_S;
-  const label = await resolveLogsLabel(instance, start, end);
-  if (!label) {
-    return null;
-  }
-  const res = await getResource<LokiVolumeRangeResponse>(instance, 'index/volume_range', {
-    query: `{${label}=~".+"}`,
-    start,
-    end,
-    step: '30m',
-  });
   // Sum the per-label matrix into one total-ingest series (timestamps are unix seconds).
   const buckets = new Map<number, number>();
-  for (const series of res?.data?.result ?? []) {
+  for (const series of volumeRange?.data?.result ?? []) {
     for (const [ts, value] of series.values ?? []) {
       buckets.set(ts * 1000, (buckets.get(ts * 1000) ?? 0) + (Number(value) || 0));
     }
   }
-  return toSparkline([...buckets.entries()], 'Ingest volume');
+  return {
+    bytes: Array.isArray(volumes) ? volumes.reduce((total, entry) => total + (Number(entry.value?.[1]) || 0), 0) : null,
+    sources: Array.isArray(values?.data) ? values.data.length : null,
+    series: toSparkline([...buckets.entries()], 'Ingest volume'),
+  };
 }
 
 /**
@@ -158,20 +144,18 @@ export async function fetchTracesActivity(ds: Pick<DataSourceInstanceListItem, '
     step: '30m',
   });
   const buckets = new Map<number, number>();
-  let spans = 0;
-  let seen = false;
   for (const series of res?.series ?? []) {
     for (const sample of series.samples ?? []) {
       // Sparse samples: zero buckets may be omitted; values may arrive as strings.
       const ts = Number(sample.timestampMs);
       const value = Number(sample.value ?? 0);
-      if (!Number.isFinite(ts) || !Number.isFinite(value)) {
-        continue;
+      if (Number.isFinite(ts) && Number.isFinite(value)) {
+        buckets.set(ts, (buckets.get(ts) ?? 0) + value);
       }
-      seen = true;
-      spans += value;
-      buckets.set(ts, (buckets.get(ts) ?? 0) + value);
     }
   }
-  return { spans: seen ? spans : null, series: toSparkline([...buckets.entries()], 'Span throughput') };
+  return {
+    spans: buckets.size > 0 ? [...buckets.values()].reduce((total, value) => total + value, 0) : null,
+    series: toSparkline([...buckets.entries()], 'Span throughput'),
+  };
 }

--- a/public/app/features/home/Recommendations/telemetryData.ts
+++ b/public/app/features/home/Recommendations/telemetryData.ts
@@ -39,8 +39,11 @@ interface TempoTagValuesResponse {
   tagValues?: Array<{ value?: string }>;
 }
 
+// Failures are expected (endpoint disabled, 403s) and handled by the caller; never toast.
 function getResource<T>(instance: DataSourceWithBackend, path: string, params: Record<string, unknown>): Promise<T> {
-  return withRetry(() => withTimeout(instance.getResource<T>(path, params), PROBE_TIMEOUT_MS));
+  return withRetry(() =>
+    withTimeout(instance.getResource<T>(path, params, { showErrorAlert: false }), PROBE_TIMEOUT_MS)
+  );
 }
 
 // Points are [unix ms, value]; a real trend needs at least two of them.
@@ -80,8 +83,11 @@ export async function fetchLogsActivity(ds: Pick<DataSourceInstanceListItem, 'ui
     return empty;
   }
   const query = `{${label}=~".+"}`;
+  // aggregateBy=labels collapses both volume responses to one server-side total series, so the
+  // per-query series limit cannot truncate what we present as a complete number.
+  const aggregate = { aggregateBy: 'labels', targetLabels: label };
   const [volume, values, volumeRange] = await Promise.all([
-    getResource<LokiVolumeResponse>(instance, 'index/volume', { query, start: statsStart, end, limit: 1000 }).catch(
+    getResource<LokiVolumeResponse>(instance, 'index/volume', { query, start: statsStart, end, ...aggregate }).catch(
       () => null
     ),
     getResource<{ data?: unknown }>(instance, `label/${encodeURIComponent(label)}/values`, {
@@ -93,10 +99,11 @@ export async function fetchLogsActivity(ds: Pick<DataSourceInstanceListItem, 'ui
       start: end - DATA_LOOKBACK_HOURS * 3600 * NS_IN_S,
       end,
       step: '30m',
+      ...aggregate,
     }).catch(() => null),
   ]);
   const volumes = volume?.data?.result;
-  // Sum the per-label matrix into one total-ingest series (timestamps are unix seconds).
+  // Sum the (single-series) matrix into ingest buckets (timestamps are unix seconds).
   const buckets = new Map<number, number>();
   for (const series of volumeRange?.data?.result ?? []) {
     for (const [ts, value] of series.values ?? []) {

--- a/public/app/features/home/Recommendations/useTelemetrySolutions.ts
+++ b/public/app/features/home/Recommendations/useTelemetrySolutions.ts
@@ -15,8 +15,8 @@ export interface TelemetrySolutions {
 
 /**
  * Logs and Traces solution providers: an entry appears only for a confirmed-active signal
- * ('unknown' never invents one), filled with live stats from the datasource that won the probe.
- * Detail fetches fail soft: the entry renders without the failed stat or sparkline.
+ * ('unknown' never invents one) AND when its detail fetches produced something to show —
+ * a bare title card with every stat failed-soft reads as broken, so it is dropped instead.
  */
 export function useTelemetrySolutions(): TelemetrySolutions {
   const { value: resolution, loading: stateLoading } = useSolutionState();
@@ -32,33 +32,47 @@ export function useTelemetrySolutions(): TelemetrySolutions {
   const tracesActivity = useAsync(async () => (tempoDs ? fetchTracesActivity(tempoDs) : undefined), [tempoDs]);
   const tracesServices = useAsync(async () => (tempoDs ? fetchTracesServices(tempoDs) : undefined), [tempoDs]);
 
-  const logs: ExistingSolutionProviderResult = lokiDs
-    ? {
-        loading: false,
-        item: buildLogsItem({
-          bytes: logsActivity.value?.bytes,
-          sources: logsActivity.value?.sources,
-          volumeSeries: logsActivity.value?.series ?? null,
-          activityLoading: logsActivity.loading,
-          datasourceName: lokiDs.name,
-          drilldownAvailable: availableApps.has(LOGS_DRILLDOWN_APP_ID),
-        }),
-      }
-    : { loading: stateLoading, item: null };
+  let logs: ExistingSolutionProviderResult = { loading: stateLoading, item: null };
+  if (lokiDs) {
+    const activity = logsActivity.value;
+    // Stats need bytes, the sparkline needs the series; with neither there is nothing to render.
+    logs =
+      logsActivity.loading || !activity
+        ? { loading: logsActivity.loading, item: null }
+        : activity.bytes == null && activity.series == null
+          ? { loading: false, item: null }
+          : {
+              loading: false,
+              item: buildLogsItem({
+                bytes: activity.bytes,
+                sources: activity.sources,
+                volumeSeries: activity.series,
+                datasourceName: lokiDs.name,
+                drilldownAvailable: availableApps.has(LOGS_DRILLDOWN_APP_ID),
+              }),
+            };
+  }
 
-  const traces: ExistingSolutionProviderResult = tempoDs
-    ? {
-        loading: false,
-        item: buildTracesItem({
-          spans: tracesActivity.value?.spans,
-          services: tracesServices.value,
-          activityLoading: tracesActivity.loading,
-          throughputSeries: tracesActivity.value?.series ?? null,
-          datasourceName: tempoDs.name,
-          drilldownAvailable: availableApps.has(HOSTED_TRACES_APP_ID),
-        }),
-      }
-    : { loading: stateLoading, item: null };
+  let traces: ExistingSolutionProviderResult = { loading: stateLoading, item: null };
+  if (tempoDs) {
+    const activity = tracesActivity.value;
+    // The services count alone renders nothing (it is the stats secondary), so it cannot carry a card.
+    traces =
+      tracesActivity.loading || tracesServices.loading || !activity
+        ? { loading: tracesActivity.loading || tracesServices.loading, item: null }
+        : activity.spans == null && activity.series == null
+          ? { loading: false, item: null }
+          : {
+              loading: false,
+              item: buildTracesItem({
+                spans: activity.spans,
+                services: tracesServices.value ?? null,
+                throughputSeries: activity.series,
+                datasourceName: tempoDs.name,
+                drilldownAvailable: availableApps.has(HOSTED_TRACES_APP_ID),
+              }),
+            };
+  }
 
   return { logs, traces };
 }

--- a/public/app/features/home/Recommendations/useTelemetrySolutions.ts
+++ b/public/app/features/home/Recommendations/useTelemetrySolutions.ts
@@ -5,7 +5,7 @@ import { useAppPluginMetas } from '@grafana/runtime/internal';
 import { HOSTED_TRACES_APP_ID, LOGS_DRILLDOWN_APP_ID } from './appPluginIds';
 import { buildLogsItem, buildTracesItem } from './buildTelemetryItems';
 import { useSolutionState } from './solutionState';
-import { fetchLogsStats, fetchLogsVolumeSeries, fetchTracesActivity, fetchTracesServices } from './telemetryData';
+import { fetchLogsActivity, fetchTracesActivity, fetchTracesServices } from './telemetryData';
 import { type ExistingSolutionProviderResult } from './types';
 
 export interface TelemetrySolutions {
@@ -28,8 +28,7 @@ export function useTelemetrySolutions(): TelemetrySolutions {
   const tempoDs = resolution?.state.traces === 'active' ? resolution.tempoDatasource : null;
 
   // Gate inside the callbacks (ds in the deps): an inactive or unknown signal never queries.
-  const logsStats = useAsync(async () => (lokiDs ? fetchLogsStats(lokiDs) : undefined), [lokiDs]);
-  const logsVolume = useAsync(async () => (lokiDs ? fetchLogsVolumeSeries(lokiDs) : undefined), [lokiDs]);
+  const logsActivity = useAsync(async () => (lokiDs ? fetchLogsActivity(lokiDs) : undefined), [lokiDs]);
   const tracesActivity = useAsync(async () => (tempoDs ? fetchTracesActivity(tempoDs) : undefined), [tempoDs]);
   const tracesServices = useAsync(async () => (tempoDs ? fetchTracesServices(tempoDs) : undefined), [tempoDs]);
 
@@ -37,10 +36,10 @@ export function useTelemetrySolutions(): TelemetrySolutions {
     ? {
         loading: false,
         item: buildLogsItem({
-          stats: logsStats.value,
-          statsLoading: logsStats.loading,
-          volumeSeries: logsVolume.value ?? null,
-          volumeLoading: logsVolume.loading,
+          bytes: logsActivity.value?.bytes,
+          sources: logsActivity.value?.sources,
+          volumeSeries: logsActivity.value?.series ?? null,
+          activityLoading: logsActivity.loading,
           datasourceName: lokiDs.name,
           drilldownAvailable: availableApps.has(LOGS_DRILLDOWN_APP_ID),
         }),

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -11037,10 +11037,11 @@
       },
       "logs": {
         "action": "Open Explore (Logs)",
+        "action-explore": "Open in Explore",
         "datasource": "via {{name}}",
         "stats": "ingested · 7d",
-        "stats-sources_one": "ingested · 7d · {{count}} source",
-        "stats-sources_other": "ingested · 7d · {{count}} sources",
+        "stats-sources_one": "ingested · 7d · ~{{count}} source",
+        "stats-sources_other": "ingested · 7d · ~{{count}} sources",
         "title": "Hosted Logs",
         "volume": "Ingest volume · last 24h"
       },
@@ -11049,11 +11050,13 @@
         "badge": "Getting started",
         "connect": "Connect a data source",
         "description": "Connect a data source to light up your dashboards and alerts, pick from available solutions, or follow a getting started guide.",
+        "description-partial": "Some signals are already flowing. Connect more data sources or pick a solution to see live stats here.",
         "popular-solutions": "Popular solutions",
         "solution-k6": "k6",
         "solution-kubernetes": "Kubernetes Monitoring",
         "solution-synthetics": "Synthetic Monitoring",
-        "title": "No data flowing yet"
+        "title": "No data flowing yet",
+        "title-partial": "Add more telemetry"
       },
       "pause": "Pause",
       "previous": "Previous",
@@ -11065,6 +11068,7 @@
       "title": "Recommendations for your stack",
       "traces": {
         "action": "Open Traces Drilldown",
+        "action-explore": "Open in Explore",
         "datasource": "via {{name}}",
         "spans_one": "{{value}} span",
         "spans_other": "{{value}} spans",


### PR DESCRIPTION
**What is this feature?**

Solution probes get time/budget bounds and fail silently, are gated on the collapsed preference, and the kubernetes probe becomes budget-bound and error-aware. Telemetry entries with nothing to show are dropped, NoDataCard variants stop overclaiming, logs source counts are marked approximate, the Explore fallback points at the winning datasource, and the region hides when there is nothing to recommend.