### PR TITLE
AdHocTransforms: PoC dashboard schema and plugin capability - panel hooks

### DIFF
--- a/packages/grafana-ui/src/components/PanelChrome/index.ts
+++ b/packages/grafana-ui/src/components/PanelChrome/index.ts
@@ -34,5 +34,7 @@ export {
 } from './LoadingIndicator';
 
 export { usePanelContext, PanelContextProvider, type PanelContext, PanelContextRoot } from './PanelContext';
+export { useAdHocTransformations, type AdHocTransformationsApi } from './useAdHocTransformations';
+export { useTransformedData, type TransformedPanelData } from './useTransformedData';
 
 export * from './types';

--- a/packages/grafana-ui/src/components/PanelChrome/useAdHocTransformations.test.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/useAdHocTransformations.test.tsx
@@ -1,0 +1,204 @@
+import { renderHook } from '@testing-library/react';
+import { type ReactNode } from 'react';
+
+import { EventBusSrv, type PanelPluginMeta, PluginContextProvider, PluginType } from '@grafana/data';
+import { type DataTransformerConfig } from '@grafana/schema';
+
+import { type PanelContext, PanelContextProvider } from './PanelContext';
+import { useAdHocTransformations } from './useAdHocTransformations';
+
+const pluginMeta: PanelPluginMeta = {
+  id: 'table',
+  name: 'Table',
+  type: PluginType.panel,
+  sort: 1,
+  module: '',
+  baseUrl: '',
+  info: {
+    author: { name: 'Grafana Labs' },
+    description: '',
+    links: [],
+    logos: { large: '', small: '' },
+    screenshots: [],
+    updated: '',
+    version: '',
+  },
+};
+
+interface SetupOptions {
+  enabled?: boolean;
+  transformations?: DataTransformerConfig[];
+}
+
+function setup({ enabled = true, transformations = [] }: SetupOptions = {}) {
+  let current = transformations;
+  const setTransformations = jest.fn((next: DataTransformerConfig[]) => {
+    current = next;
+  });
+
+  const context: PanelContext = {
+    eventsScope: 'test',
+    eventBus: new EventBusSrv(),
+    isAdHocTransformsEnabled: () => enabled,
+    getTransformations: () => current,
+    setTransformations,
+  };
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <PluginContextProvider meta={pluginMeta}>
+      <PanelContextProvider value={context}>{children}</PanelContextProvider>
+    </PluginContextProvider>
+  );
+
+  const { result, rerender } = renderHook(() => useAdHocTransformations(), { wrapper });
+
+  return { result, rerender, setTransformations, getCurrent: () => current };
+}
+
+describe('useAdHocTransformations', () => {
+  it('is disabled when the panel does not own the pipeline', () => {
+    const { result } = setup({ enabled: false });
+
+    expect(result.current.enabled).toBe(false);
+    expect(result.current.transformations).toEqual([]);
+  });
+
+  it('is disabled when the host provides no transformation members at all', () => {
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <PanelContextProvider value={{ eventsScope: 'test', eventBus: new EventBusSrv() }}>
+        {children}
+      </PanelContextProvider>
+    );
+    const { result } = renderHook(() => useAdHocTransformations(), { wrapper });
+
+    expect(result.current.enabled).toBe(false);
+    // Mutators must be safe no-ops rather than throwing.
+    expect(() => result.current.add({ id: 'organize', options: {} })).not.toThrow();
+  });
+
+  it('exposes the whole pipeline', () => {
+    const transformations: DataTransformerConfig[] = [
+      { id: 'organize', options: {} },
+      { id: 'limit', options: { limitField: 5 } },
+    ];
+    const { result } = setup({ transformations });
+
+    expect(result.current.transformations).toEqual(transformations);
+  });
+
+  describe('adHocTransformations', () => {
+    it('only includes panel-authored entries', () => {
+      const { result } = setup({
+        transformations: [
+          { id: 'a', options: {} },
+          { id: 'b', options: {}, origin: { source: 'editor' } },
+          { id: 'c', options: {}, origin: { source: 'panel', pluginId: 'table' } },
+        ],
+      });
+
+      expect(result.current.adHocTransformations.map((t) => t.id)).toEqual(['c']);
+    });
+  });
+
+  describe('add', () => {
+    it('stamps the origin with the plugin id from the plugin context', () => {
+      const { result, setTransformations } = setup();
+
+      result.current.add({ id: 'organize', options: { excludeByName: { a: true } } });
+
+      expect(setTransformations).toHaveBeenCalledWith([
+        { id: 'organize', options: { excludeByName: { a: true } }, origin: { source: 'panel', pluginId: 'table' } },
+      ]);
+    });
+
+    it('appends after existing entries', () => {
+      const { result, setTransformations } = setup({ transformations: [{ id: 'existing', options: {} }] });
+
+      result.current.add({ id: 'organize', options: {} });
+
+      expect(setTransformations.mock.calls[0][0].map((t: DataTransformerConfig) => t.id)).toEqual([
+        'existing',
+        'organize',
+      ]);
+    });
+
+    // Locks in the append-never-merge decision: transformation options have no merge contract.
+    it('adds a second entry for an id that already exists', () => {
+      const { result, setTransformations } = setup({
+        transformations: [{ id: 'organize', options: {}, origin: { source: 'panel' } }],
+      });
+
+      result.current.add({ id: 'organize', options: { excludeByName: { a: true } } });
+
+      expect(setTransformations.mock.calls[0][0]).toHaveLength(2);
+    });
+  });
+
+  describe('replaceAdHoc', () => {
+    it('keeps editor entries in order and puts panel entries last', () => {
+      const { result, setTransformations } = setup({
+        transformations: [
+          { id: 'editor-1', options: {}, origin: { source: 'editor' } },
+          { id: 'old-panel', options: {}, origin: { source: 'panel' } },
+          { id: 'editor-2', options: {} },
+        ],
+      });
+
+      result.current.replaceAdHoc([{ id: 'new-panel', options: {} }]);
+
+      expect(setTransformations.mock.calls[0][0].map((t: DataTransformerConfig) => t.id)).toEqual([
+        'editor-1',
+        'editor-2',
+        'new-panel',
+      ]);
+    });
+
+    it('stamps the replacements', () => {
+      const { result, setTransformations } = setup();
+
+      result.current.replaceAdHoc([{ id: 'organize', options: {} }]);
+
+      expect(setTransformations.mock.calls[0][0][0].origin).toEqual({ source: 'panel', pluginId: 'table' });
+    });
+  });
+
+  describe('clearAdHoc', () => {
+    it('removes every panel entry by default', () => {
+      const { result, setTransformations } = setup({
+        transformations: [
+          { id: 'editor', options: {} },
+          { id: 'panel-a', options: {}, origin: { source: 'panel' } },
+          { id: 'panel-b', options: {}, origin: { source: 'panel' } },
+        ],
+      });
+
+      result.current.clearAdHoc();
+
+      expect(setTransformations.mock.calls[0][0].map((t: DataTransformerConfig) => t.id)).toEqual(['editor']);
+    });
+
+    it('removes only matching panel entries when given a predicate', () => {
+      const { result, setTransformations } = setup({
+        transformations: [
+          { id: 'panel-a', options: {}, origin: { source: 'panel' } },
+          { id: 'panel-b', options: {}, origin: { source: 'panel' } },
+        ],
+      });
+
+      result.current.clearAdHoc((t) => t.id === 'panel-a');
+
+      expect(setTransformations.mock.calls[0][0].map((t: DataTransformerConfig) => t.id)).toEqual(['panel-b']);
+    });
+  });
+
+  describe('set', () => {
+    it('writes the pipeline verbatim without stamping', () => {
+      const { result, setTransformations } = setup();
+      const next: DataTransformerConfig[] = [{ id: 'organize', options: {} }];
+
+      result.current.set(next);
+
+      expect(setTransformations).toHaveBeenCalledWith(next);
+    });
+  });
+});

