### PR TITLE
Provisioning: Document allowed_git_urls setting

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -2571,7 +2571,7 @@ allow_insecure = false
 
 # Comma-separated allowlist of Git hosts, IPs, or CIDR ranges permitted even when they resolve
 # to an otherwise-blocked address. To prevent SSRF, repository URLs resolving to loopback,
-# private (RFC1918), link-local, or unspecified addresses are rejected by default; public
+# private (RFC 1918), link-local, or unspecified addresses are rejected by default; public
 # addresses are always allowed. Add entries here to allow an internal Git server (for example
 # an on-prem GitHub Enterprise host). Each entry may be a hostname, host:port, a full URL (only
 # the host is used), a literal IP, or a CIDR. Empty by default.

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -2569,6 +2569,14 @@ allow_image_rendering = true
 # (it is also implicitly allowed when app_mode = development).
 allow_insecure = false
 
+# Comma-separated allowlist of Git hosts, IPs, or CIDR ranges permitted even when they resolve
+# to an otherwise-blocked address. To prevent SSRF, repository URLs resolving to loopback,
+# private (RFC1918), link-local, or unspecified addresses are rejected by default; public
+# addresses are always allowed. Add entries here to allow an internal Git server (for example
+# an on-prem GitHub Enterprise host). Each entry may be a hostname, host:port, a full URL (only
+# the host is used), a literal IP, or a CIDR. Empty by default.
+allowed_git_urls =
+
 # The minimum sync interval that can be set for a repository. This is how often the controller
 # will check if there has been any changes to the repository not propagated by a webhook.
 # The minimum value is 10 seconds.

--- a/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/set-up-before.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/set-up-before.md
@@ -158,5 +158,3 @@ Finally, install the app:
 1. On the installation page, copy **`installationID`** from the page URL https://github.com/settings/installations/installationID
 
 You can now proceed to [Set up Git Sync](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/git-sync-setup/)!
-
-

--- a/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/set-up-before.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/set-up-before.md
@@ -79,6 +79,26 @@ If you're using Grafana Enterprise v12.4.0 and want to set up Git Sync with pure
 
 1. Save the changes to the file and restart Grafana.
 
