### PR TITLE
Dashboards: Fix missing space for the top row panel outline

### DIFF
--- a/public/app/features/dashboard-scene/sidebar/DashboardSidebarSplitter.tsx
+++ b/public/app/features/dashboard-scene/sidebar/DashboardSidebarSplitter.tsx
@@ -281,8 +281,11 @@ function getStyles(theme: GrafanaTheme2) {
       scrollbarGutter: 'stable',
       // the tabIndex is only here to allow keyboard scrolling, so suppress the focus outline.
       outline: 'none',
-      // Clip-bleed: top padding to accommodate space for outer outlines of panels in the top row
-      padding: theme.spacing(1, 1, 2, 2),
+      // Clip-bleed: top padding + matching negative margin cancel out visually but extend the
+      // clip box under the controls bar, so top-row selection outlines aren't sheared off. The
+      // bar paints over the overlap — see DashboardControlsChrome.
+      padding: theme.spacing(1.125, 1, 2, 2),
+      marginTop: theme.spacing(-1),
     }),
     scrollContainerNoSidebar: css({
       paddingRight: theme.spacing(2),

--- a/public/app/features/dashboard-scene/sidebar/DashboardSidebarSplitter.tsx
+++ b/public/app/features/dashboard-scene/sidebar/DashboardSidebarSplitter.tsx
@@ -281,11 +281,8 @@ function getStyles(theme: GrafanaTheme2) {
       scrollbarGutter: 'stable',
       // the tabIndex is only here to allow keyboard scrolling, so suppress the focus outline.
       outline: 'none',
-      // Clip-bleed: top padding + matching negative margin cancel out visually but extend the
-      // clip box under the controls bar, so top-row selection outlines aren't sheared off. The
-      // bar paints over the overlap — see DashboardControlsChrome.
+      // Clip-bleed: top padding to accommodate space for outer outlines of panels in the top row
       padding: theme.spacing(1, 1, 2, 2),
-      marginTop: theme.spacing(-1),
     }),
     scrollContainerNoSidebar: css({
       paddingRight: theme.spacing(2),


### PR DESCRIPTION
When a panel is selected in the top row the top outline is clipped. Started to happen in https://github.com/grafana/grafana/pull/129334. 

I think the extra 1px space is actually required to fit outer outline

| before | after |
|---|---|
| <img width="807" height="370" alt="Screenshot 2026-07-29 at 15 16 40" src="https://github.com/user-attachments/assets/cf6e06ff-2bd7-448a-a408-1879556277f6" /> | <img width="801" height="405" alt="Screenshot 2026-07-29 at 15 53 02" src="https://github.com/user-attachments/assets/e338a840-a230-4ad4-9bb3-a7582cf3c058" /> |
