### PR TITLE
Annotations: handle /tags in migration proxy

### DIFF
--- a/pkg/api/annotations.go
+++ b/pkg/api/annotations.go
@@ -498,6 +498,11 @@ func (hs *HTTPServer) GetAnnotationTags(c *contextmodel.ReqContext) response.Res
 		Limit: c.QueryInt64("limit"),
 	}
 
+	// Default limit if not specified
+	if query.Limit == 0 {
+		query.Limit = defaultAnnotationsLimit
+	}
+
 	result, err := hs.annotationsRepo.FindTags(c.Req.Context(), query)
 	if err != nil {
 		return response.Error(http.StatusInternalServerError, "Failed to find annotation tags", err)

--- a/pkg/api/annotations_test.go
+++ b/pkg/api/annotations_test.go
@@ -356,6 +356,57 @@ func TestAPI_Annotations(t *testing.T) {
 	}
 }
 
+func TestAPI_GetAnnotationTags(t *testing.T) {
+	tests := []struct {
+		desc          string
+		path          string
+		expectedLimit int64
+	}{
+		{
+			desc:          "applies the default limit when none is supplied",
+			path:          "/api/annotations/tags",
+			expectedLimit: defaultAnnotationsLimit,
+		},
+		{
+			desc:          "passes an explicit limit through unchanged",
+			path:          "/api/annotations/tags?limit=250",
+			expectedLimit: 250,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			repo := annotations.FakeAnnotationsRepo{}
+			var gotQuery *annotations.TagsQuery
+			repo.On("FindTags", mock.Anything, mock.Anything).
+				Run(func(args mock.Arguments) {
+					gotQuery = args.Get(1).(*annotations.TagsQuery)
+				}).
+				Return(annotations.FindTagsResult{}, nil)
+
+			server := SetupAPITestServer(t, func(hs *HTTPServer) {
+				hs.Cfg = setting.NewCfg()
+				hs.annotationsRepo = &repo
+				hs.Features = featuremgmt.WithFeatures()
+				hs.AccessControl = acimpl.ProvideAccessControl(featuremgmt.WithFeatures())
+			})
+
+			permissions := []accesscontrol.Permission{{Action: accesscontrol.ActionAnnotationsRead}}
+			req := webtest.RequestWithSignedInUser(
+				server.NewRequest(http.MethodGet, tt.path, nil),
+				authedUserWithPermissions(1, 1, permissions),
+			)
+			res, err := server.SendJSON(req)
+			require.NoError(t, err)
+			require.NoError(t, res.Body.Close())
+			require.Equal(t, http.StatusOK, res.StatusCode)
+
+			require.NotNil(t, gotQuery)
+			assert.Equal(t, tt.expectedLimit, gotQuery.Limit)
+		})
+	}
+}
+
 func TestService_AnnotationTypeScopeResolver(t *testing.T) {
 	rootDashUID := "root-dashboard"
 	folderDashUID := "folder-dashboard"

--- a/pkg/registry/apps/annotation/memory_store.go
+++ b/pkg/registry/apps/annotation/memory_store.go
@@ -261,6 +261,9 @@ func (m *memoryStore) ListTags(ctx context.Context, namespace string, opts TagLi
 	for name, count := range tagCounts {
 		tags = append(tags, Tag{Name: name, Count: count})
 	}
+	slices.SortFunc(tags, func(a, b Tag) int {
+		return cmp.Compare(a.Name, b.Name)
+	})
 
 	if opts.Limit > 0 && len(tags) > opts.Limit {
 		tags = tags[:opts.Limit]

--- a/pkg/registry/apps/annotation/postgres_tags.go
+++ b/pkg/registry/apps/annotation/postgres_tags.go
@@ -103,7 +103,7 @@ func (s *PostgreSQLStore) ListTags(ctx context.Context, namespace string, opts T
 
 	query += `
 		GROUP BY tag
-		ORDER BY count DESC, tag
+		ORDER BY tag
 	`
 
 	// Add limit

--- a/pkg/registry/apps/annotation/tags_handler_test.go
+++ b/pkg/registry/apps/annotation/tags_handler_test.go
@@ -63,6 +63,15 @@ func TestIntegrationTagsHandler(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "a-8", Namespace: "namespace2"},
 			Spec:       annotationV0.AnnotationSpec{Text: "test", Time: 1000, Tags: []string{"tag3"}},
 		},
+		// namespace3 annotations
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "a-9", Namespace: "namespace3"},
+			Spec:       annotationV0.AnnotationSpec{Text: "test", Time: 1000, Tags: []string{"aardvark", "zebra"}},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "a-10", Namespace: "namespace3"},
+			Spec:       annotationV0.AnnotationSpec{Text: "test", Time: 1000, Tags: []string{"zebra"}},
+		},
 	}
 	for _, anno := range annotations {
 		ctx := k8srequest.WithNamespace(identity.WithServiceIdentityContext(ctx, 1), anno.Namespace)
@@ -74,11 +83,12 @@ func TestIntegrationTagsHandler(t *testing.T) {
 	handler := newTagsHandler(store, allowAll, tracing.InitializeTracerForTest(), ProvideMetrics(nil), log.NewNopLogger())
 
 	tests := []struct {
-		name         string
-		namespace    string
-		queryParams  url.Values
-		expectedTags map[string]int64
-		maxResults   int
+		name          string
+		namespace     string
+		queryParams   url.Values
+		expectedTags  map[string]int64
+		expectedOrder []string
+		maxResults    int
 	}{
 		{
 			name:        "No filters - returns all tags with default limit",
@@ -91,6 +101,7 @@ func TestIntegrationTagsHandler(t *testing.T) {
 				"incident":    1,
 				"release":     1,
 			},
+			expectedOrder: []string{"deployment", "env-prod", "env-staging", "incident", "release"},
 		},
 		{
 			name:      "Filter by prefix matching one tag",
@@ -127,7 +138,12 @@ func TestIntegrationTagsHandler(t *testing.T) {
 			queryParams: url.Values{
 				"limit": []string{"2"},
 			},
-			maxResults: 2,
+			expectedTags: map[string]int64{
+				"deployment": 3,
+				"env-prod":   2,
+			},
+			expectedOrder: []string{"deployment", "env-prod"},
+			maxResults:    2,
 		},
 		{
 			name:      "Invalid limit (not a number) - uses default of 100",
@@ -150,7 +166,23 @@ func TestIntegrationTagsHandler(t *testing.T) {
 				"prefix": []string{"env-"},
 				"limit":  []string{"1"},
 			},
-			maxResults: 1,
+			expectedTags: map[string]int64{
+				"env-prod": 2,
+			},
+			expectedOrder: []string{"env-prod"},
+			maxResults:    1,
+		},
+		{
+			name:      "Limit keeps alphabetically-first tag over higher-count tags",
+			namespace: "namespace3",
+			queryParams: url.Values{
+				"limit": []string{"1"},
+			},
+			expectedTags: map[string]int64{
+				"aardvark": 1,
+			},
+			expectedOrder: []string{"aardvark"},
+			maxResults:    1,
 		},
 		{
 			name:        "Namespace isolation - namespace1 only sees its own tags",
@@ -219,6 +251,15 @@ func TestIntegrationTagsHandler(t *testing.T) {
 				}
 
 				assert.Equal(t, tt.expectedTags, actualTags, "Tags and counts should match expected values")
+			}
+
+			if tt.expectedOrder != nil {
+				actualOrder := make([]string, 0, len(result.Tags))
+				for _, tag := range result.Tags {
+					actualOrder = append(actualOrder, tag.Tag)
+				}
+
+				assert.Equal(t, tt.expectedOrder, actualOrder, "Tags should be ordered by name")
 			}
 		})
 	}

--- a/pkg/services/annotations/annotationsapi/api_client.go
+++ b/pkg/services/annotations/annotationsapi/api_client.go
@@ -31,6 +31,7 @@ type annotationClient interface {
 	Delete(ctx context.Context, orgID int64, name string) error
 	GetByLegacyID(ctx context.Context, orgID int64, annotationID int64) (*annotationV0.Annotation, error)
 	Search(ctx context.Context, orgID int64, query *annotations.ItemQuery) ([]*annotationV0.Annotation, error)
+	ListTags(ctx context.Context, orgID int64, query *annotations.TagsQuery) ([]annotationV0.GetTagsV0alpha1BodyTags, error)
 }
 
 var _ annotationClient = (*annotationAPIClient)(nil)
@@ -195,6 +196,31 @@ func (s *annotationAPIClient) Search(ctx context.Context, orgID int64, query *an
 		result[i] = &list[i]
 	}
 	return result, nil
+}
+
+// ListTags calls the /tags custom route, which aggregates tag counts across the org.
+func (s *annotationAPIClient) ListTags(ctx context.Context, orgID int64, query *annotations.TagsQuery) ([]annotationV0.GetTagsV0alpha1BodyTags, error) {
+	req := s.client.Get().
+		Namespace(s.nsMapper(orgID)).
+		Resource("tags")
+
+	if query.Tag != "" {
+		req = req.Param("prefix", query.Tag)
+	}
+	if query.Limit != 0 {
+		req = req.Param("limit", strconv.FormatInt(query.Limit, 10))
+	}
+
+	raw, err := req.DoRaw(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var body annotationV0.GetTagsBody
+	if err := json.Unmarshal(raw, &body); err != nil {
+		return nil, fmt.Errorf("decode tags response: %w", err)
+	}
+	return body.Tags, nil
 }
 
 // collection builds a request against the namespaced annotations collection for orgID.

--- a/pkg/services/annotations/annotationsapi/api_client_test.go
+++ b/pkg/services/annotations/annotationsapi/api_client_test.go
@@ -295,6 +295,36 @@ func TestAnnotationAPIClient_Requests(t *testing.T) {
 		assert.ErrorIs(t, err, ErrNotFound)
 	})
 
