### PR TITLE
Transformations: Fix field lookup failing for the Countries and USA States gazetteers

### DIFF
--- a/public/app/features/geo/gazetteer/worldmap.test.ts
+++ b/public/app/features/geo/gazetteer/worldmap.test.ts
@@ -27,4 +27,22 @@ describe('Placename lookup from worldmap format', () => {
     // Items with 'keys' should get allow looking them up
     expect(gaz.find('US')).toEqual(gaz.find('USA'));
   });
+
+  it('exposes a frame and row index so fields can be looked up', async () => {
+    const gaz = await getGazetteer('countries-frame');
+    expect(gaz.error).toBeUndefined();
+
+    const frame = gaz.frame?.();
+    expect(frame).toBeDefined();
+    expect(frame!.length).toBe(gaz.count);
+
+    const found = gaz.find('FR');
+    expect(found?.index).toBeDefined();
+    expect(frame!.fields.map((f) => [f.name, f.values[found!.index!]])).toEqual([
+      ['id', 'FR'],
+      ['name', 'France'],
+      ['lng', 2.213749],
+      ['lat', 46.227638],
+    ]);
+  });
 });

--- a/public/app/features/geo/gazetteer/worldmap.test.ts
+++ b/public/app/features/geo/gazetteer/worldmap.test.ts
@@ -34,7 +34,9 @@ describe('Placename lookup from worldmap format', () => {
   });
 
   it('exposes a frame and row index so fields can be looked up', async () => {
-    const gaz = await getGazetteer('countries-frame');
+    // getGazetteer caches by path in a module-level registry, so this is the same instance the
+    // test above loaded rather than a second fetch.
+    const gaz = await getGazetteer('countries');
     expect(gaz.error).toBeUndefined();
 
     const frame = gaz.frame?.();

--- a/public/app/features/geo/gazetteer/worldmap.test.ts
+++ b/public/app/features/geo/gazetteer/worldmap.test.ts
@@ -15,6 +15,11 @@ describe('Placename lookup from worldmap format', () => {
     } as unknown as Response);
   });
 
