### PR TITLE
CI: Disable Ryuk reaper in integration tests to fix Gitea container flake

### DIFF
--- a/.github/workflows/pr-test-integration.yml
+++ b/.github/workflows/pr-test-integration.yml
@@ -31,6 +31,13 @@ concurrency:
 
 permissions: {}
 
+env:
+  # Parallel test binaries share one testcontainers session; Ryuk prunes all
+  # session containers 10s after its last client disconnects, which races with
+  # binaries that are still using their containers. Runners are ephemeral, so
+  # container cleanup is unnecessary here anyway.
+  TESTCONTAINERS_RYUK_DISABLED: 'true'
+
 jobs:
   detect-changes:
     # Run on `grafana/grafana` main branch, or on pull requests to prevent double-running on mirrors


### PR DESCRIPTION
**What is this?**

Disables the testcontainers Ryuk reaper in the integration test workflow.

**Why do we need it?**

Provisioning integration tests flake with errors like `container exec create: ... container <id> is not running` followed by `No such container`, for example [this run](https://github.com/grafana/grafana/actions/runs/30478956592/job/90667670919). The Gitea container serving a test package disappears mid run while tests are still using it.

Diagnosis from the failing run:

- The container is stopped and then removed while the package is still running. Nothing in the test code does this: the shared server is only torn down after `m.Run()` ([RunTestMain](https://github.com/grafana/grafana/blob/main/pkg/tests/apis/provisioning/common/testing.go)), and its own teardown found the container already gone (`failed to terminate container: ... No such container` at the end of the job log).
- `go test` runs package binaries in parallel, and all binaries of one invocation share a single testcontainers session and a single Ryuk container. Ryuk removes everything labeled with the session 10 seconds after its last client disconnects ([Ryuk docs](https://golang.testcontainers.org/features/garbage_collector/#ryuk)). The failing run shows two provisioning packages with Gitea containers running concurrently, so a prune triggered by one binary exiting can race against another binary still using its container.
- Ryuk is [enabled by default](https://golang.testcontainers.org/features/garbage_collector/#ryuk) and nothing turns it off today: the [workflow](https://github.com/grafana/grafana/blob/main/.github/workflows/pr-test-integration.yml) sets no testcontainers env, the repo has [no `TESTCONTAINERS_RYUK_DISABLED` or `testcontainers.properties` anywhere](https://github.com/search?q=repo%3Agrafana%2Fgrafana+TESTCONTAINERS_RYUK_DISABLED&type=code), and the runner image sets neither: `ubuntu-x64-large-io` is defined in [deployment_tools](https://github.com/grafana/deployment_tools/blob/master/terraform/projects/aws/github-runners-prod/templates/runner-configs/io/ubu-x64-large-io.yaml), uses the `packer-ubuntu24` AMI from [shared config](https://github.com/grafana/deployment_tools/blob/master/terraform/projects/aws/github-runners-prod/templates/shared-configs/ubuntu-x64.yaml), which is built from [grafana/runner-images](https://github.com/grafana/runner-images), where [`ryuk`](https://github.com/search?q=repo%3Agrafana%2Frunner-images+ryuk&type=code) and [`testcontainers`](https://github.com/search?q=repo%3Agrafana%2Frunner-images+testcontainers&type=code) have zero code search hits.

Ryuk exists to clean up leaked containers, which is pointless on ephemeral CI runners: the instance is discarded after the job. Disabling it removes this failure mode with no loss of cleanup.

Why it always hits "Sqlite Enterprise 13/16": [shard assignment is round-robin over the sorted package list](https://github.com/grafana/grafana/blob/main/scripts/ci/backend-tests/shard.sh), so the Gitea-using provisioning packages land on shard 13 every run, and the sqlite jobs are the only ones running package binaries in parallel (the MySQL and Postgres jobs pass `-p=1`), which is the precondition for the race.

---

*PR description generated by Claude Code.*
