### PR TITLE
Apiserver: Add versionpolicy registry and layered resolver

### DIFF
--- a/pkg/services/apiserver/versionpolicy/registry.go
+++ b/pkg/services/apiserver/versionpolicy/registry.go
@@ -1,0 +1,70 @@
+// Package versionpolicy resolves and serves the global API version policy: an advisory preferred
+// version and a max-allowed-version persist ceiling per group. All layers are operator config
+// (compiled defaults, ini, and the live runtime layer) — there is no tenant-writable surface.
+package versionpolicy
+
+import (
+	"maps"
+	"sync"
+)
+
+type VersionPolicy struct {
+	// advisory: affects discovery only, never storage
+	PreferredVersion string
+	// persist ceiling: writes whose version outranks it are rejected
+	MaxAllowedVersion string
+}
+
+// VersionPolicyRegistry serves the resolved global policy. base holds the static layers
+// (defaults, ini); the live runtime layer is applied on top via ReplaceRuntimeLayer.
+type VersionPolicyRegistry struct {
+	mu       sync.RWMutex
+	resolver *Resolver
+	base     []map[string]VersionPolicy
+	global   map[string]VersionPolicy
+}
+
+func NewVersionPolicyRegistry(resolver *Resolver, base ...map[string]VersionPolicy) *VersionPolicyRegistry {
+	return &VersionPolicyRegistry{
+		resolver: resolver,
+		base:     base,
+		global:   resolver.Resolve(base...),
+	}
+}
+
+// ReplaceRuntimeLayer re-resolves the static base with the live runtime layer on top and swaps it in.
+// Returns whether the resolved global changed, so callers only re-prioritize discovery on a real change.
+func (r *VersionPolicyRegistry) ReplaceRuntimeLayer(layer map[string]VersionPolicy) bool {
+	layers := append(append([]map[string]VersionPolicy{}, r.base...), layer)
+	resolved := r.resolver.Resolve(layers...)
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if maps.Equal(r.global, resolved) {
+		return false
+	}
+	r.global = resolved
+	return true
+}
+
+func (r *VersionPolicyRegistry) Preferred(group string) string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.global[group].PreferredVersion
+}
+
+// IsVersionAllowed reports whether version is at or below the group's max-allowed version.
+// allowed is true when no ceiling is configured; maxAllowedVersion is the configured ceiling ("" if none).
+func (r *VersionPolicyRegistry) IsVersionAllowed(group, version string) (allowed bool, maxAllowedVersion string) {
+	r.mu.RLock()
+	max := r.global[group].MaxAllowedVersion
+	r.mu.RUnlock()
+
+	if max == "" {
+		return true, ""
+	}
+	if r.resolver.Outranks(group, version, max) {
+		return false, max
+	}
+	return true, max
+}

