### PR TITLE
Search: let a flag-configured apiserver serve the search endpoints

### DIFF
--- a/pkg/extensions/enterprise_imports.go
+++ b/pkg/extensions/enterprise_imports.go
@@ -335,6 +335,7 @@ import (
 	_ "github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
 	_ "github.com/grafana/grafana/pkg/services/apiserver/options"
 	_ "github.com/grafana/grafana/pkg/services/apiserver/restcfg"
+	_ "github.com/grafana/grafana/pkg/services/apiserver/searchroutes"
 	_ "github.com/grafana/grafana/pkg/services/apiserver/standalone"
 	_ "github.com/grafana/grafana/pkg/services/apiserver/utils"
 	_ "github.com/grafana/grafana/pkg/services/auth"

--- a/pkg/services/apiserver/options/extra.go
+++ b/pkg/services/apiserver/options/extra.go
@@ -22,6 +22,11 @@ type ExtraOptions struct {
 	APIURL          string
 	Verbosity       int
 	RequestTimeout  time.Duration
+	// EnableSearchAPI is the flag equivalent of [grafana-apiserver]
+	// enable_search_api, for servers configured by flags rather than an ini file.
+	// Temporary, while the per-resource search endpoints are being built out; it
+	// goes away once kinds opt in through their manifest.
+	EnableSearchAPI bool
 }
 
 func NewExtraOptions() *ExtraOptions {
@@ -37,6 +42,8 @@ func (o *ExtraOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.ExternalAddress, "grafana-apiserver-host", o.ExternalAddress, "Host")
 	fs.StringVar(&o.APIURL, "grafana-apiserver-api-url", o.APIURL, "API URL")
 	fs.IntVar(&o.Verbosity, "verbosity", o.Verbosity, "Verbosity")
+	fs.BoolVar(&o.EnableSearchAPI, "grafana-apiserver-enable-search-api", o.EnableSearchAPI,
+		"Serve the per-resource search endpoints")
 }
 
 func (o *ExtraOptions) Validate() []error {

--- a/pkg/services/apiserver/options/storage.go
+++ b/pkg/services/apiserver/options/storage.go
@@ -29,6 +29,7 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/storage/unified/apistore"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
+	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 )
 
 type StorageType string
@@ -86,6 +87,13 @@ type StorageOptions struct {
 
 	// Support writing secrets inline
 	InlineSecrets secret.InlineSecureValueSupport
+
+	// SearchIndexClient is the search half of the client ApplyTo built, kept so
+	// the search endpoints do not build a second client with the same
+	// credentials. Deliberately the narrow interface: this is not a general back
+	// door to unified storage. Nil until ApplyTo runs, and for storage types that
+	// have no client.
+	SearchIndexClient resourcepb.ResourceIndexClient
 
 	// {resource}.{group} = 1|2|3|4
 	UnifiedStorageConfig map[string]setting.UnifiedStorageConfig
@@ -286,6 +294,8 @@ func (o *StorageOptions) ApplyTo(serverConfig *genericapiserver.RecommendedConfi
 		}
 		o.InlineSecrets = inlineSecureValueService
 	}
+
+	o.SearchIndexClient = unified
 
 	getter := apistore.NewRESTOptionsGetterForClient(unified, o.InlineSecrets, etcdOptions.StorageConfig, o.ConfigProvider)
 	serverConfig.RESTOptionsGetter = getter

--- a/pkg/services/apiserver/searchroutes/searchroutes.go
+++ b/pkg/services/apiserver/searchroutes/searchroutes.go
@@ -12,8 +12,8 @@ import (
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	searchapi "github.com/grafana/grafana/pkg/registry/apis/search"
 	"github.com/grafana/grafana/pkg/services/apiserver/builder"
-	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
+	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 )
 
 // namespacedScope is the manifest's spelling for a kind that lives in a
@@ -35,25 +35,29 @@ type groupResource struct {
 	resource string
 }
 
-// Build returns the search routes to mount, or nil when the endpoint is off.
+// Build returns the search routes to mount, or nil when the endpoint is off or
+// there is no client to serve it with.
 //
 // builders and installers are the two ways a kind reaches the apiserver; a route
 // is only mounted on a group version one of them actually serves.
 func Build(
-	cfg *setting.Cfg,
+	enabled bool,
 	tracer tracing.Tracer,
-	unified resource.ResourceClient,
+	index resourcepb.ResourceIndexClient,
 	builders []builder.APIGroupBuilder,
 	installers []appsdkapiserver.AppInstaller,
 ) []builder.GroupVersionRoutes {
-	if cfg == nil || !cfg.SectionWithEnvOverrides(searchapi.ConfigSection).Key(searchapi.ConfigKey).MustBool(false) {
+	// Whether the endpoint is on is read by the caller, because the two servers
+	// that mount it are configured differently: one from an ini file, one from
+	// flags.
+	if !enabled || index == nil {
 		return nil
 	}
 
 	// Search fields come from the compiled-in app manifests, the same
 	// declarations the index mapping is built from.
 	manifests := resource.AppManifests()
-	handler := searchapi.NewHandler(unified, resource.NewManifestBackedProvider(manifests), tracer)
+	handler := searchapi.NewHandler(index, resource.NewManifestBackedProvider(manifests), tracer)
 
 	served := servedGroupVersions(builders, installers)
 	byGroupVersion := map[schema.GroupVersion][]searchapi.Route{}

--- a/pkg/services/apiserver/searchroutes/searchroutes_test.go
+++ b/pkg/services/apiserver/searchroutes/searchroutes_test.go
@@ -11,9 +11,12 @@ import (
 	"k8s.io/kube-openapi/pkg/common"
 
 	"github.com/grafana/grafana/pkg/services/apiserver/builder"
-	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
+	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 )
+
+// Build only hands the client to the handler; nothing here calls it.
+type fakeClient struct{ resourcepb.ResourceIndexClient }
 
 type fakeBuilder struct {
 	gvs []schema.GroupVersion
@@ -26,18 +29,6 @@ func (b *fakeBuilder) UpdateAPIGroupInfo(*genericapiserver.APIGroupInfo, builder
 }
 func (b *fakeBuilder) GetOpenAPIDefinitions() common.GetOpenAPIDefinitions { return nil }
 func (b *fakeBuilder) AllowedV0Alpha1Resources() []string                  { return nil }
-
-func enabledCfg(t *testing.T, enabled bool) *setting.Cfg {
-	t.Helper()
-	cfg := setting.NewCfg()
-	section, err := cfg.Raw.NewSection("grafana-apiserver")
-	require.NoError(t, err)
-	if enabled {
-		_, err = section.NewKey("enable_search_api", "true")
-		require.NoError(t, err)
-	}
-	return cfg
-}
 
 // paths flattens the result so assertions read as the served endpoints do.
 func paths(routes []builder.GroupVersionRoutes) map[string][]string {
@@ -53,11 +44,12 @@ func paths(routes []builder.GroupVersionRoutes) map[string][]string {
 	return out
 }
 
-func TestBuild_DisabledByDefault(t *testing.T) {
-	b := &fakeBuilder{gvs: []schema.GroupVersion{{Group: "dashboard.grafana.app", Version: "v1"}}}
+func TestBuild_NothingMountedWhenOffOrUnusable(t *testing.T) {
+	b := []builder.APIGroupBuilder{&fakeBuilder{gvs: []schema.GroupVersion{{Group: "dashboard.grafana.app", Version: "v1"}}}}
 
-	assert.Nil(t, Build(enabledCfg(t, false), nil, nil, []builder.APIGroupBuilder{b}, nil))
-	assert.Nil(t, Build(nil, nil, nil, []builder.APIGroupBuilder{b}, nil))
+	assert.Nil(t, Build(false, nil, fakeClient{}, b, nil), "off")
+	// A server without a unified storage client has nothing to search.
+	assert.Nil(t, Build(true, nil, nil, b, nil), "no client")
 }
 
 func TestBuild_MountsAllowedKinds(t *testing.T) {
@@ -66,7 +58,7 @@ func TestBuild_MountsAllowedKinds(t *testing.T) {
 		{Group: "folder.grafana.app", Version: "v1"},
 	}}
 
-	got := paths(Build(enabledCfg(t, true), nil, nil, []builder.APIGroupBuilder{b}, nil))
+	got := paths(Build(true, nil, fakeClient{}, []builder.APIGroupBuilder{b}, nil))
 
 	assert.Equal(t, []string{"dashboards/search"}, got["dashboard.grafana.app/v1"])
 	assert.Equal(t, []string{"folders/search"}, got["folder.grafana.app/v1"])
@@ -77,7 +69,7 @@ func TestBuild_MountsAllowedKinds(t *testing.T) {
 func TestBuild_SkipsGroupVersionsNotServed(t *testing.T) {
 	b := &fakeBuilder{gvs: []schema.GroupVersion{{Group: "dashboard.grafana.app", Version: "v1"}}}
 
-	got := paths(Build(enabledCfg(t, true), nil, nil, []builder.APIGroupBuilder{b}, nil))
+	got := paths(Build(true, nil, fakeClient{}, []builder.APIGroupBuilder{b}, nil))
 
 	assert.Contains(t, got, "dashboard.grafana.app/v1")
 	assert.NotContains(t, got, "dashboard.grafana.app/v2", "v2 is a served version, but not served by this builder")
@@ -92,7 +84,7 @@ func TestBuild_SkipsKindsNotAllowed(t *testing.T) {
 	}
 	b := &fakeBuilder{gvs: notAllowed}
 
-	assert.Empty(t, paths(Build(enabledCfg(t, true), nil, nil, []builder.APIGroupBuilder{b}, nil)))
+	assert.Empty(t, paths(Build(true, nil, fakeClient{}, []builder.APIGroupBuilder{b}, nil)))
 }
 
 // Every served version of an allowed kind gets the endpoint, so a client can use
@@ -111,7 +103,7 @@ func TestBuild_MountsEveryServedVersion(t *testing.T) {
 	}
 	require.NotEmpty(t, dashboardGVs)
 
-	got := paths(Build(enabledCfg(t, true), nil, nil,
+	got := paths(Build(true, nil, fakeClient{},
 		[]builder.APIGroupBuilder{&fakeBuilder{gvs: dashboardGVs}}, nil))
 
 	assert.Len(t, got, len(dashboardGVs))

--- a/pkg/services/apiserver/service.go
+++ b/pkg/services/apiserver/service.go
@@ -35,6 +35,7 @@ import (
 	"github.com/grafana/grafana/pkg/middleware"
 	"github.com/grafana/grafana/pkg/modules"
 	"github.com/grafana/grafana/pkg/registry"
+	searchapi "github.com/grafana/grafana/pkg/registry/apis/search"
 	secret "github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
 	"github.com/grafana/grafana/pkg/services/apiserver/aggregatorrunner"
 	"github.com/grafana/grafana/pkg/services/apiserver/appinstaller"
@@ -369,7 +370,8 @@ func (s *service) start(ctx context.Context) error {
 
 	// Built once and used twice: the routes have to reach both the OpenAPI spec
 	// and the served WebServices, or the endpoint works but is undiscoverable.
-	searchRoutes := searchroutes.Build(s.cfg, s.tracing, s.unified, builders, s.appInstallers)
+	searchAPIEnabled := s.cfg.SectionWithEnvOverrides(searchapi.ConfigSection).Key(searchapi.ConfigKey).MustBool(false)
+	searchRoutes := searchroutes.Build(searchAPIEnabled, s.tracing, s.unified, builders, s.appInstallers)
 
 	// Add OpenAPI specs for each group+version (existing builders)
 	err = builder.SetupConfig(


### PR DESCRIPTION
The search endpoints are mounted centrally, but only where the ini setting can be read. The multi-tenant apiserver is configured by flags, and the two things `searchroutes.Build` needs were out of reach there: a client to search with, and a way to say the endpoints are on.

- `ExtraOptions` gains `EnableSearchAPI` and a `--grafana-apiserver-enable-search-api` flag, off by default. Temporary, like the ini setting — both go once kinds opt in through their manifest.
- `StorageOptions` keeps the search half of the client `ApplyTo` already builds, so nothing constructs a second one with the same credentials. Typed as `resourcepb.ResourceIndexClient`, not `resource.ResourceClient`: search needs four methods, and a field named `ResourceClient` would invite use as a general back door to unified storage.
- `Build` takes `enabled bool` instead of `*setting.Cfg`, so each server reads its own config source, and returns nil when there is no client.

No behaviour change: single-tenant reads the same ini setting, and nothing sets the new flag. The consumer is grafana/grafana-enterprise#12868, on a branch of the same name.

Epic: grafana/search-and-storage-team#869.