### PR TITLE
InfluxDB: Add to default bundled and preinstalled plugins

### DIFF
--- a/pkg/setting/setting_plugins.go
+++ b/pkg/setting/setting_plugins.go
@@ -48,6 +48,7 @@ var (
 		"jaeger":                        {ID: "jaeger"},
 		"loki":                          {ID: "loki"},
 		"mysql":                         {ID: "mysql"},
+		"influxdb":                      {ID: "influxdb"},
 		"grafana-advisor-app":           {ID: "grafana-advisor-app"},
 		"grafana-postgresql-datasource": {ID: "grafana-postgresql-datasource"},
 		"grafana-pyroscope-datasource":  {ID: "grafana-pyroscope-datasource"},

--- a/scripts/catalog-plugins-defaults
+++ b/scripts/catalog-plugins-defaults
@@ -10,5 +10,6 @@ mssql
 jaeger
 loki
 mysql
+influxdb
 grafana-postgresql-datasource
 grafana-pyroscope-datasource


### PR DESCRIPTION
**What is this feature?**

Add InfluxDB to the default plugin lists so on-prem and OSS users continue to have access to it after it is removed from core.
This is the on-prem preparation step before removing InfluxDB from core. With both core and bundled versions present, nightly builds can validate that the external plugin works correctly as a drop-in replacement.

**Why do we need this feature?**

To be able to remove InfluxDB from grafana/grafana 

**Who is this feature for?**

Grafana developers

Reference PR:
- https://github.com/grafana/grafana/pull/126842

Please check that:
- [ ] It works as expected from a user's perspective.