### PR TITLE
Dashboards: Default fieldConfig when a v2 panel spec omits it

### DIFF
--- a/public/app/features/dashboard-scene/scene/changePanelPlugin.test.ts
+++ b/public/app/features/dashboard-scene/scene/changePanelPlugin.test.ts
@@ -1,0 +1,45 @@
+import { getPanelPlugin } from '@grafana/data/test';
+import { setDataSourceSrv, setPluginImportUtils, type DataSourceSrv } from '@grafana/runtime';
+import { VizPanel } from '@grafana/scenes';
+
+setPluginImportUtils({
+  importPanelPlugin: (id: string) => Promise.resolve(getPanelPlugin({})),
+  getPanelPluginFromCache: (id: string) => undefined,
+});
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+setDataSourceSrv({ getInstanceSettings: () => undefined } as unknown as DataSourceSrv);
+
+import { DashboardScene } from './DashboardScene';
+import { DefaultGridLayoutManager } from './layout-default/DefaultGridLayoutManager';
+
+describe('DashboardScene.changePanelPlugin', () => {
+  function buildScene(panel: VizPanel) {
+    return new DashboardScene({
+      title: 'Test dashboard',
+      uid: 'test-uid',
+      body: DefaultGridLayoutManager.fromVizPanels([panel]),
+    });
+  }
+
+  it('carries existing overrides across a plugin change', async () => {
+    const panel = new VizPanel({
+      pluginId: 'timeseries',
+      title: 'Has field config',
+      fieldConfig: {
+        defaults: { unit: 'bytes', custom: { lineWidth: 3 } },
+        overrides: [{ matcher: { id: 'byName', options: 'A' }, properties: [{ id: 'unit', value: 'percent' }] }],
+      },
+    });
+
+    const scene = buildScene(panel);
+
+    await scene.changePanelPlugin(panel, 'stat');
+
+    // Standard defaults are re-derived against the new plugin's registry, but
+    // the existing overrides must still be carried across.
+    expect(panel.state.fieldConfig.overrides).toEqual([
+      expect.objectContaining({ matcher: { id: 'byName', options: 'A' } }),
+    ]);
+  });
+});

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.test.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.test.ts
@@ -407,6 +407,25 @@ describe('buildVizPanel', () => {
     return viz.state.$timeRange;
   }
 
+  it('builds a panel when vizConfig.spec omits fieldConfig', () => {
+    const base = defaultPanelSpec();
+    const panel: PanelKind = {
+      kind: 'Panel',
+      spec: {
+        ...base,
+        vizConfig: {
+          ...base.vizConfig,
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+          spec: {} as PanelKind['spec']['vizConfig']['spec'],
+        },
+      },
+    };
+
+    const viz = buildVizPanel(panel);
+
+    expect(viz.state.fieldConfig).toEqual({ defaults: {}, overrides: [] });
+  });
+
   it.each([
     ['timeCompare', 'compareWith', '1d'],
     ['timeFrom', 'timeFrom', '2h'],

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.ts
@@ -22,6 +22,7 @@ import {
   type QueryVariableKind,
   type TabsLayoutTabKind,
   type DataQueryKind,
+  defaultFieldConfigSource,
   defaultPanelQueryKind,
 } from '@grafana/schema/apis/dashboard.grafana.app/v2';
 import { SHARED_DASHBOARD_QUERY } from 'app/plugins/datasource/dashboard/constants';
@@ -84,7 +85,11 @@ export function buildVizPanel(panel: PanelKind, id?: number): VizPanel {
     description: panel.spec.description,
     pluginId: panel.spec.vizConfig.group,
     options,
-    fieldConfig: transformMappingsToV1(panel.spec.vizConfig.spec.fieldConfig),
+    // VizConfigSpec requires fieldConfig, but specs reaching us from the
+    // mutation API can omit it. VizPanelState requires it too, and passing an
+    // explicit undefined defeats the VizPanel constructor default, so resolve
+    // it here (same as options above).
+    fieldConfig: transformMappingsToV1(panel.spec.vizConfig.spec.fieldConfig ?? defaultFieldConfigSource()),
     // An empty/absent version means the caller didn't pin one (it's optional in
     // the spec); leave pluginVersion undefined so the panel uses the running
     // plugin's current version rather than migrating against a bogus value.


### PR DESCRIPTION
## What this PR does

Defaults `fieldConfig` in `buildVizPanel` when a v2 panel spec omits it, so a panel spec without `vizConfig.spec.fieldConfig` no longer throws `Cannot read properties of undefined (reading 'defaults')` while the panel is being built.

## Why it broke

Two types both declare `fieldConfig` as **required**, and both were being handed an `undefined`:

| Type | Expectation |
|---|---|
| `VizConfigSpec` (v2beta1) | `fieldConfig: FieldConfigSource` is required, with a `defaultFieldConfigSource()` helper alongside it. |
| `VizPanelState` (scenes) | `fieldConfig: FieldConfigSource<...>` is required. |

`buildVizPanel` passed `panel.spec.vizConfig.spec.fieldConfig` straight into `transformMappingsToV1`, which reads `fieldConfig.defaults`, so the build threw.

ADD_PANEL is not affected: its command schema already defaults the field (`schemas.ts:498-501`). The exposed callers are the ones that reach `buildVizPanel` without going through that schema, notably `APPLY_SPEC`, whose `validate` flag defaults to `false` and which casts the caller-supplied spec with `as unknown as DashboardV2Spec` on the assumption that the transform checks it.

Beyond the immediate throw, `VizPanel`'s constructor applies its defaults as `{ options: {}, fieldConfig: { defaults: {}, overrides: [] }, ...state }`. An **explicit** `fieldConfig: undefined` in `state` therefore overrides the default rather than falling back to it, leaving `state.fieldConfig` undefined for every later consumer. `DashboardScene.changePanelPlugin` reads `panel.state.fieldConfig.defaults` and produces the same error text from that direction.

## Fix

Resolve the value at the point where `VizPanelState` is declared, so both required types actually hold:

```ts
fieldConfig: transformMappingsToV1(panel.spec.vizConfig.spec.fieldConfig ?? defaultFieldConfigSource()),
```

This matches how the sibling required field `options` is already defaulted a few lines above (`panel.spec.vizConfig.spec.options ?? {}`).

Fixing it here rather than adding optional checks in `transformMappingsToV1` or `changePanelPlugin` keeps those signatures honest. Both legitimately require a defined `FieldConfigSource`, and loosening them would make the required types misleading for every other caller.

`buildVizPanel` is the shared constructor for every v2 layout serializer (default grid, auto grid, notebook), `ADD_PANEL`, and the JSON inspect tab, so the single fix covers all of them.

## Tests

- `layoutSerializers/utils.test.ts`: `buildVizPanel` with `vizConfig.spec: {}` now yields `{ defaults: {}, overrides: [] }`. Fails on `main` with the exact error above.
- `scene/changePanelPlugin.test.ts` (new): first direct coverage for `changePanelPlugin`, asserting existing overrides survive a plugin change. It is mocked at every call site (`panelCommands.test.ts`, `getVizSuggestionForQuery.test.ts`), which is why nothing caught this.

## Verification

- `yarn jest public/app/features/dashboard-scene/{serialization,mutation-api,scene}` — 1612 passed. 4 suites fail identically on a clean `main` checkout (missing generated fixture directory, and pre-existing `panel-timerange` / `PanelFieldConfigVariables` failures), unrelated to this change.
- `tsc --noEmit` clean.
- `eslint` clean on changed files.
