### PR TITLE
Dashboards: Rename DashboardEditPane to DashboardSidebar

### DIFF
--- a/public/app/features/dashboard-scene/addToDashboard/addPanelsOnLoadBehavior.test.ts
+++ b/public/app/features/dashboard-scene/addToDashboard/addPanelsOnLoadBehavior.test.ts
@@ -99,7 +99,7 @@ describe('addPanelsOnLoadBehavior', () => {
     });
   });
 
-  it('defers panel addition until editPane activates when it is not yet active', () => {
+  it('defers panel addition until sidebar activates when it is not yet active', () => {
     store.setObject(DASHBOARD_FROM_LS_KEY, buildTestDTO());
     const scene = buildTestScene();
     const addPanelSpy = jest.spyOn(scene, 'addPanel');

--- a/public/app/features/dashboard-scene/edit-pane/DashboardSidebar.test.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardSidebar.test.tsx
@@ -30,7 +30,7 @@ import { activateFullSceneTree } from '../utils/test-utils';
 
 import { DashboardOutline } from './outline/DashboardOutline';
 import { dashboardEditActions } from './shared';
-import { type DashboardEditPaneLike } from './types';
+import { type DashboardSidebarLike } from './types';
 
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
@@ -44,7 +44,7 @@ setPluginImportUtils({
   getPanelPluginFromCache: (id: string) => undefined,
 });
 
-describe('DashboardEditPane', () => {
+describe('DashboardSidebar', () => {
   describe('Selection', () => {
     it('Can select dashboard', () => {
       const scene = buildTestScene();
@@ -54,165 +54,165 @@ describe('DashboardEditPane', () => {
 
     it('single panel and multi panel selection', () => {
       const scene = buildTestScene();
-      const editPane = scene.state.editPane;
+      const sidebar = scene.state.editPane;
       const panel1 = scene.onCreateNewPanel();
 
-      expect(editPane.getSelectedObject()).toBe(panel1);
+      expect(sidebar.getSelectedObject()).toBe(panel1);
 
       // Selecting same object should clear selection
-      editPane.selectObject(panel1);
+      sidebar.selectObject(panel1);
 
-      expect(editPane.getSelectedObject()).toBeUndefined();
+      expect(sidebar.getSelectedObject()).toBeUndefined();
 
       const panel2 = scene.onCreateNewPanel();
-      editPane.state.selectionContext.onSelect({ id: panel1.state.key! }, { multi: true });
+      sidebar.state.selectionContext.onSelect({ id: panel1.state.key! }, { multi: true });
 
-      expect(editPane.state.selectionContext.selected).toHaveLength(2);
+      expect(sidebar.state.selectionContext.selected).toHaveLength(2);
 
       // Selecting one that is already selected should remove it
-      editPane.state.selectionContext.onSelect({ id: panel2.state.key! }, { multi: true });
+      sidebar.state.selectionContext.onSelect({ id: panel2.state.key! }, { multi: true });
 
-      expect(editPane.state.selectionContext.selected).toHaveLength(1);
-      expect(editPane.getSelectedObject()).toBe(panel1);
+      expect(sidebar.state.selectionContext.selected).toHaveLength(1);
+      expect(sidebar.getSelectedObject()).toBe(panel1);
     });
 
     it('Clear selection should select dashboard when docked', () => {
       const scene = buildTestScene();
-      const editPane = scene.state.editPane;
+      const sidebar = scene.state.editPane;
 
       const panel = scene.onCreateNewPanel();
-      editPane.clearSelection();
+      sidebar.clearSelection();
 
-      expect(editPane.getSelectedObject()).toBeUndefined();
+      expect(sidebar.getSelectedObject()).toBeUndefined();
 
-      editPane.setState({ isDocked: true });
-      editPane.selectObject(panel);
-      editPane.clearSelection();
+      sidebar.setState({ isDocked: true });
+      sidebar.selectObject(panel);
+      sidebar.clearSelection();
 
-      expect(editPane.getSelectedObject()).toBe(scene);
+      expect(sidebar.getSelectedObject()).toBe(scene);
     });
 
     it('Force selecting should keep selecting if already selected', () => {
       const scene = buildTestScene();
-      const editPane = scene.state.editPane;
+      const sidebar = scene.state.editPane;
 
       // This selects panel
       const panel = scene.onCreateNewPanel();
 
       // Force select
-      editPane.state.selectionContext.onSelect({ id: panel.state.key! }, { multi: false, force: true });
+      sidebar.state.selectionContext.onSelect({ id: panel.state.key! }, { multi: false, force: true });
 
-      expect(editPane.getSelectedObject()).toBe(panel);
-      expect(editPane.state.selectionContext.selected).toHaveLength(1);
+      expect(sidebar.getSelectedObject()).toBe(panel);
+      expect(sidebar.state.selectionContext.selected).toHaveLength(1);
 
       // Force select with multi
-      editPane.state.selectionContext.onSelect({ id: panel.state.key! }, { multi: true, force: true });
+      sidebar.state.selectionContext.onSelect({ id: panel.state.key! }, { multi: true, force: true });
 
       // Still only 1 item selected
-      expect(editPane.state.selectionContext.selected).toHaveLength(1);
+      expect(sidebar.state.selectionContext.selected).toHaveLength(1);
     });
 
     it('Selecting when none element pane is open should not toggle selection', () => {
       const scene = buildTestScene();
-      const editPane = scene.state.editPane;
+      const sidebar = scene.state.editPane;
 
       const panel = scene.onCreateNewPanel();
 
-      editPane.openPane(new DashboardOutline({}));
+      sidebar.openPane(new DashboardOutline({}));
 
-      expect(editPane.getSelectedObject()).toBe(panel);
+      expect(sidebar.getSelectedObject()).toBe(panel);
 
       // Select panel again (when it is still selected)
-      editPane.state.selectionContext.onSelect({ id: panel.state.key! }, { force: false });
+      sidebar.state.selectionContext.onSelect({ id: panel.state.key! }, { force: false });
 
       // Should still be selected
-      expect(editPane.getSelectedObject()).toBe(panel);
+      expect(sidebar.getSelectedObject()).toBe(panel);
     });
 
     it('Selecting tab with closed edit pane should not select tab', () => {
-      const { editPane, tab1 } = setupWithTwoTabs();
+      const { sidebar, tab1 } = setupWithTwoTabs();
 
       // Selecting tab with closed edit pane should not select tab
-      editPane.selectObject(tab1);
-      expect(editPane.getSelectedObject()).toBeUndefined();
+      sidebar.selectObject(tab1);
+      expect(sidebar.getSelectedObject()).toBeUndefined();
     });
 
     it('Selecting tab with open edit pane should select tab', () => {
-      const { editPane, tab1 } = setupWithTwoTabs();
+      const { sidebar, tab1 } = setupWithTwoTabs();
 
       // Selecting tab with closed edit pane should not select tab
-      editPane.openPane(new DashboardOutline({}));
-      editPane.selectObject(tab1);
-      expect(editPane.getSelectedObject()).toBe(tab1);
+      sidebar.openPane(new DashboardOutline({}));
+      sidebar.selectObject(tab1);
+      expect(sidebar.getSelectedObject()).toBe(tab1);
     });
 
     it('Removing a panel that is not selected', () => {
       const scene = buildTestScene();
-      const editPane = scene.state.editPane;
+      const sidebar = scene.state.editPane;
 
       const panel1 = scene.onCreateNewPanel();
       const panel2 = scene.onCreateNewPanel();
 
       scene.removePanel(panel1);
 
-      expect(editPane.getSelectedObject()).toBe(panel2);
+      expect(sidebar.getSelectedObject()).toBe(panel2);
     });
 
     it('Force selecting tab should always select it', () => {
-      const { editPane, tab1 } = setupWithTwoTabs();
+      const { sidebar, tab1 } = setupWithTwoTabs();
 
-      editPane.selectObject(tab1, { force: true });
-      expect(editPane.getSelectedObject()).toBe(tab1);
+      sidebar.selectObject(tab1, { force: true });
+      expect(sidebar.getSelectedObject()).toBe(tab1);
     });
   });
 
   it('Handles edit action events that adds objects', () => {
     const scene = buildTestScene();
-    const editPane = scene.state.editPane;
+    const sidebar = scene.state.editPane;
 
     scene.onCreateNewPanel();
 
-    expect(editPane.state.undoStack).toHaveLength(1);
+    expect(sidebar.state.undoStack).toHaveLength(1);
 
     // Should select object
-    expect(editPane.getSelectedObject()).toBeDefined();
+    expect(sidebar.getSelectedObject()).toBeDefined();
 
-    editPane.undoAction();
+    sidebar.undoAction();
 
-    expect(editPane.state.undoStack).toHaveLength(0);
+    expect(sidebar.state.undoStack).toHaveLength(0);
 
     // should clear selection
-    expect(editPane.getSelectedObject()).toBeUndefined();
+    expect(sidebar.getSelectedObject()).toBeUndefined();
   });
 
   it('when new action comes in clears redo stack', () => {
     const scene = buildTestScene();
-    const editPane = scene.state.editPane;
+    const sidebar = scene.state.editPane;
 
     scene.onCreateNewPanel();
 
-    editPane.undoAction();
+    sidebar.undoAction();
 
-    expect(editPane.state.redoStack).toHaveLength(1);
+    expect(sidebar.state.redoStack).toHaveLength(1);
 
     scene.onCreateNewPanel();
 
-    expect(editPane.state.redoStack).toHaveLength(0);
+    expect(sidebar.state.redoStack).toHaveLength(0);
   });
 
   it('clone should not include undo/redo history', () => {
     const scene = buildTestScene();
-    const editPane = scene.state.editPane;
+    const sidebar = scene.state.editPane;
 
     scene.onCreateNewPanel();
     scene.onCreateNewPanel();
 
-    editPane.undoAction();
+    sidebar.undoAction();
 
-    expect(editPane.state.redoStack).toHaveLength(1);
-    expect(editPane.state.undoStack).toHaveLength(1);
+    expect(sidebar.state.redoStack).toHaveLength(1);
+    expect(sidebar.state.undoStack).toHaveLength(1);
 
-    const cloned = editPane.clone({});
+    const cloned = sidebar.clone({});
 
     expect(cloned.state.redoStack).toHaveLength(0);
     expect(cloned.state.undoStack).toHaveLength(0);
@@ -220,13 +220,13 @@ describe('DashboardEditPane', () => {
 
   it('clone should preserve the outline collapsed state', () => {
     const scene = buildTestScene();
-    const editPane = scene.state.editPane;
-    const outlinePane = editPane.state.outlinePane!;
+    const sidebar = scene.state.editPane;
+    const outlinePane = sidebar.state.outlinePane!;
 
     outlinePane.setNodeCollapsed('some-key', false);
     outlinePane.setNodeCollapsed('another-key', true);
 
-    const cloned = editPane.clone({});
+    const cloned = sidebar.clone({});
     const clonedOutline = cloned.state.outlinePane!;
 
     expect(clonedOutline.isNodeCollapsed('some-key', true)).toBe(false);
@@ -254,8 +254,8 @@ describe('DashboardEditPane', () => {
 
     activateFullSceneTree(dashboard);
 
-    const editPane = dashboard.state.editPane;
-    editPane.selectObject(variable, { force: true });
+    const sidebar = dashboard.state.editPane;
+    sidebar.selectObject(variable, { force: true });
 
     const changedVariable = new ConstantVariable({ name: 'service' });
     dashboardEditActions.changeVariableType({
@@ -265,17 +265,17 @@ describe('DashboardEditPane', () => {
     });
 
     expect(variableSet.state.variables[0]).toBe(changedVariable);
-    expect(editPane.getSelectedObject()).toBe(changedVariable);
+    expect(sidebar.getSelectedObject()).toBe(changedVariable);
 
-    editPane.undoAction();
+    sidebar.undoAction();
 
     expect(variableSet.state.variables[0]).toBe(variable);
-    expect(editPane.getSelectedObject()).toBe(variable);
+    expect(sidebar.getSelectedObject()).toBe(variable);
 
-    editPane.redoAction();
+    sidebar.redoAction();
 
     expect(variableSet.state.variables[0]).toBe(changedVariable);
-    expect(editPane.getSelectedObject()).toBe(changedVariable);
+    expect(sidebar.getSelectedObject()).toBe(changedVariable);
   });
 
   it('restores dropped predefined variables when undoing a shadowing rename', () => {
@@ -394,8 +394,8 @@ describe('DashboardEditPane', () => {
         }),
       });
 
-      const { editPane } = buildTestSceneWithRepeat(layoutManager);
-      editPane.enableSelection();
+      const { sidebar } = buildTestSceneWithRepeat(layoutManager);
+      sidebar.enableSelection();
 
       const gridItems = layoutManager.state.grid.state.children as DashboardGridItem[];
       const sourcePanel = gridItems[0].state.body;
@@ -404,9 +404,9 @@ describe('DashboardEditPane', () => {
 
       expect(clonePanel.state.repeatSourceKey).toBe(sourcePanel.state.key);
 
-      editPane.state.selectionContext.onSelect({ id: clonePanel.state.key! }, {});
+      sidebar.state.selectionContext.onSelect({ id: clonePanel.state.key! }, {});
 
-      expect(editPane.getSelectedObject()).toBe(sourcePanel);
+      expect(sidebar.getSelectedObject()).toBe(sourcePanel);
     });
 
     it('Selecting a repeated tab inside a repeated row selects the source tab', () => {
@@ -428,9 +428,9 @@ describe('DashboardEditPane', () => {
           }),
         ],
       });
-      const { scene, editPane, variables } = buildTestSceneWithRepeat(layoutManager);
-      editPane.enableSelection();
-      editPane.selectObject(scene);
+      const { scene, sidebar, variables } = buildTestSceneWithRepeat(layoutManager);
+      sidebar.enableSelection();
+      sidebar.selectObject(scene);
 
       const [sourceRow] = layoutManager.state.rows;
       const [sourceTab] = (sourceRow.state.layout as TabsLayoutManager).state.tabs;
@@ -453,116 +453,116 @@ describe('DashboardEditPane', () => {
       const [clonedTabInClonedRow] = tabInClonedRow.state.repeatedTabs!;
       expect(clonedTabInClonedRow.state.repeatSourceKey).toBe(sourceTab.state.key);
 
-      editPane.state.selectionContext.onSelect({ id: clonedTabInClonedRow.state.key! }, {});
+      sidebar.state.selectionContext.onSelect({ id: clonedTabInClonedRow.state.key! }, {});
 
-      expect(editPane.getSelectedObject()).toBe(sourceTab);
+      expect(sidebar.getSelectedObject()).toBe(sourceTab);
     });
   });
 
   describe('addNewPanel', () => {
     it('adds panel to the correct tab layout when target is first tab', () => {
-      const { tab1, tab2, editPane } = setupWithTwoTabs();
-      editPane.addNewPanel(tab1);
+      const { tab1, tab2, sidebar } = setupWithTwoTabs();
+      sidebar.addNewPanel(tab1);
       expect(tab1.getLayout().getVizPanels()).toHaveLength(2);
       expect(tab2.getLayout().getVizPanels()).toHaveLength(0);
     });
 
     it('adds panel to the correct tab layout when target is second tab', () => {
-      const { tab1, tab2, editPane } = setupWithTwoTabs();
-      editPane.addNewPanel(tab2);
+      const { tab1, tab2, sidebar } = setupWithTwoTabs();
+      sidebar.addNewPanel(tab2);
       expect(tab1.getLayout().getVizPanels()).toHaveLength(1);
       expect(tab2.getLayout().getVizPanels()).toHaveLength(1);
     });
 
     it('adds panel to the correct row layout when target is first row', () => {
-      const { row1, row2, editPane } = setupWithTwoRows();
-      editPane.addNewPanel(row1);
+      const { row1, row2, sidebar } = setupWithTwoRows();
+      sidebar.addNewPanel(row1);
       expect(row1.getLayout().getVizPanels()).toHaveLength(2);
       expect(row2.getLayout().getVizPanels()).toHaveLength(0);
     });
 
     it('adds panel to the correct row layout when target is second row', () => {
-      const { row1, row2, editPane } = setupWithTwoRows();
-      editPane.addNewPanel(row2);
+      const { row1, row2, sidebar } = setupWithTwoRows();
+      sidebar.addNewPanel(row2);
       expect(row1.getLayout().getVizPanels()).toHaveLength(1);
       expect(row2.getLayout().getVizPanels()).toHaveLength(1);
     });
 
     it('adds panel to the first element in the dashboard when target is the dashboard itself', () => {
-      const { dashboard, tab1, tab2, editPane } = setupWithTwoTabs();
-      editPane.addNewPanel(dashboard);
+      const { dashboard, tab1, tab2, sidebar } = setupWithTwoTabs();
+      sidebar.addNewPanel(dashboard);
       expect(tab1.getLayout().getVizPanels()).toHaveLength(2);
       expect(tab2.getLayout().getVizPanels()).toHaveLength(0);
     });
 
     it('adds panel to the first element in the dashboard when target is undefined', () => {
-      const { tab1, tab2, editPane } = setupWithTwoTabs();
-      editPane.addNewPanel(undefined);
+      const { tab1, tab2, sidebar } = setupWithTwoTabs();
+      sidebar.addNewPanel(undefined);
       expect(tab1.getLayout().getVizPanels()).toHaveLength(2);
       expect(tab2.getLayout().getVizPanels()).toHaveLength(0);
     });
 
     it('adds panel to the dashboard when dashboard is empty', () => {
-      const { dashboard, editPane } = setupEmptyDashboard();
-      editPane.addNewPanel(undefined);
+      const { dashboard, sidebar } = setupEmptyDashboard();
+      sidebar.addNewPanel(undefined);
       expect(dashboard.getLayout().getVizPanels()).toHaveLength(1);
     });
   });
 
   describe('pastePanel', () => {
     it('adds pasted panel to the correct tab layout when target is first tab', () => {
-      const { dashboard, tab1, tab2, tab1Viz, editPane } = setupWithTwoTabs();
+      const { dashboard, tab1, tab2, tab1Viz, sidebar } = setupWithTwoTabs();
       dashboard.copyPanel(tab1Viz);
-      editPane.pastePanel(tab1);
+      sidebar.pastePanel(tab1);
       expect(tab1.getLayout().getVizPanels()).toHaveLength(2);
       expect(tab2.getLayout().getVizPanels()).toHaveLength(0);
     });
 
     it('adds pasted panel to the correct tab layout when target is second tab', () => {
-      const { dashboard, tab1, tab2, tab1Viz, editPane } = setupWithTwoTabs();
+      const { dashboard, tab1, tab2, tab1Viz, sidebar } = setupWithTwoTabs();
       dashboard.copyPanel(tab1Viz);
-      editPane.pastePanel(tab2);
+      sidebar.pastePanel(tab2);
       expect(tab1.getLayout().getVizPanels()).toHaveLength(1);
       expect(tab2.getLayout().getVizPanels()).toHaveLength(1);
     });
 
     it('adds pasted panel to the correct row layout when target is first row', () => {
-      const { dashboard, row1, row2, row1Viz, editPane } = setupWithTwoRows();
+      const { dashboard, row1, row2, row1Viz, sidebar } = setupWithTwoRows();
       dashboard.copyPanel(row1Viz);
-      editPane.pastePanel(row1);
+      sidebar.pastePanel(row1);
       expect(row1.getLayout().getVizPanels()).toHaveLength(2);
       expect(row2.getLayout().getVizPanels()).toHaveLength(0);
     });
 
     it('adds pasted panel to the correct row layout when target is second row', () => {
-      const { dashboard, row1, row2, row1Viz, editPane } = setupWithTwoRows();
+      const { dashboard, row1, row2, row1Viz, sidebar } = setupWithTwoRows();
       dashboard.copyPanel(row1Viz);
-      editPane.pastePanel(row2);
+      sidebar.pastePanel(row2);
       expect(row1.getLayout().getVizPanels()).toHaveLength(1);
       expect(row2.getLayout().getVizPanels()).toHaveLength(1);
     });
 
     it('adds pasted panel to the first element in the dashboard when target is the dashboard itself', () => {
-      const { dashboard, tab1, tab2, editPane } = setupWithTwoTabs();
+      const { dashboard, tab1, tab2, sidebar } = setupWithTwoTabs();
       dashboard.copyPanel(tab1.getLayout().getVizPanels()[0]);
-      editPane.pastePanel(dashboard);
+      sidebar.pastePanel(dashboard);
       expect(tab1.getLayout().getVizPanels()).toHaveLength(2);
       expect(tab2.getLayout().getVizPanels()).toHaveLength(0);
     });
 
     it('adds pasted panel to the first element in the dashboard when target is undefined', () => {
-      const { dashboard, tab1, tab2, editPane } = setupWithTwoTabs();
+      const { dashboard, tab1, tab2, sidebar } = setupWithTwoTabs();
       dashboard.copyPanel(tab1.getLayout().getVizPanels()[0]);
-      editPane.pastePanel(undefined);
+      sidebar.pastePanel(undefined);
       expect(tab1.getLayout().getVizPanels()).toHaveLength(2);
       expect(tab2.getLayout().getVizPanels()).toHaveLength(0);
     });
 
     it('preserves the source panel config when pasting with target undefined into a RowsLayout dashboard', () => {
-      const { dashboard, row1, row2, row1Viz, editPane } = setupWithTwoRows();
+      const { dashboard, row1, row2, row1Viz, sidebar } = setupWithTwoRows();
       dashboard.copyPanel(row1Viz);
 
-      editPane.pastePanel(undefined);
+      sidebar.pastePanel(undefined);
 
       const row1Panels = row1.getLayout().getVizPanels();
       expect(row1Panels).toHaveLength(2);
@@ -574,10 +574,10 @@ describe('DashboardEditPane', () => {
     });
 
     it('preserves the source panel config when pasting with target undefined into a TabsLayout dashboard', () => {
-      const { dashboard, tab1, tab2, tab1Viz, editPane } = setupWithTwoTabs();
+      const { dashboard, tab1, tab2, tab1Viz, sidebar } = setupWithTwoTabs();
       dashboard.copyPanel(tab1Viz);
 
-      editPane.pastePanel(undefined);
+      sidebar.pastePanel(undefined);
 
       const tab1Panels = tab1.getLayout().getVizPanels();
       expect(tab1Panels).toHaveLength(2);
@@ -589,7 +589,7 @@ describe('DashboardEditPane', () => {
     });
 
     it('adds pasted panel to the dashboard when dashboard is empty', () => {
-      const { dashboard, editPane } = setupEmptyDashboard();
+      const { dashboard, sidebar } = setupEmptyDashboard();
       const panel = new VizPanel({ key: 'panel-1', pluginId: 'text', title: 'P1' });
       const gridItem = new AutoGridItem({ body: panel });
       const layoutWithPanel = new AutoGridLayoutManager({
@@ -605,7 +605,7 @@ describe('DashboardEditPane', () => {
       activateFullSceneTree(sourceDashboard);
       sourceDashboard.copyPanel(panel);
 
-      editPane.pastePanel(dashboard);
+      sidebar.pastePanel(dashboard);
       expect(dashboard.getLayout().getVizPanels()).toHaveLength(1);
     });
   });
@@ -667,14 +667,14 @@ function buildTestSceneWithRepeat(layoutManager: DashboardLayoutManager) {
 
   return {
     variables,
-    editPane: scene.state.editPane,
+    sidebar: scene.state.editPane,
     scene,
   };
 }
 
 function setupEmptyDashboard(): {
   dashboard: DashboardScene;
-  editPane: DashboardEditPaneLike;
+  sidebar: DashboardSidebarLike;
 } {
   const dashboard = new DashboardScene({
     $timeRange: new SceneTimeRange({ from: 'now-6h', to: 'now' }),
@@ -683,7 +683,7 @@ function setupEmptyDashboard(): {
   });
   config.featureToggles.dashboardNewLayouts = true;
   activateFullSceneTree(dashboard);
-  return { dashboard, editPane: dashboard.state.editPane };
+  return { dashboard, sidebar: dashboard.state.editPane };
 }
 
 function setupWithTwoTabs(): {
@@ -691,7 +691,7 @@ function setupWithTwoTabs(): {
   tab1: TabItem;
   tab2: TabItem;
   tab1Viz: VizPanel;
-  editPane: DashboardEditPaneLike;
+  sidebar: DashboardSidebarLike;
 } {
   const panel = new VizPanel({ key: 'panel-1', pluginId: 'text', title: 'P1' });
   const gridItem = new AutoGridItem({ body: panel });
@@ -707,7 +707,7 @@ function setupWithTwoTabs(): {
   });
   config.featureToggles.dashboardNewLayouts = true;
   activateFullSceneTree(dashboard);
-  return { dashboard, tab1, tab2, tab1Viz: panel, editPane: dashboard.state.editPane };
+  return { dashboard, tab1, tab2, tab1Viz: panel, sidebar: dashboard.state.editPane };
 }
 
 function setupWithTwoRows(): {
@@ -715,7 +715,7 @@ function setupWithTwoRows(): {
   row1: RowItem;
   row2: RowItem;
   row1Viz: VizPanel;
-  editPane: DashboardEditPaneLike;
+  sidebar: DashboardSidebarLike;
 } {
   const panel = new VizPanel({ key: 'panel-1', pluginId: 'text', title: 'P1' });
   const gridItem = new AutoGridItem({ body: panel });
@@ -731,5 +731,5 @@ function setupWithTwoRows(): {
   });
   config.featureToggles.dashboardNewLayouts = true;
   activateFullSceneTree(dashboard);
-  return { dashboard, row1, row2, row1Viz: panel, editPane: dashboard.state.editPane };
+  return { dashboard, row1, row2, row1Viz: panel, sidebar: dashboard.state.editPane };
 }

--- a/public/app/features/dashboard-scene/edit-pane/DashboardSidebar.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardSidebar.tsx
@@ -28,10 +28,10 @@ import {
 } from './events';
 import { DashboardOutline } from './outline/DashboardOutline';
 import { getEditableElementFor } from './shared';
-import { type DashboardSidebarPane, type DashboardEditPaneLike, type DashboardEditPaneState } from './types';
+import { type DashboardSidebarPane, type DashboardSidebarLike, type DashboardSidebarState } from './types';
 
-export class DashboardEditPane extends SceneObjectBase<DashboardEditPaneState> implements DashboardEditPaneLike {
-  public constructor(state?: Partial<DashboardEditPaneState>) {
+export class DashboardSidebar extends SceneObjectBase<DashboardSidebarState> implements DashboardSidebarLike {
+  public constructor(state?: Partial<DashboardSidebarState>) {
     super({
       selectionContext: {
         enabled: false,
@@ -54,7 +54,7 @@ export class DashboardEditPane extends SceneObjectBase<DashboardEditPaneState> i
     this.panelEditAction = editAction;
   }
 
-  public clone(withState: Partial<DashboardEditPaneState>): this {
+  public clone(withState: Partial<DashboardSidebarState>): this {
     // Clone without any undo/redo history
     return super.clone({ ...withState, redoStack: [], undoStack: [] });
   }
@@ -324,7 +324,7 @@ export class DashboardEditPane extends SceneObjectBase<DashboardEditPaneState> i
       document.activeElement.blur();
     }
 
-    const newState: DashboardEditPaneState = {
+    const newState: DashboardSidebarState = {
       ...this.state,
       selectionContext: { ...this.state.selectionContext, selected },
       openPane: selected.length ? new ElementEditPane({}) : undefined,
@@ -459,9 +459,9 @@ function trySwitchingToSourceTab(source: SceneObject) {
 }
 
 function getStateForPaneHistory(
-  currentState: DashboardEditPaneState | undefined,
-  newState?: DashboardEditPaneState
-): DashboardEditPaneState | undefined {
+  currentState: DashboardSidebarState | undefined,
+  newState?: DashboardSidebarState
+): DashboardSidebarState | undefined {
   if (!currentState || !currentState.openPane) {
     return undefined;
   }

--- a/public/app/features/dashboard-scene/edit-pane/DashboardSidebarRenderer.test.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardSidebarRenderer.test.tsx
@@ -14,7 +14,7 @@ import { DefaultGridLayoutManager } from '../scene/layout-default/DefaultGridLay
 import { DashboardInteractions } from '../utils/interactions';
 import { activateFullSceneTree } from '../utils/test-utils';
 
-import { DashboardEditPaneSplitter } from './DashboardEditPaneSplitter';
+import { DashboardSidebarSplitter } from './DashboardSidebarSplitter';
 
 setPluginImportUtils({
   importPanelPlugin: (id: string) => Promise.resolve(getPanelPlugin({})),
@@ -74,7 +74,7 @@ export function buildTestScene() {
   return testScene;
 }
 
-describe('DashboardEditPaneRenderer', () => {
+describe('DashboardSidebarRenderer', () => {
   beforeEach(() => {
     config.featureToggles.dashboardNewLayouts = true;
     // Sidebar state is persisted to localStorage — clear between tests so each test
@@ -92,7 +92,7 @@ describe('DashboardEditPaneRenderer', () => {
 
     act(() => activateFullSceneTree(scene));
 
-    render(<DashboardEditPaneSplitter dashboard={scene} />);
+    render(<DashboardSidebarSplitter dashboard={scene} />);
 
     expect(await screen.findByTestId(selectors.pages.Dashboard.Sidebar.outlineButton)).toBeInTheDocument();
   });
@@ -102,7 +102,7 @@ describe('DashboardEditPaneRenderer', () => {
 
     act(() => activateFullSceneTree(scene));
 
-    render(<DashboardEditPaneSplitter dashboard={scene} isEditing />);
+    render(<DashboardSidebarSplitter dashboard={scene} isEditing />);
 
     act(() => screen.getByLabelText('Outline').click());
 
@@ -124,7 +124,7 @@ describe('DashboardEditPaneRenderer', () => {
 
       act(() => activateFullSceneTree(scene));
 
-      render(<DashboardEditPaneSplitter dashboard={scene} isEditing />);
+      render(<DashboardSidebarSplitter dashboard={scene} isEditing />);
       const outlineButton = screen.getByTestId(selectors.pages.Dashboard.Sidebar.outlineButton);
       await user.click(outlineButton);
       expect(DashboardInteractions.dashboardOutlineClicked).toHaveBeenCalled();
@@ -137,7 +137,7 @@ describe('DashboardEditPaneRenderer', () => {
       scene.setState({ isEditing: false });
       act(() => activateFullSceneTree(scene));
 
-      render(<DashboardEditPaneSplitter dashboard={scene} />);
+      render(<DashboardSidebarSplitter dashboard={scene} />);
 
       const hideButton = await screen.findByTestId(selectors.components.Sidebar.showHideToggle);
       expect(hideButton).toBeInTheDocument();
@@ -147,7 +147,7 @@ describe('DashboardEditPaneRenderer', () => {
       const scene = buildTestScene();
       act(() => activateFullSceneTree(scene));
 
-      render(<DashboardEditPaneSplitter dashboard={scene} isEditing />);
+      render(<DashboardSidebarSplitter dashboard={scene} isEditing />);
 
       const hideButton = await screen.findByTestId(selectors.components.Sidebar.showHideToggle);
       expect(hideButton).toBeInTheDocument();
@@ -158,7 +158,7 @@ describe('DashboardEditPaneRenderer', () => {
       const scene = buildTestScene();
       act(() => activateFullSceneTree(scene));
 
-      render(<DashboardEditPaneSplitter dashboard={scene} isEditing />);
+      render(<DashboardSidebarSplitter dashboard={scene} isEditing />);
 
       // Open the outline pane first
       await user.click(screen.getByTestId(selectors.pages.Dashboard.Sidebar.outlineButton));
@@ -178,7 +178,7 @@ describe('DashboardEditPaneRenderer', () => {
       const scene = buildTestScene();
       act(() => activateFullSceneTree(scene));
 
-      render(<DashboardEditPaneSplitter dashboard={scene} isEditing />);
+      render(<DashboardSidebarSplitter dashboard={scene} isEditing />);
 
       // Hide the sidebar
       await user.click(screen.getByTestId(selectors.components.Sidebar.showHideToggle));

--- a/public/app/features/dashboard-scene/edit-pane/DashboardSidebarRenderer.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardSidebarRenderer.tsx
@@ -23,7 +23,7 @@ import { ShareExportDashboardButton } from './DashboardExportButton';
 import { AddNewEditPane } from './add-new/AddNewEditPane';
 import { ToggleViewPanePaneEvent } from './events';
 import { DashboardOutline } from './outline/DashboardOutline';
-import { type DashboardEditPaneLike, type DashboardSidebarPane } from './types';
+import { type DashboardSidebarLike, type DashboardSidebarPane } from './types';
 
 export interface Props {
   dashboard: DashboardScene;
@@ -32,25 +32,25 @@ export interface Props {
 /**
  * Making the EditPane rendering completely standalone (not using editPane.Component) in order to pass custom react props
  */
-export function DashboardEditPaneRenderer({ dashboard }: Props) {
-  const editPane = dashboard.state.editPane;
-  const { openPane, selectionContext, outlinePane } = useSceneObjectState(editPane, {
+export function DashboardSidebarRenderer({ dashboard }: Props) {
+  const sidebar = dashboard.state.editPane;
+  const { openPane, selectionContext, outlinePane } = useSceneObjectState(sidebar, {
     shouldActivateOrKeepAlive: true,
   });
   const { isEditing, meta, uid, viewPanel } = dashboard.useState();
   const styles = useStyles2(getStyles, isEditing);
   const hasUid = Boolean(uid);
   const isEmbedded = meta.isEmbedded;
-  const selectedObject = editPane.getSelectedObject();
+  const selectedObject = sidebar.getSelectedObject();
   const sidebarContext = useSidebarContext();
   const viewPanelPane = useFlagGrafanaViewPanelPane();
   const onClickHideSidebar: React.MouseEventHandler<HTMLButtonElement> = useCallback(
     (e) => {
-      editPane.closePane();
+      sidebar.closePane();
       sidebarContext?.setIsHidden(true);
       e.currentTarget.blur();
     },
-    [editPane, sidebarContext]
+    [sidebar, sidebarContext]
   );
 
   /**
@@ -58,10 +58,10 @@ export function DashboardEditPaneRenderer({ dashboard }: Props) {
    */
   useEffect(() => {
     if (!selectedObject && selectionContext.selected.length > 0) {
-      editPane.fixSelectionOfRemovedObject();
+      sidebar.fixSelectionOfRemovedObject();
       return;
     }
-  }, [selectedObject, selectionContext.selected, editPane]);
+  }, [selectedObject, selectionContext.selected, sidebar]);
 
   return (
     <>
@@ -76,7 +76,7 @@ export function DashboardEditPaneRenderer({ dashboard }: Props) {
             <Sidebar.Button
               icon="plus"
               variant="primary"
-              onClick={() => editPane.openPane(new AddNewEditPane({}))}
+              onClick={() => sidebar.openPane(new AddNewEditPane({}))}
               title={t('dashboard.sidebar.add.title', 'Add')}
               tooltip={t('dashboard.sidebar.add.tooltip', 'Add new element')}
               data-testid={selectors.pages.Dashboard.Sidebar.addButton}
@@ -84,7 +84,7 @@ export function DashboardEditPaneRenderer({ dashboard }: Props) {
             />
             <Sidebar.Button
               icon="cog"
-              onClick={() => editPane.selectObject(dashboard)}
+              onClick={() => sidebar.selectObject(dashboard)}
               title={t('dashboard.sidebar.dashboard-options.title', 'Options')}
               tooltip={t('dashboard.sidebar.dashboard-options.tooltip', 'Dashboard options')}
               data-testid={selectors.pages.Dashboard.Sidebar.optionsButton}
@@ -114,7 +114,7 @@ export function DashboardEditPaneRenderer({ dashboard }: Props) {
               tooltip={t('dashboard.sidebar.edit-schema.tooltip', 'Edit as code')}
               title={t('dashboard.sidebar.edit-schema.title', 'Code')}
               icon="brackets-curly"
-              onClick={() => editPane.openPane(new DashboardCodePane({}))}
+              onClick={() => sidebar.openPane(new DashboardCodePane({}))}
               active={openPane instanceof DashboardCodePane}
             />
             {config.featureToggles.dashboardUndoRedo && (
@@ -132,7 +132,7 @@ export function DashboardEditPaneRenderer({ dashboard }: Props) {
             icon="list-ui-alt"
             onClick={() => {
               DashboardInteractions.dashboardOutlineClicked();
-              editPane.openPane(outlinePane!);
+              sidebar.openPane(outlinePane!);
             }}
             title={t('dashboard.sidebar.outline.title', 'Outline')}
             tooltip={t('dashboard.sidebar.outline.tooltip', 'Content outline')}
@@ -140,14 +140,14 @@ export function DashboardEditPaneRenderer({ dashboard }: Props) {
             active={openPane instanceof DashboardOutline}
           />
           {config.featureToggles.dashboardNewLayouts && config.featureToggles.dashboardUnifiedDrilldownControls && (
-            <FiltersOverviewButton editPane={editPane} openPane={openPane} />
+            <FiltersOverviewButton sidebar={sidebar} openPane={openPane} />
           )}
           {dashboard.isManaged() && Boolean(meta.canEdit) && <ManagedDashboardNavBarBadge dashboard={dashboard} />}
           {renderEnterpriseItems()}
           {viewPanel && viewPanelPane && (
             <Sidebar.Button
               icon="layer-group"
-              onClick={() => editPane.publishEvent(new ToggleViewPanePaneEvent())}
+              onClick={() => sidebar.publishEvent(new ToggleViewPanePaneEvent())}
               title={t('dashboard.sidebar.view-panel.title', 'View panel controls')}
               data-testid={selectors.pages.Dashboard.Sidebar.viewPanelControls}
               active={openPane?.getId() === 'view-panel-pane'}
@@ -176,13 +176,13 @@ export function DashboardEditPaneRenderer({ dashboard }: Props) {
 }
 
 function FiltersOverviewButton({
-  editPane,
+  sidebar,
   openPane,
 }: {
-  editPane: DashboardEditPaneLike;
+  sidebar: DashboardSidebarLike;
   openPane: DashboardSidebarPane | undefined;
 }) {
-  const variables: SceneVariable[] = sceneGraph.getVariables(editPane)?.useState().variables ?? [];
+  const variables: SceneVariable[] = sceneGraph.getVariables(sidebar)?.useState().variables ?? [];
   const hasFilters = variables.some((v) => v.state.type === 'adhoc');
 
   if (!hasFilters) {
@@ -192,7 +192,7 @@ function FiltersOverviewButton({
   return (
     <Sidebar.Button
       icon="filter"
-      onClick={() => editPane.openPane(new DashboardFiltersOverviewPane({}))}
+      onClick={() => sidebar.openPane(new DashboardFiltersOverviewPane({}))}
       title={t('dashboard.sidebar.filters', 'Filters')}
       tooltip={t('dashboard.sidebar.open', 'Filters overview')}
       active={openPane instanceof DashboardFiltersOverviewPane}
@@ -214,8 +214,8 @@ function renderEnterpriseItems() {
 }
 
 function UndoButton({ dashboard }: ToolbarActionProps) {
-  const editPane = dashboard.state.editPane;
-  const { undoStack } = editPane.useState();
+  const sidebar = dashboard.state.editPane;
+  const { undoStack } = sidebar.useState();
   const undoAction = undoStack[undoStack.length - 1];
   const undoWord = t('dashboard.sidebar.undo', 'Undo');
   const tooltip = `${undoWord}${undoAction?.description ? ` ${undoAction.description}` : ''}`;
@@ -224,7 +224,7 @@ function UndoButton({ dashboard }: ToolbarActionProps) {
     <Sidebar.Button
       icon="corner-up-left"
       disabled={undoStack.length === 0}
-      onClick={() => editPane.undoAction()}
+      onClick={() => sidebar.undoAction()}
       title={undoWord}
       tooltip={tooltip}
     />
@@ -232,8 +232,8 @@ function UndoButton({ dashboard }: ToolbarActionProps) {
 }
 
 function RedoButton({ dashboard }: ToolbarActionProps) {
-  const editPane = dashboard.state.editPane;
-  const { redoStack } = editPane.useState();
+  const sidebar = dashboard.state.editPane;
+  const { redoStack } = sidebar.useState();
   const redoAction = redoStack[redoStack.length - 1];
   const redoWord = t('dashboard.sidebar.redo', 'Redo');
   const tooltip = `${redoWord}${redoAction?.description ? ` ${redoAction.description}` : ''}`;
@@ -244,7 +244,7 @@ function RedoButton({ dashboard }: ToolbarActionProps) {
       disabled={redoStack.length === 0}
       title={redoWord}
       tooltip={tooltip}
-      onClick={() => editPane.redoAction()}
+      onClick={() => sidebar.redoAction()}
     />
   );
 }

--- a/public/app/features/dashboard-scene/edit-pane/DashboardSidebarSplitter.test.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardSidebarSplitter.test.tsx
@@ -13,7 +13,7 @@ import { AutoGridLayoutManager } from '../scene/layout-auto-grid/AutoGridLayoutM
 import { DashboardGridItem } from '../scene/layout-default/DashboardGridItem';
 import { DefaultGridLayoutManager } from '../scene/layout-default/DefaultGridLayoutManager';
 
-import { DashboardEditPaneSplitter } from './DashboardEditPaneSplitter';
+import { DashboardSidebarSplitter } from './DashboardSidebarSplitter';
 
 setPluginImportUtils({
   importPanelPlugin: (id: string) => Promise.resolve(getPanelPlugin({})),
@@ -27,7 +27,7 @@ const autoLayoutInputs = [
   selectors.components.PanelEditor.ElementEditPane.AutoGridLayout.fillScreen,
 ];
 
-describe('DashboardEditPaneSplitter', () => {
+describe('DashboardSidebarSplitter', () => {
   beforeEach(() => {
     config.featureToggles.dashboardNewLayouts = true;
   });
@@ -36,7 +36,7 @@ describe('DashboardEditPaneSplitter', () => {
     const user = userEvent.setup();
     const scene = buildTestScene();
 
-    render(<DashboardEditPaneSplitter dashboard={scene} />);
+    render(<DashboardSidebarSplitter dashboard={scene} />);
 
     await user.click(screen.getByTestId(selectors.pages.Dashboard.Sidebar.optionsButton));
 
@@ -65,7 +65,7 @@ describe('DashboardEditPaneSplitter', () => {
   it('makes the scroll container keyboard-focusable so arrow/page keys can scroll the dashboard', () => {
     const scene = buildTestScene();
 
-    render(<DashboardEditPaneSplitter dashboard={scene} />);
+    render(<DashboardSidebarSplitter dashboard={scene} />);
 
     const scrollContainer = screen.getByTestId(selectors.components.DashboardEditPaneSplitter.bodyContainer);
     expect(scrollContainer).toHaveAttribute('tabindex', '0');

--- a/public/app/features/dashboard-scene/edit-pane/DashboardSidebarSplitter.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardSidebarSplitter.tsx
@@ -28,7 +28,7 @@ import { PublicDashboardBadge } from '../scene/new-toolbar/actions/PublicDashboa
 import { StarButton } from '../scene/new-toolbar/actions/StarButton';
 import { dynamicDashNavActions } from '../utils/registerDynamicDashNavAction';
 
-import { DashboardEditPaneRenderer } from './DashboardEditPaneRenderer';
+import { DashboardSidebarRenderer } from './DashboardSidebarRenderer';
 import { type DashboardSidebarPane } from './types';
 
 interface Props {
@@ -38,15 +38,15 @@ interface Props {
   controls?: React.ReactNode;
 }
 
-export function DashboardEditPaneSplitter(props: Props) {
+export function DashboardSidebarSplitter(props: Props) {
   if (config.featureToggles.dashboardNewLayouts) {
-    return <DashboardEditPaneSplitterNewLayouts {...props} />;
+    return <DashboardSidebarSplitterNewLayouts {...props} />;
   } else {
-    return <DashboardEditPaneSplitterLegacy {...props} />;
+    return <DashboardSidebarSplitterLegacy {...props} />;
   }
 }
 
-function DashboardEditPaneSplitterLegacy({ dashboard, body, controls }: Props) {
+function DashboardSidebarSplitterLegacy({ dashboard, body, controls }: Props) {
   const styles = useStyles2(getStyles);
 
   return (
@@ -60,7 +60,7 @@ function DashboardEditPaneSplitterLegacy({ dashboard, body, controls }: Props) {
   );
 }
 
-function DashboardEditPaneSplitterNewLayouts({ dashboard, isEditing, body, controls }: Props) {
+function DashboardSidebarSplitterNewLayouts({ dashboard, isEditing, body, controls }: Props) {
   const { editPane } = dashboard.state;
   const styles = useStyles2(getStyles);
   const { chrome } = useGrafana();
@@ -103,7 +103,7 @@ function DashboardEditPaneSplitterNewLayouts({ dashboard, isEditing, body, contr
   useSidebarPaneMinWidth(openPane, sidebarContext);
 
   /**
-   * Sync docked state to editPane state
+   * Sync docked state to sidebar state
    */
   useEffect(() => {
     editPane.setState({ isDocked: sidebarContext.isDocked });
@@ -159,7 +159,7 @@ function DashboardEditPaneSplitterNewLayouts({ dashboard, isEditing, body, contr
         </div>
 
         <Sidebar contextValue={sidebarContext}>
-          <DashboardEditPaneRenderer dashboard={dashboard} />
+          <DashboardSidebarRenderer dashboard={dashboard} />
         </Sidebar>
       </div>
     );

--- a/public/app/features/dashboard-scene/edit-pane/ElementEditPane.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/ElementEditPane.tsx
@@ -5,8 +5,8 @@ import { type GrafanaTheme2 } from '@grafana/data';
 import { type SceneComponentProps, sceneGraph, SceneObjectBase } from '@grafana/scenes';
 import { ScrollContainer, useStyles2, Box } from '@grafana/ui';
 
-import { DashboardEditPane } from './DashboardEditPane';
-import { EditPaneHeader } from './EditPaneHeader';
+import { DashboardSidebar } from './DashboardSidebar';
+import { ElementEditPaneHeader } from './ElementEditPaneHeader';
 import { getEditableElementForSelection } from './shared';
 
 export class ElementEditPane extends SceneObjectBase {
@@ -21,14 +21,14 @@ export class ElementEditPane extends SceneObjectBase {
 function ElementEditPaneRenderer({ model }: SceneComponentProps<ElementEditPane>) {
   const styles = useStyles2(getStyles);
 
-  const editPane = sceneGraph.getAncestor(model, DashboardEditPane);
-  const selected = editPane.state.selectionContext.selected;
+  const sidebar = sceneGraph.getAncestor(model, DashboardSidebar);
+  const selected = sidebar.state.selectionContext.selected;
 
   const element = useMemo(() => {
-    return getEditableElementForSelection(editPane, selected);
-  }, [editPane, selected]);
+    return getEditableElementForSelection(sidebar, selected);
+  }, [sidebar, selected]);
 
-  const categories = element?.useEditPaneOptions ? element.useEditPaneOptions(editPane.state.isNewElement) : [];
+  const categories = element?.useEditPaneOptions ? element.useEditPaneOptions(sidebar.state.isNewElement) : [];
 
   if (!element) {
     return null;
@@ -36,7 +36,7 @@ function ElementEditPaneRenderer({ model }: SceneComponentProps<ElementEditPane>
 
   return (
     <div className={styles.wrapper}>
-      <EditPaneHeader element={element} editPane={editPane} />
+      <ElementEditPaneHeader element={element} sidebar={sidebar} />
       <ScrollContainer showScrollIndicators={true}>
         <div className={styles.categories}>
           {element.renderTopButton && (

--- a/public/app/features/dashboard-scene/edit-pane/ElementEditPaneHeader.test.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/ElementEditPaneHeader.test.tsx
@@ -18,8 +18,8 @@ import { type EditableDashboardElement } from '../scene/types/EditableDashboardE
 import { DashboardInteractions } from '../utils/interactions';
 import { activateFullSceneTree } from '../utils/test-utils';
 
-import { type DashboardEditPane } from './DashboardEditPane';
-import { EditPaneHeader } from './EditPaneHeader';
+import { type DashboardSidebar } from './DashboardSidebar';
+import { ElementEditPaneHeader } from './ElementEditPaneHeader';
 import { getEditableElementFor } from './shared';
 
 setPluginImportUtils({
@@ -35,7 +35,7 @@ jest.mock('../utils/interactions', () => ({
   },
 }));
 
-describe('EditPaneHeader', () => {
+describe('ElementEditPaneHeader', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -81,22 +81,22 @@ function WrapSidebar({ children }: { children: React.ReactElement }) {
   return <Sidebar contextValue={sidebarContext}>{children}</Sidebar>;
 }
 
-const renderEditPaneHeader = (editableElement: EditableDashboardElement, mockEditPane: DashboardEditPane) => {
+const renderEditPaneHeader = (editableElement: EditableDashboardElement, mockEditPane: DashboardSidebar) => {
   render(
     <WrapSidebar>
-      <EditPaneHeader element={editableElement} editPane={mockEditPane} />
+      <ElementEditPaneHeader element={editableElement} sidebar={mockEditPane} />
     </WrapSidebar>
   );
 };
 
 const setup = (
   layout: 'row' | 'tab' | 'panel'
-): { row?: RowItem; tab?: TabItem; panel?: VizPanel; mockEditPane: DashboardEditPane } => {
+): { row?: RowItem; tab?: TabItem; panel?: VizPanel; mockEditPane: DashboardSidebar } => {
   const mockEditPane = {
     state: { selection: null },
     clearSelection: jest.fn(),
     getOnGetBackCallback: () => jest.fn(),
-  } as unknown as DashboardEditPane;
+  } as unknown as DashboardSidebar;
 
   switch (layout) {
     case 'row': {

--- a/public/app/features/dashboard-scene/edit-pane/ElementEditPaneHeader.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/ElementEditPaneHeader.tsx
@@ -10,14 +10,14 @@ import { useClipboardState } from '../scene/layouts-shared/useClipboardState';
 import { type EditableDashboardElement } from '../scene/types/EditableDashboardElement';
 import { DashboardInteractions } from '../utils/interactions';
 
-import { type DashboardEditPane } from './DashboardEditPane';
+import { type DashboardSidebar } from './DashboardSidebar';
 
 interface EditPaneHeaderProps {
   element: EditableDashboardElement;
-  editPane: DashboardEditPane;
+  sidebar: DashboardSidebar;
 }
 
-export function EditPaneHeader({ element, editPane }: EditPaneHeaderProps) {
+export function ElementEditPaneHeader({ element, sidebar }: EditPaneHeaderProps) {
   const elementInfo = element.getEditableElementInfo();
   const { hasCopiedPanel } = useClipboardState();
 
@@ -76,8 +76,8 @@ export function EditPaneHeader({ element, editPane }: EditPaneHeaderProps) {
           fill="text"
           data-testid={selectors.components.EditPaneHeader.paste}
           onClick={() => {
-            const target = editPane.getSelectedObject();
-            editPane.pastePanel(target);
+            const target = sidebar.getSelectedObject();
+            sidebar.pastePanel(target);
             DashboardInteractions.trackPastePanelClick('editPaneHeader', getLayoutType(target), 'click');
           }}
         >

--- a/public/app/features/dashboard-scene/edit-pane/add-new/AddNewEditPane.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/add-new/AddNewEditPane.tsx
@@ -14,7 +14,7 @@ import addPanelSvg from 'img/dashboards/add-panel.svg';
 import { useClipboardState } from '../../scene/layouts-shared/useClipboardState';
 import { getDashboardSceneLike } from '../../scene/types/dashboard';
 import { DashboardInteractions } from '../../utils/interactions';
-import { DashboardEditPane } from '../DashboardEditPane';
+import { DashboardSidebar } from '../DashboardSidebar';
 
 import { AddAnnotationQuery } from './AddAnnotationQuery';
 import { AddButton } from './AddButton';
@@ -33,12 +33,12 @@ export class AddNewEditPane extends SceneObjectBase {
 }
 
 function AddNewEditPaneRenderer({ model }: SceneComponentProps<AddNewEditPane>) {
-  const editPane = sceneGraph.getAncestor(model, DashboardEditPane);
+  const sidebar = sceneGraph.getAncestor(model, DashboardSidebar);
   const { hasCopiedPanel } = useClipboardState();
   const styles = useStyles2(getStyles);
   const dashboardScene = getDashboardSceneLike(model);
   const orchestrator = dashboardScene.state.layoutOrchestrator;
-  const selectedObj = editPane.getSelectedObject();
+  const selectedObj = sidebar.getSelectedObject();
 
   const onStartDragging = (result: { draggableId: string }) => {
     const mode = result.draggableId === 'paste-panel-drag' ? 'paste' : 'newPanel';
@@ -46,7 +46,7 @@ function AddNewEditPaneRenderer({ model }: SceneComponentProps<AddNewEditPane>) 
   };
 
   const pastePanel = () => {
-    editPane.pastePanel(selectedObj);
+    sidebar.pastePanel(selectedObj);
     DashboardInteractions.trackPastePanelClick('sidebar', getLayoutType(selectedObj), 'click');
   };
 
@@ -73,11 +73,11 @@ function AddNewEditPaneRenderer({ model }: SceneComponentProps<AddNewEditPane>) 
                           {...dragProvided.draggableProps}
                           {...dragProvided.dragHandleProps}
                           className={cx(styles.imageContainer, dragSnapshot.isDragging && styles.dragging)}
-                          onClick={() => editPane.addNewPanel(selectedObj)}
+                          onClick={() => sidebar.addNewPanel(selectedObj)}
                           onKeyDown={(e) => {
                             if (e.key === 'Enter' || e.key === ' ') {
                               e.preventDefault();
-                              editPane.addNewPanel(selectedObj);
+                              sidebar.addNewPanel(selectedObj);
                             }
                           }}
                           aria-label={t('dashboard.add.new-panel.title', 'Panel')}

--- a/public/app/features/dashboard-scene/edit-pane/dashboard/DashboardBasicOptions.test.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/dashboard/DashboardBasicOptions.test.tsx
@@ -8,7 +8,7 @@ import { type DashboardScene } from '../../scene/DashboardScene';
 import { type DashboardSceneState } from '../../scene/types/dashboard';
 import { transformSaveModelToScene } from '../../serialization/transformSaveModelToScene';
 import { activateFullSceneTree } from '../../utils/test-utils';
-import { type DashboardEditPaneLike } from '../types';
+import { type DashboardSidebarLike } from '../types';
 
 import { DashboardDescriptionInput, DashboardTitleInput } from './DashboardBasicOptions';
 
@@ -50,50 +50,50 @@ async function testDashboardEditableElement(dashboard: DashboardScene, inputElem
     fireEvent.blur(inputElement);
   };
 
-  const editPane = dashboard.state.editPane;
-  expect(editPane.state.undoStack).toHaveLength(0);
-  expect(editPane.state.redoStack).toHaveLength(0);
+  const sidebar = dashboard.state.editPane;
+  expect(sidebar.state.undoStack).toHaveLength(0);
+  expect(sidebar.state.redoStack).toHaveLength(0);
   expect(inputElement).toHaveValue('initial');
 
   await updateInput('first');
   expect(inputElement).toHaveValue('first');
-  expect(editPane.state.undoStack).toHaveLength(1);
-  expect(editPane.state.redoStack).toHaveLength(0);
+  expect(sidebar.state.undoStack).toHaveLength(1);
+  expect(sidebar.state.redoStack).toHaveLength(0);
 
-  undo(editPane);
+  undo(sidebar);
   expect(inputElement).toHaveValue('initial');
-  expect(editPane.state.undoStack).toHaveLength(0);
-  expect(editPane.state.redoStack).toHaveLength(1);
+  expect(sidebar.state.undoStack).toHaveLength(0);
+  expect(sidebar.state.redoStack).toHaveLength(1);
 
   await updateInput('second');
   expect(inputElement).toHaveValue('second');
-  expect(editPane.state.redoStack).toHaveLength(0);
-  expect(editPane.state.undoStack).toHaveLength(1);
+  expect(sidebar.state.redoStack).toHaveLength(0);
+  expect(sidebar.state.undoStack).toHaveLength(1);
 
   await updateInput('third');
   expect(inputElement).toHaveValue('third');
-  expect(editPane.state.redoStack).toHaveLength(0);
-  expect(editPane.state.undoStack).toHaveLength(2);
+  expect(sidebar.state.redoStack).toHaveLength(0);
+  expect(sidebar.state.undoStack).toHaveLength(2);
 
   await updateInput('fourth');
   expect(inputElement).toHaveValue('fourth');
-  expect(editPane.state.redoStack).toHaveLength(0);
-  expect(editPane.state.undoStack).toHaveLength(3);
+  expect(sidebar.state.redoStack).toHaveLength(0);
+  expect(sidebar.state.undoStack).toHaveLength(3);
 
-  undo(editPane);
+  undo(sidebar);
   expect(inputElement).toHaveValue('third');
-  expect(editPane.state.redoStack).toHaveLength(1);
-  expect(editPane.state.undoStack).toHaveLength(2);
+  expect(sidebar.state.redoStack).toHaveLength(1);
+  expect(sidebar.state.undoStack).toHaveLength(2);
 
-  undo(editPane);
+  undo(sidebar);
   expect(inputElement).toHaveValue('second');
-  expect(editPane.state.redoStack).toHaveLength(2);
-  expect(editPane.state.undoStack).toHaveLength(1);
+  expect(sidebar.state.redoStack).toHaveLength(2);
+  expect(sidebar.state.undoStack).toHaveLength(1);
 
-  redo(editPane);
+  redo(sidebar);
   expect(inputElement).toHaveValue('third');
-  expect(editPane.state.redoStack).toHaveLength(1);
-  expect(editPane.state.undoStack).toHaveLength(2);
+  expect(sidebar.state.redoStack).toHaveLength(1);
+  expect(sidebar.state.undoStack).toHaveLength(2);
 }
 
 function setup(overrides?: Partial<DashboardSceneState>) {
@@ -137,14 +137,14 @@ function setup(overrides?: Partial<DashboardSceneState>) {
   return { dashboard, renderTitleInput, renderDescriptionInput };
 }
 
-function undo(editPane: DashboardEditPaneLike) {
+function undo(sidebar: DashboardSidebarLike) {
   act(() => {
-    editPane.undoAction();
+    sidebar.undoAction();
   });
 }
 
-function redo(editPane: DashboardEditPaneLike) {
+function redo(sidebar: DashboardSidebarLike) {
   act(() => {
-    editPane.redoAction();
+    sidebar.redoAction();
   });
 }

--- a/public/app/features/dashboard-scene/edit-pane/outline/DashboardOutline.test.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/outline/DashboardOutline.test.tsx
@@ -107,15 +107,15 @@ describe('DashboardOutline', () => {
     it('should retain expanded/collapsed state when the pane is closed and reopened', async () => {
       const user = userEvent.setup();
       const scene = buildTestScene();
-      const editPane = scene.state.editPane;
-      const outlinePane = editPane.state.outlinePane!;
+      const sidebar = scene.state.editPane;
+      const outlinePane = sidebar.state.outlinePane!;
 
       scene.onEnterEditMode();
-      editPane.enableSelection();
-      editPane.openPane(outlinePane);
+      sidebar.enableSelection();
+      sidebar.openPane(outlinePane);
 
       const { unmount } = render(
-        <ElementSelectionContext.Provider value={editPane.state.selectionContext}>
+        <ElementSelectionContext.Provider value={sidebar.state.selectionContext}>
           <WrapSidebar>
             <outlinePane.Component model={outlinePane} />
           </WrapSidebar>
@@ -128,7 +128,7 @@ describe('DashboardOutline', () => {
       unmount();
 
       render(
-        <ElementSelectionContext.Provider value={editPane.state.selectionContext}>
+        <ElementSelectionContext.Provider value={sidebar.state.selectionContext}>
           <WrapSidebar>
             <outlinePane.Component model={outlinePane} />
           </WrapSidebar>
@@ -156,14 +156,14 @@ describe('DashboardOutline', () => {
     it('should preserve collapsed state after entering and exiting edit mode', async () => {
       const user = userEvent.setup();
       const scene = buildTestScene();
-      const editPane = scene.state.editPane;
-      const outlinePane = editPane.state.outlinePane!;
+      const sidebar = scene.state.editPane;
+      const outlinePane = sidebar.state.outlinePane!;
 
-      editPane.enableSelection();
-      editPane.openPane(outlinePane);
+      sidebar.enableSelection();
+      sidebar.openPane(outlinePane);
 
       const { unmount } = render(
-        <ElementSelectionContext.Provider value={editPane.state.selectionContext}>
+        <ElementSelectionContext.Provider value={sidebar.state.selectionContext}>
           <WrapSidebar>
             <outlinePane.Component model={outlinePane} />
           </WrapSidebar>
@@ -374,15 +374,15 @@ describe('DashboardOutline', () => {
     it('retains search query when the pane is closed and reopened', async () => {
       const user = userEvent.setup();
       const scene = buildTestScene();
-      const editPane = scene.state.editPane;
-      const outlinePane = editPane.state.outlinePane!;
+      const sidebar = scene.state.editPane;
+      const outlinePane = sidebar.state.outlinePane!;
 
       scene.onEnterEditMode();
-      editPane.enableSelection();
-      editPane.openPane(outlinePane);
+      sidebar.enableSelection();
+      sidebar.openPane(outlinePane);
 
       const { unmount } = render(
-        <ElementSelectionContext.Provider value={editPane.state.selectionContext}>
+        <ElementSelectionContext.Provider value={sidebar.state.selectionContext}>
           <WrapSidebar>
             <outlinePane.Component model={outlinePane} />
           </WrapSidebar>
@@ -396,7 +396,7 @@ describe('DashboardOutline', () => {
       unmount();
 
       render(
-        <ElementSelectionContext.Provider value={editPane.state.selectionContext}>
+        <ElementSelectionContext.Provider value={sidebar.state.selectionContext}>
           <WrapSidebar>
             <outlinePane.Component model={outlinePane} />
           </WrapSidebar>
@@ -409,14 +409,14 @@ describe('DashboardOutline', () => {
     it('preserves search query after entering and exiting edit mode', async () => {
       const user = userEvent.setup();
       const scene = buildTestScene();
-      const editPane = scene.state.editPane;
-      const outlinePane = editPane.state.outlinePane!;
+      const sidebar = scene.state.editPane;
+      const outlinePane = sidebar.state.outlinePane!;
 
-      editPane.enableSelection();
-      editPane.openPane(outlinePane);
+      sidebar.enableSelection();
+      sidebar.openPane(outlinePane);
 
       const { unmount } = render(
-        <ElementSelectionContext.Provider value={editPane.state.selectionContext}>
+        <ElementSelectionContext.Provider value={sidebar.state.selectionContext}>
           <WrapSidebar>
             <outlinePane.Component model={outlinePane} />
           </WrapSidebar>

--- a/public/app/features/dashboard-scene/edit-pane/outline/DashboardOutlineNode.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/outline/DashboardOutlineNode.tsx
@@ -14,7 +14,7 @@ import { SectionFiltersSet } from '../../settings/variables/SectionFiltersSet';
 import { isRepeatCloneOrChildOf } from '../../utils/clone';
 import { DashboardInteractions } from '../../utils/interactions';
 import { getEditableElementFor } from '../shared';
-import { type DashboardEditPaneLike } from '../types';
+import { type DashboardSidebarLike } from '../types';
 import { useOutlineRename } from '../useOutlineRename';
 
 import { type DashboardOutline } from './DashboardOutline';
@@ -22,7 +22,7 @@ import { DashboardOutlineNodeButtonContent } from './DashboardOutlineNodeButtonC
 
 interface DashboardOutlineNodeProps {
   sceneObject: SceneObject;
-  editPane: DashboardEditPaneLike;
+  sidebar: DashboardSidebarLike;
   outline: DashboardOutline;
   isEditing: boolean | undefined;
   depth: number;
@@ -33,7 +33,7 @@ interface DashboardOutlineNodeProps {
 
 export function DashboardOutlineNode({
   sceneObject,
-  editPane,
+  sidebar,
   outline,
   isEditing,
   depth,
@@ -76,9 +76,9 @@ export function DashboardOutlineNode({
         sceneObject instanceof DashboardFiltersSet ||
         sceneObject instanceof SectionFiltersSet
       ) {
-        // Select directly via editPane.selectObject because these objects are not
+        // Select directly via sidebar.selectObject because these objects are not
         // in the scene graph, so sceneGraph.findByKey (used by onSelect) can't find them.
-        editPane.selectObject(sceneObject);
+        sidebar.selectObject(sceneObject);
       } else {
         onSelect?.(e);
       }
@@ -156,7 +156,7 @@ export function DashboardOutlineNode({
               <DashboardOutlineNode
                 key={child.state.key}
                 sceneObject={child}
-                editPane={editPane}
+                sidebar={sidebar}
                 outline={outline}
                 depth={depth + 1}
                 isEditing={isEditing}

--- a/public/app/features/dashboard-scene/edit-pane/outline/DashboardOutlineRenderer.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/outline/DashboardOutlineRenderer.tsx
@@ -49,7 +49,7 @@ export function DashboardOutlineRenderer({ model }: SceneComponentProps<Dashboar
             <DashboardOutlineNode
               sceneObject={dashboard}
               isEditing={isEditing}
-              editPane={dashboard.state.editPane}
+              sidebar={dashboard.state.editPane}
               outline={model}
               depth={0}
               index={0}

--- a/public/app/features/dashboard-scene/edit-pane/shared.ts
+++ b/public/app/features/dashboard-scene/edit-pane/shared.ts
@@ -35,7 +35,7 @@ import {
 } from '../settings/variables/utils';
 import { isPredefinedOrigin } from '../utils/predefinedVariables';
 
-import { type DashboardEditPane } from './DashboardEditPane';
+import { type DashboardSidebar } from './DashboardSidebar';
 import { MultiSelectedObjectsEditableElement } from './MultiSelectedObjectsEditableElement';
 import { VizPanelEditableElement } from './VizPanelEditableElement';
 import { DashboardEditableElement } from './dashboard/DashboardEditableElement';
@@ -48,18 +48,18 @@ export function useEditPaneCollapsed() {
 }
 
 export function getEditableElementForSelection(
-  editPane: DashboardEditPane,
+  sidebar: DashboardSidebar,
   selected: ElementSelectionContextItem[]
 ): EditableDashboardElement | undefined {
   if (selected.length === 1) {
-    const obj = editPane.getSelectedObject(selected[0].id);
+    const obj = sidebar.getSelectedObject(selected[0].id);
     if (obj) {
       return getEditableElementFor(obj);
     }
   }
 
   if (selected.length > 1) {
-    const objects = selected.map((s) => editPane.getSelectedObject(s.id));
+    const objects = selected.map((s) => sidebar.getSelectedObject(s.id));
     const elements: BulkActionElement[] = objects
       .map((obj) => getEditableElementFor(obj))
       .filter((e): e is BulkActionElement => Boolean(e) && isBulkActionElement(e!));

--- a/public/app/features/dashboard-scene/edit-pane/types.ts
+++ b/public/app/features/dashboard-scene/edit-pane/types.ts
@@ -4,7 +4,7 @@ import { type ElementSelectionContextState, type ElementSelectionOnSelectOptions
 import { type DashboardEditActionEvent, type DashboardEditActionEventPayload } from './events';
 import { type DashboardOutline } from './outline/DashboardOutline';
 
-export interface DashboardEditPaneState extends SceneObjectState {
+export interface DashboardSidebarState extends SceneObjectState {
   selectionContext: ElementSelectionContextState;
 
   undoStack: DashboardEditActionEventPayload[];
@@ -14,18 +14,18 @@ export interface DashboardEditPaneState extends SceneObjectState {
   /** Temp hack for Link and LinkSet that are not part of the scene but need to be selected for now  */
   selectedDisconnectedObject?: SceneObject;
   /** Previous state */
-  previousState?: DashboardEditPaneState;
+  previousState?: DashboardSidebarState;
   /** True when a new element is being added and selected */
   isNewElement: boolean;
   isDocked?: boolean;
 }
 
 /**
- * Subset of DashboardEditPane used by assistant view-mode components
- * so they can avoid importing the full DashboardEditPane (which would
+ * Subset of DashboardSidebar used by assistant view-mode components
+ * so they can avoid importing the full DashboardSidebar (which would
  * create circular dependencies through DashboardScene).
  */
-export interface DashboardEditPaneLike extends SceneObject<DashboardEditPaneState> {
+export interface DashboardSidebarLike extends SceneObject<DashboardSidebarState> {
   enableSelection(): void;
   disableSelection(): void;
   clearSelection(noEvent?: boolean): void;

--- a/public/app/features/dashboard-scene/scene/DashboardControlsChrome.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardControlsChrome.tsx
@@ -16,7 +16,7 @@ interface DashboardControlsChromeProps {
  * Shared chrome for the dashboard controls bar on the scrolling dashboard canvas (view + edit). It
  * does two canvas-specific jobs: pins the bar below the fixed app header while the canvas scrolls
  * beneath it, and paints an opaque background over the canvas clip-bleed strip (see scrollContainer
- * in DashboardEditPaneSplitter).
+ * in DashboardSidebarSplitter).
  *
  * Surfaces without those two concerns don't use it. Panel edit is a self-contained editor that
  * manages its own scrolling (including the short-viewport reflow layout) and has no clip-bleed
@@ -44,7 +44,7 @@ function getStyles(theme: GrafanaTheme2, headerHeight: number, visualRefreshEnab
       {
         label: 'dashboard-controls-chrome',
         // The dashboard canvas extends its scroll clip box up under this bar (clip-bleed, see
-        // scrollContainer in DashboardEditPaneSplitter), so the bar must paint over that strip on
+        // scrollContainer in DashboardSidebarSplitter), so the bar must paint over that strip on
         // every viewport: opaque background plus its own paint order.
         position: 'relative',
         zIndex: 1,

--- a/public/app/features/dashboard-scene/scene/DashboardLayoutOrchestrator.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardLayoutOrchestrator.tsx
@@ -447,7 +447,7 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
           currentTabSlug: tab.getSlug(),
         });
 
-        // Make sure outline is refreshed in DashboardEditPane
+        // Make sure outline is refreshed in DashboardSidebar
         source.publishEvent(new ObjectsReorderedOnCanvasEvent(source), true);
         destination.publishEvent(new ObjectsReorderedOnCanvasEvent(destination), true);
 
@@ -461,7 +461,7 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
         tab.clearParent();
         source.setState({ tabs: prevSourceTabs, currentTabSlug: prevSourceSlug });
 
-        // Make sure outline is refreshed in DashboardEditPane
+        // Make sure outline is refreshed in DashboardSidebar
         source.publishEvent(new ObjectsReorderedOnCanvasEvent(source), true);
         destination.publishEvent(new ObjectsReorderedOnCanvasEvent(destination), true);
 

--- a/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
@@ -270,20 +270,20 @@ describe('DashboardScene', () => {
       });
 
       it('activateEditPane activates an inactive edit pane and releases it on exit', () => {
-        const editPane = scene.state.editPane;
-        expect(editPane.isActive).toBe(false);
+        const sidebar = scene.state.editPane;
+        expect(sidebar.isActive).toBe(false);
 
         scene.activateEditPane();
-        expect(editPane.isActive).toBe(true);
+        expect(sidebar.isActive).toBe(true);
 
         scene.exitEditMode({ skipConfirm: true });
-        expect(editPane.isActive).toBe(false);
+        expect(sidebar.isActive).toBe(false);
       });
 
       it('activateEditPane is a no-op when the edit pane is already active', () => {
-        const editPane = scene.state.editPane;
-        const activateSpy = jest.spyOn(editPane, 'activate');
-        editPane.activate();
+        const sidebar = scene.state.editPane;
+        const activateSpy = jest.spyOn(sidebar, 'activate');
+        sidebar.activate();
 
         scene.activateEditPane();
 
@@ -291,17 +291,17 @@ describe('DashboardScene', () => {
       });
 
       it('re-activates the swapped-in edit pane when discarding and keeping edit', () => {
-        const editPane = scene.state.editPane;
+        const sidebar = scene.state.editPane;
         scene.activateEditPane();
-        expect(editPane.isActive).toBe(true);
+        expect(sidebar.isActive).toBe(true);
 
         scene.discardChangesAndKeepEditing();
 
         // The original pane is released, but a fresh clone is swapped in and re-activated so
         // programmatic mutations keep working while we stay in edit mode.
-        expect(editPane.isActive).toBe(false);
+        expect(sidebar.isActive).toBe(false);
         const newEditPane = scene.state.editPane;
-        expect(newEditPane).not.toBe(editPane);
+        expect(newEditPane).not.toBe(sidebar);
         expect(newEditPane.isActive).toBe(true);
       });
 

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -62,7 +62,7 @@ import {
   ManagerKind,
   type ResourceForCreate,
 } from '../../apiserver/types';
-import { DashboardEditPane } from '../edit-pane/DashboardEditPane';
+import { DashboardSidebar } from '../edit-pane/DashboardSidebar';
 import { dashboardEditActions } from '../edit-pane/shared';
 import { DashboardSceneChangeTracker } from '../saving/DashboardSceneChangeTracker';
 import { SaveDashboardDrawer } from '../saving/SaveDashboardDrawer';
@@ -209,7 +209,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
         state.body ?? state.preferences?.defaultLayoutTemplate?.clone() ?? DefaultGridLayoutManager.fromVizPanels([]),
       links: state.links ?? [],
       ...state,
-      editPane: new DashboardEditPane(),
+      editPane: new DashboardSidebar(),
       layoutOrchestrator: new DashboardLayoutOrchestrator(),
       preferences: state.preferences ?? {},
     });

--- a/public/app/features/dashboard-scene/scene/DashboardSceneRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneRenderer.tsx
@@ -8,7 +8,7 @@ import { getNavModel } from 'app/core/selectors/navModel';
 import { useScopesServices } from 'app/features/scopes/ScopesContextProvider';
 import { useSelector } from 'app/types/store';
 
-import { DashboardEditPaneSplitter } from '../edit-pane/DashboardEditPaneSplitter';
+import { DashboardSidebarSplitter } from '../edit-pane/DashboardSidebarSplitter';
 import { SoloPanelContextProvider, useDefineSoloPanelContext } from '../solo/SoloPanelContext';
 
 import { type DashboardScene } from './DashboardScene';
@@ -109,7 +109,7 @@ export function DashboardSceneRenderer({ model }: SceneComponentProps<DashboardS
       <Page navModel={navModel} pageNav={pageNav} layout={PageLayoutType.Custom}>
         {editPanel && <editPanel.Component model={editPanel} />}
         {!editPanel && (
-          <DashboardEditPaneSplitter
+          <DashboardSidebarSplitter
             dashboard={model}
             isEditing={isEditing}
             controls={controls && <controls.Component model={controls} />}

--- a/public/app/features/dashboard-scene/scene/dashboard-filters-overview/DashboardFiltersOverviewPane.tsx
+++ b/public/app/features/dashboard-scene/scene/dashboard-filters-overview/DashboardFiltersOverviewPane.tsx
@@ -6,7 +6,7 @@ import { t } from '@grafana/i18n';
 import { type SceneComponentProps, sceneGraph, SceneObjectBase, sceneUtils } from '@grafana/scenes';
 import { Box, IconButton, Text, useStyles2 } from '@grafana/ui';
 
-import { DashboardEditPane } from '../../edit-pane/DashboardEditPane';
+import { DashboardSidebar } from '../../edit-pane/DashboardSidebar';
 
 import { DashboardFiltersOverview } from './DashboardFiltersOverview';
 import { DashboardFiltersOverviewSearch } from './DashboardFiltersOverviewSearch';
@@ -21,7 +21,7 @@ export class DashboardFiltersOverviewPane extends SceneObjectBase {
 }
 
 function DashboardFiltersOverviewPaneRenderer({ model }: SceneComponentProps<DashboardFiltersOverviewPane>) {
-  const editPane = sceneGraph.getAncestor(model, DashboardEditPane);
+  const sidebar = sceneGraph.getAncestor(model, DashboardSidebar);
   const styles = useStyles2(getStyles);
   const [searchQuery, setSearchQuery] = useState('');
   const { variables } = sceneGraph.getVariables(model)!.useState();
@@ -34,7 +34,7 @@ function DashboardFiltersOverviewPaneRenderer({ model }: SceneComponentProps<Das
         <IconButton
           name="times"
           size="lg"
-          onClick={() => editPane.closePane()}
+          onClick={() => sidebar.closePane()}
           aria-label={t('dashboard.filters-overview.close', 'Close')}
         />
         <div className={styles.title}>
@@ -46,7 +46,7 @@ function DashboardFiltersOverviewPaneRenderer({ model }: SceneComponentProps<Das
         <DashboardFiltersOverview
           adhocFilters={adHocVar}
           groupByVariable={groupByVar}
-          onClose={() => editPane.closePane()}
+          onClose={() => sidebar.closePane()}
           searchQuery={searchQuery}
         />
       </div>

--- a/public/app/features/dashboard-scene/scene/keyboardShortcuts.ts
+++ b/public/app/features/dashboard-scene/scene/keyboardShortcuts.ts
@@ -289,9 +289,9 @@ export function setupKeyboardShortcuts(scene: DashboardScene) {
       key: 'p v',
       onTrigger: () => {
         if (scene.state.isEditing && store.exists(LS_PANEL_COPY_KEY)) {
-          const editPane = scene.state.editPane;
-          const selectedObj = editPane.getSelectedObject();
-          editPane.pastePanel(selectedObj);
+          const sidebar = scene.state.editPane;
+          const selectedObj = sidebar.getSelectedObject();
+          sidebar.pastePanel(selectedObj);
 
           DashboardInteractions.trackPastePanelClick('keyboard', getLayoutType(selectedObj), 'keyboard');
         }

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManager.tsx
@@ -337,8 +337,8 @@ export class RowsLayoutManager
       return;
     }
 
-    const editPane = getDashboardSceneFor(this).state.editPane;
-    editPane.selectObject(row!, { force: true, multi: false });
+    const sidebar = getDashboardSceneFor(this).state.editPane;
+    sidebar.selectObject(row!, { force: true, multi: false });
   }
 
   public static createEmpty(): RowsLayoutManager {

--- a/public/app/features/dashboard-scene/scene/types/dashboard.ts
+++ b/public/app/features/dashboard-scene/scene/types/dashboard.ts
@@ -3,7 +3,7 @@ import { type DashboardLink } from '@grafana/schema';
 import { type ScopeMeta } from 'app/features/dashboard/state/DashboardModel';
 import { type DashboardMeta } from 'app/types/dashboard';
 
-import { type DashboardEditPaneLike } from '../../edit-pane/types';
+import { type DashboardSidebarLike } from '../../edit-pane/types';
 import { type PanelEditor } from '../../panel-edit/PanelEditor';
 import { type DashboardEditView } from '../../settings/utils';
 import { type DashboardControls } from '../DashboardControls';
@@ -63,7 +63,7 @@ export interface DashboardSceneState extends SceneObjectState {
   /** How many panels to show per row for search results */
   panelsPerRow?: number;
   /** options pane */
-  editPane: DashboardEditPaneLike;
+  editPane: DashboardSidebarLike;
   /** Manages dragging/dropping of layout items */
   layoutOrchestrator: DashboardLayoutOrchestrator;
   /** True while default variables from datasources are being loaded */

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.test.ts
@@ -47,7 +47,7 @@ import {
 import { GrafanaQueryType } from 'app/plugins/datasource/grafana/types';
 import { MIXED_DATASOURCE_NAME } from 'app/plugins/datasource/mixed/MixedDataSource';
 
-import { DashboardEditPane } from '../edit-pane/DashboardEditPane';
+import { DashboardSidebar } from '../edit-pane/DashboardSidebar';
 import { DashboardAnnotationsDataLayer } from '../scene/DashboardAnnotationsDataLayer';
 import { DashboardControls } from '../scene/DashboardControls';
 import { DashboardDataLayerSet } from '../scene/DashboardDataLayerSet';
@@ -288,7 +288,7 @@ describe('transformSceneToSaveModelSchemaV2', () => {
         }),
       }),
       meta: {},
-      editPane: new DashboardEditPane(),
+      editPane: new DashboardSidebar(),
       $behaviors: [
         new behaviors.CursorSync({
           sync: DashboardCursorSyncV1.Crosshair,

--- a/public/app/features/dashboard-scene/settings/links/LinkAddEditableElement.test.tsx
+++ b/public/app/features/dashboard-scene/settings/links/LinkAddEditableElement.test.tsx
@@ -81,50 +81,50 @@ describe('LinkAddEditableElement', () => {
 
     it('registers an undoable action on the edit pane', () => {
       const dashboard = buildDashboard();
-      const editPane = dashboard.state.editPane;
+      const sidebar = dashboard.state.editPane;
 
-      expect(editPane.state.undoStack).toHaveLength(0);
+      expect(sidebar.state.undoStack).toHaveLength(0);
 
       openAddLinkPane(dashboard);
 
-      expect(editPane.state.undoStack).toHaveLength(1);
+      expect(sidebar.state.undoStack).toHaveLength(1);
     });
 
     it('supports undo of the added link', () => {
       const dashboard = buildDashboard([createTestLink({ title: 'Existing' })]);
-      const editPane = dashboard.state.editPane;
+      const sidebar = dashboard.state.editPane;
 
       openAddLinkPane(dashboard);
       expect(dashboard.state.links).toHaveLength(2);
 
-      act(() => editPane.undoAction());
+      act(() => sidebar.undoAction());
       expect(dashboard.state.links).toHaveLength(1);
       expect(dashboard.state.links[0].title).toBe('Existing');
     });
 
     it('clears selection on undo after adding a link', () => {
       const dashboard = buildDashboard();
-      const editPane = dashboard.state.editPane;
+      const sidebar = dashboard.state.editPane;
 
       openAddLinkPane(dashboard);
-      expect(editPane.getSelectedObject()).toBeDefined();
+      expect(sidebar.getSelectedObject()).toBeDefined();
 
-      act(() => editPane.undoAction());
-      expect(editPane.getSelectedObject()).toBeUndefined();
+      act(() => sidebar.undoAction());
+      expect(sidebar.getSelectedObject()).toBeUndefined();
     });
 
     it('reselects the link on redo after undo', () => {
       const dashboard = buildDashboard();
-      const editPane = dashboard.state.editPane;
+      const sidebar = dashboard.state.editPane;
 
       openAddLinkPane(dashboard);
-      expect(editPane.getSelectedObject()).toBeDefined();
+      expect(sidebar.getSelectedObject()).toBeDefined();
 
-      act(() => editPane.undoAction());
-      expect(editPane.getSelectedObject()).toBeUndefined();
+      act(() => sidebar.undoAction());
+      expect(sidebar.getSelectedObject()).toBeUndefined();
 
-      act(() => editPane.redoAction());
-      expect(editPane.getSelectedObject()).toBeDefined();
+      act(() => sidebar.redoAction());
+      expect(sidebar.getSelectedObject()).toBeDefined();
       expect(dashboard.state.links).toHaveLength(1);
     });
   });
@@ -200,10 +200,10 @@ describe('LinkAddEditableElement', () => {
 
         element.onDelete();
 
-        const editPane = dashboard.state.editPane;
-        expect(editPane.state.undoStack).toHaveLength(1);
+        const sidebar = dashboard.state.editPane;
+        expect(sidebar.state.undoStack).toHaveLength(1);
 
-        act(() => editPane.undoAction());
+        act(() => sidebar.undoAction());
         expect(dashboard.state.links).toHaveLength(1);
       });
     });

--- a/public/app/features/dashboard-scene/settings/links/LinkAddEditableElement.tsx
+++ b/public/app/features/dashboard-scene/settings/links/LinkAddEditableElement.tsx
@@ -242,16 +242,16 @@ export class LinkEditEditableElement implements EditableDashboardElement {
 
   public onDelete(): void {
     const dashboard = this.linkEdit.state.dashboardRef.resolve();
-    const editPane = dashboard.state.editPane;
+    const sidebar = dashboard.state.editPane;
     const linkIndex = this.linkEdit.state.linkIndex;
     const currentLinks = dashboard.state.links ?? [];
 
     if (linkIndex < 0 || linkIndex >= currentLinks.length) {
-      editPane.selectObject(dashboard);
+      sidebar.selectObject(dashboard);
       return;
     }
 
     linkEditActions.removeLink({ dashboard, linkIndex });
-    editPane.selectObject(dashboard);
+    sidebar.selectObject(dashboard);
   }
 }

--- a/public/app/features/dashboard-scene/settings/links/LinkBasicOptions.test.tsx
+++ b/public/app/features/dashboard-scene/settings/links/LinkBasicOptions.test.tsx
@@ -90,7 +90,7 @@ describe('LinkBasicOptions', () => {
       it('supports undo/redo for title changes', async () => {
         const dashboard = buildDashboard([LINK_TYPE_LINK]);
         const linkEdit = createLinkEdit(dashboard);
-        const editPane = dashboard.state.editPane;
+        const sidebar = dashboard.state.editPane;
 
         render(<LinkTextInput linkEdit={linkEdit} prop="title" />);
 
@@ -102,15 +102,15 @@ describe('LinkBasicOptions', () => {
         fireEvent.blur(input);
 
         expect(input).toHaveValue('Changed');
-        expect(editPane.state.undoStack).toHaveLength(1);
+        expect(sidebar.state.undoStack).toHaveLength(1);
 
-        act(() => editPane.undoAction());
+        act(() => sidebar.undoAction());
 
         expect(input).toHaveValue('Test Link');
-        expect(editPane.state.undoStack).toHaveLength(0);
-        expect(editPane.state.redoStack).toHaveLength(1);
+        expect(sidebar.state.undoStack).toHaveLength(0);
+        expect(sidebar.state.redoStack).toHaveLength(1);
 
-        act(() => editPane.redoAction());
+        act(() => sidebar.redoAction());
 
         expect(input).toHaveValue('Changed');
       });

--- a/public/app/features/dashboard-scene/settings/variables/VariableEditableElement.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/VariableEditableElement.test.tsx
@@ -7,7 +7,7 @@ import { selectors } from '@grafana/e2e-selectors';
 import { CustomVariable, SceneTimeRange, SceneVariableSet } from '@grafana/scenes';
 import { Sidebar, useSidebar } from '@grafana/ui';
 
-import { DashboardEditPaneRenderer } from '../../edit-pane/DashboardEditPaneRenderer';
+import { DashboardSidebarRenderer } from '../../edit-pane/DashboardSidebarRenderer';
 import { DashboardScene } from '../../scene/DashboardScene';
 import { AutoGridLayoutManager } from '../../scene/layout-auto-grid/AutoGridLayoutManager';
 import { RowItem } from '../../scene/layout-rows/RowItem';
@@ -166,7 +166,7 @@ function WrapSidebar({ children }: { children: ReactNode }) {
 function renderVariableEditPane(dashboard: DashboardScene) {
   render(
     <WrapSidebar>
-      <DashboardEditPaneRenderer dashboard={dashboard} />
+      <DashboardSidebarRenderer dashboard={dashboard} />
     </WrapSidebar>
   );
 }

--- a/public/app/features/dashboard-scene/settings/variables/VariableTypeSelectionPane.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/VariableTypeSelectionPane.test.tsx
@@ -7,7 +7,7 @@ import { selectors } from '@grafana/e2e-selectors';
 import { CustomVariable, SceneGridLayout, SceneTimeRange, SceneVariableSet } from '@grafana/scenes';
 import { Sidebar, useSidebar } from '@grafana/ui';
 
-import { DashboardEditPaneRenderer } from '../../edit-pane/DashboardEditPaneRenderer';
+import { DashboardSidebarRenderer } from '../../edit-pane/DashboardSidebarRenderer';
 import { DashboardScene } from '../../scene/DashboardScene';
 import { DefaultGridLayoutManager } from '../../scene/layout-default/DefaultGridLayoutManager';
 import { RowItem } from '../../scene/layout-rows/RowItem';
@@ -178,7 +178,7 @@ function WrapSidebar({ children }: { children: ReactNode }) {
 function renderVariableEditPane(dashboard: DashboardScene) {
   render(
     <WrapSidebar>
-      <DashboardEditPaneRenderer dashboard={dashboard} />
+      <DashboardSidebarRenderer dashboard={dashboard} />
     </WrapSidebar>
   );
 }


### PR DESCRIPTION
**What is this feature?**

Pure rename refactor, part 1 of a 4-PR stack. Renames the `DashboardEditPane` scene object and its companion symbols to match what the component has become — the dashboard sidebar:

- `DashboardEditPane` → `DashboardSidebar`
- `DashboardEditPaneLike` → `DashboardSidebarLike`
- `DashboardEditPaneState` → `DashboardSidebarState`
- `DashboardEditPaneRenderer` → `DashboardSidebarRenderer`
- `DashboardEditPaneSplitter` → `DashboardSidebarSplitter`

Files are renamed accordingly (via `git mv`, history preserved). No behavior change.

The e2e selector key `selectors.components.DashboardEditPaneSplitter` is intentionally left unchanged — selector keys are a public API that external plugin e2e tests depend on.

**Stack:**

1. 👉 This PR — rename `DashboardEditPane*` symbols and files
2. Rename `editPane` state key to `sidebar`
3. Rename `edit-pane` folder to `sidebar`
4. Rename `dashboard.edit-pane.*` i18n keys and fix translations

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Mechanical rename; verified with typecheck, lint, and the dashboard-scene jest suites.

Made with [Cursor](https://cursor.com)