### PR TITLE
Dashboards: Improve ungrouping of groups

### DIFF
--- a/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/dashboard-groupings.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/dashboard-groupings.md
@@ -41,11 +41,11 @@ image_maps:
       - x_coord: 52
         y_coord: 9.5
         content: |
-          Ungroups all the tabs inside **Row with tabs**, leaving the panels in that row.
+          Ungroups the tabs inside **Row with tabs**. Nested rows move up a level and tabs that contain only panels are converted to rows.
       - x_coord: 20.5
         y_coord: 96
         content: |
-          Removes all groupings on the dashboard, leaving just the panels on the dashboard.
+          Ungroups the top-level rows. Nested tabs move up a level and rows that contain only panels are converted to tabs.
 ---
 
 # Dashboard panel groupings
@@ -185,8 +185,18 @@ You can add more one more level of grouping if needed.
 
 You can ungroup some or all of the dashboard groupings without losing your panels.
 
-When you ungroup a row or tab, all the groupings inside it are ungrouped and the panels are moved into the next higher-level grouping.
-If there are no more groupings left, the panels are moved onto the dashboard.
+What happens when you ungroup rows or tabs depends on what they contain:
+
+- **Groupings that contain only panels**: The grouping level is removed and the panels are merged into the next higher-level grouping. If there are no groupings left, the panels are moved onto the dashboard.
+- **Groupings that contain nested groupings**: Only the grouping level you're ungrouping is removed. The nested groupings move up a level, and any groupings at the same level that contain only panels are converted to the same grouping type, so the structure of your dashboard content is preserved.
+
+When the groupings you're ungrouping contain nested groupings, the following rules apply:
+
+- If the nested groupings are all rows or all tabs, Grafana automatically converts everything at that level to that grouping type.
+- If the nested groupings are a mix of rows and tabs, or if converting to tabs isn't possible because tabs can't be directly nested inside a tab, you're prompted to choose between **Convert to rows** and **Convert to tabs**.
+- If any of the ungrouped groupings have repeat options configured, those repeat options are lost. Grafana warns you before making the change.
+
+Section-level variables and filters configured on the ungrouped groupings aren't lost; they move up to the next level.
 
 {{< image-map key="ungrouping" >}}
 
@@ -201,8 +211,9 @@ To remove groupings, follow these steps:
 1. Navigate to the dashboard you want to update.
 1. Click **Edit**.
 1. (Optional) Click the **Content outline** icon to quickly navigate to the grouping you want to remove.
-1. Hover your mouse over the relevant area to show the **Ungroup rows** or **Ungroup tabs** button, then click it to ungroup all rows or tabs, including any nested groupings.
+1. Hover your mouse over the relevant area to show the **Ungroup rows** or **Ungroup tabs** button, then click it.
 1. If you've ungrouped panels that were previously in different panel layouts, you'll be prompted to select a common layout type for all the panels; click **Convert to Auto grid** or **Convert to Custom**.
+1. If the ungrouped groupings contain a mix of nested rows and tabs, you'll be prompted to select how to convert them; click **Convert to rows** or **Convert to tabs**.
 1. Click **Save**.
 1. (Optional) Enter a description of the changes you've made.
 1. Click **Save**.
@@ -241,3 +252,4 @@ Panels in the grouping resolve section-level variables and filters first, then f
 
 The panel query editor is context-aware, so the autocomplete only shows the variables available to the panel you're editing.
 Also, section-level variables and filters carry over when you convert between rows and tabs, change layouts, and work with repeating rows and tabs.
+When you ungroup rows or tabs, their section-level variables and filters move up to the next level.

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
@@ -138,16 +138,23 @@ export class RowItem
     return getSlugForRowOrTab(this, siblings);
   }
 
