### PR TITLE
Zanzana: Harden gRPC client against unresponsive server connections

### DIFF
--- a/pkg/services/authz/zanzana.go
+++ b/pkg/services/authz/zanzana.go
@@ -13,14 +13,18 @@ import (
 	"github.com/grafana/authlib/types"
 	"github.com/grafana/dskit/middleware"
 	"github.com/grafana/dskit/services"
+	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
 	grpcAuth "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/auth"
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/backoff"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	healthv1pb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/keepalive"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	clientrest "k8s.io/client-go/rest"
 
@@ -60,6 +64,7 @@ func ProvideZanzanaClient(cfg *setting.Cfg, db db.DB, zanzanaServer zanzana.Serv
 			TokenExchangeURL: cfg.ZanzanaClient.TokenExchangeURL,
 			TokenNamespace:   cfg.ZanzanaClient.TokenNamespace,
 			ServerCertFile:   cfg.ZanzanaClient.ServerCertFile,
+			KeepaliveTime:    cfg.ZanzanaClient.KeepaliveTime,
 		}
 		return NewRemoteZanzanaClient(zanzanaConfig, reg)
 
@@ -237,6 +242,7 @@ func ProvideStandaloneZanzanaClient(cfg *setting.Cfg, features featuremgmt.Featu
 		TokenExchangeURL: cfg.ZanzanaClient.TokenExchangeURL,
 		TokenNamespace:   cfg.ZanzanaClient.TokenNamespace,
 		ServerCertFile:   cfg.ZanzanaClient.ServerCertFile,
+		KeepaliveTime:    cfg.ZanzanaClient.KeepaliveTime,
 	}
 
 	return NewRemoteZanzanaClient(zanzanaConfig, reg)
@@ -248,6 +254,22 @@ type ZanzanaClientConfig struct {
 	TokenExchangeURL string
 	TokenNamespace   string
 	ServerCertFile   string
+	KeepaliveTime    time.Duration
+}
+
+// defaultCallTimeout is applied to unary calls whose context carries no deadline. It spans
+// all retry attempts, so it must comfortably exceed the retry interceptor's total backoff.
+const defaultCallTimeout = 30 * time.Second
+
+func unaryDefaultTimeout(timeout time.Duration) grpc.UnaryClientInterceptor {
+	return func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, timeout)
+			defer cancel()
+		}
+		return invoker(ctx, method, req, reply, cc, opts...)
+	}
 }
 
 // NewRemoteZanzanaClient creates a new Zanzana client that connects to remote Zanzana server.
@@ -277,13 +299,45 @@ func NewRemoteZanzanaClient(cfg ZanzanaClientConfig, reg prometheus.Registerer) 
 	}, []string{"operation", "status_code"})
 	unaryInterceptors, streamInterceptors := instrument(authzRequestDuration, middleware.ReportGRPCStatusOption)
 
+	// Retry transient failures so in-flight calls survive server pod restarts (e.g. GOAWAY on shutdown).
+	retryInterceptor := grpc_retry.UnaryClientInterceptor(
+		grpc_retry.WithMax(3),
+		grpc_retry.WithBackoff(grpc_retry.BackoffExponentialWithJitter(time.Second, 0.5)),
+		grpc_retry.WithCodes(codes.ResourceExhausted, codes.Unavailable, codes.Aborted),
+	)
+
+	// Background callers (reconcilers, hooks) may pass contexts without deadlines; a default
+	// deadline prevents calls from blocking indefinitely on an unresponsive connection.
+	timeoutInterceptor := unaryDefaultTimeout(defaultCallTimeout)
+
 	dialOptions := []grpc.DialOption{
 		grpc.WithTransportCredentials(transportCredentials),
 		grpc.WithPerRPCCredentials(
 			NewGRPCTokenAuth(AuthzServiceAudience, cfg.TokenNamespace, tokenClient),
 		),
-		grpc.WithChainUnaryInterceptor(unaryInterceptors...),
+		grpc.WithChainUnaryInterceptor(append([]grpc.UnaryClientInterceptor{timeoutInterceptor, retryInterceptor}, unaryInterceptors...)...),
 		grpc.WithChainStreamInterceptor(streamInterceptors...),
+		grpc.WithDefaultServiceConfig(`{"loadBalancingPolicy":"round_robin"}`),
+		// Fast connection backoff for quicker recovery from transient failures (e.g. during pod
+		// restarts). Default gRPC backoff waits up to 120s between reconnect attempts.
+		grpc.WithConnectParams(grpc.ConnectParams{
+			Backoff: backoff.Config{
+				BaseDelay:  100 * time.Millisecond,
+				Multiplier: 1.6,
+				Jitter:     0.2,
+				MaxDelay:   10 * time.Second,
+			},
+			MinConnectTimeout: 5 * time.Second,
+		}),
+	}
+
+	// Keepalive pings detect silently dead connections (e.g. an unresponsive server pod)
+	// that would otherwise block calls until the peer is torn down externally.
+	if cfg.KeepaliveTime > 0 {
+		dialOptions = append(dialOptions, grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			Time:    cfg.KeepaliveTime,
+			Timeout: 10 * time.Second,
+		}))
 	}
 
 	conn, err := grpc.NewClient(cfg.Addr, dialOptions...)

