### PR TITLE
Provisioning: Add ClassicAlerting resource parsing support to Git Sync

### DIFF
--- a/pkg/registry/apis/provisioning/resources/fileformat.go
+++ b/pkg/registry/apis/provisioning/resources/fileformat.go
@@ -13,7 +13,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer/yaml"
 
+	goyaml "go.yaml.in/yaml/v3"
+
 	"github.com/grafana/grafana-app-sdk/logging"
+	alertingv0alpha1 "github.com/grafana/grafana/apps/alerting/rules/pkg/apis/alerting/v0alpha1"
 	dashboard "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v0alpha1"
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
@@ -38,27 +41,92 @@ func ReadClassicResource(ctx context.Context, info *repository.FileInfo) (*unstr
 	// Strip BOMs from file data before parsing
 	cleanData := util.StripBOMFromBytes(info.Data)
 
-	// Try parsing as JSON
-	if cleanData[0] == '{' {
+	// Try parsing as JSON or YAML
+	if len(cleanData) > 0 && cleanData[0] == '{' {
 		err := json.Unmarshal(cleanData, &value)
 		if err != nil {
 			return nil, nil, "", err
 		}
-		// Strip BOMs from all string values in the parsed JSON
-		stripped, ok := util.StripBOMFromInterface(value).(map[string]any)
-		if !ok {
-			return nil, nil, "", fmt.Errorf("unexpected type after BOM stripping")
-		}
-		value = stripped
 	} else {
-		return nil, nil, "", fmt.Errorf("unable to read file")
+		err := goyaml.Unmarshal(cleanData, &value)
+		if err != nil {
+			return nil, nil, "", err
+		}
 	}
+	// Strip BOMs from all string values in the parsed data
+	stripped, ok := util.StripBOMFromInterface(value).(map[string]any)
+	if !ok {
+		return nil, nil, "", fmt.Errorf("unexpected type after BOM stripping")
+	}
+	value = stripped
 
 	// regular version headers exist
 	// TODO: do we intend on this checking Kind or kind? document reasoning.
 	if value["apiVersion"] != nil {
 		if value["kind"] != nil {
 			return nil, nil, "", ErrClassicResourceIsAlreadyK8sForm
+		}
+
+		// Handle classic provisioning apiVersion: 1 (e.g. Alerting provisioning)
+		var isApiVer1 bool
+		if fmt.Sprintf("%v", value["apiVersion"]) == "1" {
+			isApiVer1 = true
+		}
+
+		if isApiVer1 && (value["groups"] != nil || value["rules"] != nil) {
+			var name string
+			var ruleSpec map[string]any
+
+			if groups, ok := value["groups"].([]any); ok && len(groups) > 0 {
+				if grpMap, ok := groups[0].(map[string]any); ok {
+					if n, ok := grpMap["name"].(string); ok && n != "" {
+						name = n
+					}
+					if rules, ok := grpMap["rules"].([]any); ok && len(rules) > 0 {
+						if r, ok := rules[0].(map[string]any); ok {
+							ruleSpec = r
+						}
+					}
+				}
+			}
+			if ruleSpec == nil {
+				if rules, ok := value["rules"].([]any); ok && len(rules) > 0 {
+					if r, ok := rules[0].(map[string]any); ok {
+						ruleSpec = r
+					}
+				}
+			}
+			if ruleSpec == nil {
+				return nil, nil, "", ErrUnableToReadResourceBytes
+			}
+
+			kind := "AlertRule"
+			if _, ok := ruleSpec["record"]; ok {
+				kind = "RecordingRule"
+			}
+
+			gvk := &schema.GroupVersionKind{
+				Group:   alertingv0alpha1.APIGroup,
+				Version: alertingv0alpha1.APIVersion,
+				Kind:    kind,
+			}
+
+			if uid, ok := ruleSpec["uid"].(string); ok && uid != "" {
+				name = uid
+			} else if name == "" {
+				name = util.GenerateShortUID()
+			}
+
+			return &unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": gvk.GroupVersion().String(),
+					"kind":       gvk.Kind,
+					"metadata": map[string]any{
+						"name": name,
+					},
+					"spec": ruleSpec,
+				},
+			}, gvk, provisioning.ClassicAlerting, nil
 		}
 
 		logging.FromContext(ctx).Debug("TODO... likely a provisioning",

--- a/pkg/registry/apis/provisioning/resources/fileformat_test.go
+++ b/pkg/registry/apis/provisioning/resources/fileformat_test.go
@@ -85,6 +85,94 @@ spec:
 		require.NotNil(t, obj)
 	})
 
