### PR TITLE
Team: template raw read queries

### DIFF
--- a/pkg/services/team/teamimpl/queries/get_team_by_id.sql
+++ b/pkg/services/team/teamimpl/queries/get_team_by_id.sql
@@ -1,0 +1,26 @@
+SELECT
+  team.id AS id,
+  team.uid,
+  team.org_id,
+  team.name AS name,
+  team.email AS email,
+  team.external_uid AS external_uid,
+  team.is_provisioned AS is_provisioned,
+  (
+    SELECT COUNT(*)
+    FROM {{ .Ident .TeamMemberTable }} AS team_member
+    {{ if .FilteredUsers -}}
+    INNER JOIN {{ .Ident .UserTable }} AS member_user ON team_member.user_id = member_user.id
+    {{ end -}}
+    WHERE team_member.team_id = team.id
+    {{ if .FilteredUsers -}}
+      AND member_user.login NOT IN ({{ .ArgList .FilteredUsers }})
+    {{ end -}}
+  ) AS member_count
+FROM {{ .Ident .TeamTable }} AS team
+WHERE team.org_id = {{ .Arg .OrgID }}
+{{ if .ID -}}
+  AND team.id = {{ .Arg .ID }}
+{{ else -}}
+  AND team.uid = {{ .Arg .UID }}
+{{ end -}}

--- a/pkg/services/team/teamimpl/queries/get_team_ids_by_user.sql
+++ b/pkg/services/team/teamimpl/queries/get_team_ids_by_user.sql
@@ -1,0 +1,6 @@
+SELECT team_member.team_id, team.uid
+FROM {{ .Ident .TeamMemberTable }} AS team_member
+INNER JOIN {{ .Ident .TeamTable }} AS team ON team.id = team_member.team_id
+WHERE team_member.user_id = {{ .Arg .UserID }}
+  AND team_member.org_id = {{ .Arg .OrgID }}
+ORDER BY team_member.team_id ASC

--- a/pkg/services/team/teamimpl/queries/get_teams_by_user.sql
+++ b/pkg/services/team/teamimpl/queries/get_teams_by_user.sql
@@ -1,0 +1,22 @@
+SELECT
+  team.id AS id,
+  team.uid,
+  team.org_id,
+  team.name AS name,
+  team.email AS email,
+  team.external_uid AS external_uid,
+  team.is_provisioned AS is_provisioned,
+  (
+    SELECT COUNT(*)
+    FROM {{ .Ident .TeamMemberTable }} AS member_count_team_member
+    WHERE member_count_team_member.team_id = team.id
+  ) AS member_count
+FROM {{ .Ident .TeamTable }} AS team
+INNER JOIN {{ .Ident .TeamMemberTable }} AS team_member ON team.id = team_member.team_id
+WHERE team.org_id = {{ .Arg .OrgID }}
+  AND team_member.user_id = {{ .Arg .UserID }}
+{{ if .AccessTeamIDs -}}
+  AND team.id IN ({{ .ArgList .AccessTeamIDs }})
+{{ else if not .AccessAll -}}
+  AND 1 = 0
+{{ end -}}

--- a/pkg/services/team/teamimpl/queries/is_team_member.sql
+++ b/pkg/services/team/teamimpl/queries/is_team_member.sql
@@ -1,0 +1,5 @@
+SELECT 1
+FROM {{ .Ident .TeamMemberTable }}
+WHERE org_id = {{ .Arg .OrgID }}
+  AND team_id = {{ .Arg .TeamID }}
+  AND user_id = {{ .Arg .UserID }}

--- a/pkg/services/team/teamimpl/queries/search_teams.sql
+++ b/pkg/services/team/teamimpl/queries/search_teams.sql
@@ -1,0 +1,47 @@
+SELECT
+  team.id AS id,
+  team.uid,
+  team.org_id,
+  team.name AS name,
+  team.email AS email,
+  team.external_uid AS external_uid,
+  team.is_provisioned AS is_provisioned,
+  (
+    SELECT COUNT(*)
+    FROM {{ .Ident .TeamMemberTable }} AS team_member
+    {{ if .FilteredUsers -}}
+    INNER JOIN {{ .Ident .UserTable }} AS member_user ON team_member.user_id = member_user.id
+    {{ end -}}
+    WHERE team_member.team_id = team.id
+    {{ if .FilteredUsers -}}
+      AND member_user.login NOT IN ({{ .ArgList .FilteredUsers }})
+    {{ end -}}
+  ) AS member_count
+FROM {{ .Ident .TeamTable }} AS team
+WHERE team.org_id = {{ .Arg .OrgID }}
+{{ if .NamePattern -}}
+  AND team.name {{ if eq .DialectName "postgres" }}ILIKE{{ else }}LIKE{{ end }} {{ .Arg .NamePattern }}
+{{ end -}}
+{{ if .Name -}}
+  AND LOWER(team.name) = LOWER({{ .Arg .Name }})
+{{ end -}}
+{{ if .TeamIDs -}}
+  AND team.id IN ({{ .ArgList .TeamIDs }})
+{{ end -}}
+{{ if .UIDs -}}
+  AND team.uid IN ({{ .ArgList .UIDs }})
+{{ end -}}
+{{ if .AccessTeamIDs -}}
+  AND team.id IN ({{ .ArgList .AccessTeamIDs }})
+{{ else if not .AccessAll -}}
+  AND 1 = 0
+{{ end -}}
+ORDER BY
+{{ if .Sorts -}}
+  {{ range $index, $sort := .Sorts }}{{ if $index }}, {{ end }}{{ $sort }}{{ end }}
+{{ else -}}
+  team.name ASC
+{{ end -}}
+{{ if .Limit -}}
+LIMIT {{ .Arg .Limit }} OFFSET {{ .Arg .Offset }}
+{{ end -}}

--- a/pkg/services/team/teamimpl/store.go
+++ b/pkg/services/team/teamimpl/store.go
@@ -1,7 +1,6 @@
 package teamimpl
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -14,6 +13,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/team"
 	"github.com/grafana/grafana/pkg/services/team/teamdelete"
 	"github.com/grafana/grafana/pkg/storage/legacysql"
+	"github.com/grafana/grafana/pkg/storage/unified/sql/sqltemplate"
 	"github.com/grafana/grafana/pkg/util"
 )
 
@@ -68,35 +68,6 @@ func getFilteredUsers(signedInUser identity.Requester, hiddenUsers map[string]st
 	}
 
 	return filteredUsers
