### PR TITLE
[POC] LibraryPanels: Register unified storage data migration

### DIFF
--- a/pkg/registry/apis/dashboard/libary_panel.go
+++ b/pkg/registry/apis/dashboard/libary_panel.go
@@ -2,6 +2,7 @@ package dashboard
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 
@@ -15,7 +16,10 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/registry/apis/dashboard/legacy"
 	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
+	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/libraryelements"
+	"github.com/grafana/grafana/pkg/services/libraryelements/model"
 )
 
 var (
@@ -57,6 +61,37 @@ func (s *LibraryPanelStore) ConvertToTable(ctx context.Context, object runtime.O
 	return s.ResourceInfo.TableConverter().ConvertToTable(ctx, object, tableOptions)
 }
 
+// translateLegacyError maps library element service errors onto k8s status errors
+// so that API clients (and the legacy /api wrapper handlers) can react to the
+// failure reason instead of receiving an opaque 500.
+func (s *LibraryPanelStore) translateLegacyError(name string, err error) error {
+	if err == nil {
+		return nil
+	}
+	gr := s.ResourceInfo.GroupResource()
+	switch {
+	case errors.Is(err, model.ErrLibraryElementNotFound):
+		return s.ResourceInfo.NewNotFound(name)
+	case errors.Is(err, model.ErrLibraryElementAlreadyExists):
+		return apierrors.NewAlreadyExists(gr, name)
+	// the legacy API reports both as 409 Conflict; the /api wrapper distinguishes
+	// them by message to keep returning 412 for version mismatches
+	case errors.Is(err, model.ErrLibraryElementVersionMismatch),
+		errors.Is(err, model.ErrLibraryElementProvisionedFolder):
+		return apierrors.NewConflict(gr, name, err)
+	case errors.Is(err, model.ErrLibraryElementHasConnections),
+		errors.Is(err, model.ErrLibraryElementInsufficientPermissions),
+		errors.Is(err, folder.ErrAccessDenied):
+		return apierrors.NewForbidden(gr, name, err)
+	case errors.Is(err, model.ErrLibraryElementInvalidUID),
+		errors.Is(err, model.ErrLibraryElementUIDTooLong),
+		errors.Is(err, model.ErrLibraryElementUnSupportedElementKind),
+		errors.Is(err, dashboards.ErrFolderNotFound):
+		return apierrors.NewBadRequest(err.Error())
+	}
+	return err
+}
+
 func (s *LibraryPanelStore) Create(ctx context.Context, obj runtime.Object, createValidation rest.ValidateObjectFunc, options *metav1.CreateOptions) (runtime.Object, error) {
 	user, err := identity.GetRequester(ctx)
 	if err != nil {
@@ -64,13 +99,13 @@ func (s *LibraryPanelStore) Create(ctx context.Context, obj runtime.Object, crea
 	}
 	cmd, err := libraryelements.ToCreateLibraryElementCommand(obj)
 	if err != nil {
-		return nil, err
+		return nil, apierrors.NewBadRequest(err.Error())
 	}
 
 	// NOTE: this includes all access control checks
 	out, err := s.service.CreateElement(ctx, user, *cmd)
 	if err != nil {
-		return nil, err
+		return nil, s.translateLegacyError(cmd.UID, err)
 	}
 	if out.UID == "" {
 		return nil, fmt.Errorf("created library panel has empty UID")
@@ -96,12 +131,12 @@ func (s *LibraryPanelStore) Update(ctx context.Context, name string, objInfo res
 
 	cmd, err := libraryelements.ToPatchLibraryElementCommand(obj)
 	if err != nil {
-		return nil, false, err
+		return nil, false, apierrors.NewBadRequest(err.Error())
 	}
 
 	out, err := s.service.PatchLibraryElement(ctx, user, *cmd, name)
 	if err != nil {
-		return nil, false, err
+		return nil, false, s.translateLegacyError(name, err)
 	}
 	if out.UID == "" {
 		return nil, false, fmt.Errorf("created library panel has empty UID")
@@ -119,7 +154,7 @@ func (s *LibraryPanelStore) Delete(ctx context.Context, name string, deleteValid
 	// NOTE: this includes all access control checks
 	_, err = s.service.DeleteLibraryElement(ctx, user, name)
 	if err != nil {
-		return nil, false, err
+		return nil, false, s.translateLegacyError(name, err)
 	}
 	return nil, true, nil
 }

--- a/pkg/registry/apis/dashboard/librarypanels_migration_registrar.go
+++ b/pkg/registry/apis/dashboard/librarypanels_migration_registrar.go
@@ -1,0 +1,39 @@
+package dashboard
+
+import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	dashV0 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v0alpha1"
+	"github.com/grafana/grafana/pkg/registry/apis/dashboard/migrator"
+	"github.com/grafana/grafana/pkg/storage/unified/migrations"
+)
+
+func LibraryPanelsMigration(migrator migrator.LibraryPanelsMigrator) migrations.MigrationDefinition {
+	libraryPanelGR := schema.GroupResource{
+		Group:    dashV0.GROUP,
+		Resource: dashV0.LIBRARY_PANEL_RESOURCE,
+	}
+
+	return migrations.MigrationDefinition{
+		ID:          "librarypanels",
+		MigrationID: "librarypanels migration",
+		Resources: []migrations.ResourceInfo{
+			{
+				GroupResource: libraryPanelGR,
+				LockTables:    []string{"library_element"},
+				FloorVersion:  dashV0.VERSION,
+			},
+		},
+		Migrators: map[schema.GroupResource]migrations.MigratorFunc{
+			libraryPanelGR: migrator.MigrateLibraryPanels,
+		},
+		Validators: []migrations.ValidatorFactory{
+			migrations.CountValidation(libraryPanelGR, migrations.CountValidationOptions{
+				Table: "library_element",
+				Where: "org_id = ?",
+			}),
+		},
+		// The library_element table is still read by the legacy service in dual-write modes
+		RenameTables: []string{},
+	}
+}

--- a/pkg/registry/apis/dashboard/migrator/migrator.go
+++ b/pkg/registry/apis/dashboard/migrator/migrator.go
@@ -13,7 +13,11 @@ type FoldersDashboardsMigrator interface {
 	MigrateFolders(ctx context.Context, orgId int64, opts migrations.MigrateOptions, stream resourcepb.BulkStore_BulkProcessClient) error
 }
 
-// foldersDashboardsMigrator handles migrating dashboards, folders, and library panels
+type LibraryPanelsMigrator interface {
+	MigrateLibraryPanels(ctx context.Context, orgId int64, opts migrations.MigrateOptions, stream resourcepb.BulkStore_BulkProcessClient) error
+}
+
+// foldersDashboardsMigrator handles migrating dashboards and folders
 // from legacy SQL storage.
 type foldersDashboardsMigrator struct {
 	migrator legacy.Migrator
@@ -40,8 +44,22 @@ func (m *foldersDashboardsMigrator) MigrateFolders(ctx context.Context, orgId in
 	return m.migrator.MigrateFolders(ctx, orgId, opts, stream)
 }
 
+// libraryPanelsMigrator handles migrating library panels from legacy SQL storage.
+type libraryPanelsMigrator struct {
+	migrator legacy.Migrator
+}
+
+// ProvideLibraryPanelsMigrator creates a libraryPanelsMigrator for use in wire DI.
+func ProvideLibraryPanelsMigrator(
+	migrator legacy.Migrator,
+) LibraryPanelsMigrator {
+	return &libraryPanelsMigrator{
+		migrator: migrator,
+	}
+}
+
 // MigrateLibraryPanels reads library panels from legacy SQL storage and streams them
 // to the unified storage bulk process API.
-func (m *foldersDashboardsMigrator) MigrateLibraryPanels(ctx context.Context, orgId int64, opts migrations.MigrateOptions, stream resourcepb.BulkStore_BulkProcessClient) error {
+func (m *libraryPanelsMigrator) MigrateLibraryPanels(ctx context.Context, orgId int64, opts migrations.MigrateOptions, stream resourcepb.BulkStore_BulkProcessClient) error {
 	return m.migrator.MigrateLibraryPanels(ctx, orgId, opts, stream)
 }

--- a/pkg/registry/apis/dashboard/register.go
+++ b/pkg/registry/apis/dashboard/register.go
@@ -125,7 +125,6 @@ type DashboardsAPIBuilder struct {
 	dualWriter               dualwrite.Service
 	folderClientProvider     client.K8sHandlerProvider
 	libraryPanels            libraryelements.Service // for legacy library panels
-	libraryPanelsEnabled     bool
 	publicDashboardService   publicdashboards.Service
 	snapshotService          dashboardsnapshots.Service
 	snapshotOptions          dashv0.SnapshotSharingOptions
@@ -202,7 +201,6 @@ func RegisterAPIService(
 		dashboardK8sClient:       dashboardClient,
 		folderClientProvider:     newSimpleClientProvider(folderClient),
 		libraryPanels:            libraryPanels,
-		libraryPanelsEnabled:     features.IsEnabledGlobally(featuremgmt.FlagGrafanaAPIServerWithExperimentalAPIs), // nolint:staticcheck
 		publicDashboardService:   publicDashboardService,
 		snapshotService:          snapshotService,
 		snapshotOptions:          snapshotOptions,
@@ -855,14 +853,11 @@ func (b *DashboardsAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver
 	// EnableFolderSupport=false and any folder-scoped write (e.g. provisioning syncing a panel
 	// into a managed folder) is rejected with "folders are not supported". The folder is
 	// optional (panels may live at the root), so RequireFolder stays false.
-	//nolint:staticcheck // not yet migrated to OpenFeature
-	if b.libraryPanelsEnabled {
-		opts.StorageOptsRegister(dashv0.LibraryPanelResourceInfo.GroupResource(), apistore.StorageOptions{
-			Scheme:              opts.Scheme,
-			Index:               b.unified,
-			EnableFolderSupport: true,
-		})
-	}
+	opts.StorageOptsRegister(dashv0.LibraryPanelResourceInfo.GroupResource(), apistore.StorageOptions{
+		Scheme:              opts.Scheme,
+		Index:               b.unified,
+		EnableFolderSupport: true,
+	})
 
 	// v0alpha1
 	if err := b.storageForVersion(apiGroupInfo, opts,
@@ -1050,6 +1045,15 @@ func (b *DashboardsAPIBuilder) storageForVersion(
 			return err
 		}
 
+		// Standalone mode has no legacy SQL, so library panels are served from
+		// unified storage directly (no dual writer).
+		if libraryPanels != nil {
+			storage[libraryPanels.StoragePath()], err = grafanaregistry.NewRegistryStore(opts.Scheme, *libraryPanels, opts.OptsGetter)
+			if err != nil {
+				return err
+			}
+		}
+
 		return nil
 	}
 
@@ -1074,9 +1078,8 @@ func (b *DashboardsAPIBuilder) storageForVersion(
 		return err
 	}
 
-	// Expose read library panels
-	//nolint:staticcheck // not yet migrated to OpenFeature
-	if libraryPanels != nil && b.libraryPanelsEnabled {
+	// Library panels - only v0alpha1
+	if libraryPanels != nil {
 		legacyLibraryStore := &LibraryPanelStore{
 			Access:       b.legacy,
 			ResourceInfo: *libraryPanels,

--- a/pkg/server/bootstrap/wire/sets.go
+++ b/pkg/server/bootstrap/wire/sets.go
@@ -226,6 +226,7 @@ var Basic = wire.NewSet(
 	provisioning.ProvideStubProvisioningService,
 	dashboardlegacy.ProvideMigrator,
 	dashboardmigrator.ProvideFoldersDashboardsMigrator,
+	dashboardmigrator.ProvideLibraryPanelsMigrator,
 	playlistmigrator.ProvidePlaylistMigrator,
 	querycachingmigrator.ProvideQueryCacheConfigMigrator,
 	shorturlmigrator.ProvideShortURLMigrator,

--- a/pkg/server/bootstrap/wire/wire_gen.go
+++ b/pkg/server/bootstrap/wire/wire_gen.go
@@ -583,6 +583,7 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts server.Options, apiO
 	}
 	legacyMigrator := legacy.ProvideMigrator(legacyDatabaseProvider, stubProvisioningService, accessControl)
 	foldersDashboardsMigrator := migrator2.ProvideFoldersDashboardsMigrator(legacyMigrator)
+	libraryPanelsMigrator := migrator2.ProvideLibraryPanelsMigrator(legacyMigrator)
 	playlistMigrator := playlist.ProvidePlaylistMigrator(legacyDatabaseProvider)
 	shortURLMigrator := migrator3.ProvideShortURLMigrator(legacyDatabaseProvider)
 	snapshotMigrator := migrator4.ProvideSnapshotMigrator(legacyDatabaseProvider, secretsService)
@@ -620,7 +621,7 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts server.Options, apiO
 	starsMigrator := legacy2.ProvideStarsMigrator(legacyDatabaseProvider)
 	preferencesMigrator := legacy3.ProvidePreferencesMigrator(legacyDatabaseProvider)
 	queryCacheConfigMigrator := migrator6.ProvideQueryCacheConfigMigrator(legacyDatabaseProvider)
-	migrationRegistry := server.ProvideMigrationRegistry(foldersDashboardsMigrator, playlistMigrator, shortURLMigrator, snapshotMigrator, dataSourceMigrator, starsMigrator, preferencesMigrator, queryCacheConfigMigrator)
+	migrationRegistry := server.ProvideMigrationRegistry(foldersDashboardsMigrator, libraryPanelsMigrator, playlistMigrator, shortURLMigrator, snapshotMigrator, dataSourceMigrator, starsMigrator, preferencesMigrator, queryCacheConfigMigrator)
 	unifiedMigrator := migrations2.ProvideUnifiedMigrator(resourceClient, migrationRegistry)
 	unifiedStorageMigrationService := migrations2.ProvideUnifiedStorageMigrationService(unifiedMigrator, legacyDatabaseProvider, cfg, sqlStore, kvStore, resourceClient, migrationRegistry, gcGate)
 	migrationStatusReader, err := migrations2.ProvideMigrationStatusReader(sqlStore, cfg, migrationRegistry, registerer)
@@ -1341,6 +1342,7 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 	}
 	legacyMigrator := legacy.ProvideMigrator(legacyDatabaseProvider, stubProvisioningService, accessControl)
 	foldersDashboardsMigrator := migrator2.ProvideFoldersDashboardsMigrator(legacyMigrator)
+	libraryPanelsMigrator := migrator2.ProvideLibraryPanelsMigrator(legacyMigrator)
 	playlistMigrator := playlist.ProvidePlaylistMigrator(legacyDatabaseProvider)
 	shortURLMigrator := migrator3.ProvideShortURLMigrator(legacyDatabaseProvider)
 	snapshotMigrator := migrator4.ProvideSnapshotMigrator(legacyDatabaseProvider, secretsService)
@@ -1367,7 +1369,7 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 	starsMigrator := legacy2.ProvideStarsMigrator(legacyDatabaseProvider)
 	preferencesMigrator := legacy3.ProvidePreferencesMigrator(legacyDatabaseProvider)
 	queryCacheConfigMigrator := migrator6.ProvideQueryCacheConfigMigrator(legacyDatabaseProvider)
-	migrationRegistry := server.ProvideMigrationRegistry(foldersDashboardsMigrator, playlistMigrator, shortURLMigrator, snapshotMigrator, dataSourceMigrator, starsMigrator, preferencesMigrator, queryCacheConfigMigrator)
+	migrationRegistry := server.ProvideMigrationRegistry(foldersDashboardsMigrator, libraryPanelsMigrator, playlistMigrator, shortURLMigrator, snapshotMigrator, dataSourceMigrator, starsMigrator, preferencesMigrator, queryCacheConfigMigrator)
 	unifiedMigrator := migrations2.ProvideUnifiedMigrator(resourceClient, migrationRegistry)
 	unifiedStorageMigrationService := migrations2.ProvideUnifiedStorageMigrationService(unifiedMigrator, legacyDatabaseProvider, cfg, sqlStore, kvStore, resourceClient, migrationRegistry, gcGate)
 	migrationStatusReader, err := migrations2.ProvideMigrationStatusReader(sqlStore, cfg, migrationRegistry, registerer)

--- a/pkg/server/wire_core.go
+++ b/pkg/server/wire_core.go
@@ -225,6 +225,7 @@ var wireBasicSet = wire.NewSet(
 	provisioning.ProvideStubProvisioningService,
 	dashboardlegacy.ProvideMigrator,
 	dashboardmigrator.ProvideFoldersDashboardsMigrator,
+	dashboardmigrator.ProvideLibraryPanelsMigrator,
 	playlistmigrator.ProvidePlaylistMigrator,
 	querycachingmigrator.ProvideQueryCacheConfigMigrator,
 	shorturlmigrator.ProvideShortURLMigrator,

--- a/pkg/server/wire_helpers.go
+++ b/pkg/server/wire_helpers.go
@@ -32,6 +32,7 @@ func OtelTracer() trace.Tracer {
 // the registry here.
 func ProvideMigrationRegistry(
 	dashMigrator dashboardmigrator.FoldersDashboardsMigrator,
+	libraryPanelsMigrator dashboardmigrator.LibraryPanelsMigrator,
 	playlistMigrator playlistmigrator.PlaylistMigrator,
 	shortURLMigrator shorturlmigrator.ShortURLMigrator,
 	snapshotMigrator snapshotmigrator.SnapshotMigrator,
@@ -42,6 +43,7 @@ func ProvideMigrationRegistry(
 ) *unifiedmigrations.MigrationRegistry {
 	r := unifiedmigrations.NewMigrationRegistry()
 	r.Register(dashboardmigration.FoldersDashboardsMigration(dashMigrator))
+	r.Register(dashboardmigration.LibraryPanelsMigration(libraryPanelsMigrator))
 	r.Register(playlistmigration.PlaylistMigration(playlistMigrator))
 	r.Register(shorturlmigration.ShortURLMigration(shortURLMigrator))
 	r.Register(snapshotmigration.SnapshotMigration(snapshotMigrator))

--- a/pkg/services/libraryelements/api.go
+++ b/pkg/services/libraryelements/api.go
@@ -1,11 +1,16 @@
 package libraryelements
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"hash/fnv"
 	"net/http"
+	"slices"
+	gosort "sort"
+	"strconv"
+	"strings"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,6 +22,7 @@ import (
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/api/routing"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/infra/metrics"
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
@@ -28,8 +34,10 @@ import (
 	foldermodel "github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/libraryelements/model"
 	"github.com/grafana/grafana/pkg/services/org"
+	"github.com/grafana/grafana/pkg/services/search/sort"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/util"
 	"github.com/grafana/grafana/pkg/util/errhttp"
 	"github.com/grafana/grafana/pkg/web"
 	"github.com/open-feature/go-sdk/openfeature"
@@ -40,14 +48,21 @@ func (l *LibraryElementService) registerAPIEndpoints() {
 
 	l.RouteRegister.Group("/api/library-elements", func(entities routing.RouteRegister) {
 		uidScope := ScopeLibraryPanelsProvider.GetResourceScopeUID(ac.Parameter(":uid"))
-		entities.Post("/", authorize(ac.EvalPermission(ActionLibraryPanelsCreate)), routing.Wrap(l.createHandler))                 // TODO: add wrapper for k8s
-		entities.Delete("/:uid", authorize(ac.EvalPermission(ActionLibraryPanelsDelete, uidScope)), routing.Wrap(l.deleteHandler)) // TODO: add wrapper for k8s
-		entities.Get("/", authorize(ac.EvalPermission(ActionLibraryPanelsRead)), routing.Wrap(l.getAllHandler))                    // TODO: add wrapper for k8s - requires search
+		entities.Post("/", authorize(ac.EvalPermission(ActionLibraryPanelsCreate)), routing.Wrap(l.createHandler))
+		entities.Delete("/:uid", authorize(ac.EvalPermission(ActionLibraryPanelsDelete, uidScope)), routing.Wrap(l.deleteHandler))
+		entities.Get("/", authorize(ac.EvalPermission(ActionLibraryPanelsRead)), routing.Wrap(l.getAllHandler))
 		entities.Get("/:uid", authorize(ac.EvalPermission(ActionLibraryPanelsRead)), routing.Wrap(l.getHandler))
 		entities.Get("/:uid/connections/", authorize(ac.EvalPermission(ActionLibraryPanelsRead, uidScope)), routing.Wrap(l.getConnectionsHandler))
-		entities.Get("/name/:name", authorize(ac.EvalPermission(ActionLibraryPanelsRead)), routing.Wrap(l.getByNameHandler))    // TODO: add wrapper for k8s - requires search
-		entities.Patch("/:uid", authorize(ac.EvalPermission(ActionLibraryPanelsWrite, uidScope)), routing.Wrap(l.patchHandler)) // TODO: add wrapper for k8s
+		entities.Get("/name/:name", authorize(ac.EvalPermission(ActionLibraryPanelsRead)), routing.Wrap(l.getByNameHandler))
+		entities.Patch("/:uid", authorize(ac.EvalPermission(ActionLibraryPanelsWrite, uidScope)), routing.Wrap(l.patchHandler))
 	})
+}
+
+// useKubernetesLibraryPanels reports whether legacy /api/library-elements requests
+// should be served by the k8s /apis endpoints. Evaluated per request so cloud can
+// flip the flag per tenant without a restart.
+func useKubernetesLibraryPanels(ctx context.Context) bool {
+	return openfeature.NewDefaultClient().Boolean(ctx, featuremgmt.FlagLibraryelementsKubernetesLibraryPanels, false, openfeature.TransactionContext(ctx))
 }
 
 // swagger:route POST /library-elements library_elements createLibraryElement
@@ -64,6 +79,11 @@ func (l *LibraryElementService) registerAPIEndpoints() {
 // 404: notFoundError
 // 500: internalServerError
 func (l *LibraryElementService) createHandler(c *contextmodel.ReqContext) response.Response {
+	if useKubernetesLibraryPanels(c.Req.Context()) {
+		l.k8sHandler.createK8sLibraryElement(c)
+		return nil // already handled in the k8s handler
+	}
+
 	cmd := model.CreateLibraryElementCommand{}
 	if err := web.Bind(c.Req, &cmd); err != nil {
 		return response.Error(http.StatusBadRequest, "bad request data", err)
@@ -124,6 +144,11 @@ func (l *LibraryElementService) createHandler(c *contextmodel.ReqContext) respon
 // 404: notFoundError
 // 500: internalServerError
 func (l *LibraryElementService) deleteHandler(c *contextmodel.ReqContext) response.Response {
+	if useKubernetesLibraryPanels(c.Req.Context()) {
+		l.k8sHandler.deleteK8sLibraryElement(c)
+		return nil // already handled in the k8s handler
+	}
+
 	id, err := l.DeleteLibraryElement(c.Req.Context(), c.SignedInUser, web.Params(c.Req)[":uid"])
 	if err != nil {
 		return l.toLibraryElementError(err, "Failed to delete library element")
@@ -149,8 +174,7 @@ func (l *LibraryElementService) deleteHandler(c *contextmodel.ReqContext) respon
 // 500: internalServerError
 func (l *LibraryElementService) getHandler(c *contextmodel.ReqContext) response.Response {
 	ctx := c.Req.Context()
-	shouldUseKubeApi := openfeature.NewDefaultClient().Boolean(ctx, featuremgmt.FlagLibraryelementsKubernetesLibraryPanels, false, openfeature.TransactionContext(ctx))
-	if shouldUseKubeApi {
+	if useKubernetesLibraryPanels(ctx) {
 		l.k8sHandler.getK8sLibraryElement(c)
 		return nil // already handled in the k8s handler
 	}
@@ -200,6 +224,11 @@ func (l *LibraryElementService) getAllHandler(c *contextmodel.ReqContext) respon
 		FolderFilter:     c.Query("folderFilter"),
 		FolderFilterUIDs: c.Query("folderFilterUIDs"),
 	}
+
+	if useKubernetesLibraryPanels(c.Req.Context()) {
+		l.k8sHandler.getAllK8sLibraryElements(c, query)
+		return nil // already handled in the k8s handler
+	}
 	// Add cache entry to context for enabling folder tree caching
 	c.Req = c.Req.WithContext(withCache(c.Req.Context()))
 	elementsResult, err := l.getAllLibraryElements(c.Req.Context(), c.SignedInUser, query)
@@ -231,6 +260,11 @@ func (l *LibraryElementService) getAllHandler(c *contextmodel.ReqContext) respon
 // 412: preconditionFailedError
 // 500: internalServerError
 func (l *LibraryElementService) patchHandler(c *contextmodel.ReqContext) response.Response {
+	if useKubernetesLibraryPanels(c.Req.Context()) {
+		l.k8sHandler.patchK8sLibraryElement(c)
+		return nil // already handled in the k8s handler
+	}
+
 	cmd := model.PatchLibraryElementCommand{}
 	if err := web.Bind(c.Req, &cmd); err != nil {
 		return response.Error(http.StatusBadRequest, "bad request data", err)
@@ -294,11 +328,21 @@ func (l *LibraryElementService) getConnectionsHandler(c *contextmodel.ReqContext
 	libraryPanelUID := web.Params(c.Req)[":uid"]
 
 	// make sure the library element exists
-	element, err := l.getLibraryElementByUid(c.Req.Context(), c.SignedInUser, model.GetLibraryElementCommand{
-		UID: libraryPanelUID,
-	}, nil)
-	if err != nil {
-		return l.toLibraryElementError(err, "Failed to get library element")
+	var element model.LibraryElementDTO
+	if useKubernetesLibraryPanels(c.Req.Context()) {
+		dto, ok := l.k8sHandler.fetchK8sLibraryElementDTO(c, libraryPanelUID)
+		if !ok {
+			return nil // error already handled in the k8s handler
+		}
+		element = *dto
+	} else {
+		legacyElement, err := l.getLibraryElementByUid(c.Req.Context(), c.SignedInUser, model.GetLibraryElementCommand{
+			UID: libraryPanelUID,
+		}, nil)
+		if err != nil {
+			return l.toLibraryElementError(err, "Failed to get library element")
+		}
+		element = legacyElement
 	}
 
 	// now get all dashboards connected to this library element
@@ -359,6 +403,11 @@ func (l *LibraryElementService) getConnectionsHandler(c *contextmodel.ReqContext
 // 404: notFoundError
 // 500: internalServerError
 func (l *LibraryElementService) getByNameHandler(c *contextmodel.ReqContext) response.Response {
+	if useKubernetesLibraryPanels(c.Req.Context()) {
+		l.k8sHandler.getByNameK8sLibraryElement(c)
+		return nil // already handled in the k8s handler
+	}
+
 	elements, err := l.getLibraryElementsByName(c.Req.Context(), c.SignedInUser, web.Params(c.Req)[":name"])
 	if err != nil {
 		return l.toLibraryElementError(err, "Failed to get library element")
@@ -592,17 +641,68 @@ func newLibraryElementsK8sHandler(cfg *setting.Cfg, clientConfigProvider grafana
 }
 
 func (lk8s *libraryElementsK8sHandler) getK8sLibraryElement(c *contextmodel.ReqContext) {
+	uid := web.Params(c.Req)[":uid"]
+	dto, ok := lk8s.fetchK8sLibraryElementDTO(c, uid)
+	if !ok {
+		return
+	}
+	c.JSON(http.StatusOK, model.LibraryElementResponse{Result: *dto})
+}
+
+// fetchK8sLibraryElementDTO gets a library panel from the k8s API and converts it to
+// the legacy DTO. On failure the error response has already been written and ok is false.
+func (lk8s *libraryElementsK8sHandler) fetchK8sLibraryElementDTO(c *contextmodel.ReqContext, uid string) (*model.LibraryElementDTO, bool) {
+	client, ok := lk8s.getClient(c)
+	if !ok {
+		return nil, false
+	}
+	out, err := client.Get(c.Req.Context(), uid, v1.GetOptions{})
+	if err != nil {
+		lk8s.writeError(c, err)
+		return nil, false
+	}
+
+	dto, err := lk8s.unstructuredToLegacyLibraryPanelDTO(c, *out)
+	if err != nil {
+		c.JsonApiErr(http.StatusInternalServerError, "conversion error", err)
+		return nil, false
+	}
+	return dto, true
+}
+
+func (lk8s *libraryElementsK8sHandler) createK8sLibraryElement(c *contextmodel.ReqContext) {
+	cmd := model.CreateLibraryElementCommand{}
+	if err := web.Bind(c.Req, &cmd); err != nil {
+		c.JsonApiErr(http.StatusBadRequest, "bad request data", err)
+		return
+	}
+	if model.LibraryElementKind(cmd.Kind) != model.PanelElement {
+		c.JsonApiErr(http.StatusBadRequest, model.ErrLibraryElementUnSupportedElementKind.Error(), nil)
+		return
+	}
 	client, ok := lk8s.getClient(c)
 	if !ok {
 		return
 	}
-	uid := web.Params(c.Req)[":uid"]
-	out, err := client.Get(c.Req.Context(), uid, v1.GetOptions{})
+
+	uid := cmd.UID
+	if uid == "" {
+		uid = util.GenerateShortUID()
+	}
+	folderUID := ""
+	if cmd.FolderUID != nil {
+		folderUID = *cmd.FolderUID
+	}
+	obj, err := legacyLibraryPanelToUnstructured(uid, cmd.Name, folderUID, 0, cmd.Model)
+	if err != nil {
+		c.JsonApiErr(http.StatusBadRequest, "invalid library element model", err)
+		return
+	}
+	out, err := client.Create(c.Req.Context(), obj, v1.CreateOptions{})
 	if err != nil {
 		lk8s.writeError(c, err)
 		return
 	}
-
 	dto, err := lk8s.unstructuredToLegacyLibraryPanelDTO(c, *out)
 	if err != nil {
 		c.JsonApiErr(http.StatusInternalServerError, "conversion error", err)
@@ -611,54 +711,438 @@ func (lk8s *libraryElementsK8sHandler) getK8sLibraryElement(c *contextmodel.ReqC
 	c.JSON(http.StatusOK, model.LibraryElementResponse{Result: *dto})
 }
 
+func (lk8s *libraryElementsK8sHandler) patchK8sLibraryElement(c *contextmodel.ReqContext) {
+	cmd := model.PatchLibraryElementCommand{}
+	if err := web.Bind(c.Req, &cmd); err != nil {
+		c.JsonApiErr(http.StatusBadRequest, "bad request data", err)
+		return
+	}
+	if model.LibraryElementKind(cmd.Kind) != model.PanelElement {
+		c.JsonApiErr(http.StatusBadRequest, model.ErrLibraryElementUnSupportedElementKind.Error(), nil)
+		return
+	}
+	uid := web.Params(c.Req)[":uid"]
+	// renames are delete+create in k8s and are not supported through this wrapper
+	if cmd.UID != "" && cmd.UID != uid {
+		c.JsonApiErr(http.StatusBadRequest, "changing the uid of a library element is not supported", nil)
+		return
+	}
+	client, ok := lk8s.getClient(c)
+	if !ok {
+		return
+	}
+
+	existing, err := client.Get(c.Req.Context(), uid, v1.GetOptions{})
+	if err != nil {
+		lk8s.writeError(c, err)
+		return
+	}
+	existingPanel, err := unstructuredToLibraryPanel(existing)
+	if err != nil {
+		c.JsonApiErr(http.StatusInternalServerError, "conversion error", err)
+		return
+	}
+
+	// legacy PATCH semantics: name, model, and folderUid all keep their current
+	// value when they are absent from the request
+	name := cmd.Name
+	if name == "" {
+		name = existingPanel.Spec.Title
+	}
+	modelJSON := cmd.Model
+	if modelJSON == nil {
+		modelJSON, err = LibraryPanelToLegacyModel(existingPanel)
+		if err != nil {
+			c.JsonApiErr(http.StatusInternalServerError, "conversion error", err)
+			return
+		}
+	}
+	folderUID := existing.GetAnnotations()[utils.AnnoKeyFolder]
+	if cmd.FolderUID != nil {
+		folderUID = *cmd.FolderUID
+	}
+
+	// cmd.Version travels via metadata.generation and carries the legacy
+	// optimistic-concurrency check through the k8s update path
+	obj, err := legacyLibraryPanelToUnstructured(uid, name, folderUID, cmd.Version, modelJSON)
+	if err != nil {
+		c.JsonApiErr(http.StatusBadRequest, "invalid library element model", err)
+		return
+	}
+	out, err := client.Update(c.Req.Context(), obj, v1.UpdateOptions{})
+	if err != nil {
+		lk8s.writeError(c, err)
+		return
+	}
+	dto, err := lk8s.unstructuredToLegacyLibraryPanelDTO(c, *out)
+	if err != nil {
+		c.JsonApiErr(http.StatusInternalServerError, "conversion error", err)
+		return
+	}
+	c.JSON(http.StatusOK, model.LibraryElementResponse{Result: *dto})
+}
+
+func (lk8s *libraryElementsK8sHandler) deleteK8sLibraryElement(c *contextmodel.ReqContext) {
+	client, ok := lk8s.getClient(c)
+	if !ok {
+		return
+	}
+	uid := web.Params(c.Req)[":uid"]
+
+	// the legacy delete response includes the internal id of the deleted element
+	existing, err := client.Get(c.Req.Context(), uid, v1.GetOptions{})
+	if err != nil {
+		lk8s.writeError(c, err)
+		return
+	}
+	id := int64(0)
+	if meta, err := utils.MetaAccessor(existing); err == nil {
+		id = meta.GetDeprecatedInternalID() // nolint:staticcheck
+	}
+
+	if err := client.Delete(c.Req.Context(), uid, v1.DeleteOptions{}); err != nil {
+		lk8s.writeError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, model.DeleteLibraryElementResponse{
+		Message: "Library element deleted",
+		ID:      id,
+	})
+}
+
+// getAllK8sLibraryElements serves GET /api/library-elements from the k8s API.
+// Per-item read permissions (including folder inheritance) are enforced by the
+// stores themselves: the legacy store evaluates library.panels:read per item and
+// unified storage filters through the authz access client. This makes the legacy
+// handler's folder-tree post-filtering redundant here, with one deliberate
+// difference: a panel the user can read through a direct panel-scoped grant is
+// returned even when its parent folder is not viewable, whereas the legacy
+// folder-tree filter would hide it.
+func (lk8s *libraryElementsK8sHandler) getAllK8sLibraryElements(c *contextmodel.ReqContext, query model.SearchLibraryElementsQuery) {
+	if query.PerPage <= 0 {
+		query.PerPage = 100
+	}
+	if query.Page <= 0 {
+		query.Page = 1
+	}
+
+	folderUIDFilter, ok := lk8s.resolveFolderFilter(c, query)
+	if !ok {
+		return
+	}
+
+	client, ok := lk8s.getClient(c)
+	if !ok {
+		return
+	}
+	items, ok := lk8s.listAllK8sLibraryPanels(c, client)
+	if !ok {
+		return
+	}
+
+	filtered := lk8s.filterK8sLibraryPanels(c, items, query, folderUIDFilter)
+
+	sortAsc := query.SortDirection != sort.SortAlphaDesc.Name
+	gosort.SliceStable(filtered, func(i, j int) bool {
+		iName, _, _ := unstructured.NestedString(filtered[i].Object, "spec", "title")
+		jName, _, _ := unstructured.NestedString(filtered[j].Object, "spec", "title")
+		if sortAsc {
+			return iName < jName
+		}
+		return iName > jName
+	})
+
+	totalCount := int64(len(filtered))
+	start := query.PerPage * (query.Page - 1)
+	if start > len(filtered) {
+		start = len(filtered)
+	}
+	end := start + query.PerPage
+	if end > len(filtered) {
+		end = len(filtered)
+	}
+
+	elements := make([]model.LibraryElementDTO, 0, end-start)
+	for _, item := range filtered[start:end] {
+		dto, err := lk8s.unstructuredToLegacyLibraryPanelDTO(c, item)
+		if err != nil {
+			c.JsonApiErr(http.StatusInternalServerError, "conversion error", err)
+			return
+		}
+		elements = append(elements, *dto)
+	}
+
+	c.JSON(http.StatusOK, model.LibraryElementSearchResponse{Result: model.LibraryElementSearchResult{
+		TotalCount: totalCount,
+		Elements:   elements,
+		Page:       query.Page,
+		PerPage:    query.PerPage,
+	}})
+}
+
+// filterK8sLibraryPanels applies the legacy search query semantics to the listed
+// library panels.
+func (lk8s *libraryElementsK8sHandler) filterK8sLibraryPanels(c *contextmodel.ReqContext, items []unstructured.Unstructured, query model.SearchLibraryElementsQuery, folderUIDFilter []string) []unstructured.Unstructured {
+	var typeFilter []string
+	if len(strings.TrimSpace(query.TypeFilter)) > 0 {
+		typeFilter = strings.Split(query.TypeFilter, ",")
+	}
+	searchString := strings.ToLower(strings.TrimSpace(query.SearchString))
+
+	// the legacy search also matches elements whose folder title contains the search
+	// string (unless an explicit folder filter is set), so resolve folder titles first
+	folderTitles := map[string]string{}
+	if searchString != "" && len(folderUIDFilter) == 0 {
+		folderTitles = lk8s.resolveFolderTitles(c, items)
+	}
+
+	filtered := make([]unstructured.Unstructured, 0, len(items))
+	for _, item := range items {
+		panelType, _, _ := unstructured.NestedString(item.Object, "spec", "type")
+		folderUID := item.GetAnnotations()[utils.AnnoKeyFolder]
+
+		if query.ExcludeUID != "" && item.GetName() == query.ExcludeUID {
+			continue
+		}
+		if len(typeFilter) > 0 && !slices.Contains(typeFilter, panelType) {
+			continue
+		}
+		if len(folderUIDFilter) > 0 && !matchesFolderFilter(folderUID, folderUIDFilter) {
+			continue
+		}
+		if !matchesSearchString(item, searchString, folderTitles[folderUID]) {
+			continue
+		}
+		filtered = append(filtered, item)
+	}
+	return filtered
+}
+
+// resolveFolderTitles returns the folder title for every distinct folder that
+// contains one of the given library panels; unresolvable folders map to "".
+func (lk8s *libraryElementsK8sHandler) resolveFolderTitles(c *contextmodel.ReqContext, items []unstructured.Unstructured) map[string]string {
+	folderTitles := map[string]string{}
+	for _, item := range items {
+		folderUID := item.GetAnnotations()[utils.AnnoKeyFolder]
+		if folderUID == "" {
+			continue
+		}
+		if _, found := folderTitles[folderUID]; found {
+			continue
+		}
+		title := ""
+		if folder, err := lk8s.folderService.Get(c.Req.Context(), &foldermodel.GetFolderQuery{
+			OrgID:        c.OrgID,
+			UID:          &folderUID,
+			SignedInUser: c.SignedInUser,
+		}); err == nil {
+			title = folder.Title
+		}
+		folderTitles[folderUID] = title
+	}
+	return folderTitles
+}
+
+// matchesFolderFilter mirrors the legacy folder filter: root-level panels match
+// via the "general" folder sentinel.
+func matchesFolderFilter(folderUID string, folderUIDFilter []string) bool {
+	if folderUID == "" {
+		return slices.Contains(folderUIDFilter, ac.GeneralFolderUID)
+	}
+	return slices.Contains(folderUIDFilter, folderUID)
+}
+
+// matchesSearchString mirrors the legacy search: the panel matches when its name,
+// description, or containing folder title contains the search string.
+func matchesSearchString(item unstructured.Unstructured, searchString string, folderTitle string) bool {
+	if searchString == "" {
+		return true
+	}
+	name, _, _ := unstructured.NestedString(item.Object, "spec", "title")
+	if strings.Contains(strings.ToLower(name), searchString) {
+		return true
+	}
+	description, _, _ := unstructured.NestedString(item.Object, "spec", "description")
+	if strings.Contains(strings.ToLower(description), searchString) {
+		return true
+	}
+	return folderTitle != "" && strings.Contains(strings.ToLower(folderTitle), searchString)
+}
+
+func (lk8s *libraryElementsK8sHandler) getByNameK8sLibraryElement(c *contextmodel.ReqContext) {
+	name := web.Params(c.Req)[":name"]
+	client, ok := lk8s.getClient(c)
+	if !ok {
+		return
+	}
+	items, ok := lk8s.listAllK8sLibraryPanels(c, client)
+	if !ok {
+		return
+	}
+
+	elements := make([]model.LibraryElementDTO, 0)
+	for _, item := range items {
+		itemName, _, _ := unstructured.NestedString(item.Object, "spec", "title")
+		if itemName != name {
+			continue
+		}
+		dto, err := lk8s.unstructuredToLegacyLibraryPanelDTO(c, item)
+		if err != nil {
+			c.JsonApiErr(http.StatusInternalServerError, "conversion error", err)
+			return
+		}
+		elements = append(elements, *dto)
+	}
+	if len(elements) == 0 {
+		c.JsonApiErr(http.StatusNotFound, model.ErrLibraryElementNotFound.Error(), nil)
+		return
+	}
+	c.JSON(http.StatusOK, model.LibraryElementArrayResponse{Result: elements})
+}
+
+// resolveFolderFilter converts the legacy folder filter query parameters into a list
+// of folder UIDs (the deprecated folderFilter parameter carries folder ids). On
+// failure the error response has already been written and ok is false.
+func (lk8s *libraryElementsK8sHandler) resolveFolderFilter(c *contextmodel.ReqContext, query model.SearchLibraryElementsQuery) ([]string, bool) {
+	hasFolderFilterIDs := len(strings.TrimSpace(query.FolderFilter)) > 0 // nolint:staticcheck
+	hasFolderFilterUIDs := len(strings.TrimSpace(query.FolderFilterUIDs)) > 0
+	if hasFolderFilterIDs && hasFolderFilterUIDs {
+		c.JsonApiErr(http.StatusBadRequest, "cannot pass both folderFilter and folderFilterUIDs", nil)
+		return nil, false
+	}
+
+	if hasFolderFilterUIDs {
+		return strings.Split(query.FolderFilterUIDs, ","), true
+	}
+
+	if !hasFolderFilterIDs {
+		return nil, true
+	}
+
+	folderUIDs := make([]string, 0)
+	for _, filter := range strings.Split(query.FolderFilter, ",") { // nolint:staticcheck
+		folderID, err := strconv.ParseInt(filter, 10, 64)
+		if err != nil {
+			c.JsonApiErr(http.StatusBadRequest, "invalid folderFilter", err)
+			return nil, false
+		}
+		if folderID == 0 {
+			folderUIDs = append(folderUIDs, ac.GeneralFolderUID)
+			continue
+		}
+		folder, err := lk8s.folderService.Get(c.Req.Context(), &foldermodel.GetFolderQuery{
+			OrgID:        c.OrgID,
+			ID:           &folderID, // nolint:staticcheck
+			SignedInUser: c.SignedInUser,
+		})
+		if err != nil {
+			// unresolvable ids match nothing, same as the legacy SQL filter
+			continue
+		}
+		folderUIDs = append(folderUIDs, folder.UID)
+	}
+	return folderUIDs, true
+}
+
+// listAllK8sLibraryPanels pages through the k8s list endpoint until all library
+// panels for the org have been collected. On failure the error response has already
+// been written and ok is false.
+func (lk8s *libraryElementsK8sHandler) listAllK8sLibraryPanels(c *contextmodel.ReqContext, client dynamic.ResourceInterface) ([]unstructured.Unstructured, bool) {
+	items := make([]unstructured.Unstructured, 0)
+	opts := v1.ListOptions{Limit: 500}
+	for {
+		out, err := client.List(c.Req.Context(), opts)
+		if err != nil {
+			lk8s.writeError(c, err)
+			return nil, false
+		}
+		items = append(items, out.Items...)
+		opts.Continue = out.GetContinue()
+		if opts.Continue == "" {
+			return items, true
+		}
+	}
+}
+
+// legacyLibraryPanelToUnstructured builds the k8s representation of a library panel
+// from the fields of a legacy create/patch command.
+func legacyLibraryPanelToUnstructured(uid string, name string, folderUID string, version int64, legacyModel json.RawMessage) (*unstructured.Unstructured, error) {
+	spec, status, err := LegacyModelToLibraryPanel(name, legacyModel)
+	if err != nil {
+		return nil, err
+	}
+	panel := &dashboardV0.LibraryPanel{
+		TypeMeta: v1.TypeMeta{
+			APIVersion: dashboardV0.APIVERSION,
+			Kind:       "LibraryPanel",
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name: uid,
+		},
+		Spec:   spec,
+		Status: status,
+	}
+	meta, err := utils.MetaAccessor(panel)
+	if err != nil {
+		return nil, err
+	}
+	if folderUID != "" {
+		meta.SetFolder(folderUID)
+	}
+	if version > 0 {
+		meta.SetGeneration(version)
+	}
+
+	data, err := json.Marshal(panel)
+	if err != nil {
+		return nil, err
+	}
+	obj := &unstructured.Unstructured{}
+	if err := obj.UnmarshalJSON(data); err != nil {
+		return nil, err
+	}
+	return obj, nil
+}
+
+func unstructuredToLibraryPanel(item *unstructured.Unstructured) (*dashboardV0.LibraryPanel, error) {
+	data, err := item.MarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	panel := &dashboardV0.LibraryPanel{}
+	if err := json.Unmarshal(data, panel); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal object into LibraryPanel: %w", err)
+	}
+	return panel, nil
+}
+
 func (lk8s *libraryElementsK8sHandler) unstructuredToLegacyLibraryPanelDTO(c *contextmodel.ReqContext, item unstructured.Unstructured) (*model.LibraryElementDTO, error) {
-	spec, exists := item.Object["spec"].(map[string]interface{})
-	if !exists {
-		return nil, fmt.Errorf("spec not found in unstructured object")
+	panel, err := unstructuredToLibraryPanel(&item)
+	if err != nil {
+		return nil, err
 	}
 
 	id := int64(0)
 	folderUID := ""
-	meta, err := utils.MetaAccessor(&item)
+	meta, err := utils.MetaAccessor(panel)
 	if err == nil {
 		id = meta.GetDeprecatedInternalID() // nolint:staticcheck
 		folderUID = meta.GetFolder()
 	}
 
-	var libraryPanelSpec dashboardV0.LibraryPanelSpec
-	specJSON, err := json.Marshal(spec)
+	// rebuild the legacy model blob, then re-attach the identifiers the legacy API inlines
+	modelJSON, err := LibraryPanelToLegacyModel(panel)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal spec: %w", err)
+		return nil, err
 	}
-
-	err = json.Unmarshal(specJSON, &libraryPanelSpec)
-	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal spec into LibraryPanelSpec: %w", err)
-	}
-
-	// need to reconstruct this section from what we have in the k8s object
 	legacyModel := map[string]any{}
-	legacyModel["datasource"] = libraryPanelSpec.Datasource
-	legacyModel["description"] = libraryPanelSpec.Description
-	legacyModel["fieldConfig"] = libraryPanelSpec.FieldConfig.Object
-	legacyModel["gridPos"] = libraryPanelSpec.GridPos
+	if err := json.Unmarshal(modelJSON, &legacyModel); err != nil {
+		return nil, err
+	}
 	legacyModel["id"] = id
-	legacyModel["options"] = libraryPanelSpec.Options.Object
-	legacyModel["pluginVersion"] = libraryPanelSpec.PluginVersion
-	legacyModel["type"] = libraryPanelSpec.Type
-	legacyModel["title"] = libraryPanelSpec.PanelTitle // this is the title of the panel when displayed in the dashboard
 	legacyModel["libraryPanel"] = map[string]string{
-		"name": libraryPanelSpec.Title, // this is the title of the actual library panel, when displayed in the library panel list
+		"name": panel.Spec.Title, // this is the title of the actual library panel, when displayed in the library panel list
 		"uid":  item.GetName(),
-	}
-	if len(libraryPanelSpec.Links) > 0 {
-		legacyModel["links"] = libraryPanelSpec.Links
-	}
-	if len(libraryPanelSpec.Targets) > 0 {
-		legacyModel["targets"] = libraryPanelSpec.Targets
-	}
-	if libraryPanelSpec.Transparent {
-		legacyModel["transparent"] = libraryPanelSpec.Transparent
 	}
 	finalModel, err := json.Marshal(legacyModel)
 	if err != nil {
@@ -670,10 +1154,10 @@ func (lk8s *libraryElementsK8sHandler) unstructuredToLegacyLibraryPanelDTO(c *co
 		OrgID:       c.OrgID,
 		FolderUID:   folderUID,
 		UID:         item.GetName(),
-		Name:        libraryPanelSpec.Title,
+		Name:        panel.Spec.Title,
 		Kind:        int64(model.PanelElement),
-		Type:        libraryPanelSpec.Type,
-		Description: libraryPanelSpec.Description,
+		Type:        panel.Spec.Type,
+		Description: panel.Spec.Description,
 		Model:       finalModel,
 		Version:     item.GetGeneration(),
 		Meta: model.LibraryElementDTOMeta{
@@ -696,7 +1180,10 @@ func (lk8s *libraryElementsK8sHandler) unstructuredToLegacyLibraryPanelDTO(c *co
 		dto.FolderID = folder.ID // nolint:staticcheck
 	}
 
-	dashboards, err := lk8s.dashboardsService.GetDashboardsByLibraryPanelUID(c.Req.Context(), item.GetName(), c.OrgID)
+	// count connections with a service identity so the result does not depend on the
+	// calling user's folder permissions, mirroring enrichConnectedDashboards
+	serviceCtx, _ := identity.WithServiceIdentity(c.Req.Context(), c.OrgID)
+	dashboards, err := lk8s.dashboardsService.GetDashboardsByLibraryPanelUID(serviceCtx, item.GetName(), c.OrgID)
 	if err != nil {
 		return nil, err
 	}
@@ -756,7 +1243,22 @@ func (lk8s *libraryElementsK8sHandler) writeError(c *contextmodel.ReqContext, er
 	//nolint:errorlint
 	statusError, ok := err.(*k8serrors.StatusError)
 	if ok {
-		c.JsonApiErr(int(statusError.Status().Code), statusError.Status().Message, err)
+		code := int(statusError.Status().Code)
+		message := statusError.Status().Message
+		// keep the legacy /api contract for errors the k8s apiserver expresses differently
+		switch {
+		case k8serrors.IsAlreadyExists(err):
+			code = http.StatusBadRequest
+			message = model.ErrLibraryElementAlreadyExists.Error()
+		case k8serrors.IsConflict(err) && strings.Contains(message, model.ErrLibraryElementVersionMismatch.Error()):
+			code = http.StatusPreconditionFailed
+			message = model.ErrLibraryElementVersionMismatch.Error()
+		case k8serrors.IsConflict(err) && strings.Contains(message, model.ErrLibraryElementProvisionedFolder.Error()):
+			message = model.ErrLibraryElementProvisionedFolder.Error()
+		case k8serrors.IsForbidden(err) && strings.Contains(message, model.ErrLibraryElementHasConnections.Error()):
+			message = model.ErrLibraryElementHasConnections.Error()
+		}
+		c.JsonApiErr(code, message, err)
 		return
 	}
 	errhttp.Write(c.Req.Context(), err, c.Resp)

--- a/pkg/services/libraryelements/conversions.go
+++ b/pkg/services/libraryelements/conversions.go
@@ -56,7 +56,89 @@ func ToPatchLibraryElementCommand(raw runtime.Object) (*model.PatchLibraryElemen
 func toRawMessage(raw runtime.Object) (json.RawMessage, error) {
 	switch obj := raw.(type) {
 	case *v0alpha1.LibraryPanel:
-		return json.Marshal(obj.Spec)
+		return LibraryPanelToLegacyModel(obj)
 	}
 	return nil, fmt.Errorf("unsupported library panel type: %T", raw)
+}
+
+// LibraryPanelToLegacyModel rebuilds the legacy `model` JSON blob (the panel body
+// stored in the library_element table) from a k8s LibraryPanel. It is the inverse
+// of LegacyModelToLibraryPanel: properties that have no typed field on
+// LibraryPanelSpec travel in status.missing, so they are used as the base of the
+// model to keep unknown panel keys (e.g. transformations) intact across the
+// k8s <-> legacy round trip.
+func LibraryPanelToLegacyModel(panel *v0alpha1.LibraryPanel) (json.RawMessage, error) {
+	legacyModel := map[string]any{}
+	if panel.Status != nil {
+		for k, v := range panel.Status.Missing.Object {
+			legacyModel[k] = v
+		}
+	}
+
+	spec := panel.Spec
+	legacyModel["type"] = spec.Type
+	// in the legacy model blob, "title" is the title of the panel as displayed in
+	// dashboards, while the library panel name lives in the SQL column / spec.title.
+	legacyModel["title"] = spec.PanelTitle
+	if spec.PluginVersion != "" {
+		legacyModel["pluginVersion"] = spec.PluginVersion
+	}
+	if spec.Description != "" {
+		legacyModel["description"] = spec.Description
+	}
+	options := spec.Options.Object
+	if options == nil {
+		options = map[string]any{}
+	}
+	legacyModel["options"] = options
+	fieldConfig := spec.FieldConfig.Object
+	if fieldConfig == nil {
+		fieldConfig = map[string]any{}
+	}
+	legacyModel["fieldConfig"] = fieldConfig
+	legacyModel["gridPos"] = spec.GridPos
+	if spec.Datasource != nil {
+		legacyModel["datasource"] = spec.Datasource
+	}
+	if len(spec.Targets) > 0 {
+		legacyModel["targets"] = spec.Targets
+	}
+	if len(spec.Links) > 0 {
+		legacyModel["links"] = spec.Links
+	}
+	if spec.Transparent {
+		legacyModel["transparent"] = spec.Transparent
+	}
+
+	return json.Marshal(legacyModel)
+}
+
+// libraryPanelSpecKeys are the legacy model properties that map to typed fields on
+// LibraryPanelSpec. Everything else is preserved in status.missing.
+var libraryPanelSpecKeys = []string{"type", "pluginVersion", "title", "description", "options", "fieldConfig", "datasource", "targets", "libraryPanel", "id", "gridPos"}
+
+// LegacyModelToLibraryPanel builds the spec and status of a k8s LibraryPanel from a
+// legacy `model` JSON blob and the library panel name (the SQL name column). Model
+// properties without a typed spec field are kept in status.missing.
+func LegacyModelToLibraryPanel(name string, legacyModel json.RawMessage) (v0alpha1.LibraryPanelSpec, *v0alpha1.LibraryPanelStatus, error) {
+	spec := v0alpha1.LibraryPanelSpec{}
+	status := &v0alpha1.LibraryPanelStatus{}
+	if err := json.Unmarshal(legacyModel, &spec); err != nil {
+		return spec, status, fmt.Errorf("invalid library panel model: %w", err)
+	}
+	if err := json.Unmarshal(legacyModel, &status.Missing.Object); err != nil {
+		return spec, status, fmt.Errorf("invalid library panel model: %w", err)
+	}
+
+	// the panel title used in dashboards and title of the library panel can differ
+	// in the old model blob, the panel title is specified as "title", and the library panel title is
+	// in "libraryPanel.name", or as the column in the db.
+	spec.PanelTitle = spec.Title
+	spec.Title = name
+
+	for _, k := range libraryPanelSpecKeys {
+		delete(status.Missing.Object, k)
+	}
+
+	return spec, status, nil
 }

--- a/pkg/services/libraryelements/conversions_test.go
+++ b/pkg/services/libraryelements/conversions_test.go
@@ -67,12 +67,14 @@ func TestConversionsCommands(t *testing.T) {
 					},
 				},
 			},
+			// in the legacy model blob "title" is the panel display title (spec.panelTitle),
+			// while the library panel name (spec.title) maps to the command Name / SQL column
 			expectedCreate: &model.CreateLibraryElementCommand{
 				FolderUID: new("aaa"),
 				UID:       "uid",
 				Name:      "title",
 				Kind:      1,
-				Model:     json.RawMessage(`{"type":"timeseries","pluginVersion":"1.2.3","title":"title","panelTitle":"panel title","description":"descr","options":{"hello":"options"},"fieldConfig":{"hello":"fieldConfig"},"datasource":{"type":"ttt","uid":"uid","apiVersion":"v0alpha1"},"gridPos":{"w":1,"h":2,"x":3,"y":4},"transparent":true,"links":[{"link1":"hello"}]}`),
+				Model:     json.RawMessage(`{"datasource":{"type":"ttt","uid":"uid","apiVersion":"v0alpha1"},"description":"descr","fieldConfig":{"hello":"fieldConfig"},"gridPos":{"w":1,"h":2,"x":3,"y":4},"links":[{"link1":"hello"}],"options":{"hello":"options"},"pluginVersion":"1.2.3","title":"panel title","transparent":true,"type":"timeseries"}`),
 			},
 			expectedPatch: &model.PatchLibraryElementCommand{
 				FolderUID: new("aaa"),
@@ -80,7 +82,7 @@ func TestConversionsCommands(t *testing.T) {
 				Name:      "title",
 				Kind:      1,
 				Version:   3,
-				Model:     json.RawMessage(`{"type":"timeseries","pluginVersion":"1.2.3","title":"title","panelTitle":"panel title","description":"descr","options":{"hello":"options"},"fieldConfig":{"hello":"fieldConfig"},"datasource":{"type":"ttt","uid":"uid","apiVersion":"v0alpha1"},"gridPos":{"w":1,"h":2,"x":3,"y":4},"transparent":true,"links":[{"link1":"hello"}]}`),
+				Model:     json.RawMessage(`{"datasource":{"type":"ttt","uid":"uid","apiVersion":"v0alpha1"},"description":"descr","fieldConfig":{"hello":"fieldConfig"},"gridPos":{"w":1,"h":2,"x":3,"y":4},"links":[{"link1":"hello"}],"options":{"hello":"options"},"pluginVersion":"1.2.3","title":"panel title","transparent":true,"type":"timeseries"}`),
 			},
 		},
 	}
@@ -99,5 +101,66 @@ func TestConversionsCommands(t *testing.T) {
 				require.FailNowf(t, "Path mismatch (-want +got):%s", diff)
 			}
 		})
+	}
+}
+
+func TestLegacyModelToLibraryPanel(t *testing.T) {
+	legacyModel := json.RawMessage(`{
+		"type": "timeseries",
+		"title": "panel title",
+		"description": "descr",
+		"options": {"hello": "options"},
+		"fieldConfig": {"hello": "fieldConfig"},
+		"gridPos": {"w": 1, "h": 2, "x": 3, "y": 4},
+		"transformations": [{"id": "reduce", "options": {}}],
+		"maxDataPoints": 100,
+		"libraryPanel": {"uid": "uid", "name": "my library panel"},
+		"id": 4
+	}`)
+
+	spec, status, err := LegacyModelToLibraryPanel("my library panel", legacyModel)
+	require.NoError(t, err)
+
+	// the library panel name lands in spec.title, the display title in spec.panelTitle
+	require.Equal(t, "my library panel", spec.Title)
+	require.Equal(t, "panel title", spec.PanelTitle)
+	require.Equal(t, "timeseries", spec.Type)
+	require.Equal(t, "descr", spec.Description)
+	require.Equal(t, v0alpha1.GridPos{W: 1, H: 2, X: 3, Y: 4}, spec.GridPos)
+
+	// properties without a typed spec field are preserved in status.missing,
+	// while spec-mapped keys are stripped from it
+	require.Contains(t, status.Missing.Object, "transformations")
+	require.Contains(t, status.Missing.Object, "maxDataPoints")
+	require.NotContains(t, status.Missing.Object, "type")
+	require.NotContains(t, status.Missing.Object, "title")
+	require.NotContains(t, status.Missing.Object, "libraryPanel")
+	require.NotContains(t, status.Missing.Object, "id")
+}
+
+func TestLibraryPanelModelRoundTrip(t *testing.T) {
+	legacyModel := json.RawMessage(`{
+		"type": "timeseries",
+		"title": "panel title",
+		"description": "descr",
+		"options": {"hello": "options"},
+		"fieldConfig": {"hello": "fieldConfig"},
+		"gridPos": {"w": 1, "h": 2, "x": 3, "y": 4},
+		"transparent": true,
+		"transformations": [{"id": "reduce", "options": {}}],
+		"maxDataPoints": 100
+	}`)
+
+	spec, status, err := LegacyModelToLibraryPanel("my library panel", legacyModel)
+	require.NoError(t, err)
+
+	rebuilt, err := LibraryPanelToLegacyModel(&v0alpha1.LibraryPanel{Spec: spec, Status: status})
+	require.NoError(t, err)
+
+	var want, got map[string]any
+	require.NoError(t, json.Unmarshal(legacyModel, &want))
+	require.NoError(t, json.Unmarshal(rebuilt, &got))
+	if diff := cmp.Diff(want, got); diff != "" {
+		require.FailNowf(t, "model round trip mismatch (-want +got):%s", diff)
 	}
 }

--- a/pkg/setting/setting_unified_storage.go
+++ b/pkg/setting/setting_unified_storage.go
@@ -24,6 +24,7 @@ const (
 	DashboardResource        = "dashboards.dashboard.grafana.app"
 	ShortURLResource         = "shorturls.shorturl.grafana.app"
 	SnapshotResource         = "snapshots.dashboard.grafana.app"
+	LibraryPanelResource     = "librarypanels.dashboard.grafana.app"
 	StarsResource            = "stars.collections.grafana.app"
 	PreferencesResource      = "preferences.preferences.grafana.app"
 	DataSourceResources      = "datasources.datasource.grafana.app" // All datasources
@@ -37,6 +38,7 @@ var MigratedUnifiedResources = map[string]bool{
 	DashboardResource:        true,  // Only Mode5!
 	ShortURLResource:         false, // Requires kubernetesShortURLs to be enabled by default
 	SnapshotResource:         false, // Requires kubernetesSnapshots to be enabled by default
+	LibraryPanelResource:     false, // Requires libraryelements.kubernetesLibraryPanels to be enabled by default
 	StarsResource:            false,
 	PreferencesResource:      false,
 	DataSourceResources:      false,

--- a/pkg/storage/unified/migrations/README.md
+++ b/pkg/storage/unified/migrations/README.md
@@ -12,6 +12,7 @@ The migration system transfers resources from legacy SQL tables to Grafana's uni
 |----------|-----------|--------------|
 | Folders | `folder.grafana.app` | `dashboard` |
 | Dashboards | `dashboard.grafana.app` | `dashboard` |
+| Library panels | `dashboard.grafana.app` | `library_element` |
 | Playlists | `playlist.grafana.app` | `playlist` |
 | Short URLs | `shorturl.grafana.app` | `short_url` |
 | Datasources | `*.datasource.grafana.app` | `data_source` |

--- a/pkg/storage/unified/migrations/migrator_test.go
+++ b/pkg/storage/unified/migrations/migrator_test.go
@@ -47,6 +47,7 @@ func defaultMigrationTestCases() []testcases.ResourceMigratorTestCase {
 		testcases.NewStarsTestCase(),
 		testcases.NewPreferencesTestCase(),
 		testcases.NewSnapshotsTestCase(),
+		testcases.NewLibraryPanelsTestCase(),
 	}
 	// TODO: fix datasource migration tests on sqlite, see:
 	// https://github.com/grafana/grafana-enterprise/issues/11313
@@ -353,6 +354,7 @@ const (
 	preferencesID          = "preferences migration"
 	datasourceID           = "datasources migration"
 	snapshotsID            = "snapshots migration"
+	librarypanelsID        = "librarypanels migration"
 )
 
 var migrationIDsToDefault = map[string]bool{
@@ -363,6 +365,7 @@ var migrationIDsToDefault = map[string]bool{
 	starsID:                false,
 	preferencesID:          false,
 	snapshotsID:            false,
+	librarypanelsID:        false,
 }
 
 func verifyRegisteredMigrations(t *testing.T, helper *apis.K8sTestHelper, onlyDefault bool, optOut bool, extraMigrationIDs map[string]bool) {

--- a/pkg/storage/unified/migrations/testcases/librarypanels.go
+++ b/pkg/storage/unified/migrations/testcases/librarypanels.go
@@ -1,0 +1,82 @@
+package testcases
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	authlib "github.com/grafana/authlib/types"
+	dashV0 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v0alpha1"
+	"github.com/grafana/grafana/pkg/services/libraryelements"
+	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
+	"github.com/grafana/grafana/pkg/tests/apis"
+)
+
+// libraryPanelsTestCase tests the "librarypanels" ResourceMigration.
+type libraryPanelsTestCase struct {
+	uids []string
+}
+
+// NewLibraryPanelsTestCase creates a test case for the library panels migrator
+func NewLibraryPanelsTestCase() ResourceMigratorTestCase {
+	return &libraryPanelsTestCase{
+		uids: []string{},
+	}
+}
+
+func (tc *libraryPanelsTestCase) Name() string {
+	return "librarypanels"
+}
+
+func (tc *libraryPanelsTestCase) FeatureToggles() []string {
+	return nil
+}
+
+func (tc *libraryPanelsTestCase) RenameTables() []string {
+	return []string{}
+}
+
+func (tc *libraryPanelsTestCase) Resources() []schema.GroupVersionResource {
+	return []schema.GroupVersionResource{
+		dashV0.LibraryPanelResourceInfo.GroupVersionResource(),
+	}
+}
+
+func (tc *libraryPanelsTestCase) AddLegacySQLMigrations(mg *migrator.Migrator) {
+	// library_element is still created on startup, nothing to add
+}
+
+func (tc *libraryPanelsTestCase) Setup(t *testing.T, helper *apis.K8sTestHelper) bool {
+	t.Helper()
+
+	sqlDB := helper.GetEnv().SQLStore
+	cfg := helper.GetEnv().Cfg
+
+	libraryElements := libraryelements.ProvideService(cfg, sqlDB, nil, nil, nil,
+		&alwaysYesAccessControl{}, nil, nil, nil)
+
+	// root-level library panels: folders have their own migration and test case
+	for _, name := range []string{"lp-mig-test-1", "lp-mig-test-2", "lp-mig-test-3"} {
+		uid := createTestLibraryPanel(t, helper, libraryElements, name, "")
+		tc.uids = append(tc.uids, uid)
+	}
+
+	return true // library panels are served over k8s apis, reading from legacy in Mode0
+}
+
+func (tc *libraryPanelsTestCase) Verify(t *testing.T, helper *apis.K8sTestHelper, shouldExist bool) {
+	t.Helper()
+
+	namespace := authlib.OrgNamespaceFormatter(helper.Org1.OrgID)
+	client := helper.GetResourceClient(apis.ResourceClientArgs{
+		User:      helper.Org1.Admin,
+		Namespace: namespace,
+		GVR:       dashV0.LibraryPanelResourceInfo.GroupVersionResource(),
+	})
+
+	// No total-count assertion: the folders/dashboards test case creates a library
+	// panel in the same org and the librarypanels migration moves that one too.
+	for _, uid := range tc.uids {
+		verifyResource(t, client, uid, shouldExist)
+	}
+}

--- a/pkg/tests/apis/dashboard/integration/library_panels_api_validation_test.go
+++ b/pkg/tests/apis/dashboard/integration/library_panels_api_validation_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
@@ -12,6 +13,7 @@ import (
 
 	dashboardV0 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/tests/apis"
@@ -29,7 +31,7 @@ func TestIntegrationLibraryPanelConnections(t *testing.T) {
 	helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
 		DisableAnonymous: true,
 		EnableFeatureToggles: []string{
-			"kubernetesLibraryPanels",
+			featuremgmt.FlagLibraryelementsKubernetesLibraryPanels,
 		},
 	})
 	ctx := createTestContext(t, helper, helper.Org1)
@@ -87,8 +89,7 @@ func TestIntegrationLibraryElementPermissions(t *testing.T) {
 	helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
 		DisableAnonymous: true,
 		EnableFeatureToggles: []string{
-			"kubernetesLibraryPanels",
-			"grafanaAPIServerWithExperimentalAPIs", // needed until we move it to v0beta1 at least (currently v0alpha1)
+			featuremgmt.FlagLibraryelementsKubernetesLibraryPanels,
 		},
 	})
 	ctx := createTestContext(t, helper, helper.Org1)
@@ -225,6 +226,113 @@ func runLibraryElementCrossOrgTests(t *testing.T, org1Ctx, org2Ctx TestContext) 
 	})
 }
 
+// exercises the legacy /api/library-elements surface while requests are routed through
+// the k8s /apis endpoints, to ensure the responses keep the legacy contract
+func TestIntegrationLibraryElementLegacyAPIThroughK8s(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
+		DisableAnonymous: true,
+		EnableFeatureToggles: []string{
+			featuremgmt.FlagLibraryelementsKubernetesLibraryPanels,
+		},
+	})
+	ctx := createTestContext(t, helper, helper.Org1)
+
+	// create: the display title and properties without a typed spec field (e.g.
+	// transformations) must survive the conversion round trip
+	created, err := postHelper(t, &ctx, "/api/library-elements", map[string]interface{}{
+		"kind": 1,
+		"name": "CRUDPanel",
+		"model": map[string]interface{}{
+			"type":            "text",
+			"title":           "CRUD panel display title",
+			"description":     "some description",
+			"transformations": []interface{}{map[string]interface{}{"id": "reduce"}},
+		},
+	}, ctx.AdminUser)
+	require.NoError(t, err)
+	result := created["result"].(map[string]interface{})
+	uid := result["uid"].(string)
+	require.NotEmpty(t, uid)
+	require.Equal(t, "CRUDPanel", result["name"])
+	require.Equal(t, float64(1), result["version"])
+	createdModel := result["model"].(map[string]interface{})
+	require.Equal(t, "CRUD panel display title", createdModel["title"])
+	require.Contains(t, createdModel, "transformations")
+	require.Equal(t, "some description", createdModel["description"])
+
+	// get by uid
+	got, err := getDashboardViaHTTP(t, &ctx, fmt.Sprintf("/api/library-elements/%s", uid), ctx.AdminUser)
+	require.NoError(t, err)
+	gotResult := got["result"].(map[string]interface{})
+	require.Equal(t, uid, gotResult["uid"])
+	gotModel := gotResult["model"].(map[string]interface{})
+	require.Equal(t, "CRUD panel display title", gotModel["title"])
+	require.Contains(t, gotModel, "transformations")
+
+	// get all, with and without a matching search string
+	all, err := getDashboardViaHTTP(t, &ctx, "/api/library-elements", ctx.AdminUser)
+	require.NoError(t, err)
+	require.Equal(t, float64(1), all["result"].(map[string]interface{})["totalCount"])
+	require.Len(t, all["result"].(map[string]interface{})["elements"], 1)
+
+	filtered, err := getDashboardViaHTTP(t, &ctx, "/api/library-elements?searchString=crudpanel", ctx.AdminUser)
+	require.NoError(t, err)
+	require.Equal(t, float64(1), filtered["result"].(map[string]interface{})["totalCount"])
+
+	empty, err := getDashboardViaHTTP(t, &ctx, "/api/library-elements?searchString=doesnotmatch", ctx.AdminUser)
+	require.NoError(t, err)
+	require.Equal(t, float64(0), empty["result"].(map[string]interface{})["totalCount"])
+
+	// get by name
+	byName, err := getDashboardViaHTTP(t, &ctx, "/api/library-elements/name/CRUDPanel", ctx.AdminUser)
+	require.NoError(t, err)
+	require.Len(t, byName["result"], 1)
+
+	// patch with a stale version must fail the optimistic concurrency check
+	staleBody, err := json.Marshal(map[string]interface{}{"kind": 1, "name": "CRUDPanelRenamed", "version": 99})
+	require.NoError(t, err)
+	staleResp := apis.DoRequest(ctx.Helper, apis.RequestParams{
+		User:        ctx.AdminUser,
+		Method:      http.MethodPatch,
+		Path:        fmt.Sprintf("/api/library-elements/%s", uid),
+		Body:        staleBody,
+		ContentType: "application/json",
+	}, &struct{}{})
+	require.Equal(t, http.StatusPreconditionFailed, staleResp.Response.StatusCode)
+
+	// patch: rename keeps the model and bumps the version
+	patchBody, err := json.Marshal(map[string]interface{}{"kind": 1, "name": "CRUDPanelRenamed", "version": 1})
+	require.NoError(t, err)
+	patchResp := apis.DoRequest(ctx.Helper, apis.RequestParams{
+		User:        ctx.AdminUser,
+		Method:      http.MethodPatch,
+		Path:        fmt.Sprintf("/api/library-elements/%s", uid),
+		Body:        patchBody,
+		ContentType: "application/json",
+	}, &struct{}{})
+	require.Equal(t, http.StatusOK, patchResp.Response.StatusCode)
+	var patched map[string]interface{}
+	require.NoError(t, json.Unmarshal(patchResp.Body, &patched))
+	patchedResult := patched["result"].(map[string]interface{})
+	require.Equal(t, "CRUDPanelRenamed", patchedResult["name"])
+	require.Equal(t, float64(2), patchedResult["version"])
+	patchedModel := patchedResult["model"].(map[string]interface{})
+	require.Equal(t, "CRUD panel display title", patchedModel["title"])
+	require.Contains(t, patchedModel, "transformations")
+
+	// delete, then a get must return 404
+	err = deleteLibraryElement(t, ctx, ctx.AdminUser, uid)
+	require.NoError(t, err)
+	getResp := apis.DoRequest(ctx.Helper, apis.RequestParams{
+		User:   ctx.AdminUser,
+		Method: http.MethodGet,
+		Path:   fmt.Sprintf("/api/library-elements/%s", uid),
+	}, &struct{}{})
+	require.Equal(t, http.StatusNotFound, getResp.Response.StatusCode)
+}
+
 func getLibraryElementGVR() schema.GroupVersionResource {
 	return schema.GroupVersionResource{
 		Group:    dashboardV0.APIGroup,
@@ -284,7 +392,7 @@ func TestIntegrationLibraryPanelConnectionsWithFolderAccess(t *testing.T) {
 	helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
 		DisableAnonymous: true,
 		EnableFeatureToggles: []string{
-			"kubernetesLibraryPanels",
+			featuremgmt.FlagLibraryelementsKubernetesLibraryPanels,
 		},
 	})
 	ctx := createTestContext(t, helper, helper.Org1)
@@ -498,7 +606,7 @@ func TestIntegrationLibraryElementFolderHierarchy(t *testing.T) {
 	opts := testinfra.GrafanaOpts{
 		DisableAnonymous: true,
 		EnableFeatureToggles: []string{
-			"kubernetesLibraryPanels",
+			featuremgmt.FlagLibraryelementsKubernetesLibraryPanels,
 		},
 		DisableAuthZClientCache: true,
 	}


### PR DESCRIPTION
**POC — part 3 of 3** of the library panels app platform (MT) migration. **Stacked on the part 1 backend PR** #129614 — its integration test needs the unconditional `librarypanels` API registration. Part 2 (frontend client): #129615.

## What this does

- Registers a `librarypanels` migration definition with the unified storage migration framework, wiring up the already-existing `MigrateLibraryPanels` bulk migrator (dashboard group). Locks `library_element` during migration and count-validates; no table rename since the legacy service still reads the table in dual-write modes (same as snapshots and folders/dashboards).
- Adds `librarypanels.dashboard.grafana.app` to `MigratedUnifiedResources` with migration **opt-in** (default off), enabled per instance via:

  ```ini
  [unified_storage.librarypanels.dashboard.grafana.app]
  enableMigration = true
  ```

  matching the snapshots/shorturls rollout pattern so cloud can migrate stacks over time.
- Adds a migration suite test case (`testcases/librarypanels.go`) covering all four suite steps: legacy-only visibility in Mode0, absence from unified storage when opted out, correctly skipped by default, and migrated + verified once opted in.

## Current limitation for existing-instance rollout

Legacy `PATCH /api/library-elements/:uid` supports changing the library panel UID, but the App Platform resource name is immutable. Phase 1 targets fresh instances and Grafana's frontend does not rename UIDs, so this does not block the clean-instance path. Before enabling the migration/routing for existing instances or third-party legacy clients, we must either preserve UID-changing PATCH via a legacy fallback or explicitly deprecate that behavior.

## Testing

`TestIntegrationMigrations` passes with the new case; wire regenerated via `make gen-go`; framework README updated per its checklist.


---

Tracked by #129650 · sub-epic #110230