### PR TITLE
IAM: Fix LDAP group mappings applying Grafana Admin toggle to the wrong row

### DIFF
--- a/public/app/features/admin/ldap/LdapGroupMapping.test.tsx
+++ b/public/app/features/admin/ldap/LdapGroupMapping.test.tsx
@@ -1,0 +1,79 @@
+import { FormProvider, useForm, useFormContext } from 'react-hook-form';
+import { render, screen } from 'test/test-utils';
+
+import { contextSrv } from 'app/core/services/context_srv';
+import { type LdapPayload } from 'app/types/ldap';
+
+import { GroupMappingComponent } from './LdapGroupMapping';
+
+const GROUP_MAPPINGS_PATH = 'settings.config.servers.0.group_mappings' as const;
+
+const groupMappings = [
+  { group_dn: 'CN=Group1', org_role: 'Admin', org_id: 1, grafana_admin: true },
+  { group_dn: 'CN=Group2', org_role: 'Admin', org_id: 1, grafana_admin: false },
+  { group_dn: 'CN=Group3', org_role: 'Editor', org_id: 1, grafana_admin: false },
+];
+
+// Mirrors how LdapDrawer renders and removes rows, index-based React key
+// included, so the list behaves the same here as it does in the drawer.
+const GroupMappings = () => {
+  const { getValues, setValue, watch } = useFormContext<LdapPayload>();
+
+  const onRemove = (index: number) => {
+    const mappings = getValues(GROUP_MAPPINGS_PATH);
+    setValue(GROUP_MAPPINGS_PATH, [...mappings.slice(0, index), ...mappings.slice(index + 1)]);
+  };
+
+  return (
+    <>
+      {watch(GROUP_MAPPINGS_PATH)?.map((_, i) => (
+        <GroupMappingComponent key={i} groupMappingIndex={i} onRemove={() => onRemove(i)} />
+      ))}
+    </>
+  );
+};
+
+const Wrapper = () => {
+  const methods = useForm<LdapPayload>({
+    defaultValues: {
+      settings: { config: { servers: [{ group_mappings: groupMappings }] } },
+    },
+  });
+  return (
+    <FormProvider {...methods}>
+      <GroupMappings />
+    </FormProvider>
+  );
+};
+
+const setup = () => render(<Wrapper />);
+
+// Anchored, because Field renders the description inside the <label> too
+const inputsFor = (label: string) => screen.getAllByLabelText<HTMLInputElement>(new RegExp(`^${label}`));
+
+describe('GroupMappingComponent', () => {
+  beforeEach(() => {
+    contextSrv.isGrafanaAdmin = true;
+  });
+
+  // Duplicate ids make every row's label point at the first row's input, so
+  // clicking one row's Grafana Admin toggle flips a different row's mapping.
+  it('gives each group mapping row its own form control ids', () => {
+    setup();
+
+    for (const label of ['Group DN', 'Org ID', 'Grafana Admin']) {
+      const controls = inputsFor(label);
+      expect(controls).toHaveLength(groupMappings.length);
+      expect(new Set(controls.map(({ id }) => id)).size).toBe(groupMappings.length);
+    }
+  });
+
+  it('shows the remaining mappings after one is removed', async () => {
+    const { user } = setup();
+
+    await user.click(screen.getAllByRole('button', { name: 'Remove group mapping' })[1]);
+
+    expect(inputsFor('Group DN').map(({ value }) => value)).toEqual(['CN=Group1', 'CN=Group3']);
+    expect(inputsFor('Grafana Admin').map(({ checked }) => checked)).toEqual([true, false]);
+  });
+});

