### PR TITLE
Home: fetch Loki/Tempo/Prometheus activity for the left card

### DIFF
--- a/public/app/features/home/Recommendations/kubernetesData.test.ts
+++ b/public/app/features/home/Recommendations/kubernetesData.test.ts
@@ -64,8 +64,9 @@ let probeHangUids: Set<string>;
 // Probe queries against these uids emit LoadingState.Error for the first N attempts.
 let probeFailuresByUid: Record<string, number>;
 let probeAttempts: Record<string, number>;
-// Non-probe query batches: always emit LoadingState.Error.
+// Non-probe batches containing these refIds emit LoadingState.Error; sibling refIds' frames survive.
 let queryErrorRefIds: Set<string>;
+let lastErrorData: PanelData | undefined;
 let valuesByRefId: Record<string, number>;
 
 type CapturedRun = { datasource: { uid: string }; queries: Array<{ refId: string; expr: string }> };
@@ -91,6 +92,7 @@ beforeEach(() => {
   probeFailuresByUid = {};
   probeAttempts = {};
   queryErrorRefIds = new Set();
+  lastErrorData = undefined;
   valuesByRefId = {};
   mockCreateQueryRunner.mockImplementation(() => {
     // Per-runner capture: parallel probes each get their own runner, so a shared variable would race.
@@ -112,10 +114,19 @@ beforeEach(() => {
             return of({ state: LoadingState.Error, series: [] as DataFrame[], timeRange: {} } as PanelData);
           }
         }
-        if (!isProbe && captured?.queries.some((q) => queryErrorRefIds.has(q.refId))) {
-          return of({ state: LoadingState.Error, series: [] as DataFrame[], timeRange: {} } as PanelData);
-        }
         const count = dataByUid[uid] ?? 0;
+        if (!isProbe && captured?.queries.some((q) => queryErrorRefIds.has(q.refId))) {
+          // Runner partial-error shape: erroring targets drop out, sibling frames survive.
+          const survivors = captured.queries
+            .filter((q) => !queryErrorRefIds.has(q.refId))
+            .map((q) =>
+              numberFrame(q.refId, [
+                valuesByRefId[q.refId] ?? (q.refId === 'clusters' || q.refId === 'pods' ? count : 0),
+              ])
+            );
+          lastErrorData = { state: LoadingState.Error, series: survivors, timeRange: {} } as PanelData;
+          return of(lastErrorData);
+        }
         let series: DataFrame[] = [];
         if (isProbe && count > 0) {
           series = [numberFrame('namespaces', [count])];
@@ -516,12 +527,14 @@ describe('Kubernetes Prometheus resolution', () => {
     }
   });
 
-  it('rejects when the inventory query fails', async () => {
+  it('rejects when one inventory query errors even though the sibling frame survives', async () => {
     setDataSources([{ uid: 'k8s-uid', name: 'k8s-prom', isDefault: true }]);
     dataByUid = { 'k8s-uid': 2 };
     queryErrorRefIds = new Set(['clusters']);
 
-    await expect(fetchKubernetesInventory()).rejects.toThrow();
+    await expect(fetchKubernetesInventory()).rejects.toThrow('Prometheus query failed');
+    // Pin the scenario: the pods frame really survived and was discarded — not an empty error.
+    expect(lastErrorData?.series.map((f) => f.refId)).toEqual(['pods']);
     expect(inventoryCalls()).toHaveLength(1);
   });
 

--- a/public/app/features/home/Recommendations/promQuery.test.ts
+++ b/public/app/features/home/Recommendations/promQuery.test.ts
@@ -112,6 +112,16 @@ describe('runInstantQueries', () => {
     expect(destroy).toHaveBeenCalled();
   });
 
+  it('returns the surviving frames when only some targets error', async () => {
+    setRunnerResult([numberFrame('A', [42])], LoadingState.Error);
+
+    const frames = await runInstantQueries({ A: 'up', B: 'bad' }, { uid: 'prom', type: 'prometheus' });
+
+    expect(readScalar(frames, 'A')).toBe(42);
+    expect(readScalar(frames, 'B')).toBeNull();
+    expect(destroy).toHaveBeenCalled();
+  });
+
   it('rejects (and still destroys the runner) when the runner never reaches a terminal state', async () => {
     jest.useFakeTimers();
 

--- a/public/app/features/home/Recommendations/promQuery.test.ts
+++ b/public/app/features/home/Recommendations/promQuery.test.ts
@@ -112,13 +112,22 @@ describe('runInstantQueries', () => {
     expect(destroy).toHaveBeenCalled();
   });
 
-  it('returns the surviving frames when only some targets error', async () => {
+  it('keeps the surviving frames when the caller opts into partial results', async () => {
     setRunnerResult([numberFrame('A', [42])], LoadingState.Error);
 
-    const frames = await runInstantQueries({ A: 'up', B: 'bad' }, { uid: 'prom', type: 'prometheus' });
+    const frames = await runInstantQueries({ A: 'up', B: 'bad' }, { uid: 'prom', type: 'prometheus' }, undefined, true);
 
     expect(readScalar(frames, 'A')).toBe(42);
     expect(readScalar(frames, 'B')).toBeNull();
+    expect(destroy).toHaveBeenCalled();
+  });
+
+  it('rejects by default when some targets error even though other frames survive', async () => {
+    setRunnerResult([numberFrame('A', [42])], LoadingState.Error);
+
+    await expect(runInstantQueries({ A: 'up', B: 'bad' }, { uid: 'prom', type: 'prometheus' })).rejects.toThrow(
+      'Prometheus query failed'
+    );
     expect(destroy).toHaveBeenCalled();
   });
 

--- a/public/app/features/home/Recommendations/promQuery.ts
+++ b/public/app/features/home/Recommendations/promQuery.ts
@@ -18,9 +18,8 @@ import { type PromQuery } from '@grafana/prometheus';
 import { createQueryRunner } from '@grafana/runtime';
 
 export function readScalar(frames: DataFrame[], refId: string): number | null {
-  const field = frames.find((f) => f.refId === refId)?.fields.find((f) => f.type === FieldType.number);
-  const v = field && field.values.length ? field.values[field.values.length - 1] : undefined;
-  return typeof v === 'number' && Number.isFinite(v) ? v : null;
+  // '' is never a label key, so this shares readLabeledScalar's lookup with the label discarded.
+  return readLabeledScalar(frames, refId, '')?.value ?? null;
 }
 
 /** Last sample of the `refId` instant vector plus one identifying label off its number field. */

--- a/public/app/features/home/Recommendations/promQuery.ts
+++ b/public/app/features/home/Recommendations/promQuery.ts
@@ -59,14 +59,16 @@ export function readSeries(frames: DataFrame[], refId: string): FieldSparkline |
 /**
  * Run queries through the shared {@link createQueryRunner | QueryRunner} against `ds` — core
  * plumbing owns request building, interval math, and frame conversion. Works for any datasource
- * whose targets are expressible as DataQuery (Prometheus PromQL, Tempo TraceQL). Throws only when
- * the request yields no frames; surviving frames are returned and missing refIds read as null.
+ * whose targets are expressible as DataQuery (Prometheus PromQL, Tempo TraceQL). Throws on query
+ * errors; `partial` callers instead receive the surviving targets' frames and must handle absent
+ * refIds themselves — an error response with no frames at all still throws.
  */
 export async function runDatasourceQueries(
   queries: DataQuery[],
   range: TimeRange,
   ds: Pick<DataSourceInstanceSettings, 'uid' | 'type'>,
-  timeoutMs = 30_000
+  timeoutMs = 30_000,
+  partial = false
 ): Promise<DataFrame[]> {
   const runner = createQueryRunner();
   try {
@@ -86,8 +88,8 @@ export async function runDatasourceQueries(
         timeout(timeoutMs)
       )
     );
-    // Partial failure keeps the surviving targets' frames; only a request that produced nothing throws.
-    if (data.state === LoadingState.Error && data.series.length === 0) {
+    // Errors reject by default — `?? 0` readers would render a dropped refId as a real zero.
+    if (data.state === LoadingState.Error && (!partial || data.series.length === 0)) {
       throw new Error(data.errors?.[0]?.message ?? data.error?.message ?? 'Prometheus query failed');
     }
     return data.series;
@@ -98,12 +100,14 @@ export async function runDatasourceQueries(
 
 /**
  * Run a batch of instant queries (refId -> PromQL) and return the response frames. The overview
- * cards read single-value scalars off the result via {@link readScalar}.
+ * cards read single-value scalars off the result via {@link readScalar}. Set `partial` to
+ * tolerate individual query errors and keep the surviving frames.
  */
 export async function runInstantQueries(
   queries: Record<string, string>,
   ds: Pick<DataSourceInstanceSettings, 'uid' | 'type'>,
-  timeoutMs?: number
+  timeoutMs?: number,
+  partial = false
 ): Promise<DataFrame[]> {
   const targets: PromQuery[] = Object.entries(queries).map(([refId, expr]) => ({
     refId,
@@ -111,7 +115,7 @@ export async function runInstantQueries(
     instant: true,
     range: false,
   }));
-  return runDatasourceQueries(targets, getDefaultTimeRange(), ds, timeoutMs);
+  return runDatasourceQueries(targets, getDefaultTimeRange(), ds, timeoutMs, partial);
 }
 
 /**

--- a/public/app/features/home/Recommendations/promQuery.ts
+++ b/public/app/features/home/Recommendations/promQuery.ts
@@ -59,8 +59,8 @@ export function readSeries(frames: DataFrame[], refId: string): FieldSparkline |
 /**
  * Run queries through the shared {@link createQueryRunner | QueryRunner} against `ds` — core
  * plumbing owns request building, interval math, and frame conversion. Works for any datasource
- * whose targets are expressible as DataQuery (Prometheus PromQL, Tempo TraceQL). Throws (surfaced
- * as an error; callers omit the entry) when the query errors or times out.
+ * whose targets are expressible as DataQuery (Prometheus PromQL, Tempo TraceQL). Throws only when
+ * the request yields no frames; surviving frames are returned and missing refIds read as null.
  */
 export async function runDatasourceQueries(
   queries: DataQuery[],
@@ -86,7 +86,8 @@ export async function runDatasourceQueries(
         timeout(timeoutMs)
       )
     );
-    if (data.state === LoadingState.Error) {
+    // Partial failure keeps the surviving targets' frames; only a request that produced nothing throws.
+    if (data.state === LoadingState.Error && data.series.length === 0) {
       throw new Error(data.errors?.[0]?.message ?? data.error?.message ?? 'Prometheus query failed');
     }
     return data.series;

--- a/public/app/features/home/Recommendations/promQuery.ts
+++ b/public/app/features/home/Recommendations/promQuery.ts
@@ -23,6 +23,20 @@ export function readScalar(frames: DataFrame[], refId: string): number | null {
   return typeof v === 'number' && Number.isFinite(v) ? v : null;
 }
 
+/** Last sample of the `refId` instant vector plus one identifying label off its number field. */
+export function readLabeledScalar(
+  frames: DataFrame[],
+  refId: string,
+  label: string
+): { value: number; label: string | null } | null {
+  const field = frames.find((f) => f.refId === refId)?.fields.find((f) => f.type === FieldType.number);
+  if (!field || field.values.length === 0) {
+    return null;
+  }
+  const v = field.values[field.values.length - 1];
+  return typeof v === 'number' && Number.isFinite(v) ? { value: v, label: field.labels?.[label] ?? null } : null;
+}
+
 // Extract the first usable time series for `refId` as a sparkline input. Requires a real series
 // (> 1 point) so a single-point instant/vector frame is rejected; skips frames whose time/number
 // fields are absent or length-mismatched rather than trusting the first refId match.

--- a/public/app/features/home/Recommendations/telemetryData.test.ts
+++ b/public/app/features/home/Recommendations/telemetryData.test.ts
@@ -1,11 +1,12 @@
-import { createDataFrame, type DataSourceInstanceListItem, FieldType } from '@grafana/data';
+import { getAPINamespace } from '@grafana/api-clients';
 import {
-  type BackendSrv,
-  type DataSourceSrv,
-  type DataSourceWithBackend,
-  getBackendSrv,
-  getDataSourceSrv,
-} from '@grafana/runtime';
+  createDataFrame,
+  type DataSourceInstanceListItem,
+  type DataSourceInstanceSettings,
+  FieldType,
+} from '@grafana/data';
+import { type BackendSrv, type DataSourceWithBackend, getBackendSrv } from '@grafana/runtime';
+import { getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 
 import { resolveBackendInstance } from './probeUtils';
 import { runInstantQueries, runRangeQuery } from './promQuery';
@@ -35,11 +36,22 @@ jest.mock('@grafana/runtime', () => ({
   getDataSourceSrv: jest.fn(),
 }));
 
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getDataSourceInstanceSettings: jest.fn(),
+}));
+
+jest.mock('@grafana/api-clients', () => ({
+  ...jest.requireActual('@grafana/api-clients'),
+  getAPINamespace: jest.fn(),
+}));
+
 const mockResolveBackendInstance = jest.mocked(resolveBackendInstance);
 const mockRunInstantQueries = jest.mocked(runInstantQueries);
 const mockRunRangeQuery = jest.mocked(runRangeQuery);
 const mockProxyGet = jest.fn();
-const mockGetInstanceSettings = jest.fn();
+const mockGetDataSourceInstanceSettings = jest.mocked(getDataSourceInstanceSettings);
+const mockGetAPINamespace = jest.mocked(getAPINamespace);
 
 const DATA_LOOKBACK_HOURS = 24;
 const NS_IN_MS = 1e6;
@@ -61,10 +73,10 @@ beforeEach(() => {
   mockRunRangeQuery.mockReset();
   mockRunRangeQuery.mockResolvedValue([]);
   jest.mocked(getBackendSrv).mockReturnValue({ get: mockProxyGet } as unknown as BackendSrv);
-  mockGetInstanceSettings.mockReset();
-  jest.mocked(getDataSourceSrv).mockReturnValue({
-    getInstanceSettings: mockGetInstanceSettings,
-  } as unknown as DataSourceSrv);
+  mockGetDataSourceInstanceSettings.mockReset();
+  mockGetDataSourceInstanceSettings.mockResolvedValue(undefined);
+  mockGetAPINamespace.mockReset();
+  mockGetAPINamespace.mockReturnValue('default');
 });
 
 afterEach(() => {
@@ -260,6 +272,7 @@ describe('fetchTracesActivity', () => {
 
 describe('fetchMetricsActivity', () => {
   const prom = { uid: 'prom-uid', type: 'prometheus' };
+  const usageSettings = { uid: 'grafanacloud-usage', type: 'prometheus' } as unknown as DataSourceInstanceSettings;
 
   const scalarFrame = (refId: string, value: number, labels?: Record<string, string>) =>
     createDataFrame({ refId, fields: [{ name: 'Value', type: FieldType.number, values: [value], labels }] });
@@ -327,7 +340,9 @@ describe('fetchMetricsActivity', () => {
   });
 
   it('skips the head-series sparkline on Mimir/Cortex-backed datasources', async () => {
-    mockGetInstanceSettings.mockReturnValue({ jsonData: { prometheusType: 'Mimir' } });
+    mockGetDataSourceInstanceSettings.mockResolvedValue({
+      jsonData: { prometheusType: 'Mimir' },
+    } as unknown as DataSourceInstanceSettings);
     const getResource = jest.fn(async (path: string) => {
       if (path === 'api/v1/cardinality/label_values') {
         return { series_count_total: 4_200_000 };
@@ -344,6 +359,140 @@ describe('fetchMetricsActivity', () => {
     expect(activity.series).toBe(4_200_000);
     expect(activity.seriesSparkline).toBeNull();
     expect(mockRunRangeQuery).not.toHaveBeenCalled();
+  });
+
+  it('sources series, sparkline, and ingest rate from the usage datasource on a Cloud stack', async () => {
+    mockGetAPINamespace.mockReturnValue('stacks-12345');
+    mockGetDataSourceInstanceSettings.mockImplementation(async (ref) =>
+      ref === 'grafanacloud-usage'
+        ? usageSettings
+        : ({ jsonData: { prometheusType: 'Mimir' } } as unknown as DataSourceInstanceSettings)
+    );
+    const getResource = jest.fn(async (path: string) => {
+      if (path === 'api/v1/cardinality/label_values') {
+        return { series_count_total: 4_200_000 };
+      }
+      return { data: ['up'] };
+    });
+    mockResolveBackendInstance.mockResolvedValue(instanceWith(getResource));
+    mockRunInstantQueries.mockImplementation(async (queries, ds) =>
+      ds.uid === 'grafanacloud-usage'
+        ? [scalarFrame('activeSeries', 9_900_000), scalarFrame('dataPointsPerMinute', 5_160_000)]
+        : [scalarFrame('hosts', 12)]
+    );
+    mockRunRangeQuery.mockResolvedValue([
+      createDataFrame({
+        refId: 'series',
+        fields: [
+          { name: 'Time', type: FieldType.time, values: [1_000, 2_000] },
+          { name: 'Value', type: FieldType.number, values: [30, 40] },
+        ],
+      }),
+    ]);
+
+    const activity = await fetchMetricsActivity(prom);
+
+    expect(mockRunInstantQueries).toHaveBeenCalledWith(
+      {
+        activeSeries: 'sum(grafanacloud_instance_active_series{stack_id="12345"})',
+        dataPointsPerMinute: '60 * sum(grafanacloud_instance_samples_per_second{stack_id="12345"})',
+      },
+      { uid: 'grafanacloud-usage', type: 'prometheus' }
+    );
+    // The trend works on Cloud via usage metrics even though the product datasource is Mimir-typed.
+    expect(mockRunRangeQuery).toHaveBeenCalledWith(
+      'series',
+      'sum(grafanacloud_instance_active_series{stack_id="12345"})',
+      DATA_LOOKBACK_HOURS,
+      { uid: 'grafanacloud-usage', type: 'prometheus' }
+    );
+    expect(activity.series).toBe(9_900_000);
+    expect(activity.dataPointsPerMinute).toBe(5_160_000);
+    expect(activity.seriesSparkline?.y.values).toEqual([30, 40]);
+  });
+
+  it('never queries the usage datasource outside a Cloud stack', async () => {
+    mockGetDataSourceInstanceSettings.mockResolvedValue({
+      jsonData: { prometheusType: 'Mimir' },
+    } as unknown as DataSourceInstanceSettings);
+    const getResource = jest.fn(async () => ({ data: ['up'] }));
+    mockResolveBackendInstance.mockResolvedValue(instanceWith(getResource));
+    mockRunInstantQueries.mockResolvedValue([scalarFrame('hosts', 12)]);
+
+    const activity = await fetchMetricsActivity(prom);
+
+    expect(mockGetDataSourceInstanceSettings).not.toHaveBeenCalledWith('grafanacloud-usage');
+    expect(mockRunInstantQueries).toHaveBeenCalledTimes(1);
+    expect(mockRunInstantQueries).toHaveBeenCalledWith(expect.not.objectContaining({ dpm: expect.anything() }), prom);
+    expect(activity.dataPointsPerMinute).toBeNull();
+  });
+
+  it('reads the ingest rate from Prometheus self-monitoring on vanilla datasources', async () => {
+    const getResource = jest.fn(async () => ({ data: ['up'] }));
+    mockResolveBackendInstance.mockResolvedValue(instanceWith(getResource));
+    mockRunInstantQueries.mockResolvedValue([scalarFrame('hosts', 12), scalarFrame('dpm', 250_000)]);
+
+    const activity = await fetchMetricsActivity(prom);
+
+    expect(mockRunInstantQueries).toHaveBeenCalledWith(
+      expect.objectContaining({ dpm: '60 * sum(rate(prometheus_tsdb_head_samples_appended_total[5m]))' }),
+      prom
+    );
+    expect(activity.dataPointsPerMinute).toBe(250_000);
+  });
+
+  it('keeps the prom path when the stack has no usage datasource', async () => {
+    mockGetAPINamespace.mockReturnValue('stacks-12345');
+    const getResource = jest.fn(async (path: string) => {
+      if (path === 'api/v1/cardinality/label_values') {
+        return { series_count_total: 4_200_000 };
+      }
+      return { data: ['up'] };
+    });
+    mockResolveBackendInstance.mockResolvedValue(instanceWith(getResource));
+
+    const activity = await fetchMetricsActivity(prom);
+
+    expect(activity.series).toBe(4_200_000);
+    expect(mockRunRangeQuery).toHaveBeenCalledWith(
+      'series',
+      'sum(prometheus_tsdb_head_series)',
+      DATA_LOOKBACK_HOURS,
+      prom
+    );
+    expect(mockRunInstantQueries).toHaveBeenCalledTimes(1);
+    expect(mockRunInstantQueries).toHaveBeenCalledWith(
+      expect.objectContaining({ hosts: 'count(node_uname_info)' }),
+      prom
+    );
+  });
+
+  it('falls back to the per-datasource values when usage queries fail', async () => {
+    mockGetAPINamespace.mockReturnValue('stacks-12345');
+    mockGetDataSourceInstanceSettings.mockImplementation(async (ref) =>
+      ref === 'grafanacloud-usage' ? usageSettings : undefined
+    );
+    const getResource = jest.fn(async (path: string) => {
+      if (path === 'api/v1/cardinality/label_values') {
+        return { series_count_total: 4_200_000 };
+      }
+      return { data: ['up'] };
+    });
+    mockResolveBackendInstance.mockResolvedValue(instanceWith(getResource));
+    mockRunInstantQueries.mockImplementation(async (queries, ds) => {
+      if (ds.uid === 'grafanacloud-usage') {
+        throw new Error('usage unavailable');
+      }
+      return [scalarFrame('hosts', 12)];
+    });
+    mockRunRangeQuery.mockRejectedValue(new Error('usage unavailable'));
+
+    const activity = await fetchMetricsActivity(prom);
+
+    expect(activity.series).toBe(4_200_000);
+    expect(activity.dataPointsPerMinute).toBeNull();
+    expect(activity.seriesSparkline).toBeNull();
+    expect(activity.hosts).toBe(12);
   });
 
   it('falls back to TSDB head stats when the cardinality API is unavailable', async () => {
@@ -417,6 +566,7 @@ describe('fetchMetricsActivity', () => {
 
     await expect(fetchMetricsActivity(prom)).resolves.toEqual({
       series: null,
+      dataPointsPerMinute: null,
       names: null,
       hosts: null,
       seriesSparkline: null,

--- a/public/app/features/home/Recommendations/telemetryData.test.ts
+++ b/public/app/features/home/Recommendations/telemetryData.test.ts
@@ -1,0 +1,396 @@
+import { createDataFrame, type DataSourceInstanceListItem, FieldType } from '@grafana/data';
+import { type BackendSrv, type DataSourceWithBackend, getBackendSrv } from '@grafana/runtime';
+
+import { resolveBackendInstance } from './probeUtils';
+import { runInstantQueries, runRangeQuery } from './promQuery';
+import {
+  fetchLogsActivity,
+  fetchMetricsActivity,
+  fetchTracesActivity,
+  fetchTracesServices,
+  LOGS_STATS_LOOKBACK_DAYS,
+  METRICS_STATS_LOOKBACK_DAYS,
+} from './telemetryData';
+
+jest.mock('./probeUtils', () => ({
+  ...jest.requireActual('./probeUtils'),
+  resolveBackendInstance: jest.fn(),
+}));
+
+jest.mock('./promQuery', () => ({
+  ...jest.requireActual('./promQuery'),
+  runInstantQueries: jest.fn(),
+  runRangeQuery: jest.fn(),
+}));
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getBackendSrv: jest.fn(),
+}));
+
+const mockResolveBackendInstance = jest.mocked(resolveBackendInstance);
+const mockRunInstantQueries = jest.mocked(runInstantQueries);
+const mockRunRangeQuery = jest.mocked(runRangeQuery);
+const mockProxyGet = jest.fn();
+
+const DATA_LOOKBACK_HOURS = 24;
+const NS_IN_MS = 1e6;
+
+const loki: Pick<DataSourceInstanceListItem, 'uid'> = { uid: 'loki-uid' };
+const tempo = { uid: 'tempo-uid' };
+
+function instanceWith(getResource: jest.Mock): DataSourceWithBackend {
+  return { getResource } as unknown as DataSourceWithBackend;
+}
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  jest.setSystemTime(new Date('2026-07-24T12:00:00Z'));
+  mockResolveBackendInstance.mockReset();
+  mockProxyGet.mockReset();
+  mockRunInstantQueries.mockReset();
+  mockRunInstantQueries.mockResolvedValue([]);
+  mockRunRangeQuery.mockReset();
+  mockRunRangeQuery.mockResolvedValue([]);
+  jest.mocked(getBackendSrv).mockReturnValue({ get: mockProxyGet } as unknown as BackendSrv);
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe('fetchLogsActivity', () => {
+  it('sums index volume, counts sources, and builds the ingest series over the right windows', async () => {
+    const getResource = jest.fn(async (path: string) => {
+      if (path === 'labels') {
+        return { data: ['filename', 'job', 'service_name'] };
+      }
+      if (path === 'index/volume') {
+        return {
+          data: {
+            result: [
+              { metric: { service_name: 'a' }, value: [1, '30000000000'] },
+              { metric: { service_name: 'b' }, value: [1, '17000000000'] },
+            ],
+          },
+        };
+      }
+      if (path === 'index/volume_range') {
+        return {
+          data: {
+            result: [
+              {
+                metric: { service_name: 'a' },
+                values: [
+                  [1_000, '10'],
+                  [1_060, '20'],
+                ],
+              },
+              {
+                metric: { service_name: 'b' },
+                values: [
+                  [1_000, '5'],
+                  [1_060, '15'],
+                ],
+              },
+            ],
+          },
+        };
+      }
+      if (path === 'label/service_name/values') {
+        return { data: ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'] };
+      }
+      throw new Error(`unexpected path ${path}`);
+    });
+    mockResolveBackendInstance.mockResolvedValue(instanceWith(getResource));
+
+    const activity = await fetchLogsActivity(loki);
+
+    expect(activity.bytes).toBe(47_000_000_000);
+    expect(activity.sources).toBe(8);
+    expect(activity.series?.x?.values).toEqual([1_000_000, 1_060_000]);
+    expect(activity.series?.y.values).toEqual([15, 35]);
+
+    const end = Date.now() * NS_IN_MS;
+    const statsStart = end - LOGS_STATS_LOOKBACK_DAYS * 24 * 3600 * 1e9;
+    const silent = { showErrorAlert: false };
+    expect(getResource).toHaveBeenCalledWith('labels', { start: statsStart, end }, silent);
+    expect(getResource).toHaveBeenCalledWith(
+      'index/volume',
+      { query: '{service_name=~".+"}', start: statsStart, end, aggregateBy: 'labels', targetLabels: 'service_name' },
+      silent
+    );
+    expect(getResource).toHaveBeenCalledWith('label/service_name/values', { start: statsStart, end }, silent);
+    expect(getResource).toHaveBeenCalledWith(
+      'index/volume_range',
+      {
+        query: '{service_name=~".+"}',
+        start: end - DATA_LOOKBACK_HOURS * 3600 * 1e9,
+        end,
+        step: '30m',
+        aggregateBy: 'labels',
+        targetLabels: 'service_name',
+      },
+      silent
+    );
+  });
+
+  it('falls back to job when service_name is absent', async () => {
+    const getResource = jest.fn(async (path: string) => {
+      if (path === 'labels') {
+        return { data: ['filename', 'job'] };
+      }
+      if (path === 'index/volume') {
+        return { data: { result: [] } };
+      }
+      if (path === 'index/volume_range') {
+        return { data: { result: [] } };
+      }
+      return { data: ['a'] };
+    });
+    mockResolveBackendInstance.mockResolvedValue(instanceWith(getResource));
+
+    await expect(fetchLogsActivity(loki)).resolves.toEqual({ bytes: 0, sources: 1, series: null });
+    expect(getResource).toHaveBeenCalledWith('label/job/values', expect.anything(), expect.anything());
+  });
+
+  it('keeps the other fields when one endpoint is unavailable', async () => {
+    const getResource = jest.fn(async (path: string) => {
+      if (path === 'labels') {
+        return { data: ['job'] };
+      }
+      if (path === 'index/volume' || path === 'index/volume_range') {
+        throw new Error('volume disabled');
+      }
+      return { data: ['a', 'b'] };
+    });
+    mockResolveBackendInstance.mockResolvedValue(instanceWith(getResource));
+
+    await expect(fetchLogsActivity(loki)).resolves.toEqual({ bytes: null, sources: 2, series: null });
+  });
+
+  it('reports nulls when no usable label exists', async () => {
+    const getResource = jest.fn(async () => ({ data: ['__stream_shard__'] }));
+    mockResolveBackendInstance.mockResolvedValue(instanceWith(getResource));
+
+    await expect(fetchLogsActivity(loki)).resolves.toEqual({ bytes: null, sources: null, series: null });
+    expect(getResource).toHaveBeenCalledTimes(1);
+  });
+
+  it('drops a single-point series', async () => {
+    const getResource = jest.fn(async (path: string) => {
+      if (path === 'labels') {
+        return { data: ['job'] };
+      }
+      if (path === 'index/volume_range') {
+        return { data: { result: [{ metric: {}, values: [[1_000, '10']] }] } };
+      }
+      return { data: [] };
+    });
+    mockResolveBackendInstance.mockResolvedValue(instanceWith(getResource));
+
+    const activity = await fetchLogsActivity(loki);
+
+    expect(activity.series).toBeNull();
+  });
+});
+
+describe('fetchTracesServices', () => {
+  it('counts tag values through the datasource proxy over the lookback in unix seconds', async () => {
+    mockProxyGet.mockResolvedValue({ tagValues: [{ value: 'a' }, { value: 'b' }] });
+
+    await expect(fetchTracesServices(tempo)).resolves.toBe(2);
+
+    const end = Math.floor(Date.now() / 1000);
+    expect(mockProxyGet).toHaveBeenCalledWith(
+      '/api/datasources/proxy/uid/tempo-uid/api/v2/search/tag/resource.service.name/values',
+      { start: end - DATA_LOOKBACK_HOURS * 3600, end },
+      undefined,
+      { showErrorAlert: false }
+    );
+  });
+});
+
+describe('fetchTracesActivity', () => {
+  it('sums the query_range samples into a span count and throughput series', async () => {
+    mockProxyGet.mockResolvedValue({
+      series: [
+        {
+          samples: [
+            { timestampMs: '1000', value: 100 },
+            { timestampMs: '2000', value: 200 },
+            { timestampMs: '3000', value: 300 },
+          ],
+        },
+      ],
+    });
+
+    const activity = await fetchTracesActivity(tempo);
+
+    expect(activity.spans).toBe(600);
+    expect(activity.series?.x?.values).toEqual([1000, 2000, 3000]);
+    expect(activity.series?.y.values).toEqual([100, 200, 300]);
+    const end = Math.floor(Date.now() / 1000);
+    expect(mockProxyGet).toHaveBeenCalledWith(
+      '/api/datasources/proxy/uid/tempo-uid/api/metrics/query_range',
+      { q: '{} | count_over_time()', start: end - DATA_LOOKBACK_HOURS * 3600, end, step: '30m' },
+      undefined,
+      { showErrorAlert: false }
+    );
+  });
+
+  it('reports null spans when the response has no samples', async () => {
+    mockProxyGet.mockResolvedValue({ series: [] });
+
+    await expect(fetchTracesActivity(tempo)).resolves.toEqual({ spans: null, series: null });
+  });
+});
+
+describe('fetchMetricsActivity', () => {
+  const prom = { uid: 'prom-uid', type: 'prometheus' };
+
+  const scalarFrame = (refId: string, value: number, labels?: Record<string, string>) =>
+    createDataFrame({ refId, fields: [{ name: 'Value', type: FieldType.number, values: [value], labels }] });
+
+  it('reads cardinality, name count, hosts, disk pressure, and the series sparkline', async () => {
+    const getResource = jest.fn(async (path: string) => {
+      if (path === 'api/v1/cardinality/label_values') {
+        return { series_count_total: 4_200_000 };
+      }
+      if (path === 'api/v1/label/__name__/values') {
+        return { data: ['up', 'node_cpu_seconds_total', 'node_uname_info'] };
+      }
+      throw new Error(`unexpected path ${path}`);
+    });
+    mockResolveBackendInstance.mockResolvedValue(instanceWith(getResource));
+    mockRunRangeQuery.mockResolvedValue([
+      createDataFrame({
+        refId: 'series',
+        fields: [
+          { name: 'Time', type: FieldType.time, values: [1_000, 2_000] },
+          { name: 'Value', type: FieldType.number, values: [10, 20] },
+        ],
+      }),
+    ]);
+    mockRunInstantQueries.mockImplementation(async (queries) =>
+      'eta' in queries
+        ? [scalarFrame('eta', 6.4)]
+        : [
+            scalarFrame('hosts', 12),
+            scalarFrame('diskHosts', 3),
+            scalarFrame('diskWorst', 0.96, { instance: 'web-03:9100' }),
+          ]
+    );
+
+    const activity = await fetchMetricsActivity(prom);
+
+    expect(activity.series).toBe(4_200_000);
+    expect(activity.names).toBe(3);
+    expect(activity.hosts).toBe(12);
+    expect(activity.seriesSparkline?.y.values).toEqual([10, 20]);
+    expect(activity.disk).toEqual({
+      hostsAbove: 3,
+      worstInstance: 'web-03:9100',
+      worstRatio: 0.96,
+      hoursToFull: 6.4,
+    });
+
+    const end = Math.floor(Date.now() / 1000);
+    expect(getResource).toHaveBeenCalledWith(
+      'api/v1/label/__name__/values',
+      { start: end - METRICS_STATS_LOOKBACK_DAYS * 24 * 3600, end },
+      { showErrorAlert: false }
+    );
+    expect(mockRunRangeQuery).toHaveBeenCalledWith(
+      'series',
+      'sum(prometheus_tsdb_head_series)',
+      DATA_LOOKBACK_HOURS,
+      prom
+    );
+    // The follow-up ETA query pins the worst host by its full instance label.
+    expect(mockRunInstantQueries).toHaveBeenCalledWith(
+      { eta: expect.stringContaining('instance="web-03:9100"') },
+      prom
+    );
+  });
+
+  it('falls back to TSDB head stats when the cardinality API is unavailable', async () => {
+    const getResource = jest.fn(async (path: string) => {
+      if (path === 'api/v1/cardinality/label_values') {
+        throw new Error('unsupported');
+      }
+      if (path === 'api/v1/status/tsdb') {
+        return { data: { headStats: { numSeries: 987 } } };
+      }
+      return { data: ['up'] };
+    });
+    mockResolveBackendInstance.mockResolvedValue(instanceWith(getResource));
+
+    await expect(fetchMetricsActivity(prom)).resolves.toMatchObject({ series: 987, names: 1 });
+  });
+
+  it('keeps the name count when both active-series sources fail', async () => {
+    const getResource = jest.fn(async (path: string) => {
+      if (path === 'api/v1/label/__name__/values') {
+        return { data: ['up', 'process_cpu_seconds_total'] };
+      }
+      throw new Error('unsupported');
+    });
+    mockResolveBackendInstance.mockResolvedValue(instanceWith(getResource));
+
+    const promise = fetchMetricsActivity(prom);
+    await jest.advanceTimersByTimeAsync(10_000);
+
+    await expect(promise).resolves.toMatchObject({ series: null, names: 2 });
+  });
+
+  it('reports no disk pressure and skips the ETA query when nobody is above threshold', async () => {
+    const getResource = jest.fn(async () => ({ data: [] }));
+    mockResolveBackendInstance.mockResolvedValue(instanceWith(getResource));
+    // count() over an empty vector returns an empty result, not zero: no diskHosts frame.
+    mockRunInstantQueries.mockResolvedValue([scalarFrame('hosts', 12)]);
+
+    const promise = fetchMetricsActivity(prom);
+    await jest.advanceTimersByTimeAsync(10_000);
+    const activity = await promise;
+
+    expect(activity.hosts).toBe(12);
+    expect(activity.disk).toBeNull();
+    expect(mockRunInstantQueries).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([90, 0])('drops a meaningless linear ETA (%s h)', async (eta) => {
+    const getResource = jest.fn(async () => ({ data: [] }));
+    mockResolveBackendInstance.mockResolvedValue(instanceWith(getResource));
+    mockRunInstantQueries.mockImplementation(async (queries) =>
+      'eta' in queries
+        ? [scalarFrame('eta', eta)]
+        : [scalarFrame('diskHosts', 1), scalarFrame('diskWorst', 0.93, { instance: 'db-01:9100' })]
+    );
+
+    const promise = fetchMetricsActivity(prom);
+    await jest.advanceTimersByTimeAsync(10_000);
+    const activity = await promise;
+
+    expect(activity.disk).toEqual({
+      hostsAbove: 1,
+      worstInstance: 'db-01:9100',
+      worstRatio: 0.93,
+      hoursToFull: null,
+    });
+  });
+
+  it('resolves all-null without querying when the datasource has no backend instance', async () => {
+    mockResolveBackendInstance.mockResolvedValue(null);
+
+    await expect(fetchMetricsActivity(prom)).resolves.toEqual({
+      series: null,
+      names: null,
+      hosts: null,
+      seriesSparkline: null,
+      disk: null,
+    });
+    expect(mockRunInstantQueries).not.toHaveBeenCalled();
+    expect(mockRunRangeQuery).not.toHaveBeenCalled();
+  });
+});

--- a/public/app/features/home/Recommendations/telemetryData.test.ts
+++ b/public/app/features/home/Recommendations/telemetryData.test.ts
@@ -431,6 +431,66 @@ describe('fetchMetricsActivity', () => {
     expect(activity.seriesSparkline?.y.values).toEqual([30, 40]);
   });
 
+  it('falls back to the head-series sparkline when the usage series is empty', async () => {
+    mockGetAPINamespace.mockReturnValue('stacks-12345');
+    mockGetDataSourceInstanceSettings.mockImplementation(async (ref) =>
+      ref === 'grafanacloud-usage' ? usageSettings : undefined
+    );
+    const getResource = jest.fn(async () => ({ data: ['up'] }));
+    mockResolveBackendInstance.mockResolvedValue(instanceWith(getResource));
+    mockRunRangeQuery.mockImplementation(async (_refId, query) =>
+      query === 'sum(prometheus_tsdb_head_series)'
+        ? [
+            createDataFrame({
+              refId: 'series',
+              fields: [
+                { name: 'Time', type: FieldType.time, values: [1_000, 2_000] },
+                { name: 'Value', type: FieldType.number, values: [10, 20] },
+              ],
+            }),
+          ]
+        : []
+    );
+
+    const activity = await fetchMetricsActivity(prom);
+
+    expect(activity.seriesSparkline?.y.values).toEqual([10, 20]);
+    expect(mockRunRangeQuery).toHaveBeenCalledWith(
+      'series',
+      'sum(max by (id) (grafanacloud_instance_active_series{stack_id="12345"}))',
+      DATA_LOOKBACK_HOURS,
+      { uid: 'grafanacloud-usage', type: 'prometheus' }
+    );
+    expect(mockRunRangeQuery).toHaveBeenCalledWith(
+      'series',
+      'sum(prometheus_tsdb_head_series)',
+      DATA_LOOKBACK_HOURS,
+      prom
+    );
+  });
+
+  it('keeps the sparkline null on empty usage when the datasource is Mimir-backed', async () => {
+    mockGetAPINamespace.mockReturnValue('stacks-12345');
+    mockGetDataSourceInstanceSettings.mockImplementation(async (ref) =>
+      ref === 'grafanacloud-usage'
+        ? usageSettings
+        : ({ jsonData: { prometheusType: 'Mimir' } } as unknown as DataSourceInstanceSettings)
+    );
+    const getResource = jest.fn(async () => ({ data: ['up'] }));
+    mockResolveBackendInstance.mockResolvedValue(instanceWith(getResource));
+
+    const activity = await fetchMetricsActivity(prom);
+
+    expect(activity.seriesSparkline).toBeNull();
+    expect(mockRunRangeQuery).toHaveBeenCalledTimes(1);
+    expect(mockRunRangeQuery).toHaveBeenCalledWith(
+      'series',
+      'sum(max by (id) (grafanacloud_instance_active_series{stack_id="12345"}))',
+      DATA_LOOKBACK_HOURS,
+      { uid: 'grafanacloud-usage', type: 'prometheus' }
+    );
+  });
+
   it('never queries the usage datasource outside a Cloud stack', async () => {
     mockGetDataSourceInstanceSettings.mockResolvedValue({
       jsonData: { prometheusType: 'Mimir' },

--- a/public/app/features/home/Recommendations/telemetryData.test.ts
+++ b/public/app/features/home/Recommendations/telemetryData.test.ts
@@ -242,6 +242,12 @@ describe('fetchTracesServices', () => {
       { showErrorAlert: false }
     );
   });
+
+  it('propagates a proxy rejection (callers fail soft)', async () => {
+    mockProxyGet.mockRejectedValue(new Error('tempo 404'));
+
+    await expect(fetchTracesServices(tempo)).rejects.toThrow('tempo 404');
+  });
 });
 
 describe('fetchTracesActivity', () => {

--- a/public/app/features/home/Recommendations/telemetryData.test.ts
+++ b/public/app/features/home/Recommendations/telemetryData.test.ts
@@ -318,7 +318,7 @@ describe('fetchMetricsActivity', () => {
         : [
             scalarFrame('hosts', 12),
             scalarFrame('diskHosts', 3),
-            scalarFrame('diskWorst', 0.96, { instance: 'web-03:9100' }),
+            scalarFrame('diskWorst', 0.96, { instance: 'web-03:9100', mountpoint: '/data' }),
           ]
     );
 
@@ -352,9 +352,16 @@ describe('fetchMetricsActivity', () => {
       DATA_LOOKBACK_HOURS,
       prom
     );
-    // The follow-up ETA query pins the worst host by its full instance label.
+    // diskWorst must stay per-filesystem (no `max by (instance)`) or the mountpoint label is lost.
     expect(mockRunInstantQueries).toHaveBeenCalledWith(
-      { eta: expect.stringContaining('instance="web-03:9100"') },
+      expect.objectContaining({
+        diskWorst: expect.stringMatching(/^topk\(1, \(1 - node_filesystem_avail_bytes\{/),
+      }),
+      prom
+    );
+    // The follow-up ETA query pins the exact filesystem shown: worst host AND its fullest mountpoint.
+    expect(mockRunInstantQueries).toHaveBeenCalledWith(
+      { eta: expect.stringContaining('instance="web-03:9100",mountpoint="/data"') },
       prom
     );
   });
@@ -620,13 +627,30 @@ describe('fetchMetricsActivity', () => {
     expect(mockRunInstantQueries).toHaveBeenCalledTimes(1);
   });
 
+  it('omits the ETA and skips its query when the worst filesystem has no mountpoint label', async () => {
+    const getResource = jest.fn(async () => ({ data: [] }));
+    mockResolveBackendInstance.mockResolvedValue(instanceWith(getResource));
+    mockRunInstantQueries.mockResolvedValue([
+      scalarFrame('diskHosts', 1),
+      scalarFrame('diskWorst', 0.93, { instance: 'db-01:9100' }),
+    ]);
+
+    const promise = fetchMetricsActivity(prom);
+    await jest.advanceTimersByTimeAsync(10_000);
+    const activity = await promise;
+
+    expect(activity.disk).toEqual({ hostsAbove: 1, worstInstance: 'db-01:9100', worstRatio: 0.93, hoursToFull: null });
+    // Without a filesystem identity there is nothing honest to query.
+    expect(mockRunInstantQueries).toHaveBeenCalledTimes(1);
+  });
+
   it.each([90, 0])('drops a meaningless linear ETA (%s h)', async (eta) => {
     const getResource = jest.fn(async () => ({ data: [] }));
     mockResolveBackendInstance.mockResolvedValue(instanceWith(getResource));
     mockRunInstantQueries.mockImplementation(async (queries) =>
       'eta' in queries
         ? [scalarFrame('eta', eta)]
-        : [scalarFrame('diskHosts', 1), scalarFrame('diskWorst', 0.93, { instance: 'db-01:9100' })]
+        : [scalarFrame('diskHosts', 1), scalarFrame('diskWorst', 0.93, { instance: 'db-01:9100', mountpoint: '/srv' })]
     );
 
     const promise = fetchMetricsActivity(prom);

--- a/public/app/features/home/Recommendations/telemetryData.test.ts
+++ b/public/app/features/home/Recommendations/telemetryData.test.ts
@@ -1,5 +1,11 @@
 import { createDataFrame, type DataSourceInstanceListItem, FieldType } from '@grafana/data';
-import { type BackendSrv, type DataSourceWithBackend, getBackendSrv } from '@grafana/runtime';
+import {
+  type BackendSrv,
+  type DataSourceSrv,
+  type DataSourceWithBackend,
+  getBackendSrv,
+  getDataSourceSrv,
+} from '@grafana/runtime';
 
 import { resolveBackendInstance } from './probeUtils';
 import { runInstantQueries, runRangeQuery } from './promQuery';
@@ -26,12 +32,14 @@ jest.mock('./promQuery', () => ({
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
   getBackendSrv: jest.fn(),
+  getDataSourceSrv: jest.fn(),
 }));
 
 const mockResolveBackendInstance = jest.mocked(resolveBackendInstance);
 const mockRunInstantQueries = jest.mocked(runInstantQueries);
 const mockRunRangeQuery = jest.mocked(runRangeQuery);
 const mockProxyGet = jest.fn();
+const mockGetInstanceSettings = jest.fn();
 
 const DATA_LOOKBACK_HOURS = 24;
 const NS_IN_MS = 1e6;
@@ -53,6 +61,10 @@ beforeEach(() => {
   mockRunRangeQuery.mockReset();
   mockRunRangeQuery.mockResolvedValue([]);
   jest.mocked(getBackendSrv).mockReturnValue({ get: mockProxyGet } as unknown as BackendSrv);
+  mockGetInstanceSettings.mockReset();
+  jest.mocked(getDataSourceSrv).mockReturnValue({
+    getInstanceSettings: mockGetInstanceSettings,
+  } as unknown as DataSourceSrv);
 });
 
 afterEach(() => {
@@ -312,6 +324,26 @@ describe('fetchMetricsActivity', () => {
       { eta: expect.stringContaining('instance="web-03:9100"') },
       prom
     );
+  });
+
+  it('skips the head-series sparkline on Mimir/Cortex-backed datasources', async () => {
+    mockGetInstanceSettings.mockReturnValue({ jsonData: { prometheusType: 'Mimir' } });
+    const getResource = jest.fn(async (path: string) => {
+      if (path === 'api/v1/cardinality/label_values') {
+        return { series_count_total: 4_200_000 };
+      }
+      if (path === 'api/v1/label/__name__/values') {
+        return { data: ['up'] };
+      }
+      throw new Error(`unexpected path ${path}`);
+    });
+    mockResolveBackendInstance.mockResolvedValue(instanceWith(getResource));
+
+    const activity = await fetchMetricsActivity(prom);
+
+    expect(activity.series).toBe(4_200_000);
+    expect(activity.seriesSparkline).toBeNull();
+    expect(mockRunRangeQuery).not.toHaveBeenCalled();
   });
 
   it('falls back to TSDB head stats when the cardinality API is unavailable', async () => {

--- a/public/app/features/home/Recommendations/telemetryData.test.ts
+++ b/public/app/features/home/Recommendations/telemetryData.test.ts
@@ -331,6 +331,11 @@ describe('fetchMetricsActivity', () => {
 
     const end = Math.floor(Date.now() / 1000);
     expect(getResource).toHaveBeenCalledWith(
+      'api/v1/cardinality/label_values',
+      { 'label_names[]': '__name__', count_method: 'active' },
+      { showErrorAlert: false }
+    );
+    expect(getResource).toHaveBeenCalledWith(
       'api/v1/label/__name__/values',
       { start: end - METRICS_STATS_LOOKBACK_DAYS * 24 * 3600, end },
       { showErrorAlert: false }
@@ -403,15 +408,15 @@ describe('fetchMetricsActivity', () => {
 
     expect(mockRunInstantQueries).toHaveBeenCalledWith(
       {
-        activeSeries: 'sum(grafanacloud_instance_active_series{stack_id="12345"})',
-        dataPointsPerMinute: '60 * sum(grafanacloud_instance_samples_per_second{stack_id="12345"})',
+        activeSeries: 'sum(max by (id) (grafanacloud_instance_active_series{stack_id="12345"}))',
+        dataPointsPerMinute: '60 * sum(max by (id) (grafanacloud_instance_samples_per_second{stack_id="12345"}))',
       },
       { uid: 'grafanacloud-usage', type: 'prometheus' }
     );
     // The trend works on Cloud via usage metrics even though the product datasource is Mimir-typed.
     expect(mockRunRangeQuery).toHaveBeenCalledWith(
       'series',
-      'sum(grafanacloud_instance_active_series{stack_id="12345"})',
+      'sum(max by (id) (grafanacloud_instance_active_series{stack_id="12345"}))',
       DATA_LOOKBACK_HOURS,
       { uid: 'grafanacloud-usage', type: 'prometheus' }
     );

--- a/public/app/features/home/Recommendations/telemetryData.test.ts
+++ b/public/app/features/home/Recommendations/telemetryData.test.ts
@@ -102,6 +102,7 @@ describe('fetchLogsActivity', () => {
       if (path === 'index/volume_range') {
         return {
           data: {
+            // Prod aggregateBy=labels collapses this to one total series; two here pin the defensive cross-series sum.
             result: [
               {
                 metric: { service_name: 'a' },
@@ -195,6 +196,14 @@ describe('fetchLogsActivity', () => {
 
   it('reports nulls when no usable label exists', async () => {
     const getResource = jest.fn(async () => ({ data: ['__stream_shard__'] }));
+    mockResolveBackendInstance.mockResolvedValue(instanceWith(getResource));
+
+    await expect(fetchLogsActivity(loki)).resolves.toEqual({ bytes: null, sources: null, series: null });
+    expect(getResource).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports nulls when the labels lookup itself fails', async () => {
+    const getResource = jest.fn().mockRejectedValue(new Error('labels 403'));
     mockResolveBackendInstance.mockResolvedValue(instanceWith(getResource));
 
     await expect(fetchLogsActivity(loki)).resolves.toEqual({ bytes: null, sources: null, series: null });

--- a/public/app/features/home/Recommendations/telemetryData.test.ts
+++ b/public/app/features/home/Recommendations/telemetryData.test.ts
@@ -357,7 +357,9 @@ describe('fetchMetricsActivity', () => {
       expect.objectContaining({
         diskWorst: expect.stringMatching(/^topk\(1, \(1 - node_filesystem_avail_bytes\{/),
       }),
-      prom
+      prom,
+      undefined,
+      true
     );
     // The follow-up ETA query pins the exact filesystem shown: worst host AND its fullest mountpoint.
     expect(mockRunInstantQueries).toHaveBeenCalledWith(
@@ -424,7 +426,9 @@ describe('fetchMetricsActivity', () => {
         activeSeries: 'sum(max by (id) (grafanacloud_instance_active_series{stack_id="12345"}))',
         dataPointsPerMinute: '60 * sum(max by (id) (grafanacloud_instance_samples_per_second{stack_id="12345"}))',
       },
-      { uid: 'grafanacloud-usage', type: 'prometheus' }
+      { uid: 'grafanacloud-usage', type: 'prometheus' },
+      undefined,
+      true
     );
     // The trend works on Cloud via usage metrics even though the product datasource is Mimir-typed.
     expect(mockRunRangeQuery).toHaveBeenCalledWith(
@@ -510,7 +514,12 @@ describe('fetchMetricsActivity', () => {
 
     expect(mockGetDataSourceInstanceSettings).not.toHaveBeenCalledWith('grafanacloud-usage');
     expect(mockRunInstantQueries).toHaveBeenCalledTimes(1);
-    expect(mockRunInstantQueries).toHaveBeenCalledWith(expect.not.objectContaining({ dpm: expect.anything() }), prom);
+    expect(mockRunInstantQueries).toHaveBeenCalledWith(
+      expect.not.objectContaining({ dpm: expect.anything() }),
+      prom,
+      undefined,
+      true
+    );
     expect(activity.dataPointsPerMinute).toBeNull();
   });
 
@@ -523,7 +532,9 @@ describe('fetchMetricsActivity', () => {
 
     expect(mockRunInstantQueries).toHaveBeenCalledWith(
       expect.objectContaining({ dpm: '60 * sum(rate(prometheus_tsdb_head_samples_appended_total[5m]))' }),
-      prom
+      prom,
+      undefined,
+      true
     );
     expect(activity.dataPointsPerMinute).toBe(250_000);
   });
@@ -550,7 +561,9 @@ describe('fetchMetricsActivity', () => {
     expect(mockRunInstantQueries).toHaveBeenCalledTimes(1);
     expect(mockRunInstantQueries).toHaveBeenCalledWith(
       expect.objectContaining({ hosts: 'count(node_uname_info)' }),
-      prom
+      prom,
+      undefined,
+      true
     );
   });
 

--- a/public/app/features/home/Recommendations/telemetryData.ts
+++ b/public/app/features/home/Recommendations/telemetryData.ts
@@ -89,8 +89,7 @@ export async function fetchLogsActivity(ds: Pick<DataSourceInstanceListItem, 'ui
     return empty;
   }
   const query = `{${label}=~".+"}`;
-  // aggregateBy=labels collapses both volume responses to one server-side total series, so the
-  // per-query series limit cannot truncate what we present as a complete number.
+  // aggregateBy=labels totals by label NAME, not value — one series; Loki's series limit cannot truncate it.
   const aggregate = { aggregateBy: 'labels', targetLabels: label };
   const [volume, values, volumeRange] = await Promise.all([
     getResource<LokiVolumeResponse>(instance, 'index/volume', { query, start: statsStart, end, ...aggregate }).catch(

--- a/public/app/features/home/Recommendations/telemetryData.ts
+++ b/public/app/features/home/Recommendations/telemetryData.ts
@@ -5,7 +5,8 @@ import {
   FieldType,
   getMinMaxAndDelta,
 } from '@grafana/data';
-import { type DataSourceWithBackend } from '@grafana/runtime';
+import { PromApplication, type PromOptions } from '@grafana/prometheus';
+import { type DataSourceWithBackend, getDataSourceSrv } from '@grafana/runtime';
 
 import { probeProxyGet, PROBE_TIMEOUT_MS, resolveBackendInstance, withTimeout } from './probeUtils';
 import { readLabeledScalar, readScalar, readSeries, runInstantQueries, runRangeQuery } from './promQuery';
@@ -240,6 +241,23 @@ async function fetchDiskHoursToFull(
   return hours != null && hours > 0 && hours <= DISK_ETA_MAX_HOURS ? hours : null;
 }
 
+// prometheus_tsdb_head_series is a Prometheus self-monitoring metric. On multi-tenant
+// remote-write backends (Mimir/Cortex — every Grafana Cloud hosted datasource) any such
+// series was ingested from other Prometheus servers, so the trend would chart a foreign
+// population; skip rather than mislabel it. Vanilla/untyped datasources keep the query.
+async function fetchSeriesSparkline(
+  ds: Pick<DataSourceInstanceListItem, 'uid' | 'type'>
+): Promise<FieldSparkline | null> {
+  const jsonData = getDataSourceSrv().getInstanceSettings(ds.uid)?.jsonData as PromOptions | undefined;
+  const promType = jsonData?.prometheusType;
+  if (promType === PromApplication.Mimir || promType === PromApplication.Cortex) {
+    return null;
+  }
+  return runRangeQuery('series', 'sum(prometheus_tsdb_head_series)', DATA_LOOKBACK_HOURS, ds)
+    .then((frames) => readSeries(frames, 'series'))
+    .catch(() => null);
+}
+
 /**
  * Active-series count, metric-name count, node_exporter host count, the 24h active-series
  * sparkline, and disk pressure for the worst host. Every field fails soft to null; the card
@@ -262,9 +280,7 @@ export async function fetchMetricsActivity(
     getResource<{ data?: unknown }>(instance, 'api/v1/label/__name__/values', { start, end })
       .then((res) => (Array.isArray(res?.data) ? res.data.length : null))
       .catch(() => null),
-    runRangeQuery('series', 'sum(prometheus_tsdb_head_series)', DATA_LOOKBACK_HOURS, ds)
-      .then((frames) => readSeries(frames, 'series'))
-      .catch(() => null),
+    fetchSeriesSparkline(ds),
     runInstantQueries(
       {
         hosts: 'count(node_uname_info)',

--- a/public/app/features/home/Recommendations/telemetryData.ts
+++ b/public/app/features/home/Recommendations/telemetryData.ts
@@ -336,6 +336,8 @@ export async function fetchMetricsActivity(
       ? runRangeQuery('series', usage.activeSeries, DATA_LOOKBACK_HOURS, usage.ds)
           .then((frames) => readSeries(frames, 'series'))
           .catch(() => null)
+          // Zero-ingestion stacks have no usage series; chain the counts' self-monitoring fallback.
+          .then((sparkline) => sparkline ?? fetchSeriesSparkline(ds, mimir))
       : fetchSeriesSparkline(ds, mimir),
     runInstantQueries(
       {

--- a/public/app/features/home/Recommendations/telemetryData.ts
+++ b/public/app/features/home/Recommendations/telemetryData.ts
@@ -83,7 +83,7 @@ export async function fetchLogsActivity(ds: Pick<DataSourceInstanceListItem, 'ui
   }
   const end = Date.now() * NS_IN_MS;
   const statsStart = end - LOGS_STATS_LOOKBACK_DAYS * 24 * 3600 * NS_IN_S;
-  const label = await resolveLogsLabel(instance, statsStart, end);
+  const label = await resolveLogsLabel(instance, statsStart, end).catch(() => null);
   if (!label) {
     return empty;
   }
@@ -256,9 +256,10 @@ async function isMimirOrCortex(ds: Pick<DataSourceInstanceListItem, 'uid'>): Pro
 }
 
 async function fetchSeriesSparkline(
-  ds: Pick<DataSourceInstanceListItem, 'uid' | 'type'>
+  ds: Pick<DataSourceInstanceListItem, 'uid' | 'type'>,
+  mimir: boolean
 ): Promise<FieldSparkline | null> {
-  if (await isMimirOrCortex(ds)) {
+  if (mimir) {
     return null;
   }
   return runRangeQuery('series', 'sum(prometheus_tsdb_head_series)', DATA_LOOKBACK_HOURS, ds)
@@ -331,7 +332,7 @@ export async function fetchMetricsActivity(
       ? runRangeQuery('series', usage.activeSeries, DATA_LOOKBACK_HOURS, usage.ds)
           .then((frames) => readSeries(frames, 'series'))
           .catch(() => null)
-      : fetchSeriesSparkline(ds),
+      : fetchSeriesSparkline(ds, mimir),
     runInstantQueries(
       {
         ...(mimir ? {} : { dpm: PROM_DPM_QUERY }),

--- a/public/app/features/home/Recommendations/telemetryData.ts
+++ b/public/app/features/home/Recommendations/telemetryData.ts
@@ -62,7 +62,8 @@ function toSparkline(points: Array<[number, number]>, name: string): FieldSparkl
   return { x, y: { ...y, state: { range: getMinMaxAndDelta(y) } } };
 }
 
-// Loki rejects matcher-less queries; pick the label the org's streams actually carry.
+// Loki rejects matcher-less queries. service_name/job cover conventional setups; otherwise
+// best effort — streams missing the fallback label drop out of the totals.
 async function resolveLogsLabel(instance: DataSourceWithBackend, start: number, end: number): Promise<string | null> {
   const res = await getResource<{ data?: unknown }>(instance, 'labels', { start, end });
   const labels = Array.isArray(res?.data)
@@ -123,8 +124,9 @@ export async function fetchLogsActivity(ds: Pick<DataSourceInstanceListItem, 'ui
 }
 
 /**
- * Distinct services seen by Tempo in the lookback, or null when the lookup fails. Uses the
- * datasource proxy: Tempo's resource router 404s these paths on cloud stacks.
+ * Distinct services seen by Tempo in the lookback, or null when the response is unusable;
+ * rejections propagate (callers fail soft). Uses the datasource proxy: Tempo's resource router
+ * 404s these paths on cloud stacks.
  */
 export async function fetchTracesServices(ds: Pick<DataSourceInstanceListItem, 'uid'>): Promise<number | null> {
   const end = Math.floor(Date.now() / 1000);

--- a/public/app/features/home/Recommendations/telemetryData.ts
+++ b/public/app/features/home/Recommendations/telemetryData.ts
@@ -1,0 +1,292 @@
+import {
+  type DataSourceInstanceListItem,
+  type Field,
+  type FieldSparkline,
+  FieldType,
+  getMinMaxAndDelta,
+} from '@grafana/data';
+import { type DataSourceWithBackend } from '@grafana/runtime';
+
+import { probeProxyGet, PROBE_TIMEOUT_MS, resolveBackendInstance, withTimeout } from './probeUtils';
+import { readLabeledScalar, readScalar, readSeries, runInstantQueries, runRangeQuery } from './promQuery';
+import { DATA_LOOKBACK_HOURS } from './solutionDataProbes';
+
+/** Stats window for the logs card (design-fixed), distinct from the 24h sparkline lookback. */
+export const LOGS_STATS_LOOKBACK_DAYS = 7;
+
+/** Stats window for the metric-name fallback count (design-fixed), distinct from the 24h lookback. */
+export const METRICS_STATS_LOOKBACK_DAYS = 7;
+
+const NS_IN_MS = 1e6;
+const NS_IN_S = 1e9;
+
+export interface LogsActivity {
+  bytes: number | null;
+  sources: number | null;
+  series: FieldSparkline | null;
+}
+
+export interface TracesActivity {
+  spans: number | null;
+  series: FieldSparkline | null;
+}
+
+interface LokiVolumeResponse {
+  data?: { result?: Array<{ value?: [number, string] }> };
+}
+
+interface LokiVolumeRangeResponse {
+  data?: { result?: Array<{ values?: Array<[number, string]> }> };
+}
+
+interface TempoTagValuesResponse {
+  tagValues?: Array<{ value?: string }>;
+}
+
+// Failures are expected (endpoint disabled, 403s) and handled by the caller; never toast.
+function getResource<T>(instance: DataSourceWithBackend, path: string, params: Record<string, unknown>): Promise<T> {
+  return withTimeout(instance.getResource<T>(path, params, { showErrorAlert: false }), PROBE_TIMEOUT_MS);
+}
+
+// Points are [unix ms, value]; a real trend needs at least two of them.
+function toSparkline(points: Array<[number, number]>, name: string): FieldSparkline | null {
+  if (points.length < 2) {
+    return null;
+  }
+  points.sort(([a], [b]) => a - b);
+  const x: Field = { name: 'Time', type: FieldType.time, values: points.map(([ts]) => ts), config: {} };
+  const y: Field = { name, type: FieldType.number, values: points.map(([, value]) => value), config: {} };
+  return { x, y: { ...y, state: { range: getMinMaxAndDelta(y) } } };
+}
+
+// Loki rejects matcher-less queries; pick the label the org's streams actually carry.
+async function resolveLogsLabel(instance: DataSourceWithBackend, start: number, end: number): Promise<string | null> {
+  const res = await getResource<{ data?: unknown }>(instance, 'labels', { start, end });
+  const labels = Array.isArray(res?.data)
+    ? res.data.filter((label): label is string => typeof label === 'string' && !label.startsWith('__'))
+    : [];
+  return ['service_name', 'job'].find((preferred) => labels.includes(preferred)) ?? labels[0] ?? null;
+}
+
+/**
+ * Ingested bytes and distinct sources over the stats window plus the 24h ingest-volume
+ * sparkline, all riding Loki's index (cheap even over 7d). Each field fails soft to null.
+ */
+export async function fetchLogsActivity(ds: Pick<DataSourceInstanceListItem, 'uid'>): Promise<LogsActivity> {
+  const empty: LogsActivity = { bytes: null, sources: null, series: null };
+  const instance = await resolveBackendInstance(ds.uid);
+  if (!instance) {
+    return empty;
+  }
+  const end = Date.now() * NS_IN_MS;
+  const statsStart = end - LOGS_STATS_LOOKBACK_DAYS * 24 * 3600 * NS_IN_S;
+  const label = await resolveLogsLabel(instance, statsStart, end);
+  if (!label) {
+    return empty;
+  }
+  const query = `{${label}=~".+"}`;
+  // aggregateBy=labels collapses both volume responses to one server-side total series, so the
+  // per-query series limit cannot truncate what we present as a complete number.
+  const aggregate = { aggregateBy: 'labels', targetLabels: label };
+  const [volume, values, volumeRange] = await Promise.all([
+    getResource<LokiVolumeResponse>(instance, 'index/volume', { query, start: statsStart, end, ...aggregate }).catch(
+      () => null
+    ),
+    getResource<{ data?: unknown }>(instance, `label/${encodeURIComponent(label)}/values`, {
+      start: statsStart,
+      end,
+    }).catch(() => null),
+    getResource<LokiVolumeRangeResponse>(instance, 'index/volume_range', {
+      query,
+      start: end - DATA_LOOKBACK_HOURS * 3600 * NS_IN_S,
+      end,
+      step: '30m',
+      ...aggregate,
+    }).catch(() => null),
+  ]);
+  const volumes = volume?.data?.result;
+  // Sum the (single-series) matrix into ingest buckets (timestamps are unix seconds).
+  const buckets = new Map<number, number>();
+  for (const series of volumeRange?.data?.result ?? []) {
+    for (const [ts, value] of series.values ?? []) {
+      buckets.set(ts * 1000, (buckets.get(ts * 1000) ?? 0) + (Number(value) || 0));
+    }
+  }
+  return {
+    bytes: Array.isArray(volumes) ? volumes.reduce((total, entry) => total + (Number(entry.value?.[1]) || 0), 0) : null,
+    sources: Array.isArray(values?.data) ? values.data.length : null,
+    series: toSparkline([...buckets.entries()], 'Ingest volume'),
+  };
+}
+
+/**
+ * Distinct services seen by Tempo in the lookback, or null when the lookup fails. Uses the
+ * datasource proxy: Tempo's resource router 404s these paths on cloud stacks.
+ */
+export async function fetchTracesServices(ds: Pick<DataSourceInstanceListItem, 'uid'>): Promise<number | null> {
+  const end = Math.floor(Date.now() / 1000);
+  const start = end - DATA_LOOKBACK_HOURS * 3600;
+  const res = await probeProxyGet<TempoTagValuesResponse>(ds.uid, 'api/v2/search/tag/resource.service.name/values', {
+    start,
+    end,
+  });
+  return Array.isArray(res?.tagValues) ? res.tagValues.length : null;
+}
+
+interface TempoQueryRangeResponse {
+  series?: Array<{ samples?: Array<{ timestampMs?: string | number; value?: number }> }>;
+}
+
+/**
+ * Span throughput over the last 24h via Tempo's TraceQL-metrics HTTP API: the summed series
+ * feeds the sparkline, its integral is the span count. Datasource proxy on purpose — the
+ * frontend query path rebuilds raw targets on some plugin versions. Needs the
+ * metrics-generator; callers fail soft on rejection.
+ */
+export async function fetchTracesActivity(ds: Pick<DataSourceInstanceListItem, 'uid'>): Promise<TracesActivity> {
+  const end = Math.floor(Date.now() / 1000);
+  const start = end - DATA_LOOKBACK_HOURS * 3600;
+  const res = await probeProxyGet<TempoQueryRangeResponse>(ds.uid, 'api/metrics/query_range', {
+    q: '{} | count_over_time()',
+    start,
+    end,
+    step: '30m',
+  });
+  const buckets = new Map<number, number>();
+  for (const series of res?.series ?? []) {
+    for (const sample of series.samples ?? []) {
+      // Sparse samples: zero buckets may be omitted; values may arrive as strings.
+      const ts = Number(sample.timestampMs);
+      const value = Number(sample.value ?? 0);
+      if (Number.isFinite(ts) && Number.isFinite(value)) {
+        buckets.set(ts, (buckets.get(ts) ?? 0) + value);
+      }
+    }
+  }
+  return {
+    spans: buckets.size > 0 ? [...buckets.values()].reduce((total, value) => total + value, 0) : null,
+    series: toSparkline([...buckets.entries()], 'Span throughput'),
+  };
+}
+
+interface MetricsDiskPressure {
+  /** Hosts whose fullest filesystem exceeds the pressure threshold. */
+  hostsAbove: number;
+  worstInstance: string | null;
+  /** 0..1 fill ratio of the worst host. */
+  worstRatio: number | null;
+  /** Linear fill ETA for the worst host; null when not shrinking or beyond the clamp. */
+  hoursToFull: number | null;
+}
+
+export interface MetricsActivity {
+  /** Active series (cardinality API / TSDB head stats). */
+  series: number | null;
+  /** Distinct metric names over the stats window (fallback primary). */
+  names: number | null;
+  /** node_exporter host count. */
+  hosts: number | null;
+  /** Active-series trend over the last 24h. */
+  seriesSparkline: FieldSparkline | null;
+  /** null when below threshold or node metrics absent. */
+  disk: MetricsDiskPressure | null;
+}
+
+// Threshold and ETA clamp for the disk-pressure alert row (design/judgment constants).
+const DISK_PRESSURE_RATIO = 0.9;
+const DISK_ETA_MAX_HOURS = 48;
+
+const FS_EXCLUDE = 'fstype!~"tmpfs|overlay|squashfs|iso9660|ramfs"';
+// Fullest-filesystem fill ratio per host; pseudo filesystems excluded.
+const FS_USED = `(1 - node_filesystem_avail_bytes{${FS_EXCLUDE}} / node_filesystem_size_bytes{${FS_EXCLUDE}})`;
+
+// Active series, cloud-first: Mimir's cardinality API, then vanilla Prometheus TSDB head stats.
+// Both absent/broken → null and the metric-name count carries the card instead.
+async function fetchActiveSeries(instance: DataSourceWithBackend): Promise<number | null> {
+  const cardinality = await getResource<{ series_count_total?: unknown }>(instance, 'api/v1/cardinality/label_values', {
+    'label_names[]': '__name__',
+  })
+    .then((res) => Number(res?.series_count_total))
+    .catch(() => null);
+  if (cardinality != null && Number.isFinite(cardinality) && cardinality > 0) {
+    return cardinality;
+  }
+  const headSeries = await getResource<{ data?: { headStats?: { numSeries?: unknown } } }>(
+    instance,
+    'api/v1/status/tsdb',
+    {}
+  )
+    .then((res) => Number(res?.data?.headStats?.numSeries))
+    .catch(() => null);
+  return headSeries != null && Number.isFinite(headSeries) && headSeries > 0 ? headSeries : null;
+}
+
+// Linear ETA until the worst host's fastest-shrinking filesystem fills. Growing/steady
+// filesystems drop out via `> 0`; past the clamp a linear estimate is noise.
+async function fetchDiskHoursToFull(
+  instanceLabel: string,
+  ds: Pick<DataSourceInstanceListItem, 'uid' | 'type'>
+): Promise<number | null> {
+  const escaped = instanceLabel.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  const selector = `{instance="${escaped}",${FS_EXCLUDE}}`;
+  const hours = await runInstantQueries(
+    {
+      eta: `min((node_filesystem_avail_bytes${selector} / -deriv(node_filesystem_avail_bytes${selector}[6h])) > 0) / 3600`,
+    },
+    ds
+  )
+    .then((frames) => readScalar(frames, 'eta'))
+    .catch(() => null);
+  return hours != null && hours > 0 && hours <= DISK_ETA_MAX_HOURS ? hours : null;
+}
+
+/**
+ * Active-series count, metric-name count, node_exporter host count, the 24h active-series
+ * sparkline, and disk pressure for the worst host. Every field fails soft to null; the card
+ * drops when nothing renderable remains. Never a matcher-less series query — cardinality on
+ * large tenants is prohibitive.
+ */
+export async function fetchMetricsActivity(
+  ds: Pick<DataSourceInstanceListItem, 'uid' | 'type'>
+): Promise<MetricsActivity> {
+  const empty: MetricsActivity = { series: null, names: null, hosts: null, seriesSparkline: null, disk: null };
+  const instance = await resolveBackendInstance(ds.uid);
+  if (!instance) {
+    return empty;
+  }
+  // Prometheus resource calls take epoch seconds (unlike Loki's nanoseconds above).
+  const end = Math.floor(Date.now() / 1000);
+  const start = end - METRICS_STATS_LOOKBACK_DAYS * 24 * 3600;
+  const [series, names, seriesSparkline, healthFrames] = await Promise.all([
+    fetchActiveSeries(instance),
+    getResource<{ data?: unknown }>(instance, 'api/v1/label/__name__/values', { start, end })
+      .then((res) => (Array.isArray(res?.data) ? res.data.length : null))
+      .catch(() => null),
+    runRangeQuery('series', 'sum(prometheus_tsdb_head_series)', DATA_LOOKBACK_HOURS, ds)
+      .then((frames) => readSeries(frames, 'series'))
+      .catch(() => null),
+    runInstantQueries(
+      {
+        hosts: 'count(node_uname_info)',
+        diskHosts: `count(max by (instance) (${FS_USED}) > ${DISK_PRESSURE_RATIO})`,
+        diskWorst: `topk(1, max by (instance) (${FS_USED}))`,
+      },
+      ds
+    ).catch(() => null),
+  ]);
+  const hosts = healthFrames ? readScalar(healthFrames, 'hosts') : null;
+  // Empty diskHosts vector (nobody above threshold) reads as null — zero here.
+  const hostsAbove = healthFrames ? (readScalar(healthFrames, 'diskHosts') ?? 0) : 0;
+  const worst = healthFrames ? readLabeledScalar(healthFrames, 'diskWorst', 'instance') : null;
+  let disk: MetricsDiskPressure | null = null;
+  if (hostsAbove >= 1) {
+    const worstInstance = worst?.label ?? null;
+    disk = {
+      hostsAbove,
+      worstInstance,
+      worstRatio: worst?.value ?? null,
+      hoursToFull: worstInstance ? await fetchDiskHoursToFull(worstInstance, ds) : null,
+    };
+  }
+  return { series, names, hosts, seriesSparkline, disk };
+}

--- a/public/app/features/home/Recommendations/telemetryData.ts
+++ b/public/app/features/home/Recommendations/telemetryData.ts
@@ -6,9 +6,9 @@ import {
   FieldType,
   getMinMaxAndDelta,
 } from '@grafana/data';
-import { PromApplication } from '@grafana/prometheus';
 import { type DataSourceWithBackend } from '@grafana/runtime';
 import { getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
+import { PromApplication } from 'app/types/unified-alerting-dto';
 
 import { probeProxyGet, PROBE_TIMEOUT_MS, resolveBackendInstance, withTimeout } from './probeUtils';
 import { readLabeledScalar, readScalar, readSeries, runInstantQueries, runRangeQuery } from './promQuery';

--- a/public/app/features/home/Recommendations/telemetryData.ts
+++ b/public/app/features/home/Recommendations/telemetryData.ts
@@ -179,7 +179,7 @@ interface MetricsDiskPressure {
   worstInstance: string | null;
   /** 0..1 fill ratio of the worst host. */
   worstRatio: number | null;
-  /** Linear fill ETA for the worst host; null when not shrinking or beyond the clamp. */
+  /** Linear fill ETA for the shown filesystem; null when it cannot be identified, is not shrinking, or is beyond the clamp. */
   hoursToFull: number | null;
 }
 
@@ -203,7 +203,7 @@ const DISK_PRESSURE_RATIO = 0.9;
 const DISK_ETA_MAX_HOURS = 48;
 
 const FS_EXCLUDE = 'fstype!~"tmpfs|overlay|squashfs|iso9660|ramfs"';
-// Fullest-filesystem fill ratio per host; pseudo filesystems excluded.
+// Per-filesystem fill ratio; pseudo filesystems excluded.
 const FS_USED = `(1 - node_filesystem_avail_bytes{${FS_EXCLUDE}} / node_filesystem_size_bytes{${FS_EXCLUDE}})`;
 
 // Active series, cloud-first: Mimir's cardinality API, then vanilla Prometheus TSDB head stats.
@@ -229,14 +229,15 @@ async function fetchActiveSeries(instance: DataSourceWithBackend): Promise<numbe
   return headSeries != null && Number.isFinite(headSeries) && headSeries > 0 ? headSeries : null;
 }
 
-// Linear ETA until the worst host's fastest-shrinking filesystem fills. Growing/steady
-// filesystems drop out via `> 0`; past the clamp a linear estimate is noise.
+// Linear ETA until the shown (fullest) filesystem fills. Growing/steady filesystems drop
+// out via `> 0`; past the clamp a linear estimate is noise.
 async function fetchDiskHoursToFull(
   instanceLabel: string,
+  mountpoint: string,
   ds: Pick<DataSourceInstanceListItem, 'uid' | 'type'>
 ): Promise<number | null> {
-  const escaped = instanceLabel.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-  const selector = `{instance="${escaped}",${FS_EXCLUDE}}`;
+  const esc = (v: string) => v.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  const selector = `{instance="${esc(instanceLabel)}",mountpoint="${esc(mountpoint)}",${FS_EXCLUDE}}`;
   const hours = await runInstantQueries(
     {
       eta: `min((node_filesystem_avail_bytes${selector} / -deriv(node_filesystem_avail_bytes${selector}[6h])) > 0) / 3600`,
@@ -344,7 +345,7 @@ export async function fetchMetricsActivity(
         ...(mimir ? {} : { dpm: PROM_DPM_QUERY }),
         hosts: 'count(node_uname_info)',
         diskHosts: `count(max by (instance) (${FS_USED}) > ${DISK_PRESSURE_RATIO})`,
-        diskWorst: `topk(1, max by (instance) (${FS_USED}))`,
+        diskWorst: `topk(1, ${FS_USED})`,
       },
       ds
     ).catch(() => null),
@@ -368,6 +369,7 @@ export async function fetchMetricsActivity(
   // Empty diskHosts vector (nobody above threshold) reads as null — zero here.
   const hostsAbove = healthFrames ? (readScalar(healthFrames, 'diskHosts') ?? 0) : 0;
   const worst = healthFrames ? readLabeledScalar(healthFrames, 'diskWorst', 'instance') : null;
+  const worstMount = healthFrames ? (readLabeledScalar(healthFrames, 'diskWorst', 'mountpoint')?.label ?? null) : null;
   let disk: MetricsDiskPressure | null = null;
   if (hostsAbove >= 1) {
     const worstInstance = worst?.label ?? null;
@@ -375,7 +377,7 @@ export async function fetchMetricsActivity(
       hostsAbove,
       worstInstance,
       worstRatio: worst?.value ?? null,
-      hoursToFull: worstInstance ? await fetchDiskHoursToFull(worstInstance, ds) : null,
+      hoursToFull: worstInstance && worstMount ? await fetchDiskHoursToFull(worstInstance, worstMount, ds) : null,
     };
   }
   return { series: usageSeries ?? series, dataPointsPerMinute, names, hosts, seriesSparkline, disk };

--- a/public/app/features/home/Recommendations/telemetryData.ts
+++ b/public/app/features/home/Recommendations/telemetryData.ts
@@ -5,7 +5,7 @@ import {
   FieldType,
   getMinMaxAndDelta,
 } from '@grafana/data';
-import { PromApplication, type PromOptions } from '@grafana/prometheus';
+import { PromApplication } from '@grafana/prometheus';
 import { type DataSourceWithBackend, getDataSourceSrv } from '@grafana/runtime';
 
 import { probeProxyGet, PROBE_TIMEOUT_MS, resolveBackendInstance, withTimeout } from './probeUtils';
@@ -248,8 +248,8 @@ async function fetchDiskHoursToFull(
 async function fetchSeriesSparkline(
   ds: Pick<DataSourceInstanceListItem, 'uid' | 'type'>
 ): Promise<FieldSparkline | null> {
-  const jsonData = getDataSourceSrv().getInstanceSettings(ds.uid)?.jsonData as PromOptions | undefined;
-  const promType = jsonData?.prometheusType;
+  const jsonData = getDataSourceSrv().getInstanceSettings(ds.uid)?.jsonData;
+  const promType = jsonData && 'prometheusType' in jsonData ? jsonData.prometheusType : undefined;
   if (promType === PromApplication.Mimir || promType === PromApplication.Cortex) {
     return null;
   }

--- a/public/app/features/home/Recommendations/telemetryData.ts
+++ b/public/app/features/home/Recommendations/telemetryData.ts
@@ -210,6 +210,8 @@ const FS_USED = `(1 - node_filesystem_avail_bytes{${FS_EXCLUDE}} / node_filesyst
 async function fetchActiveSeries(instance: DataSourceWithBackend): Promise<number | null> {
   const cardinality = await getResource<{ series_count_total?: unknown }>(instance, 'api/v1/cardinality/label_values', {
     'label_names[]': '__name__',
+    // Mimir defaults count_method to inmemory, which also counts stale series held in open TSDB heads.
+    count_method: 'active',
   })
     .then((res) => Number(res?.series_count_total))
     .catch(() => null);
@@ -293,8 +295,9 @@ async function resolveUsageQueries(): Promise<UsageQueries | null> {
   }
   return {
     ds: { uid: usage.uid, type: usage.type },
-    activeSeries: `sum(grafanacloud_instance_active_series{stack_id="${stackId}"})`,
-    dataPointsPerMinute: `60 * sum(grafanacloud_instance_samples_per_second{stack_id="${stackId}"})`,
+    // max by (id) dedupes HA-duplicate usage series before the stack-wide sum.
+    activeSeries: `sum(max by (id) (grafanacloud_instance_active_series{stack_id="${stackId}"}))`,
+    dataPointsPerMinute: `60 * sum(max by (id) (grafanacloud_instance_samples_per_second{stack_id="${stackId}"}))`,
   };
 }
 

--- a/public/app/features/home/Recommendations/telemetryData.ts
+++ b/public/app/features/home/Recommendations/telemetryData.ts
@@ -1,3 +1,4 @@
+import { getAPINamespace } from '@grafana/api-clients';
 import {
   type DataSourceInstanceListItem,
   type Field,
@@ -6,7 +7,8 @@ import {
   getMinMaxAndDelta,
 } from '@grafana/data';
 import { PromApplication } from '@grafana/prometheus';
-import { type DataSourceWithBackend, getDataSourceSrv } from '@grafana/runtime';
+import { type DataSourceWithBackend } from '@grafana/runtime';
+import { getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 
 import { probeProxyGet, PROBE_TIMEOUT_MS, resolveBackendInstance, withTimeout } from './probeUtils';
 import { readLabeledScalar, readScalar, readSeries, runInstantQueries, runRangeQuery } from './promQuery';
@@ -183,6 +185,8 @@ interface MetricsDiskPressure {
 export interface MetricsActivity {
   /** Active series (cardinality API / TSDB head stats). */
   series: number | null;
+  /** Ingest rate (stack-scoped usage metrics, else Prometheus self-monitoring). */
+  dataPointsPerMinute: number | null;
   /** Distinct metric names over the stats window (fallback primary). */
   names: number | null;
   /** node_exporter host count. */
@@ -245,17 +249,52 @@ async function fetchDiskHoursToFull(
 // remote-write backends (Mimir/Cortex — every Grafana Cloud hosted datasource) any such
 // series was ingested from other Prometheus servers, so the trend would chart a foreign
 // population; skip rather than mislabel it. Vanilla/untyped datasources keep the query.
+async function isMimirOrCortex(ds: Pick<DataSourceInstanceListItem, 'uid'>): Promise<boolean> {
+  const jsonData = (await getDataSourceInstanceSettings(ds.uid))?.jsonData;
+  const promType = jsonData && 'prometheusType' in jsonData ? jsonData.prometheusType : undefined;
+  return promType === PromApplication.Mimir || promType === PromApplication.Cortex;
+}
+
 async function fetchSeriesSparkline(
   ds: Pick<DataSourceInstanceListItem, 'uid' | 'type'>
 ): Promise<FieldSparkline | null> {
-  const jsonData = getDataSourceSrv().getInstanceSettings(ds.uid)?.jsonData;
-  const promType = jsonData && 'prometheusType' in jsonData ? jsonData.prometheusType : undefined;
-  if (promType === PromApplication.Mimir || promType === PromApplication.Cortex) {
+  if (await isMimirOrCortex(ds)) {
     return null;
   }
   return runRangeQuery('series', 'sum(prometheus_tsdb_head_series)', DATA_LOOKBACK_HOURS, ds)
     .then((frames) => readSeries(frames, 'series'))
     .catch(() => null);
+}
+
+const CLOUD_USAGE_DATASOURCE_UID = 'grafanacloud-usage';
+// Same self-monitoring trust story as prometheus_tsdb_head_series: skip on Mimir/Cortex.
+const PROM_DPM_QUERY = '60 * sum(rate(prometheus_tsdb_head_samples_appended_total[5m]))';
+
+interface UsageQueries {
+  ds: Pick<DataSourceInstanceListItem, 'uid' | 'type'>;
+  activeSeries: string;
+  dataPointsPerMinute: string;
+}
+
+/**
+ * Stack-scoped usage queries when this Grafana is a Cloud stack with the usage datasource;
+ * never query the shared usage datasource without a stack scope.
+ */
+async function resolveUsageQueries(): Promise<UsageQueries | null> {
+  const namespace = getAPINamespace();
+  const stackId = namespace.startsWith('stacks-') ? namespace.slice('stacks-'.length) : '';
+  if (!stackId) {
+    return null;
+  }
+  const usage = await getDataSourceInstanceSettings(CLOUD_USAGE_DATASOURCE_UID);
+  if (!usage || usage.type !== 'prometheus') {
+    return null;
+  }
+  return {
+    ds: { uid: usage.uid, type: usage.type },
+    activeSeries: `sum(grafanacloud_instance_active_series{stack_id="${stackId}"})`,
+    dataPointsPerMinute: `60 * sum(grafanacloud_instance_samples_per_second{stack_id="${stackId}"})`,
+  };
 }
 
 /**
@@ -267,29 +306,57 @@ async function fetchSeriesSparkline(
 export async function fetchMetricsActivity(
   ds: Pick<DataSourceInstanceListItem, 'uid' | 'type'>
 ): Promise<MetricsActivity> {
-  const empty: MetricsActivity = { series: null, names: null, hosts: null, seriesSparkline: null, disk: null };
+  const empty: MetricsActivity = {
+    series: null,
+    dataPointsPerMinute: null,
+    names: null,
+    hosts: null,
+    seriesSparkline: null,
+    disk: null,
+  };
   const instance = await resolveBackendInstance(ds.uid);
   if (!instance) {
     return empty;
   }
+  const [usage, mimir] = await Promise.all([resolveUsageQueries(), isMimirOrCortex(ds)]);
   // Prometheus resource calls take epoch seconds (unlike Loki's nanoseconds above).
   const end = Math.floor(Date.now() / 1000);
   const start = end - METRICS_STATS_LOOKBACK_DAYS * 24 * 3600;
-  const [series, names, seriesSparkline, healthFrames] = await Promise.all([
+  const [series, names, seriesSparkline, healthFrames, usageStats] = await Promise.all([
     fetchActiveSeries(instance),
     getResource<{ data?: unknown }>(instance, 'api/v1/label/__name__/values', { start, end })
       .then((res) => (Array.isArray(res?.data) ? res.data.length : null))
       .catch(() => null),
-    fetchSeriesSparkline(ds),
+    usage
+      ? runRangeQuery('series', usage.activeSeries, DATA_LOOKBACK_HOURS, usage.ds)
+          .then((frames) => readSeries(frames, 'series'))
+          .catch(() => null)
+      : fetchSeriesSparkline(ds),
     runInstantQueries(
       {
+        ...(mimir ? {} : { dpm: PROM_DPM_QUERY }),
         hosts: 'count(node_uname_info)',
         diskHosts: `count(max by (instance) (${FS_USED}) > ${DISK_PRESSURE_RATIO})`,
         diskWorst: `topk(1, max by (instance) (${FS_USED}))`,
       },
       ds
     ).catch(() => null),
+    usage
+      ? runInstantQueries(
+          { activeSeries: usage.activeSeries, dataPointsPerMinute: usage.dataPointsPerMinute },
+          usage.ds
+        )
+          .then((frames) => ({
+            series: readScalar(frames, 'activeSeries'),
+            dpm: readScalar(frames, 'dataPointsPerMinute'),
+          }))
+          .catch(() => null)
+      : Promise.resolve(null),
   ]);
+  const usageSeries = usageStats?.series != null && usageStats.series > 0 ? usageStats.series : null;
+  const promDpm = healthFrames ? readScalar(healthFrames, 'dpm') : null;
+  const usageDpm = usageStats?.dpm != null && usageStats.dpm > 0 ? usageStats.dpm : null;
+  const dataPointsPerMinute = usageDpm ?? (promDpm != null && promDpm > 0 ? promDpm : null);
   const hosts = healthFrames ? readScalar(healthFrames, 'hosts') : null;
   // Empty diskHosts vector (nobody above threshold) reads as null — zero here.
   const hostsAbove = healthFrames ? (readScalar(healthFrames, 'diskHosts') ?? 0) : 0;
@@ -304,5 +371,5 @@ export async function fetchMetricsActivity(
       hoursToFull: worstInstance ? await fetchDiskHoursToFull(worstInstance, ds) : null,
     };
   }
-  return { series, names, hosts, seriesSparkline, disk };
+  return { series: usageSeries ?? series, dataPointsPerMinute, names, hosts, seriesSparkline, disk };
 }

--- a/public/app/features/home/Recommendations/telemetryData.ts
+++ b/public/app/features/home/Recommendations/telemetryData.ts
@@ -347,12 +347,18 @@ export async function fetchMetricsActivity(
         diskHosts: `count(max by (instance) (${FS_USED}) > ${DISK_PRESSURE_RATIO})`,
         diskWorst: `topk(1, ${FS_USED})`,
       },
-      ds
+      ds,
+      undefined,
+      // partial: readers are null-safe; one failed query keeps the rest.
+      true
     ).catch(() => null),
     usage
       ? runInstantQueries(
           { activeSeries: usage.activeSeries, dataPointsPerMinute: usage.dataPointsPerMinute },
-          usage.ds
+          usage.ds,
+          undefined,
+          // partial: readers are null-safe; one failed query keeps the rest.
+          true
         )
           .then((frames) => ({
             series: readScalar(frames, 'activeSeries'),


### PR DESCRIPTION
**What is this feature?**

Adds the telemetry activity fetchers behind the homepage left card:

- logs: 7-day Loki stats (streams/entries) plus a 24h volume sparkline,
- traces: 24h trace activity and distinct service count off Tempo's APIs,
- metrics: active series, metric names, node_exporter host count, a series sparkline, and a disk-pressure summary (worst host, fill ETA).

Also adds `readLabeledScalar` to the promQuery helpers (last sample of an instant vector plus one identifying label).

**Special notes for your reviewer:**

Fetchers are read-only data plumbing with their own tests; the hooks that surface them on the homepage land in the next PR of the stack.
