### PR TITLE
Home: show live existing solutions and no-data cards

### DIFF
--- a/packages/grafana-data/src/types/plugin.ts
+++ b/packages/grafana-data/src/types/plugin.ts
@@ -180,6 +180,10 @@ export interface PluginInclude {
   // Adds the "page" or "dashboard" type includes to the navigation if set to `true`.
   addToNav?: boolean;
 
+  // Marks the app's default page: the one the app root URL resolves to. Serialized by the
+  // plugin settings endpoints; at most one include should set it.
+  defaultNav?: boolean;
+
   // Angular app pages
   component?: string;
 

--- a/public/app/features/datasources/utils.ts
+++ b/public/app/features/datasources/utils.ts
@@ -1,6 +1,6 @@
-import { type DataSourceJsonData, type DataSourceSettings, urlUtil, locationUtil } from '@grafana/data';
+import { type DataSourceSettings, urlUtil, locationUtil } from '@grafana/data';
 
-export const constructDataSourceExploreUrl = (dataSource: DataSourceSettings<DataSourceJsonData, {}>) => {
+export const constructDataSourceExploreUrl = (dataSource: Pick<DataSourceSettings, 'name'>) => {
   const exploreState = JSON.stringify({ datasource: dataSource.name, context: 'explore' });
   const exploreUrl = urlUtil.renderUrl(locationUtil.assureBaseUrl('/explore'), { left: exploreState });
 

--- a/public/app/features/home/Recommendations/ExistingSolutionCard.tsx
+++ b/public/app/features/home/Recommendations/ExistingSolutionCard.tsx
@@ -8,12 +8,13 @@ import { Button, Dropdown, Icon, LinkButton, Menu, Stack, Text, useStyles2 } fro
 import { ctaClicked } from '../analytics/main';
 
 import { SolutionSparkline } from './SolutionSparkline';
+import { type ExistingSolutionId } from './solutionsMatrix';
 import { type ExistingItem } from './types';
 
 interface ExistingSolutionCardProps {
   existing: ExistingItem[];
   selected: ExistingItem;
-  onSelect: (title: string) => void;
+  onSelect: (id: ExistingSolutionId) => void;
 }
 
 export function ExistingSolutionCard({ existing, selected, onSelect }: ExistingSolutionCardProps) {
@@ -44,9 +45,9 @@ export function ExistingSolutionCard({ existing, selected, onSelect }: ExistingS
                           solution: item.id,
                         });
                       }
-                      onSelect(item.title);
+                      onSelect(item.id);
                     }}
-                    component={item.title === selected.title ? SelectedCheck : undefined}
+                    component={item.id === selected.id ? SelectedCheck : undefined}
                   />
                 ))}
               </Menu.Group>

--- a/public/app/features/home/Recommendations/NoDataCard.test.tsx
+++ b/public/app/features/home/Recommendations/NoDataCard.test.tsx
@@ -49,6 +49,14 @@ describe('NoDataCard', () => {
     expect(screen.getByRole('link', { name: /Connect a data source/ })).toBeInTheDocument();
   });
 
