### PR TITLE
User Storage: Implement deleteItem method + fix getItem return type

### DIFF
--- a/packages/grafana-data/src/types/userStorage.ts
+++ b/packages/grafana-data/src/types/userStorage.ts
@@ -12,4 +12,10 @@ export interface UserStorage {
    * @returns A promise that resolves when the item is set.
    */
   setItem(key: string, value: string): Promise<void>;
+  /**
+   * Deletes an item from the backend user storage or local storage if not enabled.
+   * @param key - The key of the item to delete.
+   * @returns A promise that resolves when the item is deleted.
+   */
+  deleteItem(key: string): Promise<void>;
 }

--- a/packages/grafana-runtime/src/utils/userStorage.test.tsx
+++ b/packages/grafana-runtime/src/utils/userStorage.test.tsx
@@ -312,7 +312,7 @@ describe('userStorage', () => {
 
       // Should not make a GET request because cache has the updated data
       expect(request).not.toHaveBeenCalled();
-      expect(value).toBeUndefined();
+      expect(value).toBeNull();
     });
 
     it('verifies other keys remain after deletion', async () => {
@@ -330,7 +330,7 @@ describe('userStorage', () => {
       // Get the deleted key
       request.mockReset();
       const deletedValue = await storage.getItem('key1');
-      expect(deletedValue).toBeUndefined();
+      expect(deletedValue).toBeNull();
 
       // Get another key
       const otherValue = await storage.getItem('key2');

--- a/packages/grafana-runtime/src/utils/userStorage.test.tsx
+++ b/packages/grafana-runtime/src/utils/userStorage.test.tsx
@@ -24,6 +24,7 @@ jest.mock('@grafana/data', () => {
   const storeMocks = {
     get: jest.fn(),
     set: jest.fn(),
+    delete: jest.fn(),
   };
   return {
     ...jest.requireActual('@grafana/data'),
@@ -48,6 +49,7 @@ describe('userStorage', () => {
     const store = getStoreMocks();
     store.get.mockReset();
     store.set.mockReset();
+    store.delete.mockReset();
     _clearStorageCache();
   });
 
@@ -230,6 +232,109 @@ describe('userStorage', () => {
       // Verify the value was updated
       const value = await storage.getItem('key');
       expect(value).toBe('new-value');
+    });
+  });
+
+  describe('deleteItem', () => {
+    it('use localStorage if the user is not logged in', async () => {
+      config.bootData.user.isSignedIn = false;
+      const storage = renderHook(() => usePluginUserStorage()).result.current;
+      await storage.deleteItem('key');
+      expect(getStoreMocks().delete).toHaveBeenCalledWith('plugin-id:abc:key');
+    });
+
+    it('use localStorage if the user storage is not found', async () => {
+      request.mockReturnValue(Promise.reject({ status: 404 } as FetchError));
+      const storage = renderHook(() => usePluginUserStorage()).result.current;
+      await storage.deleteItem('key');
+      expect(getStoreMocks().delete).toHaveBeenCalledWith('plugin-id:abc:key');
+    });
+
+    it('deletes an item from the user storage', async () => {
+      request.mockReturnValueOnce(
+        Promise.resolve({
+          status: 200,
+          data: { metadata: { name: 'service:abc' }, spec: { data: { key: 'value', other: 'data' } } },
+        } as FetchResponse)
+      );
+      request.mockReturnValueOnce(Promise.resolve({ status: 200 } as FetchResponse));
+      const storage = renderHook(() => usePluginUserStorage()).result.current;
+      await storage.deleteItem('key');
+      expect(request).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: '/apis/userstorage.grafana.app/v0alpha1/namespaces/default/user-storage/plugin-id:abc',
+          method: 'GET',
+          showErrorAlert: false,
+        })
+      );
+      expect(request).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: '/apis/userstorage.grafana.app/v0alpha1/namespaces/default/user-storage/plugin-id:abc',
+          method: 'PATCH',
+          data: {
+            spec: {
+              data: { key: null },
+            },
+          },
+        })
+      );
+    });
+
+    it('falls back to localStorage if the delete operation fails', async () => {
+      request.mockReturnValueOnce(
+        Promise.resolve({
+          status: 200,
+          data: { metadata: { name: 'service:abc' }, spec: { data: { key: 'value' } } },
+        } as FetchResponse)
+      );
+      request.mockReturnValueOnce(Promise.reject({ status: 403 } as FetchError));
+      const storage = renderHook(() => usePluginUserStorage()).result.current;
+      await storage.deleteItem('key');
+      expect(getStoreMocks().delete).toHaveBeenCalledWith('plugin-id:abc:key');
+    });
+
+    it('updates cache after deleting an item', async () => {
+      request.mockReturnValueOnce(
+        Promise.resolve({
+          status: 200,
+          data: { spec: { data: { key: 'value', other: 'data' } } },
+        } as FetchResponse)
+      );
+      request.mockReturnValueOnce(Promise.resolve({ status: 200 } as FetchResponse));
+
+      const storage1 = renderHook(() => usePluginUserStorage()).result.current;
+      await storage1.deleteItem('key');
+
+      // Second instance should see updated cache without network request
+      request.mockReset();
+      const storage2 = renderHook(() => usePluginUserStorage()).result.current;
+      const value = await storage2.getItem('key');
+
+      // Should not make a GET request because cache has the updated data
+      expect(request).not.toHaveBeenCalled();
+      expect(value).toBeUndefined();
+    });
+
+    it('verifies other keys remain after deletion', async () => {
+      request.mockReturnValueOnce(
+        Promise.resolve({
+          status: 200,
+          data: { spec: { data: { key1: 'value1', key2: 'value2' } } },
+        } as FetchResponse)
+      );
+      request.mockReturnValueOnce(Promise.resolve({ status: 200 } as FetchResponse));
+
+      const storage = renderHook(() => usePluginUserStorage()).result.current;
+      await storage.deleteItem('key1');
+
+      // Get the deleted key
+      request.mockReset();
+      const deletedValue = await storage.getItem('key1');
+      expect(deletedValue).toBeUndefined();
+
+      // Get another key
+      const otherValue = await storage.getItem('key2');
+      expect(otherValue).toBe('value2');
     });
   });
 

