### PR TITLE
Search: derive the exact-term filter decision from field capabilities

### DIFF
--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -822,9 +822,7 @@ func (b *bleveBackend) BuildIndex(
 	}
 
 	idx := b.newBleveIndex(key, prepared.index, prepared.indexStorage, fields, allFields, standardSearchFields, updater, b.log.New("namespace", key.Namespace, "group", key.Group, "resource", key.Resource))
-	idx.facetFieldByRequestName = facetFieldsForMapping(searchFieldsProvider, key.Group, key.Resource)
-	idx.fieldVariants = fieldVariantsOf(fieldDefinitionsForMapping(searchFieldsProvider, key.Group, key.Resource))
-	idx.textQueryKinds = textQueryKindsForMapping(searchFieldsProvider, key.Group, key.Resource, selectableFields)
+	idx.searchFields = newKindSearchFields(searchFieldsProvider, key.Group, key.Resource, selectableFields)
 
 	if prepared.source.needsBuild() {
 		// Type-convert so buildIndexFromScratch can call updateResourceVersion after the builder returns.
@@ -1238,9 +1236,7 @@ func (b *bleveBackend) promoteBuildIndexToFile(
 	}
 
 	promoted := b.newBleveIndex(key, fileIndex, indexStorageFile, fields, allFields, standardSearchFields, updater, delegate.logger)
-	promoted.facetFieldByRequestName = delegate.facetFieldByRequestName
-	promoted.fieldVariants = delegate.fieldVariants
-	promoted.textQueryKinds = delegate.textQueryKinds
+	promoted.searchFields = delegate.searchFields
 	promoted.resourceVersion.Store(delegate.resourceVersion.Load())
 	cleanup = false
 
@@ -1617,16 +1613,9 @@ type bleveIndex struct {
 
 	standard resource.SearchableDocumentFields
 	fields   resource.SearchableDocumentFields
-	// facetFieldByRequestName maps ResourceSearchRequest facet field names to
-	// keyword-analyzed Bleve index field names.
-	facetFieldByRequestName map[string]string
-	// fieldVariants drives the index-time copy of per-kind values into the
-	// variant fields this kind's mapping declares. Derived from the same
-	// declarations as the mapping, once per index rather than per document.
-	fieldVariants []fieldVariant
-	// textQueryKinds maps physical index field names to the query their
-	// analyzer needs.
-	textQueryKinds map[string]textQueryKind
+	// searchFields is what this kind's declarations mean for querying and
+	// indexing, so neither has to consult a hardcoded name list.
+	searchFields kindSearchFields
 
 	indexStorage string // memory or file, used when updating metrics
 
@@ -1712,7 +1701,7 @@ func (b *bleveIndex) BulkIndex(req *resource.BulkIndexRequest) error {
 				return fmt.Errorf("missing document")
 			}
 			doc := item.Doc.UpdateCopyFields()
-			populateFieldVariants(doc, b.fieldVariants)
+			populateFieldVariants(doc, b.searchFields.variants)
 
 			// The static fields.* mapping drops values written under an undeclared
 			// name; collect them so the loss is logged, not silent.
@@ -1757,7 +1746,7 @@ func (b *bleveIndex) isDeclaredField(name string) bool {
 	// Variant fields are mapped but never named by a document builder, so they
 	// only show up here when a document is indexed twice.
 	bare := strings.TrimPrefix(name, resource.SEARCH_FIELD_PREFIX)
-	for _, v := range b.fieldVariants {
+	for _, v := range b.searchFields.variants {
 		if bare == v.keyword || bare == v.ngram {
 			return true
 		}
@@ -2245,11 +2234,11 @@ func (b *bleveIndex) toBleveSearchRequest(ctx context.Context, req *resourcepb.R
 
 	facets := bleve.FacetsRequest{}
 	for name, facet := range req.Facet {
-		field, ok := b.facetFieldByRequestName[facet.Field]
-		if !ok {
+		kf, ok := b.keywordFieldFor(facet.Field)
+		if !ok || !kf.facetable {
 			return nil, resource.NewBadRequestError(fmt.Sprintf("field %q does not support faceting", facet.Field))
 		}
-		facets[name] = bleve.NewFacetRequest(field, int(facet.Limit))
+		facets[name] = bleve.NewFacetRequest(kf.name, int(facet.Limit))
 	}
 
 	// Convert resource-specific fields to bleve fields. Any field declared
@@ -2320,7 +2309,7 @@ func (b *bleveIndex) toBleveSearchRequest(ctx context.Context, req *resourcepb.R
 	}
 
 	// Add the sort fields
-	sorting := getSortFields(req, b.fields)
+	sorting := b.getSortFields(req)
 	searchrequest.SortBy(sorting)
 
 	// When no sort fields are provided, sort by score if there is a query,
@@ -2563,7 +2552,7 @@ func (b *bleveIndex) buildTextQuery(searchrequest *bleve.SearchRequest, req *res
 
 // textQueryKindFor reports how a physical index field has to be queried.
 func (b *bleveIndex) textQueryKindFor(name string) textQueryKind {
-	if kind, ok := b.textQueryKinds[name]; ok {
+	if kind, ok := b.searchFields.textQueryKinds[name]; ok {
 		return kind
 	}
 	if strings.HasPrefix(name, referenceFieldPrefix) {
@@ -2804,7 +2793,7 @@ func safeInt64ToInt(i64 int64) (int, error) {
 	return int(i64), nil
 }
 
-func getSortFields(req *resourcepb.ResourceSearchRequest, fields resource.SearchableDocumentFields) []string {
+func (b *bleveIndex) getSortFields(req *resourcepb.ResourceSearchRequest) []string {
 	if len(req.SortBy) == 0 {
 		return nil
 	}
@@ -2812,11 +2801,12 @@ func getSortFields(req *resourcepb.ResourceSearchRequest, fields resource.Search
 	sorting := make([]string, 0, len(req.SortBy)+1)
 	hasNameSort := false
 	for _, sort := range req.SortBy {
-		// title sorts on its populated, doc-valued keyword variant (title_phrase);
-		// other fields sort on their indexed name.
-		input := resolveFieldName(fields, sort.Field)
-		if input == resource.SEARCH_FIELD_TITLE {
-			input = resource.SEARCH_FIELD_TITLE_PHRASE
+		input := resolveFieldName(b.fields, sort.Field)
+		// Sort on the keyword form, or the analyzed field would order by its first
+		// token instead of the whole value. Those copies are stored lowercased, so
+		// sorting is case-insensitive, as it has always been for title.
+		if kf, ok := b.keywordFieldFor(input); ok {
+			input = kf.name
 		}
 
 		hasNameSort = hasNameSort || input == resource.SEARCH_FIELD_NAME
@@ -2836,23 +2826,40 @@ const (
 	whitespaceCharacters = " \t\r\n"
 )
 
-// exactTermQueryFields are fields where filters use Bleve TermQuery directly.
-var exactTermQueryFields = []string{
-	resource.SEARCH_FIELD_OWNER_REFERENCES,
-	resource.SEARCH_FIELD_CREATED_BY,
-	// FIXME: special case for login and email to use term query only because those fields are using keyword analyzer
-	// This should be fixed by using the info from the schema
-	"login",
-	"email",
+// keywordFieldFor reports the keyword-analyzed index field backing a filter or
+// sort field, and false when the field has no keyword form.
+func (b *bleveIndex) keywordFieldFor(key string) (keywordField, bool) {
+	fields := b.searchFields.keywordFields
+	if fields == nil {
+		// Index opened without per-kind declarations; standard fields still apply.
+		fields = standardKeywordFields
+	}
+	kf, ok := fields[key]
+	return kf, ok
+}
+
+// usesExactTermFilter reports whether "=" or "in" on key matches the whole value
+// as one token rather than going through the analyzed path. That is what the
+// filter capability means: the field is keyword-analyzed. "==" does not ask,
+// being exact by definition.
+func (b *bleveIndex) usesExactTermFilter(key string) bool {
+	// "=" on title expands across its phrase, token and ngram variants instead,
+	// even though title is filter-capable. "in" on title is exact; see the caller.
+	if key == resource.SEARCH_FIELD_TITLE {
+		return false
+	}
+	// Selectable fields are keyword-mapped even for kinds that declare no search
+	// fields, so the prefix alone settles it.
+	if strings.HasPrefix(key, resource.SEARCH_SELECTABLE_FIELDS_PREFIX) {
+		return true
+	}
+	kf, ok := b.keywordFieldFor(key)
+	return ok && kf.filterable
 }
 
 // Convert a "requirement" into a bleve query
 func (b *bleveIndex) requirementQuery(req *resourcepb.Requirement) (query.Query, *resourcepb.ErrorResult) {
-	// The exact-term allowlist is keyed by logical (public) field names. Label
-	// requirements arrive with their physical labels.<key> prefix, so match the
-	// allowlist against the logical key while still querying the physical field.
-	allowlistKey := strings.TrimPrefix(req.Key, resource.SEARCH_FIELD_LABELS+".")
-	useExactTermQuery := slices.Contains(exactTermQueryFields, allowlistKey) || strings.HasPrefix(req.Key, resource.SEARCH_SELECTABLE_FIELDS_PREFIX)
+	useExactTermQuery := b.usesExactTermFilter(req.Key)
 	switch selection.Operator(req.Operator) {
 	case selection.DoubleEquals:
 		// DoubleEquals does exact matching via TermQuery (single value only).
@@ -2863,13 +2870,13 @@ func (b *bleveIndex) requirementQuery(req *resourcepb.Requirement) (query.Query,
 	case selection.Equals:
 		return allRequirementValuesQuery(req.Values, func(v string) query.Query {
 			if useExactTermQuery {
-				return exactFieldTermQuery(req.Key, v)
+				return b.exactFieldValueQuery(req.Key, v)
 			}
 			return fieldFilterQuery(req.Key, filterValue(req.Key, v))
 		}), nil
 
 	case selection.In:
-		// "in" is set membership: exact for the keyword allowlist and for title
+		// "in" is set membership: exact for keyword-analyzed fields and for title
 		// (via its populated title_phrase variant); other fields use the analyzed
 		// path, matching legacy behavior.
 		return anyRequirementValueQuery(req.Values, func(v string) query.Query {
@@ -2885,8 +2892,11 @@ func (b *bleveIndex) requirementQuery(req *resourcepb.Requirement) (query.Query,
 		var mustNotQueries []query.Query
 		for _, value := range req.Values {
 			var q query.Query
-			// notin keeps the legacy analyzed path for every field except the
-			// intentional exact-title case (kept consistent with "in" on title).
+			// notin stays on the analyzed path, unlike "=" and "in". On a keyword
+			// field that is already an exact exclusion, and it is what lets a
+			// wildcard value exclude a prefix, or "*" exclude everything. Only a
+			// field with both a text and a keyword form ends up asymmetric with
+			// "in"; title is handled here so the two agree on it.
 			if req.Key == resource.SEARCH_FIELD_TITLE {
 				q = b.exactFieldValueQuery(req.Key, value)
 			} else {
@@ -2968,14 +2978,13 @@ func addWildcardQueries(disjoin *query.DisjunctionQuery, pattern string, field s
 	}
 }
 
-// exactFieldValueQuery builds an exact term query for one filter value. title
-// routes to its populated keyword variant (title_phrase); other fields match on
-// their indexed field. Custom text fields have no populated keyword variant yet
-// (tracked as a follow-up in the search-v1 epic).
+// exactFieldValueQuery builds an exact term query for one filter value, against
+// the field's keyword form. Where that form is a separate copy (title_phrase, a
+// text field's <name>_keyword) the copy is stored lowercased, so the term has to
+// be lowercased too.
 func (b *bleveIndex) exactFieldValueQuery(key, value string) query.Query {
-	if key == resource.SEARCH_FIELD_TITLE {
-		key = resource.SEARCH_FIELD_TITLE_PHRASE
-		value = strings.ToLower(value) // title_phrase stores pre-lowered values
+	if kf, ok := b.keywordFieldFor(key); ok {
+		return exactFieldTermQuery(kf.name, kf.term(value))
 	}
 	return exactFieldTermQuery(key, value)
 }

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -2804,7 +2804,7 @@ func (b *bleveIndex) getSortFields(req *resourcepb.ResourceSearchRequest) []stri
 		input := resolveFieldName(b.fields, sort.Field)
 		// Sort on the keyword form, or the analyzed field would order by its first
 		// token instead of the whole value. Those copies are stored lowercased, so
-		// sorting is case-insensitive, as it has always been for title.
+		// sorting is case-insensitive.
 		if kf, ok := b.keywordFieldFor(input); ok {
 			input = kf.name
 		}

--- a/pkg/storage/unified/search/bleve_mappings.go
+++ b/pkg/storage/unified/search/bleve_mappings.go
@@ -13,6 +13,30 @@ import (
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 )
 
+// kindSearchFields is what the query and indexing paths need to know about a
+// kind's declared search fields. Each lookup answers a different question and
+// is keyed differently, so they are derived once per index rather than walked
+// per request.
+type kindSearchFields struct {
+	// keywordFields maps a filter, sort or facet field name to the
+	// keyword-analyzed index field backing it.
+	keywordFields map[string]keywordField
+	// textQueryKinds maps physical index field names to the query their analyzer
+	// needs.
+	textQueryKinds map[string]textQueryKind
+	// variants drives the index-time copy of per-kind values into the variant
+	// fields this kind's mapping declares.
+	variants []fieldVariant
+}
+
+func newKindSearchFields(provider resource.SearchFieldsProvider, group, kindResource string, selectableFields []string) kindSearchFields {
+	return kindSearchFields{
+		keywordFields:  keywordFieldsForMapping(provider, group, kindResource, selectableFields),
+		textQueryKinds: textQueryKindsForMapping(provider, group, kindResource, selectableFields),
+		variants:       fieldVariantsOf(fieldDefinitionsForMapping(provider, group, kindResource)),
+	}
+}
+
 // fieldDefinitionsForMapping returns the SearchFieldDefinition slice that
 // drives the per-kind fields.* sub-document mapping. The provider is the
 // only source of truth: a kind that wants per-kind bleve mappings must
@@ -22,32 +46,6 @@ func fieldDefinitionsForMapping(provider resource.SearchFieldsProvider, group, k
 		return nil
 	}
 	return provider.Fields(schema.GroupVersionResource{Group: group, Resource: kindResource})
-}
-
-// facetFieldsForMapping returns the logical facet field names accepted by the
-// search API and the keyword-analyzed bleve fields that back them. Dynamic
-// fields are deliberately absent because they have no facet capability.
-func facetFieldsForMapping(provider resource.SearchFieldsProvider, group, kindResource string) map[string]string {
-	fields := make(map[string]string)
-	add := func(def resource.SearchFieldDefinition, prefix string) {
-		if !def.HasCapability(resource.SearchCapabilityFacet) {
-			return
-		}
-		logicalName := prefix + def.Name
-		fields[logicalName] = prefix + keywordVariantName(def.Name, def.HasCapability(resource.SearchCapabilityText))
-	}
-
-	for _, def := range resource.StandardSearchFieldDefinitions() {
-		add(def, "")
-	}
-	for _, def := range fieldDefinitionsForMapping(provider, group, kindResource) {
-		add(def, resource.SEARCH_FIELD_PREFIX)
-		// Requests accept per-kind fields with or without the internal fields. prefix.
-		if physicalName, ok := fields[resource.SEARCH_FIELD_PREFIX+def.Name]; ok {
-			fields[def.Name] = physicalName
-		}
-	}
-	return fields
 }
 
 // textQueryKind is the free-text query a physical index field needs, so callers
@@ -107,6 +105,75 @@ func textQueryKindsForMapping(provider resource.SearchFieldsProvider, group, kin
 	}
 	return kinds
 }
+
+// keywordField is the keyword-analyzed index field backing a logical field.
+// lowered marks the copies that are written lowercased (see
+// populateFieldVariants and UpdateCopyFields). filterable and facetable carry
+// the capabilities that decide what a request may ask of the field: a keyword
+// form can exist for sorting alone.
+type keywordField struct {
+	name       string
+	lowered    bool
+	filterable bool
+	facetable  bool
+}
+
+// term returns value in the form the field was indexed in, because a TermQuery
+// does not analyze its input.
+func (k keywordField) term(value string) string {
+	if k.lowered {
+		return strings.ToLower(value)
+	}
+	return value
+}
+
+// keywordFieldsForMapping derives which fields are keyword-analyzed, and where
+// that keyword form lives, from the declarations that produced the mapping, so
+// the query side cannot drift from it (see keywordVariant).
+//
+// Keys are the names filters, sorts and facets arrive with. Labels are absent on
+// purpose: the label sub-document has no keyword analyzer.
+func keywordFieldsForMapping(provider resource.SearchFieldsProvider, group, kindResource string, selectableFields []string) map[string]keywordField {
+	fields := map[string]keywordField{}
+	add := func(key string, def resource.SearchFieldDefinition, prefix string) {
+		name, ok := keywordVariant(def)
+		if !ok {
+			return
+		}
+		fields[key] = keywordField{
+			name: prefix + name,
+			// A keyword form under a different name is a lowercased copy.
+			lowered:    name != def.Name,
+			filterable: def.HasCapability(resource.SearchCapabilityFilter),
+			facetable:  def.HasCapability(resource.SearchCapabilityFacet),
+		}
+	}
+
+	for _, def := range resource.StandardSearchFieldDefinitions() {
+		add(def.Name, def, "")
+	}
+	for _, def := range fieldDefinitionsForMapping(provider, group, kindResource) {
+		add(resource.SEARCH_FIELD_PREFIX+def.Name, def, resource.SEARCH_FIELD_PREFIX)
+		// Requests may name a per-kind field without the internal fields. prefix.
+		// A standard field of the same name wins, matching resolveFieldName.
+		if _, taken := fields[def.Name]; !taken {
+			add(def.Name, def, resource.SEARCH_FIELD_PREFIX)
+		}
+	}
+	// Selectable fields and the keyword sub-documents exist to be filtered on,
+	// but declare no capabilities (see getBleveDocMappings).
+	for _, name := range selectableFields {
+		key := resource.SEARCH_SELECTABLE_FIELDS_PREFIX + name
+		fields[key] = keywordField{name: key, filterable: true}
+	}
+	for _, name := range keywordSubDocumentFields {
+		fields[name] = keywordField{name: name, filterable: true}
+	}
+	return fields
+}
+
+// standardKeywordFields covers an index opened without per-kind declarations.
+var standardKeywordFields = keywordFieldsForMapping(nil, "", "", nil)
 
 // keywordSubDocumentFields are keyword-mapped fields that live in sub-documents
 // and so are not modellable as SearchFieldDefinitions yet (see

--- a/pkg/storage/unified/search/bleve_mappings.go
+++ b/pkg/storage/unified/search/bleve_mappings.go
@@ -154,7 +154,7 @@ func keywordFieldsForMapping(provider resource.SearchFieldsProvider, group, kind
 	}
 	for _, def := range fieldDefinitionsForMapping(provider, group, kindResource) {
 		add(resource.SEARCH_FIELD_PREFIX+def.Name, def, resource.SEARCH_FIELD_PREFIX)
-		// Requests may name a per-kind field without the internal fields. prefix.
+		// Requests may name a per-kind field without the internal fields prefix.
 		// A standard field of the same name wins, matching resolveFieldName.
 		if _, taken := fields[def.Name]; !taken {
 			add(def.Name, def, resource.SEARCH_FIELD_PREFIX)

--- a/pkg/storage/unified/search/bleve_mappings_internal_test.go
+++ b/pkg/storage/unified/search/bleve_mappings_internal_test.go
@@ -216,34 +216,60 @@ func TestAddCapabilityFieldMappings_FacetOnly(t *testing.T) {
 	assert.False(t, m.Store)
 }
 
-func TestFacetFieldsForMapping(t *testing.T) {
+func TestKeywordFieldsForMapping(t *testing.T) {
 	gvr := schema.GroupVersionResource{Group: "example.test", Version: "v1", Resource: "widgets"}
 	provider := resource.NewMapProvider(map[schema.GroupVersionResource][]resource.SearchFieldDefinition{
 		gvr: {
-			{
-				Name: "summary",
-				Type: resource.SearchFieldTypeString,
-				Capabilities: []resource.SearchCapability{
-					resource.SearchCapabilityText,
-					resource.SearchCapabilityFacet,
-				},
-			},
-			{
-				Name:         "category",
-				Type:         resource.SearchFieldTypeString,
-				Capabilities: []resource.SearchCapability{resource.SearchCapabilityFacet},
-			},
+			// Same shape as the IAM user kind's login/email.
+			{Name: "login", Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityFilter, resource.SearchCapabilityRetrieve}},
+			{Name: "summary", Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityText, resource.SearchCapabilityFilter}},
+			{Name: "category", Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityFacet}},
+			{Name: "panel_title", Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityText}},
+			{Name: "views", Type: resource.SearchFieldTypeInt64, Capabilities: []resource.SearchCapability{resource.SearchCapabilitySort}},
 		},
 	}, nil)
 
-	fields := facetFieldsForMapping(provider, gvr.Group, gvr.Resource)
-	assert.Equal(t, resource.SEARCH_FIELD_TAGS, fields[resource.SEARCH_FIELD_TAGS])
-	assert.Equal(t, resource.SEARCH_FIELD_MANAGED_BY, fields[resource.SEARCH_FIELD_MANAGED_BY])
-	assert.Equal(t, "fields.summary_keyword", fields["summary"])
-	assert.Equal(t, "fields.summary_keyword", fields["fields.summary"])
-	assert.Equal(t, "fields.category", fields["category"])
-	assert.NotContains(t, fields, resource.SEARCH_FIELD_FOLDER)
-	assert.NotContains(t, fields, "labels.region")
+	fields := keywordFieldsForMapping(provider, gvr.Group, gvr.Resource, []string{"spec.login"})
+
+	// Filter-only per-kind fields are keyword-analyzed under their own name.
+	assert.Equal(t, keywordField{name: "fields.login", filterable: true}, fields["fields.login"])
+	// A text field's keyword form is a separate, lowercased variant.
+	assert.Equal(t, keywordField{name: "fields.summary_keyword", lowered: true, filterable: true}, fields["fields.summary"])
+	// tags is both filterable and facetable; managedBy is facet-only.
+	assert.Equal(t, keywordField{name: resource.SEARCH_FIELD_TAGS, filterable: true, facetable: true}, fields[resource.SEARCH_FIELD_TAGS])
+	// A facet-only field has a keyword form, but filtering it is not declared.
+	assert.Equal(t, keywordField{name: "fields.category", facetable: true}, fields["fields.category"])
+	// Standard fields.
+	assert.Equal(t, keywordField{name: resource.SEARCH_FIELD_TITLE_PHRASE, lowered: true, filterable: true}, fields[resource.SEARCH_FIELD_TITLE])
+	assert.Equal(t, keywordField{name: resource.SEARCH_FIELD_CREATED_BY, filterable: true}, fields[resource.SEARCH_FIELD_CREATED_BY])
+	assert.Equal(t, keywordField{name: resource.SEARCH_FIELD_OWNER_REFERENCES, filterable: true}, fields[resource.SEARCH_FIELD_OWNER_REFERENCES])
+	assert.Equal(t, keywordField{name: resource.SEARCH_FIELD_MANAGED_BY, facetable: true}, fields[resource.SEARCH_FIELD_MANAGED_BY])
+	assert.Equal(t, keywordField{name: resource.SEARCH_SELECTABLE_FIELDS_PREFIX + "spec.login", filterable: true}, fields[resource.SEARCH_SELECTABLE_FIELDS_PREFIX+"spec.login"])
+
+	// Facet requests may name a per-kind field with or without the prefix.
+	assert.Equal(t, fields["fields.summary"], fields["summary"])
+	assert.Equal(t, fields["fields.category"], fields["category"])
+
+	// Fields with no keyword form: text-only, and a non-string field.
+	assert.NotContains(t, fields, "fields.panel_title")
+	assert.NotContains(t, fields, "fields.views")
+	assert.NotContains(t, fields, resource.SEARCH_FIELD_DESCRIPTION)
+	// Labels have no keyword analyzer.
+	assert.NotContains(t, fields, "labels.login")
+}
+
+func TestKeywordFieldsForMapping_StandardNameWins(t *testing.T) {
+	// A per-kind field named like a standard one must not take over the bare
+	// name: resolveFieldName keeps standard fields top-level, so a filter on
+	// "tags" has to reach the standard field.
+	gvr := schema.GroupVersionResource{Group: "example.test", Version: "v1", Resource: "widgets"}
+	provider := resource.NewMapProvider(map[schema.GroupVersionResource][]resource.SearchFieldDefinition{
+		gvr: {{Name: resource.SEARCH_FIELD_TAGS, Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityFilter}}},
+	}, nil)
+
+	fields := keywordFieldsForMapping(provider, gvr.Group, gvr.Resource, nil)
+	assert.Equal(t, resource.SEARCH_FIELD_TAGS, fields[resource.SEARCH_FIELD_TAGS].name)
+	assert.Equal(t, resource.SEARCH_FIELD_PREFIX+resource.SEARCH_FIELD_TAGS, fields[resource.SEARCH_FIELD_PREFIX+resource.SEARCH_FIELD_TAGS].name)
 }
 
 func TestTextQueryKindsForMapping(t *testing.T) {
@@ -314,7 +340,7 @@ func TestTextQueryKindsForMapping(t *testing.T) {
 }
 
 func TestBleveIndex_textQueryKindFor(t *testing.T) {
-	b := &bleveIndex{textQueryKinds: map[string]textQueryKind{resource.SEARCH_FIELD_TITLE_PHRASE: textQueryTerm}}
+	b := &bleveIndex{searchFields: kindSearchFields{textQueryKinds: map[string]textQueryKind{resource.SEARCH_FIELD_TITLE_PHRASE: textQueryTerm}}}
 	assert.Equal(t, textQueryTerm, b.textQueryKindFor(resource.SEARCH_FIELD_TITLE_PHRASE))
 	// reference keys are dynamic, so the keyword sub-document is matched by prefix.
 	assert.Equal(t, textQueryTerm, b.textQueryKindFor("reference.datasource"))
@@ -404,15 +430,26 @@ func TestResolveFieldName(t *testing.T) {
 	assert.Equal(t, resource.SEARCH_FIELD_TITLE_NGRAM, resolveFieldName(reserved, resource.SEARCH_FIELD_TITLE_NGRAM))
 }
 
-func TestBleveIndex_exactFieldValueQuery(t *testing.T) {
-	fields, err := resource.NewSearchableDocumentFields(resource.SearchFieldDefinitionsToTableColumns(
-		[]resource.SearchFieldDefinition{
-			{Name: "note", Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityText, resource.SearchCapabilityFilter}},
-			{Name: "tag", Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityFilter}},
-		},
-	))
+// customFieldsIndex returns an index whose per-kind declarations are the given
+// definitions, wired the way openIndex does it.
+func customFieldsIndex(t *testing.T, defs ...resource.SearchFieldDefinition) *bleveIndex {
+	t.Helper()
+	fields, err := resource.NewSearchableDocumentFields(resource.SearchFieldDefinitionsToTableColumns(defs))
 	require.NoError(t, err)
-	b := &bleveIndex{fields: fields, standard: resource.StandardSearchFields()}
+	gvr := schema.GroupVersionResource{Group: "example.test", Version: "v1", Resource: "widgets"}
+	provider := resource.NewMapProvider(map[schema.GroupVersionResource][]resource.SearchFieldDefinition{gvr: defs}, nil)
+	return &bleveIndex{
+		fields:       fields,
+		standard:     resource.StandardSearchFields(),
+		searchFields: newKindSearchFields(provider, gvr.Group, gvr.Resource, nil),
+	}
+}
+
+func TestBleveIndex_exactFieldValueQuery(t *testing.T) {
+	b := customFieldsIndex(t,
+		resource.SearchFieldDefinition{Name: "note", Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityText, resource.SearchCapabilityFilter}},
+		resource.SearchFieldDefinition{Name: "tag", Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityFilter}},
+	)
 
 	termOf := func(q query.Query) *query.TermQuery {
 		tq, ok := q.(*query.TermQuery)
@@ -425,23 +462,26 @@ func TestBleveIndex_exactFieldValueQuery(t *testing.T) {
 	assert.Equal(t, resource.SEARCH_FIELD_TITLE_PHRASE, title.Field())
 	assert.Equal(t, "foo bar", title.Term)
 
-	// Custom fields match on their indexed name (their <name>_keyword variant is
-	// not populated at index time), value unchanged. This holds for text+filter
-	// and filter-only fields alike.
-	assert.Equal(t, resource.SEARCH_FIELD_PREFIX+"note", termOf(b.exactFieldValueQuery(resource.SEARCH_FIELD_PREFIX+"note", "Exact")).Field())
-	assert.Equal(t, resource.SEARCH_FIELD_PREFIX+"tag", termOf(b.exactFieldValueQuery(resource.SEARCH_FIELD_PREFIX+"tag", "x")).Field())
+	// A text field's keyword form lives in a separate variant, which stores
+	// lowercased values.
+	note := termOf(b.exactFieldValueQuery(resource.SEARCH_FIELD_PREFIX+"note", "Exact"))
+	assert.Equal(t, resource.SEARCH_FIELD_PREFIX+"note_keyword", note.Field())
+	assert.Equal(t, "exact", note.Term)
+
+	// A filter-only field is keyword-analyzed under its own name, value unchanged.
+	tag := termOf(b.exactFieldValueQuery(resource.SEARCH_FIELD_PREFIX+"tag", "X"))
+	assert.Equal(t, resource.SEARCH_FIELD_PREFIX+"tag", tag.Field())
+	assert.Equal(t, "X", tag.Term)
+
 	// A standard non-text field is unchanged.
 	assert.Equal(t, resource.SEARCH_FIELD_FOLDER, termOf(b.exactFieldValueQuery(resource.SEARCH_FIELD_FOLDER, "x")).Field())
 }
 
 func TestRequirementQuery_TextFilterDispatch(t *testing.T) {
-	fields, err := resource.NewSearchableDocumentFields(resource.SearchFieldDefinitionsToTableColumns(
-		[]resource.SearchFieldDefinition{
-			{Name: "note", Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityText, resource.SearchCapabilityFilter}},
-		},
-	))
-	require.NoError(t, err)
-	b := &bleveIndex{fields: fields, standard: resource.StandardSearchFields()}
+	b := customFieldsIndex(t,
+		resource.SearchFieldDefinition{Name: "note", Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityText, resource.SearchCapabilityFilter}},
+		resource.SearchFieldDefinition{Name: "panel_title", Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityText}},
+	)
 
 	// title has a populated keyword variant, so "in" dispatches an exact TermQuery
 	// against title_phrase.
@@ -452,39 +492,112 @@ func TestRequirementQuery_TextFilterDispatch(t *testing.T) {
 	assert.Equal(t, resource.SEARCH_FIELD_TITLE_PHRASE, tq.Field())
 	assert.Equal(t, "foo bar", tq.Term)
 
-	// A custom text+filter field has no populated keyword variant, so "in" stays
-	// on the analyzed indexed field (exact set-membership for such fields is a
-	// tracked follow-up that needs index-time keyword population).
+	// A custom text+filter field is filtered on its populated keyword variant.
 	note := resource.SEARCH_FIELD_PREFIX + "note" // resolved physical name, as filterQueries passes it
 	q, errRes = b.requirementQuery(&resourcepb.Requirement{Key: note, Operator: "in", Values: []string{"Foo Bar"}})
 	require.Nil(t, errRes)
+	tq, ok = q.(*query.TermQuery)
+	require.True(t, ok, "in on a custom text+filter field should build an exact TermQuery")
+	assert.Equal(t, note+"_keyword", tq.Field())
+	assert.Equal(t, "foo bar", tq.Term)
+
+	// A text-only field has no keyword form, so it stays on the analyzed path.
+	panelTitle := resource.SEARCH_FIELD_PREFIX + "panel_title"
+	q, errRes = b.requirementQuery(&resourcepb.Requirement{Key: panelTitle, Operator: "in", Values: []string{"Foo Bar"}})
+	require.Nil(t, errRes)
 	mq, ok := q.(*query.MatchQuery)
-	require.True(t, ok, "in on a custom text field should build an analyzed MatchQuery")
+	require.True(t, ok, "in on a text-only field should build an analyzed MatchQuery")
+	assert.Equal(t, panelTitle, mq.Field())
+
+	// notin is deliberately not symmetric with in: it excludes on the analyzed
+	// field, so it also excludes documents that merely contain the value. Making
+	// it exact has been tried and reverted; change it only on purpose.
+	q, errRes = b.requirementQuery(&resourcepb.Requirement{Key: note, Operator: "notin", Values: []string{"Foo"}})
+	require.Nil(t, errRes)
+	bq, ok := q.(*query.BooleanQuery)
+	require.True(t, ok)
+	mustNot, ok := bq.MustNot.(*query.DisjunctionQuery)
+	require.True(t, ok)
+	require.Len(t, mustNot.Disjuncts, 1)
+	mq, ok = mustNot.Disjuncts[0].(*query.MatchQuery)
+	require.True(t, ok, "notin on a text+filter field should stay on the analyzed field")
 	assert.Equal(t, note, mq.Field())
 }
 
-func TestFilterQueries_LabelExactTermAllowlist(t *testing.T) {
+func TestRequirementQuery_ExactPathFromCapabilities(t *testing.T) {
+	b := customFieldsIndex(t,
+		resource.SearchFieldDefinition{Name: "category", Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityFilter}},
+		resource.SearchFieldDefinition{Name: "summary", Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityText}},
+		resource.SearchFieldDefinition{Name: "kind", Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityFacet}},
+	)
+
+	// A filter-only field is keyword-analyzed, so "=" matches the whole value as
+	// one token. Nothing about the field's name says so: the capability does.
+	category := resource.SEARCH_FIELD_PREFIX + "category"
+	q, errRes := b.requirementQuery(&resourcepb.Requirement{Key: category, Operator: "=", Values: []string{"Two Words"}})
+	require.Nil(t, errRes)
+	tq, ok := q.(*query.TermQuery)
+	require.True(t, ok, "= on a filter-capable field should build an exact TermQuery")
+	assert.Equal(t, category, tq.Field())
+	assert.Equal(t, "Two Words", tq.Term)
+
+	// The same kind's text-only field is analyzed, so it takes the match path.
+	summary := resource.SEARCH_FIELD_PREFIX + "summary"
+	q, errRes = b.requirementQuery(&resourcepb.Requirement{Key: summary, Operator: "=", Values: []string{"Two Words"}})
+	require.Nil(t, errRes)
+	_, ok = q.(*query.MatchQuery)
+	assert.True(t, ok, "= on a text-only field should build an analyzed MatchQuery")
+
+	// A facet-only field is keyword-mapped, but it never declared that it can be
+	// filtered, so filtering it keeps the analyzed path.
+	kind := resource.SEARCH_FIELD_PREFIX + "kind"
+	q, errRes = b.requirementQuery(&resourcepb.Requirement{Key: kind, Operator: "=", Values: []string{"x"}})
+	require.Nil(t, errRes)
+	_, ok = q.(*query.MatchQuery)
+	assert.True(t, ok, "= on a facet-only field should build an analyzed MatchQuery")
+
+	// An undeclared field cannot be shown to be keyword-analyzed, so it keeps the
+	// analyzed path.
+	q, errRes = b.requirementQuery(&resourcepb.Requirement{Key: resource.SEARCH_FIELD_PREFIX + "unknown", Operator: "=", Values: []string{"x"}})
+	require.Nil(t, errRes)
+	_, ok = q.(*query.MatchQuery)
+	assert.True(t, ok, "= on an undeclared field should build an analyzed MatchQuery")
+}
+
+func TestRequirementQuery_StandardExactFields(t *testing.T) {
+	// createdBy and ownerReferences are declared filter-capable standard fields:
+	// they stay exact without being named anywhere in the query path.
 	b := &bleveIndex{standard: resource.StandardSearchFields()}
-	// A label whose key is in the exact-term allowlist keeps its TermQuery
-	// semantics even though it is hoisted to labels.<key> for the physical query
-	// (labels are standard-analyzed, so the analyzed path would tokenize the value).
+	for _, key := range []string{resource.SEARCH_FIELD_CREATED_BY, resource.SEARCH_FIELD_OWNER_REFERENCES} {
+		q, errRes := b.requirementQuery(&resourcepb.Requirement{Key: key, Operator: "=", Values: []string{"user:abc"}})
+		require.Nil(t, errRes)
+		tq, ok := q.(*query.TermQuery)
+		require.True(t, ok, "= on %s should build an exact TermQuery", key)
+		assert.Equal(t, key, tq.Field())
+		assert.Equal(t, "user:abc", tq.Term)
+	}
+}
+
+func TestFilterQueries_LabelsUseAnalyzedPath(t *testing.T) {
+	b := &bleveIndex{standard: resource.StandardSearchFields()}
+	// Labels are standard-analyzed, so every label filter goes through the
+	// analyzed path. "login" used to be an exception, hardcoded back when the
+	// exact-term decision was a name list.
 	req := &resourcepb.ResourceSearchRequest{Options: &resourcepb.ListOptions{
 		Labels: []*resourcepb.Requirement{{Key: "login", Operator: "in", Values: []string{"foo-bar"}}},
 	}}
 	queries, e := b.filterQueries(req)
 	require.Nil(t, e)
 	require.Len(t, queries, 1)
-	tq, ok := queries[0].(*query.TermQuery)
-	require.True(t, ok, "login label filter should use an exact TermQuery")
-	assert.Equal(t, resource.SEARCH_FIELD_LABELS+".login", tq.Field())
-	assert.Equal(t, "foo-bar", tq.Term)
+	mq, ok := queries[0].(*query.MatchQuery)
+	require.True(t, ok, "label filter should use an analyzed MatchQuery")
+	assert.Equal(t, resource.SEARCH_FIELD_LABELS+".login", mq.Field())
+	assert.Equal(t, "foo-bar", mq.Match)
 }
 
 func TestFilterQueries_LabelNotInUsesAnalyzedPath(t *testing.T) {
 	b := &bleveIndex{standard: resource.StandardSearchFields()}
-	// notin keeps the legacy analyzed path even for an allowlist label key: only
-	// "="/"in" consult the exact-term allowlist, and title is the sole notin exact
-	// case. A raw TermQuery here would fail to exclude standard-analyzed labels.
+	// A raw TermQuery here would fail to exclude standard-analyzed labels.
 	req := &resourcepb.ResourceSearchRequest{Options: &resourcepb.ListOptions{
 		Labels: []*resourcepb.Requirement{{Key: "login", Operator: "notin", Values: []string{"foo-bar"}}},
 	}}
@@ -518,28 +631,30 @@ func TestFilterQueries_DoesNotMutateRequest(t *testing.T) {
 }
 
 func TestGetSortFields_ResolvesPhysicalNames(t *testing.T) {
-	fields, err := resource.NewSearchableDocumentFields(resource.SearchFieldDefinitionsToTableColumns(
-		[]resource.SearchFieldDefinition{
-			{Name: "note", Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityText, resource.SearchCapabilitySort}},
-			{Name: "num", Type: resource.SearchFieldTypeInt64, Capabilities: []resource.SearchCapability{resource.SearchCapabilitySort}},
-		},
-	))
+	defs := []resource.SearchFieldDefinition{
+		{Name: "note", Type: resource.SearchFieldTypeString, Capabilities: []resource.SearchCapability{resource.SearchCapabilityText, resource.SearchCapabilitySort}},
+		{Name: "num", Type: resource.SearchFieldTypeInt64, Capabilities: []resource.SearchCapability{resource.SearchCapabilitySort}},
+	}
+	fields, err := resource.NewSearchableDocumentFields(resource.SearchFieldDefinitionsToTableColumns(defs))
 	require.NoError(t, err)
+	gvr := schema.GroupVersionResource{Group: "example.test", Version: "v1", Resource: "widgets"}
+	provider := resource.NewMapProvider(map[schema.GroupVersionResource][]resource.SearchFieldDefinition{gvr: defs}, nil)
+	b := &bleveIndex{fields: fields, searchFields: newKindSearchFields(provider, gvr.Group, gvr.Resource, nil)}
 
 	req := &resourcepb.ResourceSearchRequest{SortBy: []*resourcepb.ResourceSearchRequest_Sort{
 		{Field: resource.SEARCH_FIELD_TITLE},           // standard title -> populated title_phrase
-		{Field: "note"},                                // text field -> indexed name (no _keyword)
+		{Field: "note"},                                // text field -> doc-valued keyword variant
 		{Field: "num"},                                 // numeric sort field -> its indexed name
-		{Field: resource.SEARCH_FIELD_PREFIX + "note"}, // already-prefixed text-only name is preserved
+		{Field: resource.SEARCH_FIELD_PREFIX + "note"}, // already-prefixed name resolves the same way
 	}}
 	// name is appended as a stable tie-breaker.
 	assert.Equal(t, []string{
 		resource.SEARCH_FIELD_TITLE_PHRASE,
-		resource.SEARCH_FIELD_PREFIX + "note",
+		resource.SEARCH_FIELD_PREFIX + "note_keyword",
 		resource.SEARCH_FIELD_PREFIX + "num",
-		resource.SEARCH_FIELD_PREFIX + "note",
+		resource.SEARCH_FIELD_PREFIX + "note_keyword",
 		resource.SEARCH_FIELD_NAME,
-	}, getSortFields(req, fields))
+	}, b.getSortFields(req))
 }
 
 func TestBleveIndex_resolveQueryFields(t *testing.T) {

--- a/pkg/storage/unified/search/bleve_test.go
+++ b/pkg/storage/unified/search/bleve_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 	bolterrors "go.etcd.io/bbolt/errors"
 	"go.uber.org/goleak"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/selection"
 
 	authlib "github.com/grafana/authlib/types"
@@ -812,6 +813,10 @@ func testBleveBackend(t *testing.T, backend *bleveBackend) {
 func TestGetSortFields(t *testing.T) {
 	dashboardFields, err := resource.SearchableFieldsFromProvider(DashboardSearchFieldsProviderForTest(), "dashboard.grafana.app", "dashboards")
 	require.NoError(t, err)
+	idx := &bleveIndex{
+		fields:       dashboardFields,
+		searchFields: newKindSearchFields(DashboardSearchFieldsProviderForTest(), "dashboard.grafana.app", "dashboards", nil),
+	}
 
 	t.Run("will prepend 'fields.' to sort fields when they are dashboard fields", func(t *testing.T) {
 		searchReq := &resourcepb.ResourceSearchRequest{
@@ -819,7 +824,7 @@ func TestGetSortFields(t *testing.T) {
 				{Field: "views_total", Desc: false},
 			},
 		}
-		sortFields := getSortFields(searchReq, dashboardFields)
+		sortFields := idx.getSortFields(searchReq)
 		assert.Equal(t, []string{"fields.views_total", resource.SEARCH_FIELD_NAME}, sortFields)
 	})
 	t.Run("will prepend sort fields with a '-' when sort is Desc", func(t *testing.T) {
@@ -828,7 +833,7 @@ func TestGetSortFields(t *testing.T) {
 				{Field: "views_total", Desc: true},
 			},
 		}
-		sortFields := getSortFields(searchReq, dashboardFields)
+		sortFields := idx.getSortFields(searchReq)
 		assert.Equal(t, []string{"-fields.views_total", resource.SEARCH_FIELD_NAME}, sortFields)
 	})
 	t.Run("will not prepend 'fields.' to common fields", func(t *testing.T) {
@@ -837,7 +842,7 @@ func TestGetSortFields(t *testing.T) {
 				{Field: "description", Desc: false},
 			},
 		}
-		sortFields := getSortFields(searchReq, dashboardFields)
+		sortFields := idx.getSortFields(searchReq)
 		assert.Equal(t, []string{"description", resource.SEARCH_FIELD_NAME}, sortFields)
 	})
 	t.Run("will use title_phrase for title and append name as tie-breaker", func(t *testing.T) {
@@ -846,7 +851,7 @@ func TestGetSortFields(t *testing.T) {
 				{Field: resource.SEARCH_FIELD_TITLE, Desc: false},
 			},
 		}
-		sortFields := getSortFields(searchReq, dashboardFields)
+		sortFields := idx.getSortFields(searchReq)
 		assert.Equal(t, []string{resource.SEARCH_FIELD_TITLE_PHRASE, resource.SEARCH_FIELD_NAME}, sortFields)
 	})
 	t.Run("will not append a duplicate name sort", func(t *testing.T) {
@@ -855,15 +860,15 @@ func TestGetSortFields(t *testing.T) {
 				{Field: resource.SEARCH_FIELD_NAME, Desc: true},
 			},
 		}
-		sortFields := getSortFields(searchReq, dashboardFields)
+		sortFields := idx.getSortFields(searchReq)
 		assert.Equal(t, []string{"-" + resource.SEARCH_FIELD_NAME}, sortFields)
 	})
 }
 
 func TestBleveSearchRequestDefaultSortIncludesNameTieBreaker(t *testing.T) {
 	idx := &bleveIndex{
-		fields:                  resource.StandardSearchFields(),
-		facetFieldByRequestName: facetFieldsForMapping(nil, "", ""),
+		fields:       resource.StandardSearchFields(),
+		searchFields: newKindSearchFields(nil, "", "", nil),
 	}
 
 	t.Run("sorts match-all by title then name", func(t *testing.T) {
@@ -2351,4 +2356,114 @@ func TestBuildIndexReturnsErrorWhenIndexLocked(t *testing.T) {
 
 	// Clean up: close first backend to release the file lock
 	backend1.Stop()
+}
+
+// TestBleveTextFieldFilterAndSort covers a per-kind field that is both searched
+// as text and used for exact filters and sorting. Those three uses need
+// different index fields, and only the keyword copy can answer the last two.
+func TestBleveTextFieldFilterAndSort(t *testing.T) {
+	group, kindResource := "example.grafana.app", "widgets"
+	gvr := schema.GroupVersionResource{Group: group, Version: "v1", Resource: kindResource}
+	provider := resource.NewMapProvider(map[schema.GroupVersionResource][]resource.SearchFieldDefinition{
+		gvr: {{
+			Name: "note",
+			Type: resource.SearchFieldTypeString,
+			Capabilities: []resource.SearchCapability{
+				resource.SearchCapabilityText,
+				resource.SearchCapabilityFilter,
+				resource.SearchCapabilitySort,
+			},
+		}},
+	}, nil)
+
+	backend, err := NewBleveBackend(BleveOptions{
+		Root:          t.TempDir(),
+		FileThreshold: 5,
+		SearchFields: resource.NewSearchFieldsRegistry(nil, nil, map[resource.LowerGroupResource]resource.SearchFieldsProvider{
+			resource.NewLowerGroupResource(group, kindResource): provider,
+		}),
+	}, nil)
+	require.NoError(t, err)
+	t.Cleanup(backend.Stop)
+
+	key := &resourcepb.ResourceKey{Namespace: "ns", Group: group, Resource: kindResource}
+	ctx := identity.WithRequester(context.Background(), &user.SignedInUser{Namespace: "ns"})
+
+	doc := func(name, note string) *resource.BulkIndexItem {
+		return &resource.BulkIndexItem{
+			Action: resource.ActionIndex,
+			Doc: &resource.IndexableDocument{
+				RV:     1,
+				Name:   name,
+				Key:    &resourcepb.ResourceKey{Name: name, Namespace: "ns", Group: group, Resource: kindResource},
+				Title:  name,
+				Fields: map[string]any{"note": note},
+			},
+		}
+	}
+	index, err := backend.BuildIndex(ctx, resource.NamespacedResource{
+		Namespace: key.Namespace, Group: key.Group, Resource: key.Resource,
+	}, 3, "test", func(index resource.ResourceIndex) (int64, error) {
+		if err := index.BulkIndex(&resource.BulkIndexRequest{
+			Items: []*resource.BulkIndexItem{
+				doc("one", "Zeta Apple"),
+				doc("two", "beta gamma"),
+				doc("three", "Cherry Tart"),
+			},
+		}); err != nil {
+			return 0, err
+		}
+		return 1, nil
+	}, nil, false, time.Time{}, 0)
+	require.NoError(t, err)
+
+	names := func(req *resourcepb.ResourceSearchRequest) []string {
+		req.Limit = 100
+		req.Options.Key = key
+		rsp, err := index.Search(ctx, NewStubAccessClient(map[string]bool{kindResource: true}), req, nil, nil)
+		require.NoError(t, err)
+		require.Nil(t, rsp.Error)
+		out := make([]string, 0, len(rsp.Results.Rows))
+		for _, row := range rsp.Results.Rows {
+			out = append(out, row.Key.Name)
+		}
+		return out
+	}
+
+	t.Run("filter matches the whole value, ignoring case", func(t *testing.T) {
+		got := names(&resourcepb.ResourceSearchRequest{
+			Options: &resourcepb.ListOptions{Fields: []*resourcepb.Requirement{{
+				Key: "note", Operator: string(selection.Equals), Values: []string{"zeta apple"},
+			}}},
+		})
+		assert.Equal(t, []string{"one"}, got)
+	})
+
+	t.Run("filter does not match a single word of the value", func(t *testing.T) {
+		got := names(&resourcepb.ResourceSearchRequest{
+			Options: &resourcepb.ListOptions{Fields: []*resourcepb.Requirement{{
+				Key: "note", Operator: string(selection.Equals), Values: []string{"Zeta"},
+			}}},
+		})
+		assert.Empty(t, got)
+	})
+
+	// Sorting on the analyzed field would order by each value's first token
+	// ("apple" before "beta"), which is not the order a user asked for.
+	t.Run("sort orders by the whole value, ignoring case", func(t *testing.T) {
+		got := names(&resourcepb.ResourceSearchRequest{
+			Options: &resourcepb.ListOptions{},
+			SortBy:  []*resourcepb.ResourceSearchRequest_Sort{{Field: "note"}},
+		})
+		assert.Equal(t, []string{"two", "three", "one"}, got)
+	})
+
+	t.Run("text search still matches single words", func(t *testing.T) {
+		got := names(&resourcepb.ResourceSearchRequest{
+			Options:     &resourcepb.ListOptions{},
+			Query:       "apple",
+			QueryFields: []*resourcepb.ResourceSearchRequest_QueryField{{Name: "fields.note"}},
+		})
+		assert.Equal(t, []string{"one"}, got)
+	})
 }


### PR DESCRIPTION
The Bleve backend decided whether a filter matches a whole token or goes through the analyzed path from a hardcoded list of four field names, with a FIXME saying it should come from the schema. It now comes from the declared filter capability, read through the same `keywordVariant()` rule that builds the mapping.

Exact filters and sorts on a text-capable field now use its `<name>_keyword` variant, lowercased to match how the variant is stored. Sorting such a field previously ordered by the value's first token.

Behaviour notes:

- `login`, `email`, `createdBy` and `ownerReferences` stay exact, now via their declared filter capability.
- Label filters lose the exact treatment for the keys `login`, `email`, `createdBy` and `ownerReferences`: labels are standard-analyzed, so the mapping never justified it. The only label filter in tree is on `grafana.app/deprecatedInternalID` and is unaffected.
- Other keyword-mapped fields (`name`, `folder`, `tags`, `manager.*`, `source.*`) take the exact path for `=` and `in`. A MatchQuery on a keyword field already produced the same token, so the difference is that wildcard values are no longer expanded; the new search API rejects those anyway.
- `notin` is unchanged: on a keyword field it is already exact, and the analyzed path is what lets a wildcard exclude a prefix.

Follow-up filed: grafana/search-and-storage-team#885 (one naming rule for keyword variants).

Part of grafana/search-and-storage-team#869.
