### PR TITLE
Home: Health-filter probe candidates and drop the retry machinery

### DIFF
--- a/public/app/features/home/Recommendations/kubernetesData.test.ts
+++ b/public/app/features/home/Recommendations/kubernetesData.test.ts
@@ -9,7 +9,7 @@ import {
   type PanelData,
   type QueryRunner,
 } from '@grafana/data';
-import { config, createQueryRunner } from '@grafana/runtime';
+import { type BackendSrv, config, createQueryRunner, getBackendSrv } from '@grafana/runtime';
 import { getDataSourceInstanceList } from '@grafana/runtime/unstable';
 
 import {
@@ -23,6 +23,7 @@ import {
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
   createQueryRunner: jest.fn(),
+  getBackendSrv: jest.fn(),
 }));
 
 jest.mock('@grafana/runtime/unstable', () => ({
@@ -35,6 +36,7 @@ const mockGetDataSourceInstanceList = jest.mocked(getDataSourceInstanceList);
 
 const run = jest.fn();
 const destroy = jest.fn();
+const healthGet = jest.fn();
 
 // Mirrors the k8s app's persisted-choice key (grafana-k8s-app src/constants.ts K8S_STORAGE_KEY).
 const K8S_APP_STORAGE_KEY = 'grafana.k8s-app.navigation.storage';
@@ -62,12 +64,9 @@ let probeHangUids: Set<string>;
 // Probe queries against these uids emit LoadingState.Error for the first N attempts.
 let probeFailuresByUid: Record<string, number>;
 let probeAttempts: Record<string, number>;
-// Non-probe query batches: emit LoadingState.Error for the first N attempts per refId (keyed by first refId).
-let queryFailuresByRefId: Record<string, number>;
 // Non-probe query batches: always emit LoadingState.Error.
 let queryErrorRefIds: Set<string>;
 let valuesByRefId: Record<string, number>;
-let queryAttempts: Record<string, number>;
 
 type CapturedRun = { datasource: { uid: string }; queries: Array<{ refId: string; expr: string }> };
 
@@ -80,6 +79,10 @@ beforeEach(() => {
   destroy.mockReset();
   mockCreateQueryRunner.mockReset();
   mockGetDataSourceInstanceList.mockReset();
+  healthGet.mockReset();
+  // Health pre-filter: every candidate healthy unless a test overrides by uid.
+  healthGet.mockResolvedValue({ status: 'OK' });
+  jest.mocked(getBackendSrv).mockReturnValue({ get: healthGet } as unknown as BackendSrv);
   window.localStorage.clear();
   resetKubernetesPrometheusResolution();
   dataByUid = {};
@@ -87,10 +90,8 @@ beforeEach(() => {
   probeHangUids = new Set();
   probeFailuresByUid = {};
   probeAttempts = {};
-  queryFailuresByRefId = {};
   queryErrorRefIds = new Set();
   valuesByRefId = {};
-  queryAttempts = {};
   mockCreateQueryRunner.mockImplementation(() => {
     // Per-runner capture: parallel probes each get their own runner, so a shared variable would race.
     let captured: CapturedRun | undefined;
@@ -111,15 +112,8 @@ beforeEach(() => {
             return of({ state: LoadingState.Error, series: [] as DataFrame[], timeRange: {} } as PanelData);
           }
         }
-        if (!isProbe && captured) {
-          const batchKey = captured.queries[0]?.refId ?? '';
-          queryAttempts[batchKey] = (queryAttempts[batchKey] ?? 0) + 1;
-          const maxTransientFailures = Math.max(0, ...captured.queries.map((q) => queryFailuresByRefId[q.refId] ?? 0));
-          const errorTransient = maxTransientFailures > 0 && queryAttempts[batchKey] <= maxTransientFailures;
-          const errorAlways = captured.queries.some((q) => queryErrorRefIds.has(q.refId));
-          if (errorAlways || errorTransient) {
-            return of({ state: LoadingState.Error, series: [] as DataFrame[], timeRange: {} } as PanelData);
-          }
+        if (!isProbe && captured?.queries.some((q) => queryErrorRefIds.has(q.refId))) {
+          return of({ state: LoadingState.Error, series: [] as DataFrame[], timeRange: {} } as PanelData);
         }
         const count = dataByUid[uid] ?? 0;
         let series: DataFrame[] = [];
@@ -220,6 +214,24 @@ describe('Kubernetes Prometheus resolution', () => {
     expect(inventoryCalls()[0][0].datasource.uid).toBe('team-uid');
     const probedUids = probeCalls().map(([o]) => o.datasource.uid);
     expect(probedUids).toEqual(expect.arrayContaining(['default-uid', 'team-uid']));
+  });
+
+  it('skips an unhealthy datasource before probing', async () => {
+    setDataSources([
+      { uid: 'default-uid', name: 'default-prom', isDefault: true },
+      { uid: 'team-uid', name: 'team-prom' },
+    ]);
+    dataByUid = { 'default-uid': 5, 'team-uid': 1 };
+    healthGet.mockImplementation(async (url: string) =>
+      url.includes('default-uid') ? { status: 'ERROR' } : { status: 'OK' }
+    );
+
+    const inventory = await fetchKubernetesInventory();
+
+    expect(inventoryCalls()[0][0].datasource.uid).toBe('team-uid');
+    expect(inventory.clusters).toBe(1);
+    // The unhealthy datasource is dropped before the namespace probe ever runs.
+    expect(probeCalls().map(([o]) => o.datasource.uid)).toEqual(['team-uid']);
   });
 
   it('falls through to the first sibling in list order when several have data', async () => {
@@ -458,7 +470,7 @@ describe('Kubernetes Prometheus resolution', () => {
     }
   });
 
-  it('an errored leader probe falls through to the fan-out without retrying', async () => {
+  it('an errored probe reads as no data and a sibling wins', async () => {
     setDataSources([
       { uid: 'default-uid', name: 'default-prom', isDefault: true },
       { uid: 'team-uid', name: 'team-prom' },
@@ -483,73 +495,8 @@ describe('Kubernetes Prometheus resolution', () => {
     dataByUid = { 'a-uid': 3, 'b-uid': 3 };
     probeErrorUids = new Set(['a-uid', 'b-uid']);
 
-    await expect(fetchKubernetesInventory()).rejects.toThrow(/prometheus datasource probe\(s\) failed/);
+    await expect(fetchKubernetesInventory()).rejects.toThrow('No Prometheus datasource with Kubernetes data');
     expect(inventoryCalls()).toHaveLength(0);
-  });
-
-  it('probes only the leader when the top-priority datasource has data', async () => {
-    setDataSources([
-      { uid: 'default-uid', name: 'default-prom', isDefault: true },
-      { uid: 'team-uid', name: 'team-prom' },
-    ]);
-    dataByUid = { 'default-uid': 3, 'team-uid': 2 };
-
-    await fetchKubernetesInventory();
-
-    expect(probeCalls()).toHaveLength(1);
-    expect(probeCalls()[0][0].datasource.uid).toBe('default-uid');
-  });
-
-  it('retries a transient inventory query error instead of blanking the region', async () => {
-    setDataSources([{ uid: 'k8s-uid', name: 'k8s-prom', isDefault: true }]);
-    dataByUid = { 'k8s-uid': 2 };
-    queryFailuresByRefId = { clusters: 1 };
-
-    jest.useFakeTimers();
-    try {
-      const promise = fetchKubernetesInventory();
-      await jest.advanceTimersByTimeAsync(10_000);
-      const inventory = await promise;
-
-      expect(inventory.clusters).toBe(2);
-      expect(inventoryCalls()).toHaveLength(2);
-    } finally {
-      jest.useRealTimers();
-    }
-  });
-
-  it('retries a transient cpu query error', async () => {
-    setDataSources([{ uid: 'k8s-uid', name: 'k8s-prom', isDefault: true }]);
-    dataByUid = { 'k8s-uid': 2 };
-    queryFailuresByRefId = { cpu: 1 };
-
-    jest.useFakeTimers();
-    try {
-      const promise = fetchClusterCpuSeries();
-      await jest.advanceTimersByTimeAsync(10_000);
-      await promise;
-
-      expect(cpuCalls()).toHaveLength(2);
-    } finally {
-      jest.useRealTimers();
-    }
-  });
-
-  it('retries a transient datasource-list failure', async () => {
-    mockGetDataSourceInstanceList
-      .mockRejectedValueOnce(new Error('gateway blip'))
-      .mockResolvedValue([createPrometheusListItem({ uid: 'k8s-uid', name: 'k8s-prom', isDefault: true })]);
-    dataByUid = { 'k8s-uid': 2 };
-
-    jest.useFakeTimers();
-    try {
-      const promise = fetchKubernetesInventory();
-      await jest.advanceTimersByTimeAsync(10_000);
-      expect((await promise).clusters).toBe(2);
-      expect(mockGetDataSourceInstanceList).toHaveBeenCalledTimes(2);
-    } finally {
-      jest.useRealTimers();
-    }
   });
 
   it('does not cache a failed resolution for the TTL window', async () => {
@@ -572,38 +519,13 @@ describe('Kubernetes Prometheus resolution', () => {
     }
   });
 
-  it('rejects after three failed inventory attempts', async () => {
+  it('rejects when the inventory query fails', async () => {
     setDataSources([{ uid: 'k8s-uid', name: 'k8s-prom', isDefault: true }]);
     dataByUid = { 'k8s-uid': 2 };
     queryErrorRefIds = new Set(['clusters']);
 
-    jest.useFakeTimers();
-    try {
-      const assertion = expect(fetchKubernetesInventory()).rejects.toThrow();
-      await jest.advanceTimersByTimeAsync(10_000);
-      await assertion;
-      expect(inventoryCalls()).toHaveLength(3);
-    } finally {
-      jest.useRealTimers();
-    }
-  });
-
-  it('recovers when only the third inventory attempt succeeds', async () => {
-    setDataSources([{ uid: 'k8s-uid', name: 'k8s-prom', isDefault: true }]);
-    dataByUid = { 'k8s-uid': 2 };
-    queryFailuresByRefId = { clusters: 2 };
-
-    jest.useFakeTimers();
-    try {
-      const promise = fetchKubernetesInventory();
-      await jest.advanceTimersByTimeAsync(10_000);
-      const inventory = await promise;
-
-      expect(inventory.clusters).toBe(2);
-      expect(inventoryCalls()).toHaveLength(3);
-    } finally {
-      jest.useRealTimers();
-    }
+    await expect(fetchKubernetesInventory()).rejects.toThrow();
+    expect(inventoryCalls()).toHaveLength(1);
   });
 
   it('uses the configured state-history metric name in the alerts union', async () => {

--- a/public/app/features/home/Recommendations/kubernetesData.ts
+++ b/public/app/features/home/Recommendations/kubernetesData.ts
@@ -8,12 +8,12 @@ import { config } from '@grafana/runtime';
 
 import {
   createTtlCachedPromise,
-  findDatasourceWithDataStrict,
+  filterHealthyDatasources,
+  findDatasourceWithData,
   listProbeCandidates,
   MAX_PROBED_DATASOURCES,
   PROBE_TIMEOUT_MS,
   PROBE_TTL_MS,
-  withRetry,
 } from './probeUtils';
 import { readScalar, readSeries, runInstantQueries, runRangeQuery } from './promQuery';
 
@@ -85,18 +85,17 @@ async function orderedCandidates(): Promise<DataSourceInstanceListItem[]> {
   return storedMatch ? [storedMatch, ...ordered.filter((ds) => ds !== storedMatch)] : ordered;
 }
 
-// Single attempt so the solution-state signal budget outlasts leader + fan-out; errors
-// propagate so an all-errored scan reads inconclusive, not "no data".
+// Single attempt inside the probe timeout; errors read as no data in the parallel scan.
 async function hasKubernetesNamespaces(ds: Pick<DataSourceInstanceSettings, 'uid' | 'type'>): Promise<boolean> {
   const frames = await runInstantQueries({ namespaces: NAMESPACE_PROBE }, ds, PROBE_TIMEOUT_MS);
   return (readScalar(frames, 'namespaces') ?? 0) > 0;
 }
 
-// Leader-first strict scan over the ordered candidates; rejects when nothing was found and any
-// probe errored, so an inconclusive scan never settles as "no data".
+// Health-filtered parallel scan over the ordered candidates; first candidate with data wins.
 async function resolveKubernetesPrometheus(): Promise<DataSourceInstanceListItem | null> {
-  const candidates = (await orderedCandidates()).slice(0, MAX_PROBED_DATASOURCES);
-  return findDatasourceWithDataStrict(candidates, hasKubernetesNamespaces, 'prometheus');
+  // Filter after the cap: broken datasources consume cap slots, same as they consumed probe slots.
+  const candidates = await filterHealthyDatasources((await orderedCandidates()).slice(0, MAX_PROBED_DATASOURCES));
+  return findDatasourceWithData(candidates, hasKubernetesNamespaces);
 }
 
 const kubernetesPrometheusResolution = createTtlCachedPromise(resolveKubernetesPrometheus, PROBE_TTL_MS);
@@ -120,7 +119,7 @@ export async function fetchKubernetesInventory(): Promise<KubernetesInventory> {
   if (!ds) {
     throw new Error(NO_KUBERNETES_DATA_ERROR);
   }
-  const frames = await withRetry(() => runInstantQueries(INVENTORY_QUERIES, ds));
+  const frames = await runInstantQueries(INVENTORY_QUERIES, ds);
   return {
     clusters: readScalar(frames, 'clusters') ?? 0,
     pods: readScalar(frames, 'pods') ?? 0,
@@ -148,7 +147,7 @@ export async function fetchKubernetesHealth(): Promise<KubernetesHealth> {
   };
 
   const [frames, grafanaAlertsFiring] = await Promise.all([
-    withRetry(() => runInstantQueries(queries, ds)),
+    runInstantQueries(queries, ds),
     sameDatasource ? Promise.resolve(null) : fetchGrafanaManagedAlertCount(grafanaAlertsUid, grafanaMetric),
   ]);
 
@@ -169,8 +168,9 @@ export async function fetchKubernetesHealth(): Promise<KubernetesHealth> {
 // A broken/absent state-history datasource must not blank the whole health row: fail to null.
 async function fetchGrafanaManagedAlertCount(uid: string, metric: string): Promise<number | null> {
   try {
-    const frames = await withRetry(() =>
-      runInstantQueries({ grafanaAlertsFiring: `count(${metric}${ALERTS_MATCHER})` }, { uid, type: 'prometheus' })
+    const frames = await runInstantQueries(
+      { grafanaAlertsFiring: `count(${metric}${ALERTS_MATCHER})` },
+      { uid, type: 'prometheus' }
     );
     return readScalar(frames, 'grafanaAlertsFiring');
   } catch {
@@ -184,8 +184,6 @@ export async function fetchClusterCpuSeries(): Promise<FieldSparkline | null> {
   if (!ds) {
     throw new Error(NO_KUBERNETES_DATA_ERROR);
   }
-  const frames = await withRetry(() =>
-    runRangeQuery('cpu', 'sum(rate(container_cpu_usage_seconds_total{container!=""}[5m]))', 24, ds)
-  );
+  const frames = await runRangeQuery('cpu', 'sum(rate(container_cpu_usage_seconds_total{container!=""}[5m]))', 24, ds);
   return readSeries(frames, 'cpu');
 }

--- a/public/app/features/home/Recommendations/probeUtils.test.ts
+++ b/public/app/features/home/Recommendations/probeUtils.test.ts
@@ -1,7 +1,19 @@
 import { type DataSourceInstanceListItem } from '@grafana/data';
+import { type BackendSrv, getBackendSrv } from '@grafana/runtime';
 import { getDataSourceInstanceList } from '@grafana/runtime/unstable';
 
-import { listProbeCandidates, MAX_PROBED_DATASOURCES, withTimeout } from './probeUtils';
+import {
+  filterHealthyDatasources,
+  findDatasourceWithData,
+  listProbeCandidates,
+  MAX_PROBED_DATASOURCES,
+  withTimeout,
+} from './probeUtils';
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getBackendSrv: jest.fn(),
+}));
 
 jest.mock('@grafana/runtime/unstable', () => ({
   ...jest.requireActual('@grafana/runtime/unstable'),
@@ -9,6 +21,7 @@ jest.mock('@grafana/runtime/unstable', () => ({
 }));
 
 const getDataSourceInstanceListMock = jest.mocked(getDataSourceInstanceList);
+const healthGetMock = jest.fn();
 
 function listItem(ds: { uid?: string; name: string; isDefault?: boolean }): DataSourceInstanceListItem {
   return {
@@ -95,5 +108,102 @@ describe('listProbeCandidates', () => {
 
     expect(candidates).toHaveLength(MAX_PROBED_DATASOURCES);
     expect(candidates[0].name).toBe('the-default');
+  });
+});
+
+describe('filterHealthyDatasources', () => {
+  beforeEach(() => {
+    healthGetMock.mockReset();
+    jest.mocked(getBackendSrv).mockReturnValue({ get: healthGetMock } as unknown as BackendSrv);
+  });
+
+  it('keeps candidates whose health check reports OK', async () => {
+    healthGetMock.mockResolvedValue({ status: 'OK' });
+
+    const kept = await filterHealthyDatasources([listItem({ uid: 'healthy', name: 'healthy' })]);
+
+    expect(kept.map((ds) => ds.uid)).toEqual(['healthy']);
+    expect(healthGetMock).toHaveBeenCalledWith('/api/datasources/uid/healthy/health', undefined, undefined, {
+      showErrorAlert: false,
+    });
+  });
+
+  it('drops a candidate whose health check reports a non-OK status', async () => {
+    healthGetMock.mockImplementation(async (url: string) => ({ status: url.includes('sick') ? 'ERROR' : 'OK' }));
+
+    const kept = await filterHealthyDatasources([
+      listItem({ uid: 'sick', name: 'sick' }),
+      listItem({ uid: 'healthy', name: 'healthy' }),
+    ]);
+
+    expect(kept.map((ds) => ds.uid)).toEqual(['healthy']);
+  });
+
+  it('drops a candidate whose health check rejects', async () => {
+    healthGetMock.mockImplementation((url: string) =>
+      url.includes('broken') ? Promise.reject(new Error('connection refused')) : Promise.resolve({ status: 'OK' })
+    );
+
+    const kept = await filterHealthyDatasources([
+      listItem({ uid: 'broken', name: 'broken' }),
+      listItem({ uid: 'healthy', name: 'healthy' }),
+    ]);
+
+    expect(kept.map((ds) => ds.uid)).toEqual(['healthy']);
+  });
+
+  it('drops a candidate whose health check hangs past the 3s cutoff', async () => {
+    jest.useFakeTimers();
+    try {
+      healthGetMock.mockImplementation((url: string) =>
+        url.includes('hung') ? new Promise(() => {}) : Promise.resolve({ status: 'OK' })
+      );
+
+      const promise = filterHealthyDatasources([
+        listItem({ uid: 'hung', name: 'hung' }),
+        listItem({ uid: 'healthy', name: 'healthy' }),
+      ]);
+      await jest.advanceTimersByTimeAsync(3_500);
+
+      expect((await promise).map((ds) => ds.uid)).toEqual(['healthy']);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});
+
+describe('findDatasourceWithData', () => {
+  it('prefers the first candidate in priority order even when a later one settles sooner', async () => {
+    jest.useFakeTimers();
+    try {
+      const first = listItem({ uid: 'first', name: 'first' });
+      const second = listItem({ uid: 'second', name: 'second' });
+      const hasData = (ds: DataSourceInstanceListItem) =>
+        ds.uid === 'first'
+          ? new Promise<boolean>((resolve) => setTimeout(() => resolve(true), 20))
+          : Promise.resolve(true);
+
+      const promise = findDatasourceWithData([first, second], hasData);
+      await jest.advanceTimersByTimeAsync(25);
+
+      await expect(promise).resolves.toBe(first);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('reads a rejected probe as no data', async () => {
+    const candidates = [listItem({ uid: 'broken', name: 'broken' }), listItem({ uid: 'empty', name: 'empty' })];
+    const hasData = (ds: DataSourceInstanceListItem) =>
+      ds.uid === 'broken' ? Promise.reject(new Error('probe failed')) : Promise.resolve(false);
+
+    await expect(findDatasourceWithData(candidates, hasData)).resolves.toBeNull();
+  });
+
+  it('settles null for an empty candidate list without probing', async () => {
+    const hasData = jest.fn();
+
+    await expect(findDatasourceWithData([], hasData)).resolves.toBeNull();
+    expect(hasData).not.toHaveBeenCalled();
   });
 });

--- a/public/app/features/home/Recommendations/probeUtils.ts
+++ b/public/app/features/home/Recommendations/probeUtils.ts
@@ -5,25 +5,20 @@ import { getDataSourceInstance, getDataSourceInstanceList } from '@grafana/runti
 /** Cap the probe fan-out: only the first N candidates (in priority order) are probed per page load. */
 export const MAX_PROBED_DATASOURCES = 10;
 
-// Probes gate homepage cards: 3 attempts x 30s meant a fallback could wait 92s+. 10s per attempt
-// bounds the leader to ~32s worst case while still outlasting a slow-but-alive datasource.
+// Probes gate homepage cards: 10s outlasts a slow-but-alive datasource without stalling the region.
 export const PROBE_TIMEOUT_MS = 10_000;
 
 /** One shared probe resolution per TTL window; a later home visit re-resolves after datasource changes. */
 export const PROBE_TTL_MS = 60_000;
 
-// Spacing between retry attempts: the transient browser-side failures observed on the homepage
-// (connection queuing, gateway blips) can outlast an immediate retry; a short backoff covers
-// them while the region shows its skeleton. 3 attempts total.
-const RETRY_DELAYS_MS = [500, 1500];
+// ponytail: 3s /health cutoff (drilldown's) — suspected too tight for OPS-scale instances; revisit as follow-up.
+const HEALTH_CHECK_TIMEOUT_MS = 3000;
 
 // Exact names of Grafana Cloud's utility Prometheus datasources (billing/ML) — never where product data lives.
 const CLOUD_UTILITY_DATASOURCE_NAMES: Record<string, true> = {
   'grafanacloud-usage': true,
   'grafanacloud-ml-metrics': true,
 };
-
-const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
 /** Backend-capable datasource instance for `uid`, or null when it cannot serve resource calls. */
 export async function resolveBackendInstance(uid: string): Promise<DataSourceWithBackend | null> {
@@ -34,31 +29,10 @@ export async function resolveBackendInstance(uid: string): Promise<DataSourceWit
 /**
  * GET through the classic datasource proxy, timeout-bounded, never toasts. Some datasource
  * backends (e.g. Tempo) serve their HTTP API only here, not on the resource router.
- * `retry: false` keeps a probe inside its caller's deadline.
  */
-export async function probeProxyGet<T>(
-  uid: string,
-  path: string,
-  params: Record<string, unknown>,
-  { retry = true } = {}
-): Promise<T> {
+export async function probeProxyGet<T>(uid: string, path: string, params: Record<string, unknown>): Promise<T> {
   const url = `/api/datasources/proxy/uid/${encodeURIComponent(uid)}/${path}`;
-  const call = () =>
-    withTimeout(getBackendSrv().get<T>(url, params, undefined, { showErrorAlert: false }), PROBE_TIMEOUT_MS);
-  return retry ? withRetry(call) : call();
-}
-
-export async function withRetry<T>(fn: () => Promise<T>): Promise<T> {
-  for (let attempt = 0; ; attempt++) {
-    try {
-      return await fn();
-    } catch (err) {
-      if (attempt >= RETRY_DELAYS_MS.length) {
-        throw err;
-      }
-      await sleep(RETRY_DELAYS_MS[attempt]);
-    }
-  }
+  return withTimeout(getBackendSrv().get<T>(url, params, undefined, { showErrorAlert: false }), PROBE_TIMEOUT_MS);
 }
 
 /** Rejects when `promise` outlasts `ms`; the underlying request keeps running but stops gating the caller. */
@@ -113,13 +87,11 @@ export async function listProbeCandidates(
   cap = MAX_PROBED_DATASOURCES,
   excludeUids?: ReadonlySet<string>
 ): Promise<DataSourceInstanceListItem[]> {
-  const list = await withRetry(() =>
-    getDataSourceInstanceList({
-      type,
-      // Reject the -- Grafana -- builtin by meta.id; a ds.type check would drop alias datasources.
-      filter: (ds) => ds.meta.id !== 'grafana',
-    })
-  );
+  const list = await getDataSourceInstanceList({
+    type,
+    // Reject the -- Grafana -- builtin by meta.id; a ds.type check would drop alias datasources.
+    filter: (ds) => ds.meta.id !== 'grafana',
+  });
   const eligible = excludeUids ? list.filter((ds) => !excludeUids.has(ds.uid)) : list;
   const preferred = eligible.filter((ds) => !CLOUD_UTILITY_DATASOURCE_NAMES[ds.name]);
   const pool = preferred.length > 0 ? preferred : eligible;
@@ -128,58 +100,35 @@ export async function listProbeCandidates(
   return ordered.slice(0, cap);
 }
 
-/**
- * Probe the top-priority candidate alone first: in the common case (the default datasource has
- * the data) this issues 1 query instead of N, and a transient sibling race can never outrank it.
- * Only when the leader has no data (or errors) fan out to the rest in parallel. `hasData` must
- * not throw — an unusable datasource counts as no data.
- */
-async function findDatasourceWithData(
+/** Candidates whose /health reports OK; broken or slow datasources drop out of detection. */
+export async function filterHealthyDatasources(
+  candidates: DataSourceInstanceListItem[]
+): Promise<DataSourceInstanceListItem[]> {
+  const results = await Promise.allSettled(
+    candidates.map((ds) =>
+      withTimeout(
+        getBackendSrv().get<{ status?: string }>(
+          `/api/datasources/uid/${encodeURIComponent(ds.uid)}/health`,
+          undefined,
+          undefined,
+          { showErrorAlert: false }
+        ),
+        HEALTH_CHECK_TIMEOUT_MS
+      )
+    )
+  );
+  return candidates.filter((_, i) => {
+    const result = results[i];
+    return result.status === 'fulfilled' && result.value?.status === 'OK';
+  });
+}
+
+/** First candidate (in priority order) whose probe confirms data; probe errors read as no data. */
+export async function findDatasourceWithData(
   candidates: DataSourceInstanceListItem[],
   hasData: (ds: DataSourceInstanceListItem) => Promise<boolean>
 ): Promise<DataSourceInstanceListItem | null> {
-  if (candidates.length === 0) {
-    return null;
-  }
-  if (await hasData(candidates[0])) {
-    return candidates[0];
-  }
-  const rest = candidates.slice(1);
-  // Parallel probe for hasData while retaining priority of original list
-  for (const [index, probe] of rest.map(hasData).entries()) {
-    if (await probe) {
-      return rest[index];
-    }
-  }
-  return null;
-}
-
-/**
- * findDatasourceWithData with error accounting: null only when every candidate probed
- * clean-and-empty; throws when nothing was found and any candidate errored (an errored
- * datasource may hold the data). Unlike findDatasourceWithData, hasData may throw.
- */
-export async function findDatasourceWithDataStrict(
-  candidates: DataSourceInstanceListItem[],
-  hasData: (ds: DataSourceInstanceListItem) => Promise<boolean>,
-  type: string
-): Promise<DataSourceInstanceListItem | null> {
-  let errored = 0;
-  // findDatasourceWithData requires a non-throwing callback; count failures for the unknown check.
-  const guardedHasData = async (ds: DataSourceInstanceListItem) => {
-    try {
-      return await hasData(ds);
-    } catch {
-      errored++;
-      return false;
-    }
-  };
-  const found = await findDatasourceWithData(candidates, guardedHasData);
-  if (found) {
-    return found;
-  }
-  if (errored > 0) {
-    throw new Error(`${errored} ${type} datasource probe(s) failed with no data found elsewhere`);
-  }
-  return null;
+  const results = await Promise.allSettled(candidates.map((ds) => hasData(ds)));
+  const winner = results.findIndex((result) => result.status === 'fulfilled' && result.value === true);
+  return winner === -1 ? null : candidates[winner];
 }

--- a/public/app/features/home/Recommendations/solutionDataProbes.test.ts
+++ b/public/app/features/home/Recommendations/solutionDataProbes.test.ts
@@ -33,6 +33,8 @@ beforeEach(() => {
   jest.setSystemTime(new Date('2026-07-24T12:00:00Z'));
   mockList.mockReset();
   mockProxyGet.mockReset();
+  // Health checks share getBackendSrv().get: answer /health OK by default so candidates survive the filter.
+  mockProxyGet.mockImplementation(async (url: string) => (url.endsWith('/health') ? { status: 'OK' } : undefined));
   jest.mocked(getBackendSrv).mockReturnValue({ get: mockProxyGet } as unknown as BackendSrv);
 });
 
@@ -63,7 +65,7 @@ describe('probeFound', () => {
     expect(hasData).not.toHaveBeenCalled();
   });
 
-  it('throws when a candidate errored and no data was found elsewhere', async () => {
+  it('settles null when a candidate errored and no data was found elsewhere', async () => {
     mockList.mockResolvedValue([datasource('tempo', 'broken'), datasource('tempo', 'empty')]);
 
     await expect(
@@ -73,7 +75,21 @@ describe('probeFound', () => {
         }
         return false;
       })
-    ).rejects.toThrow(/1 tempo datasource probe\(s\) failed/);
+    ).resolves.toBeNull();
+  });
+
+  it('never probes an unhealthy candidate', async () => {
+    mockList.mockResolvedValue([datasource('loki', 'broken'), datasource('loki', 'healthy')]);
+    mockProxyGet.mockImplementation((url: string) =>
+      url.includes('broken') ? Promise.reject(new Error('health check failed')) : Promise.resolve({ status: 'OK' })
+    );
+
+    const hasData = jest.fn().mockResolvedValue(true);
+    const found = await probeFound('loki', hasData);
+
+    expect(found?.name).toBe('healthy');
+    expect(hasData).toHaveBeenCalledTimes(1);
+    expect(hasData).toHaveBeenCalledWith(expect.objectContaining({ uid: 'healthy' }));
   });
 
   it('never probes excluded uids', async () => {
@@ -109,13 +125,9 @@ describe('tempoHasTraces', () => {
     await expect(tempoHasTraces(datasource('tempo'))).resolves.toBe(false);
   });
 
-  it('throws when the search endpoint keeps failing', async () => {
+  it('throws when the search endpoint fails', async () => {
     mockProxyGet.mockRejectedValue(new Error('HTTP 404'));
 
-    const promise = tempoHasTraces(datasource('tempo'));
-    // Sink the rejection before the retry sleeps run out, or Jest flags it as unhandled.
-    const outcome = expect(promise).rejects.toThrow('HTTP 404');
-    await jest.advanceTimersByTimeAsync(5_000);
-    await outcome;
+    await expect(tempoHasTraces(datasource('tempo'))).rejects.toThrow('HTTP 404');
   });
 });

--- a/public/app/features/home/Recommendations/solutionDataProbes.ts
+++ b/public/app/features/home/Recommendations/solutionDataProbes.ts
@@ -1,22 +1,21 @@
 import { type DataSourceInstanceListItem } from '@grafana/data';
 
-import { findDatasourceWithDataStrict, listProbeCandidates, probeProxyGet } from './probeUtils';
+import { filterHealthyDatasources, findDatasourceWithData, listProbeCandidates, probeProxyGet } from './probeUtils';
 
 // "Seen recently" lookback shared by all data probes, tolerating scrape/ingest gaps.
 export const DATA_LOOKBACK_HOURS = 24;
 
 /**
- * The first probed candidate datasource of `type` where `hasData` confirms data, or null when
- * every candidate probed clean-and-empty (or none exist). Throws when nothing was found and any
- * candidate errored: an errored datasource may hold the data, so absence is not settled.
+ * The first probed healthy candidate datasource of `type` where `hasData` confirms data, or null
+ * when no candidate confirmed data. Rejects only when listing datasources fails.
  */
 export async function probeFound(
   type: string,
   hasData: (ds: DataSourceInstanceListItem) => Promise<boolean>,
   excludeUids?: ReadonlySet<string>
 ): Promise<DataSourceInstanceListItem | null> {
-  const candidates = await listProbeCandidates(type, undefined, excludeUids);
-  return findDatasourceWithDataStrict(candidates, hasData, type);
+  const candidates = await filterHealthyDatasources(await listProbeCandidates(type, undefined, excludeUids));
+  return findDatasourceWithData(candidates, hasData);
 }
 
 interface TempoSearchResponse {
@@ -31,12 +30,6 @@ interface TempoSearchResponse {
 export async function tempoHasTraces(ds: Pick<DataSourceInstanceListItem, 'uid'>): Promise<boolean> {
   const end = Math.floor(Date.now() / 1000);
   const start = end - DATA_LOOKBACK_HOURS * 3600;
-  // Single attempt so the traces signal budget outlasts the whole probe (see solutionState).
-  const res = await probeProxyGet<TempoSearchResponse>(
-    ds.uid,
-    'api/search',
-    { q: '{}', limit: 1, start, end },
-    { retry: false }
-  );
+  const res = await probeProxyGet<TempoSearchResponse>(ds.uid, 'api/search', { q: '{}', limit: 1, start, end });
   return Array.isArray(res?.traces) && res.traces.length > 0;
 }

--- a/public/app/features/home/Recommendations/solutionState.test.ts
+++ b/public/app/features/home/Recommendations/solutionState.test.ts
@@ -1,11 +1,16 @@
 import { createDataFrame, type DataSourceInstanceListItem, FieldType } from '@grafana/data';
-import { DataSourceWithBackend } from '@grafana/runtime';
+import { type BackendSrv, DataSourceWithBackend, getBackendSrv } from '@grafana/runtime';
 import { getDataSourceInstance, getDataSourceInstanceList } from '@grafana/runtime/unstable';
 
 import { resolveKubernetesDatasource } from './kubernetesData';
 import { runInstantQueries } from './promQuery';
 import { tempoHasTraces } from './solutionDataProbes';
 import { resetSolutionStateResolution, resolveSolutionState } from './solutionState';
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getBackendSrv: jest.fn(),
+}));
 
 jest.mock('@grafana/runtime/unstable', () => ({
   ...jest.requireActual('@grafana/runtime/unstable'),
@@ -33,6 +38,7 @@ const instanceMock = jest.mocked(getDataSourceInstance);
 const tempoHasTracesMock = jest.mocked(tempoHasTraces);
 const kubernetesMock = jest.mocked(resolveKubernetesDatasource);
 const instantQueriesMock = jest.mocked(runInstantQueries);
+const backendSrvGetMock = jest.fn();
 
 const DATA_LOOKBACK_HOURS = 24;
 const SIGNAL_BUDGET_MS = 30_000;
@@ -122,6 +128,10 @@ describe('resolveSolutionState', () => {
     tempoHasTracesMock.mockReset();
     kubernetesMock.mockReset();
     instantQueriesMock.mockReset();
+    backendSrvGetMock.mockReset();
+    // Health pre-filter: every candidate healthy unless a test overrides by uid.
+    backendSrvGetMock.mockResolvedValue({ status: 'OK' });
+    jest.mocked(getBackendSrv).mockReturnValue({ get: backendSrvGetMock } as unknown as BackendSrv);
     // Span-metrics probe settles clean-empty unless a test overrides it.
     instantQueriesMock.mockResolvedValue([]);
     resetSolutionStateResolution();
@@ -181,9 +191,8 @@ describe('resolveSolutionState', () => {
     expect(resolution.tempoDatasource?.uid).toBe('tempo-main');
   });
 
-  it('treats an errored candidate as unknown when no data was found elsewhere, active when it was', async () => {
-    const { promResource } = freshCloudFixture();
-    const failing = jest.fn().mockRejectedValue(new Error('gateway blew up'));
+  it('skips a candidate whose health check fails', async () => {
+    freshCloudFixture();
     const withData = jest.fn().mockResolvedValue({ data: ['__name__'] });
     setupFixture({
       prometheus: [
@@ -193,32 +202,48 @@ describe('resolveSolutionState', () => {
       loki: [listItem('loki', { uid: 'loki-main', name: 'grafanacloud-logs' })],
       tempo: [],
       instances: {
-        'prom-broken': backendInstance(failing),
         'prom-main': backendInstance(withData),
         'loki-main': backendInstance(emptyLokiResource()),
       },
     });
+    backendSrvGetMock.mockImplementation((url: string) =>
+      url.includes('prom-broken') ? Promise.reject(new Error('health check failed')) : Promise.resolve({ status: 'OK' })
+    );
 
-    let resolution = await resolveWithTimers();
+    const resolution = await resolveSolutionState();
+
     expect(resolution.state.metrics).toBe('active');
-
-    // Same broken candidate, but the healthy one is empty: the errored one may hold data.
-    resetSolutionStateResolution();
-    failing.mockClear();
-    withData.mockResolvedValue({ data: [] });
-
-    resolution = await resolveWithTimers();
-    expect(resolution.state.metrics).toBe('unknown');
-    expect(promResource).not.toHaveBeenCalled();
+    expect(resolution.prometheusDatasource?.uid).toBe('prom-main');
+    // The unhealthy candidate is dropped before its probe could run.
+    expect(instanceMock).not.toHaveBeenCalledWith({ uid: 'prom-broken' });
   });
 
-  it('maps an all-errored traces probe to unknown without touching the other signals', async () => {
+  it('reads inactive when the only candidate with data potential errors', async () => {
+    freshCloudFixture();
+    const failing = jest.fn().mockRejectedValue(new Error('gateway blew up'));
+    setupFixture({
+      prometheus: [listItem('prometheus', { uid: 'prom-broken', name: 'broken', isDefault: true })],
+      loki: [listItem('loki', { uid: 'loki-main', name: 'grafanacloud-logs' })],
+      tempo: [],
+      instances: {
+        'prom-broken': backendInstance(failing),
+        'loki-main': backendInstance(emptyLokiResource()),
+      },
+    });
+
+    const resolution = await resolveSolutionState();
+
+    expect(resolution.state.metrics).toBe('inactive');
+    expect(failing).toHaveBeenCalled();
+  });
+
+  it('reads an all-errored traces probe as inactive without touching the other signals', async () => {
     freshCloudFixture();
     tempoHasTracesMock.mockRejectedValue(new Error('tempo down'));
 
     const resolution = await resolveWithTimers();
 
-    expect(resolution.state.traces).toBe('unknown');
+    expect(resolution.state.traces).toBe('inactive');
     expect(resolution.state.logs).toBe('inactive');
     expect(resolution.state.metrics).toBe('inactive');
   });
@@ -234,13 +259,13 @@ describe('resolveSolutionState', () => {
     expect(resolution.state.metrics).toBe('inactive');
   });
 
-  it('settles a hung probe to unknown within the signal budget, preserving siblings', async () => {
+  it('settles a hung probe as no data within the signal budget, preserving siblings', async () => {
     const { lokiResource } = freshCloudFixture();
     lokiResource.mockImplementation(() => new Promise(() => {}));
 
     const resolution = await resolveWithTimers();
 
-    expect(resolution.state.logs).toBe('unknown');
+    expect(resolution.state.logs).toBe('inactive');
     expect(resolution.state.metrics).toBe('inactive');
     expect(resolution.state.traces).toBe('inactive');
   });
@@ -328,8 +353,8 @@ describe('resolveSolutionState', () => {
     const resolution = await resolveWithTimers();
 
     expect(resolution.state.spanMetrics).toBe('inactive');
-    // The core metrics signal keeps the strict direction: errored candidate + no data = unknown.
-    expect(resolution.state.metrics).toBe('unknown');
+    // Metrics reads the same direction: the errored candidate is no data, not unknown.
+    expect(resolution.state.metrics).toBe('inactive');
   });
 
   it('still settles span metrics active when a healthy candidate has series beside a broken one', async () => {

--- a/public/app/features/home/Recommendations/solutionState.ts
+++ b/public/app/features/home/Recommendations/solutionState.ts
@@ -27,8 +27,7 @@ const CLOUD_UTILITY_LOKI_DATASOURCE_UIDS: ReadonlySet<string> = new Set([
   'grafanacloud-alert-state-history',
 ]);
 
-// Hard ceiling per signal. Candidates are single-attempt (leader + fan-out ≤ 2x10s), so no
-// request outlives an unknown; transient failures self-heal on the next TTL cycle.
+// Hard ceiling per signal; one parallel scan (3s health filter + 10s probes) settles well inside it.
 const SIGNAL_BUDGET_MS = 30_000;
 
 export interface SolutionStateResolution {
@@ -48,8 +47,8 @@ interface SignalResolution {
   datasource: DataSourceInstanceListItem | null;
 }
 
-// Empty results are definitive 'inactive'; ANY rejection or timeout — transport errors,
-// 401/403, every-candidate-errored — is 'unknown'. The two are never conflated.
+// Empty results are definitive 'inactive'; 'unknown' = candidate-list or resolution failure or
+// signal-budget timeout. Probe errors read as no data; the health filter drops broken candidates.
 async function resolveSignal(probe: () => Promise<DataSourceInstanceListItem | null>): Promise<SignalResolution> {
   try {
     const datasource = await withTimeout(probe(), SIGNAL_BUDGET_MS);
@@ -91,15 +90,10 @@ async function lokiHasRecentLabels(ds: DataSourceInstanceListItem): Promise<bool
   return Array.isArray(res?.data) && res.data.length > 0;
 }
 
-// A broken candidate counts as no span metrics: one dead datasource must not hide the App O11y
-// card behind an unknown (the kubernetes probe's failure direction; core signals stay strict).
+// Span metrics prove App O11y usage; a probe error reads as no span metrics in the scan.
 async function prometheusHasSpanMetrics(ds: DataSourceInstanceListItem): Promise<boolean> {
-  try {
-    const frames = await runInstantQueries({ probe: SPAN_METRICS_PROBE }, ds, PROBE_TIMEOUT_MS);
-    return (readScalar(frames, 'probe') ?? 0) > 0;
-  } catch {
-    return false;
-  }
+  const frames = await runInstantQueries({ probe: SPAN_METRICS_PROBE }, ds, PROBE_TIMEOUT_MS);
+  return (readScalar(frames, 'probe') ?? 0) > 0;
 }
 
 // Each signal resolver settles on its own (never rejects), so Promise.all cannot discard

--- a/public/app/features/home/Recommendations/telemetryData.test.ts
+++ b/public/app/features/home/Recommendations/telemetryData.test.ts
@@ -166,11 +166,7 @@ describe('fetchLogsActivity', () => {
     });
     mockResolveBackendInstance.mockResolvedValue(instanceWith(getResource));
 
-    const promise = fetchLogsActivity(loki);
-    // withRetry sleeps between volume attempts; drive the fake timers past them.
-    await jest.advanceTimersByTimeAsync(5_000);
-
-    await expect(promise).resolves.toEqual({ bytes: null, sources: 2, series: null });
+    await expect(fetchLogsActivity(loki)).resolves.toEqual({ bytes: null, sources: 2, series: null });
   });
 
   it('reports nulls when no usable label exists', async () => {
@@ -330,11 +326,7 @@ describe('fetchMetricsActivity', () => {
     });
     mockResolveBackendInstance.mockResolvedValue(instanceWith(getResource));
 
-    const promise = fetchMetricsActivity(prom);
-    // withRetry sleeps between cardinality attempts; drive the fake timers past them.
-    await jest.advanceTimersByTimeAsync(5_000);
-
-    await expect(promise).resolves.toMatchObject({ series: 987, names: 1 });
+    await expect(fetchMetricsActivity(prom)).resolves.toMatchObject({ series: 987, names: 1 });
   });
 
   it('keeps the name count when both active-series sources fail', async () => {

--- a/public/app/features/home/Recommendations/telemetryData.ts
+++ b/public/app/features/home/Recommendations/telemetryData.ts
@@ -7,7 +7,7 @@ import {
 } from '@grafana/data';
 import { type DataSourceWithBackend } from '@grafana/runtime';
 
-import { probeProxyGet, PROBE_TIMEOUT_MS, resolveBackendInstance, withRetry, withTimeout } from './probeUtils';
+import { probeProxyGet, PROBE_TIMEOUT_MS, resolveBackendInstance, withTimeout } from './probeUtils';
 import { readLabeledScalar, readScalar, readSeries, runInstantQueries, runRangeQuery } from './promQuery';
 import { DATA_LOOKBACK_HOURS } from './solutionDataProbes';
 
@@ -45,9 +45,7 @@ interface TempoTagValuesResponse {
 
 // Failures are expected (endpoint disabled, 403s) and handled by the caller; never toast.
 function getResource<T>(instance: DataSourceWithBackend, path: string, params: Record<string, unknown>): Promise<T> {
-  return withRetry(() =>
-    withTimeout(instance.getResource<T>(path, params, { showErrorAlert: false }), PROBE_TIMEOUT_MS)
-  );
+  return withTimeout(instance.getResource<T>(path, params, { showErrorAlert: false }), PROBE_TIMEOUT_MS);
 }
 
 // Points are [unix ms, value]; a real trend needs at least two of them.


### PR DESCRIPTION
**What is this feature?**

Datasource candidates are health-filtered before probing, and the per-probe retry machinery is removed.