--- a/pkg/services/authz/zanzana.go
+++ b/pkg/services/authz/zanzana.go
@@ -319,11 +319,12 @@ func NewRemoteZanzanaClient(cfg ZanzanaClientConfig, reg prometheus.Registerer) 
 	unaryInterceptors, streamInterceptors := instrument(authzRequestDuration, middleware.ReportGRPCStatusOption)
 
 	// Retry transient failures so in-flight calls survive server pod restarts (e.g. GOAWAY on shutdown).
+	// Worst case fits the 30s default call deadline: 3x8s attempts + ~4.5s jittered backoff.
 	retryInterceptor := grpc_retry.UnaryClientInterceptor(
 		grpc_retry.WithMax(3),
 		grpc_retry.WithBackoff(grpc_retry.BackoffExponentialWithJitter(time.Second, 0.5)),
 		grpc_retry.WithCodes(codes.ResourceExhausted, codes.Unavailable, codes.Aborted),
-		grpc_retry.WithPerRetryTimeout(10*time.Second),
+		grpc_retry.WithPerRetryTimeout(8*time.Second),
 	)
 
 	// Metrics/tracing outermost so a retried call records one duration entry, then the

--- a/pkg/services/authz/zanzana.go
+++ b/pkg/services/authz/zanzana.go
@@ -319,13 +319,18 @@ func NewRemoteZanzanaClient(cfg ZanzanaClientConfig, reg prometheus.Registerer) 
 	unaryInterceptors, streamInterceptors := instrument(authzRequestDuration, middleware.ReportGRPCStatusOption)
 
 	// Retry transient failures so in-flight calls survive server pod restarts (e.g. GOAWAY on shutdown).
-	// Worst case fits the 30s default call deadline: 3x8s attempts + ~4.5s jittered backoff.
-	retryInterceptor := grpc_retry.UnaryClientInterceptor(
+	retryOptions := []grpc_retry.CallOption{
 		grpc_retry.WithMax(3),
 		grpc_retry.WithBackoff(grpc_retry.BackoffExponentialWithJitter(time.Second, 0.5)),
 		grpc_retry.WithCodes(codes.ResourceExhausted, codes.Unavailable, codes.Aborted),
-		grpc_retry.WithPerRetryTimeout(8*time.Second),
-	)
+	}
+	if cfg.CallTimeout > 0 {
+		// Cap each attempt at a quarter of the call deadline so all three retries plus
+		// backoff fit within it; a hung attempt is cut early and retried instead of one
+		// attempt consuming the whole budget.
+		retryOptions = append(retryOptions, grpc_retry.WithPerRetryTimeout(cfg.CallTimeout/4))
+	}
+	retryInterceptor := grpc_retry.UnaryClientInterceptor(retryOptions...)
 
 	// Metrics/tracing outermost so a retried call records one duration entry, then the
 	// default deadline spanning all attempts, then retry, then the per-attempt retry counter.

