### PR TITLE
Search: authorize search and trash as reads in the chain

### DIFF
--- a/pkg/apis/search/v0alpha1/types.go
+++ b/pkg/apis/search/v0alpha1/types.go
@@ -18,6 +18,11 @@ const (
 	KindSearchResults = "SearchResults"
 	KindTrashQuery    = "TrashQuery"
 	KindTrashResults  = "TrashResults"
+
+	// Here rather than beside the routes because the authorization chain needs
+	// them and cannot depend on the handler package.
+	SearchPathSegment = "search"
+	TrashPathSegment  = "trash"
 )
 
 // WhereNode is a single node of the where tree. Exactly one field must be set;

--- a/pkg/registry/apis/dashboard/register.go
+++ b/pkg/registry/apis/dashboard/register.go
@@ -48,7 +48,6 @@ import (
 	"github.com/grafana/grafana/pkg/registry/apis/dashboard/home"
 	"github.com/grafana/grafana/pkg/registry/apis/dashboard/legacy"
 	"github.com/grafana/grafana/pkg/registry/apis/dashboard/snapshot"
-	searchapi "github.com/grafana/grafana/pkg/registry/apis/search"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/apiserver"
 	grafanaauthorizer "github.com/grafana/grafana/pkg/services/apiserver/auth/authorizer"
@@ -1460,9 +1459,6 @@ func (b *DashboardsAPIBuilder) GetAuthorizer() authorizer.Authorizer {
 		func(ctx context.Context, attr authorizer.Attributes) (authorizer.Decision, string, error) {
 			if attr.IsResourceRequest() && attr.GetResource() == dashv0.SNAPSHOT_RESOURCE {
 				return snapshotAuthorizer.Authorize(ctx, attr)
-			}
-			if searchapi.IsSearchRequest(attr) {
-				attr = searchapi.AsReadAttributes(attr)
 			}
 			return serviceAuthorizer.Authorize(ctx, attr)
 		})

--- a/pkg/registry/apis/search/route.go
+++ b/pkg/registry/apis/search/route.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"strings"
 
-	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/kube-openapi/pkg/spec3"
 	"k8s.io/kube-openapi/pkg/validation/spec"
 
@@ -18,8 +17,8 @@ const (
 	ConfigKey     = "enable_search_api"
 )
 
-// searchPathSegment is the last segment of the search endpoint path.
-const searchPathSegment = "search"
+// Aliased so the authorization chain and the route cannot drift apart.
+const searchPathSegment = searchv0.SearchPathSegment
 
 // Route is an endpoint to mount, described in terms the caller's apiserver
 // wiring can consume. Deliberately not Grafana's builder.APIRouteHandler: the
@@ -60,40 +59,6 @@ func capitalize(s string) string {
 		return s
 	}
 	return strings.ToUpper(s[:1]) + s[1:]
-}
-
-// IsSearchRequest reports whether attr describes a call to a kind's search
-// endpoint. Kubernetes parses that path as a create on the kind named "search",
-// which a real create never is: creating an object posts to the collection and
-// so carries no name.
-func IsSearchRequest(attr authorizer.Attributes) bool {
-	return attr.IsResourceRequest() &&
-		attr.GetVerb() == "create" &&
-		attr.GetSubresource() == "" &&
-		attr.GetName() == searchPathSegment
-}
-
-// AsReadAttributes restates a search request as the read it performs. Without
-// this, searching would demand permission to create the kind.
-func AsReadAttributes(attr authorizer.Attributes) authorizer.Attributes {
-	fieldSelector, fieldErr := attr.GetFieldSelector()
-	labelSelector, labelErr := attr.GetLabelSelector()
-	return authorizer.AttributesRecord{
-		User:            attr.GetUser(),
-		Verb:            "list",
-		Namespace:       attr.GetNamespace(),
-		APIGroup:        attr.GetAPIGroup(),
-		APIVersion:      attr.GetAPIVersion(),
-		Resource:        attr.GetResource(),
-		Subresource:     attr.GetSubresource(),
-		ResourceRequest: true,
-		Path:            attr.GetPath(),
-
-		FieldSelectorRequirements: fieldSelector,
-		FieldSelectorParsingErr:   fieldErr,
-		LabelSelectorRequirements: labelSelector,
-		LabelSelectorParsingErr:   labelErr,
-	}
 }
 
 func searchRouteSpec(kindName, version string) *spec3.PathProps {

--- a/pkg/registry/apis/search/route_test.go
+++ b/pkg/registry/apis/search/route_test.go
@@ -1,90 +1,13 @@
 package search
 
 import (
-	"net/http"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/trace/noop"
-	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apiserver/pkg/authorization/authorizer"
-	"k8s.io/apiserver/pkg/endpoints/request"
 )
-
-// attributesFor runs a path through the same parser the apiserver uses, so the
-// assumptions below are pinned to real behaviour rather than a guess.
-func attributesFor(t *testing.T, method, path string) authorizer.Attributes {
-	t.Helper()
-	f := &request.RequestInfoFactory{
-		APIPrefixes:          sets.NewString("apis"),
-		GrouplessAPIPrefixes: sets.NewString(),
-	}
-	r, err := http.NewRequest(method, path, nil)
-	require.NoError(t, err)
-	info, err := f.NewRequestInfo(r)
-	require.NoError(t, err)
-
-	return authorizer.AttributesRecord{
-		Verb:            info.Verb,
-		Namespace:       info.Namespace,
-		APIGroup:        info.APIGroup,
-		APIVersion:      info.APIVersion,
-		Resource:        info.Resource,
-		Subresource:     info.Subresource,
-		Name:            info.Name,
-		ResourceRequest: info.IsResourceRequest,
-		Path:            path,
-	}
-}
-
-const (
-	searchPath = "/apis/dashboard.grafana.app/v0alpha1/namespaces/default/dashboards/search"
-	listPath   = "/apis/dashboard.grafana.app/v0alpha1/namespaces/default/dashboards"
-)
-
-func TestIsSearchRequest(t *testing.T) {
-	// The endpoint is a POST so it can carry a body, which the apiserver parses
-	// as a create on the kind named "search".
-	searchAttr := attributesFor(t, http.MethodPost, searchPath)
-	require.Equal(t, "create", searchAttr.GetVerb())
-	require.Equal(t, "dashboards", searchAttr.GetResource())
-	require.Equal(t, searchPathSegment, searchAttr.GetName())
-	assert.True(t, IsSearchRequest(searchAttr))
-
-	// Creating a dashboard posts to the collection, so it carries no name and
-	// must not be mistaken for a search.
-	createAttr := attributesFor(t, http.MethodPost, listPath)
-	require.Empty(t, createAttr.GetName())
-	assert.False(t, IsSearchRequest(createAttr))
-
-	// Reads of the collection are untouched.
-	assert.False(t, IsSearchRequest(attributesFor(t, http.MethodGet, listPath)))
-
-	// A dashboard that happens to be named "search" is only ever reached with a
-	// non-create verb, so it stays a normal object operation.
-	assert.False(t, IsSearchRequest(attributesFor(t, http.MethodGet, searchPath)))
-	assert.False(t, IsSearchRequest(attributesFor(t, http.MethodPut, searchPath)))
-	assert.False(t, IsSearchRequest(attributesFor(t, http.MethodDelete, searchPath)))
-}
-
-func TestAsReadAttributes(t *testing.T) {
-	read := AsReadAttributes(attributesFor(t, http.MethodPost, searchPath))
-
-	// Searching reads the kind, so it must not demand permission to create it.
-	assert.Equal(t, "list", read.GetVerb())
-	assert.True(t, read.IsReadOnly())
-	// "search" was a path segment, not an object.
-	assert.Empty(t, read.GetName())
-
-	// Everything the authorizer scopes on is preserved.
-	assert.Equal(t, "dashboard.grafana.app", read.GetAPIGroup())
-	assert.Equal(t, "v0alpha1", read.GetAPIVersion())
-	assert.Equal(t, "dashboards", read.GetResource())
-	assert.Equal(t, "default", read.GetNamespace())
-	assert.True(t, read.IsResourceRequest())
-}
 
 func TestSearchRoute(t *testing.T) {
 	h := NewHandler(&fakeIndexClient{resp: emptyResponse()}, testProvider(), noop.NewTracerProvider().Tracer(""))

--- a/pkg/services/apiserver/auth/authorizer/authorizer.go
+++ b/pkg/services/apiserver/auth/authorizer/authorizer.go
@@ -68,6 +68,11 @@ func (a *GrafanaAuthorizer) Register(gv schema.GroupVersion, fn authorizer.Autho
 
 // Authorize implements authorizer.Authorizer.
 func (a *GrafanaAuthorizer) Authorize(ctx context.Context, attr authorizer.Attributes) (authorized authorizer.Decision, reason string, err error) {
+	// Restated before the chain, not inside one link: the org role authorizer
+	// allows a viewer to list but not to create.
+	if IsSearchRequest(attr) {
+		attr = AsReadAttributes(attr)
+	}
 	return a.auth.Authorize(ctx, attr)
 }
 

--- a/pkg/services/apiserver/auth/authorizer/search.go
+++ b/pkg/services/apiserver/auth/authorizer/search.go
@@ -1,0 +1,48 @@
+package authorizer
+
+import (
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+
+	searchv0 "github.com/grafana/grafana/pkg/apis/search/v0alpha1"
+)
+
+// IsSearchRequest reports whether attr is a call to a kind's search or trash
+// endpoint. Kubernetes parses those as a create on an object named after the
+// segment; a real create posts to the collection and so carries no name.
+//
+// Exported because the multi-tenant apiserver has its own chain and has to apply
+// the same rule.
+func IsSearchRequest(attr authorizer.Attributes) bool {
+	if !attr.IsResourceRequest() || attr.GetVerb() != "create" || attr.GetSubresource() != "" {
+		return false
+	}
+	switch attr.GetName() {
+	case searchv0.SearchPathSegment, searchv0.TrashPathSegment:
+		return true
+	default:
+		return false
+	}
+}
+
+// AsReadAttributes restates a search request as the read it performs. Without
+// this, searching a kind would demand permission to create it.
+func AsReadAttributes(attr authorizer.Attributes) authorizer.Attributes {
+	fieldSelector, fieldErr := attr.GetFieldSelector()
+	labelSelector, labelErr := attr.GetLabelSelector()
+	return authorizer.AttributesRecord{
+		User:            attr.GetUser(),
+		Verb:            "list",
+		Namespace:       attr.GetNamespace(),
+		APIGroup:        attr.GetAPIGroup(),
+		APIVersion:      attr.GetAPIVersion(),
+		Resource:        attr.GetResource(),
+		Subresource:     attr.GetSubresource(),
+		ResourceRequest: true,
+		Path:            attr.GetPath(),
+
+		FieldSelectorRequirements: fieldSelector,
+		FieldSelectorParsingErr:   fieldErr,
+		LabelSelectorRequirements: labelSelector,
+		LabelSelectorParsingErr:   labelErr,
+	}
+}

--- a/pkg/services/apiserver/auth/authorizer/search_test.go
+++ b/pkg/services/apiserver/auth/authorizer/search_test.go
@@ -1,0 +1,115 @@
+package authorizer
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+	"k8s.io/apiserver/pkg/endpoints/request"
+)
+
+// Uses the apiserver's own parser, so the assumptions below are pinned to real
+// behaviour rather than a guess.
+func attributesFor(t *testing.T, method, path string) authorizer.Attributes {
+	t.Helper()
+	f := &request.RequestInfoFactory{
+		APIPrefixes:          sets.NewString("apis"),
+		GrouplessAPIPrefixes: sets.NewString(),
+	}
+	r, err := http.NewRequest(method, path, nil)
+	require.NoError(t, err)
+	info, err := f.NewRequestInfo(r)
+	require.NoError(t, err)
+
+	return authorizer.AttributesRecord{
+		Verb:            info.Verb,
+		Namespace:       info.Namespace,
+		APIGroup:        info.APIGroup,
+		APIVersion:      info.APIVersion,
+		Resource:        info.Resource,
+		Subresource:     info.Subresource,
+		Name:            info.Name,
+		ResourceRequest: info.IsResourceRequest,
+		Path:            path,
+	}
+}
+
+const (
+	base       = "/apis/dashboard.grafana.app/v0alpha1/namespaces/default/dashboards"
+	searchPath = base + "/search"
+	trashPath  = base + "/trash"
+	listPath   = base
+)
+
+func TestIsSearchRequest(t *testing.T) {
+	for _, path := range []string{searchPath, trashPath} {
+		attr := attributesFor(t, http.MethodPost, path)
+		require.Equal(t, "create", attr.GetVerb())
+		require.Equal(t, "dashboards", attr.GetResource())
+		assert.True(t, IsSearchRequest(attr), "path %s", path)
+	}
+
+	// Creating a dashboard posts to the collection, so it carries no name and
+	// must not be mistaken for a search.
+	createAttr := attributesFor(t, http.MethodPost, listPath)
+	require.Empty(t, createAttr.GetName())
+	assert.False(t, IsSearchRequest(createAttr))
+
+	assert.False(t, IsSearchRequest(attributesFor(t, http.MethodGet, listPath)))
+
+	// An object may legitimately be named "search" or "trash", and is only ever
+	// reached with a non-create verb.
+	for _, path := range []string{searchPath, trashPath} {
+		assert.False(t, IsSearchRequest(attributesFor(t, http.MethodGet, path)), "path %s", path)
+		assert.False(t, IsSearchRequest(attributesFor(t, http.MethodPut, path)), "path %s", path)
+		assert.False(t, IsSearchRequest(attributesFor(t, http.MethodDelete, path)), "path %s", path)
+	}
+
+	// A subresource named "search" is a different endpoint and not ours.
+	sub := attributesFor(t, http.MethodPost, base+"/my-dash/search")
+	require.Equal(t, "search", sub.GetSubresource())
+	assert.False(t, IsSearchRequest(sub))
+}
+
+func TestAsReadAttributes(t *testing.T) {
+	read := AsReadAttributes(attributesFor(t, http.MethodPost, searchPath))
+
+	// Searching reads the kind, so it must not demand permission to create it.
+	assert.Equal(t, "list", read.GetVerb())
+	assert.True(t, read.IsReadOnly())
+	// "search" was a path segment, not an object.
+	assert.Empty(t, read.GetName())
+
+	// Everything the authorizer scopes on is preserved.
+	assert.Equal(t, "dashboard.grafana.app", read.GetAPIGroup())
+	assert.Equal(t, "v0alpha1", read.GetAPIVersion())
+	assert.Equal(t, "dashboards", read.GetResource())
+	assert.Equal(t, "default", read.GetNamespace())
+	assert.True(t, read.IsResourceRequest())
+}
+
+// The org role authorizer allows a viewer to list but not to create, which is why
+// the restatement has to happen before the chain.
+func TestGrafanaAuthorizer_ViewerMaySearchButNotCreate(t *testing.T) {
+	var seen []string
+	recorder := authorizer.AuthorizerFunc(
+		func(_ context.Context, attr authorizer.Attributes) (authorizer.Decision, string, error) {
+			seen = append(seen, attr.GetVerb())
+			return authorizer.DecisionNoOpinion, "", nil
+		})
+
+	a := &GrafanaAuthorizer{auth: recorder}
+
+	_, _, err := a.Authorize(context.Background(), attributesFor(t, http.MethodPost, searchPath))
+	require.NoError(t, err)
+	_, _, err = a.Authorize(context.Background(), attributesFor(t, http.MethodPost, trashPath))
+	require.NoError(t, err)
+	_, _, err = a.Authorize(context.Background(), attributesFor(t, http.MethodPost, listPath))
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"list", "list", "create"}, seen)
+}


