### PR TITLE
Frontend: Add e2e selectors for pathfinder guides

### DIFF
--- a/e2e-playwright/dashboard-new-layouts/dashboard-group-panels.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboard-group-panels.spec.ts
@@ -40,7 +40,7 @@ test.describe(
       await page.getByTestId(selectors.components.DashboardImportPage.submit).click();
       await page.getByTestId(selectors.components.ImportDashboardForm.name).fill(title);
       await page.getByTestId(selectors.components.DataSourcePicker.inputV2).click();
-      await page.locator('div[data-testid="data-source-card"]').first().click();
+      await page.locator('div[data-testid^="data-testid data source card"]').first().click();
       await page.getByTestId(selectors.components.ImportDashboardForm.submit).click();
     }
 

--- a/e2e-playwright/dashboard-new-layouts/utils.ts
+++ b/e2e-playwright/dashboard-new-layouts/utils.ts
@@ -184,7 +184,7 @@ export async function importTestDashboard(
   await page.getByTestId(selectors.components.ImportDashboardForm.name).fill(title);
   if (options.requiresDataSourceSelection) {
     await page.getByTestId(selectors.components.DataSourcePicker.inputV2).click();
-    await page.locator('div[data-testid="data-source-card"]').first().click();
+    await page.locator('div[data-testid^="data-testid data source card"]').first().click();
   }
   await page.getByTestId(selectors.components.ImportDashboardForm.submit).click();
   const undockMenuButton = page.locator('[aria-label="Undock menu"]');

--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -185,6 +185,9 @@ export const versionedComponents = {
     absoluteTimeRangeTitle: {
       [MIN_GRAFANA_VERSION]: 'data-testid-absolute-time-range-narrow',
     },
+    timeRangeOption: {
+      '13.2.0': (from: string, to: string) => `data-testid TimePicker time range option ${from} to ${to}`,
+    },
   },
   DataSourcePermissions: {
     form: { '9.5.0': () => 'form[name="addPermission"]' },
@@ -1154,6 +1157,16 @@ export const versionedComponents = {
       },
     },
   },
