### PR TITLE
Search: rebuild indexes missing required index features

### DIFF
--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -99,6 +99,47 @@ type IndexBuildInfo struct {
 	BuildVersion     *semver.Version // Grafana version used when originally building the index. This value doesn't change on subsequent index updates.
 	SelectableFields []string        // List of selectable fields used when index was built.
 	SearchFieldsHash string          // Hash captured at build time over the SearchFieldDefinition slices registered for (group, resource), across all versions. Empty when no SearchFieldsProvider was in use.
+	Features         []IndexFeature  // Index features the index was built with. Empty on indexes built before index features existed.
+}
+
+// IndexFeature names a mapping change an older index cannot satisfy.
+type IndexFeature string
+
+// currentIndexFeatures is recorded in every index this binary builds.
+var currentIndexFeatures = []IndexFeature{}
+
+// requiredIndexFeatures is the subset an index must already have to be used. An
+// index without one of these features is rebuilt before it serves anything, even
+// on startup, so only require a feature whose absence gives wrong answers — not
+// one that only makes results incomplete. Requiring a feature also makes every
+// existing index rebuild once.
+//
+// Every required feature must also be current, otherwise indexes rebuild forever
+// (TestRequiredIndexFeaturesAreCurrent).
+var requiredIndexFeatures = []IndexFeature{}
+
+// CurrentIndexFeatures returns the features sorted, so declaration order cannot
+// change what an index records.
+func CurrentIndexFeatures() []IndexFeature {
+	return slices.Sorted(slices.Values(currentIndexFeatures))
+}
+
+// RequiredIndexFeatures returns the features an index must have to be used.
+func RequiredIndexFeatures() []IndexFeature {
+	return slices.Sorted(slices.Values(requiredIndexFeatures))
+}
+
+// MissingIndexFeatures returns the required features the index does not have.
+// Features the index has and this binary does not require are ignored: an index
+// from a newer binary is the build version check's business.
+func MissingIndexFeatures(buildInfo IndexBuildInfo, requiredFeatures []IndexFeature) []IndexFeature {
+	var missing []IndexFeature
+	for _, feature := range requiredFeatures {
+		if !slices.Contains(buildInfo.Features, feature) {
+			missing = append(missing, feature)
+		}
+	}
+	return missing
 }
 
 type ResourceIndex interface {
@@ -216,6 +257,7 @@ type searchServer struct {
 	minBuildVersion      *semver.Version
 	buildVersion         *semver.Version
 	searchFields         *SearchFieldsRegistry
+	requiredFeatures     []IndexFeature
 
 	bgTaskWg     sync.WaitGroup
 	bgTaskCancel func()
@@ -309,6 +351,7 @@ func newSearchServer(opts SearchOptions, storage StorageBackend, vectorBackend v
 		minBuildVersion:           opts.MinBuildVersion,
 		buildVersion:              opts.BuildVersion,
 		searchFields:              searchFields,
+		requiredFeatures:          RequiredIndexFeatures(),
 		injectFailuresPercent:     opts.InjectFailuresPercent,
 		indexModificationCacheTTL: opts.IndexModificationCacheTTL,
 
@@ -1420,7 +1463,7 @@ func (s *searchServer) findIndexesToRebuild(lastImportTimes map[NamespacedResour
 		sfKey := NewLowerGroupResource(key.Group, key.Resource)
 		sfields, expectedSearchFieldsHash, _ := s.searchFields.For(sfKey)
 
-		if shouldRebuildIndex(bi, s.minBuildVersion, s.buildVersion, minBuildTime, lastImportTime, sfields, expectedSearchFieldsHash, nil) {
+		if shouldRebuildIndex(bi, s.minBuildVersion, s.buildVersion, minBuildTime, lastImportTime, sfields, expectedSearchFieldsHash, s.requiredFeatures, nil) {
 			completeCh := make(chan struct{})
 			completeChs = append(completeChs, completeCh)
 			rebuildReq := newRebuildRequest(key, minBuildTime, lastImportTime, s.minBuildVersion, sfields, expectedSearchFieldsHash, completeCh)
@@ -1491,7 +1534,7 @@ func (s *searchServer) rebuildIndex(ctx context.Context, req rebuildRequest) {
 		l.Error("failed to get build info for index to rebuild", "error", err)
 	}
 
-	rebuild := shouldRebuildIndex(bi, req.minBuildVersion, s.buildVersion, req.minBuildTime, req.lastImportTime, req.selectableFields, req.expectedSearchFieldsHash, l)
+	rebuild := shouldRebuildIndex(bi, req.minBuildVersion, s.buildVersion, req.minBuildTime, req.lastImportTime, req.selectableFields, req.expectedSearchFieldsHash, s.requiredFeatures, l)
 	if !rebuild {
 		span.AddEvent("index not rebuilt")
 		l.Info("index doesn't need to be rebuilt")
@@ -1564,7 +1607,7 @@ func (s *searchServer) rebuildIndex(ctx context.Context, req rebuildRequest) {
 	}
 }
 
-func shouldRebuildIndex(buildInfo IndexBuildInfo, minBuildVersion, maxBuildVersion *semver.Version, minBuildTime time.Time, lastImportTime time.Time, selectableFields []string, expectedSearchFieldsHash string, rebuildLogger log.Logger) bool {
+func shouldRebuildIndex(buildInfo IndexBuildInfo, minBuildVersion, maxBuildVersion *semver.Version, minBuildTime time.Time, lastImportTime time.Time, selectableFields []string, expectedSearchFieldsHash string, requiredFeatures []IndexFeature, rebuildLogger log.Logger) bool {
 	if !minBuildTime.IsZero() {
 		if buildInfo.BuildTime.IsZero() || buildInfo.BuildTime.Before(minBuildTime) {
 			if rebuildLogger != nil {
@@ -1624,6 +1667,13 @@ func shouldRebuildIndex(buildInfo IndexBuildInfo, minBuildVersion, maxBuildVersi
 	if expectedSearchFieldsHash != "" && expectedSearchFieldsHash != buildInfo.SearchFieldsHash {
 		if rebuildLogger != nil {
 			rebuildLogger.Info("search field metadata changed since the index was built, rebuilding the index")
+		}
+		return true
+	}
+
+	if missing := MissingIndexFeatures(buildInfo, requiredFeatures); len(missing) > 0 {
+		if rebuildLogger != nil {
+			rebuildLogger.Info("index is missing required features, rebuilding the index", "features", missing)
 		}
 		return true
 	}

--- a/pkg/storage/unified/resource/search_test.go
+++ b/pkg/storage/unified/resource/search_test.go
@@ -636,6 +636,15 @@ func TestCombineBuildRequests(t *testing.T) {
 	}
 }
 
+// TestRequiredIndexFeaturesAreCurrent guards the invariant that makes required
+// features safe: requiring a feature this binary never records would rebuild
+// every index on every check, forever.
+func TestRequiredIndexFeaturesAreCurrent(t *testing.T) {
+	for _, required := range RequiredIndexFeatures() {
+		require.Contains(t, CurrentIndexFeatures(), required)
+	}
+}
+
 func TestShouldRebuildIndex(t *testing.T) {
 	type testcase struct {
 		buildInfo                IndexBuildInfo
@@ -645,145 +654,171 @@ func TestShouldRebuildIndex(t *testing.T) {
 		maxBuildVersion          *semver.Version
 		selectableFields         []string
 		expectedSearchFieldsHash string
+		requiredFeatures         []IndexFeature
 
-		expected bool
+		expectedRebuild bool
 	}
 
 	now := time.Now()
 
 	for name, tc := range map[string]testcase{
 		"empty build info, with no rebuild conditions": {
-			buildInfo: IndexBuildInfo{},
-			expected:  false,
+			buildInfo:       IndexBuildInfo{},
+			expectedRebuild: false,
 		},
 		"empty build info, with minTime": {
-			buildInfo: IndexBuildInfo{},
-			minTime:   now,
-			expected:  true,
+			buildInfo:       IndexBuildInfo{},
+			minTime:         now,
+			expectedRebuild: true,
 		},
 		"empty build info, with lastImportTime": {
-			buildInfo:      IndexBuildInfo{},
-			lastImportTime: now,
-			expected:       true,
+			buildInfo:       IndexBuildInfo{},
+			lastImportTime:  now,
+			expectedRebuild: true,
 		},
 		"empty build info, with minVersion": {
 			buildInfo:       IndexBuildInfo{},
 			minBuildVersion: semver.MustParse("10.15.20"),
-			expected:        true,
+			expectedRebuild: true,
 		},
 		"build time before min time": {
-			buildInfo: IndexBuildInfo{BuildTime: now.Add(-2 * time.Hour)},
-			minTime:   now,
-			expected:  true,
+			buildInfo:       IndexBuildInfo{BuildTime: now.Add(-2 * time.Hour)},
+			minTime:         now,
+			expectedRebuild: true,
 		},
 		"build time after min time": {
-			buildInfo: IndexBuildInfo{BuildTime: now.Add(2 * time.Hour)},
-			minTime:   now,
-			expected:  false,
+			buildInfo:       IndexBuildInfo{BuildTime: now.Add(2 * time.Hour)},
+			minTime:         now,
+			expectedRebuild: false,
 		},
 		"build time before last import time": {
-			buildInfo:      IndexBuildInfo{BuildTime: now.Add(-2 * time.Hour)},
-			lastImportTime: now,
-			expected:       true,
+			buildInfo:       IndexBuildInfo{BuildTime: now.Add(-2 * time.Hour)},
+			lastImportTime:  now,
+			expectedRebuild: true,
 		},
 		"build time after last import time": {
-			buildInfo:      IndexBuildInfo{BuildTime: now.Add(2 * time.Hour)},
-			lastImportTime: now,
-			expected:       false,
+			buildInfo:       IndexBuildInfo{BuildTime: now.Add(2 * time.Hour)},
+			lastImportTime:  now,
+			expectedRebuild: false,
 		},
 		"build version before min version": {
 			buildInfo:       IndexBuildInfo{BuildVersion: semver.MustParse("10.15.19")},
 			minBuildVersion: semver.MustParse("10.15.20"),
-			expected:        true,
+			expectedRebuild: true,
 		},
 		"build version after min version": {
 			buildInfo:       IndexBuildInfo{BuildVersion: semver.MustParse("11.0.0")},
 			minBuildVersion: semver.MustParse("10.15.20"),
-			expected:        false,
+			expectedRebuild: false,
 		},
 		"build version newer than running version": {
 			buildInfo:       IndexBuildInfo{BuildVersion: semver.MustParse("12.0.0")},
 			maxBuildVersion: semver.MustParse("11.0.0"),
-			expected:        true,
+			expectedRebuild: true,
 		},
 		"build version same as running version": {
 			buildInfo:       IndexBuildInfo{BuildVersion: semver.MustParse("11.0.0")},
 			maxBuildVersion: semver.MustParse("11.0.0"),
-			expected:        false,
+			expectedRebuild: false,
 		},
 		"build version older than running version": {
 			buildInfo:       IndexBuildInfo{BuildVersion: semver.MustParse("10.0.0")},
 			maxBuildVersion: semver.MustParse("11.0.0"),
-			expected:        false,
+			expectedRebuild: false,
 		},
 		"no index build version with maxBuildVersion set": {
 			buildInfo:       IndexBuildInfo{},
 			maxBuildVersion: semver.MustParse("11.0.0"),
-			expected:        false,
+			expectedRebuild: false,
 		},
 		"index with no previous selectable fields, and no new selectable fields": {
 			buildInfo:        IndexBuildInfo{},
 			selectableFields: nil,
-			expected:         false,
+			expectedRebuild:  false,
 		},
 		"index with no previous selectable fields, with new selectable fields": {
 			buildInfo:        IndexBuildInfo{},
 			selectableFields: []string{"title"},
-			expected:         true,
+			expectedRebuild:  true,
 		},
 		"index with existing fields, and no new selectable fields": {
 			buildInfo:        IndexBuildInfo{SelectableFields: []string{"title", "team"}},
 			selectableFields: nil,
-			expected:         false,
+			expectedRebuild:  false,
 		},
 		"index with existing fields, and subset of fields": {
 			buildInfo:        IndexBuildInfo{SelectableFields: []string{"title", "team"}},
 			selectableFields: []string{"title"},
-			expected:         false,
+			expectedRebuild:  false,
 		},
 		"index with existing fields, and same selectable fields": {
 			buildInfo:        IndexBuildInfo{SelectableFields: []string{"title", "team"}},
 			selectableFields: []string{"title", "team"},
-			expected:         false,
+			expectedRebuild:  false,
 		},
 		"index with existing fields, and different selectable fields": {
 			buildInfo:        IndexBuildInfo{SelectableFields: []string{"title", "team"}},
 			selectableFields: []string{"new.title", "new.team"},
-			expected:         true,
+			expectedRebuild:  true,
 		},
 		"index with existing fields, and additional selectable fields": {
 			buildInfo:        IndexBuildInfo{SelectableFields: []string{"title", "team"}},
 			selectableFields: []string{"title", "team", "new.field"},
-			expected:         true,
+			expectedRebuild:  true,
 		},
 		"no expected hash, no stored hash": {
-			buildInfo: IndexBuildInfo{},
-			expected:  false,
+			buildInfo:       IndexBuildInfo{},
+			expectedRebuild: false,
 		},
 		"no expected hash, stored hash present": {
 			buildInfo:                IndexBuildInfo{SearchFieldsHash: "abc"},
 			expectedSearchFieldsHash: "",
-			expected:                 false,
+			expectedRebuild:          false,
 		},
 		"expected hash present, no stored hash": {
 			buildInfo:                IndexBuildInfo{},
 			expectedSearchFieldsHash: "abc",
-			expected:                 true,
+			expectedRebuild:          true,
 		},
 		"expected hash matches stored hash": {
 			buildInfo:                IndexBuildInfo{SearchFieldsHash: "abc"},
 			expectedSearchFieldsHash: "abc",
-			expected:                 false,
+			expectedRebuild:          false,
 		},
 		"expected hash differs from stored hash": {
 			buildInfo:                IndexBuildInfo{SearchFieldsHash: "abc"},
 			expectedSearchFieldsHash: "def",
-			expected:                 true,
+			expectedRebuild:          true,
+		},
+		"no features on the index, none required": {
+			buildInfo:       IndexBuildInfo{},
+			expectedRebuild: false,
+		},
+		"index has the required feature": {
+			buildInfo:        IndexBuildInfo{Features: []IndexFeature{"alpha"}},
+			requiredFeatures: []IndexFeature{"alpha"},
+			expectedRebuild:  false,
+		},
+		"index is missing a required feature": {
+			buildInfo:        IndexBuildInfo{Features: []IndexFeature{"alpha"}},
+			requiredFeatures: []IndexFeature{"alpha", "beta"},
+			expectedRebuild:  true,
+		},
+		// An index from a newer binary has features this one does not know. That is
+		// the build version check's business, not this one's.
+		"index has a feature this binary does not require": {
+			buildInfo:       IndexBuildInfo{Features: []IndexFeature{"alpha", "beta"}},
+			expectedRebuild: false,
+		},
+		"index built before features existed, one required": {
+			buildInfo:        IndexBuildInfo{},
+			requiredFeatures: []IndexFeature{"alpha"},
+			expectedRebuild:  true,
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			res := shouldRebuildIndex(tc.buildInfo, tc.minBuildVersion, tc.maxBuildVersion, tc.minTime, tc.lastImportTime, tc.selectableFields, tc.expectedSearchFieldsHash, nil)
-			require.Equal(t, tc.expected, res)
+			res := shouldRebuildIndex(tc.buildInfo, tc.minBuildVersion, tc.maxBuildVersion, tc.minTime, tc.lastImportTime, tc.selectableFields, tc.expectedSearchFieldsHash, tc.requiredFeatures, nil)
+			require.Equal(t, tc.expectedRebuild, res)
 		})
 	}
 }

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -87,6 +87,11 @@ type BleveOptions struct {
 	// May be nil in tests.
 	SearchFields *resource.SearchFieldsRegistry
 
+	// RequiredIndexFeatures overrides the index features an existing index must
+	// already have to be reused; nil means resource.RequiredIndexFeatures. Only
+	// tests set it. New indexes always record resource.CurrentIndexFeatures.
+	RequiredIndexFeatures []resource.IndexFeature
+
 	// Snapshot configures remote index snapshot download at build time.
 	// If Snapshot.Store is nil, the feature is disabled and BuildIndex behaves exactly as before.
 	Snapshot SnapshotOptions
@@ -182,6 +187,9 @@ type bleveBackend struct {
 
 	fields *resource.SearchFieldsRegistry
 
+	// Index features an existing index must have to be reused. See BleveOptions.
+	requiredFeatures []resource.IndexFeature
+
 	// Parsed opts.BuildVersion for snapshot tier comparisons. Nil if BuildVersion
 	// is empty. Guaranteed non-nil when opts.Snapshot.Store is set.
 	runningBuildVersion *semver.Version
@@ -259,6 +267,11 @@ func NewBleveBackend(opts BleveOptions, indexMetrics *resource.BleveIndexMetrics
 		fields = resource.NewSearchFieldsRegistry(nil, nil, nil)
 	}
 
+	requiredFeatures := opts.RequiredIndexFeatures
+	if requiredFeatures == nil {
+		requiredFeatures = resource.RequiredIndexFeatures()
+	}
+
 	be := &bleveBackend{
 		log:                     l,
 		cache:                   map[resource.NamespacedResource]*bleveIndex{},
@@ -266,6 +279,7 @@ func NewBleveBackend(opts BleveOptions, indexMetrics *resource.BleveIndexMetrics
 		ownsIndexFn:             ownFn,
 		indexMetrics:            indexMetrics,
 		fields:                  fields,
+		requiredFeatures:        requiredFeatures,
 		runningBuildVersion:     runningBuildVersion,
 		maxSupportedIndexFormat: maxSupportedFormat,
 		lastUploadTime:          map[resource.NamespacedResource]time.Time{},
@@ -646,6 +660,7 @@ func newBleveIndex(path string, mapper mapping.IndexMapping, buildTime time.Time
 		BuildVersion:     buildVersion,
 		SelectableFields: selectableFields,
 		SearchFieldsHash: searchFieldsHash,
+		Features:         resource.CurrentIndexFeatures(),
 	}
 
 	biBytes, err := json.Marshal(bi)
@@ -662,10 +677,23 @@ func newBleveIndex(path string, mapper mapping.IndexMapping, buildTime time.Time
 }
 
 type buildInfo struct {
-	BuildTime        int64    `json:"build_time"`                   // Unix seconds timestamp of time when the index was built
-	BuildVersion     string   `json:"build_version"`                // Grafana version used when building the index
-	SelectableFields []string `json:"selectable_fields,omitempty"`  // List of selectable fields used when index was created.
-	SearchFieldsHash string   `json:"search_fields_hash,omitempty"` // Hash over the SearchFieldDefinition slices registered for (group, resource) at build time, across every version. Empty when no SearchFieldsProvider was in use.
+	// Unix seconds timestamp of time when the index was built.
+	BuildTime int64 `json:"build_time"`
+
+	// Grafana version used when building the index.
+	BuildVersion string `json:"build_version"`
+
+	// List of selectable fields used when index was created.
+	SelectableFields []string `json:"selectable_fields,omitempty"`
+
+	// Hash over the SearchFieldDefinition slices registered for (group, resource)
+	// at build time, across every version. Empty when no SearchFieldsProvider was
+	// in use.
+	SearchFieldsHash string `json:"search_fields_hash,omitempty"`
+
+	// Index features the index was built with. Absent on indexes built before
+	// index features existed.
+	Features []resource.IndexFeature `json:"features,omitempty"`
 }
 
 type buildIndexSource int
@@ -1044,7 +1072,7 @@ func (b *bleveBackend) prepareUncachedFileIndex(
 
 func (b *bleveBackend) tryReuseFileIndex(resourceDir string, lastImportTime time.Time, logger log.Logger) (bleve.Index, string, int64, error) {
 	idx, name, rv, err := b.findPreviousFileBasedIndex(resourceDir)
-	if err != nil || idx == nil || lastImportTime.IsZero() {
+	if err != nil || idx == nil {
 		return idx, name, rv, err
 	}
 
@@ -1053,16 +1081,26 @@ func (b *bleveBackend) tryReuseFileIndex(resourceDir string, lastImportTime time
 		logger.Warn("failed to get build info from existing index", "error", err)
 		return idx, name, rv, nil
 	}
-	if bi.BuildTime <= 0 {
+
+	indexBuildTime := time.Time{}
+	if bi.BuildTime > 0 {
+		indexBuildTime = time.Unix(bi.BuildTime, 0)
+	}
+
+	// Opening an outdated index is deliberate: startup stays fast and the rebuild
+	// scan replaces it shortly after. Only an index that would answer incorrectly
+	// is rejected. An index with no build time counts as older than any import.
+	reason := ""
+	if missing := resource.MissingIndexFeatures(bi.resourceBuildInfo(), b.requiredFeatures); len(missing) > 0 {
+		reason = fmt.Sprintf("index is missing required features %v", missing)
+	} else if !lastImportTime.IsZero() && indexBuildTime.Before(lastImportTime) {
+		reason = "index was built before the last import"
+	}
+	if reason == "" {
 		return idx, name, rv, nil
 	}
 
-	indexBuildTime := time.Unix(bi.BuildTime, 0)
-	if !indexBuildTime.Before(lastImportTime) {
-		return idx, name, rv, nil
-	}
-
-	logger.Info("File-based index needs rebuild before opening", "buildTime", indexBuildTime, "lastImportTime", lastImportTime)
+	logger.Info("File-based index needs rebuild before opening", "reason", reason, "buildTime", indexBuildTime, "lastImportTime", lastImportTime)
 	_ = idx.Close()
 	// Release the registration findPreviousFileBasedIndex installed on this
 	// directory: we are discarding the reused index, so cleanOldIndexes is
@@ -1859,7 +1897,13 @@ func (b *bleveIndex) BuildInfo() (resource.IndexBuildInfo, error) {
 	if err != nil {
 		return resource.IndexBuildInfo{}, err
 	}
+	return bi.resourceBuildInfo(), nil
+}
 
+// resourceBuildInfo converts the persisted form into the one the rebuild and
+// reuse checks consume. An unparseable build version reads as unknown, so it
+// cannot make an index look newer than it is.
+func (bi buildInfo) resourceBuildInfo() resource.IndexBuildInfo {
 	bt := time.Time{}
 	if bi.BuildTime > 0 {
 		bt = time.Unix(bi.BuildTime, 0)
@@ -1878,7 +1922,8 @@ func (b *bleveIndex) BuildInfo() (resource.IndexBuildInfo, error) {
 		BuildVersion:     bv,
 		SelectableFields: bi.SelectableFields,
 		SearchFieldsHash: bi.SearchFieldsHash,
-	}, nil
+		Features:         bi.Features,
+	}
 }
 
 func (b *bleveIndex) ListManagedObjects(ctx context.Context, req *resourcepb.ListManagedObjectsRequest, stats *resource.SearchStats) (*resourcepb.ListManagedObjectsResponse, error) {

--- a/pkg/storage/unified/search/bleve_snapshot.go
+++ b/pkg/storage/unified/search/bleve_snapshot.go
@@ -416,7 +416,13 @@ func snapshotTier(v, minVersion, running *semver.Version) int {
 }
 
 // validateDownloadedIndex reads the internal RV + buildInfo from the opened
-// index to confirm the snapshot is well-formed. Returns the RV on success.
+// index to confirm the snapshot is well-formed and safe to serve. Returns the RV
+// on success.
+//
+// Snapshot selection accepts an older Grafana version (see snapshotTier), so
+// this is where a snapshot that would answer incorrectly gets rejected. That
+// costs a download first; recording index features in the snapshot metadata
+// would let selection skip such a snapshot instead. Follow-up.
 func (b *bleveBackend) validateDownloadedIndex(idx bleve.Index) (int64, error) {
 	rv, err := getRV(idx)
 	if err != nil {
@@ -425,8 +431,12 @@ func (b *bleveBackend) validateDownloadedIndex(idx bleve.Index) (int64, error) {
 	if rv <= 0 {
 		return 0, fmt.Errorf("snapshot has non-positive rv: %d", rv)
 	}
-	if _, err := getBuildInfo(idx); err != nil {
+	bi, err := getBuildInfo(idx)
+	if err != nil {
 		return 0, fmt.Errorf("reading build info: %w", err)
+	}
+	if missing := resource.MissingIndexFeatures(bi.resourceBuildInfo(), b.requiredFeatures); len(missing) > 0 {
+		return 0, fmt.Errorf("snapshot is missing required index features %v", missing)
 	}
 	return rv, nil
 }

--- a/pkg/storage/unified/search/bleve_test.go
+++ b/pkg/storage/unified/search/bleve_test.go
@@ -1142,6 +1142,86 @@ func withSearchFields(reg *resource.SearchFieldsRegistry) setupOption {
 		options.SearchFields = reg
 	}
 }
+
+func withRequiredIndexFeatures(features ...resource.IndexFeature) setupOption {
+	return func(options *BleveOptions) {
+		options.RequiredIndexFeatures = features
+	}
+}
+
+// TestBuildIndexReuseChecksRequiredFeatures covers an on-disk index built before
+// a mapping change: a binary requiring an index feature the index lacks rebuilds
+// rather than serve wrong answers, and reuses the index when it requires none.
+func TestBuildIndexReuseChecksRequiredFeatures(t *testing.T) {
+	ns := resource.NamespacedResource{Namespace: "test", Group: "group", Resource: "resource"}
+
+	const (
+		firstIndexDocsCount  = 10
+		secondIndexDocsCount = 20
+	)
+
+	for _, tc := range []struct {
+		name             string
+		required         []resource.IndexFeature
+		expectedDocCount int64
+	}{
+		{
+			name:             "no required feature reuses the index",
+			expectedDocCount: firstIndexDocsCount,
+		},
+		{
+			name:             "newly required feature rebuilds the index",
+			required:         []resource.IndexFeature{"beta"},
+			expectedDocCount: secondIndexDocsCount,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+
+			backend, _ := setupBleveBackend(t, withFileThreshold(5), withRootDir(tmpDir))
+			_, err := backend.BuildIndex(t.Context(), ns, firstIndexDocsCount, "test", indexTestDocs(ns, firstIndexDocsCount, 100), nil, false, time.Time{}, 0)
+			require.NoError(t, err)
+			backend.Stop()
+
+			newBackend, _ := setupBleveBackend(t, withFileThreshold(5), withRootDir(tmpDir), withRequiredIndexFeatures(tc.required...))
+			idx, err := newBackend.BuildIndex(t.Context(), ns, secondIndexDocsCount, "test", indexTestDocs(ns, secondIndexDocsCount, 100), nil, false, time.Time{}, 0)
+			require.NoError(t, err)
+
+			cnt, err := idx.DocCount(t.Context(), "", nil)
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedDocCount, cnt)
+		})
+	}
+}
+
+// TestValidateDownloadedIndexChecksRequiredFeatures covers the other way an
+// outdated index arrives: a snapshot from an older binary, which snapshot
+// selection accepts on version alone.
+func TestValidateDownloadedIndexChecksRequiredFeatures(t *testing.T) {
+	newIndexWithoutFeatures := func(t *testing.T) bleve.Index {
+		t.Helper()
+		idx, err := newBleveIndex("", bleve.NewIndexMapping(), time.Now(), buildVersion, nil, "")
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = idx.Close() })
+		require.NoError(t, setRV(idx, 42))
+		return idx
+	}
+
+	t.Run("accepted when no feature is required", func(t *testing.T) {
+		backend, _ := setupBleveBackend(t, withRootDir(t.TempDir()))
+
+		rv, err := backend.validateDownloadedIndex(newIndexWithoutFeatures(t))
+		require.NoError(t, err)
+		require.Equal(t, int64(42), rv)
+	})
+
+	t.Run("rejected when it lacks a required feature", func(t *testing.T) {
+		backend, _ := setupBleveBackend(t, withRootDir(t.TempDir()), withRequiredIndexFeatures("alpha"))
+
+		_, err := backend.validateDownloadedIndex(newIndexWithoutFeatures(t))
+		require.ErrorContains(t, err, "missing required index features [alpha]")
+	})
+}
 func TestMemoryBleveIndexCanBeCopiedToFilesystem(t *testing.T) {
 	mapper, err := GetBleveMappings(nil, "", "", nil)
 	require.NoError(t, err)


### PR DESCRIPTION
An index keeps the Bleve mapping it was built with, and there is no way to say that an older index would now answer incorrectly. It gets served until some unrelated signal — age, build version, a search field change — happens to trigger a rebuild.

Every index now records the features it was built with, in the build info already stored inside it, which also travels inside snapshots. An index missing a required feature is rebuilt before it serves anything: on the rebuild scan, and on both startup paths that reuse an index, a local file index and a downloaded snapshot.

Recorded and required features are separate lists, so a feature can be recorded for a release before anything requires it. Both ship empty, so nothing changes until a feature is added.

Requiring a feature is deliberately expensive — it gives up a fast start and rebuilds every index once — so it is only for changes that make older answers wrong. Merely incomplete results keep today's behaviour: the index is opened and the rebuild scan replaces it within minutes.

Also, a local index with no recorded build time used to be reused unconditionally and now rebuilds.

Follow-ups: record features in the snapshot metadata so an unusable snapshot is skipped instead of downloaded and rejected; run the rebuild scan at startup instead of waiting for the first tick.
