### PR TITLE
konrad/rulelist v3 04 filters

### DIFF
--- a/public/app/features/alerting/unified/Analytics.ts
+++ b/public/app/features/alerting/unified/Analytics.ts
@@ -349,8 +349,8 @@ export function trackFolderBulkActionsUnpauseFail() {
 
 export function trackAlertRuleFilterEvent(
   payload:
-    | { filterMethod: 'search-input'; filter: RulesFilter; filterVariant: 'v1' | 'v2' }
-    | { filterMethod: 'filter-component'; filter: keyof RulesFilter; filterVariant: 'v1' | 'v2' }
+    | { filterMethod: 'search-input'; filter: RulesFilter; filterVariant: 'v1' | 'v2' | 'v3' }
+    | { filterMethod: 'filter-component'; filter: keyof RulesFilter; filterVariant: 'v1' | 'v2' | 'v3' }
 ) {
   const variant = payload.filterVariant;
   if (payload.filterMethod === 'search-input') {

--- a/public/app/features/alerting/unified/rule-list/RuleList.v3.test.tsx
+++ b/public/app/features/alerting/unified/rule-list/RuleList.v3.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen, waitFor } from 'test/test-utils';
+import { byTestId } from 'testing-library-selector';
+
+import { setPluginComponentsHook, setPluginLinksHook } from '@grafana/runtime';
+import { AccessControlAction } from 'app/types/accessControl';
+
+import { setupMswServer } from '../mockApi';
+import { grantUserPermissions } from '../mocks';
+import { alertRuleHitFactory, recordingRuleHitFactory } from '../mocks/server/entities/k8s/ruleSearchHits';
+import { rulesSearchHandlerFor } from '../mocks/server/handlers/k8s/rulesSearch.k8s';
+
+import RuleListPage from './RuleList.v3';
+import { loadDefaultSavedSearch } from './filter/useSavedSearches';
+
+jest.mock('@grafana/assistant', () => ({
+  useAssistant: () => ({ isAvailable: false, openAssistant: jest.fn() }),
+}));
+
+jest.mock('./filter/useSavedSearches', () => ({
+  ...jest.requireActual('./filter/useSavedSearches'),
+  loadDefaultSavedSearch: jest.fn(),
+  useSavedSearches: jest.fn(() => ({
+    savedSearches: [],
+    isLoading: false,
+    saveSearch: jest.fn(),
+    renameSearch: jest.fn(),
+    deleteSearch: jest.fn(),
+    setDefaultSearch: jest.fn(),
+  })),
+}));
+
+const loadDefaultSavedSearchMock = loadDefaultSavedSearch as jest.MockedFunction<typeof loadDefaultSavedSearch>;
+
+setPluginLinksHook(() => ({ links: [], isLoading: false }));
+setPluginComponentsHook(() => ({ components: [], isLoading: false }));
+
+grantUserPermissions([AccessControlAction.AlertingRuleRead]);
+
+const server = setupMswServer();
+
+const ui = {
+  searchInput: byTestId('search-query-input'),
+};
+
+beforeEach(() => {
+  loadDefaultSavedSearchMock.mockResolvedValue(null);
+  sessionStorage.clear();
+  sessionStorage.setItem('grafana.alerting.ruleList.visited', 'true');
+
+  server.use(
+    rulesSearchHandlerFor([
+      alertRuleHitFactory.build({ name: 'alert-uid', title: 'CPU usage high' }),
+      recordingRuleHitFactory.build({ name: 'recording-uid', title: 'Memory usage average' }),
+    ])
+  );
+});
+
+describe('RuleListPage v3', () => {
+  it('renders the search input and the flat list', async () => {
+    render(<RuleListPage />);
+
+    expect(await screen.findByText('CPU usage high')).toBeInTheDocument();
+    expect(screen.getByText('Memory usage average')).toBeInTheDocument();
+    expect(ui.searchInput.get()).toBeInTheDocument();
+  });
+
+  it('applies a URL search query server-side (type filter)', async () => {
+    render(<RuleListPage />, { historyOptions: { initialEntries: ['/?search=type:recording'] } });
+
+    expect(await screen.findByText('Memory usage average')).toBeInTheDocument();
+    expect(screen.queryByText('CPU usage high')).not.toBeInTheDocument();
+  });
+
+  it('filters the list server-side as the user types a query', async () => {
+    const { user } = render(<RuleListPage />);
+
+    expect(await screen.findByText('CPU usage high')).toBeInTheDocument();
+
+    await user.type(ui.searchInput.get(), 'rule:memory{Enter}');
+
+    await waitFor(() => expect(screen.queryByText('CPU usage high')).not.toBeInTheDocument());
+    expect(screen.getByText('Memory usage average')).toBeInTheDocument();
+  });
+});

--- a/public/app/features/alerting/unified/rule-list/RuleList.v3.tsx
+++ b/public/app/features/alerting/unified/rule-list/RuleList.v3.tsx
@@ -1,8 +1,11 @@
+import { Stack } from '@grafana/ui';
+
 import { AlertingPageWrapper } from '../components/AlertingPageWrapper';
 import { useRulesFilter } from '../hooks/useFilteredRules';
 import { useAlertRulesNav } from '../navigation/useAlertRulesNav';
 
 import { FilterViewV3 } from './FilterView.v3';
+import RulesFilterV3 from './filter/RulesFilter.v3';
 
 export default function RuleListPage() {
   const { navId, pageNav } = useAlertRulesNav();
@@ -10,7 +13,10 @@ export default function RuleListPage() {
 
   return (
     <AlertingPageWrapper navId={navId} pageNav={pageNav}>
-      <FilterViewV3 filterState={filterState} />
+      <Stack direction="column" gap={2}>
+        <RulesFilterV3 />
+        <FilterViewV3 filterState={filterState} />
+      </Stack>
     </AlertingPageWrapper>
   );
 }

--- a/public/app/features/alerting/unified/rule-list/filter/RulesFilter.v3.tsx
+++ b/public/app/features/alerting/unified/rule-list/filter/RulesFilter.v3.tsx
@@ -1,0 +1,202 @@
+import { css } from '@emotion/css';
+import { useCallback, useEffect } from 'react';
+import { Controller, useForm } from 'react-hook-form';
+
+import { type GrafanaTheme2 } from '@grafana/data';
+import { Trans, t } from '@grafana/i18n';
+import { Box, FilterInput, Icon, Label, Stack, useStyles2 } from '@grafana/ui';
+
+import { trackAlertRuleFilterEvent, trackRulesSearchInputCleared } from '../../Analytics';
+import { PopupCard } from '../../components/HoverCard';
+import { SavedSearches } from '../../components/saved-searches/SavedSearches';
+import { type SavedSearch } from '../../components/saved-searches/savedSearchesSchema';
+import { useRulesFilter } from '../../hooks/useFilteredRules';
+import { getSearchFilterFromQuery } from '../../search/rulesSearchParser';
+
+import { trackSavedSearchApplied, useSavedSearches } from './useSavedSearches';
+
+type SearchQueryForm = {
+  query: string;
+};
+
+/**
+ * v3 search input: free-text DSL box + saved searches. Trimmed from v2 — no view-mode selector (v3
+ * has no grouped view) and the query help only lists filters v3 forwards to the k8s `/search`
+ * endpoint (backend-only filtering; see `buildSearchArgs`).
+ */
+export default function RulesFilterV3() {
+  const { searchQuery, updateFilters } = useRulesFilter();
+
+  const {
+    savedSearches,
+    isLoading: savedSearchesLoading,
+    saveSearch,
+    renameSearch,
+    deleteSearch,
+    setDefaultSearch,
+  } = useSavedSearches();
+
+  const { control, setValue, handleSubmit } = useForm<SearchQueryForm>({
+    defaultValues: {
+      query: searchQuery,
+    },
+  });
+
+  useEffect(() => {
+    setValue('query', searchQuery);
+  }, [searchQuery, setValue]);
+
+  const handleApplySearch = useCallback(
+    (search: SavedSearch) => {
+      const parsedFilter = getSearchFilterFromQuery(search.query);
+      updateFilters(parsedFilter);
+      trackSavedSearchApplied(search);
+    },
+    [updateFilters]
+  );
+
+  const submitHandler = (values: SearchQueryForm) => {
+    const parsedFilter = getSearchFilterFromQuery(values.query);
+    trackAlertRuleFilterEvent({ filterMethod: 'search-input', filter: parsedFilter, filterVariant: 'v3' });
+    updateFilters(parsedFilter);
+  };
+
+  return (
+    <form onSubmit={handleSubmit(submitHandler)} onReset={() => {}}>
+      <Stack direction="column" gap={1}>
+        <Label htmlFor="rulesSearchInput">
+          <Stack gap={0.5} alignItems="center">
+            <span>
+              <Trans i18nKey="alerting.rules-filter.search">Search</Trans>
+            </span>
+            <PopupCard content={<SearchQueryHelp />}>
+              <Icon
+                name="info-circle"
+                size="sm"
+                tabIndex={0}
+                title={t('alerting.rules-filter.title-search-help', 'Search help')}
+              />
+            </PopupCard>
+          </Stack>
+        </Label>
+        <Stack direction="row" alignItems="center" gap={1}>
+          <Box flex={1}>
+            <Controller
+              name="query"
+              control={control}
+              render={({ field }) => (
+                <FilterInput
+                  id="rulesSearchInput"
+                  data-testid="search-query-input"
+                  placeholder={t(
+                    'alerting.rules-filter.filter-options.placeholder-search-input',
+                    'Search by name or enter filter query...'
+                  )}
+                  name="searchQuery"
+                  escapeRegex={false}
+                  onChange={(next) => {
+                    trackRulesSearchInputCleared(field.value, next);
+                    field.onChange(next);
+                  }}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter' || event.key === 'NumpadEnter') {
+                      event.preventDefault();
+                      handleSubmit(submitHandler)();
+                    }
+                  }}
+                  onBlur={() => {
+                    const parsedFilter = getSearchFilterFromQuery(field.value);
+                    trackAlertRuleFilterEvent({
+                      filterMethod: 'search-input',
+                      filter: parsedFilter,
+                      filterVariant: 'v3',
+                    });
+                    updateFilters(parsedFilter);
+                  }}
+                  value={field.value}
+                />
+              )}
+            />
+          </Box>
+          <SavedSearches
+            savedSearches={savedSearches}
+            currentSearchQuery={searchQuery}
+            onSave={saveSearch}
+            onRename={renameSearch}
+            onDelete={deleteSearch}
+            onApply={handleApplySearch}
+            onSetDefault={setDefaultSearch}
+            isLoading={savedSearchesLoading}
+          />
+        </Stack>
+      </Stack>
+    </form>
+  );
+}
+
+function SearchQueryHelp() {
+  const styles = useStyles2(helpStyles);
+
+  return (
+    <div>
+      <div>
+        <Trans i18nKey="alerting.search-query-help.search-syntax">
+          Search syntax allows to query alert rules by the parameters defined below.
+        </Trans>
+      </div>
+      <hr />
+      <div className={styles.grid}>
+        <div>
+          <Trans i18nKey="alerting.search-query-help.filter-type">Filter type</Trans>
+        </div>
+        <div>
+          <Trans i18nKey="alerting.search-query-help.expression">Expression</Trans>
+        </div>
+        <HelpRow
+          title={t('alerting.search-query-help.title-datasources', 'Datasources')}
+          expr="datasource:mimir datasource:prometheus"
+        />
+        <HelpRow title={t('alerting.search-query-help.title-group', 'Group')} expr="group:cpu-usage" />
+        <HelpRow title={t('alerting.search-query-help.title-rule', 'Rule')} expr='rule:"cpu 80%"' />
+        <HelpRow
+          title={t('alerting.search-query-help.title-labels', 'Labels')}
+          expr='label:team=A label:"cluster=new york"'
+        />
+        <HelpRow title={t('alerting.search-query-help.title-type', 'Type')} expr="type:alerting|recording" />
+        <HelpRow
+          title={t('alerting.search-query-help.title-dashboard-uid', 'Dashboard UID')}
+          expr="dashboard:eadde4c7-54e6-4964-85c0-484ab852fd04"
+        />
+        <HelpRow
+          title={t('alerting.search-query-help.title-contact-point', 'Contact point')}
+          expr="contactPoint:slack"
+        />
+        <HelpRow title={t('alerting.search-query-help.title-policy', 'Policy')} expr="policy:team-a-policy" />
+      </div>
+    </div>
+  );
+}
+
+function HelpRow({ title, expr }: { title: string; expr: string }) {
+  const styles = useStyles2(helpStyles);
+
+  return (
+    <>
+      <div>{title}</div>
+      <code className={styles.code}>{expr}</code>
+    </>
+  );
+}
+
+const helpStyles = (theme: GrafanaTheme2) => ({
+  grid: css({
+    display: 'grid',
+    gridTemplateColumns: 'max-content auto',
+    gap: theme.spacing(1),
+    alignItems: 'center',
+  }),
+  code: css({
+    display: 'block',
+    textAlign: 'center',
+  }),
+});