+  CommandPalette: {
+    searchInput: {
+      '13.2.0': 'data-testid Command palette search input',
+    },
+  },
+  SearchField: {
+    searchInput: {
+      '13.2.0': 'data-testid Search field input',
+    },
+  },
 
   PageToolbar: {
     container: { [MIN_GRAFANA_VERSION]: () => '.page-toolbar' },
@@ -1285,6 +1298,11 @@ export const versionedComponents = {
     },
     dataSourceList: {
       '10.4.0': 'data-testid Data source list dropdown',
+    },
+    dataSourceCard: {
+      '13.2.0': (name: string) => `data-testid data source card ${name}`,
+      // Before 13.2.0 the card carried a hardcoded, non-parameterized testid.
+      [MIN_GRAFANA_VERSION]: (_name: string) => 'data-source-card',
     },
     advancedModal: {
       dataSourceList: {

--- a/packages/grafana-e2e-selectors/src/selectors/pages.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/pages.ts
@@ -70,6 +70,7 @@ export const versionedPages = {
       [MIN_GRAFANA_VERSION]: '/datasources',
     },
     dataSources: {
+      '13.2.0': (dataSourceName: string) => `data-testid Data source list item ${dataSourceName}`,
       [MIN_GRAFANA_VERSION]: (dataSourceName: string) => `Data source list item ${dataSourceName}`,
     },
     dataSourceAddButton: {
@@ -95,6 +96,16 @@ export const versionedPages = {
       '13.1.0': (pluginName: string) => `data-testid Add new data source ${pluginName}`,
       '9.3.1': (pluginName: string) => `Add new data source ${pluginName}`,
       [MIN_GRAFANA_VERSION]: (pluginName: string) => `Data source plugin item ${pluginName}`,
+    },
+  },
+  Connections: {
+    AddNewConnection: {
+      url: {
+        '13.2.0': '/connections/add-new-connection',
+      },
+      pluginCard: {
+        '13.2.0': (name: string) => `data-testid Connections plugin card ${name}`,
+      },
     },
   },
   ConfirmModal: {
@@ -1041,6 +1052,9 @@ export const versionedPages = {
       addTo: {
         '12.4.0': 'data-testid explore-toolbar-add-dropdown-button',
       },
+      addToDashboardButton: {
+        '13.2.0': 'data-testid explore-toolbar-add-to-dashboard-button',
+      },
       share: {
         '12.4.0': 'data-testid explore-toolbar-share-button',
       },
@@ -1110,6 +1124,9 @@ export const versionedPages = {
     },
   },
   BrowseDashboards: {
+    searchInput: {
+      '13.2.0': 'data-testid Browse dashboards search input',
+    },
     table: {
       body: {
         '10.2.0': 'data-testid browse-dashboards-table',

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeOption.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeOption.tsx
@@ -2,6 +2,7 @@ import { css, cx } from '@emotion/css';
 import { memo, useId } from 'react';
 
 import { type GrafanaTheme2, type TimeOption } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
 
 import { useStyles2 } from '../../../themes/ThemeContext';
 import { getFocusStyles } from '../../../themes/mixins';
@@ -65,7 +66,10 @@ export const TimeRangeOption = memo<Props>(({ value, onSelect, selected = false,
   const id = useId();
 
   return (
-    <li className={styles.container}>
+    <li
+      className={styles.container}
+      data-testid={selectors.components.TimePicker.timeRangeOption(value.from, value.to)}
+    >
       <input
         className={styles.radio}
         checked={selected}

--- a/public/app/features/browse-dashboards/BrowseDashboardsPage.tsx
+++ b/public/app/features/browse-dashboards/BrowseDashboardsPage.tsx
@@ -5,6 +5,7 @@ import { useLocation, useParams } from 'react-router-dom-v5-compat';
 import AutoSizer, { type Size } from 'react-virtualized-auto-sizer';
 
 import { type GrafanaTheme2 } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
 import { Drawer, FilterInput, IconButton, useStyles2, Text, Stack } from '@grafana/ui';
@@ -184,6 +185,7 @@ const BrowseDashboardsPage = memo(({ queryParams }: { queryParams: Record<string
         {isRecentlyViewedEnabled && <RecentlyViewedDashboards />}
         <div>
           <FilterInput
+            data-testid={selectors.pages.BrowseDashboards.searchInput}
             placeholder={getSearchPlaceholder(searchState.includePanels)}
             value={searchState.query}
             escapeRegex={false}

--- a/public/app/features/commandPalette/KBarSearch.tsx
+++ b/public/app/features/commandPalette/KBarSearch.tsx
@@ -3,6 +3,7 @@ import { useKBar, VisualState } from 'kbar';
 import * as React from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
 import { useStyles2 } from '@grafana/ui';
 
 const KBAR_LISTBOX = 'kbar-listbox';
@@ -47,6 +48,7 @@ export function KBarSearch(
       /* eslint-disable-next-line jsx-a11y/no-autofocus */
       autoFocus
       autoComplete="off"
+      data-testid={selectors.components.CommandPalette.searchInput}
       role="combobox"
       spellCheck="false"
       aria-expanded={showing}

--- a/public/app/features/connections/tabs/ConnectData/CardGrid/CardGrid.tsx
+++ b/public/app/features/connections/tabs/ConnectData/CardGrid/CardGrid.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/css';
 import * as React from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 import { featureEnabled } from '@grafana/runtime';
 import { Badge, Card, Grid, Stack, useStyles2 } from '@grafana/ui';
@@ -88,6 +89,7 @@ export const CardGrid = ({ items, onClickItem }: CardGridProps) => {
           noMargin
           className={styles.card}
           href={item.url}
+          data-testid={selectors.pages.Connections.AddNewConnection.pluginCard(item.name)}
           onClick={(e) => {
             if (onClickItem) {
               onClickItem(e, item);

--- a/public/app/features/datasources/components/DataSourcesList.tsx
+++ b/public/app/features/datasources/components/DataSourcesList.tsx
@@ -3,6 +3,7 @@ import { useVirtualizer } from '@tanstack/react-virtual';
 import { type RefObject, useEffect, useMemo, useRef, useState } from 'react';
 
 import { type DataSourceSettings, type GrafanaTheme2 } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { useFavoriteDatasources, type FavoriteDatasources } from '@grafana/runtime';
 import { EmptyState, LinkButton, TextLink, useStyles2, useTheme2 } from '@grafana/ui';
@@ -123,7 +124,13 @@ export function DataSourcesListView({
       <EmptyState
         variant="call-to-action"
         button={
-          <LinkButton disabled={!hasCreateRights} href={ROUTES.DataSourcesNew} icon="database" size="lg">
+          <LinkButton
+            disabled={!hasCreateRights}
+            href={ROUTES.DataSourcesNew}
+            icon="database"
+            size="lg"
+            data-testid={selectors.pages.DataSources.dataSourceAddButton}
+          >
             <Trans i18nKey="data-source-list.empty-state.button-title">Add data source</Trans>
           </LinkButton>
         }

--- a/public/app/features/datasources/components/DataSourcesListCard.tsx
+++ b/public/app/features/datasources/components/DataSourcesListCard.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/css';
 import Skeleton from 'react-loading-skeleton';
 
 import { type DataSourceSettings, type GrafanaTheme2 } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
 import { Trans } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 import { Card, LinkButton, Stack, Tag, useStyles2 } from '@grafana/ui';
@@ -25,7 +26,11 @@ export function DataSourcesListCard({ dataSource, hasWriteRights, hasExploreRigh
   const styles = useStyles2(getStyles);
 
   return (
-    <Card noMargin href={hasWriteRights ? dsLink : undefined}>
+    <Card
+      noMargin
+      href={hasWriteRights ? dsLink : undefined}
+      data-testid={selectors.pages.DataSources.dataSources(dataSource.name)}
+    >
       <Card.Heading>{dataSource.name}</Card.Heading>
       <Card.Figure>
         <img src={dataSource.typeLogoUrl} alt="" height="40px" width="40px" className={styles.logo} />

--- a/public/app/features/datasources/components/picker/DataSourceCardItem.tsx
+++ b/public/app/features/datasources/components/picker/DataSourceCardItem.tsx
@@ -1,4 +1,5 @@
 import type { DataSourceInstanceSettings, DataSourceRef } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
 import { type FavoriteDatasources, reportInteraction } from '@grafana/runtime';
 
 import { DataSourceCard } from './DataSourceCard';
@@ -26,7 +27,7 @@ export function DataSourceCardItem({
 }: DataSourceCardItemProps) {
   return (
     <DataSourceCard
-      data-testid="data-source-card"
+      data-testid={selectors.components.DataSourcePicker.dataSourceCard(ds.name)}
       {...(enableKeyboardNavigation && {
         'data-role': 'keyboardSelectableItem',
         'data-selecteditem': isSelected ? 'true' : 'false',

--- a/public/app/features/datasources/components/picker/DataSourceModal.test.tsx
+++ b/public/app/features/datasources/components/picker/DataSourceModal.test.tsx
@@ -190,7 +190,7 @@ describe('DataSourceDropdown with virtualized list', () => {
 
   it('should render only a subset of items in the DOM', async () => {
     setup({ current: largeMockDSList[0] });
-    const cards = await screen.findAllByTestId('data-source-card');
+    const cards = await screen.findAllByTestId(/^data-testid data source card/);
     expect(cards.length).toBeGreaterThan(0);
     expect(cards.length).toBeLessThan(100);
   });
@@ -200,7 +200,7 @@ describe('DataSourceDropdown with virtualized list', () => {
     const onChange = jest.fn();
     setup({ onChange, current: largeMockDSList[0] });
 
-    const cards = await screen.findAllByTestId('data-source-card');
+    const cards = await screen.findAllByTestId(/^data-testid data source card/);
     const button = cards[1].querySelector('button')!;
     await user.click(button);
     expect(onChange).toHaveBeenCalledTimes(1);
@@ -215,7 +215,7 @@ describe('DataSourceDropdown with virtualized list', () => {
     await user.keyboard('datasource-50');
 
     expect(await screen.findByText('datasource-50', { selector: 'span' })).toBeInTheDocument();
-    const cards = screen.getAllByTestId('data-source-card');
+    const cards = screen.getAllByTestId(/^data-testid data source card/);
     // Search should narrow the list significantly
     expect(cards.length).toBeLessThan(10);
   });

--- a/public/app/features/datasources/components/picker/DataSourcePicker.test.tsx
+++ b/public/app/features/datasources/components/picker/DataSourcePicker.test.tsx
@@ -160,13 +160,13 @@ describe('DataSourcePicker', () => {
       //Mock ds is set as current, it appears on top
       getInstanceSettingsMock.mockReturnValue(mockDS1);
       await setupOpenDropdown(user, { onChange: jest.fn(), current: mockDS1.name });
-      let cards = await screen.findAllByTestId('data-source-card');
+      let cards = await screen.findAllByTestId(/^data-testid data source card/);
       expect(await findByText(cards[0], mockDS1.name, { selector: 'span' })).toBeInTheDocument();
 
       //xMock ds is set as current, it appears on top
       getInstanceSettingsMock.mockReturnValue(mockDS2);
       await setupOpenDropdown(user, { onChange: jest.fn(), current: mockDS2.name });
-      cards = await screen.findAllByTestId('data-source-card');
+      cards = await screen.findAllByTestId(/^data-testid data source card/);
       expect(await findByText(cards[0], mockDS2.name, { selector: 'span' })).toBeInTheDocument();
     });
 

--- a/public/app/features/explore/extensions/AddToDashboard/index.tsx
+++ b/public/app/features/explore/extensions/AddToDashboard/index.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
+import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 import { onInteraction, reportInteraction } from '@grafana/runtime';
 import { Modal, ToolbarButton } from '@grafana/ui';
@@ -49,6 +50,7 @@ export const AddToDashboard = ({ exploreId }: Props) => {
         onClick={() => setIsOpen(true)}
         aria-label={addToDashboardLabel}
         disabled={!explorePaneHasQueries}
+        data-testid={selectors.pages.Explore.toolbar.addToDashboardButton}
       >
         {addToDashboardLabel}
       </ToolbarButton>

--- a/public/app/features/plugins/admin/components/SearchField.tsx
+++ b/public/app/features/plugins/admin/components/SearchField.tsx
@@ -2,6 +2,7 @@ import { useState, useRef } from 'react';
 import * as React from 'react';
 import { useDebounce } from 'react-use';
 
+import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 import { FilterInput } from '@grafana/ui';
 
@@ -38,6 +39,7 @@ export const SearchField = ({ id, value, onSearch }: Props) => {
   return (
     <FilterInput
       id={id}
+      data-testid={selectors.components.SearchField.searchInput}
       value={query}
       onKeyDown={(e) => {
         if (e.key === 'Enter' || e.keyCode === 13) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Adds versioned `13.2.0` selectors to `@grafana/e2e-selectors` and adds them to the JSX that previously had no stable test hooks:

- Command palette search input
- Browse-dashboards search input
- Time picker range options (parameterized by `from`/`to`)
- Connections "Add new connection" plugin cards + plugins search field
- Data source list cards (wires the previously-unused `pages.DataSources.dataSources` selector) and the empty-state "Add data source" button (reuses `dataSourceAddButton`)
- Standalone "Add to dashboard" button in the Explore toolbar
- Data source picker cards: the hardcoded `data-testid="data-source-card"` (identical on every card) is now parameterized by datasource name

**Why do we need this feature?**

Based on an audit of the Grafana Pathfinder bundled interactive guides found lots of weak `reftarget` selectors (`button:contains(...)`, `:nth-match`, placeholder/aria text) because these elements expose nothing stable to target. 

Text-based selectors break under i18n and copy changes and positional selectors break on layout changes. 

**Who is this feature for?**

Grafana users,  Pathfinder guide authors, e2e test authors

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
