### PR TITLE
Home: Add the metrics solution card and follow the selected solution

### DIFF
--- a/public/app/features/home/Recommendations/ExistingSolutionCard.tsx
+++ b/public/app/features/home/Recommendations/ExistingSolutionCard.tsx
@@ -8,12 +8,13 @@ import { Button, Dropdown, Icon, LinkButton, Menu, Stack, Text, useStyles2 } fro
 import { ctaClicked } from '../analytics/main';
 
 import { SolutionSparkline } from './SolutionSparkline';
+import { type ExistingSolutionId } from './solutionsMatrix';
 import { type ExistingItem } from './types';
 
 interface ExistingSolutionCardProps {
   existing: ExistingItem[];
   selected: ExistingItem;
-  onSelect: (title: string) => void;
+  onSelect: (id: ExistingSolutionId) => void;
 }
 
 export function ExistingSolutionCard({ existing, selected, onSelect }: ExistingSolutionCardProps) {
@@ -44,9 +45,9 @@ export function ExistingSolutionCard({ existing, selected, onSelect }: ExistingS
                           solution: item.id,
                         });
                       }
-                      onSelect(item.title);
+                      onSelect(item.id);
                     }}
-                    component={item.title === selected.title ? SelectedCheck : undefined}
+                    component={item.id === selected.id ? SelectedCheck : undefined}
                   />
                 ))}
               </Menu.Group>

--- a/public/app/features/home/Recommendations/RecommendationCard.tsx
+++ b/public/app/features/home/Recommendations/RecommendationCard.tsx
@@ -10,9 +10,11 @@ import type { RecommendationItem } from './types';
 interface RecommendationCardProps {
   recommendation: RecommendationItem;
   startingState: string;
+  /** Solution view active when the card was clicked; absent when no solution is selected. */
+  solution?: string;
 }
 
