### PR TITLE
User Storage: Implement allItems method

### DIFF
--- a/packages/grafana-data/src/types/userStorage.ts
+++ b/packages/grafana-data/src/types/userStorage.ts
@@ -18,4 +18,9 @@ export interface UserStorage {
    * @returns A promise that resolves when the item is deleted.
    */
   deleteItem(key: string): Promise<void>;
+  /**
+   * Returns all items from the backend user storage or local storage if not enabled.
+   * @returns A promise that resolves to a record of all key-value pairs.
+   */
+  allItems(): Promise<Record<string, string>>;
 }

--- a/packages/grafana-data/src/utils/store.test.ts
+++ b/packages/grafana-data/src/utils/store.test.ts
@@ -14,6 +14,15 @@ describe('Store', () => {
               delete target[key];
             };
           }
+          if (prop === 'length') {
+            return Object.keys(target).length;
+          }
+          if (prop === 'key') {
+            return (index: number) => Object.keys(target)[index] ?? null;
+          }
+          if (prop === 'getItem') {
+            return (key: string) => target[key] ?? null;
+          }
           return target[prop as string];
         },
         set(target, prop, value) {
@@ -78,6 +87,40 @@ describe('Store', () => {
       expect(store.get(testKey)).toBe(undefined);
 
       expect(window.localStorage[testKey]).toBe(undefined);
+    });
+  });
+
+  describe('all', () => {
+    it('returns all keys', () => {
+      store.set('service:user:key1', 'value1');
+      store.set('service:user:key2', 'value2');
+      store.set('other:user:key3', 'value3');
+
+      const result = store.all();
+
+      expect(result).toEqual({
+        'service:user:key1': 'value1',
+        'service:user:key2': 'value2',
+        'other:user:key3': 'value3',
+      });
+    });
+
+    it('returns all keys matching the given prefix', () => {
+      store.set('service:user:key1', 'value1');
+      store.set('service:user:key2', 'value2');
+      store.set('other:user:key3', 'value3');
+
+      const result = store.all('service:user:');
+
+      expect(result).toEqual({ key1: 'value1', key2: 'value2' });
+    });
+
+    it('returns empty object when no keys match the prefix', () => {
+      store.set('other:user:key1', 'value1');
+
+      const result = store.all('service:user:');
+
+      expect(result).toEqual({});
     });
   });
 });

--- a/packages/grafana-data/src/utils/store.ts
+++ b/packages/grafana-data/src/utils/store.ts
@@ -110,6 +110,25 @@ export class Store {
     this.storage?.removeItem(key);
     this.notifySubscribers(key);
   }
+
+  all(prefix?: string): Record<string, string> {
+    const result: Record<string, string> = {};
+    const storage = this.storage;
+    if (!storage) {
+      return result;
+    }
+    for (let i = 0; i < storage.length; i++) {
+      const rawKey = storage.key(i);
+      if (rawKey && rawKey.startsWith(prefix ?? '')) {
+        const key = rawKey.slice(prefix?.length ?? 0);
+        const value = storage.getItem(rawKey);
+        if (value !== null) {
+          result[key] = value;
+        }
+      }
+    }
+    return result;
+  }
 }
 
 export const store = new Store();

--- a/packages/grafana-runtime/src/utils/userStorage.test.tsx
+++ b/packages/grafana-runtime/src/utils/userStorage.test.tsx
@@ -338,6 +338,70 @@ describe('userStorage', () => {
     });
   });
 
+  describe('allItems', () => {
+    it('uses localStorage if the user is not logged in', async () => {
+      config.bootData.user.isSignedIn = false;
+      getStoreMocks().all = jest.fn().mockReturnValue({ key: 'value' });
+      const storage = renderHook(() => usePluginUserStorage()).result.current;
+      const result = await storage.allItems();
+      expect(getStoreMocks().all).toHaveBeenCalledWith('plugin-id:abc:');
+      expect(result).toEqual({ key: 'value' });
+    });
+
+    it('returns all items from user storage', async () => {
+      request.mockReturnValue(
+        Promise.resolve({
+          status: 200,
+          data: { spec: { data: { key1: 'value1', key2: 'value2' } } },
+        } as FetchResponse)
+      );
+      const storage = renderHook(() => usePluginUserStorage()).result.current;
+      const result = await storage.allItems();
+      expect(result).toEqual({ key1: 'value1', key2: 'value2' });
+    });
+
+    it('returns empty object when user storage is not found', async () => {
+      request.mockReturnValue(Promise.reject({ status: 404 } as FetchError));
+      getStoreMocks().all = jest.fn().mockReturnValue({});
+      const storage = renderHook(() => usePluginUserStorage()).result.current;
+      const result = await storage.allItems();
+      expect(result).toEqual({});
+    });
+
+    it('returns a copy of the cached data without additional network requests', async () => {
+      request.mockReturnValueOnce(
+        Promise.resolve({
+          status: 200,
+          data: { spec: { data: { key1: 'value1', key2: 'value2' } } },
+        } as FetchResponse)
+      );
+      const storage = renderHook(() => usePluginUserStorage()).result.current;
+      // Prime the cache
+      await storage.getItem('key1');
+      request.mockReset();
+      // allItems should use the cache
+      const result = await storage.allItems();
+      expect(request).not.toHaveBeenCalled();
+      expect(result).toEqual({ key1: 'value1', key2: 'value2' });
+    });
+
+    it('returns data reflecting updates from setItem', async () => {
+      request.mockReturnValueOnce(
+        Promise.resolve({
+          status: 200,
+          data: { spec: { data: { key1: 'old' } } },
+        } as FetchResponse)
+      );
+      request.mockReturnValueOnce(Promise.resolve({ status: 200 } as FetchResponse));
+      const storage = renderHook(() => usePluginUserStorage()).result.current;
+      await storage.setItem('key1', 'new');
+      request.mockReset();
+      const result = await storage.allItems();
+      expect(request).not.toHaveBeenCalled();
+      expect(result).toEqual({ key1: 'new' });
+    });
+  });
+
   describe('Cache behavior', () => {
     it('multiple instances share the same network request', async () => {
       request.mockReturnValue(

--- a/packages/grafana-runtime/src/utils/userStorage.tsx
+++ b/packages/grafana-runtime/src/utils/userStorage.tsx
@@ -340,6 +340,31 @@ export class UserStorage implements UserStorageType {
       releaseLock();
     }
   }
+
+  async allItems(): Promise<Record<string, string>> {
+    if (!this.canUseUserStorage) {
+      // Fallback to localStorage
+      return store.all(`${this.resourceName}:`);
+    }
+
+    // Acquire lock to serialize operations
+    const releaseLock = await this.acquireLock();
+    try {
+      // Ensure storage is initialized
+      await this.init();
+      let storageSpec = storageCache.get(this.resourceName);
+      if (storageSpec instanceof Promise) {
+        storageSpec = await storageSpec;
+      }
+      if (!storageSpec) {
+        // Storage doesn't exist, fallback to localStorage
+        return store.all(`${this.resourceName}:`);
+      }
+      return { ...storageSpec.data };
+    } finally {
+      releaseLock();
+    }
+  }
 }
 
 // This is a type alias to avoid breaking changes


### PR DESCRIPTION
**What is this feature?**

Implements a new `allItems` method on `UserStorage`, allowing for all items to be retrieved from storage.

**Why do we need this feature?**

Two main use cases:

- Making a single async call when many values from storage are required
- Enabling the deletion of keys that aren't in a known in-use set

**Who is this feature for?**

Developers,

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
