### PR TITLE
API server: Decouple update authorization from request context

### DIFF
--- a/pkg/services/apiserver/auth/authorizer/storewrapper/wrapper.go
+++ b/pkg/services/apiserver/auth/authorizer/storewrapper/wrapper.go
@@ -19,7 +19,6 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	k8srest "k8s.io/apiserver/pkg/registry/rest"
 
-	"github.com/grafana/authlib/types"
 	"github.com/grafana/grafana/pkg/apimachinery/errutil"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apiserver/rest"
@@ -392,9 +391,8 @@ func (w *Wrapper) Update(
 		span.End()
 	}()
 
-	requester, requesterErr := identity.GetRequester(ctx)
-	authInfo, hasAuthInfo := types.AuthInfoFrom(ctx)
-	if requesterErr != nil || !hasAuthInfo {
+	requester, err := identity.GetRequester(ctx)
+	if err != nil {
 		return nil, false, ErrUnauthenticated
 	}
 
@@ -403,7 +401,6 @@ func (w *Wrapper) Update(
 		inner:      objInfo,
 		authorizer: w.authorizer,
 		requester:  requester,
-		authInfo:   authInfo,
 		tracer:     w.tracer,
 		observer:   w.observer,
 		resource:   w.resource,
@@ -420,7 +417,6 @@ type authorizedUpdateInfo struct {
 	inner      k8srest.UpdatedObjectInfo
 	authorizer ResourceStorageAuthorizer
 	requester  identity.Requester
-	authInfo   types.AuthInfo
 	tracer     trace.Tracer
 	observer   Observer
 	resource   schema.GroupResource
@@ -461,9 +457,7 @@ func (a *authorizedUpdateInfo) UpdatedObject(ctx context.Context, oldObj runtime
 }
 
 func (a *authorizedUpdateInfo) authorizationContext(ctx context.Context) context.Context {
-	ctx = identity.WithRequester(ctx, a.requester)
-	ctx = types.WithAuthInfo(ctx, a.authInfo)
-	return ctx
+	return identity.WithRequester(ctx, a.requester)
 }
 
 func (w *Wrapper) Watch(ctx context.Context, options *internalversion.ListOptions) (result watch.Interface, err error) {

--- a/pkg/services/apiserver/auth/authorizer/storewrapper/wrapper.go
+++ b/pkg/services/apiserver/auth/authorizer/storewrapper/wrapper.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	k8srest "k8s.io/apiserver/pkg/registry/rest"
 
+	"github.com/grafana/authlib/types"
 	"github.com/grafana/grafana/pkg/apimachinery/errutil"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apiserver/rest"
@@ -395,7 +396,7 @@ func (w *Wrapper) Update(
 	wrappedObjInfo := &authorizedUpdateInfo{
 		inner:      objInfo,
 		authorizer: w.authorizer,
-		userCtx:    ctx, // Keep original context for authorization
+		userCtx:    ctx, // Keep the original user values for authorization.
 		tracer:     w.tracer,
 		observer:   w.observer,
 		resource:   w.resource,
@@ -428,8 +429,12 @@ func (a *authorizedUpdateInfo) UpdatedObject(ctx context.Context, oldObj runtime
 		return nil, err
 	}
 
-	// Enforce authorization using the original user context
-	authzCtx, span := startSpan(a.userCtx, a.tracer, a.resource, "UpdateAuthz")
+	// The inner store may execute UpdatedObject after the request has returned,
+	// for example when a dual writer replicates an update in the background.
+	// Keep the execution context's lifetime while restoring the original user
+	// identity that storeCtx replaced with a service identity.
+	authzCtx := authorizationContext(ctx, a.userCtx)
+	authzCtx, span := startSpan(authzCtx, a.tracer, a.resource, "UpdateAuthz")
 	defer func() {
 		recordSpanError(span, err)
 		span.End()
@@ -445,6 +450,16 @@ func (a *authorizedUpdateInfo) UpdatedObject(ctx context.Context, oldObj runtime
 	}
 
 	return updatedObj, nil
+}
+
+func authorizationContext(ctx, userCtx context.Context) context.Context {
+	if user, err := identity.GetRequester(userCtx); err == nil {
+		ctx = identity.WithRequester(ctx, user)
+	}
+	if authInfo, ok := types.AuthInfoFrom(userCtx); ok {
+		ctx = types.WithAuthInfo(ctx, authInfo)
+	}
+	return ctx
 }
 
 func (w *Wrapper) Watch(ctx context.Context, options *internalversion.ListOptions) (result watch.Interface, err error) {

--- a/pkg/services/apiserver/auth/authorizer/storewrapper/wrapper.go
+++ b/pkg/services/apiserver/auth/authorizer/storewrapper/wrapper.go
@@ -392,14 +392,20 @@ func (w *Wrapper) Update(
 		span.End()
 	}()
 
+	requester, requesterErr := identity.GetRequester(ctx)
+	authInfo, hasAuthInfo := types.AuthInfoFrom(ctx)
+
 	// Create a wrapper around UpdatedObjectInfo to inject authorization
 	wrappedObjInfo := &authorizedUpdateInfo{
-		inner:      objInfo,
-		authorizer: w.authorizer,
-		userCtx:    ctx, // Keep the original user values for authorization.
-		tracer:     w.tracer,
-		observer:   w.observer,
-		resource:   w.resource,
+		inner:        objInfo,
+		authorizer:   w.authorizer,
+		requester:    requester,
+		hasRequester: requesterErr == nil,
+		authInfo:     authInfo,
+		hasAuthInfo:  hasAuthInfo,
+		tracer:       w.tracer,
+		observer:     w.observer,
+		resource:     w.resource,
 	}
 
 	innerStart := time.Now()
@@ -410,12 +416,15 @@ func (w *Wrapper) Update(
 }
 
 type authorizedUpdateInfo struct {
-	inner      k8srest.UpdatedObjectInfo
-	authorizer ResourceStorageAuthorizer
-	userCtx    context.Context
-	tracer     trace.Tracer
-	observer   Observer
-	resource   schema.GroupResource
+	inner        k8srest.UpdatedObjectInfo
+	authorizer   ResourceStorageAuthorizer
+	requester    identity.Requester
+	hasRequester bool
+	authInfo     types.AuthInfo
+	hasAuthInfo  bool
+	tracer       trace.Tracer
+	observer     Observer
+	resource     schema.GroupResource
 }
 
 func (a *authorizedUpdateInfo) Preconditions() *metaV1.Preconditions {
@@ -431,9 +440,9 @@ func (a *authorizedUpdateInfo) UpdatedObject(ctx context.Context, oldObj runtime
 
 	// The inner store may execute UpdatedObject after the request has returned,
 	// for example when a dual writer replicates an update in the background.
-	// Keep the execution context's lifetime while restoring the original user
-	// identity that storeCtx replaced with a service identity.
-	authzCtx := authorizationContext(ctx, a.userCtx)
+	// Rebuild authorization on the execution context from only the auth values
+	// captured before storeCtx replaced them with a service identity.
+	authzCtx := a.authorizationContext(ctx)
 	authzCtx, span := startSpan(authzCtx, a.tracer, a.resource, "UpdateAuthz")
 	defer func() {
 		recordSpanError(span, err)
@@ -452,12 +461,12 @@ func (a *authorizedUpdateInfo) UpdatedObject(ctx context.Context, oldObj runtime
 	return updatedObj, nil
 }
 
-func authorizationContext(ctx, userCtx context.Context) context.Context {
-	if user, err := identity.GetRequester(userCtx); err == nil {
-		ctx = identity.WithRequester(ctx, user)
+func (a *authorizedUpdateInfo) authorizationContext(ctx context.Context) context.Context {
+	if a.hasRequester {
+		ctx = identity.WithRequester(ctx, a.requester)
 	}
-	if authInfo, ok := types.AuthInfoFrom(userCtx); ok {
-		ctx = types.WithAuthInfo(ctx, authInfo)
+	if a.hasAuthInfo {
+		ctx = types.WithAuthInfo(ctx, a.authInfo)
 	}
 	return ctx
 }

--- a/pkg/services/apiserver/auth/authorizer/storewrapper/wrapper.go
+++ b/pkg/services/apiserver/auth/authorizer/storewrapper/wrapper.go
@@ -394,18 +394,19 @@ func (w *Wrapper) Update(
 
 	requester, requesterErr := identity.GetRequester(ctx)
 	authInfo, hasAuthInfo := types.AuthInfoFrom(ctx)
+	if requesterErr != nil || !hasAuthInfo {
+		return nil, false, ErrUnauthenticated
+	}
 
 	// Create a wrapper around UpdatedObjectInfo to inject authorization
 	wrappedObjInfo := &authorizedUpdateInfo{
-		inner:        objInfo,
-		authorizer:   w.authorizer,
-		requester:    requester,
-		hasRequester: requesterErr == nil,
-		authInfo:     authInfo,
-		hasAuthInfo:  hasAuthInfo,
-		tracer:       w.tracer,
-		observer:     w.observer,
-		resource:     w.resource,
+		inner:      objInfo,
+		authorizer: w.authorizer,
+		requester:  requester,
+		authInfo:   authInfo,
+		tracer:     w.tracer,
+		observer:   w.observer,
+		resource:   w.resource,
 	}
 
 	innerStart := time.Now()
@@ -416,15 +417,13 @@ func (w *Wrapper) Update(
 }
 
 type authorizedUpdateInfo struct {
-	inner        k8srest.UpdatedObjectInfo
-	authorizer   ResourceStorageAuthorizer
-	requester    identity.Requester
-	hasRequester bool
-	authInfo     types.AuthInfo
-	hasAuthInfo  bool
-	tracer       trace.Tracer
-	observer     Observer
-	resource     schema.GroupResource
+	inner      k8srest.UpdatedObjectInfo
+	authorizer ResourceStorageAuthorizer
+	requester  identity.Requester
+	authInfo   types.AuthInfo
+	tracer     trace.Tracer
+	observer   Observer
+	resource   schema.GroupResource
 }
 
 func (a *authorizedUpdateInfo) Preconditions() *metaV1.Preconditions {
@@ -462,12 +461,8 @@ func (a *authorizedUpdateInfo) UpdatedObject(ctx context.Context, oldObj runtime
 }
 
 func (a *authorizedUpdateInfo) authorizationContext(ctx context.Context) context.Context {
-	if a.hasRequester {
-		ctx = identity.WithRequester(ctx, a.requester)
-	}
-	if a.hasAuthInfo {
-		ctx = types.WithAuthInfo(ctx, a.authInfo)
-	}
+	ctx = identity.WithRequester(ctx, a.requester)
+	ctx = types.WithAuthInfo(ctx, a.authInfo)
 	return ctx
 }
 

--- a/pkg/services/apiserver/auth/authorizer/storewrapper/wrapper_test.go
+++ b/pkg/services/apiserver/auth/authorizer/storewrapper/wrapper_test.go
@@ -448,8 +448,8 @@ func TestWrapper_UpdateFailsClosedWithoutOriginalIdentity(t *testing.T) {
 			require.ErrorIs(t, err, ErrUnauthenticated)
 			assert.Nil(t, result)
 			assert.False(t, updated)
-			mockStore.AssertNotCalled(t, "Update")
-			mockAuth.AssertNotCalled(t, "BeforeUpdate")
+			mockStore.AssertNumberOfCalls(t, "Update", 0)
+			mockAuth.AssertNumberOfCalls(t, "BeforeUpdate", 0)
 		})
 	}
 }

--- a/pkg/services/apiserver/auth/authorizer/storewrapper/wrapper_test.go
+++ b/pkg/services/apiserver/auth/authorizer/storewrapper/wrapper_test.go
@@ -363,6 +363,65 @@ func TestWrapper_Update(t *testing.T) {
 	setup.mockStore.AssertExpectations(t)
 }
 
+func TestWrapper_UpdateAuthorizationDoesNotRetainRequestContext(t *testing.T) {
+	type contextKey string
+
+	const (
+		requestOnlyKey   contextKey = "fake-request-only-key"
+		executionOnlyKey contextKey = "fake-execution-only-key"
+	)
+
+	mockStore := rest.NewMockStorage(t)
+	mockAuth := &FakeAuthorizer{}
+	wrapper := New(mockStore, testResource, mockAuth)
+	requester := &identity.StaticRequester{UserUID: "fake-user-uid", Type: types.TypeUser}
+	requestCtx := identity.WithRequester(context.Background(), requester)
+	requestCtx = context.WithValue(requestCtx, requestOnlyKey, "fake-request-only-value")
+
+	oldObj := &fakeObject{ObjectMeta: metaV1.ObjectMeta{Name: "fake-object"}}
+	objInfo := &fakeUpdatedObjectInfo{obj: oldObj}
+	updateOpts := &metaV1.UpdateOptions{}
+
+	var authzInfo *authorizedUpdateInfo
+	mockStore.On(
+		"Update",
+		mock.MatchedBy(matchesServiceIdentity()),
+		"fake-object",
+		mock.MatchedBy(func(info *authorizedUpdateInfo) bool {
+			authzInfo = info
+			return true
+		}),
+		mock.Anything,
+		mock.Anything,
+		false,
+		updateOpts,
+	).Return(oldObj, true, nil)
+
+	_, _, err := wrapper.Update(requestCtx, "fake-object", objInfo, nil, nil, false, updateOpts)
+	require.NoError(t, err)
+	require.NotNil(t, authzInfo)
+
+	mockAuth.On(
+		"BeforeUpdate",
+		mock.MatchedBy(func(ctx context.Context) bool {
+			actualRequester, err := identity.GetRequester(ctx)
+			return err == nil &&
+				actualRequester.GetUID() == "user:fake-user-uid" &&
+				ctx.Value(requestOnlyKey) == nil &&
+				ctx.Value(executionOnlyKey) == "fake-execution-only-value"
+		}),
+		oldObj,
+		oldObj,
+	).Return(nil)
+
+	executionCtx := context.WithValue(context.Background(), executionOnlyKey, "fake-execution-only-value")
+	_, err = authzInfo.UpdatedObject(executionCtx, oldObj)
+	require.NoError(t, err)
+
+	mockAuth.AssertExpectations(t)
+	mockStore.AssertExpectations(t)
+}
+
 func TestWrapper_PassthroughMethods(t *testing.T) {
 	setup := newTestSetup(t)
 

--- a/pkg/services/apiserver/auth/authorizer/storewrapper/wrapper_test.go
+++ b/pkg/services/apiserver/auth/authorizer/storewrapper/wrapper_test.go
@@ -422,6 +422,40 @@ func TestWrapper_UpdateAuthorizationDoesNotRetainRequestContext(t *testing.T) {
 	mockStore.AssertExpectations(t)
 }
 
+func TestWrapper_UpdateFailsClosedWithoutOriginalIdentity(t *testing.T) {
+	testCases := map[string]context.Context{
+		"no auth values": context.Background(),
+		"AuthInfo without requester": types.WithAuthInfo(
+			context.Background(),
+			&identity.StaticRequester{UserUID: "fake-user-uid", Type: types.TypeUser},
+		),
+	}
+
+	for name, ctx := range testCases {
+		t.Run(name, func(t *testing.T) {
+			mockStore := rest.NewMockStorage(t)
+			mockAuth := &FakeAuthorizer{}
+			wrapper := New(mockStore, testResource, mockAuth)
+
+			result, updated, err := wrapper.Update(
+				ctx,
+				"fake-object",
+				&fakeUpdatedObjectInfo{obj: &fakeObject{}},
+				nil,
+				nil,
+				false,
+				&metaV1.UpdateOptions{},
+			)
+
+			require.ErrorIs(t, err, ErrUnauthenticated)
+			assert.Nil(t, result)
+			assert.False(t, updated)
+			mockStore.AssertNotCalled(t, "Update")
+			mockAuth.AssertNotCalled(t, "BeforeUpdate")
+		})
+	}
+}
+
 func TestWrapper_PassthroughMethods(t *testing.T) {
 	setup := newTestSetup(t)
 

--- a/pkg/services/apiserver/auth/authorizer/storewrapper/wrapper_test.go
+++ b/pkg/services/apiserver/auth/authorizer/storewrapper/wrapper_test.go
@@ -363,20 +363,17 @@ func TestWrapper_Update(t *testing.T) {
 	setup.mockStore.AssertExpectations(t)
 }
 
-func TestWrapper_UpdateAuthorizationDoesNotRetainRequestContext(t *testing.T) {
+func TestWrapper_UpdateAuthorizationUsesExecutionContext(t *testing.T) {
 	type contextKey string
 
-	const (
-		requestOnlyKey   contextKey = "fake-request-only-key"
-		executionOnlyKey contextKey = "fake-execution-only-key"
-	)
+	const authorizationContextKey contextKey = "fake-authorization-context-key"
 
 	mockStore := rest.NewMockStorage(t)
 	mockAuth := &FakeAuthorizer{}
 	wrapper := New(mockStore, testResource, mockAuth)
 	requester := &identity.StaticRequester{UserUID: "fake-user-uid", Type: types.TypeUser}
-	requestCtx := identity.WithRequester(context.Background(), requester)
-	requestCtx = context.WithValue(requestCtx, requestOnlyKey, "fake-request-only-value")
+	requestCtx, cancelRequest := context.WithCancel(identity.WithRequester(context.Background(), requester))
+	requestCtx = context.WithValue(requestCtx, authorizationContextKey, "fake-request-value")
 
 	oldObj := &fakeObject{ObjectMeta: metaV1.ObjectMeta{Name: "fake-object"}}
 	objInfo := &fakeUpdatedObjectInfo{obj: oldObj}
@@ -400,21 +397,22 @@ func TestWrapper_UpdateAuthorizationDoesNotRetainRequestContext(t *testing.T) {
 	_, _, err := wrapper.Update(requestCtx, "fake-object", objInfo, nil, nil, false, updateOpts)
 	require.NoError(t, err)
 	require.NotNil(t, authzInfo)
+	cancelRequest()
 
 	mockAuth.On(
 		"BeforeUpdate",
 		mock.MatchedBy(func(ctx context.Context) bool {
 			actualRequester, err := identity.GetRequester(ctx)
-			return err == nil &&
+			return ctx.Err() == nil &&
+				err == nil &&
 				actualRequester.GetUID() == "user:fake-user-uid" &&
-				ctx.Value(requestOnlyKey) == nil &&
-				ctx.Value(executionOnlyKey) == "fake-execution-only-value"
+				ctx.Value(authorizationContextKey) == "fake-execution-value"
 		}),
 		oldObj,
 		oldObj,
 	).Return(nil)
 
-	executionCtx := context.WithValue(context.Background(), executionOnlyKey, "fake-execution-only-value")
+	executionCtx := context.WithValue(context.Background(), authorizationContextKey, "fake-execution-value")
 	_, err = authzInfo.UpdatedObject(executionCtx, oldObj)
 	require.NoError(t, err)
 

--- a/pkg/storage/legacysql/dualwrite/dualwriter_mode1_test.go
+++ b/pkg/storage/legacysql/dualwrite/dualwriter_mode1_test.go
@@ -6,14 +6,18 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/authlib/types"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/apis/example"
+	k8srest "k8s.io/apiserver/pkg/registry/rest"
 
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apiserver/rest"
+	"github.com/grafana/grafana/pkg/services/apiserver/auth/authorizer/storewrapper"
 )
 
 var now = time.Now()
@@ -358,4 +362,151 @@ func TestMode1_Update(t *testing.T) {
 			require.NotEqual(t, obj, anotherObj)
 		})
 	}
+}
+
+func TestMode1_UpdateBackgroundAuthorizationOutlivesRequest(t *testing.T) {
+	legacy := &fakeStorage{}
+	legacy.onUpdate(exampleObj, nil)
+
+	unified := &blockingUpdateStorage{
+		fakeStorage: &fakeStorage{},
+		started:     make(chan struct{}),
+		release:     make(chan struct{}),
+		result:      make(chan backgroundUpdateResult, 1),
+	}
+
+	dw, err := newStorage(kind, rest.Mode1, legacy, unified)
+	require.NoError(t, err)
+	inner, ok := dw.(storewrapper.K8sStorage)
+	require.True(t, ok)
+
+	authz := &requestLifecycleAuthorizer{result: make(chan authorizationResult, 1)}
+	storage := storewrapper.New(inner, kind, authz)
+
+	requestCtx, cancelRequest := context.WithCancel(identity.WithRequester(
+		context.Background(),
+		&identity.StaticRequester{UserUID: "fake-user-uid", Type: types.TypeUser, Namespace: "fake-namespace"},
+	))
+
+	obj, _, err := storage.Update(
+		requestCtx,
+		"foo",
+		updatedObjInfoObj{},
+		func(context.Context, runtime.Object) error { return nil },
+		func(context.Context, runtime.Object, runtime.Object) error { return nil },
+		false,
+		&metav1.UpdateOptions{},
+	)
+	require.NoError(t, err)
+	require.Equal(t, exampleObj, obj)
+
+	select {
+	case <-unified.started:
+	case <-time.After(time.Second):
+		t.Fatal("background unified update did not start")
+	}
+
+	cancelRequest()
+	close(unified.release)
+
+	select {
+	case got := <-authz.result:
+		require.NoError(t, got.contextErr)
+		require.NoError(t, got.identityErr)
+		require.Equal(t, "user:fake-user-uid", got.uid)
+		require.True(t, got.authInfoOK)
+		require.Equal(t, "fake-namespace", got.namespace)
+	case <-time.After(time.Second):
+		t.Fatal("background authorization did not complete")
+	}
+
+	select {
+	case got := <-unified.result:
+		require.NoError(t, got.contextErr)
+		require.NoError(t, got.updateErr)
+	case <-time.After(time.Second):
+		t.Fatal("background unified update did not complete")
+	}
+}
+
+type blockingUpdateStorage struct {
+	*fakeStorage
+	started chan struct{}
+	release chan struct{}
+	result  chan backgroundUpdateResult
+}
+
+type backgroundUpdateResult struct {
+	contextErr error
+	updateErr  error
+}
+
+func (s *blockingUpdateStorage) Update(
+	ctx context.Context,
+	_ string,
+	objInfo k8srest.UpdatedObjectInfo,
+	_ k8srest.ValidateObjectFunc,
+	_ k8srest.ValidateObjectUpdateFunc,
+	_ bool,
+	_ *metav1.UpdateOptions,
+) (runtime.Object, bool, error) {
+	close(s.started)
+	<-s.release
+
+	_, err := objInfo.UpdatedObject(ctx, exampleObj)
+	s.result <- backgroundUpdateResult{contextErr: ctx.Err(), updateErr: err}
+	return anotherObj, false, err
+}
+
+type requestLifecycleAuthorizer struct {
+	result chan authorizationResult
+}
+
+type authorizationResult struct {
+	contextErr  error
+	identityErr error
+	uid         string
+	authInfoOK  bool
+	namespace   string
+}
+
+func (a *requestLifecycleAuthorizer) BeforeCreate(context.Context, runtime.Object) error {
+	return nil
+}
+
+func (a *requestLifecycleAuthorizer) BeforeUpdate(ctx context.Context, _, _ runtime.Object) error {
+	user, identityErr := identity.GetRequester(ctx)
+	uid := ""
+	if identityErr == nil {
+		uid = user.GetUID()
+	}
+	authInfo, authInfoOK := types.AuthInfoFrom(ctx)
+	namespace := ""
+	if authInfoOK {
+		namespace = authInfo.GetNamespace()
+	}
+	a.result <- authorizationResult{
+		contextErr:  ctx.Err(),
+		identityErr: identityErr,
+		uid:         uid,
+		authInfoOK:  authInfoOK,
+		namespace:   namespace,
+	}
+	return ctx.Err()
+}
+
+func (a *requestLifecycleAuthorizer) BeforeDelete(context.Context, runtime.Object) error {
+	return nil
+}
+
+func (a *requestLifecycleAuthorizer) AfterGet(context.Context, runtime.Object) error {
+	return nil
+}
+
+func (a *requestLifecycleAuthorizer) FilterList(_ context.Context, list runtime.Object) (runtime.Object, error) {
+	return list, nil
+}
+
+func (a *requestLifecycleAuthorizer) WatchFilter(context.Context) (storewrapper.WatchEventFilter, error) {
+	return storewrapper.PassThroughWatchFilter, nil
 }

--- a/pkg/storage/legacysql/dualwrite/dualwriter_mode1_test.go
+++ b/pkg/storage/legacysql/dualwrite/dualwriter_mode1_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grafana/authlib/types"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
@@ -15,9 +14,7 @@ import (
 	"k8s.io/apiserver/pkg/apis/example"
 	k8srest "k8s.io/apiserver/pkg/registry/rest"
 
-	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apiserver/rest"
-	"github.com/grafana/grafana/pkg/services/apiserver/auth/authorizer/storewrapper"
 )
 
 var now = time.Now()
@@ -364,7 +361,7 @@ func TestMode1_Update(t *testing.T) {
 	}
 }
 
-func TestMode1_UpdateBackgroundAuthorizationOutlivesRequest(t *testing.T) {
+func TestMode1_UpdateBackgroundOutlivesRequest(t *testing.T) {
 	legacy := &fakeStorage{}
 	legacy.onUpdate(exampleObj, nil)
 
@@ -377,18 +374,11 @@ func TestMode1_UpdateBackgroundAuthorizationOutlivesRequest(t *testing.T) {
 
 	dw, err := newStorage(kind, rest.Mode1, legacy, unified)
 	require.NoError(t, err)
-	inner, ok := dw.(storewrapper.K8sStorage)
-	require.True(t, ok)
 
-	authz := &requestLifecycleAuthorizer{result: make(chan authorizationResult, 1)}
-	storage := storewrapper.New(inner, kind, authz)
+	requestCtx := context.WithValue(context.Background(), backgroundUpdateContextKey{}, "fake-request-value")
+	requestCtx, cancelRequest := context.WithCancel(requestCtx)
 
-	requestCtx, cancelRequest := context.WithCancel(identity.WithRequester(
-		context.Background(),
-		&identity.StaticRequester{UserUID: "fake-user-uid", Type: types.TypeUser, Namespace: "fake-namespace"},
-	))
-
-	obj, _, err := storage.Update(
+	obj, _, err := dw.Update(
 		requestCtx,
 		"foo",
 		updatedObjInfoObj{},
@@ -410,24 +400,16 @@ func TestMode1_UpdateBackgroundAuthorizationOutlivesRequest(t *testing.T) {
 	close(unified.release)
 
 	select {
-	case got := <-authz.result:
-		require.NoError(t, got.contextErr)
-		require.NoError(t, got.identityErr)
-		require.Equal(t, "user:fake-user-uid", got.uid)
-		require.True(t, got.authInfoOK)
-		require.Equal(t, "fake-namespace", got.namespace)
-	case <-time.After(time.Second):
-		t.Fatal("background authorization did not complete")
-	}
-
-	select {
 	case got := <-unified.result:
 		require.NoError(t, got.contextErr)
 		require.NoError(t, got.updateErr)
+		require.Equal(t, "fake-request-value", got.contextValue)
 	case <-time.After(time.Second):
 		t.Fatal("background unified update did not complete")
 	}
 }
+
+type backgroundUpdateContextKey struct{}
 
 type blockingUpdateStorage struct {
 	*fakeStorage
@@ -437,8 +419,9 @@ type blockingUpdateStorage struct {
 }
 
 type backgroundUpdateResult struct {
-	contextErr error
-	updateErr  error
+	contextErr   error
+	updateErr    error
+	contextValue any
 }
 
 func (s *blockingUpdateStorage) Update(
@@ -454,59 +437,10 @@ func (s *blockingUpdateStorage) Update(
 	<-s.release
 
 	_, err := objInfo.UpdatedObject(ctx, exampleObj)
-	s.result <- backgroundUpdateResult{contextErr: ctx.Err(), updateErr: err}
+	s.result <- backgroundUpdateResult{
+		contextErr:   ctx.Err(),
+		updateErr:    err,
+		contextValue: ctx.Value(backgroundUpdateContextKey{}),
+	}
 	return anotherObj, false, err
-}
-
-type requestLifecycleAuthorizer struct {
-	result chan authorizationResult
-}
-
-type authorizationResult struct {
-	contextErr  error
-	identityErr error
-	uid         string
-	authInfoOK  bool
-	namespace   string
-}
-
-func (a *requestLifecycleAuthorizer) BeforeCreate(context.Context, runtime.Object) error {
-	return nil
-}
-
-func (a *requestLifecycleAuthorizer) BeforeUpdate(ctx context.Context, _, _ runtime.Object) error {
-	user, identityErr := identity.GetRequester(ctx)
-	uid := ""
-	if identityErr == nil {
-		uid = user.GetUID()
-	}
-	authInfo, authInfoOK := types.AuthInfoFrom(ctx)
-	namespace := ""
-	if authInfoOK {
-		namespace = authInfo.GetNamespace()
-	}
-	a.result <- authorizationResult{
-		contextErr:  ctx.Err(),
-		identityErr: identityErr,
-		uid:         uid,
-		authInfoOK:  authInfoOK,
-		namespace:   namespace,
-	}
-	return ctx.Err()
-}
-
-func (a *requestLifecycleAuthorizer) BeforeDelete(context.Context, runtime.Object) error {
-	return nil
-}
-
-func (a *requestLifecycleAuthorizer) AfterGet(context.Context, runtime.Object) error {
-	return nil
-}
-
-func (a *requestLifecycleAuthorizer) FilterList(_ context.Context, list runtime.Object) (runtime.Object, error) {
-	return list, nil
-}
-
-func (a *requestLifecycleAuthorizer) WatchFilter(context.Context) (storewrapper.WatchEventFilter, error) {
-	return storewrapper.PassThroughWatchFilter, nil
 }

--- a/pkg/storage/legacysql/dualwrite/storage_mocks_test.go
+++ b/pkg/storage/legacysql/dualwrite/storage_mocks_test.go
@@ -237,8 +237,6 @@ func (f *fakeStorage) DeleteCollection(ctx context.Context, deleteValidation res
 type updatedObjInfoObj struct{}
 
 func (u updatedObjInfoObj) UpdatedObject(ctx context.Context, oldObj runtime.Object) (newObj runtime.Object, err error) { // nolint:staticcheck
-	// nolint:staticcheck
-	oldObj = exampleObj
-	return oldObj, nil
+	return exampleObj.DeepCopy(), nil
 }
 func (u updatedObjInfoObj) Preconditions() *metav1.Preconditions { return &metav1.Preconditions{} }


### PR DESCRIPTION
## What does this change do?

This change decouples update authorization identity from the original request lifecycle.

`storewrapper.Wrapper` replaces the caller with a service identity before invoking storage. Previously, `authorizedUpdateInfo` retained the entire request context so `BeforeUpdate` could recover the original caller.

It now captures only the canonical `identity.Requester` before that replacement and applies it to the context supplied by the actual update execution. `identity.WithRequester` sets both the Grafana requester and authlib auth info, avoiding split identity state. Updates without a requester fail with `ErrUnauthenticated` before storage, so they cannot inherit the wrapper's privileged service identity.

## Why is this necessary?

In asynchronous dual-write mode:

1. The legacy update succeeds.
2. Unified replication starts with a detached background context.
3. The HTTP request completes and its context is canceled.
4. The authorization wrapper uses its retained request context.
5. Authorization RPCs fail with `context canceled`, leaving unified storage stale even though the API returned success.

`context.WithoutCancel` in the dual writer was working correctly. Cancellation re-entered through the request context retained by `authorizedUpdateInfo`.

TeamLBAC exposed the regression, but it is in the generic update authorization wrapper. It can affect asynchronous updates for other wrapped resources, including team bindings, resource permissions, users, roles, and role bindings. Update-based operations include `PUT`, `PATCH`, server-side apply, and subresource updates.

The execution context still controls cancellation, deadlines, tracing, and other values. Foreground authoritative writes therefore continue to respect request cancellation, while explicitly detached background replication can outlive the request.

Mode 1 still authorizes the foreground and background operations separately, and this PR does not add durable retry or reconciliation for failed background writes.

## Tests

Added coverage verifying that:

- update authorization uses the live execution context after the original request is canceled;
- the original fake requester is applied to that execution context;
- missing requester state, including auth-info-only state, fails closed before storage;
- a mode-1 background update completes after request cancellation and preserves values carried by `context.WithoutCancel`;
- the dual-writer test has no dependency on the API-server authorization package.

```text
go test ./pkg/services/apiserver/auth/authorizer/storewrapper ./pkg/storage/legacysql/dualwrite
go test -race ./pkg/services/apiserver/auth/authorizer/storewrapper
```
