### PR TITLE
Explore: Fix correlation editor dropping datasource change on save

### DIFF
--- a/public/app/features/explore/CorrelationEditorModeBar.test.tsx
+++ b/public/app/features/explore/CorrelationEditorModeBar.test.tsx
@@ -1,0 +1,73 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+
+import { configureStore } from 'app/store/configureStore';
+import { CORRELATION_EDITOR_POST_CONFIRM_ACTION, type ExploreItemState, type ExploreState } from 'app/types/explore';
+
+import { CorrelationEditorModeBar } from './CorrelationEditorModeBar';
+import { changeDatasource } from './state/datasource';
+
+jest.mock('./state/datasource', () => ({
+  ...jest.requireActual('./state/datasource'),
+  changeDatasource: jest.fn(),
+}));
+jest.mock('./state/correlations', () => ({
+  ...jest.requireActual('./state/correlations'),
+  saveCurrentCorrelation: jest.fn(() => ({ type: 'mock/saveCurrentCorrelation' })),
+}));
+jest.mock('./state/query', () => ({
+  ...jest.requireActual('./state/query'),
+  runQueries: jest.fn(() => ({ type: 'mock/runQueries' })),
+}));
+jest.mock('./state/explorePane', () => ({
+  ...jest.requireActual('./state/explorePane'),
+  changeCorrelationHelperData: jest.fn(() => ({ type: 'mock/changeCorrelationHelperData' })),
+}));
+
+const changeDatasourceMock = jest.mocked(changeDatasource);
+const CHANGE_DATASOURCE_ACTION = { type: 'mock/changeDatasource' };
+
+describe('CorrelationEditorModeBar', () => {
+  beforeEach(() => {
+    changeDatasourceMock.mockReturnValue(CHANGE_DATASOURCE_ACTION as unknown as ReturnType<typeof changeDatasource>);
+  });
+
+  // Regression test (2026-07-02 DataPro code audit, finding #15): saving from the unsaved-changes
+  // modal while a datasource change is pending must actually apply the datasource change. The
+  // `changeDatasource` thunk was created but never dispatched, so the change was silently dropped.
+  it('dispatches changeDatasource when saving with a pending datasource change', () => {
+    const store = configureStore({
+      explore: {
+        panes: { left: {} },
+        correlationEditorDetails: {
+          editorMode: true,
+          isExiting: true,
+          correlationDirty: true,
+          queryEditorDirty: false,
+          canSave: true,
+          label: 'my correlation',
+          description: 'desc',
+          postConfirmAction: {
+            exploreId: 'left',
+            action: CORRELATION_EDITOR_POST_CONFIRM_ACTION.CHANGE_DATASOURCE,
+            changeDatasourceUid: 'new-ds-uid',
+            isActionLeft: true,
+          },
+        },
+      } as unknown as ExploreState,
+    });
+    const dispatchSpy = jest.spyOn(store, 'dispatch');
+
+    render(
+      <Provider store={store}>
+        <CorrelationEditorModeBar panes={[['left', {} as ExploreItemState]]} />
+      </Provider>
+    );
+
+    // The unsaved-changes modal appears because a datasource change is pending with a dirty correlation.
+    fireEvent.click(screen.getByRole('button', { name: /save correlation/i }));
+
+    expect(changeDatasourceMock).toHaveBeenCalledWith({ exploreId: 'left', datasource: 'new-ds-uid' });
+    expect(dispatchSpy).toHaveBeenCalledWith(CHANGE_DATASOURCE_ACTION);
+  });
+});

--- a/public/app/features/explore/CorrelationEditorModeBar.tsx
+++ b/public/app/features/explore/CorrelationEditorModeBar.tsx
@@ -167,7 +167,7 @@ export const CorrelationEditorModeBar = ({ panes }: { panes: Array<[string, Expl
         action === CORRELATION_EDITOR_POST_CONFIRM_ACTION.CHANGE_DATASOURCE &&
         changeDatasourceUid !== undefined
       ) {
-        changeDatasource({ exploreId, datasource: changeDatasourceUid });
+        dispatch(changeDatasource({ exploreId, datasource: changeDatasourceUid }));
         resetEditor();
       }
     } else {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Note
Closed as duplicate of #128947. This branch was used only to locally apply and **UI-validate** the same one-line `dispatch(changeDatasource(...))` fix from that PR against #128944.

## Validation result
* **Bug confirmed on main:** Save from unsaved-changes modal after a left-pane datasource change kept the old datasource.
* **Fix confirmed:** With the #128947 change applied, Save switches the left pane to the newly selected datasource.

See agent walkthrough artifacts for screenshots/recording.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aea4d203-13bf-4190-8ac3-2c37725cd323"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aea4d203-13bf-4190-8ac3-2c37725cd323"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

