### PR TITLE
Plugins: add user list tab extension point

### DIFF
--- a/packages/grafana-data/src/types/pluginExtensions.ts
+++ b/packages/grafana-data/src/types/pluginExtensions.ts
@@ -241,6 +241,7 @@ export enum PluginExtensionPoints {
   HomepageTabs = 'grafana/homepage/tabs/v1',
   HomepageAssistant = 'grafana/homepage/assistant/v1',
   HomepageExtra = 'grafana/homepage/extra/v1',
+  UserListTab = 'grafana/admin/user-list/tab/v1',
 }
 
 // Don't use directly in a plugin!

--- a/public/app/features/admin/UserListPage.test.tsx
+++ b/public/app/features/admin/UserListPage.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { selectors as e2eSelectors } from '@grafana/e2e-selectors';
 import { type GrafanaBootConfig } from '@grafana/runtime';
 import config from 'app/core/config';
+import { AccessControlAction } from 'app/types/accessControl';
 
 import { TestProvider } from '../../../test/helpers/TestProvider';
 import { contextSrv } from '../../core/services/context_srv';
@@ -163,5 +164,13 @@ describe('Tables rendering', () => {
     expect(screen.queryByTestId(tabsSelector.publicDashboardsUsers)).not.toBeInTheDocument();
 
     expect(screen.getByTestId(selectors.UsersListPage.container)).toBeInTheDocument();
+  });
+  it('should render the global admin user list when user only has UsersRead (not OrgUsersRead)', () => {
+    jest.spyOn(contextSrv, 'hasPermission').mockImplementation((action) => action === AccessControlAction.UsersRead);
+
+    renderPage();
+
+    expect(screen.getByTestId(selectors.UserListAdminPage.container)).toBeInTheDocument();
+    expect(screen.queryByTestId(selectors.UsersListPage.container)).not.toBeInTheDocument();
   });
 });

--- a/public/app/features/admin/UserListPage.tsx
+++ b/public/app/features/admin/UserListPage.tsx
@@ -115,6 +115,13 @@ export default function UserListPage() {
           content: <UserListAnonymousDevicesPageContent />,
         });
       }
+    } else if (hasAccessToAdminUsers) {
+      result.push({
+        id: TabView.ADMIN,
+        label: t('admin.user-list-page.label-all-users', 'All users'),
+        testId: selectors.tabs.allUsers,
+        content: <UserListAdminPageContent />,
+      });
     } else if (isEmailSharingEnabled()) {
       result.push({
         id: TabView.ORG,
@@ -140,7 +147,7 @@ export default function UserListPage() {
     }
 
     return result;
-  }, [showAdminAndOrgTabs]);
+  }, [showAdminAndOrgTabs, hasAccessToAdminUsers]);
 
   const allTabs = [...builtInTabs, ...extensionTabs];
   const activeTabId = allTabs.some((tab) => tab.id === view) ? view : (allTabs[0]?.id ?? '');

--- a/public/app/features/admin/UserListPage.tsx
+++ b/public/app/features/admin/UserListPage.tsx
@@ -1,8 +1,8 @@
 import { css } from '@emotion/css';
