### PR TITLE
NodeGraph: Report edges that reference a missing node

### DIFF
--- a/public/app/plugins/panel/nodeGraph/utils.test.ts
+++ b/public/app/plugins/panel/nodeGraph/utils.test.ts
@@ -268,6 +268,16 @@ describe('processNodes', () => {
 
     expect(() => processNodes(nodesFrame, undefined)).toThrow(/fixedX/);
   });
+
+  it('throws a helpful error if an edge references a node that is not in the nodes frame', () => {
+    expect(() =>
+      processNodes(makeNodesDataFrame(2), makeEdgesDataFrame([{ source: '0', target: 'no-such-node' }]))
+    ).toThrow(/no-such-node/);
+
+    expect(() =>
+      processNodes(makeNodesDataFrame(2), makeEdgesDataFrame([{ source: 'no-such-node', target: '1' }]))
+    ).toThrow(/no-such-node/);
+  });
 });
 
 describe('finds connections', () => {

--- a/public/app/plugins/panel/nodeGraph/utils.ts
+++ b/public/app/plugins/panel/nodeGraph/utils.ts
@@ -264,6 +264,15 @@ function processEdges(edges: DataFrame, edgeFields: EdgeFields, nodesMap: { [id:
     const sourceNode = nodesMap[source];
     const targetNode = nodesMap[target];
 
+    // An edge can name an id that the nodes frame does not contain. Left unchecked that
+    // surfaces as a TypeError here and again when counting incoming edges and when the
+    // layout resolves the endpoints.
+    if (!sourceNode || !targetNode) {
+      throw new Error(
+        `Edge "${id}" references "${!sourceNode ? source : target}", which is not an id in the nodes data frame.`
+      );
+    }
+
     return {
       id,
       dataFrameRowIndex: index,


### PR DESCRIPTION
<!-- Enter your PR description in this space above -->

Closes #128554

## What this fixes

If an edge names a `source` or `target` id that the nodes data frame does not
contain, the Node Graph panel crashes:

```
An unexpected error happened
TypeError: Cannot read properties of undefined (reading 'nodeRadius')
```

The stack trace says nothing about which edge or which id caused it, so there is
no way to find the offending row from the panel. The reporter had to work it out
themselves.

## Why

`processEdges` looks both endpoints up in `nodesMap` and uses them without
checking:

```ts
const sourceNode = nodesMap[source];
const targetNode = nodesMap[target];
// ...
sourceNodeRadius: !sourceNode.nodeRadius ? nodeR : sourceNode.nodeRadius.values[...]
```

A missing node also breaks two further places, so guarding only the radius would
move the crash rather than remove it:

- `processNodes` counts incoming edges with `nodesMap[e.target].incoming++`
- `layout.ts` resolves `source: nodesMap[e.source]` / `target: nodesMap[e.target]`
  and would hand `undefined` to the force layout

Checking once in `processEdges` covers all three, since nothing downstream runs
if it throws.

## The change

```ts
if (!sourceNode || !targetNode) {
  throw new Error(
    `Edge "${id}" references "${!sourceNode ? source : target}", which is not an id in the nodes data frame.`
  );
}
```

This matches how the same function already reports malformed input
(`throw new Error('id field is required for edges data frame.')`), and how
`processNodes` reports bad `fixedX`/`fixedY` values, so it surfaces through the
existing panel error path.

## The alternative I did not take

Dangling edges could instead be dropped, letting the panel render the valid part
of the graph. That is probably nicer for the user who just wants to see their
graph, but it silently discards rows the user supplied, and it is a behaviour
call rather than a crash fix — so I did not make it unasked. Say the word and
I'll switch this to a filter.

## Tests

`utils.test.ts` gains a case for a dangling `target` and a dangling `source`,
alongside the existing `throws error if fixedX/Y is used incorrectly`.

| | before | after |
|---|---|---|
| `public/app/plugins/panel/nodeGraph` (6 suites) | 31 passed, 1 failed | 32 passed |

Before the change the new test fails with the reported error:

```
Expected pattern: /no-such-node/
Received message: "Cannot read properties of undefined (reading 'nodeRadius')"
```

`yarn typecheck` (14 projects), `yarn eslint` and `yarn prettier --check` on both
files are clean. `public/app/features/explore/NodeGraph` also still passes.

## Known limitation

I reproduced this through `processNodes` in a unit test, not by wiring up the
Infinity data source described in the issue. The crash site and the error string
match what was reported, and the two further dereferences above are read from the
code rather than observed.