### PR DESCRIPTION
The search endpoint is a POST, so Kubernetes parses it as a create on an object named after the last path segment. Dashboards restated that as a `list` inside their own authorizer, which meant any other kind mounting the endpoint had to remember to do the same.

The restatement moves into the chain, so a kind gets it by being served rather than by remembering to ask, and the dashboard-specific copy is removed. Trash is covered too — same shape, same problem, and one manifest flag is expected to govern both endpoints.

**Which kinds this actually matters for.** Kinds using `ResourceAuthorizer` — `iam`, `secret`, `advisor`, `plugins` — pass `attr.GetVerb()` straight to `AccessClient.Check`, so a search arriving as a create is checked as a create against user permissions and a reader is denied. Dashboards and folders use `NewServiceAuthorizer` instead, whose coarse gate checks token permissions and defers user permissions to later in the flow, so they would not deny a reader today. Verified by removing the restatement and observing that a viewer's dashboard search still succeeds. The kinds where it bites are the ones most likely to join the allowlist next, and the restatement also makes auditing record a search as a read rather than a create.

It happens before the chain rather than inside one link because more than one link reads the verb: `RoleAuthorizer` allows a viewer to `list` but not to `create`. That link is only reached when the per-group authorizer returns no opinion, which is another reason not to rely on where in the chain it sits.

The path segments move to the API types package. The authorization chain needs them, and importing the handler package there would add ~1100 dependencies to a package that sits under everything; the types package adds one.

`IsSearchRequest` and `AsReadAttributes` are exported despite having no other caller in this repo: the multi-tenant apiserver has its own chain (`CompositeAuthorizer`) and has to apply the same rule. grafana/grafana-enterprise#12849 calls them, on a branch of the same name. Duplicating the predicate there would reintroduce the second copy this PR removes.

No behaviour change for dashboards. This unblocks adding kinds to the search allowlist, which previously required checking each kind's authorizer by hand.