### PR TITLE
Chore: Improve add-e2e-selectors Claude skill with Pathfinder guide support

### DIFF
--- a/.claude/skills/add-e2e-selectors/SKILL.md
+++ b/.claude/skills/add-e2e-selectors/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: add-e2e-selectors
-description: Add reliable @grafana/e2e-selectors to interactive elements and key containers in the Grafana frontend. Use when adding e2e selectors, data-testid attributes, or test selectors to React components, when a file or component lacks selectors for testing, or when asked to make elements testable. Defines versioned selectors in the e2e-selectors package and wires data-testid into JSX. Accepts an optional target (a file path, directory, or the current/open file); scans the whole project when no target is given.
+description: Add reliable @grafana/e2e-selectors to interactive elements and key containers in the Grafana frontend. Use when adding e2e selectors, data-testid attributes, or test selectors to React components, when a file or component lacks selectors for testing, or when asked to make elements testable. Also use when given a Grafana Pathfinder interactive guide (a guide directory or content.json) to audit or fix — it extracts the guide's reftarget selectors, identifies weak ones, and fixes them at the source in Grafana's JSX. Defines versioned selectors in the e2e-selectors package and wires data-testid into JSX. Accepts a file path, a list of targets, a directory, a pathfinder guide, or the current/open file.
 ---
 
 # Add e2e-selectors
@@ -16,10 +16,33 @@ correctly and don't break plugin end-to-end tests.
 Interpret the argument to decide scope:
 
 - **A file path** → only that file.
+- **A list of files or described elements** → each named target, one by one.
 - **A directory** → all `.tsx` files under it.
+- **A Grafana Pathfinder interactive guide** — a guide directory or its `content.json` (e.g.
+  under `grafana-pathfinder-app/src/bundled-interactives/`) → see "Pathfinder guide as target".
 - **"current file" / "open file" / no path but a file is open** → the open file.
-- **No argument** → the whole frontend (`public/app/`, `packages/grafana-ui/src/`). Work
-  file-by-file and summarize at the end; don't try to do everything in one pass.
+- **No argument and no open file** → ask for a target; never scan the whole frontend.
+
+### Pathfinder guide as target
+
+Interactive guides drive Grafana's UI through CSS selectors (`reftarget` fields), so a weak
+selector breaks a guide the same way it breaks a test. Process the guide, then fix the weak
+targets at the source:
+
+1. Extract targets: `grep -o '"reftarget": *"[^"]*"' <guide>/content.json`
+2. Skip navigation targets — blocks with `"action": "navigate"` or URL-shaped values
+   (starting with `/` or `http`).
+3. Classify the rest. **Strong** (leave alone): `data-testid`/`data-cy`-based selectors and
+   `grafana:` / `{grafana:...}` tokens. **Weak** (fix): text matching (`:contains`, `:text`),
+   `aria-label` / `placeholder` / `title` attributes, `href`, bare-id compounds, and positional
+   selectors (`:nth-of-type`, `:nth-child`, `:nth-match`).
+4. Locate the JSX in this repo rendering each weak target (search by id, testid fragment,
+   button text, aria-label). Some targets are not fixable here — external npm packages
+   (`@grafana/plugin-ui`, `@grafana/prometheus`), Monaco editor internals, instance data
+   (dashboard titles, datasource names) — report those instead of forcing a change.
+5. Run Steps 1–6 below for the located elements. Updating the guide itself is out of scope —
+   include a weak-selector → new-selector mapping in your summary so the guide author can adopt
+   them.
 
 ## Step 1 — Find the version key
 
@@ -27,11 +50,13 @@ All new selectors added in this run use a single version key: the current `main`
 `-pre` and build tags stripped.
 
 ```bash
-git show main:package.json | awk -F'"' '/"version": ".+"/{ print $4; exit; }'
+grep -m1 '"version"' package.json
 ```
 
-`13.2.0-pre` → use `'13.2.0'`. If you know the change will be backported, use the lowest
-release version instead. Never hardcode — always compute it.
+`13.2.0-pre` → use `'13.2.0'`. On a release branch, read main's copy instead
+(`git show main:package.json | grep -m1 '"version"'` — the local `main` ref can be stale, so
+fetch first if in doubt). If you know the change will be backported, use the lowest release
+version instead. Never hardcode — always compute it.
 
 ## Step 2 — Identify elements
 
@@ -44,6 +69,26 @@ Target these in the file:
 - **Key containers** tests scope queries to: modals, panels, page sections, dialogs.
 
 Skip any element that already has a `data-testid` or an existing selector — don't duplicate.
