### PR TITLE
Datasources (backend): Capture frontend panel data for diagnostics bundles

### DIFF
--- a/pkg/api/ds_query_diagnostics.go
+++ b/pkg/api/ds_query_diagnostics.go
@@ -25,16 +25,6 @@ type diagnosticsRequest struct {
 	dtos.MetricRequest
 	Dashboard json.RawMessage `json:"dashboard"`
 	Panel     json.RawMessage `json:"panel"`
-	// PanelData is the data frames the client's frontend was holding for this panel, bundled as
-	// paneldata.json. Optional: the frontend omits it when it had nothing to capture, and sends a
-	// {version, captureError} record in place of the frames when the capture itself failed -- so an
-	// absent artifact means "nothing to capture" rather than "the capture broke". An absent payload --
-	// or a well-formed one of an unexpected shape -- never fails the request. Two things do, and both
-	// cost the caller the entire bundle rather than just this artifact: a syntactically malformed
-	// payload, because encoding/json validates the bytes it captures into a RawMessage and so the
-	// web.Bind below rejects the whole body; and size, because web.MaxBindBodyBytes caps the whole
-	// request (at 100MiB) rather than this field. Bounding both is the client's job; see
-	// diagnostics.WithPanelData.
 	PanelData json.RawMessage `json:"panelData"`
 }
 

--- a/pkg/api/ds_query_diagnostics.go
+++ b/pkg/api/ds_query_diagnostics.go
@@ -27,7 +27,10 @@ type diagnosticsRequest struct {
 	Panel     json.RawMessage `json:"panel"`
 	// PanelData is the data frames the client's frontend was holding for this panel, bundled as
 	// paneldata.json. Optional: the frontend omits it when it could not be serialized, and an absent
-	// or unusable payload never fails the request.
+	// or malformed payload never fails the request. Size is the exception -- web.MaxBindBodyBytes caps
+	// the whole request rather than this field, so a payload past it fails the web.Bind below and costs
+	// the caller the entire bundle, not just this artifact. Bounding it is the client's job; see
+	// diagnostics.WithPanelData.
 	PanelData json.RawMessage `json:"panelData"`
 }
 

--- a/pkg/api/ds_query_diagnostics.go
+++ b/pkg/api/ds_query_diagnostics.go
@@ -25,6 +25,10 @@ type diagnosticsRequest struct {
 	dtos.MetricRequest
 	Dashboard json.RawMessage `json:"dashboard"`
 	Panel     json.RawMessage `json:"panel"`
+	// PanelData is the data frames the client's frontend was holding for this panel, bundled as
+	// paneldata.json. Optional: the frontend omits it when it could not be serialized, and an absent
+	// or unusable payload never fails the request.
+	PanelData json.RawMessage `json:"panelData"`
 }
 
 // diagnosticsFeatureClient is a shared OpenFeature client reused across requests. Flags are
@@ -108,7 +112,8 @@ func (hs *HTTPServer) QueryDiagnostics(c *contextmodel.ReqContext) response.Resp
 	if marshalErr != nil {
 		queryRequestJSON = nil
 	}
-	bundle, err := diagnostics.NewBundler().Build(resp, harBuffer, reqDTO.Panel, reqDTO.Dashboard, queryRequestJSON, marshalErr, bundleErr)
+	bundle, err := diagnostics.NewBundler().Build(resp, harBuffer, reqDTO.Panel, reqDTO.Dashboard, queryRequestJSON, marshalErr, bundleErr,
+		diagnostics.WithPanelData(reqDTO.PanelData))
 	if err != nil {
 		return response.Error(http.StatusInternalServerError, "failed to build diagnostics bundle", err)
 	}

