### PR TITLE
Datasources: Capture panel images for diagnostics bundles (frontend)

### DIFF
--- a/public/app/features/dashboard-scene/sharing/DownloadDashboardDiagnostics.tsx
+++ b/public/app/features/dashboard-scene/sharing/DownloadDashboardDiagnostics.tsx
@@ -2,9 +2,9 @@ import { css } from '@emotion/css';
 import { useEffect, useRef, useState } from 'react';
 import { useAsyncFn } from 'react-use';
 
-import { type GrafanaTheme2 } from '@grafana/data';
+import { LoadingState, type GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { isFetchError } from '@grafana/runtime';
+import { isFetchError, logError } from '@grafana/runtime';
 import {
   sceneGraph,
   type SceneComponentProps,
@@ -12,11 +12,13 @@ import {
   type SceneObject,
   SceneObjectBase,
   type SceneObjectRef,
+  type SceneDataProvider,
   SceneQueryRunner,
   VizPanel,
 } from '@grafana/scenes';
 import { type DataQuery } from '@grafana/schema';
 import { Alert, Button, useStyles2 } from '@grafana/ui';
+import { capturePanelScreenshot } from 'app/features/query/diagnostics/capturePanelScreenshot';
 import {
   type DashboardDiagnosticsPanel,
   downloadDashboardDiagnostics,
@@ -33,6 +35,10 @@ import { type SceneShareTabState, type ShareView } from './types';
 // generation timeout) before giving up client-side.
 const POLL_INTERVAL_MS = 1000;
 const MAX_POLL_ATTEMPTS = 300;
+
+// How long to wait for one panel's data before capturing it anyway. Bounded
+// so a single panel whose query never settles cannot hold up the whole bundle.
+const PANEL_DATA_TIMEOUT_MS = 15_000;
 
 export interface DownloadDashboardDiagnosticsState extends SceneShareTabState {
   dashboardRef?: SceneObjectRef<DashboardScene>;
@@ -51,7 +57,7 @@ export class DownloadDashboardDiagnostics
   public getSubtitle() {
     return t(
       'dashboard.diagnostics.subtitle-dashboard',
-      'Bundle HTTP traffic (HAR) and panel JSON for every panel in this dashboard to help troubleshoot.'
+      'Bundle HTTP traffic (HAR), panel JSON, and a screenshot for every panel in this dashboard to help troubleshoot.'
     );
   }
 }
@@ -72,6 +78,11 @@ function getQueryRunnerFor(sceneObject: SceneObject | undefined): SceneQueryRunn
   return undefined;
 }
 
+// Reported through logError rather than surfaced in the UI or written to the console: on a whole-dashboard
+// run an individual panel can legitimately fail to capture, so an alert per miss would be noise, and the
+// manifest records each reason anyway.
+const SCREENSHOT_FAILURE_MESSAGE = 'Download diagnostics: failed to capture panel screenshot for';
+
 // panel.state.key is "panel-<id>"; parse the numeric id without importing utils (import cycle, as above).
 // Mirrors getPanelIdForVizPanel in dashboard-scene/utils/utils.ts, including its non-null assertion:
 // every VizPanel in the scene graph is keyed this way, so an undefined key indicates a real bug
@@ -91,7 +102,7 @@ async function collectDashboardPanels(dashboard: DashboardScene): Promise<Dashbo
   // Promise.all preserves scene-graph order, and null entries (non-VizPanels, panels with no active
   // queries such as text panels) are dropped afterwards.
   const collected = await Promise.all(
-    vizPanels.map(async (obj): Promise<DashboardDiagnosticsPanel | null> => {
+    vizPanels.map(async (obj): Promise<{ panel: VizPanel; entry: DashboardDiagnosticsPanel } | null> => {
       const panel = obj instanceof VizPanel ? obj : undefined;
       if (!panel) {
         return null;
@@ -119,16 +130,107 @@ async function collectDashboardPanels(dashboard: DashboardScene): Promise<Dashbo
       // save-model elements), so the id has to match that source panel for the backend to resolve its
       // panel JSON. Each clone still gets its own array entry, so its captured queries aren't lost.
       return {
-        id: panelIdFrom(panel),
-        title: panel.state.title ?? '',
-        from: String(timeRange.from.valueOf()),
-        to: String(timeRange.to.valueOf()),
-        queries,
+        panel,
+        entry: {
+          id: panelIdFrom(panel),
+          title: panel.state.title ?? '',
+          from: String(timeRange.from.valueOf()),
+          to: String(timeRange.to.valueOf()),
+          queries,
+        },
       };
     })
   );
 
-  return collected.filter((panel): panel is DashboardDiagnosticsPanel => panel !== null);
+  const resolved = collected.filter((c): c is { panel: VizPanel; entry: DashboardDiagnosticsPanel } => c !== null);
+  await attachPanelScreenshots(resolved);
+  return resolved.map((c) => c.entry);
+}
+
+/**
+ * Captures every panel and attaches the PNG to its request entry.
+ *
+ * The problem this solves: on a dashboard taller than the viewport, most panels have never run their
+ * queries. Scenes wraps each panel in `LazyLoader` with `mode="query"`, which mounts the panel's DOM
+ * immediately but forwards viewport intersection to its query runner; `SceneQueryRunner.runWithTimeRange`
+ * then skips the query outright while the panel is out of view. Capturing as-is would yield an empty
+ * "No data" image for every panel below the fold -- worse than no image, because it is indistinguishable
+ * from the empty-panel bug the bundle usually exists to diagnose.
+ *
+ * So each panel's query runner is told to ignore the viewport (`bypassIsInViewChanged`, the same lever
+ * the dashboard datasource uses to read an off-screen source panel), its data is awaited, and only then
+ * is it captured. An off-screen panel paints normally once it has data -- it is in the layout, merely
+ * scrolled past -- so nothing has to be scrolled into view and the user's scroll position is untouched.
+ *
+ * Bypass is enabled for every panel up front so their queries run concurrently, then captures are taken
+ * one at a time: capture is main-thread work (the renderer walks every stylesheet in the document), so
+ * running them in parallel would not make it faster.
+ */
+async function attachPanelScreenshots(items: Array<{ panel: VizPanel; entry: DashboardDiagnosticsPanel }>) {
+  const providers = items.map(({ panel }) => getDataProviderFor(panel));
+  providers.forEach((provider) => provider?.bypassIsInViewChanged?.(true));
+
+  try {
+    for (const [index, { panel, entry }] of items.entries()) {
+      const onError = (error: Error) =>
+        logError(error, { context: SCREENSHOT_FAILURE_MESSAGE, panelKey: panel.state.key ?? '' });
+      try {
+        await waitForPanelData(providers[index]);
+      } catch (error) {
+        // A panel whose data never settles is still worth capturing -- whatever it shows (a spinner, an
+        // error, "No data") is what the user would see, and the reason is reported either way.
+        onError(error instanceof Error ? error : new Error(String(error)));
+      }
+      // requireInViewport is off here precisely because the wait above removed the reason for it.
+      entry.screenshot = await capturePanelScreenshot(panel.getPathId(), onError, { requireInViewport: false });
+    }
+  } finally {
+    // Always hand the viewport back to the query runners, even if a capture threw: leaving bypass on
+    // would keep off-screen panels refreshing for the rest of the session.
+    providers.forEach((provider) => provider?.bypassIsInViewChanged?.(false));
+  }
+}
+
+/** The panel's data provider (a query runner, or the transformer wrapping one). Repeat clones share the
+ * provider with their parent, hence the parent fallback -- same lookup the drawers already use. */
+function getDataProviderFor(panel: VizPanel): SceneDataProvider | undefined {
+  return panel.state.$data ?? panel.parent?.state.$data;
+}
+
+function hasSettled(provider: SceneDataProvider): boolean {
+  const state = provider.state.data?.state;
+  return state === LoadingState.Done || state === LoadingState.Error;
+}
+
+/**
+ * Waits for the provider to reach a terminal state, bounded so one stuck panel can't hold the bundle.
+ *
+ * Returns immediately when there is nothing to wait for: no provider, an **inactive** one, or data that
+ * has already settled. The inactive check is the important one -- an inactive provider never runs its
+ * queries, so waiting on it would burn the full timeout per panel for a result that is never coming.
+ *
+ * Event-driven rather than polled, so a result that arrives early is not waited out.
+ */
+function waitForPanelData(provider: SceneDataProvider | undefined): Promise<void> {
+  if (!provider || !provider.isActive || hasSettled(provider)) {
+    return Promise.resolve();
+  }
+  return new Promise((resolve, reject) => {
+    const finish = (settle: () => void) => {
+      clearTimeout(timer);
+      subscription.unsubscribe();
+      settle();
+    };
+    const timer = setTimeout(
+      () => finish(() => reject(new Error(`panel data did not settle within ${PANEL_DATA_TIMEOUT_MS}ms`))),
+      PANEL_DATA_TIMEOUT_MS
+    );
+    const subscription = provider.subscribeToState(() => {
+      if (hasSettled(provider)) {
+        finish(resolve);
+      }
+    });
+  });
 }
 
 // The download uses blob/json fetches whose FetchError carries the detail in status/statusText, so
@@ -223,8 +325,8 @@ function DownloadDashboardDiagnosticsRenderer({ model }: SceneComponentProps<Dow
         title={t('dashboard.diagnostics.sensitive-warning-title', 'May contain sensitive data')}
       >
         <Trans i18nKey="dashboard.diagnostics.sensitive-warning-body">
-          The bundle can include request headers, query parameters, and server log lines. Review it before sharing
-          outside your organization.
+          The bundle can include request headers, query parameters, server log lines, and images of the panels as
+          currently displayed. Review it before sharing outside your organization.
         </Trans>
       </Alert>
 

--- a/public/app/features/dashboard-scene/sharing/DownloadDiagnostics.tsx
+++ b/public/app/features/dashboard-scene/sharing/DownloadDiagnostics.tsx
@@ -17,6 +17,7 @@ import {
 } from '@grafana/scenes';
 import { type DataQuery } from '@grafana/schema';
 import { Alert, Button, useStyles2 } from '@grafana/ui';
+import { capturePanelScreenshot } from 'app/features/query/diagnostics/capturePanelScreenshot';
 import { downloadDiagnosticsForQueries } from 'app/features/query/diagnostics/downloadDiagnostics';
 import { interpolateDiagnosticsQueries } from 'app/features/query/diagnostics/interpolateQueries';
 
@@ -41,12 +42,14 @@ export class DownloadDiagnostics extends SceneObjectBase<DownloadDiagnosticsStat
   public getSubtitle() {
     return t(
       'dashboard.diagnostics.subtitle-panel',
-      'Bundle HTTP traffic (HAR), logs, and panel JSON to help troubleshoot this panel.'
+      'Bundle HTTP traffic (HAR), logs, panel JSON, and a screenshot of this panel to help troubleshoot it.'
     );
   }
 }
 
 const SAVE_MODEL_FAILURE_MESSAGE = 'Download diagnostics: failed to build panel/dashboard JSON, bundling without it';
+const SCREENSHOT_FAILURE_MESSAGE =
+  'Download diagnostics: failed to capture panel screenshot, bundling without panel.png';
 
 // Inlined rather than imported from dashboard-scene/utils/utils: that module transitively reaches
 // DashboardScene, which imports ShareDrawer (which imports this view), creating an import cycle.
@@ -160,6 +163,17 @@ function DownloadDiagnosticsRenderer({ model }: SceneComponentProps<DownloadDiag
     const controller = new AbortController();
     abortRef.current = controller;
 
+    // Capture the panel before anything else awaits. The drawer overlays the dashboard without
+    // reflowing it, so the panel is still mounted at the size the user was looking at; capturing first
+    // keeps panel.png a picture of that, taken before the diagnostic re-run produces different data.
+    // Best-effort: a failure is logged and the bundle ships without panel.png.
+    const screenshot = await capturePanelScreenshot(panel.getPathId(), (error) => {
+      logError(error, { context: SCREENSHOT_FAILURE_MESSAGE, panelKey: panel.state.key ?? '' });
+    });
+    if (controller.signal.aborted) {
+      return;
+    }
+
     // Interpolate template and scoped variables so the captured request matches the request the
     // panel actually ran; scopedVars carries the panel so scene variables (including a repeated
     // panel's clone-local value) resolve correctly.
@@ -203,7 +217,8 @@ function DownloadDiagnosticsRenderer({ model }: SceneComponentProps<DownloadDiag
       String(timeRange.to.valueOf()),
       controller.signal,
       panelModel,
-      dashboardModel
+      dashboardModel,
+      screenshot
     );
   }, [panelRef, dashboardRef]);
 
@@ -227,8 +242,8 @@ function DownloadDiagnosticsRenderer({ model }: SceneComponentProps<DownloadDiag
         title={t('dashboard.diagnostics.sensitive-warning-title', 'May contain sensitive data')}
       >
         <Trans i18nKey="dashboard.diagnostics.sensitive-warning-body">
-          The bundle can include request headers, query parameters, and server log lines. Review it before sharing
-          outside your organization.
+          The bundle can include request headers, query parameters, server log lines, and images of the panels as
+          currently displayed. Review it before sharing outside your organization.
         </Trans>
       </Alert>
 

--- a/public/app/features/query/diagnostics/capturePanelScreenshot.test.ts
+++ b/public/app/features/query/diagnostics/capturePanelScreenshot.test.ts
@@ -1,0 +1,115 @@
+import { getPanelScreenshotService } from '@grafana/runtime';
+
+import { capturePanelScreenshot } from './capturePanelScreenshot';
+
+jest.mock('@grafana/runtime', () => ({
+  getPanelScreenshotService: jest.fn(),
+}));
+
+const getServiceMock = jest.mocked(getPanelScreenshotService);
+
+/** The 8-byte PNG signature followed by a marker, so the encoded output is recognisable. */
+const PNG_BYTES = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x41]);
+
+function mockCapture(impl: () => Promise<Blob>) {
+  const capture = jest.fn(impl);
+  getServiceMock.mockReturnValue({ capture });
+  return capture;
+}
+
+/** Puts a panel element in the DOM with a rect that is inside, or outside, the viewport. */
+function mountPanel(panelPathId: string, { inViewport }: { inViewport: boolean }) {
+  const el = document.createElement('div');
+  el.setAttribute('data-viz-panel-id', panelPathId);
+  document.body.appendChild(el);
+  const top = inViewport ? 10 : window.innerHeight + 500;
+  el.getBoundingClientRect = () =>
+    ({ top, bottom: top + 300, left: 0, right: 400, width: 400, height: 300, x: 0, y: top }) as DOMRect;
+  return el;
+}
+
+describe('capturePanelScreenshot', () => {
+  const onError = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    document.body.innerHTML = '';
+    mountPanel('panel-1', { inViewport: true });
+    mountPanel('web-1$panel-3', { inViewport: true });
+  });
+
+  it('returns the PNG as base64 without the data-URL prefix', async () => {
+    mockCapture(async () => new Blob([PNG_BYTES], { type: 'image/png' }));
+
+    const result = await capturePanelScreenshot('panel-1', onError);
+
+    // The backend base64-decodes this field directly, so a `data:` prefix would corrupt panel.png.
+    expect(result).toBe(Buffer.from(PNG_BYTES).toString('base64'));
+    expect(result).not.toContain('data:');
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('requests a PNG for the given panelPathId', async () => {
+    const capture = mockCapture(async () => new Blob([PNG_BYTES], { type: 'image/png' }));
+
+    await capturePanelScreenshot('web-1$panel-3', onError);
+
+    // The path id is opaque and must be passed through unchanged — it disambiguates repeat instances.
+    expect(capture).toHaveBeenCalledWith('web-1$panel-3', { format: 'png' });
+  });
+
+  it('reports the failure and resolves undefined when capture throws', async () => {
+    mockCapture(async () => {
+      throw new Error('Panel not in DOM');
+    });
+
+    const result = await capturePanelScreenshot('panel-1', onError);
+
+    // Best-effort: the caller must be able to ship the bundle without panel.png.
+    expect(result).toBeUndefined();
+    expect(onError).toHaveBeenCalledWith(expect.objectContaining({ message: 'Panel not in DOM' }));
+  });
+
+  it('reports the failure and resolves undefined when the service is unavailable', async () => {
+    // @ts-expect-error deliberately modelling a context that never ran the app bootstrap
+    getServiceMock.mockReturnValue(undefined);
+
+    const result = await capturePanelScreenshot('panel-1', onError);
+
+    expect(result).toBeUndefined();
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining('not available') })
+    );
+  });
+
+  it('gives up rather than hanging when the renderer never settles', async () => {
+    // The renderer has no timeout of its own and its cost scales with document size, so a capture that
+    // never settles must not stall the download the user is waiting on.
+    jest.useFakeTimers();
+    mockCapture(() => new Promise<Blob>(() => {}));
+
+    const pending = capturePanelScreenshot('panel-1', onError);
+    await jest.advanceTimersByTimeAsync(10_000);
+    const result = await pending;
+
+    expect(result).toBeUndefined();
+    expect(onError).toHaveBeenCalledWith(expect.objectContaining({ message: expect.stringContaining('timed out') }));
+    jest.useRealTimers();
+  });
+
+  it('refuses to capture a panel scrolled out of the viewport', async () => {
+    // Off-screen panels are still mounted (LazyLoader mode="query"), but their queries may not have
+    // run — so capturing would produce an empty panel the user never actually saw.
+    document.body.innerHTML = '';
+    mountPanel('panel-9', { inViewport: false });
+    const capture = mockCapture(async () => new Blob([PNG_BYTES], { type: 'image/png' }));
+
+    const result = await capturePanelScreenshot('panel-9', onError);
+
+    expect(result).toBeUndefined();
+    expect(capture).not.toHaveBeenCalled();
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining('scrolled out of the viewport') })
+    );
+  });
+});

