### PR TITLE
Geomap: Add unit tests for gazetteer, layer registry, esri, and style dimensions

### DIFF
--- a/public/app/features/geo/gazetteer/gazetteer.test.ts
+++ b/public/app/features/geo/gazetteer/gazetteer.test.ts
@@ -144,7 +144,7 @@ describe('frameAsGazetter', () => {
       });
       const latField = frame.fields.find((f) => f.name === latName)!;
       const lngField = frame.fields.find((f) => f.name === lngName)!;
-      const expected = pointFieldFromLonLat(lngField, latField).values[0]!.getCoordinates();
+      const expected = (pointFieldFromLonLat(lngField, latField).values[0] as Point).getCoordinates();
 
       const gaz = frameAsGazetter(frame, { path: 't' });
       expect(gaz.find('a')!.point()!.getCoordinates()).toEqual(expected);
@@ -158,7 +158,7 @@ describe('frameAsGazetter', () => {
         ],
       });
       const geohashField = frame.fields.find((f) => f.name === 'geohash')!;
-      const expected = pointFieldFromGeohash(geohashField).values[0]!.getCoordinates();
+      const expected = (pointFieldFromGeohash(geohashField).values[0] as Point).getCoordinates();
 
       const gaz = frameAsGazetter(frame, { path: 't' });
       expect(gaz.find('g')!.point()!.getCoordinates()).toEqual(expected);

--- a/public/app/features/geo/gazetteer/gazetteer.test.ts
+++ b/public/app/features/geo/gazetteer/gazetteer.test.ts
@@ -1,6 +1,11 @@
+import { LineString, Point } from 'ol/geom';
+
+import { FieldType, toDataFrame } from '@grafana/data';
 import { getCenterPointWGS84 } from 'app/features/transformers/spatial/utils';
 
