### PR TITLE
Logs: Fix log context stopping at rows sharing a timestamp

### DIFF
--- a/public/app/features/logs/components/panel/LogLineContext.test.tsx
+++ b/public/app/features/logs/components/panel/LogLineContext.test.tsx
@@ -330,7 +330,16 @@ describe('LogLineContext', () => {
   });
 
   test('should render rows sharing the selected row timestamp once', async () => {
-    const selected = dataFrameToLogsModel([burstFrame([[BURST_MS, 'selected']], 'anchor')]).rows[0];
+    const selected = dataFrameToLogsModel([
+      // The gate reads repeats off the original result, so the frame must contain a sibling.
+      burstFrame(
+        [
+          [BURST_MS, 'selected'],
+          [BURST_MS, 'a sibling in the original result'],
+        ],
+        'anchor'
+      ),
+    ]).rows[0];
     const getRowContext = jest.fn().mockImplementation(async (_, options) => ({
       data: [
         burstFrame(
@@ -371,8 +380,141 @@ describe('LogLineContext', () => {
     expect(screen.getAllByText('selected')).toHaveLength(1);
   });
 
+  test('should leave the same-timestamp handling off when the timestamp does not repeat', async () => {
+    // Only one row at this timestamp in the original result, so none of the widening or
+    // page-growing should happen: one request per direction, at the plain page size.
+    const selected = dataFrameToLogsModel([burstFrame([[BURST_MS, 'the only row']], 'anchor')]).rows[0];
+    const newer: BurstRow[] = Array.from({ length: PAGE_SIZE }, (_, i) => [BURST_MS + i + 1, `newer ${i}`]);
+    const older: BurstRow[] = Array.from({ length: PAGE_SIZE }, (_, i) => [BURST_MS - i - 1, `older ${i}`]);
+    const getRowContext = jest
+      .fn()
+      .mockImplementation(async (_, options) =>
+        options.direction === LogRowContextQueryDirection.Forward
+          ? { data: [burstFrame(newer, 'ctx-fwd')] }
+          : { data: [burstFrame(older, 'ctx-bwd')] }
+      );
+
+    render(
+      <LogLineContext
+        log={selected}
+        open={true}
+        onClose={() => {}}
+        getRowContext={getRowContext}
+        timeZone={timeZone}
+        sortOrder={LogsSortOrder.Descending}
+      />
+    );
+
+    await waitFor(() => expect(getRowContext).toHaveBeenCalledTimes(2));
+    for (const [requestRow, options] of getRowContext.mock.calls) {
+      expect(options.limit).toBe(PAGE_SIZE);
+      expect(requestRow.timeEpochNs).toBe(`${BURST_MS}000000`);
+    }
+  });
+
+  test('should split rows sharing the timestamp the way the original result ordered them', async () => {
+    // The selected row sits between two rows sharing its timestamp in the original result.
+    const original = burstFrame(
+      [
+        [BURST_MS, 'above in the original'],
+        [BURST_MS, 'the selected row'],
+        [BURST_MS, 'below in the original'],
+      ],
+      'anchor'
+    );
+    const selected = dataFrameToLogsModel([original]).rows[1];
+    expect(selected.entry).toBe('the selected row');
+
+    // The forward request returns the whole burst, as a data source would.
+    const getRowContext = jest.fn().mockImplementation(async (_, options) =>
+      options.direction === LogRowContextQueryDirection.Forward
+        ? {
+            data: [
+              burstFrame(
+                [
+                  [BURST_MS, 'below in the original'],
+                  [BURST_MS, 'above in the original'],
+                ],
+                'ctx-fwd'
+              ),
+            ],
+          }
+        : { data: [burstFrame([[BURST_MS - 1, 'before the burst']], 'ctx-bwd')] }
+    );
+
+    render(
+      <LogLineContext
+        log={selected}
+        open={true}
+        onClose={() => {}}
+        getRowContext={getRowContext}
+        timeZone={timeZone}
+        sortOrder={LogsSortOrder.Descending}
+      />
+    );
+
+    await waitFor(() => expect(screen.getByText('above in the original')).toBeInTheDocument());
+
+    const above = screen.getByText('above in the original');
+    const below = screen.getByText('below in the original');
+    // The selected line is also shown in the modal header, so take its last occurrence: the
+    // list renders after the header. The assertion is that it sits between the two siblings,
+    // which only holds if they were split rather than both attached to the fetching side.
+    const selectedInList = screen.getAllByText('the selected row').at(-1)!;
+    const isFollowedBy = (a: Element, b: Element) =>
+      Boolean(a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING);
+
+    expect(isFollowedBy(above, selectedInList)).toBe(true);
+    expect(isFollowedBy(selectedInList, below)).toBe(true);
+  });
+
+  test('should not report the end of the logs when a response only fed the opposite side', async () => {
+    const original = burstFrame(
+      [
+        [BURST_MS, 'sibling before'],
+        [BURST_MS, 'the selected row'],
+        [BURST_MS, 'sibling after'],
+      ],
+      'anchor'
+    );
+    const selected = dataFrameToLogsModel([original]).rows[1];
+    // Descending, so 'above' issues the forward request. It returns only the sibling the
+    // original result placed after the selected row, so every row it brings is assigned below
+    // and the above side gains nothing -- which is not the same as running out of logs.
+    const getRowContext = jest
+      .fn()
+      .mockImplementation(async (_, options) =>
+        options.direction === LogRowContextQueryDirection.Forward
+          ? { data: [burstFrame([[BURST_MS, 'sibling after']], 'ctx-fwd')] }
+          : { data: [burstFrame([[BURST_MS - 1, 'older row']], 'ctx-bwd')] }
+      );
+
+    render(
+      <LogLineContext
+        log={selected}
+        open={true}
+        onClose={() => {}}
+        getRowContext={getRowContext}
+        timeZone={timeZone}
+        sortOrder={LogsSortOrder.Descending}
+      />
+    );
+
+    await waitFor(() => expect(screen.getByText('sibling after')).toBeInTheDocument());
+    expect(screen.queryByText('No more logs available.')).not.toBeInTheDocument();
+  });
+
   test('should ask the forward request from one nanosecond before the selected row', async () => {
-    const selected = dataFrameToLogsModel([burstFrame([[BURST_MS, 'selected']], 'anchor')]).rows[0];
+    const selected = dataFrameToLogsModel([
+      // The gate reads repeats off the original result, so the frame must contain a sibling.
+      burstFrame(
+        [
+          [BURST_MS, 'selected'],
+          [BURST_MS, 'a sibling in the original result'],
+        ],
+        'anchor'
+      ),
+    ]).rows[0];
     const getRowContext = jest.fn().mockResolvedValue({ data: [] });
 
     render(
@@ -398,7 +540,16 @@ describe('LogLineContext', () => {
   });
 
   test('should request more logs when a full page is entirely one timestamp', async () => {
-    const selected = dataFrameToLogsModel([burstFrame([[BURST_MS, 'selected']], 'anchor')]).rows[0];
+    const selected = dataFrameToLogsModel([
+      // The gate reads repeats off the original result, so the frame must contain a sibling.
+      burstFrame(
+        [
+          [BURST_MS, 'selected'],
+          [BURST_MS, 'a sibling in the original result'],
+        ],
+        'anchor'
+      ),
+    ]).rows[0];
     // The page is full and entirely on the selected row's timestamp, so a bigger request is the
     // only way out even though this page did bring new rows.
     const insideBurst: BurstRow[] = Array.from({ length: PAGE_SIZE }, (_, i) => [BURST_MS, `burst ${i}`]);
@@ -440,7 +591,16 @@ describe('LogLineContext', () => {
   });
 
   test('should request more logs when a full page holds nothing new', async () => {
-    const selected = dataFrameToLogsModel([burstFrame([[BURST_MS, 'selected']], 'anchor')]).rows[0];
+    const selected = dataFrameToLogsModel([
+      // The gate reads repeats off the original result, so the frame must contain a sibling.
+      burstFrame(
+        [
+          [BURST_MS, 'selected'],
+          [BURST_MS, 'a sibling in the original result'],
+        ],
+        'anchor'
+      ),
+    ]).rows[0];
     // Data sources anchor the context query on a timestamp and cannot skip rows, so the
     // first page of a burst bigger than PAGE_SIZE only repeats the rows already displayed.
     const firstPage: BurstRow[] = Array.from({ length: PAGE_SIZE }, () => [BURST_MS, 'selected']);

--- a/public/app/features/logs/components/panel/LogLineContext.test.tsx
+++ b/public/app/features/logs/components/panel/LogLineContext.test.tsx
@@ -78,6 +78,21 @@ const dfAfter = createDataFrame({
   ],
 });
 
+// Rows of a burst of logs sharing a timestamp, as [milliseconds, log line] pairs.
+type BurstRow = [number, string];
+const BURST_MS = 1700000000000;
+const burstFrame = (rows: BurstRow[], refId: string) =>
+  createDataFrame({
+    // Row uids are derived from the refId, and duplicated uids break rendering.
+    refId,
+    fields: [
+      { name: 'time', type: FieldType.time, values: rows.map(([ms]) => ms) },
+      { name: 'message', type: FieldType.string, values: rows.map(([, line]) => line) },
+      // Nanoseconds are strings: epoch nanoseconds do not fit in a JS number.
+      { name: 'tsNs', type: FieldType.string, values: rows.map(([ms]) => `${ms}000000`) },
+    ],
+  });
+
 let getRowContext = jest.fn();
 const dispatchMock = jest.fn();
 jest.mock('app/types/store', () => ({
@@ -312,6 +327,160 @@ describe('LogLineContext', () => {
     await waitFor(() => {
       expect(screen.getAllByText('foo123').length).toBe(3);
     });
+  });
+
+  test('should render rows sharing the selected row timestamp once', async () => {
+    const selected = dataFrameToLogsModel([burstFrame([[BURST_MS, 'selected']], 'anchor')]).rows[0];
+    const getRowContext = jest.fn().mockImplementation(async (_, options) => ({
+      data: [
+        burstFrame(
+          // A data source with an end-inclusive range returns the burst in both directions.
+          options.direction === LogRowContextQueryDirection.Forward
+            ? [
+                [BURST_MS, 'selected'],
+                [BURST_MS, 'burst 1'],
+                [BURST_MS, 'burst 2'],
+              ]
+            : [
+                [BURST_MS, 'selected'],
+                [BURST_MS, 'burst 1'],
+                [BURST_MS, 'burst 2'],
+                [BURST_MS - 1, 'before the burst'],
+              ],
+          `context-${options.direction}`
+        ),
+      ],
+    }));
+
+    render(
+      <LogLineContext
+        log={selected}
+        open={true}
+        onClose={() => {}}
+        getRowContext={getRowContext}
+        timeZone={timeZone}
+        sortOrder={LogsSortOrder.Descending}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('before the burst')).toBeInTheDocument();
+    });
+    expect(screen.getAllByText('burst 1')).toHaveLength(1);
+    expect(screen.getAllByText('burst 2')).toHaveLength(1);
+    expect(screen.getAllByText('selected')).toHaveLength(1);
+  });
+
+  test('should ask the forward request from one nanosecond before the selected row', async () => {
+    const selected = dataFrameToLogsModel([burstFrame([[BURST_MS, 'selected']], 'anchor')]).rows[0];
+    const getRowContext = jest.fn().mockResolvedValue({ data: [] });
+
+    render(
+      <LogLineContext
+        log={selected}
+        open={true}
+        onClose={() => {}}
+        getRowContext={getRowContext}
+        timeZone={timeZone}
+        sortOrder={LogsSortOrder.Descending}
+      />
+    );
+
+    await waitFor(() => expect(getRowContext).toHaveBeenCalledTimes(2));
+    const rowFor = (direction: LogRowContextQueryDirection) =>
+      getRowContext.mock.calls.find(([, options]) => options.direction === direction)?.[0];
+
+    // Forward ranges exclude the reference nanosecond, hiding every row sharing it.
+    // Values are spelled out because epoch nanoseconds exceed Number.MAX_SAFE_INTEGER.
+    expect(`${BURST_MS}000000`).toBe('1700000000000000000');
+    expect(rowFor(LogRowContextQueryDirection.Forward).timeEpochNs).toBe('1699999999999999999');
+    expect(rowFor(LogRowContextQueryDirection.Backward).timeEpochNs).toBe('1700000000000000000');
+  });
+
+  test('should request more logs when a full page is entirely one timestamp', async () => {
+    const selected = dataFrameToLogsModel([burstFrame([[BURST_MS, 'selected']], 'anchor')]).rows[0];
+    // The page is full and entirely on the selected row's timestamp, so a bigger request is the
+    // only way out even though this page did bring new rows.
+    const insideBurst: BurstRow[] = Array.from({ length: PAGE_SIZE }, (_, i) => [BURST_MS, `burst ${i}`]);
+    const pastBurst: BurstRow[] = [[BURST_MS + 1, 'after the burst']];
+    const getRowContext = jest.fn().mockImplementation(async (_, options) => {
+      if (options.direction === LogRowContextQueryDirection.Backward) {
+        return { data: [burstFrame([[BURST_MS - 1, 'before the burst']], 'context-backward')] };
+      }
+      return {
+        data: [
+          burstFrame(
+            options.limit > PAGE_SIZE ? [...insideBurst, ...pastBurst] : insideBurst,
+            `context-forward-${options.limit}`
+          ),
+        ],
+      };
+    });
+
+    render(
+      <LogLineContext
+        log={selected}
+        open={true}
+        onClose={() => {}}
+        getRowContext={getRowContext}
+        timeZone={timeZone}
+        sortOrder={LogsSortOrder.Descending}
+      />
+    );
+
+    await waitFor(() => {
+      expect(getRowContext).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ limit: PAGE_SIZE * 2, direction: LogRowContextQueryDirection.Forward })
+      );
+    });
+    await waitFor(() => {
+      expect(screen.getAllByText(/^burst \d+$/).length).toBeGreaterThan(0);
+    });
+  });
+
+  test('should request more logs when a full page holds nothing new', async () => {
+    const selected = dataFrameToLogsModel([burstFrame([[BURST_MS, 'selected']], 'anchor')]).rows[0];
+    // Data sources anchor the context query on a timestamp and cannot skip rows, so the
+    // first page of a burst bigger than PAGE_SIZE only repeats the rows already displayed.
+    const firstPage: BurstRow[] = Array.from({ length: PAGE_SIZE }, () => [BURST_MS, 'selected']);
+    const secondPage: BurstRow[] = Array.from({ length: PAGE_SIZE }, (_, i) => [BURST_MS, `burst ${i}`]);
+    const getRowContext = jest.fn().mockImplementation(async (_, options) => {
+      if (options.direction === LogRowContextQueryDirection.Backward) {
+        return { data: [burstFrame([[BURST_MS - 1, 'before the burst']], 'context-backward')] };
+      }
+      return {
+        data: [
+          burstFrame(
+            options.limit > PAGE_SIZE ? [...firstPage, ...secondPage] : firstPage,
+            `context-forward-${options.limit}`
+          ),
+        ],
+      };
+    });
+
+    render(
+      <LogLineContext
+        log={selected}
+        open={true}
+        onClose={() => {}}
+        getRowContext={getRowContext}
+        timeZone={timeZone}
+        sortOrder={LogsSortOrder.Descending}
+      />
+    );
+
+    await waitFor(() => {
+      expect(getRowContext).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ limit: PAGE_SIZE * 2, direction: LogRowContextQueryDirection.Forward })
+      );
+    });
+    // Only the rows next to the selected one are rendered, so match any of the burst.
+    await waitFor(() => {
+      expect(screen.getAllByText(/^burst \d+$/).length).toBeGreaterThan(0);
+    });
+    expect(screen.queryByText('No more logs available.')).not.toBeInTheDocument();
   });
 
   test('Should highlight the same `foo123` searchwords', async () => {

--- a/public/app/features/logs/components/panel/LogLineContext.tsx
+++ b/public/app/features/logs/components/panel/LogLineContext.tsx
@@ -69,6 +69,9 @@ interface LogLineContextProps {
 }
 
 export const PAGE_SIZE = 100;
+// Context queries are anchored on a timestamp and cannot skip rows, so the only way past a
+// burst sharing one timestamp is a bigger request. One per size: 4 requests, 800 rows max.
+const CONTEXT_PAGE_SIZES = [PAGE_SIZE, PAGE_SIZE * 2, PAGE_SIZE * 4, PAGE_SIZE * 8];
 export const DEFAULT_TIME_WINDOW = 7200000;
 
 // Merge the above/below context request states into one for InfiniteScroll, preserving Streaming/Error.
@@ -169,20 +172,41 @@ export const LogLineContext = memo(
 
     const getContextLogs = useCallback(
       async (place: 'above' | 'below', refLog: LogRowModel, timeWindowMs?: number): Promise<LogRowModel[]> => {
-        const result = await getRowContext(normalizeLogRefId(refLog), {
-          limit: PAGE_SIZE,
-          direction: getLoadMoreDirection(place, sortOrder),
-          // Only on the initial request
-          timeWindowMs,
-        });
+        const direction = getLoadMoreDirection(place, sortOrder);
+        const requestRow = direction === LogRowContextQueryDirection.Forward ? withPrecedingNanosecond(refLog) : refLog;
+        let usableLogs: LogRowModel[] = [];
 
-        const newLogs = dataFrameToLogsModel(result.data).rows;
-        if (sortOrder === LogsSortOrder.Ascending) {
-          newLogs.reverse();
+        for (const limit of CONTEXT_PAGE_SIZES) {
+          const result = await getRowContext(normalizeLogRefId(requestRow), {
+            limit,
+            direction,
+            // Only on the initial request
+            timeWindowMs,
+          });
+
+          const newLogs = dataFrameToLogsModel(result.data).rows;
+          if (sortOrder === LogsSortOrder.Ascending) {
+            newLogs.reverse();
+          }
+          usableLogs = newLogs.filter(
+            (r) =>
+              !containsRow(allLogs, r) &&
+              // Rows sharing the anchor's timestamp belong to neither side, so they are kept on
+              // the forward one only, or a data source returning them in both shows them twice.
+              (direction === LogRowContextQueryDirection.Forward || r.timeEpochNs !== log.timeEpochNs)
+          );
+          // A full page on one timestamp is stuck inside a burst: the same request would return
+          // an arbitrary subset of the same rows, so try the next size rather than paging on.
+          const stuckInsideOneTimestamp =
+            newLogs.length >= limit && newLogs.every((r) => r.timeEpochNs === newLogs[0].timeEpochNs);
+          if ((usableLogs.length > 0 && !stuckInsideOneTimestamp) || newLogs.length < limit) {
+            break;
+          }
         }
-        return newLogs.filter((r) => !containsRow(allLogs, r));
+
+        return usableLogs;
       },
-      [allLogs, getRowContext, sortOrder]
+      [allLogs, getRowContext, log.timeEpochNs, sortOrder]
     );
 
     const loadMore = useCallback(
@@ -195,9 +219,21 @@ export const LogLineContext = memo(
             // apply the original row's searchWords to all the rows for highlighting
             !r.searchWords || !r.searchWords?.length ? { ...r, searchWords: log.searchWords } : r
           );
-          const [older, newer] = partition(newLogs, (newRow) => newRow.timeEpochNs > log.timeEpochNs);
+          const [sameTimestamp, differentTimestamp] = partition(
+            newLogs,
+            (newRow) => newRow.timeEpochNs === log.timeEpochNs
+          );
+          const [older, newer] = partition(differentTimestamp, (newRow) => newRow.timeEpochNs > log.timeEpochNs);
           const newAbove = sortOrder === LogsSortOrder.Ascending ? newer : older;
           const newBelow = sortOrder === LogsSortOrder.Ascending ? older : newer;
+
+          // getContextLogs only keeps same-timestamp rows from the forward request, and the
+          // side that issues it is this `place`, so they belong here.
+          if (place === 'above') {
+            newAbove.push(...sameTimestamp);
+          } else {
+            newBelow.push(...sameTimestamp);
+          }
 
           setAboveLogs((aboveLogs: LogRowModel[]) => {
             return newAbove.length > 0 ? sortLogRows([...newAbove, ...aboveLogs], sortOrder) : aboveLogs;
@@ -612,6 +648,15 @@ const normalizeLogRefId = (log: LogRowModel): LogRowModel => {
       refId: `context_${log.uid ?? log.dataFrame.refId ?? log.timeEpochMs}`,
     },
   };
+};
+
+// Forward context ranges start one nanosecond after the reference row, excluding every other
+// row sharing it. Asking a nanosecond earlier reaches them. BigInt: epoch ns is a string.
+const withPrecedingNanosecond = (log: LogRowModel): LogRowModel => {
+  if (!/^\d+$/.test(log.timeEpochNs)) {
+    return log;
+  }
+  return { ...log, timeEpochNs: (BigInt(log.timeEpochNs) - BigInt(1)).toString() };
 };
 
 const containsRow = (rows: LogRowModel[], row: LogRowModel) => {

--- a/public/app/features/logs/components/panel/LogLineContext.tsx
+++ b/public/app/features/logs/components/panel/LogLineContext.tsx
@@ -34,6 +34,7 @@ import { splitOpen } from 'app/features/explore/state/main';
 import { type GetFieldLinksFn } from 'app/plugins/panel/logs/types';
 import { useDispatch } from 'app/types/store';
 
+import { parseLogsFrame } from '../../logsFrame';
 import { dataFrameToLogsModel } from '../../logsModel';
 import { sortLogRows } from '../../utils';
 import { LoadingIndicator } from '../LoadingIndicator';
@@ -170,13 +171,21 @@ export const LogLineContext = memo(
       }
     }, [updateContextQuery, open, log]);
 
+    // The selected row carries the frame it came from, so the order of the rows that shared
+    // its timestamp there is already known, with no extra request.
+    const siblingPositions = useMemo(() => getSiblingPositions(log), [log]);
+    // None of the same-timestamp handling runs without repeats, so behaviour is unchanged when
+    // the original result shows the selected row's timestamp only once.
+    const hasRepeatedTimestamp = siblingPositions.size > 1;
+
     const getContextLogs = useCallback(
       async (place: 'above' | 'below', refLog: LogRowModel, timeWindowMs?: number): Promise<LogRowModel[]> => {
         const direction = getLoadMoreDirection(place, sortOrder);
-        const requestRow = direction === LogRowContextQueryDirection.Forward ? withPrecedingNanosecond(refLog) : refLog;
+        const widenToReachSiblings = hasRepeatedTimestamp && direction === LogRowContextQueryDirection.Forward;
+        const requestRow = widenToReachSiblings ? withPrecedingNanosecond(refLog) : refLog;
         let usableLogs: LogRowModel[] = [];
 
-        for (const limit of CONTEXT_PAGE_SIZES) {
+        for (const limit of hasRepeatedTimestamp ? CONTEXT_PAGE_SIZES : [PAGE_SIZE]) {
           const result = await getRowContext(normalizeLogRefId(requestRow), {
             limit,
             direction,
@@ -206,7 +215,7 @@ export const LogLineContext = memo(
 
         return usableLogs;
       },
-      [allLogs, getRowContext, log.timeEpochNs, sortOrder]
+      [allLogs, getRowContext, hasRepeatedTimestamp, log.timeEpochNs, sortOrder]
     );
 
     const loadMore = useCallback(
@@ -227,12 +236,18 @@ export const LogLineContext = memo(
           const newAbove = sortOrder === LogsSortOrder.Ascending ? newer : older;
           const newBelow = sortOrder === LogsSortOrder.Ascending ? older : newer;
 
-          // getContextLogs only keeps same-timestamp rows from the forward request, and the
-          // side that issues it is this `place`, so they belong here.
-          if (place === 'above') {
-            newAbove.push(...sameTimestamp);
-          } else {
-            newBelow.push(...sameTimestamp);
+          // Rows sharing the selected row's timestamp are neither older nor newer than it, but
+          // the original result already ordered them, so reuse that instead of picking a side.
+          for (const row of sortBySiblingPosition(sameTimestamp, siblingPositions)) {
+            const position = siblingPositions.get(row.entry);
+            if (position === undefined) {
+              // Absent from the original result, so there is no known position to reuse.
+              (place === 'above' ? newAbove : newBelow).push(row);
+            } else if (position < log.rowIndex) {
+              newAbove.push(row);
+            } else {
+              newBelow.push(row);
+            }
           }
 
           setAboveLogs((aboveLogs: LogRowModel[]) => {
@@ -243,17 +258,17 @@ export const LogLineContext = memo(
           });
 
           setState(LoadingState.NotStarted);
-          if (!newAbove.length && place === 'above') {
-            setAboveState(LoadingState.Done);
-          }
-          if (!newBelow.length && place === 'below') {
-            setBelowState(LoadingState.Done);
+          // With repeats a response's rows can all be assigned to the opposite side, which is
+          // not the end of this one, so exhaustion keys off the whole response instead.
+          const gained = place === 'above' ? newAbove.length : newBelow.length;
+          if (hasRepeatedTimestamp ? !newLogs.length : !gained) {
+            setState(LoadingState.Done);
           }
         } catch {
           setState(LoadingState.Error);
         }
       },
-      [getContextLogs, log, sortOrder]
+      [getContextLogs, hasRepeatedTimestamp, log, siblingPositions, sortOrder]
     );
 
     useEffect(() => {
@@ -658,6 +673,34 @@ const withPrecedingNanosecond = (log: LogRowModel): LogRowModel => {
   }
   return { ...log, timeEpochNs: (BigInt(log.timeEpochNs) - BigInt(1)).toString() };
 };
+
+// Maps each line sharing the selected row's timestamp to its row index in the original result.
+// Keyed by line: a data source cannot hold two entries with the same timestamp and line.
+const getSiblingPositions = (log: LogRowModel): Map<string, number> => {
+  const positions = new Map<string, number>();
+  const frame = parseLogsFrame(log.dataFrame);
+  if (!frame) {
+    return positions;
+  }
+  const bodies = frame.bodyField.values;
+  const nanoseconds = frame.timeNanosecondField?.values;
+  for (let i = 0; i < bodies.length; i++) {
+    const sharesTimestamp = nanoseconds
+      ? String(nanoseconds[i]) === log.timeEpochNs
+      : frame.timeField.values[i] === log.timeEpochMs;
+    if (sharesTimestamp) {
+      positions.set(String(bodies[i]), i);
+    }
+  }
+  return positions;
+};
+
+// Keeps rows sharing a timestamp in the order the original result had them; rows missing from
+// it have no position and go last.
+const sortBySiblingPosition = (rows: LogRowModel[], positions: Map<string, number>): LogRowModel[] =>
+  [...rows].sort(
+    (a, b) => (positions.get(a.entry) ?? Number.MAX_SAFE_INTEGER) - (positions.get(b.entry) ?? Number.MAX_SAFE_INTEGER)
+  );
 
 const containsRow = (rows: LogRowModel[], row: LogRowModel) => {
   return rows.some((r) => r.entry === row.entry && r.timeEpochNs === row.timeEpochNs);


### PR DESCRIPTION
Draft — opening this for feedback on the approach 😄 

Fixes #129559

Because a context query is anchored on a timestamp and can't skip rows, a burst sharing one
timestamp is escaped by over-fetching: the request size grows 100 → 200 → 400 → 800 until the
page reaches past the burst, and rows already displayed are discarded. `getSiblingPositions`
then reads the selected row's own data frame to map each line sharing its timestamp to the row
index it had in the original result. Those positions decide the split — lower index goes above
the selected row, higher goes below — and order the rows within each side, so the context view
matches the log list it was opened from.

## 🐛
I can't seem to get scroll to logline to work or having the selected log line be at the top.

## Test 🧪
- I created fake data in the [drilldown repo](https://github.com/grafana/drilldown/pull/34) `service_name=same-log-timestamp-burst`
<img width="1089" height="591" alt="Screenshot 2026-07-29 at 12 16 28 PM" src="https://github.com/user-attachments/assets/98972418-2831-47d0-95ca-8fb3e08e8a5a" />