--- a/public/app/features/query/diagnostics/capturePanelScreenshot.ts
+++ b/public/app/features/query/diagnostics/capturePanelScreenshot.ts
@@ -1,0 +1,128 @@
+import { getPanelScreenshotService } from '@grafana/runtime';
+
+/**
+ * Upper bound on how long we wait for a panel capture.
+ *
+ * The underlying renderer (`html-to-image`, via the panel screenshot service) has no timeout of its
+ * own, and its cost scales with the size of the *document*, not the panel: it walks every entry in
+ * `document.styleSheets` on each call to inline web fonts. On a small dashboard a capture measures in
+ * the low hundreds of milliseconds; on a large one (Grafana's emotion styles run to ~1000 sheets) the
+ * same call has been measured taking tens of seconds. Without a bound, an unlucky capture would stall
+ * the bundle the user is waiting for, so give up and ship the bundle without panel.png instead.
+ */
+const CAPTURE_TIMEOUT_MS = 10_000;
+
+export interface CapturePanelScreenshotOptions {
+  /**
+   * Refuse to capture a panel scrolled out of the viewport. Defaults to `true`.
+   *
+   * The default protects the single-panel path, where an off-screen panel would be one that never ran
+   * its queries (see {@link requireInViewport}). The whole-dashboard path sets this to `false`: it
+   * deliberately makes off-screen panels run their queries first, so by the time it captures, "off
+   * screen" no longer implies "empty".
+   */
+  requireInViewport?: boolean;
+}
+
+/**
+ * Captures the panel as the user currently sees it and returns it as base64 PNG, or `undefined` if it
+ * could not be captured.
+ *
+ * Best-effort by design. The screenshot is supporting evidence in a bundle whose primary artifacts are
+ * the captured traffic and query data, so no capture failure may sink the download — every failure
+ * path resolves to `undefined` and is reported to the caller through `onError` for recording.
+ *
+ * Must be called while the panel is mounted and painted: the service reads the live DOM, so it
+ * faithfully reproduces whatever is on screen — including a panel that has not finished rendering,
+ * which would be captured as a blank plot area.
+ */
+export async function capturePanelScreenshot(
+  panelPathId: string,
+  onError: (error: Error) => void,
+  options: CapturePanelScreenshotOptions = {}
+): Promise<string | undefined> {
+  try {
+    // The service is registered during app startup. Guard anyway: this module is also reachable from
+    // contexts (tests, embedded hosts) that never ran that bootstrap.
+    const service = getPanelScreenshotService();
+    if (!service) {
+      throw new Error('panel screenshot service is not available');
+    }
+
+    if (options.requireInViewport ?? true) {
+      requireInViewport(panelPathId);
+    }
+
+    const blob = await withTimeout(service.capture(panelPathId, { format: 'png' }), CAPTURE_TIMEOUT_MS);
+    return await blobToBase64(blob);
+  } catch (error) {
+    onError(error instanceof Error ? error : new Error(String(error)));
+    return undefined;
+  }
+}
+
+/**
+ * Refuses to capture a panel that is scrolled out of the viewport.
+ *
+ * Dashboard panels are wrapped in scenes' `LazyLoader` with `mode="query"`, which mounts every panel's
+ * DOM immediately but forwards viewport intersection to the query runner (`isInViewChanged`) so that an
+ * off-screen panel can defer running its queries. The consequence for us: an off-screen panel *is*
+ * capturable, but often renders as an empty "No data" panel because its query never ran.
+ *
+ * Shipping that image would be actively misleading — an unpopulated panel is indistinguishable from
+ * the empty-panel bug this bundle usually exists to diagnose, and it was never on the user's screen
+ * anyway. So treat "not in the viewport" as a refusal with a recorded reason, not as a capture.
+ */
+function requireInViewport(panelPathId: string): void {
+  const element = document.querySelector(`[data-viz-panel-id="${CSS.escape(panelPathId)}"]`);
+  if (!element) {
+    // Let the capture service raise its own, more specific "Panel not in DOM" error.
+    return;
+  }
+  const rect = element.getBoundingClientRect();
+  const viewportHeight = window.innerHeight || document.documentElement.clientHeight;
+  const viewportWidth = window.innerWidth || document.documentElement.clientWidth;
+  const intersects = rect.bottom > 0 && rect.top < viewportHeight && rect.right > 0 && rect.left < viewportWidth;
+  if (!intersects) {
+    throw new Error(
+      'panel was scrolled out of the viewport, so it was not captured (its queries may not have run, ' +
+        'which would make the image show an empty panel the user never saw)'
+    );
+  }
+}
+
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout>;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`panel screenshot timed out after ${ms}ms`)), ms);
+  });
+  // The capture promise is abandoned rather than cancelled on timeout -- the renderer exposes no abort
+  // signal. Clearing the timer keeps a fast capture from holding a pending timeout open.
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+}
+
+/**
+ * Reads the Blob as a base64 string, without the `data:image/png;base64,` prefix the backend does not
+ * expect. FileReader is used rather than `btoa` over the bytes: a multi-megabyte PNG spread across
+ * `String.fromCharCode(...bytes)` risks blowing the argument limit.
+ */
+function blobToBase64(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () => reject(reader.error ?? new Error('failed to read screenshot blob'));
+    reader.onload = () => {
+      const result = reader.result;
+      if (typeof result !== 'string') {
+        reject(new Error('screenshot blob did not read as a data URL'));
+        return;
+      }
+      const comma = result.indexOf(',');
+      if (comma === -1) {
+        reject(new Error('screenshot data URL had no base64 payload'));
+        return;
+      }
+      resolve(result.slice(comma + 1));
+    };
+    reader.readAsDataURL(blob);
+  });
+}

