### PR TITLE
[release-13.0.5] Packaging: Fix error removing bundled plugins dir wh…

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -25,6 +25,9 @@ logs = data/log
 # Directory where grafana will automatically scan and look for plugins
 plugins = data/plugins
 
+# Directory where grafana looks for the plugins bundled with the Grafana distribution
+bundled_plugins = data/plugins-bundled
+
 # folder that contains provisioning config files that grafana will apply on startup and while running.
 provisioning = conf/provisioning
 

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -23,6 +23,9 @@
 # Directory where grafana will automatically scan and look for plugins
 ;plugins = /var/lib/grafana/plugins
 
+# Directory where grafana looks for the plugins bundled with the Grafana distribution
+;bundled_plugins = /var/lib/grafana/plugins-bundled
+
 # folder that contains provisioning config files that grafana will apply on startup and while running.
 ;provisioning = conf/provisioning
 

--- a/packaging/deb/control/postinst
+++ b/packaging/deb/control/postinst
@@ -13,6 +13,7 @@ if [ "$1" = configure ]; then
   [ -z "$GRAFANA_USER" ] && GRAFANA_USER="grafana"
   [ -z "$GRAFANA_GROUP" ] && GRAFANA_GROUP="grafana"
   [ -z "$GRAFANA_HOME" ] && GRAFANA_HOME="/usr/share/grafana"
+  [ -z "$DATA_DIR" ] && DATA_DIR="/var/lib/grafana"
   if ! getent group "$GRAFANA_GROUP" > /dev/null 2>&1 ; then
     addgroup --system "$GRAFANA_GROUP" --quiet
   fi
@@ -23,9 +24,18 @@ if [ "$1" = configure ]; then
   fi
 
   # Set user permissions on /var/log/grafana, /var/lib/grafana
-  mkdir -p /var/log/grafana /var/lib/grafana
-  chown -R $GRAFANA_USER:$GRAFANA_GROUP /var/log/grafana /var/lib/grafana
-  chmod 755 /var/log/grafana /var/lib/grafana
+  mkdir -p /var/log/grafana "$DATA_DIR"
+  # Bundled plugins must live under $DATA_DIR (writable by grafana) so the
+  # plugin auto-updater can replace them; the service points
+  # paths.bundled_plugins there. Copy instead of move so the packaged files
+  # stay in place and `dpkg --verify` stays clean. Any copy already at the
+  # destination is stale and safe to clobber.
+  if [ -d "$GRAFANA_HOME/data/plugins-bundled" ]; then
+    rm -rf "${DATA_DIR:?}/plugins-bundled"
+    cp -a "$GRAFANA_HOME/data/plugins-bundled" "$DATA_DIR"
+  fi
+  chown -R "$GRAFANA_USER":"$GRAFANA_GROUP" /var/log/grafana "$DATA_DIR"
+  chmod 755 /var/log/grafana "$DATA_DIR"
 
   # copy user config files
   if [ ! -f $CONF_FILE ]; then

--- a/packaging/deb/init.d/grafana-server
+++ b/packaging/deb/init.d/grafana-server
@@ -56,7 +56,7 @@ if [ -f "$DEFAULT" ]; then
   . "$DEFAULT"
 fi
 
