### PR TITLE
fix: strip monotonic clock reading from timestamps in xorm str2Time to prevent startup failure on upgrade

### DIFF
--- a/pkg/util/xorm/session_convert.go
+++ b/pkg/util/xorm/session_convert.go
@@ -23,6 +23,18 @@ const (
 
 func (session *Session) str2Time(col *core.Column, data string) (outTime time.Time, outErr error) {
 	sdata := strings.TrimSpace(data)
+
+	// Strip monotonic clock reading (Go's time.Time.String() appends " m=+xxx.xxxxx")
+	// which can cause parse failures when upgrading from older Grafana versions.
+	if idx := strings.Index(sdata, " m="); idx >= 0 {
+		sdata = sdata[:idx]
+		// Also strip the duplicate timezone offset that appears when the zone name is numeric.
+		// Go's time.String() format: "2006-01-02 15:04:05.999999999 +0330 +0330"
+		// where the second +0330 is the zone name.
+		if parts := strings.Fields(sdata); len(parts) >= 4 && parts[len(parts)-1] == parts[len(parts)-2] {
+			sdata = strings.Join(parts[:len(parts)-1], " ")
+		}
+	}
 	var x time.Time
 	var err error
 
@@ -51,6 +63,12 @@ func (session *Session) str2Time(col *core.Column, data string) (outTime time.Ti
 		if err != nil {
 			x, err = time.ParseInLocation("2006-01-02 15:04:05.9999999 Z07:00", sdata, parseLoc)
 			//session.engine.logger.Debugf("time(3) key[%v]: %+v | sdata: [%v]\n", col.FieldName, x, sdata)
+		}
+		if err != nil {
+			// Type 4: Go time.String() format without monotonic clock
+			// Format: "2006-01-02 15:04:05.999999999 -0700 MST"
+			x, err = time.ParseInLocation("2006-01-02 15:04:05.999999999 -0700 MST", sdata, parseLoc)
+			//session.engine.logger.Debugf("time(4) key[%v]: %+v | sdata: [%v]\n", col.FieldName, x, sdata)
 		}
 	} else if len(sdata) == 19 && strings.Contains(sdata, "-") {
 		x, err = time.ParseInLocation("2006-01-02 15:04:05", sdata, parseLoc)


### PR DESCRIPTION
### Description

Fixes #129295

When upgrading from Grafana 12.x to 13.x with a persistent SQLite database, the server fails to start with:



### Root Cause

The xorm ORM's `str2Time` function tries to parse timestamps stored in SQLite using several predefined formats. However, Go's `time.Time.String()` format includes a monotonic clock reading (`m=+xxx.xxxxx`) and a duplicate timezone offset (when the zone name is numeric), which none of the existing parsing formats handle.

### Changes

1. **Preprocessing**: Strip the monotonic clock reading (`m=+...`) from the timestamp string before parsing, and remove the duplicate timezone offset.
2. **New format**: Add a 4th parsing attempt using Go's `time.Time.String()` format (`2006-01-02 15:04:05.999999999 -0700 MST`) to handle the remaining Go time string format.

### Testing

- The fix is backward compatible: existing formats are tried first, the new format is only attempted as a fallback.
- All existing timestamps (RFC3339Nano, without timezone, etc.) continue to work unchanged.
- The monotonic clock stripping only triggers when the string contains ` m=`, which is specific to Go's `time.Time.String()` output.