### PR TITLE
test: Fix E2E flakiness when drag'n'dropping rows or tabs (again)

### DIFF
--- a/e2e-playwright/dashboard-new-layouts/dashboard-repeats-row-layout.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboard-repeats-row-layout.spec.ts
@@ -526,7 +526,7 @@ test.describe(
       // so retry the position check until the reorder has been applied
       await expect(async () => {
         const singleRowBox = await getRowBox(dashboardPage, selectors, singleRowTitle);
-        const repeatedRowBox = await getRowBox(dashboardPage, selectors, `${repeatTitleBase}1`);
+        const repeatedRowBox = await getRowBox(dashboardPage, selectors, `${repeatTitleBase}4`); // note: 4 (the last repeated row) because we wait for the whole repeated group to move ;)
         expect(singleRowBox.y).toBeLessThan(repeatedRowBox.y);
       }).toPass();
 

--- a/e2e-playwright/dashboard-new-layouts/dashboards-repeats-tabs-layout.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboards-repeats-tabs-layout.spec.ts
@@ -256,7 +256,7 @@ test.describe(
       // The tab order is only updated after the drop animation finishes (onDragEnd),
       // so retry the position check until the reorder has been applied
       await expect(async () => {
-        const repeatedTab = await getTabPosition(dashboardPage, selectors, `${repeatTitleBase}${repeatOptions.at(0)}`);
+        const repeatedTab = await getTabPosition(dashboardPage, selectors, `${repeatTitleBase}${repeatOptions.at(-1)}`); // note: -1 (the last repeated tab) because we have to wait for the whole repeated group to move ;)
         const normalTab = await getTabPosition(dashboardPage, selectors, 'New tab');
         expect(normalTab?.x).toBeLessThan(repeatedTab!.x);
       }).toPass();


### PR DESCRIPTION
Follow-up of https://github.com/grafana/grafana/pull/129321

This PR finishes fixing the flakiness in the "move repeated rows" and "move repeated tabs" E2E tests.

#129321 made the post-drop position checks retry with `toPass()`, but it did not fix it all: the retried assertion was still racy.

## Problem

#129321 correctly identified that `@hello-pangea/dnd` only applies the reorder after its drop animation completes (`onDragEnd` → `moveRow`/`moveTab`), and wrapped the position checks in retrying `expect(...).toPass()` blocks.

However, both checks asserted on the position of the **first** repeated row/tab, the very element being dragged. 

During the drag and the drop animation, `@hello-pangea/dnd` moves that element visually via CSS transforms, so its bounding box can already read at the destination position *before* the layout model has been updated. The `toPass()` block could therefore pass on a purely visual, transient state, and the subsequent save/reload assertions would intermittently observe the old order.

## How to test

Run each spec repeatedly to check for flakiness:

- `yarn e2e:pw --project dashboard-new-layouts --reporter list --repeat-each=3 -- dashboard-repeats-row-layout.spec.ts`
- `yarn e2e:pw --project dashboard-new-layouts --reporter list --repeat-each=3 -- dashboards-repeats-tabs-layout.spec.ts`