--- a/pkg/services/apiserver/versionpolicy/registry_test.go
+++ b/pkg/services/apiserver/versionpolicy/registry_test.go
@@ -1,0 +1,94 @@
+package versionpolicy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var fooOrder = map[string][]string{"foo.grafana.app": {"v2", "v1", "v1beta1"}}
+
+func newTestRegistry(order map[string][]string, base ...map[string]VersionPolicy) *VersionPolicyRegistry {
+	return NewVersionPolicyRegistry(NewResolver(order), base...)
+}
+
+func TestVersionPolicyRegistryPreferredAndMax(t *testing.T) {
+	t.Run("empty serves nothing", func(t *testing.T) {
+		r := newTestRegistry(nil)
+		assert.Equal(t, "", r.Preferred("foo.grafana.app"))
+		allowed, _ := r.IsVersionAllowed("foo.grafana.app", "v2")
+		assert.True(t, allowed)
+	})
+
+	t.Run("resolved base (defaults, ini) serves preferred and cap", func(t *testing.T) {
+		r := newTestRegistry(fooOrder,
+			nil, // defaults
+			map[string]VersionPolicy{"foo.grafana.app": {PreferredVersion: "v1beta1", MaxAllowedVersion: "v1"}}, // ini
+		)
+		assert.Equal(t, "v1beta1", r.Preferred("foo.grafana.app"))
+		allowed, maxAllowed := r.IsVersionAllowed("foo.grafana.app", "v2")
+		assert.False(t, allowed)
+		assert.Equal(t, "v1", maxAllowed)
+	})
+}
+
+func TestVersionPolicyRegistryReplaceRuntimeLayer(t *testing.T) {
+	t.Run("runtime layer feeds preferred and reports changed", func(t *testing.T) {
+		r := newTestRegistry(fooOrder, nil, nil)
+		changed := r.ReplaceRuntimeLayer(map[string]VersionPolicy{"foo.grafana.app": {PreferredVersion: "v1"}})
+		assert.True(t, changed)
+		assert.Equal(t, "v1", r.Preferred("foo.grafana.app"))
+	})
+
+	t.Run("re-applying the same layer reports unchanged", func(t *testing.T) {
+		r := newTestRegistry(fooOrder, nil, nil)
+		r.ReplaceRuntimeLayer(map[string]VersionPolicy{"foo.grafana.app": {PreferredVersion: "v1"}})
+		assert.False(t, r.ReplaceRuntimeLayer(map[string]VersionPolicy{"foo.grafana.app": {PreferredVersion: "v1"}}))
+	})
+
+	t.Run("runtime preferred does not clobber an ini maxAllowedVersion (per-field merge)", func(t *testing.T) {
+		r := newTestRegistry(fooOrder,
+			nil,
+			map[string]VersionPolicy{"foo.grafana.app": {MaxAllowedVersion: "v1"}}, // ini cap
+		)
+		r.ReplaceRuntimeLayer(map[string]VersionPolicy{"foo.grafana.app": {PreferredVersion: "v1beta1"}})
+		assert.Equal(t, "v1beta1", r.Preferred("foo.grafana.app"))
+		allowed, maxAllowed := r.IsVersionAllowed("foo.grafana.app", "v2")
+		assert.False(t, allowed, "ini maxAllowedVersion survives the preferred-only runtime layer")
+		assert.Equal(t, "v1", maxAllowed)
+	})
+
+	t.Run("clearing the runtime layer reverts to the base and reports changed", func(t *testing.T) {
+		r := newTestRegistry(fooOrder, nil, nil)
+		r.ReplaceRuntimeLayer(map[string]VersionPolicy{"foo.grafana.app": {PreferredVersion: "v1"}})
+		assert.True(t, r.ReplaceRuntimeLayer(nil))
+		assert.Equal(t, "", r.Preferred("foo.grafana.app"))
+	})
+}
+
+func TestVersionPolicyRegistryIsVersionAllowed(t *testing.T) {
+	capReg := func(max string) *VersionPolicyRegistry {
+		return newTestRegistry(fooOrder, nil, map[string]VersionPolicy{"foo.grafana.app": {MaxAllowedVersion: max}})
+	}
+
+	t.Run("version above the cap is not allowed", func(t *testing.T) {
+		allowed, maxAllowed := capReg("v1").IsVersionAllowed("foo.grafana.app", "v2")
+		assert.False(t, allowed)
+		assert.Equal(t, "v1", maxAllowed)
+	})
+	t.Run("version at or below the cap is allowed", func(t *testing.T) {
+		allowed, _ := capReg("v1").IsVersionAllowed("foo.grafana.app", "v1")
+		assert.True(t, allowed)
+		allowed, _ = capReg("v1").IsVersionAllowed("foo.grafana.app", "v1beta1")
+		assert.True(t, allowed)
+	})
+	t.Run("no cap set: allowed, empty ceiling", func(t *testing.T) {
+		allowed, maxAllowed := newTestRegistry(fooOrder).IsVersionAllowed("foo.grafana.app", "v2")
+		assert.True(t, allowed)
+		assert.Empty(t, maxAllowed)
+	})
+	t.Run("unregistered version is allowed (never ranks above the cap)", func(t *testing.T) {
+		allowed, _ := capReg("v1").IsVersionAllowed("foo.grafana.app", "v99")
+		assert.True(t, allowed)
+	})
+}