--- a/pkg/services/authz/zanzana.go
+++ b/pkg/services/authz/zanzana.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/fullstorydev/grpchan/inprocgrpc"
@@ -14,6 +15,7 @@ import (
 	"github.com/grafana/dskit/middleware"
 	"github.com/grafana/dskit/services"
 	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
+	"github.com/grpc-ecosystem/go-grpc-middleware/util/metautils"
 	grpcAuth "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/auth"
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	"github.com/prometheus/client_golang/prometheus"
@@ -65,6 +67,7 @@ func ProvideZanzanaClient(cfg *setting.Cfg, db db.DB, zanzanaServer zanzana.Serv
 			TokenNamespace:   cfg.ZanzanaClient.TokenNamespace,
 			ServerCertFile:   cfg.ZanzanaClient.ServerCertFile,
 			KeepaliveTime:    cfg.ZanzanaClient.KeepaliveTime,
+			CallTimeout:      cfg.ZanzanaClient.CallTimeout,
 		}
 		return NewRemoteZanzanaClient(zanzanaConfig, reg)
 
@@ -243,6 +246,7 @@ func ProvideStandaloneZanzanaClient(cfg *setting.Cfg, features featuremgmt.Featu
 		TokenNamespace:   cfg.ZanzanaClient.TokenNamespace,
 		ServerCertFile:   cfg.ZanzanaClient.ServerCertFile,
 		KeepaliveTime:    cfg.ZanzanaClient.KeepaliveTime,
+		CallTimeout:      cfg.ZanzanaClient.CallTimeout,
 	}
 
 	return NewRemoteZanzanaClient(zanzanaConfig, reg)
@@ -255,18 +259,29 @@ type ZanzanaClientConfig struct {
 	TokenNamespace   string
 	ServerCertFile   string
 	KeepaliveTime    time.Duration
+	CallTimeout      time.Duration
 }
 
-// defaultCallTimeout is applied to unary calls whose context carries no deadline. It spans
+// unaryDefaultTimeout applies a deadline to calls whose context carries no deadline. It spans
 // all retry attempts, so it must comfortably exceed the retry interceptor's total backoff.
-const defaultCallTimeout = 30 * time.Second
-
 func unaryDefaultTimeout(timeout time.Duration) grpc.UnaryClientInterceptor {
 	return func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 		if _, hasDeadline := ctx.Deadline(); !hasDeadline {
 			var cancel context.CancelFunc
 			ctx, cancel = context.WithTimeout(ctx, timeout)
 			defer cancel()
+		}
+		return invoker(ctx, method, req, reply, cc, opts...)
+	}
+}
+
+// unaryRetryInstrument counts retried attempts, identified by the retry attempt metadata
+// the retry interceptor sets on each re-invocation.
+func unaryRetryInstrument(metric *prometheus.CounterVec) grpc.UnaryClientInterceptor {
+	return func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		attempt, err := strconv.Atoi(metautils.ExtractOutgoing(ctx).Get(grpc_retry.AttemptMetadataKey))
+		if err == nil && attempt > 0 {
+			metric.WithLabelValues(method).Inc()
 		}
 		return invoker(ctx, method, req, reply, cc, opts...)
 	}
@@ -297,6 +312,10 @@ func NewRemoteZanzanaClient(cfg ZanzanaClientConfig, reg prometheus.Registerer) 
 		NativeHistogramMaxBucketNumber:  160,
 		NativeHistogramMinResetDuration: time.Hour,
 	}, []string{"operation", "status_code"})
+	authzRequestRetries := promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+		Name: "authz_zanzana_grpc_client_request_retries_total",
+		Help: "Total number of retries for requests to zanzana server.",
+	}, []string{"operation"})
 	unaryInterceptors, streamInterceptors := instrument(authzRequestDuration, middleware.ReportGRPCStatusOption)
 
 	// Retry transient failures so in-flight calls survive server pod restarts (e.g. GOAWAY on shutdown).
@@ -304,18 +323,25 @@ func NewRemoteZanzanaClient(cfg ZanzanaClientConfig, reg prometheus.Registerer) 
 		grpc_retry.WithMax(3),
 		grpc_retry.WithBackoff(grpc_retry.BackoffExponentialWithJitter(time.Second, 0.5)),
 		grpc_retry.WithCodes(codes.ResourceExhausted, codes.Unavailable, codes.Aborted),
+		grpc_retry.WithPerRetryTimeout(10*time.Second),
 	)
 
