### PR TITLE
Search: keep deleted objects in the index for trash search

### DIFF
--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -724,6 +724,7 @@ type Cfg struct {
 	IndexCacheTTL                              time.Duration
 	IndexMinUpdateInterval                     time.Duration // Don't update index if it was updated less than this interval ago.
 	IndexModificationCacheTTL                  time.Duration // TTL for dedup cache used in ListModifiedSince. 0 disables the cache.
+	IndexDeletedDocuments                      bool          // Keep deleted objects in the search index, so trash searches can find them.
 	MaxFileIndexAge                            time.Duration // Max age of file-based indexes. Index older than this will be rebuilt asynchronously.
 	MinFileIndexBuildVersion                   string        // Minimum version of Grafana that built the file-based index. If index was built with older Grafana, it will be rebuilt asynchronously.
 	IndexSnapshotEnabled                       bool          // Enable remote index snapshots

--- a/pkg/setting/setting_unified_storage.go
+++ b/pkg/setting/setting_unified_storage.go
@@ -219,6 +219,10 @@ func (cfg *Cfg) setUnifiedStorageConfig() {
 	cfg.IndexCacheTTL = section.Key("index_cache_ttl").MustDuration(10 * time.Minute)
 	cfg.IndexMinUpdateInterval = section.Key("index_min_update_interval").MustDuration(0)
 	cfg.IndexModificationCacheTTL = section.Key("index_modification_cache_ttl").MustDuration(0)
+	// Off by default: switching this on makes the next rebuild of every index pull
+	// in all trash the storage still holds, which is unbounded where garbage
+	// collection is disabled.
+	cfg.IndexDeletedDocuments = section.Key("index_deleted_documents").MustBool(false)
 	cfg.SprinklesApiServer = section.Key("sprinkles_api_server").String()
 	cfg.SprinklesApiServerPageLimit = section.Key("sprinkles_api_server_page_limit").MustInt(10000)
 	cfg.CACertPath = section.Key("ca_cert_path").String()

--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -295,6 +295,7 @@ type searchServer struct {
 
 	injectFailuresPercent     int
 	indexModificationCacheTTL time.Duration
+	indexDeletedDocuments     bool
 
 	backendDiagnostics resourcepb.DiagnosticsServer //nolint:staticcheck
 }
@@ -373,6 +374,7 @@ func newSearchServer(opts SearchOptions, storage StorageBackend, vectorBackend v
 		requiredFeatures:          RequiredIndexFeatures(),
 		injectFailuresPercent:     opts.InjectFailuresPercent,
 		indexModificationCacheTTL: opts.IndexModificationCacheTTL,
+		indexDeletedDocuments:     opts.IndexDeletedDocuments,
 
 		queryCache:             opts.QueryCache,
 		queryCacheMaxPerTenant: opts.QueryCacheMaxPerTenant,
@@ -1978,7 +1980,7 @@ func (s *searchServer) build(ctx context.Context, nsr NamespacedResource, size i
 			calledAt = lastCalledAt
 		}
 
-		keepDeleted := indexKeepsDeletedDocuments(index, logger)
+		keepDeleted := s.keepsDeletedDocuments(index, logger)
 
 		listModifiedTime := time.Now()
 		rv, it := s.storage.ListModifiedSince(ctx, NamespacedResource{
@@ -2128,10 +2130,14 @@ func (s *searchServer) build(ctx context.Context, nsr NamespacedResource, size i
 	return index, err
 }
 
-// indexKeepsDeletedDocuments reports whether an index maps the markers a deleted
-// document needs. When it does not, keeping the document would serve it as live,
-// so it is removed instead until the index is rebuilt.
-func indexKeepsDeletedDocuments(index ResourceIndex, logger log.Logger) bool {
+// keepsDeletedDocuments reports whether deleted objects should stay in this
+// index. They do not when the feature is switched off, or when the index predates
+// the marker mappings and would serve a marked document as live. Either way the
+// document is removed instead, as it was before trash search existed.
+func (s *searchServer) keepsDeletedDocuments(index ResourceIndex, logger log.Logger) bool {
+	if !s.indexDeletedDocuments {
+		return false
+	}
 	info, err := index.BuildInfo()
 	if err != nil {
 		logger.Warn("cannot read index features, removing deleted documents instead of keeping them", "err", err)
@@ -2153,9 +2159,9 @@ func (s *searchServer) indexTrash(ctx context.Context, nsr NamespacedResource, i
 	ctx, span := tracer.Start(ctx, "resource.searchServer.indexTrash")
 	defer span.End()
 
-	// Nothing to do for an index that cannot hold the markers: the documents would
-	// be dropped, so listing trash and building them would be wasted work.
-	if !indexKeepsDeletedDocuments(index, logger) {
+	// Nothing to do when deleted objects are not kept: listing trash and building
+	// documents that get dropped would be wasted work.
+	if !s.keepsDeletedDocuments(index, logger) {
 		return nil
 	}
 

--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"hash/fnv"
 	"math/rand"
@@ -42,6 +43,11 @@ import (
 )
 
 const maxBatchSize = 1000
+
+// listEverything is the limit an index build passes to say "no limit". Backends
+// take req.Limit+1 to spot a next page, so MaxInt64 would overflow; this is far
+// past any real resource count.
+const listEverything = 1000000000000
 
 // openIndexStatsMaxAge is how far back startup accepts the local open index list.
 const openIndexStatsMaxAge = time.Hour
@@ -1824,6 +1830,43 @@ func (s *searchServer) getOrCreateIndex(ctx context.Context, stats *SearchStats,
 	return idx, nil
 }
 
+// bulkIndexBatcher hands documents to an index in batches, so building an index
+// for a large resource does not hold every document in memory at once.
+type bulkIndexBatcher struct {
+	index ResourceIndex
+	span  trace.Span
+	items []*BulkIndexItem
+	total int
+}
+
+func newBulkIndexBatcher(index ResourceIndex, span trace.Span) *bulkIndexBatcher {
+	return &bulkIndexBatcher{index: index, span: span, items: make([]*BulkIndexItem, 0, maxBatchSize)}
+}
+
+func (b *bulkIndexBatcher) add(item *BulkIndexItem) error {
+	b.items = append(b.items, item)
+	if len(b.items) < maxBatchSize {
+		return nil
+	}
+	return b.flush()
+}
+
+func (b *bulkIndexBatcher) flush() error {
+	if len(b.items) == 0 {
+		return nil
+	}
+	b.span.AddEvent("bulk indexing", trace.WithAttributes(attribute.Int("count", len(b.items))))
+	if err := b.index.BulkIndex(&BulkIndexRequest{Items: b.items}); err != nil {
+		return err
+	}
+	b.total += len(b.items)
+	b.items = b.items[:0]
+	return nil
+}
+
+// indexed returns how many documents have been handed to the index.
+func (b *bulkIndexBatcher) indexed() int { return b.total }
+
 //nolint:gocyclo
 func (s *searchServer) build(ctx context.Context, nsr NamespacedResource, size int64, indexBuildReason string, rebuild bool, lastImportTime time.Time) (ResourceIndex, error) {
 	ctx, span := tracer.Start(ctx, "resource.searchServer.build")
@@ -1848,7 +1891,7 @@ func (s *searchServer) build(ctx context.Context, nsr NamespacedResource, size i
 		span.AddEvent("building index", trace.WithAttributes(attribute.Int64("size", size), attribute.String("reason", indexBuildReason)))
 
 		listRV, err := s.storage.ListIterator(ctx, &resourcepb.ListRequest{
-			Limit: 1000000000000, // big number
+			Limit: listEverything,
 			Options: &resourcepb.ListOptions{
 				Key: &resourcepb.ResourceKey{
 					Group:     nsr.Group,
@@ -1857,10 +1900,7 @@ func (s *searchServer) build(ctx context.Context, nsr NamespacedResource, size i
 				},
 			},
 		}, func(iter ListIterator) error {
-			// Process documents in batches to avoid memory issues
-			// When dealing with large collections (e.g., 100k+ documents),
-			// loading all documents into memory at once can cause OOM errors.
-			items := make([]*BulkIndexItem, 0, maxBatchSize)
+			batch := newBulkIndexBatcher(index, span)
 
 			for iter.Next() {
 				if err = iter.Error(); err != nil {
@@ -1884,33 +1924,31 @@ func (s *searchServer) build(ctx context.Context, nsr NamespacedResource, size i
 					continue
 				}
 
-				// Add to bulk items
-				items = append(items, &BulkIndexItem{
-					Action: ActionIndex,
-					Doc:    doc,
-				})
-
-				// When we reach the batch size, perform bulk index and reset the batch.
-				if len(items) >= maxBatchSize {
-					span.AddEvent("bulk indexing", trace.WithAttributes(attribute.Int("count", len(items))))
-					if err = index.BulkIndex(&BulkIndexRequest{Items: items}); err != nil {
-						return err
-					}
-
-					items = items[:0]
-				}
-			}
-
-			// Index any remaining items in the final batch.
-			if len(items) > 0 {
-				span.AddEvent("bulk indexing", trace.WithAttributes(attribute.Int("count", len(items))))
-				if err = index.BulkIndex(&BulkIndexRequest{Items: items}); err != nil {
+				if err = batch.add(&BulkIndexItem{Action: ActionIndex, Doc: doc}); err != nil {
 					return err
 				}
 			}
+
+			if err = batch.flush(); err != nil {
+				return err
+			}
 			return iter.Error()
 		})
-		return listRV, err
+		if err != nil {
+			return listRV, err
+		}
+
+		// Deleted objects are not on the list above, and nothing will re-announce
+		// them: an object is deleted once. Without this pass every rebuild would
+		// drop the whole trash for this resource.
+		//
+		// The resource version stays the one from the live pass, which is the older
+		// of the two, so anything that changed while this pass ran is replayed by
+		// the updater rather than missed.
+		if err := s.indexTrash(ctx, nsr, index, logger); err != nil {
+			return listRV, err
+		}
+		return listRV, nil
 	}
 
 	var dedupCache *gocache.Cache
@@ -1939,6 +1977,8 @@ func (s *searchServer) build(ctx context.Context, nsr NamespacedResource, size i
 		if lastSinceRV > 0 && sinceRV == lastSinceRV {
 			calledAt = lastCalledAt
 		}
+
+		keepDeleted := indexKeepsDeletedDocuments(index, logger)
 
 		listModifiedTime := time.Now()
 		rv, it := s.storage.ListModifiedSince(ctx, NamespacedResource{
@@ -1994,10 +2034,30 @@ func (s *searchServer) build(ctx context.Context, nsr NamespacedResource, size i
 					Doc:    doc,
 				})
 			case resourcepb.WatchEvent_DELETED:
-				span.AddEvent("deleting document", trace.WithAttributes(attribute.String("name", res.Key.Name)))
+				// The delete event carries the object as it was, so trash searches can
+				// find it. Two things send it to the index as a removal instead: an
+				// index that cannot hold the markers, and a body we cannot read.
+				var doc *IndexableDocument
+				if keepDeleted {
+					doc, err = buildDeletedDocument(key, res.ResourceVersion, res.Value)
+					if err != nil {
+						span.RecordError(err)
+						logger.Warn("error building search document for deleted resource, removing it from the index instead", "key", SearchID(key), "err", err)
+					}
+				}
+				if doc == nil {
+					span.AddEvent("deleting document", trace.WithAttributes(attribute.String("name", res.Key.Name)))
+					items = append(items, &BulkIndexItem{
+						Action: ActionDelete,
+						Key:    &res.Key,
+					})
+					break
+				}
+
+				span.AddEvent("marking document deleted", trace.WithAttributes(attribute.String("name", res.Key.Name)))
 				items = append(items, &BulkIndexItem{
-					Action: ActionDelete,
-					Key:    &res.Key,
+					Action: ActionIndex,
+					Doc:    doc,
 				})
 			default:
 				logger.Error("can't update index with item, unknown action", "action", res.Action, "key", key)
@@ -2066,6 +2126,133 @@ func (s *searchServer) build(ctx context.Context, nsr NamespacedResource, size i
 	}
 
 	return index, err
+}
+
+// indexKeepsDeletedDocuments reports whether an index maps the markers a deleted
+// document needs. When it does not, keeping the document would serve it as live,
+// so it is removed instead until the index is rebuilt.
+func indexKeepsDeletedDocuments(index ResourceIndex, logger log.Logger) bool {
+	info, err := index.BuildInfo()
+	if err != nil {
+		logger.Warn("cannot read index features, removing deleted documents instead of keeping them", "err", err)
+		return false
+	}
+	missing := MissingIndexFeatures(info, []IndexFeature{IndexFeatureDeletedMarker})
+	if len(missing) > 0 {
+		logger.Debug("index does not map the markers on deleted documents, removing them until it is rebuilt", "missing", missing)
+		return false
+	}
+	return true
+}
+
+// indexTrash adds the currently-deleted objects of a resource to the index,
+// marked so only trash searches find them. Deleted objects are absent from the
+// live listing the build runs, so this is the only thing that puts them back
+// after a rebuild.
+func (s *searchServer) indexTrash(ctx context.Context, nsr NamespacedResource, index ResourceIndex, logger log.Logger) error {
+	ctx, span := tracer.Start(ctx, "resource.searchServer.indexTrash")
+	defer span.End()
+
+	// Nothing to do for an index that cannot hold the markers: the documents would
+	// be dropped, so listing trash and building them would be wasted work.
+	if !indexKeepsDeletedDocuments(index, logger) {
+		return nil
+	}
+
+	req := &resourcepb.ListRequest{
+		Limit:  listEverything,
+		Source: resourcepb.ListRequest_TRASH,
+		Options: &resourcepb.ListOptions{
+			Key: &resourcepb.ResourceKey{
+				Group:     nsr.Group,
+				Resource:  nsr.Resource,
+				Namespace: nsr.Namespace,
+			},
+		},
+	}
+
+	batch := newBulkIndexBatcher(index, span)
+	_, err := s.storage.ListHistory(ctx, req, func(iter ListIterator) error {
+		for iter.Next() {
+			if err := iter.Error(); err != nil {
+				return err
+			}
+
+			key := &resourcepb.ResourceKey{
+				Group:     nsr.Group,
+				Resource:  nsr.Resource,
+				Namespace: nsr.Namespace,
+				Name:      iter.Name(),
+			}
+
+			doc, err := buildDeletedDocument(key, iter.ResourceVersion(), iter.Value())
+			if err != nil {
+				span.RecordError(err)
+				logger.Error("error building search document for deleted resource", "key", SearchID(key), "err", err)
+				continue
+			}
+
+			if err := batch.add(&BulkIndexItem{Action: ActionIndex, Doc: doc}); err != nil {
+				return err
+			}
+		}
+
+		if err := batch.flush(); err != nil {
+			return err
+		}
+		return iter.Error()
+	})
+	if errors.Is(err, errUnimplemented) {
+		// The IAM backends (resourcepermission, noopstorage) embed
+		// UnimplementedStorageBackend and serve their resource from legacy SQL, so
+		// they have no history to list, and no trash to index either.
+		logger.Debug("storage backend does not support listing trash, skipping deleted resources")
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	span.SetAttributes(attribute.Int("documents", batch.indexed()))
+	if batch.indexed() > 0 {
+		logger.Debug("indexed deleted resources", "documents", batch.indexed())
+	}
+	return nil
+}
+
+// buildDeletedDocument builds the document for an object that is in the trash.
+// Trash serves a fixed field set, so the kind's builder is skipped: it would only
+// add live-only fields, at about twice the cost. Its title comes from the same
+// FindTitle, so trash and live search agree.
+//
+// Fields are listed rather than cleared, so a field added to IndexableDocument
+// later cannot reach trash documents by accident.
+func buildDeletedDocument(key *resourcepb.ResourceKey, rv int64, value []byte) (*IndexableDocument, error) {
+	var u unstructured.Unstructured
+	if err := u.UnmarshalJSON(value); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal deleted object: %w", err)
+	}
+	obj, err := utils.MetaAccessor(&u)
+	if err != nil {
+		return nil, err
+	}
+
+	doc := &IndexableDocument{
+		Key: key,
+		// Searches sort on name as the final tie-breaker, so it has to be set.
+		Name:   key.Name,
+		RV:     rv,
+		Title:  obj.FindTitle(key.Name),
+		Folder: obj.GetFolder(),
+
+		IsDeleted: new(true),
+	}
+	// Only provisioned documents carry the marker, so absent means "not
+	// provisioned", matching how the deleted marker works.
+	if obj.GetAnnotation(utils.AnnoKeyManagerKind) != "" {
+		doc.IsProvisioned = new(true)
+	}
+	return doc, nil
 }
 
 type builderCache struct {

--- a/pkg/storage/unified/resource/search_test.go
+++ b/pkg/storage/unified/resource/search_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"iter"
 	"net/http"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -22,6 +23,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	dashboardv1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 )
@@ -38,6 +40,9 @@ type MockResourceIndex struct {
 	buildInfo IndexBuildInfo
 	docCount  int64
 
+	// Items passed to BulkIndex, guarded by updateIndexMu.
+	bulkItems []*BulkIndexItem
+
 	// Optional configured results for the managed-object RPCs. When nil the
 	// methods return an error, matching the default "not expected" behaviour.
 	managedObjects *resourcepb.ListManagedObjectsResponse
@@ -45,11 +50,28 @@ type MockResourceIndex struct {
 }
 
 func (m *MockResourceIndex) BuildInfo() (IndexBuildInfo, error) {
-	return m.buildInfo, nil
+	bi := m.buildInfo
+	// The mock stands for an index this binary built, so it maps the current
+	// features unless a test sets them. A test that wants an older index sets them
+	// to an empty (non-nil) slice.
+	if bi.Features == nil {
+		bi.Features = CurrentIndexFeatures()
+	}
+	return bi, nil
 }
 
-func (m *MockResourceIndex) BulkIndex(_ *BulkIndexRequest) error {
+func (m *MockResourceIndex) BulkIndex(req *BulkIndexRequest) error {
+	m.updateIndexMu.Lock()
+	defer m.updateIndexMu.Unlock()
+	m.bulkItems = append(m.bulkItems, req.Items...)
 	return nil
+}
+
+// indexedItems returns the items passed to BulkIndex so far.
+func (m *MockResourceIndex) indexedItems() []*BulkIndexItem {
+	m.updateIndexMu.Lock()
+	defer m.updateIndexMu.Unlock()
+	return slices.Clone(m.bulkItems)
 }
 
 func (m *MockResourceIndex) Search(_ context.Context, _ types.AccessClient, _ *resourcepb.ResourceSearchRequest, _ []ResourceIndex, _ *SearchStats) (*resourcepb.ResourceSearchResponse, error) {
@@ -192,6 +214,8 @@ type mockSearchBackend struct {
 	cache             map[NamespacedResource]ResourceIndex
 	stopCalls         atomic.Int32
 	snapshotThreshold int64
+	// Updater from the most recent BuildIndex, so a test can drive it.
+	lastUpdater UpdateFn
 }
 
 func (m *mockSearchBackend) SnapshotCountThreshold() int64 {
@@ -250,6 +274,9 @@ func (m *mockSearchBackend) GetIndex(key NamespacedResource) ResourceIndex {
 
 func (m *mockSearchBackend) BuildIndex(ctx context.Context, key NamespacedResource, size int64, reason string, builder BuildFn, updater UpdateFn, rebuild bool, lastImportTime time.Time, _ time.Duration) (ResourceIndex, error) {
 	index := &MockResourceIndex{}
+	m.mu.Lock()
+	m.lastUpdater = updater
+	m.mu.Unlock()
 
 	// Call the builder function (required by the contract)
 	_, err := builder(index)
@@ -1712,4 +1739,272 @@ func TestSumDocCount(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, int64(10), got)
 	require.Equal(t, []string{"root", "a", "b"}, idx.calls)
+}
+
+// trashStorageBackend serves a fixed set of trash entries from ListHistory and a
+// fixed set of modifications from ListModifiedSince.
+type trashStorageBackend struct {
+	mockStorageBackend
+
+	trash     []trashEntry
+	modified  []*ModifiedResource
+	trashReqs []*resourcepb.ListRequest
+}
+
+type trashEntry struct {
+	name  string
+	rv    int64
+	value []byte
+}
+
+func (m *trashStorageBackend) ListHistory(_ context.Context, req *resourcepb.ListRequest, callback func(ListIterator) error) (int64, error) {
+	m.trashReqs = append(m.trashReqs, req)
+	return 1, callback(&trashIterator{entries: m.trash, pos: -1})
+}
+
+func (m *trashStorageBackend) ListModifiedSince(_ context.Context, _ NamespacedResource, _ int64, _ *time.Time) (int64, iter.Seq2[*ModifiedResource, error]) {
+	return 2, func(yield func(*ModifiedResource, error) bool) {
+		for _, res := range m.modified {
+			if !yield(res, nil) {
+				return
+			}
+		}
+	}
+}
+
+type trashIterator struct {
+	entries []trashEntry
+	pos     int
+}
+
+func (i *trashIterator) Next() bool             { i.pos++; return i.pos < len(i.entries) }
+func (i *trashIterator) Error() error           { return nil }
+func (i *trashIterator) ContinueToken() string  { return "" }
+func (i *trashIterator) ResourceVersion() int64 { return i.entries[i.pos].rv }
+func (i *trashIterator) Namespace() string      { return "ns" }
+func (i *trashIterator) Name() string           { return i.entries[i.pos].name }
+func (i *trashIterator) Folder() string         { return "" }
+func (i *trashIterator) Value() []byte          { return i.entries[i.pos].value }
+
+func testObjectJSON(name, title string) []byte {
+	return []byte(fmt.Sprintf(`{"apiVersion":"group/v1","kind":"Thing","metadata":{"name":%q},"spec":{"title":%q,"tags":["tag-a"]}}`, name, title))
+}
+
+func testProvisionedObjectJSON(name, title string) []byte {
+	return []byte(fmt.Sprintf(`{"apiVersion":"group/v1","kind":"Thing","metadata":{"name":%q,"annotations":{%q:"repo"}},"spec":{"title":%q}}`,
+		name, utils.AnnoKeyManagerKind, title))
+}
+
+// A full build has to list trash itself: deleted objects are absent from the live
+// listing and nothing re-announces them, so without this a rebuild would drop
+// every deleted document for the resource.
+func TestIndexTrash(t *testing.T) {
+	key := NamespacedResource{Namespace: "ns", Group: "group", Resource: "resource"}
+	storage := &trashStorageBackend{trash: []trashEntry{
+		{name: "gone-1", rv: 10, value: testObjectJSON("gone-1", "Gone one")},
+		{name: "gone-2", rv: 11, value: testObjectJSON("gone-2", "Gone two")},
+	}}
+
+	server, err := newSearchServer(SearchOptions{
+		Backend:   &mockSearchBackend{},
+		Resources: &TestDocumentBuilderSupplier{GroupsResources: map[string]string{"group": "resource"}},
+	}, storage, nil, nil, nil, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	index := &MockResourceIndex{}
+	require.NoError(t, server.indexTrash(t.Context(), key, index, log.NewNopLogger()))
+
+	items := index.indexedItems()
+	require.Len(t, items, 2)
+	for i, name := range []string{"gone-1", "gone-2"} {
+		require.Equal(t, ActionIndex, items[i].Action)
+		require.Equal(t, name, items[i].Doc.Key.Name)
+		require.NotNil(t, items[i].Doc.IsDeleted, "document should carry the deleted marker")
+		require.True(t, *items[i].Doc.IsDeleted)
+	}
+
+	require.Len(t, storage.trashReqs, 1)
+	require.Equal(t, resourcepb.ListRequest_TRASH, storage.trashReqs[0].Source)
+
+	// A backend that serves one resource from legacy storage has no history to
+	// list, and no trash either, so the build must not fail on it.
+	t.Run("a backend without history support builds anyway", func(t *testing.T) {
+		server, err := newSearchServer(SearchOptions{
+			Backend:   &mockSearchBackend{},
+			Resources: &TestDocumentBuilderSupplier{GroupsResources: map[string]string{"group": "resource"}},
+		}, &noHistoryStorageBackend{}, nil, nil, nil, nil, nil, nil, nil, nil)
+		require.NoError(t, err)
+
+		index := &MockResourceIndex{}
+		require.NoError(t, server.indexTrash(t.Context(), key, index, log.NewNopLogger()))
+		require.Empty(t, index.indexedItems())
+	})
+
+	// The full build has to run that pass, not just be able to.
+	t.Run("a full build indexes trash", func(t *testing.T) {
+		search := &mockSearchBackend{}
+		server, err := newSearchServer(SearchOptions{
+			Backend:   search,
+			Resources: &TestDocumentBuilderSupplier{GroupsResources: map[string]string{"group": "resource"}},
+		}, storage, nil, nil, nil, nil, nil, nil, nil, nil)
+		require.NoError(t, err)
+
+		built, err := server.build(t.Context(), key, 1, "test", false, time.Time{})
+		require.NoError(t, err)
+
+		items := built.(*MockResourceIndex).indexedItems()
+		require.Len(t, items, 2, "the two deleted objects should have been indexed")
+		for _, item := range items {
+			require.Equal(t, ActionIndex, item.Action)
+			require.NotNil(t, item.Doc.IsDeleted)
+			require.True(t, *item.Doc.IsDeleted)
+		}
+	})
+}
+
+// A delete event carries the object as it was, so the updater can mark it instead
+// of removing it. Without a usable body there is nothing to index and removal is
+// all that is left.
+func TestUpdaterMarksDeletedDocuments(t *testing.T) {
+	key := NamespacedResource{Namespace: "ns", Group: "group", Resource: "resource"}
+	// Built in place: a ResourceKey carries a lock, so copying one trips vet.
+	deleted := func(name string, value []byte, rv int64) *ModifiedResource {
+		return &ModifiedResource{
+			Action:          resourcepb.WatchEvent_DELETED,
+			Key:             resourcepb.ResourceKey{Namespace: key.Namespace, Group: key.Group, Resource: key.Resource, Name: name},
+			ResourceVersion: rv,
+			Value:           value,
+		}
+	}
+
+	storage := &trashStorageBackend{modified: []*ModifiedResource{
+		deleted("gone", testObjectJSON("gone", "Gone"), 10),
+		deleted("broken", []byte("not json"), 11),
+	}}
+
+	search := &mockSearchBackend{}
+	server, err := newSearchServer(SearchOptions{
+		Backend:   search,
+		Resources: &TestDocumentBuilderSupplier{GroupsResources: map[string]string{"group": "resource"}},
+	}, storage, nil, nil, nil, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	_, err = server.build(t.Context(), key, 1, "test", false, time.Time{})
+	require.NoError(t, err)
+
+	search.mu.Lock()
+	updater := search.lastUpdater
+	search.mu.Unlock()
+	require.NotNil(t, updater)
+
+	index := &MockResourceIndex{}
+	_, docs, err := updater(t.Context(), index, 1)
+	require.NoError(t, err)
+	require.Equal(t, 2, docs)
+
+	items := index.indexedItems()
+	require.Len(t, items, 2)
+
+	require.Equal(t, ActionIndex, items[0].Action)
+	require.Equal(t, "gone", items[0].Doc.Key.Name)
+	require.NotNil(t, items[0].Doc.IsDeleted)
+	require.True(t, *items[0].Doc.IsDeleted)
+
+	require.Equal(t, ActionDelete, items[1].Action, "an unusable body leaves nothing to index")
+	require.Equal(t, "broken", items[1].Key.Name)
+}
+
+// noHistoryStorageBackend stands for a backend that serves a single resource from
+// legacy storage: everything outside that is unimplemented.
+type noHistoryStorageBackend struct {
+	UnimplementedStorageBackend
+}
+
+// Trash serves a fixed field set, so a deleted document keeps only those fields.
+// Anything a kind declares is live-only: keeping it would grow the index and move
+// term statistics for live searches.
+func TestBuildDeletedDocumentKeepsOnlyTrashFields(t *testing.T) {
+	key := &resourcepb.ResourceKey{Namespace: "ns", Group: "group", Resource: "resource", Name: "gone"}
+
+	// The same object indexed as live carries kind fields, or this test proves
+	// nothing.
+	live, err := (&testDocumentBuilder{}).BuildDocument(t.Context(), key, 10, testObjectJSON("gone", "Gone"))
+	require.NoError(t, err)
+	require.NotEmpty(t, live.Tags)
+	require.NotEmpty(t, live.Fields)
+
+	doc, err := buildDeletedDocument(key, 10, testObjectJSON("gone", "Gone"))
+	require.NoError(t, err)
+
+	require.Equal(t, "Gone", doc.Title)
+	require.Equal(t, "gone", doc.Key.Name)
+	require.Equal(t, "gone", doc.Name, "searches tie-break on name")
+	require.Equal(t, int64(10), doc.RV)
+	require.NotNil(t, doc.IsDeleted)
+	require.True(t, *doc.IsDeleted)
+
+	require.Nil(t, doc.IsProvisioned, "the object was not provisioned")
+	require.Empty(t, doc.Tags)
+	require.Empty(t, doc.Fields)
+	require.Empty(t, doc.Labels)
+	require.Empty(t, doc.References)
+	require.Empty(t, doc.Description)
+	require.Nil(t, doc.Manager)
+}
+
+// Trash never returns an object that was provisioned when it was deleted, and a
+// trimmed document keeps no manager fields to work that out later, so it is
+// captured at delete time.
+func TestBuildDeletedDocumentMarksProvisionedObjects(t *testing.T) {
+	key := &resourcepb.ResourceKey{Namespace: "ns", Group: "group", Resource: "resource", Name: "gone"}
+
+	doc, err := buildDeletedDocument(key, 10, testProvisionedObjectJSON("gone", "Gone"))
+	require.NoError(t, err)
+	require.NotNil(t, doc.IsProvisioned)
+	require.True(t, *doc.IsProvisioned)
+}
+
+// An index built before the markers were mapped drops them, which would serve a
+// deleted document as live. The producer checks first, so the documents are not
+// even built, and the index gets a removal exactly as it did before.
+func TestDeletedDocumentsAreRemovedWhenIndexCannotHoldMarkers(t *testing.T) {
+	key := NamespacedResource{Namespace: "ns", Group: "group", Resource: "resource"}
+	storage := &trashStorageBackend{
+		trash:    []trashEntry{{name: "gone-1", rv: 10, value: testObjectJSON("gone-1", "Gone one")}},
+		modified: nil,
+	}
+	storage.modified = []*ModifiedResource{{
+		Action:          resourcepb.WatchEvent_DELETED,
+		Key:             resourcepb.ResourceKey{Namespace: key.Namespace, Group: key.Group, Resource: key.Resource, Name: "gone-2"},
+		ResourceVersion: 11,
+		Value:           testObjectJSON("gone-2", "Gone two"),
+	}}
+
+	search := &mockSearchBackend{}
+	server, err := newSearchServer(SearchOptions{
+		Backend:   search,
+		Resources: &TestDocumentBuilderSupplier{GroupsResources: map[string]string{"group": "resource"}},
+	}, storage, nil, nil, nil, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	// An index reporting no features: what a binary from before the mapping built.
+	older := &MockResourceIndex{buildInfo: IndexBuildInfo{Features: []IndexFeature{}}}
+	require.False(t, indexKeepsDeletedDocuments(older, log.NewNopLogger()))
+
+	require.NoError(t, server.indexTrash(t.Context(), key, older, log.NewNopLogger()))
+	require.Empty(t, older.indexedItems(), "trash listing should be skipped entirely")
+
+	_, err = server.build(t.Context(), key, 1, "test", false, time.Time{})
+	require.NoError(t, err)
+	search.mu.Lock()
+	updater := search.lastUpdater
+	search.mu.Unlock()
+
+	_, _, err = updater(t.Context(), older, 1)
+	require.NoError(t, err)
+
+	items := older.indexedItems()
+	require.Len(t, items, 1)
+	require.Equal(t, ActionDelete, items[0].Action)
+	require.Equal(t, "gone-2", items[0].Key.Name)
 }

--- a/pkg/storage/unified/resource/search_test.go
+++ b/pkg/storage/unified/resource/search_test.go
@@ -1798,6 +1798,16 @@ func testProvisionedObjectJSON(name, title string) []byte {
 // A full build has to list trash itself: deleted objects are absent from the live
 // listing and nothing re-announces them, so without this a rebuild would drop
 // every deleted document for the resource.
+// trashSearchOptions returns search options with deleted objects kept in the
+// index, which is off by default.
+func trashSearchOptions(backend SearchBackend) SearchOptions {
+	return SearchOptions{
+		Backend:               backend,
+		Resources:             &TestDocumentBuilderSupplier{GroupsResources: map[string]string{"group": "resource"}},
+		IndexDeletedDocuments: true,
+	}
+}
+
 func TestIndexTrash(t *testing.T) {
 	key := NamespacedResource{Namespace: "ns", Group: "group", Resource: "resource"}
 	storage := &trashStorageBackend{trash: []trashEntry{
@@ -1805,10 +1815,7 @@ func TestIndexTrash(t *testing.T) {
 		{name: "gone-2", rv: 11, value: testObjectJSON("gone-2", "Gone two")},
 	}}
 
-	server, err := newSearchServer(SearchOptions{
-		Backend:   &mockSearchBackend{},
-		Resources: &TestDocumentBuilderSupplier{GroupsResources: map[string]string{"group": "resource"}},
-	}, storage, nil, nil, nil, nil, nil, nil, nil, nil)
+	server, err := newSearchServer(trashSearchOptions(&mockSearchBackend{}), storage, nil, nil, nil, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	index := &MockResourceIndex{}
@@ -1829,10 +1836,7 @@ func TestIndexTrash(t *testing.T) {
 	// A backend that serves one resource from legacy storage has no history to
 	// list, and no trash either, so the build must not fail on it.
 	t.Run("a backend without history support builds anyway", func(t *testing.T) {
-		server, err := newSearchServer(SearchOptions{
-			Backend:   &mockSearchBackend{},
-			Resources: &TestDocumentBuilderSupplier{GroupsResources: map[string]string{"group": "resource"}},
-		}, &noHistoryStorageBackend{}, nil, nil, nil, nil, nil, nil, nil, nil)
+		server, err := newSearchServer(trashSearchOptions(&mockSearchBackend{}), &noHistoryStorageBackend{}, nil, nil, nil, nil, nil, nil, nil, nil)
 		require.NoError(t, err)
 
 		index := &MockResourceIndex{}
@@ -1843,10 +1847,7 @@ func TestIndexTrash(t *testing.T) {
 	// The full build has to run that pass, not just be able to.
 	t.Run("a full build indexes trash", func(t *testing.T) {
 		search := &mockSearchBackend{}
-		server, err := newSearchServer(SearchOptions{
-			Backend:   search,
-			Resources: &TestDocumentBuilderSupplier{GroupsResources: map[string]string{"group": "resource"}},
-		}, storage, nil, nil, nil, nil, nil, nil, nil, nil)
+		server, err := newSearchServer(trashSearchOptions(search), storage, nil, nil, nil, nil, nil, nil, nil, nil)
 		require.NoError(t, err)
 
 		built, err := server.build(t.Context(), key, 1, "test", false, time.Time{})
@@ -1883,10 +1884,7 @@ func TestUpdaterMarksDeletedDocuments(t *testing.T) {
 	}}
 
 	search := &mockSearchBackend{}
-	server, err := newSearchServer(SearchOptions{
-		Backend:   search,
-		Resources: &TestDocumentBuilderSupplier{GroupsResources: map[string]string{"group": "resource"}},
-	}, storage, nil, nil, nil, nil, nil, nil, nil, nil)
+	server, err := newSearchServer(trashSearchOptions(search), storage, nil, nil, nil, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	_, err = server.build(t.Context(), key, 1, "test", false, time.Time{})
@@ -1912,6 +1910,46 @@ func TestUpdaterMarksDeletedDocuments(t *testing.T) {
 
 	require.Equal(t, ActionDelete, items[1].Action, "an unusable body leaves nothing to index")
 	require.Equal(t, "broken", items[1].Key.Name)
+}
+
+// The option is off by default, and with it off a delete has to behave exactly as
+// it did before deleted objects were kept: the document is removed and no trash is
+// listed.
+func TestDeletedDocumentsAreRemovedWhenTheOptionIsOff(t *testing.T) {
+	key := NamespacedResource{Namespace: "ns", Group: "group", Resource: "resource"}
+	storage := &trashStorageBackend{
+		trash: []trashEntry{{name: "gone-1", rv: 10, value: testObjectJSON("gone-1", "Gone one")}},
+		modified: []*ModifiedResource{{
+			Action:          resourcepb.WatchEvent_DELETED,
+			Key:             resourcepb.ResourceKey{Namespace: key.Namespace, Group: key.Group, Resource: key.Resource, Name: "gone-2"},
+			ResourceVersion: 11,
+			Value:           testObjectJSON("gone-2", "Gone two"),
+		}},
+	}
+
+	search := &mockSearchBackend{}
+	options := trashSearchOptions(search)
+	options.IndexDeletedDocuments = false
+	server, err := newSearchServer(options, storage, nil, nil, nil, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	built, err := server.build(t.Context(), key, 1, "test", false, time.Time{})
+	require.NoError(t, err)
+	require.Empty(t, built.(*MockResourceIndex).indexedItems(), "no trash should be listed or indexed")
+	require.Empty(t, storage.trashReqs)
+
+	search.mu.Lock()
+	updater := search.lastUpdater
+	search.mu.Unlock()
+
+	index := &MockResourceIndex{}
+	_, _, err = updater(t.Context(), index, 1)
+	require.NoError(t, err)
+
+	items := index.indexedItems()
+	require.Len(t, items, 1)
+	require.Equal(t, ActionDelete, items[0].Action)
+	require.Equal(t, "gone-2", items[0].Key.Name)
 }
 
 // noHistoryStorageBackend stands for a backend that serves a single resource from
@@ -1970,26 +2008,22 @@ func TestBuildDeletedDocumentMarksProvisionedObjects(t *testing.T) {
 func TestDeletedDocumentsAreRemovedWhenIndexCannotHoldMarkers(t *testing.T) {
 	key := NamespacedResource{Namespace: "ns", Group: "group", Resource: "resource"}
 	storage := &trashStorageBackend{
-		trash:    []trashEntry{{name: "gone-1", rv: 10, value: testObjectJSON("gone-1", "Gone one")}},
-		modified: nil,
+		trash: []trashEntry{{name: "gone-1", rv: 10, value: testObjectJSON("gone-1", "Gone one")}},
+		modified: []*ModifiedResource{{
+			Action:          resourcepb.WatchEvent_DELETED,
+			Key:             resourcepb.ResourceKey{Namespace: key.Namespace, Group: key.Group, Resource: key.Resource, Name: "gone-2"},
+			ResourceVersion: 11,
+			Value:           testObjectJSON("gone-2", "Gone two"),
+		}},
 	}
-	storage.modified = []*ModifiedResource{{
-		Action:          resourcepb.WatchEvent_DELETED,
-		Key:             resourcepb.ResourceKey{Namespace: key.Namespace, Group: key.Group, Resource: key.Resource, Name: "gone-2"},
-		ResourceVersion: 11,
-		Value:           testObjectJSON("gone-2", "Gone two"),
-	}}
 
 	search := &mockSearchBackend{}
-	server, err := newSearchServer(SearchOptions{
-		Backend:   search,
-		Resources: &TestDocumentBuilderSupplier{GroupsResources: map[string]string{"group": "resource"}},
-	}, storage, nil, nil, nil, nil, nil, nil, nil, nil)
+	server, err := newSearchServer(trashSearchOptions(search), storage, nil, nil, nil, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	// An index reporting no features: what a binary from before the mapping built.
 	older := &MockResourceIndex{buildInfo: IndexBuildInfo{Features: []IndexFeature{}}}
-	require.False(t, indexKeepsDeletedDocuments(older, log.NewNopLogger()))
+	require.False(t, server.keepsDeletedDocuments(older, log.NewNopLogger()))
 
 	require.NoError(t, server.indexTrash(t.Context(), key, older, log.NewNopLogger()))
 	require.Empty(t, older.indexedItems(), "trash listing should be skipped entirely")

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -290,6 +290,10 @@ type SearchOptions struct {
 	// TTL for the dedup cache used in ListModifiedSince updates. 0 disables the cache.
 	IndexModificationCacheTTL time.Duration
 
+	// Keep deleted objects in the index so trash searches can find them. Off means
+	// a delete removes the document, as it did before trash search existed.
+	IndexDeletedDocuments bool
+
 	// Percentage of search requests that should fail immediately (0-100). 0 = disabled, 100 = all requests fail.
 	InjectFailuresPercent int
 

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -1642,6 +1642,8 @@ type bleveIndex struct {
 	key resource.NamespacedResource
 	// Holds live and deleted documents together, so queries go through scopeQuery.
 	index bleve.Index
+	// Index features this index was built with, from its build info.
+	features []resource.IndexFeature
 
 	// RV returned by last List/ListModifiedSince operation. Updated when updating index.
 	resourceVersion atomic.Int64
@@ -1703,9 +1705,18 @@ func (b *bleveBackend) newBleveIndex(
 	updaterFn resource.UpdateFn,
 	logger log.Logger,
 ) *bleveIndex {
+	// Read once: what an index maps cannot change while it is open.
+	var features []resource.IndexFeature
+	if info, err := getBuildInfo(index); err == nil {
+		features = info.Features
+	} else {
+		logger.Warn("failed to read index features, treating the index as having none", "err", err)
+	}
+
 	bi := &bleveIndex{
 		key:                  key,
 		index:                index,
+		features:             features,
 		indexStorage:         newIndexType,
 		fields:               fields,
 		allFields:            allFields,
@@ -1733,12 +1744,24 @@ func (b *bleveIndex) BulkIndex(req *resource.BulkIndexRequest) error {
 
 	batch := b.index.NewBatch()
 	var undeclaredFields map[string]struct{}
+	droppedMarkers := 0
 	for _, item := range req.Items {
 		switch item.Action {
 		case resource.ActionIndex:
 			if item.Doc == nil {
 				return fmt.Errorf("missing document")
 			}
+
+			// An index built before these fields were mapped drops them, which would
+			// serve the document as live or expose a provisioned one in trash. Remove
+			// it instead, which is how this index behaved before deleted documents were
+			// kept, until it is rebuilt.
+			if item.Doc.IsDeleted != nil && *item.Doc.IsDeleted && !b.mapsTrashMarkers() {
+				batch.Delete(resource.SearchID(item.Doc.Key))
+				droppedMarkers++
+				continue
+			}
+
 			doc := item.Doc.UpdateCopyFields()
 			populateFieldVariants(doc, b.searchFields.variants)
 
@@ -1765,11 +1788,24 @@ func (b *bleveIndex) BulkIndex(req *resource.BulkIndexRequest) error {
 	for name := range undeclaredFields {
 		b.logger.Warn("search field written to document is not declared for this kind, so it is dropped from the index and cannot be stored or queried", "field", name)
 	}
+	if droppedMarkers > 0 {
+		// Debug because this fires per batch, and the producer already avoids
+		// building these documents: reaching here means a writer skipped that check.
+		b.logger.Debug("index does not map the trash markers, so deleted documents were removed instead of kept; they appear once the index is rebuilt",
+			"documents", droppedMarkers)
+	}
 
 	if err := b.index.Batch(batch); err != nil {
 		return err
 	}
 	return b.addSnapshotMutationCount(int64(len(req.Items)))
+}
+
+// mapsTrashMarkers reports whether this index can hold every marker a deleted
+// document relies on. An index built before those mappings existed cannot, and
+// bleve drops the values silently.
+func (b *bleveIndex) mapsTrashMarkers() bool {
+	return slices.Contains(b.features, resource.IndexFeatureDeletedMarker)
 }
 
 // isDeclaredField reports whether name is a declared search field for this

--- a/pkg/storage/unified/search/bleve_test.go
+++ b/pkg/storage/unified/search/bleve_test.go
@@ -2616,6 +2616,45 @@ func TestIsDeletedMarkerIndexing(t *testing.T) {
 	}
 }
 
+// An index built before the marker was mapped drops it silently, which would
+// leave a deleted document looking live. BulkIndex removes such a document
+// instead, so trash is missing from search rather than leaking into it, until the
+// index is rebuilt.
+func TestBulkIndexRemovesMarkedDocumentsWhenTheMarkerIsNotMapped(t *testing.T) {
+	mapper, err := GetBleveMappings(nil, "", "", nil)
+	require.NoError(t, err)
+	raw, err := newBleveIndex("", mapper, time.Now(), buildVersion, nil, "")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = raw.Close() })
+
+	key := &resourcepb.ResourceKey{Namespace: "default", Group: "g", Resource: "r", Name: "dash-1"}
+	doc := func(deleted *bool) *resource.BulkIndexItem {
+		return &resource.BulkIndexItem{
+			Action: resource.ActionIndex,
+			Doc:    &resource.IndexableDocument{Key: key, Title: "Production Overview", IsDeleted: deleted},
+		}
+	}
+
+	// features left empty: an index whose mapping predates the marker.
+	legacy := &bleveIndex{index: raw, logger: log.NewNopLogger()}
+	require.NoError(t, legacy.BulkIndex(&resource.BulkIndexRequest{Items: []*resource.BulkIndexItem{doc(nil)}}))
+	count, err := raw.DocCount()
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), count)
+
+	require.NoError(t, legacy.BulkIndex(&resource.BulkIndexRequest{Items: []*resource.BulkIndexItem{doc(new(true))}}))
+	count, err = raw.DocCount()
+	require.NoError(t, err)
+	assert.Equal(t, uint64(0), count, "marked document should be removed, not indexed as live")
+
+	// An index that maps the marker keeps the document.
+	current := &bleveIndex{index: raw, features: resource.CurrentIndexFeatures(), logger: log.NewNopLogger()}
+	require.NoError(t, current.BulkIndex(&resource.BulkIndexRequest{Items: []*resource.BulkIndexItem{doc(new(true))}}))
+	count, err = raw.DocCount()
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1), count)
+}
+
 // TestScopeQueryTrashBrowseDrivesOffTheMarker pins the shape for a trash browse
 // with nothing to match on. Bleve only ever drives iteration from the Must side,
 // so leaving match-all there and testing the marker as a Filter would read every

--- a/pkg/storage/unified/search/options.go
+++ b/pkg/storage/unified/search/options.go
@@ -138,6 +138,7 @@ func NewSearchOptions(
 			BuildVersion:              buildVersion,
 			IndexMinUpdateInterval:    cfg.IndexMinUpdateInterval,
 			IndexModificationCacheTTL: cfg.IndexModificationCacheTTL,
+			IndexDeletedDocuments:     cfg.IndexDeletedDocuments,
 			InjectFailuresPercent:     cfg.SearchInjectFailuresPercent,
 
 			IndexSnapshotEnabled:            cfg.IndexSnapshotEnabled,


### PR DESCRIPTION
Deleting an object removed it from the search index, so trash could only be served by listing over storage history — no text search, no ranking, no facets. Deleted objects now stay in the index, marked, and the exclusion clause that shipped earlier keeps them out of live results.

A delete event writes a marked document instead of removing one. A full build also lists trash after the live pass, because an object is deleted once and nothing re-announces it — without that, every rebuild would drop the resource's whole trash. It keeps the live pass's resource version, so anything changing in between is replayed rather than missed.

Deleted documents keep only what trash serves: title, folder, identity and the markers. Everything a kind declares is live-only, so the kind's builder is skipped — it costs about twice as much and derives the title the same way. Fields are listed rather than cleared, so a field added later cannot reach trash by accident.

Both writers check the index maps the markers before keeping anything. An index built before they existed behaves exactly as today until rebuilt, so nothing has to be reindexed. Restore needs no code: reindexing without the marker replaces the document.

Indexing deleted objects is off by default, behind `index_deleted_documents` in `[unified_storage]`, kept out of `defaults.ini`. Switching it on makes the next rebuild of every index pull in all the trash storage still holds, which is unbounded where garbage collection is disabled, so it is worth enabling deliberately rather than on upgrade. With it off, a delete removes the document and a build lists no trash, exactly as before.

Trash grows the index, and only a rebuild drops entries storage has already collected. A retention filter and cleanup pass are follow-ups.

Part of grafana/search-and-storage-team#869.
