### PR TITLE
Search: mount the search endpoint from central wiring

### DIFF
--- a/pkg/registry/apis/dashboard/register.go
+++ b/pkg/registry/apis/dashboard/register.go
@@ -67,7 +67,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/publicdashboards"
 	"github.com/grafana/grafana/pkg/services/quota"
 	"github.com/grafana/grafana/pkg/services/user"
-	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/storage/legacysql"
 	"github.com/grafana/grafana/pkg/storage/legacysql/dualwrite"
 	"github.com/grafana/grafana/pkg/storage/unified/apistore"
@@ -121,7 +120,6 @@ type DashboardsAPIBuilder struct {
 	resourcePermissionsSvc   *dynamic.NamespaceableResourceInterface
 	scheme                   *runtime.Scheme
 	search                   *SearchHandler
-	searchAPI                *searchapi.Handler // nil unless the search API is enabled in config
 	QuotaService             quota.Service
 	ProvisioningService      provisioning.ProvisioningService
 	minRefreshInterval       string
@@ -198,7 +196,6 @@ func RegisterAPIService(
 		accessClient:             accessClient,
 		unified:                  unified,
 		search:                   NewSearchHandler(tracing, unified, features),
-		searchAPI:                newSearchAPIHandler(cfg, tracing, unified),
 		QuotaService:             quotaService,
 		ProvisioningService:      provisioning,
 		minRefreshInterval:       cfg.MinRefreshInterval,
@@ -1401,17 +1398,6 @@ func (b *DashboardsAPIBuilder) PostProcessOpenAPI(oas *spec3.OpenAPI) (*spec3.Op
 func (b *DashboardsAPIBuilder) GetAPIRoutes(gv schema.GroupVersion) *builder.APIRoutes {
 	routes := &builder.APIRoutes{}
 
-	// The search API is mounted under every served version, so a client can use
-	// the same version it uses for the rest of the kind.
-	if b.searchAPI != nil {
-		r := b.searchAPI.SearchRoute(gv.Group, gv.Version, dashv0.DASHBOARD_RESOURCE, "Dashboard")
-		routes.Namespace = append(routes.Namespace, builder.APIRouteHandler{
-			Path:    r.Path,
-			Spec:    r.Spec,
-			Handler: r.Handler,
-		})
-	}
-
 	if gv.Version == dashv0.VERSION {
 		defs := b.GetOpenAPIDefinitions()(func(path string) spec.Ref { return spec.Ref{} })
 		legacySearchRoutes := b.search.GetAPIRoutes(defs)
@@ -1427,17 +1413,6 @@ func (b *DashboardsAPIBuilder) GetAPIRoutes(gv schema.GroupVersion) *builder.API
 		return nil
 	}
 	return routes
-}
-
-// newSearchAPIHandler returns the search API handler, or nil when the endpoint
-// is disabled. Search fields come from the compiled-in app manifests, the same
-// declarations the index mapping is built from.
-func newSearchAPIHandler(cfg *setting.Cfg, tracer tracing.Tracer, unified resource.ResourceClient) *searchapi.Handler {
-	if !cfg.SectionWithEnvOverrides(searchapi.ConfigSection).Key(searchapi.ConfigKey).MustBool(false) {
-		return nil
-	}
-	provider := resource.NewManifestBackedProvider(resource.AppManifests())
-	return searchapi.NewHandler(unified, provider, tracer)
 }
 
 // GetPolicyRuleEvaluator defines the rules for logging auditing events from the API server.

--- a/pkg/services/apiserver/builder/common.go
+++ b/pkg/services/apiserver/builder/common.go
@@ -111,6 +111,13 @@ type APIRouteHandler struct {
 	Handler http.HandlerFunc // when Level = resource, the resource will be available in context
 }
 
+// GroupVersionRoutes are routes the caller mounts itself, for an endpoint that
+// belongs to no single builder.
+type GroupVersionRoutes struct {
+	GroupVersion schema.GroupVersion
+	Routes       *APIRoutes
+}
+
 // APIRoutes define explicit HTTP handlers in an apiserver
 // TBD: is this actually necessary -- there may be more k8s native options for this
 type APIRoutes struct {

--- a/pkg/services/apiserver/builder/helper.go
+++ b/pkg/services/apiserver/builder/helper.go
@@ -124,6 +124,7 @@ func SetupConfig(
 	additionalOpenAPIDefGetters []common.GetOpenAPIDefinitions,
 	reg prometheus.Registerer,
 	apiResourceConfig *serverstorage.ResourceConfig,
+	extraRoutes ...GroupVersionRoutes,
 ) error {
 	serverConfig.AdmissionControl = NewAdmissionFromBuilders(builders)
 	defsGetter := GetOpenAPIDefinitions(builders, additionalOpenAPIDefGetters...)
@@ -136,7 +137,7 @@ func SetupConfig(
 		openapinamer.NewDefinitionNamer(scheme, k8sscheme.Scheme))
 
 	// Add the custom routes to service discovery
-	serverConfig.OpenAPIV3Config.PostProcessSpec = getOpenAPIPostProcessor(buildVersion, builders, gvs, apiResourceConfig)
+	serverConfig.OpenAPIV3Config.PostProcessSpec = getOpenAPIPostProcessor(buildVersion, builders, gvs, apiResourceConfig, extraRoutes)
 	serverConfig.OpenAPIV3Config.GetOperationIDAndTagsFromRoute = func(r common.Route) (string, []string, error) {
 		meta := r.Metadata()
 		kind := ""

--- a/pkg/services/apiserver/builder/openapi.go
+++ b/pkg/services/apiserver/builder/openapi.go
@@ -63,12 +63,37 @@ func GetOpenAPIDefinitions(builders []APIGroupBuilder, additionalGetters ...open
 	}
 }
 
+// addRoutePaths publishes a group version's custom routes in the spec, so a
+// served endpoint is discoverable rather than only documented in code.
+func addRoutePaths(openAPISpec *spec3.OpenAPI, gv schema.GroupVersion, routes *APIRoutes) {
+	for _, route := range routes.Root {
+		openAPISpec.Paths.Paths["/apis/"+gv.String()+"/"+route.Path] = &spec3.Path{
+			PathProps: *route.Spec,
+		}
+	}
+	for _, route := range routes.Namespace {
+		openAPISpec.Paths.Paths["/apis/"+gv.String()+"/namespaces/{namespace}/"+route.Path] = &spec3.Path{
+			PathProps: *route.Spec,
+		}
+	}
+}
+
 func addBuilderRoutes(
 	targetGroupVersion schema.GroupVersion,
 	openAPISpec *spec3.OpenAPI,
 	apiGroupBuilders []APIGroupBuilder,
 	apiResourceConfig *serverstorage.ResourceConfig,
+	extra []GroupVersionRoutes,
 ) (*spec3.OpenAPI, error) {
+	// Before the builders, because a builder that post-processes the spec returns
+	// from the loop below without visiting the rest.
+	for _, e := range extra {
+		if e.Routes == nil || e.GroupVersion != targetGroupVersion {
+			continue
+		}
+		addRoutePaths(openAPISpec, e.GroupVersion, e.Routes)
+	}
+
 	for _, apiGroupBuilder := range apiGroupBuilders {
 		// Optionally include raw http handlers for all builders
 		for _, gv := range GetGroupVersions(apiGroupBuilder) {
@@ -79,17 +104,7 @@ func addBuilderRoutes(
 			if ok && provider != nil {
 				routes := provider.GetAPIRoutes(gv)
 				if routes != nil {
-					for _, route := range routes.Root {
-						openAPISpec.Paths.Paths["/apis/"+gv.String()+"/"+route.Path] = &spec3.Path{
-							PathProps: *route.Spec,
-						}
-					}
-
-					for _, route := range routes.Namespace {
-						openAPISpec.Paths.Paths["/apis/"+gv.String()+"/namespaces/{namespace}/"+route.Path] = &spec3.Path{
-							PathProps: *route.Spec,
-						}
-					}
+					addRoutePaths(openAPISpec, gv, routes)
 				}
 			}
 			// Support direct manipulation of API results
@@ -134,7 +149,7 @@ func isAllRoute(prefix, path string, paths map[string]*spec3.Path) bool {
 
 // Modify the OpenAPI spec to include the additional routes.
 // nolint:gocyclo
-func getOpenAPIPostProcessor(version string, builders []APIGroupBuilder, gvs []schema.GroupVersion, apiResourceConfig *serverstorage.ResourceConfig) func(*spec3.OpenAPI) (*spec3.OpenAPI, error) {
+func getOpenAPIPostProcessor(version string, builders []APIGroupBuilder, gvs []schema.GroupVersion, apiResourceConfig *serverstorage.ResourceConfig, extra []GroupVersionRoutes) func(*spec3.OpenAPI) (*spec3.OpenAPI, error) {
 	return func(s *spec3.OpenAPI) (*spec3.OpenAPI, error) {
 		if s.Paths == nil {
 			return s, nil
@@ -267,7 +282,7 @@ func getOpenAPIPostProcessor(version string, builders []APIGroupBuilder, gvs []s
 						}
 					}
 				}
-				result, err := addBuilderRoutes(gv, &copy, builders, apiResourceConfig)
+				result, err := addBuilderRoutes(gv, &copy, builders, apiResourceConfig, extra)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/services/apiserver/builder/openapi_test.go
+++ b/pkg/services/apiserver/builder/openapi_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/kube-openapi/pkg/spec3"
 )
 
@@ -73,4 +74,42 @@ func TestOpenAPI_GetPathOperations(t *testing.T) {
 			}
 		})
 	}
+}
+
+// A caller-supplied route is served over HTTP, so it has to be discoverable in
+// the spec too, not only the routes that come from builders.
+func TestAddBuilderRoutes_PublishesCallerSuppliedRoutes(t *testing.T) {
+	gv := schema.GroupVersion{Group: "example.grafana.app", Version: "v1"}
+	var reached string
+
+	spec := &spec3.OpenAPI{Paths: &spec3.Paths{Paths: map[string]*spec3.Path{}}}
+	got, err := addBuilderRoutes(gv, spec, nil, enabledConfig(gv), []GroupVersionRoutes{
+		{
+			GroupVersion: gv,
+			Routes:       &APIRoutes{Namespace: []APIRouteHandler{postRoute("widgets/search", &reached, "Search")}},
+		},
+	})
+	require.NoError(t, err)
+
+	path := got.Paths.Paths["/apis/example.grafana.app/v1/namespaces/{namespace}/widgets/search"]
+	require.NotNil(t, path, "the served path is missing from the spec")
+	require.NotNil(t, path.Post)
+	require.Equal(t, "listSearch", path.Post.OperationId)
+}
+
+// Routes for another group version must not leak into this one's spec.
+func TestAddBuilderRoutes_IgnoresOtherGroupVersions(t *testing.T) {
+	target := schema.GroupVersion{Group: "example.grafana.app", Version: "v1"}
+	other := schema.GroupVersion{Group: "other.grafana.app", Version: "v1"}
+	var reached string
+
+	spec := &spec3.OpenAPI{Paths: &spec3.Paths{Paths: map[string]*spec3.Path{}}}
+	got, err := addBuilderRoutes(target, spec, nil, enabledConfig(target), []GroupVersionRoutes{
+		{
+			GroupVersion: other,
+			Routes:       &APIRoutes{Namespace: []APIRouteHandler{postRoute("widgets/search", &reached, "Search")}},
+		},
+	})
+	require.NoError(t, err)
+	require.Empty(t, got.Paths.Paths)
 }

--- a/pkg/services/apiserver/builder/request_handler.go
+++ b/pkg/services/apiserver/builder/request_handler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/endpoints/request"
 	serverstorage "k8s.io/apiserver/pkg/server/storage"
 	klog "k8s.io/klog/v2"
@@ -45,11 +46,14 @@ func convertHandlerToRouteFunction(handler http.HandlerFunc) restful.RouteFuncti
 
 // AugmentWebServicesWithCustomRoutes adds custom routes from builders to existing WebServices
 // in the container.
+//
+// extra is variadic to leave existing callers untouched.
 func AugmentWebServicesWithCustomRoutes(
 	container *restful.Container,
 	builders []APIGroupBuilder,
 	metricsRegistry prometheus.Registerer,
 	apiResourceConfig *serverstorage.ResourceConfig,
+	extra ...GroupVersionRoutes,
 ) error {
 	if container == nil {
 		return fmt.Errorf("container cannot be nil")
@@ -70,10 +74,9 @@ func AugmentWebServicesWithCustomRoutes(
 		}
 
 		for _, gv := range GetGroupVersions(b) {
-			// Filter out disabled API groups
-			gvr := gv.WithResource("")
-			if apiResourceConfig != nil && !apiResourceConfig.ResourceEnabled(gvr) {
-				klog.InfoS("Skipping custom routes for disabled group version", "gv", gv.String())
+			// Checked before GetAPIRoutes, which for some builders builds OpenAPI
+			// definitions.
+			if !customRoutesEnabled(apiResourceConfig, gv) {
 				continue
 			}
 
@@ -82,52 +85,73 @@ func AugmentWebServicesWithCustomRoutes(
 				continue
 			}
 
-			// Find or create WebService for this group version
-			rootPath := "/apis/" + gv.String()
-			ws, exists := existingWebServices[rootPath]
-			if !exists {
-				// Create a new WebService if one doesn't exist
-				ws = new(restful.WebService)
-				ws.Path(rootPath)
-				container.Add(ws)
-				existingWebServices[rootPath] = ws
-			}
-
-			// Add root handlers using OpenAPI specs
-			for _, route := range routes.Root {
-				instrumentedHandler := metrics.InstrumentHandler(
-					gv.Group,
-					gv.Version,
-					route.Path,
-					route.Handler,
-				)
-				routeFunction := convertHandlerToRouteFunction(instrumentedHandler)
-
-				// Use OpenAPI spec to configure routes properly
-				if err := addRouteFromSpec(ws, route.Path, route.Spec, routeFunction, false); err != nil {
-					return fmt.Errorf("failed to add root route %s: %w", route.Path, err)
-				}
-			}
-
-			// Add namespace handlers using OpenAPI specs
-			for _, route := range routes.Namespace {
-				instrumentedHandler := metrics.InstrumentHandler(
-					gv.Group,
-					gv.Version,
-					route.Path,
-					route.Handler,
-				)
-				routeFunction := convertHandlerToRouteFunction(instrumentedHandler)
-
-				// Use OpenAPI spec to configure routes properly
-				if err := addRouteFromSpec(ws, route.Path, route.Spec, routeFunction, true); err != nil {
-					return fmt.Errorf("failed to add namespace route %s: %w", route.Path, err)
-				}
+			if err := addRoutesToWebService(container, existingWebServices, metrics, gv, routes); err != nil {
+				return err
 			}
 		}
 	}
 
+	for _, e := range extra {
+		if e.Routes == nil || !customRoutesEnabled(apiResourceConfig, e.GroupVersion) {
+			continue
+		}
+		if err := addRoutesToWebService(container, existingWebServices, metrics, e.GroupVersion, e.Routes); err != nil {
+			return err
+		}
+	}
+
 	return nil
+}
+
+func customRoutesEnabled(apiResourceConfig *serverstorage.ResourceConfig, gv schema.GroupVersion) bool {
+	if apiResourceConfig != nil && !apiResourceConfig.ResourceEnabled(gv.WithResource("")) {
+		klog.InfoS("Skipping custom routes for disabled group version", "gv", gv.String())
+		return false
+	}
+	return true
+}
+
+// addRoutesToWebService mounts routes for gv, creating the WebService if it is
+// missing. existingWebServices is updated on creation because a second
+// WebService on the same root path would shadow the first.
+func addRoutesToWebService(
+	container *restful.Container,
+	existingWebServices map[string]*restful.WebService,
+	metrics *CustomRouteMetrics,
+	gv schema.GroupVersion,
+	routes *APIRoutes,
+) error {
+	rootPath := "/apis/" + gv.String()
+	ws, exists := existingWebServices[rootPath]
+	if !exists {
+		ws = new(restful.WebService)
+		ws.Path(rootPath)
+		container.Add(ws)
+		existingWebServices[rootPath] = ws
+	}
+
+	for _, route := range routes.Root {
+		if err := addInstrumentedRoute(ws, metrics, gv, route, false); err != nil {
+			return fmt.Errorf("failed to add root route %s: %w", route.Path, err)
+		}
+	}
+	for _, route := range routes.Namespace {
+		if err := addInstrumentedRoute(ws, metrics, gv, route, true); err != nil {
+			return fmt.Errorf("failed to add namespace route %s: %w", route.Path, err)
+		}
+	}
+	return nil
+}
+
+func addInstrumentedRoute(
+	ws *restful.WebService,
+	metrics *CustomRouteMetrics,
+	gv schema.GroupVersion,
+	route APIRouteHandler,
+	isNamespaced bool,
+) error {
+	instrumented := metrics.InstrumentHandler(gv.Group, gv.Version, route.Path, route.Handler)
+	return addRouteFromSpec(ws, route.Path, route.Spec, convertHandlerToRouteFunction(instrumented), isNamespaced)
 }
 
 // addRouteFromSpec adds routes to a WebService using OpenAPI specs

--- a/pkg/services/apiserver/builder/request_handler_test.go
+++ b/pkg/services/apiserver/builder/request_handler_test.go
@@ -1,0 +1,160 @@
+package builder
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	restful "github.com/emicklei/go-restful/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	genericapiserver "k8s.io/apiserver/pkg/server"
+	serverstorage "k8s.io/apiserver/pkg/server/storage"
+	"k8s.io/kube-openapi/pkg/common"
+	"k8s.io/kube-openapi/pkg/spec3"
+)
+
+var testGV = schema.GroupVersion{Group: "example.grafana.app", Version: "v1"}
+
+type routeProviderBuilder struct {
+	gv     schema.GroupVersion
+	routes *APIRoutes
+}
+
+func (b *routeProviderBuilder) GetGroupVersion() schema.GroupVersion { return b.gv }
+func (b *routeProviderBuilder) GetAPIRoutes(schema.GroupVersion) *APIRoutes {
+	return b.routes
+}
+func (b *routeProviderBuilder) InstallSchema(*runtime.Scheme) error { return nil }
+func (b *routeProviderBuilder) UpdateAPIGroupInfo(*genericapiserver.APIGroupInfo, APIGroupOptions) error {
+	return nil
+}
+func (b *routeProviderBuilder) GetOpenAPIDefinitions() common.GetOpenAPIDefinitions { return nil }
+func (b *routeProviderBuilder) AllowedV0Alpha1Resources() []string                  { return nil }
+
+func postRoute(path string, reached *string, name string) APIRouteHandler {
+	return APIRouteHandler{
+		Path: path,
+		Spec: &spec3.PathProps{
+			Post: &spec3.Operation{
+				OperationProps: spec3.OperationProps{OperationId: "list" + name},
+			},
+		},
+		Handler: func(w http.ResponseWriter, _ *http.Request) {
+			*reached = name
+			w.WriteHeader(http.StatusOK)
+		},
+	}
+}
+
+// dispatch goes through the container so the assertions cover real routing, not
+// the shape of the WebService.
+func dispatch(t *testing.T, container *restful.Container, method, path string) int {
+	t.Helper()
+	req := httptest.NewRequest(method, path, nil)
+	rec := httptest.NewRecorder()
+	container.ServeHTTP(rec, req)
+	return rec.Code
+}
+
+func newContainer() *restful.Container {
+	container := restful.NewContainer()
+	container.Router(restful.CurlyRouter{})
+	return container
+}
+
+func enabledConfig(gvs ...schema.GroupVersion) *serverstorage.ResourceConfig {
+	cfg := serverstorage.NewResourceConfig()
+	cfg.EnableVersions(gvs...)
+	return cfg
+}
+
+func TestAugmentWebServices_MountsCallerSuppliedRoutes(t *testing.T) {
+	container := newContainer()
+
+	var reached string
+	err := AugmentWebServicesWithCustomRoutes(container, nil, nil, enabledConfig(testGV),
+		GroupVersionRoutes{
+			GroupVersion: testGV,
+			Routes: &APIRoutes{
+				Namespace: []APIRouteHandler{postRoute("widgets/search", &reached, "Search")},
+			},
+		})
+	require.NoError(t, err)
+
+	code := dispatch(t, container, http.MethodPost,
+		"/apis/example.grafana.app/v1/namespaces/default/widgets/search")
+	assert.Equal(t, http.StatusOK, code)
+	assert.Equal(t, "Search", reached, "the caller-supplied handler should have run")
+}
+
+// A caller may supply routes for a group version that registered none of its own.
+func TestAugmentWebServices_CreatesWebServiceWhenAbsent(t *testing.T) {
+	container := newContainer()
+	require.Empty(t, container.RegisteredWebServices())
+
+	var reached string
+	err := AugmentWebServicesWithCustomRoutes(container, nil, nil, enabledConfig(testGV),
+		GroupVersionRoutes{
+			GroupVersion: testGV,
+			Routes:       &APIRoutes{Namespace: []APIRouteHandler{postRoute("widgets/search", &reached, "Search")}},
+		})
+	require.NoError(t, err)
+
+	require.Len(t, container.RegisteredWebServices(), 1)
+	assert.Equal(t, "/apis/example.grafana.app/v1", container.RegisteredWebServices()[0].RootPath())
+}
+
+// Multi-tenant deployments serve one group per process and disable the rest.
+func TestAugmentWebServices_SkipsDisabledGroupVersion(t *testing.T) {
+	container := newContainer()
+
+	other := schema.GroupVersion{Group: "other.grafana.app", Version: "v1"}
+	var reached string
+	err := AugmentWebServicesWithCustomRoutes(container, nil, nil, enabledConfig(other),
+		GroupVersionRoutes{
+			GroupVersion: testGV,
+			Routes:       &APIRoutes{Namespace: []APIRouteHandler{postRoute("widgets/search", &reached, "Search")}},
+		})
+	require.NoError(t, err)
+
+	assert.Empty(t, container.RegisteredWebServices())
+	assert.Empty(t, reached)
+}
+
+func TestAugmentWebServices_IgnoresEmptyRoutes(t *testing.T) {
+	container := newContainer()
+
+	err := AugmentWebServicesWithCustomRoutes(container, nil, nil, enabledConfig(testGV),
+		GroupVersionRoutes{GroupVersion: testGV, Routes: nil})
+	require.NoError(t, err)
+	assert.Empty(t, container.RegisteredWebServices())
+}
+
+// A second WebService on the same root path would shadow the first.
+func TestAugmentWebServices_SharesWebServiceWithBuilderRoutes(t *testing.T) {
+	container := newContainer()
+
+	var builderReached, extraReached string
+	b := &routeProviderBuilder{
+		gv:     testGV,
+		routes: &APIRoutes{Namespace: []APIRouteHandler{postRoute("widgets/existing", &builderReached, "Existing")}},
+	}
+
+	err := AugmentWebServicesWithCustomRoutes(container, []APIGroupBuilder{b}, nil, enabledConfig(testGV),
+		GroupVersionRoutes{
+			GroupVersion: testGV,
+			Routes:       &APIRoutes{Namespace: []APIRouteHandler{postRoute("widgets/search", &extraReached, "Search")}},
+		})
+	require.NoError(t, err)
+
+	require.Len(t, container.RegisteredWebServices(), 1)
+
+	const base = "/apis/example.grafana.app/v1/namespaces/default/widgets/"
+	assert.Equal(t, http.StatusOK, dispatch(t, container, http.MethodPost, base+"existing"))
+	assert.Equal(t, "Existing", builderReached)
+	assert.Equal(t, http.StatusOK, dispatch(t, container, http.MethodPost, base+"search"))
+	assert.Equal(t, "Search", extraReached)
+}

--- a/pkg/services/apiserver/searchroutes/searchroutes.go
+++ b/pkg/services/apiserver/searchroutes/searchroutes.go
@@ -1,0 +1,130 @@
+// Package searchroutes mounts the search API on the kinds that support it.
+//
+// It exists as glue because the routes are the same for every kind and so belong
+// to no single builder, and because both the single-tenant and multi-tenant
+// apiservers mount them from wiring that mirrors each other.
+package searchroutes
+
+import (
+	appsdkapiserver "github.com/grafana/grafana-app-sdk/k8s/apiserver"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/grafana/grafana/pkg/infra/tracing"
+	searchapi "github.com/grafana/grafana/pkg/registry/apis/search"
+	"github.com/grafana/grafana/pkg/services/apiserver/builder"
+	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/storage/unified/resource"
+)
+
+// namespacedScope is the manifest's spelling for a kind that lives in a
+// namespace. Cluster-scoped kinds have no namespace to search within.
+const namespacedScope = "Namespaced"
+
+// allowed lists the kinds that expose the search API, as (group, resource).
+//
+// Temporary, and deliberately one kind for now. Every namespaced kind is a
+// candidate, but a kind can only be added once its authorizer restates a search
+// request as the read it performs: the endpoint is a POST, so Kubernetes parses
+// it as a create, and a kind that does not restate would demand create
+// permission to search. Dashboards do this in their own authorizer today. Moving
+// that to the authorization chain, which means both the single-tenant and
+// multi-tenant chains, is what unblocks widening this set.
+var allowed = map[groupResource]bool{
+	{group: "dashboard.grafana.app", resource: "dashboards"}: true,
+}
+
+type groupResource struct {
+	group    string
+	resource string
+}
+
+// Build returns the search routes to mount, or nil when the endpoint is off.
+//
+// builders and installers are the two ways a kind reaches the apiserver; a route
+// is only mounted on a group version one of them actually serves.
+func Build(
+	cfg *setting.Cfg,
+	tracer tracing.Tracer,
+	unified resource.ResourceClient,
+	builders []builder.APIGroupBuilder,
+	installers []appsdkapiserver.AppInstaller,
+) []builder.GroupVersionRoutes {
+	if cfg == nil || !cfg.SectionWithEnvOverrides(searchapi.ConfigSection).Key(searchapi.ConfigKey).MustBool(false) {
+		return nil
+	}
+
+	// Search fields come from the compiled-in app manifests, the same
+	// declarations the index mapping is built from.
+	manifests := resource.AppManifests()
+	handler := searchapi.NewHandler(unified, resource.NewManifestBackedProvider(manifests), tracer)
+
+	served := servedGroupVersions(builders, installers)
+	byGroupVersion := map[schema.GroupVersion][]searchapi.Route{}
+
+	for _, m := range manifests {
+		if m.ManifestData == nil {
+			continue
+		}
+		for _, version := range m.ManifestData.Versions {
+			if !version.Served {
+				continue
+			}
+			gv := schema.GroupVersion{Group: m.ManifestData.Group, Version: version.Name}
+			if !served[gv] {
+				continue
+			}
+			for _, kind := range version.Kinds {
+				if kind.Scope != namespacedScope {
+					continue
+				}
+				resourceName := resource.ManifestResourceName(kind)
+				if !allowed[groupResource{group: gv.Group, resource: resourceName}] {
+					continue
+				}
+				byGroupVersion[gv] = append(byGroupVersion[gv],
+					handler.SearchRoute(gv.Group, gv.Version, resourceName, kind.Kind))
+			}
+		}
+	}
+
+	return toGroupVersionRoutes(byGroupVersion)
+}
+
+// servedGroupVersions reports which group versions this process actually serves.
+// A manifest describes kinds that a given deployment may not serve at all.
+func servedGroupVersions(
+	builders []builder.APIGroupBuilder,
+	installers []appsdkapiserver.AppInstaller,
+) map[schema.GroupVersion]bool {
+	served := map[schema.GroupVersion]bool{}
+	for _, b := range builders {
+		for _, gv := range builder.GetGroupVersions(b) {
+			served[gv] = true
+		}
+	}
+	for _, i := range installers {
+		for _, gv := range i.GroupVersions() {
+			served[gv] = true
+		}
+	}
+	return served
+}
+
+func toGroupVersionRoutes(byGroupVersion map[schema.GroupVersion][]searchapi.Route) []builder.GroupVersionRoutes {
+	out := make([]builder.GroupVersionRoutes, 0, len(byGroupVersion))
+	for gv, routes := range byGroupVersion {
+		handlers := make([]builder.APIRouteHandler, 0, len(routes))
+		for _, r := range routes {
+			handlers = append(handlers, builder.APIRouteHandler{
+				Path:    r.Path,
+				Spec:    r.Spec,
+				Handler: r.Handler,
+			})
+		}
+		out = append(out, builder.GroupVersionRoutes{
+			GroupVersion: gv,
+			Routes:       &builder.APIRoutes{Namespace: handlers},
+		})
+	}
+	return out
+}

--- a/pkg/services/apiserver/searchroutes/searchroutes_test.go
+++ b/pkg/services/apiserver/searchroutes/searchroutes_test.go
@@ -1,0 +1,133 @@
+package searchroutes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	genericapiserver "k8s.io/apiserver/pkg/server"
+	"k8s.io/kube-openapi/pkg/common"
+
+	"github.com/grafana/grafana/pkg/services/apiserver/builder"
+	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/storage/unified/resource"
+)
+
+type fakeBuilder struct {
+	gvs []schema.GroupVersion
+}
+
+func (b *fakeBuilder) GetGroupVersions() []schema.GroupVersion { return b.gvs }
+func (b *fakeBuilder) InstallSchema(*runtime.Scheme) error     { return nil }
+func (b *fakeBuilder) UpdateAPIGroupInfo(*genericapiserver.APIGroupInfo, builder.APIGroupOptions) error {
+	return nil
+}
+func (b *fakeBuilder) GetOpenAPIDefinitions() common.GetOpenAPIDefinitions { return nil }
+func (b *fakeBuilder) AllowedV0Alpha1Resources() []string                  { return nil }
+
+func enabledCfg(t *testing.T, enabled bool) *setting.Cfg {
+	t.Helper()
+	cfg := setting.NewCfg()
+	section, err := cfg.Raw.NewSection("grafana-apiserver")
+	require.NoError(t, err)
+	if enabled {
+		_, err = section.NewKey("enable_search_api", "true")
+		require.NoError(t, err)
+	}
+	return cfg
+}
+
+// paths flattens the result so assertions read as the served endpoints do.
+func paths(routes []builder.GroupVersionRoutes) map[string][]string {
+	out := map[string][]string{}
+	for _, r := range routes {
+		if r.Routes == nil {
+			continue
+		}
+		for _, h := range r.Routes.Namespace {
+			out[r.GroupVersion.String()] = append(out[r.GroupVersion.String()], h.Path)
+		}
+	}
+	return out
+}
+
+func TestBuild_DisabledByDefault(t *testing.T) {
+	b := &fakeBuilder{gvs: []schema.GroupVersion{{Group: "dashboard.grafana.app", Version: "v1"}}}
+
+	assert.Nil(t, Build(enabledCfg(t, false), nil, nil, []builder.APIGroupBuilder{b}, nil))
+	assert.Nil(t, Build(nil, nil, nil, []builder.APIGroupBuilder{b}, nil))
+}
+
+func TestBuild_MountsAllowedKinds(t *testing.T) {
+	b := &fakeBuilder{gvs: []schema.GroupVersion{
+		{Group: "dashboard.grafana.app", Version: "v1"},
+		{Group: "folder.grafana.app", Version: "v1"},
+	}}
+
+	got := paths(Build(enabledCfg(t, true), nil, nil, []builder.APIGroupBuilder{b}, nil))
+
+	assert.Equal(t, []string{"dashboards/search"}, got["dashboard.grafana.app/v1"])
+	// Folders are served and namespaced but not allowed yet: their authorizer
+	// would treat a search as a create.
+	assert.NotContains(t, got, "folder.grafana.app/v1")
+}
+
+// A manifest describes kinds this process may not serve, so the served group
+// versions decide what gets mounted.
+func TestBuild_SkipsGroupVersionsNotServed(t *testing.T) {
+	b := &fakeBuilder{gvs: []schema.GroupVersion{{Group: "dashboard.grafana.app", Version: "v1"}}}
+
+	got := paths(Build(enabledCfg(t, true), nil, nil, []builder.APIGroupBuilder{b}, nil))
+
+	assert.Contains(t, got, "dashboard.grafana.app/v1")
+	assert.NotContains(t, got, "dashboard.grafana.app/v2", "v2 is a served version, but not served by this builder")
+}
+
+// The allowlist is what keeps the endpoint off kinds nobody has reviewed yet.
+func TestBuild_SkipsKindsNotAllowed(t *testing.T) {
+	notAllowed := []schema.GroupVersion{
+		{Group: "secret.grafana.app", Version: "v1beta1"},
+		{Group: "iam.grafana.app", Version: "v0alpha1"},
+		{Group: "playlist.grafana.app", Version: "v0alpha1"},
+		{Group: "folder.grafana.app", Version: "v1"},
+	}
+	b := &fakeBuilder{gvs: notAllowed}
+
+	assert.Empty(t, paths(Build(enabledCfg(t, true), nil, nil, []builder.APIGroupBuilder{b}, nil)))
+}
+
+// Every served version of an allowed kind gets the endpoint, so a client can use
+// whichever version it already uses for the kind.
+func TestBuild_MountsEveryServedVersion(t *testing.T) {
+	var dashboardGVs []schema.GroupVersion
+	for _, m := range resource.AppManifests() {
+		if m.ManifestData == nil || m.ManifestData.Group != "dashboard.grafana.app" {
+			continue
+		}
+		for _, v := range m.ManifestData.Versions {
+			if v.Served {
+				dashboardGVs = append(dashboardGVs, schema.GroupVersion{Group: m.ManifestData.Group, Version: v.Name})
+			}
+		}
+	}
+	require.NotEmpty(t, dashboardGVs)
+
+	got := paths(Build(enabledCfg(t, true), nil, nil,
+		[]builder.APIGroupBuilder{&fakeBuilder{gvs: dashboardGVs}}, nil))
+
+	assert.Len(t, got, len(dashboardGVs))
+	for _, gv := range dashboardGVs {
+		assert.Equal(t, []string{"dashboards/search"}, got[gv.String()], "missing route for %s", gv)
+	}
+}
+
+func TestServedGroupVersions_CoversBothRegistrationPaths(t *testing.T) {
+	fromBuilder := schema.GroupVersion{Group: "dashboard.grafana.app", Version: "v1"}
+	b := &fakeBuilder{gvs: []schema.GroupVersion{fromBuilder}}
+
+	served := servedGroupVersions([]builder.APIGroupBuilder{b}, nil)
+	assert.True(t, served[fromBuilder])
+	assert.False(t, served[schema.GroupVersion{Group: "other.grafana.app", Version: "v1"}])
+}

--- a/pkg/services/apiserver/service.go
+++ b/pkg/services/apiserver/service.go
@@ -367,6 +367,10 @@ func (s *service) start(ctx context.Context) error {
 	serverConfig.AuditBackend = s.auditBackend
 	serverConfig.AuditPolicyRuleEvaluator = s.auditPolicyRuleProvider.PolicyRuleProvider(builder.EvaluatorPolicyRuleFromBuilders(s.builders))
 
+	// Built once and used twice: the routes have to reach both the OpenAPI spec
+	// and the served WebServices, or the endpoint works but is undiscoverable.
+	searchRoutes := searchroutes.Build(s.cfg, s.tracing, s.unified, builders, s.appInstallers)
+
 	// Add OpenAPI specs for each group+version (existing builders)
 	err = builder.SetupConfig(
 		s.scheme,
@@ -378,6 +382,7 @@ func (s *service) start(ctx context.Context) error {
 		defGetters,
 		s.metrics,
 		apiResourceConfig,
+		searchRoutes...,
 	)
 	if err != nil {
 		return err
@@ -437,7 +442,6 @@ func (s *service) start(ctx context.Context) error {
 	// Augment existing WebServices with custom routes from builders
 	// This directly adds routes to existing WebServices using the OpenAPI specs from builders
 	if server.Handler != nil && server.Handler.GoRestfulContainer != nil {
-		searchRoutes := searchroutes.Build(s.cfg, s.tracing, s.unified, builders, s.appInstallers)
 		if err := builder.AugmentWebServicesWithCustomRoutes(
 			server.Handler.GoRestfulContainer,
 			builders,

--- a/pkg/services/apiserver/service.go
+++ b/pkg/services/apiserver/service.go
@@ -42,6 +42,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/apiserver/auth/authorizer"
 	"github.com/grafana/grafana/pkg/services/apiserver/builder"
 	grafanaapiserveroptions "github.com/grafana/grafana/pkg/services/apiserver/options"
+	"github.com/grafana/grafana/pkg/services/apiserver/searchroutes"
 	"github.com/grafana/grafana/pkg/services/apiserver/utils"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -436,11 +437,13 @@ func (s *service) start(ctx context.Context) error {
 	// Augment existing WebServices with custom routes from builders
 	// This directly adds routes to existing WebServices using the OpenAPI specs from builders
 	if server.Handler != nil && server.Handler.GoRestfulContainer != nil {
+		searchRoutes := searchroutes.Build(s.cfg, s.tracing, s.unified, builders, s.appInstallers)
 		if err := builder.AugmentWebServicesWithCustomRoutes(
 			server.Handler.GoRestfulContainer,
 			builders,
 			s.metrics,
 			serverConfig.MergedResourceConfig,
+			searchRoutes...,
 		); err != nil {
 			return fmt.Errorf("failed to augment web services with custom routes: %w", err)
 		}


### PR DESCRIPTION
The dashboard builder mounted the search endpoint itself, so every kind wanting one would repeat that wiring. The endpoint is identical for every kind, so it now comes from one place that knows which group versions the process serves — whether they arrive via a builder or an app installer.

To make that possible, `AugmentWebServicesWithCustomRoutes` accepts routes from its caller, filtered by the same resource config the builder path already applies, so a deployment serving one group does not mount routes for the others. The parameter is variadic to leave existing callers untouched, including the near-identical call in grafana-enterprise.

**Nothing changes for a user.** The endpoint is still off unless `[grafana-apiserver] enable_search_api` is set, and when it is set only dashboards get it — the same endpoint as before, served from elsewhere.

The enabled set is a hardcoded allowlist rather than every namespaced kind, because a kind can only be added once its authorizer restates a search request as the read it performs. The endpoint is a POST, so Kubernetes parses it as a create on an object named `search`; a kind that does not restate would demand create permission to search. Dashboards do this in their own authorizer, folders do not. Moving that into the authorization chain — both the single-tenant and multi-tenant ones, which are different types — comes next and unblocks widening the allowlist.