### PR TITLE
NewFolder: Auto focus input

### DIFF
--- a/public/app/features/browse-dashboards/components/NewFolderForm.tsx
+++ b/public/app/features/browse-dashboards/components/NewFolderForm.tsx
@@ -74,6 +74,7 @@ export function NewFolderForm({ onCancel, onConfirm, parentFolder }: Props) {
           <Input
             data-testid={selectors.pages.BrowseDashboards.NewFolderForm.nameInput}
             id="folder-name-input"
+            autoFocus
             defaultValue={initialFormModel.folderName}
             {...register('folderName', {
               required: translatedFolderNameRequiredPhrase,
@@ -83,7 +84,7 @@ export function NewFolderForm({ onCancel, onConfirm, parentFolder }: Props) {
         </Field>
         {showFolderOwnerSelector && (
           <>
-            <Box>
+            <Box display="flex" alignItems="center" gap={1}>
               <Checkbox
                 value={createTeamFolder}
                 label={t(

--- a/public/app/features/browse-dashboards/components/NewFolderForm.tsx
+++ b/public/app/features/browse-dashboards/components/NewFolderForm.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 
 import { selectors } from '@grafana/e2e-selectors';
@@ -35,6 +35,12 @@ export function NewFolderForm({ onCancel, onConfirm, parentFolder }: Props) {
 
   const [createTeamFolder, setCreateTeamFolder] = useState(false);
   const [selectedTeam, setSelectedTeam] = useState<OwnerReference | null>(null);
+  const nameInputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    const frame = setTimeout(() => nameInputRef.current?.focus(), 50);
+    return () => clearTimeout(frame);
+  }, []);
 
   const handleTeamFolderToggle = () => {
     setCreateTeamFolder(!createTeamFolder);
@@ -50,6 +56,11 @@ export function NewFolderForm({ onCancel, onConfirm, parentFolder }: Props) {
   );
 
   const fieldNameLabel = t('browse-dashboards.new-folder-form.name-label', 'Folder name');
+
+  const { ref: nameInputCallback, ...folderNameProps } = register('folderName', {
+    required: translatedFolderNameRequiredPhrase,
+    validate: async (v) => await validateFolderName(v, parentFolder?.uid),
+  });
 
   return (
     <form
@@ -74,12 +85,12 @@ export function NewFolderForm({ onCancel, onConfirm, parentFolder }: Props) {
           <Input
             data-testid={selectors.pages.BrowseDashboards.NewFolderForm.nameInput}
             id="folder-name-input"
-            autoFocus
             defaultValue={initialFormModel.folderName}
-            {...register('folderName', {
-              required: translatedFolderNameRequiredPhrase,
-              validate: async (v) => await validateFolderName(v, parentFolder?.uid),
-            })}
+            {...folderNameProps}
+            ref={(e) => {
+              nameInputRef.current = e;
+              nameInputCallback(e);
+            }}
           />
         </Field>
         {showFolderOwnerSelector && (


### PR DESCRIPTION
Was frustrated by input not being auto focused on new folder form (or save as dashboard drawer). 

Sadly autoFocus does not work in the input, something with the floating ui or other is taking focus away from the input even after mount, have to do the focus after some time (hence the setTimeout). 

I am sure someone smarter than me or Claude can figure out a better solution ;) 