### PR TITLE
Dashboard: Fix subpath duplication when closing panel edit with the e shortcut

### DIFF
--- a/public/app/features/dashboard-scene/scene/keyboardShortcuts.test.ts
+++ b/public/app/features/dashboard-scene/scene/keyboardShortcuts.test.ts
@@ -1,4 +1,7 @@
-import { LegacyGraphHoverClearEvent, SetPanelAttentionEvent } from '@grafana/data';
+import { createBrowserHistory } from 'history';
+
+import { type GrafanaConfig, LegacyGraphHoverClearEvent, locationUtil, SetPanelAttentionEvent } from '@grafana/data';
+import { HistoryWrapper, setLocationService } from '@grafana/runtime';
 import { behaviors, sceneGraph, SceneTimeRange, VizPanel } from '@grafana/scenes';
 import { DashboardCursorSync } from '@grafana/schema';
 import { appEvents } from 'app/core/app_events';
@@ -6,12 +9,14 @@ import { LS_PANEL_COPY_KEY } from 'app/core/constants';
 import { KeybindingSet } from 'app/core/services/KeybindingSet';
 import { mockLocalStorage } from 'app/features/alerting/unified/mocks';
 
+import { buildPanelEditScene } from '../panel-edit/PanelEditor';
 import { buildShareUrl } from '../sharing/ShareButton/utils';
 import { DashboardInteractions } from '../utils/interactions';
 import { findVizPanelByPathId } from '../utils/pathId';
 
 import { DashboardScene } from './DashboardScene';
 import { setupKeyboardShortcuts } from './keyboardShortcuts';
