### PR TITLE
Datasources (frontend): Capture frontend panel data for diagnostics bundles

### DIFF
--- a/public/app/features/dashboard-scene/sharing/DownloadDiagnostics.test.tsx
+++ b/public/app/features/dashboard-scene/sharing/DownloadDiagnostics.test.tsx
@@ -66,7 +66,7 @@ describe('DownloadDiagnostics', () => {
     await userEvent.click(screen.getByRole('button', { name: 'Download diagnostics' }));
 
     expect(downloadDiagnosticsForQueries).toHaveBeenCalledTimes(1);
-    const [queries, from, to] = jest.mocked(downloadDiagnosticsForQueries).mock.calls[0];
+    const [{ queries, from, to }] = jest.mocked(downloadDiagnosticsForQueries).mock.calls[0];
     // The component forwards the panel's queries verbatim; hidden-query filtering happens
     // downstream in downloadDiagnosticsForQueries (mocked here).
     expect(queries).toEqual([{ refId: 'A' }, { refId: 'B', hide: true }]);
@@ -80,7 +80,7 @@ describe('DownloadDiagnostics', () => {
     render(<tab.Component model={tab} />);
     await userEvent.click(screen.getByRole('button', { name: 'Download diagnostics' }));
 
-    const [, , , , panelModel, dashboardModel] = jest.mocked(downloadDiagnosticsForQueries).mock.calls[0];
+    const [{ panel: panelModel, dashboard: dashboardModel }] = jest.mocked(downloadDiagnosticsForQueries).mock.calls[0];
     // The whole dashboard save model is sent (bundled as dashboard.json), and this panel's JSON is
     // resolved from it by id (VizPanel key "panel-1" -> id 1) and sent as panel.json.
     expect(dashboardModel).toEqual(expect.objectContaining({ uid: 'dash-1' }));
@@ -99,7 +99,8 @@ describe('DownloadDiagnostics', () => {
     render(<tab.Component model={tab} />);
     await userEvent.click(screen.getByRole('button', { name: 'Download diagnostics' }));
 
-    const [, , , , panelModel, forwardedDashboardModel] = jest.mocked(downloadDiagnosticsForQueries).mock.calls[0];
+    const [{ panel: panelModel, dashboard: forwardedDashboardModel }] =
+      jest.mocked(downloadDiagnosticsForQueries).mock.calls[0];
     expect(forwardedDashboardModel).toBe(dashboardModel);
     expect(panelModel).toBe(panelElement);
   });
@@ -118,7 +119,7 @@ describe('DownloadDiagnostics', () => {
     await userEvent.click(screen.getByRole('button', { name: 'Download diagnostics' }));
 
     expect(downloadDiagnosticsForQueries).toHaveBeenCalledTimes(1);
-    const [, , , , panelModel, dashboardModel] = jest.mocked(downloadDiagnosticsForQueries).mock.calls[0];
+    const [{ panel: panelModel, dashboard: dashboardModel }] = jest.mocked(downloadDiagnosticsForQueries).mock.calls[0];
     expect(panelModel).toBeUndefined();
     expect(dashboardModel).toBeUndefined();
     expect(screen.queryByText('Failed to generate diagnostics')).not.toBeInTheDocument();
@@ -137,7 +138,7 @@ describe('DownloadDiagnostics', () => {
     render(<tab.Component model={tab} />);
     await userEvent.click(screen.getByRole('button', { name: 'Download diagnostics' }));
 
-    const [, , , , , , panelData] = jest.mocked(downloadDiagnosticsForQueries).mock.calls[0];
+    const [{ panelData }] = jest.mocked(downloadDiagnosticsForQueries).mock.calls[0];
     // Bundled as paneldata.json, which is what querydata.json (the backend's frames) gets diffed against.
     expect(panelData).toMatchObject({
       version: 1,
@@ -165,7 +166,7 @@ describe('DownloadDiagnostics', () => {
     await userEvent.click(screen.getByRole('button', { name: 'Download diagnostics' }));
 
     expect(downloadDiagnosticsForQueries).toHaveBeenCalledTimes(1);
-    const [, , , , , , panelData] = jest.mocked(downloadDiagnosticsForQueries).mock.calls[0];
+    const [{ panelData }] = jest.mocked(downloadDiagnosticsForQueries).mock.calls[0];
     // The failure is recorded rather than dropped: an absent artifact would be indistinguishable from a
     // panel that had no frames to give. No frames key, which would read as exactly that.
     expect(panelData).toEqual({
@@ -190,7 +191,7 @@ describe('DownloadDiagnostics', () => {
     render(<tab.Component model={tab} />);
     await userEvent.click(screen.getByRole('button', { name: 'Download diagnostics' }));
 
-    const [queries] = jest.mocked(downloadDiagnosticsForQueries).mock.calls[0];
+    const [{ queries }] = jest.mocked(downloadDiagnosticsForQueries).mock.calls[0];
     expect(queries).toEqual([
       // A had no datasource -> filled from the runner; B keeps its own.
       { refId: 'A', datasource: { uid: 'runner-ds', type: 'prometheus' } },
@@ -211,7 +212,7 @@ describe('DownloadDiagnostics', () => {
     render(<tab.Component model={tab} />);
     await userEvent.click(screen.getByRole('button', { name: 'Download diagnostics' }));
 
-    const [queries] = jest.mocked(downloadDiagnosticsForQueries).mock.calls[0];
+    const [{ queries }] = jest.mocked(downloadDiagnosticsForQueries).mock.calls[0];
     // The resolved query, not the literal $job, is what gets captured (WMD1 / #1530).
     expect(queries).toEqual([
       { refId: 'A', datasource: { uid: 'prom', type: 'prometheus' }, expr: 'up{job="grafana"}' },

--- a/public/app/features/dashboard-scene/sharing/DownloadDiagnostics.test.tsx
+++ b/public/app/features/dashboard-scene/sharing/DownloadDiagnostics.test.tsx
@@ -2,7 +2,7 @@ import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { render } from 'test/test-utils';
 
-import { type ScopedVars } from '@grafana/data';
+import { getDefaultTimeRange, LoadingState, toDataFrame, type PanelData, type ScopedVars } from '@grafana/data';
 import { getPanelPlugin } from '@grafana/data/test';
 import { logError, setPluginImportUtils } from '@grafana/runtime';
 import { getDataSourceInstance } from '@grafana/runtime/unstable';
@@ -129,6 +129,57 @@ describe('DownloadDiagnostics', () => {
     consoleWarn.mockRestore();
   });
 
+  it('forwards the frames the frontend was holding for the panel', async () => {
+    const runner = new SceneQueryRunner({ queries: [{ refId: 'A' }] });
+    runner.setState({ data: dataWith(toDataFrame({ refId: 'A', name: 'host-a', fields: [] })) });
+    const { tab } = setupScenario(undefined, runner);
+
+    render(<tab.Component model={tab} />);
+    await userEvent.click(screen.getByRole('button', { name: 'Download diagnostics' }));
+
+    const [, , , , , , panelData] = jest.mocked(downloadDiagnosticsForQueries).mock.calls[0];
+    // Bundled as paneldata.json, which is what querydata.json (the backend's frames) gets diffed against.
+    expect(panelData).toMatchObject({
+      version: 1,
+      panelKey: 'panel-1',
+      frames: [expect.objectContaining({ schema: expect.objectContaining({ name: 'host-a' }) })],
+    });
+  });
+
+  it('records a capture failure in the payload instead of sinking the whole download', async () => {
+    // dataFrameToJSON copies field config by reference, so an unserializable frame gets through it and
+    // only blows up in the request's JSON.stringify. That has to be contained here, or one bad frame
+    // costs the user traffic.har and querydata.json too.
+    const consoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    const runner = new SceneQueryRunner({ queries: [{ refId: 'A' }] });
+    runner.setState({
+      data: dataWith(
+        toDataFrame({ refId: 'A', fields: [{ name: 'value', values: [1], config: { custom: circular } }] })
+      ),
+    });
+    const { tab } = setupScenario(undefined, runner);
+
+    render(<tab.Component model={tab} />);
+    await userEvent.click(screen.getByRole('button', { name: 'Download diagnostics' }));
+
+    expect(downloadDiagnosticsForQueries).toHaveBeenCalledTimes(1);
+    const [, , , , , , panelData] = jest.mocked(downloadDiagnosticsForQueries).mock.calls[0];
+    // The failure is recorded rather than dropped: an absent artifact would be indistinguishable from a
+    // panel that had no frames to give. No frames key, which would read as exactly that.
+    expect(panelData).toEqual({
+      version: 1,
+      panelKey: 'panel-1',
+      pluginId: 'table',
+      captureError: expect.stringContaining('circular'),
+    });
+    expect(screen.queryByText('Failed to generate diagnostics')).not.toBeInTheDocument();
+    expect(logError).toHaveBeenCalledWith(expect.any(Error), { panelKey: 'panel-1' });
+    expect(consoleWarn).toHaveBeenCalled();
+    consoleWarn.mockRestore();
+  });
+
   it('fills the runner-level datasource onto queries that lack one', async () => {
     const runner = new SceneQueryRunner({
       datasource: { uid: 'runner-ds', type: 'prometheus' },
@@ -233,6 +284,11 @@ describe('DownloadDiagnostics', () => {
     expect(downloadDiagnosticsForQueries).not.toHaveBeenCalled();
   });
 });
+
+// Resolved query-runner data, as the runner would hold it after a completed query.
+function dataWith(...series: PanelData['series']): PanelData {
+  return { state: LoadingState.Done, series, timeRange: getDefaultTimeRange() };
+}
 
 function setupScenario(
   onDismiss?: () => void,

--- a/public/app/features/dashboard-scene/sharing/DownloadDiagnostics.test.tsx
+++ b/public/app/features/dashboard-scene/sharing/DownloadDiagnostics.test.tsx
@@ -174,6 +174,9 @@ describe('DownloadDiagnostics', () => {
       panelKey: 'panel-1',
       pluginId: 'table',
       captureError: expect.stringContaining('circular'),
+      // The stack of the throw, which is the part that says which line of the capture broke. Matched
+      // loosely: the frames come from whichever engine ran the serialization guard.
+      captureStack: expect.any(String),
     });
     expect(screen.queryByText('Failed to generate diagnostics')).not.toBeInTheDocument();
     expect(logError).toHaveBeenCalledWith(expect.any(Error), { panelKey: 'panel-1' });

--- a/public/app/features/dashboard-scene/sharing/DownloadDiagnostics.tsx
+++ b/public/app/features/dashboard-scene/sharing/DownloadDiagnostics.tsx
@@ -228,15 +228,15 @@ function DownloadDiagnosticsRenderer({ model }: SceneComponentProps<DownloadDiag
       panelData = capturePanelDataFailure(panel, error);
     }
 
-    await downloadDiagnosticsForQueries(
+    await downloadDiagnosticsForQueries({
       queries,
-      String(timeRange.from.valueOf()),
-      String(timeRange.to.valueOf()),
-      controller.signal,
-      panelModel,
-      dashboardModel,
-      panelData
-    );
+      from: String(timeRange.from.valueOf()),
+      to: String(timeRange.to.valueOf()),
+      signal: controller.signal,
+      panel: panelModel,
+      dashboard: dashboardModel,
+      panelData,
+    });
   }, [panelRef, dashboardRef]);
 
   const handleDismiss = () => {

--- a/public/app/features/dashboard-scene/sharing/DownloadDiagnostics.tsx
+++ b/public/app/features/dashboard-scene/sharing/DownloadDiagnostics.tsx
@@ -17,7 +17,11 @@ import {
 } from '@grafana/scenes';
 import { type DataQuery } from '@grafana/schema';
 import { Alert, Button, useStyles2 } from '@grafana/ui';
-import { capturePanelData } from 'app/features/query/diagnostics/capturePanelData';
+import {
+  capturePanelData,
+  capturePanelDataFailure,
+  type PanelDataPayload,
+} from 'app/features/query/diagnostics/capturePanelData';
 import { downloadDiagnosticsForQueries } from 'app/features/query/diagnostics/downloadDiagnostics';
 import { interpolateDiagnosticsQueries } from 'app/features/query/diagnostics/interpolateQueries';
 
@@ -49,7 +53,7 @@ export class DownloadDiagnostics extends SceneObjectBase<DownloadDiagnosticsStat
 
 const SAVE_MODEL_FAILURE_MESSAGE = 'Download diagnostics: failed to build panel/dashboard JSON, bundling without it';
 const PANEL_DATA_FAILURE_MESSAGE =
-  'Download diagnostics: failed to serialize frontend panel data, bundling without paneldata.json';
+  'Download diagnostics: failed to serialize frontend panel data, recording the failure in paneldata.json';
 
 // Inlined rather than imported from dashboard-scene/utils/utils: that module transitively reaches
 // DashboardScene, which imports ShareDrawer (which imports this view), creating an import cycle.
@@ -200,18 +204,28 @@ function DownloadDiagnosticsRenderer({ model }: SceneComponentProps<DownloadDiag
       panelModel = undefined;
     }
 
-    // Serialize the frames the frontend is holding. Reads resolved scene state only -- no queries run
-    // and no transformations re-apply -- but a plugin can still hand back an unserializable frame, so
-    // a failure here only costs the bundle paneldata.json.
-    let panelData: unknown;
+    // Serialize the frames the frontend is holding. Reads resolved scene state only -- no queries run and
+    // no transformations re-apply -- and it reuses the runner resolved above so the frames come from the
+    // same runner as the queries.
+    //
+    // dataFrameToJSON copies field config and values by reference rather than stringifying them, so an
+    // unserializable frame (a circular object in field.config.custom, a BigInt value) does not fail here:
+    // it fails later inside backendSrv's JSON.stringify, outside this guard, taking the whole bundle with
+    // it. Stringify once here so that failure is contained to this artifact -- one extra pass over the
+    // payload is worth not losing traffic.har and querydata.json to a single bad frame.
+    let panelData: PanelDataPayload | undefined;
     try {
-      panelData = capturePanelData(panel);
+      const captured = capturePanelData(panel, runner);
+      JSON.stringify(captured);
+      panelData = captured;
     } catch (error) {
       console.warn(PANEL_DATA_FAILURE_MESSAGE, error);
       logError(error instanceof Error ? error : new Error(PANEL_DATA_FAILURE_MESSAGE), {
         panelKey: panel.state.key ?? '',
       });
-      panelData = undefined;
+      // Record the failure rather than dropping it: an absent artifact would be indistinguishable from a
+      // panel that had no frames to give.
+      panelData = capturePanelDataFailure(panel, error);
     }
 
     await downloadDiagnosticsForQueries(

--- a/public/app/features/dashboard-scene/sharing/DownloadDiagnostics.tsx
+++ b/public/app/features/dashboard-scene/sharing/DownloadDiagnostics.tsx
@@ -17,6 +17,7 @@ import {
 } from '@grafana/scenes';
 import { type DataQuery } from '@grafana/schema';
 import { Alert, Button, useStyles2 } from '@grafana/ui';
+import { capturePanelData } from 'app/features/query/diagnostics/capturePanelData';
 import { downloadDiagnosticsForQueries } from 'app/features/query/diagnostics/downloadDiagnostics';
 import { interpolateDiagnosticsQueries } from 'app/features/query/diagnostics/interpolateQueries';
 
@@ -47,6 +48,8 @@ export class DownloadDiagnostics extends SceneObjectBase<DownloadDiagnosticsStat
 }
 
 const SAVE_MODEL_FAILURE_MESSAGE = 'Download diagnostics: failed to build panel/dashboard JSON, bundling without it';
+const PANEL_DATA_FAILURE_MESSAGE =
+  'Download diagnostics: failed to serialize frontend panel data, bundling without paneldata.json';
 
 // Inlined rather than imported from dashboard-scene/utils/utils: that module transitively reaches
 // DashboardScene, which imports ShareDrawer (which imports this view), creating an import cycle.
@@ -197,13 +200,28 @@ function DownloadDiagnosticsRenderer({ model }: SceneComponentProps<DownloadDiag
       panelModel = undefined;
     }
 
+    // Serialize the frames the frontend is holding. Reads resolved scene state only -- no queries run
+    // and no transformations re-apply -- but a plugin can still hand back an unserializable frame, so
+    // a failure here only costs the bundle paneldata.json.
+    let panelData: unknown;
+    try {
+      panelData = capturePanelData(panel);
+    } catch (error) {
+      console.warn(PANEL_DATA_FAILURE_MESSAGE, error);
+      logError(error instanceof Error ? error : new Error(PANEL_DATA_FAILURE_MESSAGE), {
+        panelKey: panel.state.key ?? '',
+      });
+      panelData = undefined;
+    }
+
     await downloadDiagnosticsForQueries(
       queries,
       String(timeRange.from.valueOf()),
       String(timeRange.to.valueOf()),
       controller.signal,
       panelModel,
-      dashboardModel
+      dashboardModel,
+      panelData
     );
   }, [panelRef, dashboardRef]);
 

--- a/public/app/features/query/diagnostics/capturePanelData.test.ts
+++ b/public/app/features/query/diagnostics/capturePanelData.test.ts
@@ -155,6 +155,54 @@ describe('capturePanelData', () => {
     ]);
   });
 
+  it('records the stack of the exception the plugin frontend threw', () => {
+    // toDataQueryError hands back the thrown object, so a real Error arrives here with its stack -- the only
+    // field in the bundle that names the frame the data was lost in. querydata.json, traffic.har and the
+    // server logs all have nothing to say about a browser-side throw.
+    const thrown = Object.assign(new Error('Cannot read properties of undefined (reading "result")'), {
+      refId: 'A',
+    });
+    const captured = capturePanelData(
+      panel(),
+      runnerWith(panelData({ state: LoadingState.Error, series: [], error: thrown }))
+    );
+
+    expect(captured?.errors?.[0].stack).toContain('capturePanelData.test.ts');
+  });
+
+  it('caps a runaway stack and marks where it was cut', () => {
+    // A recursion blows past any sane frame count, and the frames past the cap repeat the ones before it.
+    // Cutting from the far end keeps the throw site, which comes first.
+    const thrown = Object.assign(new Error('Maximum call stack size exceeded'), {
+      stack: `Error: Maximum call stack size exceeded\n${'    at process (module.js:1:1)\n'.repeat(500)}`,
+    });
+    const captured = capturePanelData(
+      panel(),
+      runnerWith(panelData({ state: LoadingState.Error, series: [], error: thrown }))
+    );
+
+    const stack = captured?.errors?.[0].stack ?? '';
+    expect(stack).toMatch(/^Error: Maximum call stack size exceeded\n {4}at process/);
+    // Marked, so a stack ending mid-frame reads as truncated rather than as the throw having no deeper frames.
+    expect(stack).toContain('… [stack truncated at 4096 characters]');
+    expect(stack.length).toBeLessThan(4200);
+  });
+
+  it('omits the stack for a server-reported query error, which never had one', () => {
+    const captured = capturePanelData(
+      panel(),
+      runnerWith(
+        panelData({
+          state: LoadingState.Error,
+          series: [],
+          errors: [{ refId: 'A', message: 'upstream exploded', status: 502 }],
+        })
+      )
+    );
+
+    expect(captured?.errors?.[0].stack).toBeUndefined();
+  });
+
   it('prefers the errors array over the deprecated singular error', () => {
     const captured = capturePanelData(
       panel(),
@@ -236,7 +284,7 @@ describe('capturePanelDataFailure', () => {
   it('records the failure with the panel identity and no frames', () => {
     const failure = capturePanelDataFailure(panel(), new Error('circular structure'));
 
-    expect(failure).toEqual({
+    expect(failure).toMatchObject({
       version: 1,
       panelKey: 'panel-1',
       pluginId: 'timeseries',
@@ -247,7 +295,28 @@ describe('capturePanelDataFailure', () => {
     expect(failure).not.toHaveProperty('frames');
   });
 
-  it('stringifies a non-Error throw', () => {
-    expect(capturePanelDataFailure(panel(), 'plugin exploded').captureError).toBe('plugin exploded');
+  it('records the stack of what the capture threw, which localises the fault to this code', () => {
+    // "circular structure" says a capture broke and nothing more; every candidate for breaking it is a
+    // line in capturePanelData. Nothing else in the bundle records a browser-side throw.
+    const failure = capturePanelDataFailure(panel(), new Error('circular structure'));
+
+    expect(failure.captureStack).toContain('capturePanelData.test.ts');
+  });
+
+  it('caps the stack of what the capture threw', () => {
+    const thrown = Object.assign(new Error('circular structure'), {
+      stack: `Error: circular structure\n${'    at serialize (module.js:1:1)\n'.repeat(500)}`,
+    });
+
+    const stack = capturePanelDataFailure(panel(), thrown).captureStack ?? '';
+    expect(stack).toContain('… [stack truncated at 4096 characters]');
+    expect(stack.length).toBeLessThan(4200);
+  });
+
+  it('stringifies a non-Error throw, which has no stack to record', () => {
+    const failure = capturePanelDataFailure(panel(), 'plugin exploded');
+
+    expect(failure.captureError).toBe('plugin exploded');
+    expect(failure.captureStack).toBeUndefined();
   });
 });

--- a/public/app/features/query/diagnostics/capturePanelData.test.ts
+++ b/public/app/features/query/diagnostics/capturePanelData.test.ts
@@ -88,7 +88,9 @@ describe('capturePanelData', () => {
 
     // querydata.json is a server-side re-run at its own resolution, so without this a step or point-count
     // difference is indistinguishable from data the plugin's frontend lost.
-    expect(captured?.request).toEqual({
+    // toStrictEqual, not toEqual: the latter treats an undefined property as absent, so the inFlight
+    // expectation below would hold whether or not the key was set.
+    expect(captured?.request).toStrictEqual({
       from: 1_700_000_000_000,
       to: 1_700_000_300_000,
       intervalMs: 15_000,

--- a/public/app/features/query/diagnostics/capturePanelData.test.ts
+++ b/public/app/features/query/diagnostics/capturePanelData.test.ts
@@ -125,6 +125,109 @@ describe('capturePanelData', () => {
 
     expect(captured?.request?.inFlight).toBeUndefined();
   });
+
+  it('omits errors when the query did not error', () => {
+    // An absent key has to read as "nothing went wrong", not "nobody looked".
+    expect(capturePanelData(panel(), runnerWith(panelData()))?.errors).toBeUndefined();
+  });
+
+  it('records why the frames are missing when the plugin frontend threw', () => {
+    // The case the artifact is weakest without: runRequest's catchError emits state Error with no series
+    // and only the deprecated singular error set. Empty frames against a healthy querydata.json localise
+    // the loss to the frontend, but the reason lives nowhere else -- traffic.har recorded a successful
+    // round trip and the server never saw a browser-side exception.
+    const captured = capturePanelData(
+      panel(),
+      runnerWith(
+        panelData({
+          state: LoadingState.Error,
+          series: [],
+          error: { refId: 'A', message: 'Cannot read properties of undefined (reading "result")' },
+        })
+      )
+    );
+
+    expect(captured?.frames).toEqual([]);
+    expect(captured?.errors).toEqual([
+      expect.objectContaining({ refId: 'A', message: 'Cannot read properties of undefined (reading "result")' }),
+    ]);
+  });
+
+  it('prefers the errors array over the deprecated singular error', () => {
+    const captured = capturePanelData(
+      panel(),
+      runnerWith(
+        panelData({
+          state: LoadingState.Error,
+          errors: [
+            { refId: 'A', message: 'upstream exploded', status: 502, statusText: 'Bad Gateway', traceId: 'abc123' },
+            { refId: 'B', message: 'also this one' },
+          ],
+          error: { message: 'upstream exploded' },
+        })
+      )
+    );
+
+    expect(captured?.errors).toEqual([
+      {
+        refId: 'A',
+        message: 'upstream exploded',
+        status: 502,
+        statusText: 'Bad Gateway',
+        traceId: 'abc123',
+        type: undefined,
+        detail: undefined,
+      },
+      expect.objectContaining({ refId: 'B', message: 'also this one' }),
+    ]);
+  });
+
+  it('copies scalar fields out rather than embedding the thrown object', () => {
+    // toDataQueryError returns *the object that was thrown* with a message attached, so PanelData.error is
+    // not the tidy DataQueryError its type claims -- a fetch/axios error brings a circular config along.
+    // Embedding it would fail the caller's serialization guard and cost the frames too, to explain why the
+    // frames are missing.
+    const thrown: Record<string, unknown> = { refId: 'A', message: 'Request failed', status: 500 };
+    thrown.config = { adapter: () => undefined, self: thrown };
+    const captured = capturePanelData(
+      panel(),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      runnerWith(panelData({ state: LoadingState.Error, series: [], error: thrown as any }))
+    );
+
+    expect(() => JSON.stringify(captured)).not.toThrow();
+    expect(captured?.errors).toEqual([
+      {
+        refId: 'A',
+        message: 'Request failed',
+        status: 500,
+        statusText: undefined,
+        traceId: undefined,
+        type: undefined,
+        detail: undefined,
+      },
+    ]);
+  });
+
+  it('records the server detail a development-mode Grafana returns', () => {
+    const captured = capturePanelData(
+      panel(),
+      runnerWith(
+        panelData({
+          state: LoadingState.Error,
+          errors: [
+            {
+              refId: 'A',
+              message: 'Query data error',
+              data: { message: 'Query data error', error: 'pq: relation "foo" does not exist' },
+            },
+          ],
+        })
+      )
+    );
+
+    expect(captured?.errors?.[0].detail).toBe('pq: relation "foo" does not exist');
+  });
 });
 
 describe('capturePanelDataFailure', () => {

--- a/public/app/features/query/diagnostics/capturePanelData.test.ts
+++ b/public/app/features/query/diagnostics/capturePanelData.test.ts
@@ -1,0 +1,148 @@
+import {
+  dateTime,
+  LoadingState,
+  toDataFrame,
+  type DataQueryRequest,
+  type PanelData,
+  type TimeRange,
+} from '@grafana/data';
+import { SceneQueryRunner, VizPanel } from '@grafana/scenes';
+
+import { capturePanelData, capturePanelDataFailure } from './capturePanelData';
+
+const timeRange: TimeRange = {
+  from: dateTime(1_700_000_000_000),
+  to: dateTime(1_700_000_300_000),
+  raw: { from: 'now-5m', to: 'now' },
+};
+
+function panel(): VizPanel {
+  return new VizPanel({ key: 'panel-1', pluginId: 'timeseries', title: 'Panel' });
+}
+
+// Only the fields capturePanelData reads; a full DataQueryRequest would be noise here.
+function request(overrides: Partial<DataQueryRequest> = {}): DataQueryRequest {
+  return {
+    range: timeRange,
+    intervalMs: 15_000,
+    maxDataPoints: 800,
+    endTime: 1_700_000_300_100,
+    ...overrides,
+  } as DataQueryRequest;
+}
+
+function runnerWith(data: PanelData | undefined): SceneQueryRunner {
+  const runner = new SceneQueryRunner({ queries: [{ refId: 'A' }] });
+  if (data) {
+    runner.setState({ data });
+  }
+  return runner;
+}
+
+function panelData(overrides: Partial<PanelData> = {}): PanelData {
+  return {
+    state: LoadingState.Done,
+    series: [toDataFrame({ refId: 'A', name: 'host-a', fields: [{ name: 'value', values: [1, 2] }] })],
+    timeRange,
+    request: request(),
+    ...overrides,
+  };
+}
+
+describe('capturePanelData', () => {
+  it('returns undefined when the panel has no query runner', () => {
+    expect(capturePanelData(panel(), undefined)).toBeUndefined();
+  });
+
+  it('returns undefined when the query runner has no resolved data', () => {
+    // The caller then omits panelData entirely, so an absent paneldata.json means "nothing to capture"
+    // rather than "capture failed" (which capturePanelDataFailure records instead).
+    expect(capturePanelData(panel(), runnerWith(undefined))).toBeUndefined();
+  });
+
+  it('captures the frames as DataFrameJSON alongside the panel identity and loading state', () => {
+    const captured = capturePanelData(panel(), runnerWith(panelData()));
+
+    expect(captured).toMatchObject({
+      version: 1,
+      panelKey: 'panel-1',
+      pluginId: 'timeseries',
+      state: LoadingState.Done,
+    });
+    // DataFrameJSON is the same encoding the backend uses for querydata.json, so the two artifacts can
+    // be diffed field-for-field.
+    expect(captured?.frames).toEqual([
+      {
+        schema: expect.objectContaining({
+          refId: 'A',
+          name: 'host-a',
+          fields: [expect.objectContaining({ name: 'value' })],
+        }),
+        data: { values: [[1, 2]] },
+      },
+    ]);
+  });
+
+  it('records the request the frames were produced from', () => {
+    const captured = capturePanelData(panel(), runnerWith(panelData()));
+
+    // querydata.json is a server-side re-run at its own resolution, so without this a step or point-count
+    // difference is indistinguishable from data the plugin's frontend lost.
+    expect(captured?.request).toEqual({
+      from: 1_700_000_000_000,
+      to: 1_700_000_300_000,
+      intervalMs: 15_000,
+      maxDataPoints: 800,
+      inFlight: undefined,
+    });
+  });
+
+  it('omits the request when the panel has data but no recorded request', () => {
+    const captured = capturePanelData(panel(), runnerWith(panelData({ request: undefined })));
+
+    // e.g. frames supplied by a snapshot rather than a query: better omitted than sent half-empty.
+    expect(captured?.request).toBeUndefined();
+    expect(captured?.frames).toHaveLength(1);
+  });
+
+  it('marks a request that has not returned yet, whose frames are therefore from the previous run', () => {
+    // runRequest emits a loading packet carrying the new request and no series 200ms into every query,
+    // and preProcessPanelData refills those empty series from the last result. So mid-refresh the frames
+    // and the request come from different runs, which would otherwise read as a resolution mismatch --
+    // or, on a first load, as frames the plugin's frontend lost.
+    const captured = capturePanelData(
+      panel(),
+      runnerWith(panelData({ state: LoadingState.Loading, request: request({ endTime: undefined }) }))
+    );
+
+    expect(captured?.request?.inFlight).toBe(true);
+  });
+
+  it('does not mark a request that has already returned a packet', () => {
+    // endTime is stamped when the first packet arrives, so a still-Loading multi-packet response is this
+    // request's own partial output and the frames do belong to it.
+    const captured = capturePanelData(panel(), runnerWith(panelData({ state: LoadingState.Loading })));
+
+    expect(captured?.request?.inFlight).toBeUndefined();
+  });
+});
+
+describe('capturePanelDataFailure', () => {
+  it('records the failure with the panel identity and no frames', () => {
+    const failure = capturePanelDataFailure(panel(), new Error('circular structure'));
+
+    expect(failure).toEqual({
+      version: 1,
+      panelKey: 'panel-1',
+      pluginId: 'timeseries',
+      captureError: 'circular structure',
+    });
+    // No frames key: an empty one would read as "the frontend was holding nothing", which is the
+    // frontend-loss misreading this artifact exists to settle.
+    expect(failure).not.toHaveProperty('frames');
+  });
+
+  it('stringifies a non-Error throw', () => {
+    expect(capturePanelDataFailure(panel(), 'plugin exploded').captureError).toBe('plugin exploded');
+  });
+});

--- a/public/app/features/query/diagnostics/capturePanelData.ts
+++ b/public/app/features/query/diagnostics/capturePanelData.ts
@@ -43,9 +43,8 @@ interface PanelDataRequestContext {
  * **Scope, deliberately narrow.** This captures the *query runner's* output — the datasource's frames
  * after the plugin's own frontend processing — and nothing further down the pipeline. Transformations,
  * field config, axis ticks and legend calcs are all applied later, so neither a transform that drops data
- * nor a *rendering* fault is visible here. Transform evidence is a separate artifact
- * (`frontend-processing.json`); this one answers exactly one question: did the plugin's frontend return
- * what its backend produced?
+ * nor a *rendering* fault is visible here. This artifact answers exactly one question: did the plugin's
+ * frontend return what its backend produced?
  *
  * Returns `undefined` when the panel has no query runner or no resolved data, so the caller simply omits
  * the artifact rather than sending an empty one.
@@ -79,9 +78,9 @@ export function capturePanelData(panel: VizPanel): PanelDataArtifact | undefined
     // this artifact. That is accepted at this stage: the feature is experimental, admin-only and
     // on-prem gated, and no bound can be chosen well before we have seen what real bundles weigh. When
     // it is added it belongs here rather than on the backend (which deliberately defers the decision to
-    // this side, see the "oversized payload" row in the backend PR), and it should follow the ladder
-    // frontend-processing.json already uses: drop frames first, keep the identifying fields, and stamp
-    // a truncation marker so a reduced capture is never misread as data the frontend lost.
+    // this side, see the "oversized payload" row in the backend PR), and it should drop frames first,
+    // keep the identifying fields, and stamp a truncation marker so a reduced capture is never misread
+    // as data the frontend lost.
     frames: (data.series ?? []).map((frame) => dataFrameToJSON(frame)),
   };
 }

--- a/public/app/features/query/diagnostics/capturePanelData.ts
+++ b/public/app/features/query/diagnostics/capturePanelData.ts
@@ -1,4 +1,4 @@
-import { dataFrameToJSON, LoadingState, type DataFrameJSON } from '@grafana/data';
+import { dataFrameToJSON, LoadingState, type DataFrameJSON, type PanelData } from '@grafana/data';
 import { type SceneQueryRunner, type VizPanel } from '@grafana/scenes';
 
 /** Schema version stamped into paneldata.json so a reader knows how to interpret it. */
@@ -23,7 +23,34 @@ export interface PanelDataArtifact extends PanelDataArtifactHeader {
   /** LoadingState at capture time (`Done`, `Error`, `Loading`, …), as the query runner reported it. */
   state?: string;
   request?: PanelDataRequestContext;
+  /** Why the frames are missing or short, when the frontend knows. Omitted when the query did not error. */
+  errors?: PanelDataError[];
   frames: DataFrameJSON[];
+}
+
+/**
+ * A query error as the frontend recorded it — the counterpart to the missing frames.
+ *
+ * Without this the artifact can prove a frontend loss and not explain it: when a plugin's frontend
+ * throws, `runRequest`'s `catchError` emits `state: Error` with no series, so the capture shows empty
+ * `frames` against a healthy `querydata.json` and the reason is nowhere in the bundle — `traffic.har`
+ * recorded a successful round trip and the server logs never saw a browser-side exception.
+ *
+ * Scalar fields only, copied out one by one rather than spread. `toDataQueryError` returns *the object
+ * that was thrown* with a `message` attached, so `PanelData.error` is not the tidy `DataQueryError` its
+ * type suggests — it can be a fetch/axios error carrying a circular `config` or `request`. Spreading it
+ * would push captures that are otherwise fine into `captureError`, losing the frames to salvage the
+ * explanation for why they are missing.
+ */
+interface PanelDataError {
+  refId?: string;
+  message?: string;
+  status?: number;
+  statusText?: string;
+  traceId?: string;
+  type?: string;
+  /** `data.error`: the server's detailed message, populated only when Grafana runs in development mode. */
+  detail?: string;
 }
 
 /**
@@ -60,6 +87,25 @@ interface PanelDataRequestContext {
    * a difference against `querydata.json`.
    */
   inFlight?: true;
+}
+
+function captureErrors(data: PanelData): PanelDataError[] | undefined {
+  // errors[] is the modern field, but runRequest's catchError sets only the deprecated singular error --
+  // which is exactly the plugin-frontend-threw case this is here for. Read both.
+  const errors = data.errors?.length ? data.errors : data.error ? [data.error] : [];
+  if (!errors.length) {
+    return undefined;
+  }
+
+  return errors.map((error) => ({
+    refId: error.refId,
+    message: error.message,
+    status: error.status,
+    statusText: error.statusText,
+    traceId: error.traceId,
+    type: error.type,
+    detail: error.data?.error,
+  }));
 }
 
 /**
@@ -113,6 +159,9 @@ export function capturePanelData(panel: VizPanel, runner: SceneQueryRunner | und
           inFlight: inFlight ? true : undefined,
         }
       : undefined,
+    // Omitted when the query did not error, so an absent key reads as "nothing went wrong here" rather
+    // than "nobody looked".
+    errors: captureErrors(data),
     // Deliberately unbounded, for now. A very large panel makes for a large request body, and past
     // web.MaxBindBodyBytes (100MiB) web.Bind rejects it and the whole bundle is lost rather than just
     // this artifact. That is accepted at this stage: the feature is experimental, admin-only and

--- a/public/app/features/query/diagnostics/capturePanelData.ts
+++ b/public/app/features/query/diagnostics/capturePanelData.ts
@@ -1,8 +1,15 @@
-import { dataFrameToJSON, type DataFrameJSON } from '@grafana/data';
-import { SceneDataTransformer, SceneQueryRunner, type SceneObject, type VizPanel } from '@grafana/scenes';
+import { dataFrameToJSON, LoadingState, type DataFrameJSON } from '@grafana/data';
+import { type SceneQueryRunner, type VizPanel } from '@grafana/scenes';
 
 /** Schema version stamped into paneldata.json so a reader knows how to interpret it. */
 const PANEL_DATA_ARTIFACT_VERSION = 1;
+
+/** Identifies which panel a capture came from, whether it succeeded or failed. */
+interface PanelDataArtifactHeader {
+  version: number;
+  panelKey?: string;
+  pluginId?: string;
+}
 
 /**
  * `paneldata.json`: the data frames the **frontend** was holding for a panel.
@@ -12,10 +19,7 @@ const PANEL_DATA_ARTIFACT_VERSION = 1;
  * (Prometheus, for one, does a lot of it), so frames present in `querydata.json` but missing or altered
  * here localise the loss to the plugin's frontend rather than its backend or the upstream.
  */
-interface PanelDataArtifact {
-  version: number;
-  panelKey?: string;
-  pluginId?: string;
+export interface PanelDataArtifact extends PanelDataArtifactHeader {
   /** LoadingState at capture time (`Done`, `Error`, `Loading`, …), as the query runner reported it. */
   state?: string;
   request?: PanelDataRequestContext;
@@ -23,7 +27,23 @@ interface PanelDataArtifact {
 }
 
 /**
- * The request these frames were produced from, so the `querydata.json` diff can be read correctly.
+ * A capture that threw, recorded in place of the frames.
+ *
+ * Deliberately carries no `frames` key: an empty one would read as "the frontend was holding nothing",
+ * which is the frontend-loss misreading this artifact exists to settle. With this shape an absent
+ * `paneldata.json` means there was nothing to capture — no query runner, or no resolved data — rather
+ * than a capture that broke on the way out.
+ */
+export interface PanelDataCaptureFailure extends PanelDataArtifactHeader {
+  captureError: string;
+}
+
+/** What the drawer sends as `panelData`, either way. */
+export type PanelDataPayload = PanelDataArtifact | PanelDataCaptureFailure;
+
+/**
+ * The request these frames were produced from, so the `querydata.json` diff can be read correctly —
+ * unless `inFlight` is set, in which case they were not.
  */
 interface PanelDataRequestContext {
   /** Epoch ms, matching the units of the `from`/`to` the diagnostics request sends. */
@@ -31,6 +51,15 @@ interface PanelDataRequestContext {
   to: number;
   intervalMs?: number;
   maxDataPoints?: number;
+  /**
+   * Set when this request had returned nothing yet at capture time, so the frames are *not* its output:
+   * `runRequest` emits a loading packet carrying the new request and no series 200ms into every query,
+   * and `preProcessPanelData` then refills those empty series from the panel's previous result. So a
+   * capture taken mid-refresh holds the previous run's frames (or none, on a first load) while the
+   * request describes the run still in flight — this window and resolution must not be used to explain
+   * a difference against `querydata.json`.
+   */
+  inFlight?: true;
 }
 
 /**
@@ -46,17 +75,27 @@ interface PanelDataRequestContext {
  * nor a *rendering* fault is visible here. This artifact answers exactly one question: did the plugin's
  * frontend return what its backend produced?
  *
- * Returns `undefined` when the panel has no query runner or no resolved data, so the caller simply omits
- * the artifact rather than sending an empty one.
+ * One caveat for the diff: core normalises every frame on the way in — `preProcessPanelData` runs each
+ * through `toDataFrame` and `guessFieldTypes` — so a field the backend typed one way and this artifact
+ * types another is core normalising, not the plugin rewriting anything.
+ *
+ * Takes the query runner the caller already resolved rather than walking to it again, so the frames here
+ * are guaranteed to come from the same runner as the queries the caller sends alongside them.
+ *
+ * Returns `undefined` when there is no query runner or no resolved data, so the caller simply omits the
+ * artifact rather than sending an empty one.
  */
-export function capturePanelData(panel: VizPanel): PanelDataArtifact | undefined {
-  const runner = findQueryRunner(panel);
+export function capturePanelData(panel: VizPanel, runner: SceneQueryRunner | undefined): PanelDataArtifact | undefined {
   const data = runner?.state.data;
   if (!data) {
     return undefined;
   }
 
   const request = data.request;
+  // endTime is stamped onto the request when its first response packet arrives, so an unset endTime on a
+  // Loading packet marks exactly the case where the frames and the request come from different runs (see
+  // inFlight). Once a packet has landed, a Loading or Streaming state is this request's own partial output.
+  const inFlight = data.state === LoadingState.Loading && request?.endTime === undefined;
 
   return {
     version: PANEL_DATA_ARTIFACT_VERSION,
@@ -71,6 +110,7 @@ export function capturePanelData(panel: VizPanel): PanelDataArtifact | undefined
           to: request.range.to.valueOf(),
           intervalMs: request.intervalMs,
           maxDataPoints: request.maxDataPoints,
+          inFlight: inFlight ? true : undefined,
         }
       : undefined,
     // Deliberately unbounded, for now. A very large panel makes for a large request body, and past
@@ -86,22 +126,17 @@ export function capturePanelData(panel: VizPanel): PanelDataArtifact | undefined
 }
 
 /**
- * Walks the panel's data chain to its query runner.
+ * Records a capture that failed, so the omission is visible in the bundle.
  *
- * A panel's `$data` is either a `SceneQueryRunner` or a `SceneDataTransformer` wrapping one, and the
- * provider can also live on the parent (repeat clones share it), which is why both are checked —
- * mirroring getQueryRunnerFor in the diagnostics drawers.
+ * Sending nothing would leave a support engineer unable to tell a browser that had no frames to give from
+ * a capture that broke on the way out — the same conflation the backend's `WithPanelData` refuses to make
+ * between an absent payload and an empty one.
  */
-function findQueryRunner(sceneObject: SceneObject | undefined): SceneQueryRunner | undefined {
-  if (!sceneObject) {
-    return undefined;
-  }
-  const provider = sceneObject.state.$data ?? sceneObject.parent?.state.$data;
-  if (provider instanceof SceneQueryRunner) {
-    return provider;
-  }
-  if (provider instanceof SceneDataTransformer) {
-    return findQueryRunner(provider);
-  }
-  return undefined;
+export function capturePanelDataFailure(panel: VizPanel, error: unknown): PanelDataCaptureFailure {
+  return {
+    version: PANEL_DATA_ARTIFACT_VERSION,
+    panelKey: panel.state.key,
+    pluginId: panel.state.pluginId,
+    captureError: error instanceof Error ? error.message : String(error),
+  };
 }

--- a/public/app/features/query/diagnostics/capturePanelData.ts
+++ b/public/app/features/query/diagnostics/capturePanelData.ts
@@ -18,7 +18,19 @@ interface PanelDataArtifact {
   pluginId?: string;
   /** LoadingState at capture time (`Done`, `Error`, `Loading`, …), as the query runner reported it. */
   state?: string;
+  request?: PanelDataRequestContext;
   frames: DataFrameJSON[];
+}
+
+/**
+ * The request these frames were produced from, so the `querydata.json` diff can be read correctly.
+ */
+interface PanelDataRequestContext {
+  /** Epoch ms, matching the units of the `from`/`to` the diagnostics request sends. */
+  from: number;
+  to: number;
+  intervalMs?: number;
+  maxDataPoints?: number;
 }
 
 /**
@@ -45,11 +57,31 @@ export function capturePanelData(panel: VizPanel): PanelDataArtifact | undefined
     return undefined;
   }
 
+  const request = data.request;
+
   return {
     version: PANEL_DATA_ARTIFACT_VERSION,
     panelKey: panel.state.key,
     pluginId: panel.state.pluginId,
     state: data.state,
+    // Omitted rather than sent half-empty when the panel has data but no recorded request (e.g. frames
+    // supplied by a snapshot rather than a query).
+    request: request
+      ? {
+          from: request.range.from.valueOf(),
+          to: request.range.to.valueOf(),
+          intervalMs: request.intervalMs,
+          maxDataPoints: request.maxDataPoints,
+        }
+      : undefined,
+    // Deliberately unbounded, for now. A very large panel makes for a large request body, and past
+    // web.MaxBindBodyBytes (100MiB) web.Bind rejects it and the whole bundle is lost rather than just
+    // this artifact. That is accepted at this stage: the feature is experimental, admin-only and
+    // on-prem gated, and no bound can be chosen well before we have seen what real bundles weigh. When
+    // it is added it belongs here rather than on the backend (which deliberately defers the decision to
+    // this side, see the "oversized payload" row in the backend PR), and it should follow the ladder
+    // frontend-processing.json already uses: drop frames first, keep the identifying fields, and stamp
+    // a truncation marker so a reduced capture is never misread as data the frontend lost.
     frames: (data.series ?? []).map((frame) => dataFrameToJSON(frame)),
   };
 }

--- a/public/app/features/query/diagnostics/capturePanelData.ts
+++ b/public/app/features/query/diagnostics/capturePanelData.ts
@@ -1,0 +1,76 @@
+import { dataFrameToJSON, type DataFrameJSON } from '@grafana/data';
+import { SceneDataTransformer, SceneQueryRunner, type SceneObject, type VizPanel } from '@grafana/scenes';
+
+/** Schema version stamped into paneldata.json so a reader knows how to interpret it. */
+const PANEL_DATA_ARTIFACT_VERSION = 1;
+
+/**
+ * `paneldata.json`: the data frames the **frontend** was holding for a panel.
+ *
+ * The counterpart to `querydata.json`, which holds the frames the datasource's **backend** returned.
+ * Comparing the two is the point: a datasource plugin's *frontend* code also processes the response
+ * (Prometheus, for one, does a lot of it), so frames present in `querydata.json` but missing or altered
+ * here localise the loss to the plugin's frontend rather than its backend or the upstream.
+ */
+interface PanelDataArtifact {
+  version: number;
+  panelKey?: string;
+  pluginId?: string;
+  /** LoadingState at capture time (`Done`, `Error`, `Loading`, …), as the query runner reported it. */
+  state?: string;
+  frames: DataFrameJSON[];
+}
+
+/**
+ * Serialises the frames a panel's query runner is holding, for bundling as `paneldata.json`.
+ *
+ * Reads already-resolved scene state, so it runs no queries and re-applies no transformations: it records
+ * what the frontend had at the moment the user asked for a bundle. Frames use `DataFrameJSON`, the same
+ * encoding the backend uses for `querydata.json`, so the two can be diffed field-for-field.
+ *
+ * **Scope, deliberately narrow.** This captures the *query runner's* output — the datasource's frames
+ * after the plugin's own frontend processing — and nothing further down the pipeline. Transformations,
+ * field config, axis ticks and legend calcs are all applied later, so neither a transform that drops data
+ * nor a *rendering* fault is visible here. Transform evidence is a separate artifact
+ * (`frontend-processing.json`); this one answers exactly one question: did the plugin's frontend return
+ * what its backend produced?
+ *
+ * Returns `undefined` when the panel has no query runner or no resolved data, so the caller simply omits
+ * the artifact rather than sending an empty one.
+ */
+export function capturePanelData(panel: VizPanel): PanelDataArtifact | undefined {
+  const runner = findQueryRunner(panel);
+  const data = runner?.state.data;
+  if (!data) {
+    return undefined;
+  }
+
+  return {
+    version: PANEL_DATA_ARTIFACT_VERSION,
+    panelKey: panel.state.key,
+    pluginId: panel.state.pluginId,
+    state: data.state,
+    frames: (data.series ?? []).map((frame) => dataFrameToJSON(frame)),
+  };
+}
+
+/**
+ * Walks the panel's data chain to its query runner.
+ *
+ * A panel's `$data` is either a `SceneQueryRunner` or a `SceneDataTransformer` wrapping one, and the
+ * provider can also live on the parent (repeat clones share it), which is why both are checked —
+ * mirroring getQueryRunnerFor in the diagnostics drawers.
+ */
+function findQueryRunner(sceneObject: SceneObject | undefined): SceneQueryRunner | undefined {
+  if (!sceneObject) {
+    return undefined;
+  }
+  const provider = sceneObject.state.$data ?? sceneObject.parent?.state.$data;
+  if (provider instanceof SceneQueryRunner) {
+    return provider;
+  }
+  if (provider instanceof SceneDataTransformer) {
+    return findQueryRunner(provider);
+  }
+  return undefined;
+}

--- a/public/app/features/query/diagnostics/capturePanelData.ts
+++ b/public/app/features/query/diagnostics/capturePanelData.ts
@@ -4,6 +4,14 @@ import { type SceneQueryRunner, type VizPanel } from '@grafana/scenes';
 /** Schema version stamped into paneldata.json so a reader knows how to interpret it. */
 const PANEL_DATA_ARTIFACT_VERSION = 1;
 
+/**
+ * How much of an exception's stack to keep. Ten frames of a bundled stack land well inside this, so the
+ * cap only bites on a runaway recursion — where the frames past it are repeats of the ones before.
+ * Capped rather than dropped because the stack is the one field that says *where* the frontend lost the
+ * data, and truncated rather than elided from the far end because the throw site comes first.
+ */
+const MAX_ERROR_STACK_CHARS = 4096;
+
 /** Identifies which panel a capture came from, whether it succeeded or failed. */
 interface PanelDataArtifactHeader {
   version: number;
@@ -41,6 +49,12 @@ export interface PanelDataArtifact extends PanelDataArtifactHeader {
  * type suggests — it can be a fetch/axios error carrying a circular `config` or `request`. Spreading it
  * would push captures that are otherwise fine into `captureError`, losing the frames to salvage the
  * explanation for why they are missing.
+ *
+ * That same looseness is why `stack` is worth taking: when the thrown object is a real `Error` it is the
+ * only field in the whole bundle that says *which frame* of the plugin's frontend dropped the data, and
+ * it is a plain string, so the circularity above does not apply to it. It adds no class of content the
+ * capture did not already carry either — a stack opens with the `message` recorded beside it, and the
+ * rest is code locations from Grafana's own bundle.
  */
 interface PanelDataError {
   refId?: string;
@@ -51,6 +65,11 @@ interface PanelDataError {
   type?: string;
   /** `data.error`: the server's detailed message, populated only when Grafana runs in development mode. */
   detail?: string;
+  /**
+   * The exception's own stack, when one was thrown, capped at `MAX_ERROR_STACK_CHARS` and marked where
+   * it was cut. Absent for a server-reported query error, which never had one.
+   */
+  stack?: string;
 }
 
 /**
@@ -63,6 +82,13 @@ interface PanelDataError {
  */
 export interface PanelDataCaptureFailure extends PanelDataArtifactHeader {
   captureError: string;
+  /**
+   * The stack of whatever the capture threw, on the same terms as `PanelDataError.stack` — capped and
+   * marked where it was cut. Named apart from that field because it localises a fault in *this* code
+   * rather than in the plugin's frontend: it says which line of the capture broke, not where data was
+   * lost. Absent when the throw brought no stack.
+   */
+  captureStack?: string;
 }
 
 /** What the drawer sends as `panelData`, either way. */
@@ -89,6 +115,33 @@ interface PanelDataRequestContext {
   inFlight?: true;
 }
 
+/**
+ * The stack of the object that was thrown, if it brought one, capped at `MAX_ERROR_STACK_CHARS`.
+ *
+ * Duck-typed off `unknown` rather than narrowed to `Error`, because neither caller is handed an `Error`:
+ * `DataQueryError` does not declare `stack` at all (the field is there because `toDataQueryError` hands
+ * back the thrown object itself), and a capture failure is whatever a `throw` produced. So the check is a
+ * runtime one, and an object that carries a stack without extending `Error` still gets read.
+ */
+function captureStack(error: unknown): string | undefined {
+  if (typeof error !== 'object' || error === null || !('stack' in error)) {
+    return undefined;
+  }
+
+  const { stack } = error;
+  if (typeof stack !== 'string' || !stack) {
+    return undefined;
+  }
+
+  if (stack.length <= MAX_ERROR_STACK_CHARS) {
+    return stack;
+  }
+
+  // Marked, so a support engineer reading a stack that stops mid-frame knows the capture cut it and no
+  // deeper frame is implied to be absent.
+  return `${stack.slice(0, MAX_ERROR_STACK_CHARS)}\n… [stack truncated at ${MAX_ERROR_STACK_CHARS} characters]`;
+}
+
 function captureErrors(data: PanelData): PanelDataError[] | undefined {
   // errors[] is the modern field, but runRequest's catchError sets only the deprecated singular error --
   // which is exactly the plugin-frontend-threw case this is here for. Read both.
@@ -105,6 +158,7 @@ function captureErrors(data: PanelData): PanelDataError[] | undefined {
     traceId: error.traceId,
     type: error.type,
     detail: error.data?.error,
+    stack: captureStack(error),
   }));
 }
 
@@ -189,6 +243,11 @@ export function capturePanelData(panel: VizPanel, runner: SceneQueryRunner | und
  * Sending nothing would leave a support engineer unable to tell a browser that had no frames to give from
  * a capture that broke on the way out — the same conflation the backend's `WithPanelData` refuses to make
  * between an absent payload and an empty one.
+ *
+ * The stack comes along for the same reason it does on a query error: the message alone says a capture
+ * broke, and every candidate for breaking it — a frame that will not serialise, a scene shape this does
+ * not expect — is a line in this file or the one that calls it. Nothing else in the bundle records a
+ * browser-side throw, so without the stack the next person has one sentence and a re-read of the source.
  */
 export function capturePanelDataFailure(panel: VizPanel, error: unknown): PanelDataCaptureFailure {
   return {
@@ -196,5 +255,6 @@ export function capturePanelDataFailure(panel: VizPanel, error: unknown): PanelD
     panelKey: panel.state.key,
     pluginId: panel.state.pluginId,
     captureError: error instanceof Error ? error.message : String(error),
+    captureStack: captureStack(error),
   };
 }

--- a/public/app/features/query/diagnostics/capturePanelData.ts
+++ b/public/app/features/query/diagnostics/capturePanelData.ts
@@ -121,9 +121,18 @@ function captureErrors(data: PanelData): PanelDataError[] | undefined {
  * nor a *rendering* fault is visible here. This artifact answers exactly one question: did the plugin's
  * frontend return what its backend produced?
  *
- * One caveat for the diff: core normalises every frame on the way in — `preProcessPanelData` runs each
- * through `toDataFrame` and `guessFieldTypes` — so a field the backend typed one way and this artifact
- * types another is core normalising, not the plugin rewriting anything.
+ * Two caveats for the diff, both cases of core moving data around rather than the plugin losing it:
+ *
+ * 1. Core normalises every frame on the way in — `preProcessPanelData` runs each through `toDataFrame`
+ *    and `guessFieldTypes` — so a field the backend typed one way and this artifact types another is
+ *    core normalising, not the plugin rewriting anything.
+ * 2. Annotation frames are **not** here. `processResponsePacket` routes every frame whose
+ *    `meta.dataTopic` is `Annotations` out of `series` and into `PanelData.annotations`, so a datasource
+ *    that returns them from a panel query (testdata's annotations scenario, the dashboard datasource)
+ *    has those frames in `querydata.json` and absent here — which reads as exactly the frontend loss
+ *    this artifact exists to prove. They are left out rather than captured because
+ *    `SceneQueryRunner._combineDataLayers` merges the dashboard's own annotation layers into that field,
+ *    so it is not the datasource's output alone and the part that is is not separately reachable.
  *
  * Takes the query runner the caller already resolved rather than walking to it again, so the frames here
  * are guaranteed to come from the same runner as the queries the caller sends alongside them.

--- a/public/app/features/query/diagnostics/downloadDiagnostics.test.ts
+++ b/public/app/features/query/diagnostics/downloadDiagnostics.test.ts
@@ -28,7 +28,7 @@ describe('downloadDiagnosticsForQueries', () => {
   it('does nothing when there are no visible queries', async () => {
     const fetch = setupBackendSrv({});
 
-    await downloadDiagnosticsForQueries([{ refId: 'A', hide: true }], '1', '2');
+    await downloadDiagnosticsForQueries({ queries: [{ refId: 'A', hide: true }], from: '1', to: '2' });
 
     expect(fetch).not.toHaveBeenCalled();
     expect(saveAs).not.toHaveBeenCalled();
@@ -42,7 +42,7 @@ describe('downloadDiagnosticsForQueries', () => {
     });
     const queries: DataQuery[] = [{ refId: 'A' }, { refId: 'B', hide: true }];
 
-    await downloadDiagnosticsForQueries(queries, '100', '200');
+    await downloadDiagnosticsForQueries({ queries, from: '100', to: '200' });
 
     expect(fetch).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -62,7 +62,7 @@ describe('downloadDiagnosticsForQueries', () => {
     const panel = { id: 1, type: 'timeseries' };
     const dashboard = { uid: 'd1', panels: [panel] };
 
-    await downloadDiagnosticsForQueries([{ refId: 'A' }], '100', '200', undefined, panel, dashboard);
+    await downloadDiagnosticsForQueries({ queries: [{ refId: 'A' }], from: '100', to: '200', panel, dashboard });
 
     expect(fetch).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -79,7 +79,7 @@ describe('downloadDiagnosticsForQueries', () => {
     const fetch = setupBackendSrv({ data: blob, headers: new Headers() });
     const panelData = { version: 1, panelKey: 'panel-1', pluginId: 'timeseries', frames: [] };
 
-    await downloadDiagnosticsForQueries([{ refId: 'A' }], '100', '200', undefined, undefined, undefined, panelData);
+    await downloadDiagnosticsForQueries({ queries: [{ refId: 'A' }], from: '100', to: '200', panelData });
 
     expect(fetch).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -95,7 +95,7 @@ describe('downloadDiagnosticsForQueries', () => {
     const blob = new Blob(['bundle'], { type: 'application/gzip' });
     setupBackendSrv({ data: blob, headers: new Headers() });
 
-    await downloadDiagnosticsForQueries([{ refId: 'A' }], '1', '2');
+    await downloadDiagnosticsForQueries({ queries: [{ refId: 'A' }], from: '1', to: '2' });
 
     expect(saveAs).toHaveBeenCalledTimes(1);
     const [, filename] = jest.mocked(saveAs).mock.calls[0];
@@ -183,7 +183,7 @@ describe('Content-Disposition filename parsing', () => {
     const blob = new Blob(['bundle'], { type: 'application/gzip' });
     setupBackendSrv({ data: blob, headers: new Headers({ 'Content-Disposition': header }) });
 
-    await downloadDiagnosticsForQueries([{ refId: 'A' }], '1', '2');
+    await downloadDiagnosticsForQueries({ queries: [{ refId: 'A' }], from: '1', to: '2' });
 
     expect(saveAs).toHaveBeenCalledWith(blob, expected);
   });
@@ -198,7 +198,7 @@ describe('Content-Disposition filename parsing', () => {
     const blob = new Blob(['bundle'], { type: 'application/gzip' });
     setupBackendSrv({ data: blob, headers: new Headers({ 'Content-Disposition': header }) });
 
-    await downloadDiagnosticsForQueries([{ refId: 'A' }], '1', '2');
+    await downloadDiagnosticsForQueries({ queries: [{ refId: 'A' }], from: '1', to: '2' });
 
     expect(saveAs).toHaveBeenCalledTimes(1);
     const [, filename] = jest.mocked(saveAs).mock.calls[0];
@@ -215,7 +215,7 @@ describe('abort signal handling', () => {
     const fetch = setupBackendSrv({ data: new Blob(['x']), headers: new Headers() });
     const { signal } = new AbortController();
 
-    await downloadDiagnosticsForQueries([{ refId: 'A' }], '1', '2', signal);
+    await downloadDiagnosticsForQueries({ queries: [{ refId: 'A' }], from: '1', to: '2', signal });
 
     // The drawer's AbortController.signal must reach getBackendSrv so cancel/unmount can abort the
     // in-flight request; showErrorAlert stays false so the drawer surfaces failures itself.
@@ -249,7 +249,7 @@ describe('abort signal handling', () => {
     const fetch = jest.fn().mockReturnValue(throwError(() => err));
     jest.mocked(getBackendSrv).mockReturnValue({ fetch } as unknown as ReturnType<typeof getBackendSrv>);
 
-    await expect(downloadDiagnosticsForQueries([{ refId: 'A' }], '1', '2')).rejects.toBe(err);
+    await expect(downloadDiagnosticsForQueries({ queries: [{ refId: 'A' }], from: '1', to: '2' })).rejects.toBe(err);
     expect(saveAs).not.toHaveBeenCalled();
   });
 });

--- a/public/app/features/query/diagnostics/downloadDiagnostics.test.ts
+++ b/public/app/features/query/diagnostics/downloadDiagnostics.test.ts
@@ -74,6 +74,23 @@ describe('downloadDiagnosticsForQueries', () => {
     );
   });
 
+  it('includes the captured frontend panel data in the POST body when provided', async () => {
+    const blob = new Blob(['bundle'], { type: 'application/gzip' });
+    const fetch = setupBackendSrv({ data: blob, headers: new Headers() });
+    const panelData = { version: 1, panelKey: 'panel-1', pluginId: 'timeseries', frames: [] };
+
+    await downloadDiagnosticsForQueries([{ refId: 'A' }], '100', '200', undefined, undefined, undefined, panelData);
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: '/api/ds/diagnostics',
+        method: 'POST',
+        // paneldata.json is bundled server-side from this, and is what querydata.json gets diffed against.
+        data: { from: '100', to: '200', queries: [{ refId: 'A' }], panelData },
+      })
+    );
+  });
+
   it('falls back to a generated filename when no Content-Disposition is returned', async () => {
     const blob = new Blob(['bundle'], { type: 'application/gzip' });
     setupBackendSrv({ data: blob, headers: new Headers() });

--- a/public/app/features/query/diagnostics/downloadDiagnostics.ts
+++ b/public/app/features/query/diagnostics/downloadDiagnostics.ts
@@ -27,27 +27,40 @@ function fileNameFromContentDisposition(header: string | null): string | undefin
 }
 
 /**
+ * One panel diagnostics request.
+ */
+export interface DiagnosticsRequest {
+  queries: DataQuery[];
+  /** Epoch ms as a string, matching what the endpoint expects. */
+  from: string;
+  to: string;
+  /** Cancelling the drawer aborts the in-flight request. */
+  signal?: AbortSignal;
+  /** Panel and dashboard save models, bundled as panel.json / dashboard.json (the backend includes
+   * them verbatim); omitted keys simply aren't sent. */
+  panel?: unknown;
+  dashboard?: unknown;
+  /** Frames the frontend was holding for this panel, bundled as paneldata.json. Unlike the save models
+   * above this is data rather than a definition, so nothing has to be re-run to read it. */
+  panelData?: PanelDataPayload;
+}
+
+/**
  * Requests a diagnostic bundle for the given panel queries from the backend and downloads it.
  *
  * The bundle is generated server-side by `POST /api/ds/diagnostics`. That endpoint is not available
  * yet (it lands in a separate backend PR); until then this call fails and the drawer surfaces the
  * error. The request/response contract and this download flow are final.
  */
-export async function downloadDiagnosticsForQueries(
-  queries: DataQuery[],
-  from: string,
-  to: string,
-  signal?: AbortSignal,
-  // Optional panel and dashboard save models. When supplied they are bundled as panel.json /
-  // dashboard.json (the backend includes them verbatim); omitted keys simply aren't sent.
-  panel?: unknown,
-  dashboard?: unknown,
-  // Optional frames the frontend was holding for this panel, bundled as paneldata.json. Unlike the
-  // save models above this is data rather than a definition, so nothing has to be re-run to read it.
-  // Typed, unlike those two, so transposing it with one of them is a compile error rather than a panel
-  // definition silently bundled as paneldata.json.
-  panelData?: PanelDataPayload
-): Promise<void> {
+export async function downloadDiagnosticsForQueries({
+  queries,
+  from,
+  to,
+  signal,
+  panel,
+  dashboard,
+  panelData,
+}: DiagnosticsRequest): Promise<void> {
   const visibleQueries = queries.filter((query) => !query.hide);
 
   if (visibleQueries.length === 0) {

--- a/public/app/features/query/diagnostics/downloadDiagnostics.ts
+++ b/public/app/features/query/diagnostics/downloadDiagnostics.ts
@@ -39,7 +39,10 @@ export async function downloadDiagnosticsForQueries(
   // Optional panel and dashboard save models. When supplied they are bundled as panel.json /
   // dashboard.json (the backend includes them verbatim); omitted keys simply aren't sent.
   panel?: unknown,
-  dashboard?: unknown
+  dashboard?: unknown,
+  // Optional frames the frontend was holding for this panel, bundled as paneldata.json. Unlike the
+  // save models above this is data rather than a definition, so nothing has to be re-run to read it.
+  panelData?: unknown
 ): Promise<void> {
   const visibleQueries = queries.filter((query) => !query.hide);
 
@@ -52,7 +55,7 @@ export async function downloadDiagnosticsForQueries(
       url: DIAGNOSTICS_ENDPOINT,
       method: 'POST',
       responseType: 'blob',
-      data: { from, to, queries: visibleQueries, panel, dashboard },
+      data: { from, to, queries: visibleQueries, panel, dashboard, panelData },
       // Surface failures in the drawer instead of a global toast.
       showErrorAlert: false,
       // Cancelling the drawer aborts the in-flight request.

--- a/public/app/features/query/diagnostics/downloadDiagnostics.ts
+++ b/public/app/features/query/diagnostics/downloadDiagnostics.ts
@@ -5,6 +5,8 @@ import { t } from '@grafana/i18n';
 import { getBackendSrv } from '@grafana/runtime';
 import { type DataQuery } from '@grafana/schema';
 
+import { type PanelDataPayload } from './capturePanelData';
+
 const DIAGNOSTICS_ENDPOINT = '/api/ds/diagnostics';
 const DASHBOARD_DIAGNOSTICS_ENDPOINT = '/api/ds/dashboard-diagnostics';
 
@@ -42,7 +44,9 @@ export async function downloadDiagnosticsForQueries(
   dashboard?: unknown,
   // Optional frames the frontend was holding for this panel, bundled as paneldata.json. Unlike the
   // save models above this is data rather than a definition, so nothing has to be re-run to read it.
-  panelData?: unknown
+  // Typed, unlike those two, so transposing it with one of them is a compile error rather than a panel
+  // definition silently bundled as paneldata.json.
+  panelData?: PanelDataPayload
 ): Promise<void> {
   const visibleQueries = queries.filter((query) => !query.hide);
 


### PR DESCRIPTION
> **Frontend half.** The backend that stores the artifact is grafana/grafana#129494. Until it merges this
> is inert: the field is ignored and no artifact appears — which is also why the two can merge in either
> order.

## The gap

Every evidence artifact in a diagnostic bundle is recorded on the **server**: `traffic.har` is the HTTP
round-trip, `querydata.json` is the plugin's `QueryData` response, and `panel.json` / `dashboard.json` are
definitions.

A datasource plugin's **frontend** code also processes the response — Prometheus does a lot of it — and it
sits downstream of all of them. So a plugin whose frontend half loses data produces a bundle that reads as
**perfectly healthy** while the user is staring at a missing series. There is currently nothing in the
bundle that can localise that.

See backend PR for more information.