### PR TITLE
Unified Storage: Add migration_locking config to skip source table locks

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -2642,3 +2642,9 @@ webhook_rate_limit_rps = 0
 # If empty, defaults to "<data_dir>/unified-search/bleve" (see [paths] section).
 # Please note that sharing the same index_path between multiple running Grafana instances is not supported.
 index_path =
+
+# Lock source tables (e.g. dashboard) during migration to unified storage. Set to false only for
+# databases that prohibit table locks (e.g. Percona XtraDB Cluster with pxc_strict_mode=ENFORCING).
+# Warning: disabling can cause data drift and is only safe with no concurrent writers (single instance, no HA, no rolling upgrades).
+# Default: true.
+migration_locking = true

--- a/pkg/storage/unified/migrations/resource_migration.go
+++ b/pkg/storage/unified/migrations/resource_migration.go
@@ -61,6 +61,16 @@ type RunOptions struct {
 	UsingDistributor bool
 }
 
+// legacyTableRenameEnabled reports whether legacy tables should be renamed after migration.
+// Skipped when explicitly disabled, or when locking is off: the MySQL rename path needs the READ
+// lock to order the RENAME, so without it the rename would hang.
+func (r *MigrationRunner) legacyTableRenameEnabled() bool {
+	if r.cfg.DisableLegacyTableRename {
+		return false
+	}
+	return r.cfg.Raw.Section("unified_storage").Key("migration_locking").MustBool(true)
+}
+
 // Run executes the migration logic for all organizations.
 func (r *MigrationRunner) Run(ctx context.Context, sess *xorm.Session, mg *migrator.Migrator, opts RunOptions) error {
 	orgs, err := r.getAllOrgs(sess)
@@ -162,7 +172,7 @@ func (r *MigrationRunner) Run(ctx context.Context, sess *xorm.Session, mg *migra
 		}
 	}
 
-	if !r.cfg.DisableLegacyTableRename {
+	if r.legacyTableRenameEnabled() {
 		if err := r.tableRenamer.RenameTables(ctx, r.definition.RenameTables, unlockTables); err != nil {
 			return err
 		}
@@ -234,7 +244,7 @@ func (r *MigrationRunner) MigrateOrg(ctx context.Context, sess *xorm.Session, en
 	// On MySQL with rename, use a separate session so validator SELECTs don't hold
 	// shared MDL on sess's transaction (would deadlock with RENAME's exclusive MDL).
 	validationSess := sess
-	if opts.DriverName == migrator.MySQL && len(r.definition.RenameTables) > 0 && !r.cfg.DisableLegacyTableRename {
+	if opts.DriverName == migrator.MySQL && len(r.definition.RenameTables) > 0 && r.legacyTableRenameEnabled() {
 		validationSess = engine.NewSession()
 		defer validationSess.Close()
 	}

--- a/pkg/storage/unified/migrations/resource_migration_test.go
+++ b/pkg/storage/unified/migrations/resource_migration_test.go
@@ -80,10 +80,24 @@ func testDef(gr schema.GroupResource, lockTables, renameTables []string) Migrati
 
 func newRunner(t *testing.T, locker MigrationTableLocker, renamer MigrationTableRenamer, def MigrationDefinition) (*MigrationRunner, *fakeUnifiedMigrator) {
 	t.Helper()
+	return newRunnerCfg(t, setting.NewCfg(), locker, renamer, def)
+}
+
+func newRunnerCfg(t *testing.T, cfg *setting.Cfg, locker MigrationTableLocker, renamer MigrationTableRenamer, def MigrationDefinition) (*MigrationRunner, *fakeUnifiedMigrator) {
+	t.Helper()
 	fake := &fakeUnifiedMigrator{
 		migrateResponse: &resourcepb.BulkResponse{},
 	}
-	return NewMigrationRunner(fake, locker, renamer, setting.NewCfg(), def, nil), fake
+	return NewMigrationRunner(fake, locker, renamer, cfg, def, nil), fake
+}
+
+// cfgMigrationLockingDisabled: [unified_storage] migration_locking = false.
+func cfgMigrationLockingDisabled(t *testing.T) *setting.Cfg {
+	t.Helper()
+	cfg := setting.NewCfg()
+	_, err := cfg.Raw.Section("unified_storage").NewKey("migration_locking", "false")
+	require.NoError(t, err)
+	return cfg
 }
 
 func ensureOrg(t *testing.T, engine *xorm.Engine) {
@@ -240,6 +254,48 @@ func TestIntegrationRun_Rename(t *testing.T) {
 			} else {
 				assertNotRenamed(t, env.engine, tables[0])
 			}
+		})
+	}
+}
+
+// With migration_locking=false, rename must be skipped. On MySQL the lock-dependent rename would
+// otherwise hang until the deadline; the short waitDeadline makes a regression fail fast.
+func TestIntegrationRun_LockingDisabledSkipsRename(t *testing.T) {
+	env := newTestEnv(t)
+
+	cases := []struct {
+		name    string
+		skip    func() bool
+		renamer func() MigrationTableRenamer
+	}{
+		{
+			name:    "MySQL",
+			skip:    func() bool { return !db.IsTestDbMySQL() },
+			renamer: func() MigrationTableRenamer { return &mysqlTableRenamer{log: logger, waitDeadline: 2 * time.Second} },
+		},
+		{
+			name:    "Postgres",
+			skip:    func() bool { return !db.IsTestDbPostgres() },
+			renamer: func() MigrationTableRenamer { return &transactionalTableRenamer{log: logger} },
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.skip() {
+				t.Skip("skipped for this DB type")
+			}
+
+			table := uniqueTable(t, env.engine)
+			locker := newTableLocker(env.store, legacysql.NewDatabaseProvider(env.store), false)
+			require.IsType(t, &noopTableLocker{}, locker)
+
+			// RenameTables configured, but disabled locking must force renaming off.
+			def := testDef(dummyGR(), []string{table}, []string{table})
+			runner, _ := newRunnerCfg(t, cfgMigrationLockingDisabled(t), locker, tc.renamer(), def)
+			runMigration(t, env.engine, runner, env.engine.DriverName())
+
+			assertNotRenamed(t, env.engine, table)
 		})
 	}
 }