+	t.Run("ListTags maps the tags query onto the tags route's parameters", func(t *testing.T) {
+		c, seen := newClient(t, respondJSON(`{"tags":[{"tag":"outage","count":3}]}`))
+
+		tags, err := c.ListTags(ctx, 1, &annotations.TagsQuery{OrgID: 1, Tag: "out", Limit: 25})
+		require.NoError(t, err)
+		require.Len(t, tags, 1)
+		assert.Equal(t, "outage", tags[0].Tag)
+		assert.Equal(t, float64(3), tags[0].Count)
+
+		require.Len(t, *seen, 1)
+		req := (*seen)[0]
+		assert.Equal(t, http.MethodGet, req.method)
+		assert.Equal(t, base+"/tags", req.path, "tags hangs off the namespace, not the annotations collection")
+		assert.Equal(t, url.Values{
+			"prefix": {"out"},
+			"limit":  {"25"},
+		}, req.query, "the legacy tag term becomes a prefix match")
+	})
+
+	t.Run("ListTags omits parameters the query leaves unset", func(t *testing.T) {
+		c, seen := newClient(t, respondJSON(`{"tags":[]}`))
+
+		tags, err := c.ListTags(ctx, 1, &annotations.TagsQuery{OrgID: 1})
+		require.NoError(t, err)
+		assert.Empty(t, tags)
+
+		require.Len(t, *seen, 1)
+		assert.Empty(t, (*seen)[0].query, "the server applies its own default limit")
+	})
+
 	t.Run("requests are scoped to the org's namespace", func(t *testing.T) {
 		c, seen := newClient(t, respondJSON(`{"items":[]}`))
 

--- a/pkg/services/annotations/annotationsapi/handler.go
+++ b/pkg/services/annotations/annotationsapi/handler.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"sort"
 	"strings"
 
 	authnlib "github.com/grafana/authlib/authn"
@@ -151,6 +152,47 @@ func Merge(newItems, legacyItems []*annotations.ItemDTO, limit int64) []*annotat
 		}
 		return cmp.Compare(b.Time, a.Time)
 	})