-import { useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import * as React from 'react';
 
-import { type GrafanaTheme2 } from '@grafana/data';
+import { type ComponentTypeWithExtensionMeta, type GrafanaTheme2 } from '@grafana/data';
 import { selectors as e2eSelectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
@@ -16,92 +16,156 @@ import { UsersListPageContent } from '../users/UsersListPage';
 
 import { UserListAdminPageContent } from './UserListAdminPage';
 import { UserListAnonymousDevicesPageContent } from './UserListAnonymousPage';
+import { type UserListTab, type UserListTabExtensionProps, validateUserListTab } from './UserListPage.types';
 import { UserListPublicDashboardPage } from './UserListPublicDashboardPage/UserListPublicDashboardPage';
+import { useUserListTabExtensions } from './useUserListTabExtensions';
 
 enum TabView {
+  ACTIVE_USERS = 'active-users',
   ADMIN = 'admin',
   ORG = 'org',
   PUBLIC_DASHBOARDS = 'public-dashboards',
   ANON = 'anon',
 }
 
+type TabDef = {
+  id: string;
+  label: string;
+  testId?: string;
+  counter?: number;
+  content: React.ReactElement;
+};
+
 const selectors = e2eSelectors.pages.UserListPage;
 
-const PublicDashboardsTab = ({ view, setView }: { view: TabView | null; setView: (v: TabView | null) => void }) => {
-  return (
-    <Tab
-      label={t('users-access-list.tabs.shared-dashboard-users-tab-title', 'Shared dashboard users')}
-      active={view === TabView.PUBLIC_DASHBOARDS}
-      onChangeTab={() => setView(TabView.PUBLIC_DASHBOARDS)}
-      data-testid={selectors.tabs.publicDashboardsUsers}
-    />
-  );
-};
+function UserListExtensionTab({
+  Component,
+  registerTab,
+  activeTab,
+}: {
+  Component: ComponentTypeWithExtensionMeta<UserListTabExtensionProps>;
+  registerTab: (tab: UserListTab) => () => void;
+  activeTab: string;
+}) {
+  const [id, setId] = useState<string | null>(null);
+  const register = useCallback(
+    (tab: unknown) => {
+      validateUserListTab(tab);
 
-const TAB_PAGE_MAP: Record<TabView, React.ReactElement> = {
-  [TabView.ADMIN]: <UserListAdminPageContent />,
-  [TabView.ORG]: <UsersListPageContent />,
-  [TabView.PUBLIC_DASHBOARDS]: <UserListPublicDashboardPage />,
-  [TabView.ANON]: <UserListAnonymousDevicesPageContent />,
-};
+      setId(tab.id);
+      const unregister = registerTab(tab);
+
+      return () => {
+        setId(null);
+        unregister();
+      };
+    },
+    [registerTab]
+  );
+
+  return <Component register={register} active={activeTab === id} />;
+}
 
 export default function UserListPage() {
   const styles = useStyles2(getStyles);
 
   const hasAccessToAdminUsers = contextSrv.hasPermission(AccessControlAction.UsersRead);
   const hasAccessToOrgUsers = contextSrv.hasPermission(AccessControlAction.OrgUsersRead);
+  const showAdminAndOrgTabs = hasAccessToOrgUsers && hasAccessToAdminUsers;
 
-  const [view, setView] = useState(() => {
+  const [view, setView] = useState<string>(() => {
     if (hasAccessToAdminUsers) {
       return TabView.ADMIN;
     } else if (hasAccessToOrgUsers) {
       return TabView.ORG;
     }
-    return null;
+    return TabView.ACTIVE_USERS;
   });
 
-  const showAdminAndOrgTabs = hasAccessToOrgUsers && hasAccessToAdminUsers;
+  const [extensionTabs, setExtensionTabs] = useState<UserListTab[]>([]);
+
+  const extensionComponents = useUserListTabExtensions();
+
+  const registerTab = useCallback((tab: UserListTab) => {
+    setExtensionTabs((prev) => [...prev, tab]);
+    return () => setExtensionTabs((prev) => prev.filter((t) => t !== tab));
+  }, []);
+
+  const builtInTabs = useMemo<TabDef[]>(() => {
+    const result: TabDef[] = [];
+
+    if (showAdminAndOrgTabs) {
+      result.push({
+        id: TabView.ADMIN,
+        label: t('admin.user-list-page.label-all-users', 'All users'),
+        testId: selectors.tabs.allUsers,
+        content: <UserListAdminPageContent />,
+      });
+      result.push({
+        id: TabView.ORG,
+        label: t('admin.user-list-page.label-organization-users', 'Organization users'),
+        testId: selectors.tabs.orgUsers,
+        content: <UsersListPageContent />,
+      });
+      if (config.anonymousEnabled) {
+        result.push({
+          id: TabView.ANON,
+          label: t('admin.user-list-page.label-anonymous-devices', 'Anonymous devices'),
+          testId: selectors.tabs.anonUserDevices,
+          content: <UserListAnonymousDevicesPageContent />,
+        });
+      }
+    } else if (isEmailSharingEnabled()) {
+      result.push({
+        id: TabView.ORG,
+        label: t('admin.user-list-page.label-users', 'Users'),
+        testId: selectors.tabs.users,
+        content: <UsersListPageContent />,
+      });
+    } else {
+      result.push({
+        id: TabView.ACTIVE_USERS,
+        label: t('admin.user-list-page.label-active-users', 'Active users'),
+        content: <UsersListPageContent />,
+      });
+    }
+
+    if (isEmailSharingEnabled()) {
+      result.push({
+        id: TabView.PUBLIC_DASHBOARDS,
+        label: t('users-access-list.tabs.shared-dashboard-users-tab-title', 'Shared dashboard users'),
+        testId: selectors.tabs.publicDashboardsUsers,
+        content: <UserListPublicDashboardPage />,
+      });
+    }
+
+    return result;
+  }, [showAdminAndOrgTabs]);
+
+  const allTabs = [...builtInTabs, ...extensionTabs];
+  const activeTabId = allTabs.some((tab) => tab.id === view) ? view : (allTabs[0]?.id ?? '');
 
   return (
     <Page navId={'global-users'}>
-      {showAdminAndOrgTabs ? (
+      {allTabs.length > 1 && (
         <TabsBar className={styles.tabsMargin}>
-          <Tab
-            label={t('admin.user-list-page.label-all-users', 'All users')}
-            active={view === TabView.ADMIN}
-            onChangeTab={() => setView(TabView.ADMIN)}
-            data-testid={selectors.tabs.allUsers}
-          />
-          <Tab
-            label={t('admin.user-list-page.label-organization-users', 'Organization users')}
-            active={view === TabView.ORG}
-            onChangeTab={() => setView(TabView.ORG)}
-            data-testid={selectors.tabs.orgUsers}
-          />
-          {config.anonymousEnabled && (
+          {allTabs.map((tab) => (
             <Tab
-              label={t('admin.user-list-page.label-anonymous-devices', 'Anonymous devices')}
-              active={view === TabView.ANON}
-              onChangeTab={() => setView(TabView.ANON)}
-              data-testid={selectors.tabs.anonUserDevices}
+              key={tab.id}
+              label={tab.label}
+              icon={'icon' in tab ? tab.icon : undefined}
+              counter={tab.counter}
+              active={activeTabId === tab.id}
+              onChangeTab={() => setView(tab.id)}
+              {...('testId' in tab && tab.testId ? { 'data-testid': tab.testId } : {})}
             />
-          )}
-          {isEmailSharingEnabled() && <PublicDashboardsTab view={view} setView={setView} />}
+          ))}
         </TabsBar>
-      ) : (
-        isEmailSharingEnabled() && (
-          <TabsBar className={styles.tabsMargin}>
-            <Tab
-              label={t('admin.user-list-page.label-users', 'Users')}
-              active={view === TabView.ORG}
-              onChangeTab={() => setView(TabView.ORG)}
-              data-testid={selectors.tabs.users}
-            />
-            <PublicDashboardsTab view={view} setView={setView} />
-          </TabsBar>
-        )
       )}
-      {view ? TAB_PAGE_MAP[view] : <UsersListPageContent />}
+      {builtInTabs.find((tab) => tab.id === activeTabId)?.content}
+      {extensionComponents.map((Component, i) => (
+        <UserListExtensionTab key={i} Component={Component} registerTab={registerTab} activeTab={activeTabId} />
+      ))}
     </Page>
   );
 }

--- a/public/app/features/admin/UserListPage.types.ts
+++ b/public/app/features/admin/UserListPage.types.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+
+import { isIconName } from '@grafana/data';
+
+const UserListTabSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  icon: z.string().refine(isIconName, { error: 'Unknown icon' }).optional(),
+  counter: z.number().optional(),
+});
+
+export type UserListTab = z.infer<typeof UserListTabSchema>;
+
+export function validateUserListTab(value: unknown): asserts value is UserListTab {
+  const result = UserListTabSchema.safeParse(value);
+  if (!result.success) {
+    throw new Error(`Invalid tab object returned from extension: ${z.prettifyError(result.error)}`);
+  }
+}
+
+export interface UserListTabExtensionProps {
+  active: boolean;
+  register: (tab: UserListTab) => () => void;
+}

--- a/public/app/features/admin/useUserListTabExtensions.ts
+++ b/public/app/features/admin/useUserListTabExtensions.ts
@@ -1,0 +1,18 @@
+import { useMemo } from 'react';
+
+import { type ComponentTypeWithExtensionMeta, PluginExtensionPoints } from '@grafana/data';
+import { SETUPGUIDE_PLUGIN_ID } from 'app/core/constants';
+import { usePluginComponents } from 'app/features/plugins/extensions/usePluginComponents';
+
+import { type UserListTabExtensionProps } from './UserListPage.types';
+
+export function useUserListTabExtensions(): Array<ComponentTypeWithExtensionMeta<UserListTabExtensionProps>> {
+  const { components } = usePluginComponents<UserListTabExtensionProps>({
+    extensionPointId: PluginExtensionPoints.UserListTab,
+  });
+
+  return useMemo(
+    () => components.filter((component) => component.meta.pluginId === SETUPGUIDE_PLUGIN_ID),
+    [components]
+  );
+}

--- a/public/app/features/users/UsersActionBar.tsx
+++ b/public/app/features/users/UsersActionBar.tsx
@@ -4,6 +4,7 @@ import { connect, type ConnectedProps } from 'react-redux';
 import { Trans, t } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
 import { RadioButtonGroup, LinkButton, FilterInput, InlineField } from '@grafana/ui';
+import { useUserListTabExtensions } from 'app/features/admin/useUserListTabExtensions';
 import { type StoreState } from 'app/types/store';
 
 import { selectTotal } from '../invites/state/selectors';
@@ -13,7 +14,7 @@ import { changeSearchQuery } from './state/actions';
 import { getUsersSearchQuery } from './state/selectors';
 import { getCanInviteUsersToOrg } from './utils';
 
-interface OwnProps {
+export interface OwnProps {
   showInvites: boolean;
   onShowInvites: () => void;
 }
@@ -40,6 +41,8 @@ export const UsersActionBarUnconnected = ({
   onShowInvites,
   showInvites,
 }: Props): JSX.Element => {
+  const hasUserListExtension = useUserListTabExtensions().length > 0;
+
   const options = [
     { label: t('users.users-action-bar-unconnected.options.label.users', 'Users'), value: 'users' },
     { label: `Pending Invites (${pendingInvitesCount})`, value: 'invites' },
@@ -74,7 +77,7 @@ export const UsersActionBarUnconnected = ({
           <Trans i18nKey="users.users-action-bar-unconnected.invite">Invite</Trans>
         </LinkButton>
       )}
-      <UsersExternalButton onExternalUserMngClick={onExternalUserMngClick} />
+      {!hasUserListExtension && <UsersExternalButton onExternalUserMngClick={onExternalUserMngClick} />}
     </div>
   );
 };

--- a/public/app/features/users/UsersActionBar.tsx
+++ b/public/app/features/users/UsersActionBar.tsx
@@ -14,7 +14,7 @@ import { changeSearchQuery } from './state/actions';
 import { getUsersSearchQuery } from './state/selectors';
 import { getCanInviteUsersToOrg } from './utils';
 
-export interface OwnProps {
+interface OwnProps {
   showInvites: boolean;
   onShowInvites: () => void;
 }

--- a/public/app/features/users/UsersListPage.tsx
+++ b/public/app/features/users/UsersListPage.tsx
@@ -6,6 +6,7 @@ import { config } from '@grafana/runtime';
 import { Alert } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 import { contextSrv } from 'app/core/services/context_srv';
+import { useUserListTabExtensions } from 'app/features/admin/useUserListTabExtensions';
 import { type StoreState } from 'app/types/store';
 import { type OrgUser } from 'app/types/user';
 
@@ -60,7 +61,9 @@ export const UsersListPageUnconnected = ({
   changeSort,
 }: Props) => {
   const [showInvites, setShowInvites] = useState(false);
-  const externalUserMngInfoHtml = config.externalUserMngInfo ? renderMarkdown(config.externalUserMngInfo) : '';
+  const hasUserListExtension = useUserListTabExtensions().length > 0;
+  const externalUserMngInfoHtml =
+    config.externalUserMngInfo && !hasUserListExtension ? renderMarkdown(config.externalUserMngInfo) : '';
 
   useEffect(() => {
     loadUsers();

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -270,6 +270,7 @@
       "placeholder-search-devices-by-ip-address": "Search devices by IP address."
     },
     "user-list-page": {
+      "label-active-users": "Active users",
       "label-all-users": "All users",
       "label-anonymous-devices": "Anonymous devices",
       "label-organization-users": "Organization users",


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Adds a new frontend plugin extension point, `grafana/admin/user-list/tab/v1` (`PluginExtensionPoints.UserListTab`), that lets a plugin register its own tab(s) on the admin User list page (`/admin/users`).

The `UserListPage` component was refactored from hardcoded tab rendering to a data-driven tab list. Built-in tabs (All users, Organization users, Anonymous devices, Shared dashboard users, Active users) are now generated from a single `TabDef[]` array, and extension-provided tabs are appended alongside them. An extension component mounts, registers its tab metadata (id, label, icon, counter) via a `register` callback validated with a zod schema, and only renders its content when its tab is active — mirroring the existing homepage tabs pattern.

When an extension takes over the user list (currently gated to the setup guide plugin, `grafana-setupguide-app`), the built-in external user management UI is hidden: the "External user management" button in `UsersActionBar` and the `externalUserMngInfo` markdown notice in `UsersListPage`.

Key changes:

- `packages/grafana-data/src/types/pluginExtensions.ts` — new `UserListTab` extension point
- `public/app/features/admin/UserListPage.tsx` — data-driven tabs + extension mounting
- `public/app/features/admin/UserListPage.types.ts` — tab type + zod validation
- `public/app/features/admin/useUserListTabExtensions.ts` — hook resolving registered extension components
- `public/app/features/users/UsersActionBar.tsx`, `UsersListPage.tsx` — hide built-in external user management when an extension is present

**Why do we need this feature?**

The setup guide plugin needs to surface its own user management experience within Grafana's existing User list page rather than as a disconnected page. Today the tabs on that page are hardcoded, so there's no supported way for a plugin to contribute a tab or replace the built-in external user management prompts. This extension point provides that integration surface in a controlled, validated way.

**Who is this feature for?**

Grafana admins using the setup guide plugin, and (via the new extension point) plugin developers who need to extend the admin User list page. The consuming implementation lives in the setup guide plugin: https://github.com/grafana/grafana-setupguide-app/pull/1323

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

The extension point is currently restricted to the `grafana-setupguide-app` plugin ID in `useUserListTabExtensions`. The consuming PR is https://github.com/grafana/grafana-setupguide-app/pull/1323.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
