### PR TITLE
Unified storage: add exemption to the limited client

### DIFF
--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -693,7 +693,9 @@ type Cfg struct {
 	ShortLinkExpiration int
 
 	// Unified Storage
-	UnifiedStorage map[string]UnifiedStorageConfig
+	UnifiedStorage                      map[string]UnifiedStorageConfig
+	UnifiedStorageAuthzExemptionEnabled bool
+	UnifiedStorageAuthzExemptResources  []string
 	// DisableLegacyTableRename will skip renaming legacy tables (e.g., playlist → playlist_legacy) after migration
 	DisableLegacyTableRename bool
 	// MigrationCacheSizeKB sets SQLite PRAGMA cache_size during data migrations (in KB).

--- a/pkg/setting/setting_unified_storage.go
+++ b/pkg/setting/setting_unified_storage.go
@@ -173,6 +173,8 @@ func (cfg *Cfg) setUnifiedStorageConfig() {
 	cfg.MigrationChunkMaxBytes = section.Key("migration_chunk_max_bytes").MustInt64(256 * 1024 * 1024)
 	cfg.DisableLegacyTableRename = section.Key("disable_legacy_table_rename").MustBool(false)
 	cfg.RenameWaitDeadline = section.Key("rename_wait_deadline").MustDuration(time.Minute)
+	cfg.UnifiedStorageAuthzExemptionEnabled = section.Key("authz_exemption_enabled").MustBool(false)
+	cfg.UnifiedStorageAuthzExemptResources = parseCommaSeparatedList(section.Key("authz_exempt_resources").String())
 	cfg.SearchInjectFailuresPercent = section.Key("search_inject_failures_percent").MustInt(0)
 	if cfg.SearchInjectFailuresPercent < 0 {
 		cfg.SearchInjectFailuresPercent = 0

--- a/pkg/setting/setting_unified_storage_test.go
+++ b/pkg/setting/setting_unified_storage_test.go
@@ -234,6 +234,51 @@ func TestCfg_setUnifiedStorageConfig(t *testing.T) {
 		assert.Equal(t, 3, cfg.IndexWorkers)
 	})
 
+	t.Run("authorization defaults preserve allowlist behavior", func(t *testing.T) {
+		cfg := NewCfg()
+		err := cfg.Load(CommandLineArgs{HomePath: "../../", Config: "../../conf/defaults.ini"})
+		assert.NoError(t, err)
+
+		cfg.setUnifiedStorageConfig()
+
+		assert.False(t, cfg.UnifiedStorageAuthzExemptionEnabled)
+		assert.Empty(t, cfg.UnifiedStorageAuthzExemptResources)
+	})
+
+	t.Run("authorization config reads INI controls", func(t *testing.T) {
+		cfg := NewCfg()
+		err := cfg.Load(CommandLineArgs{HomePath: "../../", Config: "../../conf/defaults.ini"})
+		assert.NoError(t, err)
+		section := cfg.Raw.Section("unified_storage")
+		section.Key("authz_exemption_enabled").SetValue("true")
+		section.Key("authz_exempt_resources").SetValue(" example.grafana.app/widgets,querycaching.grafana.app/querycacheconfigs, ")
+
+		cfg.setUnifiedStorageConfig()
+
+		assert.True(t, cfg.UnifiedStorageAuthzExemptionEnabled)
+		assert.Equal(t, []string{
+			"example.grafana.app/widgets",
+			"querycaching.grafana.app/querycacheconfigs",
+		}, cfg.UnifiedStorageAuthzExemptResources)
+	})
+
+	t.Run("authorization config supports unified storage env overrides", func(t *testing.T) {
+		t.Setenv("GF_UNIFIED_STORAGE_AUTHZ_EXEMPTION_ENABLED", "true")
+		t.Setenv("GF_UNIFIED_STORAGE_AUTHZ_EXEMPT_RESOURCES", "example.grafana.app/widgets,querycaching.grafana.app/querycacheconfigs")
+
+		cfg := NewCfg()
+		err := cfg.Load(CommandLineArgs{HomePath: "../../", Config: "../../conf/defaults.ini"})
+		assert.NoError(t, err)
+
+		cfg.setUnifiedStorageConfig()
+
+		assert.True(t, cfg.UnifiedStorageAuthzExemptionEnabled)
+		assert.Equal(t, []string{
+			"example.grafana.app/widgets",
+			"querycaching.grafana.app/querycacheconfigs",
+		}, cfg.UnifiedStorageAuthzExemptResources)
+	})
+
 	t.Run("chunked writes config defaults", func(t *testing.T) {
 		cfg := NewCfg()
 		err := cfg.Load(CommandLineArgs{HomePath: "../../", Config: "../../conf/defaults.ini"})

--- a/pkg/storage/unified/resource/access.go
+++ b/pkg/storage/unified/resource/access.go
@@ -77,38 +77,78 @@ func newMetrics(reg prometheus.Registerer) *accessMetrics {
 	return m
 }
 
+// rbacAllowlist is a map of group to resources that are compatible with RBAC.
+var rbacAllowlist = groupResource{
+	"dashboard.grafana.app": map[string]interface{}{"dashboards": nil},
+	"folder.grafana.app":    map[string]interface{}{"folders": nil},
+	"iam.grafana.app":       map[string]interface{}{"users": nil, "teams": nil, "serviceaccounts": nil},
+}
+
 // authzLimitedClient is a client that enforces RBAC for the limited number of groups and resources.
 // This is a temporary solution until the authz service is fully implemented.
 // The authz service will be responsible for enforcing RBAC.
 // For now, it makes one call to the authz service for each list items. This is known to be inefficient.
 type authzLimitedClient struct {
 	client claims.AccessClient
-	// allowlist is a map of group to resources that are compatible with RBAC.
-	allowlist groupResource
-	logger    log.Logger
-	metrics   *accessMetrics
+	// exemptionEnabled inverts the gate: every group and resource is enforced,
+	// except the exemptions below. Temporary, until every resource is mapped.
+	exemptionEnabled bool
+	exemptions       groupResource
+	logger           log.Logger
+	metrics          *accessMetrics
 }
 
 type AuthzOptions struct {
-	Registry prometheus.Registerer
+	Registry         prometheus.Registerer
+	ExemptionEnabled bool
+	ExemptResources  []string
 }
 
 // NewAuthzLimitedClient creates a new authzLimitedClient.
-func NewAuthzLimitedClient(client claims.AccessClient, opts AuthzOptions) claims.AccessClient {
+func NewAuthzLimitedClient(client claims.AccessClient, opts AuthzOptions) (claims.AccessClient, error) {
 	logger := log.New("limited-authz-client")
 	if opts.Registry == nil {
 		opts.Registry = prometheus.DefaultRegisterer
 	}
-	return &authzLimitedClient{
-		client: client,
-		allowlist: groupResource{
-			"dashboard.grafana.app": map[string]interface{}{"dashboards": nil},
-			"folder.grafana.app":    map[string]interface{}{"folders": nil},
-			"iam.grafana.app":       map[string]interface{}{"users": nil, "teams": nil, "serviceaccounts": nil},
-		},
-		logger:  logger,
-		metrics: newMetrics(opts.Registry),
+	exemptions, err := parseAuthzExemptions(opts.ExemptResources)
+	if err != nil {
+		return nil, err
 	}
+	return &authzLimitedClient{
+		client:           client,
+		exemptionEnabled: opts.ExemptionEnabled,
+		exemptions:       exemptions,
+		logger:           logger,
+		metrics:          newMetrics(opts.Registry),
+	}, nil
+}
+
+// parseAuthzExemptions validates the configured exemptions, whether or not the
+// exemption gate is enabled, so a bad value never silently drops enforcement.
+func parseAuthzExemptions(values []string) (groupResource, error) {
+	exemptions := make(groupResource)
+	for _, value := range values {
+		group, resource, _ := strings.Cut(value, "/")
+		if strings.Count(value, "/") != 1 || strings.Contains(value, "*") || group == "" || resource == "" {
+			return nil, fmt.Errorf("invalid unified storage authz exemption %q: expecting an exact group/resource", value)
+		}
+		if alwaysEnforced(group, resource) {
+			return nil, fmt.Errorf("invalid unified storage authz exemption %q: it is already enforced", value)
+		}
+		if exemptions[group] == nil {
+			exemptions[group] = make(map[string]interface{})
+		}
+		exemptions[group][resource] = nil
+	}
+	return exemptions, nil
+}
+
+func alwaysEnforced(group, resource string) bool {
+	if strings.HasSuffix(group, ".ext.grafana.app") {
+		return true
+	}
+	_, ok := rbacAllowlist[group][resource]
+	return ok
 }
 
 // Check implements claims.AccessClient.
@@ -190,15 +230,14 @@ func (c authzLimitedClient) IsCompatibleWithRBAC(group, resource string) bool {
 	// for K8s-native CRDs. This mirrors narrowing in
 	// rbac.Service.checkPermission and keeps folder/dashboard/iam flow on the
 	// existing allow-list path.
-	if strings.HasSuffix(group, ".ext.grafana.app") {
+	if alwaysEnforced(group, resource) {
 		return true
 	}
-	if _, ok := c.allowlist[group]; ok {
-		if _, ok := c.allowlist[group][resource]; ok {
-			return true
-		}
+	if !c.exemptionEnabled {
+		return false
 	}
-	return false
+	_, exempt := c.exemptions[group][resource]
+	return !exempt
 }
 
 func (c authzLimitedClient) BatchCheck(ctx context.Context, id claims.AuthInfo, req claims.BatchCheckRequest) (claims.BatchCheckResponse, error) {

--- a/pkg/storage/unified/resource/access.go
+++ b/pkg/storage/unified/resource/access.go
@@ -105,14 +105,16 @@ type AuthzOptions struct {
 }
 
 // NewAuthzLimitedClient creates a new authzLimitedClient.
-func NewAuthzLimitedClient(client claims.AccessClient, opts AuthzOptions) (claims.AccessClient, error) {
+func NewAuthzLimitedClient(client claims.AccessClient, opts AuthzOptions) claims.AccessClient {
 	logger := log.New("limited-authz-client")
 	if opts.Registry == nil {
 		opts.Registry = prometheus.DefaultRegisterer
 	}
 	exemptions, err := parseAuthzExemptions(opts.ExemptResources)
 	if err != nil {
-		return nil, err
+		// Callers validate with ValidateAuthzOptions first. Drop the whole list
+		// rather than apply part of one that did not parse.
+		logger.Error("Ignoring unified storage authz exemptions", "error", err)
 	}
 	return &authzLimitedClient{
 		client:           client,
@@ -120,7 +122,14 @@ func NewAuthzLimitedClient(client claims.AccessClient, opts AuthzOptions) (claim
 		exemptions:       exemptions,
 		logger:           logger,
 		metrics:          newMetrics(opts.Registry),
-	}, nil
+	}
+}
+
+// ValidateAuthzOptions reports exemptions the client would refuse to apply, so
+// startup fails instead of running with a list that is silently ignored.
+func ValidateAuthzOptions(opts AuthzOptions) error {
+	_, err := parseAuthzExemptions(opts.ExemptResources)
+	return err
 }
 
 // parseAuthzExemptions validates the configured exemptions, whether or not the

--- a/pkg/storage/unified/resource/access_test.go
+++ b/pkg/storage/unified/resource/access_test.go
@@ -13,10 +13,17 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 )
 
+func newTestAuthzClient(t *testing.T, client authlib.AccessClient, opts AuthzOptions) authlib.AccessClient {
+	t.Helper()
+	wrapped, err := NewAuthzLimitedClient(client, opts)
+	require.NoError(t, err)
+	return wrapped
+}
+
 func TestAuthzLimitedClient_BatchCheck(t *testing.T) {
 	t.Run("RBAC compatible resources should use underlying client", func(t *testing.T) {
 		mockClient := authlib.FixedAccessClient(false)
-		client := NewAuthzLimitedClient(mockClient, AuthzOptions{})
+		client := newTestAuthzClient(t, mockClient, AuthzOptions{})
 
 		req := authlib.BatchCheckRequest{
 			Namespace: "stacks-1",
@@ -35,7 +42,7 @@ func TestAuthzLimitedClient_BatchCheck(t *testing.T) {
 
 	t.Run("non-RBAC compatible resources should be allowed", func(t *testing.T) {
 		mockClient := authlib.FixedAccessClient(false)
-		client := NewAuthzLimitedClient(mockClient, AuthzOptions{})
+		client := newTestAuthzClient(t, mockClient, AuthzOptions{})
 
 		req := authlib.BatchCheckRequest{
 			Namespace: "stacks-1",
@@ -54,7 +61,7 @@ func TestAuthzLimitedClient_BatchCheck(t *testing.T) {
 
 	t.Run("mixed resources - some RBAC compatible, some not", func(t *testing.T) {
 		mockClient := authlib.FixedAccessClient(false)
-		client := NewAuthzLimitedClient(mockClient, AuthzOptions{})
+		client := newTestAuthzClient(t, mockClient, AuthzOptions{})
 
 		req := authlib.BatchCheckRequest{
 			Namespace: "stacks-1",
@@ -78,7 +85,7 @@ func TestAuthzLimitedClient_BatchCheck(t *testing.T) {
 
 	t.Run("RBAC compatible resources with allowed client", func(t *testing.T) {
 		mockClient := authlib.FixedAccessClient(true)
-		client := NewAuthzLimitedClient(mockClient, AuthzOptions{})
+		client := newTestAuthzClient(t, mockClient, AuthzOptions{})
 
 		req := authlib.BatchCheckRequest{
 			Namespace: "stacks-1",
@@ -96,7 +103,7 @@ func TestAuthzLimitedClient_BatchCheck(t *testing.T) {
 
 func TestAuthzLimitedClient_Check(t *testing.T) {
 	mockClient := authlib.FixedAccessClient(false)
-	client := NewAuthzLimitedClient(mockClient, AuthzOptions{})
+	client := newTestAuthzClient(t, mockClient, AuthzOptions{})
 
 	tests := []struct {
 		group    string
@@ -123,7 +130,7 @@ func TestAuthzLimitedClient_Check(t *testing.T) {
 
 func TestAuthzLimitedClient_Compile(t *testing.T) {
 	mockClient := authlib.FixedAccessClient(false)
-	client := NewAuthzLimitedClient(mockClient, AuthzOptions{})
+	client := newTestAuthzClient(t, mockClient, AuthzOptions{})
 
 	tests := []struct {
 		group    string
@@ -156,7 +163,7 @@ func TestAuthzLimitedClient_Compile(t *testing.T) {
 func TestNamespaceMatching(t *testing.T) {
 	// Create a mock client that always returns allowed=true
 	mockClient := authlib.FixedAccessClient(true)
-	client := NewAuthzLimitedClient(mockClient, AuthzOptions{})
+	client := newTestAuthzClient(t, mockClient, AuthzOptions{})
 
 	// Create a context with fallback disabled
 	ctx := context.Background()
@@ -238,6 +245,80 @@ func TestNamespaceMatching(t *testing.T) {
 				assert.NoError(t, checkErr, "Check should not return error when namespaces match")
 				assert.NoError(t, compileErr, "Compile should not return error when namespaces match")
 			}
+		})
+	}
+}
+
+func TestNewAuthzLimitedClientValidation(t *testing.T) {
+	for _, value := range []string{"", "group", "/resource", "group/", "group/resource/extra", "group/*"} {
+		t.Run("rejects malformed exemption "+value, func(t *testing.T) {
+			_, err := NewAuthzLimitedClient(authlib.FixedAccessClient(true), AuthzOptions{
+				ExemptResources: []string{value},
+			})
+			require.ErrorContains(t, err, "invalid unified storage authz exemption")
+		})
+	}
+
+	for _, value := range []string{
+		"dashboard.grafana.app/dashboards",
+		"folder.grafana.app/folders",
+		"iam.grafana.app/users",
+		"iam.grafana.app/teams",
+		"iam.grafana.app/serviceaccounts",
+		"plugin.ext.grafana.app/widgets",
+	} {
+		t.Run("rejects already enforced exemption "+value, func(t *testing.T) {
+			_, err := NewAuthzLimitedClient(authlib.FixedAccessClient(true), AuthzOptions{
+				ExemptResources: []string{value},
+			})
+			require.ErrorContains(t, err, "it is already enforced")
+		})
+	}
+
+	t.Run("deduplicates exact exemptions", func(t *testing.T) {
+		client, err := NewAuthzLimitedClient(authlib.FixedAccessClient(true), AuthzOptions{
+			ExemptResources: []string{"example.grafana.app/widgets", "example.grafana.app/widgets"},
+		})
+		require.NoError(t, err)
+		wrapped := client.(*authzLimitedClient)
+		require.Len(t, wrapped.exemptions, 1)
+		require.Len(t, wrapped.exemptions["example.grafana.app"], 1)
+	})
+}
+
+func TestAuthzLimitedClientExemptionGate(t *testing.T) {
+	exempted := AuthzOptions{ExemptionEnabled: true, ExemptResources: []string{"example.grafana.app/widgets"}}
+
+	tests := []struct {
+		name       string
+		opts       AuthzOptions
+		group      string
+		resource   string
+		isEnforced bool
+	}{
+		{"disabled enforces allowlist resource", AuthzOptions{}, "dashboard.grafana.app", "dashboards", true},
+		{"disabled enforces extension group", AuthzOptions{}, "plugin.ext.grafana.app", "widgets", true},
+		{"disabled bypasses unknown resource", AuthzOptions{}, "example.grafana.app", "widgets", false},
+		{"disabled ignores exemptions", AuthzOptions{ExemptResources: exempted.ExemptResources}, "example.grafana.app", "widgets", false},
+		{"enabled without exemptions enforces unknown resource", AuthzOptions{ExemptionEnabled: true}, "example.grafana.app", "widgets", true},
+		{"enabled enforces dashboards", AuthzOptions{ExemptionEnabled: true}, "dashboard.grafana.app", "dashboards", true},
+		{"enabled enforces folders", AuthzOptions{ExemptionEnabled: true}, "folder.grafana.app", "folders", true},
+		{"enabled enforces iam", AuthzOptions{ExemptionEnabled: true}, "iam.grafana.app", "users", true},
+		{"enabled enforces extension group", AuthzOptions{ExemptionEnabled: true}, "plugin.ext.grafana.app", "widgets", true},
+		{"enabled bypasses exact exemption", exempted, "example.grafana.app", "widgets", false},
+		{"enabled enforces sibling of exemption", exempted, "example.grafana.app", "gadgets", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := newTestAuthzClient(t, authlib.FixedAccessClient(false), tt.opts)
+
+			// The underlying client denies everything, so an allowed response means the check was bypassed.
+			check, err := client.Check(context.Background(), &identity.StaticRequester{Namespace: "stacks-1"}, authlib.CheckRequest{
+				Group: tt.group, Resource: tt.resource, Verb: utils.VerbGet, Namespace: "stacks-1", Name: "one",
+			}, "")
+			require.NoError(t, err)
+			assert.Equal(t, !tt.isEnforced, check.Allowed)
 		})
 	}
 }

--- a/pkg/storage/unified/resource/access_test.go
+++ b/pkg/storage/unified/resource/access_test.go
@@ -13,17 +13,10 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 )
 
-func newTestAuthzClient(t *testing.T, client authlib.AccessClient, opts AuthzOptions) authlib.AccessClient {
-	t.Helper()
-	wrapped, err := NewAuthzLimitedClient(client, opts)
-	require.NoError(t, err)
-	return wrapped
-}
-
 func TestAuthzLimitedClient_BatchCheck(t *testing.T) {
 	t.Run("RBAC compatible resources should use underlying client", func(t *testing.T) {
 		mockClient := authlib.FixedAccessClient(false)
-		client := newTestAuthzClient(t, mockClient, AuthzOptions{})
+		client := NewAuthzLimitedClient(mockClient, AuthzOptions{})
 
 		req := authlib.BatchCheckRequest{
 			Namespace: "stacks-1",
@@ -42,7 +35,7 @@ func TestAuthzLimitedClient_BatchCheck(t *testing.T) {
 
 	t.Run("non-RBAC compatible resources should be allowed", func(t *testing.T) {
 		mockClient := authlib.FixedAccessClient(false)
-		client := newTestAuthzClient(t, mockClient, AuthzOptions{})
+		client := NewAuthzLimitedClient(mockClient, AuthzOptions{})
 
 		req := authlib.BatchCheckRequest{
 			Namespace: "stacks-1",
@@ -61,7 +54,7 @@ func TestAuthzLimitedClient_BatchCheck(t *testing.T) {
 
 	t.Run("mixed resources - some RBAC compatible, some not", func(t *testing.T) {
 		mockClient := authlib.FixedAccessClient(false)
-		client := newTestAuthzClient(t, mockClient, AuthzOptions{})
+		client := NewAuthzLimitedClient(mockClient, AuthzOptions{})
 
 		req := authlib.BatchCheckRequest{
 			Namespace: "stacks-1",
@@ -85,7 +78,7 @@ func TestAuthzLimitedClient_BatchCheck(t *testing.T) {
 
 	t.Run("RBAC compatible resources with allowed client", func(t *testing.T) {
 		mockClient := authlib.FixedAccessClient(true)
-		client := newTestAuthzClient(t, mockClient, AuthzOptions{})
+		client := NewAuthzLimitedClient(mockClient, AuthzOptions{})
 
 		req := authlib.BatchCheckRequest{
 			Namespace: "stacks-1",
@@ -103,7 +96,7 @@ func TestAuthzLimitedClient_BatchCheck(t *testing.T) {
 
 func TestAuthzLimitedClient_Check(t *testing.T) {
 	mockClient := authlib.FixedAccessClient(false)
-	client := newTestAuthzClient(t, mockClient, AuthzOptions{})
+	client := NewAuthzLimitedClient(mockClient, AuthzOptions{})
 
 	tests := []struct {
 		group    string
@@ -130,7 +123,7 @@ func TestAuthzLimitedClient_Check(t *testing.T) {
 
 func TestAuthzLimitedClient_Compile(t *testing.T) {
 	mockClient := authlib.FixedAccessClient(false)
-	client := newTestAuthzClient(t, mockClient, AuthzOptions{})
+	client := NewAuthzLimitedClient(mockClient, AuthzOptions{})
 
 	tests := []struct {
 		group    string
@@ -163,7 +156,7 @@ func TestAuthzLimitedClient_Compile(t *testing.T) {
 func TestNamespaceMatching(t *testing.T) {
 	// Create a mock client that always returns allowed=true
 	mockClient := authlib.FixedAccessClient(true)
-	client := newTestAuthzClient(t, mockClient, AuthzOptions{})
+	client := NewAuthzLimitedClient(mockClient, AuthzOptions{})
 
 	// Create a context with fallback disabled
 	ctx := context.Background()
@@ -249,12 +242,10 @@ func TestNamespaceMatching(t *testing.T) {
 	}
 }
 
-func TestNewAuthzLimitedClientValidation(t *testing.T) {
+func TestValidateAuthzOptions(t *testing.T) {
 	for _, value := range []string{"", "group", "/resource", "group/", "group/resource/extra", "group/*"} {
 		t.Run("rejects malformed exemption "+value, func(t *testing.T) {
-			_, err := NewAuthzLimitedClient(authlib.FixedAccessClient(true), AuthzOptions{
-				ExemptResources: []string{value},
-			})
+			err := ValidateAuthzOptions(AuthzOptions{ExemptResources: []string{value}})
 			require.ErrorContains(t, err, "invalid unified storage authz exemption")
 		})
 	}
@@ -268,21 +259,26 @@ func TestNewAuthzLimitedClientValidation(t *testing.T) {
 		"plugin.ext.grafana.app/widgets",
 	} {
 		t.Run("rejects already enforced exemption "+value, func(t *testing.T) {
-			_, err := NewAuthzLimitedClient(authlib.FixedAccessClient(true), AuthzOptions{
-				ExemptResources: []string{value},
-			})
+			err := ValidateAuthzOptions(AuthzOptions{ExemptResources: []string{value}})
 			require.ErrorContains(t, err, "it is already enforced")
 		})
 	}
 
 	t.Run("deduplicates exact exemptions", func(t *testing.T) {
-		client, err := NewAuthzLimitedClient(authlib.FixedAccessClient(true), AuthzOptions{
+		client := NewAuthzLimitedClient(authlib.FixedAccessClient(true), AuthzOptions{
 			ExemptResources: []string{"example.grafana.app/widgets", "example.grafana.app/widgets"},
 		})
-		require.NoError(t, err)
 		wrapped := client.(*authzLimitedClient)
 		require.Len(t, wrapped.exemptions, 1)
 		require.Len(t, wrapped.exemptions["example.grafana.app"], 1)
+	})
+
+	t.Run("client ignores exemptions that fail validation", func(t *testing.T) {
+		client := NewAuthzLimitedClient(authlib.FixedAccessClient(true), AuthzOptions{
+			ExemptionEnabled: true,
+			ExemptResources:  []string{"example.grafana.app/widgets", "malformed"},
+		})
+		require.True(t, client.(*authzLimitedClient).IsCompatibleWithRBAC("example.grafana.app", "widgets"))
 	})
 }
 
@@ -311,7 +307,7 @@ func TestAuthzLimitedClientExemptionGate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client := newTestAuthzClient(t, authlib.FixedAccessClient(false), tt.opts)
+			client := NewAuthzLimitedClient(authlib.FixedAccessClient(false), tt.opts)
 
 			// The underlying client denies everything, so an allowed response means the check was bypassed.
 			check, err := client.Check(context.Background(), &identity.StaticRequester{Namespace: "stacks-1"}, authlib.CheckRequest{

--- a/pkg/storage/unified/sql/server.go
+++ b/pkg/storage/unified/sql/server.go
@@ -163,11 +163,18 @@ func withSecureValueService(opts *ServerOptions, resourceOpts *resource.Resource
 }
 
 func withAccessClient(opts *ServerOptions, resourceOpts *resource.ResourceServerOptions) error {
-	if opts.AccessClient != nil {
-		resourceOpts.AccessClient = resource.NewAuthzLimitedClient(opts.AccessClient, resource.AuthzOptions{
-			Registry: opts.Reg,
-		})
+	if opts.AccessClient == nil {
+		return nil
 	}
+	client, err := resource.NewAuthzLimitedClient(opts.AccessClient, resource.AuthzOptions{
+		Registry:         opts.Reg,
+		ExemptionEnabled: opts.Cfg.UnifiedStorageAuthzExemptionEnabled,
+		ExemptResources:  opts.Cfg.UnifiedStorageAuthzExemptResources,
+	})
+	if err != nil {
+		return err
+	}
+	resourceOpts.AccessClient = client
 	return nil
 }
 

--- a/pkg/storage/unified/sql/server.go
+++ b/pkg/storage/unified/sql/server.go
@@ -163,18 +163,17 @@ func withSecureValueService(opts *ServerOptions, resourceOpts *resource.Resource
 }
 
 func withAccessClient(opts *ServerOptions, resourceOpts *resource.ResourceServerOptions) error {
-	if opts.AccessClient == nil {
-		return nil
-	}
-	client, err := resource.NewAuthzLimitedClient(opts.AccessClient, resource.AuthzOptions{
+	authzOpts := resource.AuthzOptions{
 		Registry:         opts.Reg,
 		ExemptionEnabled: opts.Cfg.UnifiedStorageAuthzExemptionEnabled,
 		ExemptResources:  opts.Cfg.UnifiedStorageAuthzExemptResources,
-	})
-	if err != nil {
+	}
+	if err := resource.ValidateAuthzOptions(authzOpts); err != nil {
 		return err
 	}
-	resourceOpts.AccessClient = client
+	if opts.AccessClient != nil {
+		resourceOpts.AccessClient = resource.NewAuthzLimitedClient(opts.AccessClient, authzOpts)
+	}
 	return nil
 }
 

--- a/pkg/storage/unified/sql/server_test.go
+++ b/pkg/storage/unified/sql/server_test.go
@@ -3,8 +3,10 @@ package sql
 import (
 	"testing"
 
+	"github.com/grafana/authlib/types"
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/stretchr/testify/require"
 )
 
@@ -137,6 +139,37 @@ func TestIsHighAvailabilityEnabled(t *testing.T) {
 			result := isHighAvailabilityEnabled(tt.cfg.SectionWithEnvOverrides("database"),
 				tt.cfg.SectionWithEnvOverrides("resource_api"))
 			require.Equal(t, tt.isHA, result)
+		})
+	}
+}
+
+func TestWithAccessClientValidatesAuthzConfig(t *testing.T) {
+	tests := []struct {
+		name       string
+		enabled    bool
+		exemptions []string
+		wantError  string
+	}{
+		{name: "disabled with empty exemptions is valid"},
+		{name: "enabled with empty exemptions is valid", enabled: true},
+		{name: "enabled with exact exemption is valid", enabled: true, exemptions: []string{"example.grafana.app/widgets"}},
+		{name: "malformed exemption fails initialization while disabled", exemptions: []string{"invalid"}, wantError: "invalid unified storage authz exemption"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := setting.NewCfg()
+			cfg.UnifiedStorageAuthzExemptionEnabled = tt.enabled
+			cfg.UnifiedStorageAuthzExemptResources = tt.exemptions
+			err := withAccessClient(&ServerOptions{
+				Cfg:          cfg,
+				AccessClient: types.FixedAccessClient(true),
+			}, &resource.ResourceServerOptions{})
+			if tt.wantError != "" {
+				require.ErrorContains(t, err, tt.wantError)
+				return
+			}
+			require.NoError(t, err)
 		})
 	}
 }


### PR DESCRIPTION
Adds two `[unified_storage]` keys, `authz_exemption_enabled` and `authz_exempt_resources`.

When enabled, `authzLimitedClient` enforces authorization for every group/resource except the listed exemptions, instead of only the built-in allowlist. Defaults are off, so behavior is unchanged. Dashboards, folders, iam and `*.ext.grafana.app` are always enforced and cannot be exempted.