--- a/packages/grafana-ui/src/components/PanelChrome/useAdHocTransformations.ts
+++ b/packages/grafana-ui/src/components/PanelChrome/useAdHocTransformations.ts
@@ -1,0 +1,106 @@
+import { useCallback, useMemo } from 'react';
+
+import { usePluginContext } from '@grafana/data';
+import { type DataTransformerConfig } from '@grafana/schema';
+
+import { usePanelContext } from './PanelContext';
+
+const EMPTY: DataTransformerConfig[] = [];
+
+/** A transformation the panel itself created, as opposed to one authored in the editor. */
+function isAdHoc(config: DataTransformerConfig): boolean {
+  return config.origin?.source === 'panel';
+}
+
+/**
+ * @alpha -- experimental
+ */
+export interface AdHocTransformationsApi {
+  /**
+   * False when the host does not support ad-hoc transformations, or the panel plugin has not
+   * declared `adHocTransforms` in its plugin.json. All mutators are no-ops when false.
+   */
+  enabled: boolean;
+
+  /** The whole pipeline in execution order, template variables already interpolated. */
+  transformations: DataTransformerConfig[];
+
+  /** Just the entries this panel created. */
+  adHocTransformations: DataTransformerConfig[];
+
+  /**
+   * Appends a transformation, stamped as panel-created. Always appends — it never merges into an
+   * existing entry of the same id, because transformation options have no merge contract and
+   * rewriting an editor-authored entry would be surprising. Use `replaceAdHoc` to keep a single
+   * entry in sync with panel state instead of appending on every interaction.
+   */
+  add: (config: DataTransformerConfig) => void;
+
+  /**
+   * Replaces every panel-created entry with `configs`, keeping editor-authored entries in their
+   * existing order first. Panel-created transformations therefore always run last.
+   */
+  replaceAdHoc: (configs: DataTransformerConfig[]) => void;
+
+  /** Removes panel-created entries — all of them, or just those matching `predicate`. */
+  clearAdHoc: (predicate?: (config: DataTransformerConfig) => boolean) => void;
+
+  /** Replaces the whole pipeline verbatim, without stamping anything. */
+  set: (configs: DataTransformerConfig[]) => void;
+}
+
+/**
+ * Read and write the panel's transformation pipeline from inside a panel plugin, so the
+ * visualization can offer its own transformation UI.
+ *
+ * Only meaningful for panels that declare `adHocTransforms: true` in their plugin.json. Such a
+ * panel receives untransformed data and is responsible for applying the pipeline itself — see
+ * `useTransformedData`.
+ *
+ * @alpha -- experimental
+ */
+export function useAdHocTransformations(): AdHocTransformationsApi {
+  const { isAdHocTransformsEnabled, getTransformations, setTransformations } = usePanelContext();
+  const pluginContext = usePluginContext();
+  const pluginId = pluginContext?.meta.id;
+
+  const enabled = Boolean(isAdHocTransformsEnabled?.() && getTransformations && setTransformations);
+  const transformations = (enabled && getTransformations?.()) || EMPTY;
+
+  const adHocTransformations = useMemo(() => transformations.filter(isAdHoc), [transformations]);
+
+  const set = useCallback(
+    (configs: DataTransformerConfig[]) => {
+      if (enabled) {
+        setTransformations?.(configs);
+      }
+    },
+    [enabled, setTransformations]
+  );
+
+  const stamp = useCallback(
+    (config: DataTransformerConfig): DataTransformerConfig => ({
+      ...config,
+      origin: { source: 'panel', ...(pluginId && { pluginId }), ...config.origin },
+    }),
+    [pluginId]
+  );
+
+  const add = useCallback(
+    (config: DataTransformerConfig) => set([...transformations, stamp(config)]),
+    [set, stamp, transformations]
+  );
+
+  const replaceAdHoc = useCallback(
+    (configs: DataTransformerConfig[]) => set([...transformations.filter((t) => !isAdHoc(t)), ...configs.map(stamp)]),
+    [set, stamp, transformations]
+  );
+
+  const clearAdHoc = useCallback(
+    (predicate?: (config: DataTransformerConfig) => boolean) =>
+      set(transformations.filter((t) => !isAdHoc(t) || (predicate ? !predicate(t) : false))),
+    [set, transformations]
+  );
+
+  return { enabled, transformations, adHocTransformations, add, replaceAdHoc, clearAdHoc, set };
+}