+
+**Exception — a static testid on a repeated item.** A hardcoded literal inside a `.map()`
+(every card rendering the same `data-testid="data-source-card"`) identifies nothing: consumers
+are forced into text matching or positional hacks to pick one item, so it's as weak as no
+selector at all. Migrate it:
+
+1. Define a parameterized selector keyed by a stable per-item value.
+2. Preserve the legacy literal as the `MIN_GRAFANA_VERSION` entry so version-resolved consumers
+   keep working against older Grafana, keeping the signature compatible:
+
+   ```typescript
+   dataSourceCard: {
+     '13.2.0': (name: string) => `data-testid data source card ${name}`,
+     [MIN_GRAFANA_VERSION]: (_name: string) => 'data-source-card',
+   },
+   ```
+
+3. Update every in-repo usage of the old literal (jest and Playwright — grep `public/` and
+   `e2e-playwright/`), and note in your summary that external code hardcoding the literal will
+   need the same one-line update.
 
 ### Loop rule (important)
 
@@ -78,6 +123,14 @@ grep -rn "<keyword>" packages/grafana-e2e-selectors/src/selectors/components.ts 
 If you're modifying UI that **already has** a selector, reuse it — creating a new one breaks
 plugin e2e tests. Only create a new selector for genuinely new UI.
 
+Two special cases the grep can surface:
+
+- **Dormant entry** — defined in the package but never wired into JSX (grep its value across
+  `public/` and `packages/`): wire it instead of creating a parallel one, adding a
+  `data-testid `-prefixed version key first if the existing value is un-prefixed.
+- **Orphaned entry** — the UI it tagged has been deleted: leave the entry in place (never
+  delete) and mention it in your summary.
+
 ## Step 4 — Confirm the element accepts a selector prop
 
 Before defining a selector for an element, confirm the target can actually receive it:
@@ -87,7 +140,10 @@ Before defining a selector for an element, confirm the target can actually recei
   Open the component and check that it either spreads remaining props onto the rendered DOM
   (`{...rest}` / `{...otherProps}` extending an `HTMLAttributes` type) **or** exposes a dedicated
   prop for the test id (e.g. grafana-ui's `Menu.Item` uses a `testId` prop, not `data-testid`).
-  Use whichever the component actually supports.
+  Use whichever the component actually supports. Known cases, to save a lookup (the source is
+  still authoritative if in doubt): `Button`, `Input`, `FilterInput`, and `ToolbarButton`
+  forward rest props, so plain `data-testid` works; `Card` spreads `htmlProps` onto its
+  container div; `Menu.Item` takes `testId`.
 
 If the component accepts **neither** `data-testid` nor an equivalent prop, **stop for that
 element** and surface it to the user — name the component, the file, and that it doesn't forward
@@ -96,10 +152,12 @@ it accept one. Move on to the remaining elements and report the skipped one in y
 
 ## Step 5 — Define the selector
 
-- **Where:** `packages/grafana-e2e-selectors/src/selectors/components.ts` for reusable
-  components; `pages.ts` for page-/screen-level elements and URLs.
+- **Where:** `packages/grafana-e2e-selectors/src/selectors/components.ts` if the element is
+  rendered on more than one route or ships in grafana-ui; `pages.ts` if it's tied to a single
+  route/screen (URLs also live there).
 - **Group:** nest under an existing group that mirrors the UI hierarchy, or add a new group
-  named after the component/page.
+  named after the component/page. Place a new group next to related groups — the files are not
+  alphabetical.
 - **Shape:** a versioned object whose key is the version from Step 1 and whose value is
   prefixed `data-testid ` (the prefix tells the framework to match the `data-testid`
   attribute rather than an aria-label):
@@ -152,6 +210,18 @@ table: {
 },
 ```
 
+  Parameterize by a **stable value** (a uid, refId, or `from`/`to` token), never by display
+  text — translated or user-editable text reintroduces the i18n fragility the selector exists
+  to remove. Prefer a single parameter: some consumers (e.g. Pathfinder `{grafana:path:param}`
+  tokens) can only pass one. When adding a version key to a function selector, keep the
+  signature compatible across all keys (see the migration example in Step 2).
+
+- **Upgrading legacy aria-label entries.** A value without the `data-testid ` prefix tells the
+  framework to match `aria-label` instead. Don't add aria-labels to JSX just to satisfy such an
+  entry — the upgrade path is to add a new prefixed version key to the *existing* entry and wire
+  `data-testid` in the JSX. Keep an aria-label only where it carries genuine accessibility value
+  (see "Aria-Labels vs data-testid" in `contribute/style-guides/e2e-playwright.md`).
+
 - **Never edit or delete an existing entry.** To change an existing selector's value, add a
   **new version key** alongside the old one and keep the signature backwards compatible.
 
@@ -166,6 +236,20 @@ table: {
   Expect **zero** matches other than the entry you just added. Also confirm the new values are
   unique against each other within this run. If a value collides, pick a more specific one
   (include the component/page name and the element's role).
+
+- **Check for in-flight collisions.** `components.ts` and `pages.ts` are hot files — someone may
+  be adding selectors for the same UI right now. Before finalizing group names and values, scan
+  open PRs touching them: `gh pr list --search "e2e-selectors" --state open`. Always avoid group
+  names and values those PRs introduce. What to do about overlapping *UI* depends on why you're
+  touching it:
+  - **The element was explicitly requested** (named in the task, or a weak guide target you were
+    asked to fix): do the work anyway and surface the overlap in your summary — an open draft PR
+    is not a reason to silently return nothing the user asked for. If the PR's approach conflicts
+    with this skill's rules (e.g. it satisfies a legacy entry with an aria-label), say so; the
+    user decides which lands.
+  - **You found the element during open-ended discovery** (directory sweep, guide scan choosing
+    among many candidates): skip UI an open PR already covers and spend the effort on uncovered
+    targets instead.
 
 ## Step 6 — Apply in JSX
 
@@ -220,13 +304,24 @@ plain DOM elements set the attribute literally.
 - New selectors use the version key from Step 1 (no `-pre`/build tags).
 - To change a value, add a new version key — don't edit the old value or change the signature.
 - In loops, selector goes on the row/container, not each inner element.
+- A static testid on a repeated item is as weak as none — migrate it to a parameterized
+  selector, preserving the legacy literal as the `MIN_GRAFANA_VERSION` entry and updating every
+  in-repo usage of the old literal.
+- Wire dormant (defined-but-never-used) entries instead of creating parallel ones; report
+  orphaned entries, never delete them.
+- Function-selector parameters are stable values (uid, refId, tokens), never display text;
+  prefer a single parameter.
 
 See `packages/grafana-e2e-selectors/src/selectors/README.md` and
 `contribute/style-guides/e2e-playwright.md` for the authoritative guidance.
 
 ## Verify
 
-- `yarn typecheck` — confirms the selector path and any function signature resolve.
+- `yarn typecheck` — confirms the selector path and any function signature resolve. This runs
+  the whole monorepo and takes several minutes; that's expected.
+- If a literal testid was replaced (Step 2 exception), grep the old literal across `public/`
+  and `e2e-playwright/` — expect zero remaining references.
 - Selectors are resolved at runtime by the package's resolver; **no codegen step** is needed
   after editing `components.ts` / `pages.ts`.
-- Optionally `yarn lint` the changed files.
+- `yarn lint` the changed files — the `import/order` rule cares where the new
+  `@grafana/e2e-selectors` import lands (alphabetical within the `@grafana/*` group).


### PR DESCRIPTION
**What is this feature?**

Improves the `add-e2e-selectors` Claude skill (`.claude/skills/add-e2e-selectors/SKILL.md`) with policies learned from a real end-to-end run (the walkthrough behind #129398):

- **Pathfinder guide target mode** (replaces the whole-frontend scan): point the skill at a guide directory/`content.json` and it extracts `reftarget`s, classifies weak selectors, and fixes them at the source
- Migration recipe for static testids on repeated items (parameterize; preserve the legacy literal as the `MIN_GRAFANA_VERSION` entry; update in-repo usages)
- Upgrade path for legacy aria-label entries (add a prefixed version key, wire `data-testid` — don't add aria-labels to satisfy entries)
- Dormant/orphaned selector entry handling, stable function-selector parameters, `pages.ts` vs `components.ts` boundary rule, in-flight PR collision check scoped by task type, richer verify guidance

**Why do we need this feature?**

The skill was silent on several decisions that had to be invented mid-run. Validated with a 3-eval subagent benchmark against the previous skill version: new skill 18/18 assertions, baseline 15/18 (baseline failures were exactly the documented gaps).

**Who is this feature for?**

Anyone using Claude Code in this repo to add e2e selectors or fix weak Pathfinder guide selectors.

**Which issue(s) does this PR fix?**:

Fixes n/a

**Special notes for your reviewer:**

Docs/tooling only — no runtime code changes. Note `.gitignore` re-includes this path via `!.claude/skills/add-e2e-selectors`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)