+
+	if limit > 0 && int64(len(merged)) > limit {
+		merged = merged[:limit]
+	}
+	return merged
+}
+
+// FindTags fetches org-wide tag counts from the new store.
+func (h *MigrationProxy) FindTags(ctx context.Context, orgID int64, query *annotations.TagsQuery) (annotations.FindTagsResult, error) {
+	tags, err := h.client.ListTags(ctx, orgID, query)
+	if err != nil {
+		return annotations.FindTagsResult{}, err
+	}
+
+	// Convert the new store's tag counts to the legacy DTO shape.
+	result := make([]*annotations.TagsDTO, 0, len(tags))
+	for _, tag := range tags {
+		result = append(result, &annotations.TagsDTO{
+			Tag:   tag.Tag,
+			Count: int64(tag.Count),
+		})
+	}
+	return annotations.FindTagsResult{Tags: result}, nil
+}
+
+// MergeTags combines new-store and legacy tag counts, summing the counts of tags present in
+// both stores, then sorts ascending by tag and applies limit to match the legacy response shape.
+func MergeTags(newTags, legacyTags []*annotations.TagsDTO, limit int64) []*annotations.TagsDTO {
+	counts := make(map[string]int64, len(newTags)+len(legacyTags))
+	for _, tag := range newTags {
+		counts[tag.Tag] += tag.Count
+	}
+	for _, tag := range legacyTags {
+		counts[tag.Tag] += tag.Count
+	}
+
+	merged := make([]*annotations.TagsDTO, 0, len(counts))
+	for tag, count := range counts {
+		merged = append(merged, &annotations.TagsDTO{Tag: tag, Count: count})
+	}
+	sort.Sort(annotations.SortedTags(merged))
 
 	if limit > 0 && int64(len(merged)) > limit {
 		merged = merged[:limit]

--- a/pkg/services/annotations/annotationsapi/handler_test.go
+++ b/pkg/services/annotations/annotationsapi/handler_test.go
@@ -384,4 +384,99 @@ func TestMigrationProxy(t *testing.T) {
 			assert.Empty(t, client.deletedNames, "the old record must not be deleted if the new one was not created")
 		})
 	})
