### PR TITLE
Home: add the solutions matrix model

### DIFF
--- a/public/app/features/home/Recommendations/solutionsMatrix.test.ts
+++ b/public/app/features/home/Recommendations/solutionsMatrix.test.ts
@@ -1,0 +1,137 @@
+import {
+  type BaseRow,
+  EXISTING_SOLUTION_IDS,
+  orderCardsForSolution,
+  type RecommendedCardId,
+  selectRecommendations,
+  type SignalStatus,
+  SOLUTION_CARD_PRIORITY,
+  type SolutionState,
+} from './solutionsMatrix';
+
+function state(m: SignalStatus, l: SignalStatus, t: SignalStatus, k: SignalStatus): SolutionState {
+  // spanMetrics inactive = App Observability not in use; specific cases override it.
+  return { metrics: m, logs: l, traces: t, kubernetes: k, spanMetrics: 'inactive' };
+}
+
+const on = 'active' as const;
+const off = 'inactive' as const;
+
+describe('selectRecommendations', () => {
+  // All 12 reachable core combinations (kubernetes ⇒ metrics removes 4 of 16).
+  it.each<[SolutionState, RecommendedCardId[], BaseRow]>([
+    [state(off, off, off, off), ['connect-metrics', 'enable-logs', 'hosted-traces'], 'empty'],
+    [state(off, off, on, off), ['connect-metrics'], 'partial_telemetry'],
+    [state(off, on, off, off), ['connect-metrics'], 'logs_only'],
+    [state(off, on, on, off), ['connect-metrics'], 'partial_telemetry'],
+    [state(on, off, off, off), ['enable-logs'], 'metrics_only'],
+    [state(on, off, on, off), ['enable-logs'], 'metrics_only'],
+    [state(on, off, off, on), ['enable-logs-k8s'], 'k8s_no_logs'],
+    [state(on, off, on, on), ['enable-logs-k8s'], 'k8s_no_logs'],
+    [state(on, on, off, off), ['hosted-traces', 'kubernetes-monitoring'], 'ml_no_traces'],
+    [state(on, on, off, on), ['hosted-traces'], 'mlk_no_traces'],
+    [state(on, on, on, off), ['application-observability', 'kubernetes-monitoring'], 'mlt'],
+    [state(on, on, on, on), ['application-observability'], 'fully_active'],
+  ])('m=%s selects %s (%s)', (input, cards, baseRow) => {
+    expect(selectRecommendations(input)).toEqual({ cards, baseRow });
+  });
+
+  // A single unknown core signal blanks the selection even when the settled signals would produce cards.
+  it.each<Exclude<keyof SolutionState, 'spanMetrics'>>(['metrics', 'logs', 'traces', 'kubernetes'])(
+    'short-circuits to no cards when %s is unknown',
+    (signal) => {
+      const cardProducing = state(on, on, off, off);
+      expect(selectRecommendations({ ...cardProducing, [signal]: 'unknown' })).toEqual({
+        cards: [],
+        baseRow: 'unknown',
+      });
+    }
+  );
+
+  it('drops the App Observability card when span metrics show it is already in use', () => {
+    expect(selectRecommendations({ ...state(on, on, on, off), spanMetrics: 'active' })).toEqual({
+      cards: ['kubernetes-monitoring'],
+      baseRow: 'mlt',
+    });
+    expect(selectRecommendations({ ...state(on, on, on, on), spanMetrics: 'active' })).toEqual({
+      cards: [],
+      baseRow: 'fully_active',
+    });
+  });
+
+  it('fails the App Observability card toward hiding on an unknown span-metrics probe, without blanking', () => {
+    expect(selectRecommendations({ ...state(on, on, on, off), spanMetrics: 'unknown' })).toEqual({
+      cards: ['kubernetes-monitoring'],
+      baseRow: 'mlt',
+    });
+  });
+
+  it('ignores span metrics outside the M+L+T rows', () => {
+    expect(selectRecommendations({ ...state(on, on, off, off), spanMetrics: 'active' })).toEqual({
+      cards: ['hosted-traces', 'kubernetes-monitoring'],
+      baseRow: 'ml_no_traces',
+    });
+  });
+});
+
+describe('orderCardsForSolution', () => {
+  const ALL_CARD_IDS: RecommendedCardId[] = [
+    'connect-metrics',
+    'enable-logs',
+    'enable-logs-k8s',
+    'hosted-traces',
+    'kubernetes-monitoring',
+    'application-observability',
+  ];
+
+  it('leads ml_no_traces with K8s Monitoring for metrics and Hosted Traces for logs', () => {
+    const { cards } = selectRecommendations(state(on, on, off, off));
+
+    expect(orderCardsForSolution(cards, 'metrics')).toEqual(['kubernetes-monitoring', 'hosted-traces']);
+    expect(orderCardsForSolution(cards, 'logs')).toEqual(['hosted-traces', 'kubernetes-monitoring']);
+  });
+
+  it('leads mlt with K8s Monitoring for metrics and App Observability for logs and traces', () => {
+    const { cards } = selectRecommendations(state(on, on, on, off));
+
+    expect(orderCardsForSolution(cards, 'metrics')).toEqual(['kubernetes-monitoring', 'application-observability']);
+    expect(orderCardsForSolution(cards, 'logs')).toEqual(['application-observability', 'kubernetes-monitoring']);
+    expect(orderCardsForSolution(cards, 'traces')).toEqual(['application-observability', 'kubernetes-monitoring']);
+  });
+
+  it('only reorders: every solution view yields a permutation of every reachable selection', () => {
+    // All 12 reachable core combinations (kubernetes ⇒ metrics removes 4 of 16).
+    const reachable: SolutionState[] = (['active', 'inactive'] as const).flatMap((m) =>
+      (['active', 'inactive'] as const).flatMap((l) =>
+        (['active', 'inactive'] as const).flatMap((t) =>
+          (['active', 'inactive'] as const)
+            .filter((k) => !(k === 'active' && m === 'inactive'))
+            .map((k) => state(m, l, t, k))
+        )
+      )
+    );
+    expect(reachable).toHaveLength(12);
+
+    for (const solutionState of reachable) {
+      const { cards } = selectRecommendations(solutionState);
+      for (const id of EXISTING_SOLUTION_IDS) {
+        const ordered = orderCardsForSolution(cards, id);
+        expect([...ordered].sort()).toEqual([...cards].sort());
+      }
+    }
+  });
+
+  it('holds a complete total order per solution: every card id exactly once', () => {
+    for (const id of EXISTING_SOLUTION_IDS) {
+      expect([...SOLUTION_CARD_PRIORITY[id]].sort()).toEqual([...ALL_CARD_IDS].sort());
+    }
+  });
+
+  it('never mutates its input', () => {
+    const cards: RecommendedCardId[] = ['hosted-traces', 'kubernetes-monitoring'];
+
+    orderCardsForSolution(cards, 'metrics');
+
+    expect(cards).toEqual(['hosted-traces', 'kubernetes-monitoring']);
+  });
+});

