### PR TITLE
Dashboards: Show "Add row" and "Add tab" when dashboard is empty

### DIFF
--- a/public/app/features/dashboard-scene/scene/layouts-shared/useIsLayoutEmpty.ts
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/useIsLayoutEmpty.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+
+import { SceneObjectStateChangedEvent } from '@grafana/scenes';
+
+import { type DashboardLayoutManager } from '../types/DashboardLayoutManager';
+
+/**
+ * Whether the layout currently contains no panels. Scene state change events
+ * bubble up the graph, so subscribing on the layout manager also reacts to
+ * panels being added or removed anywhere in its subtree.
+ */
+export function useIsLayoutEmpty(layout: DashboardLayoutManager): boolean {
+  const [isEmpty, setIsEmpty] = useState(() => layout.getVizPanels().length === 0);
+
+  useEffect(() => {
+    setIsEmpty(layout.getVizPanels().length === 0);
+
+    const sub = layout.subscribeToEvent(SceneObjectStateChangedEvent, () => {
+      setIsEmpty(layout.getVizPanels().length === 0);
+    });
+
+    return () => sub.unsubscribe();
+  }, [layout]);
+
+  return isEmpty;
+}

--- a/public/app/features/dashboard-scene/sidebar/add-new/AddRow.test.tsx
+++ b/public/app/features/dashboard-scene/sidebar/add-new/AddRow.test.tsx
@@ -1,6 +1,9 @@
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
+import { VizPanel } from '@grafana/scenes';
+
+import { AutoGridItem } from '../../scene/layout-auto-grid/AutoGridItem';
 import { AutoGridLayoutManager } from '../../scene/layout-auto-grid/AutoGridLayoutManager';
 import { RowItem } from '../../scene/layout-rows/RowItem';
 import { RowsLayoutManager } from '../../scene/layout-rows/RowsLayoutManager';