--- a/packages/grafana-runtime/src/utils/userStorage.tsx
+++ b/packages/grafana-runtime/src/utils/userStorage.tsx
@@ -285,6 +285,61 @@ export class UserStorage implements UserStorageType {
       releaseLock();
     }
   }
+
+  async deleteItem(key: string): Promise<void> {
+    if (!this.canUseUserStorage) {
+      // Fallback to localStorage
+      store.delete(`${this.resourceName}:${key}`);
+      return;
+    }
+
+    // Acquire lock to serialize operations
+    const releaseLock = await this.acquireLock();
+    try {
+      // Ensure storage is initialized
+      const error = await this.init();
+      if (error) {
+        // Fallback to localStorage
+        store.delete(`${this.resourceName}:${key}`);
+        return;
+      }
+
+      let storageSpec = storageCache.get(this.resourceName);
+      if (storageSpec instanceof Promise) {
+        storageSpec = await storageSpec;
+      }
+      if (!storageSpec) {
+        // Storage doesn't exist, nothing to delete
+        store.delete(`${this.resourceName}:${key}`);
+        return;
+      }
+
+      // Clone the storage spec to avoid mutating the cached object directly
+      const updatedData = { ...storageSpec.data };
+      delete updatedData[key];
+      const updatedSpec: UserStorageSpec = { data: updatedData };
+
+      const deleteResult = await apiRequest<UserStorageSpec>({
+        headers: { 'Content-Type': 'application/merge-patch+json' },
+        url: `/${this.resourceName}`,
+        method: 'PATCH',
+        body: { spec: { data: { [key]: null } } },
+        manageError: (error) => {
+          // Fallback to localStorage
+          store.delete(`${this.resourceName}:${key}`);
+          return { error };
+        },
+      });
+      if ('error' in deleteResult && deleteResult.error) {
+        // Error occurred, fallback already handled in manageError
+        return;
+      }
+      // Update global cache with the modified storage (using cloned object)
+      storageCache.set(this.resourceName, updatedSpec);
+    } finally {
+      releaseLock();
+    }
+  }
 }
 
 // This is a type alias to avoid breaking changes

--- a/packages/grafana-runtime/src/utils/userStorage.tsx
+++ b/packages/grafana-runtime/src/utils/userStorage.tsx
@@ -205,7 +205,7 @@ export class UserStorage implements UserStorageType {
         const result = await storageSpec;
         return result?.data[key] ?? null;
       }
-      return storageSpec.data[key];
+      return storageSpec.data[key] ?? null;
     } finally {
       releaseLock();
     }


### PR DESCRIPTION
**What is this feature?**

Implements a new `deleteItem` method on `UserStorage`, allowing for items to be deleted.

Also, updates `getItem` to return `null` when the key is not found.

**Why do we need this feature?**

Items could not be deleted before, only set to an empty string.

`getItem` would return `undefined` for a non-existent key, even though the typings stated it would return `null`.

**Who is this feature for?**

Developers.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
