### PR TITLE
Home: use standard number formatting for Kubernetes usage

### DIFF
--- a/public/app/features/home/Recommendations/RecommendationExisting.test.tsx
+++ b/public/app/features/home/Recommendations/RecommendationExisting.test.tsx
@@ -40,8 +40,6 @@ const mockFetchInventory = jest.mocked(fetchKubernetesInventory);
 const mockFetchHealth = jest.mocked(fetchKubernetesHealth);
 const mockFetchCpuSeries = jest.mocked(fetchClusterCpuSeries);
 
-const compactFormatter = new Intl.NumberFormat(undefined, { notation: 'compact', maximumFractionDigits: 1 });
-
 const settings = { id: 'grafana-k8s-app' } as PluginMeta<{}>;
 const datasource: DataSourceInstanceListItem = {
   uid: 'k8s-uid',
@@ -255,14 +253,12 @@ describe('RecommendationExisting', () => {
     expect(screen.queryByTestId('kubernetes-stats-skeleton')).not.toBeInTheDocument();
   });
 
-  it('compact-formats large pod counts', async () => {
-    const pods = 311101;
-    mockResolvedKubernetes({ clusters: 17, pods });
+  it('uses the standard short format for large pod counts', async () => {
+    mockResolvedKubernetes({ clusters: 17, pods: 311101 });
 
     render(<RecommendationExisting />);
 
-    const expectedPods = compactFormatter.format(pods);
-    expect(await screen.findByText(`${expectedPods} pods`)).toBeInTheDocument();
+    expect(await screen.findByText('311 K pods')).toBeInTheDocument();
   });
 
   it('shows stub stats without skeletons when switching away while Kubernetes data is pending', async () => {

--- a/public/app/features/home/Recommendations/buildKubernetesItem.ts
+++ b/public/app/features/home/Recommendations/buildKubernetesItem.ts
@@ -1,4 +1,10 @@
-import { type FieldSparkline, type PluginMeta, locationUtil } from '@grafana/data';
+import {
+  formattedValueToString,
+  getValueFormat,
+  type FieldSparkline,
+  type PluginMeta,
+  locationUtil,
+} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { createBridgeURL } from 'app/features/alerting/unified/components/PluginBridge';
 import { canAccessPluginPage } from 'app/features/alerting/unified/hooks/usePluginBridge';
@@ -11,8 +17,7 @@ import {
 } from './kubernetesData';
 import { type ExistingItem } from './types';
 
-// Browser locale is the deliberate choice: the homepage number format follows the user's environment.
-const compactFormatter = new Intl.NumberFormat(undefined, { notation: 'compact', maximumFractionDigits: 1 });
+const formatUsageNumber = getValueFormat('short');
 
 export interface KubernetesItemParts {
   inventory: KubernetesInventory | undefined;
@@ -79,13 +84,13 @@ export function buildKubernetesItem(parts: KubernetesItemParts, settings: Plugin
       ? {
           primary: t('home.recommendations.kubernetes.clusters', '', {
             count: clusterCount,
-            value: compactFormatter.format(clusterCount),
+            value: formattedValueToString(formatUsageNumber(clusterCount)),
             defaultValue_one: '{{value}} cluster',
             defaultValue_other: '{{value}} clusters',
           }),
           secondary: t('home.recommendations.kubernetes.pods', '', {
             count: podCount,
-            value: compactFormatter.format(podCount),
+            value: formattedValueToString(formatUsageNumber(podCount)),
             defaultValue_one: '{{value}} pod',
             defaultValue_other: '{{value}} pods',
           }),
@@ -105,7 +110,7 @@ export function buildKubernetesItem(parts: KubernetesItemParts, settings: Plugin
             alertsFiring > 0
               ? t('home.recommendations.kubernetes.alerts-firing', '', {
                   count: Math.ceil(alertsFiring),
-                  value: compactFormatter.format(Math.ceil(alertsFiring)),
+                  value: formattedValueToString(formatUsageNumber(Math.ceil(alertsFiring))),
                   defaultValue_one: '{{value}} alert firing',
                   defaultValue_other: '{{value}} alerts firing',
                 })


### PR DESCRIPTION
## Summary

Replaces the Kubernetes card's standalone compact-number formatter with Grafana's standard `short` value formatter for cluster, pod, and firing-alert counts. This keeps number abbreviations consistent with the rest of Grafana.