### PR TITLE
Alerting: Fix flaky RuleViewer test and strengthen rule group cache invalidation test

### DIFF
--- a/public/app/features/alerting/unified/RuleViewer.test.tsx
+++ b/public/app/features/alerting/unified/RuleViewer.test.tsx
@@ -1,16 +1,23 @@
 import { render, screen } from 'test/test-utils';
 
 import RuleViewer from './RuleViewer';
-import { stringifyErrorLike } from './utils/misc';
 
 describe('Rule Viewer page', () => {
   it('should throw an error if rule ID cannot be decoded', () => {
-    // check console errors
-    jest.spyOn(console, 'error').mockImplementation((error) => {
-      expect(stringifyErrorLike(error)).toContain('Error: Rule ID is required');
-    });
+    // React reports the boundary-caught error over three console.error calls, and the last one is a
+    // component stack that does not mention the error message. Assertions must therefore live in the
+    // test body, not in the mock implementation — an expect() that throws inside React's error
+    // logging path escapes as an uncaught exception and gets attributed to whichever test is running
+    // when it surfaces.
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
 
     render(<RuleViewer />);
+
     expect(screen.getByText(/Error: Rule ID is required/i)).toBeInTheDocument();
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining('Rule ID is required') })
+    );
+
+    consoleError.mockRestore();
   });
 });

