### PR TITLE
Connections: Normalize nav urls on the landing page cards

### DIFF
--- a/public/app/features/connections/Connections.test.tsx
+++ b/public/app/features/connections/Connections.test.tsx
@@ -1,8 +1,9 @@
 import { type RenderResult, screen } from '@testing-library/react';
 import { Route, Routes } from 'react-router-dom-v5-compat';
-import { render } from 'test/test-utils';
+import { render, userEvent } from 'test/test-utils';
 
-import { config } from '@grafana/runtime';
+import { type GrafanaConfig, locationUtil } from '@grafana/data';
+import { config, locationService } from '@grafana/runtime';
 import { contextSrv } from 'app/core/services/context_srv';
 import * as api from 'app/features/datasources/api';
 import { getMockDataSources } from 'app/features/datasources/mocks/dataSourcesMocks';
@@ -113,6 +114,62 @@ describe('Connections', () => {
     expect(screen.queryByText('Collector')).not.toBeInTheDocument();
     expect(screen.queryByText('Integrations')).not.toBeInTheDocument();
     expect(screen.queryByText('Private data source connect')).not.toBeInTheDocument();
+  });
+
+  describe('when Grafana is served under a subpath', () => {
+    // The backend prefixes every nav url with appSubUrl
+    // (navtree.go: baseUrl := s.cfg.AppSubURL + "/connections"), so the landing page
+    // cards receive subpath-prefixed urls.
+    const SUB_PATH = '/grafana';
+
+    const initLocationUtil = (appSubUrl: string) =>
+      locationUtil.initialize({
+        config: { appSubUrl } as GrafanaConfig,
+        getVariablesUrlParams: jest.fn(),
+        getTimeRangeForUrl: jest.fn(),
+      });
+
+    const subPathStore = () =>
+      configureStore({
+        navIndex: {
+          ...navIndex,
+          connections: {
+            ...navIndex.connections,
+            children: [
+              {
+                id: 'connections-add-new-connection',
+                text: 'Add new connection',
+                url: `${SUB_PATH}/connections/add-new-connection`,
+              },
+              { id: 'connections-datasources', text: 'Data sources', url: `${SUB_PATH}/connections/datasources` },
+            ],
+          },
+        },
+        plugins: getPluginsStateMock([]),
+      });
+
+    beforeEach(() => initLocationUtil(SUB_PATH));
+    afterEach(() => initLocationUtil(''));
+
+    test('navigates to a path relative to the router basename', async () => {
+      const user = userEvent.setup();
+      renderPage(ROUTES.Base, subPathStore());
+
+      await user.click(await screen.findByRole('button', { name: /^Data sources/i }));
+
+      // The router basename is the subpath, so pushing a prefixed path would repeat it.
+      expect(locationService.getLocation().pathname).toBe('/connections/datasources');
+    });
+
+    test('still resolves card metadata for subpath-prefixed nav urls', async () => {
+      config.pluginAdminExternalManageEnabled = false;
+      renderPage(ROUTES.Base, subPathStore());
+
+      // CardMetadata is keyed on the unprefixed path, so an unnormalized url
+      // silently falls back to the raw nav text and subtitle.
+      expect(await screen.findByText('View configured data sources')).toBeVisible();
+      expect(await screen.findByText('Connect to a new data source')).toBeVisible();
+    });
   });
 
   test('renders the correct tab even if accessing it with a "sub-url"', async () => {

--- a/public/app/features/connections/pages/ConnectionsHomePage.tsx
+++ b/public/app/features/connections/pages/ConnectionsHomePage.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 
-import { type GrafanaTheme2, type IconName, isIconName } from '@grafana/data';
+import { type GrafanaTheme2, type IconName, isIconName, locationUtil } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 import { useStyles2 } from '@grafana/ui';
@@ -31,9 +31,13 @@ export default function ConnectionsHomePage() {
   const cardsData = (navIndex['connections']?.children ?? [])
     .filter((item) => item.url)
     .map((item) => {
-      const meta = cardMetadata[item.url!];
+      // Nav urls carry appSubUrl, but cardMetadata is keyed on the unprefixed path and
+      // locationService expects paths relative to the router basename.
+      const url = locationUtil.stripBaseFromUrl(item.url!);
+      const meta = cardMetadata[url];
       return {
         ...item,
+        url,
         text: meta?.text ?? item.text,
         icon: resolveIcon(meta?.icon, item.icon),
         subTitle: meta?.subTitle ?? item.subTitle ?? '',


### PR DESCRIPTION
<!-- Enter your PR description in this space above -->

Closes #128972

## Note on prior art

@Clarity-89 opened #129201 for this and closed it on 28 Jul without comment, so I
don't know the reason — if that was a deliberate call, or if a reworked
Connections nav makes this moot, please say so and I'll close this. I only picked
it up because the issue is still open and nothing has landed on `main`
(last change to the file is #122017). Happy to defer to your version.

## What this fixes

With `GF_SERVER_SERVE_FROM_SUB_PATH=true`, the Connections landing page cards
have two problems, and both come from the same cause:

1. Clicking a card navigates to a duplicated subpath —
   `/grafana/grafana/connections/datasources` — which 404s.
2. The cards silently lose their icon, title and subtitle, falling back to the
   raw nav entry. No error, nothing in the console.

## Why

The backend prefixes every nav url with `appSubUrl`:

```go
// pkg/services/navtree/navtreeimpl/navtree.go
baseUrl := s.cfg.AppSubURL + "/connections"
```

`ConnectionsHomePage` passes that url straight to two consumers that both expect
the *unprefixed* path:

- `PageCard` calls `locationService.push(url)`. The history basename is already
  the subpath (`createBrowserHistory({ basename: config.appSubUrl })`), so the
  prefix is applied a second time.
- `cardMetadata[item.url]` is keyed on paths like `/connections/datasources`, so
  a prefixed url misses the lookup entirely and the metadata falls back to the
  nav entry's own text and subtitle.

## The change

Strip the base once, where the nav url enters the component, so both consumers
get a path relative to the router basename:

```diff
-      const meta = cardMetadata[item.url!];
+      const url = locationUtil.stripBaseFromUrl(item.url!);
+      const meta = cardMetadata[url];
       return {
         ...item,
+        url,
```

`stripBaseFromUrl` is a no-op when no subpath is configured, so the default
deployment is unaffected.

I did not change `PageCard`. Normalizing at the single point where the url
enters means the card keeps taking a plain path, and the metadata lookup is
fixed by the same line.

## Tests

Two tests in `Connections.test.tsx`, using nav urls shaped the way the backend
emits them under a subpath:

- clicking the "Data sources" card pushes `/connections/datasources`, not the
  prefixed path
- card metadata still resolves, so the OSS title and subtitles still render

Measured:

| | before | after |
|---|---|---|
| `Connections.test.tsx` | 6 passed, 2 failed | 8 passed |
| `public/app/features/connections` (8 suites) | 67 passed | 69 passed |

The failures before the change:

```
Expected: "/connections/datasources"
Received: "/grafana/connections/datasources"

Unable to find an element with the text: View configured data sources
```

`yarn typecheck` (14 projects), `yarn eslint` and `yarn prettier --check` on both
files are clean.

## Known limitation

`test/test-utils` builds a `createMemoryHistory`, and history v4's memory history
takes no `basename`, so the test asserts the path handed to the router rather
than the doubled url in the address bar. That path is the root cause — a
basename-relative path is what `locationService` requires — but the duplication
itself is only reproduced end-to-end in a browser. I have not run this against a
real proxied instance.
