### PR TITLE
Dashboard: Let plugins check mutation API availability and permissions

### DIFF
--- a/packages/grafana-data/src/context/plugins/RestrictedGrafanaApis.test.tsx
+++ b/packages/grafana-data/src/context/plugins/RestrictedGrafanaApis.test.tsx
@@ -16,6 +16,9 @@ const mockDashboardMutationAPI = {
   execute: jest.fn(async () => ({ success: true, changes: [] })),
   getPayloadSchema: jest.fn(() => null),
   getAvailableCommands: jest.fn(() => []),
+  isAvailable: jest.fn(() => false),
+  getSupportedCommands: jest.fn(() => []),
+  onAvailabilityChange: jest.fn(() => () => {}),
 };
 
 describe('RestrictedGrafanaApis', () => {

--- a/packages/grafana-data/src/context/plugins/RestrictedGrafanaApis.test.tsx
+++ b/packages/grafana-data/src/context/plugins/RestrictedGrafanaApis.test.tsx
@@ -17,7 +17,6 @@ const mockDashboardMutationAPI = {
   getPayloadSchema: jest.fn(() => null),
   getAvailableCommands: jest.fn(() => []),
   isAvailable: jest.fn(() => false),
-  getSupportedCommands: jest.fn(() => []),
   onAvailabilityChange: jest.fn(() => () => {}),
 };
 

--- a/packages/grafana-data/src/context/plugins/RestrictedGrafanaApis.test.tsx
+++ b/packages/grafana-data/src/context/plugins/RestrictedGrafanaApis.test.tsx
@@ -16,6 +16,7 @@ const mockDashboardMutationAPI = {
   execute: jest.fn(async () => ({ success: true, changes: [] })),
   getPayloadSchema: jest.fn(() => null),
   getAvailableCommands: jest.fn(() => []),
+  canExecute: jest.fn(() => ({ allowed: true }) as const),
   isAvailable: jest.fn(() => false),
   onAvailabilityChange: jest.fn(() => () => {}),
 };

--- a/packages/grafana-data/src/context/plugins/RestrictedGrafanaApis.tsx
+++ b/packages/grafana-data/src/context/plugins/RestrictedGrafanaApis.tsx
@@ -87,13 +87,18 @@ export interface DashboardMutationAPI {
    */
   getPayloadSchema(commandId: string): ZodSchema | null;
   /**
-   * The commands {@link execute} can dispatch right now. Empty when no dashboard
-   * is open.
+   * The commands that would run right now: implemented by this version, with a
+   * dashboard open, and permitted on it. Filtered by the same per-command checks
+   * {@link execute} applies, so a listed command is one you can use. Empty when no
+   * dashboard is open.
    *
-   * Listing a command means it exists and has a dashboard to act on, not that
-   * this call will succeed. Permissions, snapshot state, and feature toggles are
-   * evaluated per command inside {@link execute}, so a listed command can still
-   * come back with `success: false`.
+   * A command can still come back with `success: false` for a reason that is not
+   * knowable up front, such as a payload that fails validation.
+   *
+   * Absence does not say why, since a command is missing whether this version
+   * lacks it, no dashboard is open, the dashboard cannot be edited, or a feature
+   * toggle is off. Use {@link getPayloadSchema} for a version check and
+   * {@link canExecute} for the reason.
    */
   getAvailableCommands(): string[];
   /**
@@ -101,11 +106,10 @@ export interface DashboardMutationAPI {
    * them. Accepts one command or several, matched case-insensitively, and is
    * all-of: `allowed` is true only when every command passes.
    *
-   * This runs the same per-command checks {@link execute} runs, so it covers what
-   * {@link getAvailableCommands} cannot: no dashboard open, a command this
-   * version does not implement, insufficient permission, a snapshot, and
-   * commands behind a disabled feature toggle. Use it to decide whether to offer
-   * a capability at all.
+   * Equivalent to checking membership in {@link getAvailableCommands}, plus the
+   * part a list cannot carry: why each unusable command is unusable. Reach for
+   * this when you need to explain or log the reason, and for a plain decision use
+   * the list.
    *
    * An empty list is vacuously allowed, since there is nothing to check.
    */

--- a/packages/grafana-data/src/context/plugins/RestrictedGrafanaApis.tsx
+++ b/packages/grafana-data/src/context/plugins/RestrictedGrafanaApis.tsx
@@ -6,35 +6,90 @@ interface ZodSchema {
   safeParse: (data: unknown) => { success: boolean; data?: unknown; error?: unknown };
 }
 
+/** Outcome of a single {@link DashboardMutationAPI.execute} call. */
 export interface DashboardMutationResult {
+  /** Whether the command ran to completion. */
   success: boolean;
-  error?: string; // structured validation/execution error message
+  /** Why the command did not run, or failed. Set whenever `success` is false. */
+  error?: string;
+  /**
+   * What the command changed, one entry per mutated path. Always empty when
+   * `success` is false: a failed command leaves the dashboard untouched.
+   */
   changes: Array<{ path: string; previousValue: unknown; newValue: unknown }>;
+  /** Non-fatal problems. Present on successful calls too. */
   warnings?: string[];
-  data?: unknown; // command-specific return data
+  /** Command-specific payload, such as the read state for a read command. */
+  data?: unknown;
 }
 
+/**
+ * Command-based API for reading and modifying the dashboard the user has open.
+ *
+ * Commands are dispatched by name through {@link execute}. Each one declares a
+ * payload schema, a permission check, and whether it writes, so callers describe
+ * the change they want rather than manipulating dashboard internals.
+ *
+ * Writes apply to the open dashboard in place and are not persisted. Saving
+ * stays with the user, and there is no command for it.
+ *
+ * Two lifetimes are involved, which is the distinction most of these methods
+ * exist to make visible:
+ *
+ * - This API object is created when Grafana starts and is available for as long
+ *   as the app is running.
+ * - The commands it dispatches to belong to the open dashboard, and come and go
+ *   as the user navigates. {@link isAvailable} reports whether one is there.
+ *
+ * So holding this object means the host supports dashboard mutation, not that
+ * there is a dashboard to mutate.
+ */
 export interface DashboardMutationAPI {
-  execute(mutation: { type: string; payload: unknown }): Promise<DashboardMutationResult>;
-  getPayloadSchema(commandId: string): ZodSchema | null;
-  /** Commands that can be executed right now. Empty when no dashboard is loaded. */
-  getAvailableCommands(): string[];
   /**
-   * Whether a dashboard is loaded, so `execute` has something to mutate.
+   * Run a command against the open dashboard.
    *
-   * The API object itself exists for the lifetime of the app, so its presence
-   * says nothing about whether a dashboard is open.
+   * `type` is a command name, matched case-insensitively. `payload` must satisfy
+   * that command's schema, which {@link getPayloadSchema} returns.
+   *
+   * Rejects when no dashboard is open. Everything else resolves with
+   * `success: false` and an `error`: an unrecognised command name, a payload
+   * that fails validation, a command the current user or dashboard state does
+   * not permit, or an error raised while applying the change.
    */
+  execute(mutation: { type: string; payload: unknown }): Promise<DashboardMutationResult>;
+  /**
+   * The Zod schema a command's payload must satisfy, or `null` for a command
+   * this Grafana version does not implement. `commandId` is matched
+   * case-insensitively.
+   *
+   * Schemas come from the static command registry, so this answers with no
+   * dashboard open. That makes a `null` return usable as a version check, which
+   * {@link getAvailableCommands} cannot be, since it is empty either when the
+   * version lacks the command or when no dashboard is open.
+   */
+  getPayloadSchema(commandId: string): ZodSchema | null;
+  /**
+   * The commands {@link execute} can dispatch right now. Empty when no dashboard
+   * is open.
+   *
+   * Listing a command means it exists and has a dashboard to act on, not that
+   * this call will succeed. Permissions, snapshot state, and feature toggles are
+   * evaluated per command inside {@link execute}, so a listed command can still
+   * come back with `success: false`.
+   */
+  getAvailableCommands(): string[];
+  /** Whether a dashboard is open, so {@link execute} has something to act on. */
   isAvailable(): boolean;
   /**
-   * Subscribe to a dashboard being loaded or unloaded. Returns an unsubscribe
-   * function.
+   * Observe dashboards being opened and closed. Returns a function that
+   * unsubscribes.
    *
-   * Also called when one dashboard replaces another, with `true` again, since
-   * the commands now dispatch against a different dashboard.
+   * The listener receives the new availability, and is also called with `true`
+   * when one dashboard replaces another, since commands then dispatch against a
+   * different dashboard.
    *
-   * The listener is not called with the current state on subscribe; read
-   * `isAvailable()` for that.
+   * It is not called on subscribe. Read {@link isAvailable} for the current
+   * state.
    */
   onAvailabilityChange(listener: (isAvailable: boolean) => void): () => void;
 }

--- a/packages/grafana-data/src/context/plugins/RestrictedGrafanaApis.tsx
+++ b/packages/grafana-data/src/context/plugins/RestrictedGrafanaApis.tsx
@@ -27,12 +27,6 @@ export interface DashboardMutationAPI {
    */
   isAvailable(): boolean;
   /**
-   * Commands this Grafana version implements, whether or not a dashboard is
-   * loaded. Use for capability checks, and `getAvailableCommands` for what can
-   * run right now.
-   */
-  getSupportedCommands(): string[];
-  /**
    * Subscribe to a dashboard being loaded or unloaded. Returns an unsubscribe
    * function.
    *

--- a/packages/grafana-data/src/context/plugins/RestrictedGrafanaApis.tsx
+++ b/packages/grafana-data/src/context/plugins/RestrictedGrafanaApis.tsx
@@ -23,24 +23,6 @@ export interface DashboardMutationResult {
   data?: unknown;
 }
 
-/** A command that cannot run, and why. */
-export interface BlockedDashboardMutation {
-  /** The command name, upper-cased. */
-  command: string;
-  /**
-   * Why it cannot run: an unrecognised command name, no dashboard open,
-   * insufficient permission, a snapshot, or a disabled feature toggle.
-   */
-  reason: string;
-}
-
-/**
- * Whether a set of commands can run. Every blocked command is reported, not
- * just the first, so a caller gating on several commands learns all of the
- * reasons at once.
- */
-export type DashboardMutationPermission = { allowed: true } | { allowed: false; blocked: BlockedDashboardMutation[] };
-
 /**
  * Command-based API for reading and modifying the dashboard the user has open.
  *
@@ -111,9 +93,15 @@ export interface DashboardMutationAPI {
    * this when you need to explain or log the reason, and for a plain decision use
    * the list.
    *
+   * Every blocked command is reported, not just the first, and each `reason`
+   * names the cause: an unrecognised command, no dashboard open, insufficient
+   * permission, a snapshot, or a disabled feature toggle.
+   *
    * An empty list is vacuously allowed, since there is nothing to check.
    */
-  canExecute(commands: string | string[]): DashboardMutationPermission;
+  canExecute(
+    commands: string | string[]
+  ): { allowed: true } | { allowed: false; blocked: Array<{ command: string; reason: string }> };
   /** Whether a dashboard is open, so {@link execute} has something to act on. */
   isAvailable(): boolean;
   /**

--- a/packages/grafana-data/src/context/plugins/RestrictedGrafanaApis.tsx
+++ b/packages/grafana-data/src/context/plugins/RestrictedGrafanaApis.tsx
@@ -17,7 +17,32 @@ export interface DashboardMutationResult {
 export interface DashboardMutationAPI {
   execute(mutation: { type: string; payload: unknown }): Promise<DashboardMutationResult>;
   getPayloadSchema(commandId: string): ZodSchema | null;
+  /** Commands that can be executed right now. Empty when no dashboard is loaded. */
   getAvailableCommands(): string[];
+  /**
+   * Whether a dashboard is loaded, so `execute` has something to mutate.
+   *
+   * The API object itself exists for the lifetime of the app, so its presence
+   * says nothing about whether a dashboard is open.
+   */
+  isAvailable(): boolean;
+  /**
+   * Commands this Grafana version implements, whether or not a dashboard is
+   * loaded. Use for capability checks, and `getAvailableCommands` for what can
+   * run right now.
+   */
+  getSupportedCommands(): string[];
+  /**
+   * Subscribe to a dashboard being loaded or unloaded. Returns an unsubscribe
+   * function.
+   *
+   * Also called when one dashboard replaces another, with `true` again, since
+   * the commands now dispatch against a different dashboard.
+   *
+   * The listener is not called with the current state on subscribe; read
+   * `isAvailable()` for that.
+   */
+  onAvailabilityChange(listener: (isAvailable: boolean) => void): () => void;
 }
 
 interface RestrictedGrafanaApisContextTypeInternal {

--- a/packages/grafana-data/src/context/plugins/RestrictedGrafanaApis.tsx
+++ b/packages/grafana-data/src/context/plugins/RestrictedGrafanaApis.tsx
@@ -23,6 +23,24 @@ export interface DashboardMutationResult {
   data?: unknown;
 }
 
+/** A command that cannot run, and why. */
+export interface BlockedDashboardMutation {
+  /** The command name, upper-cased. */
+  command: string;
+  /**
+   * Why it cannot run: an unrecognised command name, no dashboard open,
+   * insufficient permission, a snapshot, or a disabled feature toggle.
+   */
+  reason: string;
+}
+
+/**
+ * Whether a set of commands can run. Every blocked command is reported, not
+ * just the first, so a caller gating on several commands learns all of the
+ * reasons at once.
+ */
+export type DashboardMutationPermission = { allowed: true } | { allowed: false; blocked: BlockedDashboardMutation[] };
+
 /**
  * Command-based API for reading and modifying the dashboard the user has open.
  *
@@ -78,6 +96,20 @@ export interface DashboardMutationAPI {
    * come back with `success: false`.
    */
   getAvailableCommands(): string[];
+  /**
+   * Whether the given commands would be permitted right now, without executing
+   * them. Accepts one command or several, matched case-insensitively, and is
+   * all-of: `allowed` is true only when every command passes.
+   *
+   * This runs the same per-command checks {@link execute} runs, so it covers what
+   * {@link getAvailableCommands} cannot: no dashboard open, a command this
+   * version does not implement, insufficient permission, a snapshot, and
+   * commands behind a disabled feature toggle. Use it to decide whether to offer
+   * a capability at all.
+   *
+   * An empty list is vacuously allowed, since there is nothing to check.
+   */
+  canExecute(commands: string | string[]): DashboardMutationPermission;
   /** Whether a dashboard is open, so {@link execute} has something to act on. */
   isAvailable(): boolean;
   /**

--- a/packages/grafana-data/src/index.ts
+++ b/packages/grafana-data/src/index.ts
@@ -474,8 +474,6 @@ export {
   type RestrictedGrafanaApisAllowList,
   type DashboardMutationAPI,
   type DashboardMutationResult,
-  type DashboardMutationPermission,
-  type BlockedDashboardMutation,
   RestrictedGrafanaApisContext,
   RestrictedGrafanaApisContextProvider,
   useRestrictedGrafanaApis,

--- a/packages/grafana-data/src/index.ts
+++ b/packages/grafana-data/src/index.ts
@@ -474,6 +474,8 @@ export {
   type RestrictedGrafanaApisAllowList,
   type DashboardMutationAPI,
   type DashboardMutationResult,
+  type DashboardMutationPermission,
+  type BlockedDashboardMutation,
   RestrictedGrafanaApisContext,
   RestrictedGrafanaApisContextProvider,
   useRestrictedGrafanaApis,

--- a/public/app/features/dashboard-scene/mutation-api/DashboardMutationClient.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/DashboardMutationClient.test.ts
@@ -1,0 +1,76 @@
+import { config } from '@grafana/runtime';
+
+import type { DashboardScene } from '../scene/DashboardScene';
+
+import { DashboardMutationClient } from './DashboardMutationClient';
+
+function createClient(canEditDashboard: boolean): DashboardMutationClient {
+  // canEditDashboard is the only scene member the permission checks read.
+  return new DashboardMutationClient({ canEditDashboard: () => canEditDashboard } as unknown as DashboardScene);
+}
+
+describe('DashboardMutationClient.canExecute', () => {
+  let originalNewLayouts: boolean | undefined;
+
+  beforeEach(() => {
+    originalNewLayouts = config.featureToggles.dashboardNewLayouts;
+    config.featureToggles.dashboardNewLayouts = true;
+  });
+
+  afterEach(() => {
+    config.featureToggles.dashboardNewLayouts = originalNewLayouts;
+  });
+
+  it('allows commands the current dashboard permits', () => {
+    expect(createClient(true).canExecute(['ADD_PANEL', 'REMOVE_PANEL'])).toEqual({ allowed: true });
+  });
+
+  it('matches command names case-insensitively', () => {
+    expect(createClient(true).canExecute(['add_panel'])).toEqual({ allowed: true });
+  });
+
+  it('names the command and the reason when the dashboard cannot be edited', () => {
+    expect(createClient(false).canExecute(['ADD_PANEL'])).toEqual({
+      allowed: false,
+      blocked: [{ command: 'ADD_PANEL', reason: expect.stringContaining('insufficient permissions') }],
+    });
+  });
+
+  // The gap a command list cannot express: layout commands are registered
+  // whatever the toggle says, and refused when it is off.
+  it('reports the feature toggle a command is waiting on', () => {
+    config.featureToggles.dashboardNewLayouts = false;
+
+    expect(createClient(true).canExecute(['ADD_ROW'])).toEqual({
+      allowed: false,
+      blocked: [{ command: 'ADD_ROW', reason: expect.stringContaining('dashboardNewLayouts') }],
+    });
+  });
+
+  it('reports a command this version does not implement', () => {
+    expect(createClient(true).canExecute(['TELEPORT_PANEL'])).toEqual({
+      allowed: false,
+      blocked: [{ command: 'TELEPORT_PANEL', reason: 'Unknown command type: TELEPORT_PANEL' }],
+    });
+  });
+
+  // Reporting only the first would make a caller fix one thing, retry, and
+  // discover the next.
+  it('reports every blocked command, not just the first', () => {
+    config.featureToggles.dashboardNewLayouts = false;
+
+    const permission = createClient(true).canExecute(['ADD_ROW', 'ADD_PANEL', 'TELEPORT_PANEL']);
+
+    expect(permission).toEqual({
+      allowed: false,
+      blocked: [
+        { command: 'ADD_ROW', reason: expect.stringContaining('dashboardNewLayouts') },
+        { command: 'TELEPORT_PANEL', reason: 'Unknown command type: TELEPORT_PANEL' },
+      ],
+    });
+  });
+
+  it('allows an empty list', () => {
+    expect(createClient(false).canExecute([])).toEqual({ allowed: true });
+  });
+});

--- a/public/app/features/dashboard-scene/mutation-api/DashboardMutationClient.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/DashboardMutationClient.test.ts
@@ -9,6 +9,41 @@ function createClient(canEditDashboard: boolean): DashboardMutationClient {
   return new DashboardMutationClient({ canEditDashboard: () => canEditDashboard } as unknown as DashboardScene);
 }
 
+describe('DashboardMutationClient.getAvailableCommands', () => {
+  let originalNewLayouts: boolean | undefined;
+
+  beforeEach(() => {
+    originalNewLayouts = config.featureToggles.dashboardNewLayouts;
+    config.featureToggles.dashboardNewLayouts = true;
+  });
+
+  afterEach(() => {
+    config.featureToggles.dashboardNewLayouts = originalNewLayouts;
+  });
+
+  it('lists the write commands on an editable dashboard', () => {
+    expect(createClient(true).getAvailableCommands()).toEqual(expect.arrayContaining(['ADD_PANEL', 'ADD_ROW']));
+  });
+
+  // A read-only dashboard, Grafana Home being the one users hit, used to
+  // advertise the full registry.
+  it('omits write commands on a dashboard that cannot be edited, and keeps reads', () => {
+    const commands = createClient(false).getAvailableCommands();
+
+    expect(commands).not.toContain('ADD_PANEL');
+    expect(commands).toContain('LIST_PANELS');
+  });
+
+  it('omits commands behind a disabled feature toggle', () => {
+    config.featureToggles.dashboardNewLayouts = false;
+
+    const commands = createClient(true).getAvailableCommands();
+
+    expect(commands).not.toContain('ADD_ROW');
+    expect(commands).toContain('ADD_PANEL');
+  });
+});
+
 describe('DashboardMutationClient.canExecute', () => {
   let originalNewLayouts: boolean | undefined;
 

--- a/public/app/features/dashboard-scene/mutation-api/DashboardMutationClient.ts
+++ b/public/app/features/dashboard-scene/mutation-api/DashboardMutationClient.ts
@@ -79,8 +79,15 @@ export class DashboardMutationClient implements MutationClient {
     }
   }
 
+  /**
+   * Commands that would run against this dashboard, filtered by the same
+   * permission check `execute` applies. A caller asking what it can do gets an
+   * answer it can act on, rather than the full registry.
+   */
   getAvailableCommands(): string[] {
-    return Array.from(this.commands.keys());
+    return Array.from(this.commands.entries())
+      .filter(([, registration]) => registration.canExecute(this.scene).allowed)
+      .map(([command]) => command);
   }
 
   /**

--- a/public/app/features/dashboard-scene/mutation-api/DashboardMutationClient.ts
+++ b/public/app/features/dashboard-scene/mutation-api/DashboardMutationClient.ts
@@ -17,7 +17,7 @@ import type { DashboardScene } from '../scene/DashboardScene';
 
 import { ALL_COMMANDS, validatePayload } from './commands/registry';
 import type { MutationCommand, MutationContext } from './commands/types';
-import type { MutationClient, MutationRequest, MutationResult } from './types';
+import type { BlockedMutation, MutationClient, MutationPermission, MutationRequest, MutationResult } from './types';
 
 type MutationHandler = (payload: unknown, context: MutationContext) => Promise<MutationResult>;
 
@@ -81,6 +81,32 @@ export class DashboardMutationClient implements MutationClient {
 
   getAvailableCommands(): string[] {
     return Array.from(this.commands.keys());
+  }
+
+  /**
+   * Run each command's permission check without executing anything, and report
+   * every command that is blocked rather than only the first. A caller gating a
+   * feature on several commands otherwise has to retry to discover the rest.
+   */
+  canExecute(commands: string[]): MutationPermission {
+    const blocked: BlockedMutation[] = [];
+
+    for (const command of commands) {
+      const type = command.toUpperCase();
+      const registration = this.commands.get(type);
+
+      if (!registration) {
+        blocked.push({ command: type, reason: `Unknown command type: ${type}` });
+        continue;
+      }
+
+      const permission = registration.canExecute(this.scene);
+      if (!permission.allowed) {
+        blocked.push({ command: type, reason: permission.error });
+      }
+    }
+
+    return blocked.length > 0 ? { allowed: false, blocked } : { allowed: true };
   }
 
   private registerCommand(cmd: MutationCommand): void {

--- a/public/app/features/dashboard-scene/mutation-api/README.md
+++ b/public/app/features/dashboard-scene/mutation-api/README.md
@@ -31,7 +31,7 @@ Scenes can overlap, so the client is replaced rather than cleared when one dashb
 ```typescript
 isAvailable(): boolean
 getAvailableCommands(): string[]
-canExecute(commands: string | string[]): DashboardMutationPermission
+canExecute(commands: string | string[]): { allowed: true } | { allowed: false; blocked: Array<{ command: string; reason: string }> }
 onAvailabilityChange(listener: (isAvailable: boolean) => void): () => void
 ```
 

--- a/public/app/features/dashboard-scene/mutation-api/README.md
+++ b/public/app/features/dashboard-scene/mutation-api/README.md
@@ -19,6 +19,19 @@ All responses share this shape:
 
 On failure, `success` is `false` and `error` contains a message. `changes` is always `[]` on failure.
 
+## Availability
+
+The API object exists for the lifetime of the app, so holding a reference to it does not mean a dashboard is open. Commands dispatch against a client that is created when a `DashboardScene` activates and destroyed when it deactivates.
+
+| Question                                       | Use                                                               |
+| ---------------------------------------------- | ----------------------------------------------------------------- |
+| Is a dashboard loaded right now?               | `isAvailable()`                                                   |
+| Does this Grafana version implement a command? | `getSupportedCommands()`                                          |
+| What can I execute right now?                  | `getAvailableCommands()`, empty when no dashboard is loaded       |
+| Tell me when that changes                      | `onAvailabilityChange(listener)`, returns an unsubscribe function |
+
+`execute` rejects when no dashboard is loaded.
+
 ---
 
 ## Layout

--- a/public/app/features/dashboard-scene/mutation-api/README.md
+++ b/public/app/features/dashboard-scene/mutation-api/README.md
@@ -23,12 +23,12 @@ On failure, `success` is `false` and `error` contains a message. `changes` is al
 
 The API object exists for the lifetime of the app, so holding a reference to it does not mean a dashboard is open. Commands dispatch against a client that is created when a `DashboardScene` activates and destroyed when it deactivates.
 
-| Question                                       | Use                                                               |
-| ---------------------------------------------- | ----------------------------------------------------------------- |
-| Is a dashboard loaded right now?               | `isAvailable()`                                                   |
-| Does this Grafana version implement a command? | `getSupportedCommands()`                                          |
-| What can I execute right now?                  | `getAvailableCommands()`, empty when no dashboard is loaded       |
-| Tell me when that changes                      | `onAvailabilityChange(listener)`, returns an unsubscribe function |
+| Question                                       | Use                                                                                                                   |
+| ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| Is a dashboard loaded right now?               | `isAvailable()`                                                                                                       |
+| What can I execute right now?                  | `getAvailableCommands()`, empty when no dashboard is loaded                                                           |
+| Tell me when that changes                      | `onAvailabilityChange(listener)`, returns an unsubscribe function                                                     |
+| Does this Grafana version implement a command? | `getPayloadSchema(command) !== null`, which reads the static command registry and so answers with no dashboard loaded |
 
 `execute` rejects when no dashboard is loaded.
 

--- a/public/app/features/dashboard-scene/mutation-api/README.md
+++ b/public/app/features/dashboard-scene/mutation-api/README.md
@@ -37,23 +37,25 @@ onAvailabilityChange(listener: (isAvailable: boolean) => void): () => void
 
 ### State
 
-|                          | No dashboard open | Dashboard open                               |
-| ------------------------ | ----------------- | -------------------------------------------- |
-| `isAvailable()`          | `false`           | `true`                                       |
-| `getAvailableCommands()` | `[]`              | every command the running version implements |
-| `execute`                | rejects           | resolves with a `success` result             |
+|                          | No dashboard open | Dashboard open                           |
+| ------------------------ | ----------------- | ---------------------------------------- |
+| `isAvailable()`          | `false`           | `true`                                   |
+| `getAvailableCommands()` | `[]`              | the commands permitted on this dashboard |
+| `execute`                | rejects           | resolves with a `success` result         |
 
 `execute` is the only member that rejects. Once a dashboard is open, a command that cannot run resolves with `success: false` instead.
 
 ### `getAvailableCommands`
 
-Reports what `execute` can dispatch, not what will succeed. When a dashboard is open the client registers every command the running version implements, unfiltered by permission, snapshot state, dashboard layout, or feature toggle. All four are evaluated per command inside `execute`, so a listed command can still come back with `success: false`.
+The commands that would run right now: implemented by this version, with a dashboard open, and permitted on it. Filtered by the same per-command checks `execute` applies, so a listed command is one you can use. A read-only dashboard such as Grafana Home lists its read commands and none of the writes, and a command behind a disabled feature toggle is not listed at all.
 
-Because the list is empty both when no dashboard is open and when the version does not implement a command, it cannot answer version questions on its own. Use `getPayloadSchema(command) !== null` for that: schemas come from the static command registry, so it answers with no dashboard open.
+A listed command can still come back with `success: false` for a reason that is not knowable up front, a payload that fails validation being the usual one.
+
+Absence does not say why. A command is missing whether this version lacks it, no dashboard is open, the dashboard cannot be edited, or a toggle is off. For a version check use `getPayloadSchema(command) !== null`, which reads the static registry and so answers with no dashboard open. For the reason, use `canExecute`.
 
 ### `canExecute`
 
-Runs the same per-command checks `execute` runs, without executing anything. This is the member to gate a feature on, because it covers everything `getAvailableCommands` cannot: no dashboard open, an unrecognised command, insufficient permission, a snapshot, and commands behind a disabled feature toggle.
+Answers the same question as checking membership in `getAvailableCommands`, and adds the part a list cannot carry: why a command is unusable. Reach for it when you need to explain, log, or surface the reason; a plain membership check is enough to decide.
 
 All-of over the commands given, and every blocked command is reported rather than only the first, so a caller does not have to fix one thing and retry to discover the next. An empty list is vacuously allowed.
 

--- a/public/app/features/dashboard-scene/mutation-api/README.md
+++ b/public/app/features/dashboard-scene/mutation-api/README.md
@@ -21,16 +21,54 @@ On failure, `success` is `false` and `error` contains a message. `changes` is al
 
 ## Availability
 
-The API object exists for the lifetime of the app, so holding a reference to it does not mean a dashboard is open. Commands dispatch against a client that is created when a `DashboardScene` activates and destroyed when it deactivates.
+Two objects with different lifetimes are involved:
 
-| Question                                       | Use                                                                                                                   |
-| ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| Is a dashboard loaded right now?               | `isAvailable()`                                                                                                       |
-| What can I execute right now?                  | `getAvailableCommands()`, empty when no dashboard is loaded                                                           |
-| Tell me when that changes                      | `onAvailabilityChange(listener)`, returns an unsubscribe function                                                     |
-| Does this Grafana version implement a command? | `getPayloadSchema(command) !== null`, which reads the static command registry and so answers with no dashboard loaded |
+- The **API object** is created at app boot and lives for as long as the app runs. Obtaining it means the host supports dashboard mutation, nothing more.
+- The **client** it dispatches to is created when a `DashboardScene` activates and destroyed when that scene deactivates. Commands need it.
 
-`execute` rejects when no dashboard is loaded.
+Scenes can overlap, so the client is replaced rather than cleared when one dashboard succeeds another, and a deactivating scene only clears the client it installed itself.
+
+```typescript
+isAvailable(): boolean
+getAvailableCommands(): string[]
+onAvailabilityChange(listener: (isAvailable: boolean) => void): () => void
+```
+
+### State
+
+|                          | No dashboard open | Dashboard open                               |
+| ------------------------ | ----------------- | -------------------------------------------- |
+| `isAvailable()`          | `false`           | `true`                                       |
+| `getAvailableCommands()` | `[]`              | every command the running version implements |
+| `execute`                | rejects           | resolves with a `success` result             |
+
+`execute` is the only member that rejects. Once a dashboard is open, a command that cannot run resolves with `success: false` instead.
+
+### `getAvailableCommands`
+
+Reports what `execute` can dispatch, not what will succeed. When a dashboard is open the client registers every command the running version implements, unfiltered by permission, snapshot state, dashboard layout, or feature toggle. All four are evaluated per command inside `execute`, so a listed command can still come back with `success: false`.
+
+Because the list is empty both when no dashboard is open and when the version does not implement a command, it cannot answer version questions on its own. Use `getPayloadSchema(command) !== null` for that: schemas come from the static command registry, so it answers with no dashboard open.
+
+### `onAvailabilityChange`
+
+Called with the new availability whenever a dashboard is opened or closed, and returns a function that unsubscribes.
+
+- It is **not** called on subscribe. Read `isAvailable()` for the current state.
+- It is called with `true` again when one dashboard replaces another, because commands then dispatch against a different dashboard.
+
+The client is installed slightly after the scene object appears, so a caller that has just triggered navigation should wait for a notification rather than assume the next tick:
+
+```typescript
+const unsubscribe = api.onAvailabilityChange((isAvailable) => {
+  if (isAvailable) {
+    // A dashboard is open, or a different one replaced the previous one.
+    refreshFromDashboard();
+  } else {
+    discardDashboardState();
+  }
+});
+```
 
 ---
 

--- a/public/app/features/dashboard-scene/mutation-api/README.md
+++ b/public/app/features/dashboard-scene/mutation-api/README.md
@@ -31,6 +31,7 @@ Scenes can overlap, so the client is replaced rather than cleared when one dashb
 ```typescript
 isAvailable(): boolean
 getAvailableCommands(): string[]
+canExecute(commands: string | string[]): DashboardMutationPermission
 onAvailabilityChange(listener: (isAvailable: boolean) => void): () => void
 ```
 
@@ -49,6 +50,21 @@ onAvailabilityChange(listener: (isAvailable: boolean) => void): () => void
 Reports what `execute` can dispatch, not what will succeed. When a dashboard is open the client registers every command the running version implements, unfiltered by permission, snapshot state, dashboard layout, or feature toggle. All four are evaluated per command inside `execute`, so a listed command can still come back with `success: false`.
 
 Because the list is empty both when no dashboard is open and when the version does not implement a command, it cannot answer version questions on its own. Use `getPayloadSchema(command) !== null` for that: schemas come from the static command registry, so it answers with no dashboard open.
+
+### `canExecute`
+
+Runs the same per-command checks `execute` runs, without executing anything. This is the member to gate a feature on, because it covers everything `getAvailableCommands` cannot: no dashboard open, an unrecognised command, insufficient permission, a snapshot, and commands behind a disabled feature toggle.
+
+All-of over the commands given, and every blocked command is reported rather than only the first, so a caller does not have to fix one thing and retry to discover the next. An empty list is vacuously allowed.
+
+```typescript
+const permission = api.canExecute(['ADD_PANEL', 'ADD_ROW']);
+
+if (!permission.allowed) {
+  // [{ command: 'ADD_ROW', reason: 'Layout management requires the "dashboardNewLayouts" feature toggle...' }]
+  hideDashboardEditing(permission.blocked);
+}
+```
 
 ### `onAvailabilityChange`
 

--- a/public/app/features/dashboard-scene/mutation-api/types.ts
+++ b/public/app/features/dashboard-scene/mutation-api/types.ts
@@ -28,9 +28,18 @@ interface MutationChange {
   newValue: unknown;
 }
 
+/** Why a set of commands cannot run, one entry per command that is blocked. */
+export type MutationPermission = { allowed: true } | { allowed: false; blocked: BlockedMutation[] };
+
+export interface BlockedMutation {
+  command: string;
+  reason: string;
+}
+
 export interface MutationClient {
   execute(mutation: MutationRequest): Promise<MutationResult>;
   getAvailableCommands(): string[];
+  canExecute(commands: string[]): MutationPermission;
 }
 
 type LayoutItemKind = GridLayoutItemKind | AutoGridLayoutItemKind;

--- a/public/app/features/plugins/components/restrictedGrafanaApis/dashboardMutation/dashboardMutationApi.test.ts
+++ b/public/app/features/plugins/components/restrictedGrafanaApis/dashboardMutation/dashboardMutationApi.test.ts
@@ -14,6 +14,7 @@ function createMockClient(): MutationClient {
       })
     ),
     getAvailableCommands: jest.fn(() => []),
+    canExecute: jest.fn(() => ({ allowed: true }) as const),
   };
 }
 
@@ -88,6 +89,41 @@ describe('dashboardMutationApi', () => {
 
       setDashboardMutationClientForTests(null);
       expect(dashboardMutationApi.isAvailable()).toBe(false);
+    });
+  });
+
+  describe('canExecute', () => {
+    it('reports every requested command as blocked when no dashboard is open', () => {
+      const permission = dashboardMutationApi.canExecute(['ADD_PANEL', 'REMOVE_PANEL']);
+
+      expect(permission).toEqual({
+        allowed: false,
+        blocked: [
+          { command: 'ADD_PANEL', reason: expect.stringContaining('No dashboard is currently open') },
+          { command: 'REMOVE_PANEL', reason: expect.stringContaining('No dashboard is currently open') },
+        ],
+      });
+    });
+
+    it('accepts a single command name', () => {
+      expect(dashboardMutationApi.canExecute('add_panel')).toEqual({
+        allowed: false,
+        blocked: [{ command: 'ADD_PANEL', reason: expect.any(String) }],
+      });
+    });
+
+    // All-of over nothing. Called with a tool's command list, an empty list means
+    // the caller needs no commands, not that it should be refused.
+    it('allows an empty list', () => {
+      expect(dashboardMutationApi.canExecute([])).toEqual({ allowed: true });
+    });
+
+    it('delegates to the client once a dashboard is open', () => {
+      const client = createMockClient();
+      setDashboardMutationClientForTests(client);
+
+      expect(dashboardMutationApi.canExecute(['ADD_PANEL'])).toEqual({ allowed: true });
+      expect(client.canExecute).toHaveBeenCalledWith(['ADD_PANEL']);
     });
   });
 

