### PR TITLE
Alerting: Save options when tooltip closes

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen, userEvent } from 'test/test-utils';
+
+import { type AlertQuery } from 'app/types/unified-alerting-dto';
+
+import { QueryOptions } from './QueryOptions';
+import { MaxDataPointsOption, MinIntervalOption } from './QueryWrapper';
+
+describe('query options', () => {
+  it('saves max data points when unmounted before blur', async () => {
+    const onChange = jest.fn();
+    const { unmount } = render(<MaxDataPointsOption options={{}} onChange={onChange} />);
+
+    await userEvent.type(screen.getByRole('spinbutton'), '1234');
+    unmount();
+
+    expect(onChange).toHaveBeenCalledWith({ maxDataPoints: 1234 });
+  });
+
+  it('saves the interval when unmounted before blur', async () => {
+    const onChange = jest.fn();
+    const { unmount } = render(<MinIntervalOption options={{}} onChange={onChange} />);
+
+    await userEvent.type(screen.getByRole('textbox'), '15s');
+    unmount();
+
+    expect(onChange).toHaveBeenCalledWith({ minInterval: '15s' });
+  });
+
+  it('keeps max data points zero normalized when unmounted before blur', async () => {
+    const onChange = jest.fn();
+    const { unmount } = render(<MaxDataPointsOption options={{ maxDataPoints: 100 }} onChange={onChange} />);
+    const input = screen.getByRole('spinbutton');
+
+    await userEvent.clear(input);
+    await userEvent.type(input, '0');
+    unmount();
+
+    expect(onChange).toHaveBeenCalledWith({ maxDataPoints: undefined });
+  });
+
+  it('does not save max data points twice when blur happens before unmount', async () => {
+    const onChange = jest.fn();
+    const { unmount } = render(<MaxDataPointsOption options={{}} onChange={onChange} />);
+    const input = screen.getByRole('spinbutton');
+
+    await userEvent.type(input, '1234');
+    await userEvent.tab();
+    unmount();
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith({ maxDataPoints: 1234 });
+  });
+
+  it('saves max data points when clicking outside the Options toggletip', async () => {
+    const onChangeQueryOptions = jest.fn();
+    render(
+      <QueryOptions
+        query={{ relativeTimeRange: { from: 300, to: 0 } } as AlertQuery}
+        queryOptions={{}}
+        onChangeQueryOptions={onChangeQueryOptions}
+        index={0}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /options/i }));
+    await userEvent.type(await screen.findByRole('spinbutton'), '1234');
+    await userEvent.click(document.body);
+
+    expect(onChangeQueryOptions).toHaveBeenCalledWith({ maxDataPoints: 1234 }, 0);
+  });
+});

--- a/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.tsx
@@ -229,18 +229,35 @@ export function MaxDataPointsOption({
   onChange: (options: AlertQueryOptions) => void;
 }) {
   const value = options.maxDataPoints ?? '';
+  const inputValueRef = React.useRef(value.toString());
+  const optionsRef = React.useRef(options);
+  const onChangeRef = React.useRef(onChange);
+  const lastSavedValueRef = React.useRef(options.maxDataPoints);
 
-  const onMaxDataPointsBlur = (event: ChangeEvent<HTMLInputElement>) => {
-    const maxDataPointsNumber = parseInt(event.target.value, 10);
+  optionsRef.current = options;
+  onChangeRef.current = onChange;
 
+  const saveMaxDataPoints = React.useCallback((inputValue: string) => {
+    const maxDataPointsNumber = parseInt(inputValue, 10);
     const maxDataPoints = isNaN(maxDataPointsNumber) || maxDataPointsNumber === 0 ? undefined : maxDataPointsNumber;
 
-    if (maxDataPoints !== options.maxDataPoints) {
-      onChange({
-        ...options,
-        maxDataPoints,
-      });
+    if (maxDataPoints !== lastSavedValueRef.current) {
+      lastSavedValueRef.current = maxDataPoints;
+      if (maxDataPoints !== optionsRef.current.maxDataPoints) {
+        onChangeRef.current({
+          ...optionsRef.current,
+          maxDataPoints,
+        });
+      }
     }
+  }, []);
+
+  React.useEffect(() => {
+    return () => saveMaxDataPoints(inputValueRef.current);
+  }, [saveMaxDataPoints]);
+
+  const onMaxDataPointsBlur = (event: ChangeEvent<HTMLInputElement>) => {
+    saveMaxDataPoints(event.target.value);
   };
 
   return (
@@ -257,6 +274,7 @@ export function MaxDataPointsOption({
         width={10}
         placeholder={DEFAULT_MAX_DATA_POINTS.toString()}
         spellCheck={false}
+        onChange={(event) => (inputValueRef.current = event.target.value)}
         onBlur={onMaxDataPointsBlur}
         defaultValue={value}
       />
@@ -272,15 +290,32 @@ export function MinIntervalOption({
   onChange: (options: AlertQueryOptions) => void;
 }) {
   const value = options.minInterval ?? '';
+  const inputValueRef = React.useRef(value);
+  const optionsRef = React.useRef(options);
+  const onChangeRef = React.useRef(onChange);
+  const lastSavedValueRef = React.useRef(value);
+
+  optionsRef.current = options;
+  onChangeRef.current = onChange;
+
+  const saveMinInterval = React.useCallback((minInterval: string) => {
+    if (minInterval !== lastSavedValueRef.current) {
+      lastSavedValueRef.current = minInterval;
+      if (minInterval !== optionsRef.current.minInterval) {
+        onChangeRef.current({
+          ...optionsRef.current,
+          minInterval,
+        });
+      }
+    }
+  }, []);
+
+  React.useEffect(() => {
+    return () => saveMinInterval(inputValueRef.current);
+  }, [saveMinInterval]);
 
   const onMinIntervalBlur = (event: ChangeEvent<HTMLInputElement>) => {
-    const minInterval = event.target.value;
-    if (minInterval !== value) {
-      onChange({
-        ...options,
-        minInterval,
-      });
-    }
+    saveMinInterval(event.target.value);
   };
 
   return (
@@ -299,6 +334,7 @@ export function MinIntervalOption({
         width={10}
         placeholder={DEFAULT_MIN_INTERVAL}
         spellCheck={false}
+        onChange={(event) => (inputValueRef.current = event.target.value)}
         onBlur={onMinIntervalBlur}
         defaultValue={value}
       />


### PR DESCRIPTION
Fixes alert option values being lost when the Options tooltip closes.

The Interval and Max data points inputs now retain their latest values and save them during unmount, while preserving existing blur behavior, normalization, and duplicate-save prevention. This addresses the root cause: the tooltip unmounted the inputs before `onBlur` could commit changes.

Tests:
- Confirmed the focused regression suite failed on the unpatched baseline.
- Focused tests: 5 passed.
- Alert rule-editor suite: 24 suites, 240 tests passed, 1 skipped, 26 snapshots.
- ESLint, Prettier, and `git diff --check` passed.

Fixes #111664