### PR TITLE
Datasources: Record the Grafana build and plugin versions in diagnostic bundles

### DIFF
--- a/pkg/api/ds_query_dashboard_diagnostics.go
+++ b/pkg/api/ds_query_dashboard_diagnostics.go
@@ -374,6 +374,10 @@ func (hs *HTTPServer) buildDashboardDiagnosticsArchive(ctx context.Context, user
 		queryData = hs.queryDataService.QueryDataNew
 	}
 
+	// Fallback for panels the client posts without inline JSON (it sends the dashboard once instead).
+	vizPluginIDByPanelID := diagnostics.PanelPluginIDs(reqDTO.Dashboard)
+	var envRefs diagnostics.EnvironmentRefs
+
 	panels := make([]diagnostics.DashboardPanel, 0, len(reqDTO.Panels))
 	for i, p := range reqDTO.Panels {
 		// ctx is detachedCtx (see QueryDashboardDiagnostics), derived from context.WithoutCancel, so
@@ -388,6 +392,14 @@ func (hs *HTTPServer) buildDashboardDiagnosticsArchive(ctx context.Context, user
 			PanelJSON:   p.Panel,
 			Datasources: panelDatasourceUIDs(p.MetricRequest),
 		}
+
+		// Recorded before the skip below: a non-data panel still has a viz plugin worth naming.
+		panelRefs := panelEnvironmentRefs(p.MetricRequest, p.Panel)
+		if len(panelRefs.PanelPluginIDs) == 0 {
+			panelRefs.AddPanelPluginID(vizPluginIDByPanelID[p.ID])
+		}
+		panel.PluginIDs = panelRefs.PluginIDs()
+		envRefs.Merge(panelRefs)
 
 		// A single panel's unserializable query request must not abort the whole archive: record it
 		// against this panel (surfaced in the manifest) and carry on, the same way query and capture
@@ -423,7 +435,23 @@ func (hs *HTTPServer) buildDashboardDiagnosticsArchive(ctx context.Context, user
 		dashboardDiagnosticsJobs.setProgress(jobUID, i+1)
 	}
 
-	return diagnostics.NewBundler().BuildDashboard(reqDTO.Dashboard, panels)
+	env := diagnostics.CollectEnvironment(ctx, hs.Cfg, hs.pluginStore, envRefs)
+	return diagnostics.NewBundler(env).BuildDashboard(reqDTO.Dashboard, panels)
+}
+
+// panelEnvironmentRefs collects the plugins one panel referenced, from the payload the client
+// already posted: each query's datasource type, plus the panel's viz plugin ID.
+func panelEnvironmentRefs(req dtos.MetricRequest, panelJSON json.RawMessage) diagnostics.EnvironmentRefs {
+	var refs diagnostics.EnvironmentRefs
+	for _, q := range req.Queries {
+		if q == nil {
+			continue
+		}
+		ds := q.Get("datasource")
+		refs.AddDatasource(ds.Get("uid").MustString(), ds.Get("type").MustString())
+	}
+	refs.AddPanelPluginID(diagnostics.PanelPluginID(panelJSON))
+	return refs
 }
 
 // panelDatasourceUIDs returns the unique datasource UIDs referenced by a panel's queries.

--- a/pkg/api/ds_query_dashboard_diagnostics.go
+++ b/pkg/api/ds_query_dashboard_diagnostics.go
@@ -15,6 +15,7 @@ import (
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/expr"
 	"github.com/grafana/grafana/pkg/infra/httpclient/harcapture"
 	"github.com/grafana/grafana/pkg/services/contexthandler"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
@@ -448,7 +449,15 @@ func panelEnvironmentRefs(req dtos.MetricRequest, panelJSON json.RawMessage) dia
 			continue
 		}
 		ds := q.Get("datasource")
-		refs.AddDatasource(ds.Get("uid").MustString(), ds.Get("type").MustString())
+		uid := ds.Get("uid").MustString()
+		pluginID := ds.Get("type").MustString()
+		// Expression and ML nodes are served by pkg/expr, not by a plugin, so recording their type
+		// would have the plugin store report a phantom uninstalled plugin. Recorded with no plugin ID
+		// rather than dropped, so every UID in the manifest still resolves in environment.json.
+		if expr.IsDataSource(uid) || uid == expr.MLDatasourceUID {
+			pluginID = ""
+		}
+		refs.AddDatasource(uid, pluginID)
 	}
 	refs.AddPanelPluginID(diagnostics.PanelPluginID(panelJSON))
 	return refs

