### PR TITLE
Storage: Retry unconditional deletes on resource version conflict

### DIFF
--- a/pkg/storage/unified/apistore/store.go
+++ b/pkg/storage/unified/apistore/store.go
@@ -363,15 +363,16 @@ func (s *Storage) Delete(
 	// surfacing the conflict; explicit preconditions are re-checked against
 	// the fresh read each attempt. This mirrors the upstream etcd3
 	// conditionalDelete retry loop.
-	for attempt := 1; ; attempt++ {
+	k, err := s.getKey(key)
+	if err != nil {
+		return storage.NewKeyNotFoundError(key, 0)
+	}
+
+	for attempt := 1; attempt <= MaxUpdateAttempts; attempt++ {
 		if err := s.Get(ctx, key, storage.GetOptions{}, out); err != nil {
 			return err
 		}
 
-		k, err := s.getKey(key)
-		if err != nil {
-			return err
-		}
 		cmd := &resourcepb.DeleteRequest{Key: k}
 
 		if preconditions != nil {
@@ -418,6 +419,8 @@ func (s *Storage) Delete(
 
 		return s.versioner.UpdateObject(out, uint64(rsp.ResourceVersion))
 	}
+
+	return nil
 }
 
 // This version is not yet passing the watch tests

--- a/pkg/storage/unified/apistore/store.go
+++ b/pkg/storage/unified/apistore/store.go
@@ -356,59 +356,69 @@ func (s *Storage) Delete(
 		return errors.New("missing auth info")
 	}
 
-	if err := s.Get(ctx, key, storage.GetOptions{}, out); err != nil {
-		return err
-	}
-
 	k, err := s.getKey(key)
 	if err != nil {
 		return err
 	}
-	cmd := &resourcepb.DeleteRequest{Key: k}
 
-	if preconditions != nil {
-		if err := preconditions.Check(key, out); err != nil {
+	// The delete is conditional on the resource version read here, so a
+	// concurrent write (e.g. a controller status update) between the read and
+	// the delete produces a conflict. Callers of an unconditional delete never
+	// supplied that resource version, so re-read and retry rather than
+	// surfacing the conflict; explicit preconditions are re-checked against
+	// the fresh read each attempt. This mirrors the upstream etcd3
+	// conditionalDelete retry loop.
+	for attempt := 1; ; attempt++ {
+		if err := s.Get(ctx, key, storage.GetOptions{}, out); err != nil {
 			return err
 		}
-		if preconditions.UID != nil {
-			cmd.Uid = string(*preconditions.UID)
+
+		cmd := &resourcepb.DeleteRequest{Key: k}
+
+		if preconditions != nil {
+			if err := preconditions.Check(key, out); err != nil {
+				return err
+			}
+			if preconditions.UID != nil {
+				cmd.Uid = string(*preconditions.UID)
+			}
 		}
-	}
 
-	if validateDeletion != nil {
-		if err := validateDeletion(ctx, out); err != nil {
-			return err
+		if validateDeletion != nil {
+			if err := validateDeletion(ctx, out); err != nil {
+				return err
+			}
 		}
-	}
 
-	meta, err := utils.MetaAccessor(out)
-	if err != nil {
-		return fmt.Errorf("unable to read object %w", err)
-	}
-	if err = checkManagerPropertiesOnDelete(info, meta); err != nil {
-		return s.handleManagedResourceRouting(ctx, err, resourcepb.WatchEvent_DELETED, key, out, out)
-	}
+		meta, err := utils.MetaAccessor(out)
+		if err != nil {
+			return fmt.Errorf("unable to read object %w", err)
+		}
+		if err = checkManagerPropertiesOnDelete(info, meta); err != nil {
+			return s.handleManagedResourceRouting(ctx, err, resourcepb.WatchEvent_DELETED, key, out, out)
+		}
 
-	cmd.ResourceVersion, err = meta.GetResourceVersionInt64()
-	if err != nil {
-		return resource.GetError(resource.AsErrorResult(err))
-	}
-	rsp, err := s.store.Delete(ctx, cmd)
-	if err != nil {
-		return resource.GetError(resource.AsErrorResult(err))
-	}
-	if rsp.Error != nil {
-		return resource.GetError(rsp.Error)
-	}
+		cmd.ResourceVersion, err = meta.GetResourceVersionInt64()
+		if err != nil {
+			return resource.GetError(resource.AsErrorResult(err))
+		}
+		rsp, err := s.store.Delete(ctx, cmd)
+		if err != nil {
+			return resource.GetError(resource.AsErrorResult(err))
+		}
+		if rsp.Error != nil {
+			if rsp.Error.Code == http.StatusConflict && attempt < MaxUpdateAttempts {
+				continue
+			}
+			return resource.GetError(rsp.Error)
+		}
 
-	if err = handleSecureValuesDelete(ctx, s.opts.SecureValues, meta); err != nil {
-		logging.FromContext(ctx).Warn("failed to delete inline secure values", "err", err)
-	}
+		if err = handleSecureValuesDelete(ctx, s.opts.SecureValues, meta); err != nil {
+			logging.FromContext(ctx).Warn("failed to delete inline secure values", "err", err)
+		}
 
-	if err := s.versioner.UpdateObject(out, uint64(rsp.ResourceVersion)); err != nil {
-		return err
+		return s.versioner.UpdateObject(out, uint64(rsp.ResourceVersion))
 	}
-	return nil
 }
 
 // This version is not yet passing the watch tests

--- a/pkg/storage/unified/apistore/store.go
+++ b/pkg/storage/unified/apistore/store.go
@@ -356,11 +356,6 @@ func (s *Storage) Delete(
 		return errors.New("missing auth info")
 	}
 
-	k, err := s.getKey(key)
-	if err != nil {
-		return err
-	}
-
 	// The delete is conditional on the resource version read here, so a
 	// concurrent write (e.g. a controller status update) between the read and
 	// the delete produces a conflict. Callers of an unconditional delete never
@@ -373,6 +368,10 @@ func (s *Storage) Delete(
 			return err
 		}
 
+		k, err := s.getKey(key)
+		if err != nil {
+			return err
+		}
 		cmd := &resourcepb.DeleteRequest{Key: k}
 
 		if preconditions != nil {

--- a/pkg/storage/unified/apistore/store_test.go
+++ b/pkg/storage/unified/apistore/store_test.go
@@ -234,6 +234,13 @@ func TestDeleteWithSuggestionAndConflict(t *testing.T) {
 	storagetesting.RunTestDeleteWithSuggestionAndConflict(ctx, t, store)
 }
 
+func TestDeleteWithConflict(t *testing.T) {
+	ctx, store, destroyFunc, err := testSetup(t)
+	defer destroyFunc()
+	assert.NoError(t, err)
+	storagetesting.RunTestDeleteWithConflict(ctx, t, store)
+}
+
 type resourceClientMock struct {
 	resourcepb.ResourceStoreClient
 	resourcepb.ResourceStatsClient


### PR DESCRIPTION
**What is this feature?**

Unified storage now retries a delete when it hits a resource version conflict, instead of failing the request. The delete is internally conditional on the version read just before it. If something else writes to the object in that window, for example a controller updating its status, the delete failed with a conflict error even though the caller never asked for a conditional delete. Deletes now re-read the object and try again, while deletes that explicitly ask for a specific version still fail if that version no longer matches. This matches how the Kubernetes etcd storage layer behaves, and how updates already behave in unified storage.

**Why do we need this feature?**

Resources that are actively reconciled by a controller, such as provisioning connections and repositories, could randomly fail to delete right after creation. This has been causing recurring flaky integration tests (TestIntegrationProvisioning_ConnectionDeleteWithNoReferences, TestIntegrationV1Beta1Connection_Get) and can produce spurious conflict errors for real clients deleting such resources.

**Who is this feature for?**

Anyone deleting resources backed by unified storage, and everyone tired of these flaky tests.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Client-side change only, no storage server or contract changes.

---
Description generated by Claude Code.