### PR TITLE
Home: anchor solution sparklines at zero

### DIFF
--- a/public/app/features/home/Recommendations/SolutionSparkline.tsx
+++ b/public/app/features/home/Recommendations/SolutionSparkline.tsx
@@ -10,6 +10,7 @@ const SPARKLINE_HEIGHT = 56;
 // stable config reference across renders.
 const sparklineConfig: FieldConfig<GraphFieldConfig> = {
   color: { mode: 'fixed', fixedColor: 'blue' },
+  min: 0,
   custom: {
     lineWidth: 2,
     fillOpacity: 30,


### PR DESCRIPTION
## Summary

Anchors the shared homepage solution sparkline at zero so small changes in otherwise steady signals are not visually exaggerated. This applies consistently to every existing-solution card that renders a trend.