+	t.Run("load classic alerting json", func(t *testing.T) {
+		obj, gvk, classic, err := ReadClassicResource(context.Background(), &repository.FileInfo{
+			Data: []byte(`{
+			"apiVersion": 1,
+			"groups": [
+				{
+					"name": "cpu_rules",
+					"rules": [
+						{"uid": "cpu_high", "title": "High CPU Usage"}
+					]
+				}
+			]
+		}`),
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, provisioning.ClassicAlerting, classic)
+		require.Equal(t, &schema.GroupVersionKind{
+			Group:   "rules.alerting.grafana.app",
+			Version: "v0alpha1",
+			Kind:    "AlertRule",
+		}, gvk)
+		require.NotNil(t, obj)
+		require.NotEmpty(t, obj.GetName())
+	})
+
+	t.Run("load classic alerting yaml", func(t *testing.T) {
+		obj, gvk, classic, err := ReadClassicResource(context.Background(), &repository.FileInfo{
+			Data: []byte(`
+apiVersion: 1
+groups:
+  - name: my_rule_group
+    folder: my_first_folder
+    interval: 60s
+    rules:
+      - uid: my_id_1
+        title: my_first_rule
+        condition: A
+`),
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, provisioning.ClassicAlerting, classic)
+		require.Equal(t, &schema.GroupVersionKind{
+			Group:   "rules.alerting.grafana.app",
+			Version: "v0alpha1",
+			Kind:    "AlertRule",
+		}, gvk)
+		require.NotNil(t, obj)
+		require.Equal(t, "my_id_1", obj.GetName())
+		spec, ok := obj.Object["spec"].(map[string]any)
+		require.True(t, ok)
+		require.Equal(t, "my_first_rule", spec["title"])
+	})
+
+	t.Run("load classic recording rule yaml", func(t *testing.T) {
+		obj, gvk, classic, err := ReadClassicResource(context.Background(), &repository.FileInfo{
+			Data: []byte(`
+apiVersion: 1
+groups:
+  - name: rec_group
+    rules:
+      - record: metric:rate5m
+        expr: rate(http_requests_total[5m])
+`),
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, provisioning.ClassicAlerting, classic)
+		require.Equal(t, &schema.GroupVersionKind{
+			Group:   "rules.alerting.grafana.app",
+			Version: "v0alpha1",
+			Kind:    "RecordingRule",
+		}, gvk)
+		require.NotNil(t, obj)
+	})
+
+	t.Run("reject empty classic alerting groups yaml", func(t *testing.T) {
+		_, _, _, err := ReadClassicResource(context.Background(), &repository.FileInfo{
+			Data: []byte(`
+apiVersion: 1
+groups: []
+`),
+		})
+
+		require.Error(t, err)
+	})
+
 	t.Run("lint dashboard", func(t *testing.T) {
 		// Use an inline classic (v1) dashboard rather than reading a devenv file, which
 		// avoids a cross-package file dependency and stays a classic dashboard regardless


### PR DESCRIPTION
**What is this feature?**

Adds file format recognition and parsing support for file-provisioned Alert Rules (`apiVersion: 1` with `groups` or `rules`) to Grafana's Git Sync engine in `pkg/registry/apis/provisioning/resources/fileformat.go`.

**Why do we need this feature?**

A starting point to implement alerting for Git Sync - when it scans a repository containing alert rule provisioning files (YAML/JSON), it returns `ErrUnableToReadResourceBytes` because `ReadClassicResource` only recognized `Dashboard` resources.

**Who is this feature for?**

Grafana users looking to manage Alert Rules alongside Dashboards in Git-synced repositories (Observability as Code).

**Which issue(s) does this PR fix?**:

Related to epic #125453 and sub-task #125463 (GitSync support for rules).

**Special notes for your reviewer:**

- **First-time contributor note:** Hello! I am a first-time contributor and currently learning Go, looking forward for feedback to improve.
- Reuses existing `provisioning.ClassicAlerting` enum constant from `v0alpha1/classic.go`.
- Added parser support for both JSON and YAML classic alert provisioning files, mapping parsed alert definitions to `rules.alerting.grafana.app/v0alpha1` `AlertRule` and `RecordingRule` resources with `metadata.name`.
- Rejects empty/malformed alerting files (`groups: []`) with `ErrUnableToReadResourceBytes`.
- Includes passing unit test cases (`load classic alerting json`, `load classic alerting yaml`, `load classic recording rule yaml`, `reject empty classic alerting groups yaml`) in `fileformat_test.go`.
- **To run unit tests locally:** `go test ./pkg/registry/apis/provisioning/resources -run TestUtils -v`