### PR TITLE
Canvas: Fix flaky icon mappings e2e test

### DIFF
--- a/e2e-playwright/panels-suite/canvas-icon-mappings.spec.ts
+++ b/e2e-playwright/panels-suite/canvas-icon-mappings.spec.ts
@@ -37,16 +37,15 @@ test.describe('Canvas Panel - Icon Mappings', () => {
       });
     });
 
-    await test.step('Navigate to dashboard and wait for SVGs to load', async () => {
+    await test.step('Navigate to dashboard', async () => {
       await gotoDashboardPage({ uid: DASHBOARD_UID });
-      await page.waitForSelector('svg:not([aria-hidden="true"])', { timeout: 10000 });
-      await page.waitForLoadState('networkidle', { timeout: 10000 });
     });
 
     await test.step('Verify at least 5 visible SVG icons are rendered (3 mapped + 2 fixed)', async () => {
       const visibleSvgs = page.locator('[data-testid="data-testid panel content"] svg:not([aria-hidden="true"])');
-      const svgCount = await visibleSvgs.count();
-      expect(svgCount).toBeGreaterThanOrEqual(5);
+      // Icons render via react-inlinesvg, which fetches each source and inlines the <svg> on a
+      // later tick, so the count settles asynchronously. Poll instead of sampling a single frame.
+      await expect.poll(() => visibleSvgs.count(), { timeout: 10000 }).toBeGreaterThanOrEqual(5);
     });
 
     await test.step('Verify visible SVG icons have content', async () => {


### PR DESCRIPTION
**What is this feature?**

Fixes a flaky Playwright e2e test — `Canvas Panel - Icon Mappings › should render fixed path icons correctly` in `e2e-playwright/panels-suite/canvas-icon-mappings.spec.ts`.

**Why do we need this feature?**

The test has been failing intermittently in CI, including on unrelated PRs (failing both the initial run and the CI retry).

Root cause is a rendering race. Canvas icons render through `SanitizedSVG` → `react-inlinesvg`, which fetches each icon source and inlines the `<svg>` on a later tick, so the number of `<svg>` elements in the panel settles asynchronously. The test previously:

1. `await page.waitForSelector('svg:not([aria-hidden="true"])')`
2. `await page.waitForLoadState('networkidle')`
3. sampled `visibleSvgs.count()` **once** and asserted `>= 5`.

When the icon SVGs are served from cache there is no network activity, so `networkidle` resolves immediately — before react-inlinesvg finishes inlining — and the single-sample count reads `0`, failing the assertion. `networkidle` is also discouraged by Playwright for exactly this reason.

The fix replaces the racy `waitForSelector` + `networkidle` + single-sample count with an auto-retrying `expect.poll(() => visibleSvgs.count()).toBeGreaterThanOrEqual(5)`, which waits for the count to settle within the timeout. No product code changes; the assertion semantics are unchanged.

**Who is this feature for?**

Grafana contributors — reduces CI flakiness.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

- Test-only change, scoped to the one flaky test; the other three tests in the file are untouched.
- Verified `eslint` and `prettier` pass on the file. I was not able to run the full Playwright suite locally (needs a built backend+frontend + its own server), so a green e2e run in CI is the real confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)