--- a/pkg/api/ds_query_diagnostics.go
+++ b/pkg/api/ds_query_diagnostics.go
@@ -26,12 +26,15 @@ type diagnosticsRequest struct {
 	Dashboard json.RawMessage `json:"dashboard"`
 	Panel     json.RawMessage `json:"panel"`
 	// PanelData is the data frames the client's frontend was holding for this panel, bundled as
-	// paneldata.json. Optional: the frontend omits it when it could not be serialized, and an absent
-	// payload -- or a well-formed one of an unexpected shape -- never fails the request. Two things do,
-	// and both cost the caller the entire bundle rather than just this artifact: a syntactically
-	// malformed payload, because encoding/json validates the bytes it captures into a RawMessage and so
-	// the web.Bind below rejects the whole body; and size, because web.MaxBindBodyBytes caps the whole
-	// request rather than this field. Bounding both is the client's job; see diagnostics.WithPanelData.
+	// paneldata.json. Optional: the frontend omits it when it had nothing to capture, and sends a
+	// {version, captureError} record in place of the frames when the capture itself failed -- so an
+	// absent artifact means "nothing to capture" rather than "the capture broke". An absent payload --
+	// or a well-formed one of an unexpected shape -- never fails the request. Two things do, and both
+	// cost the caller the entire bundle rather than just this artifact: a syntactically malformed
+	// payload, because encoding/json validates the bytes it captures into a RawMessage and so the
+	// web.Bind below rejects the whole body; and size, because web.MaxBindBodyBytes caps the whole
+	// request (at 100MiB) rather than this field. Bounding both is the client's job; see
+	// diagnostics.WithPanelData.
 	PanelData json.RawMessage `json:"panelData"`
 }
 

--- a/pkg/api/ds_query_diagnostics.go
+++ b/pkg/api/ds_query_diagnostics.go
@@ -27,10 +27,11 @@ type diagnosticsRequest struct {
 	Panel     json.RawMessage `json:"panel"`
 	// PanelData is the data frames the client's frontend was holding for this panel, bundled as
 	// paneldata.json. Optional: the frontend omits it when it could not be serialized, and an absent
-	// or malformed payload never fails the request. Size is the exception -- web.MaxBindBodyBytes caps
-	// the whole request rather than this field, so a payload past it fails the web.Bind below and costs
-	// the caller the entire bundle, not just this artifact. Bounding it is the client's job; see
-	// diagnostics.WithPanelData.
+	// payload -- or a well-formed one of an unexpected shape -- never fails the request. Two things do,
+	// and both cost the caller the entire bundle rather than just this artifact: a syntactically
+	// malformed payload, because encoding/json validates the bytes it captures into a RawMessage and so
+	// the web.Bind below rejects the whole body; and size, because web.MaxBindBodyBytes caps the whole
+	// request rather than this field. Bounding both is the client's job; see diagnostics.WithPanelData.
 	PanelData json.RawMessage `json:"panelData"`
 }
 

--- a/pkg/api/ds_query_diagnostics_test.go
+++ b/pkg/api/ds_query_diagnostics_test.go
@@ -343,3 +343,24 @@ func TestQueryDiagnostics_noCapturePerRefIDError_returns400(t *testing.T) {
 	// No HAR captured + a per-refID error -> bare 400, no bundle (matches QueryMetricsV2's per-refID handling).
 	require.Equal(t, http.StatusBadRequest, hs.QueryDiagnostics(c).Status())
 }
+
+func TestQueryDiagnostics_bundlesPanelData(t *testing.T) {
+	setupOpenFeatureFlag(t, featuremgmt.FlagGrafanaOnDemandDiagnostics, true)
+	fakeQuery := query.NewFakeQueryService(t)
+	returnFreshHARResponse(fakeQuery, "QueryData")
+	hs := &HTTPServer{queryDataService: fakeQuery}
+	c, rec := newDiagReqCtx(t, `{
+		"queries":[{"refId":"A"}],
+		"panelData":{"version":1,"frames":[{"schema":{"name":"frontend-marker"}}]}
+	}`, nil)
+
+	resp := hs.QueryDiagnostics(c)
+	require.Equal(t, http.StatusOK, resp.Status())
+
+	resp.WriteTo(c)
+	files := readTarGzFiles(t, rec.Body.Bytes())
+	// The frontend's frames land in their own artifact, so they can be diffed against querydata.json
+	// (the backend's response) to localise data lost inside the plugin's frontend code.
+	require.Contains(t, string(files["paneldata.json"]), "frontend-marker")
+	require.NotContains(t, string(files["querydata.json"]), "frontend-marker")
+}

