### PR TITLE
AdHocTransforms: PoC dashboard schema and plugin capability - frontend plumbing

### DIFF
--- a/packages/grafana-data/src/index.ts
+++ b/packages/grafana-data/src/index.ts
@@ -306,6 +306,7 @@ export {
   doStandardCalcs,
 } from './transformations/fieldReducer';
 export { transformDataFrame } from './transformations/transformDataFrame';
+export { transformPanelData } from './transformations/transformPanelData';
 export {
   type TransformerRegistryItem,
   type TransformerUIProps,

--- a/packages/grafana-data/src/transformations/transformPanelData.test.ts
+++ b/packages/grafana-data/src/transformations/transformPanelData.test.ts
@@ -1,0 +1,143 @@
+import { lastValueFrom } from 'rxjs';
+
+import { toDataFrame } from '../dataframe/processDataFrame';
+import { LoadingState } from '../types/data';
+import { FieldType } from '../types/dataFrame';
+import { type PanelData } from '../types/panel';
+import { DataTopic } from '../types/query';
+import { type DataTransformerConfig } from '../types/transformations';
+
+import { standardTransformersRegistry, type TransformerRegistryItem } from './standardTransformersRegistry';
+import { transformPanelData } from './transformPanelData';
+import { limitTransformer } from './transformers/limit';
+import { organizeFieldsTransformer } from './transformers/organize';
+
+beforeAll(() => {
+  standardTransformersRegistry.setInit(
+    () =>
+      [
+        {
+          id: organizeFieldsTransformer.id,
+          name: organizeFieldsTransformer.name,
+          transformation: () => Promise.resolve(organizeFieldsTransformer),
+          editor: () => null,
+        },
+        {
+          id: limitTransformer.id,
+          name: limitTransformer.name,
+          transformation: () => Promise.resolve(limitTransformer),
+          editor: () => null,
+        },
+      ] as unknown as TransformerRegistryItem[]
+  );
+});
+
+function panelData(overrides: Partial<PanelData> = {}): PanelData {
+  return {
+    state: LoadingState.Done,
+    series: [
+      toDataFrame({
+        refId: 'A',
+        fields: [
+          { name: 'keep', type: FieldType.number, values: [1, 2, 3] },
+          { name: 'drop', type: FieldType.number, values: [4, 5, 6] },
+        ],
+      }),
+    ],
+    timeRange: { from: {}, to: {}, raw: { from: 'now-6h', to: 'now' } } as PanelData['timeRange'],
+    ...overrides,
+  };
+}
+
+describe('transformPanelData', () => {
+  it('applies series transformations to series frames', async () => {
+    const configs: DataTransformerConfig[] = [{ id: 'organize', options: { excludeByName: { drop: true } } }];
+
+    const result = await lastValueFrom(transformPanelData(configs, panelData()));
+
+    expect(result.series[0].fields.map((f) => f.name)).toEqual(['keep']);
+  });
+
+  it('preserves the rest of the PanelData', async () => {
+    const input = panelData({ state: LoadingState.Streaming });
+
+    const result = await lastValueFrom(transformPanelData([{ id: 'organize', options: {} }], input));
+
+    expect(result.state).toBe(LoadingState.Streaming);
+    expect(result.timeRange).toBe(input.timeRange);
+  });
+
+  // Real annotation frames carry meta.dataTopic (the annotations data layer sets it) and output is
+  // bucketed by that, exactly as the host pipeline does.
+  function annotationFrame(values: string[]) {
+    return toDataFrame({
+      meta: { dataTopic: DataTopic.Annotations },
+      fields: [{ name: 'text', type: FieldType.string, values }],
+    });
+  }
+
+  it('routes annotation-topic transformations to annotations only', async () => {
+    const input = panelData({ annotations: [annotationFrame(['a', 'b', 'c'])] });
+    const configs: DataTransformerConfig[] = [
+      { id: 'limit', options: { limitField: 1 }, topic: DataTopic.Annotations },
+    ];
+
+    const result = await lastValueFrom(transformPanelData(configs, input));
+
+    expect(result.annotations?.[0].length).toBe(1);
+    // Series untouched.
+    expect(result.series[0].length).toBe(3);
+  });
+
+  it('treats a config with no topic as a series transformation', async () => {
+    const input = panelData({ annotations: [annotationFrame(['a', 'b'])] });
+
+    const result = await lastValueFrom(transformPanelData([{ id: 'limit', options: { limitField: 1 } }], input));
+
+    expect(result.series[0].length).toBe(1);
+    expect(result.annotations?.[0].length).toBe(2);
+  });
+
+  it('drops alertStates-topic transformations rather than running them against series', async () => {
+    const configs: DataTransformerConfig[] = [
+      { id: 'organize', options: { excludeByName: { drop: true } }, topic: DataTopic.AlertStates },
+    ];
+
+    const result = await lastValueFrom(transformPanelData(configs, panelData()));
+
+    expect(result.series[0].fields.map((f) => f.name)).toEqual(['keep', 'drop']);
+  });
+
+  it('buckets output frames by dataTopic, so a transformation can move frames between topics', async () => {
+    const input = panelData({
+      series: [
+        toDataFrame({
+          refId: 'A',
+          meta: { dataTopic: DataTopic.Annotations },
+          fields: [{ name: 'text', type: FieldType.string, values: ['a'] }],
+        }),
+      ],
+    });
+
+    const result = await lastValueFrom(transformPanelData([{ id: 'organize', options: {} }], input));
+
+    expect(result.series).toHaveLength(0);
+    expect(result.annotations).toHaveLength(1);
+  });
+
+  it('leaves annotations undefined when the input had none', async () => {
+    const result = await lastValueFrom(transformPanelData([{ id: 'organize', options: {} }], panelData()));
+
+    expect(result.annotations).toBeUndefined();
+  });
+
+  it('skips disabled transformations', async () => {
+    const configs: DataTransformerConfig[] = [
+      { id: 'organize', options: { excludeByName: { drop: true } }, disabled: true },
+    ];
+
+    const result = await lastValueFrom(transformPanelData(configs, panelData()));
+
+    expect(result.series[0].fields.map((f) => f.name)).toEqual(['keep', 'drop']);
+  });
+});

--- a/packages/grafana-data/src/transformations/transformPanelData.ts
+++ b/packages/grafana-data/src/transformations/transformPanelData.ts
@@ -1,0 +1,96 @@
+import { forkJoin, type Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+import { type DataFrame } from '../types/dataFrame';
+import { type PanelData } from '../types/panel';
+import { DataTopic } from '../types/query';
+import {
+  type CustomTransformOperator,
+  type DataTransformContext,
+  type DataTransformerConfig,
+} from '../types/transformations';
+
+import { transformDataFrame } from './transformDataFrame';
+
+type Transformations = Array<DataTransformerConfig | CustomTransformOperator>;
+
+/**
+ * Splits a pipeline into the frames it applies to. A config with no topic targets series, which
+ * is the overwhelmingly common case. Configs targeting alert states are dropped rather than
+ * silently run against series.
+ */
+function partitionByTopic(transformations: Transformations): [Transformations, Transformations] {
+  const series: Transformations = [];
+  const annotations: Transformations = [];
+
+  for (const transformation of transformations) {
+    // Custom operators are functions and carry no topic, so they target series.
+    const topic = typeof transformation === 'function' ? undefined : transformation.topic;
+
+    if (topic == null || topic === DataTopic.Series) {
+      series.push(transformation);
+    } else if (topic === DataTopic.Annotations) {
+      annotations.push(transformation);
+    }
+  }
+
+  return [series, annotations];
+}
+
+/**
+ * Transformations are free to move frames between topics (an annotation transformation can emit
+ * series frames and vice versa), so the results are re-bucketed by frame metadata rather than by
+ * which input they came from. A frame therefore has to carry `meta.dataTopic` to be treated as an
+ * annotation — which real annotation frames do, and which matches how the host pipeline buckets.
+ */
+function bucketByDataTopic(results: DataFrame[][]): { series: DataFrame[]; annotations: DataFrame[] } {
+  const series: DataFrame[] = [];
+  const annotations: DataFrame[] = [];
+
+  for (const frames of results) {
+    for (const frame of frames) {
+      if (frame.meta?.dataTopic === DataTopic.Annotations) {
+        annotations.push(frame);
+      } else {
+        series.push(frame);
+      }
+    }
+  }
+
+  return { series, annotations };
+}
+
+/**
+ * Applies a transformation pipeline to a whole `PanelData`, routing each transformation to the
+ * series or annotation frames according to its `topic` and re-bucketing the output.
+ *
+ * Use this instead of calling `transformDataFrame` directly whenever you hold a `PanelData` — for
+ * example in a panel that declares `adHocTransforms` and therefore applies its own pipeline.
+ *
+ * Template variables are NOT interpolated here. `transformDataFrame` deliberately skips
+ * interpolation inside a scene, so callers must pass configs that are already interpolated.
+ */
+export function transformPanelData(
+  transformations: Transformations,
+  data: PanelData,
+  ctx?: DataTransformContext
+): Observable<PanelData> {
+  const [seriesTransformations, annotationsTransformations] = partitionByTopic(transformations);
+
+  return forkJoin([
+    transformDataFrame(seriesTransformations, data.series, ctx),
+    transformDataFrame(annotationsTransformations, data.annotations ?? [], ctx),
+  ]).pipe(
+    map((results) => {
+      const { series, annotations } = bucketByDataTopic(results);
+
+      return {
+        ...data,
+        series,
+        // Preserve "no annotations" rather than turning it into an empty array, which some
+        // consumers treat as a meaningful difference.
+        annotations: annotations.length > 0 || data.annotations ? annotations : undefined,
+      };
+    })
+  );
+}

--- a/packages/grafana-data/src/types/panel.ts
+++ b/packages/grafana-data/src/types/panel.ts
@@ -21,6 +21,11 @@ export type InterpolateFunction = (value: string, scopedVars?: ScopedVars, forma
 export interface PanelPluginMeta extends PluginMeta {
   /** Indicates that panel does not issue queries */
   skipDataQuery?: boolean;
+  /**
+   * Indicates the panel renders its own transformation UI and applies the transformation
+   * pipeline itself. The host skips the pipeline and passes untransformed data instead.
+   */
+  adHocTransforms?: boolean;
   /** Indicates that the panel implements suggestions */
   suggestions?: boolean;
   /** Indicates that panel should not be available in visualisation picker */

--- a/packages/grafana-runtime/src/services/pluginMeta/mappers/v0alpha1PanelMapper.test.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/mappers/v0alpha1PanelMapper.test.ts
@@ -70,6 +70,27 @@ describe('v0alpha1PanelMapper', () => {
       expect(result[pluginId].suggestions).toEqual(panels[pluginId].suggestions);
     });
 
+    it('should default adHocTransforms to false when plugin.json omits it', () => {
+      const result = v0alpha1PanelMapper(v0alpha1Response);
+
+      expect(result[pluginId].adHocTransforms).toBe(false);
+    });
+
+    it('should map adHocTransforms property correctly', () => {
+      const response = {
+        ...v0alpha1Response,
+        items: v0alpha1Response.items.map((item) =>
+          item.spec.pluginJson.id === pluginId
+            ? { ...item, spec: { ...item.spec, pluginJson: { ...item.spec.pluginJson, adHocTransforms: true } } }
+            : item
+        ),
+      };
+
+      const result = v0alpha1PanelMapper(response);
+
+      expect(result[pluginId].adHocTransforms).toBe(true);
+    });
+
     it('should map state property correctly', () => {
       const result = v0alpha1PanelMapper(v0alpha1Response);
 

--- a/packages/grafana-runtime/src/services/pluginMeta/mappers/v0alpha1PanelMapper.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/mappers/v0alpha1PanelMapper.ts
@@ -39,7 +39,14 @@ function sortMapper(spec: v0alpha1Spec): number {
 }
 
 function specMapper(spec: v0alpha1Spec): PanelPluginMeta {
-  const { id, name, hideFromList = false, skipDataQuery = false, suggestions } = spec.pluginJson;
+  const {
+    id,
+    name,
+    hideFromList = false,
+    skipDataQuery = false,
+    adHocTransforms = false,
+    suggestions,
+  } = spec.pluginJson;
   const state = stateMapper(spec, logPluginMetaWarning);
   const info = infoMapper(spec);
   const loadingStrategy = loadingStrategyMapper(spec);
@@ -60,6 +67,7 @@ function specMapper(spec: v0alpha1Spec): PanelPluginMeta {
     hideFromList,
     sort,
     skipDataQuery,
+    adHocTransforms,
     suggestions,
     state,
     baseUrl,

--- a/packages/grafana-schema/src/veneer/dashboard.types.ts
+++ b/packages/grafana-schema/src/veneer/dashboard.types.ts
@@ -58,6 +58,13 @@ export interface MatcherConfig<TConfig = any> extends raw.MatcherConfig {
   options?: TConfig;
 }
 
+/**
+ * Records how a transformation was created, so a visualization that renders its own
+ * transformation UI can tell its own entries apart from editor-authored ones.
+ * An absent origin means the transformation was authored in the transformations editor.
+ */
+export type TransformationOrigin = NonNullable<raw.DataTransformerConfig['origin']>;
+
 export interface DataTransformerConfig<TOptions = any> extends raw.DataTransformerConfig {
   options: TOptions;
   topic?: DataTopic;

--- a/packages/grafana-ui/src/components/PanelChrome/PanelContext.ts
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelContext.ts
@@ -8,7 +8,9 @@ import {
   type DataLinkPostProcessor,
   type EventBus,
   EventBusSrv,
+  type PanelData,
 } from '@grafana/data';
+import { type DataTransformerConfig } from '@grafana/schema';
 
 import { type AdHocFilterItem } from '../Table/types';
 
@@ -63,6 +65,54 @@ export interface PanelContext {
    * Used to apply multiple filters at once
    */
   onAddAdHocFilters?: (items: AdHocFilterItem[]) => void;
+
+  /**
+   * True when this panel declares `adHocTransforms` in its plugin.json and the host has handed
+   * the transformation pipeline over to it. When true `PanelProps.data` is untransformed and the
+   * panel is responsible for applying the pipeline itself.
+   *
+   * @alpha -- experimental
+   */
+  isAdHocTransformsEnabled?: () => boolean;
+
+  /**
+   * The panel's transformation pipeline, in execution order, with template variables already
+   * interpolated. Custom (function) transform operators are omitted since a panel cannot render
+   * or persist them. The returned array keeps a stable identity while its contents are unchanged,
+   * so it is safe to use as a hook dependency.
+   *
+   * @alpha -- experimental
+   */
+  getTransformations?: () => DataTransformerConfig[];
+
+  /**
+   * Replaces the panel's transformation pipeline verbatim. Persisted to the dashboard.
+   *
+   * @alpha -- experimental
+   */
+  setTransformations?: (configs: DataTransformerConfig[]) => void;
+
+  /**
+   * Source data as it left the query runner: before the transformation pipeline and before
+   * field config was applied. Only useful to panels that own the pipeline.
+   *
+   * @alpha -- experimental
+   */
+  getUntransformedData?: () => PanelData | undefined;
+
+  /**
+   * Applies the panel's field config and overrides to arbitrary data. Pure — it holds no cache,
+   * so callers must memoize. Intended for panels that transform data themselves and therefore
+   * need field config applied after their transforms rather than before.
+   *
+   * Only ever pass data that has NOT already been through field config: panel default data links
+   * are appended to whatever the frame carries, so applying this to already-processed frames
+   * accumulates a duplicate link per call. Start from `getUntransformedData()`, not
+   * `PanelProps.data`.
+   *
+   * @alpha -- experimental
+   */
+  applyFieldConfig?: (data: PanelData) => PanelData;
 
   /**
    * Used by the panel header status popover to open the errors and notices view.

--- a/public/app/features/dashboard-scene/inspect/InspectDataTab.tsx
+++ b/public/app/features/dashboard-scene/inspect/InspectDataTab.tsx
@@ -14,6 +14,7 @@ import { InspectTab } from 'app/features/inspector/types';
 import { type GetDataOptions } from 'app/features/query/state/PanelQueryRunner';
 
 import { InspectDataTab as InspectDataTabOld } from '../../inspector/InspectDataTab';
+import { useRunPanelTransformations } from '../utils/runPanelTransformations';
 
 export interface InspectDataTabState extends SceneObjectState {
   panelRef: SceneObjectRef<VizPanel>;
@@ -43,33 +44,38 @@ export class InspectDataTab extends SceneObjectBase<InspectDataTabState> {
     this.setState({ options });
   };
 
-  static Component = ({ model }: SceneComponentProps<InspectDataTab>) => {
-    const { options } = model.useState();
-    const panel = model.state.panelRef.resolve();
-    const dataProvider = sceneGraph.getData(panel);
-    const { data } = getDataProviderToSubscribeTo(dataProvider, options.withTransforms).useState();
-    const timeRange = sceneGraph.getTimeRange(panel);
+  static Component = InspectDataTabRendered;
+}
 
-    if (!data) {
-      <div>
-        <Trans i18nKey="dashboard-scene.inspect-data-tab.no-data-found">No data found</Trans>
-      </div>;
-    }
+function InspectDataTabRendered({ model }: SceneComponentProps<InspectDataTab>) {
+  const { options } = model.useState();
+  const panel = model.state.panelRef.resolve();
+  const dataProvider = sceneGraph.getData(panel);
+  const { data: providerData } = getDataProviderToSubscribeTo(dataProvider, options.withTransforms).useState();
+  const timeRange = sceneGraph.getTimeRange(panel);
+  // A panel that owns its own pipeline leaves the transformer as a pass-through, so
+  // "Apply panel transformations" has to run the pipeline here or it would be a no-op.
+  const data = useRunPanelTransformations(options.withTransforms ? dataProvider : undefined, providerData);
 
-    return (
-      <InspectDataTabOld
-        isLoading={data?.state === LoadingState.Loading}
-        data={data?.series}
-        options={options}
-        hasTransformations={hasTransformations(dataProvider)}
-        timeZone={timeRange.getTimeZone()}
-        panelPluginId={panel.state.pluginId}
-        dataName={sceneGraph.interpolate(panel, panel.state.title)}
-        fieldConfig={panel.state.fieldConfig}
-        onOptionsChange={model.onOptionsChange}
-      />
-    );
-  };
+  if (!data) {
+    <div>
+      <Trans i18nKey="dashboard-scene.inspect-data-tab.no-data-found">No data found</Trans>
+    </div>;
+  }
+
+  return (
+    <InspectDataTabOld
+      isLoading={data?.state === LoadingState.Loading}
+      data={data?.series}
+      options={options}
+      hasTransformations={hasTransformations(dataProvider)}
+      timeZone={timeRange.getTimeZone()}
+      panelPluginId={panel.state.pluginId}
+      dataName={sceneGraph.interpolate(panel, panel.state.title)}
+      fieldConfig={panel.state.fieldConfig}
+      onOptionsChange={model.onOptionsChange}
+    />
+  );
 }
 
 function hasTransformations(dataProvider: SceneDataProvider) {

--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataTransformationsTab.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataTransformationsTab.tsx
@@ -20,6 +20,8 @@ import { Button, ButtonGroup, ConfirmModal, Tab, useStyles2 } from '@grafana/ui'
 import { TransformationOperationRows } from 'app/features/dashboard/components/TransformationsEditor/TransformationOperationRows';
 import { ExpressionQueryType } from 'app/features/expressions/types';
 
+import { withEditorOrigin } from '../../scene/adHocTransformations';
+import { useRunPanelTransformations } from '../../utils/runPanelTransformations';
 import { getQueryRunnerFor } from '../../utils/utils';
 import { TRANSFORMATION_EDIT_INTERACTION_THROTTLE_TIME } from '../PanelEditNext/constants';
 
@@ -81,7 +83,11 @@ export class PanelDataTransformationsTab
 export function PanelDataTransformationsTabRendered({ model }: SceneComponentProps<PanelDataTransformationsTab>) {
   const styles = useStyles2(getStyles);
   const sourceData = model.getQueryRunner().useState();
-  const { data, transformations: transformsWrongType } = model.getDataTransformer().useState();
+  const transformer = model.getDataTransformer();
+  const { data: transformerData, transformations: transformsWrongType } = transformer.useState();
+  // A panel that owns its own pipeline leaves the transformer as a pass-through, so the output
+  // preview has to be computed here rather than read off the transformer.
+  const data = useRunPanelTransformations(transformer, transformerData);
 
   // Type guard to ensure transformations are DataTransformerConfig[]
   const transformations = useMemo<DataTransformerConfig[]>(() => {
@@ -131,7 +137,7 @@ export function PanelDataTransformationsTabRendered({ model }: SceneComponentPro
 
   const onAddTransformation = useCallback(
     (transformationId: string) => {
-      model.onChangeTransformations([...transformations, { id: transformationId, options: {} }]);
+      model.onChangeTransformations([...transformations, withEditorOrigin({ id: transformationId, options: {} })]);
     },
     [model, transformations]
   );
@@ -147,7 +153,7 @@ export function PanelDataTransformationsTabRendered({ model }: SceneComponentPro
         if (selected.value === undefined) {
           return;
         }
-        model.onChangeTransformations([...transformations, { id: selected.value, options: {} }]);
+        model.onChangeTransformations([...transformations, withEditorOrigin({ id: selected.value, options: {} })]);
         closeDrawer();
       }}
       isOpen={drawerOpen}

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/PanelDataPaneNext.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/PanelDataPaneNext.tsx
@@ -26,6 +26,7 @@ import { storeLastUsedDataSourceInLocalStorage } from 'app/features/datasources/
 import { MIXED_DATASOURCE_NAME } from 'app/plugins/datasource/mixed/MixedDataSource';
 import { type QueryGroupOptions } from 'app/types/query';
 
+import { withEditorOrigin } from '../../scene/adHocTransformations';
 import { PanelTimeRange } from '../../scene/panel-timerange/PanelTimeRange';
 import { getUpdatedHoverHeader } from '../../scene/panel-timerange/utils';
 import { getDashboardSceneFor, getQueryRunnerFor } from '../../utils/utils';
@@ -538,7 +539,7 @@ export class PanelDataPaneNext extends SceneObjectBase<PanelDataPaneNextState> {
     });
 
     const transformations = filterDataTransformerConfigs([...transformer.state.transformations]);
-    const newConfig: DataTransformerConfig = { id: transformationId, options: {} };
+    const newConfig: DataTransformerConfig = withEditorOrigin({ id: transformationId, options: {} });
     const insertAt = afterIndex !== undefined ? afterIndex + 1 : transformations.length;
     transformations.splice(insertAt, 0, newConfig);
     transformer.setState({ transformations });

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditor.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditor.tsx
@@ -28,6 +28,7 @@ import { vizSuggestionsTracker } from 'app/features/panel/components/VizTypePick
 import { DashboardSceneChangeTracker } from '../saving/DashboardSceneChangeTracker';
 import { type LibraryPanelBehavior } from '../scene/LibraryPanelBehavior';
 import { UNCONFIGURED_PANEL_PLUGIN_ID } from '../scene/UnconfiguredPanel';
+import { syncSkipTransformationsBehavior } from '../scene/adHocTransformations';
 import { DashboardGridItem } from '../scene/layout-default/DashboardGridItem';
 import { type DashboardLayoutItem, isDashboardLayoutItem } from '../scene/types/DashboardLayoutItem';
 import { vizPanelToPanel } from '../serialization/transformSceneToSaveModel';
@@ -292,6 +293,7 @@ export class PanelEditor extends SceneObjectBase<PanelEditorState> {
               queries: [{ refId: 'A' }],
             }),
             transformations: [],
+            $behaviors: [syncSkipTransformationsBehavior],
           }),
         });
       }

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -113,6 +113,7 @@ import { createMutationClient } from './DashboardMutationClientSetter';
 import { DashboardSceneRenderer } from './DashboardSceneRenderer';
 import { DashboardSceneUrlSync } from './DashboardSceneUrlSync';
 import { LibraryPanelBehavior } from './LibraryPanelBehavior';
+import { syncSkipTransformationsBehavior } from './adHocTransformations';
 import { setupKeyboardShortcuts } from './keyboardShortcuts';
 import { AutoGridItem } from './layout-auto-grid/AutoGridItem';
 import { DashboardGridItem } from './layout-default/DashboardGridItem';
@@ -1109,6 +1110,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
             queries: [{ refId: 'A' }],
           }),
           transformations: [],
+          $behaviors: [syncSkipTransformationsBehavior],
         }),
       });
     }

--- a/public/app/features/dashboard-scene/scene/adHocTransformations.test.ts
+++ b/public/app/features/dashboard-scene/scene/adHocTransformations.test.ts
@@ -1,0 +1,407 @@
+import {
+  type DataFrame,
+  FieldType,
+  LoadingState,
+  type PanelData,
+  type PanelPluginMeta,
+  standardEditorsRegistry,
+  standardFieldConfigEditorRegistry,
+  toDataFrame,
+} from '@grafana/data';
+import { getPanelPlugin } from '@grafana/data/test';
+import { config, setPluginImportUtils } from '@grafana/runtime';
+import { getPanelPluginMetasMapSync } from '@grafana/runtime/internal';
+import {
+  CustomVariable,
+  SceneDataNode,
+  SceneDataTransformer,
+  SceneVariableSet,
+  VizPanel,
+  type CustomTransformOperator,
+} from '@grafana/scenes';
+import { type DataTransformerConfig } from '@grafana/schema';
+import { type PanelContext } from '@grafana/ui';
+import { getAllOptionEditors, getAllStandardFieldConfigs } from 'app/core/components/OptionsUI/registry';
+
+import {
+  panelSkipsTransformationPipeline,
+  setAdHocTransformationsPanelContext,
+  syncSkipTransformationsBehavior,
+  withEditorOrigin,
+} from './adHocTransformations';
+
+// These are normally wired up during app boot. Without them PanelPlugin.fieldConfigRegistry is
+// empty and applyFieldOverrides has no standard properties to apply.
+standardEditorsRegistry.setInit(getAllOptionEditors);
+standardFieldConfigEditorRegistry.setInit(getAllStandardFieldConfigs);
+
+setPluginImportUtils({
+  importPanelPlugin: () => Promise.resolve(getPanelPlugin({}).useFieldConfig()),
+  getPanelPluginFromCache: () => undefined,
+});
+
+jest.mock('@grafana/runtime/internal', () => ({
+  ...jest.requireActual('@grafana/runtime/internal'),
+  getPanelPluginMetasMapSync: jest.fn(),
+}));
+
+const mockGetPanelPluginMetasMapSync = jest.mocked(getPanelPluginMetasMapSync);
+
+function stubPanelMetas(metas: Record<string, Partial<PanelPluginMeta>>) {
+  mockGetPanelPluginMetasMapSync.mockReturnValue(metas as Record<string, PanelPluginMeta>);
+}
+
+beforeEach(() => {
+  mockGetPanelPluginMetasMapSync.mockReset();
+  stubPanelMetas({});
+  config.featureToggles.panelAdHocTransformations = true;
+});
+
+afterEach(() => {
+  config.featureToggles.panelAdHocTransformations = false;
+});
+
+describe('panelSkipsTransformationPipeline', () => {
+  it('is false when the feature toggle is off', () => {
+    config.featureToggles.panelAdHocTransformations = false;
+    stubPanelMetas({ table: { adHocTransforms: true } });
+
+    expect(panelSkipsTransformationPipeline('table')).toBe(false);
+  });
+
+  it('is true when the plugin declares adHocTransforms', () => {
+    stubPanelMetas({ table: { adHocTransforms: true } });
+
+    expect(panelSkipsTransformationPipeline('table')).toBe(true);
+  });
+
+  it('is false for a plugin that does not declare it', () => {
+    stubPanelMetas({ timeseries: { adHocTransforms: false } });
+
+    expect(panelSkipsTransformationPipeline('timeseries')).toBe(false);
+    expect(panelSkipsTransformationPipeline('unknown-plugin')).toBe(false);
+    expect(panelSkipsTransformationPipeline(undefined)).toBe(false);
+  });
+
+  it('is false when the plugin also declares skipDataQuery, which never gets a transformer', () => {
+    stubPanelMetas({ text: { adHocTransforms: true, skipDataQuery: true } });
+
+    expect(panelSkipsTransformationPipeline('text')).toBe(false);
+  });
+
+  it('is false when the plugin meta cache is not initialised yet', () => {
+    mockGetPanelPluginMetasMapSync.mockImplementation(() => {
+      throw new Error('not initialised');
+    });
+
+    expect(panelSkipsTransformationPipeline('table')).toBe(false);
+  });
+});
+
+function buildPanel(
+  pluginId: string,
+  transformations: Array<DataTransformerConfig | CustomTransformOperator> = [],
+  data?: PanelData
+) {
+  const sourceData: PanelData = data ?? {
+    state: LoadingState.Done,
+    series: [toDataFrame({ fields: [{ name: 'value', type: FieldType.number, values: [1, 2] }] })],
+    timeRange: { from: {}, to: {}, raw: { from: 'now-6h', to: 'now' } } as PanelData['timeRange'],
+  };
+
+  const transformer = new SceneDataTransformer({
+    $data: new SceneDataNode({ data: sourceData }),
+    transformations,
+    $behaviors: [syncSkipTransformationsBehavior],
+  });
+
+  const panel = new VizPanel({ pluginId, $data: transformer });
+
+  return { panel, transformer, sourceData };
+}
+
+describe('syncSkipTransformationsBehavior', () => {
+  it('sets the flag from the panel plugin on activation', () => {
+    stubPanelMetas({ table: { adHocTransforms: true } });
+    const { panel, transformer } = buildPanel('table');
+
+    panel.activate();
+    transformer.activate();
+
+    expect(transformer.state.skipTransformations).toBe(true);
+  });
+
+  it('leaves the flag off for a plugin that does not opt in', () => {
+    stubPanelMetas({ timeseries: {} });
+    const { panel, transformer } = buildPanel('timeseries');
+
+    panel.activate();
+    transformer.activate();
+
+    expect(transformer.state.skipTransformations).toBeFalsy();
+  });
+
+  it('flips the flag in both directions when the visualization type changes', () => {
+    stubPanelMetas({ table: { adHocTransforms: true }, timeseries: {} });
+    const { panel, transformer } = buildPanel('table');
+
+    panel.activate();
+    transformer.activate();
+    expect(transformer.state.skipTransformations).toBe(true);
+
+    panel.setState({ pluginId: 'timeseries' });
+    expect(transformer.state.skipTransformations).toBe(false);
+
+    panel.setState({ pluginId: 'table' });
+    expect(transformer.state.skipTransformations).toBe(true);
+  });
+
+  it('keeps the transformations when the visualization type changes', () => {
+    stubPanelMetas({ table: { adHocTransforms: true }, timeseries: {} });
+    const transformations: DataTransformerConfig[] = [
+      { id: 'organize', options: {}, origin: { source: 'panel', pluginId: 'table' } },
+    ];
+    const { panel, transformer } = buildPanel('table', transformations);
+
+    panel.activate();
+    transformer.activate();
+
+    panel.setState({ pluginId: 'timeseries' });
+
+    expect(transformer.state.transformations).toEqual(transformations);
+  });
+});
+
+describe('withEditorOrigin', () => {
+  it('stamps an editor origin', () => {
+    expect(withEditorOrigin({ id: 'organize', options: {} })).toEqual({
+      id: 'organize',
+      options: {},
+      origin: { source: 'editor' },
+    });
+  });
+
+  it('leaves dashboard JSON untouched when the feature toggle is off', () => {
+    config.featureToggles.panelAdHocTransformations = false;
+
+    expect(withEditorOrigin({ id: 'organize', options: {} })).toEqual({ id: 'organize', options: {} });
+  });
+
+  it('does not overwrite an existing origin', () => {
+    const existing: DataTransformerConfig = { id: 'organize', options: {}, origin: { source: 'panel' } };
+
+    expect(withEditorOrigin(existing)).toBe(existing);
+  });
+});
+
+describe('setAdHocTransformationsPanelContext', () => {
+  function setup(
+    pluginId = 'table',
+    transformations: Array<DataTransformerConfig | CustomTransformOperator> = [],
+    data?: PanelData
+  ) {
+    const { panel, transformer, sourceData } = buildPanel(pluginId, transformations, data);
+    const context = {} as PanelContext;
+
+    setAdHocTransformationsPanelContext(panel, context);
+
+    return { panel, transformer, context, sourceData };
+  }
+
+  describe('isAdHocTransformsEnabled', () => {
+    it('reflects the current plugin', () => {
+      stubPanelMetas({ table: { adHocTransforms: true }, timeseries: {} });
+      const { panel, context } = setup('table');
+
+      expect(context.isAdHocTransformsEnabled!()).toBe(true);
+
+      // The context object is memoized by VizPanel, so this has to stay correct after a viz change.
+      panel.setState({ pluginId: 'timeseries' });
+      expect(context.isAdHocTransformsEnabled!()).toBe(false);
+    });
+  });
+
+  describe('getTransformations', () => {
+    it('returns the pipeline', () => {
+      const transformations: DataTransformerConfig[] = [{ id: 'organize', options: { excludeByName: { a: true } } }];
+      const { context } = setup('table', transformations);
+
+      expect(context.getTransformations!()).toEqual(transformations);
+    });
+
+    it('keeps a stable array identity while unchanged', () => {
+      const { context } = setup('table', [{ id: 'organize', options: {} }]);
+
+      expect(context.getTransformations!()).toBe(context.getTransformations!());
+    });
+
+    it('returns a new array after the pipeline changes', () => {
+      const { context, transformer } = setup('table', [{ id: 'organize', options: {} }]);
+      const first = context.getTransformations!();
+
+      transformer.setState({ transformations: [{ id: 'organize', options: { excludeByName: { a: true } } }] });
+
+      expect(context.getTransformations!()).not.toBe(first);
+      expect(context.getTransformations!()[0].options).toEqual({ excludeByName: { a: true } });
+    });
+
+    it('filters out custom transform operators, which cannot be persisted', () => {
+      const customOperator: CustomTransformOperator = () => (source) => source;
+      const { context } = setup('table', [{ id: 'organize', options: {} }, customOperator]);
+
+      expect(context.getTransformations!()).toEqual([{ id: 'organize', options: {} }]);
+    });
+
+    it('interpolates template variables', () => {
+      const { context, panel } = setup('table', [{ id: 'filterByValue', options: { value: '$env' } }]);
+      panel.setState({
+        $variables: new SceneVariableSet({
+          variables: [new CustomVariable({ name: 'env', value: 'prod', text: 'prod', query: 'prod' })],
+        }),
+      });
+      panel.activate();
+
+      expect(context.getTransformations!()[0].options).toEqual({ value: 'prod' });
+    });
+
+    it('returns an empty array when the panel has no transformer', () => {
+      const panel = new VizPanel({ pluginId: 'table' });
+      const context = {} as PanelContext;
+      setAdHocTransformationsPanelContext(panel, context);
+
+      expect(context.getTransformations!()).toEqual([]);
+    });
+  });
+
+  describe('setTransformations', () => {
+    it('writes the pipeline to the transformer', () => {
+      const { context, transformer } = setup('table', [{ id: 'organize', options: {} }]);
+      const next: DataTransformerConfig[] = [{ id: 'limit', options: { limitField: 1 } }];
+
+      context.setTransformations!(next);
+
+      expect(transformer.state.transformations).toEqual(next);
+    });
+
+    it('reprocesses so a change takes effect even when the source frames are unchanged', () => {
+      const { context, transformer } = setup('table', [{ id: 'organize', options: {} }]);
+      const reprocess = jest.spyOn(transformer, 'reprocessTransformations');
+
+      context.setTransformations!([{ id: 'limit', options: { limitField: 1 } }]);
+
+      expect(reprocess).toHaveBeenCalled();
+    });
+  });
+
+  describe('getUntransformedData', () => {
+    it('returns the source data from before the pipeline', () => {
+      const { context, sourceData } = setup('table', [{ id: 'organize', options: {} }]);
+
+      expect(context.getUntransformedData!()).toBe(sourceData);
+    });
+
+    it('honours the series limit the renderer would apply', () => {
+      const series = [
+        toDataFrame({ refId: 'A', fields: [{ name: 'a', type: FieldType.number, values: [1] }] }),
+        toDataFrame({ refId: 'B', fields: [{ name: 'b', type: FieldType.number, values: [2] }] }),
+      ];
+      const { context, panel } = setup('table', [], { state: LoadingState.Done, series } as PanelData);
+
+      panel.setState({ seriesLimit: 1 });
+      expect(context.getUntransformedData!()!.series).toHaveLength(1);
+
+      panel.setState({ seriesLimitShowAll: true });
+      expect(context.getUntransformedData!()!.series).toHaveLength(2);
+    });
+
+    // Callers use `series` as a hook dependency, so a fresh slice per call would loop forever.
+    it('returns a stable identity while the source data and limit are unchanged', () => {
+      const series = [
+        toDataFrame({ refId: 'A', fields: [{ name: 'a', type: FieldType.number, values: [1] }] }),
+        toDataFrame({ refId: 'B', fields: [{ name: 'b', type: FieldType.number, values: [2] }] }),
+      ];
+      const { context, panel } = setup('table', [], { state: LoadingState.Done, series } as PanelData);
+      panel.setState({ seriesLimit: 1 });
+
+      expect(context.getUntransformedData!()).toBe(context.getUntransformedData!());
+      expect(context.getUntransformedData!()!.series).toBe(context.getUntransformedData!()!.series);
+    });
+  });
+
+  describe('applyFieldConfig', () => {
+    function setupWithPlugin() {
+      const { panel, transformer, context, sourceData } = setup('table');
+      // getPlugin() only resolves once the plugin has loaded.
+      panel.activate();
+      transformer.activate();
+      return { panel, context, sourceData };
+    }
+
+    it('applies field config defaults to the given data', async () => {
+      const { panel, context, sourceData } = setupWithPlugin();
+      await new Promise(process.nextTick);
+      panel.setState({ fieldConfig: { defaults: { unit: 'bytes' }, overrides: [] } });
+
+      const result = context.applyFieldConfig!(sourceData);
+
+      expect(result.series[0].fields[0].config.unit).toBe('bytes');
+    });
+
+    it('does not disturb the panel structureRev, which would thrash uPlot and table column widths', async () => {
+      const { panel, context, sourceData } = setupWithPlugin();
+      await new Promise(process.nextTick);
+
+      const first = panel.applyFieldConfig(sourceData).structureRev;
+
+      // A panel that owns its pipeline calls this every render with different frames.
+      context.applyFieldConfig!({
+        ...sourceData,
+        series: [toDataFrame({ fields: [{ name: 'other', type: FieldType.string, values: ['x'] }] })],
+      });
+
+      expect(panel.applyFieldConfig(sourceData).structureRev).toBe(first);
+    });
+
+    // setFieldConfigDefaults *pushes* panel default links onto whatever the frame already carries,
+    // so this must only ever be handed pre-field-config data. getUntransformedData() guarantees
+    // that; passing already-processed frames would accumulate a link per call.
+    it('applies panel default links exactly once to raw frames', async () => {
+      const { panel, context } = setupWithPlugin();
+      await new Promise(process.nextTick);
+
+      panel.setState({
+        fieldConfig: { defaults: { links: [{ title: 'Go', url: 'http://example.com' }] }, overrides: [] },
+      });
+
+      const frames: DataFrame[] = [toDataFrame({ fields: [{ name: 'value', type: FieldType.number, values: [1] }] })];
+      const result = context.applyFieldConfig!({ state: LoadingState.Done, series: frames } as PanelData);
+
+      expect(result.series[0].fields[0].config.links).toHaveLength(1);
+    });
+
+    it('merges datasource-provided links with the panel defaults', async () => {
+      const { panel, context } = setupWithPlugin();
+      await new Promise(process.nextTick);
+
+      panel.setState({
+        fieldConfig: { defaults: { links: [{ title: 'Panel', url: 'http://panel.example' }] }, overrides: [] },
+      });
+
+      const frames: DataFrame[] = [
+        toDataFrame({
+          fields: [
+            {
+              name: 'value',
+              type: FieldType.number,
+              values: [1],
+              config: { links: [{ title: 'Datasource', url: 'http://ds.example' }] },
+            },
+          ],
+        }),
+      ];
+      const result = context.applyFieldConfig!({ state: LoadingState.Done, series: frames } as PanelData);
+
+      expect(result.series[0].fields[0].config.links?.map((l) => l.title)).toEqual(['Datasource', 'Panel']);
+    });
+  });
+});

--- a/public/app/features/dashboard-scene/scene/adHocTransformations.ts
+++ b/public/app/features/dashboard-scene/scene/adHocTransformations.ts
@@ -1,0 +1,225 @@
+import { applyFieldOverrides, type PanelData } from '@grafana/data';
+import { config } from '@grafana/runtime';
+import { getPanelPluginMetasMapSync, type PanelPluginMetas } from '@grafana/runtime/internal';
+import { SceneDataTransformer, sceneGraph, VizPanel } from '@grafana/scenes';
+import { type DataTransformerConfig } from '@grafana/schema';
+import { type PanelContext } from '@grafana/ui';
+
+/**
+ * getPanelPluginMetasMapSync throws when the plugin meta cache has not been initialised yet,
+ * which happens in tests and during early app boot. Treat that as "no panel opts in".
+ */
+function safePanelMetas(): PanelPluginMetas {
+  try {
+    return getPanelPluginMetasMapSync();
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Whether the panel plugin owns the transformation pipeline, in which case the host stops
+ * executing it and hands the panel untransformed data.
+ */
+export function panelSkipsTransformationPipeline(
+  pluginId: string | undefined,
+  panelMetas: PanelPluginMetas = safePanelMetas()
+): boolean {
+  if (!config.featureToggles.panelAdHocTransformations || !pluginId) {
+    return false;
+  }
+
+  const meta = panelMetas[pluginId];
+
+  // skipDataQuery panels never get a data provider at all, so opting them in is meaningless.
+  return Boolean(meta?.adHocTransforms && !meta.skipDataQuery);
+}
+
+/**
+ * Keeps `skipTransformations` in sync with the parent panel's plugin, so switching the
+ * visualization type hands the pipeline back and forth without any call site having to remember.
+ * There are several `changePluginType` call sites and only one of them handles the analogous
+ * `skipDataQuery` transition today.
+ */
+export function syncSkipTransformationsBehavior(transformer: SceneDataTransformer) {
+  const panel = transformer.parent;
+
+  if (!(panel instanceof VizPanel)) {
+    return;
+  }
+
+  const sync = (pluginId: string) => {
+    const skipTransformations = panelSkipsTransformationPipeline(pluginId);
+
+    if (skipTransformations !== Boolean(transformer.state.skipTransformations)) {
+      // SceneDataTransformer re-runs transform() itself when this flag flips.
+      transformer.setState({ skipTransformations });
+    }
+  };
+
+  sync(panel.state.pluginId);
+
+  const sub = panel.subscribeToState((newState, prevState) => {
+    if (newState.pluginId !== prevState.pluginId) {
+      sync(newState.pluginId);
+    }
+  });
+
+  return () => sub.unsubscribe();
+}
+
+/**
+ * Stamps a transformation the user added in the transformations editor. Gated on the feature
+ * toggle so dashboard JSON is untouched while the feature is off — an absent origin already means
+ * "editor", so nothing is lost by not writing it.
+ */
+export function withEditorOrigin(transformation: DataTransformerConfig): DataTransformerConfig {
+  if (!config.featureToggles.panelAdHocTransformations || transformation.origin) {
+    return transformation;
+  }
+
+  return { ...transformation, origin: { source: 'editor' } };
+}
+
+const EMPTY_TRANSFORMATIONS: DataTransformerConfig[] = [];
+
+/** Matches `$var`, `${var}` and `[[var]]`. */
+const VARIABLE_PATTERN = /\$|\[\[/;
+
+function getDataTransformer(vizPanel: VizPanel): SceneDataTransformer | undefined {
+  const provider = vizPanel.state.$data;
+  return provider instanceof SceneDataTransformer ? provider : undefined;
+}
+
+/**
+ * Adds the transformation members to a panel context. Panels that own their pipeline read and
+ * write it through these; everything else ignores them.
+ *
+ * All members are functions rather than values because VizPanel memoizes the context object
+ * after the first `getPanelContext()` call, so a snapshot value would go stale. Re-rendering is
+ * already handled for us: VizPanelRenderer subscribes to the whole SceneDataTransformer state,
+ * so mutating `transformations` re-renders the panel and these getters are called again.
+ */
+export function setAdHocTransformationsPanelContext(vizPanel: VizPanel, context: PanelContext) {
+  let cachedJson: string | undefined;
+  let cachedConfigs: DataTransformerConfig[] = EMPTY_TRANSFORMATIONS;
+
+  context.isAdHocTransformsEnabled = () => panelSkipsTransformationPipeline(vizPanel.state.pluginId);
+
+  context.getTransformations = () => {
+    const transformer = getDataTransformer(vizPanel);
+
+    if (!transformer) {
+      return EMPTY_TRANSFORMATIONS;
+    }
+
+    // Custom transform operators are functions. They only exist in code-built scenes, can't be
+    // interpolated and can't be persisted, so a panel should never see them.
+    const raw = transformer.state.transformations.filter(
+      (t): t is DataTransformerConfig => typeof t === 'object' && t !== null && 'id' in t
+    );
+
+    if (raw.length === 0) {
+      return EMPTY_TRANSFORMATIONS;
+    }
+
+    const json = JSON.stringify(raw);
+
+    // Keep a stable array identity so callers can use the result as a hook dependency.
+    if (json === cachedJson) {
+      return cachedConfigs;
+    }
+
+    cachedJson = json;
+    cachedConfigs = VARIABLE_PATTERN.test(json)
+      ? // Mirrors SceneDataTransformer's own interpolation, including the request scoped vars
+        // that carry repeat-by-row values. Panels must not interpolate with replaceVariables,
+        // which does not see those.
+        JSON.parse(sceneGraph.interpolate(transformer, json, transformer.state.data?.request?.scopedVars))
+      : raw;
+
+    return cachedConfigs;
+  };
+
+  context.setTransformations = (configs: DataTransformerConfig[]) => {
+    const transformer = getDataTransformer(vizPanel);
+
+    if (!transformer) {
+      return;
+    }
+
+    transformer.setState({ transformations: configs });
+    // Required when the pipeline is not bypassed: the source frames are reference-equal so the
+    // transformer would otherwise short-circuit.
+    transformer.reprocessTransformations();
+  };
+
+  let cachedSourceData: PanelData | undefined;
+  let cachedSeriesLimit: number | undefined;
+  let cachedLimitedData: PanelData | undefined;
+
+  context.getUntransformedData = () => {
+    const transformer = getDataTransformer(vizPanel);
+    const data = transformer ? (transformer.state.$data?.state.data ?? transformer.state.data) : undefined;
+
+    if (!data) {
+      return undefined;
+    }
+
+    const { seriesLimit, seriesLimitShowAll } = vizPanel.state;
+
+    if (!seriesLimit || seriesLimitShowAll) {
+      return data;
+    }
+
+    // Parity with the series limit VizPanelRenderer applies before handing data to the panel.
+    // The slice has to be cached: callers use `series` as a hook dependency, so handing back a
+    // fresh array on every call would re-trigger their effects indefinitely.
+    if (!cachedLimitedData || cachedSourceData !== data || cachedSeriesLimit !== seriesLimit) {
+      cachedSourceData = data;
+      cachedSeriesLimit = seriesLimit;
+      cachedLimitedData = { ...data, series: data.series.slice(0, seriesLimit) };
+    }
+
+    return cachedLimitedData;
+  };
+
+  context.applyFieldConfig = (data: PanelData): PanelData => {
+    const plugin = vizPanel.getPlugin();
+
+    if (!plugin || plugin.meta.skipDataQuery) {
+      return data;
+    }
+
+    const dataSupport = plugin.dataSupport ?? { alertStates: false, annotations: false };
+    const shared = {
+      fieldConfigRegistry: plugin.fieldConfigRegistry,
+      replaceVariables: vizPanel.interpolate,
+      theme: config.theme2,
+      timeZone: data.request?.timezone,
+    };
+
+    const result: PanelData = {
+      ...data,
+      series: applyFieldOverrides({ ...shared, data: data.series, fieldConfig: vizPanel.state.fieldConfig }),
+    };
+
+    if (result.annotations) {
+      result.annotations = applyFieldOverrides({
+        ...shared,
+        data: result.annotations,
+        fieldConfig: { defaults: {}, overrides: [] },
+      });
+    }
+
+    if (!dataSupport.alertStates) {
+      result.alertState = undefined;
+    }
+
+    if (!dataSupport.annotations) {
+      result.annotations = undefined;
+    }
+
+    return result;
+  };
+}

--- a/public/app/features/dashboard-scene/scene/setDashboardPanelContext.ts
+++ b/public/app/features/dashboard-scene/scene/setDashboardPanelContext.ts
@@ -1,5 +1,5 @@
 import { AnnotationChangeEvent, type AnnotationEventUIModel, CoreApp, type DataFrame } from '@grafana/data';
-import { getDataSourceSrv, reportInteraction } from '@grafana/runtime';
+import { config, getDataSourceSrv, reportInteraction } from '@grafana/runtime';
 import { AdHocFiltersVariable, dataLayers, sceneGraph, sceneUtils, type VizPanel } from '@grafana/scenes';
 import { type DataSourceRef } from '@grafana/schema';
 import { type AdHocFilterItem, type PanelContext } from '@grafana/ui';
@@ -18,6 +18,7 @@ import {
 } from '../utils/utils';
 
 import { type DashboardScene } from './DashboardScene';
+import { setAdHocTransformationsPanelContext } from './adHocTransformations';
 
 export function setDashboardPanelContext(vizPanel: VizPanel, context: PanelContext) {
   const dashboard = getDashboardSceneFor(vizPanel);
@@ -138,6 +139,10 @@ export function setDashboardPanelContext(vizPanel: VizPanel, context: PanelConte
     const filterVar = getAdHocFilterVariableFor(dashboard, datasource);
     updateAdHocFilterVariable(filterVar, newFilter);
   };
+
+  if (config.featureToggles.panelAdHocTransformations) {
+    setAdHocTransformationsPanelContext(vizPanel, context);
+  }
 
   context.getFiltersBasedOnGrouping = (items: AdHocFilterItem[]) => {
     const dashboard = getDashboardSceneFor(vizPanel);

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.ts
@@ -36,6 +36,7 @@ import { panelLinksBehavior, panelMenuBehavior } from '../../scene/PanelMenuBeha
 import { PanelNotices } from '../../scene/PanelNotices';
 import { VizPanelHeaderActions } from '../../scene/VizPanelHeaderActions';
 import { VizPanelSubHeader } from '../../scene/VizPanelSubHeader';
+import { panelSkipsTransformationPipeline, syncSkipTransformationsBehavior } from '../../scene/adHocTransformations';
 import { type AutoGridItem } from '../../scene/layout-auto-grid/AutoGridItem';
 import { type DashboardGridItem } from '../../scene/layout-default/DashboardGridItem';
 import { PanelTimeRange } from '../../scene/panel-timerange/PanelTimeRange';
@@ -236,6 +237,8 @@ function createPanelDataProvider(
         topic: transformDataTopic(normalized.spec.topic),
       };
     }),
+    skipTransformations: panelSkipsTransformationPipeline(panel.vizConfig?.group, panelMetas),
+    $behaviors: [syncSkipTransformationsBehavior],
   });
 }
 

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModel.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModel.test.ts
@@ -693,6 +693,24 @@ describe('transformSceneToSaveModel', () => {
         uid: 'abc',
       });
     });
+
+    it('Given panel with a transformation created by the visualization', () => {
+      const panel = buildGridItemFromPanelSchema({
+        transformations: [
+          {
+            id: 'organize',
+            options: { excludeByName: { value: true } },
+            origin: { source: 'panel', pluginId: 'table' },
+          },
+        ],
+        targets: [{ refId: 'A' }],
+      });
+
+      const result = gridItemToPanel(panel);
+
+      expect(result.transformations?.[0].origin).toEqual({ source: 'panel', pluginId: 'table' });
+    });
+
     it('Given panel with shared query', () => {
       const panel = buildGridItemFromPanelSchema({
         datasource: {

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.test.ts
@@ -1,5 +1,6 @@
 import {
   VariableRefresh,
+  type DataTransformerConfig,
   type PanelData,
   LoadingState,
   toDataFrame,
@@ -1233,6 +1234,49 @@ describe('getVizPanelQueries', () => {
       expect(result[0].spec.query.spec.snapshot).toHaveLength(1);
       // Verify it gets data from the nested $data (SceneDataNode) not the transformer
       expect(result[0].spec.query.spec.snapshot[0].schema?.fields).toBeDefined();
+    });
+  });
+
+  describe('transformation origin', () => {
+    function panelWithTransformations(transformations: DataTransformerConfig[]) {
+      return new VizPanel({
+        key: 'panel-1',
+        pluginId: 'table',
+        $data: new SceneDataTransformer({
+          $data: new SceneDataNode({
+            data: { series: [], state: LoadingState.Done, timeRange: getDefaultTimeRange() },
+          }),
+          transformations,
+        }),
+      });
+    }
+
+    // TransformationSpec is built field by field, so origin has to be carried explicitly.
+    it('serializes a panel-authored origin', () => {
+      const vizPanel = panelWithTransformations([
+        { id: 'organize', options: { excludeByName: { a: true } }, origin: { source: 'panel', pluginId: 'table' } },
+      ]);
+
+      const result = vizPanelToSchemaV2(vizPanel);
+
+      expect(result.spec.data.spec.transformations[0].spec.origin).toEqual({ source: 'panel', pluginId: 'table' });
+    });
+
+    it('serializes an editor-authored origin', () => {
+      const vizPanel = panelWithTransformations([{ id: 'organize', options: {}, origin: { source: 'editor' } }]);
+
+      const result = vizPanelToSchemaV2(vizPanel);
+
+      expect(result.spec.data.spec.transformations[0].spec.origin).toEqual({ source: 'editor' });
+    });
+
+    // An absent origin already means "editor", so nothing should be invented.
+    it('omits origin when the transformation has none', () => {
+      const vizPanel = panelWithTransformations([{ id: 'organize', options: {} }]);
+
+      const result = vizPanelToSchemaV2(vizPanel);
+
+      expect(result.spec.data.spec.transformations[0].spec).not.toHaveProperty('origin');
     });
   });
 });

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
@@ -516,6 +516,7 @@ function getVizPanelTransformations(vizPanel: VizPanel): TransformationKind[] {
           filter: transformation.filter,
           ...(transformation.topic && { topic: transformation.topic }),
           options: transformation.options,
+          ...(transformation.origin && { origin: transformation.origin }),
         };
 
         transformations.push({

--- a/public/app/features/dashboard-scene/utils/createPanelDataProvider.ts
+++ b/public/app/features/dashboard-scene/utils/createPanelDataProvider.ts
@@ -4,6 +4,7 @@ import { type DataQuery, type DataSourceRef } from '@grafana/schema';
 import { type PanelModel } from 'app/features/dashboard/state/PanelModel';
 
 import { DashboardDatasourceBehaviour } from '../scene/DashboardDatasourceBehaviour';
+import { panelSkipsTransformationPipeline, syncSkipTransformationsBehavior } from '../scene/adHocTransformations';
 
 export function createPanelDataProvider(
   panel: PanelModel,
@@ -40,6 +41,8 @@ export function createPanelDataProvider(
   return new SceneDataTransformer({
     $data: dataProvider,
     transformations: panel.transformations || [],
+    skipTransformations: panelSkipsTransformationPipeline(panel.type, panelMetas),
+    $behaviors: [syncSkipTransformationsBehavior],
   });
 }
 

--- a/public/app/features/dashboard-scene/utils/runPanelTransformations.ts
+++ b/public/app/features/dashboard-scene/utils/runPanelTransformations.ts
@@ -1,0 +1,105 @@
+import { useEffect, useState } from 'react';
+import { of, type Observable } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+
+import { LoadingState, type PanelData, transformPanelData } from '@grafana/data';
+import { toDataQueryError } from '@grafana/runtime';
+import { SceneDataTransformer, sceneGraph, type SceneDataProvider } from '@grafana/scenes';
+import { type DataTransformerConfig } from '@grafana/schema';
+
+/**
+ * True when this provider holds a transformation pipeline it is deliberately not executing,
+ * because the panel plugin owns it.
+ */
+export function isBypassedDataTransformer(dataProvider: SceneDataProvider | undefined): boolean {
+  return (
+    dataProvider instanceof SceneDataTransformer &&
+    Boolean(dataProvider.state.skipTransformations) &&
+    dataProvider.state.transformations.length > 0
+  );
+}
+
+/**
+ * Runs a bypassed transformer's pipeline on demand.
+ *
+ * Anything that wants the *transformed* result of a panel that owns its own pipeline has to run
+ * that pipeline itself, because the transformer only passes source data through. Used by the
+ * dashboard datasource (`withTransforms`), panel inspect, and the panel editor's transformation
+ * preview — all of which would otherwise silently show untransformed data.
+ *
+ * Returns the input unchanged when the provider is not a bypassed transformer, so callers can
+ * route through this unconditionally.
+ */
+export function runPanelTransformations(
+  dataProvider: SceneDataProvider | undefined,
+  data: PanelData
+): Observable<PanelData> {
+  if (!isBypassedDataTransformer(dataProvider) || !(dataProvider instanceof SceneDataTransformer)) {
+    return of(data);
+  }
+
+  const transformations = dataProvider.state.transformations.filter(
+    (t): t is DataTransformerConfig => typeof t === 'object' && t !== null && 'id' in t
+  );
+
+  if (transformations.length === 0) {
+    return of(data);
+  }
+
+  // SceneDataTransformer interpolates before transforming and transformDataFrame skips
+  // interpolation inside a scene, so it has to happen here too.
+  const interpolated: DataTransformerConfig[] = JSON.parse(
+    sceneGraph.interpolate(dataProvider, JSON.stringify(transformations), data.request?.scopedVars)
+  );
+
+  return transformPanelData(interpolated, data).pipe(
+    catchError((err) => {
+      const error = toDataQueryError(err);
+      error.message = `Error transforming data: ${error.message}`;
+
+      return of({
+        ...data,
+        state: LoadingState.Error,
+        errors: [...(data.errors ?? []), error],
+      });
+    })
+  );
+}
+
+/**
+ * React flavour of {@link runPanelTransformations}, for panel inspect and the panel editor's
+ * transformation preview. Returns `data` untouched unless the provider is a bypassed transformer,
+ * in which case it returns the transformed result once it resolves.
+ */
+export function useRunPanelTransformations(
+  dataProvider: SceneDataProvider | undefined,
+  data: PanelData | undefined
+): PanelData | undefined {
+  const [transformed, setTransformed] = useState<PanelData | undefined>(undefined);
+  const bypassed = isBypassedDataTransformer(dataProvider);
+
+  // With the pipeline bypassed `state.data` keeps the same identity when transformations change,
+  // so the configs have to be part of the dependencies for edits to take effect.
+  const transformationsKey =
+    bypassed && dataProvider instanceof SceneDataTransformer
+      ? JSON.stringify(dataProvider.state.transformations)
+      : undefined;
+
+  useEffect(() => {
+    if (!bypassed || !data) {
+      setTransformed(undefined);
+      return;
+    }
+
+    const subscription = runPanelTransformations(dataProvider, data).subscribe(setTransformed);
+
+    return () => subscription.unsubscribe();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [bypassed, dataProvider, data, transformationsKey]);
+
+  if (!bypassed) {
+    return data;
+  }
+
+  return transformed ?? data;
+}

--- a/public/app/features/dashboard-scene/utils/utils.ts
+++ b/public/app/features/dashboard-scene/utils/utils.ts
@@ -33,6 +33,7 @@ import { panelMenuBehavior } from '../scene/PanelMenuBehavior';
 import { UNCONFIGURED_PANEL_PLUGIN_ID } from '../scene/UnconfiguredPanel';
 import { VizPanelHeaderActions } from '../scene/VizPanelHeaderActions';
 import { VizPanelSubHeader } from '../scene/VizPanelSubHeader';
+import { syncSkipTransformationsBehavior } from '../scene/adHocTransformations';
 import { AutoGridLayoutManager } from '../scene/layout-auto-grid/AutoGridLayoutManager';
 import { type DashboardGridItem } from '../scene/layout-default/DashboardGridItem';
 import { DefaultGridLayoutManager } from '../scene/layout-default/DefaultGridLayoutManager';
@@ -313,6 +314,7 @@ export function getDefaultVizPanel(): VizPanel {
             $behaviors: [new DashboardDatasourceBehaviour({})],
           }),
           transformations: [],
+          $behaviors: [syncSkipTransformationsBehavior],
         })
       : undefined,
   });

--- a/public/app/plugins/datasource/dashboard/datasource.ts
+++ b/public/app/plugins/datasource/dashboard/datasource.ts
@@ -1,4 +1,16 @@
-import { type Observable, debounce, debounceTime, defer, filter, finalize, first, interval, map, of } from 'rxjs';
+import {
+  type Observable,
+  debounce,
+  debounceTime,
+  defer,
+  filter,
+  finalize,
+  first,
+  interval,
+  map,
+  of,
+  switchMap,
+} from 'rxjs';
 
 import {
   DataSourceApi,
@@ -28,6 +40,7 @@ import {
   SceneDataTransformer,
   type SceneObject,
 } from '@grafana/scenes';
+import { runPanelTransformations } from 'app/features/dashboard-scene/utils/runPanelTransformations';
 import {
   activateSceneObjectAndParentTree,
   findVizPanelByKey,
@@ -141,6 +154,13 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
           const sourceRange = sceneGraph.getTimeRange(sourceDataProvider!).state.value;
           return isSameRange(upstreamRange, sourceRange);
         }),
+        // When the source panel owns its own transformation pipeline the transformer only passes
+        // data through, so "use transformed data" has to run that pipeline here instead.
+        switchMap((result) =>
+          query.withTransforms
+            ? runPanelTransformations(sourceDataProvider, result.data).pipe(map((data) => ({ ...result, data })))
+            : of(result)
+        ),
         map((result) => {
           return {
             data: this.getDataFramesForQueryTopic(result.data, query, adHocFilters),


### PR DESCRIPTION
feat(ad-hoc transforms): hand the transformation pipeline to opted-in panels

A panel plugin declaring adHocTransforms now receives untransformed data and reads and writes its own pipeline through PanelContext.

The pipeline stays in SceneDataTransformer.state.transformations as the single source of truth, so the serializers, both panel-edit transformation UIs and PanelModelCompatibilityWrapper keep working untouched. The transformer just stops executing it, via the skipTransformations flag added in grafana/scenes#1589.

- panelSkipsTransformationPipeline plus a $behavior that keeps the flag in step with the panel's pluginId, so switching visualization type hands the pipeline back and forth. changePluginType has six call sites and only one of them handles the analogous skipDataQuery transition today.
- PanelContext gains getTransformations/setTransformations, plus getUntransformedData and a pure applyFieldConfig. All are functions because VizPanel memoizes the context object, so a snapshot value would go stale. Re-rendering is already covered: VizPanelRenderer subscribes to the whole transformer state.
- Interpolation happens in the getter using the request scoped vars, matching SceneDataTransformer. PanelProps.replaceVariables does not see those and would resolve $var differently for repeated panels.
- transformPanelData in @grafana/data routes each transformation to series or annotations by topic, shared so the panel-side and scene-side paths cannot diverge.

Also fixes three places that would silently show untransformed data once the pipeline is bypassed, since they all read the transformer's output: the dashboard datasource's withTransforms, panel inspect's "Apply panel transformations", and the panel editor's transformation preview.

**Special notes for your reviewer:**
PoC / UNVERIFIED

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
