### PR TITLE
E2E selectors: Add selectors for RadioButtonGroup options, Explore, Logs and Trace view

### DIFF
--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -1358,6 +1358,9 @@ export const versionedComponents = {
     spanBar: {
       '9.0.0': 'data-testid SpanBar--wrapper',
     },
+    filtersRow: {
+      '13.2.0': 'data-testid trace-page-header-adhoc-filters-row',
+    },
   },
   QueryField: {
     container: {
@@ -1719,6 +1722,18 @@ export const versionedComponents = {
       },
       applyInverse: {
         ['12.1.0']: 'data-testid viz-tooltip-footer-apply-inverse-filters-button',
+      },
+    },
+  },
+  Logs: {
+    logLineMenu: {
+      menuButton: {
+        '13.2.0': 'data-testid Log line menu button',
+      },
+    },
+    fieldsSidebar: {
+      searchInput: {
+        '13.2.0': 'data-testid Log fields search input',
       },
     },
   },

--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -17,6 +17,9 @@ export const versionedComponents = {
     container: {
       '10.2.3': 'data-testid radio-button',
     },
+    option: {
+      '13.2.0': (value: string) => `data-testid radio-button-option ${value}`,
+    },
   },
   Breadcrumbs: {
     breadcrumb: {

--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -17,6 +17,16 @@ export const versionedComponents = {
     container: {
       '10.2.3': 'data-testid radio-button',
     },
+    /**
+     * Identifies one option of a RadioButtonGroup by its `value`, so the selector does not depend
+     * on the option's translated label.
+     *
+     * Unique **within a group, not across a page** — generic values collide, and `true`/`false`
+     * are used by a dozen different groups. Always scope it to the group, either via the group's
+     * own `data-testid` prop or `RadioGroup.container`:
+     *
+     *     `${RadioGroup.container} ${RadioButton.option('code')}`
+     */
     option: {
       '13.2.0': (value: string) => `data-testid radio-button-option ${value}`,
     },

--- a/packages/grafana-e2e-selectors/src/selectors/pages.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/pages.ts
@@ -1052,6 +1052,9 @@ export const versionedPages = {
       split: {
         '12.4.0': 'data-testid explore-toolbar-split-button',
       },
+      closeSplit: {
+        '13.2.0': 'data-testid explore-toolbar-close-split-button',
+      },
       addTo: {
         '12.4.0': 'data-testid explore-toolbar-add-dropdown-button',
       },

--- a/packages/grafana-ui/src/components/Forms/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/packages/grafana-ui/src/components/Forms/RadioButtonGroup/RadioButtonGroup.tsx
@@ -104,9 +104,11 @@ export function RadioButtonGroup<T>({
         const hasNonIconPart = Boolean(opt.imgUrl || opt.label || opt.component);
         const labelTitle = typeof opt.label === 'string' ? opt.label : undefined;
         // Keyed on the option's value, not its label, so the selector survives translation.
-        // Skipped for non-primitive values, which have no meaningful string form.
+        // Skipped for objects and undefined, which have no meaningful string form.
         const testIdValue =
-          typeof opt.value === 'string' || typeof opt.value === 'number' ? String(opt.value) : undefined;
+          typeof opt.value === 'string' || typeof opt.value === 'number' || typeof opt.value === 'boolean'
+            ? String(opt.value)
+            : undefined;
 
         return (
           <RadioButton

--- a/packages/grafana-ui/src/components/Forms/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/packages/grafana-ui/src/components/Forms/RadioButtonGroup/RadioButtonGroup.tsx
@@ -103,6 +103,10 @@ export function RadioButtonGroup<T>({
         const icon = opt.icon ? toIconName(opt.icon) : undefined;
         const hasNonIconPart = Boolean(opt.imgUrl || opt.label || opt.component);
         const labelTitle = typeof opt.label === 'string' ? opt.label : undefined;
+        // Keyed on the option's value, not its label, so the selector survives translation.
+        // Skipped for non-primitive values, which have no meaningful string form.
+        const testIdValue =
+          typeof opt.value === 'string' || typeof opt.value === 'number' ? String(opt.value) : undefined;
 
         return (
           <RadioButton
@@ -110,6 +114,7 @@ export function RadioButtonGroup<T>({
             disabled={isItemDisabled || disabled}
             active={value === opt.value}
             key={`o.label-${i}`}
+            data-testid={testIdValue === undefined ? undefined : selectors.components.RadioButton.option(testIdValue)}
             aria-label={opt.ariaLabel}
             aria-invalid={!!invalid}
             aria-describedby={ariaDescribedBy}

--- a/public/app/features/explore/ExploreToolbar.tsx
+++ b/public/app/features/explore/ExploreToolbar.tsx
@@ -276,6 +276,7 @@ export function ExploreToolbar({ exploreId, onChangeTime, onContentOutlineToogle
                 className={cx(shouldRotateSplitIcon && styles.rotateIcon)}
               />
               <ToolbarButton
+                data-testid={selectors.pages.Explore.toolbar.closeSplit}
                 tooltip={t('explore.toolbar.split-close-tooltip', 'Close split pane')}
                 onClick={onCloseSplitView}
                 icon="times"

--- a/public/app/features/explore/SecondaryActions.tsx
+++ b/public/app/features/explore/SecondaryActions.tsx
@@ -126,6 +126,7 @@ export function SecondaryActions({
         variant={queryInspectorButtonActive ? 'active' : 'canvas'}
         aria-label={t('explore.secondary-actions.query-inspector-button-aria-label', 'Query inspector')}
         onClick={onClickQueryInspectorButton}
+        data-testid={Components.QueryTab.queryInspectorButton}
         icon="info-circle"
       >
         <Trans i18nKey="explore.secondary-actions.query-inspector-button">Query inspector</Trans>

--- a/public/app/features/explore/TraceView/components/TracePageHeader/TracePageHeader.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/TracePageHeader.tsx
@@ -25,6 +25,7 @@ import {
   type GrafanaTheme2,
   PluginExtensionPoints,
 } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import {
   reportInteraction,
@@ -405,7 +406,7 @@ export const TracePageHeader = memo((props: TracePageHeaderProps) => {
       {!hideHeaderDetails && (
         <div className={styles.filtersContainer}>
           <Label>{t('explore.trace-page-header.filters', 'Filters')}</Label>
-          <div className={styles.adhocFiltersRow}>
+          <div className={styles.adhocFiltersRow} data-testid={selectors.components.TraceViewer.filtersRow}>
             {controller && <AdHocFiltersComboboxRenderer controller={controller} />}
           </div>
           {trace && (

--- a/public/app/features/logs/components/fieldSelector/FieldSearch.tsx
+++ b/public/app/features/logs/components/fieldSelector/FieldSearch.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/css';
 import * as React from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 import { Field, IconButton, Input, useStyles2 } from '@grafana/ui';
 
@@ -26,6 +27,7 @@ export function FieldSearch({ collapse, onChange, value }: Props) {
         <Input
           value={value}
           type="text"
+          data-testid={selectors.components.Logs.fieldsSidebar.searchInput}
           placeholder={t('logs.field-selector.placeholder-search-fields-by-name', 'Search fields by name')}
           onChange={onChange}
           suffix={

--- a/public/app/features/logs/components/panel/LogLineMenu.tsx
+++ b/public/app/features/logs/components/panel/LogLineMenu.tsx
@@ -1,6 +1,7 @@
 import { type MouseEvent, useCallback, useMemo, useRef } from 'react';
 
 import { type LogRowContextOptions, type LogRowModel } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
 import { type DataQuery } from '@grafana/schema';
@@ -172,6 +173,7 @@ export const LogLineMenu = ({ active, log, styles }: Props) => {
       <Dropdown overlay={menu} placement="bottom-start">
         <IconButton
           className={styles.menuIcon}
+          data-testid={selectors.components.Logs.logLineMenu.menuButton}
           name={active ? 'angle-right' : 'ellipsis-v'}
           aria-label={t('logs.log-line-menu.icon-label', 'Log menu')}
           role="button"

--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -527,6 +527,9 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
         {!isEditingQueryLibrary && (
           <QueryOperationAction
             title={t('query-operation.header.duplicate-query', 'Duplicate query')}
+            // Set explicitly so the test id stays stable across locales: QueryOperationAction
+            // otherwise derives it from the translated title.
+            dataTestId={selectors.components.QueryEditorRow.actionButton('Duplicate query')}
             icon="copy"
             onClick={this.onCopyQuery}
           />


### PR DESCRIPTION
## What this PR does

Adds versioned `@grafana/e2e-selectors` entries for interactive controls that had no stable test id, and wires up one existing-but-unused selector. Every control here was previously only addressable by **translated** text — visible label, `aria-label`, `tooltip`, `title` or `placeholder` — which breaks on non-English Grafana and on any copy change.

### New selectors

| Selector | Element | File |
| --- | --- | --- |
| `components.RadioButton.option(value)` | Any RadioButtonGroup option | `packages/grafana-ui/.../RadioButtonGroup.tsx` |
| `pages.Explore.toolbar.closeSplit` | Close split pane button | `public/app/features/explore/ExploreToolbar.tsx` |
| `components.Logs.logLineMenu.menuButton` | Per-log-line menu trigger | `public/app/features/logs/components/panel/LogLineMenu.tsx` |
| `components.Logs.fieldsSidebar.searchInput` | Log fields search input | `public/app/features/logs/components/fieldSelector/FieldSearch.tsx` |
| `components.TraceViewer.filtersRow` | Trace header ad-hoc filters row | `.../TracePageHeader/TracePageHeader.tsx` |

### Existing selector wired up

`components.QueryTab.queryInspectorButton` has existed since 13.1.0 and is used by the dashboard panel editor, but Explore's own **Query inspector** button never consumed it — it was only reachable via its translated `aria-label`. Now wired in `SecondaryActions.tsx`.

## The RadioButtonGroup change is the most broadly useful bit

`RadioButtonGroup` gave **every** option the same static `data-testid radio-button`. Nothing in the DOM distinguished one option from another except translated text:

```html
<div data-testid="data-testid radio-button">        <!-- identical for ALL options -->
  <input id="_r_3v_" title="Builder" value="on">    <!-- id random (useId), value always "on", title translated -->
  <label for="_r_3v_" title="Builder">Builder</label>
```

The component already receives `opt.value` — a stable, non-localized value (e.g. `builder` / `code`) — it just never reached the DOM. `RadioButton.option` is keyed on that value instead of the label, so the selector survives translation.

This follows the e2e-selectors loop guidance: one parameterized selector on the repeated element, keyed by a unique stable value.

Notes:
- Applied via the existing prop spread onto the `<input>` (`RadioButtonProps extends Omit<HTMLProps<HTMLInputElement>, 'size'>`), so **no new prop** was added to the component.
- The container's `radio-button` testid is **untouched**, so existing callers keep working. `resolveGrafanaSelector` is exact-match by default (`[data-testid="..."]`), and no caller opts into `startsWith`, so the new value cannot inflate existing `RadioButton.container` matches.
- Options with non-primitive values are skipped — they have no meaningful string form.
- Chosen value is `radio-button-option <value>` rather than `radio-button <value>` specifically so prefix matching can't confuse the two.

## Why

The driver is a [Grafana Pathfinder](https://github.com/grafana/interactive-tutorials) interactive guide for Explore, which currently has to target these controls by localized accessible name — including `:contains('Builder')` / `:contains('Code')` / `:contains('Search')` / `:contains('Service Graph')` for radio options, which is both text-dependent and non-standard CSS.

I verified each gap against a live Grafana Cloud 13.2.0 instance rather than inferring from source: the Query inspector button has only `aria-label="Query inspector"` and no test id; the Prometheus **Operations** button has only `title="Add operation"`; radio options expose only random `useId` ids and translated `title`.

## Note for reviewers

The dependent guide PR is grafana/interactive-tutorials#489. Guide steps relying on the **new** selectors here have deliberately been **left on their existing localized selectors** so the guide keeps working against current releases; they'll be switched over once these ship. Only steps that could move to already-released selectors were converted there.

One judgement call worth a look: `Logs.logLineMenu.menuButton` sits on a control that renders **once per log line**. The loop guidance prefers a single parameterized selector on a repeated row over a static id on a per-row control. I kept a static id because (a) the log list is virtualized so the attribute count is bounded to visible rows, (b) it is the row's primary control rather than one of many inner elements, and (c) a `log.uid`-parameterized row selector would be unusable for the guide, which cannot know a uid at authoring time. Happy to switch to a parameterized row selector on `LogLine.tsx` if you'd prefer.

## Verification

- `yarn jest` on affected suites — **99 tests pass**: `RadioButtonGroup`, all of `grafana-ui/.../Forms`, all of `explore/spec` (incl. `split`), `LogLineMenu`, `SecondaryActions`, `FieldSelector`, `TracePageHeader`, plus the 4 `grafana-e2e-selectors` resolver tests
- `tsc --noEmit` clean across the whole project
- `eslint` and `prettier --check` clean on all changed files
- No `.snap` files contain radio-button markup, so no snapshots needed updating
- No existing selector values or signatures were modified; all changes are additive under version key `13.2.0`
- No user-visible strings changed, so no i18n extraction needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
