### PR TITLE
Provisioning: keep only latest version of Jobs and HistoricJobs

### DIFF
--- a/pkg/storage/unified/resource/pruner_history_limits.go
+++ b/pkg/storage/unified/resource/pruner_history_limits.go
@@ -7,6 +7,10 @@ const defaultPrunerHistoryLimit = 20
 // The key format is "group/resource".
 var customPrunerHistoryLimits = map[string]int{
 	"plugins.grafana.app/plugins": 3,
+	// Jobs are ephemeral work items and HistoricJobs are terminal audit
+	// records; neither benefits from a version trail, so keep only the latest.
+	"provisioning.grafana.app/jobs":         1,
+	"provisioning.grafana.app/historicjobs": 1,
 }
 
 // LookupPrunerHistoryLimit returns the history limit for the given group/resource,


### PR DESCRIPTION
## What

Reduces unified-storage version-history retention for the provisioning `Job` (`provisioning.grafana.app/jobs`) and `HistoricJob` (`provisioning.grafana.app/historicjobs`) kinds from the default of 20 versions to **1** (latest only).

## Why

Both storage backends (KV and SQL) retain up to `defaultPrunerHistoryLimit = 20` prior versions per object for any kind not special-cased in `customPrunerHistoryLimits`. Jobs are ephemeral work items that churn through status transitions (pending → working → done) and are then deleted; HistoricJobs are terminal, write-once audit records. Neither is ever read by version, so keeping 19 stale versions of each is wasted storage and pruning work with no benefit.

## How

Add both group/resource keys to the existing `customPrunerHistoryLimits` map in `pkg/storage/unified/resource/pruner_history_limits.go` with a limit of `1`. This is the same central lookup (`LookupPrunerHistoryLimit`) used by both the KV backend (`storage_backend.go`) and the SQL backend (`sql/backend.go`), so no other wiring is needed. Deletion tombstones are still preserved by the pruner regardless of the limit, so watch/informer semantics are unaffected.

The change is backwards-compatible in both directions between the unified-storage service and the API layer (per `pkg/storage/unified/AGENTS.md`): API-layer callers never depend on old versions of these objects existing.

## Testing

- `go test ./pkg/storage/unified/resource/ -run TestPruner` — pass
- `go vet ./pkg/storage/unified/resource/` — clean
- `gofmt` — clean

## Checklist

- [x] Existing pruner tests pass
- [ ] Documentation updated (n/a — internal retention default)
- [x] No breaking changes

## Note

A related follow-up (out of scope here): Jobs and HistoricJobs currently also get full bleve search indexes with no per-kind opt-out. That is wasteful for these ephemeral/audit kinds but would require adding a new group/resource-keyed hook in the search layer, so it is not addressed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)