--- a/public/app/features/alerting/unified/rule-list/hooks/useK8sRulesSearch.test.ts
+++ b/public/app/features/alerting/unified/rule-list/hooks/useK8sRulesSearch.test.ts
@@ -3,6 +3,7 @@ import { HttpResponse, http } from 'msw';
 import { getWrapper } from 'test/test-utils';
 
 import { setupMswServer } from 'app/features/alerting/unified/mockApi';
+import { mockDataSource } from 'app/features/alerting/unified/mocks';
 import {
   alertRuleHitFactory,
   recordingRuleHitFactory,
@@ -12,6 +13,7 @@ import {
   rulesSearchHandlerFor,
 } from 'app/features/alerting/unified/mocks/server/handlers/k8s/rulesSearch.k8s';
 import { getSearchFilterFromQuery } from 'app/features/alerting/unified/search/rulesSearchParser';
+import { setupDataSources } from 'app/features/alerting/unified/testSetup/datasources';
 
 import { buildSearchArgs, useK8sRulesSearch } from './useK8sRulesSearch';
 
@@ -61,6 +63,29 @@ describe('buildSearchArgs', () => {
     expect(args.dashboardUid).toBe('my-dashboard-uid');
   });
 
+  it('maps notification policy to routingTree', () => {
+    const filter = getSearchFilterFromQuery('policy:team-a-policy');
+    const args = buildSearchArgs(filter);
+
+    expect(args.routingTree).toBe('team-a-policy');
+  });
+
+  it('maps the hide-plugin-rules filter to a not-exists label matcher', () => {
+    const filter = getSearchFilterFromQuery('plugins:hide label:severity=critical');
+    const args = buildSearchArgs(filter);
+
+    expect(args.labels).toEqual(['severity=critical', '!__grafana_origin']);
+  });
+
+  it('resolves datasource names to uids for datasourceUiDs, skipping unknown names', () => {
+    setupDataSources(mockDataSource({ name: 'Prometheus', uid: 'prometheus-uid' }));
+
+    const filter = getSearchFilterFromQuery('datasource:Prometheus datasource:Deleted');
+    const args = buildSearchArgs(filter);
+
+    expect(args.datasourceUiDs).toEqual(['prometheus-uid']);
+  });
+
   it('always sorts by title and forwards the page size as limit', () => {
     const args = buildSearchArgs(emptyFilter, 10);
 
@@ -76,7 +101,9 @@ describe('buildSearchArgs', () => {
     expect(args.groups).toBeUndefined();
     expect(args.type).toBeUndefined();
     expect(args.receiver).toBeUndefined();
+    expect(args.routingTree).toBeUndefined();
     expect(args.dashboardUid).toBeUndefined();
+    expect(args.datasourceUiDs).toBeUndefined();
   });
 });
 

--- a/public/app/features/alerting/unified/rule-list/hooks/useK8sRulesSearch.ts
+++ b/public/app/features/alerting/unified/rule-list/hooks/useK8sRulesSearch.ts
@@ -7,7 +7,10 @@ import {
   useLazyGetSearchRulesQuery,
 } from '@grafana/api-clients/rtkq/rules.alerting/v0alpha1';
 
+import { logWarning } from '../../Analytics';
 import { type RulesFilter } from '../../search/rulesSearchParser';
+import { getDatasourceAPIUid } from '../../utils/datasource';
+import { GRAFANA_ORIGIN_LABEL } from '../../utils/labels';
 
 /** The `type` discriminant used by the k8s `/search` endpoint's rule hits. */
 export enum GrafanaRuleType {
@@ -42,9 +45,11 @@ function toGrafanaRuleType(ruleType: RulesFilter['ruleType']): GrafanaRuleType |
 }
 
 /**
- * Maps the definition-compatible subset of `RulesFilter` to `/search` query args.
- * Datasource, state and health filters are dropped — the search endpoint is
- * definition-only and has no server-side concept of them.
+ * Maps the definition-compatible subset of `RulesFilter` to `/search` query args — every filter v3
+ * offers is applied server-side. State and health filters are dropped (the search endpoint is
+ * definition-only). The folder/namespace filter is not yet forwarded: `/search`'s `folders` param
+ * matches folder UIDs, but `RulesFilter.namespace` holds a folder name — that resolution needs a
+ * pure-k8s, uid-valued folder options source that doesn't exist yet.
  */
 export function buildSearchArgs(
   filterState: RulesFilter,
@@ -54,14 +59,45 @@ export function buildSearchArgs(
 
   return {
     q,
-    labels: toApiArgArray(filterState.labels),
+    labels: toApiArgArray(buildLabelMatchers(filterState)),
     groups: toApiArgArray(filterState.groupName ? [filterState.groupName] : []),
     type: toGrafanaRuleType(filterState.ruleType),
     receiver: filterState.contactPoint ?? undefined,
+    routingTree: filterState.policy ?? undefined,
     dashboardUid: filterState.dashboardUid,
+    datasourceUiDs: toApiArgArray(resolveDatasourceUids(filterState.dataSourceNames)),
     sort: 'title',
     limit: String(limit),
   };
+}
+
+/**
+ * Label matchers forwarded to `/search`. The "hide plugin-provided rules" filter (`plugins: 'hide'`)
+ * is really a label filter: plugin-authored rules carry the `__grafana_origin` label, so hiding them
+ * is a not-exists matcher on that label — expressed server-side, not client-side.
+ */
+function buildLabelMatchers(filterState: RulesFilter): string[] {
+  const labels = [...filterState.labels];
+  if (filterState.plugins === 'hide') {
+    labels.push(`!${GRAFANA_ORIGIN_LABEL}`);
+  }
+  return labels;
+}
+
+/**
+ * The datasource filter matches rules by their *queried* datasources; `RulesFilter` stores datasource
+ * names, but `/search` expects UIDs. Names that don't resolve (e.g. a since-deleted datasource) are
+ * skipped rather than failing the whole search.
+ */
+function resolveDatasourceUids(dataSourceNames: string[]): string[] {
+  return dataSourceNames.flatMap((name) => {
+    try {
+      return [getDatasourceAPIUid(name)];
+    } catch {
+      logWarning('Ignoring datasource filter value that could not be resolved to a UID', { dataSourceName: name });
+      return [];
+    }
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds the v3 rule-list search and filter interface, and maps every supported v3 filter to the Kubernetes `/search` endpoint.

- Adds `RulesFilterV3`: search input, query help, saved searches, and v3 analytics.
- Applies labels, group, rule type, contact point, policy/routing tree, dashboard UID, and datasource filters server-side.
- Maps `plugins:hide` to a negated `__grafana_origin` label matcher.
- Resolves datasource names to API UIDs; unknown/deleted datasource names are skipped with a warning.
- Adds UI and request-argument test coverage.

## Scope

Folder filtering is deliberately deferred to the next PR, which supplies a pure-Kubernetes UID-based folder source. This PR performs no client-side filtering.

## Stack

Depends on #128273 (and ultimately #126119).

## Testing

Not run locally as part of this PR-description update.