### PR TITLE
AnnotationsTooltip: Fix k8s annos not being editable

### DIFF
--- a/public/app/plugins/panel/timeseries/plugins/annotations/getAnnotationTooltip.test.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/annotations/getAnnotationTooltip.test.tsx
@@ -1,0 +1,68 @@
+import { getAnnotationTooltip } from './getAnnotationTooltip';
+import { type AnnotationVals } from './types';
+
+// AnnotationVals types ids as numbers, but annotations served by the k8s annotations API
+// have string ids (metadata.name), see issue #120097
+function makeAnnoVals(id: number | string | null, dashboardUID: string | null = 'dash-1'): AnnotationVals {
+  return {
+    time: [1759388895560],
+    text: ['annotation text'],
+    id: [id as number],
+    dashboardUID: [dashboardUID],
+  };
+}
+
+describe('getAnnotationTooltip', () => {
+  const canEditAnnotations = jest.fn(() => true);
+  const canDeleteAnnotations = jest.fn(() => true);
+  const onAnnotationDelete = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function getTooltip(annoVals: AnnotationVals) {
+    return getAnnotationTooltip(annoVals, 0, 'utc', canEditAnnotations, canDeleteAnnotations, onAnnotationDelete);
+  }
+
+  it.each([
+    ['a numeric id from the legacy API', 4683],
+    ['a non-numeric string id from the k8s annotations API', 'aef3b1c2-d5e6'],
+    ['a numeric string id from the sql-backed k8s annotations API', '23'],
+  ])('allows editing and deleting with %s', (_desc, id) => {
+    const { canEdit, canDelete } = getTooltip(makeAnnoVals(id));
+    expect(canEdit).toBe(true);
+    expect(canDelete).toBe(true);
+  });
+
+  it.each([
+    ['an id of 0 (loki-sourced alert annotation)', 0],
+    ['a null id', null],
+  ])('disallows editing and deleting with %s', (_desc, id) => {
+    const { canEdit, canDelete } = getTooltip(makeAnnoVals(id));
+    expect(canEdit).toBe(false);
+    expect(canDelete).toBe(false);
+  });
+
+  it('disallows editing and deleting without a dashboardUID', () => {
+    const { canEdit, canDelete } = getTooltip(makeAnnoVals(4683, null));
+    expect(canEdit).toBe(false);
+    expect(canDelete).toBe(false);
+  });
+
+  it('respects the permission callbacks', () => {
+    canEditAnnotations.mockReturnValue(false);
+    canDeleteAnnotations.mockReturnValue(false);
+    const { canEdit, canDelete } = getTooltip(makeAnnoVals('aef3b1c2-d5e6'));
+    expect(canEdit).toBe(false);
+    expect(canDelete).toBe(false);
+    expect(canEditAnnotations).toHaveBeenCalledWith('dash-1');
+    expect(canDeleteAnnotations).toHaveBeenCalledWith('dash-1');
+  });
+
+  it('passes the string id through to onAnnotationDelete', () => {
+    const { onDelete } = getTooltip(makeAnnoVals('aef3b1c2-d5e6'));
+    onDelete!();
+    expect(onAnnotationDelete).toHaveBeenCalledWith('aef3b1c2-d5e6');
+  });
+});

--- a/public/app/plugins/panel/timeseries/plugins/annotations/getAnnotationTooltip.test.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/annotations/getAnnotationTooltip.test.tsx
@@ -3,7 +3,7 @@ import { type AnnotationVals } from './types';
 
 // AnnotationVals types ids as numbers, but annotations served by the k8s annotations API
 // have string ids (metadata.name), see issue #120097