-  public switchLayout(layout: DashboardLayoutManager) {
+  public switchLayout(layout: DashboardLayoutManager, skipUndo?: boolean) {
     const currentLayout = this.state.layout;
+
+    const perform = () => {
+      this.setState({ layout });
+      this.publishEvent(new NewSceneObjectAddedEvent(this), true);
+    };
+
+    if (skipUndo) {
+      perform();
+      return;
+    }
 
     dashboardEditActions.edit({
       description: t('dashboard.edit-actions.switch-layout-row', 'Switch layout'),
       source: this,
-      perform: () => {
-        this.setState({ layout });
-        this.publishEvent(new NewSceneObjectAddedEvent(this), true);
-      },
+      perform,
       undo: () => {
         this.setState({ layout: currentLayout });
         this.publishEvent(new NewSceneObjectAddedEvent(this), true);

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManager.test.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManager.test.tsx
@@ -1,5 +1,5 @@
 import { VariableHide } from '@grafana/data';
-import { ConstantVariable, SceneGridLayout, SceneVariableSet, VizPanel } from '@grafana/scenes';
+import { ConstantVariable, LocalValueVariable, SceneGridLayout, SceneVariableSet, VizPanel } from '@grafana/scenes';
 import { appEvents } from 'app/core/app_events';
 import { ShowConfirmModalEvent, ShowModalReactEvent } from 'app/types/events';
 
@@ -324,6 +324,26 @@ describe('RowsLayoutManager', () => {
       rowsLayoutManager.hoistNestedGroups('rows');
 
       expect(scene.state.$variables?.state.variables).toContain(variable);
+    });
+
+    it('should not move repeater-injected local variables up when dissolving a repeated row', () => {
+      const sectionVariable = new ConstantVariable({ name: 'env', value: 'prod' });
+      const localVariable = new LocalValueVariable({ name: 'server', value: 'A', text: 'A' });
+      const rowsLayoutManager = buildRowsLayoutManager([
+        new RowItem({
+          title: 'Repeated',
+          repeatByVariable: 'server',
+          layout: new RowsLayoutManager({ rows: [new RowItem({ title: 'Inner' })] }),
+          $variables: new SceneVariableSet({ variables: [sectionVariable, localVariable] }),
+        }),
+      ]);
+      const scene = rowsLayoutManager.parent as DashboardScene;
+
+      rowsLayoutManager.hoistNestedGroups('rows');
+
+      const sceneVariables = scene.state.$variables?.state.variables ?? [];
+      expect(sceneVariables).toContain(sectionVariable);
+      expect(sceneVariables).not.toContain(localVariable);
     });
 
     it('should hoist nested rows into this layout and convert nested tabs into rows when hoisting to rows', () => {

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManager.test.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManager.test.tsx
@@ -372,6 +372,38 @@ describe('RowsLayoutManager', () => {
       expect(rowsLayoutManager.state.rows[1]).toBe(innerRow2);
       expect(rowsLayoutManager.state.rows[3]).toBe(gridRow);
     });
+
+    it('should make tab titles unique when hoisting to tabs produces clashing titles', () => {
+      const rowsLayoutManager = buildRowsLayoutManager([
+        new RowItem({ title: 'Row 1', layout: new TabsLayoutManager({ tabs: [new TabItem({ title: 'Overview' })] }) }),
+        new RowItem({ title: 'Row 2', layout: new TabsLayoutManager({ tabs: [new TabItem({ title: 'Overview' })] }) }),
+        new RowItem({ title: 'Overview' }),
+      ]);
+
+      rowsLayoutManager.hoistNestedGroups('tabs');
+
+      const newLayout = (ungroupLayout as jest.Mock).mock.calls[0][1] as TabsLayoutManager;
+      expect(newLayout.state.tabs.map((tab) => tab.state.title)).toEqual(['Overview', 'Overview 1', 'Overview 2']);
+    });
+
+    it('should make row titles unique when hoisting to rows produces clashing titles', () => {
+      const rowsLayoutManager = buildRowsLayoutManager([
+        new RowItem({ title: 'Outer', layout: new RowsLayoutManager({ rows: [new RowItem({ title: 'Overview' })] }) }),
+        new RowItem({
+          title: 'Tabs row',
+          layout: new TabsLayoutManager({ tabs: [new TabItem({ title: 'Overview' })] }),
+        }),
+        new RowItem({ title: 'Overview' }),
+      ]);
+
+      rowsLayoutManager.hoistNestedGroups('rows');
+
+      expect(rowsLayoutManager.state.rows.map((row) => row.state.title)).toEqual([
+        'Overview',
+        'Overview 1',
+        'Overview 2',
+      ]);
+    });
   });
 
   describe('ungroupRows', () => {

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManager.test.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManager.test.tsx
@@ -16,6 +16,8 @@ import { RowItem } from './RowItem';
 import { RowsLayoutManager } from './RowsLayoutManager';
 
 let lastUndo: (() => void) | undefined;
+let lastEditPerform: (() => void) | undefined;
+let lastEditUndo: (() => void) | undefined;
 let ungroupLayoutCalled = false;
 
 jest.mock('../../sidebar/shared', () => ({
@@ -28,8 +30,10 @@ jest.mock('../../sidebar/shared', () => ({
       perform();
       lastUndo = undo;
     }),
-    edit: jest.fn(({ perform }) => {
+    edit: jest.fn(({ perform, undo }) => {
       perform();
+      lastEditPerform = perform;
+      lastEditUndo = undo;
     }),
   },
 }));
@@ -355,6 +359,8 @@ describe('RowsLayoutManager', () => {
 
     beforeEach(() => {
       jest.clearAllMocks();
+      lastEditPerform = undefined;
+      lastEditUndo = undefined;
       publishSpy = jest.spyOn(appEvents, 'publish').mockImplementation(() => {});
     });
 
@@ -455,6 +461,40 @@ describe('RowsLayoutManager', () => {
       rowsLayoutManager.ungroupRows();
 
       expect(publishSpy).not.toHaveBeenCalled();
+      expect(scene.state.$variables?.state.variables).toContain(variable);
+    });
+
+    it('should redo the hoist after undo by re-installing the resulting layout', () => {
+      const innerRow = new RowItem({ title: 'Inner row' });
+      const variable = new ConstantVariable({ name: 'env', value: 'prod' });
+      const rowsLayoutManager = buildRowsLayoutManager([
+        new RowItem({
+          title: 'Outer',
+          layout: new RowsLayoutManager({ rows: [innerRow] }),
+          $variables: new SceneVariableSet({ variables: [variable] }),
+        }),
+      ]);
+      const scene = rowsLayoutManager.parent as DashboardScene;
+
+      rowsLayoutManager.ungroupRows();
+
+      expect(rowsLayoutManager.state.rows).toHaveLength(1);
+      expect(rowsLayoutManager.state.rows[0]).toBe(innerRow);
+      expect(scene.state.$variables?.state.variables).toContain(variable);
+
+      // Undo detaches the hoisted layout and re-installs a clone of the pre-hoist state
+      lastEditUndo!();
+
+      expect(scene.state.body).not.toBe(rowsLayoutManager);
+      expect(scene.state.body).toBeInstanceOf(RowsLayoutManager);
+      expect(scene.state.$variables?.state.variables ?? []).not.toContain(variable);
+
+      // Redo must re-install the hoist result instead of re-running it on the detached original
+      lastEditPerform!();
+
+      expect(scene.state.body).toBe(rowsLayoutManager);
+      expect(rowsLayoutManager.state.rows).toHaveLength(1);
+      expect(rowsLayoutManager.state.rows[0]).toBe(innerRow);
       expect(scene.state.$variables?.state.variables).toContain(variable);
     });
   });

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManager.test.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManager.test.tsx
@@ -1,11 +1,16 @@
 import { VariableHide } from '@grafana/data';
 import { ConstantVariable, SceneGridLayout, SceneVariableSet, VizPanel } from '@grafana/scenes';
+import { appEvents } from 'app/core/app_events';
+import { ShowConfirmModalEvent, ShowModalReactEvent } from 'app/types/events';
 
 import { dashboardEditActions } from '../../sidebar/shared';
 import { DashboardScene } from '../DashboardScene';
 import { AutoGridLayoutManager } from '../layout-auto-grid/AutoGridLayoutManager';
 import { DashboardGridItem } from '../layout-default/DashboardGridItem';
 import { DefaultGridLayoutManager } from '../layout-default/DefaultGridLayoutManager';
+import { TabItem } from '../layout-tabs/TabItem';
+import { TabsLayoutManager } from '../layout-tabs/TabsLayoutManager';
+import { ungroupLayout } from '../layouts-shared/utils';
 
 import { RowItem } from './RowItem';
 import { RowsLayoutManager } from './RowsLayoutManager';
@@ -253,6 +258,204 @@ describe('RowsLayoutManager', () => {
         expect(rowsLayoutManager.state.rows).toHaveLength(1);
         expect(rowsLayoutManager.state.rows[0]).toBe(row);
       });
+    });
+  });
+
+  describe('hoistNestedGroups', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should hoist nested tabs to the top level when hoisting to tabs', () => {
+      const tab1 = new TabItem({ title: 'Tab 1' });
+      const tab2 = new TabItem({ title: 'Tab 2' });
+      const tab3 = new TabItem({ title: 'Tab 3' });
+      const rowsLayoutManager = buildRowsLayoutManager([
+        new RowItem({ title: 'Row 1', layout: new TabsLayoutManager({ tabs: [tab1, tab2] }) }),
+        new RowItem({ title: 'Row 2', layout: new TabsLayoutManager({ tabs: [tab3] }) }),
+      ]);
+
+      rowsLayoutManager.hoistNestedGroups('tabs');
+
+      expect(ungroupLayout).toHaveBeenCalledTimes(1);
+      const [source, newLayout, skipUndo] = (ungroupLayout as jest.Mock).mock.calls[0];
+      expect(source).toBe(rowsLayoutManager);
+      expect(skipUndo).toBe(true);
+      expect(newLayout).toBeInstanceOf(TabsLayoutManager);
+      expect(newLayout.state.tabs).toHaveLength(3);
+      expect(newLayout.state.tabs[0]).toBe(tab1);
+      expect(newLayout.state.tabs[1]).toBe(tab2);
+      expect(newLayout.state.tabs[2]).toBe(tab3);
+    });
+
+    it('should convert grid rows and nested rows into tabs when hoisting to tabs', () => {
+      const gridLayout = AutoGridLayoutManager.createEmpty();
+      const rowsLayoutManager = buildRowsLayoutManager([
+        new RowItem({ title: 'Tabs row', layout: new TabsLayoutManager({ tabs: [new TabItem({ title: 'Tab 1' })] }) }),
+        new RowItem({
+          title: 'Rows row',
+          layout: new RowsLayoutManager({ rows: [new RowItem({ title: 'Inner row' })] }),
+        }),
+        new RowItem({ title: 'Grid row', layout: gridLayout }),
+      ]);
+
+      rowsLayoutManager.hoistNestedGroups('tabs');
+
+      const newLayout = (ungroupLayout as jest.Mock).mock.calls[0][1] as TabsLayoutManager;
+      expect(newLayout.state.tabs.map((tab) => tab.state.title)).toEqual(['Tab 1', 'Inner row', 'Grid row']);
+      expect(newLayout.state.tabs[2].state.layout).toBe(gridLayout);
+    });
+
+    it('should move section variables of dissolved rows up to the dashboard', () => {
+      const variable = new ConstantVariable({ name: 'env', value: 'prod' });
+      const rowsLayoutManager = buildRowsLayoutManager([
+        new RowItem({
+          title: 'Outer',
+          layout: new RowsLayoutManager({ rows: [new RowItem({ title: 'Inner' })] }),
+          $variables: new SceneVariableSet({ variables: [variable] }),
+        }),
+      ]);
+      const scene = rowsLayoutManager.parent as DashboardScene;
+
+      rowsLayoutManager.hoistNestedGroups('rows');
+
+      expect(scene.state.$variables?.state.variables).toContain(variable);
+    });
+
+    it('should hoist nested rows into this layout and convert nested tabs into rows when hoisting to rows', () => {
+      const innerRow1 = new RowItem({ title: 'Inner 1' });
+      const innerRow2 = new RowItem({ title: 'Inner 2' });
+      const gridRow = new RowItem({ title: 'Grid row' });
+      const rowsLayoutManager = buildRowsLayoutManager([
+        new RowItem({ title: 'Outer', layout: new RowsLayoutManager({ rows: [innerRow1, innerRow2] }) }),
+        new RowItem({
+          title: 'Tabs row',
+          layout: new TabsLayoutManager({ tabs: [new TabItem({ title: 'Inner tab' })] }),
+        }),
+        gridRow,
+      ]);
+
+      rowsLayoutManager.hoistNestedGroups('rows');
+
+      expect(ungroupLayout).not.toHaveBeenCalled();
+      expect(rowsLayoutManager.state.rows.map((row) => row.state.title)).toEqual([
+        'Inner 1',
+        'Inner 2',
+        'Inner tab',
+        'Grid row',
+      ]);
+      expect(rowsLayoutManager.state.rows[0]).toBe(innerRow1);
+      expect(rowsLayoutManager.state.rows[1]).toBe(innerRow2);
+      expect(rowsLayoutManager.state.rows[3]).toBe(gridRow);
+    });
+  });
+
+  describe('ungroupRows', () => {
+    let publishSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      publishSpy = jest.spyOn(appEvents, 'publish').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      publishSpy.mockRestore();
+    });
+
+    it('should hoist nested tabs without any modal when at the top level', () => {
+      const rowsLayoutManager = buildRowsLayoutManager([
+        new RowItem({ title: 'Row 1', layout: new TabsLayoutManager({ tabs: [new TabItem({ title: 'Tab 1' })] }) }),
+      ]);
+
+      rowsLayoutManager.ungroupRows();
+
+      expect(publishSpy).not.toHaveBeenCalled();
+      expect(ungroupLayout).toHaveBeenCalledTimes(1);
+      expect((ungroupLayout as jest.Mock).mock.calls[0][1]).toBeInstanceOf(TabsLayoutManager);
+    });
+
+    it('should show the ungroup groups modal when nested groups are mixed', () => {
+      const rowsLayoutManager = buildRowsLayoutManager([
+        new RowItem({ title: 'Tabs row', layout: new TabsLayoutManager({ tabs: [new TabItem({})] }) }),
+        new RowItem({ title: 'Rows row', layout: new RowsLayoutManager({ rows: [new RowItem({})] }) }),
+      ]);
+
+      rowsLayoutManager.ungroupRows();
+
+      expect(publishSpy).toHaveBeenCalledTimes(1);
+      const event = publishSpy.mock.calls[0][0];
+      expect(event).toBeInstanceOf(ShowModalReactEvent);
+      expect(event.payload.props).toEqual(expect.objectContaining({ disabledTabsReason: undefined }));
+    });
+
+    it('should show the ungroup groups modal with the tabs option disabled when a direct child of a tab', () => {
+      const rowsLayoutManager = new RowsLayoutManager({
+        rows: [new RowItem({ title: 'Tabs row', layout: new TabsLayoutManager({ tabs: [new TabItem({})] }) })],
+      });
+      new DashboardScene({
+        body: new TabsLayoutManager({ tabs: [new TabItem({ title: 'Outer tab', layout: rowsLayoutManager })] }),
+      });
+
+      rowsLayoutManager.ungroupRows();
+
+      expect(publishSpy).toHaveBeenCalledTimes(1);
+      const event = publishSpy.mock.calls[0][0];
+      expect(event).toBeInstanceOf(ShowModalReactEvent);
+      expect(event.payload.props).toEqual(expect.objectContaining({ disabledTabsReason: expect.any(String) }));
+    });
+
+    it('should hoist nested tabs without any modal when under a tab but not its direct child', () => {
+      const rowsLayoutManager = new RowsLayoutManager({
+        rows: [new RowItem({ title: 'Tabs row', layout: new TabsLayoutManager({ tabs: [new TabItem({})] }) })],
+      });
+      new DashboardScene({
+        body: new TabsLayoutManager({
+          tabs: [
+            new TabItem({
+              title: 'Outer tab',
+              layout: new RowsLayoutManager({ rows: [new RowItem({ title: 'Outer row', layout: rowsLayoutManager })] }),
+            }),
+          ],
+        }),
+      });
+
+      rowsLayoutManager.ungroupRows();
+
+      expect(publishSpy).not.toHaveBeenCalled();
+      expect(ungroupLayout).toHaveBeenCalledTimes(1);
+      expect((ungroupLayout as jest.Mock).mock.calls[0][1]).toBeInstanceOf(TabsLayoutManager);
+    });
+
+    it('should ask for confirmation when hoisting would lose repeat options', () => {
+      const rowsLayoutManager = buildRowsLayoutManager([
+        new RowItem({
+          title: 'Rows row',
+          repeatByVariable: 'server',
+          layout: new RowsLayoutManager({ rows: [new RowItem({})] }),
+        }),
+      ]);
+
+      rowsLayoutManager.ungroupRows();
+
+      expect(publishSpy).toHaveBeenCalledTimes(1);
+      expect(publishSpy.mock.calls[0][0]).toBeInstanceOf(ShowConfirmModalEvent);
+    });
+
+    it('should hoist directly without confirmation when dissolved rows only have section variables', () => {
+      const variable = new ConstantVariable({ name: 'env', value: 'prod' });
+      const rowsLayoutManager = buildRowsLayoutManager([
+        new RowItem({
+          title: 'Rows row',
+          layout: new RowsLayoutManager({ rows: [new RowItem({})] }),
+          $variables: new SceneVariableSet({ variables: [variable] }),
+        }),
+      ]);
+      const scene = rowsLayoutManager.parent as DashboardScene;
+
+      rowsLayoutManager.ungroupRows();
+
+      expect(publishSpy).not.toHaveBeenCalled();
+      expect(scene.state.$variables?.state.variables).toContain(variable);
     });
   });
 

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManager.tsx
@@ -36,7 +36,13 @@ import {
   showUngroupConfirmation,
   showUngroupGroupsModal,
 } from '../layouts-shared/ungroupConfirmation';