--- a/public/app/features/plugins/components/restrictedGrafanaApis/dashboardMutation/dashboardMutationApi.test.ts
+++ b/public/app/features/plugins/components/restrictedGrafanaApis/dashboardMutation/dashboardMutationApi.test.ts
@@ -91,19 +91,6 @@ describe('dashboardMutationApi', () => {
     });
   });
 
-  describe('getSupportedCommands', () => {
-    it('reports the commands this Grafana version implements', () => {
-      expect(dashboardMutationApi.getSupportedCommands()).toEqual(ALL_COMMANDS.map((cmd) => cmd.name));
-    });
-
-    // The distinction the two probes exist for: capability does not depend on a
-    // dashboard being open, availability does.
-    it('is populated with no dashboard loaded, where getAvailableCommands is empty', () => {
-      expect(dashboardMutationApi.getSupportedCommands().length).toBeGreaterThan(0);
-      expect(dashboardMutationApi.getAvailableCommands()).toEqual([]);
-    });
-  });
-
   describe('onAvailabilityChange', () => {
     it('notifies on load and unload', () => {
       const listener = jest.fn();

--- a/public/app/features/plugins/components/restrictedGrafanaApis/dashboardMutation/dashboardMutationApi.test.ts
+++ b/public/app/features/plugins/components/restrictedGrafanaApis/dashboardMutation/dashboardMutationApi.test.ts
@@ -1,5 +1,7 @@
 import { ALL_COMMANDS } from 'app/features/dashboard-scene/mutation-api';
 import type { MutationClient, MutationRequest, MutationResult } from 'app/features/dashboard-scene/mutation-api/types';
+import { createMutationClient } from 'app/features/dashboard-scene/scene/DashboardMutationClientSetter';
+import type { DashboardScene } from 'app/features/dashboard-scene/scene/DashboardScene';
 
 import { dashboardMutationApi, setDashboardMutationClientForTests } from './dashboardMutationApi';
 
@@ -74,6 +76,126 @@ describe('dashboardMutationApi', () => {
         const schema = dashboardMutationApi.getPayloadSchema(cmd.name);
         expect(schema).toBe(cmd.payloadSchema);
       }
+    });
+  });
+
+  describe('isAvailable', () => {
+    it('is false until a dashboard is loaded, and false again once it unloads', () => {
+      expect(dashboardMutationApi.isAvailable()).toBe(false);
+
+      setDashboardMutationClientForTests(createMockClient());
+      expect(dashboardMutationApi.isAvailable()).toBe(true);
+
+      setDashboardMutationClientForTests(null);
+      expect(dashboardMutationApi.isAvailable()).toBe(false);
+    });
+  });
+
+  describe('getSupportedCommands', () => {
+    it('reports the commands this Grafana version implements', () => {
+      expect(dashboardMutationApi.getSupportedCommands()).toEqual(ALL_COMMANDS.map((cmd) => cmd.name));
+    });
+
+    // The distinction the two probes exist for: capability does not depend on a
+    // dashboard being open, availability does.
+    it('is populated with no dashboard loaded, where getAvailableCommands is empty', () => {
+      expect(dashboardMutationApi.getSupportedCommands().length).toBeGreaterThan(0);
+      expect(dashboardMutationApi.getAvailableCommands()).toEqual([]);
+    });
+  });
+
+  describe('onAvailabilityChange', () => {
+    it('notifies on load and unload', () => {
+      const listener = jest.fn();
+      dashboardMutationApi.onAvailabilityChange(listener);
+
+      setDashboardMutationClientForTests(createMockClient());
+      expect(listener).toHaveBeenCalledWith(true);
+
+      setDashboardMutationClientForTests(null);
+      expect(listener).toHaveBeenCalledWith(false);
+      expect(listener).toHaveBeenCalledTimes(2);
+    });
+
+    it('stops notifying once unsubscribed', () => {
+      const listener = jest.fn();
+      const unsubscribe = dashboardMutationApi.onAvailabilityChange(listener);
+      unsubscribe();
+
+      setDashboardMutationClientForTests(createMockClient());
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('does not notify when the same client is set again', () => {
+      const client = createMockClient();
+      setDashboardMutationClientForTests(client);
+
+      const listener = jest.fn();
+      dashboardMutationApi.onAvailabilityChange(listener);
+      setDashboardMutationClientForTests(client);
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('keeps notifying the other listeners when one throws', () => {
+      const thrower = jest.fn(() => {
+        throw new Error('listener boom');
+      });
+      const listener = jest.fn();
+      jest.spyOn(console, 'error').mockImplementation(() => {});
+      const unsubscribeThrower = dashboardMutationApi.onAvailabilityChange(thrower);
+      const unsubscribeListener = dashboardMutationApi.onAvailabilityChange(listener);
+
+      setDashboardMutationClientForTests(createMockClient());
+
+      expect(thrower).toHaveBeenCalled();
+      expect(listener).toHaveBeenCalledWith(true);
+
+      unsubscribeThrower();
+      unsubscribeListener();
+      jest.mocked(console.error).mockRestore();
+    });
+  });
+
+  describe('scene teardown', () => {
+    const sceneA = {} as DashboardScene;
+    const sceneB = {} as DashboardScene;
+
+    // Two dashboard scenes can be mounted at once, and they do not deactivate in
+    // activation order. Clearing the client unconditionally on teardown left the
+    // surviving scene with no mutation API.
+    it('leaves the live client alone when a superseded scene deactivates', () => {
+      const teardownA = createMutationClient(sceneA);
+      const teardownB = createMutationClient(sceneB);
+
+      teardownA();
+
+      expect(dashboardMutationApi.isAvailable()).toBe(true);
+
+      teardownB();
+
+      expect(dashboardMutationApi.isAvailable()).toBe(false);
+    });
+
+    it('does not report the API as gone when a superseded scene deactivates', () => {
+      const listener = jest.fn();
+      const unsubscribe = dashboardMutationApi.onAvailabilityChange(listener);
+
+      const teardownA = createMutationClient(sceneA);
+      const teardownB = createMutationClient(sceneB);
+      // Both loads notify, the second because commands now dispatch against B.
+      expect(listener.mock.calls).toEqual([[true], [true]]);
+      listener.mockClear();
+
+      teardownA();
+
+      expect(listener).not.toHaveBeenCalled();
+
+      teardownB();
+
+      expect(listener.mock.calls).toEqual([[false]]);
+      unsubscribe();
     });
   });
 

--- a/public/app/features/plugins/components/restrictedGrafanaApis/dashboardMutation/dashboardMutationApi.ts
+++ b/public/app/features/plugins/components/restrictedGrafanaApis/dashboardMutation/dashboardMutationApi.ts
@@ -77,6 +77,22 @@ export const dashboardMutationApi: DashboardMutationAPI = {
   getAvailableCommands: () => {
     return _client?.getAvailableCommands() ?? [];
   },
+  canExecute: (commands) => {
+    const requested = typeof commands === 'string' ? [commands] : commands;
+    if (requested.length === 0) {
+      return { allowed: true };
+    }
+    if (!_client) {
+      return {
+        allowed: false,
+        blocked: requested.map((command) => ({
+          command: command.toUpperCase(),
+          reason: 'No dashboard is currently open, so there is nothing to mutate.',
+        })),
+      };
+    }
+    return _client.canExecute(requested);
+  },
   isAvailable: () => {
     return _client !== null;
   },

--- a/public/app/features/plugins/components/restrictedGrafanaApis/dashboardMutation/dashboardMutationApi.ts
+++ b/public/app/features/plugins/components/restrictedGrafanaApis/dashboardMutation/dashboardMutationApi.ts
@@ -80,9 +80,6 @@ export const dashboardMutationApi: DashboardMutationAPI = {
   isAvailable: () => {
     return _client !== null;
   },
-  getSupportedCommands: () => {
-    return ALL_COMMANDS.map((cmd) => cmd.name);
-  },
   onAvailabilityChange: (listener) => {
     _availabilityListeners.add(listener);
     return () => {

--- a/public/app/features/plugins/components/restrictedGrafanaApis/dashboardMutation/dashboardMutationApi.ts
+++ b/public/app/features/plugins/components/restrictedGrafanaApis/dashboardMutation/dashboardMutationApi.ts
@@ -18,25 +18,48 @@ import { provideMutationClientFactory } from 'app/features/dashboard-scene/scene
 import type { DashboardScene } from 'app/features/dashboard-scene/scene/DashboardScene';
 
 let _client: MutationClient | null = null;
+const _availabilityListeners = new Set<(isAvailable: boolean) => void>();
+
+function setClient(client: MutationClient | null): void {
+  if (_client === client) {
+    return;
+  }
+  _client = client;
+
+  for (const listener of _availabilityListeners) {
+    try {
+      listener(_client !== null);
+    } catch (error) {
+      console.error('Dashboard Mutation API availability listener threw:', error);
+    }
+  }
+}
 
 provideMutationClientFactory((sceneObject) => {
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const scene = sceneObject as unknown as DashboardScene;
 
+  let client: MutationClient | null = null;
   try {
-    _client = new DashboardMutationClient(scene);
+    client = new DashboardMutationClient(scene);
+    setClient(client);
   } catch (error) {
     console.error('Failed to register Dashboard Mutation API:', error);
   }
 
   return () => {
-    _client = null;
+    // Only the scene that owns the live client may clear it. Two dashboard
+    // scenes can be mounted at once, and without this the first to deactivate
+    // takes the survivor's client with it.
+    if (client && _client === client) {
+      setClient(null);
+    }
   };
 });
 
 /** @internal — exposed only for unit tests that need to inject a mock client. */
 export function setDashboardMutationClientForTests(client: MutationClient | null): void {
-  _client = client;
+  setClient(client);
 }
 
 export const dashboardMutationApi: DashboardMutationAPI = {
@@ -53,5 +76,17 @@ export const dashboardMutationApi: DashboardMutationAPI = {
   },
   getAvailableCommands: () => {
     return _client?.getAvailableCommands() ?? [];
+  },
+  isAvailable: () => {
+    return _client !== null;
+  },
+  getSupportedCommands: () => {
+    return ALL_COMMANDS.map((cmd) => cmd.name);
+  },
+  onAvailabilityChange: (listener) => {
+    _availabilityListeners.add(listener);
+    return () => {
+      _availabilityListeners.delete(listener);
+    };
   },
 };


### PR DESCRIPTION
**What is this feature?**

`getAvailableCommands()` now returns the commands that would actually run, filtered by the same per-command permission check `execute` applies. Before, it returned the whole registry, so Grafana Home advertised the full write surface while refusing all of it, and layout commands were advertised with `dashboardNewLayouts` off.

Plus three read-only additions:

| Method | Answers |
| --- | --- |
| `isAvailable()` | Is a dashboard open, so `execute` has something to act on? |
| `canExecute(commands)` | Same as membership in the list, plus which commands are unusable and why. |
| `onAvailabilityChange(listener)` | Tell me when a dashboard is opened or closed. Returns an unsubscribe function. |

And one fix: teardown cleared the client unconditionally. Two dashboard scenes can be mounted at once and they do not deactivate in activation order, so the first to deactivate took the survivor's client with it and left the API unavailable with a dashboard still open. Teardown is now guarded by client identity.

**Why do we need this feature?**

`dashboardMutationApi` is a module singleton created at app boot, so it lives as long as the app. What decides whether commands can run is the private `_client`, created and destroyed by `DashboardScene` activation, and nothing exposed it:

```ts
getAvailableCommands: () => _client?.getAvailableCommands() ?? [],
```

That is indirect enough that a consumer can reasonably reach for `!!api` instead, which is `true` on every page including those with no dashboard, and the mistake stays invisible until `execute` rejects. Reacting to a change was not possible at all, so a consumer waiting for a dashboard had to poll.

The command list had the same problem one level down: its name and every caller's instinct say "what can I do", while it returned "what exists here". Filtering makes the obvious usage correct instead of merely possible, which is cheaper than asking every consumer to learn a second method.

**Who is this feature for?**

Plugins allow-listed for the dashboard mutation restricted API, which need to decide whether to offer a dashboard-editing capability before calling `execute` and getting a rejection.

**Which issue(s) does this PR fix?**:

None filed.

**Special notes for your reviewer:**

- The filtering is a behaviour change, in the direction of the documented name. A consumer using a non-empty list as "is a dashboard open" still gets that, since read commands are always permitted.
- Its cost: absence no longer says why, since a command is missing whether the version lacks it, no dashboard is open, or it is not permitted. Version checks belong on `getPayloadSchema`, which reads the static registry, and `canExecute` carries the reason. Both documented on the interface and in the module README.
- Filtering and `canExecute` both reuse each command's existing `permission` predicate, documented as pure, so neither adds decision logic. `canEditDashboard()` reads `state.meta` and a config flag, so filtering per call is cheap.
- `canExecute` is all-of and reports every blocked command, not just the first. An empty list is vacuously allowed; say so if you would rather it were refused.
- `onAvailabilityChange` also fires with `true` when one dashboard replaces another. It is not called on subscribe; callers read `isAvailable()`.
- 21 new unit tests. The two teardown tests fail if the identity guard is reverted.