-function makeAnnoVals(id: number | string | null, dashboardUID: string | null = 'dash-1'): AnnotationVals {
+function makeAnnoVals(id: number | string | null | undefined, dashboardUID: string | null = 'dash-1'): AnnotationVals {
   return {
     time: [1759388895560],
     text: ['annotation text'],
@@ -37,6 +37,9 @@ describe('getAnnotationTooltip', () => {
 
   it.each([
     ['an id of 0 (loki-sourced alert annotation)', 0],
+    // loki-sourced alert annotations actually omit the id key on the wire (int64 zero + json omitempty),
+    // so undefined is what reaches the tooltip for them
+    ['an undefined id (loki-sourced alert annotation)', undefined],
     ['a null id', null],
   ])('disallows editing and deleting with %s', (_desc, id) => {
     const { canEdit, canDelete } = getTooltip(makeAnnoVals(id));

--- a/public/app/plugins/panel/timeseries/plugins/annotations/getAnnotationTooltip.test.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/annotations/getAnnotationTooltip.test.tsx
@@ -13,12 +13,14 @@ function makeAnnoVals(id: number | string | null | undefined, dashboardUID: stri
 }
 
 describe('getAnnotationTooltip', () => {
-  const canEditAnnotations = jest.fn(() => true);
-  const canDeleteAnnotations = jest.fn(() => true);
+  const canEditAnnotations = jest.fn();
+  const canDeleteAnnotations = jest.fn();
   const onAnnotationDelete = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
+    canEditAnnotations.mockReturnValue(true);
+    canDeleteAnnotations.mockReturnValue(true);
   });
 
   function getTooltip(annoVals: AnnotationVals) {

--- a/public/app/plugins/panel/timeseries/plugins/annotations/getAnnotationTooltip.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/annotations/getAnnotationTooltip.tsx
@@ -22,9 +22,10 @@ export function getAnnotationTooltip(
   const timeEnd = annoVals.timeEnd?.[annoIdx];
   const isRegion = annoVals.isRegion?.[annoIdx] && timeEnd != null;
 
-  // grafana can be configured to load alert rules from loki. Those annotations cannot be edited or deleted. A missing id (undefined,
-  // or 0) is the best indicator the annotation came from loki.
-  // Annotations served by the k8s annotations API have non-numeric string ids, so any truthy id is editable.
+  // Grafana can be configured to load alert rules from Loki; those annotations cannot be
+  // edited or deleted, and a falsy id (0 from the legacy API, or absent) is the best
+  // signal. k8s annotations carry non-numeric string ids; so falsy - not `> 0`
+  // This matches the `if (!annotation.id)` guard in the annotation API client.
   const canUpdateAnno = dashboardUID !== undefined && Boolean(annoId);
   const canEdit = canUpdateAnno && canEditAnnotations(dashboardUID);
   const canDelete = canUpdateAnno && canDeleteAnnotations(dashboardUID) && onAnnotationDelete != null;

--- a/public/app/plugins/panel/timeseries/plugins/annotations/getAnnotationTooltip.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/annotations/getAnnotationTooltip.tsx
@@ -22,8 +22,9 @@ export function getAnnotationTooltip(
   const timeEnd = annoVals.timeEnd?.[annoIdx];
   const isRegion = annoVals.isRegion?.[annoIdx] && timeEnd != null;
 
-  // grafana can be configured to load alert rules from loki. Those annotations cannot be edited or deleted. The id being 0 is the best indicator the annotation came from loki
-  const canUpdateAnno = dashboardUID !== undefined && annoId != null && annoId > 0;
+  // grafana can be configured to load alert rules from loki. Those annotations cannot be edited or deleted. The id being 0 is the best indicator the annotation came from loki.
+  // Annotations served by the k8s annotations API have non-numeric string ids, so anything truthy (other than loki's 0) is editable.
+  const canUpdateAnno = dashboardUID !== undefined && Boolean(annoId);
   const canEdit = canUpdateAnno && canEditAnnotations(dashboardUID);
   const canDelete = canUpdateAnno && canDeleteAnnotations(dashboardUID) && onAnnotationDelete != null;
 

--- a/public/app/plugins/panel/timeseries/plugins/annotations/getAnnotationTooltip.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/annotations/getAnnotationTooltip.tsx
@@ -22,8 +22,9 @@ export function getAnnotationTooltip(
   const timeEnd = annoVals.timeEnd?.[annoIdx];
   const isRegion = annoVals.isRegion?.[annoIdx] && timeEnd != null;
 
-  // grafana can be configured to load alert rules from loki. Those annotations cannot be edited or deleted. The id being 0 is the best indicator the annotation came from loki.
-  // Annotations served by the k8s annotations API have non-numeric string ids, so anything truthy (other than loki's 0) is editable.
+  // grafana can be configured to load alert rules from loki. Those annotations cannot be edited or deleted. A missing id (undefined,
+  // or 0) is the best indicator the annotation came from loki.
+  // Annotations served by the k8s annotations API have non-numeric string ids, so any truthy id is editable.
   const canUpdateAnno = dashboardUID !== undefined && Boolean(annoId);
   const canEdit = canUpdateAnno && canEditAnnotations(dashboardUID);
   const canDelete = canUpdateAnno && canDeleteAnnotations(dashboardUID) && onAnnotationDelete != null;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

In the case of k8s annotations, which come with string IDs, the anno tooltip does not allow editing or deleting. This PR addresses that while taking into account the niche Loki scenario that returns with a 0 ID. For Loki, we do not want to enable editing or deleting, and we figure that out based on the 0 ID. 

From what I've gathered, Loki annotations actually return undefined nowadays, so this change will not affect them.

**Why do we need this feature?**

Fixes the tooltip for k8s annotations that have string IDs.

**Who is this feature for?**

Everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Related to [this](https://raintank-corp.slack.com/archives/C09J9S0KVKK/p1784575036404719) thread

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