--- a/public/app/features/home/Recommendations/solutionsMatrix.ts
+++ b/public/app/features/home/Recommendations/solutionsMatrix.ts
@@ -1,0 +1,158 @@
+/**
+ * Pure recommendation matrix ("Homepage Led Growth" analytics matrix), scoped to Logs, Traces
+ * (Hosted Traces), Kubernetes Monitoring and Application Observability. No I/O: signal
+ * detection lives in solutionState.ts.
+ */
+
+export type SignalStatus = 'active' | 'inactive' | 'unknown';
+
+export interface SolutionState {
+  metrics: SignalStatus;
+  logs: SignalStatus;
+  traces: SignalStatus;
+  kubernetes: SignalStatus;
+  /**
+   * Span metrics in the org's Prometheus — the "App Observability in use" signal. Only gates
+   * the application-observability card and fails toward hiding it: unlike the core signals,
+   * 'unknown' never blanks the selection.
+   */
+  spanMetrics: SignalStatus;
+}
+
+export type RecommendedCardId =
+  | 'connect-metrics'
+  | 'enable-logs'
+  | 'enable-logs-k8s'
+  | 'hosted-traces'
+  | 'kubernetes-monitoring'
+  | 'application-observability';
+
+/**
+ * Existing-solution ids the left card can display (ExistingItem.id values) — the KEYS of the
+ * priority table below. Distinct namespace from RecommendedCardId (the card ids inside the
+ * arrays).
+ */
+export const EXISTING_SOLUTION_IDS = ['kubernetes', 'metrics', 'logs', 'traces'] as const;
+export type ExistingSolutionId = (typeof EXISTING_SOLUTION_IDS)[number];
+
+// Complete total orders (every RecommendedCardId appears once) so the sort is deterministic;
+// gating means several entries are unreachable for a given solution, which is harmless.
+// Exported for the completeness invariant test only — consumers go through orderCardsForSolution.
+export const SOLUTION_CARD_PRIORITY: Record<ExistingSolutionId, readonly RecommendedCardId[]> = {
+  // Infra affinity: K8s Monitoring turns the metrics already flowing into curated views.
+  metrics: [
+    'enable-logs',
+    'enable-logs-k8s',
+    'kubernetes-monitoring',
+    'hosted-traces',
+    'application-observability',
+    'connect-metrics',
+  ],
+  // Logs↔traces correlation is the classic next step from logs.
+  logs: [
+    'connect-metrics',
+    'hosted-traces',
+    'application-observability',
+    'kubernetes-monitoring',
+    'enable-logs',
+    'enable-logs-k8s',
+  ],
+  // Traces are the App Observability foundation.
+  traces: [
+    'application-observability',
+    'connect-metrics',
+    'enable-logs',
+    'enable-logs-k8s',
+    'kubernetes-monitoring',
+    'hosted-traces',
+  ],
+  kubernetes: [
+    'enable-logs-k8s',
+    'enable-logs',
+    'hosted-traces',
+    'application-observability',
+    'connect-metrics',
+    'kubernetes-monitoring',
+  ],
+};
+
+/**
+ * Reorder a settled selection for the solution the user is viewing. Membership NEVER changes:
+ * the matrix's blocking rules (selectRecommendations) stay authoritative; a solution view only
+ * changes which of the selected cards leads the carousel.
+ */
+export function orderCardsForSolution(cards: RecommendedCardId[], solution: ExistingSolutionId): RecommendedCardId[] {
+  const priority = SOLUTION_CARD_PRIORITY[solution];
+  return [...cards].sort((a, b) => priority.indexOf(a) - priority.indexOf(b));
+}
+
+/**
+ * Matrix row that drove the selection — a selection driver id for analytics
+ * (`starting_state`), not a full state descriptor.
+ */
+export type BaseRow =
+  | 'empty'
+  | 'logs_only'
+  | 'partial_telemetry'
+  | 'metrics_only'
+  | 'k8s_no_logs'
+  | 'ml_no_traces'
+  | 'mlk_no_traces'
+  | 'mlt'
+  | 'fully_active'
+  | 'unknown';
+
+export interface RecommendationSelection {
+  cards: RecommendedCardId[];
+  baseRow: BaseRow;
+}
+
+/**
+ * Select the recommendation cards for a settled solution state.
+ *
+ * Any `unknown` signal short-circuits to no cards: a transient probe failure must never select
+ * a wrong row or pollute `starting_state`; the probe TTL re-resolves shortly. Kubernetes data
+ * implies metrics (kube-state-metrics live in a Prometheus), so `kubernetes` active with
+ * `metrics` inactive is unreachable — solutionState enforces the invariant.
+ */
+export function selectRecommendations(state: SolutionState): RecommendationSelection {
+  const { metrics, logs, traces, kubernetes, spanMetrics } = state;
+  // The core-signal short-circuit deliberately excludes spanMetrics: it only gates one card.
+  if (metrics === 'unknown' || logs === 'unknown' || traces === 'unknown' || kubernetes === 'unknown') {
+    return { cards: [], baseRow: 'unknown' };
+  }
+
+  if (metrics === 'inactive') {
+    // Empty orgs still get a full onboarding carousel: the three telemetry pillars.
+    if (logs === 'inactive' && traces === 'inactive') {
+      return { cards: ['connect-metrics', 'enable-logs', 'hosted-traces'], baseRow: 'empty' };
+    }
+    // Metrics is the foundation gate: the "Logs-only" row recommends Metrics, and partial
+    // telemetry without metrics funnels there too before anything else.
+    if (logs === 'active' && traces === 'inactive') {
+      return { cards: ['connect-metrics'], baseRow: 'logs_only' };
+    }
+    return { cards: ['connect-metrics'], baseRow: 'partial_telemetry' };
+  }
+
+  if (logs === 'inactive') {
+    // Logs is PRIMARY before any traces/k8s recommendation; the K8s row only changes the copy
+    // (Helm values flag). The row's Traces cell is moot when traces are already active.
+    return kubernetes === 'active'
+      ? { cards: ['enable-logs-k8s'], baseRow: 'k8s_no_logs' }
+      : { cards: ['enable-logs'], baseRow: 'metrics_only' };
+  }
+
+  if (traces === 'inactive') {
+    // Distinct rows so Hosted Traces clicks segment by Kubernetes presence.
+    return kubernetes === 'active'
+      ? { cards: ['hosted-traces'], baseRow: 'mlk_no_traces' }
+      : { cards: ['hosted-traces', 'kubernetes-monitoring'], baseRow: 'ml_no_traces' };
+  }
+
+  // M+L+T (OTel starters): App Observability unless span metrics show it is already in use.
+  const appO11y: RecommendedCardId[] = spanMetrics === 'inactive' ? ['application-observability'] : [];
+  return kubernetes === 'active'
+    ? { cards: appO11y, baseRow: 'fully_active' }
+    : { cards: [...appO11y, 'kubernetes-monitoring'], baseRow: 'mlt' };
+}


### PR DESCRIPTION
**What is this feature?**

Adds the solutions matrix: a pure decision table that maps settled solution signals (metrics/logs/traces/kubernetes/spanMetrics, each active/inactive/unknown) to the recommendation cards the homepage should show, plus a per-solution total order for re-sorting those cards when a solution view is selected. Pure model + exhaustive tests; nothing renders from it yet.

**Special notes for your reviewer:**

The matrix `empty` row's onboarding cards only render once the top of this stack wires the recommendations region to the matrix; until then this module is dead code by design (its tests are the only consumers).
