### PR TITLE
Search: keep documents marked deleted out of live results

### DIFF
--- a/pkg/storage/unified/resource/document.go
+++ b/pkg/storage/unified/resource/document.go
@@ -146,6 +146,11 @@ type IndexableDocument struct {
 	// live document for nothing to read. Nil means live, which is also what every
 	// document written before this field looks like.
 	IsDeleted *bool `json:"_deleted,omitempty"`
+
+	// Set on a deleted document that was provisioned when it was deleted. Trash
+	// never returns those, and a deleted document keeps no manager fields to work
+	// it out later. Pointer for the same reason as IsDeleted.
+	IsProvisioned *bool `json:"_provisioned,omitempty"`
 }
 
 func (m *IndexableDocument) UpdateCopyFields() *IndexableDocument {
@@ -510,10 +515,11 @@ const (
 	SEARCH_FIELD_ALL_FIELDS         = "_all_columns"      // sentinel: return all known columns in search results (deliberately distinct from bleve's "_all" composite field)
 	SEARCH_SELECTABLE_FIELDS_PREFIX = "selectableFields." // Prefix for searching selectable fields.
 
-	// Internal marker for deleted documents. Kept out of
-	// StandardSearchFieldDefinitions so it does not change IndexAffectingHash for
-	// every kind, and so live search callers cannot filter on it themselves.
-	SEARCH_FIELD_IS_DELETED = "_deleted"
+	// Internal markers on deleted documents. Kept out of
+	// StandardSearchFieldDefinitions so they do not change IndexAffectingHash for
+	// every kind, and so live search callers cannot filter on them themselves.
+	SEARCH_FIELD_IS_DELETED     = "_deleted"
+	SEARCH_FIELD_IS_PROVISIONED = "_provisioned"
 )
 
 var standardSearchFieldsInit sync.Once

--- a/pkg/storage/unified/resource/document.go
+++ b/pkg/storage/unified/resource/document.go
@@ -139,6 +139,13 @@ type IndexableDocument struct {
 
 	// When the manager knows about file paths
 	Source *utils.SourceProperties `json:"source,omitempty"`
+
+	// Marks a document as deleted, so trash searches find it and ordinary ones
+	// leave it out. A pointer because bleve indexes struct fields by reflection
+	// and ignores omitempty, so a plain bool would write "not deleted" into every
+	// live document for nothing to read. Nil means live, which is also what every
+	// document written before this field looks like.
+	IsDeleted *bool `json:"_deleted,omitempty"`
 }
 
 func (m *IndexableDocument) UpdateCopyFields() *IndexableDocument {
@@ -502,6 +509,11 @@ const (
 	SEARCH_FIELD_EXPLAIN            = "_explain"          // score explanation as JSON object
 	SEARCH_FIELD_ALL_FIELDS         = "_all_columns"      // sentinel: return all known columns in search results (deliberately distinct from bleve's "_all" composite field)
 	SEARCH_SELECTABLE_FIELDS_PREFIX = "selectableFields." // Prefix for searching selectable fields.
+
+	// Internal marker for deleted documents. Kept out of
+	// StandardSearchFieldDefinitions so it does not change IndexAffectingHash for
+	// every kind, and so live search callers cannot filter on it themselves.
+	SEARCH_FIELD_IS_DELETED = "_deleted"
 )
 
 var standardSearchFieldsInit sync.Once

--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -105,8 +105,16 @@ type IndexBuildInfo struct {
 // IndexFeature names a mapping change an older index cannot satisfy.
 type IndexFeature string
 
+// IndexFeatureDeletedMarker means the index maps SEARCH_FIELD_IS_DELETED. An
+// index without it drops the marker, so a deleted document indexed there would
+// look live. Recorded but not required: rather than reindex every existing index
+// to add the mapping, writers check for this feature before marking a document.
+const IndexFeatureDeletedMarker IndexFeature = "deleted-marker"
+
 // currentIndexFeatures is recorded in every index this binary builds.
-var currentIndexFeatures = []IndexFeature{}
+var currentIndexFeatures = []IndexFeature{
+	IndexFeatureDeletedMarker,
+}
 
 // requiredIndexFeatures is the subset an index must already have to be used. An
 // index without one of these features is rebuilt before it serves anything, even

--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -102,7 +102,10 @@ type IndexBuildInfo struct {
 	Features         []IndexFeature  // Index features the index was built with. Empty on indexes built before index features existed.
 }
 
-// IndexFeature names a mapping change an older index cannot satisfy.
+// IndexFeature names a mapping change an older index cannot satisfy. Only for
+// changes no declared search field describes, such as an internal marker: a
+// declared field already moves IndexAffectingHash. Choosing wrong is silent — no
+// rebuild, missing data, no error.
 type IndexFeature string
 
 // IndexFeatureDeletedMarker means the index maps SEARCH_FIELD_IS_DELETED. An

--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -108,10 +108,12 @@ type IndexBuildInfo struct {
 // rebuild, missing data, no error.
 type IndexFeature string
 
-// IndexFeatureDeletedMarker means the index maps SEARCH_FIELD_IS_DELETED. An
-// index without it drops the marker, so a deleted document indexed there would
-// look live. Recorded but not required: rather than reindex every existing index
-// to add the mapping, writers check for this feature before marking a document.
+// IndexFeatureDeletedMarker means the index maps the markers on deleted
+// documents, SEARCH_FIELD_IS_DELETED and SEARCH_FIELD_IS_PROVISIONED. An index
+// without them drops the values, so a deleted document indexed there would look
+// live, and a provisioned one would show up in trash. Recorded but not required:
+// rather than reindex every existing index to add the mapping, writers check for
+// this feature before keeping a deleted document.
 const IndexFeatureDeletedMarker IndexFeature = "deleted-marker"
 
 // currentIndexFeatures is recorded in every index this binary builds.

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -1639,7 +1639,8 @@ type updateResult struct {
 }
 
 type bleveIndex struct {
-	key   resource.NamespacedResource
+	key resource.NamespacedResource
+	// Holds live and deleted documents together, so queries go through scopeQuery.
 	index bleve.Index
 
 	// RV returned by last List/ListModifiedSince operation. Updated when updating index.
@@ -1954,7 +1955,7 @@ func (b *bleveIndex) ListManagedObjects(ctx context.Context, req *resourcepb.Lis
 	stats.AddResultsConversionTime(time.Since(start))
 
 	found, err := b.index.SearchInContext(ctx, &bleve.SearchRequest{
-		Query: q,
+		Query: scopeQuery(q, false),
 		Fields: []string{
 			resource.SEARCH_FIELD_TITLE,
 			resource.SEARCH_FIELD_FOLDER,
@@ -2036,7 +2037,7 @@ func (b *bleveIndex) ListManagedObjects(ctx context.Context, req *resourcepb.Lis
 
 func (b *bleveIndex) CountManagedObjects(ctx context.Context, stats *resource.SearchStats) ([]*resourcepb.CountManagedObjectsResponse_ResourceCount, error) {
 	found, err := b.index.SearchInContext(ctx, &bleve.SearchRequest{
-		Query: bleve.NewMatchAllQuery(),
+		Query: scopeQuery(bleve.NewMatchAllQuery(), false),
 		Size:  0,
 		Facets: bleve.FacetsRequest{
 			"count": bleve.NewFacetRequest(resource.SEARCH_FIELD_MANAGED_BY, 1000), // typically less then 5
@@ -2200,22 +2201,24 @@ func (b *bleveIndex) Search(
 	return response, nil
 }
 
+// DocCount counts live documents, so callers using it as a size estimate
+// undercount by whatever trash the index holds. Close enough for a threshold.
 func (b *bleveIndex) DocCount(ctx context.Context, folder string, stats *resource.SearchStats) (int64, error) {
 	ctx, span := tracer.Start(ctx, "search.bleveIndex.DocCount")
 	defer span.End()
 
-	if folder == "" {
-		count, err := b.index.DocCount()
-		return int64(count), err
+	var q query.Query = bleve.NewMatchAllQuery()
+	if folder != "" {
+		q = &query.TermQuery{
+			Term:     folder,
+			FieldVal: resource.SEARCH_FIELD_FOLDER,
+		}
 	}
 
 	req := &bleve.SearchRequest{
 		Size:   0, // we just need the count
 		Fields: []string{},
-		Query: &query.TermQuery{
-			Term:     folder,
-			FieldVal: resource.SEARCH_FIELD_FOLDER,
-		},
+		Query:  scopeQuery(q, false),
 	}
 	rsp, err := b.index.SearchInContext(ctx, req)
 	if rsp == nil {
@@ -2340,7 +2343,7 @@ func (b *bleveIndex) toBleveSearchRequest(ctx context.Context, req *resourcepb.R
 		return nil, errResult
 	}
 	textQuery := b.buildTextQuery(searchrequest, req)
-	searchrequest.Query = combineFilterAndTextQueries(filters, textQuery)
+	searchrequest.Query = scopeQuery(combineFilterAndTextQueries(filters, textQuery), req.IsDeleted)
 
 	// postFilter applies authorization after ranking in runPostFilterAuthz, so
 	// skip the in-searcher wrapper here and let bleve return unfiltered ranked hits.
@@ -2391,6 +2394,26 @@ func (b *bleveIndex) toBleveSearchRequest(ctx context.Context, req *resourcepb.R
 	}
 
 	return searchrequest, nil
+}
+
+// scopeQuery restricts q to live documents, or to deleted ones for trash. Every
+// query this index issues goes through here, so a read path cannot forget the
+// distinction and serve trash as if it were live.
+//
+// Live is "not marked deleted" rather than "marked not deleted", because
+// documents written before the marker carry no value for the field.
+func scopeQuery(q query.Query, deleted bool) query.Query {
+	marked := bleve.NewBoolFieldQuery(true)
+	marked.SetField(resource.SEARCH_FIELD_IS_DELETED)
+
+	if deleted {
+		return bleve.NewConjunctionQuery(q, marked)
+	}
+
+	scoped := bleve.NewBooleanQuery()
+	scoped.AddMust(q)
+	scoped.AddMustNot(marked)
+	return scoped
 }
 
 // combineFilterAndTextQueries assembles the final bleve query from the filter

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -2406,6 +2406,14 @@ func scopeQuery(q query.Query, deleted bool) query.Query {
 	marked := bleve.NewBoolFieldQuery(true)
 	marked.SetField(resource.SEARCH_FIELD_IS_DELETED)
 
+	// Bleve drives iteration from the Must clause and uses Filter only to test the
+	// documents that clause produced. With nothing to match on, the marker is the
+	// query, so trash comes off its own (small) posting list instead of a walk over
+	// every document. Nothing ranks these results, so scoring it costs nothing.
+	if _, matchAll := q.(*query.MatchAllQuery); matchAll && deleted {
+		return marked
+	}
+
 	scoped := bleve.NewBooleanQuery()
 	scoped.AddMust(q)
 	if deleted {

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -2406,23 +2406,33 @@ func scopeQuery(q query.Query, deleted bool) query.Query {
 	marked := bleve.NewBoolFieldQuery(true)
 	marked.SetField(resource.SEARCH_FIELD_IS_DELETED)
 
-	// Bleve drives iteration from the Must clause and uses Filter only to test the
-	// documents that clause produced. With nothing to match on, the marker is the
-	// query, so trash comes off its own (small) posting list instead of a walk over
-	// every document. Nothing ranks these results, so scoring it costs nothing.
-	if _, matchAll := q.(*query.MatchAllQuery); matchAll && deleted {
-		return marked
+	scoped := bleve.NewBooleanQuery()
+	if !deleted {
+		scoped.AddMust(q)
+		scoped.AddMustNot(marked)
+		return scoped
 	}
 
-	scoped := bleve.NewBooleanQuery()
-	scoped.AddMust(q)
-	if deleted {
-		// Filter, not Must: a scoring clause would tie absolute scores to how much
-		// trash the index holds. MustNot never scores.
-		scoped.AddFilter(marked)
-	} else {
-		scoped.AddMustNot(marked)
+	// An object that was provisioned when it was deleted is never returned from
+	// trash: it comes back from its repository instead.
+	provisioned := bleve.NewBoolFieldQuery(true)
+	provisioned.SetField(resource.SEARCH_FIELD_IS_PROVISIONED)
+	scoped.AddMustNot(provisioned)
+
+	// Bleve drives iteration from the Must clause and uses Filter only to test the
+	// documents that clause produced. With nothing to match on, the marker becomes
+	// the Must clause, so trash comes off its own (small) posting list instead of a
+	// walk over every document. Nothing ranks these results, so scoring it costs
+	// nothing.
+	if _, matchAll := q.(*query.MatchAllQuery); matchAll {
+		scoped.AddMust(marked)
+		return scoped
 	}
+
+	// Filter, not Must: a scoring clause would tie absolute scores to how much
+	// trash the index holds. MustNot never scores either.
+	scoped.AddMust(q)
+	scoped.AddFilter(marked)
 	return scoped
 }
 

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -2406,13 +2406,15 @@ func scopeQuery(q query.Query, deleted bool) query.Query {
 	marked := bleve.NewBoolFieldQuery(true)
 	marked.SetField(resource.SEARCH_FIELD_IS_DELETED)
 
-	if deleted {
-		return bleve.NewConjunctionQuery(q, marked)
-	}
-
 	scoped := bleve.NewBooleanQuery()
 	scoped.AddMust(q)
-	scoped.AddMustNot(marked)
+	if deleted {
+		// Filter, not Must: a scoring clause would tie absolute scores to how much
+		// trash the index holds. MustNot never scores.
+		scoped.AddFilter(marked)
+	} else {
+		scoped.AddMustNot(marked)
+	}
 	return scoped
 }
 

--- a/pkg/storage/unified/search/bleve_mappings.go
+++ b/pkg/storage/unified/search/bleve_mappings.go
@@ -462,6 +462,8 @@ func getBleveDocMappings(provider resource.SearchFieldsProvider, group, kindReso
 		addCapabilityFieldMappings(mapper, def)
 	}
 
+	mapper.AddFieldMappingsAt(resource.SEARCH_FIELD_IS_DELETED, isDeletedField())
+
 	mapper.AddSubDocumentMapping("manager", managerSubDocumentMapping())
 	mapper.AddSubDocumentMapping("source", sourceSubDocumentMapping())
 
@@ -507,6 +509,24 @@ func getBleveDocMappings(provider resource.SearchFieldsProvider, group, kindReso
 	mapper.AddSubDocumentMapping(strings.TrimSuffix(resource.SEARCH_SELECTABLE_FIELDS_PREFIX, "."), selectableFieldsMapper)
 
 	return mapper
+}
+
+// isDeletedField maps the marker separating deleted documents from live ones.
+// Mapped here rather than declared as a SearchFieldDefinition because the
+// standard definitions feed IndexAffectingHash, and are also what callers may
+// filter and retrieve.
+//
+// Live documents carry no value for it at all: bleve skips the nil pointer, so
+// they are indexed exactly as they were before this field existed.
+func isDeletedField() *mapping.FieldMapping {
+	m := bleve.NewBooleanFieldMapping()
+	m.Store = false
+	m.Index = true
+	m.DocValues = false
+	m.IncludeInAll = false
+	m.IncludeTermVectors = false
+	m.SkipFreqNorm = true
+	return m
 }
 
 // keywordSubField returns a keyword (exact-match) field mapping for use inside

--- a/pkg/storage/unified/search/bleve_mappings.go
+++ b/pkg/storage/unified/search/bleve_mappings.go
@@ -462,7 +462,8 @@ func getBleveDocMappings(provider resource.SearchFieldsProvider, group, kindReso
 		addCapabilityFieldMappings(mapper, def)
 	}
 
-	mapper.AddFieldMappingsAt(resource.SEARCH_FIELD_IS_DELETED, isDeletedField())
+	mapper.AddFieldMappingsAt(resource.SEARCH_FIELD_IS_DELETED, internalBoolField())
+	mapper.AddFieldMappingsAt(resource.SEARCH_FIELD_IS_PROVISIONED, internalBoolField())
 
 	mapper.AddSubDocumentMapping("manager", managerSubDocumentMapping())
 	mapper.AddSubDocumentMapping("source", sourceSubDocumentMapping())
@@ -511,14 +512,13 @@ func getBleveDocMappings(provider resource.SearchFieldsProvider, group, kindReso
 	return mapper
 }
 
-// isDeletedField maps the marker separating deleted documents from live ones.
-// Mapped here rather than declared as a SearchFieldDefinition because the
-// standard definitions feed IndexAffectingHash, and are also what callers may
-// filter and retrieve.
+// internalBoolField maps a marker the trash scope reads. Mapped here rather than
+// declared as a SearchFieldDefinition because the standard definitions feed
+// IndexAffectingHash, and are also what callers may filter and retrieve.
 //
-// Live documents carry no value for it at all: bleve skips the nil pointer, so
-// they are indexed exactly as they were before this field existed.
-func isDeletedField() *mapping.FieldMapping {
+// Live documents carry no value for these at all: bleve skips the nil pointer, so
+// they are indexed exactly as they were before the fields existed.
+func internalBoolField() *mapping.FieldMapping {
 	m := bleve.NewBooleanFieldMapping()
 	m.Store = false
 	m.Index = true

--- a/pkg/storage/unified/search/bleve_search_test.go
+++ b/pkg/storage/unified/search/bleve_search_test.go
@@ -11,8 +11,10 @@ import (
 	authlib "github.com/grafana/authlib/types"
 	"github.com/stretchr/testify/require"
 	apischema "k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/selection"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
@@ -2004,4 +2006,180 @@ func TestSearchPostRankAuthzFederated(t *testing.T) {
 		got := pageAllFederated(t, dash, folder, ac, 5)
 		require.Equal(t, want, got, "duplicate titles must page deterministically by _id across the alias")
 	})
+}
+
+// Deleted documents share an index with live ones, so every read path has to pick
+// a side. These cover each path that builds its own query, plus the document with
+// no marker at all, which must stay live without a reindex.
+func TestSearchSeparatesDeletedFromLiveDocuments(t *testing.T) {
+	key := resource.NamespacedResource{
+		Namespace: "default",
+		Group:     "dashboard.grafana.app",
+		Resource:  "dashboards",
+	}
+	const folder = "folder-1"
+	manager := utils.ManagerProperties{Kind: utils.ManagerKindRepo, Identity: "repo-x"}
+
+	doc := func(name, title string, deleted *bool) *resource.BulkIndexItem {
+		return &resource.BulkIndexItem{
+			Action: resource.ActionIndex,
+			Doc: &resource.IndexableDocument{
+				Key: &resourcepb.ResourceKey{
+					Namespace: key.Namespace,
+					Group:     key.Group,
+					Resource:  key.Resource,
+					Name:      name,
+				},
+				Title:     title,
+				Folder:    folder,
+				Tags:      []string{"tag-a"},
+				Manager:   &manager,
+				IsDeleted: deleted,
+			},
+		}
+	}
+
+	index := newTestDashboardsIndex(t, threshold, 3, func(index resource.ResourceIndex) (int64, error) {
+		return 1, index.BulkIndex(&resource.BulkIndexRequest{Items: []*resource.BulkIndexItem{
+			// What every document written before the marker looks like.
+			doc("no-marker", "Alpha one", nil),
+			doc("live", "Alpha two", new(false)),
+			doc("trashed", "Alpha three", new(true)),
+		}})
+	})
+
+	liveNames := []string{"no-marker", "live"}
+
+	t.Run("search leaves deleted documents out", func(t *testing.T) {
+		q := newTestQuery("Alpha")
+		checkSearchQueryUnordered(t, index, q, liveNames)
+	})
+
+	t.Run("search with IsDeleted returns only deleted documents", func(t *testing.T) {
+		q := newTestQuery("Alpha")
+		q.IsDeleted = true
+		checkSearchQueryUnordered(t, index, q, []string{"trashed"})
+	})
+
+	// A query with filters and no text takes the other branch of
+	// combineFilterAndTextQueries, where filters drive iteration.
+	t.Run("filter-only search leaves deleted documents out", func(t *testing.T) {
+		q := newTestQuery("")
+		q.Options.Fields = []*resourcepb.Requirement{{
+			Key:      resource.SEARCH_FIELD_TAGS,
+			Operator: string(selection.In),
+			Values:   []string{"tag-a"},
+		}}
+		checkSearchQueryUnordered(t, index, q, liveNames)
+
+		q.IsDeleted = true
+		checkSearchQueryUnordered(t, index, q, []string{"trashed"})
+	})
+
+	t.Run("facets and total hits ignore deleted documents", func(t *testing.T) {
+		q := newTestQuery("")
+		q.Facet = map[string]*resourcepb.ResourceSearchRequest_Facet{
+			"tags": {Field: resource.SEARCH_FIELD_TAGS, Limit: 100},
+		}
+
+		res, err := index.Search(context.Background(), nil, q, nil, nil)
+		require.NoError(t, err)
+		require.Nil(t, res.Error)
+		require.Equal(t, int64(len(liveNames)), res.TotalHits)
+
+		facet, ok := res.Facet["tags"]
+		require.True(t, ok)
+		require.Equal(t, int64(len(liveNames)), facet.Total)
+		require.Len(t, facet.Terms, 1)
+		require.Equal(t, "tag-a", facet.Terms[0].Term)
+		require.Equal(t, int64(len(liveNames)), facet.Terms[0].Count)
+	})
+
+	t.Run("doc counts ignore deleted documents", func(t *testing.T) {
+		all, err := index.DocCount(context.Background(), "", nil)
+		require.NoError(t, err)
+		require.Equal(t, int64(len(liveNames)), all)
+
+		inFolder, err := index.DocCount(context.Background(), folder, nil)
+		require.NoError(t, err)
+		require.Equal(t, int64(len(liveNames)), inFolder)
+	})
+
+	// A deleted object provisioning can still see looks like one to keep managing.
+	t.Run("managed object listing and counts ignore deleted documents", func(t *testing.T) {
+		listed, err := index.ListManagedObjects(context.Background(), &resourcepb.ListManagedObjectsRequest{
+			Namespace: key.Namespace,
+			Kind:      string(manager.Kind),
+			Id:        manager.Identity,
+		}, &resource.SearchStats{})
+		require.NoError(t, err)
+		require.Nil(t, listed.Error)
+
+		names := make([]string, 0, len(listed.Items))
+		for _, item := range listed.Items {
+			names = append(names, item.Object.Name)
+		}
+		require.ElementsMatch(t, liveNames, names)
+
+		counts, err := index.CountManagedObjects(context.Background(), &resource.SearchStats{})
+		require.NoError(t, err)
+		require.Len(t, counts, 1)
+		require.Equal(t, int64(len(liveNames)), counts[0].Count)
+	})
+}
+
+// The post-ranking authorization path runs its own search loop, so a leak there
+// would only show up where that path is enabled.
+func TestSearchPostRankAuthzSeparatesDeletedFromLiveDocuments(t *testing.T) {
+	index := newTestDashboardsIndexPostRank(t, 3)
+
+	doc := func(name string, deleted *bool) *resource.BulkIndexItem {
+		return &resource.BulkIndexItem{
+			Action: resource.ActionIndex,
+			Doc: &resource.IndexableDocument{
+				Key: &resourcepb.ResourceKey{
+					Namespace: postRankKey.Namespace,
+					Group:     postRankKey.Group,
+					Resource:  postRankKey.Resource,
+					Name:      name,
+				},
+				Title:     name,
+				Folder:    "folder-a",
+				IsDeleted: deleted,
+			},
+		}
+	}
+	indexDocs(t, index, []*resource.BulkIndexItem{
+		doc("no-marker", nil),
+		doc("live", new(false)),
+		doc("trashed", new(true)),
+	})
+
+	ac := &countingAccessClient{allowAll: true}
+
+	names, res := searchNames(t, index, ac, listQuery(100))
+	require.ElementsMatch(t, []string{"no-marker", "live"}, names)
+	require.Equal(t, int64(2), res.TotalHits)
+
+	q := listQuery(100)
+	q.IsDeleted = true
+	names, res = searchNames(t, index, ac, q)
+	require.Equal(t, []string{"trashed"}, names)
+	require.Equal(t, int64(1), res.TotalHits)
+}
+
+// checkSearchQueryUnordered asserts on the set of names, where order is not under
+// test.
+func checkSearchQueryUnordered(t *testing.T, index resource.ResourceIndex, query *resourcepb.ResourceSearchRequest, expectedNames []string) {
+	t.Helper()
+	res, err := index.Search(context.Background(), nil, query, nil, nil)
+	require.NoError(t, err)
+	require.Nil(t, res.Error)
+	require.Equal(t, int64(len(expectedNames)), res.TotalHits)
+
+	names := make([]string, 0, len(res.Results.Rows))
+	for _, row := range res.Results.Rows {
+		names = append(names, row.Key.Name)
+	}
+	require.ElementsMatch(t, expectedNames, names)
 }

--- a/pkg/storage/unified/search/bleve_search_test.go
+++ b/pkg/storage/unified/search/bleve_search_test.go
@@ -2061,6 +2061,13 @@ func TestSearchSeparatesDeletedFromLiveDocuments(t *testing.T) {
 		checkSearchQueryUnordered(t, index, q, []string{"trashed"})
 	})
 
+	// Browsing trash with no query at all takes its own path in scopeQuery.
+	t.Run("browsing trash with no query returns only deleted documents", func(t *testing.T) {
+		q := newTestQuery("")
+		q.IsDeleted = true
+		checkSearchQueryUnordered(t, index, q, []string{"trashed"})
+	})
+
 	// A query with filters and no text takes the other branch of
 	// combineFilterAndTextQueries, where filters drive iteration.
 	t.Run("filter-only search leaves deleted documents out", func(t *testing.T) {

--- a/pkg/storage/unified/search/bleve_search_test.go
+++ b/pkg/storage/unified/search/bleve_search_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"slices"
 	"testing"
 	"time"
 
@@ -2110,6 +2111,54 @@ func TestSearchSeparatesDeletedFromLiveDocuments(t *testing.T) {
 		inFolder, err := index.DocCount(context.Background(), folder, nil)
 		require.NoError(t, err)
 		require.Equal(t, int64(len(liveNames)), inFolder)
+	})
+
+	// An object that was provisioned when it was deleted comes back from its
+	// repository, not from trash, so trash must not return it.
+	t.Run("trash leaves out objects that were provisioned when deleted", func(t *testing.T) {
+		provisioned := &resource.BulkIndexItem{
+			Action: resource.ActionIndex,
+			Doc: &resource.IndexableDocument{
+				Key:           &resourcepb.ResourceKey{Namespace: key.Namespace, Group: key.Group, Resource: key.Resource, Name: "trashed-from-repo"},
+				Title:         "Alpha four",
+				Folder:        folder,
+				IsDeleted:     new(true),
+				IsProvisioned: new(true),
+			},
+		}
+		require.NoError(t, index.BulkIndex(&resource.BulkIndexRequest{Items: []*resource.BulkIndexItem{provisioned}}))
+
+		trashQuery := newTestQuery("Alpha")
+		trashQuery.IsDeleted = true
+		checkSearchQueryUnordered(t, index, trashQuery, []string{"trashed"})
+
+		// It is still absent from live search: it is deleted, after all.
+		checkSearchQueryUnordered(t, index, newTestQuery("Alpha"), liveNames)
+	})
+
+	// Restoring an object reindexes it without the marker, which has to put it back
+	// into live results and take it out of trash.
+	t.Run("reindexing without the marker restores the document", func(t *testing.T) {
+		restored := &resource.BulkIndexItem{
+			Action: resource.ActionIndex,
+			Doc: &resource.IndexableDocument{
+				Key:    &resourcepb.ResourceKey{Namespace: key.Namespace, Group: key.Group, Resource: key.Resource, Name: "trashed"},
+				Title:  "Alpha three",
+				Folder: folder,
+			},
+		}
+		require.NoError(t, index.BulkIndex(&resource.BulkIndexRequest{Items: []*resource.BulkIndexItem{restored}}))
+		t.Cleanup(func() {
+			// Put it back in the trash for the other subtests.
+			restored.Doc.IsDeleted = new(true)
+			require.NoError(t, index.BulkIndex(&resource.BulkIndexRequest{Items: []*resource.BulkIndexItem{restored}}))
+		})
+
+		checkSearchQueryUnordered(t, index, newTestQuery("Alpha"), append(slices.Clone(liveNames), "trashed"))
+
+		trashQuery := newTestQuery("Alpha")
+		trashQuery.IsDeleted = true
+		checkSearchQueryUnordered(t, index, trashQuery, nil)
 	})
 
 	// A deleted object provisioning can still see looks like one to keep managing.

--- a/pkg/storage/unified/search/bleve_test.go
+++ b/pkg/storage/unified/search/bleve_test.go
@@ -2564,13 +2564,14 @@ func TestIsDeletedMarkerIndexing(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(backend.Stop)
 
-	doc := func(name string, deleted *bool) *resource.BulkIndexItem {
+	doc := func(name string, deleted, provisioned *bool) *resource.BulkIndexItem {
 		return &resource.BulkIndexItem{
 			Action: resource.ActionIndex,
 			Doc: &resource.IndexableDocument{
-				Key:       &resourcepb.ResourceKey{Namespace: key.Namespace, Group: group, Resource: kindResource, Name: name},
-				Title:     name,
-				IsDeleted: deleted,
+				Key:           &resourcepb.ResourceKey{Namespace: key.Namespace, Group: group, Resource: kindResource, Name: name},
+				Title:         name,
+				IsDeleted:     deleted,
+				IsProvisioned: provisioned,
 			},
 		}
 	}
@@ -2578,9 +2579,9 @@ func TestIsDeletedMarkerIndexing(t *testing.T) {
 	index, err := backend.BuildIndex(t.Context(), key, 3, "test", func(index resource.ResourceIndex) (int64, error) {
 		return 1, index.BulkIndex(&resource.BulkIndexRequest{
 			Items: []*resource.BulkIndexItem{
-				doc("live-unset", nil),
-				doc("live-explicit", new(false)),
-				doc("trashed", new(true)),
+				doc("live-unset", nil, nil),
+				doc("live-explicit", new(false), nil),
+				doc("trashed", new(true), new(true)),
 			},
 		})
 	}, nil, false, time.Time{}, 0)
@@ -2589,10 +2590,10 @@ func TestIsDeletedMarkerIndexing(t *testing.T) {
 	bi, ok := index.(*bleveIndex)
 	require.True(t, ok)
 
-	markerHits := func(t *testing.T, value bool) []string {
+	markerHits := func(t *testing.T, field string, value bool) []string {
 		t.Helper()
 		q := bleve.NewBoolFieldQuery(value)
-		q.SetField(resource.SEARCH_FIELD_IS_DELETED)
+		q.SetField(field)
 		res, err := bi.index.Search(bleve.NewSearchRequest(q))
 		require.NoError(t, err)
 		names := make([]string, 0, len(res.Hits))
@@ -2603,30 +2604,68 @@ func TestIsDeletedMarkerIndexing(t *testing.T) {
 		return names
 	}
 
-	assert.Equal(t, []string{"default/example.test/widgets/trashed"}, markerHits(t, true))
-	assert.Equal(t, []string{"default/example.test/widgets/live-explicit"}, markerHits(t, false))
+	assert.Equal(t, []string{"default/example.test/widgets/trashed"}, markerHits(t, resource.SEARCH_FIELD_IS_DELETED, true))
+	assert.Equal(t, []string{"default/example.test/widgets/trashed"}, markerHits(t, resource.SEARCH_FIELD_IS_PROVISIONED, true))
+	assert.Equal(t, []string{"default/example.test/widgets/live-explicit"}, markerHits(t, resource.SEARCH_FIELD_IS_DELETED, false))
 
 	// The marker is not a declared field, so callers cannot ask for it and it
 	// stays out of the hash that forces reindexing.
-	assert.Nil(t, resource.StandardSearchFields().Field(resource.SEARCH_FIELD_IS_DELETED))
-	assert.False(t, bi.isDeclaredField(resource.SEARCH_FIELD_IS_DELETED))
+	for _, field := range []string{resource.SEARCH_FIELD_IS_DELETED, resource.SEARCH_FIELD_IS_PROVISIONED} {
+		assert.Nil(t, resource.StandardSearchFields().Field(field))
+		assert.False(t, bi.isDeclaredField(field))
+	}
 }
 
 // TestScopeQueryTrashBrowseDrivesOffTheMarker pins the shape for a trash browse
 // with nothing to match on. Bleve only ever drives iteration from the Must side,
-// so wrapping match-all in Must and filtering by the marker would read every
+// so leaving match-all there and testing the marker as a Filter would read every
 // document in the index to find the few deleted ones.
 func TestScopeQueryTrashBrowseDrivesOffTheMarker(t *testing.T) {
-	scoped := scopeQuery(bleve.NewMatchAllQuery(), true)
+	scoped, ok := scopeQuery(bleve.NewMatchAllQuery(), true).(*query.BooleanQuery)
+	require.True(t, ok)
 
-	marker, ok := scoped.(*query.BoolFieldQuery)
-	require.True(t, ok, "expected the marker query itself, got %T", scoped)
-	assert.True(t, marker.Bool)
-	assert.Equal(t, resource.SEARCH_FIELD_IS_DELETED, marker.FieldVal)
+	assert.Equal(t, []string{resource.SEARCH_FIELD_IS_DELETED}, boolFieldsOf(t, scoped.Must),
+		"the marker has to drive iteration, not sit in Filter")
+	assert.Equal(t, []string{resource.SEARCH_FIELD_IS_PROVISIONED}, boolFieldsOf(t, scoped.MustNot))
+	assert.Nil(t, scoped.Filter)
 
-	// Live browsing has to read every document regardless, so it keeps the wrapper.
-	_, ok = scopeQuery(bleve.NewMatchAllQuery(), false).(*query.BooleanQuery)
-	assert.True(t, ok)
+	// A real query drives iteration itself, so the marker moves to Filter where it
+	// does not score.
+	textQuery := bleve.NewMatchQuery("hello")
+	scoped, ok = scopeQuery(textQuery, true).(*query.BooleanQuery)
+	require.True(t, ok)
+	assert.Equal(t, []string{resource.SEARCH_FIELD_IS_DELETED}, boolFieldsOf(t, scoped.Filter))
+	assert.Equal(t, []string{resource.SEARCH_FIELD_IS_PROVISIONED}, boolFieldsOf(t, scoped.MustNot))
+
+	// Live searches only exclude the marker; provisioning is irrelevant to them.
+	scoped, ok = scopeQuery(bleve.NewMatchAllQuery(), false).(*query.BooleanQuery)
+	require.True(t, ok)
+	assert.Equal(t, []string{resource.SEARCH_FIELD_IS_DELETED}, boolFieldsOf(t, scoped.MustNot))
+	assert.Nil(t, scoped.Filter)
+}
+
+// boolFieldsOf returns the fields of the boolean-field queries in a clause,
+// looking through the conjunction or disjunction bleve wraps clauses in.
+func boolFieldsOf(t *testing.T, clause query.Query) []string {
+	t.Helper()
+	var fields []string
+	var walk func(query.Query)
+	walk = func(q query.Query) {
+		switch typed := q.(type) {
+		case *query.BoolFieldQuery:
+			fields = append(fields, typed.FieldVal)
+		case *query.ConjunctionQuery:
+			for _, sub := range typed.Conjuncts {
+				walk(sub)
+			}
+		case *query.DisjunctionQuery:
+			for _, sub := range typed.Disjuncts {
+				walk(sub)
+			}
+		}
+	}
+	walk(clause)
+	return fields
 }
 
 // TestScopeQueryKeepsScores pins both scopes to the unscoped query's scores. The

--- a/pkg/storage/unified/search/bleve_test.go
+++ b/pkg/storage/unified/search/bleve_test.go
@@ -2612,10 +2612,9 @@ func TestIsDeletedMarkerIndexing(t *testing.T) {
 	assert.False(t, bi.isDeclaredField(resource.SEARCH_FIELD_IS_DELETED))
 }
 
-// TestScopeQueryKeepsScores guards ranking against the exclusion clause: bleve
-// scores a boolean query with one Must clause exactly as that clause alone, and
-// MustNot adds nothing. A future scopeQuery that used Should or a boost would
-// quietly reweight every search.
+// TestScopeQueryKeepsScores pins both scopes to the unscoped query's scores. The
+// marker has to sit in a non-scoring position, or absolute scores move with the
+// amount of trash in the index.
 func TestScopeQueryKeepsScores(t *testing.T) {
 	key := resource.NamespacedResource{Namespace: "default", Group: "example.test", Resource: "widgets"}
 
@@ -2623,19 +2622,27 @@ func TestScopeQueryKeepsScores(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(backend.Stop)
 
-	titles := map[string]string{
-		"a": "hello world",
-		"b": "hello hello world of hello",
-		"c": "world of warcraft",
-		"d": "hello",
+	docs := []struct {
+		name    string
+		title   string
+		deleted bool
+	}{
+		{name: "live-1", title: "hello world"},
+		{name: "live-2", title: "hello hello world of hello"},
+		{name: "trashed-1", title: "hello there", deleted: true},
+		{name: "trashed-2", title: "hello hello there", deleted: true},
 	}
 	index, err := backend.BuildIndex(t.Context(), key, 5, "test", func(index resource.ResourceIndex) (int64, error) {
-		items := make([]*resource.BulkIndexItem, 0, len(titles))
-		for name, title := range titles {
-			items = append(items, &resource.BulkIndexItem{Action: resource.ActionIndex, Doc: &resource.IndexableDocument{
-				Key:   &resourcepb.ResourceKey{Namespace: key.Namespace, Group: key.Group, Resource: key.Resource, Name: name},
-				Title: title,
-			}})
+		items := make([]*resource.BulkIndexItem, 0, len(docs))
+		for _, d := range docs {
+			doc := &resource.IndexableDocument{
+				Key:   &resourcepb.ResourceKey{Namespace: key.Namespace, Group: key.Group, Resource: key.Resource, Name: d.name},
+				Title: d.title,
+			}
+			if d.deleted {
+				doc.IsDeleted = new(true)
+			}
+			items = append(items, &resource.BulkIndexItem{Action: resource.ActionIndex, Doc: doc})
 		}
 		return 1, index.BulkIndex(&resource.BulkIndexRequest{Items: items})
 	}, nil, false, time.Time{}, 0)
@@ -2646,17 +2653,30 @@ func TestScopeQueryKeepsScores(t *testing.T) {
 	textQuery := bleve.NewMatchQuery("hello")
 	textQuery.SetField(resource.SEARCH_FIELD_TITLE)
 
-	scores := func(q query.Query) []string {
+	scores := func(q query.Query) map[string]float64 {
 		req := bleve.NewSearchRequest(q)
 		req.Size = 10
 		res, err := bi.index.Search(req)
 		require.NoError(t, err)
-		out := make([]string, 0, len(res.Hits))
+		out := map[string]float64{}
 		for _, hit := range res.Hits {
-			out = append(out, fmt.Sprintf("%s=%.6f", hit.ID, hit.Score))
+			out[hit.ID] = hit.Score
 		}
 		return out
 	}
 
-	assert.Equal(t, scores(textQuery), scores(scopeQuery(textQuery, false)))
+	id := func(name string) string { return key.Namespace + "/" + key.Group + "/" + key.Resource + "/" + name }
+
+	unscoped := scores(textQuery)
+	require.Len(t, unscoped, len(docs))
+
+	assert.Equal(t, map[string]float64{
+		id("live-1"): unscoped[id("live-1")],
+		id("live-2"): unscoped[id("live-2")],
+	}, scores(scopeQuery(textQuery, false)))
+
+	assert.Equal(t, map[string]float64{
+		id("trashed-1"): unscoped[id("trashed-1")],
+		id("trashed-2"): unscoped[id("trashed-2")],
+	}, scores(scopeQuery(textQuery, true)))
 }

--- a/pkg/storage/unified/search/bleve_test.go
+++ b/pkg/storage/unified/search/bleve_test.go
@@ -2612,6 +2612,23 @@ func TestIsDeletedMarkerIndexing(t *testing.T) {
 	assert.False(t, bi.isDeclaredField(resource.SEARCH_FIELD_IS_DELETED))
 }
 
+// TestScopeQueryTrashBrowseDrivesOffTheMarker pins the shape for a trash browse
+// with nothing to match on. Bleve only ever drives iteration from the Must side,
+// so wrapping match-all in Must and filtering by the marker would read every
+// document in the index to find the few deleted ones.
+func TestScopeQueryTrashBrowseDrivesOffTheMarker(t *testing.T) {
+	scoped := scopeQuery(bleve.NewMatchAllQuery(), true)
+
+	marker, ok := scoped.(*query.BoolFieldQuery)
+	require.True(t, ok, "expected the marker query itself, got %T", scoped)
+	assert.True(t, marker.Bool)
+	assert.Equal(t, resource.SEARCH_FIELD_IS_DELETED, marker.FieldVal)
+
+	// Live browsing has to read every document regardless, so it keeps the wrapper.
+	_, ok = scopeQuery(bleve.NewMatchAllQuery(), false).(*query.BooleanQuery)
+	assert.True(t, ok)
+}
+
 // TestScopeQueryKeepsScores pins both scopes to the unscoped query's scores. The
 // marker has to sit in a non-scoring position, or absolute scores move with the
 // amount of trash in the index.

--- a/pkg/storage/unified/search/bleve_test.go
+++ b/pkg/storage/unified/search/bleve_test.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -16,6 +17,7 @@ import (
 
 	"github.com/blevesearch/bleve/v2"
 	blevesearch "github.com/blevesearch/bleve/v2/search"
+	"github.com/blevesearch/bleve/v2/search/query"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
@@ -2546,4 +2548,115 @@ func TestBleveTextFieldFilterAndSort(t *testing.T) {
 		})
 		assert.Equal(t, []string{"one"}, got)
 	})
+}
+
+// TestIsDeletedMarkerIndexing pins how the marker reaches the index. A document
+// that does not carry it must leave no trace under that field, which is what
+// lets documents written before the marker existed count as live.
+func TestIsDeletedMarkerIndexing(t *testing.T) {
+	const group, kindResource = "example.test", "widgets"
+	key := resource.NamespacedResource{Namespace: "default", Group: group, Resource: kindResource}
+
+	backend, err := NewBleveBackend(BleveOptions{
+		Root:          t.TempDir(),
+		FileThreshold: 5, // stay in memory
+	}, nil)
+	require.NoError(t, err)
+	t.Cleanup(backend.Stop)
+
+	doc := func(name string, deleted *bool) *resource.BulkIndexItem {
+		return &resource.BulkIndexItem{
+			Action: resource.ActionIndex,
+			Doc: &resource.IndexableDocument{
+				Key:       &resourcepb.ResourceKey{Namespace: key.Namespace, Group: group, Resource: kindResource, Name: name},
+				Title:     name,
+				IsDeleted: deleted,
+			},
+		}
+	}
+
+	index, err := backend.BuildIndex(t.Context(), key, 3, "test", func(index resource.ResourceIndex) (int64, error) {
+		return 1, index.BulkIndex(&resource.BulkIndexRequest{
+			Items: []*resource.BulkIndexItem{
+				doc("live-unset", nil),
+				doc("live-explicit", new(false)),
+				doc("trashed", new(true)),
+			},
+		})
+	}, nil, false, time.Time{}, 0)
+	require.NoError(t, err)
+
+	bi, ok := index.(*bleveIndex)
+	require.True(t, ok)
+
+	markerHits := func(t *testing.T, value bool) []string {
+		t.Helper()
+		q := bleve.NewBoolFieldQuery(value)
+		q.SetField(resource.SEARCH_FIELD_IS_DELETED)
+		res, err := bi.index.Search(bleve.NewSearchRequest(q))
+		require.NoError(t, err)
+		names := make([]string, 0, len(res.Hits))
+		for _, hit := range res.Hits {
+			names = append(names, hit.ID)
+		}
+		slices.Sort(names)
+		return names
+	}
+
+	assert.Equal(t, []string{"default/example.test/widgets/trashed"}, markerHits(t, true))
+	assert.Equal(t, []string{"default/example.test/widgets/live-explicit"}, markerHits(t, false))
+
+	// The marker is not a declared field, so callers cannot ask for it and it
+	// stays out of the hash that forces reindexing.
+	assert.Nil(t, resource.StandardSearchFields().Field(resource.SEARCH_FIELD_IS_DELETED))
+	assert.False(t, bi.isDeclaredField(resource.SEARCH_FIELD_IS_DELETED))
+}
+
+// TestScopeQueryKeepsScores guards ranking against the exclusion clause: bleve
+// scores a boolean query with one Must clause exactly as that clause alone, and
+// MustNot adds nothing. A future scopeQuery that used Should or a boost would
+// quietly reweight every search.
+func TestScopeQueryKeepsScores(t *testing.T) {
+	key := resource.NamespacedResource{Namespace: "default", Group: "example.test", Resource: "widgets"}
+
+	backend, err := NewBleveBackend(BleveOptions{Root: t.TempDir(), FileThreshold: 5}, nil)
+	require.NoError(t, err)
+	t.Cleanup(backend.Stop)
+
+	titles := map[string]string{
+		"a": "hello world",
+		"b": "hello hello world of hello",
+		"c": "world of warcraft",
+		"d": "hello",
+	}
+	index, err := backend.BuildIndex(t.Context(), key, 5, "test", func(index resource.ResourceIndex) (int64, error) {
+		items := make([]*resource.BulkIndexItem, 0, len(titles))
+		for name, title := range titles {
+			items = append(items, &resource.BulkIndexItem{Action: resource.ActionIndex, Doc: &resource.IndexableDocument{
+				Key:   &resourcepb.ResourceKey{Namespace: key.Namespace, Group: key.Group, Resource: key.Resource, Name: name},
+				Title: title,
+			}})
+		}
+		return 1, index.BulkIndex(&resource.BulkIndexRequest{Items: items})
+	}, nil, false, time.Time{}, 0)
+	require.NoError(t, err)
+	bi, ok := index.(*bleveIndex)
+	require.True(t, ok)
+
+	textQuery := bleve.NewMatchQuery("hello")
+	textQuery.SetField(resource.SEARCH_FIELD_TITLE)
+
+	scores := func(q query.Query) []string {
+		req := bleve.NewSearchRequest(q)
+		req.Size = 10
+		res, err := bi.index.Search(req)
+		require.NoError(t, err)
+		out := make([]string, 0, len(res.Hits))
+		for _, hit := range res.Hits {
+			out = append(out, fmt.Sprintf("%s=%.6f", hit.ID, hit.Score))
+		}
+		return out
+	}
+
+	assert.Equal(t, scores(textQuery), scores(scopeQuery(textQuery, false)))
 }

--- a/pkg/storage/unified/search/testdata/bleve_mapping_dashboard.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_dashboard.json
@@ -18,6 +18,17 @@
           }
         ]
       },
+      "_provisioned": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "boolean",
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
       "created": {
         "enabled": true,
         "dynamic": true,

--- a/pkg/storage/unified/search/testdata/bleve_mapping_dashboard.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_dashboard.json
@@ -7,6 +7,17 @@
         "enabled": false,
         "dynamic": false
       },
+      "_deleted": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "boolean",
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
       "created": {
         "enabled": true,
         "dynamic": true,

--- a/pkg/storage/unified/search/testdata/bleve_mapping_empty.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_empty.json
@@ -18,6 +18,17 @@
           }
         ]
       },
+      "_provisioned": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "boolean",
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
       "created": {
         "enabled": true,
         "dynamic": true,

--- a/pkg/storage/unified/search/testdata/bleve_mapping_empty.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_empty.json
@@ -7,6 +7,17 @@
         "enabled": false,
         "dynamic": false
       },
+      "_deleted": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "boolean",
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
       "created": {
         "enabled": true,
         "dynamic": true,

--- a/pkg/storage/unified/search/testdata/bleve_mapping_external_group_mapping.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_external_group_mapping.json
@@ -18,6 +18,17 @@
           }
         ]
       },
+      "_provisioned": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "boolean",
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
       "created": {
         "enabled": true,
         "dynamic": true,

--- a/pkg/storage/unified/search/testdata/bleve_mapping_external_group_mapping.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_external_group_mapping.json
@@ -7,6 +7,17 @@
         "enabled": false,
         "dynamic": false
       },
+      "_deleted": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "boolean",
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
       "created": {
         "enabled": true,
         "dynamic": true,

--- a/pkg/storage/unified/search/testdata/bleve_mapping_provider_driven.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_provider_driven.json
@@ -18,6 +18,17 @@
           }
         ]
       },
+      "_provisioned": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "boolean",
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
       "created": {
         "enabled": true,
         "dynamic": true,

--- a/pkg/storage/unified/search/testdata/bleve_mapping_provider_driven.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_provider_driven.json
@@ -7,6 +7,17 @@
         "enabled": false,
         "dynamic": false
       },
+      "_deleted": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "boolean",
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
       "created": {
         "enabled": true,
         "dynamic": true,

--- a/pkg/storage/unified/search/testdata/bleve_mapping_selectable_fields.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_selectable_fields.json
@@ -18,6 +18,17 @@
           }
         ]
       },
+      "_provisioned": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "boolean",
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
       "created": {
         "enabled": true,
         "dynamic": true,

--- a/pkg/storage/unified/search/testdata/bleve_mapping_selectable_fields.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_selectable_fields.json
@@ -7,6 +7,17 @@
         "enabled": false,
         "dynamic": false
       },
+      "_deleted": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "boolean",
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
       "created": {
         "enabled": true,
         "dynamic": true,

--- a/pkg/storage/unified/search/testdata/bleve_mapping_team.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_team.json
@@ -18,6 +18,17 @@
           }
         ]
       },
+      "_provisioned": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "boolean",
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
       "created": {
         "enabled": true,
         "dynamic": true,

--- a/pkg/storage/unified/search/testdata/bleve_mapping_team.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_team.json
@@ -7,6 +7,17 @@
         "enabled": false,
         "dynamic": false
       },
+      "_deleted": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "boolean",
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
       "created": {
         "enabled": true,
         "dynamic": true,

--- a/pkg/storage/unified/search/testdata/bleve_mapping_team_binding.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_team_binding.json
@@ -18,6 +18,17 @@
           }
         ]
       },
+      "_provisioned": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "boolean",
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
       "created": {
         "enabled": true,
         "dynamic": true,

--- a/pkg/storage/unified/search/testdata/bleve_mapping_team_binding.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_team_binding.json
@@ -7,6 +7,17 @@
         "enabled": false,
         "dynamic": false
       },
+      "_deleted": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "boolean",
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
       "created": {
         "enabled": true,
         "dynamic": true,

--- a/pkg/storage/unified/search/testdata/bleve_mapping_user.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_user.json
@@ -18,6 +18,17 @@
           }
         ]
       },
+      "_provisioned": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "boolean",
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
       "created": {
         "enabled": true,
         "dynamic": true,

--- a/pkg/storage/unified/search/testdata/bleve_mapping_user.json
+++ b/pkg/storage/unified/search/testdata/bleve_mapping_user.json
@@ -7,6 +7,17 @@
         "enabled": false,
         "dynamic": false
       },
+      "_deleted": {
+        "enabled": true,
+        "dynamic": true,
+        "fields": [
+          {
+            "type": "boolean",
+            "index": true,
+            "skip_freq_norm": true
+          }
+        ]
+      },
       "created": {
         "enabled": true,
         "dynamic": true,

--- a/pkg/tests/apis/dashboard/testdata/searchV0/t06-panel-title-orange.json
+++ b/pkg/tests/apis/dashboard/testdata/searchV0/t06-panel-title-orange.json
@@ -26,64 +26,76 @@
                               {
                                 "children": [
                                   {
-                                    "message": "boost",
-                                    "value": 5
-                                  },
-                                  {
-                                    "message": "idf(docFreq=1, maxDocs=17)",
-                                    "value": 2.485
-                                  },
-                                  {
-                                    "message": "queryNorm",
-                                    "value": 0.025
-                                  }
-                                ],
-                                "message": "queryWeight(fields.panel_title:orange^5.000000), product of:",
-                                "value": 0.313
-                              },
-                              {
-                                "children": [
-                                  {
-                                    "message": "tf(termFreq(fields.panel_title:orange)=3",
-                                    "value": 1.732
-                                  },
-                                  {
                                     "children": [
                                       {
-                                        "message": "fieldNorm(field=fields.panel_title), b=0.750000, fieldLength=38.000002, avgFieldLength=13.000000)",
-                                        "value": 2.442
+                                        "children": [
+                                          {
+                                            "message": "boost",
+                                            "value": 5
+                                          },
+                                          {
+                                            "message": "idf(docFreq=1, maxDocs=17)",
+                                            "value": 2.485
+                                          },
+                                          {
+                                            "message": "queryNorm",
+                                            "value": 0.025
+                                          }
+                                        ],
+                                        "message": "queryWeight(fields.panel_title:orange^5.000000), product of:",
+                                        "value": 0.313
+                                      },
+                                      {
+                                        "children": [
+                                          {
+                                            "message": "tf(termFreq(fields.panel_title:orange)=3",
+                                            "value": 1.732
+                                          },
+                                          {
+                                            "children": [
+                                              {
+                                                "message": "fieldNorm(field=fields.panel_title), b=0.750000, fieldLength=38.000002, avgFieldLength=13.000000)",
+                                                "value": 2.442
+                                              }
+                                            ],
+                                            "message": "saturation(term:), k1=1.200000/(tf=1.732051 + k1*fieldNorm=2.442308))",
+                                            "value": 0.257
+                                          },
+                                          {
+                                            "message": "idf(docFreq=1, maxDocs=17)",
+                                            "value": 2.485
+                                          }
+                                        ],
+                                        "message": "fieldWeight(fields.panel_title:orange in \u003cdocID\u003e), as per bm25 model, product of:",
+                                        "value": 1.108
                                       }
                                     ],
-                                    "message": "saturation(term:), k1=1.200000/(tf=1.732051 + k1*fieldNorm=2.442308))",
-                                    "value": 0.257
-                                  },
-                                  {
-                                    "message": "idf(docFreq=1, maxDocs=17)",
-                                    "value": 2.485
+                                    "message": "weight(fields.panel_title:orange^5.000000 in \u003cdocID\u003e), product of:",
+                                    "value": 0.346
                                   }
                                 ],
-                                "message": "fieldWeight(fields.panel_title:orange in <docID>), as per bm25 model, product of:",
-                                "value": 1.108
+                                "message": "sum of:",
+                                "value": 0.346
                               }
                             ],
-                            "message": "weight(fields.panel_title:orange^5.000000 in <docID>), product of:",
+                            "message": "sum of:",
                             "value": 0.346
+                          },
+                          {
+                            "message": "coord(1/4)",
+                            "value": 0.25
                           }
                         ],
-                        "message": "sum of:",
-                        "value": 0.346
+                        "message": "product of:",
+                        "partial_match": true,
+                        "value": 0.087
                       }
                     ],
                     "message": "sum of:",
-                    "value": 0.346
-                  },
-                  {
-                    "message": "coord(1/4)",
-                    "value": 0.25
+                    "value": 0.087
                   }
                 ],
-                "message": "product of:",
-                "partial_match": true,
+                "message": "sum of:",
                 "value": 0.087
               }
             ],


### PR DESCRIPTION
Trash search needs deleted documents in the search index, which means every read path has to pick between live and deleted ones. This adds the markers those documents will carry and the scope that separates them, before anything sets them. Nothing is marked yet, so it is a no-op on landing.

A deleted document carries two internal markers: that it is deleted, and whether the object was provisioned when it was deleted. Trash never returns provisioned objects — they come back from their repository — and a deleted document keeps no manager fields to work that out later. Both are internal fields, deliberately not declared search fields: declaring them would change the hash that forces reindexing for every kind, and would let live-endpoint callers filter on them. Live documents carry no value for either, so anything written before this counts as live without a reindex.

`scopeQuery` is the only place the distinction is made, and every query the index issues goes through it — both searches, facets and total hits, `DocCount`, and the two managed object paths. That is the point: a future read path cannot forget and start serving trash as live. It also honours the existing `IsDeleted` request flag, which had no consumer until now.

`DocCount` now counts live documents only, so callers using it as a size estimate undercount by whatever trash an index holds. Close enough for a threshold; the internal size accounting is untouched.

One `deleted-marker` index feature covers both mappings, so an index either holds both markers or neither, and a writer can check before keeping a deleted document there. It is not required, so nothing gets rebuilt.

Left for the follow-up that starts marking documents: check that feature first, or the markers are dropped and a deleted document looks live.

Part of grafana/search-and-storage-team#869.
