### PR TITLE
Annotations: handle /mass-delete in migration proxy

### DIFF
--- a/pkg/services/annotations/annotationsapi/handler.go
+++ b/pkg/services/annotations/annotationsapi/handler.go
@@ -293,6 +293,32 @@ func (h *MigrationProxy) Delete(ctx context.Context, orgID int64, annotationID i
 	return h.client.Delete(ctx, orgID, existing.GetName())
 }
 
+// MassDelete removes every annotation on a dashboard panel from the new store.
+// The new API has no delete-collection route, so this enumerates the panel's annotations
+// via /search and deletes them one by one.
+func (h *MigrationProxy) MassDelete(ctx context.Context, orgID int64, dashboardUID string, panelID int64) error {
+	query := &annotations.ItemQuery{DashboardUID: dashboardUID, PanelID: panelID}
+	const maxMassDeletePasses = 1000
+	for range maxMassDeletePasses {
+		annos, err := h.client.Search(ctx, orgID, query)
+		if err != nil {
+			return err
+		}
+		// Continue querying relevant annotations until the list is empty.
+		if len(annos) == 0 {
+			return nil
+		}
+
+		for _, anno := range annos {
+			if err := h.client.Delete(ctx, orgID, anno.GetName()); err != nil {
+				return fmt.Errorf("deleting annotation %q: %w", anno.GetName(), err)
+			}
+		}
+	}
+
+	return fmt.Errorf("annotation mass delete: exceeded %d passes for dashboard %q panel %d", maxMassDeletePasses, dashboardUID, panelID)
+}
+
 // Get reads a single annotation from the new store. Returns ErrNotFound if the
 // record is not there yet (caller falls back to legacy) or ErrGone if it was
 // soft-deleted (caller must not fall back).

--- a/pkg/services/annotations/annotationsapi/handler_test.go
+++ b/pkg/services/annotations/annotationsapi/handler_test.go
@@ -2,6 +2,7 @@ package annotationsapi
 
 import (
 	"context"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -172,6 +173,10 @@ type fakeClient struct {
 	deletedNames []string
 	deleteErr    error
 	createErr    error
+
+	live      []annotationV0.Annotation
+	pageSize  int
+	searchErr error
 }
 
 func (f *fakeClient) GetByLegacyID(context.Context, int64, int64) (*annotationV0.Annotation, error) {
@@ -187,7 +192,28 @@ func (f *fakeClient) Update(_ context.Context, _ int64, anno *annotationV0.Annot
 }
 func (f *fakeClient) Delete(_ context.Context, _ int64, name string) error {
 	f.deletedNames = append(f.deletedNames, name)
-	return f.deleteErr
+	if f.deleteErr != nil {
+		return f.deleteErr
+	}
+	f.live = slices.DeleteFunc(f.live, func(a annotationV0.Annotation) bool {
+		return a.GetName() == name
+	})
+	return nil
+}
+
+// Search returns one page of the live annotations, mirroring the real store's server-side
+// limit: deletes remove items, so the remaining ones only surface on a later call.
+func (f *fakeClient) Search(_ context.Context, _ int64, _ *annotations.ItemQuery) ([]*annotationV0.Annotation, error) {
+	if f.searchErr != nil {
+		return nil, f.searchErr
+	}
+
+	live := slices.Clone(f.live[:min(f.pageSize, len(f.live))])
+	page := make([]*annotationV0.Annotation, len(live))
+	for i := range live {
+		page[i] = &live[i]
+	}
+	return page, nil
 }
 
 func TestMigrationProxy(t *testing.T) {
@@ -382,6 +408,63 @@ func TestMigrationProxy(t *testing.T) {
 			err := proxy.Update(context.Background(), orgID, legacyID, &annotations.Item{Text: "before", Epoch: 5000})
 			require.ErrorIs(t, err, assert.AnError)
 			assert.Empty(t, client.deletedNames, "the old record must not be deleted if the new one was not created")
+		})
+	})
+
+	t.Run("MassDelete", func(t *testing.T) {
+		const orgID = int64(1)
+
+		newProxy := func(client annotationClient) *MigrationProxy {
+			return &MigrationProxy{client: client, logger: log.New("test")}
+		}
+
+		live := func(names ...string) []annotationV0.Annotation {
+			annos := make([]annotationV0.Annotation, len(names))
+			for i, name := range names {
+				annos[i] = annotationV0.Annotation{ObjectMeta: metav1.ObjectMeta{Name: name}}
+			}
+			return annos
+		}
+
+		t.Run("deletes every annotation on the panel", func(t *testing.T) {
+			client := &fakeClient{live: live("a-1", "a-2"), pageSize: 10}
+			proxy := newProxy(client)
+
+			require.NoError(t, proxy.MassDelete(context.Background(), orgID, "dash-1", 2))
+			assert.Equal(t, []string{"a-1", "a-2"}, client.deletedNames)
+		})
+
+		t.Run("deletes every annotation when they span multiple pages", func(t *testing.T) {
+			client := &fakeClient{live: live("a-1", "a-2", "a-3", "a-4", "a-5"), pageSize: 2}
+			proxy := newProxy(client)
+
+			require.NoError(t, proxy.MassDelete(context.Background(), orgID, "dash-1", 2))
+			assert.Equal(t, []string{"a-1", "a-2", "a-3", "a-4", "a-5"}, client.deletedNames)
+			assert.Empty(t, client.live)
+		})
+
+		t.Run("is a no-op when the panel has no annotations", func(t *testing.T) {
+			client := &fakeClient{pageSize: 10}
+			proxy := newProxy(client)
+
+			require.NoError(t, proxy.MassDelete(context.Background(), orgID, "dash-1", 2))
+			assert.Empty(t, client.deletedNames)
+		})
+
+		t.Run("propagates a search failure", func(t *testing.T) {
+			client := &fakeClient{searchErr: assert.AnError, pageSize: 10}
+			proxy := newProxy(client)
+
+			require.ErrorIs(t, proxy.MassDelete(context.Background(), orgID, "dash-1", 2), assert.AnError)
+			assert.Empty(t, client.deletedNames)
+		})
+
+		t.Run("stops and propagates a delete failure", func(t *testing.T) {
+			client := &fakeClient{live: live("a-1", "a-2"), pageSize: 10, deleteErr: assert.AnError}
+			proxy := newProxy(client)
+
+			require.ErrorIs(t, proxy.MassDelete(context.Background(), orgID, "dash-1", 2), assert.AnError)
+			assert.Equal(t, []string{"a-1"}, client.deletedNames, "it stops at the first failure")
 		})
 	})
 

