### PR TITLE
Provisioning: Fix job user attribution in multi-tenant deployments

### DIFF
--- a/apps/provisioning/pkg/jobs/mutator.go
+++ b/apps/provisioning/pkg/jobs/mutator.go
@@ -49,47 +49,35 @@ func (m *AdmissionMutator) Mutate(ctx context.Context, a admission.Attributes, o
 	if job.Annotations == nil {
 		job.Annotations = map[string]string{}
 	}
+	// Never let a caller set the email annotation
+	delete(job.Annotations, AnnoAuthorEmail)
 
 	enabled := m.userAttributionEnabled != nil && m.userAttributionEnabled(ctx)
 
-	// Never trust client-supplied author annotations: clear them and set them
-	// only from the request identity below. The provisioning service identity
-	// is exempt so the webhook dispatcher can attribute jobs to the webhook
-	// sender, but only for the fields a webhook carries: name, id, and origin.
-	delete(job.Annotations, AnnoAuthorEmail)
-	if info, ok := types.AuthInfoFrom(ctx); !enabled || !ok || !identity.IsProvisioningServiceIdentity(info) {
-		delete(job.Annotations, AnnoAuthor)
-		delete(job.Annotations, AnnoAuthorID)
-		delete(job.Annotations, AnnoAuthorOrigin)
-	}
+	requester, err := identity.GetRequester(ctx)
+	isUser := err == nil && requester.IsIdentityType(types.TypeUser)
 
-	if !enabled {
+	if enabled && isUser {
+		job.Annotations[AnnoAuthor] = requester.GetName()
+		job.Annotations[AnnoAuthorEmail] = requester.GetEmail()
+		job.Annotations[AnnoAuthorID] = requester.GetUID()
+		job.Annotations[AnnoAuthorOrigin] = "Grafana"
 		return nil
 	}
 
-	if info, ok := types.AuthInfoFrom(ctx); ok && identity.IsProvisioningServiceIdentity(info) {
+	info, hasInfo := types.AuthInfoFrom(ctx)
+	isProvisioningService := hasInfo && identity.IsProvisioningServiceIdentity(info)
+
+	if enabled && isProvisioningService {
 		if job.Annotations[AnnoAuthorOrigin] == "" {
 			job.Annotations[AnnoAuthorOrigin] = "Grafana"
 		}
 		return nil
 	}
 
-	requester, err := identity.GetRequester(ctx)
-	if err != nil || !requester.IsIdentityType(types.TypeUser) {
-		job.Annotations[AnnoAuthorOrigin] = "Unknown"
-		return nil
-	}
-
-	if name := requester.GetName(); name != "" {
-		job.Annotations[AnnoAuthor] = name
-	}
-	if email := requester.GetEmail(); email != "" {
-		job.Annotations[AnnoAuthorEmail] = email
-	}
-	if uid := requester.GetUID(); uid != "" {
-		job.Annotations[AnnoAuthorID] = uid
-	}
-	job.Annotations[AnnoAuthorOrigin] = "Grafana"
+	delete(job.Annotations, AnnoAuthor)
+	delete(job.Annotations, AnnoAuthorID)
+	delete(job.Annotations, AnnoAuthorOrigin)
 
 	return nil
 }

--- a/apps/provisioning/pkg/jobs/mutator_test.go
+++ b/apps/provisioning/pkg/jobs/mutator_test.go
@@ -73,7 +73,7 @@ func TestAdmissionMutator_Mutate(t *testing.T) {
 			},
 			enabled:     true,
 			annotations: map[string]string{AnnoAuthor: "Spoofed"},
-			expected:    map[string]string{AnnoAuthorOrigin: "Unknown"},
+			expected:    map[string]string{},
 		},
 		{
 			name:        "user cannot spoof the author id and origin",
@@ -81,6 +81,22 @@ func TestAdmissionMutator_Mutate(t *testing.T) {
 			requester:   userRequester,
 			enabled:     true,
 			annotations: map[string]string{AnnoAuthorID: "user:someone-else", AnnoAuthorOrigin: "GitHub"},
+			expected: map[string]string{
+				AnnoAuthor:       "Test User",
+				AnnoAuthorEmail:  "test@example.com",
+				AnnoAuthorID:     "user:abc123",
+				AnnoAuthorOrigin: "Grafana",
+			},
+		},
+		{
+			name:      "user whose token carries the provisioning audience is still attributed",
+			operation: admission.Create,
+			requester: fakeProvisioningAuthInfo{
+				StaticRequester: userRequester,
+				audience:        []string{"provisioning.grafana.app"},
+			},
+			enabled:     true,
+			annotations: map[string]string{AnnoAuthor: "Spoofed", AnnoAuthorOrigin: "GitHub"},
 			expected: map[string]string{
 				AnnoAuthor:       "Test User",
 				AnnoAuthorEmail:  "test@example.com",

--- a/apps/provisioning/pkg/jobs/validator.go
+++ b/apps/provisioning/pkg/jobs/validator.go
@@ -416,12 +416,6 @@ func validateAuthor(ctx context.Context, a admission.Attributes, job *provisioni
 
 	switch a.GetOperation() {
 	case admission.Create:
-		if info, ok := types.AuthInfoFrom(ctx); ok && identity.IsProvisioningServiceIdentity(info) {
-			if email != "" {
-				return apierrors.NewBadRequest(fmt.Sprintf("annotation %s may not be set by the provisioning service", AnnoAuthorEmail))
-			}
-			return nil
-		}
 		if requester, err := identity.GetRequester(ctx); err == nil && requester.IsIdentityType(types.TypeUser) {
 			if name == "" && email == "" && id == "" && origin == "" {
 				return nil
@@ -440,11 +434,17 @@ func validateAuthor(ctx context.Context, a admission.Attributes, job *provisioni
 			}
 			return nil
 		}
+		if info, ok := types.AuthInfoFrom(ctx); ok && identity.IsProvisioningServiceIdentity(info) {
+			if email != "" {
+				return apierrors.NewBadRequest(fmt.Sprintf("annotation %s may not be set by the provisioning service", AnnoAuthorEmail))
+			}
+			return nil
+		}
 		if name != "" || email != "" || id != "" {
 			return apierrors.NewBadRequest("job author annotations may only be set by a user or the provisioning service")
 		}
-		if origin != "" && origin != "Unknown" {
-			return apierrors.NewBadRequest(fmt.Sprintf("annotation %s must be Unknown when no user or provisioning service is involved", AnnoAuthorOrigin))
+		if origin != "" {
+			return apierrors.NewBadRequest(fmt.Sprintf("annotation %s may not be set when no user or provisioning service is involved", AnnoAuthorOrigin))
 		}
 	case admission.Update:
 		old, ok := a.GetOldObject().(*provisioning.Job)

--- a/apps/provisioning/pkg/jobs/validator_test.go
+++ b/apps/provisioning/pkg/jobs/validator_test.go
@@ -1493,6 +1493,15 @@ func TestValidateAuthor(t *testing.T) {
 			annotations: map[string]string{AnnoAuthor: "grot", AnnoAuthorID: "123", AnnoAuthorOrigin: "github"},
 		},
 		{
+			name: "create by a user whose token carries the provisioning audience",
+			ctx: identity.WithRequester(t.Context(), fakeProvisioningAuthInfo{
+				StaticRequester: requester,
+				audience:        []string{"provisioning.grafana.app"},
+			}),
+			operation:   admission.Create,
+			annotations: annotations,
+		},
+		{
 			name:            "create with mismatched id",
 			ctx:             userCtx,
 			operation:       admission.Create,
@@ -1528,13 +1537,7 @@ func TestValidateAuthor(t *testing.T) {
 			ctx:             t.Context(),
 			operation:       admission.Create,
 			annotations:     map[string]string{AnnoAuthorOrigin: "github"},
-			wantErrContains: AnnoAuthorOrigin + " must be Unknown",
-		},
-		{
-			name:        "create with only an origin and no requester is allowed",
-			ctx:         t.Context(),
-			operation:   admission.Create,
-			annotations: map[string]string{AnnoAuthorOrigin: "Unknown"},
+			wantErrContains: AnnoAuthorOrigin + " may not be set",
 		},
 		{
 			name:           "update with unchanged annotations",


### PR DESCRIPTION
**What is this feature?**

Fixes user attribution for provisioning jobs in multi-tenant deployments. Jobs triggered by a user from the Grafana UI now record that user as the author, and their commits are attributed to them instead of the default Grafana identity.

**Why do we need this feature?**

In multi-tenant deployments, every request to the provisioning service carries a token that also identifies as the provisioning service itself. Job attribution treated those requests as the internal service, so user-triggered jobs showed no author and commits fell back to the default identity. Attribution now prefers the requesting user when one is present, keeping the service path for background and webhook jobs.

**Who is this feature for?**

Users of Git Sync in Grafana Cloud.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Jobs with no identifiable author no longer get an origin recorded; the UI already shows its own fallback label for those.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

---

*Description generated by Claude Code.*