### PR TITLE
Annotations: replace `client.K8sHandler` with `rest.RESTClient` in migration proxy

### DIFF
--- a/pkg/services/annotations/annotationsapi/api_client.go
+++ b/pkg/services/annotations/annotationsapi/api_client.go
@@ -9,15 +9,12 @@ import (
 	"slices"
 	"strconv"
 	"strings"
-	"sync"
 
 	authnlib "github.com/grafana/authlib/authn"
 	claims "github.com/grafana/authlib/types"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
 	"github.com/grafana/grafana/pkg/setting"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/client-go/dynamic"
@@ -25,11 +22,7 @@ import (
 
 	annotationV0 "github.com/grafana/grafana/apps/annotation/pkg/apis/annotation/v0alpha1"
 	"github.com/grafana/grafana/pkg/services/annotations"
-	"github.com/grafana/grafana/pkg/services/apiserver/client"
-	"github.com/grafana/grafana/pkg/services/user"
 )
-
-const annotationServerAudience = "annotation.grafana.app"
 
 // annotationClient defines the interface for interacting with the annotation API server.
 type annotationClient interface {
@@ -37,44 +30,36 @@ type annotationClient interface {
 	Update(ctx context.Context, orgID int64, anno *annotationV0.Annotation) (*annotationV0.Annotation, error)
 	Delete(ctx context.Context, orgID int64, name string) error
 	GetByLegacyID(ctx context.Context, orgID int64, annotationID int64) (*annotationV0.Annotation, error)
-	GetUsersFromMeta(ctx context.Context, usersMeta []string) (map[string]*user.User, error)
 	Search(ctx context.Context, orgID int64, query *annotations.ItemQuery) ([]*annotationV0.Annotation, error)
 }
 
 var _ annotationClient = (*annotationAPIClient)(nil)
 
-// TODO: consider replacing k8sClient with a rest.RESTClient built from restCfg for consistency -
-// CRUD ops (Create, Update, Delete, also GetByLegacyID) currently go through k8sClient (dynamic),
-// while Search uses rest.RESTClient directly.
 type annotationAPIClient struct {
-	k8sClient client.K8sHandler
-	restCfg   *rest.Config
-
-	mu         sync.Mutex
-	restClient *rest.RESTClient
+	client   *rest.RESTClient
+	nsMapper request.NamespaceMapper
 }
 
 // newAnnotationAPIClient returns a client for the new annotation API server.
 // It returns nil when APIServerURL is empty (proxy disabled).
-func newAnnotationAPIClient(cfg *setting.Cfg, userSvc user.Service, exchanger authnlib.TokenExchanger) *annotationAPIClient {
+func newAnnotationAPIClient(cfg *setting.Cfg, exchanger authnlib.TokenExchanger) (*annotationAPIClient, error) {
 	url := strings.TrimSpace(cfg.AnnotationAppPlatform.APIServerURL)
 	if url == "" {
-		return nil
+		return nil, fmt.Errorf("annotation proxy: api_server_url must be set")
 	}
 
 	nsMapper := request.GetNamespaceMapper(cfg)
 	restCfg := buildRESTConfig(url, exchanger, nsMapper, cfg.AnnotationAppPlatform.TLSClientConfig)
 
-	return &annotationAPIClient{
-		k8sClient: client.NewK8sHandler(
-			nsMapper,
-			annotationV0.AnnotationKind().GroupVersionResource(),
-			func(_ context.Context) (*rest.Config, error) { return restCfg, nil },
-			userSvc,
-			nil,
-		),
-		restCfg: restCfg,
+	client, err := rest.RESTClientFor(restCfg)
+	if err != nil {
+		return nil, fmt.Errorf("annotation proxy: creating REST client: %w", err)
 	}
+
+	return &annotationAPIClient{
+		client:   client,
+		nsMapper: nsMapper,
+	}, nil
 }
 
 // ProvideTokenExchanger returns a TokenExchanger for the annotation API server, or nil if the proxy is disabled.
@@ -99,31 +84,41 @@ func ProvideTokenExchanger(cfg *setting.Cfg) (authnlib.TokenExchanger, error) {
 }
 
 func (s *annotationAPIClient) Create(ctx context.Context, orgID int64, anno *annotationV0.Annotation) (*annotationV0.Annotation, error) {
-	obj, err := toUnstructured(anno)
+	body, err := json.Marshal(anno)
+	if err != nil {
+		return nil, fmt.Errorf("encode annotation: %w", err)
+	}
+
+	raw, err := s.collection(http.MethodPost, orgID).
+		SetHeader("Content-Type", runtime.ContentTypeJSON).
+		Body(body).
+		DoRaw(ctx)
 	if err != nil {
 		return nil, err
 	}
-	result, err := s.k8sClient.Create(ctx, obj, orgID, v1.CreateOptions{})
-	if err != nil {
-		return nil, err
-	}
-	return fromUnstructured(result)
+
+	return decodeAnnotation(raw)
 }
 
 func (s *annotationAPIClient) Update(ctx context.Context, orgID int64, anno *annotationV0.Annotation) (*annotationV0.Annotation, error) {
-	obj, err := toUnstructured(anno)
+	body, err := json.Marshal(anno)
+	if err != nil {
+		return nil, fmt.Errorf("encode annotation: %w", err)
+	}
+
+	raw, err := s.named(http.MethodPut, orgID, anno.GetName()).
+		SetHeader("Content-Type", runtime.ContentTypeJSON).
+		Body(body).
+		DoRaw(ctx)
 	if err != nil {
 		return nil, err
 	}
-	result, err := s.k8sClient.Update(ctx, obj, orgID, v1.UpdateOptions{})
-	if err != nil {
-		return nil, err
-	}
-	return fromUnstructured(result)
+
+	return decodeAnnotation(raw)
 }
 
 func (s *annotationAPIClient) Delete(ctx context.Context, orgID int64, name string) error {
-	return s.k8sClient.Delete(ctx, name, orgID, v1.DeleteOptions{})
+	return s.named(http.MethodDelete, orgID, name).Do(ctx).Error()
 }
 
 // GetByLegacyID fetches an annotation by its legacy ID, including the tombstone if it has
@@ -132,31 +127,22 @@ func (s *annotationAPIClient) Delete(ctx context.Context, orgID int64, name stri
 // TODO: expensive — the legacyID index does not cover the time partition, so this scans
 // every partition. Carrying the annotation time to the call sites would let us prune them.
 func (s *annotationAPIClient) GetByLegacyID(ctx context.Context, orgID int64, annotationID int64) (*annotationV0.Annotation, error) {
-	rc, err := s.getRESTClient()
-	if err != nil {
-		return nil, err
-	}
-
-	namespace := s.k8sClient.GetNamespace(orgID)
-	raw, err := rc.Get().
-		AbsPath("apis", annotationV0.APIGroup, annotationV0.APIVersion, "namespaces", namespace, "search").
+	req := s.client.Get().
+		Namespace(s.nsMapper(orgID)).
+		Resource("search").
 		Param("legacyID", strconv.FormatInt(annotationID, 10)).
-		Param("deleted", "include"). // include the tombstone so we can distinguish between deleted and missing
-		DoRaw(ctx)
+		Param("deleted", "include") // include the tombstone so we can distinguish between deleted and missing
+
+	list, err := doSearch(ctx, req)
 	if err != nil {
 		return nil, err
 	}
-
-	var list annotationV0.AnnotationList
-	if err := json.Unmarshal(raw, &list); err != nil {
-		return nil, fmt.Errorf("decode search response: %w", err)
-	}
-	if len(list.Items) == 0 {
+	if len(list) == 0 {
 		return nil, ErrNotFound
 	}
 
 	// Return the newest live annotation, or the tombstone if all are deleted.
-	live := slices.DeleteFunc(slices.Clone(list.Items), func(a annotationV0.Annotation) bool {
+	live := slices.DeleteFunc(slices.Clone(list), func(a annotationV0.Annotation) bool {
 		return a.GetDeletionTimestamp() != nil
 	})
 	if len(live) > 0 {
@@ -165,22 +151,14 @@ func (s *annotationAPIClient) GetByLegacyID(ctx context.Context, orgID int64, an
 		})
 		return &newest, nil
 	}
-	return &list.Items[0], nil
-}
-
-func (s *annotationAPIClient) GetUsersFromMeta(ctx context.Context, usersMeta []string) (map[string]*user.User, error) {
-	return s.k8sClient.GetUsersFromMeta(ctx, usersMeta)
+	return &list[0], nil
 }
 
 // Search calls the /search custom route, which handles all filtering server-side including tags.
 func (s *annotationAPIClient) Search(ctx context.Context, orgID int64, query *annotations.ItemQuery) ([]*annotationV0.Annotation, error) {
-	rc, err := s.getRESTClient()
-	if err != nil {
-		return nil, err
-	}
-
-	namespace := s.k8sClient.GetNamespace(orgID)
-	req := rc.Get().AbsPath("apis", annotationV0.APIGroup, annotationV0.APIVersion, "namespaces", namespace, "search")
+	req := s.client.Get().
+		Namespace(s.nsMapper(orgID)).
+		Resource("search")
 
 	if query.DashboardUID != "" {
 		req = req.Param("dashboardUID", query.DashboardUID)
@@ -207,6 +185,32 @@ func (s *annotationAPIClient) Search(ctx context.Context, orgID int64, query *an
 		req = req.Param("createdBy", query.UserUID)
 	}
 
+	list, err := doSearch(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]*annotationV0.Annotation, len(list))
+	for i := range list {
+		result[i] = &list[i]
+	}
+	return result, nil
+}
+
+// collection builds a request against the namespaced annotations collection for orgID.
+func (s *annotationAPIClient) collection(verb string, orgID int64) *rest.Request {
+	return s.client.Verb(verb).
+		Namespace(s.nsMapper(orgID)).
+		Resource(annotationV0.AnnotationKind().Plural())
+}
+
+// named builds a request against a single annotation by its resource name.
+func (s *annotationAPIClient) named(verb string, orgID int64, name string) *rest.Request {
+	return s.collection(verb, orgID).Name(name)
+}
+
+// doSearch runs a request against the /search custom route and decodes the matching annotations.
+func doSearch(ctx context.Context, req *rest.Request) ([]annotationV0.Annotation, error) {
 	raw, err := req.DoRaw(ctx)
 	if err != nil {
 		return nil, err
@@ -216,47 +220,15 @@ func (s *annotationAPIClient) Search(ctx context.Context, orgID int64, query *an
 	if err := json.Unmarshal(raw, &list); err != nil {
 		return nil, fmt.Errorf("decode search response: %w", err)
 	}
-
-	result := make([]*annotationV0.Annotation, len(list.Items))
-	for i := range list.Items {
-		result[i] = &list.Items[i]
-	}
-	return result, nil
+	return list.Items, nil
 }
 
-func toUnstructured(anno *annotationV0.Annotation) (*unstructured.Unstructured, error) {
-	obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(anno)
-	if err != nil {
-		return nil, fmt.Errorf("annotation to unstructured: %w", err)
-	}
-	return &unstructured.Unstructured{Object: obj}, nil
-}
-
-func fromUnstructured(obj *unstructured.Unstructured) (*annotationV0.Annotation, error) {
+func decodeAnnotation(raw []byte) (*annotationV0.Annotation, error) {
 	var anno annotationV0.Annotation
-	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &anno); err != nil {
-		return nil, fmt.Errorf("unstructured to annotation: %w", err)
+	if err := json.Unmarshal(raw, &anno); err != nil {
+		return nil, fmt.Errorf("decode annotation response: %w", err)
 	}
 	return &anno, nil
-}
-
-// getRESTClient returns a cached REST client for calling custom routes.
-// Pattern from pkg/services/user/userk8s: dynamic.ConfigFor sets JSON content negotiation,
-// GroupVersion scopes the client to the annotation API group.
-func (s *annotationAPIClient) getRESTClient() (*rest.RESTClient, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.restClient != nil {
-		return s.restClient, nil
-	}
-	dynCfg := dynamic.ConfigFor(s.restCfg)
-	dynCfg.GroupVersion = &annotationV0.GroupVersion
-	rc, err := rest.RESTClientFor(dynCfg)
-	if err != nil {
-		return nil, fmt.Errorf("create REST client: %w", err)
-	}
-	s.restClient = rc
-	return rc, nil
 }
 
 func newTokenExchangeClient(token, tokenExchangeURL string, allowInsecure bool) (authnlib.TokenExchanger, error) {
@@ -280,11 +252,14 @@ func newTokenExchangeClient(token, tokenExchangeURL string, allowInsecure bool) 
 }
 
 func buildRESTConfig(url string, exchanger authnlib.TokenExchanger, nsMapper request.NamespaceMapper, tlsConfig rest.TLSClientConfig) *rest.Config {
-	return &rest.Config{
+	cfg := dynamic.ConfigFor(&rest.Config{
 		Host:            url,
 		WrapTransport:   newBearerTokenExchangeWrapper(exchanger, nsMapper),
 		TLSClientConfig: tlsConfig,
-	}
+	})
+	cfg.APIPath = "apis"
+	cfg.GroupVersion = &annotationV0.GroupVersion
+	return cfg
 }
 
 type bearerTokenExchangeRT struct {
@@ -303,7 +278,7 @@ func (rt *bearerTokenExchangeRT) RoundTrip(req *http.Request) (*http.Response, e
 	namespace := rt.nsMapper(requester.GetOrgID())
 
 	exchangeReq := authnlib.TokenExchangeRequest{
-		Audiences: []string{annotationServerAudience},
+		Audiences: []string{annotationV0.APIGroup},
 		Namespace: namespace,
 	}
 

--- a/pkg/services/annotations/annotationsapi/api_client_test.go
+++ b/pkg/services/annotations/annotationsapi/api_client_test.go
@@ -2,12 +2,19 @@ package annotationsapi
 
 import (
 	"context"
+	"encoding/json"
+	"io"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	authnlib "github.com/grafana/authlib/authn"
 	claims "github.com/grafana/authlib/types"
+	annotationV0 "github.com/grafana/grafana/apps/annotation/pkg/apis/annotation/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/services/annotations"
+	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -82,12 +89,20 @@ func TestNewAnnotationAPIClient_TokenExchange(t *testing.T) {
 			}
 
 			exchanger := &fakeTokenExchanger{}
-			c := newAnnotationAPIClient(cfg, nil, exchanger)
+			c, err := newAnnotationAPIClient(cfg, exchanger)
+			require.NoError(t, err)
 			require.NotNil(t, c)
-			require.NotNil(t, c.restCfg.WrapTransport)
+
+			restCfg := buildRESTConfig(
+				cfg.AnnotationAppPlatform.APIServerURL,
+				exchanger,
+				request.GetNamespaceMapper(cfg),
+				cfg.AnnotationAppPlatform.TLSClientConfig,
+			)
+			require.NotNil(t, restCfg.WrapTransport)
 
 			next := &stubRoundTripper{}
-			rt := c.restCfg.WrapTransport(next)
+			rt := restCfg.WrapTransport(next)
 
 			req, err := http.NewRequest(http.MethodPost, cfg.AnnotationAppPlatform.APIServerURL+"/annotations", http.NoBody)
 			require.NoError(t, err)
@@ -106,9 +121,187 @@ func TestNewAnnotationAPIClient_TokenExchange(t *testing.T) {
 			require.Equal(t, http.StatusOK, resp.StatusCode)
 
 			assert.Equal(t, tt.wantNamespace, exchanger.gotRequest.Namespace)
-			assert.Equal(t, []string{annotationServerAudience}, exchanger.gotRequest.Audiences)
+			assert.Equal(t, []string{annotationV0.APIGroup}, exchanger.gotRequest.Audiences)
 			assert.Equal(t, tt.wantSubject, exchanger.gotRequest.Subject)
 			assert.Equal(t, "signed-token", next.gotToken)
 		})
 	}
+}
+
+func TestAnnotationAPIClient_Requests(t *testing.T) {
+	type recorded struct {
+		method      string
+		path        string
+		query       url.Values
+		contentType string
+		body        []byte
+	}
+
+	newClient := func(t *testing.T, handler http.HandlerFunc) (*annotationAPIClient, *[]recorded) {
+		t.Helper()
+		var seen []recorded
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			seen = append(seen, recorded{
+				method:      r.Method,
+				path:        r.URL.Path,
+				query:       r.URL.Query(),
+				contentType: r.Header.Get("Content-Type"),
+				body:        body,
+			})
+			handler(w, r)
+		}))
+		t.Cleanup(srv.Close)
+
+		cfg := &setting.Cfg{AnnotationAppPlatform: setting.AnnotationAppPlatformSettings{APIServerURL: srv.URL}}
+		c, err := newAnnotationAPIClient(cfg, &fakeTokenExchanger{})
+		require.NoError(t, err)
+		require.NotNil(t, c)
+		return c, &seen
+	}
+
+	ctx := identity.WithRequester(context.Background(),
+		&identity.StaticRequester{Type: claims.TypeUser, UserID: 1, OrgID: 1})
+
+	const base = "/apis/annotation.grafana.app/v0alpha1/namespaces/default"
+
+	respondJSON := func(payload string) http.HandlerFunc {
+		return func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(payload))
+		}
+	}
+
+	sentBody := func(t *testing.T, req recorded) *annotationV0.Annotation {
+		t.Helper()
+		var anno annotationV0.Annotation
+		require.NoError(t, json.Unmarshal(req.body, &anno))
+		return &anno
+	}
+
+	t.Run("Create POSTs the annotation to the namespaced collection", func(t *testing.T) {
+		c, seen := newClient(t, respondJSON(`{"metadata":{"name":"anno-1"},"spec":{"text":"hello"}}`))
+
+		input := &annotationV0.Annotation{
+			Spec: annotationV0.AnnotationSpec{Text: "hello", Time: 1000},
+		}
+		anno, err := c.Create(ctx, 1, input)
+		require.NoError(t, err)
+		assert.Equal(t, "anno-1", anno.GetName(), "the created annotation is decoded from the response")
+
+		require.Len(t, *seen, 1)
+		req := (*seen)[0]
+		assert.Equal(t, http.MethodPost, req.method)
+		assert.Equal(t, base+"/annotations", req.path)
+		assert.Equal(t, "application/json", req.contentType)
+
+		sent := sentBody(t, req)
+		assert.Equal(t, input, sent)
+	})
+
+	t.Run("Update PUTs the annotation to its own URL", func(t *testing.T) {
+		c, seen := newClient(t, respondJSON(`{"metadata":{"name":"anno-1"},"spec":{"text":"after"}}`))
+
+		anno := &annotationV0.Annotation{Spec: annotationV0.AnnotationSpec{Text: "after", Time: 1000}}
+		anno.SetName("anno-1")
+
+		updated, err := c.Update(ctx, 1, anno)
+		require.NoError(t, err)
+		assert.Equal(t, "after", updated.Spec.Text)
+
+		require.Len(t, *seen, 1)
+		req := (*seen)[0]
+		assert.Equal(t, http.MethodPut, req.method)
+		assert.Equal(t, base+"/annotations/anno-1", req.path,
+			"the URL is derived from the annotation's own name")
+		assert.Equal(t, "application/json", req.contentType)
+		assert.Equal(t, anno, sentBody(t, req))
+	})
+
+	t.Run("Delete targets the named annotation", func(t *testing.T) {
+		c, seen := newClient(t, respondJSON(`{}`))
+
+		require.NoError(t, c.Delete(ctx, 1, "anno-1"))
+
+		require.Len(t, *seen, 1)
+		assert.Equal(t, http.MethodDelete, (*seen)[0].method)
+		assert.Equal(t, base+"/annotations/anno-1", (*seen)[0].path)
+	})
+
+	t.Run("Search maps the query onto the search route's parameters", func(t *testing.T) {
+		c, seen := newClient(t, respondJSON(`{"items":[{"metadata":{"name":"anno-1"}}]}`))
+
+		results, err := c.Search(ctx, 1, &annotations.ItemQuery{
+			DashboardUID: "dash-1",
+			PanelID:      2,
+			From:         100,
+			To:           200,
+			Limit:        5,
+			Tags:         []string{"a", "b"},
+			MatchAny:     true,
+			UserUID:      "user-1",
+		})
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.Equal(t, "anno-1", results[0].GetName())
+
+		require.Len(t, *seen, 1)
+		req := (*seen)[0]
+		assert.Equal(t, http.MethodGet, req.method)
+		assert.Equal(t, base+"/search", req.path, "search hangs off the namespace, not the annotations collection")
+		assert.Equal(t, url.Values{
+			"dashboardUID": {"dash-1"},
+			"panelID":      {"2"},
+			"from":         {"100"},
+			"to":           {"200"},
+			"limit":        {"5"},
+			"tag":          {"a", "b"},
+			"tagsMatchAny": {"true"},
+			"createdBy":    {"user-1"},
+		}, req.query)
+	})
+
+	t.Run("Search omits parameters the query leaves unset", func(t *testing.T) {
+		c, seen := newClient(t, respondJSON(`{"items":[]}`))
+
+		_, err := c.Search(ctx, 1, &annotations.ItemQuery{MatchAny: true})
+		require.NoError(t, err)
+
+		require.Len(t, *seen, 1)
+		assert.Empty(t, (*seen)[0].query, "tagsMatchAny is meaningless without tags, so it is not sent either")
+	})
+
+	t.Run("GetByLegacyID searches by legacy ID and asks for tombstones", func(t *testing.T) {
+		c, seen := newClient(t, respondJSON(`{"items":[{"metadata":{"name":"anno-1"}}]}`))
+
+		anno, err := c.GetByLegacyID(ctx, 1, 42)
+		require.NoError(t, err)
+		assert.Equal(t, "anno-1", anno.GetName())
+
+		require.Len(t, *seen, 1)
+		req := (*seen)[0]
+		assert.Equal(t, base+"/search", req.path)
+		assert.Equal(t, url.Values{
+			"legacyID": {"42"},
+			"deleted":  {"include"},
+		}, req.query)
+	})
+
+	t.Run("GetByLegacyID reports ErrNotFound when the search comes back empty", func(t *testing.T) {
+		c, _ := newClient(t, respondJSON(`{"items":[]}`))
+
+		_, err := c.GetByLegacyID(ctx, 1, 42)
+		assert.ErrorIs(t, err, ErrNotFound)
+	})
+
+	t.Run("requests are scoped to the org's namespace", func(t *testing.T) {
+		c, seen := newClient(t, respondJSON(`{"items":[]}`))
+
+		_, err := c.Search(ctx, 7, &annotations.ItemQuery{})
+		require.NoError(t, err)
+
+		require.Len(t, *seen, 1)
+		assert.Equal(t, "/apis/annotation.grafana.app/v0alpha1/namespaces/org-7/search", (*seen)[0].path)
+	})
 }

--- a/pkg/services/annotations/annotationsapi/handler.go
+++ b/pkg/services/annotations/annotationsapi/handler.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	annotationpkg "github.com/grafana/grafana/pkg/registry/apps/annotation"
 	"github.com/grafana/grafana/pkg/services/annotations"
+	"github.com/grafana/grafana/pkg/services/apiserver/client"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -44,8 +45,9 @@ func (e *partialDecodeError) Unwrap() error { return e.Err }
 
 // MigrationProxy routes annotation writes to the new API server.
 type MigrationProxy struct {
-	client annotationClient
-	logger log.Logger
+	client  annotationClient
+	userSvc user.Service
+	logger  log.Logger
 }
 
 // ProvideMigrationProxy builds the proxy that routes legacy annotation operations to the new API server.
@@ -66,9 +68,15 @@ func ProvideMigrationProxy(cfg *setting.Cfg, userSvc user.Service, exchanger aut
 		return nil, fmt.Errorf("annotation proxy: api_server_url must be set when api_migration_phase is %q", phase)
 	}
 
+	client, err := newAnnotationAPIClient(cfg, exchanger)
+	if err != nil {
+		return nil, err
+	}
+
 	return &MigrationProxy{
-		client: newAnnotationAPIClient(cfg, userSvc, exchanger),
-		logger: log.New("annotationsapi"),
+		client:  client,
+		userSvc: userSvc,
+		logger:  log.New("annotationsapi"),
 	}, nil
 }
 
@@ -92,7 +100,7 @@ func (h *MigrationProxy) List(ctx context.Context, orgID int64, query *annotatio
 	userMap := map[string]*user.User{}
 	if len(createdByMeta) > 0 {
 		var err error
-		userMap, err = h.client.GetUsersFromMeta(ctx, createdByMeta)
+		userMap, err = client.GetUsersFromMeta(ctx, h.userSvc, createdByMeta)
 		if err != nil {
 			h.logger.Warn("failed to hydrate annotation users", "err", err)
 		}
@@ -267,7 +275,7 @@ func (h *MigrationProxy) Get(ctx context.Context, orgID int64, annotationID int6
 
 	createdBy := anno.GetCreatedBy()
 	if createdBy != "" {
-		if users, err := h.client.GetUsersFromMeta(ctx, []string{createdBy}); err == nil {
+		if users, err := client.GetUsersFromMeta(ctx, h.userSvc, []string{createdBy}); err == nil {
 			if u, ok := users[createdBy]; ok {
 				applyUserToDTO(u, dto)
 			}

--- a/pkg/services/apiserver/client/client.go
+++ b/pkg/services/apiserver/client/client.go
@@ -154,6 +154,10 @@ func (h *k8sHandler) GetStats(ctx context.Context, orgID int64) (*resourcepb.Res
 
 // GetUsersFromMeta takes what meta accessor gives you from `GetCreatedBy` or `GetUpdatedBy` and returns the user(s), with the meta as the key
 func (h *k8sHandler) GetUsersFromMeta(ctx context.Context, usersMeta []string) (map[string]*user.User, error) {
+	return GetUsersFromMeta(ctx, h.userService, usersMeta)
+}
+
+func GetUsersFromMeta(ctx context.Context, userService user.Service, usersMeta []string) (map[string]*user.User, error) {
 	uids := []string{}
 	ids := []int64{}
 	metaToId := make(map[string]int64)
@@ -177,7 +181,7 @@ func (h *k8sHandler) GetUsersFromMeta(ctx context.Context, usersMeta []string) (
 		}
 	}
 
-	users, err := h.userService.ListByIdOrUID(ctx, uids, ids)
+	users, err := userService.ListByIdOrUID(ctx, uids, ids)
 	if err != nil {
 		return userMap, nil
 	}


### PR DESCRIPTION
This PR refactors the annotation migration proxy's API client to use the `rest.RESTClient` directly instead of depending on the more opinionated `client.K8sHandler`. This not only unifies the implementation on the REST client, which was already used for calls to the custom `/search` route, but also provides more flexibility in how requests are made to the new API and opens the door for leveraging its support for `PATCH` requests.

It also adds a basic set of tests for the API client layer to assert that the resulting request shapes are what we expect them to be.

Resolves: https://github.com/grafana/grafana-org/issues/955