### PR TITLE
Chore: Fix tests for thresholds editor

### DIFF
--- a/public/app/features/dimensions/editors/ThresholdsEditor/ThresholdsEditor.test.tsx
+++ b/public/app/features/dimensions/editors/ThresholdsEditor/ThresholdsEditor.test.tsx
@@ -27,10 +27,6 @@ describe('ThresholdsEditor', () => {
     restoreThemeContext = mockThemeContext(createTheme());
   });
 
-  beforeEach(() => {
-    setTestFlags({ 'grafana.thresholdsInterpolation': true });
-  });
-
   afterAll(() => {
     restoreThemeContext();
   });
@@ -52,8 +48,7 @@ describe('ThresholdsEditor', () => {
   it('can add thresholds', async () => {
     setup();
 
-    // only the base threshold input
-    expect(screen.getAllByRole('textbox')).toHaveLength(1);
+    expect(screen.queryAllByRole('spinbutton')).toHaveLength(0);
 
     let baseThreshold = screen.getByRole('textbox', { name: 'Threshold 1' });
     expect(baseThreshold).toBeInTheDocument();
@@ -62,12 +57,12 @@ describe('ThresholdsEditor', () => {
 
     await userEvent.click(screen.getByRole('button', { name: 'Add threshold' }));
 
-    expect(screen.getAllByRole('textbox')).toHaveLength(2);
+    expect(screen.getAllByRole('spinbutton')).toHaveLength(1);
 
-    let customThreshold = screen.getByRole('textbox', { name: 'Threshold 1' });
+    let customThreshold = screen.getByRole('spinbutton', { name: 'Threshold 1' });
     expect(customThreshold).toBeInTheDocument();
     expect(customThreshold).not.toBeDisabled();
-    expect(customThreshold).toHaveValue('0');
+    expect(customThreshold).toHaveValue(0);
 
     baseThreshold = screen.getByRole('textbox', { name: 'Threshold 2' });
     expect(baseThreshold).toBeInTheDocument();
@@ -76,17 +71,17 @@ describe('ThresholdsEditor', () => {
 
     await userEvent.click(screen.getByRole('button', { name: 'Add threshold' }));
 
-    expect(screen.getAllByRole('textbox')).toHaveLength(3);
+    expect(screen.getAllByRole('spinbutton')).toHaveLength(2);
 
-    let customThreshold2 = screen.getByRole('textbox', { name: 'Threshold 1' });
+    let customThreshold2 = screen.getByRole('spinbutton', { name: 'Threshold 1' });
     expect(customThreshold2).toBeInTheDocument();
     expect(customThreshold2).not.toBeDisabled();
-    expect(customThreshold2).toHaveValue('10');
+    expect(customThreshold2).toHaveValue(10);
 
-    customThreshold = screen.getByRole('textbox', { name: 'Threshold 2' });
+    customThreshold = screen.getByRole('spinbutton', { name: 'Threshold 2' });
     expect(customThreshold).toBeInTheDocument();
     expect(customThreshold).not.toBeDisabled();
-    expect(customThreshold).toHaveValue('0');
+    expect(customThreshold).toHaveValue(0);
 
     baseThreshold = screen.getByRole('textbox', { name: 'Threshold 3' });
     expect(baseThreshold).toBeInTheDocument();
@@ -105,17 +100,17 @@ describe('ThresholdsEditor', () => {
     };
     setup({ thresholds });
 
-    expect(screen.getAllByRole('textbox')).toHaveLength(3);
+    expect(screen.getAllByRole('spinbutton')).toHaveLength(2);
 
-    let customThreshold2 = screen.getByRole('textbox', { name: 'Threshold 1' });
+    let customThreshold2 = screen.getByRole('spinbutton', { name: 'Threshold 1' });
     expect(customThreshold2).toBeInTheDocument();
     expect(customThreshold2).not.toBeDisabled();
-    expect(customThreshold2).toHaveValue('75');
+    expect(customThreshold2).toHaveValue(75);
 
-    let customThreshold = screen.getByRole('textbox', { name: 'Threshold 2' });
+    let customThreshold = screen.getByRole('spinbutton', { name: 'Threshold 2' });
     expect(customThreshold).toBeInTheDocument();
     expect(customThreshold).not.toBeDisabled();
-    expect(customThreshold).toHaveValue('50');
+    expect(customThreshold).toHaveValue(50);
 
     let baseThreshold = screen.getByRole('textbox', { name: 'Threshold 3' });
     expect(baseThreshold).toBeInTheDocument();
@@ -124,12 +119,12 @@ describe('ThresholdsEditor', () => {
 
     await userEvent.click(screen.getByRole('button', { name: 'Remove threshold 1' }));
 
-    expect(screen.getAllByRole('textbox')).toHaveLength(2);
+    expect(screen.getAllByRole('spinbutton')).toHaveLength(1);
 
-    customThreshold = screen.getByRole('textbox', { name: 'Threshold 1' });
+    customThreshold = screen.getByRole('spinbutton', { name: 'Threshold 1' });
     expect(customThreshold).toBeInTheDocument();
     expect(customThreshold).not.toBeDisabled();
-    expect(customThreshold).toHaveValue('50');
+    expect(customThreshold).toHaveValue(50);
 
     baseThreshold = screen.getByRole('textbox', { name: 'Threshold 2' });
     expect(baseThreshold).toBeInTheDocument();
@@ -138,7 +133,7 @@ describe('ThresholdsEditor', () => {
 
     await userEvent.click(screen.getByRole('button', { name: 'Remove threshold 1' }));
 
-    expect(screen.getAllByRole('textbox')).toHaveLength(1);
+    expect(screen.queryAllByRole('spinbutton')).toHaveLength(0);
 
     baseThreshold = screen.getByRole('textbox', { name: 'Threshold 1' });
     expect(baseThreshold).toBeInTheDocument();
@@ -164,197 +159,14 @@ describe('ThresholdsEditor', () => {
     };
     setup({ thresholds });
 
-    expect(screen.getByRole('textbox', { name: 'Threshold 1' })).toHaveValue('75');
-    expect(screen.getByRole('textbox', { name: 'Threshold 2' })).toHaveValue('50');
+    expect(screen.getByRole('spinbutton', { name: 'Threshold 1' })).toHaveValue(75);
+    expect(screen.getByRole('spinbutton', { name: 'Threshold 2' })).toHaveValue(50);
 
-    await userEvent.clear(screen.getByRole('textbox', { name: 'Threshold 2' }));
-    await userEvent.type(screen.getByRole('textbox', { name: 'Threshold 2' }), '100');
+    await userEvent.clear(screen.getByRole('spinbutton', { name: 'Threshold 2' }));
+    await userEvent.type(screen.getByRole('spinbutton', { name: 'Threshold 2' }), '100');
 
-    expect(screen.getByRole('textbox', { name: 'Threshold 1' })).toHaveValue('100');
-    expect(screen.getByRole('textbox', { name: 'Threshold 2' })).toHaveValue('75');
-  });
-
-  it('stores a typed variable expression as valueExpr, keeping the numeric value as fallback', async () => {
-    const onChange = jest.fn();
-    const thresholds = {
-      mode: ThresholdsMode.Absolute,
-      steps: [
-        { value: -Infinity, color: '#7EB26D' },
-        { value: 50, color: '#EAB839' },
-        { value: 75, color: '#6ED0E0' },
-      ],
-    };
-    setup({ thresholds, onChange });
-
-    // Threshold 2 is the step with value 50; replace its text in one edit so the
-    // numeric value survives as the fallback
-    const input = screen.getByRole('textbox', { name: 'Threshold 2' });
-    await userEvent.tripleClick(input);
-    await userEvent.paste('$warn');
-
-    // steps keep sorting by their numeric (fallback) value: 50 stays below 75
-    expect(screen.getByRole('textbox', { name: 'Threshold 1' })).toHaveValue('75');
-    expect(screen.getByRole('textbox', { name: 'Threshold 2' })).toHaveValue('$warn');
-
-    await userEvent.tab();
-
-    expect(onChange).toHaveBeenCalledWith({
-      mode: ThresholdsMode.Absolute,
-      steps: [
-        { value: -Infinity, color: '#7EB26D' },
-        { value: 50, valueExpr: '$warn', color: '#EAB839' },
-        { value: 75, color: '#6ED0E0' },
-      ],
-    });
-  });
-
-  it('falls back to 0 when the field is cleared before typing an expression', async () => {
-    const onChange = jest.fn();
-    const thresholds = {
-      mode: ThresholdsMode.Absolute,
-      steps: [
-        { value: -Infinity, color: '#7EB26D' },
-        { value: 50, color: '#EAB839' },
-      ],
-    };
-    setup({ thresholds, onChange });
-
-    // clearing fires a change event that empties the numeric value before the
-    // expression is typed; the fallback must still persist as a number
-    const input = screen.getByRole('textbox', { name: 'Threshold 1' });
-    await userEvent.clear(input);
-    await userEvent.type(input, '$warn');
-    await userEvent.tab();
-
-    expect(onChange).toHaveBeenCalledWith({
-      mode: ThresholdsMode.Absolute,
-      steps: [
-        { value: -Infinity, color: '#7EB26D' },
-        { value: 0, valueExpr: '$warn', color: '#EAB839' },
-      ],
-    });
-  });
-
-  it('persists an emptied field as 0 on blur', async () => {
-    const onChange = jest.fn();
-    const thresholds = {
-      mode: ThresholdsMode.Absolute,
-      steps: [
-        { value: -Infinity, color: '#7EB26D' },
-        { value: 50, color: '#EAB839' },
-      ],
-    };
-    setup({ thresholds, onChange });
-
-    await userEvent.clear(screen.getByRole('textbox', { name: 'Threshold 1' }));
-    await userEvent.tab();
-
-    expect(onChange).toHaveBeenCalledWith({
-      mode: ThresholdsMode.Absolute,
-      steps: [
-        { value: -Infinity, color: '#7EB26D' },
-        { value: 0, color: '#EAB839' },
-      ],
-    });
-  });
-
-  it('clears valueExpr when a numeric value is typed', async () => {
-    const onChange = jest.fn();
-    const thresholds = {
-      mode: ThresholdsMode.Absolute,
-      steps: [
-        { value: -Infinity, color: '#7EB26D' },
-        { value: 50, valueExpr: '$warn', color: '#EAB839' },
-      ],
-    };
-    setup({ thresholds, onChange });
-
-    const input = screen.getByRole('textbox', { name: 'Threshold 1' });
-    expect(input).toHaveValue('$warn');
-
-    await userEvent.tripleClick(input);
-    // paste to exercise the comma-to-dot conversion in one change event
-    await userEvent.paste('4,2');
-    await userEvent.tab();
-
-    expect(onChange).toHaveBeenCalledWith({
-      mode: ThresholdsMode.Absolute,
-      steps: [
-        { value: -Infinity, color: '#7EB26D' },
-        { value: 4.2, color: '#EAB839' },
-      ],
-    });
-  });
-
-  it('renders valueExpr steps from saved thresholds and ignores an expression on the base step', () => {
-    setup({
-      thresholds: {
-        mode: ThresholdsMode.Absolute,
-        steps: [
-          { value: -Infinity, valueExpr: '$ignored', color: '#7EB26D' },
-          { value: 50, color: '#EAB839' },
-          { value: 75, valueExpr: '$warn', color: '#6ED0E0' },
-        ],
-      },
-    });
-
-    expect(screen.getByRole('textbox', { name: 'Threshold 1' })).toHaveValue('$warn');
-    expect(screen.getByRole('textbox', { name: 'Threshold 2' })).toHaveValue('50');
-
-    const baseThreshold = screen.getByRole('textbox', { name: 'Threshold 3' });
-    expect(baseThreshold).toBeDisabled();
-    expect(baseThreshold).toHaveValue('Base');
-  });
-
-  it('keeps numeric-only inputs and does not store expressions when the feature toggle is disabled', async () => {
-    setTestFlags({ 'grafana.thresholdsInterpolation': false });
-
-    const onChange = jest.fn();
-    const thresholds = {
-      mode: ThresholdsMode.Absolute,
-      steps: [
-        { value: -Infinity, color: '#7EB26D' },
-        { value: 50, valueExpr: '$warn', color: '#EAB839' },
-      ],
-    };
-    setup({ thresholds, onChange });
-
-    // number input (spinbutton) showing the numeric fallback, not the expression
-    const input = screen.getByRole('spinbutton', { name: 'Threshold 1' });
-    expect(input).toHaveValue(50);
-
-    await userEvent.tripleClick(input);
-    await userEvent.paste('42');
-    await userEvent.tab();
-
-    // the edited step is written back numeric-only
-    expect(onChange).toHaveBeenCalledWith({
-      mode: ThresholdsMode.Absolute,
-      steps: [
-        { value: -Infinity, color: '#7EB26D' },
-        { value: 42, color: '#EAB839' },
-      ],
-    });
-  });
-
-  it('adds the next threshold based on the highest numeric value, including fallbacks', async () => {
-    setup({
-      thresholds: {
-        mode: ThresholdsMode.Absolute,
-        steps: [
-          { value: -Infinity, color: '#7EB26D' },
-          { value: 50, color: '#EAB839' },
-          { value: 70, valueExpr: '$warn', color: '#6ED0E0' },
-        ],
-      },
-    });
-
-    await userEvent.click(screen.getByRole('button', { name: 'Add threshold' }));
-
-    // next value is 70 + 10, sorted above the expression step's fallback of 70
-    expect(screen.getByRole('textbox', { name: 'Threshold 1' })).toHaveValue('80');
-    expect(screen.getByRole('textbox', { name: 'Threshold 2' })).toHaveValue('$warn');
-    expect(screen.getByRole('textbox', { name: 'Threshold 3' })).toHaveValue('50');
+    expect(screen.getByRole('spinbutton', { name: 'Threshold 1' })).toHaveValue(100);
+    expect(screen.getByRole('spinbutton', { name: 'Threshold 2' })).toHaveValue(75);
   });
 
   it('should not steal focus on mount', () => {
@@ -381,7 +193,7 @@ describe('ThresholdsEditor', () => {
 
     await userEvent.click(screen.getByRole('button', { name: 'Add threshold' }));
 
-    const newInput = screen.getByRole('textbox', { name: 'Threshold 1' });
+    const newInput = screen.getByRole('spinbutton', { name: 'Threshold 1' });
     expect(newInput).toHaveFocus();
   });
 
@@ -420,7 +232,7 @@ describe('ThresholdsEditor', () => {
       />
     );
 
-    expect(screen.getAllByRole('textbox')).toHaveLength(1);
+    expect(screen.queryAllByRole('spinbutton')).toHaveLength(0);
 
     rerender(
       <ThresholdsEditor
@@ -436,9 +248,9 @@ describe('ThresholdsEditor', () => {
       />
     );
 
-    expect(screen.getAllByRole('textbox')).toHaveLength(3);
-    expect(screen.getByRole('textbox', { name: 'Threshold 1' })).toHaveValue('80');
-    expect(screen.getByRole('textbox', { name: 'Threshold 2' })).toHaveValue('60');
+    expect(screen.getAllByRole('spinbutton')).toHaveLength(2);
+    expect(screen.getByRole('spinbutton', { name: 'Threshold 1' })).toHaveValue(80);
+    expect(screen.getByRole('spinbutton', { name: 'Threshold 2' })).toHaveValue(60);
   });
 
   it('should exclude invalid steps and render a proper list', () => {
@@ -456,11 +268,337 @@ describe('ThresholdsEditor', () => {
       },
     });
 
-    expect(screen.getByRole('textbox', { name: 'Threshold 1' })).toHaveValue('78');
-    expect(screen.getByRole('textbox', { name: 'Threshold 2' })).toHaveValue('75');
+    expect(screen.getByRole('spinbutton', { name: 'Threshold 1' })).toHaveValue(78);
+    expect(screen.getByRole('spinbutton', { name: 'Threshold 2' })).toHaveValue(75);
     const baseThreshold = screen.getByRole('textbox', { name: 'Threshold 3' });
     expect(baseThreshold).toBeInTheDocument();
     expect(baseThreshold).toBeDisabled();
     expect(baseThreshold).toHaveValue('Base');
+  });
+
+  it('keeps numeric-only inputs and does not store expressions', async () => {
+    const onChange = jest.fn();
+    const thresholds = {
+      mode: ThresholdsMode.Absolute,
+      steps: [
+        { value: -Infinity, color: '#7EB26D' },
+        { value: 50, valueExpr: '$warn', color: '#EAB839' },
+      ],
+    };
+    setup({ thresholds, onChange });
+
+    // number input (spinbutton) showing the numeric fallback, not the expression
+    const input = screen.getByRole('spinbutton', { name: 'Threshold 1' });
+    expect(input).toHaveValue(50);
+
+    await userEvent.tripleClick(input);
+    await userEvent.paste('42');
+    await userEvent.tab();
+
+    // the edited step is written back numeric-only
+    expect(onChange).toHaveBeenCalledWith({
+      mode: ThresholdsMode.Absolute,
+      steps: [
+        { value: -Infinity, color: '#7EB26D' },
+        { value: 42, color: '#EAB839' },
+      ],
+    });
+  });
+
+  describe('with thresholdsInterpolation enabled', () => {
+    beforeEach(() => {
+      setTestFlags({ 'grafana.thresholdsInterpolation': true });
+    });
+
+    // reset in afterAll rather than afterEach: RTL's cleanup runs after this
+    // block's afterEach, so resetting per-test would emit a flag change into a
+    // still-mounted component and trip the act() warning
+    afterAll(() => {
+      setTestFlags();
+    });
+
+    it('can add thresholds', async () => {
+      setup();
+
+      // only the base threshold input
+      expect(screen.getAllByRole('textbox')).toHaveLength(1);
+
+      let baseThreshold = screen.getByRole('textbox', { name: 'Threshold 1' });
+      expect(baseThreshold).toBeInTheDocument();
+      expect(baseThreshold).toBeDisabled();
+      expect(baseThreshold).toHaveValue('Base');
+
+      await userEvent.click(screen.getByRole('button', { name: 'Add threshold' }));
+
+      expect(screen.getAllByRole('textbox')).toHaveLength(2);
+
+      let customThreshold = screen.getByRole('textbox', { name: 'Threshold 1' });
+      expect(customThreshold).toBeInTheDocument();
+      expect(customThreshold).not.toBeDisabled();
+      expect(customThreshold).toHaveValue('0');
+
+      baseThreshold = screen.getByRole('textbox', { name: 'Threshold 2' });
+      expect(baseThreshold).toBeInTheDocument();
+      expect(baseThreshold).toBeDisabled();
+      expect(baseThreshold).toHaveValue('Base');
+
+      await userEvent.click(screen.getByRole('button', { name: 'Add threshold' }));
+
+      expect(screen.getAllByRole('textbox')).toHaveLength(3);
+
+      let customThreshold2 = screen.getByRole('textbox', { name: 'Threshold 1' });
+      expect(customThreshold2).toBeInTheDocument();
+      expect(customThreshold2).not.toBeDisabled();
+      expect(customThreshold2).toHaveValue('10');
+
+      customThreshold = screen.getByRole('textbox', { name: 'Threshold 2' });
+      expect(customThreshold).toBeInTheDocument();
+      expect(customThreshold).not.toBeDisabled();
+      expect(customThreshold).toHaveValue('0');
+
+      baseThreshold = screen.getByRole('textbox', { name: 'Threshold 3' });
+      expect(baseThreshold).toBeInTheDocument();
+      expect(baseThreshold).toBeDisabled();
+      expect(baseThreshold).toHaveValue('Base');
+    });
+
+    it('can remove thresholds', async () => {
+      const thresholds = {
+        mode: ThresholdsMode.Absolute,
+        steps: [
+          { value: -Infinity, color: '#7EB26D' },
+          { value: 50, color: '#EAB839' },
+          { value: 75, color: '#6ED0E0' },
+        ],
+      };
+      setup({ thresholds });
+
+      expect(screen.getAllByRole('textbox')).toHaveLength(3);
+
+      let customThreshold2 = screen.getByRole('textbox', { name: 'Threshold 1' });
+      expect(customThreshold2).toBeInTheDocument();
+      expect(customThreshold2).not.toBeDisabled();
+      expect(customThreshold2).toHaveValue('75');
+
+      let customThreshold = screen.getByRole('textbox', { name: 'Threshold 2' });
+      expect(customThreshold).toBeInTheDocument();
+      expect(customThreshold).not.toBeDisabled();
+      expect(customThreshold).toHaveValue('50');
+
+      let baseThreshold = screen.getByRole('textbox', { name: 'Threshold 3' });
+      expect(baseThreshold).toBeInTheDocument();
+      expect(baseThreshold).toBeDisabled();
+      expect(baseThreshold).toHaveValue('Base');
+
+      await userEvent.click(screen.getByRole('button', { name: 'Remove threshold 1' }));
+
+      expect(screen.getAllByRole('textbox')).toHaveLength(2);
+
+      customThreshold = screen.getByRole('textbox', { name: 'Threshold 1' });
+      expect(customThreshold).toBeInTheDocument();
+      expect(customThreshold).not.toBeDisabled();
+      expect(customThreshold).toHaveValue('50');
+
+      baseThreshold = screen.getByRole('textbox', { name: 'Threshold 2' });
+      expect(baseThreshold).toBeInTheDocument();
+      expect(baseThreshold).toBeDisabled();
+      expect(baseThreshold).toHaveValue('Base');
+
+      await userEvent.click(screen.getByRole('button', { name: 'Remove threshold 1' }));
+
+      expect(screen.getAllByRole('textbox')).toHaveLength(1);
+
+      baseThreshold = screen.getByRole('textbox', { name: 'Threshold 1' });
+      expect(baseThreshold).toBeInTheDocument();
+      expect(baseThreshold).toBeDisabled();
+      expect(baseThreshold).toHaveValue('Base');
+    });
+
+    it('sorts thresholds when values change', async () => {
+      const thresholds = {
+        mode: ThresholdsMode.Absolute,
+        steps: [
+          { value: -Infinity, color: '#7EB26D' },
+          { value: 50, color: '#EAB839' },
+          { value: 75, color: '#6ED0E0' },
+        ],
+      };
+      setup({ thresholds });
+
+      expect(screen.getByRole('textbox', { name: 'Threshold 1' })).toHaveValue('75');
+      expect(screen.getByRole('textbox', { name: 'Threshold 2' })).toHaveValue('50');
+
+      await userEvent.clear(screen.getByRole('textbox', { name: 'Threshold 2' }));
+      await userEvent.type(screen.getByRole('textbox', { name: 'Threshold 2' }), '100');
+
+      expect(screen.getByRole('textbox', { name: 'Threshold 1' })).toHaveValue('100');
+      expect(screen.getByRole('textbox', { name: 'Threshold 2' })).toHaveValue('75');
+    });
+
+    it('should focus the new threshold input when user adds a threshold', async () => {
+      setup({
+        thresholds: {
+          mode: ThresholdsMode.Absolute,
+          steps: [{ value: -Infinity, color: 'green' }],
+        },
+      });
+
+      await userEvent.click(screen.getByRole('button', { name: 'Add threshold' }));
+
+      const newInput = screen.getByRole('textbox', { name: 'Threshold 1' });
+      expect(newInput).toHaveFocus();
+    });
+
+    it('stores a typed variable expression as valueExpr, keeping the numeric value as fallback', async () => {
+      const onChange = jest.fn();
+      const thresholds = {
+        mode: ThresholdsMode.Absolute,
+        steps: [
+          { value: -Infinity, color: '#7EB26D' },
+          { value: 50, color: '#EAB839' },
+          { value: 75, color: '#6ED0E0' },
+        ],
+      };
+      setup({ thresholds, onChange });
+
+      // Threshold 2 is the step with value 50; replace its text in one edit so the
+      // numeric value survives as the fallback
+      const input = screen.getByRole('textbox', { name: 'Threshold 2' });
+      await userEvent.tripleClick(input);
+      await userEvent.paste('$warn');
+
+      // steps keep sorting by their numeric (fallback) value: 50 stays below 75
+      expect(screen.getByRole('textbox', { name: 'Threshold 1' })).toHaveValue('75');
+      expect(screen.getByRole('textbox', { name: 'Threshold 2' })).toHaveValue('$warn');
+
+      await userEvent.tab();
+
+      expect(onChange).toHaveBeenCalledWith({
+        mode: ThresholdsMode.Absolute,
+        steps: [
+          { value: -Infinity, color: '#7EB26D' },
+          { value: 50, valueExpr: '$warn', color: '#EAB839' },
+          { value: 75, color: '#6ED0E0' },
+        ],
+      });
+    });
+
+    it('falls back to 0 when the field is cleared before typing an expression', async () => {
+      const onChange = jest.fn();
+      const thresholds = {
+        mode: ThresholdsMode.Absolute,
+        steps: [
+          { value: -Infinity, color: '#7EB26D' },
+          { value: 50, color: '#EAB839' },
+        ],
+      };
+      setup({ thresholds, onChange });
+
+      // clearing fires a change event that empties the numeric value before the
+      // expression is typed; the fallback must still persist as a number
+      const input = screen.getByRole('textbox', { name: 'Threshold 1' });
+      await userEvent.clear(input);
+      await userEvent.type(input, '$warn');
+      await userEvent.tab();
+
+      expect(onChange).toHaveBeenCalledWith({
+        mode: ThresholdsMode.Absolute,
+        steps: [
+          { value: -Infinity, color: '#7EB26D' },
+          { value: 0, valueExpr: '$warn', color: '#EAB839' },
+        ],
+      });
+    });
+
+    it('persists an emptied field as 0 on blur', async () => {
+      const onChange = jest.fn();
+      const thresholds = {
+        mode: ThresholdsMode.Absolute,
+        steps: [
+          { value: -Infinity, color: '#7EB26D' },
+          { value: 50, color: '#EAB839' },
+        ],
+      };
+      setup({ thresholds, onChange });
+
+      await userEvent.clear(screen.getByRole('textbox', { name: 'Threshold 1' }));
+      await userEvent.tab();
+
+      expect(onChange).toHaveBeenCalledWith({
+        mode: ThresholdsMode.Absolute,
+        steps: [
+          { value: -Infinity, color: '#7EB26D' },
+          { value: 0, color: '#EAB839' },
+        ],
+      });
+    });
+
+    it('clears valueExpr when a numeric value is typed', async () => {
+      const onChange = jest.fn();
+      const thresholds = {
+        mode: ThresholdsMode.Absolute,
+        steps: [
+          { value: -Infinity, color: '#7EB26D' },
+          { value: 50, valueExpr: '$warn', color: '#EAB839' },
+        ],
+      };
+      setup({ thresholds, onChange });
+
+      const input = screen.getByRole('textbox', { name: 'Threshold 1' });
+      expect(input).toHaveValue('$warn');
+
+      await userEvent.tripleClick(input);
+      // paste to exercise the comma-to-dot conversion in one change event
+      await userEvent.paste('4,2');
+      await userEvent.tab();
+
+      expect(onChange).toHaveBeenCalledWith({
+        mode: ThresholdsMode.Absolute,
+        steps: [
+          { value: -Infinity, color: '#7EB26D' },
+          { value: 4.2, color: '#EAB839' },
+        ],
+      });
+    });
+
+    it('renders valueExpr steps from saved thresholds and ignores an expression on the base step', () => {
+      setup({
+        thresholds: {
+          mode: ThresholdsMode.Absolute,
+          steps: [
+            { value: -Infinity, valueExpr: '$ignored', color: '#7EB26D' },
+            { value: 50, color: '#EAB839' },
+            { value: 75, valueExpr: '$warn', color: '#6ED0E0' },
+          ],
+        },
+      });
+
+      expect(screen.getByRole('textbox', { name: 'Threshold 1' })).toHaveValue('$warn');
+      expect(screen.getByRole('textbox', { name: 'Threshold 2' })).toHaveValue('50');
+
+      const baseThreshold = screen.getByRole('textbox', { name: 'Threshold 3' });
+      expect(baseThreshold).toBeDisabled();
+      expect(baseThreshold).toHaveValue('Base');
+    });
+
+    it('adds the next threshold based on the highest numeric value, including fallbacks', async () => {
+      setup({
+        thresholds: {
+          mode: ThresholdsMode.Absolute,
+          steps: [
+            { value: -Infinity, color: '#7EB26D' },
+            { value: 50, color: '#EAB839' },
+            { value: 70, valueExpr: '$warn', color: '#6ED0E0' },
+          ],
+        },
+      });
+
+      await userEvent.click(screen.getByRole('button', { name: 'Add threshold' }));
+
+      // next value is 70 + 10, sorted above the expression step's fallback of 70
+      expect(screen.getByRole('textbox', { name: 'Threshold 1' })).toHaveValue('80');
+      expect(screen.getByRole('textbox', { name: 'Threshold 2' })).toHaveValue('$warn');
+      expect(screen.getByRole('textbox', { name: 'Threshold 3' })).toHaveValue('50');
+    });
   });
 });


### PR DESCRIPTION
I missed pushing this commit on https://github.com/grafana/grafana/pull/128451. It splits the tests into 2 sections, one for the old threshold input without the FF and one for when the FF is enabled. Thought it went through on that PR, but apparently didn't so I'm opening this chore PR