-import { generateUniqueTitle, GridLayoutType, mapIdToGridLayoutType, ungroupLayout } from '../layouts-shared/utils';
+import {
+  deduplicateTitles,
+  generateUniqueTitle,
+  GridLayoutType,
+  mapIdToGridLayoutType,
+  ungroupLayout,
+} from '../layouts-shared/utils';
 import { type DashboardDropTarget } from '../types/DashboardDropTarget';
 import { isDashboardLayoutGrid } from '../types/DashboardLayoutGrid';
 import {
@@ -423,6 +429,7 @@ export class RowsLayoutManager
         }
       }
 
+      deduplicateTitles(tabs);
       ungroupLayout(this, new TabsLayoutManager({ tabs }), true);
       return;
     }
@@ -454,6 +461,7 @@ export class RowsLayoutManager
       }
     }
 
+    deduplicateTitles(rows);
     this.setState({ rows });
   }
 

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManager.tsx
@@ -7,6 +7,8 @@ import {
   type SceneObject,
   SceneObjectBase,
   type SceneObjectState,
+  type SceneVariable,
+  type SceneVariables,
   SceneVariableSet,
   type VizPanel,
 } from '@grafana/scenes';
@@ -293,7 +295,7 @@ export class RowsLayoutManager
     });
   }
 