--- a/pkg/api/ds_query_diagnostics_test.go
+++ b/pkg/api/ds_query_diagnostics_test.go
@@ -362,5 +362,8 @@ func TestQueryDiagnostics_bundlesPanelData(t *testing.T) {
 	// The frontend's frames land in their own artifact, so they can be diffed against querydata.json
 	// (the backend's response) to localise data lost inside the plugin's frontend code.
 	require.Contains(t, string(files["paneldata.json"]), "frontend-marker")
+	// Anchored: without this, the assertion below passes vacuously if querydata.json ever stops being
+	// written -- the missing key yields an empty string, which contains nothing.
+	require.Contains(t, files, "querydata.json")
 	require.NotContains(t, string(files["querydata.json"]), "frontend-marker")
 }

--- a/pkg/api/ds_query_diagnostics_test.go
+++ b/pkg/api/ds_query_diagnostics_test.go
@@ -367,3 +367,36 @@ func TestQueryDiagnostics_bundlesPanelData(t *testing.T) {
 	require.Contains(t, files, "querydata.json")
 	require.NotContains(t, string(files["querydata.json"]), "frontend-marker")
 }
+
+// TestQueryDiagnostics_wrongShapedPanelDataDoesNotSinkTheBundle pins the containment claim on the
+// PanelData field that is actually REACHABLE here. The bundler's own test covers a syntactically
+// malformed payload and notes in the same breath that web.Bind rejects it before Build runs -- so the
+// worst that survives binding is a well-formed payload of an unexpected shape, and that is the case
+// the field comment promises costs the caller nothing else. Nothing asserted it until now.
+func TestQueryDiagnostics_wrongShapedPanelDataDoesNotSinkTheBundle(t *testing.T) {
+	setupOpenFeatureFlag(t, featuremgmt.FlagGrafanaOnDemandDiagnostics, true)
+
+	// Every JSON kind a RawMessage will accept in place of the expected object. A scalar is the shape a
+	// caller is likeliest to arrive with by accident; an array is the one likeliest to come from
+	// serializing the frames without their envelope.
+	for _, payload := range []string{`42`, `"not-an-object"`, `[]`, `{"unexpected":true}`} {
+		t.Run(payload, func(t *testing.T) {
+			fakeQuery := query.NewFakeQueryService(t)
+			returnFreshHARResponse(fakeQuery, "QueryData")
+			hs := &HTTPServer{queryDataService: fakeQuery}
+			c, rec := newDiagReqCtx(t, `{"queries":[{"refId":"A"}],"panelData":`+payload+`}`, nil)
+
+			resp := hs.QueryDiagnostics(c)
+			require.Equal(t, http.StatusOK, resp.Status(), "an unexpected shape must not fail the request")
+
+			resp.WriteTo(c)
+			files := readTarGzFiles(t, rec.Body.Bytes())
+			// Stored as sent: nothing on this side parses the payload, so its shape is not the bundler's
+			// business -- a reader keying off the frontend's version stamp decides what to make of it.
+			require.Equal(t, payload, string(files["paneldata.json"]))
+			// The point of the test: the rest of the bundle is untouched.
+			require.Contains(t, files, "querydata.json")
+			require.Contains(t, files, "traffic.har")
+		})
+	}
+}

