### PR TITLE
Search: return a host-neutral route type from SearchRoute

### DIFF
--- a/pkg/registry/apis/dashboard/register.go
+++ b/pkg/registry/apis/dashboard/register.go
@@ -1404,8 +1404,12 @@ func (b *DashboardsAPIBuilder) GetAPIRoutes(gv schema.GroupVersion) *builder.API
 	// The search API is mounted under every served version, so a client can use
 	// the same version it uses for the rest of the kind.
 	if b.searchAPI != nil {
-		routes.Namespace = append(routes.Namespace, b.searchAPI.SearchRoute(
-			gv.Group, gv.Version, dashv0.DASHBOARD_RESOURCE, "Dashboard"))
+		r := b.searchAPI.SearchRoute(gv.Group, gv.Version, dashv0.DASHBOARD_RESOURCE, "Dashboard")
+		routes.Namespace = append(routes.Namespace, builder.APIRouteHandler{
+			Path:    r.Path,
+			Spec:    r.Spec,
+			Handler: r.Handler,
+		})
 	}
 
 	if gv.Version == dashv0.VERSION {

--- a/pkg/registry/apis/search/route.go
+++ b/pkg/registry/apis/search/route.go
@@ -1,6 +1,7 @@
 package search
 
 import (
+	"net/http"
 	"strings"
 
 	"k8s.io/apiserver/pkg/authorization/authorizer"
@@ -8,7 +9,6 @@ import (
 	"k8s.io/kube-openapi/pkg/validation/spec"
 
 	searchv0 "github.com/grafana/grafana/pkg/apis/search/v0alpha1"
-	"github.com/grafana/grafana/pkg/services/apiserver/builder"
 )
 
 // ConfigSection and ConfigKey name the ini setting that turns these endpoints
@@ -21,15 +21,25 @@ const (
 // searchPathSegment is the last segment of the search endpoint path.
 const searchPathSegment = "search"
 
+// Route is an endpoint to mount, described in terms the caller's apiserver
+// wiring can consume. Deliberately not Grafana's builder.APIRouteHandler: the
+// same handler is mounted by more than one host, so the mapping to any one
+// host's route type belongs to that host.
+type Route struct {
+	Path    string
+	Spec    *spec3.PathProps
+	Handler http.HandlerFunc
+}
+
 // SearchRoute returns the namespaced route for a kind's search endpoint,
 // mounted at .../namespaces/{namespace}/{resource}/search.
 //
 // POST is deliberate: it carries a request body, and it does not collide with
 // the standard verbs, where create is a POST on the collection and object
 // operations are GET/PUT/PATCH/DELETE on .../{resource}/{name}.
-func (h *Handler) SearchRoute(group, version, resourceName, kindName string) builder.APIRouteHandler {
+func (h *Handler) SearchRoute(group, version, resourceName, kindName string) Route {
 	kind := kindRef{group: group, version: version, resource: resourceName, kind: kindName}
-	return builder.APIRouteHandler{
+	return Route{
 		Path:    resourceName + "/" + searchPathSegment,
 		Spec:    searchRouteSpec(kindName, version),
 		Handler: h.SearchFor(kind),

--- a/pkg/registry/apis/search/route_test.go
+++ b/pkg/registry/apis/search/route_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace/noop"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/apiserver/pkg/endpoints/request"
@@ -83,6 +84,21 @@ func TestAsReadAttributes(t *testing.T) {
 	assert.Equal(t, "dashboards", read.GetResource())
 	assert.Equal(t, "default", read.GetNamespace())
 	assert.True(t, read.IsResourceRequest())
+}
+
+func TestSearchRoute(t *testing.T) {
+	h := NewHandler(&fakeIndexClient{resp: emptyResponse()}, testProvider(), noop.NewTracerProvider().Tracer(""))
+	r := h.SearchRoute("dashboard.grafana.app", "v0alpha1", "dashboards", "Dashboard")
+
+	// Relative to the group-version root the caller mounts under, so the served
+	// path ends up .../namespaces/{namespace}/dashboards/search.
+	assert.Equal(t, "dashboards/search", r.Path)
+	require.NotNil(t, r.Handler)
+
+	require.NotNil(t, r.Spec)
+	require.NotNil(t, r.Spec.Post, "search is a POST, so no other method should be described")
+	assert.Nil(t, r.Spec.Get)
+	assert.Equal(t, "listDashboardSearchV0alpha1", r.Spec.Post.OperationId)
 }
 
 func TestSearchOperationID(t *testing.T) {


### PR DESCRIPTION
`pkg/registry/apis/search` described its route with `builder.APIRouteHandler`, tying it to one host's apiserver wiring. `SearchRoute` now returns a local `Route` — path, OpenAPI spec, handler func — and the dashboard builder maps it where it registers the route.

Groundwork for mounting the same handler centrally, from wiring that exists both in `pkg/services/apiserver/service.go` and in the multi-tenant apiserver in grafana-enterprise. Split out because that change spans two hosts and alters behaviour, so a type change is easier to review on its own than buried inside it.

No behaviour change. Adds a test for the route contract, which nothing covered before.