### PR TITLE
AdHocTransforms: PoC dashboard schema and plugin capability - table example

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableNG/components/HeaderCell.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/components/HeaderCell.tsx
@@ -1,17 +1,53 @@
 import { css } from '@emotion/css';
 import memoize from 'micro-memoize';
-import React, { useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 
 import { type Field, type GrafanaTheme2 } from '@grafana/data';
+import { t } from '@grafana/i18n';
 import { type Column, type SortDirection } from '@grafana/react-data-grid';
 
 import { useStyles2 } from '../../../../themes/ThemeContext';
 import { getFieldTypeIcon } from '../../../../types/icon';
+import { Dropdown } from '../../../Dropdown/Dropdown';
 import { Icon } from '../../../Icon/Icon';
 import { Stack } from '../../../Layout/Stack/Stack';
+import { Menu } from '../../../Menu/Menu';
+import { useAdHocTransformations } from '../../../PanelChrome/useAdHocTransformations';
 import { Filter } from '../Filter/Filter';
 import { type FilterType, type TableRow, type TableSummaryRow } from '../types';
 import { getDisplayName } from '../utils';
+
+const ORGANIZE_TRANSFORMATION_ID = 'organize';
+
+/**
+ * Hides a column by keeping a single panel-authored `organize` transformation in sync with the
+ * set of hidden fields, rather than appending a new transformation per click.
+ */
+function useHideColumn(field: Field): (() => void) | undefined {
+  const { enabled, adHocTransformations, replaceAdHoc } = useAdHocTransformations();
+
+  const organize = useMemo(
+    () => adHocTransformations.find((t) => t.id === ORGANIZE_TRANSFORMATION_ID),
+    [adHocTransformations]
+  );
+
+  const hideColumn = useCallback(() => {
+    const others = adHocTransformations.filter((t) => t.id !== ORGANIZE_TRANSFORMATION_ID);
+
+    replaceAdHoc([
+      ...others,
+      {
+        id: ORGANIZE_TRANSFORMATION_ID,
+        options: {
+          ...organize?.options,
+          excludeByName: { ...organize?.options?.excludeByName, [field.name]: true },
+        },
+      },
+    ]);
+  }, [adHocTransformations, organize, replaceAdHoc, field.name]);
+
+  return enabled ? hideColumn : undefined;
+}
 
 interface HeaderCellProps {
   column: Column<TableRow, TableSummaryRow>;
@@ -47,6 +83,7 @@ export const HeaderCell: React.FC<HeaderCellProps> = ({
   const styles = useStyles2(getStyles, headerCellWrap);
   const displayName = getDisplayName(field);
   const filterable = field.config.custom?.filterable ?? false;
+  const hideColumn = useHideColumn(field);
 
   // we have to remove/reset the filter if the column is not filterable
   useEffect(() => {
@@ -120,6 +157,29 @@ export const HeaderCell: React.FC<HeaderCellProps> = ({
           crossFilterTailRows={crossFilterTailRows}
         />
       )}
+
+      {hideColumn && (
+        <Dropdown
+          overlay={
+            <Menu>
+              <Menu.Item
+                label={t('grafana-ui.table.header-cell.hide-column', 'Hide column')}
+                icon="eye-slash"
+                onClick={hideColumn}
+              />
+            </Menu>
+          }
+          placement="bottom-start"
+        >
+          <button
+            tabIndex={0}
+            className={styles.headerCellMenuButton}
+            aria-label={t('grafana-ui.table.header-cell.column-options', 'Column options')}
+          >
+            <Icon className={styles.headerCellIcon} name="ellipsis-v" size="sm" />
+          </button>
+        </Dropdown>
+      )}
     </Stack>
   );
 };
@@ -145,5 +205,15 @@ const getStyles = memoize((theme: GrafanaTheme2, headerTextWrap?: boolean) => ({
   }),
   headerCellIcon: css({
     color: theme.colors.text.secondary,
+  }),
+  headerCellMenuButton: css({
+    all: 'unset',
+    cursor: 'pointer',
+    display: 'flex',
+    alignItems: 'center',
+    borderRadius: theme.spacing(0.25),
+    '&:hover': {
+      color: theme.colors.text.primary,
+    },
   }),
 }));

--- a/public/app/plugins/panel/table/TablePanel.tsx
+++ b/public/app/plugins/panel/table/TablePanel.tsx
@@ -2,7 +2,7 @@ import { getFrameDisplayName, type PanelProps, type SelectableValue } from '@gra
 import { t } from '@grafana/i18n';
 import { PanelDataErrorView } from '@grafana/runtime';
 import { type TableOptions } from '@grafana/schema';
-import { Combobox, Field, Stack, usePanelContext, useTheme2 } from '@grafana/ui';
+import { Combobox, Field, Stack, usePanelContext, useTheme2, useTransformedData } from '@grafana/ui';
 import { TableNG } from '@grafana/ui/unstable';
 import {
   useCacheFieldDisplayNames,
@@ -21,7 +21,6 @@ interface Props extends PanelProps<TableOptions> {
 
 export function TablePanel(props: Props) {
   const {
-    data,
     height,
     width,
     options,
@@ -33,6 +32,10 @@ export function TablePanel(props: Props) {
     initialRowIndex,
     sortByBehavior = 'initial',
   } = props;
+
+  // The table declares `adHocTransforms`, so in a dashboard it receives untransformed data and
+  // applies the pipeline itself. Everywhere else this returns props.data unchanged.
+  const { data } = useTransformedData(props.data);
 
   useCacheFieldDisplayNames(data.series);
 

--- a/public/app/plugins/panel/table/plugin.json
+++ b/public/app/plugins/panel/table/plugin.json
@@ -3,6 +3,7 @@
   "name": "Table",
   "id": "table",
   "suggestions": true,
+  "adHocTransforms": true,
   "info": {
     "description": "Supports many column styles",
     "author": {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -10623,6 +10623,10 @@
           "count": "Count"
         }
       },
+      "header-cell": {
+        "column-options": "Column options",
+        "hide-column": "Hide column"
+      },
       "inspect-drawer-title": "Inspect value",
       "nested-table": {
         "expander-column-name": "Expand nested rows",


### PR DESCRIPTION
Not an actual UI we want to add, just the simplest demonstration of the capability

<img width="1707" height="513" alt="image" src="https://github.com/user-attachments/assets/8d713609-0b0e-4a91-b3ac-15f4416a04b3" />

First consumer of the ad-hoc transformation hooks. The table panel declares adHocTransforms, applies its own pipeline via useTransformedData, and gains a "Hide column" item in the column header menu.

HeaderCell calls useAdHocTransformations directly rather than threading a callback down through TableNG: it already renders inside PanelContextProvider, and other TableNG components use usePanelContext the same way. The menu item simply does not render in hosts where ad-hoc transformations are unavailable.

Hidden columns are kept as one panel-authored organize transformation, rewritten on each interaction, rather than appending a transformation per click.

**Special notes for your reviewer:**
The simplicity of this example happens to fit the current spec well, but https://github.com/grafana/grafana/pull/129563 is probably better as an illustration of the problems the parent branches should address for a long-term stable API that gives panels the level of control they need to create UI for arbitrary transformations

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