+import { DefaultGridLayoutManager } from './layout-default/DefaultGridLayoutManager';
 
 // Mock dependencies
 jest.mock('app/core/app_events', () => ({
@@ -280,6 +285,80 @@ describe('setupKeyboardShortcuts', () => {
     it('should setup dashboard settings shortcut (d s) when can edit', () => {
       const dsBinding = mockKeybindingSet.addBinding.mock.calls.find((call) => call[0].key === 'd s');
       expect(dsBinding).toBeDefined();
+    });
+  });
+
+  describe('panel edit shortcut (e) when Grafana is served under a subpath', () => {
+    const getBinding = (key: string) =>
+      mockKeybindingSet.addBinding.mock.calls.find((call) => call[0].key === key)?.[0];
+
+    function focusPanel(pathId: string) {
+      const attentionHandler = jest.mocked(appEvents.subscribe).mock.calls[0][1];
+      attentionHandler(new SetPanelAttentionEvent({ panelId: pathId }));
+    }
+
+    // The router basename is the subpath, so any path handed to locationService must be
+    // basename-relative — otherwise the subpath is prepended a second time.
+    function serveUnderSubpath(url: string) {
+      window.history.replaceState({}, '', url);
+      setLocationService(new HistoryWrapper(createBrowserHistory({ basename: '/grafana' })));
+    }
+
+    let panel: VizPanel;
+    let scene: DashboardScene;
+
+    beforeEach(() => {
+      locationUtil.initialize({
+        config: { appSubUrl: '/grafana' } as GrafanaConfig,
+        getVariablesUrlParams: jest.fn(),
+        getTimeRangeForUrl: jest.fn(),
+      });
+
+      // The panel needs to sit in the scene graph: the shortcut only acts when the focused
+      // panel's root is a DashboardScene, and buildPanelEditScene requires a layout item parent.
+      panel = new VizPanel({ key: 'panel-1', pluginId: 'table' });
+      scene = new DashboardScene({
+        title: 'Test Dashboard',
+        uid: 'test-uid',
+        $timeRange: new SceneTimeRange({ from: 'now-6h', to: 'now' }),
+        body: DefaultGridLayoutManager.fromVizPanels([panel]),
+      });
+
+      jest.spyOn(scene, 'canEditDashboard').mockReturnValue(true);
+      jest.mocked(findVizPanelByPathId).mockReturnValue(panel);
+      jest.spyOn(DashboardInteractions, 'panelActionClicked').mockImplementation();
+    });
+
+    afterEach(() => {
+      locationUtil.initialize({
+        config: { appSubUrl: '' } as GrafanaConfig,
+        getVariablesUrlParams: jest.fn(),
+        getTimeRangeForUrl: jest.fn(),
+      });
+      setLocationService(new HistoryWrapper());
+    });
+
+    it('keeps the subpath intact when opening panel edit', () => {
+      serveUnderSubpath('/grafana/d/test-uid/test-dashboard');
+      setupKeyboardShortcuts(scene);
+      focusPanel('panel-1');
+
+      getBinding('e')!.onTrigger();
+
+      expect(window.location.pathname).toBe('/grafana/d/test-uid/test-dashboard');
+      expect(window.location.search).toContain('editPanel=1');
+    });
+
+    it('keeps the subpath intact when closing panel edit', () => {
+      serveUnderSubpath('/grafana/d/test-uid/test-dashboard?editPanel=1');
+      scene.setState({ editPanel: buildPanelEditScene(panel) });
+      setupKeyboardShortcuts(scene);
+      focusPanel('panel-1');
+
+      getBinding('e')!.onTrigger();
+
+      expect(window.location.pathname).toBe('/grafana/d/test-uid/test-dashboard');
+      expect(window.location.search).not.toContain('editPanel');
     });
   });
 

--- a/public/app/features/dashboard-scene/scene/keyboardShortcuts.ts
+++ b/public/app/features/dashboard-scene/scene/keyboardShortcuts.ts
@@ -234,11 +234,7 @@ export function setupKeyboardShortcuts(scene: DashboardScene) {
         const sceneRoot = vizPanel.getRoot();
         if (sceneRoot instanceof DashboardScene) {
           if (scene.state.editPanel) {
-            locationService.push(
-              locationUtil.getUrlForPartial(locationService.getLocation(), {
-                editPanel: undefined,
-              })
-            );
+            locationService.partial({ editPanel: undefined });
           } else {
             const url = locationUtil.stripBaseFromUrl(getEditPanelUrl(panelId));
             locationService.push(url);


### PR DESCRIPTION
<!-- Enter your PR description in this space above -->

Closes #129581

## What this fixes

When Grafana is served under a subpath, closing panel edit with the `e` keyboard
shortcut redirected to a URL with the subpath duplicated, resulting in a 404:

```
actual:   /grafana/grafana/d/ad6n52j/my-dashboard?orgId=1&...
expected: /grafana/d/ad6n52j/my-dashboard?orgId=1&...
```

Opening panel edit with `e` was unaffected, which matches the report.

## Why it happened

The router basename is the configured subpath — `HistoryWrapper` creates
`createBrowserHistory({ basename: config.appSubUrl })`. Any path handed to
`locationService` must therefore be basename-relative, or the subpath ends up in
the URL twice.

`locationUtil.getUrlForPartial` ends in `assureBaseUrl`, which *prepends* the
subpath. Pushing that result made the history prepend it a second time. The
sibling branch that *opens* panel edit already guards against exactly this with
`locationUtil.stripBaseFromUrl`; the closing branch did not.

## The change

```diff
-            locationService.push(
-              locationUtil.getUrlForPartial(locationService.getLocation(), {
-                editPanel: undefined,
-              })
-            );
+            locationService.partial({ editPanel: undefined });
```

This follows the view-panel (`v`) shortcut a few lines above, which handles the
analogous "close" case the same way. `partial` derives the URL from the same
location and the same query parser as `getUrlForPartial`
(`locationSearchToObject` delegates to `urlUtil.parseKeyValue`, the same function
`getUrlForPartial` uses) but without `assureBaseUrl` — so removing the
duplication is the only behavioural change.

Wrapping the existing call in `stripBaseFromUrl` would also work and would match
`DashboardScene.exitEditMode`. I went with `partial` because it is smaller and
matches the immediately adjacent binding in the same file.

## Tests

Two tests in `keyboardShortcuts.test.ts` drive the shortcut through a real
`createBrowserHistory({ basename: '/grafana' })` and assert `window.location`,
rather than asserting on a mocked `push` call, so the duplication itself is what
gets pinned:

- opening panel edit keeps the subpath intact — passes before and after this
  change, and guards the branch that was already correct
- closing panel edit keeps the subpath intact — fails before, passes after

Measured on this branch:

| | before | after |
|---|---|---|
| `keyboardShortcuts.test.ts` | 36 passed, 1 failed | 37 passed |
| `public/app/features/dashboard-scene/scene` (54 suites) | 838 passed | 840 passed |

The failure before the change was exactly the reported duplication:

```
Expected: "/grafana/d/test-uid/test-dashboard"
Received: "/grafana/grafana/d/test-uid/test-dashboard"
```

`yarn typecheck` (14 projects), `yarn eslint` on both files and
`yarn prettier --check` are clean.

## Deliberately not included

- **The `p x` explore shortcut.** #101516 was closed by #102089, which was a
  backend fix in `pkg/middleware/org_redirect.go` for cross-org links. The
  keyboard-shortcut variant @Hipska raised in that thread was never addressed. It
  is a different code path (`tryGetExploreUrlForPanel`, whose URL comes from
  `getExploreUrl`), so I left it alone rather than widen this PR. Happy to look
  at it separately.
- **The `stripBaseFromUrl` call in the opening branch.** It is redundant only in
  the sense that it is the correct guard; I did not touch it.

## Known limitation

The reproduction runs in jsdom. `createMemoryHistory` in history v4 does not
accept a `basename`, so the tests use `createBrowserHistory` and restore the
previous `locationUtil` config and location service afterwards. I did not verify
the fix against a real Nginx-proxied instance — the behaviour above is measured
in the test environment, and the root cause is read from the code path.
