### PR TITLE
Dashboards: Fix time picker and variable overlays opening behind the canvas on narrow viewports

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardControlsChrome.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardControlsChrome.tsx
@@ -47,12 +47,14 @@ function getStyles(theme: GrafanaTheme2, headerHeight: number, visualRefreshEnab
         // scrollContainer in DashboardSidebarSplitter), so the bar must paint over that strip on
         // every viewport: opaque background plus its own paint order.
         position: 'relative',
-        zIndex: 1,
+        // Above the docked dashboard Sidebar (zIndex navBarFixed) and above the canvas. The time
+        // picker and the variable pickers render their overlays inside this wrapper, so whatever
+        // z-index it carries is the one they compete with: leaving it at 1 on narrow viewports
+        // traps those overlays in a low stacking context and the panels paint over them.
+        zIndex: theme.zIndex.sidemenu,
         background: visualRefreshEnabled ? theme.colors.background.page : theme.colors.background.canvas,
         [theme.breakpoints.up('md')]: {
           position: 'sticky',
-          // above docked dashboard edit Sidebar (zIndex navBarFixed); otherwise time picker popover stays under it.
-          zIndex: theme.zIndex.sidemenu,
           top: headerHeight,
         },
       },

--- a/public/app/features/dashboard-scene/scene/DashboardControlsChrome.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardControlsChrome.tsx
@@ -47,14 +47,16 @@ function getStyles(theme: GrafanaTheme2, headerHeight: number, visualRefreshEnab
         // scrollContainer in DashboardSidebarSplitter), so the bar must paint over that strip on
         // every viewport: opaque background plus its own paint order.
         position: 'relative',
-        // Above the docked dashboard Sidebar (zIndex navBarFixed) and above the canvas. The time
-        // picker and the variable pickers render their overlays inside this wrapper, so whatever
-        // z-index it carries is the one they compete with: leaving it at 1 on narrow viewports
-        // traps those overlays in a low stacking context and the panels paint over them.
-        zIndex: theme.zIndex.sidemenu,
+        // The canvas wrapper next to us is also z-index 1 and comes later in DOM order, so it wins the
+        // tie and paints over the time picker and variable overlays, which render inside this wrapper.
+        // Enough to clear it, and low enough to stay under the fixed app top bar that the controls row
+        // scrolls past on narrow viewports.
+        zIndex: 2,
         background: visualRefreshEnabled ? theme.colors.background.page : theme.colors.background.canvas,
         [theme.breakpoints.up('md')]: {
           position: 'sticky',
+          // above docked dashboard edit Sidebar (zIndex navBarFixed); otherwise time picker popover stays under it.
+          zIndex: theme.zIndex.sidemenu,
           top: headerHeight,
         },
       },


### PR DESCRIPTION
**What is this feature?**

Raises the `DashboardControlsChrome` wrapper from `z-index: 1` to `z-index: 2` at the base (narrow) viewport. The `md`-and-up block is untouched: it still switches to `position: sticky`, `top: headerHeight` and `theme.zIndex.sidemenu` exactly as before, so nothing changes at tablet width and above.

**Why do we need this feature?**

Below `md`, tapping the time picker looks like it does nothing: the range menu opens behind the dashboard.

The time picker and the variable pickers render their overlay *inside* this wrapper. The overlay is `position: fixed; z-index: 1050`, but a fixed box does not escape an ancestor stacking context, so the value the wrapper carries is the one the overlay effectively competes with.

The element that actually paints over it is not a panel. It is the dashboard canvas wrapper — a **later sibling of the chrome under the same parent, also `position: relative; z-index: 1`**. Equal z-index means the tie is broken by DOM order, and the canvas comes second, so it wins. The chrome therefore only has to beat `1`, and `2` does it.

**Who is this feature for?**

Anyone opening a dashboard on a phone, and embedded/kiosk surfaces at phone width.

**Which issue(s) does this PR fix?**:

None filed.

**Special notes for your reviewer:**

*Why a literal `2` and not a semantic token.* Raising the base value all the way to `theme.zIndex.sidemenu` (1020) was tried first and rejected. Two regressions appear, both confined to phone widths, because below `sm` the chrome is `position: relative` and the document scrolls:

1. The controls row travels up into the fixed app top bar (`header`, `z-index: 1000`, earlier in DOM order). At 1000 or 1020 the controls row completely covers the top bar while scrolling; at the original `1` the top bar stays intact.
2. `AppChrome`'s `sidebarContainerFloating` (the small-screen extension sidebar) sits at `navbarFixed + 1` = 1001, so a chrome at 1020 pokes through it.

There is no theme token in the gap between `1` and `1000` that fits this meaning — `activePanel` (999) is semantically wrong here — so a literal `2` with a comment explaining the DOM-order tie is the honest choice. It is deliberately the minimum: high enough to clear the sibling canvas, low enough to stay under the top bar the controls row scrolls past.

*Testing.* Verified against a live dashboard at 390x800 by driving the real picker button over CDP and checking what actually paints at the overlay's coordinates. At `z-index: 1` the overlay is covered; at `2` the range menu paints in front and is usable. A sweep of `2` / `999` / `1000` / `1020` all fix the popover identically, which is what pinned the culprit to the `z-index: 1` sibling rather than the panels. Scrolling was then re-checked at each value: only `2` leaves the app top bar and the floating sidebar intact. Widths 600px, 800px and 1400px are unaffected — they already resolved to `zIndex.sidemenu` and still do.

Overlays that legitimately sit above the controls (`dropdown` 1030, `modal` 1060) still do.

**Before**

<img width="1206" height="864" alt="IMG_0636" src="https://github.com/user-attachments/assets/1baa6b93-80e7-4087-aec1-a19d66716deb" />

**After**

<img width="574" height="572" alt="Bildschirmfoto 2026-07-30 um 13 35 24" src="https://github.com/user-attachments/assets/26566ed4-387e-4ccb-91b7-9a5100ea9068" />


Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.

Made with [Cursor](https://cursor.com)