+  // Jest is not configured to restore mocks between tests, so the fetch spy has to be undone here.
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it('unified worldmap config', async () => {
     const gaz = await getGazetteer('countries');
     expect(gaz.error).toBeUndefined();

--- a/public/app/features/geo/gazetteer/worldmap.ts
+++ b/public/app/features/geo/gazetteer/worldmap.ts
@@ -1,6 +1,8 @@
 import { Point } from 'ol/geom';
 import { fromLonLat } from 'ol/proj';
 
+import { FieldType, toDataFrame } from '@grafana/data';
+
 import { type PlacenameInfo, type Gazetteer } from './gazetteer';
 
 // https://github.com/grafana/worldmap-panel/blob/master/src/data/countries.json
@@ -13,13 +15,26 @@ export interface WorldmapPoint {
 }
 
 export function loadWorldmapPoints(path: string, data: WorldmapPoint[]): Gazetteer {
-  let count = 0;
+  // The field lookup transform reads values out of a frame, so expose the points as one too.
+  // Field names match what frameAsGazetter recognises, so the frame round-trips as a gazetteer.
+  const frame = toDataFrame({
+    fields: [
+      { name: 'id', type: FieldType.string, values: data.map((v) => v.key ?? v.keys?.[0]) },
+      { name: 'name', type: FieldType.string, values: data.map((v) => v.name) },
+      { name: 'lng', type: FieldType.number, values: data.map((v) => v.longitude) },
+      { name: 'lat', type: FieldType.number, values: data.map((v) => v.latitude) },
+    ],
+  });
+
   const values = new Map<string, PlacenameInfo>();
+  let index = 0;
   for (const v of data) {
     const point = new Point(fromLonLat([v.longitude, v.latitude]));
     const info: PlacenameInfo = {
       point: () => point,
       geometry: () => point,
+      frame,
+      index,
     };
     if (v.name) {
       values.set(v.name, info);
@@ -35,7 +50,7 @@ export function loadWorldmapPoints(path: string, data: WorldmapPoint[]): Gazette
         values.set(key.toUpperCase(), info);
       }
     }
-    count++;
+    index++;
   }
   return {
     path,
@@ -46,7 +61,8 @@ export function loadWorldmapPoints(path: string, data: WorldmapPoint[]): Gazette
       }
       return v;
     },
-    count,
+    frame: () => frame,
+    count: frame.length,
     examples: (count) => {
       const first: string[] = [];
       if (values.size < 1) {

--- a/public/app/features/transformers/lookupGazetteer/fieldLookup.test.ts
+++ b/public/app/features/transformers/lookupGazetteer/fieldLookup.test.ts
@@ -1,7 +1,43 @@
+import { lastValueFrom, of } from 'rxjs';
+
 import { DataTransformerID, toDataFrame, FieldMatcherID, fieldMatchers, FieldType } from '@grafana/data';
 import { frameAsGazetter } from 'app/features/geo/gazetteer/gazetteer';
 
-import { addFieldsFromGazetteer } from './fieldLookup';
+import countriesJSON from '../../../../gazetteer/countries.json';
+
+import { addFieldsFromGazetteer, fieldLookupTransformer } from './fieldLookup';
+
+describe('Lookup gazetteer from the worldmap format', () => {
+  beforeAll(() => {
+    window.__grafana_public_path__ = 'https://grafana.fake/public/';
+  });
+
+  beforeEach(() => {
+    jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: jest.fn().mockResolvedValue(countriesJSON),
+    } as unknown as Response);
+  });
+
+  it('adds country fields using the default countries gazetteer', async () => {
+    const data = toDataFrame({
+      name: 'countries',
+      fields: [{ name: 'code2letters', type: FieldType.string, values: ['FR'] }],
+    });
+
+    const operator = fieldLookupTransformer.operator({ lookupField: 'code2letters' }, { interpolate: (v) => v });
+    const out = await lastValueFrom(of([data]).pipe(operator));
+
+    expect(out[0].fields.map((f) => [f.name, f.values])).toEqual([
+      ['code2letters', ['FR']],
+      ['id', ['FR']],
+      ['name', ['France']],
+      ['lng', [2.213749]],
+      ['lat', [46.227638]],
+    ]);
+  });
+});
 
 describe('Lookup gazetteer', () => {
   it('adds lat/lon based on string field', async () => {

--- a/public/app/features/transformers/lookupGazetteer/fieldLookup.test.ts
+++ b/public/app/features/transformers/lookupGazetteer/fieldLookup.test.ts
@@ -7,9 +7,21 @@ import countriesJSON from '../../../../gazetteer/countries.json';
 
 import { addFieldsFromGazetteer, fieldLookupTransformer } from './fieldLookup';
 
+// Jest is not configured to restore mocks between tests, so each spy below has to be undone
+// here or it leaks into the following describe blocks.
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
 describe('Lookup gazetteer from the worldmap format', () => {
+  const publicPath = window.__grafana_public_path__;
+
   beforeAll(() => {
     window.__grafana_public_path__ = 'https://grafana.fake/public/';
+  });
+
+  afterAll(() => {
+    window.__grafana_public_path__ = publicPath;
   });
 
   beforeEach(() => {

--- a/public/app/features/transformers/lookupGazetteer/fieldLookup.test.ts
+++ b/public/app/features/transformers/lookupGazetteer/fieldLookup.test.ts
@@ -39,6 +39,24 @@ describe('Lookup gazetteer from the worldmap format', () => {
   });
 });
 
+describe('Lookup gazetteer error handling', () => {
+  it('rejects with an error naming the gazetteer that could not be loaded', async () => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    jest.spyOn(global, 'fetch').mockRejectedValue(new Error('network down'));
+
+    const data = toDataFrame({
+      fields: [{ name: 'code2letters', type: FieldType.string, values: ['FR'] }],
+    });
+
+    const operator = fieldLookupTransformer.operator(
+      { lookupField: 'code2letters', gazetteer: 'https://example.com/broken.json' },
+      { interpolate: (v) => v }
+    );
+
+    await expect(lastValueFrom(of([data]).pipe(operator))).rejects.toThrow(/broken\.json/);
+  });
+});
+
 describe('Lookup gazetteer', () => {
   it('adds lat/lon based on string field', async () => {
     const cfg = {

--- a/public/app/features/transformers/lookupGazetteer/fieldLookup.test.ts
+++ b/public/app/features/transformers/lookupGazetteer/fieldLookup.test.ts
@@ -115,6 +115,73 @@ describe('Lookup gazetteer', () => {
     `);
   });
 
+  it('does not look up more values than the frame has rows', () => {
+    const data = toDataFrame({
+      name: 'countries',
+      fields: [{ name: 'code2letters', type: FieldType.string, values: ['FR'] }],
+    });
+
+    const matcher = fieldMatchers.get(FieldMatcherID.byName).get('code2letters');
+
+    const frame = toDataFrame({
+      fields: [
+        { name: 'id', values: ['FR', 'DE', 'ES'] },
+        { name: 'name', values: ['France', 'Germany', 'Spain'] },
+        { name: 'lng', values: [2.2137, 10.4515, -3.7492] },
+        { name: 'lat', values: [46.2276, 51.1657, 40.4637] },
+      ],
+    });
+    const gaz = frameAsGazetter(frame, { path: 'path/to/gaz.json' });
+    const find = jest.spyOn(gaz, 'find');
+
+    const out = addFieldsFromGazetteer([data], gaz, matcher)[0];
+
+    expect(find).toHaveBeenCalledTimes(1);
+    expect(find).toHaveBeenCalledWith('FR');
+
+    expect(out.length).toBe(1);
+    for (const field of out.fields) {
+      expect(field.values).toHaveLength(1);
+    }
+    expect(out.fields.map((f) => [f.name, f.values])).toEqual([
+      ['code2letters', ['FR']],
+      ['id', ['FR']],
+      ['name', ['France']],
+      ['lng', [2.2137]],
+      ['lat', [46.2276]],
+    ]);
+  });
+
+  it('looks up rows past the number of gazetteer entries', () => {
+    const data = toDataFrame({
+      name: 'locations',
+      fields: [
+        { name: 'location', type: FieldType.string, values: ['AL', 'AK', 'AZ', 'CA'] },
+        { name: 'values', type: FieldType.number, values: [0, 10, 5, 1] },
+      ],
+    });
+
+    const matcher = fieldMatchers.get(FieldMatcherID.byName).get('location');
+
+    const frame = toDataFrame({
+      fields: [
+        { name: 'id', values: ['CA', 'AL'] },
+        { name: 'name', values: ['California', 'Alabama'] },
+      ],
+    });
+    const gaz = frameAsGazetter(frame, { path: 'path/to/gaz.json' });
+
+    const out = addFieldsFromGazetteer([data], gaz, matcher)[0];
+
+    // 'CA' is row 3, past the 2 gazetteer entries, and must still be looked up
+    expect(out.fields.map((f) => [f.name, f.values])).toEqual([
+      ['location', ['AL', 'AK', 'AZ', 'CA']],
+      ['id', ['AL', undefined, undefined, 'CA']],
+      ['name', ['Alabama', undefined, undefined, 'California']],
+      ['values', [0, 10, 5, 1]],
+    ]);
+  });
+
   it('goes through entire gazetteer to find matches', async () => {
     const cfg = {
       id: DataTransformerID.fieldLookup,

--- a/public/app/features/transformers/lookupGazetteer/fieldLookup.ts
+++ b/public/app/features/transformers/lookupGazetteer/fieldLookup.ts
@@ -31,7 +31,8 @@ async function doGazetteerXform(frames: DataFrame[], options: FieldLookupOptions
   const gazetteer = await getGazetteer(options?.gazetteer ?? GAZETTEER_OPTIONS.countries.path);
 
   if (!gazetteer.frame) {
-    return Promise.reject('missing frame in gazetteer');
+    const reason = gazetteer.error ?? 'it contains no lookup data';
+    return Promise.reject(new Error(`Could not look up fields in "${gazetteer.path}": ${reason}`));
   }
 
   return addFieldsFromGazetteer(frames, gazetteer, fieldMatches);

--- a/public/app/features/transformers/lookupGazetteer/fieldLookup.ts
+++ b/public/app/features/transformers/lookupGazetteer/fieldLookup.ts
@@ -61,7 +61,8 @@ export function addFieldsFromGazetteer(frames: DataFrame[], gazetteer: Gazetteer
           fields.push({ ...gazetteerField, values: buffer });
         }
 
-        for (let valueIndex = 0; valueIndex < gazetteer.count!; valueIndex++) {
+        // One lookup per row: the buffers above are sized to the frame, not to the gazetteer
+        for (let valueIndex = 0; valueIndex < frameLength; valueIndex++) {
           const foundValue = gazetteer.find(values[valueIndex]);
 
           if (foundValue?.index != null) {


### PR DESCRIPTION
**Fixes #55826**

**What is this feature?**

Fixes **Lookup fields from resource**, which threw `missing frame in gazetteer` and produced
no output for two of its three built-in gazetteers — including the default, Countries.

1. `loadWorldmapPoints` now exposes its points as a `DataFrame` and records each entry's row
   `index` on the `PlacenameInfo` it returns. Both were missing, so `doGazetteerXform` bailed
   at `if (!gazetteer.frame)` before any lookup ran.
2. The lookup loop is bounded by the frame's row count instead of `gazetteer.count`. The read
   source (`field.values`) and the write buffer (`new Array(frameLength)`) are both sized to
   the frame, so the old bound over-ran in one direction and under-ran in the other.
3. A genuinely missing frame (custom URL that fails to fetch or parse) now rejects with an
   `Error` naming the gazetteer, rather than the bare string that surfaced as a stack-less
   *"Uncaught missing frame in gazetteer"*.

**Why do we need this feature?**

`countries.json` and `usa-states.json` are both in the legacy worldmap format
(`{keys, latitude, longitude, name}`). `loadGazetteer` routes that shape to
`loadWorldmapPoints`, which never built a frame — so the transform failed 100% of the time
for those two options. Only `airports.geojson` went through `frameAsGazetter`, which is why
this survived so long.

The loop bound was a second, quieter bug: with `usa-states.json` (55 entries), any frame with
more than 55 rows silently dropped the lookup for every row past 55 — no error, just empty
columns.

**Special notes for your reviewer:**

⚠️ **This changes rendered output for existing dashboards.** Panels that were throwing will
start showing data, and panels with more rows than gazetteer entries will fill in columns
that used to be blank.

Verified in a local instance, not only unit tests:

- The issue's repro — single-row `code2letters: ["FR"]`, default gazetteer — now returns
  `id: FR, name: France, lng: 2.213749, lat: 46.227638`.
- 60 rows against the 55-entry `usa-states.json` populate to the last row; rows 56–60 were
  previously empty.

**Screenshots**

<img width="1280" height="720" alt="dpro248-dashboard" src="https://github.com/user-attachments/assets/bcf9150d-dfad-4809-a14d-30a77e5a1d80" />

<img width="1280" height="720" alt="dpro248-panel2-bottom" src="https://github.com/user-attachments/assets/11c03339-8b77-426f-827b-6d30715feddb" />
