### PR TITLE
chore: add otel/baggage to generated enterprise imports

### DIFF
--- a/pkg/extensions/enterprise_imports.go
+++ b/pkg/extensions/enterprise_imports.go
@@ -610,6 +610,7 @@ import (
 	_ "go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	_ "go.opentelemetry.io/otel"
 	_ "go.opentelemetry.io/otel/attribute"
+	_ "go.opentelemetry.io/otel/baggage"
 	_ "go.opentelemetry.io/otel/codes"
 	_ "go.opentelemetry.io/otel/propagation"
 	_ "go.opentelemetry.io/otel/semconv/v1.17.0"


### PR DESCRIPTION
Regenerates `pkg/extensions/enterprise_imports.go` via `make update-workspace` to include `go.opentelemetry.io/otel/baggage`.