-import { getGazetteer, GAZETTEER_OPTIONS } from './gazetteer';
+import { pointFieldFromGeohash, pointFieldFromLonLat } from '../format/utils';
+
+import { frameAsGazetter, getGazetteer, GAZETTEER_OPTIONS } from './gazetteer';
 
 const geojsonObject = {
   type: 'FeatureCollection',
@@ -119,5 +124,149 @@ describe('Placename lookup from geojson format', () => {
         2,
       ]
     `);
+  });
+});
+
+describe('frameAsGazetter', () => {
+  describe('geometry derivation', () => {
+    it.each([
+      ['LAT', 'LON'],
+      ['LATITUTE', 'LONGITUE'], // real (misspelled) aliases the code accepts
+      ['LAT', 'LNG'],
+      ['LAT', 'LONG'],
+    ])('builds points from lat/lng fields named %s/%s', (latName, lngName) => {
+      const frame = toDataFrame({
+        fields: [
+          { name: 'id', type: FieldType.string, values: ['a'] },
+          { name: latName, type: FieldType.number, values: [12] },
+          { name: lngName, type: FieldType.number, values: [34] },
+        ],
+      });
+      const latField = frame.fields.find((f) => f.name === latName)!;
+      const lngField = frame.fields.find((f) => f.name === lngName)!;
+      const expected = pointFieldFromLonLat(lngField, latField).values[0]!.getCoordinates();
+
+      const gaz = frameAsGazetter(frame, { path: 't' });
+      expect(gaz.find('a')!.point()!.getCoordinates()).toEqual(expected);
+    });
+
+    it('derives points from a geohash field', () => {
+      const frame = toDataFrame({
+        fields: [
+          { name: 'id', type: FieldType.string, values: ['g'] },
+          { name: 'geohash', type: FieldType.string, values: ['9q8yy'] },
+        ],
+      });
+      const geohashField = frame.fields.find((f) => f.name === 'geohash')!;
+      const expected = pointFieldFromGeohash(geohashField).values[0]!.getCoordinates();
+
+      const gaz = frameAsGazetter(frame, { path: 't' });
+      expect(gaz.find('g')!.point()!.getCoordinates()).toEqual(expected);
+    });
+
+    it('uses an existing Point geo field directly', () => {
+      const pt = new Point([5, 6]);
+      const frame = toDataFrame({
+        fields: [
+          { name: 'id', type: FieldType.string, values: ['x'] },
+          { name: 'geometry', type: FieldType.geo, values: [pt] },
+        ],
+      });
+
+      const info = frameAsGazetter(frame, { path: 't' }).find('x')!;
+      expect(info.geometry()).toBe(pt);
+      expect(info.point()!.getCoordinates()).toEqual([5, 6]);
+    });
+
+    it('returns the centroid of a non-point geometry from point()', () => {
+      const line = new LineString([
+        [0, 0],
+        [10, 20],
+      ]);
+      const frame = toDataFrame({
+        fields: [
+          { name: 'id', type: FieldType.string, values: ['x'] },
+          { name: 'geometry', type: FieldType.geo, values: [line] },
+        ],
+      });
+
+      const info = frameAsGazetter(frame, { path: 't' }).find('x')!;
+      expect(info.geometry()).toBe(line);
+      // point() collapses a non-point to the center of its extent
+      expect(info.point()!.getCoordinates()).toEqual([5, 10]);
+    });
+  });
+
+  describe('key detection', () => {
+    const coords = (n: number) => ({
+      lat: { name: 'LAT', type: FieldType.number, values: Array.from({ length: n }, (_, i) => i + 1) },
+      lon: { name: 'LON', type: FieldType.number, values: Array.from({ length: n }, (_, i) => i + 1) },
+    });
+
+    it('keys off a *_CODE suffixed field, not the first string field', () => {
+      const c = coords(1);
+      const frame = toDataFrame({
+        fields: [
+          { name: 'label', type: FieldType.string, values: ['L'] },
+          { name: 'some_code', type: FieldType.string, values: ['B'] },
+          c.lat,
+          c.lon,
+        ],
+      });
+      const gaz = frameAsGazetter(frame, { path: 't' });
+      expect(gaz.find('B')!.index).toBe(0);
+      expect(gaz.find('L')).toBeUndefined();
+    });
+
+    it('keys off a UID field', () => {
+      const c = coords(1);
+      const frame = toDataFrame({
+        fields: [
+          { name: 'label', type: FieldType.string, values: ['L'] },
+          { name: 'UID', type: FieldType.string, values: ['u1'] },
+          c.lat,
+          c.lon,
+        ],
+      });
+      const gaz = frameAsGazetter(frame, { path: 't' });
+      expect(gaz.find('u1')!.index).toBe(0);
+      expect(gaz.find('L')).toBeUndefined();
+    });
+
+    it('falls back to the first string field when no key field exists', () => {
+      const c = coords(1);
+      const frame = toDataFrame({
+        fields: [{ name: 'place', type: FieldType.string, values: ['P'] }, c.lat, c.lon],
+      });
+      expect(frameAsGazetter(frame, { path: 't' }).find('P')!.index).toBe(0);
+    });
+
+    it('resolves keys case-insensitively and returns undefined for misses', () => {
+      const c = coords(2);
+      const frame = toDataFrame({
+        fields: [{ name: 'id', type: FieldType.string, values: ['us', 'fr'] }, c.lat, c.lon],
+      });
+      const gaz = frameAsGazetter(frame, { path: 't' });
+      expect(gaz.find('us')!.index).toBe(0);
+      expect(gaz.find('US')!.index).toBe(0);
+      expect(gaz.find('fr')!.index).toBe(1);
+      expect(gaz.find('zz')).toBeUndefined();
+    });
+  });
+
+  it('exposes count and a bounded examples list', () => {
+    const frame = toDataFrame({
+      fields: [
+        { name: 'id', type: FieldType.string, values: ['a', 'b', 'c'] },
+        { name: 'LAT', type: FieldType.number, values: [1, 2, 3] },
+        { name: 'LON', type: FieldType.number, values: [4, 5, 6] },
+      ],
+    });
+    const gaz = frameAsGazetter(frame, { path: 't' });
+    expect(gaz.count).toBe(3);
+    // examples(v) returns v+1 entries
+    expect(gaz.examples(0)).toHaveLength(1);
+    expect(gaz.examples(1)).toHaveLength(2);
+    expect(gaz.frame!()).toBe(frame);
   });
 });

--- a/public/app/plugins/panel/geomap/layers/basemaps/esri.test.ts
+++ b/public/app/plugins/panel/geomap/layers/basemaps/esri.test.ts
@@ -1,0 +1,68 @@
+import type OpenLayersMap from 'ol/Map';
+import TileLayer from 'ol/layer/Tile';
+import XYZ from 'ol/source/XYZ';
+
+import { type EventBus, type GrafanaTheme2, type MapLayerOptions } from '@grafana/data';
+
+import { esriLayers } from './esri';
+
+// The generic XYZ layer interpolates the URL via getTemplateSrv().replace()
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getTemplateSrv: () => ({ replace: (v: string) => v }),
+}));
+
+const [esriXYZ] = esriLayers;
+
+const map = {} as OpenLayersMap;
+const eventBus = {} as EventBus;
+const theme = { isDark: false } as GrafanaTheme2;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function initSource(config: any): Promise<XYZ> {
+  const handler = await esriXYZ.create(
+    map,
+    { name: 'esri', type: 'esri-xyz', config } as MapLayerOptions,
+    eventBus,
+    theme
+  );
+  const layer = handler.init();
+  return (layer as TileLayer<XYZ>).getSource() as XYZ;
+}
+
+const ARCGIS = 'https://services.arcgisonline.com/ArcGIS/rest/services/';
+
+describe('esri (ArcGIS MapServer) basemap', () => {
+  it('defaults to the World Street Map service when no server is set', async () => {
+    const source = await initSource({});
+    expect(source.getUrls()?.[0]).toBe(`${ARCGIS}World_Street_Map/MapServer/tile/{z}/{y}/{x}`);
+  });
+
+  it.each([
+    ['streets', 'World_Street_Map'],
+    ['world-imagery', 'World_Imagery'],
+    ['topo', 'World_Topo_Map'],
+    ['ocean', 'Ocean/World_Ocean_Base'],
+  ])('maps the "%s" service to its ArcGIS slug URL', async (server, slug) => {
+    const source = await initSource({ server });
+    expect(source.getUrls()?.[0]).toBe(`${ARCGIS}${slug}/MapServer/tile/{z}/{y}/{x}`);
+  });
+
+  it('uses the caller-supplied url unchanged for a custom server', async () => {
+    const url = 'https://tiles.example.com/{z}/{x}/{y}.png';
+    const source = await initSource({ server: 'custom', url });
+    expect(source.getUrls()?.[0]).toBe(url);
+  });
+
+  it('returns a TileLayer backed by an XYZ source', async () => {
+    const handler = await esriXYZ.create(
+      map,
+      { name: 'esri', type: 'esri-xyz', config: { server: 'streets' } } as MapLayerOptions,
+      eventBus,
+      theme
+    );
+    const layer = handler.init();
+    expect(layer).toBeInstanceOf(TileLayer);
+    expect((layer as TileLayer<XYZ>).getSource()).toBeInstanceOf(XYZ);
+  });
+});

--- a/public/app/plugins/panel/geomap/layers/basemaps/maplibre.test.ts
+++ b/public/app/plugins/panel/geomap/layers/basemaps/maplibre.test.ts
@@ -1,0 +1,67 @@
+import type OpenLayersMap from 'ol/Map';
+import LayerGroup from 'ol/layer/Group';
+
+import { type EventBus, type GrafanaTheme2, type MapLayerOptions } from '@grafana/data';
+
+// ol-mapbox-style is untransformed ESM under jest and only its side effect (apply) matters here.
+const applyMock = jest.fn().mockResolvedValue(undefined);
+jest.mock('ol-mapbox-style', () => ({
+  apply: (...args: unknown[]) => applyMock(...args),
+}));
+
+import { maplibreLayers } from './maplibre';
+
+const [maplibreLayer] = maplibreLayers;
+
+const DEFAULT_STYLE_URL = 'https://tiles.stadiamaps.com/styles/alidade_smooth.json';
+
+const map = {} as OpenLayersMap;
+const eventBus = {} as EventBus;
+const theme = { isDark: false } as GrafanaTheme2;
+
+async function initLayer(options: Partial<MapLayerOptions>): Promise<LayerGroup> {
+  const handler = await maplibreLayer.create(
+    map,
+    { name: 'maplibre', type: 'maplibre', config: {}, ...options } as MapLayerOptions,
+    eventBus,
+    theme
+  );
+  return handler.init() as LayerGroup;
+}
+
+describe('maplibre basemap', () => {
+  beforeEach(() => {
+    applyMock.mockClear();
+    jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: jest.fn().mockResolvedValue({ layers: [] }),
+    } as unknown as Response);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns a LayerGroup and defaults opacity to 1', async () => {
+    const layer = await initLayer({});
+    expect(layer).toBeInstanceOf(LayerGroup);
+    expect(layer.getOpacity()).toBe(1);
+  });
+
+  it('applies the configured layer opacity to the group', async () => {
+    const layer = await initLayer({ opacity: 0.4 });
+    expect(layer.getOpacity()).toBe(0.4);
+  });
+
+  it('fetches the default style URL when no config url is set', async () => {
+    await initLayer({ config: {} });
+    expect(fetch).toHaveBeenCalledWith(DEFAULT_STYLE_URL);
+  });
+
+  it('fetches the configured style URL when one is provided', async () => {
+    const url = 'https://tiles.example.com/style.json';
+    await initLayer({ config: { url } });
+    expect(fetch).toHaveBeenCalledWith(url);
+  });
+});

--- a/public/app/plugins/panel/geomap/layers/data/lastPointTracker.test.ts
+++ b/public/app/plugins/panel/geomap/layers/data/lastPointTracker.test.ts
@@ -1,0 +1,87 @@
+import type OpenLayersMap from 'ol/Map';
+import VectorLayer from 'ol/layer/Vector';
+
+import {
+  createTheme,
+  EventBusSrv,
+  FieldType,
+  FrameGeometrySourceMode,
+  getDefaultTimeRange,
+  LoadingState,
+  type MapLayerOptions,
+  type PanelData,
+  toDataFrame,
+} from '@grafana/data';
+import { getCenterPointWGS84 } from 'app/features/transformers/spatial/utils';
+
+import { lastPointTracker } from './lastPointTracker';
+
+// lastPointTracker imports the whole `ol/source` barrel, which pulls in ol/source/GeoTIFF ->
+// geotiff -> quick-lru (untransformed ESM under jest). Only Vector is used, so stub the barrel.
+jest.mock('ol/source', () => ({
+  Vector: jest.requireActual('ol/source/Vector').default,
+}));
+
+jest.mock('app/features/geo/gazetteer/gazetteer', () => ({
+  ...jest.requireActual('app/features/geo/gazetteer/gazetteer'),
+  getGazetteer: jest.fn().mockResolvedValue(undefined),
+}));
+
+const coordsData = (lats: number[], lons: number[]): PanelData => ({
+  state: LoadingState.Done,
+  timeRange: getDefaultTimeRange(),
+  series: [
+    toDataFrame({
+      fields: [
+        { name: 'time', type: FieldType.time, values: lats.map((_, i) => i) },
+        { name: 'lat', type: FieldType.number, values: lats },
+        { name: 'lon', type: FieldType.number, values: lons },
+      ],
+    }),
+  ],
+});
+
+async function setup() {
+  return lastPointTracker.create(
+    {} as OpenLayersMap,
+    {
+      type: 'last-point-tracker',
+      name: 'Last point',
+      location: { mode: FrameGeometrySourceMode.Coords, latitude: 'lat', longitude: 'lon' },
+      config: {},
+    } as MapLayerOptions,
+    new EventBusSrv(),
+    createTheme()
+  );
+}
+
+describe('lastPointTracker', () => {
+  it('init() returns a vector layer holding a single feature', async () => {
+    const handler = await setup();
+    const layer = handler.init();
+    expect(layer).toBeInstanceOf(VectorLayer);
+    expect((layer as VectorLayer).getSource()!.getFeatures()).toHaveLength(1);
+  });
+
+  it('update() moves the point to the last row coordinate', async () => {
+    const handler = await setup();
+    const layer = handler.init() as VectorLayer;
+
+    handler.update!(coordsData([0, 10, 20], [0, 30, 60]));
+
+    const point = layer.getSource()!.getFeatures()[0].getGeometry()!;
+    const [lon, lat] = getCenterPointWGS84(point)!;
+    expect(lon).toBeCloseTo(60);
+    expect(lat).toBeCloseTo(20);
+  });
+
+  it('update() leaves the point untouched for an empty frame', async () => {
+    const handler = await setup();
+    const layer = handler.init() as VectorLayer;
+    const point = layer.getSource()!.getFeatures()[0];
+
+    handler.update!({ state: LoadingState.Done, timeRange: getDefaultTimeRange(), series: [] });
+
+    expect(point.getGeometry()).toBeUndefined();
+  });
+});

--- a/public/app/plugins/panel/geomap/layers/registry.test.ts
+++ b/public/app/plugins/panel/geomap/layers/registry.test.ts
@@ -1,0 +1,77 @@
+import { getLayersOptions } from './registry';
+
+let mockHasAlphaPanels = false;
+
+jest.mock('app/core/config', () => ({
+  ...jest.requireActual('app/core/config'),
+  get hasAlphaPanels() {
+    return mockHasAlphaPanels;
+  },
+}));
+
+// Use deterministic fake layer sets so the assertions test the selection logic itself
+// (alpha gating, beta labelling, ordering) rather than the churn of real layer registrations.
+// Mocking the barrels also avoids loading real data layers, which pull ol/source -> geotiff
+// (untransformed ESM under jest).
+jest.mock('./basemaps', () => ({
+  basemapLayers: [{ id: 'base-a', name: 'Base A' }],
+}));
+jest.mock('./data', () => {
+  const { PluginState } = jest.requireActual('@grafana/data');
+  return {
+    dataLayers: [
+      { id: 'data-a', name: 'Data A' },
+      { id: 'data-beta', name: 'Data Beta', state: PluginState.beta },
+      { id: 'data-alpha', name: 'Data Alpha', state: PluginState.alpha },
+    ],
+  };
+});
+
+const ids = (opts: Array<{ value?: string }>) => opts.map((o) => o.value);
+
+describe('getLayersOptions', () => {
+  beforeEach(() => {
+    mockHasAlphaPanels = false;
+  });
+
+  it('offers the default base layer plus basemaps for basemap selection, excluding data layers', () => {
+    const { options } = getLayersOptions(true);
+    expect(ids(options)).toEqual(['default', 'base-a']);
+  });
+
+  it('offers data layers plus basemaps for overlay selection', () => {
+    const { options } = getLayersOptions(false);
+    expect(ids(options)).toContain('data-a');
+    expect(ids(options)).toContain('base-a');
+  });
+
+  it('labels beta layers and still includes them (switch falls through to default)', () => {
+    const { options } = getLayersOptions(false);
+    const beta = options.find((o) => o.value === 'data-beta');
+    expect(beta!.label).toBe('Data Beta (Beta)');
+  });
+
+  it('reports the current selection separately', () => {
+    const { current } = getLayersOptions(false, 'data-a');
+    expect(ids(current)).toEqual(['data-a']);
+  });
+
+  describe('alpha layer gating', () => {
+    it('hides alpha layers when alpha panels are disabled', () => {
+      const { options } = getLayersOptions(false);
+      expect(ids(options)).not.toContain('data-alpha');
+      expect(options.some((o) => o.label?.includes('(Alpha)'))).toBe(false);
+    });
+
+    it('shows alpha layers labelled, bolt-iconed, and ordered last when alpha panels are enabled', () => {
+      mockHasAlphaPanels = true;
+      const { options } = getLayersOptions(false);
+
+      const alpha = options.find((o) => o.value === 'data-alpha');
+      expect(alpha!.label).toBe('Data Alpha (Alpha)');
+      expect(alpha!.icon).toBe('bolt');
+      // alpha layers are appended after the regular (non-alpha) layers
+      expect(ids(options).indexOf('data-alpha')).toBeGreaterThan(ids(options).indexOf('data-a'));
+    });
+  });
+});

--- a/public/app/plugins/panel/geomap/style/markers.test.ts
+++ b/public/app/plugins/panel/geomap/style/markers.test.ts
@@ -1,4 +1,4 @@
-import { Fill, Stroke, Style } from 'ol/style';
+import { Fill, RegularShape, Stroke, Style } from 'ol/style';
 
 import { getPublicOrAbsoluteUrl } from 'app/features/dimensions/resource';
 
@@ -258,5 +258,27 @@ describe('shape marker makers', () => {
     const maker = await getMarkerMaker(getMarkerAsPath('square')!);
     const result = maker({ color: '#000', opacity: 1 });
     expect(result).toBeInstanceOf(Style);
+  });
+});
+
+describe('getMarkerMaker fallbacks', () => {
+  it('returns the text marker when no symbol is given but a text label is present', async () => {
+    const maker = await getMarkerMaker(undefined, true);
+    expect(maker).toBe(textMarker);
+  });
+
+  it('falls back to the error marker for an unknown, non-svg symbol', async () => {
+    const maker = await getMarkerMaker('not-a-registered-shape');
+
+    const result = maker({ color: '#000', opacity: 1, size: 10 });
+    // errorMarker renders two red-stroked RegularShapes (an X over a plus).
+    expect(Array.isArray(result)).toBe(true);
+    const styles = Array.isArray(result) ? result : [result];
+    expect(styles).toHaveLength(2);
+    for (const s of styles) {
+      const image = s.getImage();
+      expect(image).toBeInstanceOf(RegularShape);
+      expect((image as RegularShape).getStroke()?.getColor()).toBe('#F00');
+    }
   });
 });

--- a/public/app/plugins/panel/geomap/utils/utils.test.ts
+++ b/public/app/plugins/panel/geomap/utils/utils.test.ts
@@ -8,7 +8,6 @@ import WebGLPointsLayer from 'ol/layer/WebGLPoints';
 import TileSource from 'ol/source/Tile';
 import VectorSource from 'ol/source/Vector';
 
-import { getTemplateSrv } from '@grafana/runtime';
 
 // Mock the config module to avoid undefined panels error
 jest.mock('@grafana/runtime', () => ({
@@ -34,10 +33,25 @@ jest.mock('app/plugins/datasource/grafana/datasource', () => ({
   getGrafanaDatasource: jest.fn(),
 }));
 
+
+import { createTheme } from '@grafana/data';
+import { getTemplateSrv } from '@grafana/runtime';
+import { getColorDimension } from 'app/features/dimensions/color';
+import { getScalarDimension } from 'app/features/dimensions/scalar';
+import { getScaledDimension } from 'app/features/dimensions/scale';
+import { getTextDimension } from 'app/features/dimensions/text';
+
 import { type GeomapPanel } from '../GeomapPanel';
+import { defaultStyleConfig, type StyleConfig, type StyleConfigState } from '../style/types';
 import { type MapLayerState } from '../types';
 
-import { hasVariableDependencies, hasLayerData, isSegmentVisible, getNextLayerName } from './utils';
+import {
+  hasVariableDependencies,
+  hasLayerData,
+  isSegmentVisible,
+  getNextLayerName,
+  getStyleDimension,
+} from './utils';
 
 // Test fixtures
 const createTestFeature = () => new Feature(new Point([0, 0]));
@@ -245,5 +259,61 @@ describe('isSegmentVisible', () => {
     },
   ])('$name', ({ pixelTolerance, start, end, expected }) => {
     expect(isSegmentVisible(map, pixelTolerance, start, end)).toBe(expected);
+  });
+});
+
+describe('getStyleDimension', () => {
+  const theme = createTheme();
+  const frame = undefined;
+
+  // getStyleDimension only reads style.config and style.fields
+  const styleState = (fields?: StyleConfigState['fields']): StyleConfigState =>
+    ({ config: defaultStyleConfig, fields }) as unknown as StyleConfigState;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('builds color, size and rotation (but not text) from a custom style config', () => {
+    const custom = { color: defaultStyleConfig.color } as StyleConfig;
+
+    const dims = getStyleDimension(frame, styleState(), theme, custom);
+
+    expect(getColorDimension).toHaveBeenCalledTimes(1);
+    expect(getScaledDimension).toHaveBeenCalledTimes(1);
+    expect(getScalarDimension).toHaveBeenCalledTimes(1);
+    expect(getTextDimension).not.toHaveBeenCalled();
+    expect(dims.text).toBeUndefined();
+  });
+
+  it.each([
+    { desc: 'fixed value', text: { fixed: 'hi' }, called: true },
+    { desc: 'field binding', text: { field: 'label' }, called: true },
+    { desc: 'neither field nor fixed', text: {}, called: false },
+  ])('includes a text dimension for a custom config only with a $desc', ({ text, called }) => {
+    const custom = { color: defaultStyleConfig.color, text } as unknown as StyleConfig;
+
+    getStyleDimension(frame, styleState(), theme, custom);
+
+    expect(getTextDimension).toHaveBeenCalledTimes(called ? 1 : 0);
+  });
+
+  it('builds only the dimensions flagged in style.fields when there is no custom config', () => {
+    getStyleDimension(frame, styleState({ color: true, rotation: true }), theme);
+
+    expect(getColorDimension).toHaveBeenCalledTimes(1);
+    expect(getScalarDimension).toHaveBeenCalledTimes(1);
+    expect(getScaledDimension).not.toHaveBeenCalled();
+    expect(getTextDimension).not.toHaveBeenCalled();
+  });
+
+  it('builds no dimensions when style.fields is undefined and there is no custom config', () => {
+    const dims = getStyleDimension(frame, styleState(undefined), theme);
+
+    expect(getColorDimension).not.toHaveBeenCalled();
+    expect(getScaledDimension).not.toHaveBeenCalled();
+    expect(getScalarDimension).not.toHaveBeenCalled();
+    expect(getTextDimension).not.toHaveBeenCalled();
+    expect(dims).toEqual({});
   });
 });

--- a/public/app/plugins/panel/geomap/utils/utils.test.ts
+++ b/public/app/plugins/panel/geomap/utils/utils.test.ts
@@ -8,7 +8,6 @@ import WebGLPointsLayer from 'ol/layer/WebGLPoints';
 import TileSource from 'ol/source/Tile';
 import VectorSource from 'ol/source/Vector';
 
-
 // Mock the config module to avoid undefined panels error
 jest.mock('@grafana/runtime', () => ({
   getTemplateSrv: jest.fn(),
@@ -33,7 +32,6 @@ jest.mock('app/plugins/datasource/grafana/datasource', () => ({
   getGrafanaDatasource: jest.fn(),
 }));
 
-
 import { createTheme } from '@grafana/data';
 import { getTemplateSrv } from '@grafana/runtime';
 import { getColorDimension } from 'app/features/dimensions/color';
@@ -45,13 +43,7 @@ import { type GeomapPanel } from '../GeomapPanel';
 import { defaultStyleConfig, type StyleConfig, type StyleConfigState } from '../style/types';
 import { type MapLayerState } from '../types';
 
-import {
-  hasVariableDependencies,
-  hasLayerData,
-  isSegmentVisible,
-  getNextLayerName,
-  getStyleDimension,
-} from './utils';
+import { hasVariableDependencies, hasLayerData, isSegmentVisible, getNextLayerName, getStyleDimension } from './utils';
 
 // Test fixtures
 const createTestFeature = () => new Feature(new Point([0, 0]));
@@ -299,7 +291,8 @@ describe('getStyleDimension', () => {
   });
 
   it('builds only the dimensions flagged in style.fields when there is no custom config', () => {
-    getStyleDimension(frame, styleState({ color: true, rotation: true }), theme);
+    // StyleConfigFields values are the driving field names (truthy strings), not booleans
+    getStyleDimension(frame, styleState({ color: 'metric', rotation: 'metric' }), theme);
 
     expect(getColorDimension).toHaveBeenCalledTimes(1);
     expect(getScalarDimension).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## What

Focused, unit-first test coverage for geomap/geo pure logic — the DataViz squad's
second-lowest-covered area. No product code changes.

**Core pure-logic paths:**

- **`frameAsGazetter`** (`features/geo/gazetteer/gazetteer.ts`) — previously only exercised
  transitively. Now covers lat/lng field detection including the real misspelled aliases
  `LATITUTE`/`LONGITUE` (`it.each`), geohash and existing-`Point` derivation, non-point →
  centroid via `point()`, key detection (`*_CODE`/`UID`/first-string fallback),
  case-insensitive lookup, and `count`/`examples`.
- **`getLayersOptions`** (`plugins/panel/geomap/layers/registry.ts`) — no test existed. Covers
  basemap vs overlay selection sets, `current` reporting, alpha gating on `hasAlphaPanels`
  (`(Alpha)` label + bolt icon + ordered last), and the intentional `beta` switch fall-through.
  Uses deterministic mocked layer barrels so the test asserts the selection logic itself and
  avoids loading real data layers (which pull `ol/source` → `geotiff`, untransformed under jest).
- **`esri` basemap `create()`** (`plugins/panel/geomap/layers/basemaps/esri.ts`) — mirrors the
  existing `carto.test.ts` idiom: service → ArcGIS slug URL (`it.each`), default fallback,
  custom-server passthrough, and the `TileLayer`/`XYZ` result shape.
- **`getStyleDimension`** (`plugins/panel/geomap/utils/utils.ts`) — custom-config vs
  `style.fields` branches, the `text.field || text.fixed` gate, and empty-when-unflagged,
  reusing the file's existing dimension-helper mocks.

**Stretch layer/marker paths:**

- **`lastPointTracker`** (`plugins/panel/geomap/layers/data/lastPointTracker.ts`) —
  `create().init()` returns a `VectorLayer` with a single feature; `update()` moves the point to
  the **last** row's coordinate (asserted via `getCenterPointWGS84`); an empty frame leaves the
  geometry untouched. Stubs the `ol/source` barrel (Vector only) to dodge the `geotiff` ESM gap.
- **`maplibre` basemap `init()`** (`plugins/panel/geomap/layers/basemaps/maplibre.ts`) — returns
  a `LayerGroup` whose opacity defaults to 1 and honors `options.opacity`, and fetches the default
  style URL when `config.url` is unset, otherwise the configured URL. Mocks `ol-mapbox-style`.
- **`getMarkerMaker` fallbacks** (`plugins/panel/geomap/style/markers.ts`) — the `hasTextLabel` →
  `textMarker` branch and the unknown-non-svg → `errorMarker` fallback (asserted via its two red
  `#F00` `RegularShape` styles).

## Why

Raises DataViz-owned coverage (`check-frontend-test-coverage.yml` gates the squad). Follows the
`panel-testing-strategy` skill: real `ol` as data constructors, concrete-value / exact-call
assertions, `it.each` for variants, one data-frame builder per file, no DOM snapshots. Each new
file was mutation-checked (breaking the asserted source value fails the test).

## Notes

- Test-only. Infra mocks match existing geomap conventions (`getTemplateSrv` for the XYZ layer;
  barrel / `ol-mapbox-style` / `ol/source` mocks for the jest ESM transform gap).
- Follow-up (not in this PR): geomap lacks the `scanForA11yViolations` E2E `@a11y` test the skill
  requires of every panel — its 3 Playwright specs are `@panels`-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
