### PR TITLE
TraceView: Cross sell for missing Database Observability plugin

### DIFF
--- a/public/app/features/explore/TraceView/TraceView.test.tsx
+++ b/public/app/features/explore/TraceView/TraceView.test.tsx
@@ -26,6 +26,14 @@ jest.mock('@grafana/runtime', () => ({
 
 const mockUseAppPluginInstalled = jest.mocked(useAppPluginInstalled);
 
+function mockPluginInstalled(installedPluginIds: string[] = []) {
+  mockUseAppPluginInstalled.mockImplementation((pluginId: string) => ({
+    loading: false,
+    error: undefined,
+    value: installedPluginIds.includes(pluginId),
+  }));
+}
+
 function getTraceView(frames: DataFrame[]) {
   const store = configureStore();
   const topOfViewRef = createRef<HTMLDivElement>();
@@ -61,11 +69,7 @@ function renderTraceViewNew() {
 
 describe('TraceView', () => {
   beforeEach(() => {
-    mockUseAppPluginInstalled.mockReturnValue({
-      loading: false,
-      error: undefined,
-      value: undefined,
-    });
+    mockPluginInstalled();
   });
 
   afterEach(() => {
@@ -180,32 +184,20 @@ describe('TraceView', () => {
     });
 
     it('does not render the banner when grafana-adaptivetraces-app is not installed', async () => {
-      mockUseAppPluginInstalled.mockReturnValue({
-        loading: false,
-        error: undefined,
-        value: false,
-      });
+      mockPluginInstalled();
       renderTraceView([frameRestoredByAdaptiveTraces]);
       expect(screen.queryByText(restoredBannerTitle)).not.toBeInTheDocument();
     });
 
     it('renders the banner when at least one span has grafana.adaptivetraces.restored=true', async () => {
-      mockUseAppPluginInstalled.mockReturnValue({
-        loading: false,
-        error: undefined,
-        value: true,
-      });
+      mockPluginInstalled(['grafana-adaptivetraces-app']);
       renderTraceView([frameRestoredByAdaptiveTraces]);
       expect(await screen.findByText(restoredBannerTitle)).toBeInTheDocument();
       expect(screen.getByRole('link', { name: /documentation/ })).toBeInTheDocument();
     });
 
     it('hides the banner after the user dismisses it', async () => {
-      mockUseAppPluginInstalled.mockReturnValue({
-        loading: false,
-        error: undefined,
-        value: true,
-      });
+      mockPluginInstalled(['grafana-adaptivetraces-app']);
       renderTraceView([frameRestoredByAdaptiveTraces]);
       expect(await screen.findByText(restoredBannerTitle)).toBeInTheDocument();
 
@@ -214,11 +206,7 @@ describe('TraceView', () => {
     });
 
     it('shows the banner again after dismiss when navigating directly to a different restored trace', async () => {
-      mockUseAppPluginInstalled.mockReturnValue({
-        loading: false,
-        error: undefined,
-        value: true,
-      });
+      mockPluginInstalled(['grafana-adaptivetraces-app']);
       const { rerender } = render(getTraceView([frameRestoredByAdaptiveTraces]));
       expect(await screen.findByText(restoredBannerTitle)).toBeInTheDocument();
 

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/AccordionCategorizedKeyValues.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/AccordionCategorizedKeyValues.tsx
@@ -13,6 +13,7 @@ import {
   SERVICE_HEXAGON_CATEGORY_ICON,
 } from './attributeCategories';
 import { ServiceHexagonIcon } from './icons/ServiceHexagonIcon';
+import { type AttributePluginPromoGetter } from './pluginPromo/attributePluginPromos';
 
 export type AccordionCategorizedKeyValuesProps = {
   data: TraceKeyValuePair[];
@@ -21,6 +22,7 @@ export type AccordionCategorizedKeyValuesProps = {
   label: React.ReactNode;
   linksGetter?: (pairs: TraceKeyValuePair[], index: number) => KeyValuesTableLink[];
   onToggle?: null | (() => void);
+  promoGetter?: AttributePluginPromoGetter;
 };
 
 export default function AccordionCategorizedKeyValues({
@@ -30,6 +32,7 @@ export default function AccordionCategorizedKeyValues({
   label,
   linksGetter,
   onToggle = null,
+  promoGetter,
 }: AccordionCategorizedKeyValuesProps) {
   const styles = useStyles2(getStyles);
   const isEmpty = !Array.isArray(data) || !data.length;
@@ -85,7 +88,7 @@ export default function AccordionCategorizedKeyValues({
       </div>
       {isOpen &&
         (showFlatAttributes ? (
-          <KeyValuesTable data={data} linksGetter={linksGetter} />
+          <KeyValuesTable data={data} linksGetter={linksGetter} promoGetter={promoGetter} />
         ) : (
           <div className={styles.categories} data-testid="AccordionCategorizedKeyValues--categories">
             {groupedCategories.map(({ category, attributes }) => {
@@ -114,7 +117,7 @@ export default function AccordionCategorizedKeyValues({
                   </button>
                   {isCategoryOpen && (
                     <div className={styles.categoryContent}>
-                      <KeyValuesTable data={attributes} linksGetter={linksGetter} />
+                      <KeyValuesTable data={attributes} linksGetter={linksGetter} promoGetter={promoGetter} />
                     </div>
                   )}
                 </div>

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/AccordionKeyValues.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/AccordionKeyValues.tsx
@@ -25,6 +25,7 @@ import type TNil from '../../types/TNil';
 import * as markers from './AccordionKeyValues.markers';
 import { KeyValuesSummary } from './KeyValuesSummary';
 import KeyValuesTable, { type KeyValuesTableLink } from './KeyValuesTable';
+import { type AttributePluginPromoGetter } from './pluginPromo/attributePluginPromos';
 
 import { alignIcon } from '.';
 
@@ -76,6 +77,7 @@ export type AccordionKeyValuesProps = {
   label: string | React.ReactNode;
   linksGetter?: (pairs: TraceKeyValuePair[], index: number) => KeyValuesTableLink[];
   onToggle?: null | (() => void);
+  promoGetter?: AttributePluginPromoGetter;
 };
 
 export default function AccordionKeyValues({
@@ -91,6 +93,7 @@ export default function AccordionKeyValues({
   showSummary = true,
   showCountBadge = false,
   onToggle = null,
+  promoGetter,
 }: AccordionKeyValuesProps) {
   const isEmpty = (!Array.isArray(data) || !data.length) && !logName;
   const styles = useStyles2(getStyles);
@@ -134,7 +137,14 @@ export default function AccordionKeyValues({
           </span>
         )}
       </div>
-      {isOpen && <KeyValuesTable data={tableFields} linksGetter={linksGetter} onlyValues={onlyValues} />}
+      {isOpen && (
+        <KeyValuesTable
+          data={tableFields}
+          linksGetter={linksGetter}
+          onlyValues={onlyValues}
+          promoGetter={promoGetter}
+        />
+      )}
     </div>
   );
 }

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/KeyValuesTable.test.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/KeyValuesTable.test.tsx
@@ -190,4 +190,55 @@ describe('KeyValuesTable tests', () => {
     expect(values[0].innerHTML).toBe('"&lt;img src=x onerror=alert(1)&gt;":');
     expect(values[1].innerHTML).toBe('"&lt;img src=x onerror=alert(1)&gt;"');
   });
+
+  it('wraps matching values with the attribute plugin promo tip', async () => {
+    const user = userEvent.setup();
+    setup({
+      data: [
+        { key: 'db.system', value: 'postgresql' },
+        { key: 'http.method', value: 'GET' },
+      ],
+      promoGetter: (key) =>
+        key.startsWith('db.')
+          ? {
+              pluginId: 'grafana-dbo11y-app',
+              icon: 'database-observability',
+              title: 'Find slow queries faster',
+              body: 'Database Observability surfaces visual explain plans, wait events, and query samples.',
+              match: () => true,
+            }
+          : undefined,
+    });
+
+    expect(screen.getByText('"postgresql"')).toBeInTheDocument();
+    expect(screen.getByTestId('attribute-plugin-promo-trigger')).toBeInTheDocument();
+    expect(screen.queryByText('Find slow queries faster')).not.toBeInTheDocument();
+
+    await user.click(screen.getByTestId('attribute-plugin-promo-trigger'));
+    expect(await screen.findByText('Find slow queries faster')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /learn more/i })).toBeInTheDocument();
+  });
+
+  it('does not wrap values when they already have a plugin link', () => {
+    setup({
+      data: [{ key: 'db.query.text', value: 'SELECT 1' }],
+      promoGetter: () => ({
+        pluginId: 'grafana-dbo11y-app',
+        icon: 'database-observability',
+        title: 'Find slow queries faster',
+        body: 'body',
+        match: () => true,
+      }),
+      linksGetter: () => [
+        {
+          path: '/a/grafana-dbo11y-app/overview',
+          title: 'View Query Details',
+          icon: 'database',
+        },
+      ],
+    });
+
+    expect(screen.getByRole('link', { name: 'View Query Details' })).toBeInTheDocument();
+    expect(screen.queryByText('Find slow queries faster')).not.toBeInTheDocument();
+  });
 });

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/KeyValuesTable.test.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/KeyValuesTable.test.tsx
@@ -239,6 +239,22 @@ describe('KeyValuesTable tests', () => {
     });
 
     expect(screen.getByRole('link', { name: 'View Query Details' })).toBeInTheDocument();
-    expect(screen.queryByText('Find slow queries faster')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('attribute-plugin-promo-trigger')).not.toBeInTheDocument();
+  });
+
+  it('does not wrap values that are auto-linkified urls', () => {
+    setup({
+      data: [{ key: 'db.connection_string', value: 'https://example.com/db' }],
+      promoGetter: () => ({
+        pluginId: 'grafana-dbo11y-app',
+        icon: 'database-observability',
+        title: 'Find slow queries faster',
+        body: 'body',
+        match: () => true,
+      }),
+    });
+
+    expect(screen.getByRole('link', { name: 'https://example.com/db' })).toBeInTheDocument();
+    expect(screen.queryByTestId('attribute-plugin-promo-trigger')).not.toBeInTheDocument();
   });
 });

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
@@ -270,8 +270,7 @@ export default function KeyValuesTable(props: KeyValuesTableProps) {
 
             // Skip promo when value markup already has an anchor (jsonMarkup auto-linkifies
             // http(s) strings) to avoid nesting interactive content inside the promo <button>.
-            const promo =
-              links.length === 0 && !html.includes('<a ') ? promoGetter?.(row.key) : undefined;
+            const promo = links.length === 0 && !html.includes('<a ') ? promoGetter?.(row.key) : undefined;
             if (promo) {
               valueMarkup = <AttributePluginPromoTip promo={promo}>{valueMarkup}</AttributePluginPromoTip>;
             }

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
@@ -25,6 +25,8 @@ import { autoColor } from '../../Theme';
 import CopyIcon from '../../common/CopyIcon';
 
 import jsonMarkup from './jsonMarkup';
+import { AttributePluginPromoTip } from './pluginPromo/AttributePluginPromoTip';
+import { type AttributePluginPromoGetter } from './pluginPromo/attributePluginPromos';
 
 const getStyles = (theme: GrafanaTheme2) => {
   const keyColor = theme.colors.text.secondary;
@@ -233,10 +235,11 @@ export type KeyValuesTableProps = {
   data: TraceKeyValuePair[];
   linksGetter?: (pairs: TraceKeyValuePair[], index: number) => KeyValuesTableLink[];
   onlyValues?: boolean;
+  promoGetter?: AttributePluginPromoGetter;
 };
 
 export default function KeyValuesTable(props: KeyValuesTableProps) {
-  const { data, linksGetter, onlyValues } = props;
+  const { data, linksGetter, onlyValues, promoGetter } = props;
   const styles = useStyles2(getStyles);
   return (
     <div className={cx(styles.KeyValueTable)} data-testid="KeyValueTable">
@@ -256,7 +259,7 @@ export default function KeyValuesTable(props: KeyValuesTableProps) {
               <div className={styles.jsonTable} dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(html) }} />
             );
             const links = linksGetter?.(data, i) ?? [];
-            const valueMarkup =
+            let valueMarkup =
               links.length > 1 ? (
                 <LinkValuesMenu links={links}>{jsonTable}</LinkValuesMenu>
               ) : links.length === 1 ? (
@@ -264,6 +267,11 @@ export default function KeyValuesTable(props: KeyValuesTableProps) {
               ) : (
                 jsonTable
               );
+
+            const promo = links.length === 0 ? promoGetter?.(row.key) : undefined;
+            if (promo) {
+              valueMarkup = <AttributePluginPromoTip promo={promo}>{valueMarkup}</AttributePluginPromoTip>;
+            }
 
             return (
               // `i` is necessary in the key because row.key can repeat

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
@@ -268,7 +268,10 @@ export default function KeyValuesTable(props: KeyValuesTableProps) {
                 jsonTable
               );
 
-            const promo = links.length === 0 ? promoGetter?.(row.key) : undefined;
+            // Skip promo when value markup already has an anchor (jsonMarkup auto-linkifies
+            // http(s) strings) to avoid nesting interactive content inside the promo <button>.
+            const promo =
+              links.length === 0 && !html.includes('<a ') ? promoGetter?.(row.key) : undefined;
             if (promo) {
               valueMarkup = <AttributePluginPromoTip promo={promo}>{valueMarkup}</AttributePluginPromoTip>;
             }

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/attributeCategories.test.ts
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/attributeCategories.test.ts
@@ -1,4 +1,14 @@
-import { groupAttributesByCategory, SERVICE_CATEGORY_ID } from './attributeCategories';
+import { groupAttributesByCategory, isDatabaseAttribute, SERVICE_CATEGORY_ID } from './attributeCategories';
+
+describe('isDatabaseAttribute', () => {
+  it.each(['db.system', 'db.statement', 'db_name', 'DB.operation'])('matches %s', (key) => {
+    expect(isDatabaseAttribute(key)).toBe(true);
+  });
+
+  it.each(['http.method', 'service.name', 'dbc.something', 'database.system'])('does not match %s', (key) => {
+    expect(isDatabaseAttribute(key)).toBe(false);
+  });
+});
 
 describe('groupAttributesByCategory', () => {
   it('groups resource attributes by semantic namespace', () => {

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/attributeCategories.ts
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/attributeCategories.ts
@@ -225,6 +225,11 @@ function getAttributeCategories(sectionType: AttributeSectionType): AttributeCat
   return orderAttributeCategories(buildAttributeCategories(), SECTION_CATEGORY_PRIORITY[sectionType]);
 }
 
+/** Returns true when an attribute key matches the OpenTelemetry `db.*` / `db_*` namespace. */
+export function isDatabaseAttribute(key: string): boolean {
+  return matchesPrefixes(key, ['db']);
+}
+
 export function groupAttributesByCategory(
   attributes: TraceKeyValuePair[],
   sectionType: AttributeSectionType

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.test.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.test.tsx
@@ -29,6 +29,16 @@ jest.mock('@grafana/runtime/unstable', () => ({
   useDataSourceInstanceSettings: jest.fn().mockReturnValue({ isLoading: false, settings: undefined }),
 }));
 
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  useAppPluginInstalled: jest.fn().mockReturnValue({ loading: false, value: false, error: undefined }),
+}));
+
+jest.mock('./pluginPromo/attributePluginPromos', () => ({
+  ...jest.requireActual('./pluginPromo/attributePluginPromos'),
+  useAttributePluginPromoGetter: jest.fn(() => () => undefined),
+}));
+
 import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.tsx
@@ -53,6 +53,7 @@ import AccordionReferences from './AccordionReferences';
 import type DetailState from './DetailState';
 import { SpanDetailLinkButtons } from './SpanDetailLinkButtons';
 import SpanFlameGraph from './SpanFlameGraph';
+import { useAttributePluginPromoGetter } from './pluginPromo/attributePluginPromos';
 
 const useResourceAttributesExtensionLinks = ({
   process,
@@ -455,6 +456,7 @@ export default function SpanDetail(props: SpanDetailProps) {
     spanID,
     spanStartTime: startTime,
   });
+  const promoGetter = useAttributePluginPromoGetter();
 
   const listOfContentCards = [];
 
@@ -466,6 +468,7 @@ export default function SpanDetail(props: SpanDetailProps) {
         isOpen={isSummaryAttributesOpen}
         linksGetter={resourceLinksGetter}
         onToggle={() => summaryAttributesToggle(spanID)}
+        promoGetter={promoGetter}
       />
     );
   }
@@ -478,6 +481,7 @@ export default function SpanDetail(props: SpanDetailProps) {
       isOpen={isTagsOpen}
       linksGetter={resourceLinksGetter}
       onToggle={() => tagsToggle(spanID)}
+      promoGetter={promoGetter}
     />
   );
 
@@ -501,6 +505,7 @@ export default function SpanDetail(props: SpanDetailProps) {
         linksGetter={resourceLinksGetter}
         isOpen={isProcessOpen}
         onToggle={() => processToggle(spanID)}
+        promoGetter={promoGetter}
       />
     );
   }

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/pluginPromo/AttributePluginPromoTip.test.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/pluginPromo/AttributePluginPromoTip.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { locationUtil } from '@grafana/data';
+
+import { AttributePluginPromoTip } from './AttributePluginPromoTip';
+import { type AttributePluginPromo } from './attributePluginPromos';
+
+const promo: AttributePluginPromo = {
+  pluginId: 'grafana-dbo11y-app',
+  icon: 'database-observability',
+  title: 'Find slow queries faster',
+  body: 'Database Observability surfaces visual explain plans, wait events, and query samples — helping you diagnose issues beyond trace spans.',
+  match: () => true,
+};
+
+describe('AttributePluginPromoTip', () => {
+  it('renders children and shows promo content on click', async () => {
+    const user = userEvent.setup();
+    render(
+      <AttributePluginPromoTip promo={promo}>
+        <span>SELECT 1</span>
+      </AttributePluginPromoTip>
+    );
+
+    expect(screen.getByText('SELECT 1')).toBeInTheDocument();
+    expect(screen.getByTestId('attribute-plugin-promo-trigger')).toBeInTheDocument();
+
+    await user.click(screen.getByTestId('attribute-plugin-promo-trigger'));
+
+    expect(await screen.findByText('Find slow queries faster')).toBeInTheDocument();
+    expect(screen.getByText(/visual explain plans, wait events, and query samples/i)).toBeInTheDocument();
+
+    const learnMore = screen.getByRole('link', { name: /learn more/i });
+    expect(learnMore).toHaveAttribute('href', locationUtil.assureBaseUrl(`/plugins/${promo.pluginId}`));
+  });
+});

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/pluginPromo/AttributePluginPromoTip.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/pluginPromo/AttributePluginPromoTip.tsx
@@ -1,0 +1,88 @@
+import { css } from '@emotion/css';
+import { type PropsWithChildren } from 'react';
+
+import { type GrafanaTheme2, locationUtil } from '@grafana/data';
+import { Trans } from '@grafana/i18n';
+import { Icon, LinkButton, Stack, Text, Toggletip, useStyles2 } from '@grafana/ui';
+
+import { type AttributePluginPromo } from './attributePluginPromos';
+
+type Props = PropsWithChildren<{
+  promo: AttributePluginPromo;
+}>;
+
+/**
+ * Clickable attribute-value wrapper that promotes installing a related app plugin.
+ */
+export function AttributePluginPromoTip({ promo, children }: Props) {
+  const styles = useStyles2(getStyles);
+  const catalogUrl = locationUtil.assureBaseUrl(`/plugins/${promo.pluginId}`);
+
+  return (
+    <Toggletip
+      title={
+        <div className={styles.content}>
+          <Stack gap={0.5} direction="row" alignItems="center">
+            <Icon name={promo.icon} size="sm" />
+            <Text element="span" variant="body" weight="medium">
+              {promo.title}
+            </Text>
+          </Stack>
+        </div>
+      }
+      content={
+        <div className={styles.content}>
+          <p className={styles.body}>{promo.body}</p>
+        </div>
+      }
+      footer={
+        <LinkButton href={catalogUrl} size="sm">
+          <Trans i18nKey="explore.trace-view.attribute-plugin-promo.learn-more">Learn more</Trans>
+        </LinkButton>
+      }
+      placement="top"
+    >
+      <button type="button" className={styles.trigger} data-testid="attribute-plugin-promo-trigger">
+        <Icon name={promo.icon} size="sm" className={styles.triggerIcon} />
+        {children}
+      </button>
+    </Toggletip>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  trigger: css({
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: theme.spacing(0.5),
+    padding: 0,
+    margin: 0,
+    background: 'none',
+    border: 'none',
+    cursor: 'pointer',
+    color: theme.colors.text.link,
+    font: 'inherit',
+    textAlign: 'left',
+    '&:hover': {
+      textDecoration: 'underline',
+    },
+    // Match KeyValuesTable link styling so json-markup spans use the link color
+    span: {
+      color: `${theme.colors.text.link} !important`,
+    },
+  }),
+  triggerIcon: css({
+    flexShrink: 0,
+    color: `${theme.colors.text.primary} !important`,
+  }),
+  content: css({
+    maxWidth: 300,
+  }),
+  body: css({
+    margin: 0,
+    color: theme.colors.text.secondary,
+    fontSize: theme.typography.bodySmall.fontSize,
+    fontWeight: theme.typography.fontWeightRegular,
+    lineHeight: theme.typography.bodySmall.lineHeight,
+  }),
+});

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/pluginPromo/attributePluginPromos.test.ts
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/pluginPromo/attributePluginPromos.test.ts
@@ -4,6 +4,7 @@ import { config } from '@grafana/runtime';
 import { useAppPluginMetas } from '@grafana/runtime/internal';
 
 import { isDatabaseAttribute } from '../attributeCategories';
+
 import { getAttributePluginPromos, useAttributePluginPromoGetter } from './attributePluginPromos';
 
 jest.mock('@grafana/runtime/internal', () => ({

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/pluginPromo/attributePluginPromos.test.ts
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/pluginPromo/attributePluginPromos.test.ts
@@ -1,0 +1,100 @@
+import { renderHook } from '@testing-library/react';
+
+import { config } from '@grafana/runtime';
+import { useAppPluginMetas } from '@grafana/runtime/internal';
+
+import { isDatabaseAttribute } from '../attributeCategories';
+import { getAttributePluginPromos, useAttributePluginPromoGetter } from './attributePluginPromos';
+
+jest.mock('@grafana/runtime/internal', () => ({
+  ...jest.requireActual('@grafana/runtime/internal'),
+  useAppPluginMetas: jest.fn(),
+}));
+
+const mockUseAppPluginMetas = jest.mocked(useAppPluginMetas);
+
+describe('getAttributePluginPromos', () => {
+  const originalNamespace = config.namespace;
+
+  afterEach(() => {
+    config.namespace = originalNamespace;
+  });
+
+  it('includes Database Observability promo for db.* attributes on Cloud', () => {
+    config.namespace = 'stacks-12345';
+
+    const promos = getAttributePluginPromos();
+    const dbPromo = promos.find((promo) => promo.pluginId === 'grafana-dbo11y-app');
+
+    expect(dbPromo).toBeDefined();
+    expect(dbPromo!.match('db.system')).toBe(true);
+    expect(dbPromo!.match('db.namespace')).toBe(true);
+    expect(dbPromo!.match('http.method')).toBe(false);
+    expect(isDatabaseAttribute('db.system')).toBe(true);
+  });
+
+  it('omits Database Observability promo on on-prem', () => {
+    config.namespace = 'default';
+
+    expect(getAttributePluginPromos()).toEqual([]);
+  });
+});
+
+describe('useAttributePluginPromoGetter', () => {
+  const originalNamespace = config.namespace;
+
+  beforeEach(() => {
+    config.namespace = 'stacks-12345';
+  });
+
+  afterEach(() => {
+    config.namespace = originalNamespace;
+    jest.clearAllMocks();
+  });
+
+  it('returns no promo while plugin metas are loading', () => {
+    mockUseAppPluginMetas.mockReturnValue({ loading: true, error: undefined, value: undefined });
+
+    const { result } = renderHook(() => useAttributePluginPromoGetter());
+
+    expect(result.current('db.system')).toBeUndefined();
+  });
+
+  it('returns no promo when plugin metas are unavailable', () => {
+    mockUseAppPluginMetas.mockReturnValue({ loading: false, error: new Error('failed'), value: undefined });
+
+    const { result } = renderHook(() => useAttributePluginPromoGetter());
+
+    expect(result.current('db.system')).toBeUndefined();
+  });
+
+  it('returns a promo when the matching plugin is not installed', () => {
+    mockUseAppPluginMetas.mockReturnValue({ loading: false, error: undefined, value: [] });
+
+    const { result } = renderHook(() => useAttributePluginPromoGetter());
+
+    expect(result.current('db.system')?.pluginId).toBe('grafana-dbo11y-app');
+    expect(result.current('http.method')).toBeUndefined();
+  });
+
+  it('returns no promo when the matching plugin is installed', () => {
+    mockUseAppPluginMetas.mockReturnValue({
+      loading: false,
+      error: undefined,
+      value: [{ id: 'grafana-dbo11y-app' } as never],
+    });
+
+    const { result } = renderHook(() => useAttributePluginPromoGetter());
+
+    expect(result.current('db.system')).toBeUndefined();
+  });
+
+  it('returns no promo on on-prem', () => {
+    config.namespace = 'default';
+    mockUseAppPluginMetas.mockReturnValue({ loading: false, error: undefined, value: [] });
+
+    const { result } = renderHook(() => useAttributePluginPromoGetter());
+
+    expect(result.current('db.system')).toBeUndefined();
+  });
+});

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/pluginPromo/attributePluginPromos.ts
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/pluginPromo/attributePluginPromos.ts
@@ -1,0 +1,69 @@
+import { useCallback, useMemo } from 'react';
+
+import { type IconName } from '@grafana/data';
+import { t } from '@grafana/i18n';
+import { useAppPluginMetas } from '@grafana/runtime/internal';
+import { isOnPrem } from 'app/core/utils/isOnPrem';
+
+import { isDatabaseAttribute } from '../attributeCategories';
+
+export type AttributePluginPromo = {
+  pluginId: string;
+  icon: IconName;
+  title: string;
+  body: string;
+  match: (attributeKey: string) => boolean;
+};
+
+/**
+ * Promos shown on attribute values when the related app plugin is not installed.
+ * Add new entries here as other apps (Knowledge Graph, App O11y, etc.) adopt this pattern.
+ * Cloud-only: never shown on on-prem OSS or Enterprise (`isOnPrem()`).
+ */
+export function getAttributePluginPromos(): AttributePluginPromo[] {
+  if (isOnPrem()) {
+    return [];
+  }
+
+  return [
+    {
+      pluginId: 'grafana-dbo11y-app',
+      icon: 'database-observability',
+      title: t('explore.trace-view.database-observability-promo.title', 'Find slow queries faster'),
+      body: t(
+        'explore.trace-view.database-observability-promo.body',
+        'Database Observability surfaces visual explain plans, wait events, and query samples — helping you diagnose issues beyond trace spans.'
+      ),
+      match: isDatabaseAttribute,
+    },
+  ];
+}
+
+export type AttributePluginPromoGetter = (attributeKey: string) => AttributePluginPromo | undefined;
+
+/**
+ * Returns a getter for attribute promos whose plugins are not installed.
+ * Adding a promo only requires a new entry in {@link getAttributePluginPromos}.
+ * Returns no promo while plugin metas are loading or unavailable, to avoid a flash for installed plugins.
+ */
+export function useAttributePluginPromoGetter(): AttributePluginPromoGetter {
+  const promos = useMemo(() => getAttributePluginPromos(), []);
+  const { loading, value: appMetas } = useAppPluginMetas();
+
+  const installedPluginIds = useMemo(() => {
+    if (loading || appMetas === undefined) {
+      return undefined;
+    }
+    return new Set(appMetas.map((app) => app.id));
+  }, [appMetas, loading]);
+
+  return useCallback(
+    (attributeKey: string) => {
+      if (!installedPluginIds) {
+        return undefined;
+      }
+      return promos.find((promo) => !installedPluginIds.has(promo.pluginId) && promo.match(attributeKey));
+    },
+    [installedPluginIds, promos]
+  );
+}

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetailRow.test.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetailRow.test.tsx
@@ -24,6 +24,13 @@ jest.mock('@grafana/runtime/unstable', () => ({
   useDataSourceInstanceSettings: jest.fn().mockReturnValue({ isLoading: false, settings: undefined }),
 }));
 
+// useAttributePluginPromoGetter uses useAppPluginMetas (async); stub it so SpanDetail
+// doesn't schedule an un-acted state update when rendered via SpanDetailRow.
+jest.mock('./SpanDetail/pluginPromo/attributePluginPromos', () => ({
+  ...jest.requireActual('./SpanDetail/pluginPromo/attributePluginPromos'),
+  useAttributePluginPromoGetter: jest.fn(() => () => undefined),
+}));
+
 import DetailState from './SpanDetail/DetailState';
 import SpanDetailRow, { type SpanDetailRowProps } from './SpanDetailRow';
 

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -8989,6 +8989,13 @@
         "title": "Trace restored by Adaptive Traces"
       },
       "aria-label-copy": "Copy to clipboard",
+      "attribute-plugin-promo": {
+        "learn-more": "Learn more"
+      },
+      "database-observability-promo": {
+        "body": "Database Observability surfaces visual explain plans, wait events, and query samples — helping you diagnose issues beyond trace spans.",
+        "title": "Find slow queries faster"
+      },
       "no-data": "No data",
       "tooltip-copy-icon": "Copied"
     },


### PR DESCRIPTION
**What is this feature?**

Part of https://github.com/grafana/grafana/issues/129072

TraceView: Cross sell for missing Database Observability plugin

- When Cloud Trace View has `db.*` attributes and `grafana-dbo11y-app` is not installed, show a clickable promo tip on those attribute values (toggletip → Learn more → plugin page).
- Hide the promo when the plugin is installed.

**Why do we need this feature?**

Point users to DB O11y where they can get better insights for their DB attributes.

**Who is this feature for?**

Trace view users with DB O11y.

**Special notes for your reviewer:**

<img width="304" height="199" alt="Screenshot 2026-07-29 at 10 15 12" src="https://github.com/user-attachments/assets/e50aece5-c2c1-45fa-a410-bee206c30eb8" />
