### PR TITLE
Dashboards: Add dashboard definition fetch duration to dashboard_render events

### DIFF
--- a/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.test.ts
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.test.ts
@@ -481,6 +481,16 @@ describe('DashboardScenePageStateManager v1', () => {
       expect(consumeDashboardFetchTiming('fake-dash')).toBeGreaterThanOrEqual(0);
     });
 
+    it('should not record dashboard fetch timing when the fetch is cancelled', async () => {
+      // fetchDashboard swallows cancelled fetch errors and resolves to null (see isFetchError(e) && e.cancelled).
+      setupLoadDashboardMockReject({ status: 0, data: null, cancelled: true });
+
+      const loader = new DashboardScenePageStateManager({});
+      await loader.loadDashboard({ uid: 'fake-dash-cancelled', route: DashboardRoutes.Normal });
+
+      expect(consumeDashboardFetchTiming('fake-dash-cancelled')).toBeUndefined();
+    });
+
     it('should use DashboardScene creator to initialize the snapshot scene', async () => {
       setupLoadDashboardMock({ dashboard: { uid: 'fake-dash' }, meta: {} });
 

--- a/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.test.ts
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.test.ts
@@ -16,6 +16,7 @@ import { markAsUrlRewrite } from 'app/core/navigation/urlRewrite';
 import { contextSrv } from 'app/core/services/context_srv';
 import { getDashboardAPI } from 'app/features/dashboard/api/dashboard_api';
 import { DashboardVersionError, type DashboardWithAccessInfo } from 'app/features/dashboard/api/types';
+import { consumeDashboardFetchTiming } from 'app/features/dashboard/services/DashboardFetchTiming';
 import {
   type DashboardLoaderSrv,
   type DashboardLoaderSrvV2,
@@ -469,6 +470,15 @@ describe('DashboardScenePageStateManager v1', () => {
 
       expect(loader.state.dashboard).toBeInstanceOf(DashboardScene);
       expect(loader.state.isLoading).toBe(false);
+    });
+
+    it('should record dashboard fetch timing for the loaded uid', async () => {
+      setupLoadDashboardMock({ dashboard: { uid: 'fake-dash' }, meta: {} });
+
+      const loader = new DashboardScenePageStateManager({});
+      await loader.loadDashboard({ uid: 'fake-dash', route: DashboardRoutes.Normal });
+
+      expect(consumeDashboardFetchTiming('fake-dash')).toBeGreaterThanOrEqual(0);
     });
 
     it('should use DashboardScene creator to initialize the snapshot scene', async () => {

--- a/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
@@ -534,11 +534,14 @@ abstract class DashboardScenePageStateManagerBase<T>
     // this resolves - record it separately so it can be attached to those events later.
     const fetchStart = performance.now();
     const rsp = await this.fetchDashboard(options);
-    recordDashboardFetchTiming(options.uid || undefined, performance.now() - fetchStart);
 
     if (!rsp) {
+      // Cancelled or failed fetch - nothing was actually loaded, so don't record a timing
+      // that could get misattributed to a later, unrelated load.
       return null;
     }
+
+    recordDashboardFetchTiming(options.uid || undefined, performance.now() - fetchStart);
 
     const enrichedOptions = await this.enrichLoadOptions(rsp, options);
     const scene = this.transformResponseToScene(rsp, enrichedOptions);

--- a/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
@@ -36,6 +36,7 @@ import {
   isV2StoredVersion,
 } from 'app/features/dashboard/api/utils';
 import { initializeDashboardAnalyticsAggregator } from 'app/features/dashboard/services/DashboardAnalyticsAggregator';
+import { recordDashboardFetchTiming } from 'app/features/dashboard/services/DashboardFetchTiming';
 import { dashboardLoaderSrv, DashboardLoaderSrvV2 } from 'app/features/dashboard/services/DashboardLoaderSrv';
 import { getDashboardSceneProfiler } from 'app/features/dashboard/services/DashboardProfiler';
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
@@ -529,7 +530,11 @@ abstract class DashboardScenePageStateManagerBase<T>
       return await this.loadHomeDashboard();
     }
 
+    // dashboard_view/dashboard_render profiling only starts once the scene exists, i.e. after
+    // this resolves - record it separately so it can be attached to those events later.
+    const fetchStart = performance.now();
     const rsp = await this.fetchDashboard(options);
+    recordDashboardFetchTiming(options.uid || undefined, performance.now() - fetchStart);
 
     if (!rsp) {
       return null;
@@ -934,7 +939,9 @@ export class DashboardScenePageStateManager extends DashboardScenePageStateManag
     try {
       this.setState({ isLoading: true });
 
+      const fetchStart = performance.now();
       const rsp = await dashboardLoaderSrv.loadDashboard('db', dashboard.state.meta.slug, uid, queryParams);
+      recordDashboardFetchTiming(uid, performance.now() - fetchStart);
       const fromCache = this.getSceneFromCache(uid);
 
       // check if cached db version is same as both
@@ -1285,7 +1292,9 @@ export class DashboardScenePageStateManagerV2 extends DashboardScenePageStateMan
     try {
       this.setState({ isLoading: true });
 
+      const fetchStart = performance.now();
       const rsp = await this.dashboardLoader.loadDashboard('db', dashboard.state.meta.slug, uid, queryParams);
+      recordDashboardFetchTiming(uid, performance.now() - fetchStart);
       const fromCache = this.getSceneFromCache(uid);
 
       if (

--- a/public/app/features/dashboard/services/DashboardAnalyticsAggregator.test.ts
+++ b/public/app/features/dashboard/services/DashboardAnalyticsAggregator.test.ts
@@ -2,6 +2,7 @@ import { logMeasurement } from '@grafana/runtime';
 import { type performanceUtils } from '@grafana/scenes';
 
 import { DashboardAnalyticsAggregator } from './DashboardAnalyticsAggregator';
+import { recordDashboardFetchTiming } from './DashboardFetchTiming';
 
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
@@ -45,6 +46,57 @@ describe('DashboardAnalyticsAggregator', () => {
     jest.spyOn(performance, 'measure').mockReturnValue({ duration: 0 } as PerformanceMeasure);
     aggregator = new DashboardAnalyticsAggregator();
     aggregator.initialize('dash-uid', 'Test dashboard');
+    // Reset the DashboardFetchTiming store to a uid that won't match 'dash-uid', so tests
+    // that don't care about fetch timing aren't affected by leakage across test files.
+    recordDashboardFetchTiming('unrelated-uid', 0);
+  });
+
+  function completeDashboardInteraction() {
+    aggregator.onDashboardInteractionComplete({
+      interactionType: 'dashboard_view',
+      operationId: 'op-1',
+      timestamp: 1000,
+      duration: 250,
+      networkDuration: 120.5,
+      longFramesCount: 0,
+      longFramesTotalTime: 0,
+    });
+  }
+
+  function getDashboardRenderPayloads() {
+    return logMeasurementMock.mock.calls
+      .filter(([event]) => event === 'dashboard_render')
+      .map(([, payload]) => payload);
+  }
+
+  it('includes dashboardFetchDuration when the fetch timing store has a matching uid', () => {
+    recordDashboardFetchTiming('dash-uid', 87.26);
+
+    completeDashboardInteraction();
+
+    expect(getDashboardRenderPayloads()[0]).toMatchObject({ dashboardFetchDuration: 87.3 });
+  });
+
+  it('omits dashboardFetchDuration when the fetch timing store has no matching uid', () => {
+    recordDashboardFetchTiming('some-other-dashboard', 87.26);
+
+    completeDashboardInteraction();
+
+    expect(getDashboardRenderPayloads()[0]).not.toHaveProperty('dashboardFetchDuration');
+  });
+
+  it('consumes the fetch timing once - a second dashboard_render for the same load omits it', () => {
+    recordDashboardFetchTiming('dash-uid', 87.26);
+
+    // First interaction (e.g. the load itself) carries the fetch duration...
+    completeDashboardInteraction();
+    // ...a later interaction on the same dashboard (e.g. a refresh) must not re-report it.
+    completeDashboardInteraction();
+
+    const payloads = getDashboardRenderPayloads();
+    expect(payloads).toHaveLength(2);
+    expect(payloads[0]).toMatchObject({ dashboardFetchDuration: 87.3 });
+    expect(payloads[1]).not.toHaveProperty('dashboardFetchDuration');
   });
 
   it('reports a per-phase duration breakdown alongside total_time on the panel_render event', () => {

--- a/public/app/features/dashboard/services/DashboardAnalyticsAggregator.test.ts
+++ b/public/app/features/dashboard/services/DashboardAnalyticsAggregator.test.ts
@@ -99,6 +99,25 @@ describe('DashboardAnalyticsAggregator', () => {
     expect(payloads[1]).not.toHaveProperty('dashboardFetchDuration');
   });
 
+  it('omits dashboardFetchDuration when the recorded fetch is stale (a slow refetch that resolved long after this profile started)', () => {
+    jest.spyOn(performance, 'now').mockReturnValue(0);
+    recordDashboardFetchTiming('dash-uid', 87.26);
+    jest.spyOn(performance, 'now').mockRestore();
+
+    // profileStart = timestamp - duration = 19750, far outside the attribution window around 0.
+    aggregator.onDashboardInteractionComplete({
+      interactionType: 'dashboard_view',
+      operationId: 'op-1',
+      timestamp: 2e4,
+      duration: 250,
+      networkDuration: 120.5,
+      longFramesCount: 0,
+      longFramesTotalTime: 0,
+    });
+
+    expect(getDashboardRenderPayloads()[0]).not.toHaveProperty('dashboardFetchDuration');
+  });
+
   it('reports a per-phase duration breakdown alongside total_time on the panel_render event', () => {
     aggregator.onPanelOperationStart(panelOp('query', 0));
 

--- a/public/app/features/dashboard/services/DashboardAnalyticsAggregator.ts
+++ b/public/app/features/dashboard/services/DashboardAnalyticsAggregator.ts
@@ -1,6 +1,7 @@
 import { logMeasurement, reportInteraction } from '@grafana/runtime';
 import { type performanceUtils } from '@grafana/scenes';
 
+import { consumeDashboardFetchTiming } from './DashboardFetchTiming';
 import { SLOW_OPERATION_THRESHOLD_MS } from './performanceConstants';
 import {
   registerPerformanceObserver,
@@ -240,6 +241,12 @@ export class DashboardAnalyticsAggregator implements performanceUtils.ScenePerfo
    * Send analytics report for dashboard interactions
    */
   private sendAnalyticsReport(data: performanceUtils.DashboardInteractionCompleteData): void {
+    // Consumed (not just read) - the fetch duration belongs only to the interaction that
+    // actually loaded the definition. Later interactions on the same dashboard (refresh,
+    // time_range_change, ...) must not re-report it. This is the only call site, so
+    // consuming here is safe.
+    const dashboardFetchDuration = consumeDashboardFetchTiming(this.dashboardUID);
+
     const payload = {
       duration: data.duration || 0,
       networkDuration: data.networkDuration || 0,
@@ -248,6 +255,10 @@ export class DashboardAnalyticsAggregator implements performanceUtils.ScenePerfo
       timeSinceBoot: performance.measure('time_since_boot', 'frontend_boot_js_done_time_seconds').duration,
       longFramesCount: data.longFramesCount,
       longFramesTotalTime: data.longFramesTotalTime,
+      // Omitted entirely when unknown (e.g. cached scene, no matching fetch recorded) rather than reported as 0.
+      ...(dashboardFetchDuration !== undefined && {
+        dashboardFetchDuration: Math.round(dashboardFetchDuration * 10) / 10,
+      }),
       ...getPerformanceMemory(),
     };
 

--- a/public/app/features/dashboard/services/DashboardAnalyticsAggregator.ts
+++ b/public/app/features/dashboard/services/DashboardAnalyticsAggregator.ts
@@ -1,7 +1,7 @@
 import { logMeasurement, reportInteraction } from '@grafana/runtime';
 import { type performanceUtils } from '@grafana/scenes';
 
-import { consumeDashboardFetchTiming } from './DashboardFetchTiming';
+import { consumeDashboardFetchTiming, FETCH_ATTRIBUTION_MAX_LEAD_MS } from './DashboardFetchTiming';
 import { SLOW_OPERATION_THRESHOLD_MS } from './performanceConstants';
 import {
   registerPerformanceObserver,
@@ -245,7 +245,15 @@ export class DashboardAnalyticsAggregator implements performanceUtils.ScenePerfo
     // actually loaded the definition. Later interactions on the same dashboard (refresh,
     // time_range_change, ...) must not re-report it. This is the only call site, so
     // consuming here is safe.
-    const dashboardFetchDuration = consumeDashboardFetchTiming(this.dashboardUID);
+    // data.timestamp is the profile's end, data.duration spans back to its start - a fetch
+    // recorded any earlier than that (minus a small allowance for the scene-transform work
+    // that sits between the fetch resolving and the profile starting) belongs to an
+    // abandoned/cancelled load, not this interaction.
+    const profileStart = data.timestamp - (data.duration || 0);
+    const dashboardFetchDuration = consumeDashboardFetchTiming(
+      this.dashboardUID,
+      profileStart - FETCH_ATTRIBUTION_MAX_LEAD_MS
+    );
 
     const payload = {
       duration: data.duration || 0,

--- a/public/app/features/dashboard/services/DashboardFetchTiming.test.ts
+++ b/public/app/features/dashboard/services/DashboardFetchTiming.test.ts
@@ -1,6 +1,10 @@
 import { consumeDashboardFetchTiming, recordDashboardFetchTiming } from './DashboardFetchTiming';
 
 describe('DashboardFetchTiming', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it('returns the recorded duration for a matching uid', () => {
     recordDashboardFetchTiming('dash-1', 123.4);
 
@@ -39,5 +43,30 @@ describe('DashboardFetchTiming', () => {
 
     expect(consumeDashboardFetchTiming('dash-1')).toBeUndefined();
     expect(consumeDashboardFetchTiming('dash-2')).toBe(20);
+  });
+
+  describe('notBefore staleness guard', () => {
+    it('returns the duration when recorded at or after notBefore', () => {
+      jest.spyOn(performance, 'now').mockReturnValue(1000);
+      recordDashboardFetchTiming('dash-1', 42);
+
+      expect(consumeDashboardFetchTiming('dash-1', 900)).toBe(42);
+    });
+
+    it('discards a timing recorded before notBefore, but still clears the slot', () => {
+      jest.spyOn(performance, 'now').mockReturnValue(1000);
+      recordDashboardFetchTiming('dash-1', 42);
+
+      expect(consumeDashboardFetchTiming('dash-1', 1500)).toBeUndefined();
+      // The stale timing must not be attributed to a later consume - the slot is gone either way.
+      expect(consumeDashboardFetchTiming('dash-1', 900)).toBeUndefined();
+    });
+
+    it('applies the old (unguarded) behavior when notBefore is omitted', () => {
+      jest.spyOn(performance, 'now').mockReturnValue(1000);
+      recordDashboardFetchTiming('dash-1', 42);
+
+      expect(consumeDashboardFetchTiming('dash-1')).toBe(42);
+    });
   });
 });

--- a/public/app/features/dashboard/services/DashboardFetchTiming.test.ts
+++ b/public/app/features/dashboard/services/DashboardFetchTiming.test.ts
@@ -1,0 +1,43 @@
+import { consumeDashboardFetchTiming, recordDashboardFetchTiming } from './DashboardFetchTiming';
+
+describe('DashboardFetchTiming', () => {
+  it('returns the recorded duration for a matching uid', () => {
+    recordDashboardFetchTiming('dash-1', 123.4);
+
+    expect(consumeDashboardFetchTiming('dash-1')).toBe(123.4);
+  });
+
+  it('returns undefined when the requested uid does not match the stored one', () => {
+    recordDashboardFetchTiming('dash-1', 123.4);
+
+    expect(consumeDashboardFetchTiming('dash-2')).toBeUndefined();
+  });
+
+  it('leaves the slot untouched on a uid mismatch, so a later matching read still succeeds', () => {
+    recordDashboardFetchTiming('dash-1', 123.4);
+
+    expect(consumeDashboardFetchTiming('dash-2')).toBeUndefined();
+    expect(consumeDashboardFetchTiming('dash-1')).toBe(123.4);
+  });
+
+  it('matches any uid when the stored uid is undefined (slug-based routes)', () => {
+    recordDashboardFetchTiming(undefined, 55);
+
+    expect(consumeDashboardFetchTiming('dash-1')).toBe(55);
+  });
+
+  it('is consume-once - a second read after a match returns undefined', () => {
+    recordDashboardFetchTiming('dash-1', 42);
+
+    expect(consumeDashboardFetchTiming('dash-1')).toBe(42);
+    expect(consumeDashboardFetchTiming('dash-1')).toBeUndefined();
+  });
+
+  it('reflects the most recent recording, overwriting the previous slot', () => {
+    recordDashboardFetchTiming('dash-1', 10);
+    recordDashboardFetchTiming('dash-2', 20);
+
+    expect(consumeDashboardFetchTiming('dash-1')).toBeUndefined();
+    expect(consumeDashboardFetchTiming('dash-2')).toBe(20);
+  });
+});

--- a/public/app/features/dashboard/services/DashboardFetchTiming.ts
+++ b/public/app/features/dashboard/services/DashboardFetchTiming.ts
@@ -10,16 +10,18 @@
  * The fetch duration belongs only to the dashboard_render event that actually loaded the
  * definition - consuming it clears the slot so later interactions on the same dashboard
  * (refresh, time_range_change, ...) correctly omit dashboardFetchDuration instead of
- * re-reporting a stale value.
- *
- * Known acceptable edge case: if a profile is cancelled (e.g. the tab is hidden mid-load),
- * the slot survives uncommitted and the next completed interaction for that uid consumes
- * it late, attributing the fetch to the wrong interaction. Rare enough not to guard against.
+ * re-reporting a stale value. A slow refetch can also resolve after its triggering profile
+ * has already completed; consumeDashboardFetchTiming's `notBefore` guard drops timings that
+ * are too old to belong to the interaction being reported, rather than letting them get
+ * misattributed to whichever interaction happens to consume them next.
  */
+
+export const FETCH_ATTRIBUTION_MAX_LEAD_MS = 5000;
 
 interface DashboardFetchTimingSlot {
   uid: string | undefined;
   durationMs: number;
+  recordedAt: number;
 }
 
 let lastFetchTiming: DashboardFetchTimingSlot | undefined;
@@ -30,7 +32,7 @@ let lastFetchTiming: DashboardFetchTimingSlot | undefined;
  * still match it up.
  */
 export function recordDashboardFetchTiming(uid: string | undefined, durationMs: number): void {
-  lastFetchTiming = { uid, durationMs };
+  lastFetchTiming = { uid, durationMs, recordedAt: performance.now() };
 }
 
 /**
@@ -38,8 +40,15 @@ export function recordDashboardFetchTiming(uid: string | undefined, durationMs: 
  * match so subsequent calls return undefined until the next fetch is recorded. A stored uid
  * of undefined matches any request. On a uid mismatch (or empty slot), returns undefined and
  * leaves the slot untouched.
+ *
+ * `notBefore`, when given, rejects (and discards) a timing recorded earlier than that instant.
+ * The initial-load fetch legitimately completes before the interaction's profile starts (scene
+ * transform work sits in between), so callers should pass a `notBefore` a little earlier than
+ * their profile's start - see FETCH_ATTRIBUTION_MAX_LEAD_MS. Anything older than that is a fetch
+ * from an abandoned or cancelled load and gets dropped rather than misattributed to whatever
+ * interaction consumes it next.
  */
-export function consumeDashboardFetchTiming(uid: string): number | undefined {
+export function consumeDashboardFetchTiming(uid: string, notBefore?: number): number | undefined {
   if (!lastFetchTiming) {
     return undefined;
   }
@@ -48,7 +57,12 @@ export function consumeDashboardFetchTiming(uid: string): number | undefined {
     return undefined;
   }
 
-  const { durationMs } = lastFetchTiming;
+  const { durationMs, recordedAt } = lastFetchTiming;
   lastFetchTiming = undefined;
+
+  if (notBefore !== undefined && recordedAt < notBefore) {
+    return undefined;
+  }
+
   return durationMs;
 }

--- a/public/app/features/dashboard/services/DashboardFetchTiming.ts
+++ b/public/app/features/dashboard/services/DashboardFetchTiming.ts
@@ -1,0 +1,54 @@
+/**
+ * Tracks how long the most recent dashboard definition fetch took.
+ *
+ * dashboard_view/dashboard_render profiling starts only after the dashboard definition
+ * has resolved (see DashboardScenePageStateManager.loadScene), so fetch time is otherwise
+ * invisible in that profile. This module bridges the gap: the state manager records the
+ * fetch duration here, and DashboardAnalyticsAggregator consumes it back when building the
+ * dashboard_render payload.
+ *
+ * The fetch duration belongs only to the dashboard_render event that actually loaded the
+ * definition - consuming it clears the slot so later interactions on the same dashboard
+ * (refresh, time_range_change, ...) correctly omit dashboardFetchDuration instead of
+ * re-reporting a stale value.
+ *
+ * Known acceptable edge case: if a profile is cancelled (e.g. the tab is hidden mid-load),
+ * the slot survives uncommitted and the next completed interaction for that uid consumes
+ * it late, attributing the fetch to the wrong interaction. Rare enough not to guard against.
+ */
+
+interface DashboardFetchTimingSlot {
+  uid: string | undefined;
+  durationMs: number;
+}
+
+let lastFetchTiming: DashboardFetchTimingSlot | undefined;
+
+/**
+ * Records the duration of a dashboard definition fetch. `uid` should be undefined when
+ * the fetch was made before the uid was known (e.g. slug-based routes) so the consumer can
+ * still match it up.
+ */
+export function recordDashboardFetchTiming(uid: string | undefined, durationMs: number): void {
+  lastFetchTiming = { uid, durationMs };
+}
+
+/**
+ * Consumes the last recorded fetch duration if it applies to `uid`, clearing the slot on a
+ * match so subsequent calls return undefined until the next fetch is recorded. A stored uid
+ * of undefined matches any request. On a uid mismatch (or empty slot), returns undefined and
+ * leaves the slot untouched.
+ */
+export function consumeDashboardFetchTiming(uid: string): number | undefined {
+  if (!lastFetchTiming) {
+    return undefined;
+  }
+
+  if (lastFetchTiming.uid !== undefined && lastFetchTiming.uid !== uid) {
+    return undefined;
+  }
+
+  const { durationMs } = lastFetchTiming;
+  lastFetchTiming = undefined;
+  return durationMs;
+}


### PR DESCRIPTION
The `dashboard_view` render profile only starts once the dashboard definition has resolved, so `dashboard_render` Faro events never showed how long fetching the definition took.

This measures the fetch in the scene state manager (initial load, plus `reloadDashboardsOnParamsChange` refetches) and attaches it to the `dashboard_render` payload as `dashboardFetchDuration`, with consume-once semantics: only the interaction that actually fetched the definition carries the value - refreshes and time-range changes omit it. Gated like the rest of `dashboard_render` by `dashboard_performance_metrics`.


ref https://github.com/grafana/hyperion-planning/issues/672