--- a/pkg/storage/unified/migrations/service.go
+++ b/pkg/storage/unified/migrations/service.go
@@ -48,8 +48,9 @@ func ProvideUnifiedStorageMigrationService(
 	lockingEnabled := cfg.Raw.Section("unified_storage").Key("migration_locking").MustBool(true)
 	if !lockingEnabled {
 		logger.Warn("unified_storage.migration_locking is disabled; source tables are NOT locked " +
-			"during migration. Concurrent writes may be missed (data drift). Only safe when no other " +
-			"writers exist during migration (single instance, no HA, no rolling upgrades).")
+			"during migration and legacy tables are NOT renamed. Concurrent writes may be missed " +
+			"(data drift). Only safe when no other writers exist during migration (single instance, " +
+			"no HA, no rolling upgrades).")
 	}
 	return &UnifiedStorageMigrationServiceImpl{
 		migrator:     migrator,

--- a/pkg/storage/unified/migrations/service.go
+++ b/pkg/storage/unified/migrations/service.go
@@ -45,9 +45,15 @@ func ProvideUnifiedStorageMigrationService(
 	registry *MigrationRegistry,
 	gcGate *resource.GCGate,
 ) contract.UnifiedStorageMigrationService {
+	lockingEnabled := cfg.Raw.Section("unified_storage").Key("migration_locking").MustBool(true)
+	if !lockingEnabled {
+		logger.Warn("unified_storage.migration_locking is disabled; source tables are NOT locked " +
+			"during migration. Concurrent writes may be missed (data drift). Only safe when no other " +
+			"writers exist during migration (single instance, no HA, no rolling upgrades).")
+	}
 	return &UnifiedStorageMigrationServiceImpl{
 		migrator:     migrator,
-		tableLocker:  newTableLocker(sqlStore, sql),
+		tableLocker:  newTableLocker(sqlStore, sql, lockingEnabled),
 		tableRenamer: newTableRenamer(string(sqlStore.GetDBType()), logger, cfg.RenameWaitDeadline),
 		cfg:          cfg,
 		sqlStore:     sqlStore,

--- a/pkg/storage/unified/migrations/table_locker.go
+++ b/pkg/storage/unified/migrations/table_locker.go
@@ -20,11 +20,15 @@ type MigrationTableLocker interface {
 	LockMigrationTables(ctx context.Context, sess *xorm.Session, tables []string) (func(context.Context) error, error)
 }
 
-// newTableLocker returns the appropriate locker for the database type.
-func newTableLocker(sqlStore db.DB, sql legacysql.LegacyDatabaseProvider) MigrationTableLocker {
+// newTableLocker returns the appropriate locker for the database type. When lockingEnabled is
+// false, source tables are not locked during migration (see [unified_storage] migration_locking).
+func newTableLocker(sqlStore db.DB, sql legacysql.LegacyDatabaseProvider, lockingEnabled bool) MigrationTableLocker {
+	if !lockingEnabled {
+		return &noopTableLocker{}
+	}
 	switch string(sqlStore.GetDBType()) {
 	case "sqlite3":
-		return &sqliteTableLocker{}
+		return &noopTableLocker{}
 	case "postgres":
 		return &postgresTableLocker{sql: sql}
 	default:
@@ -32,10 +36,10 @@ func newTableLocker(sqlStore db.DB, sql legacysql.LegacyDatabaseProvider) Migrat
 	}
 }
 
-// sqliteTableLocker implements a no-op table locker
-type sqliteTableLocker struct{}
+// noopTableLocker implements a no-op table locker (used for SQLite and when locking is disabled).
+type noopTableLocker struct{}
 
-func (l *sqliteTableLocker) LockMigrationTables(_ context.Context, _ *xorm.Session, _ []string) (func(context.Context) error, error) {
+func (l *noopTableLocker) LockMigrationTables(_ context.Context, _ *xorm.Session, _ []string) (func(context.Context) error, error) {
 	return func(context.Context) error { return nil }, nil
 }
 

--- a/pkg/storage/unified/migrations/table_locker_test.go
+++ b/pkg/storage/unified/migrations/table_locker_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/infra/db/dbtest"
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/storage/legacysql"
@@ -111,7 +112,7 @@ func TestIntegrationTableLocker(t *testing.T) {
 	default:
 		setup = lockerTestSetup{
 			name:   "sqlite",
-			locker: &sqliteTableLocker{},
+			locker: &noopTableLocker{},
 			sess:   func(t *testing.T) *xorm.Session { return nil },
 		}
 	}
@@ -169,5 +170,64 @@ func TestIntegrationTableLocker(t *testing.T) {
 		case <-time.After(10 * time.Second):
 			t.Fatal("Write is still blocked after unlock")
 		}
+	})
+}
+
+// TestIntegrationTableLockerDisabled verifies that with [unified_storage] migration_locking=false,
+// newTableLocker returns the no-op locker even on MySQL/Postgres, so source-table locks are never
+// issued and concurrent writers are not blocked during migration.
+func TestIntegrationTableLockerDisabled(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+	if db.IsTestDbSQLite() {
+		t.Skip("SQLite already uses the no-op locker")
+	}
+
+	dbstore := db.InitTestDB(t)
+	t.Cleanup(db.CleanupTestDB)
+	engine := dbstore.GetEngine()
+	ctx := context.Background()
+
+	// Locking disabled: expect the no-op locker regardless of the real DB type.
+	locker := newTableLocker(dbstore, legacysql.NewDatabaseProvider(dbstore), false)
+	require.IsType(t, &noopTableLocker{}, locker)
+
+	table := createTestTable(t, dbstore)
+	unlock, err := locker.LockMigrationTables(ctx, nil, []string{table})
+	require.NoError(t, err)
+	require.NotNil(t, unlock)
+
+	// A concurrent write must NOT be blocked, since no lock was taken.
+	writeErr := make(chan error, 1)
+	go func() {
+		_, werr := engine.Exec(fmt.Sprintf("UPDATE %s SET val=val WHERE id=-1", engine.Quote(table)))
+		writeErr <- werr
+	}()
+	select {
+	case err = <-writeErr:
+		require.NoError(t, err, "Write should succeed immediately when locking is disabled")
+	case <-time.After(5 * time.Second):
+		t.Fatal("Write was blocked despite locking being disabled")
+	}
+
+	require.NoError(t, unlock(ctx))
+}
+
+func TestNewTableLocker(t *testing.T) {
+	// FakeDB.GetDBType() returns "", hitting the default (MySQL) branch.
+	store := dbtest.NewFakeDB()
+
+	t.Run("locking enabled uses the DB-specific locker", func(t *testing.T) {
+		locker := newTableLocker(store, nil, true)
+		require.IsType(t, &mysqlTableLocker{}, locker)
+	})
+
+	t.Run("locking disabled uses the no-op locker regardless of DB type", func(t *testing.T) {
+		locker := newTableLocker(store, nil, false)
+		require.IsType(t, &noopTableLocker{}, locker)
+
+		unlock, err := locker.LockMigrationTables(context.Background(), nil, []string{"dashboard"})
+		require.NoError(t, err)
+		require.NotNil(t, unlock)
+		require.NoError(t, unlock(context.Background()))
 	})
 }


### PR DESCRIPTION
## What

Add `[unified_storage] migration_locking` config (default `true`). When `false`, source tables (e.g. `dashboard`) are not locked during the migration to unified storage, and legacy tables are not renamed.

## Why

`[database] migration_locking` only gates the migrator's advisory lock. The source-table locks (`LOCK TABLES ... READ` on MySQL, `LOCK TABLE ... IN SHARE MODE` on Postgres) were issued unconditionally, gated by no config. Some clustered databases prohibit these statements (e.g. Percona XtraDB Cluster with `pxc_strict_mode=ENFORCING`), making the migration fail on startup.

## How

- `newTableLocker` returns the no-op locker for all DB types when disabled.
- Flag read in `ProvideUnifiedStorageMigrationService`, mirroring the existing `[database]` read.
- Renamed `sqliteTableLocker` → `noopTableLocker` (reused for SQLite + disabled case).
- **Rename must also be skipped when locking is off.** The MySQL rename path (`waitForRenamesQueued`) depends on the READ lock being held so RENAMEs queue behind it; with no lock they run immediately and the renamer times out after `rename_wait_deadline`, failing startup. A single `legacyTableRenameEnabled()` check forces renaming off whenever locking is disabled.

## Safety

Skips all source-table locks and legacy-table renames. With concurrent writers this can cause data drift, so only safe with a single writer (no HA, no rolling upgrades). Logs a warning at startup when disabled.

## Tests

- `TestNewTableLocker` (unit): enabled → DB-specific locker; disabled → no-op.
- `TestIntegrationTableLockerDisabled` (MySQL + Postgres): no-op locker used, concurrent write not blocked.
- `TestIntegrationRun_LockingDisabledSkipsRename` (MySQL + Postgres): rename skipped with locking off; MySQL uses a short `waitDeadline` so a regression (the hang) fails fast.

Verified locally against real MySQL and Postgres; existing locker/rename suites still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)