-	// Background callers (reconcilers, hooks) may pass contexts without deadlines; a default
-	// deadline prevents calls from blocking indefinitely on an unresponsive connection.
-	timeoutInterceptor := unaryDefaultTimeout(defaultCallTimeout)
+	// Metrics/tracing outermost so a retried call records one duration entry, then the
+	// default deadline spanning all attempts, then retry, then the per-attempt retry counter.
+	unaryChain := unaryInterceptors
+	if cfg.CallTimeout > 0 {
+		// Background callers (reconcilers, hooks) may pass contexts without deadlines; a default
+		// deadline prevents calls from blocking indefinitely on an unresponsive connection.
+		unaryChain = append(unaryChain, unaryDefaultTimeout(cfg.CallTimeout))
+	}
+	unaryChain = append(unaryChain, retryInterceptor, unaryRetryInstrument(authzRequestRetries))
 
 	dialOptions := []grpc.DialOption{
 		grpc.WithTransportCredentials(transportCredentials),
 		grpc.WithPerRPCCredentials(
 			NewGRPCTokenAuth(AuthzServiceAudience, cfg.TokenNamespace, tokenClient),
 		),
-		grpc.WithChainUnaryInterceptor(append([]grpc.UnaryClientInterceptor{timeoutInterceptor, retryInterceptor}, unaryInterceptors...)...),
+		grpc.WithChainUnaryInterceptor(unaryChain...),
 		grpc.WithChainStreamInterceptor(streamInterceptors...),
 		grpc.WithDefaultServiceConfig(`{"loadBalancingPolicy":"round_robin"}`),
 		// Fast connection backoff for quicker recovery from transient failures (e.g. during pod

--- a/pkg/services/authz/zanzana.go
+++ b/pkg/services/authz/zanzana.go
@@ -262,14 +262,17 @@ type ZanzanaClientConfig struct {
 	CallTimeout      time.Duration
 }
 
-// unaryDefaultTimeout applies a deadline to calls whose context carries no deadline. It spans
-// all retry attempts, so it must comfortably exceed the retry interceptor's total backoff.
+// unaryDefaultTimeout applies a deadline to calls whose context carries no deadline, plus a
+// per-attempt cap so all retries fit within it. Callers that bring their own deadline sized
+// their budget deliberately and keep it untouched — one attempt may use it in full.
 func unaryDefaultTimeout(timeout time.Duration) grpc.UnaryClientInterceptor {
 	return func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 		if _, hasDeadline := ctx.Deadline(); !hasDeadline {
 			var cancel context.CancelFunc
 			ctx, cancel = context.WithTimeout(ctx, timeout)
 			defer cancel()
+			// A quarter of the deadline per attempt leaves room for three attempts plus backoff.
+			opts = append(opts, grpc_retry.WithPerRetryTimeout(timeout/4))
 		}
 		return invoker(ctx, method, req, reply, cc, opts...)
 	}
@@ -318,19 +321,14 @@ func NewRemoteZanzanaClient(cfg ZanzanaClientConfig, reg prometheus.Registerer) 
 	}, []string{"operation"})
 	unaryInterceptors, streamInterceptors := instrument(authzRequestDuration, middleware.ReportGRPCStatusOption)
 
-	// Retry transient failures so in-flight calls survive server pod restarts (e.g. GOAWAY on shutdown).
-	retryOptions := []grpc_retry.CallOption{
+	// Retry transient failures so in-flight calls survive server pod restarts (e.g. GOAWAY on
+	// shutdown). Per-attempt timeouts are attached per call by unaryDefaultTimeout, which
+	// knows each call's actual deadline.
+	retryInterceptor := grpc_retry.UnaryClientInterceptor(
 		grpc_retry.WithMax(3),
 		grpc_retry.WithBackoff(grpc_retry.BackoffExponentialWithJitter(time.Second, 0.5)),
 		grpc_retry.WithCodes(codes.ResourceExhausted, codes.Unavailable, codes.Aborted),
-	}
-	if cfg.CallTimeout > 0 {
-		// Cap each attempt at a quarter of the call deadline so all three retries plus
-		// backoff fit within it; a hung attempt is cut early and retried instead of one
-		// attempt consuming the whole budget.
-		retryOptions = append(retryOptions, grpc_retry.WithPerRetryTimeout(cfg.CallTimeout/4))
-	}
-	retryInterceptor := grpc_retry.UnaryClientInterceptor(retryOptions...)
+	)
 
 	// Metrics/tracing outermost so a retried call records one duration entry, then the
 	// default deadline spanning all attempts, then retry, then the per-attempt retry counter.