--- a/pkg/api/ds_query_dashboard_diagnostics_test.go
+++ b/pkg/api/ds_query_dashboard_diagnostics_test.go
@@ -22,6 +22,7 @@ import (
 	backend "github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/expr"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/contexthandler"
 	"github.com/grafana/grafana/pkg/services/contexthandler/ctxkey"
@@ -479,4 +480,42 @@ func TestPanelDatasourceUIDs(t *testing.T) {
 	require.Equal(t, []string{"prom", "loki"}, panelDatasourceUIDs(req))
 
 	require.Empty(t, panelDatasourceUIDs(dtos.MetricRequest{}))
+}
+
+func TestPanelEnvironmentRefs(t *testing.T) {
+	q := func(uid, dsType string) *simplejson.Json {
+		j := simplejson.New()
+		j.SetPath([]string{"datasource", "uid"}, uid)
+		j.SetPath([]string{"datasource", "type"}, dsType)
+		return j
+	}
+
+	t.Run("collects the datasource types and the viz plugin", func(t *testing.T) {
+		req := dtos.MetricRequest{Queries: []*simplejson.Json{q("P1", "prometheus"), nil}}
+		refs := panelEnvironmentRefs(req, json.RawMessage(`{"id":1,"type":"timeseries"}`))
+
+		require.Equal(t, map[string]string{"P1": "prometheus"}, refs.DatasourcesByUID)
+		require.Equal(t, []string{"prometheus", "timeseries"}, refs.PluginIDs())
+	})
+
+	t.Run("expression and ML nodes are recorded without a plugin id", func(t *testing.T) {
+		// pkg/expr serves these, so resolving their type against the plugin store would report a
+		// phantom uninstalled plugin in environment.json.
+		req := dtos.MetricRequest{Queries: []*simplejson.Json{
+			q("P1", "prometheus"),
+			q(expr.DatasourceUID, expr.DatasourceType),
+			q(expr.OldDatasourceUID, expr.DatasourceType),
+			q(expr.MLDatasourceUID, "__ml__"),
+		}}
+		refs := panelEnvironmentRefs(req, nil)
+
+		// Still present as UIDs, so every UID the manifest lists resolves in environment.json.
+		require.Equal(t, map[string]string{
+			"P1":                  "prometheus",
+			expr.DatasourceUID:    "",
+			expr.OldDatasourceUID: "",
+			expr.MLDatasourceUID:  "",
+		}, refs.DatasourcesByUID)
+		require.Equal(t, []string{"prometheus"}, refs.PluginIDs(), "only real plugins are looked up")
+	})
 }

--- a/pkg/api/ds_query_diagnostics.go
+++ b/pkg/api/ds_query_diagnostics.go
@@ -109,7 +109,9 @@ func (hs *HTTPServer) QueryDiagnostics(c *contextmodel.ReqContext) response.Resp
 	if marshalErr != nil {
 		queryRequestJSON = nil
 	}
-	bundle, err := diagnostics.NewBundler().Build(resp, harBuffer, reqDTO.Panel, reqDTO.Dashboard, queryRequestJSON, marshalErr, bundleErr,
+	refs := panelEnvironmentRefs(reqDTO.MetricRequest, reqDTO.Panel)
+	env := diagnostics.CollectEnvironment(ctx, hs.Cfg, hs.pluginStore, refs)
+	bundle, err := diagnostics.NewBundler(env).Build(resp, harBuffer, reqDTO.Panel, reqDTO.Dashboard, queryRequestJSON, marshalErr, bundleErr,
 		diagnostics.WithPanelData(reqDTO.PanelData))
 	if err != nil {
 		return response.Error(http.StatusInternalServerError, "failed to build diagnostics bundle", err)

--- a/pkg/services/diagnostics/diagnostics.go
+++ b/pkg/services/diagnostics/diagnostics.go
@@ -21,7 +21,10 @@ import (
 )
 
 // Bundler assembles diagnostic bundles.
-type Bundler struct{}
+type Bundler struct {
+	// Written as environment.json by both bundle shapes; nil omits the artifact.
+	env *Environment
+}
 
 // Query responses can contain substantially more data than the diagnostic traffic itself. Keep
 // their uncompressed JSON bounded independently so adding querydata.json cannot multiply a large
@@ -38,9 +41,20 @@ const (
 // truncated fallbacks) so a reader can tell how to interpret the artifact.
 const queryDataArtifactVersion = 1
 
-// NewBundler returns a Bundler.
-func NewBundler() *Bundler {
-	return &Bundler{}
+// NewBundler returns a Bundler that writes env as environment.json into the bundles it assembles.
+func NewBundler(env *Environment) *Bundler {
+	return &Bundler{env: env}
+}
+
+// addEnvironment writes environment.json, if there is one. A marshal failure drops this artifact
+// alone rather than the captured traffic with it, as for manifest.json.
+func (b *Bundler) addEnvironment(files map[string][]byte) {
+	if b == nil || b.env == nil {
+		return
+	}
+	if data, err := json.MarshalIndent(b.env, "", "  "); err == nil {
+		files["environment.json"] = data
+	}
 }
 
 // BuildOption sets optional bundle contents. An option, rather than another parameter on Build, because
@@ -101,6 +115,7 @@ func WithPanelData(panelData json.RawMessage) BuildOption {
 // unrelated activity into a bundle meant for external sharing; they will be tackled in a follow-up.
 func (b *Bundler) Build(resp *backend.QueryDataResponse, harBuffer *harcapture.Buffer, panelJSON, dashboardJSON, queryRequestJSON json.RawMessage, queryRequestErr, queryErr error, opts ...BuildOption) ([]byte, error) {
 	files := map[string][]byte{}
+	b.addEnvironment(files)
 
 	cfg := buildConfig{}
 	for _, opt := range opts {
@@ -360,6 +375,7 @@ type DashboardPanel struct {
 	// unserializable request only costs this panel its request JSON, not the whole multi-panel bundle.
 	QueryRequestErr error
 	Datasources     []string                   // datasource UIDs the panel references (for the manifest)
+	PluginIDs       []string                   // plugin IDs the panel references (datasource + viz), for the manifest
 	Resp            *backend.QueryDataResponse // query response, carries external plugins' __har__ frames
 	HARBuffer       *harcapture.Buffer         // in-process capture buffer for this panel's queries
 	QueryErr        error                      // top-level error running the panel's queries, if any
@@ -376,10 +392,12 @@ type dashboardManifest struct {
 }
 
 type manifestPanelEntry struct {
-	ID                 int64    `json:"id"`
-	Title              string   `json:"title"`
-	Dir                string   `json:"dir,omitempty"`
-	Datasources        []string `json:"datasources,omitempty"`
+	ID          int64    `json:"id"`
+	Title       string   `json:"title"`
+	Dir         string   `json:"dir,omitempty"`
+	Datasources []string `json:"datasources,omitempty"`
+	// The plugins this panel used, keying into environment.json (which holds the versions).
+	PluginIDs          []string `json:"pluginIds,omitempty"`
 	HARBytes           int      `json:"harBytes,omitempty"`
 	QueryDataBytes     int      `json:"queryDataBytes,omitempty"`
 	QueryDataTruncated bool     `json:"queryDataTruncated,omitempty"`
@@ -404,6 +422,7 @@ func (b *Bundler) BuildDashboard(dashboardJSON json.RawMessage, panels []Dashboa
 	}
 
 	files := map[string][]byte{}
+	b.addEnvironment(files)
 	if len(dashboardJSON) > 0 {
 		files["dashboard.json"] = indentJSON(dashboardJSON)
 	}
@@ -412,7 +431,7 @@ func (b *Bundler) BuildDashboard(dashboardJSON json.RawMessage, panels []Dashboa
 	queryDataBytesRemaining := maxDashboardQueryDataBytes
 	panelJSONByID := indexPanelJSON(dashboardJSON)
 	for _, p := range panels {
-		entry := manifestPanelEntry{ID: p.ID, Title: p.Title, Datasources: p.Datasources}
+		entry := manifestPanelEntry{ID: p.ID, Title: p.Title, Datasources: p.Datasources, PluginIDs: p.PluginIDs}
 
 		if p.Skipped != "" {
 			entry.Skipped = p.Skipped

--- a/pkg/services/diagnostics/diagnostics.go
+++ b/pkg/services/diagnostics/diagnostics.go
@@ -1,6 +1,7 @@
 // Package diagnostics assembles on-demand datasource diagnostic bundles: captured HTTP traffic
-// (HAR), QueryData request/results, and the panel/dashboard JSON. The HTTP handler in pkg/api runs
-// the queries with capture active and delegates bundle assembly here.
+// (HAR), QueryData request/results, the panel/dashboard JSON, and the Grafana build and plugin
+// versions that produced them. The HTTP handler in pkg/api runs the queries with capture active and
+// delegates bundle assembly here.
 package diagnostics
 
 import (

--- a/pkg/services/diagnostics/diagnostics_test.go
+++ b/pkg/services/diagnostics/diagnostics_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestBundler_Build(t *testing.T) {
 	// No HAR captured (empty buffer, nil response) -> traffic.har omitted; only panel.json present.
-	blob, err := NewBundler().Build(nil, &harcapture.Buffer{}, json.RawMessage(`{"id":1}`), nil, nil, nil, nil)
+	blob, err := NewBundler(nil).Build(nil, &harcapture.Buffer{}, json.RawMessage(`{"id":1}`), nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -37,7 +37,7 @@ func TestBundler_Build(t *testing.T) {
 
 func TestBundler_Build_recordsQueryError(t *testing.T) {
 	// A failed query must still produce a bundle, with the error recorded (capture is not discarded).
-	blob, err := NewBundler().Build(nil, &harcapture.Buffer{}, nil, nil, nil, nil, errors.New("datasource timeout"))
+	blob, err := NewBundler(nil).Build(nil, &harcapture.Buffer{}, nil, nil, nil, nil, errors.New("datasource timeout"))
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -51,7 +51,7 @@ func TestBundler_Build_recordsQueryDataMarshalError(t *testing.T) {
 	// error is recorded and the other artifacts still ship, mirroring the per-panel dashboard path.
 	buf := bufferWithEntry(t, "http://ds/1")
 
-	blob, err := NewBundler().Build(nil, buf, nil, nil, json.RawMessage(`{invalid`), nil, nil)
+	blob, err := NewBundler(nil).Build(nil, buf, nil, nil, json.RawMessage(`{invalid`), nil, nil)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -67,7 +67,7 @@ func TestBundler_Build_recordsQueryRequestSerializeError(t *testing.T) {
 	// mirroring how the per-panel dashboard path surfaces the same failure via manifest.queryDataError.
 	buf := bufferWithEntry(t, "http://ds/1")
 
-	blob, err := NewBundler().Build(nil, buf, nil, nil, nil, errors.New("unsupported value: +Inf"), nil)
+	blob, err := NewBundler(nil).Build(nil, buf, nil, nil, nil, errors.New("unsupported value: +Inf"), nil)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -84,7 +84,7 @@ func TestBundler_Build_recordsQueryDataResponse(t *testing.T) {
 		"A": {Frames: data.Frames{frame}},
 	}}
 
-	blob, err := NewBundler().Build(resp, &harcapture.Buffer{}, nil, nil, nil, nil, nil)
+	blob, err := NewBundler(nil).Build(resp, &harcapture.Buffer{}, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -96,7 +96,7 @@ func TestBundler_Build_recordsQueryDataResponse(t *testing.T) {
 func TestBundler_Build_recordsQueryDataRequest(t *testing.T) {
 	request := json.RawMessage(`{"from":"now-1h","to":"now","queries":[{"refId":"A","expr":"up"}]}`)
 
-	blob, err := NewBundler().Build(nil, &harcapture.Buffer{}, nil, nil, request, nil, nil)
+	blob, err := NewBundler(nil).Build(nil, &harcapture.Buffer{}, nil, nil, request, nil, nil)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -114,7 +114,7 @@ func TestBundler_Build_excludesCaptureFramesFromQueryData(t *testing.T) {
 		"__har__ds": {Frames: data.Frames{capture}},
 	}}
 
-	blob, err := NewBundler().Build(resp, &harcapture.Buffer{}, nil, nil, nil, nil, nil)
+	blob, err := NewBundler(nil).Build(resp, &harcapture.Buffer{}, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -128,7 +128,7 @@ func TestBundler_Build_boundsOversizedQueryData(t *testing.T) {
 		"A": {Frames: data.Frames{frame}},
 	}}
 
-	blob, err := NewBundler().Build(resp, &harcapture.Buffer{}, nil, nil, nil, nil, nil)
+	blob, err := NewBundler(nil).Build(resp, &harcapture.Buffer{}, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -143,7 +143,7 @@ func TestBundler_Build_boundsOversizedRequestWithoutResponse(t *testing.T) {
 	// An oversized request with no response must truncate without claiming a response was omitted.
 	request := json.RawMessage(`{"expr":"` + strings.Repeat("x", maxQueryDataArtifactBytes) + `"}`)
 
-	blob, err := NewBundler().Build(nil, &harcapture.Buffer{}, nil, nil, request, nil, nil)
+	blob, err := NewBundler(nil).Build(nil, &harcapture.Buffer{}, nil, nil, request, nil, nil)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -171,7 +171,7 @@ func TestBundler_Build_preservesUpstreamAndPluginResultsForComparison(t *testing
 	queryResp := &backend.QueryDataResponse{Responses: backend.Responses{
 		"A": {Frames: data.Frames{pluginFrame}},
 	}}
-	blob, err := NewBundler().Build(queryResp, buf, nil, nil, nil, nil, nil)
+	blob, err := NewBundler(nil).Build(queryResp, buf, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -308,7 +308,7 @@ func TestCollectHAR_nilBuffer_noPanic(t *testing.T) {
 	require.Nil(t, out)
 
 	// A nil buffer must also flow through Build without panicking.
-	bundle, err := NewBundler().Build(nil, nil, nil, nil, nil, nil, nil)
+	bundle, err := NewBundler(nil).Build(nil, nil, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 	require.NotNil(t, bundle)
 }
@@ -531,7 +531,7 @@ func TestBuildDashboard(t *testing.T) {
 		{ID: 1, Title: "CPU Usage", PanelJSON: json.RawMessage(`{"id":1}`), Datasources: []string{"prom"}, HARBuffer: bufferWithEntry(t, "http://ds/1")},
 		{ID: 2, Title: "Text panel", Skipped: "no queries (non-data panel)"},
 	}
-	blob, err := NewBundler().BuildDashboard(json.RawMessage(`{"title":"My dash"}`), panels)
+	blob, err := NewBundler(nil).BuildDashboard(json.RawMessage(`{"title":"My dash"}`), panels)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -566,7 +566,7 @@ func TestBuildDashboard_recordsQueryDataPerPanel(t *testing.T) {
 		}},
 	}}
 
-	blob, err := NewBundler().BuildDashboard(nil, panels)
+	blob, err := NewBundler(nil).BuildDashboard(nil, panels)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -588,7 +588,7 @@ func TestBuildDashboard_boundsAggregateQueryData(t *testing.T) {
 		})
 	}
 
-	blob, err := NewBundler().BuildDashboard(nil, panels)
+	blob, err := NewBundler(nil).BuildDashboard(nil, panels)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -620,7 +620,7 @@ func TestBuildDashboard_resolvesPanelJSONFromDashboardModel(t *testing.T) {
 		{ID: 1, Title: "CPU Usage", HARBuffer: bufferWithEntry(t, "http://ds/1")},
 		{ID: 2, Title: "Logs", HARBuffer: bufferWithEntry(t, "http://ds/2")},
 	}
-	blob, err := NewBundler().BuildDashboard(dashboardJSON, panels)
+	blob, err := NewBundler(nil).BuildDashboard(dashboardJSON, panels)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -648,7 +648,7 @@ func TestBuildDashboard_resolvesPanelJSONFromDashboardV2Model(t *testing.T) {
 		{ID: 3, Title: "CPU Usage", HARBuffer: bufferWithEntry(t, "http://ds/3")},
 		{ID: 4, Title: "Shared Errors", HARBuffer: bufferWithEntry(t, "http://ds/4")},
 	}
-	blob, err := NewBundler().BuildDashboard(dashboardJSON, panels)
+	blob, err := NewBundler(nil).BuildDashboard(dashboardJSON, panels)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -672,7 +672,7 @@ func TestBuildDashboard_recordsPanelQueryError(t *testing.T) {
 	panels := []DashboardPanel{
 		{ID: 7, Title: "Broken", QueryErr: errors.New("datasource exploded")},
 	}
-	blob, err := NewBundler().BuildDashboard(nil, panels)
+	blob, err := NewBundler(nil).BuildDashboard(nil, panels)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -691,7 +691,7 @@ func TestBuildDashboard_dirCollision(t *testing.T) {
 		{ID: 3, Title: "Same", HARBuffer: bufferWithEntry(t, "http://ds/a")},
 		{ID: 3, Title: "Same", HARBuffer: bufferWithEntry(t, "http://ds/b")},
 	}
-	blob, err := NewBundler().BuildDashboard(nil, panels)
+	blob, err := NewBundler(nil).BuildDashboard(nil, panels)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -710,7 +710,7 @@ func TestBuildDashboard_recordsQueryRequestError(t *testing.T) {
 		{ID: 1, Title: "Broken request", QueryRequestErr: errors.New("unsupported value: NaN")},
 		{ID: 2, Title: "CPU Usage", HARBuffer: bufferWithEntry(t, "http://ds/2")},
 	}
-	blob, err := NewBundler().BuildDashboard(nil, panels)
+	blob, err := NewBundler(nil).BuildDashboard(nil, panels)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -735,7 +735,7 @@ func TestBuildDashboard_joinsQueryDataErrors(t *testing.T) {
 		QueryRequestErr: errors.New("request: unsupported value: +Inf"),
 		Resp:            &backend.QueryDataResponse{Responses: backend.Responses{"A": {Frames: data.Frames{frame}}}},
 	}}
-	blob, err := NewBundler().BuildDashboard(nil, panels)
+	blob, err := NewBundler(nil).BuildDashboard(nil, panels)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -761,7 +761,7 @@ func TestBundler_Build_keepsRequestWhenResponseEncodingFails(t *testing.T) {
 	resp := &backend.QueryDataResponse{Responses: backend.Responses{"A": {Frames: data.Frames{frame}}}}
 	request := json.RawMessage(`{"queries":[{"refId":"A","expr":"up"}]}`)
 
-	blob, err := NewBundler().Build(resp, &harcapture.Buffer{}, nil, nil, request, nil, nil)
+	blob, err := NewBundler(nil).Build(resp, &harcapture.Buffer{}, nil, nil, request, nil, nil)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -785,7 +785,7 @@ func TestBuildDashboard_keepsRequestWhenResponseEncodingFails(t *testing.T) {
 		QueryRequest: json.RawMessage(`{"queries":[{"refId":"A","expr":"up"}]}`),
 		Resp:         &backend.QueryDataResponse{Responses: backend.Responses{"A": {Frames: data.Frames{frame}}}},
 	}}
-	blob, err := NewBundler().BuildDashboard(nil, panels)
+	blob, err := NewBundler(nil).BuildDashboard(nil, panels)
 	require.NoError(t, err)
 
 	files := readTarGz(t, blob)
@@ -1015,7 +1015,7 @@ func readTarGz(t *testing.T, data []byte) map[string][]byte {
 func TestBundler_Build_bundlesPanelData(t *testing.T) {
 	panelData := json.RawMessage(`{"version":1,"frames":[{"schema":{"name":"frontend-frames"}}]}`)
 
-	blob, err := NewBundler().Build(nil, &harcapture.Buffer{}, nil, nil, nil, nil, nil,
+	blob, err := NewBundler(nil).Build(nil, &harcapture.Buffer{}, nil, nil, nil, nil, nil,
 		WithPanelData(panelData))
 	require.NoError(t, err)
 
@@ -1024,7 +1024,7 @@ func TestBundler_Build_bundlesPanelData(t *testing.T) {
 }
 
 func TestBundler_Build_omitsPanelDataWhenNotSupplied(t *testing.T) {
-	blob, err := NewBundler().Build(nil, &harcapture.Buffer{}, nil, nil, nil, nil, nil)
+	blob, err := NewBundler(nil).Build(nil, &harcapture.Buffer{}, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	require.NotContains(t, readTarGz(t, blob), "paneldata.json")
@@ -1034,7 +1034,7 @@ func TestBundler_Build_omitsPanelDataWhenNull(t *testing.T) {
 	// A client that sends "panelData": null supplied nothing, so no artifact: one whose whole content is
 	// `null` reads as "the frontend was holding no frames", which is a frontend loss that never happened.
 	for _, payload := range []string{`null`, ` null `, ``} {
-		blob, err := NewBundler().Build(nil, &harcapture.Buffer{}, nil, nil, nil, nil, nil,
+		blob, err := NewBundler(nil).Build(nil, &harcapture.Buffer{}, nil, nil, nil, nil, nil,
 			WithPanelData(json.RawMessage(payload)))
 		require.NoError(t, err)
 
@@ -1047,7 +1047,7 @@ func TestBundler_Build_unparseablePanelDataDoesNotSinkTheBundle(t *testing.T) {
 	// bundle nothing else: every other artifact still ships. Unreachable through the HTTP endpoint --
 	// web.Bind rejects a body that isn't valid JSON before Build runs, so the worst that arrives there is
 	// a well-formed payload of the wrong shape -- this pins the contract for direct callers.
-	blob, err := NewBundler().Build(nil, &harcapture.Buffer{}, json.RawMessage(`{"id":1}`), nil, nil, nil, nil,
+	blob, err := NewBundler(nil).Build(nil, &harcapture.Buffer{}, json.RawMessage(`{"id":1}`), nil, nil, nil, nil,
 		WithPanelData(json.RawMessage(`{"version":1,`)))
 	require.NoError(t, err)
 

--- a/pkg/services/diagnostics/environment.go
+++ b/pkg/services/diagnostics/environment.go
@@ -1,0 +1,256 @@
+package diagnostics
+
+import (
+	"context"
+	"encoding/json"
+	"sort"
+
+	"github.com/grafana/grafana/pkg/services/pluginsintegration/pluginstore"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+// environmentArtifactVersion is stamped into every environment.json so a reader can tell how to
+// interpret the artifact.
+const environmentArtifactVersion = 1
+
+// Environment is environment.json: which Grafana build ran the queries and which plugin versions
+// were installed. Nothing else in the bundle records either -- panel.json's pluginVersion is the
+// version at last save, which drives migrations rather than describing what ran.
+//
+// One per bundle, not one per panel: Grafana runs a single version of a plugin per install (see
+// pluginstore.Store.Plugin), so per-panel copies would all be identical.
+type Environment struct {
+	Version int          `json:"version"`
+	Grafana GrafanaBuild `json:"grafana"`
+	// Only the plugins this bundle's panels reference, keyed by plugin ID.
+	Plugins map[string]PluginVersion `json:"plugins,omitempty"`
+	// Referenced datasource UID -> plugin ID, joining manifest.panels[].datasources to Plugins.
+	Datasources map[string]string `json:"datasources,omitempty"`
+}
+
+// GrafanaBuild identifies the Grafana build that produced the bundle.
+type GrafanaBuild struct {
+	// Version and Edition are emitted even when empty: an absent key is indistinguishable from an
+	// older schema that lacked it. Version comes from ldflags, so a build without them has none.
+	Version          string `json:"version"`
+	Edition          string `json:"edition"`
+	Commit           string `json:"commit,omitempty"`
+	EnterpriseCommit string `json:"enterpriseCommit,omitempty"`
+	Branch           string `json:"branch,omitempty"`
+	BuildStamp       int64  `json:"buildStamp,omitempty"`
+	Packaging        string `json:"packaging,omitempty"`
+	Env              string `json:"env,omitempty"`
+}
+
+// PluginVersion is one referenced plugin's installed version and provenance.
+type PluginVersion struct {
+	Type string `json:"type,omitempty"`
+	// Empty for core plugins, which declare no version of their own (the loader blanks the
+	// "%VERSION%" placeholder): with class "core" that means "shipped with this build", so read
+	// Grafana.Version instead.
+	Version       string `json:"version"`
+	Class         string `json:"class,omitempty"`
+	Backend       bool   `json:"backend,omitempty"`
+	Signature     string `json:"signature,omitempty"`
+	SignatureType string `json:"signatureType,omitempty"`
+	SignatureOrg  string `json:"signatureOrg,omitempty"`
+	Error         string `json:"error,omitempty"`
+	// Set when a panel references a plugin the instance doesn't have.
+	NotInstalled bool `json:"notInstalled,omitempty"`
+}
+
+// EnvironmentRefs is the set of plugins one bundle touches, filled by the caller from the query and
+// panel JSON it already holds.
+type EnvironmentRefs struct {
+	// Datasource UID -> plugin ID (a datasource's "type").
+	DatasourcesByUID map[string]string
+	PanelPluginIDs   []string
+}
+
+// AddPanelPluginID records a viz plugin ID, ignoring blanks and duplicates.
+func (r *EnvironmentRefs) AddPanelPluginID(id string) {
+	if id == "" {
+		return
+	}
+	for _, existing := range r.PanelPluginIDs {
+		if existing == id {
+			return
+		}
+	}
+	r.PanelPluginIDs = append(r.PanelPluginIDs, id)
+}
+
+// AddDatasource records a datasource reference. A UID whose type is unknown is still recorded, so
+// the reader sees the panel referenced it.
+func (r *EnvironmentRefs) AddDatasource(uid, pluginID string) {
+	if uid == "" {
+		return
+	}
+	if r.DatasourcesByUID == nil {
+		r.DatasourcesByUID = map[string]string{}
+	}
+	// A later query's blank type must not overwrite a resolved one.
+	if existing, ok := r.DatasourcesByUID[uid]; ok && existing != "" {
+		return
+	}
+	r.DatasourcesByUID[uid] = pluginID
+}
+
+// Merge folds another panel's references into r, so a whole-dashboard caller can accumulate one set
+// across panels.
+func (r *EnvironmentRefs) Merge(other EnvironmentRefs) {
+	for uid, pluginID := range other.DatasourcesByUID {
+		r.AddDatasource(uid, pluginID)
+	}
+	for _, id := range other.PanelPluginIDs {
+		r.AddPanelPluginID(id)
+	}
+}
+
+// PluginIDs returns every referenced plugin ID, deduplicated and sorted for deterministic output.
+func (r EnvironmentRefs) PluginIDs() []string {
+	seen := map[string]bool{}
+	ids := make([]string, 0, len(r.DatasourcesByUID)+len(r.PanelPluginIDs))
+	for _, id := range r.DatasourcesByUID {
+		if id != "" && !seen[id] {
+			seen[id] = true
+			ids = append(ids, id)
+		}
+	}
+	for _, id := range r.PanelPluginIDs {
+		if !seen[id] {
+			seen[id] = true
+			ids = append(ids, id)
+		}
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+// PluginVersionSource is the slice of pluginstore.Store CollectEnvironment needs, narrowed so tests
+// need no plugin registry.
+type PluginVersionSource interface {
+	Plugin(ctx context.Context, pluginID string) (pluginstore.Plugin, bool)
+}
+
+// CollectEnvironment snapshots the Grafana build and the installed versions of the plugins in refs.
+// Returns nil when cfg is nil, so the bundle omits the artifact rather than carrying an empty build
+// stanza that reads as "version unknown". A nil store records the plugin IDs without versions.
+func CollectEnvironment(ctx context.Context, cfg *setting.Cfg, store PluginVersionSource, refs EnvironmentRefs) *Environment {
+	if cfg == nil {
+		return nil
+	}
+
+	// Edition describes the binary, so it comes from the build flag rather than the licensing service:
+	// an Enterprise binary running unlicensed is still the Enterprise binary. May therefore differ
+	// from the edition in the UI footer.
+	edition := "Open Source"
+	if cfg.IsEnterprise {
+		edition = "Enterprise"
+	}
+
+	// An OSS build sets this to the "NA" placeholder rather than leaving it empty; drop it so the
+	// artifact doesn't report a non-value as a commit (as setting.go does before publishing it).
+	enterpriseCommit := cfg.EnterpriseBuildCommit
+	if enterpriseCommit == "NA" {
+		enterpriseCommit = ""
+	}
+
+	env := &Environment{
+		Version: environmentArtifactVersion,
+		Grafana: GrafanaBuild{
+			Version:          cfg.BuildVersion,
+			Commit:           cfg.BuildCommit,
+			EnterpriseCommit: enterpriseCommit,
+			Branch:           cfg.BuildBranch,
+			BuildStamp:       cfg.BuildStamp,
+			Edition:          edition,
+			Packaging:        cfg.Packaging,
+			Env:              cfg.Env,
+		},
+	}
+
+	if len(refs.DatasourcesByUID) > 0 {
+		env.Datasources = make(map[string]string, len(refs.DatasourcesByUID))
+		for uid, pluginID := range refs.DatasourcesByUID {
+			env.Datasources[uid] = pluginID
+		}
+	}
+
+	pluginIDs := refs.PluginIDs()
+	if len(pluginIDs) == 0 {
+		return env
+	}
+	env.Plugins = make(map[string]PluginVersion, len(pluginIDs))
+	for _, id := range pluginIDs {
+		if store == nil {
+			env.Plugins[id] = PluginVersion{}
+			continue
+		}
+		p, exists := store.Plugin(ctx, id)
+		if !exists {
+			env.Plugins[id] = PluginVersion{NotInstalled: true}
+			continue
+		}
+		entry := PluginVersion{
+			Type:          string(p.Type),
+			Version:       p.Info.Version,
+			Class:         string(p.Class),
+			Backend:       p.Backend,
+			Signature:     string(p.Signature),
+			SignatureType: string(p.SignatureType),
+			SignatureOrg:  p.SignatureOrg,
+		}
+		if p.Error != nil {
+			// Bounded: the text is plugin-authored and this artifact is otherwise fixed-size.
+			entry.Error = truncateDiagnosticString(p.Error.Error(), 1024)
+		}
+		env.Plugins[id] = entry
+	}
+	return env
+}
+
+// PanelPluginID returns the viz plugin ID a panel save model names, or "" if undeterminable. It
+// handles both shapes panel.json can take (see indexPanelJSON): v1's "type", and a v2 element's
+// spec.vizConfig.group, falling back to spec.vizConfig.kind for v2alpha1. Mirrors readV2PanelSpec in
+// pkg/services/store/kind/dashboard.
+func PanelPluginID(panelJSON json.RawMessage) string {
+	if len(panelJSON) == 0 {
+		return ""
+	}
+	var doc struct {
+		Kind string `json:"kind"`
+		Type string `json:"type"`
+		Spec struct {
+			VizConfig struct {
+				Kind  string `json:"kind"`
+				Group string `json:"group"`
+			} `json:"vizConfig"`
+		} `json:"spec"`
+	}
+	if err := json.Unmarshal(panelJSON, &doc); err != nil {
+		return ""
+	}
+	if doc.Kind == "Panel" || doc.Kind == "LibraryPanel" {
+		if group := doc.Spec.VizConfig.Group; group != "" {
+			return group
+		}
+		if kind := doc.Spec.VizConfig.Kind; kind != "" && kind != "VizConfig" {
+			return kind
+		}
+		return ""
+	}
+	return doc.Type
+}
+
+// PanelPluginIDs returns each panel's viz plugin ID by panel id, for a caller holding a v1 or v2
+// dashboard save model but no inline panel JSON.
+func PanelPluginIDs(dashboardJSON json.RawMessage) map[int64]string {
+	byID := map[int64]string{}
+	for id, raw := range indexPanelJSON(dashboardJSON) {
+		if pluginID := PanelPluginID(raw); pluginID != "" {
+			byID[id] = pluginID
+		}
+	}
+	return byID
+}

--- a/pkg/services/diagnostics/environment.go
+++ b/pkg/services/diagnostics/environment.go
@@ -218,7 +218,12 @@ func PanelPluginID(panelJSON json.RawMessage) string {
 	if err := json.Unmarshal(panelJSON, &doc); err != nil {
 		return ""
 	}
-	if doc.Kind == "Panel" || doc.Kind == "LibraryPanel" {
+	// A library panel names no viz plugin in either v1 or v2 save model; v1 writes this sentinel type
+	// in its place (see transformSceneToSaveModel.ts).
+	if doc.Kind == "LibraryPanel" || doc.Type == "library-panel-ref" {
+		return ""
+	}
+	if doc.Kind == "Panel" {
 		if group := doc.Spec.VizConfig.Group; group != "" {
 			return group
 		}

--- a/pkg/services/diagnostics/environment.go
+++ b/pkg/services/diagnostics/environment.go
@@ -17,10 +17,10 @@ const environmentArtifactVersion = 1
 // One per bundle, not one per panel: Grafana runs a single version of a plugin per install (see
 // pluginstore.Store.Plugin), so per-panel copies would all be identical.
 type Environment struct {
-	Version int          `json:"version"`
-	Grafana GrafanaBuild `json:"grafana"`
-	Plugins map[string]PluginVersion `json:"plugins,omitempty"`
-	Datasources map[string]string `json:"datasources,omitempty"`
+	Version     int                      `json:"version"`
+	Grafana     GrafanaBuild             `json:"grafana"`
+	Plugins     map[string]PluginVersion `json:"plugins,omitempty"`
+	Datasources map[string]string        `json:"datasources,omitempty"`
 }
 
 // GrafanaBuild identifies the Grafana build that produced the bundle.

--- a/pkg/services/diagnostics/environment.go
+++ b/pkg/services/diagnostics/environment.go
@@ -13,18 +13,13 @@ import (
 // interpret the artifact.
 const environmentArtifactVersion = 1
 
-// Environment is environment.json: which Grafana build ran the queries and which plugin versions
-// were installed. Nothing else in the bundle records either -- panel.json's pluginVersion is the
-// version at last save, which drives migrations rather than describing what ran.
-//
+// Environment is environment.json, which describes the Grafana build and the plugins that were installed.
 // One per bundle, not one per panel: Grafana runs a single version of a plugin per install (see
 // pluginstore.Store.Plugin), so per-panel copies would all be identical.
 type Environment struct {
 	Version int          `json:"version"`
 	Grafana GrafanaBuild `json:"grafana"`
-	// Only the plugins this bundle's panels reference, keyed by plugin ID.
 	Plugins map[string]PluginVersion `json:"plugins,omitempty"`
-	// Referenced datasource UID -> plugin ID, joining manifest.panels[].datasources to Plugins.
 	Datasources map[string]string `json:"datasources,omitempty"`
 }
 
@@ -45,9 +40,7 @@ type GrafanaBuild struct {
 // PluginVersion is one referenced plugin's installed version and provenance.
 type PluginVersion struct {
 	Type string `json:"type,omitempty"`
-	// Empty for core plugins, which declare no version of their own (the loader blanks the
-	// "%VERSION%" placeholder): with class "core" that means "shipped with this build", so read
-	// Grafana.Version instead.
+	// Empty for core plugins, which declare no version of their own.
 	Version       string `json:"version"`
 	Class         string `json:"class,omitempty"`
 	Backend       bool   `json:"backend,omitempty"`
@@ -62,7 +55,6 @@ type PluginVersion struct {
 // EnvironmentRefs is the set of plugins one bundle touches, filled by the caller from the query and
 // panel JSON it already holds.
 type EnvironmentRefs struct {
-	// Datasource UID -> plugin ID (a datasource's "type").
 	DatasourcesByUID map[string]string
 	PanelPluginIDs   []string
 }
@@ -134,23 +126,20 @@ type PluginVersionSource interface {
 }
 
 // CollectEnvironment snapshots the Grafana build and the installed versions of the plugins in refs.
-// Returns nil when cfg is nil, so the bundle omits the artifact rather than carrying an empty build
-// stanza that reads as "version unknown". A nil store records the plugin IDs without versions.
+// Returns nil when cfg is nil, so the bundle omits the artifact rather than carrying an empty build.
+// Nil also for plugin IDs without versions.
 func CollectEnvironment(ctx context.Context, cfg *setting.Cfg, store PluginVersionSource, refs EnvironmentRefs) *Environment {
 	if cfg == nil {
 		return nil
 	}
 
-	// Edition describes the binary, so it comes from the build flag rather than the licensing service:
-	// an Enterprise binary running unlicensed is still the Enterprise binary. May therefore differ
-	// from the edition in the UI footer.
+	// Edition describes the binary, so it comes from the build flag rather than the licensing service.
 	edition := "Open Source"
 	if cfg.IsEnterprise {
 		edition = "Enterprise"
 	}
 
-	// An OSS build sets this to the "NA" placeholder rather than leaving it empty; drop it so the
-	// artifact doesn't report a non-value as a commit (as setting.go does before publishing it).
+	// An OSS build sets this to the "NA" placeholder
 	enterpriseCommit := cfg.EnterpriseBuildCommit
 	if enterpriseCommit == "NA" {
 		enterpriseCommit = ""
@@ -210,10 +199,8 @@ func CollectEnvironment(ctx context.Context, cfg *setting.Cfg, store PluginVersi
 	return env
 }
 
-// PanelPluginID returns the viz plugin ID a panel save model names, or "" if undeterminable. It
-// handles both shapes panel.json can take (see indexPanelJSON): v1's "type", and a v2 element's
-// spec.vizConfig.group, falling back to spec.vizConfig.kind for v2alpha1. Mirrors readV2PanelSpec in
-// pkg/services/store/kind/dashboard.
+// PanelPluginID returns the viz plugin ID (table, timeseries, etc.) of a panel.
+// It handles both v1 and v2 panel types (see indexPanelJSON).
 func PanelPluginID(panelJSON json.RawMessage) string {
 	if len(panelJSON) == 0 {
 		return ""

--- a/pkg/services/diagnostics/environment_test.go
+++ b/pkg/services/diagnostics/environment_test.go
@@ -190,7 +190,10 @@ func TestPanelPluginID(t *testing.T) {
 		{"v1 panel", `{"id":1,"type":"timeseries"}`, "timeseries"},
 		{"v2 stable element", `{"kind":"Panel","spec":{"id":1,"vizConfig":{"kind":"VizConfig","group":"timeseries"}}}`, "timeseries"},
 		{"v2alpha1 element carries the plugin id in kind", `{"kind":"Panel","spec":{"id":1,"vizConfig":{"kind":"timeseries"}}}`, "timeseries"},
-		{"v2 library panel", `{"kind":"LibraryPanel","spec":{"id":1,"vizConfig":{"kind":"VizConfig","group":"table"}}}`, "table"},
+		// Neither save model names a library panel's viz plugin, so both must yield nothing rather than
+		// a sentinel the plugin store would report as uninstalled.
+		{"v1 library panel carries a sentinel type", `{"id":1,"title":"Shared","libraryPanel":{"uid":"abc","name":"Shared"},"type":"library-panel-ref"}`, ""},
+		{"v2 library panel carries no vizConfig", `{"kind":"LibraryPanel","spec":{"id":1,"title":"Shared","libraryPanel":{"uid":"abc","name":"Shared"}}}`, ""},
 		{"v2 element with no group never yields the literal VizConfig", `{"kind":"Panel","spec":{"id":1,"vizConfig":{"kind":"VizConfig"}}}`, ""},
 		{"v2 element with no vizConfig", `{"kind":"Panel","spec":{"id":1}}`, ""},
 		{"malformed", `{not json`, ""},
@@ -207,10 +210,11 @@ func TestPanelPluginIDs(t *testing.T) {
 	v1 := json.RawMessage(`{"panels":[
 		{"id":1,"type":"timeseries"},
 		{"id":2,"type":"row","panels":[{"id":3,"type":"table"}]},
-		{"id":4}
+		{"id":4},
+		{"id":5,"libraryPanel":{"uid":"abc","name":"Shared"},"type":"library-panel-ref"}
 	]}`)
 	require.Equal(t, map[int64]string{1: "timeseries", 2: "row", 3: "table"}, PanelPluginIDs(v1),
-		"collapsed row children are indexed too; a panel with no type is omitted")
+		"collapsed row children are indexed too; a panel with no type, and a library panel's sentinel type, are omitted")
 
 	v2 := json.RawMessage(`{"elements":{
 		"a":{"kind":"Panel","spec":{"id":1,"vizConfig":{"kind":"VizConfig","group":"timeseries"}}}

--- a/pkg/services/diagnostics/environment_test.go
+++ b/pkg/services/diagnostics/environment_test.go
@@ -1,0 +1,295 @@
+package diagnostics
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/plugins"
+	"github.com/grafana/grafana/pkg/services/pluginsintegration/pluginstore"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+func testCfg() *setting.Cfg {
+	return &setting.Cfg{
+		BuildVersion: "12.3.0",
+		BuildCommit:  "abc1234",
+		BuildBranch:  "HEAD",
+		BuildStamp:   1761000000,
+		Packaging:    "deb",
+		Env:          "production",
+	}
+}
+
+func externalPlugin() pluginstore.Plugin {
+	return pluginstore.Plugin{
+		JSONData: plugins.JSONData{
+			ID:      "grafana-mongodb-datasource",
+			Type:    plugins.TypeDataSource,
+			Backend: true,
+			Info:    plugins.Info{Version: "1.4.2"},
+		},
+		Class:         plugins.ClassExternal,
+		Signature:     plugins.SignatureStatusValid,
+		SignatureType: plugins.SignatureTypeCommercial,
+		SignatureOrg:  "Grafana Labs",
+	}
+}
+
+// corePlugin mirrors a core datasource: loaded from Grafana's own binary and carrying NO version of
+// its own (the loader blanks the "%VERSION%" placeholder).
+func corePlugin() pluginstore.Plugin {
+	return pluginstore.Plugin{
+		JSONData: plugins.JSONData{ID: "prometheus", Type: plugins.TypeDataSource, Backend: true},
+		Class:    plugins.ClassCore,
+	}
+}
+
+func TestCollectEnvironment(t *testing.T) {
+	store := pluginstore.NewFakePluginStore(externalPlugin(), corePlugin(), pluginstore.Plugin{
+		JSONData: plugins.JSONData{ID: "timeseries", Type: plugins.TypePanel},
+		Class:    plugins.ClassCore,
+	})
+
+	var refs EnvironmentRefs
+	refs.AddDatasource("P123", "grafana-mongodb-datasource")
+	refs.AddDatasource("P456", "prometheus")
+	refs.AddPanelPluginID("timeseries")
+
+	env := CollectEnvironment(context.Background(), testCfg(), store, refs)
+	require.NotNil(t, env)
+
+	require.Equal(t, environmentArtifactVersion, env.Version)
+	require.Equal(t, "12.3.0", env.Grafana.Version)
+	require.Equal(t, "abc1234", env.Grafana.Commit)
+	require.Equal(t, "deb", env.Grafana.Packaging)
+	require.Equal(t, "Open Source", env.Grafana.Edition, "edition follows the build flag, not a license")
+
+	// The UID -> plugin ID join, so manifest.panels[].datasources (UIDs) can reach a version.
+	require.Equal(t, map[string]string{"P123": "grafana-mongodb-datasource", "P456": "prometheus"}, env.Datasources)
+
+	external := env.Plugins["grafana-mongodb-datasource"]
+	require.Equal(t, "1.4.2", external.Version)
+	require.Equal(t, "external", external.Class)
+	require.Equal(t, "datasource", external.Type)
+	require.True(t, external.Backend)
+	require.Equal(t, "valid", external.Signature)
+	require.Equal(t, "commercial", external.SignatureType)
+	require.Equal(t, "Grafana Labs", external.SignatureOrg)
+
+	// A core plugin ships no version of its own: empty version + class "core" means "this Grafana build".
+	core := env.Plugins["prometheus"]
+	require.Empty(t, core.Version)
+	require.Equal(t, "core", core.Class)
+	require.False(t, core.NotInstalled)
+
+	require.Contains(t, env.Plugins, "timeseries", "the panel's viz plugin is recorded too")
+	require.Len(t, env.Plugins, 3)
+}
+
+func TestCollectEnvironment_enterpriseEdition(t *testing.T) {
+	cfg := testCfg()
+	cfg.IsEnterprise = true
+	cfg.EnterpriseBuildCommit = "ent9876"
+
+	env := CollectEnvironment(context.Background(), cfg, nil, EnvironmentRefs{})
+	require.NotNil(t, env)
+	require.Equal(t, "Enterprise", env.Grafana.Edition)
+	require.Equal(t, "ent9876", env.Grafana.EnterpriseCommit)
+}
+
+func TestCollectEnvironment_dropsNAEnterpriseCommit(t *testing.T) {
+	cfg := testCfg()
+	cfg.EnterpriseBuildCommit = "NA" // what an OSS build sets
+
+	env := CollectEnvironment(context.Background(), cfg, nil, EnvironmentRefs{})
+	require.NotNil(t, env)
+	require.Empty(t, env.Grafana.EnterpriseCommit)
+}
+
+func TestCollectEnvironment_marksPluginNotInstalled(t *testing.T) {
+	// A dashboard imported from an environment that had the plugin: the absence IS the finding.
+	var refs EnvironmentRefs
+	refs.AddDatasource("P123", "grafana-mongodb-datasource")
+
+	env := CollectEnvironment(context.Background(), testCfg(), pluginstore.NewFakePluginStore(), refs)
+	require.NotNil(t, env)
+	require.True(t, env.Plugins["grafana-mongodb-datasource"].NotInstalled)
+	require.Empty(t, env.Plugins["grafana-mongodb-datasource"].Version)
+}
+
+func TestCollectEnvironment_recordsPluginLoadError(t *testing.T) {
+	broken := externalPlugin()
+	broken.Error = &plugins.Error{PluginID: broken.ID, ErrorCode: plugins.ErrorCodeSignatureModified}
+
+	var refs EnvironmentRefs
+	refs.AddDatasource("P123", broken.ID)
+
+	env := CollectEnvironment(context.Background(), testCfg(), pluginstore.NewFakePluginStore(broken), refs)
+	require.NotNil(t, env)
+	require.NotEmpty(t, env.Plugins[broken.ID].Error)
+}
+
+func TestCollectEnvironment_withoutCfgOrStore(t *testing.T) {
+	// No config -> no artifact at all, rather than one that reads like "version unknown".
+	require.Nil(t, CollectEnvironment(context.Background(), nil, nil, EnvironmentRefs{}))
+
+	// No store -> the referenced IDs are still recorded, just without versions.
+	var refs EnvironmentRefs
+	refs.AddPanelPluginID("timeseries")
+	env := CollectEnvironment(context.Background(), testCfg(), nil, refs)
+	require.NotNil(t, env)
+	require.Contains(t, env.Plugins, "timeseries")
+	require.Empty(t, env.Plugins["timeseries"].Version)
+}
+
+func TestEnvironmentRefs(t *testing.T) {
+	var refs EnvironmentRefs
+	refs.AddDatasource("", "ignored")        // no UID -> not recorded
+	refs.AddDatasource("P123", "prometheus") // resolved
+	refs.AddDatasource("P123", "")           // a later blank type must not overwrite it
+	refs.AddDatasource("P789", "")           // UID with no type is still worth recording
+	refs.AddPanelPluginID("timeseries")
+	refs.AddPanelPluginID("timeseries") // deduplicated
+	refs.AddPanelPluginID("")           // ignored
+
+	require.Equal(t, map[string]string{"P123": "prometheus", "P789": ""}, refs.DatasourcesByUID)
+	require.Equal(t, []string{"timeseries"}, refs.PanelPluginIDs)
+	// Sorted, deduplicated, and the empty plugin ID for P789 is dropped.
+	require.Equal(t, []string{"prometheus", "timeseries"}, refs.PluginIDs())
+}
+
+func TestEnvironmentRefs_Merge(t *testing.T) {
+	var all EnvironmentRefs
+
+	var first EnvironmentRefs
+	first.AddDatasource("P123", "prometheus")
+	first.AddPanelPluginID("timeseries")
+
+	var second EnvironmentRefs
+	second.AddDatasource("P456", "loki")
+	second.AddPanelPluginID("timeseries") // same viz plugin as the first panel
+	second.AddPanelPluginID("table")
+
+	all.Merge(first)
+	all.Merge(second)
+
+	require.Equal(t, map[string]string{"P123": "prometheus", "P456": "loki"}, all.DatasourcesByUID)
+	require.Equal(t, []string{"loki", "prometheus", "table", "timeseries"}, all.PluginIDs())
+}
+
+func TestPanelPluginID(t *testing.T) {
+	tests := []struct {
+		name  string
+		panel string
+		want  string
+	}{
+		{"v1 panel", `{"id":1,"type":"timeseries"}`, "timeseries"},
+		{"v2 stable element", `{"kind":"Panel","spec":{"id":1,"vizConfig":{"kind":"VizConfig","group":"timeseries"}}}`, "timeseries"},
+		{"v2alpha1 element carries the plugin id in kind", `{"kind":"Panel","spec":{"id":1,"vizConfig":{"kind":"timeseries"}}}`, "timeseries"},
+		{"v2 library panel", `{"kind":"LibraryPanel","spec":{"id":1,"vizConfig":{"kind":"VizConfig","group":"table"}}}`, "table"},
+		{"v2 element with no group never yields the literal VizConfig", `{"kind":"Panel","spec":{"id":1,"vizConfig":{"kind":"VizConfig"}}}`, ""},
+		{"v2 element with no vizConfig", `{"kind":"Panel","spec":{"id":1}}`, ""},
+		{"malformed", `{not json`, ""},
+		{"empty", ``, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, PanelPluginID(json.RawMessage(tc.panel)))
+		})
+	}
+}
+
+func TestPanelPluginIDs(t *testing.T) {
+	v1 := json.RawMessage(`{"panels":[
+		{"id":1,"type":"timeseries"},
+		{"id":2,"type":"row","panels":[{"id":3,"type":"table"}]},
+		{"id":4}
+	]}`)
+	require.Equal(t, map[int64]string{1: "timeseries", 2: "row", 3: "table"}, PanelPluginIDs(v1),
+		"collapsed row children are indexed too; a panel with no type is omitted")
+
+	v2 := json.RawMessage(`{"elements":{
+		"a":{"kind":"Panel","spec":{"id":1,"vizConfig":{"kind":"VizConfig","group":"timeseries"}}}
+	}}`)
+	require.Equal(t, map[int64]string{1: "timeseries"}, PanelPluginIDs(v2))
+
+	require.Empty(t, PanelPluginIDs(nil))
+}
+
+func TestBundler_Build_writesEnvironment(t *testing.T) {
+	var refs EnvironmentRefs
+	refs.AddDatasource("P123", "grafana-mongodb-datasource")
+	env := CollectEnvironment(context.Background(), testCfg(), pluginstore.NewFakePluginStore(externalPlugin()), refs)
+
+	blob, err := NewBundler(env).Build(nil, nil, json.RawMessage(`{"id":1,"type":"timeseries"}`), nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	files := readTarGz(t, blob)
+	require.Contains(t, files, "environment.json", "the single-panel bundle has no manifest, so this is the only place versions land")
+
+	var got Environment
+	require.NoError(t, json.Unmarshal(files["environment.json"], &got))
+	require.Equal(t, "12.3.0", got.Grafana.Version)
+	require.Equal(t, "1.4.2", got.Plugins["grafana-mongodb-datasource"].Version)
+
+	// Indented like the other JSON artifacts, so it's readable unpacked.
+	require.Contains(t, string(files["environment.json"]), "\n  \"grafana\": {")
+}
+
+func TestBundler_Build_omitsEnvironmentWhenUnavailable(t *testing.T) {
+	blob, err := NewBundler(nil).Build(nil, nil, json.RawMessage(`{"id":1}`), nil, nil, nil, nil)
+	require.NoError(t, err)
+	require.NotContains(t, readTarGz(t, blob), "environment.json")
+}
+
+func TestBundler_BuildDashboard_writesEnvironmentAndPanelPluginIDs(t *testing.T) {
+	var refs EnvironmentRefs
+	refs.AddDatasource("P123", "grafana-mongodb-datasource")
+	refs.AddPanelPluginID("timeseries")
+	env := CollectEnvironment(context.Background(), testCfg(), pluginstore.NewFakePluginStore(externalPlugin()), refs)
+
+	panels := []DashboardPanel{{
+		ID:          1,
+		Title:       "Mongo latency",
+		Datasources: []string{"P123"},
+		PluginIDs:   []string{"grafana-mongodb-datasource", "timeseries"},
+	}}
+
+	blob, err := NewBundler(env).BuildDashboard(json.RawMessage(`{"title":"My dash"}`), panels)
+	require.NoError(t, err)
+
+	files := readTarGz(t, blob)
+	require.Contains(t, files, "environment.json")
+
+	var manifest struct {
+		Panels []struct {
+			Datasources []string `json:"datasources"`
+			PluginIDs   []string `json:"pluginIds"`
+		} `json:"panels"`
+	}
+	require.NoError(t, json.Unmarshal(files["manifest.json"], &manifest))
+	require.Len(t, manifest.Panels, 1)
+	require.Equal(t, []string{"P123"}, manifest.Panels[0].Datasources)
+	require.Equal(t, []string{"grafana-mongodb-datasource", "timeseries"}, manifest.Panels[0].PluginIDs)
+
+	// Versions are recorded ONCE at instance level, not repeated per panel.
+	require.NotContains(t, string(files["manifest.json"]), "1.4.2")
+	require.Contains(t, string(files["environment.json"]), "1.4.2")
+}
+
+func TestCollectEnvironment_boundsPluginError(t *testing.T) {
+	broken := externalPlugin()
+	broken.Error = &plugins.Error{PluginID: strings.Repeat("x", 4096), ErrorCode: plugins.ErrorCodeSignatureModified}
+
+	var refs EnvironmentRefs
+	refs.AddDatasource("P123", broken.ID)
+
+	env := CollectEnvironment(context.Background(), testCfg(), pluginstore.NewFakePluginStore(broken), refs)
+	require.NotNil(t, env)
+	require.LessOrEqual(t, len(env.Plugins[broken.ID].Error), 1024+len("…"),
+		"environment.json is otherwise fixed-size; a plugin-authored error must not blow that up")
+}

--- a/pkg/tests/api/diagnostics/diagnostics_test.go
+++ b/pkg/tests/api/diagnostics/diagnostics_test.go
@@ -138,6 +138,37 @@ func TestIntegrationDiagnosticsSinglePanel(t *testing.T) {
 		assert.Contains(t, memberNames(members), "panel.json")
 		assert.Contains(t, memberNames(members), "dashboard.json")
 
+		// environment.json records the running Grafana build and the versions of the plugins this panel
+		// used -- the single-panel bundle has no manifest.json, so this is the only place they land.
+		envRaw, ok := members["environment.json"]
+		require.True(t, ok, "bundle members: %v", memberNames(members))
+		var env environmentArtifact
+		require.NoError(t, json.Unmarshal(envRaw, &env))
+		assert.Equal(t, 1, env.Version)
+		assert.Contains(t, []string{"Open Source", "Enterprise"}, env.Grafana.Edition)
+
+		// The recorded build must be the build that served the request. Asserted against what Grafana
+		// itself reports rather than a literal: the version and commit are injected via ldflags at build
+		// time, so BOTH are empty in a `go test` binary -- an assertion on a non-empty string would only
+		// pass in a packaged build, while this equality holds either way and is what actually matters.
+		healthVersion, healthCommit := serverBuildInfo(t, addr)
+		assert.Equal(t, healthVersion, env.Grafana.Version, "environment.json must report the running build")
+		assert.Equal(t, healthCommit, env.Grafana.Commit)
+
+		// The queried datasource resolves UID -> plugin ID -> that plugin's entry.
+		require.Equal(t, map[string]string{dsUID: testDataSourceType}, env.Datasources)
+		ds, ok := env.Plugins[testDataSourceType]
+		require.True(t, ok, "plugins: %v", env.Plugins)
+		assert.Equal(t, "datasource", ds.Type)
+		assert.Equal(t, "core", ds.Class)
+		assert.Empty(t, ds.Version, "a core plugin ships no version of its own; read grafana.version instead")
+		assert.False(t, ds.NotInstalled)
+
+		// The panel's viz plugin is recorded too, read from the posted panel JSON ("type":"timeseries").
+		viz, ok := env.Plugins["timeseries"]
+		require.True(t, ok, "plugins: %v", env.Plugins)
+		assert.Equal(t, "panel", viz.Type)
+
 		// testdata makes no HTTP calls, so nothing is captured on the wire: no traffic.har here.
 		assert.NotContains(t, memberNames(members), "traffic.har")
 	})
@@ -240,27 +271,51 @@ func TestIntegrationDiagnosticsDashboard(t *testing.T) {
 	require.Contains(t, names, "dashboard.json")
 	require.Contains(t, names, "manifest.json")
 
+	require.Contains(t, names, "environment.json")
+
 	// Manifest: 2 panels total, exactly one ran successfully, and panel 2 carries an error string.
 	var manifest struct {
 		PanelsTotal int `json:"panelsTotal"`
 		PanelsRun   int `json:"panelsRun"`
 		Panels      []struct {
-			ID    int64  `json:"id"`
-			Dir   string `json:"dir"`
-			Error string `json:"error"`
+			ID        int64    `json:"id"`
+			Dir       string   `json:"dir"`
+			Error     string   `json:"error"`
+			PluginIDs []string `json:"pluginIds"`
 		} `json:"panels"`
 	}
 	require.NoError(t, json.Unmarshal(members["manifest.json"], &manifest))
 	assert.Equal(t, 2, manifest.PanelsTotal)
 	assert.Equal(t, 1, manifest.PanelsRun, "only the success panel should count as run")
 
-	byID := map[int64]struct{ dir, err string }{}
+	byID := map[int64]struct {
+		dir, err  string
+		pluginIDs []string
+	}{}
 	for _, p := range manifest.Panels {
-		byID[p.ID] = struct{ dir, err string }{p.Dir, p.Error}
+		byID[p.ID] = struct {
+			dir, err  string
+			pluginIDs []string
+		}{p.Dir, p.Error, p.PluginIDs}
 	}
 	require.Len(t, byID, 2, "manifest should carry one entry per panel: %s", string(members["manifest.json"]))
 	assert.Empty(t, byID[1].err, "success panel should have no error")
 	assert.NotEmpty(t, byID[2].err, "error panel should record its datasource error")
+
+	// Each panel names its plugins; the versions themselves live once in environment.json, keyed by
+	// these IDs, rather than being repeated per panel.
+	assert.ElementsMatch(t, []string{testDataSourceType, "timeseries"}, byID[1].pluginIDs)
+	var env environmentArtifact
+	require.NoError(t, json.Unmarshal(members["environment.json"], &env))
+	// See TestIntegrationDiagnosticsSinglePanel: the build stanza is checked against what the server
+	// reports, because version/commit are ldflags-injected and empty in a test binary.
+	healthVersion, _ := serverBuildInfo(t, addr)
+	assert.Equal(t, healthVersion, env.Grafana.Version)
+	for _, id := range byID[1].pluginIDs {
+		assert.Contains(t, env.Plugins, id, "every plugin id in the manifest must resolve in environment.json")
+	}
+	assert.Equal(t, map[string]string{dsUID: testDataSourceType}, env.Datasources,
+		"both panels query the same datasource, recorded once")
 
 	// Per-panel directories, resolved from the manifest rather than guessed from a name prefix -- that
 	// also checks each manifest dir pointer actually resolves to members in the archive.
@@ -300,6 +355,42 @@ type queryDataArtifact struct {
 	Version  int             `json:"version"`
 	Request  json.RawMessage `json:"request"`
 	Response json.RawMessage `json:"response"`
+}
+
+// environmentArtifact mirrors the shape written to environment.json. Declared here rather than
+// reusing diagnostics.Environment so the test asserts on the JSON contract a support engineer reads,
+// not on the producing struct -- a renamed field would otherwise pass silently.
+type environmentArtifact struct {
+	Version int `json:"version"`
+	Grafana struct {
+		Version string `json:"version"`
+		Commit  string `json:"commit"`
+		Edition string `json:"edition"`
+	} `json:"grafana"`
+	Plugins map[string]struct {
+		Type         string `json:"type"`
+		Version      string `json:"version"`
+		Class        string `json:"class"`
+		NotInstalled bool   `json:"notInstalled"`
+	} `json:"plugins"`
+	Datasources map[string]string `json:"datasources"`
+}
+
+// serverBuildInfo returns the version and commit the running server reports via /api/health, so a
+// test can check environment.json against Grafana's own answer instead of a hardcoded string.
+func serverBuildInfo(t *testing.T, addr string) (version, commit string) {
+	t.Helper()
+	resp, err := http.Get(fmt.Sprintf("http://%s/api/health", addr)) //nolint:gosec // test-local address
+	require.NoError(t, err)
+	defer func() { require.NoError(t, resp.Body.Close()) }()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var health struct {
+		Version string `json:"version"`
+		Commit  string `json:"commit"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&health))
+	return health.Version, health.Commit
 }
 
 func addTestDataSource(t *testing.T, ctx context.Context, testEnv *server.TestEnv, uid string) string {


### PR DESCRIPTION
**What is this feature?**

Adds `environment.json` to the on-demand diagnostics bundle — both the single-panel and whole-dashboard shapes. It records:

- the **Grafana build** that ran the queries: version, commit, enterprise commit, branch, build stamp,
  edition, packaging, env;
- the **installed version of every plugin the bundle's panels reference** — datasource plugins and
  panel (viz) plugins alike — with each plugin's `class` (core/external) and other metadata.

In addition, `manifest.json` gains `pluginIds` per panel.

**Why do we need this feature?**

Understanding which Grafana and plugin versions a user is using is vital for support and software engineering.

**Who is this feature for?**

Support and engineering triaging an on-prem "wrong or missing data" report from a bundle alone, without
access to the customer's environment.