@@ -41,13 +44,35 @@ jest.mock('./AddButton', () => ({
 const mockedAddNewRowTo = jest.mocked(addNewRowTo);
 const mockedUseNestingRestrictions = jest.mocked(useNestingRestrictions);
 
+function createAutoGridWithPanel(): AutoGridLayoutManager {
+  const layout = AutoGridLayoutManager.createEmpty();
+  layout.state.layout.setState({
+    children: [new AutoGridItem({ body: new VizPanel({ pluginId: 'timeseries' }) })],
+  });
+  return layout;
+}
+
 describe('AddRow', () => {
   beforeEach(() => {
     mockedAddNewRowTo.mockReset();
     mockedUseNestingRestrictions.mockReset();
   });
 
-  it('shows "Group into rows" label when layout is not rows', () => {
+  it('shows "Group into rows" label when layout is not rows and has panels', () => {
+    mockedUseNestingRestrictions.mockReturnValue({
+      disableGrouping: false,
+      disableTabs: false,
+      disableTabsReason: undefined,
+    });
+    const layout = createAutoGridWithPanel();
+    const dashboardScene = { getLayout: () => layout } as never;
+
+    render(<AddRow dashboardScene={dashboardScene} selectedElement={undefined} />);
+
+    expect(screen.getByRole('button', { name: 'Group into rows' })).toBeEnabled();
+  });
+
+  it('shows "Add row" label when layout is empty', () => {
     mockedUseNestingRestrictions.mockReturnValue({
       disableGrouping: false,
       disableTabs: false,
@@ -58,7 +83,7 @@ describe('AddRow', () => {
 
     render(<AddRow dashboardScene={dashboardScene} selectedElement={undefined} />);
 
-    expect(screen.getByRole('button', { name: 'Group into rows' })).toBeEnabled();
+    expect(screen.getByRole('button', { name: 'Add row' })).toBeEnabled();
   });
 
   it('shows "Add row" label when layout is rows', () => {
@@ -75,13 +100,35 @@ describe('AddRow', () => {
     expect(screen.getByRole('button', { name: 'Add row' })).toBeEnabled();
   });
 
+  it('updates label from "Add row" to "Group into rows" when a panel is added', () => {
+    mockedUseNestingRestrictions.mockReturnValue({
+      disableGrouping: false,
+      disableTabs: false,
+      disableTabsReason: undefined,
+    });
+    const layout = AutoGridLayoutManager.createEmpty();
+    const dashboardScene = { getLayout: () => layout } as never;
+
+    render(<AddRow dashboardScene={dashboardScene} selectedElement={undefined} />);
+
+    expect(screen.getByRole('button', { name: 'Add row' })).toBeEnabled();
+
+    act(() => {
+      layout.state.layout.setState({
+        children: [new AutoGridItem({ body: new VizPanel({ pluginId: 'timeseries' }) })],
+      });
+    });
+
+    expect(screen.getByRole('button', { name: 'Group into rows' })).toBeEnabled();
+  });
+
   it('disables row action at max nesting depth and shows tooltip', () => {
     mockedUseNestingRestrictions.mockReturnValue({
       disableGrouping: true,
       disableTabs: true,
       disableTabsReason: 'max-depth',
     });
-    const layout = AutoGridLayoutManager.createEmpty();
+    const layout = createAutoGridWithPanel();
     const dashboardScene = { getLayout: () => layout } as never;
 
     render(<AddRow dashboardScene={dashboardScene} selectedElement={undefined} />);
@@ -97,7 +144,7 @@ describe('AddRow', () => {
       disableTabs: false,
       disableTabsReason: undefined,
     });
-    const layout = AutoGridLayoutManager.createEmpty();
+    const layout = createAutoGridWithPanel();
     const dashboardScene = { getLayout: () => layout } as never;
     const user = userEvent.setup();
 
@@ -116,7 +163,7 @@ describe('AddRow', () => {
       disableTabsReason: undefined,
     });
     const rootLayout = AutoGridLayoutManager.createEmpty();
-    const rowInnerLayout = AutoGridLayoutManager.createEmpty();
+    const rowInnerLayout = createAutoGridWithPanel();
     const selectedRow = new RowItem({ layout: rowInnerLayout });
     const dashboardScene = { getLayout: () => rootLayout } as never;
     const user = userEvent.setup();
@@ -136,7 +183,7 @@ describe('AddRow', () => {
       disableTabsReason: undefined,
     });
     const rootLayout = AutoGridLayoutManager.createEmpty();
-    const tabInnerLayout = AutoGridLayoutManager.createEmpty();
+    const tabInnerLayout = createAutoGridWithPanel();
     const selectedTab = new TabItem({ layout: tabInnerLayout });
     const dashboardScene = { getLayout: () => rootLayout } as never;
     const user = userEvent.setup();

--- a/public/app/features/dashboard-scene/sidebar/add-new/AddRow.tsx
+++ b/public/app/features/dashboard-scene/sidebar/add-new/AddRow.tsx
@@ -6,6 +6,7 @@ import { type SceneObject } from '@grafana/scenes';
 import { RowsLayoutManager } from '../../scene/layout-rows/RowsLayoutManager';
 import { addNewRowTo } from '../../scene/layouts-shared/addNew';
 import { getNestingRestrictionMessage, useNestingRestrictions } from '../../scene/layouts-shared/nestingRestrictions';
+import { useIsLayoutEmpty } from '../../scene/layouts-shared/useIsLayoutEmpty';
 import { isLayoutParent } from '../../scene/types/LayoutParent';
 import { type DashboardSceneLike } from '../../scene/types/dashboard';
 
@@ -26,14 +27,16 @@ export function AddRow({ dashboardScene, selectedElement }: AddRowProps) {
   }, [dashboardScene, selectedElement]);
 
   const { disableGrouping } = useNestingRestrictions(layout);
+  const isLayoutEmpty = useIsLayoutEmpty(layout);
 
   const label = useMemo(() => {
-    if (layout instanceof RowsLayoutManager) {
+    // With no panels there is nothing to group, so present the action as a plain "add"
+    if (layout instanceof RowsLayoutManager || isLayoutEmpty) {
       return t('dashboard-scene.add-row.add-label', 'Add row');
     }
 
     return t('dashboard-scene.add-row.group-label', 'Group into rows');
-  }, [layout]);
+  }, [layout, isLayoutEmpty]);
 
   const onAddRowClick = useCallback(() => {
     addNewRowTo(layout);

--- a/public/app/features/dashboard-scene/sidebar/add-new/AddTab.test.tsx
+++ b/public/app/features/dashboard-scene/sidebar/add-new/AddTab.test.tsx
@@ -1,6 +1,9 @@
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
+import { VizPanel } from '@grafana/scenes';
+
+import { AutoGridItem } from '../../scene/layout-auto-grid/AutoGridItem';
 import { AutoGridLayoutManager } from '../../scene/layout-auto-grid/AutoGridLayoutManager';
 import { RowItem } from '../../scene/layout-rows/RowItem';
 import { TabsLayoutManager } from '../../scene/layout-tabs/TabsLayoutManager';
@@ -40,13 +43,35 @@ jest.mock('./AddButton', () => ({
 const mockedAddNewTabTo = jest.mocked(addNewTabTo);
 const mockedUseNestingRestrictions = jest.mocked(useNestingRestrictions);
 
+function createAutoGridWithPanel(): AutoGridLayoutManager {
+  const layout = AutoGridLayoutManager.createEmpty();
+  layout.state.layout.setState({
+    children: [new AutoGridItem({ body: new VizPanel({ pluginId: 'timeseries' }) })],
+  });
+  return layout;
+}
+
 describe('AddTab', () => {
   beforeEach(() => {
     mockedAddNewTabTo.mockReset();
     mockedUseNestingRestrictions.mockReset();
   });
 
-  it('shows "Group into tabs" label when layout is not tabs', () => {
+  it('shows "Group into tabs" label when layout is not tabs and has panels', () => {
+    mockedUseNestingRestrictions.mockReturnValue({
+      disableGrouping: false,
+      disableTabs: false,
+      disableTabsReason: undefined,
+    });
+    const layout = createAutoGridWithPanel();
+    const dashboardScene = { getLayout: () => layout } as never;
+
+    render(<AddTab dashboardScene={dashboardScene} selectedElement={undefined} />);
+
+    expect(screen.getByRole('button', { name: 'Group into tabs' })).toBeEnabled();
+  });
+
+  it('shows "Add tab" label when layout is empty', () => {
     mockedUseNestingRestrictions.mockReturnValue({
       disableGrouping: false,
       disableTabs: false,
@@ -56,6 +81,28 @@ describe('AddTab', () => {
     const dashboardScene = { getLayout: () => layout } as never;
 
     render(<AddTab dashboardScene={dashboardScene} selectedElement={undefined} />);
+
+    expect(screen.getByRole('button', { name: 'Add tab' })).toBeEnabled();
+  });
+
+  it('updates label from "Add tab" to "Group into tabs" when a panel is added', () => {
+    mockedUseNestingRestrictions.mockReturnValue({
+      disableGrouping: false,
+      disableTabs: false,
+      disableTabsReason: undefined,
+    });
+    const layout = AutoGridLayoutManager.createEmpty();
+    const dashboardScene = { getLayout: () => layout } as never;
+
+    render(<AddTab dashboardScene={dashboardScene} selectedElement={undefined} />);
+
+    expect(screen.getByRole('button', { name: 'Add tab' })).toBeEnabled();
+
+    act(() => {
+      layout.state.layout.setState({
+        children: [new AutoGridItem({ body: new VizPanel({ pluginId: 'timeseries' }) })],
+      });
+    });
 
     expect(screen.getByRole('button', { name: 'Group into tabs' })).toBeEnabled();
   });
@@ -80,7 +127,7 @@ describe('AddTab', () => {
       disableTabs: true,
       disableTabsReason: 'nested-tabs',
     });
-    const layout = AutoGridLayoutManager.createEmpty();
+    const layout = createAutoGridWithPanel();
     const dashboardScene = { getLayout: () => layout } as never;
 
     render(<AddTab dashboardScene={dashboardScene} selectedElement={undefined} />);
@@ -96,7 +143,7 @@ describe('AddTab', () => {
       disableTabs: true,
       disableTabsReason: 'max-depth',
     });
-    const layout = AutoGridLayoutManager.createEmpty();
+    const layout = createAutoGridWithPanel();
     const dashboardScene = { getLayout: () => layout } as never;
 
     render(<AddTab dashboardScene={dashboardScene} selectedElement={undefined} />);
@@ -113,7 +160,7 @@ describe('AddTab', () => {
       disableTabs: true,
       disableTabsReason: 'max-depth',
     });
-    const layout = AutoGridLayoutManager.createEmpty();
+    const layout = createAutoGridWithPanel();
     const dashboardScene = { getLayout: () => layout } as never;
 
     render(<AddTab dashboardScene={dashboardScene} selectedElement={undefined} />);
@@ -129,7 +176,7 @@ describe('AddTab', () => {
       disableTabs: false,
       disableTabsReason: undefined,
     });
-    const layout = AutoGridLayoutManager.createEmpty();
+    const layout = createAutoGridWithPanel();
     const dashboardScene = { getLayout: () => layout } as never;
     const user = userEvent.setup();
 
@@ -148,7 +195,7 @@ describe('AddTab', () => {
       disableTabsReason: undefined,
     });
     const rootLayout = AutoGridLayoutManager.createEmpty();
-    const rowInnerLayout = AutoGridLayoutManager.createEmpty();
+    const rowInnerLayout = createAutoGridWithPanel();
     const selectedRow = new RowItem({ layout: rowInnerLayout });
     const dashboardScene = { getLayout: () => rootLayout } as never;
     const user = userEvent.setup();

--- a/public/app/features/dashboard-scene/sidebar/add-new/AddTab.tsx
+++ b/public/app/features/dashboard-scene/sidebar/add-new/AddTab.tsx
@@ -6,6 +6,7 @@ import { type SceneObject } from '@grafana/scenes';
 import { TabsLayoutManager } from '../../scene/layout-tabs/TabsLayoutManager';
 import { addNewTabTo } from '../../scene/layouts-shared/addNew';
 import { getDisableTabsMessage, useNestingRestrictions } from '../../scene/layouts-shared/nestingRestrictions';
+import { useIsLayoutEmpty } from '../../scene/layouts-shared/useIsLayoutEmpty';
 import { isLayoutParent } from '../../scene/types/LayoutParent';
 import { type DashboardSceneLike } from '../../scene/types/dashboard';
 
@@ -25,14 +26,16 @@ export function AddTab({ dashboardScene, selectedElement }: AddTabProps) {
   }, [dashboardScene, selectedElement]);
 
   const { disableTabs, disableTabsReason } = useNestingRestrictions(layout);
+  const isLayoutEmpty = useIsLayoutEmpty(layout);
 
   const label = useMemo(() => {
-    if (layout instanceof TabsLayoutManager) {
+    // With no panels there is nothing to group, so present the action as a plain "add"
+    if (layout instanceof TabsLayoutManager || isLayoutEmpty) {
       return t('dashboard-scene.add-tab.add-label', 'Add tab');
     }
 
     return t('dashboard-scene.add-tab.group-label', 'Group into tabs');
-  }, [layout]);
+  }, [layout, isLayoutEmpty]);
 
   const disabledTooltip = useMemo(() => getDisableTabsMessage(disableTabsReason), [disableTabsReason]);
 


### PR DESCRIPTION
**What is this feature?**

Show "Add row" and "Add tab" instead of "Group into rows" and "Group into tabs" when dashboard is empty.

**Why do we need this feature?**

Reduce confusion.

**Who is this feature for?**

-

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/121832

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
