### PR TITLE
Provisioning: Fix ruleset bypass check for org-level branch protection rules

### DIFF
--- a/apps/provisioning/pkg/repository/github/impl.go
+++ b/apps/provisioning/pkg/repository/github/impl.go
@@ -225,7 +225,10 @@ func (r *githubClient) GetRulesets(ctx context.Context, branch string) (*Ruleset
 	}
 
 	for rulesetID := range rulesetIDs {
-		ruleset, _, err := r.gh.Repositories.GetRuleset(ctx, r.owner, r.repo, rulesetID, false)
+		// includes_parents=true is required so that rulesets inherited from a
+		// parent organization are resolved. With false, an org-level ruleset ID
+		// returns 404 because the ruleset belongs to the org, not the repo.
+		ruleset, _, err := r.gh.Repositories.GetRuleset(ctx, r.owner, r.repo, rulesetID, true)
 		if err != nil {
 			// Fail-closed: a silent false negative would let the Repository save and
 			// then fail every subsequent sync push with a 403. Surfacing a block at

--- a/apps/provisioning/pkg/repository/github/impl_test.go
+++ b/apps/provisioning/pkg/repository/github/impl_test.go
@@ -1708,6 +1708,50 @@ func TestGithubClient_GetRulesets(t *testing.T) {
 			wantErr:      nil,
 		},
 		{
+			name: "org-level ruleset with bypass mode always returns no block",
+			mockHandler: mockhub.NewMockedHTTPClient(
+				mockhub.WithRequestMatchHandler(
+					mockhub.GetReposRulesBranchesByOwnerByRepoByBranch,
+					http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+						rules := []map[string]interface{}{
+							{
+								"type":                "pull_request",
+								"ruleset_source_type": "Organization",
+								"ruleset_source":      "test-org",
+								"ruleset_id":          42,
+								"parameters":          map[string]interface{}{},
+							},
+						}
+						w.WriteHeader(http.StatusOK)
+						require.NoError(t, json.NewEncoder(w).Encode(rules))
+					}),
+				),
+				mockhub.WithRequestMatchHandler(
+					mockhub.GetReposRulesetsByOwnerByRepoByRulesetId,
+					http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						// includes_parents=true must be passed so that the API
+						// resolves org-level rulesets. Without it, GitHub returns
+						// 404 because the ruleset ID belongs to the org, not the repo.
+						require.True(t, r.URL.Query().Get("includes_parents") == "true",
+							"GetRuleset must be called with includes_parents=true to resolve org-level rulesets")
+						w.WriteHeader(http.StatusOK)
+						require.NoError(t, json.NewEncoder(w).Encode(map[string]interface{}{
+							"id":                      42,
+							"name":                    "org-ruleset",
+							"source":                  "test-org",
+							"enforcement":             "active",
+							"current_user_can_bypass": "always",
+						}))
+					}),
+				),
+			),
+			owner:        "test-owner",
+			repository:   "test-repo",
+			branch:       "main",
+			wantRulesets: nil,
+			wantErr:      nil,
+		},
+		{
 			name: "pull request rule with bypass mode exempt returns no block",
 			mockHandler: mockhub.NewMockedHTTPClient(
 				mockhub.WithRequestMatchHandler(


### PR DESCRIPTION
## What is this feature?

Fixes a bug where the provisioning preflight check for the `write` workflow incorrectly reports a branch as blocked when it is protected by an **organization-level** GitHub ruleset.

## Why do we need this feature?

When a GitHub repository's branch is protected by an organization-level ruleset, the `GetRuleset` API call was made with `includes_parents=false`. Since the ruleset ID belongs to the organization (not the repository), the call returns a 404. The fail-closed error handling then treats the branch as blocked, even when the configured GitHub App is listed in the ruleset's bypass actors with `bypass_mode: always` and can successfully push directly.

This affects users who configure Grafana provisioning against GitHub repositories where branch protection is enforced through organization-level rulesets, a common pattern in enterprise GitHub organizations.

## What does this change?

Changed the `includes_parents` parameter from `false` to `true` in the `GetRuleset` call in `apps/provisioning/pkg/repository/github/impl.go`. Per the [GitHub API docs](https://docs.github.com/en/rest/repos/rules#get-a-repository-ruleset), `includes_parents` must be `true` to resolve rulesets inherited from a parent organization.

## Which issue(s) does this PR fix?

Fixes #129079

## Special notes for your reviewer

- Added a test case (`org-level ruleset with bypass mode always returns no block`) that verifies the `includes_parents=true` query parameter is sent and that an org-level ruleset with `bypass_mode: always` correctly returns no block.
- All existing tests continue to pass (18 test cases in `TestGithubClient_GetRulesets` plus the dedup test and repository-level tests).
- `go vet` and `gofmt` are clean.

## Verification

```bash
go test -v -count=1 ./apps/provisioning/pkg/repository/github/
```

All tests pass including the new test case.