--- a/public/app/features/alerting/unified/api/alertRuleApi.test.ts
+++ b/public/app/features/alerting/unified/api/alertRuleApi.test.ts
@@ -89,12 +89,19 @@ describe('alertRuleApi', () => {
     it('refetches combined rule queries after a group is saved', async () => {
       const store = createTestStore();
 
+      // Count only the combined-rule GET requests. Counting *all* fetches would make this pass on the
+      // mutation's own POST alone, so the test would still be green with the invalidation removed.
+      const combinedRuleRequestCount = () =>
+        fetchMock.mock.calls.filter(([request]) =>
+          String(request?.url).includes(`api/prometheus/${GRAFANA_RULES_SOURCE_NAME}/api/v1/rules`)
+        ).length;
+
       // Keep a combined-rule-backed query subscribed so invalidation can trigger a refetch.
       const querySubscription = store.dispatch(
         alertRuleApi.endpoints.prometheusRuleNamespaces.initiate({ ruleSourceName: GRAFANA_RULES_SOURCE_NAME })
       );
       await querySubscription;
-      const callsAfterInitialQuery = fetchMock.mock.calls.length;
+      expect(combinedRuleRequestCount()).toBe(1);
 
       await store.dispatch(
         alertRuleApi.endpoints.upsertRuleGroupForNamespace.initiate({
@@ -105,9 +112,11 @@ describe('alertRuleApi', () => {
       );
 
       await waitFor(() => {
-        expect(fetchMock.mock.calls.length).toBeGreaterThan(callsAfterInitialQuery);
+        expect(combinedRuleRequestCount()).toBe(2);
       });
 
+      // Unsubscribe before afterEach clears the mock implementation, so a late refetch can't fire
+      // against a fetch mock that no longer returns an observable.
       querySubscription.unsubscribe();
     });
   });

--- a/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.test.tsx
@@ -279,11 +279,16 @@ describe('RuleViewer', () => {
 
         expect(screen.getAllByRole('row')[6]).toHaveTextContent(/1Unknown 2025-01-13 04:35:17/i);
 
+        // findBy* resolves as soon as the button exists — it does not retry the enabled/disabled
+        // assertion — so the state check has to be wrapped in waitFor to survive a loaded CI runner.
+        const compareButton = screen.getByRole('button', { name: /Compare versions/i });
+
         await user.click(screen.getByLabelText('1'));
         await user.click(screen.getByLabelText('2'));
-        expect(await screen.findByRole('button', { name: /Compare versions/i })).toBeEnabled();
+        await waitFor(() => expect(compareButton).toBeEnabled());
+
         await user.click(screen.getByLabelText('1'));
-        expect(await screen.findByRole('button', { name: /Compare versions/i })).toBeDisabled();
+        await waitFor(() => expect(compareButton).toBeDisabled());
       });
       it('shows version history with special case `updated_by` values', async () => {
         await renderRuleViewer(mockRule, mockRuleIdentifier, ActiveTab.VersionHistory);


### PR DESCRIPTION
**What is this feature?**

Test-only fixes for the two alerting-owned tests flagged in the daily flaky test report, plus a leftover race from a previous flake fix.

**1. `unified/RuleViewer.test.tsx` — the persistent flake**

The test placed an assertion *inside* a `console.error` mock:

```ts
jest.spyOn(console, 'error').mockImplementation((error) => {
  expect(stringifyErrorLike(error)).toContain('Error: Rule ID is required');
});
```

React reports the boundary-caught error over **three** `console.error` calls, and the third is a component stack:

```
The above error occurred in the <RuleViewer> component:
    at RuleViewer (.../RuleViewer.tsx:21:27)
```

That message does not contain `Error: Rule ID is required`, so the inner `expect` throws on **every single run** — confirmed deterministically by instrumenting the mock (`consoleErrorCalls: 3, innerExpectFailures: ["call 3: expect(received).toContain(expected)"]`).

It normally goes unnoticed because the throw happens inside React's error-logging path, where it is swallowed. When it *does* escape, jest-circus attributes the uncaught exception to whichever test happens to be running at that moment — which is why this presented as a low-frequency flake that never reproduced locally and was hard to attribute to a specific test.

Fixed by silencing the mock, moving both assertions into the test body, and restoring the spy.

**2. `api/alertRuleApi.test.ts` — the assertion was a tautology**

`refetches combined rule queries after a group is saved` asserted that `fetchMock.mock.calls.length` grew after the mutation. But the mutation's own POST satisfies that on its own, independent of any cache invalidation.

Verified by deleting the `'CombinedAlertRule'` tag from `invalidatesTags` in `alertRuleApi.ts`: **the test still passed**. It never tested the regression it was written for.

It now counts only the `api/prometheus/grafana/api/v1/rules` GETs, so the mutation's POST cannot satisfy it. Re-running the same experiment, the test now correctly **fails** with the tag removed.

Also documented why `querySubscription.unsubscribe()` matters: a late refetch firing after `afterEach`'s `mockReset()` would hit a mock with no implementation.

**3. `components/rule-viewer/RuleViewer.test.tsx` — third call site missed by #126263**

#126263 fixed two of **three** identical call sites. The remaining one still did:

```ts
expect(await screen.findByRole('button', { name: /Compare versions/i })).toBeEnabled();
```

`findBy*` resolves as soon as the element exists and never retries the enabled/disabled state, so this is the same race the other two sites were fixed for. Now wrapped in `waitFor`.

**Why do we need this feature?**

A flaky test is worse than no test. `RuleViewer.test.tsx` had been failing on main for ≥3 days, and the `alertRuleApi` test was passing while asserting nothing about the invalidation it was named for — so a real regression in panel-alerts-list refresh behaviour would have shipped silently.

**Who is this feature for?**

Grafana contributors — reduces CI noise and restores real coverage of rule group cache invalidation.

**Which issue(s) does this PR fix?**:

N/A — reported via the Daily CI Test Report (Jul 29, 2026).

**Special notes for your reviewer:**

No production code changes — the two `alertRuleApi.ts` edits described above were temporary experiments to prove the tests catch real regressions, and were reverted (working tree contains only the 3 test files).

Verification:

| Check | Result |
| --- | --- |
| 3 suites, 28 tests | pass |
| Combined stress, 12 iterations under 12-proc CPU load | 12/12 pass |
| Per-suite stress on originals | 15/15, 17/17, 40/40 pass |
| `alertRuleApi` test catches its regression | now fails with tag removed (previously passed) |
| `eslint` / `prettier --check` / `yarn typecheck` | clean |

Note the per-suite stress runs passing on the *unfixed* tests is expected, not a contradiction — it confirms these are not simple timing flakes reproducible under load, consistent with the swallow/escape mechanism described above.