--- a/public/app/features/admin/ldap/LdapGroupMapping.tsx
+++ b/public/app/features/admin/ldap/LdapGroupMapping.tsx
@@ -21,14 +21,17 @@ export const GroupMappingComponent = ({ groupMappingIndex, onRemove }: GroupMapp
   return (
     <Box borderColor="strong" borderStyle="solid" padding={2} marginBottom={2}>
       <Field
-        htmlFor="group-dn"
+        htmlFor={`group-dn-${groupMappingIndex}`}
         label={t('ldap-drawer.group-mapping.group-dn.label', 'Group DN')}
         description={t(
           'ldap-drawer.group-mapping.group-dn.description',
           'The name of the key used to extract the ID token from the returned OAuth2 token.'
         )}
       >
-        <Input id="group-dn" {...register(`settings.config.servers.0.group_mappings.${groupMappingIndex}.group_dn`)} />
+        <Input
+          id={`group-dn-${groupMappingIndex}`}
+          {...register(`settings.config.servers.0.group_mappings.${groupMappingIndex}.group_dn`)}
+        />
       </Field>
       <Field label={t('ldap-drawer.group-mapping.org-role.label', 'Org role *')}>
         <RadioButtonGroup
@@ -39,7 +42,7 @@ export const GroupMappingComponent = ({ groupMappingIndex, onRemove }: GroupMapp
         />
       </Field>
       <Field
-        htmlFor="org-id"
+        htmlFor={`org-id-${groupMappingIndex}`}
         label={t('ldap-drawer.group-mapping.org-id.label', 'Org ID')}
         description={t(
           'ldap-drawer.group-mapping.org-id.description',
@@ -47,14 +50,14 @@ export const GroupMappingComponent = ({ groupMappingIndex, onRemove }: GroupMapp
         )}
       >
         <Input
-          id="org-id"
+          id={`org-id-${groupMappingIndex}`}
           type="number"
           {...register(`settings.config.servers.0.group_mappings.${groupMappingIndex}.org_id`, { valueAsNumber: true })}
         />
       </Field>
       {contextSrv.isGrafanaAdmin && (
         <Field
-          htmlFor="grafana-admin"
+          htmlFor={`grafana-admin-${groupMappingIndex}`}
           label={t('ldap-drawer.group-mapping.grafana-admin.label', 'Grafana Admin')}
           description={t(
             'ldap-drawer.group-mapping.grafana-admin.description',
@@ -62,7 +65,7 @@ export const GroupMappingComponent = ({ groupMappingIndex, onRemove }: GroupMapp
           )}
         >
           <Switch
-            id="grafana-admin"
+            id={`grafana-admin-${groupMappingIndex}`}
             {...register(`settings.config.servers.0.group_mappings.${groupMappingIndex}.grafana_admin`)}
           />
         </Field>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/grafana/grafana/blob/HEAD/CONTRIBUTING.md and https://github.com/grafana/grafana/blob/HEAD/contribute/developer-guide.md
2. Ensure you include and run the appropriate tests as part of your Pull Request.
3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.
4. If the PR is meant to fix an issue, please include a comment linking the issue.

-->

**What is this feature?**

Fixes the **Grafana Admin** toggle in Administration → Authentication → LDAP → Advanced settings → Group mappings. With more than one group mapping configured, clicking the toggle on any row changed the *first* row instead, so every row after the first appeared impossible to toggle.

## How it works

Every group mapping row rendered its form controls with the same hardcoded DOM ids (`group-dn`, `org-id`, `grafana-admin`). `Switch` renders a visually hidden checkbox with the visible switch as a `<label htmlFor>`, so with duplicate ids the browser resolved every row's label to the first matching input on the page. This suffixes the ids with the row index, matching what the Org role `RadioButtonGroup` in the same component already did.

- **Grafana Admin toggles now apply to the row that was clicked**, instead of always the first row.
- **Group DN and Org ID labels point at their own inputs**, fixing label-click focus and label association for those fields too.
- No behavior change with a single group mapping configured.

**Why do we need this feature?**

Toggling Grafana Admin on one group silently changed a different group's mapping, so the wrong LDAP group could be granted server admin. 

**Who is this feature for?**

Grafana server admins configuring LDAP group mappings through the UI.

**Which issue(s) does this PR fix?**

Part of https://github.com/grafana/support-escalations/issues/23484

