### PR TITLE
Teams: Remove team member UID migration

### DIFF
--- a/pkg/services/team/teamimpl/legacy_team.go
+++ b/pkg/services/team/teamimpl/legacy_team.go
@@ -27,10 +27,6 @@ type LegacyService struct {
 func NewLegacyService(db db.DB, cfg *setting.Cfg, tracer tracing.Tracer) (team.Service, error) {
 	store := &xormStore{db: db, cfg: cfg, deletes: []string{}}
 
-	if err := store.teamMemberUidMigration(); err != nil {
-		return nil, err
-	}
-
 	return &LegacyService{
 		cache:  localcache.New(defaultCacheDuration, 2*defaultCacheDuration),
 		store:  store,

--- a/pkg/services/team/teamimpl/store.go
+++ b/pkg/services/team/teamimpl/store.go
@@ -11,7 +11,6 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/db"
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
-	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
 	"github.com/grafana/grafana/pkg/services/team"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
@@ -618,26 +617,4 @@ func (ss *xormStore) getTeamMembers(ctx context.Context, query *team.GetTeamMemb
 // RegisterDelete registers a delete query to be executed when the transaction is committed
 func (ss *xormStore) RegisterDelete(query string) {
 	ss.deletes = append(ss.deletes, query)
-}
-
-// teamMemberUidMigration ensures that all team members have a valid uid.
-// To protect against upgrade / downgrade we need to run this for a couple of releases.
-// FIXME: Remove this migration around Q2 2026
-func (ss *xormStore) teamMemberUidMigration() error {
-	return ss.db.WithDbSession(context.Background(), func(sess *db.Session) error {
-		switch ss.db.GetDBType() {
-		case migrator.SQLite:
-			_, err := sess.Exec("UPDATE team_member SET uid=printf('tm%09d',id) WHERE uid IS NULL OR uid = '';")
-			return err
-		case migrator.Postgres:
-			_, err := sess.Exec("UPDATE team_member SET uid='tm' || lpad('' || id::text,9,'0') WHERE uid IS NULL OR uid = '';")
-			return err
-		case migrator.MySQL:
-			_, err := sess.Exec("UPDATE team_member SET uid=concat('tm',lpad(id,9,'0')) WHERE uid IS NULL OR uid = '';")
-			return err
-		default:
-			// this branch should be unreachable
-			return nil
-		}
-	})
 }


### PR DESCRIPTION
**What is this feature?**

Removes the temporary `teamMemberUidMigration` backfill from the legacy team service.

**Why do we need this feature?**

The migration was explicitly scheduled for removal around Q2 2026. Removing it avoids running an unnecessary database update whenever the legacy team service is initialized and simplifies the ongoing migration to templated queries.