+
+	t.Run("FindTags", func(t *testing.T) {
+		t.Run("converts the tag counts from the new store", func(t *testing.T) {
+			client := &fakeTagClient{tags: []annotationV0.GetTagsV0alpha1BodyTags{
+				{Tag: "outage", Count: 3},
+				{Tag: "region:eu", Count: 1},
+			}}
+			proxy := &MigrationProxy{client: client, logger: log.New("test")}
+
+			result, err := proxy.FindTags(context.Background(), 1, &annotations.TagsQuery{OrgID: 1, Tag: "o", Limit: 10})
+			require.NoError(t, err)
+			assert.Equal(t, []*annotations.TagsDTO{
+				{Tag: "outage", Count: 3},
+				{Tag: "region:eu", Count: 1},
+			}, result.Tags)
+
+			require.Len(t, client.tagQueries, 1)
+			assert.Equal(t, "o", client.tagQueries[0].Tag, "the query is passed through unchanged")
+		})
+
+		t.Run("propagates the client error", func(t *testing.T) {
+			proxy := &MigrationProxy{client: &fakeTagClient{err: assert.AnError}, logger: log.New("test")}
+
+			_, err := proxy.FindTags(context.Background(), 1, &annotations.TagsQuery{OrgID: 1})
+			require.ErrorIs(t, err, assert.AnError)
+		})
+	})
+}
+
+type fakeTagClient struct {
+	annotationClient
+
+	tags       []annotationV0.GetTagsV0alpha1BodyTags
+	err        error
+	tagQueries []*annotations.TagsQuery
+}
+
+func (f *fakeTagClient) ListTags(_ context.Context, _ int64, query *annotations.TagsQuery) ([]annotationV0.GetTagsV0alpha1BodyTags, error) {
+	f.tagQueries = append(f.tagQueries, query)
+	return f.tags, f.err
+}
+
+func TestMergeTags(t *testing.T) {
+	tag := func(name string, count int64) *annotations.TagsDTO {
+		return &annotations.TagsDTO{Tag: name, Count: count}
+	}
+
+	tests := []struct {
+		name       string
+		newTags    []*annotations.TagsDTO
+		legacyTags []*annotations.TagsDTO
+		limit      int64
+		want       []*annotations.TagsDTO
+	}{
+		{
+			name:       "sums the counts of tags present in both stores",
+			newTags:    []*annotations.TagsDTO{tag("shared", 2)},
+			legacyTags: []*annotations.TagsDTO{tag("shared", 3)},
+			want:       []*annotations.TagsDTO{tag("shared", 5)},
+		},
+		{
+			name:       "sorts ascending by tag regardless of the input ordering",
+			newTags:    []*annotations.TagsDTO{tag("zebra", 9), tag("alpha", 1)},
+			legacyTags: []*annotations.TagsDTO{tag("middle", 5)},
+			want:       []*annotations.TagsDTO{tag("alpha", 1), tag("middle", 5), tag("zebra", 9)},
+		},
+		{
+			name:       "truncates to the limit after sorting",
+			newTags:    []*annotations.TagsDTO{tag("c", 1), tag("a", 1)},
+			legacyTags: []*annotations.TagsDTO{tag("b", 1), tag("d", 1)},
+			limit:      3,
+			want:       []*annotations.TagsDTO{tag("a", 1), tag("b", 1), tag("c", 1)},
+		},
+		{
+			name:       "keeps every tag when the limit is zero",
+			newTags:    []*annotations.TagsDTO{tag("a", 1)},
+			legacyTags: []*annotations.TagsDTO{tag("b", 1)},
+			want:       []*annotations.TagsDTO{tag("a", 1), tag("b", 1)},
+		},
+		{
+			name: "returns an empty result when neither store has tags",
+			want: []*annotations.TagsDTO{},
+		},
+		{
+			name:    "keeps key:value tags distinct from their bare key",
+			newTags: []*annotations.TagsDTO{tag("region:eu", 1), tag("region", 2)},
+			want:    []*annotations.TagsDTO{tag("region", 2), tag("region:eu", 1)},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, MergeTags(tt.newTags, tt.legacyTags, tt.limit))
+		})
+	}
 }

--- a/pkg/services/annotations/annotationsapi/migration_repository.go
+++ b/pkg/services/annotations/annotationsapi/migration_repository.go
@@ -19,6 +19,7 @@ type annotationProxy interface {
 	Delete(ctx context.Context, orgID int64, annotationID int64) error
 	Get(ctx context.Context, orgID int64, annotationID int64) (*annotations.ItemDTO, error)
 	List(ctx context.Context, orgID int64, query *annotations.ItemQuery) ([]*annotations.ItemDTO, error)
+	FindTags(ctx context.Context, orgID int64, query *annotations.TagsQuery) (annotations.FindTagsResult, error)
 }
 
 var _ annotations.Repository = (*migrationRepository)(nil)
@@ -195,7 +196,26 @@ func (r *migrationRepository) Delete(ctx context.Context, params *annotations.De
 	}
 }
 