-  private _wrapUngroupInEdit(perform: () => void) {
+  private _wrapUngroupInEdit(performUngroup: () => void) {
     const parent = this.parent;
     if (!parent || !isLayoutParent(parent)) {
       throw new Error('Ungroup rows failed: parent is not a layout container');
@@ -307,12 +309,33 @@ export class RowsLayoutManager
       previousVariableSet instanceof SceneVariableSet ? [...previousVariableSet.state.variables] : undefined;
     const scene = getDashboardSceneFor(this);
 
+    // Undo replaces this layout with a detached clone, so redo cannot run the ungroup again
+    // (it would mutate this detached original while leaking variables into the live parent).
+    // Instead, the result of the first run is captured and redo re-installs it.
+    let nextLayout: DashboardLayoutManager | undefined;
+    let nextVariableSet: SceneVariables | undefined;
+    let nextVariables: SceneVariable[] | undefined;
+
     dashboardEditActions.edit({
       description: t('dashboard.rows-layout.edit.ungroup-rows', 'Ungroup rows'),
       source: scene,
-      perform,
+      perform: () => {
+        if (nextLayout) {
+          parent.switchLayout(nextLayout, true);
+          if (nextVariableSet instanceof SceneVariableSet && nextVariables) {
+            nextVariableSet.setState({ variables: nextVariables });
+          }
+          parent.setState({ $variables: nextVariableSet });
+          return;
+        }
+
+        performUngroup();
+        nextLayout = parent.getLayout();
+        nextVariableSet = parent.state.$variables;
+        nextVariables = nextVariableSet instanceof SceneVariableSet ? [...nextVariableSet.state.variables] : undefined;
+      },
       undo: () => {
-        parent.switchLayout(previousLayout);
+        parent.switchLayout(previousLayout, true);
         if (previousVariableSet instanceof SceneVariableSet && previousVariables) {
           previousVariableSet.setState({ variables: previousVariables });
         }

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManager.tsx
@@ -7,6 +7,7 @@ import {
   type SceneObject,
   SceneObjectBase,
   type SceneObjectState,
+  SceneVariableSet,
   type VizPanel,
 } from '@grafana/scenes';
 import { type Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.grafana.app/v2';
@@ -21,14 +22,27 @@ import { AutoGridLayoutManager } from '../layout-auto-grid/AutoGridLayoutManager
 import { DashboardGridItem } from '../layout-default/DashboardGridItem';
 import { DefaultGridLayoutManager } from '../layout-default/DefaultGridLayoutManager';
 import { RowRepeaterBehavior } from '../layout-default/RowRepeaterBehavior';
+import { type TabItem } from '../layout-tabs/TabItem';
 import { TabsLayoutManager } from '../layout-tabs/TabsLayoutManager';
+import { convertRowToTab } from '../layouts-shared/convertRowToTab';
+import { convertTabToRow } from '../layouts-shared/convertTabToRow';
+import { moveSectionVariablesUp } from '../layouts-shared/moveSectionVariablesUp';
 import { getRowFromClipboard } from '../layouts-shared/paste';
-import { showConvertMixedGridsModal, showUngroupConfirmation } from '../layouts-shared/ungroupConfirmation';
+import {
+  showConvertMixedGridsModal,
+  showRepeatLossConfirmation,
+  showUngroupConfirmation,
+  showUngroupGroupsModal,
+} from '../layouts-shared/ungroupConfirmation';
 import { generateUniqueTitle, GridLayoutType, mapIdToGridLayoutType, ungroupLayout } from '../layouts-shared/utils';
 import { type DashboardDropTarget } from '../types/DashboardDropTarget';
 import { isDashboardLayoutGrid } from '../types/DashboardLayoutGrid';
-import { type DashboardLayoutGroup, isDashboardLayoutGroup } from '../types/DashboardLayoutGroup';
-import { type DashboardLayoutManager } from '../types/DashboardLayoutManager';
+import {
+  type DashboardLayoutGroup,
+  isDashboardLayoutGroup,
+  type NestedGroupsTarget,
+} from '../types/DashboardLayoutGroup';
+import { type DashboardLayoutManager, isDashboardLayoutManager } from '../types/DashboardLayoutManager';
 import { isLayoutParent } from '../types/LayoutParent';
 import { type LayoutRegistryItem } from '../types/LayoutRegistryItem';
 
@@ -203,47 +217,106 @@ export class RowsLayoutManager
   }
 
   public ungroupRows() {
-    const hasNonGridLayout = this.state.rows.some((row) => !row.getLayout().descriptor.isGridLayout);
+    const layouts = this.state.rows.map((row) => row.getLayout());
+    const hasNestedRows = layouts.some((layout) => layout instanceof RowsLayoutManager);
+    const hasNestedTabs = layouts.some((layout) => layout instanceof TabsLayoutManager);
     const gridTypes = new Set(this.getAllGridTypes());
 
-    showUngroupConfirmation({
-      hasNonGridLayout,
-      gridTypes,
-      onConfirm: (gridLayoutType) => {
-        this.wrapUngroupRowsInEdit(gridLayoutType);
-      },
-      onConvertMixedGrids: (availableIds) => {
-        this._confirmConvertMixedGrids(availableIds);
-      },
-    });
+    // Grids only: merge them into a single grid, asking for the grid type when grids are mixed
+    if (!hasNestedRows && !hasNestedTabs) {
+      showUngroupConfirmation({
+        gridTypes,
+        onConfirm: (gridLayoutType) => {
+          this._wrapUngroupInEdit(() => this.ungroup(gridLayoutType));
+        },
+        onConvertMixedGrids: (availableIds) => {
+          this._confirmConvertMixedGrids(availableIds);
+        },
+      });
+      return;
+    }
+
+    const willLoseRepeatOptions = this.state.rows.some(
+      (row) => !row.getLayout().descriptor.isGridLayout && Boolean(row.state.repeatByVariable)
+    );
+    const disabledTabsReason = this._isDirectChildOfTabsLayout()
+      ? t('dashboard.canvas-actions.disabled-nested-tabs', 'Tabs cannot be nested inside other tabs')
+      : undefined;
+
+    // Ask the user when nested groups are mixed, or when the graceful target would be
+    // tabs but this layout lives inside a tab, where nested tabs are not allowed
+    if ((hasNestedRows && hasNestedTabs) || (hasNestedTabs && disabledTabsReason)) {
+      showUngroupGroupsModal({
+        disabledTabsReason,
+        showRepeatLossWarning: willLoseRepeatOptions,
+        onSelect: (target) => {
+          this._wrapUngroupInEdit(() => this.hoistNestedGroups(target));
+        },
+      });
+      return;
+    }
+
+    // Single nested group type: hoist gracefully, confirming first if repeat options would be lost
+    const target: NestedGroupsTarget = hasNestedTabs ? 'tabs' : 'rows';
+    const perform = () => this._wrapUngroupInEdit(() => this.hoistNestedGroups(target));
+
+    if (willLoseRepeatOptions) {
+      showRepeatLossConfirmation(perform);
+    } else {
+      perform();
+    }
+  }
+
+  /**
+   * Whether replacing this layout with a tabs layout would create tabs directly nested in tabs,
+   * which is the only forbidden tabs nesting
+   */
+  private _isDirectChildOfTabsLayout(): boolean {
+    let ancestor: SceneObject | undefined = this.parent;
+
+    while (ancestor) {
+      if (isDashboardLayoutManager(ancestor)) {
+        return ancestor instanceof TabsLayoutManager;
+      }
+      ancestor = ancestor.parent;
+    }
+
+    return false;
   }
 
   private _confirmConvertMixedGrids(availableIds: Set<string>) {
     showConvertMixedGridsModal(availableIds, (id: string) => {
       const selected = mapIdToGridLayoutType(id);
       if (selected) {
-        this.wrapUngroupRowsInEdit(selected);
+        this._wrapUngroupInEdit(() => this.ungroup(selected));
       }
     });
   }
 
-  private wrapUngroupRowsInEdit(gridLayoutType: GridLayoutType) {
+  private _wrapUngroupInEdit(perform: () => void) {
     const parent = this.parent;
     if (!parent || !isLayoutParent(parent)) {
       throw new Error('Ungroup rows failed: parent is not a layout container');
     }
 
     const previousLayout = this.clone({});
+    // Ungrouping moves the section-level variables of the dissolved rows up to the parent,
+    // so undo needs to restore the parent's variables in addition to restoring the layout
+    const previousVariableSet = parent.state.$variables;
+    const previousVariables =
+      previousVariableSet instanceof SceneVariableSet ? [...previousVariableSet.state.variables] : undefined;
     const scene = getDashboardSceneFor(this);
 
     dashboardEditActions.edit({
       description: t('dashboard.rows-layout.edit.ungroup-rows', 'Ungroup rows'),
       source: scene,
-      perform: () => {
-        this.ungroup(gridLayoutType);
-      },
+      perform,
       undo: () => {
         parent.switchLayout(previousLayout);
+        if (previousVariableSet instanceof SceneVariableSet && previousVariables) {
+          previousVariableSet.setState({ variables: previousVariables });
+        }
+        parent.setState({ $variables: previousVariableSet });
       },
     });
   }
@@ -264,6 +337,9 @@ export class RowsLayoutManager
       }
     }
 
+    // All rows are dissolved when merging into a single grid, so their variables move up a level
+    moveSectionVariablesUp(this.state.rows, this);
+
     this.convertAllGridLayouts(gridLayoutType);
 
     const firstRow = this.state.rows[0];
@@ -282,6 +358,80 @@ export class RowsLayoutManager
     this.setState({ rows: [firstRow] });
     this.removeRow(firstRow, true);
     ungroupLayout(this, firstRow.state.layout, true);
+  }
+
+  /**
+   * Removes the rows level while preserving content structure:
+   * nested groups are hoisted up a level and other rows are converted to the target group type.
+   */
+  public hoistNestedGroups(target: NestedGroupsTarget) {
+    // Rows holding nested groups are dissolved (their content is hoisted),
+    // so their section-level variables move up a level instead of being lost
+    moveSectionVariablesUp(
+      this.state.rows.filter((row) => !row.getLayout().descriptor.isGridLayout && !row.state.repeatSourceKey),
+      this
+    );
+
+    if (target === 'tabs') {
+      const tabs: TabItem[] = [];
+
+      for (const row of this.state.rows) {
+        if (row.state.repeatSourceKey) {
+          continue;
+        }
+
+        const layout = row.getLayout();
+
+        if (layout instanceof TabsLayoutManager) {
+          for (const tab of layout.state.tabs) {
+            if (!tab.state.repeatSourceKey) {
+              tab.clearParent();
+              tabs.push(tab);
+            }
+          }
+        } else if (layout instanceof RowsLayoutManager) {
+          for (const innerRow of layout.state.rows) {
+            if (!innerRow.state.repeatSourceKey) {
+              tabs.push(convertRowToTab(innerRow));
+            }
+          }
+        } else {
+          tabs.push(convertRowToTab(row));
+        }
+      }
+
+      ungroupLayout(this, new TabsLayoutManager({ tabs }), true);
+      return;
+    }
+
+    const rows: RowItem[] = [];
+
+    for (const row of this.state.rows) {
+      if (row.state.repeatSourceKey) {
+        continue;
+      }
+
+      const layout = row.getLayout();
+
+      if (layout instanceof RowsLayoutManager) {
+        for (const innerRow of layout.state.rows) {
+          if (!innerRow.state.repeatSourceKey) {
+            innerRow.clearParent();
+            rows.push(innerRow);
+          }
+        }
+      } else if (layout instanceof TabsLayoutManager) {
+        for (const tab of layout.state.tabs) {
+          if (!tab.state.repeatSourceKey) {
+            rows.push(convertTabToRow(tab));
+          }
+        }
+      } else {
+        rows.push(row);
+      }
+    }
+
+    this.setState({ rows });
   }
 
   public removeRow(row: RowItem, skipUndo?: boolean) {

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabItem.tsx
@@ -139,16 +139,23 @@ export class TabItem
     return parentLayout.state.currentTabSlug === this.getSlug();
   }
 
-  public switchLayout(layout: DashboardLayoutManager) {
+  public switchLayout(layout: DashboardLayoutManager, skipUndo?: boolean) {
     const currentLayout = this.state.layout;
+
+    const perform = () => {
+      this.setState({ layout });
+      this.publishEvent(new NewSceneObjectAddedEvent(this), true);
+    };
+
+    if (skipUndo) {
+      perform();
+      return;
+    }
 
     dashboardEditActions.edit({
       description: t('dashboard.edit-actions.switch-layout-tab', 'Switch layout'),
       source: this,
-      perform: () => {
-        this.setState({ layout });
-        this.publishEvent(new NewSceneObjectAddedEvent(this), true);
-      },
+      perform,
       undo: () => {
         this.setState({ layout: currentLayout });
         this.publishEvent(new NewSceneObjectAddedEvent(this), true);

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.test.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.test.tsx
@@ -1,4 +1,4 @@
-import { ConstantVariable, SceneGridLayout, SceneVariableSet, VizPanel } from '@grafana/scenes';
+import { ConstantVariable, LocalValueVariable, SceneGridLayout, SceneVariableSet, VizPanel } from '@grafana/scenes';
 import { appEvents } from 'app/core/app_events';
 import { ShowConfirmModalEvent, ShowModalReactEvent } from 'app/types/events';
 
@@ -582,6 +582,26 @@ describe('TabsLayoutManager', () => {
       expect(scene.state.$variables?.state.variables).toContain(variable);
     });
 
+    it('should not move repeater-injected local variables up when dissolving a repeated tab', () => {
+      const sectionVariable = new ConstantVariable({ name: 'env', value: 'prod' });
+      const localVariable = new LocalValueVariable({ name: 'server', value: 'A', text: 'A' });
+      const tabsLayoutManager = buildTabsLayoutManager([
+        new TabItem({
+          title: 'Repeated',
+          repeatByVariable: 'server',
+          layout: new RowsLayoutManager({ rows: [new RowItem({ title: 'Row 1' })] }),
+          $variables: new SceneVariableSet({ variables: [sectionVariable, localVariable] }),
+        }),
+      ]);
+      const scene = tabsLayoutManager.parent as DashboardScene;
+
+      tabsLayoutManager.hoistNestedGroups('rows');
+
+      const sceneVariables = scene.state.$variables?.state.variables ?? [];
+      expect(sceneVariables).toContain(sectionVariable);
+      expect(sceneVariables).not.toContain(localVariable);
+    });
+
     it('should hoist nested tabs into this layout and convert nested rows into tabs when hoisting to tabs', () => {
       const innerTab1 = new TabItem({ title: 'Inner 1' });
       const innerTab2 = new TabItem({ title: 'Inner 2' });
@@ -650,6 +670,30 @@ describe('TabsLayoutManager', () => {
       tabsLayoutManager.ungroup(GridLayoutType.GridLayout);
 
       expect(scene.state.$variables?.state.variables).toContain(variable);
+    });
+
+    it('should not move repeater-injected local variables up when merging a repeated tab', () => {
+      const sectionVariable = new ConstantVariable({ name: 'env', value: 'prod' });
+      const localVariable = new LocalValueVariable({ name: 'server', value: 'A', text: 'A' });
+      const tabsLayoutManager = buildTabsLayoutManager([
+        new TabItem({
+          title: 'Repeated',
+          repeatByVariable: 'server',
+          layout: DefaultGridLayoutManager.fromVizPanels([new VizPanel({ key: 'panel-1' })]),
+          $variables: new SceneVariableSet({ variables: [sectionVariable, localVariable] }),
+        }),
+        new TabItem({
+          title: 'Tab 2',
+          layout: DefaultGridLayoutManager.fromVizPanels([new VizPanel({ key: 'panel-2' })]),
+        }),
+      ]);
+      const scene = tabsLayoutManager.parent as DashboardScene;
+
+      tabsLayoutManager.ungroup(GridLayoutType.GridLayout);
+
+      const sceneVariables = scene.state.$variables?.state.variables ?? [];
+      expect(sceneVariables).toContain(sectionVariable);
+      expect(sceneVariables).not.toContain(localVariable);
     });
 
     it('should flatten nested groups recursively into a single grid', () => {

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.test.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.test.tsx
@@ -1,4 +1,6 @@
-import { SceneGridLayout, VizPanel } from '@grafana/scenes';
+import { ConstantVariable, SceneGridLayout, SceneVariableSet, VizPanel } from '@grafana/scenes';
+import { appEvents } from 'app/core/app_events';
+import { ShowConfirmModalEvent, ShowModalReactEvent } from 'app/types/events';
 
 import { dashboardEditActions } from '../../sidebar/shared';
 import { getLegacySlugForRowOrTab } from '../../utils/utils';
@@ -8,6 +10,7 @@ import { DashboardGridItem } from '../layout-default/DashboardGridItem';
 import { DefaultGridLayoutManager } from '../layout-default/DefaultGridLayoutManager';
 import { RowItem } from '../layout-rows/RowItem';
 import { RowsLayoutManager } from '../layout-rows/RowsLayoutManager';
+import { GridLayoutType } from '../layouts-shared/utils';
 
 import { TabItem } from './TabItem';
 import { getTabsLayoutUrlKeysToTry, TabsLayoutManager } from './TabsLayoutManager';
@@ -514,6 +517,232 @@ describe('TabsLayoutManager', () => {
       expect(tabsManager.state.tabs).toHaveLength(2);
       expect(tabsManager.state.tabs[0].state.title).toBe('New row');
       expect(tabsManager.state.tabs[1].state.title).toBe('New tab');
+    });
+  });
+
+  describe('hoistNestedGroups', () => {
+    it('should hoist nested rows to the top level when hoisting to rows', () => {
+      const row1 = new RowItem({ title: 'Row 1' });
+      const row2 = new RowItem({ title: 'Row 2' });
+      const tabsLayoutManager = buildTabsLayoutManager([
+        new TabItem({ title: 'Tab 1', layout: new RowsLayoutManager({ rows: [row1, row2] }) }),
+      ]);
+      const scene = tabsLayoutManager.parent as DashboardScene;
+
+      tabsLayoutManager.hoistNestedGroups('rows');
+
+      const newLayout = scene.state.body;
+      expect(newLayout).toBeInstanceOf(RowsLayoutManager);
+      const rows = (newLayout as RowsLayoutManager).state.rows;
+      expect(rows).toHaveLength(2);
+      expect(rows[0]).toBe(row1);
+      expect(rows[1]).toBe(row2);
+    });
+
+    it('should convert grid tabs and nested tabs into rows when hoisting to rows', () => {
+      const row1 = new RowItem({ title: 'Row 1' });
+      const gridLayout = AutoGridLayoutManager.createEmpty();
+      const tabsLayoutManager = buildTabsLayoutManager([
+        new TabItem({ title: 'Rows tab', layout: new RowsLayoutManager({ rows: [row1] }) }),
+        new TabItem({
+          title: 'Tabs tab',
+          layout: new TabsLayoutManager({ tabs: [new TabItem({ title: 'Inner tab' })] }),
+        }),
+        new TabItem({ title: 'Grid tab', layout: gridLayout }),
+      ]);
+      const scene = tabsLayoutManager.parent as DashboardScene;
+
+      tabsLayoutManager.hoistNestedGroups('rows');
+
+      const newLayout = scene.state.body;
+      expect(newLayout).toBeInstanceOf(RowsLayoutManager);
+      const rows = (newLayout as RowsLayoutManager).state.rows;
+      expect(rows.map((row) => row.state.title)).toEqual(['Row 1', 'Inner tab', 'Grid tab']);
+      expect(rows[0]).toBe(row1);
+      expect(rows[2].state.layout).toBe(gridLayout);
+    });
+
+    it('should move section variables of dissolved tabs up to the dashboard', () => {
+      const variable = new ConstantVariable({ name: 'env', value: 'prod' });
+      const tabsLayoutManager = buildTabsLayoutManager([
+        new TabItem({
+          title: 'Rows tab',
+          layout: new RowsLayoutManager({ rows: [new RowItem({ title: 'Row 1' })] }),
+          $variables: new SceneVariableSet({ variables: [variable] }),
+        }),
+      ]);
+      const scene = tabsLayoutManager.parent as DashboardScene;
+
+      tabsLayoutManager.hoistNestedGroups('rows');
+
+      expect(scene.state.$variables?.state.variables).toContain(variable);
+    });
+
+    it('should hoist nested tabs into this layout and convert nested rows into tabs when hoisting to tabs', () => {
+      const innerTab1 = new TabItem({ title: 'Inner 1' });
+      const innerTab2 = new TabItem({ title: 'Inner 2' });
+      const gridTab = new TabItem({ title: 'Grid tab' });
+      const tabsLayoutManager = buildTabsLayoutManager([
+        new TabItem({ title: 'Outer', layout: new TabsLayoutManager({ tabs: [innerTab1, innerTab2] }) }),
+        new TabItem({
+          title: 'Rows tab',
+          layout: new RowsLayoutManager({ rows: [new RowItem({ title: 'Inner row' })] }),
+        }),
+        gridTab,
+      ]);
+      const scene = tabsLayoutManager.parent as DashboardScene;
+
+      tabsLayoutManager.hoistNestedGroups('tabs');
+
+      expect(scene.state.body).toBe(tabsLayoutManager);
+      expect(tabsLayoutManager.state.tabs.map((tab) => tab.state.title)).toEqual([
+        'Inner 1',
+        'Inner 2',
+        'Inner row',
+        'Grid tab',
+      ]);
+      expect(tabsLayoutManager.state.tabs[0]).toBe(innerTab1);
+      expect(tabsLayoutManager.state.tabs[1]).toBe(innerTab2);
+      expect(tabsLayoutManager.state.tabs[3]).toBe(gridTab);
+    });
+  });
+
+  describe('ungroup', () => {
+    it('should merge grids into a single grid when no tab contains a nested group', () => {
+      const tabsLayoutManager = buildTabsLayoutManager([
+        new TabItem({
+          title: 'Tab 1',
+          layout: DefaultGridLayoutManager.fromVizPanels([new VizPanel({ key: 'panel-1' })]),
+        }),
+        new TabItem({
+          title: 'Tab 2',
+          layout: DefaultGridLayoutManager.fromVizPanels([new VizPanel({ key: 'panel-2' })]),
+        }),
+      ]);
+      const scene = tabsLayoutManager.parent as DashboardScene;
+
+      tabsLayoutManager.ungroup(GridLayoutType.GridLayout);
+
+      const newLayout = scene.state.body;
+      expect(newLayout).toBeInstanceOf(DefaultGridLayoutManager);
+      expect(newLayout.getVizPanels()).toHaveLength(2);
+    });
+
+    it('should move section variables of merged tabs up to the dashboard', () => {
+      const variable = new ConstantVariable({ name: 'env', value: 'prod' });
+      const tabsLayoutManager = buildTabsLayoutManager([
+        new TabItem({
+          title: 'Tab 1',
+          layout: DefaultGridLayoutManager.fromVizPanels([new VizPanel({ key: 'panel-1' })]),
+          $variables: new SceneVariableSet({ variables: [variable] }),
+        }),
+        new TabItem({
+          title: 'Tab 2',
+          layout: DefaultGridLayoutManager.fromVizPanels([new VizPanel({ key: 'panel-2' })]),
+        }),
+      ]);
+      const scene = tabsLayoutManager.parent as DashboardScene;
+
+      tabsLayoutManager.ungroup(GridLayoutType.GridLayout);
+
+      expect(scene.state.$variables?.state.variables).toContain(variable);
+    });
+
+    it('should flatten nested groups recursively into a single grid', () => {
+      const tabsLayoutManager = buildTabsLayoutManager([
+        new TabItem({
+          title: 'Tab 1',
+          layout: new RowsLayoutManager({
+            rows: [
+              new RowItem({
+                title: 'Row 1',
+                layout: DefaultGridLayoutManager.fromVizPanels([new VizPanel({ key: 'panel-1' })]),
+              }),
+            ],
+          }),
+        }),
+        new TabItem({
+          title: 'Tab 2',
+          layout: DefaultGridLayoutManager.fromVizPanels([new VizPanel({ key: 'panel-2' })]),
+        }),
+      ]);
+      const scene = tabsLayoutManager.parent as DashboardScene;
+
+      tabsLayoutManager.ungroup(GridLayoutType.GridLayout);
+
+      const newLayout = scene.state.body;
+      expect(newLayout).toBeInstanceOf(DefaultGridLayoutManager);
+      expect(newLayout.getVizPanels()).toHaveLength(2);
+    });
+  });
+
+  describe('ungroupTabs', () => {
+    let publishSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      publishSpy = jest.spyOn(appEvents, 'publish').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      publishSpy.mockRestore();
+    });
+
+    it('should hoist directly without any modal when only one nested group type exists', () => {
+      const row1 = new RowItem({ title: 'Row 1' });
+      const tabsLayoutManager = buildTabsLayoutManager([
+        new TabItem({ title: 'Tab 1', layout: new RowsLayoutManager({ rows: [row1] }) }),
+      ]);
+      const scene = tabsLayoutManager.parent as DashboardScene;
+
+      tabsLayoutManager.ungroupTabs();
+
+      expect(publishSpy).not.toHaveBeenCalled();
+      expect(scene.state.body).toBeInstanceOf(RowsLayoutManager);
+    });
+
+    it('should show the ungroup groups modal when nested groups are mixed', () => {
+      const tabsLayoutManager = buildTabsLayoutManager([
+        new TabItem({ title: 'Rows tab', layout: new RowsLayoutManager({ rows: [new RowItem({})] }) }),
+        new TabItem({ title: 'Tabs tab', layout: new TabsLayoutManager({ tabs: [new TabItem({})] }) }),
+      ]);
+
+      tabsLayoutManager.ungroupTabs();
+
+      expect(publishSpy).toHaveBeenCalledTimes(1);
+      expect(publishSpy.mock.calls[0][0]).toBeInstanceOf(ShowModalReactEvent);
+    });
+
+    it('should ask for confirmation when hoisting would lose repeat options', () => {
+      const tabsLayoutManager = buildTabsLayoutManager([
+        new TabItem({
+          title: 'Rows tab',
+          repeatByVariable: 'server',
+          layout: new RowsLayoutManager({ rows: [new RowItem({})] }),
+        }),
+      ]);
+
+      tabsLayoutManager.ungroupTabs();
+
+      expect(publishSpy).toHaveBeenCalledTimes(1);
+      expect(publishSpy.mock.calls[0][0]).toBeInstanceOf(ShowConfirmModalEvent);
+    });
+
+    it('should hoist directly without confirmation when dissolved tabs only have section variables', () => {
+      const variable = new ConstantVariable({ name: 'env', value: 'prod' });
+      const tabsLayoutManager = buildTabsLayoutManager([
+        new TabItem({
+          title: 'Rows tab',
+          layout: new RowsLayoutManager({ rows: [new RowItem({})] }),
+          $variables: new SceneVariableSet({ variables: [variable] }),
+        }),
+      ]);
+      const scene = tabsLayoutManager.parent as DashboardScene;
+
+      tabsLayoutManager.ungroupTabs();
+
+      expect(publishSpy).not.toHaveBeenCalled();
+      expect(scene.state.body).toBeInstanceOf(RowsLayoutManager);
+      expect(scene.state.$variables?.state.variables).toContain(variable);
     });
   });
 

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.test.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.test.tsx
@@ -629,6 +629,31 @@ describe('TabsLayoutManager', () => {
       expect(tabsLayoutManager.state.tabs[1]).toBe(innerTab2);
       expect(tabsLayoutManager.state.tabs[3]).toBe(gridTab);
     });
+
+    it('should make row titles unique when hoisting to rows produces clashing titles', () => {
+      const tabsLayoutManager = buildTabsLayoutManager([
+        new TabItem({ title: 'Tab 1', layout: new RowsLayoutManager({ rows: [new RowItem({ title: 'Overview' })] }) }),
+        new TabItem({ title: 'Tab 2', layout: new RowsLayoutManager({ rows: [new RowItem({ title: 'Overview' })] }) }),
+        new TabItem({ title: 'Overview' }),
+      ]);
+      const scene = tabsLayoutManager.parent as DashboardScene;
+
+      tabsLayoutManager.hoistNestedGroups('rows');
+
+      const newLayout = scene.state.body as RowsLayoutManager;
+      expect(newLayout.state.rows.map((row) => row.state.title)).toEqual(['Overview', 'Overview 1', 'Overview 2']);
+    });
+
+    it('should make tab titles unique when hoisting to tabs produces clashing titles', () => {
+      const tabsLayoutManager = buildTabsLayoutManager([
+        new TabItem({ title: 'Group', layout: new TabsLayoutManager({ tabs: [new TabItem({ title: 'Overview' })] }) }),
+        new TabItem({ title: 'Overview' }),
+      ]);
+
+      tabsLayoutManager.hoistNestedGroups('tabs');
+
+      expect(tabsLayoutManager.state.tabs.map((tab) => tab.state.title)).toEqual(['Overview', 'Overview 1']);
+    });
   });
 
   describe('ungroup', () => {

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.test.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.test.tsx
@@ -16,6 +16,8 @@ import { TabItem } from './TabItem';
 import { getTabsLayoutUrlKeysToTry, TabsLayoutManager } from './TabsLayoutManager';
 
 let lastUndo: (() => void) | undefined;
+let lastEditPerform: (() => void) | undefined;
+let lastEditUndo: (() => void) | undefined;
 
 jest.mock('../../sidebar/shared', () => ({
   dashboardEditActions: {
@@ -31,8 +33,10 @@ jest.mock('../../sidebar/shared', () => ({
       perform();
       lastUndo = undo;
     }),
-    edit: jest.fn(({ perform }) => {
+    edit: jest.fn(({ perform, undo }) => {
       perform();
+      lastEditPerform = perform;
+      lastEditUndo = undo;
     }),
   },
   ObjectsReorderedOnCanvasEvent: jest.fn().mockImplementation(() => ({})),
@@ -680,6 +684,8 @@ describe('TabsLayoutManager', () => {
     let publishSpy: jest.SpyInstance;
 
     beforeEach(() => {
+      lastEditPerform = undefined;
+      lastEditUndo = undefined;
       publishSpy = jest.spyOn(appEvents, 'publish').mockImplementation(() => {});
     });
 
@@ -742,6 +748,37 @@ describe('TabsLayoutManager', () => {
 
       expect(publishSpy).not.toHaveBeenCalled();
       expect(scene.state.body).toBeInstanceOf(RowsLayoutManager);
+      expect(scene.state.$variables?.state.variables).toContain(variable);
+    });
+
+    it('should redo the hoist after undo by re-installing the resulting layout', () => {
+      const variable = new ConstantVariable({ name: 'env', value: 'prod' });
+      const tabsLayoutManager = buildTabsLayoutManager([
+        new TabItem({
+          title: 'Rows tab',
+          layout: new RowsLayoutManager({ rows: [new RowItem({ title: 'Row 1' })] }),
+          $variables: new SceneVariableSet({ variables: [variable] }),
+        }),
+      ]);
+      const scene = tabsLayoutManager.parent as DashboardScene;
+
+      tabsLayoutManager.ungroupTabs();
+
+      const layoutAfterUngroup = scene.state.body;
+      expect(layoutAfterUngroup).toBeInstanceOf(RowsLayoutManager);
+      expect(scene.state.$variables?.state.variables).toContain(variable);
+
+      // Undo detaches the hoisted layout and re-installs a clone of the pre-hoist state
+      lastEditUndo!();
+
+      expect(scene.state.body).toBeInstanceOf(TabsLayoutManager);
+      expect(scene.state.body).not.toBe(tabsLayoutManager);
+      expect(scene.state.$variables?.state.variables ?? []).not.toContain(variable);
+
+      // Redo must re-install the hoist result instead of re-running it on the detached original
+      lastEditPerform!();
+
+      expect(scene.state.body).toBe(layoutAfterUngroup);
       expect(scene.state.$variables?.state.variables).toContain(variable);
     });
   });

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.tsx
@@ -32,7 +32,13 @@ import {
   showUngroupConfirmation,
   showUngroupGroupsModal,
 } from '../layouts-shared/ungroupConfirmation';
-import { generateUniqueTitle, ungroupLayout, GridLayoutType, mapIdToGridLayoutType } from '../layouts-shared/utils';
+import {
+  deduplicateTitles,
+  generateUniqueTitle,
+  ungroupLayout,
+  GridLayoutType,
+  mapIdToGridLayoutType,
+} from '../layouts-shared/utils';
 import { type DashboardDropTarget } from '../types/DashboardDropTarget';
 import { isDashboardLayoutGrid } from '../types/DashboardLayoutGrid';
 import {
@@ -486,6 +492,7 @@ export class TabsLayoutManager
         }
       }
 
+      deduplicateTitles(rows);
       ungroupLayout(this, new RowsLayoutManager({ rows }), true);
       return;
     }
@@ -517,6 +524,7 @@ export class TabsLayoutManager
       }
     }
 
+    deduplicateTitles(tabs);
     this.setState({ tabs, currentTabSlug: undefined });
   }
 

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.tsx
@@ -6,6 +6,8 @@ import {
   type SceneObjectState,
   SceneObjectUrlSyncConfig,
   type SceneObjectUrlValues,
+  type SceneVariable,
+  type SceneVariables,
   SceneVariableSet,
   type VizPanel,
 } from '@grafana/scenes';
@@ -357,7 +359,7 @@ export class TabsLayoutManager
     });
   }
 
-  private _wrapUngroupInEdit(perform: () => void) {
+  private _wrapUngroupInEdit(performUngroup: () => void) {
     const parent = this.parent;
     if (!parent || !isLayoutParent(parent)) {
       throw new Error('Ungroup tabs failed: parent is not a layout container');
@@ -371,12 +373,33 @@ export class TabsLayoutManager
       previousVariableSet instanceof SceneVariableSet ? [...previousVariableSet.state.variables] : undefined;
     const scene = getDashboardSceneFor(this);
 
+    // Undo replaces this layout with a detached clone, so redo cannot run the ungroup again
+    // (it would mutate this detached original while leaking variables into the live parent).
+    // Instead, the result of the first run is captured and redo re-installs it.
+    let nextLayout: DashboardLayoutManager | undefined;
+    let nextVariableSet: SceneVariables | undefined;
+    let nextVariables: SceneVariable[] | undefined;
+
     dashboardEditActions.edit({
       description: t('dashboard.tabs-layout.edit.ungroup-tabs', 'Ungroup tabs'),
       source: scene,
-      perform,
+      perform: () => {
+        if (nextLayout) {
+          parent.switchLayout(nextLayout, true);
+          if (nextVariableSet instanceof SceneVariableSet && nextVariables) {
+            nextVariableSet.setState({ variables: nextVariables });
+          }
+          parent.setState({ $variables: nextVariableSet });
+          return;
+        }
+
+        performUngroup();
+        nextLayout = parent.getLayout();
+        nextVariableSet = parent.state.$variables;
+        nextVariables = nextVariableSet instanceof SceneVariableSet ? [...nextVariableSet.state.variables] : undefined;
+      },
       undo: () => {
-        parent.switchLayout(previousLayout);
+        parent.switchLayout(previousLayout, true);
         if (previousVariableSet instanceof SceneVariableSet && previousVariables) {
           previousVariableSet.setState({ variables: previousVariables });
         }

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.tsx
@@ -6,6 +6,7 @@ import {
   type SceneObjectState,
   SceneObjectUrlSyncConfig,
   type SceneObjectUrlValues,
+  SceneVariableSet,
   type VizPanel,
 } from '@grafana/scenes';
 import { type Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.grafana.app/v2';
@@ -19,12 +20,24 @@ import { AutoGridLayoutManager } from '../layout-auto-grid/AutoGridLayoutManager
 import { DefaultGridLayoutManager } from '../layout-default/DefaultGridLayoutManager';
 import { RowItem } from '../layout-rows/RowItem';
 import { RowsLayoutManager } from '../layout-rows/RowsLayoutManager';
+import { convertRowToTab } from '../layouts-shared/convertRowToTab';
+import { convertTabToRow } from '../layouts-shared/convertTabToRow';
+import { moveSectionVariablesUp } from '../layouts-shared/moveSectionVariablesUp';
 import { getTabFromClipboard } from '../layouts-shared/paste';
-import { showConvertMixedGridsModal, showUngroupConfirmation } from '../layouts-shared/ungroupConfirmation';
+import {
+  showConvertMixedGridsModal,
+  showRepeatLossConfirmation,
+  showUngroupConfirmation,
+  showUngroupGroupsModal,
+} from '../layouts-shared/ungroupConfirmation';
 import { generateUniqueTitle, ungroupLayout, GridLayoutType, mapIdToGridLayoutType } from '../layouts-shared/utils';
 import { type DashboardDropTarget } from '../types/DashboardDropTarget';
 import { isDashboardLayoutGrid } from '../types/DashboardLayoutGrid';
-import { type DashboardLayoutGroup, isDashboardLayoutGroup } from '../types/DashboardLayoutGroup';
+import {
+  type DashboardLayoutGroup,
+  isDashboardLayoutGroup,
+  type NestedGroupsTarget,
+} from '../types/DashboardLayoutGroup';
 import { type DashboardLayoutManager } from '../types/DashboardLayoutManager';
 import { isLayoutParent } from '../types/LayoutParent';
 import { type LayoutRegistryItem } from '../types/LayoutRegistryItem';
@@ -263,19 +276,49 @@ export class TabsLayoutManager
   }
 
   public ungroupTabs() {
-    const hasNonGridLayout = this.state.tabs.some((tab) => !tab.getLayout().descriptor.isGridLayout);
+    const layouts = this.state.tabs.map((tab) => tab.getLayout());
+    const hasNestedRows = layouts.some((layout) => layout instanceof RowsLayoutManager);
+    const hasNestedTabs = layouts.some((layout) => layout instanceof TabsLayoutManager);
     const gridTypes = new Set(this.getAllGridTypes());
 
-    showUngroupConfirmation({
-      hasNonGridLayout,
-      gridTypes,
-      onConfirm: (gridLayoutType) => {
-        this.wrapUngroupTabsInEdit(gridLayoutType);
-      },
-      onConvertMixedGrids: (availableIds) => {
-        this._confirmConvertMixedGrids(availableIds);
-      },
-    });
+    // Grids only: merge them into a single grid, asking for the grid type when grids are mixed
+    if (!hasNestedRows && !hasNestedTabs) {
+      showUngroupConfirmation({
+        gridTypes,
+        onConfirm: (gridLayoutType) => {
+          this._wrapUngroupInEdit(() => this.ungroup(gridLayoutType));
+        },
+        onConvertMixedGrids: (availableIds) => {
+          this._confirmConvertMixedGrids(availableIds);
+        },
+      });
+      return;
+    }
+
+    const willLoseRepeatOptions = this.state.tabs.some(
+      (tab) => !tab.getLayout().descriptor.isGridLayout && Boolean(tab.state.repeatByVariable)
+    );
+
+    // Mixed nested groups: ask whether to convert them to rows or to tabs
+    if (hasNestedRows && hasNestedTabs) {
+      showUngroupGroupsModal({
+        showRepeatLossWarning: willLoseRepeatOptions,
+        onSelect: (target) => {
+          this._wrapUngroupInEdit(() => this.hoistNestedGroups(target));
+        },
+      });
+      return;
+    }
+
+    // Single nested group type: hoist gracefully, confirming first if repeat options would be lost
+    const target: NestedGroupsTarget = hasNestedRows ? 'rows' : 'tabs';
+    const perform = () => this._wrapUngroupInEdit(() => this.hoistNestedGroups(target));
+
+    if (willLoseRepeatOptions) {
+      showRepeatLossConfirmation(perform);
+    } else {
+      perform();
+    }
   }
 
   /**
@@ -309,28 +352,35 @@ export class TabsLayoutManager
     showConvertMixedGridsModal(availableIds, (id: string) => {
       const selected = mapIdToGridLayoutType(id);
       if (selected) {
-        this.wrapUngroupTabsInEdit(selected);
+        this._wrapUngroupInEdit(() => this.ungroup(selected));
       }
     });
   }
 
-  private wrapUngroupTabsInEdit(gridLayoutType: GridLayoutType) {
+  private _wrapUngroupInEdit(perform: () => void) {
     const parent = this.parent;
     if (!parent || !isLayoutParent(parent)) {
       throw new Error('Ungroup tabs failed: parent is not a layout container');
     }
 
     const previousLayout = this.clone({});
+    // Ungrouping moves the section-level variables of the dissolved tabs up to the parent,
+    // so undo needs to restore the parent's variables in addition to restoring the layout
+    const previousVariableSet = parent.state.$variables;
+    const previousVariables =
+      previousVariableSet instanceof SceneVariableSet ? [...previousVariableSet.state.variables] : undefined;
     const scene = getDashboardSceneFor(this);
 
     dashboardEditActions.edit({
       description: t('dashboard.tabs-layout.edit.ungroup-tabs', 'Ungroup tabs'),
       source: scene,
-      perform: () => {
-        this.ungroup(gridLayoutType);
-      },
+      perform,
       undo: () => {
         parent.switchLayout(previousLayout);
+        if (previousVariableSet instanceof SceneVariableSet && previousVariables) {
+          previousVariableSet.setState({ variables: previousVariables });
+        }
+        parent.setState({ $variables: previousVariableSet });
       },
     });
   }
@@ -351,6 +401,9 @@ export class TabsLayoutManager
       }
     }
 
+    // All tabs are dissolved when merging into a single grid, so their variables move up a level
+    moveSectionVariablesUp(this.state.tabs, this);
+
     this.convertAllGridLayouts(gridLayoutType);
 
     const firstTab = this.state.tabs[0];
@@ -368,6 +421,80 @@ export class TabsLayoutManager
 
     this.setState({ tabs: [firstTab] });
     ungroupLayout(this, firstTab.state.layout, true);
+  }
+
+  /**
+   * Removes the tabs level while preserving content structure:
+   * nested groups are hoisted up a level and other tabs are converted to the target group type.
+   */
+  public hoistNestedGroups(target: NestedGroupsTarget) {
+    // Tabs holding nested groups are dissolved (their content is hoisted),
+    // so their section-level variables move up a level instead of being lost
+    moveSectionVariablesUp(
+      this.state.tabs.filter((tab) => !tab.getLayout().descriptor.isGridLayout && !tab.state.repeatSourceKey),
+      this
+    );
+
+    if (target === 'rows') {
+      const rows: RowItem[] = [];
+
+      for (const tab of this.state.tabs) {
+        if (tab.state.repeatSourceKey) {
+          continue;
+        }
+
+        const layout = tab.getLayout();
+
+        if (layout instanceof RowsLayoutManager) {
+          for (const row of layout.state.rows) {
+            if (!row.state.repeatSourceKey) {
+              row.clearParent();
+              rows.push(row);
+            }
+          }
+        } else if (layout instanceof TabsLayoutManager) {
+          for (const innerTab of layout.state.tabs) {
+            if (!innerTab.state.repeatSourceKey) {
+              rows.push(convertTabToRow(innerTab));
+            }
+          }
+        } else {
+          rows.push(convertTabToRow(tab));
+        }
+      }
+
+      ungroupLayout(this, new RowsLayoutManager({ rows }), true);
+      return;
+    }
+
+    const tabs: TabItem[] = [];
+
+    for (const tab of this.state.tabs) {
+      if (tab.state.repeatSourceKey) {
+        continue;
+      }
+
+      const layout = tab.getLayout();
+
+      if (layout instanceof TabsLayoutManager) {
+        for (const innerTab of layout.state.tabs) {
+          if (!innerTab.state.repeatSourceKey) {
+            innerTab.clearParent();
+            tabs.push(innerTab);
+          }
+        }
+      } else if (layout instanceof RowsLayoutManager) {
+        for (const row of layout.state.rows) {
+          if (!row.state.repeatSourceKey) {
+            tabs.push(convertRowToTab(row));
+          }
+        }
+      } else {
+        tabs.push(tab);
+      }
+    }
+
+    this.setState({ tabs, currentTabSlug: undefined });
   }
 
   public removeTab(tab: TabItem, skipUndo?: boolean) {

--- a/public/app/features/dashboard-scene/scene/layouts-shared/ConvertMixedGridsModal.tsx
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/ConvertMixedGridsModal.tsx
@@ -1,7 +1,7 @@
 import { t, Trans } from '@grafana/i18n';
 import { Modal, Button } from '@grafana/ui';
 
-import { layoutRegistry } from '../layouts-shared/layoutRegistry';
+import { layoutRegistry } from './layoutRegistry';
 
 interface ConvertMixedGridsModalProps {
   availableIds: Set<string>;

--- a/public/app/features/dashboard-scene/scene/layouts-shared/UngroupGroupsModal.tsx
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/UngroupGroupsModal.tsx
@@ -1,0 +1,65 @@
+import { t, Trans } from '@grafana/i18n';
+import { Alert, Button, Modal } from '@grafana/ui';
+
+import { type NestedGroupsTarget } from '../types/DashboardLayoutGroup';
+
+export interface UngroupGroupsModalProps {
+  /** When set, the tabs option is disabled and this text is shown as the tooltip */
+  disabledTabsReason?: string;
+  /** Warn that repeat options configured on the dissolved groups will be lost */
+  showRepeatLossWarning?: boolean;
+  onSelect: (target: NestedGroupsTarget) => void;
+  onDismiss: () => void;
+}
+
+export function UngroupGroupsModal({
+  disabledTabsReason,
+  showRepeatLossWarning,
+  onSelect,
+  onDismiss,
+}: UngroupGroupsModalProps) {
+  const select = (target: NestedGroupsTarget) => {
+    onSelect(target);
+    onDismiss();
+  };
+
+  return (
+    <Modal
+      isOpen={true}
+      title={t('dashboard.layout.ungroup-groups-title', 'Ungroup nested groups?')}
+      onDismiss={onDismiss}
+    >
+      <p>
+        <Trans i18nKey="dashboard.layout.ungroup-groups-text">
+          Nested groups will be moved up a level and converted to rows or tabs.
+        </Trans>
+      </p>
+      {showRepeatLossWarning && (
+        <Alert
+          severity="warning"
+          title={t(
+            'dashboard.layout.ungroup-repeat-loss',
+            'Repeat options configured on the ungrouped groups will be lost.'
+          )}
+        />
+      )}
+      <Modal.ButtonRow>
+        <Button variant="secondary" fill="outline" onClick={onDismiss}>
+          <Trans i18nKey="dashboard.layout.cancel">Cancel</Trans>
+        </Button>
+        <Button icon="list-ul" variant="primary" onClick={() => select('rows')}>
+          <Trans i18nKey="dashboard.layout.ungroup-convert-to-rows">Convert to rows</Trans>
+        </Button>
+        <Button
+          icon="window"
+          variant="primary"
+          disabled={Boolean(disabledTabsReason)}
+          tooltip={disabledTabsReason}
+          onClick={() => select('tabs')}
+        >
+          <Trans i18nKey="dashboard.layout.ungroup-convert-to-tabs">Convert to tabs</Trans>
+        </Button>
+      </Modal.ButtonRow>
+    </Modal>
+  );
+}

--- a/public/app/features/dashboard-scene/scene/layouts-shared/convertRowToTab.ts
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/convertRowToTab.ts
@@ -1,0 +1,23 @@
+import { type RowItem } from '../layout-rows/RowItem';
+import { TabItem } from '../layout-tabs/TabItem';
+
+export function convertRowToTab(row: RowItem): TabItem {
+  const conditionalRendering = row.state.conditionalRendering;
+  conditionalRendering?.clearParent();
+  // We need to clear the target since we don't want to point to the original row anymore (if it was set)
+  conditionalRendering?.setTarget(undefined);
+
+  const layout = row.state.layout;
+  layout.clearParent();
+
+  const $variables = row.state.$variables;
+  $variables?.clearParent();
+
+  return new TabItem({
+    layout,
+    title: row.state.title,
+    conditionalRendering,
+    repeatByVariable: row.state.repeatByVariable,
+    $variables,
+  });
+}

--- a/public/app/features/dashboard-scene/scene/layouts-shared/convertTabToRow.ts
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/convertTabToRow.ts
@@ -1,0 +1,23 @@
+import { RowItem } from '../layout-rows/RowItem';
+import { type TabItem } from '../layout-tabs/TabItem';
+
+export function convertTabToRow(tab: TabItem): RowItem {
+  const conditionalRendering = tab.state.conditionalRendering;
+  conditionalRendering?.clearParent();
+  // We need to clear the target since we don't want to point to the original tab anymore (if it was set)
+  conditionalRendering?.setTarget(undefined);
+
+  const layout = tab.state.layout;
+  layout.clearParent();
+
+  const $variables = tab.state.$variables;
+  $variables?.clearParent();
+
+  return new RowItem({
+    layout,
+    title: tab.state.title,
+    conditionalRendering,
+    repeatByVariable: tab.state.repeatByVariable,
+    $variables,
+  });
+}

--- a/public/app/features/dashboard-scene/scene/layouts-shared/moveSectionVariablesUp.ts
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/moveSectionVariablesUp.ts
@@ -1,5 +1,6 @@
 import { type SceneObject, SceneVariableSet } from '@grafana/scenes';
 
+import { filterSectionRepeatLocalVariables } from '../../variables/utils';
 import { type DashboardLayoutManager } from '../types/DashboardLayoutManager';
 
 /**
@@ -7,7 +8,12 @@ import { type DashboardLayoutManager } from '../types/DashboardLayoutManager';
  * up one level, to the object holding the layout (dashboard, row or tab), instead of losing them
  */
 export function moveSectionVariablesUp(items: SceneObject[], layout: DashboardLayoutManager) {
-  const variables = items.flatMap((item) => item.state.$variables?.state.variables ?? []);
+  // Repeater-injected local values are stripped: lifting them would shadow
+  // the real template variable of the same name on the parent
+  const variables = items.flatMap((item) => {
+    const variableSet = item.state.$variables;
+    return variableSet ? filterSectionRepeatLocalVariables(variableSet.state.variables, variableSet) : [];
+  });
   const target = layout.parent;
 
   if (variables.length === 0 || !target) {

--- a/public/app/features/dashboard-scene/scene/layouts-shared/moveSectionVariablesUp.ts
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/moveSectionVariablesUp.ts
@@ -1,0 +1,28 @@
+import { type SceneObject, SceneVariableSet } from '@grafana/scenes';
+
+import { type DashboardLayoutManager } from '../types/DashboardLayoutManager';
+
+/**
+ * Moves the section-level variables of items that are about to be dissolved during ungrouping
+ * up one level, to the object holding the layout (dashboard, row or tab), instead of losing them
+ */
+export function moveSectionVariablesUp(items: SceneObject[], layout: DashboardLayoutManager) {
+  const variables = items.flatMap((item) => item.state.$variables?.state.variables ?? []);
+  const target = layout.parent;
+
+  if (variables.length === 0 || !target) {
+    return;
+  }
+
+  for (const variable of variables) {
+    variable.clearParent();
+  }
+
+  const targetVariableSet = target.state.$variables;
+
+  if (targetVariableSet instanceof SceneVariableSet) {
+    targetVariableSet.setState({ variables: [...targetVariableSet.state.variables, ...variables] });
+  } else {
+    target.setState({ $variables: new SceneVariableSet({ variables }) });
+  }
+}

--- a/public/app/features/dashboard-scene/scene/layouts-shared/ungroupConfirmation.tsx
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/ungroupConfirmation.tsx
@@ -2,55 +2,28 @@ import { t } from '@grafana/i18n';
 import { appEvents } from 'app/core/app_events';
 import { ShowConfirmModalEvent, ShowModalReactEvent } from 'app/types/events';
 
-import { ConvertMixedGridsModal } from '../layout-rows/ConvertMixedGridsModal';
+import { type NestedGroupsTarget } from '../types/DashboardLayoutGroup';
 
+import { ConvertMixedGridsModal } from './ConvertMixedGridsModal';
+import { UngroupGroupsModal } from './UngroupGroupsModal';
 import { type GridLayoutType, mapIdToGridLayoutType } from './utils';
 
 export interface UngroupConfirmationOptions {
-  hasNonGridLayout: boolean;
   gridTypes: Set<string>;
   onConfirm: (gridLayoutType: GridLayoutType) => void;
   onConvertMixedGrids: (availableIds: Set<string>) => void;
 }
 
-export function showUngroupConfirmation({
-  hasNonGridLayout,
-  gridTypes,
-  onConfirm,
-  onConvertMixedGrids,
-}: UngroupConfirmationOptions) {
-  if (hasNonGridLayout) {
-    appEvents.publish(
-      new ShowConfirmModalEvent({
-        title: t('dashboard.layout.ungroup-nested-title', 'Ungroup nested groups?'),
-        text: t('dashboard.layout.ungroup-nested-text', 'This will ungroup all nested groups.'),
-        yesText: t('dashboard.layout.continue', 'Continue'),
-        noText: t('dashboard.layout.cancel', 'Cancel'),
-        onConfirm: () => {
-          if (gridTypes.size > 1) {
-            requestAnimationFrame(() => {
-              onConvertMixedGrids(gridTypes);
-            });
-          } else {
-            const gridLayoutType = mapIdToGridLayoutType(gridTypes.values().next().value);
-            if (gridLayoutType) {
-              onConfirm(gridLayoutType);
-            }
-          }
-        },
-      })
-    );
-    return;
-  }
-
+/** Grid-only ungroup: merge grids directly, or ask for the grid type when grids are mixed */
+export function showUngroupConfirmation({ gridTypes, onConfirm, onConvertMixedGrids }: UngroupConfirmationOptions) {
   if (gridTypes.size > 1) {
     onConvertMixedGrids(gridTypes);
     return;
-  } else {
-    const gridLayoutType = mapIdToGridLayoutType(gridTypes.values().next().value);
-    if (gridLayoutType) {
-      onConfirm(gridLayoutType);
-    }
+  }
+
+  const gridLayoutType = mapIdToGridLayoutType(gridTypes.values().next().value);
+  if (gridLayoutType) {
+    onConfirm(gridLayoutType);
   }
 }
 
@@ -62,6 +35,38 @@ export function showConvertMixedGridsModal(availableIds: Set<string>, onSelect: 
         availableIds,
         onSelect,
       },
+    })
+  );
+}
+
+export interface UngroupGroupsOptions {
+  disabledTabsReason?: string;
+  showRepeatLossWarning?: boolean;
+  onSelect: (target: NestedGroupsTarget) => void;
+}
+
+/** Ask the user how nested groups should be ungrouped: converted to rows or to tabs */
+export function showUngroupGroupsModal(props: UngroupGroupsOptions) {
+  appEvents.publish(
+    new ShowModalReactEvent({
+      component: UngroupGroupsModal,
+      props,
+    })
+  );
+}
+
+/** Confirm ungrouping when repeat options configured on the dissolved groups would be lost */
+export function showRepeatLossConfirmation(onConfirm: () => void) {
+  appEvents.publish(
+    new ShowConfirmModalEvent({
+      title: t('dashboard.layout.ungroup-repeat-loss-title', 'Ungroup?'),
+      text: t(
+        'dashboard.layout.ungroup-repeat-loss',
+        'Repeat options configured on the ungrouped groups will be lost.'
+      ),
+      yesText: t('dashboard.layout.continue', 'Continue'),
+      noText: t('dashboard.layout.cancel', 'Cancel'),
+      onConfirm,
     })
   );
 }

--- a/public/app/features/dashboard-scene/scene/layouts-shared/utils.ts
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/utils.ts
@@ -3,6 +3,8 @@ import { useEffect, useRef } from 'react';
 import { config } from '@grafana/runtime';
 import { contextSrv } from 'app/core/services/context_srv';
 
+import { type RowItem } from '../layout-rows/RowItem';
+import { type TabItem } from '../layout-tabs/TabItem';
 import { type DashboardLayoutManager } from '../types/DashboardLayoutManager';
 import { isLayoutParent } from '../types/LayoutParent';
 import { type LayoutRegistryItem } from '../types/LayoutRegistryItem';
@@ -54,6 +56,24 @@ export function generateUniqueTitle(title: string | undefined, existingTitles: S
   }
 
   return baseTitle;
+}
+
+export function deduplicateTitles(items: TabItem[] | RowItem[]) {
+  const existingTitles = new Set<string>();
+
+  for (const item of items) {
+    if (!item.state.title) {
+      continue;
+    }
+
+    const uniqueTitle = generateUniqueTitle(item.state.title, existingTitles);
+
+    if (uniqueTitle !== item.state.title) {
+      item.setState({ title: uniqueTitle });
+    }
+
+    existingTitles.add(uniqueTitle);
+  }
 }
 
 function switchLayoutOnParent(current: DashboardLayoutManager, newLayout: DashboardLayoutManager, skipUndo?: boolean) {

--- a/public/app/features/dashboard-scene/scene/types/DashboardLayoutGroup.ts
+++ b/public/app/features/dashboard-scene/scene/types/DashboardLayoutGroup.ts
@@ -2,12 +2,21 @@ import { type GridLayoutType } from '../layouts-shared/utils';
 
 import { type DashboardLayoutManager } from './DashboardLayoutManager';
 
+export type NestedGroupsTarget = 'rows' | 'tabs';
+
 export interface DashboardLayoutGroup extends DashboardLayoutManager {
   /**
-   * Ungroup the group
+   * Flatten the group and all nested groups into a single grid of the given type
    * @param gridLayoutType
    */
   ungroup(gridLayoutType: GridLayoutType): void;
+
+  /**
+   * Remove this grouping level while preserving content structure:
+   * nested groups are hoisted up a level and other children are converted to the target group type
+   * @param target
+   */
+  hoistNestedGroups(target: NestedGroupsTarget): void;
 
   /**
    * Convert all layouts to the given grid layout type

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -5914,8 +5914,12 @@
         }
       },
       "scroll-content": "Dashboard content",
-      "ungroup-nested-text": "This will ungroup all nested groups.",
-      "ungroup-nested-title": "Ungroup nested groups?"
+      "ungroup-convert-to-rows": "Convert to rows",
+      "ungroup-convert-to-tabs": "Convert to tabs",
+      "ungroup-groups-text": "Nested groups will be moved up a level and converted to rows or tabs.",
+      "ungroup-groups-title": "Ungroup nested groups?",
+      "ungroup-repeat-loss": "Repeat options configured on the ungrouped groups will be lost.",
+      "ungroup-repeat-loss-title": "Ungroup?"
     },
     "minimalistic-pagination": {
       "page-count": "{{currentPage}} of {{numberOfPages}}",


### PR DESCRIPTION
**What is this feature?**

This PR improves the ungrouping of top-level groups.

1. If the top-level groups contain the same type of inner structures, they are maintained as they are.
2. If the top-level groups contain different types of inner structures (i.e. some contain tabs, some contain rows), the user has to pick what the result should be: tabs or rows.
3. If the top-level groups contain any type of inner structures but some contain grids, the grids would be wrapped in a container according to rule 2.
4. If the top-level groups do not contain any inner structures but they all contain grids, the user has to pick what grid they want the result to be.

**Why do we need this feature?**

Maintain inner structures when ungrouping top-level groups.

**Who is this feature for?**

Users who want to ungroup top-level groups.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/127841

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
