### PR TITLE
Search: expose the search endpoint on folders

### DIFF
--- a/pkg/services/apiserver/searchroutes/searchroutes.go
+++ b/pkg/services/apiserver/searchroutes/searchroutes.go
@@ -22,15 +22,12 @@ const namespacedScope = "Namespaced"
 
 // allowed lists the kinds that expose the search API, as (group, resource).
 //
-// Temporary, and deliberately one kind for now. Every namespaced kind is a
-// candidate, but a kind can only be added once its authorizer restates a search
-// request as the read it performs: the endpoint is a POST, so Kubernetes parses
-// it as a create, and a kind that does not restate would demand create
-// permission to search. Dashboards do this in their own authorizer today. Moving
-// that to the authorization chain, which means both the single-tenant and
-// multi-tenant chains, is what unblocks widening this set.
+// Temporary. Every namespaced kind is a candidate, but turning them all on at
+// once would expose endpoints on kinds nobody has looked at yet, so the set is
+// widened deliberately. A manifest opt-out replaces this.
 var allowed = map[groupResource]bool{
 	{group: "dashboard.grafana.app", resource: "dashboards"}: true,
+	{group: "folder.grafana.app", resource: "folders"}:       true,
 }
 
 type groupResource struct {

--- a/pkg/services/apiserver/searchroutes/searchroutes_test.go
+++ b/pkg/services/apiserver/searchroutes/searchroutes_test.go
@@ -69,9 +69,7 @@ func TestBuild_MountsAllowedKinds(t *testing.T) {
 	got := paths(Build(enabledCfg(t, true), nil, nil, []builder.APIGroupBuilder{b}, nil))
 
 	assert.Equal(t, []string{"dashboards/search"}, got["dashboard.grafana.app/v1"])
-	// Folders are served and namespaced but not allowed yet: their authorizer
-	// would treat a search as a create.
-	assert.NotContains(t, got, "folder.grafana.app/v1")
+	assert.Equal(t, []string{"folders/search"}, got["folder.grafana.app/v1"])
 }
 
 // A manifest describes kinds this process may not serve, so the served group
@@ -91,7 +89,6 @@ func TestBuild_SkipsKindsNotAllowed(t *testing.T) {
 		{Group: "secret.grafana.app", Version: "v1beta1"},
 		{Group: "iam.grafana.app", Version: "v0alpha1"},
 		{Group: "playlist.grafana.app", Version: "v0alpha1"},
-		{Group: "folder.grafana.app", Version: "v1"},
 	}
 	b := &fakeBuilder{gvs: notAllowed}
 

--- a/pkg/tests/apis/dashboard/searchapi_test.go
+++ b/pkg/tests/apis/dashboard/searchapi_test.go
@@ -169,6 +169,31 @@ func TestIntegrationSearchAPI(t *testing.T) {
 		assert.Equal(t, http.StatusUnprocessableEntity, code)
 	})
 
+	// Folders declare no search fields of their own, so this exercises a kind that
+	// has only the standard set.
+	t.Run("searches folders too", func(t *testing.T) {
+		folderGVR := schema.GroupVersionResource{
+			Group:    "folder.grafana.app",
+			Version:  "v1beta1",
+			Resource: "folders",
+		}
+		results, code := search(t, ctx, helper.Org1.Admin, folderGVR, searchV0.SearchQuery{
+			Where: &searchV0.WhereNode{
+				Text: &searchV0.TextPredicate{Value: "Search API folder"},
+			},
+			Fields: []string{"title"},
+			Limit:  10,
+		})
+		require.Equal(t, http.StatusOK, code)
+		require.NotEmpty(t, results.Items, "the folder created above should be found")
+
+		item := results.Items[0]
+		assert.Equal(t, "folder.grafana.app", item.Resource.Group)
+		assert.Equal(t, "folders", item.Resource.Resource)
+		assert.Equal(t, "Folder", item.Resource.Kind)
+		assert.Equal(t, folderUID, item.Resource.Name)
+	})
+
 	// A malformed body cannot be validated at all, so it is a bad request.
 	t.Run("rejects an unknown top-level field", func(t *testing.T) {
 		code := postRaw(t, ctx, helper.Org1.Admin, gvr,


### PR DESCRIPTION
Folders are the second kind to get `/search`, which is what the allowlist is for — widen one kind at a time rather than turning on every namespaced kind at once. Epic: grafana/search-and-storage-team#869.

Folders declare no search fields of their own, so this is the first kind served entirely from the standard set.

The comment on the allowlist described a constraint that no longer exists, since restating a search as a read moved into the authorization chain in #129554 and grafana/grafana-enterprise#12849. It now says why the list is still narrow.

An integration subtest covers a folders search end to end. I checked that it earns its place: without the allowlist entry the same request returns 405, since the group version has no POST at that path.