### PR TITLE
docs: remove deprecated Go Report Card badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 The open-source platform for monitoring and observability
 
 [![License](https://img.shields.io/github/license/grafana/grafana)](LICENSE)
-[![Go Report Card](https://goreportcard.com/badge/github.com/grafana/grafana)](https://goreportcard.com/report/github.com/grafana/grafana)
 
 Grafana allows you to query, visualize, alert on and understand your metrics no matter where they are stored. Create, explore, and share dashboards with your team and foster a data-driven culture:
 


### PR DESCRIPTION
## What
Removes the Go Report Card badge from the top of `README.md`. The License badge is kept.

## Why
Go Report Card has been [sunset](https://goreportcard.com/) after more than a decade, and its repository ([gojp/goreportcard](https://github.com/gojp/goreportcard)) was archived and made read-only on 2026-07-01. The badge now points at a deprecated service, so it no longer provides a meaningful code-quality signal.

There is no direct drop-in replacement badge. If a code-quality/coverage signal is desired later, alternatives such as Codecov or a CodeQL status badge could be wired up, but none is currently configured in this repo — so the badge is simply removed rather than swapped.

## How
Deleted the single badge line in `README.md`. No other changes.

## Testing
- Docs-only change; rendered the README locally to confirm the remaining License badge displays correctly and no broken markdown remains.

## Checklist
- [x] Tests added/updated (N/A — docs only)
- [x] Documentation updated
- [x] No breaking changes

🤖 Generated with Claude Code