### PR TITLE
PluginMeta: return null when meta load fails

### DIFF
--- a/packages/grafana-runtime/src/services/pluginMeta/apps.test.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/apps.test.ts
@@ -107,7 +107,7 @@ describe('when plugins.useMTPlugins flag is enabled', () => {
           expect(getLogger('grafana/runtime.plugins.meta').logWarning).toHaveBeenCalledTimes(1);
           expect(getLogger('grafana/runtime.plugins.meta').logWarning).toHaveBeenCalledWith(
             'PluginMeta: plugin meta yielded an empty result so Grafana is falling back to bootdata',
-            { pluginType: 'app' }
+            { pluginType: 'app', requestUrl: 'apis/plugins.grafana.app/v0alpha1/namespaces/default/metas' }
           );
         }
       );
@@ -120,7 +120,48 @@ describe('when plugins.useMTPlugins flag is enabled', () => {
           expect(getLogger('grafana/runtime.plugins.meta').logWarning).toHaveBeenCalledTimes(1);
           expect(getLogger('grafana/runtime.plugins.meta').logWarning).toHaveBeenCalledWith(
             'PluginMeta: plugin meta yielded an empty result so Grafana is falling back to bootdata',
-            { pluginType: 'app' }
+            { pluginType: 'app', requestUrl: 'apis/plugins.grafana.app/v0alpha1/namespaces/default/metas' }
+          );
+        }
+      );
+    });
+
+    describe('and initPluginMetas returns null because plugin metas failed to load', () => {
+      beforeEach(() => {
+        jest.resetAllMocks();
+        initPluginMetasMock.mockResolvedValue(null);
+        // can't use mockLogger here because that would cause a circular dependency between @grafana/runtime and @grafana/test-utils
+        setLogger('grafana/runtime.plugins.meta', {
+          logDebug: jest.fn(),
+          logError: jest.fn(),
+          logInfo: jest.fn(),
+          logMeasurement: jest.fn(),
+          logWarning: jest.fn(),
+        });
+      });
+
+      it.each([{ func: getAppPluginMetas }])(
+        `when func:$func is called then an error warning should be logged`,
+        async ({ func }) => {
+          await func();
+
+          expect(getLogger('grafana/runtime.plugins.meta').logWarning).toHaveBeenCalledTimes(1);
+          expect(getLogger('grafana/runtime.plugins.meta').logWarning).toHaveBeenCalledWith(
+            'PluginMeta: plugin meta failed to load so Grafana is falling back to bootdata',
+            { pluginType: 'app', requestUrl: 'apis/plugins.grafana.app/v0alpha1/namespaces/default/metas' }
+          );
+        }
+      );
+
+      it.each([{ func: getAppPluginMeta }, { func: isAppPluginInstalled }, { func: getAppPluginVersion }])(
+        `when func:$func is called then an error warning should be logged`,
+        async ({ func }) => {
+          await func('');
+
+          expect(getLogger('grafana/runtime.plugins.meta').logWarning).toHaveBeenCalledTimes(1);
+          expect(getLogger('grafana/runtime.plugins.meta').logWarning).toHaveBeenCalledWith(
+            'PluginMeta: plugin meta failed to load so Grafana is falling back to bootdata',
+            { pluginType: 'app', requestUrl: 'apis/plugins.grafana.app/v0alpha1/namespaces/default/metas' }
           );
         }
       );

--- a/packages/grafana-runtime/src/services/pluginMeta/apps.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/apps.ts
@@ -4,10 +4,10 @@ import { config } from '../../config';
 import { getFeatureFlagClient } from '../../internal/openFeature';
 import { FlagKeys } from '../../internal/openFeature/openfeature.gen';
 
-import { FALLBACK_TO_BOOTDATA_WARNING } from './constants';
+import { FALLBACK_TO_BOOTDATA_ERROR_WARNING, FALLBACK_TO_BOOTDATA_WARNING } from './constants';
 import { logPluginMetaDebug, logPluginMetaWarning } from './logging';
 import { getAppPluginMapper } from './mappers/mappers';
-import { initPluginMetas } from './plugins';
+import { getPluginMetasUrl, initPluginMetas } from './plugins';
 import type { AppPluginMetas, PluginMetasResponse } from './types';
 
 let apps: AppPluginMetas = {};
@@ -20,18 +20,19 @@ function setApps(input: AppPluginMetas) {
   apps = input;
 }
 
-function setMetas(metas: PluginMetasResponse) {
-  if (!metas.items.length) {
-    // something failed while trying to fetch plugin meta
-    // fallback to config.panels from bootdata
+function setMetas(metas: PluginMetasResponse | null) {
+  if (!metas?.items.length) {
+    // null means plugin meta failed to load, empty items means the API had nothing
+    const message = metas ? FALLBACK_TO_BOOTDATA_WARNING : FALLBACK_TO_BOOTDATA_ERROR_WARNING;
     // eslint-disable-next-line @grafana/no-config-apps
     setApps(config.apps);
-    logPluginMetaWarning(FALLBACK_TO_BOOTDATA_WARNING, { pluginType: PluginType.app });
+    logPluginMetaWarning(message, { pluginType: PluginType.app, requestUrl: getPluginMetasUrl() });
     return;
   }
 
   const mapper = getAppPluginMapper();
   setApps(mapper(metas));
+  logPluginMetaDebug('PluginMeta: initializing app plugins cache with meta values', {});
 }
 
 async function initAppPluginMetas(): Promise<void> {
@@ -44,7 +45,6 @@ async function initAppPluginMetas(): Promise<void> {
 
   const metas = await initPluginMetas();
   setMetas(metas);
-  logPluginMetaDebug('PluginMeta: initializing app plugins cache with meta values', {});
 }
 
 export async function getAppPluginMetas(): Promise<AppPluginConfig[]> {

--- a/packages/grafana-runtime/src/services/pluginMeta/constants.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/constants.ts
@@ -1,1 +1,2 @@
 export const FALLBACK_TO_BOOTDATA_WARNING = `PluginMeta: plugin meta yielded an empty result so Grafana is falling back to bootdata`;
+export const FALLBACK_TO_BOOTDATA_ERROR_WARNING = `PluginMeta: plugin meta failed to load so Grafana is falling back to bootdata`;

--- a/packages/grafana-runtime/src/services/pluginMeta/datasources.test.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/datasources.test.ts
@@ -6,7 +6,7 @@ import { FlagKeys } from '../../internal/openFeature/openfeature.gen';
 import { type BackendSrv, setBackendSrv } from '../backendSrv';
 import { setLogger } from '../logging/registry';
 
-import { FALLBACK_TO_BOOTDATA_WARNING } from './constants';
+import { FALLBACK_TO_BOOTDATA_ERROR_WARNING, FALLBACK_TO_BOOTDATA_WARNING } from './constants';
 import {
   getDatasourcePluginMeta,
   getDatasourcePluginMetas,
@@ -228,7 +228,75 @@ describe('when plugins.useMTPlugins flag is enabled', () => {
       expect(logPluginMetaWarningMock).toHaveBeenCalledTimes(1);
       expect(logPluginMetaWarningMock).toHaveBeenCalledWith(FALLBACK_TO_BOOTDATA_WARNING, {
         pluginType: 'datasource',
+        requestUrl: 'apis/plugins.grafana.app/v0alpha1/namespaces/default/metas',
       });
+    });
+  });
+
+  describe('and initPluginMetas returns null because plugin metas failed to load', () => {
+    const originalConfigDatasources = config.datasources;
+
+    beforeEach(() => {
+      setDatasourcePluginMetas({});
+      jest.resetAllMocks();
+      initPluginMetasMock.mockResolvedValue(null);
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      config.datasources = {
+        Prometheus: { type: 'prometheus', meta: prometheusMeta } as (typeof config.datasources)[string],
+      };
+    });
+
+    afterEach(() => {
+      config.datasources = originalConfigDatasources;
+    });
+
+    it('should fall back to bootdata when plugin metas fail to load', async () => {
+      const result = await getDatasourcePluginMetas();
+
+      expect(result).toEqual([prometheusMeta]);
+      expect(initPluginMetasMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('should log an error warning when falling back to bootdata', async () => {
+      await getDatasourcePluginMetas();
+
+      expect(logPluginMetaWarningMock).toHaveBeenCalledTimes(1);
+      expect(logPluginMetaWarningMock).toHaveBeenCalledWith(FALLBACK_TO_BOOTDATA_ERROR_WARNING, {
+        pluginType: 'datasource',
+        requestUrl: 'apis/plugins.grafana.app/v0alpha1/namespaces/default/metas',
+      });
+    });
+  });
+
+  describe('and refetchPluginMetas returns null because plugin metas failed to load', () => {
+    const originalConfigDatasources = config.datasources;
+
+    beforeEach(() => {
+      setDatasourcePluginMetas({});
+      jest.resetAllMocks();
+      refetchPluginMetasMock.mockResolvedValue(null);
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      config.datasources = {
+        Prometheus: { type: 'prometheus', meta: prometheusMeta } as (typeof config.datasources)[string],
+      };
+    });
+
+    afterEach(() => {
+      config.datasources = originalConfigDatasources;
+    });
+
+    it('refetchDatasourcePluginMetas should fall back to bootdata and log an error warning', async () => {
+      await refetchDatasourcePluginMetas();
+
+      expect(logPluginMetaWarningMock).toHaveBeenCalledTimes(1);
+      expect(logPluginMetaWarningMock).toHaveBeenCalledWith(FALLBACK_TO_BOOTDATA_ERROR_WARNING, {
+        pluginType: 'datasource',
+        requestUrl: 'apis/plugins.grafana.app/v0alpha1/namespaces/default/metas',
+      });
+
+      const result = await getDatasourcePluginMetas();
+      expect(result).toEqual([prometheusMeta]);
+      expect(initPluginMetasMock).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/grafana-runtime/src/services/pluginMeta/datasources.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/datasources.ts
@@ -5,10 +5,10 @@ import { getFeatureFlagClient } from '../../internal/openFeature';
 import { FlagKeys } from '../../internal/openFeature/openfeature.gen';
 import { getBackendSrv } from '../backendSrv';
 
-import { FALLBACK_TO_BOOTDATA_WARNING } from './constants';
+import { FALLBACK_TO_BOOTDATA_ERROR_WARNING, FALLBACK_TO_BOOTDATA_WARNING } from './constants';
 import { logPluginMetaDebug, logPluginMetaWarning } from './logging';
 import { getDatasourcePluginMapper } from './mappers/mappers';
-import { initPluginMetas, refetchPluginMetas } from './plugins';
+import { getPluginMetasUrl, initPluginMetas, refetchPluginMetas } from './plugins';
 import type { DatasourcePluginMetas, FrontendSettings, PluginMetasResponse } from './types';
 
 let datasources: DatasourcePluginMetas = {};
@@ -78,18 +78,19 @@ function extractFromConfig(
   return seen;
 }
 
-function setMetas(metas: PluginMetasResponse) {
-  if (!metas.items.length) {
-    // something failed while trying to fetch plugin meta
-    // fallback to config.datasources from bootdata
+function setMetas(metas: PluginMetasResponse | null) {
+  if (!metas?.items.length) {
+    // null means plugin meta failed to load, empty items means the API had nothing
+    const message = metas ? FALLBACK_TO_BOOTDATA_WARNING : FALLBACK_TO_BOOTDATA_ERROR_WARNING;
     // eslint-disable-next-line no-restricted-syntax
     setDatasourcesAndAliases(extractFromConfig(config.datasources));
-    logPluginMetaWarning(FALLBACK_TO_BOOTDATA_WARNING, { pluginType: PluginType.datasource });
+    logPluginMetaWarning(message, { pluginType: PluginType.datasource, requestUrl: getPluginMetasUrl() });
     return;
   }
 
   const mapper = getDatasourcePluginMapper();
   setDatasourcesAndAliases(mapper(metas));
+  logPluginMetaDebug('PluginMeta: initializing datasource plugins cache with meta values', {});
 }
 
 async function initDatasourcePluginMetas(): Promise<void> {
@@ -102,7 +103,6 @@ async function initDatasourcePluginMetas(): Promise<void> {
 
   const metas = await initPluginMetas();
   setMetas(metas);
-  logPluginMetaDebug('PluginMeta: initializing datasource plugins cache with meta values', {});
 }
 
 export async function getDatasourcePluginMetas(): Promise<DataSourcePluginMeta[]> {

--- a/packages/grafana-runtime/src/services/pluginMeta/panels.test.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/panels.test.ts
@@ -168,7 +168,7 @@ describe('when plugins.useMTPlugins flag is enabled', () => {
         expect(getLogger('grafana/runtime.plugins.meta').logWarning).toHaveBeenCalledTimes(1);
         expect(getLogger('grafana/runtime.plugins.meta').logWarning).toHaveBeenCalledWith(
           'PluginMeta: plugin meta yielded an empty result so Grafana is falling back to bootdata',
-          { pluginType: 'panel' }
+          { pluginType: 'panel', requestUrl: 'apis/plugins.grafana.app/v0alpha1/namespaces/default/metas' }
         );
       });
 
@@ -180,7 +180,52 @@ describe('when plugins.useMTPlugins flag is enabled', () => {
           expect(getLogger('grafana/runtime.plugins.meta').logWarning).toHaveBeenCalledTimes(1);
           expect(getLogger('grafana/runtime.plugins.meta').logWarning).toHaveBeenCalledWith(
             'PluginMeta: plugin meta yielded an empty result so Grafana is falling back to bootdata',
-            { pluginType: 'panel' }
+            { pluginType: 'panel', requestUrl: 'apis/plugins.grafana.app/v0alpha1/namespaces/default/metas' }
+          );
+        }
+      );
+    });
+
+    describe('and initPluginMetas or refetchPluginMetas returns null because plugin metas failed to load', () => {
+      beforeEach(() => {
+        jest.resetAllMocks();
+        // can't use mockLogger here because that would cause a circular dependency between @grafana/runtime and @grafana/test-utils
+        setLogger('grafana/runtime.plugins.meta', {
+          logDebug: jest.fn(),
+          logError: jest.fn(),
+          logInfo: jest.fn(),
+          logMeasurement: jest.fn(),
+          logWarning: jest.fn(),
+        });
+        initPluginMetasMock.mockResolvedValue(null);
+        refetchPluginMetasMock.mockResolvedValue(null);
+      });
+
+      it.each([
+        { func: getPanelPluginMetas },
+        { func: getListedPanelPluginMetas },
+        { func: getPanelPluginMetasMap },
+        { func: getListedPanelPluginIds },
+        { func: refetchPanelPluginMetas },
+      ])(`when func:$func is called then an error warning should be logged`, async ({ func }) => {
+        await func();
+
+        expect(getLogger('grafana/runtime.plugins.meta').logWarning).toHaveBeenCalledTimes(1);
+        expect(getLogger('grafana/runtime.plugins.meta').logWarning).toHaveBeenCalledWith(
+          'PluginMeta: plugin meta failed to load so Grafana is falling back to bootdata',
+          { pluginType: 'panel', requestUrl: 'apis/plugins.grafana.app/v0alpha1/namespaces/default/metas' }
+        );
+      });
+
+      it.each([{ func: getPanelPluginMeta }, { func: isPanelPluginInstalled }, { func: getPanelPluginVersion }])(
+        `when func:$func is called then an error warning should be logged`,
+        async ({ func }) => {
+          await func('');
+
+          expect(getLogger('grafana/runtime.plugins.meta').logWarning).toHaveBeenCalledTimes(1);
+          expect(getLogger('grafana/runtime.plugins.meta').logWarning).toHaveBeenCalledWith(
+            'PluginMeta: plugin meta failed to load so Grafana is falling back to bootdata',
+            { pluginType: 'panel', requestUrl: 'apis/plugins.grafana.app/v0alpha1/namespaces/default/metas' }
           );
         }
       );

--- a/packages/grafana-runtime/src/services/pluginMeta/panels.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/panels.ts
@@ -5,10 +5,10 @@ import { getFeatureFlagClient } from '../../internal/openFeature';
 import { FlagKeys } from '../../internal/openFeature/openfeature.gen';
 import { getBackendSrv } from '../backendSrv';
 
-import { FALLBACK_TO_BOOTDATA_WARNING } from './constants';
+import { FALLBACK_TO_BOOTDATA_ERROR_WARNING, FALLBACK_TO_BOOTDATA_WARNING } from './constants';
 import { logPluginMetaDebug, logPluginMetaWarning } from './logging';
 import { getPanelPluginMapper } from './mappers/mappers';
-import { initPluginMetas, refetchPluginMetas } from './plugins';
+import { getPluginMetasUrl, initPluginMetas, refetchPluginMetas } from './plugins';
 import type { PanelPluginMetas, PluginMetasResponse } from './types';
 
 let panels: PanelPluginMetas = {};
@@ -50,18 +50,19 @@ function setPanelsAndAliases(input: PanelPluginMetas) {
   panelsByAliasIDs = resolveAliasIDs(panels);
 }
 
-function setMetas(metas: PluginMetasResponse) {
-  if (!metas.items.length) {
-    // something failed while trying to fetch plugin meta
-    // fallback to config.panels from bootdata
+function setMetas(metas: PluginMetasResponse | null) {
+  if (!metas?.items.length) {
+    // null means plugin meta failed to load, empty items means the API had nothing
+    const message = metas ? FALLBACK_TO_BOOTDATA_WARNING : FALLBACK_TO_BOOTDATA_ERROR_WARNING;
     // eslint-disable-next-line @grafana/no-config-panels
     setPanelsAndAliases(config.panels);
-    logPluginMetaWarning(FALLBACK_TO_BOOTDATA_WARNING, { pluginType: PluginType.panel });
+    logPluginMetaWarning(message, { pluginType: PluginType.panel, requestUrl: getPluginMetasUrl() });
     return;
   }
 
   const mapper = getPanelPluginMapper();
   setPanelsAndAliases(mapper(metas));
+  logPluginMetaDebug('PluginMeta: initializing panel plugins cache with meta values', {});
 }
 
 async function initPanelPluginMetas(): Promise<void> {
@@ -74,7 +75,6 @@ async function initPanelPluginMetas(): Promise<void> {
 
   const metas = await initPluginMetas();
   setMetas(metas);
-  logPluginMetaDebug('PluginMeta: initializing panel plugins cache with meta values', {});
 }
 
 function getListedPanels(panels: PanelPluginMeta[]): PanelPluginMeta[] {

--- a/packages/grafana-runtime/src/services/pluginMeta/plugins.test.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/plugins.test.ts
@@ -7,6 +7,7 @@ import { getLogger, setLogger } from '../logging/registry';
 
 import {
   getPluginMetaFromCache,
+  getPluginMetasUrl,
   initPluginMetas,
   installPluginMeta,
   refetchPluginMeta,
@@ -22,6 +23,13 @@ beforeEach(() => {
   invalidateCachedPromisesCache();
   // can't use mockLogger here because that would cause a circular dependency between @grafana/runtime and @grafana/test-utils
   setLogger('grafana/runtime.utils.getCachedPromise', {
+    logDebug: jest.fn(),
+    logError: jest.fn(),
+    logInfo: jest.fn(),
+    logMeasurement: jest.fn(),
+    logWarning: jest.fn(),
+  });
+  setLogger('grafana/runtime.plugins.meta', {
     logDebug: jest.fn(),
     logError: jest.fn(),
     logInfo: jest.fn(),
@@ -53,8 +61,9 @@ describe('when plugins.useMTPlugins flag is enabled', () => {
 
       const response = await initPluginMetas();
 
-      expect(response.items).toHaveLength(1);
-      expect(response.items[0]).toBe(v0alpha1Meta);
+      expect(response).not.toBeNull();
+      expect(response?.items).toHaveLength(1);
+      expect(response?.items[0]).toBe(v0alpha1Meta);
       expect(global.fetch).toHaveBeenCalledTimes(1);
       expect(global.fetch).toHaveBeenCalledWith('apis/plugins.grafana.app/v0alpha1/namespaces/default/metas');
     });
@@ -93,7 +102,7 @@ describe('when plugins.useMTPlugins flag is enabled', () => {
   });
 
   describe('and errors occur', () => {
-    it('initPluginMetas should log when fetch fails', async () => {
+    it('initPluginMetas should log and resolve to null when fetch fails', async () => {
       global.fetch = jest
         .fn()
         .mockResolvedValueOnce({
@@ -107,10 +116,13 @@ describe('when plugins.useMTPlugins flag is enabled', () => {
           json: () => Promise.resolve({ items: [v0alpha1Meta] }),
         });
 
-      await initPluginMetas();
-      await initPluginMetas();
-      await initPluginMetas();
+      const first = await initPluginMetas();
+      const second = await initPluginMetas();
+      const third = await initPluginMetas();
 
+      expect(first).toBeNull();
+      expect(second).toStrictEqual({ items: [v0alpha1Meta] });
+      expect(third).toStrictEqual({ items: [v0alpha1Meta] });
       expect(global.fetch).toHaveBeenCalledTimes(2); // first + second (because first throws), third is cached
       expect(global.fetch).toHaveBeenCalledWith('apis/plugins.grafana.app/v0alpha1/namespaces/default/metas');
       const logErrorMock = getLogger('grafana/runtime.utils.getCachedPromise').logError as jest.Mock;
@@ -120,9 +132,16 @@ describe('when plugins.useMTPlugins flag is enabled', () => {
       expect(loggedError.message).toBe('getCachedPromise: Something failed while resolving a cached promise');
       expect(loggedError.cause).toStrictEqual(new Error('Failed to load plugin metas 500:Internal Server Error'));
       expect(context).toEqual({ key: expect.stringMatching(/^loadPluginMetas:-?\d+$/) });
+      const metaLogErrorMock = getLogger('grafana/runtime.plugins.meta').logError as jest.Mock;
+      expect(metaLogErrorMock).toHaveBeenCalledTimes(1);
+      expect(metaLogErrorMock).toHaveBeenCalledWith(expect.any(TracedError), {
+        requestUrl: 'apis/plugins.grafana.app/v0alpha1/namespaces/default/metas',
+        status: '500',
+        statusText: 'Internal Server Error',
+      });
     });
 
-    it('initPluginMetas should log when fetch rejects', async () => {
+    it('initPluginMetas should log and resolve to null when fetch rejects', async () => {
       global.fetch = jest
         .fn()
         .mockRejectedValueOnce(new Error('Network Error'))
@@ -132,10 +151,13 @@ describe('when plugins.useMTPlugins flag is enabled', () => {
           json: () => Promise.resolve({ items: [v0alpha1Meta] }),
         });
 
-      await initPluginMetas();
-      await initPluginMetas();
-      await initPluginMetas();
+      const first = await initPluginMetas();
+      const second = await initPluginMetas();
+      const third = await initPluginMetas();
 
+      expect(first).toBeNull();
+      expect(second).toStrictEqual({ items: [v0alpha1Meta] });
+      expect(third).toStrictEqual({ items: [v0alpha1Meta] });
       expect(global.fetch).toHaveBeenCalledTimes(2); // first + second (because first throws), third is cached
       expect(global.fetch).toHaveBeenCalledWith('apis/plugins.grafana.app/v0alpha1/namespaces/default/metas');
       const logErrorMock = getLogger('grafana/runtime.utils.getCachedPromise').logError as jest.Mock;
@@ -145,6 +167,57 @@ describe('when plugins.useMTPlugins flag is enabled', () => {
       expect(loggedError.message).toBe('getCachedPromise: Something failed while resolving a cached promise');
       expect(loggedError.cause).toStrictEqual(new Error('Network Error'));
       expect(context).toEqual({ key: expect.stringMatching(/^loadPluginMetas:-?\d+$/) });
+    });
+
+    it('refetchPluginMetas should resolve to null when fetch fails', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: false,
+        statusText: 'Internal Server Error',
+        status: 500,
+      });
+
+      const response = await refetchPluginMetas();
+
+      expect(response).toBeNull();
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('initPluginMetas should resolve to empty items when the API returns empty items', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ items: [] }),
+      });
+
+      const response = await initPluginMetas();
+
+      expect(response).toStrictEqual({ items: [] });
+    });
+
+    it('getPluginMetaFromCache should return null when fetch fails', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: false,
+        statusText: 'Internal Server Error',
+        status: 500,
+      });
+
+      const response = await getPluginMetaFromCache(v0alpha1Meta.spec.pluginJson.id);
+
+      expect(response).toBeNull();
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('refetchPluginMeta should return null when fetch fails', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: false,
+        statusText: 'Internal Server Error',
+        status: 500,
+      });
+
+      const response = await refetchPluginMeta(v0alpha1Meta.spec.pluginJson.id);
+
+      expect(response).toBeNull();
+      expect(global.fetch).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -325,7 +398,7 @@ describe('when plugins.useMTPlugins flag is disabled', () => {
     it('initPluginMetas should call loadPluginMetas and return correct result if response is ok', async () => {
       const response = await initPluginMetas();
 
-      expect(response.items).toHaveLength(0);
+      expect(response).toStrictEqual({ items: [] });
       expect(global.fetch).not.toHaveBeenCalled();
     });
   });
@@ -396,5 +469,11 @@ describe('when plugins.useMTPlugins flag is disabled', () => {
       expect(response).toStrictEqual(null);
       expect(global.fetch).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe('getPluginMetasUrl', () => {
+  it('should build the metas request url from api version and namespace', () => {
+    expect(getPluginMetasUrl()).toBe('apis/plugins.grafana.app/v0alpha1/namespaces/default/metas');
   });
 });

--- a/packages/grafana-runtime/src/services/pluginMeta/plugins.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/plugins.ts
@@ -13,16 +13,22 @@ function getApiVersion(): string {
   return 'v0alpha1';
 }
 
+export function getPluginMetasUrl(): string {
+  return `apis/plugins.grafana.app/${getApiVersion()}/namespaces/${config.namespace}/metas`;
+}
+
 async function loadPluginMetas(): Promise<PluginMetasResponse> {
   if (!getFeatureFlagClient().getBooleanValue(FlagKeys.PluginsUseMTPlugins, false)) {
     const result = { items: [] };
     return result;
   }
 
-  const metas = await fetch(`apis/plugins.grafana.app/${getApiVersion()}/namespaces/${config.namespace}/metas`);
+  const requestUrl = getPluginMetasUrl();
+  const metas = await fetch(requestUrl);
   if (!metas.ok) {
     const error = new Error(`Failed to load plugin metas ${metas.status}:${metas.statusText}`);
     logPluginMetaError('PluginMeta: failed to load plugin metas', error, {
+      requestUrl,
       status: String(metas.status),
       statusText: metas.statusText,
     });
@@ -88,13 +94,13 @@ export async function uninstallPluginMeta(pluginId: string): Promise<void> {
   }
 }
 
-export function initPluginMetas(): Promise<PluginMetasResponse> {
-  return getCachedPromise(loadPluginMetas, { defaultValue: { items: [] } });
+export function initPluginMetas(): Promise<PluginMetasResponse | null> {
+  return getCachedPromise<PluginMetasResponse | null>(loadPluginMetas, { defaultValue: null });
 }
 
-export function refetchPluginMetas(): Promise<PluginMetasResponse> {
-  return getCachedPromise(loadPluginMetas, {
-    defaultValue: { items: [] },
+export function refetchPluginMetas(): Promise<PluginMetasResponse | null> {
+  return getCachedPromise<PluginMetasResponse | null>(loadPluginMetas, {
+    defaultValue: null,
     invalidate: true,
   });
 }
@@ -105,7 +111,7 @@ export async function getPluginMetaFromCache(pluginId: string): Promise<Meta | n
   }
 
   const metas = await initPluginMetas();
-  const meta = metas.items.find((i) => i.spec.pluginJson.id === pluginId);
+  const meta = metas?.items.find((i) => i.spec.pluginJson.id === pluginId);
   return meta ? structuredClone(meta) : null;
 }
 
@@ -115,6 +121,6 @@ export async function refetchPluginMeta(pluginId: string): Promise<Meta | null> 
   }
 
   const metas = await refetchPluginMetas();
-  const meta = metas.items.find((i) => i.spec.pluginJson.id === pluginId);
+  const meta = metas?.items.find((i) => i.spec.pluginJson.id === pluginId);
   return meta ? structuredClone(meta) : null;
 }


### PR DESCRIPTION
**What is this feature?**

This PR makes a failed plugin metas fetch distinguishable from an empty result. `initPluginMetas` and `refetchPluginMetas` now resolve to `null` when the fetch fails, and an empty result keeps resolving to `{ items: [] }`. The bootdata fallbacks in `apps.ts`, `datasources.ts` and `panels.ts` log a distinct warning per case, and all fallback warnings plus the fetch error include a `requestUrl` in the log context. Also fixes the success debug log that used to claim the cache was initialized with meta values even when we had fallen back to bootdata.

```ts
function setMetas(metas: PluginMetasResponse | null) {
  if (!metas?.items.length) {
    // null means plugin meta failed to load, empty items means the API had nothing
    const message = metas ? FALLBACK_TO_BOOTDATA_WARNING : FALLBACK_TO_BOOTDATA_ERROR_WARNING;
    // eslint-disable-next-line @grafana/no-config-apps
    setApps(config.apps);
    logPluginMetaWarning(message, { pluginType: PluginType.app, requestUrl: getPluginMetasUrl() });
    return;
  }

  const mapper = getAppPluginMapper();
  setApps(mapper(metas));
  logPluginMetaDebug('PluginMeta: initializing app plugins cache with meta values', {});
}
```

**Why do we need this feature?**

So Faro logs can tell a failed metas fetch from a genuinely empty result

**Who is this feature for?**

Grafana devs

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Heads up for anyone with saved Faro queries on `PluginMeta: plugin meta yielded an empty result so Grafana is falling back to bootdata`: error-caused fallbacks now log `PluginMeta: plugin meta failed to load so Grafana is falling back to bootdata` instead, so the old message only counts genuinely empty results from now on.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
