### PR TITLE
Alerting: Normalize empty selectors and trailing commas when hashing queries

### DIFF
--- a/public/app/features/alerting/unified/utils/rule-id.test.tsx
+++ b/public/app/features/alerting/unified/utils/rule-id.test.tsx
@@ -394,6 +394,43 @@ max by (environment, namespace, service) (service_condition{environment!="produc
 
     expect(hashQuery(query1)).toBe(hashQuery(query2));
   });
+
+  it('should produce the same hash for queries with and without an empty label selector', () => {
+    const query1 = `max by (cluster) (cluster:app_sync:healthy{  })`;
+    const query2 = `max by (cluster) (cluster:app_sync:healthy)`;
+
+    expect(hashQuery(query1)).toBe(hashQuery(query2));
+  });
+
+  it('should produce the same hash for queries with and without a trailing comma in a selector', () => {
+    const query1 = `group by (cluster) (
+  monitor_status{
+    cluster!~".+autotest.+",
+  }
+)`;
+    const query2 = `group by (cluster) (monitor_status{cluster!~".+autotest.+"})`;
+
+    expect(hashQuery(query1)).toBe(hashQuery(query2));
+  });
+
+  it('should produce the same hash for a ruler expr and its re-serialized Prometheus query', () => {
+    const rulerExpr = `(group by (k8s_cluster) (platform_cluster_monitor_status)
+) * on(k8s_cluster) group_left() ((max by (k8s_cluster) (k8s_cluster:app_sync:healthy{  })) * on(k8s_cluster) group_left() (group by (k8s_cluster) (
+  platform_cluster_monitor_status{
+    governance_zone!~"china|fedhigh",
+  }
+)
+)
+)
+ < 1`;
+    const promQuery = `(group by (k8s_cluster) (platform_cluster_monitor_status)) * on (k8s_cluster) group_left () ((max by (k8s_cluster) (k8s_cluster:app_sync:healthy)) * on (k8s_cluster) group_left () (group by (k8s_cluster) (platform_cluster_monitor_status{governance_zone!~"china|fedhigh"}))) < 1`;
+
+    expect(hashQuery(rulerExpr)).toBe(hashQuery(promQuery));
+  });
+
+  it('should not conflate an empty selector with a template string', () => {
+    expect(hashQuery(`label_format origin="{{.app_host}}"`)).not.toBe(hashQuery(`label_format origin="{}"`));
+  });
 });
 
 describe('stripPromQLComments', () => {

--- a/public/app/features/alerting/unified/utils/rule-id.ts
+++ b/public/app/features/alerting/unified/utils/rule-id.ts
@@ -350,6 +350,14 @@ export function hashQuery(query: string) {
   // Convert `{{.field}}` to "{{.field}}"
   query = query.replace(/`([^`]*)`/g, '"$1"');
 
+  // Mimir re-serializes the expression when exposing it via the Prometheus rules API, which drops
+  // trailing commas and empty label selectors that are legal in hand-written ruler YAML. Both have
+  // to go before hashing, or a ruler `expr` and its Prometheus `query` fingerprint differently.
+  // Convert `metric{foo="bar",}` to `metric{foo="bar"}`
+  query = query.replace(/,(?=})/g, '');
+  // Convert `metric{}` to `metric`
+  query = query.replace(/{}/g, '');
+
   // remove quotes, brackets, parentheses, backslashes, and backticks
   query = query.replace(/['"()\[\]\\`]/g, '');
 


### PR DESCRIPTION
**What is this feature?**

Normalizes empty label selectors (`metric{}`) and trailing commas in selectors (`metric{foo="bar",}`) in `hashQuery`, so a ruler `expr` and its Prometheus `query` produce the same fingerprint.

**Why do we need this feature?**

Mimir re-serializes the expression when exposing it via the Prometheus rules API, dropping both constructs — they're legal in hand-written ruler YAML but never survive the round trip. `hashQuery` stripped whitespace, comments, quotes, parens and brackets, but never `{`, `}` or `,`, so those surplus characters ended up in the fingerprint.

Because the rule details page recomputes a `cri` identifier when the ruler is reachable, a `pri` URL only resolves if `hashRulerRule === hashRule`. The prom/ruler join has a loose pass that ignores the query, so affected rules rendered fine in the list while their "Copy link" / `/find` URLs returned "Rule not found".

Same class of fix as #126152.

**Who is this feature for?**

Users of datasource-managed alert rules (Mimir/GEM/Loki) who share rule links — from "Copy link" or from Slack notifications built on the `/find` URL.

**Which issue(s) does this PR fix?**:

\/

**Special notes for your reviewer:**

\/

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