-// TODO: FindTags reads from legacy only. Follow up to proxy tag searches to the new store.
+// FindTags reads tag counts from the new store and merges in counts from legacy.
+// Since alert annotations remain in the legacy store, we always merge in legacy results.
 func (r *migrationRepository) FindTags(ctx context.Context, query *annotations.TagsQuery) (annotations.FindTagsResult, error) {
-	return r.legacy.FindTags(ctx, query)
+	newResult, err := r.proxy.FindTags(ctx, query.OrgID, query)
+	if err != nil {
+		if r.cfg.AnnotationAppPlatform.ProxyAll() {
+			// In proxy-all the new store is authoritative; a silent legacy fallback would
+			// hide tags behind a 200. Only degrade while legacy still holds everything.
+			return annotations.FindTagsResult{}, err
+		}
+		r.logger.Warn("new store tag search failed, returning legacy results only", "err", err)
+		newResult = annotations.FindTagsResult{}
+	}
+
+	legacyResult, err := r.legacy.FindTags(ctx, query)
+	if err != nil {
+		return annotations.FindTagsResult{}, err
+	}
+
+	return annotations.FindTagsResult{
+		Tags: MergeTags(newResult.Tags, legacyResult.Tags, query.Limit),
+	}, nil
 }

--- a/pkg/services/annotations/annotationsapi/migration_repository.go
+++ b/pkg/services/annotations/annotationsapi/migration_repository.go
@@ -222,6 +222,9 @@ func (r *migrationRepository) FindTags(ctx context.Context, query *annotations.T
 func (r *migrationRepository) legacyTagsToMerge(ctx context.Context, query *annotations.TagsQuery) ([]*annotations.TagsDTO, error) {
 	// In the proxy-writes phase the new store only has annotations created since the
 	// migration started, so we still merge in every tag from legacy.
+	// Note: If legacy annotations have been backfilled into the new store,
+	// this could result in double-counting tags if the instance is still in `proxy-writes` mode.
+	// This is a known limitation of the migration and will self-resolve once the instance is moved to `proxy-all`.
 	if !r.cfg.AnnotationAppPlatform.ProxyAll() {
 		result, err := r.legacy.FindTags(ctx, query)
 		return result.Tags, err

--- a/pkg/services/annotations/annotationsapi/migration_repository.go
+++ b/pkg/services/annotations/annotationsapi/migration_repository.go
@@ -196,8 +196,7 @@ func (r *migrationRepository) Delete(ctx context.Context, params *annotations.De
 	}
 }
 
-// FindTags reads tag counts from the new store and merges in counts from legacy.
-// Since alert annotations remain in the legacy store, we always merge in legacy results.
+// FindTags reads tag counts from the new store and merges in what the legacy store still owns.
 func (r *migrationRepository) FindTags(ctx context.Context, query *annotations.TagsQuery) (annotations.FindTagsResult, error) {
 	newResult, err := r.proxy.FindTags(ctx, query.OrgID, query)
 	if err != nil {
@@ -210,12 +209,28 @@ func (r *migrationRepository) FindTags(ctx context.Context, query *annotations.T
 		newResult = annotations.FindTagsResult{}
 	}
 
-	legacyResult, err := r.legacy.FindTags(ctx, query)
+	legacyTags, err := r.legacyTagsToMerge(ctx, query)
 	if err != nil {
 		return annotations.FindTagsResult{}, err
 	}
 
 	return annotations.FindTagsResult{
-		Tags: MergeTags(newResult.Tags, legacyResult.Tags, query.Limit),
+		Tags: MergeTags(newResult.Tags, legacyTags, query.Limit),
 	}, nil
+}
+
+func (r *migrationRepository) legacyTagsToMerge(ctx context.Context, query *annotations.TagsQuery) ([]*annotations.TagsDTO, error) {
+	// In the proxy-writes phase the new store only has annotations created since the
+	// migration started, so we still merge in every tag from legacy.
+	if !r.cfg.AnnotationAppPlatform.ProxyAll() {
+		result, err := r.legacy.FindTags(ctx, query)
+		return result.Tags, err
+	}
+
+	// In the proxy-all phase, the new store holds all user annotations, so
+	// we only need to merge in tags from alert annotations
+	alertQuery := *query
+	alertQuery.Type = "alert"
+	result, err := r.legacy.FindTags(ctx, &alertQuery)
+	return result.Tags, err
 }

--- a/pkg/services/annotations/annotationsapi/migration_repository_test.go
+++ b/pkg/services/annotations/annotationsapi/migration_repository_test.go
@@ -25,9 +25,10 @@ type fakeLegacy struct {
 	deleteParams []*annotations.DeleteParams
 	deleteErr    error
 
-	findTagsResult annotations.FindTagsResult
-	findTagsErr    error
-	findTagsCalls  []*annotations.TagsQuery
+	findTagsResult        annotations.FindTagsResult
+	findTagsResultsByType map[string]annotations.FindTagsResult
+	findTagsErr           error
+	findTagsCalls         []*annotations.TagsQuery
 }
 
 func (f *fakeLegacy) Find(_ context.Context, query *annotations.ItemQuery) ([]*annotations.ItemDTO, error) {
@@ -46,6 +47,9 @@ func (f *fakeLegacy) Delete(_ context.Context, params *annotations.DeleteParams)
 }
 func (f *fakeLegacy) FindTags(_ context.Context, query *annotations.TagsQuery) (annotations.FindTagsResult, error) {
 	f.findTagsCalls = append(f.findTagsCalls, query)
+	if f.findTagsResultsByType != nil {
+		return f.findTagsResultsByType[query.Type], f.findTagsErr
+	}
 	return f.findTagsResult, f.findTagsErr
 }
 
@@ -527,20 +531,38 @@ func TestMigrationRepository_FindTags(t *testing.T) {
 		return result
 	}
 
-	for _, phase := range []string{"proxy-writes", "proxy-all"} {
-		t.Run("merges new store and legacy tags in "+phase, func(t *testing.T) {
-			legacy := &fakeLegacy{findTagsResult: tags("alert", 3, "shared", 1)}
-			proxy := &fakeProxy{findTagsResult: tags("shared", 2, "new", 4)}
-			repo := newTestRepo(t, phase, legacy, proxy, usertest.NewUserServiceFake())
+	t.Run("merges the full legacy tag set in proxy-writes", func(t *testing.T) {
+		legacy := &fakeLegacy{findTagsResult: tags("alert", 3, "shared", 1)}
+		proxy := &fakeProxy{findTagsResult: tags("shared", 2, "new", 4)}
+		repo := newTestRepo(t, "proxy-writes", legacy, proxy, usertest.NewUserServiceFake())
 
-			result, err := repo.FindTags(context.Background(), &annotations.TagsQuery{OrgID: 1})
-			require.NoError(t, err)
-			assert.Equal(t, tags("alert", 3, "new", 4, "shared", 3).Tags, result.Tags,
-				"legacy still owns alert annotations in every phase, so its tags are always merged in")
-			require.Len(t, proxy.findTagsCalls, 1)
-			require.Len(t, legacy.findTagsCalls, 1)
-		})
-	}
+		result, err := repo.FindTags(context.Background(), &annotations.TagsQuery{OrgID: 1})
+		require.NoError(t, err)
+		assert.Equal(t, tags("alert", 3, "new", 4, "shared", 3).Tags, result.Tags,
+			"legacy still holds pre-migration annotations, so every legacy tag is merged in")
+
+		require.Len(t, proxy.findTagsCalls, 1)
+		require.Len(t, legacy.findTagsCalls, 1)
+		assert.Empty(t, legacy.findTagsCalls[0].Type, "all legacy tags count in this phase")
+	})
+
+	t.Run("merges only legacy alert tags in proxy-all", func(t *testing.T) {
+		legacy := &fakeLegacy{findTagsResultsByType: map[string]annotations.FindTagsResult{
+			"":      tags("alert", 3, "shared", 9),
+			"alert": tags("alert", 3),
+		}}
+		proxy := &fakeProxy{findTagsResult: tags("shared", 2, "new", 4)}
+		repo := newTestRepo(t, "proxy-all", legacy, proxy, usertest.NewUserServiceFake())
+
+		result, err := repo.FindTags(context.Background(), &annotations.TagsQuery{OrgID: 1})
+		require.NoError(t, err)
+		assert.Equal(t, tags("alert", 3, "new", 4, "shared", 2).Tags, result.Tags,
+			"the shared tag keeps the new store's count only")
+
+		require.Len(t, proxy.findTagsCalls, 1)
+		require.Len(t, legacy.findTagsCalls, 1)
+		assert.Equal(t, "alert", legacy.findTagsCalls[0].Type)
+	})
 
 	t.Run("applies the query limit to the merged result", func(t *testing.T) {
 		legacy := &fakeLegacy{findTagsResult: tags("c", 1, "d", 1)}

--- a/pkg/services/annotations/annotationsapi/migration_repository_test.go
+++ b/pkg/services/annotations/annotationsapi/migration_repository_test.go
@@ -24,6 +24,10 @@ type fakeLegacy struct {
 	updateItems  []*annotations.Item
 	deleteParams []*annotations.DeleteParams
 	deleteErr    error
+
+	findTagsResult annotations.FindTagsResult
+	findTagsErr    error
+	findTagsCalls  []*annotations.TagsQuery
 }
 
 func (f *fakeLegacy) Find(_ context.Context, query *annotations.ItemQuery) ([]*annotations.ItemDTO, error) {
@@ -40,8 +44,9 @@ func (f *fakeLegacy) Delete(_ context.Context, params *annotations.DeleteParams)
 	f.deleteParams = append(f.deleteParams, params)
 	return f.deleteErr
 }
-func (f *fakeLegacy) FindTags(context.Context, *annotations.TagsQuery) (annotations.FindTagsResult, error) {
-	return annotations.FindTagsResult{}, nil
+func (f *fakeLegacy) FindTags(_ context.Context, query *annotations.TagsQuery) (annotations.FindTagsResult, error) {
+	f.findTagsCalls = append(f.findTagsCalls, query)
+	return f.findTagsResult, f.findTagsErr
 }
 
 type fakeProxy struct {
@@ -62,6 +67,15 @@ type fakeProxy struct {
 
 	deleteErr   error
 	deleteCalls int
+
+	findTagsResult annotations.FindTagsResult
+	findTagsErr    error
+	findTagsCalls  []*annotations.TagsQuery
+}
+
+func (f *fakeProxy) FindTags(_ context.Context, _ int64, query *annotations.TagsQuery) (annotations.FindTagsResult, error) {
+	f.findTagsCalls = append(f.findTagsCalls, query)
+	return f.findTagsResult, f.findTagsErr
 }
 
 func (f *fakeProxy) List(_ context.Context, _ int64, query *annotations.ItemQuery) ([]*annotations.ItemDTO, error) {
@@ -498,5 +512,72 @@ func TestMigrationRepository_Delete(t *testing.T) {
 		require.NoError(t, repo.Delete(context.Background(), &annotations.DeleteParams{OrgID: 1, DashboardID: 9, PanelID: 2}))
 		assert.Zero(t, proxy.deleteCalls)
 		require.Len(t, legacy.deleteParams, 1)
+	})
+}
+
+func TestMigrationRepository_FindTags(t *testing.T) {
+	tags := func(pairs ...any) annotations.FindTagsResult {
+		result := annotations.FindTagsResult{}
+		for i := 0; i < len(pairs); i += 2 {
+			result.Tags = append(result.Tags, &annotations.TagsDTO{
+				Tag:   pairs[i].(string),
+				Count: int64(pairs[i+1].(int)),
+			})
+		}
+		return result
+	}
+
+	for _, phase := range []string{"proxy-writes", "proxy-all"} {
+		t.Run("merges new store and legacy tags in "+phase, func(t *testing.T) {
+			legacy := &fakeLegacy{findTagsResult: tags("alert", 3, "shared", 1)}
+			proxy := &fakeProxy{findTagsResult: tags("shared", 2, "new", 4)}
+			repo := newTestRepo(t, phase, legacy, proxy, usertest.NewUserServiceFake())
+
+			result, err := repo.FindTags(context.Background(), &annotations.TagsQuery{OrgID: 1})
+			require.NoError(t, err)
+			assert.Equal(t, tags("alert", 3, "new", 4, "shared", 3).Tags, result.Tags,
+				"legacy still owns alert annotations in every phase, so its tags are always merged in")
+			require.Len(t, proxy.findTagsCalls, 1)
+			require.Len(t, legacy.findTagsCalls, 1)
+		})
+	}
+
+	t.Run("applies the query limit to the merged result", func(t *testing.T) {
+		legacy := &fakeLegacy{findTagsResult: tags("c", 1, "d", 1)}
+		proxy := &fakeProxy{findTagsResult: tags("a", 1, "b", 1)}
+		repo := newTestRepo(t, "proxy-writes", legacy, proxy, usertest.NewUserServiceFake())
+
+		result, err := repo.FindTags(context.Background(), &annotations.TagsQuery{OrgID: 1, Limit: 2})
+		require.NoError(t, err)
+		assert.Equal(t, tags("a", 1, "b", 1).Tags, result.Tags)
+	})
+
+	t.Run("degrades to legacy tags when the new store fails in proxy-writes", func(t *testing.T) {
+		legacy := &fakeLegacy{findTagsResult: tags("legacy", 1)}
+		proxy := &fakeProxy{findTagsErr: assert.AnError}
+		repo := newTestRepo(t, "proxy-writes", legacy, proxy, usertest.NewUserServiceFake())
+
+		result, err := repo.FindTags(context.Background(), &annotations.TagsQuery{OrgID: 1})
+		require.NoError(t, err)
+		assert.Equal(t, tags("legacy", 1).Tags, result.Tags)
+	})
+
+	t.Run("fails when the new store fails in proxy-all", func(t *testing.T) {
+		legacy := &fakeLegacy{findTagsResult: tags("legacy", 1)}
+		proxy := &fakeProxy{findTagsErr: assert.AnError}
+		repo := newTestRepo(t, "proxy-all", legacy, proxy, usertest.NewUserServiceFake())
+
+		_, err := repo.FindTags(context.Background(), &annotations.TagsQuery{OrgID: 1})
+		require.ErrorIs(t, err, assert.AnError)
+		assert.Empty(t, legacy.findTagsCalls, "the new store is authoritative, so we do not mask the failure")
+	})
+
+	t.Run("fails when legacy fails", func(t *testing.T) {
+		legacy := &fakeLegacy{findTagsErr: assert.AnError}
+		proxy := &fakeProxy{findTagsResult: tags("new", 1)}
+		repo := newTestRepo(t, "proxy-writes", legacy, proxy, usertest.NewUserServiceFake())
+
+		_, err := repo.FindTags(context.Background(), &annotations.TagsQuery{OrgID: 1})
+		require.ErrorIs(t, err, assert.AnError)
 	})
 }

--- a/pkg/services/annotations/annotationsimpl/xorm_store.go
+++ b/pkg/services/annotations/annotationsimpl/xorm_store.go
@@ -601,6 +601,13 @@ func (r *xormRepositoryImpl) GetTags(ctx context.Context, query annotations.Tags
 		sql.WriteString(`WHERE annotation.org_id = ?`)
 		params = append(params, query.OrgID)
 
+		switch query.Type {
+		case "alert":
+			sql.WriteString(` AND annotation.alert_id > 0`)
+		case "annotation":
+			sql.WriteString(` AND annotation.alert_id = 0`)
+		}
+
 		sql.WriteString(` AND (`)
 		s, p := r.db.GetDialect().LikeOperator(tagKey, true, query.Tag, true)
 		sql.WriteString(s)

--- a/pkg/services/annotations/annotationsimpl/xorm_store_test.go
+++ b/pkg/services/annotations/annotationsimpl/xorm_store_test.go
@@ -620,6 +620,47 @@ func TestIntegrationAnnotations(t *testing.T) {
 			require.Equal(t, int64(1), result.Tags[1].Count)
 		})
 
+		t.Run("Should filter tags by annotation type", func(t *testing.T) {
+			alertAnnotation := &annotations.Item{
+				OrgID:   1,
+				UserID:  1,
+				AlertID: 1, // alert_id > 0 is what makes a row an alert annotation
+				Text:    "alerting",
+				Epoch:   30,
+				Tags:    []string{"alert-only", "server:server-1"},
+			}
+			require.NoError(t, store.Add(context.Background(), alertAnnotation))
+			t.Cleanup(func() {
+				require.NoError(t, store.Delete(context.Background(),
+					&annotations.DeleteParams{ID: alertAnnotation.ID, OrgID: 1}))
+			})
+
+			byTag := func(query annotations.TagsQuery) map[string]int64 {
+				result, err := store.GetTags(context.Background(), query)
+				require.NoError(t, err)
+				counts := map[string]int64{}
+				for _, tag := range result.Tags {
+					counts[tag.Tag] = tag.Count
+				}
+				return counts
+			}
+
+			alertTags := byTag(annotations.TagsQuery{OrgID: 1, Type: "alert"})
+			assert.Equal(t, int64(1), alertTags["alert-only"])
+			assert.Equal(t, int64(1), alertTags["server:server-1"], "only the alert row contributes")
+			assert.NotContains(t, alertTags, "deploy", "org annotations are excluded")
+
+			userTags := byTag(annotations.TagsQuery{OrgID: 1, Type: "annotation"})
+			assert.NotContains(t, userTags, "alert-only")
+			assert.Contains(t, userTags, "deploy")
+
+			allTags := byTag(annotations.TagsQuery{OrgID: 1})
+			for tag, count := range allTags {
+				assert.Equal(t, count, alertTags[tag]+userTags[tag],
+					"alert and annotation counts should sum to the unfiltered count for %q", tag)
+			}
+		})
+
 		t.Run("Should not find tags in other org", func(t *testing.T) {
 			result, err := store.GetTags(context.Background(), annotations.TagsQuery{
 				OrgID: 0,

--- a/pkg/services/annotations/models.go
+++ b/pkg/services/annotations/models.go
@@ -32,6 +32,7 @@ type ItemQuery struct {
 type TagsQuery struct {
 	OrgID int64  `json:"orgId"`
 	Tag   string `json:"tag"`
+	Type  string `json:"type"` // filter based on annotation type: "alert" or "annotation"
 
 	Limit int64 `json:"limit"`
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR addresses a follow-up from the initial annotation migration proxy work around proxying requests to the `/tags` endpoint when searching available annotation tags. Previously we were just including results from the legacy store, but this PR updates it to also aggregate results from the new API.

The following changes were made to address this:
* The migration proxy was changed to request _both_ the new API and fetch from legacy.
* The new API's store was modified to align tag sorting with legacy (by name ascending) for a consistent merged result
* Added support for querying tags in the legacy store by annotation type (user-created or alerting) so we are able to just fetch the alert-related tags post-migration.
* Updated the legacy API's default limit behavior to be applied at the handler level. This resolved an issue with merging legacy and new results since it is currently only [applied within the xorm_store implementation](https://github.com/grafana/grafana/blob/1ac6e917a188772785e1d8fe7963f5fcb201c89f/pkg/services/annotations/annotationsimpl/xorm_store.go#L582-L584), so was not getting propagated to the migration proxy.

**Why do we need this feature?**

This finishes the implementation for proxying requests made to the legacy `/api/annotations/tags` endpoint by including tags that exist in the new store.

**Who is this feature for?**

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Partially addresses https://github.com/grafana/grafana-org/issues/953 (`/mass-delete` to come in a separate [PR](https://github.com/grafana/grafana/pull/129625))

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