-}
-
-func getTeamMemberCount(dbHelper *legacysql.LegacyDatabaseHelper, filteredUsers []string) string {
-	qTeamMember := quoteTable(dbHelper, "team_member")
-	if len(filteredUsers) > 0 {
-		qUser := quoteTable(dbHelper, "user")
-		userRef := dbHelper.DB.GetDialect().Quote("user")
-		return `(SELECT COUNT(*) FROM ` + qTeamMember + `
-			INNER JOIN ` + qUser + ` ON team_member.user_id = ` + userRef + `.id
-			WHERE team_member.team_id = team.id AND ` + userRef + `.login NOT IN (?` +
-			strings.Repeat(",?", len(filteredUsers)-1) + ")" +
-			`) AS member_count `
-	}
-
-	return "(SELECT COUNT(*) FROM " + qTeamMember + " WHERE team_member.team_id = team.id) AS member_count "
-}
-
-func getTeamSelectSQLBase(dbHelper *legacysql.LegacyDatabaseHelper, filteredUsers []string) string {
-	qTeam := quoteTable(dbHelper, "team")
-	return `SELECT
-		team.id as id,
-		team.uid,
-		team.org_id,
-		team.name as name,
-		team.email as email,
-		team.external_uid as external_uid,
-		team.is_provisioned as is_provisioned, ` +
-		getTeamMemberCount(dbHelper, filteredUsers) +
-		` FROM ` + qTeam + ` AS team `
 }
 
 func (ss *xormStore) Create(ctx context.Context, cmd *team.CreateTeamCommand) (team.Team, error) {
@@ -228,6 +199,30 @@ func isTeamNameTaken(dbHelper *legacysql.LegacyDatabaseHelper, orgId int64, name
 	return false, nil
 }
 
+type searchTeamsQuery struct {
+	sqltemplate.SQLTemplate
+	TeamTable       string
+	TeamMemberTable string
+	UserTable       string
+	FilteredUsers   []string
+	OrgID           int64
+	NamePattern     string
+	Name            string
+	TeamIDs         []int64
+	UIDs            []string
+	AccessAll       bool
+	AccessTeamIDs   []any
+	Sorts           []string
+	Limit           int
+	Offset          int
+}
+
+func (q searchTeamsQuery) Validate() error { return nil }
+
+func accessControlQueryFields(filter ac.SQLFilter) (bool, []any) {
+	return strings.TrimSpace(filter.Where) == "1 = 1", filter.Args
+}
+
 func (ss *xormStore) Search(ctx context.Context, query *team.SearchTeamsQuery) (team.SearchTeamQueryResult, error) {
 	queryResult := team.SearchTeamQueryResult{
 		Teams: make([]*team.TeamDTO, 0),
@@ -239,68 +234,52 @@ func (ss *xormStore) Search(ctx context.Context, query *team.SearchTeamsQuery) (
 	}
 
 	err = dbHelper.DB.WithDbSession(ctx, func(sess *db.Session) error {
-		var sql bytes.Buffer
-		params := make([]any, 0)
-
 		filteredUsers := getFilteredUsers(query.SignedInUser, query.HiddenUsers)
-		for _, user := range filteredUsers {
-			params = append(params, user)
-		}
-
-		sql.WriteString(getTeamSelectSQLBase(dbHelper, filteredUsers))
-		sql.WriteString(` WHERE team.org_id = ?`)
-		params = append(params, query.OrgID)
-
-		if query.Query != "" {
-			like, param := dbHelper.DB.GetDialect().LikeOperator("team.name", true, query.Query, true)
-			sql.WriteString(" and " + like)
-			params = append(params, param)
-		}
-
-		if query.Name != "" {
-			sql.WriteString(` and LOWER(team.name) = LOWER(?)`)
-			params = append(params, query.Name)
-		}
-
-		if len(query.TeamIds) > 0 {
-			sql.WriteString(` and team.id IN (?` + strings.Repeat(",?", len(query.TeamIds)-1) + ")")
-			for _, id := range query.TeamIds {
-				params = append(params, id)
-			}
-		}
-
-		if len(query.UIDs) > 0 {
-			sql.WriteString(` and team.uid IN (?` + strings.Repeat(",?", len(query.UIDs)-1) + ")")
-			for _, uid := range query.UIDs {
-				params = append(params, uid)
-			}
-		}
-
 		acFilter, err := ac.Filter(query.SignedInUser, "team.id", "teams:id:", ac.ActionTeamsRead)
 		if err != nil {
 			return err
 		}
-		sql.WriteString(` and` + acFilter.Where)
-		params = append(params, acFilter.Args...)
+		accessAll, accessTeamIDs := accessControlQueryFields(acFilter)
 
-		if len(query.SortOpts) > 0 {
-			orderBy := ` order by `
-			for i := range query.SortOpts {
-				for j := range query.SortOpts[i].Filter {
-					orderBy += query.SortOpts[i].Filter[j].OrderBy() + ","
-				}
+		sorts := make([]string, 0, len(query.SortOpts))
+		for i := range query.SortOpts {
+			for j := range query.SortOpts[i].Filter {
+				sorts = append(sorts, query.SortOpts[i].Filter[j].OrderBy())
 			}
-			sql.WriteString(orderBy[:len(orderBy)-1])
-		} else {
-			sql.WriteString(` order by team.name asc`)
 		}
 
+		offset := 0
 		if query.Limit != 0 {
-			offset := query.Limit * (query.Page - 1)
-			sql.WriteString(dbHelper.DB.GetDialect().LimitOffset(int64(query.Limit), int64(offset)))
+			offset = query.Limit * (query.Page - 1)
+		}
+		namePattern := ""
+		if query.Query != "" {
+			namePattern = "%" + query.Query + "%"
 		}
 
-		if err := sess.SQL(sql.String(), params...).Find(&queryResult.Teams); err != nil {
+		sqlQuery := searchTeamsQuery{
+			SQLTemplate:     sqltemplate.New(dbHelper.DialectForDriver()),
+			TeamTable:       dbHelper.Table("team"),
+			TeamMemberTable: dbHelper.Table("team_member"),
+			UserTable:       dbHelper.Table("user"),
+			FilteredUsers:   filteredUsers,
+			OrgID:           query.OrgID,
+			NamePattern:     namePattern,
+			Name:            query.Name,
+			TeamIDs:         query.TeamIds,
+			UIDs:            query.UIDs,
+			AccessAll:       accessAll,
+			AccessTeamIDs:   accessTeamIDs,
+			Sorts:           sorts,
+			Limit:           query.Limit,
+			Offset:          offset,
+		}
+		rawSQL, err := sqltemplate.Execute(searchTeamsTemplate, sqlQuery)
+		if err != nil {
+			return err
+		}
+
+		if err := sess.SQL(rawSQL, sqlQuery.GetArgs()...).Find(&queryResult.Teams); err != nil {
 			return err
 		}
 
@@ -339,6 +318,19 @@ func (ss *xormStore) Search(ctx context.Context, query *team.SearchTeamsQuery) (
 	return queryResult, nil
 }
 
+type getTeamByIDQuery struct {
+	sqltemplate.SQLTemplate
+	TeamTable       string
+	TeamMemberTable string
+	UserTable       string
+	FilteredUsers   []string
+	OrgID           int64
+	ID              int64
+	UID             string
+}
+
+func (q getTeamByIDQuery) Validate() error { return nil }
+
 func (ss *xormStore) GetByID(ctx context.Context, query *team.GetTeamByIDQuery) (*team.TeamDTO, error) {
 	var queryResult *team.TeamDTO
 
@@ -353,26 +345,24 @@ func (ss *xormStore) GetByID(ctx context.Context, query *team.GetTeamByIDQuery) 
 	}
 
 	err = dbHelper.DB.WithDbSession(ctx, func(sess *db.Session) error {
-		var sql bytes.Buffer
-		params := make([]any, 0)
-
 		filteredUsers := getFilteredUsers(query.SignedInUser, query.HiddenUsers)
-		sql.WriteString(getTeamSelectSQLBase(dbHelper, filteredUsers))
-		for _, user := range filteredUsers {
-			params = append(params, user)
+		sqlQuery := getTeamByIDQuery{
+			SQLTemplate:     sqltemplate.New(dbHelper.DialectForDriver()),
+			TeamTable:       dbHelper.Table("team"),
+			TeamMemberTable: dbHelper.Table("team_member"),
+			UserTable:       dbHelper.Table("user"),
+			FilteredUsers:   filteredUsers,
+			OrgID:           query.OrgID,
+			ID:              query.ID,
+			UID:             query.UID,
 		}
-
-		// Prioritize ID over UID
-		if query.ID != 0 {
-			sql.WriteString(` WHERE team.org_id = ? and team.id = ?`)
-			params = append(params, query.OrgID, query.ID)
-		} else {
-			sql.WriteString(` WHERE team.org_id = ? and team.uid = ?`)
-			params = append(params, query.OrgID, query.UID)
+		rawSQL, err := sqltemplate.Execute(getTeamByIDTemplate, sqlQuery)
+		if err != nil {
+			return err
 		}
 
 		var t team.TeamDTO
-		exists, err := sess.SQL(sql.String(), params...).Get(&t)
+		exists, err := sess.SQL(rawSQL, sqlQuery.GetArgs()...).Get(&t)
 
 		if err != nil {
 			return err
@@ -391,6 +381,18 @@ func (ss *xormStore) GetByID(ctx context.Context, query *team.GetTeamByIDQuery) 
 	return queryResult, nil
 }
 
+type getTeamsByUserQuery struct {
+	sqltemplate.SQLTemplate
+	TeamTable       string
+	TeamMemberTable string
+	OrgID           int64
+	UserID          int64
+	AccessAll       bool
+	AccessTeamIDs   []any
+}
+
+func (q getTeamsByUserQuery) Validate() error { return nil }
+
 // GetTeamsByUser is used by the Guardian when checking a users' permissions
 func (ss *xormStore) GetByUser(ctx context.Context, query *team.GetTeamsByUserQuery) ([]*team.TeamDTO, error) {
 	queryResult := make([]*team.TeamDTO, 0)
@@ -400,29 +402,43 @@ func (ss *xormStore) GetByUser(ctx context.Context, query *team.GetTeamsByUserQu
 	}
 
 	err = dbHelper.DB.WithDbSession(ctx, func(sess *db.Session) error {
-		var sql bytes.Buffer
-		var params []any
-		params = append(params, query.OrgID, query.UserID)
-
-		sql.WriteString(getTeamSelectSQLBase(dbHelper, []string{}))
-		sql.WriteString(` INNER JOIN ` + quoteTable(dbHelper, "team_member") + ` on team.id = team_member.team_id`)
-		sql.WriteString(` WHERE team.org_id = ? and team_member.user_id = ?`)
-
 		acFilter, err := ac.Filter(query.SignedInUser, "team.id", "teams:id:", ac.ActionTeamsRead)
 		if err != nil {
 			return err
 		}
-		sql.WriteString(` and` + acFilter.Where)
-		params = append(params, acFilter.Args...)
+		accessAll, accessTeamIDs := accessControlQueryFields(acFilter)
 
-		err = sess.SQL(sql.String(), params...).Find(&queryResult)
-		return err
+		sqlQuery := getTeamsByUserQuery{
+			SQLTemplate:     sqltemplate.New(dbHelper.DialectForDriver()),
+			TeamTable:       dbHelper.Table("team"),
+			TeamMemberTable: dbHelper.Table("team_member"),
+			OrgID:           query.OrgID,
+			UserID:          query.UserID,
+			AccessAll:       accessAll,
+			AccessTeamIDs:   accessTeamIDs,
+		}
+		rawSQL, err := sqltemplate.Execute(getTeamsByUserTemplate, sqlQuery)
+		if err != nil {
+			return err
+		}
+
+		return sess.SQL(rawSQL, sqlQuery.GetArgs()...).Find(&queryResult)
 	})
 	if err != nil {
 		return nil, err
 	}
 	return queryResult, nil
 }
+
+type getTeamIDsByUserQuery struct {
+	sqltemplate.SQLTemplate
+	TeamTable       string
+	TeamMemberTable string
+	UserID          int64
+	OrgID           int64
+}
+
+func (q getTeamIDsByUserQuery) Validate() error { return nil }
 
 // GetIDsByUser returns a list of team IDs for the given user
 func (ss *xormStore) GetIDsByUser(ctx context.Context, query *team.GetTeamIDsByUserQuery) ([]int64, []string, error) {
@@ -435,13 +451,19 @@ func (ss *xormStore) GetIDsByUser(ctx context.Context, query *team.GetTeamIDsByU
 	}
 
 	err = dbHelper.DB.WithDbSession(ctx, func(sess *db.Session) error {
-		qTeamMember := quoteTable(dbHelper, "team_member")
-		qTeam := quoteTable(dbHelper, "team")
-		rows, err := sess.QueryRows(`SELECT tm.team_id, team.uid
-			FROM `+qTeamMember+` AS tm
-			JOIN `+qTeam+` ON team.id = tm.team_id
-			WHERE tm.user_id=? AND tm.org_id=?
-			ORDER BY tm.team_id asc`, query.UserID, query.OrgID)
+		sqlQuery := getTeamIDsByUserQuery{
+			SQLTemplate:     sqltemplate.New(dbHelper.DialectForDriver()),
+			TeamTable:       dbHelper.Table("team"),
+			TeamMemberTable: dbHelper.Table("team_member"),
+			UserID:          query.UserID,
+			OrgID:           query.OrgID,
+		}
+		rawSQL, err := sqltemplate.Execute(getTeamIDsByUserTemplate, sqlQuery)
+		if err != nil {
+			return err
+		}
+
+		rows, err := sess.QueryRows(rawSQL, sqlQuery.GetArgs()...)
 		if err != nil {
 			return err
 		}
@@ -465,6 +487,16 @@ func (ss *xormStore) GetIDsByUser(ctx context.Context, query *team.GetTeamIDsByU
 	}
 	return ids, uids, nil
 }
+
+type isTeamMemberQuery struct {
+	sqltemplate.SQLTemplate
+	TeamMemberTable string
+	OrgID           int64
+	TeamID          int64
+	UserID          int64
+}
+
+func (q isTeamMemberQuery) Validate() error { return nil }
 
 func getTeamMember(dbHelper *legacysql.LegacyDatabaseHelper, sess *db.Session, orgId int64, teamId int64, userId int64) (team.TeamMember, error) {
 	rawSQL := `SELECT * FROM ` + quoteTable(dbHelper, "team_member") + ` WHERE org_id=? and team_id=? and user_id=?`
@@ -499,8 +531,19 @@ func (ss *xormStore) IsMember(ctx context.Context, orgId int64, teamId int64, us
 }
 
 func isTeamMember(dbHelper *legacysql.LegacyDatabaseHelper, sess *db.Session, orgId int64, teamId int64, userId int64) (bool, error) {
-	query := "SELECT 1 FROM " + quoteTable(dbHelper, "team_member") + " WHERE org_id=? and team_id=? and user_id=?"
-	if res, err := sess.Query(query, orgId, teamId, userId); err != nil {
+	query := isTeamMemberQuery{
+		SQLTemplate:     sqltemplate.New(dbHelper.DialectForDriver()),
+		TeamMemberTable: dbHelper.Table("team_member"),
+		OrgID:           orgId,
+		TeamID:          teamId,
+		UserID:          userId,
+	}
+	rawSQL, err := sqltemplate.Execute(isTeamMemberTemplate, query)
+	if err != nil {
+		return false, err
+	}
+
+	if res, err := sess.Query(append([]any{rawSQL}, query.GetArgs()...)...); err != nil {
 		return false, err
 	} else if len(res) != 1 {
 		return false, nil

--- a/pkg/services/team/teamimpl/store_provider_test.go
+++ b/pkg/services/team/teamimpl/store_provider_test.go
@@ -1,0 +1,129 @@
+package teamimpl
+
+import (
+	"context"
+	"regexp"
+	"sync"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/infra/db/dbtest"
+	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
+	"github.com/grafana/grafana/pkg/services/team"
+	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/grafana/grafana/pkg/storage/legacysql"
+	"github.com/grafana/grafana/pkg/util/xorm"
+	"github.com/grafana/grafana/pkg/util/xorm/core"
+)
+
+var registerTeamSQLMockXormDriverOnce sync.Once
+
+type teamSQLMockXormDriver struct{}
+
+func (teamSQLMockXormDriver) Parse(string, string) (*core.Uri, error) {
+	return &core.Uri{DbType: core.SQLITE}, nil
+}
+
+type sqlmockTeamDB struct {
+	dbtest.FakeDB
+	engine *xorm.Engine
+}
+
+func (d *sqlmockTeamDB) WithDbSession(_ context.Context, callback sqlstore.DBTransactionFunc) error {
+	sess := &sqlstore.DBSession{Session: d.engine.NewSession()}
+	defer sess.Close()
+	return callback(sess)
+}
+
+func (d *sqlmockTeamDB) GetDBType() core.DbType {
+	return core.SQLITE
+}
+
+func TestStoreReadQueriesUseProviderTables(t *testing.T) {
+	registerTeamSQLMockXormDriverOnce.Do(func() {
+		if core.QueryDriver("sqlmock") == nil {
+			core.RegisterDriver("sqlmock", teamSQLMockXormDriver{})
+		}
+	})
+
+	dsn := "team-store"
+	mockDB, mock, err := sqlmock.NewWithDSN(dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = mockDB.Close() })
+
+	engine, err := xorm.NewEngine("sqlmock", dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = engine.Close() })
+
+	legacyDB := &sqlmockTeamDB{engine: engine}
+	type contextKey struct{}
+	ctx := context.WithValue(context.Background(), contextKey{}, "provider context")
+	providerCalls := 0
+	provider := func(gotCtx context.Context) (*legacysql.LegacyDatabaseHelper, error) {
+		require.Equal(t, "provider context", gotCtx.Value(contextKey{}))
+		providerCalls++
+		return &legacysql.LegacyDatabaseHelper{
+			DB: legacyDB,
+			Table: func(name string) string {
+				return "test_schema." + name
+			},
+		}, nil
+	}
+	store := &xormStore{sql: provider}
+	signedInUser := &user.SignedInUser{
+		OrgID: 7,
+		Permissions: map[int64]map[string][]string{
+			7: {ac.ActionTeamsRead: {ac.ScopeTeamsAll}},
+		},
+	}
+	teamColumns := []string{"id", "uid", "org_id", "name", "email", "external_uid", "is_provisioned", "member_count"}
+	teamRow := func() *sqlmock.Rows {
+		return sqlmock.NewRows(teamColumns).AddRow(int64(11), "team-a", int64(7), "Operations", "ops@example.com", "", false, int64(1))
+	}
+
+	mock.ExpectQuery(regexp.QuoteMeta(`FROM "test_schema"."team" AS team`)).
+		WithArgs(int64(7)).
+		WillReturnRows(teamRow())
+	mock.ExpectQuery(`(?i)SELECT count\(\*\) FROM .*test_schema.*team`).
+		WithArgs(int64(7)).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(int64(1)))
+	result, err := store.Search(ctx, &team.SearchTeamsQuery{OrgID: 7, SignedInUser: signedInUser})
+	require.NoError(t, err)
+	require.Len(t, result.Teams, 1)
+
+	mock.ExpectQuery(regexp.QuoteMeta(`FROM "test_schema"."team" AS team`)).
+		WithArgs(int64(7), int64(11)).
+		WillReturnRows(teamRow())
+	gotTeam, err := store.GetByID(ctx, &team.GetTeamByIDQuery{OrgID: 7, ID: 11})
+	require.NoError(t, err)
+	require.Equal(t, int64(11), gotTeam.ID)
+
+	mock.ExpectQuery(regexp.QuoteMeta(`INNER JOIN "test_schema"."team_member" AS team_member`)).
+		WithArgs(int64(7), int64(42)).
+		WillReturnRows(teamRow())
+	teams, err := store.GetByUser(ctx, &team.GetTeamsByUserQuery{OrgID: 7, UserID: 42, SignedInUser: signedInUser})
+	require.NoError(t, err)
+	require.Len(t, teams, 1)
+
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT team_member.team_id, team.uid
+FROM "test_schema"."team_member" AS team_member`)).
+		WithArgs(int64(42), int64(7)).
+		WillReturnRows(sqlmock.NewRows([]string{"team_id", "uid"}).AddRow(int64(11), "team-a"))
+	ids, uids, err := store.GetIDsByUser(ctx, &team.GetTeamIDsByUserQuery{OrgID: 7, UserID: 42})
+	require.NoError(t, err)
+	require.Equal(t, []int64{11}, ids)
+	require.Equal(t, []string{"team-a"}, uids)
+
+	mock.ExpectQuery(regexp.QuoteMeta(`FROM "test_schema"."team_member"`)).
+		WithArgs(int64(7), int64(11), int64(42)).
+		WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
+	isMember, err := store.IsMember(ctx, 7, 11, 42)
+	require.NoError(t, err)
+	require.True(t, isMember)
+
+	require.Equal(t, 5, providerCalls)
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/pkg/services/team/teamimpl/templates.go
+++ b/pkg/services/team/teamimpl/templates.go
@@ -1,0 +1,29 @@
+package teamimpl
+
+import (
+	"embed"
+	"fmt"
+	"text/template"
+)
+
+var (
+	//go:embed queries/*.sql
+	sqlTemplatesFS embed.FS
+
+	sqlTemplates = template.Must(template.New("sql").ParseFS(sqlTemplatesFS, "queries/*.sql"))
+)
+
+func mustTemplate(filename string) *template.Template {
+	if tmpl := sqlTemplates.Lookup(filename); tmpl != nil {
+		return tmpl
+	}
+	panic(fmt.Sprintf("template file not found: %s", filename))
+}
+
+var (
+	searchTeamsTemplate      = mustTemplate("search_teams.sql")
+	getTeamByIDTemplate      = mustTemplate("get_team_by_id.sql")
+	getTeamsByUserTemplate   = mustTemplate("get_teams_by_user.sql")
+	getTeamIDsByUserTemplate = mustTemplate("get_team_ids_by_user.sql")
+	isTeamMemberTemplate     = mustTemplate("is_team_member.sql")
+)

--- a/pkg/services/team/teamimpl/templates_test.go
+++ b/pkg/services/team/teamimpl/templates_test.go
@@ -1,0 +1,119 @@
+package teamimpl
+
+import (
+	"testing"
+	"text/template"
+
+	"github.com/grafana/grafana/pkg/storage/legacysql"
+	"github.com/grafana/grafana/pkg/storage/unified/sql/sqltemplate"
+	"github.com/grafana/grafana/pkg/storage/unified/sql/sqltemplate/mocks"
+)
+
+func TestTemplates(t *testing.T) {
+	dbHelper := &legacysql.LegacyDatabaseHelper{
+		Table: func(name string) string {
+			return "test_schema." + name
+		},
+	}
+	queryTemplate := func() sqltemplate.SQLTemplate {
+		return mocks.NewTestingSQLTemplate()
+	}
+
+	searchQuery := func(accessAll bool, accessTeamIDs []any) sqltemplate.SQLTemplate {
+		return &searchTeamsQuery{
+			SQLTemplate:     queryTemplate(),
+			TeamTable:       dbHelper.Table("team"),
+			TeamMemberTable: dbHelper.Table("team_member"),
+			UserTable:       dbHelper.Table("user"),
+			FilteredUsers:   []string{"hidden-user", "another-hidden-user"},
+			OrgID:           7,
+			NamePattern:     "%operations%",
+			Name:            "Operations",
+			TeamIDs:         []int64{11, 12},
+			UIDs:            []string{"team-a", "team-b"},
+			AccessAll:       accessAll,
+			AccessTeamIDs:   accessTeamIDs,
+			Sorts:           []string{"LOWER(team.name) DESC", "member_count ASC"},
+			Limit:           25,
+			Offset:          50,
+		}
+	}
+	defaultSearchQuery := func() sqltemplate.SQLTemplate {
+		return &searchTeamsQuery{
+			SQLTemplate:     queryTemplate(),
+			TeamTable:       dbHelper.Table("team"),
+			TeamMemberTable: dbHelper.Table("team_member"),
+			UserTable:       dbHelper.Table("user"),
+			OrgID:           7,
+			AccessAll:       true,
+		}
+	}
+	teamByIDQuery := func(id int64, uid string, filteredUsers []string) sqltemplate.SQLTemplate {
+		return &getTeamByIDQuery{
+			SQLTemplate:     queryTemplate(),
+			TeamTable:       dbHelper.Table("team"),
+			TeamMemberTable: dbHelper.Table("team_member"),
+			UserTable:       dbHelper.Table("user"),
+			FilteredUsers:   filteredUsers,
+			OrgID:           7,
+			ID:              id,
+			UID:             uid,
+		}
+	}
+	teamsByUserQuery := func(accessAll bool, accessTeamIDs []any) sqltemplate.SQLTemplate {
+		return &getTeamsByUserQuery{
+			SQLTemplate:     queryTemplate(),
+			TeamTable:       dbHelper.Table("team"),
+			TeamMemberTable: dbHelper.Table("team_member"),
+			OrgID:           7,
+			UserID:          42,
+			AccessAll:       accessAll,
+			AccessTeamIDs:   accessTeamIDs,
+		}
+	}
+
+	mocks.CheckQuerySnapshots(t, mocks.TemplateTestSetup{
+		RootDir:        "testdata",
+		SQLTemplatesFS: sqlTemplatesFS,
+		Templates: map[*template.Template][]mocks.TemplateTestCase{
+			searchTeamsTemplate: {
+				{Name: "all_filters", Data: searchQuery(false, []any{11, 12})},
+				{Name: "default", Data: defaultSearchQuery()},
+				{Name: "denied", Data: searchQuery(false, nil)},
+			},
+			getTeamByIDTemplate: {
+				{Name: "by_id_with_hidden_users", Data: teamByIDQuery(11, "", []string{"hidden-user"})},
+				{Name: "by_uid", Data: teamByIDQuery(0, "team-a", nil)},
+			},
+			getTeamsByUserTemplate: {
+				{Name: "all_teams", Data: teamsByUserQuery(true, nil)},
+				{Name: "selected_teams", Data: teamsByUserQuery(false, []any{11, 12})},
+				{Name: "denied", Data: teamsByUserQuery(false, nil)},
+			},
+			getTeamIDsByUserTemplate: {
+				{
+					Name: "team_ids",
+					Data: &getTeamIDsByUserQuery{
+						SQLTemplate:     queryTemplate(),
+						TeamTable:       dbHelper.Table("team"),
+						TeamMemberTable: dbHelper.Table("team_member"),
+						UserID:          42,
+						OrgID:           7,
+					},
+				},
+			},
+			isTeamMemberTemplate: {
+				{
+					Name: "team_member",
+					Data: &isTeamMemberQuery{
+						SQLTemplate:     queryTemplate(),
+						TeamMemberTable: dbHelper.Table("team_member"),
+						OrgID:           7,
+						TeamID:          11,
+						UserID:          42,
+					},
+				},
+			},
+		},
+	})
+}

--- a/pkg/services/team/teamimpl/testdata/mysql--get_team_by_id-by_id_with_hidden_users.sql
+++ b/pkg/services/team/teamimpl/testdata/mysql--get_team_by_id-by_id_with_hidden_users.sql
@@ -1,0 +1,18 @@
+SELECT
+  team.id AS id,
+  team.uid,
+  team.org_id,
+  team.name AS name,
+  team.email AS email,
+  team.external_uid AS external_uid,
+  team.is_provisioned AS is_provisioned,
+  (
+    SELECT COUNT(*)
+    FROM `test_schema`.`team_member` AS team_member
+    INNER JOIN `test_schema`.`user` AS member_user ON team_member.user_id = member_user.id
+    WHERE team_member.team_id = team.id
+    AND member_user.login NOT IN ('hidden-user')
+    ) AS member_count
+FROM `test_schema`.`team` AS team
+WHERE team.org_id = 7
+AND team.id = 11

--- a/pkg/services/team/teamimpl/testdata/mysql--get_team_by_id-by_uid.sql
+++ b/pkg/services/team/teamimpl/testdata/mysql--get_team_by_id-by_uid.sql
@@ -1,0 +1,16 @@
+SELECT
+  team.id AS id,
+  team.uid,
+  team.org_id,
+  team.name AS name,
+  team.email AS email,
+  team.external_uid AS external_uid,
+  team.is_provisioned AS is_provisioned,
+  (
+    SELECT COUNT(*)
+    FROM `test_schema`.`team_member` AS team_member
+    WHERE team_member.team_id = team.id
+    ) AS member_count
+FROM `test_schema`.`team` AS team
+WHERE team.org_id = 7
+AND team.uid = 'team-a'

--- a/pkg/services/team/teamimpl/testdata/mysql--get_team_ids_by_user-team_ids.sql
+++ b/pkg/services/team/teamimpl/testdata/mysql--get_team_ids_by_user-team_ids.sql
@@ -1,0 +1,6 @@
+SELECT team_member.team_id, team.uid
+FROM `test_schema`.`team_member` AS team_member
+INNER JOIN `test_schema`.`team` AS team ON team.id = team_member.team_id
+WHERE team_member.user_id = 42
+  AND team_member.org_id = 7
+ORDER BY team_member.team_id ASC

--- a/pkg/services/team/teamimpl/testdata/mysql--get_teams_by_user-all_teams.sql
+++ b/pkg/services/team/teamimpl/testdata/mysql--get_teams_by_user-all_teams.sql
@@ -1,0 +1,17 @@
+SELECT
+  team.id AS id,
+  team.uid,
+  team.org_id,
+  team.name AS name,
+  team.email AS email,
+  team.external_uid AS external_uid,
+  team.is_provisioned AS is_provisioned,
+  (
+    SELECT COUNT(*)
+    FROM `test_schema`.`team_member` AS member_count_team_member
+    WHERE member_count_team_member.team_id = team.id
+  ) AS member_count
+FROM `test_schema`.`team` AS team
+INNER JOIN `test_schema`.`team_member` AS team_member ON team.id = team_member.team_id
+WHERE team.org_id = 7
+  AND team_member.user_id = 42

--- a/pkg/services/team/teamimpl/testdata/mysql--get_teams_by_user-denied.sql
+++ b/pkg/services/team/teamimpl/testdata/mysql--get_teams_by_user-denied.sql
@@ -1,0 +1,18 @@
+SELECT
+  team.id AS id,
+  team.uid,
+  team.org_id,
+  team.name AS name,
+  team.email AS email,
+  team.external_uid AS external_uid,
+  team.is_provisioned AS is_provisioned,
+  (
+    SELECT COUNT(*)
+    FROM `test_schema`.`team_member` AS member_count_team_member
+    WHERE member_count_team_member.team_id = team.id
+  ) AS member_count
+FROM `test_schema`.`team` AS team
+INNER JOIN `test_schema`.`team_member` AS team_member ON team.id = team_member.team_id
+WHERE team.org_id = 7
+  AND team_member.user_id = 42
+AND 1 = 0

--- a/pkg/services/team/teamimpl/testdata/mysql--get_teams_by_user-selected_teams.sql
+++ b/pkg/services/team/teamimpl/testdata/mysql--get_teams_by_user-selected_teams.sql
@@ -1,0 +1,18 @@
+SELECT
+  team.id AS id,
+  team.uid,
+  team.org_id,
+  team.name AS name,
+  team.email AS email,
+  team.external_uid AS external_uid,
+  team.is_provisioned AS is_provisioned,
+  (
+    SELECT COUNT(*)
+    FROM `test_schema`.`team_member` AS member_count_team_member
+    WHERE member_count_team_member.team_id = team.id
+  ) AS member_count
+FROM `test_schema`.`team` AS team
+INNER JOIN `test_schema`.`team_member` AS team_member ON team.id = team_member.team_id
+WHERE team.org_id = 7
+  AND team_member.user_id = 42
+AND team.id IN (11, 12)

--- a/pkg/services/team/teamimpl/testdata/mysql--is_team_member-team_member.sql
+++ b/pkg/services/team/teamimpl/testdata/mysql--is_team_member-team_member.sql
@@ -1,0 +1,5 @@
+SELECT 1
+FROM `test_schema`.`team_member`
+WHERE org_id = 7
+  AND team_id = 11
+  AND user_id = 42

--- a/pkg/services/team/teamimpl/testdata/mysql--search_teams-all_filters.sql
+++ b/pkg/services/team/teamimpl/testdata/mysql--search_teams-all_filters.sql
@@ -1,0 +1,25 @@
+SELECT
+  team.id AS id,
+  team.uid,
+  team.org_id,
+  team.name AS name,
+  team.email AS email,
+  team.external_uid AS external_uid,
+  team.is_provisioned AS is_provisioned,
+  (
+    SELECT COUNT(*)
+    FROM `test_schema`.`team_member` AS team_member
+    INNER JOIN `test_schema`.`user` AS member_user ON team_member.user_id = member_user.id
+    WHERE team_member.team_id = team.id
+    AND member_user.login NOT IN ('hidden-user', 'another-hidden-user')
+    ) AS member_count
+FROM `test_schema`.`team` AS team
+WHERE team.org_id = 7
+AND team.name LIKE '%operations%'
+AND LOWER(team.name) = LOWER('Operations')
+AND team.id IN (11, 12)
+AND team.uid IN ('team-a', 'team-b')
+AND team.id IN (11, 12)
+ORDER BY
+LOWER(team.name) DESC, member_count ASC
+LIMIT 25 OFFSET 50

--- a/pkg/services/team/teamimpl/testdata/mysql--search_teams-default.sql
+++ b/pkg/services/team/teamimpl/testdata/mysql--search_teams-default.sql
@@ -1,0 +1,17 @@
+SELECT
+  team.id AS id,
+  team.uid,
+  team.org_id,
+  team.name AS name,
+  team.email AS email,
+  team.external_uid AS external_uid,
+  team.is_provisioned AS is_provisioned,
+  (
+    SELECT COUNT(*)
+    FROM `test_schema`.`team_member` AS team_member
+    WHERE team_member.team_id = team.id
+    ) AS member_count
+FROM `test_schema`.`team` AS team
+WHERE team.org_id = 7
+ORDER BY
+team.name ASC

--- a/pkg/services/team/teamimpl/testdata/mysql--search_teams-denied.sql
+++ b/pkg/services/team/teamimpl/testdata/mysql--search_teams-denied.sql
@@ -1,0 +1,25 @@
+SELECT
+  team.id AS id,
+  team.uid,
+  team.org_id,
+  team.name AS name,
+  team.email AS email,
+  team.external_uid AS external_uid,
+  team.is_provisioned AS is_provisioned,
+  (
+    SELECT COUNT(*)
+    FROM `test_schema`.`team_member` AS team_member
+    INNER JOIN `test_schema`.`user` AS member_user ON team_member.user_id = member_user.id
+    WHERE team_member.team_id = team.id
+    AND member_user.login NOT IN ('hidden-user', 'another-hidden-user')
+    ) AS member_count
+FROM `test_schema`.`team` AS team
+WHERE team.org_id = 7
+AND team.name LIKE '%operations%'
+AND LOWER(team.name) = LOWER('Operations')
+AND team.id IN (11, 12)
+AND team.uid IN ('team-a', 'team-b')
+AND 1 = 0
+ORDER BY
+LOWER(team.name) DESC, member_count ASC
+LIMIT 25 OFFSET 50

--- a/pkg/services/team/teamimpl/testdata/postgres--get_team_by_id-by_id_with_hidden_users.sql
+++ b/pkg/services/team/teamimpl/testdata/postgres--get_team_by_id-by_id_with_hidden_users.sql
@@ -1,0 +1,18 @@
+SELECT
+  team.id AS id,
+  team.uid,
+  team.org_id,
+  team.name AS name,
+  team.email AS email,
+  team.external_uid AS external_uid,
+  team.is_provisioned AS is_provisioned,
+  (
+    SELECT COUNT(*)
+    FROM "test_schema"."team_member" AS team_member
+    INNER JOIN "test_schema"."user" AS member_user ON team_member.user_id = member_user.id
+    WHERE team_member.team_id = team.id
+    AND member_user.login NOT IN ('hidden-user')
+    ) AS member_count
+FROM "test_schema"."team" AS team
+WHERE team.org_id = 7
+AND team.id = 11

--- a/pkg/services/team/teamimpl/testdata/postgres--get_team_by_id-by_uid.sql
+++ b/pkg/services/team/teamimpl/testdata/postgres--get_team_by_id-by_uid.sql
@@ -1,0 +1,16 @@
+SELECT
+  team.id AS id,
+  team.uid,
+  team.org_id,
+  team.name AS name,
+  team.email AS email,
+  team.external_uid AS external_uid,
+  team.is_provisioned AS is_provisioned,
+  (
+    SELECT COUNT(*)
+    FROM "test_schema"."team_member" AS team_member
+    WHERE team_member.team_id = team.id
+    ) AS member_count
+FROM "test_schema"."team" AS team
+WHERE team.org_id = 7
+AND team.uid = 'team-a'

--- a/pkg/services/team/teamimpl/testdata/postgres--get_team_ids_by_user-team_ids.sql
+++ b/pkg/services/team/teamimpl/testdata/postgres--get_team_ids_by_user-team_ids.sql
@@ -1,0 +1,6 @@
+SELECT team_member.team_id, team.uid
+FROM "test_schema"."team_member" AS team_member
+INNER JOIN "test_schema"."team" AS team ON team.id = team_member.team_id
+WHERE team_member.user_id = 42
+  AND team_member.org_id = 7
+ORDER BY team_member.team_id ASC

--- a/pkg/services/team/teamimpl/testdata/postgres--get_teams_by_user-all_teams.sql
+++ b/pkg/services/team/teamimpl/testdata/postgres--get_teams_by_user-all_teams.sql
@@ -1,0 +1,17 @@
+SELECT
+  team.id AS id,
+  team.uid,
+  team.org_id,
+  team.name AS name,
+  team.email AS email,
+  team.external_uid AS external_uid,
+  team.is_provisioned AS is_provisioned,
+  (
+    SELECT COUNT(*)
+    FROM "test_schema"."team_member" AS member_count_team_member
+    WHERE member_count_team_member.team_id = team.id
+  ) AS member_count
+FROM "test_schema"."team" AS team
+INNER JOIN "test_schema"."team_member" AS team_member ON team.id = team_member.team_id
+WHERE team.org_id = 7
+  AND team_member.user_id = 42

--- a/pkg/services/team/teamimpl/testdata/postgres--get_teams_by_user-denied.sql
+++ b/pkg/services/team/teamimpl/testdata/postgres--get_teams_by_user-denied.sql
@@ -1,0 +1,18 @@
+SELECT
+  team.id AS id,
+  team.uid,
+  team.org_id,
+  team.name AS name,
+  team.email AS email,
+  team.external_uid AS external_uid,
+  team.is_provisioned AS is_provisioned,
+  (
+    SELECT COUNT(*)
+    FROM "test_schema"."team_member" AS member_count_team_member
+    WHERE member_count_team_member.team_id = team.id
+  ) AS member_count
+FROM "test_schema"."team" AS team
+INNER JOIN "test_schema"."team_member" AS team_member ON team.id = team_member.team_id
+WHERE team.org_id = 7
+  AND team_member.user_id = 42
+AND 1 = 0

--- a/pkg/services/team/teamimpl/testdata/postgres--get_teams_by_user-selected_teams.sql
+++ b/pkg/services/team/teamimpl/testdata/postgres--get_teams_by_user-selected_teams.sql
@@ -1,0 +1,18 @@
+SELECT
+  team.id AS id,
+  team.uid,
+  team.org_id,
+  team.name AS name,
+  team.email AS email,
+  team.external_uid AS external_uid,
+  team.is_provisioned AS is_provisioned,
+  (
+    SELECT COUNT(*)
+    FROM "test_schema"."team_member" AS member_count_team_member
+    WHERE member_count_team_member.team_id = team.id
+  ) AS member_count
+FROM "test_schema"."team" AS team
+INNER JOIN "test_schema"."team_member" AS team_member ON team.id = team_member.team_id
+WHERE team.org_id = 7
+  AND team_member.user_id = 42
+AND team.id IN (11, 12)

--- a/pkg/services/team/teamimpl/testdata/postgres--is_team_member-team_member.sql
+++ b/pkg/services/team/teamimpl/testdata/postgres--is_team_member-team_member.sql
@@ -1,0 +1,5 @@
+SELECT 1
+FROM "test_schema"."team_member"
+WHERE org_id = 7
+  AND team_id = 11
+  AND user_id = 42

--- a/pkg/services/team/teamimpl/testdata/postgres--search_teams-all_filters.sql
+++ b/pkg/services/team/teamimpl/testdata/postgres--search_teams-all_filters.sql
@@ -1,0 +1,25 @@
+SELECT
+  team.id AS id,
+  team.uid,
+  team.org_id,
+  team.name AS name,
+  team.email AS email,
+  team.external_uid AS external_uid,
+  team.is_provisioned AS is_provisioned,
+  (
+    SELECT COUNT(*)
+    FROM "test_schema"."team_member" AS team_member
+    INNER JOIN "test_schema"."user" AS member_user ON team_member.user_id = member_user.id
+    WHERE team_member.team_id = team.id
+    AND member_user.login NOT IN ('hidden-user', 'another-hidden-user')
+    ) AS member_count
+FROM "test_schema"."team" AS team
+WHERE team.org_id = 7
+AND team.name ILIKE '%operations%'
+AND LOWER(team.name) = LOWER('Operations')
+AND team.id IN (11, 12)
+AND team.uid IN ('team-a', 'team-b')
+AND team.id IN (11, 12)
+ORDER BY
+LOWER(team.name) DESC, member_count ASC
+LIMIT 25 OFFSET 50

--- a/pkg/services/team/teamimpl/testdata/postgres--search_teams-default.sql
+++ b/pkg/services/team/teamimpl/testdata/postgres--search_teams-default.sql
@@ -1,0 +1,17 @@
+SELECT
+  team.id AS id,
+  team.uid,
+  team.org_id,
+  team.name AS name,
+  team.email AS email,
+  team.external_uid AS external_uid,
+  team.is_provisioned AS is_provisioned,
+  (
+    SELECT COUNT(*)
+    FROM "test_schema"."team_member" AS team_member
+    WHERE team_member.team_id = team.id
+    ) AS member_count
+FROM "test_schema"."team" AS team
+WHERE team.org_id = 7
+ORDER BY
+team.name ASC

--- a/pkg/services/team/teamimpl/testdata/postgres--search_teams-denied.sql
+++ b/pkg/services/team/teamimpl/testdata/postgres--search_teams-denied.sql
@@ -1,0 +1,25 @@
+SELECT
+  team.id AS id,
+  team.uid,
+  team.org_id,
+  team.name AS name,
+  team.email AS email,
+  team.external_uid AS external_uid,
+  team.is_provisioned AS is_provisioned,
+  (
+    SELECT COUNT(*)
+    FROM "test_schema"."team_member" AS team_member
+    INNER JOIN "test_schema"."user" AS member_user ON team_member.user_id = member_user.id
+    WHERE team_member.team_id = team.id
+    AND member_user.login NOT IN ('hidden-user', 'another-hidden-user')
+    ) AS member_count
+FROM "test_schema"."team" AS team
+WHERE team.org_id = 7
+AND team.name ILIKE '%operations%'
+AND LOWER(team.name) = LOWER('Operations')
+AND team.id IN (11, 12)
+AND team.uid IN ('team-a', 'team-b')
+AND 1 = 0
+ORDER BY
+LOWER(team.name) DESC, member_count ASC
+LIMIT 25 OFFSET 50

--- a/pkg/services/team/teamimpl/testdata/sqlite--get_team_by_id-by_id_with_hidden_users.sql
+++ b/pkg/services/team/teamimpl/testdata/sqlite--get_team_by_id-by_id_with_hidden_users.sql
@@ -1,0 +1,18 @@
+SELECT
+  team.id AS id,
+  team.uid,
+  team.org_id,
+  team.name AS name,
+  team.email AS email,
+  team.external_uid AS external_uid,
+  team.is_provisioned AS is_provisioned,
+  (
+    SELECT COUNT(*)
+    FROM "test_schema"."team_member" AS team_member
+    INNER JOIN "test_schema"."user" AS member_user ON team_member.user_id = member_user.id
+    WHERE team_member.team_id = team.id
+    AND member_user.login NOT IN ('hidden-user')
+    ) AS member_count
+FROM "test_schema"."team" AS team
+WHERE team.org_id = 7
+AND team.id = 11

--- a/pkg/services/team/teamimpl/testdata/sqlite--get_team_by_id-by_uid.sql
+++ b/pkg/services/team/teamimpl/testdata/sqlite--get_team_by_id-by_uid.sql
@@ -1,0 +1,16 @@
+SELECT
+  team.id AS id,
+  team.uid,
+  team.org_id,
+  team.name AS name,
+  team.email AS email,
+  team.external_uid AS external_uid,
+  team.is_provisioned AS is_provisioned,
+  (
+    SELECT COUNT(*)
+    FROM "test_schema"."team_member" AS team_member
+    WHERE team_member.team_id = team.id
+    ) AS member_count
+FROM "test_schema"."team" AS team
+WHERE team.org_id = 7
+AND team.uid = 'team-a'

--- a/pkg/services/team/teamimpl/testdata/sqlite--get_team_ids_by_user-team_ids.sql
+++ b/pkg/services/team/teamimpl/testdata/sqlite--get_team_ids_by_user-team_ids.sql
@@ -1,0 +1,6 @@
+SELECT team_member.team_id, team.uid
+FROM "test_schema"."team_member" AS team_member
+INNER JOIN "test_schema"."team" AS team ON team.id = team_member.team_id
+WHERE team_member.user_id = 42
+  AND team_member.org_id = 7
+ORDER BY team_member.team_id ASC

--- a/pkg/services/team/teamimpl/testdata/sqlite--get_teams_by_user-all_teams.sql
+++ b/pkg/services/team/teamimpl/testdata/sqlite--get_teams_by_user-all_teams.sql
@@ -1,0 +1,17 @@
+SELECT
+  team.id AS id,
+  team.uid,
+  team.org_id,
+  team.name AS name,
+  team.email AS email,
+  team.external_uid AS external_uid,
+  team.is_provisioned AS is_provisioned,
+  (
+    SELECT COUNT(*)
+    FROM "test_schema"."team_member" AS member_count_team_member
+    WHERE member_count_team_member.team_id = team.id
+  ) AS member_count
+FROM "test_schema"."team" AS team
+INNER JOIN "test_schema"."team_member" AS team_member ON team.id = team_member.team_id
+WHERE team.org_id = 7
+  AND team_member.user_id = 42

--- a/pkg/services/team/teamimpl/testdata/sqlite--get_teams_by_user-denied.sql
+++ b/pkg/services/team/teamimpl/testdata/sqlite--get_teams_by_user-denied.sql
@@ -1,0 +1,18 @@
+SELECT
+  team.id AS id,
+  team.uid,
+  team.org_id,
+  team.name AS name,
+  team.email AS email,
+  team.external_uid AS external_uid,
+  team.is_provisioned AS is_provisioned,
+  (
+    SELECT COUNT(*)
+    FROM "test_schema"."team_member" AS member_count_team_member
+    WHERE member_count_team_member.team_id = team.id
+  ) AS member_count
+FROM "test_schema"."team" AS team
+INNER JOIN "test_schema"."team_member" AS team_member ON team.id = team_member.team_id
+WHERE team.org_id = 7
+  AND team_member.user_id = 42
+AND 1 = 0

--- a/pkg/services/team/teamimpl/testdata/sqlite--get_teams_by_user-selected_teams.sql
+++ b/pkg/services/team/teamimpl/testdata/sqlite--get_teams_by_user-selected_teams.sql
@@ -1,0 +1,18 @@
+SELECT
+  team.id AS id,
+  team.uid,
+  team.org_id,
+  team.name AS name,
+  team.email AS email,
+  team.external_uid AS external_uid,
+  team.is_provisioned AS is_provisioned,
+  (
+    SELECT COUNT(*)
+    FROM "test_schema"."team_member" AS member_count_team_member
+    WHERE member_count_team_member.team_id = team.id
+  ) AS member_count
+FROM "test_schema"."team" AS team
+INNER JOIN "test_schema"."team_member" AS team_member ON team.id = team_member.team_id
+WHERE team.org_id = 7
+  AND team_member.user_id = 42
+AND team.id IN (11, 12)

--- a/pkg/services/team/teamimpl/testdata/sqlite--is_team_member-team_member.sql
+++ b/pkg/services/team/teamimpl/testdata/sqlite--is_team_member-team_member.sql
@@ -1,0 +1,5 @@
+SELECT 1
+FROM "test_schema"."team_member"
+WHERE org_id = 7
+  AND team_id = 11
+  AND user_id = 42

--- a/pkg/services/team/teamimpl/testdata/sqlite--search_teams-all_filters.sql
+++ b/pkg/services/team/teamimpl/testdata/sqlite--search_teams-all_filters.sql
@@ -1,0 +1,25 @@
+SELECT
+  team.id AS id,
+  team.uid,
+  team.org_id,
+  team.name AS name,
+  team.email AS email,
+  team.external_uid AS external_uid,
+  team.is_provisioned AS is_provisioned,
+  (
+    SELECT COUNT(*)
+    FROM "test_schema"."team_member" AS team_member
+    INNER JOIN "test_schema"."user" AS member_user ON team_member.user_id = member_user.id
+    WHERE team_member.team_id = team.id
+    AND member_user.login NOT IN ('hidden-user', 'another-hidden-user')
+    ) AS member_count
+FROM "test_schema"."team" AS team
+WHERE team.org_id = 7
+AND team.name LIKE '%operations%'
+AND LOWER(team.name) = LOWER('Operations')
+AND team.id IN (11, 12)
+AND team.uid IN ('team-a', 'team-b')
+AND team.id IN (11, 12)
+ORDER BY
+LOWER(team.name) DESC, member_count ASC
+LIMIT 25 OFFSET 50

--- a/pkg/services/team/teamimpl/testdata/sqlite--search_teams-default.sql
+++ b/pkg/services/team/teamimpl/testdata/sqlite--search_teams-default.sql
@@ -1,0 +1,17 @@
+SELECT
+  team.id AS id,
+  team.uid,
+  team.org_id,
+  team.name AS name,
+  team.email AS email,
+  team.external_uid AS external_uid,
+  team.is_provisioned AS is_provisioned,
+  (
+    SELECT COUNT(*)
+    FROM "test_schema"."team_member" AS team_member
+    WHERE team_member.team_id = team.id
+    ) AS member_count
+FROM "test_schema"."team" AS team
+WHERE team.org_id = 7
+ORDER BY
+team.name ASC

--- a/pkg/services/team/teamimpl/testdata/sqlite--search_teams-denied.sql
+++ b/pkg/services/team/teamimpl/testdata/sqlite--search_teams-denied.sql
@@ -1,0 +1,25 @@
+SELECT
+  team.id AS id,
+  team.uid,
+  team.org_id,
+  team.name AS name,
+  team.email AS email,
+  team.external_uid AS external_uid,
+  team.is_provisioned AS is_provisioned,
+  (
+    SELECT COUNT(*)
+    FROM "test_schema"."team_member" AS team_member
+    INNER JOIN "test_schema"."user" AS member_user ON team_member.user_id = member_user.id
+    WHERE team_member.team_id = team.id
+    AND member_user.login NOT IN ('hidden-user', 'another-hidden-user')
+    ) AS member_count
+FROM "test_schema"."team" AS team
+WHERE team.org_id = 7
+AND team.name LIKE '%operations%'
+AND LOWER(team.name) = LOWER('Operations')
+AND team.id IN (11, 12)
+AND team.uid IN ('team-a', 'team-b')
+AND 1 = 0
+ORDER BY
+LOWER(team.name) DESC, member_count ASC
+LIMIT 25 OFFSET 50


### PR DESCRIPTION
**What is this feature?**

This changes five raw SQL reads in `teamimpl` to use embedded SQL templates:

- team search
- team lookup by ID or UID
- teams for a user
- team IDs for a user
- team membership checks

Table names use `.Ident`. Query values use `.Arg` and `.ArgList`. The remaining XORM queries are unchanged.

**Why do we need this feature?**

The team store resolves operation-scoped table names through `LegacyDatabaseHelper`, following the database-provider boundary merged in #129491. These raw reads still built SQL strings around those names. Templates consistently quote resolved table names and bind query values for MySQL, PostgreSQL, and SQLite.

Please check that:
- [x] It works as expected from a user perspective.
- [ ] A feature toggle is not needed because this is an internal SQL change.
- [ ] Docs are not needed because there is no user-facing change.