-export function RecommendationCard({ recommendation, startingState }: RecommendationCardProps) {
+export function RecommendationCard({ recommendation, startingState, solution }: RecommendationCardProps) {
   const styles = useStyles2(getStyles, recommendation.color);
 
   return (
@@ -47,6 +49,7 @@ export function RecommendationCard({ recommendation, startingState }: Recommenda
               placement: 'card',
               recommendation_id: recommendation.id,
               starting_state: startingState,
+              solution,
             })
           }
         >

--- a/public/app/features/home/Recommendations/RecommendationExisting.test.tsx
+++ b/public/app/features/home/Recommendations/RecommendationExisting.test.tsx
@@ -20,7 +20,7 @@ import {
 import { readSeries } from './promQuery';
 import { useSolutionState } from './solutionState';
 import { type SolutionState } from './solutionsMatrix';
-import { fetchLogsActivity, fetchTracesActivity, fetchTracesServices } from './telemetryData';
+import { fetchLogsActivity, fetchMetricsActivity, fetchTracesActivity, fetchTracesServices } from './telemetryData';
 
 jest.mock('app/features/alerting/unified/hooks/usePluginBridge', () => ({
   ...jest.requireActual('app/features/alerting/unified/hooks/usePluginBridge'),
@@ -46,6 +46,7 @@ jest.mock('./solutionState', () => ({
 jest.mock('./telemetryData', () => ({
   ...jest.requireActual('./telemetryData'),
   fetchLogsActivity: jest.fn(),
+  fetchMetricsActivity: jest.fn(),
   fetchTracesActivity: jest.fn(),
   fetchTracesServices: jest.fn(),
 }));
@@ -63,6 +64,7 @@ const mockFetchCpuSeries = jest.mocked(fetchClusterCpuSeries);
 const mockUseSolutionState = jest.mocked(useSolutionState);
 const mockUseAppPluginMetas = jest.mocked(useAppPluginMetas);
 const mockFetchLogsActivity = jest.mocked(fetchLogsActivity);
+const mockFetchMetricsActivity = jest.mocked(fetchMetricsActivity);
 const mockFetchTracesActivity = jest.mocked(fetchTracesActivity);
 const mockFetchTracesServices = jest.mocked(fetchTracesServices);
 
@@ -96,9 +98,22 @@ const tempoDatasource: DataSourceInstanceListItem = {
   isDefault: false,
 };
 
+const prometheusDatasource: DataSourceInstanceListItem = {
+  uid: 'prom-uid',
+  name: 'grafanacloud-prom',
+  type: 'prometheus',
+  meta: { id: 'prometheus' } as DataSourceInstanceListItem['meta'],
+  readOnly: false,
+  isDefault: false,
+};
+
 function setSolutionState(
   overrides: Partial<SolutionState>,
-  ds: { loki?: DataSourceInstanceListItem; tempo?: DataSourceInstanceListItem } = {}
+  ds: {
+    loki?: DataSourceInstanceListItem;
+    tempo?: DataSourceInstanceListItem;
+    prometheus?: DataSourceInstanceListItem;
+  } = {}
 ) {
   mockUseSolutionState.mockReturnValue({
     value: {
@@ -112,6 +127,7 @@ function setSolutionState(
       },
       lokiDatasource: ds.loki ?? null,
       tempoDatasource: ds.tempo ?? null,
+      prometheusDatasource: ds.prometheus ?? null,
     },
     loading: false,
   });
@@ -163,6 +179,14 @@ beforeEach(() => {
   mockFetchTracesActivity.mockResolvedValue({ spans: null, series: null });
   mockFetchTracesServices.mockReset();
   mockFetchTracesServices.mockResolvedValue(null);
+  mockFetchMetricsActivity.mockReset();
+  mockFetchMetricsActivity.mockResolvedValue({
+    series: null,
+    names: null,
+    hosts: null,
+    seriesSparkline: null,
+    disk: null,
+  });
 });
 
 afterEach(() => jest.restoreAllMocks());
@@ -183,11 +207,18 @@ describe('RecommendationExisting', () => {
 
   it('lists live solutions in registry order with no stub entries', async () => {
     mockActiveLogs();
+    mockFetchMetricsActivity.mockResolvedValue({
+      series: 4_200_000,
+      names: null,
+      hosts: null,
+      seriesSparkline: null,
+      disk: null,
+    });
     mockFetchTracesActivity.mockResolvedValue({ spans: 4_800_000, series: null });
     mockFetchTracesServices.mockResolvedValue(34);
     setSolutionState(
       { metrics: 'active', logs: 'active', traces: 'active' },
-      { loki: lokiDatasource, tempo: tempoDatasource }
+      { prometheus: prometheusDatasource, loki: lokiDatasource, tempo: tempoDatasource }
     );
 
     const { user } = render(<RecommendationExisting />);
@@ -196,7 +227,7 @@ describe('RecommendationExisting', () => {
     await user.click(screen.getByRole('button', { name: /Switch solution/i }));
 
     const items = screen.getAllByRole('menuitem').map((item) => item.textContent?.trim());
-    expect(items).toEqual(['Kubernetes Monitoring', 'Hosted Logs', 'Hosted Traces']);
+    expect(items).toEqual(['Kubernetes Monitoring', 'Metrics & infrastructure', 'Hosted Logs', 'Hosted Traces']);
   });
 
   it('shows traces stats and the drilldown href when the app is available', async () => {
@@ -251,6 +282,85 @@ describe('RecommendationExisting', () => {
       'href',
       '/a/grafana-lokiexplore-app'
     );
+  });
+
+  it('shows metrics stats, the disk alert, and the drilldown href when the app is available', async () => {
+    mockUsePluginBridge.mockReturnValue({ loading: false, installed: false, settings: undefined });
+    setSolutionState({ metrics: 'active' }, { prometheus: prometheusDatasource });
+    mockFetchMetricsActivity.mockResolvedValue({
+      series: 4_200_000,
+      names: 1_200,
+      hosts: 12,
+      seriesSparkline: null,
+      disk: { hostsAbove: 3, worstInstance: 'web-03:9100', worstRatio: 0.96, hoursToFull: 6.4 },
+    });
+    mockUseAppPluginMetas.mockReturnValue({
+      loading: false,
+      error: undefined,
+      value: [{ id: 'grafana-metricsdrilldown-app' } as AppPluginConfig],
+    });
+
+    render(<RecommendationExisting />);
+
+    expect(await screen.findByRole('heading', { name: 'Metrics & infrastructure' })).toBeInTheDocument();
+    expect(screen.getByText('via grafanacloud-prom')).toBeInTheDocument();
+    expect(await screen.findByText('4.2M series')).toBeInTheDocument();
+    expect(screen.getByText('active · 12 hosts')).toBeInTheDocument();
+    expect(screen.getByText('3 hosts above 90% disk')).toBeInTheDocument();
+    // Scrape port stripped from the worst host; the rounded ETA rides along.
+    expect(screen.getByText('web-03 at 96%')).toBeInTheDocument();
+    expect(screen.getByText('~6 h to full')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /View/ }).getAttribute('href')).toMatch(/^\/explore\?left=/);
+    expect(screen.getByRole('link', { name: /Open Metrics Drilldown/ })).toHaveAttribute(
+      'href',
+      '/a/grafana-metricsdrilldown-app'
+    );
+  });
+
+  it('falls back to the name count and Explore when no active-series source responded', async () => {
+    mockUsePluginBridge.mockReturnValue({ loading: false, installed: false, settings: undefined });
+    setSolutionState({ metrics: 'active' }, { prometheus: prometheusDatasource });
+    mockFetchMetricsActivity.mockResolvedValue({
+      series: null,
+      names: 1_200,
+      hosts: null,
+      seriesSparkline: null,
+      disk: null,
+    });
+
+    render(<RecommendationExisting />);
+
+    expect(await screen.findByRole('heading', { name: 'Metrics & infrastructure' })).toBeInTheDocument();
+    expect(await screen.findByText('1.2K metrics')).toBeInTheDocument();
+    // No host count: the secondary degrades to the bare qualifier, and no alert row renders.
+    expect(screen.getByText('active')).toBeInTheDocument();
+    expect(screen.queryByText(/above 90% disk/)).not.toBeInTheDocument();
+    const href = screen.getByRole('link', { name: /Open in Explore/ }).getAttribute('href') ?? '';
+    expect(href).toMatch(/^\/explore\?left=/);
+    const left = new URLSearchParams(href.split('?')[1]).get('left') ?? '';
+    expect(JSON.parse(left)).toEqual({ datasource: 'grafanacloud-prom', context: 'explore' });
+  });
+
+  it('drops the metrics entry when series, names, and sparkline all failed soft', async () => {
+    mockUsePluginBridge.mockReturnValue({ loading: false, installed: false, settings: undefined });
+    setSolutionState({ metrics: 'active', logs: 'active' }, { prometheus: prometheusDatasource, loki: lokiDatasource });
+    mockFetchLogsActivity.mockResolvedValue({ bytes: 47_000_000_000, sources: 8, series: null });
+    // Hosts alone are secondary content — they cannot carry the card.
+    mockFetchMetricsActivity.mockResolvedValue({
+      series: null,
+      names: null,
+      hosts: 12,
+      seriesSparkline: null,
+      disk: null,
+    });
+
+    const { user } = render(<RecommendationExisting />);
+
+    expect(await screen.findByRole('heading', { name: 'Hosted Logs' })).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /Switch solution/i }));
+
+    const items = screen.getAllByRole('menuitem').map((item) => item.textContent?.trim());
+    expect(items).toEqual(['Hosted Logs']);
   });
 
   it('never invents an entry for an unknown signal', async () => {
@@ -568,7 +678,7 @@ describe('RecommendationExisting', () => {
         surface: 'existing_solution',
         action: 'open_solution',
         placement: 'card',
-        solution: 'kubernetes-monitoring',
+        solution: 'kubernetes',
       });
     });
 
@@ -588,7 +698,7 @@ describe('RecommendationExisting', () => {
         surface: 'existing_solution',
         action: 'view_alerts',
         placement: 'card',
-        solution: 'kubernetes-monitoring',
+        solution: 'kubernetes',
       });
     });
 

--- a/public/app/features/home/Recommendations/RecommendationExisting.tsx
+++ b/public/app/features/home/Recommendations/RecommendationExisting.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useLayoutEffect, useState } from 'react';
 import Skeleton from 'react-loading-skeleton';
 
 import { Stack } from '@grafana/ui';
@@ -6,19 +6,37 @@ import { Stack } from '@grafana/ui';
 import { ExistingSolutionCard } from './ExistingSolutionCard';
 import { NoDataCard } from './NoDataCard';
 import { useSolutionState } from './solutionState';
+import { type ExistingSolutionId } from './solutionsMatrix';
+import { type ExistingItem } from './types';
 import { useExistingSolutions } from './useExistingSolutions';
 
-export function RecommendationExisting() {
-  const [selectedTitle, setSelectedTitle] = useState<string>();
+interface RecommendationExistingProps {
+  /** Reports the solution the card displays — explicit pick or default — undefined until one settles. */
+  onSelectionChange?: (id: ExistingSolutionId | undefined) => void;
+}
+
+export function RecommendationExisting({ onSelectionChange }: RecommendationExistingProps) {
+  const [selectedId, setSelectedId] = useState<ExistingSolutionId>();
   const { loading, solutions } = useExistingSolutions();
   // Shares the TTL-cached resolution with useExistingSolutions — no extra probes.
   const { value: resolution } = useSolutionState();
+
+  // The effective selection (explicit pick ?? default) is computed before the early returns so
+  // the report effect runs unconditionally (Rules of Hooks). While loading/empty it is
+  // undefined and the parent shows the global list.
+  const selected: ExistingItem | undefined = solutions.find((item) => item.id === selectedId) ?? solutions[0];
+  const effectiveId = selected?.id;
+  // useLayoutEffect: the parent's carousel swap commits before paint, so the list never
+  // flashes the global order once the default selection settles.
+  useLayoutEffect(() => {
+    onSelectionChange?.(effectiveId);
+  }, [effectiveId, onSelectionChange]);
 
   if (loading) {
     return <RecommendationExistingSkeleton />;
   }
 
-  if (solutions.length === 0) {
+  if (!selected) {
     // NoDataCard's hard claim is only true when every core signal settled inactive; anything
     // else (active-but-no-entry, unknown) gets the softened variant.
     const s = resolution?.state;
@@ -31,8 +49,7 @@ export function RecommendationExisting() {
     return <NoDataCard variant={allInactive ? 'empty' : 'partial'} />;
   }
 
-  const selected = solutions.find((item) => item.title === selectedTitle) ?? solutions[0];
-  return <ExistingSolutionCard existing={solutions} selected={selected} onSelect={setSelectedTitle} />;
+  return <ExistingSolutionCard existing={solutions} selected={selected} onSelect={setSelectedId} />;
 }
 
 // Mirrors the card body (dropdown pill, icon + title, stats, CTA) while the solution

--- a/public/app/features/home/Recommendations/RecommendationPill.tsx
+++ b/public/app/features/home/Recommendations/RecommendationPill.tsx
@@ -10,9 +10,11 @@ import type { RecommendationItem } from './types';
 interface RecommendationPillProps {
   recommendation: RecommendationItem;
   startingState: string;
+  /** Solution view active when the pill was clicked; absent when no solution is selected. */
+  solution?: string;
 }
 
-export function RecommendationPill({ recommendation, startingState }: RecommendationPillProps) {
+export function RecommendationPill({ recommendation, startingState, solution }: RecommendationPillProps) {
   const styles = useStyles2(getStyles, recommendation.color);
 
   return (
@@ -29,6 +31,7 @@ export function RecommendationPill({ recommendation, startingState }: Recommenda
           placement: 'pill',
           recommendation_id: recommendation.id,
           starting_state: startingState,
+          solution,
         })
       }
       className={styles.pill}

--- a/public/app/features/home/Recommendations/Recommendations.test.tsx
+++ b/public/app/features/home/Recommendations/Recommendations.test.tsx
@@ -1,6 +1,6 @@
 import { act, render, screen, userEvent, waitFor, within } from 'test/test-utils';
 
-import { type PluginMeta } from '@grafana/data';
+import { type DataSourceInstanceListItem, type PluginMeta } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { interceptLinkClicks } from 'app/core/navigation/patch/interceptLinkClicks';
 import { contextSrv } from 'app/core/services/context_srv';
@@ -21,6 +21,7 @@ import {
 } from './kubernetesData';
 import { useSolutionState } from './solutionState';
 import { type SolutionState } from './solutionsMatrix';
+import { fetchLogsActivity, fetchMetricsActivity } from './telemetryData';
 
 const mockGet = jest.fn();
 jest.mock('@grafana/runtime', () => ({
@@ -56,6 +57,14 @@ jest.mock('./solutionState', () => ({
   useSolutionState: jest.fn(),
 }));
 
+jest.mock('./telemetryData', () => ({
+  ...jest.requireActual('./telemetryData'),
+  fetchLogsActivity: jest.fn(),
+  fetchMetricsActivity: jest.fn(),
+  fetchTracesActivity: jest.fn(),
+  fetchTracesServices: jest.fn(),
+}));
+
 // Removed-app ids stay literal: the never-render guard must outlive their deleted constants.
 const LEGACY_APP_IDS = ['grafana-synthetic-monitoring-app', 'grafana-app-observability-app', 'grafana-kowalski-app'];
 const APP_IDS = [HOSTED_TRACES_APP_ID, KUBERNETES_APP_ID, ...LEGACY_APP_IDS];
@@ -69,8 +78,31 @@ const listItem = (id: string, overrides: Partial<LocalPlugin> = {}) => ({
 
 const mockUsePluginBridge = jest.mocked(usePluginBridge);
 const mockUseSolutionState = jest.mocked(useSolutionState);
+const mockFetchLogsActivity = jest.mocked(fetchLogsActivity);
+const mockFetchMetricsActivity = jest.mocked(fetchMetricsActivity);
 
-function setSolutionState(overrides: Partial<SolutionState>) {
+const prometheusDatasource: DataSourceInstanceListItem = {
+  uid: 'prom-uid',
+  name: 'grafanacloud-prom',
+  type: 'prometheus',
+  meta: { id: 'prometheus' } as DataSourceInstanceListItem['meta'],
+  readOnly: false,
+  isDefault: false,
+};
+
+const lokiDatasource: DataSourceInstanceListItem = {
+  uid: 'loki-uid',
+  name: 'grafanacloud-logs',
+  type: 'loki',
+  meta: { id: 'loki' } as DataSourceInstanceListItem['meta'],
+  readOnly: false,
+  isDefault: false,
+};
+
+function setSolutionState(
+  overrides: Partial<SolutionState>,
+  ds: { loki?: DataSourceInstanceListItem; prometheus?: DataSourceInstanceListItem } = {}
+) {
   // Honor the enabled gate like the real hook: a collapsed region resolves nothing.
   mockUseSolutionState.mockImplementation((enabled = true) =>
     enabled
@@ -84,8 +116,9 @@ function setSolutionState(overrides: Partial<SolutionState>) {
               spanMetrics: 'inactive',
               ...overrides,
             },
-            lokiDatasource: null,
+            lokiDatasource: ds.loki ?? null,
             tempoDatasource: null,
+            prometheusDatasource: ds.prometheus ?? null,
           },
           loading: false,
         }
@@ -105,6 +138,16 @@ beforeEach(() => {
   mockGet.mockReset();
   mockGet.mockResolvedValue(APP_IDS.map((id) => listItem(id)));
   mockUseSolutionState.mockReset();
+  mockFetchLogsActivity.mockReset();
+  mockFetchLogsActivity.mockResolvedValue({ bytes: null, sources: null, series: null });
+  mockFetchMetricsActivity.mockReset();
+  mockFetchMetricsActivity.mockResolvedValue({
+    series: null,
+    names: null,
+    hosts: null,
+    seriesSparkline: null,
+    disk: null,
+  });
   // Metrics + Logs, no Traces: the two-card row (hosted-traces, kubernetes-monitoring).
   setSolutionState({ metrics: 'active', logs: 'active' });
   jest.spyOn(contextSrv, 'hasPermission').mockReturnValue(true);
@@ -115,6 +158,8 @@ afterEach(() => jest.restoreAllMocks());
 const carouselRegion = async () => screen.findByRole('region', { name: 'Recommended apps' });
 
 describe('Recommendations', () => {
+  // The default fixtures resolve no solution datasources, so the left card is in its no-data
+  // state and no solution view is active: the carousel keeps the global matrix order.
   it('renders the matrix-selected cards in matrix order for ml_no_traces', async () => {
     render(<Recommendations />);
 
@@ -127,6 +172,49 @@ describe('Recommendations', () => {
     expect(
       within(region).getByRole('link', { name: /Enable Kubernetes Monitoring/, hidden: true })
     ).toBeInTheDocument();
+  });
+
+  it('follows the selected solution: metrics-led by default, logs-led after switching', async () => {
+    setSolutionState({ metrics: 'active', logs: 'active' }, { prometheus: prometheusDatasource, loki: lokiDatasource });
+    mockFetchMetricsActivity.mockResolvedValue({
+      series: 4_200_000,
+      names: null,
+      hosts: 12,
+      seriesSparkline: null,
+      disk: null,
+    });
+    mockFetchLogsActivity.mockResolvedValue({ bytes: 47_000_000_000, sources: 8, series: null });
+
+    const { user } = render(<Recommendations />);
+
+    // The left card defaults to the first registry entry (kubernetes resolves no datasource).
+    expect(await screen.findByRole('heading', { name: 'Metrics & infrastructure' })).toBeInTheDocument();
+
+    const region = await carouselRegion();
+    const titles = () =>
+      within(region)
+        .getAllByRole('heading', { level: 3, hidden: true })
+        .map((heading) => heading.textContent?.trim());
+    // The metrics view leads with K8s Monitoring — the reverse of the matrix order.
+    expect(titles()).toEqual(['Monitor your Kubernetes fleet', 'Trace requests across services']);
+
+    // Advance to the second slide so the switch provably resets the carousel.
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+    expect(screen.getByRole('button', { name: 'Go to recommendation 1' })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /Switch solution/i }));
+    await user.click(screen.getByRole('menuitem', { name: 'Hosted Logs' }));
+
+    expect(screen.getByRole('heading', { name: 'Hosted Logs' })).toBeInTheDocument();
+    // The logs view re-leads with Hosted Traces and restarts on the first slide.
+    expect(titles()).toEqual(['Trace requests across services', 'Monitor your Kubernetes fleet']);
+    expect(screen.queryByRole('button', { name: 'Go to recommendation 1' })).not.toBeInTheDocument();
+    expect(jest.mocked(ctaClicked)).toHaveBeenCalledWith({
+      surface: 'existing_solution',
+      action: 'switch_solution',
+      placement: 'card',
+      solution: 'logs',
+    });
   });
 
   it('shows a skeleton while the solution state is resolving', async () => {
@@ -609,6 +697,36 @@ describe('Recommendations', () => {
         placement: 'card',
         recommendation_id: 'hosted-traces',
         starting_state: 'ml_no_traces',
+      });
+    });
+
+    it('tracks the active solution view on card clicks once a solution is selected', async () => {
+      setSolutionState(
+        { metrics: 'active', logs: 'active' },
+        { prometheus: prometheusDatasource, loki: lokiDatasource }
+      );
+      mockFetchMetricsActivity.mockResolvedValue({
+        series: 4_200_000,
+        names: null,
+        hosts: null,
+        seriesSparkline: null,
+        disk: null,
+      });
+      mockFetchLogsActivity.mockResolvedValue({ bytes: 47_000_000_000, sources: 8, series: null });
+
+      const { user } = render(<Recommendations />);
+
+      // Once the default (metrics) selection settles, its leading card is K8s Monitoring.
+      expect(await screen.findByRole('heading', { name: 'Metrics & infrastructure' })).toBeInTheDocument();
+      await user.click(await screen.findByRole('link', { name: /Enable Kubernetes Monitoring/ }));
+
+      expect(jest.mocked(ctaClicked)).toHaveBeenCalledWith({
+        surface: 'recommendations',
+        action: 'enable',
+        placement: 'card',
+        recommendation_id: 'kubernetes-monitoring',
+        starting_state: 'ml_no_traces',
+        solution: 'metrics',
       });
     });
 

--- a/public/app/features/home/Recommendations/Recommendations.tsx
+++ b/public/app/features/home/Recommendations/Recommendations.tsx
@@ -10,7 +10,12 @@ import { RecommendationsSkeleton } from './RecommendationsSkeleton';
 import { RecommendationsView } from './RecommendationsView';
 import { fetchInstalledPlugins, getRecommendationCards, type PluginRecommendationCard } from './pluginRecommendations';
 import { useSolutionState } from './solutionState';
-import { selectRecommendations } from './solutionsMatrix';
+import {
+  type ExistingSolutionId,
+  orderCardsForSolution,
+  type RecommendedCardId,
+  selectRecommendations,
+} from './solutionsMatrix';
 import { type RecommendationItem } from './types';
 
 const HOME_RECOMMENDATIONS_COLLAPSED_LOCAL_STORAGE_KEY = 'grafana.home.recommendations.collapsed';
@@ -66,29 +71,43 @@ function GatedRecommendations({ canInstall }: GatedRecommendationsProps) {
   // least the core plugins, so an empty response means the list is unreliable and also fails closed.
   const listReady = !!plugins.value && plugins.value.length > 0;
 
-  const recommendations = selectedCards.flatMap((card): RecommendationItem[] => {
-    if (card.kind === 'connection') {
-      // Independent of the plugin list: a failing /api/plugins must not hide a connection card.
-      return contextSrv.hasPermission(AccessControlAction.DataSourcesCreate) ? [{ ...card, cta: 'enable' }] : [];
-    }
-    if (!listReady) {
-      return [];
-    }
-    const plugin = pluginsById.get(card.pluginId);
-    if (!plugin) {
-      // Unlistable plugins take the install-only path.
-      return canInstall ? [toEnableItem(card)] : [];
-    }
-    if (plugin.enabled) {
-      // Selection already established the solution is silent; the setup CTA leads into the app,
-      // so it only renders for users who can open it.
-      return contextSrv.hasPermissionInMetadata(AccessControlAction.PluginsAppAccess, plugin)
-        ? [toSetupItem(card)]
-        : [];
-    }
-    // plugins:write is scoped to this plugin.
-    return contextSrv.hasPermissionInMetadata(AccessControlAction.PluginsWrite, plugin) ? [toEnableItem(card)] : [];
-  });
+  const toItems = (cards: RecommendedCardId[]): RecommendationItem[] =>
+    cards.flatMap((cardId): RecommendationItem[] => {
+      const card = cardsById[cardId];
+      if (card.kind === 'connection') {
+        // Independent of the plugin list: a failing /api/plugins must not hide a connection card.
+        return contextSrv.hasPermission(AccessControlAction.DataSourcesCreate) ? [{ ...card, cta: 'enable' }] : [];
+      }
+      if (!listReady) {
+        return [];
+      }
+      const plugin = pluginsById.get(card.pluginId);
+      if (!plugin) {
+        // Unlistable plugins take the install-only path.
+        return canInstall ? [toEnableItem(card)] : [];
+      }
+      if (plugin.enabled) {
+        // Selection already established the solution is silent; the setup CTA leads into the app,
+        // so it only renders for users who can open it.
+        return contextSrv.hasPermissionInMetadata(AccessControlAction.PluginsAppAccess, plugin)
+          ? [toSetupItem(card)]
+          : [];
+      }
+      // plugins:write is scoped to this plugin.
+      return contextSrv.hasPermissionInMetadata(AccessControlAction.PluginsWrite, plugin) ? [toEnableItem(card)] : [];
+    });
+
+  const recommendations = toItems(selection?.cards ?? []);
+  // Per-solution views are permutations of the same selection (membership is the matrix's
+  // call, never the view's), so the skeleton and region-hide gates below stay list-agnostic.
+  // The Record type keeps the literal in lockstep with EXISTING_SOLUTION_IDS.
+  const forSolution = (id: ExistingSolutionId) => toItems(orderCardsForSolution(selection?.cards ?? [], id));
+  const recommendationsBySolution: Record<ExistingSolutionId, RecommendationItem[]> = {
+    kubernetes: forSolution('kubernetes'),
+    metrics: forSolution('metrics'),
+    logs: forSolution('logs'),
+    traces: forSolution('traces'),
+  };
 
   // The region renders once state settles; recommendations only decide the right column.
   // Collapsed (gated-off) renders immediately as just the header row.
@@ -108,6 +127,7 @@ function GatedRecommendations({ canInstall }: GatedRecommendationsProps) {
   return (
     <RecommendationsView
       recommendations={recommendations}
+      recommendationsBySolution={recommendationsBySolution}
       startingState={selection?.baseRow ?? 'unknown'}
       collapsed={collapsed}
       setCollapsed={setCollapsed}

--- a/public/app/features/home/Recommendations/RecommendationsView.tsx
+++ b/public/app/features/home/Recommendations/RecommendationsView.tsx
@@ -8,11 +8,13 @@ import { Badge, Button, Grid, Icon, Stack, Text, useStyles2 } from '@grafana/ui'
 import { RecommendationCard } from './RecommendationCard';
 import { RecommendationExisting } from './RecommendationExisting';
 import { RecommendationPill } from './RecommendationPill';
-import { type BaseRow } from './solutionsMatrix';
+import { type BaseRow, type ExistingSolutionId } from './solutionsMatrix';
 import { type RecommendationItem } from './types';
 
 interface RecommendationsViewProps {
   recommendations: RecommendationItem[];
+  /** The same recommendations reordered per solution view; keyed by ExistingItem id. */
+  recommendationsBySolution: Record<ExistingSolutionId, RecommendationItem[]>;
   /** Matrix row that drove the selection; threaded into cta_clicked as starting_state. */
   startingState: BaseRow;
   /** Owned by the parent: the stored preference also gates the solution probes there. */
@@ -22,6 +24,7 @@ interface RecommendationsViewProps {
 
 export function RecommendationsView({
   recommendations,
+  recommendationsBySolution,
   startingState,
   collapsed,
   setCollapsed,
@@ -40,11 +43,21 @@ export function RecommendationsView({
   const [index, setIndex] = useState(0);
   const [paused, setPaused] = useState(() => window.matchMedia('(prefers-reduced-motion: reduce)').matches);
 
+  // The carousel follows the solution displayed on the left card (default selection included);
+  // undefined = no solution settled yet, so the global matrix order stands.
+  const [activeSolution, setActiveSolution] = useState<ExistingSolutionId>();
+  const items = activeSolution ? recommendationsBySolution[activeSolution] : recommendations;
+
+  // A solution switch restarts the carousel: the point of the swap is the new leading card.
+  useEffect(() => {
+    setIndex(0);
+  }, [activeSolution]);
+
   // Clamp during render so a shrinking list cannot select an undefined entry.
-  const safeIndex = Math.min(index, recommendations.length - 1);
-  const hasRecommendations = recommendations.length > 0;
+  const safeIndex = Math.min(index, items.length - 1);
+  const hasRecommendations = items.length > 0;
   // A single card needs no carousel controls and must not auto-advance onto itself.
-  const showControls = recommendations.length > 1;
+  const showControls = items.length > 1;
 
   useEffect(() => {
     if (collapsed || paused || !showControls) {
@@ -52,11 +65,11 @@ export function RecommendationsView({
     }
 
     const timeout = setTimeout(() => {
-      setIndex((safeIndex + 1) % recommendations.length);
+      setIndex((safeIndex + 1) % items.length);
     }, 5000);
 
     return () => clearTimeout(timeout);
-  }, [collapsed, paused, safeIndex, recommendations.length, showControls]);
+  }, [collapsed, paused, safeIndex, items.length, showControls]);
 
   return (
     <div>
@@ -68,11 +81,12 @@ export function RecommendationsView({
         {collapsed && hasRecommendations && (
           <div className={styles.pills}>
             <Stack direction="row" alignItems="center" gap={1} wrap="wrap">
-              {recommendations.map((recommendation) => (
+              {items.map((recommendation) => (
                 <RecommendationPill
                   key={recommendation.id}
                   recommendation={recommendation}
                   startingState={startingState}
+                  solution={activeSolution}
                 />
               ))}
             </Stack>
@@ -104,7 +118,7 @@ export function RecommendationsView({
         <div className={styles.cards} hidden={collapsed}>
           <Grid gap={0} columns={hasRecommendations ? { xs: 1, md: 2 } : 1}>
             <div className={styles.card}>
-              <RecommendationExisting />
+              <RecommendationExisting onSelectionChange={setActiveSolution} />
 
               {hasRecommendations && (
                 <div className={styles.arrow}>
@@ -130,11 +144,11 @@ export function RecommendationsView({
                         size="sm"
                         fill="text"
                         icon="angle-left"
-                        onClick={() => setIndex((safeIndex - 1 + recommendations.length) % recommendations.length)}
+                        onClick={() => setIndex((safeIndex - 1 + items.length) % items.length)}
                         aria-label={t('home.recommendations.previous', 'Previous')}
                       />
 
-                      {recommendations.map((_, i) =>
+                      {items.map((_, i) =>
                         i === safeIndex ? (
                           <Button
                             key={i}
@@ -171,7 +185,7 @@ export function RecommendationsView({
                         size="sm"
                         fill="text"
                         icon="angle-right"
-                        onClick={() => setIndex((safeIndex + 1) % recommendations.length)}
+                        onClick={() => setIndex((safeIndex + 1) % items.length)}
                         aria-label={t('home.recommendations.next', 'Next')}
                       />
                     </Stack>
@@ -180,14 +194,18 @@ export function RecommendationsView({
 
                 <div className={styles.outer}>
                   <div className={styles.inner} style={{ transform: `translateX(-${safeIndex * 100}%)` }}>
-                    {recommendations.map((recommendation, i) => (
+                    {items.map((recommendation, i) => (
                       <div
                         key={recommendation.id}
                         className={styles.item}
                         aria-hidden={i !== safeIndex}
                         {...(i !== safeIndex && { inert: '' })}
                       >
-                        <RecommendationCard recommendation={recommendation} startingState={startingState} />
+                        <RecommendationCard
+                          recommendation={recommendation}
+                          startingState={startingState}
+                          solution={activeSolution}
+                        />
                       </div>
                     ))}
                   </div>

--- a/public/app/features/home/Recommendations/appPluginIds.ts
+++ b/public/app/features/home/Recommendations/appPluginIds.ts
@@ -3,3 +3,4 @@ export const SYNTHETIC_MONITORING_APP_ID = 'grafana-synthetic-monitoring-app';
 export const APP_OBSERVABILITY_APP_ID = 'grafana-app-observability-app';
 export const HOSTED_TRACES_APP_ID = 'grafana-exploretraces-app';
 export const LOGS_DRILLDOWN_APP_ID = 'grafana-lokiexplore-app';
+export const METRICS_DRILLDOWN_APP_ID = 'grafana-metricsdrilldown-app';

--- a/public/app/features/home/Recommendations/buildKubernetesItem.ts
+++ b/public/app/features/home/Recommendations/buildKubernetesItem.ts
@@ -71,7 +71,7 @@ export function buildKubernetesItem(parts: KubernetesItemParts, settings: Plugin
   const hasInventoryStats = inventory !== undefined && (clusterCount > 0 || podCount > 0);
 
   return {
-    id: 'kubernetes-monitoring',
+    id: 'kubernetes',
     title: t('home.recommendations.kubernetes.title', 'Kubernetes Monitoring'),
     icon: 'kubernetes',
     subtitle: t('home.recommendations.kubernetes.datasource', 'via {{name}}', { name: parts.datasourceName }),

--- a/public/app/features/home/Recommendations/buildTelemetryItems.ts
+++ b/public/app/features/home/Recommendations/buildTelemetryItems.ts
@@ -2,7 +2,8 @@ import { type FieldSparkline, formattedValueToString, getValueFormat, locationUt
 import { t } from '@grafana/i18n';
 import { constructDataSourceExploreUrl } from 'app/features/datasources/utils';
 
-import { HOSTED_TRACES_APP_ID, LOGS_DRILLDOWN_APP_ID } from './appPluginIds';
+import { HOSTED_TRACES_APP_ID, LOGS_DRILLDOWN_APP_ID, METRICS_DRILLDOWN_APP_ID } from './appPluginIds';
+import { type MetricsDiskPressure } from './telemetryData';
 import { type ExistingItem } from './types';
 
 // Browser locale is the deliberate choice: the homepage number format follows the user's environment.
@@ -103,6 +104,105 @@ export function buildTracesItem(parts: TracesItemParts): ExistingItem {
       : t('home.recommendations.traces.action-explore', 'Open in Explore'),
     href: drilldown
       ? locationUtil.assureBaseUrl(`/a/${HOSTED_TRACES_APP_ID}`)
+      : constructDataSourceExploreUrl({ name: parts.datasourceName }),
+  };
+}
+
+export interface MetricsItemParts {
+  series: number | null;
+  names: number | null;
+  hosts: number | null;
+  seriesSparkline: FieldSparkline | null;
+  disk: MetricsDiskPressure | null;
+  datasourceName: string;
+  drilldownAvailable: boolean;
+}
+
+/** Build the Metrics & infrastructure entry from live Prometheus data; the caller guarantees something to show. */
+export function buildMetricsItem(parts: MetricsItemParts): ExistingItem {
+  const { series, names, hosts, disk } = parts;
+  const drilldown = parts.drilldownAvailable;
+  const secondary =
+    hosts != null
+      ? t('home.recommendations.metrics.stats-hosts', '', {
+          count: hosts,
+          defaultValue_one: 'active · {{count}} host',
+          defaultValue_other: 'active · {{count}} hosts',
+        })
+      : t('home.recommendations.metrics.stats', 'active');
+  let stats: ExistingItem['stats'];
+  if (series != null) {
+    stats = {
+      primary: t('home.recommendations.metrics.series', '', {
+        count: Math.ceil(series),
+        value: compactFormatter.format(Math.ceil(series)),
+        defaultValue_one: '{{value}} series',
+        defaultValue_other: '{{value}} series',
+      }),
+      secondary,
+    };
+  } else if (names != null) {
+    // Fallback primary: the distinct-name count when no active-series source responded.
+    stats = {
+      primary: t('home.recommendations.metrics.names', '', {
+        count: Math.ceil(names),
+        value: compactFormatter.format(Math.ceil(names)),
+        defaultValue_one: '{{value}} metric',
+        defaultValue_other: '{{value}} metrics',
+      }),
+      secondary,
+    };
+  }
+  const alertDetails: string[] = [];
+  if (disk?.worstInstance && disk.worstRatio != null) {
+    alertDetails.push(
+      t('home.recommendations.metrics.disk-worst', '{{host}} at {{percent}}%', {
+        // The design shows the bare host ("web-03"), not the scrape target ("web-03:9100").
+        host: disk.worstInstance.replace(/:\d+$/, ''),
+        percent: Math.round(disk.worstRatio * 100),
+      })
+    );
+  }
+  if (disk?.hoursToFull != null) {
+    alertDetails.push(
+      t('home.recommendations.metrics.disk-eta', '', {
+        count: Math.round(disk.hoursToFull),
+        defaultValue_one: '~{{count}} h to full',
+        defaultValue_other: '~{{count}} h to full',
+      })
+    );
+  }
+  return {
+    id: 'metrics',
+    title: t('home.recommendations.metrics.title', 'Metrics & infrastructure'),
+    icon: 'chart-line',
+    subtitle: t('home.recommendations.metrics.datasource', 'via {{name}}', { name: parts.datasourceName }),
+    stats,
+    sparkline: parts.seriesSparkline
+      ? {
+          series: parts.seriesSparkline,
+          caption: t('home.recommendations.metrics.series-trend', 'Active series · last 24h'),
+        }
+      : undefined,
+    alert:
+      disk != null && disk.hostsAbove > 0
+        ? {
+            primary: t('home.recommendations.metrics.disk-hosts', '', {
+              count: disk.hostsAbove,
+              defaultValue_one: '{{count}} host above 90% disk',
+              defaultValue_other: '{{count}} hosts above 90% disk',
+            }),
+            details: alertDetails,
+            action: t('home.recommendations.metrics.view', 'View'),
+            // No app route exists for host disk detail; Explore with the datasource preselected.
+            href: constructDataSourceExploreUrl({ name: parts.datasourceName }),
+          }
+        : undefined,
+    action: drilldown
+      ? t('home.recommendations.metrics.action', 'Open Metrics Drilldown')
+      : t('home.recommendations.metrics.action-explore', 'Open in Explore'),
+    href: drilldown
+      ? locationUtil.assureBaseUrl(`/a/${METRICS_DRILLDOWN_APP_ID}`)
       : constructDataSourceExploreUrl({ name: parts.datasourceName }),
   };
 }

--- a/public/app/features/home/Recommendations/promQuery.ts
+++ b/public/app/features/home/Recommendations/promQuery.ts
@@ -23,6 +23,20 @@ export function readScalar(frames: DataFrame[], refId: string): number | null {
   return typeof v === 'number' && Number.isFinite(v) ? v : null;
 }
 
+/** Last sample of the `refId` instant vector plus one identifying label off its number field. */
+export function readLabeledScalar(
+  frames: DataFrame[],
+  refId: string,
+  label: string
+): { value: number; label: string | null } | null {
+  const field = frames.find((f) => f.refId === refId)?.fields.find((f) => f.type === FieldType.number);
+  if (!field || field.values.length === 0) {
+    return null;
+  }
+  const v = field.values[field.values.length - 1];
+  return typeof v === 'number' && Number.isFinite(v) ? { value: v, label: field.labels?.[label] ?? null } : null;
+}
+
 // Extract the first usable time series for `refId` as a sparkline input. Requires a real series
 // (> 1 point) so a single-point instant/vector frame is rejected; skips frames whose time/number
 // fields are absent or length-mismatched rather than trusting the first refId match.

--- a/public/app/features/home/Recommendations/solutionState.test.ts
+++ b/public/app/features/home/Recommendations/solutionState.test.ts
@@ -145,6 +145,7 @@ describe('resolveSolutionState', () => {
     });
     expect(resolution.lokiDatasource).toBeNull();
     expect(resolution.tempoDatasource).toBeNull();
+    expect(resolution.prometheusDatasource).toBeNull();
   });
 
   it('never probes cloud utility datasources, even when they are all there is', async () => {
@@ -269,6 +270,24 @@ describe('resolveSolutionState', () => {
 
     expect(resolution.state.kubernetes).toBe('active');
     expect(resolution.state.metrics).toBe('active');
+  });
+
+  it('exposes the winning prometheus datasource, falling back to the kubernetes one', async () => {
+    const { promResource } = freshCloudFixture();
+    promResource.mockResolvedValue({ data: ['__name__'] });
+
+    let resolution = await resolveSolutionState();
+    expect(resolution.state.metrics).toBe('active');
+    expect(resolution.prometheusDatasource?.uid).toBe('prom-main');
+
+    // Metrics probe empty but kubernetes active: its (Prometheus) datasource carries the card.
+    resetSolutionStateResolution();
+    promResource.mockResolvedValue({ data: [] });
+    kubernetesMock.mockResolvedValue(listItem('prometheus', { uid: 'prom-k8s', name: 'k8s-prom' }));
+
+    resolution = await resolveSolutionState();
+    expect(resolution.state.metrics).toBe('active');
+    expect(resolution.prometheusDatasource?.uid).toBe('prom-k8s');
   });
 
   it('settles span metrics active when the probe finds series', async () => {

--- a/public/app/features/home/Recommendations/solutionState.ts
+++ b/public/app/features/home/Recommendations/solutionState.ts
@@ -36,6 +36,11 @@ export interface SolutionStateResolution {
   /** Datasources that won the logs/traces probes; null unless the signal is active. */
   lokiDatasource: DataSourceInstanceListItem | null;
   tempoDatasource: DataSourceInstanceListItem | null;
+  /**
+   * Datasource that won the metrics probe (or the kubernetes probe when kubernetes forced
+   * metrics active); null unless metrics is active.
+   */
+  prometheusDatasource: DataSourceInstanceListItem | null;
 }
 
 interface SignalResolution {
@@ -119,6 +124,9 @@ async function resolveAllSignals(): Promise<SolutionStateResolution> {
     },
     lokiDatasource: logs.datasource,
     tempoDatasource: traces.datasource,
+    // The kubernetes⇒metrics invariant can force metrics active with an empty metrics probe;
+    // the kubernetes datasource is a Prometheus (kube-state-metrics), so it carries the card.
+    prometheusDatasource: metrics.datasource ?? (kubernetes.status === 'active' ? kubernetes.datasource : null),
   };
 }
 

--- a/public/app/features/home/Recommendations/solutionsMatrix.test.ts
+++ b/public/app/features/home/Recommendations/solutionsMatrix.test.ts
@@ -1,8 +1,11 @@
 import {
   type BaseRow,
+  EXISTING_SOLUTION_IDS,
+  orderCardsForSolution,
   type RecommendedCardId,
   selectRecommendations,
   type SignalStatus,
+  SOLUTION_CARD_PRIORITY,
   type SolutionState,
 } from './solutionsMatrix';
 
@@ -68,5 +71,67 @@ describe('selectRecommendations', () => {
       cards: ['hosted-traces', 'kubernetes-monitoring'],
       baseRow: 'ml_no_traces',
     });
+  });
+});
+
+describe('orderCardsForSolution', () => {
+  const ALL_CARD_IDS: RecommendedCardId[] = [
+    'connect-metrics',
+    'enable-logs',
+    'enable-logs-k8s',
+    'hosted-traces',
+    'kubernetes-monitoring',
+    'application-observability',
+  ];
+
+  it('leads ml_no_traces with K8s Monitoring for metrics and Hosted Traces for logs', () => {
+    const { cards } = selectRecommendations(state(on, on, off, off));
+
+    expect(orderCardsForSolution(cards, 'metrics')).toEqual(['kubernetes-monitoring', 'hosted-traces']);
+    expect(orderCardsForSolution(cards, 'logs')).toEqual(['hosted-traces', 'kubernetes-monitoring']);
+  });
+
+  it('leads mlt with K8s Monitoring for metrics and App Observability for logs and traces', () => {
+    const { cards } = selectRecommendations(state(on, on, on, off));
+
+    expect(orderCardsForSolution(cards, 'metrics')).toEqual(['kubernetes-monitoring', 'application-observability']);
+    expect(orderCardsForSolution(cards, 'logs')).toEqual(['application-observability', 'kubernetes-monitoring']);
+    expect(orderCardsForSolution(cards, 'traces')).toEqual(['application-observability', 'kubernetes-monitoring']);
+  });
+
+  it('only reorders: every solution view yields a permutation of every reachable selection', () => {
+    // All 12 reachable core combinations (kubernetes ⇒ metrics removes 4 of 16).
+    const reachable: SolutionState[] = (['active', 'inactive'] as const).flatMap((m) =>
+      (['active', 'inactive'] as const).flatMap((l) =>
+        (['active', 'inactive'] as const).flatMap((t) =>
+          (['active', 'inactive'] as const)
+            .filter((k) => !(k === 'active' && m === 'inactive'))
+            .map((k) => state(m, l, t, k))
+        )
+      )
+    );
+    expect(reachable).toHaveLength(12);
+
+    for (const solutionState of reachable) {
+      const { cards } = selectRecommendations(solutionState);
+      for (const id of EXISTING_SOLUTION_IDS) {
+        const ordered = orderCardsForSolution(cards, id);
+        expect([...ordered].sort()).toEqual([...cards].sort());
+      }
+    }
+  });
+
+  it('holds a complete total order per solution: every card id exactly once', () => {
+    for (const id of EXISTING_SOLUTION_IDS) {
+      expect([...SOLUTION_CARD_PRIORITY[id]].sort()).toEqual([...ALL_CARD_IDS].sort());
+    }
+  });
+
+  it('never mutates its input', () => {
+    const cards: RecommendedCardId[] = ['hosted-traces', 'kubernetes-monitoring'];
+
+    orderCardsForSolution(cards, 'metrics');
+
+    expect(cards).toEqual(['hosted-traces', 'kubernetes-monitoring']);
   });
 });

--- a/public/app/features/home/Recommendations/solutionsMatrix.ts
+++ b/public/app/features/home/Recommendations/solutionsMatrix.ts
@@ -28,6 +28,65 @@ export type RecommendedCardId =
   | 'application-observability';
 
 /**
+ * Existing-solution ids the left card can display (ExistingItem.id values) — the KEYS of the
+ * priority table below. Distinct namespace from RecommendedCardId (the card ids inside the
+ * arrays).
+ */
+export const EXISTING_SOLUTION_IDS = ['kubernetes', 'metrics', 'logs', 'traces'] as const;
+export type ExistingSolutionId = (typeof EXISTING_SOLUTION_IDS)[number];
+
+// Complete total orders (every RecommendedCardId appears once) so the sort is deterministic;
+// gating means several entries are unreachable for a given solution, which is harmless.
+// Exported for the completeness invariant test only — consumers go through orderCardsForSolution.
+export const SOLUTION_CARD_PRIORITY: Record<ExistingSolutionId, readonly RecommendedCardId[]> = {
+  // Infra affinity: K8s Monitoring turns the metrics already flowing into curated views.
+  metrics: [
+    'enable-logs',
+    'enable-logs-k8s',
+    'kubernetes-monitoring',
+    'hosted-traces',
+    'application-observability',
+    'connect-metrics',
+  ],
+  // Logs↔traces correlation is the classic next step from logs.
+  logs: [
+    'connect-metrics',
+    'hosted-traces',
+    'application-observability',
+    'kubernetes-monitoring',
+    'enable-logs',
+    'enable-logs-k8s',
+  ],
+  // Traces are the App Observability foundation.
+  traces: [
+    'application-observability',
+    'connect-metrics',
+    'enable-logs',
+    'enable-logs-k8s',
+    'kubernetes-monitoring',
+    'hosted-traces',
+  ],
+  kubernetes: [
+    'enable-logs-k8s',
+    'enable-logs',
+    'hosted-traces',
+    'application-observability',
+    'connect-metrics',
+    'kubernetes-monitoring',
+  ],
+};
+
+/**
+ * Reorder a settled selection for the solution the user is viewing. Membership NEVER changes:
+ * the matrix's blocking rules (selectRecommendations) stay authoritative; a solution view only
+ * changes which of the selected cards leads the carousel.
+ */
+export function orderCardsForSolution(cards: RecommendedCardId[], solution: ExistingSolutionId): RecommendedCardId[] {
+  const priority = SOLUTION_CARD_PRIORITY[solution];
+  return [...cards].sort((a, b) => priority.indexOf(a) - priority.indexOf(b));
+}
+
+/**
  * Matrix row that drove the selection — a selection driver id for analytics
  * (`starting_state`), not a full state descriptor.
  */

--- a/public/app/features/home/Recommendations/telemetryData.test.ts
+++ b/public/app/features/home/Recommendations/telemetryData.test.ts
@@ -1,12 +1,26 @@
-import { type DataSourceInstanceListItem } from '@grafana/data';
+import { createDataFrame, type DataSourceInstanceListItem, FieldType } from '@grafana/data';
 import { type BackendSrv, type DataSourceWithBackend, getBackendSrv } from '@grafana/runtime';
 
 import { resolveBackendInstance } from './probeUtils';
-import { fetchLogsActivity, fetchTracesActivity, fetchTracesServices, LOGS_STATS_LOOKBACK_DAYS } from './telemetryData';
+import { runInstantQueries, runRangeQuery } from './promQuery';
+import {
+  fetchLogsActivity,
+  fetchMetricsActivity,
+  fetchTracesActivity,
+  fetchTracesServices,
+  LOGS_STATS_LOOKBACK_DAYS,
+  METRICS_STATS_LOOKBACK_DAYS,
+} from './telemetryData';
 
 jest.mock('./probeUtils', () => ({
   ...jest.requireActual('./probeUtils'),
   resolveBackendInstance: jest.fn(),
+}));
+
+jest.mock('./promQuery', () => ({
+  ...jest.requireActual('./promQuery'),
+  runInstantQueries: jest.fn(),
+  runRangeQuery: jest.fn(),
 }));
 
 jest.mock('@grafana/runtime', () => ({
@@ -15,6 +29,8 @@ jest.mock('@grafana/runtime', () => ({
 }));
 
 const mockResolveBackendInstance = jest.mocked(resolveBackendInstance);
+const mockRunInstantQueries = jest.mocked(runInstantQueries);
+const mockRunRangeQuery = jest.mocked(runRangeQuery);
 const mockProxyGet = jest.fn();
 
 const DATA_LOOKBACK_HOURS = 24;
@@ -32,6 +48,10 @@ beforeEach(() => {
   jest.setSystemTime(new Date('2026-07-24T12:00:00Z'));
   mockResolveBackendInstance.mockReset();
   mockProxyGet.mockReset();
+  mockRunInstantQueries.mockReset();
+  mockRunInstantQueries.mockResolvedValue([]);
+  mockRunRangeQuery.mockReset();
+  mockRunRangeQuery.mockResolvedValue([]);
   jest.mocked(getBackendSrv).mockReturnValue({ get: mockProxyGet } as unknown as BackendSrv);
 });
 
@@ -227,5 +247,158 @@ describe('fetchTracesActivity', () => {
     mockProxyGet.mockResolvedValue({ series: [] });
 
     await expect(fetchTracesActivity(tempo)).resolves.toEqual({ spans: null, series: null });
+  });
+});
+
+describe('fetchMetricsActivity', () => {
+  const prom = { uid: 'prom-uid', type: 'prometheus' };
+
+  const scalarFrame = (refId: string, value: number, labels?: Record<string, string>) =>
+    createDataFrame({ refId, fields: [{ name: 'Value', type: FieldType.number, values: [value], labels }] });
+
+  it('reads cardinality, name count, hosts, disk pressure, and the series sparkline', async () => {
+    const getResource = jest.fn(async (path: string) => {
+      if (path === 'api/v1/cardinality/label_values') {
+        return { series_count_total: 4_200_000 };
+      }
+      if (path === 'api/v1/label/__name__/values') {
+        return { data: ['up', 'node_cpu_seconds_total', 'node_uname_info'] };
+      }
+      throw new Error(`unexpected path ${path}`);
+    });
+    mockResolveBackendInstance.mockResolvedValue(instanceWith(getResource));
+    mockRunRangeQuery.mockResolvedValue([
+      createDataFrame({
+        refId: 'series',
+        fields: [
+          { name: 'Time', type: FieldType.time, values: [1_000, 2_000] },
+          { name: 'Value', type: FieldType.number, values: [10, 20] },
+        ],
+      }),
+    ]);
+    mockRunInstantQueries.mockImplementation(async (queries) =>
+      'eta' in queries
+        ? [scalarFrame('eta', 6.4)]
+        : [
+            scalarFrame('hosts', 12),
+            scalarFrame('diskHosts', 3),
+            scalarFrame('diskWorst', 0.96, { instance: 'web-03:9100' }),
+          ]
+    );
+
+    const activity = await fetchMetricsActivity(prom);
+
+    expect(activity.series).toBe(4_200_000);
+    expect(activity.names).toBe(3);
+    expect(activity.hosts).toBe(12);
+    expect(activity.seriesSparkline?.y.values).toEqual([10, 20]);
+    expect(activity.disk).toEqual({
+      hostsAbove: 3,
+      worstInstance: 'web-03:9100',
+      worstRatio: 0.96,
+      hoursToFull: 6.4,
+    });
+
+    const end = Math.floor(Date.now() / 1000);
+    expect(getResource).toHaveBeenCalledWith(
+      'api/v1/label/__name__/values',
+      { start: end - METRICS_STATS_LOOKBACK_DAYS * 24 * 3600, end },
+      { showErrorAlert: false }
+    );
+    expect(mockRunRangeQuery).toHaveBeenCalledWith(
+      'series',
+      'sum(prometheus_tsdb_head_series)',
+      DATA_LOOKBACK_HOURS,
+      prom
+    );
+    // The follow-up ETA query pins the worst host by its full instance label.
+    expect(mockRunInstantQueries).toHaveBeenCalledWith(
+      { eta: expect.stringContaining('instance="web-03:9100"') },
+      prom
+    );
+  });
+
+  it('falls back to TSDB head stats when the cardinality API is unavailable', async () => {
+    const getResource = jest.fn(async (path: string) => {
+      if (path === 'api/v1/cardinality/label_values') {
+        throw new Error('unsupported');
+      }
+      if (path === 'api/v1/status/tsdb') {
+        return { data: { headStats: { numSeries: 987 } } };
+      }
+      return { data: ['up'] };
+    });
+    mockResolveBackendInstance.mockResolvedValue(instanceWith(getResource));
+
+    const promise = fetchMetricsActivity(prom);
+    // withRetry sleeps between cardinality attempts; drive the fake timers past them.
+    await jest.advanceTimersByTimeAsync(5_000);
+
+    await expect(promise).resolves.toMatchObject({ series: 987, names: 1 });
+  });
+
+  it('keeps the name count when both active-series sources fail', async () => {
+    const getResource = jest.fn(async (path: string) => {
+      if (path === 'api/v1/label/__name__/values') {
+        return { data: ['up', 'process_cpu_seconds_total'] };
+      }
+      throw new Error('unsupported');
+    });
+    mockResolveBackendInstance.mockResolvedValue(instanceWith(getResource));
+
+    const promise = fetchMetricsActivity(prom);
+    await jest.advanceTimersByTimeAsync(10_000);
+
+    await expect(promise).resolves.toMatchObject({ series: null, names: 2 });
+  });
+
+  it('reports no disk pressure and skips the ETA query when nobody is above threshold', async () => {
+    const getResource = jest.fn(async () => ({ data: [] }));
+    mockResolveBackendInstance.mockResolvedValue(instanceWith(getResource));
+    // count() over an empty vector returns an empty result, not zero: no diskHosts frame.
+    mockRunInstantQueries.mockResolvedValue([scalarFrame('hosts', 12)]);
+
+    const promise = fetchMetricsActivity(prom);
+    await jest.advanceTimersByTimeAsync(10_000);
+    const activity = await promise;
+
+    expect(activity.hosts).toBe(12);
+    expect(activity.disk).toBeNull();
+    expect(mockRunInstantQueries).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([90, 0])('drops a meaningless linear ETA (%s h)', async (eta) => {
+    const getResource = jest.fn(async () => ({ data: [] }));
+    mockResolveBackendInstance.mockResolvedValue(instanceWith(getResource));
+    mockRunInstantQueries.mockImplementation(async (queries) =>
+      'eta' in queries
+        ? [scalarFrame('eta', eta)]
+        : [scalarFrame('diskHosts', 1), scalarFrame('diskWorst', 0.93, { instance: 'db-01:9100' })]
+    );
+
+    const promise = fetchMetricsActivity(prom);
+    await jest.advanceTimersByTimeAsync(10_000);
+    const activity = await promise;
+
+    expect(activity.disk).toEqual({
+      hostsAbove: 1,
+      worstInstance: 'db-01:9100',
+      worstRatio: 0.93,
+      hoursToFull: null,
+    });
+  });
+
+  it('resolves all-null without querying when the datasource has no backend instance', async () => {
+    mockResolveBackendInstance.mockResolvedValue(null);
+
+    await expect(fetchMetricsActivity(prom)).resolves.toEqual({
+      series: null,
+      names: null,
+      hosts: null,
+      seriesSparkline: null,
+      disk: null,
+    });
+    expect(mockRunInstantQueries).not.toHaveBeenCalled();
+    expect(mockRunRangeQuery).not.toHaveBeenCalled();
   });
 });

--- a/public/app/features/home/Recommendations/telemetryData.ts
+++ b/public/app/features/home/Recommendations/telemetryData.ts
@@ -8,10 +8,14 @@ import {
 import { type DataSourceWithBackend } from '@grafana/runtime';
 
 import { probeProxyGet, PROBE_TIMEOUT_MS, resolveBackendInstance, withRetry, withTimeout } from './probeUtils';
+import { readLabeledScalar, readScalar, readSeries, runInstantQueries, runRangeQuery } from './promQuery';
 import { DATA_LOOKBACK_HOURS } from './solutionDataProbes';
 
 /** Stats window for the logs card (design-fixed), distinct from the 24h sparkline lookback. */
 export const LOGS_STATS_LOOKBACK_DAYS = 7;
+
+/** Stats window for the metric-name fallback count (design-fixed), distinct from the 24h lookback. */
+export const METRICS_STATS_LOOKBACK_DAYS = 7;
 
 const NS_IN_MS = 1e6;
 const NS_IN_S = 1e9;
@@ -165,4 +169,126 @@ export async function fetchTracesActivity(ds: Pick<DataSourceInstanceListItem, '
     spans: buckets.size > 0 ? [...buckets.values()].reduce((total, value) => total + value, 0) : null,
     series: toSparkline([...buckets.entries()], 'Span throughput'),
   };
+}
+
+export interface MetricsDiskPressure {
+  /** Hosts whose fullest filesystem exceeds the pressure threshold. */
+  hostsAbove: number;
+  worstInstance: string | null;
+  /** 0..1 fill ratio of the worst host. */
+  worstRatio: number | null;
+  /** Linear fill ETA for the worst host; null when not shrinking or beyond the clamp. */
+  hoursToFull: number | null;
+}
+
+export interface MetricsActivity {
+  /** Active series (cardinality API / TSDB head stats). */
+  series: number | null;
+  /** Distinct metric names over the stats window (fallback primary). */
+  names: number | null;
+  /** node_exporter host count. */
+  hosts: number | null;
+  /** Active-series trend over the last 24h. */
+  seriesSparkline: FieldSparkline | null;
+  /** null when below threshold or node metrics absent. */
+  disk: MetricsDiskPressure | null;
+}
+
+// Threshold and ETA clamp for the disk-pressure alert row (design/judgment constants).
+const DISK_PRESSURE_RATIO = 0.9;
+const DISK_ETA_MAX_HOURS = 48;
+
+const FS_EXCLUDE = 'fstype!~"tmpfs|overlay|squashfs|iso9660|ramfs"';
+// Fullest-filesystem fill ratio per host; pseudo filesystems excluded.
+const FS_USED = `(1 - node_filesystem_avail_bytes{${FS_EXCLUDE}} / node_filesystem_size_bytes{${FS_EXCLUDE}})`;
+
+// Active series, cloud-first: Mimir's cardinality API, then vanilla Prometheus TSDB head stats.
+// Both absent/broken → null and the metric-name count carries the card instead.
+async function fetchActiveSeries(instance: DataSourceWithBackend): Promise<number | null> {
+  const cardinality = await getResource<{ series_count_total?: unknown }>(instance, 'api/v1/cardinality/label_values', {
+    'label_names[]': '__name__',
+  })
+    .then((res) => Number(res?.series_count_total))
+    .catch(() => null);
+  if (cardinality != null && Number.isFinite(cardinality) && cardinality > 0) {
+    return cardinality;
+  }
+  const headSeries = await getResource<{ data?: { headStats?: { numSeries?: unknown } } }>(
+    instance,
+    'api/v1/status/tsdb',
+    {}
+  )
+    .then((res) => Number(res?.data?.headStats?.numSeries))
+    .catch(() => null);
+  return headSeries != null && Number.isFinite(headSeries) && headSeries > 0 ? headSeries : null;
+}
+
+// Linear ETA until the worst host's fastest-shrinking filesystem fills. Growing/steady
+// filesystems drop out via `> 0`; past the clamp a linear estimate is noise.
+async function fetchDiskHoursToFull(
+  instanceLabel: string,
+  ds: Pick<DataSourceInstanceListItem, 'uid' | 'type'>
+): Promise<number | null> {
+  const escaped = instanceLabel.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  const selector = `{instance="${escaped}",${FS_EXCLUDE}}`;
+  const hours = await runInstantQueries(
+    {
+      eta: `min((node_filesystem_avail_bytes${selector} / -deriv(node_filesystem_avail_bytes${selector}[6h])) > 0) / 3600`,
+    },
+    ds
+  )
+    .then((frames) => readScalar(frames, 'eta'))
+    .catch(() => null);
+  return hours != null && hours > 0 && hours <= DISK_ETA_MAX_HOURS ? hours : null;
+}
+
+/**
+ * Active-series count, metric-name count, node_exporter host count, the 24h active-series
+ * sparkline, and disk pressure for the worst host. Every field fails soft to null; the card
+ * drops when nothing renderable remains. Never a matcher-less series query — cardinality on
+ * large tenants is prohibitive.
+ */
+export async function fetchMetricsActivity(
+  ds: Pick<DataSourceInstanceListItem, 'uid' | 'type'>
+): Promise<MetricsActivity> {
+  const empty: MetricsActivity = { series: null, names: null, hosts: null, seriesSparkline: null, disk: null };
+  const instance = await resolveBackendInstance(ds.uid);
+  if (!instance) {
+    return empty;
+  }
+  // Prometheus resource calls take epoch seconds (unlike Loki's nanoseconds above).
+  const end = Math.floor(Date.now() / 1000);
+  const start = end - METRICS_STATS_LOOKBACK_DAYS * 24 * 3600;
+  const [series, names, seriesSparkline, healthFrames] = await Promise.all([
+    fetchActiveSeries(instance),
+    getResource<{ data?: unknown }>(instance, 'api/v1/label/__name__/values', { start, end })
+      .then((res) => (Array.isArray(res?.data) ? res.data.length : null))
+      .catch(() => null),
+    runRangeQuery('series', 'sum(prometheus_tsdb_head_series)', DATA_LOOKBACK_HOURS, ds)
+      .then((frames) => readSeries(frames, 'series'))
+      .catch(() => null),
+    runInstantQueries(
+      {
+        hosts: 'count(node_uname_info)',
+        diskHosts: `count(max by (instance) (${FS_USED}) > ${DISK_PRESSURE_RATIO})`,
+        diskWorst: `topk(1, max by (instance) (${FS_USED}))`,
+      },
+      ds
+    ).catch(() => null),
+  ]);
+  const hosts = healthFrames ? readScalar(healthFrames, 'hosts') : null;
+  // Empty diskHosts vector (nobody above threshold) reads as null — zero here.
+  const hostsAbove = healthFrames ? (readScalar(healthFrames, 'diskHosts') ?? 0) : 0;
+  const worst = healthFrames ? readLabeledScalar(healthFrames, 'diskWorst', 'instance') : null;
+  let disk: MetricsDiskPressure | null = null;
+  if (hostsAbove >= 1) {
+    const worstInstance = worst?.label ?? null;
+    disk = {
+      hostsAbove,
+      worstInstance,
+      worstRatio: worst?.value ?? null,
+      hoursToFull: worstInstance ? await fetchDiskHoursToFull(worstInstance, ds) : null,
+    };
+  }
+  return { series, names, hosts, seriesSparkline, disk };
 }

--- a/public/app/features/home/Recommendations/types.ts
+++ b/public/app/features/home/Recommendations/types.ts
@@ -1,6 +1,7 @@
 import { type GrafanaTheme2, type IconName } from '@grafana/data';
 
 import { type SolutionSparklineData } from './SolutionSparkline';
+import { type ExistingSolutionId } from './solutionsMatrix';
 
 export interface RecommendationItem {
   id: string; // stable telemetry id (recommendation_id)
@@ -16,7 +17,7 @@ export interface RecommendationItem {
 }
 
 export interface ExistingItem {
-  id: string; // stable telemetry id (solution)
+  id: ExistingSolutionId; // stable telemetry id (solution)
   title: string;
   icon: IconName;
   subtitle?: string;

--- a/public/app/features/home/Recommendations/useExistingSolutions.test.ts
+++ b/public/app/features/home/Recommendations/useExistingSolutions.test.ts
@@ -17,10 +17,18 @@ const mockUseKubernetesSolution = jest.mocked(useKubernetesSolution);
 const mockUseTelemetrySolutions = jest.mocked(useTelemetrySolutions);
 
 const kubernetesItem: ExistingItem = {
-  id: 'kubernetes-monitoring',
+  id: 'kubernetes',
   title: 'Kubernetes Monitoring',
   icon: 'kubernetes',
   action: 'Open K8s app',
+  href: '#',
+};
+
+const metricsItem: ExistingItem = {
+  id: 'metrics',
+  title: 'Metrics & infrastructure',
+  icon: 'chart-line',
+  action: 'Open Metrics Drilldown',
   href: '#',
 };
 
@@ -44,7 +52,7 @@ const settled = (item: ExistingItem | null) => ({ loading: false, item });
 
 beforeEach(() => {
   mockUseKubernetesSolution.mockReturnValue(settled(null));
-  mockUseTelemetrySolutions.mockReturnValue({ logs: settled(null), traces: settled(null) });
+  mockUseTelemetrySolutions.mockReturnValue({ metrics: settled(null), logs: settled(null), traces: settled(null) });
 });
 
 describe('useExistingSolutions', () => {
@@ -57,7 +65,11 @@ describe('useExistingSolutions', () => {
   });
 
   it('reports loading while a telemetry provider is still resolving', () => {
-    mockUseTelemetrySolutions.mockReturnValue({ logs: { loading: true, item: null }, traces: settled(null) });
+    mockUseTelemetrySolutions.mockReturnValue({
+      metrics: settled(null),
+      logs: { loading: true, item: null },
+      traces: settled(null),
+    });
 
     const { result } = renderHook(() => useExistingSolutions());
 
@@ -78,18 +90,26 @@ describe('useExistingSolutions', () => {
     expect(result.current).toEqual({ loading: false, solutions: [kubernetesItem] });
   });
 
-  it('orders solutions kubernetes, logs, traces with no duplicates', () => {
+  it('orders solutions kubernetes, metrics, logs, traces with no duplicates', () => {
     mockUseKubernetesSolution.mockReturnValue(settled(kubernetesItem));
-    mockUseTelemetrySolutions.mockReturnValue({ logs: settled(logsItem), traces: settled(tracesItem) });
+    mockUseTelemetrySolutions.mockReturnValue({
+      metrics: settled(metricsItem),
+      logs: settled(logsItem),
+      traces: settled(tracesItem),
+    });
 
     const { result } = renderHook(() => useExistingSolutions());
 
-    expect(result.current.solutions).toEqual([kubernetesItem, logsItem, tracesItem]);
+    expect(result.current.solutions).toEqual([kubernetesItem, metricsItem, logsItem, tracesItem]);
   });
 
   it('renders a discovered solution immediately even if a provider still reports loading', () => {
     mockUseKubernetesSolution.mockReturnValue({ loading: true, item: null });
-    mockUseTelemetrySolutions.mockReturnValue({ logs: settled(logsItem), traces: settled(null) });
+    mockUseTelemetrySolutions.mockReturnValue({
+      metrics: settled(null),
+      logs: settled(logsItem),
+      traces: settled(null),
+    });
 
     const { result } = renderHook(() => useExistingSolutions());
 

--- a/public/app/features/home/Recommendations/useExistingSolutions.ts
+++ b/public/app/features/home/Recommendations/useExistingSolutions.ts
@@ -14,10 +14,10 @@ export interface ExistingSolutionsResult {
  */
 export function useExistingSolutions(): ExistingSolutionsResult {
   const kubernetes = useKubernetesSolution();
-  const { logs, traces } = useTelemetrySolutions();
+  const { metrics, logs, traces } = useTelemetrySolutions();
 
-  // UI order: kubernetes, logs, traces.
-  const providers: ExistingSolutionProviderResult[] = [kubernetes, logs, traces];
+  // UI order: kubernetes, metrics, logs, traces.
+  const providers: ExistingSolutionProviderResult[] = [kubernetes, metrics, logs, traces];
 
   const solutions = providers.flatMap((provider) => (provider.item ? [provider.item] : []));
   // A discovered solution renders immediately; the empty state waits for every

--- a/public/app/features/home/Recommendations/useTelemetrySolutions.ts
+++ b/public/app/features/home/Recommendations/useTelemetrySolutions.ts
@@ -2,20 +2,21 @@ import { useAsync } from 'react-use';
 
 import { useAppPluginMetas } from '@grafana/runtime/internal';
 
-import { HOSTED_TRACES_APP_ID, LOGS_DRILLDOWN_APP_ID } from './appPluginIds';
-import { buildLogsItem, buildTracesItem } from './buildTelemetryItems';
+import { HOSTED_TRACES_APP_ID, LOGS_DRILLDOWN_APP_ID, METRICS_DRILLDOWN_APP_ID } from './appPluginIds';
+import { buildLogsItem, buildMetricsItem, buildTracesItem } from './buildTelemetryItems';
 import { useSolutionState } from './solutionState';
-import { fetchLogsActivity, fetchTracesActivity, fetchTracesServices } from './telemetryData';
+import { fetchLogsActivity, fetchMetricsActivity, fetchTracesActivity, fetchTracesServices } from './telemetryData';
 import { type ExistingSolutionProviderResult } from './types';
 
 export interface TelemetrySolutions {
+  metrics: ExistingSolutionProviderResult;
   logs: ExistingSolutionProviderResult;
   traces: ExistingSolutionProviderResult;
 }
 
 /**
- * Logs and Traces solution providers: an entry appears only for a confirmed-active signal
- * ('unknown' never invents one) AND when its detail fetches produced something to show —
+ * Metrics, Logs and Traces solution providers: an entry appears only for a confirmed-active
+ * signal ('unknown' never invents one) AND when its detail fetches produced something to show —
  * a bare title card with every stat failed-soft reads as broken, so it is dropped instead.
  */
 export function useTelemetrySolutions(): TelemetrySolutions {
@@ -24,13 +25,39 @@ export function useTelemetrySolutions(): TelemetrySolutions {
   const { value: appMetas } = useAppPluginMetas();
   const availableApps = new Set((appMetas ?? []).map((app) => app.id));
 
+  const promDs = resolution?.state.metrics === 'active' ? resolution.prometheusDatasource : null;
   const lokiDs = resolution?.state.logs === 'active' ? resolution.lokiDatasource : null;
   const tempoDs = resolution?.state.traces === 'active' ? resolution.tempoDatasource : null;
 
   // Gate inside the callbacks (ds in the deps): an inactive or unknown signal never queries.
+  const metricsActivity = useAsync(async () => (promDs ? fetchMetricsActivity(promDs) : undefined), [promDs]);
   const logsActivity = useAsync(async () => (lokiDs ? fetchLogsActivity(lokiDs) : undefined), [lokiDs]);
   const tracesActivity = useAsync(async () => (tempoDs ? fetchTracesActivity(tempoDs) : undefined), [tempoDs]);
   const tracesServices = useAsync(async () => (tempoDs ? fetchTracesServices(tempoDs) : undefined), [tempoDs]);
+
+  let metrics: ExistingSolutionProviderResult = { loading: stateLoading, item: null };
+  if (promDs) {
+    const activity = metricsActivity.value;
+    // Hosts/disk are secondary/alert content; without a series count, name count, or sparkline
+    // there is nothing to carry the card.
+    metrics =
+      metricsActivity.loading || !activity
+        ? { loading: metricsActivity.loading, item: null }
+        : activity.series == null && activity.names == null && activity.seriesSparkline == null
+          ? { loading: false, item: null }
+          : {
+              loading: false,
+              item: buildMetricsItem({
+                series: activity.series,
+                names: activity.names,
+                hosts: activity.hosts,
+                seriesSparkline: activity.seriesSparkline,
+                disk: activity.disk,
+                datasourceName: promDs.name,
+                drilldownAvailable: availableApps.has(METRICS_DRILLDOWN_APP_ID),
+              }),
+            };
+  }
 
   let logs: ExistingSolutionProviderResult = { loading: stateLoading, item: null };
   if (lokiDs) {
@@ -74,5 +101,5 @@ export function useTelemetrySolutions(): TelemetrySolutions {
             };
   }
 
-  return { logs, traces };
+  return { metrics, logs, traces };
 }

--- a/public/app/features/home/analytics/types.ts
+++ b/public/app/features/home/analytics/types.ts
@@ -51,6 +51,10 @@ export interface CtaClicked extends EventProperty {
    * values are the BaseRow union in solutionsMatrix.ts.
    */
   starting_state?: string;
-  /** Stable id of the solution whose control was clicked (surfaces 'existing_solution' and 'no_data_card' only). */
+  /**
+   * Stable id of the solution whose control was clicked (surfaces 'existing_solution' and
+   * 'no_data_card'). Also valid for surface 'recommendations', where it carries the solution
+   * view active when the card/pill was clicked.
+   */
   solution?: string;
 }

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -11045,6 +11045,26 @@
         "title": "Hosted Logs",
         "volume": "Ingest volume · last 24h"
       },
+      "metrics": {
+        "action": "Open Metrics Drilldown",
+        "action-explore": "Open in Explore",
+        "datasource": "via {{name}}",
+        "disk-eta_one": "~{{count}} h to full",
+        "disk-eta_other": "~{{count}} h to full",
+        "disk-hosts_one": "{{count}} host above 90% disk",
+        "disk-hosts_other": "{{count}} hosts above 90% disk",
+        "disk-worst": "{{host}} at {{percent}}%",
+        "names_one": "{{value}} metric",
+        "names_other": "{{value}} metrics",
+        "series_one": "{{value}} series",
+        "series_other": "{{value}} series",
+        "series-trend": "Active series · last 24h",
+        "stats": "active",
+        "stats-hosts_one": "active · {{count}} host",
+        "stats-hosts_other": "active · {{count}} hosts",
+        "title": "Metrics & infrastructure",
+        "view": "View"
+      },
       "next": "Next",
       "no-data": {
         "badge": "Getting started",


### PR DESCRIPTION
**What is this feature?**

Adds the Metrics & infrastructure left-card with activity stats and a sparkline, and makes the carousel reorder per selected solution via the matrix priority tables.

**Special notes for your reviewer:**

Only the card order changes with the selected solution — the matrix blocking rules keep deciding membership.