### PR TITLE
fix(e2e): remove unused imports and fix type mismatch in dashboard-new-layouts specs

### DIFF
--- a/e2e-playwright/dashboard-new-layouts/dashboard-url-syncing.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboard-url-syncing.spec.ts
@@ -1,4 +1,5 @@
 import { selectors } from '@grafana/e2e-selectors';
+import type { E2ESelectorGroups } from '@grafana/plugin-e2e';
 
 import v2DashboardWithTabsForSlug from '../dashboards/V2DashboardWithTabsForSlugTest.json';
 
@@ -99,7 +100,7 @@ test.describe(
       try {
         await flows.dashboards.importTestDashboard(
           page,
-          selectors,
+          selectors as unknown as E2ESelectorGroups,
           'url-sync-tabs-test',
           JSON.stringify(v2DashboardWithTabsForSlug)
         );


### PR DESCRIPTION
These three spec files in e2e-playwright/dashboard-new-layouts/ have TypeScript errors that would surface if the directory were included in a tsconfig (see #129355). The errors are all unused imports/variables plus one type mismatch, none of them affect runtime behavior.

dashboards-repeats-auto-grid.spec.ts: removed unused Page (playwright-core) and DashboardPage (@grafana/plugin-e2e) imports that were left over from a page-object migration.

dashboards-repeats-custom-grid.spec.ts: removed the unused goToPanelSnapshot import (only referenced in commented-out test bodies) and the unused embedPanelTitle local variable in the embedded-panel test.

dashboard-url-syncing.spec.ts: the beforeAll hook passes the module-level selectors constant from @grafana/e2e-selectors to importTestDashboard, which expects E2ESelectorGroups (the fixture-provided type that also carries constants and apis). Added an explicit cast so the call type-checks; the function only reads selectors.pages and selectors.components, both present on the module-level constant.

Fixes part of #129355.