+## Allow internal or private Git servers
+
+By default, Git Sync rejects repository URLs whose host resolves to a loopback, private (RFC 1918), link-local, or unspecified address. This protects your Grafana instance against server-side request forgery (SSRF). Public Git servers such as `github.com`, `gitlab.com`, and `bitbucket.org` resolve to public addresses and are always allowed.
+
+This setting applies to self-managed Grafana (OSS and Enterprise). It's not configurable in Grafana Cloud.
+
+If you connect Git Sync to a Git server on a private network — for example, a self-hosted GitHub Enterprise, GitLab, or Bitbucket instance reachable only through an internal address — add its host to the `allowed_git_urls` allowlist:
+
+1. Open your Grafana configuration file, either `grafana.ini` or `custom.ini`.
+1. Add each internal Git host to `allowed_git_urls` as a comma-separated list:
+
+   ```ini
+   [provisioning]
+   allowed_git_urls = git.internal.example.com, ghe.example.com:8443
+   ```
+
+1. Save the changes to the file and restart Grafana.
+
+Each entry can be a hostname, `host:port`, a full URL (only the host is used), a literal IP address, or a CIDR range. Prefer specific hosts or narrow ranges: a broad CIDR such as `10.0.0.0/8` re-exposes the entire private range that SSRF protection blocks. Only add hosts you trust — an allowlisted host receives the configured Git token on every sync, fetch, and push.
+
 ## Create a GitHub App
 
 GitHub Apps are tools that extend GitHub functionality. They use fine-grained permissions and short-lived tokens, giving you more control over which repositories are being accessed. Find out more in the [GitHub Apps official documentation](https://docs.github.com/en/apps/overview).

--- a/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/set-up-before.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/set-up-before.md
@@ -81,11 +81,13 @@ If you're using Grafana Enterprise v12.4.0 and want to set up Git Sync with pure
 
 ## Allow internal or private Git servers
 
-By default, Git Sync rejects repository URLs whose host resolves to a loopback, private (RFC 1918), link-local, or unspecified address. This protects your Grafana instance against server-side request forgery (SSRF). Public Git servers such as `github.com`, `gitlab.com`, and `bitbucket.org` resolve to public addresses and are always allowed.
-
+{{< admonition type="note" >}}
 This setting applies to self-managed Grafana (OSS and Enterprise). It's not configurable in Grafana Cloud.
+{{< /admonition >}}
 
-If you connect Git Sync to a Git server on a private network — for example, a self-hosted GitHub Enterprise, GitLab, or Bitbucket instance reachable only through an internal address — add its host to the `allowed_git_urls` allowlist:
+While public Git servers such as `github.com`, `gitlab.com`, and `bitbucket.org` resolve to public addresses and are always allowed, by default Git Sync rejects repository URLs with a host that resolves to a loopback, a private (RFC 1918), link-local, or an unspecified address. This protects your Grafana instance against server-side request forgery (SSRF).
+
+If you connect Git Sync to a Git server on a private network such as a self-hosted GitHub Enterprise, GitLab, or Bitbucket instance reachable only through an internal address, add its host to the `allowed_git_urls` allowlist:
 
 1. Open your Grafana configuration file, either `grafana.ini` or `custom.ini`.
 1. Add each internal Git host to `allowed_git_urls` as a comma-separated list:
@@ -97,7 +99,9 @@ If you connect Git Sync to a Git server on a private network — for example, a 
 
 1. Save the changes to the file and restart Grafana.
 
-Each entry can be a hostname, `host:port`, a full URL (only the host is used), a literal IP address, or a CIDR range. Prefer specific hosts or narrow ranges: a broad CIDR such as `10.0.0.0/8` re-exposes the entire private range that SSRF protection blocks. Only add hosts you trust — an allowlisted host receives the configured Git token on every sync, fetch, and push.
+Each entry can be a hostname, `host:port`, a full URL (only the host is used), a literal IP address, or a CIDR range. If possible, use specific hosts or narrow ranges, since a broad CIDR such as `10.0.0.0/8` re-exposes the entire private range that SSRF protection blocks.
+
+**Only add hosts you trust** because an allowlisted host receives the configured Git token on every sync, fetch, and push.
 
 ## Create a GitHub App
 

--- a/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/set-up-before.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/set-up-before.md
@@ -27,6 +27,26 @@ Before you begin to set up Git Sync, ensure you have the following:
 - If you're [using webhooks or image rendering](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/git-sync-setup/set-up-extend), a public instance with external access
   - Optional: The [Image Renderer service](https://github.com/grafana/grafana-image-renderer) to save image previews with your PRs
 
+## Enable required feature toggles
+
+The `provisioning` feature toggle is enabled by default in Grafana Cloud and, starting in Grafana v13, for OSS and Enterprise as well. No manual configuration is required.
+
+For more information about feature toggles, refer to [Configure feature toggles](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/feature-toggles/).
+
+## Enable Git providers
+
+If you're using Grafana Enterprise v12.4.0 and want to set up Git Sync with pure Git, GitLab or Bitbucket, or if you're using Grafana OSS v12.4.0 and want to set up Git Sync with pure Git, add them to your configuration file:
+
+1. Open your Grafana configuration file, either `grafana.ini` or `custom.ini`.
+1. Add the available providers:
+
+   ```ini
+   [provisioning]
+   repository_types = "git|github|bitbucket|gitlab|local"
+   ```
+
+1. Save the changes to the file and restart Grafana.
+
 ## Network connectivity and IP allowlisting
 
 Git Sync requires network connectivity between your Grafana instance and Git server. Understanding the traffic patterns helps you configure firewall rules and allowlists correctly.
@@ -59,30 +79,10 @@ Finally, get acquainted with the following topics:
 - [Role and resource permissions](#resource-and-role-permissions)
 - For further details on how Git Sync operates, refer to the [key concepts](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/key-concepts)
 
-## Enable required feature toggles
-
-The `provisioning` feature toggle is enabled by default in Grafana Cloud and, starting in Grafana v13, for OSS and Enterprise as well. No manual configuration is required.
-
-For more information about feature toggles, refer to [Configure feature toggles](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/feature-toggles/).
-
-### Enable Git providers
-
-If you're using Grafana Enterprise v12.4.0 and want to set up Git Sync with pure Git, GitLab or Bitbucket, or if you're using Grafana OSS v12.4.0 and want to set up Git Sync with pure Git, add them to your configuration file:
-
-1. Open your Grafana configuration file, either `grafana.ini` or `custom.ini`.
-1. Add the available providers:
-
-   ```ini
-   [provisioning]
-   repository_types = "git|github|bitbucket|gitlab|local"
-   ```
-
-1. Save the changes to the file and restart Grafana.
-
 ## Allow internal or private Git servers
 
 {{< admonition type="note" >}}
-This setting applies to self-managed Grafana (OSS and Enterprise). It's not configurable in Grafana Cloud.
+This setting is available starting in Grafana v13.0.0 and applies to self-managed Grafana (OSS and Enterprise) only. It's not configurable in Grafana Cloud.
 {{< /admonition >}}
 
 While public Git servers such as `github.com`, `gitlab.com`, and `bitbucket.org` resolve to public addresses and are always allowed, by default Git Sync rejects repository URLs with a host that resolves to a loopback, a private (RFC 1918), link-local, or an unspecified address. This protects your Grafana instance against server-side request forgery (SSRF).
@@ -102,6 +102,18 @@ If you connect Git Sync to a Git server on a private network such as a self-host
 Each entry can be a hostname, `host:port`, a full URL (only the host is used), a literal IP address, or a CIDR range. If possible, use specific hosts or narrow ranges, since a broad CIDR such as `10.0.0.0/8` re-exposes the entire private range that SSRF protection blocks.
 
 **Only add hosts you trust** because an allowlisted host receives the configured Git token on every sync, fetch, and push.
+
+## Resource and role permissions
+
+By default, folders provisioned with Git Sync have these roles:
+
+- Admin = Admin
+- Editor = Editor
+- Viewer = Viewer.
+
+Refer to [Git Sync permissions](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/permissions-grafana) for details on how to set up permissions in Git Sync. To modify them, refer to [Manage folder permissions](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/use-git-sync#manage-folder-permissions).
+
+Refer to [Roles and permissions](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/roles-and-permissions) for more information about Grafana roles.
 
 ## Create a GitHub App
 
@@ -147,14 +159,4 @@ Finally, install the app:
 
 You can now proceed to [Set up Git Sync](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/git-sync-setup/)!
 
-## Resource and role permissions
 
-By default, folders provisioned with Git Sync have these roles:
-
-- Admin = Admin
-- Editor = Editor
-- Viewer = Viewer.
-
-Refer to [Git Sync permissions](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/permissions-grafana) for details on how to set up permissions in Git Sync. To modify them, refer to [Manage folder permissions](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/use-git-sync#manage-folder-permissions).
-
-Refer to [Roles and permissions](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/roles-and-permissions) for more information about Grafana roles.

--- a/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/set-up-before.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/set-up-before.md
@@ -82,7 +82,7 @@ Finally, get acquainted with the following topics:
 ## Allow internal or private Git servers
 
 {{< admonition type="note" >}}
-This setting is available starting in Grafana v13.0.0 and applies to self-managed Grafana (OSS and Enterprise) only. It's not configurable in Grafana Cloud.
+This setting is available for Grafana v13.0.4 and Grafana v13.1.1 onwards and applies to self-managed Grafana (OSS and Enterprise) only. It's not configurable in Grafana Cloud.
 {{< /admonition >}}
 
 While public Git servers such as `github.com`, `gitlab.com`, and `bitbucket.org` resolve to public addresses and are always allowed, by default Git Sync rejects repository URLs with a host that resolves to a loopback, a private (RFC 1918), link-local, or an unspecified address. This protects your Grafana instance against server-side request forgery (SSRF).

--- a/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/set-up-before.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/set-up-before.md
@@ -82,7 +82,7 @@ Finally, get acquainted with the following topics:
 ## Allow internal or private Git servers
 
 {{< admonition type="note" >}}
-This setting is available for Grafana v13.0.4 and Grafana v13.1.1 onwards and applies to self-managed Grafana (OSS and Enterprise) only. It's not configurable in Grafana Cloud.
+This setting is available for Grafana v13.0.4 and Grafana v13.1.1 and later. It only applies to self-managed Grafana (OSS and Enterprise), but it's not configurable in Grafana Cloud.
 {{< /admonition >}}
 
 While public Git servers such as `github.com`, `gitlab.com`, and `bitbucket.org` resolve to public addresses and are always allowed, by default Git Sync rejects repository URLs with a host that resolves to a loopback, a private (RFC 1918), link-local, or an unspecified address. This protects your Grafana instance against server-side request forgery (SSRF).

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -2874,6 +2874,12 @@ Whether image rendering is allowed for dashboard previews. Requires the image re
 
 Whether to allow `http://` repository URLs together with a configured token. Because this sends the token in cleartext on every Git operation, it's rejected by default. Intended for local and development use only. It's also implicitly allowed when `app_mode = development`. Default is `false`.
 
+#### `allowed_git_urls`
+
+Comma-separated allowlist of Git hosts, IP addresses, or CIDR ranges that are permitted even when they resolve to an address that would otherwise be blocked.
+
+To prevent server-side request forgery (SSRF), repository URLs that resolve to loopback, private (RFC 1918), link-local, or unspecified addresses are rejected by default. Add an entry here to allow an internal or self-hosted Git server, such as an on-premises GitHub Enterprise host. Each entry can be a hostname, `host:port`, a full URL (only the host is used), a literal IP address, or a CIDR range. Public addresses are always allowed. Empty by default.
+
 #### `min_sync_interval`
 
 The minimum sync interval that you can set for a repository. Indicates how often the controller will check for changes in the repository that were not propagated by a webhook. The minimum value is `10s`. Default is `10s`.

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -2876,9 +2876,11 @@ Whether to allow `http://` repository URLs together with a configured token. Bec
 
 #### `allowed_git_urls`
 
-Comma-separated allowlist of Git hosts, IP addresses, or CIDR ranges that are permitted even when they resolve to an address that would otherwise be blocked.
+While public addresses are always allowed, to prevent server-side request forgery (SSRF), repository URLs that resolve to loopback, private (RFC 1918), link-local, or unspecified addresses are rejected by default.
 
-To prevent server-side request forgery (SSRF), repository URLs that resolve to loopback, private (RFC 1918), link-local, or unspecified addresses are rejected by default. Add an entry here to allow an internal or self-hosted Git server, such as an on-premises GitHub Enterprise host. Each entry can be a hostname, `host:port`, a full URL (only the host is used), a literal IP address, or a CIDR range. Public addresses are always allowed. Empty by default.
+If you want to allow an internal or self-hosted Git server, such as an on-premises GitHub Enterprise host, add an entry here. Each entry can be a hostname, `host:port`, a full URL (only the host is used), a literal IP address, or a CIDR range.
+
+This field is empty by default.
 
 #### `min_sync_interval`
 


### PR DESCRIPTION
## What this PR does

Documents the `allowed_git_urls` provisioning setting (docs + config template only — no code).

- **`conf/defaults.ini`**: adds the `allowed_git_urls` key under `[provisioning]` with an explanatory comment and its empty default.
- **Configuration reference** (`setup-grafana/configure-grafana/_index.md`): adds an `allowed_git_urls` entry to the `[provisioning]` section, alongside its sibling keys.
- **Git Sync setup docs** (`set-up-before.md`): adds an "Allow internal or private Git servers" section explaining the default SSRF protection and how to allowlist an internal Git host.

## Context

The `allowed_git_urls` key is the operator-facing part of the SSRF / PAT-exfiltration hardening for the Git Sync repository types. By default, repository URLs whose host resolves to a loopback, private (RFC1918), link-local, or unspecified address are rejected to prevent server-side request forgery; public hosts (github.com, gitlab.com, bitbucket.org) are always allowed. This key adds exceptions for internal/self-hosted Git servers (for example, an on-prem GitHub Enterprise host).

Each entry may be a hostname, `host:port`, a full URL (only the host is used), a literal IP, or a CIDR range. The docs steer users toward specific hosts / narrow ranges and warn that an allowlisted host receives the configured Git token on every git operation.

Docs-only follow-up to the hardening tracked in `git-ui-sync-project` issues [#1145](https://github.com/grafana/git-ui-sync-project/issues/1145) and [#1146](https://github.com/grafana/git-ui-sync-project/issues/1146).

Closes https://github.com/grafana/git-ui-sync-project/issues/1145
Closes https://github.com/grafana/git-ui-sync-project/issues/1146

## Notes for reviewers

- Setting is read at `pkg/registry/apis/provisioning/register.go` (`allowed_git_urls`), parsed by `repository.NewAllowlist` and enforced by `repository.URLValidator` (`apps/provisioning/pkg/repository/`). Behavior already covered by existing unit tests; no new tests.
- `conf/sample.ini` intentionally not touched (curated subset — only carries a couple of provisioning keys).

🤖 Generated with [Claude Code](https://claude.com/claude-code)