### PR TITLE
Homepage: Use the IRM plugin instead of the deprecated Incident plugin

### DIFF
--- a/public/app/features/home/AlertsIncidents/AlertIncidentTabs.test.tsx
+++ b/public/app/features/home/AlertsIncidents/AlertIncidentTabs.test.tsx
@@ -54,16 +54,16 @@ function mockAlerts(alerts: AlertmanagerAlert[]) {
   server.use(http.get('/api/alertmanager/:datasourceUid/api/v2/alerts', () => HttpResponse.json(alerts)));
 }
 
-/** Report the Incident/IRM plugins as absent so the component only shows the alerts tab. */
-function mockNoIncidentPlugin() {
+/** Report the IRM plugin as absent so the component only shows the alerts tab. */
+function mockNoIrmPlugin() {
   server.use(http.get('/api/plugins/:pluginId/settings', () => HttpResponse.json({ enabled: false })));
 }
 
-/** Install the Incident plugin (IRM stays absent) with optional page includes for access gating. */
-function mockIncidentPlugin(settings?: Partial<PluginMeta>) {
+/** Install the IRM plugin with optional page includes for access gating. */
+function mockIrmPlugin(settings?: Partial<PluginMeta>) {
   server.use(
-    http.get(`/api/plugins/${SupportedPlugin.Incident}/settings`, () =>
-      HttpResponse.json({ ...pluginMeta[SupportedPlugin.Incident], includes: [], ...settings })
+    http.get(`/api/plugins/${SupportedPlugin.Irm}/settings`, () =>
+      HttpResponse.json({ ...pluginMeta[SupportedPlugin.Irm], includes: [], ...settings })
     )
   );
 }
@@ -91,9 +91,9 @@ beforeEach(async () => {
     .mockImplementation((action: string) => action === AccessControlAction.AlertingInstanceRead);
   mockTeams([]);
   mockAlerts([]);
-  // The component probes the IRM/Incident plugin settings; absent by default.
-  // Tests that need the incidents tab layer mockIncidentPlugin() on top.
-  mockNoIncidentPlugin();
+  // The component probes the IRM plugin settings; absent by default.
+  // Tests that need the incidents tab layer mockIrmPlugin() on top.
+  mockNoIrmPlugin();
   // AlertIncidentTabs only ships in the growth-homepage redesign, which is flag-gated,
   // so exercise it in the same flag state it renders in production.
   await act(async () => {
@@ -150,7 +150,7 @@ describe('AlertIncidentTabs', () => {
 
   it("shows '50+' on the Incidents tab counter when the server reports more incidents beyond the query limit", async () => {
     jest.spyOn(contextSrv, 'hasPermission').mockReturnValue(false);
-    mockIncidentPlugin();
+    mockIrmPlugin();
     const fullPage: IncidentPreview[] = Array.from({ length: ACTIVE_INCIDENTS_QUERY_LIMIT }, (_, i) => ({
       incidentID: String(i),
       title: `Incident ${i}`,
@@ -167,7 +167,7 @@ describe('AlertIncidentTabs', () => {
 
   it('shows the exact count on the Incidents tab counter when a full page has nothing beyond it', async () => {
     jest.spyOn(contextSrv, 'hasPermission').mockReturnValue(false);
-    mockIncidentPlugin();
+    mockIrmPlugin();
     const fullPage: IncidentPreview[] = Array.from({ length: ACTIVE_INCIDENTS_QUERY_LIMIT }, (_, i) => ({
       incidentID: String(i),
       title: `Incident ${i}`,
@@ -185,7 +185,7 @@ describe('AlertIncidentTabs', () => {
 
   it('defaults to the Incidents tab for a user without alerting permission when the plugin is installed', async () => {
     jest.spyOn(contextSrv, 'hasPermission').mockReturnValue(false);
-    mockIncidentPlugin();
+    mockIrmPlugin();
     mockIncidents([activeIncident]);
 
     render(<AlertIncidentTabs />);
@@ -198,7 +198,7 @@ describe('AlertIncidentTabs', () => {
 
   it('switches to the Incidents tab and renders incident content', async () => {
     mockAlerts([makeAlert({ labels: { alertname: 'CPU Critical', severity: 'critical' } })]);
-    mockIncidentPlugin();
+    mockIrmPlugin();
     mockIncidents([activeIncident]);
 
     const { user } = render(<AlertIncidentTabs />);
@@ -216,7 +216,7 @@ describe('AlertIncidentTabs', () => {
   it('shows the incidents footer actions when the user can declare and access incidents', async () => {
     jest.spyOn(contextSrv, 'hasPermission').mockReturnValue(false);
     // No page includes to gate on, so canDeclare/canAccess both resolve to true.
-    mockIncidentPlugin({ includes: [] });
+    mockIrmPlugin({ includes: [] });
     mockIncidents([activeIncident]);
 
     render(<AlertIncidentTabs />);
@@ -228,19 +228,19 @@ describe('AlertIncidentTabs', () => {
 
   it('hides the incidents footer actions when the user lacks the plugin page permissions', async () => {
     jest.spyOn(contextSrv, 'hasPermission').mockReturnValue(false);
-    mockIncidentPlugin({
+    mockIrmPlugin({
       includes: [
         {
           type: PluginIncludeType.page,
           name: 'Incidents',
-          path: '/a/grafana-incident-app/incidents',
-          action: 'grafana-incident-app.incidents:read',
+          path: '/a/grafana-irm-app/incidents',
+          action: 'grafana-irm-app.incidents:read',
         },
         {
           type: PluginIncludeType.page,
           name: 'Declare incident',
-          path: '/a/grafana-incident-app/incidents/declare',
-          action: 'grafana-incident-app.incidents:write',
+          path: '/a/grafana-irm-app/incidents/declare',
+          action: 'grafana-irm-app.incidents:write',
         },
       ],
     });

--- a/public/app/features/home/AlertsIncidents/AlertIncidentTabs.tsx
+++ b/public/app/features/home/AlertsIncidents/AlertIncidentTabs.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { t } from '@grafana/i18n';
 import { Box, ScrollContainer, Stack, Tab, TabContent, TabsBar, Text } from '@grafana/ui';
 import { ACTIVE_INCIDENTS_QUERY_LIMIT } from 'app/features/alerting/unified/api/incidentsApi';
-import { useIrmPlugin } from 'app/features/alerting/unified/hooks/usePluginBridge';
+import { usePluginBridge } from 'app/features/alerting/unified/hooks/usePluginBridge';
 import { SupportedPlugin } from 'app/features/alerting/unified/types/pluginBridges';
 
 import { DASHBOARD_TABS_SCROLL_HEIGHT_REDESIGN } from '../DashboardTabs/types';
@@ -21,7 +21,7 @@ const ALERTS_TAB_ID = 'firing-alerts';
 const INCIDENTS_TAB_ID = 'incidents';
 
 export function AlertIncidentTabs() {
-  const { installed, loading } = useIrmPlugin(SupportedPlugin.Incident);
+  const { installed, loading } = usePluginBridge(SupportedPlugin.Irm);
   const canViewIncidents = Boolean(installed && !loading);
   const canViewAlerts = canViewFiringAlerts();
 

--- a/public/app/features/home/AlertsIncidents/IncidentsCard.test.tsx
+++ b/public/app/features/home/AlertsIncidents/IncidentsCard.test.tsx
@@ -8,7 +8,7 @@ import { interceptLinkClicks } from 'app/core/navigation/patch/interceptLinkClic
 import { backendSrv } from 'app/core/services/backend_srv';
 import { contextSrv } from 'app/core/services/context_srv';
 import { ACTIVE_INCIDENTS_QUERY_LIMIT, type IncidentPreview } from 'app/features/alerting/unified/api/incidentsApi';
-import { useIrmPlugin } from 'app/features/alerting/unified/hooks/usePluginBridge';
+import { usePluginBridge } from 'app/features/alerting/unified/hooks/usePluginBridge';
 import { pluginMeta } from 'app/features/alerting/unified/testSetup/plugins';
 import { SupportedPlugin } from 'app/features/alerting/unified/types/pluginBridges';
 import { configureStore } from 'app/store/configureStore';
@@ -19,7 +19,7 @@ import { IncidentsCard } from './IncidentsCard';
 
 jest.mock('app/features/alerting/unified/hooks/usePluginBridge', () => ({
   ...jest.requireActual('app/features/alerting/unified/hooks/usePluginBridge'),
-  useIrmPlugin: jest.fn(),
+  usePluginBridge: jest.fn(),
 }));
 jest.mock('../analytics/main', () => ({
   ctaClicked: jest.fn(),
@@ -31,7 +31,7 @@ jest.mock('../analytics/main', () => ({
 setBackendSrv(backendSrv);
 setupMockServer();
 
-const mockUseIrmPlugin = jest.mocked(useIrmPlugin);
+const mockUsePluginBridge = jest.mocked(usePluginBridge);
 
 const QUERY_PREVIEWS_PATH = '/api/plugins/:pluginId/resources/api/v1/IncidentsService.QueryIncidentPreviews';
 
@@ -61,11 +61,10 @@ function mockIncidents(incidents: IncidentPreview[], { hasMore = false } = {}) {
 beforeEach(() => {
   setPluginComponentsHook(() => ({ components: [], isLoading: false }));
   // Default: plugin installed. Individual tests override availability as needed.
-  mockUseIrmPlugin.mockReturnValue({
-    pluginId: SupportedPlugin.Incident,
+  mockUsePluginBridge.mockReturnValue({
     installed: true,
     loading: false,
-    settings: { ...pluginMeta[SupportedPlugin.Incident], includes: [] },
+    settings: { ...pluginMeta[SupportedPlugin.Irm], includes: [] },
   });
 });
 
@@ -92,7 +91,7 @@ describe('IncidentsCard', () => {
     // Detail link is keyed by incidentID, routed through the plugin bridge
     expect(screen.getByRole('link', { name: 'Database outage' })).toHaveAttribute(
       'href',
-      '/a/grafana-incident-app/incidents/101'
+      '/a/grafana-irm-app/incidents/101'
     );
 
     // Populated card footer shows both the declare action and the view-all link.
@@ -130,18 +129,17 @@ describe('IncidentsCard', () => {
 
   it('renders incident titles as plain text when the user cannot access the incidents page', async () => {
     jest.spyOn(contextSrv, 'hasPermission').mockReturnValue(false);
-    mockUseIrmPlugin.mockReturnValue({
-      pluginId: SupportedPlugin.Incident,
+    mockUsePluginBridge.mockReturnValue({
       installed: true,
       loading: false,
       settings: {
-        ...pluginMeta[SupportedPlugin.Incident],
+        ...pluginMeta[SupportedPlugin.Irm],
         includes: [
           {
             type: PluginIncludeType.page,
             name: 'Incidents',
-            path: '/a/grafana-incident-app/incidents',
-            action: 'grafana-incident-app.incidents:read',
+            path: '/a/grafana-irm-app/incidents',
+            action: 'grafana-irm-app.incidents:read',
           },
         ],
       },
@@ -206,25 +204,24 @@ describe('IncidentsCard', () => {
 
     expect(await screen.findByRole('link', { name: /declare an incident/i })).toHaveAttribute(
       'href',
-      '/a/grafana-incident-app/incidents?declare=new'
+      '/a/grafana-irm-app/incidents?declare=new'
     );
     expect(screen.getByRole('link', { name: /view all incidents/i })).toBeInTheDocument();
   });
 
   it('hides the Declare CTA when the user cannot declare incidents', async () => {
     jest.spyOn(contextSrv, 'hasPermission').mockReturnValue(false);
-    mockUseIrmPlugin.mockReturnValue({
-      pluginId: SupportedPlugin.Incident,
+    mockUsePluginBridge.mockReturnValue({
       installed: true,
       loading: false,
       settings: {
-        ...pluginMeta[SupportedPlugin.Incident],
+        ...pluginMeta[SupportedPlugin.Irm],
         includes: [
           {
             type: PluginIncludeType.page,
             name: 'Declare',
-            path: '/a/grafana-incident-app/incidents/declare',
-            action: 'grafana-incident-app.incidents:write',
+            path: '/a/grafana-irm-app/incidents/declare',
+            action: 'grafana-irm-app.incidents:write',
           },
         ],
       },

--- a/public/app/features/home/AlertsIncidents/useIncidents.ts
+++ b/public/app/features/home/AlertsIncidents/useIncidents.ts
@@ -4,7 +4,7 @@ import { useMemo } from 'react';
 import { isFetchError } from '@grafana/runtime';
 import { incidentsApi } from 'app/features/alerting/unified/api/incidentsApi';
 import { createBridgeURL } from 'app/features/alerting/unified/components/PluginBridge';
-import { canAccessPluginPage, useIrmPlugin } from 'app/features/alerting/unified/hooks/usePluginBridge';
+import { canAccessPluginPage, usePluginBridge } from 'app/features/alerting/unified/hooks/usePluginBridge';
 import { SupportedPlugin } from 'app/features/alerting/unified/types/pluginBridges';
 
 import { HOME_CARD_MAX_ITEMS } from './constants';
@@ -16,7 +16,8 @@ export type IncidentsData = ReturnType<typeof useIncidents>;
  * shared between the old-layout card and the redesigned tabs.
  */
 export function useIncidents() {
-  const { pluginId, installed, loading: pluginLoading, settings } = useIrmPlugin(SupportedPlugin.Incident);
+  const { installed, loading: pluginLoading, settings } = usePluginBridge(SupportedPlugin.Irm);
+  const pluginId = SupportedPlugin.Irm;
 
   // Gate incident links like DeclareIncidentButton/InstanceDetailsDrawerTitle do: a user without
   // access to the plugin's incidents page sees titles as plain text, not links that 403 on click.

--- a/public/app/features/home/HomePage.test.tsx
+++ b/public/app/features/home/HomePage.test.tsx
@@ -9,8 +9,7 @@ import server, { setupMockServer } from '@grafana/test-utils/server';
 import { setTestFlags } from '@grafana/test-utils/unstable';
 import { backendSrv } from 'app/core/services/backend_srv';
 import { contextSrv } from 'app/core/services/context_srv';
-import { useIrmPlugin } from 'app/features/alerting/unified/hooks/usePluginBridge';
-import { SupportedPlugin } from 'app/features/alerting/unified/types/pluginBridges';
+import { usePluginBridge } from 'app/features/alerting/unified/hooks/usePluginBridge';
 import { createComponentWithMeta } from 'app/features/plugins/extensions/usePluginComponents';
 import { useNewsFeed } from 'app/plugins/panel/news/useNewsFeed';
 
@@ -20,7 +19,7 @@ import { homepageViewed } from './analytics/main';
 
 jest.mock('app/features/alerting/unified/hooks/usePluginBridge', () => ({
   ...jest.requireActual('app/features/alerting/unified/hooks/usePluginBridge'),
-  useIrmPlugin: jest.fn(),
+  usePluginBridge: jest.fn(),
 }));
 
 jest.mock('./analytics/main', () => ({
@@ -35,13 +34,13 @@ jest.mock('app/plugins/panel/news/useNewsFeed');
 setBackendSrv(backendSrv);
 setupMockServer();
 
-const mockUseIrmPlugin = jest.mocked(useIrmPlugin);
+const mockUsePluginBridge = jest.mocked(usePluginBridge);
 const useNewsFeedMock = jest.mocked(useNewsFeed);
 
 beforeEach(() => {
   jest.clearAllMocks();
   setPluginComponentsHook(() => ({ components: [], isLoading: false }));
-  mockUseIrmPlugin.mockReturnValue({ pluginId: SupportedPlugin.Incident, installed: false, loading: false });
+  mockUsePluginBridge.mockReturnValue({ installed: false, loading: false });
   useNewsFeedMock.mockReturnValue({
     state: { loading: false, error: undefined, value: undefined },
     getNews: jest.fn(),
@@ -53,7 +52,7 @@ beforeEach(() => {
   server.use(
     http.get('/api/user/teams', () => HttpResponse.json([])),
     http.get('/api/alertmanager/:datasourceUid/api/v2/alerts', () => HttpResponse.json([])),
-    // IncidentsCard checks the IRM/Incident plugins; report them absent so it renders nothing
+    // Report any probed app plugin as absent so plugin-gated cards render nothing
     http.get('/api/plugins/:pluginId/settings', () => HttpResponse.json({ enabled: false }))
   );
 });
@@ -201,8 +200,8 @@ describe('HomePage', () => {
     expect(jest.mocked(homepageViewed)).not.toHaveBeenCalled();
   });
 
-  it('renders a skeleton instead of the page content while incidents plugin is loading', async () => {
-    mockUseIrmPlugin.mockReturnValue({ pluginId: SupportedPlugin.Incident, installed: undefined, loading: true });
+  it('renders a skeleton instead of the page content while the IRM plugin is loading', async () => {
+    mockUsePluginBridge.mockReturnValue({ installed: undefined, loading: true });
 
     render(<HomePage />);
 

--- a/public/app/features/home/HomePage.tsx
+++ b/public/app/features/home/HomePage.tsx
@@ -11,7 +11,7 @@ import { Page } from 'app/core/components/Page/Page';
 import { ASSISTANT_PLUGIN_ID, SETUPGUIDE_PLUGIN_ID } from 'app/core/constants';
 import { isOnPrem } from 'app/core/utils/isOnPrem';
 
-import { useIrmPlugin } from '../alerting/unified/hooks/usePluginBridge';
+import { usePluginBridge } from '../alerting/unified/hooks/usePluginBridge';
 import { SupportedPlugin } from '../alerting/unified/types/pluginBridges';
 
 import { AlertIncidentTabs } from './AlertsIncidents/AlertIncidentTabs';
@@ -69,7 +69,7 @@ export default function HomePage() {
     extensionPointId: PluginExtensionPoints.HomepageTabs,
   });
 
-  const irm = useIrmPlugin(SupportedPlugin.Incident);
+  const irm = usePluginBridge(SupportedPlugin.Irm);
 
   const isWaitingForTabs = !redesignEnabled && isLoadingTabs;
   const isWaitingForIRM = !redesignEnabled && irm.loading;


### PR DESCRIPTION
**What is this feature?**

Remove the deprecated IRM plugin fallback that causes 404 errors. 