### PR TITLE
[release-13.0.5] CI: sync release-comms.yml + backport #129513

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -120,7 +120,8 @@ jobs:
             const {REF, VERSION, BUILD_ID, BUCKET, GRAFANA_COMMIT, PUBLIC_COMMIT, SOURCE_EVENT, REPO} = process.env;
             // grafana-enterprise has no #patched branches, so dispatch it on the plain
             // release branch (e.g. release-13.0.0#patched -> release-13.0.0).
-            const enterpriseRef = REF.replace(/#patched$/, '');
+            let enterpriseRef = REF.replace(/#patched$/, '');
+
             let workflow = 'release-build-enterprise.yml';
 
             if (REF == 'main' && SOURCE_EVENT == 'push') {
@@ -147,6 +148,33 @@ jobs:
               // upstream-run-id is used with the github actions API and `gh run watch` to ensure coupled workflows
               // fail together.
               inputs["upstream-run-id"] = String(BUILD_ID);
+            }
+
+            // If the +security branch doesn't exist in grafana-enterprise yet, fall back to
+            // the base release branch (e.g. release-13.0.0+security-01 -> release-13.0.0).
+            // We probe by attempting the dispatch itself so no extra permission beyond
+            // actions:write is needed — a separate repos.getBranch call would require
+            // contents:read which the dispatch token does not have.
+            if (enterpriseRef.includes('+security-')) {
+              try {
+                await github.rest.actions.createWorkflowDispatch({
+                  owner: 'grafana',
+                  repo: 'grafana-enterprise',
+                  workflow_id: workflow,
+                  ref: enterpriseRef,
+                  inputs,
+                });
+                return;
+              } catch (e) {
+                // GitHub returns 422 "No ref found for <ref>" when the branch doesn't exist.
+                if (e.status === 422 && String(e.message).includes('No ref found')) {
+                  const fallback = enterpriseRef.replace(/\+security-[0-9]+$/, '');
+                  core.info(`Enterprise branch ${enterpriseRef} not found; falling back to ${fallback}`);
+                  enterpriseRef = fallback;
+                } else {
+                  throw e;
+                }
+              }
             }
 
             await github.rest.actions.createWorkflowDispatch({

--- a/.github/workflows/release-comms.yml
+++ b/.github/workflows/release-comms.yml
@@ -22,9 +22,7 @@ on:
     - 'release-*.*.*'
 
 permissions:
-  contents: write
-  pull-requests: write
-  id-token: write
+  contents: read
 
 jobs:
   setup:
@@ -35,14 +33,12 @@ jobs:
       release_branch: ${{ steps.output.outputs.release_branch }}
       dry_run: ${{ steps.output.outputs.dry_run }}
       latest: ${{ steps.output.outputs.latest }}
-      private_key: ${{ steps.output.outputs.delivery_bot_pem }}
-      app_id: ${{ vars.DELIVERY_BOT_APP_ID }}
     env:
       HEAD_REF: ${{ github.head_ref }}
       DRY_RUN: ${{ inputs.dry_run }}
       LATEST: ${{ inputs.latest && '1' || '0' }}
       VERSION: ${{ inputs.version }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-arm64-small
     steps:
     - if: ${{ github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/') }}
       run: |
@@ -66,6 +62,12 @@ jobs:
   create_next_release_branch_grafana:
     name: Create next release branch (Grafana)
     needs: setup
+    # Security releases don't open a new patch development branch: the next branch is the
+    # incremented +security-NN created below, not a version bump.
+    if: ${{ !contains(needs.setup.outputs.version, '+security') }}
+    permissions:
+      contents: read
+      id-token: write
     uses: grafana/grafana/.github/workflows/create-next-release-branch.yml@main
     with:
       ownerRepo: 'grafana/grafana'
@@ -73,21 +75,22 @@ jobs:
   create_next_release_branch_enterprise:
     name: Create next release branch (Grafana Enterprise)
     needs: setup
+    if: ${{ !contains(needs.setup.outputs.version, '+security') }}
+    permissions:
+      contents: read
+      id-token: write
     uses: grafana/grafana/.github/workflows/create-next-release-branch.yml@main
     with:
       ownerRepo: 'grafana/grafana-enterprise'
       source: ${{ needs.setup.outputs.release_branch }}
-  create_security_branch_grafana:
-    name: Create security branch (Grafana Security Mirror)
-    needs: setup
-    uses: grafana/grafana/.github/workflows/create-security-branch.yml@main
-    with:
-      release_branch: ${{ needs.setup.outputs.release_branch }}
-      security_branch_number: "01"
-      repository: grafana/grafana-security-mirror
+  # No security-mirror job: grafana-security-mirror branches are created automatically
+  # from the release branch (the part before the +), so the branch always exists.
   create_security_branch_enterprise:
     name: Create security branch (Enterprise)
     needs: setup
+    permissions:
+      contents: read
+      id-token: write
     uses: grafana/grafana/.github/workflows/create-security-branch.yml@main
     with:
       release_branch: ${{ needs.setup.outputs.release_branch }}
@@ -97,6 +100,11 @@ jobs:
     needs:
       - setup
       - create_next_release_branch_grafana
+    # No next branch is created for security releases, so there is nothing to migrate to.
+    if: ${{ !contains(needs.setup.outputs.version, '+security') }}
+    permissions:
+      contents: read
+      id-token: write
     uses: grafana/grafana/.github/workflows/migrate-prs.yml@main
     with:
       ownerRepo: 'grafana/grafana'
@@ -106,6 +114,10 @@ jobs:
     needs:
       - setup
       - create_next_release_branch_enterprise
+    if: ${{ !contains(needs.setup.outputs.version, '+security') }}
+    permissions:
+      contents: read
+      id-token: write
     uses: grafana/grafana/.github/workflows/migrate-prs.yml@main
     with:
       ownerRepo: 'grafana/grafana-enterprise'
@@ -123,14 +135,90 @@ jobs:
     # The github-release action retrieves the changelog using the /repos/grafana/grafana/contents/CHANGELOG.md API
     # endpoint.
     needs: setup
+    permissions:
+      contents: write
+      id-token: write
     uses: grafana/grafana/.github/workflows/github-release.yml@main
     with:
       version: ${{ needs.setup.outputs.version }}
       dry_run: ${{ needs.setup.outputs.dry_run == 'true' }}
       latest: ${{ needs.setup.outputs.latest }}
+
+  # Attach this release's deb/rpm to the GitHub release so the external apt/yum repo-sync can consume
+  # them. Runs for every non-+security, non-dry-run public release. The gcom public packages API is the
+  # authoritative manifest (it holds exactly this version's build), so no build id is needed. Sources
+  # packages from dl.grafana.com (no GCS) and verifies each checksum against that API before uploading.
+  # RPMs are the signed ones served by dl.grafana.com.
+  attach_release_packages:
+    name: Attach Linux packages to the GitHub release
+    needs:
+      - setup
+      - create_github_release
+    if: ${{ needs.setup.outputs.dry_run != 'true' && !contains(needs.setup.outputs.version, '+security') }}
+    runs-on: ubuntu-arm64-small
+    permissions:
+      contents: write
+    env:
+      VERSION: ${{ needs.setup.outputs.version }}
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+    steps:
+      - name: Download, verify checksums, and attach deb/rpm
+        run: |
+          set -euo pipefail
+
+          version="${VERSION#v}"   # gcom API + dl.grafana.com filenames use the bare version
+          tag="v${version}"        # the GitHub release tag
+
+          workdir="$(mktemp -d)"
+          files=()
+
+          for product in grafana grafana-enterprise; do
+            api="https://grafana.com/api/${product}/versions/${version}/packages"
+            echo "Reading package manifest: ${api}"
+            # The gcom public packages API is the authoritative manifest: each entry has url
+            # (dl.grafana.com) + sha256. gcom holds exactly this version's build, so selecting by the
+            # .deb/.rpm extension yields the right set without needing a build id.
+            manifest="$(curl -fsSL "$api")"
+            count="$(printf '%s' "$manifest" | jq '(.items // .) | length')"
+
+            i=0
+            while [ "$i" -lt "$count" ]; do
+              url="$(printf '%s' "$manifest" | jq -r "(.items // .)[$i].url")"
+              sha="$(printf '%s' "$manifest" | jq -r "(.items // .)[$i].sha256" | tr -d '[:space:]')"
+              i=$((i + 1))
+
+              case "$url" in
+                *.deb | *.rpm) ;;
+                *) continue ;;
+              esac
+
+              fname="$(basename "$url")"
+              dest="${workdir}/${fname}"
+              echo "Downloading ${url}"
+              curl -fsSL -o "$dest" "$url"
+
+              actual="$(sha256sum "$dest" | awk '{print $1}')"
+              if [ "$actual" != "$sha" ]; then
+                echo "::error::checksum mismatch for ${fname}: expected '${sha}', got '${actual}'"
+                exit 1
+              fi
+              echo "verified ${fname}"
+              files+=("$dest")
+            done
+          done
+
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "::error::no deb/rpm found for ${version} in the gcom packages manifest"
+            exit 1
+          fi
+
+          echo "Uploading ${#files[@]} package(s) to release ${tag}..."
+          gh release upload "$tag" "${files[@]}" --clobber --repo "$GH_REPO"
+
   post_on_slack:
     needs: setup
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-arm64-small
     env:
       DRY_RUN: ${{ needs.setup.outputs.dry_run }}
       VERSION: ${{ needs.setup.outputs.version }}


### PR DESCRIPTION
Syncs the post-release workflow from main (current permissions; drops the security-mirror branch job) and backports the release-build enterprise-dispatch fallback
  (#129513).