### PR TITLE
Plugins: Fetch the requested version directly when installing a pinned version

### DIFF
--- a/pkg/plugins/repo/models.go
+++ b/pkg/plugins/repo/models.go
@@ -19,6 +19,7 @@ type PluginVersions struct {
 
 type Version struct {
 	Version           string              `json:"version"`
+	Status            string              `json:"status"`
 	Arch              map[string]ArchMeta `json:"packages"`
 	URL               string              `json:"url"`
 	CreatedAt         string              `json:"createdAt"`

--- a/pkg/plugins/repo/service.go
+++ b/pkg/plugins/repo/service.go
@@ -82,6 +82,17 @@ func (m *Manager) GetPluginArchiveInfo(ctx context.Context, pluginID, version st
 
 // PluginVersion will return plugin version based on the requested information
 func (m *Manager) PluginVersion(ctx context.Context, pluginID, version string, compatOpts CompatOpts) (VersionData, error) {
+	if version != "" {
+		if v, ok := m.specificPluginVersion(ctx, pluginID, version, compatOpts); ok {
+			if err := corePluginError(pluginID, v); err != nil {
+				return VersionData{}, err
+			}
+			return v, nil
+		}
+		// The requested version couldn't be used directly, so fall through to
+		// the version listing, which reproduces the existing error behavior.
+	}
+
 	versions, err := m.grafanaCompatiblePluginVersions(ctx, pluginID, compatOpts)
 	if err != nil {
 		return VersionData{}, err
@@ -92,14 +103,70 @@ func (m *Manager) PluginVersion(ctx context.Context, pluginID, version string, c
 		return VersionData{}, err
 	}
 
-	isGrafanaCorePlugin := strings.HasPrefix(compatibleVer.URL, "https://github.com/grafana/grafana/tree/main/public/app/plugins/")
-	_, hasAnyArch := compatibleVer.Arch["any"]
-	if isGrafanaCorePlugin && hasAnyArch {
-		// Trying to install a coupled core plugin
-		return VersionData{}, ErrCorePlugin(pluginID)
+	if err = corePluginError(pluginID, compatibleVer); err != nil {
+		return VersionData{}, err
 	}
 
 	return compatibleVer, nil
+}
+
+func corePluginError(pluginID string, v VersionData) error {
+	isGrafanaCorePlugin := strings.HasPrefix(v.URL, "https://github.com/grafana/grafana/tree/main/public/app/plugins/")
+	_, hasAnyArch := v.Arch["any"]
+	if isGrafanaCorePlugin && hasAnyArch {
+		// Trying to install a coupled core plugin
+		return ErrCorePlugin(pluginID)
+	}
+	return nil
+}
+
+// specificPluginVersion optimistically fetches the requested version from
+// /api/plugins/$pluginID/versions/$version, which is much cheaper for the
+// backend than the full version listing. It returns false whenever the
+// version can't be used directly, so the caller falls back to the listing.
+// The version listing only contains active versions, so any other status
+// must be rejected here to keep hidden versions uninstallable.
+func (m *Manager) specificPluginVersion(ctx context.Context, pluginID, version string, compatOpts CompatOpts) (VersionData, bool) {
+	sysCompatOpts, exists := compatOpts.System()
+	if !exists {
+		return VersionData{}, false
+	}
+
+	u, err := url.Parse(m.client.grafanaComAPIURL)
+	if err != nil {
+		return VersionData{}, false
+	}
+
+	u.Path = path.Join(u.Path, pluginID, "versions", normalizeVersion(version))
+
+	body, err := m.client.SendReq(ctx, u, compatOpts)
+	if err != nil {
+		m.log.Debugf("Failed to fetch plugin version %s v%s directly, falling back to the version listing: %s", pluginID, version, err)
+		return VersionData{}, false
+	}
+
+	var v Version
+	if err = json.Unmarshal(body, &v); err != nil {
+		m.log.Error("Failed to unmarshal plugin repo response", err)
+		return VersionData{}, false
+	}
+
+	if v.Status != "active" {
+		return VersionData{}, false
+	}
+	if v.IsCompatible != nil && !*v.IsCompatible {
+		return VersionData{}, false
+	}
+	if !supportsCurrentArch(v, sysCompatOpts) {
+		return VersionData{}, false
+	}
+
+	return VersionData{
+		Version:  v.Version,
+		Checksum: checksum(v, sysCompatOpts),
+		Arch:     v.Arch,
+		URL:      v.URL,
+	}, true
 }
 
 func (m *Manager) downloadURL(pluginID, version string) string {

--- a/pkg/plugins/repo/service_test.go
+++ b/pkg/plugins/repo/service_test.go
@@ -108,6 +108,153 @@ func TestGetPluginArchive(t *testing.T) {
 	}
 }
 
+func TestPluginVersionWithExplicitVersion(t *testing.T) {
+	const (
+		pluginID       = "grafana-test-datasource"
+		grafanaVersion = "10.0.0"
+		opSys          = "darwin"
+		arch           = "amd64"
+	)
+	compatOpts := NewCompatOpts(grafanaVersion, opSys, arch)
+
+	type hits struct {
+		single int
+		list   int
+	}
+
+	// newManager serves /versions/1.0.0 with the given status code and body,
+	// and /versions with the given listing, counting requests to each.
+	newManager := func(t *testing.T, singleStatus int, singleBody, listBody string, count *hits) *Manager {
+		t.Helper()
+		mux := http.NewServeMux()
+		mux.HandleFunc(fmt.Sprintf("/%s/versions/1.0.0", pluginID), func(w http.ResponseWriter, r *http.Request) {
+			count.single++
+			require.Equal(t, grafanaVersion, r.Header.Get("grafana-version"))
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(singleStatus)
+			_, _ = w.Write([]byte(singleBody))
+		})
+		mux.HandleFunc(fmt.Sprintf("/%s/versions", pluginID), func(w http.ResponseWriter, r *http.Request) {
+			count.list++
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(listBody))
+		})
+		srv := httptest.NewServer(mux)
+		t.Cleanup(srv.Close)
+		return NewManager(ManagerCfg{
+			SkipTLSVerify: false,
+			BaseURL:       srv.URL,
+			Logger:        log.NewTestPrettyLogger(),
+		})
+	}
+
+	activeSingle := `{"version": "1.0.0", "status": "active", "packages": {"darwin-amd64": {"sha256": "abc"}}, "url": "https://github.com/grafana/test", "isCompatible": true}`
+	listWithV100 := `{"items": [{"version": "1.0.0", "packages": {"darwin-amd64": {"sha256": "abc"}}, "url": "https://github.com/grafana/test", "isCompatible": true}]}`
+	listWithoutV100 := `{"items": [{"version": "2.0.0", "packages": {"darwin-amd64": {"sha256": "def"}}, "isCompatible": true}]}`
+
+	t.Run("active version is fetched directly without the listing", func(t *testing.T) {
+		count := &hits{}
+		m := newManager(t, http.StatusOK, activeSingle, listWithV100, count)
+
+		v, err := m.PluginVersion(context.Background(), pluginID, "1.0.0", compatOpts)
+		require.NoError(t, err)
+		require.Equal(t, "1.0.0", v.Version)
+		require.Equal(t, "abc", v.Checksum)
+		require.Equal(t, hits{single: 1, list: 0}, *count)
+	})
+
+	t.Run("version prefix is normalized before the direct fetch", func(t *testing.T) {
+		count := &hits{}
+		m := newManager(t, http.StatusOK, activeSingle, listWithV100, count)
+
+		v, err := m.PluginVersion(context.Background(), pluginID, "v1.0.0", compatOpts)
+		require.NoError(t, err)
+		require.Equal(t, "1.0.0", v.Version)
+		require.Equal(t, hits{single: 1, list: 0}, *count)
+	})
+
+	t.Run("no explicit version uses the listing only", func(t *testing.T) {
+		count := &hits{}
+		m := newManager(t, http.StatusOK, activeSingle, listWithV100, count)
+
+		v, err := m.PluginVersion(context.Background(), pluginID, "", compatOpts)
+		require.NoError(t, err)
+		require.Equal(t, "1.0.0", v.Version)
+		require.Equal(t, hits{single: 0, list: 1}, *count)
+	})
+
+	t.Run("missing version falls back and keeps the not found error", func(t *testing.T) {
+		count := &hits{}
+		m := newManager(t, http.StatusNotFound, `{"code": "NotFound"}`, listWithoutV100, count)
+
+		_, err := m.PluginVersion(context.Background(), pluginID, "1.0.0", compatOpts)
+		require.ErrorIs(t, err, ErrVersionNotFoundBase)
+		require.Equal(t, hits{single: 1, list: 1}, *count)
+	})
+
+	t.Run("non-active version stays uninstallable", func(t *testing.T) {
+		// the listing only contains active versions, so a pending version is
+		// not found today; the direct fetch returns it and must reject it
+		pendingSingle := `{"version": "1.0.0", "status": "pending", "packages": {"darwin-amd64": {"sha256": "abc"}}, "isCompatible": true}`
+		count := &hits{}
+		m := newManager(t, http.StatusOK, pendingSingle, listWithoutV100, count)
+
+		_, err := m.PluginVersion(context.Background(), pluginID, "1.0.0", compatOpts)
+		require.ErrorIs(t, err, ErrVersionNotFoundBase)
+		require.Equal(t, hits{single: 1, list: 1}, *count)
+	})
+
+	t.Run("incompatible version keeps the not compatible error", func(t *testing.T) {
+		incompatibleSingle := `{"version": "1.0.0", "status": "active", "packages": {"darwin-amd64": {"sha256": "abc"}}, "isCompatible": false}`
+		listV100Incompatible := `{"items": [
+			{"version": "2.0.0", "packages": {"darwin-amd64": {"sha256": "def"}}, "isCompatible": true},
+			{"version": "1.0.0", "packages": {"darwin-amd64": {"sha256": "abc"}}, "isCompatible": false}
+		]}`
+		count := &hits{}
+		m := newManager(t, http.StatusOK, incompatibleSingle, listV100Incompatible, count)
+
+		_, err := m.PluginVersion(context.Background(), pluginID, "1.0.0", compatOpts)
+		require.ErrorIs(t, err, ErrVersionNotCompatibleBase)
+		require.Equal(t, hits{single: 1, list: 1}, *count)
+	})
+
+	t.Run("unsupported arch keeps the unsupported error", func(t *testing.T) {
+		linuxOnlySingle := `{"version": "1.0.0", "status": "active", "packages": {"linux-amd64": {"sha256": "abc"}}, "isCompatible": true}`
+		listV100LinuxOnly := `{"items": [
+			{"version": "2.0.0", "packages": {"darwin-amd64": {"sha256": "def"}}, "isCompatible": true},
+			{"version": "1.0.0", "packages": {"linux-amd64": {"sha256": "abc"}}, "isCompatible": true}
+		]}`
+		count := &hits{}
+		m := newManager(t, http.StatusOK, linuxOnlySingle, listV100LinuxOnly, count)
+
+		_, err := m.PluginVersion(context.Background(), pluginID, "1.0.0", compatOpts)
+		require.ErrorIs(t, err, ErrVersionUnsupportedBase)
+		require.Equal(t, hits{single: 1, list: 1}, *count)
+	})
+
+	t.Run("direct fetch failure falls back to the listing", func(t *testing.T) {
+		count := &hits{}
+		m := newManager(t, http.StatusInternalServerError, `oops`, listWithV100, count)
+
+		v, err := m.PluginVersion(context.Background(), pluginID, "1.0.0", compatOpts)
+		require.NoError(t, err)
+		require.Equal(t, "1.0.0", v.Version)
+		require.Equal(t, "abc", v.Checksum)
+		require.Equal(t, hits{single: 1, list: 1}, *count)
+	})
+
+	t.Run("core plugin is rejected on the direct fetch", func(t *testing.T) {
+		coreSingle := `{"version": "1.0.0", "status": "active", "packages": {"any": {"sha256": "abc"}}, "url": "https://github.com/grafana/grafana/tree/main/public/app/plugins/test", "isCompatible": true}`
+		count := &hits{}
+		m := newManager(t, http.StatusOK, coreSingle, listWithV100, count)
+
+		_, err := m.PluginVersion(context.Background(), pluginID, "1.0.0", compatOpts)
+		require.ErrorIs(t, err, ErrCorePluginBase)
+		require.Equal(t, hits{single: 1, list: 0}, *count)
+	})
+}
+
 func TestPluginIndex(t *testing.T) {
 	const (
 		pluginID = "grafana-test-datasource"


### PR DESCRIPTION
**What is this feature?**

When a plugin is installed with an explicit version (`grafana-cli plugins install <id> <version>`, pinned preinstalls, catalog installs), the installer now fetches `/api/plugins/{id}/versions/{version}` directly instead of downloading the full version list and picking the requested version out of it. If the direct fetch can't be used (version missing, not active, incompatible with the running Grafana version, no build for the current OS/arch, or the request fails), the installer falls back to the existing list-based flow, so every error case behaves exactly as before.

**Why do we need this feature?**

The version list endpoint returns every version of a plugin and is much more expensive for grafana.com to serve than the single version lookup. Installs with a pinned version are the common case in automated environments where many instances install the same plugins at the same time, and none of them need the full list. The update flow also fetches the list twice per update today (once to resolve, once to download).

The fallback also covers a subtle case on purpose: the list endpoint only contains active versions, while the single version endpoint returns pending, preview and deprecated versions too. The direct fetch rejects anything not active, so versions that are hidden from the list stay uninstallable and keep failing with the same version-not-found error.

**Who is this feature for?**

Anyone installing plugins with pinned versions, and grafana.com which serves the requests.

**Which issue(s) does this PR fix?**:

**Special notes for your reviewer:**

The new `TestPluginVersionWithExplicitVersion` pins the behavior parity: each fallback case asserts the same error as the current flow and counts requests to both endpoints. The pre-existing `TestGetPluginArchive` mock has no single-version route, so it now exercises the fallback path as well.
