### PR TITLE
Zanzana: Bound folder permission writes and harden gRPC client connections

### DIFF
--- a/pkg/registry/apis/folders/zanzana_permission_store.go
+++ b/pkg/registry/apis/folders/zanzana_permission_store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -13,6 +14,10 @@ import (
 	authzextv1 "github.com/grafana/grafana/pkg/services/authz/proto/v1"
 	"github.com/grafana/grafana/pkg/services/authz/zanzana"
 )
+
+// defaultWriteTimeout bounds Zanzana writes; callers (e.g. delete hooks) may pass a context
+// without a deadline, which would otherwise block indefinitely if Zanzana is unreachable.
+const defaultWriteTimeout = 15 * time.Second
 
 // PermissionStore interface for managing folder permissions
 type PermissionStore interface {
@@ -43,6 +48,9 @@ func (c *ZanzanaPermissionStore) SetFolderParent(ctx context.Context, namespace,
 		),
 	)
 	defer span.End()
+
+	ctx, cancel := context.WithTimeout(ctx, defaultWriteTimeout)
+	defer cancel()
 
 	if err := c.zanzanaClient.Mutate(ctx, &authzextv1.MutateRequest{
 		Namespace: namespace,
@@ -120,6 +128,9 @@ func (c *ZanzanaPermissionStore) DeleteFolderParents(ctx context.Context, namesp
 		),
 	)
 	defer span.End()
+
+	ctx, cancel := context.WithTimeout(ctx, defaultWriteTimeout)
+	defer cancel()
 
 	if err := c.zanzanaClient.Mutate(ctx, &authzextv1.MutateRequest{
 		Namespace: namespace,

--- a/pkg/registry/apis/folders/zanzana_permission_store_test.go
+++ b/pkg/registry/apis/folders/zanzana_permission_store_test.go
@@ -1,0 +1,67 @@
+package folders
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	authzextv1 "github.com/grafana/grafana/pkg/services/authz/proto/v1"
+	"github.com/grafana/grafana/pkg/services/authz/zanzana"
+)
+
+// deadlineCapturingClient records whether Mutate received a context with a deadline.
+type deadlineCapturingClient struct {
+	zanzana.Client
+	hasDeadline bool
+	deadline    time.Time
+}
+
+func (c *deadlineCapturingClient) Mutate(ctx context.Context, _ *authzextv1.MutateRequest) error {
+	c.deadline, c.hasDeadline = ctx.Deadline()
+	return nil
+}
+
+func TestZanzanaPermissionStore_WritesAreBounded(t *testing.T) {
+	tests := []struct {
+		name string
+		call func(store PermissionStore, ctx context.Context) error
+	}{
+		{
+			name: "SetFolderParent",
+			call: func(store PermissionStore, ctx context.Context) error {
+				return store.SetFolderParent(ctx, "stacks-1", "child", "parent")
+			},
+		},
+		{
+			name: "DeleteFolderParents",
+			call: func(store PermissionStore, ctx context.Context) error {
+				return store.DeleteFolderParents(ctx, "stacks-1", "child")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name+" adds deadline to context without one", func(t *testing.T) {
+			client := &deadlineCapturingClient{}
+			store := NewZanzanaPermissionStore(client)
+
+			require.NoError(t, tt.call(store, context.Background()))
+			require.True(t, client.hasDeadline)
+			require.WithinDuration(t, time.Now().Add(defaultWriteTimeout), client.deadline, time.Minute)
+		})
+
+		t.Run(tt.name+" keeps earlier caller deadline", func(t *testing.T) {
+			client := &deadlineCapturingClient{}
+			store := NewZanzanaPermissionStore(client)
+
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+
+			require.NoError(t, tt.call(store, ctx))
+			require.True(t, client.hasDeadline)
+			require.WithinDuration(t, time.Now().Add(time.Second), client.deadline, time.Minute)
+		})
+	}
+}

--- a/pkg/services/authz/zanzana.go
+++ b/pkg/services/authz/zanzana.go
@@ -13,14 +13,18 @@ import (
 	"github.com/grafana/authlib/types"
 	"github.com/grafana/dskit/middleware"
 	"github.com/grafana/dskit/services"
+	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
 	grpcAuth "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/auth"
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/backoff"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	healthv1pb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/keepalive"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	clientrest "k8s.io/client-go/rest"
 
@@ -60,6 +64,7 @@ func ProvideZanzanaClient(cfg *setting.Cfg, db db.DB, zanzanaServer zanzana.Serv
 			TokenExchangeURL: cfg.ZanzanaClient.TokenExchangeURL,
 			TokenNamespace:   cfg.ZanzanaClient.TokenNamespace,
 			ServerCertFile:   cfg.ZanzanaClient.ServerCertFile,
+			KeepaliveTime:    cfg.ZanzanaClient.KeepaliveTime,
 		}
 		return NewRemoteZanzanaClient(zanzanaConfig, reg)
 
@@ -237,6 +242,7 @@ func ProvideStandaloneZanzanaClient(cfg *setting.Cfg, features featuremgmt.Featu
 		TokenExchangeURL: cfg.ZanzanaClient.TokenExchangeURL,
 		TokenNamespace:   cfg.ZanzanaClient.TokenNamespace,
 		ServerCertFile:   cfg.ZanzanaClient.ServerCertFile,
+		KeepaliveTime:    cfg.ZanzanaClient.KeepaliveTime,
 	}
 
 	return NewRemoteZanzanaClient(zanzanaConfig, reg)
@@ -248,6 +254,7 @@ type ZanzanaClientConfig struct {
 	TokenExchangeURL string
 	TokenNamespace   string
 	ServerCertFile   string
+	KeepaliveTime    time.Duration
 }
 
 // NewRemoteZanzanaClient creates a new Zanzana client that connects to remote Zanzana server.
@@ -277,13 +284,41 @@ func NewRemoteZanzanaClient(cfg ZanzanaClientConfig, reg prometheus.Registerer) 
 	}, []string{"operation", "status_code"})
 	unaryInterceptors, streamInterceptors := instrument(authzRequestDuration, middleware.ReportGRPCStatusOption)
 
+	// Retry transient failures so in-flight calls survive server pod restarts (e.g. GOAWAY on shutdown).
+	retryInterceptor := grpc_retry.UnaryClientInterceptor(
+		grpc_retry.WithMax(3),
+		grpc_retry.WithBackoff(grpc_retry.BackoffExponentialWithJitter(time.Second, 0.5)),
+		grpc_retry.WithCodes(codes.ResourceExhausted, codes.Unavailable, codes.Aborted),
+	)
+
 	dialOptions := []grpc.DialOption{
 		grpc.WithTransportCredentials(transportCredentials),
 		grpc.WithPerRPCCredentials(
 			NewGRPCTokenAuth(AuthzServiceAudience, cfg.TokenNamespace, tokenClient),
 		),
-		grpc.WithChainUnaryInterceptor(unaryInterceptors...),
+		grpc.WithChainUnaryInterceptor(append([]grpc.UnaryClientInterceptor{retryInterceptor}, unaryInterceptors...)...),
 		grpc.WithChainStreamInterceptor(streamInterceptors...),
+		grpc.WithDefaultServiceConfig(`{"loadBalancingPolicy":"round_robin"}`),
+		// Fast connection backoff for quicker recovery from transient failures (e.g. during pod
+		// restarts). Default gRPC backoff waits up to 120s between reconnect attempts.
+		grpc.WithConnectParams(grpc.ConnectParams{
+			Backoff: backoff.Config{
+				BaseDelay:  100 * time.Millisecond,
+				Multiplier: 1.6,
+				Jitter:     0.2,
+				MaxDelay:   10 * time.Second,
+			},
+			MinConnectTimeout: 5 * time.Second,
+		}),
+	}
+
+	// Keepalive pings detect silently dead connections (e.g. an unresponsive server pod)
+	// that would otherwise block calls until the peer is torn down externally.
+	if cfg.KeepaliveTime > 0 {
+		dialOptions = append(dialOptions, grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			Time:    cfg.KeepaliveTime,
+			Timeout: 10 * time.Second,
+		}))
 	}
 
 	conn, err := grpc.NewClient(cfg.Addr, dialOptions...)

