### PR TITLE
PanelEditNext: Add button labels (A/B test)

### DIFF
--- a/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
@@ -65,6 +65,7 @@ declare module "@openfeature/core" {
     | "grafana.useDefaultScopesEndpoint"
     | "grafana.logLevelInference"
     | "plugins.initDataSourcesAsync"
+    | "paneledit.buttonLabels"
     | "grafana.panelEditNextFeedbackEvent"
     | "grafana.visualDesignRefresh"
     | "dashboard.vectorSearch"

--- a/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
@@ -117,6 +117,8 @@ export const FlagKeys = {
   NewSavedQueriesExperience: "newSavedQueriesExperience",
   /** Applies OTel formatting templates to displayed logs */
   OtelLogsFormatting: "otelLogsFormatting",
+  /** Shows text labels on the add and stacked view buttons in PanelEditNext */
+  PaneleditButtonLabels: "paneledit.buttonLabels",
   /** Initializes data source instance settings asynchronously from the API instead of synchronously from boot data */
   PluginsInitDataSourcesAsync: "plugins.initDataSourcesAsync",
   /** Enables plugins setting from new apis */
@@ -731,6 +733,17 @@ export const useFlagNewSavedQueriesExperience = (options?: ReactFlagEvaluationOp
  */
 export const useFlagOtelLogsFormatting = (options?: ReactFlagEvaluationOptions): boolean => {
   return useFlag("otelLogsFormatting", false, options).value;
+};
+
+/**
+ * Shows text labels on the add and stacked view buttons in PanelEditNext
+ *
+ * **Details:**
+ * - flag key: `paneledit.buttonLabels`
+ * - default value: `false`
+ */
+export const useFlagPaneleditButtonLabels = (options?: ReactFlagEvaluationOptions): boolean => {
+  return useFlag("paneledit.buttonLabels", false, options).value;
 };
 
 /**

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -2923,6 +2923,15 @@ var (
 			Generate:     Generate{Go: true},
 		},
 		{
+			Name:         "paneledit.buttonLabels",
+			Description:  "Shows text labels on the add and stacked view buttons in PanelEditNext",
+			Stage:        FeatureStageExperimental,
+			Owner:        grafanaDataProSquad,
+			HideFromDocs: true,
+			Expression:   "false",
+			Generate:     Generate{React: true},
+		},
+		{
 			Name:         "grafana.panelEditNextFeedbackEvent",
 			Description:  "Enables firing an event for PanelEditNext feedback that triggers an in-house survey",
 			Stage:        FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -339,6 +339,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-05-22,grafana.logLevelInference,deprecated,@grafana/observability-logs,false,false,true
 2026-05-26,plugins.initDataSourcesAsync,experimental,@grafana/grafana-catalog,false,false,true
 2026-05-22,frontendService.reducedBootDataAPI,experimental,@grafana/grafana-frontend-platform,false,false,false
+2026-07-30,paneledit.buttonLabels,experimental,@grafana/datapro,false,false,true
 2026-05-27,grafana.panelEditNextFeedbackEvent,experimental,@grafana/datapro,false,false,true
 2026-06-12,grafana.visualDesignRefresh,experimental,@grafana/grafana-frontend-platform,false,false,true
 2026-06-09,dashboard.vectorSearch,experimental,@grafana/search-and-storage,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -4581,6 +4581,21 @@
     },
     {
       "metadata": {
+        "name": "paneledit.buttonLabels",
+        "resourceVersion": "1785381918358",
+        "creationTimestamp": "2026-07-30T03:25:18Z"
+      },
+      "spec": {
+        "description": "Shows text labels on the add and stacked view buttons in PanelEditNext",
+        "stage": "experimental",
+        "codeowner": "@grafana/datapro",
+        "frontend": true,
+        "hideFromDocs": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "pdfTables",
         "resourceVersion": "1779440584464",
         "creationTimestamp": "2023-11-06T13:39:22Z"

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/AddCardButton.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/AddCardButton.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { css, cx } from '@emotion/css';
 import { useCallback, useMemo, useState } from 'react';
 
 import { CoreApp, type GrafanaTheme2 } from '@grafana/data';
@@ -35,10 +35,18 @@ interface AddCardButtonProps {
   variant: 'query' | 'transformation';
   afterId?: string;
   alwaysVisible?: boolean;
+  showLabel?: boolean;
   onAdd?: () => void;
 }
 
-export const AddCardButton = ({ variant, afterId, onAdd, alwaysVisible = false }: AddCardButtonProps) => {
+export const AddCardButton = ({
+  variant,
+  afterId,
+  onAdd,
+  alwaysVisible = false,
+  showLabel = false,
+}: AddCardButtonProps) => {
+  const showButtonLabel = alwaysVisible && showLabel;
   const styles = useStyles2(getStyles, alwaysVisible);
   const theme = useTheme2();
   const { dsSettings } = useDatasourceContext();
@@ -150,17 +158,19 @@ export const AddCardButton = ({ variant, afterId, onAdd, alwaysVisible = false }
   }, [afterId, setPendingTransformation, onAdd]);
 
   const ariaLabel = getButtonAriaLabel(variant, afterId);
+  const buttonLabel = t('query-editor-next.sidebar.add', 'Add');
 
   if (variant === 'transformation') {
     return (
       <button
-        className={styles.button}
+        className={cx(styles.button, { [styles.buttonWithLabel]: showButtonLabel })}
         data-add-button={!alwaysVisible || undefined}
         type="button"
         aria-label={ariaLabel}
         onClick={handleTransformationClick}
       >
         <Icon name="plus" size={alwaysVisible ? 'sm' : 'md'} />
+        {showButtonLabel && buttonLabel}
       </button>
     );
   }
@@ -173,13 +183,14 @@ export const AddCardButton = ({ variant, afterId, onAdd, alwaysVisible = false }
       onVisibleChange={handleMenuVisibleChange}
     >
       <button
-        className={styles.button}
+        className={cx(styles.button, { [styles.buttonWithLabel]: showButtonLabel })}
         data-add-button={!alwaysVisible || undefined}
         data-menu-open={menuOpen || undefined}
         type="button"
         aria-label={ariaLabel}
       >
         <Icon name="plus" size={alwaysVisible ? 'sm' : 'md'} />
+        {showButtonLabel && buttonLabel}
       </button>
     </Dropdown>
   );
@@ -237,6 +248,13 @@ function getStyles(theme: GrafanaTheme2, alwaysVisible: boolean) {
           pointerEvents: 'auto' as const,
         }),
       },
+    }),
+    buttonWithLabel: css({
+      width: 'auto',
+      gap: theme.spacing(0.5),
+      padding: theme.spacing(0, 0.75),
+      fontSize: theme.typography.bodySmall.fontSize,
+      fontWeight: theme.typography.fontWeightMedium,
     }),
   };
 }

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/AddCardButton.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/AddCardButton.tsx
@@ -255,6 +255,7 @@ function getStyles(theme: GrafanaTheme2, alwaysVisible: boolean) {
       padding: theme.spacing(0, 0.75),
       fontSize: theme.typography.bodySmall.fontSize,
       fontWeight: theme.typography.fontWeightMedium,
+      marginLeft: 'auto',
     }),
   };
 }

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueriesAndTransformationsView.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueriesAndTransformationsView.tsx
@@ -14,7 +14,11 @@ import { DraggableList } from './DraggableList/DraggableList';
 import { useSidebarDragAndDrop } from './DraggableList/useSidebarDragAndDrop';
 import { SectionEmptyState } from './SectionEmptyState';
 
-export function QueriesAndTransformationsView() {
+interface QueriesAndTransformationsViewProps {
+  showButtonLabels?: boolean;
+}
+
+export function QueriesAndTransformationsView({ showButtonLabels = false }: QueriesAndTransformationsViewProps) {
   const { queries } = useQueryRunnerContext();
   const { transformations } = usePanelContext();
   const { pendingExpression, pendingSavedQuery, pendingTransformation, multiSelectMode } = useQueryEditorUIContext();
@@ -45,7 +49,9 @@ export function QueriesAndTransformationsView() {
         label={t('query-editor-next.sidebar.queries-expressions', 'Queries & Expressions')}
         isOpen={queriesOpen}
         onToggle={setQueriesOpen}
-        headerAction={<AddCardButton variant="query" alwaysVisible onAdd={expandQueries} />}
+        headerAction={
+          <AddCardButton variant="query" alwaysVisible showLabel={showButtonLabels} onAdd={expandQueries} />
+        }
       >
         {queries.length > 0 && (
           <DraggableList
@@ -67,7 +73,14 @@ export function QueriesAndTransformationsView() {
         label={t('query-editor-next.sidebar.transformations', 'Transformations')}
         isOpen={transformationsOpen}
         onToggle={setTransformationsOpen}
-        headerAction={<AddCardButton variant="transformation" alwaysVisible onAdd={expandTransformations} />}
+        headerAction={
+          <AddCardButton
+            variant="transformation"
+            alwaysVisible
+            showLabel={showButtonLabels}
+            onAdd={expandTransformations}
+          />
+        }
       >
         {transformations.length > 0 && (
           <DraggableList

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Sidebar.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Sidebar.test.tsx
@@ -50,7 +50,7 @@ describe('QueryEditorSidebar', () => {
 
       expect(screen.getByRole('button', { name: 'Add query or expression' })).toHaveTextContent('Add');
       expect(screen.getByRole('button', { name: 'Add transformation' })).toHaveTextContent('Add');
-      expect(screen.getByRole('button', { name: 'Enter stacked view' })).toHaveTextContent(/^Stack$/);
+      expect(screen.getByRole('button', { name: 'Stack' })).toHaveTextContent(/^Stack$/);
     });
   });
 

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Sidebar.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Sidebar.test.tsx
@@ -40,7 +40,7 @@ describe('QueryEditorSidebar', () => {
 
       expect(screen.getByRole('button', { name: 'Add query or expression' })).not.toHaveTextContent('Add');
       expect(screen.getByRole('button', { name: 'Add transformation' })).not.toHaveTextContent('Add');
-      expect(screen.getByRole('button', { name: 'Enter stacked view' })).not.toHaveTextContent('Stacked');
+      expect(screen.getByRole('button', { name: 'Enter stacked view' })).not.toHaveTextContent('Stack');
     });
 
     it('labels the add and stacked view buttons in the treatment variant', () => {
@@ -50,7 +50,7 @@ describe('QueryEditorSidebar', () => {
 
       expect(screen.getByRole('button', { name: 'Add query or expression' })).toHaveTextContent('Add');
       expect(screen.getByRole('button', { name: 'Add transformation' })).toHaveTextContent('Add');
-      expect(screen.getByRole('button', { name: 'Enter stacked view' })).toHaveTextContent(/^Stacked$/);
+      expect(screen.getByRole('button', { name: 'Enter stacked view' })).toHaveTextContent(/^Stack$/);
     });
   });
 

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Sidebar.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Sidebar.test.tsx
@@ -1,6 +1,8 @@
-import { screen } from '@testing-library/react';
+import { act, screen } from '@testing-library/react';
 
 import { reportInteraction } from '@grafana/runtime';
+import { FlagKeys } from '@grafana/runtime/internal';
+import { setTestFlags } from '@grafana/test-utils/unstable';
 
 import { SidebarSize } from '../../constants';
 import { type QueryEditorUIState } from '../QueryEditorContext';
@@ -24,7 +26,32 @@ describe('QueryEditorSidebar', () => {
   });
 
   afterEach(() => {
+    act(() => {
+      setTestFlags({});
+    });
     jest.restoreAllMocks();
+  });
+
+  describe('button labels experiment', () => {
+    it('keeps the add and stacked view buttons icon-only in the control variant', () => {
+      setTestFlags({ [FlagKeys.PaneleditButtonLabels]: false });
+
+      renderWithQueryEditorProvider(<Sidebar sidebarSize={SidebarSize.Full} setSidebarSize={jest.fn()} />);
+
+      expect(screen.getByRole('button', { name: 'Add query or expression' })).not.toHaveTextContent('Add');
+      expect(screen.getByRole('button', { name: 'Add transformation' })).not.toHaveTextContent('Add');
+      expect(screen.getByRole('button', { name: 'Enter stacked view' })).not.toHaveTextContent('Stacked');
+    });
+
+    it('labels the add and stacked view buttons in the treatment variant', () => {
+      setTestFlags({ [FlagKeys.PaneleditButtonLabels]: true });
+
+      renderWithQueryEditorProvider(<Sidebar sidebarSize={SidebarSize.Full} setSidebarSize={jest.fn()} />);
+
+      expect(screen.getByRole('button', { name: 'Add query or expression' })).toHaveTextContent('Add');
+      expect(screen.getByRole('button', { name: 'Add transformation' })).toHaveTextContent('Add');
+      expect(screen.getByRole('button', { name: 'Enter stacked view' })).toHaveTextContent(/^Stacked$/);
+    });
   });
 
   describe('header view toggle at narrow widths', () => {

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Sidebar.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Sidebar.tsx
@@ -96,7 +96,6 @@ export const Sidebar = memo(function Sidebar({ sidebarSize, setSidebarSize }: Si
                 className={styles.stackedModeButton}
                 data-active={stackedMode.enabled}
                 onClick={handleStackedModeToggle}
-                aria-label={stackedModeLabel}
                 aria-pressed={stackedMode.enabled}
                 tooltip={stackedModeLabel}
               >

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Sidebar.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Sidebar.tsx
@@ -1,9 +1,10 @@
-import { css, cx } from '@emotion/css';
+import { css } from '@emotion/css';
 import { memo, useRef } from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { IconButton, ScrollContainer, useStyles2 } from '@grafana/ui';
+import { useFlagPaneleditButtonLabels } from '@grafana/runtime/internal';
+import { Button, IconButton, ScrollContainer, useStyles2 } from '@grafana/ui';
 
 import { SegmentedToggle, type SegmentedToggleProps } from '../../SegmentedToggle';
 import { QueryEditorType, type SidebarSize } from '../../constants';
@@ -24,7 +25,7 @@ interface SidebarProps {
 }
 
 export const Sidebar = memo(function Sidebar({ sidebarSize, setSidebarSize }: SidebarProps) {
-  const styles = useStyles2(getStyles);
+  const showButtonLabels = useFlagPaneleditButtonLabels();
   const {
     setSelectedAlert,
     cardType,
@@ -35,6 +36,7 @@ export const Sidebar = memo(function Sidebar({ sidebarSize, setSidebarSize }: Si
     selectedTransformation,
   } = useQueryEditorUIContext();
   const { alertRules, loading } = useAlertingContext();
+  const styles = useStyles2(getStyles);
 
   const contentRef = useRef<HTMLDivElement>(null);
 
@@ -85,16 +87,33 @@ export const Sidebar = memo(function Sidebar({ sidebarSize, setSidebarSize }: Si
         contentKey={alertsLabel}
         trailing={
           showStackedModeAction ? (
-            <IconButton
-              name="layer-group"
-              size="sm"
-              variant="secondary"
-              className={cx({ [styles.stackedModeActionButtonActive]: stackedMode.enabled })}
-              onClick={handleStackedModeToggle}
-              aria-label={stackedModeLabel}
-              aria-pressed={stackedMode.enabled}
-              tooltip={stackedModeLabel}
-            />
+            showButtonLabels ? (
+              <Button
+                icon="layer-group"
+                size="sm"
+                fill="text"
+                variant="secondary"
+                className={styles.stackedModeButton}
+                data-active={stackedMode.enabled}
+                onClick={handleStackedModeToggle}
+                aria-label={stackedModeLabel}
+                aria-pressed={stackedMode.enabled}
+                tooltip={stackedModeLabel}
+              >
+                {t('query-editor-next.sidebar.stacked', 'Stack')}
+              </Button>
+            ) : (
+              <span className={styles.stackedModeIconButton} data-active={stackedMode.enabled}>
+                <IconButton
+                  name="layer-group"
+                  size="sm"
+                  variant="secondary"
+                  onClick={handleStackedModeToggle}
+                  aria-pressed={stackedMode.enabled}
+                  tooltip={stackedModeLabel}
+                />
+              </span>
+            )
           ) : undefined
         }
       >
@@ -115,7 +134,7 @@ export const Sidebar = memo(function Sidebar({ sidebarSize, setSidebarSize }: Si
           {cardType === QueryEditorType.Alert ? (
             <AlertsView alertRules={alertRules} />
           ) : (
-            <QueriesAndTransformationsView />
+            <QueriesAndTransformationsView showButtonLabels={showButtonLabels} />
           )}
         </div>
       </ScrollContainer>
@@ -139,11 +158,20 @@ function getStyles(theme: GrafanaTheme2) {
       paddingLeft: theme.spacing(1),
       paddingRight: theme.spacing(1),
     }),
-    stackedModeActionButtonActive: css({
-      color: theme.colors.primary.text,
-      '&::before, &:hover::before': {
+    stackedModeButton: css({
+      '&[data-active="true"]': {
+        color: theme.colors.primary.text,
         backgroundColor: theme.colors.primary.transparent,
-        opacity: 1,
+      },
+    }),
+    stackedModeIconButton: css({
+      display: 'inline-flex',
+      '&[data-active="true"] button': {
+        color: theme.colors.primary.text,
+        '&::before, &:hover::before': {
+          backgroundColor: theme.colors.primary.transparent,
+          opacity: 1,
+        },
       },
     }),
   };

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/tracking.test.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/tracking.test.ts
@@ -1,0 +1,48 @@
+import { faro } from '@grafana/faro-web-sdk';
+import { reportInteraction } from '@grafana/runtime';
+import { FlagKeys } from '@grafana/runtime/internal';
+import { setTestFlags } from '@grafana/test-utils/unstable';
+
+import { trackEditorVersionToggle } from './tracking';
+
+jest.mock('@grafana/faro-web-sdk', () => ({
+  faro: {
+    api: {
+      pushEvent: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  reportInteraction: jest.fn(),
+}));
+
+const mockPushEvent = jest.mocked(faro.api.pushEvent);
+const mockReportInteraction = jest.mocked(reportInteraction);
+
+describe('trackEditorVersionToggle', () => {
+  afterEach(() => {
+    setTestFlags({});
+    jest.clearAllMocks();
+  });
+
+  it.each([
+    ['upgrade', false],
+    ['upgrade', true],
+    ['downgrade', false],
+    ['downgrade', true],
+  ] as const)('dual-writes direction=%s with paneledit.buttonLabels=%s', (direction, buttonLabelsEnabled) => {
+    setTestFlags({ [FlagKeys.PaneleditButtonLabels]: buttonLabelsEnabled });
+
+    trackEditorVersionToggle(direction);
+
+    const payload = {
+      action: 'toggle_editor_version',
+      direction,
+      'paneledit.buttonLabels': String(buttonLabelsEnabled),
+    };
+    expect(mockPushEvent).toHaveBeenCalledWith('grafana_panel_edit_next_interaction', payload);
+    expect(mockReportInteraction).toHaveBeenCalledWith('grafana_panel_edit_next_interaction', payload);
+  });
+});

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/tracking.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/tracking.ts
@@ -1,5 +1,6 @@
 import { debounce } from 'lodash';
 
+import { faro } from '@grafana/faro-web-sdk';
 import { getAppEvents, reportInteraction } from '@grafana/runtime';
 import { FlagKeys, getFeatureFlagClient } from '@grafana/runtime/internal';
 import { PanelEditNextFeedbackEvent } from 'app/types/events';
@@ -119,10 +120,13 @@ export function trackReorder(itemType: 'query' | 'transformation', options?: { s
 }
 
 export function trackEditorVersionToggle(direction: 'upgrade' | 'downgrade') {
-  reportInteraction(EVENT_PANEL_EDIT_NEXT, {
+  const payload: Record<string, string> = {
     action: 'toggle_editor_version',
     direction,
-  });
+    'paneledit.buttonLabels': String(getFeatureFlagClient().getBooleanValue(FlagKeys.PaneleditButtonLabels, false)),
+  };
+  faro.api.pushEvent(EVENT_PANEL_EDIT_NEXT, payload);
+  reportInteraction(EVENT_PANEL_EDIT_NEXT, payload);
 }
 
 export function trackBannerDismiss() {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -14719,7 +14719,7 @@
       "new-type": "New {{type}}",
       "queries-empty": "No queries or expressions",
       "queries-expressions": "Queries & Expressions",
-      "stacked": "Stacked",
+      "stacked": "Stack",
       "toggle-size": "Toggle sidebar size",
       "transformations": "Transformations",
       "transformations-empty": "No transformations",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -14693,6 +14693,7 @@
       "message": "Add a query, expression, or transformation to get started"
     },
     "sidebar": {
+      "add": "Add",
       "add-below": "Add below {{id}}",
       "add-expression": "Add expression",
       "add-expression-disabled": "Expressions are not supported with the Dashboard data source",
@@ -14718,6 +14719,7 @@
       "new-type": "New {{type}}",
       "queries-empty": "No queries or expressions",
       "queries-expressions": "Queries & Expressions",
+      "stacked": "Stacked",
       "toggle-size": "Toggle sidebar size",
       "transformations": "Transformations",
       "transformations-empty": "No transformations",


### PR DESCRIPTION
## Motivation

Closes [DPRO-259](https://linear.app/grafana/issue/DPRO-259/configure-paneleditnext-ui-for-button-label-experiment) / Closes https://github.com/grafana/grafana/issues/129591.

## What does this PR do?

This PR adds labels to a couple of key buttons in PanelEditNext: the Stacked View button, and the Add (+) button. When the buttons have labels, we justify the buttons to the right of the query stack instead of right next to the section name. I thought this looked much better, but I'm open to feedback.

It also sets up measurements for an A/B test. When the user downgrades to the v1 panel edit, or upgrades to the v2 panel edit, we track* the value of the `'paneledit.buttonLabels'` feature flag.

* Currently, we need to dual-write the event with `reportInteraction` and Faro Custom Events. In the future, I expect we'll use only Faro Custom Events for A/B testing.

## Demo

https://github.com/user-attachments/assets/762a17ce-4e6a-4c10-bcec-8aa7e4b82e3d

## How to test

After checking out the `nickrichmond/dpro-257` branch and spinning up the dev server:
- Edit a dashboard panel
- Set `&featureControl` in the URL to enable the feature flag toggling interface
- Set the `paneledit.buttonLabels` to `true` / `false` to see the UI changes (the aforementioned buttons have labels when `true`)
- Check different widths of the query stack - does it look okay?