--- a/pkg/services/authz/zanzana_test.go
+++ b/pkg/services/authz/zanzana_test.go
@@ -10,7 +10,8 @@ import (
 )
 
 func TestUnaryDefaultTimeout(t *testing.T) {
-	interceptor := unaryDefaultTimeout(defaultCallTimeout)
+	callTimeout := 30 * time.Second
+	interceptor := unaryDefaultTimeout(callTimeout)
 
 	invoke := func(ctx context.Context) (deadline time.Time, ok bool) {
 		invoker := func(ctx context.Context, _ string, _, _ any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
@@ -24,7 +25,7 @@ func TestUnaryDefaultTimeout(t *testing.T) {
 	t.Run("adds deadline when context has none", func(t *testing.T) {
 		deadline, ok := invoke(context.Background())
 		require.True(t, ok)
-		require.WithinDuration(t, time.Now().Add(defaultCallTimeout), deadline, 5*time.Second)
+		require.WithinDuration(t, time.Now().Add(callTimeout), deadline, 5*time.Second)
 	})
 
 	t.Run("keeps existing deadline", func(t *testing.T) {

--- a/pkg/services/authz/zanzana_test.go
+++ b/pkg/services/authz/zanzana_test.go
@@ -35,13 +35,15 @@ func TestUnaryDefaultTimeout(t *testing.T) {
 		require.Equal(t, 1, retryOpts)
 	})
 
-	t.Run("keeps existing deadline and adds no per-attempt timeout", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	// Longer than the default deadline, so wrongly applying the default would tighten it
+	// and fail the assertion; a shorter one would survive by winning the earlier-deadline rule.
+	t.Run("keeps existing longer deadline and adds no per-attempt timeout", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 		defer cancel()
 
 		deadline, ok, retryOpts := invoke(ctx)
 		require.True(t, ok)
-		require.WithinDuration(t, time.Now().Add(time.Second), deadline, 5*time.Second)
+		require.WithinDuration(t, time.Now().Add(60*time.Second), deadline, 5*time.Second)
 		require.Zero(t, retryOpts)
 	})
 }

--- a/pkg/services/authz/zanzana_test.go
+++ b/pkg/services/authz/zanzana_test.go
@@ -1,0 +1,38 @@
+package authz
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+func TestUnaryDefaultTimeout(t *testing.T) {
+	interceptor := unaryDefaultTimeout(defaultCallTimeout)
+
+	invoke := func(ctx context.Context) (deadline time.Time, ok bool) {
+		invoker := func(ctx context.Context, _ string, _, _ any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
+			deadline, ok = ctx.Deadline()
+			return nil
+		}
+		require.NoError(t, interceptor(ctx, "method", nil, nil, nil, invoker))
+		return deadline, ok
+	}
+
+	t.Run("adds deadline when context has none", func(t *testing.T) {
+		deadline, ok := invoke(context.Background())
+		require.True(t, ok)
+		require.WithinDuration(t, time.Now().Add(defaultCallTimeout), deadline, time.Minute)
+	})
+
+	t.Run("keeps existing deadline", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+
+		deadline, ok := invoke(ctx)
+		require.True(t, ok)
+		require.WithinDuration(t, time.Now().Add(time.Second), deadline, time.Minute)
+	})
+}

--- a/pkg/services/authz/zanzana_test.go
+++ b/pkg/services/authz/zanzana_test.go
@@ -24,7 +24,7 @@ func TestUnaryDefaultTimeout(t *testing.T) {
 	t.Run("adds deadline when context has none", func(t *testing.T) {
 		deadline, ok := invoke(context.Background())
 		require.True(t, ok)
-		require.WithinDuration(t, time.Now().Add(defaultCallTimeout), deadline, time.Minute)
+		require.WithinDuration(t, time.Now().Add(defaultCallTimeout), deadline, 5*time.Second)
 	})
 
 	t.Run("keeps existing deadline", func(t *testing.T) {
@@ -33,6 +33,6 @@ func TestUnaryDefaultTimeout(t *testing.T) {
 
 		deadline, ok := invoke(ctx)
 		require.True(t, ok)
-		require.WithinDuration(t, time.Now().Add(time.Second), deadline, time.Minute)
+		require.WithinDuration(t, time.Now().Add(time.Second), deadline, 5*time.Second)
 	})
 }

--- a/pkg/services/authz/zanzana_test.go
+++ b/pkg/services/authz/zanzana_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 )
@@ -13,27 +14,34 @@ func TestUnaryDefaultTimeout(t *testing.T) {
 	callTimeout := 30 * time.Second
 	interceptor := unaryDefaultTimeout(callTimeout)
 
-	invoke := func(ctx context.Context) (deadline time.Time, ok bool) {
-		invoker := func(ctx context.Context, _ string, _, _ any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
+	invoke := func(ctx context.Context) (deadline time.Time, ok bool, retryOpts int) {
+		invoker := func(ctx context.Context, _ string, _, _ any, _ *grpc.ClientConn, opts ...grpc.CallOption) error {
 			deadline, ok = ctx.Deadline()
+			for _, o := range opts {
+				if _, isRetryOpt := o.(grpc_retry.CallOption); isRetryOpt {
+					retryOpts++
+				}
+			}
 			return nil
 		}
 		require.NoError(t, interceptor(ctx, "method", nil, nil, nil, invoker))
-		return deadline, ok
+		return deadline, ok, retryOpts
 	}
 
-	t.Run("adds deadline when context has none", func(t *testing.T) {
-		deadline, ok := invoke(context.Background())
+	t.Run("adds deadline and per-attempt timeout when context has none", func(t *testing.T) {
+		deadline, ok, retryOpts := invoke(context.Background())
 		require.True(t, ok)
 		require.WithinDuration(t, time.Now().Add(callTimeout), deadline, 5*time.Second)
+		require.Equal(t, 1, retryOpts)
 	})
 
-	t.Run("keeps existing deadline", func(t *testing.T) {
+	t.Run("keeps existing deadline and adds no per-attempt timeout", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 		defer cancel()
 
-		deadline, ok := invoke(ctx)
+		deadline, ok, retryOpts := invoke(ctx)
 		require.True(t, ok)
 		require.WithinDuration(t, time.Now().Add(time.Second), deadline, 5*time.Second)
+		require.Zero(t, retryOpts)
 	})
 }

--- a/pkg/setting/settings_zanzana.go
+++ b/pkg/setting/settings_zanzana.go
@@ -55,6 +55,10 @@ type ZanzanaClientSettings struct {
 	// is 5m) or the server closes the connection. Zero disables keepalive pings.
 	// Only used when mode is set to client.
 	KeepaliveTime time.Duration
+	// CallTimeout is the deadline applied to calls whose context has none, so background
+	// callers cannot block indefinitely on an unresponsive connection. It spans all retry
+	// attempts. Zero disables the default deadline. Only used when mode is set to client.
+	CallTimeout time.Duration
 }
 
 type ZanzanaReconcilerMode string
@@ -306,6 +310,7 @@ func (cfg *Cfg) readZanzanaSettings() {
 	zc.Addr = clientSec.Key("address").MustString("")
 	zc.ServerCertFile = clientSec.Key("tls_cert").MustString("")
 	zc.KeepaliveTime = clientSec.Key("grpc_client_keepalive_time").MustDuration(6 * time.Minute)
+	zc.CallTimeout = clientSec.Key("grpc_client_timeout").MustDuration(30 * time.Second)
 
 	grpcClientAuthSection := cfg.SectionWithEnvOverrides("grpc_client_authentication")
 	zc.Token = grpcClientAuthSection.Key("token").MustString("")

--- a/pkg/setting/settings_zanzana.go
+++ b/pkg/setting/settings_zanzana.go
@@ -50,6 +50,11 @@ type ZanzanaClientSettings struct {
 	// PrimaryEngine selects which engine is on the hot path when the shadow
 	// client is active. Accepted values: "rbac" (default) and "zanzana".
 	PrimaryEngine ZanzanaPrimaryEngine
+	// KeepaliveTime is the gRPC client keepalive ping interval, used to detect dead
+	// connections. Must exceed the server's keepalive enforcement min_time (gRPC default
+	// is 5m) or the server closes the connection. Zero disables keepalive pings.
+	// Only used when mode is set to client.
+	KeepaliveTime time.Duration
 }
 
 type ZanzanaReconcilerMode string
@@ -300,6 +305,7 @@ func (cfg *Cfg) readZanzanaSettings() {
 
 	zc.Addr = clientSec.Key("address").MustString("")
 	zc.ServerCertFile = clientSec.Key("tls_cert").MustString("")
+	zc.KeepaliveTime = clientSec.Key("grpc_client_keepalive_time").MustDuration(6 * time.Minute)
 
 	grpcClientAuthSection := cfg.SectionWithEnvOverrides("grpc_client_authentication")
 	zc.Token = grpcClientAuthSection.Key("token").MustString("")

--- a/pkg/setting/settings_zanzana_test.go
+++ b/pkg/setting/settings_zanzana_test.go
@@ -142,3 +142,20 @@ grpc_client_keepalive_time = 0
 		assert.Equal(t, time.Duration(0), cfg.ZanzanaClient.KeepaliveTime)
 	})
 }
+
+func TestReadZanzanaSettings_ClientCallTimeout(t *testing.T) {
+	t.Run("defaults to 30s", func(t *testing.T) {
+		cfg, err := NewCfgFromBytes(nil)
+		require.NoError(t, err)
+		assert.Equal(t, 30*time.Second, cfg.ZanzanaClient.CallTimeout)
+	})
+
+	t.Run("reads timeout from config", func(t *testing.T) {
+		cfg, err := NewCfgFromBytes([]byte(`
+[zanzana.client]
+grpc_client_timeout = 10s
+`))
+		require.NoError(t, err)
+		assert.Equal(t, 10*time.Second, cfg.ZanzanaClient.CallTimeout)
+	})
+}

--- a/pkg/setting/settings_zanzana_test.go
+++ b/pkg/setting/settings_zanzana_test.go
@@ -2,6 +2,7 @@ package setting
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -113,5 +114,31 @@ experimentals = enable-check-optimizations
 `))
 		require.NoError(t, err)
 		assert.Equal(t, []string{"weighted_graph_check"}, cfg.ZanzanaServer.OpenFgaServerSettings.Experimentals)
+	})
+}
+
+func TestReadZanzanaSettings_ClientKeepalive(t *testing.T) {
+	t.Run("defaults to 6m", func(t *testing.T) {
+		cfg, err := NewCfgFromBytes(nil)
+		require.NoError(t, err)
+		assert.Equal(t, 6*time.Minute, cfg.ZanzanaClient.KeepaliveTime)
+	})
+
+	t.Run("reads keepalive time from config", func(t *testing.T) {
+		cfg, err := NewCfgFromBytes([]byte(`
+[zanzana.client]
+grpc_client_keepalive_time = 30s
+`))
+		require.NoError(t, err)
+		assert.Equal(t, 30*time.Second, cfg.ZanzanaClient.KeepaliveTime)
+	})
+
+	t.Run("zero disables keepalive", func(t *testing.T) {
+		cfg, err := NewCfgFromBytes([]byte(`
+[zanzana.client]
+grpc_client_keepalive_time = 0
+`))
+		require.NoError(t, err)
+		assert.Equal(t, time.Duration(0), cfg.ZanzanaClient.KeepaliveTime)
 	})
 }


### PR DESCRIPTION
Calls to an unresponsive Zanzana pod could hang for hours: the client had no way to detect a silently dead connection, no deadline on calls from background paths, and slow default reconnect backoff.  We can see we had a bunch of calls just sitting there until the pod was finally killed https://ops.grafana-ops.net/goto/sbphmt?orgId=stacks-27821.

This adds:

- client keepalive pings to detect dead connections (default 6m, configurable via [zanzana.client] grpc_client_keepalive_time)
- default 30s deadline on unary calls whose context has none
- fast reconnect backoff (100ms-10s) instead of gRPC default (max 120s)
- retry on transient codes and round_robin load balancing


See https://raintank-corp.slack.com/archives/C06JFJ7H3GC/p1785348861041389 for slack context