### PR TITLE
Transformations: Fix inner join returning rows when a frame is dropped

### DIFF
--- a/docs/sources/visualizations/panels-visualizations/query-transform-data/transform-data/index.md
+++ b/docs/sources/visualizations/panels-visualizations/query-transform-data/transform-data/index.md
@@ -900,6 +900,8 @@ The result after applying the inner join transformation looks like the following
 
 The inner join only includes rows where there is a match between the "StudentID" in both tables. In this case, the result does not include "Jennifer" from the "Students" table because there are no matching enrollments for her in the "Enrollments" table.
 
+If a query returns data that doesn't contain the join field, then no row can match in every query, so the result is empty. To join only some of your queries, add a [Filter data by query refId](#filter-data-by-query-refid) transformation before the join.
+
 #### Outer join (for Time Series data)
 
 An outer join includes all data from an inner join and rows where values do not match in every input. While the inner join joins Query A and Query B on the time field, the outer join includes all rows that don't match on the time field.

--- a/packages/grafana-data/src/transformations/transformers/joinByField.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/joinByField.test.ts
@@ -877,7 +877,10 @@ describe('JOIN Transformer', () => {
       });
     });
 
-    it('joins if fields are missing', async () => {
+    // A frame that has no fields contributes no join values, so there is nothing for the other
+    // frames to match against and an inner join must produce no rows. The outer join equivalent of
+    // this test drops the empty frame and joins the rest instead.
+    it('does not join if fields are missing', async () => {
       const cfg: DataTransformerConfig<JoinByFieldOptions> = {
         id: DataTransformerID.seriesToColumns,
         options: {
@@ -910,6 +913,7 @@ describe('JOIN Transformer', () => {
       await expect(transformDataFrame([cfg], [frame1, frame2, frame3])).toEmitValuesWith((received) => {
         const data = received[0];
         const filtered = data[0];
+        expect(filtered.length).toBe(0);
         expect(filtered.fields).toMatchInlineSnapshot(`
           [
             {
@@ -917,11 +921,7 @@ describe('JOIN Transformer', () => {
               "name": "time",
               "state": {},
               "type": "time",
-              "values": [
-                1,
-                2,
-                3,
-              ],
+              "values": [],
             },
             {
               "config": {},
@@ -931,11 +931,7 @@ describe('JOIN Transformer', () => {
               "name": "temperature",
               "state": {},
               "type": "number",
-              "values": [
-                10,
-                11,
-                12,
-              ],
+              "values": [],
             },
             {
               "config": {},
@@ -945,11 +941,7 @@ describe('JOIN Transformer', () => {
               "name": "temperature",
               "state": {},
               "type": "number",
-              "values": [
-                20,
-                22,
-                24,
-              ],
+              "values": [],
             },
           ]
         `);

--- a/packages/grafana-data/src/transformations/transformers/joinDataFrames.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/joinDataFrames.test.ts
@@ -768,6 +768,156 @@ describe('align frames', () => {
     );
   });
 
+  describe('inner joins with frames that cannot participate', () => {
+    // An inner join only yields rows present in every input, so a frame that cannot be joined at
+    // all -- because it has no fields, or none matching the join field -- leaves nothing to match
+    // against and the result must be empty. Outer joins keep dropping such frames instead, so that
+    // one unrelated series in a panel cannot blank out the whole visualization.
+    const joinByGA = fieldMatchers.get(FieldMatcherID.byName).get('GA');
+
+    const measurements = toDataFrame({
+      refId: 'A',
+      fields: [
+        { name: 'GA', type: FieldType.string, values: ['a', 'b'] },
+        { name: 'Val', type: FieldType.number, values: [1, 2] },
+      ],
+    });
+    const lookup = toDataFrame({
+      refId: 'B',
+      fields: [
+        { name: 'GA', type: FieldType.string, values: ['a', 'b'] },
+        { name: 'GA_TEXT', type: FieldType.string, values: ['Alpha', 'Beta'] },
+      ],
+    });
+    const otherLookup = toDataFrame({
+      refId: 'C',
+      fields: [
+        { name: 'PA', type: FieldType.string, values: ['x', 'y'] },
+        { name: 'PA_TEXT', type: FieldType.string, values: ['Ex', 'Why'] },
+      ],
+    });
+
+    it('should return no rows when one of several frames is missing the join field', () => {
+      const out = joinDataFrames({
+        frames: [measurements, lookup, otherLookup],
+        joinBy: joinByGA,
+        mode: JoinMode.inner,
+      })!;
+
+      expect(out.length).toBe(0);
+      expect(out.fields.map((f) => ({ name: f.name, values: f.values }))).toEqual([
+        { name: 'GA', values: [] },
+        { name: 'Val', values: [] },
+        { name: 'GA_TEXT', values: [] },
+      ]);
+    });
+
+    // Only one frame can be joined, so joinTabular's merge loop never runs and previously returned
+    // that frame's rows verbatim -- an inner join that matched nothing yet output everything.
+    it('should return no rows when only one frame has the join field', () => {
+      const out = joinDataFrames({
+        frames: [otherLookup, lookup],
+        joinBy: joinByGA,
+        mode: JoinMode.inner,
+      })!;
+
+      expect(out.length).toBe(0);
+      expect(out.fields.map((f) => ({ name: f.name, values: f.values }))).toEqual([
+        { name: 'GA', values: [] },
+        { name: 'GA_TEXT', values: [] },
+      ]);
+    });
+
+    it('should return no rows when a frame has no fields at all', () => {
+      const out = joinDataFrames({
+        frames: [toDataFrame({ refId: 'A', fields: [] }), lookup],
+        joinBy: joinByGA,
+        mode: JoinMode.inner,
+      })!;
+
+      expect(out.length).toBe(0);
+      expect(out.fields.map((f) => ({ name: f.name, values: f.values }))).toEqual([
+        { name: 'GA', values: [] },
+        { name: 'GA_TEXT', values: [] },
+      ]);
+    });
+
+    // A query that returns nothing often drops the join field along with its rows -- e.g. Prometheus
+    // emits only Time/Value columns for an empty result, with no label columns to join on.
+    it('should return no rows when an empty frame between two joinable frames lacks the join field', () => {
+      const emptyResult = toDataFrame({
+        refId: 'B',
+        fields: [
+          { name: 'Time', type: FieldType.time, values: [] },
+          { name: 'Value', type: FieldType.number, values: [] },
+        ],
+      });
+
+      const out = joinDataFrames({
+        frames: [measurements, emptyResult, lookup],
+        joinBy: joinByGA,
+        mode: JoinMode.inner,
+      })!;
+
+      expect(out.length).toBe(0);
+      expect(out.fields.map((f) => ({ name: f.name, values: f.values }))).toEqual([
+        { name: 'GA', values: [] },
+        { name: 'Val', values: [] },
+        { name: 'GA_TEXT', values: [] },
+      ]);
+    });
+
+    // A lone frame is handled by its own code path, but the rule is the same at every arity: with no
+    // field to join on there are no matching rows.
+    it('should return no rows when the only frame is missing the join field', () => {
+      const out = joinDataFrames({
+        frames: [otherLookup],
+        joinBy: joinByGA,
+        mode: JoinMode.inner,
+      })!;
+
+      expect(out.length).toBe(0);
+      expect(out.fields).toEqual([]);
+    });
+
+    // Panels join all of their series with an outer join and must still render a single series that
+    // has no field to join by, so outer joins deliberately keep returning a lone frame untouched.
+    it.each([JoinMode.outer, JoinMode.outerTabular])(
+      '%s join should return a lone frame that is missing the join field untouched',
+      (mode) => {
+        const out = joinDataFrames({
+          frames: [otherLookup],
+          joinBy: joinByGA,
+          mode,
+        })!;
+
+        expect(out.length).toBe(2);
+        expect(out.fields.map((f) => ({ name: f.name, values: f.values }))).toEqual([
+          { name: 'PA', values: ['x', 'y'] },
+          { name: 'PA_TEXT', values: ['Ex', 'Why'] },
+        ]);
+      }
+    );
+
+    it.each([JoinMode.outer, JoinMode.outerTabular])(
+      '%s join should keep dropping a frame that is missing the join field',
+      (mode) => {
+        const out = joinDataFrames({
+          frames: [measurements, lookup, otherLookup],
+          joinBy: joinByGA,
+          mode,
+        })!;
+
+        expect(out.length).toBe(2);
+        expect(out.fields.map((f) => ({ name: f.name, values: f.values }))).toEqual([
+          { name: 'GA', values: ['a', 'b'] },
+          { name: 'Val', values: [1, 2] },
+          { name: 'GA_TEXT', values: ['Alpha', 'Beta'] },
+        ]);
+      }
+    );
+  });
+
   describe('check ascending data', () => {
     it('simple ascending', () => {
       const v = [1, 2, 3, 4, 5];

--- a/packages/grafana-data/src/transformations/transformers/joinDataFrames.ts
+++ b/packages/grafana-data/src/transformations/transformers/joinDataFrames.ts
@@ -41,7 +41,8 @@ export interface JoinOptions {
   frames: DataFrame[];
 
   /**
-   * The field to join -- frames that do not have this field will be dropped
+   * The field to join -- frames that do not have this field will be dropped, except for
+   * JoinMode.inner, where they instead make the result empty
    */
   joinBy?: FieldMatcher;
 
@@ -113,6 +114,16 @@ export function joinDataFrames(options: JoinOptions): DataFrame | undefined {
     const joinFieldMatcher = getJoinMatcher(options);
     let joinIndex = frameCopy.fields.findIndex((f) => joinFieldMatcher(f, frameCopy, options.frames));
 
+    if (joinIndex < 0 && options.mode === JoinMode.inner) {
+      // nothing to join on, so there are no matching rows -- same result as the multi-frame path
+      // gives when no frame has the join field. Outer joins instead return the frame untouched, so
+      // that a panel with a single series still renders when it has no field to join by.
+      return {
+        length: 0,
+        fields: [],
+      };
+    }
+
     if (options.keepOriginIndices) {
       frameCopy = {
         ...frame,
@@ -169,10 +180,17 @@ export function joinDataFrames(options: JoinOptions): DataFrame | undefined {
   const originalFields: Field[] = [];
   const joinFieldMatcher = getJoinMatcher(options);
 
+  // Frames that cannot be joined are dropped (see JoinOptions.joinBy), which for an outer join keeps
+  // one unrelated series from blanking out a whole visualization. An inner join only yields rows
+  // present in every input, so there dropping a frame would widen the result instead: nothing can
+  // match a frame that contributes no join values, making the correct output zero rows.
+  let droppedFrame = false;
+
   for (let frameIndex = 0; frameIndex < options.frames.length; frameIndex++) {
     const frame = options.frames[frameIndex];
 
     if (!frame || !frame.fields?.length) {
+      droppedFrame = true;
       continue; // skip the frame
     }
 
@@ -221,6 +239,7 @@ export function joinDataFrames(options: JoinOptions): DataFrame | undefined {
     }
 
     if (!join) {
+      droppedFrame = true;
       continue; // skip the frame
     }
 
@@ -248,6 +267,14 @@ export function joinDataFrames(options: JoinOptions): DataFrame | undefined {
     return {
       length: 0,
       fields: originalFields,
+    };
+  }
+
+  if (droppedFrame && options.mode === JoinMode.inner) {
+    // keep the joinable frames' fields so consumers still see the expected columns, just no rows
+    return {
+      length: 0,
+      fields: originalFields.map((f) => ({ ...f, values: [] })),
     };
   }
 


### PR DESCRIPTION
**Fixes** grafana/grafana#88033

**What is this feature?**

`joinDataFrames` drops a frame from the join input at two places, unconditionally and  <br>regardless of join mode:

* `joinDataFrames.ts:174` — frame has no fields
* `joinDataFrames.ts:232` — frame has fields, but none match `joinBy`

For an **inner** join that silently *widens* the result: the surviving frames just join with  <br>each other. When only one survives, `joinTabular`'s merge loop  <br>(`for (ti = 1; ti < tables.length)`) never executes and returns that table verbatim — so an  <br>inner join that matched nothing outputs everything.

The behavior was already self-inconsistent: when *no* frame has the join field,  <br>`allData.length === 0` returns 0 rows. When *exactly one* does, all its rows pass through.  <br>Neither joined anything.

**The fix:** track whether any frame was dropped and, for `JoinMode.inner` only, return zero  <br>rows. An inner join yields only rows present in every input, so a frame contributing no join  <br>values means nothing can match. The result keeps the joinable frames' fields with empty  <br>values, so tables still render their expected columns. Applied at every arity, including the  <br>single-frame path that returns before the join is set up.

**Why do we need this feature?**

An inner join that matches nothing returning every row is a data-correctness bug — the panel  <br>shows rows the user's join should have excluded, with no indication anything went wrong.

⚠️ **Outer joins are unchanged, deliberately.** Panels join all their series with an outer  <br>join, so dropping a frame is what stops one unrelated series from blanking a visualization.  <br>`JoinMode.inner` is only ever passed by `joinByFieldTransformer`; every panel caller  <br>(`GraphNG`, barchart, heatmap, candlestick, timeline, histogram, `prepareTimeSeries`) uses the  <br>default outer mode. Tests pin outer/outerTabular to current behavior on both sides of the  <br>asymmetry.

**Special notes for your reviewer:**

`joinByField.test.ts` — `inner join › joins if fields are missing` asserted the buggy output  <br>and is inverted here. It isn't encoding a deliberate decision: [#27453](<https://github.com/grafana/grafana/issues/27453>) (2020) wrote it as an  <br>**outer** join test, and [#53865](<https://github.com/grafana/grafana/issues/53865>) (2022) added inner support by copying the outer describe block  <br>and flipping `mode`, inheriting the snapshot mechanically. Its input shape (3 frames, middle  <br>with `fields: []`, inner mode) is exactly the bug reported here.

Verified in a running Grafana with a provisioned dashboard, since transformations run  <br>client-side:

<!-- linear:table-colwidths:266,266,266 -->
| scenario | mode | result |
| -- | -- | -- |
| query B lacks the join field | inner | 0 rows, headers rendered, "No rows" |
| query B lacks the join field | outer | 2 rows, B dropped (unchanged) |
| 3 queries, middle frame has 0 fields | inner | 0 rows |

The first case is the shape in [this issue's confirming comment](<https://github.com/grafana/grafana/issues/88033#issuecomment-2549021612>)  <br>— a query returning no rows also drops its label columns, so the frame arrives with only  <br>`Time`/`Value` and no join field. Before this change that produced a one-row "joined" result.

Known limitation, not addressed: **a query that returns zero frames is invisible to this**< />< />  <br>< />< />**transformation.** Some datasources return no frame at all for an empty result rather than an  <br>empty frame, and `DataFrame[]` can't distinguish "returned nothing" from "wasn't there".  <br>Fixing that needs the datasource or query runner to emit an empty frame.

"Problem 2" from the issue (chaining two joins on different fields) is split out as grafana/grafana#129587  <br>and fixed in grafana/grafana#129600.

**Release notes**

Inner joins in the **Join by field** transformation now return no rows when a query returns  <br>data without the join field, instead of joining the remaining queries. A panel that relied on  <br>the previous behavior should add a **Filter data by query refId** transformation before the  <br>join.