### PR TITLE
fix: use rune count for dashboard tag character limit, raise to 100

### DIFF
--- a/pkg/registry/apis/dashboard/register.go
+++ b/pkg/registry/apis/dashboard/register.go
@@ -7,6 +7,7 @@ import (
 	"maps"
 	"strconv"
 	"sync"
+	"unicode/utf8"
 
 	"github.com/prometheus/client_golang/prometheus"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -794,7 +795,7 @@ func validateDashboardTags(obj runtime.Object) error {
 	}
 
 	for _, tag := range tags {
-		if len(tag) > 50 {
+		if utf8.RuneCountInString(tag) > 100 {
 			return dashboards.ErrDashboardTagTooLong
 		}
 	}

--- a/pkg/services/dashboards/errors.go
+++ b/pkg/services/dashboards/errors.go
@@ -57,7 +57,7 @@ var (
 		StatusCode: 400,
 	}
 	ErrDashboardTagTooLong = dashboardaccess.DashboardErr{
-		Reason:     "dashboard tag too long, max 50 characters",
+		Reason:     "dashboard tag too long, max 100 characters",
 		StatusCode: 400,
 		Status:     "tag-too-long",
 	}

--- a/pkg/services/sqlstore/migrations/dashboard_mig.go
+++ b/pkg/services/sqlstore/migrations/dashboard_mig.go
@@ -266,6 +266,10 @@ func addDashboardMigration(mg *Migrator) {
 		Cols: []string{"dashboard_uid"},
 		Type: IndexType,
 	}))
+
+	mg.AddMigration("widen dashboard_tag.term column from 50 to 100", NewRawSQLMigration("").
+		Postgres("ALTER TABLE dashboard_tag ALTER COLUMN term TYPE VARCHAR(100);").
+		Mysql("ALTER TABLE dashboard_tag MODIFY term VARCHAR(100);"))
 }
 
 type FillDashbordUIDAndOrgIDMigration struct {

--- a/public/app/features/manage-dashboards/import/utils/validation.ts
+++ b/public/app/features/manage-dashboards/import/utils/validation.ts
@@ -18,9 +18,9 @@ export const validateDashboardJson = (json: string) => {
       if (hasInvalidTag) {
         return t('dashboard.validation.tags-expected-strings', 'tags expected array of strings');
       }
-      const hasTooLongTag = dashboard.tags.some((tag: string) => tag.length > 50);
+      const hasTooLongTag = dashboard.tags.some((tag: string) => tag.length > 100);
       if (hasTooLongTag) {
-        return t('dashboard.validation.tag-too-long', 'Dashboard tag too long, max 50 characters');
+        return t('dashboard.validation.tag-too-long', 'Dashboard tag too long, max 100 characters');
       }
     } else {
       return t('dashboard.validation.tags-expected-array', 'tags expected array');


### PR DESCRIPTION
## Description

This PR fixes the dashboard tag character limit issue where the validation used Go's `len()` (UTF-8 bytes) instead of actual character count. A tag of 50 characters containing a multi-byte code point (e.g. Cyrillic, CJK, emoji) was incorrectly rejected, and the error message misleadingly said "characters" while counting bytes.

### Changes

1. **Backend validation** (`pkg/registry/apis/dashboard/register.go`): Changed `len(tag) > 50` to `utf8.RuneCountInString(tag) > 100` — counts actual Unicode characters, not bytes. Raised the limit to 100 characters to match alerting labels (which have no length limit).

2. **Error message** (`pkg/services/dashboards/errors.go`): Updated to reflect the new 100-character limit.

3. **Frontend validation** (`public/app/features/manage-dashboards/import/utils/validation.ts`): Updated to match the new 100-character limit.

4. **DB migration** (`pkg/services/sqlstore/migrations/dashboard_mig.go`): Added migration to widen `dashboard_tag.term` column from NVARCHAR(50) to NVARCHAR(100) for PostgreSQL and MySQL (SQLite does not enforce column length).

### Testing

- A tag of 50 ASCII characters → 200 OK (unchanged behavior)
- A tag of 49 ASCII + 1 Cyrillic character → 200 OK (previously rejected as 51 bytes)
- A tag of 101 ASCII characters → 400 (correctly rejected)
- A tag of 100 CJK characters → 200 OK (100 characters, 300 bytes — new limit)

### Related Issues

Fixes #129193