### PR TITLE
Table: Use aria-expanded on the column filter trigger

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableNG/Filter/Filter.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Filter/Filter.tsx
@@ -66,7 +66,7 @@ export const Filter = memo(
         ref={ref}
         type="button"
         aria-haspopup="dialog"
-        aria-pressed={isPopoverVisible}
+        aria-expanded={isPopoverVisible}
         aria-label={t('grafana-ui.table.filter.button', `Filter {{name}}`, {
           name: field ? getDisplayName(field) : '',
         })}

--- a/packages/grafana-ui/src/components/Table/TableNG/components/HeaderCell.test.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/components/HeaderCell.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { type Field, FieldType } from '@grafana/data';
 import { type Column } from '@grafana/react-data-grid';
@@ -75,6 +76,14 @@ describe('HeaderCell', () => {
   it('does not render a filter button when the field is not filterable', () => {
     render(<HeaderCell {...baseProps} field={makeField()} />);
     expect(screen.queryByLabelText('Filter Field1')).not.toBeInTheDocument();
+  });
+
+  it('exposes the filter popover state via aria-expanded on the filter button', async () => {
+    render(<HeaderCell {...baseProps} field={makeField({ config: { custom: { filterable: true } } })} />);
+    const filterButton = screen.getByLabelText('Filter Field1');
+    expect(filterButton).toHaveAttribute('aria-expanded', 'false');
+    await userEvent.click(filterButton);
+    expect(filterButton).toHaveAttribute('aria-expanded', 'true');
   });
 
   it('removes a stale filter for a field that is no longer filterable', () => {


### PR DESCRIPTION
**What is this feature?**

Changes the table column filter trigger from `aria-pressed` to `aria-expanded` (`Filter.tsx`) so that screen readers can announce expanded or collapsed for the filter popover instead of a pressed toggle state.
The button already has `aria-haspopup="dialog"` so adding `aria-expanded` completes the standard disclosure pattern and matches how the rest of TableNG communicates expansion e.g. `RowExpander`, nested rows, and the styles keyed on `[aria-expanded]`

**Why do we need this feature?**

#113434 reported the filter button announcing as just "Button" with no state. The naming half was fixed by #117354 which added `aria-label="Filter {column}"` and #118141 then added `aria-haspopup` and `aria-pressed` for the state, but the issue stayed open as screen readers announce pressed rather than the Expanded/Collapsed the reporter expected.

This PR swaps that attribute so the state #118141 wired up announces correctly. `aria-pressed` here tracks popover visibility which is expansion state in toggle clothing essentially

**Who is this feature for?**

Screen reader users filtering table columns

**Which issue(s) does this PR fix?**:

Fixes #113434

**Special notes for your reviewer:**

Added a unit test asserting `aria-expanded` flips false to true when the trigger opens the popover. The test fails against the previous attribute.
The nearby `aria-pressed` usages, match-case toggle in `FilterPopup` and pin toggle in `TableCellTooltip`, are genuine toggles and are deliberately untouched

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.