--- a/pkg/services/diagnostics/diagnostics.go
+++ b/pkg/services/diagnostics/diagnostics.go
@@ -67,6 +67,14 @@ type buildConfig struct {
 // raw bytes for anything it cannot parse, so a malformed payload yields a malformed artifact rather
 // than a failed bundle. Size is likewise unbounded here -- the client decides what is worth sending,
 // and web.Bind's 100MiB request cap is the backstop.
+//
+// That unbounded size is deliberately asymmetric with querydata.json, which IS capped
+// (maxQueryDataArtifactBytes) and degrades to a frame summary above it. So on a panel whose backend
+// response exceeds that cap, the bundle holds full frontend frames beside a summarized backend
+// artifact, and the diff above is only a name/rows/fields comparison rather than a field-for-field
+// one. That case announces itself -- querydata.json carries "truncated": true -- so read the marker
+// before reading a series missing here as a frontend loss. Capping this artifact to match would cost
+// the common case (a complete diff) to make the rare one symmetric, so it is left uncapped.
 func WithPanelData(panelData json.RawMessage) BuildOption {
 	return func(cfg *buildConfig) {
 		cfg.panelData = panelData

--- a/pkg/services/diagnostics/diagnostics.go
+++ b/pkg/services/diagnostics/diagnostics.go
@@ -53,7 +53,9 @@ type buildConfig struct {
 }
 
 // WithPanelData bundles paneldata.json: the data frames the user's browser was holding for the panel,
-// serialized client-side from already-resolved scene state.
+// serialized client-side from already-resolved scene state -- or, when that serialization failed, the
+// {version, captureError} record the frontend sends in their place, so a capture that broke on the way
+// out stays distinguishable from a browser that had no frames to give (which sends nothing at all).
 //
 // This is the frontend counterpart to querydata.json, which holds what the datasource's *backend*
 // returned. Diffing the two is the point: a datasource plugin's frontend code also processes the
@@ -72,13 +74,19 @@ type buildConfig struct {
 // feature.
 //
 // Size is the one failure this does NOT contain, and it is the client's to bound: web.MaxBindBodyBytes
-// caps the whole REQUEST rather than this field, so a payload past it fails web.Bind before Build runs
-// and costs the caller the entire bundle instead of just this artifact. Bounding it is intentionally
-// postponed.
+// caps the whole REQUEST (at 100MiB) rather than this field, so a payload past it fails web.Bind before
+// Build runs and costs the caller the entire bundle instead of just this artifact. Bounding it is
+// intentionally postponed.
 //
 // Leaving it uncapped is also deliberately asymmetric with querydata.json, which IS capped
 // (maxQueryDataArtifactBytes) and degrades to a frame summary above it. Matching that cap would cost
 // the common case a complete diff to make the rare oversized one symmetric.
+//
+// Note for whoever adds the client-side bound: that reasoning only holds BELOW
+// maxQueryDataArtifactBytes. Past it querydata.json is already a frame summary, so a complete
+// paneldata.json has no fields left to be diffed against -- only frame and row counts -- and the
+// uncapped side stops buying a complete diff exactly where the payload is heaviest. Pick the two caps
+// together rather than independently.
 func WithPanelData(panelData json.RawMessage) BuildOption {
 	return func(cfg *buildConfig) {
 		cfg.panelData = panelData
@@ -87,7 +95,7 @@ func WithPanelData(panelData json.RawMessage) BuildOption {
 
 // Build assembles a .tar.gz bundle from the query response, the captured HAR buffer, and the
 // optional panel/dashboard JSON the client supplied. traffic.har is omitted when nothing was
-// captured.
+// captured. Artifacts only some callers can supply arrive through opts; see BuildOption.
 //
 // Server logs are intentionally omitted because they are not scoped to this request and would leak
 // unrelated activity into a bundle meant for external sharing; they will be tackled in a follow-up.

--- a/pkg/services/diagnostics/diagnostics.go
+++ b/pkg/services/diagnostics/diagnostics.go
@@ -44,7 +44,8 @@ func NewBundler() *Bundler {
 }
 
 // BuildOption sets optional bundle contents. An option, rather than another parameter on Build, because
-// only some callers can supply these artifacts -- paneldata.json needs a browser.
+// only some callers can supply these artifacts -- paneldata.json needs a browser. BuildDashboard accepts
+// none of these: paneldata.json is single-panel-only for now.
 type BuildOption func(*buildConfig)
 
 type buildConfig struct {
@@ -55,15 +56,26 @@ type buildConfig struct {
 // serialized client-side from already-resolved scene state.
 //
 // This is the frontend counterpart to querydata.json, which holds what the datasource's *backend*
-// returned.
+// returned. Diffing the two is the point: a datasource plugin's frontend code also processes the
+// response, so frames present in querydata.json but missing or altered here pin the loss on the
+// plugin's frontend rather than on its backend or the upstream.
 //
 // Unlike panel.json it is data, not a definition: reading it re-runs no queries and re-applies no
 // transformations.
 //
-// The payload is stored byte-for-byte as the client sent it: deliberately unvalidated, not
-// pretty-printed (unlike the other JSON artifacts -- indenting would hold a second, larger copy of an
-// unbounded payload), and not capped -- this is an experimental, admin-only, on-prem-gated feature and
-// the failure mode is contained.
+// The payload is stored byte-for-byte as the client sent it: deliberately unvalidated and, unlike the
+// other JSON artifacts, not pretty-printed. Nothing here parses it, so a malformed payload yields a
+// malformed artifact rather than a failed bundle, and indenting would hold a second, larger copy of an
+// unbounded input. This is an experimental, admin-only, on-prem-gated feature.
+//
+// Size is the one failure this does NOT contain, and it is the client's to bound: web.MaxBindBodyBytes
+// caps the whole REQUEST rather than this field, so a payload past it fails web.Bind before Build runs
+// and costs the caller the entire bundle instead of just this artifact. Bounding it is intentionally
+// postponed.
+//
+// Leaving it uncapped is also deliberately asymmetric with querydata.json, which IS capped
+// (maxQueryDataArtifactBytes) and degrades to a frame summary above it. Matching that cap would cost
+// the common case a complete diff to make the rare oversized one symmetric.
 func WithPanelData(panelData json.RawMessage) BuildOption {
 	return func(cfg *buildConfig) {
 		cfg.panelData = panelData
@@ -119,8 +131,8 @@ func (b *Bundler) Build(resp *backend.QueryDataResponse, harBuffer *harcapture.B
 
 	// A bare "null" is 4 bytes of valid JSON, so it clears a length check: treat it as not supplied
 	// rather than bundling an artifact whose whole content reads as "the frontend was holding no
-	// frames". Absent (not supplied) and empty (supplied, nothing in it) must not collapse into the
-	// same signal -- that is exactly the frontend-loss misreading WithPanelData warns about.
+	// frames". A real capture of zero frames ({"version":1,"frames":[]}) still ships -- that one IS a
+	// frontend loss worth seeing, and it must not collapse into "the client had nothing to send".
 	if panelData := bytes.TrimSpace(cfg.panelData); len(panelData) > 0 && !bytes.Equal(panelData, []byte("null")) {
 		// Stored as sent, not indented -- see WithPanelData for why.
 		files["paneldata.json"] = panelData

--- a/pkg/services/diagnostics/diagnostics.go
+++ b/pkg/services/diagnostics/diagnostics.go
@@ -55,26 +55,15 @@ type buildConfig struct {
 // serialized client-side from already-resolved scene state.
 //
 // This is the frontend counterpart to querydata.json, which holds what the datasource's *backend*
-// returned. Diffing the two is the point: a datasource plugin's frontend code also processes the
-// response, so frames present in querydata.json but missing or altered here pin the loss on the
-// plugin's frontend rather than on its backend or the upstream.
+// returned.
 //
 // Unlike panel.json it is data, not a definition: reading it re-runs no queries and re-applies no
 // transformations.
 //
-// The payload is stored as the client sent it, deliberately unvalidated. This is an experimental,
-// admin-only, on-prem-gated feature, and the failure mode is contained: indentJSON falls back to the
-// raw bytes for anything it cannot parse, so a malformed payload yields a malformed artifact rather
-// than a failed bundle. Size is likewise unbounded here -- the client decides what is worth sending,
-// and web.Bind's 100MiB request cap is the backstop.
-//
-// That unbounded size is deliberately asymmetric with querydata.json, which IS capped
-// (maxQueryDataArtifactBytes) and degrades to a frame summary above it. So on a panel whose backend
-// response exceeds that cap, the bundle holds full frontend frames beside a summarized backend
-// artifact, and the diff above is only a name/rows/fields comparison rather than a field-for-field
-// one. That case announces itself -- querydata.json carries "truncated": true -- so read the marker
-// before reading a series missing here as a frontend loss. Capping this artifact to match would cost
-// the common case (a complete diff) to make the rare one symmetric, so it is left uncapped.
+// The payload is stored byte-for-byte as the client sent it: deliberately unvalidated, not
+// pretty-printed (unlike the other JSON artifacts -- indenting would hold a second, larger copy of an
+// unbounded payload), and not capped -- this is an experimental, admin-only, on-prem-gated feature and
+// the failure mode is contained.
 func WithPanelData(panelData json.RawMessage) BuildOption {
 	return func(cfg *buildConfig) {
 		cfg.panelData = panelData
@@ -128,8 +117,13 @@ func (b *Bundler) Build(resp *backend.QueryDataResponse, harBuffer *harcapture.B
 		files["traffic.har"] = har
 	}
 
-	if len(cfg.panelData) > 0 {
-		files["paneldata.json"] = indentJSON(cfg.panelData)
+	// A bare "null" is 4 bytes of valid JSON, so it clears a length check: treat it as not supplied
+	// rather than bundling an artifact whose whole content reads as "the frontend was holding no
+	// frames". Absent (not supplied) and empty (supplied, nothing in it) must not collapse into the
+	// same signal -- that is exactly the frontend-loss misreading WithPanelData warns about.
+	if panelData := bytes.TrimSpace(cfg.panelData); len(panelData) > 0 && !bytes.Equal(panelData, []byte("null")) {
+		// Stored as sent, not indented -- see WithPanelData for why.
+		files["paneldata.json"] = panelData
 	}
 
 	if len(panelJSON) > 0 {

--- a/pkg/services/diagnostics/diagnostics.go
+++ b/pkg/services/diagnostics/diagnostics.go
@@ -63,10 +63,13 @@ type buildConfig struct {
 // Unlike panel.json it is data, not a definition: reading it re-runs no queries and re-applies no
 // transformations.
 //
-// The payload is stored byte-for-byte as the client sent it: deliberately unvalidated and, unlike the
-// other JSON artifacts, not pretty-printed. Nothing here parses it, so a malformed payload yields a
-// malformed artifact rather than a failed bundle, and indenting would hold a second, larger copy of an
-// unbounded input. This is an experimental, admin-only, on-prem-gated feature.
+// The payload is stored as the client sent it, outer whitespace aside: deliberately unvalidated and,
+// unlike the other JSON artifacts, not pretty-printed. Nothing here parses it, so a malformed payload
+// yields a malformed artifact rather than a failed bundle, and indenting would hold a second, larger
+// copy of an unbounded input. That containment is for direct callers: through the HTTP endpoint
+// web.Bind rejects a syntactically malformed payload before Build runs, so the worst that reaches here
+// is a well-formed payload of the wrong shape. This is an experimental, admin-only, on-prem-gated
+// feature.
 //
 // Size is the one failure this does NOT contain, and it is the client's to bound: web.MaxBindBodyBytes
 // caps the whole REQUEST rather than this field, so a payload past it fails web.Bind before Build runs

--- a/pkg/services/diagnostics/diagnostics.go
+++ b/pkg/services/diagnostics/diagnostics.go
@@ -43,14 +43,49 @@ func NewBundler() *Bundler {
 	return &Bundler{}
 }
 
+// BuildOption sets optional bundle contents. An option, rather than another parameter on Build, because
+// only some callers can supply these artifacts -- paneldata.json needs a browser.
+type BuildOption func(*buildConfig)
+
+type buildConfig struct {
+	panelData json.RawMessage
+}
+
+// WithPanelData bundles paneldata.json: the data frames the user's browser was holding for the panel,
+// serialized client-side from already-resolved scene state.
+//
+// This is the frontend counterpart to querydata.json, which holds what the datasource's *backend*
+// returned. Diffing the two is the point: a datasource plugin's frontend code also processes the
+// response, so frames present in querydata.json but missing or altered here pin the loss on the
+// plugin's frontend rather than on its backend or the upstream.
+//
+// Unlike panel.json it is data, not a definition: reading it re-runs no queries and re-applies no
+// transformations.
+//
+// The payload is stored as the client sent it, deliberately unvalidated. This is an experimental,
+// admin-only, on-prem-gated feature, and the failure mode is contained: indentJSON falls back to the
+// raw bytes for anything it cannot parse, so a malformed payload yields a malformed artifact rather
+// than a failed bundle. Size is likewise unbounded here -- the client decides what is worth sending,
+// and web.Bind's 100MiB request cap is the backstop.
+func WithPanelData(panelData json.RawMessage) BuildOption {
+	return func(cfg *buildConfig) {
+		cfg.panelData = panelData
+	}
+}
+
 // Build assembles a .tar.gz bundle from the query response, the captured HAR buffer, and the
 // optional panel/dashboard JSON the client supplied. traffic.har is omitted when nothing was
 // captured.
 //
 // Server logs are intentionally omitted because they are not scoped to this request and would leak
 // unrelated activity into a bundle meant for external sharing; they will be tackled in a follow-up.
-func (b *Bundler) Build(resp *backend.QueryDataResponse, harBuffer *harcapture.Buffer, panelJSON, dashboardJSON, queryRequestJSON json.RawMessage, queryRequestErr, queryErr error) ([]byte, error) {
+func (b *Bundler) Build(resp *backend.QueryDataResponse, harBuffer *harcapture.Buffer, panelJSON, dashboardJSON, queryRequestJSON json.RawMessage, queryRequestErr, queryErr error, opts ...BuildOption) ([]byte, error) {
 	files := map[string][]byte{}
+
+	cfg := buildConfig{}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
 
 	// queryRequestErr is the caller's failure to serialize the request into queryRequestJSON. Record it
 	// so a support engineer can tell the request JSON was omitted because serialization failed rather
@@ -83,6 +118,10 @@ func (b *Bundler) Build(resp *backend.QueryDataResponse, harBuffer *harcapture.B
 	}
 	if len(har) > 0 {
 		files["traffic.har"] = har
+	}
+
+	if len(cfg.panelData) > 0 {
+		files["paneldata.json"] = indentJSON(cfg.panelData)
 	}
 
 	if len(panelJSON) > 0 {

--- a/pkg/services/diagnostics/diagnostics_test.go
+++ b/pkg/services/diagnostics/diagnostics_test.go
@@ -1020,7 +1020,7 @@ func TestBundler_Build_bundlesPanelData(t *testing.T) {
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
-	require.JSONEq(t, string(panelData), string(files["paneldata.json"]))
+	require.Equal(t, string(panelData), string(files["paneldata.json"]), "stored as sent")
 }
 
 func TestBundler_Build_omitsPanelDataWhenNotSupplied(t *testing.T) {

--- a/pkg/services/diagnostics/diagnostics_test.go
+++ b/pkg/services/diagnostics/diagnostics_test.go
@@ -1011,3 +1011,33 @@ func readTarGz(t *testing.T, data []byte) map[string][]byte {
 	}
 	return out
 }
+
+func TestBundler_Build_bundlesPanelData(t *testing.T) {
+	panelData := json.RawMessage(`{"version":1,"frames":[{"schema":{"name":"frontend-frames"}}]}`)
+
+	blob, err := NewBundler().Build(nil, &harcapture.Buffer{}, nil, nil, nil, nil, nil,
+		WithPanelData(panelData))
+	require.NoError(t, err)
+
+	files := readTarGz(t, blob)
+	require.JSONEq(t, string(panelData), string(files["paneldata.json"]))
+}
+
+func TestBundler_Build_omitsPanelDataWhenNotSupplied(t *testing.T) {
+	blob, err := NewBundler().Build(nil, &harcapture.Buffer{}, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	require.NotContains(t, readTarGz(t, blob), "paneldata.json")
+}
+
+func TestBundler_Build_malformedPanelDataDoesNotSinkTheBundle(t *testing.T) {
+	// The payload is client-supplied and deliberately unvalidated (experimental feature). What must hold
+	// is that garbage in it costs the bundle nothing else: every other artifact still ships.
+	blob, err := NewBundler().Build(nil, &harcapture.Buffer{}, json.RawMessage(`{"id":1}`), nil, nil, nil, nil,
+		WithPanelData(json.RawMessage(`{"version":1,`)))
+	require.NoError(t, err)
+
+	files := readTarGz(t, blob)
+	require.Contains(t, files, "panel.json")
+	require.Equal(t, `{"version":1,`, string(files["paneldata.json"]), "stored as sent")
+}

--- a/pkg/services/diagnostics/diagnostics_test.go
+++ b/pkg/services/diagnostics/diagnostics_test.go
@@ -1030,9 +1030,23 @@ func TestBundler_Build_omitsPanelDataWhenNotSupplied(t *testing.T) {
 	require.NotContains(t, readTarGz(t, blob), "paneldata.json")
 }
 
-func TestBundler_Build_malformedPanelDataDoesNotSinkTheBundle(t *testing.T) {
-	// The payload is client-supplied and deliberately unvalidated (experimental feature). What must hold
-	// is that garbage in it costs the bundle nothing else: every other artifact still ships.
+func TestBundler_Build_omitsPanelDataWhenNull(t *testing.T) {
+	// A client that sends "panelData": null supplied nothing, so no artifact: one whose whole content is
+	// `null` reads as "the frontend was holding no frames", which is a frontend loss that never happened.
+	for _, payload := range []string{`null`, ` null `, ``} {
+		blob, err := NewBundler().Build(nil, &harcapture.Buffer{}, nil, nil, nil, nil, nil,
+			WithPanelData(json.RawMessage(payload)))
+		require.NoError(t, err)
+
+		require.NotContains(t, readTarGz(t, blob), "paneldata.json", "payload %q", payload)
+	}
+}
+
+func TestBundler_Build_unparseablePanelDataDoesNotSinkTheBundle(t *testing.T) {
+	// Build stores the payload as sent and parses none of it, so a payload it could not parse costs the
+	// bundle nothing else: every other artifact still ships. Unreachable through the HTTP endpoint --
+	// web.Bind rejects a body that isn't valid JSON before Build runs, so the worst that arrives there is
+	// a well-formed payload of the wrong shape -- this pins the contract for direct callers.
 	blob, err := NewBundler().Build(nil, &harcapture.Buffer{}, json.RawMessage(`{"id":1}`), nil, nil, nil, nil,
 		WithPanelData(json.RawMessage(`{"version":1,`)))
 	require.NoError(t, err)


### PR DESCRIPTION
**Backend half** of `paneldata.json`. The frontend that serialises the frames is
grafana/grafana#129484 — the two can merge in either order.

## The gap

Every evidence artifact in a diagnostic bundle is recorded on the **server**: `traffic.har` is the HTTP
round-trip, `querydata.json` is the plugin's `QueryData` response, and `panel.json` / `dashboard.json` are
definitions.

A datasource plugin's **frontend** code also processes the response — Prometheus does a lot of it — and it
sits downstream of all of them. So a plugin whose frontend half loses data produces a bundle that reads as
**perfectly healthy** while the user is looking at a missing series. Nothing in the bundle can localise
that today.

## What this adds

`paneldata.json`: the data frames the browser was holding for the panel. The value is the **diff**:

```
querydata.json   (backend frames)   host-a, host-b     <- healthy
paneldata.json   (frontend frames)  host-a             <- host-b gone
                                    ------
                        finding:    host-b lost inside the plugin FRONTEND
```

Frames arrive as `DataFrameJSON` — the same encoding `querydata.json` uses — so the two compare
field-for-field rather than across formats.

## Independently deployable

`panelData` is an **optional** field on the existing request body, so this merges on its own: with no
frontend sending it, the artifact is simply absent. Equally the frontend can merge first — the field is
ignored and no artifact appears.

## Deliberately minimal — the limitations are the design

This is an **experimental, admin-only, on-prem-gated** feature (`grafana.onDemandDiagnostics`, on-prem
only, Grafana admin only). As such, corner cases and bundle size limitations are ignored for now—deferred in future, non-MVP versions.
