### PR TITLE
VisualRefresh: Reduce contrast for selected/hover color

### DIFF
--- a/packages/grafana-data/src/themes/themeDefinitions/visual_refresh_dark.json
+++ b/packages/grafana-data/src/themes/themeDefinitions/visual_refresh_dark.json
@@ -90,9 +90,9 @@
     },
     "contrastThreshold": 4.5,
     "action": {
-      "selected": "hsl(from palette.ink100 h s l / 0.12)",
-      "hover": "hsl(from palette.ink100 h s l / 0.09)",
-      "focus": "hsl(from palette.ink100 h s l / 0.09)",
+      "selected": "hsl(from palette.ink100 h s l / 0.10)",
+      "hover": "hsl(from palette.ink100 h s l / 0.08)",
+      "focus": "hsl(from palette.ink100 h s l / 0.08)",
       "selectedBorder": "palette.orange500"
     }
   },

--- a/packages/grafana-data/src/themes/themeDefinitions/visual_refresh_dark.json
+++ b/packages/grafana-data/src/themes/themeDefinitions/visual_refresh_dark.json
@@ -91,8 +91,8 @@
     "contrastThreshold": 4.5,
     "action": {
       "selected": "hsl(from palette.ink100 h s l / 0.10)",
-      "hover": "hsl(from palette.ink100 h s l / 0.08)",
-      "focus": "hsl(from palette.ink100 h s l / 0.08)",
+      "hover": "hsl(from palette.ink100 h s l / 0.07)",
+      "focus": "hsl(from palette.ink100 h s l / 0.07)",
       "selectedBorder": "palette.orange500"
     }
   },


### PR DESCRIPTION
Feel like the selected and hover state are a bit too high contrast (esp on canvas in mega menu) 

Before:
<img width="756" height="1471" alt="Screenshot 2026-07-29 at 11 00 55" src="https://github.com/user-attachments/assets/39749c5b-ce43-4070-8fce-f0886c023cac" />

After:
<img width="644" height="1348" alt="Screenshot 2026-07-29 at 11 03 59" src="https://github.com/user-attachments/assets/cfa20f4c-0d33-4edd-9aea-aef53f66a1ff" />
