### PR TITLE
Explore: Deduplicate identical span links in Trace View (#128810)

### DIFF
--- a/public/app/features/explore/TraceView/createSpanLink.test.ts
+++ b/public/app/features/explore/TraceView/createSpanLink.test.ts
@@ -1648,6 +1648,152 @@ describe('dataFrame links', () => {
     );
     expect(links![2].type).toBe(SpanLinkType.Unknown);
   });
+
+  // REPRODUCTION TEST FOR GITHUB ISSUE #128810: DUPLICATE AZURE MONITOR LINKS
+  describe('should handle duplicate links correctly (Issue #128810)', () => {
+    beforeAll(() => {
+      setDataSourceSrv({
+        getInstanceSettings() {
+          return { uid: 'azure_monitor_uid', name: 'Azure Monitor', type: 'azuremonitor' } as unknown as DataSourceInstanceSettings;
+        },
+      } as unknown as DataSourceSrv);
+
+      setLinkSrv(new LinkSrv());
+      setTemplateSrv(new TemplateSrv());
+    });
+
+    it('should deduplicate identical links from multiple fields (reproduces exemplar bug)', () => {
+      // Create a dataFrame that simulates the Azure Monitor trace scenario from Prometheus exemplars
+      // This reproduces the case where multiple fields have the same link configuration
+      const duplicateLinksDataFrame = createDataFrame({
+        fields: [
+          { name: 'traceID', values: ['testTraceId'] },
+          { name: 'spanID', values: ['testSpanId'] },
+          // Field 1: Azure Monitor link
+          {
+            name: 'trace_link_field_1',
+            config: {
+              links: [{
+                title: 'View Query in Azure Portal',
+                url: 'https://portal.azure.com/#blade/WebsitesExtension/AppServicesBladeV2/resourceType/Microsoft.Web%2Fsites/resourceName/myapp/resourceGroup/mygroup',
+                target: '_blank'
+              }]
+            },
+            values: ['link1']
+          },
+          // Field 2: IDENTICAL Azure Monitor link (this causes duplication)
+          {
+            name: 'trace_link_field_2', 
+            config: {
+              links: [{
+                title: 'View Query in Azure Portal', // SAME title
+                url: 'https://portal.azure.com/#blade/WebsitesExtension/AppServicesBladeV2/resourceType/Microsoft.Web%2Fsites/resourceName/myapp/resourceGroup/mygroup', // SAME URL
+                target: '_blank'
+              }]
+            },
+            values: ['link2']
+          },
+          // Field 3: ANOTHER IDENTICAL Azure Monitor link
+          {
+            name: 'trace_link_field_3',
+            config: {
+              links: [{
+                title: 'View Query in Azure Portal', // SAME title again
+                url: 'https://portal.azure.com/#blade/WebsitesExtension/AppServicesBladeV2/resourceType/Microsoft.Web%2Fsites/resourceName/myapp/resourceGroup/mygroup', // SAME URL again
+                target: '_blank'
+              }]
+            },
+            values: ['link3']
+          }
+        ]
+      });
+
+      const splitOpenFn = jest.fn();
+      const createLink = createSpanLinkFactory({
+        splitOpenFn,
+        dataFrame: duplicateLinksDataFrame,
+        trace: dummyTraceData,
+      });
+
+      const links = createLink!(createTraceSpan());
+
+      // BEFORE FIX: This would fail because we get 3 identical links
+      // AFTER FIX: This should pass because duplicates are removed
+      expect(links).toBeDefined();
+      
+      // We should have only 1 unique link, not 3 duplicates
+      expect(links?.length).toBe(1);
+      
+      // Check that the single link has the correct properties
+      const singleLink = links![0];
+      expect(singleLink.title).toBe('View Query in Azure Portal');
+      expect(singleLink.href).toBe('https://portal.azure.com/#blade/WebsitesExtension/AppServicesBladeV2/resourceType/Microsoft.Web%2Fsites/resourceName/myapp/resourceGroup/mygroup');
+      expect(singleLink.type).toBe(SpanLinkType.Unknown);
+    });
+
+    it('should preserve distinct links while removing duplicates', () => {
+      // Test that we keep distinct links but remove duplicates
+      const mixedLinksDataFrame = createDataFrame({
+        fields: [
+          { name: 'traceID', values: ['testTraceId'] },
+          { name: 'spanID', values: ['testSpanId'] },
+          // Unique link 1
+          {
+            name: 'field1',
+            config: {
+              links: [{
+                title: 'Azure Traces',
+                url: 'https://portal.azure.com/traces',
+                target: '_blank'
+              }]
+            },
+            values: ['value1']
+          },
+          // Duplicate of link 1
+          {
+            name: 'field2',
+            config: {
+              links: [{
+                title: 'Azure Traces', // SAME as field1
+                url: 'https://portal.azure.com/traces', // SAME as field1
+                target: '_blank'
+              }]
+            },
+            values: ['value2']
+          },
+          // Unique link 2 (different from link 1)
+          {
+            name: 'field3',
+            config: {
+              links: [{
+                title: 'Azure Metrics',
+                url: 'https://portal.azure.com/metrics',  // DIFFERENT URL
+                target: '_blank'
+              }]
+            },
+            values: ['value3']
+          }
+        ]
+      });
+
+      const splitOpenFn = jest.fn();
+      const createLink = createSpanLinkFactory({
+        splitOpenFn,
+        dataFrame: mixedLinksDataFrame,
+        trace: dummyTraceData,
+      });
+
+      const links = createLink!(createTraceSpan());
+      
+      // Should have exactly 2 unique links (duplicates removed)
+      expect(links).toBeDefined();
+      expect(links?.length).toBe(2);
+      
+      // Check that we have both unique links
+      const linkTitles = links!.map(l => l.title).sort();
+      expect(linkTitles).toEqual(['Azure Metrics', 'Azure Traces']);
+    });
+  });
 });
 
 function setupSpanLinkFactory(

--- a/public/app/features/explore/TraceView/createSpanLink.test.ts
+++ b/public/app/features/explore/TraceView/createSpanLink.test.ts
@@ -1649,8 +1649,7 @@ describe('dataFrame links', () => {
     expect(links![2].type).toBe(SpanLinkType.Unknown);
   });
 
-  // REPRODUCTION TEST FOR GITHUB ISSUE #128810: DUPLICATE AZURE MONITOR LINKS
-  describe('should handle duplicate links correctly (Issue #128810)', () => {
+  describe('should handle duplicate links correctly', () => {
     beforeAll(() => {
       setDataSourceSrv({
         getInstanceSettings() {
@@ -1662,7 +1661,7 @@ describe('dataFrame links', () => {
       setTemplateSrv(new TemplateSrv());
     });
 
-    it('should deduplicate identical links from multiple fields (reproduces exemplar bug)', () => {
+    it('should deduplicate identical links from multiple fields', () => {
       // Create a dataFrame that simulates the Azure Monitor trace scenario from Prometheus exemplars
       // This reproduces the case where multiple fields have the same link configuration
       const duplicateLinksDataFrame = createDataFrame({
@@ -1717,8 +1716,6 @@ describe('dataFrame links', () => {
 
       const links = createLink!(createTraceSpan());
 
-      // BEFORE FIX: This would fail because we get 3 identical links
-      // AFTER FIX: This should pass because duplicates are removed
       expect(links).toBeDefined();
       
       // We should have only 1 unique link, not 3 duplicates

--- a/public/app/features/explore/TraceView/createSpanLink.tsx
+++ b/public/app/features/explore/TraceView/createSpanLink.tsx
@@ -109,8 +109,7 @@ export function createSpanLinkFactory({
           links = links.concat(fieldLinksForExplore);
         });
 
-        // Deduplicate identical links to fix Issue #128810: Multiple "View Query in Azure Portal" links
-        // This occurs when multiple fields in the dataFrame have the same link configuration
+        // Deduplicate identical links from multiple fields with the same link configuration
         const uniqueLinks = uniqBy(links, (link) => `${link.href}|${link.title}`);
 
         const newSpanLinks: SpanLinkDef[] = uniqueLinks.map((link) => {

--- a/public/app/features/explore/TraceView/createSpanLink.tsx
+++ b/public/app/features/explore/TraceView/createSpanLink.tsx
@@ -97,9 +97,7 @@ export function createSpanLinkFactory({
         const shouldCreatePyroscopeLink = hasConfiguredPyroscopeDS && hasPyroscopeProfile;
 
         let links: ExploreFieldLinkModel[] = [];
-        // Debug: Processing fields for span links
-        
-        fields.forEach((field, fieldIndex) => {
+        fields.forEach((field) => {
           const fieldLinksForExplore = getFieldLinksForExplore({
             field,
             rowIndex: span.dataFrameRowIndex!,
@@ -108,14 +106,12 @@ export function createSpanLinkFactory({
             dataFrame,
             vars: scopedVars,
           });
-          // Debug: Field generated links
           links = links.concat(fieldLinksForExplore);
         });
 
         // Deduplicate identical links to fix Issue #128810: Multiple "View Query in Azure Portal" links
         // This occurs when multiple fields in the dataFrame have the same link configuration
         const uniqueLinks = uniqBy(links, (link) => `${link.href}|${link.title}`);
-        // Debug: Deduplication applied - removed duplicates
 
         const newSpanLinks: SpanLinkDef[] = uniqueLinks.map((link) => {
           return {
@@ -128,8 +124,6 @@ export function createSpanLinkFactory({
             target: link.target,
           };
         });
-
-        // Debug: Final span links ready
 
         spanLinks.push.apply(spanLinks, newSpanLinks);
       } catch (error) {

--- a/public/app/features/explore/TraceView/createSpanLink.tsx
+++ b/public/app/features/explore/TraceView/createSpanLink.tsx
@@ -13,6 +13,7 @@ import {
   type SplitOpen,
   type TimeRange,
 } from '@grafana/data';
+import { uniqBy } from 'lodash';
 import { t } from '@grafana/i18n';
 import {
   type TraceToProfilesOptions,
@@ -96,7 +97,9 @@ export function createSpanLinkFactory({
         const shouldCreatePyroscopeLink = hasConfiguredPyroscopeDS && hasPyroscopeProfile;
 
         let links: ExploreFieldLinkModel[] = [];
-        fields.forEach((field) => {
+        // Debug: Processing fields for span links
+        
+        fields.forEach((field, fieldIndex) => {
           const fieldLinksForExplore = getFieldLinksForExplore({
             field,
             rowIndex: span.dataFrameRowIndex!,
@@ -105,10 +108,16 @@ export function createSpanLinkFactory({
             dataFrame,
             vars: scopedVars,
           });
+          // Debug: Field generated links
           links = links.concat(fieldLinksForExplore);
         });
 
-        const newSpanLinks: SpanLinkDef[] = links.map((link) => {
+        // Deduplicate identical links to fix Issue #128810: Multiple "View Query in Azure Portal" links
+        // This occurs when multiple fields in the dataFrame have the same link configuration
+        const uniqueLinks = uniqBy(links, (link) => `${link.href}|${link.title}`);
+        // Debug: Deduplication applied - removed duplicates
+
+        const newSpanLinks: SpanLinkDef[] = uniqueLinks.map((link) => {
           return {
             title: link.title,
             href: link.href,
@@ -119,6 +128,8 @@ export function createSpanLinkFactory({
             target: link.target,
           };
         });
+
+        // Debug: Final span links ready
 
         spanLinks.push.apply(spanLinks, newSpanLinks);
       } catch (error) {


### PR DESCRIPTION
## Summary
- Fixes duplicate "View Query in Azure Portal" links when Azure Monitor traces are opened via Prometheus exemplars ([#128810](https://github.com/grafana/grafana/issues/128810)).
- Deduplicates span links by `href` + `title` after collecting field links in `createSpanLinkFactory`, so identical links from multiple DataFrame fields only appear once.
- Adds unit tests covering full duplication and mixed unique/duplicate link scenarios.

## Test plan
- [ ] Run `createSpanLink` unit tests (including the new Issue #128810 cases)
- [ ] Manually: open a Prometheus explore view with exemplars pointing at Azure Monitor, click an exemplar into the trace view, and confirm each span shows a single "View Query in Azure Portal" link
- [ ] Manually: open the same trace directly via Azure Monitor Explore and confirm existing single-link behavior is unchanged
- [ ] Confirm spans with distinct links (different titles/URLs) still show all unique links

Fixes #128810