### PR TITLE
featuremgmt: migrate reportingV2Layouts to OpenFeature

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -329,11 +329,6 @@ export interface FeatureToggles {
   */
   pdfTables?: boolean;
   /**
-  * Enable v2 dashboard layout support in reports (auto-grid, tabs, rows)
-  * @default false
-  */
-  reportingV2Layouts?: boolean;
-  /**
   * Enables render binding support for report rendering
   * @default false
   */

--- a/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
@@ -23,6 +23,7 @@ declare module "@openfeature/core" {
     | "grafana.newPanelQueryErrorsUI"
     | "useKubernetesShortURLsAPI"
     | "dashboard.notebooks"
+    | "grafana.reportingV2Layouts"
     | "stateTimeline.nameAboveBars"
     | "grafana.secretsReferenceValueUI"
     | "sqlExpressionsColumnAutoComplete"

--- a/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
@@ -85,6 +85,8 @@ export const FlagKeys = {
   GrafanaPanelEditNextFeedbackEvent: "grafana.panelEditNextFeedbackEvent",
   /** Enables a redesigned query variable editor with split-pane preview and a spreadsheet for managing static options */
   GrafanaQueryVarEditorRedesign: "grafana.queryVarEditorRedesign",
+  /** Enable v2 dashboard layout support in reports (auto-grid, tabs, rows) */
+  GrafanaReportingV2Layouts: "grafana.reportingV2Layouts",
   /** Enables the dedicated Saved queries page and its navigation entry */
   GrafanaSavedQueriesPage: "grafana.savedQueriesPage",
   /** Prevents flickering in dashboards */
@@ -551,6 +553,17 @@ export const useFlagGrafanaPanelEditNextFeedbackEvent = (options?: ReactFlagEval
  */
 export const useFlagGrafanaQueryVarEditorRedesign = (options?: ReactFlagEvaluationOptions): boolean => {
   return useFlag("grafana.queryVarEditorRedesign", true, options).value;
+};
+
+/**
+ * Enable v2 dashboard layout support in reports (auto-grid, tabs, rows)
+ *
+ * **Details:**
+ * - flag key: `grafana.reportingV2Layouts`
+ * - default value: `false`
+ */
+export const useFlagGrafanaReportingV2Layouts = (options?: ReactFlagEvaluationOptions): boolean => {
+  return useFlag("grafana.reportingV2Layouts", false, options).value;
 };
 
 /**

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -709,10 +709,10 @@ var (
 			Expression:  "false",
 		},
 		{
-			Name:        "reportingV2Layouts",
+			Name:        "grafana.reportingV2Layouts",
 			Description: "Enable v2 dashboard layout support in reports (auto-grid, tabs, rows)",
 			Stage:       FeatureStageExperimental,
-			Generate:    Generate{LegacyFrontend: true},
+			Generate:    Generate{React: true},
 			Owner:       grafanaOperatorExperienceSquad,
 			Expression:  "false",
 		},

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -80,7 +80,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2024-12-02,feedbackButton,preview,@grafana/dashboards-squad,false,false,true
 2023-11-06,pdfTables,preview,@grafana/grafana-operator-experience-squad,false,false,false
 2026-05-22,reporting.pdfTablesFrontend,experimental,@grafana/grafana-operator-experience-squad,false,false,false
-2026-05-22,reportingV2Layouts,experimental,@grafana/grafana-operator-experience-squad,false,false,true
+2026-07-28,grafana.reportingV2Layouts,experimental,@grafana/grafana-operator-experience-squad,false,false,true
 2026-05-22,reportRenderBinding,experimental,@grafana/grafana-operator-experience-squad,false,false,false
 2024-01-02,canvasPanelPanZoom,preview,@grafana/dataviz-squad,false,false,true
 2026-06-08,canvasExternalPlugin,experimental,@grafana/dataviz-squad,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2995,6 +2995,20 @@
     },
     {
       "metadata": {
+        "name": "grafana.reportingV2Layouts",
+        "resourceVersion": "1785231301633",
+        "creationTimestamp": "2026-07-28T09:35:01Z"
+      },
+      "spec": {
+        "description": "Enable v2 dashboard layout support in reports (auto-grid, tabs, rows)",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-operator-experience-squad",
+        "frontend": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "grafana.savedQueriesPage",
         "resourceVersion": "1784068714544",
         "creationTimestamp": "2026-07-14T22:38:34Z"
@@ -5390,7 +5404,8 @@
       "metadata": {
         "name": "reportingV2Layouts",
         "resourceVersion": "1779440584464",
-        "creationTimestamp": "2026-05-22T09:03:04Z"
+        "creationTimestamp": "2026-05-22T09:03:04Z",
+        "deletionTimestamp": "2026-07-28T09:35:01Z"
       },
       "spec": {
         "description": "Enable v2 dashboard layout support in reports (auto-grid, tabs, rows)",


### PR DESCRIPTION
## Summary

Migrates the `reportingV2Layouts` feature flag to OpenFeature as part of the [operator-experience feature-flag migration epic](https://github.com/grafana/grafana-operator-experience-squad/issues/1602) (sub-issue: [#1929](https://github.com/grafana/grafana-operator-experience-squad/issues/1929)).

- Renamed `reportingV2Layouts` → `grafana.reportingV2Layouts` to satisfy the `component.flagName` naming convention enforced by `verifyFlagName` in `pkg/services/featuremgmt/toggles_gen_test.go` once the `Legacy*` fields are removed.
- Switched `Generate{LegacyFrontend: true}` → `Generate{React: true}` so the flag is emitted into `packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts` and readable via the OpenFeature client, and no longer via the deprecated `config.featureToggles.*` path.
- Regenerated `toggles_gen.json`, `toggles_gen.csv`, `featureToggles.gen.ts`, `openfeature.gen.ts`, `openfeature-types.gen.d.ts` via `make gen-feature-toggles`.

The rename is safe because the flag has **no callsites** in `grafana`, `grafana-enterprise`, or any adjacent repo — it was defined but never consumed.

## Test plan

- [ ] `make gen-feature-toggles` reports "feature toggles already up-to-date" (i.e. codegen is stable)
- [ ] CI passes