### PR TITLE
Annotations: change default scopes matching behavior

### DIFF
--- a/pkg/registry/apps/annotation/search_handler.go
+++ b/pkg/registry/apps/annotation/search_handler.go
@@ -120,6 +120,8 @@ func listOptionsFromQueryParams(queryParams url.Values) ListOptions {
 		opts.Scopes = scopes
 	}
 
+	// Scopes default to matching any of the requested values to align with other scope-based filtering in Grafana.
+	opts.ScopesMatchAny = true
 	if v := queryParams.Get("scopesMatchAny"); v != "" {
 		if matchAny, err := strconv.ParseBool(v); err == nil {
 			opts.ScopesMatchAny = matchAny

--- a/pkg/registry/apps/annotation/search_handler_test.go
+++ b/pkg/registry/apps/annotation/search_handler_test.go
@@ -101,9 +101,17 @@ func TestSearchHandler(t *testing.T) {
 			expectedNames: []string{"a-1", "a-2", "a-4"},
 		},
 		{
-			name: "Filter by multiple scopes without matchAny (AND - default)",
+			name: "Filter by multiple scopes without matchAny (OR - default)",
 			queryParams: url.Values{
 				"scope": []string{"scope1", "scope2"},
+			},
+			expectedNames: []string{"a-1", "a-2", "a-4"},
+		},
+		{
+			name: "Filter by multiple scopes with matchAny=false (AND)",
+			queryParams: url.Values{
+				"scope":          []string{"scope1", "scope2"},
+				"scopesMatchAny": []string{"false"},
 			},
 			expectedNames: []string{"a-4"},
 		},
@@ -116,11 +124,20 @@ func TestSearchHandler(t *testing.T) {
 			expectedNames: []string{"a-1", "a-4"},
 		},
 		{
-			name: "Filter by tags (OR) and scopes (AND)",
+			name: "Filter by tags (OR) and scopes (OR by default)",
 			queryParams: url.Values{
 				"tag":          []string{"tag1", "tag2"},
 				"tagsMatchAny": []string{"true"},
 				"scope":        []string{"scope1", "scope2"},
+			},
+			expectedNames: []string{"a-1", "a-2", "a-4"},
+		},
+		{
+			name: "Filter by tags (AND by default) and scopes (AND)",
+			queryParams: url.Values{
+				"tag":            []string{"tag1", "tag2"},
+				"scope":          []string{"scope1", "scope2"},
+				"scopesMatchAny": []string{"false"},
 			},
 			expectedNames: []string{"a-4"},
 		},
@@ -133,7 +150,7 @@ func TestSearchHandler(t *testing.T) {
 			expectedNames: []string{"a-1", "a-4"},
 		},
 		{
-			name: "Invalid scopesMatchAny value (should be ignored, defaults to false)",
+			name: "Invalid scopesMatchAny value (should be ignored, defaults to true)",
 			queryParams: url.Values{
 				"scope":          []string{"scope1"},
 				"scopesMatchAny": []string{"not-valid"},


### PR DESCRIPTION
This PR makes a change to the new annotation API to modify the default scope matching behavior. The current behavior of the API is to match on an `AND` basis, but other scope-based filtering in Grafana (e.g. Prometheus metrics) match on an `OR` basis, so this PR aligns the default behavior for annotations with other feature areas that support scopes.