### PR TITLE
Provisioning: Retry connection integration test deletes on RV conflict

### DIFF
--- a/pkg/tests/apis/provisioning/v1beta1/connection_test.go
+++ b/pkg/tests/apis/provisioning/v1beta1/connection_test.go
@@ -3,6 +3,7 @@ package v1beta1
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -74,9 +75,12 @@ func TestIntegrationV1Beta1Connection_Create_GitHub(t *testing.T) {
 	// Secure values should not be returned (Create should be empty)
 	require.Empty(t, createdConn.Secure.PrivateKey.Create)
 
-	// Clean up
-	err = client.Resource.Delete(t.Context(), connection.Name, metav1.DeleteOptions{})
-	require.NoError(t, err)
+	// Clean up. Retry on transient 409 conflicts: unified storage guards the delete with the object's
+	// current RV, which the ConnectionController's async /status patches keep bumping.
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		err := client.Resource.Delete(t.Context(), connection.Name, metav1.DeleteOptions{})
+		require.NoError(collect, err)
+	}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
 }
 
 func TestIntegrationV1Beta1Connection_Create_GitLab(t *testing.T) {
@@ -129,9 +133,12 @@ func TestIntegrationV1Beta1Connection_Create_GitLab(t *testing.T) {
 	require.Equal(t, provisioning.GitlabConnectionType, createdConn.Spec.Type)
 	require.Equal(t, "gitlab-client-123", createdConn.Spec.Gitlab.ClientID)
 
-	// Clean up
-	err = client.Resource.Delete(t.Context(), connection.Name, metav1.DeleteOptions{})
-	require.NoError(t, err)
+	// Clean up. Retry on transient 409 conflicts: unified storage guards the delete with the object's
+	// current RV, which the ConnectionController's async /status patches keep bumping.
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		err := client.Resource.Delete(t.Context(), connection.Name, metav1.DeleteOptions{})
+		require.NoError(collect, err)
+	}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
 }
 
 func TestIntegrationV1Beta1Connection_Create_Bitbucket(t *testing.T) {
@@ -184,9 +191,12 @@ func TestIntegrationV1Beta1Connection_Create_Bitbucket(t *testing.T) {
 	require.Equal(t, provisioning.BitbucketConnectionType, createdConn.Spec.Type)
 	require.Equal(t, "bitbucket-client-456", createdConn.Spec.Bitbucket.ClientID)
 
-	// Clean up
-	err = client.Resource.Delete(t.Context(), connection.Name, metav1.DeleteOptions{})
-	require.NoError(t, err)
+	// Clean up. Retry on transient 409 conflicts: unified storage guards the delete with the object's
+	// current RV, which the ConnectionController's async /status patches keep bumping.
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		err := client.Resource.Delete(t.Context(), connection.Name, metav1.DeleteOptions{})
+		require.NoError(collect, err)
+	}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
 }
 
 func TestIntegrationV1Beta1Connection_Get(t *testing.T) {
@@ -245,9 +255,12 @@ func TestIntegrationV1Beta1Connection_Get(t *testing.T) {
 	require.Equal(t, namespace, retrievedConn.Namespace)
 	require.Equal(t, provisioning.GithubConnectionType, retrievedConn.Spec.Type)
 
-	// Clean up
-	err = client.Resource.Delete(t.Context(), connection.Name, metav1.DeleteOptions{})
-	require.NoError(t, err)
+	// Clean up. Retry on transient 409 conflicts: unified storage guards the delete with the object's
+	// current RV, which the ConnectionController's async /status patches keep bumping.
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		err := client.Resource.Delete(t.Context(), connection.Name, metav1.DeleteOptions{})
+		require.NoError(collect, err)
+	}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
 }
 
 func TestIntegrationV1Beta1Connection_List(t *testing.T) {
@@ -311,9 +324,12 @@ func TestIntegrationV1Beta1Connection_List(t *testing.T) {
 	}
 	require.True(t, found, "Created connection should be in the list")
 
-	// Clean up
-	err = client.Resource.Delete(t.Context(), connection.Name, metav1.DeleteOptions{})
-	require.NoError(t, err)
+	// Clean up. Retry on transient 409 conflicts: unified storage guards the delete with the object's
+	// current RV, which the ConnectionController's async /status patches keep bumping.
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		err := client.Resource.Delete(t.Context(), connection.Name, metav1.DeleteOptions{})
+		require.NoError(collect, err)
+	}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
 }
 
 func TestIntegrationV1Beta1Connection_Update(t *testing.T) {
@@ -389,9 +405,12 @@ func TestIntegrationV1Beta1Connection_Update(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "999999", retrievedConn.Spec.GitHub.AppID)
 
-	// Clean up
-	err = client.Resource.Delete(t.Context(), connection.Name, metav1.DeleteOptions{})
-	require.NoError(t, err)
+	// Clean up. Retry on transient 409 conflicts: unified storage guards the delete with the object's
+	// current RV, which the ConnectionController's async /status patches keep bumping.
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		err := client.Resource.Delete(t.Context(), connection.Name, metav1.DeleteOptions{})
+		require.NoError(collect, err)
+	}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
 }
 
 func TestIntegrationV1Beta1Connection_Delete(t *testing.T) {
@@ -439,9 +458,12 @@ func TestIntegrationV1Beta1Connection_Delete(t *testing.T) {
 	_, err = client.Resource.Create(t.Context(), unstructuredObj, metav1.CreateOptions{})
 	require.NoError(t, err)
 
-	// Delete the connection
-	err = client.Resource.Delete(t.Context(), "test-delete-connection", metav1.DeleteOptions{})
-	require.NoError(t, err)
+	// Delete the connection. Retry on transient 409 conflicts: unified storage guards the delete with the
+	// object's current RV, which the ConnectionController's async /status patches keep bumping.
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		err := client.Resource.Delete(t.Context(), "test-delete-connection", metav1.DeleteOptions{})
+		require.NoError(collect, err)
+	}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
 
 	// Verify it's deleted
 	_, err = client.Resource.Get(t.Context(), "test-delete-connection", metav1.GetOptions{})


### PR DESCRIPTION
## What

`TestIntegrationV1Beta1Connection_*` integration tests could flake with:

```
Operation cannot be fulfilled on connections.provisioning.grafana.app "test-update-connection": requested RV does not match current RV
```

The observed failure is on the final cleanup `Delete`, not the `Update`.

## Why

- `ConnectionController` keeps patching the `/status` subresource asynchronously after create/update (observedGeneration, token, health, conditions, fieldErrors), bumping the object's `resourceVersion`.
- Even a bare `Delete` with empty `metav1.DeleteOptions{}` (no client precondition) races: unified storage reads the object and stamps its **current RV onto the delete command itself** (`apistore.Storage.Delete`), with no internal retry. If a status patch lands in the read→write window, the backend rejects the delete with a transient 409 conflict.
- `Connection` has no finalizers, so it takes the immediate-delete path.

This is a test-side optimistic-concurrency race, not a product bug.

## What changed

Wrap every `client.Resource.Delete` in `connection_test.go` in `require.EventuallyWithT` so it retries until the async status patches quiesce — matching the idiom already used by the v0alpha1 connection tests.

## Verification

- `make gofmt` — clean.
- `make lint-go-diff` — 0 issues.
- Integration tests not run in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)