--- a/pkg/services/authz/zanzana.go
+++ b/pkg/services/authz/zanzana.go
@@ -257,6 +257,21 @@ type ZanzanaClientConfig struct {
 	KeepaliveTime    time.Duration
 }
 
+// defaultCallTimeout is applied to unary calls whose context carries no deadline. It spans
+// all retry attempts, so it must comfortably exceed the retry interceptor's total backoff.
+const defaultCallTimeout = 30 * time.Second
+
+func unaryDefaultTimeout(timeout time.Duration) grpc.UnaryClientInterceptor {
+	return func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, timeout)
+			defer cancel()
+		}
+		return invoker(ctx, method, req, reply, cc, opts...)
+	}
+}
+
 // NewRemoteZanzanaClient creates a new Zanzana client that connects to remote Zanzana server.
 func NewRemoteZanzanaClient(cfg ZanzanaClientConfig, reg prometheus.Registerer) (zanzana.Client, error) {
 	tokenClient, err := authnlib.NewTokenExchangeClient(authnlib.TokenExchangeConfig{
@@ -291,12 +306,16 @@ func NewRemoteZanzanaClient(cfg ZanzanaClientConfig, reg prometheus.Registerer) 
 		grpc_retry.WithCodes(codes.ResourceExhausted, codes.Unavailable, codes.Aborted),
 	)
 
+	// Background callers (reconcilers, hooks) may pass contexts without deadlines; a default
+	// deadline prevents calls from blocking indefinitely on an unresponsive connection.
+	timeoutInterceptor := unaryDefaultTimeout(defaultCallTimeout)
+
 	dialOptions := []grpc.DialOption{
 		grpc.WithTransportCredentials(transportCredentials),
 		grpc.WithPerRPCCredentials(
 			NewGRPCTokenAuth(AuthzServiceAudience, cfg.TokenNamespace, tokenClient),
 		),
-		grpc.WithChainUnaryInterceptor(append([]grpc.UnaryClientInterceptor{retryInterceptor}, unaryInterceptors...)...),
+		grpc.WithChainUnaryInterceptor(append([]grpc.UnaryClientInterceptor{timeoutInterceptor, retryInterceptor}, unaryInterceptors...)...),
 		grpc.WithChainStreamInterceptor(streamInterceptors...),
 		grpc.WithDefaultServiceConfig(`{"loadBalancingPolicy":"round_robin"}`),
 		// Fast connection backoff for quicker recovery from transient failures (e.g. during pod

--- a/pkg/services/authz/zanzana_test.go
+++ b/pkg/services/authz/zanzana_test.go
@@ -1,0 +1,38 @@
+package authz
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+func TestUnaryDefaultTimeout(t *testing.T) {
+	interceptor := unaryDefaultTimeout(defaultCallTimeout)
+
+	invoke := func(ctx context.Context) (deadline time.Time, ok bool) {
+		invoker := func(ctx context.Context, _ string, _, _ any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
+			deadline, ok = ctx.Deadline()
+			return nil
+		}
+		require.NoError(t, interceptor(ctx, "method", nil, nil, nil, invoker))
+		return deadline, ok
+	}
+
+	t.Run("adds deadline when context has none", func(t *testing.T) {
+		deadline, ok := invoke(context.Background())
+		require.True(t, ok)
+		require.WithinDuration(t, time.Now().Add(defaultCallTimeout), deadline, time.Minute)
+	})
+
+	t.Run("keeps existing deadline", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+
+		deadline, ok := invoke(ctx)
+		require.True(t, ok)
+		require.WithinDuration(t, time.Now().Add(time.Second), deadline, time.Minute)
+	})
+}

--- a/pkg/setting/settings_zanzana.go
+++ b/pkg/setting/settings_zanzana.go
@@ -50,6 +50,11 @@ type ZanzanaClientSettings struct {
 	// PrimaryEngine selects which engine is on the hot path when the shadow
 	// client is active. Accepted values: "rbac" (default) and "zanzana".
 	PrimaryEngine ZanzanaPrimaryEngine
+	// KeepaliveTime is the gRPC client keepalive ping interval, used to detect dead
+	// connections. Must exceed the server's keepalive enforcement min_time (gRPC default
+	// is 5m) or the server closes the connection. Zero disables keepalive pings.
+	// Only used when mode is set to client.
+	KeepaliveTime time.Duration
 }
 
 type ZanzanaReconcilerMode string
@@ -300,6 +305,7 @@ func (cfg *Cfg) readZanzanaSettings() {
 
 	zc.Addr = clientSec.Key("address").MustString("")
 	zc.ServerCertFile = clientSec.Key("tls_cert").MustString("")
+	zc.KeepaliveTime = clientSec.Key("grpc_client_keepalive_time").MustDuration(6 * time.Minute)
 
 	grpcClientAuthSection := cfg.SectionWithEnvOverrides("grpc_client_authentication")
 	zc.Token = grpcClientAuthSection.Key("token").MustString("")

--- a/pkg/setting/settings_zanzana_test.go
+++ b/pkg/setting/settings_zanzana_test.go
@@ -2,6 +2,7 @@ package setting
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -113,5 +114,31 @@ experimentals = enable-check-optimizations
 `))
 		require.NoError(t, err)
 		assert.Equal(t, []string{"weighted_graph_check"}, cfg.ZanzanaServer.OpenFgaServerSettings.Experimentals)
+	})
+}
+
+func TestReadZanzanaSettings_ClientKeepalive(t *testing.T) {
+	t.Run("defaults to 6m", func(t *testing.T) {
+		cfg, err := NewCfgFromBytes(nil)
+		require.NoError(t, err)
+		assert.Equal(t, 6*time.Minute, cfg.ZanzanaClient.KeepaliveTime)
+	})
+
+	t.Run("reads keepalive time from config", func(t *testing.T) {
+		cfg, err := NewCfgFromBytes([]byte(`
+[zanzana.client]
+grpc_client_keepalive_time = 30s
+`))
+		require.NoError(t, err)
+		assert.Equal(t, 30*time.Second, cfg.ZanzanaClient.KeepaliveTime)
+	})
+
+	t.Run("zero disables keepalive", func(t *testing.T) {
+		cfg, err := NewCfgFromBytes([]byte(`
+[zanzana.client]
+grpc_client_keepalive_time = 0
+`))
+		require.NoError(t, err)
+		assert.Equal(t, time.Duration(0), cfg.ZanzanaClient.KeepaliveTime)
 	})
 }


### PR DESCRIPTION
**What is this feature?**

Hardens the folder app's Zanzana gRPC client after an incident where folder permission writes hung for up to ~5 hours against a silently dead Zanzana pod.

- 15s per-call timeout on SetFolderParent/DeleteFolderParents — delete hooks call with context.Background(), so a dead connection blocked calls indefinitely. Now every write fails within 15s regardless of connection state.
- Client keepalive pings (default 6m, [zanzana.client] grpc_client_keepalive_time) — detects connections where the peer stopped responding but TCP stayed up, and tears them down instead of waiting for the pod to be externally killed. Default stays above gRPC's 5m server-side ping enforcement minimum.
- Fast reconnect backoff (100ms base, 10s cap) — replaces gRPC's default backoff (up to 120s between attempts), matching the pattern already used by unified storage, ring, and apiserver storage clients for pod-restart recovery.
- Retry + round_robin — retries transient Unavailable/ResourceExhausted/Aborted failures (3 attempts) so graceful pod restarts don't surface as errors; round_robin avoids pick_first latching onto a dead pod IP.

**Why do we need this feature?**

A Zanzana pod became unresponsive without closing connections. Every folder permission write blocked with no timeout, no dead-connection detection, and no retry — calls queued for hours and only failed when Kubernetes finally restarted the pod.