### PR TITLE
Home: rebuild the solution probes on health-filtered candidates

### DIFF
--- a/public/app/features/home/Recommendations/kubernetesData.test.ts
+++ b/public/app/features/home/Recommendations/kubernetesData.test.ts
@@ -9,7 +9,7 @@ import {
   type PanelData,
   type QueryRunner,
 } from '@grafana/data';
-import { config, createQueryRunner } from '@grafana/runtime';
+import { type BackendSrv, config, createQueryRunner, getBackendSrv } from '@grafana/runtime';
 import { getDataSourceInstanceList } from '@grafana/runtime/unstable';
 
 import {
@@ -23,6 +23,7 @@ import {
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
   createQueryRunner: jest.fn(),
+  getBackendSrv: jest.fn(),
 }));
 
 jest.mock('@grafana/runtime/unstable', () => ({
@@ -35,6 +36,7 @@ const mockGetDataSourceInstanceList = jest.mocked(getDataSourceInstanceList);
 
 const run = jest.fn();
 const destroy = jest.fn();
+const healthGet = jest.fn();
 
 // Mirrors the k8s app's persisted-choice key (grafana-k8s-app src/constants.ts K8S_STORAGE_KEY).
 const K8S_APP_STORAGE_KEY = 'grafana.k8s-app.navigation.storage';
@@ -62,12 +64,9 @@ let probeHangUids: Set<string>;
 // Probe queries against these uids emit LoadingState.Error for the first N attempts.
 let probeFailuresByUid: Record<string, number>;
 let probeAttempts: Record<string, number>;
-// Non-probe query batches: emit LoadingState.Error for the first N attempts per refId (keyed by first refId).
-let queryFailuresByRefId: Record<string, number>;
 // Non-probe query batches: always emit LoadingState.Error.
 let queryErrorRefIds: Set<string>;
 let valuesByRefId: Record<string, number>;
-let queryAttempts: Record<string, number>;
 
 type CapturedRun = { datasource: { uid: string }; queries: Array<{ refId: string; expr: string }> };
 
@@ -80,6 +79,10 @@ beforeEach(() => {
   destroy.mockReset();
   mockCreateQueryRunner.mockReset();
   mockGetDataSourceInstanceList.mockReset();
+  healthGet.mockReset();
+  // Health pre-filter: every candidate healthy unless a test overrides by uid.
+  healthGet.mockResolvedValue({ status: 'OK' });
+  jest.mocked(getBackendSrv).mockReturnValue({ get: healthGet } as unknown as BackendSrv);
   window.localStorage.clear();
   resetKubernetesPrometheusResolution();
   dataByUid = {};
@@ -87,10 +90,8 @@ beforeEach(() => {
   probeHangUids = new Set();
   probeFailuresByUid = {};
   probeAttempts = {};
-  queryFailuresByRefId = {};
   queryErrorRefIds = new Set();
   valuesByRefId = {};
-  queryAttempts = {};
   mockCreateQueryRunner.mockImplementation(() => {
     // Per-runner capture: parallel probes each get their own runner, so a shared variable would race.
     let captured: CapturedRun | undefined;
@@ -111,15 +112,8 @@ beforeEach(() => {
             return of({ state: LoadingState.Error, series: [] as DataFrame[], timeRange: {} } as PanelData);
           }
         }
-        if (!isProbe && captured) {
-          const batchKey = captured.queries[0]?.refId ?? '';
-          queryAttempts[batchKey] = (queryAttempts[batchKey] ?? 0) + 1;
-          const maxTransientFailures = Math.max(0, ...captured.queries.map((q) => queryFailuresByRefId[q.refId] ?? 0));
-          const errorTransient = maxTransientFailures > 0 && queryAttempts[batchKey] <= maxTransientFailures;
-          const errorAlways = captured.queries.some((q) => queryErrorRefIds.has(q.refId));
-          if (errorAlways || errorTransient) {
-            return of({ state: LoadingState.Error, series: [] as DataFrame[], timeRange: {} } as PanelData);
-          }
+        if (!isProbe && captured?.queries.some((q) => queryErrorRefIds.has(q.refId))) {
+          return of({ state: LoadingState.Error, series: [] as DataFrame[], timeRange: {} } as PanelData);
         }
         const count = dataByUid[uid] ?? 0;
         let series: DataFrame[] = [];
@@ -220,6 +214,24 @@ describe('Kubernetes Prometheus resolution', () => {
     expect(inventoryCalls()[0][0].datasource.uid).toBe('team-uid');
     const probedUids = probeCalls().map(([o]) => o.datasource.uid);
     expect(probedUids).toEqual(expect.arrayContaining(['default-uid', 'team-uid']));
+  });
+
+  it('skips an unhealthy datasource before probing', async () => {
+    setDataSources([
+      { uid: 'default-uid', name: 'default-prom', isDefault: true },
+      { uid: 'team-uid', name: 'team-prom' },
+    ]);
+    dataByUid = { 'default-uid': 5, 'team-uid': 1 };
+    healthGet.mockImplementation(async (url: string) =>
+      url.includes('default-uid') ? { status: 'ERROR' } : { status: 'OK' }
+    );
+
+    const inventory = await fetchKubernetesInventory();
+
+    expect(inventoryCalls()[0][0].datasource.uid).toBe('team-uid');
+    expect(inventory.clusters).toBe(1);
+    // The unhealthy datasource is dropped before the namespace probe ever runs.
+    expect(probeCalls().map(([o]) => o.datasource.uid)).toEqual(['team-uid']);
   });
 
   it('falls through to the first sibling in list order when several have data', async () => {
@@ -458,7 +470,7 @@ describe('Kubernetes Prometheus resolution', () => {
     }
   });
 
-  it('retries an errored probe so a transient failure keeps the default', async () => {
+  it('an errored probe reads as no data and a sibling wins', async () => {
     setDataSources([
       { uid: 'default-uid', name: 'default-prom', isDefault: true },
       { uid: 'team-uid', name: 'team-prom' },
@@ -466,19 +478,13 @@ describe('Kubernetes Prometheus resolution', () => {
     dataByUid = { 'default-uid': 5, 'team-uid': 1 };
     probeFailuresByUid = { 'default-uid': 1 };
 
-    jest.useFakeTimers();
-    try {
-      const inventoryPromise = fetchKubernetesInventory();
-      const healthPromise = fetchKubernetesHealth();
-      await jest.advanceTimersByTimeAsync(10_000);
-      const inventory = await inventoryPromise;
-      await healthPromise;
+    const inventory = await fetchKubernetesInventory();
+    await fetchKubernetesHealth();
 
-      expect(inventoryCalls()[0][0].datasource.uid).toBe('default-uid');
-      expect(inventory.clusters).toBe(5);
-    } finally {
-      jest.useRealTimers();
-    }
+    expect(inventoryCalls()[0][0].datasource.uid).toBe('team-uid');
+    expect(inventory.clusters).toBe(1);
+    // Exactly one attempt per candidate: the probe never retries.
+    expect(probeAttempts).toEqual({ 'default-uid': 1, 'team-uid': 1 });
   });
 
   it('rejects when every probe errors', async () => {
@@ -489,82 +495,8 @@ describe('Kubernetes Prometheus resolution', () => {
     dataByUid = { 'a-uid': 3, 'b-uid': 3 };
     probeErrorUids = new Set(['a-uid', 'b-uid']);
 
-    jest.useFakeTimers();
-    try {
-      const assertion = expect(fetchKubernetesInventory()).rejects.toThrow(
-        'No Prometheus datasource with Kubernetes data'
-      );
-      await jest.advanceTimersByTimeAsync(10_000);
-      await assertion;
-      expect(inventoryCalls()).toHaveLength(0);
-    } finally {
-      jest.useRealTimers();
-    }
-  });
-
-  it('probes only the leader when the top-priority datasource has data', async () => {
-    setDataSources([
-      { uid: 'default-uid', name: 'default-prom', isDefault: true },
-      { uid: 'team-uid', name: 'team-prom' },
-    ]);
-    dataByUid = { 'default-uid': 3, 'team-uid': 2 };
-
-    await fetchKubernetesInventory();
-
-    expect(probeCalls()).toHaveLength(1);
-    expect(probeCalls()[0][0].datasource.uid).toBe('default-uid');
-  });
-
-  it('retries a transient inventory query error instead of blanking the region', async () => {
-    setDataSources([{ uid: 'k8s-uid', name: 'k8s-prom', isDefault: true }]);
-    dataByUid = { 'k8s-uid': 2 };
-    queryFailuresByRefId = { clusters: 1 };
-
-    jest.useFakeTimers();
-    try {
-      const promise = fetchKubernetesInventory();
-      await jest.advanceTimersByTimeAsync(10_000);
-      const inventory = await promise;
-
-      expect(inventory.clusters).toBe(2);
-      expect(inventoryCalls()).toHaveLength(2);
-    } finally {
-      jest.useRealTimers();
-    }
-  });
-
-  it('retries a transient cpu query error', async () => {
-    setDataSources([{ uid: 'k8s-uid', name: 'k8s-prom', isDefault: true }]);
-    dataByUid = { 'k8s-uid': 2 };
-    queryFailuresByRefId = { cpu: 1 };
-
-    jest.useFakeTimers();
-    try {
-      const promise = fetchClusterCpuSeries();
-      await jest.advanceTimersByTimeAsync(10_000);
-      await promise;
-
-      expect(cpuCalls()).toHaveLength(2);
-    } finally {
-      jest.useRealTimers();
-    }
-  });
-
-  it('retries a transient datasource-list failure', async () => {
-    mockGetDataSourceInstanceList
-      .mockRejectedValueOnce(new Error('gateway blip'))
-      .mockResolvedValue([createPrometheusListItem({ uid: 'k8s-uid', name: 'k8s-prom', isDefault: true })]);
-    dataByUid = { 'k8s-uid': 2 };
-
-    jest.useFakeTimers();
-    try {
-      const promise = fetchKubernetesInventory();
-      await jest.advanceTimersByTimeAsync(10_000);
-      expect((await promise).clusters).toBe(2);
-      expect(mockGetDataSourceInstanceList).toHaveBeenCalledTimes(2);
-    } finally {
-      jest.useRealTimers();
-    }
+    await expect(fetchKubernetesInventory()).rejects.toThrow('No Prometheus datasource with Kubernetes data');
+    expect(inventoryCalls()).toHaveLength(0);
   });
 
   it('does not cache a failed resolution for the TTL window', async () => {
@@ -587,61 +519,13 @@ describe('Kubernetes Prometheus resolution', () => {
     }
   });
 
-  it('rejects after three failed inventory attempts', async () => {
+  it('rejects when the inventory query fails', async () => {
     setDataSources([{ uid: 'k8s-uid', name: 'k8s-prom', isDefault: true }]);
     dataByUid = { 'k8s-uid': 2 };
     queryErrorRefIds = new Set(['clusters']);
 
-    jest.useFakeTimers();
-    try {
-      const assertion = expect(fetchKubernetesInventory()).rejects.toThrow();
-      await jest.advanceTimersByTimeAsync(10_000);
-      await assertion;
-      expect(inventoryCalls()).toHaveLength(3);
-    } finally {
-      jest.useRealTimers();
-    }
-  });
-
-  it('recovers when only the third inventory attempt succeeds', async () => {
-    setDataSources([{ uid: 'k8s-uid', name: 'k8s-prom', isDefault: true }]);
-    dataByUid = { 'k8s-uid': 2 };
-    queryFailuresByRefId = { clusters: 2 };
-
-    jest.useFakeTimers();
-    try {
-      const promise = fetchKubernetesInventory();
-      await jest.advanceTimersByTimeAsync(10_000);
-      const inventory = await promise;
-
-      expect(inventory.clusters).toBe(2);
-      expect(inventoryCalls()).toHaveLength(3);
-    } finally {
-      jest.useRealTimers();
-    }
-  });
-
-  it('keeps the default when its probe fails twice then succeeds', async () => {
-    setDataSources([
-      { uid: 'default-uid', name: 'default-prom', isDefault: true },
-      { uid: 'team-uid', name: 'team-prom' },
-    ]);
-    dataByUid = { 'default-uid': 5, 'team-uid': 1 };
-    probeFailuresByUid = { 'default-uid': 2 };
-
-    jest.useFakeTimers();
-    try {
-      const inventoryPromise = fetchKubernetesInventory();
-      await jest.advanceTimersByTimeAsync(10_000);
-      const inventory = await inventoryPromise;
-
-      expect(inventoryCalls()[0][0].datasource.uid).toBe('default-uid');
-      expect(inventory.clusters).toBe(5);
-      expect(probeAttempts['default-uid']).toBe(3);
-      expect(probeCalls().map(([o]) => o.datasource.uid)).not.toContain('team-uid');
-    } finally {
-      jest.useRealTimers();
-    }
+    await expect(fetchKubernetesInventory()).rejects.toThrow();
+    expect(inventoryCalls()).toHaveLength(1);
   });
 
   it('uses the configured state-history metric name in the alerts union', async () => {

--- a/public/app/features/home/Recommendations/kubernetesData.ts
+++ b/public/app/features/home/Recommendations/kubernetesData.ts
@@ -8,12 +8,12 @@ import { config } from '@grafana/runtime';
 
 import {
   createTtlCachedPromise,
+  filterHealthyDatasources,
   findDatasourceWithData,
   listProbeCandidates,
   MAX_PROBED_DATASOURCES,
   PROBE_TIMEOUT_MS,
   PROBE_TTL_MS,
-  withRetry,
 } from './probeUtils';
 import { readScalar, readSeries, runInstantQueries, runRangeQuery } from './promQuery';
 
@@ -85,20 +85,16 @@ async function orderedCandidates(): Promise<DataSourceInstanceListItem[]> {
   return storedMatch ? [storedMatch, ...ordered.filter((ds) => ds !== storedMatch)] : ordered;
 }
 
-// "Has Kubernetes data" = namespaces detected; an errored probe retries with backoff, then counts
-// as no data — an unusable datasource must not win the probe.
+// Single attempt inside the probe timeout; errors read as no data in the parallel scan.
 async function hasKubernetesNamespaces(ds: Pick<DataSourceInstanceSettings, 'uid' | 'type'>): Promise<boolean> {
-  try {
-    const frames = await withRetry(() => runInstantQueries({ namespaces: NAMESPACE_PROBE }, ds, PROBE_TIMEOUT_MS));
-    return (readScalar(frames, 'namespaces') ?? 0) > 0;
-  } catch {
-    return false;
-  }
+  const frames = await runInstantQueries({ namespaces: NAMESPACE_PROBE }, ds, PROBE_TIMEOUT_MS);
+  return (readScalar(frames, 'namespaces') ?? 0) > 0;
 }
 
-// Leader-first probe over the ordered candidates; see findDatasourceWithData for the fan-out rules.
+// Health-filtered parallel scan over the ordered candidates; first candidate with data wins.
 async function resolveKubernetesPrometheus(): Promise<DataSourceInstanceListItem | null> {
-  const candidates = (await orderedCandidates()).slice(0, MAX_PROBED_DATASOURCES);
+  // Filter after the cap: broken datasources consume cap slots, same as they consumed probe slots.
+  const candidates = await filterHealthyDatasources((await orderedCandidates()).slice(0, MAX_PROBED_DATASOURCES));
   return findDatasourceWithData(candidates, hasKubernetesNamespaces);
 }
 
@@ -123,7 +119,7 @@ export async function fetchKubernetesInventory(): Promise<KubernetesInventory> {
   if (!ds) {
     throw new Error(NO_KUBERNETES_DATA_ERROR);
   }
-  const frames = await withRetry(() => runInstantQueries(INVENTORY_QUERIES, ds));
+  const frames = await runInstantQueries(INVENTORY_QUERIES, ds);
   return {
     clusters: readScalar(frames, 'clusters') ?? 0,
     pods: readScalar(frames, 'pods') ?? 0,
@@ -151,7 +147,7 @@ export async function fetchKubernetesHealth(): Promise<KubernetesHealth> {
   };
 
   const [frames, grafanaAlertsFiring] = await Promise.all([
-    withRetry(() => runInstantQueries(queries, ds)),
+    runInstantQueries(queries, ds),
     sameDatasource ? Promise.resolve(null) : fetchGrafanaManagedAlertCount(grafanaAlertsUid, grafanaMetric),
   ]);
 
@@ -172,8 +168,9 @@ export async function fetchKubernetesHealth(): Promise<KubernetesHealth> {
 // A broken/absent state-history datasource must not blank the whole health row: fail to null.
 async function fetchGrafanaManagedAlertCount(uid: string, metric: string): Promise<number | null> {
   try {
-    const frames = await withRetry(() =>
-      runInstantQueries({ grafanaAlertsFiring: `count(${metric}${ALERTS_MATCHER})` }, { uid, type: 'prometheus' })
+    const frames = await runInstantQueries(
+      { grafanaAlertsFiring: `count(${metric}${ALERTS_MATCHER})` },
+      { uid, type: 'prometheus' }
     );
     return readScalar(frames, 'grafanaAlertsFiring');
   } catch {
@@ -187,8 +184,6 @@ export async function fetchClusterCpuSeries(): Promise<FieldSparkline | null> {
   if (!ds) {
     throw new Error(NO_KUBERNETES_DATA_ERROR);
   }
-  const frames = await withRetry(() =>
-    runRangeQuery('cpu', 'sum(rate(container_cpu_usage_seconds_total{container!=""}[5m]))', 24, ds)
-  );
+  const frames = await runRangeQuery('cpu', 'sum(rate(container_cpu_usage_seconds_total{container!=""}[5m]))', 24, ds);
   return readSeries(frames, 'cpu');
 }

--- a/public/app/features/home/Recommendations/probeUtils.test.ts
+++ b/public/app/features/home/Recommendations/probeUtils.test.ts
@@ -1,4 +1,38 @@
-import { withTimeout } from './probeUtils';
+import { type DataSourceInstanceListItem } from '@grafana/data';
+import { type BackendSrv, getBackendSrv } from '@grafana/runtime';
+import { getDataSourceInstanceList } from '@grafana/runtime/unstable';
+
+import {
+  filterHealthyDatasources,
+  findDatasourceWithData,
+  listProbeCandidates,
+  MAX_PROBED_DATASOURCES,
+  withTimeout,
+} from './probeUtils';
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getBackendSrv: jest.fn(),
+}));
+
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getDataSourceInstanceList: jest.fn(),
+}));
+
+const getDataSourceInstanceListMock = jest.mocked(getDataSourceInstanceList);
+const healthGetMock = jest.fn();
+
+function listItem(ds: { uid?: string; name: string; isDefault?: boolean }): DataSourceInstanceListItem {
+  return {
+    uid: ds.uid ?? ds.name,
+    name: ds.name,
+    type: 'loki',
+    meta: { id: 'loki' } as DataSourceInstanceListItem['meta'],
+    readOnly: false,
+    isDefault: ds.isDefault ?? false,
+  };
+}
 
 describe('withTimeout', () => {
   it('resolves with the promise value when it settles inside the deadline', async () => {
@@ -13,5 +47,163 @@ describe('withTimeout', () => {
     const hang = new Promise<never>(() => {});
 
     await expect(withTimeout(hang, 20)).rejects.toThrow(/timed out/i);
+  });
+});
+
+describe('listProbeCandidates', () => {
+  beforeEach(() => {
+    getDataSourceInstanceListMock.mockReset();
+  });
+
+  it('drops excluded uids', async () => {
+    getDataSourceInstanceListMock.mockResolvedValue([
+      listItem({ uid: 'excluded', name: 'utility' }),
+      listItem({ uid: 'kept', name: 'product' }),
+    ]);
+
+    const candidates = await listProbeCandidates('loki', undefined, new Set(['excluded']));
+
+    expect(candidates.map((ds) => ds.uid)).toEqual(['kept']);
+  });
+
+  it('never re-admits excluded uids through the utility-name fallback', async () => {
+    // Every datasource is a cloud utility by name: the name fallback re-admits them, but an
+    // excluded uid must stay out even then.
+    getDataSourceInstanceListMock.mockResolvedValue([
+      listItem({ uid: 'usage', name: 'grafanacloud-usage' }),
+      listItem({ uid: 'ml', name: 'grafanacloud-ml-metrics' }),
+    ]);
+
+    const candidates = await listProbeCandidates('prometheus', undefined, new Set(['usage']));
+
+    expect(candidates.map((ds) => ds.uid)).toEqual(['ml']);
+  });
+
+  it('returns empty when exclusions empty the list', async () => {
+    getDataSourceInstanceListMock.mockResolvedValue([listItem({ uid: 'only', name: 'grafanacloud-usage' })]);
+
+    await expect(listProbeCandidates('prometheus', undefined, new Set(['only']))).resolves.toEqual([]);
+  });
+
+  it('skips cloud utility datasources unless they are all there is', async () => {
+    getDataSourceInstanceListMock.mockResolvedValue([
+      listItem({ name: 'grafanacloud-usage' }),
+      listItem({ name: 'product' }),
+    ]);
+
+    await expect(listProbeCandidates('prometheus')).resolves.toEqual([listItem({ name: 'product' })]);
+
+    getDataSourceInstanceListMock.mockResolvedValue([listItem({ name: 'grafanacloud-usage' })]);
+
+    await expect(listProbeCandidates('prometheus')).resolves.toEqual([listItem({ name: 'grafanacloud-usage' })]);
+  });
+
+  it('puts the default datasource first and applies the cap', async () => {
+    getDataSourceInstanceListMock.mockResolvedValue([
+      ...Array.from({ length: MAX_PROBED_DATASOURCES }, (_, i) => listItem({ name: `ds-${i}` })),
+      listItem({ name: 'the-default', isDefault: true }),
+    ]);
+
+    const candidates = await listProbeCandidates('loki');
+
+    expect(candidates).toHaveLength(MAX_PROBED_DATASOURCES);
+    expect(candidates[0].name).toBe('the-default');
+  });
+});
+
+describe('filterHealthyDatasources', () => {
+  beforeEach(() => {
+    healthGetMock.mockReset();
+    jest.mocked(getBackendSrv).mockReturnValue({ get: healthGetMock } as unknown as BackendSrv);
+  });
+
+  it('keeps candidates whose health check reports OK', async () => {
+    healthGetMock.mockResolvedValue({ status: 'OK' });
+
+    const kept = await filterHealthyDatasources([listItem({ uid: 'healthy', name: 'healthy' })]);
+
+    expect(kept.map((ds) => ds.uid)).toEqual(['healthy']);
+    expect(healthGetMock).toHaveBeenCalledWith('/api/datasources/uid/healthy/health', undefined, undefined, {
+      showErrorAlert: false,
+    });
+  });
+
+  it('drops a candidate whose health check reports a non-OK status', async () => {
+    healthGetMock.mockImplementation(async (url: string) => ({ status: url.includes('sick') ? 'ERROR' : 'OK' }));
+
+    const kept = await filterHealthyDatasources([
+      listItem({ uid: 'sick', name: 'sick' }),
+      listItem({ uid: 'healthy', name: 'healthy' }),
+    ]);
+
+    expect(kept.map((ds) => ds.uid)).toEqual(['healthy']);
+  });
+
+  it('drops a candidate whose health check rejects', async () => {
+    healthGetMock.mockImplementation((url: string) =>
+      url.includes('broken') ? Promise.reject(new Error('connection refused')) : Promise.resolve({ status: 'OK' })
+    );
+
+    const kept = await filterHealthyDatasources([
+      listItem({ uid: 'broken', name: 'broken' }),
+      listItem({ uid: 'healthy', name: 'healthy' }),
+    ]);
+
+    expect(kept.map((ds) => ds.uid)).toEqual(['healthy']);
+  });
+
+  it('drops a candidate whose health check hangs past the 3s cutoff', async () => {
+    jest.useFakeTimers();
+    try {
+      healthGetMock.mockImplementation((url: string) =>
+        url.includes('hung') ? new Promise(() => {}) : Promise.resolve({ status: 'OK' })
+      );
+
+      const promise = filterHealthyDatasources([
+        listItem({ uid: 'hung', name: 'hung' }),
+        listItem({ uid: 'healthy', name: 'healthy' }),
+      ]);
+      await jest.advanceTimersByTimeAsync(3_500);
+
+      expect((await promise).map((ds) => ds.uid)).toEqual(['healthy']);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});
+
+describe('findDatasourceWithData', () => {
+  it('prefers the first candidate in priority order even when a later one settles sooner', async () => {
+    jest.useFakeTimers();
+    try {
+      const first = listItem({ uid: 'first', name: 'first' });
+      const second = listItem({ uid: 'second', name: 'second' });
+      const hasData = (ds: DataSourceInstanceListItem) =>
+        ds.uid === 'first'
+          ? new Promise<boolean>((resolve) => setTimeout(() => resolve(true), 20))
+          : Promise.resolve(true);
+
+      const promise = findDatasourceWithData([first, second], hasData);
+      await jest.advanceTimersByTimeAsync(25);
+
+      await expect(promise).resolves.toBe(first);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('reads a rejected probe as no data', async () => {
+    const candidates = [listItem({ uid: 'broken', name: 'broken' }), listItem({ uid: 'empty', name: 'empty' })];
+    const hasData = (ds: DataSourceInstanceListItem) =>
+      ds.uid === 'broken' ? Promise.reject(new Error('probe failed')) : Promise.resolve(false);
+
+    await expect(findDatasourceWithData(candidates, hasData)).resolves.toBeNull();
+  });
+
+  it('settles null for an empty candidate list without probing', async () => {
+    const hasData = jest.fn();
+
+    await expect(findDatasourceWithData([], hasData)).resolves.toBeNull();
+    expect(hasData).not.toHaveBeenCalled();
   });
 });

--- a/public/app/features/home/Recommendations/probeUtils.ts
+++ b/public/app/features/home/Recommendations/probeUtils.ts
@@ -1,15 +1,18 @@
 import { type DataSourceInstanceListItem } from '@grafana/data';
+import { getBackendSrv } from '@grafana/runtime';
 import { getDataSourceInstanceList } from '@grafana/runtime/unstable';
 
 /** Cap the probe fan-out: only the first N candidates (in priority order) are probed per page load. */
 export const MAX_PROBED_DATASOURCES = 10;
 
-// Probes gate homepage cards: 3 attempts x 30s meant a fallback could wait 92s+. 10s per attempt
-// bounds the leader to ~32s worst case while still outlasting a slow-but-alive datasource.
+// Probes gate homepage cards: 10s outlasts a slow-but-alive datasource without stalling the region.
 export const PROBE_TIMEOUT_MS = 10_000;
 
 /** One shared probe resolution per TTL window; a later home visit re-resolves after datasource changes. */
 export const PROBE_TTL_MS = 60_000;
+
+// ponytail: 3s /health cutoff (drilldown's) — suspected too tight for OPS-scale instances; revisit as follow-up.
+const HEALTH_CHECK_TIMEOUT_MS = 3000;
 
 // Spacing between retry attempts: the transient browser-side failures observed on the homepage
 // (connection queuing, gateway blips) can outlast an immediate retry; a short backoff covers
@@ -35,6 +38,15 @@ export async function withRetry<T>(fn: () => Promise<T>): Promise<T> {
       await sleep(RETRY_DELAYS_MS[attempt]);
     }
   }
+}
+
+/**
+ * GET through the classic datasource proxy, timeout-bounded, never toasts. Some datasource
+ * backends (e.g. Tempo) serve their HTTP API only here, not on the resource router.
+ */
+export async function probeProxyGet<T>(uid: string, path: string, params: Record<string, unknown>): Promise<T> {
+  const url = `/api/datasources/proxy/uid/${encodeURIComponent(uid)}/${path}`;
+  return withTimeout(getBackendSrv().get<T>(url, params, undefined, { showErrorAlert: false }), PROBE_TIMEOUT_MS);
 }
 
 /** Rejects when `promise` outlasts `ms`; the underlying request keeps running but stops gating the caller. */
@@ -79,50 +91,58 @@ export function createTtlCachedPromise<T>(fn: () => Promise<T>, ttlMs: number): 
 }
 
 /**
- * Candidate datasources of `type` for a data-existence probe: cloud utility datasources are
+ * Candidate datasources of `type` for a data-existence probe: `excludeUids` are dropped
+ * unconditionally (never re-admitted by any fallback), cloud utility datasources are
  * skipped (unless they are all there is), the default datasource leads, capped for fan-out.
  * Pass an Infinity `cap` when the caller reorders before capping itself.
  */
 export async function listProbeCandidates(
   type: string,
-  cap = MAX_PROBED_DATASOURCES
+  cap = MAX_PROBED_DATASOURCES,
+  excludeUids?: ReadonlySet<string>
 ): Promise<DataSourceInstanceListItem[]> {
-  const list = await withRetry(() =>
-    getDataSourceInstanceList({
-      type,
-      // Reject the -- Grafana -- builtin by meta.id; a ds.type check would drop alias datasources.
-      filter: (ds) => ds.meta.id !== 'grafana',
-    })
-  );
-  const preferred = list.filter((ds) => !CLOUD_UTILITY_DATASOURCE_NAMES[ds.name]);
-  const pool = preferred.length > 0 ? preferred : list;
+  const list = await getDataSourceInstanceList({
+    type,
+    // Reject the -- Grafana -- builtin by meta.id; a ds.type check would drop alias datasources.
+    filter: (ds) => ds.meta.id !== 'grafana',
+  });
+  const eligible = excludeUids ? list.filter((ds) => !excludeUids.has(ds.uid)) : list;
+  const preferred = eligible.filter((ds) => !CLOUD_UTILITY_DATASOURCE_NAMES[ds.name]);
+  const pool = preferred.length > 0 ? preferred : eligible;
   const def = pool.find((ds) => ds.isDefault);
   const ordered = def ? [def, ...pool.filter((ds) => ds !== def)] : [...pool];
   return ordered.slice(0, cap);
 }
 
-/**
- * Probe the top-priority candidate alone first: in the common case (the default datasource has
- * the data) this issues 1 query instead of N, and a transient sibling race can never outrank it.
- * Only when the leader has no data (or errors) fan out to the rest in parallel. `hasData` must
- * not throw — an unusable datasource counts as no data.
- */
+/** Candidates whose /health reports OK; broken or slow datasources drop out of detection. */
+export async function filterHealthyDatasources(
+  candidates: DataSourceInstanceListItem[]
+): Promise<DataSourceInstanceListItem[]> {
+  const results = await Promise.allSettled(
+    candidates.map((ds) =>
+      withTimeout(
+        getBackendSrv().get<{ status?: string }>(
+          `/api/datasources/uid/${encodeURIComponent(ds.uid)}/health`,
+          undefined,
+          undefined,
+          { showErrorAlert: false }
+        ),
+        HEALTH_CHECK_TIMEOUT_MS
+      )
+    )
+  );
+  return candidates.filter((_, i) => {
+    const result = results[i];
+    return result.status === 'fulfilled' && result.value?.status === 'OK';
+  });
+}
+
+/** First candidate (in priority order) whose probe confirms data; probe errors read as no data. */
 export async function findDatasourceWithData(
   candidates: DataSourceInstanceListItem[],
   hasData: (ds: DataSourceInstanceListItem) => Promise<boolean>
 ): Promise<DataSourceInstanceListItem | null> {
-  if (candidates.length === 0) {
-    return null;
-  }
-  if (await hasData(candidates[0])) {
-    return candidates[0];
-  }
-  const rest = candidates.slice(1);
-  // Parallel probe for hasData while retaining priority of original list
-  for (const [index, probe] of rest.map(hasData).entries()) {
-    if (await probe) {
-      return rest[index];
-    }
-  }
-  return null;
+  const results = await Promise.allSettled(candidates.map((ds) => hasData(ds)));
+  const winner = results.findIndex((result) => result.status === 'fulfilled' && result.value === true);
+  return winner === -1 ? null : candidates[winner];
 }

--- a/public/app/features/home/Recommendations/solutionDataProbes.test.ts
+++ b/public/app/features/home/Recommendations/solutionDataProbes.test.ts
@@ -1,9 +1,9 @@
 import { createDataFrame, type DataSourceInstanceListItem, FieldType } from '@grafana/data';
-import { getBackendSrv } from '@grafana/runtime';
+import { type BackendSrv, getBackendSrv } from '@grafana/runtime';
 import { getDataSourceInstanceList } from '@grafana/runtime/unstable';
 
 import { runDatasourceQueries, runInstantQueries } from './promQuery';
-import { hasSolutionData, resetSolutionDataProbes } from './solutionDataProbes';
+import { hasSolutionData, probeFound, resetSolutionDataProbes, tempoHasTraces } from './solutionDataProbes';
 
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
@@ -22,13 +22,13 @@ jest.mock('./promQuery', () => ({
 }));
 
 const mockList = jest.mocked(getDataSourceInstanceList);
+const mockProxyGet = jest.fn();
 const mockInstant = jest.mocked(runInstantQueries);
 const mockQueries = jest.mocked(runDatasourceQueries);
-const mockGet = jest.fn();
 
 function datasource(type: string, name = `${type}-ds`): DataSourceInstanceListItem {
   return {
-    uid: `${name}-uid`,
+    uid: name,
     name,
     type,
     meta: { id: type } as DataSourceInstanceListItem['meta'],
@@ -45,12 +45,113 @@ function scalarFrame(refId: string, value: number) {
 }
 
 beforeEach(() => {
-  resetSolutionDataProbes();
+  jest.useFakeTimers();
+  jest.setSystemTime(new Date('2026-07-24T12:00:00Z'));
   mockList.mockReset();
+  mockProxyGet.mockReset();
+  // Health checks share getBackendSrv().get: answer /health OK by default so candidates survive the filter.
+  mockProxyGet.mockImplementation(async (url: string) => (url.endsWith('/health') ? { status: 'OK' } : undefined));
+  jest.mocked(getBackendSrv).mockReturnValue({ get: mockProxyGet } as unknown as BackendSrv);
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+beforeEach(() => {
+  resetSolutionDataProbes();
   mockInstant.mockReset();
   mockQueries.mockReset();
-  mockGet.mockReset();
-  jest.mocked(getBackendSrv).mockReturnValue({ get: mockGet } as unknown as ReturnType<typeof getBackendSrv>);
+});
+
+describe('probeFound', () => {
+  it('returns the first candidate that confirms data', async () => {
+    mockList.mockResolvedValue([datasource('tempo', 'first'), datasource('tempo', 'second')]);
+
+    const found = await probeFound('tempo', async (ds) => ds.name === 'second');
+
+    expect(found?.name).toBe('second');
+  });
+
+  it('settles null when every candidate probes clean-and-empty', async () => {
+    mockList.mockResolvedValue([datasource('tempo')]);
+
+    await expect(probeFound('tempo', async () => false)).resolves.toBeNull();
+  });
+
+  it('settles null for an empty candidate list', async () => {
+    mockList.mockResolvedValue([]);
+
+    const hasData = jest.fn();
+    await expect(probeFound('tempo', hasData)).resolves.toBeNull();
+    expect(hasData).not.toHaveBeenCalled();
+  });
+
+  it('settles null when a candidate errored and no data was found elsewhere', async () => {
+    mockList.mockResolvedValue([datasource('tempo', 'broken'), datasource('tempo', 'empty')]);
+
+    await expect(
+      probeFound('tempo', async (ds) => {
+        if (ds.name === 'broken') {
+          throw new Error('probe failed');
+        }
+        return false;
+      })
+    ).resolves.toBeNull();
+  });
+
+  it('never probes an unhealthy candidate', async () => {
+    mockList.mockResolvedValue([datasource('loki', 'broken'), datasource('loki', 'healthy')]);
+    mockProxyGet.mockImplementation((url: string) =>
+      url.includes('broken') ? Promise.reject(new Error('health check failed')) : Promise.resolve({ status: 'OK' })
+    );
+
+    const hasData = jest.fn().mockResolvedValue(true);
+    const found = await probeFound('loki', hasData);
+
+    expect(found?.name).toBe('healthy');
+    expect(hasData).toHaveBeenCalledTimes(1);
+    expect(hasData).toHaveBeenCalledWith(expect.objectContaining({ uid: 'healthy' }));
+  });
+
+  it('never probes excluded uids', async () => {
+    mockList.mockResolvedValue([datasource('loki', 'excluded'), datasource('loki', 'kept')]);
+
+    const hasData = jest.fn().mockResolvedValue(true);
+    const found = await probeFound('loki', hasData, new Set(['excluded']));
+
+    expect(found?.name).toBe('kept');
+    expect(hasData).toHaveBeenCalledTimes(1);
+    expect(hasData).toHaveBeenCalledWith(expect.objectContaining({ uid: 'kept' }));
+  });
+});
+
+describe('tempoHasTraces', () => {
+  it('reports data when the Tempo search API returns a trace', async () => {
+    mockProxyGet.mockResolvedValue({ traces: [{ traceID: 'abc' }] });
+
+    await expect(tempoHasTraces(datasource('tempo'))).resolves.toBe(true);
+
+    const end = Math.floor(Date.now() / 1000);
+    expect(mockProxyGet).toHaveBeenCalledWith(
+      '/api/datasources/proxy/uid/tempo-ds/api/search',
+      { q: '{}', limit: 1, start: end - 24 * 3600, end },
+      undefined,
+      { showErrorAlert: false }
+    );
+  });
+
+  it('reports no data when the Tempo search is empty', async () => {
+    mockProxyGet.mockResolvedValue({ traces: [] });
+
+    await expect(tempoHasTraces(datasource('tempo'))).resolves.toBe(false);
+  });
+
+  it('throws when the search endpoint fails', async () => {
+    mockProxyGet.mockRejectedValue(new Error('HTTP 404'));
+
+    await expect(tempoHasTraces(datasource('tempo'))).rejects.toThrow('HTTP 404');
+  });
 });
 
 describe('hasSolutionData', () => {
@@ -97,32 +198,6 @@ describe('hasSolutionData', () => {
       expect(mockInstant).toHaveBeenCalledTimes(1);
     });
 
-    it('fails toward hiding the recommendation when every datasource probe errors', async () => {
-      mockList.mockResolvedValue([datasource('prometheus', 'prom-a'), datasource('prometheus', 'prom-b')]);
-      mockInstant.mockRejectedValue(new Error('query timeout'));
-
-      await expect(hasSolutionData('grafana-synthetic-monitoring-app')).resolves.toBe(true);
-    }, 15_000);
-
-    it('reports data when one datasource errors but another has the metric', async () => {
-      mockList.mockResolvedValue([datasource('prometheus', 'prom-a'), datasource('prometheus', 'prom-b')]);
-      mockInstant.mockImplementation(async (_queries, ds) =>
-        ds.uid === 'prom-a-uid' ? Promise.reject(new Error('403')) : [scalarFrame('probe', 7)]
-      );
-
-      await expect(hasSolutionData('grafana-synthetic-monitoring-app')).resolves.toBe(true);
-    }, 15_000);
-
-    it('fails toward hiding when one datasource errors even if the rest probe clean and empty', async () => {
-      // The errored datasource may hold the data, so absence is not established.
-      mockList.mockResolvedValue([datasource('prometheus', 'prom-a'), datasource('prometheus', 'prom-b')]);
-      mockInstant.mockImplementation(async (_queries, ds) =>
-        ds.uid === 'prom-a-uid' ? Promise.reject(new Error('403')) : []
-      );
-
-      await expect(hasSolutionData('grafana-synthetic-monitoring-app')).resolves.toBe(true);
-    }, 15_000);
-
     it('probes both span-metric naming schemes for Application Observability', async () => {
       mockList.mockResolvedValue([datasource('prometheus')]);
       mockInstant.mockResolvedValue([scalarFrame('probe', 3)]);
@@ -136,63 +211,5 @@ describe('hasSolutionData', () => {
         expect.any(Number)
       );
     });
-  });
-
-  describe('Hosted Traces', () => {
-    it('reports data when a Tempo search returns a trace', async () => {
-      mockList.mockResolvedValue([datasource('tempo')]);
-      mockQueries.mockResolvedValue([
-        createDataFrame({ refId: 'traces', fields: [{ name: 'traceID', type: FieldType.string, values: ['abc'] }] }),
-      ]);
-
-      await expect(hasSolutionData('grafana-exploretraces-app')).resolves.toBe(true);
-    });
-
-    it('reports no data when the Tempo search is empty', async () => {
-      mockList.mockResolvedValue([datasource('tempo')]);
-      mockQueries.mockResolvedValue([]);
-
-      await expect(hasSolutionData('grafana-exploretraces-app')).resolves.toBe(false);
-    });
-
-    it('reports no data when there is no Tempo datasource', async () => {
-      mockList.mockResolvedValue([]);
-
-      await expect(hasSolutionData('grafana-exploretraces-app')).resolves.toBe(false);
-      expect(mockQueries).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('Frontend Observability', () => {
-    it('reports data when the Faro app lists a configured app through its proxy route', async () => {
-      mockGet.mockResolvedValue([{ name: 'my-app' }]);
-
-      await expect(hasSolutionData('grafana-kowalski-app')).resolves.toBe(true);
-      expect(mockGet).toHaveBeenCalledWith(
-        expect.stringContaining('/api/plugin-proxy/grafana-kowalski-app/api-proxy/api/v1/app'),
-        undefined,
-        undefined,
-        // Probe failures are expected; a toast per failed attempt would spam the homepage.
-        expect.objectContaining({ showErrorAlert: false })
-      );
-    });
-
-    it('reports no data when the Faro app list is empty', async () => {
-      mockGet.mockResolvedValue([]);
-
-      await expect(hasSolutionData('grafana-kowalski-app')).resolves.toBe(false);
-    });
-
-    it('treats a non-array response as no data so the setup card still shows', async () => {
-      mockGet.mockResolvedValue({ items: [{ name: 'my-app' }] });
-
-      await expect(hasSolutionData('grafana-kowalski-app')).resolves.toBe(false);
-    });
-
-    it('fails toward hiding the recommendation when the registry is unreachable', async () => {
-      mockGet.mockRejectedValue(new Error('api unavailable'));
-
-      await expect(hasSolutionData('grafana-kowalski-app')).resolves.toBe(true);
-    }, 15_000);
   });
 });

--- a/public/app/features/home/Recommendations/solutionDataProbes.ts
+++ b/public/app/features/home/Recommendations/solutionDataProbes.ts
@@ -1,4 +1,4 @@
-import { type DataQuery, type DataSourceInstanceListItem, dateTime, type TimeRange } from '@grafana/data';
+import { type DataSourceInstanceListItem } from '@grafana/data';
 
 import {
   APP_OBSERVABILITY_APP_ID,
@@ -9,71 +9,56 @@ import {
 import { fetchFaroApps } from './frontendObservabilityApi';
 import {
   createTtlCachedPromise,
+  filterHealthyDatasources,
   findDatasourceWithData,
   listProbeCandidates,
   PROBE_TIMEOUT_MS,
   PROBE_TTL_MS,
+  probeProxyGet,
   withRetry,
   withTimeout,
 } from './probeUtils';
-import { readScalar, runDatasourceQueries, runInstantQueries } from './promQuery';
+import { readScalar, runInstantQueries } from './promQuery';
 
 // "Seen recently" lookback shared by all data probes, tolerating scrape/ingest gaps.
 const DATA_LOOKBACK_HOURS = 24;
 
-// True when any probed candidate datasource of `type` satisfies `hasData`. Throws when nothing
-// was found and any candidate errored: an errored datasource may hold the data, so absence is
-// only settled when every candidate probed clean.
-async function probeFound(
+/**
+ * The first probed healthy candidate datasource of `type` where `hasData` confirms data, or null
+ * when no candidate confirmed data. Rejects only when listing datasources fails.
+ */
+export async function probeFound(
   type: string,
-  hasData: (ds: DataSourceInstanceListItem) => Promise<boolean>
-): Promise<boolean> {
-  const candidates = await listProbeCandidates(type);
-  let errored = 0;
-  // findDatasourceWithData requires a non-throwing callback; count failures for the unknown check.
-  const guardedHasData = async (ds: DataSourceInstanceListItem) => {
-    try {
-      return await hasData(ds);
-    } catch {
-      errored++;
-      return false;
-    }
-  };
-  const found = await findDatasourceWithData(candidates, guardedHasData);
-  if (found) {
-    return true;
-  }
-  if (errored > 0) {
-    throw new Error(`${errored} ${type} datasource probe(s) failed with no data found elsewhere`);
-  }
-  return false;
+  hasData: (ds: DataSourceInstanceListItem) => Promise<boolean>,
+  excludeUids?: ReadonlySet<string>
+): Promise<DataSourceInstanceListItem | null> {
+  const candidates = await filterHealthyDatasources(await listProbeCandidates(type, undefined, excludeUids));
+  return findDatasourceWithData(candidates, hasData);
+}
+
+interface TempoSearchResponse {
+  traces?: unknown[];
+}
+
+/**
+ * One matching trace in the lookback proves data exists. Uses Tempo's search HTTP API via the
+ * datasource proxy: the frontend query path misreads streamed empty results as data (observed
+ * live with traceQLStreaming) and the resource router 404s Tempo paths on cloud stacks.
+ */
+export async function tempoHasTraces(ds: Pick<DataSourceInstanceListItem, 'uid'>): Promise<boolean> {
+  const end = Math.floor(Date.now() / 1000);
+  const start = end - DATA_LOOKBACK_HOURS * 3600;
+  const res = await probeProxyGet<TempoSearchResponse>(ds.uid, 'api/search', { q: '{}', limit: 1, start, end });
+  return Array.isArray(res?.traces) && res.traces.length > 0;
 }
 
 // Any series in the lookback means the solution produces data; which datasource holds it is irrelevant.
 async function prometheusHasMetric(expr: string): Promise<boolean> {
-  return probeFound('prometheus', async (ds) => {
+  const found = await probeFound('prometheus', async (ds) => {
     const frames = await withRetry(() => runInstantQueries({ probe: expr }, ds, PROBE_TIMEOUT_MS));
     return (readScalar(frames, 'probe') ?? 0) > 0;
   });
-}
-
-interface TempoSearchQuery extends DataQuery {
-  query: string;
-  limit: number;
-}
-
-async function tempoHasTraces(ds: DataSourceInstanceListItem): Promise<boolean> {
-  const toTime = dateTime();
-  const fromTime = dateTime().subtract(DATA_LOOKBACK_HOURS, 'h');
-  const range: TimeRange = {
-    from: fromTime,
-    to: toTime,
-    raw: { from: `now-${DATA_LOOKBACK_HOURS}h`, to: 'now' },
-  };
-  // Tempo search target: match-all TraceQL, one result is enough to prove data exists.
-  const target: TempoSearchQuery = { refId: 'traces', queryType: 'traceql', query: '{}', limit: 1 };
-  const frames = await withRetry(() => runDatasourceQueries([target], range, ds, PROBE_TIMEOUT_MS));
-  return frames.some((frame) => frame.length > 0);
+  return found !== null;
 }
 
 // Frontend Observability telemetry lives behind the Faro collector, not in a probeable stack
@@ -100,7 +85,7 @@ const probesBySolution: Record<string, { get(): Promise<boolean>; reset(): void 
       ),
     PROBE_TTL_MS
   ),
-  [HOSTED_TRACES_APP_ID]: createTtlCachedPromise(() => probeFound('tempo', tempoHasTraces), PROBE_TTL_MS),
+  [HOSTED_TRACES_APP_ID]: createTtlCachedPromise(() => probeFound('tempo', tempoHasTraces).then(Boolean), PROBE_TTL_MS),
   [FRONTEND_OBSERVABILITY_APP_ID]: createTtlCachedPromise(hasFrontendObservabilityData, PROBE_TTL_MS),
 };
 

--- a/public/app/features/home/Recommendations/solutionDataProbes.ts
+++ b/public/app/features/home/Recommendations/solutionDataProbes.ts
@@ -90,9 +90,8 @@ const probesBySolution: Record<string, { get(): Promise<boolean>; reset(): void 
 };
 
 /**
- * True when the solution already receives data. An empty candidate list (or empty Faro registry)
- * is definitive no-data; an errored probe — including any candidate failing while no data was
- * found elsewhere — reports true: unknown fails toward hiding the recommendation.
+ * True when the solution already receives data. When the probe cannot answer, unknown fails
+ * toward true: hiding a recommendation beats recommending setup for data that may exist.
  */
 export async function hasSolutionData(pluginId: string): Promise<boolean> {
   const probe = probesBySolution[pluginId];


### PR DESCRIPTION
**What is this feature?**

Rebuilds the data-existence probes the homepage uses:

- `probeFound` now health-filters candidate datasources (3s `/health` cutoff) and returns the winning datasource (or null) instead of a bare boolean; probe errors read as no data instead of failing the scan.
- `tempoHasTraces` probes Tempo's search HTTP API through the classic datasource proxy: the frontend query path misreads streamed empty results as data, and the resource router 404s Tempo paths on cloud stacks.
- `kubernetesData` moves onto the same health-filtered candidate flow (identical export surface).

