### PR TITLE
Transformations: Fix Filter by value regex matching null values

### DIFF
--- a/packages/grafana-data/src/transformations/matchers/valueMatchers/regexMatchers.test.ts
+++ b/packages/grafana-data/src/transformations/matchers/valueMatchers/regexMatchers.test.ts
@@ -82,4 +82,41 @@ describe('regex value matcher', () => {
       expect(matcher(valueIndex, field, frame, data)).toBeFalsy();
     });
   });
+
+  describe('nullish values', () => {
+    const nullishData: DataFrame[] = [
+      toDataFrame({
+        fields: [
+          {
+            name: 'temp',
+            values: [null, undefined, 0, ''],
+          },
+        ],
+      }),
+    ];
+
+    it.each(['.*', '.+', '\\w*', 'null', 'undefined'])('should not match null or undefined with %s', (value) => {
+      const matcher = getValueMatcher({
+        id: ValueMatcherID.regex,
+        options: { value },
+      });
+      const frame = nullishData[0];
+      const field = frame.fields[0];
+
+      expect(matcher(0, field, frame, nullishData)).toBeFalsy();
+      expect(matcher(1, field, frame, nullishData)).toBeFalsy();
+    });
+
+    it('should still match falsy non-nullish values', () => {
+      const matcher = getValueMatcher({
+        id: ValueMatcherID.regex,
+        options: { value: '.*' },
+      });
+      const frame = nullishData[0];
+      const field = frame.fields[0];
+
+      expect(matcher(2, field, frame, nullishData)).toBeTruthy();
+      expect(matcher(3, field, frame, nullishData)).toBeTruthy();
+    });
+  });
 });

--- a/packages/grafana-data/src/transformations/matchers/valueMatchers/regexMatchers.ts
+++ b/packages/grafana-data/src/transformations/matchers/valueMatchers/regexMatchers.ts
@@ -13,7 +13,9 @@ const regexValueMatcher: ValueMatcherInfo<BasicValueMatcherOptions<string>> = {
 
     return (valueIndex: number, field: Field) => {
       const value = field.values[valueIndex];
-      return regex.test(value);
+      // RegExp.test coerces its argument to a string, so without this guard null/undefined
+      // become "null"/"undefined" and match patterns like .* or .+
+      return value != null && regex.test(value);
     };
   },
   getOptionsDisplayText: (options) => {

--- a/packages/grafana-data/src/transformations/transformers/filterByValue.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/filterByValue.test.ts
@@ -93,6 +93,41 @@ describe('FilterByValue transformer', () => {
     });
   });
 
+  it('should not include null values when matching by regex', async () => {
+    const seriesWithNulls = toDataFrame({
+      name: 'A',
+      length: 4,
+      fields: [
+        { name: 'time', type: FieldType.time, values: [1000, 2000, 3000, 4000] },
+        { name: 'names', type: FieldType.string, values: ['a', null, 'b', undefined] },
+      ],
+    });
+
+    const cfg: DataTransformerConfig<FilterByValueTransformerOptions> = {
+      id: DataTransformerID.filterByValue,
+      options: {
+        type: FilterByValueType.include,
+        match: FilterByValueMatch.all,
+        filters: [
+          {
+            fieldName: 'names',
+            config: {
+              id: ValueMatcherID.regex,
+              options: { value: '.*' },
+            },
+          },
+        ],
+      },
+    };
+
+    await expect(transformDataFrame([cfg], [seriesWithNulls])).toEmitValuesWith((received) => {
+      const processed = received[0];
+
+      expect(processed[0].fields[0].values).toEqual([1000, 3000]);
+      expect(processed[0].fields[1].values).toEqual(['a', 'b']);
+    });
+  });
+
   it('should not cross frame boundaries when equals 0', async () => {
     const cfg: DataTransformerConfig<FilterByValueTransformerOptions> = {
       id: DataTransformerID.filterByValue,


### PR DESCRIPTION
**Fixes #81475**

**What is this feature?**

Fixes the `regex` value matcher so it no longer matches `null` and `undefined`.
`RegExp.prototype.test` coerces its argument to a string, so an absent value became the
literal `"null"` before being tested — meaning `.*` and `.+` matched empty rows, and
**Filter data by values → Include → Regex** could not filter nulls out.

The guard is `value != null`, matching the convention in `nullMatchers.ts`. Deliberately not
`typeof value === 'string'` — numeric coercion is intentional and covered by an existing test
(`100` matches `\d+`) — and not the `value &&` idiom, which would wrongly reject `0` and `''`.

**Why do we need this feature?**

Filtering out nulls is the point of the reported workflow, and regex was the only route to it.
The dedicated null filter (#81465) is already fixed, so this was the last blocker.

**Special notes for your reviewer:**

⚠️ **Behavior change:** because a null no longer *matches*, it is no longer *excluded* either.
**Exclude → Regex `.+`** used to return "No rows" and now returns the null rows. The one real
regression is anyone using **Exclude → Regex `null`** as a workaround to drop null rows — that
stops working, and is superseded by the dedicated "Is null" filter.

Tests: null/undefined against `.*`, `.+`, `\w*` and the literal patterns `null`/`undefined`,
plus a case asserting `0` and `''` still match. Added a `filterByValue` test since that
transformation is the only consumer of this matcher.

**Screenshots**

Local instance, testdata `csv_content` producing real nulls.

Before:
<img width="1600" height="620" alt="dpro251-before" src="https://github.com/user-attachments/assets/aeb6329f-6e3b-43bb-be6d-1f67278fb4f3" />

After:
<img width="1600" height="620" alt="dpro251-after" src="https://github.com/user-attachments/assets/2be43626-4aa5-4299-9f38-d42d46d3f372" />
