### PR TITLE
Alerting: Return an error from state.Manager.ProcessEvalResults

### DIFF
--- a/pkg/services/ngalert/api/api_testing.go
+++ b/pkg/services/ngalert/api/api_testing.go
@@ -107,7 +107,7 @@ func (srv TestingApiSrv) RouteTestGrafanaRuleConfig(c *contextmodel.ReqContext, 
 	}
 	manager := state.NewManager(cfg, state.NewNoopPersister())
 	includeFolder := !srv.cfg.ReservedLabels.IsReservedLabelDisabled(models.FolderTitleLabel)
-	transitions := manager.ProcessEvalResults(
+	transitions, err := manager.ProcessEvalResults(
 		c.Req.Context(),
 		now,
 		rule,
@@ -115,6 +115,9 @@ func (srv TestingApiSrv) RouteTestGrafanaRuleConfig(c *contextmodel.ReqContext, 
 		state.GetRuleExtraLabels(log.New("testing"), rule, folder.Fullpath, includeFolder, srv.featureManager),
 		nil,
 	)
+	if err != nil {
+		return ErrResp(http.StatusInternalServerError, err, "Failed to process evaluation results")
+	}
 
 	alerts := make([]*amv2.PostableAlert, 0, len(transitions))
 	for _, alertState := range transitions {

--- a/pkg/services/ngalert/backtesting/engine.go
+++ b/pkg/services/ngalert/backtesting/engine.go
@@ -41,7 +41,7 @@ type backtestingEvaluator interface {
 }
 
 type stateManager interface {
-	ProcessEvalResults(context.Context, time.Time, *models.AlertRule, eval.Results, data.Labels, state.Sender) state.StateTransitions
+	ProcessEvalResults(context.Context, time.Time, *models.AlertRule, eval.Results, data.Labels, state.Sender) (state.StateTransitions, error)
 	schedule.RuleStateProvider
 }
 
@@ -183,7 +183,10 @@ func (e *Engine) Test(ctx context.Context, user identity.Requester, rule *models
 				builder.AddWarn(warn)
 			}
 		}
-		states := stateMgr.ProcessEvalResults(ruleCtx, currentTime, rule, results, extraLabels, nil)
+		states, err := stateMgr.ProcessEvalResults(ruleCtx, currentTime, rule, results, extraLabels, nil)
+		if err != nil {
+			return false, err
+		}
 		for _, s := range states {
 			if !historian.ShouldRecord(s) {
 				continue

--- a/pkg/services/ngalert/backtesting/engine_test.go
+++ b/pkg/services/ngalert/backtesting/engine_test.go
@@ -252,8 +252,8 @@ type fakeStateManager struct {
 	stateCallback func(now time.Time) []state.StateTransition
 }
 
-func (f *fakeStateManager) ProcessEvalResults(_ context.Context, evaluatedAt time.Time, _ *models.AlertRule, _ eval.Results, _ data.Labels, _ state.Sender) state.StateTransitions {
-	return f.stateCallback(evaluatedAt)
+func (f *fakeStateManager) ProcessEvalResults(_ context.Context, evaluatedAt time.Time, _ *models.AlertRule, _ eval.Results, _ data.Labels, _ state.Sender) (state.StateTransitions, error) {
+	return f.stateCallback(evaluatedAt), nil
 }
 
 func (f *fakeStateManager) GetStatesForRuleUID(_ context.Context, orgID int64, alertRuleUID string) []*state.State {

--- a/pkg/services/ngalert/evaluation_runner_test.go
+++ b/pkg/services/ngalert/evaluation_runner_test.go
@@ -211,7 +211,7 @@ func TestEvaluationRunner_PersisterIsActive(t *testing.T) {
 	rule := models.RuleGen.GenerateRef()
 	now := clk.Now()
 	results := eval.GenerateResults(1, eval.ResultGen(eval.WithEvaluatedAt(now)))
-	_ = h.ng.stateManager.ProcessEvalResults(h.ctx, now, rule, results, make(data.Labels), nil)
+	_, _ = h.ng.stateManager.ProcessEvalResults(h.ctx, now, rule, results, make(data.Labels), nil)
 
 	var saveCount int
 	for _, op := range fakeStore.RecordedOps() {

--- a/pkg/services/ngalert/schedule/alert_rule.go
+++ b/pkg/services/ngalert/schedule/alert_rule.go
@@ -473,7 +473,7 @@ func (a *alertRule) evaluate(ctx context.Context, e *Evaluation, span trace.Span
 		))
 	}
 	start = a.clock.Now()
-	_ = a.stateManager.ProcessEvalResults(
+	_, _ = a.stateManager.ProcessEvalResults(
 		ctx,
 		e.scheduledAt,
 		e.rule,

--- a/pkg/services/ngalert/schedule/alert_rule_test.go
+++ b/pkg/services/ngalert/schedule/alert_rule_test.go
@@ -731,7 +731,7 @@ func TestRuleRoutine(t *testing.T) {
 			sender := NewSyncAlertsSenderMock()
 			sch, _, _, _ := createSchedule(make(chan time.Time), sender, clock.NewMock())
 
-			_ = sch.stateManager.ProcessEvalResults(context.Background(), sch.clock.Now(), rule, genEvalResults(sch.clock.Now()), nil, nil)
+			_, _ = sch.stateManager.ProcessEvalResults(context.Background(), sch.clock.Now(), rule, genEvalResults(sch.clock.Now()), nil, nil)
 			expectedStates := sch.stateManager.GetStatesForRuleUID(context.Background(), rule.OrgID, rule.UID)
 			require.NotEmpty(t, expectedStates)
 
@@ -756,7 +756,7 @@ func TestRuleRoutine(t *testing.T) {
 			sender := NewSyncAlertsSenderMock()
 			sch, _, _, _ := createSchedule(make(chan time.Time), sender, clock.NewMock())
 
-			_ = sch.stateManager.ProcessEvalResults(context.Background(), sch.clock.Now(), rule, genEvalResults(sch.clock.Now()), nil, nil)
+			_, _ = sch.stateManager.ProcessEvalResults(context.Background(), sch.clock.Now(), rule, genEvalResults(sch.clock.Now()), nil, nil)
 			require.NotEmpty(t, sch.stateManager.GetStatesForRuleUID(context.Background(), rule.OrgID, rule.UID))
 
 			factory := ruleFactoryFromScheduler(sch)
@@ -780,7 +780,7 @@ func TestRuleRoutine(t *testing.T) {
 			sender.EXPECT().Send(mock.Anything, mock.Anything, mock.Anything).Times(1)
 			sch, _, _, _ := createSchedule(make(chan time.Time), sender, clock.NewMock())
 
-			_ = sch.stateManager.ProcessEvalResults(context.Background(), sch.clock.Now(), rule, genEvalResults(sch.clock.Now()), nil, nil)
+			_, _ = sch.stateManager.ProcessEvalResults(context.Background(), sch.clock.Now(), rule, genEvalResults(sch.clock.Now()), nil, nil)
 			require.NotEmpty(t, sch.stateManager.GetStatesForRuleUID(context.Background(), rule.OrgID, rule.UID))
 
 			factory := ruleFactoryFromScheduler(sch)

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -298,6 +298,7 @@ func (st *Manager) ResetStateByRuleUID(ctx context.Context, rule *ngModels.Alert
 // ProcessEvalResults updates the current states that belong to a rule with the evaluation results.
 // if extraLabels is not empty, those labels will be added to every state. The extraLabels take precedence over rule labels and result labels
 // This will update the states in cache/store and return the state transitions that need to be sent to the alertmanager.
+// A non-nil error means the results were not applied; the returned StateTransitions is nil in that case.
 func (st *Manager) ProcessEvalResults(
 	ctx context.Context,
 	evaluatedAt time.Time,
@@ -305,7 +306,7 @@ func (st *Manager) ProcessEvalResults(
 	results eval.Results,
 	extraLabels data.Labels,
 	send Sender,
-) StateTransitions {
+) (StateTransitions, error) {
 	utcTick := evaluatedAt.UTC().Format(time.RFC3339Nano)
 	ctx, span := st.tracer.Start(ctx, "alert rule state calculation", trace.WithAttributes(
 		attribute.String("rule_uid", alertRule.UID),
@@ -370,7 +371,7 @@ func (st *Manager) ProcessEvalResults(
 		send(ctx, statesToSend)
 	}
 
-	return allChanges
+	return allChanges, nil
 }
 
 // updateLastSentAt returns the subset StateTransitions that need sending and updates their LastSentAt field.

--- a/pkg/services/ngalert/state/manager_bench_test.go
+++ b/pkg/services/ngalert/state/manager_bench_test.go
@@ -46,7 +46,7 @@ func BenchmarkProcessEvalResults(b *testing.B) {
 	b.ResetTimer()
 
 	for range b.N {
-		ans = sut.ProcessEvalResults(context.Background(), now, &rule, results, labels, nil)
+		ans, _ = sut.ProcessEvalResults(context.Background(), now, &rule, results, labels, nil)
 	}
 
 	b.StopTimer()

--- a/pkg/services/ngalert/state/manager_private_test.go
+++ b/pkg/services/ngalert/state/manager_private_test.go
@@ -327,7 +327,7 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 			results := resultsAtTime[ts]
 			clk.Set(ts)
 			var statesToSend StateTransitions
-			actual := st.ProcessEvalResults(context.Background(), ts, alertRule, results, systemLabels, func(_ context.Context, states StateTransitions) {
+			actual, _ := st.ProcessEvalResults(context.Background(), ts, alertRule, results, systemLabels, func(_ context.Context, states StateTransitions) {
 				statesToSend = states
 			})
 
@@ -5575,7 +5575,7 @@ func TestProcessEvalResults_Screenshots(t *testing.T) {
 				for idx := range results {
 					results[idx].EvaluatedAt = tx
 				}
-				transitions := mgr.ProcessEvalResults(ctx, t1, &baseRule, results, nil, nil)
+				transitions, _ := mgr.ProcessEvalResults(ctx, t1, &baseRule, results, nil, nil)
 
 				for _, transition := range transitions {
 					assert.Equalf(t, tc.imageService.Image, transition.Image, "Transition %s does not have image but should", transition.Labels.String())

--- a/pkg/services/ngalert/state/manager_test.go
+++ b/pkg/services/ngalert/state/manager_test.go
@@ -338,7 +338,7 @@ func TestIntegrationDashboardAnnotations(t *testing.T) {
 	st.Warm(ctx, dbstore, dbstore, ng.InstanceStore)
 	bValue := float64(42)
 	cValue := float64(1)
-	_ = st.ProcessEvalResults(ctx, evaluationTime, rule, eval.Results{{
+	_, _ = st.ProcessEvalResults(ctx, evaluationTime, rule, eval.Results{{
 		Instance:    data.Labels{"instance_label": "testValue2"},
 		State:       eval.Alerting,
 		EvaluatedAt: evaluationTime,
@@ -402,7 +402,7 @@ func TestIntegrationProcessEvalResultsTemplatedLabelKeysAreNotExpanded(t *testin
 	})
 
 	st.Warm(ctx, dbstore, dbstore, ng.InstanceStore)
-	_ = st.ProcessEvalResults(ctx, evaluationTime, rule, eval.Results{{
+	_, _ = st.ProcessEvalResults(ctx, evaluationTime, rule, eval.Results{{
 		Instance:    data.Labels{"instance_label": "test-value"},
 		State:       eval.Alerting,
 		EvaluatedAt: evaluationTime,
@@ -1788,7 +1788,7 @@ func TestProcessEvalResults(t *testing.T) {
 					res[i].EvaluatedAt = evalTime
 				}
 				clk.Set(evalTime)
-				_ = st.ProcessEvalResults(context.Background(), evalTime, tc.alertRule, res, systemLabels, state.NoopSender)
+				_, _ = st.ProcessEvalResults(context.Background(), evalTime, tc.alertRule, res, systemLabels, state.NoopSender)
 				results += len(res)
 			}
 
@@ -1888,7 +1888,7 @@ func TestProcessEvalResults(t *testing.T) {
 			}),
 		)}
 
-		_ = st.ProcessEvalResults(context.Background(), time, rule, res, systemLabels, state.NoopSender)
+		_, _ = st.ProcessEvalResults(context.Background(), time, rule, res, systemLabels, state.NoopSender)
 
 		states := st.GetStatesForRuleUID(context.Background(), rule.OrgID, rule.UID)
 		require.Len(t, states, 1)
@@ -1918,7 +1918,7 @@ func TestProcessEvalResults(t *testing.T) {
 		now := clk.Now()
 		var results = eval.GenerateResults(rand.Intn(4)+1, eval.ResultGen(eval.WithEvaluatedAt(now)))
 
-		states := st.ProcessEvalResults(context.Background(), now, rule, results, make(data.Labels), nil)
+		states, _ := st.ProcessEvalResults(context.Background(), now, rule, results, make(data.Labels), nil)
 		require.NotEmpty(t, states)
 
 		savedStates := make(map[data.Fingerprint]models.AlertInstance)
@@ -2098,7 +2098,7 @@ func TestIntegrationStaleResultsHandler(t *testing.T) {
 					evalTime = re.EvaluatedAt
 				}
 			}
-			st.ProcessEvalResults(context.Background(), evalTime, rule, res, data.Labels{
+			_, _ = st.ProcessEvalResults(context.Background(), evalTime, rule, res, data.Labels{
 				"alertname":                    rule.Title,
 				"__alert_rule_namespace_uid__": rule.NamespaceUID,
 				"__alert_rule_uid__":           rule.UID,
@@ -2188,7 +2188,7 @@ func TestStaleResults(t *testing.T) {
 
 	// Init
 	var statesToSend state.StateTransitions
-	processed := st.ProcessEvalResults(ctx, clk.Now(), rule, initResults, nil, func(_ context.Context, states state.StateTransitions) {
+	processed, _ := st.ProcessEvalResults(ctx, clk.Now(), rule, initResults, nil, func(_ context.Context, states state.StateTransitions) {
 		statesToSend = states
 	})
 	checkExpectedStateTransitions(t, processed, initStates)
@@ -2210,7 +2210,7 @@ func TestStaleResults(t *testing.T) {
 
 	var expectedStaleKeys []models.AlertInstanceKey
 	t.Run("should mark missing states as stale", func(t *testing.T) {
-		processed = st.ProcessEvalResults(ctx, clk.Now(), rule, results, nil, nil)
+		processed, _ = st.ProcessEvalResults(ctx, clk.Now(), rule, results, nil, nil)
 		checkExpectedStateTransitions(t, processed, initStates)
 		for _, s := range processed {
 			if s.CacheID == state1 {
@@ -2795,7 +2795,7 @@ func TestStateManager_HistorianIntegration(t *testing.T) {
 				// Clear historian state transitions before the evaluation
 				historian.StateTransitions = nil
 
-				mgr.ProcessEvalResults(
+				_, _ = mgr.ProcessEvalResults(
 					context.Background(),
 					evalTime,
 					scenario.rule,


### PR DESCRIPTION
## What is this PR

Changes `state.Manager.ProcessEvalResults` to return `(StateTransitions, error)` instead of just `StateTransitions`. This is a mechanical, behavior-preserving signature change — the method always returns a `nil` error today. All call sites (production and tests) are updated accordingly.

## Why

Groundwork for #22293 / grafana-ruler's state-cache readiness gate: a follow-up change (stacked on this one) will have `ProcessEvalResults` return an error when the state cache isn't warmed yet, instead of relying on a separate pre-check in the scheduler. Landing the signature change on its own keeps that behavioral change reviewable in isolation.

## Test plan
- [x] `go build ./...`
- [x] `go test ./pkg/services/ngalert/...`
- [x] `golangci-lint run ./pkg/services/ngalert/...` (pre-existing unrelated staticcheck finding in `remote/compat.go` left untouched)