--- a/packages/grafana-ui/src/components/PanelChrome/useTransformedData.test.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/useTransformedData.test.tsx
@@ -1,0 +1,204 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { type ReactNode } from 'react';
+import { map, type Observable } from 'rxjs';
+
+import {
+  type DataFrame,
+  EventBusSrv,
+  FieldType,
+  LoadingState,
+  type PanelData,
+  standardTransformersRegistry,
+  toDataFrame,
+  type TransformerRegistryItem,
+} from '@grafana/data';
+import { type DataTransformerConfig } from '@grafana/schema';
+
+import { type PanelContext, PanelContextProvider } from './PanelContext';
+import { useTransformedData } from './useTransformedData';
+
+const excludeDropField: DataTransformerConfig[] = [{ id: 'dropFields', options: { exclude: ['drop'] } }];
+
+/** Drops the named fields from every frame. Enough to prove the pipeline ran. */
+const dropFieldsTransformer = {
+  id: 'dropFields',
+  name: 'Drop fields',
+  operator: (options: { exclude: string[] }) => (source: Observable<DataFrame[]>) =>
+    source.pipe(
+      map((frames) =>
+        frames.map((frame) => {
+          const fields = frame.fields.filter((f) => !options.exclude.includes(f.name));
+          return { ...frame, fields, length: frame.length };
+        })
+      )
+    ),
+};
+
+// The registry can only be initialised once per module, so everything is registered up front.
+beforeAll(() => {
+  standardTransformersRegistry.setInit(
+    () =>
+      [
+        {
+          id: dropFieldsTransformer.id,
+          name: dropFieldsTransformer.name,
+          transformation: () => Promise.resolve(dropFieldsTransformer),
+          editor: () => null,
+        },
+        {
+          id: 'boom',
+          name: 'Boom',
+          transformation: () => Promise.reject(new Error('kaboom')),
+          editor: () => null,
+        },
+      ] as unknown as TransformerRegistryItem[]
+  );
+});
+
+function makeData(overrides: Partial<PanelData> = {}): PanelData {
+  return {
+    state: LoadingState.Done,
+    series: [
+      toDataFrame({
+        refId: 'A',
+        fields: [
+          { name: 'keep', type: FieldType.number, values: [1, 2] },
+          { name: 'drop', type: FieldType.number, values: [3, 4] },
+        ],
+      }),
+    ],
+    timeRange: { from: {}, to: {}, raw: { from: 'now-6h', to: 'now' } } as PanelData['timeRange'],
+    ...overrides,
+  };
+}
+
+interface SetupOptions {
+  enabled?: boolean;
+  transformations?: DataTransformerConfig[];
+  source?: PanelData;
+  applyFieldConfig?: jest.Mock;
+}
+
+function setup(input: PanelData, options: SetupOptions = {}) {
+  const { enabled = true, transformations = [], source, applyFieldConfig = jest.fn((d: PanelData) => d) } = options;
+
+  const context: PanelContext = {
+    eventsScope: 'test',
+    eventBus: new EventBusSrv(),
+    isAdHocTransformsEnabled: () => enabled,
+    getTransformations: () => transformations,
+    setTransformations: jest.fn(),
+    // Undefined makes the hook fall back to the current props, which is what we want when the
+    // test is not specifically exercising pre-field-config source data.
+    getUntransformedData: () => source,
+    applyFieldConfig,
+  };
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <PanelContextProvider value={context}>{children}</PanelContextProvider>
+  );
+
+  const { result, rerender } = renderHook((props: PanelData) => useTransformedData(props), {
+    wrapper,
+    initialProps: input,
+  });
+
+  return { result, rerender, applyFieldConfig };
+}
+
+describe('useTransformedData', () => {
+  it('returns the input untouched when the panel does not own the pipeline', () => {
+    const input = makeData();
+    const { result } = setup(input, { enabled: false, transformations: excludeDropField });
+
+    expect(result.current.data).toBe(input);
+    expect(result.current.isTransforming).toBe(false);
+  });
+
+  it('returns the input untouched when the pipeline is empty', () => {
+    const input = makeData();
+    const { result } = setup(input, { transformations: [] });
+
+    expect(result.current.data).toBe(input);
+  });
+
+  it('does not apply field config when inactive', () => {
+    const input = makeData();
+    const { applyFieldConfig } = setup(input, { enabled: false, transformations: excludeDropField });
+
+    expect(applyFieldConfig).not.toHaveBeenCalled();
+  });
+
+  it('runs the pipeline and applies field config to the result', async () => {
+    const input = makeData();
+    const { result, applyFieldConfig } = setup(input, { transformations: excludeDropField });
+
+    await waitFor(() => expect(result.current.isTransforming).toBe(false));
+
+    expect(applyFieldConfig).toHaveBeenCalledTimes(1);
+    expect(result.current.data.series).toHaveLength(1);
+  });
+
+  it('reports loading on the very first run rather than flashing untransformed frames', async () => {
+    const input = makeData();
+    const { result } = setup(input, { transformations: excludeDropField });
+
+    expect(result.current.isTransforming).toBe(true);
+    expect(result.current.data.state).toBe(LoadingState.Loading);
+    // The frames the panel would flash are held back until the pipeline resolves.
+    expect(result.current.data.series[0].fields).toHaveLength(2);
+
+    // Let the pipeline settle so the state update lands inside the test.
+    await waitFor(() => expect(result.current.isTransforming).toBe(false));
+  });
+
+  it('surfaces a transformation error', async () => {
+    const input = makeData();
+    const { result } = setup(input, { transformations: [{ id: 'boom', options: {} }] });
+
+    await waitFor(() => expect(result.current.error).toBeDefined());
+    expect(result.current.error?.message).toContain('Error transforming data');
+  });
+
+  it('does not re-run the pipeline for a metadata-only change on the input', async () => {
+    const input = makeData({ state: LoadingState.Loading });
+    const { result, rerender, applyFieldConfig } = setup(input, { transformations: excludeDropField });
+
+    await waitFor(() => expect(applyFieldConfig).toHaveBeenCalledTimes(1));
+
+    // Same frames, different loading state — the pipeline must not run again.
+    rerender({ ...input, state: LoadingState.Done });
+
+    await waitFor(() => expect(result.current.data.series).toHaveLength(1));
+    expect(applyFieldConfig).toHaveBeenCalledTimes(1);
+  });
+
+  // getUntransformedData is called on every render, so if it hands back a fresh series array the
+  // effect re-subscribes forever. This asserts we run the pipeline once for stable source data.
+  it('runs the pipeline once when the source data identity is stable', async () => {
+    const input = makeData();
+    const source = makeData();
+    const { result, rerender, applyFieldConfig } = setup(input, { transformations: excludeDropField, source });
+
+    await waitFor(() => expect(result.current.isTransforming).toBe(false));
+
+    rerender({ ...input });
+    rerender({ ...input });
+
+    await waitFor(() => expect(result.current.data.series).toHaveLength(1));
+    expect(applyFieldConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps structureRev stable while the frame structure is unchanged', async () => {
+    const input = makeData();
+    const { result, rerender } = setup(input, { transformations: excludeDropField });
+
+    await waitFor(() => expect(result.current.isTransforming).toBe(false));
+    const first = result.current.data.structureRev;
+
+    rerender({ ...input, state: LoadingState.Streaming });
+    await waitFor(() => expect(result.current.data.state).toBe(LoadingState.Streaming));
+
+    expect(result.current.data.structureRev).toBe(first);
+  });
+});

--- a/packages/grafana-ui/src/components/PanelChrome/useTransformedData.ts
+++ b/packages/grafana-ui/src/components/PanelChrome/useTransformedData.ts
@@ -1,0 +1,159 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+import {
+  compareArrayValues,
+  compareDataFrameStructures,
+  type DataFrame,
+  type DataQueryError,
+  LoadingState,
+  type PanelData,
+  transformPanelData,
+} from '@grafana/data';
+
+import { usePanelContext } from './PanelContext';
+import { useAdHocTransformations } from './useAdHocTransformations';
+
+/**
+ * @alpha -- experimental
+ */
+export interface TransformedPanelData {
+  /**
+   * Transformed data with field config applied. Identical to the input when the panel does not own
+   * the pipeline, so it is safe to use unconditionally.
+   */
+  data: PanelData;
+
+  /** True while a transformation run is in flight. The previous result is kept meanwhile. */
+  isTransforming: boolean;
+
+  /**
+   * Set when the pipeline threw. `data.state` is `Error` and `data.errors` carries this too, but
+   * PanelChrome's header cannot see it, so a panel should surface it (e.g. PanelDataErrorView).
+   */
+  error?: DataQueryError;
+}
+
+interface TransformResult {
+  series: DataFrame[];
+  annotations?: DataFrame[];
+}
+
+/**
+ * Mirrors the message SceneDataTransformer produces for a failing pipeline. `toDataQueryError`
+ * lives in @grafana/runtime, which @grafana/ui cannot depend on, so the shape is built here.
+ */
+function toTransformationError(err: unknown): DataQueryError {
+  let message = 'Unknown error';
+
+  if (typeof err === 'string') {
+    message = err;
+  } else if (err instanceof Error) {
+    message = err.message;
+  } else if (err && typeof err === 'object' && 'message' in err && typeof err.message === 'string') {
+    message = err.message;
+  }
+
+  return { message: `Error transforming data: ${message}` };
+}
+
+/**
+ * Applies the panel's own transformation pipeline, for panels that declare `adHocTransforms: true`
+ * in their plugin.json and therefore receive untransformed data.
+ *
+ * Returns `input` unchanged when the panel does not own the pipeline, so a panel can adopt this
+ * with a single line and keep working in every host (Explore, alert previews, plugin-hosted
+ * panels) where ad-hoc transformations are unavailable.
+ *
+ * Field config is applied *after* the transformations, which is what the normal pipeline does and
+ * what makes transformations that rename or create fields render correctly. Note this means the
+ * returned data went through field config exactly once, from pre-field-config source data — do not
+ * mix frames from `props.data` with frames from here.
+ *
+ * @alpha -- experimental
+ */
+export function useTransformedData(input: PanelData): TransformedPanelData {
+  const { getUntransformedData, applyFieldConfig } = usePanelContext();
+  const { enabled, transformations } = useAdHocTransformations();
+
+  const active = enabled && transformations.length > 0;
+  const source = (active && getUntransformedData?.()) || input;
+
+  const [result, setResult] = useState<TransformResult | undefined>(undefined);
+  const [error, setError] = useState<DataQueryError | undefined>(undefined);
+  const [isTransforming, setIsTransforming] = useState(false);
+
+  const structureRev = useRef(0);
+  const prevSeries = useRef<DataFrame[]>([]);
+
+  useEffect(() => {
+    if (!active) {
+      setResult(undefined);
+      setError(undefined);
+      setIsTransforming(false);
+      return;
+    }
+
+    setIsTransforming(true);
+
+    // Deliberately keyed on the frames rather than on `source` identity: a metadata-only change
+    // (loading state, request, errors) must not re-run the pipeline. Same trick as
+    // SceneDataTransformer's own memoization.
+    const subscription = transformPanelData(transformations, source).subscribe({
+      next: (transformed) => {
+        setResult({ series: transformed.series, annotations: transformed.annotations });
+        setError(undefined);
+        setIsTransforming(false);
+      },
+      error: (err) => {
+        setError(toTransformationError(err));
+        setIsTransforming(false);
+      },
+    });
+
+    return () => subscription.unsubscribe();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [active, transformations, source.series, source.annotations]);
+
+  // Field config is the expensive part, so it only re-runs when the frames themselves change.
+  const withFieldConfig = useMemo(() => {
+    if (!result) {
+      return undefined;
+    }
+
+    if (!compareArrayValues(result.series, prevSeries.current, compareDataFrameStructures)) {
+      structureRev.current++;
+      prevSeries.current = result.series;
+    }
+
+    const next: PanelData = { ...source, series: result.series, annotations: result.annotations };
+
+    return applyFieldConfig ? applyFieldConfig(next) : next;
+    // `source` is excluded on purpose — only the frames matter here, and including it would
+    // re-apply field config on every metadata change.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [result, applyFieldConfig]);
+
+  const data = useMemo(() => {
+    if (!active) {
+      return input;
+    }
+
+    if (!withFieldConfig) {
+      // First run: hold back the untransformed frames rather than flashing them for a tick.
+      return isTransforming ? { ...input, state: LoadingState.Loading } : input;
+    }
+
+    return {
+      ...withFieldConfig,
+      structureRev: structureRev.current,
+      // Metadata always comes from the current source, so a refresh is reflected immediately even
+      // while the previous transformed frames are still on screen.
+      state: error ? LoadingState.Error : source.state,
+      request: source.request,
+      timeRange: source.timeRange,
+      errors: error ? [...(source.errors ?? []), error] : source.errors,
+    };
+  }, [active, input, withFieldConfig, isTransforming, error, source]);
+
+  return { data, isTransforming, error };
+}

--- a/packages/grafana-ui/src/index.ts
+++ b/packages/grafana-ui/src/index.ts
@@ -180,6 +180,10 @@ export {
   type PanelContext,
   PanelContextRoot,
   usePanelContext,
+  useAdHocTransformations,
+  type AdHocTransformationsApi,
+  useTransformedData,
+  type TransformedPanelData,
 } from './components/PanelChrome';
 export {
   VizLayout,


### PR DESCRIPTION
Two hooks so a panel plugin does not have to re-solve the awkward parts.

useAdHocTransformations reads and writes the pipeline and stamps origin: { source: 'panel', pluginId } from the plugin context. It appends and never merges: transformation options have no merge contract, and rewriting an editor-authored entry would defeat the point of recording origin. Panels that want a single entry kept in step with their own view state use replaceAdHoc, which keeps editor entries first so panel entries always run last.

useTransformedData applies the pipeline and returns PanelData, so a panel can shadow props.data in one line and still work in hosts where ad-hoc transformations are unavailable. It is state-based rather than suspense (transformDataFrame resolves operators through a dynamic import, so suspense would unmount the panel subtree on every change), keeps the previous result while a run is in flight, holds back untransformed frames on the first run rather than flashing them, and only re-runs when the frames change so a metadata-only update is free.

Field config is applied after the transformations, which is what the normal pipeline does and what makes transformations that rename or create fields render correctly.

**Special notes for your reviewer:**
PoC / UNVERIFIED

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