-DAEMON_OPTS="server --pidfile=${PID_FILE} --config=${CONF_FILE} --packaging=deb cfg:default.paths.provisioning=$PROVISIONING_CFG_DIR cfg:default.paths.data=${DATA_DIR} cfg:default.paths.logs=${LOG_DIR} cfg:default.paths.plugins=${PLUGINS_DIR}"
+DAEMON_OPTS="server --pidfile=${PID_FILE} --config=${CONF_FILE} --packaging=deb cfg:default.paths.provisioning=$PROVISIONING_CFG_DIR cfg:default.paths.data=${DATA_DIR} cfg:default.paths.logs=${LOG_DIR} cfg:default.paths.plugins=${PLUGINS_DIR} cfg:default.paths.bundled_plugins=${DATA_DIR}/plugins-bundled"
 
 function checkUser() {
   if [ `id -u` -ne 0 ]; then

--- a/packaging/deb/systemd/grafana-server.service
+++ b/packaging/deb/systemd/grafana-server.service
@@ -21,7 +21,8 @@ ExecStart=/usr/share/grafana/bin/grafana server                                 
                             cfg:default.paths.logs=${LOG_DIR}                       \
                             cfg:default.paths.data=${DATA_DIR}                      \
                             cfg:default.paths.plugins=${PLUGINS_DIR}                \
-                            cfg:default.paths.provisioning=${PROVISIONING_CFG_DIR}
+                            cfg:default.paths.provisioning=${PROVISIONING_CFG_DIR}  \
+                            cfg:default.paths.bundled_plugins=${DATA_DIR}/plugins-bundled
 
 LimitNOFILE=10000
 TimeoutStopSec=20

--- a/packaging/rpm/control/postinst
+++ b/packaging/rpm/control/postinst
@@ -19,6 +19,8 @@ stopGrafana() {
 if [ $1 -eq 1 ] ; then
   [ -z "$GRAFANA_USER" ] && GRAFANA_USER="grafana"
   [ -z "$GRAFANA_GROUP" ] && GRAFANA_GROUP="grafana"
+  [ -z "$GRAFANA_HOME" ] && GRAFANA_HOME="/usr/share/grafana"
+  [ -z "$DATA_DIR" ] && DATA_DIR="/var/lib/grafana"
   if ! getent group "$GRAFANA_GROUP" > /dev/null 2>&1 ; then
     groupadd -r "$GRAFANA_GROUP"
   fi
@@ -28,9 +30,18 @@ if [ $1 -eq 1 ] ; then
   fi
 
   # Set user permissions on /var/log/grafana, /var/lib/grafana
-  mkdir -p /var/log/grafana /var/lib/grafana
-  chown -R $GRAFANA_USER:$GRAFANA_GROUP /var/log/grafana /var/lib/grafana
-  chmod 755 /var/log/grafana /var/lib/grafana
+  mkdir -p /var/log/grafana "$DATA_DIR"
+  # Bundled plugins must live under $DATA_DIR (writable by grafana) so the
+  # plugin auto-updater can replace them; the service points
+  # paths.bundled_plugins there. Copy instead of move so the packaged files
+  # stay in place and `rpm -V` stays clean. Any copy already at the
+  # destination is stale and safe to clobber.
+  if [ -d "$GRAFANA_HOME/data/plugins-bundled" ]; then
+    rm -rf "${DATA_DIR:?}/plugins-bundled"
+    cp -a "$GRAFANA_HOME/data/plugins-bundled" "$DATA_DIR"
+  fi
+  chown -R "$GRAFANA_USER":"$GRAFANA_GROUP" /var/log/grafana "$DATA_DIR"
+  chmod 755 /var/log/grafana "$DATA_DIR"
 
   # copy user config files
   if [ ! -f $CONF_FILE ]; then
@@ -72,6 +83,20 @@ if [ $1 -eq 1 ] ; then
   echo " sudo /bin/systemctl start grafana-server.service"
 
 elif [ $1 -ge 2 ] ; then
+  [ -z "$GRAFANA_USER" ] && GRAFANA_USER="grafana"
+  [ -z "$GRAFANA_GROUP" ] && GRAFANA_GROUP="grafana"
+  [ -z "$GRAFANA_HOME" ] && GRAFANA_HOME="/usr/share/grafana"
+  [ -z "$DATA_DIR" ] && DATA_DIR="/var/lib/grafana"
+
+  # Replace the bundled plugins with the ones shipped in the new package.
+  # See the matching copy in the fresh-install branch above.
+  if [ -d "$GRAFANA_HOME/data/plugins-bundled" ]; then
+    mkdir -p "$DATA_DIR"
+    rm -rf "${DATA_DIR:?}/plugins-bundled"
+    cp -a "$GRAFANA_HOME/data/plugins-bundled" "$DATA_DIR"
+    chown -R "$GRAFANA_USER":"$GRAFANA_GROUP" "$DATA_DIR/plugins-bundled"
+  fi
+
   if [ "$RESTART_ON_UPGRADE" == "true" ]; then
     stopGrafana
     startGrafana

--- a/packaging/rpm/systemd/grafana-server.service
+++ b/packaging/rpm/systemd/grafana-server.service
@@ -21,7 +21,8 @@ ExecStart=/usr/share/grafana/bin/grafana server                                 
                             cfg:default.paths.logs=${LOG_DIR}                       \
                             cfg:default.paths.data=${DATA_DIR}                      \
                             cfg:default.paths.plugins=${PLUGINS_DIR}                \
-                            cfg:default.paths.provisioning=${PROVISIONING_CFG_DIR}
+                            cfg:default.paths.provisioning=${PROVISIONING_CFG_DIR}  \
+                            cfg:default.paths.bundled_plugins=${DATA_DIR}/plugins-bundled
 
 LimitNOFILE=10000
 TimeoutStopSec=20

--- a/packaging/wrappers/grafana
+++ b/packaging/wrappers/grafana
@@ -37,7 +37,7 @@ if [ "$1" = cli ] || [ "$1" = server ]; then
   OPTS=(
     "--homepath=${GRAFANA_HOME}"
     "--config=${CONF_FILE}"
-    "--configOverrides=cfg:default.paths.provisioning=${PROVISIONING_CFG_DIR} cfg:default.paths.data=${DATA_DIR} cfg:default.paths.logs=${LOG_DIR} cfg:default.paths.plugins=${PLUGINS_DIR}"
+    "--configOverrides=cfg:default.paths.provisioning=${PROVISIONING_CFG_DIR} cfg:default.paths.data=${DATA_DIR} cfg:default.paths.logs=${LOG_DIR} cfg:default.paths.plugins=${PLUGINS_DIR} cfg:default.paths.bundled_plugins=${DATA_DIR}/plugins-bundled"
   )
   # special handling to pass --pluginsDir to cli
   # can remove once it fully supports cfg:default.paths.plugins


### PR DESCRIPTION
…en upgrading Grafana (#129003)

* Packaging: Fix error removing bundled plugins dir when upgrading Grafana

(cherry picked from commit 7a00a8dfd7f2e39ce22d94f4601f5ad9423f6908)

See also: https://github.com/grafana/grafana/pull/129003