### PR TITLE
Alerting: Gate rule evaluation until the state cache is warmed

### DIFF
--- a/pkg/services/ngalert/evaluation_runner_test.go
+++ b/pkg/services/ngalert/evaluation_runner_test.go
@@ -234,6 +234,7 @@ func withStateManager(mgr *state.Manager) alertNGOption {
 
 func createTestAlertNG(sched *testSchedule, coordinator *testEvaluationCoordinator, opts ...alertNGOption) *AlertNG {
 	defaultCfg := state.ManagerCfg{
+		Clock:                     clock.NewMock(),
 		Log:                       log.NewNopLogger(),
 		StatePeriodicSaveInterval: time.Minute,
 	}

--- a/pkg/services/ngalert/metrics/scheduler.go
+++ b/pkg/services/ngalert/metrics/scheduler.go
@@ -180,9 +180,9 @@ func NewSchedulerMetrics(r prometheus.Registerer) *Scheduler {
 				Namespace: Namespace,
 				Subsystem: Subsystem,
 				Name:      "schedule_rule_evaluations_missed_total",
-				Help:      "The total number of rule evaluations missed due to a slow rule evaluation.",
+				Help:      "The total number of rule evaluations missed, labelled by reason (e.g. a slow rule evaluation, or the state cache not yet being warmed).",
 			},
-			[]string{"org", "name"},
+			[]string{"org", "name", "reason"},
 		),
 		SimplifiedEditorRules: promauto.With(r).NewGaugeVec(
 			prometheus.GaugeOpts{

--- a/pkg/services/ngalert/schedule/alert_rule.go
+++ b/pkg/services/ngalert/schedule/alert_rule.go
@@ -396,6 +396,24 @@ func (a *alertRule) Run() error {
 	}
 }
 
+// readyToProcessState reports whether this evaluation's results may be applied to the state cache.
+// It returns false only while the cache is cold and within the grace window (logging and counting
+// the skip); after the grace elapses it returns true but logs the cold read. Checked after eval so
+// the query gives the cache time to warm; gating is off in vanilla Grafana, on in the ruler.
+func (a *alertRule) readyToProcessState(logger log.Logger, e *Evaluation) bool {
+	switch a.stateManager.EvaluationReadiness(e.rule) {
+	case state.ReadinessWarmed:
+		// Cache is warm (or gating is disabled) — process normally.
+	case state.ReadinessNotWarmed:
+		logger.Warn("Skip processing evaluation results because the state cache is not warmed yet")
+		a.metrics.EvaluationMissed.WithLabelValues(fmt.Sprint(a.key.OrgID), e.rule.Title, "state_not_warmed").Inc()
+		return false
+	case state.ReadinessTimedOut:
+		logger.Warn("Processing evaluation results before the state cache is warmed; readiness grace period elapsed")
+	}
+	return true
+}
+
 func (a *alertRule) evaluate(ctx context.Context, e *Evaluation, span trace.Span, retry bool, logger log.Logger) error {
 	orgID := fmt.Sprint(a.key.OrgID)
 	evalAttemptTotal := a.metrics.EvalAttemptTotal.WithLabelValues(orgID)
@@ -472,6 +490,11 @@ func (a *alertRule) evaluate(ctx context.Context, e *Evaluation, span trace.Span
 			attribute.Int64("results", int64(len(results))),
 		))
 	}
+	// Don't apply results to a cold cache, or we write spurious transitions to state history.
+	if !a.readyToProcessState(logger, e) {
+		return nil
+	}
+
 	start = a.clock.Now()
 	_, _ = a.stateManager.ProcessEvalResults(
 		ctx,

--- a/pkg/services/ngalert/schedule/alert_rule.go
+++ b/pkg/services/ngalert/schedule/alert_rule.go
@@ -396,24 +396,6 @@ func (a *alertRule) Run() error {
 	}
 }
 
-// readyToProcessState reports whether this evaluation's results may be applied to the state cache.
-// It returns false only while the cache is cold and within the grace window (logging and counting
-// the skip); after the grace elapses it returns true but logs the cold read. Checked after eval so
-// the query gives the cache time to warm; gating is off in vanilla Grafana, on in the ruler.
-func (a *alertRule) readyToProcessState(logger log.Logger, e *Evaluation) bool {
-	switch a.stateManager.Ready() {
-	case state.Ready:
-		// Cache is warm (or gating is disabled) — process normally.
-	case state.NotReady:
-		logger.Warn("Skip processing evaluation results because the state cache is not warmed yet")
-		a.metrics.EvaluationMissed.WithLabelValues(fmt.Sprint(a.key.OrgID), e.rule.Title, "state_not_warmed").Inc()
-		return false
-	case state.TimedOut:
-		logger.Warn("Processing evaluation results before the state cache is warmed; readiness grace period elapsed")
-	}
-	return true
-}
-
 func (a *alertRule) evaluate(ctx context.Context, e *Evaluation, span trace.Span, retry bool, logger log.Logger) error {
 	orgID := fmt.Sprint(a.key.OrgID)
 	evalAttemptTotal := a.metrics.EvalAttemptTotal.WithLabelValues(orgID)
@@ -490,13 +472,8 @@ func (a *alertRule) evaluate(ctx context.Context, e *Evaluation, span trace.Span
 			attribute.Int64("results", int64(len(results))),
 		))
 	}
-	// Don't apply results to a cold cache, or we write spurious transitions to state history.
-	if !a.readyToProcessState(logger, e) {
-		return nil
-	}
-
 	start = a.clock.Now()