--- a/public/app/features/query/diagnostics/downloadDiagnostics.ts
+++ b/public/app/features/query/diagnostics/downloadDiagnostics.ts
@@ -39,7 +39,11 @@ export async function downloadDiagnosticsForQueries(
   // Optional panel and dashboard save models. When supplied they are bundled as panel.json /
   // dashboard.json (the backend includes them verbatim); omitted keys simply aren't sent.
   panel?: unknown,
-  dashboard?: unknown
+  dashboard?: unknown,
+  // Optional base64 PNG of the panel as the browser rendered it, bundled as panel.png. Unlike the
+  // save models this is not a definition the reader has to re-run, so it is the one artifact that
+  // shows what the user actually saw. Omitted when capture failed.
+  screenshot?: string
 ): Promise<void> {
   const visibleQueries = queries.filter((query) => !query.hide);
 
@@ -52,7 +56,7 @@ export async function downloadDiagnosticsForQueries(
       url: DIAGNOSTICS_ENDPOINT,
       method: 'POST',
       responseType: 'blob',
-      data: { from, to, queries: visibleQueries, panel, dashboard },
+      data: { from, to, queries: visibleQueries, panel, dashboard, screenshot },
       // Surface failures in the drawer instead of a global toast.
       showErrorAlert: false,
       // Cancelling the drawer aborts the in-flight request.
@@ -73,6 +77,9 @@ export interface DashboardDiagnosticsPanel {
   from: string;
   to: string;
   queries: DataQuery[];
+  /** Base64 PNG of the panel as the browser drew it, bundled as <panel-dir>/panel.png. Undefined when
+   * it could not be captured — typically a panel the user never scrolled into view. */
+  screenshot?: string;
 }
 
 /** State of an async dashboard-diagnostics generation job, as reported by the status endpoint. */

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -5615,10 +5615,10 @@
       "no-queries": "This panel has no active queries to capture.",
       "progress": "Capturing panel {{done}} of {{total}}…",
       "request-failed": "Request failed",
-      "sensitive-warning-body": "The bundle can include request headers, query parameters, and server log lines. Review it before sharing outside your organization.",
+      "sensitive-warning-body": "The bundle can include request headers, query parameters, server log lines, and images of the panels as currently displayed. Review it before sharing outside your organization.",
       "sensitive-warning-title": "May contain sensitive data",
-      "subtitle-dashboard": "Bundle HTTP traffic (HAR) and panel JSON for every panel in this dashboard to help troubleshoot.",
-      "subtitle-panel": "Bundle HTTP traffic (HAR), logs, and panel JSON to help troubleshoot this panel.",
+      "subtitle-dashboard": "Bundle HTTP traffic (HAR), panel JSON, and a screenshot for every panel in this dashboard to help troubleshoot.",
+      "subtitle-panel": "Bundle HTTP traffic (HAR), logs, panel JSON, and a screenshot of this panel to help troubleshoot it.",
       "timed-out": "Timed out waiting for diagnostics generation",
       "title": "Download diagnostics"
     },


### PR DESCRIPTION
> **Frontend half.** The backend that stores the artifact is grafana/grafana#129485. Until it merges this
> is inert: the field is ignored and no artifact appears — which is also why the two can merge in either
> order.

## What this adds

A diagnostic bundle currently carries the panel's **definition** (`panel.json`, `dashboard.json`) and the
**data behind it** (`querydata.json`, `traffic.har`) — but nothing showing what the user actually saw.
Every existing artifact needs Grafana to import it and re-run or re-render to produce a picture, so *"the
panel looked wrong"* can only be inferred.

This captures the panel in the user's **own browser** and posts the PNG with the diagnostics request.
Both drawers are wired: the single-panel one captures the panel it is scoped to, and the whole-dashboard
one captures **every** panel.

It reuses the already-merged panel screenshot API (`getPanelScreenshotService`, #124045, Grafana 13.1+),
so this is wiring rather than new machinery. Bytes are stored byte-for-byte — re-encoding would defeat the
point. **No datasource, no re-query and no Grafana re-render** is involved; the capture reads the DOM the
user was looking at.

## Capturing every panel of a dashboard

A dashboard taller than the viewport has not run most of its queries. Scenes wraps each panel in
`LazyLoader` with `mode="query"`, which mounts the panel's DOM immediately but forwards viewport
intersection to its query runner, and `SceneQueryRunner.runWithTimeRange` then skips the query outright:

```js
if (this.isQueryModeAuto() && !this._isInView && !this._bypassIsInView) {
  this._queryNotExecutedWhenOutOfView = true;
  return;
}
```

Capturing those panels where they sit would be **worse than skipping them**: an off-screen panel renders
as an empty "No data" panel, indistinguishable from the empty-panel bug the bundle usually exists to
diagnose.

So the dashboard path tells each query runner to ignore the viewport — `bypassIsInViewChanged`, the same
lever `plugins/datasource/dashboard/datasource.ts` already uses to read an off-screen source panel — waits
for the data, then captures. An off-screen panel paints normally once it has data (it is in the layout,
merely scrolled past), so **nothing is scrolled and the user's scroll position is untouched**. An earlier
scroll-into-view implementation was discarded in favour of this.

Bypass is enabled for all panels up front so their queries run concurrently; captures are then taken one
at a time, since capture is main-thread work (the renderer walks every stylesheet in the document).
Bypass is always restored in a `finally` — otherwise off-screen panels would keep refreshing for the rest
of the session.

## Guards, each from a verified fact

- **10s capture timeout** — `html-to-image` has none of its own, and its cost scales with the size of the
  *document*, not the panel (`getCSSRules` walks every `document.styleSheets` entry per call; only
  external CSS *fetches* are cached, not the rule walk).
- **`requireInViewport`** — on for the single-panel path, where an off-screen panel would be one that
  never ran its queries; off for the dashboard path, where the wait above removes the reason for it.
- **Client-supplied bytes are validated** — size cap and PNG signature are checked before anything is
  bundled under a `.png` name.
- **Best-effort throughout** — a capture failure is recorded and never sinks a bundle whose captured
  traffic is already valid.

## Verification

Driven through the real drawer on **both** paths. On a 6-panel dashboard ~4× the viewport height with
only 2 panels visible:

| | before | after |
|---|---|---|
| panels with data | 2 / 6 | **6 / 6** |
| captured | 2 | **6** (4 while still off-screen) |
| `panel.png` in bundle | — | **6 / 6**, valid PNG, 2208×972 (2× DPR) |
| `manifest.json` | — | `screenshotBytes` on all 6, no `screenshotError` |

Also confirmed the bundled PNG is **byte-identical** to what the browser produced, and that fidelity holds
for timeseries, stat, table and **error-state** panels (badge + "No data").

`tsc --noEmit`, prettier and `make i18n-extract` are clean. The Go tests for the artifact live with the
backend in #129485.

## Not verified

`capturePanelScreenshot.test.ts` is written but **has never executed**: the frontend jest environment in
my checkout fails on a clean tree too (`jest-fail-on-console` with `shouldFailOnInfo: true` trips on an
i18next `console.info` at `public/test/setupTests.ts:29` — 18/18 pre-existing failures), so this is
unrelated to the change but means CI is the first real run of those tests.

## Gating

Unchanged — behind `grafana.onDemandDiagnostics`, on-prem only, Grafana admin only.