--- a/pkg/services/apiserver/versionpolicy/resolver.go
+++ b/pkg/services/apiserver/versionpolicy/resolver.go
@@ -1,0 +1,105 @@
+package versionpolicy
+
+import (
+	"github.com/grafana/grafana/pkg/infra/log"
+)
+
+var logger = log.New("versionpolicy")
+
+// Resolver merges policy layers and ranks versions against an immutable snapshot of each group's
+// natural (registration) order — highest priority first. The snapshot is captured at construction, so
+// a later preferred-version change to the live scheme cannot move the enforcement ceiling.
+type Resolver struct {
+	order map[string][]string
+}
+
+// NewResolver captures an immutable snapshot of group -> versions (highest priority first).
+func NewResolver(order map[string][]string) *Resolver {
+	snapshot := make(map[string][]string, len(order))
+	for group, versions := range order {
+		snapshot[group] = append([]string(nil), versions...)
+	}
+	return &Resolver{order: snapshot}
+}
+
+// Resolve merges layers low to high (later layers win) per field; values not registered for their
+// group fall through, and groups with no resolved value are omitted. Callers order layers as
+// defaults, ini, runtime.
+func (r *Resolver) Resolve(layers ...map[string]VersionPolicy) map[string]VersionPolicy {
+	result := make(map[string]VersionPolicy)
+	for group := range r.groups(layers...) {
+		preferred := r.resolveField(group, "preferredVersion", fieldValues(layers, group, pickPreferred)...)
+		maxAllowed := r.resolveField(group, "maxAllowedVersion", fieldValues(layers, group, pickMaxAllowed)...)
+
+		if preferred == "" && maxAllowed == "" {
+			continue
+		}
+		result[group] = VersionPolicy{PreferredVersion: preferred, MaxAllowedVersion: maxAllowed}
+	}
+	return result
+}
+
+func pickPreferred(p VersionPolicy) string  { return p.PreferredVersion }
+func pickMaxAllowed(p VersionPolicy) string { return p.MaxAllowedVersion }
+
+// fieldValues extracts one field from each layer (low to high) for a group.
+func fieldValues(layers []map[string]VersionPolicy, group string, pick func(VersionPolicy) string) []string {
+	out := make([]string, len(layers))
+	for i, layer := range layers {
+		out[i] = pick(layer[group])
+	}
+	return out
+}
+
+func (r *Resolver) groups(layers ...map[string]VersionPolicy) map[string]struct{} {
+	groups := make(map[string]struct{})
+	for _, layer := range layers {
+		for group := range layer {
+			groups[group] = struct{}{}
+		}
+	}
+	return groups
+}
+
+// resolveField keeps the highest-precedence registered value; field labels the ignore log.
+func (r *Resolver) resolveField(group, field string, layers ...string) string {
+	result := ""
+	for _, version := range layers {
+		if version == "" {
+			continue
+		}
+		if !r.isRegistered(group, version) {
+			logger.Warn("ignoring unregistered version in version policy layer",
+				"group", group, "field", field, "version", version)
+			continue
+		}
+		result = version
+	}
+	return result
+}
+
+func (r *Resolver) isRegistered(group, version string) bool {
+	_, ok := r.rank(group, version)
+	return ok
+}
+
+// rank returns version's priority index (lower = higher priority) and whether it is registered,
+// against the immutable snapshot.
+func (r *Resolver) rank(group, version string) (int, bool) {
+	for i, v := range r.order[group] {
+		if v == version {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+// Outranks reports whether a ranks strictly higher than b; false if equal or either is unregistered.
+func (r *Resolver) Outranks(group, a, b string) bool {
+	rankA, okA := r.rank(group, a)
+	rankB, okB := r.rank(group, b)
+	if !okA || !okB {
+		return false
+	}
+	return rankA < rankB
+}

--- a/pkg/services/apiserver/versionpolicy/resolver_test.go
+++ b/pkg/services/apiserver/versionpolicy/resolver_test.go
@@ -1,0 +1,124 @@
+package versionpolicy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolverResolve(t *testing.T) {
+	order := map[string][]string{"foo.grafana.app": {"v2", "v1", "v1beta1"}}
+
+	tests := []struct {
+		name     string
+		defaults map[string]VersionPolicy
+		ini      map[string]VersionPolicy
+		resource map[string]VersionPolicy
+		want     map[string]VersionPolicy
+	}{
+		{
+			name: "resource wins over ini wins over default, both fields",
+			defaults: map[string]VersionPolicy{
+				"foo.grafana.app": {PreferredVersion: "v1", MaxAllowedVersion: "v1"},
+			},
+			ini: map[string]VersionPolicy{
+				"foo.grafana.app": {PreferredVersion: "v1beta1", MaxAllowedVersion: "v1beta1"},
+			},
+			resource: map[string]VersionPolicy{
+				"foo.grafana.app": {PreferredVersion: "v2", MaxAllowedVersion: "v2"},
+			},
+			want: map[string]VersionPolicy{
+				"foo.grafana.app": {PreferredVersion: "v2", MaxAllowedVersion: "v2"},
+			},
+		},
+		{
+			name: "per-field independence: resource sets max only, preferred falls through to ini",
+			defaults: map[string]VersionPolicy{
+				"foo.grafana.app": {PreferredVersion: "v1"},
+			},
+			ini: map[string]VersionPolicy{
+				"foo.grafana.app": {PreferredVersion: "v1beta1"},
+			},
+			resource: map[string]VersionPolicy{
+				"foo.grafana.app": {MaxAllowedVersion: "v2"},
+			},
+			want: map[string]VersionPolicy{
+				"foo.grafana.app": {PreferredVersion: "v1beta1", MaxAllowedVersion: "v2"},
+			},
+		},
+		{
+			name: "only default sets a field; other field absent everywhere",
+			defaults: map[string]VersionPolicy{
+				"foo.grafana.app": {PreferredVersion: "v1"},
+			},
+			ini:      map[string]VersionPolicy{},
+			resource: map[string]VersionPolicy{},
+			want: map[string]VersionPolicy{
+				"foo.grafana.app": {PreferredVersion: "v1"},
+			},
+		},
+		{
+			name:     "all layers absent for every group yields an empty result",
+			defaults: map[string]VersionPolicy{},
+			ini:      map[string]VersionPolicy{},
+			resource: map[string]VersionPolicy{},
+			want:     map[string]VersionPolicy{},
+		},
+		{
+			name: "unknown version at the resource layer is ignored, falls through to ini",
+			defaults: map[string]VersionPolicy{
+				"foo.grafana.app": {PreferredVersion: "v1"},
+			},
+			ini: map[string]VersionPolicy{
+				"foo.grafana.app": {PreferredVersion: "v1beta1"},
+			},
+			resource: map[string]VersionPolicy{
+				"foo.grafana.app": {PreferredVersion: "v99"},
+			},
+			want: map[string]VersionPolicy{
+				"foo.grafana.app": {PreferredVersion: "v1beta1"},
+			},
+		},
+		{
+			name: "unknown version at every layer for a field leaves it empty",
+			defaults: map[string]VersionPolicy{
+				"foo.grafana.app": {MaxAllowedVersion: "v97"},
+			},
+			ini: map[string]VersionPolicy{
+				"foo.grafana.app": {MaxAllowedVersion: "v98"},
+			},
+			resource: map[string]VersionPolicy{
+				"foo.grafana.app": {MaxAllowedVersion: "v99"},
+			},
+			want: map[string]VersionPolicy{},
+		},
+		{
+			name: "unregistered group (empty priority slice) is treated as all-unknown",
+			defaults: map[string]VersionPolicy{
+				"unknown.grafana.app": {PreferredVersion: "v1"},
+			},
+			ini:      map[string]VersionPolicy{},
+			resource: map[string]VersionPolicy{},
+			want:     map[string]VersionPolicy{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewResolver(order)
+			got := r.Resolve(tt.defaults, tt.ini, tt.resource)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestResolverOutranks(t *testing.T) {
+	order := map[string][]string{"foo.grafana.app": {"v2", "v1", "v1beta1"}}
+	r := NewResolver(order)
+
+	assert.True(t, r.Outranks("foo.grafana.app", "v2", "v1beta1"), "v2 should outrank v1beta1")
+	assert.False(t, r.Outranks("foo.grafana.app", "v1beta1", "v2"), "v1beta1 should not outrank v2")
+	assert.False(t, r.Outranks("foo.grafana.app", "v1", "v1"), "a version does not outrank itself")
+	assert.False(t, r.Outranks("foo.grafana.app", "v2", "v99"), "unregistered version never outranks or is outranked")
+	assert.False(t, r.Outranks("unknown.grafana.app", "v1", "v2"), "unregistered group never ranks")
+}


### PR DESCRIPTION
## What

Adds the `versionpolicy` package: a registry that serves a single resolved **global** API version policy per group (an advisory `preferredVersion` and a `maxAllowedVersion` persist ceiling), plus a layered resolver.

- `Resolve(...layers)` merges ordered layers low→high per field (callers order them `defaults < ini < runtime`), dropping any version not registered for its group (with a warn) so bad config degrades to a no-op.
- `VersionPolicyRegistry`: `ReplaceRuntimeLayer(layer) bool` swaps the live runtime layer and reports whether the resolved result changed (so consumers only react on real change); `Preferred(group)` and `IsVersionAllowed(group, version) (allowed bool, maxAllowedVersion string)` serve the resolved policy. Order-based ranking via `Outranks`.

## Why

Requirement for runtime, DB-backed `preferredVersion`/`maxAllowedVersion`, precedence over compiled defaults, no redeploy.

Tracked in grafana/search-and-storage-team#881.

All layers are operator config (compiled defaults, ini, and a live runtime layer) — there is **no tenant-writable surface** and no per-namespace policy.

## Scope

- Package-only; nothing consumes it yet (enforcement in `apistore` and the discovery re-prioritization land in follow-up PRs in the stack). No behavior change on its own.
- Backend-only. Behind feature flag `grafana.apiVersionPolicy` once wired higher in the stack.

## Tests

`go test ./pkg/services/apiserver/versionpolicy/` — resolver precedence + per-field merge + unregistered-version drop; registry `ReplaceRuntimeLayer` changed-gating, `Preferred`, `IsVersionAllowed`.