-	_, _ = a.stateManager.ProcessEvalResults(
+	_, procErr := a.stateManager.ProcessEvalResults(
 		ctx,
 		e.scheduledAt,
 		e.rule,
@@ -511,6 +488,11 @@ func (a *alertRule) evaluate(ctx context.Context, e *Evaluation, span trace.Span
 			sendDuration.Observe(a.clock.Now().Sub(start).Seconds())
 		},
 	)
+	if errors.Is(procErr, state.ErrNotReady) {
+		logger.Warn("Skip processing evaluation results because the state cache is not ready")
+		a.metrics.EvaluationMissed.WithLabelValues(fmt.Sprint(a.key.OrgID), e.rule.Title, "state_not_warmed").Inc()
+		return nil
+	}
 	processDuration.Observe(a.clock.Now().Sub(start).Seconds())
 
 	return nil

--- a/pkg/services/ngalert/schedule/alert_rule.go
+++ b/pkg/services/ngalert/schedule/alert_rule.go
@@ -401,14 +401,14 @@ func (a *alertRule) Run() error {
 // the skip); after the grace elapses it returns true but logs the cold read. Checked after eval so
 // the query gives the cache time to warm; gating is off in vanilla Grafana, on in the ruler.
 func (a *alertRule) readyToProcessState(logger log.Logger, e *Evaluation) bool {
-	switch a.stateManager.EvaluationReadiness(e.rule) {
-	case state.ReadinessWarmed:
+	switch a.stateManager.Ready() {
+	case state.Ready:
 		// Cache is warm (or gating is disabled) — process normally.
-	case state.ReadinessNotWarmed:
+	case state.NotReady:
 		logger.Warn("Skip processing evaluation results because the state cache is not warmed yet")
 		a.metrics.EvaluationMissed.WithLabelValues(fmt.Sprint(a.key.OrgID), e.rule.Title, "state_not_warmed").Inc()
 		return false
-	case state.ReadinessTimedOut:
+	case state.TimedOut:
 		logger.Warn("Processing evaluation results before the state cache is warmed; readiness grace period elapsed")
 	}
 	return true

--- a/pkg/services/ngalert/schedule/alert_rule_test.go
+++ b/pkg/services/ngalert/schedule/alert_rule_test.go
@@ -511,7 +511,7 @@ func TestRuleRoutine_GatedUntilWarmed(t *testing.T) {
 			withSchedulerClock(clock.NewMock()), withStateGatingUntilWarm(time.Minute))
 		sch.evalAppliedFunc = func(_ models.AlertRuleKey, tm time.Time) { evalAppliedChan <- tm }
 
-		require.False(t, sch.stateManager.IsWarmed(), "manager must start not-warmed")
+		require.Equal(t, state.NotReady, sch.stateManager.Ready(), "manager must start not-warmed")
 
 		rule := gen.With(withQueryForState(t, eval.Alerting)).GenerateRef()
 		ruleStore.PutRule(context.Background(), rule)

--- a/pkg/services/ngalert/schedule/alert_rule_test.go
+++ b/pkg/services/ngalert/schedule/alert_rule_test.go
@@ -499,6 +499,48 @@ func TestAlertRuleAfterEval(t *testing.T) {
 	})
 }
 
+func TestRuleRoutine_GatedUntilWarmed(t *testing.T) {
+	gen := models.RuleGen
+
+	t.Run("results are not applied while the state cache is not warmed", func(t *testing.T) {
+		evalAppliedChan := make(chan time.Time)
+		ruleStore := newFakeRulesStore()
+		instanceStore := &state.FakeInstanceStore{}
+		reg := prometheus.NewPedanticRegistry()
+		sch := setupScheduler(t, ruleStore, instanceStore, reg, nil, nil, nil,
+			withSchedulerClock(clock.NewMock()), withStateGatingUntilWarm(time.Minute))
+		sch.evalAppliedFunc = func(_ models.AlertRuleKey, tm time.Time) { evalAppliedChan <- tm }
+
+		require.False(t, sch.stateManager.IsWarmed(), "manager must start not-warmed")
+
+		rule := gen.With(withQueryForState(t, eval.Alerting)).GenerateRef()
+		ruleStore.PutRule(context.Background(), rule)
+		folderTitle := ruleStore.getNamespaceTitle(rule.NamespaceUID)
+		factory := ruleFactoryFromScheduler(sch)
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+		ruleInfo := factory.new(ctx, ruleWithFolder{rule: rule, folderTitle: folderTitle})
+		go func() { _ = ruleInfo.Run() }()
+
+		ruleInfo.Eval(&Evaluation{scheduledAt: time.UnixMicro(rand.Int63()), rule: rule, folderTitle: folderTitle})
+		waitForTimeChannel(t, evalAppliedChan)
+
+		orgID := fmt.Sprint(rule.OrgID)
+
+		// The evaluation runs (giving the cache time to warm)...
+		require.Equal(t, 1.0, testutil.ToFloat64(sch.metrics.EvalTotal.WithLabelValues(orgID)),
+			"the rule should still be evaluated")
+
+		// ...but its results are not applied to the cold cache: no state is produced...
+		states := sch.stateManager.GetStatesForRuleUID(context.Background(), rule.OrgID, rule.UID)
+		require.Empty(t, states, "no state should be produced while gated")
+
+		// ...and the skipped processing is counted with the not-warmed reason.
+		require.Equal(t, 1.0, testutil.ToFloat64(
+			sch.metrics.EvaluationMissed.WithLabelValues(orgID, rule.Title, "state_not_warmed")))
+	})
+}
+
 func blankRuleForTests(ctx context.Context, key models.AlertRuleKeyWithGroup) *alertRule {
 	managerCfg := state.ManagerCfg{
 		Historian: &state.FakeHistorian{},

--- a/pkg/services/ngalert/schedule/alert_rule_test.go
+++ b/pkg/services/ngalert/schedule/alert_rule_test.go
@@ -543,6 +543,7 @@ func TestRuleRoutine_GatedUntilWarmed(t *testing.T) {
 
 func blankRuleForTests(ctx context.Context, key models.AlertRuleKeyWithGroup) *alertRule {
 	managerCfg := state.ManagerCfg{
+		Clock:     clock.NewMock(),
 		Historian: &state.FakeHistorian{},
 		Log:       log.NewNopLogger(),
 	}

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -448,7 +448,7 @@ func (sch *schedule) runJobFn(next readyToRunItem, prev ...readyToRunItem) func(
 		if dropped != nil {
 			sch.log.Warn("Tick dropped because alert rule evaluation is too slow", append(key.LogContext(), "time", next.scheduledAt, "droppedTick", dropped.scheduledAt)...)
 			orgID := fmt.Sprint(key.OrgID)
-			sch.metrics.EvaluationMissed.WithLabelValues(orgID, next.rule.Title).Inc()
+			sch.metrics.EvaluationMissed.WithLabelValues(orgID, next.rule.Title, "slow_evaluation").Inc()
 		}
 	}
 }

--- a/pkg/services/ngalert/schedule/schedule_unit_test.go
+++ b/pkg/services/ngalert/schedule/schedule_unit_test.go
@@ -1196,12 +1196,21 @@ func TestSchedule_deleteAlertRule(t *testing.T) {
 }
 
 type schedulerOpts struct {
-	clock clock.Clock
+	clock           clock.Clock
+	gateUntilWarm   bool
+	warmGateTimeout time.Duration
 }
 
 func withSchedulerClock(clock clock.Clock) func(opts *schedulerOpts) {
 	return func(opts *schedulerOpts) {
 		opts.clock = clock
+	}
+}
+
+func withStateGatingUntilWarm(timeout time.Duration) func(opts *schedulerOpts) {
+	return func(opts *schedulerOpts) {
+		opts.gateUntilWarm = true
+		opts.warmGateTimeout = timeout
 	}
 }
 
@@ -1309,6 +1318,9 @@ func setupScheduler(
 		Tracer:                  testTracer,
 		Log:                     log.New("ngalert.state.manager"),
 		MaxStateSaveConcurrency: 1,
+
+		GateEvaluationUntilWarmed: opts.gateUntilWarm,
+		WarmGateTimeout:           opts.warmGateTimeout,
 	}
 	syncStatePersister := state.NewSyncStatePersisiter(log.New("ngalert.state.manager.perist"), managerCfg)
 	st := state.NewManager(managerCfg, syncStatePersister)

--- a/pkg/services/ngalert/schedule/schedule_unit_test.go
+++ b/pkg/services/ngalert/schedule/schedule_unit_test.go
@@ -1319,8 +1319,8 @@ func setupScheduler(
 		Log:                     log.New("ngalert.state.manager"),
 		MaxStateSaveConcurrency: 1,
 
-		GateEvaluationUntilWarmed: opts.gateUntilWarm,
-		WarmGateTimeout:           opts.warmGateTimeout,
+		RequireWarm:     opts.gateUntilWarm,
+		WarmGateTimeout: opts.warmGateTimeout,
 	}
 	syncStatePersister := state.NewSyncStatePersisiter(log.New("ngalert.state.manager.perist"), managerCfg)
 	st := state.NewManager(managerCfg, syncStatePersister)

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -156,7 +156,7 @@ func (st *Manager) Run(ctx context.Context) error {
 func (st *Manager) Warm(ctx context.Context, orgReader OrgReader, rulesReader RuleReader, instanceReader InstanceReader) {
 	logger := st.log.FromContext(ctx)
 
-	var success bool
+	success := true
 	startTime := time.Now()
 	rulesCount := 0
 	statesCount := 0
@@ -173,6 +173,7 @@ func (st *Manager) Warm(ctx context.Context, orgReader OrgReader, rulesReader Ru
 
 	if orgReader == nil || rulesReader == nil || instanceReader == nil {
 		logger.Error("Unable to warm state cache, missing required store readers")
+		success = false
 		return
 	}
 
@@ -181,6 +182,7 @@ func (st *Manager) Warm(ctx context.Context, orgReader OrgReader, rulesReader Ru
 	orgIds, err := orgReader.FetchOrgIds(ctx)
 	if err != nil {
 		logger.Error("Unable to warm state cache, failed to fetch org IDs", "error", err)
+		success = false
 		return
 	}
 
@@ -192,6 +194,7 @@ func (st *Manager) Warm(ctx context.Context, orgReader OrgReader, rulesReader Ru
 		alertRules, err := rulesReader.ListAlertRules(ctx, &ruleCmd)
 		if err != nil {
 			logger.Error("Unable to fetch rules", "error", err)
+			success = false
 			continue
 		}
 		rulesCount += len(alertRules)
@@ -223,6 +226,7 @@ func (st *Manager) Warm(ctx context.Context, orgReader OrgReader, rulesReader Ru
 		alertInstances, err := instanceReader.ListAlertInstances(ctx, &cmd)
 		if err != nil {
 			logger.Error("Unable to fetch previous state.", "error", err)
+			success = false
 			continue
 		}
 

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -344,6 +344,18 @@ func (st *Manager) ProcessEvalResults(
 	extraLabels data.Labels,
 	send Sender,
 ) (StateTransitions, error) {
+	logger := st.log.FromContext(ctx)
+
+	// Don't apply results to a cold cache, or we write spurious transitions to state history.
+	switch st.readiness.Ready() {
+	case Ready:
+		// Cache is warm (or gating is disabled) — process normally.
+	case NotReady:
+		return nil, ErrNotReady
+	case TimedOut:
+		logger.Warn("Processing evaluation results before the state cache is ready; readiness grace period elapsed")
+	}
+
 	utcTick := evaluatedAt.UTC().Format(time.RFC3339Nano)
 	ctx, span := st.tracer.Start(ctx, "alert rule state calculation", trace.WithAttributes(
 		attribute.String("rule_uid", alertRule.UID),
@@ -352,8 +364,6 @@ func (st *Manager) ProcessEvalResults(
 		attribute.String("tick", utcTick),
 		attribute.Int("results", len(results))))
 	defer span.End()
-
-	logger := st.log.FromContext(ctx)
 
 	// lazy evaluation of takeImage only once and only if it is requested.
 	var fn takeImageFn

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -122,11 +122,6 @@ type ManagerCfg struct {
 }
 
 func NewManager(cfg ManagerCfg, statePersister StatePersister) *Manager {
-	// Default the clock so readiness bookkeeping has a time source (some tests leave it unset).
-	if cfg.Clock == nil {
-		cfg.Clock = clock.New()
-	}
-
 	// Metrics for the cache use a collector, so they need access to the register directly.
 	c := newCache()
 	// Only expose the metrics if this grafana server does execute alerts.

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/benbjohnson/clock"
@@ -59,7 +60,30 @@ type Manager struct {
 	persister StatePersister
 
 	ignorePendingForNoDataAndError bool
+
+	// ready reports whether the cache is warm enough to evaluate against. Set at construction (true
+	// unless gating is requested) and by a successful Warm.
+	ready atomic.Bool
+	// notReadySince marks when readiness gating began; it bounds the warm grace window.
+	notReadySince time.Time
+	// warmGateTimeout is the grace window before gated evaluation proceeds anyway.
+	warmGateTimeout time.Duration
 }
+
+// EvalReadiness reports whether a rule's results are safe to apply to the state cache.
+type EvalReadiness int
+
+const (
+	// ReadinessWarmed means the cache is warm (or gating is off) — apply results normally.
+	ReadinessWarmed EvalReadiness = iota
+	// ReadinessNotWarmed means the cache is cold and within the grace window — skip processing.
+	ReadinessNotWarmed
+	// ReadinessTimedOut means the cache is cold but the grace window elapsed — apply anyway.
+	ReadinessTimedOut
+)
+
+// defaultWarmGateTimeout is used when gating is enabled without an explicit WarmGateTimeout.
+const defaultWarmGateTimeout = 2 * time.Minute
 
 type ManagerCfg struct {
 	Metrics       *metrics.State
@@ -89,14 +113,30 @@ type ManagerCfg struct {
 	Log    log.Logger
 
 	IgnorePendingForNoDataAndError bool // TODO: Remove
+
+	// GateEvaluationUntilWarmed skips applying evaluation results until the cache is warmed. Off by
+	// default (vanilla Grafana warms before evaluating); the ruler enables it as it warms async.
+	GateEvaluationUntilWarmed bool
+	// WarmGateTimeout is the grace window before gated evaluation proceeds anyway. 0 uses the default.
+	WarmGateTimeout time.Duration
 }
 
 func NewManager(cfg ManagerCfg, statePersister StatePersister) *Manager {
+	// Default the clock so readiness bookkeeping has a time source (some tests leave it unset).
+	if cfg.Clock == nil {
+		cfg.Clock = clock.New()
+	}
+
 	// Metrics for the cache use a collector, so they need access to the register directly.
 	c := newCache()
 	// Only expose the metrics if this grafana server does execute alerts.
 	if cfg.Metrics != nil && !cfg.DisableExecution {
 		c.RegisterMetrics(cfg.Metrics.Registerer())
+	}
+
+	warmGateTimeout := cfg.WarmGateTimeout
+	if warmGateTimeout <= 0 {
+		warmGateTimeout = defaultWarmGateTimeout
 	}
 
 	m := &Manager{
@@ -115,9 +155,33 @@ func NewManager(cfg ManagerCfg, statePersister StatePersister) *Manager {
 		tracer:                 cfg.Tracer,
 
 		ignorePendingForNoDataAndError: cfg.IgnorePendingForNoDataAndError,
+
+		notReadySince:   cfg.Clock.Now(),
+		warmGateTimeout: warmGateTimeout,
 	}
+	// Start ready unless gating is requested, so vanilla Grafana is never gated.
+	m.ready.Store(!cfg.GateEvaluationUntilWarmed)
 
 	return m
+}
+
+// EvaluationReadiness reports whether the rule's results may be applied to the state cache: warmed
+// (or gating off), not-warmed (within the grace window, skip), or timed-out (grace elapsed, apply
+// anyway). The rule is accepted for future per-rule scoping but is unused today.
+func (st *Manager) EvaluationReadiness(_ *ngModels.AlertRule) EvalReadiness {
+	if st.ready.Load() {
+		return ReadinessWarmed
+	}
+	if st.clock.Since(st.notReadySince) >= st.warmGateTimeout {
+		return ReadinessTimedOut
+	}
+	return ReadinessNotWarmed
+}
+
+// IsWarmed reports whether a Warm has succeeded (or gating is off). It ignores the grace timeout so
+// callers can decide whether to retry warming.
+func (st *Manager) IsWarmed() bool {
+	return st.ready.Load()
 }
 
 func (st *Manager) ClearCache() {
@@ -207,6 +271,10 @@ func (st *Manager) Warm(ctx context.Context, orgReader OrgReader, rulesReader Ru
 			statesCount++
 		}
 	}
+
+	// Mark warmed only after the cache is fully populated; the early error returns above leave it
+	// unset so evaluation stays gated.
+	st.ready.Store(true)
 
 	logger.Info("State cache has been initialized", "states", statesCount, "duration", time.Since(startTime))
 }

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -229,7 +229,7 @@ func (st *Manager) Warm(ctx context.Context, orgReader OrgReader, rulesReader Ru
 			success = false
 			continue
 		}
-
+		// TODO change this to consider situation when there is already a state, e.g. when readiness probe expired and state started from scratch.
 		for _, entry := range alertInstances {
 			ruleForEntry, ok := ruleByUID[entry.RuleUID]
 			if !ok {

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/url"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	"github.com/benbjohnson/clock"
@@ -61,29 +60,9 @@ type Manager struct {
 
 	ignorePendingForNoDataAndError bool
 
-	// ready reports whether the cache is warm enough to evaluate against. Set at construction (true
-	// unless gating is requested) and by a successful Warm.
-	ready atomic.Bool
-	// notReadySince marks when readiness gating began; it bounds the warm grace window.
-	notReadySince time.Time
-	// warmGateTimeout is the grace window before gated evaluation proceeds anyway.
-	warmGateTimeout time.Duration
+	// readiness gates whether evaluation results may be applied before the cache is warmed.
+	readiness ReadinessProbe
 }
-
-// EvalReadiness reports whether a rule's results are safe to apply to the state cache.
-type EvalReadiness int
-
-const (
-	// ReadinessWarmed means the cache is warm (or gating is off) — apply results normally.
-	ReadinessWarmed EvalReadiness = iota
-	// ReadinessNotWarmed means the cache is cold and within the grace window — skip processing.
-	ReadinessNotWarmed
-	// ReadinessTimedOut means the cache is cold but the grace window elapsed — apply anyway.
-	ReadinessTimedOut
-)
-
-// defaultWarmGateTimeout is used when gating is enabled without an explicit WarmGateTimeout.
-const defaultWarmGateTimeout = 2 * time.Minute
 
 type ManagerCfg struct {
 	Metrics       *metrics.State
@@ -114,9 +93,9 @@ type ManagerCfg struct {
 
 	IgnorePendingForNoDataAndError bool // TODO: Remove
 
-	// GateEvaluationUntilWarmed skips applying evaluation results until the cache is warmed. Off by
-	// default (vanilla Grafana warms before evaluating); the ruler enables it as it warms async.
-	GateEvaluationUntilWarmed bool
+	// RequireWarm gates evaluation until the cache is warmed. Off by default; the ruler sets it
+	// because it warms asynchronously after (re)assignment.
+	RequireWarm bool
 	// WarmGateTimeout is the grace window before gated evaluation proceeds anyway. 0 uses the default.
 	WarmGateTimeout time.Duration
 }
@@ -129,9 +108,11 @@ func NewManager(cfg ManagerCfg, statePersister StatePersister) *Manager {
 		c.RegisterMetrics(cfg.Metrics.Registerer())
 	}
 
-	warmGateTimeout := cfg.WarmGateTimeout
-	if warmGateTimeout <= 0 {
-		warmGateTimeout = defaultWarmGateTimeout
+	// Vanilla Grafana warms before evaluating, so it never needs to gate; the ruler warms
+	// asynchronously and sets RequireWarm to gate until the cache is warmed.
+	var readiness ReadinessProbe = AlwaysReady{}
+	if cfg.RequireWarm {
+		readiness = newGatedProbe(cfg.Clock, cfg.WarmGateTimeout)
 	}
 
 	m := &Manager{
@@ -151,36 +132,20 @@ func NewManager(cfg ManagerCfg, statePersister StatePersister) *Manager {
 
 		ignorePendingForNoDataAndError: cfg.IgnorePendingForNoDataAndError,
 
-		notReadySince:   cfg.Clock.Now(),
-		warmGateTimeout: warmGateTimeout,
+		readiness: readiness,
 	}
-	// Start ready unless gating is requested, so vanilla Grafana is never gated.
-	m.ready.Store(!cfg.GateEvaluationUntilWarmed)
 
 	return m
 }
 
-// EvaluationReadiness reports whether the rule's results may be applied to the state cache: warmed
-// (or gating off), not-warmed (within the grace window, skip), or timed-out (grace elapsed, apply
-// anyway). The rule is accepted for future per-rule scoping but is unused today.
-func (st *Manager) EvaluationReadiness(_ *ngModels.AlertRule) EvalReadiness {
-	if st.ready.Load() {
-		return ReadinessWarmed
-	}
-	if st.clock.Since(st.notReadySince) >= st.warmGateTimeout {
-		return ReadinessTimedOut
-	}
-	return ReadinessNotWarmed
-}
-
-// IsWarmed reports whether a Warm has succeeded (or gating is off). It ignores the grace timeout so
-// callers can decide whether to retry warming.
-func (st *Manager) IsWarmed() bool {
-	return st.ready.Load()
+// Ready reports whether results may be applied to the state cache.
+func (st *Manager) Ready() Readiness {
+	return st.readiness.Ready()
 }
 
 func (st *Manager) ClearCache() {
 	st.cache.reset()
+	st.readiness.Reset()
 }
 
 func (st *Manager) Run(ctx context.Context) error {
@@ -191,12 +156,26 @@ func (st *Manager) Run(ctx context.Context) error {
 func (st *Manager) Warm(ctx context.Context, orgReader OrgReader, rulesReader RuleReader, instanceReader InstanceReader) {
 	logger := st.log.FromContext(ctx)
 
+	var success bool
+	startTime := time.Now()
+	rulesCount := 0
+	statesCount := 0
+	defer func() {
+		// TODO this is how it works since the inception. This needs to be reviewed and changed because it has an implication for state history.
+		// Mark ready regardless of the outcome.
+		st.readiness.MarkReady()
+		if !success {
+			logger.Warn("State cache initialization finished with errors. Continue with empty state")
+			return
+		}
+		logger.Info("State cache has been initialized", "rules", rulesCount, "states", statesCount, "duration", time.Since(startTime))
+	}()
+
 	if orgReader == nil || rulesReader == nil || instanceReader == nil {
 		logger.Error("Unable to warm state cache, missing required store readers")
 		return
 	}
 
-	startTime := time.Now()
 	logger.Info("Warming state cache for startup")
 
 	orgIds, err := orgReader.FetchOrgIds(ctx)
@@ -205,7 +184,6 @@ func (st *Manager) Warm(ctx context.Context, orgReader OrgReader, rulesReader Ru
 		return
 	}
 
-	statesCount := 0
 	for _, orgId := range orgIds {
 		// Get Rules
 		ruleCmd := ngModels.ListAlertRulesQuery{
@@ -213,8 +191,10 @@ func (st *Manager) Warm(ctx context.Context, orgReader OrgReader, rulesReader Ru
 		}
 		alertRules, err := rulesReader.ListAlertRules(ctx, &ruleCmd)
 		if err != nil {
-			logger.Error("Unable to fetch previous state", "error", err)
+			logger.Error("Unable to fetch rules", "error", err)
+			continue
 		}
+		rulesCount += len(alertRules)
 
 		ruleByUID := make(map[string]*ngModels.AlertRule, len(alertRules))
 		groupSizes := make(map[string]int64)
@@ -242,13 +222,13 @@ func (st *Manager) Warm(ctx context.Context, orgReader OrgReader, rulesReader Ru
 		}
 		alertInstances, err := instanceReader.ListAlertInstances(ctx, &cmd)
 		if err != nil {
-			logger.Error("Unable to fetch previous state", "error", err)
+			logger.Error("Unable to fetch previous state.", "error", err)
+			continue
 		}
 
 		for _, entry := range alertInstances {
 			ruleForEntry, ok := ruleByUID[entry.RuleUID]
 			if !ok {
-				// TODO Should we delete the orphaned state from the db?
 				continue
 			}
 
@@ -266,12 +246,6 @@ func (st *Manager) Warm(ctx context.Context, orgReader OrgReader, rulesReader Ru
 			statesCount++
 		}
 	}
-
-	// Mark warmed only after the cache is fully populated; the early error returns above leave it
-	// unset so evaluation stays gated.
-	st.ready.Store(true)
-
-	logger.Info("State cache has been initialized", "states", statesCount, "duration", time.Since(startTime))
 }
 
 func (st *Manager) Get(orgID int64, alertRuleUID string, stateId data.Fingerprint) *State {

--- a/pkg/services/ngalert/state/manager_readiness_test.go
+++ b/pkg/services/ngalert/state/manager_readiness_test.go
@@ -1,0 +1,71 @@
+package state_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/benbjohnson/clock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/services/ngalert/state"
+)
+
+type fakeOrgReader struct {
+	orgs []int64
+}
+
+func (f fakeOrgReader) FetchOrgIds(_ context.Context) ([]int64, error) { return f.orgs, nil }
+
+func newReadinessManager(t *testing.T, clk clock.Clock, gate bool, timeout time.Duration) *state.Manager {
+	t.Helper()
+	cfg := state.ManagerCfg{
+		Clock:                     clk,
+		Log:                       log.NewNopLogger(),
+		GateEvaluationUntilWarmed: gate,
+		WarmGateTimeout:           timeout,
+	}
+	return state.NewManager(cfg, state.NewNoopPersister())
+}
+
+func warm(t *testing.T, mgr *state.Manager) {
+	t.Helper()
+	mgr.Warm(context.Background(), fakeOrgReader{}, &state.FakeRuleReader{}, &state.FakeInstanceStore{})
+}
+
+func TestManager_EvaluationReadiness_GateDisabled(t *testing.T) {
+	mgr := newReadinessManager(t, clock.NewMock(), false, time.Minute)
+
+	// With gating off (vanilla Grafana default) the manager starts ready, so evaluation is never
+	// gated, even before Warm.
+	require.True(t, mgr.IsWarmed())
+	require.Equal(t, state.ReadinessWarmed, mgr.EvaluationReadiness(&ngmodels.AlertRule{}))
+}
+
+func TestManager_EvaluationReadiness_GateEnabled(t *testing.T) {
+	clk := clock.NewMock()
+	mgr := newReadinessManager(t, clk, true, time.Minute)
+
+	// Before Warm: gated.
+	require.Equal(t, state.ReadinessNotWarmed, mgr.EvaluationReadiness(&ngmodels.AlertRule{}))
+	require.False(t, mgr.IsWarmed())
+
+	// After a successful Warm: ready.
+	warm(t, mgr)
+	require.True(t, mgr.IsWarmed())
+	require.Equal(t, state.ReadinessWarmed, mgr.EvaluationReadiness(&ngmodels.AlertRule{}))
+}
+
+func TestManager_EvaluationReadiness_GraceTimeout(t *testing.T) {
+	clk := clock.NewMock()
+	mgr := newReadinessManager(t, clk, true, time.Minute)
+
+	require.Equal(t, state.ReadinessNotWarmed, mgr.EvaluationReadiness(&ngmodels.AlertRule{}))
+
+	// Once the grace window elapses without a successful Warm, evaluation proceeds (degraded).
+	clk.Add(time.Minute)
+	require.Equal(t, state.ReadinessTimedOut, mgr.EvaluationReadiness(&ngmodels.AlertRule{}))
+	require.False(t, mgr.IsWarmed(), "timeout must not report the cache as warmed")
+}

--- a/pkg/services/ngalert/state/manager_readiness_test.go
+++ b/pkg/services/ngalert/state/manager_readiness_test.go
@@ -9,6 +9,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/infra/tracing"
+	"github.com/grafana/grafana/pkg/services/ngalert/eval"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/state"
 )
 
@@ -23,6 +26,8 @@ func newReadinessManager(t *testing.T, clk clock.Clock, requireWarm bool, timeou
 	cfg := state.ManagerCfg{
 		Clock:           clk,
 		Log:             log.NewNopLogger(),
+		Tracer:          tracing.InitializeTracerForTest(),
+		Images:          &state.NoopImageService{},
 		RequireWarm:     requireWarm,
 		WarmGateTimeout: timeout,
 	}
@@ -75,4 +80,61 @@ func TestManager_Readiness_ClearCacheResets(t *testing.T) {
 
 	mgr.ClearCache()
 	require.Equal(t, state.NotReady, mgr.Ready())
+}
+
+// processResults applies a single Alerting result for a generated rule.
+func processResults(t *testing.T, mgr *state.Manager, now time.Time) (*models.AlertRule, state.StateTransitions, error) {
+	t.Helper()
+	rule := models.RuleGen.GenerateRef()
+	results := eval.Results{eval.ResultGen(eval.WithState(eval.Alerting), eval.WithEvaluatedAt(now))()}
+	transitions, err := mgr.ProcessEvalResults(context.Background(), now, rule, results, nil, nil)
+	return rule, transitions, err
+}
+
+func TestManager_ProcessEvalResults_Readiness(t *testing.T) {
+	t.Run("returns ErrNotReady and applies nothing while gated", func(t *testing.T) {
+		clk := clock.NewMock()
+		mgr := newReadinessManager(t, clk, true, time.Minute)
+
+		rule, transitions, err := processResults(t, mgr, clk.Now())
+
+		require.ErrorIs(t, err, state.ErrNotReady)
+		require.Empty(t, transitions)
+		require.Empty(t, mgr.GetStatesForRuleUID(context.Background(), rule.OrgID, rule.UID),
+			"no state should be written to a cold cache")
+	})
+
+	t.Run("applies results once warmed", func(t *testing.T) {
+		clk := clock.NewMock()
+		mgr := newReadinessManager(t, clk, true, time.Minute)
+		warm(t, mgr)
+
+		rule, transitions, err := processResults(t, mgr, clk.Now())
+
+		require.NoError(t, err)
+		require.NotEmpty(t, transitions)
+		require.NotEmpty(t, mgr.GetStatesForRuleUID(context.Background(), rule.OrgID, rule.UID))
+	})
+
+	t.Run("applies results once the grace window elapses", func(t *testing.T) {
+		clk := clock.NewMock()
+		mgr := newReadinessManager(t, clk, true, time.Minute)
+		clk.Add(time.Minute)
+
+		rule, transitions, err := processResults(t, mgr, clk.Now())
+
+		require.NoError(t, err, "a timed-out probe must not block processing")
+		require.NotEmpty(t, transitions)
+		require.NotEmpty(t, mgr.GetStatesForRuleUID(context.Background(), rule.OrgID, rule.UID))
+	})
+
+	t.Run("never gates when a warm is not required", func(t *testing.T) {
+		clk := clock.NewMock()
+		mgr := newReadinessManager(t, clk, false, time.Minute)
+
+		_, transitions, err := processResults(t, mgr, clk.Now())
+
+		require.NoError(t, err)
+		require.NotEmpty(t, transitions)
+	})
 }

--- a/pkg/services/ngalert/state/manager_readiness_test.go
+++ b/pkg/services/ngalert/state/manager_readiness_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/infra/log"
-	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/state"
 )
 
@@ -19,13 +18,13 @@ type fakeOrgReader struct {
 
 func (f fakeOrgReader) FetchOrgIds(_ context.Context) ([]int64, error) { return f.orgs, nil }
 
-func newReadinessManager(t *testing.T, clk clock.Clock, gate bool, timeout time.Duration) *state.Manager {
+func newReadinessManager(t *testing.T, clk clock.Clock, requireWarm bool, timeout time.Duration) *state.Manager {
 	t.Helper()
 	cfg := state.ManagerCfg{
-		Clock:                     clk,
-		Log:                       log.NewNopLogger(),
-		GateEvaluationUntilWarmed: gate,
-		WarmGateTimeout:           timeout,
+		Clock:           clk,
+		Log:             log.NewNopLogger(),
+		RequireWarm:     requireWarm,
+		WarmGateTimeout: timeout,
 	}
 	return state.NewManager(cfg, state.NewNoopPersister())
 }
@@ -35,37 +34,45 @@ func warm(t *testing.T, mgr *state.Manager) {
 	mgr.Warm(context.Background(), fakeOrgReader{}, &state.FakeRuleReader{}, &state.FakeInstanceStore{})
 }
 
-func TestManager_EvaluationReadiness_GateDisabled(t *testing.T) {
+func TestManager_Readiness_WarmNotRequired(t *testing.T) {
 	mgr := newReadinessManager(t, clock.NewMock(), false, time.Minute)
 
-	// With gating off (vanilla Grafana default) the manager starts ready, so evaluation is never
-	// gated, even before Warm.
-	require.True(t, mgr.IsWarmed())
-	require.Equal(t, state.ReadinessWarmed, mgr.EvaluationReadiness(&ngmodels.AlertRule{}))
+	// When a warm is not required (vanilla Grafana default) the manager is ready immediately,
+	// even before Warm.
+	require.Equal(t, state.Ready, mgr.Ready())
 }
 
-func TestManager_EvaluationReadiness_GateEnabled(t *testing.T) {
+func TestManager_Readiness_WarmRequired(t *testing.T) {
 	clk := clock.NewMock()
 	mgr := newReadinessManager(t, clk, true, time.Minute)
 
 	// Before Warm: gated.
-	require.Equal(t, state.ReadinessNotWarmed, mgr.EvaluationReadiness(&ngmodels.AlertRule{}))
-	require.False(t, mgr.IsWarmed())
+	require.Equal(t, state.NotReady, mgr.Ready())
 
 	// After a successful Warm: ready.
 	warm(t, mgr)
-	require.True(t, mgr.IsWarmed())
-	require.Equal(t, state.ReadinessWarmed, mgr.EvaluationReadiness(&ngmodels.AlertRule{}))
+	require.Equal(t, state.Ready, mgr.Ready())
 }
 
-func TestManager_EvaluationReadiness_GraceTimeout(t *testing.T) {
+func TestManager_Readiness_GraceTimeout(t *testing.T) {
 	clk := clock.NewMock()
 	mgr := newReadinessManager(t, clk, true, time.Minute)
 
-	require.Equal(t, state.ReadinessNotWarmed, mgr.EvaluationReadiness(&ngmodels.AlertRule{}))
+	require.Equal(t, state.NotReady, mgr.Ready())
 
-	// Once the grace window elapses without a successful Warm, evaluation proceeds (degraded).
+	// Confirms ManagerCfg.WarmGateTimeout reaches the probe; exhaustive grace-window
+	// timing is covered by the probe's own tests in readiness_test.go.
 	clk.Add(time.Minute)
-	require.Equal(t, state.ReadinessTimedOut, mgr.EvaluationReadiness(&ngmodels.AlertRule{}))
-	require.False(t, mgr.IsWarmed(), "timeout must not report the cache as warmed")
+	require.Equal(t, state.TimedOut, mgr.Ready())
+}
+
+func TestManager_Readiness_ClearCacheResets(t *testing.T) {
+	clk := clock.NewMock()
+	mgr := newReadinessManager(t, clk, true, time.Minute)
+
+	warm(t, mgr)
+	require.Equal(t, state.Ready, mgr.Ready())
+
+	mgr.ClearCache()
+	require.Equal(t, state.NotReady, mgr.Ready())
 }

--- a/pkg/services/ngalert/state/readiness.go
+++ b/pkg/services/ngalert/state/readiness.go
@@ -1,0 +1,77 @@
+package state
+
+import (
+	"sync/atomic"
+	"time"
+
+	"github.com/benbjohnson/clock"
+)
+
+// Readiness reports whether a consumer may proceed.
+type Readiness int
+
+const (
+	// Ready means the probe is ready — proceed normally.
+	Ready Readiness = iota
+	// NotReady means the probe is not ready yet — hold.
+	NotReady
+	// TimedOut means the probe is not ready but the grace window elapsed — proceed anyway.
+	TimedOut
+)
+
+// defaultReadinessTimeout is used when a gated probe is created without an explicit timeout.
+const defaultReadinessTimeout = 2 * time.Minute
+
+// ReadinessProbe reports whether a consumer may proceed.
+type ReadinessProbe interface {
+	// Ready reports the current readiness.
+	Ready() Readiness
+	// MarkReady records that the probe is now ready.
+	MarkReady()
+	// Reset returns the probe to not-ready, restarting the grace window.
+	Reset()
+}
+
+// AlwaysReady is a ReadinessProbe that is always ready.
+type AlwaysReady struct{}
+
+func (AlwaysReady) Ready() Readiness { return Ready }
+func (AlwaysReady) MarkReady()       {}
+func (AlwaysReady) Reset()           {}
+
+// gatedProbe starts not-ready and becomes ready once MarkReady is called. A grace timeout reports
+// ready anyway if that never happens, so a stuck dependency cannot block a consumer forever.
+type gatedProbe struct {
+	clock   clock.Clock
+	timeout time.Duration
+	since   atomic.Int64 // unix nanos
+	ready   atomic.Bool
+}
+
+// newGatedProbe returns a probe that starts not-ready. A timeout <= 0 uses the default.
+func newGatedProbe(clk clock.Clock, timeout time.Duration) *gatedProbe {
+	if timeout <= 0 {
+		timeout = defaultReadinessTimeout
+	}
+	p := &gatedProbe{clock: clk, timeout: timeout}
+	p.since.Store(clk.Now().UnixNano())
+	return p
+}
+
+func (p *gatedProbe) Ready() Readiness {
+	if p.ready.Load() {
+		return Ready
+	}
+	if p.clock.Since(time.Unix(0, p.since.Load())) >= p.timeout {
+		return TimedOut
+	}
+	return NotReady
+}
+
+func (p *gatedProbe) MarkReady() { p.ready.Store(true) }
+
+// Reset returns the probe to not-ready and restarts the grace window from now.
+func (p *gatedProbe) Reset() {
+	p.since.Store(p.clock.Now().UnixNano())
+	p.ready.Store(false)
+}

--- a/pkg/services/ngalert/state/readiness.go
+++ b/pkg/services/ngalert/state/readiness.go
@@ -1,11 +1,16 @@
 package state
 
 import (
+	"errors"
 	"sync/atomic"
 	"time"
 
 	"github.com/benbjohnson/clock"
 )
+
+// ErrNotReady is returned by ProcessEvalResults when the state cache is not ready and within its
+// grace window; the caller should treat it as a skipped, not a failed, evaluation.
+var ErrNotReady = errors.New("state cache is not ready")
 
 // Readiness reports whether a consumer may proceed.
 type Readiness int

--- a/pkg/services/ngalert/state/readiness_test.go
+++ b/pkg/services/ngalert/state/readiness_test.go
@@ -1,0 +1,57 @@
+package state
+
+import (
+	"testing"
+	"time"
+
+	"github.com/benbjohnson/clock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAlwaysReady(t *testing.T) {
+	p := AlwaysReady{}
+
+	t.Run("ready by default", func(t *testing.T) {
+		require.Equal(t, Ready, p.Ready())
+	})
+
+	t.Run("MarkReady is a no-op", func(t *testing.T) {
+		p.MarkReady()
+		require.Equal(t, Ready, p.Ready())
+	})
+
+	t.Run("Reset is a no-op", func(t *testing.T) {
+		p.Reset()
+		require.Equal(t, Ready, p.Ready())
+	})
+}
+
+func TestGatedProbe(t *testing.T) {
+	clk := clock.NewMock()
+	p := newGatedProbe(clk, time.Minute)
+
+	t.Run("starts not ready", func(t *testing.T) {
+		require.Equal(t, NotReady, p.Ready())
+	})
+
+	t.Run("times out once the grace window elapses", func(t *testing.T) {
+		clk.Add(time.Minute)
+		require.Equal(t, TimedOut, p.Ready())
+	})
+
+	t.Run("MarkReady overrides a timed-out probe", func(t *testing.T) {
+		p.MarkReady()
+		require.Equal(t, Ready, p.Ready())
+	})
+
+	t.Run("Reset returns to not ready and restarts the window", func(t *testing.T) {
+		p.Reset()
+		require.Equal(t, NotReady, p.Ready())
+
+		clk.Add(time.Minute - time.Nanosecond)
+		require.Equal(t, NotReady, p.Ready())
+
+		clk.Add(time.Nanosecond)
+		require.Equal(t, TimedOut, p.Ready())
+	})
+}


### PR DESCRIPTION
## What this does

Adds an **opt-in** readiness gate to the alerting state `Manager` so evaluation results are not
applied to a **cold cache** before `Warm` has restored state.

- `Warm` marks the Manager ready; `ClearCache` resets it back to not-ready.
- The gate lives **inside `ProcessEvalResults`**, so the state layer owns the decision and callers
  can't forget to pre-check:
  - **not ready** (within the grace window) → returns `state.ErrNotReady`, applies nothing.
  - **grace window elapsed** → the Manager logs the cold read and proceeds (degraded) rather than
    stalling forever.
- The scheduler reacts to `ErrNotReady` by logging and incrementing
  `schedule_rule_evaluations_missed_total` with a new `reason` label (`state_not_warmed`; the
  existing slow-eval site now uses `reason="slow_evaluation"`).

Readiness is checked **after** the query runs, since `ProcessEvalResults` is called post-evaluation —
the query duration itself widens the window for `Warm` to land.

## Why

Gating is **off by default**, so vanilla Grafana — which warms synchronously before evaluating
(`evaluation_runner.go`) — is unaffected.

It is intended for the multi-tenant Grafana ruler, which warms **asynchronously** after a rule
group is (re)assigned to a pod (ring reshard / first start / restart). Today the ruler's scheduler
can evaluate freshly-seeded rules against a cold cache, deriving a spurious `Normal → Pending` that
`Warm` later overwrites silently — leaving alerts stuck showing `Normal → Pending` in state history.
See grafana/grafana-ruler#22293.

## Compatibility note

`schedule_rule_evaluations_missed_total` gains a `reason` label. Sum-based queries are unaffected;
exact-match PromQL / recording rules on that metric may need updating.

## Tests

- `state`: the `ReadinessProbe` lifecycle (`AlwaysReady` and the gated probe, incl. `Reset` and the
  grace timeout), plus `ProcessEvalResults` returning `ErrNotReady` / applying results once warmed /
  proceeding after the grace window / never gating when a warm isn't required.
- `schedule`: a tick against a not-warmed manager still evaluates but produces no state, and is
  counted with `reason="state_not_warmed"`.
- `go test ./pkg/services/ngalert/...` passes; `golangci-lint run ./pkg/services/ngalert/...` clean
  (one pre-existing unrelated finding in `remote/compat.go` left untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)