### PR TITLE
Home: detect live solution signals

### DIFF
--- a/public/app/features/home/Recommendations/kubernetesData.test.ts
+++ b/public/app/features/home/Recommendations/kubernetesData.test.ts
@@ -292,15 +292,12 @@ describe('Kubernetes Prometheus resolution', () => {
     expect(probedUids).not.toContain('ml-uid');
   });
 
-  it('still probes and picks a lone utility-named datasource', async () => {
+  it('never probes a lone utility-named datasource', async () => {
     setDataSources([{ uid: 'usage-uid', name: 'grafanacloud-usage' }]);
     dataByUid = { 'usage-uid': 1 };
 
-    const inventory = await fetchKubernetesInventory();
-    await fetchKubernetesHealth();
-
-    expect(inventoryCalls()[0][0].datasource.uid).toBe('usage-uid');
-    expect(inventory.clusters).toBe(1);
+    await expect(fetchKubernetesInventory()).rejects.toThrow('No Prometheus datasource with Kubernetes data');
+    expect(probeCalls()).toHaveLength(0);
   });
 
   it('keeps a user datasource whose name merely contains "usage" (exact-match skip)', async () => {

--- a/public/app/features/home/Recommendations/probeUtils.test.ts
+++ b/public/app/features/home/Recommendations/probeUtils.test.ts
@@ -96,6 +96,33 @@ describe('listProbeCandidates', () => {
     getDataSourceInstanceListMock.mockResolvedValue([listItem({ name: 'grafanacloud-usage' })]);
 
     await expect(listProbeCandidates('prometheus')).resolves.toEqual([listItem({ name: 'grafanacloud-usage' })]);
+
+    getDataSourceInstanceListMock.mockResolvedValue([listItem({ name: 'grafanacloud-acme-usage-insights' })]);
+
+    await expect(listProbeCandidates('loki')).resolves.toEqual([
+      listItem({ name: 'grafanacloud-acme-usage-insights' }),
+    ]);
+  });
+
+  it('skips stack-prefixed Cloud utility Loki datasources by name', async () => {
+    getDataSourceInstanceListMock.mockResolvedValue([
+      listItem({ uid: 'abc123', name: 'grafanacloud-acme-usage-insights' }),
+      listItem({ uid: 'def456', name: 'grafanacloud-acme-alert-state-history' }),
+      listItem({ uid: 'loki-main', name: 'grafanacloud-acme-logs' }),
+    ]);
+
+    const candidates = await listProbeCandidates('loki');
+
+    expect(candidates.map((ds) => ds.uid)).toEqual(['loki-main']);
+  });
+
+  it('skips the unprefixed utility Loki name form beside a product datasource', async () => {
+    getDataSourceInstanceListMock.mockResolvedValue([
+      listItem({ name: 'grafanacloud-usage-insights' }),
+      listItem({ name: 'product' }),
+    ]);
+
+    await expect(listProbeCandidates('loki')).resolves.toEqual([listItem({ name: 'product' })]);
   });
 
   it('puts the default datasource first and applies the cap', async () => {

--- a/public/app/features/home/Recommendations/probeUtils.test.ts
+++ b/public/app/features/home/Recommendations/probeUtils.test.ts
@@ -66,26 +66,13 @@ describe('listProbeCandidates', () => {
     expect(candidates.map((ds) => ds.uid)).toEqual(['kept']);
   });
 
-  it('never re-admits excluded uids through the utility-name fallback', async () => {
-    // Every datasource is a cloud utility by name: the name fallback re-admits them, but an
-    // excluded uid must stay out even then.
-    getDataSourceInstanceListMock.mockResolvedValue([
-      listItem({ uid: 'usage', name: 'grafanacloud-usage' }),
-      listItem({ uid: 'ml', name: 'grafanacloud-ml-metrics' }),
-    ]);
-
-    const candidates = await listProbeCandidates('prometheus', undefined, new Set(['usage']));
-
-    expect(candidates.map((ds) => ds.uid)).toEqual(['ml']);
-  });
-
   it('returns empty when exclusions empty the list', async () => {
     getDataSourceInstanceListMock.mockResolvedValue([listItem({ uid: 'only', name: 'grafanacloud-usage' })]);
 
     await expect(listProbeCandidates('prometheus', undefined, new Set(['only']))).resolves.toEqual([]);
   });
 
-  it('skips cloud utility datasources unless they are all there is', async () => {
+  it('never probes cloud utility datasources, even as the only candidates', async () => {
     getDataSourceInstanceListMock.mockResolvedValue([
       listItem({ name: 'grafanacloud-usage' }),
       listItem({ name: 'product' }),
@@ -95,13 +82,11 @@ describe('listProbeCandidates', () => {
 
     getDataSourceInstanceListMock.mockResolvedValue([listItem({ name: 'grafanacloud-usage' })]);
 
-    await expect(listProbeCandidates('prometheus')).resolves.toEqual([listItem({ name: 'grafanacloud-usage' })]);
+    await expect(listProbeCandidates('prometheus')).resolves.toEqual([]);
 
     getDataSourceInstanceListMock.mockResolvedValue([listItem({ name: 'grafanacloud-acme-usage-insights' })]);
 
-    await expect(listProbeCandidates('loki')).resolves.toEqual([
-      listItem({ name: 'grafanacloud-acme-usage-insights' }),
-    ]);
+    await expect(listProbeCandidates('loki')).resolves.toEqual([]);
   });
 
   it('skips stack-prefixed Cloud utility Loki datasources by name', async () => {

--- a/public/app/features/home/Recommendations/probeUtils.ts
+++ b/public/app/features/home/Recommendations/probeUtils.ts
@@ -19,11 +19,18 @@ const HEALTH_CHECK_TIMEOUT_MS = 3000;
 // them while the region shows its skeleton. 3 attempts total.
 const RETRY_DELAYS_MS = [500, 1500];
 
-// Exact names of Grafana Cloud's utility Prometheus datasources (billing/ML) — never where product data lives.
+// Grafana Cloud's utility datasources — never where product data lives. Prometheus utilities
+// (billing/ML) carry exact unprefixed names; Loki utilities (query logs, alert history) are
+// provisioned with stack-prefixed names (grafanacloud-<slug>-usage-insights) over stable
+// unprefixed uids, so the name check matches both forms.
 const CLOUD_UTILITY_DATASOURCE_NAMES: Record<string, true> = {
   'grafanacloud-usage': true,
   'grafanacloud-ml-metrics': true,
 };
+const CLOUD_UTILITY_LOKI_NAME_PATTERN = /^grafanacloud-(.+-)?(usage-insights|alert-state-history)$/;
+function isCloudUtilityDatasourceName(name: string): boolean {
+  return Boolean(CLOUD_UTILITY_DATASOURCE_NAMES[name]) || CLOUD_UTILITY_LOKI_NAME_PATTERN.test(name);
+}
 
 const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
@@ -113,7 +120,7 @@ export async function listProbeCandidates(
     filter: (ds) => ds.meta.id !== 'grafana',
   });
   const eligible = excludeUids ? list.filter((ds) => !excludeUids.has(ds.uid)) : list;
-  const preferred = eligible.filter((ds) => !CLOUD_UTILITY_DATASOURCE_NAMES[ds.name]);
+  const preferred = eligible.filter((ds) => !isCloudUtilityDatasourceName(ds.name));
   const pool = preferred.length > 0 ? preferred : eligible;
   const def = pool.find((ds) => ds.isDefault);
   const ordered = def ? [def, ...pool.filter((ds) => ds !== def)] : [...pool];

--- a/public/app/features/home/Recommendations/probeUtils.ts
+++ b/public/app/features/home/Recommendations/probeUtils.ts
@@ -103,12 +103,7 @@ export function createTtlCachedPromise<T>(fn: () => Promise<T>, ttlMs: number): 
   };
 }
 
-/**
- * Candidate datasources of `type` for a data-existence probe: `excludeUids` are dropped
- * unconditionally (never re-admitted by any fallback), cloud utility datasources are
- * skipped (unless they are all there is), the default datasource leads, capped for fan-out.
- * Pass an Infinity `cap` when the caller reorders before capping itself.
- */
+/** Probe candidates of `type`. Cloud utilities and `excludeUids` never qualify, even as the only candidates: platform telemetry must not settle a product-data probe. */
 export async function listProbeCandidates(
   type: string,
   cap = MAX_PROBED_DATASOURCES,
@@ -119,9 +114,7 @@ export async function listProbeCandidates(
     // Reject the -- Grafana -- builtin by meta.id; a ds.type check would drop alias datasources.
     filter: (ds) => ds.meta.id !== 'grafana',
   });
-  const eligible = excludeUids ? list.filter((ds) => !excludeUids.has(ds.uid)) : list;
-  const preferred = eligible.filter((ds) => !isCloudUtilityDatasourceName(ds.name));
-  const pool = preferred.length > 0 ? preferred : eligible;
+  const pool = list.filter((ds) => !excludeUids?.has(ds.uid) && !isCloudUtilityDatasourceName(ds.name));
   const def = pool.find((ds) => ds.isDefault);
   const ordered = def ? [def, ...pool.filter((ds) => ds !== def)] : [...pool];
   return ordered.slice(0, cap);

--- a/public/app/features/home/Recommendations/probeUtils.ts
+++ b/public/app/features/home/Recommendations/probeUtils.ts
@@ -1,6 +1,6 @@
 import { type DataSourceInstanceListItem } from '@grafana/data';
-import { getBackendSrv } from '@grafana/runtime';
-import { getDataSourceInstanceList } from '@grafana/runtime/unstable';
+import { DataSourceWithBackend, getBackendSrv } from '@grafana/runtime';
+import { getDataSourceInstance, getDataSourceInstanceList } from '@grafana/runtime/unstable';
 
 /** Cap the probe fan-out: only the first N candidates (in priority order) are probed per page load. */
 export const MAX_PROBED_DATASOURCES = 10;
@@ -38,6 +38,12 @@ export async function withRetry<T>(fn: () => Promise<T>): Promise<T> {
       await sleep(RETRY_DELAYS_MS[attempt]);
     }
   }
+}
+
+/** Backend-capable datasource instance for `uid`, or null when it cannot serve resource calls. */
+export async function resolveBackendInstance(uid: string): Promise<DataSourceWithBackend | null> {
+  const instance = await getDataSourceInstance({ uid });
+  return instance instanceof DataSourceWithBackend ? instance : null;
 }
 
 /**

--- a/public/app/features/home/Recommendations/solutionDataProbes.ts
+++ b/public/app/features/home/Recommendations/solutionDataProbes.ts
@@ -23,6 +23,10 @@ import { readScalar, runInstantQueries } from './promQuery';
 // "Seen recently" lookback shared by all data probes, tolerating scrape/ingest gaps.
 export const DATA_LOOKBACK_HOURS = 24;
 
+// Span metrics prove App Observability is in use, under both supported emitter namings:
+// the spanmetrics connector emits traces_spanmetrics_*, OTel/Alloy emits traces_span_metrics_*.
+export const SPAN_METRICS_PROBE = `count(last_over_time(traces_spanmetrics_calls_total[${DATA_LOOKBACK_HOURS}h])) or count(last_over_time(traces_span_metrics_calls_total[${DATA_LOOKBACK_HOURS}h]))`;
+
 /**
  * The first probed healthy candidate datasource of `type` where `hasData` confirms data, or null
  * when no candidate confirmed data. Rejects only when listing datasources fails.
@@ -76,15 +80,7 @@ const probesBySolution: Record<string, { get(): Promise<boolean>; reset(): void 
     () => prometheusHasMetric(`count(last_over_time(sm_check_info[${DATA_LOOKBACK_HOURS}h]))`),
     PROBE_TTL_MS
   ),
-  // Application Observability span metrics arrive under two supported naming schemes:
-  // the spanmetrics connector emits traces_spanmetrics_*, OTel/Alloy emits traces_span_metrics_*.
-  [APP_OBSERVABILITY_APP_ID]: createTtlCachedPromise(
-    () =>
-      prometheusHasMetric(
-        `count(last_over_time(traces_spanmetrics_calls_total[${DATA_LOOKBACK_HOURS}h])) or count(last_over_time(traces_span_metrics_calls_total[${DATA_LOOKBACK_HOURS}h]))`
-      ),
-    PROBE_TTL_MS
-  ),
+  [APP_OBSERVABILITY_APP_ID]: createTtlCachedPromise(() => prometheusHasMetric(SPAN_METRICS_PROBE), PROBE_TTL_MS),
   [HOSTED_TRACES_APP_ID]: createTtlCachedPromise(() => probeFound('tempo', tempoHasTraces).then(Boolean), PROBE_TTL_MS),
   [FRONTEND_OBSERVABILITY_APP_ID]: createTtlCachedPromise(hasFrontendObservabilityData, PROBE_TTL_MS),
 };

--- a/public/app/features/home/Recommendations/solutionDataProbes.ts
+++ b/public/app/features/home/Recommendations/solutionDataProbes.ts
@@ -21,7 +21,7 @@ import {
 import { readScalar, runInstantQueries } from './promQuery';
 
 // "Seen recently" lookback shared by all data probes, tolerating scrape/ingest gaps.
-const DATA_LOOKBACK_HOURS = 24;
+export const DATA_LOOKBACK_HOURS = 24;
 
 /**
  * The first probed healthy candidate datasource of `type` where `hasData` confirms data, or null

--- a/public/app/features/home/Recommendations/solutionState.test.ts
+++ b/public/app/features/home/Recommendations/solutionState.test.ts
@@ -1,0 +1,404 @@
+import { createDataFrame, type DataSourceInstanceListItem, FieldType } from '@grafana/data';
+import { type BackendSrv, DataSourceWithBackend, getBackendSrv } from '@grafana/runtime';
+import { getDataSourceInstance, getDataSourceInstanceList } from '@grafana/runtime/unstable';
+
+import { resolveKubernetesDatasource } from './kubernetesData';
+import { runInstantQueries } from './promQuery';
+import { tempoHasTraces } from './solutionDataProbes';
+import { resetSolutionStateResolution, resolveSolutionState } from './solutionState';
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getBackendSrv: jest.fn(),
+}));
+
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getDataSourceInstanceList: jest.fn(),
+  getDataSourceInstance: jest.fn(),
+}));
+
+jest.mock('./solutionDataProbes', () => ({
+  ...jest.requireActual('./solutionDataProbes'),
+  tempoHasTraces: jest.fn(),
+}));
+
+jest.mock('./promQuery', () => ({
+  ...jest.requireActual('./promQuery'),
+  runInstantQueries: jest.fn(),
+}));
+
+jest.mock('./kubernetesData', () => ({
+  ...jest.requireActual('./kubernetesData'),
+  resolveKubernetesDatasource: jest.fn(),
+}));
+
+const listMock = jest.mocked(getDataSourceInstanceList);
+const instanceMock = jest.mocked(getDataSourceInstance);
+const tempoHasTracesMock = jest.mocked(tempoHasTraces);
+const kubernetesMock = jest.mocked(resolveKubernetesDatasource);
+const instantQueriesMock = jest.mocked(runInstantQueries);
+const backendSrvGetMock = jest.fn();
+
+const DATA_LOOKBACK_HOURS = 24;
+const SIGNAL_BUDGET_MS = 30_000;
+
+function listItem(type: string, ds: { uid: string; name?: string; isDefault?: boolean }): DataSourceInstanceListItem {
+  return {
+    uid: ds.uid,
+    name: ds.name ?? ds.uid,
+    type,
+    meta: { id: type } as DataSourceInstanceListItem['meta'],
+    readOnly: false,
+    isDefault: ds.isDefault ?? false,
+  };
+}
+
+function backendInstance(getResource: jest.Mock): DataSourceWithBackend {
+  const instance: DataSourceWithBackend = Object.create(DataSourceWithBackend.prototype);
+  instance.getResource = getResource;
+  return instance;
+}
+
+interface Fixture {
+  prometheus?: DataSourceInstanceListItem[];
+  loki?: DataSourceInstanceListItem[];
+  tempo?: DataSourceInstanceListItem[];
+  instances?: Record<string, DataSourceWithBackend>;
+}
+
+function setupFixture(fixture: Fixture) {
+  listMock.mockImplementation(async (filters) => {
+    const list = fixture[(filters?.type ?? '') as keyof Omit<Fixture, 'instances'>];
+    if (!list) {
+      throw new Error(`No fixture for type ${filters?.type}`);
+    }
+    return list;
+  });
+  instanceMock.mockImplementation(async (ref) => {
+    const uid = typeof ref === 'string' ? ref : (ref?.uid ?? '');
+    const instance = fixture.instances?.[uid];
+    if (!instance) {
+      throw new Error(`No instance fixture for uid ${uid}`);
+    }
+    return instance;
+  });
+}
+
+const emptyPromResource = () => jest.fn().mockResolvedValue({ data: [] });
+const emptyLokiResource = () => jest.fn().mockResolvedValue({ data: null });
+
+// A fresh cloud stack: every datasource preinstalled, none with product data.
+function freshCloudFixture() {
+  const promResource = emptyPromResource();
+  const lokiResource = emptyLokiResource();
+  setupFixture({
+    prometheus: [
+      listItem('prometheus', { uid: 'grafanacloud-usage', name: 'grafanacloud-usage' }),
+      listItem('prometheus', { uid: 'prom-main', name: 'grafanacloud-prom', isDefault: true }),
+    ],
+    loki: [
+      listItem('loki', { uid: 'grafanacloud-usage-insights' }),
+      listItem('loki', { uid: 'grafanacloud-alert-state-history' }),
+      listItem('loki', { uid: 'loki-main', name: 'grafanacloud-logs' }),
+    ],
+    tempo: [listItem('tempo', { uid: 'tempo-main', name: 'grafanacloud-traces' })],
+    instances: {
+      'prom-main': backendInstance(promResource),
+      'loki-main': backendInstance(lokiResource),
+    },
+  });
+  tempoHasTracesMock.mockResolvedValue(false);
+  kubernetesMock.mockResolvedValue(null);
+  return { promResource, lokiResource };
+}
+
+async function resolveWithTimers() {
+  const promise = resolveSolutionState();
+  await jest.advanceTimersByTimeAsync(SIGNAL_BUDGET_MS + 5_000);
+  return promise;
+}
+
+describe('resolveSolutionState', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-07-24T12:00:00Z'));
+    listMock.mockReset();
+    instanceMock.mockReset();
+    tempoHasTracesMock.mockReset();
+    kubernetesMock.mockReset();
+    instantQueriesMock.mockReset();
+    backendSrvGetMock.mockReset();
+    // Health pre-filter: every candidate healthy unless a test overrides by uid.
+    backendSrvGetMock.mockResolvedValue({ status: 'OK' });
+    jest.mocked(getBackendSrv).mockReturnValue({ get: backendSrvGetMock } as unknown as BackendSrv);
+    // Span-metrics probe settles clean-empty unless a test overrides it.
+    instantQueriesMock.mockResolvedValue([]);
+    resetSolutionStateResolution();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('settles a fresh cloud stack to all-inactive (presence is not usage)', async () => {
+    freshCloudFixture();
+
+    const resolution = await resolveSolutionState();
+
+    expect(resolution.state).toEqual({
+      metrics: 'inactive',
+      logs: 'inactive',
+      traces: 'inactive',
+      kubernetes: 'inactive',
+      spanMetrics: 'inactive',
+    });
+    expect(resolution.lokiDatasource).toBeNull();
+    expect(resolution.tempoDatasource).toBeNull();
+    expect(resolution.prometheusDatasource).toBeNull();
+  });
+
+  it('never probes cloud utility datasources, even when they are all there is', async () => {
+    setupFixture({
+      prometheus: [listItem('prometheus', { uid: 'grafanacloud-usage', name: 'grafanacloud-usage' })],
+      loki: [
+        listItem('loki', { uid: 'grafanacloud-usage-insights' }),
+        listItem('loki', { uid: 'grafanacloud-alert-state-history' }),
+      ],
+      tempo: [],
+    });
+    tempoHasTracesMock.mockResolvedValue(false);
+    kubernetesMock.mockResolvedValue(null);
+
+    const resolution = await resolveSolutionState();
+
+    expect(resolution.state.metrics).toBe('inactive');
+    expect(resolution.state.logs).toBe('inactive');
+    expect(instanceMock).not.toHaveBeenCalled();
+    expect(instantQueriesMock).not.toHaveBeenCalled();
+  });
+
+  it('reports active with the winning datasource when a probe finds data', async () => {
+    const { lokiResource } = freshCloudFixture();
+    lokiResource.mockResolvedValue({ data: ['job', 'service_name'] });
+    tempoHasTracesMock.mockResolvedValue(true);
+
+    const resolution = await resolveSolutionState();
+
+    expect(resolution.state.logs).toBe('active');
+    expect(resolution.lokiDatasource?.uid).toBe('loki-main');
+    expect(resolution.state.traces).toBe('active');
+    expect(resolution.tempoDatasource?.uid).toBe('tempo-main');
+  });
+
+  it('skips a candidate whose health check fails', async () => {
+    freshCloudFixture();
+    const withData = jest.fn().mockResolvedValue({ data: ['__name__'] });
+    setupFixture({
+      prometheus: [
+        listItem('prometheus', { uid: 'prom-broken', name: 'broken', isDefault: true }),
+        listItem('prometheus', { uid: 'prom-main', name: 'grafanacloud-prom' }),
+      ],
+      loki: [listItem('loki', { uid: 'loki-main', name: 'grafanacloud-logs' })],
+      tempo: [],
+      instances: {
+        'prom-main': backendInstance(withData),
+        'loki-main': backendInstance(emptyLokiResource()),
+      },
+    });
+    backendSrvGetMock.mockImplementation((url: string) =>
+      url.includes('prom-broken') ? Promise.reject(new Error('health check failed')) : Promise.resolve({ status: 'OK' })
+    );
+
+    const resolution = await resolveSolutionState();
+
+    expect(resolution.state.metrics).toBe('active');
+    expect(resolution.prometheusDatasource?.uid).toBe('prom-main');
+    // The unhealthy candidate is dropped before its probe could run.
+    expect(instanceMock).not.toHaveBeenCalledWith({ uid: 'prom-broken' });
+  });
+
+  it('reads inactive when the only candidate with data potential errors', async () => {
+    freshCloudFixture();
+    const failing = jest.fn().mockRejectedValue(new Error('gateway blew up'));
+    setupFixture({
+      prometheus: [listItem('prometheus', { uid: 'prom-broken', name: 'broken', isDefault: true })],
+      loki: [listItem('loki', { uid: 'loki-main', name: 'grafanacloud-logs' })],
+      tempo: [],
+      instances: {
+        'prom-broken': backendInstance(failing),
+        'loki-main': backendInstance(emptyLokiResource()),
+      },
+    });
+
+    const resolution = await resolveSolutionState();
+
+    expect(resolution.state.metrics).toBe('inactive');
+    expect(failing).toHaveBeenCalled();
+  });
+
+  it('reads an all-errored traces probe as inactive without touching the other signals', async () => {
+    freshCloudFixture();
+    tempoHasTracesMock.mockRejectedValue(new Error('tempo down'));
+
+    const resolution = await resolveWithTimers();
+
+    expect(resolution.state.traces).toBe('inactive');
+    expect(resolution.state.logs).toBe('inactive');
+    expect(resolution.state.metrics).toBe('inactive');
+  });
+
+  it('maps a rejecting kubernetes resolution to unknown without forcing metrics', async () => {
+    freshCloudFixture();
+    kubernetesMock.mockRejectedValue(new Error('all probes failed'));
+
+    const resolution = await resolveWithTimers();
+
+    expect(resolution.state.kubernetes).toBe('unknown');
+    // The k8s ⇒ metrics invariant must not fire on unknown.
+    expect(resolution.state.metrics).toBe('inactive');
+  });
+
+  it('settles a hung probe as no data within the signal budget, preserving siblings', async () => {
+    const { lokiResource } = freshCloudFixture();
+    lokiResource.mockImplementation(() => new Promise(() => {}));
+
+    const resolution = await resolveWithTimers();
+
+    expect(resolution.state.logs).toBe('inactive');
+    expect(resolution.state.metrics).toBe('inactive');
+    expect(resolution.state.traces).toBe('inactive');
+  });
+
+  it('maps a candidate-list rejection to unknown while the aggregate still resolves', async () => {
+    freshCloudFixture();
+    listMock.mockImplementation(async (filters) => {
+      if (filters?.type === 'loki') {
+        throw new Error('list unavailable');
+      }
+      return filters?.type === 'prometheus'
+        ? [listItem('prometheus', { uid: 'prom-main', name: 'grafanacloud-prom' })]
+        : [];
+    });
+
+    const resolution = await resolveWithTimers();
+
+    expect(resolution.state.logs).toBe('unknown');
+    expect(resolution.state.metrics).toBe('inactive');
+  });
+
+  it('forces metrics active when kubernetes data exists', async () => {
+    freshCloudFixture();
+    kubernetesMock.mockResolvedValue(listItem('prometheus', { uid: 'prom-main', name: 'grafanacloud-prom' }));
+
+    const resolution = await resolveSolutionState();
+
+    expect(resolution.state.kubernetes).toBe('active');
+    expect(resolution.state.metrics).toBe('active');
+  });
+
+  it('exposes the winning prometheus datasource, falling back to the kubernetes one', async () => {
+    const { promResource } = freshCloudFixture();
+    promResource.mockResolvedValue({ data: ['__name__'] });
+
+    let resolution = await resolveSolutionState();
+    expect(resolution.state.metrics).toBe('active');
+    expect(resolution.prometheusDatasource?.uid).toBe('prom-main');
+
+    // Metrics probe empty but kubernetes active: its (Prometheus) datasource carries the card.
+    resetSolutionStateResolution();
+    promResource.mockResolvedValue({ data: [] });
+    kubernetesMock.mockResolvedValue(listItem('prometheus', { uid: 'prom-k8s', name: 'k8s-prom' }));
+
+    resolution = await resolveSolutionState();
+    expect(resolution.state.metrics).toBe('active');
+    expect(resolution.prometheusDatasource?.uid).toBe('prom-k8s');
+  });
+
+  it('settles span metrics active when the probe finds series', async () => {
+    freshCloudFixture();
+    instantQueriesMock.mockResolvedValue([
+      createDataFrame({ refId: 'probe', fields: [{ name: 'Value', type: FieldType.number, values: [12] }] }),
+    ]);
+
+    const resolution = await resolveSolutionState();
+
+    expect(resolution.state.spanMetrics).toBe('active');
+    expect(instantQueriesMock).toHaveBeenCalledWith(
+      { probe: expect.stringMatching(/traces_spanmetrics_calls_total.*traces_span_metrics_calls_total/s) },
+      expect.objectContaining({ uid: 'prom-main' }),
+      expect.any(Number)
+    );
+  });
+
+  it('settles span metrics inactive when a candidate query fails - a dead datasource must not hide the card', async () => {
+    setupFixture({
+      prometheus: [
+        listItem('prometheus', { uid: 'prom-main', name: 'grafanacloud-prom', isDefault: true }),
+        listItem('prometheus', { uid: 'prom-demo', name: 'Prometheus Demo' }),
+      ],
+      loki: [],
+      tempo: [],
+      instances: { 'prom-main': backendInstance(emptyPromResource()) },
+    });
+    tempoHasTracesMock.mockResolvedValue(false);
+    kubernetesMock.mockResolvedValue(null);
+    instantQueriesMock.mockImplementation(async (_queries, ds) => {
+      if (ds.uid === 'prom-demo') {
+        throw new Error('dial tcp: no such host');
+      }
+      return [];
+    });
+
+    const resolution = await resolveWithTimers();
+
+    expect(resolution.state.spanMetrics).toBe('inactive');
+    // Metrics reads the same direction: the errored candidate is no data, not unknown.
+    expect(resolution.state.metrics).toBe('inactive');
+  });
+
+  it('still settles span metrics active when a healthy candidate has series beside a broken one', async () => {
+    freshCloudFixture();
+    instantQueriesMock.mockImplementation(async (_queries, ds) => {
+      if (ds.uid !== 'prom-main') {
+        throw new Error('dial tcp: no such host');
+      }
+      return [createDataFrame({ refId: 'probe', fields: [{ name: 'Value', type: FieldType.number, values: [12] }] })];
+    });
+
+    const resolution = await resolveWithTimers();
+
+    expect(resolution.state.spanMetrics).toBe('active');
+  });
+
+  it('probes the label endpoints with the lookback window in each datasource unit', async () => {
+    const { promResource, lokiResource } = freshCloudFixture();
+
+    await resolveSolutionState();
+
+    const nowMs = Date.now();
+    const silent = { showErrorAlert: false };
+    expect(promResource).toHaveBeenCalledWith(
+      'api/v1/labels',
+      { start: Math.floor(nowMs / 1000) - DATA_LOOKBACK_HOURS * 3600, end: Math.floor(nowMs / 1000) },
+      silent
+    );
+    expect(lokiResource).toHaveBeenCalledWith(
+      'labels',
+      { start: nowMs * 1e6 - DATA_LOOKBACK_HOURS * 3600 * 1e9, end: nowMs * 1e6 },
+      silent
+    );
+  });
+
+  it('fans out once for concurrent callers and re-resolves after a reset', async () => {
+    freshCloudFixture();
+
+    await Promise.all([resolveSolutionState(), resolveSolutionState()]);
+    // prometheus is listed twice (labels probe + span-metrics probe), loki and tempo once.
+    expect(listMock).toHaveBeenCalledTimes(4);
+
+    resetSolutionStateResolution();
+    await resolveSolutionState();
+    expect(listMock).toHaveBeenCalledTimes(8);
+  });
+});

--- a/public/app/features/home/Recommendations/solutionState.test.ts
+++ b/public/app/features/home/Recommendations/solutionState.test.ts
@@ -202,6 +202,44 @@ describe('resolveSolutionState', () => {
     expect(instanceMock).not.toHaveBeenCalledWith({ uid: 'rand0m01' });
   });
 
+  it('never settles logs from a lone utility Loki whose uid escapes the exclusion set', async () => {
+    const utilityLokiResource = jest.fn().mockResolvedValue({ data: ['job', 'service_name'] });
+    setupFixture({
+      prometheus: [listItem('prometheus', { uid: 'grafanacloud-usage', name: 'grafanacloud-usage' })],
+      loki: [listItem('loki', { uid: 'rand0m01', name: 'grafanacloud-acme-usage-insights' })],
+      tempo: [],
+      instances: { rand0m01: backendInstance(utilityLokiResource) },
+    });
+    tempoHasTracesMock.mockResolvedValue(false);
+    kubernetesMock.mockResolvedValue(null);
+
+    const resolution = await resolveSolutionState();
+
+    expect(resolution.state.logs).toBe('inactive');
+    expect(resolution.lokiDatasource).toBeNull();
+    expect(utilityLokiResource).not.toHaveBeenCalled();
+    expect(instanceMock).not.toHaveBeenCalled();
+  });
+
+  it('never settles metrics from a lone utility Prometheus whose uid escapes the exclusion set', async () => {
+    const utilityPromResource = jest.fn().mockResolvedValue({ data: ['__name__', 'instance'] });
+    setupFixture({
+      prometheus: [listItem('prometheus', { uid: 'rand0m02', name: 'grafanacloud-usage' })],
+      loki: [],
+      tempo: [],
+      instances: { rand0m02: backendInstance(utilityPromResource) },
+    });
+    tempoHasTracesMock.mockResolvedValue(false);
+    kubernetesMock.mockResolvedValue(null);
+
+    const resolution = await resolveSolutionState();
+
+    expect(resolution.state.metrics).toBe('inactive');
+    expect(resolution.prometheusDatasource).toBeNull();
+    expect(utilityPromResource).not.toHaveBeenCalled();
+    expect(instanceMock).not.toHaveBeenCalled();
+  });
+
   it('reports active with the winning datasource when a probe finds data', async () => {
     const { lokiResource } = freshCloudFixture();
     lokiResource.mockResolvedValue({ data: ['job', 'service_name'] });

--- a/public/app/features/home/Recommendations/solutionState.test.ts
+++ b/public/app/features/home/Recommendations/solutionState.test.ts
@@ -178,6 +178,30 @@ describe('resolveSolutionState', () => {
     expect(instantQueriesMock).not.toHaveBeenCalled();
   });
 
+  it('never probes a stack-prefixed utility Loki even when its uid escapes the exclusion set', async () => {
+    // Hypothetical provisioning that gives the query-log store an unlisted uid while keeping the
+    // stack-prefixed name: the name layer must keep it out of the probe pool, so the (empty)
+    // product Loki settles logs inactive.
+    setupFixture({
+      prometheus: [listItem('prometheus', { uid: 'grafanacloud-usage', name: 'grafanacloud-usage' })],
+      loki: [
+        listItem('loki', { uid: 'rand0m01', name: 'grafanacloud-acme-usage-insights' }),
+        listItem('loki', { uid: 'loki-main', name: 'grafanacloud-acme-logs' }),
+      ],
+      tempo: [],
+      instances: {
+        'loki-main': backendInstance(emptyLokiResource()),
+      },
+    });
+    tempoHasTracesMock.mockResolvedValue(false);
+    kubernetesMock.mockResolvedValue(null);
+
+    const resolution = await resolveSolutionState();
+
+    expect(resolution.state.logs).toBe('inactive');
+    expect(instanceMock).not.toHaveBeenCalledWith({ uid: 'rand0m01' });
+  });
+
   it('reports active with the winning datasource when a probe finds data', async () => {
     const { lokiResource } = freshCloudFixture();
     lokiResource.mockResolvedValue({ data: ['job', 'service_name'] });

--- a/public/app/features/home/Recommendations/solutionState.ts
+++ b/public/app/features/home/Recommendations/solutionState.ts
@@ -9,11 +9,8 @@ import {
   withTimeout,
 } from './probeUtils';
 import { readScalar, runInstantQueries } from './promQuery';
-import { DATA_LOOKBACK_HOURS, probeFound, tempoHasTraces } from './solutionDataProbes';
+import { DATA_LOOKBACK_HOURS, probeFound, SPAN_METRICS_PROBE, tempoHasTraces } from './solutionDataProbes';
 import { type SignalStatus, type SolutionState } from './solutionsMatrix';
-
-// Span metrics prove App O11y is in use; both emitter namings (spanmetrics connector, OTel/Alloy).
-const SPAN_METRICS_PROBE = `count(last_over_time(traces_spanmetrics_calls_total[${DATA_LOOKBACK_HOURS}h])) or count(last_over_time(traces_span_metrics_calls_total[${DATA_LOOKBACK_HOURS}h]))`;
 
 // Platform telemetry, never the org's product data: excluded unconditionally.
 const CLOUD_UTILITY_PROM_DATASOURCE_UIDS: ReadonlySet<string> = new Set([

--- a/public/app/features/home/Recommendations/solutionState.ts
+++ b/public/app/features/home/Recommendations/solutionState.ts
@@ -1,0 +1,130 @@
+import { type DataSourceInstanceListItem } from '@grafana/data';
+
+import { resolveKubernetesDatasource } from './kubernetesData';
+import {
+  createTtlCachedPromise,
+  PROBE_TIMEOUT_MS,
+  PROBE_TTL_MS,
+  resolveBackendInstance,
+  withTimeout,
+} from './probeUtils';
+import { readScalar, runInstantQueries } from './promQuery';
+import { DATA_LOOKBACK_HOURS, probeFound, tempoHasTraces } from './solutionDataProbes';
+import { type SignalStatus, type SolutionState } from './solutionsMatrix';
+
+// Span metrics prove App O11y is in use; both emitter namings (spanmetrics connector, OTel/Alloy).
+const SPAN_METRICS_PROBE = `count(last_over_time(traces_spanmetrics_calls_total[${DATA_LOOKBACK_HOURS}h])) or count(last_over_time(traces_span_metrics_calls_total[${DATA_LOOKBACK_HOURS}h]))`;
+
+// Platform telemetry, never the org's product data: excluded unconditionally.
+const CLOUD_UTILITY_PROM_DATASOURCE_UIDS: ReadonlySet<string> = new Set([
+  'grafanacloud-usage',
+  'grafanacloud-ml-metrics',
+]);
+const CLOUD_UTILITY_LOKI_DATASOURCE_UIDS: ReadonlySet<string> = new Set([
+  'grafanacloud-usage-insights',
+  'grafanacloud-alert-state-history',
+]);
+
+// Hard ceiling per signal; one parallel scan (3s health filter + 10s probes) settles well inside it.
+const SIGNAL_BUDGET_MS = 30_000;
+
+export interface SolutionStateResolution {
+  state: SolutionState;
+  /** Datasources that won the logs/traces probes; null unless the signal is active. */
+  lokiDatasource: DataSourceInstanceListItem | null;
+  tempoDatasource: DataSourceInstanceListItem | null;
+  /**
+   * Datasource that won the metrics probe (or the kubernetes probe when kubernetes forced
+   * metrics active); null unless metrics is active.
+   */
+  prometheusDatasource: DataSourceInstanceListItem | null;
+}
+
+interface SignalResolution {
+  status: SignalStatus;
+  datasource: DataSourceInstanceListItem | null;
+}
+
+// Empty results are definitive 'inactive'; 'unknown' = candidate-list or resolution failure or
+// signal-budget timeout. Probe errors read as no data; the health filter drops broken candidates.
+async function resolveSignal(probe: () => Promise<DataSourceInstanceListItem | null>): Promise<SignalResolution> {
+  try {
+    const datasource = await withTimeout(probe(), SIGNAL_BUDGET_MS);
+    return { status: datasource ? 'active' : 'inactive', datasource };
+  } catch {
+    return { status: 'unknown', datasource: null };
+  }
+}
+
+// Label metadata is a cheap, index-only recency check; empty within the lookback is definitive
+// "no data". Failures are expected (dead datasources, 403s) — never toast.
+function labelRecencyProbe(path: string, toEpoch: (ms: number) => number) {
+  return async (ds: DataSourceInstanceListItem): Promise<boolean> => {
+    const instance = await resolveBackendInstance(ds.uid);
+    if (!instance) {
+      return false;
+    }
+    const end = toEpoch(Date.now());
+    const start = end - toEpoch(DATA_LOOKBACK_HOURS * 3600 * 1000);
+    const res = await withTimeout(
+      instance.getResource<{ data?: unknown }>(path, { start, end }, { showErrorAlert: false }),
+      PROBE_TIMEOUT_MS
+    );
+    // Loki responds data: null when empty (and Prometheus data: [] — same emptiness test).
+    return Array.isArray(res?.data) && res.data.length > 0;
+  };
+}
+
+const prometheusHasRecentLabels = labelRecencyProbe('api/v1/labels', (ms) => Math.floor(ms / 1000));
+// Loki takes nanoseconds; ms * 1e6 mirrors LokiDatasource.getTimeRangeParams (precision loss accepted).
+const lokiHasRecentLabels = labelRecencyProbe('labels', (ms) => ms * 1e6);
+
+// Span metrics prove App O11y usage; a probe error reads as no span metrics in the scan.
+async function prometheusHasSpanMetrics(ds: DataSourceInstanceListItem): Promise<boolean> {
+  const frames = await runInstantQueries({ probe: SPAN_METRICS_PROBE }, ds, PROBE_TIMEOUT_MS);
+  return (readScalar(frames, 'probe') ?? 0) > 0;
+}
+
+// Each signal resolver settles on its own (never rejects), so Promise.all cannot discard
+// sibling results.
+async function resolveAllSignals(): Promise<SolutionStateResolution> {
+  const [metrics, logs, traces, kubernetes, spanMetrics] = await Promise.all([
+    resolveSignal(() => probeFound('prometheus', prometheusHasRecentLabels, CLOUD_UTILITY_PROM_DATASOURCE_UIDS)),
+    resolveSignal(() => probeFound('loki', lokiHasRecentLabels, CLOUD_UTILITY_LOKI_DATASOURCE_UIDS)),
+    resolveSignal(() => probeFound('tempo', tempoHasTraces)),
+    resolveSignal(resolveKubernetesDatasource),
+    resolveSignal(() => probeFound('prometheus', prometheusHasSpanMetrics, CLOUD_UTILITY_PROM_DATASOURCE_UIDS)),
+  ]);
+
+  return {
+    state: {
+      // Kubernetes data lives in a Prometheus (kube-state-metrics), so it proves metrics.
+      metrics: kubernetes.status === 'active' ? 'active' : metrics.status,
+      logs: logs.status,
+      traces: traces.status,
+      kubernetes: kubernetes.status,
+      spanMetrics: spanMetrics.status,
+    },
+    lokiDatasource: logs.datasource,
+    tempoDatasource: traces.datasource,
+    // The kubernetes⇒metrics invariant can force metrics active with an empty metrics probe;
+    // the kubernetes datasource is a Prometheus (kube-state-metrics), so it carries the card.
+    prometheusDatasource: metrics.datasource ?? (kubernetes.status === 'active' ? kubernetes.datasource : null),
+  };
+}
+
+// Carousel + solution providers mounting together fan out one resolution per TTL window.
+const solutionStateResolution = createTtlCachedPromise(resolveAllSignals, PROBE_TTL_MS);
+
+/**
+ * Settled solution signals plus the datasources that won the logs/traces probes.
+ * Never rejects; every field settles to a SignalStatus.
+ */
+export async function resolveSolutionState(): Promise<SolutionStateResolution> {
+  return solutionStateResolution.get();
+}
+
+/** Reset the cached resolution (test seam). Does NOT reset kubernetesData's own TTL cache. */
+export function resetSolutionStateResolution(): void {
+  solutionStateResolution.reset();
+}


### PR DESCRIPTION
**What is this feature?**

Adds `resolveSolutionState`: one TTL-cached, parallel scan that settles every solution signal the homepage cares about — metrics and logs via cheap label-recency probes (Prometheus `api/v1/labels`, Loki `labels`), traces via the Tempo search probe, kubernetes via the existing datasource resolution, plus a span-metrics probe for App Observability. Each signal settles independently to active/inactive/unknown with the winning datasource, inside a hard 30s budget; failures never reject the scan and never toast.

**Special notes for your reviewer:**

Cloud utility datasources (billing/ML/usage-insights) are excluded unconditionally so platform telemetry never counts as product data. The `useSolutionState` React hook lands later in the stack with its first consumer.
