### PR TITLE
Query Editor: Cancel a row's scroll pin when the scroll target changes

### DIFF
--- a/public/app/features/query/components/QueryEditorRow.test.tsx
+++ b/public/app/features/query/components/QueryEditorRow.test.tsx
@@ -504,6 +504,33 @@ describe('QueryEditorRow', () => {
       expect(pinScrollIntoView).toHaveBeenCalledTimes(1);
     });
 
+    it('cancels the pin when the scroll is retargeted at another row', async () => {
+      const onScrollIntoView = jest.fn();
+      const initialProps = props(data);
+      const { rerender } = render(
+        <QueryEditorRow {...initialProps} scrollIntoView onScrollIntoView={onScrollIntoView} />
+      );
+      await waitFor(() => expect(scrollIntoViewSpy).toHaveBeenCalled());
+
+      rerender(<QueryEditorRow {...initialProps} scrollIntoView={false} onScrollIntoView={onScrollIntoView} />);
+      fireEvent.wheel(window);
+
+      // The pin is gone, so the row neither re-scrolls nor reports back — reporting would clear the
+      // owner's new scroll target.
+      expect(onScrollIntoView).not.toHaveBeenCalled();
+    });
+
+    it('pins again if the row is retargeted later', async () => {
+      const initialProps = props(data);
+      const { rerender } = render(<QueryEditorRow {...initialProps} scrollIntoView />);
+      await waitFor(() => expect(scrollIntoViewSpy).toHaveBeenCalled());
+
+      rerender(<QueryEditorRow {...initialProps} scrollIntoView={false} />);
+      rerender(<QueryEditorRow {...initialProps} scrollIntoView />);
+
+      expect(pinScrollIntoView).toHaveBeenCalledTimes(2);
+    });
+
     it('does not scroll when the flag is not set', async () => {
       render(<QueryEditorRow {...props(data)} />);
 

--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -195,6 +195,15 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
       this.setState({ data: dataFilteredByRefId });
     }
 
+    // The owner retargeted the scroll (e.g. a second expression added before this pin settled).
+    // Drop this row's pin so it stops fighting the new target — cancelling rather than finishing,
+    // since finishing would report back and clear the target the owner just set.
+    if (prevProps.scrollIntoView && !this.props.scrollIntoView) {
+      this.cancelScrollPin?.();
+      this.cancelScrollPin = undefined;
+      this.hasStartedScrollIntoView = false;
+    }
+
     this.scrollIntoViewIfNeeded();
 
     // check if we need to load another datasource


### PR DESCRIPTION
## Description

Follow-up to #129101. A `QueryEditorRow` starts a scroll pin when `scrollIntoView` becomes true but never stops it when the prop goes back to false, so adding a second SQL expression within the 1.5s settle window leaves two rows pinned to the same container, fighting over the scroll position. The stale pin can also fire `onScrollIntoView` late, clearing the `scrollToRefId` the owner just set for the new row — if that row's datasource hasn't resolved yet it never renders, never pins, and silently doesn't scroll.

## Changes

* `QueryEditorRow.componentDidUpdate`: when `scrollIntoView` flips from true to false, cancel the in-flight pin and reset the `hasStartedScrollIntoView` latch so the row can be retargeted later. Cancelling rather than finishing is deliberate — finishing would report back and clear the owner's new scroll target.
* Added two tests: one asserting a cancelled pin neither re-scrolls nor reports back, one asserting a retargeted row pins again.

## Risks

Very low. The change is confined to the retarget path, which previously did nothing at all, and the cancel is a no-op in the normal single-expression flow because the pin has already cleared `cancelScrollPin` by the time its own `onDone` flips the prop. Only reachable from the old panel editor's "go to queries" flow.

## Demo

Not applicable — no visual change outside the edge case described above.

## Testing Instructions

* Open a panel with a few queries on a datasource with a non-trivial editor (e.g. Prometheus).
* From the Transformations tab, click "Go to queries" to add a SQL expression, then immediately add a second one before the first scroll settles.
* Confirm the view lands on the second expression and stays there, instead of jittering between the two rows.
* `yarn jest public/app/features/query/components/QueryEditorRow.test.tsx`

## Reviewer Checklist

- [x] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [x] Code is meaningfully improved if applicable

Close DPRO-252