### PR TITLE
alerting: save query options when toggletip closes

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/QueryOptions.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryOptions.test.tsx
@@ -1,0 +1,35 @@
+import { fireEvent, render, screen, userEvent } from 'test/test-utils';
+
+import { type ToggletipProps } from '@grafana/ui';
+
+import { QueryOptions } from './QueryOptions';
+
+jest.mock('@grafana/ui', () => ({
+  ...jest.requireActual('@grafana/ui'),
+  Toggletip: ({ children, content, onClose }: ToggletipProps) => (
+    <>
+      {children}
+      <button type="button" onClick={onClose}>
+        Close options
+      </button>
+      {content}
+    </>
+  ),
+}));
+
+describe('QueryOptions', () => {
+  it('saves max data points when the options toggletip closes', async () => {
+    const onChangeQueryOptions = jest.fn();
+    const user = userEvent.setup();
+
+    render(
+      <QueryOptions query={{} as never} queryOptions={{}} index={0} onChangeQueryOptions={onChangeQueryOptions} />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Options' }));
+    await user.type(screen.getByRole('spinbutton'), '42');
+    fireEvent.click(screen.getByRole('button', { name: 'Close options' }));
+
+    expect(onChangeQueryOptions).toHaveBeenCalledWith({ maxDataPoints: 42 }, 0);
+  });
+});

--- a/public/app/features/alerting/unified/components/rule-editor/QueryOptions.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryOptions.tsx
@@ -31,6 +31,14 @@ export const QueryOptions = ({
 
   const separator = <span>, </span>;
 
+  const onOptionsClose = () => {
+    setShowOptions(false);
+
+    if (document.activeElement instanceof HTMLInputElement) {
+      document.activeElement.blur();
+    }
+  };
+
   return (
     <>
       <Toggletip
@@ -50,6 +58,8 @@ export const QueryOptions = ({
         }
         closeButton={true}
         placement="bottom-start"
+        onClose={onOptionsClose}
+        onOpen={() => setShowOptions(true)}
       >
         <button type="button" className={styles.actionLink} onClick={() => setShowOptions(!showOptions)}>
           <Trans i18nKey="alerting.query-options.button-options">Options</Trans>{' '}


### PR DESCRIPTION
## Problem
Closing the query options toggletip can dismiss an active interval or max-data-points input before its blur handler saves the value.

## Change
Blur the active query-option input when the toggletip closes and keep the options indicator synchronized with toggletip visibility.

## Tests
- node .yarn/releases/yarn-4.17.1.cjs jest public/app/features/alerting/unified/components/rule-editor/QueryOptions.test.tsx --watchAll=false — passed
- node .yarn/releases/yarn-4.17.1.cjs prettier --check public/app/features/alerting/unified/components/rule-editor/QueryOptions.tsx public/app/features/alerting/unified/components/rule-editor/QueryOptions.test.tsx — passed

Fixes #111664