--- a/pkg/services/annotations/annotationsapi/migration_repository.go
+++ b/pkg/services/annotations/annotationsapi/migration_repository.go
@@ -17,6 +17,7 @@ type annotationProxy interface {
 	Create(ctx context.Context, orgID int64, item *annotations.Item) (int64, error)
 	Update(ctx context.Context, orgID int64, annotationID int64, item *annotations.Item) error
 	Delete(ctx context.Context, orgID int64, annotationID int64) error
+	MassDelete(ctx context.Context, orgID int64, dashboardUID string, panelID int64) error
 	Get(ctx context.Context, orgID int64, annotationID int64) (*annotations.ItemDTO, error)
 	List(ctx context.Context, orgID int64, query *annotations.ItemQuery) ([]*annotations.ItemDTO, error)
 	FindTags(ctx context.Context, orgID int64, query *annotations.TagsQuery) (annotations.FindTagsResult, error)
@@ -175,9 +176,9 @@ func (r *migrationRepository) Update(ctx context.Context, item *annotations.Item
 // When a record is already deleted in the new store (ErrGone), we still best-effort delete the
 // legacy record to ensure consistency.
 func (r *migrationRepository) Delete(ctx context.Context, params *annotations.DeleteParams) error {
-	// No ID means a mass delete by dashboard/panel, which the proxy can't express.
+	// No ID means a mass delete by dashboard/panel.
 	if params.ID == 0 {
-		return r.legacy.Delete(ctx, params)
+		return r.massDelete(ctx, params)
 	}
 	err := r.proxy.Delete(ctx, params.OrgID, params.ID)
 	switch {
@@ -194,6 +195,25 @@ func (r *migrationRepository) Delete(ctx context.Context, params *annotations.De
 	default:
 		return err
 	}
+}
+
+// massDelete removes every annotation on a dashboard panel from both stores.
+func (r *migrationRepository) massDelete(ctx context.Context, params *annotations.DeleteParams) error {
+	if params.DashboardUID == "" {
+		return errors.New("dashboard UID is required for mass delete")
+	}
+
+	if err := r.proxy.MassDelete(ctx, params.OrgID, params.DashboardUID, params.PanelID); err != nil {
+		return err
+	}
+
+	// Best-effort, matching the single delete pattern. A failure here means the annotations could
+	// briefly resurface in a merged read until legacy is retired. A retry would land here again and retry the cleanup.
+	if err := r.legacy.Delete(ctx, params); err != nil {
+		r.logger.Warn("failed to delete legacy copies after new-store mass delete",
+			"orgID", params.OrgID, "dashboardUID", params.DashboardUID, "panelID", params.PanelID, "err", err)
+	}
+	return nil
 }
 
 // FindTags reads tag counts from the new store and merges in what the legacy store still owns.

--- a/pkg/services/annotations/annotationsapi/migration_repository_test.go
+++ b/pkg/services/annotations/annotationsapi/migration_repository_test.go
@@ -72,6 +72,9 @@ type fakeProxy struct {
 	deleteErr   error
 	deleteCalls int
 
+	massDeleteErr   error
+	massDeleteCalls []massDeleteCall
+
 	findTagsResult annotations.FindTagsResult
 	findTagsErr    error
 	findTagsCalls  []*annotations.TagsQuery
@@ -80,6 +83,12 @@ type fakeProxy struct {
 func (f *fakeProxy) FindTags(_ context.Context, _ int64, query *annotations.TagsQuery) (annotations.FindTagsResult, error) {
 	f.findTagsCalls = append(f.findTagsCalls, query)
 	return f.findTagsResult, f.findTagsErr
+}
+
+type massDeleteCall struct {
+	orgID        int64
+	dashboardUID string
+	panelID      int64
 }
 
 func (f *fakeProxy) List(_ context.Context, _ int64, query *annotations.ItemQuery) ([]*annotations.ItemDTO, error) {
@@ -101,6 +110,10 @@ func (f *fakeProxy) Update(context.Context, int64, int64, *annotations.Item) err
 func (f *fakeProxy) Delete(context.Context, int64, int64) error {
 	f.deleteCalls++
 	return f.deleteErr
+}
+func (f *fakeProxy) MassDelete(_ context.Context, orgID int64, dashboardUID string, panelID int64) error {
+	f.massDeleteCalls = append(f.massDeleteCalls, massDeleteCall{orgID: orgID, dashboardUID: dashboardUID, panelID: panelID})
+	return f.massDeleteErr
 }
 
 type fakeReader struct {
@@ -508,14 +521,50 @@ func TestMigrationRepository_Delete(t *testing.T) {
 		require.Len(t, legacy.deleteParams, 1)
 	})
 
-	t.Run("mass delete by dashboard/panel goes straight to legacy", func(t *testing.T) {
+	t.Run("mass delete clears the new store then dual-deletes the legacy copies", func(t *testing.T) {
 		legacy := &fakeLegacy{}
 		proxy := &fakeProxy{}
 		repo := newTestRepo(t, "proxy-all", legacy, proxy, usertest.NewUserServiceFake())
 
-		require.NoError(t, repo.Delete(context.Background(), &annotations.DeleteParams{OrgID: 1, DashboardID: 9, PanelID: 2}))
-		assert.Zero(t, proxy.deleteCalls)
+		params := &annotations.DeleteParams{OrgID: 1, DashboardUID: "dash-1", PanelID: 2}
+		require.NoError(t, repo.Delete(context.Background(), params))
+
+		require.Len(t, proxy.massDeleteCalls, 1)
+		assert.Equal(t, massDeleteCall{orgID: 1, dashboardUID: "dash-1", panelID: 2}, proxy.massDeleteCalls[0])
 		require.Len(t, legacy.deleteParams, 1)
+		assert.Zero(t, proxy.deleteCalls, "mass delete must not use the single-delete path")
+	})
+
+	t.Run("mass delete succeeds even when the best-effort legacy delete fails", func(t *testing.T) {
+		legacy := &fakeLegacy{deleteErr: assert.AnError}
+		proxy := &fakeProxy{}
+		repo := newTestRepo(t, "proxy-all", legacy, proxy, usertest.NewUserServiceFake())
+
+		params := &annotations.DeleteParams{OrgID: 1, DashboardUID: "dash-1", PanelID: 2}
+		require.NoError(t, repo.Delete(context.Background(), params))
+		require.Len(t, proxy.massDeleteCalls, 1)
+	})
+
+	t.Run("mass delete propagates new-store errors without deleting the legacy copies", func(t *testing.T) {
+		legacy := &fakeLegacy{}
+		proxy := &fakeProxy{massDeleteErr: assert.AnError}
+		repo := newTestRepo(t, "proxy-all", legacy, proxy, usertest.NewUserServiceFake())
+
+		params := &annotations.DeleteParams{OrgID: 1, DashboardUID: "dash-1", PanelID: 2}
+		require.ErrorIs(t, repo.Delete(context.Background(), params), assert.AnError)
+		assert.Empty(t, legacy.deleteParams)
+	})
+
+	t.Run("mass delete without a dashboard UID fails without touching either store", func(t *testing.T) {
+		legacy := &fakeLegacy{}
+		proxy := &fakeProxy{}
+		repo := newTestRepo(t, "proxy-all", legacy, proxy, usertest.NewUserServiceFake())
+
+		params := &annotations.DeleteParams{OrgID: 1, DashboardID: 9, PanelID: 2}
+		require.ErrorContains(t, repo.Delete(context.Background(), params), "dashboard UID is required for mass delete")
+
+		assert.Empty(t, proxy.massDeleteCalls)
+		assert.Empty(t, legacy.deleteParams)
 	})
 }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR updates the `/mass-delete` functionality in the annotation migration proxy to delete annotations from both the new store and legacy store. This resolves a follow-up from the initial migration proxy work where we were only removing them from the legacy store.

Since the new annotation API does not have bulk delete functionality, the proxy lists annotations for the given dashboard/panel and then deletes them one-by-one.

**Why do we need this feature?**

To support `/mass-delete` when the legacy API is proxying to the new API during the migration.

**Who is this feature for?**

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana-org/issues/953

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
