### PR TITLE
Dashboards: Rename editPane state key to sidebar

### DIFF
--- a/public/app/features/dashboard-scene/addToDashboard/addPanelsOnLoadBehavior.test.ts
+++ b/public/app/features/dashboard-scene/addToDashboard/addPanelsOnLoadBehavior.test.ts
@@ -47,7 +47,7 @@ describe('addPanelsOnLoadBehavior', () => {
   describe('when there is no data in localStorage', () => {
     it('does not call scene.addPanel and does not throw', () => {
       const scene = buildTestScene();
-      scene.state.editPane.activate();
+      scene.state.sidebar.activate();
       const addPanelSpy = jest.spyOn(scene, 'addPanel');
 
       addPanelsOnLoadBehavior(scene);
@@ -61,7 +61,7 @@ describe('addPanelsOnLoadBehavior', () => {
     it('always clears the LS key', () => {
       store.setObject(DASHBOARD_FROM_LS_KEY, buildTestDTO());
       const scene = buildTestScene();
-      scene.state.editPane.activate();
+      scene.state.sidebar.activate();
 
       addPanelsOnLoadBehavior(scene);
       expect(store.exists(DASHBOARD_FROM_LS_KEY)).toBe(false);
@@ -70,7 +70,7 @@ describe('addPanelsOnLoadBehavior', () => {
     it('adds each panel to the scene via scene.addPanel', () => {
       store.setObject(DASHBOARD_FROM_LS_KEY, buildTestDTO());
       const scene = buildTestScene();
-      scene.state.editPane.activate();
+      scene.state.sidebar.activate();
       const addPanelSpy = jest.spyOn(scene, 'addPanel');
 
       addPanelsOnLoadBehavior(scene);
@@ -90,7 +90,7 @@ describe('addPanelsOnLoadBehavior', () => {
         })
       );
       const scene = buildTestScene();
-      scene.state.editPane.activate();
+      scene.state.sidebar.activate();
       const addPanelSpy = jest.spyOn(scene, 'addPanel');
 
       addPanelsOnLoadBehavior(scene);
@@ -108,7 +108,7 @@ describe('addPanelsOnLoadBehavior', () => {
 
     expect(addPanelSpy).not.toHaveBeenCalled();
 
-    scene.state.editPane.activate();
+    scene.state.sidebar.activate();
 
     expect(addPanelSpy).toHaveBeenCalledTimes(1);
     expect(addPanelSpy).toHaveBeenCalledWith(expect.any(VizPanel));
@@ -119,7 +119,7 @@ describe('addPanelsOnLoadBehavior', () => {
       const dto = buildTestDTO({ time: { from: 'now-6h', to: 'now' } });
       store.setObject(DASHBOARD_FROM_LS_KEY, dto);
       const scene = buildTestScene();
-      scene.state.editPane.activate();
+      scene.state.sidebar.activate();
 
       addPanelsOnLoadBehavior(scene);
 
@@ -130,7 +130,7 @@ describe('addPanelsOnLoadBehavior', () => {
     it('does not modify the scene time range when the DTO has no time', () => {
       store.setObject(DASHBOARD_FROM_LS_KEY, buildTestDTO());
       const scene = buildTestScene();
-      scene.state.editPane.activate();
+      scene.state.sidebar.activate();
       const originalFrom = scene.state.$timeRange?.state.from;
       const originalTo = scene.state.$timeRange?.state.to;
 

--- a/public/app/features/dashboard-scene/addToDashboard/addPanelsOnLoadBehavior.ts
+++ b/public/app/features/dashboard-scene/addToDashboard/addPanelsOnLoadBehavior.ts
@@ -43,10 +43,10 @@ export function addPanelsOnLoadBehavior(scene: DashboardScene) {
     return;
   }
 
-  if (scene.state.editPane.isActive) {
+  if (scene.state.sidebar.isActive) {
     addPanels();
   } else {
-    scene.state.editPane.addActivationHandler(() => {
+    scene.state.sidebar.addActivationHandler(() => {
       addPanels();
     });
   }

--- a/public/app/features/dashboard-scene/edit-pane/DashboardSidebar.test.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardSidebar.test.tsx
@@ -48,13 +48,13 @@ describe('DashboardSidebar', () => {
   describe('Selection', () => {
     it('Can select dashboard', () => {
       const scene = buildTestScene();
-      scene.state.editPane.state.selectionContext.onSelect({ id: scene.state.key! }, {});
-      expect(scene.state.editPane.getSelectedObject()).toBe(scene);
+      scene.state.sidebar.state.selectionContext.onSelect({ id: scene.state.key! }, {});
+      expect(scene.state.sidebar.getSelectedObject()).toBe(scene);
     });
 
     it('single panel and multi panel selection', () => {
       const scene = buildTestScene();
-      const sidebar = scene.state.editPane;
+      const sidebar = scene.state.sidebar;
       const panel1 = scene.onCreateNewPanel();
 
       expect(sidebar.getSelectedObject()).toBe(panel1);
@@ -78,7 +78,7 @@ describe('DashboardSidebar', () => {
 
     it('Clear selection should select dashboard when docked', () => {
       const scene = buildTestScene();
-      const sidebar = scene.state.editPane;
+      const sidebar = scene.state.sidebar;
 
       const panel = scene.onCreateNewPanel();
       sidebar.clearSelection();
@@ -94,7 +94,7 @@ describe('DashboardSidebar', () => {
 
     it('Force selecting should keep selecting if already selected', () => {
       const scene = buildTestScene();
-      const sidebar = scene.state.editPane;
+      const sidebar = scene.state.sidebar;
 
       // This selects panel
       const panel = scene.onCreateNewPanel();
@@ -114,7 +114,7 @@ describe('DashboardSidebar', () => {
 
     it('Selecting when none element pane is open should not toggle selection', () => {
       const scene = buildTestScene();
-      const sidebar = scene.state.editPane;
+      const sidebar = scene.state.sidebar;
 
       const panel = scene.onCreateNewPanel();
 
@@ -148,7 +148,7 @@ describe('DashboardSidebar', () => {
 
     it('Removing a panel that is not selected', () => {
       const scene = buildTestScene();
-      const sidebar = scene.state.editPane;
+      const sidebar = scene.state.sidebar;
 
       const panel1 = scene.onCreateNewPanel();
       const panel2 = scene.onCreateNewPanel();
@@ -168,7 +168,7 @@ describe('DashboardSidebar', () => {
 
   it('Handles edit action events that adds objects', () => {
     const scene = buildTestScene();
-    const sidebar = scene.state.editPane;
+    const sidebar = scene.state.sidebar;
 
     scene.onCreateNewPanel();
 
@@ -187,7 +187,7 @@ describe('DashboardSidebar', () => {
 
   it('when new action comes in clears redo stack', () => {
     const scene = buildTestScene();
-    const sidebar = scene.state.editPane;
+    const sidebar = scene.state.sidebar;
 
     scene.onCreateNewPanel();
 
@@ -202,7 +202,7 @@ describe('DashboardSidebar', () => {
 
   it('clone should not include undo/redo history', () => {
     const scene = buildTestScene();
-    const sidebar = scene.state.editPane;
+    const sidebar = scene.state.sidebar;
 
     scene.onCreateNewPanel();
     scene.onCreateNewPanel();
@@ -220,7 +220,7 @@ describe('DashboardSidebar', () => {
 
   it('clone should preserve the outline collapsed state', () => {
     const scene = buildTestScene();
-    const sidebar = scene.state.editPane;
+    const sidebar = scene.state.sidebar;
     const outlinePane = sidebar.state.outlinePane!;
 
     outlinePane.setNodeCollapsed('some-key', false);
@@ -254,7 +254,7 @@ describe('DashboardSidebar', () => {
 
     activateFullSceneTree(dashboard);
 
-    const sidebar = dashboard.state.editPane;
+    const sidebar = dashboard.state.sidebar;
     sidebar.selectObject(variable, { force: true });
 
     const changedVariable = new ConstantVariable({ name: 'service' });
@@ -304,7 +304,7 @@ describe('DashboardSidebar', () => {
     expect(local.state.name).toBe('env');
     expect(variableSet.state.variables).toEqual([local]);
 
-    dashboard.state.editPane.undoAction();
+    dashboard.state.sidebar.undoAction();
 
     expect(local.state.name).toBe('localVar');
     expect(variableSet.state.variables).toEqual([predefined, local]);
@@ -667,7 +667,7 @@ function buildTestSceneWithRepeat(layoutManager: DashboardLayoutManager) {
 
   return {
     variables,
-    sidebar: scene.state.editPane,
+    sidebar: scene.state.sidebar,
     scene,
   };
 }
@@ -683,7 +683,7 @@ function setupEmptyDashboard(): {
   });
   config.featureToggles.dashboardNewLayouts = true;
   activateFullSceneTree(dashboard);
-  return { dashboard, sidebar: dashboard.state.editPane };
+  return { dashboard, sidebar: dashboard.state.sidebar };
 }
 
 function setupWithTwoTabs(): {
@@ -707,7 +707,7 @@ function setupWithTwoTabs(): {
   });
   config.featureToggles.dashboardNewLayouts = true;
   activateFullSceneTree(dashboard);
-  return { dashboard, tab1, tab2, tab1Viz: panel, sidebar: dashboard.state.editPane };
+  return { dashboard, tab1, tab2, tab1Viz: panel, sidebar: dashboard.state.sidebar };
 }
 
 function setupWithTwoRows(): {
@@ -731,5 +731,5 @@ function setupWithTwoRows(): {
   });
   config.featureToggles.dashboardNewLayouts = true;
   activateFullSceneTree(dashboard);
-  return { dashboard, row1, row2, row1Viz: panel, sidebar: dashboard.state.editPane };
+  return { dashboard, row1, row2, row1Viz: panel, sidebar: dashboard.state.sidebar };
 }

--- a/public/app/features/dashboard-scene/edit-pane/DashboardSidebarRenderer.test.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardSidebarRenderer.test.tsx
@@ -109,12 +109,12 @@ describe('DashboardSidebarRenderer', () => {
     expect(await screen.findByTestId(selectors.components.Sidebar.dockToggle)).toBeInTheDocument();
 
     // With defaultToDocked: true when editing, sidebar starts docked
-    expect(scene.state.editPane.state.isDocked).toBe(true);
+    expect(scene.state.sidebar.state.isDocked).toBe(true);
 
     // Clicking dock toggle should undock the sidebar
     act(() => screen.getByTestId(selectors.components.Sidebar.dockToggle).click());
 
-    expect(scene.state.editPane.state.isDocked).toBe(false);
+    expect(scene.state.sidebar.state.isDocked).toBe(false);
   });
 
   describe('outline interactions tracking', () => {
@@ -162,13 +162,13 @@ describe('DashboardSidebarRenderer', () => {
 
       // Open the outline pane first
       await user.click(screen.getByTestId(selectors.pages.Dashboard.Sidebar.outlineButton));
-      expect(scene.state.editPane.state.openPane).toBeDefined();
+      expect(scene.state.sidebar.state.openPane).toBeDefined();
 
       // Click hide
       await user.click(screen.getByTestId(selectors.components.Sidebar.showHideToggle));
 
       // Pane should be cleared
-      expect(scene.state.editPane.state.openPane).toBeUndefined();
+      expect(scene.state.sidebar.state.openPane).toBeUndefined();
       // The sidebar container should no longer be rendered (only the show toggle remains)
       expect(screen.queryByTestId(selectors.components.Sidebar.container)).not.toBeInTheDocument();
     });
@@ -186,14 +186,14 @@ describe('DashboardSidebarRenderer', () => {
 
       // Select the panel programmatically (clicking a panel in real UX)
       const panel = scene.state.body.getVizPanels()[0];
-      act(() => scene.state.editPane.selectObject(panel));
+      act(() => scene.state.sidebar.selectObject(panel));
 
       // Sidebar pops up — effective isDocked is false during temp-show
       expect(screen.getByTestId(selectors.components.Sidebar.container)).toBeInTheDocument();
-      expect(scene.state.editPane.state.isDocked).toBe(false);
+      expect(scene.state.sidebar.state.isDocked).toBe(false);
 
       // De-selecting closes the pane and re-hides the sidebar
-      act(() => scene.state.editPane.clearSelection(true));
+      act(() => scene.state.sidebar.clearSelection(true));
 
       expect(screen.queryByTestId(selectors.components.Sidebar.container)).not.toBeInTheDocument();
     });

--- a/public/app/features/dashboard-scene/edit-pane/DashboardSidebarRenderer.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardSidebarRenderer.tsx
@@ -30,10 +30,10 @@ export interface Props {
 }
 
 /**
- * Making the EditPane rendering completely standalone (not using editPane.Component) in order to pass custom react props
+ * Making the Sidebar rendering completely standalone (not using editPane.Component) in order to pass custom react props
  */
 export function DashboardSidebarRenderer({ dashboard }: Props) {
-  const sidebar = dashboard.state.editPane;
+  const sidebar = dashboard.state.sidebar;
   const { openPane, selectionContext, outlinePane } = useSceneObjectState(sidebar, {
     shouldActivateOrKeepAlive: true,
   });
@@ -214,7 +214,7 @@ function renderEnterpriseItems() {
 }
 
 function UndoButton({ dashboard }: ToolbarActionProps) {
-  const sidebar = dashboard.state.editPane;
+  const sidebar = dashboard.state.sidebar;
   const { undoStack } = sidebar.useState();
   const undoAction = undoStack[undoStack.length - 1];
   const undoWord = t('dashboard.sidebar.undo', 'Undo');
@@ -232,7 +232,7 @@ function UndoButton({ dashboard }: ToolbarActionProps) {
 }
 
 function RedoButton({ dashboard }: ToolbarActionProps) {
-  const sidebar = dashboard.state.editPane;
+  const sidebar = dashboard.state.sidebar;
   const { redoStack } = sidebar.useState();
   const redoAction = redoStack[redoStack.length - 1];
   const redoWord = t('dashboard.sidebar.redo', 'Redo');

--- a/public/app/features/dashboard-scene/edit-pane/DashboardSidebarSplitter.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardSidebarSplitter.tsx
@@ -61,7 +61,7 @@ function DashboardSidebarSplitterLegacy({ dashboard, body, controls }: Props) {
 }
 
 function DashboardSidebarSplitterNewLayouts({ dashboard, isEditing, body, controls }: Props) {
-  const { editPane } = dashboard.state;
+  const { sidebar } = dashboard.state;
   const styles = useStyles2(getStyles);
   const { chrome } = useGrafana();
   const { kioskMode } = chrome.useState();
@@ -72,18 +72,18 @@ function DashboardSidebarSplitterNewLayouts({ dashboard, isEditing, body, contro
    */
   useUpdateAppChromeActions(dashboard);
 
-  const { selectionContext, openPane, previousState } = useSceneObjectState(editPane, {
+  const { selectionContext, openPane, previousState } = useSceneObjectState(sidebar, {
     shouldActivateOrKeepAlive: true,
   });
 
   // Selection is only needed in edit mode.
   useEffect(() => {
     if (isEditing) {
-      editPane.enableSelection();
+      sidebar.enableSelection();
     } else {
-      editPane.disableSelection();
+      sidebar.disableSelection();
     }
-  }, [isEditing, editPane]);
+  }, [isEditing, sidebar]);
 
   const theme = useTheme2();
   const isMobile = useMedia(`(max-width: ${theme.breakpoints.values.sm}px)`);
@@ -94,8 +94,8 @@ function DashboardSidebarSplitterNewLayouts({ dashboard, isEditing, body, contro
     persistenceKey: isEditing ? 'dashboard' : 'dashboard-view',
     hiddenPersistenceKey: 'dashboard',
     defaultToDocked: isEditing ? true : false,
-    onClosePane: () => editPane.closePane(),
-    onGoBack: () => editPane.goBackToPrevious(),
+    onClosePane: () => sidebar.closePane(),
+    onGoBack: () => sidebar.goBackToPrevious(),
     canGoBack: previousState !== undefined,
     defaultIsHidden: isEditing ? false : isMobile,
   });
@@ -106,15 +106,15 @@ function DashboardSidebarSplitterNewLayouts({ dashboard, isEditing, body, contro
    * Sync docked state to sidebar state
    */
   useEffect(() => {
-    editPane.setState({ isDocked: sidebarContext.isDocked });
-  }, [sidebarContext.isDocked, editPane]);
+    sidebar.setState({ isDocked: sidebarContext.isDocked });
+  }, [sidebarContext.isDocked, sidebar]);
 
   const onClearSelection: React.PointerEventHandler<HTMLDivElement> = (evt) => {
     if (evt.shiftKey) {
       return;
     }
 
-    editPane.clearSelection();
+    sidebar.clearSelection();
   };
 
   const onBodyRef = (ref: HTMLDivElement | null) => {

--- a/public/app/features/dashboard-scene/edit-pane/add-new/AddFilters.test.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/add-new/AddFilters.test.tsx
@@ -24,7 +24,7 @@ describe('openAddFilterForm', () => {
   it('adds an adhoc filter to the dashboard variable set', () => {
     const variableSet = new SceneVariableSet({ variables: [] });
     const dashboard = new DashboardScene({ $variables: variableSet, isEditing: true });
-    jest.spyOn(dashboard.state.editPane, 'selectObject');
+    jest.spyOn(dashboard.state.sidebar, 'selectObject');
 
     openAddFilterForm(dashboard, dashboard);
 
@@ -32,7 +32,7 @@ describe('openAddFilterForm', () => {
     const { source, addedObject } = addVariableMock.mock.calls[0][0];
     expect(source).toBe(variableSet);
     expect(addedObject).toBeInstanceOf(AdHocFiltersVariable);
-    expect(dashboard.state.editPane.selectObject).toHaveBeenCalledWith(addedObject, { force: true, multi: false });
+    expect(dashboard.state.sidebar.selectObject).toHaveBeenCalledWith(addedObject, { force: true, multi: false });
   });
 
   it('adds an adhoc filter to a section variable set', () => {
@@ -45,7 +45,7 @@ describe('openAddFilterForm', () => {
       body: new RowsLayoutManager({ rows: [row] }),
       isEditing: true,
     });
-    jest.spyOn(dashboard.state.editPane, 'selectObject');
+    jest.spyOn(dashboard.state.sidebar, 'selectObject');
 
     openAddFilterForm(dashboard, row);
 
@@ -53,7 +53,7 @@ describe('openAddFilterForm', () => {
     const { source, addedObject } = addVariableMock.mock.calls[0][0];
     expect(source).toBe(sectionVarSet);
     expect(addedObject).toBeInstanceOf(AdHocFiltersVariable);
-    expect(dashboard.state.editPane.selectObject).toHaveBeenCalledWith(addedObject, { force: true, multi: false });
+    expect(dashboard.state.sidebar.selectObject).toHaveBeenCalledWith(addedObject, { force: true, multi: false });
   });
 
   it('creates a variable set on the section if none exists', () => {
@@ -62,7 +62,7 @@ describe('openAddFilterForm', () => {
       body: new RowsLayoutManager({ rows: [row] }),
       isEditing: true,
     });
-    jest.spyOn(dashboard.state.editPane, 'selectObject');
+    jest.spyOn(dashboard.state.sidebar, 'selectObject');
 
     expect(row.state.$variables).toBeUndefined();
 
@@ -86,7 +86,7 @@ describe('openAddFilterForm', () => {
       body: new RowsLayoutManager({ rows: [row] }),
       isEditing: true,
     });
-    jest.spyOn(dashboard.state.editPane, 'selectObject');
+    jest.spyOn(dashboard.state.sidebar, 'selectObject');
 
     openAddFilterForm(dashboard, row);
 

--- a/public/app/features/dashboard-scene/edit-pane/add-new/AddFilters.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/add-new/AddFilters.tsx
@@ -25,7 +25,7 @@ export function openAddFilterForm(dashboard: DashboardSceneLike, sectionOwner: S
   });
 
   dashboardEditActions.addVariable({ source: variablesSet, addedObject: newVar });
-  dashboard.state.editPane.selectObject(newVar, { force: true, multi: false });
+  dashboard.state.sidebar.selectObject(newVar, { force: true, multi: false });
 }
 
 export function AddFilters({ dashboardScene }: { dashboardScene: DashboardSceneLike }) {

--- a/public/app/features/dashboard-scene/edit-pane/dashboard/DashboardAnnotationsList.test.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/dashboard/DashboardAnnotationsList.test.tsx
@@ -36,7 +36,7 @@ async function renderAnnotationsList(annotationLayers: DashboardAnnotationsDataL
   const dashboardScene = new DashboardScene({ $data: dataLayerSet });
 
   activateFullSceneTree(dashboardScene);
-  jest.spyOn(dashboardScene.state.editPane, 'selectObject');
+  jest.spyOn(dashboardScene.state.sidebar, 'selectObject');
 
   let renderResult!: ReturnType<typeof render>;
 
@@ -188,7 +188,7 @@ describe('User interactions', () => {
 
       await user.click(getByText(visibleEnabled.state.name));
 
-      expect(elements.dashboardScene.state.editPane.selectObject).toHaveBeenCalledWith(visibleEnabled);
+      expect(elements.dashboardScene.state.sidebar.selectObject).toHaveBeenCalledWith(visibleEnabled);
     });
   });
 

--- a/public/app/features/dashboard-scene/edit-pane/dashboard/DashboardAnnotationsList.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/dashboard/DashboardAnnotationsList.tsx
@@ -35,8 +35,8 @@ export function DashboardAnnotationsList({ dataLayerSet }: { dataLayerSet: Dashb
   );
 
   const onClickAnnotation = useCallback((a: DashboardAnnotationsDataLayer) => {
-    const { editPane } = getDashboardSceneFor(a).state;
-    editPane.selectObject(a);
+    const { sidebar } = getDashboardSceneFor(a).state;
+    sidebar.selectObject(a);
   }, []);
 
   const onDragEnd = useCallback(

--- a/public/app/features/dashboard-scene/edit-pane/dashboard/DashboardBasicOptions.test.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/dashboard/DashboardBasicOptions.test.tsx
@@ -50,7 +50,7 @@ async function testDashboardEditableElement(dashboard: DashboardScene, inputElem
     fireEvent.blur(inputElement);
   };
 
-  const sidebar = dashboard.state.editPane;
+  const sidebar = dashboard.state.sidebar;
   expect(sidebar.state.undoStack).toHaveLength(0);
   expect(sidebar.state.redoStack).toHaveLength(0);
   expect(inputElement).toHaveValue('initial');

--- a/public/app/features/dashboard-scene/edit-pane/dashboard/DashboardFiltersList.test.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/dashboard/DashboardFiltersList.test.tsx
@@ -36,7 +36,7 @@ function renderFiltersList(variables: SceneVariable[] = []) {
     isEditing: true,
   });
   activateFullSceneTree(dashboardScene);
-  jest.spyOn(dashboardScene.state.editPane, 'selectObject');
+  jest.spyOn(dashboardScene.state.sidebar, 'selectObject');
 
   const renderResult = render(<DashboardFiltersList variableSet={variableSet} />);
 
@@ -102,7 +102,7 @@ describe('<DashboardFiltersList />', () => {
 
         await user.click(getByText(visibleFilter1.state.name));
 
-        expect(elements.dashboardScene.state.editPane.selectObject).toHaveBeenCalledWith(visibleFilter1);
+        expect(elements.dashboardScene.state.sidebar.selectObject).toHaveBeenCalledWith(visibleFilter1);
       });
     });
 

--- a/public/app/features/dashboard-scene/edit-pane/dashboard/DashboardFiltersList.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/dashboard/DashboardFiltersList.tsx
@@ -31,8 +31,8 @@ export function DashboardFiltersList({ variableSet }: { variableSet: SceneVariab
   const { visible, controlsMenu, hidden } = useMemo(() => partitionVariablesByDisplay(filters), [filters]);
 
   const onClickFilter = useCallback((variable: SceneVariable) => {
-    const { editPane } = getDashboardSceneFor(variable).state;
-    editPane.selectObject(variable);
+    const { sidebar } = getDashboardSceneFor(variable).state;
+    sidebar.selectObject(variable);
   }, []);
 
   const onDragEnd = useMemo(

--- a/public/app/features/dashboard-scene/edit-pane/dashboard/DashboardLinksList.test.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/dashboard/DashboardLinksList.test.tsx
@@ -37,7 +37,7 @@ function renderLinksList(links: DashboardLink[] = []) {
     isEditing: true,
   });
   activateFullSceneTree(dashboardScene);
-  jest.spyOn(dashboardScene.state.editPane, 'selectObject');
+  jest.spyOn(dashboardScene.state.sidebar, 'selectObject');
 
   const renderResult = render(<DashboardLinksList dashboard={dashboardScene} />);
 

--- a/public/app/features/dashboard-scene/edit-pane/dashboard/DashboardVariablesList.test.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/dashboard/DashboardVariablesList.test.tsx
@@ -52,7 +52,7 @@ function renderVariablesList(
     isEditing: true,
   });
   activateFullSceneTree(dashboardScene);
-  jest.spyOn(dashboardScene.state.editPane, 'selectObject');
+  jest.spyOn(dashboardScene.state.sidebar, 'selectObject');
 
   const renderResult = render(
     <DashboardVariablesList
@@ -133,7 +133,7 @@ describe('<DashboardVariablesList />', () => {
 
         await user.click(getByText(visibleVar1.state.name));
 
-        expect(elements.dashboardScene.state.editPane.selectObject).toHaveBeenCalledWith(visibleVar1);
+        expect(elements.dashboardScene.state.sidebar.selectObject).toHaveBeenCalledWith(visibleVar1);
       });
     });
 

--- a/public/app/features/dashboard-scene/edit-pane/dashboard/DashboardVariablesList.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/dashboard/DashboardVariablesList.tsx
@@ -58,8 +58,8 @@ export function DashboardVariablesList({
   const { visible, controlsMenu, hidden } = useMemo(() => partitionVariablesByDisplay(editable), [editable]);
 
   const onClickVariable = useCallback((variable: SceneVariable) => {
-    const { editPane } = getDashboardSceneFor(variable).state;
-    editPane.selectObject(variable);
+    const { sidebar } = getDashboardSceneFor(variable).state;
+    sidebar.selectObject(variable);
   }, []);
 
   const onDragEnd = useMemo(

--- a/public/app/features/dashboard-scene/edit-pane/outline/DashboardOutline.test.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/outline/DashboardOutline.test.tsx
@@ -107,7 +107,7 @@ describe('DashboardOutline', () => {
     it('should retain expanded/collapsed state when the pane is closed and reopened', async () => {
       const user = userEvent.setup();
       const scene = buildTestScene();
-      const sidebar = scene.state.editPane;
+      const sidebar = scene.state.sidebar;
       const outlinePane = sidebar.state.outlinePane!;
 
       scene.onEnterEditMode();
@@ -156,7 +156,7 @@ describe('DashboardOutline', () => {
     it('should preserve collapsed state after entering and exiting edit mode', async () => {
       const user = userEvent.setup();
       const scene = buildTestScene();
-      const sidebar = scene.state.editPane;
+      const sidebar = scene.state.sidebar;
       const outlinePane = sidebar.state.outlinePane!;
 
       sidebar.enableSelection();
@@ -178,12 +178,12 @@ describe('DashboardOutline', () => {
       scene.onEnterEditMode();
       scene.exitEditMode({ skipConfirm: true });
 
-      const newOutlinePane = scene.state.editPane.state.outlinePane!;
-      scene.state.editPane.enableSelection();
-      scene.state.editPane.openPane(newOutlinePane);
+      const newOutlinePane = scene.state.sidebar.state.outlinePane!;
+      scene.state.sidebar.enableSelection();
+      scene.state.sidebar.openPane(newOutlinePane);
 
       render(
-        <ElementSelectionContext.Provider value={scene.state.editPane.state.selectionContext}>
+        <ElementSelectionContext.Provider value={scene.state.sidebar.state.selectionContext}>
           <WrapSidebar>
             <newOutlinePane.Component model={newOutlinePane} />
           </WrapSidebar>
@@ -202,11 +202,11 @@ describe('DashboardOutline', () => {
 
       // enable selection on the edit pane to activate real selection behavior
       scene.onEnterEditMode();
-      scene.state.editPane.enableSelection();
-      scene.state.editPane.openPane(pane);
+      scene.state.sidebar.enableSelection();
+      scene.state.sidebar.openPane(pane);
 
       render(
-        <ElementSelectionContext.Provider value={scene.state.editPane.state.selectionContext}>
+        <ElementSelectionContext.Provider value={scene.state.sidebar.state.selectionContext}>
           <WrapSidebar>
             <pane.Component model={pane} />
           </WrapSidebar>
@@ -248,11 +248,11 @@ describe('DashboardOutline', () => {
       const pane = new DashboardOutline({});
 
       // enable selection on the edit pane to activate real selection behavior
-      scene.state.editPane.enableSelection();
-      scene.state.editPane.openPane(pane);
+      scene.state.sidebar.enableSelection();
+      scene.state.sidebar.openPane(pane);
 
       render(
-        <ElementSelectionContext.Provider value={scene.state.editPane.state.selectionContext}>
+        <ElementSelectionContext.Provider value={scene.state.sidebar.state.selectionContext}>
           <WrapSidebar>
             <pane.Component model={pane} />
           </WrapSidebar>
@@ -275,11 +275,11 @@ describe('DashboardOutline', () => {
       const pane = new DashboardOutline({});
 
       scene.onEnterEditMode();
-      scene.state.editPane.enableSelection();
-      scene.state.editPane.openPane(pane);
+      scene.state.sidebar.enableSelection();
+      scene.state.sidebar.openPane(pane);
 
       render(
-        <ElementSelectionContext.Provider value={scene.state.editPane.state.selectionContext}>
+        <ElementSelectionContext.Provider value={scene.state.sidebar.state.selectionContext}>
           <WrapSidebar>
             <pane.Component model={pane} />
           </WrapSidebar>
@@ -314,11 +314,11 @@ describe('DashboardOutline', () => {
       const pane = new DashboardOutline({});
 
       scene.onEnterEditMode();
-      scene.state.editPane.enableSelection();
-      scene.state.editPane.openPane(pane);
+      scene.state.sidebar.enableSelection();
+      scene.state.sidebar.openPane(pane);
 
       render(
-        <ElementSelectionContext.Provider value={scene.state.editPane.state.selectionContext}>
+        <ElementSelectionContext.Provider value={scene.state.sidebar.state.selectionContext}>
           <WrapSidebar>
             <pane.Component model={pane} />
           </WrapSidebar>
@@ -343,11 +343,11 @@ describe('DashboardOutline', () => {
       const pane = new DashboardOutline({});
 
       scene.onEnterEditMode();
-      scene.state.editPane.enableSelection();
-      scene.state.editPane.openPane(pane);
+      scene.state.sidebar.enableSelection();
+      scene.state.sidebar.openPane(pane);
 
       render(
-        <ElementSelectionContext.Provider value={scene.state.editPane.state.selectionContext}>
+        <ElementSelectionContext.Provider value={scene.state.sidebar.state.selectionContext}>
           <WrapSidebar>
             <pane.Component model={pane} />
           </WrapSidebar>
@@ -374,7 +374,7 @@ describe('DashboardOutline', () => {
     it('retains search query when the pane is closed and reopened', async () => {
       const user = userEvent.setup();
       const scene = buildTestScene();
-      const sidebar = scene.state.editPane;
+      const sidebar = scene.state.sidebar;
       const outlinePane = sidebar.state.outlinePane!;
 
       scene.onEnterEditMode();
@@ -409,7 +409,7 @@ describe('DashboardOutline', () => {
     it('preserves search query after entering and exiting edit mode', async () => {
       const user = userEvent.setup();
       const scene = buildTestScene();
-      const sidebar = scene.state.editPane;
+      const sidebar = scene.state.sidebar;
       const outlinePane = sidebar.state.outlinePane!;
 
       sidebar.enableSelection();
@@ -432,12 +432,12 @@ describe('DashboardOutline', () => {
       scene.onEnterEditMode();
       scene.exitEditMode({ skipConfirm: true });
 
-      const newOutlinePane = scene.state.editPane.state.outlinePane!;
-      scene.state.editPane.enableSelection();
-      scene.state.editPane.openPane(newOutlinePane);
+      const newOutlinePane = scene.state.sidebar.state.outlinePane!;
+      scene.state.sidebar.enableSelection();
+      scene.state.sidebar.openPane(newOutlinePane);
 
       render(
-        <ElementSelectionContext.Provider value={scene.state.editPane.state.selectionContext}>
+        <ElementSelectionContext.Provider value={scene.state.sidebar.state.selectionContext}>
           <WrapSidebar>
             <newOutlinePane.Component model={newOutlinePane} />
           </WrapSidebar>

--- a/public/app/features/dashboard-scene/edit-pane/outline/DashboardOutlineRenderer.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/outline/DashboardOutlineRenderer.tsx
@@ -49,7 +49,7 @@ export function DashboardOutlineRenderer({ model }: SceneComponentProps<Dashboar
             <DashboardOutlineNode
               sceneObject={dashboard}
               isEditing={isEditing}
-              sidebar={dashboard.state.editPane}
+              sidebar={dashboard.state.sidebar}
               outline={model}
               depth={0}
               index={0}

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditor.test.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditor.test.ts
@@ -140,12 +140,12 @@ describe('PanelEditor', () => {
         }),
       });
 
-      dashboard.state.editPane.selectObject(panel, { force: true });
-      expect(dashboard.state.editPane.getSelectedObject()).toBe(panel);
+      dashboard.state.sidebar.selectObject(panel, { force: true });
+      expect(dashboard.state.sidebar.getSelectedObject()).toBe(panel);
 
       deactivate = activateFullSceneTree(dashboard);
 
-      expect(dashboard.state.editPane.getSelectedObject()).toBeUndefined();
+      expect(dashboard.state.sidebar.getSelectedObject()).toBeUndefined();
     });
   });
 

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditor.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditor.tsx
@@ -99,7 +99,7 @@ export class PanelEditor extends SceneObjectBase<PanelEditorState> {
 
     // Clear any panel selection when entering panel edit mode.
     // Need to clear selection here since selection is activated when panel edit mode is entered through the panel actions menu. This causes sidebar panel editor to be open when exiting panel edit mode
-    dashboard.state.editPane.clearSelection();
+    dashboard.state.sidebar.clearSelection();
 
     if (panel.state.pluginId === UNCONFIGURED_PANEL_PLUGIN_ID) {
       const isPaneCollapsed = sessionStorage.getItem(EDIT_PANE_COLLAPSED_KEY) === 'true';
@@ -165,7 +165,7 @@ export class PanelEditor extends SceneObjectBase<PanelEditorState> {
     // is not active while panel edit is active so we have to let the edit pane (which owns undo/redo)
     // publish this event when it activates
     const dashboard = getDashboardSceneFor(this);
-    dashboard.state.editPane.setPanelEditAction(editAction);
+    dashboard.state.sidebar.setPanelEditAction(editAction);
   }
 
   public waitForPlugin(retry = 0) {

--- a/public/app/features/dashboard-scene/scene/DashboardDataLayerControls.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardDataLayerControls.tsx
@@ -46,7 +46,7 @@ export function DataLayerControlEditWrapper({ layer, inMenu }: { layer: SceneDat
 
   const onClickEditLayer = useCallback(() => {
     const dashboard = sceneGraph.getAncestor(layer, DashboardScene);
-    dashboard.state.editPane.selectObject(layer);
+    dashboard.state.sidebar.selectObject(layer);
   }, [layer]);
 
   const onClickDeleteLayer = useCallback(() => {

--- a/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
@@ -270,7 +270,7 @@ describe('DashboardScene', () => {
       });
 
       it('activateEditPane activates an inactive edit pane and releases it on exit', () => {
-        const sidebar = scene.state.editPane;
+        const sidebar = scene.state.sidebar;
         expect(sidebar.isActive).toBe(false);
 
         scene.activateEditPane();
@@ -281,7 +281,7 @@ describe('DashboardScene', () => {
       });
 
       it('activateEditPane is a no-op when the edit pane is already active', () => {
-        const sidebar = scene.state.editPane;
+        const sidebar = scene.state.sidebar;
         const activateSpy = jest.spyOn(sidebar, 'activate');
         sidebar.activate();
 
@@ -291,7 +291,7 @@ describe('DashboardScene', () => {
       });
 
       it('re-activates the swapped-in edit pane when discarding and keeping edit', () => {
-        const sidebar = scene.state.editPane;
+        const sidebar = scene.state.sidebar;
         scene.activateEditPane();
         expect(sidebar.isActive).toBe(true);
 
@@ -300,7 +300,7 @@ describe('DashboardScene', () => {
         // The original pane is released, but a fresh clone is swapped in and re-activated so
         // programmatic mutations keep working while we stay in edit mode.
         expect(sidebar.isActive).toBe(false);
-        const newEditPane = scene.state.editPane;
+        const newEditPane = scene.state.sidebar;
         expect(newEditPane).not.toBe(sidebar);
         expect(newEditPane.isActive).toBe(true);
       });
@@ -684,10 +684,10 @@ describe('DashboardScene', () => {
       });
 
       it('Should select new row', () => {
-        scene.state.editPane.activate();
+        scene.state.sidebar.activate();
 
         const row = scene.onCreateNewRow();
-        expect(scene.state.editPane.getSelectedObject()).toBe(row);
+        expect(scene.state.sidebar.getSelectedObject()).toBe(row);
       });
 
       it('Should fail to copy a panel if it does not have a grid item parent', () => {

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -209,7 +209,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
         state.body ?? state.preferences?.defaultLayoutTemplate?.clone() ?? DefaultGridLayoutManager.fromVizPanels([]),
       links: state.links ?? [],
       ...state,
-      editPane: new DashboardSidebar(),
+      sidebar: new DashboardSidebar(),
       layoutOrchestrator: new DashboardLayoutOrchestrator(),
       preferences: state.preferences ?? {},
     });
@@ -395,13 +395,13 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
    * reference-counted, so we retain the handler and release it on exit (see deactivateEditPane).
    */
   public activateEditPane() {
-    const { editPane } = this.state;
-    if (editPane.isActive) {
+    const { sidebar } = this.state;
+    if (sidebar.isActive) {
       return;
     }
     // Release the previous pane's activation before acquiring a new one.
     this.deactivateEditPane();
-    this._editPaneActivation = editPane.activate();
+    this._editPaneActivation = sidebar.activate();
   }
 
   private deactivateEditPane() {

--- a/public/app/features/dashboard-scene/scene/VariableControls.tsx
+++ b/public/app/features/dashboard-scene/scene/VariableControls.tsx
@@ -79,7 +79,7 @@ export function VariableValueSelectWrapper({ variable, inMenu, isEditingNewLayou
 
   const onClickEditVariable = useCallback(() => {
     const dashboard = sceneGraph.getAncestor(variable, DashboardScene);
-    dashboard.state.editPane.selectObject(variable);
+    dashboard.state.sidebar.selectObject(variable);
   }, [variable]);
 
   const onClickDeleteVariable = useCallback(() => {

--- a/public/app/features/dashboard-scene/scene/keyboardShortcuts.ts
+++ b/public/app/features/dashboard-scene/scene/keyboardShortcuts.ts
@@ -289,7 +289,7 @@ export function setupKeyboardShortcuts(scene: DashboardScene) {
       key: 'p v',
       onTrigger: () => {
         if (scene.state.isEditing && store.exists(LS_PANEL_COPY_KEY)) {
-          const sidebar = scene.state.editPane;
+          const sidebar = scene.state.sidebar;
           const selectedObj = sidebar.getSelectedObject();
           sidebar.pastePanel(selectedObj);
 

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManager.tsx
@@ -337,7 +337,7 @@ export class RowsLayoutManager
       return;
     }
 
-    const sidebar = getDashboardSceneFor(this).state.editPane;
+    const sidebar = getDashboardSceneFor(this).state.sidebar;
     sidebar.selectObject(row!, { force: true, multi: false });
   }
 

--- a/public/app/features/dashboard-scene/scene/types/dashboard.ts
+++ b/public/app/features/dashboard-scene/scene/types/dashboard.ts
@@ -63,7 +63,7 @@ export interface DashboardSceneState extends SceneObjectState {
   /** How many panels to show per row for search results */
   panelsPerRow?: number;
   /** options pane */
-  editPane: DashboardSidebarLike;
+  sidebar: DashboardSidebarLike;
   /** Manages dragging/dropping of layout items */
   layoutOrchestrator: DashboardLayoutOrchestrator;
   /** True while default variables from datasources are being loaded */

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.test.ts
@@ -288,7 +288,7 @@ describe('transformSceneToSaveModelSchemaV2', () => {
         }),
       }),
       meta: {},
-      editPane: new DashboardSidebar(),
+      sidebar: new DashboardSidebar(),
       $behaviors: [
         new behaviors.CursorSync({
           sync: DashboardCursorSyncV1.Crosshair,

--- a/public/app/features/dashboard-scene/settings/AnnotationsEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/AnnotationsEditView.tsx
@@ -159,7 +159,7 @@ function AnnotationsSettingsView({ model }: SceneComponentProps<AnnotationsEditV
   const goToSidebar = () => {
     // close settings and open dashboard sidebar
     const dashboard = getDashboardSceneFor(model);
-    dashboard.state.editPane.selectObject(dashboard);
+    dashboard.state.sidebar.selectObject(dashboard);
     locationService.partial({
       editview: null,
       [HIGHLIGHT_CATEGORY_PARAM_NAME]: 'dashboard-annotations',

--- a/public/app/features/dashboard-scene/settings/JsonModelEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/JsonModelEditView.tsx
@@ -161,7 +161,7 @@ function JsonModelEditViewComponent({ model }: SceneComponentProps<JsonModelEdit
   const goToSidebar = () => {
     // close settings and open the "Edit as code" sidebar pane
     const dashboard = getDashboardSceneFor(model);
-    dashboard.state.editPane.openPane(new DashboardCodePane({}));
+    dashboard.state.sidebar.openPane(new DashboardCodePane({}));
     locationService.partial({ editview: null });
 
     DashboardInteractions.takeMeToSidebarClicked({ item: 'json-model' });

--- a/public/app/features/dashboard-scene/settings/VariablesEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/VariablesEditView.tsx
@@ -264,7 +264,7 @@ function VariableEditorSettingsListView({ model }: SceneComponentProps<Variables
   const goToSidebar = () => {
     // close settings and open dashboard sidebar
     const dashboard = getDashboardSceneFor(model);
-    dashboard.state.editPane.selectObject(dashboard);
+    dashboard.state.sidebar.selectObject(dashboard);
     locationService.partial({
       editview: null,
       [HIGHLIGHT_CATEGORY_PARAM_NAME]: 'dashboard-variables',

--- a/public/app/features/dashboard-scene/settings/annotations/AnnotationList.tsx
+++ b/public/app/features/dashboard-scene/settings/annotations/AnnotationList.tsx
@@ -24,8 +24,8 @@ export function AnnotationList({ dataLayerSet }: { dataLayerSet: DashboardDataLa
 
   const onSelectAnnotation = useCallback(
     (layer: SceneDataLayerProvider) => {
-      const { editPane } = getDashboardSceneFor(dataLayerSet).state;
-      editPane.selectObject(layer);
+      const { sidebar } = getDashboardSceneFor(dataLayerSet).state;
+      sidebar.selectObject(layer);
     },
     [dataLayerSet]
   );

--- a/public/app/features/dashboard-scene/settings/links/LinkAddEditableElement.test.tsx
+++ b/public/app/features/dashboard-scene/settings/links/LinkAddEditableElement.test.tsx
@@ -81,7 +81,7 @@ describe('LinkAddEditableElement', () => {
 
     it('registers an undoable action on the edit pane', () => {
       const dashboard = buildDashboard();
-      const sidebar = dashboard.state.editPane;
+      const sidebar = dashboard.state.sidebar;
 
       expect(sidebar.state.undoStack).toHaveLength(0);
 
@@ -92,7 +92,7 @@ describe('LinkAddEditableElement', () => {
 
     it('supports undo of the added link', () => {
       const dashboard = buildDashboard([createTestLink({ title: 'Existing' })]);
-      const sidebar = dashboard.state.editPane;
+      const sidebar = dashboard.state.sidebar;
 
       openAddLinkPane(dashboard);
       expect(dashboard.state.links).toHaveLength(2);
@@ -104,7 +104,7 @@ describe('LinkAddEditableElement', () => {
 
     it('clears selection on undo after adding a link', () => {
       const dashboard = buildDashboard();
-      const sidebar = dashboard.state.editPane;
+      const sidebar = dashboard.state.sidebar;
 
       openAddLinkPane(dashboard);
       expect(sidebar.getSelectedObject()).toBeDefined();
@@ -115,7 +115,7 @@ describe('LinkAddEditableElement', () => {
 
     it('reselects the link on redo after undo', () => {
       const dashboard = buildDashboard();
-      const sidebar = dashboard.state.editPane;
+      const sidebar = dashboard.state.sidebar;
 
       openAddLinkPane(dashboard);
       expect(sidebar.getSelectedObject()).toBeDefined();
@@ -200,7 +200,7 @@ describe('LinkAddEditableElement', () => {
 
         element.onDelete();
 
-        const sidebar = dashboard.state.editPane;
+        const sidebar = dashboard.state.sidebar;
         expect(sidebar.state.undoStack).toHaveLength(1);
 
         act(() => sidebar.undoAction());

--- a/public/app/features/dashboard-scene/settings/links/LinkAddEditableElement.tsx
+++ b/public/app/features/dashboard-scene/settings/links/LinkAddEditableElement.tsx
@@ -50,7 +50,7 @@ export function linkSelectionId(linkIndex: number) {
 
 export function openLinkEditPane(dashboard: DashboardSceneLike, linkIndex: number) {
   const element = createLinkEdit(dashboard, linkIndex);
-  dashboard.state.editPane.selectObject(element, { force: true, multi: false });
+  dashboard.state.sidebar.selectObject(element, { force: true, multi: false });
 }
 
 export interface LinkEditState extends SceneObjectState {
@@ -242,7 +242,7 @@ export class LinkEditEditableElement implements EditableDashboardElement {
 
   public onDelete(): void {
     const dashboard = this.linkEdit.state.dashboardRef.resolve();
-    const sidebar = dashboard.state.editPane;
+    const sidebar = dashboard.state.sidebar;
     const linkIndex = this.linkEdit.state.linkIndex;
     const currentLinks = dashboard.state.links ?? [];
 

--- a/public/app/features/dashboard-scene/settings/links/LinkBasicOptions.test.tsx
+++ b/public/app/features/dashboard-scene/settings/links/LinkBasicOptions.test.tsx
@@ -90,7 +90,7 @@ describe('LinkBasicOptions', () => {
       it('supports undo/redo for title changes', async () => {
         const dashboard = buildDashboard([LINK_TYPE_LINK]);
         const linkEdit = createLinkEdit(dashboard);
-        const sidebar = dashboard.state.editPane;
+        const sidebar = dashboard.state.sidebar;
 
         render(<LinkTextInput linkEdit={linkEdit} prop="title" />);
 
@@ -157,7 +157,7 @@ describe('LinkBasicOptions', () => {
         fireEvent.blur(input);
 
         expect(dashboard.state.links[0].url).toBe('https://new-url.com');
-        expect(dashboard.state.editPane.state.undoStack).toHaveLength(1);
+        expect(dashboard.state.sidebar.state.undoStack).toHaveLength(1);
       });
     });
 

--- a/public/app/features/dashboard-scene/settings/variables/VariableEditableElement.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/VariableEditableElement.test.tsx
@@ -148,7 +148,7 @@ describe('VariableEditableElement', () => {
     renderVariableEditPane(dashboard);
 
     await user.click(screen.getByTestId(selectors.components.PanelEditor.ElementEditPane.changeVariableType));
-    expect(dashboard.state.editPane.state.openPane).toBeInstanceOf(VariableTypeChangePane);
+    expect(dashboard.state.sidebar.state.openPane).toBeInstanceOf(VariableTypeChangePane);
     expect(screen.getByText('Change variable type')).toBeInTheDocument();
   });
 });
@@ -188,7 +188,7 @@ function buildDashboardVariableScene() {
   });
 
   activateFullSceneTree(dashboard);
-  dashboard.state.editPane.selectObject(variable, { force: true });
+  dashboard.state.sidebar.selectObject(variable, { force: true });
 
   return { dashboard, variableSet };
 }

--- a/public/app/features/dashboard-scene/settings/variables/VariableSetEditableElement.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/VariableSetEditableElement.tsx
@@ -95,8 +95,8 @@ export function VariableList({ set }: { set: SceneVariableSet }) {
 
   const onEditVariable = useCallback(
     (variable: SceneVariable) => {
-      const { editPane } = getDashboardSceneFor(set).state;
-      editPane.selectObject(variable);
+      const { sidebar } = getDashboardSceneFor(set).state;
+      sidebar.selectObject(variable);
     },
     [set]
   );

--- a/public/app/features/dashboard-scene/settings/variables/VariableTypeSelectionPane.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/VariableTypeSelectionPane.test.tsx
@@ -71,7 +71,7 @@ describe('VariableAddPane', () => {
     const variableTypeSelectedSpy = jest.spyOn(DashboardInteractions, 'variableTypeSelected');
     const dashboard = buildTestScene();
     const pane = new VariableAddPane({ sectionOwner: dashboard.getRef() });
-    dashboard.state.editPane.openPane(pane);
+    dashboard.state.sidebar.openPane(pane);
 
     const { getByRole } = render(
       <WrapSidebar>
@@ -87,7 +87,7 @@ describe('VariableAddPane', () => {
   it('generates a non-conflicting name when an existing variable already exists', () => {
     const dashboard = buildTestSceneWithExistingVar('custom0');
     const pane = new VariableAddPane({ sectionOwner: dashboard.getRef() });
-    dashboard.state.editPane.openPane(pane);
+    dashboard.state.sidebar.openPane(pane);
 
     const { getByRole } = render(
       <WrapSidebar>
@@ -128,7 +128,7 @@ describe('VariableTypeChangePane', () => {
     expect(updatedVariable.state.type).toBe('constant');
     expect(updatedVariable.state.name).toBe('service');
     expect(updatedVariable.state.label).toBe('Service');
-    expect(dashboard.state.editPane.getSelectedObject()).toBe(updatedVariable);
+    expect(dashboard.state.sidebar.getSelectedObject()).toBe(updatedVariable);
     expect(screen.getByTestId(selectors.components.PanelEditor.ElementEditPane.variableNameInput)).toHaveValue(
       'service'
     );
@@ -145,7 +145,7 @@ describe('VariableTypeChangePane', () => {
     renderVariableEditPane(dashboard);
 
     await user.click(screen.getByTestId(selectors.components.PanelEditor.ElementEditPane.changeVariableType));
-    expect(dashboard.state.editPane.state.openPane).toBeInstanceOf(VariableTypeChangePane);
+    expect(dashboard.state.sidebar.state.openPane).toBeInstanceOf(VariableTypeChangePane);
 
     await user.click(
       within(screen.getByTestId(selectors.components.PanelEditor.ElementEditPane.variableType('textbox'))).getByRole(
@@ -161,7 +161,7 @@ describe('VariableTypeChangePane', () => {
     expect(updatedVariable.state.name).toBe('shared');
     expect(updatedVariable.state.label).toBe('Section variable');
     expect(dashboardVariable.state.name).toBe('shared');
-    expect(dashboard.state.editPane.getSelectedObject()).toBe(updatedVariable);
+    expect(dashboard.state.sidebar.getSelectedObject()).toBe(updatedVariable);
   });
 });
 
@@ -204,7 +204,7 @@ function buildDashboardVariableScene() {
   });
 
   activateFullSceneTree(dashboard);
-  dashboard.state.editPane.selectObject(variable, { force: true });
+  dashboard.state.sidebar.selectObject(variable, { force: true });
 
   return { dashboard, variableSet };
 }
@@ -234,7 +234,7 @@ function buildSectionVariableScene() {
   });
 
   activateFullSceneTree(dashboard);
-  dashboard.state.editPane.selectObject(sectionVariable, { force: true });
+  dashboard.state.sidebar.selectObject(sectionVariable, { force: true });
 
   return { dashboard, dashboardVariable, sectionVariableSet };
 }

--- a/public/app/features/dashboard-scene/settings/variables/VariableTypeSelectionPane.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/VariableTypeSelectionPane.tsx
@@ -30,11 +30,11 @@ import {
 } from './utils';
 
 export function openAddVariablePane(dashboard: DashboardSceneLike) {
-  dashboard.state.editPane.openPane(new VariableAddPane({ sectionOwner: dashboard.getRef() }));
+  dashboard.state.sidebar.openPane(new VariableAddPane({ sectionOwner: dashboard.getRef() }));
 }
 
 export function openAddSectionVariablePane(dashboard: DashboardSceneLike, sectionOwner: SceneObject) {
-  dashboard.state.editPane.openPane(new VariableAddPane({ sectionOwner: sectionOwner.getRef() }));
+  dashboard.state.sidebar.openPane(new VariableAddPane({ sectionOwner: sectionOwner.getRef() }));
 }
 
 export interface VariableAddPaneState extends SceneObjectState {
@@ -105,7 +105,7 @@ export class VariableTypeChangePane
 
 export function openChangeVariableTypePane(variable: SceneVariable) {
   const dashboard = getDashboardSceneLike(variable);
-  dashboard.state.editPane.openPane(new VariableTypeChangePane({ variableRef: variable.getRef() }));
+  dashboard.state.sidebar.openPane(new VariableTypeChangePane({ variableRef: variable.getRef() }));
 }
 
 function VariableTypeChangePaneRenderer({ model }: SceneComponentProps<VariableTypeChangePane>) {
@@ -121,7 +121,7 @@ function VariableTypeChangePaneRenderer({ model }: SceneComponentProps<VariableT
       }
 
       if (type === variable.state.type) {
-        dashboard.state.editPane.goBackToPrevious();
+        dashboard.state.sidebar.goBackToPrevious();
         return;
       }
 

--- a/public/app/features/dashboard-scene/solo/ViewPanelSidePane.tsx
+++ b/public/app/features/dashboard-scene/solo/ViewPanelSidePane.tsx
@@ -67,7 +67,7 @@ function ViewPanelSidePaneRenderer({ model }: SceneComponentProps<ViewPanelSideP
    */
   useEffect(() => {
     if (!viewPanel) {
-      dashboard.state.editPane.closePane();
+      dashboard.state.sidebar.closePane();
     }
   }, [viewPanel, dashboard]);
 

--- a/public/app/features/dashboard-scene/solo/ViewPanelWrapper.tsx
+++ b/public/app/features/dashboard-scene/solo/ViewPanelWrapper.tsx
@@ -24,7 +24,7 @@ export function ViewPanelWrapper({ panel, showControlsPane }: { panel: VizPanel;
 
 function ViewPanelWithPane({ panel, dataProvider }: { panel: VizPanel; dataProvider: SceneDataProvider }) {
   const dashboard = getDashboardSceneLike(panel);
-  const { editPane } = dashboard.useState();
+  const { sidebar } = dashboard.useState();
   const { data } = dataProvider.useState();
   const context = usePanelSceneContextObject(panel);
   const isSmallScreen = !useMediaQueryMinWidth('sm');
@@ -34,23 +34,23 @@ function ViewPanelWithPane({ panel, dataProvider }: { panel: VizPanel; dataProvi
   // Open pane on mount
   useEffect(() => {
     if (!isSmallScreen) {
-      editPane.openPane(viewPanelPane);
+      sidebar.openPane(viewPanelPane);
     }
-  }, [editPane, isSmallScreen, viewPanelPane]);
+  }, [sidebar, isSmallScreen, viewPanelPane]);
 
   // Handle manual toggling of the pane via the edit pane buttons
   // This is done via an event that sidebar pane button publishes as the ViewPanelSidePane instance & panel ref is only available from this component
   useEffect(() => {
-    const sub = editPane.subscribeToEvent(ToggleViewPanePaneEvent, () => {
-      if (editPane.state.openPane === viewPanelPane) {
-        editPane.closePane();
+    const sub = sidebar.subscribeToEvent(ToggleViewPanePaneEvent, () => {
+      if (sidebar.state.openPane === viewPanelPane) {
+        sidebar.closePane();
       } else {
-        editPane.openPane(viewPanelPane);
+        sidebar.openPane(viewPanelPane);
       }
     });
 
     return () => sub.unsubscribe();
-  }, [viewPanelPane, editPane]);
+  }, [viewPanelPane, sidebar]);
 
   if (!context || !data || !fanoutMode) {
     return <panel.Component model={panel} />;

--- a/public/app/features/dashboard-scene/utils/getVariablesCompatibility.test.ts
+++ b/public/app/features/dashboard-scene/utils/getVariablesCompatibility.test.ts
@@ -94,7 +94,7 @@ describe('getVariablesCompatibility', () => {
         body: new RowsLayoutManager({ rows: [row1, row2] }),
       });
 
-      dashboard.state.editPane.selectObject(sectionVar);
+      dashboard.state.sidebar.selectObject(sectionVar);
 
       const result = getVariablesCompatibility(dashboard);
       const names = result.map((v) => v.name);
@@ -139,7 +139,7 @@ describe('getVariablesCompatibility', () => {
         body: new RowsLayoutManager({ rows: [row] }),
       });
 
-      dashboard.state.editPane.selectObject(queryVar);
+      dashboard.state.sidebar.selectObject(queryVar);
 
       const result = getVariablesCompatibility(dashboard);
       const names = result.map((v) => v.name);

--- a/public/app/features/dashboard-scene/utils/getVariablesCompatibility.ts
+++ b/public/app/features/dashboard-scene/utils/getVariablesCompatibility.ts
@@ -18,7 +18,7 @@ export function getVariablesCompatibility(sceneObject: SceneObject): TypedVariab
   // scope to that object's ancestry so datasource pickers only show variables from
   // the same section + dashboard globals.
   if (sceneObject instanceof DashboardScene) {
-    const selectedObject = sceneObject.state.editPane.getSelectedObject();
+    const selectedObject = sceneObject.state.sidebar.getSelectedObject();
 
     if (selectedObject) {
       // @ts-expect-error

--- a/public/app/features/dashboard/dashgrid/DashboardEmpty/DashboardEmpty.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardEmpty/DashboardEmpty.tsx
@@ -64,7 +64,7 @@ interface NewLayoutEmptyProps {
 }
 
 const NewLayoutEmpty = ({ dashboard, styles }: NewLayoutEmptyProps) => {
-  const { uid, isEditing, editPane, body } = dashboard.useState();
+  const { uid, isEditing, sidebar, body } = dashboard.useState();
   const isEditingNewDashboard = isEditing && !uid;
   const isAutoGrid = body instanceof AutoGridLayoutManager;
 
@@ -76,11 +76,11 @@ const NewLayoutEmpty = ({ dashboard, styles }: NewLayoutEmptyProps) => {
     if (
       isEditingNewDashboard &&
       dashboard.getEditSessionSource() !== 'assistant' &&
-      editPane.state.openPane?.getId() !== 'add'
+      sidebar.state.openPane?.getId() !== 'add'
     ) {
-      editPane.openPane(new AddNewEditPane({}));
+      sidebar.openPane(new AddNewEditPane({}));
     }
-  }, [isEditingNewDashboard, dashboard, editPane]);
+  }, [isEditingNewDashboard, dashboard, sidebar]);
 
   const onSelectAutoGrid = () => {
     dashboard.switchLayout(AutoGridLayoutManager.createEmpty());


### PR DESCRIPTION
**What is this feature?**

Pure rename refactor, part 2 of a 4-PR stack (based on #129434). Renames the `editPane` property in `DashboardSceneState` (and local variables/usages) to `sidebar`, matching the renamed `DashboardSidebar` scene object.

Scene state is runtime-only, so nothing persisted is affected. No behavior change.

**Stack:**

1. #129434 — rename `DashboardEditPane*` symbols and files
2. 👉 This PR — rename `editPane` state key to `sidebar`
3. Rename `edit-pane` folder to `sidebar`
4. Rename `dashboard.edit-pane.*` i18n keys and fix translations

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Mechanical rename; verified with typecheck and the dashboard-scene jest suites. Will be retargeted to `main` once #129434 merges.

Made with [Cursor](https://cursor.com)