### PR TITLE
UI: Fix Alert background border radius

### DIFF
--- a/packages/grafana-ui/src/components/Alert/Alert.tsx
+++ b/packages/grafana-ui/src/components/Alert/Alert.tsx
@@ -160,7 +160,7 @@ const getStyles = (
         bottom: 0,
         right: 0,
         background: theme.colors.background.primary,
-        borderRadius: theme.shape.radius.default,
+        borderRadius: theme.shape.radius.lg,
         zIndex: -1,
       },
     }),


### PR DESCRIPTION
**What is this feature?**

<img width="34" height="38" alt="image" src="https://github.com/user-attachments/assets/8b719776-80b1-41f2-a43a-031f4fbd7b17" />

**Why do we need this feature?**

<img width="34" height="38" alt="image" src="https://github.com/user-attachments/assets/2192a618-b899-4cb9-b444-a8f52afd3ccf" />

**Who is this feature for?**

Developers.

**Which issue(s) does this PR fix?**:

cc #126409

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