+  it('renders neutral copy for the unknown variant, never claiming data flows', () => {
+    render(<NoDataCard variant="unknown" />);
+
+    expect(screen.getByRole('heading', { name: 'Add more telemetry', level: 3 })).toBeInTheDocument();
+    expect(screen.getByText(/We couldn't confirm live data yet/)).toBeInTheDocument();
+    expect(screen.queryByText(/Some signals are already flowing/)).not.toBeInTheDocument();
+  });
+
   it('links the popular solutions to a prefilled catalog search when the apps are not available', () => {
     setAvailableApps([]);
 

--- a/public/app/features/home/Recommendations/NoDataCard.test.tsx
+++ b/public/app/features/home/Recommendations/NoDataCard.test.tsx
@@ -41,6 +41,14 @@ describe('NoDataCard', () => {
     expect(screen.getByText('Popular solutions')).toBeInTheDocument();
   });
 
+  it('renders the softened copy for the partial variant, keeping the connect CTA', () => {
+    render(<NoDataCard variant="partial" />);
+
+    expect(screen.getByRole('heading', { name: 'Add more telemetry', level: 3 })).toBeInTheDocument();
+    expect(screen.getByText(/Some signals are already flowing/)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Connect a data source/ })).toBeInTheDocument();
+  });
+
   it('links the popular solutions to a prefilled catalog search when the apps are not available', () => {
     setAvailableApps([]);
 

--- a/public/app/features/home/Recommendations/NoDataCard.tsx
+++ b/public/app/features/home/Recommendations/NoDataCard.tsx
@@ -63,8 +63,11 @@ function getSolutionHref(solution: PopularSolution, appAvailable: boolean): stri
 }
 
 interface NoDataCardProps {
-  /** 'partial': telemetry flows (or detection was inconclusive) but nothing is renderable. */
-  variant?: 'empty' | 'partial';
+  /**
+   * 'partial': at least one signal is confirmed active but nothing is renderable.
+   * 'unknown': detection was inconclusive — no signal confirmed active, some unsettled.
+   */
+  variant?: 'empty' | 'partial' | 'unknown';
 }
 
 /** Left recommendations card for instances where no solution is reporting data yet. */
@@ -85,9 +88,9 @@ export function NoDataCard({ variant = 'empty' }: NoDataCardProps) {
         />
 
         <Text element="h3" variant="h3" color="primary">
-          {variant === 'partial'
-            ? t('home.recommendations.no-data.title-partial', 'Add more telemetry')
-            : t('home.recommendations.no-data.title', 'No data flowing yet')}
+          {variant === 'empty'
+            ? t('home.recommendations.no-data.title', 'No data flowing yet')
+            : t('home.recommendations.no-data.title-partial', 'Add more telemetry')}
         </Text>
 
         <Text variant="body">
@@ -96,10 +99,15 @@ export function NoDataCard({ variant = 'empty' }: NoDataCardProps) {
                 'home.recommendations.no-data.description-partial',
                 'Some signals are already flowing. Connect more data sources or pick a solution to see live stats here.'
               )
-            : t(
-                'home.recommendations.no-data.description',
-                'Connect a data source to light up your dashboards and alerts, pick from available solutions, or follow a getting started guide.'
-              )}
+            : variant === 'unknown'
+              ? t(
+                  'home.recommendations.no-data.description-unknown',
+                  "We couldn't confirm live data yet. Connect more data sources or pick a solution to see live stats here."
+                )
+              : t(
+                  'home.recommendations.no-data.description',
+                  'Connect a data source to light up your dashboards and alerts, pick from available solutions, or follow a getting started guide.'
+                )}
         </Text>
 
         <Stack direction="column" gap={1}>

--- a/public/app/features/home/Recommendations/NoDataCard.tsx
+++ b/public/app/features/home/Recommendations/NoDataCard.tsx
@@ -62,8 +62,13 @@ function getSolutionHref(solution: PopularSolution, appAvailable: boolean): stri
   return locationUtil.assureBaseUrl(`/plugins?${search}`);
 }
 
+interface NoDataCardProps {
+  /** 'partial': telemetry flows (or detection was inconclusive) but nothing is renderable. */
+  variant?: 'empty' | 'partial';
+}
+
 /** Left recommendations card for instances where no solution is reporting data yet. */
-export function NoDataCard() {
+export function NoDataCard({ variant = 'empty' }: NoDataCardProps) {
   const styles = useStyles2(getStyles);
   // Availability only picks the link target; while the lookup is pending the pills
   // fall back to the catalog, so the card never blocks on it.
@@ -80,14 +85,21 @@ export function NoDataCard() {
         />
 
         <Text element="h3" variant="h3" color="primary">
-          <Trans i18nKey="home.recommendations.no-data.title">No data flowing yet</Trans>
+          {variant === 'partial'
+            ? t('home.recommendations.no-data.title-partial', 'Add more telemetry')
+            : t('home.recommendations.no-data.title', 'No data flowing yet')}
         </Text>
 
         <Text variant="body">
-          <Trans i18nKey="home.recommendations.no-data.description">
-            Connect a data source to light up your dashboards and alerts, pick from available solutions, or follow a
-            getting started guide.
-          </Trans>
+          {variant === 'partial'
+            ? t(
+                'home.recommendations.no-data.description-partial',
+                'Some signals are already flowing. Connect more data sources or pick a solution to see live stats here.'
+              )
+            : t(
+                'home.recommendations.no-data.description',
+                'Connect a data source to light up your dashboards and alerts, pick from available solutions, or follow a getting started guide.'
+              )}
         </Text>
 
         <Stack direction="column" gap={1}>

--- a/public/app/features/home/Recommendations/RecommendationExisting.test.tsx
+++ b/public/app/features/home/Recommendations/RecommendationExisting.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen } from 'test/test-utils';
 
 import { createDataFrame, FieldType, type DataSourceInstanceListItem, type PluginMeta } from '@grafana/data';
-import { type AppPluginConfig } from '@grafana/runtime';
 import { useAppPluginMetas } from '@grafana/runtime/internal';
 import { interceptLinkClicks } from 'app/core/navigation/patch/interceptLinkClicks';
 import { usePluginBridge } from 'app/features/alerting/unified/hooks/usePluginBridge';
@@ -10,6 +9,7 @@ import { ctaClicked } from '../analytics/main';
 
 import { RecommendationExisting } from './RecommendationExisting';
 import {
+  KUBERNETES_APP_ID,
   fetchClusterCpuSeries,
   fetchKubernetesHealth,
   fetchKubernetesInventory,
@@ -161,7 +161,11 @@ function mockResolvedKubernetes(
 }
 
 beforeEach(() => {
-  mockUsePluginBridge.mockReturnValue({ loading: false, installed: true, settings });
+  mockUsePluginBridge.mockImplementation((plugin) =>
+    plugin === KUBERNETES_APP_ID
+      ? { loading: false, installed: true, settings }
+      : { loading: false, installed: false, settings: undefined }
+  );
   mockResolvedKubernetes();
   mockResolveDatasource.mockClear();
   mockFetchInventory.mockClear();
@@ -231,13 +235,12 @@ describe('RecommendationExisting', () => {
   });
 
   it('shows traces stats and the drilldown href when the app is available', async () => {
-    mockUsePluginBridge.mockReturnValue({ loading: false, installed: false, settings: undefined });
+    mockUsePluginBridge.mockImplementation((plugin) =>
+      plugin === 'grafana-exploretraces-app'
+        ? { loading: false, installed: true, settings: { id: 'grafana-exploretraces-app' } as PluginMeta<{}> }
+        : { loading: false, installed: false, settings: undefined }
+    );
     mockActiveTraces();
-    mockUseAppPluginMetas.mockReturnValue({
-      loading: false,
-      error: undefined,
-      value: [{ id: 'grafana-exploretraces-app' } as AppPluginConfig],
-    });
 
     render(<RecommendationExisting />);
 
@@ -252,9 +255,11 @@ describe('RecommendationExisting', () => {
   });
 
   it('falls back to Explore while the app lookup is pending or the app is absent', async () => {
-    mockUsePluginBridge.mockReturnValue({ loading: false, installed: false, settings: undefined });
+    // Drilldown probes pend; kubernetes must settle absent or the whole card stays a skeleton.
+    mockUsePluginBridge.mockImplementation((plugin) =>
+      plugin === KUBERNETES_APP_ID ? { loading: false, installed: false, settings: undefined } : { loading: true }
+    );
     mockActiveLogs();
-    mockUseAppPluginMetas.mockReturnValue({ loading: true, error: undefined, value: undefined });
 
     render(<RecommendationExisting />);
 
@@ -266,13 +271,12 @@ describe('RecommendationExisting', () => {
   });
 
   it('links the logs entry into Logs Drilldown when the app is available', async () => {
-    mockUsePluginBridge.mockReturnValue({ loading: false, installed: false, settings: undefined });
+    mockUsePluginBridge.mockImplementation((plugin) =>
+      plugin === 'grafana-lokiexplore-app'
+        ? { loading: false, installed: true, settings: { id: 'grafana-lokiexplore-app' } as PluginMeta<{}> }
+        : { loading: false, installed: false, settings: undefined }
+    );
     mockActiveLogs();
-    mockUseAppPluginMetas.mockReturnValue({
-      loading: false,
-      error: undefined,
-      value: [{ id: 'grafana-lokiexplore-app' } as AppPluginConfig],
-    });
 
     render(<RecommendationExisting />);
 
@@ -285,7 +289,11 @@ describe('RecommendationExisting', () => {
   });
 
   it('shows metrics stats, the disk alert, and the drilldown href when the app is available', async () => {
-    mockUsePluginBridge.mockReturnValue({ loading: false, installed: false, settings: undefined });
+    mockUsePluginBridge.mockImplementation((plugin) =>
+      plugin === 'grafana-metricsdrilldown-app'
+        ? { loading: false, installed: true, settings: { id: 'grafana-metricsdrilldown-app' } as PluginMeta<{}> }
+        : { loading: false, installed: false, settings: undefined }
+    );
     setSolutionState({ metrics: 'active' }, { prometheus: prometheusDatasource });
     mockFetchMetricsActivity.mockResolvedValue({
       series: 4_200_000,
@@ -294,11 +302,6 @@ describe('RecommendationExisting', () => {
       hosts: 12,
       seriesSparkline: null,
       disk: { hostsAbove: 3, worstInstance: 'web-03:9100', worstRatio: 0.96, hoursToFull: 6.4 },
-    });
-    mockUseAppPluginMetas.mockReturnValue({
-      loading: false,
-      error: undefined,
-      value: [{ id: 'grafana-metricsdrilldown-app' } as AppPluginConfig],
     });
 
     render(<RecommendationExisting />);

--- a/public/app/features/home/Recommendations/RecommendationExisting.test.tsx
+++ b/public/app/features/home/Recommendations/RecommendationExisting.test.tsx
@@ -416,6 +416,16 @@ describe('RecommendationExisting', () => {
     expect(mockFetchTracesActivity).not.toHaveBeenCalled();
   });
 
+  it('uses the inconclusive copy when no signal is confirmed active', async () => {
+    mockUsePluginBridge.mockReturnValue({ loading: false, installed: false, settings: undefined });
+    setSolutionState({ metrics: 'unknown', logs: 'unknown', traces: 'unknown', kubernetes: 'unknown' });
+
+    render(<RecommendationExisting />);
+
+    expect(await screen.findByText(/We couldn't confirm live data yet/)).toBeInTheDocument();
+    expect(screen.queryByText(/Some signals are already flowing/)).not.toBeInTheDocument();
+  });
+
   it('drops an active entry when every detail fetch came back empty', async () => {
     mockUsePluginBridge.mockReturnValue({ loading: false, installed: false, settings: undefined });
     setSolutionState(
@@ -443,6 +453,7 @@ describe('RecommendationExisting', () => {
     render(<RecommendationExisting />);
 
     expect(await screen.findByRole('heading', { name: 'Add more telemetry' })).toBeInTheDocument();
+    expect(screen.getByText(/Some signals are already flowing/)).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Connect a data source/ })).toBeInTheDocument();
   });
 

--- a/public/app/features/home/Recommendations/RecommendationExisting.test.tsx
+++ b/public/app/features/home/Recommendations/RecommendationExisting.test.tsx
@@ -241,7 +241,7 @@ describe('RecommendationExisting', () => {
 
     expect(await screen.findByRole('heading', { name: 'Hosted Traces' })).toBeInTheDocument();
     expect(screen.getByText('via grafanacloud-traces')).toBeInTheDocument();
-    expect(await screen.findByText('4.8M spans')).toBeInTheDocument();
+    expect(await screen.findByText('4.80 Mil spans')).toBeInTheDocument();
     expect(screen.getByText('traced · 24h · 34 services')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Open Traces Drilldown/ })).toHaveAttribute(
       'href',
@@ -302,7 +302,7 @@ describe('RecommendationExisting', () => {
 
     expect(await screen.findByRole('heading', { name: 'Metrics & infrastructure' })).toBeInTheDocument();
     expect(screen.getByText('via grafanacloud-prom')).toBeInTheDocument();
-    expect(await screen.findByText('4.2M series')).toBeInTheDocument();
+    expect(await screen.findByText('4.20 Mil series')).toBeInTheDocument();
     expect(screen.getByText('active · 12 hosts')).toBeInTheDocument();
     expect(screen.getByText('3 hosts above 90% disk')).toBeInTheDocument();
     // Scrape port stripped from the worst host; the rounded ETA rides along.
@@ -329,7 +329,7 @@ describe('RecommendationExisting', () => {
     render(<RecommendationExisting />);
 
     expect(await screen.findByRole('heading', { name: 'Metrics & infrastructure' })).toBeInTheDocument();
-    expect(await screen.findByText('1.2K metrics')).toBeInTheDocument();
+    expect(await screen.findByText('1.20 K metrics')).toBeInTheDocument();
     // No host count: the secondary degrades to the bare qualifier, and no alert row renders.
     expect(screen.getByText('active')).toBeInTheDocument();
     expect(screen.queryByText(/above 90% disk/)).not.toBeInTheDocument();

--- a/public/app/features/home/Recommendations/RecommendationExisting.test.tsx
+++ b/public/app/features/home/Recommendations/RecommendationExisting.test.tsx
@@ -318,6 +318,23 @@ describe('RecommendationExisting', () => {
     );
   });
 
+  it('never rounds a sub-hour disk ETA down to zero', async () => {
+    mockUsePluginBridge.mockReturnValue({ loading: false, installed: false, settings: undefined });
+    setSolutionState({ metrics: 'active' }, { prometheus: prometheusDatasource });
+    mockFetchMetricsActivity.mockResolvedValue({
+      series: 4_200_000,
+      dataPointsPerMinute: null,
+      names: null,
+      hosts: 620,
+      seriesSparkline: null,
+      disk: { hostsAbove: 3, worstInstance: 'web-03:9100', worstRatio: 0.96, hoursToFull: 0.3 },
+    });
+
+    render(<RecommendationExisting />);
+
+    expect(await screen.findByText('~1 h to full')).toBeInTheDocument();
+  });
+
   it('shows the ingest rate as the metrics secondary when available', async () => {
     mockUsePluginBridge.mockReturnValue({ loading: false, installed: false, settings: undefined });
     setSolutionState({ metrics: 'active' }, { prometheus: prometheusDatasource });

--- a/public/app/features/home/Recommendations/RecommendationExisting.test.tsx
+++ b/public/app/features/home/Recommendations/RecommendationExisting.test.tsx
@@ -180,6 +180,7 @@ beforeEach(() => {
   mockFetchMetricsActivity.mockReset();
   mockFetchMetricsActivity.mockResolvedValue({
     series: null,
+    dataPointsPerMinute: null,
     names: null,
     hosts: null,
     seriesSparkline: null,
@@ -207,6 +208,7 @@ describe('RecommendationExisting', () => {
     mockActiveLogs();
     mockFetchMetricsActivity.mockResolvedValue({
       series: 4_200_000,
+      dataPointsPerMinute: null,
       names: null,
       hosts: null,
       seriesSparkline: null,
@@ -287,6 +289,7 @@ describe('RecommendationExisting', () => {
     setSolutionState({ metrics: 'active' }, { prometheus: prometheusDatasource });
     mockFetchMetricsActivity.mockResolvedValue({
       series: 4_200_000,
+      dataPointsPerMinute: null,
       names: 1_200,
       hosts: 12,
       seriesSparkline: null,
@@ -315,11 +318,32 @@ describe('RecommendationExisting', () => {
     );
   });
 
+  it('shows the ingest rate as the metrics secondary when available', async () => {
+    mockUsePluginBridge.mockReturnValue({ loading: false, installed: false, settings: undefined });
+    setSolutionState({ metrics: 'active' }, { prometheus: prometheusDatasource });
+    mockFetchMetricsActivity.mockResolvedValue({
+      series: 4_200_000,
+      dataPointsPerMinute: 5_160_000,
+      names: null,
+      hosts: 12,
+      seriesSparkline: null,
+      disk: null,
+    });
+
+    render(<RecommendationExisting />);
+
+    expect(await screen.findByRole('heading', { name: 'Metrics & infrastructure' })).toBeInTheDocument();
+    expect(await screen.findByText(/data points\/min/)).toBeInTheDocument();
+    // The ingest rate replaces the whole 'active · N hosts' secondary.
+    expect(screen.queryByText(/^active/)).not.toBeInTheDocument();
+  });
+
   it('falls back to the name count and Explore when no active-series source responded', async () => {
     mockUsePluginBridge.mockReturnValue({ loading: false, installed: false, settings: undefined });
     setSolutionState({ metrics: 'active' }, { prometheus: prometheusDatasource });
     mockFetchMetricsActivity.mockResolvedValue({
       series: null,
+      dataPointsPerMinute: null,
       names: 1_200,
       hosts: null,
       seriesSparkline: null,
@@ -346,6 +370,7 @@ describe('RecommendationExisting', () => {
     // Hosts alone are secondary content — they cannot carry the card.
     mockFetchMetricsActivity.mockResolvedValue({
       series: null,
+      dataPointsPerMinute: null,
       names: null,
       hosts: 12,
       seriesSparkline: null,

--- a/public/app/features/home/Recommendations/RecommendationExisting.test.tsx
+++ b/public/app/features/home/Recommendations/RecommendationExisting.test.tsx
@@ -1,8 +1,15 @@
 import { render, screen } from 'test/test-utils';
 
-import { createDataFrame, FieldType, type DataSourceInstanceListItem, type PluginMeta } from '@grafana/data';
+import {
+  createDataFrame,
+  FieldType,
+  PluginIncludeType,
+  type DataSourceInstanceListItem,
+  type PluginMeta,
+} from '@grafana/data';
 import { useAppPluginMetas } from '@grafana/runtime/internal';
 import { interceptLinkClicks } from 'app/core/navigation/patch/interceptLinkClicks';
+import { contextSrv } from 'app/core/services/context_srv';
 import { usePluginBridge } from 'app/features/alerting/unified/hooks/usePluginBridge';
 
 import { ctaClicked } from '../analytics/main';
@@ -318,6 +325,70 @@ describe('RecommendationExisting', () => {
     expect(screen.getByRole('link', { name: /Open Metrics Drilldown/ })).toHaveAttribute(
       'href',
       '/a/grafana-metricsdrilldown-app'
+    );
+  });
+
+  it('falls back to Explore when the user cannot access the drilldown default page', async () => {
+    mockUsePluginBridge.mockImplementation((plugin) =>
+      plugin === 'grafana-lokiexplore-app'
+        ? {
+            loading: false,
+            installed: true,
+            settings: {
+              id: 'grafana-lokiexplore-app',
+              includes: [
+                {
+                  type: PluginIncludeType.page,
+                  name: 'Logs',
+                  path: '/a/grafana-lokiexplore-app/explore',
+                  defaultNav: true,
+                  action: 'datasources:explore',
+                },
+              ],
+            } as PluginMeta<{}>,
+          }
+        : { loading: false, installed: false, settings: undefined }
+    );
+    jest.spyOn(contextSrv, 'hasPermission').mockReturnValue(false);
+    mockActiveLogs();
+
+    render(<RecommendationExisting />);
+
+    expect(await screen.findByRole('heading', { name: 'Hosted Logs' })).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /Open Explore \(Logs\)/ })).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Open in Explore/ }).getAttribute('href')).toMatch(/^\/explore\?left=/);
+  });
+
+  it('keeps the drilldown CTA when the user can access the declared default page', async () => {
+    mockUsePluginBridge.mockImplementation((plugin) =>
+      plugin === 'grafana-exploretraces-app'
+        ? {
+            loading: false,
+            installed: true,
+            settings: {
+              id: 'grafana-exploretraces-app',
+              includes: [
+                {
+                  type: PluginIncludeType.page,
+                  name: 'Traces',
+                  path: '/a/grafana-exploretraces-app/',
+                  defaultNav: true,
+                  action: 'datasources:explore',
+                },
+              ],
+            } as PluginMeta<{}>,
+          }
+        : { loading: false, installed: false, settings: undefined }
+    );
+    jest.spyOn(contextSrv, 'hasPermission').mockReturnValue(true);
+    mockActiveTraces();
+
+    render(<RecommendationExisting />);
+
+    expect(await screen.findByRole('heading', { name: 'Hosted Traces' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Open Traces Drilldown/ })).toHaveAttribute(
+      'href',
+      '/a/grafana-exploretraces-app'
     );
   });
 

--- a/public/app/features/home/Recommendations/RecommendationExisting.test.tsx
+++ b/public/app/features/home/Recommendations/RecommendationExisting.test.tsx
@@ -1,6 +1,8 @@
 import { render, screen } from 'test/test-utils';
 
 import { createDataFrame, FieldType, type DataSourceInstanceListItem, type PluginMeta } from '@grafana/data';
+import { type AppPluginConfig } from '@grafana/runtime';
+import { useAppPluginMetas } from '@grafana/runtime/internal';
 import { interceptLinkClicks } from 'app/core/navigation/patch/interceptLinkClicks';
 import { usePluginBridge } from 'app/features/alerting/unified/hooks/usePluginBridge';
 
@@ -16,6 +18,9 @@ import {
   type KubernetesInventory,
 } from './kubernetesData';
 import { readSeries } from './promQuery';
+import { useSolutionState } from './solutionState';
+import { type SolutionState } from './solutionsMatrix';
+import { fetchLogsActivity, fetchMetricsActivity, fetchTracesActivity, fetchTracesServices } from './telemetryData';
 
 jest.mock('app/features/alerting/unified/hooks/usePluginBridge', () => ({
   ...jest.requireActual('app/features/alerting/unified/hooks/usePluginBridge'),
@@ -34,11 +39,34 @@ jest.mock('../analytics/main', () => ({
   ctaClicked: jest.fn(),
 }));
 
+jest.mock('./solutionState', () => ({
+  useSolutionState: jest.fn(),
+}));
+
+jest.mock('./telemetryData', () => ({
+  ...jest.requireActual('./telemetryData'),
+  fetchLogsActivity: jest.fn(),
+  fetchMetricsActivity: jest.fn(),
+  fetchTracesActivity: jest.fn(),
+  fetchTracesServices: jest.fn(),
+}));
+
+jest.mock('@grafana/runtime/internal', () => ({
+  ...jest.requireActual('@grafana/runtime/internal'),
+  useAppPluginMetas: jest.fn(),
+}));
+
 const mockUsePluginBridge = jest.mocked(usePluginBridge);
 const mockResolveDatasource = jest.mocked(resolveKubernetesDatasource);
 const mockFetchInventory = jest.mocked(fetchKubernetesInventory);
 const mockFetchHealth = jest.mocked(fetchKubernetesHealth);
 const mockFetchCpuSeries = jest.mocked(fetchClusterCpuSeries);
+const mockUseSolutionState = jest.mocked(useSolutionState);
+const mockUseAppPluginMetas = jest.mocked(useAppPluginMetas);
+const mockFetchLogsActivity = jest.mocked(fetchLogsActivity);
+const mockFetchMetricsActivity = jest.mocked(fetchMetricsActivity);
+const mockFetchTracesActivity = jest.mocked(fetchTracesActivity);
+const mockFetchTracesServices = jest.mocked(fetchTracesServices);
 
 const settings = { id: 'grafana-k8s-app' } as PluginMeta<{}>;
 const datasource: DataSourceInstanceListItem = {
@@ -49,6 +77,70 @@ const datasource: DataSourceInstanceListItem = {
   readOnly: false,
   isDefault: false,
 };
+
+const lokiDatasource: DataSourceInstanceListItem = {
+  uid: 'loki-uid',
+  name: 'grafanacloud-logs',
+  type: 'loki',
+  meta: { id: 'loki' } as DataSourceInstanceListItem['meta'],
+  readOnly: false,
+  isDefault: false,
+};
+
+const tempoDatasource: DataSourceInstanceListItem = {
+  uid: 'tempo-uid',
+  name: 'grafanacloud-traces',
+  type: 'tempo',
+  meta: { id: 'tempo' } as DataSourceInstanceListItem['meta'],
+  readOnly: false,
+  isDefault: false,
+};
+
+const prometheusDatasource: DataSourceInstanceListItem = {
+  uid: 'prom-uid',
+  name: 'grafanacloud-prom',
+  type: 'prometheus',
+  meta: { id: 'prometheus' } as DataSourceInstanceListItem['meta'],
+  readOnly: false,
+  isDefault: false,
+};
+
+function setSolutionState(
+  overrides: Partial<SolutionState>,
+  ds: {
+    loki?: DataSourceInstanceListItem;
+    tempo?: DataSourceInstanceListItem;
+    prometheus?: DataSourceInstanceListItem;
+  } = {}
+) {
+  mockUseSolutionState.mockReturnValue({
+    value: {
+      state: {
+        metrics: 'inactive',
+        logs: 'inactive',
+        traces: 'inactive',
+        kubernetes: 'inactive',
+        spanMetrics: 'inactive',
+        ...overrides,
+      },
+      lokiDatasource: ds.loki ?? null,
+      tempoDatasource: ds.tempo ?? null,
+      prometheusDatasource: ds.prometheus ?? null,
+    },
+    loading: false,
+  });
+}
+
+function mockActiveLogs() {
+  setSolutionState({ metrics: 'active', logs: 'active' }, { loki: lokiDatasource });
+  mockFetchLogsActivity.mockResolvedValue({ bytes: 47_000_000_000, sources: 8, series: null });
+}
+
+function mockActiveTraces() {
+  setSolutionState({ metrics: 'active', logs: 'active', traces: 'active' }, { tempo: tempoDatasource });
+  mockFetchTracesActivity.mockResolvedValue({ spans: 4_800_000, series: null });
+  mockFetchTracesServices.mockResolvedValue(34);
+}
 
 const healthyInventory: KubernetesInventory = { clusters: 3, pods: 247 };
 const healthyHealth: KubernetesHealth = {
@@ -76,20 +168,250 @@ beforeEach(() => {
   mockFetchHealth.mockClear();
   mockFetchCpuSeries.mockClear();
   jest.mocked(ctaClicked).mockClear();
+  mockUseSolutionState.mockReset();
+  setSolutionState({});
+  mockUseAppPluginMetas.mockReturnValue({ loading: false, error: undefined, value: [] });
+  mockFetchLogsActivity.mockReset();
+  mockFetchLogsActivity.mockResolvedValue({ bytes: null, sources: null, series: null });
+  mockFetchTracesActivity.mockReset();
+  mockFetchTracesActivity.mockResolvedValue({ spans: null, series: null });
+  mockFetchTracesServices.mockReset();
+  mockFetchTracesServices.mockResolvedValue(null);
+  mockFetchMetricsActivity.mockReset();
+  mockFetchMetricsActivity.mockResolvedValue({
+    series: null,
+    names: null,
+    hosts: null,
+    seriesSparkline: null,
+    disk: null,
+  });
 });
 
 afterEach(() => jest.restoreAllMocks());
 
 describe('RecommendationExisting', () => {
   it('opens the dropdown and switches the selected solution', async () => {
+    mockActiveLogs();
     const { user } = render(<RecommendationExisting />);
 
     expect(await screen.findByRole('heading', { name: 'Kubernetes Monitoring' })).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: /Switch solution/i }));
-    await user.click(screen.getByRole('menuitem', { name: 'Hosted Metrics' }));
+    await user.click(screen.getByRole('menuitem', { name: 'Hosted Logs' }));
 
-    expect(screen.getByRole('heading', { name: 'Hosted Metrics' })).toBeInTheDocument();
-    expect(screen.getByText('4.2M series')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Hosted Logs' })).toBeInTheDocument();
+    expect(await screen.findByText('47 GB')).toBeInTheDocument();
+    expect(screen.getByText('ingested · 7d · ~8 sources')).toBeInTheDocument();
+  });
+
+  it('lists live solutions in registry order with no stub entries', async () => {
+    mockActiveLogs();
+    mockFetchMetricsActivity.mockResolvedValue({
+      series: 4_200_000,
+      names: null,
+      hosts: null,
+      seriesSparkline: null,
+      disk: null,
+    });
+    mockFetchTracesActivity.mockResolvedValue({ spans: 4_800_000, series: null });
+    mockFetchTracesServices.mockResolvedValue(34);
+    setSolutionState(
+      { metrics: 'active', logs: 'active', traces: 'active' },
+      { prometheus: prometheusDatasource, loki: lokiDatasource, tempo: tempoDatasource }
+    );
+
+    const { user } = render(<RecommendationExisting />);
+
+    expect(await screen.findByRole('heading', { name: 'Kubernetes Monitoring' })).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /Switch solution/i }));
+
+    const items = screen.getAllByRole('menuitem').map((item) => item.textContent?.trim());
+    expect(items).toEqual(['Kubernetes Monitoring', 'Metrics & infrastructure', 'Hosted Logs', 'Hosted Traces']);
+  });
+
+  it('shows traces stats and the drilldown href when the app is available', async () => {
+    mockUsePluginBridge.mockReturnValue({ loading: false, installed: false, settings: undefined });
+    mockActiveTraces();
+    mockUseAppPluginMetas.mockReturnValue({
+      loading: false,
+      error: undefined,
+      value: [{ id: 'grafana-exploretraces-app' } as AppPluginConfig],
+    });
+
+    render(<RecommendationExisting />);
+
+    expect(await screen.findByRole('heading', { name: 'Hosted Traces' })).toBeInTheDocument();
+    expect(screen.getByText('via grafanacloud-traces')).toBeInTheDocument();
+    expect(await screen.findByText('4.8M spans')).toBeInTheDocument();
+    expect(screen.getByText('traced · 24h · 34 services')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Open Traces Drilldown/ })).toHaveAttribute(
+      'href',
+      '/a/grafana-exploretraces-app'
+    );
+  });
+
+  it('falls back to Explore while the app lookup is pending or the app is absent', async () => {
+    mockUsePluginBridge.mockReturnValue({ loading: false, installed: false, settings: undefined });
+    mockActiveLogs();
+    mockUseAppPluginMetas.mockReturnValue({ loading: true, error: undefined, value: undefined });
+
+    render(<RecommendationExisting />);
+
+    expect(await screen.findByRole('heading', { name: 'Hosted Logs' })).toBeInTheDocument();
+    const href = screen.getByRole('link', { name: /Open in Explore/ }).getAttribute('href') ?? '';
+    expect(href).toMatch(/^\/explore\?left=/);
+    const left = new URLSearchParams(href.split('?')[1]).get('left') ?? '';
+    expect(JSON.parse(left)).toEqual({ datasource: 'grafanacloud-logs', context: 'explore' });
+  });
+
+  it('links the logs entry into Logs Drilldown when the app is available', async () => {
+    mockUsePluginBridge.mockReturnValue({ loading: false, installed: false, settings: undefined });
+    mockActiveLogs();
+    mockUseAppPluginMetas.mockReturnValue({
+      loading: false,
+      error: undefined,
+      value: [{ id: 'grafana-lokiexplore-app' } as AppPluginConfig],
+    });
+
+    render(<RecommendationExisting />);
+
+    expect(await screen.findByRole('heading', { name: 'Hosted Logs' })).toBeInTheDocument();
+    expect(screen.getByText('via grafanacloud-logs')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Open Explore \(Logs\)/ })).toHaveAttribute(
+      'href',
+      '/a/grafana-lokiexplore-app'
+    );
+  });
+
+  it('shows metrics stats, the disk alert, and the drilldown href when the app is available', async () => {
+    mockUsePluginBridge.mockReturnValue({ loading: false, installed: false, settings: undefined });
+    setSolutionState({ metrics: 'active' }, { prometheus: prometheusDatasource });
+    mockFetchMetricsActivity.mockResolvedValue({
+      series: 4_200_000,
+      names: 1_200,
+      hosts: 12,
+      seriesSparkline: null,
+      disk: { hostsAbove: 3, worstInstance: 'web-03:9100', worstRatio: 0.96, hoursToFull: 6.4 },
+    });
+    mockUseAppPluginMetas.mockReturnValue({
+      loading: false,
+      error: undefined,
+      value: [{ id: 'grafana-metricsdrilldown-app' } as AppPluginConfig],
+    });
+
+    render(<RecommendationExisting />);
+
+    expect(await screen.findByRole('heading', { name: 'Metrics & infrastructure' })).toBeInTheDocument();
+    expect(screen.getByText('via grafanacloud-prom')).toBeInTheDocument();
+    expect(await screen.findByText('4.2M series')).toBeInTheDocument();
+    expect(screen.getByText('active · 12 hosts')).toBeInTheDocument();
+    expect(screen.getByText('3 hosts above 90% disk')).toBeInTheDocument();
+    // Scrape port stripped from the worst host; the rounded ETA rides along.
+    expect(screen.getByText('web-03 at 96%')).toBeInTheDocument();
+    expect(screen.getByText('~6 h to full')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /View/ }).getAttribute('href')).toMatch(/^\/explore\?left=/);
+    expect(screen.getByRole('link', { name: /Open Metrics Drilldown/ })).toHaveAttribute(
+      'href',
+      '/a/grafana-metricsdrilldown-app'
+    );
+  });
+
+  it('falls back to the name count and Explore when no active-series source responded', async () => {
+    mockUsePluginBridge.mockReturnValue({ loading: false, installed: false, settings: undefined });
+    setSolutionState({ metrics: 'active' }, { prometheus: prometheusDatasource });
+    mockFetchMetricsActivity.mockResolvedValue({
+      series: null,
+      names: 1_200,
+      hosts: null,
+      seriesSparkline: null,
+      disk: null,
+    });
+
+    render(<RecommendationExisting />);
+
+    expect(await screen.findByRole('heading', { name: 'Metrics & infrastructure' })).toBeInTheDocument();
+    expect(await screen.findByText('1.2K metrics')).toBeInTheDocument();
+    // No host count: the secondary degrades to the bare qualifier, and no alert row renders.
+    expect(screen.getByText('active')).toBeInTheDocument();
+    expect(screen.queryByText(/above 90% disk/)).not.toBeInTheDocument();
+    const href = screen.getByRole('link', { name: /Open in Explore/ }).getAttribute('href') ?? '';
+    expect(href).toMatch(/^\/explore\?left=/);
+    const left = new URLSearchParams(href.split('?')[1]).get('left') ?? '';
+    expect(JSON.parse(left)).toEqual({ datasource: 'grafanacloud-prom', context: 'explore' });
+  });
+
+  it('drops the metrics entry when series, names, and sparkline all failed soft', async () => {
+    mockUsePluginBridge.mockReturnValue({ loading: false, installed: false, settings: undefined });
+    setSolutionState({ metrics: 'active', logs: 'active' }, { prometheus: prometheusDatasource, loki: lokiDatasource });
+    mockFetchLogsActivity.mockResolvedValue({ bytes: 47_000_000_000, sources: 8, series: null });
+    // Hosts alone are secondary content — they cannot carry the card.
+    mockFetchMetricsActivity.mockResolvedValue({
+      series: null,
+      names: null,
+      hosts: 12,
+      seriesSparkline: null,
+      disk: null,
+    });
+
+    const { user } = render(<RecommendationExisting />);
+
+    expect(await screen.findByRole('heading', { name: 'Hosted Logs' })).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /Switch solution/i }));
+
+    const items = screen.getAllByRole('menuitem').map((item) => item.textContent?.trim());
+    expect(items).toEqual(['Hosted Logs']);
+  });
+
+  it('never invents an entry for an unknown signal', async () => {
+    mockUsePluginBridge.mockReturnValue({ loading: false, installed: false, settings: undefined });
+    setSolutionState({ logs: 'unknown', traces: 'unknown' }, { loki: lokiDatasource, tempo: tempoDatasource });
+
+    render(<RecommendationExisting />);
+
+    expect(await screen.findByRole('heading', { name: 'Add more telemetry' })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Hosted Logs' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Hosted Traces' })).not.toBeInTheDocument();
+    expect(mockFetchLogsActivity).not.toHaveBeenCalled();
+    expect(mockFetchTracesActivity).not.toHaveBeenCalled();
+  });
+
+  it('drops an active entry when every detail fetch came back empty', async () => {
+    mockUsePluginBridge.mockReturnValue({ loading: false, installed: false, settings: undefined });
+    setSolutionState(
+      { metrics: 'active', logs: 'active', traces: 'active' },
+      { loki: lokiDatasource, tempo: tempoDatasource }
+    );
+    // Signals are active but stats and sparklines all failed soft: a bare title card reads
+    // as broken, so neither solution renders.
+    mockFetchLogsActivity.mockResolvedValue({ bytes: null, sources: null, series: null });
+    mockFetchTracesActivity.mockResolvedValue({ spans: null, series: null });
+    mockFetchTracesServices.mockResolvedValue(34);
+
+    render(<RecommendationExisting />);
+
+    expect(await screen.findByRole('heading', { name: 'Add more telemetry' })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Hosted Logs' })).not.toBeInTheDocument();
+    // The services count alone renders nothing, so it cannot carry the traces card.
+    expect(screen.queryByRole('heading', { name: 'Hosted Traces' })).not.toBeInTheDocument();
+  });
+
+  it('softens the no-data claim for a metrics-only org with nothing renderable', async () => {
+    mockUsePluginBridge.mockReturnValue({ loading: false, installed: false, settings: undefined });
+    setSolutionState({ metrics: 'active' });
+
+    render(<RecommendationExisting />);
+
+    expect(await screen.findByRole('heading', { name: 'Add more telemetry' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Connect a data source/ })).toBeInTheDocument();
+  });
+
+  it('keeps an entry whose sparkline failed but whose stats resolved', async () => {
+    mockUsePluginBridge.mockReturnValue({ loading: false, installed: false, settings: undefined });
+    mockActiveLogs();
+
+    render(<RecommendationExisting />);
+
+    expect(await screen.findByRole('heading', { name: 'Hosted Logs' })).toBeInTheDocument();
+    expect(await screen.findByText('47 GB')).toBeInTheDocument();
   });
 
   it('shows a full-card skeleton while settings are pending', async () => {
@@ -157,7 +479,7 @@ describe('RecommendationExisting', () => {
 
     expect(await screen.findByRole('heading', { name: 'No data flowing yet' })).toBeInTheDocument();
     expect(screen.queryByRole('heading', { name: 'Kubernetes Monitoring' })).not.toBeInTheDocument();
-    expect(screen.queryByRole('heading', { name: 'Hosted Metrics' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Hosted Logs' })).not.toBeInTheDocument();
   });
 
   it('shows the no-data card when resolution rejects without flashing the Kubernetes title', async () => {
@@ -221,7 +543,7 @@ describe('RecommendationExisting', () => {
     expect(await screen.findByRole('heading', { name: 'Kubernetes Monitoring' })).toBeInTheDocument();
     expect(screen.getByText('via k8s-prom')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Open K8s app' })).toBeInTheDocument();
-    expect(screen.queryByRole('heading', { name: 'Hosted Metrics' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Hosted Logs' })).not.toBeInTheDocument();
     expect(screen.queryByTestId('kubernetes-stats-skeleton')).not.toBeInTheDocument();
   });
 
@@ -261,7 +583,8 @@ describe('RecommendationExisting', () => {
     expect(await screen.findByText('311 K pods')).toBeInTheDocument();
   });
 
-  it('shows stub stats without skeletons when switching away while Kubernetes data is pending', async () => {
+  it('shows live logs stats without Kubernetes skeletons when switching away mid-fetch', async () => {
+    mockActiveLogs();
     mockFetchInventory.mockImplementation(() => new Promise(() => {}));
     mockFetchCpuSeries.mockImplementation(() => new Promise(() => {}));
 
@@ -269,9 +592,9 @@ describe('RecommendationExisting', () => {
 
     expect(await screen.findByTestId('kubernetes-stats-skeleton')).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: /Switch solution/i }));
-    await user.click(screen.getByRole('menuitem', { name: 'Hosted Metrics' }));
+    await user.click(screen.getByRole('menuitem', { name: 'Hosted Logs' }));
 
-    expect(screen.getByText('4.2M series')).toBeInTheDocument();
+    expect(await screen.findByText('47 GB')).toBeInTheDocument();
     expect(screen.queryByTestId('kubernetes-stats-skeleton')).not.toBeInTheDocument();
     expect(screen.queryByTestId('kubernetes-sparkline-skeleton')).not.toBeInTheDocument();
   });
@@ -319,14 +642,15 @@ describe('RecommendationExisting', () => {
     expect(await screen.findByText('via k8s-prom')).toBeInTheDocument();
   });
 
-  it('omits the datasource subtitle on stub solutions', async () => {
+  it('names the winning datasource on telemetry solutions', async () => {
+    mockActiveLogs();
     const { user } = render(<RecommendationExisting />);
 
     expect(await screen.findByRole('heading', { name: 'Kubernetes Monitoring' })).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: /Switch solution/i }));
-    await user.click(screen.getByRole('menuitem', { name: 'Hosted Metrics' }));
+    await user.click(screen.getByRole('menuitem', { name: 'Hosted Logs' }));
 
-    expect(screen.queryByText(/^via /)).not.toBeInTheDocument();
+    expect(screen.getByText('via grafanacloud-logs')).toBeInTheDocument();
   });
 
   describe('analytics', () => {
@@ -350,7 +674,7 @@ describe('RecommendationExisting', () => {
         surface: 'existing_solution',
         action: 'open_solution',
         placement: 'card',
-        solution: 'kubernetes-monitoring',
+        solution: 'kubernetes',
       });
     });
 
@@ -370,40 +694,40 @@ describe('RecommendationExisting', () => {
         surface: 'existing_solution',
         action: 'view_alerts',
         placement: 'card',
-        solution: 'kubernetes-monitoring',
+        solution: 'kubernetes',
       });
     });
 
-    it('tracks stub solutions with their own id', async () => {
-      // Stubs are only reachable behind a live solution now; without one the card
-      // renders the no-data state instead, so switch to the stub first.
+    it('tracks telemetry solutions with their own id', async () => {
+      mockActiveLogs();
       const { user } = render(<RecommendationExisting />);
 
       expect(await screen.findByRole('heading', { name: 'Kubernetes Monitoring' })).toBeInTheDocument();
       await user.click(screen.getByRole('button', { name: /Switch solution/i }));
-      await user.click(screen.getByRole('menuitem', { name: 'Hosted Metrics' }));
-      await user.click(await screen.findByRole('link', { name: /Open infrastructure/ }));
+      await user.click(screen.getByRole('menuitem', { name: 'Hosted Logs' }));
+      await user.click(await screen.findByRole('link', { name: /Open in Explore/ }));
 
       expect(jest.mocked(ctaClicked)).toHaveBeenCalledWith({
         surface: 'existing_solution',
         action: 'open_solution',
         placement: 'card',
-        solution: 'hosted-metrics',
+        solution: 'logs',
       });
     });
 
     it('tracks switch_solution with the picked solution id', async () => {
+      mockActiveLogs();
       const { user } = render(<RecommendationExisting />);
 
       expect(await screen.findByRole('heading', { name: 'Kubernetes Monitoring' })).toBeInTheDocument();
       await user.click(screen.getByRole('button', { name: /Switch solution/i }));
-      await user.click(screen.getByRole('menuitem', { name: 'Hosted Metrics' }));
+      await user.click(screen.getByRole('menuitem', { name: 'Hosted Logs' }));
 
       expect(jest.mocked(ctaClicked)).toHaveBeenCalledWith({
         surface: 'existing_solution',
         action: 'switch_solution',
         placement: 'card',
-        solution: 'hosted-metrics',
+        solution: 'logs',
       });
     });
 

--- a/public/app/features/home/Recommendations/RecommendationExisting.tsx
+++ b/public/app/features/home/Recommendations/RecommendationExisting.tsx
@@ -38,16 +38,18 @@ export function RecommendationExisting({ onSelectionChange }: RecommendationExis
   }
 
   if (!selected) {
-    // NoDataCard's hard claim is only true when every core signal settled inactive; anything
-    // else (active-but-no-entry, unknown) gets the softened variant.
+    // NoDataCard's hard claim is only true when every core signal settled inactive; a confirmed
+    // active signal earns the "already flowing" copy; anything else (all unknown, resolution
+    // missing) gets the neutral inconclusive variant so the card never overclaims.
     const s = resolution?.state;
-    const allInactive =
-      !!s &&
-      s.metrics === 'inactive' &&
-      s.logs === 'inactive' &&
-      s.traces === 'inactive' &&
-      s.kubernetes === 'inactive';
-    return <NoDataCard variant={allInactive ? 'empty' : 'partial'} />;
+    const core = s ? [s.metrics, s.logs, s.traces, s.kubernetes] : [];
+    const variant =
+      core.length > 0 && core.every((v) => v === 'inactive')
+        ? 'empty'
+        : core.some((v) => v === 'active')
+          ? 'partial'
+          : 'unknown';
+    return <NoDataCard variant={variant} />;
   }
 
   return <ExistingSolutionCard existing={solutions} selected={selected} onSelect={setSelectedId} />;

--- a/public/app/features/home/Recommendations/RecommendationExisting.tsx
+++ b/public/app/features/home/Recommendations/RecommendationExisting.tsx
@@ -1,66 +1,56 @@
-import { useState } from 'react';
+import { useLayoutEffect, useState } from 'react';
 import Skeleton from 'react-loading-skeleton';
 
 import { Stack } from '@grafana/ui';
 
 import { ExistingSolutionCard } from './ExistingSolutionCard';
 import { NoDataCard } from './NoDataCard';
+import { useSolutionState } from './solutionState';
+import { type ExistingSolutionId } from './solutionsMatrix';
 import { type ExistingItem } from './types';
 import { useExistingSolutions } from './useExistingSolutions';
 
-const stubbedExisting: ExistingItem[] = [
-  {
-    id: 'hosted-metrics',
-    title: 'Hosted Metrics',
-    icon: 'chart-line',
-    stats: {
-      primary: '4.2M series',
-      secondary: '12 hosts',
-    },
-    alert: {
-      primary: '3 hosts above 90% disk',
-      details: ['web-03 critical at 96%, ~6 h to full'],
-      action: 'View',
-      href: '#',
-    },
-    action: 'Open infrastructure',
-    href: '#',
-  },
-  {
-    id: 'hosted-logs',
-    title: 'Hosted Logs',
-    icon: 'file-alt',
-    stats: {
-      primary: '47 GB ingested',
-      secondary: '8 sources',
-    },
-    alert: {
-      primary: 'Ingest spike detected',
-      details: ['checkout-service logs up 3x in the last hour'],
-      action: 'View',
-      href: '#',
-    },
-    action: 'Open Explore (Logs)',
-    href: '#',
-  },
-];
+interface RecommendationExistingProps {
+  /** Selection the card displays: undefined while providers settle, null when none exists, else the id. */
+  onSelectionChange?: (id: ExistingSolutionId | null | undefined) => void;
+}
 
-export function RecommendationExisting() {
-  const [selectedTitle, setSelectedTitle] = useState<string>();
+export function RecommendationExisting({ onSelectionChange }: RecommendationExistingProps) {
+  const [selectedId, setSelectedId] = useState<ExistingSolutionId>();
   const { loading, solutions } = useExistingSolutions();
+  // Shares the TTL-cached resolution with useExistingSolutions — no extra probes.
+  const { value: resolution } = useSolutionState();
+
+  // The effective selection (explicit pick ?? default) is computed before the early returns so
+  // the report effect runs unconditionally (Rules of Hooks). While loading it reports undefined
+  // (the parent holds the carousel skeleton); settled with no solution it reports null (the
+  // parent shows the global list).
+  const selected: ExistingItem | undefined = solutions.find((item) => item.id === selectedId) ?? solutions[0];
+  const effectiveId = loading ? undefined : (selected?.id ?? null);
+  // useLayoutEffect: the parent's carousel swap commits before paint, so the list never
+  // flashes the global order once the default selection settles.
+  useLayoutEffect(() => {
+    onSelectionChange?.(effectiveId);
+  }, [effectiveId, onSelectionChange]);
 
   if (loading) {
     return <RecommendationExistingSkeleton />;
   }
 
-  // Stubs are placeholders, not live solutions: they never satisfy the no-data check.
-  if (solutions.length === 0) {
-    return <NoDataCard />;
+  if (!selected) {
+    // NoDataCard's hard claim is only true when every core signal settled inactive; anything
+    // else (active-but-no-entry, unknown) gets the softened variant.
+    const s = resolution?.state;
+    const allInactive =
+      !!s &&
+      s.metrics === 'inactive' &&
+      s.logs === 'inactive' &&
+      s.traces === 'inactive' &&
+      s.kubernetes === 'inactive';
+    return <NoDataCard variant={allInactive ? 'empty' : 'partial'} />;
   }
 
-  const existing = [...solutions, ...stubbedExisting];
-  const selected = existing.find((item) => item.title === selectedTitle) ?? existing[0];
-  return <ExistingSolutionCard existing={existing} selected={selected} onSelect={setSelectedTitle} />;
+  return <ExistingSolutionCard existing={solutions} selected={selected} onSelect={setSelectedId} />;
 }
 
 // Mirrors the card body (dropdown pill, icon + title, stats, CTA) while the solution

--- a/public/app/features/home/Recommendations/Recommendations.test.tsx
+++ b/public/app/features/home/Recommendations/Recommendations.test.tsx
@@ -140,14 +140,6 @@ describe('Recommendations', () => {
     expect(await screen.findByText('Recommendations for your stack')).toBeInTheDocument();
   });
 
-  it('shows the no-data card when no datasource has Kubernetes data', async () => {
-    render(<Recommendations />);
-
-    expect(await screen.findByRole('heading', { name: 'No data flowing yet' })).toBeInTheDocument();
-    expect(screen.queryByRole('heading', { name: 'Kubernetes Monitoring' })).not.toBeInTheDocument();
-    expect(screen.queryByRole('heading', { name: 'Hosted Metrics' })).not.toBeInTheDocument();
-  });
-
   it('renders nothing when the user cannot manage plugins', async () => {
     jest.mocked(contextSrv.hasPermission).mockReturnValue(false);
 

--- a/public/app/features/home/Recommendations/appPluginIds.ts
+++ b/public/app/features/home/Recommendations/appPluginIds.ts
@@ -3,3 +3,5 @@ export const SYNTHETIC_MONITORING_APP_ID = 'grafana-synthetic-monitoring-app';
 export const APP_OBSERVABILITY_APP_ID = 'grafana-app-observability-app';
 export const HOSTED_TRACES_APP_ID = 'grafana-exploretraces-app';
 export const FRONTEND_OBSERVABILITY_APP_ID = 'grafana-kowalski-app';
+export const LOGS_DRILLDOWN_APP_ID = 'grafana-lokiexplore-app';
+export const METRICS_DRILLDOWN_APP_ID = 'grafana-metricsdrilldown-app';

--- a/public/app/features/home/Recommendations/buildKubernetesItem.ts
+++ b/public/app/features/home/Recommendations/buildKubernetesItem.ts
@@ -76,7 +76,7 @@ export function buildKubernetesItem(parts: KubernetesItemParts, settings: Plugin
   const hasInventoryStats = inventory !== undefined && (clusterCount > 0 || podCount > 0);
 
   return {
-    id: 'kubernetes-monitoring',
+    id: 'kubernetes',
     title: t('home.recommendations.kubernetes.title', 'Kubernetes Monitoring'),
     icon: 'kubernetes',
     subtitle: t('home.recommendations.kubernetes.datasource', 'via {{name}}', { name: parts.datasourceName }),

--- a/public/app/features/home/Recommendations/buildTelemetryItems.ts
+++ b/public/app/features/home/Recommendations/buildTelemetryItems.ts
@@ -6,8 +6,7 @@ import { HOSTED_TRACES_APP_ID, LOGS_DRILLDOWN_APP_ID, METRICS_DRILLDOWN_APP_ID }
 import { type MetricsDiskPressure } from './telemetryData';
 import { type ExistingItem } from './types';
 
-// Browser locale is the deliberate choice: the homepage number format follows the user's environment.
-const compactFormatter = new Intl.NumberFormat(undefined, { notation: 'compact', maximumFractionDigits: 1 });
+const formatUsageNumber = getValueFormat('short');
 
 export interface LogsItemParts {
   bytes: number | null;
@@ -79,7 +78,7 @@ export function buildTracesItem(parts: TracesItemParts): ExistingItem {
         ? {
             primary: t('home.recommendations.traces.spans', '', {
               count: Math.ceil(spans),
-              value: compactFormatter.format(Math.ceil(spans)),
+              value: formattedValueToString(formatUsageNumber(Math.ceil(spans))),
               defaultValue_one: '{{value}} span',
               defaultValue_other: '{{value}} spans',
             }),
@@ -135,7 +134,7 @@ export function buildMetricsItem(parts: MetricsItemParts): ExistingItem {
     stats = {
       primary: t('home.recommendations.metrics.series', '', {
         count: Math.ceil(series),
-        value: compactFormatter.format(Math.ceil(series)),
+        value: formattedValueToString(formatUsageNumber(Math.ceil(series))),
         defaultValue_one: '{{value}} series',
         defaultValue_other: '{{value}} series',
       }),
@@ -146,7 +145,7 @@ export function buildMetricsItem(parts: MetricsItemParts): ExistingItem {
     stats = {
       primary: t('home.recommendations.metrics.names', '', {
         count: Math.ceil(names),
-        value: compactFormatter.format(Math.ceil(names)),
+        value: formattedValueToString(formatUsageNumber(Math.ceil(names))),
         defaultValue_one: '{{value}} metric',
         defaultValue_other: '{{value}} metrics',
       }),

--- a/public/app/features/home/Recommendations/buildTelemetryItems.ts
+++ b/public/app/features/home/Recommendations/buildTelemetryItems.ts
@@ -170,7 +170,7 @@ export function buildMetricsItem(parts: MetricsItemParts): ExistingItem {
   if (disk?.hoursToFull != null) {
     alertDetails.push(
       t('home.recommendations.metrics.disk-eta', '', {
-        count: Math.round(disk.hoursToFull),
+        count: Math.max(1, Math.round(disk.hoursToFull)),
         defaultValue_one: '~{{count}} h to full',
         defaultValue_other: '~{{count}} h to full',
       })

--- a/public/app/features/home/Recommendations/buildTelemetryItems.ts
+++ b/public/app/features/home/Recommendations/buildTelemetryItems.ts
@@ -1,0 +1,208 @@
+import { type FieldSparkline, formattedValueToString, getValueFormat, locationUtil } from '@grafana/data';
+import { t } from '@grafana/i18n';
+import { constructDataSourceExploreUrl } from 'app/features/datasources/utils';
+
+import { HOSTED_TRACES_APP_ID, LOGS_DRILLDOWN_APP_ID, METRICS_DRILLDOWN_APP_ID } from './appPluginIds';
+import { type MetricsDiskPressure } from './telemetryData';
+import { type ExistingItem } from './types';
+
+// Browser locale is the deliberate choice: the homepage number format follows the user's environment.
+const compactFormatter = new Intl.NumberFormat(undefined, { notation: 'compact', maximumFractionDigits: 1 });
+
+export interface LogsItemParts {
+  bytes: number | null;
+  sources: number | null;
+  volumeSeries: FieldSparkline | null;
+  datasourceName: string;
+  drilldownAvailable: boolean;
+}
+
+/** Build the Hosted Logs entry from live Loki data; the caller guarantees something to show. */
+export function buildLogsItem(parts: LogsItemParts): ExistingItem {
+  const { bytes, sources } = parts;
+  const drilldown = parts.drilldownAvailable;
+  return {
+    id: 'logs',
+    title: t('home.recommendations.logs.title', 'Hosted Logs'),
+    icon: 'gf-logs',
+    subtitle: t('home.recommendations.logs.datasource', 'via {{name}}', { name: parts.datasourceName }),
+    stats:
+      bytes != null
+        ? {
+            primary: formattedValueToString(getValueFormat('decbytes')(bytes)),
+            secondary:
+              sources != null
+                ? // '~': Loki label-values may scan a wider window than requested, so the count can
+                  // include stale sources.
+                  t('home.recommendations.logs.stats-sources', '', {
+                    count: sources,
+                    defaultValue_one: 'ingested · 7d · ~{{count}} source',
+                    defaultValue_other: 'ingested · 7d · ~{{count}} sources',
+                  })
+                : t('home.recommendations.logs.stats', 'ingested · 7d'),
+          }
+        : undefined,
+    sparkline: parts.volumeSeries
+      ? {
+          series: parts.volumeSeries,
+          caption: t('home.recommendations.logs.volume', 'Ingest volume · last 24h'),
+        }
+      : undefined,
+    action: drilldown
+      ? t('home.recommendations.logs.action', 'Open Explore (Logs)')
+      : t('home.recommendations.logs.action-explore', 'Open in Explore'),
+    href: drilldown
+      ? locationUtil.assureBaseUrl(`/a/${LOGS_DRILLDOWN_APP_ID}`)
+      : constructDataSourceExploreUrl({ name: parts.datasourceName }),
+  };
+}
+
+export interface TracesItemParts {
+  spans: number | null;
+  services: number | null;
+  throughputSeries: FieldSparkline | null;
+  datasourceName: string;
+  drilldownAvailable: boolean;
+}
+
+/** Build the Hosted Traces entry from live Tempo data; the caller guarantees something to show. */
+export function buildTracesItem(parts: TracesItemParts): ExistingItem {
+  const { spans, services } = parts;
+  const drilldown = parts.drilldownAvailable;
+  return {
+    id: 'traces',
+    title: t('home.recommendations.traces.title', 'Hosted Traces'),
+    icon: 'gf-traces',
+    subtitle: t('home.recommendations.traces.datasource', 'via {{name}}', { name: parts.datasourceName }),
+    stats:
+      spans != null
+        ? {
+            primary: t('home.recommendations.traces.spans', '', {
+              count: Math.ceil(spans),
+              value: compactFormatter.format(Math.ceil(spans)),
+              defaultValue_one: '{{value}} span',
+              defaultValue_other: '{{value}} spans',
+            }),
+            secondary:
+              services != null
+                ? t('home.recommendations.traces.stats-services', '', {
+                    count: services,
+                    defaultValue_one: 'traced · 24h · {{count}} service',
+                    defaultValue_other: 'traced · 24h · {{count}} services',
+                  })
+                : t('home.recommendations.traces.stats', 'traced · 24h'),
+          }
+        : undefined,
+    sparkline: parts.throughputSeries
+      ? {
+          series: parts.throughputSeries,
+          caption: t('home.recommendations.traces.throughput', 'Span throughput · last 24h'),
+        }
+      : undefined,
+    action: drilldown
+      ? t('home.recommendations.traces.action', 'Open Traces Drilldown')
+      : t('home.recommendations.traces.action-explore', 'Open in Explore'),
+    href: drilldown
+      ? locationUtil.assureBaseUrl(`/a/${HOSTED_TRACES_APP_ID}`)
+      : constructDataSourceExploreUrl({ name: parts.datasourceName }),
+  };
+}
+
+export interface MetricsItemParts {
+  series: number | null;
+  names: number | null;
+  hosts: number | null;
+  seriesSparkline: FieldSparkline | null;
+  disk: MetricsDiskPressure | null;
+  datasourceName: string;
+  drilldownAvailable: boolean;
+}
+
+/** Build the Metrics & infrastructure entry from live Prometheus data; the caller guarantees something to show. */
+export function buildMetricsItem(parts: MetricsItemParts): ExistingItem {
+  const { series, names, hosts, disk } = parts;
+  const drilldown = parts.drilldownAvailable;
+  const secondary =
+    hosts != null
+      ? t('home.recommendations.metrics.stats-hosts', '', {
+          count: hosts,
+          defaultValue_one: 'active · {{count}} host',
+          defaultValue_other: 'active · {{count}} hosts',
+        })
+      : t('home.recommendations.metrics.stats', 'active');
+  let stats: ExistingItem['stats'];
+  if (series != null) {
+    stats = {
+      primary: t('home.recommendations.metrics.series', '', {
+        count: Math.ceil(series),
+        value: compactFormatter.format(Math.ceil(series)),
+        defaultValue_one: '{{value}} series',
+        defaultValue_other: '{{value}} series',
+      }),
+      secondary,
+    };
+  } else if (names != null) {
+    // Fallback primary: the distinct-name count when no active-series source responded.
+    stats = {
+      primary: t('home.recommendations.metrics.names', '', {
+        count: Math.ceil(names),
+        value: compactFormatter.format(Math.ceil(names)),
+        defaultValue_one: '{{value}} metric',
+        defaultValue_other: '{{value}} metrics',
+      }),
+      secondary,
+    };
+  }
+  const alertDetails: string[] = [];
+  if (disk?.worstInstance && disk.worstRatio != null) {
+    alertDetails.push(
+      t('home.recommendations.metrics.disk-worst', '{{host}} at {{percent}}%', {
+        // The design shows the bare host ("web-03"), not the scrape target ("web-03:9100").
+        host: disk.worstInstance.replace(/:\d+$/, ''),
+        percent: Math.round(disk.worstRatio * 100),
+      })
+    );
+  }
+  if (disk?.hoursToFull != null) {
+    alertDetails.push(
+      t('home.recommendations.metrics.disk-eta', '', {
+        count: Math.round(disk.hoursToFull),
+        defaultValue_one: '~{{count}} h to full',
+        defaultValue_other: '~{{count}} h to full',
+      })
+    );
+  }
+  return {
+    id: 'metrics',
+    title: t('home.recommendations.metrics.title', 'Metrics & infrastructure'),
+    icon: 'chart-line',
+    subtitle: t('home.recommendations.metrics.datasource', 'via {{name}}', { name: parts.datasourceName }),
+    stats,
+    sparkline: parts.seriesSparkline
+      ? {
+          series: parts.seriesSparkline,
+          caption: t('home.recommendations.metrics.series-trend', 'Active series · last 24h'),
+        }
+      : undefined,
+    alert:
+      disk != null && disk.hostsAbove > 0
+        ? {
+            primary: t('home.recommendations.metrics.disk-hosts', '', {
+              count: disk.hostsAbove,
+              defaultValue_one: '{{count}} host above 90% disk',
+              defaultValue_other: '{{count}} hosts above 90% disk',
+            }),
+            details: alertDetails,
+            action: t('home.recommendations.metrics.view', 'View'),
+            // No app route exists for host disk detail; Explore with the datasource preselected.
+            href: constructDataSourceExploreUrl({ name: parts.datasourceName }),
+          }
+        : undefined,
+    action: drilldown
+      ? t('home.recommendations.metrics.action', 'Open Metrics Drilldown')
+      : t('home.recommendations.metrics.action-explore', 'Open in Explore'),
+    href: drilldown
+      ? locationUtil.assureBaseUrl(`/a/${METRICS_DRILLDOWN_APP_ID}`)
+      : constructDataSourceExploreUrl({ name: parts.datasourceName }),
+  };
+}

--- a/public/app/features/home/Recommendations/buildTelemetryItems.ts
+++ b/public/app/features/home/Recommendations/buildTelemetryItems.ts
@@ -109,6 +109,7 @@ export function buildTracesItem(parts: TracesItemParts): ExistingItem {
 
 export interface MetricsItemParts {
   series: number | null;
+  dataPointsPerMinute: number | null;
   names: number | null;
   hosts: number | null;
   seriesSparkline: FieldSparkline | null;
@@ -122,13 +123,17 @@ export function buildMetricsItem(parts: MetricsItemParts): ExistingItem {
   const { series, names, hosts, disk } = parts;
   const drilldown = parts.drilldownAvailable;
   const secondary =
-    hosts != null
-      ? t('home.recommendations.metrics.stats-hosts', '', {
-          count: hosts,
-          defaultValue_one: 'active · {{count}} host',
-          defaultValue_other: 'active · {{count}} hosts',
+    parts.dataPointsPerMinute != null
+      ? t('home.recommendations.metrics.data-points-per-minute', '{{value}} data points/min', {
+          value: formattedValueToString(formatUsageNumber(Math.ceil(parts.dataPointsPerMinute))),
         })
-      : t('home.recommendations.metrics.stats', 'active');
+      : hosts != null
+        ? t('home.recommendations.metrics.stats-hosts', '', {
+            count: hosts,
+            defaultValue_one: 'active · {{count}} host',
+            defaultValue_other: 'active · {{count}} hosts',
+          })
+        : t('home.recommendations.metrics.stats', 'active');
   let stats: ExistingItem['stats'];
   if (series != null) {
     stats = {

--- a/public/app/features/home/Recommendations/solutionState.ts
+++ b/public/app/features/home/Recommendations/solutionState.ts
@@ -1,3 +1,5 @@
+import { useAsync } from 'react-use';
+
 import { type DataSourceInstanceListItem } from '@grafana/data';
 
 import { resolveKubernetesDatasource } from './kubernetesData';
@@ -124,4 +126,9 @@ export async function resolveSolutionState(): Promise<SolutionStateResolution> {
 /** Reset the cached resolution (test seam). Does NOT reset kubernetesData's own TTL cache. */
 export function resetSolutionStateResolution(): void {
   solutionStateResolution.reset();
+}
+
+/** Gate inside the callback (Rules of Hooks): a disabled caller never triggers the probes. */
+export function useSolutionState(enabled = true): { value?: SolutionStateResolution; loading: boolean } {
+  return useAsync(async () => (enabled ? resolveSolutionState() : undefined), [enabled]);
 }

--- a/public/app/features/home/Recommendations/telemetryData.test.ts
+++ b/public/app/features/home/Recommendations/telemetryData.test.ts
@@ -175,8 +175,23 @@ describe('fetchLogsActivity', () => {
     });
     mockResolveBackendInstance.mockResolvedValue(instanceWith(getResource));
 
-    await expect(fetchLogsActivity(loki)).resolves.toEqual({ bytes: 0, sources: 1, series: null });
+    await expect(fetchLogsActivity(loki)).resolves.toEqual({ bytes: null, sources: 1, series: null });
     expect(getResource).toHaveBeenCalledWith('label/job/values', expect.anything(), expect.anything());
+  });
+
+  it('reports null bytes when the volume result is empty', async () => {
+    const getResource = jest.fn(async (path: string) => {
+      if (path === 'labels') {
+        return { data: ['service_name'] };
+      }
+      if (path === 'index/volume' || path === 'index/volume_range') {
+        return { data: { result: [] } };
+      }
+      return { data: ['a'] };
+    });
+    mockResolveBackendInstance.mockResolvedValue(instanceWith(getResource));
+
+    await expect(fetchLogsActivity(loki)).resolves.toEqual({ bytes: null, sources: 1, series: null });
   });
 
   it('keeps the other fields when one endpoint is unavailable', async () => {

--- a/public/app/features/home/Recommendations/telemetryData.ts
+++ b/public/app/features/home/Recommendations/telemetryData.ts
@@ -173,7 +173,7 @@ export async function fetchTracesActivity(ds: Pick<DataSourceInstanceListItem, '
   };
 }
 
-interface MetricsDiskPressure {
+export interface MetricsDiskPressure {
   /** Hosts whose fullest filesystem exceeds the pressure threshold. */
   hostsAbove: number;
   worstInstance: string | null;

--- a/public/app/features/home/Recommendations/telemetryData.ts
+++ b/public/app/features/home/Recommendations/telemetryData.ts
@@ -116,7 +116,10 @@ export async function fetchLogsActivity(ds: Pick<DataSourceInstanceListItem, 'ui
     }
   }
   return {
-    bytes: Array.isArray(volumes) ? volumes.reduce((total, entry) => total + (Number(entry.value?.[1]) || 0), 0) : null,
+    bytes:
+      Array.isArray(volumes) && volumes.length > 0
+        ? volumes.reduce((total, entry) => total + (Number(entry.value?.[1]) || 0), 0)
+        : null,
     sources: Array.isArray(values?.data) ? values.data.length : null,
     series: toSparkline([...buckets.entries()], 'Ingest volume'),
   };

--- a/public/app/features/home/Recommendations/types.ts
+++ b/public/app/features/home/Recommendations/types.ts
@@ -1,6 +1,7 @@
 import { type GrafanaTheme2, type IconName } from '@grafana/data';
 
 import { type SolutionSparklineData } from './SolutionSparkline';
+import { type ExistingSolutionId } from './solutionsMatrix';
 
 export interface RecommendationItem {
   id: string; // stable telemetry id (recommendation_id)
@@ -16,7 +17,7 @@ export interface RecommendationItem {
 }
 
 export interface ExistingItem {
-  id: string; // stable telemetry id (solution)
+  id: ExistingSolutionId; // stable telemetry id (solution)
   title: string;
   icon: IconName;
   subtitle?: string;

--- a/public/app/features/home/Recommendations/useExistingSolutions.test.ts
+++ b/public/app/features/home/Recommendations/useExistingSolutions.test.ts
@@ -3,20 +3,57 @@ import { renderHook } from '@testing-library/react';
 import { type ExistingItem } from './types';
 import { useExistingSolutions } from './useExistingSolutions';
 import { useKubernetesSolution } from './useKubernetesSolution';
+import { useTelemetrySolutions } from './useTelemetrySolutions';
 
 jest.mock('./useKubernetesSolution', () => ({
   useKubernetesSolution: jest.fn(),
 }));
 
+jest.mock('./useTelemetrySolutions', () => ({
+  useTelemetrySolutions: jest.fn(),
+}));
+
 const mockUseKubernetesSolution = jest.mocked(useKubernetesSolution);
+const mockUseTelemetrySolutions = jest.mocked(useTelemetrySolutions);
 
 const kubernetesItem: ExistingItem = {
-  id: 'kubernetes-monitoring',
+  id: 'kubernetes',
   title: 'Kubernetes Monitoring',
   icon: 'kubernetes',
   action: 'Open K8s app',
   href: '#',
 };
+
+const metricsItem: ExistingItem = {
+  id: 'metrics',
+  title: 'Metrics & infrastructure',
+  icon: 'chart-line',
+  action: 'Open Metrics Drilldown',
+  href: '#',
+};
+
+const logsItem: ExistingItem = {
+  id: 'logs',
+  title: 'Hosted Logs',
+  icon: 'gf-logs',
+  action: 'Open Explore (Logs)',
+  href: '#',
+};
+
+const tracesItem: ExistingItem = {
+  id: 'traces',
+  title: 'Hosted Traces',
+  icon: 'gf-traces',
+  action: 'Open Traces Drilldown',
+  href: '#',
+};
+
+const settled = (item: ExistingItem | null) => ({ loading: false, item });
+
+beforeEach(() => {
+  mockUseKubernetesSolution.mockReturnValue(settled(null));
+  mockUseTelemetrySolutions.mockReturnValue({ metrics: settled(null), logs: settled(null), traces: settled(null) });
+});
 
 describe('useExistingSolutions', () => {
   it('reports loading while a provider is still probing and nothing was found', () => {
@@ -27,27 +64,55 @@ describe('useExistingSolutions', () => {
     expect(result.current).toEqual({ loading: true, solutions: [] });
   });
 
-  it('settles empty when every provider settles without an item', () => {
-    mockUseKubernetesSolution.mockReturnValue({ loading: false, item: null });
+  it('reports loading while a telemetry provider is still resolving', () => {
+    mockUseTelemetrySolutions.mockReturnValue({
+      metrics: settled(null),
+      logs: { loading: true, item: null },
+      traces: settled(null),
+    });
 
+    const { result } = renderHook(() => useExistingSolutions());
+
+    expect(result.current).toEqual({ loading: true, solutions: [] });
+  });
+
+  it('settles empty when every provider settles without an item', () => {
     const { result } = renderHook(() => useExistingSolutions());
 
     expect(result.current).toEqual({ loading: false, solutions: [] });
   });
 
   it('returns the provider item once found', () => {
-    mockUseKubernetesSolution.mockReturnValue({ loading: false, item: kubernetesItem });
+    mockUseKubernetesSolution.mockReturnValue(settled(kubernetesItem));
 
     const { result } = renderHook(() => useExistingSolutions());
 
     expect(result.current).toEqual({ loading: false, solutions: [kubernetesItem] });
   });
 
-  it('renders a discovered solution immediately even if a provider still reports loading', () => {
-    mockUseKubernetesSolution.mockReturnValue({ loading: true, item: kubernetesItem });
+  it('orders solutions kubernetes, metrics, logs, traces with no duplicates', () => {
+    mockUseKubernetesSolution.mockReturnValue(settled(kubernetesItem));
+    mockUseTelemetrySolutions.mockReturnValue({
+      metrics: settled(metricsItem),
+      logs: settled(logsItem),
+      traces: settled(tracesItem),
+    });
 
     const { result } = renderHook(() => useExistingSolutions());
 
-    expect(result.current).toEqual({ loading: false, solutions: [kubernetesItem] });
+    expect(result.current.solutions).toEqual([kubernetesItem, metricsItem, logsItem, tracesItem]);
+  });
+
+  it('keeps reporting loading until every provider settles so the default selection is final', () => {
+    mockUseKubernetesSolution.mockReturnValue({ loading: true, item: null });
+    mockUseTelemetrySolutions.mockReturnValue({
+      metrics: settled(null),
+      logs: settled(logsItem),
+      traces: settled(null),
+    });
+
+    const { result } = renderHook(() => useExistingSolutions());
+
+    expect(result.current).toEqual({ loading: true, solutions: [logsItem] });
   });
 });

--- a/public/app/features/home/Recommendations/useExistingSolutions.ts
+++ b/public/app/features/home/Recommendations/useExistingSolutions.ts
@@ -1,5 +1,6 @@
 import { type ExistingItem, type ExistingSolutionProviderResult } from './types';
 import { useKubernetesSolution } from './useKubernetesSolution';
+import { useTelemetrySolutions } from './useTelemetrySolutions';
 
 export interface ExistingSolutionsResult {
   loading: boolean;
@@ -13,13 +14,15 @@ export interface ExistingSolutionsResult {
  */
 export function useExistingSolutions(): ExistingSolutionsResult {
   const kubernetes = useKubernetesSolution();
+  const { metrics, logs, traces } = useTelemetrySolutions();
 
-  const providers: ExistingSolutionProviderResult[] = [kubernetes];
+  // UI order: kubernetes, metrics, logs, traces.
+  const providers: ExistingSolutionProviderResult[] = [kubernetes, metrics, logs, traces];
 
   const solutions = providers.flatMap((provider) => (provider.item ? [provider.item] : []));
-  // A discovered solution renders immediately; the empty state waits for every
-  // provider to settle so a slow probe never yields a premature no-data card.
-  const loading = solutions.length === 0 && providers.some((provider) => provider.loading);
+  // Every provider must settle before anything renders: the default selection is solutions[0],
+  // and a later-settling provider earlier in UI order would swap it after first paint.
+  const loading = providers.some((provider) => provider.loading);
 
   return { loading, solutions };
 }

--- a/public/app/features/home/Recommendations/useTelemetrySolutions.test.tsx
+++ b/public/app/features/home/Recommendations/useTelemetrySolutions.test.tsx
@@ -1,7 +1,7 @@
 import { act, render, waitFor } from 'test/test-utils';
 
 import { type DataSourceInstanceListItem } from '@grafana/data';
-import { useAppPluginMetas } from '@grafana/runtime/internal';
+import { usePluginBridge } from 'app/features/alerting/unified/hooks/usePluginBridge';
 
 import { useSolutionState } from './solutionState';
 import { type SolutionState } from './solutionsMatrix';
@@ -20,13 +20,13 @@ jest.mock('./telemetryData', () => ({
   fetchTracesServices: jest.fn(),
 }));
 
-jest.mock('@grafana/runtime/internal', () => ({
-  ...jest.requireActual('@grafana/runtime/internal'),
-  useAppPluginMetas: jest.fn(),
+jest.mock('app/features/alerting/unified/hooks/usePluginBridge', () => ({
+  ...jest.requireActual('app/features/alerting/unified/hooks/usePluginBridge'),
+  usePluginBridge: jest.fn(),
 }));
 
 const mockUseSolutionState = jest.mocked(useSolutionState);
-const mockUseAppPluginMetas = jest.mocked(useAppPluginMetas);
+const mockUsePluginBridge = jest.mocked(usePluginBridge);
 const mockFetchLogsActivity = jest.mocked(fetchLogsActivity);
 const mockFetchMetricsActivity = jest.mocked(fetchMetricsActivity);
 const mockFetchTracesActivity = jest.mocked(fetchTracesActivity);
@@ -88,7 +88,7 @@ beforeEach(() => {
   frames.length = 0;
   mockUseSolutionState.mockReset();
   setSolutionState({});
-  mockUseAppPluginMetas.mockReturnValue({ loading: false, error: undefined, value: [] });
+  mockUsePluginBridge.mockReturnValue({ loading: false, installed: false, settings: undefined });
   mockFetchMetricsActivity.mockReset();
   mockFetchMetricsActivity.mockResolvedValue({
     series: null,

--- a/public/app/features/home/Recommendations/useTelemetrySolutions.test.tsx
+++ b/public/app/features/home/Recommendations/useTelemetrySolutions.test.tsx
@@ -1,0 +1,177 @@
+import { act, render, waitFor } from 'test/test-utils';
+
+import { type DataSourceInstanceListItem } from '@grafana/data';
+import { useAppPluginMetas } from '@grafana/runtime/internal';
+
+import { useSolutionState } from './solutionState';
+import { type SolutionState } from './solutionsMatrix';
+import { fetchLogsActivity, fetchMetricsActivity, fetchTracesActivity, fetchTracesServices } from './telemetryData';
+import { useTelemetrySolutions, type TelemetrySolutions } from './useTelemetrySolutions';
+
+jest.mock('./solutionState', () => ({
+  useSolutionState: jest.fn(),
+}));
+
+jest.mock('./telemetryData', () => ({
+  ...jest.requireActual('./telemetryData'),
+  fetchLogsActivity: jest.fn(),
+  fetchMetricsActivity: jest.fn(),
+  fetchTracesActivity: jest.fn(),
+  fetchTracesServices: jest.fn(),
+}));
+
+jest.mock('@grafana/runtime/internal', () => ({
+  ...jest.requireActual('@grafana/runtime/internal'),
+  useAppPluginMetas: jest.fn(),
+}));
+
+const mockUseSolutionState = jest.mocked(useSolutionState);
+const mockUseAppPluginMetas = jest.mocked(useAppPluginMetas);
+const mockFetchLogsActivity = jest.mocked(fetchLogsActivity);
+const mockFetchMetricsActivity = jest.mocked(fetchMetricsActivity);
+const mockFetchTracesActivity = jest.mocked(fetchTracesActivity);
+const mockFetchTracesServices = jest.mocked(fetchTracesServices);
+
+const prometheusDatasource: DataSourceInstanceListItem = {
+  uid: 'prom-uid',
+  name: 'grafanacloud-prom',
+  type: 'prometheus',
+  meta: { id: 'prometheus' } as DataSourceInstanceListItem['meta'],
+  readOnly: false,
+  isDefault: false,
+};
+
+const tempoDatasource: DataSourceInstanceListItem = {
+  uid: 'tempo-uid',
+  name: 'grafanacloud-traces',
+  type: 'tempo',
+  meta: { id: 'tempo' } as DataSourceInstanceListItem['meta'],
+  readOnly: false,
+  isDefault: false,
+};
+
+function setSolutionState(
+  overrides: Partial<SolutionState>,
+  ds: {
+    loki?: DataSourceInstanceListItem;
+    tempo?: DataSourceInstanceListItem;
+    prometheus?: DataSourceInstanceListItem;
+  } = {}
+) {
+  mockUseSolutionState.mockReturnValue({
+    value: {
+      state: {
+        metrics: 'inactive',
+        logs: 'inactive',
+        traces: 'inactive',
+        kubernetes: 'inactive',
+        spanMetrics: 'inactive',
+        ...overrides,
+      },
+      lokiDatasource: ds.loki ?? null,
+      tempoDatasource: ds.tempo ?? null,
+      prometheusDatasource: ds.prometheus ?? null,
+    },
+    loading: false,
+  });
+}
+
+// Frame-capture probe: the one-frame settled-empty hazard re-renders away before
+// post-`act` DOM assertions could see it, so record every render's hook result instead.
+const frames: TelemetrySolutions[] = [];
+function Probe() {
+  frames.push(useTelemetrySolutions());
+  return null;
+}
+
+beforeEach(() => {
+  frames.length = 0;
+  mockUseSolutionState.mockReset();
+  setSolutionState({});
+  mockUseAppPluginMetas.mockReturnValue({ loading: false, error: undefined, value: [] });
+  mockFetchMetricsActivity.mockReset();
+  mockFetchMetricsActivity.mockResolvedValue({
+    series: null,
+    dataPointsPerMinute: null,
+    names: null,
+    hosts: null,
+    seriesSparkline: null,
+    disk: null,
+  });
+  mockFetchLogsActivity.mockReset();
+  mockFetchLogsActivity.mockResolvedValue({ bytes: null, sources: null, series: null });
+  mockFetchTracesActivity.mockReset();
+  mockFetchTracesActivity.mockResolvedValue({ spans: null, series: null });
+  mockFetchTracesServices.mockReset();
+  mockFetchTracesServices.mockResolvedValue(null);
+});
+
+describe('useTelemetrySolutions', () => {
+  it('never reports settled-empty on the render where a signal flips active', async () => {
+    mockUseSolutionState.mockReturnValue({ value: undefined, loading: true });
+    mockFetchMetricsActivity.mockReturnValue(new Promise<never>(() => {}));
+
+    const { rerender } = render(<Probe />);
+    // Let the disabled useAsync run settle `undefined`.
+    await act(async () => {});
+
+    setSolutionState({ metrics: 'active' }, { prometheus: prometheusDatasource });
+    rerender(<Probe />);
+    await act(async () => {});
+
+    // The fetch never settles, so every captured frame must still read as loading —
+    // including the flip frame, where useAsync still exposes the disabled run's settle.
+    expect(frames.length).toBeGreaterThan(0);
+    expect(frames.every((f) => f.metrics.loading)).toBe(true);
+    expect(frames.every((f) => f.metrics.item === null)).toBe(true);
+  });
+
+  it('settles with the item once the fetch resolves', async () => {
+    setSolutionState({ metrics: 'active' }, { prometheus: prometheusDatasource });
+    mockFetchMetricsActivity.mockResolvedValue({
+      series: 4_200_000,
+      dataPointsPerMinute: null,
+      names: null,
+      hosts: null,
+      seriesSparkline: null,
+      disk: null,
+    });
+
+    render(<Probe />);
+
+    await waitFor(() => {
+      const last = frames[frames.length - 1];
+      expect(last?.metrics.loading).toBe(false);
+      expect(last?.metrics.item).not.toBeNull();
+    });
+  });
+
+  it('fails closed when a detail fetch rejects', async () => {
+    setSolutionState({ traces: 'active' }, { tempo: tempoDatasource });
+    mockFetchTracesActivity.mockRejectedValue(new Error('tempo down'));
+    mockFetchTracesServices.mockResolvedValue(3);
+
+    render(<Probe />);
+
+    await waitFor(() => {
+      const last = frames[frames.length - 1];
+      expect(last?.traces.loading).toBe(false);
+      expect(last?.traces.item).toBeNull();
+    });
+  });
+
+  it('ships the traces card without waiting for the services count', async () => {
+    setSolutionState({ traces: 'active' }, { tempo: tempoDatasource });
+    mockFetchTracesActivity.mockResolvedValue({ spans: 4_800_000, series: null });
+    mockFetchTracesServices.mockReturnValue(new Promise<never>(() => {}));
+
+    render(<Probe />);
+
+    await waitFor(() => {
+      const last = frames[frames.length - 1];
+      expect(last?.traces.loading).toBe(false);
+      expect(last?.traces.item).not.toBeNull();
+      expect(last?.traces.item?.stats?.secondary).toBe('traced · 24h');
+    });
+  });
+});

--- a/public/app/features/home/Recommendations/useTelemetrySolutions.ts
+++ b/public/app/features/home/Recommendations/useTelemetrySolutions.ts
@@ -1,6 +1,6 @@
 import { useAsync } from 'react-use';
 
-import { useAppPluginMetas } from '@grafana/runtime/internal';
+import { canAccessPluginPage, usePluginBridge } from 'app/features/alerting/unified/hooks/usePluginBridge';
 
 import { HOSTED_TRACES_APP_ID, LOGS_DRILLDOWN_APP_ID, METRICS_DRILLDOWN_APP_ID } from './appPluginIds';
 import { buildLogsItem, buildMetricsItem, buildTracesItem } from './buildTelemetryItems';
@@ -36,15 +36,26 @@ function toProviderResult<T>(
 }
 
 /**
+ * Whether a drilldown app is installed, enabled, and its root page is accessible — bootdata
+ * membership alone lists installed-but-disabled apps (config.apps carries no enabled state),
+ * which would turn the CTA into a dead /a/<id> link instead of the working Explore fallback.
+ */
+function useDrilldownAvailable(appId: string): boolean {
+  const { installed, settings } = usePluginBridge(appId);
+  return !!installed && !!settings && canAccessPluginPage(settings, `/a/${appId}`);
+}
+
+/**
  * Metrics, Logs and Traces solution providers: an entry appears only for a confirmed-active
  * signal ('unknown' never invents one) AND when its detail fetches produced something to show —
  * a bare title card with every stat failed-soft reads as broken, so it is dropped instead.
  */
 export function useTelemetrySolutions(): TelemetrySolutions {
   const { value: resolution, loading: stateLoading } = useSolutionState();
-  // Availability only picks link targets; a pending lookup falls back to /explore (never blocks).
-  const { value: appMetas } = useAppPluginMetas();
-  const availableApps = new Set((appMetas ?? []).map((app) => app.id));
+  // Availability only picks link targets; a pending probe falls back to /explore (never blocks).
+  const metricsDrilldown = useDrilldownAvailable(METRICS_DRILLDOWN_APP_ID);
+  const logsDrilldown = useDrilldownAvailable(LOGS_DRILLDOWN_APP_ID);
+  const tracesDrilldown = useDrilldownAvailable(HOSTED_TRACES_APP_ID);
 
   const promDs = resolution?.state.metrics === 'active' ? resolution.prometheusDatasource : null;
   const lokiDs = resolution?.state.logs === 'active' ? resolution.lokiDatasource : null;
@@ -85,7 +96,7 @@ export function useTelemetrySolutions(): TelemetrySolutions {
             seriesSparkline: activity.seriesSparkline,
             disk: activity.disk,
             datasourceName: promDs.name,
-            drilldownAvailable: availableApps.has(METRICS_DRILLDOWN_APP_ID),
+            drilldownAvailable: metricsDrilldown,
           })
     );
   }
@@ -101,7 +112,7 @@ export function useTelemetrySolutions(): TelemetrySolutions {
             sources: activity.sources,
             volumeSeries: activity.series,
             datasourceName: lokiDs.name,
-            drilldownAvailable: availableApps.has(LOGS_DRILLDOWN_APP_ID),
+            drilldownAvailable: logsDrilldown,
           })
     );
   }
@@ -119,7 +130,7 @@ export function useTelemetrySolutions(): TelemetrySolutions {
             services: tracesServices.value ?? null,
             throughputSeries: activity.series,
             datasourceName: tempoDs.name,
-            drilldownAvailable: availableApps.has(HOSTED_TRACES_APP_ID),
+            drilldownAvailable: tracesDrilldown,
           })
     );
   }

--- a/public/app/features/home/Recommendations/useTelemetrySolutions.ts
+++ b/public/app/features/home/Recommendations/useTelemetrySolutions.ts
@@ -6,12 +6,31 @@ import { HOSTED_TRACES_APP_ID, LOGS_DRILLDOWN_APP_ID, METRICS_DRILLDOWN_APP_ID }
 import { buildLogsItem, buildMetricsItem, buildTracesItem } from './buildTelemetryItems';
 import { useSolutionState } from './solutionState';
 import { fetchLogsActivity, fetchMetricsActivity, fetchTracesActivity, fetchTracesServices } from './telemetryData';
-import { type ExistingSolutionProviderResult } from './types';
+import { type ExistingItem, type ExistingSolutionProviderResult } from './types';
 
 export interface TelemetrySolutions {
   metrics: ExistingSolutionProviderResult;
   logs: ExistingSolutionProviderResult;
   traces: ExistingSolutionProviderResult;
+}
+
+// Shared settle gate for the three providers. Error fails closed (settled no-data — the types.ts
+// provider contract). Loading or an undefined value reads as loading: on the render where a
+// signal flips active, useAsync still exposes the disabled run's settled `undefined` (its effect
+// re-runs only after paint), and a datasource-change refetch retains the prior value — neither
+// may paint as settled (same guard as useKubernetesSolution). `build` returns null when the
+// activity has nothing to carry a card.
+function toProviderResult<T>(
+  state: { loading: boolean; error?: Error; value?: { activity: T } },
+  build: (activity: T) => ExistingItem | null
+): ExistingSolutionProviderResult {
+  if (state.error) {
+    return { loading: false, item: null };
+  }
+  if (state.loading || !state.value) {
+    return { loading: true, item: null };
+  }
+  return { loading: false, item: build(state.value.activity) };
 }
 
 /**
@@ -30,76 +49,77 @@ export function useTelemetrySolutions(): TelemetrySolutions {
   const tempoDs = resolution?.state.traces === 'active' ? resolution.tempoDatasource : null;
 
   // Gate inside the callbacks (ds in the deps): an inactive or unknown signal never queries.
-  const metricsActivity = useAsync(async () => (promDs ? fetchMetricsActivity(promDs) : undefined), [promDs]);
-  const logsActivity = useAsync(async () => (lokiDs ? fetchLogsActivity(lokiDs) : undefined), [lokiDs]);
-  const tracesActivity = useAsync(async () => (tempoDs ? fetchTracesActivity(tempoDs) : undefined), [tempoDs]);
+  // Values are wrapped so only an enabled run can produce a defined value: on the render where
+  // a signal flips active, useAsync still reports the disabled run's settled `undefined`, which
+  // must read as loading — not as a settled empty fetch (same guard as useKubernetesSolution).
+  const metricsActivity = useAsync(
+    async () => (promDs ? { activity: await fetchMetricsActivity(promDs) } : undefined),
+    [promDs]
+  );
+  const logsActivity = useAsync(
+    async () => (lokiDs ? { activity: await fetchLogsActivity(lokiDs) } : undefined),
+    [lokiDs]
+  );
+  const tracesActivity = useAsync(
+    async () => (tempoDs ? { activity: await fetchTracesActivity(tempoDs) } : undefined),
+    [tempoDs]
+  );
+  // Best-effort enrichment, never a settle gate: undefined (pending or stale) and a rejection
+  // both render the card without a service count, so this one needs no wrap.
   const tracesServices = useAsync(async () => (tempoDs ? fetchTracesServices(tempoDs) : undefined), [tempoDs]);
 
   let metrics: ExistingSolutionProviderResult = { loading: stateLoading, item: null };
   if (promDs) {
-    const activity = metricsActivity.value;
     // Hosts/disk are secondary/alert content; without a series count, name count, or sparkline
     // there is nothing to carry the card.
-    metrics =
-      metricsActivity.loading || !activity
-        ? { loading: metricsActivity.loading, item: null }
-        : activity.series == null && activity.names == null && activity.seriesSparkline == null
-          ? { loading: false, item: null }
-          : {
-              loading: false,
-              item: buildMetricsItem({
-                series: activity.series,
-                dataPointsPerMinute: activity.dataPointsPerMinute,
-                names: activity.names,
-                hosts: activity.hosts,
-                seriesSparkline: activity.seriesSparkline,
-                disk: activity.disk,
-                datasourceName: promDs.name,
-                drilldownAvailable: availableApps.has(METRICS_DRILLDOWN_APP_ID),
-              }),
-            };
+    metrics = toProviderResult(metricsActivity, (activity) =>
+      activity.series == null && activity.names == null && activity.seriesSparkline == null
+        ? null
+        : buildMetricsItem({
+            series: activity.series,
+            dataPointsPerMinute: activity.dataPointsPerMinute,
+            names: activity.names,
+            hosts: activity.hosts,
+            seriesSparkline: activity.seriesSparkline,
+            disk: activity.disk,
+            datasourceName: promDs.name,
+            drilldownAvailable: availableApps.has(METRICS_DRILLDOWN_APP_ID),
+          })
+    );
   }
 
   let logs: ExistingSolutionProviderResult = { loading: stateLoading, item: null };
   if (lokiDs) {
-    const activity = logsActivity.value;
     // Stats need bytes, the sparkline needs the series; with neither there is nothing to render.
-    logs =
-      logsActivity.loading || !activity
-        ? { loading: logsActivity.loading, item: null }
-        : activity.bytes == null && activity.series == null
-          ? { loading: false, item: null }
-          : {
-              loading: false,
-              item: buildLogsItem({
-                bytes: activity.bytes,
-                sources: activity.sources,
-                volumeSeries: activity.series,
-                datasourceName: lokiDs.name,
-                drilldownAvailable: availableApps.has(LOGS_DRILLDOWN_APP_ID),
-              }),
-            };
+    logs = toProviderResult(logsActivity, (activity) =>
+      activity.bytes == null && activity.series == null
+        ? null
+        : buildLogsItem({
+            bytes: activity.bytes,
+            sources: activity.sources,
+            volumeSeries: activity.series,
+            datasourceName: lokiDs.name,
+            drilldownAvailable: availableApps.has(LOGS_DRILLDOWN_APP_ID),
+          })
+    );
   }
 
   let traces: ExistingSolutionProviderResult = { loading: stateLoading, item: null };
   if (tempoDs) {
-    const activity = tracesActivity.value;
-    // The services count alone renders nothing (it is the stats secondary), so it cannot carry a card.
-    traces =
-      tracesActivity.loading || tracesServices.loading || !activity
-        ? { loading: tracesActivity.loading || tracesServices.loading, item: null }
-        : activity.spans == null && activity.series == null
-          ? { loading: false, item: null }
-          : {
-              loading: false,
-              item: buildTracesItem({
-                spans: activity.spans,
-                services: tracesServices.value ?? null,
-                throughputSeries: activity.series,
-                datasourceName: tempoDs.name,
-                drilldownAvailable: availableApps.has(HOSTED_TRACES_APP_ID),
-              }),
-            };
+    // The services count alone renders nothing (it is the stats secondary), so it cannot carry a
+    // card — and a slow count must not stall the left card: the card ships without it and the
+    // count fills in when it lands.
+    traces = toProviderResult(tracesActivity, (activity) =>
+      activity.spans == null && activity.series == null
+        ? null
+        : buildTracesItem({
+            spans: activity.spans,
+            services: tracesServices.value ?? null,
+            throughputSeries: activity.series,
+            datasourceName: tempoDs.name,
+            drilldownAvailable: availableApps.has(HOSTED_TRACES_APP_ID),
+          })
+    );
   }
 
   return { metrics, logs, traces };

--- a/public/app/features/home/Recommendations/useTelemetrySolutions.ts
+++ b/public/app/features/home/Recommendations/useTelemetrySolutions.ts
@@ -49,6 +49,7 @@ export function useTelemetrySolutions(): TelemetrySolutions {
               loading: false,
               item: buildMetricsItem({
                 series: activity.series,
+                dataPointsPerMinute: activity.dataPointsPerMinute,
                 names: activity.names,
                 hosts: activity.hosts,
                 seriesSparkline: activity.seriesSparkline,

--- a/public/app/features/home/Recommendations/useTelemetrySolutions.ts
+++ b/public/app/features/home/Recommendations/useTelemetrySolutions.ts
@@ -36,13 +36,20 @@ function toProviderResult<T>(
 }
 
 /**
- * Whether a drilldown app is installed, enabled, and its root page is accessible — bootdata
+ * Whether a drilldown app is installed, enabled, and its default page is accessible — bootdata
  * membership alone lists installed-but-disabled apps (config.apps carries no enabled state),
  * which would turn the CTA into a dead /a/<id> link instead of the working Explore fallback.
+ * The CTA links to the app root, which lands on the default-nav include's page, so that is the
+ * path whose role/action gate must pass (canAccessPluginPage exact-matches declared include
+ * paths and allows unmatched ones, like the core app route guard).
  */
 function useDrilldownAvailable(appId: string): boolean {
   const { installed, settings } = usePluginBridge(appId);
-  return !!installed && !!settings && canAccessPluginPage(settings, `/a/${appId}`);
+  if (!installed || !settings) {
+    return false;
+  }
+  const defaultPage = settings.includes?.find((include) => include.defaultNav && include.path)?.path;
+  return canAccessPluginPage(settings, defaultPage ?? `/a/${appId}`);
 }
 
 /**

--- a/public/app/features/home/Recommendations/useTelemetrySolutions.ts
+++ b/public/app/features/home/Recommendations/useTelemetrySolutions.ts
@@ -1,0 +1,105 @@
+import { useAsync } from 'react-use';
+
+import { useAppPluginMetas } from '@grafana/runtime/internal';
+
+import { HOSTED_TRACES_APP_ID, LOGS_DRILLDOWN_APP_ID, METRICS_DRILLDOWN_APP_ID } from './appPluginIds';
+import { buildLogsItem, buildMetricsItem, buildTracesItem } from './buildTelemetryItems';
+import { useSolutionState } from './solutionState';
+import { fetchLogsActivity, fetchMetricsActivity, fetchTracesActivity, fetchTracesServices } from './telemetryData';
+import { type ExistingSolutionProviderResult } from './types';
+
+export interface TelemetrySolutions {
+  metrics: ExistingSolutionProviderResult;
+  logs: ExistingSolutionProviderResult;
+  traces: ExistingSolutionProviderResult;
+}
+
+/**
+ * Metrics, Logs and Traces solution providers: an entry appears only for a confirmed-active
+ * signal ('unknown' never invents one) AND when its detail fetches produced something to show —
+ * a bare title card with every stat failed-soft reads as broken, so it is dropped instead.
+ */
+export function useTelemetrySolutions(): TelemetrySolutions {
+  const { value: resolution, loading: stateLoading } = useSolutionState();
+  // Availability only picks link targets; a pending lookup falls back to /explore (never blocks).
+  const { value: appMetas } = useAppPluginMetas();
+  const availableApps = new Set((appMetas ?? []).map((app) => app.id));
+
+  const promDs = resolution?.state.metrics === 'active' ? resolution.prometheusDatasource : null;
+  const lokiDs = resolution?.state.logs === 'active' ? resolution.lokiDatasource : null;
+  const tempoDs = resolution?.state.traces === 'active' ? resolution.tempoDatasource : null;
+
+  // Gate inside the callbacks (ds in the deps): an inactive or unknown signal never queries.
+  const metricsActivity = useAsync(async () => (promDs ? fetchMetricsActivity(promDs) : undefined), [promDs]);
+  const logsActivity = useAsync(async () => (lokiDs ? fetchLogsActivity(lokiDs) : undefined), [lokiDs]);
+  const tracesActivity = useAsync(async () => (tempoDs ? fetchTracesActivity(tempoDs) : undefined), [tempoDs]);
+  const tracesServices = useAsync(async () => (tempoDs ? fetchTracesServices(tempoDs) : undefined), [tempoDs]);
+
+  let metrics: ExistingSolutionProviderResult = { loading: stateLoading, item: null };
+  if (promDs) {
+    const activity = metricsActivity.value;
+    // Hosts/disk are secondary/alert content; without a series count, name count, or sparkline
+    // there is nothing to carry the card.
+    metrics =
+      metricsActivity.loading || !activity
+        ? { loading: metricsActivity.loading, item: null }
+        : activity.series == null && activity.names == null && activity.seriesSparkline == null
+          ? { loading: false, item: null }
+          : {
+              loading: false,
+              item: buildMetricsItem({
+                series: activity.series,
+                names: activity.names,
+                hosts: activity.hosts,
+                seriesSparkline: activity.seriesSparkline,
+                disk: activity.disk,
+                datasourceName: promDs.name,
+                drilldownAvailable: availableApps.has(METRICS_DRILLDOWN_APP_ID),
+              }),
+            };
+  }
+
+  let logs: ExistingSolutionProviderResult = { loading: stateLoading, item: null };
+  if (lokiDs) {
+    const activity = logsActivity.value;
+    // Stats need bytes, the sparkline needs the series; with neither there is nothing to render.
+    logs =
+      logsActivity.loading || !activity
+        ? { loading: logsActivity.loading, item: null }
+        : activity.bytes == null && activity.series == null
+          ? { loading: false, item: null }
+          : {
+              loading: false,
+              item: buildLogsItem({
+                bytes: activity.bytes,
+                sources: activity.sources,
+                volumeSeries: activity.series,
+                datasourceName: lokiDs.name,
+                drilldownAvailable: availableApps.has(LOGS_DRILLDOWN_APP_ID),
+              }),
+            };
+  }
+
+  let traces: ExistingSolutionProviderResult = { loading: stateLoading, item: null };
+  if (tempoDs) {
+    const activity = tracesActivity.value;
+    // The services count alone renders nothing (it is the stats secondary), so it cannot carry a card.
+    traces =
+      tracesActivity.loading || tracesServices.loading || !activity
+        ? { loading: tracesActivity.loading || tracesServices.loading, item: null }
+        : activity.spans == null && activity.series == null
+          ? { loading: false, item: null }
+          : {
+              loading: false,
+              item: buildTracesItem({
+                spans: activity.spans,
+                services: tracesServices.value ?? null,
+                throughputSeries: activity.series,
+                datasourceName: tempoDs.name,
+                drilldownAvailable: availableApps.has(HOSTED_TRACES_APP_ID),
+              }),
+            };
+  }
+
+  return { metrics, logs, traces };
+}

--- a/public/app/features/home/Recommendations/useTelemetrySolutions.ts
+++ b/public/app/features/home/Recommendations/useTelemetrySolutions.ts
@@ -17,9 +17,11 @@ export interface TelemetrySolutions {
 // Shared settle gate for the three providers. Error fails closed (settled no-data — the types.ts
 // provider contract). Loading or an undefined value reads as loading: on the render where a
 // signal flips active, useAsync still exposes the disabled run's settled `undefined` (its effect
-// re-runs only after paint), and a datasource-change refetch retains the prior value — neither
-// may paint as settled (same guard as useKubernetesSolution). `build` returns null when the
-// activity has nothing to carry a card.
+// re-runs only after paint) — that frame must not paint as settled empty (same guard as
+// useKubernetesSolution). Results are not keyed to the datasource: solution resolution is
+// one-shot per mount (undefined → at most one datasource, never A → B), so a retained value
+// cannot belong to a different datasource — an in-place datasource swap would need uid-keyed
+// results first. `build` returns null when the activity has nothing to carry a card.
 function toProviderResult<T>(
   state: { loading: boolean; error?: Error; value?: { activity: T } },
   build: (activity: T) => ExistingItem | null

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -10987,16 +10987,48 @@
         "title": "Kubernetes Monitoring",
         "view": "View"
       },
+      "logs": {
+        "action": "Open Explore (Logs)",
+        "action-explore": "Open in Explore",
+        "datasource": "via {{name}}",
+        "stats": "ingested · 7d",
+        "stats-sources_one": "ingested · 7d · ~{{count}} source",
+        "stats-sources_other": "ingested · 7d · ~{{count}} sources",
+        "title": "Hosted Logs",
+        "volume": "Ingest volume · last 24h"
+      },
+      "metrics": {
+        "action": "Open Metrics Drilldown",
+        "action-explore": "Open in Explore",
+        "datasource": "via {{name}}",
+        "disk-eta_one": "~{{count}} h to full",
+        "disk-eta_other": "~{{count}} h to full",
+        "disk-hosts_one": "{{count}} host above 90% disk",
+        "disk-hosts_other": "{{count}} hosts above 90% disk",
+        "disk-worst": "{{host}} at {{percent}}%",
+        "names_one": "{{value}} metric",
+        "names_other": "{{value}} metrics",
+        "series_one": "{{value}} series",
+        "series_other": "{{value}} series",
+        "series-trend": "Active series · last 24h",
+        "stats": "active",
+        "stats-hosts_one": "active · {{count}} host",
+        "stats-hosts_other": "active · {{count}} hosts",
+        "title": "Metrics & infrastructure",
+        "view": "View"
+      },
       "next": "Next",
       "no-data": {
         "badge": "Getting started",
         "connect": "Connect a data source",
         "description": "Connect a data source to light up your dashboards and alerts, pick from available solutions, or follow a getting started guide.",
+        "description-partial": "Some signals are already flowing. Connect more data sources or pick a solution to see live stats here.",
         "popular-solutions": "Popular solutions",
         "solution-k6": "k6",
         "solution-kubernetes": "Kubernetes Monitoring",
         "solution-synthetics": "Synthetic Monitoring",
-        "title": "No data flowing yet"
+        "title": "No data flowing yet",
+        "title-partial": "Add more telemetry"
       },
       "pause": "Pause",
       "previous": "Previous",
@@ -11012,7 +11044,19 @@
         "setup-action": "Set up Synthetic Monitoring",
         "title": "Watch your cluster from outside"
       },
-      "title": "Recommendations for your stack"
+      "title": "Recommendations for your stack",
+      "traces": {
+        "action": "Open Traces Drilldown",
+        "action-explore": "Open in Explore",
+        "datasource": "via {{name}}",
+        "spans_one": "{{value}} span",
+        "spans_other": "{{value}} spans",
+        "stats": "traced · 24h",
+        "stats-services_one": "traced · 24h · {{count}} service",
+        "stats-services_other": "traced · 24h · {{count}} services",
+        "throughput": "Span throughput · last 24h",
+        "title": "Hosted Traces"
+      }
     },
     "starred-dashboards-tab": {
       "empty": "Your starred dashboards will appear here.",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -11000,6 +11000,7 @@
       "metrics": {
         "action": "Open Metrics Drilldown",
         "action-explore": "Open in Explore",
+        "data-points-per-minute": "{{value}} data points/min",
         "datasource": "via {{name}}",
         "disk-eta_one": "~{{count}} h to full",
         "disk-eta_other": "~{{count}} h to full",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -11024,6 +11024,7 @@
         "connect": "Connect a data source",
         "description": "Connect a data source to light up your dashboards and alerts, pick from available solutions, or follow a getting started guide.",
         "description-partial": "Some signals are already flowing. Connect more data sources or pick a solution to see live stats here.",
+        "description-unknown": "We couldn't confirm live data yet. Connect more data sources or pick a solution to see live stats here.",
         "popular-solutions": "Popular solutions",
         "solution-k6": "k6",
         "solution-kubernetes": "Kubernetes Monitoring",


### PR DESCRIPTION
**What is this feature?**

The left card goes live:

- `useTelemetrySolutions` turns the settled solution signals into metrics/logs/traces cards with real activity numbers and sparklines (via the telemetry fetchers below in the stack), joining the existing Kubernetes provider in `useExistingSolutions`.
- `useExistingSolutions` now waits for every provider to settle before anything renders, so the default selection never swaps after first paint.
- Solution selection is typed by the solutions matrix ids end to end (`ExistingItem.id`, `ExistingSolutionCard.onSelect`).
- `NoDataCard` becomes honest: the hard "No data flowing yet" claim renders only when every core signal settled inactive; anything unknown gets a softened variant.

**Special notes for your reviewer:**

The provider hooks and the card UI ship together deliberately: the settle-before-paint contract of `useExistingSolutions` is only observable through `RecommendationExisting`, and the hooks have no other consumer. One legacy test asserting the kubernetes-only left card's hard no-data claim is deleted here (its contract no longer exists); the settled/softened variants are covered by `RecommendationExisting.test`.

Two symbols in this PR are wired up by the next PR in the stack (homepage matrix), not here: `RecommendationExisting.onSelectionChange` (the matrix passes `onSelectionChange={setActiveSolution}` to drive the carousel) and the `enabled` parameter of `useSolutionState` (the matrix gates probes with `useSolutionState(probesEnabled)`). They are not dead code.

Analytics heads-up: typing `ExistingItem.id` by the solutions-matrix ids changes the `solution` property of `existing_solution` CTA events for the Kubernetes card from `kubernetes-monitoring` to `kubernetes` (the previous id shipped on main via #128971 on 2026-07-23). The recommended-card namespace (`RecommendedCardId`, NoDataCard pills) deliberately keeps `kubernetes-monitoring`. Dashboards filtering `surface=existing_solution` on the old id should account for the split.
